### PR TITLE
Fix: remove 8 dangling crossReferences (404 Related Proofs links)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-04-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-02/meta.json
@@ -127,11 +127,6 @@
       "targetId": "derangements",
       "relationship": "foundational",
       "description": "Root: derangement definitions and the recurrences numDerangements_add_two / numDerangements_succ underlying both component facts."
-    },
-    {
-      "targetId": "chinese-remainder-theorem",
-      "relationship": "foundational",
-      "description": "The fusion of the two coprime-modulus congruences into one modulo n(n−1) is a direct application of the CRT (here via IsCoprime.mul_dvd)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/derangements-convergence-oq-04-oq-04/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-04-oq-04/meta.json
@@ -121,11 +121,6 @@
       "description": "Parent entry, which proved (n−1) ∣ D(n) from the additive recurrence and posed a bijective proof of that recurrence as an open question."
     },
     {
-      "targetId": "derangements-convergence-oq-04-oq-01",
-      "relationship": "sibling",
-      "description": "Companion child that identifies the quotient D(n)/(n−1) as OEIS A000255; this entry instead gives the bijective proof of the recurrence itself."
-    },
-    {
       "targetId": "derangements",
       "relationship": "foundational",
       "description": "Root: derangement numbers, the additive recurrence numDerangements_add_two, and the recursion bijection derangementsRecursionEquiv used here."

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-02/meta.json
@@ -134,36 +134,43 @@
       "targetId": "lagrange-four-squares-waring-g2",
       "relationship": "extends",
       "description": "Parent entry proves Waring's problem for squares g(2) = 4 (the easy Waring number). This entry addresses its open question OQ-02 about the hard Waring number G(k) for k ≥ 3, proving the elementary congruence lower bounds."
-    },
-    {
-      "targetId": "lagrange-four-squares-waring-g2-oq-01",
-      "relationship": "related",
-      "description": "Sibling OQ-01 pins the EASY Waring number g(k) = 2^k + ⌊(3/2)^k⌋ − 2 (lower bound proved, upper axiomatized). This entry treats the distinct HARD Waring number G(k) and its lower bounds."
     }
   ],
   "references": [
     {
-      "authors": ["G. H. Hardy", "E. M. Wright"],
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
       "title": "An Introduction to the Theory of Numbers",
       "year": "2008",
       "note": "6th ed., Chapter XXI (Waring's problem); the congruence lower bounds for G(k) and the values G(2)=4, G(4)=16."
     },
     {
-      "authors": ["H. Davenport"],
+      "authors": [
+        "H. Davenport"
+      ],
       "title": "On Waring's problem for fourth powers",
       "year": "1939",
       "note": "Annals of Mathematics 40, 731-747; proves G(4) = 16, matching the mod-16 lower bound of this entry."
     },
     {
-      "authors": ["R. C. Vaughan", "T. D. Wooley"],
+      "authors": [
+        "R. C. Vaughan",
+        "T. D. Wooley"
+      ],
       "title": "Waring's problem: a survey",
       "year": "2002",
       "note": "Number Theory for the Millennium III, 301-340; modern account of bounds on G(k)."
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["BigOperators"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
     "namespace": "WaringGgLowerBoundsOQ02",
     "lineCount": 183,
     "axiomCount": 0,

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-03/meta.json
@@ -120,11 +120,6 @@
       "targetId": "newton-power-sum-identities-oq-01",
       "relationship": "extends",
       "description": "Parent entry recording the forward scalar low-degree Newton identities p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, which this entry packages as determinants."
-    },
-    {
-      "targetId": "newton-power-sum-identities-oq-01-oq-02",
-      "relationship": "dual",
-      "description": "Sibling entry proving the reverse Toeplitz-determinant form k!·eₖ = det Tₖ (each elementary symmetric polynomial as a determinant in the power sums). This entry proves the dual forward determinant pₖ = det Mₖ (each power sum as a determinant in the elementary symmetric polynomials)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/shapley-folkman-oq-04/meta.json
+++ b/src/data/proofs/shapley-folkman-oq-04/meta.json
@@ -120,11 +120,6 @@
       "targetId": "shapley-folkman-oq-03",
       "relationship": "extends",
       "description": "Sharpens OQ03's Starr distance bound d·δ to min(d, k)·δ and generalizes OQ03's pointwise no_excess_for_convex into the counting statement that the entire excess set lies among the non-convex summands. Reuses OQ03's point-selection argument for the metric refinement."
-    },
-    {
-      "targetId": "caratheodory-theorem",
-      "relationship": "related",
-      "description": "The Shapley-Folkman lemma is a Minkowski-sum strengthening of Carathéodory's theorem; this refinement observes that only non-convex summands contribute to the Carathéodory-style vertex excess, so convex summands are 'transparent' to the bound."
     }
   ],
   "references": [

--- a/src/data/proofs/triangle-angle-sum-oq-04/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-04/meta.json
@@ -114,7 +114,5 @@
       "Should the finite telescoped trigonometric sums and the Dirichlet kernel closed form be contributed upstream to Mathlib, which currently records only the infinite cosine power series Real.cos_eq_tsum?"
     ]
   },
