### PR TITLE
research(erdos-83): complete starLikeFamily def + prove starLikeFamily_valid [axiom 6→5, sorry 3→2]

### DIFF
--- a/proofs/Proofs/Erdos83Problem.lean
+++ b/proofs/Proofs/Erdos83Problem.lean
@@ -172,15 +172,43 @@ def erdos83Question (n : ℕ) : Prop :=
 -/
 
 /--
+**The Core Set:**
+The fixed `2n`-element core `{0, 1, …, 2n-1} ⊆ [4n]`, realized as the first `2n`
+elements of `Fin (4n)`.  This is the "core" from which majority sets take at
+least `n+1` elements.
+-/
+def erdos83Core (n : ℕ) : Finset (Fin (4 * n)) :=
+  Finset.univ.filter (fun i => (i : ℕ) < 2 * n)
+
+/--
+**The Core has exactly `2n` elements.**
+`erdos83Core n` is the image of `Fin (2n)` under the order-preserving embedding
+`Fin (2n) ↪ Fin (4n)`, hence has cardinality `2n`.
+-/
+theorem erdos83Core_card (n : ℕ) : (erdos83Core n).card = 2 * n := by
+  have h : (2 : ℕ) * n ≤ 4 * n := by omega
+  have hmap : erdos83Core n = Finset.univ.map (Fin.castLEEmb h) := by
+    ext i
+    simp only [erdos83Core, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_map,
+      Fin.castLEEmb_apply]
+    constructor
+    · intro hi
+      exact ⟨⟨(i : ℕ), hi⟩, by apply Fin.ext; rfl⟩
+    · rintro ⟨j, rfl⟩
+      simp only [Fin.coe_castLE]
+      exact j.isLt
+  rw [hmap, Finset.card_map, Finset.card_univ, Fintype.card_fin]
+
+/--
 **Star-Like Family (Majority Family):**
-Sets containing at least n+1 elements from a fixed 2n-set (the core).
-For this problem with t=2, r=n-1: sets containing ≥ n+1 elements from [2n].
-Two majority sets always share ≥ 2 elements by pigeonhole:
-(n+1) + (n+1) - 2n = 2.
+All `2n`-subsets of `[4n]` containing at least `n+1` elements from the fixed
+`2n`-element core.  For this problem with `t = 2, r = n-1`: sets containing
+`≥ n+1` elements from `[2n]`.  Two majority sets always share `≥ 2` elements by
+pigeonhole: `(n+1) + (n+1) - 2n = 2`.
 -/
 def starLikeFamily (n : ℕ) : Finset (Finset (Fin (4 * n))) :=
-  -- All 2n-subsets of [4n] containing ≥ n+1 elements from [2n]
-  sorry -- Construction requires embedding Fin (2*n) into Fin (4*n)
+  (Finset.univ : Finset (Fin (4 * n))).powerset.filter
+    (fun S => S.card = 2 * n ∧ n + 1 ≤ (S ∩ erdos83Core n).card)
 
 /--
 **Extremal Family Achieves Bound:**
@@ -190,9 +218,42 @@ axiom starLikeFamily_achieves (n : ℕ) (hn : n ≥ 1) :
 
 /--
 **Extremal Family is Valid:**
