### PR TITLE
research(mantel-theorem-oq-01-oq-02): handshake counting bridge — near-extremal triangle-free graphs have O(εn) low-degree vertices [VERIFIED]

### DIFF
--- a/proofs/Proofs/MantelTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/MantelTheoremOQ01OQ02.lean
@@ -1,0 +1,264 @@
+/-
+Copyright (c) 2024-2026 lean-genius contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# A handshake-counting bridge: near-extremal triangle-free graphs have few low-degree vertices
+
+This file formalizes a *stability* step used in the Andrásfai–Erdős–Sós circle of ideas:
+if a triangle-free graph on `n` vertices is within `ε n²` edges of the Mantel maximum `n²/4`,
+then only `O(ε n)` of its vertices have degree `≤ 2n/5`.
+
+The Andrásfai–Erdős–Sós theorem states that a triangle-free graph with minimum degree
+`> 2n/5` is bipartite. Turán-stability arguments frequently need to *pass from an edge-count
+hypothesis to a min-degree hypothesis*: a graph with almost `n²/4` edges cannot have many
+vertices far below the average degree `n/2`. This file makes that passage precise and fully
+machine-checked.
+
+## Proof outline
+
+The argument is a second-moment (Chebyshev) estimate on the degree sequence `d(v)`:
+
+1. **Handshake identity** (`SimpleGraph.sum_degrees_eq_twice_card_edges`):
+   `∑ d(v) = 2e`, so the average degree is `2e/n`.
+
+2. **Triangle-free second-moment bound** (`sum_sq_degree_le_card_mul_card_edge`):
+   for a triangle-free graph, `∑ d(v)² ≤ n · e`. This is where triangle-freeness enters: for
+   an edge `uv` the neighbourhoods `N(u), N(v)` are disjoint, so `d(u) + d(v) ≤ n`; summing
+   this over all darts gives `2 ∑ d(v)² ≤ 2 n e`.
+
+3. **Variance bound**: combining (1) and (2), `∑ (d(v) − 2e/n)² ≤ n e − 4e²/n`, and when
+   `e ≥ n²/4 − ε n²` the right-hand side is `≤ ε n³`.
+
+4. **Chebyshev counting** (`abstract_low_value_count_le`): any value that is a fixed distance
+   below the mean contributes at least that squared distance to the variance, so the number of
+   `v` with `d(v) ≤ 2n/5` is `≤ (ε n³) / (n/20)² = 400 ε n`.
+
+The abstract counting step is isolated as a self-contained real-analysis lemma so it can be
+reused; the graph-theoretic input is the triangle-free second-moment bound.
+-/
+
+open Finset
+
+namespace MantelBridge
+
+/-! ### Step 4 as a standalone lemma: a Chebyshev / second-moment counting bound -/
+
+/-- **Second-moment counting bound.** Let `d : ι → ℝ` be any real-valued function on a finite
+index type with `n` elements and total `T = ∑ d i`, hence mean `T / n`. Suppose the sum of
+squares is bounded, `∑ (d i)² ≤ Q`. Then for any threshold `m` strictly below the mean, the
+number of indices with `d i ≤ m` is controlled by the "variance budget" `Q − T²/n`:
+
+`#{i | d i ≤ m} · (T/n − m)² ≤ Q − T²/n`.
+
+This is Chebyshev's inequality in counting form: values sitting a fixed distance `T/n − m`
+below the mean each spend at least `(T/n − m)²` of the total variance, so there cannot be too
+many of them. -/
+theorem abstract_low_value_count_le {ι : Type*} [Fintype ι] (d : ι → ℝ) (Q : ℝ) (m : ℝ)
+    (hn : 0 < Fintype.card ι)
+    (hm : m ≤ (∑ i, d i) / Fintype.card ι)
+    (hQ : ∑ i, (d i) ^ 2 ≤ Q) :
+    (((univ.filter fun i => d i ≤ m).card : ℝ)) * ((∑ i, d i) / Fintype.card ι - m) ^ 2
+      ≤ Q - (∑ i, d i) ^ 2 / Fintype.card ι := by
+  classical
+  set n : ℝ := (Fintype.card ι : ℝ) with hn_def
+  have hn0 : (0 : ℝ) < n := by rw [hn_def]; exact_mod_cast hn
+  have hn0' : n ≠ 0 := ne_of_gt hn0
+  set T : ℝ := ∑ i, d i with hT_def
+  set μ : ℝ := T / n with hμ_def
+  set L : Finset ι := univ.filter fun i => d i ≤ m with hL_def
+  -- General variance identity for any constant `c`.
+  have hgen : ∀ c : ℝ, ∑ i, (d i - c) ^ 2
+      = (∑ i, (d i) ^ 2) - 2 * c * T + n * c ^ 2 := by
+    intro c
+    rw [Finset.sum_congr rfl (fun i _ => (by ring :
+      (d i - c) ^ 2 = (d i) ^ 2 - 2 * c * d i + c ^ 2))]
+    rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, ← Finset.mul_sum,
+      Finset.sum_const, nsmul_eq_mul, Finset.card_univ, ← hn_def, ← hT_def]
+  -- Specialize to the mean `μ = T/n`: variance = ∑ d² − T²/n.
+  have hvar : ∑ i, (d i - μ) ^ 2 = (∑ i, (d i) ^ 2) - T ^ 2 / n := by
+    rw [hgen μ, hμ_def]; field_simp; ring
+  -- Variance is bounded by Q − T²/n.
+  have hvar_le : ∑ i, (d i - μ) ^ 2 ≤ Q - T ^ 2 / n := by
+    rw [hvar]; linarith [hQ]
+  -- `m ≤ μ` in the local names.
+  have hmμ : m ≤ μ := hm
+  -- Each low index contributes at least (μ − m)² to the variance.
+  have hlow : (L.card : ℝ) * (μ - m) ^ 2 ≤ ∑ i ∈ L, (d i - μ) ^ 2 := by
+    have hterm : ∀ i ∈ L, (μ - m) ^ 2 ≤ (d i - μ) ^ 2 := by
+      intro i hi
+      have hdi : d i ≤ m := by
+        rw [hL_def, mem_filter] at hi; exact hi.2
+      nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ m - d i)
+        (by linarith : (0 : ℝ) ≤ 2 * μ - m - d i)]
+    calc (L.card : ℝ) * (μ - m) ^ 2
+        = ∑ _i ∈ L, (μ - m) ^ 2 := by rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ ∑ i ∈ L, (d i - μ) ^ 2 := Finset.sum_le_sum hterm
+  -- The variance over L is at most the variance over everything.
+  have hsub : ∑ i ∈ L, (d i - μ) ^ 2 ≤ ∑ i, (d i - μ) ^ 2 := by
+    apply Finset.sum_le_sum_of_subset_of_nonneg (Finset.subset_univ L)
+    intro i _ _; positivity
+  -- Chain everything together.
+  calc (L.card : ℝ) * (μ - m) ^ 2
+      ≤ ∑ i ∈ L, (d i - μ) ^ 2 := hlow
+    _ ≤ ∑ i, (d i - μ) ^ 2 := hsub
+    _ ≤ Q - T ^ 2 / n := hvar_le
+
+/-! ### Step 2: the triangle-free second-moment bound `∑ d(v)² ≤ n·e` -/
+
+open SimpleGraph
+
+variable {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+
+/-- **Adjacent degrees add to at most `n` in a triangle-free graph.** If `u v` are adjacent and
+`G` is triangle-free (`K₃`-free), their neighbourhoods are disjoint (a common neighbour would
+complete a triangle), so `d(u) + d(v) = #(N(u) ∪ N(v)) ≤ n`. -/
+theorem adjacent_degree_add_le (h : G.CliqueFree 3) {u v : V} (huv : G.Adj u v) :
+    G.degree u + G.degree v ≤ Fintype.card V := by
+  classical
+  have hdisj : Disjoint (G.neighborFinset u) (G.neighborFinset v) := by
+    rw [Finset.disjoint_left]
+    intro w hw hw'
+    rw [mem_neighborFinset] at hw hw'
+    exact h {u, v, w} (by rw [is3Clique_triple_iff]; exact ⟨huv, hw, hw'⟩)
+  have hcard : G.degree u + G.degree v = (G.neighborFinset u ∪ G.neighborFinset v).card := by
+    rw [Finset.card_union_of_disjoint hdisj, G.card_neighborFinset_eq_degree,
+      G.card_neighborFinset_eq_degree]
+  rw [hcard]
+  exact Finset.card_le_univ _
+
+/-- Summing `d(v)²` over vertices equals summing `d(dart.fst)` over darts, because each vertex
+`v` is the tail of exactly `d(v)` darts. -/
+theorem sum_degree_fst_eq_sum_sq :
+    ∑ x : G.Dart, G.degree x.fst = ∑ v : V, (G.degree v) ^ 2 := by
+  classical
+  rw [← Finset.sum_fiberwise_of_maps_to
+        (t := (Finset.univ : Finset V)) (g := fun x : G.Dart => x.fst)
+        (fun x _ => Finset.mem_univ x.fst) (fun x => G.degree x.fst)]
+  refine Finset.sum_congr rfl (fun v _ => ?_)
+  have hfib : ∀ x ∈ Finset.univ.filter (fun x : G.Dart => x.fst = v),
+      G.degree x.fst = G.degree v := by
+    intro x hx; rw [(Finset.mem_filter.mp hx).2]
+  rw [Finset.sum_congr rfl hfib, Finset.sum_const, smul_eq_mul,
+    G.dart_fst_fiber_card_eq_degree v, pow_two]
+
+/-- **Triangle-free second-moment bound.** For a triangle-free graph on `n` vertices with `e`
+edges, `∑ d(v)² ≤ n · e`. Combined with `∑ d(v) = 2e`, this is the arithmetic engine behind the
+`O(εn)` stability estimate. -/
+theorem sum_sq_degree_le_card_mul_card_edge (h : G.CliqueFree 3) :
+    ∑ v : V, (G.degree v) ^ 2 ≤ Fintype.card V * G.edgeFinset.card := by
+  classical
+  -- ∑ d(snd) = ∑ d(fst) via the dart-reversal involution.
+  have hsnd : ∑ x : G.Dart, G.degree x.snd = ∑ x : G.Dart, G.degree x.fst :=
+    Fintype.sum_bijective (SimpleGraph.Dart.symm) (Dart.symm_involutive.bijective)
+      (fun x => G.degree x.snd) (fun x => G.degree x.fst) (fun x => by rfl)
+  -- 2 ∑ d(v)² = ∑_dart (d(fst) + d(snd)).
+  have hdouble : 2 * ∑ v : V, (G.degree v) ^ 2
+      = ∑ x : G.Dart, (G.degree x.fst + G.degree x.snd) := by
+    rw [Finset.sum_add_distrib, hsnd, sum_degree_fst_eq_sum_sq]; ring
+  -- Each dart obeys d(fst) + d(snd) ≤ n.
+  have hbound : ∑ x : G.Dart, (G.degree x.fst + G.degree x.snd)
+      ≤ ∑ _x : G.Dart, Fintype.card V :=
+    Finset.sum_le_sum (fun x _ => adjacent_degree_add_le G h x.adj)
+  have hconst : ∑ _x : G.Dart, Fintype.card V
+      = 2 * G.edgeFinset.card * Fintype.card V := by
+    rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, G.dart_card_eq_twice_card_edges]
+  -- Combine: 2 ∑ d² ≤ 2 (n e), then cancel the factor of two.
+  have hfinal : 2 * ∑ v : V, (G.degree v) ^ 2
+      ≤ 2 * (Fintype.card V * G.edgeFinset.card) := by
+    rw [hdouble]
+    calc ∑ x : G.Dart, (G.degree x.fst + G.degree x.snd)
+        ≤ 2 * G.edgeFinset.card * Fintype.card V := hbound.trans_eq hconst
+      _ = 2 * (Fintype.card V * G.edgeFinset.card) := by ring
+  exact Nat.le_of_mul_le_mul_left hfinal (by norm_num)
+
+/-! ### Main result: near-extremal triangle-free graphs have few low-degree vertices -/
+
+/-- **Handshake-counting bridge (edge count → few low-degree vertices).**
+
+Let `G` be a triangle-free simple graph on `n ≥ 1` vertices, and let `0 ≤ ε ≤ 1/40`. If `G` has
+almost the Mantel-maximal number of edges,
+
+`#E(G) ≥ n²/4 − ε n²`,
+
+then only `O(ε n)` vertices can have degree at most `2n/5`:
+
+`#{v | d(v) ≤ 2n/5} ≤ 400 · ε · n`.
+
+In particular, if `ε` is small the graph is "almost min-degree `2n/5`", which is exactly the
+hypothesis of the Andrásfai–Erdős–Sós theorem (a triangle-free graph with minimum degree
+`> 2n/5` is bipartite). This lemma is the quantitative bridge letting a Turán-stability argument
+pass from an *edge-count* hypothesis to a *minimum-degree* hypothesis.
+
+The proof is a second-moment estimate: `∑ d(v) = 2e` (handshake) and, since `G` is triangle-free,
+`∑ d(v)² ≤ n e`; hence the degree variance is at most `ε n³`, and any vertex with degree
+`≤ 2n/5 = mean − Ω(n)` spends `Ω(n²)` of that variance. -/
+theorem low_degree_count_le
+    {V : Type*} [Fintype V] (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : G.CliqueFree 3) (ε : ℝ) (hε0 : 0 ≤ ε) (hε : ε ≤ 1 / 40)
+    (hn : 0 < Fintype.card V)
+    (hedge : (Fintype.card V : ℝ) ^ 2 / 4 - ε * (Fintype.card V : ℝ) ^ 2
+      ≤ (G.edgeFinset.card : ℝ)) :
+    ((univ.filter fun v => (G.degree v : ℝ) ≤ 2 * (Fintype.card V : ℝ) / 5).card : ℝ)
+      ≤ 400 * ε * (Fintype.card V : ℝ) := by
+  classical
+  set nR : ℝ := (Fintype.card V : ℝ) with hnR
+  set eR : ℝ := (G.edgeFinset.card : ℝ) with heR
+  have hn0 : (0 : ℝ) < nR := by rw [hnR]; exact_mod_cast hn
+  have heR0 : (0 : ℝ) ≤ eR := by rw [heR]; positivity
+  -- Handshake identity as reals.
+  have hT : ∑ v, (G.degree v : ℝ) = 2 * eR := by
+    rw [heR, ← Nat.cast_sum, G.sum_degrees_eq_twice_card_edges]; push_cast; ring
+  -- Triangle-free second moment as reals.
+  have hQ : ∑ v, (G.degree v : ℝ) ^ 2 ≤ nR * eR := by
+    have hnat := sum_sq_degree_le_card_mul_card_edge G h
+    have hcast : ∑ v, (G.degree v : ℝ) ^ 2 = ((∑ v, (G.degree v) ^ 2 : ℕ) : ℝ) := by
+      push_cast; ring
+    rw [hcast, hnR, heR]; exact_mod_cast hnat
+  -- Cauchy–Schwarz gives Mantel's bound `4e ≤ n²`.
+  have hCS : (∑ v, (G.degree v : ℝ)) ^ 2 ≤ nR * ∑ v, (G.degree v : ℝ) ^ 2 := by
+    have hcs := sq_sum_le_card_mul_sum_sq (s := (univ : Finset V))
+      (f := fun v => (G.degree v : ℝ))
+    rw [Finset.card_univ] at hcs
+    rw [hnR]; exact_mod_cast hcs
+  have hchain : 4 * eR ^ 2 ≤ nR ^ 2 * eR := by
+    have h1 : (∑ v, (G.degree v : ℝ)) ^ 2 = 4 * eR ^ 2 := by rw [hT]; ring
+    nlinarith [hCS, hQ, hn0, heR0, h1]
+  have hMantel : 4 * eR ≤ nR ^ 2 := by
+    rcases eq_or_lt_of_le heR0 with h0 | hpos
+    · nlinarith [hn0, h0]
+    · nlinarith [hchain, hpos]
+  -- `m = 2n/5` sits at or below the mean `2e/n`.
+  have h2e : nR / 2 - 2 * ε * nR ≤ 2 * eR / nR := by
+    rw [le_div_iff₀ hn0]; nlinarith [hedge, hn0]
+  have hgap1 : nR / 20 ≤ 2 * eR / nR - 2 * nR / 5 := by
+    nlinarith [h2e, mul_le_mul_of_nonneg_right hε hn0.le, hε0, hn0]
+  have hmμ : 2 * nR / 5 ≤ (∑ v, (G.degree v : ℝ)) / nR := by rw [hT]; linarith [hgap1]
+  -- Apply the abstract Chebyshev counting bound.
+  have habs := abstract_low_value_count_le (fun v => (G.degree v : ℝ)) (nR * eR) (2 * nR / 5)
+    hn hmμ hQ
+  rw [hT, ← hnR] at habs
+  set C : ℝ := ((univ.filter fun v => (G.degree v : ℝ) ≤ 2 * nR / 5).card : ℝ) with hC
+  have hC0 : 0 ≤ C := by rw [hC]; positivity
+  -- Lower-bound the squared gap.
+  have hgapsq : (nR / 20) ^ 2 ≤ (2 * eR / nR - 2 * nR / 5) ^ 2 :=
+    pow_le_pow_left₀ (by positivity) hgap1 2
+  -- Upper-bound the variance budget by `ε n³`.
+  have hii : nR * eR - (2 * eR) ^ 2 / nR ≤ ε * nR ^ 3 := by
+    have hLHS : nR * eR - (2 * eR) ^ 2 / nR = (nR ^ 2 * eR - 4 * eR ^ 2) / nR := by
+      field_simp; ring
+    rw [hLHS, div_le_iff₀ hn0]
+    nlinarith [mul_nonneg heR0 (by linarith [hedge, hMantel] :
+        (0 : ℝ) ≤ 4 * ε * nR ^ 2 - (nR ^ 2 - 4 * eR)),
+      mul_nonneg (mul_nonneg hε0 (sq_nonneg nR)) (by linarith [hMantel] :
+        (0 : ℝ) ≤ nR ^ 2 - 4 * eR)]
+  -- Chain: C · (n/20)² ≤ C · gap² ≤ variance ≤ ε n³.
+  have hchain2 : C * (nR / 20) ^ 2 ≤ ε * nR ^ 3 :=
+    le_trans (mul_le_mul_of_nonneg_left hgapsq hC0) (le_trans habs hii)
+  -- Cancel `n²` to conclude `C ≤ 400 ε n`.
+  have hfinal : C * nR ^ 2 ≤ (400 * ε * nR) * nR ^ 2 := by nlinarith [hchain2, hn0]
+  exact le_of_mul_le_mul_right hfinal (by positivity)
+
+end MantelBridge

--- a/src/data/proofs/mantel-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/mantel-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "mantel-oq0102-ann-docstring",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 7,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "The Bridge: Edge Count to Minimum Degree",
+    "content": "The module docstring lays out the four-step second-moment argument. The standard proof of Erdős–Simonovits stability for triangle-free graphs deletes low-degree vertices and then invokes the Andrásfai–Erdős–Sós theorem (min degree > 2n/5 ⇒ bipartite). To justify that the deletion is cheap, one needs to know that a near-extremal graph has few low-degree vertices — precisely the O(εn) bound proved here. The sibling entry mantel-theorem-oq-01 formalized the AES step and flagged this counting bound as open.",
+    "mathContext": "$|E(G)| \\ge n^2/4 - \\varepsilon n^2 \\Rightarrow \\#\\{v : d(v) \\le 2n/5\\} = O(\\varepsilon n)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "extremal graph theory",
+      "Erdős–Simonovits stability",
+      "Andrásfai–Erdős–Sós theorem",
+      "second-moment method"
+    ],
+    "prerequisites": [
+      "simple graphs",
+      "triangle-free graphs",
+      "vertex degree"
+    ]
+  },
+  {
+    "id": "mantel-oq0102-ann-abstract",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 107
+    },
+    "type": "technique",
+    "title": "Chebyshev Counting, Stripped of Graph Theory",
+    "content": "abstract_low_value_count_le is the probabilistic heart, stated for an arbitrary real sequence d on a finite index set. Writing μ = T/n for the mean and using the variance identity ∑ (d i − μ)² = ∑ d² − T²/n, it observes that every index with d i ≤ m ≤ μ sits at least μ − m below the mean and so contributes at least (μ − m)² to the variance. Hence #{i : d i ≤ m}·(μ − m)² ≤ ∑ d² − T²/n. The hypothesis m ≤ μ is essential: a constant sequence with m above the mean would violate the bound, and the lemma carries m ≤ (∑ d)/n explicitly.",
+    "mathContext": "$\\#\\{i : d_i \\le m\\}\\,(\\mu - m)^2 \\le \\sum_i (d_i - \\mu)^2 = \\sum_i d_i^2 - T^2/n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev's inequality",
+      "variance",
+      "second-moment method",
+      "mean"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "real arithmetic",
+      "variance identity"
+    ]
+  },
+  {
+    "id": "mantel-oq0102-ann-adjacent",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 132
+    },
+    "type": "key_step",
+    "title": "Disjoint Neighbourhoods: d(u) + d(v) ≤ n",
+    "content": "adjacent_degree_add_le is where triangle-freeness enters. If u and v are adjacent, a common neighbour w would make {u,v,w} a triangle; is3Clique_triple_iff turns the three adjacencies into IsNClique 3 {u,v,w}, contradicting CliqueFree 3. So the neighbourhoods N(u) and N(v) are disjoint, and d(u) + d(v) = #(N(u) ∪ N(v)) ≤ #V = n. This per-edge inequality is the only structural fact the whole argument needs.",
+    "mathContext": "$u \\sim v \\Rightarrow N(u) \\cap N(v) = \\varnothing \\Rightarrow d(u) + d(v) \\le n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "triangle-free graphs",
+      "neighbourhood",
+      "disjoint sets",
+      "clique"
+    ],
+    "prerequisites": [
+      "SimpleGraph.CliqueFree",
+      "neighborFinset",
+      "card_union_of_disjoint"
+    ]
+  },
+  {
+    "id": "mantel-oq0102-ann-darts",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 134,
+      "endLine": 149
+    },
+    "type": "technique",
+    "title": "Summing Over Darts: ∑ d(fst) = ∑ d(v)²",
+    "content": "sum_degree_fst_eq_sum_sq expresses ∑ d(v)² as a sum over darts (ordered adjacent pairs). Grouping darts by their tail vertex — via Finset.sum_fiberwise_of_maps_to and the fact that v is the tail of exactly d(v) darts (dart_fst_fiber_card_eq_degree) — turns ∑_{darts} d(dart.fst) into ∑_v d(v)·d(v). Working with darts rather than unordered edges is what lets the dart-reversal involution symmetrise the next step cleanly.",
+    "mathContext": "$\\sum_{\\text{darts } (u,w)} d(u) = \\sum_v d(v)\\cdot\\#\\{\\text{darts with tail } v\\} = \\sum_v d(v)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "darts",
+      "fiberwise summation",
+      "degree",
+      "handshake"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Dart",
+      "Finset.sum_fiberwise_of_maps_to"
+    ]
+  },
+  {
+    "id": "mantel-oq0102-ann-secondmoment",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 147,
+      "endLine": 175
+    },
+    "type": "key_step",
+    "title": "The Triangle-Free Second Moment: ∑ d(v)² ≤ n·e",
+    "content": "sum_sq_degree_le_card_mul_card_edge assembles the second-moment bound. The dart-reversal involution Dart.symm gives ∑_{darts} d(snd) = ∑_{darts} d(fst) = ∑ d(v)², so 2∑ d(v)² = ∑_{darts}(d(fst) + d(snd)). Each dart obeys d(fst) + d(snd) ≤ n by adjacent_degree_add_le, and there are #darts = 2e of them, so 2∑ d(v)² ≤ 2ne. Cancelling the factor 2 gives ∑ d(v)² ≤ n·e, entirely in ℕ.",
+    "mathContext": "$2\\sum_v d(v)^2 = \\sum_{\\text{darts}}(d(\\mathrm{fst}) + d(\\mathrm{snd})) \\le n \\cdot 2e \\Rightarrow \\sum_v d(v)^2 \\le n e$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "second moment",
+      "dart-reversal involution",
+      "triangle-free graphs",
+      "degree-sum"
+    ],
+    "prerequisites": [
+      "Dart.symm",
+      "Fintype.sum_bijective",
+      "dart_card_eq_twice_card_edges"
+    ]
+  },
+  {
+    "id": "mantel-oq0102-ann-main",
+    "proofId": "mantel-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 177,
+      "endLine": 263
+    },
+    "type": "key_step",
+    "title": "Assembling the O(εn) Bound",
+    "content": "low_degree_count_le casts the two ℕ facts to ℝ (∑ d(v) = 2e and ∑ d(v)² ≤ ne), reproves Mantel's inequality 4e ≤ n² from Cauchy–Schwarz to avoid an external import, and checks that the threshold 2n/5 lies below the mean 2e/n ≥ n/2 − 2εn (this needs ε ≤ 1/40). Feeding Q = ne into abstract_low_value_count_le bounds the variance budget by (e/n)(n² − 4e) ≤ (n/4)(4εn²) = εn³. Since a degree-2n/5 vertex is at least n/20 below the mean, the count times (n/20)² = n²/400 is at most εn³, giving #{v : d(v) ≤ 2n/5} ≤ 400εn.",
+    "mathContext": "$\\#\\{v : d(v) \\le 2n/5\\}\\cdot \\tfrac{n^2}{400} \\le \\mathrm{Var} \\le \\varepsilon n^3 \\Rightarrow \\#\\{v : d(v)\\le 2n/5\\} \\le 400\\varepsilon n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev's inequality",
+      "Mantel's theorem",
+      "Cauchy–Schwarz",
+      "variance budget"
+    ],
+    "prerequisites": [
+      "sq_sum_le_card_mul_sum_sq",
+      "Nat.cast",
+      "div_le_iff₀"
+    ]
+  }
+]

