### PR TITLE
Enrich denumerability-rationals-oq-04-oq-04: annotation depth fields

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-04-oq-04/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 46 },
     "type": "concept",
     "title": "Countable → Denumerable, and the Constructive Caveat",
-    "content": "The docstring frames the promotion: the parent proves the algebraic numbers are `Countable`; here we upgrade to `Denumerable`, Mathlib's strongest countability notion — an explicit bijection with ℕ. The crucial honesty: the instance is **classical/noncomputable**, factoring through `Encodable.ofCountable` (which uses `Classical.choice`). So the bijection Q̄ ≅ ℕ exists but does not compute an index for a given algebraic number; a genuinely constructive enumeration (effective root isolation) is the parent's open question 1 and remains unresolved. `#print axioms` shows only propext/Classical.choice/Quot.sound — none counting — so the file is verified, merely noncomputable."
+    "content": "The docstring frames the promotion: the parent proves the algebraic numbers are `Countable`; here we upgrade to `Denumerable`, Mathlib's strongest countability notion — an explicit bijection with ℕ. The crucial honesty: the instance is **classical/noncomputable**, factoring through `Encodable.ofCountable` (which uses `Classical.choice`). So the bijection Q̄ ≅ ℕ exists but does not compute an index for a given algebraic number; a genuinely constructive enumeration (effective root isolation) is the parent's open question 1 and remains unresolved. `#print axioms` shows only propext/Classical.choice/Quot.sound — none counting — so the file is verified, merely noncomputable.",
+    "mathContext": "$\\mathrm{Countable}\\,X \\wedge \\mathrm{Infinite}\\,X \\Rightarrow \\mathrm{Denumerable}\\,X$, i.e. $\\exists\\, X \\simeq \\mathbb{N}$. Noncomputable because $\\mathrm{Encodable.ofCountable}$ invokes $\\mathrm{Classical.choice}$.",
+    "significance": "context",
+    "relatedConcepts": ["countability", "denumerability", "Classical.choice", "noncomputable", "constructive vs classical existence", "algebraic numbers"],
+    "prerequisites": ["set theory", "cardinality", "Lean typeclasses"]
   },
   {
     "id": "ann-denum0404-countable",
@@ -13,7 +17,11 @@
     "range": { "startLine": 54, "endLine": 60 },
     "type": "concept",
     "title": "Countability from Mathlib",
-    "content": "AlgQ := {x : ℂ // IsAlgebraic ℚ x} is the field of complex algebraic numbers. Its `Countable` instance is Mathlib's `Algebraic.countable ℚ ℂ` (the algebraic elements over a countable base ring are countable), transported to the subtype by `.to_subtype`. This is Cantor's 1874 theorem, already in the library."
+    "content": "AlgQ := {x : ℂ // IsAlgebraic ℚ x} is the field of complex algebraic numbers. Its `Countable` instance is Mathlib's `Algebraic.countable ℚ ℂ` (the algebraic elements over a countable base ring are countable), transported to the subtype by `.to_subtype`. This is Cantor's 1874 theorem, already in the library.",
+    "mathContext": "$\\overline{\\mathbb{Q}} \\cap \\mathbb{C} = \\{x \\in \\mathbb{C} : x \\text{ algebraic over } \\mathbb{Q}\\}$ is countable: $\\bigcup_{f \\in \\mathbb{Q}[X]} \\{\\text{roots of } f\\}$ is a countable union of finite sets.",
+    "significance": "supporting",
+    "relatedConcepts": ["algebraic numbers", "countable union of finite sets", "Cantor's theorem (1874)", "subtype", "polynomial roots"],
+    "prerequisites": ["field theory", "countability", "polynomials over ℚ"]
   },
   {
     "id": "ann-denum0404-infinite",
@@ -21,7 +29,11 @@
     "range": { "startLine": 62, "endLine": 68 },
     "type": "proof-technique",
     "title": "Infinitude via the Embedding of ℚ",
-    "content": "The `Infinite` instance embeds the (already infinite) rationals into the algebraic numbers: q ↦ ⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩ (every rational is algebraic). Injectivity follows from `FaithfulSMul.algebraMap_injective ℚ ℂ` applied through `Subtype.ext_iff`, so `Infinite.of_injective` gives `Infinite AlgQ`. Infinitude is the only ingredient beyond the parent's countability needed for the promotion."
+    "content": "The `Infinite` instance embeds the (already infinite) rationals into the algebraic numbers: q ↦ ⟨algebraMap ℚ ℂ q, isAlgebraic_algebraMap q⟩ (every rational is algebraic). Injectivity follows from `FaithfulSMul.algebraMap_injective ℚ ℂ` applied through `Subtype.ext_iff`, so `Infinite.of_injective` gives `Infinite AlgQ`. Infinitude is the only ingredient beyond the parent's countability needed for the promotion.",
+    "mathContext": "$\\mathbb{Q} \\hookrightarrow \\overline{\\mathbb{Q}}$ via $q \\mapsto \\iota(q)$ (each rational is algebraic, a root of $X - q$); injective, so $\\overline{\\mathbb{Q}}$ is infinite.",
+    "significance": "supporting",
+    "relatedConcepts": ["injective embedding", "algebraMap", "Infinite.of_injective", "faithful action", "rationals as algebraic numbers"],
+    "prerequisites": ["injective maps", "algebra homomorphisms"]
   },
   {
     "id": "ann-denum0404-denumerable",
@@ -29,7 +41,11 @@
     "range": { "startLine": 70, "endLine": 79 },
     "type": "key-insight",
     "title": "The Denumerable Instance and the Bijection Q̄ ≅ ℕ",
-    "content": "`instDenumerableAlgQ` combines an `Encodable AlgQ` (obtained noncomputably from countability via `Encodable.ofCountable`) with the `Infinite` instance, feeding both to `Denumerable.ofEncodableOfInfinite`. `algebraicEquivNat := Denumerable.eqv AlgQ` is then the explicit bijection Q̄ ≅ ℕ requested by the open question. The `noncomputable` marker is the visible trace of the Classical.choice used inside `Encodable.ofCountable`."
+    "content": "`instDenumerableAlgQ` combines an `Encodable AlgQ` (obtained noncomputably from countability via `Encodable.ofCountable`) with the `Infinite` instance, feeding both to `Denumerable.ofEncodableOfInfinite`. `algebraicEquivNat := Denumerable.eqv AlgQ` is then the explicit bijection Q̄ ≅ ℕ requested by the open question. The `noncomputable` marker is the visible trace of the Classical.choice used inside `Encodable.ofCountable`.",
+    "mathContext": "$\\mathrm{Denumerable.ofEncodableOfInfinite} : \\mathrm{Encodable}\\,X \\to \\mathrm{Infinite}\\,X \\to \\mathrm{Denumerable}\\,X$; $\\mathrm{Denumerable.eqv} : \\overline{\\mathbb{Q}} \\simeq \\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["Denumerable", "Encodable", "bijection with ℕ", "noncomputable instance", "Denumerable.ofEncodableOfInfinite"],
+    "prerequisites": ["equivalences (≃)", "countability hierarchy", "Lean typeclasses"]
   },
   {
     "id": "ann-denum0404-existence",
@@ -37,7 +53,11 @@
     "range": { "startLine": 81, "endLine": 88 },
     "type": "concept",
     "title": "Choiceless Existence Statements",
-    "content": "`nonempty_denumerable_algQ : Nonempty (Denumerable AlgQ)` (from Mathlib's `nonempty_denumerable`, requiring only Countable + Infinite) and `nonempty_equiv_nat : Nonempty (AlgQ ≃ ℕ)` record the existence of the structure and bijection independently of any particular chosen instance."
+    "content": "`nonempty_denumerable_algQ : Nonempty (Denumerable AlgQ)` (from Mathlib's `nonempty_denumerable`, requiring only Countable + Infinite) and `nonempty_equiv_nat : Nonempty (AlgQ ≃ ℕ)` record the existence of the structure and bijection independently of any particular chosen instance.",
+    "mathContext": "$\\mathrm{Nonempty}(\\mathrm{Denumerable}\\,\\overline{\\mathbb{Q}})$ and $\\mathrm{Nonempty}(\\overline{\\mathbb{Q}} \\simeq \\mathbb{N})$: propositional existence, insensitive to which enumeration is chosen.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nonempty", "propositional truncation", "existence vs. choice", "nonempty_denumerable"],
+    "prerequisites": ["propositions vs data", "Nonempty type"]
   },
   {
     "id": "ann-denum0404-cardinal",
@@ -45,6 +65,10 @@
     "range": { "startLine": 90, "endLine": 102 },
     "type": "key-insight",
     "title": "The Cardinality Form #AlgQ = ℵ₀",
-    "content": "`cardinalMk_algQ : #AlgQ = ℵ₀` is the cardinal-arithmetic form of denumerability, from Mathlib's `cardinalMk_of_countable_of_charZero` (ℚ countable, ℂ of characteristic zero). `denumerable_iff_cardinal` proves `Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀`, confirming that the explicit bijection with ℕ and the statement 'cardinality ℵ₀' carry precisely the same information."
+    "content": "`cardinalMk_algQ : #AlgQ = ℵ₀` is the cardinal-arithmetic form of denumerability, from Mathlib's `cardinalMk_of_countable_of_charZero` (ℚ countable, ℂ of characteristic zero). `denumerable_iff_cardinal` proves `Nonempty (Denumerable AlgQ) ↔ #AlgQ = ℵ₀`, confirming that the explicit bijection with ℕ and the statement 'cardinality ℵ₀' carry precisely the same information.",
+    "mathContext": "$\\#\\overline{\\mathbb{Q}} = \\aleph_0$; and $\\mathrm{Nonempty}(\\mathrm{Denumerable}\\,X) \\iff \\#X = \\aleph_0$ — the bijection-with-ℕ and cardinal statements are equivalent.",
+    "significance": "key",
+    "relatedConcepts": ["cardinality", "aleph-null ℵ₀", "cardinal arithmetic", "characteristic zero", "Cantor"],
+    "prerequisites": ["cardinal numbers", "aleph notation"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for denumerability-rationals-oq-04-oq-04 (Denumerability of the Algebraic Numbers).

## Gap addressed
The meta.json was already complete (overview with 5 keyInsights, 4 sections, full conclusion), but all 6 annotations carried only `content` — no depth fields. Added to **all 6**:
- `mathContext` — LaTeX for the countability→denumerability promotion, the ℚ↪Q̄ embedding, Denumerable.ofEncodableOfInfinite, and #Q̄ = ℵ₀.
- `significance`, `relatedConcepts`, `prerequisites`.

Line ranges left unchanged (already verified against the Lean file). meta.json unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)