### PR TITLE
research(godel-first-incompleteness-oq01-oq-02): consistent repair — First Incompleteness from a satisfiable axiom set [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/GodelFirstIncompletenessOQ01OQ02.lean
+++ b/proofs/Proofs/GodelFirstIncompletenessOQ01OQ02.lean
@@ -1,0 +1,167 @@
+import Mathlib
+
+/-!
+# Gödel First Incompleteness OQ-01 / OQ-02: A Consistent Repair — Incompleteness from a Satisfiable Axiom Set
+
+## The Open Question (OQ-02 of `godel-first-incompleteness-oq01`)
+
+The parent file `GodelFirstIncompletenessOQ01` derives First Incompleteness from five axioms on an
+opaque provability predicate `Provable`.  The sibling analysis `…OQ01OQ03` then discovered a flaw:
+three of those axioms are **jointly inconsistent for every `P`**, so the parent's axiom set has
+**no model** and its First Incompleteness theorem holds only *vacuously* (from contradictory
+hypotheses) — a subtler cousin of the `Provable := fun _ => False` vacuity the parent set out to
+avoid.  The root cause diagnosed there: the **meta-level** self-reference `⊢G ↔ ¬⊢Prov⌜G⌝` was
+taken as an axiom, whereas only the **object-level** fixed point `F ⊢ (G ↔ ¬Prov⌜G⌝)` is legitimate.
+
+> **OQ-02.**  Is there a *consistent* (model-having) axiom set on the trio `G`, `Prov(⌜G⌝)`, `¬G`
+> from which First Incompleteness follows **non-vacuously** — i.e. the undecidability of `G` is a
+> genuine consequence of *satisfiable* hypotheses, not of a contradiction?
+
+## The answer: yes — replace the meta self-reference by the object-level diagonal clauses
+
+Working, like OQ-03, abstractly over an arbitrary `P : ℕ → Prop` on the four codes
+`G = 42`, `Prov(⌜G⌝) = 84`, `¬G = 43`, `¬Prov(⌜G⌝) = 85`, we take the five clauses that Gödel's
+proof *actually uses* — none of them the illegitimate meta equivalence:
+
+* `D1G P`      : `P G → P provG`         (Σ₁-completeness / derivability D1 at `φ = G`)
+* `FixG P`     : `P G → P negProvG`      (object-level fixed point `F ⊢ (G → ¬Prov⌜G⌝)`)
+* `Consistent P`: `¬ (P provG ∧ P negProvG)`  (consistency: `F` proves no sentence and its negation)
+* `NegGProv P` : `P negG → P provG`      (object-level fixed point `F ⊢ (¬G → Prov⌜G⌝)`)
+* `OmegaCons P`: `¬ P G → ¬ P provG`     (ω-consistency at `G`)
+
+From these we prove, **for every `P`**:
+
+* `godel_not_provable`      : `¬ P G`          (the consistency half — needs `D1G`, `FixG`, `Consistent`)
+* `neg_godel_not_provable`  : `¬ P negG`       (the ω-consistency half — adds `NegGProv`, `OmegaCons`)
+* `first_incompleteness`    : `¬ P G ∧ ¬ P negG`  (`G` is undecidable)
+
+and, crucially, that the hypotheses are **satisfiable**:
+
+* `has_model`               : `∃ P, D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P`
+* `has_nontrivial_model`    : the same, with a `P` that is **not** identically `False`
+                              (witness: `¬Prov⌜G⌝` is provable) — so incompleteness here is not the
+                              `Provable := fun _ => False` cheat.
+
+Hence First Incompleteness follows from a *consistent* theory: this is the honest, non-vacuous
+statement the parent aimed for, obtained by exactly the repair OQ-03 pointed to.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.  Everything is stated over an
+arbitrary `P`, so nothing imports the parent's (inconsistent) global axioms.
+-/
+
+namespace GodelFirstIncompletenessOQ01OQ02
+
+/-- Code of the Gödel sentence `G` (parent: `G = ⟨42⟩`). -/
+def gCode : ℕ := 42
+/-- Code of `Prov(⌜G⌝)` (parent: `Prov (godelNum G) = ⟨42 * 2⟩`). -/
+def provGCode : ℕ := 84
+/-- Code of `¬G` (parent: `neg G = ⟨42 + 1⟩`). -/
+def negGCode : ℕ := 43
+/-- Code of `¬Prov(⌜G⌝)` (`neg` of `provG`: `⟨84 + 1⟩`). -/
+def negProvGCode : ℕ := 85
+
+/-- Derivability D1 (Σ₁-completeness) at `φ = G`: provability of `G` entails provability of
+    `Prov(⌜G⌝)`. -/
+def D1G (P : ℕ → Prop) : Prop := P gCode → P provGCode
+
+/-- Object-level fixed point, forward half: `F ⊢ (G → ¬Prov⌜G⌝)`, so provability of `G` entails
+    provability of `¬Prov(⌜G⌝)`.  (This replaces OQ-03's illegitimate meta equivalence
+    `P G ↔ ¬ P provG`.) -/
+def FixG (P : ℕ → Prop) : Prop := P gCode → P negProvGCode
+
+/-- Consistency of `F`: it does not prove both `Prov(⌜G⌝)` and its negation `¬Prov(⌜G⌝)`. -/
+def Consistent (P : ℕ → Prop) : Prop := ¬ (P provGCode ∧ P negProvGCode)
+
+/-- Object-level fixed point, backward half: `F ⊢ (¬G → Prov⌜G⌝)`, so provability of `¬G` entails
+    provability of `Prov(⌜G⌝)`. -/
+def NegGProv (P : ℕ → Prop) : Prop := P negGCode → P provGCode
+
+/-- ω-consistency at `G`: if `G` is unprovable, so is `Prov(⌜G⌝)`. -/
+def OmegaCons (P : ℕ → Prop) : Prop := ¬ P gCode → ¬ P provGCode
+
+/-!
+## The incompleteness theorem, from consistent hypotheses
+-/
+
+/-- **Consistency half of First Incompleteness.**  `G` is not provable.  If it were, `D1G` gives
+    `P provG` and the object-level fixed point `FixG` gives `P negProvG`, contradicting
+    `Consistent`. -/
+theorem godel_not_provable (P : ℕ → Prop)
+    (hD1 : D1G P) (hFix : FixG P) (hCon : Consistent P) : ¬ P gCode := by
+  simp only [D1G, FixG, Consistent] at hD1 hFix hCon
+  tauto
+
+/-- **ω-consistency half of First Incompleteness.**  `¬G` is not provable.  If it were, `NegGProv`
+    gives `P provG`; but `godel_not_provable` gives `¬ P G`, whence `OmegaCons` gives `¬ P provG` —
+    a contradiction. -/
+theorem neg_godel_not_provable (P : ℕ → Prop)
+    (hD1 : D1G P) (hFix : FixG P) (hCon : Consistent P)
+    (hNeg : NegGProv P) (hOmega : OmegaCons P) : ¬ P negGCode := by
+  have hG : ¬ P gCode := godel_not_provable P hD1 hFix hCon
+  simp only [NegGProv, OmegaCons] at hNeg hOmega
+  tauto
+
+/-- **First Incompleteness (non-vacuous form).**  From the five consistent clauses, `G` is
+    undecidable: neither `G` nor `¬G` is provable. -/
+theorem first_incompleteness (P : ℕ → Prop)
+    (hD1 : D1G P) (hFix : FixG P) (hCon : Consistent P)
+    (hNeg : NegGProv P) (hOmega : OmegaCons P) : ¬ P gCode ∧ ¬ P negGCode :=
+  ⟨godel_not_provable P hD1 hFix hCon,
+   neg_godel_not_provable P hD1 hFix hCon hNeg hOmega⟩
+
+/-!
+## The hypotheses are satisfiable — the repair is genuinely non-vacuous
+
+Unlike the parent's axiom set (which `…OQ01OQ03.no_model_of_all_axioms` shows has *no* model),
+the repaired set has a model.  So the incompleteness conclusion above is drawn from *satisfiable*
+hypotheses, not from a contradiction.
+-/
+
+/-- **The repaired axiom set has a model.**  Witness: nothing provable (`P := fun _ => False`)
+    satisfies all five clauses vacuously.  This already refutes the parent's flaw
+    (`no_model_of_all_axioms`). -/
+theorem has_model :
+    ∃ P : ℕ → Prop, D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P := by
+  refine ⟨fun _ => False, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [D1G, FixG, Consistent, NegGProv, OmegaCons] <;> decide
+
+/-- **A model in which something is provable.**  Taking `¬Prov(⌜G⌝)` to be the one provable
+    sentence (`P n ↔ n = negProvG`) still satisfies all five clauses, and here `P` is *not*
+    identically `False`.  So the incompleteness of `G` does not rely on the degenerate
+    `Provable := fun _ => False` reading — a genuine, non-empty theory can be incomplete. -/
+theorem has_nontrivial_model :
+    ∃ P : ℕ → Prop,
+      (D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P) ∧ (∃ n, P n) := by
+  refine ⟨fun n => n = negProvGCode, ⟨?_, ?_, ?_, ?_, ?_⟩, ⟨negProvGCode, rfl⟩⟩ <;>
+    simp only [D1G, FixG, Consistent, NegGProv, OmegaCons] <;> decide
+
+/-- **In every model, `Prov(⌜G⌝)` is unprovable too.**  Combining `godel_not_provable` with
+    ω-consistency: since `G` is unprovable, so is `Prov(⌜G⌝)`.  (In particular no model of the
+    repaired set proves `Prov(⌜G⌝)` — consistent with `provG` never being a theorem.) -/
+theorem provG_not_provable (P : ℕ → Prop)
+    (hD1 : D1G P) (hFix : FixG P) (hCon : Consistent P) (hOmega : OmegaCons P) :
+    ¬ P provGCode := by
+  have hG : ¬ P gCode := godel_not_provable P hD1 hFix hCon
+  simp only [OmegaCons] at hOmega
+  exact hOmega hG
+
+end GodelFirstIncompletenessOQ01OQ02
+
+/-!
+## Summary
+
+Answering OQ-02 (is there a *consistent* axiom set giving First Incompleteness non-vacuously?):
+
+- The repair is exactly the one OQ-03 pointed to: drop the illegitimate meta self-reference
+  `P G ↔ ¬ P provG` and use the object-level fixed-point clauses `FixG` (`P G → P negProvG`) and
+  `NegGProv` (`P negG → P provG`) together with derivability `D1G`, `Consistent`, and `OmegaCons`.
+- `godel_not_provable`, `neg_godel_not_provable`, `first_incompleteness`: `G` is undecidable for
+  every `P` satisfying the five clauses.
+- `has_model`, `has_nontrivial_model`: the five clauses are *satisfiable* (and satisfiable by a
+  non-empty theory), so the conclusion is drawn from consistent hypotheses — the honest,
+  non-vacuous First Incompleteness the parent aimed for, and a direct fix of the vacuity found in
+  `…OQ01OQ03`.
+- `provG_not_provable`: in every such model `Prov(⌜G⌝)` is unprovable as well.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-02/annotations.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-02/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "godel-first-incompleteness-oq01-oq-02",
+    "range": { "startLine": 3, "endLine": 52 },
+    "type": "concept",
+    "title": "A Consistent Repair of the Parent's Axiomatization",
+    "content": "The sibling analysis …OQ01OQ03 proved the parent's five-axiom formalization of First Incompleteness is jointly inconsistent — its axiom set has no model, so the theorem holds only vacuously — and diagnosed the cause: the meta-level self-reference '⊢G iff ¬⊢Prov⌜G⌝' was taken as an axiom, whereas only the object-level fixed point F ⊢ (G ↔ ¬Prov⌜G⌝) is legitimate. This file performs the repair OQ-03 asked for: replace the meta equivalence by the two object-level implications the proof actually uses, and show the resulting clause set is both consistent (has a model) and sufficient (entails G's undecidability).",
+    "mathContext": "Object-level F ⊢ (G ↔ ¬Prov⌜G⌝) splits into FixG (G→¬Prov⌜G⌝) and NegGProv (¬G→Prov⌜G⌝).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gödel First Incompleteness Theorem",
+      "provability predicate",
+      "object-level vs meta-level statements",
+      "consistency as satisfiability"
+    ],
+    "prerequisites": [
+      "the sibling analysis showing the parent's axioms are inconsistent",
+      "the Diagonal Lemma fixed point F ⊢ (G ↔ ¬Prov⌜G⌝)"
+    ]
+  },
+  {
+    "id": "ann-clauses",
+    "proofId": "godel-first-incompleteness-oq01-oq-02",
+    "range": { "startLine": 54, "endLine": 80 },
+    "type": "definition",
+    "title": "The Five Repaired Clauses",
+    "content": "Over an arbitrary provability predicate P : ℕ → Prop and four codes (G=42, Prov⌜G⌝=84, ¬G=43, ¬Prov⌜G⌝=85), the clauses are: D1G (P G → P provG, derivability), FixG (P G → P negProvG, the object-level G→¬Prov⌜G⌝ replacing the meta self-reference), Consistent (¬(P provG ∧ P negProvG)), NegGProv (P negG → P provG, the object-level ¬G→Prov⌜G⌝), and OmegaCons (¬P G → ¬P provG, ω-consistency). Working abstractly over P means nothing imports the parent's inconsistent global axioms.",
+    "mathContext": "FixG and NegGProv are the two directions of the object-level fixed point, as directional implications on P.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "derivability conditions (D1)",
+      "ω-consistency",
+      "object-level fixed point"
+    ],
+    "prerequisites": [
+      "the provability predicate and Gödel numbering of G, Prov⌜G⌝, ¬G"
+    ]
+  },
+  {
+    "id": "ann-incompleteness",
+    "proofId": "godel-first-incompleteness-oq01-oq-02",
+    "range": { "startLine": 82, "endLine": 110 },
+    "type": "theorem",
+    "title": "First Incompleteness from Consistent Clauses",
+    "content": "godel_not_provable proves ¬P(G): if P(G) held, D1G gives P(Prov⌜G⌝) and FixG gives P(¬Prov⌜G⌝), contradicting Consistent (closed by tauto). neg_godel_not_provable proves ¬P(¬G): if P(¬G) held, NegGProv gives P(Prov⌜G⌝), but ¬P(G) plus OmegaCons gives ¬P(Prov⌜G⌝) — contradiction. first_incompleteness bundles these: G is undecidable. The consistency half needs D1G+FixG+Consistent; the ω-consistency half adds NegGProv+OmegaCons, matching the two directions of Gödel's argument.",
+    "mathContext": "¬P(G) ∧ ¬P(¬G) for every P satisfying the five clauses.",
+    "significance": "key",
+    "relatedConcepts": [
+      "consistency half vs ω-consistency half",
+      "undecidable sentence"
+    ],
+    "prerequisites": [
+      "the five clauses",
+      "propositional reasoning (tauto)"
+    ]
+  },
+  {
+    "id": "ann-satisfiable",
+    "proofId": "godel-first-incompleteness-oq01-oq-02",
+    "range": { "startLine": 112, "endLine": 148 },
+    "type": "insight",
+    "title": "The Hypotheses Are Satisfiable — Genuine Non-Vacuity",
+    "content": "has_model exhibits a model (P := fun _ => False satisfies all five clauses), so — unlike the parent's set, which …OQ01OQ03.no_model_of_all_axioms shows has no model — the incompleteness conclusion is drawn from consistent, not contradictory, hypotheses. has_nontrivial_model sharpens this: taking ¬Prov⌜G⌝ as the one provable sentence (P := (· = negProvGCode)) still satisfies all five clauses while being non-empty, so a genuine theory (something is a theorem) can be incomplete — the point the parent's Provable := fun _ => False failed to make. provG_not_provable notes that in every model Prov(⌜G⌝) is unprovable too. The model goals are finite decidable checks over the four codes, closed by decide.",
+    "mathContext": "∃ P, (all five clauses) ∧ ∃ n, P n; witness P n ↔ n = negProvGCode.",
+    "significance": "key",
+    "relatedConcepts": [
+      "satisfiability / existence of a model",
+      "non-vacuous truth",
+      "the Provable := False vacuity"
+    ],
+    "prerequisites": [
+      "consistency as the existence of a model",
+      "the parent's no-model result in …OQ01OQ03"
+    ]
+  }
+]

