### PR TITLE
Enrich binomial-theorem-oq-02-oq-01-oq-02-oq-01: annotation depth fields

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 55 },
     "type": "concept",
     "title": "Joint independence of disjoint blocks via PGF factorization",
-    "content": "The parent entry proved that marginals of a multinomial are binomial; its first open question asks whether the PGF method extends to JOINT independence of disjoint index subsets. In the binomial model — independent Bernoulli(p) indicators (Xᵢ) — the block-sums U = ∑_{i∈S} Xᵢ and V = ∑_{i∈T} Xᵢ over disjoint S, T should be jointly independent, each a Binomial. The certificate is generating-function factorization: for independent variables the joint PGF E[∏ tᵢ^{Xᵢ}] is the product of the per-index Bernoulli PGFs, and a joint PGF that separates into a function of u times a function of v certifies independence. Scope: the file proves this factorization rigorously; it does not re-derive the measure-theoretic PGF ⇒ independence equivalence."
+    "content": "The parent entry proved that marginals of a multinomial are binomial; its first open question asks whether the PGF method extends to JOINT independence of disjoint index subsets. In the binomial model — independent Bernoulli(p) indicators (Xᵢ) — the block-sums U = ∑_{i∈S} Xᵢ and V = ∑_{i∈T} Xᵢ over disjoint S, T should be jointly independent, each a Binomial. The certificate is generating-function factorization: for independent variables the joint PGF E[∏ tᵢ^{Xᵢ}] is the product of the per-index Bernoulli PGFs, and a joint PGF that separates into a function of u times a function of v certifies independence. Scope: the file proves this factorization rigorously; it does not re-derive the measure-theoretic PGF ⇒ independence equivalence.",
+    "mathContext": "$G_{U,V}(u,v) = \\mathbb{E}[u^{U} v^{V}]$ factors as $g(u)\\,h(v) \\iff U \\perp V$. Here $U = \\sum_{i\\in S} X_i$, $V = \\sum_{i\\in T} X_i$ with $S \\cap T = \\varnothing$.",
+    "significance": "context",
+    "relatedConcepts": ["probability generating function", "independence", "Bernoulli trials", "binomial distribution", "multinomial"],
+    "prerequisites": ["probability theory", "generating functions", "independence of random variables"]
   },
   {
     "id": "ann-binjointpgf-setup",
@@ -13,7 +17,11 @@
     "range": { "startLine": 57, "endLine": 75 },
     "type": "definition",
     "title": "Bernoulli and joint generating functions",
-    "content": "bernoulliPGF p t = (1 − p) + p·t is the PGF of a single Bernoulli(p) indicator: E[t^X] = P(X=0)·t⁰ + P(X=1)·t¹ = (1−p) + p·t. jointPGF s p t = ∏_{i∈s} bernoulliPGF (p i) (t i) is the joint PGF of independent indicators (Xᵢ)_{i∈s} with per-index success probabilities p i, evaluated at formal variables t i. Because the indicators are independent, the joint transform E[∏ tᵢ^{Xᵢ}] is exactly this product — the modelling assumption is baked into the product form."
+    "content": "bernoulliPGF p t = (1 − p) + p·t is the PGF of a single Bernoulli(p) indicator: E[t^X] = P(X=0)·t⁰ + P(X=1)·t¹ = (1−p) + p·t. jointPGF s p t = ∏_{i∈s} bernoulliPGF (p i) (t i) is the joint PGF of independent indicators (Xᵢ)_{i∈s} with per-index success probabilities p i, evaluated at formal variables t i. Because the indicators are independent, the joint transform E[∏ tᵢ^{Xᵢ}] is exactly this product — the modelling assumption is baked into the product form.",
+    "mathContext": "$G_{X}(t) = (1-p) + p t$ for $X \\sim \\mathrm{Bernoulli}(p)$; $G_{(X_i)_{i\\in s}}(t) = \\prod_{i\\in s} \\big((1-p_i) + p_i t_i\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bernoulli distribution", "product of PGFs", "Finset.prod", "expectation of a product"],
+    "prerequisites": ["expectation", "generating functions"]
   },
   {
     "id": "ann-binjointpgf-normalisation",
@@ -21,7 +29,11 @@
     "range": { "startLine": 77, "endLine": 89 },
     "type": "proof",
     "title": "These are genuine PGFs (total probability 1)",
-    "content": "bernoulliPGF_one: at t = 1, (1−p) + p·1 = 1 (by ring). jointPGF_one: evaluating every variable at 1 makes each factor 1, so the product is 1 — proved by Finset.prod_eq_one, reducing to the Bernoulli case factorwise. Evaluating a PGF at 1 recovers the total probability mass, so these lemmas confirm bernoulliPGF and jointPGF are honest generating functions rather than arbitrary polynomials."
+    "content": "bernoulliPGF_one: at t = 1, (1−p) + p·1 = 1 (by ring). jointPGF_one: evaluating every variable at 1 makes each factor 1, so the product is 1 — proved by Finset.prod_eq_one, reducing to the Bernoulli case factorwise. Evaluating a PGF at 1 recovers the total probability mass, so these lemmas confirm bernoulliPGF and jointPGF are honest generating functions rather than arbitrary polynomials.",
+    "mathContext": "$G(1) = \\sum_k \\mathbb{P}(X=k) = 1$: $\\mathrm{bernoulliPGF}\\,p\\,1 = 1$ and $\\mathrm{jointPGF}\\,s\\,p\\,\\mathbf{1} = \\prod_{i\\in s} 1 = 1$.",
+    "significance": "technical",
+    "relatedConcepts": ["normalization", "total probability", "Finset.prod_eq_one", "generating function at 1"],
+    "prerequisites": ["probability mass functions"]
   },
   {
     "id": "ann-binjointpgf-union",
@@ -29,7 +41,11 @@
     "range": { "startLine": 91, "endLine": 104 },
     "type": "proof",
     "title": "jointPGF_union: the independence certificate",
-    "content": "The joint PGF over a disjoint union factors as jointPGF (S ∪ T) p t = jointPGF S p t · jointPGF T p t. After unfolding the definitions this is exactly Finset.prod_union h (a product over a disjoint union splits into the product over each part). This separation of the joint transform into an S-part and a T-part is the generating-function certificate that the two blocks are jointly independent."
+    "content": "The joint PGF over a disjoint union factors as jointPGF (S ∪ T) p t = jointPGF S p t · jointPGF T p t. After unfolding the definitions this is exactly Finset.prod_union h (a product over a disjoint union splits into the product over each part). This separation of the joint transform into an S-part and a T-part is the generating-function certificate that the two blocks are jointly independent.",
+    "mathContext": "$S \\cap T = \\varnothing \\Rightarrow \\prod_{i\\in S\\cup T} f_i = \\big(\\prod_{i\\in S} f_i\\big)\\big(\\prod_{i\\in T} f_i\\big)$ (Finset.prod_union).",
+    "significance": "key",
+    "relatedConcepts": ["disjoint union", "Finset.prod_union", "multiplicativity", "independence factorization"],
+    "prerequisites": ["finite products", "disjoint sets"]
   },
   {
     "id": "ann-binjointpgf-const",
@@ -37,7 +53,11 @@
     "range": { "startLine": 106, "endLine": 117 },
     "type": "proof",
     "title": "jointPGF_const: a homogeneous block is a Binomial PGF",
-    "content": "With a common success probability p and a common formal variable u, the block PGF collapses: jointPGF s (fun _ => p) (fun _ => u) = bernoulliPGF p u ^ s.card = ((1−p) + p·u)^|s|. This is Finset.prod_const (a product of a constant over s equals that constant raised to s.card). The right-hand side is precisely the PGF of Binomial(|s|, p), exhibiting the block-sum as a Binomial directly from the factored form."
+    "content": "With a common success probability p and a common formal variable u, the block PGF collapses: jointPGF s (fun _ => p) (fun _ => u) = bernoulliPGF p u ^ s.card = ((1−p) + p·u)^|s|. This is Finset.prod_const (a product of a constant over s equals that constant raised to s.card). The right-hand side is precisely the PGF of Binomial(|s|, p), exhibiting the block-sum as a Binomial directly from the factored form.",
+    "mathContext": "$\\prod_{i\\in s}\\big((1-p)+pu\\big) = \\big((1-p)+pu\\big)^{|s|}$ — the PGF of $\\mathrm{Binomial}(|s|, p)$, since $G_{X+Y} = G_X G_Y$ for i.i.d. Bernoullis.",
+    "significance": "key",
+    "relatedConcepts": ["binomial distribution", "Finset.prod_const", "sum of i.i.d. Bernoullis", "PGF of a sum"],
+    "prerequisites": ["binomial distribution", "finite products"]
   },
   {
     "id": "ann-binjointpgf-bivariate",
@@ -45,6 +65,10 @@
     "range": { "startLine": 119, "endLine": 144 },
     "type": "proof",
     "title": "disjoint_blocks_pgf: two disjoint block-sums are independent Binomials",
-    "content": "Assign variable u to block S and v to disjoint block T via the selector `if i ∈ S then u else v`. The bivariate PGF ∏_{i∈S∪T} bernoulliPGF p (if i∈S then u else v) factors as ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T|. Proof: Finset.prod_union splits the product; then congr 1 handles each block. On S, every i satisfies i ∈ S so if_pos selects u and Finset.prod_const gives the |S| power. On T, disjointness (Finset.disjoint_right.mp h hi) gives i ∉ S so if_neg selects v, and Finset.prod_const gives the |T| power. The clean separation into a u-function times a v-function, each a Binomial PGF, is exactly the PGF independence criterion — answering the parent's open question in the binomial model."
+    "content": "Assign variable u to block S and v to disjoint block T via the selector `if i ∈ S then u else v`. The bivariate PGF ∏_{i∈S∪T} bernoulliPGF p (if i∈S then u else v) factors as ((1−p)+p·u)^|S| · ((1−p)+p·v)^|T|. Proof: Finset.prod_union splits the product; then congr 1 handles each block. On S, every i satisfies i ∈ S so if_pos selects u and Finset.prod_const gives the |S| power. On T, disjointness (Finset.disjoint_right.mp h hi) gives i ∉ S so if_neg selects v, and Finset.prod_const gives the |T| power. The clean separation into a u-function times a v-function, each a Binomial PGF, is exactly the PGF independence criterion — answering the parent's open question in the binomial model.",
+    "mathContext": "$G_{U,V}(u,v) = \\big((1-p)+pu\\big)^{|S|}\\big((1-p)+pv\\big)^{|T|} = G_U(u)\\,G_V(v)$, so $U \\sim \\mathrm{Bin}(|S|,p)$ and $V \\sim \\mathrm{Bin}(|T|,p)$ are independent.",
+    "significance": "key",
+    "relatedConcepts": ["bivariate PGF", "independence criterion", "if-then-else selector", "Finset.disjoint_right", "binomial blocks"],
+    "prerequisites": ["joint distributions", "finite products", "case analysis"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for binomial-theorem-oq-02-oq-01-oq-02-oq-01 (joint independence of disjoint blocks via PGF factorization).

## Gap addressed
meta.json was already complete (overview with 5 keyInsights, 6 sections, full conclusion), but all 6 annotations carried only `content`. Added `mathContext` (LaTeX for the joint-PGF factorization criterion, Bernoulli/joint PGFs, disjoint-union splitting, and the bivariate Binomial×Binomial separation), `significance`, `relatedConcepts`, and `prerequisites` to **all 6**.

Line ranges unchanged. meta.json unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)