### PR TITLE
Enrich halting-problem approximation entry: add 6 annotations (halting-problem-oq-01)

### DIFF
--- a/src/data/proofs/halting-problem-oq-01/annotations.json
+++ b/src/data/proofs/halting-problem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-haltoq01-placement",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 85, "endLine": 107 },
+    "type": "concept",
+    "title": "§1 The halting set and its Σ⁰₁/Π⁰₁ placement",
+    "content": "The parametrized halting predicate Halts n c := (eval c n).Dom says code c halts on input n, using Mathlib's universal evaluator on Nat.Partrec.Code. Three Mathlib theorems are repackaged as the hierarchy placement of K: halts_re (K is recursively enumerable — Σ⁰₁ — you can confirm halting by running), halts_not_computable (no total decider), and halts_compl_not_re (the complement Kᶜ is NOT r.e. — non-halting is not semi-decidable). This last asymmetry is the entire engine of the entry: everything downstream exploits that Kᶜ ∉ Σ⁰₁.",
+    "mathContext": "$K = \\{c : (\\text{eval } c\\, n).\\mathrm{Dom}\\}$ is $\\Sigma^0_1$ (r.e.) but not computable, and $K^c$ is $\\Pi^0_1$ and not r.e. — the approximation gap lives in $\\Pi^0_1 \\setminus \\Sigma^0_1$.",
+    "significance": "key",
+    "relatedConcepts": ["halting set K", "arithmetical hierarchy", "recursively enumerable (Σ⁰₁)", "Nat.Partrec.Code"],
+    "prerequisites": ["partial recursive functions", "the arithmetical hierarchy", "Mathlib's ComputablePred/REPred"]
+  },
+  {
+    "id": "ann-haltoq01-union",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 109, "endLine": 130 },
+    "type": "technique",
+    "title": "§2 Recursive enumerability is closed under union (REPred.or)",
+    "content": "REPred.or proves that if p and q are r.e. then so is a ↦ p a ∨ q a. The construction dovetails the two semi-deciders: each predicate is realized as the domain of a partial computable function (Part.assert), and Mathlib's Partrec.merge' runs both in parallel, halting iff either halts. Reading off the domain of the merged function (dom_re) gives the union predicate. This closure lemma is the reusable engine for the sharp non-r.e. result and is stated generically over any Primcodable type.",
+    "mathContext": "$\\mathrm{REPred}\\,p \\wedge \\mathrm{REPred}\\,q \\Rightarrow \\mathrm{REPred}(p \\vee q)$; dovetailing gives $(k\\,a).\\mathrm{Dom} \\leftrightarrow p\\,a \\vee q\\,a$.",
+    "significance": "key",
+    "relatedConcepts": ["dovetailing", "Partrec.merge'", "closure under union", "domain of a partial computable function"],
+    "prerequisites": ["partial computable functions", "Part.assert and dom_re", "parallel simulation of semi-deciders"]
+  },
+  {
+    "id": "ann-haltoq01-confirmedfalse",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 131, "endLine": 169 },
+    "type": "insight",
+    "title": "§3 Sound approximators and the r.e. confirmed-false set",
+    "content": "A partial computable f : Code →. Bool is a Sound approximator at n if every value it commits is correct (undefined = decline). re_confirmedFalse shows the confirmed-non-halting set {c | false ∈ f c} is r.e.: it is the domain of the explicit partial computable function c ↦ (f c).bind (fun b => cond b none (some ())), which is defined exactly when f confirms false. This turns 'f says c loops' into a semi-decidable event — one of the two pieces of the Kᶜ split.",
+    "mathContext": "$\\mathrm{Sound}\\,n\\,f := \\forall c\\,b,\\ b \\in f\\,c \\to (b = \\text{true} \\leftrightarrow \\mathrm{Halts}\\,n\\,c)$; $\\{c \\mid \\text{false} \\in f\\,c\\}$ is r.e. as a domain.",
+    "significance": "supporting",
+    "relatedConcepts": ["sound approximator", "declining (Option/partiality)", "domain as r.e. set", "bind/cond construction"],
+    "prerequisites": ["Part monad (bind, assert)", "partial computable Bool functions", "soundness of an approximator"]
+  },
+  {
+    "id": "ann-haltoq01-noconfirm",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 171, "endLine": 206 },
+    "type": "insight",
+    "title": "No sound approximator confirms non-halting everywhere",
+    "content": "no_sound_approx_confirms_all_nonhalting: if a sound computable f confirmed non-halting (false ∈ f c) on ALL of Kᶜ, then by re_confirmedFalse the set {c | false ∈ f c} — which would then equal Kᶜ — is r.e., contradicting halts_compl_not_re. Hence sound_approx_undefined_on_nonhalting: every sound computable approximator must be undefined (decline) on some genuinely non-halting input. This is the qualitative 'declines somewhere', later strengthened to a non-r.e. decline set.",
+    "mathContext": "If $\\{c \\mid \\text{false} \\in f\\,c\\} \\supseteq K^c$ and is r.e., then $K^c$ r.e. — contradicting $K^c \\notin \\Sigma^0_1$. So $\\exists c,\\ \\neg\\mathrm{Halts}\\,n\\,c \\wedge \\neg(f\\,c).\\mathrm{Dom}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof by contradiction", "non-r.e. complement", "forced decline", "semi-decidability limits"],
+    "prerequisites": ["re_confirmedFalse", "halts_compl_not_re", "reasoning about r.e. sets"]
+  },
+  {
+    "id": "ann-haltoq01-sharp",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 208, "endLine": 239 },
+    "type": "insight",
+    "title": "The sharp result: the decline set on Kᶜ is not r.e.",
+    "content": "decline_set_on_nonhalting_not_re is the entry's headline. Split Kᶜ = {c | false ∈ f c} ∪ {c | ¬Halts n c ∧ ¬(f c).Dom}: the first piece is r.e. (re_confirmedFalse). If the second — the decline set restricted to non-halting inputs — were also r.e., then REPred.or would make their union Kᶜ recursively enumerable, contradicting halts_compl_not_re. Therefore the decline set on the non-halting inputs is not r.e., hence infinite. Relaxing a halting decider to allow declining does not shrink the gap to a point: the give-up region is a genuinely non-r.e. set.",
+    "mathContext": "$K^c = \\{c \\mid \\text{false} \\in f\\,c\\} \\cup \\{c \\mid \\neg\\mathrm{Halts}\\,n\\,c \\wedge \\neg(f\\,c).\\mathrm{Dom}\\}$; first r.e., so second r.e. $\\Rightarrow K^c$ r.e., contradiction $\\Rightarrow$ decline set $\\notin \\Sigma^0_1$.",
+    "significance": "key",
+    "relatedConcepts": ["set splitting", "REPred.or", "non-r.e. decline set", "generic-case complexity"],
+    "prerequisites": ["closure of r.e. under union", "the confirmed-false r.e. lemma", "complement not r.e."]
+  },
+  {
+    "id": "ann-haltoq01-corollary",
+    "proofId": "halting-problem-oq-01",
+    "range": { "startLine": 240, "endLine": 255 },
+    "type": "context",
+    "title": "Corollary: the decline set is nonempty",
+    "content": "sound_approx_declines_nonempty recovers the earlier single-witness statement as a corollary of the sharp form: a not-r.e. set cannot be empty (the empty set is trivially r.e.), so the decline set on non-halting inputs contains at least one code. This closes the loop back to the schematic 'must decline somewhere' barrier from the companion HaltingApproximation.lean, now proved in the genuine computation model rather than schematically.",
+    "mathContext": "The empty predicate is r.e.; since the decline set is not r.e., it is nonempty — $\\exists c,\\ \\neg\\mathrm{Halts}\\,n\\,c \\wedge \\neg(f\\,c).\\mathrm{Dom}$.",
+    "significance": "context",
+    "relatedConcepts": ["corollary", "nonempty from non-r.e.", "schematic vs model-level barrier"],
+    "prerequisites": ["the empty set is r.e.", "the sharp non-r.e. theorem"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `halting-problem-oq-01` (Approximating the Halting Problem: the Non-r.e. Decline Set).

**Gap:** very rich `meta.json` (sections, theorems, references, mathlibDependencies all present) but **no `annotations.json`**.

**Added** `annotations.json` with **6 annotations** over the 255-line main file `HaltingArithmeticalHierarchy.lean`, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. §1 The halting set K and its Σ⁰₁/Π⁰₁ placement (the driving asymmetry)
2. §2 `REPred.or` — r.e. closed under union via `Partrec.merge'` dovetailing
3. §3 Sound approximators + the r.e. confirmed-false set (`re_confirmedFalse`)
4. No sound approximator confirms non-halting on all of Kᶜ ⇒ must decline somewhere
5. The sharp result: the decline set on non-halting inputs is **not r.e.** (Kᶜ split)
6. The nonempty-decline-set corollary

`annotations:validate` reports 0 errors for this slug (ranges on section/doc-comment lines, non-overlapping); `check-meta-size` within caps. No `meta.json` change.