### PR TITLE
Enrich Lagrange converse counterexample entry: complete annotation fields (lagrange-theorem-oq-08-oq-01)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-08-oq-01/annotations.json
@@ -8,7 +8,21 @@
     },
     "type": "concept",
     "title": "The Sharpness Witness for the Converse of Lagrange",
-    "content": "Lagrange's theorem is a one-way street: the order of every subgroup divides the order of the group. The tempting converse — *every* divisor $d$ of $|G|$ is the order of some subgroup — is false, and the header names the standard refutation. The alternating group $A_4$ (even permutations of four letters) has order $12$, the number $6$ divides $12$, yet $A_4$ has **no** subgroup of order $6$.\n\nThis entry answers the first open question of the parent Cauchy entry (`lagrange-theorem-oq-08`), which proves the converse *does* hold for prime divisors and asks for the composite counterexample to be certified formally. Together the two entries pin down the sharp boundary: prime divisors always work (Cauchy), prime powers always work (Sylow), but the first genuinely composite divisor $6 = 2\\cdot 3$ can fail.\n\nThe imports are chosen to reuse Mathlib's alternating-group machinery on four letters: `SpecificGroups.Alternating.KleinFour` (which transitively brings the cycle-type cardinality lemmas), `GroupTheory.Index` (index-two facts), and `Perm.Cycle.Type` (the order = lcm-of-cycle-type bridge)."
+    "content": "Lagrange's theorem is a one-way street: the order of every subgroup divides the order of the group. The tempting converse — *every* divisor $d$ of $|G|$ is the order of some subgroup — is false, and the header names the standard refutation. The alternating group $A_4$ (even permutations of four letters) has order $12$, the number $6$ divides $12$, yet $A_4$ has **no** subgroup of order $6$.\n\nThis entry answers the first open question of the parent Cauchy entry (`lagrange-theorem-oq-08`), which proves the converse *does* hold for prime divisors and asks for the composite counterexample to be certified formally. Together the two entries pin down the sharp boundary: prime divisors always work (Cauchy), prime powers always work (Sylow), but the first genuinely composite divisor $6 = 2\\cdot 3$ can fail.\n\nThe imports are chosen to reuse Mathlib's alternating-group machinery on four letters: `SpecificGroups.Alternating.KleinFour` (which transitively brings the cycle-type cardinality lemmas), `GroupTheory.Index` (index-two facts), and `Perm.Cycle.Type` (the order = lcm-of-cycle-type bridge).",
+    "mathContext": "Lagrange: $|H| \\mid |G|$. Naive converse (FALSE): every $d \\mid |G|$ is some subgroup's order. Witness: $A_4$, $|A_4|=12$, $6 \\mid 12$, yet no subgroup of order $6$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "converse of Lagrange",
+      "alternating group A₄",
+      "Cauchy's theorem",
+      "Sylow theorems"
+    ],
+    "prerequisites": [
+      "subgroups and cosets",
+      "order of a group",
+      "alternating/permutation groups"
+    ]
   },
   {
     "id": "ann-card-a4",
@@ -19,7 +33,18 @@
     },
     "type": "technique",
     "title": "|A₄| = 12",