--/
-axiom starLikeFamily_valid (n : ℕ) (hn : n ≥ 1) :
-  isValidErdos83Family n (starLikeFamily n)
+Every member is a `2n`-subset (`k`-uniform), and any two members meet in at least
+`2` points.  The intersection bound is a pure pigeonhole argument on the core:
+if `A, B` each contain `≥ n+1` of the `2n` core elements, then `A ∩ B` already
+contains `(n+1) + (n+1) - 2n = 2` core elements.  This is fully machine-checked
+(no dependence on the deep Ahlswede–Khachatrian axioms). -/
+theorem starLikeFamily_valid (n : ℕ) (_hn : n ≥ 1) :
+    isValidErdos83Family n (starLikeFamily n) := by
+  refine ⟨?_, ?_⟩
+  · -- k-uniform: membership forces `S.card = 2 * n`
+    intro A hA
+    simp only [starLikeFamily, Finset.mem_filter, Finset.mem_powerset] at hA
+    exact hA.2.1
+  · -- 2-intersecting: pigeonhole on the core
+    intro A hA B hB
+    simp only [starLikeFamily, Finset.mem_filter, Finset.mem_powerset] at hA hB
+    obtain ⟨_, _, hAcore⟩ := hA
+    obtain ⟨_, _, hBcore⟩ := hB
+    set X := A ∩ erdos83Core n with hX
+    set Y := B ∩ erdos83Core n with hY
+    -- `X, Y ⊆ core`, hence `X ∪ Y ⊆ core` and `|X ∪ Y| ≤ 2n`
+    have hunion_le : (X ∪ Y).card ≤ 2 * n := by
+      calc (X ∪ Y).card
+          ≤ (erdos83Core n).card :=
+            Finset.card_le_card (Finset.union_subset
+              Finset.inter_subset_right Finset.inter_subset_right)
+        _ = 2 * n := erdos83Core_card n
+    -- inclusion–exclusion on the core intersections
+    have hIE := Finset.card_union_add_card_inter X Y
+    -- `X ∩ Y ⊆ A ∩ B`, so it suffices to bound `|X ∩ Y|`
+    have hsub : X ∩ Y ⊆ A ∩ B := by
+      intro z hz
+      rw [hX, hY, Finset.mem_inter, Finset.mem_inter, Finset.mem_inter] at hz
+      exact Finset.mem_inter.mpr ⟨hz.1.1, hz.2.1⟩
+    have hcardAB : (X ∩ Y).card ≤ (A ∩ B).card := Finset.card_le_card hsub
+    have h2 : 2 ≤ (X ∩ Y).card := by omega
+    exact le_trans h2 hcardAB
 
 /-
 ## Part VI: The Complete Intersection Theorem

--- a/research/problems/erdos-83/knowledge.md
+++ b/research/problems/erdos-83/knowledge.md
@@ -3,6 +3,30 @@
 Erdős Problem #83: Complete Intersection Theorem (Ahlswede–Khachatrian 1997, $500 prize,
 SOLVED). `Proofs/Erdos83Problem.lean`. Gallery status: axiomatized.
 
+## Session 2026-07-02 (researcher-4) — VALIDITY PROVED + def sorry completed (6→5 ax, 3→2 sorry)
+
+Completed the `starLikeFamily` **definition** (was a `def ... := sorry`) and converted
+`starLikeFamily_valid` from an **axiom to a proved theorem**. Verified EXIT 0 via
+`lean` against main's prebuilt Mathlib (Docker infra down, worktree reaped mid-session →
+rebuilt in locked `/Users/rwalters/lg-r4-erdos83`). `#print axioms` on both new results:
+only `propext, Classical.choice, Quot.sound` (no sorry, no custom axioms).
+
+- New `def erdos83Core n := univ.filter (·.val < 2n)` — the fixed 2n-element core.
+- New `theorem erdos83Core_card : (erdos83Core n).card = 2*n` via the order-embedding
+  `Fin (2n) ↪ Fin (4n)` (`Fin.castLEEmb`): `erdos83Core n = univ.map (castLEEmb h)`, then
+  `card_map`/`card_univ`/`Fintype.card_fin`. (Reverse membership: `Fin.coe_castLE` + `j.isLt`.)
+- `def starLikeFamily n := univ.powerset.filter (fun S => S.card = 2n ∧ n+1 ≤ (S ∩ core).card)`.
+- `theorem starLikeFamily_valid`: k-uniform is immediate from the filter; 2-intersecting is
+  pure pigeonhole on the core. Let X=A∩core, Y=B∩core (both ⊆ core, |X|,|Y| ≥ n+1).
+  `card_union_add_card_inter X Y` gives |X∪Y|+|X∩Y| = |X|+|Y|; with |X∪Y| ≤ |core| = 2n,
+  `omega` yields |X∩Y| ≥ 2; and X∩Y ⊆ A∩B (`card_le_card`) → |A∩B| ≥ 2.
+
+Now 404L / 8thm / 13def / 5 axioms / 2 sorries. Remaining 2 sorries are BOTH `def` sorries
+(`criticalRatio`, `akFamily`) — NOT Aristotle-eligible; must be completed before the AK-side
+theorems could be attacked. `starLikeFamily_achieves` (exact count = ½(C(4n,2n)−C(2n,n)²))
+stays an axiom — genuinely hard enumeration. The 4 deep axioms (EKR bound, AK theorem,
+erdos83_from_ak, bound_asymptotic) remain out of scope (no EKR/AK in Mathlib).
+
 ## Session 2026-06-27 (researcher-1) — AXIOM HUNT
 
 Eliminated 1 axiom (7 → 6): converted `ekr_achieved` from `axiom` to a **proved theorem**.

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 83,
     "erdosUrl": "https://erdosproblems.com/83",
     "erdosProblemStatus": "solved",
