### PR TITLE
research(inverse-galois-d4-oq-03): prove Gal(X⁴−2/ℚ)≅D₄ via Sylow classification [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/InverseGaloisD4OQ03.lean
+++ b/proofs/Proofs/InverseGaloisD4OQ03.lean
@@ -1,5 +1,10 @@
 import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.GroupTheory.SpecificGroups.Dihedral
+import Mathlib.GroupTheory.Sylow
+import Mathlib.GroupTheory.Perm.Fin
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Algebra.Group.End
 import Mathlib.Algebra.Polynomial.Basic
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Proofs.InverseGaloisD4
@@ -38,16 +43,24 @@ This is a non-building scaffold proposed in S1's "next action":
    is the unique transitive subgroup of `S₄` of order 8, plus the
    identification of the splitting field's Galois group as a transitive
    subgroup of `S₄`).
-3. **Schinzel–Velez characterization (statement only)**:
-   `dihedral_iff_schinzel_velez` — the iff between the abstract
-   criterion and the finite-case Schinzel–Velez conditions. Stated
-   with `True` as the right-hand placeholder for now (one sorry); a
-   future iteration will replace `True` with the explicit conditions
-   once Capelli's theorem is upstreamed to Mathlib or proved in-tree.
+3. **Schinzel–Velez characterization (existential form)**:
+   `schinzel_velez_characterization_exists` — the (vacuous) existence
+   of a classifying predicate; the *explicit* finite-case predicate
+   still awaits Capelli's irreducibility theorem in Mathlib.
 
-The file is sorry-bearing by design — S2 SCAFFOLD lands the API
-surface; S3+ iterations (and a separate Capelli-in-Mathlib effort)
-will discharge the sorries.
+## S4 update: the `(4, 2)` case is now fully proved (no `sorry`)
+
+`dihedral_galois_xPow4_sub_2 : IsDihedralGaloisOfXnMinusA 4 2` is
+discharged. The proof factors through a self-contained group-theoretic
+classification, `order_eight_iso_dihedralFour`: *every subgroup of `S₄`
+of order `8` is isomorphic to `DihedralGroup 4`*. This holds because
+`8 = 2³` is the full `2`-part of `|S₄| = 24`, so such a subgroup is a
+Sylow `2`-subgroup, and Sylow's second theorem makes all of them
+conjugate — hence isomorphic to the explicit dihedral copy
+`⟨(0 1 2 3), (1 3)⟩ ≤ S₄` built here (`dihedralFourToPerm`). Applying
+this to the faithful action of `Gal(X⁴ − 2)` on its four roots
+(`Polynomial.Gal.galActionHom`, injective, image of order `8`) closes
+the case. Only the general `n` Schinzel–Velez criterion remains open.
 
 ## References
 
@@ -67,6 +80,102 @@ radical-extensions, schinzel-velez-classification, capelli-theorem
 namespace InverseGaloisD4OQ03
 
 open Polynomial
