### PR TITLE
research: Lp restriction map + retraction splitting extByZeroCLM (cauchy-schwarz-integral-oq-...-incomplete-01-oq-01) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01OQ01.lean
@@ -1,0 +1,218 @@
+/-
+# The Lp Restriction Map and the Splitting of Extension-by-Zero
+(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01)
+
+## What This Proves
+
+The σ-finite Lp Riesz representation development localizes a functional on `Lp(μ)`
+to each set `S` of a spanning σ-finite cover using the **extension-by-zero** map
+
+  `extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ`,   `g ↦ [S.indicator g]`.
+
+The parent open question `oq-01` asked whether the *restriction* map
+`Lp(μ) → Lp(μ.restrict S)` could instead serve as the localization device.  The
+parent's answer was "yes in principle, but `extByZeroCLM` sufficed, so the
+restriction map was never built."
+
+This file constructs that missing companion map and proves it is a genuine
+**left inverse** (retraction) of extension-by-zero.  Together, the two maps
+exhibit `Lp(μ.restrict S)` as an isometrically embedded, norm-`1`-retracted
+(hence `1`-complemented) subspace of `Lp(μ)`.
+
+### Results Proved (no sorry, no axiom)
+
+1. `extByZeroCLM` — extension-by-zero isometry `Lp(μ.restrict S) →L[ℝ] Lp(μ)`
+   (self-contained restatement, so the file verifies against Mathlib alone).
+2. `restrictToLpCLM` — the restriction map `Lp(μ) →L[ℝ] Lp(μ.restrict S)`,
+   a norm-nonincreasing CLM.
+3. `restrictToLpCLM_coeFn` — `⇑(restrictToLpCLM S f) =ᵐ[μ.restrict S] ⇑f`.
+4. `restrictToLpCLM_norm_apply_le` / `restrictToLpCLM_opNorm_le_one`
+   — `‖restrictToLpCLM S f‖ ≤ ‖f‖` and `‖restrictToLpCLM S‖ ≤ 1`.
+5. `restrictToLpCLM_extByZeroCLM` — **the retraction identity**
+   `restrictToLpCLM S (extByZeroCLM hS hp hptop g) = g`.
+6. `restrictToLpCLM_comp_extByZeroCLM` — the composed CLM is the identity.
+7. `extByZeroCLM_injective` — immediate corollary: extension-by-zero is injective.
+
+## References
+
+- Folland, Real Analysis (2nd ed.), §6.2 (Lp duality, σ-finite localization).
+- Mathlib: `MeasureTheory.MemLp.restrict`, `MeasureTheory.eLpNorm_restrict_le`,
+  `MeasureTheory.eLpNorm_indicator_eq_eLpNorm_restrict`,
+  `MeasureTheory.ae_restrict_of_ae`, `MeasureTheory.ae_restrict_mem`.
+-/
+
+import Mathlib
+
+noncomputable section
+
+open MeasureTheory ENNReal NNReal Set Filter
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+-- ============================================================================
+-- § 1. Extension-by-zero  Lp(μ.restrict S) →L[ℝ] Lp(μ)  (self-contained)
+-- ============================================================================
+
+/-- If `f ∈ Lp(μ.restrict S)`, then `S.indicator f ∈ Lp(μ)`.  The `eLpNorm` is
+literally preserved, via Mathlib's `eLpNorm_indicator_eq_eLpNorm_restrict`. -/
+private theorem memLp_indicator_of_restrict {S : Set α} (hS : MeasurableSet S)
+    {f : α → ℝ} {p : ℝ≥0∞} (hf : MemLp f p (μ.restrict S)) :
+    MemLp (S.indicator f) p μ := by
+  refine ⟨(aestronglyMeasurable_indicator_iff hS).mpr hf.1, ?_⟩
+  rw [eLpNorm_indicator_eq_eLpNorm_restrict hS]
+  exact hf.2
+
+/-- **Extension-by-zero:** the isometric embedding `Lp(μ.restrict S) →L[ℝ] Lp(μ)`
+sending a class `g` to the class of `S.indicator g`. -/
+noncomputable def extByZeroCLM {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)] :
+    Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ :=
+  LinearMap.mkContinuous
+    { toFun := fun f => (memLp_indicator_of_restrict hS (Lp.memLp f)).toLp _
+      map_add' := fun f₁ f₂ => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          (memLp_indicator_of_restrict hS (Lp.memLp (f₁ + f₂))).coeFn_toLp,
+          (memLp_indicator_of_restrict hS (Lp.memLp f₁)).coeFn_toLp,
+          (memLp_indicator_of_restrict hS (Lp.memLp f₂)).coeFn_toLp,
+          Lp.coeFn_add ((memLp_indicator_of_restrict hS (Lp.memLp f₁)).toLp _)
+            ((memLp_indicator_of_restrict hS (Lp.memLp f₂)).toLp _),
+          (ae_restrict_iff' hS).mp (Lp.coeFn_add f₁ f₂)]
+          with a h12 h1 h2 hadd hinner
+        rw [h12, hadd]
+        simp only [Pi.add_apply, h1, h2]
+        by_cases ha : a ∈ S
+        · simp only [Set.indicator_of_mem ha]; simpa using hinner ha
+        · simp only [Set.indicator_of_notMem ha, add_zero]
+      map_smul' := fun c f => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          (memLp_indicator_of_restrict hS (Lp.memLp (c • f))).coeFn_toLp,
+          (memLp_indicator_of_restrict hS (Lp.memLp f)).coeFn_toLp,
+          Lp.coeFn_smul c ((memLp_indicator_of_restrict hS (Lp.memLp f)).toLp _),
+          (ae_restrict_iff' hS).mp (Lp.coeFn_smul c f)]
+          with a hcf hf hsmul hinner
+        rw [hcf, RingHom.id_apply, hsmul]
+        simp only [Pi.smul_apply, hf, smul_eq_mul]
+        by_cases ha : a ∈ S
+        · simp only [Set.indicator_of_mem ha]; rw [hinner ha]; simp
+        · simp only [Set.indicator_of_notMem ha, mul_zero] }
+    1
+    (fun f => by
+      simp only [LinearMap.coe_mk, AddHom.coe_mk, one_mul]
+      have heq : ‖(memLp_indicator_of_restrict hS (Lp.memLp f)).toLp _‖ = ‖f‖ := by
+        simp only [Lp.norm_def]
+        congr 1
+        rw [eLpNorm_congr_ae (memLp_indicator_of_restrict hS (Lp.memLp f)).coeFn_toLp,
+            eLpNorm_indicator_eq_eLpNorm_restrict hS]
+      exact heq.le)
+
+/-- The underlying function of `extByZeroCLM hS g` agrees `μ`-a.e. with
+`S.indicator ⇑g`. -/
+theorem extByZeroCLM_coeFn {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)] (g : Lp ℝ p (μ.restrict S)) :
+    extByZeroCLM hS g =ᵐ[μ] S.indicator (g : α → ℝ) := by
+  simp only [extByZeroCLM, LinearMap.mkContinuous_apply, LinearMap.coe_mk, AddHom.coe_mk]
+  exact (memLp_indicator_of_restrict hS (Lp.memLp g)).coeFn_toLp
+
+-- ============================================================================
+-- § 2. The restriction map  Lp(μ) →L[ℝ] Lp(μ.restrict S)
+-- ============================================================================
+
+/-- **Restriction map.**  A class `f ∈ Lp ℝ p μ` restricts to a class in
+`Lp ℝ p (μ.restrict S)`: the underlying function is unchanged, only the measure
+shrinks to `μ.restrict S ≤ μ`.  This is a norm-nonincreasing continuous linear map,
+the companion of `extByZeroCLM`. -/
+noncomputable def restrictToLpCLM (S : Set α)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)] :
+    Lp ℝ p μ →L[ℝ] Lp ℝ p (μ.restrict S) :=
+  LinearMap.mkContinuous
+    { toFun := fun f => ((Lp.memLp f).restrict S).toLp _
+      map_add' := fun f₁ f₂ => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          ((Lp.memLp (f₁ + f₂)).restrict S).coeFn_toLp,
+          ((Lp.memLp f₁).restrict S).coeFn_toLp,
+          ((Lp.memLp f₂).restrict S).coeFn_toLp,
+          Lp.coeFn_add (((Lp.memLp f₁).restrict S).toLp _)
+            (((Lp.memLp f₂).restrict S).toLp _),
+          ae_restrict_of_ae (Lp.coeFn_add f₁ f₂)]
+          with a h12 h1 h2 hadd hinner
+        simp only [h12, hadd, h1, h2, hinner, Pi.add_apply]
+      map_smul' := fun c f => by
+        rw [Lp.ext_iff]
+        filter_upwards [
+          ((Lp.memLp (c • f)).restrict S).coeFn_toLp,
+          ((Lp.memLp f).restrict S).coeFn_toLp,
+          Lp.coeFn_smul c (((Lp.memLp f).restrict S).toLp _),
+          ae_restrict_of_ae (Lp.coeFn_smul c f)]
+          with a hcf hf hsmul hinner
+        simp only [hcf, hsmul, hf, hinner, Pi.smul_apply, RingHom.id_apply, smul_eq_mul] }
+    1
+    (fun f => by
+      simp only [LinearMap.coe_mk, AddHom.coe_mk, one_mul]
+      have heq : ‖((Lp.memLp f).restrict S).toLp _‖
+          = (eLpNorm (f : α → ℝ) p (μ.restrict S)).toReal := by
+        rw [Lp.norm_def, eLpNorm_congr_ae ((Lp.memLp f).restrict S).coeFn_toLp]
+      rw [heq, Lp.norm_def]
+      exact ENNReal.toReal_mono (Lp.eLpNorm_ne_top f) (eLpNorm_restrict_le _ _ _ _))
+
+/-- The underlying function of `restrictToLpCLM S f` agrees `μ.restrict S`-a.e.
+with the underlying function of `f`. -/
+theorem restrictToLpCLM_coeFn (S : Set α) {p : ℝ≥0∞} [Fact (1 ≤ p)]
+    (f : Lp ℝ p μ) :
+    restrictToLpCLM S f =ᵐ[μ.restrict S] (f : α → ℝ) := by
+  simp only [restrictToLpCLM, LinearMap.mkContinuous_apply, LinearMap.coe_mk, AddHom.coe_mk]
+  exact ((Lp.memLp f).restrict S).coeFn_toLp
+
+/-- `restrictToLpCLM` is norm-nonincreasing (pointwise form). -/
+theorem restrictToLpCLM_norm_apply_le (S : Set α) {p : ℝ≥0∞} [Fact (1 ≤ p)]
+    (f : Lp ℝ p μ) :
+    ‖restrictToLpCLM S f‖ ≤ ‖f‖ := by
+  have heq : ‖restrictToLpCLM S f‖ = (eLpNorm (f : α → ℝ) p (μ.restrict S)).toReal := by
+    rw [Lp.norm_def, eLpNorm_congr_ae (restrictToLpCLM_coeFn S f)]
+  rw [heq, Lp.norm_def]
+  exact ENNReal.toReal_mono (Lp.eLpNorm_ne_top f) (eLpNorm_restrict_le _ _ _ _)
+
+/-- The operator norm of the restriction map is at most `1`. -/
+theorem restrictToLpCLM_opNorm_le_one (S : Set α) {p : ℝ≥0∞} [Fact (1 ≤ p)] :
+    ‖(restrictToLpCLM S : Lp ℝ p μ →L[ℝ] Lp ℝ p (μ.restrict S))‖ ≤ 1 :=
+  ContinuousLinearMap.opNorm_le_bound _ zero_le_one
+    (fun f => by rw [one_mul]; exact restrictToLpCLM_norm_apply_le S f)
+
+-- ============================================================================
+-- § 3. The retraction:  restrictToLpCLM ∘ extByZeroCLM = id
+-- ============================================================================
+
+/-- **Retraction identity.**  Restricting the extension-by-zero of a class back to
+`μ.restrict S` recovers the original class.  Thus `restrictToLpCLM S` is an explicit
+left inverse of `extByZeroCLM`, exhibiting the latter as a split isometric embedding. -/
+theorem restrictToLpCLM_extByZeroCLM {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)]
+    (g : Lp ℝ p (μ.restrict S)) :
+    restrictToLpCLM S (extByZeroCLM hS g) = g := by
+  rw [Lp.ext_iff]
+  filter_upwards [restrictToLpCLM_coeFn S (extByZeroCLM hS g),
+    ae_restrict_of_ae (extByZeroCLM_coeFn hS g), ae_restrict_mem hS]
+    with a har hae hmem
+  rw [har, hae, Set.indicator_of_mem hmem]
+
+/-- The composition `restrictToLpCLM S ∘L extByZeroCLM` is the identity CLM. -/
+theorem restrictToLpCLM_comp_extByZeroCLM {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)] :
+    (restrictToLpCLM S).comp (extByZeroCLM (μ := μ) hS)
+      = ContinuousLinearMap.id ℝ (Lp ℝ p (μ.restrict S)) := by
+  refine ContinuousLinearMap.ext fun g => ?_
+  simp only [ContinuousLinearMap.comp_apply, ContinuousLinearMap.id_apply]
+  exact restrictToLpCLM_extByZeroCLM hS g
+
+/-- `extByZeroCLM` is injective (immediate from the retraction identity). -/
+theorem extByZeroCLM_injective {S : Set α} (hS : MeasurableSet S)
+    {p : ℝ≥0∞} [Fact (1 ≤ p)] :
+    Function.Injective (extByZeroCLM (μ := μ) (p := p) hS) := by
+  intro g₁ g₂ h
+  have h₁ := restrictToLpCLM_extByZeroCLM (μ := μ) hS g₁
+  have h₂ := restrictToLpCLM_extByZeroCLM (μ := μ) hS g₂
+  rw [← h₁, ← h₂, h]
+
+end

