### PR TITLE
Fix: create missing gallery entry for inverse-galois-oq-06-oq-02 (7 files, 64 thm, verified/0-axiom)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-igp0602-factors",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 101
+    },
+    "type": "definition",
+    "title": "The Three mod-7 Factors and Their Degrees",
+    "content": "The reduction of q modulo 7 is presented through three named factors over 𝔽₇: the linear factors linFactor5 = X − 5 and linFactor6 = X − 6, and the cubic cubicMod7 = X³ + 6X² + 4X + 1 (imported from the sibling OQ-01 file). Their degrees (1, 1, 3) are pinned down by compute_degree!, and each factor is shown nonzero. These degree facts are the raw data of the '(1,1,3) factor type' that Dedekind's theorem reads as a 3-cycle Frobenius.",
+    "mathContext": "Over the field $\\mathbb{F}_7 = \\mathbb{Z}/7\\mathbb{Z}$, the polynomial $q = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5$ reduces to $(X-5)(X-6)(X^3+6X^2+4X+1)$. The degree multiset $\\{1,1,3\\}$ is precisely the cycle type that the Frobenius at $p=7$ would carry."
+  },
+  {
+    "id": "ann-igp0602-irreducible",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Irreducibility via the No-Root Criterion",
+    "content": "The cubic is irreducible over 𝔽₇ because a degree-≤3 polynomial over a field is irreducible exactly when it has no root — the tactic applies Polynomial.irreducible_of_degree_le_three_of_not_isRoot, discharging the degree bound by decide and the no-root hypothesis from the sibling's exhaustive root check. The linear factors are irreducible by the standard irreducible_X_sub_C. This makes the arithmetic Dedekind input fully decidable and axiom-free.",
+    "mathContext": "For a cubic $f$ over a field, reducibility would force a linear factor, i.e. a root; contrapositively, no root over $\\mathbb{F}_7$ (checked over all 7 residues) implies irreducibility. Linear polynomials $X - c$ are always irreducible."
+  },
+  {
+    "id": "ann-igp0602-distinct",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 122,
+      "endLine": 146
+    },
+    "type": "insight",
+    "title": "The Factors Are Pairwise Non-Associated (Distinct Primes)",
+    "content": "Dedekind's theorem requires the factorization be into DISTINCT irreducibles. The two linear factors are non-associated because associated monic linears would be equal, forcing 5 = 6 in 𝔽₇ (false, by decide after evaluating at 0). A linear factor cannot be associated to the cubic because association preserves degree, and 1 ≠ 3 (closed by omega on natDegree_le_of_dvd bounds). Distinctness is what guarantees the Frobenius is a single 3-cycle rather than a repeated pattern.",
+    "mathContext": "Two polynomials are associated iff each divides the other, which for nonzero polynomials over a field forces equal degrees and a unit scalar. Distinct irreducible factors correspond to distinct prime ideals, i.e. distinct cycles in the Frobenius permutation."
+  },
+  {
+    "id": "ann-igp0602-squarefree",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 152,
+      "endLine": 184
+    },
+    "type": "insight",
+    "title": "Coprimality and Squarefreeness: 7 Is Unramified",
+    "content": "The three factors are pairwise coprime: the two linears via isCoprime_X_sub_C_of_isUnit_sub (their difference −1 is a unit), and each linear against the cubic via the irreducible's isRelPrime_iff_not_dvd together with dvd_iff_isRoot and the no-root fact. Squarefreeness of the product then follows from squarefree_mul_iff applied twice. A squarefree reduction means 7 ∤ disc(q), i.e. 7 is unramified — exactly the hypothesis Dedekind's theorem demands.",
+    "mathContext": "A prime $\\ell$ is unramified in the splitting field of $q$ iff $q \\bmod \\ell$ is squarefree iff $\\ell \\nmid \\operatorname{disc}(q)$. Pairwise coprime irreducible factors give a squarefree product, licensing the Frobenius-at-$\\ell$ interpretation."
+  },
+  {
+    "id": "ann-igp0602-factortype",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 190,
+      "endLine": 223
+    },
+    "type": "conclusion",
+    "title": "The Packaged Dedekind Input: q mod 7 Has Factor Type (1,1,3)",
+    "content": "q_mod7_factor_type bundles everything Dedekind's theorem consumes at p = 7: three irreducible factors, of degrees 1, 1, 3, pairwise non-associated, with squarefree product, whose product genuinely equals q mod 7 (q_mod7_factorization). This is the complete, 0-axiom arithmetic input. Combined with Dedekind's theorem — the one remaining Mathlib gap, owned by the sibling Frobenius track — it forces Gal(q) to contain a 3-cycle, hence 3 ∣ |Gal(q)|, which is exactly the parent A₅ entry's lone open axiom three_dvd_gal_card.",
+    "mathContext": "Dedekind's theorem: for $\\ell \\nmid \\operatorname{disc}(q)$, the cycle type of the Frobenius $\\operatorname{Frob}_\\ell \\in \\operatorname{Gal}(q)$ acting on the roots equals the degree multiset of $q \\bmod \\ell$. Here $\\{1,1,3\\}$ yields a 3-cycle, so $3 \\mid |\\operatorname{Gal}(q)|$ by Lagrange."
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-06-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "inverse-galois-oq-06-oq-02",
+  "title": "Inverse Galois OQ-06→02: The Dedekind Input for A₅ (mod-7/mod-11 factorization + the cycle-type bridge)",
+  "slug": "inverse-galois-oq-06-oq-02",
+  "description": "Isolates and fully verifies the algebraic and group-theoretic ingredients that the parent A₅-realizability entry (inverse-galois-oq-06) consumes via its lone open axiom three_dvd_gal_card. Two halves are proved with 0 axioms and 0 sorries: (A) the arithmetic input — q reduces mod 7 (and, independently, mod 11) to a product of distinct irreducibles of degree type (1,1,3), squarefree; and (B) the deterministic group-theoretic eliminator — an n-cycle on the roots forces n ∣ |Gal(q)|, in full cycle-length generality against the real Polynomial.Gal type. Together with a gap characterization (three_dvd_gal_card ⇔ |q.Gal| = 60) these pin the exact boundary of the one remaining Mathlib gap: Dedekind's theorem producing the Frobenius permutation itself.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InverseGaloisOQ06OQ02.lean",
+    "tags": [
+      "galois-theory",
+      "algebraic-number-theory",
+      "inverse-galois-problem",
+      "dedekind-theorem",
+      "finite-fields",
+      "permutation-groups"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Every theorem in all seven files is fully machine-checked with 0 axiom declarations, 0 sorries, and no native_decide (the proofs depend only on Lean's foundational propext / Classical.choice / Quot.sound). These files do NOT discharge the parent entry's open axiom three_dvd_gal_card (producing the Frobenius permutation is a genuine Mathlib 4.26 gap — Dedekind's theorem for polynomial Galois groups); they verify the deterministic inputs that axiom consumes.",
+    "lineCount": 1045,
+    "theoremCount": 64,
+    "definitionCount": 1,
+    "originalContributions": [
+      "q_mod7_factor_type: q reduces mod 7 to (X-5)(X-6)·(X³+6X²+4X+1) — distinct irreducibles of degree type (1,1,3), squarefree (the arithmetic Dedekind input at p=7)",
+      "q_mod11_factor_type: an independent second unramified prime — q reduces mod 11 to a (1,1,3) factor type, corroborating the same 3-cycle Frobenius conclusion",
+      "cubicMod7_irreducible / cubicMod11_irreducible: the degree-3 factors are irreducible over F_7 / F_11 (no roots)",
+      "dvd_card_gal_of_galActionHom_cycleType: the GENERAL faithful Dedekind bridge — if some σ ∈ Gal(q) acts on the roots as a single n-cycle, then n ∣ |Gal(q)| (arbitrary cycle length, against the real Polynomial.Gal)",
+      "three_dvd_card_gal_of_cycleType / five_dvd_card_gal_of_galActionHom_cycleType: the n=3 and n=5 corollaries — the faithful interfaces for both Frobenius inputs of the A₅ realization",
+      "three_dvd_gal_card_of_exists_galAction_threeCycle: the concrete deterministic half instantiated at q.Gal",
+      "three_dvd_card_iff_card_eq_60: gap characterization — the lone remaining axiom is equivalent to |q.Gal| = 60, showing it has no slack",
+      "frob113_cycleType / dedekind_consequence_113: the abstract (1,1,3) cycle-type ⟹ 3 ∣ |Gal| consequence isolated from the arithmetic"
+    ],
+    "relatedProblems": [
+      {
+        "id": "inverse-galois-oq-06",
+        "relationship": "Parent: the A₅-over-ℚ realization whose sole open axiom three_dvd_gal_card these files isolate and characterize"
+      },
+      {
+        "id": "inverse-galois-oq-01",
+        "relationship": "Sibling: D₄ and F₂₀ realizations in the same inverse-Galois family"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Extends: base inverse Galois problem"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Richard Dedekind's theorem (1878) connects the arithmetic of a number field to permutation groups: for a monic integer polynomial p and a prime ℓ not dividing the discriminant, the factorization type of p mod ℓ into distinct irreducibles equals the cycle type of the Frobenius element in Gal(p) acting on the roots. This is the workhorse for computing Galois groups by hand: reduce mod several primes, read off cycle types, and assemble the group. The parent entry realizes A₅ (the smallest non-solvable simple group) as a Galois group over ℚ using the quintic q(x) = x⁵−5x⁴+10x³−10x²+25x−5, but its proof depends on one Dedekind consequence that Mathlib cannot yet supply: that 3 divides |Gal(q)|, which classically follows because q mod 7 factors with a 3-cycle Frobenius. This entry dissects that dependency into its fully-formalizable parts — the arithmetic factorization and the group-theoretic eliminator — leaving exactly one irreducible gap (constructing the Frobenius permutation), which is owned by the still-open Mathlib Dedekind formalization.",
+    "problemStatement": "Verify, with no axioms, the ingredients that Dedekind's theorem consumes to force 3 ∣ |Gal(q)| for q = x⁵−5x⁴+10x³−10x²+25x−5: (A) q mod 7 = (X−5)(X−6)(X³+6X²+4X+1), a product of distinct irreducibles of degree type (1,1,3) and squarefree; and (B) the deterministic group theory — a σ ∈ Gal(q) acting on the roots as an n-cycle forces n ∣ |Gal(q)|, in arbitrary cycle length against the concrete Polynomial.Gal type.",
+    "text": "The formalization splits along the two halves Dedekind's theorem bridges. Half (A), the arithmetic, is fully elementary over finite fields: the cubic factors X³+6X²+4X+1 mod 7 and X³+…+1 mod 11 are shown irreducible by checking they have no roots (degree ≤ 3 + no root ⟹ irreducible), the two linear factors are irreducible and pairwise non-associated, hence the product is squarefree and ℓ ∤ disc(q). Half (B), the group theory, transports order information through the faithful permutation representation galActionHom : q.Gal →* Perm(rootSet): the order of a Galois element equals the order of the permutation it induces, the order of a single n-cycle is n (its cycle type is {n} and lcm{n} = n), and orderOf_dvd_card finishes with n ∣ |Gal(q)|. The n=3 corollary is the faithful interface for the parent's open axiom, and the n=5 corollary reuses the same eliminator for the already-proven 5 ∣ |Gal(q)| input. A gap-characterization file proves three_dvd_gal_card ⇔ |q.Gal| = 60, showing the lone axiom carries the entire remaining weight.",
+    "proofStrategy": "The seven files are layered from arithmetic to abstraction: InverseGaloisOQ06OQ02 (mod-7 factorization, the Dedekind input) and InverseGaloisOQ06OQ02P11 (independent mod-11 corroboration) supply half (A); InverseGaloisOQ06OQ02Cycle isolates the abstract (1,1,3) cycle-type consequence over Perm(Fin 5); InverseGaloisOQ06OQ02GalAction and InverseGaloisOQ06OQ02GalBridge instantiate the deterministic eliminator against the concrete q.Gal; InverseGaloisOQ06OQ02GenCycle generalizes it to arbitrary cycle length (subsuming both the 3-cycle and 5-cycle inputs); and InverseGaloisOQ06OQ02GapChar characterizes the residual axiom. Every file is 0-axiom / 0-sorry; the only mathematics left outside is producing the Frobenius permutation itself (Dedekind's theorem), which Mathlib does not yet formalize.",
+    "keyInsights": [
+      "Dedekind's theorem factors into an arithmetic half (mod-ℓ factorization type) and a group-theoretic half (cycle type ⟹ order-divisibility); the second half is entirely provable in current Mathlib, cleanly isolating the one genuine gap.",
+      "Irreducibility of the degree-3 mod-ℓ factors reduces to a finite root check: a cubic over a field is irreducible iff it has no root, so the arithmetic input is decidable and axiom-free.",
+      "The permutation representation galActionHom is faithful (injective), so orderOf is preserved — this single fact converts every cycle-type statement about roots into a divisibility statement about |Gal|.",
+      "Generalizing the 3-cycle bridge to arbitrary n-cycles is not idle: the n=5 instance is exactly the faithful interface for the parent's already-proven 5 ∣ |Gal(q)| constraint, so one uniform lemma serves both prime inputs of the A₅ computation.",
+      "The gap characterization three_dvd_gal_card ⇔ |q.Gal| = 60 proves the lone remaining axiom has no slack: it is logically equivalent to the exact cardinality the whole A₅ realization needs.",
+      "A second unramified prime (p = 11) is verified independently, giving corroborating (1,1,3) evidence for the same 3-cycle Frobenius conclusion the axiom asserts."
+    ],
+    "prerequisites": [
+      "Galois theory: Galois groups of polynomials, Polynomial.Gal, root sets and the permutation action",
+      "Finite fields: irreducibility of low-degree polynomials over F_p via root checks",
+      "Group theory: cycle types, orders of permutations, orderOf_dvd_card, faithful representations",
+      "Dedekind's theorem (background): mod-p factorization type ↦ Frobenius cycle type"
+    ]
+  },
+  "conclusion": {
+    "summary": "This entry fully verifies (0 axioms, 0 sorries, no native_decide) the two ingredients Dedekind's theorem consumes to force 3 ∣ |Gal(q)| in the parent A₅ realization: the arithmetic (1,1,3) factorization of q mod 7 (corroborated mod 11), and the deterministic group-theoretic eliminator that an n-cycle on the roots forces n ∣ |Gal(q)|, in arbitrary cycle length against the concrete Polynomial.Gal. A gap-characterization theorem shows the parent's lone open axiom three_dvd_gal_card is equivalent to |q.Gal| = 60, pinpointing the exact residual dependency.",
+    "implications": "The work sharpens the parent's honest scope: everything except the construction of the Frobenius permutation itself is now machine-checked. The general cycle-length bridge is a reusable interface for Galois-group cardinality arguments — it already serves both the 3-cycle and 5-cycle inputs of the A₅ computation from a single lemma — and will connect directly to a future Mathlib Dedekind's theorem to eliminate the last axiom.",
+    "openQuestions": [
+      "Formalize Dedekind's theorem in Mathlib (mod-p factorization type ↦ Frobenius cycle type in Gal), which would produce the Frobenius permutation and discharge three_dvd_gal_card outright.",
+      "Combine the mod-7 and mod-11 witnesses via a Chebotarev-style density argument to give an axiom-free existence proof of an order-3 element in Gal(q).",
+      "Package the general n-cycle bridge as a standalone Mathlib-ready lemma about faithful permutation representations of Galois groups."
+    ]
+  },
+  "leanFile": {
+    "namespace": "InverseGaloisOQ06OQ02",
+    "lineCount": 225,
+    "axiomCount": 0,
+    "theoremCount": 64,
+    "definitionCount": 1,
+    "path": "Proofs/InverseGaloisOQ06OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/InverseGaloisOQ06OQ02Cycle.lean",
+      "Proofs/InverseGaloisOQ06OQ02GalAction.lean",
+      "Proofs/InverseGaloisOQ06OQ02GalBridge.lean",
+      "Proofs/InverseGaloisOQ06OQ02GapChar.lean",
+      "Proofs/InverseGaloisOQ06OQ02GenCycle.lean",
+      "Proofs/InverseGaloisOQ06OQ02P11.lean"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-oq-06",
+      "relationship": "extends",
+      "description": "The parent A₅-over-ℚ realization; this entry isolates, generalizes, and characterizes its sole open axiom three_dvd_gal_card into fully-verified Dedekind inputs plus one residual Mathlib gap."
+    },
+    {
+      "targetId": "inverse-galois-oq-01",
+      "relationship": "related",
+      "description": "Sibling realizations (D₄, F₂₀) in the same inverse-Galois problem family."
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Base inverse Galois entry that this problem family extends."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Problem

The research problem **inverse-galois-oq-06-oq-02** ("The Dedekind input for A₅") shipped **seven** VERIFIED, 0-axiom Lean files across PRs #30359, #31031, #31055, #31085, #31137, #31276, #31544 — but a `src/data/proofs/inverse-galois-oq-06-oq-02/` directory was **never created**. Result: **64 theorems / 1 def / ~1045 lines** of verified work were completely invisible in the gallery (an orphan-scan gap: the `.lean` files are referenced by no `meta.json`).

## Fix

Adds `meta.json` + `annotations.json`, modeled on the sibling parent `inverse-galois-oq-06`.

**Files covered** (all 0-axiom / 0-sorry / no native_decide):

| File | Lines | Role |
|---|---|---|
| `InverseGaloisOQ06OQ02.lean` (main) | 225 | mod-7 factor type `(1,1,3)` — the Dedekind input |
| `InverseGaloisOQ06OQ02P11.lean` | 244 | independent mod-11 `(1,1,3)` corroboration |
| `InverseGaloisOQ06OQ02GenCycle.lean` | 127 | general bridge: n-cycle ⟹ n ∣ \|Gal\| |
| `InverseGaloisOQ06OQ02GalBridge.lean` | 116 | deterministic half against real `q.Gal` |
| `InverseGaloisOQ06OQ02GalAction.lean` | 113 | faithful permutation-representation bridge |
| `InverseGaloisOQ06OQ02Cycle.lean` | 111 | abstract `(1,1,3)` cycle-type consequence |
| `InverseGaloisOQ06OQ02GapChar.lean` | 109 | gap characterization: axiom ⇔ \|q.Gal\|=60 |

## Metadata

- `status`: **verified**, `badge`: **original**, `axiomCount`: **0**
- Every theorem is fully machine-checked (0 axiom declarations, 0 sorries, no `native_decide`; depends only on propext / Classical.choice / Quot.sound). These files do **not** discharge the parent entry's open axiom `three_dvd_gal_card` — they verify the deterministic inputs it consumes, leaving exactly one Mathlib gap (Dedekind's theorem producing the Frobenius permutation).

## Validation

- `meta.json` / `annotations.json` parse; all 3 crossReference targets exist.
- `pnpm annotations:validate` reports **0 errors for this slug** (the 5 annotation ranges anchor to real Lean constructs in the main file).
- Metadata-only change; no Lean source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)