+open scoped Pointwise
+
+/-! ## Group-theoretic core: an order-8 subgroup of `S₄` is `D₄`
+
+The classical fact that `Gal(X⁴ − 2 / ℚ) ≅ D₄` (rather than merely having
+order `8`) reduces to a purely group-theoretic statement: *any subgroup of
+`S₄` of order `8` is isomorphic to `DihedralGroup 4`*. Indeed `8 = 2³` is
+the full `2`-part of `|S₄| = 24`, so such a subgroup is a Sylow `2`-subgroup,
+and all Sylow `2`-subgroups of `S₄` are conjugate (Sylow's theorem), hence
+isomorphic — to the explicit dihedral copy `⟨(0 1 2 3), (1 3)⟩` (the
+symmetries of the square on vertices `0,1,2,3`).
+
+This section builds that copy explicitly and proves the classification, with
+no appeal to `sorry`. -/
+
+/-- The 4-cycle `(0 1 2 3)` on `Fin 4`, as a product of adjacent
+transpositions. -/
+def rho : Equiv.Perm (Fin 4) := Equiv.swap 0 1 * Equiv.swap 1 2 * Equiv.swap 2 3
+
+/-- The underlying function of the dihedral representation: rotations map to
+powers of `rho`, reflections to `(1 3)` composed with a rotation. -/
+def dihToPerm : DihedralGroup 4 → Equiv.Perm (Fin 4)
+  | DihedralGroup.r i => rho ^ i.val
+  | DihedralGroup.sr i => Equiv.swap 1 3 * rho ^ i.val
+
+/-- **`D₄` as symmetries of the square** — the explicit injective group
+homomorphism `DihedralGroup 4 →* S₄` realising `D₄` as a transitive
+subgroup of `S₄`. The homomorphism property is a finite check. -/
+def dihedralFourToPerm : DihedralGroup 4 →* Equiv.Perm (Fin 4) where
+  toFun := dihToPerm
+  map_one' := by decide
+  map_mul' := by decide
+
+theorem dihedralFourToPerm_injective : Function.Injective dihedralFourToPerm := by
+  decide
+
+/-- **Classification of order-8 subgroups of `S₄`** (Sylow's theorem):
+    any finite group `G` of order `8` that embeds in `S₄` is isomorphic to
+    `DihedralGroup 4`.
+
+    Proof: the images `f.range` and `dihedralFourToPerm.range` are both
+    subgroups of `S₄` of order `8 = 2^((24).factorization 2)`, hence Sylow
+    `2`-subgroups. By Sylow's second theorem they are conjugate, and
+    conjugation furnishes the isomorphism, giving
+    `G ≃ f.range ≃ dihedralFourToPerm.range ≃ DihedralGroup 4`. -/
+theorem order_eight_iso_dihedralFour
+    {G : Type*} [Group G] [Finite G] (hG : Nat.card G = 8)
+    (f : G →* Equiv.Perm (Fin 4)) (hf : Function.Injective f) :
+    Nonempty (G ≃* DihedralGroup 4) := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hS : Nat.card (Equiv.Perm (Fin 4)) = 24 := by
+    simp [Nat.card_eq_fintype_card, Fintype.card_perm]; rfl
+  have hfact : (Nat.card (Equiv.Perm (Fin 4))).factorization 2 = 3 := by
+    rw [hS, show (24 : ℕ) = 2 ^ 3 * 3 by norm_num,
+      Nat.factorization_mul (by norm_num) (by norm_num), Finsupp.add_apply,
+      Nat.factorization_pow_self Nat.prime_two,
+      Nat.factorization_eq_zero_of_not_dvd (by norm_num : ¬ (2 : ℕ) ∣ 3)]
+  have hfr : Nat.card f.range = 8 := by
+    rw [← hG]; exact (Nat.card_congr (MonoidHom.ofInjective hf).toEquiv).symm
+  have hdr : Nat.card dihedralFourToPerm.range = 8 := by
+    have h := (Nat.card_congr (MonoidHom.ofInjective dihedralFourToPerm_injective).toEquiv).symm
+    rw [h, DihedralGroup.nat_card]
+  let Pf : Sylow 2 (Equiv.Perm (Fin 4)) :=
+    Sylow.ofCard f.range (by rw [hfr, hfact]; norm_num)
+  let Pd : Sylow 2 (Equiv.Perm (Fin 4)) :=
+    Sylow.ofCard dihedralFourToPerm.range (by rw [hdr, hfact]; norm_num)
+  obtain ⟨g, hg⟩ := MulAction.exists_smul_eq (Equiv.Perm (Fin 4)) Pf Pd
+  have hcoe : MulAut.conj g • (Pf : Subgroup (Equiv.Perm (Fin 4)))
+      = (Pd : Subgroup (Equiv.Perm (Fin 4))) := by
+    rw [← Sylow.coe_subgroup_smul, hg]
+  have hPf : (Pf : Subgroup (Equiv.Perm (Fin 4))) = f.range := rfl
+  have hPd : (Pd : Subgroup (Equiv.Perm (Fin 4))) = dihedralFourToPerm.range := rfl
+  rw [hPf, hPd] at hcoe
+  have hend : (MulAut.conj g : Equiv.Perm (Fin 4) →* Equiv.Perm (Fin 4))
+      = MulDistribMulAction.toMonoidEnd (MulAut (Equiv.Perm (Fin 4)))
+          (Equiv.Perm (Fin 4)) (MulAut.conj g) := by
+    ext x; rfl
+  have key : f.range.map (MulAut.conj g : Equiv.Perm (Fin 4) →* Equiv.Perm (Fin 4))
+      = dihedralFourToPerm.range := by
+    rw [hend, ← Subgroup.pointwise_smul_def, hcoe]
+  exact ⟨(MonoidHom.ofInjective hf).trans
+    ((MulEquiv.subgroupMap (MulAut.conj g) f.range).trans
+      ((MulEquiv.subgroupCongr key).trans
+        (MonoidHom.ofInjective dihedralFourToPerm_injective).symm))⟩
+
+/-- **Order-8 classification, transported to an arbitrary 4-element
+    permutation domain.** If `α` has exactly `4` elements, an order-`8`
+    group embedding in `Equiv.Perm α` is `DihedralGroup 4`; obtained from
+    `order_eight_iso_dihedralFour` by relabelling `α ≃ Fin 4`. -/
+theorem order_eight_iso_dihedralFour_of_card {α : Type*} [Fintype α]
+    (hα : Fintype.card α = 4) {G : Type*} [Group G] [Finite G] (hG : Nat.card G = 8)
+    (f : G →* Equiv.Perm α) (hf : Function.Injective f) :
+    Nonempty (G ≃* DihedralGroup 4) :=
+  let e : α ≃ Fin 4 := Fintype.equivFinOfCardEq hα
+  order_eight_iso_dihedralFour hG ((Equiv.permCongrHom e).toMonoidHom.comp f)
+    ((Equiv.permCongrHom e).injective.comp hf)
 
 /-- The polynomial `X^n − a` over `ℚ`. -/
 noncomputable def xPowSub (n : ℕ) (a : ℚ) : ℚ[X] := X ^ n - C a
@@ -103,12 +212,29 @@ def IsDihedralGaloisOfXnMinusA (n : ℕ) (a : ℚ) : Prop :=
     The sorry is the bridge — the underlying mathematical content is
     classical and established (see Cox, *Galois Theory* (2nd ed., 2012),
     §13.3), but the Lean formalization requires more work than fits in
-    an S2 scaffold. S3a (this iteration) supplies the cardinality lift
-    `gal_card_xPowSub_4_2` toward this discharge; the remaining task is
-    the order-8-transitive-S₄-subgroup classification. -/
+    an S2 scaffold. S4 (this iteration) discharges it: the Galois group
+    embeds in `S₄` (faithful action on the four roots) with image of order
+    `8`, and `order_eight_iso_dihedralFour_of_card` identifies any such
+    subgroup as `D₄` via Sylow's theorem. -/
 theorem dihedral_galois_xPow4_sub_2 :
     IsDihedralGaloisOfXnMinusA 4 2 := by
-  sorry
+  refine ⟨4, by norm_num, ?_⟩
+  show Nonempty ((xPowSub 4 2).Gal ≃* DihedralGroup 4)
+  haveI : Fact (((xPowSub 4 2).map (algebraMap ℚ (xPowSub 4 2).SplittingField)).Splits) :=
+    ⟨Polynomial.SplittingField.splits _⟩
+  haveI : DecidableEq ((xPowSub 4 2).rootSet (xPowSub 4 2).SplittingField) :=
+    Classical.typeDecidableEq _
+  have hsep : (xPowSub 4 2).Separable := InverseGaloisExtensions.x_fourth_sub_2_separable
+  have hcard4 :
+      Fintype.card ((xPowSub 4 2).rootSet (xPowSub 4 2).SplittingField) = 4 := by
+    rw [Polynomial.card_rootSet_eq_natDegree hsep (Polynomial.SplittingField.splits _)]
+    exact InverseGaloisExtensions.x_fourth_sub_2_natDegree
+  have hgal8 : Nat.card (xPowSub 4 2).Gal = 8 := by
+    rw [Nat.card_eq_fintype_card]
+    exact InverseGaloisExtensions.x4_sub_2_gal_card
+  exact order_eight_iso_dihedralFour_of_card hcard4 hgal8
+    (Polynomial.Gal.galActionHom (xPowSub 4 2) (xPowSub 4 2).SplittingField)
+    (Polynomial.Gal.galActionHom_injective (xPowSub 4 2) (xPowSub 4 2).SplittingField)
 
 /-- **Cardinality lift (S3a, no sorry)**: the Galois group of
     `xPowSub 4 2 = X^4 − C 2` over `ℚ` has cardinality `8`. This is

--- a/src/data/proofs/inverse-galois-d4-oq-03/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/annotations.json
@@ -4,11 +4,11 @@
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
       "startLine": 1,
-      "endLine": 65
+      "endLine": 79
     },
     "type": "concept",
     "title": "OQ-03 in context: from (4, 2) to a uniform dihedral criterion",
-    "content": "The **parent** entry `inverse-galois-d4` proves a single concrete instance: $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$. Open Question 3 generalises that point result to a **uniform criterion**:\n\n> For which pairs $(n, a) \\in \\mathbb{N} \\times \\mathbb{Q}$ is the Galois group of $X^n - a$ over $\\mathbb{Q}$ isomorphic to a dihedral group?\n\nThe mathematical literature **already has the answer**: Velez (1979) and Schinzel (2000) gave a finite-case classification keyed on $n \\bmod 8$ and the $p$-adic valuations of $a$. The Lean obstruction is *not* mathematical — it is the absence of **Capelli's irreducibility theorem** from Mathlib `v4.26.0`. Capelli's theorem (1897) states that $X^n - a$ is irreducible over a field $K$ iff $a \\notin K^p$ for every prime $p \\mid n$ and (when $4 \\mid n$) $-4a \\notin K^4$. Every case of the Schinzel–Velez classification routes through Capelli.\n\nS1 OBSERVE (PR #17929) surveyed the literature and identified Schinzel–Velez as the answer pathway. This S2 SCAFFOLD lands the **API surface**: an abstract criterion definition (no sorry) plus statement-only declarations of the two flagship theorems (sorry-guarded). S3+ iterations and a separate Capelli-in-Mathlib effort will discharge the sorries.",
+    "content": "The **parent** entry `inverse-galois-d4` proves a single concrete instance: $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$. Open Question 3 generalises that point result to a **uniform criterion**:\n\n> For which pairs $(n, a) \\in \\mathbb{N} \\times \\mathbb{Q}$ is the Galois group of $X^n - a$ over $\\mathbb{Q}$ isomorphic to a dihedral group?\n\nThe mathematical literature **already has the answer**: Velez (1979) and Schinzel (2000) gave a finite-case classification keyed on $n \\bmod 8$ and the $p$-adic valuations of $a$. The Lean obstruction is *not* mathematical — it is the absence of **Capelli's irreducibility theorem** from Mathlib `v4.26.0`. Capelli's theorem (1897) states that $X^n - a$ is irreducible over a field $K$ iff $a \\notin K^p$ for every prime $p \\mid n$ and (when $4 \\mid n$) $-4a \\notin K^4$. Every case of the Schinzel–Velez classification routes through Capelli.\n\nS1 OBSERVE (PR #17929) surveyed the literature and identified Schinzel–Velez as the answer pathway; later iterations landed the abstract-criterion API. **This iteration discharges the flagship (4, 2) case with no sorry**: $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$, proved through a self-contained group-theoretic classification (every order-8 subgroup of $S_4$ is $\\cong D_4$, by Sylow's theorem). Only the *general-n* Schinzel–Velez predicate remains open, still blocked upstream by Capelli's theorem.",
     "mathContext": "Schinzel–Velez classification: $\\mathrm{Gal}(X^n - a / \\mathbb{Q})$ is one of cyclic, dihedral, quasi-dihedral, semi-dihedral, or the full metacyclic $\\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times$, with the case determined by $n \\bmod 8$ and $\\mathrm{ord}_p(a)$ for $p \\mid n$. Capelli: $X^n - a$ irreducible over $K$ $\\Leftrightarrow$ $a \\notin K^p\\ \\forall p \\mid n$ and $-4a \\notin K^4$ when $4 \\mid n$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -30,8 +30,8 @@
     "id": "ann-iv4o03-xpowsub",
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
-      "startLine": 67,
-      "endLine": 72
+      "startLine": 181,
+      "endLine": 195
     },
     "type": "definition",
     "title": "xPowSub: the central polynomial X^n − a",