-    "content": "`card_A4` records that $A_4$ has twelve elements. It is a direct instantiation of Mathlib's `alternatingGroup.card_of_card_eq_four`, which states $\\mathrm{Nat.card}\\,(\\text{alternatingGroup } \\alpha) = 12$ whenever the base type has four elements. The only work is supplying the hypothesis $\\mathrm{Nat.card}\\,(\\text{Fin } 4) = 4$, obtained by rewriting through `Nat.card_eq_fintype_card` and `Fintype.card_fin`.\n\nGeneral fact: $|A_n| = n!/2$, so $|A_4| = 24/2 = 12$. This $12 = 2^2 \\cdot 3$ factorization is what makes $6$ a divisor and hence a candidate subgroup order — the whole point of the counterexample."
+    "content": "`card_A4` records that $A_4$ has twelve elements. It is a direct instantiation of Mathlib's `alternatingGroup.card_of_card_eq_four`, which states $\\mathrm{Nat.card}\\,(\\text{alternatingGroup } \\alpha) = 12$ whenever the base type has four elements. The only work is supplying the hypothesis $\\mathrm{Nat.card}\\,(\\text{Fin } 4) = 4$, obtained by rewriting through `Nat.card_eq_fintype_card` and `Fintype.card_fin`.\n\nGeneral fact: $|A_n| = n!/2$, so $|A_4| = 24/2 = 12$. This $12 = 2^2 \\cdot 3$ factorization is what makes $6$ a divisor and hence a candidate subgroup order — the whole point of the counterexample.",
+    "mathContext": "$|A_n| = n!/2$, so $|A_4| = 24/2 = 12 = 2^2\\cdot 3$; the factor $3$ and factor $2^2$ make $6=2\\cdot3$ a divisor.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cardinality of the alternating group",
+      "Nat.card",
+      "factorization 12 = 2²·3"
+    ],
+    "prerequisites": [
+      "finite group order",
+      "alternatingGroup.card_of_card_eq_four"
+    ]
   },
   {
     "id": "ann-count-threecycles",
@@ -30,7 +55,20 @@
     },
     "type": "key-step",
     "title": "Counting the Eight 3-Cycles",
-    "content": "The combinatorial engine of the whole proof. A $3$-cycle in $S_4$ is an even permutation whose cycle type is the singleton multiset $\\{3\\}$. Mathlib's `AlternatingGroup.card_of_cycleType_singleton` evaluates the number of even permutations of cycle type $\\{n\\}$: for odd $n$ it is $(n-1)!\\cdot\\binom{|\\alpha|}{n}$, and for even $n$ it is $0$ (those permutations are odd).\n\nAt $n = 3$, $|\\alpha| = 4$: since $3$ is odd, the count is $(3-1)!\\cdot\\binom{4}{3} = 2!\\cdot 4 = 2\\cdot 4 = 8$. After rewriting `Fintype.card (Fin 4)` to $4$, the residual arithmetic $\\big(\\text{if Odd }3\\text{ then }2!\\cdot\\binom{4}{3}\\text{ else }0\\big) = 8$ is closed by `decide` — a kernel decision procedure over concrete numerals, so no `native_decide` (and hence no `Lean.ofReduceBool`) is involved.\n\nWhy eight matters: an order-$6$ subgroup has only six slots, but the next step forces all eight $3$-cycles into it. Eight $>$ six is the contradiction."
+    "content": "The combinatorial engine of the whole proof. A $3$-cycle in $S_4$ is an even permutation whose cycle type is the singleton multiset $\\{3\\}$. Mathlib's `AlternatingGroup.card_of_cycleType_singleton` evaluates the number of even permutations of cycle type $\\{n\\}$: for odd $n$ it is $(n-1)!\\cdot\\binom{|\\alpha|}{n}$, and for even $n$ it is $0$ (those permutations are odd).\n\nAt $n = 3$, $|\\alpha| = 4$: since $3$ is odd, the count is $(3-1)!\\cdot\\binom{4}{3} = 2!\\cdot 4 = 2\\cdot 4 = 8$. After rewriting `Fintype.card (Fin 4)` to $4$, the residual arithmetic $\\big(\\text{if Odd }3\\text{ then }2!\\cdot\\binom{4}{3}\\text{ else }0\\big) = 8$ is closed by `decide` — a kernel decision procedure over concrete numerals, so no `native_decide` (and hence no `Lean.ofReduceBool`) is involved.\n\nWhy eight matters: an order-$6$ subgroup has only six slots, but the next step forces all eight $3$-cycles into it. Eight $>$ six is the contradiction.",
+    "mathContext": "# of even permutations of cycle type $\\{n\\}$ on $|\\alpha|$ letters $= (n-1)!\\binom{|\\alpha|}{n}$ for odd $n$, else $0$. At $n=3,|\\alpha|=4$: $2!\\cdot\\binom{4}{3}=8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "3-cycles",
+      "cycle type",
+      "counting permutations",
+      "decide (kernel, no native_decide)"
+    ],
+    "prerequisites": [
+      "cycle type of a permutation",
+      "binomial coefficients",
+      "even vs odd permutations"
+    ]
   },
   {
     "id": "ann-index-two",
@@ -41,7 +79,19 @@
     },
     "type": "key-step",
     "title": "An Order-6 Subgroup Would Have Index Two",
