### PR TITLE
Fix: add missing gallery entry for halting-problem-oq-01 (approximating the halting problem)

### DIFF
--- a/src/data/proofs/halting-problem-oq-01/meta.json
+++ b/src/data/proofs/halting-problem-oq-01/meta.json
@@ -1,0 +1,236 @@
+{
+  "id": "halting-problem-oq-01",
+  "title": "Approximating the Halting Problem: the Non-r.e. Decline Set",
+  "slug": "halting-problem-oq-01",
+  "description": "What happens to the halting problem when a decider is allowed to decline on hard inputs? A two-file study of gallery open question OQ-01, 'the computational complexity of approximating the halting problem'. A schematic diagonalization shows every sound partial approximator A : ℕ → ℕ → Option Bool must decline at its own self-locating diagonal point; the genuine computation-model reading, in Mathlib's Nat.Partrec.Code, then sharpens 'declines somewhere' to 'the decline set on the non-halting inputs is itself not recursively enumerable (hence infinite)'. The obstruction is the Σ⁰₁/Π⁰₁ asymmetry: the halting set K is r.e. but its complement is not.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-01",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HaltingArithmeticalHierarchy.lean",
+    "additionalFiles": [
+      "Proofs/HaltingApproximation.lean"
+    ],
+    "tags": [
+      "computability",
+      "halting-problem",
+      "arithmetical-hierarchy",
+      "recursively-enumerable",
+      "diagonalization",
+      "partial-recursive",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 406,
+    "mathlibDependencies": [
+      {
+        "theorem": "ComputablePred.halting_problem_re",
+        "description": "The parametrized halting set K = { c | (eval c n).Dom } is recursively enumerable (Σ⁰₁)",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "ComputablePred.halting_problem",
+        "description": "The halting set K is not computable — no total decider exists",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "ComputablePred.halting_problem_not_re",
+        "description": "The complement Kᶜ is not recursively enumerable — non-halting is not semi-decidable; this asymmetry forces every sound approximator's gap",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "Partrec.merge'",
+        "description": "Dovetailing two partial computable functions: the merged function halts iff either input halts, giving closure of REPred under union",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "Partrec.dom_re",
+        "description": "The domain of a partial computable function is recursively enumerable — the bridge from 'partial computable' to 'r.e. predicate'",
+        "module": "Mathlib.Computability.Halting"
+      },
+      {
+        "theorem": "Nat.Partrec.Code.eval",
+        "description": "The universal evaluator eval : Code → ℕ →. ℕ for the standard partial-recursive code model",
+        "module": "Mathlib.Computability.PartrecCode"
+      }
+    ],
+    "originalContributions": [
+      "Two-level answer to OQ-01: the honest schematic barrier (HaltingApproximation.lean, zero Mathlib dependencies) and the genuine computation-model sharpening (HaltingArithmeticalHierarchy.lean, on Nat.Partrec.Code)",
+      "Schematic core: sound_approx_declines_on_diagonal — every sound partial approximator A : ℕ → ℕ → Option Bool must decline (answer none) at its own self-locating diagonal point, recovering the classical no-oracle theorem as the always-commit special case (no_halting_oracle_from_approx)",
+      "The bridge from the schematic Option Bool approximator to a partial-computable Code →. Bool approximator, and the lemma re_confirmedFalse that the confirmed-non-halting set of any partial computable approximator is r.e.",
+      "REPred.or — closure of recursive enumerability under union, via Mathlib's Partrec.merge' dovetailing (reusable beyond this entry)",
+      "decline_set_on_nonhalting_not_re — the sharp form: the decline set restricted to the non-halting inputs is itself not recursively enumerable (hence infinite), strictly strengthening 'declines somewhere' (sound_approx_declines_nonempty) via the Kᶜ = {confirmed false} ∪ {non-halting ∧ declines} split"
+    ],
+    "openProblems": [
+      "OQ-01b: a density/measure ('generic-case complexity') statement for the set on which halting is approximable — not established here, and encoding-sensitive (see knowledge.md)",
+      "Sharpen the placement to full completeness (K is Σ⁰₁-complete, Kᶜ is Π⁰₁-complete) rather than only proper Σ⁰₁"
+    ],
+    "theoremCount": 16,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "Turing's 1936 halting theorem rules out a total decider for whether a program halts on a given input. A natural relaxation — studied under 'generic-case complexity' (Kapovich–Myasnikov–Schupp–Shpilrain, 2003) and in classical recursion theory via the arithmetical hierarchy of Kleene (1943) and Mostowski (1947) — allows a partial decider that may decline on hard inputs, and asks how large the unavoidable gap is. In the arithmetical hierarchy the halting set K is Σ⁰₁-complete (recursively enumerable but not computable) while its complement Kᶜ is Π⁰₁ and not recursively enumerable: halting is semi-decidable (you can confirm halting by running the program), but non-halting is not (no computable process can confirm looping on every looping input). This entry formalizes both the schematic barrier for arbitrary partial approximators and the genuine computation-model consequence in Lean 4 using Mathlib's Nat.Partrec.Code model.",
+    "problemStatement": "Model an approximator for halting as a partial Boolean function that may decline. Schematic version (HaltingApproximation.lean): A : ℕ → ℕ → Option Bool with none = decline; A is sound if every committed answer is correct. Computation-model version (HaltingArithmeticalHierarchy.lean): a partial computable f : Code →. Bool, with the parametrized halting set Halts n c := (eval c n).Dom. Question (OQ-01): how hard is it to approximate halting, and how large is the forced decline set? Results: every sound approximator must decline at a self-locating diagonal point, and — in the genuine model — the decline set on the non-halting inputs is not recursively enumerable, hence infinite.",
+    "proofStrategy": "Schematic file: diagonalize against the partial approximator. Build diagApprox A n that opposes A's guess for program n on itself (defaulting to true when A declines); then A n n can never equal some (diagApprox A n) (approx_not_commit_diagonal). A total approximator therefore errs at its diagonal point; a sound approximator, at any code implementing its diagonal behavior, is forced to answer none. Computation-model file: repackage Mathlib's three halting theorems as the Σ⁰₁/Π⁰₁ placement of K. Prove REPred is closed under union (REPred.or) by dovetailing with Partrec.merge'. Show the confirmed-non-halting set {c | false ∈ f c} of a partial computable f is r.e. (re_confirmedFalse, as the domain of an explicit partial computable function). If a sound f confirmed non-halting on all of Kᶜ, then Kᶜ would be r.e., contradicting halting_problem_not_re — so f declines on some genuinely non-halting input. Finally split Kᶜ = {confirmed false} ∪ {non-halting ∧ declines}: the first piece is r.e., so were the second r.e. the union Kᶜ would be r.e. (REPred.or), a contradiction — hence the decline set on Kᶜ is not r.e.",
+    "keyInsights": [
+      "Allowing a decider to decline does not dissolve the diagonal barrier: it relocates it. Every sound partial approximator has a self-locating input — the code of its own diagonal program — on which it must give up.",
+      "The schematic Option Bool model proves the barrier with zero Mathlib and no computation model, but it can only locate a single forced gap. The genuine content requires a real model of computation.",
+      "The whole obstruction is the asymmetry K ∈ Σ⁰₁, Kᶜ ∉ Σ⁰₁: halting is semi-decidable (confirm by running), non-halting is not (no computable process confirms looping everywhere it loops).",
+      "The decline set is not a single point and not merely nonempty — it is genuinely non-recursively-enumerable (hence infinite). This follows from closing REPred under union and splitting the non-halting codes into 'confirmed false' (r.e.) and 'declined' pieces.",
+      "REPred.or — recursive enumerability is closed under union — is the reusable engine, obtained from Mathlib's Partrec.merge' dovetailing (run both semi-deciders in parallel, accept if either accepts)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "hierarchy-placement",
+      "title": "Section 1: The Parametrized Halting Set and its Hierarchy Placement",
+      "startLine": 85,
+      "endLine": 107,
+      "summary": "Defines Halts n c := (eval c n).Dom and repackages Mathlib's three halting theorems: K is r.e. (halts_re, Σ⁰₁), not computable (halts_not_computable), and its complement is not r.e. (halts_compl_not_re). So K is properly Σ⁰₁ and the approximation gap lives in Π⁰₁ ∖ Σ⁰₁.",
+      "mathContext": "Halts n c := (eval c n).Dom is the halting set K at input n. halts_re = ComputablePred.halting_problem_re; halts_not_computable = ComputablePred.halting_problem; halts_compl_not_re = ComputablePred.halting_problem_not_re."
+    },
+    {
+      "id": "repred-union",
+      "title": "Section 2: Recursive Enumerability is Closed under Union",
+      "startLine": 109,
+      "endLine": 130,
+      "summary": "Proves REPred.or: if p and q are recursively enumerable then so is fun a => p a ∨ q a, by dovetailing the two semi-deciders via Mathlib's Partrec.merge' and reading off the domain (the union of the two domains).",
+      "mathContext": "The domain of the semi-decider Part.assert (r a) (fun _ => some ()) is exactly {a | r a}. Partrec.merge' yields a partrec k with (k a).Dom ↔ p a ∨ q a, and k.dom_re gives the r.e. predicate."
+    },
+    {
+      "id": "computable-approximators",
+      "title": "Section 3: Computable Approximators and the Confirmed-False Set",
+      "startLine": 131,
+      "endLine": 169,
+      "summary": "Defines a sound partial-computable approximator f : Code →. Bool (undefined = decline) and proves re_confirmedFalse: for partial computable f, the set {c | false ∈ f c} on which f confirms non-halting is r.e. — it is the domain of an explicit partial computable function built by bind/cond.",
+      "mathContext": "Sound n f := ∀ c b, b ∈ f c → (b = true ↔ Halts n c). The witness function c ↦ (f c).bind (fun b => cond b none (some ())) is partial computable, and its domain is exactly {c | false ∈ f c}."
+    },
+    {
+      "id": "non-re-decline-set",
+      "title": "Section 4: The Decline Set on Non-Halting Inputs is Not r.e.",
+      "startLine": 171,
+      "endLine": 255,
+      "summary": "No sound computable approximator confirms non-halting on all of Kᶜ (else Kᶜ would be r.e.), so every sound approximator declines on some genuinely non-halting input. The sharp form decline_set_on_nonhalting_not_re splits Kᶜ into the r.e. 'confirmed false' set and the decline set, and uses REPred.or to conclude the decline set is not r.e.; the nonempty statement is recovered as a corollary.",
+      "mathContext": "Kᶜ = {c | false ∈ f c} ∪ {c | ¬ Halts n c ∧ ¬ (f c).Dom}. First piece r.e. by re_confirmedFalse; if the second were r.e., REPred.or would make Kᶜ r.e., contradicting halts_compl_not_re."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "halting-problem",
+      "relationship": "extends",
+      "description": "Parent entry: undecidability of the halting problem (abstract diagonalization, no computation model). This entry answers its open question OQ-01 on approximating the halting problem, first schematically (HaltingApproximation imports the parent's definitions) and then in Mathlib's genuine Nat.Partrec.Code model."
+    },
+    {
+      "targetId": "halting-problem-oq-02",
+      "relationship": "related",
+      "description": "Sibling open-question entry: undecidability of the totality problem via Rice's theorem, also in Mathlib's Nat.Partrec.Code model."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry gives a complete, 0-sorry, 0-axiom two-file answer to the gallery open question on approximating the halting problem. The schematic file proves that every sound partial approximator must decline at its own self-locating diagonal point; the computation-model file, in Mathlib's Nat.Partrec.Code, sharpens this to the statement that the decline set on the non-halting inputs is not recursively enumerable, hence infinite. The engine is the Σ⁰₁/Π⁰₁ asymmetry between the halting set and its complement, together with closure of recursive enumerability under union.",
+    "implications": "Relaxing a halting decider to allow declining does not tame the halting problem: the gap where the decider must give up is not a single point but a genuinely non-r.e. (infinite) set of non-halting inputs. Formalizing this validates that Mathlib's computability stack (Nat.Partrec.Code, REPred, ComputablePred, Partrec.merge') is expressive enough for real recursion-theoretic arguments, and yields the reusable lemma REPred.or (recursive enumerability closed under union).",
+    "openQuestions": [
+      "OQ-01b: is there a density/measure ('generic-case complexity') statement quantifying the fraction of inputs on which halting is approximable? This is encoding-sensitive and not formalized here.",
+      "Can the placement be sharpened from proper Σ⁰₁ to Σ⁰₁-completeness (and Kᶜ to Π⁰₁-completeness) inside Mathlib?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Turing, A. M.",
+      "title": "On Computable Numbers, with an Application to the Entscheidungsproblem",
+      "year": 1936,
+      "journal": "Proceedings of the London Mathematical Society",
+      "volume": "42",
+      "pages": "230–265",
+      "note": "Original undecidability of the halting problem via diagonalization"
+    },
+    {
+      "authors": "Rogers, H.",
+      "title": "Theory of Recursive Functions and Effective Computability",
+      "year": 1967,
+      "publisher": "MIT Press",
+      "note": "§5.2–5.4 — r.e. sets, the halting problem, and the arithmetical hierarchy"
+    },
+    {
+      "authors": "Kapovich, I.; Myasnikov, A.; Schupp, P.; Shpilrain, V.",
+      "title": "Generic-case complexity, decision problems in group theory, and random walks",
+      "year": 2003,
+      "journal": "Journal of Algebra",
+      "volume": "264",
+      "pages": "665–694",
+      "note": "Framework for approximating undecidable problems by allowing declining on a small set of inputs (OQ-01b context)"
+    }
+  ],
+  "sorries": 0,
+  "parentId": "halting-problem",
+  "openQuestionId": "oq-01",
+  "theorems": [
+    {
+      "name": "sound_approx_declines_on_diagonal",
+      "statement": "Sound A B → diagApprox A n = B n n → A n n = none",
+      "status": "proved",
+      "description": "Schematic core (HaltingApproximation.lean): every sound partial approximator must decline at its own self-locating diagonal point"
+    },
+    {
+      "name": "total_approx_errs",
+      "statement": "Total A → ∃ v, A n n = some v ∧ v ≠ diagApprox A n",
+      "status": "proved",
+      "description": "A total (always-committing) approximator errs at its diagonal point — the approximation-theoretic form of 'no total halting decider'"
+    },
+    {
+      "name": "halts_re",
+      "statement": "REPred (Halts n)",
+      "status": "proved",
+      "description": "The parametrized halting set K is recursively enumerable (Σ⁰₁), via ComputablePred.halting_problem_re"
+    },
+    {
+      "name": "halts_compl_not_re",
+      "statement": "¬ REPred (fun c => ¬ Halts n c)",
+      "status": "proved",
+      "description": "The complement Kᶜ is not r.e. — the asymmetry that forces every sound approximator's gap"
+    },
+    {
+      "name": "REPred.or",
+      "statement": "REPred p → REPred q → REPred (fun a => p a ∨ q a)",
+      "status": "proved",
+      "description": "Recursive enumerability is closed under union, by dovetailing via Partrec.merge'"
+    },
+    {
+      "name": "re_confirmedFalse",
+      "statement": "Partrec f → REPred (fun c => false ∈ f c)",
+      "status": "proved",
+      "description": "The confirmed-non-halting set of a partial computable approximator is r.e."
+    },
+    {
+      "name": "no_sound_approx_confirms_all_nonhalting",
+      "statement": "Partrec f → Sound n f → ¬ ∀ c, ¬ Halts n c → false ∈ f c",
+      "status": "proved",
+      "description": "No sound computable approximator can confirm non-halting on all of Kᶜ (else Kᶜ would be r.e.)"
+    },
+    {
+      "name": "decline_set_on_nonhalting_not_re",
+      "statement": "Partrec f → Sound n f → ¬ REPred (fun c => ¬ Halts n c ∧ ¬ (f c).Dom)",
+      "status": "proved",
+      "description": "Sharp form: the decline set restricted to the non-halting inputs is itself not r.e., hence infinite"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Computability.Halting"
+    ],
+    "opens": [
+      "Nat.Partrec (Code)",
+      "Nat.Partrec.Code (eval)"
+    ],
+    "namespace": "HaltingArithmeticalHierarchy",
+    "lineCount": 255,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/HaltingArithmeticalHierarchy.lean"
+  }
+}


### PR DESCRIPTION
## Fix

Two merged, verified proofs answering gallery open question OQ-01 ("the computational complexity of approximating the halting problem") had **no `src/data/proofs/` directory**, so the entire OQ-01 result was invisible in the gallery.

- `Proofs/HaltingApproximation.lean` (#30822) — schematic diagonalization: every sound partial approximator `A : ℕ → ℕ → Option Bool` must decline at its own self-locating diagonal point (6 thm / 5 def / 151 L, 0 sorry, 0 axiom).
- `Proofs/HaltingArithmeticalHierarchy.lean` (#30851) — genuine computation-model reading in Mathlib's `Nat.Partrec.Code`: the decline set on the non-halting inputs is itself **not recursively enumerable** (hence infinite), via the Σ⁰₁/Π⁰₁ asymmetry and closure of `REPred` under union (10 thm / 2 def / 255 L, 0 sorry, 0 axiom).

This PR adds `src/data/proofs/halting-problem-oq-01/meta.json` — a multi-file entry (primary = `HaltingArithmeticalHierarchy`, `additionalFiles` = `HaltingApproximation`) modeled on the sibling `halting-problem-oq-02` entry.

## Evidence

**Before**: `git cat-file -e origin/main:src/data/proofs/halting-problem-oq-01/meta.json` → absent; no meta.json anywhere references either Lean file (`git grep` → 0 hits). Both `.lean` files merged with `[verified, 0-axiom]` tags.
**After**: gallery entry present; `gallery:check-size` clean; `annotations:build` runs without errors on the new entry (pre-existing errors in other entries only). Status `verified`, badge `verified`, axiomCount 0, sorries 0.

Discovered by the missing-gallery-gap orphan scan (merged `research(<slug>)` `.lean` with no gallery dir). No auditor issue — proactively surfaced.

---
Automated fix by lean-mechanic agent.