### PR TITLE
Enrich Weyr characteristic entry: add 7 annotations (cayley-hamilton-minpoly-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "chm-oq0104-ann-pow-succ",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 51, "endLine": 61 },
+    "type": "technique",
+    "title": "Powers of N and their nested kernels",
+    "content": "Two elementary facts set up the whole argument. First, pow_succ_apply factors an extra application of N out of a power: Nᵏ⁺¹ x = Nᵏ(N x). Second, ker_pow_le_succ shows the kernels of successive powers form an increasing chain: if x is killed by Nᵏ it is killed by Nᵏ⁺¹, because Nᵏ⁺¹ x = N(Nᵏ x) = N 0 = 0. This ascending kernel chain ker N⁰ ≤ ker N¹ ≤ ker N² ≤ ⋯ is exactly the generalized-eigenspace filtration once N = f − μ.",
+    "mathContext": "$\\ker N^0 \\subseteq \\ker N^1 \\subseteq \\ker N^2 \\subseteq \\cdots$, with $N^{k+1}x = N^k(Nx) = N(N^k x)$; the sequence stabilizes at $\\ker N^{\\dim V}$ (the maximal generalized eigenspace).",
+    "significance": "supporting",
+    "relatedConcepts": ["operator powers", "kernel filtration", "generalized eigenspaces", "nilpotent part"],
+    "prerequisites": ["linear maps", "kernels", "monoid powers of an endomorphism"]
+  },
+  {
+    "id": "chm-oq0104-ann-rank-nullity",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "insight",
+    "title": "Rank–nullity realizes each dimension jump as a subspace",
+    "content": "This is the conceptual heart. Restrict the linear map Nᵏ to the subspace ker Nᵏ⁺¹ (formally, compose Nᵏ with the inclusion (ker Nᵏ⁺¹).subtype). Its range is the difference space Uₖ = Nᵏ(ker Nᵏ⁺¹); its kernel is {x ∈ ker Nᵏ⁺¹ : Nᵏ x = 0} = ker Nᵏ, which is legitimately a subspace of ker Nᵏ⁺¹ by the previous lemma. Mathlib's rank–nullity theorem finrank_range_add_finrank_ker then gives dim Uₖ + dim ker Nᵏ = dim ker Nᵏ⁺¹, i.e. dim Uₖ = aₖ₊₁ − aₖ. The comapSubtypeEquivOfLe rewrite is the bookkeeping that identifies the restricted map's kernel with ker Nᵏ inside the ambient space.",
+    "mathContext": "$\\dim\\operatorname{ran}(N^k|_{\\ker N^{k+1}}) + \\dim\\ker(N^k|_{\\ker N^{k+1}}) = \\dim\\ker N^{k+1}$, so $\\dim U_k = a_{k+1}-a_k$ where $U_k = N^k(\\ker N^{k+1})$.",
+    "significance": "key",
+    "relatedConcepts": ["rank–nullity theorem", "restriction of a linear map", "Submodule.map (image)", "difference space"],
+    "prerequisites": ["rank–nullity theorem", "images and preimages of submodules", "finite-dimensional linear algebra"]
+  },
+  {
+    "id": "chm-oq0104-ann-diff-antitone",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 76, "endLine": 87 },
+    "type": "insight",
+    "title": "The quotient-free crux: the difference spaces nest",
+    "content": "The whole monotonicity collapses to one inclusion, Uₖ₊₁ ⊆ Uₖ. Take y ∈ Uₖ₊₁, so y = Nᵏ⁺¹ x with Nᵏ⁺² x = 0. Rewrite y = Nᵏ(N x); the witness N x lies in ker Nᵏ⁺¹ because Nᵏ⁺¹(N x) = Nᵏ⁺² x = 0. Hence y ∈ Nᵏ(ker Nᵏ⁺¹) = Uₖ. This one-line preimage computation replaces the usual construction of an injection between successive quotients ker Nᵏ⁺¹ / ker Nᵏ ↪ ker Nᵏ / ker Nᵏ⁻¹ — no quotient spaces are ever formed.",
+    "mathContext": "$y = N^{k+1}x = N^k(Nx)$ with $Nx \\in \\ker N^{k+1}$ (since $N^{k+1}(Nx)=N^{k+2}x=0$), so $U_{k+1} = N^{k+1}(\\ker N^{k+2}) \\subseteq N^k(\\ker N^{k+1}) = U_k$.",
+    "significance": "key",
+    "relatedConcepts": ["subspace inclusion", "preimage witness", "quotient-free argument", "Jordan chains"],
+    "prerequisites": ["image of a submodule under a linear map", "membership in ker and map"]
+  },
+  {
+    "id": "chm-oq0104-ann-concave",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 89, "endLine": 98 },
+    "type": "concept",
+    "title": "Concavity of the kernel-dimension sequence",
+    "content": "Assembling the pieces: dim Uₖ = aₖ₊₁ − aₖ and dim Uₖ₊₁ = aₖ₊₂ − aₖ₊₁ (two instances of finrank_diff_space), while Uₖ₊₁ ⊆ Uₖ gives dim Uₖ₊₁ ≤ dim Uₖ by finrank monotonicity. Therefore aₖ₊₂ − aₖ₊₁ ≤ aₖ₊₁ − aₖ, which omega rearranges into aₖ + aₖ₊₂ ≤ 2·aₖ₊₁. This is the discrete concavity (second difference ≤ 0) of the dimension sequence aₖ = dim ker Nᵏ, valid for any endomorphism N over any field.",
+    "mathContext": "$a_{k+2}-a_{k+1} \\le a_{k+1}-a_k \\;\\Longleftrightarrow\\; a_k + a_{k+2} \\le 2a_{k+1}$; equivalently the second difference $\\Delta^2 a_k \\le 0$.",
+    "significance": "key",
+    "relatedConcepts": ["concave sequence", "second difference", "monotonicity of dimension", "Weyr characteristic"],
+    "prerequisites": ["Submodule.finrank_mono", "integer arithmetic (omega)"]
+  },
+  {
+    "id": "chm-oq0104-ann-geneig",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 100, "endLine": 106 },
+    "type": "technique",
+    "title": "Transporting concavity to generalized eigenspaces",
+    "content": "The abstract concavity is stated for an arbitrary N; specializing N = f − μ·1 gives the spectral version. Mathlib's genEigenspace_nat identifies the generalized eigenspace genEigenspace μ k with ker (f − μ·1)ᵏ, so rewriting all three terms reduces the eigenspace concavity to finrank_ker_pow_concave applied to f − μ•1. Nothing about μ being an actual eigenvalue is needed: if μ is not in the spectrum every aₖ is 0 and the inequality holds trivially.",
+    "mathContext": "$\\operatorname{genEigenspace}(\\mu,k) = \\ker(f-\\mu\\cdot 1)^k$, so $\\dim\\operatorname{genEig}(\\mu,k) + \\dim\\operatorname{genEig}(\\mu,k{+}2) \\le 2\\dim\\operatorname{genEig}(\\mu,k{+}1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["generalized eigenspace", "eigenvalue", "spectral decomposition", "genEigenspace_nat"],
+    "prerequisites": ["generalized eigenspaces", "operator f − μ·1"]
+  },
+  {
+    "id": "chm-oq0104-ann-weyr-def",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 108, "endLine": 111 },
+    "type": "definition",
+    "title": "The Weyr number wₖ",
+    "content": "The k-th Weyr number is the jump wₖ = aₖ₊₁ − aₖ = dim genEigenspace μ (k+1) − dim genEigenspace μ k. Geometrically it counts the Jordan blocks for μ of size at least k+1: each such block contributes exactly one new dimension when passing from ker Nᵏ to ker Nᵏ⁺¹. The subtraction is truncated natural-number subtraction, but ker_pow_le_succ guarantees aₖ ≤ aₖ₊₁, so it agrees with genuine subtraction. The sequence (w₀, w₁, w₂, …) is the Weyr characteristic of f at μ.",
+    "mathContext": "$w_k = a_{k+1} - a_k = \\#\\{\\text{Jordan blocks for }\\mu\\text{ of size} \\ge k+1\\}$; the Weyr characteristic $(w_0,w_1,\\dots)$ is the conjugate partition of the Segre characteristic (the block-size multiset).",
+    "significance": "key",
+    "relatedConcepts": ["Weyr characteristic", "Segre characteristic", "Jordan block sizes", "conjugate partition"],
+    "prerequisites": ["partitions and Young diagrams", "generalized eigenspace dimensions"]
+  },
+  {
+    "id": "chm-oq0104-ann-weyr-antitone",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": { "startLine": 113, "endLine": 130 },
+    "type": "insight",
+    "title": "Main result: the Weyr characteristic is non-increasing",
+    "content": "The payoff: w₀ ≥ w₁ ≥ w₂ ≥ ⋯. Because natural-number subtraction is involved, the proof also feeds omega the two monotonicity facts aₖ ≤ aₖ₊₁ ≤ aₖ₊₂ (each from ker_pow_le_succ) alongside the concavity aₖ + aₖ₊₂ ≤ 2·aₖ₊₁; together these force (aₖ₊₂ − aₖ₊₁) ≤ (aₖ₊₁ − aₖ). Interpreted through the block count, this is the statement that the number of Jordan blocks of size ≥ k+1 never exceeds the number of size ≥ k — precisely what makes the Weyr characteristic a partition and the conjugate of the Segre characteristic.",
+    "mathContext": "$w_{k+1} \\le w_k$ for all $k$, i.e. $w_0 \\ge w_1 \\ge w_2 \\ge \\cdots$; equivalently the dot diagram's column heights are non-increasing, so it is the transpose of the Jordan-block Young diagram.",
+    "significance": "key",
+    "relatedConcepts": ["antitone sequence", "Weyr characteristic", "Jordan/Weyr dot diagram", "conjugate partition", "Cayley–Hamilton theory"],
+    "prerequisites": ["truncated natural subtraction", "monotonicity of finrank", "omega arithmetic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-01-oq-04` (The Weyr Characteristic is Non-Increasing).

**Gap:** the entry had a rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

**Added** `annotations.json` with **7 annotations** spanning the full 132-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Nested kernel filtration (`pow_succ_apply`, `ker_pow_le_succ`)
2. Rank–nullity realizing each jump aₖ₊₁−aₖ as the difference space Uₖ = Nᵏ(ker Nᵏ⁺¹)
3. The quotient-free crux inclusion Uₖ₊₁ ⊆ Uₖ
4. Discrete concavity aₖ + aₖ₊₂ ≤ 2·aₖ₊₁
5. Transport to generalized eigenspaces via `genEigenspace_nat`
6. The Weyr number wₖ (block-count interpretation)
7. Main result: the Weyr characteristic is non-increasing

Interpretive thread ties the rank inequality to the Weyr = conjugate-of-Segre partition identity.

**Validation:** `annotations:validate` reports 0 errors for this slug (all ranges land on declaration doc-comments); `check-meta-size` within caps. No `meta.json` change.