### PR TITLE
Enrich Bourgain-Roth bound entry: add 6 annotations (roth-theorem-oq-01)

### DIFF
--- a/src/data/proofs/roth-theorem-oq-01/annotations.json
+++ b/src/data/proofs/roth-theorem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "roth-oq01-ann-landscape",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 8, "endLine": 93 },
+    "type": "context",
+    "title": "The quantitative-Roth landscape",
+    "content": "The module docstring tabulates seventy years of improvements to the upper bound on r₃(N) = rothNumberNat N, the largest 3-AP-free subset of {1,…,N}. Roth (1953) gave N/log log N; Bourgain (1999) — the target of this entry — first achieved a genuine power-of-log saving; the chain continues through Bourgain (2008), Sanders (2011), Bloom (2016), Bloom–Sisask (2020, breaking the log barrier), and Kelley–Meka (2023, quasi-polynomial). The key architectural decision is recorded here: because each later bound decays strictly faster, a later bound implies an earlier one, so Bourgain need not be a separate axiom.",
+    "mathContext": "Roth $\\ll N/\\log\\log N$; Bourgain $\\ll N(\\log\\log N/\\log N)^{1/2}$; Bloom–Sisask $\\ll N/(\\log N)^{1+c}$; Kelley–Meka $\\ll N\\exp(-c(\\log N)^{\\beta})$.",
+    "significance": "context",
+    "relatedConcepts": ["Roth's theorem", "arithmetic progressions", "additive combinatorics", "density increment"],
+    "prerequisites": ["3-term arithmetic progressions", "asymptotic notation", "the Roth number rothNumberNat"]
+  },
+  {
+    "id": "roth-oq01-ann-main-derivation",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 99, "endLine": 175 },
+    "type": "insight",
+    "title": "Deriving Bourgain from Bloom–Sisask by rpow monotonicity",
+    "content": "The centerpiece: rothNumberNat_bourgain is proved, not assumed. From the Bloom–Sisask witness rothNumberNat N ≤ N/(log N)^(1+c) the goal reduces (after cancelling N > 0) to the analytic inequality N/(log N)^(1+c) ≤ (1/(B·E))·N·(LL/L)^(1/2), where L = log N, LL = log log N. The proof splits L^(1+c) = L^(1/2)·L^(1/2+c) via Real.rpow_add and (LL/L)^(1/2) = LL^(1/2)/L^(1/2) via Real.div_rpow, then reads the constant C = 1/(B·E) off the N = 3 endpoint (B = (log log 3)^(1/2), E = (log 3)^(1/2+c)). Both LL^(1/2) ≥ B and L^(1/2+c) ≥ E hold by base-monotonicity Real.rpow_le_rpow, and mul_le_mul closes it. The only analytic content is monotonicity of x ↦ x^t in the base — no additive-combinatorics machinery appears on this side.",
+    "mathContext": "$\\dfrac{N}{L^{1+c}} \\le \\dfrac{1}{BE}\\,N\\Big(\\tfrac{LL}{L}\\Big)^{1/2}$, using $L^{1+c}=L^{1/2}L^{1/2+c}$, $LL^{1/2}\\ge B$, $L^{1/2+c}\\ge E$; $C=1/(BE)$ from $N=3$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow monotonicity", "log-power comparison", "axiom elimination", "endpoint constant"],
+    "prerequisites": ["real rpow and its base-monotonicity", "logarithm inequalities", "existential witness extraction"]
+  },
+  {
+    "id": "roth-oq01-ann-const-api",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 177, "endLine": 193 },
+    "type": "definition",
+    "title": "A stable constant API over Exists.choose",
+    "content": "The existential ∃ C > 0 is inconvenient downstream, so bourgainConst := rothNumberNat_bourgain.choose fixes a canonical witness (noncomputable, since Exists.choose is), bourgainConst_pos records its positivity, and rothNumberNat_le_bourgain instantiates the bound at it. Consumers get a named constant and a clean inequality without ever touching Exists.choose themselves. This is a common Lean idiom for turning an existence theorem into a reusable quantitative API.",
+    "mathContext": "$\\text{rothNumberNat}\\,N \\le \\text{bourgainConst}\\cdot N\\cdot(\\log\\log N/\\log N)^{1/2}$ with $\\text{bourgainConst} > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Exists.choose", "noncomputable definitions", "API design", "choice of witness"],
+    "prerequisites": ["existential quantifiers in Lean", "classical choice"]
+  },
+  {
+    "id": "roth-oq01-ann-littleo",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 195, "endLine": 206 },
+    "type": "context",
+    "title": "Consistency with Mathlib's qualitative Roth",
+    "content": "Mathlib already proves the qualitative statement rothNumberNat N = o(N) unconditionally (rothNumberNat_isLittleO_id). This one-line re-export records that the Bourgain bound is a strengthening of it — the Bourgain rate O(N·(log log N/log N)^(1/2)) is an explicit o(N) — so OQ-01 consumers can pull the qualitative form from this namespace without re-deriving it. It is a sanity anchor: the assumed/derived quantitative bound is consistent with what Mathlib knows unconditionally.",
+    "mathContext": "$\\text{rothNumberNat}\\,N = o(N)$ as $N\\to\\infty$; the Bourgain rate refines the $o(N)$ to an explicit decay.",
+    "significance": "context",
+    "relatedConcepts": ["little-o asymptotics", "IsLittleO", "qualitative vs quantitative bounds"],
+    "prerequisites": ["asymptotic o-notation", "Mathlib's rothNumberNat_isLittleO_id"]
+  },
+  {
+    "id": "roth-oq01-ann-behrend",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 208, "endLine": 227 },
+    "type": "technique",
+    "title": "Sandwiching against Behrend's lower bound",
+    "content": "Behrend's 1946 construction gives an unconditional lower bound rothNumberNat N ≥ N·exp(-4√(log N)) (Mathlib's Behrend.roth_lower_bound). Chaining it transitively through rothNumberNat N with the Bourgain upper bound yields N·exp(-4√(log N)) ≤ bourgainConst·N·(log log N/log N)^(1/2). The proof is a pure le_trans — it does not verify the underlying analytic domination directly; the sandwich is automatic because both bounds hold simultaneously. It documents the (very wide) gap between the best known lower and upper bounds for r₃(N).",
+    "mathContext": "$N\\,e^{-4\\sqrt{\\log N}} \\le \\text{rothNumberNat}\\,N \\le \\text{bourgainConst}\\cdot N\\,(\\log\\log N/\\log N)^{1/2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Behrend construction", "lower bounds for r₃", "transitivity le_trans", "bound sandwiching"],
+    "prerequisites": ["Behrend's lower bound", "transitivity of ≤"]
+  },
+  {
+    "id": "roth-oq01-ann-min-bound",
+    "proofId": "roth-theorem-oq-01",
+    "range": { "startLine": 229, "endLine": 249 },
+    "type": "insight",
+    "title": "OQ-02 ⟹ OQ-01 recorded as a min of both bounds",
+    "content": "Since both the Bourgain and Bloom–Sisask upper bounds hold, rothNumberNat N is bounded by their minimum — a one-line le_min. For large N the min is the faster-decaying Bloom–Sisask term N/(log N)^(1+c), so this lattice statement is the formal record that OQ-02 implies OQ-01. Crucially it sidesteps comparing the two unknown constants (bourgainConst vs blasiConst): a full unconditional domination of one right-hand side by the other would require tracking those constants, but the min-form captures the implication without them.",
+    "mathContext": "$\\text{rothNumberNat}\\,N \\le \\min\\big(\\text{bourgainConst}\\cdot N(\\log\\log N/\\log N)^{1/2},\\; N/(\\log N)^{1+\\text{blasiConst}}\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["le_min", "bound lattice", "implication between bounds", "Bloom–Sisask 2020"],
+    "prerequisites": ["min of reals", "the imported OQ-02 bound"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `roth-theorem-oq-01` (Bourgain's 1999 quantitative Roth bound).

**Gap:** rich `meta.json` but **no `annotations.json`** — zero inline coverage.

**Added** `annotations.json` with **6 annotations** over the 264-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. The quantitative-Roth landscape (Roth 1953 → Kelley–Meka 2023)
2. The **axiom-elimination core**: deriving Bourgain from Bloom–Sisask by `Real.rpow` base-monotonicity (rpow_add / div_rpow split, constant read off N=3)
3. The `Exists.choose` constant API (`bourgainConst`, `_pos`, `_le_bourgain`)
4. Consistency with Mathlib's qualitative `rothNumberNat_isLittleO_id`
5. The Behrend lower-bound sandwich via `le_trans`
6. The min-of-both-bounds record that **OQ-02 ⟹ OQ-01**

**Validation:** `annotations:validate` reports 0 errors for this slug (all ranges land on declaration doc-comments, non-overlapping); `check-meta-size` within caps. No `meta.json` change.