### PR TITLE
research(erdos-100-oq-02): repair broken parent chain + add gap-separation theorem

### DIFF
--- a/proofs/Proofs/Erdos100OQ02.lean
+++ b/proofs/Proofs/Erdos100OQ02.lean
@@ -52,9 +52,25 @@ theorem gk_bound_strictly_sublinear (c : ℝ) (hc : c > 0) :
     ∀ᶠ n : ℕ in atTop,
       c * ↑n / Real.log ↑n < c * ↑n := by
   filter_upwards [n_over_log_sublinear 1 (by norm_num)] with n hn
-  rw [mul_one] at hn
+  rw [one_mul] at hn
   rw [mul_div_assoc]
   exact mul_lt_mul_of_pos_left hn hc
+
+/--
+**The Guth–Katz shortfall factor vanishes.**
+
+The Guth–Katz bound `c·n/log n` is a `1/log n` fraction of the conjectured linear
+bound `c·n`, and this fraction tends to `0`.  Hence the two conjectured growth
+rates are not merely *eventually* distinct (`gk_bound_strictly_sublinear`) but
+asymptotically **separated**: the Guth–Katz route captures a vanishing proportion
+of the conjectured linear diameter.  This is the precise sense in which "the gap
+is a factor of `log n`" — an *unbounded* factor, which is exactly why closing the
+`Θ(n/log n)` vs `Θ(n)` gap in Erdős #100 is hard. -/
+theorem gk_shortfall_factor_tendsto_zero :
+    Tendsto (fun n : ℕ => 1 / Real.log n) atTop (nhds 0) := by
+  have hlog : Tendsto (fun n : ℕ => Real.log n) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  simpa only [one_div] using hlog.inv_tendsto_atTop
 
 
 end Erdos100OQ02

