### PR TITLE
Fix: add gallery entry for HGCD matrix invariant (bezout-identity-oq-01-oq-01-oq-01-oq-02) + v4.26 drift repair

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ01OQ01OQ01OQ02.lean
@@ -79,8 +79,8 @@ theorem Q_mulVec (q : ℤ) (v : Fin 2 → ℤ) :
     (Q q).mulVec v = euclidStep q v := by
   funext i
   fin_cases i <;>
-    simp [Q, euclidStep, Matrix.mulVec, Matrix.dotProduct, Fin.sum_univ_two,
-      Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;> ring
+    simp [Q, euclidStep, Matrix.mulVec, dotProduct, Fin.sum_univ_two,
+      Matrix.cons_val_zero, Matrix.cons_val_one] <;> ring
 
 /-- **Unimodularity of a single quotient matrix**: `det (Q q) = -1`.
     Each Euclidean step is encoded by a determinant `-1` matrix. -/

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-bezoutoq010101oq02-header",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "Do matrices encode Euclidean steps? — part (a) of the HGCD question",
+    "content": "The parent entry's second open question asks whether the O(log² n) binary-GCD analysis extends to Schönhage's half-GCD (HGCD), giving O(M(n) log n). That splits into (a) the matrix invariant that 2×2 integer matrices encode partial Euclidean steps, (b) a Master theorem (absent from Mathlib), and (c) a cost model for the multiplication primitive M. This file formalizes part (a) completely and axiom-free: it is constructive linear algebra, independent of any cost model. One Euclidean step (r₀, r₁) ↦ (r₁, r₀ − q·r₁) is left-multiplication by the quotient matrix Q(q) = !![0,1;1,−q] over ℤ. Parts (b), (c) are declared out of scope.",
+    "mathContext": "One step: $(r_0, r_1) \\mapsto (r_1, r_0 - q\\,r_1)$ is $\\begin{pmatrix}0&1\\\\1&-q\\end{pmatrix}\\begin{pmatrix}r_0\\\\r_1\\end{pmatrix}$. Accumulated product $R_k = Q(q_k)\\cdots Q(q_1)$ is unimodular, $\\det R_k = (-1)^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["half-GCD", "Euclidean algorithm", "quotient matrix", "unimodular matrix", "continuants"],
+    "prerequisites": ["Euclidean algorithm", "2×2 matrices over ℤ"]
+  },
+  {
+    "id": "ann-bezoutoq010101oq02-quotient",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 88 },
+    "type": "insight",
+    "title": "The quotient matrix Q(q): one step, and it is unimodular",
+    "content": "Q(q) = !![0, 1; 1, −q] and euclidStep q (x, y) = (y, x − q·y) are defined, then Q_mulVec proves (Q q).mulVec v = euclidStep q v — one matrix–vector multiplication performs exactly one Euclidean step. The proof does fin_cases on the Fin 2 index and expands the matrix–vector dotProduct (row 0 gives y, row 1 gives x − q·y). det_Q proves det (Q q) = −1 via Matrix.det_fin_two_of: every quotient matrix is unimodular, so each Euclidean step is encoded by a determinant −1 matrix.",
+    "mathContext": "$\\det\\begin{pmatrix}0&1\\\\1&-q\\end{pmatrix} = 0\\cdot(-q) - 1\\cdot 1 = -1$ for every $q$.",
+    "significance": "critical",
+    "relatedConcepts": ["Matrix.mulVec", "dotProduct", "Matrix.det_fin_two_of", "fin_cases"],
+    "prerequisites": ["matrix–vector product", "2×2 determinant"]
+  },
+  {
+    "id": "ann-bezoutoq010101oq02-product",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 94, "endLine": 126 },
+    "type": "insight",
+    "title": "The accumulated product Rₖ: unimodular, and it folds the steps",
+    "content": "Rprod [q_k, …, q_1] = Q(q_k) · ⋯ · Q(q_1) is defined by list recursion (Rprod_nil, Rprod_cons are the definitional simp lemmas). det_Rprod proves det (Rprod qs) = (−1)^(qs.length) by induction, using multiplicativity of the determinant (Matrix.det_mul) and det_Q — so every accumulated transformation is unimodular. This det = ±1 is exactly what lets HGCD splice a partial transformation matrix into a recursive call. Rprod_mulVec then proves the full invariant (Rprod qs).mulVec v = qs.foldr euclidStep v: applying the accumulated product to the initial remainder pair reproduces the composition of the individual Euclidean steps, threaded through Matrix.mulVec_mulVec and Q_mulVec.",
+    "mathContext": "$\\det R_k = \\prod_{i} \\det Q(q_i) = (-1)^k$; and $R_k \\cdot \\mathbf{v} = (\\text{step}_{q_k} \\circ \\cdots \\circ \\text{step}_{q_1})(\\mathbf{v})$.",
+    "significance": "critical",
+    "relatedConcepts": ["Matrix.det_mul", "Matrix.mulVec_mulVec", "List.foldr", "unimodularity", "induction"],
+    "prerequisites": ["determinant multiplicativity", "list recursion", "induction"]
+  },
+  {
+    "id": "ann-bezoutoq010101oq02-examples",
+    "proofId": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 134, "endLine": 146 },
+    "type": "example",
+    "title": "Worked examples: a concrete step and product signs",
+    "content": "Axiom-free instances discharged by the proven theorems. One step on (252, 198) with quotient 1: (Q 1).mulVec ![252, 198] = ![198, 54] (since 252 − 1·198 = 54). Determinant signs: (Rprod [1, 3, 1]).det = (−1)³ = −1 and (Rprod [2, 1, 3, 1]).det = (−1)⁴ = 1 (unimodular, orientation preserved). The determinants use kernel `decide` on concrete integers — no native_decide, so no Lean.ofReduceBool dependency.",
+    "mathContext": "$252 = 1\\cdot 198 + 54$; a 3-step product has $\\det = -1$, a 4-step product has $\\det = +1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "kernel decide", "sanity check"],
+    "prerequisites": ["Euclidean remainder step"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+  "slug": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+  "sorries": 0,
+  "title": "HGCD Matrix Invariant: 2×2 Integer Matrices Encode Euclidean Steps",
+  "description": "The parent gallery proof `bezout-identity-oq-01-oq-01-oq-01` (Binary GCD O(log² n) Bit Complexity) analyses Stein's binary GCD; its second open question asks whether that O(log² n) analysis extends to Schönhage's half-GCD (HGCD) algorithm, giving O(M(n) log n) complexity. That question decomposes into three sub-tasks: (a) HGCD's key invariant that 2×2 integer matrices encode partial Euclidean steps; (b) a Master theorem in Lean (absent from Mathlib); (c) parametrization over the multiplication primitive M. This entry formalizes part (a) completely and axiom-free — it is genuine constructive linear algebra, independent of any cost model. A single Euclidean step (r₀, r₁) ↦ (r₁, r₀ − q·r₁) is realized as left-multiplication of the remainder column by the quotient matrix Q(q) = !![0,1;1,−q] over ℤ. The file proves the four facts that make matrices encode Euclidean steps: Q_mulVec (one step: (Q q).mulVec ![x,y] = ![y, x−q·y]); det_Q (each quotient matrix is unimodular, det = −1); det_Rprod (the accumulated product Rₖ = Q(qₖ)⋯Q(q₁) has det = (−1)^k, hence is unimodular — exactly the property HGCD needs to splice a partial transformation matrix into a recursive call); and Rprod_mulVec (the full invariant: applying the product folds the individual Euclidean steps). Working directly over Matrix (Fin 2) (Fin 2) ℤ (rather than Mathlib's GenContFract convergent-determinant machinery, which proves the field-level analogue) gives the cleaner route for integer Euclidean steps. Parts (b) and (c), which rest on the Master theorem for the recurrence T(n) = 2T(n/2) + M(n) — the critical case absent from Mathlib — are out of scope; part (a) is what the open question actually asks to formalize and is provable today. 0 axioms, 0 sorries.",
+  "leanFile": {
+    "lineCount": 146,
+    "axiomCount": 0,
+    "path": "Proofs/BezoutIdentityOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 6
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (HGCD matrix invariant); classical result of Schönhage (1971) / Knuth, TAOCP Vol. 2 §4.5.3",
+    "date": "1971",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ01OQ01OQ01OQ02.lean",
+    "parentProofId": "bezout-identity-oq-01-oq-01-oq-01",
+    "tags": [
+      "number-theory",
+      "algorithms",
+      "half-gcd",
+      "euclidean-algorithm",
+      "continuants",
+      "linear-algebra",
+      "unimodular-matrices",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-02",
+    "lineCount": 146,
+    "originalContributions": [
+      "Q: the Euclidean quotient matrix Q(q) = !![0, 1; 1, -q] over ℤ, whose left-action performs one Euclidean step on a remainder pair",
+      "euclidStep: one Euclidean step as a map on the remainder pair (x, y) ↦ (y, x - q·y)",
+      "Q_mulVec: the one-step correctness lemma — (Q q).mulVec v = euclidStep q v, i.e. (Q q).mulVec ![x, y] = ![y, x - q·y]; proved by fin_cases on the index and dotProduct expansion",
+      "det_Q: unimodularity of a single quotient matrix — det (Q q) = -1, via Matrix.det_fin_two_of",
+      "Rprod: the accumulated remainder-sequence product R_k = Q(q_k) · ⋯ · Q(q_1), defined by list recursion over the quotient list",
+      "det_Rprod: unimodularity of the accumulated product — det (Rprod qs) = (-1)^(qs.length), proved by induction using Matrix.det_mul and det_Q; this det = ±1 is exactly what lets HGCD splice a partial transformation matrix into a recursive call",
+      "Rprod_mulVec: the full matrix–Euclidean invariant — (Rprod qs).mulVec v = qs.foldr euclidStep v, so applying the accumulated product folds the individual Euclidean steps; proved by induction with Matrix.mulVec_mulVec and Q_mulVec"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for all theorems (checked on Q_mulVec, det_Rprod, and Rprod_mulVec). No native_decide is used (so no Lean.ofReduceBool); the worked examples are discharged by the proven theorems together with kernel `decide` on concrete integer determinants. Only parts (b) and (c) of the parent's open question — the O(M(n) log n) asymptotic, which requires a Master/Akra–Bazzi theorem for the critical recurrence T(n) = 2T(n/2) + M(n) that Mathlib does not provide — are left out of scope; the matrix invariant formalized here (part (a)) is complete and unconditional.",
+    "theoremCount": 6,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Schönhage's fast continued-fraction / half-GCD algorithm (1971) accelerates the Euclidean algorithm from quadratic to near-linear time by processing the high-order bits of the inputs recursively, splicing together the 2×2 transformation matrices produced by each recursive call. The algebraic backbone is a classical fact going back to the theory of continuants (Knuth, TAOCP Vol. 2, §4.5.3): a run of Euclidean steps is encoded by a product of unimodular 2×2 integer matrices, whose entries are, up to sign, the Bézout cofactors s_k, t_k. Mathlib formalizes the field-level analogue for generalized-continued-fraction convergents (Mathlib/Algebra/ContinuedFractions/Determinant.lean); this entry works directly over Matrix (Fin 2) (Fin 2) ℤ, the cleaner setting for integer Euclidean steps and the one HGCD actually uses.",
+    "problemStatement": "The parent entry's second open question asks whether the O(log² n) bit-complexity analysis of Stein's binary GCD extends to Schönhage's HGCD, giving O(M(n) log n). Its first named sub-task, part (a), is to formalize HGCD's key invariant: that 2×2 integer matrices encode partial Euclidean steps. Concretely: realize one Euclidean step as multiplication by a fixed quotient matrix, show each such matrix is unimodular (det = −1), show the accumulated product over k steps is unimodular (det = (−1)^k), and show that applying the accumulated product to the initial remainder pair reproduces the composition of the individual steps.",
+    "proofStrategy": "Four verified facts over Matrix (Fin 2) (Fin 2) ℤ. (1) One step: define Q(q) = !![0,1;1,−q] and euclidStep q (x,y) = (y, x−q·y); prove Q_mulVec : (Q q).mulVec v = euclidStep q v by fin_cases on the index and expanding the matrix–vector dot product. (2) Single-step unimodularity: det_Q : det (Q q) = −1 by the explicit 2×2 determinant formula. (3) Accumulated unimodularity: define Rprod [q_k,…,q_1] = Q(q_k)·⋯·Q(q_1) by list recursion, then det_Rprod : det (Rprod qs) = (−1)^(qs.length) by induction using multiplicativity of the determinant and det_Q. (4) Full invariant: Rprod_mulVec : (Rprod qs).mulVec v = qs.foldr euclidStep v by induction, threading the associativity of matrix–vector action (Matrix.mulVec_mulVec) through Q_mulVec. Worked examples check a concrete step on (252, 198) and the sign of a 3- and 4-step product.",
+    "keyInsights": [
+      "One Euclidean step (r₀, r₁) ↦ (r₁, r₀ − q·r₁) is left-multiplication by the fixed unimodular matrix Q(q) = !![0,1;1,−q]; the entire remainder sequence is thus a single matrix product acting on the initial pair.",
+      "det (Q q) = −1 for every quotient q, so the accumulated product Rₖ has det (−1)^k = ±1. This unimodularity is precisely the structural property HGCD exploits: a partial transformation computed on the high bits can be spliced back into the recursion because it is invertible over ℤ.",
+      "The entries of Rₖ are, up to sign, the continuants K(q₁,…,q_k) — the Bézout cofactors produced by the extended Euclidean algorithm — linking the matrix picture to classical continued-fraction identities.",
+      "Working over Matrix (Fin 2) (Fin 2) ℤ rather than through Mathlib's GenContFract convergent-determinant lemmas keeps the arithmetic exact and integer-native, avoiding the field embedding that the continued-fractions route requires.",
+      "The invariant (part (a)) is genuinely independent of the cost model: it is provable today with no appeal to the Master theorem, which is what the remaining O(M(n) log n) claim (parts (b), (c)) would need and which Mathlib lacks."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (146 lines, 6 theorems, 3 definitions) of part (a) of the parent's HGCD open question: 2×2 integer matrices encode partial Euclidean steps. It proves one-step correctness (Q_mulVec), single-step and accumulated unimodularity (det_Q, det_Rprod : det Rₖ = (−1)^k), and the full matrix–Euclidean invariant (Rprod_mulVec : applying the accumulated product folds the individual steps). All facts are established directly over Matrix (Fin 2) (Fin 2) ℤ.",
+    "implications": "The invariant is the algebraic foundation for a formal HGCD complexity analysis: unimodularity (det = ±1) is exactly what licenses splicing a partial transformation matrix into a recursive call, and the matrix–step correspondence turns statements about the remainder sequence into statements about a matrix product. It also connects to Mathlib's continued-fraction determinant theory (the field-level analogue) and to the extended Euclidean algorithm via continuants. The remaining sub-tasks needed to close the parent's O(M(n) log n) question are a Master/Akra–Bazzi theorem for T(n) = 2T(n/2) + M(n) and a cost model for the multiplication primitive M — both currently absent from Mathlib.",
+    "openQuestions": [
+      "Formalize the Master theorem (or Akra–Bazzi) for the critical recurrence T(n) = 2T(n/2) + Θ(M(n)) in Lean, the missing ingredient for the closing O(M(n) log n) HGCD bound (part (b)).",
+      "Introduce a cost model / Big-O monad for the integer-multiplication primitive M(n) and parametrize the HGCD analysis over it (part (c)).",
+      "Prove the identification of the entries of Rₖ with the continuants K(q₁,…,q_k) and hence with the extended-Euclidean Bézout cofactors s_k, t_k, tightening the link to the parent Bézout-identity entries."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "The HGCD matrix invariant (part (a) of the open question)",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring framing the parent's O(M(n) log n) HGCD question and its three sub-tasks. States that part (a) — matrices encode Euclidean steps — is constructive linear algebra independent of the cost model, and previews the quotient matrix Q(q) = !![0,1;1,−q], its unimodularity, and the accumulated-product invariant. Parts (b), (c) (Master theorem, cost model) are declared out of scope."
+    },
+    {
+      "id": "quotient-matrix",
+      "title": "§I The quotient matrix Q(q) and one-step correctness",
+      "startLine": 64,
+      "endLine": 88,
+      "summary": "Defines Q(q) = !![0,1;1,−q] and euclidStep q (x,y) = (y, x−q·y). Q_mulVec proves (Q q).mulVec v = euclidStep q v (one matrix step performs one Euclidean step) by fin_cases and dotProduct expansion. det_Q proves det (Q q) = −1: each quotient matrix is unimodular."
+    },
+    {
+      "id": "remainder-product",
+      "title": "§II The accumulated product Rₖ and the full invariant",
+      "startLine": 90,
+      "endLine": 126,
+      "summary": "Defines Rprod [q_k,…,q_1] = Q(q_k)·⋯·Q(q_1) by list recursion (with simp lemmas Rprod_nil, Rprod_cons). det_Rprod proves det (Rprod qs) = (−1)^(qs.length) by induction (Matrix.det_mul + det_Q), so every accumulated transformation is unimodular. Rprod_mulVec proves (Rprod qs).mulVec v = qs.foldr euclidStep v: applying the product folds the individual Euclidean steps."
+    },
+    {
+      "id": "examples",
+      "title": "§III Worked examples",
+      "startLine": 128,
+      "endLine": 146,
+      "summary": "Axiom-free concrete instances: one step on (252, 198) with quotient 1 gives (198, 54); the determinant of a 3-step product is (−1)³ = −1 and of a 4-step product is (−1)⁴ = 1. Discharged via the proven theorems plus kernel decide (no native_decide)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Formalizes part (a) of this parent's second open question — whether its O(log² n) binary-GCD analysis extends to the half-GCD algorithm. Provides the matrix invariant (2×2 integer matrices encode Euclidean steps) on which a formal HGCD complexity analysis would rest."
+    },
+    {
+      "targetId": "bezout-identity-oq-01-oq-01",
+      "relationship": "builds-on",
+      "description": "Grandparent entry on the extended Euclidean / Bézout identity, whose Euclidean steps and Bézout cofactors (continuants) are exactly the quantities the accumulated matrix product Rₖ encodes."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "Q_mulVec",
+      "type": "core",
+      "description": "One-step correctness: applying the quotient matrix to a remainder pair performs one Euclidean step, (Q q).mulVec ![x, y] = ![y, x − q·y].",
+      "leanType": "∀ (q : ℤ) (v : Fin 2 → ℤ), (Q q).mulVec v = euclidStep q v"
+    },
+    {
+      "name": "det_Q",
+      "type": "supporting",
+      "description": "Unimodularity of a single quotient matrix: det (Q q) = −1, so each Euclidean step is encoded by a determinant −1 matrix.",
+      "leanType": "∀ (q : ℤ), (Q q).det = -1"
+    },
+    {
+      "name": "det_Rprod",
+      "type": "headline",
+      "description": "Unimodularity of the accumulated product: det (Rprod qs) = (−1)^(qs.length). Every partial Euclidean transformation matrix is unimodular — the property HGCD relies on to splice a partial matrix into a recursive call.",
+      "leanType": "∀ (qs : List ℤ), (Rprod qs).det = (-1) ^ qs.length"
+    },
+    {
+      "name": "Rprod_mulVec",
+      "type": "core",
+      "description": "The full matrix–Euclidean invariant: applying the accumulated product to a vector is the right-to-left fold of the individual Euclidean steps, (Rprod qs).mulVec v = qs.foldr euclidStep v.",
+      "leanType": "∀ (qs : List ℤ) (v : Fin 2 → ℤ), (Rprod qs).mulVec v = qs.foldr euclidStep v"
+    }
+  ],
+  "references": [
+    {
+      "authors": "A. Schönhage",
+      "title": "Schnelle Berechnung von Kettenbruchentwicklungen",
+      "year": 1971,
+      "venue": "Acta Informatica 1, 139–144",
+      "note": "The fast half-GCD / continued-fraction algorithm whose matrix invariant is formalized here."
+    },
+    {
+      "authors": "D. E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": 1997,
+      "venue": "Addison-Wesley, §4.5.3",
+      "note": "Analysis of Euclid's algorithm and continuants; the algebra of quotient matrices and Bézout cofactors."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides Matrix (Fin 2) (Fin 2) determinant API (det_fin_two_of, det_mul, mulVec_mulVec) and the field-level GenContFract convergent-determinant analogue."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

`BezoutIdentityOQ01OQ01OQ01OQ02.lean` (HGCD matrix invariant — part (a) of the parent Bézout entry's half-GCD open question, merged in #23464) was a **verified research file with no gallery entry** (`src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/` was missing), so it never appeared in the gallery. It had also **drifted against pinned Mathlib v4.26.0**.

## Evidence

**Before**:
- No `src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/` directory → entry invisible in gallery.
- `lake env lean` failed: `Unknown constant 'Matrix.dotProduct'` in `Q_mulVec` (renamed to top-level `dotProduct` in v4.26.0), which then stalled the subsequent `ring`.

**After**:
- Drift repair: `Matrix.dotProduct` → `dotProduct` in the `Q_mulVec` simp set (dropped the now-unused `Matrix.head_cons`). One-token functional change; the rest of the file was already correct.
- File compiles clean against v4.26.0. `#print axioms` on `Q_mulVec`, `det_Rprod`, `Rprod_mulVec` reports only `propext / Classical.choice / Quot.sound` → **0 real axioms, verified** (no `native_decide`, no `Lean.ofReduceBool`).
- New gallery entry: `meta.json` (`status: verified`, `axiomCount: 0`, `sorries: 0`, 146L / 6 thm / 3 def) + `annotations.json` (4 annotations; all ranges resolve under `annotations:build`).
- `pnpm gallery:check-size` passes (4503 entries); my entry produces **no** `annotations:build` validation errors.

## Content

The entry documents part (a) of the parent's HGCD (Schönhage half-GCD) question — that 2×2 integer matrices encode partial Euclidean steps — axiom-free and independent of any cost model: quotient matrix `Q(q) = !![0,1;1,-q]`, one-step correctness `Q_mulVec`, single-step unimodularity `det_Q = -1`, accumulated unimodularity `det_Rprod = (-1)^k`, and the fold invariant `Rprod_mulVec`. Parts (b)/(c) (Master theorem, cost model — absent from Mathlib) are declared out of scope in the meta.

---
Automated fix by lean-mechanic agent.