### PR TITLE
research(lagrange-theorem-oq-08-oq-01): A₄ has no subgroup of order 6 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ08OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ08OQ01.lean
@@ -1,0 +1,99 @@
+/-
+  The Converse of Lagrange's Theorem Fails: A₄ Has No Subgroup of Order 6
+  (lagrange-theorem-oq-08-oq-01)
+
+  Lagrange's theorem says the order of every subgroup divides the order of the
+  group. Its parent entry (lagrange-theorem-oq-08) records the *partial converse*
+  supplied by Cauchy's theorem: for every **prime** divisor `p` of `|G|` there is
+  a subgroup of order `p`. This file supplies the canonical *sharpness witness*
+  showing the converse genuinely fails for composite divisors:
+
+    **The alternating group A₄ = alternatingGroup (Fin 4) has order 12, the
+    number 6 divides 12, yet A₄ has no subgroup of order 6.**
+
+  This is the standard textbook counterexample to the naive converse of Lagrange.
+
+  ## Proof
+
+  Suppose `H ≤ A₄` had `Nat.card H = 6`. Since `|A₄| = 12`, `H` has index
+  `12 / 6 = 2`. An index-two subgroup contains every square (`sq_mem_of_index_two`).
+  Every 3-cycle `g` has order 3, so `g = g⁴ = (g²)²` is a square, hence lies in `H`.
+  There are exactly `2!·C(4,3) = 8` three-cycles in A₄
+  (`AlternatingGroup.card_of_cycleType_singleton`). All 8 must lie in `H`, forcing
+  `Nat.card H ≥ 8 > 6` — a contradiction.
+
+  ## Main results
+
+  * `card_A4` — `Nat.card (alternatingGroup (Fin 4)) = 12`.
+  * `no_subgroup_card_six` — no subgroup of A₄ has order 6.
+  * `six_dvd_card_A4` — 6 divides `|A₄|`.
+  * `converse_lagrange_fails` — there is a divisor of `|A₄|` that is not the order
+    of any subgroup (the negation of the naive converse of Lagrange).
+
+  Verified, 0 axioms (beyond Lean's foundational propext/Classical.choice/Quot.sound).
+-/
+import Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.Tactic
+
+namespace LagrangeTheoremOQ08OQ01
+
+open Equiv Equiv.Perm
+open scoped Finset
+
+/-- The alternating group on four letters has order 12. -/
+theorem card_A4 : Nat.card (alternatingGroup (Fin 4)) = 12 :=
+  alternatingGroup.card_of_card_eq_four (by rw [Nat.card_eq_fintype_card, Fintype.card_fin])
+
+/-- There are exactly eight 3-cycles in A₄ (`2! · C(4,3) = 8`). -/
+theorem card_threeCycles :
+    #{g : alternatingGroup (Fin 4) | (g.val).cycleType = ({3} : Multiset ℕ)} = 8 := by
+  rw [AlternatingGroup.card_of_cycleType_singleton (by decide) (by decide), Fintype.card_fin]
+  decide
+
+/-- **The converse of Lagrange's theorem fails.** The alternating group A₄ has
+order 12 and `6 ∣ 12`, but A₄ has no subgroup of order 6. -/
+theorem no_subgroup_card_six (H : Subgroup (alternatingGroup (Fin 4))) :
+    Nat.card H ≠ 6 := by
+  intro hHcard
+  -- `H` has index two, since `|A₄| = |H| · index = 12`.
+  have hindex2 : H.index = 2 := by
+    have hmul := Subgroup.card_mul_index H
+    rw [hHcard, card_A4] at hmul
+    omega
+  -- Every 3-cycle lies in `H`: it has order 3, so it is the square `(g²)²`, and
+  -- squares live in the index-two subgroup `H`.
+  have hbound : 8 ≤ Nat.card H := by
+    classical
+    rw [← card_threeCycles, Nat.card_eq_fintype_card, Fintype.card_subtype (· ∈ H)]
+    apply Finset.card_le_card
+    intro g hg
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hg ⊢
+    -- `hg : g.val.cycleType = {3}`; goal `g ∈ H`.
+    have hord : orderOf (g.val) = 3 := by
+      rw [← Equiv.Perm.lcm_cycleType, hg]; decide
+    have h1 : (g.val) ^ 3 = 1 := by rw [← hord]; exact pow_orderOf_eq_one _
+    have hg3 : g ^ 3 = 1 := by
+      rw [← SetLike.coe_eq_coe]; push_cast; exact h1
+    have hg2 : g ^ 2 ∈ H := Subgroup.sq_mem_of_index_two hindex2 g
+    have hval : (g ^ 2) ^ 2 = g := by
+      calc (g ^ 2) ^ 2 = g ^ 3 * g := by rw [← pow_mul, show 2 * 2 = 3 + 1 from rfl, pow_succ]
+        _ = 1 * g := by rw [hg3]
+        _ = g := one_mul g
+    exact hval ▸ pow_mem hg2 2
+  rw [hHcard] at hbound
+  omega
+
+/-- 6 divides the order of A₄. -/
+theorem six_dvd_card_A4 : 6 ∣ Nat.card (alternatingGroup (Fin 4)) := by
+  rw [card_A4]; norm_num
+
+/-- **Naive converse of Lagrange is false.** There is a divisor of `|A₄|` that is
+not the order of any subgroup of A₄. -/
+theorem converse_lagrange_fails :
+    ∃ d : ℕ, d ∣ Nat.card (alternatingGroup (Fin 4)) ∧
+      ¬ ∃ H : Subgroup (alternatingGroup (Fin 4)), Nat.card H = d :=
+  ⟨6, six_dvd_card_A4, fun ⟨H, hH⟩ => no_subgroup_card_six H hH⟩
+
+end LagrangeTheoremOQ08OQ01

--- a/src/data/proofs/lagrange-theorem-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-08-oq-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "The Sharpness Witness for the Converse of Lagrange",
+    "content": "Lagrange's theorem is a one-way street: the order of every subgroup divides the order of the group. The tempting converse — *every* divisor $d$ of $|G|$ is the order of some subgroup — is false, and the header names the standard refutation. The alternating group $A_4$ (even permutations of four letters) has order $12$, the number $6$ divides $12$, yet $A_4$ has **no** subgroup of order $6$.\n\nThis entry answers the first open question of the parent Cauchy entry (`lagrange-theorem-oq-08`), which proves the converse *does* hold for prime divisors and asks for the composite counterexample to be certified formally. Together the two entries pin down the sharp boundary: prime divisors always work (Cauchy), prime powers always work (Sylow), but the first genuinely composite divisor $6 = 2\\cdot 3$ can fail.\n\nThe imports are chosen to reuse Mathlib's alternating-group machinery on four letters: `SpecificGroups.Alternating.KleinFour` (which transitively brings the cycle-type cardinality lemmas), `GroupTheory.Index` (index-two facts), and `Perm.Cycle.Type` (the order = lcm-of-cycle-type bridge)."
+  },
+  {
+    "id": "ann-card-a4",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 47
+    },
+    "type": "technique",
+    "title": "|A₄| = 12",
+    "content": "`card_A4` records that $A_4$ has twelve elements. It is a direct instantiation of Mathlib's `alternatingGroup.card_of_card_eq_four`, which states $\\mathrm{Nat.card}\\,(\\text{alternatingGroup } \\alpha) = 12$ whenever the base type has four elements. The only work is supplying the hypothesis $\\mathrm{Nat.card}\\,(\\text{Fin } 4) = 4$, obtained by rewriting through `Nat.card_eq_fintype_card` and `Fintype.card_fin`.\n\nGeneral fact: $|A_n| = n!/2$, so $|A_4| = 24/2 = 12$. This $12 = 2^2 \\cdot 3$ factorization is what makes $6$ a divisor and hence a candidate subgroup order — the whole point of the counterexample."
+  },
+  {
+    "id": "ann-count-threecycles",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 53
+    },
+    "type": "key-step",
+    "title": "Counting the Eight 3-Cycles",
+    "content": "The combinatorial engine of the whole proof. A $3$-cycle in $S_4$ is an even permutation whose cycle type is the singleton multiset $\\{3\\}$. Mathlib's `AlternatingGroup.card_of_cycleType_singleton` evaluates the number of even permutations of cycle type $\\{n\\}$: for odd $n$ it is $(n-1)!\\cdot\\binom{|\\alpha|}{n}$, and for even $n$ it is $0$ (those permutations are odd).\n\nAt $n = 3$, $|\\alpha| = 4$: since $3$ is odd, the count is $(3-1)!\\cdot\\binom{4}{3} = 2!\\cdot 4 = 2\\cdot 4 = 8$. After rewriting `Fintype.card (Fin 4)` to $4$, the residual arithmetic $\\big(\\text{if Odd }3\\text{ then }2!\\cdot\\binom{4}{3}\\text{ else }0\\big) = 8$ is closed by `decide` — a kernel decision procedure over concrete numerals, so no `native_decide` (and hence no `Lean.ofReduceBool`) is involved.\n\nWhy eight matters: an order-$6$ subgroup has only six slots, but the next step forces all eight $3$-cycles into it. Eight $>$ six is the contradiction."
+  },
+  {
+    "id": "ann-index-two",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 64
+    },
+    "type": "key-step",
+    "title": "An Order-6 Subgroup Would Have Index Two",
+    "content": "The proof of `no_subgroup_card_six` is by contradiction: assume $H \\le A_4$ with $\\mathrm{Nat.card}\\,H = 6$. Mathlib's `Subgroup.card_mul_index` gives the fundamental identity $|H| \\cdot [G:H] = |G|$. Substituting $|H| = 6$ and $|A_4| = 12$ turns this into $6 \\cdot [G:H] = 12$, and `omega` concludes $[G:H] = 2$.\n\nIndex two is the pivotal structural fact. It is what makes $H$ *normal* and, more usefully here, what forces $H$ to contain a large, explicit set of elements — the squares — which the next steps exploit."
+  },
+  {
+    "id": "ann-squares-argument",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 86
+    },
+    "type": "key-step",
+    "title": "Every 3-Cycle Is a Square, So H Overflows",
+    "content": "This block establishes $8 \\le \\mathrm{Nat.card}\\,H$, contradicting $|H| = 6$. It shows the eight $3$-cycles all lie in $H$ by proving each one is a square:\n\n1. **Squares live in an index-two subgroup.** `Subgroup.sq_mem_of_index_two` gives $g^2 \\in H$ for *every* $g$ — because in the two-element quotient $G/H$ the image of any $g^2$ is the identity.\n\n2. **A 3-cycle is a square of itself.** For a $3$-cycle $g$, `Equiv.Perm.lcm_cycleType` gives $\\mathrm{orderOf}\\,g = \\mathrm{lcm}\\,\\{3\\} = 3$, so $g^3 = 1$. Then $g = g^4 = (g^2)^2$ (the `calc` block: $(g^2)^2 = g^{2\\cdot 2} = g^3\\cdot g = 1\\cdot g = g$). Since $g^2 \\in H$ and $H$ is closed under powers, $g = (g^2)^2 \\in H$.\n\n3. **Counting collision.** Every $3$-cycle is therefore in $H$, so the eight-element set of $3$-cycles injects into $H$. Formally the $3$-cycle filter is a subset of $H$'s membership filter, and `Finset.card_le_card` combined with `card_threeCycles` yields $8 \\le |H|$.\n\nWith $|H| = 6$, the final `omega` closes $8 \\le 6 \\to \\bot$. The subtlety handled by `push_cast`/`SetLike.coe_eq_coe` is transporting $g^3 = 1$ between the ambient permutation group and the subgroup $\\uparrow(\\text{alternatingGroup})$: the underlying permutation having cube $1$ is equivalent to the group element having cube $1$."
+  },
+  {
+    "id": "ann-packaging",
+    "proofId": "lagrange-theorem-oq-08-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 99
+    },
+    "type": "concept",
+    "title": "Packaging: The Naive Converse, Refuted",
+    "content": "`six_dvd_card_A4` records the arithmetic side of the counterexample, $6 \\mid |A_4|$, via $6 \\mid 12$. `converse_lagrange_fails` then bundles everything into a single existential statement: there is a divisor $d$ of $|A_4|$ (namely $d = 6$) for which no subgroup of $A_4$ has order $d$.\n\nThis is exactly the logical negation of the naive converse of Lagrange ('for every divisor $d$ of $|G|$ there is a subgroup of order $d$'), stated in a form that composes with the parent entry: Cauchy supplies the divisors for which the converse holds, and this witness supplies one for which it does not."
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-08-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-08-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "lagrange-theorem-oq-08-oq-01",
+  "title": "The Converse of Lagrange's Theorem Fails: A₄ Has No Subgroup of Order 6",
+  "slug": "lagrange-theorem-oq-08-oq-01",
+  "description": "The canonical counterexample to the naive converse of Lagrange's theorem, answering the parent entry's open question. Lagrange forces subgroup orders to divide |G|; its converse — that every divisor is realized — is false. The alternating group A₄ has order 12 and 6 ∣ 12, yet A₄ has no subgroup of order 6. The proof is the classical squares argument: a hypothetical order-6 subgroup H would have index 2, hence contain every square; each of the eight 3-cycles is a square (g = (g²)² since g³ = 1), forcing |H| ≥ 8 > 6. The eight 3-cycles are counted exactly via Mathlib's cycle-type cardinality (2!·C(4,3) = 8). Fully machine-verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ08OQ01.lean",
+    "tags": [
+      "group-theory",
+      "lagrange-theorem",
+      "alternating-group",
+      "A4",
+      "converse",
+      "counterexample",
+      "cycle-type",
+      "index-two"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 99,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (depends only on the foundational axioms propext, Classical.choice, Quot.sound). The two `decide` calls prove decidable numeric facts (2 ≤ 3, 3 ≤ card (Fin 4), and the arithmetic 2!·C(4,3) = 8) via the kernel, not the compiler — no native_decide, so Lean.ofReduceBool is not incurred.",
+    "originalContributions": [
+      "no_subgroup_card_six: the headline result — no subgroup of the alternating group A₄ = alternatingGroup (Fin 4) has order 6. This is the standard sharpness witness certifying that the converse to Lagrange genuinely fails for composite divisors, and it directly answers openQuestions[0] of the parent entry lagrange-theorem-oq-08.",
+      "converse_lagrange_fails: the packaged existential negation of the naive converse — there is a divisor d (namely 6) of |A₄| such that A₄ has no subgroup of order d.",
+      "card_A4: A₄ has order 12, extracted from Mathlib's alternatingGroup.card_of_card_eq_four via Nat.card (Fin 4) = 4.",
+      "card_threeCycles: there are exactly eight 3-cycles in A₄, computed from AlternatingGroup.card_of_cycleType_singleton as 2!·C(4,3) = 8 — the combinatorial input that makes the squares argument bite.",
+      "The squares argument as a reusable pattern: an index-two subgroup contains every square (sq_mem_of_index_two), every order-3 element g is the square (g²)² because g³ = 1, so all order-3 elements lie in any index-two subgroup — here used to overflow the putative order-6 subgroup."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The converse of Lagrange's theorem — 'if d divides |G| then G has a subgroup of order d' — is one of the first plausible-looking conjectures a group theory student meets, and one of the first to be refuted. The refutation is A₄, the group of even permutations of four objects: it has order 12, the divisor 6 divides 12, yet A₄ has no subgroup of order 6. This example dates to the 19th-century development of group theory and is a fixture of every abstract algebra course, precisely because it delimits Cauchy's theorem (1845) and the Sylow theorems (1872): the converse holds for prime divisors (Cauchy) and prime-power divisors (Sylow's first theorem), but fails at the first genuinely composite divisor. The A₄ example also foreshadows solvability theory — A₄ is the smallest group that is not the direct product dictated by its Sylow subgroups, and the failure here is the shadow of A₅ being simple.",
+    "problemStatement": "The parent entry (Cauchy's theorem) establishes the converse to Lagrange for prime divisors and explicitly asks, as its first open question, to formalize the sharpness witness: certify that the converse genuinely fails for composite divisors by proving that A₄ = Alternating (Fin 4) has order 12 but no subgroup of order 6.",
+    "proofStrategy": "**Order of A₄.** Mathlib's alternatingGroup.card_of_card_eq_four gives Nat.card (alternatingGroup α) = 12 whenever Nat.card α = 4; instantiating at α = Fin 4 (where Nat.card (Fin 4) = 4) yields card_A4.\n\n**Counting the 3-cycles.** The 3-cycles of A₄ are exactly the even permutations of cycle type {3}. Mathlib's AlternatingGroup.card_of_cycleType_singleton evaluates the number of even permutations of cycle type {n} to (n-1)!·C(card α, n) when n is odd; at n = 3, card α = 4 this is 2!·C(4,3) = 2·4 = 8, discharged by `decide`.\n\n**The squares argument.** Suppose for contradiction H ≤ A₄ has Nat.card H = 6. Since Nat.card H · H.index = Nat.card A₄ = 12, the index is H.index = 2. An index-two subgroup contains every square (sq_mem_of_index_two): for all g, g² ∈ H. Now take any 3-cycle g. It has orderOf g = 3 (the lcm of its cycle type {3}), so g³ = 1 and hence g = g⁴ = (g²)². Because g² ∈ H and H is closed under powers, g = (g²)² ∈ H. Thus H contains all eight 3-cycles, giving Nat.card H ≥ 8. Combined with Nat.card H = 6 this is a contradiction (8 ≤ 6 is false).\n\n**Packaging.** six_dvd_card_A4 records 6 ∣ 12, and converse_lagrange_fails bundles the witness d = 6 with no_subgroup_card_six into the existential negation of the naive converse.",
+    "keyInsights": [
+      "The heart of the failure is a counting collision: an index-two subgroup must swallow every square, and A₄ has eight square 3-cycles — more than the six elements an order-6 subgroup could hold. 'Too many squares' is the obstruction.",
+      "Every element of odd prime order is automatically a square (g = (g^{p+1})^{1/…}; concretely for order 3, g = (g²)²), so index-two subgroups can never avoid odd-order elements. This is why the parity obstruction targets exactly the composite divisor 6 = 2·3.",
+      "Mathlib's cycle-type cardinality formula turns a delicate combinatorial count (how many 3-cycles are there?) into a one-line decidable arithmetic fact, so the whole argument stays kernel-checkable with `decide` and never needs native_decide.",
+      "This composite-divisor failure is the exact complement of the parent's prime-divisor success: together they show 'prime' is the sharp boundary of the converse to Lagrange, with Sylow's theorem filling in the prime-power case in between."
+    ],
+    "prerequisites": [
+      "alternatingGroup.card_of_card_eq_four: |A₄| = 12 for a 4-element base type",
+      "AlternatingGroup.card_of_cycleType_singleton: the number of even permutations of a given single-cycle type",
+      "Subgroup.card_mul_index: |H| · [G:H] = |G|, used to derive index two",
+      "Subgroup.sq_mem_of_index_two: an index-two subgroup contains every square",
+      "Equiv.Perm.lcm_cycleType: the order of a permutation is the lcm of its cycle type",
+      "Cauchy's theorem (parent, lagrange-theorem-oq-08) and Lagrange's theorem (grandparent)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the counterexample (A₄ has order 12, 6 ∣ 12, no subgroup of order 6) and sketching the index-two squares argument. Imports the Klein-four/cycle-type infrastructure for the alternating group on four letters, the subgroup-index theory, and permutation cycle types."
+    },
+    {
+      "id": "card-a4",
+      "title": "The Order of A₄",
+      "startLine": 45,
+      "endLine": 47,
+      "summary": "card_A4: Nat.card (alternatingGroup (Fin 4)) = 12, obtained from Mathlib's alternatingGroup.card_of_card_eq_four instantiated at the 4-element type Fin 4."
+    },
+    {
+      "id": "count-threecycles",
+      "title": "Counting the Eight 3-Cycles",
+      "startLine": 49,
+      "endLine": 53,
+      "summary": "card_threeCycles: there are exactly eight even permutations of cycle type {3} in A₄, computed from AlternatingGroup.card_of_cycleType_singleton as (3-1)!·C(4,3) = 2·4 = 8 by `decide`."
+    },
+    {
+      "id": "no-order-six",
+      "title": "No Subgroup of Order 6",
+      "startLine": 55,
+      "endLine": 86,
+      "summary": "no_subgroup_card_six: the main theorem. A hypothetical order-6 subgroup H has index 2 (from |H|·[G:H]=12), hence contains every square. Each 3-cycle g satisfies g³=1, so g=(g²)² is a square and lies in H; the eight 3-cycles force Nat.card H ≥ 8, contradicting Nat.card H = 6."
+    },
+    {
+      "id": "packaging",
+      "title": "Packaging the Failure of the Converse",
+      "startLine": 88,
+      "endLine": 99,
+      "summary": "six_dvd_card_A4 records 6 ∣ |A₄|, and converse_lagrange_fails bundles it with no_subgroup_card_six into the existential statement that some divisor of |A₄| is not the order of any subgroup — the naive converse of Lagrange, refuted."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Presents A₄ as the standard counterexample to the converse of Lagrange's theorem, and the surrounding Sylow theory."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "note": "Discusses the failure of the converse of Lagrange and the structure of A₄, including its subgroup lattice."
+    },
+    {
+      "authors": [
+        "Gallian, J.A."
+      ],
+      "title": "Contemporary Abstract Algebra",
+      "year": "2016",
+      "venue": "9th ed., Cengage",
+      "note": "Textbook proof that A₄ has no subgroup of order 6 via the index-two/squares argument."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved the canonical sharpness witness for the converse of Lagrange's theorem: the alternating group A₄ has order 12 and 6 ∣ 12, yet A₄ has no subgroup of order 6. The argument counts the eight 3-cycles exactly (2!·C(4,3) = 8 via Mathlib's cycle-type cardinality) and shows a hypothetical order-6 subgroup, being of index two, would have to contain all of them (each 3-cycle is a square), overflowing its six slots. 99 lines, 5 theorems, 0 sorries, 0 axioms.",
+    "implications": "This closes the loop opened by the parent Cauchy entry: the converse to Lagrange holds exactly for prime divisors and fails at the first composite one, with A₄ the minimal witness. The reusable core — 'an index-two subgroup contains every odd-order element, because such elements are squares' — is a lightweight parity obstruction that recurs throughout finite group theory, and the combinatorial count of 3-cycles is the same input that drives the analysis of A₄'s Sylow structure and, one step further, the simplicity of A₅.",
+    "openQuestions": [
+      "Generalize the obstruction: characterize, for each n, which divisors of |Aₙ| = n!/2 fail to be subgroup orders, and identify the smallest such 'missing' divisor as a function of n.",
+      "Formalize the complementary positive fact for A₄: enumerate the subgroups that do exist (orders 1, 2, 3, 4, 12 — the trivial group, three ⟨transposition-pair⟩ order-2 groups, four order-3 cyclics, the Klein four V, and A₄ itself), confirming that 6 is the unique missing divisor."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-08",
+      "relationship": "extends",
+      "description": "Parent. Cauchy's theorem establishes the converse to Lagrange for prime divisors; this entry supplies the sharpness witness (A₄, divisor 6) demanded by that entry's first open question, showing the composite case fails."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Grandparent. Lagrange's theorem (subgroup orders divide |G|) is the divisibility statement whose converse is refuted here."
+    }
+  ],
+  "leanFile": {
+    "namespace": "LagrangeTheoremOQ08OQ01",
+    "lineCount": 99,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ08OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers **openQuestions[0]** of the parent entry `lagrange-theorem-oq-08` (Cauchy's theorem): certify that the *converse* of Lagrange's theorem genuinely fails for composite divisors. Proves the canonical textbook counterexample:

> The alternating group **A₄ = alternatingGroup (Fin 4)** has order 12 and **6 ∣ 12**, yet A₄ has **no subgroup of order 6**.

The parent proves the converse *holds* for prime divisors (Cauchy); this entry supplies the composite-divisor sharpness witness, pinning down "prime" as the exact boundary (with Sylow filling the prime-power case in between).

## Proof

The classical index-two / squares argument:
1. A hypothetical order-6 subgroup `H` has index `12/6 = 2` (`Subgroup.card_mul_index`).
2. An index-two subgroup contains every square (`sq_mem_of_index_two`).
3. Each 3-cycle `g` has order 3, so `g = g⁴ = (g²)²` is a square, hence lies in `H`.
4. There are exactly `2!·C(4,3) = 8` three-cycles (`AlternatingGroup.card_of_cycleType_singleton`), so `|H| ≥ 8 > 6` — contradiction.

## Verification

- **5 theorems, 0 definitions, 99 lines**
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms**, no `sorryAx`, no `native_decide`/`Lean.ofReduceBool` (the two `decide` calls are kernel decisions of concrete numeric facts).
- Compiled with `lake env lean` against the cached Mathlib toolchain (v4.26.0).

## Files
- `proofs/Proofs/LagrangeTheoremOQ08OQ01.lean`
- `src/data/proofs/lagrange-theorem-oq-08-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)