### PR TITLE
research(ramseys-theorem-oq-04-oq-03): exact 1-uniform hypergraph Ramsey number R₁(r,n)=r(n−1)+1 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RamseysTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/RamseysTheoremOQ04OQ03.lean
@@ -1,0 +1,153 @@
+/-
+Ramsey Theory — OQ-04-OQ-03: The exact 1-uniform (pigeonhole) hypergraph Ramsey number
+
+Source: open question of the ramseys-theorem gallery (hypergraph Ramsey, OQ-04)
+Parent: Proofs/RamseysTheoremOQ04.lean  (k-uniform hypergraph Ramsey)
+
+## Context
+
+The parent entry formalizes the k-uniform hypergraph Ramsey theorem. The base case
+k = 1 is the pigeonhole principle: a 1-uniform coloring is just an r-coloring of the
+vertices, and a "monochromatic set of size n" is a color class with at least n
+elements. The parent's `pigeonhole_ramsey` proves only that *some* N works. Its own
+open question 2 asks for the *best known bounds* on hypergraph Ramsey numbers for
+small k. This file settles the k = 1 case **exactly**:
+
+  R₁(r, n) = r·(n-1) + 1,
+
+with both halves proved:
+
+  * SUFFICIENCY — if `r·(n-1) < |V|` then every r-coloring of `V` has a color class of
+    size ≥ n (there is a monochromatic n-set);
+  * SHARPNESS — on a set of exactly `r·(n-1)` vertices there is an r-coloring in which
+    every color class has size ≤ n-1 (no monochromatic n-set), so the threshold cannot
+    be lowered.
+
+Everything is stated for an arbitrary finite vertex type `V` via `Fintype.card V`, so
+the two directions compose into the exact number. Self-contained (imports only
+Mathlib), axiom-free.
+
+## Results
+
+* `exists_large_color_class`   — sufficiency (generalized pigeonhole).
+* `ramsey1_of_card_lt`         — sufficiency phrased at the threshold `r·(n-1)+1`.
+* `sharp_coloring_card`        — the extremal coloring `Prod.fst` on `Fin r × Fin (n-1)`
+                                 has every color class of size exactly `n-1`.
+* `ramsey1_sharp`              — sharpness: `r·(n-1)` vertices are not enough.
+* `ramsey1_exact` bundles the two directions at the exact threshold.
+* `ramsey1_number` / `ramsey1_number_spec` — the exact Ramsey number and its
+  characterization.
+* `pigeonhole_two` — the classical "r+1 pigeons in r holes" as the `n = 2` case.
+
+References:
+- F. P. Ramsey, "On a problem of formal logic" (1930)
+- Parent entry `ramseys-theorem-oq-04` (hypergraph Ramsey theorem)
+-/
+
+import Mathlib
+
+open Finset
+
+namespace HypergraphRamseyOQ04OQ03
+
+variable {V : Type*} [Fintype V]
+
+/-- The color class of `color` under an r-coloring `c` of the vertices `V`: the set of
+vertices assigned that color. -/
+def colorClass {r : ℕ} (c : V → Fin r) (color : Fin r) : Finset V :=
+  Finset.univ.filter (fun v => c v = color)
+
+-- ============================================================================
+-- Sufficiency: a large vertex set forces a large color class
+-- ============================================================================
+
+/-- **Generalized pigeonhole / sufficiency.** If the number of vertices exceeds
+`r·(n-1)`, then any r-coloring has a color class of size at least `n`: a monochromatic
+set of size `n` exists. -/
+theorem exists_large_color_class {r n : ℕ} (hn : 1 ≤ n) (c : V → Fin r)
+    (h : r * (n - 1) < Fintype.card V) :
+    ∃ color : Fin r, n ≤ (colorClass c color).card := by
+  have hmaps : ∀ v ∈ (univ : Finset V), c v ∈ (univ : Finset (Fin r)) :=
+    fun v _ => mem_univ _
+  have hcard : (univ : Finset (Fin r)).card * (n - 1) < (univ : Finset V).card := by
+    simpa [Finset.card_univ, Fintype.card_fin] using h
+  obtain ⟨color, _, hcolor⟩ :=
+    Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to hmaps hcard
+  exact ⟨color, by simp only [colorClass]; omega⟩
+
+/-- **Sufficiency at the threshold.** If `V` has at least `r·(n-1)+1` vertices then every
+r-coloring admits a monochromatic set of size `n`. This is the "≥ R₁" half. -/
+theorem ramsey1_of_card_lt {r n : ℕ} (hn : 1 ≤ n) (c : V → Fin r)
+    (h : r * (n - 1) + 1 ≤ Fintype.card V) :
+    ∃ color : Fin r, n ≤ (colorClass c color).card :=
+  exists_large_color_class hn c (by omega)
+
+-- ============================================================================
+-- Sharpness: r·(n-1) vertices are not enough
+-- ============================================================================
+
+/-- On the extremal vertex set `Fin r × Fin (n-1)`, the projection coloring
+`Prod.fst` gives every color class size exactly `n-1`. -/
+theorem sharp_coloring_card (r n : ℕ) (color : Fin r) :
+    (colorClass (V := Fin r × Fin (n - 1)) Prod.fst color).card = n - 1 := by
+  have hset : colorClass (V := Fin r × Fin (n - 1)) Prod.fst color
+      = ({color} : Finset (Fin r)) ×ˢ (univ : Finset (Fin (n - 1))) := by
+    ext p
+    simp only [colorClass, Finset.mem_filter, Finset.mem_univ, true_and, and_true,
+      Finset.mem_product, Finset.mem_singleton]
+  rw [hset, Finset.card_product, Finset.card_singleton, one_mul, Finset.card_univ,
+    Fintype.card_fin]
+
+/-- **Sharpness.** There is a set of exactly `r·(n-1)` vertices with an r-coloring in
+which every color class has size ≤ `n-1`; hence it has no monochromatic set of size `n`.
+The threshold `r·(n-1)+1` therefore cannot be lowered. -/
+theorem ramsey1_sharp (r n : ℕ) :
+    ∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V) (c : V → Fin r),
+      Fintype.card V = r * (n - 1) ∧
+      ∀ color : Fin r, (colorClass c color).card ≤ n - 1 := by
+  refine ⟨Fin r × Fin (n - 1), inferInstance, inferInstance, Prod.fst, ?_, ?_⟩
+  · rw [Fintype.card_prod, Fintype.card_fin, Fintype.card_fin]
+  · intro color
+    rw [sharp_coloring_card]
+
+-- ============================================================================
+-- The exact Ramsey number
+-- ============================================================================
+
+/-- The exact 1-uniform (pigeonhole) Ramsey number: the least number of vertices that
+forces, under every r-coloring, a monochromatic set of size `n`. -/
+def ramsey1_number (r n : ℕ) : ℕ := r * (n - 1) + 1
+
+/-- **The two directions meet at the exact number.** With `N = ramsey1_number r n`
+vertices, sufficiency holds; and there is a coloring on `N - 1 = r·(n-1)` vertices with
+no monochromatic `n`-set. -/
+theorem ramsey1_exact {r n : ℕ} (hn : 1 ≤ n) :
+    (∀ (V : Type) [Fintype V] (c : V → Fin r),
+        r * (n - 1) + 1 ≤ Fintype.card V →
+        ∃ color : Fin r, n ≤ (colorClass c color).card)
+    ∧ (∃ (V : Type) (_ : Fintype V) (_ : DecidableEq V) (c : V → Fin r),
+        Fintype.card V = r * (n - 1) ∧
+        ∀ color : Fin r, (colorClass c color).card ≤ n - 1) := by
+  refine ⟨?_, ramsey1_sharp r n⟩
+  intro V _ c h
+  exact ramsey1_of_card_lt hn c h
+
+/-- Characterization of the Ramsey number: `ramsey1_number r n` vertices suffice to force
+a monochromatic `n`-set. -/
+theorem ramsey1_number_spec {r n : ℕ} (hn : 1 ≤ n) (c : V → Fin r)
+    (h : ramsey1_number r n ≤ Fintype.card V) :
+    ∃ color : Fin r, n ≤ (colorClass c color).card :=
+  ramsey1_of_card_lt hn c h
+
+-- ============================================================================
+-- Classical corollary
+-- ============================================================================
+
+/-- **Classical pigeonhole** as the `n = 2`, `R₁(r,2) = r+1` case: any `r`-coloring of a
+set with more than `r` elements has two vertices of the same color. -/
+theorem pigeonhole_two {r : ℕ} (c : V → Fin r) (h : r < Fintype.card V) :
+    ∃ color : Fin r, 2 ≤ (colorClass c color).card := by
+  have := exists_large_color_class (V := V) (r := r) (n := 2) (by norm_num) c (by simpa using h)
+  simpa using this
+
+end HypergraphRamseyOQ04OQ03