--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "godel-first-incompleteness-oq01-oq-02",
+  "title": "A Consistent Repair: First Incompleteness from a Satisfiable Axiom Set",
+  "slug": "godel-first-incompleteness-oq01-oq-02",
+  "description": "Answers the open question left by the sibling analysis (…OQ01OQ03): that entry proved the parent's five-axiom formalization of First Incompleteness is JOINTLY INCONSISTENT (no model), so its theorem holds only vacuously, the root cause being the illegitimate meta-level self-reference ⊢G ↔ ¬⊢Prov⌜G⌝. This entry performs exactly the repair OQ-03 called for: replace the meta equivalence by the two object-level fixed-point clauses F⊢(G→¬Prov⌜G⌝) and F⊢(¬G→Prov⌜G⌝), keeping derivability D1, consistency, and ω-consistency. Working abstractly over an arbitrary provability predicate P : ℕ → Prop on the codes G=42, Prov⌜G⌝=84, ¬G=43, ¬Prov⌜G⌝=85, it proves for every P that G is undecidable (¬P(G) ∧ ¬P(¬G)) AND that the five clauses are satisfiable — exhibiting a model, and even a non-trivial model in which a sentence is provable. So First Incompleteness follows from CONSISTENT hypotheses, the honest non-vacuous statement the parent aimed for. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "repair of the parent's axiom encoding along the object/meta distinction; formalized in Lean 4",
+    "date": "1931",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GodelFirstIncompletenessOQ01OQ02.lean",
+    "tags": [
+      "logic",
+      "incompleteness",
+      "godel",
+      "provability-predicate",
+      "model-theory",
+      "consistency"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 167,
+    "theoremCount": 6,
+    "definitionCount": 9,
+    "originalContributions": [
+      "godel_not_provable: ¬P(G) for every P satisfying D1G, FixG, Consistent — the consistency half of First Incompleteness, from the object-level fixed point rather than the parent's inconsistent meta equivalence.",
+      "neg_godel_not_provable: ¬P(¬G) for every such P also satisfying NegGProv and OmegaCons — the ω-consistency half.",
+      "first_incompleteness: ¬P(G) ∧ ¬P(¬G) — G is undecidable, derived from the five consistent clauses.",
+      "has_model: the five clauses are satisfiable (∃ P), so — unlike the parent's set (…OQ01OQ03.no_model_of_all_axioms) — the incompleteness conclusion is drawn from consistent, not contradictory, hypotheses.",
+      "has_nontrivial_model: a model in which ¬Prov⌜G⌝ is provable, so the incompleteness does not rely on the degenerate Provable := fun _ => False reading — a genuinely non-empty theory can be incomplete.",
+      "provG_not_provable: in every such model Prov(⌜G⌝) is unprovable as well."
+    ],
+    "prerequisites": [
+      "Gödel's First Incompleteness Theorem and the provability predicate",
+      "The object-level (F ⊢ φ) versus meta-level (⊢ φ in the metatheory) distinction",
+      "Satisfiability / consistency as the existence of a model; non-vacuous truth"
+    ],
+    "mathlibDependencies": []
+  },
+  "overview": {
+    "historicalContext": "Gödel's 1931 construction produces, via the Diagonal Lemma, a sentence G with F ⊢ (G ↔ ¬Prov(⌜G⌝)) — an OBJECT-level provable biconditional inside F. The parent gallery file abstracts the first incompleteness proof into five axioms on an opaque provability predicate, but (as the sibling …OQ01OQ03 discovered) it asserted the META-level equivalence '⊢G iff ¬⊢Prov⌜G⌝' as an axiom. That meta equivalence, together with derivability D1 and ω-consistency, is contradictory, so the parent's axiom set has no model and its 'non-vacuous' First Incompleteness theorem is in fact vacuous. OQ-03 explicitly asked to redo the axiomatization with the sound object-level fixed point. This entry does so.",
+    "problemStatement": "**Open Question (from …OQ01OQ03):** replace the meta self-reference axiom with the sound object-level F ⊢ (G ↔ ¬Prov⌜G⌝) and re-derive First Incompleteness from a CONSISTENT axiom set. Concretely: is there a satisfiable set of clauses on the trio G, Prov⌜G⌝, ¬G from which the undecidability of G follows non-vacuously?\n\n**Answer: yes** — the object-level fixed-point clauses FixG (P G → P ¬Prov⌜G⌝) and NegGProv (P ¬G → P Prov⌜G⌝), with D1G, Consistent, and OmegaCons, are satisfiable and entail ¬P(G) ∧ ¬P(¬G).",
+    "text": "A 167-line, fully verified (0 sorries, 0 axioms, no native_decide) file that repairs the parent's axiomatization and proves both the incompleteness conclusion and the consistency (satisfiability) of the hypotheses, the latter being exactly what the parent's set lacked.",
+    "proofStrategy": "Abstract five clauses on an arbitrary P : ℕ → Prop over four codes (G=42, Prov⌜G⌝=84, ¬G=43, ¬Prov⌜G⌝=85). The incompleteness proofs are propositional once unfolded: godel_not_provable assumes P(G), derives P(Prov⌜G⌝) (D1G) and P(¬Prov⌜G⌝) (FixG), contradicting Consistent — closed by tauto. neg_godel_not_provable assumes P(¬G), derives P(Prov⌜G⌝) (NegGProv), but ¬P(G) (the previous theorem) gives ¬P(Prov⌜G⌝) via OmegaCons — again tauto. Satisfiability is by explicit models: has_model uses P := fun _ => False (all clauses vacuously true); has_nontrivial_model uses P := (· = ¬Prov⌜G⌝-code), where the finitely many decidable equalities among the four codes are closed by decide, and exhibits the provable witness.",
+    "keyInsights": [
+      "OQ-03's diagnosis is actionable: the fix is to demote the meta equivalence to the two object-level implications that Gödel's proof actually uses — FixG (from F⊢(G→¬Prov⌜G⌝)) and NegGProv (from F⊢(¬G→Prov⌜G⌝)).",
+      "With that change the clause set becomes SATISFIABLE: fun _ => False is a model, so — unlike the parent's set — the incompleteness conclusion is not vacuously drawn from a contradiction.",
+      "Non-vacuity can be sharpened: a model exists in which ¬Prov⌜G⌝ is provable, so a non-empty theory (something is a theorem) is still incomplete — the point the parent's Provable := fun _ => False failed to make.",
+      "The consistency half needs only D1G, FixG, Consistent; the ω-consistency half additionally needs NegGProv and OmegaCons — a clean separation matching Gödel's two-directional argument.",
+      "In every model Prov(⌜G⌝) is also unprovable (provG_not_provable), consistent with the intended reading where neither G nor its provability statement is a theorem."
+    ]
+  },
+  "sections": [
+    {
+      "id": "clauses",
+      "title": "The Repaired Clauses as Predicates",
+      "startLine": 53,
+      "endLine": 80,
+      "summary": "Codes gCode=42, provGCode=84, negGCode=43, negProvGCode=85, and the five clauses D1G, FixG, Consistent, NegGProv, OmegaCons on an arbitrary P — the object-level fixed-point clauses replacing the parent's meta self-reference.",
+      "mathContext": "FixG and NegGProv encode the two directions of F ⊢ (G ↔ ¬Prov⌜G⌝) at the object level."
+    },
+    {
+      "id": "incompleteness",
+      "title": "First Incompleteness from the Consistent Clauses",
+      "startLine": 82,
+      "endLine": 110,
+      "summary": "godel_not_provable (¬P(G) from D1G, FixG, Consistent), neg_godel_not_provable (¬P(¬G), adding NegGProv, OmegaCons), and first_incompleteness (their conjunction: G is undecidable).",
+      "mathContext": "Consistency half needs D1G+FixG+Consistent; ω-consistency half adds NegGProv+OmegaCons."
+    },
+    {
+      "id": "satisfiable",
+      "title": "The Hypotheses Are Satisfiable — Genuine Non-Vacuity",
+      "startLine": 112,
+      "endLine": 148,
+      "summary": "has_model (∃ P satisfying all five — the parent's set had none), has_nontrivial_model (a model with a provable sentence, so incompleteness is not the Provable:=False cheat), and provG_not_provable (Prov⌜G⌝ unprovable in every model).",
+      "mathContext": "fun _ => False and (· = negProvGCode) are explicit models, closed by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "Replacing the parent's illegitimate meta self-reference with the two object-level fixed-point clauses yields a SATISFIABLE five-clause set that provably entails the undecidability of G (¬P(G) ∧ ¬P(¬G)) for every model. So First Incompleteness is obtained from consistent hypotheses — the honest, non-vacuous statement the parent aimed for and the sibling …OQ01OQ03 showed the parent failed to achieve.",
+    "implications": "This closes the loop on the parent/OQ-03 thread: OQ-03 audited the parent's axioms and found them inconsistent (hence vacuous); this entry supplies the corrected axiomatization and shows it is both consistent and sufficient. The lesson is methodological — a faithful abstraction of the incompleteness proof must keep the diagonal fixed point at the object level (as directional implications on the provability predicate), never as a metatheoretic biconditional. A full syntactic Diagonal-Lemma formalization would realize these clauses as genuine provable sentences.",
+    "openQuestions": [
+      "Realize the object-level clauses as provable biconditionals over an explicit syntax (a genuine Diagonal Lemma), so FixG and NegGProv are theorems of the object theory rather than assumed clauses.",
+      "Extend the repaired, consistent axiomatization to Gödel's Second Incompleteness Theorem (unprovability of Con(F)) and check it too avoids the meta/object conflation.",
+      "Compare with the Rosser-sentence formalization (…OQ01OQ01), which reaches incompleteness from plain consistency, and determine the minimal consistent clause set for each."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-03",
+      "relationship": "extends",
+      "description": "Sibling that proved the parent's axioms jointly inconsistent and asked for a consistent re-axiomatization via the object-level fixed point — the exact repair this entry carries out."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01",
+      "relationship": "related",
+      "description": "Parent: the five-axiom 'non-vacuous' First Incompleteness formalization whose meta self-reference is replaced here by object-level clauses."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01-oq-04",
+      "relationship": "related",
+      "description": "Sibling formalizing the Diagonal Lemma / fixed-point theorem underlying the object-level self-reference used here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "GodelFirstIncompletenessOQ01OQ02",
+    "lineCount": 167,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 9,
+    "mainTheorems": [
+      {
+        "name": "first_incompleteness",
+        "type": "core",
+        "description": "From the five consistent clauses, G is undecidable: neither G nor ¬G is provable",
+        "leanType": "(P : ℕ → Prop) → D1G P → FixG P → Consistent P → NegGProv P → OmegaCons P → ¬ P gCode ∧ ¬ P negGCode"
+      },
+      {
+        "name": "has_model",
+        "type": "key",
+        "description": "The repaired clause set is satisfiable — unlike the parent's, which has no model",
+        "leanType": "∃ P : ℕ → Prop, D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P"
+      },
+      {
+        "name": "has_nontrivial_model",
+        "type": "key",
+        "description": "A model in which a sentence is provable — incompleteness is not the Provable:=False cheat",
+        "leanType": "∃ P : ℕ → Prop, (D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P) ∧ (∃ n, P n)"
+      }
+    ],
+    "path": "Proofs/GodelFirstIncompletenessOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "first_incompleteness",
+      "type": "core",
+      "description": "G is undecidable, derived from the five consistent clauses",
+      "leanType": "(P : ℕ → Prop) → D1G P → FixG P → Consistent P → NegGProv P → OmegaCons P → ¬ P gCode ∧ ¬ P negGCode"
+    },
+    {
+      "name": "has_model",
+      "type": "key",
+      "description": "The repaired clauses are satisfiable — the parent's were not",
+      "leanType": "∃ P : ℕ → Prop, D1G P ∧ FixG P ∧ Consistent P ∧ NegGProv P ∧ OmegaCons P"
+    },
+    {
+      "name": "godel_not_provable",
+      "type": "key",
+      "description": "The consistency half: ¬P(G) from D1G, FixG, Consistent",
+      "leanType": "(P : ℕ → Prop) → D1G P → FixG P → Consistent P → ¬ P gCode"
+    }
+  ],
+  "openQuestions": [
+    "Realize the object-level clauses as provable biconditionals over explicit syntax (a genuine Diagonal Lemma).",
+    "Extend the consistent axiomatization to Gödel's Second Incompleteness Theorem.",
+    "Determine the minimal consistent clause set for Gödel vs Rosser incompleteness."
+  ],
+  "references": [
+    {
+      "authors": "Gödel, Kurt",
+      "title": "Über formal unentscheidbare Sätze der Principia Mathematica und verwandter Systeme I",
+      "year": "1931",
+      "venue": "Monatshefte für Mathematik und Physik 38, 173–198",
+      "note": "The original incompleteness theorems and the object-level fixed-point construction F ⊢ (G ↔ ¬Prov⌜G⌝)"
+    },
+    {
+      "authors": "Boolos, George",
+      "title": "The Logic of Provability",
+      "year": "1993",
+      "venue": "Cambridge University Press",
+      "note": "Provability logic (GL) and the object/meta distinction whose repair this entry formalizes"
+    },
+    {
+      "authors": "Smullyan, Raymond",
+      "title": "Gödel's Incompleteness Theorems",
+      "year": "1992",
+      "venue": "Oxford University Press",
+      "note": "The derivability conditions and the roles of consistency and ω-consistency in the two halves of the proof"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry `godel-first-incompleteness-oq01-oq-02`, closing the loop opened by the sibling **`…OQ01OQ03`**.

OQ-03 audited the parent's five-axiom formalization of First Incompleteness and found it **jointly inconsistent** — its axiom set has *no model*, so the theorem holds only *vacuously*. The diagnosed cause: the parent asserted the **meta-level** self-reference `⊢G ↔ ¬⊢Prov⌜G⌝` as an axiom, where only the **object-level** fixed point `F ⊢ (G ↔ ¬Prov⌜G⌝)` is legitimate. OQ-03's first open question was to *re-axiomatize consistently and re-derive incompleteness*. **This entry does exactly that.**

## Results (`Proofs/GodelFirstIncompletenessOQ01OQ02.lean`, 6 theorems, 9 defs, 167 lines)

Over an arbitrary provability predicate `P : ℕ → Prop` on codes G=42, Prov⌜G⌝=84, ¬G=43, ¬Prov⌜G⌝=85, five **object-level** clauses replace the meta equivalence:

- `D1G` (P G → P provG), `FixG` (P G → P negProvG, from `F⊢(G→¬Prov⌜G⌝)`), `Consistent` (¬(P provG ∧ P negProvG)), `NegGProv` (P negG → P provG, from `F⊢(¬G→Prov⌜G⌝)`), `OmegaCons` (¬P G → ¬P provG).

From them:

- **`first_incompleteness`**: `¬P(G) ∧ ¬P(¬G)` — G is undecidable, for *every* P satisfying the clauses. (Consistency half needs D1G+FixG+Consistent; ω-consistency half adds NegGProv+OmegaCons.)
- **`has_model`**: the five clauses are **satisfiable** (∃ P) — unlike the parent's set (`…OQ01OQ03.no_model_of_all_axioms`). So incompleteness is drawn from *consistent*, not contradictory, hypotheses.
- **`has_nontrivial_model`**: a model in which `¬Prov⌜G⌝` is provable — so a *non-empty* theory can be incomplete, sharpening non-vacuity beyond the parent's `Provable := fun _ => False` cheat.
- **`provG_not_provable`**: in every such model `Prov(⌜G⌝)` is unprovable too.

## The point

This is the **honest, non-vacuous First Incompleteness** the parent aimed for: repair the object/meta conflation OQ-03 identified, and both the incompleteness conclusion *and the consistency of its hypotheses* go through.

## Verification

Verified with `lake env lean`: **0 sorries, 0 `axiom` declarations, no `native_decide`, 0 lint warnings**. `#print axioms first_incompleteness` shows only `propext`, `Classical.choice`, `Quot.sound` → **status: verified, axiomCount 0**.

Gallery data (`meta.json` + `annotations.json`, 4 annotations) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)