### PR TITLE
Enrich angle-trisection-oq-01-oq-02: add annotations for the Gauss–Wantzel criterion

### DIFF
--- a/src/data/proofs/angle-trisection-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-02/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ann-fermat-def",
+    "proofId": "angle-trisection-oq-01-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 72
+    },
+    "type": "definition",
+    "title": "Fermat Primes and the Power-of-Two Test",
+    "content": "The building blocks. `IsFermatPrime p` is `p.Prime ∧ ∃ m, p = fermatNumber m`, where fermatNumber m = 2^(2^m)+1 — the known Fermat primes are 3, 5, 17, 257, 65537 (m = 0..4). `isTwoPow_iff` is the reusable arithmetic pivot: a positive natural is a power of two iff its only prime divisor is 2 (forward: a prime dividing 2^k must be 2; backward: Nat.eq_prime_pow_of_unique_prime_dvd). `IsFermatPrime.ne_two` records that Fermat primes are odd (fermatNumber m > 2), and `IsFermatPrime.totient_isTwoPow` computes φ(p) = p − 1 = 2^(2^m), manifestly a power of two. This last fact is the 'easy direction' of the local criterion below.",
+    "mathContext": "Fermat prime $p = F_m = 2^{2^m}+1$. Power-of-two test: for $m\\ne 0$, $(\\exists k,\\ m=2^k) \\Leftrightarrow (\\forall q\\ \\text{prime},\\ q\\mid m \\Rightarrow q=2)$. For a Fermat prime, $\\varphi(p)=p-1=2^{2^m}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fermat prime", "Euler totient φ", "power of two", "unique prime factor"],
+    "prerequisites": ["prime factorization", "Euler's totient function", "Fermat numbers"]
+  },
+  {
+    "id": "ann-local-criterion",
+    "proofId": "angle-trisection-oq-01-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 93
+    },
+    "type": "insight",
+    "title": "Local Criterion: φ(p) Is a Power of Two ⟺ p Is Fermat",
+    "content": "`totient_odd_prime_isTwoPow_iff` is the heart of the number theory: for an odd prime p, φ(p) = p − 1 is a power of two exactly when p is a Fermat prime. The nontrivial forward direction writes p − 1 = 2^k (so p = 2^k + 1 with k ≥ 1) and invokes Mathlib's `Nat.pow_of_pow_add_prime` — the theorem that a prime of the form 2^s + 1 forces s to itself be a power of two. That is precisely why the exponent must be 2^m and p = 2^(2^m) + 1 = fermatNumber m. The reverse direction is just `IsFermatPrime.totient_isTwoPow` from the previous block.",
+    "mathContext": "For odd prime $p$: $(\\exists k,\\ p-1=2^k) \\Leftrightarrow p=2^{2^m}+1$. Key: $2^s+1$ prime $\\Rightarrow s=2^m$ (else $2^s+1$ has an algebraic factor).",
+    "significance": "key",
+    "relatedConcepts": ["Fermat prime characterization", "pow_of_pow_add_prime", "totient of a prime", "constructibility"],
+    "prerequisites": ["totient of primes φ(p)=p−1", "structure of primes 2^s+1"]
+  },
+  {
+    "id": "ann-euler-product",
+    "proofId": "angle-trisection-oq-01-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 98
+    },
+    "type": "technique",
+    "title": "Euler's Totient Product Over Prime Factors",
+    "content": "`totient_eq_prod_primeFactors` rewrites Mathlib's factorization-indexed totient formula into a clean product over the finite set of prime factors: φ(n) = ∏_{p ∣ n} p^(eₚ−1)·(p−1), where eₚ = n.factorization p. This is the multiplicative bridge that lets the global 'φ(n) is a power of two' question be decided factor-by-factor: a product of naturals is a power of two iff each factor is, so the analysis reduces to each p^(eₚ−1)·(p−1).",
+    "mathContext": "$\\varphi(n) = \\prod_{p\\mid n} p^{e_p-1}(p-1)$ where $e_p = v_p(n)$ is the $p$-adic valuation. A product is a power of $2$ iff every factor's only prime divisor is $2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler product formula", "multiplicativity of φ", "prime factorization", "p-adic valuation"],
+    "prerequisites": ["multiplicative functions", "Finset.prod over prime factors"]
+  },
+  {
+    "id": "ann-main-criterion",
+    "proofId": "angle-trisection-oq-01-oq-02",
+    "range": {
+      "startLine": 99,
+      "endLine": 153
+    },
+    "type": "insight",
+    "title": "The Arithmetic Gauss–Wantzel Criterion",
+    "content": "`totient_isTwoPow_iff` is the main theorem: for n ≥ 1, φ(n) is a power of two iff every prime factor p of n is either 2 or a Fermat prime dividing n exactly once (n.factorization p = 1). Equivalently n = 2^a · (product of distinct Fermat primes) — precisely the arithmetic clause of Gauss–Wantzel. The forward direction combines the Euler product with `isTwoPow_iff`: each factor p^(eₚ−1)·(p−1) must have 2 as its sole prime, which forces eₚ = 1 for odd p (else p ∣ p^(eₚ−1) survives) and p − 1 a power of two, i.e. p Fermat (via the local criterion). The reverse direction checks that each admissible factor — 2^(e−1) at p = 2, and (p−1) = 2^(2^m) at a multiplicity-one Fermat prime — contributes only the prime 2.",
+    "mathContext": "$(\\exists k,\\ \\varphi(n)=2^k) \\Leftrightarrow \\forall p\\mid n,\\ p=2 \\vee (\\mathrm{IsFermatPrime}\\,p \\wedge v_p(n)=1)$; i.e. $n = 2^a\\prod_i F_{m_i}$ with distinct Fermat primes.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss–Wantzel theorem", "constructible regular polygon", "distinct Fermat primes", "squarefree odd part"],
+    "prerequisites": ["Euler product for φ", "the local Fermat-prime criterion", "prime factorization"]
+  },
+  {
+    "id": "ann-prime-case",
+    "proofId": "angle-trisection-oq-01-oq-02",
+    "range": {
+      "startLine": 154,
+      "endLine": 172
+    },
+    "type": "insight",
+    "title": "The Prime Case: Constructible Regular p-gons",
+    "content": "`prime_totient_isTwoPow_iff` specializes the criterion to a prime n = p: φ(p) = p − 1 is a power of two iff p = 2 or p is a Fermat prime. This is the cleanest statement of the classical result that a regular p-gon (p prime) is constructible exactly when p is a Fermat prime — the case Gauss famously settled for the 17-gon. The p = 2 branch is handled separately (φ(2) = 1 = 2^0), and the odd case reduces directly to the local criterion.",
+    "mathContext": "For prime $p$: $(\\exists k,\\ \\varphi(p)=2^k) \\Leftrightarrow (p=2 \\vee \\mathrm{IsFermatPrime}\\,p)$. Regular $p$-gon constructible $\\Leftrightarrow p\\in\\{2,3,5,17,257,65537,\\dots\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["regular polygon constructibility", "17-gon", "Fermat prime", "compass and straightedge"],
+    "prerequisites": ["the local Fermat-prime criterion", "totient of a prime"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-01-oq-02` (The Arithmetic Gauss–Wantzel Criterion; quality 41, passes 0).

## Gap addressed
The entry had a rich `meta.json` (sections, conclusion, references) but **no `annotations.json`** — zero inline coverage of the 172-line Lean file.

## What was added
New `annotations.json` with **5 annotations**, each with `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. Fermat primes + the power-of-two test (`IsFermatPrime`, `isTwoPow_iff`)
2. The local criterion: φ(p) is a power of two ⟺ p is Fermat (via `pow_of_pow_add_prime`)
3. Euler's totient product over prime factors
4. The main arithmetic Gauss–Wantzel criterion (`totient_isTwoPow_iff`)
5. The prime case: constructible regular p-gons

All ranges land on real Lean constructs. Passes `pnpm annotations:validate` (no errors for this entry) and `check-meta-size`. `meta.json` unchanged.