### PR TITLE
research(erdos-10-incomplete-01-oq-01): exact k=2 characterization mem_two_iff [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos10Incomplete01OQ01.lean
+++ b/proofs/Proofs/Erdos10Incomplete01OQ01.lean
@@ -1,0 +1,112 @@
+/-
+# Erdős Problem #10 — Incomplete 01, Open Question 01
+## The exact characterization of the `k = 2` level `mem_two_iff`
+
+Erdős Problem #10 asks whether there is a finite `k` such that every sufficiently large
+integer is the sum of a prime and at most `k` powers of `2`.  The parent file
+`Erdos10Incomplete01.lean` sets up the family
+
+  `sumPrimeAndTwoPows k = { n | ∃ p (pows : Multiset ℕ),
+                                p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2^·)).sum }`,
+
+and pins down the two smallest budgets *exactly*:
+
+* `mem_zero_iff` — `sumPrimeAndTwoPows 0` is exactly the primes;
+* `mem_one_iff`  — `n ∈ sumPrimeAndTwoPows 1` iff `n` is prime or `n = p + 2^a`.
+
+This file supplies the **next** exact level, closing the natural gap left open by the parent:
+
+* `mem_two_iff`  — `n ∈ sumPrimeAndTwoPows 2` iff `n` is prime, or `n = p + 2^a`,
+  or `n = p + 2^a + 2^b` for a prime `p` and exponents `a, b`.
+
+The characterization is *tight*: the three disjuncts correspond exactly to using `0`, `1`,
+or `2` powers of two.  The forward direction splits on `pows.card ∈ {0, 1, 2}` (using
+`Multiset.card_eq_zero / _one / _two`); the reverse direction exhibits an explicit multiset of
+exponents of the appropriate cardinality.  Everything is elementary and **axiom-free**.
+
+The definition and helper lemmas are restated here so that the file is self-contained and
+verifiable against Mathlib alone (it mirrors `Erdos10Incomplete01.lean` verbatim).
+
+## References
+- Erdős, P. (1950). "On integers of the form `2^k + p` and some related problems."
+  Summa Brasiliensis Mathematicae 2, 113–123.
+- Erdős, P.; Graham, R. (1980). *Old and New Problems and Results in Combinatorial Number
+  Theory.*
+- [erdosproblems.com/10](https://www.erdosproblems.com/10)
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Prime.Basic
+
+namespace Erdos10Incomplete01OQ01
+
+/-- The set of natural numbers expressible as a prime plus **at most `k`** powers of `2`.
+The powers-of-two component is recorded as a multiset of exponents of cardinality `≤ k`
+(so repeated powers, e.g. `2^3 + 2^3`, are permitted).  This matches the definition in the
+parent files `Erdos10Problem.lean` / `Erdos10Incomplete01.lean`. -/
+def sumPrimeAndTwoPows (k : ℕ) : Set ℕ :=
+  { n | ∃ (p : ℕ) (pows : Multiset ℕ),
+      p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2 ^ ·)).sum }
+
+/-! ## Membership basics (restated from the parent) -/
+
+/-- Every prime is a member of `sumPrimeAndTwoPows k` for every `k`: use zero powers of two. -/
+theorem prime_mem {p : ℕ} (hp : p.Prime) (k : ℕ) : p ∈ sumPrimeAndTwoPows k :=
+  ⟨p, 0, hp, by simp, by simp⟩
+
+/-- A prime plus a single power of two lies in `sumPrimeAndTwoPows 1`. -/
+theorem prime_add_pow_mem {p : ℕ} (hp : p.Prime) (a : ℕ) :
+    p + 2 ^ a ∈ sumPrimeAndTwoPows 1 :=
+  ⟨p, {a}, hp, by simp, by simp⟩
+
+/-- The family `sumPrimeAndTwoPows` is increasing in the budget `k`. -/
+theorem mem_mono {k k' : ℕ} (h : k ≤ k') :
+    sumPrimeAndTwoPows k ⊆ sumPrimeAndTwoPows k' := by
+  rintro n ⟨p, pows, hp, hcard, rfl⟩
+  exact ⟨p, pows, hp, hcard.trans h, rfl⟩
+
+/-- A prime plus two powers of two lies in `sumPrimeAndTwoPows 2`. -/
+theorem prime_add_two_pows_mem {p : ℕ} (hp : p.Prime) (a b : ℕ) :
+    p + 2 ^ a + 2 ^ b ∈ sumPrimeAndTwoPows 2 :=
+  ⟨p, a ::ₘ {b}, hp, by simp, by simp [add_assoc]⟩
+
+/-! ## The `k = 2` case, exactly -/
+
+/-- **Exact characterization of the `k = 2` level.**
+`n` is a prime plus *at most two* powers of two exactly when one of three things holds:
+`n` is prime (zero powers), `n = p + 2^a` (one power), or `n = p + 2^a + 2^b` (two powers),
+for a prime `p` and exponents `a, b`.  This is the sharp extension of the parent's
+`mem_zero_iff` and `mem_one_iff`. -/
+theorem mem_two_iff {n : ℕ} :
+    n ∈ sumPrimeAndTwoPows 2 ↔
+      n.Prime
+      ∨ (∃ p a, p.Prime ∧ n = p + 2 ^ a)
+      ∨ (∃ p a b, p.Prime ∧ n = p + 2 ^ a + 2 ^ b) := by
+  constructor
+  · rintro ⟨p, pows, hp, hcard, rfl⟩
+    have hc : pows.card = 0 ∨ pows.card = 1 ∨ pows.card = 2 := by omega
+    rcases hc with h0 | h1 | h2
+    · -- zero powers: `n` is the prime `p`
+      rw [Multiset.card_eq_zero] at h0; subst h0
+      left; simpa using hp
+    · -- one power: `n = p + 2^a`
+      rw [Multiset.card_eq_one] at h1; obtain ⟨a, ha⟩ := h1; subst ha
+      right; left; exact ⟨p, a, hp, by simp⟩
+    · -- two powers: `n = p + 2^a + 2^b`
+      rw [Multiset.card_eq_two] at h2; obtain ⟨a, b, hab⟩ := h2; subst hab
+      right; right; exact ⟨p, a, b, hp, by simp [add_assoc]⟩
+  · rintro (hp | ⟨p, a, hp, rfl⟩ | ⟨p, a, b, hp, rfl⟩)
+    · exact prime_mem hp 2
+    · exact mem_mono (by norm_num) (prime_add_pow_mem hp a)
+    · exact prime_add_two_pows_mem hp a b
+
+/-- Corollary: any prime plus two (possibly equal) powers of two lands in the `k = 2` level —
+the "hardest" of the three disjuncts of `mem_two_iff`, isolated for downstream reuse. -/
+theorem two_pows_mem_two {p a b : ℕ} (hp : p.Prime) :
+    p + 2 ^ a + 2 ^ b ∈ sumPrimeAndTwoPows 2 :=
+  prime_add_two_pows_mem hp a b
+
+#check @mem_two_iff
+#check @prime_add_two_pows_mem
+
+end Erdos10Incomplete01OQ01

