### PR TITLE
research(bezout-identity-oq-02-oq-02-oq-01-oq-02): verify multivariate Bézout + sharp boundary [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ02.lean
@@ -9,7 +9,7 @@ From bezout-identity-oq-02-oq-02-oq-01 (Constructive Divisibility Algorithm):
 "Can the algorithm be extended to multivariate Bézout identities in
 polynomial rings?"
 
-## Answer: YES
+## Answer: YES over any Bézout ring (so over F[X]); NO in genuine multivariate rings.
 
 The two-element Bézout identity `u * a + v * b = gcd a b` generalizes to a
 *finite family* `a : ι → R` in any **Bézout ring** `R` (a commutative ring in
@@ -26,14 +26,25 @@ range of `a` is finitely generated (the index type is finite), hence principal
 by the Bézout hypothesis; its generator is the sought `d`, and membership of `d`
 in the span produces the explicit coefficient vector.
 
-Because polynomial rings `F[X]` over a field are Euclidean domains — hence
-principal ideal rings, hence Bézout — the identity specializes directly to the
-multivariate polynomial setting the open question asks about. It also
-specializes to `ℤ` and to any principal ideal domain.
+Because *univariate* polynomial rings `F[X]` over a field are Euclidean domains
+— hence principal ideal rings, hence Bézout — the identity specializes directly
+to the polynomial setting the open question asks about. It also specializes to
+`ℤ` and to any principal ideal domain.
 
 This entry works over an arbitrary `IsBezout` commutative ring; no integral
 domain hypothesis is needed, since both the divisibility and the universal
 property follow from the linear combination itself.
+
+**The sharp boundary (Part VII).** The affirmative answer is exactly as wide as
+the Bézout hypothesis, and no wider. *Genuine* multivariate polynomial rings
+`F[x₁,…,xₙ]` with `n ≥ 2` are **not** Bézout rings — not even principal ideal
+domains — so the identity fails there. We exhibit the obstruction concretely in
+`F[x, y] = MvPolynomial (Fin 2) F`: the variables `X` and `Y` share no common
+non-unit factor, yet the constant polynomial `1` is **not** an `F[x,y]`-linear
+combination of `X` and `Y`, because every element of the ideal `(X, Y)` has zero
+constant term. Hence there are no cofactors `f, g` with `f·X + g·Y = 1`, and the
+extended Euclidean / Bézout construction genuinely does not survive the passage
+to more than one variable.
 -/
 
 namespace BezoutIdentityOQ02OQ02OQ01OQ02
@@ -86,7 +97,7 @@ theorem exists_bezout_coeffs {R : Type*} [CommRing R] [IsBezout R]
     {ι : Type*} [Fintype ι] (a : ι → R) :
     ∃ u : ι → R, ∑ i, u i * a i = familyGcd a := by
   have hmem : familyGcd a ∈ Submodule.span R (Set.range a) := familyGcd_mem_span a
-  rw [mem_span_range_iff_exists_fun] at hmem
+  rw [Submodule.mem_span_range_iff_exists_fun] at hmem
   obtain ⟨u, hu⟩ := hmem
   exact ⟨u, by simpa only [smul_eq_mul] using hu⟩
 
@@ -194,5 +205,56 @@ example : (1 : ℤ) * 4 + (-2) * 6 + 1 * 9 = 1 := by norm_num
 `(-1)·X + 1·(X + 1) = 1`, exhibiting the constant polynomial `1` as a gcd. -/
 example : (-1 : Polynomial ℚ) * Polynomial.X + 1 * (Polynomial.X + 1) = 1 := by
   ring
+
+/-
+## Part VII: The Sharp Boundary — Genuine Multivariate Rings are not Bézout
+
+The affirmative results above rest entirely on the `IsBezout` hypothesis, and
+`F[x₁,…,xₙ]` fails it for `n ≥ 2`.  We make the failure explicit in
+`F[x, y] = MvPolynomial (Fin 2) F`.  `X` and `Y` are coprime (they share no
+common non-unit factor), yet `1 ∉ (X, Y)`, so no Bézout identity
+`f·X + g·Y = 1` exists.  The witness is the constant-coefficient homomorphism:
+every element of `(X, Y)` has zero constant term.
+-/
+
+open MvPolynomial
+
+/-- The generating pair `{X 0, X 1}` lies in the kernel of the
+constant-coefficient homomorphism, so the whole ideal it spans does. -/
+theorem span_X_le_ker_constantCoeff {F : Type*} [CommRing F] :
+    Ideal.span {X (0 : Fin 2), X 1} ≤
+      RingHom.ker (constantCoeff : MvPolynomial (Fin 2) F →+* F) := by
+  rw [Ideal.span_le]
+  intro x hx
+  rcases hx with h | h
+  · rw [h, SetLike.mem_coe, RingHom.mem_ker, constantCoeff_X]
+  · rw [Set.mem_singleton_iff] at h
+    rw [h, SetLike.mem_coe, RingHom.mem_ker, constantCoeff_X]
+
+/-- **Boundary theorem.** In `F[x, y]` (for a nontrivial commutative ring `F`)
+the constant polynomial `1` is *not* a linear combination of `X` and `Y`, even
+though `X` and `Y` are coprime.  This is the concrete obstruction stopping the
+Bézout identity from extending to genuine multivariate polynomial rings. -/
+theorem one_not_mem_span_X_Y {F : Type*} [CommRing F] [Nontrivial F] :
+    (1 : MvPolynomial (Fin 2) F) ∉ Ideal.span {X (0 : Fin 2), X 1} := by
+  intro h
+  have hker : (1 : MvPolynomial (Fin 2) F) ∈
+      RingHom.ker (constantCoeff : MvPolynomial (Fin 2) F →+* F) :=
+    span_X_le_ker_constantCoeff h
+  rw [RingHom.mem_ker, map_one] at hker
+  exact one_ne_zero hker
+
+/-- Restated as the impossibility of the two-generator Bézout identity in
+`F[x, y]`: there are no cofactors `f, g` with `f * X + g * Y = 1`.  Contrast
+with `multivariate_bezout_polynomial`, which *does* hold in the univariate ring
+`F[X]`. -/
+theorem no_bezout_identity_X_Y {F : Type*} [CommRing F] [Nontrivial F] :
+    ¬ ∃ f g : MvPolynomial (Fin 2) F, f * X 0 + g * X 1 = 1 := by
+  rintro ⟨f, g, hfg⟩
+  refine one_not_mem_span_X_Y (F := F) ?_
+  rw [← hfg]
+  exact Ideal.add_mem _
+    (Ideal.mul_mem_left _ _ (Ideal.subset_span (by simp)))
+    (Ideal.mul_mem_left _ _ (Ideal.subset_span (by simp)))
 
 end BezoutIdentityOQ02OQ02OQ01OQ02

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,245 @@
+{
+  "id": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+  "title": "Multivariate Bézout Identity in Bézout Rings",
+  "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+  "description": "Answers open question 2 of the constructive divisibility algorithm: can the algorithm be extended to multivariate Bézout identities in polynomial rings? Answer: YES over any Bézout ring, and the answer is exactly that wide. The two-element identity u*a+v*b=gcd a b generalizes to a finite family a : ι → R over any IsBezout commutative ring: there is a gcd d = familyGcd a with coefficients u : ι → R such that ∑ i, u i * a i = d, d divides every a i, and d is greatest. The proof is structural — the span of the finite range is principal, and membership of its generator yields the coefficient vector. This specializes verbatim to F[X] (Euclidean ⇒ PID ⇒ Bézout), to ℤ, and to any PID. The sharp boundary (Part VII): genuine multivariate rings F[x,y] are NOT Bézout — 1 is not a linear combination of X and Y (every element of (X,Y) has zero constant term), so no Bézout identity f*X+g*Y=1 exists there. 12 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ02.lean",
+    "namespace": "BezoutIdentityOQ02OQ02OQ01OQ02",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MvPolynomial"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 260,
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "openQuestion": {
+    "id": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "parentId": "bezout-identity-oq-02-oq-02-oq-01",
+    "question": "Can the algorithm be extended to multivariate Bézout identities in polynomial rings?",
+    "answer": "Yes over any Bézout ring, and no wider. For a finite family a : ι → R over an IsBezout commutative ring, the ideal spanned by the range of a is finitely generated, hence principal; its generator familyGcd a is a greatest common divisor of the family and lies in the span, which produces an explicit coefficient vector u with ∑ i, u i * a i = familyGcd a (exists_bezout_coeffs / multivariate_bezout). Because a univariate polynomial ring F[X] over a field is Euclidean — hence a PID, hence Bézout — the identity specializes directly to the polynomial setting (multivariate_bezout_polynomial), and likewise to ℤ. The affirmative answer is exactly as wide as the Bézout hypothesis: genuine multivariate polynomial rings F[x₁,…,xₙ] with n ≥ 2 are not Bézout, and we exhibit the obstruction in F[x,y] — the constant polynomial 1 is not a linear combination of X and Y (one_not_mem_span_X_Y), so no Bézout identity f*X+g*Y=1 exists (no_bezout_identity_X_Y), because every element of the ideal (X,Y) has zero constant term. 0 axioms, 0 sorries."
+  },
+  "highlights": [
+    "Finite ('multivariate') Bézout: for any family a : ι → R over a Bézout ring, ∑ i, u i * a i = familyGcd a",
+    "familyGcd a divides every a i and is divisible by every common divisor — a genuine gcd, unique up to units",
+    "Structural, hypothesis-light proof: no integral-domain assumption; principal-span ⇒ coefficient vector",
+    "Specializes verbatim to univariate F[X] (Euclidean ⇒ PID ⇒ Bézout) and to ℤ",
+    "Sharp boundary: in F[x,y], 1 ∉ (X,Y), so the Bézout identity provably fails past one variable"
+  ],
+  "implications": [
+    {
+      "statement": "Over any IsBezout commutative ring, a finite family admits a gcd expressible as an explicit linear combination of its members",
+      "type": "theorem"
+    },
+    {
+      "statement": "Multivariate Bézout holds verbatim in univariate polynomial rings F[X] over a field",
+      "type": "corollary"
+    },
+    {
+      "statement": "In F[x,y] there are no cofactors f, g with f*X + g*Y = 1; the Bézout identity fails past one variable",
+      "type": "theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The classical Bézout identity writes the gcd of two integers as an integer-linear combination, and the extended Euclidean algorithm computes the coefficients. The parent problem turned this into a constructive divisibility algorithm over ℤ and asked, as its second open question, whether the construction extends to 'multivariate Bézout identities in polynomial rings'. Two distinct generalizations hide in that phrase: more generators (finitely many elements instead of two), and more variables (polynomial rings in several indeterminates). The first is a genuine and clean extension; the second is exactly where the theory breaks. The correct level of generality for the positive result is the Bézout ring — a commutative ring in which every finitely generated ideal is principal — which subsumes ℤ, every PID, and every univariate polynomial ring over a field, without any Euclidean or integral-domain machinery.",
+    "problemStatement": "Let R be a commutative ring in which every finitely generated ideal is principal (an IsBezout ring), and let a : ι → R be a finite family. Produce a greatest common divisor d of the family together with coefficients u : ι → R such that ∑ i, u i * a i = d, d ∣ a i for all i, and d is divisible by every common divisor. Determine how far this extends to polynomial rings, and identify precisely where it fails.",
+    "proofStrategy": "Positive result (Parts I–V): the ideal Ideal.span (Set.range a) is finitely generated because the index type is finite, hence principal by the Bézout hypothesis (IsBezout.isPrincipal_of_FG). Its generator familyGcd a lies in the span, and Submodule.mem_span_range_iff_exists_fun converts that membership into an explicit coefficient function u with ∑ i, u i • a i = familyGcd a. Divisibility of each a i by the generator comes from a i ∈ span {familyGcd a}; the universal property (any common divisor divides familyGcd a) follows by dividing through the linear combination (Finset.dvd_sum). Specialization to F[X] and ℤ is immediate since both are Bézout. Sharp boundary (Part VII): in F[x,y] = MvPolynomial (Fin 2) F, the generating pair {X 0, X 1} lies in the kernel of the constant-coefficient homomorphism, so the ideal (X,Y) does too; since constantCoeff 1 = 1 ≠ 0, 1 ∉ (X,Y), ruling out any Bézout identity f*X + g*Y = 1.",
+    "keyInsights": [
+      "The right hypothesis is IsBezout, not EuclideanDomain or PID: 'finitely generated ideals are principal' is exactly what the multivariate identity needs, and it costs no integral-domain assumption. Both divisibility and the gcd universal property follow from the linear combination itself.",
+      "Finiteness of the index type is the only structural input on the family: Submodule.fg_span (Set.finite_range a) makes the span finitely generated, which is what the Bézout hypothesis consumes to yield principality.",
+      "Submodule.mem_span_range_iff_exists_fun is the bridge from an abstract 'd is in the span' to a concrete coefficient vector, turning a structural existence statement into the explicit Bézout combination ∑ i, u i * a i = d.",
+      "Univariate F[X] satisfies the hypothesis for free (Euclidean ⇒ PID ⇒ Bézout), so the polynomial case in the open question needs no separate proof — it is a one-line specialization.",
+      "The boundary is genuinely at one variable: F[x,y] is not Bézout, and the constant-coefficient homomorphism gives a one-line certificate that 1 ∉ (X,Y). Coprime elements need not satisfy a Bézout identity once the ring stops being Bézout — this is the precise sense in which the extended Euclidean algorithm does not survive multiple variables."
+    ],
+    "prerequisites": [
+      "Parent: constructive divisibility algorithm via Bézout coefficients (bezout-identity-oq-02-oq-02-oq-01)",
+      "IsBezout typeclass and IsBezout.isPrincipal_of_FG",
+      "Submodule.IsPrincipal.generator / span_singleton_generator; Ideal.mem_span_singleton",
+      "Submodule.mem_span_range_iff_exists_fun (span membership ⇔ explicit coefficient vector)",
+      "MvPolynomial.constantCoeff and constantCoeff_X; Ideal.span_le, RingHom.mem_ker"
+    ]
+  },
+  "sections": [
+    {
+      "id": "principal-span",
+      "title": "The Ideal Generated by a Finite Family is Principal",
+      "startLine": 55,
+      "endLine": 85,
+      "summary": "familyGcd a is defined as the generator of Ideal.span (Set.range a), which is principal because the finite range makes the span finitely generated (IsBezout.isPrincipal_of_FG). span_range_eq_span_familyGcd and familyGcd_mem_span record that the span equals span {familyGcd a} and that the generator lies inside it.",
+      "mathContext": "Over a Bézout ring, a finitely generated ideal is principal; the generator of span (range a) is the sought gcd."
+    },
+    {
+      "id": "bezout-identity",
+      "title": "The Multivariate Bézout Identity",
+      "startLine": 86,
+      "endLine": 104,
+      "summary": "exists_bezout_coeffs: familyGcd a is an explicit R-linear combination ∑ i, u i * a i, obtained from membership of the generator in the span via Submodule.mem_span_range_iff_exists_fun.",
+      "mathContext": "d ∈ span (range a) ⇔ ∃ u, ∑ i, u i • a i = d; smul_eq_mul turns • into *."
+    },
+    {
+      "id": "divisibility",
+      "title": "Divisibility Properties of familyGcd",
+      "startLine": 105,
+      "endLine": 127,
+      "summary": "familyGcd_dvd: the generator divides every a i (from a i ∈ span {familyGcd a}). dvd_familyGcd: any common divisor divides the generator, by dividing through the Bézout combination (Finset.dvd_sum).",
+      "mathContext": "a i ∈ span {d} ⇔ d ∣ a i; c ∣ each a i ⇒ c ∣ ∑ u i * a i = d."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Assembled Multivariate Bézout Theorem",
+      "startLine": 128,
+      "endLine": 162,
+      "summary": "multivariate_bezout packages the identity and both divisibility properties into one statement over an arbitrary Bézout ring. gcd_witness_unique shows any two gcd witnesses are associated (unique up to units).",
+      "mathContext": "∃ d u, (∑ i, u i * a i = d) ∧ (∀ i, d ∣ a i) ∧ (∀ c, (∀ i, c ∣ a i) → c ∣ d)."
+    },
+    {
+      "id": "specialization",
+      "title": "Specialization to Polynomial Rings and ℤ",
+      "startLine": 163,
+      "endLine": 190,
+      "summary": "multivariate_bezout_polynomial (over F[X] for a field F) and multivariate_bezout_int are one-line specializations of the main theorem, since F[X] and ℤ are Bézout.",
+      "mathContext": "F[X] Euclidean ⇒ PID ⇒ Bézout; ℤ is a PID."
+    },
+    {
+      "id": "computational",
+      "title": "Concrete Three-Element Identities",
+      "startLine": 191,
+      "endLine": 209,
+      "summary": "Worked examples: 1·6 + (-2)·10 + 1·15 = 1 and 1·4 + (-2)·6 + 1·9 = 1 over ℤ, and (-1)·X + 1·(X+1) = 1 over ℚ[X], exhibiting explicit Bézout combinations by direct calculation.",
+      "mathContext": "The abstract generator is noncomputable, but concrete combinations are verified by norm_num / ring."
+    },
+    {
+      "id": "boundary",
+      "title": "The Sharp Boundary — Genuine Multivariate Rings are not Bézout",
+      "startLine": 210,
+      "endLine": 260,
+      "summary": "span_X_le_ker_constantCoeff: {X 0, X 1} ⊆ ker constantCoeff, so (X,Y) ≤ ker. one_not_mem_span_X_Y: 1 ∉ (X,Y) since constantCoeff 1 = 1 ≠ 0. no_bezout_identity_X_Y: there are no cofactors f, g with f*X + g*Y = 1, so the Bézout identity fails in F[x,y].",
+      "mathContext": "Every element of (X,Y) has zero constant term; 1 does not, so 1 ∉ (X,Y) and F[x,y] is not Bézout."
+    }
+  ],
+  "conclusion": {
+    "summary": "The constructive Bézout identity extends from two elements to any finite family, and from ℤ to any Bézout ring — in particular to univariate polynomial rings F[X] over a field. The gcd is the generator of the principal span of the family and is an explicit linear combination of its members, dividing every member and divisible by every common divisor. This affirmative answer is exactly as wide as the Bézout hypothesis: genuine multivariate polynomial rings F[x₁,…,xₙ] with n ≥ 2 are not Bézout, and in F[x,y] the constant polynomial 1 is not a linear combination of X and Y, so no Bézout identity f*X+g*Y=1 exists. 12 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The 'multivariate' in the parent's open question splits into two: more generators (a genuine, clean extension over any Bézout ring) and more variables (where the theory fails). Identifying IsBezout as the exact hypothesis clarifies that the constructive Bézout phenomenon is about principal finitely generated ideals, not about the Euclidean algorithm per se, and that it terminates precisely at univariate polynomial rings — the constant-coefficient obstruction in F[x,y] is the concrete witness of the failure.",
+    "openQuestions": [
+      "Over a Bézout ring that is not a UFD, describe the gcd's non-uniqueness beyond 'up to units' and its interaction with the coefficient vector.",
+      "For F[x,y], quantify how far 1 is from (X,Y): describe the quotient F[x,y]/(X,Y) ≅ F and the failure of coprimality-implies-Bézout via the Nullstellensatz."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-02-oq-01",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-02-oq-01-oq-04",
+      "relationship": "related"
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-02",
+      "relationship": "related"
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-02",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ02.lean",
+    "tags": [
+      "bezout-identity",
+      "gcd",
+      "principal-ideal",
+      "polynomial-rings",
+      "commutative-algebra",
+      "constructive-algebra",
+      "open-question"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 260,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "originalContributions": [
+      "familyGcd: the gcd of a finite family over a Bézout ring as the generator of the principal span of its range",
+      "exists_bezout_coeffs / multivariate_bezout: the finite ('multivariate') Bézout identity ∑ i, u i * a i = familyGcd a over any IsBezout ring, with full gcd universal property",
+      "multivariate_bezout_polynomial / multivariate_bezout_int: one-line specializations to F[X] and ℤ",
+      "gcd_witness_unique: any two gcd witnesses are associated (unique up to units)",
+      "one_not_mem_span_X_Y / no_bezout_identity_X_Y: the sharp boundary — F[x,y] is not Bézout, so f*X+g*Y=1 has no solution"
+    ],
+    "proofStrategy": "Take familyGcd a to be the generator of the principal span of the finite range; extract the coefficient vector via Submodule.mem_span_range_iff_exists_fun and derive both divisibility directions. Specialize to F[X] and ℤ for free. Prove the boundary by the constant-coefficient homomorphism: (X,Y) ≤ ker constantCoeff but constantCoeff 1 = 1 ≠ 0, so 1 ∉ (X,Y).",
+    "openQuestions": [
+      "Describe gcd non-uniqueness over Bézout rings that are not UFDs",
+      "Quantify the failure of coprimality-implies-Bézout in F[x,y] via the Nullstellensatz"
+    ],
+    "sections": [
+      {
+        "title": "Principal Span and the Multivariate Identity",
+        "content": "familyGcd, span_range_eq_span_familyGcd, familyGcd_mem_span, exists_bezout_coeffs.",
+        "startLine": 55,
+        "endLine": 104,
+        "theorems": [
+          "span_range_eq_span_familyGcd",
+          "familyGcd_mem_span",
+          "exists_bezout_coeffs"
+        ]
+      },
+      {
+        "title": "Divisibility, Main Theorem, Specializations",
+        "content": "familyGcd_dvd, dvd_familyGcd, multivariate_bezout, gcd_witness_unique, multivariate_bezout_polynomial, multivariate_bezout_int.",
+        "startLine": 105,
+        "endLine": 190,
+        "theorems": [
+          "familyGcd_dvd",
+          "dvd_familyGcd",
+          "multivariate_bezout",
+          "gcd_witness_unique",
+          "multivariate_bezout_polynomial",
+          "multivariate_bezout_int"
+        ]
+      },
+      {
+        "title": "The Sharp Boundary in F[x,y]",
+        "content": "span_X_le_ker_constantCoeff, one_not_mem_span_X_Y, no_bezout_identity_X_Y.",
+        "startLine": 210,
+        "endLine": 260,
+        "theorems": [
+          "span_X_le_ker_constantCoeff",
+          "one_not_mem_span_X_Y",
+          "no_bezout_identity_X_Y"
+        ]
+      }
+    ],
+    "mathContext": {
+      "field": "Commutative Algebra / Constructive Ring Theory",
+      "keyTheorem": "Over any Bézout ring, a finite family admits a gcd expressible as an explicit linear combination of its members; this extends to F[X] but fails in genuine multivariate rings F[x,y], where 1 ∉ (X,Y).",
+      "historicalBackground": "Bézout's identity and the extended Euclidean algorithm are foundational to computational number theory. The Bézout ring abstraction (finitely generated ideals are principal) captures exactly the setting where the identity survives, subsuming ℤ, PIDs, and univariate polynomial rings over fields. Multivariate polynomial rings, being non-principal for n ≥ 2, are the natural place the theory breaks — the failure is quantified in general by Hilbert's Nullstellensatz.",
+      "significance": "Pinpoints IsBezout as the exact hypothesis for the multivariate Bézout identity, gives a hypothesis-light structural proof requiring no integral domain, and exhibits a one-line certificate (the constant-coefficient homomorphism) that the identity cannot extend past one variable."
+    }
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "D. S. Dummit, R. M. Foote",
+      "title": "Abstract Algebra",
+      "year": 2004,
+      "venue": "Wiley",
+      "note": "Bézout domains, PIDs, and the ideal-theoretic view of gcd."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides IsBezout, Submodule.IsPrincipal, Submodule.mem_span_range_iff_exists_fun, MvPolynomial.constantCoeff, and the EuclideanDomain/PID/Bézout instance chain underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Research session for **bezout-identity-oq-02-oq-02-oq-01-oq-02** (open question 2 of the constructive divisibility algorithm: *"Can the algorithm be extended to multivariate Bézout identities in polynomial rings?"*).

Prior PR #32573 merged the Lean file to `main` as **UNVERIFIED / build-blocked** and never added a gallery entry. This PR closes both gaps and completes the mathematical answer.

## Progress
- **Fixes the build.** The only error was a stale identifier `mem_span_range_iff_exists_fun`; corrected to `Submodule.mem_span_range_iff_exists_fun`. The file now compiles clean.
- **Verified 0-axiom.** `#print axioms` on `multivariate_bezout`, `multivariate_bezout_polynomial`, `one_not_mem_span_X_Y`, `no_bezout_identity_X_Y` shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`. 0 sorries.
- **Adds the sharp boundary (Part VII)** the original "Answer: YES" framing omitted: genuine multivariate rings `F[x,y]` are **not** Bézout. Proves `1 ∉ (X, Y)` via the constant-coefficient homomorphism (`one_not_mem_span_X_Y`), hence no Bézout identity `f*X + g*Y = 1` exists (`no_bezout_identity_X_Y`). This makes the answer honest and two-sided: the affirmative result is *exactly* as wide as the `IsBezout` hypothesis.
- **Creates the missing gallery entry** (`src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/meta.json`), modeled on sibling `-oq-04`.

## Files
- `proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ02.lean` (build fix + Part VII; 260L, 12 thm, 1 def)
- `src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/meta.json` (new)

## Findings
- The right hypothesis for the *positive* multivariate result is `IsBezout` (finitely generated ideals are principal) — no Euclidean or integral-domain assumption needed. Univariate `F[X]` and `ℤ` are one-line specializations.
- The theory terminates precisely at one variable: the constant-coefficient obstruction in `F[x,y]` is a one-line certificate that coprimality no longer implies a Bézout identity.

## Status
**Outcome**: completed (VERIFIED, 0-axiom, 0-sorry). Build verified via `lake env lean` against the cached Mathlib olean.
**Next Steps**: none required; two shallow follow-ups recorded in the entry's `openQuestions` (Nullstellensatz-flavored quantification of the `F[x,y]` failure).

🤖 Generated by researcher-11