### PR TITLE
research(erdos-678): honest minimalN (remove false-witness sorry) + repair Mathlib drift

### DIFF
--- a/proofs/Proofs/Erdos678Aristotle.lean
+++ b/proofs/Proofs/Erdos678Aristotle.lean
@@ -10,11 +10,17 @@
   - intervalLcm_growth (FALSE, no n-independent bound) → intervalLcm_poly_upper (correct)
   - intervalLcm_chebyshev_upper (FALSE, lcm ≤ 4^k fails for large n) → intervalLcm_le_prod (correct)
 
-  Remaining sorries in main file:
+  Update (2026-07-02): the minimalN definition sorry was removed. It previously
+  used `Nat.find ⟨96, 104, sorry⟩`, whose witness falsely claimed (96,104) yields a
+  comparison for every k (it only holds at k=7). It is now a total, honest guarded
+  definition, with minimalN_spec / minimalN_le / minimalN_eq_zero_of_not_exists
+  characterizing it. Pre-existing Mathlib v4.26 drift was also repaired so the file
+  builds (intervalLcm_poly_upper, padicValNat_intervalLcm via new intervalLcm_succ).
+
+  Remaining sorries in main file (all deep Cambie-2024 open construction):
   1. erdos_678_infinitely_many — Cambie 2024 theorem, deep combinatorics
   2. cambie_2024 — same
-  3. minimalN def sorry — blocked on existence proof for all k
-  4. erdos_growth_rate — blocked on minimalN
+  3. erdos_growth_rate — Erdős's n_k/k → ∞ growth rate
 
   These companion file targets are already proved in the main file:
 -/

--- a/proofs/Proofs/Erdos678Problem.lean
+++ b/proofs/Proofs/Erdos678Problem.lean
@@ -72,6 +72,14 @@ theorem intervalLcm_one (n : ℕ) : intervalLcm n 1 = n + 1 := by
   simp [intervalLcm, Finset.range_succ,
     Finset.fold_insert Finset.not_mem_range_self]
 
+/-- Peeling the top element: `M(n, k+1) = lcm(n+1+k, M(n,k))`.
+    Keeps the tail `intervalLcm n k` folded (unlike unfolding via `rw [intervalLcm]`),
+    so downstream lemmas stated about `intervalLcm n k` still match syntactically. -/
+theorem intervalLcm_succ (n k : ℕ) :
+    intervalLcm n (k + 1) = Nat.lcm (n + 1 + k) (intervalLcm n k) := by
+  rw [intervalLcm, Finset.range_succ, Finset.fold_insert Finset.not_mem_range_self]
+  rfl
+
 /-- LCM increases when interval extends -/
 theorem intervalLcm_mono_right (n k : ℕ) :
     intervalLcm n k ∣ intervalLcm n (k + 1) := by
@@ -166,13 +174,12 @@ theorem padicValNat_intervalLcm (p : ℕ) (hp : p.Prime) (n k : ℕ) :
   induction k with
   | zero => simp [intervalLcm, padicValNat.one]
   | succ k ih =>
-    rw [intervalLcm, Finset.range_succ, Finset.fold_insert Finset.not_mem_range_self,
-        Finset.sup_insert]
+    rw [intervalLcm_succ, Finset.range_succ, Finset.sup_insert]
     have ha : (n + 1 + k) ≠ 0 := by omega
     have hb : intervalLcm n k ≠ 0 := (intervalLcm_pos n k).ne'
     rw [← factorization_def _ hp, Nat.factorization_lcm ha hb,
-        Finsupp.sup_apply, sup_eq_max,
-        factorization_def _ hp, factorization_def _ hp, ih, sup_eq_max]
+        Finsupp.sup_apply,
+        factorization_def _ hp, factorization_def _ hp, ih]
 
 /-! ## Correct Bounds on Interval LCM -/
 
@@ -207,17 +214,49 @@ theorem intervalLcm_poly_upper (n k : ℕ) : intervalLcm n k ≤ (n + k) ^ k := 
   calc intervalLcm n k
       ≤ ∏ i ∈ Finset.range k, (n + 1 + i) := intervalLcm_le_prod n k
     _ ≤ (n + k) ^ k := by
-        apply Finset.prod_le_pow_card
-        intro i hi
-        have := Finset.mem_range.mp hi
-        omega
+        have h : ∀ i ∈ Finset.range k, (n + 1 + i) ≤ (n + k) := by
+          intro i hi
+          have := Finset.mem_range.mp hi
+          omega
+        calc ∏ i ∈ Finset.range k, (n + 1 + i)
+            ≤ (n + k) ^ (Finset.range k).card := Finset.prod_le_pow_card _ _ _ h
+          _ = (n + k) ^ k := by rw [Finset.card_range]
 
 /-! ## Erdős's Observations -/
 
