### PR TITLE
Fix: add missing gallery entry for shannon-channel-coding-oq-02-oq-02 (joint typicality lemma)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-02/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-jt-overview",
+    "proofId": "shannon-channel-coding-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "The Three Properties of the Jointly Typical Set",
+    "content": "The joint typicality lemma is the engine of Shannon's random-coding achievability proof. For i.i.d. length-n sequences it asserts three facts about the jointly ε-typical set A_ε: (1) the true transmitted/received pair lands in A_ε with probability → 1 (an AEP/law-of-large-numbers statement); (2) A_ε is small, |A_ε| ≤ 2^{n(H(X,Y)+ε)}; and (3) an independently drawn pair looks jointly typical with probability at most 2^{-n(I(X;Y)-3ε)}. Only Property (1) needs analysis; (2) and (3) are exact finite-sum inequalities that follow from the definition of typicality. This file isolates and fully verifies that combinatorial core (0 axioms, 0 sorries), abstractly over any finite sequence space, and deliberately defers Property (1) rather than axiomatizing it — so the assumption count stays 0.",
+    "mathContext": "$(1)\\ P((X^n,Y^n)\\in A_\\varepsilon)\\to 1;\\quad (2)\\ |A_\\varepsilon|\\le 2^{n(H(X,Y)+\\varepsilon)};\\quad (3)\\ \\sum_{A_\\varepsilon} q \\le 2^{-n(I-3\\varepsilon)}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "joint asymptotic equipartition property",
+      "random coding",
+      "channel capacity"
+    ],
+    "prerequisites": [
+      "entropy and mutual information",
+      "asymptotic equipartition property"
+    ]
+  },
+  {
+    "id": "ann-abstract-lemmas",
+    "proofId": "shannon-channel-coding-oq-02-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 76
+    },
+    "type": "technique",
+    "title": "Two Information-Theory-Free Finite-Sum Lemmas",
+    "content": "All the content lives in two abstract inequalities with no information-theoretic input. `typicalSet_card_le` is a pigeonhole bound: if p is a sub-probability (p ≥ 0, ∑p ≤ 1) and every element of a finite set A carries mass at least δ > 0, then |A|·δ ≤ ∑_A p ≤ ∑_Ω p ≤ 1, hence |A| ≤ 1/δ — typical sequences are individually 'not too likely', so there cannot be too many of them. `prob_le_card_mul` is a dual mass bound: if every element of A has q-mass at most M, then ∑_A q ≤ |A|·M by termwise comparison against the constant M. These two facts convert the definitional typicality bounds into the size and independence bounds respectively.",
+    "mathContext": "$|A|\\,\\delta \\le \\sum_{A} p \\le \\sum_{\\Omega} p \\le 1 \\;\\Rightarrow\\; |A|\\le 1/\\delta;\\qquad \\sum_{A} q \\le |A|\\cdot M.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "finite-sum monotonicity",
+      "sub-probability measure"
+    ],
+    "prerequisites": [
+      "Finset.sum_le_sum",
+      "Finset.sum_const"
+    ]
+  },
+  {
+    "id": "ann-size-bound",
+    "proofId": "shannon-channel-coding-oq-02-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "Property (2): the Size Bound |A_ε| ≤ 2^{n(H(X,Y)+ε)}",
+    "content": "`jointlyTypicalSet_card_le` instantiates the abstract counting bound with δ = 2^{-n(H(X,Y)+ε)}, the definitional lower bound on the joint probability of a typical sequence. Positivity of δ comes from `Real.rpow_pos_of_pos`, and the final rewrite `Real.rpow_neg` + `inv_inv` turns 1/δ = 1/2^{-n(H(X,Y)+ε)} into 2^{n(H(X,Y)+ε)}. Intuitively: since each typical sequence occupies at least a 2^{-n(H(X,Y)+ε)} share of the total probability, there is room for at most 2^{n(H(X,Y)+ε)} of them.",
+    "mathContext": "$\\delta = 2^{-n(H(X,Y)+\\varepsilon)} \\;\\Rightarrow\\; |A_\\varepsilon| \\le 1/\\delta = 2^{n(H(X,Y)+\\varepsilon)}.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "typical set size",
+      "asymptotic equipartition property"
+    ],
+    "prerequisites": [
+      "Real.rpow_neg",
+      "typicalSet_card_le"
+    ]
+  },
+  {
+    "id": "ann-independence-bound",
+    "proofId": "shannon-channel-coding-oq-02-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 123
+    },
+    "type": "theorem",
+    "title": "Property (3): the Independence Bound and the Emergence of I(X;Y)",
+    "content": "`joint_typicality_independence_bound` assembles the final estimate. Under the product-of-marginals law q = p_X·p_Y, a typical sequence has q-mass at most M = 2^{-n(H(X)+H(Y)-2ε)}. Chaining `prob_le_card_mul` (mass ≤ |A|·M) with the size bound (2) gives ∑_A q ≤ 2^{n(H(X,Y)+ε)} · 2^{-n(H(X)+H(Y)-2ε)}. A single `Real.rpow_add` merges the exponents, and `ring` verifies n(H(X,Y)+ε) - n(H(X)+H(Y)-2ε) = -n((H(X)+H(Y)-H(X,Y)) - 3ε) = -n(I - 3ε). The mutual information I = H(X)+H(Y)-H(X,Y) thus appears purely from adding two exponents — no probabilistic limit. This is exactly the bound that, union-bounded over 2^{nR} codewords, makes the decoding error vanish for R < I(X;Y).",
+    "mathContext": "$\\sum_{A_\\varepsilon} q \\le 2^{n(H(X,Y)+\\varepsilon)}\\cdot 2^{-n(H(X)+H(Y)-2\\varepsilon)} = 2^{-n(I-3\\varepsilon)},\\quad I = H(X)+H(Y)-H(X,Y).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "mutual information",
+      "random coding error bound",
+      "product measure"
+    ],
+    "prerequisites": [
+      "Real.rpow_add",
+      "prob_le_card_mul",
+      "jointlyTypicalSet_card_le"
+    ]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "shannon-channel-coding-oq-02-oq-02",
+  "title": "Joint Typicality Lemma — Combinatorial Core",
+  "slug": "shannon-channel-coding-oq-02-oq-02",
+  "description": "Formalizes the non-asymptotic core of the joint typicality lemma (Cover & Thomas, Thm 7.6.1) used in the random-coding achievability proof of the channel coding theorem. Properties (2) |A_ε| ≤ 2^{n(H(X,Y)+ε)} and (3) product-law mass ≤ 2^{-n(I−3ε)} are derived purely from the per-sequence probability bounds that DEFINE joint typicality — no probabilistic limit — via two abstract finite-sum inequalities (typicalSet_card_le, prob_le_card_mul). Property (1), the AEP/LLN convergence, is the analytic half and is deliberately left unformalized rather than axiomatized, so the axiom count stays 0. Self-contained (imports only Mathlib).",
+  "meta": {
+    "author": "Thomas M. Cover & Joy A. Thomas (Thm 7.6.1), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Asymptotic_equipartition_property",
+    "date": "2006",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ02.lean",
+    "tags": [
+      "information-theory",
+      "entropy",
+      "channel-coding",
+      "joint-typicality",
+      "aep",
+      "research",
+      "open-problem"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of finite sums under a pointwise bound; underlies both abstract lemmas.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Real.rpow_add",
+        "description": "2^(a+b) = 2^a · 2^b for real exponents; combines the size and marginal bounds into the mutual-information exponent.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_pos_of_pos",
+        "description": "Positivity of real powers of a positive base; supplies the positive lower mass bound δ.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "typicalSet_card_le: an abstract counting bound — a finite set whose elements each carry mass ≥ δ under a sub-probability p has at most 1/δ elements.",
+      "prob_le_card_mul: an abstract mass bound — the total q-mass of a finite set is at most |A|·(max element mass).",
+      "jointlyTypicalSet_card_le: Property (2), the typical-set size bound |A_ε| ≤ 2^{n(H(X,Y)+ε)}.",
+      "joint_typicality_independence_bound: Property (3), the product-law independence bound ∑_{A} q ≤ 2^{-n(I−3ε)} with I = H(X)+H(Y)−H(X,Y), assembled from (2) and the marginal typicality upper bound via a single rpow_add step."
+    ],
+    "assumptions": "0 axioms and 0 sorries in this file. The two properties are proved by taking the per-sequence probability bounds that DEFINE membership in the jointly ε-typical set as hypotheses (definitional): p ω ≥ 2^{-n(H(X,Y)+ε)} for the size bound, and q ω ≤ 2^{-n(H(X)+H(Y)−2ε)} for the independence bound. Property (1) — P((Xⁿ,Yⁿ) ∈ A_ε) → 1, the weak law of large numbers applied to the empirical information density — is the genuinely analytic part and is deliberately NOT axiomatized (no axiom is introduced; the count stays at 0). NOTE ON VERIFICATION: this file was merged (PR #30752) while the Docker build host was unavailable, and has not yet been independently machine-checked in a clean build; it is therefore recorded as status \"formalized\" rather than \"verified\". The file imports only Mathlib and uses standard finite-sum / rpow lemmas; all cited lemma names were confirmed present in the pinned Mathlib v4.26.0.",
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 146,
+    "prerequisites": [
+      "Joint asymptotic equipartition property (Cover & Thomas §7.6)",
+      "Finite-sum inequalities and real powers (rpow)",
+      "Entropy and mutual information I(X;Y) = H(X)+H(Y)−H(X,Y)"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The joint typicality lemma is the combinatorial heart of Shannon's random-coding achievability argument. Shannon's 1948 paper established the channel capacity C = max_p I(X;Y) and sketched a random-coding argument, but the modern, fully rigorous version — packaged as the 'joint AEP' — is due to the textbook treatments of Gallager (1968) and, in its now-standard form, Cover & Thomas (Elements of Information Theory, §7.6, Theorem 7.6.1). The idea is to draw a random codebook and declare a decoding success whenever the received sequence is jointly typical with exactly one codeword. Three properties make this work: (1) the true transmitted/received pair is jointly typical with high probability (an AEP/law-of-large-numbers statement); (2) the jointly typical set is small, |A_ε| ≤ 2^{n(H(X,Y)+ε)}; and (3) an independently drawn pair looks jointly typical with probability at most 2^{-n(I(X;Y)−3ε)}. Union-bounding (3) over the 2^{nR} codewords shows the error probability vanishes whenever R < I(X;Y), giving achievability of every rate below capacity.\n\nProperties (2) and (3) are purely combinatorial: they are exact finite-sum inequalities that follow from the definition of the typical set, with no probabilistic limit involved. Only Property (1) requires analysis (concentration of the empirical information density). This formalization isolates and proves that combinatorial core abstractly, over any finite sequence space, so that the remaining work to complete the lemma is exactly the well-scoped analytic Property (1).",
+    "problemStatement": "For i.i.d. length-$n$ sequences with joint pmf $p$ on $\\Omega = \\mathcal{X}^n \\times \\mathcal{Y}^n$ and product-of-marginals pmf $q = p_X \\cdot p_Y$, establish the two combinatorial properties of the jointly $\\varepsilon$-typical set $A_\\varepsilon$:\n$$\\textbf{(2)}\\quad |A_\\varepsilon| \\leq 2^{n(H(X,Y)+\\varepsilon)}, \\qquad\\qquad \\textbf{(3)}\\quad \\sum_{\\omega \\in A_\\varepsilon} q(\\omega) \\leq 2^{-n(I(X;Y)-3\\varepsilon)},$$\nwhere $I(X;Y) = H(X)+H(Y)-H(X,Y)$, taking as hypotheses the per-sequence typicality bounds $p(\\omega) \\geq 2^{-n(H(X,Y)+\\varepsilon)}$ and $q(\\omega) \\leq 2^{-n(H(X)+H(Y)-2\\varepsilon)}$ that define membership in $A_\\varepsilon$.",
+    "proofStrategy": "The argument reduces to two abstract finite-sum lemmas and one algebraic combination:\n\n1. **Counting bound** (`typicalSet_card_le`): if $p \\geq 0$, $\\sum_\\omega p(\\omega) \\leq 1$, and every $\\omega \\in A$ has $p(\\omega) \\geq \\delta > 0$, then $|A|\\,\\delta \\leq \\sum_{A} p \\leq \\sum_\\Omega p \\leq 1$, hence $|A| \\leq 1/\\delta$. With $\\delta = 2^{-n(H(X,Y)+\\varepsilon)}$ and $\\texttt{rpow\\_neg}/\\texttt{inv\\_inv}$ this is exactly Property (2).\n\n2. **Mass bound** (`prob_le_card_mul`): if every $\\omega \\in A$ has $q(\\omega) \\leq M$, then $\\sum_{A} q \\leq |A|\\,M$ by termwise comparison against the constant $M$.\n\n3. **Combination** (`joint_typicality_independence_bound`): apply (2) with $\\delta$-bound and (1)'s marginal upper bound $M = 2^{-n(H(X)+H(Y)-2\\varepsilon)}$, so $\\sum_{A} q \\leq 2^{n(H(X,Y)+\\varepsilon)} \\cdot 2^{-n(H(X)+H(Y)-2\\varepsilon)}$. A single $\\texttt{Real.rpow\\_add}$ merges the exponents, and $\\texttt{ring}$ verifies $n(H(X,Y)+\\varepsilon) - n(H(X)+H(Y)-2\\varepsilon) = -n((H(X)+H(Y)-H(X,Y)) - 3\\varepsilon) = -n(I - 3\\varepsilon)$, giving Property (3).",
+    "keyInsights": [
+      "Properties (2) and (3) carry no probability limit — they are exact finite-sum inequalities in the per-sequence typicality bounds, so they can be stated and proved abstractly over any finite Ω without the AEP.",
+      "The size bound is a one-line pigeonhole: |A|·δ ≤ (mass on A) ≤ (total mass) ≤ 1, so a uniform lower mass bound δ caps the count at 1/δ.",
+      "The independence bound is (size bound) × (marginal upper bound); the mutual-information exponent I = H(X)+H(Y)−H(X,Y) appears purely from adding exponents 2^{a}·2^{b}=2^{a+b}, with ring discharging the arithmetic.",
+      "Isolating the combinatorial core cleanly separates the finished work from the remaining analytic obligation: Property (1) is exactly the weak law of large numbers for the empirical information density −(1/n)·log p(Xⁿ,Yⁿ), a well-scoped next target on Mathlib's ProbabilityTheory LLN infrastructure.",
+      "Nothing is axiomatized: the deferred analytic property is simply absent, not assumed, so the file's assumption count is genuinely 0."
+    ],
+    "prerequisites": [
+      "Information theory: entropy, mutual information, and the (joint) asymptotic equipartition property",
+      "Shannon's channel coding theorem, achievability direction via random coding",
+      "Finite-sum inequalities and real-exponent powers in Lean/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Documents the three properties of the jointly ε-typical set and states precisely which are formalized here (the combinatorial Properties (2) and (3)) and which is deferred (the analytic Property (1)). Imports Mathlib and opens the working namespace over a finite sequence space Ω.",
+      "mathContext": "Jointly ε-typical set $A_\\varepsilon \\subseteq \\mathcal{X}^n \\times \\mathcal{Y}^n$; properties (1) AEP, (2) size bound, (3) independence bound."
+    },
+    {
+      "id": "abstract-lemmas",
+      "title": "Abstract Combinatorial Lemmas",
+      "startLine": 47,
+      "endLine": 76,
+      "summary": "Proves the two information-theory-free finite-sum facts that carry all the content: `typicalSet_card_le` (a uniform lower mass bound δ forces |A| ≤ 1/δ) and `prob_le_card_mul` (total mass of A is ≤ |A|·(max element mass)).",
+      "mathContext": "$|A|\\,\\delta \\leq \\sum_A p \\leq 1$ and $\\sum_A q \\leq |A|\\cdot M$."
+    },
+    {
+      "id": "size-bound",
+      "title": "Property (2): the Typical-Set Size Bound",
+      "startLine": 78,
+      "endLine": 93,
+      "summary": "Proves `jointlyTypicalSet_card_le`: instantiating the abstract counting bound with δ = 2^{−n(H(X,Y)+ε)} and simplifying via `Real.rpow_neg`/`inv_inv` yields |A_ε| ≤ 2^{n(H(X,Y)+ε)}.",
+      "mathContext": "$|A_\\varepsilon| \\leq 2^{n(H(X,Y)+\\varepsilon)}$."
+    },
+    {
+      "id": "independence-bound",
+      "title": "Property (3): the Independence Bound",
+      "startLine": 95,
+      "endLine": 123,
+      "summary": "Proves `joint_typicality_independence_bound`: combining the size bound with the product-law marginal upper bound M = 2^{−n(H(X)+H(Y)−2ε)} and merging exponents via `Real.rpow_add` gives ∑_{A} q ≤ 2^{−n(I−3ε)} with I = H(X)+H(Y)−H(X,Y).",
+      "mathContext": "$\\sum_{\\omega\\in A_\\varepsilon} q(\\omega) \\leq 2^{-n(I(X;Y)-3\\varepsilon)}$."
+    },
+    {
+      "id": "closing-remark",
+      "title": "Closing Remark: Proved vs. Deferred",
+      "startLine": 125,
+      "endLine": 146,
+      "summary": "Explains that the definitional typicality bounds are faithful hypotheses, and that Property (1) — the LLN convergence of the empirical information density — is deliberately left unformalized (not axiomatized), keeping the axiom count at 0. Sanity `#check` commands and namespace close.",
+      "mathContext": "Deferred analytic half: $P((X^n,Y^n)\\in A_\\varepsilon)\\to 1$ via the weak law of large numbers."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file fully formalizes (0 axioms, 0 sorries) the combinatorial core of the joint typicality lemma: the size bound |A_ε| ≤ 2^{n(H(X,Y)+ε)} and the independence bound ∑_{A_ε} q ≤ 2^{−n(I−3ε)}. Both are proved abstractly over any finite sequence space from the per-sequence probability bounds that define the typical set, using only elementary finite-sum inequalities and one exponent-addition step. The mutual-information exponent emerges purely algebraically from combining the two bounds.",
+    "implications": "Properties (2) and (3) are exactly what the random-coding achievability proof consumes: union-bounding the independence bound over 2^{nR} codewords drives the decoding-error probability to 0 for every rate R below capacity C = I(X;Y). By isolating the combinatorial core, the formalization pins the remaining work down to a single, well-scoped analytic obligation (Property (1)), so the joint AEP can be completed without re-deriving the counting arguments.",
+    "openQuestions": [
+      "Formalize Property (1): P((Xⁿ,Yⁿ) ∈ A_ε) → 1, the weak law of large numbers applied to the empirical information density −(1/n)·log p(Xⁿ,Yⁿ), building on Mathlib's ProbabilityTheory LLN infrastructure.",
+      "Machine-verify this file in a clean Docker/Lake build and, once confirmed, promote its status from \"formalized\" to \"verified\".",
+      "Assemble the full random-coding achievability argument by union-bounding Property (3) over a random codebook of 2^{nR} sequences."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "extends",
+      "description": "Complements the OQ-02 channel-coding development by supplying the combinatorial core of the joint typicality lemma used in achievability."
+    },
+    {
+      "targetId": "shannon-channel-coding-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-02 follow-up: OQ-02-OQ-01 handles Fano's inequality for the converse; this file handles joint typicality for achievability."
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "supports",
+      "description": "Provides the size and independence bounds that the parent channel coding theorem's achievability direction consumes."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "InformationTheory.ChannelCoding.JointTypicality",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ShannonChannelCodingOQ02OQ02.lean",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "§7.6 Joint AEP and Theorem 7.6.1; the achievability proof (§7.7) consumes properties (1)-(3) of the jointly typical set."
+    },
+    {
+      "authors": [
+        "Claude E. Shannon"
+      ],
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal",
+      "note": "Original random-coding achievability argument for the channel coding theorem."
+    },
+    {
+      "authors": [
+        "Robert G. Gallager"
+      ],
+      "title": "Information Theory and Reliable Communication",
+      "year": 1968,
+      "venue": "Wiley",
+      "note": "Standardized the typicality-based achievability and converse proofs for discrete memoryless channels."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

`ShannonChannelCodingOQ02OQ02.lean` (joint typicality lemma — combinatorial core) was merged via PR #30752 but never received a `src/data/proofs/` gallery directory, leaving the proof invisible in the web gallery.

## Evidence

**Before**: `proofs/Proofs/ShannonChannelCodingOQ02OQ02.lean` exists on `main` (4 theorems, 146 lines, 0 axioms, 0 sorries, namespace `InformationTheory.ChannelCoding.JointTypicality`), referenced by **no** `meta.json` — no gallery entry for slug `shannon-channel-coding-oq-02-oq-02`.

**After**: adds `src/data/proofs/shannon-channel-coding-oq-02-oq-02/{meta.json,annotations.json}`, modeled on the direct sibling `shannon-channel-coding-oq-02-oq-01`.

- `pnpm gallery:check-size` — passes (entry within caps).
- `pnpm annotations:build` — my entry produces **0** annotation errors (all 4 annotation ranges land on Lean constructs). Pre-existing gallery-wide errors are unrelated and left untouched.

## Status note

Recorded conservatively as `status: "formalized"`, `badge: "mathlib"`, `axiomCount: 0`. The file was merged while the Docker build host was down (per PR #30752's commit message) and has **not** been independently machine-checked in a clean build. The proof is self-contained (imports only Mathlib) and all cited Mathlib lemma names were confirmed present in the pinned v4.26.0. An open question in the entry flags promoting to `"verified"` once a clean build confirms it.

---
Automated fix by lean-mechanic agent.