### PR TITLE
Enrich derangements inclusion-exclusion entry: add 5 annotations (derangements-convergence-oq-07-oq-02)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-07-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-deroq0702-header",
+    "proofId": "derangements-convergence-oq-07-oq-02",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "Goal: the binomial-inversion companion of the parent convolution",
+    "content": "The module docstring frames the entry as the inverse of the parent's fixed-point convolution n! = Σ C(n,k)·D(n−k): binomial (Möbius) inversion recovers the classical inclusion–exclusion count D(n) = Σ (−1)^k C(n,k)(n−k)!. Crucially it flags that Mathlib already has this alternating sum, but only in the ascending-factorial convention (numDerangements_sum), where the summand is (k+1).ascFactorial (n−k) = n!/k! rather than the textbook C(n,k)·(n−k)!. Converting between those two shapes is the real work.",
+    "mathContext": "$D(n) = \\sum_{k=0}^{n} (-1)^k \\binom{n}{k}(n-k)!$, the inverse binomial transform of $n! = \\sum_{k=0}^{n}\\binom{n}{k}D(n-k)$.",
+    "significance": "context",
+    "relatedConcepts": ["derangements", "inclusion–exclusion", "binomial inversion", "Möbius transform"],
+    "prerequisites": ["derangement numbers numDerangements", "binomial coefficients", "the parent convolution identity"]
+  },
+  {
+    "id": "ann-deroq0702-bridge",
+    "proofId": "derangements-convergence-oq-07-oq-02",
+    "range": { "startLine": 61, "endLine": 79 },
+    "type": "technique",
+    "title": "The arithmetic bridge, without ℕ-division",
+    "content": "ascFactorial_succ_eq_choose_mul_factorial is the genuine mathematical content: for k ≤ n, (k+1).ascFactorial (n−k) = C(n,k)·(n−k)!. Both sides equal n!/k!, but natural-number division truncates, so the proof avoids it entirely. It multiplies through by k! and cancels the positive factor (Nat.eq_of_mul_eq_mul_left with factorial_pos), then pins each side to n!: the left by Nat.factorial_mul_ascFactorial (k!·(k+1).ascFactorial(n−k) = (k+(n−k))! = n!), the right by Nat.choose_mul_factorial_mul_factorial (C(n,k)·k!·(n−k)! = n!). This is the recommended Mathlib idiom for identities that would otherwise involve n!/k!.",
+    "mathContext": "$(k+1)^{\\overline{\\,n-k\\,}} = \\dfrac{n!}{k!} = \\binom{n}{k}(n-k)!$; proved via $k!\\cdot(k+1)^{\\overline{\\,n-k\\,}} = n! = k!\\cdot\\binom{n}{k}(n-k)!$ and cancellation.",
+    "significance": "key",
+    "relatedConcepts": ["ascending factorial", "avoiding ℕ-division", "factorial cancellation", "choose_mul_factorial_mul_factorial"],
+    "prerequisites": ["ascending factorial ascFactorial", "cancellation in ℕ", "factorial and binomial identities"]
+  },
+  {
+    "id": "ann-deroq0702-binomial-sum",
+    "proofId": "derangements-convergence-oq-07-oq-02",
+    "range": { "startLine": 81, "endLine": 100 },
+    "type": "insight",
+    "title": "The main formula: convert term by term",
+    "content": "numDerangements_eq_sum_neg_one_pow_choose_mul_factorial is the target identity (D(n):ℤ) = Σ_{k∈range(n+1)} (−1)^k·C(n,k)·(n−k)!. The proof starts from Mathlib's numDerangements_sum, then applies Finset.sum_congr to rewrite each summand: on each term the hypothesis k ≤ n is extracted from mem_range, the bridge lemma converts the ascending-factorial factor to the binomial factor, and push_cast + ring reconcile the ℤ-cast coefficient shapes. No new combinatorics is invoked beyond the imported sum and the bridge.",
+    "mathContext": "$(D(n):\\mathbb{Z}) = \\sum_{k\\in[0,n]} (-1)^k\\binom{n}{k}(n-k)!$, obtained from $\\sum_k (-1)^k (k+1)^{\\overline{\\,n-k\\,}}$ by termwise substitution.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_congr", "termwise rewriting", "numDerangements_sum", "cast to ℤ"],
+    "prerequisites": ["finite sums over Finset.range", "push_cast/ring", "the bridge lemma"]
+  },
+  {
+    "id": "ann-deroq0702-repackaged",
+    "proofId": "derangements-convergence-oq-07-oq-02",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "technique",
+    "title": "Repackaging the sign away from the magnitude",
+    "content": "numDerangements_eq_alternating_binomial_sum restates the identity with the whole magnitude C(n,k)·(n−k)! carried under a single ℕ→ℤ cast and only the sign (−1)^k left in ℤ. This matches the usual reading 'signed count of permutations classified by the size of their fixed-point set', and makes the alternating structure syntactically explicit. The proof is a one-step push_cast/ring rewrite of the previous theorem.",
+    "mathContext": "$(D(n):\\mathbb{Z}) = \\sum_{k} (-1)^k \\big(\\underbrace{\\binom{n}{k}(n-k)!}_{\\in\\,\\mathbb{N}}\\big)$ — sign and non-negative magnitude separated.",
+    "significance": "supporting",
+    "relatedConcepts": ["alternating sum", "cast normalization", "signed enumeration"],
+    "prerequisites": ["ℕ→ℤ coercion", "push_cast"]
+  },
+  {
+    "id": "ann-deroq0702-check",
+    "proofId": "derangements-convergence-oq-07-oq-02",
+    "range": { "startLine": 114, "endLine": 118 },
+    "type": "context",
+    "title": "Numeric sanity check: D(4) = 9",
+    "content": "A worked example instantiates the formula at n = 4: 24 − 24 + 12 − 4 + 1 = 9, matching the known derangement count D(4) = 9. It exercises the integer statement on a concrete value, guarding against sign or index-shift errors in the alternating sum. Dividing by 4! = 24 gives 9/24 = 0.375, the partial sum 1 − 1 + 1/2 − 1/6 + 1/24 of e^{−1} ≈ 0.3679.",
+    "mathContext": "$\\sum_{k=0}^{4}(-1)^k\\binom{4}{k}(4-k)! = 24-24+12-4+1 = 9 = D(4)$; and $9/24 = \\sum_{k=0}^{4}(-1)^k/k! \\approx e^{-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "derangement count D(4)", "partial sum of 1/e"],
+    "prerequisites": ["evaluating factorials and binomials", "the exponential series"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-07-oq-02` (D(n) = Σ (−1)ᵏ C(n,k)(n−k)!).

**Gap:** rich `meta.json` (sections, mainTheorems, references all present) but **no `annotations.json`**.

**Added** `annotations.json` with **5 annotations** over the 120-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. Binomial-inversion framing vs. Mathlib's ascending-factorial `numDerangements_sum`
2. The **arithmetic bridge** (k+1).ascFactorial(n−k) = C(n,k)(n−k)!, proved without ℕ-division
3. The termwise-rewrite main formula (`Finset.sum_congr` + bridge + push_cast/ring)
4. The sign/magnitude repackaging under a single ℕ→ℤ cast
5. The D(4) = 24−24+12−4+1 = 9 numeric check, tied to the 1/e partial sum

`annotations:validate` reports 0 errors for this slug (ranges on declaration doc-comments, non-overlapping); `check-meta-size` within caps. No `meta.json` change.