--- a/src/data/proofs/ramseys-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-03/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-ram-oq0403-header",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Settling the k=1 Hypergraph Ramsey Number Exactly",
+    "content": "The header situates this file as the base case of the parent's k-uniform hypergraph Ramsey theorem. A 1-uniform coloring is an ordinary vertex r-coloring, and a monochromatic n-set is a color class of size ≥ n. Where the parent proves only that some N works and asks for the best small-k bounds, this file gives the exact 1-uniform Ramsey number R₁(r,n) = r(n−1)+1 with both sufficiency and sharpness.",
+    "mathContext": "R₁(r,n) is the least |V| that forces, under every r-coloring, a color class of size ≥ n.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "hypergraph Ramsey",
+      "pigeonhole principle",
+      "exact Ramsey number",
+      "base case"
+    ],
+    "prerequisites": [
+      "Ramsey theory basics",
+      "Finset combinatorics"
+    ]
+  },
+  {
+    "id": "ann-ram-oq0403-defs",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 55,
+      "endLine": 59
+    },
+    "type": "definition",
+    "title": "colorClass: the k=1 Monochromatic Set",
+    "content": "colorClass c color := univ.filter (fun v => c v = color) collects the vertices a coloring c : V → Fin r assigns to a given color. This is the 1-uniform analog of the parent's monochromatic set: a monochromatic n-set exists precisely when some color class has at least n elements. No DecidableEq V is needed — equality is decided in Fin r.",
+    "mathContext": "colorClass(c,color) = {v ∈ V : c(v) = color}.",
+    "significance": "central",
+    "relatedConcepts": [
+      "color class",
+      "vertex coloring",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "Finset.filter",
+      "Fintype.univ"
+    ]
+  },
+  {
+    "id": "ann-ram-oq0403-suff",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 60,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Sufficiency via Generalized Pigeonhole",
+    "content": "exists_large_color_class: if r·(n−1) < |V| then some color class has ≥ n elements. The proof feeds Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to with s = univ : Finset V, t = univ : Finset (Fin r), f = c; the hypothesis becomes card t · (n−1) < card s, so some fiber (color class) exceeds n−1, i.e. reaches n (omega). ramsey1_of_card_lt restates this at the threshold r(n−1)+1 ≤ |V|, the '≥ R₁' half.",
+    "mathContext": "card(Fin r)·(n−1) < card V ⟹ ∃ color, n ≤ |colorClass(c,color)|.",
+    "significance": "central",
+    "relatedConcepts": [
+      "generalized pigeonhole",
+      "fiber cardinality",
+      "Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to"
+    ],
+    "prerequisites": [
+      "pigeonhole principle",
+      "Finset.card_univ",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "ann-ram-oq0403-sharp",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 85,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "Sharpness: the Extremal Balanced Coloring",
+    "content": "sharp_coloring_card shows the projection coloring Prod.fst on Fin r × Fin (n−1) gives every color class size exactly n−1: the class equals {color} ×ˢ univ, with cardinality 1·(n−1) via Finset.card_product. ramsey1_sharp packages this into a vertex set of exactly r(n−1) elements (Fintype.card_prod) carrying an r-coloring with no monochromatic n-set — so the threshold r(n−1)+1 cannot be lowered.",
+    "mathContext": "On Fin r × Fin (n−1): |colorClass(Prod.fst,color)| = n−1 and |Fin r × Fin (n−1)| = r(n−1).",
+    "significance": "central",
+    "relatedConcepts": [
+      "sharpness",
+      "extremal coloring",
+      "balanced partition",
+      "Finset.card_product"
+    ],
+    "prerequisites": [
+      "Finset product",
+      "Fintype.card_prod",
+      "Finset.card_singleton"
+    ]
+  },
+  {
+    "id": "ann-ram-oq0403-exact",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 113,
+      "endLine": 141
+    },
+    "type": "theorem",
+    "title": "The Two Directions Meet: R₁(r,n) = r(n−1)+1",
+    "content": "ramsey1_number r n := r(n−1)+1 names the exact Ramsey number; ramsey1_number_spec confirms that many vertices force a monochromatic n-set, and ramsey1_exact bundles sufficiency (any V with r(n−1)+1 ≤ |V| works) together with sharpness (an r(n−1)-vertex counterexample). Because sharpness realizes color classes of size exactly n−1, the two bounds coincide precisely at r(n−1)+1 — the number is determined, not merely bounded.",
+    "mathContext": "r(n−1)+1 vertices suffice; r(n−1) vertices do not — so R₁(r,n) = r(n−1)+1 exactly.",
+    "significance": "central",
+    "relatedConcepts": [
+      "exact Ramsey number",
+      "threshold",
+      "tight bound"
+    ],
+    "prerequisites": [
+      "sufficiency",
+      "sharpness"
+    ]
+  },
+  {
+    "id": "ann-ram-oq0403-classical",
+    "proofId": "ramseys-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 142,
+      "endLine": 153
+    },
+    "type": "theorem",
+    "title": "Classical Pigeonhole as the n=2 Case",
+    "content": "pigeonhole_two specializes the sufficiency result to n=2: R₁(r,2) = r+1, i.e. any r-coloring of more than r vertices assigns two of them the same color. This recovers the textbook pigeonhole principle as the smallest nontrivial instance of the exact formula.",
+    "mathContext": "r < |V| ⟹ ∃ color, 2 ≤ |colorClass(c,color)| — the r+1 pigeons in r holes principle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "n=2 case",
+      "classical corollary"
+    ],
+    "prerequisites": [
+      "exists_large_color_class"
+    ]
+  }
+]

