### PR TITLE
research(konigsberg-oq-04-oq-01): prove reducedLaplacian_eq_gram (Matrix-Tree M1a-i′)

### DIFF
--- a/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
+++ b/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean
@@ -158,6 +158,40 @@ theorem incidence_mul_transpose (head tail : E → V) (hloop : ∀ e, head e ≠
   · subst h; simp [lap, incidence_mul_transpose_diag head tail hloop]
   · simp [lap, h, incidence_mul_transpose_offdiag head tail i j h]
 
+/-! ### M1a-i′: the reduced Laplacian is a Gram matrix (Cauchy–Binet precondition)
+
+The Matrix-Tree proof does not take the determinant of the *full* Laplacian `lap = B Bᵀ`
+(that determinant is `0` — every row sums to zero, cf. Mathlib's `det_lapMatrix_eq_zero`).
+It deletes the root row/column and takes the determinant of the resulting **reduced**
+Laplacian.  The lemma below records the exact object Cauchy–Binet is then applied to: the
+reduced Laplacian is itself the Gram matrix `B_f (B_f)ᵀ` of the *reduced incidence* `B_f`
+(the incidence matrix with the deleted rows removed, i.e. `incidence` restricted along any
+reindexing `f : V' → V` of the retained vertices).
+
+This is a pure consequence of M1a-i (`incidence_mul_transpose`) and the submatrix/product
+algebra (`Matrix.submatrix_mul`, `Matrix.transpose_submatrix`), for an *arbitrary* index map
+`f` — in particular the classical "delete the root" specialization `f : {v // v ≠ r} ↪ V`.
+It reduces the remaining Matrix-Tree gap to the two genuinely-absent pieces: Cauchy–Binet
+`det (B_f B_fᵀ) = Σ_S det (B_f · col S)²` (M1a-ii) and the unimodularity `det ∈ {0, ±1}`
+that identifies the nonzero terms with spanning trees. -/
+
+omit [Fintype V] [DecidableEq E] in
+/-- **Reduced Laplacian = Gram matrix of the reduced incidence.** For any reindexing
+`f : V' → V` of a subset of vertices, the Laplacian restricted to those vertices equals
+`B_f (B_f)ᵀ`, where `B_f = (incidence head tail).submatrix f id` keeps only the `f`-rows.
+Applied with `f` the inclusion of the non-root vertices, the left side is the reduced
+Laplacian whose determinant is the spanning-tree / arborescence count. -/
+theorem reducedLaplacian_eq_gram
+    (head tail : E → V) (hloop : ∀ e, head e ≠ tail e)
+    {V' : Type*} (f : V' → V) :
+    (lap head tail).submatrix f f
+      = (incidence head tail).submatrix f id *
+        ((incidence head tail).submatrix f id)ᵀ := by
+  rw [← incidence_mul_transpose head tail hloop,
+    Matrix.submatrix_mul (incidence head tail) (incidence head tail)ᵀ f id f
+      Function.bijective_id,
+    Matrix.transpose_submatrix]
+
 /-! ### Concrete K₃ bridge
 
 Realizes the general identity on a base case: the oriented incidence of K₃ (edges

--- a/research/problems/konigsberg-oq-04-oq-01/state.md
+++ b/research/problems/konigsberg-oq-04-oq-01/state.md
@@ -1,9 +1,32 @@
 # Current State
 
-**Phase**: ACT — **M1a-i PROVED** (oriented incidence ⇒ Laplacian); M1a-ii (Cauchy–Binet) + M2 (Tutte) remain
+**Phase**: ACT — **M1a-i′ PROVED** (reduced Laplacian = Gram of reduced incidence); M1a-ii (Cauchy–Binet) + M2 (Tutte) remain
 **Since**: 2026-06-14 (S1, researcher-3)
-**Iteration**: 4
-**Last Updated**: 2026-06-28 (researcher-1, **S4 ACT** — proved `incidence_mul_transpose : B Bᵀ = D − A` + K₃ bridge, 0-axiom host-verified)
+**Iteration**: 5
+**Last Updated**: 2026-07-02 (researcher-4, **S5 ACT** — proved `reducedLaplacian_eq_gram : (lap).submatrix f f = B_f B_fᵀ`, 0-axiom host-verified)
+
+## S5 ACT (researcher-4, 2026-07-02) — M1a-i′: reduced Laplacian is a Gram matrix
+
+Added the Cauchy–Binet *precondition* to `KonigsbergOQ04OQ01MatrixTree.lean`: the exact
+object whose determinant Matrix-Tree takes is now identified as a Gram matrix.
+
+- `reducedLaplacian_eq_gram (head tail) (hloop) {V'} (f : V' → V) :`
+  `(lap head tail).submatrix f f = B_f * B_fᵀ` where `B_f = (incidence head tail).submatrix f id`.
+  For **arbitrary** reindexing `f` of retained vertices — in particular the classical
+  "delete the root" inclusion `{v // v ≠ r} ↪ V`, giving the reduced Laplacian as
+  `B_r B_rᵀ`.
+- Proof is 3 rewrites off M1a-i: `← incidence_mul_transpose`, then
+  `Matrix.submatrix_mul _ _ f id f Function.bijective_id` (middle edge-index reindex is `id`,
+  bijective), then `Matrix.transpose_submatrix`. No new hypotheses.
+
+Host-verified (`lean` vs main's prebuilt Mathlib v4.26.0, EXIT 0, no warnings/sorry);
+`#print axioms reducedLaplacian_eq_gram` = `propext/Classical.choice/Quot.sound` only.
+
+**Why this matters / what remains.** The remaining Matrix-Tree gap is now cleanly two-piece:
+over this Gram form, need (M1a-ii) **Cauchy–Binet** `det (B_f B_fᵀ) = Σ_S det(B_f · col S)²`
+(still absent upstream — the hard Mathlib-PR-sized keystone) and the **unimodularity**
+`det (B_f · col S) ∈ {0, ±1}` picking out spanning-tree terms. M2 (directed Tutte) still
+needed for the BEST/arborescence path. Does NOT discharge the parent `konigsberg-oq-04` axiom.
 
 ## S4 ACT (researcher-1, 2026-06-28) — M1a-i proved, host-verified 0-axiom
 


### PR DESCRIPTION
## Matrix-Tree progress — the reduced Laplacian is a Gram matrix

Companion research file `Proofs/KonigsbergOQ04OQ01MatrixTree.lean` for `konigsberg-oq-04-oq-01` (whether Mathlib's linear-algebra API can formalize Matrix-Tree and discharge the parent `konigsberg-oq-04` `arborescenceCount` axiom).

Prior session (S4) proved **M1a-i** `incidence_mul_transpose : B Bᵀ = D − A` (the oriented incidence ⇒ Laplacian identity Mathlib lacks). This PR adds **M1a-i′**: the exact object Matrix-Tree takes the determinant of is a **Gram matrix**.

### New theorem
```lean
theorem reducedLaplacian_eq_gram (head tail : E → V) (hloop : ∀ e, head e ≠ tail e)
    {V' : Type*} (f : V' → V) :
    (lap head tail).submatrix f f
      = (incidence head tail).submatrix f id * ((incidence head tail).submatrix f id)ᵀ
```
For an **arbitrary** reindexing `f : V' → V` of retained vertices — in particular the classical delete-the-root inclusion `{v // v ≠ r} ↪ V`, which makes the left side the reduced Laplacian whose determinant is the spanning-tree / arborescence count.

Proof is three rewrites off M1a-i: `← incidence_mul_transpose`, `Matrix.submatrix_mul` (the middle edge index is reindexed by the bijective `id`), `Matrix.transpose_submatrix`. No new hypotheses.

### Verification
Host-verified with `lean` against the pinned Mathlib v4.26.0 (Docker infra down): **EXIT 0, no warnings, no sorry**. `#print axioms reducedLaplacian_eq_gram` = `propext, Classical.choice, Quot.sound` only — no custom axioms.

### What remains
The remaining Matrix-Tree gap over this Gram form is cleanly two-piece: **(M1a-ii) Cauchy–Binet** `det(B_f B_fᵀ) = Σ_S det(B_f·col S)²` and the **unimodularity** `det(B_f·col S) ∈ {0, ±1}` identifying the nonzero terms with spanning trees — both still absent upstream (Mathlib-PR-sized). M2 (directed Tutte cofactor) is still needed for the BEST/arborescence path.

**This does NOT discharge the parent `konigsberg-oq-04` axiom** — it is verified substrate the eventual proof builds on. Research companion file; no gallery entry affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)