### PR TITLE
Fix: create missing gallery entry for inverse-galois-oq-04

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-header-oq04",
+    "proofId": "inverse-galois-oq-04",
+    "range": { "startLine": 3, "endLine": 53 },
+    "type": "concept",
+    "title": "OQ-04: eliminating the last A₅ axiom, and the tower setup",
+    "content": "The docstring frames the parent's open question OQ-04 — can Dedekind's theorem be formalized to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`? A companion file already reduces that axiom to a single arithmetic fact, `3 ∣ inertiaDegIn (7) (𝒪 q.SplittingField)`, and lays out a three-step Kummer–Dedekind route: (1) a cubic factor of q mod 7 yields a prime of inertia degree 3; (2) inertia degrees multiply in a tower; (3) Galois uniformity spreads the degree to all primes over 7. This file machine-checks the abstract heart — steps (2) and (3) — with 0 axioms and 0 sorries. The variable block fixes a scalar tower R ⊆ S ⊆ T (`IsScalarTower R S T`) with a finite group G making `IsGaloisGroup G R T`, and a compatible chain of maximal ideals p ⊲ R, P ⊲ S, Q ⊲ T with lying-over instances; critically S carries NO normality hypothesis, since in the A₅ application the middle field ℚ(α) is not Galois over ℚ. The `include G Q` directive forces G and the top prime Q to be quantified arguments.",
+    "mathContext": "Inertia degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. For a Galois extension all primes over $p$ share one inertia degree, denoted $\\mathrm{inertiaDegIn}\\,p\\,T$. Here $R \\subseteq S \\subseteq T$ with $T/R$ Galois via $G$ and $S$ possibly non-normal.",
+    "significance": "critical",
+    "relatedConcepts": ["inverse Galois problem", "inertia degree", "Kummer–Dedekind", "scalar tower", "non-normal extension"]
+  },
+  {
+    "id": "ann-tower-brick",
+    "proofId": "inverse-galois-oq-04",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "technique",
+    "title": "The brick: inertiaDeg p P ∣ inertiaDegIn p T",
+    "content": "inertiaDeg_dvd_inertiaDegIn is the core theorem. Its proof is a two-line assembly: `inertiaDeg_algebra_tower` gives the multiplicativity inertiaDeg p Q = inertiaDeg p P · inertiaDeg P Q (no Galois hypothesis on S), and `inertiaDegIn_eq_inertiaDeg` uses the Galois action to identify inertiaDegIn p T with inertiaDeg p Q. Rewriting with both and applying `dvd_mul_right` exhibits inertiaDeg p P as a factor. Transitivity of lying-over (Q lies over p) comes from `LiesOver.trans`.",
+    "mathContext": "$\\mathrm{inertiaDegIn}\\,p\\,T = f(Q\\mid p) = f(P\\mid p)\\,f(Q\\mid P)$, so $f(P\\mid p) \\mid \\mathrm{inertiaDegIn}\\,p\\,T$.",
+    "significance": "critical",
+    "relatedConcepts": ["inertia degree multiplicativity", "Galois uniformity", "divisibility"]
+  },
+  {
+    "id": "ann-reduction-form",
+    "proofId": "inverse-galois-oq-04",
+    "range": { "startLine": 74, "endLine": 85 },
+    "type": "concept",
+    "title": "The reduction form consumed by the A₅ argument",
+    "content": "dvd_inertiaDegIn_of_dvd_inertiaDeg restates the brick in the shape the A₅ realization needs: to prove d ∣ inertiaDegIn p T it suffices to exhibit ONE intermediate prime P (over p, below a chosen top prime Q) with d ∣ inertiaDeg p P. The proof is `hd.trans (inertiaDeg_dvd_inertiaDegIn G p P Q)`. In the application, Kummer–Dedekind produces a prime P of 𝒪(ℚ(α)) with inertiaDeg (7) P = 3, and this lemma promotes 3 ∣ inertiaDeg (7) P to 3 ∣ inertiaDegIn (7) (𝒪 q.SplittingField).",
+    "mathContext": "$d \\mid f(P\\mid p) \\Rightarrow d \\mid \\mathrm{inertiaDegIn}\\,p\\,T$, applied with $d = 3$, $p = (7)$.",
+    "significance": "critical",
+    "relatedConcepts": ["reduction lemma", "Kummer–Dedekind", "three_dvd_gal_card", "A₅ realizability"]
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "inverse-galois-oq-04",
+  "title": "Inverse Galois OQ-04: The Dedekind Tower Brick Toward Eliminating the Last A₅ Axiom",
+  "slug": "inverse-galois-oq-04",
+  "description": "Answers the parent entry's open question OQ-04 — 'Can Dedekind's theorem be formalized to eliminate the last A₅ axiom (three_dvd_gal_card)?' — by isolating and machine-checking the abstract, reusable step of the argument. In full generality, for a tower of commutative rings R ⊆ S ⊆ T with T/R Galois (via a finite group G) and S a possibly non-normal intermediate ring, the intermediate inertia degree inertiaDeg p P divides the Galois-invariant inertia degree inertiaDegIn p T. This packages inertia-degree tower-multiplicativity together with Galois uniformity, reducing the residual gap of the A₅ realizability axiom to producing a single intermediate prime P with 3 ∣ inertiaDeg p P (supplied by Kummer–Dedekind). Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "number-theory",
+      "algebraic-number-theory",
+      "inverse-galois",
+      "inertia-degree",
+      "dedekind-domain"
+    ],
+    "proofRepoPath": "Proofs/DedekindInertiaTower.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "prerequisites": [
+      "Algebraic number theory (Dedekind domains, prime factorization in extensions, inertia degree)",
+      "Galois theory (Galois extensions, decomposition of primes, uniformity of inertia degrees)",
+      "Ring/module towers (scalar towers R ⊆ S ⊆ T, lying-over relations)"
+    ],
+    "assumptions": "None beyond the ordinary foundational axioms of Lean/Mathlib (propext, Classical.choice, Quot.sound). No `axiom` declarations and no `sorry`: both theorems are derived entirely from Mathlib's `inertiaDeg_algebra_tower` and `inertiaDegIn_eq_inertiaDeg`. This entry does not by itself close the A₅ realizability axiom `three_dvd_gal_card`; it verifies the abstract tower + Galois-uniformity step (steps 2–3 of the three-step Kummer–Dedekind route) and reduces the residual gap to the single Kummer–Dedekind divisibility `3 ∣ inertiaDeg (7) P`.",
+    "relatedProblems": [
+      {
+        "id": "inverse-galois",
+        "relationship": "Parent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+      },
+      {
+        "id": "inverse-galois-a5",
+        "relationship": "The A₅ realization whose sole remaining assumption three_dvd_gal_card this brick is designed to help discharge"
+      },
+      {
+        "id": "inverse-galois-oq-06",
+        "relationship": "Sister entry realizing A₅ over ℚ (also anchored on the InverseGaloisA5 development)"
+      }
+    ],
+    "lineCount": 85,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The Inverse Galois Problem asks whether every finite group occurs as $\\mathrm{Gal}(K/\\mathbb{Q})$. The alternating group $A_5$ — the smallest non-solvable group — is realizable over $\\mathbb{Q}$, and the Lean development `Proofs.InverseGaloisA5` formalizes this realization down to a single remaining assumption: `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`, i.e. that $3$ divides the order of the Galois group of the chosen quintic. A companion file reduces this in turn to one sharp arithmetic fact about inertia degrees, $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$, at an unramified prime over $7$. Discharging that fact via Dedekind's factorization theorem is exactly the parent entry's fourth open question (OQ-04).",
+    "problemStatement": "**Can Dedekind's theorem be formalized to eliminate the last $A_5$ axiom `three_dvd_gal_card`?**\n\nThe reduction produces a three-step route to $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$: (1) Kummer–Dedekind gives a prime of $\\mathcal{O}_{\\mathbb{Q}(\\alpha)}$ of inertia degree $3$; (2) inertia-degree multiplicativity in the tower lifts this to a prime of the splitting field; (3) Galois uniformity spreads it to all primes over $7$. This entry formalizes the abstract heart — steps (2) and (3) — as a single, fully general divisibility theorem.",
+    "text": "An 85-line, 0-axiom, 2-theorem file. It fixes an arbitrary tower of commutative rings $R \\subseteq S \\subseteq T$ with a scalar-tower structure, a finite group $G$ acting so that $T/R$ is Galois, and a compatible chain of maximal ideals $p \\lhd R$, $P \\lhd S$, $Q \\lhd T$ with $P$ lying over $p$ and $Q$ lying over $P$. The intermediate ring $S$ is allowed to be non-normal, which is essential: in the $A_5$ application the middle field $\\mathbb{Q}(\\alpha)$ is not Galois over $\\mathbb{Q}$. The main theorem `inertiaDeg_dvd_inertiaDegIn` proves $\\mathrm{inertiaDeg}\\,p\\,P \\mid \\mathrm{inertiaDegIn}\\,p\\,T$, and the reduction form `dvd_inertiaDegIn_of_dvd_inertiaDeg` restates it as: to get $d \\mid \\mathrm{inertiaDegIn}\\,p\\,T$ it suffices to exhibit one intermediate prime $P$ with $d \\mid \\mathrm{inertiaDeg}\\,p\\,P$.",
+    "proofStrategy": "The core theorem is a two-line assembly of two Mathlib facts:\n\n1. **Tower multiplicativity** (`inertiaDeg_algebra_tower`): $\\mathrm{inertiaDeg}\\,p\\,Q = \\mathrm{inertiaDeg}\\,p\\,P \\cdot \\mathrm{inertiaDeg}\\,P\\,Q$. This needs **no** Galois hypothesis on the middle ring $S$, which is exactly why the non-normal $\\mathbb{Q}(\\alpha)$ is admissible.\n\n2. **Galois uniformity** (`inertiaDegIn_eq_inertiaDeg`): because $T/R$ is Galois, every prime of $T$ over $p$ has the same inertia degree, so $\\mathrm{inertiaDegIn}\\,p\\,T = \\mathrm{inertiaDeg}\\,p\\,Q$.\n\nCombining, $\\mathrm{inertiaDegIn}\\,p\\,T = \\mathrm{inertiaDeg}\\,p\\,P \\cdot \\mathrm{inertiaDeg}\\,P\\,Q$, so $\\mathrm{inertiaDeg}\\,p\\,P$ is a factor (`dvd_mul_right`). The transitivity of the lying-over relation ($Q$ lies over $p$) is obtained from `LiesOver.trans`. The reduction form then follows by `Dvd.Trans`.",
+    "keyInsights": [
+      "**Non-normality of the middle ring is a feature, not a bug**: inertia-degree tower-multiplicativity holds with no Galois hypothesis on $S$, which is precisely what lets the argument route through the non-Galois field $\\mathbb{Q}(\\alpha)$ in the $A_5$ application.",
+      "**Galois uniformity is the only place the group acts**: the finite Galois group $G$ enters solely through `inertiaDegIn_eq_inertiaDeg`, collapsing the choice of top prime $Q$ so that a divisibility at one prime propagates to the Galois-invariant $\\mathrm{inertiaDegIn}$.",
+      "**Divisibility, not equality, is the right currency**: phrasing the brick as $\\mathrm{inertiaDeg}\\,p\\,P \\mid \\mathrm{inertiaDegIn}\\,p\\,T$ (rather than tracking exact degrees) is exactly what the $A_5$ argument consumes — it only needs $3 \\mid \\mathrm{inertiaDegIn}$, supplied by a single Kummer–Dedekind cubic factor.",
+      "**Honest partial progress**: this entry does not on its own remove `three_dvd_gal_card`; it verifies the abstract steps (2)–(3) with 0 axioms and cleanly isolates the one remaining Kummer–Dedekind input, so the residual gap is now a single concrete divisibility fact."
+    ],
+    "prerequisites": [
+      "Algebraic number theory (Dedekind domains, prime factorization in extensions, inertia degree)",
+      "Galois theory (Galois extensions, decomposition of primes, uniformity of inertia degrees)",
+      "Ring/module towers (scalar towers R ⊆ S ⊆ T, lying-over relations)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "The Tower Setup",
+      "startLine": 40,
+      "endLine": 53,
+      "summary": "Fixes a scalar tower R ⊆ S ⊆ T with T/R Galois via a finite group G, and a compatible chain of maximal ideals p, P, Q with the lying-over relations; S is allowed to be non-normal"
+    },
+    {
+      "id": "tower-brick",
+      "title": "The Tower + Galois-Uniformity Brick",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "inertiaDeg_dvd_inertiaDegIn: inertiaDeg p P ∣ inertiaDegIn p T, via tower-multiplicativity (no Galois hypothesis on S) plus Galois uniformity of the top inertia degree"
+    },
+    {
+      "id": "reduction-form",
+      "title": "The Reduction Form",
+      "startLine": 74,
+      "endLine": 85,
+      "summary": "dvd_inertiaDegIn_of_dvd_inertiaDeg: to prove d ∣ inertiaDegIn p T it suffices to exhibit one intermediate prime P with d ∣ inertiaDeg p P — the shape consumed by the A₅ argument"
+    }
+  ],
+  "conclusion": {
+    "mainResult": "For any tower of commutative rings R ⊆ S ⊆ T with T/R Galois (finite group G) and a compatible chain of maximal ideals p ⊲ R, P ⊲ S, Q ⊲ T, the intermediate inertia degree inertiaDeg p P divides the Galois-invariant inertiaDegIn p T (with S possibly non-normal). Consequently, d ∣ inertiaDegIn p T whenever some intermediate prime P satisfies d ∣ inertiaDeg p P. Both theorems are machine-checked with 0 axioms and 0 sorries.",
+    "openQuestions": [
+      "Formalize the remaining Kummer–Dedekind step (step 1): the prime of 𝒪(ℚ(α)) matching the irreducible cubic factor of q mod 7 has inertia degree 3.",
+      "Compose this brick with the Kummer–Dedekind step to fully discharge three_dvd_gal_card and make the A₅ realization axiom-free.",
+      "Generalize the reduction to other primes/degrees needed for realizations beyond A₅."
+    ],
+    "summary": "This entry answers OQ-04 in part: it formalizes, with 0 axioms and 0 sorries, the abstract tower + Galois-uniformity step of the Dedekind route toward eliminating the last A₅ axiom three_dvd_gal_card. The general theorem inertiaDeg p P ∣ inertiaDegIn p T (S possibly non-normal) reduces the residual gap to a single Kummer–Dedekind divisibility 3 ∣ inertiaDeg (7) P.",
+    "implications": "By packaging the tower-multiplicativity and Galois-uniformity steps into one reusable, fully general divisibility lemma, the brick converts the last standing A₅ realizability assumption into a single concrete Kummer–Dedekind computation. The same reduction form applies to any realization argument that needs a prescribed prime to divide a Galois-invariant inertia degree."
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Parent entry stating the Inverse Galois Problem; this entry answers its open question OQ-04"
+    },
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "related",
+      "description": "The A₅ realization whose sole remaining axiom three_dvd_gal_card this brick is designed to help eliminate"
+    },
+    {
+      "targetId": "inverse-galois-oq-06",
+      "relationship": "related",
+      "description": "Sister entry realizing A₅ over ℚ, anchored on the same InverseGaloisA5 development"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/DedekindInertiaTower.lean",
+    "lineCount": 85,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "lemmaCount": 0,
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
## Fix

`DedekindInertiaTower.lean` was merged (PR #32107, commit `b4be53ca445`, tagged `[VERIFIED, 0-axiom]`) but never received a `src/data/proofs/` directory, so it is invisible in the gallery.

## Evidence

**Before**: `proofs/Proofs/DedekindInertiaTower.lean` exists (85 lines, 2 theorems, 0 sorries, 0 `axiom` declarations — uses only `propext`/`Classical.choice`/`Quot.sound`) but is referenced by no `meta.json`; siblings `inverse-galois-oq-01/02/03/05/06` all have gallery dirs, `oq-04` did not.

**After**: adds `src/data/proofs/inverse-galois-oq-04/{meta.json,annotations.json}`. The entry answers the parent `inverse-galois` entry's fourth open question — *"Can Dedekind's theorem be formalized to eliminate the last A₅ axiom (`three_dvd_gal_card`)?"* — by machine-checking the abstract tower + Galois-uniformity step (`inertiaDeg p P ∣ inertiaDegIn p T`, with the middle ring possibly non-normal), reducing the residual gap to a single Kummer–Dedekind divisibility.

- `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` (matches sibling `inverse-galois-oq-05` profile)
- Annotation ranges validated against Lean constructs via `pnpm annotations:build` (my entry produces 0 errors)
- All three `crossReferences` targets resolve to existing dirs

---
Automated fix by lean-mechanic agent.