### PR TITLE
Enrich Chevalley–Warning explicit solution set (chevalley-warning-theorem-oq-01-oq-01-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/chevalley-warning-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chevalley-warning-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-cw3-overview",
     "proofId": "chevalley-warning-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 3, "endLine": 47 },
+    "range": { "startLine": 3, "endLine": 38 },
     "type": "concept",
     "title": "Reifying a Cardinality into an Explicit Finite Set",
     "content": "The docstring frames this third-generation entry: the parents establish the Chevalley–Warning divisibility and its cardinality consequences (0-or-≥-p, no-unique-solution, one second zero), but those all live at the level of cardinals and existence. Downstream pigeonhole arguments — above all the Erdős–Ginzburg–Ziv proof — need to iterate over an explicit Finset of common zeros, not just know how many there are. This file supplies that reification: an explicit Finset of ≥ p common zeros, an explicit Finset of ≥ p−1 zeros avoiding any given x₀, and (origin-vanishing case) an explicit Finset of ≥ p−1 nonzero common zeros — answering the parent's open question of an effective count of p−1 additional zeros. All by reifying char_le_card_of_exists through Finset.map / Finset.erase.",
@@ -10,6 +10,18 @@
     "significance": "supporting",
     "relatedConcepts": ["reification", "Erdős–Ginzburg–Ziv", "pigeonhole", "Finset", "Chevalley–Warning"],
     "prerequisites": ["finite fields", "Finset operations"]
+  },
+  {
+    "id": "ann-cw3-egz-context",
+    "proofId": "chevalley-warning-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 47 },
+    "type": "context",
+    "title": "Why an Explicit Finset: the Erdős–Ginzburg–Ziv Endgame",
+    "content": "The docstring's Context section names the downstream consumer, and it is worth spelling out. Erdős–Ginzburg–Ziv (1961) states that any 2n−1 integers contain n whose sum is divisible by n; the prime case n = p is the crux (the general case follows by multiplicativity). Its classic proof applies Chevalley–Warning over 𝔽_p to the two polynomials Σᵢ aᵢ·xᵢ^{p−1} and Σᵢ xᵢ^{p−1} in 2p−1 variables. Both have degree p−1, and the degree sum 2(p−1) < 2p−1 = the variable count, so Chevalley–Warning forces the common zeros to number a multiple of p; discarding the trivial all-zero solution leaves a nontrivial one. Since xᵢ^{p−1} ∈ {0,1} in 𝔽_p (Fermat), that zero is a {0,1}-vector: the second equation makes the count of nonzero coordinates a nonzero multiple of p — necessarily exactly p — and the first makes the corresponding aᵢ sum to 0 mod p. Extracting that nonzero selection is a Finset-level pigeonhole, which is exactly why it needs the solutions as an honest Finset — the object this file reifies. Isolating the reification makes the EGZ endgame reusable rather than re-derived.",
+    "mathContext": "EGZ (prime case): over $\\mathbb{F}_p$, $\\sum a_i x_i^{p-1}=0,\\ \\sum x_i^{p-1}=0$ in $2p-1$ vars, both degree $p-1$; $2(p-1)<2p-1$ so a nontrivial common zero exists, with exactly $p$ nonzero coordinates picking a $p$-subset of zero sum.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Ginzburg–Ziv theorem", "Chevalley–Warning theorem", "zero-sum problems", "pigeonhole", "finite fields 𝔽_p"],
+    "prerequisites": ["the Chevalley–Warning theorem", "xᵖ⁻¹ ∈ {0,1} in 𝔽_p (Fermat's little theorem)", "zero-sum combinatorics"]
   },
   {
     "id": "ann-cw3-explicit-set",


### PR DESCRIPTION
Enrichment pass for `chevalley-warning-theorem-oq-01-oq-01-oq-01` (4→5 annotations; meta.json already rich at 15.4 KB, under caps).

- **New `ann-cw3-egz-context`** (lines 39–47): the docstring's Context section names the Erdős–Ginzburg–Ziv application but no annotation covered it. This adds the full endgame: EGZ (prime case) applies Chevalley–Warning over 𝔽_p to Σ aᵢxᵢ^{p−1} and Σ xᵢ^{p−1} in 2p−1 variables (degree sum 2(p−1) < 2p−1), forcing a nontrivial {0,1} common zero with exactly p nonzero coordinates — a p-subset of zero sum. Explains precisely why the pigeonhole extraction needs the solutions as an honest Finset, motivating this file's reification.
- **Narrowed the overview** to 'What This Proves' (lines 3–38); non-overlapping.
- All 5 annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

JSON validated; annotation build reports no errors for this entry.