-    "content": "The proof of `no_subgroup_card_six` is by contradiction: assume $H \\le A_4$ with $\\mathrm{Nat.card}\\,H = 6$. Mathlib's `Subgroup.card_mul_index` gives the fundamental identity $|H| \\cdot [G:H] = |G|$. Substituting $|H| = 6$ and $|A_4| = 12$ turns this into $6 \\cdot [G:H] = 12$, and `omega` concludes $[G:H] = 2$.\n\nIndex two is the pivotal structural fact. It is what makes $H$ *normal* and, more usefully here, what forces $H$ to contain a large, explicit set of elements — the squares — which the next steps exploit."
+    "content": "The proof of `no_subgroup_card_six` is by contradiction: assume $H \\le A_4$ with $\\mathrm{Nat.card}\\,H = 6$. Mathlib's `Subgroup.card_mul_index` gives the fundamental identity $|H| \\cdot [G:H] = |G|$. Substituting $|H| = 6$ and $|A_4| = 12$ turns this into $6 \\cdot [G:H] = 12$, and `omega` concludes $[G:H] = 2$.\n\nIndex two is the pivotal structural fact. It is what makes $H$ *normal* and, more usefully here, what forces $H$ to contain a large, explicit set of elements — the squares — which the next steps exploit.",
+    "mathContext": "$|H|\\cdot[G:H]=|G|$; with $|H|=6,|G|=12$ gives $[G:H]=2$. Index-two subgroups are normal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subgroup index",
+      "card_mul_index",
+      "index-two subgroups",
+      "normal subgroups"
+    ],
+    "prerequisites": [
+      "Lagrange's index identity",
+      "proof by contradiction"
+    ]
   },
   {
     "id": "ann-squares-argument",
@@ -52,7 +102,20 @@
     },
     "type": "key-step",
     "title": "Every 3-Cycle Is a Square, So H Overflows",
-    "content": "This block establishes $8 \\le \\mathrm{Nat.card}\\,H$, contradicting $|H| = 6$. It shows the eight $3$-cycles all lie in $H$ by proving each one is a square:\n\n1. **Squares live in an index-two subgroup.** `Subgroup.sq_mem_of_index_two` gives $g^2 \\in H$ for *every* $g$ — because in the two-element quotient $G/H$ the image of any $g^2$ is the identity.\n\n2. **A 3-cycle is a square of itself.** For a $3$-cycle $g$, `Equiv.Perm.lcm_cycleType` gives $\\mathrm{orderOf}\\,g = \\mathrm{lcm}\\,\\{3\\} = 3$, so $g^3 = 1$. Then $g = g^4 = (g^2)^2$ (the `calc` block: $(g^2)^2 = g^{2\\cdot 2} = g^3\\cdot g = 1\\cdot g = g$). Since $g^2 \\in H$ and $H$ is closed under powers, $g = (g^2)^2 \\in H$.\n\n3. **Counting collision.** Every $3$-cycle is therefore in $H$, so the eight-element set of $3$-cycles injects into $H$. Formally the $3$-cycle filter is a subset of $H$'s membership filter, and `Finset.card_le_card` combined with `card_threeCycles` yields $8 \\le |H|$.\n\nWith $|H| = 6$, the final `omega` closes $8 \\le 6 \\to \\bot$. The subtlety handled by `push_cast`/`SetLike.coe_eq_coe` is transporting $g^3 = 1$ between the ambient permutation group and the subgroup $\\uparrow(\\text{alternatingGroup})$: the underlying permutation having cube $1$ is equivalent to the group element having cube $1$."
+    "content": "This block establishes $8 \\le \\mathrm{Nat.card}\\,H$, contradicting $|H| = 6$. It shows the eight $3$-cycles all lie in $H$ by proving each one is a square:\n\n1. **Squares live in an index-two subgroup.** `Subgroup.sq_mem_of_index_two` gives $g^2 \\in H$ for *every* $g$ — because in the two-element quotient $G/H$ the image of any $g^2$ is the identity.\n\n2. **A 3-cycle is a square of itself.** For a $3$-cycle $g$, `Equiv.Perm.lcm_cycleType` gives $\\mathrm{orderOf}\\,g = \\mathrm{lcm}\\,\\{3\\} = 3$, so $g^3 = 1$. Then $g = g^4 = (g^2)^2$ (the `calc` block: $(g^2)^2 = g^{2\\cdot 2} = g^3\\cdot g = 1\\cdot g = g$). Since $g^2 \\in H$ and $H$ is closed under powers, $g = (g^2)^2 \\in H$.\n\n3. **Counting collision.** Every $3$-cycle is therefore in $H$, so the eight-element set of $3$-cycles injects into $H$. Formally the $3$-cycle filter is a subset of $H$'s membership filter, and `Finset.card_le_card` combined with `card_threeCycles` yields $8 \\le |H|$.\n\nWith $|H| = 6$, the final `omega` closes $8 \\le 6 \\to \\bot$. The subtlety handled by `push_cast`/`SetLike.coe_eq_coe` is transporting $g^3 = 1$ between the ambient permutation group and the subgroup $\\uparrow(\\text{alternatingGroup})$: the underlying permutation having cube $1$ is equivalent to the group element having cube $1$.",
+    "mathContext": "Index two $\\Rightarrow g^2\\in H$ for all $g$. A 3-cycle $g$ has $\\mathrm{ord}\\,g=\\mathrm{lcm}\\{3\\}=3$, so $g=g^4=(g^2)^2\\in H$. All $8$ three-cycles lie in $H$, so $8\\le|H|=6$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squares in an index-two subgroup",
+      "order = lcm of cycle type",
+      "closure under powers",
+      "counting injection"
+    ],
+    "prerequisites": [
+      "quotient group G/H",
+      "orderOf and powers",
+      "Finset.card_le_card"
+    ]
   },
   {
     "id": "ann-packaging",
@@ -63,6 +126,17 @@
     },
     "type": "concept",
     "title": "Packaging: The Naive Converse, Refuted",
