### PR TITLE
Enrich Discharging the Hadamard Three-Lines Axiom: add crux keyInsight

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
@@ -65,7 +65,8 @@
       "The lemma is fully available in Mathlib (Complex.HadamardThreeLines) — the open question was really 'is it wired up?', and the answer is yes.",
       "The only genuine work is hypothesis translation between the entry's hand-rolled strip geometry and Mathlib's verticalStrip API; the mathematical content is Mathlib's.",
       "Discharging the three-lines axiom reduces the parent's axiom count from the analytic core; only the packaging axiom riesz_thorin (which follows from three-lines) remains.",
-      "The logarithmic form makes the convexity of t ↦ log‖F(t+iy)‖ explicit — exactly the statement that interpolates operator norms."
+      "The logarithmic form makes the convexity of t ↦ log‖F(t+iy)‖ explicit — exactly the statement that interpolates operator norms.",
+      "The technical crux of the translation is the topological identity closure(verticalStrip 0 1) = verticalClosedStrip 0 1 (from closure_preimage_re + closure_Ioo): it is what lets continuity-on-the-closed-strip plus holomorphy-on-the-open-strip assemble into Mathlib's single DiffContOnCl hypothesis, the exact input the maximum-principle result expects."
     ],
     "prerequisites": [
       "Complex analysis (maximum modulus principle)",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-02-oq-01`.

This entry was already high quality (6 fully-populated annotations covering the whole file, complete sections/conclusion/references/crossReferences). Per the size/diminishing-returns guardrails I made a single targeted improvement rather than inflating it:

- Added a 5th `keyInsight` (target is 4–5) naming the **technical crux** of the hypothesis translation — the topological identity `closure(verticalStrip 0 1) = verticalClosedStrip 0 1` (from `closure_preimage_re` + `closure_Ioo`) that assembles continuity-on-the-closed-strip + holomorphy-on-the-open-strip into Mathlib's single `DiffContOnCl` input. Previously this crux appeared only in an annotation, not in the overview insights.

meta.json is 11.5 KB, well under the 60 KB cap. No content removed; status/axiom fields unchanged (verified, 0 axioms).