### PR TITLE
research(ramsey-r4k-oq-05): full Erdős–Szekeres bound R(r,s) ≤ C(r+s-2,r-1) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RamseyR4kOQ05.lean
+++ b/proofs/Proofs/RamseyR4kOQ05.lean
@@ -1,0 +1,126 @@
+/-
+  RamseyR4kOQ05.lean
+
+  The full Erdős–Szekeres upper bound for Ramsey numbers.
+
+  ════════════════════════════════════════════════════════════════════════════
+  This answers the open question `ramsey-r4k-oq-05` from the parent gallery entry
+  `ramsey-r4k`:
+
+    "Can `ramsey_recursion` be generalized to give the full Erdős–Szekeres upper
+     bound R(r,s) ≤ C(r+s-2, r-1) by induction on r+s, using
+     `ramseyUpperBound_mono_s` and Pascal's identity to close the induction?"
+
+  The answer is YES.  Working over the parent's `RamseyProp`/`ramseyUpperBound`
+  API (from `Proofs.RamseyR4k`), we prove
+
+    RamseyProp (C(r+s-2, r-1)) r s      for all r, s ≥ 1,
+
+  i.e. the complete graph on C(r+s-2, r-1) vertices, 2-coloured, always contains a
+  red r-clique or a blue s-clique.  Equivalently, R(r,s) ≤ C(r+s-2, r-1), the
+  Erdős–Szekeres (1935) bound.  The parent only used the recursion at the single
+  point (4,k); here it is discharged for the entire diagonal-and-off-diagonal
+  table by a clean strong induction on r + s, with Pascal's identity
+  (`Nat.choose_succ_succ'`) closing the step exactly.
+  ════════════════════════════════════════════════════════════════════════════
+
+  Classical statement (Erdős–Szekeres 1935 / Ramsey 1930):
+    R(r, s) ≤ R(r-1, s) + R(r, s-1),  with  R(r,1) = R(1,s) = 1,
+  which unrolls to R(r,s) ≤ C(r+s-2, r-1).  Our `RamseyProp n r s` says K_n → (r,s),
+  so the additive recursion `ramsey_recursion` plays the role of the R(r-1,s)+R(r,s-1)
+  step and Pascal glues the two binomial coefficients into one.
+-/
+import Proofs.RamseyR4k
+
+namespace RamseyR4k
+
+open Nat
+
+/-- **Erdős–Szekeres upper bound (strong-induction core).**  For every bound `N`
+and all `r, s ≥ 1` with `r + s ≤ N`, the complete graph on `C(r+s-2, r-1)`
+vertices has the Ramsey property `RamseyProp _ r s`.  The bound variable `N`
+carries the strong induction on `r + s`. -/
+theorem ramseyProp_erdos_szekeres_aux :
+    ∀ (N r s : ℕ), r + s ≤ N → 1 ≤ r → 1 ≤ s →
+      RamseyProp (Nat.choose (r + s - 2) (r - 1)) r s := by
+  intro N
+  induction N with
+  | zero =>
+    intro r s hN hr hs
+    omega
+  | succ N IH =>
+    intro r s _ hr hs
+    -- Base case r = 1: C(1+s-2, 0) = C(s-1, 0) = 1, and K₁ → (1, s).
+    rcases Nat.lt_or_ge r 2 with hr1 | hr2
+    · have hr_eq : r = 1 := by omega
+      subst hr_eq
+      have hc : Nat.choose (1 + s - 2) (1 - 1) = 1 := by simp
+      rw [hc]
+      exact ramseyProp_one_left 1 s le_rfl
+    -- Base case s = 1: C(r+1-2, r-1) = C(r-1, r-1) = 1, and K₁ → (r, 1).
+    rcases Nat.lt_or_ge s 2 with hs1 | hs2
+    · have hs_eq : s = 1 := by omega
+      subst hs_eq
+      have hc : Nat.choose (r + 1 - 2) (r - 1) = 1 := by
+        have hidx : r + 1 - 2 = r - 1 := by omega
+        rw [hidx, Nat.choose_self]
+      rw [hc]
+      exact ramseyProp_one_right 1 r le_rfl
+    -- Inductive step: r ≥ 2 and s ≥ 2.
+    · -- IH on (r-1, s):  C((r-1)+s-2, (r-1)-1) = C(r+s-3, r-2)  vertices.
+      have ih1 : RamseyProp (Nat.choose (r - 1 + s - 2) (r - 1 - 1)) (r - 1) s :=
+        IH (r - 1) s (by omega) (by omega) hs
+      -- IH on (r, s-1):  C(r+(s-1)-2, r-1) = C(r+s-3, r-1)  vertices.
+      have ih2 : RamseyProp (Nat.choose (r + (s - 1) - 2) (r - 1)) r (s - 1) :=
+        IH r (s - 1) (by omega) hr (by omega)
+      -- Normalise the two binomial indices to a common r+s-3.
+      have e1 : r - 1 + s - 2 = r + s - 3 := by omega
+      have e1' : r - 1 - 1 = r - 2 := by omega
+      have e2 : r + (s - 1) - 2 = r + s - 3 := by omega
+      rw [e1, e1'] at ih1
+      rw [e2] at ih2
+      -- ramsey_recursion glues them additively.
+      have hrec := ramsey_recursion _ _ r s hr2 hs2 ih1 ih2
+      -- Pascal's identity turns the sum into the single coefficient C(r+s-2, r-1).
+      have hpascal : Nat.choose (r + s - 2) (r - 1)
+          = Nat.choose (r + s - 3) (r - 2) + Nat.choose (r + s - 3) (r - 1) := by
+        have h1 : r + s - 2 = (r + s - 3) + 1 := by omega
+        have h2 : r - 1 = (r - 2) + 1 := by omega
+        rw [h1, h2, Nat.choose_succ_succ']
+      rw [hpascal]
+      exact hrec
+
+/-- **The Erdős–Szekeres upper bound `R(r,s) ≤ C(r+s-2, r-1)`.**  For all
+`r, s ≥ 1`, any 2-colouring of the edges of the complete graph on
+`C(r+s-2, r-1)` vertices contains a red `r`-clique or a blue `s`-clique.
+
+This is the full generalization of the parent's `ramsey_recursion`, obtained by
+strong induction on `r + s` with Pascal's identity closing the step.  It
+subsumes every finite Ramsey-number upper bound, including the parent's
+`R(4,k) ≤ C(k+2, 3)`. -/
+theorem ramseyProp_erdos_szekeres (r s : ℕ) (hr : 1 ≤ r) (hs : 1 ≤ s) :
+    RamseyProp (Nat.choose (r + s - 2) (r - 1)) r s :=
+  ramseyProp_erdos_szekeres_aux (r + s) r s le_rfl hr hs
+
+/-- **Erdős–Szekeres stated through `ramseyUpperBound`.**  For `r, s ≥ 1`,
+`ramseyUpperBound r s = C(r+s-2, r-1)` witnesses the Ramsey property, i.e.
+`R(r,s) ≤ ramseyUpperBound r s`. -/
+theorem ramseyProp_ramseyUpperBound (r s : ℕ) (hr : 1 ≤ r) (hs : 1 ≤ s) :
+    RamseyProp (ramseyUpperBound r s) r s := by
+  have hpos : ¬ (r = 0 ∨ s = 0) := by omega
+  rw [ramseyUpperBound, if_neg hpos]
+  exact ramseyProp_erdos_szekeres r s hr hs
+
+/-- **Consistency with the parent's specialization.**  The general bound recovers
+`R(4,k) ≤ C(k+2, 3)`: `RamseyProp (C(k+2,3)) 4 k` for every `k ≥ 1`.  (The parent
+`RamseyR4k` states the upper bound `ramseyUpperBound 4 k = C(k+2,3)` numerically;
+here it is realized as an actual Ramsey guarantee.) -/
+theorem ramseyProp_r4k (k : ℕ) (hk : 1 ≤ k) :
+    RamseyProp (Nat.choose (k + 2) 3) 4 k := by
+  have h := ramseyProp_erdos_szekeres 4 k (by norm_num) hk
+  have hidx1 : 4 + k - 2 = k + 2 := by omega
+  have hidx2 : 4 - 1 = 3 := by norm_num
+  rw [hidx1, hidx2] at h
+  exact h
+
+end RamseyR4k

--- a/research/problems/ramsey-r4k-oq-05/knowledge.md
+++ b/research/problems/ramsey-r4k-oq-05/knowledge.md
@@ -1,0 +1,48 @@
+# Knowledge Base: ramsey-r4k-oq-05
+
+## Question
+
+Generalize the parent's `ramsey_recursion` to the full Erdős–Szekeres upper
+bound `R(r,s) ≤ C(r+s-2, r-1)` by induction on `r + s`, using Pascal's identity.
+
+## Status — RESOLVED (VERIFIED, 0-axiom), researcher-2, 2026-07-02
+
+**Answer: YES.** `proofs/Proofs/RamseyR4kOQ05.lean` (126 lines, 4 theorems,
+0 axioms, 0 sorries) proves, over the parent's `RamseyProp`/`ramseyUpperBound`
+API (`import Proofs.RamseyR4k`):
+
+- `ramseyProp_erdos_szekeres (r s) (1≤r) (1≤s) : RamseyProp (C(r+s-2, r-1)) r s`
+- `ramseyProp_ramseyUpperBound` — same, phrased via `ramseyUpperBound r s`
+- `ramseyProp_r4k (k) (1≤k) : RamseyProp (C(k+2,3)) 4 k` — recovers the parent's
+  R(4,k) ≤ C(k+2,3) as an actual Ramsey guarantee (consistency check).
+
+`#print axioms` on all three: `[propext, Classical.choice, Quot.sound]` only.
+
+## Proof recipe
+
+Strong induction on `r + s` via a bound variable `N` (`ramseyProp_erdos_szekeres_aux`).
+
+- **Base r = 1:** `C(s-1, 0) = 1` (simp), `ramseyProp_one_left 1 s le_rfl`.
+- **Base s = 1:** `C(r-1, r-1) = 1` (`Nat.choose_self` after `r+1-2 = r-1` by omega),
+  `ramseyProp_one_right 1 r le_rfl`.
+- **Step r,s ≥ 2:** IH on `(r-1,s)` → `C(r+s-3, r-2)` vertices, IH on `(r,s-1)` →
+  `C(r+s-3, r-1)` vertices. Normalize all indices to `r+s-3` (omega), combine with
+  `ramsey_recursion`, then Pascal `Nat.choose_succ_succ'` rewrites the sum
+  `C(r+s-3,r-2)+C(r+s-3,r-1)` as `C(r+s-2,r-1)` — closing by rfl once the
+  `(·)+1` successor forms line up (`r+s-2 = (r+s-3)+1`, `r-1 = (r-2)+1`).
+
+The only friction is Nat subtraction bookkeeping; omega handles every index identity.
+
+## Build notes (infra)
+
+- Parent olean must be built to import it: `ulimit -s 65520` before
+  `lake env lean -o .../RamseyR4k.olean Proofs/RamseyR4k.lean`. Without the raised
+  stack, olean serialization stack-overflows (exit 139, looks like a segfault).
+- Verify child + axioms the same way (`-o` build under raised stack, then a tiny
+  in-`proofs/` checker file with `#print axioms`).
+
+## Follow-ups (not pursued — depth guard)
+
+This slug is at OQ depth 1 (`ramsey-r4k-oq-05`), so follow-ups are allowed, but the
+natural next steps are substantial: the Erdős probabilistic lower bound
+`R(k,k) ≥ 2^{k/2}` over the same API, or the recent `(4-ε)^k` upper bound.

--- a/src/data/proofs/ramsey-r4k-oq-05/annotations.json
+++ b/src/data/proofs/ramsey-r4k-oq-05/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-r4koq05-overview",
+    "proofId": "ramsey-r4k-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "From ramsey_recursion at (4,k) to the Full Erdős–Szekeres Table",
+    "content": "The header states the parent open question — can ramsey_recursion be generalized to the full Erdős–Szekeres bound R(r,s) ≤ C(r+s-2, r-1) — and answers YES. The parent entry ramsey-r4k proves the additive Ramsey recursion R(r,s) ≤ R(r-1,s) + R(r,s-1) and the boundary cases, but invokes them only at the single slice (4,k). This file runs the induction in full: RamseyProp (C(r+s-2, r-1)) r s for all r, s ≥ 1. The Erdős–Szekeres recursion is exactly the Pascal recursion, so the binomial closed form is the solution of that recurrence with boundary 1's.",
+    "mathContext": "$R(r,s) \\le R(r-1,s) + R(r,s-1)$, $R(r,1)=R(1,s)=1$ $\\Rightarrow$ $R(r,s) \\le \\binom{r+s-2}{r-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey numbers",
+      "Erdős–Szekeres bound",
+      "Pascal's identity"
+    ],
+    "prerequisites": [
+      "Ramsey's theorem",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-r4koq05-basecases",
+    "proofId": "ramsey-r4k-oq-05",
+    "range": {
+      "startLine": 43,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "Strong Induction on r+s; the Two Base Cases",
+    "content": "ramseyProp_erdos_szekeres_aux carries the strong induction via a bound variable N ≥ r+s. The N = 0 case is vacuous (r+s ≤ 0 with r,s ≥ 1 is impossible, closed by omega). Two boundary cases handle the edges of the Ramsey table: when r = 1, C(1+s-2, 1-1) = C(s-1, 0) = 1 and K₁ trivially has a red 1-clique (parent's ramseyProp_one_left); when s = 1, C(r+1-2, r-1) = C(r-1, r-1) = 1 by Nat.choose_self and K₁ has a blue 1-clique (ramseyProp_one_right). Both reduce the vertex count to 1.",
+    "mathContext": "$\\binom{s-1}{0} = \\binom{r-1}{r-1} = 1$; $K_1 \\to (1,s)$ and $K_1 \\to (r,1)$ are trivial.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strong induction",
+      "boundary conditions",
+      "C(n,0) and C(n,n)"
+    ],
+    "prerequisites": [
+      "ramseyProp_one_left / ramseyProp_one_right",
+      "Nat.choose_self"
+    ]
+  },
+  {
+    "id": "ann-r4koq05-inductive-step",
+    "proofId": "ramsey-r4k-oq-05",
+    "range": {
+      "startLine": 67,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "The Inductive Step: ramsey_recursion + Pascal",
+    "content": "For r, s ≥ 2 the two induction hypotheses give the Ramsey property on C((r-1)+s-2, (r-1)-1) = C(r+s-3, r-2) vertices (for (r-1, s)) and on C(r+(s-1)-2, r-1) = C(r+s-3, r-1) vertices (for (r, s-1)). The main friction is Nat subtraction: the three index expressions are normalized to a common r+s-3 by omega (e1, e1', e2) before use. The parent's ramsey_recursion then combines the two guarantees additively into RamseyProp on C(r+s-3, r-2) + C(r+s-3, r-1) vertices, and Pascal's identity Nat.choose_succ_succ' rewrites that exact sum as C(r+s-2, r-1) — closing the step by rfl once the successor forms line up.",
+    "mathContext": "$\\binom{r+s-3}{r-2} + \\binom{r+s-3}{r-1} = \\binom{r+s-2}{r-1}$ (Pascal), matching ramsey_recursion's $n_1 + n_2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ramsey_recursion",
+      "Pascal's identity",
+      "Nat subtraction normalization"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_succ'",
+      "the additive Ramsey recursion"
+    ]
+  },
+  {
+    "id": "ann-r4koq05-main",
+    "proofId": "ramsey-r4k-oq-05",
+    "range": {
+      "startLine": 93,
+      "endLine": 112
+    },
+    "type": "concept",
+    "title": "The Bound, and Its Restatement via ramseyUpperBound",
+    "content": "ramseyProp_erdos_szekeres instantiates the strong-induction core at N = r+s, yielding the clean statement RamseyProp (C(r+s-2, r-1)) r s. ramseyProp_ramseyUpperBound then restates it through the parent's ramseyUpperBound function: since ramseyUpperBound r s = C(r+s-2, r-1) for r, s ≥ 1 (the r=0∨s=0 guard is discharged by omega), this reads directly as R(r,s) ≤ ramseyUpperBound r s, connecting to the parent's numerical upper-bound lemmas.",
+    "mathContext": "$\\mathrm{ramseyUpperBound}\\,r\\,s = \\binom{r+s-2}{r-1}$ for $r,s\\ge1$, so $R(r,s) \\le \\mathrm{ramseyUpperBound}\\,r\\,s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ramseyUpperBound",
+      "Ramsey number upper bound"
+    ],
+    "prerequisites": [
+      "the strong-induction core"
+    ]
+  },
+  {
+    "id": "ann-r4koq05-consistency",
+    "proofId": "ramsey-r4k-oq-05",
+    "range": {
+      "startLine": 114,
+      "endLine": 125
+    },
+    "type": "key-step",
+    "title": "Recovering the Parent's R(4,k) ≤ C(k+2,3)",
+    "content": "ramseyProp_r4k specializes the general bound to r = 4: since 4+k-2 = k+2 and 4-1 = 3, the theorem gives RamseyProp (C(k+2, 3)) 4 k for every k ≥ 1. This is precisely the parent entry's R(4,k) ≤ C(k+2,3), but now realized as an actual Ramsey guarantee (a coloring always yields a red 4-clique or blue k-clique) rather than only the numerical identity ramseyUpperBound 4 k = C(k+2,3) that the parent proved. The general result therefore strictly strengthens the parent.",
+    "mathContext": "$\\binom{4+k-2}{4-1} = \\binom{k+2}{3}$, giving $R(4,k) \\le \\binom{k+2}{3}$ as a realized Ramsey property.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "R(4,k)",
+      "specialization",
+      "consistency check"
+    ],
+    "prerequisites": [
+      "the main Erdős–Szekeres theorem"
+    ]
+  }
+]