--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ01.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ01.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-
+# Is Analysis Inherently Required for the Fundamental Theorem of Algebra?
+
+## The open question
+
+The parent entry (Fundamental Theorem of Algebra) records the folklore remark:
+*"Despite its name, every known proof requires analysis — there is no purely
+algebraic proof."*  The associated open question asks:
+
+> Can a purely algebraic proof of the FTA ever be found, or is analysis
+> inherently required?
+
+## The definitive answer
+
+**Analysis is inherently required — but its role can be pinned down exactly.**
+
+A proof using *only* the field axioms is impossible: the FTA is a statement
+about the specific field `ℝ` (equivalently `ℂ = ℝ[i]`), and it is simply *false*
+for other fields (`ℚ`, finite fields, …).  So any proof must consume some
+property of `ℝ` that goes beyond "being a field".  The modern
+Artin–Schreier / Galois-theoretic proof isolates that non-algebraic content to
+exactly **two** order/analytic facts about the reals:
+
+* **(A)** every odd-degree real polynomial has a real root
+  (a consequence of the Intermediate Value Theorem — hence of the *order
+  completeness* of `ℝ`);
+* **(B)** every complex number has a square root
+  (equivalently, every non-negative real has a real square root).
+
+Given (A) and (B), the remainder of the proof — that `ℝ[i]` is algebraically
+closed — is *pure algebra* (Sylow theory + Galois theory, no further analysis).
+Both (A) and (B) fail over general fields, so they carry genuine analytic
+weight; this is the precise sense in which analysis is unavoidable.
+
+This file formalizes the two analytic ingredients and the algebraic
+obstruction, then connects them to Mathlib's proof that `ℂ` is algebraically
+closed.
+
+## What is proved here
+
+* `odd_degree_real_root` — **(A)**: every real polynomial of odd degree has a
+  real root.  Proved analytically: the polynomial function `ℝ → ℝ` is
+  continuous and, having odd degree, tends to `+∞` at one end and `-∞` at the
+  other, so by `Continuous.surjective` it hits `0`.  This is the irreducible
+  IVT / order-completeness input.
+* `complex_has_sqrt` — **(B)**: every complex number has a square root, via the
+  polar form `w = √‖z‖ · exp(i·arg z / 2)`.  Non-circular: it uses only the
+  real square root, *not* the FTA.
+* `real_not_alg_closed` and `cubic_no_root_zmod2` — the **algebraic
+  obstruction**: neither "is algebraically closed" nor "odd-degree polynomials
+  have roots" is a consequence of the field axioms.  `X² + 1` has no root in
+  `ℝ`, and the odd-degree (cubic) `X³ + X + 1` has no root in the field `𝔽₂`.
+* `fta_complex` — the conclusion the Artin reduction targets, supplied by
+  Mathlib (`Complex.exists_root`): every non-constant complex polynomial has a
+  root.
+
+## Status
+
+Verified, 0 sorries, 0 axioms.  `native_decide` is **not** used.
+-/
+
+open Polynomial Filter Topology
+
+namespace FundamentalTheoremAlgebraOQ01
+
+/-! ## Analytic ingredient (A): odd-degree real polynomials have a root -/
+
+/-- Helper: an odd-degree real polynomial with **positive** leading coefficient
+tends to `+∞` at `+∞` and to `−∞` at `−∞`, hence (being continuous) is
+surjective and in particular has a root. -/
+private theorem root_of_odd_pos (p : ℝ[X]) (hodd : Odd p.natDegree)
+    (hlc : 0 < p.leadingCoeff) : ∃ x : ℝ, p.IsRoot x := by
+  -- odd degree ⇒ degree ≥ 1
+  have hpos : 0 < p.natDegree := by rcases hodd with ⟨m, hm⟩; omega
+  have hne : p ≠ 0 := by
+    intro h; rw [h, natDegree_zero] at hpos; exact lt_irrefl 0 hpos
+  have hdeg : 0 < p.degree := natDegree_pos_iff_degree_pos.mp hpos
+  have hcont : Continuous fun x : ℝ => p.eval x := p.continuous
+  -- behaviour at +∞
+  have htop : Tendsto (fun x : ℝ => p.eval x) atTop atTop :=
+    p.tendsto_atTop_of_leadingCoeff_nonneg hdeg hlc.le
+  -- behaviour at −∞, obtained by reflecting `p` through `X ↦ -X`
+  have hnd : (-X : ℝ[X]).natDegree = 1 := by rw [natDegree_neg, natDegree_X]
+  have hbot : Tendsto (fun x : ℝ => p.eval x) atBot atBot := by
+    -- leading coefficient of `p(-X)` is `-leadingCoeff p < 0`
+    have hlc' : (p.comp (-X)).leadingCoeff ≤ 0 := by
+      rw [leadingCoeff_comp (by rw [hnd]; exact one_ne_zero),
+        leadingCoeff_neg, leadingCoeff_X,
+        show (-1 : ℝ) = -(1 : ℝ) from rfl, hodd.neg_pow, one_pow]
+      linarith
+    have hqd : 0 < (p.comp (-X)).degree := by
+      rw [← natDegree_pos_iff_degree_pos, natDegree_comp, hnd, mul_one]; exact hpos
+    have hcomp : Tendsto (fun y : ℝ => (p.comp (-X)).eval y) atTop atBot :=
+      (p.comp (-X)).tendsto_atBot_of_leadingCoeff_nonpos hqd hlc'
+    have heq : (fun y : ℝ => (p.comp (-X)).eval y) = fun y : ℝ => p.eval (-y) := by
+      funext y; rw [eval_comp, eval_neg, eval_X]
+    rw [heq] at hcomp
+    have hc := hcomp.comp tendsto_neg_atBot_atTop
+    have hfun : ((fun y : ℝ => p.eval (-y)) ∘ Neg.neg) = fun x : ℝ => p.eval x := by
+      funext x; simp [Function.comp, neg_neg]
+    rwa [hfun] at hc
+  obtain ⟨x, hx⟩ := hcont.surjective htop hbot 0
+  exact ⟨x, hx⟩
+
+/-- **(A)** — Every real polynomial of odd degree has a real root.  This is the
+irreducible Intermediate-Value-Theorem input to the FTA. -/
+theorem odd_degree_real_root (p : ℝ[X]) (hodd : Odd p.natDegree) :
+    ∃ x : ℝ, p.IsRoot x := by
+  rcases lt_trichotomy p.leadingCoeff 0 with h | h | h
+  · -- negative leading coefficient: apply the helper to `-p`, same roots
+    obtain ⟨x, hx⟩ :=
+      root_of_odd_pos (-p) (by rwa [natDegree_neg]) (by rw [leadingCoeff_neg]; linarith)
+    exact ⟨x, by simpa [IsRoot, eval_neg] using hx⟩
+  · -- zero leading coefficient forces `p = 0`, whose degree `0` is not odd
+    exfalso
+    rw [leadingCoeff_eq_zero] at h
+    rw [h, natDegree_zero] at hodd
+    exact (by decide : ¬ Odd 0) hodd
+  · exact root_of_odd_pos p hodd h
+
+/-! ## Analytic ingredient (B): complex numbers have square roots -/
+
+/-- **(B)** — Every complex number has a square root, built from the *real*
+square root via the polar form `w = √‖z‖ · exp(i · arg z / 2)`.  This proof does
+not invoke the FTA, so it is a genuinely independent analytic ingredient. -/
+theorem complex_has_sqrt (z : ℂ) : ∃ w : ℂ, w ^ 2 = z := by
+  refine ⟨(Real.sqrt ‖z‖ : ℂ) * Complex.exp ((Complex.arg z : ℂ) / 2 * Complex.I), ?_⟩
+  have sq1 : ((Real.sqrt ‖z‖ : ℝ) : ℂ) ^ 2 = (‖z‖ : ℂ) := by
+    rw [← Complex.ofReal_pow, Real.sq_sqrt (norm_nonneg z)]
+  have e2 : Complex.exp ((Complex.arg z : ℂ) / 2 * Complex.I) ^ 2
+      = Complex.exp ((Complex.arg z : ℂ) * Complex.I) := by
+    rw [sq, ← Complex.exp_add]; congr 1; ring
+  calc
+    ((Real.sqrt ‖z‖ : ℂ) * Complex.exp ((Complex.arg z : ℂ) / 2 * Complex.I)) ^ 2
+        = ((Real.sqrt ‖z‖ : ℂ)) ^ 2
+            * Complex.exp ((Complex.arg z : ℂ) / 2 * Complex.I) ^ 2 := by rw [mul_pow]
+    _ = (‖z‖ : ℂ) * Complex.exp ((Complex.arg z : ℂ) * Complex.I) := by rw [sq1, e2]
+    _ = z := Complex.norm_mul_exp_arg_mul_I z
+
+/-! ## The algebraic obstruction: the two facts are not field-theoretic -/
+
+/-- `ℝ` is **not** algebraically closed: `X² + 1` has no real root.  Order
+completeness gives odd-degree roots (ingredient A), yet closure still fails —
+this is exactly why ingredient (B), the imaginary unit `i`, must be adjoined. -/
+theorem real_not_alg_closed : ∀ x : ℝ, x ^ 2 + 1 ≠ 0 := by
+  intro x
+  have : (0 : ℝ) ≤ x ^ 2 := sq_nonneg x
+  positivity
+
+/-- The "odd-degree ⇒ root" property (ingredient A) is **special to `ℝ`**, not a
+consequence of the field axioms: over the finite field `𝔽₂ = ZMod 2` the
+odd-degree (cubic) polynomial `X³ + X + 1` has no root.  Decidable, so `decide`
+suffices — no `native_decide`. -/
+theorem cubic_no_root_zmod2 : ∀ x : ZMod 2, x ^ 3 + x + 1 ≠ 0 := by decide
+
+/-- The same cubic packaged as an honest `Polynomial` with no root in `𝔽₂`. -/
+theorem cubic_poly_no_root_zmod2 :
+    ∀ x : ZMod 2, ((X ^ 3 + X + 1 : (ZMod 2)[X])).IsRoot x → False := by
+  intro x hx
+  rw [IsRoot.def] at hx
+  simp only [eval_add, eval_pow, eval_X, eval_one] at hx
+  exact cubic_no_root_zmod2 x hx
+
+/-! ## The conclusion the algebraic reduction targets (from Mathlib) -/
+
+/-- The FTA itself, as proved in Mathlib (`Complex.exists_root`, via Liouville's
+theorem).  Given the two analytic ingredients (A) and (B) above, the
+Artin–Schreier argument derives this by *pure algebra*; Mathlib instead derives
+it directly from complex analysis.  Either way, analysis enters — which answers
+the open question. -/
+theorem fta_complex (p : ℂ[X]) (hp : 0 < p.degree) : ∃ z : ℂ, p.IsRoot z :=
+  Complex.exists_root hp
+
+end FundamentalTheoremAlgebraOQ01

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-lprestrict-preamble",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "Overview: the restriction map and the splitting of extension-by-zero",
+    "content": "The σ-finite Lᵖ Riesz representation theorem localizes a functional on Lp(μ) to each set S of a σ-finite spanning cover using extension-by-zero, extByZeroCLM : Lp(μ.restrict S) →L[ℝ] Lp(μ), g ↦ [S.indicator g]. The parent's open question oq-01 asked whether the dual restriction map Lp(μ) → Lp(μ.restrict S) could serve the same role. This file constructs that map and proves it is an explicit left inverse of extension-by-zero, so the local Lᵖ space is a 1-complemented subspace of the global one. The file imports only Mathlib and is fully machine-checked (0 axioms, 0 sorries).",
+    "mathContext": "For $\\nu = \\mu\\restriction S \\le \\mu$, restriction $L^p(\\mu) \\to L^p(\\nu)$ and extension-by-zero $L^p(\\nu) \\to L^p(\\mu)$ form a retraction pair: $\\mathrm{restrict} \\circ \\mathrm{ext} = \\mathrm{id}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Riesz representation theorem",
+      "Lp spaces",
+      "complemented subspace",
+      "retraction / split monomorphism"
+    ],
+    "prerequisites": [
+      "functional analysis",
+      "Lp spaces",
+      "measure restriction"
+    ]
+  },
+  {
+    "id": "ann-lprestrict-memlp-indicator",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 56, "endLine": 64 },
+    "type": "lemma",
+    "title": "MemLp of the indicator from the sub-measure",
+    "content": "memLp_indicator_of_restrict shows that if f ∈ Lp(μ.restrict S) then S.indicator f ∈ Lp(μ). Strong measurability transfers through aestronglyMeasurable_indicator_iff, and the eLpNorm side is closed instantly by Mathlib's eLpNorm_indicator_eq_eLpNorm_restrict, which states eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S) — the eLpNorm is preserved exactly, not merely bounded.",
+    "mathContext": "$\\lVert \\mathbf 1_S f\\rVert_{L^p(\\mu)} = \\lVert f\\rVert_{L^p(\\mu\\restriction S)}$: the indicator↔restriction correspondence is an isometry of seminorms.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "indicator function",
+      "eLpNorm",
+      "measure restriction"
+    ],
+    "prerequisites": [
+      "MemLp",
+      "measurable indicator"
+    ]
+  },
+  {
+    "id": "ann-lprestrict-extbyzero",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 65, "endLine": 116 },
+    "type": "definition",
+    "title": "Extension-by-zero as an isometric CLM (self-contained)",
+    "content": "extByZeroCLM packages g ↦ [S.indicator g] into a continuous linear map Lp(μ.restrict S) →L[ℝ] Lp(μ) via LinearMap.mkContinuous. Linearity is proved classwise: on the concentration set S the indicator is transparent, off S both sides vanish, so map_add' and map_smul' reduce to a by_cases on a ∈ S. The exact eLpNorm preservation makes the map an isometry (bound constant 1). extByZeroCLM_coeFn records ⇑(extByZeroCLM hS g) =ᵐ[μ] S.indicator ⇑g. It is restated here (rather than imported from the parent) so verification depends on Mathlib alone.",
+    "mathContext": "$T_S : L^p(\\mu\\restriction S)\\to L^p(\\mu)$, $T_S g = \\mathbf 1_S g$, is a linear isometry.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "continuous linear map",
+      "isometric embedding",
+      "LinearMap.mkContinuous"
+    ],
+    "prerequisites": [
+      "Lp spaces",
+      "continuous linear maps",
+      "indicator function"
+    ]
+  },
+  {
+    "id": "ann-lprestrict-restrictmap",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 122, "endLine": 159 },
+    "type": "definition",
+    "title": "The restriction map restrictToLpCLM (the parent's missing companion)",
+    "content": "restrictToLpCLM S sends the class of f ∈ Lp(μ) to the class of the same underlying function under the smaller measure μ.restrict S ≤ μ. This is exactly the map the parent's oq-01 identified but never built. Well-definedness and linearity use MemLp.restrict and ae_restrict_of_ae — μ-a.e. equalities descend to μ.restrict S-a.e.. Crucially it needs no measurability hypothesis on S, since μ.restrict S ≤ μ holds for every set. The norm bound is supplied by eLpNorm_restrict_le, giving the bound constant 1.",
+    "mathContext": "$R_S : L^p(\\mu)\\to L^p(\\mu\\restriction S)$, $R_S[f] = [f]$; $\\lVert R_S[f]\\rVert = \\lVert f\\rVert_{L^p(\\mu\\restriction S)} \\le \\lVert f\\rVert_{L^p(\\mu)}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "restriction map",
+      "measure monotonicity",
+      "norm-nonincreasing operator"
+    ],
+    "prerequisites": [
+      "MemLp.restrict",
+      "eLpNorm monotonicity",
+      "ae_restrict_of_ae"
+    ]
+  },
+  {
+    "id": "ann-lprestrict-norm",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 160, "endLine": 182 },
+    "type": "lemma",
+    "title": "Underlying function and operator norm of the restriction map",
+    "content": "restrictToLpCLM_coeFn characterizes ⇑(restrictToLpCLM S f) =ᵐ[μ.restrict S] ⇑f. restrictToLpCLM_norm_apply_le gives ‖restrictToLpCLM S f‖ ≤ ‖f‖ (via ENNReal.toReal_mono and eLpNorm_restrict_le), and restrictToLpCLM_opNorm_le_one lifts this to the operator norm ‖restrictToLpCLM S‖ ≤ 1 through ContinuousLinearMap.opNorm_le_bound. Combined with the isometry extByZeroCLM, the norm-1 bound is what makes the pair a 1-complementation.",
+    "mathContext": "$\\lVert R_S\\rVert_{\\mathrm{op}} \\le 1$, while $T_S$ is a norm-1 isometry.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "operator norm",
+      "1-complemented subspace"
+    ],
+    "prerequisites": [
+      "operator norm",
+      "eLpNorm monotonicity"
+    ]
+  },
+  {
+    "id": "ann-lprestrict-retraction",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 187, "endLine": 217 },
+    "type": "theorem",
+    "title": "The retraction identity: restriction ∘ extension = id",
+    "content": "restrictToLpCLM_extByZeroCLM proves restrictToLpCLM S (extByZeroCLM hS g) = g. The proof reduces (Lp.ext_iff) to a pointwise a.e. statement: ⇑(restrict (ext g)) =ᵐ[μ.restrict S] S.indicator ⇑g, and since μ.restrict S is concentrated on S (ae_restrict_mem), the indicator equals ⇑g almost everywhere. restrictToLpCLM_comp_extByZeroCLM restates this at the operator level as comp = ContinuousLinearMap.id, and extByZeroCLM_injective follows immediately: a map with a left inverse is injective (a split monomorphism). This is the key result answering the parent's oq-01.",
+    "mathContext": "$R_S \\circ T_S = \\mathrm{id}_{L^p(\\mu\\restriction S)}$, so $T_S$ is a split isometric embedding and $L^p(\\mu\\restriction S)$ is 1-complemented in $L^p(\\mu)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "retraction",
+      "split monomorphism",
+      "injectivity",
+      "complemented subspace"
+    ],
+    "prerequisites": [
+      "ae_restrict_mem",
+      "Lp extensionality",
+      "continuous linear map composition"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+  "title": "The Lp Restriction Map and the Splitting of Extension-by-Zero",
+  "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01",
+  "description": "Constructs the restriction map restrictToLpCLM : Lp(μ) →L[ℝ] Lp(μ.restrict S) — the companion the parent's open question oq-01 identified but never built — and proves it is an explicit norm-1 left inverse of extension-by-zero. The retraction identity restrictToLpCLM ∘ extByZeroCLM = id exhibits Lp(μ.restrict S) as an isometrically embedded, 1-complemented subspace of Lp(μ). Fully machine-checked, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "namespace": null,
+    "lineCount": 218,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01OQ01.lean",
+    "tags": [
+      "functional-analysis",
+      "lp-spaces",
+      "riesz-representation",
+      "sigma-finite",
+      "measure-theory",
+      "continuous-linear-map",
+      "retraction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 218,
+    "buildStatus": "verified",
+    "assumptions": "None. The file imports only Mathlib and is self-contained: it restates extension-by-zero (extByZeroCLM) so that verification does not transitively depend on the drift-broken parent chain. `#print axioms` for every theorem reports only [propext, Classical.choice, Quot.sound] — the standard classical foundations that do not count as assumptions. 0 literal `axiom` declarations, 0 `sorry`, 0 `native_decide`. Verified against leanprover/lean4:v4.26.0 via `lake env lean`.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 2,
+    "theoremCount": 8,
+    "originalContributions": [
+      "restrictToLpCLM: the restriction map Lp(μ) →L[ℝ] Lp(μ.restrict S), built as a norm-nonincreasing continuous linear map. This is the companion map that the parent's open question oq-01 identified as a Mathlib infrastructure gap but never constructed.",
+      "restrictToLpCLM_extByZeroCLM: the retraction identity restrictToLpCLM S (extByZeroCLM hS g) = g, proving restrictToLpCLM is an explicit left inverse of extension-by-zero.",
+      "restrictToLpCLM_comp_extByZeroCLM: the composed continuous linear map equals ContinuousLinearMap.id, the operator-level form of the retraction.",
+      "extByZeroCLM_injective: injectivity of extension-by-zero as an immediate corollary of the retraction.",
+      "restrictToLpCLM_opNorm_le_one: the restriction map has operator norm ≤ 1, so together with the isometry extByZeroCLM the pair exhibits Lp(μ.restrict S) as a 1-complemented subspace of Lp(μ)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Riesz representation theorem for (Lᵖ)* ≅ Lq (Rudin, Real and Complex Analysis, Thm 6.16; Folland, Real Analysis §6.2) extends from finite to σ-finite measures by a localization argument: a bounded functional φ on Lᵖ(μ) is analyzed on each set S of a σ-finite spanning cover, where the finite-measure theorem applies, and the local representers are glued into a global one. Two dual continuous linear maps mediate this localization: extension-by-zero, which lifts Lᵖ(μ.restrict S) into Lᵖ(μ) by the indicator, and its retraction, restriction, which pulls a class in Lᵖ(μ) back to the sub-measure. The parent development completed the σ-finite Riesz theorem using only extension-by-zero; its open question oq-01 asked whether the restriction map — the natural but unbuilt companion — could serve the same role. This entry answers that question constructively.",
+    "problemStatement": "Construct the restriction map restrictToLpCLM : Lp(μ) →L[ℝ] Lp(μ.restrict S) as a continuous linear map, and prove it is a genuine left inverse (retraction) of the extension-by-zero embedding extByZeroCLM : Lp(μ.restrict S) →L[ℝ] Lp(μ), thereby exhibiting the local Lᵖ space as a complemented subspace of the global one.",
+    "proofStrategy": "The restriction map sends the class of f ∈ Lᵖ(μ) to the class of the same underlying function under the smaller measure μ.restrict S ≤ μ. Well-definedness and boundedness come from three Mathlib facts: MemLp.restrict (membership is preserved under passing to a sub-measure), eLpNorm_restrict_le (the eLpNorm is nonincreasing, giving operator norm ≤ 1), and ae_restrict_of_ae (μ-a.e. equalities descend to μ.restrict S-a.e., making the linear-map axioms provable classwise). The retraction identity is proved pointwise: ⇑(restrict (ext g)) =ᵐ[μ.restrict S] S.indicator ⇑g, and since μ.restrict S is concentrated on S (ae_restrict_mem), the indicator equals ⇑g almost everywhere, so the composite returns the original class. The extension-by-zero map is restated self-containedly from the eLpNorm-preservation lemma eLpNorm_indicator_eq_eLpNorm_restrict, so the whole file verifies against Mathlib alone.",
+    "keyInsights": [
+      "The restriction map needs no measurability hypothesis on S: μ.restrict S ≤ μ holds for every set, so MemLp and eLpNorm monotonicity apply unconditionally. Measurability of S enters only in the retraction, where the indicator's support must coincide with the concentration set of μ.restrict S.",
+      "eLpNorm is literally preserved by the indicator↔restriction correspondence (eLpNorm (S.indicator f) μ = eLpNorm f (μ.restrict S)), so extension-by-zero is an isometry while restriction is only norm-nonincreasing — the asymmetry that makes the composite a retraction rather than an isomorphism.",
+      "The retraction restrictToLpCLM ∘ extByZeroCLM = id means Lᵖ(μ.restrict S) sits inside Lᵖ(μ) as a 1-complemented subspace: an isometric copy that admits a norm-1 projection back onto it. This is the abstract shape underlying the σ-finite localization argument.",
+      "Injectivity of extension-by-zero is immediate once a left inverse is exhibited — a split monomorphism — avoiding any direct kernel computation on Lᵖ classes."
+    ]
+  },
+  "sections": [
+    {
+      "title": "Overview and Statement",
+      "content": "Two dual continuous linear maps relate the local Lᵖ space Lp(μ.restrict S) and the global Lp(μ): extension-by-zero (by the indicator of S) and restriction (to the sub-measure). This file builds the restriction map and proves it retracts extension-by-zero."
+    },
+    {
+      "title": "§1. Extension-by-Zero (self-contained)",
+      "content": "memLp_indicator_of_restrict lifts MemLp f p (μ.restrict S) to MemLp (S.indicator f) p μ using Mathlib's eLpNorm_indicator_eq_eLpNorm_restrict, which preserves the eLpNorm exactly. extByZeroCLM packages this into an isometric continuous linear map Lp(μ.restrict S) →L[ℝ] Lp(μ), and extByZeroCLM_coeFn records that its underlying function is S.indicator ⇑g almost everywhere."
+    },
+    {
+      "title": "§2. The Restriction Map",
+      "content": "restrictToLpCLM S sends the class of f to the class of the same function under μ.restrict S. Linearity is proved classwise via ae_restrict_of_ae; the norm bound ‖restrictToLpCLM S f‖ ≤ ‖f‖ follows from eLpNorm_restrict_le, giving operator norm ≤ 1 (restrictToLpCLM_opNorm_le_one). restrictToLpCLM_coeFn characterizes the underlying function."
+    },
+    {
+      "title": "§3. The Retraction",
+      "content": "restrictToLpCLM_extByZeroCLM proves restrictToLpCLM S (extByZeroCLM hS g) = g: restricting the extension recovers the original class, because μ.restrict S is concentrated on S (ae_restrict_mem) where the indicator equals ⇑g. restrictToLpCLM_comp_extByZeroCLM states the operator-level identity comp = id, and extByZeroCLM_injective is the immediate split-mono corollary."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Is the composite the other way, extByZeroCLM ∘ restrictToLpCLM, equal to multiplication by the indicator of S (the conditional-expectation-style projection onto functions supported in S), and is it idempotent?",
+      "difficulty": "medium",
+      "prerequisite": "A multiplication-by-indicator continuous linear map on Lp(μ)."
+    },
+    {
+      "id": "oq-02",
+      "question": "Does the restriction map generalize to a continuous linear map Lp(μ) →L[ℝ] Lp(ν) for any ν ≤ μ (not just ν = μ.restrict S), with the same norm-nonincreasing bound, and is it functorial in ν?",
+      "difficulty": "medium",
+      "prerequisite": "The absolute-continuity / measure-monotonicity API for MemLp and eLpNorm."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's open question oq-01 by constructing the restriction map restrictToLpCLM : Lp(μ) →L[ℝ] Lp(μ.restrict S) and proving it is an explicit norm-1 left inverse of extension-by-zero. The retraction identity restrictToLpCLM ∘ extByZeroCLM = id (as classes and as continuous linear maps) exhibits Lp(μ.restrict S) as an isometrically embedded, 1-complemented subspace of Lp(μ), and yields injectivity of extension-by-zero as a corollary. The file is self-contained (imports only Mathlib), fully machine-checked with 0 axioms and 0 sorries against Lean 4 / Mathlib v4.26.0.",
+    "significance": "Completes the dual pair of localization maps underlying the σ-finite Lᵖ Riesz representation theorem: extension-by-zero was enough to prove the parent theorem, but the restriction map is the conceptually natural companion, and making it a genuine retraction is what justifies calling the local Lᵖ space a complemented subspace of the global one."
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
+      "relationship": "parent",
+      "description": "Direct parent — `Lp Riesz Representation for Sigma-Finite Measures (Complete)`. Its open question oq-01 asked whether the Lp restriction map could serve as the localization device; this entry constructs that map and proves it retracts the parent's extByZeroCLM."
+    }
+  ],
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "Walter Rudin"
+      ],
+      "title": "Real and Complex Analysis",
+      "year": 1987,
+      "venue": "McGraw-Hill (3rd ed.)",
+      "note": "Riesz representation of (L^p)* ≅ L^q and the σ-finite localization argument (Theorem 6.16)."
+    },
+    {
+      "authors": [
+        "Gerald B. Folland"
+      ],
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "year": 1999,
+      "venue": "Wiley (2nd ed.)",
+      "note": "L^p duality and σ-finite measure theory, §6.2."
+    }
+  ]
+}

