### PR TITLE
Fix: remove dangling crossReference in prob-method-alteration-oq-03

### DIFF
--- a/src/data/proofs/prob-method-alteration-oq-03/meta.json
+++ b/src/data/proofs/prob-method-alteration-oq-03/meta.json
@@ -187,11 +187,6 @@
       "proofId": "prob-method-alteration",
       "relationship": "parent",
       "description": "Alteration Method (Probabilistic Method) — states the Caro–Wei bound α(G) ≥ n²/(2m+n) as the axiom caro_wei (in its OQ-02 companion) to drive the triangle-free improvement; this entry proves that exact statement, discharging the axiom."
-    },
-    {
-      "proofId": "prob-method-alteration-oq-02",
-      "relationship": "sibling",
-      "description": "The triangle-free improvement α(G) ≥ 2n/(n+2), whose derivation consumes the caro_wei axiom this entry proves; the two together turn that improvement chain's Caro–Wei input into a theorem."
     }
   ]
 }


### PR DESCRIPTION
## Fix

Remove the dangling "Related Proofs" crossReference in `prob-method-alteration-oq-03` that pointed to the nonexistent gallery entry `prob-method-alteration-oq-02`.

## Evidence

**Before**: `crossReferences` contained a `sibling` entry with `proofId: "prob-method-alteration-oq-02"`. `ProofConclusion.tsx` renders each crossReference as `<Link to={/proof/${proofId ?? targetId}}>`, so this produced a visible **404 link** — no `src/data/proofs/prob-method-alteration-oq-02/` directory exists (only `prob-method-alteration` and `prob-method-alteration-oq-03`).

**After**: the dangling reference is removed. Its content — the triangle-free improvement α(G) ≥ 2n/(n+2) and the `caro_wei` axiom — lives in `ProbMethodAlterationOQ02.lean`, which is an **`additionalFiles` component of the parent `prob-method-alteration` entry**, not a standalone entry. Creating a separate `-oq-02` entry would duplicate a file the parent already owns. The surviving `parent` crossReference already links to `prob-method-alteration` and explains the relationship ("...as the axiom caro_wei in its OQ-02 companion..."), so the removed reference was redundant as well as broken.

Scope: metadata-only, one-line JSON removal; validated as well-formed JSON. Only dangling 404 crossReference found in a full-gallery scan.

---
Automated fix by lean-mechanic agent.