@@ -71,11 +71,11 @@
       "erdos_83_summary: both directions (bound + tightness)",
       "erdos_83: final theorem statement"
     ],
-    "axiomCount": 6,
-    "lineCount": 343,
-    "assumptions": "6 axioms: erdos_ko_rado_bound, starLikeFamily_achieves, starLikeFamily_valid, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 3 sorry(s). (ekr_achieved was previously an axiom; it is now a proved theorem — the counting identity that the star family of k-subsets containing a fixed element has size C(n-1,k-1), via the insert-x bijection with (k-1)-subsets of the remaining n-1 points.)",
-    "theoremCount": 6,
-    "definitionCount": 12,
+    "axiomCount": 5,
+    "lineCount": 404,
+    "assumptions": "5 axioms: erdos_ko_rado_bound, starLikeFamily_achieves, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 2 sorry(s) (both DEFINITION sorries: criticalRatio, akFamily). (starLikeFamily_valid was previously an axiom; it is now a proved theorem — the majority family is 2-intersecting by a pure pigeonhole argument on the 2n-element core, |A∩B| ≥ (n+1)+(n+1)-2n = 2. The starLikeFamily construction sorry is also now completed via a concrete filter over the core erdos83Core, whose cardinality 2n is proved via the Fin (2n) ↪ Fin (4n) embedding. ekr_achieved was likewise previously an axiom, now a proved counting identity.)",
+    "theoremCount": 8,
+    "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Stubs/Erdos83Aristotle.lean"
     ]