--- a/src/data/proofs/erdos-10-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-10-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-header-erdos10inc01oq01",
+    "proofId": "erdos-10-incomplete-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "The k=2 level of Erdős #10, made exact",
+    "content": "Erdős Problem #10 asks for a finite k making every large integer a prime plus at most k powers of 2; Erdős and Graham conjectured no such k exists. The parent foundations file pinned down the two smallest budgets exactly — k=0 is precisely the primes (mem_zero_iff), k=1 is 'prime, or prime + one power of 2' (mem_one_iff) — and listed the k=2 case as its first open question. This file closes it: mem_two_iff describes sumPrimeAndTwoPows 2 exactly. The definition and helper lemmas are restated verbatim so the entry verifies against Mathlib alone.",
+    "mathContext": "The object is $S_k = \\{\\,n : \\exists p\\ (\\text{pows}),\\ p\\text{ prime},\\ |\\text{pows}|\\le k,\\ n = p + \\sum_{a\\in\\text{pows}} 2^a\\,\\}$; here we compute $S_2$ exactly.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Erdős problems",
+      "powers of two",
+      "additive number theory",
+      "representation functions",
+      "exact characterization"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "powers of two"
+    ]
+  },
+  {
+    "id": "ann-definition-basics-erdos10inc01oq01",
+    "proofId": "erdos-10-incomplete-01-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "sumPrimeAndTwoPows k and the reused constructors",
+    "content": "Restates the representation set (a prime plus at most k powers of 2, exponents recorded as a multiset with pows.card ≤ k) together with three helper lemmas carried over from the parent: prime_mem (every prime lies in every level, via the empty exponent multiset), prime_add_pow_mem (a prime plus one power lies in level 1, via a singleton), and mem_mono (k ≤ k′ ⟹ S_k ⊆ S_{k′}, same witness with a relaxed cardinality bound). These supply the zero- and one-power disjuncts of the main theorem.",
+    "mathContext": "$S_k = \\{ n : \\exists p\\ (\\text{pows}:\\text{Multiset }\\mathbb N),\\ p\\text{ prime} \\land |\\text{pows}| \\le k \\land n = p + \\sum_{a\\in\\text{pows}} 2^a \\}$; $p$ prime $\\Rightarrow p, p+2^a \\in S_1$; $k\\le k' \\Rightarrow S_k \\subseteq S_{k'}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiset",
+      "Multiset.card",
+      "monotone family",
+      "existential witness"
+    ],
+    "prerequisites": [
+      "multisets",
+      "prime numbers",
+      "set inclusion"
+    ]
+  },
+  {
+    "id": "ann-two-power-builder-erdos10inc01oq01",
+    "proofId": "erdos-10-incomplete-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 71
+    },
+    "type": "tactic",
+    "title": "prime_add_two_pows_mem: the two-power constructor",
+    "content": "For any prime p and exponents a, b, the number p + 2^a + 2^b is a member of sumPrimeAndTwoPows 2, witnessed by the two-element exponent multiset a ::ₘ {b}. Its cardinality is 2 (≤ 2) and its mapped sum is 2^a + 2^b, so p + (a ::ₘ {b}).map(2^·)).sum = p + 2^a + 2^b after associativity — discharged by `simp [add_assoc]`. This is the constructive core of the hardest disjunct of mem_two_iff.",
+    "mathContext": "$p$ prime $\\Rightarrow p + 2^a + 2^b \\in S_2$, witnessed by the exponent multiset $\\{a,b\\}$ of cardinality $2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Multiset.cons",
+      "Multiset.map",
+      "Multiset.sum",
+      "existential witness"
+    ],
+    "prerequisites": [
+      "multiset operations",
+      "associativity of addition"
+    ]
+  },
+  {
+    "id": "ann-mem-two-iff-erdos10inc01oq01",
+    "proofId": "erdos-10-incomplete-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 101
+    },
+    "type": "tactic",
+    "title": "mem_two_iff: the exact k=2 characterization",
+    "content": "n ∈ sumPrimeAndTwoPows 2 iff n is prime, or n = p + 2^a, or n = p + 2^a + 2^b for a prime p. Forward: from a witness with pows.card ≤ 2, `omega` splits pows.card ∈ {0,1,2}; Multiset.card_eq_zero collapses the exponent multiset to ∅ (n = p prime), card_eq_one to a singleton {a} (n = p + 2^a), and card_eq_two to a pair {a,b} (n = p + 2^a + 2^b, sum computed by simp). Reverse: the three disjuncts are discharged by prime_mem (level via empty multiset), mem_mono (by norm_num) ∘ prime_add_pow_mem (lift the one-power case from level 1), and prime_add_two_pows_mem. The three cases are in exact bijection with the number of powers used.",
+    "mathContext": "$n \\in S_2 \\iff n\\text{ prime} \\lor (\\exists p\\,a,\\ p\\text{ prime} \\land n = p + 2^a) \\lor (\\exists p\\,a\\,b,\\ p\\text{ prime} \\land n = p + 2^a + 2^b)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Multiset.card_eq_zero",
+      "Multiset.card_eq_one",
+      "Multiset.card_eq_two",
+      "case analysis",
+      "omega"
+    ],
+    "prerequisites": [
+      "multiset cardinality lemmas",
+      "disjunction elimination",
+      "existential introduction"
+    ]
+  },
+  {
+    "id": "ann-corollary-erdos10inc01oq01",
+    "proofId": "erdos-10-incomplete-01-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "two_pows_mem_two: the two-power disjunct extracted",
+    "content": "A standalone restatement of the hardest disjunct of mem_two_iff — any prime plus two (possibly equal) powers of two lies in sumPrimeAndTwoPows 2 — packaged for direct downstream reuse (e.g. by non-representability arguments that need to test membership at level 2).",
+    "mathContext": "$p$ prime $\\Rightarrow p + 2^a + 2^b \\in S_2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "corollary",
+      "membership at level 2"
+    ],
+    "prerequisites": [
+      "mem_two_iff"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-10-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-incomplete-01-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "erdos-10-incomplete-01-oq-01",
+  "title": "The Exact k=2 Characterization for Erdős #10 (mem_two_iff)",
+  "slug": "erdos-10-incomplete-01-oq-01",
+  "description": "An axiom-free extension of the exact small-budget theory of Erdős Problem #10's representation set sumPrimeAndTwoPows k (integers expressible as a prime plus at most k powers of 2). The parent file characterizes the budgets k=0 (exactly the primes) and k=1 (prime, or prime + one power of 2) and lists the k=2 case as an open question; this file proves it: n ∈ sumPrimeAndTwoPows 2 iff n is prime, or n = p + 2^a, or n = p + 2^a + 2^b for a prime p and exponents a, b (mem_two_iff). The forward direction is a cardinality analysis on the exponent multiset (pows.card ∈ {0,1,2} via Multiset.card_eq_zero / _one / _two); the reverse exhibits an explicit exponent multiset per disjunct. Fully machine-checked: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/10",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10Incomplete01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "erdos",
+      "primes",
+      "additive-combinatorics",
+      "powers-of-2",
+      "multiset",
+      "representation-functions"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 112,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. All results depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound), confirmed by #print axioms. The definition and helper lemmas are restated verbatim from the parent file so the proof is self-contained against Mathlib alone.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether some finite k makes every sufficiently large integer a prime plus at most k powers of 2; Erdős and Graham conjectured no such k exists. The problem is naturally stratified by the budget k, and the exact description of each small level is the base data every quantitative argument builds on. Crocker (1971) exhibited infinitely many odd integers that are NOT a prime plus at most two powers of two, so k=2 is provably insufficient — which makes the exact membership description at k=2 (this file) the precise object those non-representability results contradict. The parent foundations file pinned down k=0 and k=1 exactly and explicitly left k=2 as its first open question; this file closes it.",
+    "problemStatement": "Prove the exact characterization of the k=2 level of sumPrimeAndTwoPows k = { n | ∃ p (pows : Multiset ℕ), p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2^·)).sum }: show n ∈ sumPrimeAndTwoPows 2 holds iff n is prime, or n = p + 2^a, or n = p + 2^a + 2^b for a prime p and exponents a, b.",
+    "text": "Extends the parent's exact k=0 and k=1 descriptions to k=2. The 'at most two powers of two' budget resolves into exactly three cases — zero, one, or two powers — mirrored by the three disjuncts of mem_two_iff. Also isolates the two-power building lemma prime_add_two_pows_mem (a prime plus any two powers of two lands in level 2) for downstream reuse.",
+    "proofStrategy": "Forward: from a witness (p, pows) with pows.card ≤ 2, split pows.card ∈ {0,1,2}. card = 0 gives pows = 0 (Multiset.card_eq_zero) so n = p is prime; card = 1 gives a singleton {a} (Multiset.card_eq_one) so n = p + 2^a; card = 2 gives {a, b} (Multiset.card_eq_two) so n = p + 2^a + 2^b, with the sum computed by Multiset.map/sum on a two-element multiset. Reverse: each disjunct is witnessed by an exponent multiset of the right cardinality — the empty multiset (prime_mem), a singleton lifted from level 1 via mem_mono, and the cons a ::ₘ {b} for the two-power case (prime_add_two_pows_mem). Everything is elementary; the only arithmetic is associativity of + on the reconstructed sum.",
+    "keyInsights": [
+      "**Three-way split**: 'at most two powers of 2' is exactly 'zero, one, or two powers', and the multiset cardinality bound pows.card ≤ 2 makes this an omega-driven case split — the three disjuncts of mem_two_iff are in bijection with card ∈ {0,1,2}.",
+      "**Multiset.card_eq_two is the workhorse**: the genuinely new case over the parent is card = 2, where Multiset.card_eq_two turns the exponent multiset into a concrete pair {a, b}, and Multiset.map/sum reconstruct n = p + 2^a + 2^b.",
+      "**Reuse via monotonicity**: the one-power disjunct is not re-proved — it is imported from level 1 through mem_mono (1 ≤ 2), showing how the monotone tower from the parent file lets each new level lean on the previous.",
+      "**Sharp, not asymptotic**: unlike the density results of Romanoff/Gallagher, this is an exact set equality; combined with Crocker's theorem (k=2 insufficient) it shows the characterized level 2, while explicit, still misses infinitely many integers — locating precisely where the open problem lives.",
+      "**Template for general k**: the same Multiset.card_eq_* case analysis extends verbatim to any fixed k, so mem_two_iff is the k=2 instance of a uniform finite-budget membership decision."
+    ],
+    "prerequisites": [
+      "Prime numbers and divisibility",
+      "Multisets, their cardinality, and Multiset.card_eq_zero / card_eq_one / card_eq_two",
+      "Powers of two and multiset map/sum",
+      "Set membership and monotone families",
+      "Case analysis by cardinality"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Frames Erdős #10 and the k=2 goal, recalling the parent's exact k=0 and k=1 characterizations and stating mem_two_iff as their sharp extension. Notes that the definition and helper lemmas are restated so the file is self-contained against Mathlib.",
+      "startLine": 1,
+      "endLine": 42,
+      "mathContext": "sumPrimeAndTwoPows k collects n = p + Σ 2^(a_i) with p prime and at most k exponents; mem_two_iff describes the k=2 level exactly."
+    },
+    {
+      "id": "definition-and-basics",
+      "title": "Definition and membership basics",
+      "summary": "Restates sumPrimeAndTwoPows k (multiset-of-exponents encoding, pows.card ≤ k) and the helper lemmas reused from the parent: prime_mem (every prime is in every level via the empty multiset), prime_add_pow_mem (prime + one power lies in level 1), and mem_mono (the family is increasing in k).",
+      "startLine": 43,
+      "endLine": 66,
+      "mathContext": "$S_k = \\{ n : \\exists p\\ (\\text{pows}),\\ p\\text{ prime},\\ |\\text{pows}| \\le k,\\ n = p + \\sum_{a\\in\\text{pows}} 2^a \\}$; $p$ prime $\\Rightarrow p \\in S_k$; $k \\le k' \\Rightarrow S_k \\subseteq S_{k'}$."
+    },
+    {
+      "id": "two-power-builder",
+      "title": "The two-power building lemma",
+      "summary": "`prime_add_two_pows_mem`: for any prime p and exponents a, b, the number p + 2^a + 2^b lies in sumPrimeAndTwoPows 2, witnessed by the two-element exponent multiset a ::ₘ {b}. This is the constructive core of the hardest disjunct of mem_two_iff.",
+      "startLine": 68,
+      "endLine": 71,
+      "mathContext": "$p$ prime $\\Rightarrow p + 2^a + 2^b \\in S_2$ (witness: exponent multiset $\\{a, b\\}$, cardinality $2$)."
+    },
+    {
+      "id": "mem-two-iff",
+      "title": "The k=2 case, exactly",
+      "summary": "`mem_two_iff`: n ∈ sumPrimeAndTwoPows 2 iff n is prime, or n = p + 2^a, or n = p + 2^a + 2^b. Forward direction splits pows.card ∈ {0,1,2} (Multiset.card_eq_zero / card_eq_one / card_eq_two) and reads off the three shapes; reverse direction discharges each disjunct via prime_mem, mem_mono ∘ prime_add_pow_mem, and prime_add_two_pows_mem.",
+      "startLine": 73,
+      "endLine": 101,
+      "mathContext": "$n \\in S_2 \\iff n\\text{ prime} \\lor (\\exists p\\,a,\\ p\\text{ prime} \\land n = p + 2^a) \\lor (\\exists p\\,a\\,b,\\ p\\text{ prime} \\land n = p + 2^a + 2^b)$."
+    },
+    {
+      "id": "corollary",
+      "title": "Corollary: two powers land in level 2",
+      "summary": "`two_pows_mem_two` isolates the hardest disjunct of mem_two_iff as a standalone statement — any prime plus two (possibly equal) powers of two is a member of sumPrimeAndTwoPows 2 — for direct downstream use.",
+      "startLine": 103,
+      "endLine": 107,
+      "mathContext": "$p$ prime $\\Rightarrow p + 2^a + 2^b \\in S_2$ (the two-power disjunct, extracted)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Closes the first open question of the parent foundations file by proving mem_two_iff: the k=2 level of Erdős #10's representation set is exactly {n prime} ∪ {p + 2^a} ∪ {p + 2^a + 2^b}, with zero axioms and zero sorries. The proof is a clean cardinality analysis on the exponent multiset (card ∈ {0,1,2}), reusing the parent's monotonicity to inherit the one-power case and adding the two-power builder prime_add_two_pows_mem.",
+    "implications": "The exact k=2 description is the precise object that Crocker's 1971 non-representability theorem contradicts (k=2 does not suffice), so pinning it down sharpens the boundary of the open Erdős–Graham problem: level 2 is fully explicit yet still misses infinitely many integers. Methodologically, the Multiset.card_eq_* case split used here is uniform in k, giving a template for the finite-budget membership decisions that any quantitative attack on the problem must make.",
+    "openQuestions": [
+      "Generalize to a uniform mem_iff for arbitrary fixed k: n ∈ sumPrimeAndTwoPows k iff n = p + Σ_{i<j} 2^{a_i} for a prime p and some j ≤ k exponents, replacing the ad hoc three-disjunct form with a single existential over a list/multiset of length ≤ k.",
+      "Formalize Crocker's obstruction against this exact level: exhibit an infinite family of integers provably outside sumPrimeAndTwoPows 2, complementing mem_two_iff with a concrete non-membership witness.",
+      "Bridge to density: combine mem_two_iff with the parent's infinitude to state and (eventually) bound the counting function of sumPrimeAndTwoPows 2 below x."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10-incomplete-01",
+      "relationship": "extends",
+      "description": "Proves mem_two_iff, the first open question listed by the parent foundations file, using its mem_mono and the same Multiset.card case-analysis pattern as mem_zero_iff / mem_one_iff."
+    },
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Erdős Problem #10: sharpens the exact structural description of the representation set to the k=2 budget."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P.; Graham, R.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Enseign. Math. Monograph 28",
+      "note": "The conjecture that no finite k makes every large integer a prime plus at most k powers of 2."
+    },
+    {
+      "authors": "Crocker, R.",
+      "title": "On the sum of a prime and of two powers of two",
+      "year": "1971",
+      "venue": "Pacific J. Math. 36:103–107",
+      "note": "There are infinitely many odd integers that are not the sum of a prime and at most two powers of two — so the k=2 level characterized here still misses infinitely many n."
+    },
+    {
+      "authors": "Romanoff, N. P.",
+      "title": "Über einige Sätze der additiven Zahlentheorie",
+      "year": "1934",
+      "venue": "Math. Ann. 109:668–678",
+      "note": "A positive proportion of integers are a prime plus a single power of 2 (the k=1 density result)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Prime.Basic"
+    ],
+    "namespace": "Erdos10Incomplete01OQ01",
+    "lineCount": 112,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "path": "Proofs/Erdos10Incomplete01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 1
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **first open question** of the Erdős #10 foundations file `erdos-10-incomplete-01`, which characterized the representation set `sumPrimeAndTwoPows k` (integers = prime + at most `k` powers of 2) exactly at `k=0` (`mem_zero_iff`) and `k=1` (`mem_one_iff`) and explicitly listed `mem_two_iff` as its top open question.

