### PR TITLE
Fix: add missing gallery entry for erdos-493-oq-01 (exact representation count)

### DIFF
--- a/src/data/proofs/erdos-493-oq-01/annotations.json
+++ b/src/data/proofs/erdos-493-oq-01/annotations.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "erdos-493-oq-01-header",
+    "proofId": "erdos-493-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
+    "title": "Problem Overview: An Exact Theory of Product Minus Sum",
+    "content": "**Erdős Problem #493 (OQ-01).** Erdős #493 asks whether every large $n$ is $\\prod a_i - \\sum a_i$ with $a_i \\geq 2$; the answer is yes with $k = 2$. This follow-up sharpens the *existence* result of the parent into an **exact theory** of the map $(a,b) \\mapsto ab - (a+b)$ over $a, b \\geq 2$: its image, its fiber sizes, and its uniqueness pattern.",
+    "mathContext": "Every result flows from the central identity $ab - (a+b) = (a-1)(b-1) - 1$, which converts a representation of $n$ into a factorization of $n+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "integer representation",
+      "divisor function",
+      "factorization bijection"
+    ],
+    "prerequisites": [
+      "integer arithmetic",
+      "the divisor function τ"
+    ]
+  },
+  {
+    "id": "erdos-493-oq-01-exact-image",
+    "proofId": "erdos-493-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 32,
+      "endLine": 59
+    },
+    "title": "C1: Exact Image and Factorization Bijection",
+    "content": "**prodMinusSum2_iff_nonneg** proves the exact image: $\\{ab-(a+b) : a,b \\geq 2\\} = \\{n \\geq 0\\}$. The $\\leftarrow$ direction is the parent theorem; the $\\rightarrow$ (converse) direction is new. **hasProdMinusSum2_iff_factor** recasts a representation of $n$ as a factorization $n+1 = uv$ with $u,v \\geq 1$, via $u = a-1,\\ v = b-1$.",
+    "mathContext": "From $a,b \\geq 2$: $ab-(a+b) = (a-1)(b-1) - 1 \\geq 1\\cdot 1 - 1 = 0$, so every negative integer is unrepresentable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "image of a map",
+      "factorization",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "integer inequalities",
+      "existential quantification"
+    ]
+  },
+  {
+    "id": "erdos-493-oq-01-structural",
+    "proofId": "erdos-493-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 61,
+      "endLine": 90
+    },
+    "title": "C3/C4: Diagonal and Nontrivial Representations",
+    "content": "**hasSquareRep_iff (C3):** a *diagonal* representation with $a = b$ exists iff $n+1$ is a perfect square (then $(a-1)^2 = n+1$). **hasNontrivialRep_iff_factor (C4):** a representation with *both* parts $\\geq 3$ exists iff $n+1$ is composite. The 'trivial' representation $(2, n+2)$ corresponds to the unit factor $u = 1$.",
+    "mathContext": "These identify which fibers contain the diagonal (squares) and which contain a non-unit factorization (composites), setting up the uniqueness and unordered-count results.",
+    "significance": "important",
+    "relatedConcepts": [
+      "perfect square",
+      "composite number",
+      "diagonal representation"
+    ],
+    "prerequisites": [
+      "perfect squares",
+      "factorization into factors ≥ 2"
+    ]
+  },
+  {
+    "id": "erdos-493-oq-01-ordered-count",
+    "proofId": "erdos-493-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 92,
+      "endLine": 141
+    },
+    "title": "C2: Ordered Representation Count = τ(n+1)",
+    "content": "**repsFinset** packages the ordered representations of $n$ as a `Finset (ℕ × ℕ)`, using the multiplicative form $a \\cdot b = a + b + n$ to avoid $\\mathbb{N}$-subtraction. **reps_card_eq_tau (C2)** proves the count equals $\\tau(n+1)$ via the explicit bijection $u \\mapsto (u+1,\\ (n+1)/u + 1)$ between divisors of $n+1$ and representations (`Finset.card_bij`).",
+    "mathContext": "$|\\{(a,b) : a,b \\geq 2,\\ n = ab-(a+b)\\}| = \\tau(n+1)$. This is the quantitative form of the factorization bijection.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_bij",
+      "divisor count τ",
+      "explicit bijection"
+    ],
+    "prerequisites": [
+      "counting via bijections",
+      "Nat.divisors"
+    ]
+  },
+  {
+    "id": "erdos-493-oq-01-primality",
+    "proofId": "erdos-493-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 143,
+      "endLine": 202
+    },
+    "title": "C5: Primality and Uniqueness Capstone",
+    "content": "**card_divisors_eq_two_iff_prime** proves $N.\\text{divisors}.card = 2 \\iff N.\\text{Prime}$ — a reusable divisor-count form of primality. **reps_card_eq_two_iff_prime (C5)** then reads off: exactly two ordered representations $\\iff n+1$ is prime (so the single unordered representation $\\{2,n+2\\}$ is unique). **reps_card_eq_one_iff:** one representation $\\iff n = 0$.",
+    "mathContext": "$\\tau(n+1) = 2 \\iff n+1$ prime; $\\tau(n+1) = 1 \\iff n+1 = 1 \\iff n = 0$. Primality becomes a representation-count statement.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primality",
+      "divisor count",
+      "uniqueness of representation"
+    ],
+    "prerequisites": [
+      "Nat.Prime and divisors",
+      "Finset cardinality bounds"
+    ]
+  },
+  {
+    "id": "erdos-493-oq-01-unordered-count",
+    "proofId": "erdos-493-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 204,
+      "endLine": 339
+    },
+    "title": "Exact Unordered Count via Swap Involution",
+    "content": "**diag_card** counts diagonal fixed points: $1$ if $n+1$ is a perfect square, else $0$. **two_mul_unordered_card** applies the involution $(a,b) \\mapsto (b,a)$: writing $L = \\{a \\leq b\\}$, $G = \\{b \\leq a\\}$, inclusion-exclusion gives $|L|+|G| = |reps| + |diag|$ with $|L| = |G|$. **two_mul_unorderedReps_card** substitutes the closed forms to get $2 \\cdot |\\text{unordered}| = \\tau(n+1) + [\\,n+1\\text{ square}\\,]$.",
+    "mathContext": "The unordered representation count is $\\lceil \\tau(n+1)/2 \\rceil$ — the perfect-square diagonal supplies the ceiling. Proved with `Finset.card_union_add_card_inter` and `Finset.card_image_of_injective Prod.swap_injective`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "involution",
+      "inclusion-exclusion",
+      "ceiling of τ(n+1)/2"
+    ],
+    "prerequisites": [
+      "Finset inclusion-exclusion",
+      "injective image cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-493-oq-01/meta.json
+++ b/src/data/proofs/erdos-493-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "erdos-493-oq-01",
+  "title": "Erdős Problem #493 (OQ-01): Exact Image and Representation Count",
+  "slug": "erdos-493-oq-01",
+  "description": "Sharpens Erdős #493 from mere existence to an exact theory of the product-minus-sum map (a,b) ↦ ab-(a+b), a,b ≥ 2. Proves the exact image {ab-(a+b)} = {n ≥ 0}, the representation ↔ factorization bijection n = ab-(a+b) ⟺ n+1 = uv, the ordered representation count = τ(n+1), uniqueness ⟺ n+1 prime, and the exact unordered count ⌈τ(n+1)/2⌉. Fully verified (0 axioms, 0 sorries).",
+  "meta": {
+    "author": "Lean Genius researcher",
+    "sourceUrl": "https://erdosproblems.com/493",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos493OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "representation",
+      "divisor-function",
+      "combinatorics",
+      "bijective-proof"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 493,
+    "erdosUrl": "https://erdosproblems.com/493",
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_bij",
+        "description": "Counting via an explicit bijection between finite sets",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.mem_divisors",
+        "description": "Membership characterization of the divisor Finset",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Finset.card_union_add_card_inter",
+        "description": "Inclusion-exclusion for finite set cardinalities",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.Prime.divisors",
+        "description": "The divisor set of a prime is {1, p}",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "prodMinusSum2_iff_nonneg (C1): the exact image {ab-(a+b) : a,b ≥ 2} = {n ≥ 0}; the converse direction is new (the parent proves only ⊇)",
+      "hasProdMinusSum2_iff_factor: representation ↔ factorization bijection via the central identity ab-(a+b) = (a-1)(b-1)-1",
+      "hasSquareRep_iff (C3): a diagonal representation a = b exists iff n+1 is a perfect square",
+      "hasNontrivialRep_iff_factor (C4): a representation with both parts ≥ 3 exists iff n+1 is composite",
+      "reps_card_eq_tau (C2): the ordered representation count equals τ(n+1) (explicit divisor bijection)",
+      "card_divisors_eq_two_iff_prime: divisor-count form of primality (N.divisors.card = 2 ↔ N.Prime)",
+      "reps_card_eq_two_iff_prime (C5): exactly two ordered representations iff n+1 is prime",
+      "reps_card_eq_one_iff: a unique ordered representation iff n = 0",
+      "diag_card, two_mul_unordered_card, two_mul_unorderedReps_card: exact unordered count 2·(count) = τ(n+1) + [n+1 is a perfect square], i.e. ⌈τ(n+1)/2⌉, via a swap-involution inclusion-exclusion"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Divisor function τ and Nat.divisors (BigOperators / NumberTheory.Divisors)",
+      "Counting via explicit bijections (Finset.card_bij, Finset.card_image_of_injective)",
+      "Inclusion-exclusion (Finset.card_union_add_card_inter)",
+      "Basic integer and natural-number arithmetic (ring, omega, nlinarith)"
+    ],
+    "lineCount": 339,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on the headline results yields only [propext, Classical.choice, Quot.sound].",
+    "theoremCount": 14,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Erdős Problem #493 (OQ-01): the exact theory behind the product-minus-sum representation**\n\nErdős Problem #493 (attributed to Schinzel, solved by Eli Seamans) asks whether every sufficiently large $n$ can be written as $\\prod a_i - \\sum a_i$ with all $a_i \\geq 2$. The answer is yes with $k = 2$: for every $n \\geq 0$, $n = 2(n+2) - (2 + (n+2))$. The parent formalization `Erdos493Problem` establishes this *existence* result — the $\\supseteq$ direction of the image.\n\nThis open-question follow-up (OQ-01) sharpens existence into an **exact structural theory** of the two-variable map $(a,b) \\mapsto ab - (a+b)$ over $a, b \\geq 2$. The engine is the central identity $ab - (a+b) = (a-1)(b-1) - 1$, which turns every representation question into a factorization question about $n+1$. From this single identity the file derives the exact image, an explicit representation-counting theorem, a primality characterization, and an exact unordered count.",
+    "problemStatement": "Beyond the existence result of Erdős #493, describe the **image and fibers** of the product-minus-sum map $(a,b) \\mapsto ab - (a+b)$ with $a, b \\geq 2$:\n\n1. Exactly which integers are representable? (the image)\n2. How many representations does each $n$ have? (the fiber sizes)\n3. When is the representation unique?",
+    "text": "Sharpens Erdős #493 from existence to an exact theory: image = {n ≥ 0}, ordered count = τ(n+1), uniqueness ⟺ n+1 prime, unordered count = ⌈τ(n+1)/2⌉. Fully verified (0 axioms, 0 sorries).",
+    "proofStrategy": "**Everything follows from one identity.** The substitution $u = a-1,\\ v = b-1$ turns $ab - (a+b) = (a-1)(b-1) - 1$ into the equivalence\n$$n = ab - (a+b),\\ a,b \\geq 2 \\quad\\Longleftrightarrow\\quad n+1 = uv,\\ u,v \\geq 1.$$\n\n1. **Exact image (C1).** Since $(a-1)(b-1) \\geq 1$, every representable $n$ satisfies $n \\geq 0$; the parent gives the converse. Hence the image is exactly $\\{n \\geq 0\\}$.\n2. **Counting bijection (C2).** The map $u \\mapsto (u+1,\\ (n+1)/u + 1)$ is a bijection from divisors of $n+1$ to ordered representations, so the ordered count is $\\tau(n+1)$ (proved with `Finset.card_bij`).\n3. **Primality (C5).** $\\tau(n+1) = 2 \\iff n+1$ is prime (via `card_divisors_eq_two_iff_prime`), so there are exactly two ordered representations iff $n+1$ is prime — the unordered representation is then unique.\n4. **Unordered count (Part III).** The swap $(a,b) \\mapsto (b,a)$ is an involution of the representation set whose fixed points are the diagonal $a = b$ (existing iff $n+1$ is a perfect square). Inclusion-exclusion gives $2 \\cdot (\\text{unordered count}) = \\tau(n+1) + [\\,n+1\\text{ is a square}\\,] = \\lceil \\tau(n+1)/2 \\rceil$ doubled.",
+    "keyInsights": [
+      "The identity $ab - (a+b) = (a-1)(b-1) - 1$ reduces every representation question to a factorization of $n+1$",
+      "The fiber over $n$ is in explicit bijection with the divisors of $n+1$, so the ordered representation count is exactly $\\tau(n+1)$",
+      "Unordered-uniqueness is a primality test: the representation $\\{2, n+2\\}$ is the only one precisely when $n+1$ is prime (or $n = 0$)",
+      "Diagonal representations $a = b$ are the fixed points of the swap involution and occur exactly when $n+1$ is a perfect square, contributing the ceiling in $\\lceil \\tau(n+1)/2 \\rceil$",
+      "A swap-involution plus inclusion-exclusion converts the ordered count into the exact unordered count with no case analysis on $n$"
+    ],
+    "prerequisites": [
+      "The divisor function $\\tau$ and `Nat.divisors`",
+      "Counting via explicit bijections (`Finset.card_bij`)",
+      "Inclusion-exclusion for finite sets",
+      "The central algebraic identity $ab-(a+b) = (a-1)(b-1)-1$"
+    ]
+  },
+  "sections": [
+    {
+      "id": "exact-image",
+      "title": "Part I: Exact Image and Factorization Bijection",
+      "startLine": 32,
+      "endLine": 59,
+      "summary": "prodMinusSum2_iff_nonneg (C1): the image {ab-(a+b) : a,b ≥ 2} is exactly {n ≥ 0}, the converse being new. hasProdMinusSum2_iff_factor recasts a representation as a factorization n+1 = uv with u,v ≥ 1.",
+      "mathContext": "$ab - (a+b) = (a-1)(b-1) - 1 \\geq 0$, and $u = a-1,\\ v = b-1$ gives the factorization bijection"
+    },
+    {
+      "id": "structural-fibers",
+      "title": "Part II: Diagonal and Nontrivial Representations",
+      "startLine": 61,
+      "endLine": 90,
+      "summary": "hasSquareRep_iff (C3): a diagonal a = b exists iff n+1 is a perfect square. hasNontrivialRep_iff_factor (C4): a representation with both parts ≥ 3 exists iff n+1 is composite.",
+      "mathContext": "$a = b \\Rightarrow (a-1)^2 = n+1$; both parts $\\geq 3 \\Rightarrow n+1 = uv$ with $u,v \\geq 2$"
+    },
+    {
+      "id": "ordered-count",
+      "title": "Part III: Ordered Representation Count = τ(n+1)",
+      "startLine": 92,
+      "endLine": 141,
+      "summary": "repsFinset packages ordered representations as a Finset; reps_card_eq_tau (C2) proves the count equals τ(n+1) via the explicit divisor bijection u ↦ (u+1, (n+1)/u + 1).",
+      "mathContext": "$|\\{(a,b) : a,b \\geq 2,\\ n = ab-(a+b)\\}| = \\tau(n+1)$"
+    },
+    {
+      "id": "primality",
+      "title": "Part IV: Primality and Uniqueness Capstone",
+      "startLine": 143,
+      "endLine": 202,
+      "summary": "card_divisors_eq_two_iff_prime gives N.divisors.card = 2 ↔ N.Prime; reps_card_eq_two_iff_prime (C5) reads off exactly-two-representations ⟺ n+1 prime, and reps_card_eq_one_iff gives one representation ⟺ n = 0.",
+      "mathContext": "$\\tau(n+1) = 2 \\iff n+1$ prime; $\\tau(n+1) = 1 \\iff n = 0$"
+    },
+    {
+      "id": "unordered-count",
+      "title": "Part V: Exact Unordered Count ⌈τ(n+1)/2⌉",
+      "startLine": 204,
+      "endLine": 339,
+      "summary": "diag_card counts diagonal fixed points (1 iff n+1 is square); two_mul_unordered_card uses the swap involution and inclusion-exclusion; two_mul_unorderedReps_card gives 2·(unordered count) = τ(n+1) + [n+1 is a square].",
+      "mathContext": "$2 \\cdot |\\text{unordered reps}| = \\tau(n+1) + [\\,n+1\\text{ is a perfect square}\\,]$, i.e. the count is $\\lceil \\tau(n+1)/2 \\rceil$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The product-minus-sum map (a,b) ↦ ab-(a+b) over a,b ≥ 2 has image exactly {n ≥ 0}, and the fiber over n is in explicit bijection with the divisors of n+1. Hence the ordered representation count is τ(n+1), the representation is unordered-unique iff n+1 is prime (or n = 0), and the exact unordered count is ⌈τ(n+1)/2⌉. All results are fully verified in Lean with 0 axioms and 0 sorries.",
+    "implications": "**Theoretical Significance**\n\n1. **From existence to an exact fiber theory.** The parent proof answers only *whether* n is representable; OQ-01 answers *how many times* and *when uniquely*, turning a solved existence problem into a complete quantitative one via a single algebraic identity.\n\n2. **A representation-count primality test.** The equivalence 'exactly two ordered representations ⟺ n+1 prime' packages primality as a counting statement, with card_divisors_eq_two_iff_prime a reusable divisor-count characterization of primality.\n\n3. **Involution counting.** The exact unordered count is obtained not by case analysis but by a clean swap involution plus inclusion-exclusion, with the perfect-square diagonal supplying the ceiling in ⌈τ(n+1)/2⌉.",
+    "openQuestions": [
+      "What is the analogous exact count for the k-variable map (a₁,…,a_k) ↦ ∏ aᵢ - ∑ aᵢ with all aᵢ ≥ 2?",
+      "If the parts are required distinct, how does the representation count change?",
+      "What were Schinzel's original additional constraints on the problem?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Some unsolved problems",
+      "year": "1961",
+      "venue": "Magyar Tudományos Akadémia Matematikai Kutató Intézetének Közleményei 6, pp. 221-254",
+      "note": "[Er61] where the problem appears, attributed to Schinzel"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-493",
+      "relationship": "extends",
+      "description": "The parent formalization proves only the existence (⊇ direction of the image) of the product-minus-sum representation; this OQ-01 file sharpens it to the exact image, representation count τ(n+1), primality characterization, and exact unordered count ⌈τ(n+1)/2⌉"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos493Problem",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos493",
+    "lineCount": 339,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos493OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Fix

`proofs/Proofs/Erdos493OQ01.lean` was merged (via #30826 and #30849) but never received a `src/data/proofs/` gallery directory, so this verified proof was **invisible** in the gallery. This PR adds the missing `meta.json` + `annotations.json`.

## Evidence

**Before**: `Erdos493OQ01.lean` exists on `origin/main` (339 lines, 14 theorems, 2 defs, 0 sorries, 0 axioms — `#print axioms` yields only `[propext, Classical.choice, Quot.sound]`), but `src/data/proofs/erdos-493-oq-01/` did not exist. The `erdos-493` directory references a *different* file (`Erdos493Problem.lean`). The research knowledge base itself flagged: "No gallery `src/data/proofs/erdos-493-oq-01` page exists yet — the file (rich, 0-axiom) is a promotion candidate."

**After**: New gallery entry `erdos-493-oq-01` with:
- `meta.json` — status `verified`, badge `verified`, 0 axioms, 0 sorries, accurate line/theorem/def counts, modeled on the sibling `erdos-493` schema.
- `annotations.json` — 6 range-aligned annotations covering the exact image (C1), diagonal/nontrivial structure (C3/C4), the τ(n+1) ordered count (C2), the primality capstone (C5), and the exact unordered count ⌈τ(n+1)/2⌉.

Content: the OQ-01 file sharpens Erdős #493 from mere existence to an exact theory of the product-minus-sum map `(a,b) ↦ ab-(a+b)`, `a,b ≥ 2` — exact image `{n ≥ 0}`, ordered representation count `= τ(n+1)` (explicit divisor bijection), uniqueness `⟺ n+1` prime, and exact unordered count `⌈τ(n+1)/2⌉` via a swap-involution inclusion-exclusion.

## Validation

- `pnpm gallery:check-size` — passes (no size violation).
- `pnpm annotations:validate` — 0 errors for `erdos-493-oq-01` (all annotation ranges hit real Lean constructs).
- JSON well-formed; committed only the new directory (annotation-build churn discarded).

---
Automated fix by lean-mechanic agent (missing-gallery-gap scan).