@@ -84,7 +84,7 @@
     "historicalContext": "**Erdős Problem #83: The Complete Intersection Theorem**\n\nThis problem represents one of the most celebrated successes in extremal set theory, bridging a 36-year gap from conjecture to proof.\n\n**The Erdős-Ko-Rado Foundation (1961):** Erdős, Ko, and Rado proved that for $k$-subsets of $[n]$ with $n \\geq 2k$, the largest *intersecting* family (every pair shares $\\geq 1$ element) has size $\\binom{n-1}{k-1}$. This launched the field of extremal set theory. The 'star' family $\\{A : x \\in A\\}$ achieves this bound.\n\n**The $t$-Intersecting Conjecture:** EKR naturally asked: what about $t$-intersecting families ($|A \\cap B| \\geq t$)? For the specific case of $2n$-subsets of $[4n]$ with $t = 2$, they conjectured the bound $\\frac{1}{2}(\\binom{4n}{2n} - \\binom{2n}{n}^2)$. Erdős attached a **\\$500 prize** — one of his larger prizes, reflecting the difficulty.\n\n**36 Years of Partial Progress:** Wilson (1984) proved the result for $t$ sufficiently large relative to $k$. Frankl (1978) developed the 'shifting' technique, solving many special cases. But the general problem resisted all approaches.\n\n**The Breakthrough (1997):** Ahlswede and Khachatrian proved the **Complete Intersection Theorem**, which determines the maximum $t$-intersecting $k$-uniform family on $[m]$ for *all* valid parameters $(m, k, t)$. Their proof introduced the 'pushing-pulling' technique, a two-directional generalization of Frankl's shifting that preserves the $t$-intersecting property.\n\n**The Key Innovation:** Classical shifting (replacing element $j$ with element $i < j$ if the result stays in the family) preserves $1$-intersecting but can destroy $t$-intersecting for $t \\geq 2$. Ahlswede-Khachatrian's pushing-pulling modifies pairs of elements simultaneously, maintaining the stronger intersection requirement.\n\n**Phase Transitions:** A remarkable feature of the AK theorem is that the extremal family changes structure at critical parameter values. The optimal family $\\mathcal{A}(r)$ consists of all $k$-subsets with $\\geq t+r$ elements from a fixed $(t+2r)$-set, where $r$ depends on $(m, k, t)$. As parameters vary, $r$ jumps — a discrete phase transition.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $\\mathcal{F}$ be a family of subsets of $[4n]$ such that:\n- $|A| = 2n$ for all $A \\in \\mathcal{F}$ ($2n$-uniform)\n- $|A \\cap B| \\geq 2$ for all $A, B \\in \\mathcal{F}$ ($2$-intersecting)\n\nThen: $|\\mathcal{F}| \\leq \\frac{1}{2}\\left(\\binom{4n}{2n} - \\binom{2n}{n}^2\\right)$\n\n**Answer: PROVED** by Ahlswede and Khachatrian (1997)\n\nThe bound is achieved by the 'majority family': all $2n$-subsets containing $\\geq n+1$ elements from a fixed $2n$-set. The \\$500 Erdős prize was awarded.",
     "text": "For 2n-subsets of [4n] with pairwise intersections ≥ 2, the maximum family size is ½(C(4n,2n) - C(2n,n)²). Proved by Ahlswede-Khachatrian (1997), winning the $500 Erdős prize.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Definitions Layer:** `groundSet` ($[m]$ as `Fin m`), `isKUniform` ($k$-uniform families), `isTIntersecting` ($t$-intersecting property), `isIntersecting` ($t = 1$ special case).\n\n2. **EKR Background:** `erdos_ko_rado_bound` (classical EKR theorem, axiom), `ekrStarFamily` (star construction), `ekr_achieved` (tightness).\n\n3. **Problem Formulation:** `erdos83Params` ($(4n, 2n, 2)$), `isValidErdos83Family`, `erdos83Bound` ($\\frac{1}{2}(\\binom{4n}{2n} - \\binom{2n}{n}^2)$), `erdos83Question` (formal statement).\n\n4. **Extremal Construction:** `starLikeFamily` (majority family), verified valid and achieving the bound.\n\n5. **The Deep Theorem:** `criticalRatio`, `akFamily`, `ahlswede_khachatrian_theorem` (Complete Intersection Theorem, axiom) — the general result from which #83 follows.\n\n6. **Resolution:** `erdos83_from_ak` (parameter specialization), `erdos83_answer` (proved by applying AK), `erdos_83` (final theorem).\n\nThe formalization is axiom-based for the deep results (EKR bound, AK theorem), with the main theorem `erdos83_answer` proved by combining axioms with parameter verification via `linarith` and `norm_num`.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Definitions Layer:** `groundSet` ($[m]$ as `Fin m`), `isKUniform` ($k$-uniform families), `isTIntersecting` ($t$-intersecting property), `isIntersecting` ($t = 1$ special case).\n\n2. **EKR Background:** `erdos_ko_rado_bound` (classical EKR theorem, axiom), `ekrStarFamily` (star construction), `ekr_achieved` (tightness).\n\n3. **Problem Formulation:** `erdos83Params` ($(4n, 2n, 2)$), `isValidErdos83Family`, `erdos83Bound` ($\\frac{1}{2}(\\binom{4n}{2n} - \\binom{2n}{n}^2)$), `erdos83Question` (formal statement).\n\n4. **Extremal Construction:** `starLikeFamily` (majority family), now a concrete `Finset` — the `2n`-subsets of `[4n]` with `≥ n+1` elements in the fixed core `erdos83Core` (whose size `2n` is proved via the `Fin (2n) ↪ Fin (4n)` embedding). Its `2`-intersecting validity `starLikeFamily_valid` is a **proved theorem** (pure pigeonhole on the core: `(n+1)+(n+1)-2n = 2`), no longer an axiom. Only the exact count `starLikeFamily_achieves` remains axiomatized.\n\n5. **The Deep Theorem:** `criticalRatio`, `akFamily`, `ahlswede_khachatrian_theorem` (Complete Intersection Theorem, axiom) — the general result from which #83 follows.\n\n6. **Resolution:** `erdos83_from_ak` (parameter specialization), `erdos83_answer` (proved by applying AK), `erdos_83` (final theorem).\n\nThe formalization is axiom-based for the deep results (EKR bound, AK theorem), with the main theorem `erdos83_answer` proved by combining axioms with parameter verification via `linarith` and `norm_num`.",
     "keyInsights": [
       "**36-Year Gap:** From EKR's 1961 conjecture to AK's 1997 proof required fundamentally new techniques. The classical shifting method (Frankl 1978) handles $t = 1$ elegantly but breaks for $t \\geq 2$, explaining why partial results stalled for decades.",
       "**Pushing-Pulling Innovation:** Ahlswede-Khachatrian's key innovation was replacing single-element shifting with simultaneous two-element operations. This preserves the $t$-intersecting property while still converging to a canonical extremal family.",
@@ -204,12 +204,12 @@
       "Nat"
     ],
     "namespace": "Erdos83",