This adds the exact **k=2** characterization:

```
n ∈ sumPrimeAndTwoPows 2  ↔  n.Prime
                            ∨ (∃ p a, p.Prime ∧ n = p + 2^a)
                            ∨ (∃ p a b, p.Prime ∧ n = p + 2^a + 2^b)
```

## Proof

- **Forward**: from a witness with `pows.card ≤ 2`, `omega` splits `pows.card ∈ {0,1,2}`; `Multiset.card_eq_zero / card_eq_one / card_eq_two` collapse the exponent multiset to `∅ / {a} / {a,b}`, reading off the three shapes.
- **Reverse**: `prime_mem` (zero powers), `mem_mono (1≤2) ∘ prime_add_pow_mem` (reuses the parent's monotone tower for the one-power case), and a new two-power constructor `prime_add_two_pows_mem`.

The three disjuncts are in exact bijection with the number of powers used. Combined with Crocker's 1971 theorem (k=2 insufficient), this pins down the precise, fully explicit level that still misses infinitely many integers.

## Verification

- **6 theorems, 1 def, 112 lines, 0 sorries, 0 axioms**
- `#print axioms` → only `propext`, `Classical.choice`, `Quot.sound` (standard foundational trio; not counted).
- Self-contained: imports `Mathlib` only (def + helper lemmas restated verbatim from the parent), verified via `lake env lean`.
- New gallery entry: `meta.json` + `annotations.json` (passes `gallery:check-size`; annotations produce zero validation errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)