--- a/src/data/proofs/ramsey-r4k-oq-05/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-05/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "ramsey-r4k-oq-05",
+  "title": "The Full Erdős–Szekeres Ramsey Upper Bound R(r,s) ≤ C(r+s-2, r-1)",
+  "slug": "ramsey-r4k-oq-05",
+  "description": "Generalizes the parent's ramsey_recursion from the single point (4,k) to the entire Ramsey table: for all r, s ≥ 1, the complete graph on C(r+s-2, r-1) vertices, 2-coloured, always contains a red r-clique or a blue s-clique. This is the classical Erdős–Szekeres (1935) upper bound R(r,s) ≤ C(r+s-2, r-1), proved by strong induction on r+s with Pascal's identity closing the step.",
+  "meta": {
+    "author": "Robb Walters (researcher-2)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamseyR4kOQ05.lean",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "graph-theory",
+      "binomial-coefficients",
+      "induction",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked; the three exported theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Builds on the parent's verified RamseyProp / ramsey_recursion / ramseyUpperBound API from Proofs.RamseyR4k.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ'",
+        "description": "Pascal's identity C(n+1,k+1) = C(n,k) + C(n,k+1); glues the two inductive binomial coefficients into one",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_self",
+        "description": "C(n,n) = 1; the s = 1 base case",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ramseyProp_erdos_szekeres: the full Erdős–Szekeres bound RamseyProp (C(r+s-2, r-1)) r s for all r, s ≥ 1 — the parent only invoked ramsey_recursion at (4,k)",
+      "Strong-induction schema on r+s (ramseyProp_erdos_szekeres_aux) that discharges the entire diagonal-and-off-diagonal Ramsey table in one argument",
+      "ramseyProp_ramseyUpperBound: the bound restated through the parent's ramseyUpperBound function, closing the loop with the parent's numerical upper-bound lemmas",
+      "ramseyProp_r4k: recovers the parent's R(4,k) ≤ C(k+2, 3) as an actual Ramsey guarantee, confirming consistency with the parent entry"
+    ],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Ramsey's theorem and Ramsey numbers R(r,s)",
+      "Binomial coefficients and Pascal's identity",
+      "Strong induction on ℕ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "**Ramsey (1930), Erdős–Szekeres (1935).** Frank Ramsey's 1930 theorem guarantees that any sufficiently large 2-coloured complete graph contains a monochromatic clique of prescribed size; the least such size is the Ramsey number R(r,s). In 1935, Paul Erdős and George Szekeres — in the paper that also launched what Szekeres called the 'Happy Ending problem' — gave the first general quantitative bound: R(r,s) ≤ R(r-1,s) + R(r,s-1), which together with the trivial boundary R(r,1) = R(1,s) = 1 unrolls, by exactly the recursion that generates Pascal's triangle, to the closed form R(r,s) ≤ C(r+s-2, r-1). This is still the standard textbook upper bound and the source of the classical estimate R(k,k) ≤ 4^k. The parent gallery entry `ramsey-r4k` formalizes the additive recursion step (`ramsey_recursion`) and the boundary cases, but applies them only at the single slice (4,k). This entry closes the loop by running the induction in full generality.",
+    "problemStatement": "Prove the Erdős–Szekeres upper bound in the parent's API: for all $r, s \\ge 1$, $\\mathrm{RamseyProp}\\,\\binom{r+s-2}{r-1}\\,r\\,s$ holds, i.e. $R(r,s) \\le \\binom{r+s-2}{r-1}$.",
+    "text": "For all r, s ≥ 1, the complete graph on C(r+s-2, r-1) vertices with any red/blue edge colouring contains a red r-clique or a blue s-clique. Equivalently R(r,s) ≤ C(r+s-2, r-1).",
+    "proofStrategy": "Strong induction on r + s. Base cases r = 1 and s = 1 give C(·, 0) = C(n, n) = 1 and follow from the parent's ramseyProp_one_left / ramseyProp_one_right (K₁ trivially contains a 1-clique). For r, s ≥ 2, the induction hypotheses supply RamseyProp on C(r+s-3, r-2) vertices (for (r-1, s)) and on C(r+s-3, r-1) vertices (for (r, s-1)); the parent's ramsey_recursion combines these additively into RamseyProp on C(r+s-3, r-2) + C(r+s-3, r-1) vertices, and Pascal's identity Nat.choose_succ_succ' rewrites that sum as exactly C(r+s-2, r-1).",
+    "keyInsights": [
+      "The Erdős–Szekeres recursion R(r,s) ≤ R(r-1,s) + R(r,s-1) is literally the Pascal recursion for binomial coefficients — so the closed form C(r+s-2, r-1) is not a coincidence but the solution of that recurrence with boundary 1's",
+      "The parent used ramsey_recursion only at (4,k); the whole content here is realizing that the SAME lemma, run by strong induction on r+s, discharges every entry of the Ramsey table at once",
+      "Nat subtraction bookkeeping is the only real friction: the indices (r-1)+s-2, (r-2), r+(s-1)-2 must all be normalized to r+s-3 (via omega) before Pascal (Nat.choose_succ_succ') closes the step by rfl",
+      "Working over the parent's Prop-valued RamseyProp (K_n → (r,s)) rather than a numeric R(r,s) keeps the statement constructive-friendly: the recursion is an honest combinatorial pigeonhole, not arithmetic on an extremal number",
+      "The bound is realized, not just stated: ramseyProp_r4k recovers the parent's R(4,k) ≤ C(k+2,3) as an actual Ramsey guarantee, so this entry strictly strengthens what the parent proved numerically"
+    ],
+    "prerequisites": [
+      "Ramsey numbers and the Ramsey property RamseyProp",
+      "Pascal's identity for binomial coefficients",
+      "Strong induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Docstring stating the open question (parent OQ-05) and the answer: the full Erdős–Szekeres bound R(r,s) ≤ C(r+s-2, r-1). Imports the parent's Ramsey infrastructure via Proofs.RamseyR4k and reopens the RamseyR4k namespace.",
+      "mathContext": "$R(r,s) \\le R(r-1,s) + R(r,s-1)$ with $R(r,1)=R(1,s)=1$ unrolls to $R(r,s) \\le \\binom{r+s-2}{r-1}$."
+    },
+    {
+      "id": "aux-induction",
+      "title": "Strong-Induction Core",
+      "startLine": 39,
+      "endLine": 91,
+      "summary": "ramseyProp_erdos_szekeres_aux: a bound variable N carries the strong induction on r+s. Base cases r=1 (C(s-1,0)=1, ramseyProp_one_left) and s=1 (C(r-1,r-1)=1, ramseyProp_one_right); inductive step applies the two IHs, normalizes the binomial indices to r+s-3, combines them with ramsey_recursion, and closes with Pascal (Nat.choose_succ_succ').",
+      "mathContext": "IH on $(r-1,s)$ gives $\\binom{r+s-3}{r-2}$ vertices, IH on $(r,s-1)$ gives $\\binom{r+s-3}{r-1}$; ramsey_recursion yields the sum, Pascal turns it into $\\binom{r+s-2}{r-1}$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Erdős–Szekeres Upper Bound",
+      "startLine": 93,
+      "endLine": 112,
+      "summary": "ramseyProp_erdos_szekeres instantiates the core at N = r+s. ramseyProp_ramseyUpperBound restates it through the parent's ramseyUpperBound function (unfolding the r=0∨s=0 guard), giving R(r,s) ≤ ramseyUpperBound r s directly.",
+      "mathContext": "$\\mathrm{RamseyProp}\\,\\binom{r+s-2}{r-1}\\,r\\,s$; and $\\mathrm{ramseyUpperBound}\\,r\\,s = \\binom{r+s-2}{r-1}$ for $r,s\\ge 1$."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency with the Parent's R(4,k)",
+      "startLine": 114,
+      "endLine": 126,
+      "summary": "ramseyProp_r4k specializes the general bound to r=4, recovering RamseyProp (C(k+2,3)) 4 k — the parent's R(4,k) ≤ C(k+2,3), now realized as an actual Ramsey guarantee rather than a numerical identity on ramseyUpperBound.",
+      "mathContext": "$\\binom{4+k-2}{4-1} = \\binom{k+2}{3}$, so the general bound gives $R(4,k) \\le \\binom{k+2}{3}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's ramsey_recursion generalizes cleanly to the full Erdős–Szekeres upper bound R(r,s) ≤ C(r+s-2, r-1), proved for all r, s ≥ 1 by strong induction on r+s with Pascal's identity. The result is fully machine-checked with zero axioms and strictly strengthens the parent's (4,k)-only numerical bound.",
+    "implications": "This is the classical closed-form Ramsey upper bound, the source of R(k,k) ≤ 4^k. It subsumes every finite Ramsey-number upper bound in the parent family as a special case, and provides a reusable RamseyProp guarantee for arbitrary (r,s).",
+    "openQuestions": [
+      "Can the matching Erdős lower bound R(k,k) ≥ 2^{k/2} (probabilistic method) be formalized over the same RamseyProp API?",
+      "Can the improved upper bound R(k,k) ≤ C(2k-2, k-1) / factor (Erdős–Szekeres refinements, or the recent (4-ε)^k of Campos–Griffiths–Morris–Sahasrabudhe) be approached from this recursion?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RamseyR4k"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "RamseyR4k",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/RamseyR4kOQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "ramsey-r4k",
+      "relationship": "parent",
+      "description": "Parent entry providing the RamseyProp definition, ramsey_recursion (additive step), ramseyUpperBound, and the boundary lemmas ramseyProp_one_left/right. This entry generalizes ramsey_recursion from (4,k) to all (r,s)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "F. P. Ramsey",
+      "title": "On a problem of formal logic",
+      "year": 1930,
+      "venue": "Proc. London Math. Soc. (2) 30, 264–286",
+      "note": "The original Ramsey theorem guaranteeing monochromatic cliques."
+    },
+    {
+      "authors": "P. Erdős and G. Szekeres",
+      "title": "A combinatorial problem in geometry",
+      "year": 1935,
+      "venue": "Compositio Mathematica 2, 463–470",
+      "note": "Introduced the recursion R(r,s) ≤ R(r-1,s) + R(r,s-1) and the closed-form bound R(r,s) ≤ C(r+s-2, r-1) formalized here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Data.Nat.Choose.Basic",
+      "year": 2024,
+      "venue": "leanprover-community/mathlib4",
+      "note": "Supplies Pascal's identity Nat.choose_succ_succ' and Nat.choose_self used to close the induction."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent open question **ramsey-r4k-oq-05**: *"Can `ramsey_recursion` be generalized to the full Erdős–Szekeres upper bound R(r,s) ≤ C(r+s-2, r-1) by induction on r+s, using Pascal's identity?"* — **Yes.**

The parent entry `ramsey-r4k` proves the additive Ramsey recursion (`ramsey_recursion`: R(r,s) ≤ R(r-1,s) + R(r,s-1)) and boundary cases, but applies them only at the single slice (4,k). This entry runs the induction in full, over the parent's `RamseyProp` / `ramseyUpperBound` API (`import Proofs.RamseyR4k`):

- **`ramseyProp_erdos_szekeres`** — `RamseyProp (C(r+s-2, r-1)) r s` for all `r, s ≥ 1`, i.e. the classical **Erdős–Szekeres (1935)** bound `R(r,s) ≤ C(r+s-2, r-1)`.
- **`ramseyProp_ramseyUpperBound`** — same, phrased through the parent's `ramseyUpperBound r s`.
- **`ramseyProp_r4k`** — recovers the parent's `R(4,k) ≤ C(k+2,3)` as an actual Ramsey guarantee (consistency check), strictly strengthening the parent's numerical statement.

## Proof

Strong induction on `r + s`. Base cases `r = 1` / `s = 1` give `C(·,0) = C(n,n) = 1` and follow from the parent's `ramseyProp_one_left` / `ramseyProp_one_right` (K₁ trivially monochromatic). For `r, s ≥ 2`, the two induction hypotheses supply `RamseyProp` on `C(r+s-3, r-2)` and `C(r+s-3, r-1)` vertices; `ramsey_recursion` combines them additively, and **Pascal's identity** `Nat.choose_succ_succ'` rewrites the sum as exactly `C(r+s-2, r-1)`. The Erdős–Szekeres recursion *is* the Pascal recursion, so the binomial closed form is the solution of that recurrence with boundary 1's.

## Verification

`lake env lean` (Mathlib v4.26.0). **4 theorems, 0 axioms, 0 sorries, 126 lines.** `#print axioms` on all three exported theorems returns `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely axiom-free.

## Files
- `proofs/Proofs/RamseyR4kOQ05.lean` — the proof
- `src/data/proofs/ramsey-r4k-oq-05/{meta.json,annotations.json}` — new gallery entry (status `verified`, badge `original`)
- `research/problems/ramsey-r4k-oq-05/knowledge.md` — result + build notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)