### PR TITLE
Add missing gallery entry: sperner-mathlib4-oq-02 (Tucker door-choice obstruction)

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "sperner-oq02-encoding",
+    "proofId": "sperner-mathlib4-oq-02",
+    "range": { "startLine": 80, "endLine": 96 },
+    "type": "definition",
+    "title": "Labels, complementarity, and the antipodal hexagon",
+    "content": "The four Tucker labels {+1,+2,-1,-2} are encoded as Fin 4 (0↦+1, 1↦+2, 2↦-1, 3↦-2) with negation negL = ![2,3,0,1], an involution. Two labels are complementary, Compl x y := x = negL y, with a Decidable instance so the whole model is checkable by decide. V a b c gives the six boundary labels from three free labels a,b,c of v0,v1,v2, with the antipodal condition v(i+3) = -v i built in as negL a, negL b, negL c. rot i = i+1 is the cyclic successor around the hexagon.",
+    "mathContext": "$\\mathrm{negL}:\\mathbb{F}_4\\to\\mathbb{F}_4,\\quad \\mathrm{Compl}(x,y)\\iff x=\\mathrm{negL}(y),\\quad V(a,b,c)=(a,b,c,-a,-b,-c)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Tucker labelling", "antipodal symmetry", "Fin 4", "involution", "Decidable"],
+    "prerequisites": ["Tucker's lemma setup", "the hexagon-plus-centre triangulation of B²"]
+  },
+  {
+    "id": "sperner-oq02-degree-bound",
+    "proofId": "sperner-mathlib4-oq-02",
+    "range": { "startLine": 98, "endLine": 109 },
+    "type": "theorem",
+    "title": "The spoke-door graph has max degree ≤ 2",
+    "content": "degSpoke a b c d i counts how many of triangle Ti's two spokes (centre—v i and centre—v(i+1)) are complementary to the centre label d. degSpoke_le_two proves this is always ≤ 2, over all 4⁴ = 256 antipodal labellings and 6 triangles, by kernel decide. This is the crucial point of the obstruction: the naive door graph is a legal input to the path-following engine — it genuinely satisfies the paths-and-cycles hypothesis ∀ v, degree v ≤ 2 — so its failure is not a matter of ill-formedness.",
+    "mathContext": "$\\forall a,b,c,d,i:\\ \\deg_{\\mathrm{spoke}}(a,b,c,d,i)\\le 2$",
+    "significance": "central",
+    "relatedConcepts": ["door graph", "maximum degree", "path-following engine", "decide"],
+    "prerequisites": ["degSpoke definition", "the engine's structural hypothesis"]
+  },
+  {
+    "id": "sperner-oq02-obstruction",
+    "proofId": "sperner-mathlib4-oq-02",
+    "range": { "startLine": 111, "endLine": 127 },
+    "type": "theorem",
+    "title": "A single-sign door graph is not a complete certificate",
+    "content": "spoke_graph_empty_yet_complementary exhibits an antipodal labelling on which no spoke is complementary to the centre — every triangle has door-degree 0, so the path-following engine produces nothing — yet a boundary edge is complementary, so Tucker's conclusion still holds. Witness: centre d = +2 with all boundary vertices labelled ±1; then negL(+2) = -2 appears on no boundary vertex (no spoke door) while a boundary edge with labels +1,-1 is complementary. The single fixed interior door type is blind to the boundary-living complementary edge.",
+    "mathContext": "$\\exists a,b,c,d:\\ (\\forall i,\\ \\neg\\,\\mathrm{Compl}(d,V_i))\\ \\wedge\\ (\\exists i,\\ \\mathrm{Compl}(V_i,V_{\\mathrm{rot}\\,i}))$",
+    "significance": "central",
+    "relatedConcepts": ["obstruction", "complete certificate", "boundary edge", "Freund–Todd construction"],
+    "prerequisites": ["degSpoke_le_two", "the reproduced Tucker conclusion"]
+  },
+  {
+    "id": "sperner-oq02-reference-tucker",
+    "proofId": "sperner-mathlib4-oq-02",
+    "range": { "startLine": 129, "endLine": 138 },
+    "type": "theorem",
+    "title": "n = 2 Tucker on the hexagon (reference conclusion)",
+    "content": "hexagon_tucker reproduces the n = 2 Tucker conclusion on the same hexagon: for every antipodal labelling a,b,c and every centre label d, there is a complementary edge — either a boundary edge v i — v(i+1) or a spoke centre — v i — verified exhaustively over all 256 labellings by decide. Stating this alongside the obstruction makes the negative result meaningful: the empty single-sign door graph fails to certify a conclusion that genuinely holds.",
+    "mathContext": "$\\forall a,b,c,d:\\ (\\exists i,\\ \\mathrm{Compl}(V_i,V_{\\mathrm{rot}\\,i}))\\ \\vee\\ (\\exists i,\\ \\mathrm{Compl}(d,V_i))$",
+    "significance": "supporting",
+    "relatedConcepts": ["Tucker's lemma", "complementary edge", "exhaustive verification"],
+    "prerequisites": ["the hexagon model", "SpernerTuckerHexagon reference"]
+  }
+]

