### PR TITLE
Enrich Chebyshev/Dickson composition entry: add sibling cross-reference

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-02/meta.json
@@ -205,6 +205,10 @@
     {
       "proofId": "chebyshev-polynomials-oq-01",
       "relationship": "Parent entry: proves the first-kind composition law T_{m·n} = T_m ∘ T_n and the commuting monoid; this entry answers its open question #2 on the second-kind and Dickson analogues."
+    },
+    {
+      "proofId": "chebyshev-polynomials-oq-01-oq-01",
+      "relationship": "Sibling under the same parent: proves the Chebyshev index-addition law T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} and its second-kind companion. It supplies exactly the additive/product-to-sum identities the Uₙ do satisfy — the structure this entry's open question #2 flags as replacing the failed compositional monoid."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `chebyshev-polynomials-oq-01-oq-02`.

This entry was already very rich (10-theorem file, 4 annotations fully populated with mathContext/significance/relatedConcepts, complete sections/conclusion/references/5 keyInsights). Per the diminishing-returns guardrails I made a single high-value improvement rather than inflating prose:

- Added a **sibling cross-reference** to `chebyshev-polynomials-oq-01-oq-01` (the Chebyshev index-addition formulas T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} and second-kind companion). That sibling supplies precisely the additive/product-to-sum identities that *this* entry's open question #2 names as the algebraic structure replacing the failed second-kind compositional monoid — so the link is directly navigational for a reader following that thread.

meta.json is 17 KB, well under the 60 KB cap. crossReferences now 2 (cap 20). No content removed; verified/0-axiom status unchanged.