--- a/src/data/proofs/ramseys-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-03/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "ramseys-theorem-oq-04-oq-03",
+  "title": "The Exact 1-Uniform (Pigeonhole) Hypergraph Ramsey Number R₁(r,n) = r(n−1)+1",
+  "slug": "ramseys-theorem-oq-04-oq-03",
+  "description": "The parent entry (hypergraph Ramsey, OQ-04) proves only that some N works in the k=1 base case, and its open question asks for the best known bounds on hypergraph Ramsey numbers for small k. This entry settles k=1 exactly: R₁(r,n) = r(n−1)+1. Both halves are proved — sufficiency (if r(n−1) < |V| then every r-coloring of V has a color class of size ≥ n, via generalized pigeonhole) and sharpness (on exactly r(n−1) vertices the projection coloring on Fin r × Fin (n−1) gives every color class size exactly n−1, so no monochromatic n-set exists). The classical 'r+1 pigeons in r holes' is recovered as the n=2 case. Self-contained, fully verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pigeonhole_principle",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamseysTheoremOQ04OQ03.lean",
+    "tags": [
+      "ramsey-theory",
+      "hypergraph-ramsey",
+      "pigeonhole",
+      "combinatorics",
+      "exact-bounds",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to",
+        "description": "If t.card * n < s.card and f maps s into t, some fiber has > n elements — the generalized pigeonhole used for sufficiency",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "Finset.card_product",
+        "description": "(s ×ˢ t).card = s.card * t.card — counts the extremal color class {color} ×ˢ univ",
+        "module": "Mathlib.Data.Finset.Prod"
+      },
+      {
+        "theorem": "Fintype.card_prod",
+        "description": "card (α × β) = card α * card β — the extremal vertex set Fin r × Fin (n−1) has r(n−1) vertices",
+        "module": "Mathlib.Data.Fintype.Prod"
+      }
+    ],
+    "originalContributions": [
+      "colorClass: the color class of a vertex-coloring c : V → Fin r as a Finset V, the k=1 analog of the parent's monochromatic set",
+      "exists_large_color_class: generalized pigeonhole / sufficiency — r(n−1) < |V| forces a color class of size ≥ n (a monochromatic n-set)",
+      "ramsey1_of_card_lt: sufficiency phrased at the threshold r(n−1)+1 (the ≥ R₁ half)",
+      "sharp_coloring_card: the projection coloring Prod.fst on Fin r × Fin (n−1) gives every color class size exactly n−1",
+      "ramsey1_sharp: sharpness — a set of exactly r(n−1) vertices admits an r-coloring with no monochromatic n-set, so the threshold cannot be lowered",
+      "ramsey1_number := r(n−1)+1 and ramsey1_number_spec: the exact 1-uniform Ramsey number and its forcing property",
+      "ramsey1_exact: bundles sufficiency and sharpness at the exact threshold, establishing R₁(r,n) = r(n−1)+1",
+      "pigeonhole_two: the classical r+1 → 2 pigeonhole as the n=2 case, R₁(r,2) = r+1"
+    ],
+    "axiomCount": 0,
+    "lineCount": 153,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via a clean `lake env lean` build and #print axioms on the main theorems. No native_decide.",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Ramsey's theorem (1930) has a hierarchy of uniformities: coloring k-element subsets of a vertex set. The parent gallery entry formalizes the general k-uniform hypergraph Ramsey theorem, with the hard k≥2 stepping-up encoded as an axiom and the base case k=1 identified as the pigeonhole principle. The pigeonhole principle is the oldest and most elementary Ramsey-type statement, and unlike higher uniformities its Ramsey number is known exactly. This entry makes that exact value precise and machine-checked, closing the k=1 case of the parent's open question on small-k bounds.",
+    "problemStatement": "For the 1-uniform hypergraph Ramsey problem — r-coloring the vertices and seeking a monochromatic set of size n — what is the exact Ramsey number R₁(r,n): the least |V| that forces such a set under every r-coloring? The parent entry proves only that some finite value works.",
+    "text": "The exact answer is R₁(r,n) = r(n−1)+1. Sufficiency: if a vertex set has more than r(n−1) elements, the generalized pigeonhole principle guarantees a color class of size at least n. Sharpness: the vertex set Fin r × Fin (n−1) has exactly r(n−1) elements, and the projection coloring c(a,b) = a assigns every color a color class of size exactly n−1, so no monochromatic n-set exists there. Together these pin the threshold to r(n−1)+1. The classical 'r+1 objects in r boxes ⟹ two share a box' is the case n=2.",
+    "proofStrategy": "Model an r-coloring of a finite vertex type V as c : V → Fin r, and the color class of a color as the Finset colorClass c color = univ.filter (c · = color). Sufficiency is Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to with s = univ : Finset V, t = univ : Finset (Fin r), f = c: the hypothesis r·(n−1) < |V| is exactly card t · (n−1) < card s, giving a fiber (color class) of size > n−1, i.e. ≥ n. Sharpness uses the concrete extremal type Fin r × Fin (n−1): the color class of Prod.fst at color equals {color} ×ˢ univ, whose cardinality is 1·(n−1) = n−1 by Finset.card_product; and Fintype.card_prod gives |Fin r × Fin (n−1)| = r(n−1).",
+    "keyInsights": [
+      "Modelling colorings as functions V → Fin r and color classes as filtered Finsets makes both directions ordinary finite counting; no probabilistic or asymptotic argument is needed.",
+      "Sufficiency is a single application of the generalized pigeonhole lemma once the cardinality hypothesis is put in the form card(Fin r) · (n−1) < card V.",
+      "Sharpness is witnessed by the most symmetric coloring: project the product Fin r × Fin (n−1) onto its color coordinate, so every color class is a perfect copy of Fin (n−1) with exactly n−1 elements.",
+      "Because sharpness is exact (n−1, not merely ≤ n−1 in a lossy way), the two directions meet precisely at r(n−1)+1 — the Ramsey number is determined, not just bounded.",
+      "The k=1 Ramsey number is polynomial (linear in n), in stark contrast to the tower-type growth of the k≥2 hypergraph Ramsey numbers the parent entry studies."
+    ],
+    "prerequisites": [
+      "Finsets, filters, products, and cardinalities",
+      "the generalized pigeonhole principle (Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to)",
+      "Fintype.card and its behavior on products and Fin",
+      "the hypergraph Ramsey framework of the parent entry (k=1 base case)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-defs",
+      "title": "Color Classes",
+      "startLine": 55,
+      "endLine": 58,
+      "summary": "colorClass c color := univ.filter (c · = color) is the set of vertices assigned a given color under an r-coloring c : V → Fin r — the 1-uniform analog of a monochromatic set. A monochromatic n-set is a color class of size ≥ n.",
+      "mathContext": "For c : V → Fin r, colorClass(c,color) = {v : c(v) = color}; a monochromatic n-set exists iff some class has ≥ n elements."
+    },
+    {
+      "id": "sec-suff",
+      "title": "Sufficiency (Generalized Pigeonhole)",
+      "startLine": 60,
+      "endLine": 84,
+      "summary": "exists_large_color_class: if r·(n−1) < |V| then some color class has ≥ n elements, via Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to. ramsey1_of_card_lt restates this at the threshold r(n−1)+1 ≤ |V| — the '≥ R₁' half.",
+      "mathContext": "r·(n−1) < |V| ⟹ ∃ color, n ≤ |colorClass(c,color)|."
+    },
+    {
+      "id": "sec-sharp",
+      "title": "Sharpness (the Extremal Coloring)",
+      "startLine": 85,
+      "endLine": 112,
+      "summary": "sharp_coloring_card: on Fin r × Fin (n−1) the projection coloring Prod.fst gives every color class size exactly n−1 (the class equals {color} ×ˢ univ). ramsey1_sharp packages this into an r(n−1)-vertex set with no monochromatic n-set, proving the threshold cannot be lowered.",
+      "mathContext": "|Fin r × Fin (n−1)| = r(n−1) and every Prod.fst-color class has exactly n−1 elements < n."
+    },
+    {
+      "id": "sec-exact",
+      "title": "The Exact Ramsey Number",
+      "startLine": 113,
+      "endLine": 141,
+      "summary": "ramsey1_number r n := r(n−1)+1, with ramsey1_number_spec (that many vertices force a monochromatic n-set) and ramsey1_exact bundling sufficiency and sharpness at the exact threshold — establishing R₁(r,n) = r(n−1)+1.",
+      "mathContext": "R₁(r,n) = r(n−1)+1: r(n−1)+1 vertices suffice, r(n−1) do not."
+    },
+    {
+      "id": "sec-classical",
+      "title": "Classical Pigeonhole Corollary",
+      "startLine": 142,
+      "endLine": 153,
+      "summary": "pigeonhole_two: the n=2 case R₁(r,2) = r+1 — any r-coloring of more than r vertices repeats a color — recovering the textbook pigeonhole principle.",
+      "mathContext": "r < |V| ⟹ ∃ color, 2 ≤ |colorClass(c,color)|."
+    }
+  ],
+  "conclusion": {
+    "summary": "The 1-uniform hypergraph Ramsey number is determined exactly: R₁(r,n) = r(n−1)+1. Both directions are proved and axiom-free — sufficiency by the generalized pigeonhole principle and sharpness by the projection coloring on Fin r × Fin (n−1), which realizes color classes of size exactly n−1. This upgrades the parent entry's existence-only pigeonhole_ramsey to an exact value and settles the k=1 case of its open question on small-k bounds.",
+    "implications": "The k=1 case is the one uniformity where the hypergraph Ramsey number is elementary and exact (linear in n). It serves as the base case and sanity check for the whole hierarchy the parent studies, and its sharpness construction (a balanced coloring) is the prototype for the lower-bound colorings that, at higher uniformities, require the far more intricate stepping-up lemma (sibling entry OQ-04-OQ-01). The classical pigeonhole principle drops out as the n=2 instance.",
+    "openQuestions": [
+      "Formalize the exact 2-color, 2-uniform diagonal values R(3,3)=6 and R(4,4)=18 to complement this exact k=1 result with exact small k=2 values.",
+      "State and prove the exact asymmetric 1-uniform number R₁(n₁,…,n_r) = (Σ(nᵢ−1))+1 (unequal target sizes), generalizing the symmetric r(n−1)+1 proved here."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "HypergraphRamseyOQ04OQ03",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/RamseysTheoremOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "ramseys-theorem-oq-04",
+      "relationship": "specializes",
+      "description": "Parent: k-uniform hypergraph Ramsey. This entry settles the k=1 base case exactly, upgrading the parent's existence-only pigeonhole_ramsey to R₁(r,n) = r(n−1)+1."
+    },
+    {
+      "targetId": "ramseys-theorem-oq-04-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling under OQ-04: the δ-function engine of the stepping-up lemma (hypergraph Ramsey lower bounds for k≥2). This entry treats the exact k=1 lower and upper bounds instead."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "ancestor",
+      "description": "The classical 2-uniform Ramsey theorem; the pigeonhole principle formalized here is its 1-uniform base case."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **ramseys-theorem-oq-04-oq-03**, a follow-up to the hypergraph Ramsey entry (OQ-04). The parent formalizes the k-uniform hypergraph Ramsey theorem but proves only that *some* N works in the k=1 base case, and its open question 2 asks for the best known bounds on hypergraph Ramsey numbers for small k. This entry **settles k=1 exactly**:

> **R₁(r,n) = r(n−1)+1**

with *both* directions proved.

## Results (7 theorems, 2 defs, 153 lines, 0 axioms)

| Name | Statement |
|---|---|
| `colorClass` | color class of `c : V → Fin r` as a `Finset V` (the k=1 monochromatic set) |
| `exists_large_color_class` | **sufficiency:** `r(n−1) < |V|` ⟹ some color class has ≥ n elements (generalized pigeonhole) |
| `ramsey1_of_card_lt` | sufficiency at the threshold `r(n−1)+1 ≤ |V|` |
| `sharp_coloring_card` | on `Fin r × Fin (n−1)`, `Prod.fst` gives every color class size **exactly** n−1 |
| `ramsey1_sharp` | **sharpness:** `r(n−1)` vertices admit an r-coloring with no monochromatic n-set |
| `ramsey1_number` / `ramsey1_number_spec` | `R₁(r,n) := r(n−1)+1` and its forcing property |
| `ramsey1_exact` | bundles both directions at the exact threshold |
| `pigeonhole_two` | classical `r+1` pigeonhole as the `n=2` case, `R₁(r,2)=r+1` |

Sufficiency is one application of `Finset.exists_lt_card_fiber_of_mul_lt_card_of_maps_to`; sharpness is the balanced projection coloring on `Fin r × Fin (n−1)`, whose color classes are exact copies of `Fin (n−1)`. Because sharpness is exact (n−1, not lossy), the two bounds meet precisely at `r(n−1)+1`.

This upgrades the parent's existence-only `pigeonhole_ramsey` to an exact value, and is distinct from sibling **OQ-04-OQ-01** (the stepping-up δ-function for k≥2 *lower* bounds).

## Verification

- Self-contained: imports only `Mathlib`, stated for an arbitrary `[Fintype V]`.
- **0 axioms**: `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- 0 sorries, no `native_decide`.
- Verified with `lake env lean` against Mathlib 4.26.0.

Includes gallery `meta.json` (status `verified`, badge `verified`) and 6 annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)