@@ -53,8 +53,8 @@
     "id": "ann-iv4o03-abstract-criterion",
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
-      "startLine": 74,
-      "endLine": 84
+      "startLine": 197,
+      "endLine": 217
     },
     "type": "definition",
     "title": "IsDihedralGaloisOfXnMinusA: the abstract criterion (no sorry)",
@@ -78,14 +78,14 @@
     "id": "ann-iv4o03-d4-bridge",
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
-      "startLine": 86,
-      "endLine": 102
+      "startLine": 219,
+      "endLine": 257
     },
     "type": "insight",
-    "title": "dihedral_galois_xPow4_sub_2: the parent → criterion bridge",
-    "content": "States `IsDihedralGaloisOfXnMinusA 4 2` — i.e., $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$. The parent gallery entry's `d4_realizable` already proves the **order** is 8 (via the degree squeeze: $4 \\mid |\\mathrm{Gal}|$ from irreducibility, $|\\mathrm{Gal}| \\leq 8$ from the splitting field degree, and the ℝ-embedding argument ruling out 4). What is **missing** is identifying the group of order 8 as $D_4$ rather than $\\mathbb{Z}/8$, $\\mathbb{Z}/4 \\times \\mathbb{Z}/2$, $(\\mathbb{Z}/2)^3$, or the quaternion group $Q_8$.\n\nThe **classical bridge** uses:\n\n1. **Transitivity**: $\\mathrm{Gal}$ acts transitively on the 4 roots $\\{\\sqrt[4]{2},\\, i\\sqrt[4]{2},\\, -\\sqrt[4]{2},\\, -i\\sqrt[4]{2}\\}$ since the polynomial is irreducible.\n2. **Faithful embedding** $\\mathrm{Gal} \\hookrightarrow S_4$ via the permutation representation on roots.\n3. **Classification fact** (Cox §13.3): the transitive subgroups of $S_4$ are exactly $\\mathbb{Z}/4$, $V_4$ (Klein), $D_4$, $A_4$, $S_4$ — with orders $4, 4, 8, 12, 24$ respectively. **Only $D_4$ has order 8.**\n4. Combine with `Fintype.card_eq_card_iff_nonempty_equiv` (or the explicit isomorphism via the Cayley-style construction $D_4 \\hookrightarrow S_4$) to lift the cardinality match to a `MulEquiv`.\n\nThe `sorry` is honest — this is a **~50-100 line discharge** that doesn't require any Mathlib gap, just careful Lean encoding of the classification fact. Notably, this proof is **self-contained**: it does **not** depend on Capelli or Schinzel–Velez. S3 should target this first.",
+    "title": "dihedral_galois_xPow4_sub_2: Gal(X⁴ − 2 / ℚ) ≅ D₄, fully proved",
+    "content": "This is the flagship concrete instance, **now proved with no sorry**. The Galois group acts faithfully on the four roots of $X^4 - 2$ (`Polynomial.Gal.galActionHom`, injective), embedding it as a subgroup of $S_4$; the parent entry gives $|\\mathrm{Gal}| = 8$. Since $8 = 2^3$ is the full 2-part of $|S_4| = 24$, that image is a **Sylow 2-subgroup** of $S_4$. By Sylow's second theorem all Sylow 2-subgroups of $S_4$ are conjugate, hence isomorphic — in particular isomorphic to the explicit dihedral copy $\\langle (0\\,1\\,2\\,3),(1\\,3)\\rangle$ built in §1. This identifies the group as exactly $D_4$, not merely a group of order 8. The discharge is packaged as `order_eight_iso_dihedralFour_of_card` applied to `galActionHom`.",
     "mathContext": "Transitive subgroups of $S_4$ (up to conjugacy): $\\mathbb{Z}/4$ (cyclic, gen. by 4-cycle), $V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\}$, $D_4 = \\langle (1234), (13) \\rangle$, $A_4$, $S_4$. Of these only $D_4$ has order 8, so $|\\mathrm{Gal}| = 8 + \\mathrm{transitive} \\Rightarrow \\mathrm{Gal} \\cong D_4$.",
-    "significance": "key",
+    "significance": "Turns the parent's order-8 cardinality result into the full dihedral identification, the classical Galois-theory benchmark.",
     "relatedConcepts": [
       "inverse-galois-d4.d4_realizable (order-8 statement)",
       "Transitive subgroups of S₄ (Klein V₄, D₄, A₄, S₄, ℤ/4)",
@@ -103,11 +103,11 @@
     "id": "ann-iv4o03-schinzel-velez",
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
-      "startLine": 104,
-      "endLine": 125
+      "startLine": 328,
+      "endLine": 360
     },
     "type": "concept",
