### PR TITLE
research(prime-gap-bounds-oq-02): explicit Chebyshev upper bound on π(x), axiom-free [VERIFIED]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02Chebyshev.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02Chebyshev.lean
@@ -1,0 +1,194 @@
+/-
+# Bounded Prime Gaps — Open Question 02:
+# An explicit Chebyshev-type upper bound on π(x), axiom-free
+
+Source: open question `prime-gap-bounds-oq-02` of the prime-gap-bounds gallery.
+
+## Goal
+
+Rosser–Schoenfeld (1962) proved the explicit inequalities
+
+  x / log x  <  π(x)  <  1.25506 · x / log x        (x ≥ 17),
+
+whose sharp constants require a numerically verified zero-free region for ζ and an
+explicit prime number theorem. The sharp constants and the *lower* bound are out of
+reach of today's Mathlib (which has no Chebyshev lower bound and no explicit PNT).
+
+The **upper** bound, however, is derivable *now* and *axiom-free* from Mathlib's
+Chebyshev estimate `Chebyshev.theta_le_log4_mul_x : θ x ≤ log 4 · x`, by the classical
+elementary argument. This file carries out that derivation, obtaining a
+Rosser–Schoenfeld-*spirit* explicit bound with the concrete (non-sharp) constant
+`2 log 4 = log 16 ≈ 2.77`:
+
+  π(⌊x⌋) ≤ √x + 1 + (log 16) · x / log x      (x > 1).
+
+## The argument
+
+Every prime `p` with `√x < p ≤ x` contributes `log p > log √x = ½ log x` to
+`θ(x) = Σ_{p ≤ x} log p`. Keeping only this tail,
+
+  θ(x)  ≥  Σ_{√x < p ≤ x} log p  ≥  (½ log x) · #{√x < p ≤ x : p prime}
+        =  (½ log x) · (π(⌊x⌋) − π(⌊√x⌋)).
+
+Combined with `θ(x) ≤ log 4 · x` this gives
+`π(⌊x⌋) − π(⌊√x⌋) ≤ (2 log 4) x / log x`, and `π(⌊√x⌋) ≤ ⌊√x⌋ + 1 ≤ √x + 1`
+finishes it.
+
+The one piece Mathlib lacks is the bridge between `θ`'s prime sum and
+`Nat.primeCounting` (an explicit TODO in `Mathlib/NumberTheory/Chebyshev.lean`); it is
+supplied here as `count_primes_Ioc`.
+
+## Status
+
+The **upper** bound is fully proved, `0` axioms / `0` sorries. The matching **lower**
+bound and the sharp Rosser–Schoenfeld constants remain open, blocked on the absence of
+a Chebyshev lower bound and an explicit PNT error term in Mathlib.
+
+References:
+- J. B. Rosser and L. Schoenfeld, "Approximate formulas for some functions of prime
+  numbers", Illinois J. Math. 6 (1962), 64–94.
+- Mathlib `NumberTheory.Chebyshev` (θ, ψ and `theta_le_log4_mul_x`).
+-/
+
+import Mathlib
+
+open Finset
+open scoped Nat.Prime
+
+namespace BoundedPrimeGapsOQ02Chebyshev
+
+/-- **The θ ↔ π bridge (Mathlib TODO).** The number of primes in the interval
+`(a, b]` equals `π(b) − π(a)`. -/
+theorem count_primes_Ioc (a b : ℕ) (hab : a ≤ b) :
+    ((Finset.Ioc a b).filter Nat.Prime).card = Nat.primeCounting b - Nat.primeCounting a := by
+  -- `#{p ≤ m : prime} = π(m)`.
+  have key : ∀ m, ((Finset.Iic m).filter Nat.Prime).card = Nat.primeCounting m := by
+    intro m
+    have h1 : (Nat.primesBelow (m + 1)).card = Nat.primeCounting m :=
+      Nat.primesBelow_card_eq_primeCounting' (m + 1)
+    rw [← h1]
+    congr 1
+    ext p
+    simp only [Nat.primesBelow, Finset.mem_filter, Finset.mem_range, Finset.mem_Iic,
+      Nat.lt_succ_iff]
+  -- `Iic b` splits as `Iic a ⊔ Ioc a b`.
+  have hsplit : (Finset.Iic b).filter Nat.Prime =
+      (Finset.Iic a).filter Nat.Prime ∪ (Finset.Ioc a b).filter Nat.Prime := by
+    rw [← Finset.filter_union]
+    congr 1
+    ext p
+    simp only [Finset.mem_Iic, Finset.mem_Ioc, Finset.mem_union]
+    omega
+  have hdisj : Disjoint ((Finset.Iic a).filter Nat.Prime)
+      ((Finset.Ioc a b).filter Nat.Prime) := by
+    apply Finset.disjoint_filter_filter
+    rw [Finset.disjoint_left]
+    intro p hp hq
+    simp only [Finset.mem_Iic, Finset.mem_Ioc] at hp hq
+    omega
+  have hb := key b
+  rw [hsplit, Finset.card_union_of_disjoint hdisj, key a] at hb
+  have hmono : Nat.primeCounting a ≤ Nat.primeCounting b := Nat.monotone_primeCounting hab
+  omega
+
+/-- `π(n) ≤ n + 1`: the primes `≤ n` are among `{0, 1, …, n}`. -/
+theorem primeCounting_le_succ (n : ℕ) : Nat.primeCounting n ≤ n + 1 := by
+  have h1 : (Nat.primesBelow (n + 1)).card = Nat.primeCounting n :=
+    Nat.primesBelow_card_eq_primeCounting' (n + 1)
+  rw [← h1]
+  calc (Nat.primesBelow (n + 1)).card
+      ≤ (Finset.range (n + 1)).card := Finset.card_filter_le _ _
+    _ = n + 1 := Finset.card_range _
+
+/-- **Explicit Chebyshev upper bound on π.** For `x > 1`,
+`π(⌊x⌋) ≤ √x + 1 + (log 16) · x / log x`. This is a Rosser–Schoenfeld-spirit bound
+with the concrete constant `2 log 4 = log 16`, derived axiom-free from Mathlib's
+`theta_le_log4_mul_x`. -/
+theorem primeCounting_floor_le (x : ℝ) (hx : 1 < x) :
+    (Nat.primeCounting ⌊x⌋₊ : ℝ) ≤
+      Real.sqrt x + 1 + (2 * Real.log 4) * x / Real.log x := by
+  have hx0 : (0 : ℝ) < x := by linarith
+  have hLpos : 0 < Real.log x := Real.log_pos hx
+  have hsx0 : 0 < Real.sqrt x := Real.sqrt_pos.mpr hx0
+  -- Abbreviations for the floors.
+  set s := ⌊Real.sqrt x⌋₊ with hs
+  set b := ⌊x⌋₊ with hb
+  -- The prime tail `T = (s, b]`.
+  set T := (Finset.Ioc s b).filter Nat.Prime with hT
+  -- Each prime in `T` exceeds `√x`, so its log is `≥ ½ log x`.
+  have hlog_lb : ∀ p ∈ T, Real.log x / 2 ≤ Real.log (p : ℝ) := by
+    intro p hp
+    rw [hT, Finset.mem_filter, Finset.mem_Ioc] at hp
+    obtain ⟨⟨hps, _⟩, _⟩ := hp
+    -- `p > s = ⌊√x⌋`, so `(p : ℝ) ≥ s + 1 > √x`.
+    have hsx : Real.sqrt x < (p : ℝ) := by
+      have h1 : Real.sqrt x < (s : ℝ) + 1 := by
+        rw [hs]; exact Nat.lt_floor_add_one _
+      have h2 : (s : ℝ) + 1 ≤ (p : ℝ) := by
+        have : s + 1 ≤ p := hps
+        exact_mod_cast this
+      linarith
+    have hple : Real.sqrt x ≤ (p : ℝ) := le_of_lt hsx
+    calc Real.log x / 2 = Real.log (Real.sqrt x) := (Real.log_sqrt (le_of_lt hx0)).symm
+      _ ≤ Real.log (p : ℝ) := Real.log_le_log hsx0 hple
+  -- Every term of θ's sum is `≥ 0`.
+  have hlog_nonneg : ∀ p ∈ (Finset.Ioc 0 b).filter Nat.Prime, 0 ≤ Real.log (p : ℝ) := by
+    intro p hp
+    rw [Finset.mem_filter] at hp
+    have hp2 : 2 ≤ p := hp.2.two_le
+    apply Real.log_nonneg
+    have : (2 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp2
+    linarith
+  -- `T ⊆ (0, b]`-primes.
+  have hsub : T ⊆ (Finset.Ioc 0 b).filter Nat.Prime := by
+    rw [hT]
+    apply Finset.filter_subset_filter
+    intro p hp
+    rw [Finset.mem_Ioc] at hp ⊢
+    exact ⟨by omega, hp.2⟩
+  -- Lower bound θ(x) by the tail, then by `(½ log x) · |T|`.
+  have hθ_ge : (T.card : ℝ) * (Real.log x / 2) ≤ Chebyshev.theta x := by
+    have hθdef : Chebyshev.theta x
+        = ∑ p ∈ (Finset.Ioc 0 b).filter Nat.Prime, Real.log (p : ℝ) := rfl
+    calc (T.card : ℝ) * (Real.log x / 2)
+        = ∑ _p ∈ T, (Real.log x / 2) := by
+          rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ ∑ p ∈ T, Real.log (p : ℝ) := Finset.sum_le_sum hlog_lb
+      _ ≤ ∑ p ∈ (Finset.Ioc 0 b).filter Nat.Prime, Real.log (p : ℝ) :=
+          Finset.sum_le_sum_of_subset_of_nonneg hsub (fun p hp _ => hlog_nonneg p hp)
+      _ = Chebyshev.theta x := hθdef.symm
+  -- Chebyshev upper bound on θ.
+  have hθ_le : Chebyshev.theta x ≤ Real.log 4 * x := Chebyshev.theta_le_log4_mul_x (le_of_lt hx0)
+  -- Combine: `|T| · (½ log x) ≤ log 4 · x`.
+  have hcombine : (T.card : ℝ) * (Real.log x / 2) ≤ Real.log 4 * x := le_trans hθ_ge hθ_le
+  -- `s = ⌊√x⌋ ≤ ⌊x⌋ = b`, since `√x ≤ x` for `x ≥ 1`.
+  have hsb : s ≤ b := by
+    rw [hs, hb]
+    apply Nat.floor_le_floor
+    have hsq1 : (1 : ℝ) ≤ Real.sqrt x := by
+      have := Real.sqrt_le_sqrt (le_of_lt hx); simpa using this
+    have hsqx : Real.sqrt x ^ 2 = x := Real.sq_sqrt (le_of_lt hx0)
+    nlinarith [Real.sqrt_nonneg x]
+  have hmono : Nat.primeCounting s ≤ Nat.primeCounting b := Nat.monotone_primeCounting hsb
+  -- Translate `|T|` into `π(b) − π(s)`.
+  have hcard : T.card = Nat.primeCounting b - Nat.primeCounting s := by
+    rw [hT]; exact count_primes_Ioc s b hsb
+  -- `(π b : ℝ) - (π s : ℝ) = |T|`.
+  have hTreal : (T.card : ℝ) = (Nat.primeCounting b : ℝ) - (Nat.primeCounting s : ℝ) := by
+    rw [hcard, Nat.cast_sub hmono]
+  -- Isolate `π b`.
+  have hstep : ((Nat.primeCounting b : ℝ) - (Nat.primeCounting s : ℝ)) * (Real.log x / 2)
+      ≤ Real.log 4 * x := by rw [← hTreal]; exact hcombine
+  have hdiv : (Nat.primeCounting b : ℝ) - (Nat.primeCounting s : ℝ)
+      ≤ (2 * Real.log 4) * x / Real.log x := by
+    rw [le_div_iff₀ hLpos]
+    nlinarith [hstep]
+  -- `π s ≤ √x + 1`.
+  have hs_le : (Nat.primeCounting s : ℝ) ≤ Real.sqrt x + 1 := by
+    have h1 : Nat.primeCounting s ≤ s + 1 := primeCounting_le_succ s
+    have h2 : (s : ℝ) ≤ Real.sqrt x := by rw [hs]; exact Nat.floor_le (le_of_lt hsx0)
+    have : (Nat.primeCounting s : ℝ) ≤ (s : ℝ) + 1 := by exact_mod_cast h1
+    linarith
+  linarith [hdiv, hs_le]
+
+end BoundedPrimeGapsOQ02Chebyshev

--- a/src/data/proofs/prime-gap-bounds-oq-02/annotations.json
+++ b/src/data/proofs/prime-gap-bounds-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-pgb-oq02-header",
+    "proofId": "prime-gap-bounds-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "Which Half of Rosser–Schoenfeld Is Reachable Axiom-Free",
+    "content": "Rosser–Schoenfeld (1962) give x/log x < π(x) < 1.25506·x/log x, with sharp constants needing a numerical zero-free region and an explicit PNT. The header explains that only the UPPER bound is derivable from today's Mathlib — from the Chebyshev estimate θ(x) ≤ log4·x — yielding the non-sharp but honest π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x. The lower bound and sharp constants are blocked on a Chebyshev lower bound and explicit PNT that Mathlib lacks.",
+    "mathContext": "θ(x) = Σ_{p ≤ x} log p; Mathlib has θ(x) ≤ log4·x but no θ(x) ≥ c·x and no θ↔π bridge.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Rosser–Schoenfeld",
+      "Chebyshev function",
+      "prime number theorem",
+      "explicit bounds"
+    ],
+    "prerequisites": [
+      "prime counting function",
+      "Chebyshev θ"
+    ]
+  },
+  {
+    "id": "ann-pgb-oq02-bridge",
+    "proofId": "prime-gap-bounds-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "count_primes_Ioc: the θ↔π Bridge (a Mathlib TODO)",
+    "content": "Mathlib's Chebyshev.lean explicitly flags 'relate theta and psi to the prime counting function' as a TODO. count_primes_Ioc supplies exactly this: #{p ∈ (a,b] : prime} = π(b) − π(a). The proof first shows #{p ≤ m : prime} = π(m) via Nat.primesBelow (primes < m+1 = primes ≤ m), then splits Iic b = Iic a ⊔ Ioc a b and uses Finset.card_union_of_disjoint on the prime filters. This is pure finite combinatorics and is reusable for any θ/ψ-to-π transfer.",
+    "mathContext": "#{p ∈ Ioc a b : Prime} = π(b) − π(a), from Iic b = Iic a ⊔ Ioc a b.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Nat.primesBelow",
+      "primeCounting",
+      "disjoint filter cardinality",
+      "Iic/Ioc split"
+    ],
+    "prerequisites": [
+      "Nat.primesBelow_card_eq_primeCounting'",
+      "Finset.card_union_of_disjoint"
+    ]
+  },
+  {
+    "id": "ann-pgb-oq02-trivial",
+    "proofId": "prime-gap-bounds-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "π(n) ≤ n+1 for the Small Primes",
+    "content": "primeCounting_le_succ bounds π(n) ≤ n+1, since the primes ≤ n are among {0,…,n}: card_filter_le on range(n+1). This handles the primes below √x, whose contribution π(⌊√x⌋) ≤ √x + 1 is the lower-order term of the final bound.",
+    "mathContext": "π(n) ≤ n+1 via #(filter Prime (range (n+1))) ≤ #range(n+1).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "primeCounting",
+      "Finset.card_filter_le",
+      "trivial bound"
+    ],
+    "prerequisites": [
+      "Nat.primesBelow_card_eq_primeCounting'"
+    ]
+  },
+  {
+    "id": "ann-pgb-oq02-main",
+    "proofId": "prime-gap-bounds-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 194
+    },
+    "type": "theorem",
+    "title": "The Explicit Chebyshev Upper Bound on π(x)",
+    "content": "primeCounting_floor_le proves π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x for x > 1. Key step: every prime p with √x < p ≤ x satisfies log p ≥ log √x = ½ log x (Real.log_sqrt), so keeping only the tail of θ(x) = Σ_{p ≤ x} log p gives θ(x) ≥ (½ log x)·#{√x < p ≤ x : prime} = (½ log x)(π(⌊x⌋) − π(⌊√x⌋)) via sum_le_sum and sum_le_sum_of_subset_of_nonneg. Combined with θ(x) ≤ log4·x and divided by ½ log x > 0, then adding π(⌊√x⌋) ≤ √x + 1, this yields the bound. The constant 2log4 = log16 ≈ 2.77 is non-sharp but the result is unconditional and axiom-free.",
+    "mathContext": "π(⌊x⌋) − π(⌊√x⌋) ≤ (2log4)x/log x, and π(⌊√x⌋) ≤ √x + 1 ⟹ π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev tail argument",
+      "theta_le_log4_mul_x",
+      "Real.log_sqrt",
+      "single-scale √x"
+    ],
+    "prerequisites": [
+      "Chebyshev.theta_le_log4_mul_x",
+      "count_primes_Ioc",
+      "Finset.sum_le_sum_of_subset_of_nonneg"
+    ]
+  }
+]