-    "lineCount": 343,
-    "axiomCount": 6,
-    "theoremCount": 6,
-    "definitionCount": 12,
+    "lineCount": 404,
+    "axiomCount": 5,
+    "theoremCount": 8,
+    "definitionCount": 13,
     "path": "Proofs/Erdos83Problem.lean",
-    "sorries": 3,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Stubs/Erdos83Aristotle.lean"
     ]
@@ -253,5 +253,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
     }
   ],
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Erdős Problem #83 — Complete Intersection Theorem (Ahlswede–Khachatrian 1997)

Reduces the assumption footprint of `Proofs/Erdos83Problem.lean` by **eliminating one axiom** and **completing one definition sorry**, both fully machine-checked with **no dependence on the deep EKR/AK axioms**.

### What changed
- **New** `def erdos83Core n` — the fixed 2n-element core `{0,…,2n-1} ⊆ [4n]`.
- **New** `theorem erdos83Core_card : (erdos83Core n).card = 2*n` — proved via the order-preserving embedding `Fin (2n) ↪ Fin (4n)` (`Fin.castLEEmb`): the core is `univ.map (castLEEmb h)`, so `card_map`/`card_univ`/`Fintype.card_fin` give the count.
- **Completed** `def starLikeFamily` (was `:= sorry`) as the concrete *majority family*: the `2n`-subsets of `[4n]` containing `≥ n+1` core elements.
- **Converted** `starLikeFamily_valid` from an **axiom to a proved theorem**. `k`-uniformity is immediate from the filter; `2`-intersection is a pure pigeonhole argument on the core: with `X = A∩core`, `Y = B∩core` (each `≥ n+1` of the `2n` core points), `card_union_add_card_inter` + `|X∪Y| ≤ |core| = 2n` + `omega` give `|X∩Y| ≥ 2`, and `X∩Y ⊆ A∩B`.

### Verification
Verified **EXIT 0** with `lean` against Mathlib (Docker infra down). `#print axioms` on both new results lists only `propext, Classical.choice, Quot.sound` — no `sorry`, no custom axioms.

### Status
- Counts: `343L → 404L`, `6 → 8` theorems, `12 → 13` definitions, **`6 → 5` axioms**, **`3 → 2` sorries**.
- The **2 remaining sorries** are both `def` sorries (`criticalRatio`, `akFamily`) — not Aristotle-eligible.
- The **5 remaining axioms** (EKR bound, AK theorem, `starLikeFamily_achieves` exact count, `erdos83_from_ak`, `bound_asymptotic`) are genuinely deep and out of scope — Mathlib has no Erdős–Ko–Rado or Ahlswede–Khachatrian theorem.

Entry remains `status: axiomatized` (`badge: axiom`) — the deep landmark results are still assumed; this PR strengthens the extremal-construction side to fully verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)