-  "crossReferences": [
-    "triangle-angle-sum-oq-05"
-  ]
+  "crossReferences": []
 }

--- a/src/data/proofs/triangle-angle-sum-oq-06/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-06/meta.json
@@ -113,7 +113,6 @@
   },
   "crossReferences": [
     "triangle-angle-sum-oq-04",
-    "triangle-angle-sum-oq-05",
     "triangle-angle-sum-oq-07"
   ]
 }

--- a/src/data/proofs/triangle-inequality-oq-07/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-07/meta.json
@@ -139,11 +139,6 @@
       "targetId": "triangle-inequality-oq-03",
       "relationship": "related",
       "description": "Ultrametric Triangle Inequality (abstract: every triangle is isosceles)"
-    },
-    {
-      "targetId": "triangle-inequality-oq-02",
-      "relationship": "related",
-      "description": "Ultrametric Triangle Inequality in p-adic Analysis (the inequality and its equality case)"
     }
   ],
   "references": [


### PR DESCRIPTION
## Fix

Removes 8 of the 9 dangling `crossReferences` reported in the auditor issue. Each removed entry pointed to a `targetId` with **no gallery entry** — no `src/data/proofs/<slug>/` directory, and no existing entry resolves under any `id`/`slug` — so `ProofConclusion.tsx` shipped them as clickable **Related Proofs** links that 404.

## Evidence

**Before**: 9 `crossReferences[].targetId` values had no resolvable gallery entry (verified against all dirs + every entry's `id`/`slug`).
**After**: the dead links are removed. Each edited file differs from `origin/main` **only** in its `crossReferences` array (rest byte-identical after JSON reparse); each removes exactly one target.

| Source entry | Removed target |
|---|---|
| `derangements-convergence-oq-04-oq-02` | `chinese-remainder-theorem` |
| `derangements-convergence-oq-04-oq-04` | `derangements-convergence-oq-04-oq-01` |
| `lagrange-four-squares-waring-g2-oq-02` | `lagrange-four-squares-waring-g2-oq-01` |
| `newton-power-sum-identities-oq-01-oq-03` | `newton-power-sum-identities-oq-01-oq-02` |
| `shapley-folkman-oq-04` | `caratheodory-theorem` |
| `triangle-angle-sum-oq-04` | `triangle-angle-sum-oq-05` |
| `triangle-angle-sum-oq-06` | `triangle-angle-sum-oq-05` |
| `triangle-inequality-oq-07` | `triangle-inequality-oq-02` |

**Deferred (1 of 9)**: `fibonacci-divisibility-oq-07-oq-03 → fibonacci-divisibility`. The source entry's directory does not yet exist in `origin/main` (it is only present as uncommitted/unmerged work in the shared tree). It cannot be edited here; a follow-up cycle can drop that link once the entry lands.

Partially addresses #32996 (8/9 dangling links removed).

---
Automated fix by lean-mechanic agent.