### PR TITLE
research(basel-problem-oq-03-oq-02): ζ(10), ζ(12) & the irregular prime 691 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ03OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ03OQ02.lean
@@ -1,0 +1,259 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.NumberTheory.Bernoulli
+import Mathlib.Tactic
+
+/-
+# Basel Problem (OQ-03 → OQ-02): How far does the even-zeta product-reduction extend?
+
+Open Question (child of OQ-03, "Multiple Zeta Values: relationship to single
+zeta values"):
+
+The parent entry (`BaselProblemOQ03`) evaluated ζ(2), ζ(4), ζ(6), ζ(8) via
+Euler's formula and proved that every product of these even zeta values collapses
+to a single even zeta value times a *tidy* rational — ζ(2)² = (5/2)·ζ(4),
+ζ(2)·ζ(4) = (7/4)·ζ(6), ζ(4)² = (7/6)·ζ(8), … .  It stopped at weight 8.
+
+**The question this file answers.** Does the "product of even zetas reduces to a
+single even zeta" phenomenon continue past weight 8, and does the reduction
+coefficient stay "nice"?  We push two weights further, to ζ(10) and ζ(12), and
+find:
+
+* The reduction *always* holds — this is forced by Euler's formula
+  ζ(2k) = q_k · π^{2k} (`hasSum_zeta_nat`): matching π-powers turns any product of
+  even zetas into a rational multiple of the single zeta of the summed weight.
+* At weight 10 the coefficients are still tidy (33/20, 11/10, 11/4, 77/40, 385/32).
+* **At weight 12 the coefficients stop being tidy** — 715/691, 2275/1382,
+  3003/2764 — because the *irregular prime 691* enters through B₁₂ = -691/2730,
+  putting a factor of 691 in the *numerator* of ζ(12) = 691·π¹²/638512875
+  (638512875 = 3⁶·5³·7²·11·13 is coprime to 691).  Consequently every reduction
+  coefficient P/ζ(12) acquires 691 in its *denominator*: 715/691, 2275/1382 =
+  (5²·7·13)/(2·691), 3003/2764 = (3·7·11·13)/(4·691).  The prime 691 — the first
+  irregular prime, the numerator of B₁₂, the modulus of Ramanujan's τ congruence
+  — is exactly the arithmetic fingerprint that breaks the tidiness that held
+  through weight 10.
+
+## What is proved
+
+Bernoulli numbers Mathlib does not stock, computed from the defining recursion:
+
+* `bernoulli_ten`     : B₁₀ = 5/66
+* `bernoulli_twelve`  : B₁₂ = -691/2730   (the "691" number)
+
+Closed forms for the single zeta values, from `hasSum_zeta_nat`:
+
+* `hasSum_zeta_ten`   : ζ(10) = π¹⁰/93555
+* `hasSum_zeta_twelve`: ζ(12) = 691·π¹²/638512875
+
+Weight-10 product reductions (tidy coefficients):
+
+* `zeta_two_mul_eight`   : ζ(2)·ζ(8)   = (33/20)·ζ(10)
+* `zeta_four_mul_six`    : ζ(4)·ζ(6)   = (11/10)·ζ(10)
+* `zeta_two_sq_mul_six`  : ζ(2)²·ζ(6)  = (11/4)·ζ(10)
+* `zeta_two_mul_four_sq` : ζ(2)·ζ(4)²  = (77/40)·ζ(10)
+* `zeta_two_pow_five`    : ζ(2)⁵       = (385/32)·ζ(10)
+
+Weight-12 product reductions (coefficients spoiled by 691):
+
+* `zeta_six_sq`        : ζ(6)²       = (715/691)·ζ(12)
+* `zeta_two_mul_ten`   : ζ(2)·ζ(10)  = (2275/1382)·ζ(12)
+* `zeta_four_mul_eight`: ζ(4)·ζ(8)   = (3003/2764)·ζ(12)
+
+## Status
+
+Verified. Axioms: 0 (no `native_decide`). Sorries: 0.
+-/
+
+namespace BaselProblemOQ03OQ02
+
+open scoped Real
+open Nat Finset
+
+/-! ## Bernoulli numbers B₁₀ and B₁₂
+
+Mathlib stocks `bernoulli'_two`, `bernoulli'_three`, `bernoulli'_four` and stops
+there.  The parent entry computed B₆ = 1/42 and B₈ = -1/30 from `bernoulli'_def`.
+We continue the recursion two more even steps, to B₁₀ and B₁₂, using that the odd
+Bernoulli numbers vanish. -/
+
+theorem bernoulli'_five : bernoulli' 5 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_seven : bernoulli' 7 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_nine : bernoulli' 9 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_eleven : bernoulli' 11 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_six : bernoulli' 6 = 1 / 42 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five, Nat.choose]
+
+theorem bernoulli'_eight : bernoulli' 8 = -1 / 30 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five,
+    bernoulli'_six, bernoulli'_seven, Nat.choose]
+
+theorem bernoulli'_ten : bernoulli' 10 = 5 / 66 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five,
+    bernoulli'_six, bernoulli'_seven, bernoulli'_eight, bernoulli'_nine, Nat.choose]
+
+theorem bernoulli'_twelve : bernoulli' 12 = -691 / 2730 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five,
+    bernoulli'_six, bernoulli'_seven, bernoulli'_eight, bernoulli'_nine,
+    bernoulli'_ten, bernoulli'_eleven, Nat.choose]
+
+theorem bernoulli_six : bernoulli 6 = 1 / 42 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_six]
+
+theorem bernoulli_eight : bernoulli 8 = -1 / 30 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_eight]
+
+theorem bernoulli_ten : bernoulli 10 = 5 / 66 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_ten]
+
+/-- B₁₂ = -691/2730: the first Bernoulli number whose numerator is an irregular
+prime.  This 691 is the arithmetic obstruction that spoils the tidiness of the
+weight-12 product reductions below. -/
+theorem bernoulli_twelve : bernoulli 12 = -691 / 2730 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_twelve]
+
+/-! ## Closed forms for ζ(10) and ζ(12)
+
+`hasSum_zeta_two`, `hasSum_zeta_four` are in Mathlib; the parent added ζ(6), ζ(8);
+we add ζ(10) and ζ(12). -/
+
+theorem hasSum_zeta_six :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) (π ^ 6 / 945) := by
+  have h := hasSum_zeta_nat (k := 3) (by norm_num)
+  simp only [(by norm_num : (2 * 3 : ℕ) = 6), (by norm_num : (2 * 3 - 1 : ℕ) = 5)] at h
+  rw [bernoulli_six] at h
+  convert h using 1
+  rw [show (6 : ℕ)! = 720 from by norm_num]
+  push_cast
+  ring
+
+theorem hasSum_zeta_eight :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
+  have h := hasSum_zeta_nat (k := 4) (by norm_num)
+  simp only [(by norm_num : (2 * 4 : ℕ) = 8), (by norm_num : (2 * 4 - 1 : ℕ) = 7)] at h
+  rw [bernoulli_eight] at h
+  convert h using 1
+  rw [show (8 : ℕ)! = 40320 from by norm_num]
+  push_cast
+  ring
+
+theorem hasSum_zeta_ten :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 10) (π ^ 10 / 93555) := by
+  have h := hasSum_zeta_nat (k := 5) (by norm_num)
+  simp only [(by norm_num : (2 * 5 : ℕ) = 10), (by norm_num : (2 * 5 - 1 : ℕ) = 9)] at h
+  rw [bernoulli_ten] at h
+  convert h using 1
+  rw [show (10 : ℕ)! = 3628800 from by norm_num]
+  push_cast
+  ring
+
+theorem hasSum_zeta_twelve :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 12) (691 * π ^ 12 / 638512875) := by
+  have h := hasSum_zeta_nat (k := 6) (by norm_num)
+  simp only [(by norm_num : (2 * 6 : ℕ) = 12), (by norm_num : (2 * 6 - 1 : ℕ) = 11)] at h
+  rw [bernoulli_twelve] at h
+  convert h using 1
+  rw [show (12 : ℕ)! = 479001600 from by norm_num]
+  push_cast
+  ring
+
+/-! ## The single even zeta values as `tsum`s -/
+
+theorem tsum_zeta_two : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2 = π ^ 2 / 6 :=
+  hasSum_zeta_two.tsum_eq
+
+theorem tsum_zeta_four : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4 = π ^ 4 / 90 :=
+  hasSum_zeta_four.tsum_eq
+
+theorem tsum_zeta_six : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6 = π ^ 6 / 945 :=
+  hasSum_zeta_six.tsum_eq
+
+theorem tsum_zeta_eight : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 = π ^ 8 / 9450 :=
+  hasSum_zeta_eight.tsum_eq
+
+theorem tsum_zeta_ten : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 = π ^ 10 / 93555 :=
+  hasSum_zeta_ten.tsum_eq
+
+theorem tsum_zeta_twelve : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 12 = 691 * π ^ 12 / 638512875 :=
+  hasSum_zeta_twelve.tsum_eq
+
+/-! ## Weight-10 product reductions — coefficients still tidy
+
+Every product of even zeta values whose weights sum to 10 is a rational multiple
+of ζ(10).  At this weight the coefficients remain small fractions, matching the
+pattern of the parent entry's weight ≤ 8 relations. -/
+
+/-- ζ(2)·ζ(8) = (33/20)·ζ(10). -/
+theorem zeta_two_mul_eight :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8)
+      = (33 / 20) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 := by
+  rw [tsum_zeta_two, tsum_zeta_eight, tsum_zeta_ten]; ring
+
+/-- ζ(4)·ζ(6) = (11/10)·ζ(10). -/
+theorem zeta_four_mul_six :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6)
+      = (11 / 10) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 := by
+  rw [tsum_zeta_four, tsum_zeta_six, tsum_zeta_ten]; ring
+
+/-- ζ(2)²·ζ(6) = (11/4)·ζ(10). -/
+theorem zeta_two_sq_mul_six :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 2 * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6)
+      = (11 / 4) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 := by
+  rw [tsum_zeta_two, tsum_zeta_six, tsum_zeta_ten]; ring
+
+/-- ζ(2)·ζ(4)² = (77/40)·ζ(10). -/
+theorem zeta_two_mul_four_sq :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) ^ 2
+      = (77 / 40) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 := by
+  rw [tsum_zeta_two, tsum_zeta_four, tsum_zeta_ten]; ring
+
+/-- ζ(2)⁵ = (385/32)·ζ(10). -/
+theorem zeta_two_pow_five :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 5
+      = (385 / 32) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10 := by
+  rw [tsum_zeta_two, tsum_zeta_ten]; ring
+
+/-! ## Weight-12 product reductions — the tidiness breaks at 691
+
+The reduction phenomenon persists: each product below is still a rational
+multiple of ζ(12).  But because ζ(12) = 691·π¹²/638512875 carries the irregular
+prime 691 (from B₁₂ = -691/2730) in its *numerator*, every reduction coefficient
+P/ζ(12) picks up 691 in its *denominator*.  The tidy small fractions of weights
+≤ 10 give way to 715/691, 2275/1382, 3003/2764 — the first visible degradation of
+the "product of even zetas is a *simple* multiple of a single zeta" heuristic, a
+direct fingerprint of the arithmetic of Bernoulli numbers. -/
+
+/-- ζ(6)² = (715/691)·ζ(12).  The numerator 715 = 5·11·13 is tidy; the 691 in the
+denominator is the shadow of the irregular prime sitting in ζ(12)'s numerator. -/
+theorem zeta_six_sq :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6) ^ 2
+      = (715 / 691) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 12 := by
+  rw [tsum_zeta_six, tsum_zeta_twelve]; ring
+
+/-- ζ(2)·ζ(10) = (2275/1382)·ζ(12), with 1382 = 2·691. -/
+theorem zeta_two_mul_ten :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 10)
+      = (2275 / 1382) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 12 := by
+  rw [tsum_zeta_two, tsum_zeta_ten, tsum_zeta_twelve]; ring
+
+/-- ζ(4)·ζ(8) = (3003/2764)·ζ(12), with 2764 = 4·691. -/
+theorem zeta_four_mul_eight :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8)
+      = (3003 / 2764) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 12 := by
+  rw [tsum_zeta_four, tsum_zeta_eight, tsum_zeta_twelve]; ring
+
+end BaselProblemOQ03OQ02

