### PR TITLE
research(amgm-inequality-oq-02-oq-02-oq-02): Maclaurin equality case — sufficiency direction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ02.lean
@@ -1,0 +1,124 @@
+/-
+  Maclaurin's Inequality: The Equality Case (Sufficiency Direction)
+  Research: amgm-inequality-oq-02-oq-02-oq-02
+
+  The parent formalization `amgm-inequality-oq-02-oq-02`
+  (`Proofs.AmgmInequalityOQ02`) proves Newton's log-concavity and the
+  Maclaurin step Mₖ(x) ≥ Mₖ₊₁(x), where
+
+      Mⱼ(x) = (eⱼ(x) / C(n,j))^(1/j)
+
+  and eⱼ is the j-th elementary symmetric polynomial.  Its list of open
+  questions asks (OQ-02) for the **equality case**:
+
+      Mₖ(x) = Mₖ₊₁(x)   ⟺   all non-zero inputs are equal.
+
+  This file settles the *sufficiency* (⟸) direction in full generality:
+  when every coordinate equals a common constant c ≥ 0, every Maclaurin
+  mean collapses to c, so the whole chain M₁ = M₂ = ⋯ = Mₙ = c consists of
+  equalities.  The necessity (⟹) direction — that equality forces the
+  inputs to be equal up to a zero block — requires tracking when the
+  discriminant in the cleared-denominator induction is exactly zero and is
+  left open (spawns a further child problem).
+
+  Main results (0 axioms, 0 sorries):
+  1. `elemSymm_const`        — eₖ(c,…,c) = C(n,k)·cᵏ
+  2. `maclaurinMean_const`   — Mₖ(c,…,c) = c  (for c ≥ 0, 1 ≤ k ≤ n)
+  3. `maclaurin_eq_of_const` — consecutive means agree on a constant input
+  4. `maclaurin_all_eq_of_const` — every two means agree on a constant input
+  5. `not_const_of_maclaurin_ne` — contrapositive: differing means ⟹ the
+     input is not constant
+
+  References:
+  - Hardy–Littlewood–Pólya "Inequalities" (1934) §2.22
+  - Maclaurin (1729)
+  - AmgmInequalityOQ02.lean (parent formalization; source of eₖ, Mₖ)
+-/
+
+import Proofs.AmgmInequalityOQ02
+
+open Finset Real
+
+namespace MaclaurinEquality
+
+/-!
+## Elementary symmetric polynomials on a constant input
+
+If every coordinate equals `c`, then each product over a `k`-element subset
+is `cᵏ`, and there are exactly `C(n,k)` such subsets.  Hence
+`eₖ(c,…,c) = C(n,k)·cᵏ`.
+-/
+
+/-- The `k`-th elementary symmetric polynomial of the constant vector
+    `(c, …, c)` on `n` coordinates equals `C(n,k)·cᵏ`. -/
+theorem elemSymm_const {n : ℕ} (k : ℕ) (c : ℝ) :
+    elemSymm k (fun _ : Fin n => c) = (Nat.choose n k : ℝ) * c ^ k := by
+  unfold elemSymm
+  -- Every product over a `k`-subset is `c^k`.
+  have hprod : ∀ s ∈ (univ : Finset (Fin n)).powersetCard k,
+      (∏ _i ∈ s, c) = c ^ k := by
+    intro s hs
+    rw [Finset.mem_powersetCard] at hs
+    rw [Finset.prod_const, hs.2]
+  rw [Finset.sum_congr rfl hprod, Finset.sum_const, Finset.card_powersetCard,
+      Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+
+/-!
+## Maclaurin means on a constant input
+
+For `1 ≤ k ≤ n` and `c ≥ 0`, the normalization cancels `C(n,k)` and the
+outer `(·)^(1/k)` inverts the inner `cᵏ`, giving `Mₖ(c,…,c) = c`.
+-/
+
+/-- Each Maclaurin mean of a non-negative constant vector equals that
+    constant: `Mₖ(c, …, c) = c`. -/
+theorem maclaurinMean_const {n : ℕ} (k : ℕ) (c : ℝ) (hc : 0 ≤ c)
+    (hk : 1 ≤ k) (hkn : k ≤ n) :
+    maclaurinMean k (fun _ : Fin n => c) = c := by
+  have hchoose : (0 : ℝ) < (Nat.choose n k : ℝ) := by
+    have : 0 < Nat.choose n k := Nat.choose_pos hkn
+    exact_mod_cast this
+  have hkne : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  unfold maclaurinMean
+  rw [elemSymm_const]
+  -- (C(n,k)·cᵏ)/C(n,k) = cᵏ
+  rw [mul_comm, mul_div_assoc, div_self hchoose.ne', mul_one]
+  -- (cᵏ)^(1/k) = c
+  rw [← Real.rpow_natCast c k, ← Real.rpow_mul hc, mul_one_div, div_self hkne,
+      Real.rpow_one]
+
+/-- **Sufficiency, consecutive form.**  On a non-negative constant input the
+    Maclaurin step is an equality: `Mₖ(c,…,c) = Mₖ₊₁(c,…,c)`. -/
+theorem maclaurin_eq_of_const {n : ℕ} (k : ℕ) (c : ℝ) (hc : 0 ≤ c)
+    (hk : 1 ≤ k) (hkn : k + 1 ≤ n) :
+    maclaurinMean k (fun _ : Fin n => c) = maclaurinMean (k + 1) (fun _ : Fin n => c) := by
+  rw [maclaurinMean_const k c hc hk (by omega),
+      maclaurinMean_const (k + 1) c hc (by omega) hkn]
+
+/-- **Sufficiency, full chain.**  On a non-negative constant input *every*
+    pair of Maclaurin means (with indices in `1..n`) agrees; the whole
+    chain `M₁ = M₂ = ⋯ = Mₙ = c` collapses to a single value. -/
+theorem maclaurin_all_eq_of_const {n : ℕ} (j k : ℕ) (c : ℝ) (hc : 0 ≤ c)
+    (hj : 1 ≤ j) (hjn : j ≤ n) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    maclaurinMean j (fun _ : Fin n => c) = maclaurinMean k (fun _ : Fin n => c) := by
+  rw [maclaurinMean_const j c hc hj hjn, maclaurinMean_const k c hc hk hkn]
+
+/-!
+## Contrapositive
+
+If two Maclaurin means of `x` disagree, then `x` cannot be a non-negative
+constant vector.  This is the logically-equivalent statement of the
+sufficiency direction and is the shape used when Maclaurin's inequality is
+applied to detect non-constant data.
+-/
+
+/-- **Contrapositive of sufficiency.**  If some consecutive Maclaurin means
+    of `x` differ, then `x` is not a non-negative constant vector. -/
+theorem not_const_of_maclaurin_ne {n : ℕ} (k : ℕ) (x : Fin n → ℝ)
+    (hk : 1 ≤ k) (hkn : k + 1 ≤ n)
+    (h : maclaurinMean k x ≠ maclaurinMean (k + 1) x) :
+    ¬ ∃ c : ℝ, 0 ≤ c ∧ x = fun _ => c := by
+  rintro ⟨c, hc, rfl⟩
+  exact h (maclaurin_eq_of_const k c hc hk hkn)
+
+end MaclaurinEquality

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "amgm-inequality-oq-02-oq-02-oq-02",
+  "title": "Maclaurin's Inequality: The Equality Case (Sufficiency Direction)",
+  "slug": "amgm-inequality-oq-02-oq-02-oq-02",
+  "description": "The sufficiency (⟸) half of the equality case for Maclaurin's inequality: if every coordinate equals a common constant c ≥ 0, then every Maclaurin mean collapses to c, so the whole chain M₁ = M₂ = ⋯ = Mₙ = c consists of equalities. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Maclaurin%27s_inequality",
+    "date": "Classical result (Maclaurin 1729); formalized 2026",
+    "status": "verified",
+    "tags": [
+      "inequalities",
+      "elementary-symmetric-polynomials",
+      "maclaurin-inequalities",
+      "equality-case",
+      "am-gm",
+      "symmetric-functions"
+    ],
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ02OQ02.lean",
+    "additionalFiles": [],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 5 theorems verified with 0 sorries and 0 axioms (standard Lean axioms propext / Classical.choice / Quot.sound only). Imports AmgmInequalityOQ02.lean (parent) for the definitions of elemSymm and maclaurinMean.",
+    "originalContributions": [
+      "elemSymm_const: eₖ(c,…,c) = C(n,k)·cᵏ — the k-th elementary symmetric polynomial of a constant vector, via prod_const over each k-subset and card_powersetCard",
+      "maclaurinMean_const: Mₖ(c,…,c) = c for c ≥ 0 and 1 ≤ k ≤ n — the normalization cancels C(n,k) and the outer (·)^(1/k) rpow inverts the inner cᵏ",
+      "maclaurin_eq_of_const: the Maclaurin step Mₖ = Mₖ₊₁ is an equality on any non-negative constant input (sufficiency, consecutive form)",
+      "maclaurin_all_eq_of_const: every two Maclaurin means agree on a constant input — the full chain M₁ = ⋯ = Mₙ = c collapses to one value",
+      "not_const_of_maclaurin_ne: contrapositive — if consecutive Maclaurin means of x differ, then x is not a non-negative constant vector"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 124,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "problemStatement": "**Equality case of Maclaurin's inequality.** With Mⱼ(x) = (eⱼ(x)/C(n,j))^(1/j) the j-th Maclaurin mean of non-negative x₁,…,xₙ, the parent formalization (amgm-inequality-oq-02-oq-02) proves the chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ and poses as open question OQ-02 the equality characterization:\n\nMₖ(x) = Mₖ₊₁(x)  ⟺  all non-zero inputs are equal.\n\nThis entry settles the **sufficiency (⟸)** direction in full generality: a constant input forces equality throughout the chain.",
+    "proofStrategy": "The argument is a direct computation. On the constant vector (c,…,c) each product over a k-element subset is cᵏ, and there are C(n,k) subsets, so eₖ(c,…,c) = C(n,k)·cᵏ (`elemSymm_const`). Dividing by the normalizing C(n,k) leaves cᵏ, and the outer rpow exponent 1/k inverts it for c ≥ 0, giving Mₖ(c,…,c) = c (`maclaurinMean_const`). Since every mean equals the same c, all of them coincide (`maclaurin_all_eq_of_const`), and in particular the Maclaurin step is an equality (`maclaurin_eq_of_const`). The contrapositive `not_const_of_maclaurin_ne` restates this as: differing means witness non-constant data.",
+    "keyInsights": [
+      "The equality case splits into an easy sufficiency direction (constant ⟹ equality) and a hard necessity direction (equality ⟹ constant). This entry closes the sufficiency direction cleanly and generally.",
+      "The whole sufficiency argument reduces to two facts: the closed form eₖ(c,…,c) = C(n,k)·cᵏ and the rpow identity (cᵏ)^(1/k) = c for c ≥ 0.",
+      "Working with the parent's exact definitions of elemSymm and maclaurinMean (rather than a restatement) makes the result a drop-in companion to the Maclaurin chain, usable wherever the parent's inequality is applied."
+    ],
+    "historicalContext": "Colin Maclaurin stated his mean inequalities in *A Treatise of Algebra* (1748, posthumous), sharpening Newton's inequalities on the elementary symmetric functions of the roots of a polynomial. The equality analysis — that the chain of Maclaurin means is constant exactly when the inputs are equal — is the natural companion to the inequality and mirrors the AM ≥ GM equality case (AM = GM iff all terms equal), which is itself the extreme M₁ = Mₙ instance of this chain."
+  },
+  "references": [
+    {
+      "authors": "Maclaurin, Colin",
+      "title": "A Treatise of Algebra",
+      "year": "1748",
+      "venue": "London (posthumous)",
+      "note": "Source of the Maclaurin mean inequalities M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, with the classical observation that equality throughout holds exactly when the inputs coincide."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "§2.22 develops Newton's and Maclaurin's inequalities and discusses the equality conditions in terms of the discriminant of the associated real-rooted polynomial."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Answers the sufficiency direction of open question OQ-02 (the equality case) posed by the parent proof of Newton's log-concavity and the Maclaurin step."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "ancestor",
+      "description": "The Maclaurin mean chain M₁ ≥ ⋯ ≥ Mₙ whose equality case is analyzed here."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "ancestor",
+      "description": "AM ≥ GM is the extreme instance M₁ ≥ Mₙ of the Maclaurin chain; its equality case (AM = GM iff all equal) is the endpoint of the characterization begun here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "maclaurinMean_const",
+      "type": "core",
+      "statement": "$\\forall n\\, k \\in \\mathbb{N},\\ \\forall c \\in \\mathbb{R},\\ 0 \\le c \\Rightarrow 1 \\le k \\Rightarrow k \\le n \\Rightarrow M_k(c,\\dots,c) = c$",
+      "significance": "**The computational heart of the entry.** Each Maclaurin mean of a non-negative constant vector equals that constant. The normalization by $\\binom{n}{k}$ cancels the count of $k$-subsets, and the rpow exponent $1/k$ inverts the inner $c^k$ (valid because $c \\ge 0$). Everything else follows from this identity."
+    },
+    {
+      "name": "elemSymm_const",
+      "type": "supporting",
+      "statement": "$\\forall n\\, k \\in \\mathbb{N},\\ \\forall c \\in \\mathbb{R},\\ e_k(c,\\dots,c) = \\binom{n}{k}\\, c^k$",
+      "significance": "Closed form for the elementary symmetric polynomial of a constant vector: every product over a $k$-element subset equals $c^k$, and there are exactly $\\binom{n}{k}$ such subsets."
+    },
+    {
+      "name": "maclaurin_eq_of_const",
+      "type": "core",
+      "statement": "$\\forall n\\, k \\in \\mathbb{N},\\ \\forall c \\in \\mathbb{R},\\ 0 \\le c \\Rightarrow 1 \\le k \\Rightarrow k+1 \\le n \\Rightarrow M_k(c,\\dots,c) = M_{k+1}(c,\\dots,c)$",
+      "significance": "**Sufficiency, consecutive form.** On a non-negative constant input the Maclaurin step is an equality — the ⟸ direction of OQ-02 for a single step."
+    },
+    {
+      "name": "maclaurin_all_eq_of_const",
+      "type": "core",
+      "statement": "$\\forall n\\, j\\, k \\in \\mathbb{N},\\ \\forall c \\in \\mathbb{R},\\ 0 \\le c \\Rightarrow 1 \\le j \\Rightarrow j \\le n \\Rightarrow 1 \\le k \\Rightarrow k \\le n \\Rightarrow M_j(c,\\dots,c) = M_k(c,\\dots,c)$",
+      "significance": "**Sufficiency, full chain.** Every pair of Maclaurin means (indices in $1..n$) agrees on a constant input, so the whole chain $M_1 = M_2 = \\cdots = M_n = c$ collapses to one value."
+    },
+    {
+      "name": "not_const_of_maclaurin_ne",
+      "type": "corollary",
+      "statement": "$\\forall n\\, k \\in \\mathbb{N},\\ \\forall x : \\mathrm{Fin}\\,n \\to \\mathbb{R},\\ 1 \\le k \\Rightarrow k+1 \\le n \\Rightarrow M_k(x) \\ne M_{k+1}(x) \\Rightarrow \\neg\\, \\exists c,\\ 0 \\le c \\wedge x = (\\lambda\\_.\\,c)$",
+      "significance": "**Contrapositive of sufficiency.** If two consecutive Maclaurin means of $x$ differ, then $x$ is not a non-negative constant vector — the shape used when Maclaurin's inequality is applied to detect non-constant data."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.AmgmInequalityOQ02"
+    ],
+    "namespace": "MaclaurinEquality",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ02OQ02OQ02.lean",
+    "additionalFiles": [],
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "title": "Elementary symmetric polynomials on a constant input",
+      "description": "`elemSymm_const` computes eₖ(c,…,c) = C(n,k)·cᵏ. Each product over a k-subset is c^k (prod_const together with the |s| = k membership fact), and Finset.card_powersetCard counts the C(n,k) subsets."
+    },
+    {
+      "title": "Maclaurin means on a constant input",
+      "description": "`maclaurinMean_const` shows Mₖ(c,…,c) = c. After substituting elemSymm_const, the factor C(n,k) cancels (div_self, using Nat.choose_pos for k ≤ n), and (cᵏ)^(1/k) = c is obtained via Real.rpow_natCast and Real.rpow_mul with k ≠ 0."
+    },
+    {
+      "title": "Equality of the Maclaurin chain",
+      "description": "`maclaurin_eq_of_const` and `maclaurin_all_eq_of_const` rewrite every mean to c, collapsing the chain M₁ = ⋯ = Mₙ. `not_const_of_maclaurin_ne` is the contrapositive."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof of the sufficiency direction of the equality case for Maclaurin's inequality: a non-negative constant input forces every Maclaurin mean to equal that constant, hence M₁ = M₂ = ⋯ = Mₙ. The five theorems reduce to the closed form eₖ(c,…,c) = C(n,k)·cᵏ and the rpow identity (cᵏ)^(1/k) = c.",
+    "implications": "This closes the ⟸ half of the parent's open question OQ-02. Combined with the parent's chain M₁ ≥ ⋯ ≥ Mₙ, it pins down the value of the chain on constant inputs and gives the ready-to-use contrapositive test for non-constant data.",
+    "openQuestions": [
+      "**Necessity (⟹ direction).** Prove that Mₖ(x) = Mₖ₊₁(x) forces the non-zero inputs to be equal (up to one zero block). This requires tracking when the discriminant in the parent's cleared-denominator induction is exactly zero and propagating that equality; it is the substantive remaining half of OQ-02.",
+      "**First non-trivial converse case.** As a stepping stone, characterize the base step directly: M₁(x) = M₂(x) ⟺ all xᵢ are equal. Via the identity (∑xᵢ)² = ∑xᵢ² + 2e₂ this reduces to the Cauchy–Schwarz equality condition n·∑xᵢ² = (∑xᵢ)², provable from ∑_{i,j}(xᵢ − xⱼ)² = 2(n·∑xᵢ² − (∑xᵢ)²).",
+      "**Strict inequality.** Formalize the strict form Mₖ(x) > Mₖ₊₁(x) whenever the inputs are not all equal, the quantitative complement of the equality case."
+    ]
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry `amgm-inequality-oq-02-oq-02-oq-02` answering the **sufficiency (⟸) half** of open question OQ-02 (the *equality case*) posed by the parent `amgm-inequality-oq-02-oq-02` (Newton log-concavity / Maclaurin step).

With $M_j(x) = (e_j(x)/\binom{n}{j})^{1/j}$ the Maclaurin means, OQ-02 asks to characterize when $M_k = M_{k+1}$. This entry proves the easy direction **in full generality**: a non-negative constant input forces every mean to equal that constant, so the whole chain $M_1 = M_2 = \cdots = M_n = c$ collapses to equalities.

## Theorems (5, verified, 0 sorries, 0 axioms)

- `elemSymm_const`: $e_k(c,\dots,c) = \binom{n}{k} c^k$
- `maclaurinMean_const`: $M_k(c,\dots,c) = c$ for $c \ge 0,\ 1 \le k \le n$
- `maclaurin_eq_of_const`: $M_k = M_{k+1}$ on a constant input (consecutive form)
- `maclaurin_all_eq_of_const`: every two means agree — full chain collapse
- `not_const_of_maclaurin_ne`: contrapositive — differing means ⟹ non-constant input

## Verification

Built with `lake env lean` against Mathlib v4.26.0. `#print axioms` on all five theorems shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → genuinely 0-axiom. Imports the parent `Proofs.AmgmInequalityOQ02` for the actual `elemSymm` / `maclaurinMean` definitions, so the result is a drop-in companion to the Maclaurin chain.

## Scope / remaining

The **necessity** direction (equality ⟹ inputs equal, up to a zero block) needs discriminant-zero propagation through the parent's cleared-denominator induction and is documented as open (spawns a further child, with the first converse case $M_1 = M_2$ noted as a tractable stepping stone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)