### PR TITLE
Enrich cubic Pell chain (pell-equation-oq-05): add Lagrange & Neukirch references

### DIFF
--- a/src/data/proofs/pell-equation-oq-05/meta.json
+++ b/src/data/proofs/pell-equation-oq-05/meta.json
@@ -190,6 +190,20 @@
       "year": "628",
       "venue": "—",
       "note": "The composition law for x² − Dy², generalized here to the multiplicativity of the cubic norm form."
+    },
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Solution d'un problème d'arithmétique (Additions to Euler's Éléments d'algèbre)",
+      "year": "1770",
+      "venue": "Œuvres de Lagrange, vol. 1",
+      "note": "First complete proof that x² − Dy² = 1 always has a nontrivial solution, via continued fractions and the periodicity of √D — the classical real-quadratic Pell theory whose 'no solution or infinitely many' dichotomy is generalized here to the cubic field ℚ(∛2)."
+    },
+    {
+      "authors": "Neukirch, Jürgen",
+      "title": "Algebraic Number Theory",
+      "year": "1999",
+      "venue": "Grundlehren der mathematischen Wissenschaften 322, Springer",
+      "note": "Standard reference for rings of integers, norm forms N_{K/ℚ}, and Dirichlet's unit theorem in a general number field — the framework in which the fundamental unit u = ∛2 − 1 and the higher-degree Pell chain of 𝒪_K = ℤ[∛2] live."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-05`.

This entry was already fully enriched at the annotation/overview level (8 depth-field annotations, 5 keyInsights, full conclusion). Per the diminishing-returns guardrail I did not inflate those. The one genuine gap was a thin reference list (2 items) for a classical Pell-named result, missing its two most central citations:
- **Lagrange (1770)** — continued-fraction proof that x²−Dy²=1 always has a nontrivial solution; the real-quadratic Pell theory this cubic chain generalizes.
- **Neukirch (1999)** — standard reference for norm forms and Dirichlet's unit theorem, the framework for the fundamental unit ∛2−1.

References 2→4 (cap 25). Only meta.json references touched; JSON validated.

(Note: this re-opens the pell change on a clean unique branch after a branch-reuse tangle temporarily merged unrelated content under PR #32983.)