### PR TITLE
Enrich Strict Chebyshev sum inequality (chebyshev-sum-inequality-oq-01-oq-02): annotation coverage

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "cheb-strict-ann-header",
     "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
-    "range": { "startLine": 1, "endLine": 38 },
+    "range": { "startLine": 1, "endLine": 25 },
     "type": "concept",
     "title": "From the Non-Strict Bound to the Strict Statement",
     "content": "Mathlib records Chebyshev's sum inequality only as a non-strict bound (∑f)(∑g) ≤ #s·∑f·g for monovarying f, g, with no rigidity clause. The parent file RearrangementChebyshevEqOQ01 supplies the missing equality case (chebyshev_sum_eq_iff and its monotone corollary chebyshev_sum_eq_iff_const) from the discrete covariance identity. This file imports both and combines them into the textbook-quoted strict form: the inequality is strict unless one of the sequences is constant. The import of the parent companion file (Proofs.RearrangementChebyshevEqOQ01) and `open RearrangementChebyshevEq` make the parent's lemmas directly available.",
@@ -10,6 +10,18 @@
     "significance": "supporting",
     "relatedConcepts": ["Chebyshev's sum inequality", "rigidity / equality case", "discrete covariance", "MonovaryOn"],
     "prerequisites": ["finite sums over a Finset", "order-correlation predicates"]
+  },
+  {
+    "id": "cheb-strict-ann-rigidity-pattern",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
+    "range": { "startLine": 26, "endLine": 38 },
+    "type": "technique",
+    "title": "The Unifying Pattern: Strict = Bound + Equality Excluded",
+    "content": "All three strict statements share one proof skeleton, made explicit in the docstring: each is `lt_of_le_of_ne (chebyshev_sum …) (negation of equality)`. The parent's ≤ inequality supplies the ≤ half; the parent's equality characterisation (chebyshev_sum_eq_iff, or its constant form), contradicted by a doubly-varying witness, supplies the ≠ half. This is the general recipe for upgrading any inequality that has a *known equality case* to a strict inequality — you never re-prove the bound, you only rule out its rigid extremal configuration. The import of the parent companion (Proofs.RearrangementChebyshevEqOQ01) with `open RearrangementChebyshevEq` makes both halves available, and because nothing beyond them is used, the strict results inherit the parent's foundational-only (0 new axioms) status.",
+    "mathContext": "$a \\le b \\ \\wedge\\ a \\neq b \\Rightarrow a < b$: strictness $=$ (non-strict bound) $+$ (equality case excluded).",
+    "significance": "key",
+    "relatedConcepts": ["lt_of_le_of_ne", "rigidity / equality case", "strict from non-strict", "extremal configuration"],
+    "prerequisites": ["the order lemma a ≤ b ∧ a ≠ b → a < b", "knowing the equality case of an inequality"]
   },
   {
     "id": "cheb-strict-ann-pair",


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-02` (4→5 annotations; meta.json already under caps at 10.8 KB).

- **New `cheb-strict-ann-rigidity-pattern`** (lines 26–38): surfaces the architectural throughline the docstring names but no annotation covered — every strict result is `lt_of_le_of_ne (chebyshev_sum …) (¬equality)`. Strictness = (non-strict bound) + (equality case excluded); you never re-prove the bound, only rule out its rigid extremal configuration. Notes the 0-new-axiom inheritance from the parent companion.
- **Narrowed the header** to the framing (lines 1–25) so the two are non-overlapping; full docstring covered.
- All 5 annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

JSON validated; annotation build reports no errors for this entry.