-    "title": "dihedral_iff_schinzel_velez: characterization placeholder",
+    "title": "schinzel_velez_characterization_exists: the general-n placeholder (no sorry)",
     "content": "States `IsDihedralGaloisOfXnMinusA n a ↔ True` — a **deliberately incomplete iff** that holds the slot for the explicit Schinzel–Velez predicate. The `True` placeholder is a known anti-pattern, but here it is **load-bearing API**: it lets downstream files import `dihedral_iff_schinzel_velez` and pattern-match on a stable name, then a future `theorem schinzelVelez : ... ↔ schinzelVelezPredicate n a` will replace `True` once Capelli is available.\n\n**Why Capelli is the bottleneck.** The Schinzel–Velez predicate has the rough shape\n$$\\mathrm{schinzelVelezPredicate}\\ n\\ a := \\bigvee_{i \\in \\text{case}(n \\bmod 8)}\\, \\Phi_i(\\mathrm{ord}_{p_1}(a), \\dots, \\mathrm{ord}_{p_k}(a))$$\nwhere the disjunction ranges over Velez's **case analysis** (4 cases keyed on $n \\bmod 8$, plus subcases for $n = 4, 8, 16$), and each $\\Phi_i$ is a finite Boolean condition on the $p$-adic valuations of $a$. **Every case is derived by:**\n1. Using **Capelli** to enumerate the irreducible factors of $X^n - a$ (Capelli gives a `2`-power factorization criterion).\n2. Computing the cyclotomic action of $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n)^\\times$ on the radical kernel $\\mathbb{Q}(\\sqrt[n]{a})/\\mathbb{Q}$.\n3. Checking whether this action lands in $\\{\\pm 1\\}$ (dihedral) vs. the full $(\\mathbb{Z}/n)^\\times$ (metacyclic).\n\nWithout Capelli's theorem in Mathlib, **step 1 is blocked** for nearly every concrete $n$, so the predicate cannot even be stated.\n\n**Estimated cost**: Capelli is roughly **~200 lines of new infrastructure** (descent on prime $p \\mid n$ + the $4 \\mid n, -4a \\in K^4$ exceptional case). A focused Mathlib-upstream PR is the natural strategy; once landed, S4 can replace `True` with the explicit predicate and discharge the iff using Velez (1979) and Schinzel (2000) — another **~300-500 lines**.",
     "mathContext": "Schinzel–Velez (Velez 1979, Acta Arith.; Schinzel 2000, §III.2): $\\mathrm{Gal}(X^n - a / \\mathbb{Q})$ is dihedral $\\Leftrightarrow$ explicit predicate on $n \\bmod 8$ and $\\{\\mathrm{ord}_p(a) : p \\mid n\\}$. Capelli (1897): $X^n - a$ irreducible over $K$ $\\Leftrightarrow$ $a \\notin K^p$ for all primes $p \\mid n$ AND ($4 \\nmid n$ OR $-4a \\notin K^4$).",
     "significance": "key",
@@ -130,14 +130,14 @@
     "id": "ann-iv4o03-roadmap",
     "proofId": "inverse-galois-d4-oq-03",
     "range": {
-      "startLine": 127,
-      "endLine": 127
+      "startLine": 85,
+      "endLine": 179
     },
     "type": "insight",
-    "title": "Roadmap: S3, Capelli upstream, S4",
-    "content": "The S2 SCAFFOLD ends here. The remaining work decomposes into three **independent** tracks that can proceed in parallel:\n\n**Track A — S3 immediate discharge of `dihedral_galois_xPow4_sub_2`.** Self-contained, ~50-100 lines, no Mathlib gap. Bridges from `inverse-galois-d4.d4_realizable` (order 8) to the explicit `D_4` identification via the transitive-subgroup-of-$S_4$ classification. Highest expected value for the Lean Genius gallery short-term.\n\n**Track B — Capelli's theorem to Mathlib upstream.** ~200 lines, focused PR, no dependency on this entry. The natural lemma name is `Polynomial.irreducible_X_pow_sub_C_iff` (currently Mathlib has only the special case `irreducible_X_pow_sub_one` for cyclotomic minus-1). Should be pitched as a standalone contribution unrelated to OQ-03.\n\n**Track C — S4+ Schinzel–Velez characterization (post-Capelli).** ~300-500 lines, depends on Track B landing in Mathlib. Replaces `True` with the explicit predicate; discharges the iff using Velez (1979) and Schinzel (2000) §III.2.\n\n**Variant question (open)**: replace $\\mathbb{Q}$ with a general number field $K$. The metacyclic embedding $\\mathrm{Gal}(X^n - a / K) \\hookrightarrow \\mathbb{Z}/n \\rtimes (\\mathbb{Z}/n)^\\times$ generalises, but the dihedral condition depends on the cyclotomic Galois group $\\mathrm{Gal}(K(\\zeta_n)/K)$, which is no longer $(\\mathbb{Z}/n)^\\times$ in general.\n\nFor agents picking up S3+: prioritize Track A (no upstream dependency) over Track B/C unless contributing to Mathlib is itself the goal.",
+    "title": "The group-theoretic core: order-8 subgroups of S₄ are D₄ (Sylow's theorem)",
+    "content": "The (4, 2) discharge rests on a purely group-theoretic fact proved here without any Galois input: **every subgroup of $S_4$ of order 8 is isomorphic to $\\mathrm{DihedralGroup}\\,4$**. Because $8 = 2^3$ is the full 2-part of $|S_4| = 24 = 2^3\\cdot 3$, such a subgroup is a Sylow 2-subgroup; Sylow's second theorem makes all Sylow 2-subgroups conjugate, hence isomorphic to the explicit copy $\\langle(0\\,1\\,2\\,3),(1\\,3)\\rangle$ (`dihedralFourToPerm`, whose homomorphism and injectivity are finite `decide` checks). Formally: `order_eight_iso_dihedralFour` packages `Sylow.ofCard` + `MulAction.exists_smul_eq` (conjugacy) + a conjugation `MulEquiv`. What remains genuinely open is the *general-n* Schinzel–Velez criterion, still gated on Capelli's irreducibility theorem upstream in Mathlib.",
     "mathContext": "Three tracks: A (S3, self-contained), B (Capelli to Mathlib), C (S4 post-Capelli). Generalisation to number fields $K$ is a fourth, open direction.",
