### PR TITLE
research(cayley-hamilton-minpoly-oq-01-oq-04): Weyr characteristic is non-increasing [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ04.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ04.lean
@@ -1,0 +1,132 @@
+/-
+  Cayley–Hamilton / Minimal Polynomial, Open Question 01 → OQ 04:
+  The rank–nullity tower (Weyr characteristic) is non-increasing.
+
+  For a linear operator `f` on a finite-dimensional space and an eigenvalue `μ`,
+  write `aₖ = dim (genEigenspace μ k) = dim ker (f - μ)ᵏ`. The *k-th Weyr number*
+  is the jump
+
+      wₖ = a_{k+1} − aₖ                                        (§ `weyr`)
+
+  which counts the Jordan blocks for `μ` of size `≥ k+1`. The theorem proved here
+  is that this sequence is **non-increasing** (`weyr_antitone`):
+
+      w_{k+1} ≤ wₖ,   equivalently   aₖ + a_{k+2} ≤ 2·a_{k+1}   (§ `..._concave`),
+
+  i.e. the dimensions `aₖ` form a *concave* sequence. This is the abstract fact
+  underlying the shape of the Jordan/Weyr "dot diagram".
+
+  **Proof idea (quotient-free).** Set `N = f - μ`. For each `k` consider the
+  subspace
+
+      Uₖ = N^k (ker N^{k+1})  ⊆  ker N.
+
+  Restricting `N^k` to `ker N^{k+1}` has kernel `ker N^k` (which sits inside
+  `ker N^{k+1}`) and range `Uₖ`, so rank–nullity gives
+
+      dim Uₖ = a_{k+1} − aₖ   (`finrank_diff_space`).
+
+  A one-line calculation shows `U_{k+1} ⊆ Uₖ` (`diff_space_antitone`): if
+  `y = N^{k+1} x` with `x ∈ ker N^{k+2}`, then `y = N^k (N x)` with
+  `N x ∈ ker N^{k+1}`. Monotonicity of `finrank` then yields
+  `a_{k+2} − a_{k+1} ≤ a_{k+1} − aₖ`, which is the claim.
+
+  No axioms; fully machine-checked against Mathlib.
+
+  Parent: cayley-hamilton-minpoly-oq-01 (Jordan form and the minimal polynomial).
+  Reference: standard Jordan/Weyr theory (see e.g. Horn–Johnson, *Matrix Analysis*).
+-/
+
+import Mathlib
+
+open Module LinearMap
+open scoped Classical
+
+set_option linter.unusedSectionVars false
+
+namespace CayleyHamiltonMinpolyOQ01OQ04
+
+variable {K V : Type*} [Field K] [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+
+/-- Applying `Nᵏ⁺¹` is applying `Nᵏ` after one more `N`. -/
+lemma pow_succ_apply (N : Module.End K V) (j : ℕ) (x : V) :
+    (N ^ (j + 1)) x = (N ^ j) (N x) := by rw [pow_succ]; rfl
+
+/-- Kernels of successive powers grow: `ker Nᵏ ≤ ker Nᵏ⁺¹`. -/
+lemma ker_pow_le_succ (N : Module.End K V) (k : ℕ) :
+    LinearMap.ker (N ^ k) ≤ LinearMap.ker (N ^ (k + 1)) := by
+  intro x hx
+  simp only [LinearMap.mem_ker] at hx ⊢
+  have h : (N ^ (k + 1)) x = N ((N ^ k) x) := by rw [pow_succ']; rfl
+  rw [h, hx, map_zero]
+
+/-- **Rank–nullity for the tower.** `dim (Nᵏ (ker Nᵏ⁺¹)) + dim (ker Nᵏ) = dim (ker Nᵏ⁺¹)`.
+    The left summand is the "difference space" whose dimension is the jump
+    `a_{k+1} − aₖ`. -/
+lemma finrank_diff_space (N : Module.End K V) (k : ℕ) :
+    finrank K (Submodule.map (N ^ k) (LinearMap.ker (N ^ (k + 1))))
+        + finrank K (LinearMap.ker (N ^ k))
+      = finrank K (LinearMap.ker (N ^ (k + 1))) := by
+  have key := LinearMap.finrank_range_add_finrank_ker
+      ((N ^ k).comp (LinearMap.ker (N ^ (k + 1))).subtype)
+  rw [LinearMap.range_comp, Submodule.range_subtype, LinearMap.ker_comp,
+      (Submodule.comapSubtypeEquivOfLe (ker_pow_le_succ N k)).finrank_eq] at key
+  exact key
+
+/-- **The difference spaces shrink:** `N^{k+1}(ker N^{k+2}) ⊆ Nᵏ(ker Nᵏ⁺¹)`. -/
+lemma diff_space_antitone (N : Module.End K V) (k : ℕ) :
+    Submodule.map (N ^ (k + 1)) (LinearMap.ker (N ^ (k + 2)))
+      ≤ Submodule.map (N ^ k) (LinearMap.ker (N ^ (k + 1))) := by
+  intro y hy
+  rw [Submodule.mem_map] at hy ⊢
+  obtain ⟨x, hx, rfl⟩ := hy
+  rw [LinearMap.mem_ker] at hx
+  refine ⟨N x, ?_, ?_⟩
+  · rw [LinearMap.mem_ker, ← pow_succ_apply N (k + 1) x]
+    exact hx
+  · exact (pow_succ_apply N k x).symm
+
+/-- **Concavity of the kernel dimensions:** `aₖ + a_{k+2} ≤ 2·a_{k+1}` where
+    `aₖ = dim ker Nᵏ`. -/
+theorem finrank_ker_pow_concave (N : Module.End K V) (k : ℕ) :
+    finrank K (LinearMap.ker (N ^ k)) + finrank K (LinearMap.ker (N ^ (k + 2)))
+      ≤ 2 * finrank K (LinearMap.ker (N ^ (k + 1))) := by
+  have h1 := finrank_diff_space N k
+  have h2 := finrank_diff_space N (k + 1)
+  rw [show k + 1 + 1 = k + 2 from rfl] at h2
+  have h3 := Submodule.finrank_mono (diff_space_antitone N k)
+  omega
+
+/-- Concavity restated for generalized eigenspaces:
+    `dim (genEigenspace μ k) + dim (genEigenspace μ (k+2)) ≤ 2·dim (genEigenspace μ (k+1))`. -/
+theorem genEigenspace_finrank_concave (f : Module.End K V) (μ : K) (k : ℕ) :
+    finrank K (f.genEigenspace μ (k : ℕ)) + finrank K (f.genEigenspace μ (k + 2 : ℕ))
+      ≤ 2 * finrank K (f.genEigenspace μ (k + 1 : ℕ)) := by
+  rw [Module.End.genEigenspace_nat, Module.End.genEigenspace_nat, Module.End.genEigenspace_nat]
+  exact finrank_ker_pow_concave (f - μ • 1) k
+
+/-- The `k`-th **Weyr number**: `dim (genEigenspace μ (k+1)) − dim (genEigenspace μ k)`,
+    the number of Jordan blocks for `μ` of size `≥ k+1`. -/
+noncomputable def weyr (f : Module.End K V) (μ : K) (k : ℕ) : ℕ :=
+  finrank K (f.genEigenspace μ (k + 1 : ℕ)) - finrank K (f.genEigenspace μ (k : ℕ))
+
+/-- **Main result: the Weyr characteristic is non-increasing.** The sequence of
+    generalized-eigenspace dimension jumps `w₀ ≥ w₁ ≥ w₂ ≥ ⋯` decreases, i.e. the
+    number of Jordan blocks of size `≥ k+1` does not exceed the number of size
+    `≥ k`. -/
+theorem weyr_antitone (f : Module.End K V) (μ : K) (k : ℕ) :
+    weyr f μ (k + 1) ≤ weyr f μ k := by
+  unfold weyr
+  rw [show k + 1 + 1 = k + 2 from rfl]
+  have hconv := genEigenspace_finrank_concave f μ k
+  have hmono1 :
+      finrank K (f.genEigenspace μ (k : ℕ)) ≤ finrank K (f.genEigenspace μ (k + 1 : ℕ)) := by
+    rw [Module.End.genEigenspace_nat, Module.End.genEigenspace_nat]
+    exact Submodule.finrank_mono (ker_pow_le_succ (f - μ • 1) k)
+  have hmono2 :
+      finrank K (f.genEigenspace μ (k + 1 : ℕ)) ≤ finrank K (f.genEigenspace μ (k + 2 : ℕ)) := by
+    rw [Module.End.genEigenspace_nat, Module.End.genEigenspace_nat]
+    exact Submodule.finrank_mono (ker_pow_le_succ (f - μ • 1) (k + 1))
+  omega
+
+end CayleyHamiltonMinpolyOQ01OQ04

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-01-oq-04",
+  "title": "The Weyr Characteristic is Non-Increasing (Rank–Nullity Tower)",
+  "slug": "cayley-hamilton-minpoly-oq-01-oq-04",
+  "description": "Proves that for a linear endomorphism f of a finite-dimensional vector space and an eigenvalue μ, the generalized-eigenspace dimensions aₖ = dim(genEigenspace μ k) = dim ker (f - μ)ᵏ form a concave sequence: aₖ + a₍k₊₂₎ ≤ 2·a₍k₊₁₎. Equivalently, the successive dimension jumps wₖ = a₍k₊₁₎ − aₖ (the Weyr characteristic, counting Jordan blocks for μ of size ≥ k+1) are non-increasing: w₀ ≥ w₁ ≥ w₂ ≥ ⋯. The proof is quotient-free: with N = f - μ, restricting Nᵏ to ker Nᵏ⁺¹ has kernel ker Nᵏ and range Uₖ = Nᵏ(ker Nᵏ⁺¹), so rank–nullity gives dim Uₖ = a₍k₊₁₎ − aₖ, and a one-line calculation shows U₍k₊₁₎ ⊆ Uₖ, whence finrank monotonicity yields the concavity. Fully machine-checked with 0 axioms over an arbitrary field.",
+  "references": [
+    {
+      "authors": "Eduard Weyr",
+      "title": "Répartition des matrices en espèces et formation de toutes les espèces (Comptes Rendus 100)",
+      "year": 1885,
+      "note": "Introduces the Weyr characteristic — the sequence of generalized-eigenspace dimension jumps — and its non-increasing (partition-conjugate) structure."
+    },
+    {
+      "authors": "Roger A. Horn, Charles R. Johnson",
+      "title": "Matrix Analysis (2nd ed.)",
+      "year": 2013,
+      "note": "Cambridge University Press. The Weyr characteristic, its relation to Jordan block sizes, and the conjugate-partition description of the dot diagram."
+    },
+    {
+      "authors": "Kevin C. O'Meara, John Clark, Charles I. Vinsonhaler",
+      "title": "Advanced Topics in Linear Algebra: Weaving Matrix Problems through the Weyr Form",
+      "year": 2011,
+      "note": "Oxford University Press. Modern treatment of the Weyr characteristic and Weyr canonical form."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Module.End.genEigenspace, LinearMap rank–nullity and finrank/submodule infrastructure",
+      "year": 2024,
+      "note": "genEigenspace_nat (generalized eigenspaces as kernels of powers), finrank_range_add_finrank_ker, comapSubtypeEquivOfLe, and Submodule.finrank_mono used throughout."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ01OQ04.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "generalized-eigenspaces",
+      "jordan-form",
+      "weyr-characteristic",
+      "rank-nullity",
+      "cayley-hamilton",
+      "minimal-polynomial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib. Results hold over an arbitrary field K and a finite-dimensional K-vector space V; #print axioms reports only propext, Classical.choice, Quot.sound. The concavity is derived directly from Mathlib's rank–nullity theorem (LinearMap.finrank_range_add_finrank_ker) and finrank monotonicity — no Jordan normal form or field-algebraic-closure hypothesis is used.",
+    "lineCount": 132,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "finrank_ker_pow_concave: for any endomorphism N of a finite-dimensional space, dim ker Nᵏ + dim ker Nᵏ⁺² ≤ 2·dim ker Nᵏ⁺¹ (concavity of the kernel-dimension sequence)",
+      "genEigenspace_finrank_concave: the same concavity for generalized eigenspaces, dim(genEig μ k) + dim(genEig μ (k+2)) ≤ 2·dim(genEig μ (k+1))",
+      "weyr_antitone: the Weyr characteristic wₖ = dim(genEig μ (k+1)) − dim(genEig μ k) is non-increasing",
+      "finrank_diff_space: rank–nullity for the tower, dim(Nᵏ(ker Nᵏ⁺¹)) + dim ker Nᵏ = dim ker Nᵏ⁺¹, identifying the difference space whose dimension is the jump a₍k₊₁₎ − aₖ",
+      "diff_space_antitone: the quotient-free crux, N^{k+1}(ker N^{k+2}) ⊆ Nᵏ(ker Nᵏ⁺¹), which drives the monotonicity"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The sequence of generalized-eigenspace dimension jumps for an eigenvalue μ is the Weyr characteristic, introduced by the Czech mathematician Eduard Weyr in 1885. It is the conjugate partition of the Segre characteristic (the multiset of Jordan block sizes): the k-th Weyr number counts the Jordan blocks for μ of size at least k+1. Because block counts of size ≥ k can only decrease as k grows, the Weyr characteristic is a non-increasing sequence — equivalently, the generalized-eigenspace dimensions grow concavely. This is the shape of the classical Jordan/Weyr 'dot diagram'. The fact is a cornerstone of the fine structure theory refining the Cayley–Hamilton / minimal-polynomial circle of ideas (the parent entry).",
+    "problemStatement": "Let f be a linear operator on a finite-dimensional vector space and μ an eigenvalue, and set aₖ = dim(genEigenspace μ k) = dim ker (f − μ)ᵏ. Is the sequence of jumps a₁ − a₀ ≥ a₂ − a₁ ≥ a₃ − a₂ ≥ ⋯ always non-increasing (equivalently, is (aₖ) concave)?",
+    "text": "We prove YES, over any field, with no appeal to the Jordan normal form. Write N = f − μ. The key object is the 'difference space' Uₖ = Nᵏ(ker Nᵏ⁺¹). Restricting the linear map Nᵏ to the subspace ker Nᵏ⁺¹ produces a map whose kernel is exactly ker Nᵏ (which lies inside ker Nᵏ⁺¹) and whose range is Uₖ; Mathlib's rank–nullity theorem then gives dim Uₖ = a₍k₊₁₎ − aₖ. The heart of the argument is a one-line inclusion, U₍k₊₁₎ ⊆ Uₖ: if y = N^{k+1} x with x ∈ ker N^{k+2}, then y = N^k(N x) and N x ∈ ker N^{k+1}, so y ∈ Uₖ. Since finrank is monotone under inclusion, dim U₍k₊₁₎ ≤ dim Uₖ, i.e. a₍k₊₂₎ − a₍k₊₁₎ ≤ a₍k₊₁₎ − aₖ. Rearranging gives the concavity aₖ + a₍k₊₂₎ ≤ 2·a₍k₊₁₎, and the non-increasing Weyr characteristic follows immediately.",
+    "proofStrategy": "Realize each dimension jump as the finrank of a concrete difference space Uₖ = map Nᵏ (ker Nᵏ⁺¹) via rank–nullity on the restriction Nᵏ ∘ (ker Nᵏ⁺¹).subtype; prove the chain of difference spaces is decreasing by an elementary preimage computation; conclude by monotonicity of finrank and a linear-arithmetic (omega) rearrangement.",
+    "keyInsights": [
+      "The jump a₍k₊₁₎ − aₖ is not just a number: it is the dimension of the honest subspace Uₖ = Nᵏ(ker Nᵏ⁺¹), obtained from rank–nullity applied to Nᵏ restricted to ker Nᵏ⁺¹.",
+      "Monotonicity of the whole tower reduces to a single subspace inclusion U₍k₊₁₎ ⊆ Uₖ, proved by exhibiting N x as the preimage witness — this avoids constructing the usual quotient-space injection ker Nᵏ⁺¹/ker Nᵏ ↪ ker Nᵏ/ker Nᵏ⁻¹.",
+      "No Jordan normal form, algebraic closure, or perfect-field hypothesis is needed: the concavity is a rank inequality valid over any field, machine-checked with 0 axioms.",
+      "The result is the abstract engine behind the Weyr = conjugate-of-Segre partition identity: it is exactly the statement that the counts of Jordan blocks of size ≥ k form a non-increasing (partition) sequence."
+    ],
+    "prerequisites": [
+      "Generalized eigenspaces and kernels of operator powers",
+      "The rank–nullity theorem (dim range + dim ker = dim domain)",
+      "Submodules, their images (Submodule.map), and monotonicity of dimension",
+      "Jordan block sizes and the Segre/Weyr characteristics (for interpretation)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The concavity of generalized-eigenspace dimensions — equivalently, that the Weyr characteristic is non-increasing — is formalized with 0 axioms over an arbitrary field, via a quotient-free rank–nullity argument. 7 theorems/lemmas, 1 definition, 132 lines.",
+    "implications": "This is the structural fact that makes the Weyr characteristic a partition and the conjugate of the Segre (Jordan-block-size) characteristic. It refines the parent Jordan-form/minimal-polynomial entry: whereas that entry axiomatizes the Jordan-form relationship, the monotone shape of the generalized-eigenspace filtration is here reached with no axioms, over any field.",
+    "openQuestions": [
+      "Derive the full Weyr = conjugate-of-Segre partition identity from this monotonicity together with the total dimension ∑ wₖ = dim(maxGenEigenspace μ).",
+      "Show strict decrease wₖ > w₍k₊₁₎ exactly when a Jordan block of size k+1 is present, pinning the block-size multiset.",
+      "Connect the difference spaces Uₖ to explicit Jordan chains / a Jordan basis for the generalized eigenspace."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonMinpolyOQ01OQ04",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: Jordan canonical form and the minimal polynomial. This entry proves the monotone (concave) shape of the generalized-eigenspace filtration underlying the Jordan block-size structure."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry: the Jordan–Chevalley–Dunford (semisimple + nilpotent) decomposition; both are basis-free, axiom-free refinements of the Jordan-form circle of ideas."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related",
+      "description": "Minimal polynomial of an endomorphism; the Weyr characteristic at μ is governed by the multiplicity of (x − μ) in the minimal and characteristic polynomials."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Powers of an operator and their kernels",
+      "startLine": 51,
+      "endLine": 61,
+      "summary": "pow_succ_apply expresses Nᵏ⁺¹ x = Nᵏ(N x); ker_pow_le_succ shows the kernels of successive powers grow, ker Nᵏ ≤ ker Nᵏ⁺¹."
+    },
+    {
+      "title": "Rank–nullity for the tower",
+      "startLine": 63,
+      "endLine": 74,
+      "summary": "finrank_diff_space: applying rank–nullity to Nᵏ restricted to ker Nᵏ⁺¹ gives dim(Nᵏ(ker Nᵏ⁺¹)) + dim ker Nᵏ = dim ker Nᵏ⁺¹, so the difference space Nᵏ(ker Nᵏ⁺¹) has dimension equal to the jump a₍k₊₁₎ − aₖ."
+    },
+    {
+      "title": "The difference spaces shrink",
+      "startLine": 76,
+      "endLine": 87,
+      "summary": "diff_space_antitone: the quotient-free crux N^{k+1}(ker N^{k+2}) ⊆ Nᵏ(ker Nᵏ⁺¹), proved by taking N x as the preimage witness."
+    },
+    {
+      "title": "Concavity of kernel dimensions",
+      "startLine": 89,
+      "endLine": 98,
+      "summary": "finrank_ker_pow_concave: combining the two difference-space facts with finrank monotonicity yields dim ker Nᵏ + dim ker Nᵏ⁺² ≤ 2·dim ker Nᵏ⁺¹."
+    },
+    {
+      "title": "Generalized eigenspaces and the Weyr characteristic",
+      "startLine": 100,
+      "endLine": 130,
+      "summary": "genEigenspace_finrank_concave transports the concavity to generalized eigenspaces via genEigenspace_nat; weyr defines the k-th Weyr number and weyr_antitone proves it is non-increasing."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **cayley-hamilton-minpoly-oq-01-oq-04**: proves that the generalized-eigenspace dimensions `aₖ = dim(genEigenspace μ k) = dim ker (f − μ)ᵏ` form a **concave** sequence,

```
aₖ + a₍k₊₂₎ ≤ 2·a₍k₊₁₎     (finrank_ker_pow_concave / genEigenspace_finrank_concave)
```

equivalently the **Weyr characteristic** `wₖ = a₍k₊₁₎ − aₖ` (number of Jordan blocks for μ of size ≥ k+1) is **non-increasing** `w₀ ≥ w₁ ≥ ⋯` (`weyr_antitone`). This answers the claimed problem 'Prove rank-nullity tower: dim(genEigenspace μ k) − dim(genEigenspace μ (k-1)) is non-increasing'.

## Proof (quotient-free)

With `N = f − μ`, the difference space `Uₖ = Nᵏ(ker Nᵏ⁺¹)`:
- rank–nullity on `Nᵏ` restricted to `ker Nᵏ⁺¹` gives `dim Uₖ = a₍k₊₁₎ − aₖ` (`finrank_diff_space`);
- `U₍k₊₁₎ ⊆ Uₖ` by taking `N x` as preimage witness (`diff_space_antitone`);
- finrank monotonicity + `omega` give the concavity.

No Jordan normal form, algebraic closure, or perfect-field hypothesis — valid over any field.

## Verification

- `lake env lean` (single-file, against repo Mathlib cache): **0 errors**.
- `#print axioms weyr_antitone / finrank_ker_pow_concave / genEigenspace_finrank_concave` → only `[propext, Classical.choice, Quot.sound]` ⇒ **0 counted axioms**, status `verified`.
- 7 theorems/lemmas, 1 definition, 132 lines.

## Files
- `proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ04.lean` (new)
- `src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)