### PR TITLE
Enrich Maclaurin's Inequality equality case (sufficiency): add annotation coverage

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-const-input-setup",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 44, "endLine": 50 },
+    "type": "context",
+    "title": "The constant-input strategy",
+    "content": "The entire sufficiency proof rests on evaluating the symmetric machinery at a constant vector `(c,…,c)`. Two elementary observations drive everything: over a `k`-element subset the product of constant entries is `cᵏ`, and there are exactly `C(n,k)` such subsets. This section sets up that computation, which the rest of the file lifts to the Maclaurin means. The file imports the parent `Proofs.AmgmInequalityOQ02` to reuse its exact definitions of `elemSymm` and `maclaurinMean`, so these results are drop-in companions to the parent's chain M₁ ≥ ⋯ ≥ Mₙ.",
+    "mathContext": "Goal: show a non-negative constant input forces $M_1 = M_2 = \\cdots = M_n = c$, the $\\Leftarrow$ half of the equality case $M_k = M_{k+1} \\iff$ inputs equal.",
+    "significance": "context",
+    "relatedConcepts": ["elementary symmetric polynomial", "Maclaurin mean", "equality case", "AM-GM inequality"],
+    "prerequisites": ["symmetric functions", "finite sums and products"]
+  },
+  {
+    "id": "ann-elemsymm-const",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 64 },
+    "type": "technique",
+    "title": "Elementary symmetric polynomial of a constant vector",
+    "content": "Computes the closed form `eₖ(c,…,c) = C(n,k)·cᵏ`. After unfolding `elemSymm` (a sum over `k`-element subsets of products), each product is `cᵏ` by `Finset.prod_const` together with the cardinality fact `hs.2 : s.card = k` from `mem_powersetCard`. Summing the constant `cᵏ` over the `C(n,k)` subsets — counted by `Finset.card_powersetCard` — gives the result via `nsmul_eq_mul`.",
+    "mathContext": "$e_k(c,\\dots,c) = \\sum_{|s|=k} \\prod_{i\\in s} c = \\sum_{|s|=k} c^k = \\binom{n}{k}\\, c^k.$",
+    "significance": "supporting",
+    "relatedConcepts": ["elementary symmetric polynomial", "binomial coefficient", "powersetCard", "prod_const"],
+    "prerequisites": ["finite products over subsets", "binomial coefficients"]
+  },
+  {
+    "id": "ann-maclaurinmean-const",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 66, "endLine": 88 },
+    "type": "insight",
+    "title": "Each Maclaurin mean of a constant vector equals the constant",
+    "content": "The computational heart: `Mₖ(c,…,c) = c` for `c ≥ 0` and `1 ≤ k ≤ n`. Unfolding `maclaurinMean = (eₖ / C(n,k))^(1/k)` and substituting `elemSymm_const`, the normalizing `C(n,k)` cancels (`div_self`, positive by `Nat.choose_pos` for `k ≤ n`), leaving `cᵏ`. The outer exponent `1/k` then inverts it: `(cᵏ)^(1/k) = c^(k·(1/k)) = c^1 = c`, established through `Real.rpow_natCast`, `Real.rpow_mul` (needs `c ≥ 0`), and `div_self` on `k ≠ 0`. Non-negativity of `c` is essential — real `rpow` is only well-behaved for non-negative bases.",
+    "mathContext": "$M_k(c,\\dots,c) = \\left(\\frac{\\binom{n}{k} c^k}{\\binom{n}{k}}\\right)^{1/k} = (c^k)^{1/k} = c, \\quad c \\ge 0,\\ 1 \\le k \\le n.$",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin mean", "real power (rpow)", "Nat.choose_pos", "normalization"],
+    "prerequisites": ["real exponentiation", "Maclaurin means"]
+  },
+  {
+    "id": "ann-maclaurin-eq-consecutive",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 90, "endLine": 96 },
+    "type": "insight",
+    "title": "Sufficiency, consecutive step",
+    "content": "The ⟸ direction of open question OQ-02 for a single step: on a non-negative constant input the Maclaurin step `Mₖ = Mₖ₊₁` is an equality. The proof simply rewrites both sides to `c` using `maclaurinMean_const` (with the index shift `k → k+1` requiring `k+1 ≤ n`). This is the exact companion to the parent's strict-inequality chain: where the parent shows `Mₖ ≥ Mₖ₊₁`, this pins the equality case for constant data.",
+    "mathContext": "$c \\ge 0,\\ 1 \\le k,\\ k+1 \\le n \\;\\Rightarrow\\; M_k(c,\\dots,c) = M_{k+1}(c,\\dots,c) = c.$",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin mean", "equality case", "Newton's inequalities"],
+    "prerequisites": ["Maclaurin means"]
+  },
+  {
+    "id": "ann-maclaurin-all-eq",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 98, "endLine": 104 },
+    "type": "insight",
+    "title": "Sufficiency, full chain collapse",
+    "content": "Generalizes from consecutive steps to arbitrary pairs: every two Maclaurin means with indices in `1..n` agree on a constant input, so the entire chain `M₁ = M₂ = ⋯ = Mₙ = c` collapses to one value. Both means rewrite to `c` via `maclaurinMean_const`, so no induction along the chain is needed — the constant-value lemma is uniform in the index.",
+    "mathContext": "$c \\ge 0 \\;\\Rightarrow\\; M_j(c,\\dots,c) = M_k(c,\\dots,c) = c \\text{ for all } 1 \\le j,k \\le n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Maclaurin mean", "equality case", "AM-GM equality"],
+    "prerequisites": ["Maclaurin means"]
+  },
+  {
+    "id": "ann-not-const-contrapositive",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": { "startLine": 106, "endLine": 122 },
+    "type": "insight",
+    "title": "Contrapositive: differing means detect non-constant data",
+    "content": "The logically equivalent restatement: if two consecutive Maclaurin means of `x` differ, then `x` cannot be a non-negative constant vector. Proved by assuming `x = (c,…,c)` with `c ≥ 0` and deriving the equality `Mₖ = Mₖ₊₁` (from `maclaurin_eq_of_const`), contradicting the hypothesis. This is the practically useful shape: applying Maclaurin's inequality to observed data, a strict gap between consecutive means certifies that the data is not constant.",
+    "mathContext": "$M_k(x) \\ne M_{k+1}(x) \\;\\Rightarrow\\; \\neg\\,\\exists c \\ge 0,\\ x = (c,\\dots,c).$",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "Maclaurin mean", "equality case"],
+    "prerequisites": ["logical negation", "Maclaurin means"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-02-oq-02` (0 prior passes, quality 34).

## Gap
Rich `meta.json` but **no `annotations.json`** — zero inline coverage of the 124-line Lean file.

## Changes
Added `annotations.json` with **6 annotations** spanning the file:
- The constant-input strategy (section overview)
- `elemSymm_const` — eₖ(c,…,c) = C(n,k)·cᵏ
- `maclaurinMean_const` — Mₖ(c,…,c) = c (the computational heart; rpow inversion)
- `maclaurin_eq_of_const` — sufficiency, consecutive step
- `maclaurin_all_eq_of_const` — sufficiency, full chain collapse
- `not_const_of_maclaurin_ne` — the contrapositive

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; all startLines anchor on doc-comment/section boundaries.

## Validation
`pnpm annotations:validate` (strict): **0 errors for this slug** (remaining errors are the pre-existing gallery-wide baseline).