### PR TITLE
Enrich Inverse Galois OQ-04 (Dedekind inertia tower brick): annotation coverage + depth

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04/annotations.json
@@ -2,13 +2,24 @@
   {
     "id": "ann-header-oq04",
     "proofId": "inverse-galois-oq-04",
-    "range": { "startLine": 3, "endLine": 53 },
+    "range": { "startLine": 3, "endLine": 38 },
     "type": "concept",
-    "title": "OQ-04: eliminating the last A₅ axiom, and the tower setup",
-    "content": "The docstring frames the parent's open question OQ-04 — can Dedekind's theorem be formalized to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`? A companion file already reduces that axiom to a single arithmetic fact, `3 ∣ inertiaDegIn (7) (𝒪 q.SplittingField)`, and lays out a three-step Kummer–Dedekind route: (1) a cubic factor of q mod 7 yields a prime of inertia degree 3; (2) inertia degrees multiply in a tower; (3) Galois uniformity spreads the degree to all primes over 7. This file machine-checks the abstract heart — steps (2) and (3) — with 0 axioms and 0 sorries. The variable block fixes a scalar tower R ⊆ S ⊆ T (`IsScalarTower R S T`) with a finite group G making `IsGaloisGroup G R T`, and a compatible chain of maximal ideals p ⊲ R, P ⊲ S, Q ⊲ T with lying-over instances; critically S carries NO normality hypothesis, since in the A₅ application the middle field ℚ(α) is not Galois over ℚ. The `include G Q` directive forces G and the top prime Q to be quantified arguments.",
-    "mathContext": "Inertia degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. For a Galois extension all primes over $p$ share one inertia degree, denoted $\\mathrm{inertiaDegIn}\\,p\\,T$. Here $R \\subseteq S \\subseteq T$ with $T/R$ Galois via $G$ and $S$ possibly non-normal.",
+    "title": "OQ-04: the three-step route to eliminating the last A₅ axiom",
+    "content": "The docstring frames the parent's open question OQ-04 — can Dedekind's theorem be formalized to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309)? The companion file `InverseGaloisA5DedekindInstantiation` already reduces that axiom to a single sharp arithmetic fact, `3 ∣ inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)` at an unramified prime Q over 7, and its 'residual gap' note lays out a three-step Kummer–Dedekind route: (1) the prime of 𝓞 ℚ(α) matching the irreducible cubic factor of q mod 7 has inertia degree 3 (`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`); (2) inertia degrees multiply in a tower (`inertiaDeg_algebra_tower`, needing NO Galois hypothesis on the non-normal middle field ℚ(α)); (3) Galois uniformity spreads the degree to all primes of the splitting field over 7 (`inertiaDegIn_eq_inertiaDeg`). This file machine-checks the abstract heart — steps (2) and (3) — with only the foundational axioms (propext, Classical.choice, Quot.sound): no sorry, no new axiom.",
+    "mathContext": "Inertia (residue) degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. For a Galois extension all primes over $p$ share one inertia degree, denoted $\\mathrm{inertiaDegIn}\\,p\\,T$. The route factors the target $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$ through the tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$.",
     "significance": "critical",
-    "relatedConcepts": ["inverse Galois problem", "inertia degree", "Kummer–Dedekind", "scalar tower", "non-normal extension"]
+    "relatedConcepts": ["inverse Galois problem", "inertia degree", "Kummer–Dedekind", "residual gap reduction", "residue field degree"]
+  },
+  {
+    "id": "ann-tower-setup",
+    "proofId": "inverse-galois-oq-04",
+    "range": { "startLine": 40, "endLine": 53 },
+    "type": "definition",
+    "title": "The tower setup and the `include G Q` directive",
+    "content": "The variable block fixes a scalar tower R ⊆ S ⊆ T (`IsScalarTower R S T` gluing the three algebra instances) with a finite group G making T/R Galois via `IsGaloisGroup G R T`, together with a compatible chain of maximal ideals p ⊲ R, P ⊲ S, Q ⊲ T and lying-over instances `P.LiesOver p`, `Q.LiesOver P`. Critically S carries NO normality or Galois hypothesis — in the A₅ application the middle field ℚ(α) is not Galois over ℚ, so demanding normality there would break the argument. The `include G Q` directive is a genuine formalization subtlety: because G and Q occur only in the *proofs* below (not in the theorem *statements*, whose conclusions mention only p, P, T), Lean would otherwise omit them from the theorem signatures; `include` forces them to remain as explicit quantified arguments so callers can supply the intermediate prime Q and Galois group G.",
+    "mathContext": "$R \\subseteq S \\subseteq T$ with $T/R$ Galois (group $G$), and $p \\lhd R$, $P \\lhd S$, $Q \\lhd T$ maximal with $P \\mid p$ and $Q \\mid P$. Transitivity $Q \\mid p$ is recovered inside the proof, not assumed.",
+    "significance": "supporting",
+    "relatedConcepts": ["scalar tower", "non-normal extension", "lying-over relation", "Lean include directive", "quantified context variables"]
   },
   {
     "id": "ann-tower-brick",

--- a/src/data/proofs/inverse-galois-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04/meta.json
@@ -55,7 +55,8 @@
       "**Non-normality of the middle ring is a feature, not a bug**: inertia-degree tower-multiplicativity holds with no Galois hypothesis on $S$, which is precisely what lets the argument route through the non-Galois field $\\mathbb{Q}(\\alpha)$ in the $A_5$ application.",
       "**Galois uniformity is the only place the group acts**: the finite Galois group $G$ enters solely through `inertiaDegIn_eq_inertiaDeg`, collapsing the choice of top prime $Q$ so that a divisibility at one prime propagates to the Galois-invariant $\\mathrm{inertiaDegIn}$.",
       "**Divisibility, not equality, is the right currency**: phrasing the brick as $\\mathrm{inertiaDeg}\\,p\\,P \\mid \\mathrm{inertiaDegIn}\\,p\\,T$ (rather than tracking exact degrees) is exactly what the $A_5$ argument consumes — it only needs $3 \\mid \\mathrm{inertiaDegIn}$, supplied by a single Kummer–Dedekind cubic factor.",
-      "**Honest partial progress**: this entry does not on its own remove `three_dvd_gal_card`; it verifies the abstract steps (2)–(3) with 0 axioms and cleanly isolates the one remaining Kummer–Dedekind input, so the residual gap is now a single concrete divisibility fact."
+      "**Honest partial progress**: this entry does not on its own remove `three_dvd_gal_card`; it verifies the abstract steps (2)–(3) with 0 axioms and cleanly isolates the one remaining Kummer–Dedekind input, so the residual gap is now a single concrete divisibility fact.",
+      "**Formalization subtlety — `include G Q`**: the Galois group $G$ and top prime $Q$ never appear in the theorem *statements* (whose conclusions mention only $p$, $P$, $T$), so Lean would otherwise drop them from the signatures; the explicit `include G Q` directive keeps them as quantified arguments, which is what lets a caller feed in the specific intermediate prime and Galois action that make the divisibility go through."
     ],
     "prerequisites": [
       "Algebraic number theory (Dedekind domains, prime factorization in extensions, inertia degree)",
@@ -64,6 +65,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "roadmap",
+      "title": "Docstring: the three-step Kummer–Dedekind route",
+      "startLine": 3,
+      "endLine": 38,
+      "summary": "Frames OQ-04 and the companion reduction of three_dvd_gal_card to 3 ∣ inertiaDegIn (7); spells out the three-step route (Kummer–Dedekind cubic factor → tower multiplicativity → Galois uniformity) and states that this file machine-checks steps (2)–(3) with only foundational axioms"
+    },
     {
       "id": "setup",
       "title": "The Tower Setup",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04`.

## Changes
- **Annotation granularity**: split the oversized header annotation (lines 3–53, which conflated the docstring roadmap with the variable block) into two focused annotations — a docstring-roadmap annotation (3–38) and a new tower-setup annotation (40–53).
- **New formalization insight**: the tower-setup annotation documents the `include G Q` directive — G and Q appear only in the *proofs*, not the theorem *statements*, so `include` is what keeps them as quantified arguments. Added as a matching fifth `keyInsight`.
- **Section coverage**: added a `roadmap` section covering the docstring (lines 3–38); `sections` now span the file from line 3.
- Annotations now tile lines 3–85 with clean, non-overlapping ranges (4 annotations, all with mathContext/significance/relatedConcepts).

meta.json remains 12 KB, well under the 60 KB cap. No content deleted; existing high-quality prose preserved. Axiom/status fields unchanged (verified, 0 axioms) and consistent with the Lean source.