### PR TITLE
research(erdos-671): reduce orphan pointwise crux to a pure integer inequality

### DIFF
--- a/proofs/Proofs/Erdos671EquidistantOrphan.lean
+++ b/proofs/Proofs/Erdos671EquidistantOrphan.lean
@@ -164,6 +164,39 @@ theorem node_sub_node (n : ℕ) (hn : n ≥ 2) (i j : Fin n) :
   ring
 
 /--
+  MIDPOINT BASIS TERM AS AN INTEGER RATIO PRODUCT.
+
+  Substituting the two node-difference formulas into `abs_lagrangeBasis_eval`
+  cancels the common `1/(n-1)` scale in every factor, leaving a product of purely
+  *integer* ratios:
+  `|p_m(x*)| = ∏_{j ≠ m} |2j - 1| / (2 · |m - j|)`.
+
+  This is the key simplification: it removes ALL analytic / `(n-1)` structure, so
+  the residual pointwise bound becomes a finite inequality about integers only.
+  From here `∏_{j≠m} |2j-1| = (2n-3)!! / |2m-1|` and `∏_{j≠m} |m-j| = m!·(n-1-m)!`
+  recover the factorial closed form, but the ratio product itself is already the
+  cleanest object for the numeric estimate.
+-/
+theorem abs_lagrangeBasis_midPoint (n : ℕ) (hn : n ≥ 2) (m : Fin n) :
+    |(lagrangeBasis (equidistantNodes n hn) m).eval (midPoint n)| =
+      ∏ j ∈ (Finset.univ : Finset (Fin n)).filter (fun k => k ≠ m),
+        |2 * (j.val : ℝ) - 1| / (2 * |(m.val : ℝ) - (j.val : ℝ)|) := by
+  have hn_cast : (1 : ℝ) < (n : ℝ) := by exact_mod_cast Nat.lt_of_lt_of_le one_lt_two hn
+  have hn1_pos : (0 : ℝ) < (n : ℝ) - 1 := by linarith
+  rw [abs_lagrangeBasis_eval]
+  apply Finset.prod_congr rfl
+  intro j _
+  rw [midPoint_sub_node n hn j, node_sub_node n hn m j]
+  -- `|(1 - 2j)/(n-1)| / |2(m-j)/(n-1)| = |2j - 1| / (2 |m - j|)`
+  have e1 : |(1 - 2 * (j.val : ℝ)) / ((n : ℝ) - 1)|
+      = |2 * (j.val : ℝ) - 1| / ((n : ℝ) - 1) := by
+    rw [abs_div, abs_of_pos hn1_pos, abs_sub_comm]
+  have e2 : |2 * ((m.val : ℝ) - (j.val : ℝ)) / ((n : ℝ) - 1)|
+      = 2 * |(m.val : ℝ) - (j.val : ℝ)| / ((n : ℝ) - 1) := by
+    rw [abs_div, abs_of_pos hn1_pos, abs_mul, abs_two]
+  rw [e1, e2, div_div_div_cancel_right₀ hn1_pos.ne']
+
+/--
   POINTWISE LEBESGUE LOWER BOUND (the mathematical heart of `equidistant_diverges`).
 
   At the midpoint x* = -1 + 1/(n-1) of the first equidistant subinterval, the
@@ -171,21 +204,28 @@ theorem node_sub_node (n : ℕ) (hn : n ≥ 2) (i j : Fin n) :
 
   The polynomial reduction is now fully discharged: `lebesgueFunction_ge_single`
   reduces the goal to producing a single index `m` whose basis term reaches the
-  target, and `abs_lagrangeBasis_eval` + `midPoint_sub_node` + `node_sub_node`
-  express that term as the explicit factorial ratio
-  `(2n-3)!! / (|2m-1| · 2^(n-1) · m! · (n-1-m)!)`.
+  target, and `abs_lagrangeBasis_midPoint` rewrites that term as the integer
+  ratio product `∏_{j≠m} |2j-1| / (2·|m-j|)`.
 
-  The remaining sorry is therefore a PURE FINITE REAL-ARITHMETIC inequality:
-  the existence of a central index `m ≈ ⌊(n-2)/2⌋` whose ratio is `≥ 2^(n-1)/n^2`.
+  The remaining sorry is therefore a PURE INTEGER inequality with NO analytic or
+  `(n-1)` content: the existence of a central index `m ≈ ⌊(n-2)/2⌋` whose ratio
+  product is `≥ 2^(n-1)/n^2`. Equivalently the factorial inequality
+  `(2n-3)!! · n^2 ≥ |2m-1| · 2^(2n-2) · m! · (n-1-m)!`.
   Verified numerically for n = 2..25 (verify-equidistant-bound.py).
 -/
 theorem lebesgueFunction_midPoint_ge (n : ℕ) (hn : n ≥ 2) :
     lebesgueFunction (equidistantNodes n hn) (midPoint n) ≥ 2 ^ (n - 1) / (n : ℝ) ^ 2 := by
-  -- Reduce to a single central index, then to the explicit factorial ratio.
+  -- Reduce to a single central index, then (via `abs_lagrangeBasis_midPoint`) to
+  -- a pure integer-ratio inequality.
   obtain ⟨m, hm⟩ : ∃ m : Fin n,
       2 ^ (n - 1) / (n : ℝ) ^ 2
         ≤ |(lagrangeBasis (equidistantNodes n hn) m).eval (midPoint n)| := by
-    sorry
+    obtain ⟨m, hm⟩ : ∃ m : Fin n,
+        2 ^ (n - 1) / (n : ℝ) ^ 2 ≤
+          ∏ j ∈ (Finset.univ : Finset (Fin n)).filter (fun k => k ≠ m),
+            |2 * (j.val : ℝ) - 1| / (2 * |(m.val : ℝ) - (j.val : ℝ)|) := by
+      sorry
+    exact ⟨m, by rw [abs_lagrangeBasis_midPoint n hn m]; exact hm⟩
   exact le_trans hm (lebesgueFunction_ge_single _ _ m)
 
 end Erdos671Orphan

--- a/research/problems/erdos-671/knowledge.md
+++ b/research/problems/erdos-671/knowledge.md
@@ -15,6 +15,44 @@ Can Lagrange interpolation converge pointwise at a point x where the Lebesgue fu
 **Known**: Bernstein (1931): ∃ x₀ with limsup λ_n(x₀) = ∞ for any sequence.
 **Known**: Erdős-Vértesi (1980): ∃ continuous f with |L^n f(x)| → ∞ a.e. for any sequence.
 
+## Session 2026-07-02 (Session 8) — orphan residual reduced to a PURE INTEGER inequality (all analytic/(n-1) content eliminated)
+
+**Mode**: REVISIT (researcher-16). **Outcome**: real build-verified progress on the
+*orphan* (`Erdos671EquidistantOrphan.lean`). Registered gallery file unchanged
+(still axiomatized: 3 axioms + 7 sorries). Verified via `lake env lean` against the
+cached Mathlib v4.26.0 oleans (Docker/Aristotle not used; disk at 99%, so the
+single-file `lake env lean` route was chosen — it works under disk pressure).
+
+- **New build-verified lemma `abs_lagrangeBasis_midPoint`.** Substituting
+  `midPoint_sub_node` and `node_sub_node` into `abs_lagrangeBasis_eval` cancels
+  the common `1/(n-1)` scale in EVERY factor (via `div_div_div_cancel_right₀`),
+  proving the exact identity
+  `|p_m(x*)| = ∏_{j≠m} |2j-1| / (2·|m-j|)`.
+  Per-factor proof: `abs_div` + `abs_of_pos (n-1>0)` + `abs_sub_comm`
+  (`|1-2j| = |2j-1|`) + `abs_mul`/`abs_two` (`|2(m-j)| = 2|m-j|`), then the
+  group-with-zero cancellation. No `m≠j` side condition is needed — the identity
+  is structural.
+- **The single residual sorry is now a PURE INTEGER inequality**, with zero
+  analytic or `(n-1)` content:
+  `∃ m : Fin n, 2^(n-1)/n² ≤ ∏_{j≠m} |2j-1| / (2·|m-j|)`.
+  Equivalent factorial form: `(2n-3)!!·n² ≥ |2m-1|·2^(2n-2)·m!·(n-1-m)!` at a
+  central `m ≈ ⌊(n-2)/2⌋`. `lebesgueFunction_midPoint_ge` now threads this
+  through `abs_lagrangeBasis_midPoint` + `lebesgueFunction_ge_single`, so closing
+  the integer inequality closes the whole pointwise bound with no further analysis.
+- **Not attempted this session**: the integer inequality itself. It requires
+  choosing the optimal central index and a double-factorial induction — a
+  self-contained but nontrivial finite-combinatorics task (good future target;
+  numerics confirm it for n=2..25). Aristotle not tried (a hard parametrized
+  existential inequality is outside its comfort zone, per prior sessions).
+
+### Lean gotchas recorded
+- `div_div_div_cancel_right₀ (hc : c ≠ 0) : a/c/(b/c) = a/b` — pass `hn1_pos.ne'`.
+- `abs_two : |(2:ℝ)| = 2`; `abs_sub_comm a b : |a-b| = |b-a|` (turns `|1-2j|` into
+  `|2j-1|`).
+- The `m≠j` filter membership was initially threaded to prove `(m:ℝ)-(j:ℝ)≠0`, but
+  it is UNUSED — the factor identity holds even where `m=j` (excluded by the
+  filter anyway), so `intro j _` suffices.
+
 ## Session 2026-06-28 (Session 7) — orphan BUILD-VERIFIED; pointwise sorry decomposed into a pure arithmetic core
 
 **Mode**: REVISIT (researcher-2). **Outcome**: real verified progress on the *orphan*


### PR DESCRIPTION
## Summary

Build-verified incremental progress on **Erdős #671** ($250 open problem, Lagrange interpolation convergence). Works on the *unregistered orphan* `proofs/Proofs/Erdos671EquidistantOrphan.lean` that isolates the one self-contained supporting estimate (`equidistant_diverges`); the **registered gallery entry is unchanged** (still axiomatized, 3 axioms + 7 deep sorries).

### What's new
- New lemma **`abs_lagrangeBasis_midPoint`**: substituting the node-difference formulas into `abs_lagrangeBasis_eval` cancels the common `1/(n-1)` scale in every factor (via `div_div_div_cancel_right₀`), proving the exact identity
  ```
  |p_m(x*)| = ∏_{j≠m} |2j-1| / (2·|m-j|).
  ```
- The single residual `sorry` is now a **pure integer inequality** with zero analytic / `(n-1)` content:
  ```
  ∃ m : Fin n, 2^(n-1)/n² ≤ ∏_{j≠m} |2j-1| / (2·|m-j|)
  ```
  (equivalently `(2n-3)!!·n² ≥ |2m-1|·2^(2n-2)·m!·(n-1-m)!` at a central `m ≈ ⌊(n-2)/2⌋`; numerics confirm n=2..25). `lebesgueFunction_midPoint_ge` threads through the new identity, so closing this integer inequality closes the whole pointwise bound with no further analysis.

### Verification
- Verified via `lake env lean` against cached Mathlib v4.26.0 oleans. Only the one intended `sorry` remains (the integer inequality); no new axioms; no changes to the registered entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)