### PR TITLE
Add gallery entry for prime-reciprocal-divergence-oq-01 (prime zeta dichotomy)

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "prime-reciprocal-divergence-oq-01",
+  "title": "Prime Zeta Convergence Dichotomy",
+  "slug": "prime-reciprocal-divergence-oq-01",
+  "description": "The prime zeta series P(s) = ∑_p 1/p^s is summable if and only if s > 1, recovering both the divergence of ∑ 1/p at the boundary s = 1 and the convergence of ∑ 1/p² at s = 2.",
+  "meta": {
+    "author": "Lean Genius research pipeline",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "1874",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimeReciprocalDivergenceOQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "primes",
+      "prime-zeta",
+      "convergence",
+      "series"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Primes.summable_rpow",
+        "description": "The prime p-series ∑_p p^r is summable iff r < -1",
+        "module": "Mathlib.NumberTheory.SumPrimeReciprocals"
+      }
+    ],
+    "originalContributions": [
+      "Packages the full convergence/divergence dichotomy of the prime zeta function P(s) = ∑_p 1/p^s as a single iff statement",
+      "Reduces the 1/p^s form to Mathlib's p^(-s) dichotomy Nat.Primes.summable_rpow via Real.rpow_neg",
+      "Recovers the gallery's divergence headline (s = 1) and the convergent prime Basel sum (s = 2) as corollaries of the boundary"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 68,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry proves Euler's 1737 theorem that $\\sum_p 1/p$ diverges. Its OQ-01 asks for the precise Mertens error term $\\sum_{p \\leq n} 1/p = \\ln\\ln n + M + E(n)$, a result of analytic number theory beyond current Mathlib. Short of that quantitative refinement, this entry records the clean qualitative boundary that all the surrounding convergence questions reduce to: the *prime zeta function* $P(s) = \\sum_p p^{-s}$, studied since Euler and named by Glaisher (1891), converges exactly for real $s > 1$. Franz Mertens (1874) is the natural reference point, as his second theorem is the sharpening the parent OQ requests; the critical exponent $s = 1$ isolated here is precisely the boundary his asymptotic straddles.",
+    "problemStatement": "For a real exponent $s$, the prime zeta series\n\n$$P(s) = \\sum_{p \\text{ prime}} \\frac{1}{p^s}$$\n\nis summable **if and only if** $s > 1$. The divergent boundary case $s = 1$ is exactly Euler's prime reciprocal divergence; the case $s = 2$ gives the convergent prime analogue of the Basel sum.",
+    "text": "The prime zeta series P(s) = ∑_p 1/p^s converges if and only if s > 1.",
+    "proofStrategy": "The whole dichotomy reduces to Mathlib's `Nat.Primes.summable_rpow`, which states $\\sum_p p^r$ is summable iff $r < -1$. Rewriting $1/p^s = p^{-s}$ pointwise via `Real.rpow_neg` (valid since every prime is positive) turns the $1/p^s$ statement into the $p^{-s}$ statement, and $-s < -1 \\Leftrightarrow 1 < s$ closes it by `linarith`. Both one-directional corollaries (`prime_zeta_summable` for $s > 1$, `prime_zeta_not_summable` for $s \\leq 1$) then follow, and the boundary $s = 1$ and instance $s = 2$ are immediate specializations.",
+    "keyInsights": [
+      "**Single critical exponent**: the entire convergence behaviour of $P(s)$ is governed by the threshold $s = 1$ — above it the series converges, at or below it diverges, with no intermediate regime",
+      "**Reduction to one Mathlib lemma**: the $1/p^s$ packaging that the surrounding gallery questions all use is precisely the $p^{-s}$ dichotomy already in Mathlib, bridged by a one-line pointwise rewrite $1/p^s = p^{-s}$",
+      "**Boundary is the headline**: the $s = 1$ case is exactly Euler's divergence of $\\sum 1/p$ — the parent entry's main theorem — here seen as the critical exponent of $P(s)$",
+      "**Prime Basel sum**: the $s = 2$ case $\\sum_p 1/p^2 \\approx 0.4522$ (the prime zeta value $P(2)$) is the prime analogue of $\\zeta(2) = \\pi^2/6$ and drops out of the same dichotomy"
+    ],
+    "prerequisites": [
+      "Number theory (primes)",
+      "Real analysis (summability, real powers)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-documentation",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Documents how this entry relates to the parent (Euler's ∑ 1/p divergence and its Mertens-error open question), lists the four exported facts, and imports Mathlib. Opens the `Real` scope and the `PrimeReciprocalDivergenceOQ01` namespace.",
+      "mathContext": "Frames the prime zeta function $P(s) = \\sum_p 1/p^s$ as the clean convergence boundary underlying the surrounding gallery questions, reducible to Mathlib's `Nat.Primes.summable_rpow`."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Convergence Dichotomy",
+      "startLine": 31,
+      "endLine": 42,
+      "summary": "`prime_zeta_summable_iff`: `∑_p 1/p^s` is summable iff `1 < s`. Rewrites `1 / p^s = p^(-s)` pointwise via `Real.rpow_neg` (each prime is positive), applies `Nat.Primes.summable_rpow`, and finishes with `linarith` on `-s < -1 ↔ 1 < s`.",
+      "mathContext": "The core theorem. The pointwise identity $1/p^s = p^{-s}$ turns the $1/p^s$ packaging into Mathlib's $p^{-s}$ dichotomy, whose threshold $r < -1$ becomes $s > 1$."
+    },
+    {
+      "id": "directions",
+      "title": "One-Directional Corollaries",
+      "startLine": 44,
+      "endLine": 54,
+      "summary": "`prime_zeta_summable` (convergence for `s > 1`) and `prime_zeta_not_summable` (divergence for `s ≤ 1`) extract the two implications of the iff.",
+      "mathContext": "Splits the biconditional into the usable convergence and divergence statements."
+    },
+    {
+      "id": "boundary-instances",
+      "title": "Boundary and Basel Instances",
+      "startLine": 56,
+      "endLine": 68,
+      "summary": "`prime_reciprocal_not_summable_rpow`: the `s = 1` boundary, i.e. Euler's divergence of `∑ 1/p` (the parent's headline). `prime_squared_summable`: the `s = 2` instance `∑_p 1/p²` converges — the prime analogue of the Basel sum.",
+      "mathContext": "Specializes the dichotomy at the two exponents of greatest interest: the divergent critical exponent $s = 1$ and the convergent $s = 2$ (the prime zeta value $P(2)$)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "PrimeReciprocalDivergenceOQ01",
+    "lineCount": 68,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/PrimeReciprocalDivergenceOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "prime_zeta_summable_iff",
+      "type": "core",
+      "description": "The prime zeta series ∑_p 1/p^s is summable iff s > 1",
+      "leanType": "(s : R) -> (Summable (fun p : Nat.Primes => 1 / (p : R) ^ s) <-> 1 < s)"
+    },
+    {
+      "name": "prime_zeta_summable",
+      "type": "corollary",
+      "description": "Convergence for s > 1",
+      "leanType": "1 < s -> Summable (fun p : Nat.Primes => 1 / (p : R) ^ s)"
+    },
+    {
+      "name": "prime_zeta_not_summable",
+      "type": "corollary",
+      "description": "Divergence for s ≤ 1",
+      "leanType": "s <= 1 -> not (Summable (fun p : Nat.Primes => 1 / (p : R) ^ s))"
+    },
+    {
+      "name": "prime_reciprocal_not_summable_rpow",
+      "type": "corollary",
+      "description": "The s = 1 boundary: the prime reciprocal series diverges (the gallery's divergence headline)",
+      "leanType": "not (Summable (fun p : Nat.Primes => 1 / (p : R) ^ (1 : R)))"
+    },
+    {
+      "name": "prime_squared_summable",
+      "type": "corollary",
+      "description": "The s = 2 instance: ∑_p 1/p² converges (the prime analogue of the Basel sum)",
+      "leanType": "Summable (fun p : Nat.Primes => 1 / (p : R) ^ (2 : R))"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry packages the full convergence/divergence dichotomy of the prime zeta function $P(s) = \\sum_p 1/p^s$ as the single iff `prime_zeta_summable_iff`: summable exactly when $s > 1$. It reduces the $1/p^s$ form used throughout the surrounding gallery questions to Mathlib's $p^{-s}$ dichotomy `Nat.Primes.summable_rpow` by the pointwise rewrite $1/p^s = p^{-s}$, then reads off the two one-directional corollaries, the divergent boundary $s = 1$ (Euler's prime reciprocal divergence), and the convergent instance $s = 2$. All results are fully machine-checked with 0 axioms and 0 sorries.",
+    "implications": "The critical exponent $s = 1$ isolated here is exactly the boundary that the parent entry's open question — the Mertens error term $\\sum_{p \\leq n} 1/p = \\ln\\ln n + M + E(n)$ — refines quantitatively. While the sharp asymptotic remains beyond Mathlib, the qualitative dichotomy is the clean foundation on which such refinements sit, and it connects to the Riemann zeta function through $\\ln \\zeta(s) = \\sum_p \\sum_{k \\geq 1} p^{-ks}/k$, whose $s \\to 1^+$ divergence mirrors the boundary case established here."
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "description": "This entry answers the qualitative core of prime-reciprocal-divergence OQ-01 by isolating the critical exponent s = 1 of the prime zeta function; the parent's full open question asks for the precise Mertens error term.",
+      "targetId": "prime-reciprocal-divergence"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Mertens, Franz",
+      "title": "Ein Beitrag zur analytischen Zahlentheorie",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik 78, 46–62",
+      "note": "Proved the second theorem ∑_{p≤n} 1/p = ln ln n + M + O(1/ln n), the quantitative sharpening the parent open question requests"
+    },
+    {
+      "authors": "Glaisher, James Whitbread Lee",
+      "title": "On the sums of inverse powers of the prime numbers",
+      "year": "1891",
+      "venue": "Quarterly Journal of Mathematics 25, 347–362",
+      "note": "Early systematic study of the prime zeta function P(s) = ∑_p p^{-s}"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Fix

Adds the missing gallery entry for `prime-reciprocal-divergence-oq-01` — a **missing-gallery-entry gap**.

## Evidence

**Before**: `proofs/Proofs/PrimeReciprocalDivergenceOQ01.lean` (merged research artifact, VERIFIED, 0-axiom, 5 theorems / 68 lines) had **no** `src/data/proofs/` directory, so the result was invisible in the gallery.

**After**: `src/data/proofs/prime-reciprocal-divergence-oq-01/meta.json` now presents the entry.

## What the proof establishes

The prime zeta function's convergence dichotomy:

$$P(s) = \sum_{p} \frac{1}{p^s} \quad\text{summable} \iff s > 1$$

- `prime_zeta_summable_iff` — the full iff (reduces to Mathlib's `Nat.Primes.summable_rpow` via the pointwise rewrite $1/p^s = p^{-s}$)
- `prime_zeta_summable` / `prime_zeta_not_summable` — the two directions
- `prime_reciprocal_not_summable_rpow` — the $s=1$ boundary (Euler's prime reciprocal divergence, the parent entry's headline)
- `prime_squared_summable` — the $s=2$ instance $\sum_p 1/p^2$ (prime analogue of the Basel sum)

## Validation

- `lake env lean Proofs/PrimeReciprocalDivergenceOQ01.lean` against pinned Mathlib **v4.26.0** → exit 0, no drift, 0 axioms / 0 sorries
- `gallery:check-size` → passes (no oversize warning)
- `annotations build` → no new errors for this slug
- meta schema modeled on the parent `prime-reciprocal-divergence` and sibling OQ entries

---
Automated fix by lean-mechanic agent.