--- a/src/data/proofs/fundamental-theorem-algebra-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 3, "endLine": 64 },
+    "type": "concept",
+    "title": "The Question: Is Analysis Inherently Required?",
+    "content": "The parent entry records the folklore claim that the Fundamental Theorem of Algebra (FTA) has *no purely algebraic proof*. This file makes that precise.\n\nA proof using only the **field axioms** is impossible, because the FTA is false for other fields ($\\mathbb{Q}$, finite fields, …). Any proof must consume a property of $\\mathbb{R}$ beyond \"being a field.\" The Artin–Schreier theory shows the non-algebraic content reduces to exactly **two** facts:\n\n- **(A)** every odd-degree real polynomial has a real root (Intermediate Value Theorem);\n- **(B)** every complex number has a square root.\n\nGiven (A) and (B), that $\\mathbb{R}[i]$ is algebraically closed is *pure algebra* (Sylow + Galois theory).",
+    "mathContext": "FTA $\\iff$ $\\mathbb{R}$ is a real-closed field $\\iff$ (A) $\\wedge$ (B) hold.",
+    "significance": "key",
+    "prerequisites": ["algebraic closure", "field axioms", "real-closed fields"],
+    "relatedConcepts": ["Artin–Schreier theorem", "real-closed field", "algebraic closure"]
+  },
+  {
+    "id": "ann-root-of-odd-pos",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 70, "endLine": 107 },
+    "type": "proof-technique",
+    "title": "Sign Change at Infinity (positive leading coefficient)",
+    "content": "The helper proves the positive-leading-coefficient case. A degree-$n$ polynomial with $\\operatorname{lc}(p) > 0$ satisfies $p(x) \\to +\\infty$ as $x \\to +\\infty$ (`tendsto_atTop_of_leadingCoeff_nonneg`).\n\nTo get the opposite behaviour at $-\\infty$, we reflect through $X \\mapsto -X$. The polynomial $p(-X)$ has leading coefficient $\\operatorname{lc}(p)\\cdot(-1)^{\\deg p}$, and since $\\deg p$ is **odd**, $(-1)^{\\deg p} = -1$, making it negative. Hence $p(-y) \\to -\\infty$ as $y \\to +\\infty$; composing with negation gives $p(x) \\to -\\infty$ as $x \\to -\\infty$.",
+    "mathContext": "$\\operatorname{lc}(p(-X)) = \\operatorname{lc}(p)\\,(-1)^{\\deg p} = -\\operatorname{lc}(p) < 0$ when $\\deg p$ is odd.",
+    "significance": "high",
+    "prerequisites": ["leading coefficient", "polynomial composition", "limits at infinity"],
+    "relatedConcepts": ["odd parity", "leadingCoeff_comp", "tendsto atBot"]
+  },
+  {
+    "id": "ann-odd-degree-root",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 108, "endLine": 121 },
+    "type": "key-insight",
+    "title": "Ingredient (A): Odd-Degree Real Polynomials Have a Root",
+    "content": "This is the irreducible **Intermediate Value Theorem** input to the FTA. Because $p$ is continuous and tends to $+\\infty$ at $+\\infty$ and $-\\infty$ at $-\\infty$, `Continuous.surjective` makes the evaluation map $x \\mapsto p(x)$ surjective onto $\\mathbb{R}$ — in particular it attains the value $0$.\n\nThe general case reduces to the positive-leading-coefficient helper: if $\\operatorname{lc}(p) < 0$ apply it to $-p$ (same roots); $\\operatorname{lc}(p) = 0$ is impossible since odd degree forces $\\deg p \\geq 1$.\n\nThis fact is exactly what the older \"algebraic\" proofs of Euler, Lagrange, and Gauss's fourth proof silently assumed — it rests on the order-completeness of $\\mathbb{R}$, not on algebra.",
+    "mathContext": "Continuous $f:\\mathbb{R}\\to\\mathbb{R}$ with $f\\to+\\infty$ at $+\\infty$ and $f\\to-\\infty$ at $-\\infty$ is surjective, so $\\exists x,\\ p(x)=0$.",
+    "significance": "key",
+    "prerequisites": ["Intermediate Value Theorem", "continuity", "Continuous.surjective"],
+    "relatedConcepts": ["order completeness", "IVT", "odd degree"]
+  },
+  {
+    "id": "ann-complex-sqrt",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 123, "endLine": 140 },
+    "type": "key-insight",
+    "title": "Ingredient (B): Complex Numbers Have Square Roots",
+    "content": "The second analytic ingredient, proved via the **polar form** $w = \\sqrt{\\lVert z\\rVert}\\, e^{i\\,\\arg z / 2}$. Squaring: $w^2 = (\\sqrt{\\lVert z\\rVert})^2 \\cdot (e^{i\\,\\arg z/2})^2 = \\lVert z\\rVert\\, e^{i\\,\\arg z} = z$, using `Real.sq_sqrt`, `Complex.exp_add`, and `Complex.norm_mul_exp_arg_mul_I`.\n\n**Non-circularity is essential:** the proof uses only the *real* square-root function, never the algebraic closure of $\\mathbb{C}$. Proving \"every $z$ has a square root\" by appealing to the FTA would be circular, since that closure is the very thing under analysis.",
+    "mathContext": "$w = \\sqrt{\\lVert z\\rVert}\\,e^{i\\arg z/2} \\Rightarrow w^2 = \\lVert z\\rVert\\,e^{i\\arg z} = z.$",
+    "significance": "key",
+    "prerequisites": ["complex polar form", "real square root", "complex exponential"],
+    "relatedConcepts": ["arg", "polar form", "non-circular reduction"]
+  },
+  {
+    "id": "ann-obstruction",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 142, "endLine": 164 },
+    "type": "key-insight",
+    "title": "The Algebraic Obstruction: These Facts Are Not Field-Theoretic",
+    "content": "Two counterexamples show the analytic facts genuinely go beyond the field axioms:\n\n- `real_not_alg_closed`: $x^2 + 1 \\geq 1 > 0$ for all real $x$, so $\\mathbb{R}$ is **not** algebraically closed even though it satisfies the IVT. This is precisely why the imaginary unit $i$ (ingredient B) must be adjoined.\n- `cubic_no_root_zmod2`: the odd-degree cubic $X^3 + X + 1$ has **no root** in the finite field $\\mathbb{F}_2 = \\texttt{ZMod 2}$ — checked by kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool`). Thus \"odd degree $\\Rightarrow$ root\" is a special analytic property of $\\mathbb{R}$, not a theorem of field theory.\n\nTogether these confirm: no proof of the FTA can rely on field axioms alone.",
+    "mathContext": "Over $\\mathbb{F}_2$: $0^3+0+1 = 1 \\neq 0$ and $1^3+1+1 = 1 \\neq 0$. Over $\\mathbb{R}$: $x^2+1 \\geq 1$.",
+    "significance": "high",
+    "prerequisites": ["finite fields", "decidability", "algebraic closure"],
+    "relatedConcepts": ["𝔽₂", "counterexample", "field axioms"]
+  },
+  {
+    "id": "ann-fta-complex",
+    "proofId": "fundamental-theorem-algebra-oq-01",
+    "range": { "startLine": 166, "endLine": 175 },
+    "type": "concept",
+    "title": "The Conclusion the Reduction Targets",
+    "content": "The FTA itself, supplied by Mathlib's `Complex.exists_root` (proved via Liouville's theorem). Given ingredients (A) and (B), the Artin–Schreier argument derives this conclusion by pure algebra; Mathlib instead derives it directly from complex analysis. Either route uses analysis — which is the answer to the open question.",
+    "mathContext": "$\\forall p \\in \\mathbb{C}[X],\\ 0 < \\deg p \\Rightarrow \\exists z,\\ p(z) = 0.$",
+    "significance": "medium",
+    "prerequisites": ["Liouville's theorem", "algebraic closure of ℂ"],
+    "relatedConcepts": ["Complex.exists_root", "IsAlgClosed"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "fundamental-theorem-algebra-oq-01",
+  "title": "Is Analysis Inherently Required for the Fundamental Theorem of Algebra?",
+  "slug": "fundamental-theorem-algebra-oq-01",
+  "description": "Answers the open question posed by the Fundamental Theorem of Algebra entry — whether a purely algebraic proof is possible, or analysis is inherently required. The answer is definitive: analysis is unavoidable, but its role reduces to exactly two order/analytic facts about $\\mathbb{R}$. This entry formalizes both irreducible ingredients — (A) every odd-degree real polynomial has a real root (via the Intermediate Value Theorem), and (B) every complex number has a square root (via polar form, non-circular) — together with the algebraic obstruction showing that neither property follows from the field axioms alone ($X^2+1$ has no root in $\\mathbb{R}$; the cubic $X^3+X+1$ has no root in $\\mathbb{F}_2$). It then connects these ingredients to Mathlib's proof that $\\mathbb{C}$ is algebraically closed.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-9)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra#Algebraic_proofs",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "complex-analysis",
+      "polynomials",
+      "algebraic-closure",
+      "intermediate-value-theorem",
+      "open-question",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg",
+        "description": "A positive-leading-coefficient polynomial of positive degree tends to +∞ at +∞",
+        "module": "Mathlib.Analysis.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.tendsto_atBot_of_leadingCoeff_nonpos",
+        "description": "A nonpositive-leading-coefficient polynomial of positive degree tends to -∞ at +∞",
+        "module": "Mathlib.Analysis.Polynomial.Basic"
+      },
+      {
+        "theorem": "Continuous.surjective",
+        "description": "A continuous real function tending to +∞ at +∞ and -∞ at -∞ is surjective",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "Complex.norm_mul_exp_arg_mul_I",
+        "description": "Polar form: ‖z‖ · exp(arg z · i) = z",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
+      },
+      {
+        "theorem": "Complex.exists_root",
+        "description": "Every non-constant complex polynomial has a root (the FTA, via Liouville)",
+        "module": "Mathlib.Analysis.Complex.Polynomial.Basic"
+      }
+    ],
+    "originalContributions": [
+      "odd_degree_real_root - every odd-degree real polynomial has a real root, proved analytically via Continuous.surjective (the irreducible IVT / order-completeness input to the FTA)",
+      "complex_has_sqrt - every complex number has a square root via the polar form w = √‖z‖·exp(i·arg z/2), proved WITHOUT invoking the FTA (non-circular second analytic ingredient)",
+      "real_not_alg_closed - ℝ is not algebraically closed (X²+1 has no real root), showing closure fails even with the IVT",
+      "cubic_no_root_zmod2 - the odd-degree cubic X³+X+1 has no root in 𝔽₂, showing the 'odd-degree ⇒ root' property is not a field-theoretic consequence",
+      "fta_complex - the conclusion the Artin–Schreier reduction targets, supplied by Mathlib's Complex.exists_root"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 176,
+    "prerequisites": [
+      "Intermediate Value Theorem and continuity of polynomial functions",
+      "Asymptotic behaviour of polynomials at ±∞ (leading-coefficient sign)",
+      "Complex polar form and the real square-root function",
+      "Algebraic closure and the field axioms",
+      "Artin–Schreier / Galois-theoretic proof of the FTA (context)"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. `#print axioms` reports only the standard foundational axioms (propext, Classical.choice, Quot.sound); `native_decide` is NOT used (the finite-field obstruction is discharged by kernel `decide`, so no `Lean.ofReduceBool`). The concluding restatement `fta_complex` delegates to Mathlib's `Complex.exists_root`.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "substantiveTheoremCount": 4,
+    "trivialSpecializations": 1
+  },
+  "overview": {
+    "historicalContext": "The name \"Fundamental Theorem of Algebra\" is a historical misnomer: although the statement is about polynomials, every rigorous proof consumes some non-algebraic property of the real numbers. This was recognized early. Euler (1749), Lagrange (1772) and Laplace (1795) all sought algebraic proofs, and Gauss's fourth proof (1849) is frequently described as \"purely algebraic\" — but each of these arguments quietly assumes that every odd-degree real polynomial has a real root, a fact that rests on the Intermediate Value Theorem and hence on the order-completeness of $\\mathbb{R}$.\n\nThe question of exactly how much analysis is needed was settled by the algebraic theory of formally real and real-closed fields developed by Emil Artin and Otto Schreier in the 1920s. Their analysis shows that the FTA is equivalent to $\\mathbb{R}$ being a *real-closed field*, and that the only genuinely non-algebraic inputs required are the two order/analytic facts formalized in this entry. Everything else — that $\\mathbb{R}[i]$ is then algebraically closed — is a consequence of the Sylow theorems and Galois theory, i.e. pure algebra.\n\nSo the modern verdict is unambiguous: a proof from the field axioms alone is impossible (the FTA is false for $\\mathbb{Q}$, for finite fields, and for many other fields), but the analytic content is not diffuse — it condenses into precisely two facts about $\\mathbb{R}$.",
+    "problemStatement": "The Fundamental Theorem of Algebra entry records the folklore claim that \"every known proof requires analysis — there is no purely algebraic proof,\" and asks: **Can a purely algebraic proof of the FTA ever be found, or is analysis inherently required?**\n\nThis entry answers the question by isolating the exact analytic content. It proves the two order/analytic facts about $\\mathbb{R}$ that the Artin–Schreier reduction consumes, exhibits the algebraic obstruction that makes them genuinely non-algebraic, and connects them to Mathlib's proof that $\\mathbb{C}$ is algebraically closed.",
+    "text": "A 176-line, 7-theorem, 0-axiom formalization answering whether the FTA requires analysis. The answer: yes, but the analytic content reduces to exactly two facts. **Ingredient (A)** `odd_degree_real_root`: every odd-degree real polynomial has a real root. Proved analytically — the polynomial function is continuous and, having odd degree, tends to $+\\infty$ at one end and $-\\infty$ at the other (obtained by reflecting through $X \\mapsto -X$ and reading off the sign of the leading coefficient), so `Continuous.surjective` forces a zero. This is the irreducible Intermediate-Value-Theorem input. **Ingredient (B)** `complex_has_sqrt`: every complex number has a square root, built from the *real* square root via the polar form $w = \\sqrt{\\lVert z\\rVert}\\,e^{i\\,\\arg z/2}$; crucially this uses only $\\texttt{Real.sqrt}$, not the FTA, so it is a genuinely independent analytic ingredient. **The obstruction** `real_not_alg_closed` and `cubic_no_root_zmod2`: neither \"is algebraically closed\" nor \"odd-degree polynomials have roots\" is a field-theoretic consequence — $X^2+1$ has no root in $\\mathbb{R}$, and the odd-degree cubic $X^3+X+1$ has no root in the field $\\mathbb{F}_2 = \\texttt{ZMod 2}$ (discharged by kernel `decide`, not `native_decide`). Finally `fta_complex` supplies the conclusion of the reduction from Mathlib's `Complex.exists_root`.",
+    "proofStrategy": "The entry does not re-prove the full Artin–Schreier reduction (that $\\mathbb{R}[i]$ is algebraically closed given ingredients A and B — a deep Sylow/Galois argument); it formalizes the two analytic ingredients that reduction consumes, plus the obstruction, and cites the reduction as the algebraic bridge.\n\n**Ingredient (A) — odd-degree real root (via IVT):**\n1. Reduce to positive leading coefficient (negate $p$ if necessary; the zero case is impossible since odd degree $\\geq 1$).\n2. The evaluation map $x \\mapsto p(x)$ is continuous (`Polynomial.continuous`).\n3. With positive leading coefficient and positive degree, $p(x) \\to +\\infty$ as $x \\to +\\infty$ (`tendsto_atTop_of_leadingCoeff_nonneg`).\n4. Reflecting through $X \\mapsto -X$: the polynomial $p(-X)$ has leading coefficient $-\\operatorname{lc}(p) < 0$ (using $\\operatorname{lc}(-X)^{\\deg p} = (-1)^{\\text{odd}} = -1$), so $p(-y) \\to -\\infty$ as $y \\to +\\infty$; composing with negation gives $p(x) \\to -\\infty$ as $x \\to -\\infty$.\n5. `Continuous.surjective` (continuous, $+\\infty$ at $+\\infty$, $-\\infty$ at $-\\infty$) makes $p$ surjective, so $0$ is attained: $p$ has a root.\n\n**Ingredient (B) — complex square root (polar form):**\nSet $w = \\sqrt{\\lVert z\\rVert}\\cdot e^{i\\,\\arg z/2}$. Then $w^2 = \\lVert z\\rVert \\cdot e^{i\\,\\arg z}$ using $(\\sqrt{\\lVert z\\rVert})^2 = \\lVert z\\rVert$ (`Real.sq_sqrt`) and $(e^{t})^2 = e^{2t}$ (`Complex.exp_add`), which equals $z$ by `Complex.norm_mul_exp_arg_mul_I`. No appeal to algebraic closure.\n\n**Obstruction:** $x^2 + 1 \\geq 1 > 0$ over $\\mathbb{R}$ (`positivity`); over $\\mathbb{F}_2$ the finitely many values of $x^3 + x + 1$ are checked by `decide`.",
+    "keyInsights": [
+      "**Analysis is inherently required — no proof from the field axioms alone exists.** The FTA is a statement about the specific field $\\mathbb{R}$ (equivalently $\\mathbb{C} = \\mathbb{R}[i]$) and is simply false for $\\mathbb{Q}$, finite fields, and many others. Any proof must therefore consume a property of $\\mathbb{R}$ beyond \"being a field.\"",
+      "**The analytic content condenses to exactly two facts.** The Artin–Schreier / Galois-theoretic proof shows that, given (A) odd-degree real polynomials have roots and (B) complex numbers have square roots, the algebraic closure of $\\mathbb{R}[i]$ follows by *pure algebra* (Sylow theorems + Galois theory). Analysis is unavoidable but not diffuse.",
+      "**Ingredient (A) is the Intermediate Value Theorem in disguise.** An odd-degree real polynomial changes sign between $-\\infty$ and $+\\infty$; continuity plus order-completeness of $\\mathbb{R}$ (the IVT) forces a root. This is the single deepest analytic input, and it is exactly what the older \"algebraic\" proofs silently assumed.",
+      "**Ingredient (B) is genuinely independent of the FTA.** Building the complex square root from $\\texttt{Real.sqrt}$ via polar form avoids circularity: one must not prove \"every $z$ has a square root\" by invoking algebraic closure, since that closure is the very thing under analysis.",
+      "**The obstruction shows the facts are non-algebraic.** $\\mathbb{R}$ satisfies the IVT yet is still not algebraically closed ($X^2+1$ has no real root — this is why $i$ must be adjoined), and the odd-degree cubic $X^3+X+1$ has no root in $\\mathbb{F}_2$ — so \"odd degree $\\Rightarrow$ root\" is a special analytic property of $\\mathbb{R}$, not a theorem of field theory."
+    ],
+    "prerequisites": [
+      "Intermediate Value Theorem and continuity of polynomials",
+      "Behaviour of polynomials at $\\pm\\infty$",
+      "Complex polar form and the real square root",
+      "Algebraic closure, real-closed fields, and the Artin–Schreier theorem"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "answers",
+      "description": "Answers the open question posed by the parent FTA entry: whether a purely algebraic proof exists. The answer is no — analysis is required — but its content reduces to two explicit facts."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04",
+      "relationship": "complementary",
+      "description": "That entry shows $\\mathbb{C}$ is the unique algebraic closure of $\\mathbb{R}$ with $[\\mathbb{C}:\\mathbb{R}]=2$; this entry explains why a single quadratic extension suffices and why the analytic facts about $\\mathbb{R}$ are needed to get there."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Artin, Emil; Schreier, Otto",
+      "title": "Algebraische Konstruktion reeller Körper",
+      "year": "1926",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 5",
+      "note": "Theory of formally real and real-closed fields; isolates the exact non-algebraic content of the FTA"
+    },
+    {
+      "authors": "Fine, Benjamin; Rosenberger, Gerhard",
+      "title": "The Fundamental Theorem of Algebra",
+      "year": "1997",
+      "venue": "Springer Undergraduate Texts in Mathematics",
+      "note": "Collects algebraic, analytic, and topological proofs; discusses the minimal analytic hypotheses"
+    },
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Beiträge zur Theorie der algebraischen Gleichungen",
+      "year": "1849",
+      "venue": "Abhandlungen der Königlichen Gesellschaft der Wissenschaften zu Göttingen",
+      "note": "Gauss's fourth proof, often called 'purely algebraic' — but it assumes odd-degree real polynomials have roots (ingredient A)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "FundamentalTheoremAlgebraOQ01",
+    "lineCount": 176,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "substantiveTheoremCount": 4,
+    "trivialSpecializations": 1,
+    "mainTheorems": [
+      {
+        "name": "odd_degree_real_root",
+        "type": "original",
+        "description": "Every real polynomial of odd degree has a real root — the irreducible IVT / order-completeness input to the FTA",
+        "leanType": "(p : ℝ[X]) → Odd p.natDegree → ∃ x : ℝ, p.IsRoot x"
+      },
+      {
+        "name": "complex_has_sqrt",
+        "type": "original",
+        "description": "Every complex number has a square root, built from the real square root via polar form (non-circular)",
+        "leanType": "(z : ℂ) → ∃ w : ℂ, w ^ 2 = z"
+      },
+      {
+        "name": "cubic_no_root_zmod2",
+        "type": "original",
+        "description": "The odd-degree cubic X³+X+1 has no root in 𝔽₂ — the 'odd degree ⇒ root' property is not field-theoretic",
+        "leanType": "∀ x : ZMod 2, x ^ 3 + x + 1 ≠ 0"
+      },
+      {
+        "name": "fta_complex",
+        "type": "wrapper",
+        "description": "The FTA itself (Mathlib's Complex.exists_root) — the conclusion the algebraic reduction targets",
+        "leanType": "(p : ℂ[X]) → 0 < p.degree → ∃ z : ℂ, p.IsRoot z"
+      }
+    ]
+  },
+  "sorries": [],
+  "additionalFiles": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01** answering the parent's open question **oq-01**.

The parent (`…incomplete-01`, *Lp Riesz Representation for Sigma-Finite Measures*) completed the σ-finite Riesz theorem using **extension-by-zero** `extByZeroCLM : Lp(μ.restrict S) →L[ℝ] Lp(μ)`. Its oq-01 asked whether the dual **restriction** map `Lp(μ) → Lp(μ.restrict S)` — identified as a Mathlib infrastructure gap — could serve the same role. This entry constructs it and proves it retracts extension-by-zero.

## Results (all machine-checked)

- `restrictToLpCLM : Lp(μ) →L[ℝ] Lp(μ.restrict S)` — the restriction map, a norm-nonincreasing CLM (needs no measurability of `S`).
- `restrictToLpCLM_opNorm_le_one` — operator norm ≤ 1.
- `restrictToLpCLM_extByZeroCLM` — **retraction identity** `restrictToLpCLM S (extByZeroCLM hS g) = g`.
- `restrictToLpCLM_comp_extByZeroCLM` — operator form `comp = ContinuousLinearMap.id`.
- `extByZeroCLM_injective` — split-monomorphism corollary.

Together, the isometry `extByZeroCLM` and the norm-1 retraction `restrictToLpCLM` exhibit `Lp(μ.restrict S)` as a **1-complemented** subspace of `Lp(μ)`.

## Verification

- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01OQ01.lean` — 218 lines, 8 theorems, 2 defs.
- **0 sorries, 0 axioms.** `#print axioms` on every theorem reports only `[propext, Classical.choice, Quot.sound]`.
- Self-contained: imports **only Mathlib** (restates `extByZeroCLM` via Mathlib's `eLpNorm_indicator_eq_eLpNorm_restrict`), so verification does not depend on the drift-broken parent chain. Built with `lake env lean` against Lean 4 / Mathlib v4.26.0.

## Gallery

- `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/{meta.json,annotations.json}` (status `verified`, badge `original`, 6 annotations, cross-referenced to parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)