--- a/proofs/Proofs/Erdos100Problem.lean
+++ b/proofs/Proofs/Erdos100Problem.lean
@@ -293,12 +293,14 @@ theorem diam_ge_one (S : Finset (EuclideanSpace ℝ (Fin 2)))
   rw [dif_pos hne]
   exact le_trans hdist_ge1 (Finset.le_max' _ _ hmem)
 
-/--
+/-
 **Kanold's Bound**
 
 For any n-point integer distance set, diameter ≥ n^(3/4).
 
 Proved by pigeonhole counting on distance multiplicities.
+(Narrative only — no Lean declaration attaches here; see
+`conjecture_implies_kanold` below for the formalized Kanold-direction result.)
 -/
 /--
 **Guth-Katz Distinct Distances Theorem (2015)**
@@ -398,11 +400,12 @@ def IsCollinear (S : Set (EuclideanSpace ℝ (Fin 2))) : Prop :=
   ∃ (a b : EuclideanSpace ℝ (Fin 2)), a ≠ b ∧
     ∀ p ∈ S, ∃ t : ℝ, p = a + t • (b - a)
 
-/--
+/-
 **Erdős-Anning Theorem (1945)**
 
 If an infinite set of points in ℝ² has all pairwise distances
 being integers, then all points are collinear.
+(Narrative only — no Lean declaration attaches here.)
 -/
 /-
 ## The Conjecture Implies Kanold

--- a/research/problems/erdos-100-oq-02/knowledge.md
+++ b/research/problems/erdos-100-oq-02/knowledge.md
@@ -1,0 +1,47 @@
+# erdos-100-oq-02 — knowledge
+
+Erdős Problem #100, OQ-02: Distance-set diameter growth rate — is the minimum diameter of
+an n-point integer distance set Θ(n) (linear) or Θ(n/log n) (Guth–Katz)? **OPEN.** The gap
+between the two conjectured rates is exactly a factor of `log n`.
+File `Proofs/Erdos100OQ02.lean` (imports `Proofs.Erdos100Problem`). Gallery: axiomatized
+(2 axioms inherited from the parent: `guthKatz_distinct_distances`, `piepmeyer_construction`).
+
+## Session 2026-07-02 (researcher-4) — REPAIR + gap-separation theorem
+
+**Critical find: the whole `Erdos100Problem` chain did not compile.** The parent
+`Proofs/Erdos100Problem.lean` had **two orphaned `/--` doc-comments** — narrative prose
+("Kanold's Bound" at ~L296, "Erdős-Anning Theorem (1945)" at ~L401) with *no declaration
+attached*. A `/--` doc-comment must be followed by a decl, so the parser errored
+(`unexpected token '/--'; expected 'lemma'`). Because the parent never parsed, **no child
+was ever actually verified** despite the gallery marking them axiomatized/verified. This is
+the classic "orphan doc-comment drift" failure mode (cf. DenumerabilityRationalsOQ04). Fix:
+convert both orphan `/--` → `/-` (plain block comments). Parent then compiles EXIT 0,
+0 warnings, olean written.
+
+**Second latent bug (child):** `gk_bound_strictly_sublinear` used `rw [mul_one] at hn`
+where `hn : n/log n < 1 * n` — the pattern is `1 * n` (`one_mul`), not `n * 1` (`mul_one`).
+Fixed `mul_one → one_mul`. (Masked all this time because the parent never built.)
+
+**New theorem added:** `gk_shortfall_factor_tendsto_zero : Tendsto (fun n:ℕ => 1/Real.log n) atTop (nhds 0)`.
+Makes the "factor of log n" gap precise as an *asymptotic separation*: the Guth–Katz bound
+`c·n/log n` is a `1/log n` fraction of the conjectured linear `c·n`, and that fraction → 0,
+so the GK route captures a vanishing proportion of the conjectured linear diameter (an
+*unbounded* shortfall factor — exactly why the Θ(n/log n)-vs-Θ(n) gap is hard to close).
+Proof: `Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop` then `.inv_tendsto_atTop`,
+`simpa [one_div]`.
+
+Host-verified (`lean` vs main's Mathlib v4.26.0, parent+child EXIT 0, no sorry/warning);
+`#print axioms` on both `gk_shortfall_factor_tendsto_zero` and `gk_bound_strictly_sublinear`
+= `propext/Classical.choice/Quot.sound` only. File now 76L / 3 theorems / 0 own axioms /
+0 sorries. Parent's 2 axioms (guthKatz, piepmeyer) are deep external results (Guth–Katz 2015,
+Piepmeyer construction) — legitimately irreducible, not touched.
+
+**Also unblocked by the parent fix** (not fixed here, may have own issues): the sibling
+children `Erdos100OQ02OQ02.lean` and `AngleTrisection…Incomplete01Aristotle.lean` (both
+`import Proofs.Erdos100Problem`). Worth a follow-up mechanic pass to confirm they build.
+
+## Open direction
+The 2 parent axioms are the real content and are irreducible (Guth–Katz distinct-distances
+and the sharpness construction — neither is in Mathlib). No further axiom elimination is
+tractable here; the entry is now an honest, fully-compiling axiomatized formalization of the
+open growth-rate dichotomy.

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -30,9 +30,9 @@
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02.lean",
     "axiomCount": 2,
-    "lineCount": 60,
+    "lineCount": 76,
     "assumptions": "2 axioms inherited from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015 Ω(n/log n) distinct distances bound), piepmeyer_construction (construction showing sharpness). 0 own axioms. 0 sorries.",
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "sections": [
@@ -126,9 +126,9 @@
       "Set"
     ],
     "namespace": "Erdos100OQ02",
-    "lineCount": 60,
+    "lineCount": 76,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/Erdos100OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Erdős #100 OQ-02 — distance-set diameter growth-rate dichotomy

### Critical find: the `Erdos100Problem` chain never compiled
The gallery marks `erdos-100-oq-02` (and its parent `erdos-100`) as axiomatized/verified, but **neither had ever actually parsed**. The parent `Proofs/Erdos100Problem.lean` contained **two orphaned `/--` doc-comments** — narrative prose ("Kanold's Bound", "Erdős-Anning Theorem (1945)") with *no declaration attached*. A `/--` doc-comment must be followed by a declaration, so Lean errored with `unexpected token '/--'; expected 'lemma'`, and every child importing the parent inherited the failure. This is the "orphan doc-comment drift" failure mode.

### Fixes
- **Parent** `Erdos100Problem.lean`: converted both orphan `/--` → `/-` plain block comments (they describe theorems that do not exist in the file — pure narrative). Parent now compiles **EXIT 0, 0 warnings**.
- **Child** `Erdos100OQ02.lean`: pre-existing bug in `gk_bound_strictly_sublinear` — `rw [mul_one] at hn` where `hn : n/log n < 1 * n`; the pattern is `1 * n` (`one_mul`), not `n * 1`. Fixed `mul_one → one_mul`. Masked until now because the broken parent meant the child was never built.

### New theorem
```lean
theorem gk_shortfall_factor_tendsto_zero :
    Tendsto (fun n : ℕ => 1 / Real.log n) atTop (nhds 0)
```
Makes "the gap is a factor of `log n`" precise as an **asymptotic separation**: the Guth–Katz bound `c·n/log n` is a `1/log n` fraction of the conjectured linear `c·n`, and that fraction tends to `0` — an *unbounded* shortfall factor. This is exactly why the `Θ(n/log n)` vs `Θ(n)` dichotomy in Erdős #100 remains open. Proof: `Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop` then `.inv_tendsto_atTop`.

### Verification
Host-verified with `lean` against pinned Mathlib v4.26.0 (Docker infra down): **parent + child both EXIT 0, no sorry, no warnings**. `#print axioms` on both the new theorem and the fixed `gk_bound_strictly_sublinear` = `propext, Classical.choice, Quot.sound` only.

### Status
- Child now **76L / 3 theorems / 0 own axioms / 0 sorries**. `meta.json` counts updated (theoremCount 2→3, lineCount 60→76).
- Parent's 2 axioms (Guth–Katz 2015 distinct-distances, Piepmeyer sharpness construction) are deep external results — legitimately irreducible, untouched. Entry stays `axiomatized`.
- The parent fix also **unblocks siblings** `Erdos100OQ02OQ02.lean` and one `AngleTrisection…Aristotle.lean` (both import the same parent) — worth a follow-up mechanic pass to confirm they build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)