-/-- The minimal n for which comparison holds grows faster than linearly -/
+open Classical in
+/-- The minimal `n` for which a comparison `M(n,k) > M(m,k+1)` holds for some `m`,
+    or `0` when no such comparison exists for this `k`.
+
+    Note: an earlier version defined this via `Nat.find ⟨96, 104, sorry⟩`, whose
+    witness falsely asserted that `(n,m) = (96,104)` yields a comparison for *every* `k`
+    (it only holds at `k = 7`). Guarding on the existence hypothesis makes `minimalN`
+    total and honest: for the `k` where Cambie's theorem guarantees a comparison, it
+    returns the genuine least admissible `n`; otherwise it returns `0`. -/
 noncomputable def minimalN (k : ℕ) : ℕ :=
-  haveI := Classical.decPred (fun n => ∃ m : ℕ, erdosLcmComparison n m k)
-  Nat.find (⟨96, 104, by sorry⟩ : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k)
+  if h : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k then Nat.find h else 0
+
+/-- When a comparison exists for `k`, `minimalN k` is realized by an actual comparison. -/
+theorem minimalN_spec (k : ℕ) (h : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k) :
+    ∃ m : ℕ, erdosLcmComparison (minimalN k) m k := by
+  classical
+  rw [minimalN, dif_pos h]
+  exact Nat.find_spec h
+
+/-- `minimalN k` is a lower bound: any `n` admitting a comparison satisfies `minimalN k ≤ n`. -/
+theorem minimalN_le (k n : ℕ) (h : ∃ m : ℕ, erdosLcmComparison n m k) :
+    minimalN k ≤ n := by
+  classical
+  have hex : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k := ⟨n, h⟩
+  rw [minimalN, dif_pos hex]
+  exact Nat.find_min' hex h
+
+/-- If no comparison exists for `k`, `minimalN k = 0`. -/
+theorem minimalN_eq_zero_of_not_exists (k : ℕ)
+    (h : ¬ ∃ n, ∃ m : ℕ, erdosLcmComparison n m k) :
+    minimalN k = 0 := by
+  classical
+  rw [minimalN, dif_neg h]
 
 /-- Erdős proved n_k/k → ∞ -/
 theorem erdos_growth_rate : ∀ C : ℕ, ∃ K : ℕ, ∀ k ≥ K, minimalN k > C * k := by

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -64,7 +64,7 @@
       "Chebyshev-type bounds on prime products",
       "Native decision procedures in Lean 4"
     ],
-    "lineCount": 236,
+    "lineCount": 275,
     "assumptions": "0 axiom(s) and 4 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
@@ -203,11 +203,11 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 236,
+    "lineCount": 275,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 22,
     "definitionCount": 4,
-    "sorries": 4,
+    "sorries": 3,
     "path": "Proofs/Erdos678Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos678Aristotle.lean"


### PR DESCRIPTION
## Erdős Problem #678 — LCM of consecutive integer intervals

Progress on the sorry-completion task for `erdos-678-incomplete-01`. **Sorries 4 → 3**, and the file now **builds** (it was silently broken by Mathlib v4.26 drift).

### Integrity fix: honest `minimalN`
`minimalN k` was defined via `Nat.find (⟨96, 104, by sorry⟩ : ∃ n, ∃ m, erdosLcmComparison n m k)`. That witness **falsely asserts** that `(n,m) = (96,104)` yields a valid comparison `M(n,k) > M(m,k+1)` for *every* `k` — but the Selfridge pair only works at `k = 7`. The `sorry` was papering over a false mathematical claim.

Replaced with a total, honest guarded definition:
```lean
noncomputable def minimalN (k : ℕ) : ℕ :=
  if h : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k then Nat.find h else 0
```
and added three characterizing lemmas (all verified, 0-axiom):
- `minimalN_spec` — when a comparison exists, `minimalN k` realizes one
- `minimalN_le` — `minimalN k` is a lower bound over admissible `n`
- `minimalN_eq_zero_of_not_exists` — returns `0` when no comparison exists

### Pre-existing Mathlib v4.26 drift repaired (file didn't compile)
- `intervalLcm_poly_upper`: `Finset.prod_le_pow_card` no longer unifies `#(range k)` with `k`; proof now goes through `(range k).card` then `Finset.card_range`.
- `padicValNat_intervalLcm`: `rw [intervalLcm, …]` unfolded the tail so `Nat.factorization_lcm` (stated about `intervalLcm n k`) no longer matched; added helper `intervalLcm_succ` to peel the top element while keeping the tail folded, and dropped the removed `sup_eq_max` lemma (`⊔ = max` is defeq on ℕ).

### Remaining sorries (deep — Cambie 2024 open construction)
`erdos_678_infinitely_many`, `cambie_2024`, `erdos_growth_rate`. These require Cambie's 2024 existence construction (primes/prime-powers in intervals) and Erdős's `n_k/k → ∞` growth bound — genuinely deep, out of scope for a routine completion pass.

### Verification
`import Mathlib`; elaborated cleanly (`docker-build.sh` / in-container `lean`, Lean v4.26.0): **0 errors, 0 axioms**, only the 3 intended deep-sorry warnings + pre-existing deprecation lints. `axiomCount = 0`, `status = formalized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)