### PR TITLE
research(erdos-175): fix inconsistent f/maxPrimePowerExp stubs (axioms asserted false facts about a constant-0 def)

### DIFF
--- a/proofs/Proofs/Erdos175Problem.lean
+++ b/proofs/Proofs/Erdos175Problem.lean
@@ -41,9 +41,11 @@ def centralBinom (n : ℕ) : ℕ := Nat.choose (2 * n) n
 def IsSquarefree (m : ℕ) : Prop :=
   ∀ p : ℕ, Nat.Prime p → ¬(p ^ 2 ∣ m)
 
-/-- The maximum prime power exponent dividing C(2n, n) -/
+/-- The maximum prime power exponent dividing `C(2n, n)`, i.e.
+`max { v_p(C(2n,n)) : p prime }`, taken as `Finset.sup` over the prime support of
+its factorization (so it is `0` exactly when `C(2n,n) = 1`, i.e. `n = 0`). -/
 noncomputable def maxPrimePowerExp (n : ℕ) : ℕ :=
-  Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)
+  (centralBinom n).factorization.support.sup fun p => (centralBinom n).factorization p
 
 /-
 ## Part 2: Divisibility by 4
@@ -138,10 +140,21 @@ axiom granville_ramare_1996 (n : ℕ) (hn : n ≥ 5) :
 f(n) = max{k : p^k | C(2n,n) for some prime p}.
 -/
 
-/-- Maximum prime power exponent dividing a number -/
-noncomputable def f (n : ℕ) : ℕ :=
-  -- max over primes p of v_p(C(2n, n))
-  Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)
+/-- `f n = max { k : p^k ∣ C(2n,n) for some prime p } = max_p v_p(C(2n,n))`,
+the largest prime-power exponent in the factorization of the central binomial
+coefficient. Defined as `maxPrimePowerExp`; the deep theorems below concern this
+genuine object. -/
+noncomputable def f (n : ℕ) : ℕ := maxPrimePowerExp n
+
+/-- `f` genuinely dominates every prime-power valuation of `C(2n,n)`: for any
+prime (indeed any) `p`, `v_p(C(2n,n)) ≤ f n`. This is the defining property of the
+maximum, and confirms `f` is the intended object rather than a degenerate stub. -/
+theorem factorization_le_f (n p : ℕ) :
+    (centralBinom n).factorization p ≤ f n := by
+  unfold f maxPrimePowerExp
+  by_cases hp : p ∈ (centralBinom n).factorization.support
+  · exact Finset.le_sup hp
+  · rw [Finsupp.notMem_support_iff.mp hp]; exact Nat.zero_le _
 
 /-- f(n) → ∞ as n → ∞ (Sander 1992) -/
 axiom sander_1992_f_unbounded :

--- a/research/problems/erdos-175-incomplete-01/state.md
+++ b/research/problems/erdos-175-incomplete-01/state.md
@@ -1,6 +1,34 @@
 # State: erdos-175-incomplete-01
 
-**Phase**: OBSERVE
+**Phase**: ACT
 **Since**: 2026-04-03T08:28:28Z
-**Attempts**: 0
+**Attempts**: 1
 **Status**: available
