### PR TITLE
research(cauchy-schwarz-oq-08-oq-01): complex norm-rigidity of the inner product [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ08OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ08OQ01.lean
@@ -1,0 +1,131 @@
+/-
+  Norm-rigidity of the complex inner product (cauchy-schwarz-oq-08-oq-01).
+
+  The parent entry `cauchy-schwarz-oq-08` (`Norm-Rigidity of the Real Inner Product`)
+  proves that over a *real* inner-product space the inner product is a function of the
+  norm alone, so any **norm-preserving additive** map `f : F →+ F'` automatically
+  preserves the inner product:
+      ⟪f x, f y⟫_ℝ = ⟪x, y⟫_ℝ.
+  The engine is the real polarization identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 — additivity
+  alone lets one rewrite ‖f x ± f y‖ = ‖f (x ± y)‖ = ‖x ± y‖.
+
+  Over ℂ (or any `RCLike` field) the norm no longer determines the inner product from the
+  two "real-axis" diagonals ‖x ± y‖ alone: the imaginary part needs the *rotated*
+  diagonals ‖x ± i·y‖.  The complex polarization identity (Mathlib
+  `inner_eq_sum_norm_sq_div_four`) is
+
+      ⟪x, y⟫ = ( ‖x+y‖² − ‖x−y‖²
+                 + (‖x − i·y‖² − ‖x + i·y‖²)·i ) / 4,      i = RCLike.I.
+
+  ## What this file adds
+
+  The complex analogue of the parent's rigidity theorem.  For an ℝ-additive map `f`
+  between `RCLike`-inner-product spaces we impose **two** metric hypotheses:
+
+    * `hnorm : ∀ x, ‖f x‖ = ‖x‖`                       (preserves the norm), and
+    * `hI    : ∀ x y, ‖f x + i·(f y)‖ = ‖x + i·y‖`      (preserves the rotated diagonal),
+
+  and conclude `⟪f x, f y⟫ = ⟪x, y⟫`.  The second hypothesis is exactly the extra data the
+  complex polarization identity consumes; the minus-diagonal version is *derived* from it
+  by additivity (`hI x (−y)`), so a single rotated-diagonal hypothesis suffices.
+
+  Because `RCLike.I = 0` when `𝕜 = ℝ`, the hypothesis `hI` becomes vacuous there and the
+  statement collapses to the parent's real theorem — so this genuinely subsumes
+  `cauchy-schwarz-oq-08`.  As corollaries we record orthogonality preservation, injectivity,
+  the explicit ℂ specialization, and that a bundled `𝕜`-linear isometry preserves the inner
+  product (its `hI` hypothesis is automatic, since a linear map commutes with `i·(·)`).
+
+  Sorry-free and axiom-free.
+
+  ## Main results
+  - `inner_map_eq`              : norm- and rotated-diagonal-preserving additive `f` has
+                                  `⟪f x, f y⟫ = ⟪x, y⟫`   (over any `RCLike 𝕜`)
+  - `inner_map_eq_zero_iff`     : such maps preserve orthogonality
+  - `injective_of_norm_preserving` : such maps are injective
+  - `inner_map_eq_real`         : the `𝕜 = ℝ` collapse — `hI` is automatic (parent theorem)
+  - `inner_map_eq_complex`      : the explicit `𝕜 = ℂ` statement with `Complex.I`
+  - `inner_linearIsometry_eq`   : a bundled `𝕜`-linear isometry preserves the inner product
+-/
+import Mathlib
+
+open scoped InnerProductSpace ComplexConjugate
+open RCLike
+
+namespace CauchySchwarzOQ08OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E']
+
+/-- **Norm-rigidity of the `RCLike` inner product.**  Let `f : E →+ E'` be an *additive*
+map between `𝕜`-inner-product spaces (`𝕜 = ℝ` or `ℂ`) that preserves the norm and the
+rotated diagonal:
+* `hnorm : ‖f x‖ = ‖x‖` for all `x`, and
+* `hI    : ‖f x + RCLike.I • f y‖ = ‖x + RCLike.I • y‖` for all `x y`.
+
+Then `f` preserves the inner product: `⟪f x, f y⟫ = ⟪x, y⟫`.
+
+Only additivity is used (no `𝕜`-linearity): the four norms appearing in the complex
+polarization identity are rewritten to the corresponding norms of `x, y`, three of them via
+additivity (`f x ± f y = f (x ± y)`) and the last (`‖f x − i·f y‖`) from `hI` at `-y`. -/
+theorem inner_map_eq (f : E →+ E') (hnorm : ∀ x, ‖f x‖ = ‖x‖)
+    (hI : ∀ x y, ‖f x + (I : 𝕜) • f y‖ = ‖x + (I : 𝕜) • y‖) (x y : E) :
+    inner 𝕜 (f x) (f y) = inner 𝕜 x y := by
+  -- The rotated *minus*-diagonal follows from `hI` applied at `-y`, using additivity.
+  have hIm : ‖f x - (I : 𝕜) • f y‖ = ‖x - (I : 𝕜) • y‖ := by
+    have h := hI x (-y)
+    simpa only [map_neg, smul_neg, sub_eq_add_neg] using h
+  rw [inner_eq_sum_norm_sq_div_four (f x) (f y), ← map_add, ← map_sub, hnorm, hnorm,
+    hI, hIm, ← inner_eq_sum_norm_sq_div_four x y]
+
+/-- Norm- and rotated-diagonal-preserving additive maps **preserve orthogonality**. -/
+theorem inner_map_eq_zero_iff (f : E →+ E') (hnorm : ∀ x, ‖f x‖ = ‖x‖)
+    (hI : ∀ x y, ‖f x + (I : 𝕜) • f y‖ = ‖x + (I : 𝕜) • y‖) (x y : E) :
+    inner 𝕜 (f x) (f y) = 0 ↔ inner 𝕜 x y = 0 := by
+  rw [inner_map_eq f hnorm hI]
+
+omit [InnerProductSpace 𝕜 E] [InnerProductSpace 𝕜 E'] in
+/-- Norm-preserving additive maps are **injective** (a vector of norm `0` is `0`).  Needs
+only the norm hypothesis. -/
+theorem injective_of_norm_preserving (f : E →+ E') (hnorm : ∀ x, ‖f x‖ = ‖x‖) :
+    Function.Injective f := by
+  rw [injective_iff_map_eq_zero]
+  intro a ha
+  have : ‖a‖ = 0 := by rw [← hnorm a, ha, norm_zero]
+  exact norm_eq_zero.mp this
+
+/-- **Real collapse.**  When `𝕜 = ℝ` the rotated-diagonal hypothesis is automatic
+(`RCLike.I = 0`), so norm preservation alone forces preservation of the inner product.
+This recovers the parent theorem `cauchy-schwarz-oq-08`. -/
+theorem inner_map_eq_real {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+    {F' : Type*} [NormedAddCommGroup F'] [InnerProductSpace ℝ F']
+    (f : F →+ F') (hnorm : ∀ x, ‖f x‖ = ‖x‖) (x y : F) :
+    inner ℝ (f x) (f y) = inner ℝ x y := by
+  refine inner_map_eq f hnorm ?_ x y
+  intro a b
+  simp only [RCLike.I_to_real, zero_smul, add_zero, hnorm]
+
+/-- **Complex specialization.**  Over a complex inner-product space, an additive map
+preserving the norm and the rotated diagonal `‖f x + i·f y‖ = ‖x + i·y‖` (with `i =
+Complex.I`) preserves the complex inner product. -/
+theorem inner_map_eq_complex {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+    {E' : Type*} [NormedAddCommGroup E'] [InnerProductSpace ℂ E']
+    (f : E →+ E') (hnorm : ∀ x, ‖f x‖ = ‖x‖)
+    (hI : ∀ x y, ‖f x + Complex.I • f y‖ = ‖x + Complex.I • y‖) (x y : E) :
+    inner ℂ (f x) (f y) = inner ℂ x y :=
+  -- `(RCLike.I : ℂ) = Complex.I` definitionally (the `RCLike ℂ` instance sets `I := Complex.I`),
+  -- so `hI` already has the shape `inner_map_eq` expects.
+  inner_map_eq f hnorm hI x y
+
+/-- A bundled `𝕜`-linear isometry preserves the inner product.  Its rotated-diagonal
+hypothesis is automatic: `𝕜`-linearity gives `f x + i·f y = f (x + i·y)`, whose norm is
+`‖x + i·y‖` by the isometry property.  This is the elementary reason Hilbert-space
+isometries are unitary, obtained here purely from polarization. -/
+theorem inner_linearIsometry_eq (f : E →ₗᵢ[𝕜] E') (x y : E) :
+    inner 𝕜 (f x) (f y) = inner 𝕜 x y := by
+  refine inner_map_eq f.toLinearMap.toAddMonoidHom f.norm_map ?_ x y
+  intro a b
+  rw [show f.toLinearMap.toAddMonoidHom a + (I : 𝕜) • f.toLinearMap.toAddMonoidHom b
+        = f (a + (I : 𝕜) • b) by simp [map_add, map_smul], f.norm_map]
+
+end CauchySchwarzOQ08OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "csoq0801-header",
+    "proofId": "cauchy-schwarz-oq-08-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Module Header: why the complex case needs rotated diagonals",
+    "content": "The parent cauchy-schwarz-oq-08 shows that over a *real* inner-product space the norm determines the inner product (polarization $\\langle x,y\\rangle=(\\|x+y\\|^2-\\|x-y\\|^2)/4$), so norm-preservation forces inner-product-preservation. Over $\\mathbb{C}$ this fails for the norm alone: the real diagonals $\\|x\\pm y\\|$ recover only $\\mathrm{Re}\\langle x,y\\rangle$, and complex conjugation on $\\mathbb{C}$ preserves the norm while conjugating $\\langle\\cdot,\\cdot\\rangle$. The imaginary part is pinned by the *rotated* diagonals $\\|x\\pm i\\,y\\|$, which the four-term complex polarization identity consumes. The file works over an arbitrary RCLike field $\\mathbb{K}$ (so $\\mathbb{R}$ and $\\mathbb{C}$ at once), with $i=$ `RCLike.I`.",
+    "mathContext": "Complex polarization: $\\langle x,y\\rangle=\\big(\\|x+y\\|^2-\\|x-y\\|^2+(\\|x-i y\\|^2-\\|x+i y\\|^2)\\,i\\big)/4$ over any RCLike field."
+  },
+  {
+    "id": "csoq0801-rigidity",
+    "proofId": "cauchy-schwarz-oq-08-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "Norm-Rigidity of the Complex Inner Product",
+    "content": "`inner_map_eq` is the core result: an $\\mathbb{R}$-additive map $f$ preserving the norm ($\\|f x\\|=\\|x\\|$) and the rotated diagonal ($\\|f x + i\\,f y\\|=\\|x+i\\,y\\|$) satisfies $\\langle f x, f y\\rangle=\\langle x,y\\rangle$. A single rotated-diagonal hypothesis suffices: applying it at $-y$ and using additivity ($i\\cdot f(-y)=-(i\\cdot f y)$) yields the minus-diagonal $\\|f x - i\\,f y\\|=\\|x-i\\,y\\|$. The proof is then a rewrite chain — apply complex polarization, turn $f x\\pm f y$ into $f(x\\pm y)$ via `← map_add`/`← map_sub`, collapse the four norms by the two hypotheses, and fold back. `inner_map_eq_zero_iff` and `injective_of_norm_preserving` follow (the latter from the norm hypothesis alone).",
+    "mathContext": "For $\\mathbb{R}$-additive $f$ with $\\|f x\\|=\\|x\\|$ and $\\|f x+i f y\\|=\\|x+i y\\|$: $\\langle f x,f y\\rangle=\\langle x,y\\rangle$, hence $f x\\perp f y\\iff x\\perp y$ and $f$ is injective."
+  },
+  {
+    "id": "csoq0801-specializations",
+    "proofId": "cauchy-schwarz-oq-08-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "Real Collapse and Complex Specialization",
+    "content": "Because the result is stated over RCLike $\\mathbb{K}$, it specializes both ways. `inner_map_eq_real`: when $\\mathbb{K}=\\mathbb{R}$, `RCLike.I` $=0$, so the rotated-diagonal hypothesis becomes $\\|f x\\|=\\|x\\|$ — automatic — and the theorem reduces to the parent's real rigidity result. `inner_map_eq_complex`: when $\\mathbb{K}=\\mathbb{C}$, the RCLike instance sets $I:=$ `Complex.I` definitionally, so the concrete complex statement (with `Complex.I`) is a zero-cost specialization of `inner_map_eq`. The single theorem thus subsumes the real parent and answers the complex open question simultaneously.",
+    "mathContext": "$\\mathbb{K}=\\mathbb{R}$: rotated hypothesis vacuous, real parent recovered. $\\mathbb{K}=\\mathbb{C}$: $\\mathrm{RCLike.}I=\\mathrm{Complex.}I$, concrete complex rigidity."
+  },
+  {
+    "id": "csoq0801-isometry",
+    "proofId": "cauchy-schwarz-oq-08-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "Linear-Isometry Corollary",
+    "content": "`inner_linearIsometry_eq`: a bundled $\\mathbb{K}$-linear isometry $f:E\\to_{\\ell i}E'$ preserves the inner product. Both hypotheses of `inner_map_eq` are automatic here — the norm hypothesis is the isometry's `norm_map`, and the rotated-diagonal hypothesis holds because $\\mathbb{K}$-linearity commutes with $i\\cdot(\\cdot)$: $f x + i\\,f y = f(x+i\\,y)$, whose norm is $\\|x+i\\,y\\|$ by the isometry property. This is the elementary, polarization-only reason complex Hilbert-space isometries are unitary, obtained without Mathlib's bundled `inner_map_map` machinery.",
+    "mathContext": "A bundled $\\mathbb{K}$-linear isometry satisfies $\\langle f x,f y\\rangle=\\langle x,y\\rangle$; complex isometries are unitary."
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-08-oq-01/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-08-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ08OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOq08Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq08Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq08Oq01Data: ProofData = {
+  proof: cauchySchwarzOq08Oq01Proof,
+  annotations: cauchySchwarzOq08Oq01Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-08-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08-oq-01/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "cauchy-schwarz-oq-08-oq-01",
+  "title": "Norm-Rigidity of the Complex Inner Product",
+  "slug": "cauchy-schwarz-oq-08-oq-01",
+  "description": "The complex (RCLike) analogue of the parent's real norm-rigidity theorem. Over a complex inner-product space the norm no longer pins the inner product from the two real-axis diagonals ‖x±y‖ alone — the imaginary part needs the rotated diagonals ‖x±i·y‖. Using Mathlib's complex polarization identity inner_eq_sum_norm_sq_div_four, we prove that any ℝ-additive map f preserving BOTH the norm and the rotated diagonal ‖f x + i·f y‖ = ‖x + i·y‖ preserves the full complex inner product ⟪f x, f y⟫ = ⟪x, y⟫. Stated over an arbitrary RCLike field 𝕜, so the single theorem specializes to ℂ and collapses (RCLike.I = 0) to recover the real parent theorem. Corollaries: orthogonality preservation, injectivity, and that a bundled 𝕜-linear isometry preserves the inner product.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polarization_identity",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "polarization-identity",
+      "complex-analysis",
+      "isometry",
+      "rigidity",
+      "rclike",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ08OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "inner_eq_sum_norm_sq_div_four",
+        "description": "Complex polarization identity: ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖² + (‖x−i·y‖² − ‖x+i·y‖²)·i)/4 over any RCLike field (i = RCLike.I)",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.I_to_real",
+        "description": "(RCLike.I : ℝ) = 0 — makes the rotated-diagonal hypothesis vacuous when 𝕜 = ℝ, giving the real collapse",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "injective_iff_map_eq_zero",
+        "description": "An additive group hom is injective iff its kernel is trivial (f a = 0 → a = 0)",
+        "module": "Mathlib.Algebra.Group.Hom.Basic"
+      },
+      {
+        "theorem": "LinearIsometry.norm_map",
+        "description": "A bundled linear isometry preserves the norm, ‖f x‖ = ‖x‖; supplies both hypotheses in the isometry corollary",
+        "module": "Mathlib.Analysis.Normed.Operator.LinearIsometry"
+      }
+    ],
+    "originalContributions": [
+      "inner_map_eq: norm-rigidity of the RCLike inner product — every ℝ-additive map f : E →+ E' between 𝕜-inner-product spaces (𝕜 = ℝ or ℂ) preserving the norm AND the rotated diagonal ‖f x + i·f y‖ = ‖x + i·y‖ satisfies ⟪f x, f y⟫ = ⟪x, y⟫. The minus-diagonal norm is derived from the plus-diagonal hypothesis by additivity (hI at −y), so a single rotated-diagonal hypothesis suffices. This is the complex analogue explicitly requested by cauchy-schwarz-oq-08's openQuestions.",
+      "inner_map_eq_zero_iff: such maps preserve orthogonality, ⟪f x, f y⟫ = 0 ↔ ⟪x, y⟫ = 0",
+      "injective_of_norm_preserving: a norm-preserving additive map is injective (needs only the norm hypothesis)",
+      "inner_map_eq_real: the 𝕜 = ℝ collapse — because RCLike.I = 0 the rotated-diagonal hypothesis is automatic, so norm preservation alone forces inner-product preservation, recovering the parent theorem cauchy-schwarz-oq-08",
+      "inner_map_eq_complex: the explicit ℂ specialization with Complex.I, the concrete complex statement (RCLike.I = Complex.I holds definitionally in the RCLike ℂ instance)",
+      "inner_linearIsometry_eq: a bundled 𝕜-linear isometry preserves the inner product; its rotated-diagonal hypothesis is automatic because a 𝕜-linear map commutes with i·(·), so f x + i·f y = f(x + i·y) and the isometry property finishes"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 131,
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms (only the standard propext / Classical.choice / Quot.sound foundations, confirmed via #print axioms). The rotated-diagonal hypothesis ‖f x + i·f y‖ = ‖x + i·y‖ is a hypothesis of the theorem, not an axiom — it is exactly the extra metric data the complex polarization identity consumes, and it is automatic for 𝕜-linear isometries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The real polarization identity ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖²)/4 reconstructs an inner product from its norm, and its structural payoff — norm-rigidity — is the elementary reason Hilbert-space isometries are unitary. Over the complex field the story is richer: a complex inner product ⟪x,y⟫ ∈ ℂ carries both a real part and an imaginary part, and the real diagonals ‖x±y‖ recover only Re⟪x,y⟫. The full Hermitian product is recovered by the four-term complex polarization identity ⟪x,y⟫ = (1/4)Σₖ iᵏ‖x + iᵏy‖², whose imaginary part is fed by the rotated diagonals ‖x ± i·y‖. Correspondingly, a map that preserves only the norm can fix the real inner product while moving the imaginary part (e.g. complex conjugation on ℂ preserves the norm but conjugates ⟪·,·⟫). Pinning the full complex inner product therefore requires preserving the rotated diagonals too — precisely the hypothesis isolated here.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-08-oq-01)**: Formalize the complex analogue of real norm-rigidity: a norm-preserving ℝ-additive map that ALSO preserves ‖x ± i·y‖ preserves the full complex inner product, via the complex polarization identity inner_eq_sum_norm_sq_div_four. This is openQuestion[0] of the parent cauchy-schwarz-oq-08.\n\n**Result**: Proved over an arbitrary RCLike field 𝕜 (so ℝ and ℂ simultaneously): for an ℝ-additive f : E →+ E' with ‖f x‖ = ‖x‖ and ‖f x + i·f y‖ = ‖x + i·y‖ (i = RCLike.I), one has ⟪f x, f y⟫ = ⟪x, y⟫. Specializes to ℂ (inner_map_eq_complex) and collapses to the real parent when 𝕜 = ℝ (inner_map_eq_real, where the rotated hypothesis is vacuous). Orthogonality preservation, injectivity, and the linear-isometry corollary follow.",
+    "text": "Over any RCLike field, an ℝ-additive map preserving the norm and the rotated diagonal ‖x ± i·y‖ preserves the full inner product ⟪f x, f y⟫ = ⟪x, y⟫; hence orthogonality is preserved, the map is injective, and 𝕜-linear isometries are inner-product isometries. Recovers the real parent when i = 0.",
+    "proofStrategy": "**Proof Strategy: complex polarization as a rigidity engine.**\n\n1. **Complex polarization** (Mathlib inner_eq_sum_norm_sq_div_four): ⟪x,y⟫ = (‖x+y‖² − ‖x−y‖² + (‖x−i·y‖² − ‖x+i·y‖²)·i)/4, with i = RCLike.I. This recovers the full inner product from four norms — the two real diagonals ‖x±y‖ and the two rotated diagonals ‖x±i·y‖.\n2. **Derive the minus rotated diagonal** (inner_map_eq): from the single hypothesis hI : ‖f x + i·f y‖ = ‖x + i·y‖, applying it at −y and using additivity (f(−y) = −f y, i·(−f y) = −(i·f y)) gives ‖f x − i·f y‖ = ‖x − i·y‖ — so only one rotated-diagonal hypothesis is needed.\n3. **Four-rewrite chain**: apply complex polarization to ⟪f x, f y⟫, then ← map_add and ← map_sub turn f x ± f y into f(x±y); the norm hypothesis collapses ‖f(x±y)‖ = ‖x±y‖ (the two real diagonals), and hI / its derived companion collapse the two rotated diagonals; folding by ← inner_eq_sum_norm_sq_div_four x y closes the goal. No induction, no case analysis.\n4. **Real collapse** (inner_map_eq_real): RCLike.I_to_real gives (RCLike.I : ℝ) = 0, so the rotated-diagonal hypothesis becomes ‖f x‖ = ‖x‖, discharged by hnorm — recovering the parent's real theorem as a special case.\n5. **Isometry corollary** (inner_linearIsometry_eq): a 𝕜-linear map commutes with i·(·), so f x + i·f y = f(x + i·y); the isometry's norm_map supplies both the norm and rotated-diagonal hypotheses automatically.",
+    "keyInsights": [
+      "**The norm alone is not rigid over ℂ.** Complex conjugation on ℂ preserves the norm yet conjugates the inner product, so the real-only argument fails. The rotated diagonals ‖x ± i·y‖ are exactly the extra metric data that pins the imaginary part — this is the conceptual content of the extra hypothesis hI.",
+      "**One rotated-diagonal hypothesis suffices.** Naively the complex polarization needs both ‖x + i·y‖ and ‖x − i·y‖ preserved, but additivity turns the minus case into the plus case at −y (i·f(−y) = −(i·f y)). The proof isolates this so the theorem takes a single clean hypothesis.",
+      "**Additivity, not linearity.** As in the real parent, only f(x±y) = f x ± f y is used for the real diagonals; the rotated diagonals are handled entirely by the hypothesis hI. The theorem holds for any norm-and-rotation-preserving AddMonoidHom, sharper than the usual linear-isometry statement.",
+      "**Working over RCLike 𝕜 unifies ℝ and ℂ.** Because RCLike.I = 0 in ℝ and RCLike.I = Complex.I in ℂ, the single statement inner_map_eq subsumes both the real parent (hypothesis vacuous) and the complex target (hypothesis active). This is a strict generalization of cauchy-schwarz-oq-08 rather than a parallel copy.",
+      "**Definitional bridge to Complex.I.** The RCLike ℂ instance sets I := Complex.I, so inner_map_eq_complex is a zero-cost specialization: the ℂ hypothesis ‖f x + Complex.I·f y‖ = … already has the shape inner_map_eq expects, no rewriting needed.",
+      "**Isometries are unitary, elementarily.** For a bundled 𝕜-LinearIsometry the rotated-diagonal hypothesis is automatic (linearity commutes with i·(·)), so inner_linearIsometry_eq derives inner-product preservation — the complex reason Hilbert-space isometries are unitary — without Mathlib's bundled inner_map_map machinery."
+    ],
+    "prerequisites": [
+      "Complex / RCLike inner product spaces (InnerProductSpace 𝕜 E with [RCLike 𝕜] in Mathlib)",
+      "The complex polarization identity inner_eq_sum_norm_sq_div_four and RCLike.I",
+      "Additive monoid homomorphisms and bundled linear isometries (→+, →ₗᵢ)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring contrasting the real parent with the complex case, explaining why the norm alone is not rigid over ℂ and stating the complex polarization identity. Mathlib import; opens InnerProductSpace and RCLike (so I = RCLike.I); the CauchySchwarzOQ08OQ01 namespace; and the RCLike-field variables 𝕜, E, E'.",
+      "mathContext": "Work over an arbitrary RCLike field 𝕜 (ℝ or ℂ) with 𝕜-inner-product spaces (E, ⟪·,·⟫) and (E', ⟪·,·⟫); i = RCLike.I."
+    },
+    {
+      "id": "rigidity",
+      "title": "Norm-Rigidity of the Complex Inner Product",
+      "startLine": 60,
+      "endLine": 95,
+      "summary": "inner_map_eq: the core theorem that an ℝ-additive map preserving the norm and the rotated diagonal ‖f x + i·f y‖ = ‖x + i·y‖ preserves the inner product, via the derived minus-diagonal and the four-rewrite chain through complex polarization. inner_map_eq_zero_iff derives orthogonality preservation; injective_of_norm_preserving shows injectivity from the norm hypothesis alone.",
+      "mathContext": "For ℝ-additive f with ‖f x‖ = ‖x‖ and ‖f x + i·f y‖ = ‖x + i·y‖: ⟪f x, f y⟫ = ⟪x, y⟫, hence f x ⟂ f y ↔ x ⟂ y and f is injective."
+    },
+    {
+      "id": "specializations",
+      "title": "Real Collapse and Complex Specialization",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "inner_map_eq_real: when 𝕜 = ℝ the rotated-diagonal hypothesis is automatic (RCLike.I = 0), so norm preservation alone suffices — recovering the parent theorem. inner_map_eq_complex: the explicit ℂ statement with Complex.I, a definitional specialization of inner_map_eq.",
+      "mathContext": "𝕜 = ℝ: hI vacuous, real parent recovered. 𝕜 = ℂ: RCLike.I = Complex.I, the concrete complex rigidity statement."
+    },
+    {
+      "id": "isometry",
+      "title": "Linear-Isometry Corollary",
+      "startLine": 120,
+      "endLine": 131,
+      "summary": "inner_linearIsometry_eq: a bundled 𝕜-linear isometry preserves the inner product. Its rotated-diagonal hypothesis is automatic — 𝕜-linearity gives f x + i·f y = f(x + i·y), whose norm is ‖x + i·y‖ by the isometry property — so the theorem follows directly from inner_map_eq.",
+      "mathContext": "A bundled 𝕜-linear isometry f : E →ₗᵢ[𝕜] E' satisfies ⟪f x, f y⟫ = ⟪x, y⟫; the elementary reason complex isometries are unitary."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-08",
+      "relationship": "extends",
+      "description": "Parent: the real norm-rigidity theorem. This entry is its complex analogue (parent openQuestion[0]) and a strict generalization over RCLike 𝕜 — inner_map_eq_real recovers the parent as the 𝕜 = ℝ collapse where the rotated-diagonal hypothesis is vacuous."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-07",
+      "relationship": "related",
+      "description": "OQ-07 proves the parallelogram law and the bare real polarization identity; this entry uses the complex four-term polarization to pin the full Hermitian inner product from norm data."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Foundational inner-product-space result: rigidity of the complex inner product under norm- and rotation-preserving maps complements the Cauchy–Schwarz inequality in complex Hilbert-space geometry."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the complex analogue of norm-rigidity, over an arbitrary RCLike field 𝕜. An ℝ-additive map preserving the norm and the rotated diagonal ‖x ± i·y‖ preserves the full complex inner product, hence orthogonality, and is injective; the statement collapses to the real parent (i = 0) and specializes to ℂ, and bundled 𝕜-linear isometries satisfy the hypotheses automatically.",
+    "implications": "Over ℂ the norm alone is not rigid — complex conjugation preserves the norm while conjugating the inner product — so the extra rotated-diagonal hypothesis is genuinely necessary and exactly the data the four-term complex polarization consumes. Isolating it over RCLike 𝕜 gives a single result subsuming the real and complex cases and exhibits the elementary reason complex Hilbert-space isometries are unitary.",
+    "openQuestions": [
+      "Characterize when a norm-preserving ℝ-additive map is automatically ℂ-linear versus ℂ-antilinear: over ℂ such a map splits inner products into ⟪f x, f y⟫ = ⟪x, y⟫ (linear) or its conjugate (antilinear); relate the rotated-diagonal hypothesis to selecting the linear branch.",
+      "Derive that a surjective norm-and-rotation-preserving additive map is a complex inner-product isomorphism (combine injectivity here with surjectivity toward a LinearIsometryEquiv-style statement).",
+      "Formalize the full four-term real form ⟪x,y⟫ = (1/4)Σₖ iᵏ‖x + iᵏy‖² and show each of the k = 0..3 diagonals is preserved, making the rotation structure of the hypothesis explicit."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "ComplexConjugate",
+      "RCLike"
+    ],
+    "namespace": "CauchySchwarzOQ08OQ01",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ08OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "inner_map_eq",
+      "type": "core",
+      "description": "**Norm-rigidity of the RCLike inner product.** An ℝ-additive map f : E →+ E' between 𝕜-inner-product spaces (𝕜 = ℝ or ℂ) preserving the norm (∀ x, ‖f x‖ = ‖x‖) and the rotated diagonal (∀ x y, ‖f x + i·f y‖ = ‖x + i·y‖, i = RCLike.I) preserves the inner product: ⟪f x, f y⟫ = ⟪x, y⟫. Only additivity is used; the minus-diagonal norm is derived from the plus-diagonal hypothesis. This is the complex analogue requested by cauchy-schwarz-oq-08.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E E' : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] (f : E →+ E'), (∀ x, ‖f x‖ = ‖x‖) → (∀ x y, ‖f x + RCLike.I • f y‖ = ‖x + RCLike.I • y‖) → ∀ (x y : E), inner 𝕜 (f x) (f y) = inner 𝕜 x y"
+    },
+    {
+      "name": "inner_map_eq_complex",
+      "type": "core",
+      "description": "**Complex specialization.** Over a complex inner-product space, an ℝ-additive map preserving the norm and the rotated diagonal ‖f x + i·f y‖ = ‖x + i·y‖ (i = Complex.I) preserves the complex inner product. A definitional specialization of inner_map_eq (the RCLike ℂ instance sets I := Complex.I).",
+      "leanType": "∀ {E E' : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [NormedAddCommGroup E'] [InnerProductSpace ℂ E'] (f : E →+ E'), (∀ x, ‖f x‖ = ‖x‖) → (∀ x y, ‖f x + Complex.I • f y‖ = ‖x + Complex.I • y‖) → ∀ (x y : E), inner ℂ (f x) (f y) = inner ℂ x y"
+    },
+    {
+      "name": "inner_map_eq_real",
+      "type": "supporting",
+      "description": "**Real collapse.** When 𝕜 = ℝ the rotated-diagonal hypothesis is automatic (RCLike.I = 0), so a norm-preserving additive map preserves the real inner product. Recovers the parent theorem cauchy-schwarz-oq-08 as a special case of inner_map_eq.",
+      "leanType": "∀ {F F' : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] [NormedAddCommGroup F'] [InnerProductSpace ℝ F'] (f : F →+ F'), (∀ x, ‖f x‖ = ‖x‖) → ∀ (x y : F), inner ℝ (f x) (f y) = inner ℝ x y"
+    },
+    {
+      "name": "inner_map_eq_zero_iff",
+      "type": "supporting",
+      "description": "Norm- and rotated-diagonal-preserving additive maps preserve orthogonality: ⟪f x, f y⟫ = 0 ↔ ⟪x, y⟫ = 0.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E E' : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] (f : E →+ E'), (∀ x, ‖f x‖ = ‖x‖) → (∀ x y, ‖f x + RCLike.I • f y‖ = ‖x + RCLike.I • y‖) → ∀ (x y : E), inner 𝕜 (f x) (f y) = 0 ↔ inner 𝕜 x y = 0"
+    },
+    {
+      "name": "injective_of_norm_preserving",
+      "type": "supporting",
+      "description": "A norm-preserving additive map is injective: ‖f a‖ = ‖a‖ forces ‖a‖ = 0 hence a = 0 when f a = 0. Needs only the norm hypothesis.",
+      "leanType": "∀ {E E' : Type*} [NormedAddCommGroup E] [NormedAddCommGroup E'] (f : E →+ E'), (∀ x, ‖f x‖ = ‖x‖) → Function.Injective f"
+    },
+    {
+      "name": "inner_linearIsometry_eq",
+      "type": "supporting",
+      "description": "A bundled 𝕜-linear isometry preserves the inner product. Its rotated-diagonal hypothesis is automatic — 𝕜-linearity gives f x + i·f y = f(x + i·y) — so it follows directly from inner_map_eq. The elementary reason complex Hilbert-space isometries are unitary.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E E' : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [NormedAddCommGroup E'] [InnerProductSpace 𝕜 E'] (f : E →ₗᵢ[𝕜] E') (x y : E), inner 𝕜 (f x) (f y) = inner 𝕜 x y"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Jordan, Pascual; von Neumann, John",
+      "title": "On Inner Products in Linear, Metric Spaces",
+      "year": "1935",
+      "venue": "Annals of Mathematics, vol. 36, no. 3, pp. 719–723",
+      "note": "Establishes the equivalence of the parallelogram law with the existence of an inner product; the complex case requires the four-term polarization used here to recover the Hermitian product"
+    },
+    {
+      "authors": "Conway, John B.",
+      "title": "A Course in Functional Analysis",
+      "year": "1990",
+      "venue": "Springer, Graduate Texts in Mathematics 96 (2nd edition)",
+      "note": "Chapter I: the complex polarization identity ⟪x,y⟫ = (1/4)Σₖ iᵏ‖x + iᵏy‖² and inner-product preservation of Hilbert-space isometries"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering **openQuestion[0]** of the parent `cauchy-schwarz-oq-08` (*Norm-Rigidity of the Real Inner Product*): the **complex analogue**.

Over a *real* inner-product space the norm determines the inner product (real polarization), so norm-preservation forces inner-product-preservation. Over ℂ this fails for the norm alone — complex conjugation on ℂ preserves the norm while conjugating ⟪·,·⟫, and the real diagonals ‖x±y‖ recover only Re⟪x,y⟫. The imaginary part is pinned by the **rotated diagonals** ‖x ± i·y‖.

**Main theorem** (`inner_map_eq`, over any `RCLike 𝕜`): an ℝ-additive map `f : E →+ E'` with
- `‖f x‖ = ‖x‖` (preserves norm), and
- `‖f x + i·f y‖ = ‖x + i·y‖` (preserves the rotated diagonal, `i = RCLike.I`)

satisfies `⟪f x, f y⟫ = ⟪x, y⟫`. A single rotated-diagonal hypothesis suffices — the minus case is *derived* from the plus case at `-y` by additivity. Engine: Mathlib's `inner_eq_sum_norm_sq_div_four`.

Working over `RCLike 𝕜` unifies ℝ and ℂ:
- `inner_map_eq_real` — 𝕜 = ℝ collapse: `RCLike.I = 0` makes the rotated hypothesis vacuous, **recovering the parent theorem**.
- `inner_map_eq_complex` — the explicit ℂ statement (`RCLike.I = Complex.I` definitionally).

Plus corollaries: orthogonality preservation (`inner_map_eq_zero_iff`), injectivity (`injective_of_norm_preserving`), and that bundled 𝕜-linear isometries preserve the inner product (`inner_linearIsometry_eq`) — the elementary reason complex Hilbert-space isometries are unitary.

## Verification

- **6 theorems, 131 lines, 0 sorries, 0 axioms.**
- `#print axioms` on all six: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Verified via `lake env lean` against the cached Mathlib (v4.26.0) build.

## Files
- `proofs/Proofs/CauchySchwarzOQ08OQ01.lean`
- `src/data/proofs/cauchy-schwarz-oq-08-oq-01/{meta.json,annotations.json,index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)