### PR TITLE
research(central-limit-theorem-oq-01-oq-01-oq-01): regular-variation index is a well-defined asymptotic invariant [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,271 @@
+/-
+  The Regular-Variation Index is a Well-Defined Asymptotic Invariant
+  Open Question: central-limit-theorem-oq-01-oq-01-oq-01
+
+  This file is a follow-up to the Gnedenko-Kolmogorov domain-of-attraction
+  formalization (central-limit-theorem-oq-01-oq-01). There, the tail of a
+  distribution in the domain of attraction of an α-stable law is described by a
+  regularly varying function with index -α, and the stability parameter α is the
+  central invariant of the whole theory.
+
+  Here we prove that this index is *intrinsic*: it is a uniquely determined,
+  additive, and rigid asymptotic invariant of the function.
+
+  Main results:
+  * `regularlyVarying_index_unique`   — a function is regularly varying with at
+                                        most one index (the index is well-defined).
+  * `slowlyVarying_iff_regularlyVarying_zero`
+                                      — slowly varying = regularly varying of index 0.
+  * `slowlyVarying_regularlyVarying_index`
+                                      — the only possible index of a slowly
+                                        varying function is 0.
+  * `rpow_regularlyVarying`           — `x ↦ x^α` is regularly varying with
+                                        index α (the model example).
+  * `rpow_slowlyVarying_iff`          — `x ↦ x^α` is slowly varying ⇔ α = 0
+                                        (sharp non-example).
+  * `not_slowlyVarying_id`            — the identity `x ↦ x` is not slowly varying.
+  * `regularlyVarying_mul_index`      — the index is *additive* under pointwise
+                                        products: index(f·g) = index f + index g,
+                                        i.e. the index is a homomorphism into (ℝ,+).
+  * `regularlyVarying_of_asymp_equiv` — regular variation (with its index) is
+                                        preserved under asymptotic equivalence.
+  * `regularlyVarying_asymp_equiv_same_index`
+                                      — asymptotically equivalent regularly
+                                        varying functions share the same index.
+
+  Together these say: the stability/tail index of a domain-of-attraction
+  distribution is a genuine invariant — unique, additive, and unchanged by
+  asymptotically negligible perturbations.
+
+  The file is self-contained (imports only Mathlib) and axiom-free.
+
+  References:
+  - Gnedenko & Kolmogorov, "Limit Distributions for Sums of Independent
+    Random Variables" (1954)
+  - Bingham, Goldie & Teugels, "Regular Variation" (1987), Ch. 1
+  - Feller, "An Introduction to Probability Theory", Vol. 2, Ch. VIII, XVII
+-/
+
+import Mathlib
+
+open Filter Topology Real
+
+set_option maxHeartbeats 400000
+
+noncomputable section
+
+namespace DomainOfAttractionIndex
+
+-- ============================================================================
+-- Definitions (mirroring central-limit-theorem-oq-01-oq-01, kept local so the
+-- file is self-contained and axiom-free)
+-- ============================================================================
+
+/-- A function `L : ℝ → ℝ` is slowly varying at infinity if for every positive
+    scaling factor `c`, the ratio `L(cx)/L(x) → 1` as `x → +∞`. -/
+def SlowlyVarying (L : ℝ → ℝ) : Prop :=
+  (∀ x, 0 < x → L x ≠ 0) ∧
+  ∀ c : ℝ, 0 < c → Tendsto (fun x => L (c * x) / L x) atTop (𝓝 1)
+
+/-- A function is regularly varying with index `α` if the ratio
+    `f(cx)/f(x) → c^α` as `x → +∞` for every `c > 0`. -/
+def RegularlyVarying (f : ℝ → ℝ) (α : ℝ) : Prop :=
+  (∀ x, 0 < x → f x ≠ 0) ∧
+  ∀ c : ℝ, 0 < c → Tendsto (fun x => f (c * x) / f x) atTop (𝓝 (c ^ α))
+
+/-- A positive constant function is slowly varying. -/
+theorem slowlyVarying_const {a : ℝ} (ha : 0 < a) :
+    SlowlyVarying (fun _ => a) := by
+  refine ⟨fun _ _ => ne_of_gt ha, ?_⟩
+  intro c _
+  simp only [div_self (ne_of_gt ha)]
+  exact tendsto_const_nhds
+
+-- ============================================================================
+-- Part I: The index is well-defined (uniqueness)
+-- ============================================================================
+
+/-- **Uniqueness of the regular-variation index.** A function can be regularly
+    varying with at most one index. This is what makes "the index of `f`" a
+    well-defined notion.
+
+    Proof: evaluate the defining limit at `c = 2`. The ratio `f(2x)/f(x)`
+    converges to both `2^α` and `2^β`, so `2^α = 2^β` by uniqueness of limits;
+    taking logarithms and cancelling `log 2 ≠ 0` gives `α = β`. -/
+theorem regularlyVarying_index_unique {f : ℝ → ℝ} {α β : ℝ}
+    (hα : RegularlyVarying f α) (hβ : RegularlyVarying f β) : α = β := by
+  have h2 : (0 : ℝ) < 2 := by norm_num
+  have ha := hα.2 2 h2
+  have hb := hβ.2 2 h2
+  have hpow : (2 : ℝ) ^ α = (2 : ℝ) ^ β := tendsto_nhds_unique ha hb
+  have hlog := congrArg Real.log hpow
+  rw [Real.log_rpow h2, Real.log_rpow h2] at hlog
+  have hlog2 : Real.log 2 ≠ 0 := ne_of_gt (Real.log_pos (by norm_num))
+  exact mul_right_cancel₀ hlog2 hlog
+
+-- ============================================================================
+-- Part II: Slowly varying = index 0
+-- ============================================================================
+
+/-- Slowly varying functions are exactly the regularly varying functions of
+    index `0` (`c^0 = 1`). -/
+theorem slowlyVarying_iff_regularlyVarying_zero {L : ℝ → ℝ} :
+    SlowlyVarying L ↔ RegularlyVarying L 0 := by
+  constructor
+  · rintro ⟨h1, h2⟩
+    refine ⟨h1, fun c hc => ?_⟩
+    simpa [Real.rpow_zero] using h2 c hc
+  · rintro ⟨h1, h2⟩
+    refine ⟨h1, fun c hc => ?_⟩
+    simpa [Real.rpow_zero] using h2 c hc
+
+/-- The only index a slowly varying function can have is `0`. -/
+theorem slowlyVarying_regularlyVarying_index {L : ℝ → ℝ} {α : ℝ}
+    (hSV : SlowlyVarying L) (hRV : RegularlyVarying L α) : α = 0 :=
+  regularlyVarying_index_unique hRV (slowlyVarying_iff_regularlyVarying_zero.mp hSV)
+
+-- ============================================================================
+-- Part III: The model example `x ↦ x^α` and sharpness
+-- ============================================================================
+
+/-- The power function `x ↦ x^α` is regularly varying with index `α`.
+    This is the canonical example and shows every real number occurs as an index. -/
+theorem rpow_regularlyVarying (α : ℝ) :
+    RegularlyVarying (fun x => x ^ α) α := by
+  refine ⟨fun x hx => ne_of_gt (Real.rpow_pos_of_pos hx α), ?_⟩
+  intro c hc
+  have heq : (fun x : ℝ => (c * x) ^ α / x ^ α) =ᶠ[atTop] (fun _ => c ^ α) := by
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    rw [Real.mul_rpow (le_of_lt hc) (le_of_lt hx), mul_div_assoc,
+        div_self (ne_of_gt (Real.rpow_pos_of_pos hx α)), mul_one]
+  exact Tendsto.congr' heq.symm tendsto_const_nhds
+
+/-- **Sharp non-example.** The power function `x ↦ x^α` is slowly varying if and
+    only if `α = 0`. Any nonzero exponent breaks slow variation. -/
+theorem rpow_slowlyVarying_iff {α : ℝ} :
+    SlowlyVarying (fun x => x ^ α) ↔ α = 0 := by
+  constructor
+  · intro h
+    exact regularlyVarying_index_unique (rpow_regularlyVarying α)
+      (slowlyVarying_iff_regularlyVarying_zero.mp h)
+  · intro hα
+    subst hα
+    have hfun : (fun x : ℝ => x ^ (0 : ℝ)) = (fun _ => (1 : ℝ)) := by
+      ext x; exact Real.rpow_zero x
+    rw [hfun]
+    exact slowlyVarying_const (by norm_num)
+
+/-- The identity function `x ↦ x` (index `1`) is not slowly varying: the ratio
+    `(2x)/x → 2 ≠ 1`. -/
+theorem not_slowlyVarying_id : ¬ SlowlyVarying (fun x => x) := by
+  intro h
+  have h2 := h.2 2 (by norm_num)
+  have heq : (fun x : ℝ => 2 * x / x) =ᶠ[atTop] (fun _ => (2 : ℝ)) := by
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    rw [mul_div_assoc, div_self (ne_of_gt hx), mul_one]
+  have hconst : Tendsto (fun _ : ℝ => (2 : ℝ)) atTop (𝓝 1) := h2.congr' heq
+  have : (1 : ℝ) = 2 := tendsto_nhds_unique hconst tendsto_const_nhds
+  norm_num at this
+
+-- ============================================================================
+-- Part IV: The index is additive (a homomorphism into (ℝ, +))
+-- ============================================================================
+
+/-- **Additivity of the index.** The index of a pointwise product is the sum of
+    the indices: `index (f·g) = index f + index g`. Combined with uniqueness this
+    exhibits the index as a homomorphism from (regularly varying functions under
+    pointwise multiplication) into `(ℝ, +)`. -/
+theorem regularlyVarying_mul_index {f g : ℝ → ℝ} {α β : ℝ}
+    (hf : RegularlyVarying f α) (hg : RegularlyVarying g β) :
+    RegularlyVarying (fun x => f x * g x) (α + β) := by
+  refine ⟨fun x hx => mul_ne_zero (hf.1 x hx) (hg.1 x hx), ?_⟩
+  intro c hc
+  have key : (fun x => f (c * x) * g (c * x) / (f x * g x)) =ᶠ[atTop]
+      (fun x => f (c * x) / f x * (g (c * x) / g x)) := by
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    have hfx := hf.1 x hx
+    have hgx := hg.1 x hx
+    field_simp
+  rw [Real.rpow_add hc]
+  exact Tendsto.congr' key.symm ((hf.2 c hc).mul (hg.2 c hc))
+
+-- ============================================================================
+-- Part V: Rigidity — regular variation is preserved by asymptotic equivalence
+-- ============================================================================
+
+/-- **Rigidity under asymptotic equivalence.** If `f` is regularly varying with
+    index `α` and `g` is asymptotically equivalent to `f` (i.e. `f/g → 1`, with
+    `g` nonvanishing on the positives), then `g` is also regularly varying with
+    the *same* index `α`.
+
+    Proof: decompose `g(cx)/g(x) = (f(cx)/f(x))·(f(x)/g(x))·(g(cx)/f(cx))`. The
+    first factor tends to `c^α`; the second is `f/g → 1`; the third is the
+    reciprocal of `f/g` precomposed with the scaling `x ↦ cx` (which tends to
+    infinity), hence also `→ 1`. -/
+theorem regularlyVarying_of_asymp_equiv {f g : ℝ → ℝ} {α : ℝ}
+    (hf : RegularlyVarying f α)
+    (hg_pos : ∀ x, 0 < x → g x ≠ 0)
+    (hfg : Tendsto (fun x => f x / g x) atTop (𝓝 1)) :
+    RegularlyVarying g α := by
+  refine ⟨hg_pos, ?_⟩
+  intro c hc
+  have hcx : Tendsto (fun x : ℝ => c * x) atTop atTop :=
+    Filter.Tendsto.const_mul_atTop hc tendsto_id
+  have p1 : Tendsto (fun x => f (c * x) / f x) atTop (𝓝 (c ^ α)) := hf.2 c hc
+  have p2 : Tendsto (fun x => f x / g x) atTop (𝓝 1) := hfg
+  have p3 : Tendsto (fun x => g (c * x) / f (c * x)) atTop (𝓝 1) := by
+    have hfg2 : Tendsto (fun x => f (c * x) / g (c * x)) atTop (𝓝 1) := hfg.comp hcx
+    have hinv := hfg2.inv₀ (one_ne_zero)
+    rw [inv_one] at hinv
+    exact hinv.congr (fun x => inv_div _ _)
+  have hprod : Tendsto
+      (fun x => f (c * x) / f x * (f x / g x) * (g (c * x) / f (c * x)))
+      atTop (𝓝 (c ^ α * 1 * 1)) := (p1.mul p2).mul p3
+  simp only [mul_one] at hprod
+  refine Tendsto.congr' ?_ hprod
+  filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+  have hfx := hf.1 x hx
+  have hgx := hg_pos x hx
+  have hfcx := hf.1 (c * x) (mul_pos hc hx)
+  field_simp
+
+/-- Asymptotically equivalent regularly varying functions have equal indices. -/
+theorem regularlyVarying_asymp_equiv_same_index {f g : ℝ → ℝ} {α β : ℝ}
+    (hf : RegularlyVarying f α) (hg : RegularlyVarying g β)
+    (hfg : Tendsto (fun x => f x / g x) atTop (𝓝 1)) : α = β :=
+  regularlyVarying_index_unique
+    (regularlyVarying_of_asymp_equiv hf hg.1 hfg) hg
+
+-- ============================================================================
+-- Part VI: Corollaries tying the invariant back to the domain-of-attraction
+-- picture
+-- ============================================================================
+
+/-- The reciprocal of a regularly varying function negates the index:
+    `index (1/f) = -index f`. A special case of additivity, since
+    `f · (1/f) = 1` has index `0`. -/
+theorem regularlyVarying_inv_index {f : ℝ → ℝ} {α : ℝ}
+    (hf : RegularlyVarying f α) :
+    RegularlyVarying (fun x => (f x)⁻¹) (-α) := by
+  refine ⟨fun x hx => inv_ne_zero (hf.1 x hx), ?_⟩
+  intro c hc
+  have key : (fun x => (f (c * x))⁻¹ / (f x)⁻¹) =ᶠ[atTop]
+      (fun x => (f (c * x) / f x)⁻¹) := by
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with _ _
+    rw [inv_div_inv, inv_div]
+  rw [Real.rpow_neg (le_of_lt hc)]
+  refine Tendsto.congr' key.symm ?_
+  exact (hf.2 c hc).inv₀ (by positivity)
+
+/-- A slowly varying correction factor does not change the index: multiplying a
+    regularly varying function of index `α` by a slowly varying function keeps
+    the index at `α`. This is the precise sense in which the index "sees only the
+    power-law part" of a domain-of-attraction tail. -/
+theorem regularlyVarying_mul_slowlyVarying {f L : ℝ → ℝ} {α : ℝ}
+    (hf : RegularlyVarying f α) (hL : SlowlyVarying L) :
+    RegularlyVarying (fun x => f x * L x) α := by
+  have hL0 : RegularlyVarying L 0 := slowlyVarying_iff_regularlyVarying_zero.mp hL
+  have := regularlyVarying_mul_index hf hL0
+  simpa using this
+
+end DomainOfAttractionIndex

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-clt-oq010101-intro",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "significance": "supporting",
+    "title": "Why the Tail Index Must Be an Invariant",
+    "content": "In the Gnedenko-Kolmogorov theory (parent entry) a heavy tail P(|X|>x) is regularly varying with index -α, and α is the stability parameter of the limiting stable law. For this to make sense, 'the index' must be a genuine property of the tail — not of the particular formula used to write it, and not ambiguous. This file establishes exactly that: the regular-variation index is unique, additive, and rigid under asymptotic equivalence. The definitions of SlowlyVarying (L(cx)/L(x) → 1 for every c > 0) and RegularlyVarying (f(cx)/f(x) → c^α) are kept local so the file is self-contained and axiom-free.",
+    "prerequisites": ["regular variation", "domain of attraction", "stable distributions"],
+    "relatedConcepts": ["Gnedenko-Kolmogorov theorem", "tail index", "slowly varying functions", "asymptotic invariant"],
+    "mathContext": "A distribution is in the domain of attraction of an $\\alpha$-stable law iff its tail $x \\mapsto P(|X|>x)$ is regularly varying with index $-\\alpha$. The index $-\\alpha$ is the object shown here to be intrinsic."
+  },
+  {
+    "id": "ann-clt-oq010101-unique",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 105 },
+    "type": "insight",
+    "significance": "critical",
+    "title": "Uniqueness from a Single Scaling Factor",
+    "content": "regularlyVarying_index_unique proves a function has at most one index. The trick: you do not need all c > 0 — one value suffices. Specializing to c = 2, the ratio f(2x)/f(x) converges to both 2^α and 2^β, so uniqueness of limits (tendsto_nhds_unique) gives 2^α = 2^β. Taking logarithms turns this into α·log 2 = β·log 2, and since log 2 ≠ 0 we cancel to get α = β. Injectivity of a ↦ 2^a is the whole content.",
+    "prerequisites": ["uniqueness of limits", "real power function", "logarithm"],
+    "relatedConcepts": ["tendsto_nhds_unique", "injectivity of exponentials", "well-definedness"],
+    "mathContext": "From $2^\\alpha = 2^\\beta$: $\\log(2^\\alpha) = \\alpha \\log 2 = \\beta \\log 2 = \\log(2^\\beta)$, and $\\log 2 \\neq 0$ gives $\\alpha = \\beta$."
+  },
+  {
+    "id": "ann-clt-oq010101-index-zero",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 126 },
+    "type": "insight",
+    "significance": "key",
+    "title": "Slowly Varying = Index 0",
+    "content": "slowlyVarying_iff_regularlyVarying_zero identifies the slowly varying functions with the index-0 layer of regular variation (because c^0 = 1). Combined with uniqueness, slowlyVarying_regularlyVarying_index concludes that 0 is the only index a slowly varying function can have. This grades the theory: RegularlyVarying(·, α) is a family of layers, and slow variation is precisely the α = 0 slice — the 'correction factors' that carry no power-law growth.",
+    "prerequisites": ["slowly varying functions", "regular variation"],
+    "relatedConcepts": ["graded structure", "correction factors", "c^0 = 1"],
+    "mathContext": "$L$ slowly varying $\\iff$ $L$ regularly varying of index $0$, since $L(cx)/L(x) \\to 1 = c^0$."
+  },
+  {
+    "id": "ann-clt-oq010101-model",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 127, "endLine": 159 },
+    "type": "concept",
+    "significance": "key",
+    "title": "The Model Example x^α and a Sharp Boundary",
+    "content": "rpow_regularlyVarying shows x ↦ x^α has index α (via (cx)^α = c^α x^α, so the ratio is the constant c^α), so every real number is realized as an index. rpow_slowlyVarying_iff is the sharp companion: x^α is slowly varying if and only if α = 0. The forward direction combines the model example with uniqueness; the reverse uses x^0 = 1. This proves the slowly varying class is not accidentally large — among pure powers it contains only the constants.",
+    "prerequisites": ["real power function", "mul_rpow"],
+    "relatedConcepts": ["Pareto tail", "power law", "sharp boundary", "canonical example"],
+    "mathContext": "$x^\\alpha$ is regularly varying of index $\\alpha$; it is slowly varying iff $\\alpha = 0$. Every $\\alpha \\in \\mathbb{R}$ occurs as an index."
+  },
+  {
+    "id": "ann-clt-oq010101-not-id",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 160, "endLine": 169 },
+    "type": "concept",
+    "significance": "supporting",
+    "title": "The Identity Is Not Slowly Varying",
+    "content": "not_slowlyVarying_id records the simplest failure: for f(x) = x the ratio f(cx)/f(x) = (2x)/x is eventually the constant 2, which cannot converge to 1. This is the α = 1 endpoint of the sharp boundary above and a concrete witness that slow variation is a real restriction, not vacuous.",
+    "prerequisites": ["limits", "regular variation"],
+    "relatedConcepts": ["index 1", "non-example", "counterexample"],
+    "mathContext": "For $f(x) = x$: $f(2x)/f(x) = 2 \\not\\to 1$, so $x \\mapsto x$ is regularly varying of index $1$, not slowly varying."
+  },
+  {
+    "id": "ann-clt-oq010101-additivity",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 170, "endLine": 191 },
+    "type": "insight",
+    "significance": "key",
+    "title": "The Index Is a Homomorphism into (ℝ, +)",
+    "content": "regularlyVarying_mul_index proves index(f·g) = index f + index g. The product ratio f(cx)g(cx)/(f(x)g(x)) factors as (f(cx)/f(x))·(g(cx)/g(x)), whose limits multiply to c^α·c^β = c^(α+β) (Real.rpow_add). With uniqueness, this makes 'the index' a group homomorphism from the regularly varying functions under pointwise multiplication into (ℝ, +) — the reason the index behaves like a logarithm of tail growth. The corollaries regularlyVarying_inv_index (reciprocal negates the index) and regularlyVarying_mul_slowlyVarying (a slowly varying factor leaves it unchanged) are immediate consequences.",
+    "prerequisites": ["rpow_add", "product of limits"],
+    "relatedConcepts": ["group homomorphism", "logarithm of growth", "additivity"],
+    "mathContext": "$\\operatorname{index}(f \\cdot g) = \\operatorname{index} f + \\operatorname{index} g$, using $c^{\\alpha+\\beta} = c^\\alpha c^\\beta$; the index is a homomorphism into $(\\mathbb{R},+)$."
+  },
+  {
+    "id": "ann-clt-oq010101-rigidity",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 192, "endLine": 238 },
+    "type": "insight",
+    "significance": "critical",
+    "title": "Rigidity: Regular Variation Survives Asymptotic Equivalence",
+    "content": "regularlyVarying_of_asymp_equiv is the substantive result. If f is regularly varying with index α and g satisfies f/g → 1 (asymptotic equivalence), then g is regularly varying with the SAME index α. The proof writes g(cx)/g(x) = (f(cx)/f(x))·(f(x)/g(x))·(g(cx)/f(cx)). The first factor → c^α; the second is the hypothesis f/g → 1; the third is the reciprocal of f/g precomposed with the scaling x ↦ cx (which → ∞ since c > 0), hence also → 1. Multiplying, g(cx)/g(x) → c^α·1·1 = c^α. This is why the index is a property of the tail: replacing a tail by any asymptotically equivalent expression preserves the exact index (regularlyVarying_asymp_equiv_same_index).",
+    "prerequisites": ["asymptotic equivalence", "composition of limits", "reciprocal of limits"],
+    "relatedConcepts": ["rigidity", "tail equivalence", "invariance under perturbation"],
+    "mathContext": "$g(cx)/g(x) = \\dfrac{f(cx)}{f(x)} \\cdot \\dfrac{f(x)}{g(x)} \\cdot \\dfrac{g(cx)}{f(cx)} \\to c^\\alpha \\cdot 1 \\cdot 1 = c^\\alpha$ when $f/g \\to 1$."
+  },
+  {
+    "id": "ann-clt-oq010101-corollaries",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 239, "endLine": 271 },
+    "type": "concept",
+    "significance": "supporting",
+    "title": "The Index Sees Only the Power-Law Part",
+    "content": "The closing corollaries package the algebraic picture. regularlyVarying_inv_index gives index(1/f) = -index f (a special case of additivity, since f·(1/f) = 1 has index 0). regularlyVarying_mul_slowlyVarying shows multiplying by a slowly varying function keeps the index fixed — precisely the statement that the index reads only the power-law part x^{-α} of a domain-of-attraction tail and ignores the slowly varying correction factor L(x). This is the practical payoff: the stability index of a stable limit depends only on the leading power of the tail.",
+    "prerequisites": ["additivity of the index", "slowly varying functions"],
+    "relatedConcepts": ["power-law part", "correction factor", "Karamata decomposition"],
+    "mathContext": "$\\operatorname{index}(1/f) = -\\operatorname{index} f$; multiplying by a slowly varying $L$ (index $0$) preserves the index, so $f(x) \\sim x^{-\\alpha} L(x)$ has index $-\\alpha$ regardless of $L$."
+  }
+]

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "central-limit-theorem-oq-01-oq-01-oq-01",
+  "title": "The Regular-Variation Index is a Well-Defined Asymptotic Invariant",
+  "slug": "central-limit-theorem-oq-01-oq-01-oq-01",
+  "description": "In the Gnedenko-Kolmogorov domain-of-attraction theory (parent entry), a heavy tail is described by a regularly varying function of index -α, and α is the stability parameter of the limiting stable law. This entry proves that this index is intrinsic: a function is regularly varying with at most one index (uniqueness), slowly varying functions are exactly the index-0 case, the model example x^α has index α with the sharp non-example x^α slowly varying iff α = 0, the index is additive under pointwise products (a homomorphism into (ℝ,+)), and — the main rigidity result — regular variation together with its index is preserved under asymptotic equivalence. Fully machine-checked, axiom-free, self-contained.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "probability",
+      "regular-variation",
+      "slowly-varying",
+      "domain-of-attraction",
+      "stable-distributions",
+      "central-limit-theorem",
+      "asymptotic-invariant",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. The file imports only Mathlib and every result is fully proved; #print axioms reports only the standard foundational axioms propext, Classical.choice, and Quot.sound (which do not count as assumptions under the project axiom-integrity policy). No axiom declarations, no structure-encoded hypotheses, no sorries, no native_decide.",
+    "lineCount": 271,
+    "theoremCount": 12,
+    "originalContributions": [
+      "regularlyVarying_index_unique: a function is regularly varying with at most one index — the index is a well-defined invariant. Proof evaluates the defining limit at c = 2, so f(2x)/f(x) converges to both 2^α and 2^β; uniqueness of limits gives 2^α = 2^β, and taking logarithms with log 2 ≠ 0 forces α = β.",
+      "slowlyVarying_iff_regularlyVarying_zero: slowly varying = regularly varying of index 0 (c^0 = 1).",
+      "slowlyVarying_regularlyVarying_index: the only index a slowly varying function can have is 0.",
+      "rpow_regularlyVarying: x ↦ x^α is regularly varying with index α — every real number is realized as an index (the model example).",
+      "rpow_slowlyVarying_iff: SHARP non-example — x ↦ x^α is slowly varying iff α = 0; any nonzero exponent breaks slow variation.",
+      "not_slowlyVarying_id: the identity x ↦ x (index 1) is not slowly varying, since (2x)/x → 2 ≠ 1.",
+      "regularlyVarying_mul_index: ADDITIVITY — index(f·g) = index f + index g, exhibiting the index as a homomorphism from regularly varying functions (under pointwise product) into (ℝ,+).",
+      "regularlyVarying_inv_index: index(1/f) = -index f (the reciprocal negates the index).",
+      "regularlyVarying_mul_slowlyVarying: a slowly varying correction factor does not change the index — the index sees only the power-law part of a domain-of-attraction tail.",
+      "regularlyVarying_of_asymp_equiv: RIGIDITY (main result) — if f is regularly varying with index α and g is asymptotically equivalent to f (f/g → 1), then g is regularly varying with the same index α. Proof decomposes g(cx)/g(x) into three factors converging to c^α, 1, and 1.",
+      "regularlyVarying_asymp_equiv_same_index: asymptotically equivalent regularly varying functions share the same index."
+    ],
+    "mathlib_version": "4.26.0",
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The classical Central Limit Theorem gives a Gaussian limit for normalized sums of finite-variance i.i.d. random variables. Gnedenko and Kolmogorov (1954) characterized the full domain of attraction of stable laws in terms of regularly varying tails: a distribution lies in the domain of attraction of an α-stable law iff its tail x ↦ P(|X| > x) is regularly varying with index -α. The parent entry (OQ-01-OQ-01) formalizes slowly varying functions, regular variation, and the Gnedenko-Kolmogorov statement. The systematic theory of regular variation — including the key structural facts about the index — was developed by Karamata (1930s) and given its definitive treatment in Bingham, Goldie & Teugels, 'Regular Variation' (1987). A basic but foundational question underlies the whole theory: is 'the index' even well-defined, and how does it behave? This entry answers that question.",
+    "problemStatement": "Is the regular-variation index that governs the domain of attraction of a stable law an intrinsic, well-defined invariant of the tail — unique, algebraically structured, and stable under asymptotically negligible perturbations?",
+    "text": "Yes on all counts. (1) Well-defined: a function is regularly varying with at most one index. (2) Slowly varying functions are exactly the index-0 functions, so the index measures 'departure from slow variation'. (3) The index is additive under pointwise multiplication, making it a homomorphism into (ℝ,+); in particular the reciprocal negates the index and a slowly varying correction factor leaves it unchanged. (4) Rigidity: if two functions are asymptotically equivalent (their ratio tends to 1) and one is regularly varying, so is the other, with the identical index. The model example x^α realizes every real number as an index, and the sharp boundary x^α slowly varying ⇔ α = 0 shows the index is faithful.",
+    "proofStrategy": "All results are derived directly from the ε-free limit definitions of SlowlyVarying and RegularlyVarying, with no appeal to the deeper Karamata representation theorem.\n\n• Uniqueness is a one-point argument: specialize the scaling factor to c = 2, use uniqueness of limits to get 2^α = 2^β, then cancel the nonzero factor log 2.\n\n• Additivity factors the product ratio f(cx)g(cx)/(f(x)g(x)) as (f(cx)/f(x))·(g(cx)/g(x)) and multiplies the two limits, using c^(α+β) = c^α·c^β (Real.rpow_add).\n\n• Rigidity is the substantive result: g(cx)/g(x) is written as (f(cx)/f(x))·(f(x)/g(x))·(g(cx)/f(cx)). The first factor tends to c^α by regular variation of f; the second is the asymptotic-equivalence hypothesis f/g → 1; the third is the reciprocal of f/g precomposed with the scaling x ↦ cx (which tends to infinity), hence also → 1. The product of the limits is c^α·1·1 = c^α.",
+    "keyInsights": [
+      "The index is pinned down by a single scaling factor: knowing the limit of f(2x)/f(x) already determines α, because α ↦ 2^α is injective. No uniform-in-c information is needed for uniqueness.",
+      "Slowly varying = index 0 turns 'the index' into a graded structure: RegularlyVarying(·, α) refines SlowlyVarying, which is precisely the α = 0 layer.",
+      "Additivity of the index is exactly the statement c^(α+β) = c^α·c^β transported through the multiplicative structure of ratios; this is why the index behaves like a logarithm of growth.",
+      "Rigidity under asymptotic equivalence is why the index is a property of the *tail* rather than of any particular representative function: replacing a tail by an asymptotically equivalent one (e.g. smoothing, or dropping lower-order terms) preserves both regular variation and the exact index.",
+      "The sharp non-example x^α slowly varying ⇔ α = 0 shows the slowly varying class is not accidentally large: the only powers it contains are the constants."
+    ],
+    "prerequisites": [
+      "Limits of real functions along the atTop filter and uniqueness of limits (tendsto_nhds_unique)",
+      "Real power function x^α (Real.rpow) and its identities: rpow_add, rpow_zero, rpow_neg, mul_rpow",
+      "Slowly varying and regularly varying functions (parent entry OQ-01-OQ-01)",
+      "The Gnedenko-Kolmogorov domain-of-attraction characterization and the role of the tail index -α"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 59,
+      "endLine": 83,
+      "summary": "Self-contained definitions of SlowlyVarying (L(cx)/L(x) → 1 for all c > 0) and RegularlyVarying (f(cx)/f(x) → c^α), mirroring the parent entry, plus the base fact that a positive constant is slowly varying."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Part I — The Index is Well-Defined",
+      "startLine": 84,
+      "endLine": 105,
+      "summary": "regularlyVarying_index_unique: a function is regularly varying with at most one index. The proof specializes to c = 2, applies uniqueness of limits to get 2^α = 2^β, and cancels log 2 ≠ 0."
+    },
+    {
+      "id": "slowly-index-zero",
+      "title": "Part II — Slowly Varying = Index 0",
+      "startLine": 106,
+      "endLine": 126,
+      "summary": "slowlyVarying_iff_regularlyVarying_zero and slowlyVarying_regularlyVarying_index: slow variation is exactly the index-0 case, so 0 is the unique possible index of a slowly varying function."
+    },
+    {
+      "id": "model-sharp",
+      "title": "Part III — The Model Example and Sharpness",
+      "startLine": 127,
+      "endLine": 169,
+      "summary": "rpow_regularlyVarying (x^α has index α), the sharp non-example rpow_slowlyVarying_iff (x^α slowly varying ⇔ α = 0), and not_slowlyVarying_id (the identity is not slowly varying)."
+    },
+    {
+      "id": "additivity",
+      "title": "Part IV — Additivity (Homomorphism)",
+      "startLine": 170,
+      "endLine": 191,
+      "summary": "regularlyVarying_mul_index: the index of a product is the sum of the indices, exhibiting the index as a homomorphism into (ℝ,+). Uses c^(α+β) = c^α·c^β."
+    },
+    {
+      "id": "rigidity",
+      "title": "Part V — Rigidity under Asymptotic Equivalence",
+      "startLine": 192,
+      "endLine": 238,
+      "summary": "regularlyVarying_of_asymp_equiv (main result: f/g → 1 transports regular variation and the exact index from f to g) and regularlyVarying_asymp_equiv_same_index (equal indices for asymptotically equivalent regularly varying functions)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part VI — Corollaries",
+      "startLine": 239,
+      "endLine": 271,
+      "summary": "regularlyVarying_inv_index (the reciprocal negates the index) and regularlyVarying_mul_slowlyVarying (a slowly varying correction factor leaves the index unchanged — the index sees only the power-law part of the tail)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The regular-variation index that drives the Gnedenko-Kolmogorov domain-of-attraction theory is a genuine asymptotic invariant: it is uniquely determined by the function, additive under products (a homomorphism into (ℝ,+)), and rigid under asymptotic equivalence. Slowly varying functions are exactly the index-0 layer, and the powers x^α realize every index with the sharp boundary that only α = 0 is slowly varying. All twelve theorems are proved directly from the limit definitions with zero axioms.",
+    "implications": "Rigidity under asymptotic equivalence is what licenses the standard moves in stable-limit theory: one may replace a distributional tail by any asymptotically equivalent expression (smoothing it, dropping lower-order terms, passing between P(|X|>x) and its continuous majorant) without changing the stability index α of the limit law. Additivity explains why products and quotients of domain-of-attraction tails have predictable indices, and the slowly-varying = index-0 identification isolates the 'correction factor' part of a tail that does not affect α. Together these give the index the status of a well-behaved logarithm of tail growth.",
+    "openQuestions": []
+  },
+  "leanFile": {
+    "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ01.lean",
+    "namespace": "DomainOfAttractionIndex",
+    "axiomCount": 0,
+    "lineCount": 271,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "central-limit-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Gnedenko-Kolmogorov domain of attraction theorem — defines slowly varying and regularly varying functions and the tail index -α whose intrinsic nature this entry establishes"
+    },
+    {
+      "targetId": "central-limit-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "α-stable distributions — the stability parameter α is exactly the regular-variation index shown here to be a well-defined invariant"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "ancestor",
+      "description": "Classical CLT — the finite-variance case, recovered as the α = 2 / index-0-correction endpoint of the regular-variation picture"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Nicholas H. Bingham",
+        "Charles M. Goldie",
+        "Jef L. Teugels"
+      ],
+      "title": "Regular Variation",
+      "year": 1987,
+      "venue": "Cambridge University Press (Encyclopedia of Mathematics and its Applications 27)",
+      "note": "Definitive treatment of regular variation; Chapter 1 develops uniqueness of the index, the slowly-varying = index-0 characterization, and closure under asymptotic equivalence."
+    },
+    {
+      "authors": [
+        "Boris V. Gnedenko",
+        "Andrey N. Kolmogorov"
+      ],
+      "title": "Limit Distributions for Sums of Independent Random Variables",
+      "year": 1954,
+      "venue": "Addison-Wesley",
+      "note": "Classical domain-of-attraction theory: the tail index -α is the invariant governing convergence to an α-stable law."
+    },
+    {
+      "authors": [
+        "William Feller"
+      ],
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. 2",
+      "year": 1971,
+      "venue": "Wiley",
+      "note": "Chapters VIII and XVII: regular variation and its role in domains of attraction of stable laws."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry for **central-limit-theorem-oq-01-oq-01-oq-01**, a follow-up to the Gnedenko-Kolmogorov domain-of-attraction formalization (`central-limit-theorem-oq-01-oq-01`).

In that theory a heavy tail `P(|X|>x)` is regularly varying with index `-α`, and `α` is the stability parameter of the limiting stable law. This entry proves that **the index is intrinsic** — a genuine asymptotic invariant of the tail.

## Results (12 theorems, 2 defs, 271 lines, 0 axioms)

| Theorem | Statement |
|---|---|
| `regularlyVarying_index_unique` | a function is regularly varying with **at most one** index |
| `slowlyVarying_iff_regularlyVarying_zero` | slowly varying = regularly varying of index 0 |
| `slowlyVarying_regularlyVarying_index` | the only index of a slowly varying function is 0 |
| `rpow_regularlyVarying` | `x^α` has index `α` (every index is realized) |
| `rpow_slowlyVarying_iff` | **sharp:** `x^α` slowly varying ⇔ `α = 0` |
| `not_slowlyVarying_id` | the identity (index 1) is not slowly varying |
| `regularlyVarying_mul_index` | **additivity:** `index(f·g) = index f + index g` — a homomorphism into `(ℝ,+)` |
| `regularlyVarying_inv_index` | the reciprocal negates the index |
| `regularlyVarying_mul_slowlyVarying` | a slowly varying correction factor leaves the index unchanged |
| `regularlyVarying_of_asymp_equiv` | **rigidity (main):** `f/g → 1` transports regular variation *and the exact index* |
| `regularlyVarying_asymp_equiv_same_index` | asymptotically equivalent RV functions share the index |

The rigidity result is why the index is a property of the *tail* rather than of a particular representative: replacing a tail by an asymptotically equivalent one preserves the exact stability index `α`. Additivity explains why the index behaves like a logarithm of tail growth, and `mul_slowlyVarying` isolates the fact that the index reads only the power-law part `x^{-α}`, ignoring the slowly varying correction factor.

## Verification

- Self-contained: imports only `Mathlib` (definitions of `SlowlyVarying`/`RegularlyVarying` mirrored locally).
- **0 axioms**: `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (standard foundational, not counted).
- 0 sorries, no `native_decide`.
- Verified with `lake env lean` against Mathlib 4.26.0.

Includes gallery `meta.json` (status `verified`, badge `verified`) and 8 annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)