--- a/src/data/proofs/prime-gap-bounds-oq-02/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "prime-gap-bounds-oq-02",
+  "title": "An Explicit Chebyshev-Type Upper Bound on π(x), Axiom-Free",
+  "slug": "prime-gap-bounds-oq-02",
+  "description": "The Rosser–Schoenfeld inequalities x/log x < π(x) < 1.25506·x/log x have sharp constants that require a numerically verified zero-free region and an explicit prime number theorem — out of reach of current Mathlib. This entry derives the UPPER half, axiom-free, from Mathlib's Chebyshev estimate θ(x) ≤ log4·x, obtaining π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x for x > 1 (constant 2log4 = log16 ≈ 2.77, non-sharp but honest). The core new content is the θ↔π bridge count_primes_Ioc (#{primes in (a,b]} = π(b)−π(a)), an explicit TODO in Mathlib's Chebyshev.lean, plus the elementary tail argument: every prime p in (√x, x] contributes log p > ½log x to θ(x). Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rosser%27s_theorem",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/BoundedPrimeGapsOQ02Chebyshev.lean",
+    "tags": [
+      "prime-counting",
+      "chebyshev",
+      "rosser-schoenfeld",
+      "analytic-number-theory",
+      "explicit-bounds",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.theta_le_log4_mul_x",
+        "description": "θ(x) ≤ log 4 · x — Chebyshev's upper bound on the first Chebyshev function, the sole analytic input",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Nat.primesBelow_card_eq_primeCounting'",
+        "description": "#(primesBelow n) = π'(n) — connects the prime-counting function to a Finset cardinality, used to build the θ↔π bridge",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Real.log_sqrt",
+        "description": "log(√x) = log x / 2 — turns the tail estimate log p ≥ log √x into log p ≥ ½ log x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.monotone_primeCounting",
+        "description": "π is monotone — gives π(⌊√x⌋) ≤ π(⌊x⌋), needed to cast the truncated subtraction over ℝ",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      }
+    ],
+    "originalContributions": [
+      "count_primes_Ioc: the θ↔π bridge — #{p ∈ (a,b] : prime} = π(b) − π(a). Mathlib's Chebyshev.lean has an explicit TODO 'Upstream the results relating theta and psi to the prime counting function'; this supplies the missing link via primesBelow, Iic/Ioc splitting, and disjoint-filter cardinality.",
+      "primeCounting_le_succ: π(n) ≤ n+1, since the primes ≤ n are among {0,…,n} (card_filter_le on range).",
+      "primeCounting_floor_le: the main result — π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x for x > 1, a Rosser–Schoenfeld-spirit explicit upper bound derived axiom-free from Chebyshev's θ(x) ≤ log4·x via the tail argument log p > ½log x for √x < p ≤ x."
+    ],
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via a clean `lake env lean` build and #print axioms on the main theorems. No native_decide. The upper bound is unconditional; the lower bound and sharp constants are NOT claimed (see open questions).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev (1852) proved that π(x) is bounded above and below by constant multiples of x/log x, decades before the prime number theorem. Rosser and Schoenfeld (1962) made these bounds fully explicit — x/log x < π(x) < 1.25506·x/log x for x ≥ 17 — using a numerically verified zero-free region for the Riemann zeta function together with an explicit form of the PNT with error term. These explicit bounds underpin much of computational analytic number theory. In Lean's Mathlib, the Chebyshev function θ(x) = Σ_{p ≤ x} log p is available with the upper estimate θ(x) ≤ log4·x, but the library has no Chebyshev lower bound, no explicit PNT, and — flagged by its own TODO — no bridge between θ and the prime-counting function π = Nat.primeCounting.",
+    "problemStatement": "Prove Rosser–Schoenfeld-type explicit bounds on π(x) in Lean 4. Which half is reachable axiom-free from today's Mathlib, and what is the resulting explicit constant?",
+    "text": "The UPPER bound is reachable and is proved here: for x > 1, π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x. The constant 2log4 = log16 ≈ 2.77 is larger than Rosser–Schoenfeld's sharp 1.25506, but the bound is unconditional and axiom-free. The LOWER bound x/log x < π(x) and the sharp constants are NOT proved: they require a Chebyshev lower bound θ(x) ≥ c·x (absent from Mathlib) and, for sharpness, the full explicit PNT plus a numerical zero-free region.",
+    "proofStrategy": "Three steps. (1) The θ↔π bridge count_primes_Ioc: writing #{p ≤ m : prime} = π(m) via Nat.primesBelow, split Iic b = Iic a ⊔ Ioc a b and use disjoint-filter cardinality to get #{p ∈ (a,b] : prime} = π(b) − π(a). (2) The tail estimate: for a prime p with √x < p ≤ x one has log p ≥ log √x = ½ log x; keeping only these primes in θ(x) = Σ_{p ≤ x} log p and using sum_le_sum / sum_le_sum_of_subset_of_nonneg gives θ(x) ≥ (½ log x)·#{√x < p ≤ x : prime} = (½ log x)(π(⌊x⌋) − π(⌊√x⌋)). (3) Combine with θ(x) ≤ log4·x and divide by ½ log x > 0 to get π(⌊x⌋) − π(⌊√x⌋) ≤ (2log4)x/log x; finally π(⌊√x⌋) ≤ ⌊√x⌋ + 1 ≤ √x + 1.",
+    "keyInsights": [
+      "The single scale √x is what makes the elementary argument work: primes below √x are too few (≤ √x of them) to matter, and primes above √x each contribute at least ½ log x to θ.",
+      "The θ↔π bridge is pure finite combinatorics once phrased through Nat.primesBelow: Iic b = Iic a ⊔ Ioc a b and disjoint filters give the exact difference π(b) − π(a).",
+      "Only the UPPER Chebyshev bound θ ≤ log4·x is available in Mathlib; the entire asymmetry between the reachable upper bound and the blocked lower bound traces to the absence of a matching θ ≥ c·x lower bound.",
+      "Casting the truncated ℕ subtraction π(b) − π(a) to ℝ needs monotonicity π(a) ≤ π(b), obtained from ⌊√x⌋ ≤ ⌊x⌋ via √x ≤ x.",
+      "The non-sharp constant log16 is the price of the elementary θ-only argument; the sharp 1.25506 genuinely needs the analytic zero-free-region machinery that Mathlib does not yet have."
+    ],
+    "prerequisites": [
+      "the Chebyshev function θ(x) = Σ_{p ≤ x} log p and the estimate θ(x) ≤ log4·x",
+      "Nat.primeCounting / Nat.primesBelow and their cardinality characterization",
+      "Finset filtering, Iic/Ioc splitting, and disjoint-union cardinality",
+      "basic real-log facts: log_sqrt, log monotonicity, log_nonneg"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-bridge",
+      "title": "The θ↔π Bridge (Mathlib TODO)",
+      "startLine": 60,
+      "endLine": 94,
+      "summary": "count_primes_Ioc: #{p ∈ (a,b] : prime} = π(b) − π(a). Proves #{p ≤ m : prime} = π(m) through Nat.primesBelow, then splits Iic b = Iic a ⊔ Ioc a b and applies disjoint-filter cardinality. This supplies the θ↔prime-counting link Mathlib's Chebyshev.lean flags as a TODO.",
+      "mathContext": "#{p ∈ Ioc a b : Prime} = π(b) − π(a) for a ≤ b."
+    },
+    {
+      "id": "sec-trivial",
+      "title": "The Trivial π(n) ≤ n+1 Bound",
+      "startLine": 95,
+      "endLine": 105,
+      "summary": "primeCounting_le_succ: π(n) ≤ n+1, since the primes ≤ n lie among {0,…,n} (card_filter_le on range(n+1)). Used to bound the small primes π(⌊√x⌋) ≤ √x + 1.",
+      "mathContext": "π(n) ≤ n+1."
+    },
+    {
+      "id": "sec-main",
+      "title": "The Explicit Upper Bound on π(x)",
+      "startLine": 106,
+      "endLine": 194,
+      "summary": "primeCounting_floor_le: π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x for x > 1. Lower-bounds θ(x) by the tail Σ_{√x < p ≤ x} log p ≥ (½ log x)(π(⌊x⌋) − π(⌊√x⌋)) (each such prime has log p ≥ log √x = ½ log x), combines with θ(x) ≤ log4·x, and bounds the small primes π(⌊√x⌋) ≤ √x + 1.",
+      "mathContext": "π(⌊x⌋) ≤ √x + 1 + (2 log 4)·x/log x = √x + 1 + (log 16)·x/log x, x > 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The upper half of the Rosser–Schoenfeld π-bounds is formalized axiom-free: π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x for x > 1, derived from Mathlib's Chebyshev estimate θ(x) ≤ log4·x by an elementary tail argument. The needed θ↔π bridge — a standing Mathlib TODO — is supplied as count_primes_Ioc.",
+    "implications": "This is the reachable, unconditional half of the classical explicit prime-counting bounds. The θ↔π bridge count_primes_Ioc is reusable for any future θ/ψ-to-π transfer (and is a candidate for upstreaming, since Mathlib flags exactly this gap). The non-sharp constant log16 and the missing lower bound precisely delimit what elementary Chebyshev input can and cannot deliver: the sharp constant 1.25506 and the lower bound x/log x < π(x) are blocked on a Chebyshev lower bound and an explicit PNT with a numerical zero-free region, none of which are yet in Mathlib.",
+    "openQuestions": [
+      "Prove a Chebyshev LOWER bound θ(x) ≥ c·x in Mathlib (also a Chebyshev.lean TODO); combined with the bridge here it would give the lower half x/log x ≲ π(x).",
+      "Sharpen the constant from log16 ≈ 2.77 toward the Rosser–Schoenfeld 1.25506 using a more careful weighting of θ than the single-scale √x tail.",
+      "Upstream count_primes_Ioc (or a ψ/θ variant) to Mathlib, discharging its standing 'relate theta/psi to the prime counting function' TODO."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prime-gap-bounds",
+      "relationship": "ancestor",
+      "description": "Root entry (pₙ ≤ 2^{n+1} from Bertrand). This entry treats the π(x) side of explicit prime bounds, complementing the n-th-prime bounds of the family."
+    },
+    {
+      "targetId": "prime-gap-bounds-oq-01",
+      "relationship": "sibling",
+      "description": "Dusart-type n-th-prime bounds (axiomatized). This entry proves the π(x) upper bound instead, and does so axiom-free — the two are the pₙ-form and π(x)-form of Rosser–Schoenfeld."
+    },
+    {
+      "targetId": "prime-gap-bounds-oq-03",
+      "relationship": "sibling",
+      "description": "Connects the exponential prime bound to the Chebyshev functions θ and ψ; this entry uses θ's explicit upper estimate to bound π directly."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat.Prime"
+    ],
+    "namespace": "BoundedPrimeGapsOQ02Chebyshev",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/BoundedPrimeGapsOQ02Chebyshev.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **prime-gap-bounds-oq-02**. The problem asks for the Rosser–Schoenfeld π(x) bounds. Their sharp constants (`x/log x < π(x) < 1.25506·x/log x`) need a numerically verified zero-free region and an explicit PNT — neither in Mathlib. This entry proves the **upper half axiom-free** from Mathlib's Chebyshev estimate `θ(x) ≤ log4·x`:

> **π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x**   for `x > 1`

The constant `2 log 4 = log 16 ≈ 2.77` is non-sharp, but the bound is **unconditional and 0-axiom**. This realizes the recommended-next-step from the problem's own `knowledge.md` feasibility map.

## Results (3 theorems, 194 lines, 0 axioms)

| Name | Statement |
|---|---|
| `count_primes_Ioc` | **the θ↔π bridge** — `#{p ∈ (a,b] : prime} = π(b) − π(a)` |
| `primeCounting_le_succ` | `π(n) ≤ n+1` (small primes below √x) |
| `primeCounting_floor_le` | **main:** `π(⌊x⌋) ≤ √x + 1 + (log 16)·x/log x` |

**The bridge is the substantive new content.** Mathlib's `NumberTheory/Chebyshev.lean` carries an explicit TODO — *"Upstream the results relating `theta` and `psi` to the prime counting function"* — i.e. there is no θ↔π link. `count_primes_Ioc` supplies it (via `Nat.primesBelow`, an `Iic b = Iic a ⊔ Ioc a b` split, and disjoint-filter cardinality) and is reusable/upstreamable.

**The argument:** every prime `p` with `√x < p ≤ x` contributes `log p > log √x = ½ log x` to `θ(x) = Σ_{p ≤ x} log p`. Keeping only that tail gives `θ(x) ≥ (½ log x)(π(⌊x⌋) − π(⌊√x⌋))`; combine with `θ(x) ≤ log4·x` and `π(⌊√x⌋) ≤ √x + 1`.

## Scope / honesty

- **Upper bound only.** The lower bound `x/log x < π(x)` and the sharp constant `1.25506` are **not** claimed — they are blocked on a Chebyshev *lower* bound (also a Mathlib TODO) and an explicit PNT with a numerical zero-free region. This is documented in the entry's open questions.

## Verification

- Self-contained (`import Mathlib`); **0 axioms** (`#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`); 0 sorries; no `native_decide`.
- Verified with `lake env lean` against Mathlib 4.26.0.
- Gallery `meta.json` (status `verified`) + 4 annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)