### PR TITLE
research(angle-trisection-oq-01-oq-02): arithmetic Gauss–Wantzel criterion [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ01OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionOQ01OQ02.lean
@@ -1,0 +1,172 @@
+/-
+  Angle Trisection, Open Question 01 → OQ 02:
+  The arithmetic (Wantzel) criterion behind the Gauss–Wantzel theorem.
+
+  The Gauss–Wantzel theorem states that a regular n-gon is constructible with
+  compass and straightedge iff n is the product of a power of 2 and distinct
+  Fermat primes. The geometric ("constructible") half of that equivalence is not
+  yet in Mathlib. Its **arithmetic engine**, however — the classification of
+  those n for which the field degree [ℚ(ζₙ):ℚ] = φ(n) is a power of two — is a
+  self-contained number-theoretic statement, and that is what we formalize here,
+  with 0 axioms.
+
+  Main theorem (`totient_isTwoPow_iff`): for n ≥ 1,
+
+      φ(n) is a power of 2
+        ↔  every prime p ∣ n is either 2, or a Fermat prime occurring to the
+           first power.
+
+  Since a regular n-gon is constructible exactly when φ(n) is a power of two,
+  this is precisely the "n = 2ᵃ · (product of distinct Fermat primes)" clause of
+  Gauss–Wantzel, phrased directly on the prime factorization.
+
+  Ingredients:
+    • `IsFermatPrime p := p.Prime ∧ ∃ m, p = 2^(2^m)+1`;
+    • the local fact that for an odd prime p, `φ(p) = p - 1` is a power of two iff
+      p is a Fermat prime (`totient_odd_prime_isTwoPow_iff`), which uses Mathlib's
+      `Nat.pow_of_pow_add_prime` (a prime of the form 2ˢ+1 forces s to be a power
+      of two);
+    • Euler's product `φ(n) = ∏ p^{eₚ-1}(p-1)` and the fact that a positive
+      natural is a power of two iff its only prime factor is 2.
+
+  No axioms; fully machine-checked against Mathlib.
+
+  Parent: angle-trisection-oq-01 (constructibility / Galois-theoretic obstructions).
+  Reference: C. F. Gauss, Disquisitiones Arithmeticae (1801); P. Wantzel (1837).
+-/
+
+import Mathlib
+
+open Nat Finset
+open scoped Classical
+
+set_option linter.unusedSectionVars false
+
+namespace AngleTrisectionOQ01OQ02
+
+/-- A **Fermat prime**: a prime of the form `2^(2^m) + 1 = fermatNumber m`. -/
+def IsFermatPrime (p : ℕ) : Prop := p.Prime ∧ ∃ m : ℕ, p = Nat.fermatNumber m
+
+/-- A positive natural number is a power of two iff its only prime factor is 2. -/
+lemma isTwoPow_iff {m : ℕ} (hm : m ≠ 0) :
+    (∃ k, m = 2 ^ k) ↔ ∀ q, q.Prime → q ∣ m → q = 2 := by
+  constructor
+  · rintro ⟨k, rfl⟩ q hq hqd
+    exact (Nat.prime_dvd_prime_iff_eq hq Nat.prime_two).mp (hq.dvd_of_dvd_pow hqd)
+  · intro h
+    exact ⟨_, Nat.eq_prime_pow_of_unique_prime_dvd hm (fun {q} hq hqd => h q hq hqd)⟩
+
+/-- A Fermat prime is odd (indeed `≥ 3`). -/
+lemma IsFermatPrime.ne_two {p : ℕ} (hp : IsFermatPrime p) : p ≠ 2 := by
+  obtain ⟨_, m, rfl⟩ := hp
+  have := Nat.two_lt_fermatNumber m
+  omega
+
+/-- For a Fermat prime `p = 2^(2^m)+1`, the totient `φ(p) = p - 1 = 2^(2^m)` is a
+    power of two. -/
+lemma IsFermatPrime.totient_isTwoPow {p : ℕ} (hp : IsFermatPrime p) :
+    ∃ k, Nat.totient p = 2 ^ k := by
+  obtain ⟨hpp, m, rfl⟩ := hp
+  refine ⟨2 ^ m, ?_⟩
+  rw [Nat.totient_prime hpp, Nat.fermatNumber]
+  simp
+
+/-- **Local criterion.** For an odd prime `p`, `φ(p)` is a power of two iff `p` is
+    a Fermat prime. -/
+lemma totient_odd_prime_isTwoPow_iff {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) :
+    (∃ k, Nat.totient p = 2 ^ k) ↔ IsFermatPrime p := by
+  constructor
+  · rintro ⟨k, hk⟩
+    rw [Nat.totient_prime hp] at hk
+    have hp3 : 3 ≤ p := by
+      rcases hp.eq_two_or_odd' with h | h
+      · exact absurd h hp2
+      · have := hp.two_le; omega
+    -- p = 2^k + 1 with k ≥ 1
+    have hpeq : p = 2 ^ k + 1 := by omega
+    have hk0 : k ≠ 0 := by
+      rintro rfl; simp at hk; omega
+    have hPrime : (2 ^ k + 1).Prime := hpeq ▸ hp
+    obtain ⟨m, hm⟩ := Nat.pow_of_pow_add_prime (a := 2) one_lt_two hk0 hPrime
+    exact ⟨hp, m, by rw [hpeq, hm, Nat.fermatNumber]⟩
+  · intro hf; exact hf.totient_isTwoPow
+
+/-- Euler's product for the totient over the prime factors of `n`. -/
+lemma totient_eq_prod_primeFactors {n : ℕ} (hn : n ≠ 0) :
+    Nat.totient n = ∏ p ∈ n.primeFactors, p ^ (n.factorization p - 1) * (p - 1) := by
+  rw [Nat.totient_eq_prod_factorization hn, Finsupp.prod, Nat.support_factorization]
+
+/-- **The arithmetic Gauss–Wantzel criterion.** For `n ≥ 1`, the totient `φ(n)`
+    is a power of two iff every prime factor of `n` is either `2` or a Fermat
+    prime dividing `n` exactly once. Equivalently, `n = 2ᵃ · (product of distinct
+    Fermat primes)`. -/
+theorem totient_isTwoPow_iff {n : ℕ} (hn : n ≠ 0) :
+    (∃ k, Nat.totient n = 2 ^ k) ↔
+      ∀ p ∈ n.primeFactors, p = 2 ∨ (IsFermatPrime p ∧ n.factorization p = 1) := by
+  have hφ : Nat.totient n ≠ 0 := (Nat.totient_pos.mpr (Nat.pos_of_ne_zero hn)).ne'
+  have hprod := totient_eq_prod_primeFactors hn
+  rw [isTwoPow_iff hφ, hprod]
+  constructor
+  · -- φ n is a power of two ⇒ the factorization condition
+    intro hq p hp
+    by_cases hp2 : p = 2
+    · exact Or.inl hp2
+    refine Or.inr ?_
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    -- the p-factor divides the product
+    have hdvd : p ^ (n.factorization p - 1) * (p - 1)
+        ∣ ∏ q ∈ n.primeFactors, q ^ (n.factorization q - 1) * (q - 1) :=
+      Finset.dvd_prod_of_mem _ hp
+    -- multiplicity is 1: otherwise p ∣ product ⇒ p = 2
+    have hfp1 : n.factorization p = 1 := by
+      have hpos : 0 < n.factorization p :=
+        hpp.factorization_pos_of_dvd hn (Nat.dvd_of_mem_primeFactors hp)
+      by_contra hne
+      have : p ∣ p ^ (n.factorization p - 1) * (p - 1) :=
+        Dvd.dvd.mul_right (dvd_pow_self p (by omega)) _
+      exact hp2 (hq p hpp (this.trans hdvd))
+    refine ⟨?_, hfp1⟩
+    -- p - 1 is a power of two, hence p is a Fermat prime
+    apply (totient_odd_prime_isTwoPow_iff hpp hp2).mp
+    rw [Nat.totient_prime hpp, isTwoPow_iff (show p - 1 ≠ 0 by have := hpp.two_le; omega)]
+    intro q hqp hqd
+    refine hq q hqp (dvd_trans ?_ hdvd)
+    calc q ∣ p - 1 := hqd
+      _ ∣ p ^ (n.factorization p - 1) * (p - 1) := dvd_mul_left _ _
+  · -- the factorization condition ⇒ φ n is a power of two
+    intro hcond q hqp hqd
+    -- q divides the product, so it divides some p-factor
+    rw [Prime.dvd_finset_prod_iff hqp.prime] at hqd
+    obtain ⟨p, hp, hpdvd⟩ := hqd
+    rcases hcond p hp with hp2 | ⟨hf, hfp1⟩
+    · -- p = 2: factor is 2^(e-1)
+      subst hp2
+      have : q ∣ 2 ^ (n.factorization 2 - 1) := by simpa using hpdvd
+      exact (Nat.prime_dvd_prime_iff_eq hqp Nat.prime_two).mp (hqp.dvd_of_dvd_pow this)
+    · -- p a Fermat prime with multiplicity 1: factor is p - 1 = 2^(2^m)
+      obtain ⟨hpp, m, rfl⟩ := hf
+      rw [hfp1] at hpdvd
+      have hfac : Nat.fermatNumber m ^ (1 - 1) * (Nat.fermatNumber m - 1)
+          = 2 ^ (2 ^ m) := by rw [Nat.fermatNumber]; simp
+      rw [hfac] at hpdvd
+      exact (Nat.prime_dvd_prime_iff_eq hqp Nat.prime_two).mp (hqp.dvd_of_dvd_pow hpdvd)
+
+/-- The main #1003-style consequence phrased for a **prime** `n = p`: a regular
+    `p`-gon has `φ(p) = p-1` a power of two (the constructibility criterion) iff
+    `p` is a Fermat prime. -/
+theorem prime_totient_isTwoPow_iff {p : ℕ} (hp : p.Prime) :
+    (∃ k, Nat.totient p = 2 ^ k) ↔ (p = 2 ∨ IsFermatPrime p) := by
+  by_cases hp2 : p = 2
+  · subst hp2
+    rw [Nat.totient_prime Nat.prime_two]
+    constructor
+    · intro _; exact Or.inl rfl
+    · intro _; exact ⟨0, rfl⟩
+  · rw [totient_odd_prime_isTwoPow_iff hp hp2]
+    constructor
+    · exact fun h => Or.inr h
+    · rintro (h | h)
+      · exact absurd h hp2
+      · exact h
+
+end AngleTrisectionOQ01OQ02

--- a/src/data/proofs/angle-trisection-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-02/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "angle-trisection-oq-01-oq-02",
+  "title": "The Arithmetic Gauss–Wantzel Criterion (Constructible Regular Polygons)",
+  "slug": "angle-trisection-oq-01-oq-02",
+  "description": "Formalizes the number-theoretic engine of the Gauss–Wantzel theorem on regular-polygon constructibility. A regular n-gon is constructible with compass and straightedge exactly when φ(n) = [ℚ(ζₙ):ℚ] is a power of two; this entry proves the arithmetic classification of those n: for n ≥ 1, φ(n) is a power of two iff every prime factor of n is either 2 or a Fermat prime occurring to the first power — equivalently n = 2ᵃ · (product of distinct Fermat primes). The local heart is that for an odd prime p, φ(p) = p − 1 is a power of two iff p is a Fermat prime (2^(2^m)+1), using Mathlib's Nat.pow_of_pow_add_prime (a prime 2ˢ+1 forces s to be a power of two). The global statement is assembled from Euler's product φ(n) = ∏ p^(eₚ−1)(p−1) and the fact that a positive natural is a power of two iff its only prime factor is 2. Fully machine-checked with 0 axioms.",
+  "references": [
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": 1801,
+      "note": "Section VII: the constructibility of the regular 17-gon and the sufficiency direction — n a product of a power of 2 and distinct Fermat primes implies constructibility."
+    },
+    {
+      "authors": "Pierre Wantzel",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas (J. Math. Pures Appl. 2)",
+      "year": 1837,
+      "note": "Establishes the necessity direction, completing the iff: constructibility forces φ(n) to be a power of two."
+    },
+    {
+      "authors": "David A. Cox",
+      "title": "Galois Theory (2nd ed.)",
+      "year": 2012,
+      "note": "Wiley. Constructible numbers, the degree criterion [ℚ(ζₙ):ℚ] = φ(n), and the Gauss–Wantzel classification via Fermat primes."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.fermatNumber, Nat.pow_of_pow_add_prime, totient_eq_prod_factorization, eq_prime_pow_of_unique_prime_dvd",
+      "year": 2024,
+      "note": "Fermat numbers, the a^n+1 prime ⇒ n a power of two lemma, Euler's totient product, and the prime-power factorization tools used throughout."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "galois-theory",
+      "constructibility",
+      "gauss-wantzel",
+      "fermat-prime",
+      "totient",
+      "cyclotomic",
+      "regular-polygon"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib. All results are over ℕ and fully machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound. Scope note: this entry formalizes the ARITHMETIC half of Gauss–Wantzel (the classification of n with φ(n) a power of two). The GEOMETRIC equivalence 'regular n-gon constructible ⟺ φ(n) a power of two' is not formalized here (compass-and-straightedge constructibility is not yet in Mathlib); it is cited as the bridge to the geometric statement.",
+    "lineCount": 172,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "originalContributions": [
+      "totient_isTwoPow_iff: for n ≥ 1, φ(n) is a power of two iff every prime factor of n is 2 or a Fermat prime of multiplicity 1 — the arithmetic Gauss–Wantzel criterion",
+      "totient_odd_prime_isTwoPow_iff: local criterion — for an odd prime p, φ(p) = p − 1 is a power of two iff p is a Fermat prime",
+      "prime_totient_isTwoPow_iff: prime specialization — φ(p) is a power of two iff p = 2 or p is a Fermat prime (constructibility of the regular p-gon)",
+      "IsFermatPrime: a reusable predicate for primes of the form 2^(2^m)+1 = fermatNumber m, with IsFermatPrime.ne_two and IsFermatPrime.totient_isTwoPow",
+      "isTwoPow_iff: a positive natural is a power of two iff its only prime factor is 2 (via Nat.eq_prime_pow_of_unique_prime_dvd)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1796 the 19-year-old Gauss showed that the regular 17-gon is constructible, and in the Disquisitiones Arithmeticae (1801) he proved that a regular n-gon is constructible whenever n is a product of a power of 2 and distinct Fermat primes (primes of the form 2^(2^m)+1). Pierre Wantzel (1837) proved the converse, completing what is now the Gauss–Wantzel theorem — and in the same paper settled the impossibility of trisecting a general angle and doubling the cube. The bridge to number theory is the field-degree criterion: a regular n-gon is constructible iff the primitive n-th root of unity ζₙ generates an extension ℚ(ζₙ)/ℚ whose degree [ℚ(ζₙ):ℚ] = φ(n) is a power of two. Thus the whole geometric theorem rests on classifying the n for which φ(n) is a power of two — the content formalized here.",
+    "problemStatement": "For which n is a regular n-gon constructible with compass and straightedge? Via [ℚ(ζₙ):ℚ] = φ(n), this reduces to: for which n is Euler's totient φ(n) a power of two?",
+    "text": "We prove that φ(n) is a power of two iff every prime factor of n is 2 or a Fermat prime dividing n exactly once. The argument has three layers. (1) A positive natural m is a power of two iff its only prime divisor is 2 — the reverse direction is Mathlib's eq_prime_pow_of_unique_prime_dvd. (2) Local criterion: for an odd prime p, φ(p) = p − 1; if this is 2ᵏ then p = 2ᵏ + 1 is prime, and Mathlib's pow_of_pow_add_prime forces k = 2^m, so p = 2^(2^m)+1 is a Fermat prime; conversely φ of a Fermat prime is 2^(2^m). (3) Global assembly: by Euler's product φ(n) = ∏_{p∣n} p^(eₚ−1)(p−1), a prime q divides φ(n) iff it divides one of these factors. If φ(n) is a power of two, each odd prime factor p must have multiplicity 1 (else p ∣ φ(n)) and p − 1 must have only 2 as a prime factor (hence p is Fermat). Conversely, if the condition holds each factor is a power of two, so their product φ(n) is too.",
+    "proofStrategy": "Reduce 'power of two' to 'only prime factor is 2'; settle the single-odd-prime case with Mathlib's Fermat-number lemma pow_of_pow_add_prime; lift to arbitrary n through Euler's totient product and the interaction of prime divisibility with finite products (Prime.dvd_finset_prod_iff, Finset.dvd_prod_of_mem).",
+    "keyInsights": [
+      "The geometric constructibility question collapses, via [ℚ(ζₙ):ℚ] = φ(n), to a pure divisibility question about the totient — this entry isolates and proves that divisibility content.",
+      "The odd-prime case is the crux and is exactly Mathlib's pow_of_pow_add_prime: a prime of the form 2ˢ+1 must be a Fermat number 2^(2^m)+1.",
+      "Multiplicity control is automatic: if an odd prime p divides n to a power ≥ 2 then p itself divides p^(eₚ−1)(p−1) ∣ φ(n), forcing p = 2 — a contradiction — so every odd Fermat factor is squarefree in n.",
+      "The whole classification is 0-axiom over ℕ; the only unformalized link to geometry is the constructibility ⟺ (φ(n) a power of two) bridge, which awaits compass-and-straightedge constructibility in Mathlib."
+    ],
+    "prerequisites": [
+      "Euler's totient function and its multiplicativity / prime-power values",
+      "Fermat numbers 2^(2^m)+1 and Fermat primes",
+      "Field degree [ℚ(ζₙ):ℚ] = φ(n) for cyclotomic extensions (for the geometric interpretation)",
+      "Prime factorization and divisibility of finite products"
+    ]
+  },
+  "conclusion": {
+    "summary": "The arithmetic Gauss–Wantzel criterion is formalized with 0 axioms: φ(n) is a power of two iff every prime factor of n is 2 or a first-power Fermat prime. 7 theorems/lemmas, 1 definition, 172 lines.",
+    "implications": "This is the number-theoretic core of the classical theorem that pinned down exactly which regular polygons are constructible (and, in Wantzel's hands, the impossibility of general angle trisection and cube duplication). It supplies the reusable IsFermatPrime predicate and the totient-power-of-two classification on which a future formalization of the geometric equivalence can build.",
+    "openQuestions": [
+      "Formalize compass-and-straightedge constructibility and the bridge [ℚ(ζₙ):ℚ] = φ(n) to obtain the full geometric Gauss–Wantzel theorem.",
+      "Reconstruct the explicit form n = 2ᵃ · ∏ (distinct Fermat primes) as a structured decomposition rather than the per-prime condition proved here.",
+      "Connect to the only five known Fermat primes (3, 5, 17, 257, 65537) and the resulting finite list of odd constructible polygon side-counts."
+    ]
+  },
+  "leanFile": {
+    "namespace": "AngleTrisectionOQ01OQ02",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/AngleTrisectionOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: minimal-polynomial degree obstructions to constructibility. This entry supplies the positive arithmetic classification (which regular polygons ARE constructible) via the totient criterion."
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "The impossibility of trisecting a general angle (Wantzel 1837) is proved in the same work that completes the Gauss–Wantzel polygon classification formalized here."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Fermat primes and powers of two",
+      "startLine": 47,
+      "endLine": 58,
+      "summary": "Defines IsFermatPrime (a prime equal to fermatNumber m) and proves isTwoPow_iff: a positive natural is a power of two iff its only prime factor is 2."
+    },
+    {
+      "title": "The local criterion at a prime",
+      "startLine": 60,
+      "endLine": 93,
+      "summary": "IsFermatPrime.ne_two and IsFermatPrime.totient_isTwoPow, then totient_odd_prime_isTwoPow_iff: for an odd prime p, φ(p) is a power of two iff p is a Fermat prime (via Nat.pow_of_pow_add_prime)."
+    },
+    {
+      "title": "Euler's totient product",
+      "startLine": 95,
+      "endLine": 101,
+      "summary": "totient_eq_prod_primeFactors: φ(n) = ∏_{p ∣ n} p^(eₚ−1)(p−1) over the prime factors of n."
+    },
+    {
+      "title": "The arithmetic Gauss–Wantzel criterion",
+      "startLine": 103,
+      "endLine": 172,
+      "summary": "totient_isTwoPow_iff: φ(n) is a power of two iff every prime factor is 2 or a first-power Fermat prime; and prime_totient_isTwoPow_iff, the prime specialization giving the regular-p-gon constructibility condition."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **angle-trisection-oq-01-oq-02**: formalizes the number-theoretic engine of the **Gauss–Wantzel theorem** on constructible regular polygons. For `n ≥ 1`,

```
φ(n) is a power of two  ⟺  every prime factor of n is 2, or a Fermat prime of multiplicity 1
```

(`totient_isTwoPow_iff`). Since a regular n-gon is constructible exactly when `φ(n) = [ℚ(ζₙ):ℚ]` is a power of two, this is the arithmetic half of the constructible-polygon classification — equivalently `n = 2ᵃ · (product of distinct Fermat primes)`.

## Structure
- `IsFermatPrime p := p.Prime ∧ ∃ m, p = 2^(2^m)+1` (= `fermatNumber m`).
- **Local crux** (`totient_odd_prime_isTwoPow_iff`): for odd prime `p`, `φ(p) = p−1` is a power of two ⟺ `p` is a Fermat prime — via Mathlib's `Nat.pow_of_pow_add_prime` (a prime `2ˢ+1` forces `s` to be a power of two).
- **Global assembly**: Euler's product `φ(n) = ∏ p^(eₚ−1)(p−1)` + `isTwoPow_iff` (a positive nat is a power of two ⟺ its only prime factor is 2).
- `prime_totient_isTwoPow_iff`: prime specialization (regular p-gon constructible ⟺ p = 2 or p Fermat).

## Scope / honesty
This is the **arithmetic** half. The geometric equivalence *constructible ⟺ φ(n) a power of two* is **not** formalized (compass-and-straightedge constructibility is not in Mathlib); this is disclosed in `assumptions` and `overview`, and left as an open follow-up.

## Verification
- `lake env lean` (single-file, repo Mathlib cache): **0 errors**.
- `#print axioms` on the three main theorems → only `[propext, Classical.choice, Quot.sound]` ⇒ **0 counted axioms**, status `verified`.
- 7 theorems/lemmas, 1 definition, 172 lines.

## Files
- `proofs/Proofs/AngleTrisectionOQ01OQ02.lean` (new)
- `src/data/proofs/angle-trisection-oq-01-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)