### PR TITLE
Enrich Maclaurin log-concave engine (newton-inductive-step-oq-02-oq-02): annotation fields

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-02-oq-02/annotations.json
@@ -3,9 +3,22 @@
     "id": "ann-scope",
     "proofId": "newton-inductive-step-oq-02-oq-02",
     "range": { "startLine": 1, "endLine": 57 },
-    "type": "info",
+    "type": "concept",
     "title": "What This Entry Proves and How It Answers OQ1",
-    "content": "The parent (newton-inductive-step-oq-02) formalized log-concavity of the elementary symmetric means, ēₖ² ≥ ēₖ₋₁·ēₖ₊₁ (Newton's inequality), but proved only the first Maclaurin step ē₁² ≥ ē₂. Its OQ1 asked for the full chain ē₁ ≥ ē₂^{1/2} ≥ ⋯ ≥ ēₙ^{1/n}. This file supplies the missing implication in maximal generality: for ANY strictly positive sequence a₀,…,a_N with a₀ = 1 that is log-concave, it derives aₖ^{k+1} ≥ a_{k+1}^k and hence a_{k+1}^{1/(k+1)} ≤ aₖ^{1/k}. Setting aₖ = ēₖ recovers Maclaurin's inequality: the hypothesis a₀ = 1 is e₀/C(n,0) = 1, positivity holds for xᵢ > 0, and the log-concavity hypothesis is exactly Newton's inequality. The result imports only Mathlib, so it is verified independently (0 axioms: only propext, Classical.choice, Quot.sound)."
+    "content": "The parent (newton-inductive-step-oq-02) formalized log-concavity of the elementary symmetric means, ēₖ² ≥ ēₖ₋₁·ēₖ₊₁ (Newton's inequality), but proved only the first Maclaurin step ē₁² ≥ ē₂. Its OQ1 asked for the full chain ē₁ ≥ ē₂^{1/2} ≥ ⋯ ≥ ēₙ^{1/n}. This file supplies the missing implication in maximal generality: for ANY strictly positive sequence a₀,…,a_N with a₀ = 1 that is log-concave, it derives aₖ^{k+1} ≥ a_{k+1}^k and hence a_{k+1}^{1/(k+1)} ≤ aₖ^{1/k}. Setting aₖ = ēₖ recovers Maclaurin's inequality: the hypothesis a₀ = 1 is e₀/C(n,0) = 1, positivity holds for xᵢ > 0, and the log-concavity hypothesis is exactly Newton's inequality. The result imports only Mathlib, so it is verified independently (0 axioms: only propext, Classical.choice, Quot.sound).",
+    "mathContext": "$\\bar e_1 \\ge \\bar e_2^{1/2} \\ge \\cdots \\ge \\bar e_n^{1/n}$ follows from $\\bar e_k^2 \\ge \\bar e_{k-1}\\bar e_{k+1}$ by instantiating the abstract engine at $a := \\bar e$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Maclaurin's inequality",
+      "Newton's inequality",
+      "elementary symmetric means",
+      "log-concave sequences"
+    ],
+    "prerequisites": [
+      "elementary symmetric polynomials and their normalized means ēₖ",
+      "the parent log-concavity result (Newton's inequality)",
+      "AM–GM style symmetric-mean inequalities"
+    ]
   },
   {
     "id": "ann-ratio-def",
@@ -13,7 +26,20 @@
     "range": { "startLine": 58, "endLine": 89 },
     "type": "insight",
     "title": "Ratios and the Product Representation aₖ = ∏ rⱼ",
-    "content": "The whole proof pivots on the consecutive ratios rⱼ = aⱼ₊₁/aⱼ. `prod_eq` shows by induction that aₘ = ∏_{j<m} rⱼ: `Finset.prod_range_succ` peels the last factor, the inductive hypothesis rewrites the shorter product back to aₚ, and `mul_div_cancel₀ (a (p+1)) hap` collapses aₚ·(aₚ₊₁/aₚ) = aₚ₊₁. The base case is exactly the normalization a₀ = 1 — this is the one place the hypothesis a₀ = 1 is used, and it is what makes the telescoping product equal the sequence value."
+    "content": "The whole proof pivots on the consecutive ratios rⱼ = aⱼ₊₁/aⱼ. `prod_eq` shows by induction that aₘ = ∏_{j<m} rⱼ: `Finset.prod_range_succ` peels the last factor, the inductive hypothesis rewrites the shorter product back to aₚ, and `mul_div_cancel₀ (a (p+1)) hap` collapses aₚ·(aₚ₊₁/aₚ) = aₚ₊₁. The base case is exactly the normalization a₀ = 1 — this is the one place the hypothesis a₀ = 1 is used, and it is what makes the telescoping product equal the sequence value.",
+    "mathContext": "$a_m = \\prod_{j<m} r_j$ with $r_j = a_{j+1}/a_j$ and $a_0 = 1$; a telescoping product where each $a_p \\cdot (a_{p+1}/a_p) = a_{p+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "consecutive ratios",
+      "telescoping product",
+      "induction on Finset.range",
+      "normalization a₀ = 1"
+    ],
+    "prerequisites": [
+      "Finset.prod_range_succ",
+      "mul_div_cancel₀ and nonzero denominators",
+      "proof by induction on ℕ"
+    ]
   },
   {
     "id": "ann-monotone-ratios",
@@ -21,22 +47,61 @@
     "range": { "startLine": 90, "endLine": 112 },
     "type": "insight",
     "title": "Log-Concavity ⟺ Non-Increasing Ratios",
-    "content": "This is the conceptual core. `hstep` takes the log-concavity hypothesis aⱼ₊₁² ≥ aⱼ·aⱼ₊₂ and, after `div_le_div_iff₀` cross-multiplies the target rⱼ₊₁ = aⱼ₊₂/aⱼ₊₁ ≤ aⱼ₊₁/aⱼ = rⱼ, closes it with `nlinarith`. So log-concavity is EXACTLY the statement that consecutive ratios do not increase. `hmono` then chains single steps by induction on the gap d to give rⱼ₊d ≤ rⱼ throughout the range — the monotonicity that powers the key bound."
+    "content": "This is the conceptual core. `hstep` takes the log-concavity hypothesis aⱼ₊₁² ≥ aⱼ·aⱼ₊₂ and, after `div_le_div_iff₀` cross-multiplies the target rⱼ₊₁ = aⱼ₊₂/aⱼ₊₁ ≤ aⱼ₊₁/aⱼ = rⱼ, closes it with `nlinarith`. So log-concavity is EXACTLY the statement that consecutive ratios do not increase. `hmono` then chains single steps by induction on the gap d to give rⱼ₊d ≤ rⱼ throughout the range — the monotonicity that powers the key bound.",
+    "mathContext": "$a_{j+1}^2 \\ge a_j a_{j+2} \\iff r_{j+1} = \\tfrac{a_{j+2}}{a_{j+1}} \\le \\tfrac{a_{j+1}}{a_j} = r_j$; chaining gives $r_{j+d} \\le r_j$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "log-concavity",
+      "monotone (non-increasing) sequences",
+      "cross-multiplication of inequalities",
+      "induction on the gap"
+    ],
+    "prerequisites": [
+      "div_le_div_iff₀",
+      "nlinarith for nonlinear arithmetic goals",
+      "the equivalence of log-concavity and ratio monotonicity"
+    ]
   },
   {
     "id": "ann-cleared",
     "proofId": "newton-inductive-step-oq-02-oq-02",
     "range": { "startLine": 113, "endLine": 143 },
-    "type": "highlight",
+    "type": "theorem",
     "title": "The Denominator-Free Heart: aₖ ≥ rₖ^k ⟹ aₖ^{k+1} ≥ a_{k+1}^k",
-    "content": "`key` combines the two previous parts: in the product aₖ = ∏_{j<k} rⱼ every factor rⱼ (with j < k) is ≥ rₖ by monotonicity, so `Finset.prod_le_prod` gives aₖ ≥ rₖ^k. The finish is pure algebra: multiply by aₖ^k > 0 and substitute aₖ₊₁ = aₖ·rₖ to obtain aₖ^{k+1} ≥ aₖ^k·rₖ^k = a_{k+1}^k. Note that `maclaurin_of_logConcave` uses ONLY integer exponents and ordered-field arithmetic — no real powers anywhere. That is the payoff of the cleared-denominator formulation: the substantive inequality is entirely elementary."
+    "content": "`key` combines the two previous parts: in the product aₖ = ∏_{j<k} rⱼ every factor rⱼ (with j < k) is ≥ rₖ by monotonicity, so `Finset.prod_le_prod` gives aₖ ≥ rₖ^k. The finish is pure algebra: multiply by aₖ^k > 0 and substitute aₖ₊₁ = aₖ·rₖ to obtain aₖ^{k+1} ≥ aₖ^k·rₖ^k = a_{k+1}^k. Note that `maclaurin_of_logConcave` uses ONLY integer exponents and ordered-field arithmetic — no real powers anywhere. That is the payoff of the cleared-denominator formulation: the substantive inequality is entirely elementary.",
+    "mathContext": "$a_k = \\prod_{j<k} r_j \\ge r_k^k$ (each $r_j \\ge r_k$), then $a_k^{k+1} \\ge a_k^k r_k^k = a_{k+1}^k$ since $a_{k+1} = a_k r_k$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "cleared-denominator Maclaurin inequality",
+      "Finset.prod_le_prod",
+      "integer-power arithmetic",
+      "ordered field"
+    ],
+    "prerequisites": [
+      "Finset.prod_le_prod (monotonicity of products)",
+      "mul_le_mul_of_nonneg_left and pow_succ",
+      "the ratio monotonicity established above"
+    ]
   },
   {
     "id": "ann-rpow",
     "proofId": "newton-inductive-step-oq-02-oq-02",
     "range": { "startLine": 144, "endLine": 172 },
-    "type": "info",
+    "type": "theorem",
     "title": "Upgrading to the Radical Form aₖ^{1/k}",
-    "content": "`maclaurin_of_logConcave_rpow` converts the integer-power inequality a_{k+1}^k ≤ aₖ^{k+1} into the classical root form. Raising both sides to z = 1/(k(k+1)) ≥ 0 by `Real.rpow_le_rpow` is monotone; then `Real.rpow_natCast` reinterprets the natural-number powers as real powers and `Real.rpow_mul` collapses the nested exponents: (a_{k+1}^k)^z = a_{k+1}^{k·z} = a_{k+1}^{1/(k+1)} and (aₖ^{k+1})^z = aₖ^{1/k}. The two exponent identities k·z = 1/(k+1) and (k+1)·z = 1/k are discharged by `field_simp`. This is the only step that touches Mathlib's `Real.rpow`, and it is purely cosmetic — the mathematics was already settled by the cleared form."
+    "content": "`maclaurin_of_logConcave_rpow` converts the integer-power inequality a_{k+1}^k ≤ aₖ^{k+1} into the classical root form. Raising both sides to z = 1/(k(k+1)) ≥ 0 by `Real.rpow_le_rpow` is monotone; then `Real.rpow_natCast` reinterprets the natural-number powers as real powers and `Real.rpow_mul` collapses the nested exponents: (a_{k+1}^k)^z = a_{k+1}^{k·z} = a_{k+1}^{1/(k+1)} and (aₖ^{k+1})^z = aₖ^{1/k}. The two exponent identities k·z = 1/(k+1) and (k+1)·z = 1/k are discharged by `field_simp`. This is the only step that touches Mathlib's `Real.rpow`, and it is purely cosmetic — the mathematics was already settled by the cleared form.",
+    "mathContext": "Raise $a_{k+1}^k \\le a_k^{k+1}$ to $z = \\tfrac{1}{k(k+1)}$: $k z = \\tfrac{1}{k+1}$, $(k+1)z = \\tfrac1k$, giving $a_{k+1}^{1/(k+1)} \\le a_k^{1/k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow and radical form",
+      "monotonicity of x ↦ xᶻ",
+      "exponent arithmetic",
+      "radical Maclaurin inequality"
+    ],
+    "prerequisites": [
+      "Real.rpow_le_rpow (base monotonicity)",
+      "Real.rpow_natCast and Real.rpow_mul",
+      "field_simp for exponent identities"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment

`newton-inductive-step-oq-02-oq-02` had 5 annotations with `title`+`content` but **missing** `significance`, `mathContext`, `relatedConcepts`, and `prerequisites`, and used non-canonical types (`info`, `highlight`).

This PR adds all four metadata fields to every annotation and canonicalizes the types (`concept`/`insight`/`theorem`), so the entry renders full annotation metadata and scores correctly. The existing content and line ranges (already aligned to the file's five structural parts — scope, ratio/product representation, log-concavity⟺monotone ratios, the denominator-free heart, and the rpow radical upgrade) are preserved.

`annotations:build --strict` reports zero errors for this slug; all types/significance values are within the valid enums. Content-only change; no Lean source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)