+
+## Session 2026-07-02 (researcher-16)
+
+**Stale pool metadata**: `problem.md` still lists "Sorries: 1" for the
+`four_divides_iff` lemma, but that sorry was ALREADY eliminated axiom-free by
+PR #29321 (`4 | C(2n,n) ⟺ n not a power of 2`, via Kummer/2-adic valuation). The
+Lean file has **0 sorries** and 4 axioms (deep Granville-Ramaré / Sander /
+Erdős-Kolesnik results — correctly axiomatized, research-grade, not tractable).
+
+**Integrity fix shipped this session**: `f` and `maxPrimePowerExp` were degenerate
+stubs `Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)` which both evaluate to `0` for all
+`n`. The axioms `sander_1992_f_unbounded` (`f n > M` eventually),
+`sander_1995_upper_bound`, and `erdos_kolesnik_1999` therefore asserted **false**
+statements about the constant-`0` stub — e.g. `sander_1992` gives `0 > 0`, so the
+file's axioms were logically inconsistent (could derive `False`). Replaced both
+stubs with the genuine definition
+`maxPrimePowerExp n = (centralBinom n).factorization.support.sup (·.factorization)`
+(= `max_p v_p(C(2n,n))`), set `f n := maxPrimePowerExp n`, and added the
+build-verified lemma `factorization_le_f : (centralBinom n).factorization p ≤ f n`
+confirming `f` genuinely dominates every prime valuation. The 4 axioms are now
+true-but-hard statements about the real object. Build-verified via `lake env lean`
+(Mathlib 4.26.0). Gallery meta unchanged (still axiomatized, axiomCount 4,
+sorries 0; lineCount/theoremCount synced).
+
+**Ceiling**: the remaining 4 axioms are deep approximation-theory / analytic
+number-theory theorems (Granville-Ramaré squarefree result; Sander & Erdős-Kolesnik
+bounds on `f`). None is a routine Mathlib application; treat as
+complete-as-axiomatized. Future agents should NOT re-claim expecting a sorry.

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -56,7 +56,7 @@
       "Included explicit machine-checked computations for small cases"
     ],
     "axiomCount": 4,
-    "lineCount": 248,
+    "lineCount": 261,
     "references": [
       {
         "title": "The largest prime factor of (2n choose n)",
@@ -85,7 +85,7 @@
     ],
     "assumptions": "4 axioms (deep analytic results, not yet formalizable): granville_ramare_1996 (Granville-Ramaré 1996: C(2n,n) not squarefree for n≥5), sander_1992_f_unbounded (Sander 1992: f(n) → ∞), sander_1995_upper_bound (Sander 1995: f(n) ≪ log n), erdos_kolesnik_1999 (Erdős-Kolesnik: f(n) ≫ (log n)^{1/4}). 0 sorries: the divisibility characterization four_divides_iff is now fully proven (axiom-free) via Kummer theorem.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 5
   },
   "overview": {
@@ -219,9 +219,9 @@
       "Nat"
     ],
     "namespace": "Erdos175",
-    "lineCount": 248,
+    "lineCount": 261,
     "axiomCount": 4,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 5,
     "path": "Proofs/Erdos175Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Fixes a **soundness bug** in `proofs/Proofs/Erdos175Problem.lean` (Erdős #175, central binomial coefficient not squarefree).

The definitions `f` and `maxPrimePowerExp` were degenerate stubs:
```lean
noncomputable def f (n : ℕ) : ℕ := Nat.find (⟨1, trivial⟩ : ∃ _ : ℕ, True)  -- ≡ 0 for all n
```
Both evaluate to **0** for every `n`. But three axioms assert growth properties about `f`:
- `sander_1992_f_unbounded : ∀ M, ∃ N, ∀ n ≥ N, f n > M`  → with `f ≡ 0` this gives `0 > M`, i.e. **`0 > 0`**
- `sander_1995_upper_bound`, `erdos_kolesnik_1999` similarly

So the file's axiom set was **logically inconsistent** — one could derive `False` from `sander_1992_f_unbounded` alone.

## Fix
- Give both definitions the genuine object:
  ```lean
  maxPrimePowerExp n = (centralBinom n).factorization.support.sup (·.factorization)  -- = max_p v_p(C(2n,n))
  f n := maxPrimePowerExp n
  ```
- Add a build-verified lemma confirming `f` is the real maximum (not a stub):
  ```lean
  theorem factorization_le_f (n p : ℕ) : (centralBinom n).factorization p ≤ f n
  ```
- The 4 deep axioms (Granville-Ramaré 1996; Sander 1992/1995; Erdős-Kolesnik 1999) are now **true-but-hard** statements about the genuine `f`, correctly axiomatized.

## Notes
- The pool's tracked "1 sorry" (`four_divides_iff`) was already resolved axiom-free by #29321 (recorded in `state.md`).
- No new axioms. Gallery meta unchanged in status (`axiomatized`, `axiomCount` 4, `sorries` 0); `lineCount` 248→261 and `theoremCount` 8→9 synced.
- Build-verified via `lake env lean` against Mathlib 4.26.0 (Docker unavailable; disk pressure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)