--- a/src/data/proofs/basel-problem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-03-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 5, "endLine": 68 },
+    "type": "concept",
+    "title": "How Far Does the Even-Zeta Product-Reduction Extend?",
+    "content": "The parent entry evaluated ζ(2), ζ(4), ζ(6), ζ(8) and proved that every product of even zeta values collapses to a tidy rational multiple of a single even zeta value, stopping at weight 8. This file pushes two weights further, to ζ(10) and ζ(12), and asks whether the reduction persists and whether its coefficient stays 'nice'. The answer: the reduction never fails (it is forced by Euler's formula, which makes each ζ(2k) a rational multiple of π^{2k}), but at weight 12 the irregular prime 691 — the numerator of B₁₂ — enters ζ(12) and spoils the tidiness of the coefficients. 0 axioms, 0 sorries.",
+    "mathContext": "ζ(2k) ∈ ℚ·π^{2k}, so any product of even zetas of total weight 2m lies in ℚ·π^{2m} = ℚ·ζ(2m).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler even-zeta formula",
+      "Bernoulli numbers",
+      "irregular primes",
+      "Riemann zeta function"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6",
+      "parent entry basel-problem-oq-03 (even-zeta product reductions)"
+    ]
+  },
+  {
+    "id": "ann-bernoulli-recursion",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 71, "endLine": 113 },
+    "type": "computation",
+    "title": "Computing B₁₀ and B₁₂ from the Recursion",
+    "content": "Mathlib stocks the Bernoulli numbers only through B₄; the parent entry reached B₆ = 1/42 and B₈ = -1/30. This block continues two even steps further. The odd-index numbers B₅, B₇, B₉, B₁₁ vanish (bernoulli'_eq_zero_of_odd), which shortens the recursion sum, and B₆, B₈, B₁₀ = 5/66, B₁₂ = -691/2730 are read off bernoulli'_def by norm_num expanding the defining sum over the lower terms and Nat.choose.",
+    "mathContext": "bernoulli'_def: B'_n = 1 − ∑_{k<n} C(n,k)/(n−k+1)·B'_k; with odd B'_k = 0 only even lower terms contribute.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bernoulli number recursion",
+      "vanishing of odd Bernoulli numbers"
+    ],
+    "prerequisites": [
+      "the defining recursion for Bernoulli numbers"
+    ]
+  },
+  {
+    "id": "ann-b12-691",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 114, "endLine": 128 },
+    "type": "insight",
+    "title": "B₁₂ = -691/2730 and the Irregular Prime 691",
+    "content": "Converting to the standard convention (bernoulli_eq_bernoulli'_of_ne_one) gives bernoulli 12 = -691/2730. The 691 in the numerator is the smallest irregular prime — a prime dividing the numerator of some Bernoulli number, in Kummer's sense — and the modulus of Ramanujan's congruence τ(n) ≡ σ₁₁(n) (mod 691). It is exactly this 691 that will break the tidiness of the weight-12 product reductions, since it survives into the numerator of ζ(12).",
+    "mathContext": "bernoulli 12 = -691/2730; 691 is prime, irregular, and coprime to 2730 = 2·3·5·7·13.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irregular primes",
+      "Kummer's criterion",
+      "Ramanujan tau congruence"
+    ],
+    "prerequisites": [
+      "two Bernoulli conventions and their agreement for n ≠ 1"
+    ]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 129, "endLine": 192 },
+    "type": "computation",
+    "title": "Closed Forms ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875",
+    "content": "Euler's formula hasSum_zeta_nat is instantiated at k=3,4,5,6. ζ(6), ζ(8) are re-derived so the file is self-contained; ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875 are new. After substituting the Bernoulli value and fixing (2k)!, each is closed by push_cast; ring. All six even zeta values ζ(2)…ζ(12) are then recorded as tsum equalities. Note that ζ(10) has numerator 1 (like ζ(2)…ζ(8)), whereas ζ(12) carries the 691 — the first anomalous numerator among the even zeta values.",
+    "mathContext": "ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!; 638512875 = 3⁶·5³·7²·11·13 is coprime to 691.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler even-zeta formula",
+      "hasSum_zeta_nat",
+      "tsum of a HasSum"
+    ],
+    "prerequisites": [
+      "Euler's closed form for even zeta values",
+      "the computed Bernoulli numbers"
+    ]
+  },
+  {
+    "id": "ann-weight-10",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 194, "endLine": 229 },
+    "type": "theorem",
+    "title": "Weight-10 Reductions: Coefficients Still Tidy",
+    "content": "Five product-reduction identities of total weight 10 — ζ(2)·ζ(8) = (33/20)·ζ(10), ζ(4)·ζ(6) = (11/10)·ζ(10), ζ(2)²·ζ(6) = (11/4)·ζ(10), ζ(2)·ζ(4)² = (77/40)·ζ(10), ζ(2)⁵ = (385/32)·ζ(10). Each is an exact identity between the actual infinite series, proved by rewriting the tsum closed forms and a single ring step (the coefficient equals D₁₀ divided by the product of the factors' denominators). The coefficients remain small fractions, matching the parent's weight ≤ 8 pattern.",
+    "mathContext": "e.g. ζ(2)·ζ(8) = (π²/6)(π⁸/9450) = π¹⁰/56700 = (33/20)·π¹⁰/93555.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "product-reduction of even zeta values",
+      "one-dimensionality of the even-zeta ring per weight"
+    ],
+    "prerequisites": [
+      "closed forms for ζ(2), ζ(4), ζ(6), ζ(8), ζ(10)"
+    ]
+  },
+  {
+    "id": "ann-weight-12",
+    "proofId": "basel-problem-oq-03-oq-02",
+    "range": { "startLine": 230, "endLine": 258 },
+    "type": "theorem",
+    "title": "Weight-12 Reductions: The Tidiness Breaks at 691",
+    "content": "Three product-reduction identities of total weight 12 — ζ(6)² = (715/691)·ζ(12), ζ(2)·ζ(10) = (2275/1382)·ζ(12), ζ(4)·ζ(8) = (3003/2764)·ζ(12). The reduction still holds, but because ζ(12) = 691·π¹²/638512875 carries the irregular prime 691 in its numerator (coprime to the denominator, so it cannot cancel), every coefficient P/ζ(12) picks up 691 in its denominator: 1382 = 2·691, 2764 = 4·691. This is the first weight at which the reduction coefficients cease to be tidy — a direct fingerprint of the arithmetic of the Bernoulli numbers.",
+    "mathContext": "ζ(6)² = π¹²/893025 = (715/691)·(691·π¹²/638512875); 638512875 = 715·893025.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irregular primes",
+      "product-reduction of even zeta values",
+      "arithmetic of Bernoulli numbers"
+    ],
+    "prerequisites": [
+      "closed form ζ(12) = 691·π¹²/638512875",
+      "the irregular prime 691"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-03-oq-02/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "basel-problem-oq-03-oq-02",
+  "title": "How Far Does the Even-Zeta Product-Reduction Extend? ζ(10), ζ(12), and the Prime 691",
+  "slug": "basel-problem-oq-03-oq-02",
+  "description": "Pushes the parent entry's even-zeta product-reduction pattern two weights further, to ζ(10) = π¹⁰/93555 (via B₁₀ = 5/66) and ζ(12) = 691·π¹²/638512875 (via B₁₂ = -691/2730), each Bernoulli number computed from the defining recursion since Mathlib stops at B₄. The product-reduction phenomenon — every product of even zeta values collapses to a rational multiple of the single zeta of the summed weight — is shown to persist: five weight-10 relations (ζ(2)·ζ(8) = (33/20)·ζ(10), ζ(4)·ζ(6) = (11/10)·ζ(10), ζ(2)²·ζ(6) = (11/4)·ζ(10), ζ(2)·ζ(4)² = (77/40)·ζ(10), ζ(2)⁵ = (385/32)·ζ(10)) keep the tidy small coefficients of the parent, while at weight 12 the irregular prime 691 — sitting in the numerator of ζ(12) — forces a factor of 691 into the denominator of every reduction coefficient: ζ(6)² = (715/691)·ζ(12), ζ(2)·ζ(10) = (2275/1382)·ζ(12), ζ(4)·ζ(8) = (3003/2764)·ζ(12). This exhibits the exact weight at which the 'product of even zetas is a simple multiple of a single zeta' heuristic first visibly degrades, and identifies the arithmetic cause. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Euler even-zeta formula; extension to weights 10 and 12 with the 691 anomaly",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "1740",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "zeta-function",
+      "bernoulli-numbers",
+      "multiple-zeta-values",
+      "irregular-primes",
+      "infinite-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "Euler's closed form for even zeta values: HasSum (fun n => 1/n^(2k)) of (-1)^(k+1)·2^(2k-1)·π^(2k)·B_(2k)/(2k)!; instantiated at k=3,4,5,6 to obtain ζ(6), ζ(8), ζ(10), ζ(12)",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_def",
+        "description": "The defining recursion for the (second-convention) Bernoulli numbers, used to compute B₆, B₈, B₁₀ = 5/66 and B₁₂ = -691/2730 beyond Mathlib's stock B₄",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "Odd-index Bernoulli numbers B₅, B₇, B₉, B₁₁ vanish, shortening the recursion sums",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli_eq_bernoulli'_of_ne_one",
+        "description": "For n ≠ 1 the two Bernoulli conventions agree, converting the computed B'_n into the bernoulli n needed by hasSum_zeta_nat",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "ζ(2) = π²/6 (Basel), and hasSum_zeta_four for ζ(4) = π⁴/90 — the two even zeta values Mathlib stocks, used as the base of the product relations",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.tsum_eq",
+        "description": "Extracts the tsum value from a HasSum statement, converting each closed form into an equation between the actual infinite series",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Computes the Bernoulli numbers B₁₀ = 5/66 and B₁₂ = -691/2730 from the defining recursion (Mathlib stocks only through B₄; the parent entry reached B₈), including the odd-index vanishing B₉ = B₁₁ = 0",
+      "Derives the closed forms ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875 by instantiating hasSum_zeta_nat at k=5,6 — the latter exhibiting the celebrated appearance of the irregular prime 691 in the numerator of a zeta value",
+      "Proves five weight-10 product-reduction identities among the actual infinite series (not just the π-expressions), showing the reduction coefficients remain tidy small fractions through weight 10",
+      "Proves three weight-12 product-reduction identities and shows their coefficients (715/691, 2275/1382, 3003/2764) all carry 691 in the denominator — the first weight at which the reduction coefficients cease to be tidy, with the irregular prime 691 identified as the precise arithmetic cause",
+      "0 axioms (only propext / Classical.choice / Quot.sound), 0 sorries, no native_decide"
+    ],
+    "axiomCount": 0,
+    "lineCount": 259,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. Every Bernoulli number is computed from the recursion, every closed form from hasSum_zeta_nat, and every product relation is an exact identity between the infinite series verified by a single ring step.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 30,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler (1740) proved ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!, making every even zeta value a rational multiple of π^{2k} and, through the Bernoulli numbers B_{2k}, a window onto deep arithmetic. The numerators of Bernoulli numbers are where irregular primes first appear: 691, the numerator of B₁₂, is the smallest irregular prime and the modulus of Ramanujan's congruence τ(n) ≡ σ₁₁(n) (mod 691) for the Ramanujan tau function. Its emergence in ζ(12) = 691·π¹²/638512875 is the classic first sighting of arithmetic subtlety inside the otherwise 'elementary' even zeta values.",
+    "problemStatement": "The parent entry evaluated ζ(2), ζ(4), ζ(6), ζ(8) and proved that every product of these even zeta values reduces to a tidy rational multiple of a single even zeta value, stopping at weight 8. Does the product-reduction continue to higher weight, and does the reduction coefficient stay 'nice'? Concretely: compute ζ(10) and ζ(12), and determine what — if anything — changes in the reduction coefficients.",
+    "text": "Extends the even-zeta product-reduction pattern to weights 10 and 12, pinpointing the irregular prime 691 as the arithmetic obstruction that first spoils the tidiness of the reduction coefficients.",
+    "proofStrategy": "Continue the parent's Bernoulli recursion two even steps: from bernoulli'_def with the odd-index vanishing lemma, compute B₁₀ = 5/66 and B₁₂ = -691/2730, then convert to the bernoulli convention. Instantiate hasSum_zeta_nat at k=5,6 to obtain ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875, and convert all closed forms to tsum equalities. Because each ζ(2k) is a rational (times possibly 691) multiple of π^{2k}, any product of even zeta values is — by matching π-powers — a rational multiple of the single zeta of the summed weight; each product relation is closed by rewriting the tsum closed forms and one ring step. At weight 10 the coefficients (33/20, 11/10, 11/4, 77/40, 385/32) are tidy; at weight 12 the 691 in ζ(12)'s numerator forces 691 into every coefficient's denominator (715/691, 2275/1382 = (5²·7·13)/(2·691), 3003/2764 = (3·7·11·13)/(4·691)).",
+    "keyInsights": [
+      "The product-reduction of even zeta values is forced by Euler's formula alone: ζ(2k) ∈ ℚ·π^{2k}, so any product of even zetas of total weight 2m lies in ℚ·π^{2m} = ℚ·ζ(2m) — the ring they generate is one-dimensional in each weight",
+      "The reduction always holds; what changes with weight is the arithmetic complexity of the rational coefficient, which is governed by the Bernoulli numbers of the values involved",
+      "The irregular prime 691 = numerator of B₁₂ enters ζ(12) = 691·π¹²/638512875 and is coprime to the denominator 638512875 = 3⁶·5³·7²·11·13, so it cannot cancel — it is a genuine feature of the value, not an artifact",
+      "Consequently every weight-12 reduction coefficient P/ζ(12) carries 691 in its denominator (715/691, 2275/1382, 3003/2764), the first visible degradation of the tidy pattern that held through weight 10",
+      "Stating the relations between the actual tsums (not just π-expressions) keeps them honest identities about the infinite series, exactly as in the parent entry"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 and the parent entry basel-problem-oq-03 on even-zeta values and product reductions through weight 8",
+      "Euler's formula ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)! and the Bernoulli-number recursion",
+      "Irregular primes and the numerators of Bernoulli numbers (Kummer; the prime 691)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bernoulli",
+      "title": "Bernoulli Numbers B₁₀ = 5/66 and B₁₂ = -691/2730",
+      "startLine": 71,
+      "endLine": 128,
+      "summary": "Extends the parent's Bernoulli recursion two even steps. The odd-index numbers B₅, B₇, B₉, B₁₁ vanish (bernoulli'_eq_zero_of_odd); B₆, B₈, B₁₀, B₁₂ are computed from bernoulli'_def by norm_num over the recursion sum, then converted to the bernoulli convention. B₁₂ = -691/2730 is the first Bernoulli number whose numerator is an irregular prime.",
+      "mathContext": "bernoulli'_def: B'_n = 1 − ∑_{k<n} C(n,k)/(n−k+1)·B'_k; only even lower terms survive."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Closed Forms ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875",
+      "startLine": 129,
+      "endLine": 192,
+      "summary": "Instantiates Euler's formula hasSum_zeta_nat at k=3,4,5,6 (ζ(6), ζ(8) re-derived for self-containment; ζ(10), ζ(12) new), substitutes the Bernoulli values, and closes each by push_cast; ring after fixing (2k)!. Converts all six even zeta values ζ(2)…ζ(12) to tsum equalities. The 691 in ζ(12)'s numerator is the first arithmetic anomaly among the even zeta values.",
+      "mathContext": "ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!; ζ(12) numerator carries the irregular prime 691."
+    },
+    {
+      "id": "weight-10",
+      "title": "Weight-10 Reductions: Coefficients Still Tidy",
+      "startLine": 194,
+      "endLine": 229,
+      "summary": "Five product-reduction identities of total weight 10 — ζ(2)·ζ(8), ζ(4)·ζ(6), ζ(2)²·ζ(6), ζ(2)·ζ(4)², ζ(2)⁵ — each proved equal to a tidy rational multiple of ζ(10) (33/20, 11/10, 11/4, 77/40, 385/32) by rewriting the tsum closed forms and one ring step. The coefficients match the small-fraction pattern of the parent's weight ≤ 8 relations.",
+      "mathContext": "Each product lies in ℚ·π¹⁰ = ℚ·ζ(10); the coefficient is D₁₀/(product of the factors' denominators)."
+    },
+    {
+      "id": "weight-12",
+      "title": "Weight-12 Reductions: The Tidiness Breaks at 691",
+      "startLine": 230,
+      "endLine": 258,
+      "summary": "Three product-reduction identities of total weight 12 — ζ(6)², ζ(2)·ζ(10), ζ(4)·ζ(8) — each proved equal to a rational multiple of ζ(12). Because ζ(12) carries 691 in its numerator, every coefficient (715/691, 2275/1382 = (5²·7·13)/(2·691), 3003/2764 = (3·7·11·13)/(4·691)) carries 691 in its denominator — the first weight at which the reduction coefficients cease to be tidy.",
+      "mathContext": "ζ(12) = 691·π¹²/638512875; P/ζ(12) acquires 691 in its denominator, the fingerprint of the irregular prime."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 axioms, 0 sorries, no native_decide) extension of the even-zeta product-reduction pattern to weights 10 and 12: ζ(10) = π¹⁰/93555, ζ(12) = 691·π¹²/638512875, five tidy weight-10 relations, and three weight-12 relations whose coefficients (715/691, 2275/1382, 3003/2764) all carry the irregular prime 691.",
+    "implications": "The product-reduction phenomenon — a consequence of the one-dimensionality of the ring of even zeta values in each weight — never fails, but its coefficients encode the arithmetic of the Bernoulli numbers. Weight 12 is the first place this arithmetic becomes visible: the irregular prime 691, coprime to the rest of ζ(12), refuses to cancel and stamps itself on every reduction coefficient. This gives a concrete, machine-checked instance of how the 'elementary' even zeta values quietly carry the same deep arithmetic (irregular primes, Kummer's criterion, Ramanujan's τ congruence) that governs the odd/critical values, and marks the boundary of the tidy small-fraction regime the parent entry lived in.",
+    "openQuestions": [
+      "Continue to ζ(14) (B₁₄ = 7/6, still regular) and ζ(16), ζ(18), ζ(20) — B₂₀ = -174611/330 reintroduces the irregular pair 283·617 — to map exactly which weights have 'tidy' reduction coefficients and which carry irregular primes.",
+      "Prove a general theorem: for any multiset of even weights summing to 2m, the reduction coefficient of the corresponding product to ζ(2m) is the explicit rational built from the Bernoulli numbers, and characterize its prime factorization in terms of irregular primes.",
+      "Connect the 691 appearing here to the Eisenstein series E₁₂ and Ramanujan's congruence τ(n) ≡ σ₁₁(n) (mod 691), formalizing the modular-forms side of the same phenomenon."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry that evaluated ζ(2), ζ(4), ζ(6), ζ(8) via Euler's formula and proved the tidy weight ≤ 8 product reductions, stopping at weight 8 — exactly the pattern this entry extends to weights 10 and 12"
+    },
+    {
+      "targetId": "basel-problem-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry proving the stuffle relation ζ(2)² = ζ(4) + 2·ζ(2,2) from the double sum; both build on the parent's even-zeta framework, one toward multiple zeta values and this one toward higher single-zeta weights and their arithmetic"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "ancestor",
+      "description": "The Basel problem ζ(2) = π²/6, the base case of the even-zeta formula extended here to weight 12"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.NumberTheory.Bernoulli",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "BaselProblemOQ03OQ02",
+    "lineCount": 259,
+    "axiomCount": 0,
+    "theoremCount": 30,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "L. Euler",
+      "title": "De summis serierum reciprocarum",
+      "year": 1740,
+      "venue": "Comm. Acad. Sci. Petrop.",
+      "note": "Closed forms ζ(2k) = (rational)·π^{2k} via the Bernoulli numbers."
+    },
+    {
+      "authors": "E. E. Kummer",
+      "title": "Über eine allgemeine Eigenschaft der rationalen Entwicklungscoefficienten einer bestimmten Gattung analytischer Functionen",
+      "year": 1851,
+      "venue": "J. Reine Angew. Math. 41",
+      "note": "Irregular primes and the numerators of Bernoulli numbers; 691 is the numerator of B₁₂."
+    },
+    {
+      "authors": "S. Ramanujan",
+      "title": "On certain arithmetical functions",
+      "year": 1916,
+      "venue": "Trans. Cambridge Philos. Soc. 22",
+      "note": "The congruence τ(n) ≡ σ₁₁(n) (mod 691), the modular-forms manifestation of the same prime 691."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides hasSum_zeta_nat and the Bernoulli-number API (bernoulli'_def, bernoulli'_eq_zero_of_odd) underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry `basel-problem-oq-03-oq-02`, an open-question child of `basel-problem-oq-03` ("Multiple Zeta Values: relationship to single zeta values").

The parent evaluated ζ(2), ζ(4), ζ(6), ζ(8) and proved that every product of even zeta values collapses to a **tidy** rational multiple of a single even zeta value — stopping at weight 8. This entry answers the natural next open question: **how far does the product-reduction extend, and does the coefficient stay nice?**

## Results (`Proofs/BaselProblemOQ03OQ02.lean`, 30 theorems, 259 lines)

- **Bernoulli numbers** from the defining recursion (Mathlib stops at B₄): `B₁₀ = 5/66`, `B₁₂ = -691/2730`.
- **Closed forms** via `hasSum_zeta_nat`: `ζ(10) = π¹⁰/93555`, `ζ(12) = 691·π¹²/638512875`.
- **Five weight-10 reductions** with tidy coefficients: ζ(2)·ζ(8)=(33/20)ζ(10), ζ(4)·ζ(6)=(11/10)ζ(10), ζ(2)²·ζ(6)=(11/4)ζ(10), ζ(2)·ζ(4)²=(77/40)ζ(10), ζ(2)⁵=(385/32)ζ(10).
- **Three weight-12 reductions** whose coefficients all carry the **irregular prime 691** in the denominator: ζ(6)²=(715/691)ζ(12), ζ(2)·ζ(10)=(2275/1382)ζ(12), ζ(4)·ζ(8)=(3003/2764)ζ(12), with 1382=2·691, 2764=4·691.

## The point

The reduction never fails — it is forced by Euler's formula ζ(2k) ∈ ℚ·π^{2k}. But **weight 12 is the first place the tidiness breaks**: 691 (smallest irregular prime, numerator of B₁₂, modulus of Ramanujan's τ ≡ σ₁₁ congruence) sits in ζ(12)'s numerator, coprime to the denominator 638512875 = 3⁶·5³·7²·11·13, so it cannot cancel and stamps itself on every reduction coefficient. This gives a concrete, machine-checked instance of deep arithmetic hiding inside the "elementary" even zeta values.

## Verification

Verified with `lake env lean`: **0 sorries, 0 `axiom` declarations, no `native_decide`**. `#print axioms` on the main theorems shows only `propext`, `Classical.choice`, `Quot.sound` → **status: verified, axiomCount 0**.

Gallery data (`meta.json` + `annotations.json`, 6 annotations) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)