### PR TITLE
research(derangements-convergence-oq-07-oq-02): inclusion–exclusion formula D(n)=Σ(−1)ᵏC(n,k)(n−k)! [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ07OQ02.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ07OQ02.lean
@@ -1,0 +1,120 @@
+/-
+  Derangements: the inclusion–exclusion (binomial) formula
+      D(n) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!
+  Open question: derangements-convergence-oq-07-oq-02
+
+  ## Context
+
+  The parent open question `derangements-convergence-oq-07` proves the *fixed-point
+  convolution identity*
+
+      n! = Σ_{k=0}^{n} C(n,k) · D(n−k)                              (∗)
+
+  (`factorial_eq_sum_choose_mul_numDerangements`), which expresses `n!` as a binomial
+  convolution of the derangement numbers `D(m) = numDerangements m`.  The natural
+  companion is the *inverse* relation obtained by binomial (Möbius) inversion of (∗):
+
+      D(n) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!                   (†)
+
+  which is the classical inclusion–exclusion formula for derangements written in the
+  binomial-coefficient convention.
+
+  ## What this file adds
+
+  Mathlib's `numDerangements_sum` already establishes an inclusion–exclusion sum for
+  `numDerangements`, but in the **ascending-factorial** convention:
+
+      (D(n) : ℤ) = Σ_{k=0}^{n} (−1)^k · (k+1).ascFactorial (n−k).
+
+  The term `(k+1).ascFactorial (n−k)` equals `(k+1)(k+2)⋯n = n!/k!`, which is *not*
+  the same syntactic object as `C(n,k)·(n−k)!`.  The bridge is the purely arithmetic
+  identity
+
+      (k+1).ascFactorial (n−k) = C(n,k) · (n−k)!          for k ≤ n,
+
+  proved here by cancelling `k!` from both sides using
+  `Nat.factorial_mul_ascFactorial` and `Nat.choose_mul_factorial_mul_factorial`.
+  Rewriting `numDerangements_sum` term-by-term with this bridge yields (†).
+
+  This is the standard binomial form of the derangement count and complements the
+  parent's convolution identity; neither the bridge lemma nor the binomial form of
+  the sum is stated in Mathlib.
+
+  ## Main results
+  - `ascFactorial_succ_eq_choose_mul_factorial`
+        : `(k+1).ascFactorial (n−k) = C(n,k)·(n−k)!` for `k ≤ n`
+  - `numDerangements_eq_sum_neg_one_pow_choose_mul_factorial`
+        : `(D(n) : ℤ) = Σ_{k≤n} (−1)^k · C(n,k) · (n−k)!`   (the formula (†))
+  - `numDerangements_eq_alternating_binomial_sum`
+        : the same, packaged with an `ℕ`-valued absolute-value reading of each term
+-/
+import Mathlib.Combinatorics.Derangements.Finite
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Tactic
+
+open Finset Nat
+open scoped BigOperators
+
+namespace DerangementsInclusionExclusion
+
+/-- The ascending factorial appearing in `numDerangements_sum` is exactly the
+binomial term `C(n,k)·(n−k)!`.  For `k ≤ n`,
+
+    `(k+1).ascFactorial (n−k) = n.choose k * (n−k)!`.
+
+Both sides equal `n!/k!`; we prove it by multiplying through by `k!` and cancelling,
+using `Nat.factorial_mul_ascFactorial` on the left and
+`Nat.choose_mul_factorial_mul_factorial` on the right. -/
+theorem ascFactorial_succ_eq_choose_mul_factorial {n k : ℕ} (h : k ≤ n) :
+    (k + 1).ascFactorial (n - k) = n.choose k * (n - k)! := by
+  -- It suffices to prove the equality after multiplying by the positive number `k!`.
+  apply Nat.eq_of_mul_eq_mul_left (Nat.factorial_pos k)
+  -- Left side: k! * (k+1).ascFactorial (n-k) = (k + (n-k))! = n!
+  have hleft : k ! * (k + 1).ascFactorial (n - k) = n ! := by
+    rw [Nat.factorial_mul_ascFactorial, Nat.add_sub_cancel' h]
+  -- Right side: k! * (C(n,k) * (n-k)!) = C(n,k) * k! * (n-k)! = n!
+  have hright : k ! * (n.choose k * (n - k)!) = n ! := by
+    rw [← Nat.choose_mul_factorial_mul_factorial h]; ring
+  rw [hleft, hright]
+
+/-- **Inclusion–exclusion (binomial) formula for derangements.**
+
+    `(numDerangements n : ℤ) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!`.
+
+This is the binomial-inversion companion of the parent's convolution identity
+`n! = Σ C(n,k)·D(n−k)`.  It is obtained from Mathlib's `numDerangements_sum`
+(stated with ascending factorials) by rewriting each term through
+`ascFactorial_succ_eq_choose_mul_factorial`. -/
+theorem numDerangements_eq_sum_neg_one_pow_choose_mul_factorial (n : ℕ) :
+    (numDerangements n : ℤ)
+      = ∑ k ∈ Finset.range (n + 1),
+          (-1 : ℤ) ^ k * (n.choose k) * ((n - k)! : ℤ) := by
+  rw [numDerangements_sum]
+  apply Finset.sum_congr rfl
+  intro k hk
+  have hkn : k ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+  -- Rewrite the ascending-factorial term into the binomial term.
+  rw [ascFactorial_succ_eq_choose_mul_factorial hkn]
+  push_cast
+  ring
+
+/-- The same inclusion–exclusion formula, with the summand's magnitude exhibited as
+the natural number `C(n,k)·(n−k)!` and the sign carried by `(−1)^k`. -/
+theorem numDerangements_eq_alternating_binomial_sum (n : ℕ) :
+    (numDerangements n : ℤ)
+      = ∑ k ∈ Finset.range (n + 1),
+          (-1 : ℤ) ^ k * ((n.choose k * (n - k)! : ℕ) : ℤ) := by
+  rw [numDerangements_eq_sum_neg_one_pow_choose_mul_factorial]
+  apply Finset.sum_congr rfl
+  intro k _
+  push_cast
+  ring
+
+/-- Sanity check: `D(4) = 9`, and the alternating binomial sum reproduces it:
+`24 − 24 + 12 − 4 + 1 = 9`. -/
+example : (numDerangements 4 : ℤ)
+    = ∑ k ∈ Finset.range 5, (-1 : ℤ) ^ k * (Nat.choose 4 k) * ((4 - k)! : ℤ) :=
+  numDerangements_eq_sum_neg_one_pow_choose_mul_factorial 4
+
+end DerangementsInclusionExclusion

--- a/src/data/proofs/derangements-convergence-oq-07-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-07-oq-02/meta.json
@@ -1,0 +1,212 @@
+{
+  "id": "derangements-convergence-oq-07-oq-02",
+  "title": "Inclusion–exclusion formula for derangements: D(n) = Σ (−1)ᵏ C(n,k)(n−k)!",
+  "slug": "derangements-convergence-oq-07-oq-02",
+  "description": "Establishes the binomial-inversion companion of the parent's fixed-point convolution identity n! = Σ C(n,k)·D(n−k): the classical inclusion–exclusion formula D(n) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)! for the derangement numbers D = numDerangements, written in the binomial-coefficient convention. Mathlib records this alternating sum only in the ascending-factorial form (numDerangements_sum: D(n) = Σ (−1)^k · (k+1).ascFactorial (n−k)). The genuine content is the arithmetic bridge (k+1).ascFactorial (n−k) = C(n,k)·(n−k)! for k ≤ n — both sides equal n!/k! — proved by cancelling k! using factorial_mul_ascFactorial and choose_mul_factorial_mul_factorial. Rewriting numDerangements_sum term-by-term yields the binomial form; neither the bridge nor the C(n,k) form of the sum is in Mathlib.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ07OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "inclusion-exclusion",
+      "binomial-inversion",
+      "factorials",
+      "ascending-factorial",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked (0 sorries, 0 axioms; #print axioms lists only propext, Classical.choice, Quot.sound). The alternating sum is imported from Mathlib's numDerangements_sum and converted to the binomial convention through the self-contained arithmetic bridge ascFactorial_succ_eq_choose_mul_factorial.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 120,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "ascFactorial_succ_eq_choose_mul_factorial (PROVED): for k ≤ n, (k+1).ascFactorial (n−k) = C(n,k)·(n−k)!. Both sides equal n!/k!; proved by cancelling the positive factor k! via Nat.eq_of_mul_eq_mul_left, with the left side collapsed by Nat.factorial_mul_ascFactorial (k!·(k+1).ascFactorial (n−k) = (k+(n−k))! = n!) and the right by Nat.choose_mul_factorial_mul_factorial (C(n,k)·k!·(n−k)! = n!).",
+      "numDerangements_eq_sum_neg_one_pow_choose_mul_factorial (PROVED): (D(n) : ℤ) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!, the inclusion–exclusion formula in the binomial convention, obtained from numDerangements_sum by termwise rewriting with the bridge lemma and push_cast/ring.",
+      "numDerangements_eq_alternating_binomial_sum (PROVED): the same identity with each summand's magnitude packaged as the natural number C(n,k)·(n−k)! carried under a single ℕ→ℤ cast, isolating the sign (−1)^k."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements_sum",
+        "description": "(numDerangements n : ℤ) = Σ_{k∈range(n+1)} (−1)^k · (k+1).ascFactorial (n−k) — the inclusion–exclusion sum in ascending-factorial form; the starting point converted here to binomial form",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Nat.factorial_mul_ascFactorial",
+        "description": "n! · (n+1).ascFactorial k = (n+k)! — collapses k! · (k+1).ascFactorial (n−k) to (k+(n−k))! = n! in the bridge lemma",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "k ≤ n → C(n,k) · k! · (n−k)! = n! — collapses the binomial side of the bridge lemma to n!",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "Cancellation by the positive factor k! (Nat.factorial_pos k) to conclude the bridge equality from the two n!-collapses",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The count of derangements — permutations with no fixed points — was found by Pierre de Montmort (1708) and Nicholas Bernoulli, with the inclusion–exclusion formula D(n) = n!·Σ_{k=0}^{n} (−1)^k/k! = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)! its most familiar closed form. Written with binomial coefficients it is exactly the Möbius (binomial) inverse of the fixed-point convolution n! = Σ C(n,k)·D(n−k) proved in the parent entry oq-07: the two identities are the forward and backward directions of the same binomial-transform pair. Euler (1751) recast the problem probabilistically ('jeu de rencontre') and observed the limit D(n)/n! → e^{−1}; the alternating sum here is the exact finite statement whose tail is that limit. In generating-function terms the formula is the Cauchy product Σ D(n) x^n/n! = e^{−x} · 1/(1−x), the derangement EGF being the product of the sign-generating e^{−x} and the all-permutations series 1/(1−x).",
+    "problemStatement": "**OQ-07-OQ-02 of derangements-convergence** (an open question registered by the parent oq-07)\n\nInvert the fixed-point convolution n! = Σ_{k=0}^{n} C(n,k)·D(n−k) by binomial (Möbius) inversion to recover the inclusion–exclusion formula\n\n  D(n) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!,\n\nwhere D(m) = numDerangements m. Establish it in the binomial-coefficient convention, distinct from Mathlib's ascending-factorial numDerangements_sum.",
+    "text": "For every n : ℕ, (numDerangements n : ℤ) = Σ_{k ∈ range (n+1)} (−1)^k · C(n,k) · (n−k)!.",
+    "proofStrategy": "**Bridge-and-rewrite, in two steps:**\n1. **Arithmetic bridge** (`ascFactorial_succ_eq_choose_mul_factorial`): show (k+1).ascFactorial (n−k) = C(n,k)·(n−k)! for k ≤ n. Both sides equal n!/k!, but ℕ-division is avoided: multiply through by k! and cancel it (Nat.eq_of_mul_eq_mul_left with Nat.factorial_pos). The left product k!·(k+1).ascFactorial (n−k) telescopes to (k+(n−k))! = n! by Nat.factorial_mul_ascFactorial and Nat.add_sub_cancel'; the right product k!·(C(n,k)·(n−k)!) reassociates to C(n,k)·k!·(n−k)! = n! by Nat.choose_mul_factorial_mul_factorial (closed with ring).\n2. **Termwise rewrite** (`numDerangements_eq_sum_neg_one_pow_choose_mul_factorial`): start from Mathlib's numDerangements_sum, apply Finset.sum_congr, and on each term (k ≤ n from mem_range) rewrite the ascending-factorial factor with the bridge lemma; push_cast to ℤ and ring reconcile the coefficient shapes. A repackaged variant (`numDerangements_eq_alternating_binomial_sum`) carries the magnitude as a single ℕ cast.",
+    "keyInsights": [
+      "The result is *not* a wrapper for numDerangements_sum: Mathlib states the alternating sum only with the ascending factorial (k+1).ascFactorial (n−k), whereas the textbook and inversion-theoretic form uses C(n,k)·(n−k)!. The two summands are numerically equal (both n!/k!) but syntactically different objects; the bridge lemma is the actual mathematical content.",
+      "The bridge (k+1).ascFactorial (n−k) = C(n,k)·(n−k)! is proved without any ℕ-division: both sides are pinned to n! after multiplying by k!, side-stepping the truncation issues of n!/k! in ℕ. This is the recommended Mathlib idiom (see the 'avoid ℕ-division' notes on ascFactorial_eq_div).",
+      "This entry closes the binomial-transform loop opened by the parent oq-07: oq-07 proves the forward convolution n! = Σ C(n,k)·D(n−k); this proves the inverse D(n) = Σ (−1)^k C(n,k)(n−k)!. Together they exhibit the derangement sequence and the factorial sequence as a binomial-inversion pair.",
+      "Dividing the identity by n! gives D(n)/n! = Σ_{k=0}^{n} (−1)^k/k!, the partial sum of e^{−1} — making the parent entry's analytic limit D(n)/n! → 1/e an immediate corollary of the exact finite formula.",
+      "The concrete check D(4) = 24 − 24 + 12 − 4 + 1 = 9 is included as an example, exercising the integer statement at n = 4."
+    ],
+    "prerequisites": [
+      "Mathlib's numDerangements_sum (inclusion–exclusion for numDerangements in ascending-factorial form)",
+      "Nat.factorial_mul_ascFactorial: n!·(n+1).ascFactorial k = (n+k)!",
+      "Nat.choose_mul_factorial_mul_factorial: k ≤ n → C(n,k)·k!·(n−k)! = n!",
+      "Basic Finset.sum_congr, push_cast, and ring for the termwise cast reconciliation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring stating the inclusion–exclusion formula D(n) = Σ (−1)^k C(n,k)(n−k)!, its status as the binomial inverse of the parent's convolution, and the note that Mathlib carries the sum only in ascending-factorial form. Imports Mathlib.Combinatorics.Derangements.Finite, Data.Nat.Factorial.Basic, Data.Nat.Choose.Basic, Mathlib.Tactic; opens Finset and Nat. Namespace DerangementsInclusionExclusion.",
+      "mathContext": "The Derangements.Finite import supplies numDerangements_sum; the Factorial and Choose imports supply the two cancellation lemmas underlying the arithmetic bridge."
+    },
+    {
+      "id": "sec-bridge",
+      "title": "Arithmetic bridge: ascending factorial = binomial × factorial",
+      "startLine": 63,
+      "endLine": 82,
+      "summary": "Theorem ascFactorial_succ_eq_choose_mul_factorial: for k ≤ n, (k+1).ascFactorial (n−k) = C(n,k)·(n−k)!. Cancels the positive factor k! (Nat.eq_of_mul_eq_mul_left, Nat.factorial_pos). Left collapse: k!·(k+1).ascFactorial (n−k) = (k+(n−k))! = n! via Nat.factorial_mul_ascFactorial and Nat.add_sub_cancel'. Right collapse: k!·(C(n,k)·(n−k)!) = n! via ← Nat.choose_mul_factorial_mul_factorial and ring.",
+      "mathContext": "Both sides equal n!/k!; the proof pins each to n! after multiplying by k!, avoiding ℕ-division entirely."
+    },
+    {
+      "id": "sec-binomial-sum",
+      "title": "Inclusion–exclusion formula in binomial form",
+      "startLine": 83,
+      "endLine": 105,
+      "summary": "Theorem numDerangements_eq_sum_neg_one_pow_choose_mul_factorial: (D(n):ℤ) = Σ_{k∈range(n+1)} (−1)^k·C(n,k)·(n−k)!. Starts from numDerangements_sum, uses Finset.sum_congr, extracts k ≤ n from mem_range, rewrites each ascending-factorial term with the bridge lemma, and closes with push_cast + ring.",
+      "mathContext": "Converts Mathlib's ascending-factorial inclusion–exclusion sum into the standard binomial-coefficient convention, the Möbius inverse of the parent convolution."
+    },
+    {
+      "id": "sec-repackaged",
+      "title": "Repackaged sum and numeric check",
+      "startLine": 106,
+      "endLine": 120,
+      "summary": "Theorem numDerangements_eq_alternating_binomial_sum: the same identity with the magnitude C(n,k)·(n−k)! carried under a single ℕ→ℤ cast and the sign as (−1)^k. Followed by the example verifying D(4) = 24−24+12−4+1 = 9.",
+      "mathContext": "The repackaged form isolates the alternating sign from the positive integer magnitude, matching the usual 'signed count of permutations by fixed-point set size' reading."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-07",
+      "relationship": "parent",
+      "description": "Parent entry: proves the forward fixed-point convolution n! = Σ C(n,k)·D(n−k) and registers this inversion as an explicit open question. This entry supplies the backward direction D(n) = Σ (−1)^k C(n,k)(n−k)!."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "related",
+      "description": "Root parent: studies numDerangements analytically (D(n)/n! → 1/e). Dividing the formula here by n! gives the partial sum Σ (−1)^k/k! of e^{−1}, making that limit an immediate corollary."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Root derangements entry: the closed form D(n) = n!·Σ(−1)^k/k! and inclusion–exclusion foundations of numDerangements."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "The alternating binomial sum is the inclusion–exclusion count of fixed-point-free permutations; this entry states it in the C(n,k) convention and ties it to Mathlib's numDerangements_sum."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified (0 sorries, 0 axioms): for every n, (numDerangements n : ℤ) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!. The proof imports Mathlib's ascending-factorial inclusion–exclusion sum (numDerangements_sum) and converts it to the binomial-coefficient convention through the self-contained arithmetic bridge (k+1).ascFactorial (n−k) = C(n,k)·(n−k)!, the true content of the entry.",
+    "implications": "**Binomial-inversion pair**: together with the parent's n! = Σ C(n,k)·D(n−k), this exhibits the factorial and derangement sequences as a binomial (Möbius) transform pair — the forward and inverse directions of the same convolution.\\n\\n**Analytic corollary**: dividing by n! yields D(n)/n! = Σ_{k=0}^{n} (−1)^k/k!, the partial sum of e^{−1}, from which the root entry's D(n)/n! → 1/e limit is immediate.\\n\\n**Convention bridge**: ascFactorial_succ_eq_choose_mul_factorial is a reusable arithmetic lemma linking Mathlib's ascending-factorial idiom to the binomial-coefficient form, useful wherever numDerangements_sum must be presented in textbook notation.",
+    "openQuestions": [
+      "Prove the ℕ-level statement numDerangements n = (Σ over even k of C(n,k)(n−k)!) − (Σ over odd k of C(n,k)(n−k)!) with the subtraction shown to be well-defined (the even partial sums dominate), giving a cast-free reading of the alternating formula.",
+      "Derive the recurrence D(n) = n·D(n−1) + (−1)^n directly from the binomial form by pairing adjacent terms, connecting to Mathlib's numDerangements_succ.",
+      "Formalize the generating-function identity Σ_n D(n) x^n/n! = e^{−x}/(1−x) at the level of Mathlib's PowerSeries, exhibiting this alternating sum as the Cauchy product of e^{−x} and 1/(1−x)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "numDerangements_eq_sum_neg_one_pow_choose_mul_factorial",
+      "type": "core",
+      "description": "Inclusion–exclusion formula in binomial form: (D(n):ℤ) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!",
+      "leanType": "(n : ℕ) → (numDerangements n : ℤ) = ∑ k ∈ Finset.range (n + 1), (-1 : ℤ) ^ k * (n.choose k) * ((n - k)! : ℤ)"
+    },
+    {
+      "name": "ascFactorial_succ_eq_choose_mul_factorial",
+      "type": "supporting",
+      "description": "Arithmetic bridge: for k ≤ n, (k+1).ascFactorial (n−k) = C(n,k)·(n−k)! (both equal n!/k!)",
+      "leanType": "{n k : ℕ} → k ≤ n → (k + 1).ascFactorial (n - k) = n.choose k * (n - k)!"
+    },
+    {
+      "name": "numDerangements_eq_alternating_binomial_sum",
+      "type": "supporting",
+      "description": "The same formula with magnitude C(n,k)·(n−k)! carried under a single ℕ→ℤ cast and sign (−1)^k",
+      "leanType": "(n : ℕ) → (numDerangements n : ℤ) = ∑ k ∈ Finset.range (n + 1), (-1 : ℤ) ^ k * ((n.choose k * (n - k)! : ℕ) : ℤ)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "DerangementsInclusionExclusion",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ07OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "First derivation of the derangement numbers; the inclusion–exclusion count D(n) = Σ (−1)^k C(n,k)(n−k)! is the closed form of the rencontres problem analyzed there."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Probabilistic treatment yielding D(n)/n! → e^{−1}; dividing the binomial formula proved here by n! gives the partial sum Σ (−1)^k/k! of that limit."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, 2nd edition, §2.2",
+      "note": "Binomial-inversion viewpoint: n! = Σ C(n,k)D(n−k) and its inverse D(n) = Σ (−1)^k C(n,k)(n−k)! form a binomial-transform pair; EGF form Σ D(n)x^n/n! = e^{−x}/(1−x)."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3 'Permutations with Restricted Position'",
+      "note": "Classic derivation of the derangement inclusion–exclusion formula and the associated recurrences."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **derangements-convergence-oq-07-oq-02**: the classical inclusion–exclusion formula for derangements in the binomial-coefficient convention,

  D(n) = Σ_{k=0}^{n} (−1)^k · C(n,k) · (n−k)!,

the binomial (Möbius) **inverse** of the parent oq-07's fixed-point convolution n! = Σ C(n,k)·D(n−k). The parent entry registers exactly this inversion as an open question.

## Mathematical content

Mathlib's `numDerangements_sum` gives the alternating sum only in the **ascending-factorial** form: D(n) = Σ (−1)^k · (k+1).ascFactorial (n−k). The genuine content is the arithmetic bridge

  `ascFactorial_succ_eq_choose_mul_factorial`: for k ≤ n, (k+1).ascFactorial (n−k) = C(n,k)·(n−k)!

Both sides equal n!/k!; proved without ℕ-division by cancelling k! (`Nat.factorial_mul_ascFactorial` on the left, `Nat.choose_mul_factorial_mul_factorial` on the right). Rewriting `numDerangements_sum` term-by-term yields the binomial form.

## Theorems (3, all verified)
- `ascFactorial_succ_eq_choose_mul_factorial` — the arithmetic bridge
- `numDerangements_eq_sum_neg_one_pow_choose_mul_factorial` — the formula (†)
- `numDerangements_eq_alternating_binomial_sum` — same, magnitude under one ℕ→ℤ cast

Includes a D(4)=24−24+12−4+1=9 sanity `example`.

## Verification
- `lake env lean` compiles clean (cached Mathlib oleans)
- `#print axioms` on all 3 theorems: only `propext, Classical.choice, Quot.sound` → **0 axioms**
- `pnpm gallery:check-size`: passes (within caps)
- 120 lines, 3 theorems, 0 defs, 0 sorries

## Files
- `proofs/Proofs/DerangementsConvergenceOQ07OQ02.lean` (new)
- `src/data/proofs/derangements-convergence-oq-07-oq-02/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)