--- a/src/data/proofs/sperner-mathlib4-oq-02/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "sperner-mathlib4-oq-02",
+  "title": "Why Naive Door Choices Fail for n = 2 Tucker — a Machine-Checked Obstruction",
+  "slug": "sperner-mathlib4-oq-02",
+  "description": "The door-counting program for Tucker's lemma is abstractly complete up to one geometric input: the Freund–Todd construction of the door graph whose interior degree-1 vertices are exactly the complementary simplices. A natural hope is that this graph is something simple — pick one fixed sign k, declare the doors to be the complementary spokes of type {+k,-k}, and run the path-following engine. This entry kills that hope on a fully concrete hexagon-plus-centre triangulation of B². Encoding the four labels {+1,+2,-1,-2} as Fin 4 with the antipodal boundary condition built in, it verifies entirely by kernel decide (0 axioms, no native_decide) that (i) the spoke-door graph always has max degree ≤ 2 — so it does realize the engine's paths-and-cycles hypothesis — yet (ii) there is an antipodal labelling on which every spoke has door-degree 0 (the complementary edge hides on the boundary) while Tucker's conclusion still holds. Read against the reproduced n = 2 Tucker theorem, this pins down precisely why the remaining geometric construction is genuine work: the correct door structure must range over all signs and account for boundary edges, not read off a single fixed interior door type.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tucker%27s_lemma",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/SpernerTuckerHexagonDoorObstruction.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 3,
+    "definitionCount": 5,
+    "lineCount": 150,
+    "tags": [
+      "topology",
+      "tucker-lemma",
+      "borsuk-ulam",
+      "sperner-lemma",
+      "combinatorial-topology",
+      "door-counting",
+      "obstruction",
+      "decide"
+    ],
+    "assumptions": [],
+    "imports": [
+      "Mathlib"
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Tucker's lemma (Albert W. Tucker, 1945) is the combinatorial heart of the Borsuk–Ulam theorem, the antipodal analogue of the way Sperner's lemma underlies Brouwer's fixed-point theorem. Its modern algorithmic proofs (Freund–Todd 1981; Prescott–Su 2005) proceed by a door-counting / path-following argument: one builds a graph of maximum degree ≤ 2 on the almost-complementary simplices whose interior degree-1 vertices are exactly the complementary simplices Tucker asserts, and follows a path from a forced boundary door to an interior endpoint. The parent entry sperner-mathlib4 verifies the abstract door-counting engine and the dimension recursion; the sole remaining obligation is the geometric construction of that door graph. This entry is a negative result that constrains what that construction can look like: it rules out the most tempting shortcut.",
+    "problemStatement": "On the standard antipodally symmetric triangulation of B² — a hexagon with vertices v0,…,v5 in antipodal pairs (v(i+3) = -v i) plus an interior centre with label d, giving six triangles Ti = (centre, v i, v(i+1)) — encode labels {+1,+2,-1,-2} as Fin 4 with negation negL and complementarity Compl x y := x = negL y. The spoke-door graph declares a triangle's doors to be its centre-incident spokes complementary to d. Prove: (1) this graph always has max degree ≤ 2, so it satisfies the engine's structural hypothesis; but (2) there is an antipodal labelling on which no spoke is complementary to d (every triangle has door-degree 0) while a boundary edge is still complementary — so the single-sign door graph is not a complete Tucker certificate; and (3) reproduce n = 2 Tucker on this hexagon so the obstruction is read against the true conclusion.",
+    "proofStrategy": "The entire model is finite: four labels (Fin 4), six vertices (Fin 6), the antipodal condition forcing v3,v4,v5 to be the negations of the three free labels a,b,c. Every statement therefore quantifies over at most 4^4 = 256 antipodal labellings times 6 triangles, and each is discharged by kernel decide (not native_decide), so the axiom profile is the foundational trio propext / Classical.choice / Quot.sound only — no sorryAx, no Lean.ofReduceBool. degSpoke_le_two checks the degree bound over all cases. spoke_graph_empty_yet_complementary exhibits the witness (centre d = +2, all boundary vertices labelled ±1: no spoke can be complementary since -2 appears on no boundary vertex, yet a boundary edge with labels +1,-1 is complementary). hexagon_tucker reproduces the n = 2 conclusion (every antipodal labelling has a complementary boundary edge or spoke).",
+    "keyInsights": [
+      "The obstruction is not that the naive door graph violates the engine's hypotheses — degSpoke_le_two shows it genuinely has max degree ≤ 2, so it is a legal input to the path-following engine. The failure is subtler: the engine simply produces nothing because the graph can be entirely empty while Tucker's conclusion still holds.",
+      "The witness isolates the mechanism precisely: a single fixed interior door type (spokes complementary to the centre) is blind to complementary edges that live on the boundary. The centre label +2 has its negation -2 absent from every boundary vertex, so no spoke is a door, yet a +1/-1 boundary edge certifies Tucker.",
+      "Read together with the companion count-parity obstruction (the complementary-edge count is not a mod-2 invariant for n = 2), this pins down two independent reasons the n = 1 recipe cannot be transplanted, and therefore what the correct Freund–Todd door structure must do: range over all signs and account for boundary edges rather than reading off one interior door type.",
+      "The result is entirely by kernel decide on a fully concrete triangulation, so it is 0-axiom and self-contained (import Mathlib only, all definitions restated) — an honest negative certificate that a proposed simplification of the open geometric construction cannot work."
+    ]
+  },
+  "sections": [
+    {
+      "id": "encoding",
+      "title": "Label Encoding and the Hexagon Model",
+      "startLine": 80,
+      "endLine": 96,
+      "summary": "Encodes the four labels {+1,+2,-1,-2} as Fin 4 with negation negL (an involution), complementarity Compl x y := x = negL y with its Decidable instance, the six boundary labels V a b c with the antipodal condition v(i+3) = -v i built in, and the cyclic successor rot around the hexagon."
+    },
+    {
+      "id": "degree",
+      "title": "The Spoke-Door Graph and its Degree Bound",
+      "startLine": 98,
+      "endLine": 109,
+      "summary": "Defines degSpoke, the number of a triangle's two spokes that are complementary to the centre label d, and proves degSpoke_le_two: this spoke-door graph has max degree ≤ 2 over all 256 antipodal labellings and 6 triangles, so it realizes the path-following engine's structural hypothesis ∀ v, degree v ≤ 2."
+    },
+    {
+      "id": "obstruction",
+      "title": "The Obstruction: a Single-Sign Door Graph is Incomplete",
+      "startLine": 111,
+      "endLine": 127,
+      "summary": "Proves spoke_graph_empty_yet_complementary: there is an antipodal labelling on which no spoke is complementary to the centre (every triangle has door-degree 0, so the engine yields nothing) yet a boundary edge is complementary — the single-sign door graph is not a complete Tucker certificate."
+    },
+    {
+      "id": "reference-tucker",
+      "title": "n = 2 Tucker on the Hexagon (Reference Conclusion)",
+      "startLine": 129,
+      "endLine": 138,
+      "summary": "Reproduces hexagon_tucker: for every antipodal labelling and centre label d the triangulation has a complementary edge (a boundary edge v i — v(i+1) or a spoke centre — v i), verified exhaustively over all 256 labellings. The obstruction above is read against this true conclusion."
+    }
+  ],
+  "conclusion": {
+    "summary": "On a fully concrete hexagon-plus-centre triangulation of B², kernel decide establishes that the single-sign spoke-door graph for n = 2 Tucker does satisfy the path-following engine's max-degree-≤-2 hypothesis, yet can be entirely empty on an antipodal labelling for which Tucker's conclusion still holds — so it is not a complete certificate. Three theorems and five definitions, 0 axioms and 0 sorries, pin down why the remaining geometric door-graph construction is genuine work.",
+    "implications": "This negative certificate constrains the open geometric input of the Tucker door-counting program: the correct Freund–Todd door structure cannot read off a single fixed interior door type but must range over all signs and account for boundary edges. Together with the companion count-parity obstruction it explains why the n = 1 counting recipe does not transplant to n = 2.",
+    "openQuestions": [
+      "What is the correct all-signs, boundary-aware door graph on the hexagon whose interior degree-1 vertices are exactly the complementary simplices, completing the geometric input to the verified engine?",
+      "Does the degree-≤-2 spoke-door graph become a complete certificate once its doors are taken over all four signs simultaneously rather than one fixed sign?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-mathlib4",
+      "relationship": "Parent entry: supplies the verified abstract door-counting engine and dimension recursion whose sole open obligation — the geometric door graph — this obstruction constrains."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-03",
+      "relationship": "Sibling open-question entry: the combinatorial fixed-point index (mod 2) layer toward Brouwer, the Sperner analogue of the Tucker/Borsuk–Ulam program studied here."
+    },
+    {
+      "targetId": "sperner-ndim",
+      "relationship": "n-dimensional Sperner via the Freudenthal triangulation, the higher-dimensional door-counting setting."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SpernerTuckerHexagonDoorObstruction.lean",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 3,
+    "definitionCount": 5,
+    "imports": [
+      "import Mathlib"
+    ],
+    "opens": [],
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Albert W. Tucker",
+      "title": "Some topological properties of disk and sphere",
+      "year": 1945,
+      "venue": "Proc. First Canadian Math. Congress, Montreal, 285–309",
+      "note": "The original combinatorial lemma equivalent to the Borsuk–Ulam theorem."
+    },
+    {
+      "authors": "Robert M. Freund and Michael J. Todd",
+      "title": "A constructive proof of Tucker's combinatorial lemma",
+      "year": 1981,
+      "venue": "Journal of Combinatorial Theory, Series A 30(3), 321–325",
+      "note": "The path-following / door-counting construction whose door graph this entry constrains."
+    },
+    {
+      "authors": "Timothy Prescott and Francis Edward Su",
+      "title": "A constructive proof of Ky Fan's generalization of Tucker's lemma",
+      "year": 2005,
+      "venue": "Journal of Combinatorial Theory, Series A 111(2), 257–265",
+      "note": "A modern constructive door-following proof of Tucker's lemma."
+    },
+    {
+      "authors": "Jiří Matoušek",
+      "title": "Using the Borsuk–Ulam Theorem",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Tucker's lemma, its equivalence with Borsuk–Ulam, and the combinatorial door-counting viewpoint."
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Adds the missing gallery entry for **sperner-mathlib4-oq-02**, whose merged research file was invisible in the gallery for lack of a `src/data/proofs/` directory.

## Evidence

**Before**: `proofs/Proofs/SpernerTuckerHexagonDoorObstruction.lean` was merged in #31167 (`research(sperner-mathlib4-oq-02): door-choice obstruction for n=2 ... [VERIFIED, 0-axiom]`) but never got a gallery directory. Its siblings `sperner-mathlib4` and `sperner-mathlib4-oq-03` both have entries; the research-problem dir `research/problems/sperner-mathlib4-oq-02/` exists — only the gallery entry was absent, so the result did not render.

**After**: `src/data/proofs/sperner-mathlib4-oq-02/{meta.json,annotations.json}` added, modelled on the `sperner-mathlib4-oq-03` sibling.

### Content verified against source
- File: `Proofs/SpernerTuckerHexagonDoorObstruction.lean`, 150 lines
- 3 theorems (`degSpoke_le_two`, `spoke_graph_empty_yet_complementary`, `hexagon_tucker`), 5 definitions (`negL`, `Compl`, `V`, `rot`, `degSpoke`)
- 0 sorries, 0 axioms — all three theorems via **kernel `decide`** (not `native_decide`), so `#print axioms` is the foundational trio only (no `sorryAx`, no `Lean.ofReduceBool`). `status: verified`, `badge: original`, `axiomCount: 0` accordingly.
- Self-contained: `import Mathlib` only, `additionalFiles: []`.

Metadata-only change (two new files); no Lean source touched.

---
Automated fix by lean-mechanic agent.