--- a/src/data/proofs/mantel-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/mantel-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "mantel-theorem-oq-01-oq-02",
+  "title": "Handshake Counting Bridge: Near-Extremal Triangle-Free Graphs Have Few Low-Degree Vertices",
+  "slug": "mantel-theorem-oq-01-oq-02",
+  "description": "A verified formalization of the second-moment counting bound that bridges the edge-count hypothesis of Mantel-stability to the minimum-degree hypothesis of Andrásfai–Erdős–Sós. For a triangle-free (K₃-free) graph on n vertices with |E(G)| ≥ n²/4 − εn² (0 ≤ ε ≤ 1/40), the number of vertices of degree ≤ 2n/5 is at most 400·ε·n, i.e. O(εn). The proof is a Chebyshev/variance estimate resting on the triangle-free second-moment bound ∑ d(v)² ≤ n·e, itself proved from scratch via the dart-reversal involution and the disjoint-neighbourhood property of triangle-free graphs. This resolves an open question posed by the sibling entry mantel-theorem-oq-01.",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Andr%C3%A1sfai%E2%80%93Erd%C5%91s%E2%80%93S%C3%B3s_theorem",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "combinatorics",
+      "extremal-graph-theory",
+      "triangle-free",
+      "stability",
+      "second-moment-method",
+      "advanced"
+    ],
+    "proofRepoPath": "Proofs/MantelTheoremOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.sum_degrees_eq_twice_card_edges",
+        "description": "The handshake/degree-sum formula ∑ d(v) = 2·#E(G), giving the average degree 2e/n",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.dart_fst_fiber_card_eq_degree",
+        "description": "Each vertex v is the tail (fst) of exactly d(v) darts; the fiber-counting fact behind ∑ d(dart.fst) = ∑ d(v)²",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DegreeSum"
+      },
+      {
+        "theorem": "SimpleGraph.is3Clique_triple_iff",
+        "description": "IsNClique 3 {a,b,c} ↔ pairwise adjacency; used to show adjacent vertices in a triangle-free graph have disjoint neighbourhoods",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Clique"
+      },
+      {
+        "theorem": "sq_sum_le_card_mul_sum_sq",
+        "description": "Cauchy–Schwarz / Chebyshev: (∑ f)² ≤ #s · ∑ f²; combined with the second-moment bound it reproves Mantel's inequality 4e ≤ n²",
+        "module": "Mathlib.Algebra.Order.Chebyshev"
+      }
+    ],
+    "originalContributions": [
+      "low_degree_count_le: the headline handshake-counting bridge — for a triangle-free graph on n≥1 vertices with |E(G)| ≥ n²/4 − εn² and 0 ≤ ε ≤ 1/40, the number of vertices of degree ≤ 2n/5 is at most 400·ε·n = O(εn). This is the exact bridge the sibling entry mantel-theorem-oq-01 flagged as an open question.",
+      "sum_sq_degree_le_card_mul_card_edge: the triangle-free second-moment bound ∑ d(v)² ≤ n·e, proved from first principles by summing the per-edge bound d(u)+d(v) ≤ n over darts and folding the dart-reversal involution.",
+      "adjacent_degree_add_le: adjacent vertices of a triangle-free graph satisfy d(u)+d(v) ≤ n, since a common neighbour would complete a K₃ (via is3Clique_triple_iff) so the neighbourhoods are disjoint.",
+      "abstract_low_value_count_le: a self-contained Chebyshev counting lemma over an arbitrary real degree sequence — values a fixed distance below the mean each consume that squared distance of the total variance — isolating the probabilistic core from the graph theory so it can be reused.",
+      "sum_degree_fst_eq_sum_sq: the identity ∑_{darts} d(dart.fst) = ∑_v d(v)² via fiberwise summation over the tail map."
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCountNote": "0 axiom declarations, 0 structure-encoded assumptions. All five results are fully machine-checked; #print axioms low_degree_count_le reports only [propext, Classical.choice, Quot.sound]. No native_decide, no sorry. The Mantel upper bound 4e ≤ n² is reproved inline from Cauchy–Schwarz rather than imported, keeping the file self-contained."
+  },
+  "overview": {
+    "historicalContext": "Mantel's 1907 theorem gives the exact maximum edge count ⌊n²/4⌋ for a triangle-free graph (gallery entry mantel-theorem). Erdős and Simonovits established the stability phenomenon: a triangle-free graph with close to ⌊n²/4⌋ edges is structurally close to the balanced complete bipartite graph. The standard proof routes through the Andrásfai–Erdős–Sós theorem (1974) — a triangle-free graph with minimum degree > 2n/5 is bipartite — after a degree-cleaning step that deletes low-degree vertices. That cleaning step needs a quantitative guarantee that few vertices are low-degree, which is precisely the second-moment (variance) estimate formalized here. The idea that a near-extremal degree sequence is concentrated near its mean is the discrete analogue of Chebyshev's inequality, and the triangle-free input ∑ d(v)² ≤ n·e is the classical consequence of the fact that adjacent vertices in a triangle-free graph cannot share a neighbour.",
+    "problemStatement": "The sibling entry mantel-theorem-oq-01 formalized the min-degree ingredient of Mantel-stability and left open: 'Formalize the handshake-based counting bound: from |E(G)| ≥ n²/4 − εn² the set of vertices of degree ≤ 2n/5 has size O(εn), the bridge between the edge-count hypothesis and the AES min-degree hypothesis.' This entry proves exactly that, with an explicit constant (400ε n under ε ≤ 1/40).",
+    "proofStrategy": "The argument is a second-moment estimate on the degree sequence d(v). (1) The handshake identity ∑ d(v) = 2e fixes the mean degree at 2e/n ≥ n/2 − 2εn. (2) Triangle-freeness gives ∑ d(v)² ≤ n·e: for an edge uv the neighbourhoods N(u), N(v) are disjoint (a common neighbour would be a triangle), so d(u)+d(v) ≤ n; summing this over all darts and folding the dart-reversal involution yields 2∑ d(v)² ≤ 2ne. (3) Combining, the degree variance ∑ (d(v) − 2e/n)² = ∑ d(v)² − (2e)²/n ≤ ne − 4e²/n = (e/n)(n² − 4e) ≤ (n/4)(4εn²) = εn³, using Mantel's bound e ≤ n²/4 (reproved from Cauchy–Schwarz). (4) A vertex of degree ≤ 2n/5 sits at least n/20 below the mean (when ε ≤ 1/40), hence contributes ≥ (n/20)² = n²/400 to the variance; therefore #{low-degree vertices}·(n²/400) ≤ εn³, giving the O(εn) count. Step (4) is packaged as the reusable abstract lemma abstract_low_value_count_le.",
+    "keyInsights": [
+      "The whole bridge is one variance inequality: near-extremal edge count ⇒ small degree variance ⇒ few vertices far below the mean. This is Chebyshev's inequality in counting form.",
+      "Triangle-freeness enters exactly once, through ∑ d(v)² ≤ n·e. The per-edge input d(u)+d(v) ≤ n is the disjoint-neighbourhood property, and summing it over darts (rather than unordered edges) makes the dart-reversal involution do the symmetrisation cleanly.",
+      "Isolating the counting core as abstract_low_value_count_le — a statement about an arbitrary real sequence with a bounded second moment — separates the probabilistic content from the graph theory and makes the graph-specific work purely the second-moment bound.",
+      "Mantel's inequality 4e ≤ n² is not needed as an external import: it falls out of the same second-moment data via Cauchy–Schwarz ((∑ d)² ≤ n ∑ d²), keeping the development self-contained.",
+      "The explicit constant 400 (and the hypothesis ε ≤ 1/40) is an honest artefact of the 2n/5 threshold: a degree-2n/5 vertex is n/10 − 2εn below the mean, which is ≥ n/20 once ε ≤ 1/40, and (n/20)² = n²/400."
+    ]
+  },
+  "references": [
+    {
+      "authors": [
+        "Andrásfai, B.",
+        "Erdős, P.",
+        "Sós, V.T."
+      ],
+      "title": "On the connection between chromatic number, maximal clique and minimal degree of a graph",
+      "year": "1974",
+      "venue": "Discrete Mathematics 8 (3), pp. 205–218",
+      "note": "The minimum-degree threshold 2n/5 for triangle-free graphs that this counting bound feeds into."
+    },
+    {
+      "authors": [
+        "Erdős, P.",
+        "Simonovits, M."
+      ],
+      "title": "A limit theorem in graph theory",
+      "year": "1966",
+      "venue": "Studia Scientiarum Mathematicarum Hungarica 1, pp. 51–57",
+      "note": "The Erdős–Simonovits stability theorem, whose degree-cleaning proof this bound quantifies."
+    },
+    {
+      "authors": [
+        "Alon, N.",
+        "Spencer, J.H."
+      ],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "4th ed., Wiley",
+      "note": "Standard reference for second-moment/variance counting arguments of the kind used here."
+    },
+    {
+      "authors": [
+        "Bollobás, B."
+      ],
+      "title": "Extremal Graph Theory",
+      "year": "1978",
+      "venue": "London Mathematical Society Monographs 11, Academic Press",
+      "note": "Standard reference for Mantel's theorem, degree-sum identities, and triangle-free stability."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes, with no axioms or sorries, the second-moment counting bridge of Mantel-stability: a triangle-free graph on n≥1 vertices with |E(G)| ≥ n²/4 − εn² (0 ≤ ε ≤ 1/40) has at most 400·ε·n vertices of degree ≤ 2n/5. The proof supplies from first principles the triangle-free second-moment bound ∑ d(v)² ≤ n·e (via darts and disjoint neighbourhoods) and an abstract Chebyshev counting lemma, and reproves Mantel's inequality 4e ≤ n² from Cauchy–Schwarz to stay self-contained.",
+    "implications": "Together with the sibling entry mantel-theorem-oq-01 (the Andrásfai–Erdős–Sós min-degree → bipartite step), this closes the gap between the edge-count hypothesis and the min-degree hypothesis in the degree-cleaning route to Erdős–Simonovits stability. The remaining work toward full edge-count stability is the edit-distance accounting (bounding the edges lost when the O(εn) low-degree vertices are deleted and the bipartition is extended back), which is now a bounded and explicit counting task.",
+    "openQuestions": [
+      "Chain this bound with mantel-theorem-oq-01: delete the O(εn) low-degree vertices, apply the AES specialization to the high-min-degree survivor to get a bipartition, and bound the edges lost, completing a formal edge-count stability statement.",
+      "Sharpen the constant and the admissible range of ε; the value 400 and the cutoff ε ≤ 1/40 are convenient rather than optimal.",
+      "Formalize sharpness of the 2n/5 threshold via the balanced blow-up of C₅, the triangle-free non-bipartite graph with minimum degree exactly 2n/5."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "License and Imports",
+      "startLine": 1,
+      "endLine": 6,
+      "summary": "Apache-2.0 license header and a single import Mathlib, bringing in the SimpleGraph dart/degree-sum API, the clique characterisation is3Clique_triple_iff, and the Cauchy–Schwarz lemma sq_sum_le_card_mul_sum_sq.",
+      "mathContext": "Relies on Mathlib.Combinatorics.SimpleGraph.DegreeSum and Mathlib.Algebra.Order.Chebyshev."
+    },
+    {
+      "id": "docstring",
+      "title": "Statement and Proof Outline",
+      "startLine": 7,
+      "endLine": 42,
+      "summary": "Module docstring situating the result inside the Andrásfai–Erdős–Sós circle: the four-step second-moment argument (handshake mean, triangle-free second moment, variance bound, Chebyshev counting) and why triangle-freeness is the only place structure enters.",
+      "mathContext": "Bridge from |E(G)| ≥ n²/4 − εn² to #{v : d(v) ≤ 2n/5} = O(εn)."
+    },
+    {
+      "id": "abstract-counting",
+      "title": "Abstract Chebyshev Counting Bound",
+      "startLine": 47,
+      "endLine": 107,
+      "summary": "abstract_low_value_count_le: for any real sequence d on a finite index set with mean T/n and ∑ d² ≤ Q, and any threshold m at or below the mean, #{i : d i ≤ m}·(T/n − m)² ≤ Q − T²/n. Proved via the variance identity ∑ (d i − μ)² = ∑ d² − T²/n and the observation that each low index contributes at least (μ − m)² to the variance. This is the probabilistic core, stated with no graph theory.",
+      "mathContext": "Chebyshev counting: #{i : d_i ≤ m}·(μ − m)² ≤ Var, μ = mean, Var = ∑ d² − nμ²."
+    },
+    {
+      "id": "second-moment",
+      "title": "Triangle-Free Second-Moment Bound",
+      "startLine": 109,
+      "endLine": 175,
+      "summary": "adjacent_degree_add_le shows d(u)+d(v) ≤ n for adjacent u,v in a triangle-free graph (disjoint neighbourhoods via is3Clique_triple_iff). sum_degree_fst_eq_sum_sq gives ∑_{darts} d(dart.fst) = ∑ d(v)² by fiberwise summation over the tail map. sum_sq_degree_le_card_mul_card_edge combines them: folding the dart-reversal involution, 2∑ d(v)² = ∑_{darts}(d(fst)+d(snd)) ≤ n·#darts = 2ne, hence ∑ d(v)² ≤ n·e.",
+      "mathContext": "K₃-free ⇒ ∑ d(v)² ≤ n·e, the second-moment input to the variance bound."
+    },
+    {
+      "id": "main-bridge",
+      "title": "Main Handshake-Counting Bridge",
+      "startLine": 177,
+      "endLine": 263,
+      "summary": "low_degree_count_le assembles the pieces over ℝ: casts the handshake identity (∑ d(v) = 2e) and second-moment bound (∑ d(v)² ≤ ne), reproves Mantel's 4e ≤ n² from Cauchy–Schwarz, verifies 2n/5 lies below the mean, and applies abstract_low_value_count_le with the variance budget bounded by εn³ to conclude #{v : d(v) ≤ 2n/5} ≤ 400·ε·n.",
+      "mathContext": "|E(G)| ≥ n²/4 − εn², ε ≤ 1/40 ⇒ #{v : d(v) ≤ 2n/5} ≤ 400εn."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mantel-theorem-oq-01",
+      "relationship": "extends",
+      "description": "mantel-theorem-oq-01 formalized the Andrásfai–Erdős–Sós min-degree ingredient and explicitly listed this handshake counting bound as an open question; this entry resolves it."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "mantel-theorem proves the exact edge bound ⌊n²/4⌋; this entry quantifies how the degree sequence concentrates when the edge count is near that maximum."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
+    "namespace": "MantelBridge",
+    "lineCount": 264,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/MantelTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "low_degree_count_le",
+    "sum_sq_degree_le_card_mul_card_edge",
+    "adjacent_degree_add_le",
+    "abstract_low_value_count_le",
+    "sum_degree_fst_eq_sum_sq"
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **mantel-theorem-oq-01-oq-02** resolving the open question that the sibling entry `mantel-theorem-oq-01` explicitly flagged:

> *"Formalize the handshake-based counting bound: from |E(G)| ≥ n²/4 − εn² the set of vertices of degree ≤ 2n/5 has size O(εn), the bridge between the edge-count hypothesis and the AES min-degree hypothesis."*

**Main theorem** (`low_degree_count_le`): For a triangle-free (`K₃`-free) simple graph on `n ≥ 1` vertices with `0 ≤ ε ≤ 1/40`, if `#E(G) ≥ n²/4 − εn²` then

```
#{v | d(v) ≤ 2n/5} ≤ 400 · ε · n.
```

This is the quantitative bridge that lets a Turán-stability argument pass from an *edge-count* hypothesis to the *minimum-degree* hypothesis of Andrásfai–Erdős–Sós.

## Proof

A second-moment (Chebyshev) estimate on the degree sequence:

1. `adjacent_degree_add_le` — triangle-free ⇒ adjacent vertices have disjoint neighbourhoods, so `d(u)+d(v) ≤ n` (a common neighbour would complete a triangle, via `is3Clique_triple_iff`).
2. `sum_degree_fst_eq_sum_sq` / `sum_sq_degree_le_card_mul_card_edge` — summing the per-edge bound over darts and folding the dart-reversal involution gives the triangle-free second moment `∑ d(v)² ≤ n·e`.
3. `abstract_low_value_count_le` — a self-contained Chebyshev counting lemma over an arbitrary real sequence: values a fixed distance below the mean each consume that squared distance of the total variance.
4. `low_degree_count_le` — combine: the degree variance is `≤ εn³`, and a degree-`2n/5` vertex sits `≥ n/20` below the mean, so `#{low} · (n/20)² ≤ εn³`.

Mantel's inequality `4e ≤ n²` is reproved inline from Cauchy–Schwarz (`sq_sum_le_card_mul_sum_sq`) rather than imported, keeping the file self-contained.

## Verification

- **5 theorems, 0 defs, 0 axioms, 0 sorries, 264 lines.**
- `#print axioms low_degree_count_le` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`).
- Status: **verified**, badge **original**, axiomCount **0**.
- Gallery `annotations:build --strict` clean for this slug; `gallery:check-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)