### PR TITLE
audit(erdos-678): correct sorry count 4→3 (docstring false-positive)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15532,9 +15532,9 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-04T04:06:35Z",
-      "result": "clean"
+      "auditCount": 6,
+      "lastAudited": "2026-07-02T11:34:48Z",
+      "result": "issues-fixed"
     },
     "erdos-679": {
       "auditCount": 4,

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -17,7 +17,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 678,
     "erdosUrl": "https://erdosproblems.com/678",
     "erdosProblemStatus": "solved",
@@ -213,5 +213,5 @@
       "Proofs/Erdos678Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 3
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-678 (Erdős Problem #678: LCM of Consecutive Integers)
**Problem**: Sorry count mismatch — meta claimed 4, actual is 3.

## Evidence

`proofs/Proofs/Erdos678Problem.lean` contains 3 real `sorry` tokens:
- L136 `erdos_678_infinitely_many`
- L141 `cambie_2024`
- L263 `erdos_growth_rate`

A 4th `sorry` token appears only inside a **docstring** (L231), describing a
discarded earlier `Nat.find ⟨96, 104, sorry⟩` definition — not a real proof gap.
`leanFile.sorries` already correctly read 3; `meta.sorries` and the top-level
`sorries` were stale at 4.

## Fix

- `meta.sorries`: 4 → 3
- top-level `sorries`: 4 → 3

Status remains `formalized` / badge `wip` (3 open theorems). The `native_decide`
calls discharge finite example verifications only, not the open theorems, so no
axiom/verified overclaim.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)