### PR TITLE
research(cantor-diagonalization-oq-01-oq-01-wip-01): complete structural characterization of intermediate cardinals [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean
@@ -1,0 +1,185 @@
+/-
+# Intermediate cardinals: complete structural characterization (OQ-01-OQ-01-WIP-01)
+
+## Parent question
+
+The gallery entry `cantor-diagonalization-oq-01-oq-01` ("The Continuum Hypothesis:
+Independence and Consequences") answers the question
+
+  *Does there exist a cardinal κ with ℵ₀ < κ < 2^ℵ₀?*
+
+by proving `intermediate_iff_not_ch`: **an intermediate cardinal exists iff CH fails.**
+It also exhibits ℵ₁ as *an* intermediate under ¬CH, and states König's constraint on
+the possible values of 2^ℵ₀.
+
+## What this file adds
+
+The parent settles *existence*. It leaves open the finer, purely ZFC-provable
+**structural** question: *which* cardinals are the intermediates, and is there a least
+one? This file gives the complete answer, axiom-free, directly from Mathlib's
+`Cardinal.aleph` API:
+
+* `intermediate_is_aleph`         — every intermediate cardinal is `ℵ_ o` for some `0 < o`
+  (there are no "exotic" intermediates outside the aleph hierarchy).
+* `aleph_one_le_of_intermediate`  — **ℵ₁ is a lower bound**: every intermediate `κ` has `ℵ₁ ≤ κ`.
+* `aleph_one_intermediate_iff_not_ch` — ℵ₁ *is* intermediate exactly when CH fails.
+* `least_intermediate`            — whenever an intermediate exists, **ℵ₁ is the least one**
+  (it is intermediate and bounds all intermediates below).
+* `intermediate_iff`              — the exact membership test:
+  `κ` is intermediate ↔ `κ = ℵ_ o` with `0 < o` and `ℵ_ o < 𝔠`.
+* `intermediate_iff_lt_index`     — writing `𝔠 = ℵ_ δ` (the continuum is always an aleph),
+  the intermediates are **exactly** `{ ℵ_ o : 0 < o < δ }` — a bijection with the ordinal
+  interval `(0, δ)`. This pins down the whole set, not just whether it is nonempty.
+
+So beyond "an intermediate exists ⟺ ¬CH", the intermediate cardinals form an initial
+segment of the uncountable alephs with least element ℵ₁, indexed by the ordinals strictly
+between `0` and the aleph-index of the continuum.
+
+`CH` is taken here as `𝔠 = ℵ₁` (definitionally the same as
+`Proofs.ContinuumHypothesis.CH`, which unfolds to `2 ^ ℵ₀ = aleph 1`); we work with
+Mathlib's `𝔠` throughout and `two_power_aleph0 : 2 ^ ℵ₀ = 𝔠` bridges the two.
+
+## References
+- Kanamori, A. (2003). *The Higher Infinite*, §1 (the aleph hierarchy).
+- Jech, T. (2003). *Set Theory*, ch. 3 (cardinal arithmetic, König).
+-/
+
+import Mathlib
+
+namespace CantorDiagOQ0101Wip01
+
+open Cardinal Ordinal
+
+/-- A cardinal is **intermediate** if it lies strictly between `ℵ₀` and the continuum
+`𝔠 = 2 ^ ℵ₀`. -/
+def Intermediate (κ : Cardinal.{0}) : Prop := ℵ₀ < κ ∧ κ < 𝔠
+
+/-- The Continuum Hypothesis, stated as `𝔠 = ℵ₁`. This unfolds to `2 ^ ℵ₀ = aleph 1`
+via `two_power_aleph0`, matching `Proofs.ContinuumHypothesis.CH`. -/
+def CH : Prop := (𝔠 : Cardinal.{0}) = ℵ₁
+
+/-! ## Basic reformulations -/
+
+/-- `ℵ₁ ≤ 𝔠` always holds in ZFC (this is just `Cardinal.aleph_one_le_continuum`). -/
+theorem aleph_one_le_continuum : (ℵ₁ : Cardinal.{0}) ≤ 𝔠 := Cardinal.aleph_one_le_continuum
+
+/-- CH is equivalent to `ℵ₁` being *not* strictly below the continuum. -/
+theorem ch_iff_not_aleph_one_lt : CH ↔ ¬ (ℵ₁ : Cardinal.{0}) < 𝔠 := by
+  unfold CH
+  constructor
+  · intro h; rw [h]; exact lt_irrefl _
+  · intro h
+    exact le_antisymm (not_lt.mp h) aleph_one_le_continuum
+
+/-- `¬CH` is equivalent to `ℵ₁ < 𝔠`: the continuum genuinely overshoots ℵ₁. -/
+theorem not_ch_iff_aleph_one_lt : ¬CH ↔ (ℵ₁ : Cardinal.{0}) < 𝔠 := by
+  rw [ch_iff_not_aleph_one_lt, not_not]
+
+/-! ## Every intermediate cardinal is an uncountable aleph -/
+
+/-- **No exotic intermediates.** Any intermediate cardinal is `ℵ_ o` for some ordinal
+`o > 0`. This is because every cardinal `≥ ℵ₀` is an aleph, and being `> ℵ₀ = ℵ_ 0`
+forces a positive index. -/
+theorem intermediate_is_aleph {κ : Cardinal.{0}} (h : Intermediate κ) :
+    ∃ o : Ordinal.{0}, 0 < o ∧ κ = ℵ_ o := by
+  obtain ⟨hlo, _⟩ := h
+  -- κ ≥ ℵ₀, hence κ = ℵ_ o for some o.
+  obtain ⟨o, ho⟩ := mem_range_aleph_iff.mpr (le_of_lt hlo)
+  refine ⟨o, ?_, ho.symm⟩
+  -- ℵ_ 0 = ℵ₀ < κ = ℵ_ o forces 0 < o.
+  have : ℵ_ (0 : Ordinal.{0}) < ℵ_ o := by
+    rw [aleph_zero, ho]; exact hlo
+  exact aleph_lt_aleph.mp this
+
+/-- **ℵ₁ is a lower bound for the intermediates.** Every intermediate cardinal is `≥ ℵ₁`,
+so there is no room strictly between `ℵ₀` and `ℵ₁`. -/
+theorem aleph_one_le_of_intermediate {κ : Cardinal.{0}} (h : Intermediate κ) : ℵ₁ ≤ κ := by
+  obtain ⟨o, hpos, hko⟩ := intermediate_is_aleph h
+  rw [hko]
+  -- 0 < o gives 1 ≤ o, hence ℵ_ 1 ≤ ℵ_ o.
+  exact aleph_le_aleph.mpr (Ordinal.one_le_iff_ne_zero.mpr hpos.ne')
+
+/-! ## ℵ₁ as the least intermediate -/
+
+/-- `ℵ₁` is intermediate exactly when CH fails. Combined with `aleph_one_le_of_intermediate`
+this says ℵ₁ is the *canonical smallest candidate*. -/
+theorem aleph_one_intermediate_iff_not_ch : Intermediate (ℵ₁) ↔ ¬CH := by
+  rw [not_ch_iff_aleph_one_lt]
+  constructor
+  · exact fun h => h.2
+  · intro h
+    exact ⟨aleph0_lt_aleph_one, h⟩
+
+/-- **An intermediate cardinal exists iff CH fails.** (Reproves the parent's headline
+equivalence from the structural lemmas.) -/
+theorem exists_intermediate_iff_not_ch : (∃ κ, Intermediate κ) ↔ ¬CH := by
+  constructor
+  · rintro ⟨κ, hκ⟩ hch
+    -- Under CH, ℵ₁ ≤ κ < 𝔠 = ℵ₁ is contradictory.
+    have h1 : ℵ₁ ≤ κ := aleph_one_le_of_intermediate hκ
+    have h2 : κ < 𝔠 := hκ.2
+    rw [(show 𝔠 = ℵ₁ from hch)] at h2
+    exact absurd (h1.trans_lt h2) (lt_irrefl _)
+  · intro h
+    exact ⟨ℵ₁, aleph_one_intermediate_iff_not_ch.mpr h⟩
+
+/-- **ℵ₁ is the least intermediate.** Whenever any intermediate cardinal exists, `ℵ₁`
+is itself intermediate and is a lower bound for every intermediate cardinal — i.e. it is
+the minimum of the intermediate set. -/
+theorem least_intermediate (h : ∃ κ, Intermediate κ) :
+    Intermediate (ℵ₁) ∧ ∀ κ, Intermediate κ → ℵ₁ ≤ κ := by
+  have hnc : ¬CH := exists_intermediate_iff_not_ch.mp h
+  exact ⟨aleph_one_intermediate_iff_not_ch.mpr hnc, fun _ hκ => aleph_one_le_of_intermediate hκ⟩
+
+/-! ## Exact characterization of the intermediate set -/
+
+/-- **Membership test.** A cardinal is intermediate iff it is `ℵ_ o` for a positive
+ordinal `o` whose aleph is still below the continuum. -/
+theorem intermediate_iff {κ : Cardinal.{0}} :
+    Intermediate κ ↔ ∃ o : Ordinal.{0}, 0 < o ∧ κ = ℵ_ o ∧ ℵ_ o < 𝔠 := by
+  constructor
+  · intro h
+    obtain ⟨o, hpos, hko⟩ := intermediate_is_aleph h
+    exact ⟨o, hpos, hko, hko ▸ h.2⟩
+  · rintro ⟨o, hpos, hko, hlt⟩
+    refine ⟨?_, ?_⟩
+    · -- ℵ₀ = ℵ_ 0 < ℵ_ o = κ since 0 < o.
+      rw [hko, ← aleph_zero]
+      exact aleph_lt_aleph.mpr hpos
+    · rw [hko]; exact hlt
+
+/-- The continuum is itself an aleph: `𝔠 = ℵ_ δ` for some ordinal `δ` (indeed `δ ≥ 1`). -/
+theorem exists_continuum_index : ∃ δ : Ordinal.{0}, 𝔠 = ℵ_ δ := by
+  obtain ⟨δ, hδ⟩ := mem_range_aleph_iff.mpr (le_of_lt aleph0_lt_continuum)
+  exact ⟨δ, hδ.symm⟩
+
+/-- **The intermediate set, pinned down.** Fixing the aleph-index `δ` of the continuum
+(`𝔠 = ℵ_ δ`), the intermediate cardinals are *exactly* the alephs `ℵ_ o` for `0 < o < δ`.
+Thus the intermediates are order-isomorphic (via `o ↦ ℵ_ o`) to the ordinal interval
+`(0, δ)`, and their number is entirely determined by where the continuum sits in the
+aleph hierarchy. -/
+theorem intermediate_iff_lt_index {δ : Ordinal.{0}} (hδ : 𝔠 = ℵ_ δ) {κ : Cardinal.{0}} :
+    Intermediate κ ↔ ∃ o : Ordinal.{0}, 0 < o ∧ o < δ ∧ κ = ℵ_ o := by
+  rw [intermediate_iff]
+  constructor
+  · rintro ⟨o, hpos, hko, hlt⟩
+    rw [hδ] at hlt
+    exact ⟨o, hpos, aleph_lt_aleph.mp hlt, hko⟩
+  · rintro ⟨o, hpos, hlt, hko⟩
+    refine ⟨o, hpos, hko, ?_⟩
+    rw [hδ]
+    exact aleph_lt_aleph.mpr hlt
+
+/-- Corollary: under ¬CH the least intermediate is ℵ₁, and the intermediates are the
+alephs `ℵ_ o` with `1 ≤ o < δ` (where `𝔠 = ℵ_ δ`), so `δ ≥ 2`. -/
+theorem not_ch_index_ge_two {δ : Ordinal.{0}} (hδ : 𝔠 = ℵ_ δ) (h : ¬CH) : 2 ≤ δ := by
+  have hlt : ℵ₁ < 𝔠 := not_ch_iff_aleph_one_lt.mp h
+  rw [hδ] at hlt
+  have h1 : (1 : Ordinal.{0}) < δ := aleph_lt_aleph.mp hlt
+  -- 1 < δ means 2 = succ 1 ≤ δ.
+  have h2 : (2 : Ordinal.{0}) = Order.succ (1 : Ordinal.{0}) := by
+    rw [Order.succ_eq_add_one, one_add_one_eq_two]
+  rw [h2]
+  exact Order.succ_le_of_lt h1
+
+end CantorDiagOQ0101Wip01

--- a/research/problems/cantor-diagonalization-oq-01-oq-01-wip-01/knowledge.md
+++ b/research/problems/cantor-diagonalization-oq-01-oq-01-wip-01/knowledge.md
@@ -1,0 +1,31 @@
+# Knowledge Base: cantor-diagonalization-oq-01-oq-01-wip-01
+
+## Problem Understanding
+
+Parent `cantor-diagonalization-oq-01-oq-01` proves an intermediate cardinal
+(ℵ₀ < κ < 2^ℵ₀) exists **iff CH fails**. This WIP answers the finer, purely
+ZFC-provable **structural** question: *which* cardinals are the intermediates,
+and is there a least one?
+
+## Insights
+
+- Every cardinal ≥ ℵ₀ is an aleph (`mem_range_aleph_iff`), so every intermediate
+  is `ℵ_o`; being > ℵ₀ = ℵ_0 forces `o > 0`. No exotic intermediates.
+- `aleph_lt_aleph` / `aleph_le_aleph` transport cardinal comparisons to ordinal
+  index comparisons — the workhorse of the file.
+- ℵ₁ is a uniform lower bound (nothing strictly between ℵ₀ and ℵ₁), and is
+  itself intermediate iff ¬CH; hence ℵ₁ is the least intermediate when any exists.
+- The continuum is always an aleph `𝔠 = ℵ_δ`; the intermediates are exactly
+  `{ℵ_o : 0 < o < δ}` — an order-iso with the ordinal interval (0, δ).
+  CH is δ = 1 (empty); ¬CH is δ ≥ 2.
+
+## Result
+
+Shipped `CantorDiagonalizationOQ01OQ01Wip01.lean`, 185 lines, 12 theorems,
+2 definitions, **0 axioms** (#print axioms: propext, Classical.choice, Quot.sound).
+Verified via `lake env lean`. PR #33075.
+
+## Dead Ends
+
+- None; single clean pass. Universe metavariables required pinning CH and the
+  ℵ₁-vs-𝔠 statements to `Cardinal.{0}`.

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/annotations.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "cantordiag0101wip01-ann-setup",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-wip-01",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "concept",
+    "title": "From Existence to Structure of the Intermediate Cardinals",
+    "content": "The parent entry proves an intermediate cardinal (one with ℵ₀ < κ < 2^ℵ₀) exists exactly when CH fails. This file answers the finer, purely ZFC-provable question: which cardinals ARE the intermediates, and is there a least one? The predicate Intermediate κ := ℵ₀ < κ ∧ κ < 𝔠 isolates them, and CH := 𝔠 = ℵ₁ (definitionally the parent's 2^ℵ₀ = aleph 1). Everything is stated with Mathlib's continuum 𝔠 = 2^ℵ₀ and the aleph hierarchy, and proved axiom-free.",
+    "mathContext": "$\\mathrm{Intermediate}(\\kappa) \\iff \\aleph_0 < \\kappa < \\mathfrak{c}$; $\\mathrm{CH} \\iff \\mathfrak{c} = \\aleph_1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "continuum hypothesis",
+      "intermediate cardinals",
+      "aleph hierarchy",
+      "continuum 2^aleph_0"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "the aleph hierarchy",
+      "ZFC independence of CH (Gödel/Cohen)"
+    ]
+  },
+  {
+    "id": "cantordiag0101wip01-ann-chreform",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-wip-01",
+    "range": { "startLine": 61, "endLine": 77 },
+    "type": "theorem",
+    "title": "CH as the Failure of ℵ₁ < 𝔠",
+    "content": "Since ℵ₁ ≤ 𝔠 holds in ZFC (aleph_one_le_continuum, from Mathlib), the continuum is either exactly ℵ₁ (CH) or strictly above it. ch_iff_not_aleph_one_lt and not_ch_iff_aleph_one_lt make this precise: CH ⟺ ¬(ℵ₁ < 𝔠) and ¬CH ⟺ ℵ₁ < 𝔠, both by antisymmetry against the standing bound ℵ₁ ≤ 𝔠. This is the hinge that turns CH into a statement purely about the position of ℵ₁ relative to 𝔠.",
+    "mathContext": "$\\aleph_1 \\le \\mathfrak{c}$ always; $\\mathrm{CH} \\iff \\neg(\\aleph_1 < \\mathfrak{c})$, $\\ \\neg\\mathrm{CH} \\iff \\aleph_1 < \\mathfrak{c}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "aleph_one_le_continuum",
+      "antisymmetry",
+      "continuum hypothesis"
+    ],
+    "prerequisites": [
+      "order antisymmetry",
+      "ℵ₁ ≤ 𝔠"
+    ]
+  },
+  {
+    "id": "cantordiag0101wip01-ann-isaleph",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-wip-01",
+    "range": { "startLine": 78, "endLine": 101 },
+    "type": "theorem",
+    "title": "No Exotic Intermediates; ℵ₁ is a Lower Bound",
+    "content": "intermediate_is_aleph shows every intermediate cardinal is ℵ_o for some ordinal o > 0: every cardinal ≥ ℵ₀ is an aleph (mem_range_aleph_iff), and being strictly above ℵ₀ = ℵ_0 forces the index positive (aleph_lt_aleph). There are no intermediates outside the aleph hierarchy. aleph_one_le_of_intermediate then upgrades 0 < o to 1 ≤ o (one_le_iff_ne_zero) and applies monotonicity of aleph to conclude ℵ₁ ≤ κ — so nothing lies strictly between ℵ₀ and ℵ₁, and ℵ₁ bounds every intermediate from below.",
+    "mathContext": "$\\mathrm{Intermediate}(\\kappa) \\Rightarrow \\exists o>0,\\ \\kappa = \\aleph_o$, and $\\aleph_1 \\le \\kappa$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mem_range_aleph_iff",
+      "aleph_lt_aleph",
+      "Hausdorff aleph hierarchy",
+      "successor cardinal"
+    ],
+    "prerequisites": [
+      "surjectivity of aleph onto cardinals ≥ ℵ₀",
+      "monotonicity of aleph"
+    ]
+  },
+  {
+    "id": "cantordiag0101wip01-ann-least",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-wip-01",
+    "range": { "startLine": 102, "endLine": 133 },
+    "type": "theorem",
+    "title": "ℵ₁ is the Least Intermediate",
+    "content": "aleph_one_intermediate_iff_not_ch: because ℵ₀ < ℵ₁ always and ℵ₁ ≤ 𝔠 always, ℵ₁ is itself intermediate exactly when ℵ₁ < 𝔠, i.e. when ¬CH. exists_intermediate_iff_not_ch reproves the parent's dichotomy from the lower bound: under CH any intermediate would satisfy ℵ₁ ≤ κ < 𝔠 = ℵ₁, impossible. least_intermediate packages the two: whenever any intermediate exists, ℵ₁ is intermediate and is a lower bound for all of them — the minimum of the intermediate set.",
+    "mathContext": "$\\mathrm{Intermediate}(\\aleph_1) \\iff \\neg\\mathrm{CH}$; if any intermediate exists then $\\aleph_1$ is the least.",
+    "significance": "key",
+    "relatedConcepts": [
+      "least element",
+      "aleph0_lt_aleph_one",
+      "continuum hypothesis dichotomy"
+    ],
+    "prerequisites": [
+      "ℵ₀ < ℵ₁",
+      "the lower bound ℵ₁ ≤ κ"
+    ]
+  },
+  {
+    "id": "cantordiag0101wip01-ann-exact",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-wip-01",
+    "range": { "startLine": 134, "endLine": 185 },
+    "type": "theorem",
+    "title": "The Intermediate Set Pinned Down: {ℵ_o : 0 < o < δ}",
+    "content": "intermediate_iff gives the membership test κ = ℵ_o with 0 < o and ℵ_o < 𝔠. exists_continuum_index notes the continuum is itself an aleph, 𝔠 = ℵ_δ. Then intermediate_iff_lt_index is the punchline: since ℵ_o < ℵ_δ ⟺ o < δ, the intermediates are EXACTLY {ℵ_o : 0 < o < δ}, in order-preserving bijection with the ordinal interval (0, δ). So the whole set — not merely its nonemptiness — is determined by the aleph-index δ of the continuum. not_ch_index_ge_two records the boundary: ¬CH forces δ ≥ 2 (CH is exactly δ = 1).",
+    "mathContext": "With $\\mathfrak{c} = \\aleph_\\delta$: $\\ \\mathrm{Intermediate}(\\kappa) \\iff \\kappa = \\aleph_o,\\ 0 < o < \\delta$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "order isomorphism",
+      "ordinal interval",
+      "aleph index of the continuum",
+      "Easton's theorem"
+    ],
+    "prerequisites": [
+      "𝔠 = ℵ_δ (continuum is an aleph)",
+      "aleph_lt_aleph reflecting < on indices"
+    ]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-wip-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "cantor-diagonalization-oq-01-oq-01-wip-01",
+  "title": "Intermediate Cardinals: Complete Structural Characterization",
+  "slug": "cantor-diagonalization-oq-01-oq-01-wip-01",
+  "description": "The parent entry proves an intermediate cardinal (one with ℵ₀ < κ < 2^ℵ₀) exists iff CH fails. This entry answers the finer, purely ZFC-provable structural question of WHICH cardinals the intermediates are. Axiom-free from Mathlib's aleph API: every intermediate is an uncountable aleph ℵ_o (0 < o) with no exotic exceptions; ℵ₁ is a lower bound so there is no room between ℵ₀ and ℵ₁; ℵ₁ is the least intermediate whenever any exists; and, writing 𝔠 = ℵ_δ (the continuum is always an aleph), the intermediates are EXACTLY the alephs ℵ_o for 0 < o < δ — a bijection with the ordinal interval (0, δ). So the whole set is pinned down, not just whether it is nonempty.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean",
+    "tags": [
+      "set-theory",
+      "cardinals",
+      "continuum-hypothesis",
+      "aleph-hierarchy",
+      "intermediate-cardinals",
+      "cofinality"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Proved in ZFC (Mathlib's cardinal foundations) with no added axioms; #print axioms reports only propext, Classical.choice, Quot.sound on all main results. CH is defined here as 𝔠 = ℵ₁ (definitionally the same as the parent's Proofs.ContinuumHypothesis.CH, which unfolds to 2^ℵ₀ = aleph 1; two_power_aleph0 bridges the two). No independence assumptions are used: every theorem is a ZFC theorem.",
+    "lineCount": 185,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "originalContributions": [
+      "Intermediate: the predicate ℵ₀ < κ < 𝔠 isolating cardinals strictly between ℵ₀ and the continuum",
+      "intermediate_is_aleph: every intermediate cardinal is ℵ_o for some ordinal o > 0 (no intermediates outside the aleph hierarchy)",
+      "aleph_one_le_of_intermediate: ℵ₁ ≤ κ for every intermediate κ — nothing lies strictly between ℵ₀ and ℵ₁",
+      "aleph_one_intermediate_iff_not_ch: ℵ₁ itself is intermediate exactly when CH fails",
+      "least_intermediate: whenever an intermediate exists, ℵ₁ is the minimum of the intermediate set",
+      "intermediate_iff: membership test — κ is intermediate iff κ = ℵ_o with 0 < o and ℵ_o < 𝔠",
+      "exists_continuum_index: the continuum is itself an aleph, 𝔠 = ℵ_δ",
+      "intermediate_iff_lt_index: with 𝔠 = ℵ_δ, the intermediates are EXACTLY {ℵ_o : 0 < o < δ}, order-isomorphic to the ordinal interval (0, δ)",
+      "not_ch_index_ge_two: ¬CH forces the continuum's aleph-index δ ≥ 2"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cantor's theorem gives ℵ₀ < 2^ℵ₀; the Continuum Hypothesis asks whether 2^ℵ₀ = ℵ₁, equivalently whether there is any cardinal strictly between them. Gödel (1938) and Cohen (1963) proved this undecidable in ZFC. The parent gallery entry cantor-diagonalization-oq-01-oq-01 formalized the headline equivalence 'an intermediate cardinal exists ⟺ ¬CH' and exhibited ℵ₁ as an intermediate under ¬CH. What ZFC can still say unconditionally — independent of how CH is resolved — is the internal STRUCTURE of the intermediate set: every infinite cardinal is an aleph (Hausdorff's aleph hierarchy), so the intermediates form an initial segment of the uncountable alephs. This entry formalizes that structure.",
+    "problemStatement": "Beyond mere existence, exactly which cardinals are the intermediates (ℵ₀ < κ < 2^ℵ₀), and is there a least one?",
+    "text": "Every cardinal ≥ ℵ₀ is an aleph (mem_range_aleph_iff), so any intermediate κ equals ℵ_o; being > ℵ₀ = ℵ_0 forces o > 0 (intermediate_is_aleph). Since 0 < o gives 1 ≤ o, monotonicity of aleph yields ℵ₁ ≤ κ (aleph_one_le_of_intermediate): there is no cardinal strictly between ℵ₀ and ℵ₁, so ℵ₁ is a uniform lower bound. Because ℵ₁ ≤ 𝔠 always and ℵ₀ < ℵ₁ always, ℵ₁ is itself intermediate precisely when ℵ₁ < 𝔠, i.e. when ¬CH (aleph_one_intermediate_iff_not_ch); hence whenever any intermediate exists, ℵ₁ is the least one (least_intermediate). Finally the continuum is itself an aleph 𝔠 = ℵ_δ (exists_continuum_index), and ℵ_o < ℵ_δ ⟺ o < δ, so the intermediates are exactly the alephs ℵ_o with 0 < o < δ (intermediate_iff_lt_index): a bijection with the ordinal interval (0, δ). The number of intermediates is therefore completely determined by where the continuum sits in the aleph hierarchy — none under CH (δ = 1), and δ ≥ 2 under ¬CH (not_ch_index_ge_two).",
+    "proofStrategy": "Reduce every question to the aleph hierarchy. Use mem_range_aleph_iff to write cardinals ≥ ℵ₀ as alephs, then transport strict/weak inequalities through aleph_lt_aleph and aleph_le_aleph, which turn cardinal comparisons into ordinal comparisons of indices. The lower bound ℵ₁ comes from 0 < o ⟹ 1 ≤ o; the exact set from ℵ_o < ℵ_δ ⟺ o < δ.",
+    "keyInsights": [
+      "There are no 'exotic' intermediate cardinals: every one is an aleph ℵ_o, because every infinite cardinal is (Hausdorff). Structural questions about intermediates reduce to ordinal questions about their indices.",
+      "ℵ₁ is a lower bound for ALL intermediates (there is provably nothing strictly between ℵ₀ and ℵ₁), and it is itself intermediate iff ¬CH — so it is the canonical least intermediate whenever the set is nonempty.",
+      "The continuum is always an aleph 𝔠 = ℵ_δ, and the intermediate set is EXACTLY {ℵ_o : 0 < o < δ}. This is a complete description via an order-isomorphism with the ordinal interval (0, δ), sharpening the parent's existence result to a full inventory.",
+      "The 'number' of intermediate cardinals is not independent of ZFC in a vacuum: once the value 𝔠 = ℵ_δ is fixed, the intermediates are determined — CH is exactly the case δ = 1 (empty), and any failure of CH is δ ≥ 2."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic and the aleph hierarchy (Cardinal.aleph, mem_range_aleph_iff)",
+      "Monotonicity of aleph (aleph_lt_aleph, aleph_le_aleph)",
+      "The continuum 𝔠 = 2^ℵ₀ and aleph_one_le_continuum",
+      "Ordinal successor arithmetic (one_le_iff_ne_zero, succ_le_of_lt)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The intermediate cardinals (ℵ₀ < κ < 2^ℵ₀) are completely characterized, axiom-free in ZFC: each is an uncountable aleph ℵ_o with 0 < o; ℵ₁ is their least element whenever any exist; and writing 𝔠 = ℵ_δ they are exactly {ℵ_o : 0 < o < δ}, in order-preserving bijection with the ordinal interval (0, δ). 12 theorems, 2 definitions, 185 lines, 0 axioms.",
+    "implications": "This upgrades the parent's existence dichotomy ('intermediate exists ⟺ ¬CH') to a full structural inventory. It makes precise that CH is the statement δ = 1 (the continuum is the immediate successor ℵ₁), that any failure of CH means δ ≥ 2, and that the intermediates never escape the aleph hierarchy — so their order type is always an ordinal interval (0, δ). The independence of CH concerns only the value of δ; the internal structure of the intermediate set is a ZFC theorem.",
+    "openQuestions": [
+      "Formalize the order-isomorphism o ↦ ℵ_o from the ordinal interval (0, δ) onto the intermediate set as an explicit OrderIso, and read off the order type of the intermediates.",
+      "Relate the aleph-index δ of the continuum to König's constraint cf(𝔠) > ℵ₀ (proved in the sibling oq-03): which δ are excluded because ℵ_δ has cofinality ℵ₀?",
+      "Cardinal characteristics of the continuum (𝔟, 𝔡, 𝔭, …) are specific intermediates under ¬CH; formalize one and locate its aleph-index within (0, δ)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CantorDiagOQ0101Wip01",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "F. Hausdorff — every infinite cardinal is an aleph (the aleph hierarchy)",
+      "url": "https://en.wikipedia.org/wiki/Aleph_number"
+    },
+    {
+      "title": "K. Gödel (1938) & P. Cohen (1963) — independence of CH over ZFC",
+      "url": "https://en.wikipedia.org/wiki/Continuum_hypothesis"
+    },
+    {
+      "title": "Mathlib: Cardinal.aleph and mem_range_aleph_iff (surjectivity onto cardinals ≥ ℵ₀)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/SetTheory/Cardinal/Aleph.html"
+    },
+    {
+      "title": "Mathlib: Cardinal.aleph_one_le_continuum",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/SetTheory/Cardinal/Continuum.html"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: proves an intermediate cardinal exists ⟺ ¬CH. This entry characterizes the entire intermediate set — every intermediate is an aleph, ℵ₁ is the least, and 𝔠 = ℵ_δ makes them exactly {ℵ_o : 0 < o < δ}."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling: the generalized continuum function and König's constraint cf(2^{ℵ_α}) > ℵ_α, constraining which alephs the continuum ℵ_δ can be."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Root: Cantor's diagonal argument giving ℵ₀ < 2^ℵ₀, the strict inequality that opens the gap the intermediates live in."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Setup: intermediate cardinals and CH",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Docstring positioning the file against the parent (existence ⟺ ¬CH) and stating the structural results. Imports Mathlib, opens Cardinal/Ordinal, and defines Intermediate κ := ℵ₀ < κ < 𝔠 and CH := 𝔠 = ℵ₁."
+    },
+    {
+      "title": "Basic reformulations of CH",
+      "startLine": 61,
+      "endLine": 77,
+      "summary": "aleph_one_le_continuum (ℵ₁ ≤ 𝔠, from Mathlib), ch_iff_not_aleph_one_lt and not_ch_iff_aleph_one_lt: since ℵ₁ ≤ 𝔠 always, CH ⟺ ¬(ℵ₁ < 𝔠) and ¬CH ⟺ ℵ₁ < 𝔠."
+    },
+    {
+      "title": "Every intermediate is an uncountable aleph",
+      "startLine": 78,
+      "endLine": 101,
+      "summary": "intermediate_is_aleph (each intermediate is ℵ_o with o > 0, via mem_range_aleph_iff and aleph_lt_aleph) and aleph_one_le_of_intermediate (ℵ₁ ≤ κ, from 0 < o ⟹ 1 ≤ o)."
+    },
+    {
+      "title": "ℵ₁ as the least intermediate",
+      "startLine": 102,
+      "endLine": 133,
+      "summary": "aleph_one_intermediate_iff_not_ch, exists_intermediate_iff_not_ch (reproving the parent's dichotomy from the lower bound), and least_intermediate (ℵ₁ is the minimum of the intermediate set when nonempty)."
+    },
+    {
+      "title": "Exact characterization of the intermediate set",
+      "startLine": 134,
+      "endLine": 185,
+      "summary": "intermediate_iff (membership test κ = ℵ_o, 0 < o, ℵ_o < 𝔠), exists_continuum_index (𝔠 = ℵ_δ), intermediate_iff_lt_index (the intermediates are exactly {ℵ_o : 0 < o < δ}), and not_ch_index_ge_two (¬CH forces δ ≥ 2)."
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-wip-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-wip-01.json
@@ -1,0 +1,79 @@
+{
+  "slug": "cantor-diagonalization-oq-01-oq-01-wip-01",
+  "title": "Structure of the intermediate cardinals between ℵ₀ and 2^ℵ₀",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Characterize {κ : ℵ₀ < κ < 2^ℵ₀}: is every such κ an aleph, is there a least one, and what is the whole set?",
+    "plain": "The parent proves an intermediate cardinal (ℵ₀ < κ < 2^ℵ₀) exists iff CH fails. This asks the finer, ZFC-provable structural question: which cardinals ARE the intermediates, and is there a least one?",
+    "whyMatters": [
+      "Separates the ZFC-provable STRUCTURE of the intermediate set from the ZFC-independent question of whether it is nonempty.",
+      "Gives a complete inventory (order type, least element) rather than a mere existence dichotomy."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "intermediate_is_aleph: every intermediate cardinal is ℵ_o with o > 0",
+      "aleph_one_le_of_intermediate: ℵ₁ ≤ κ for every intermediate κ",
+      "least_intermediate: ℵ₁ is the least intermediate whenever any exists",
+      "intermediate_iff_lt_index: with 𝔠 = ℵ_δ, intermediates = exactly {ℵ_o : 0 < o < δ}",
+      "not_ch_index_ge_two: ¬CH forces δ ≥ 2"
+    ],
+    "open": [
+      "Explicit OrderIso from the ordinal interval (0, δ) onto the intermediate set.",
+      "Which δ are excluded by König's constraint cf(ℵ_δ) > ℵ₀."
+    ],
+    "goal": "Complete, axiom-free structural description of the intermediate cardinal set. ACHIEVED."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-02T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Shipped verified 0-axiom gallery entry.",
+    "blockers": [],
+    "nextAction": "None — complete.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: created CantorDiagonalizationOQ01OQ01Wip01.lean (185 lines, 12 theorems, 2 definitions, 0 axioms). Complete structural characterization of the intermediate cardinals: every intermediate is an uncountable aleph, ℵ₁ is the least, and 𝔠 = ℵ_δ makes them exactly {ℵ_o : 0 < o < δ}.",
+    "builtItems": [
+      "Intermediate predicate and CH := 𝔠 = ℵ₁",
+      "intermediate_is_aleph, aleph_one_le_of_intermediate (ℵ₁ lower bound)",
+      "aleph_one_intermediate_iff_not_ch, least_intermediate",
+      "intermediate_iff, exists_continuum_index, intermediate_iff_lt_index, not_ch_index_ge_two"
+    ],
+    "insights": [
+      "Every cardinal ≥ ℵ₀ is an aleph (mem_range_aleph_iff), so structural questions about intermediates reduce to ordinal questions about their aleph-indices.",
+      "ℵ₁ is a uniform lower bound: nothing lies strictly between ℵ₀ and ℵ₁, and ℵ₁ is intermediate iff ¬CH, hence the least intermediate.",
+      "The continuum is always an aleph 𝔠 = ℵ_δ; the intermediates are exactly {ℵ_o : 0 < o < δ}, an order-iso with the ordinal interval (0, δ). CH is δ = 1; ¬CH is δ ≥ 2.",
+      "aleph_lt_aleph / aleph_le_aleph transport cardinal comparisons to ordinal index comparisons — the workhorse of the whole file."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "See research/problems/cantor-diagonalization-oq-01-oq-01-wip-01/knowledge.md"
+  },
+  "tags": ["set-theory", "cardinals", "continuum-hypothesis", "aleph-hierarchy", "intermediate-cardinals"],
+  "relatedProofs": [
+    "cantor-diagonalization-oq-01-oq-01",
+    "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "cantor-diagonalization"
+  ],
+  "references": { "papers": [], "urls": [], "mathlib": ["Cardinal.aleph", "Cardinal.mem_range_aleph_iff", "Cardinal.aleph_one_le_continuum"] },
+  "started": "2026-07-02T00:00:00.000Z",
+  "lastUpdate": "2026-07-02T00:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean",
+      "filename": "CantorDiagonalizationOQ01OQ01Wip01.lean",
+      "lineCount": 185,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ01OQ01Wip01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry `cantor-diagonalization-oq-01-oq-01-wip-01` — a **fully verified, 0-axiom** structural refinement of the parent CH entry.

The parent `cantor-diagonalization-oq-01-oq-01` proves an *intermediate* cardinal (one with ℵ₀ < κ < 2^ℵ₀) exists **iff CH fails**. This entry answers the finer, purely ZFC-provable question the parent leaves open: *which* cardinals are the intermediates, and is there a least one?

## Results (all axiom-free, from Mathlib's aleph API)

- `intermediate_is_aleph` — every intermediate cardinal is `ℵ_o` for some ordinal `o > 0`; there are **no exotic intermediates** outside the aleph hierarchy.
- `aleph_one_le_of_intermediate` — `ℵ₁ ≤ κ` for every intermediate κ: nothing lies strictly between ℵ₀ and ℵ₁.
- `aleph_one_intermediate_iff_not_ch` — ℵ₁ itself is intermediate exactly when CH fails.
- `least_intermediate` — whenever an intermediate exists, **ℵ₁ is the minimum** of the intermediate set.
- `exists_continuum_index` — the continuum is itself an aleph, `𝔠 = ℵ_δ`.
- `intermediate_iff_lt_index` — the punchline: with `𝔠 = ℵ_δ`, the intermediates are **exactly** `{ℵ_o : 0 < o < δ}`, in order-preserving bijection with the ordinal interval `(0, δ)`.
- `not_ch_index_ge_two` — ¬CH forces the continuum's aleph-index `δ ≥ 2` (CH is exactly δ = 1).

So the parent's *existence* dichotomy is upgraded to a complete *inventory*: the intermediate cardinals always form an initial segment of the uncountable alephs whose order type is the ordinal interval below the continuum's index.

## Verification

- `lake env lean` compiles cleanly (0 sorries).
- `#print axioms` on all main results reports only `propext, Classical.choice, Quot.sound` — **0 added axioms**.
- 12 theorems, 2 definitions, 185 lines.
- CH is defined as `𝔠 = ℵ₁`, definitionally the parent's `Proofs.ContinuumHypothesis.CH` (`2^ℵ₀ = aleph 1`).
- Gallery meta.json + annotations.json added; annotations validate (all ranges hit real Lean constructs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)