-    "content": "`six_dvd_card_A4` records the arithmetic side of the counterexample, $6 \\mid |A_4|$, via $6 \\mid 12$. `converse_lagrange_fails` then bundles everything into a single existential statement: there is a divisor $d$ of $|A_4|$ (namely $d = 6$) for which no subgroup of $A_4$ has order $d$.\n\nThis is exactly the logical negation of the naive converse of Lagrange ('for every divisor $d$ of $|G|$ there is a subgroup of order $d$'), stated in a form that composes with the parent entry: Cauchy supplies the divisors for which the converse holds, and this witness supplies one for which it does not."
+    "content": "`six_dvd_card_A4` records the arithmetic side of the counterexample, $6 \\mid |A_4|$, via $6 \\mid 12$. `converse_lagrange_fails` then bundles everything into a single existential statement: there is a divisor $d$ of $|A_4|$ (namely $d = 6$) for which no subgroup of $A_4$ has order $d$.\n\nThis is exactly the logical negation of the naive converse of Lagrange ('for every divisor $d$ of $|G|$ there is a subgroup of order $d$'), stated in a form that composes with the parent entry: Cauchy supplies the divisors for which the converse holds, and this witness supplies one for which it does not.",
+    "mathContext": "$6\\mid|A_4|$ and $\\neg\\exists H\\le A_4,\\ |H|=6$; i.e. $\\exists d\\mid|G|$ with no subgroup of order $d$ — the negation of the naive converse.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "existential counterexample",
+      "negation of the converse",
+      "composition with Cauchy's theorem"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "existential statements in Lean"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-08-oq-01` (A₄ has no subgroup of order 6 — the converse of Lagrange fails).

**Gap:** the 6 existing annotations carried only `type`/`title`/`content` — **no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**.

**Added** all four fields to every annotation, meeting the quality target. LaTeX `mathContext` distilled from each block: |A₄|=12=2²·3, the 8 three-cycles (2!·C(4,3)), the index-two identity |H|·[G:H]=|G|, the squares-overflow g=(g²)² ⇒ 8≤|H|=6 ⊥, and the packaged existential counterexample.

Existing prose preserved verbatim. `annotations:validate` reports 0 errors for this slug.