-    "significance": "supporting",
+    "significance": "A reusable, Galois-free classification lemma; the mathematical heart of the (4, 2) discharge.",
     "relatedConcepts": [
       "Mathlib contribution workflow",
       "Tracked roadmap: S1 OBSERVE → S2 SCAFFOLD → S3 DISCHARGE → S4 CHARACTERIZE",

--- a/src/data/proofs/inverse-galois-d4-oq-03/meta.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "inverse-galois-d4-oq-03",
-  "title": "General Dihedral-Galois Criterion for X^n - a (S2 Scaffold)",
+  "title": "Dihedral Galois Group of X⁴ − 2 ≅ D₄ (proved) + General X^n − a Criterion Scaffold",
   "slug": "inverse-galois-d4-oq-03",
-  "description": "S2 scaffold for the parent's third open question: 'Is there a general criterion for when Gal(X^n - a / ℚ) is dihedral?' Defines `IsDihedralGaloisOfXnMinusA n a` abstractly via Mathlib's Polynomial.SplittingField and DihedralGroup; states the (4, 2) specialization and the Schinzel-Velez characterization, both sorry-guarded. S1 OBSERVE (PR #17929) identified the Schinzel-Velez classification as the answer pathway; this S2 lands the API surface. Capelli's irreducibility theorem (absent from Mathlib v4.26.0) is the key prerequisite for the explicit characterization.",
+  "description": "The parent's third open question: 'Is there a general criterion for when Gal(X^n − a / ℚ) is dihedral?' Defines `IsDihedralGaloisOfXnMinusA n a` abstractly via Mathlib's Polynomial.SplittingField and DihedralGroup. **The (4, 2) case is now fully proved (0 sorries): `Gal(X⁴ − 2 / ℚ) ≅ D₄`.** The discharge factors through a self-contained group-theoretic classification — *every order-8 subgroup of S₄ is ≅ D₄* — since 8 = 2³ is the full 2-part of |S₄| = 24, so such a subgroup is a Sylow 2-subgroup and all of them are conjugate (Sylow's theorem), hence isomorphic to the explicit dihedral copy ⟨(0 1 2 3),(1 3)⟩ built here. Applied to the faithful action of the Galois group on the four roots (galActionHom, injective, image order 8) it identifies the group exactly. The general-n Schinzel–Velez criterion remains a scaffold, blocked upstream by Capelli's irreducibility theorem (absent from Mathlib v4.26.0).",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/InverseGaloisD4OQ03.lean",
     "tags": [
       "galois-theory",
@@ -18,20 +18,25 @@
       "capelli-theorem",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 235,
-    "assumptions": "0 axioms; 1 sorry — `dihedral_galois_xPow4_sub_2` (the parent's (4, 2) specialization, bridging from `InverseGaloisD4.d4_realizable` which proves the order is 8 to the explicit D₄ identification via the classical fact that D₄ is the unique transitive subgroup of S₄ of order 8). S3b (researcher-4, this iteration) adds 7 no-sorry bridge helpers: `xPowSub_4_2_natDegree`, `xPowSub_4_2_irreducible`, `xPowSub_4_2_separable`, `xPowSub_4_2_monic`, `dihedralGroup_4_card`, `gal_card_eq_dihedralGroup_4_card`, and `dihedral_galois_xPow4_sub_2_of_mulEquiv` — narrowing the remaining S4 work to a single `MulEquiv` construction. S3a (researcher-12, PR #18063) closed the former second sorry on `dihedral_iff_schinzel_velez` by replacing its false `↔ True` statement with the provably-true existential `schinzel_velez_characterization_exists`, and added two no-sorry helpers `xPowSub_def` and `gal_card_xPowSub_4_2`. Imports: `Mathlib.FieldTheory.Galois.Basic`, `Mathlib.GroupTheory.SpecificGroups.Dihedral`, `Mathlib.Algebra.Polynomial.{Basic,AlgebraMap}`, `Proofs.InverseGaloisD4`.",
+    "lineCount": 361,
+    "assumptions": "0 axioms, 0 sorries — fully machine-verified (no `native_decide`; the finite homomorphism/injectivity checks on `dihedralFourToPerm` use ordinary kernel `decide`). `dihedral_galois_xPow4_sub_2 : IsDihedralGaloisOfXnMinusA 4 2` is discharged via the new self-contained group-theoretic lemma `order_eight_iso_dihedralFour` (any order-8 subgroup of S₄ is ≅ DihedralGroup 4, by Sylow.ofCard + MulAction.exists_smul_eq conjugacy + conjugation MulEquiv), transported by `order_eight_iso_dihedralFour_of_card` and applied to `Polynomial.Gal.galActionHom` on the four roots (|Gal| = 8 from the parent's x4_sub_2_gal_card). The only remaining open content is the *general-n* Schinzel–Velez predicate (`schinzel_velez_characterization_exists` is a vacuous existential), blocked by Capelli's irreducibility theorem upstream. Imports: Mathlib FieldTheory.Galois.Basic, GroupTheory.Sylow, GroupTheory.SpecificGroups.Dihedral, GroupTheory.Perm.Fin, Data.Nat.Factorization.Basic, Data.Fintype.EquivFin, Algebra.Group.End, Algebra.Polynomial.{Basic,AlgebraMap}, Proofs.InverseGaloisD4.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 11,
-    "definitionCount": 2,
+    "theoremCount": 14,
+    "definitionCount": 5,
     "originalContributions": [
+      "rho: the 4-cycle (0 1 2 3) on Fin 4 as a product of adjacent transpositions — the rotation generator of the explicit D₄ ≤ S₄.",
+      "dihedralFourToPerm: explicit injective group homomorphism DihedralGroup 4 →* Equiv.Perm (Fin 4) realising D₄ as the square's symmetry group ⟨(0 1 2 3),(1 3)⟩; homomorphism and injectivity discharged by kernel `decide`.",
+      "dihedralFourToPerm_injective: injectivity of that embedding (decide) — establishes the reference Sylow 2-subgroup of S₄.",
+      "order_eight_iso_dihedralFour: NEW group-theoretic classification — any finite group of order 8 embedding in S₄ is ≅ DihedralGroup 4. Proof: both images are Sylow 2-subgroups of S₄ (8 = 2^((24).factorization 2)), hence conjugate by Sylow's second theorem (MulAction.exists_smul_eq), and conjugation gives the MulEquiv. Reusable, self-contained, 0 axioms.",
+      "order_eight_iso_dihedralFour_of_card: the same classification transported to an arbitrary 4-element permutation domain via Equiv.permCongrHom — the form consumed by the Galois discharge (root set ≃ Fin 4).",
+      "dihedral_galois_xPow4_sub_2: FULLY PROVED (0 sorry) — Gal(X⁴ − 2 / ℚ) ≅ DihedralGroup 4. Applies order_eight_iso_dihedralFour_of_card to the faithful galActionHom action on the four roots (card 4 via card_rootSet_eq_natDegree; |Gal| = 8 from the parent), completing the parent's (4, 2) case.",
       "IsDihedralGaloisOfXnMinusA: abstract proposition for 'Gal(X^n - a / ℚ) is dihedral' phrased via Mathlib's existing Polynomial.SplittingField and DihedralGroup constructions — no new infrastructure required",
       "xPowSub: stable name for the polynomial X^n - a, factored out for use throughout the dihedral-criterion development",
       "xPowSub_def: definitional-unfolding helper (S3a, no sorry) bridging `xPowSub n a` to `X^n - C a`; lets downstream lemmas alternate between the two notations for free",
-      "dihedral_galois_xPow4_sub_2: statement of the parent's (4, 2) specialization in terms of the abstract criterion; sorry-guarded, with proof route documented (transitive-subgroup-of-S4 argument)",
       "gal_card_xPowSub_4_2: S3a cardinality lift (no sorry) — `Fintype.card (xPowSub 4 2).Gal = 8` via the parent's `x4_sub_2_gal_card`; isolates the cardinality input of the S3+ bridge from the harder 'order-8 transitive S₄ subgroup is D₄' classification step",
       "xPowSub_4_2_natDegree: S3b polynomial-degree bridge (no sorry) — `(xPowSub 4 2).natDegree = 4` via the parent's `x_fourth_sub_2_natDegree`; sets up the S₄-embedding context for S4",
       "xPowSub_4_2_irreducible: S3b irreducibility bridge (no sorry) — `Irreducible (xPowSub 4 2)` via the parent's Eisenstein-at-2 lemma; supplies the transitivity hypothesis for the `Polynomial.Gal.galActionHom` injection into S₄",
@@ -95,81 +100,95 @@
   "sections": [
     {
       "id": "intro-docstring",
-      "title": "§0: Open Question, S1 Survey Recap, and S2 SCAFFOLD Scope",
+      "title": "§0: Open Question, Survey Recap, and the S4 Discharge",
       "startLine": 1,
-      "endLine": 70,
-      "summary": "Imports (Mathlib Galois/Dihedral/Polynomial + parent InverseGaloisD4) and top-level docstring summarising the S1 OBSERVE survey findings (Schinzel-Velez classification; Capelli's theorem bottleneck), the S2 SCAFFOLD scope (3 deliverables: abstract criterion def + (4, 2) specialization stmt + SV iff stmt), and references (Velez 1979, Schinzel 2000, Capelli 1897, parent gallery).",
-      "mathContext": "Parent OQ: 'Is there a general criterion for when Gal(X^n - a / ℚ) is dihedral?' Answer pathway: Schinzel-Velez classification. Bottleneck: Capelli's irreducibility theorem, currently absent from Mathlib."
+      "endLine": 79,
+      "summary": "Imports (Mathlib Galois/Sylow/Dihedral/Perm/Factorization + parent InverseGaloisD4) and top-level docstring: the parent OQ, the Schinzel–Velez pathway and Capelli bottleneck for general n, and the S4 update — the (4, 2) case is now fully proved (no sorry) via the order-8-subgroup-of-S₄ classification.",
+      "mathContext": "Parent OQ: 'general criterion for Gal(X^n − a / ℚ) dihedral?' General case blocked on Capelli; the (4, 2) case is discharged here."
+    },
+    {
+      "id": "group-theory-core",
+      "title": "§1: Group-theoretic core — every order-8 subgroup of S₄ is D₄ (no sorry)",
+      "startLine": 85,
+      "endLine": 179,
+      "summary": "The self-contained crux. `rho` = (0 1 2 3); `dihedralFourToPerm : DihedralGroup 4 →* S₄` realises D₄ as ⟨(0 1 2 3),(1 3)⟩ (homomorphism + injectivity by kernel `decide`). `order_eight_iso_dihedralFour`: any finite group of order 8 embedding in S₄ is ≅ DihedralGroup 4 — both images are Sylow 2-subgroups (8 = 2^((24).factorization 2)), conjugate by Sylow's second theorem (`MulAction.exists_smul_eq`), with conjugation supplying the `MulEquiv`. `order_eight_iso_dihedralFour_of_card` transports this to any 4-element permutation domain via `Equiv.permCongrHom`.",
+      "mathContext": "8 = 2³ ∥ 24 = |S₄| ⇒ Sylow-2 ⇒ all conjugate ⇒ ≅ to the explicit D₄ copy. Reusable, 0 axioms."
     },
     {
       "id": "polynomial-helper",
-      "title": "§1: xPowSub + xPowSub_def — stable name for X^n - a",
-      "startLine": 71,
-      "endLine": 80,
-      "summary": "Defines `xPowSub n a := X^n - C a : ℚ[X]`, factored out for use throughout the dihedral-criterion development. Noncomputable due to ring structure. S3a adds `xPowSub_def : xPowSub n a = X^n - C a := rfl` — a definitional-unfolding helper that bridges the local `xPowSub` notation to the parent's explicit `(X : ℚ[X])^4 - C 2` form.",
-      "mathContext": "$X^n - a \\in \\mathbb{Q}[X]$ — the central polynomial whose splitting field's Galois group is the object of study."
+      "title": "§2: xPowSub + xPowSub_def — stable name for X^n − a",
+      "startLine": 181,
+      "endLine": 195,
+      "summary": "Defines `xPowSub n a := X^n − C a : ℚ[X]` and `xPowSub_def` (rfl) bridging to the parent's `(X : ℚ[X])^4 − C 2` form.",
+      "mathContext": "$X^n - a \\in \\mathbb{Q}[X]$ — the central polynomial."
     },
     {
       "id": "abstract-criterion",
-      "title": "§2: IsDihedralGaloisOfXnMinusA — abstract criterion (no sorry)",
-      "startLine": 81,
-      "endLine": 92,
-      "summary": "Defines `IsDihedralGaloisOfXnMinusA n a : Prop` as `∃ m ≥ 2, the Galois group of (xPowSub n a).SplittingField over ℚ is isomorphic (as a group) to DihedralGroup m`. Uses Mathlib's existing constructions; no new infrastructure. **Definition only (no sorry).**",
-      "mathContext": "Predicate: $\\exists m \\geq 2,\\ \\mathrm{Aut}_{\\mathbb{Q}}(\\mathbb{Q}(X^n - a)_{\\mathrm{split}}) \\cong D_m$ (MulEquiv on the Galois group)."
+      "title": "§3: IsDihedralGaloisOfXnMinusA — abstract criterion (no sorry)",
+      "startLine": 197,
+      "endLine": 217,
+      "summary": "Defines `IsDihedralGaloisOfXnMinusA n a : Prop` = `∃ m ≥ 2, the Galois group of (xPowSub n a).SplittingField over ℚ is ≅ DihedralGroup m`. Definition only, no sorry.",
+      "mathContext": "$\\exists m \\geq 2,\\ \\mathrm{Aut}_{\\mathbb{Q}}(\\mathbb{Q}(X^n - a)_{\\mathrm{split}}) \\cong D_m$."
     },
     {
       "id": "specialization-4-2",
-      "title": "§3: dihedral_galois_xPow4_sub_2 + gal_card_xPowSub_4_2 — parent (4, 2) specialization (one sorry)",
-      "startLine": 93,
-      "endLine": 125,
-      "summary": "States `IsDihedralGaloisOfXnMinusA 4 2`. The main theorem is sorry-guarded; the proof route is via the parent's `d4_realizable` (order 8) plus the classical fact that D_4 is the unique transitive subgroup of S_4 of order 8. S3a (researcher-12) adds the cardinality-lift helper `gal_card_xPowSub_4_2 : Fintype.card (xPowSub 4 2).Gal = 8` (no sorry, by `show ... = 8; exact InverseGaloisExtensions.x4_sub_2_gal_card`), isolating the cardinality input of the S4 bridge from the harder order-8-transitive-S₄-subgroup classification step.",
-      "mathContext": "$\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$. Parent proves order 8; this scaffold states the dihedral identification explicitly and S3a lifts the cardinality."
+      "title": "§4: dihedral_galois_xPow4_sub_2 — the (4, 2) case, FULLY PROVED (no sorry)",
+      "startLine": 219,
+      "endLine": 257,
+      "summary": "`IsDihedralGaloisOfXnMinusA 4 2`, i.e. `Gal(X⁴ − 2 / ℚ) ≅ D₄`, now discharged. Builds the `Fact (Splits)` and `DecidableEq` instances, computes the four-element root set (`card_rootSet_eq_natDegree`), lifts |Gal| = 8 from the parent (`gal_card_xPowSub_4_2`), and applies `order_eight_iso_dihedralFour_of_card` to `Polynomial.Gal.galActionHom` (injective). `gal_card_xPowSub_4_2` remains as the cardinality helper.",
+      "mathContext": "$\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$ — parent proves order 8; this section now proves the dihedral identification outright."
     },
     {
       "id": "s3b-bridge-helpers",
-      "title": "§4: S3b bridge helpers — natDegree/irreducible/separable/monic + DihedralGroup 4 cardinality + S4 entry point (no sorry)",
-      "startLine": 126,
-      "endLine": 207,
-      "summary": "Seven no-sorry bridge lemmas (S3b, researcher-4) narrowing the remaining S4 work to a single `MulEquiv` construction. Polynomial-side: `xPowSub_4_2_natDegree = 4`, `xPowSub_4_2_irreducible` (Eisenstein at 2), `xPowSub_4_2_separable` (char-0 irreducible ⇒ separable), `xPowSub_4_2_monic` — together setting up the `Gal ↪ S₄` embedding context. Codomain-side: `dihedralGroup_4_card : Fintype.card (DihedralGroup 4) = 8` (via Mathlib `DihedralGroup.card`). Cardinality match: `gal_card_eq_dihedralGroup_4_card` combines the §3 lift with `dihedralGroup_4_card` (necessary condition for the eventual `MulEquiv`). S4 entry point: `dihedral_galois_xPow4_sub_2_of_mulEquiv` supplies the existential witness `m = 4`, so S4 only needs the concrete `MulEquiv Gal(X⁴−2) ≃* DihedralGroup 4`.",
-      "mathContext": "Bridge lemmas reducing $\\mathrm{Gal}(X^4-2/\\mathbb{Q}) \\cong D_4$ to a single isomorphism construction: $\\deg = 4$, irreducible (Eisenstein), separable, monic, $|D_4| = 8 = |\\mathrm{Gal}|$, and the $m=4$ witness."
+      "title": "§5: bridge helpers — natDegree/irreducible/separable/monic + DihedralGroup 4 cardinality + S4 entry point (no sorry)",
+      "startLine": 259,
+      "endLine": 326,
+      "summary": "No-sorry bridge lemmas retained from earlier iterations: `xPowSub_4_2_natDegree/irreducible/separable/monic`, `dihedralGroup_4_card`, `gal_card_eq_dihedralGroup_4_card`, and `dihedral_galois_xPow4_sub_2_of_mulEquiv` (the `m = 4` witness helper). Still useful re-exported facts about the polynomial and codomain group.",
+      "mathContext": "$\\deg = 4$, irreducible (Eisenstein), separable, monic, $|D_4| = 8 = |\\mathrm{Gal}|$."
     },
     {
       "id": "schinzel-velez-iff",
-      "title": "§5: schinzel_velez_characterization_exists — abstract characterization (S3a audit fix, no sorry)",
-      "startLine": 208,
-      "endLine": 234,
-      "summary": "States `∃ P : ℕ → ℚ → Prop, ∀ n a, IsDihedralGaloisOfXnMinusA n a ↔ P n a` — proved without sorry by taking `P := IsDihedralGaloisOfXnMinusA`. S3a audit fix replacing the prior S2 statement `dihedral_iff_schinzel_velez (n a) : IsDihedralGaloisOfXnMinusA n a ↔ True`, which was unprovable as written (false for any (n, a) outside the dihedral case, e.g., n = 1 trivial or n = 5, a = 2 with Galois group F₂₀). Future iterations should replace this trivially-true existential with the explicit Schinzel-Velez predicate once Capelli's irreducibility theorem is formalized.",
-      "mathContext": "$\\exists P,\\ \\mathrm{IsDihedralGaloisOfXnMinusA}\\, n\\, a \\Leftrightarrow P(n, a)$ — content-free existential preserving the original docstring's intent; Capelli's theorem is the prerequisite for the explicit finite-case form."
+      "title": "§6: schinzel_velez_characterization_exists — abstract characterization (no sorry)",
+      "startLine": 328,
+      "endLine": 360,
+      "summary": "`∃ P : ℕ → ℚ → Prop, ∀ n a, IsDihedralGaloisOfXnMinusA n a ↔ P n a` — proved by taking `P := IsDihedralGaloisOfXnMinusA`. Placeholder for the explicit finite-case Schinzel–Velez predicate, which awaits Capelli's irreducibility theorem in Mathlib.",
+      "mathContext": "Content-free existential; Capelli's theorem is the prerequisite for the explicit general-n form."
     }
   ],
   "conclusion": {
-    "summary": "S2 SCAFFOLD landing the API surface for the dihedral-Galois criterion on X^n - a. Three deliverables: abstract criterion definition (no sorry), (4, 2) specialization statement (sorry — parent bridge), and Schinzel-Velez iff statement (sorry — `True` placeholder pending Capelli's theorem in Mathlib).",
-    "implications": "Locks down the API surface so S3+ iterations can target specific discharge goals: the (4, 2) specialization is self-contained (~50-100 lines, no Mathlib gap), while the full Schinzel-Velez characterization needs Capelli's theorem as a prerequisite. This separates the 'low-hanging-fruit' work from the 'contribute-upstream-first' work.",
+    "summary": "The (4, 2) case of the dihedral-Galois criterion is now FULLY PROVED: Gal(X⁴ − 2 / ℚ) ≅ D₄, with 0 sorries and 0 axioms, via a reusable order-8-subgroup-of-S₄ classification (Sylow's theorem). The abstract criterion and the general-n Schinzel–Velez characterization remain as scaffold, the latter blocked upstream by Capelli's irreducibility theorem.",
+    "implications": "Establishes the flagship concrete instance of the criterion outright, and contributes a self-contained group-theoretic lemma (`order_eight_iso_dihedralFour`) reusable elsewhere. The remaining work is the general-n predicate, cleanly separated as a contribute-Capelli-upstream-first task.",
     "openQuestions": [
-      "**S4 immediate**: discharge the remaining sorry on `dihedral_galois_xPow4_sub_2` by combining S3a's `gal_card_xPowSub_4_2` (the order-8 cardinality lift) with the classical 'unique transitive S₄ subgroup of order 8 is D₄' classification. Likely route: `Polynomial.Gal.galActionHom_injective` (parent) + a Mathlib transitivity witness on the root set + a new `dihedral_iso_of_order_8_transitive_subgroup_S4` auxiliary lemma. Estimate: 150-250 lines.",
-      "**Upstream contribution**: formalize Capelli's irreducibility theorem in Mathlib. Estimated ~200 lines; worth a focused PR upstream. Without this, the full Schinzel-Velez characterization cannot be stated explicitly.",
-      "**S5+ (post-Capelli)**: replace `schinzel_velez_characterization_exists` (currently the trivially-true existential) with the explicit finite-case predicate. Discharge the iff using Velez (1979) and Schinzel (2000); estimated ~300-500 lines.",
-      "**Variant**: consider the analogous criterion for `Gal(X^n - a / K)` over more general number fields `K`. Generalizes the metacyclic embedding."
+      "**Upstream contribution**: formalize Capelli's irreducibility theorem in Mathlib (~200 lines). Without it, the explicit finite-case Schinzel–Velez predicate cannot be stated.",
+      "**Post-Capelli**: replace `schinzel_velez_characterization_exists` (currently a vacuous existential) with the explicit predicate keyed on n mod 8 and the p-adic valuations of a; discharge the iff using Velez (1979) and Schinzel (2000). Estimate ~300–500 lines.",
+      "**Other dihedral (n, a)**: prove further concrete cases (e.g. via the same Sylow-classification technique generalized to larger symmetric groups, or the metacyclic embedding Gal ↪ ℤ/n ⋊ (ℤ/n)ˣ).",
+      "**Variant**: the analogous criterion for Gal(X^n − a / K) over general number fields K."
     ]
   },
   "leanFile": {
     "imports": [
       "Mathlib.FieldTheory.Galois.Basic",
       "Mathlib.GroupTheory.SpecificGroups.Dihedral",
+      "Mathlib.GroupTheory.Sylow",
+      "Mathlib.GroupTheory.Perm.Fin",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Fintype.EquivFin",
+      "Mathlib.Algebra.Group.End",
       "Mathlib.Algebra.Polynomial.Basic",
       "Mathlib.Algebra.Polynomial.AlgebraMap",
       "Proofs.InverseGaloisD4"
     ],
     "opens": [
-      "Polynomial"
+      "Polynomial",
+      "scoped Pointwise"
     ],
     "namespace": "InverseGaloisD4OQ03",
-    "lineCount": 235,
+    "lineCount": 361,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 2,
+    "theoremCount": 14,
+    "definitionCount": 5,
     "path": "Proofs/InverseGaloisD4OQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -192,6 +211,20 @@
       "significance": "API surface for all downstream work; no new infrastructure required."
     },
     {
+      "name": "dihedralFourToPerm",
+      "type": "definition",
+      "statement": "DihedralGroup 4 →* Equiv.Perm (Fin 4)",
+      "description": "Explicit injective embedding of D₄ into S₄ as the symmetry group ⟨(0 1 2 3),(1 3)⟩ of the square on vertices 0,1,2,3. Homomorphism (map_one', map_mul') and injectivity discharged by kernel `decide` over the 8-element group.",
+      "significance": "Realises the reference Sylow 2-subgroup of S₄, the conjugation target identifying the Galois group as D₄."
+    },
+    {
+      "name": "order_eight_iso_dihedralFour",
+      "type": "core",
+      "statement": "∀ {G} [Group G] [Finite G], Nat.card G = 8 → ∀ (f : G →* Equiv.Perm (Fin 4)), Function.Injective f → Nonempty (G ≃* DihedralGroup 4)",
+      "description": "NEW self-contained classification: any order-8 subgroup of S₄ is ≅ DihedralGroup 4. Proof: f.range and dihedralFourToPerm.range are Sylow 2-subgroups of S₄ (8 = 2^((24).factorization 2)); Sylow's second theorem (MulAction.exists_smul_eq) makes them conjugate; conjugation (MulEquiv.subgroupMap) supplies the isomorphism, chained through MonoidHom.ofInjective. No axioms, no native_decide.",
+      "significance": "The mathematical heart of the (4, 2) discharge, and a reusable group-theory lemma independent of Galois theory."
+    },
+    {
       "name": "xPowSub_def",
       "type": "lemma",
       "statement": "∀ (n : ℕ) (a : ℚ), xPowSub n a = X ^ n - C a",
@@ -202,8 +235,8 @@
       "name": "dihedral_galois_xPow4_sub_2",
       "type": "core",
       "statement": "IsDihedralGaloisOfXnMinusA 4 2",
-      "description": "The parent's (4, 2) case in terms of the abstract criterion. Sorry-guarded; proof route requires bridging from `d4_realizable`'s order-8 result via the 'unique transitive S₄ subgroup of order 8' fact. S3a supplies the cardinality-input piece (`gal_card_xPowSub_4_2`); the remaining sorry is the classification step.",
-      "significance": "Concrete instance proving the criterion is non-trivially satisfied."
+      "description": "FULLY PROVED (0 sorry): Gal(X⁴ − 2 / ℚ) ≅ DihedralGroup 4. Discharged by applying order_eight_iso_dihedralFour_of_card to the faithful galActionHom action of the Galois group on the four roots (root-set cardinality 4 via card_rootSet_eq_natDegree; |Gal| = 8 from the parent's x4_sub_2_gal_card). Completes the parent's (4, 2) case at the level of the abstract criterion.",
+      "significance": "Concrete, fully-verified instance witnessing the criterion — the classical benchmark Gal(X⁴−2) ≅ D₄."
     },
     {
       "name": "gal_card_xPowSub_4_2",
@@ -220,7 +253,7 @@
       "significance": "Audit fix closing the falsity-hidden-behind-a-sorry pattern; preserves the original docstring's existence-of-characterization intent without false content."
     }
   ],
-  "sorries": 1,
+  "sorries": 0,
   "references": {
     "papers": [
       "Velez, W. Y. (1979). 'On the Galois groups of X^n - a.' Acta Arithmetica 35, 191-198.",


### PR DESCRIPTION
## Summary

Discharges the `sorry` in `dihedral_galois_xPow4_sub_2`, completing the parent's benchmark case **Gal(X⁴ − 2 / ℚ) ≅ D₄** at the level of the abstract criterion `IsDihedralGaloisOfXnMinusA 4 2`. The group is now identified as **exactly D₄** (not merely a group of order 8).

**Machine-verified** via `./proofs/scripts/docker-build.sh Proofs.InverseGaloisD4OQ03` — 0 sorries, 0 axioms (kernel `decide` only, **no `native_decide`**, so no `Lean.ofReduceBool`).

## Mathematical content

A self-contained, Galois-free group-theoretic core:

- **`dihedralFourToPerm`** — explicit injective `DihedralGroup 4 →* S₄` realizing D₄ as the square's symmetry group `⟨(0 1 2 3), (1 3)⟩` (homomorphism + injectivity by finite `decide`).
- **`order_eight_iso_dihedralFour`** — *every order-8 subgroup of S₄ is ≅ DihedralGroup 4*. Since `8 = 2³` is the full 2-part of `|S₄| = 24`, such a subgroup is a **Sylow 2-subgroup**; by Sylow's second theorem all of them are conjugate (`MulAction.exists_smul_eq`), hence isomorphic via a conjugation `MulEquiv` (`Sylow.ofCard` + `MulEquiv.subgroupMap` + `MonoidHom.ofInjective`).
- **`order_eight_iso_dihedralFour_of_card`** — transported to any 4-element permutation domain via `Equiv.permCongrHom`.

The discharge applies this to `Polynomial.Gal.galActionHom` (the faithful action on the four roots; root-set cardinality 4 via `card_rootSet_eq_natDegree`, `|Gal| = 8` from the parent's `x4_sub_2_gal_card`).

## Changes

- `proofs/Proofs/InverseGaloisD4OQ03.lean`: 235 → 361 L, 11 → 14 theorems, 2 → 5 defs, **1 → 0 sorries**.
- Gallery `meta.json` / `annotations.json`: status `formalized` → `verified`, badge `wip` → `verified`, sorries → 0, updated sections/contributions/main-theorems.

## Remaining open

Only the **general-n** Schinzel–Velez criterion remains a scaffold, blocked upstream by Capelli's irreducibility theorem (absent from Mathlib v4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)