### PR TITLE
Add gallery entry for ramanujan-sum-fallacy-oq-02 (Cesàro summation)

### DIFF
--- a/src/data/proofs/ramanujan-sum-fallacy-oq-02/meta.json
+++ b/src/data/proofs/ramanujan-sum-fallacy-oq-02/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "ramanujan-sum-fallacy-oq-02",
+  "title": "Cesàro Summation: Grandi's Series Sums to ½",
+  "slug": "ramanujan-sum-fallacy-oq-02",
+  "description": "Defines Cesàro summation in Lean and proves that Grandi's series 1 − 1 + 1 − 1 + … is Cesàro-summable to 1/2, even though it diverges in the ordinary sense — a strict extension of ordinary convergence.",
+  "meta": {
+    "author": "Lean Genius research pipeline",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "1890",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamanujanSumFallacyOQ02.lean",
+    "tags": [
+      "analysis",
+      "divergent-series",
+      "cesaro-summation",
+      "summability",
+      "educational"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "tendsto_one_div_atTop_nhds_zero_nat",
+        "description": "The sequence 1/n tends to 0",
+        "module": "Mathlib.Order.Filter.Archimedean"
+      },
+      {
+        "theorem": "squeeze_zero",
+        "description": "Squeeze theorem for sequences bounded between 0 and a null sequence",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "A self-contained definition of Cesàro summation (partialSum, cesaroMean, CesaroSum) directly answering the parent's open question OQ-02",
+      "An explicit closed form cesaroMean grandi n = 1/2 − (1 − (−1)ⁿ)/(4n) for n ≥ 1, proved by two nested inductions",
+      "A squeeze argument 0 ≤ (1 − (−1)ⁿ)/(4n) ≤ 1/n driving the Cesàro means to 1/2",
+      "The contrast corollary grandi_cesaroSummable: Cesàro summability strictly extends ordinary convergence on the example the parent shows is not ordinarily summable"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 127,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The parent entry, *Ramanujan Sum Fallacy*, shows that manipulations like $1 - 1 + 1 - 1 + \\cdots = \\tfrac12$ are fallacious under ordinary (tsum) summation — Grandi's series has no ordinary sum. Yet the value $\\tfrac12$ is not meaningless: it is the *Cesàro sum*, obtained by averaging partial sums. Ernesto Cesàro introduced this method in 1890 to assign consistent values to a large class of divergent series; Grandi's series (Guido Grandi, 1703) is its textbook example. G. H. Hardy's *Divergent Series* (1949) systematizes such summation methods. This entry answers the parent's open question OQ-02: *how would you define Cesàro summation in Lean and show Grandi's series really is Cesàro-summable to 1/2?*",
+    "problemStatement": "Define Cesàro summation and prove that Grandi's series $a_k = (-1)^k$ is Cesàro-summable to $\\tfrac12$. A series is **Cesàro-summable to $L$** when the averages of its partial sums,\n\n$$\\sigma_n = \\frac{1}{n}\\sum_{k<n} s_k, \\qquad s_k = \\sum_{j<k} a_j,$$\n\nconverge to $L$. The claim is $\\sigma_n \\to \\tfrac12$ for Grandi's series, even though $s_k = 0,1,0,1,\\dots$ does not converge.",
+    "text": "Grandi's series 1 − 1 + 1 − 1 + … is Cesàro-summable to 1/2 even though it diverges in the ordinary sense.",
+    "proofStrategy": "Everything reduces to an explicit closed form. First `partialSum_grandi`: $s_n = (1 - (-1)^n)/2$ (the pattern $0,1,0,1,\\dots$), by induction. Then `cesaro_partialsum_grandi`: $\\sum_{k<n} s_k = n/2 - (1-(-1)^n)/4$, again by induction. Dividing by $n$ gives `cesaroMean_grandi`: for $n \\geq 1$, $\\sigma_n = \\tfrac12 - (1-(-1)^n)/(4n)$. Finally `grandi_cesaroSum_half`: the error term satisfies $0 \\leq (1-(-1)^n)/(4n) \\leq 1/n$, so `squeeze_zero` sends it to $0$ and $\\sigma_n \\to \\tfrac12$. The corollary `grandi_cesaroSummable` records that this is a *strict* extension of ordinary convergence, since the parent proves Grandi's series is not ordinarily summable.",
+    "keyInsights": [
+      "**Averaging tames oscillation**: the partial sums $0,1,0,1,\\dots$ never converge, but their running averages do — Cesàro summation smooths the oscillation to its mean value $\\tfrac12$",
+      "**Explicit error term**: the whole limit is controlled by the closed form $\\sigma_n = \\tfrac12 - (1-(-1)^n)/(4n)$, whose deviation from $\\tfrac12$ is $O(1/n)$ and killed by a squeeze",
+      "**Strict extension, not contradiction**: assigning $\\tfrac12$ is legitimate under Cesàro summation precisely because it is a different (weaker) notion than ordinary convergence — the parent's fallacy is conflating the two",
+      "**Junk-value convention**: `cesaroMean` divides by $n$, returning $0$ at $n = 0$; the limit statement is unaffected since it only concerns the tail $n \\to \\infty$"
+    ],
+    "prerequisites": [
+      "Real analysis (sequences, limits, filters)",
+      "Series and summability"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Cesàro Summation, Defined",
+      "startLine": 40,
+      "endLine": 60,
+      "summary": "`partialSum a n = ∑_{k<n} a k`, `cesaroMean a n = (∑_{k<n} partialSum a k)/n` (with the junk value 0 at n = 0), and the predicate `CesaroSum a L := Tendsto (cesaroMean a) atTop (𝓝 L)`. `grandi n = (-1)^n` is the series under study.",
+      "mathContext": "The infrastructure answering OQ-02: Cesàro summability as convergence of the averaged partial sums, defined from scratch over ℝ."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Partial-Sum and Cesàro-Mean Closed Forms",
+      "startLine": 61,
+      "endLine": 100,
+      "summary": "`partialSum_grandi`: $s_n = (1-(-1)^n)/2$. `cesaro_partialsum_grandi`: $\\sum_{k<n} s_k = n/2 - (1-(-1)^n)/4$. `cesaroMean_grandi`: for $n \\geq 1$, $\\sigma_n = 1/2 - (1-(-1)^n)/(4n)$. Each is a `Finset.sum_range_succ` induction closed by `ring`/`field_simp`.",
+      "mathContext": "Turns the Cesàro mean into an explicit rational expression in $n$ and $(-1)^n$, isolating the $O(1/n)$ error from the target value $1/2$."
+    },
+    {
+      "id": "limit",
+      "title": "The Limit and the Strict-Extension Corollary",
+      "startLine": 101,
+      "endLine": 127,
+      "summary": "`grandi_cesaroSum_half`: the error $(1-(-1)^n)/(4n)$ is squeezed between $0$ and $1/n$, so `squeeze_zero` plus `tendsto_congr'` give $\\sigma_n \\to 1/2$. `grandi_cesaroSummable`: existence of a Cesàro sum, contrasting with the parent's non-ordinary-summability.",
+      "mathContext": "Completes the proof that Grandi's series is Cesàro-summable to $1/2$ and records that Cesàro summation strictly extends ordinary convergence here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
+    "namespace": "RamanujanFallacyOQ02",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "path": "Proofs/RamanujanSumFallacyOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "grandi_cesaroSum_half",
+      "type": "core",
+      "description": "Grandi's series is Cesàro-summable to 1/2",
+      "leanType": "CesaroSum grandi (1 / 2)"
+    },
+    {
+      "name": "cesaroMean_grandi",
+      "type": "lemma",
+      "description": "Closed form of the Cesàro mean for n ≥ 1",
+      "leanType": "1 <= n -> cesaroMean grandi n = 1 / 2 - (1 - (-1) ^ n) / (4 * n)"
+    },
+    {
+      "name": "partialSum_grandi",
+      "type": "lemma",
+      "description": "The partial sums of Grandi's series follow the 0,1,0,1,… pattern",
+      "leanType": "partialSum grandi n = (1 - (-1) ^ n) / 2"
+    },
+    {
+      "name": "grandi_cesaroSummable",
+      "type": "corollary",
+      "description": "Grandi's series is Cesàro-summable (strict extension of ordinary convergence, which the parent shows it lacks)",
+      "leanType": "exists L, CesaroSum grandi L"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent open question OQ-02 by defining Cesàro summation in Lean — partial sums, their running averages `cesaroMean`, and the predicate `CesaroSum` — and proving `grandi_cesaroSum_half : CesaroSum grandi (1/2)`. The argument is fully explicit: two inductions give the closed form $\\sigma_n = \\tfrac12 - (1-(-1)^n)/(4n)$ for $n \\geq 1$, and a squeeze $0 \\leq (1-(-1)^n)/(4n) \\leq 1/n$ drives the means to $\\tfrac12$. All results are machine-checked with 0 axioms and 0 sorries.",
+    "implications": "Where the parent entry warns that $1 - 1 + 1 - 1 + \\cdots = \\tfrac12$ is a fallacy under ordinary summation, this entry shows the value $\\tfrac12$ is nonetheless canonical under Cesàro summation, a strictly weaker notion (`grandi_cesaroSummable` holds while ordinary summability fails). This is the first rung of the ladder of summation methods — Cesàro, Abel, and beyond — that assign consistent values to divergent series, and it makes precise exactly which notion of 'sum' the classical manipulations tacitly invoke."
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "description": "Answers ramanujan-sum-fallacy OQ-02: defines Cesàro summation and proves Grandi's series Cesàro-sums to 1/2, complementing the parent's proof that it is not ordinarily summable.",
+      "targetId": "ramanujan-sum-fallacy"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cesàro, Ernesto",
+      "title": "Sur la multiplication des séries",
+      "year": "1890",
+      "venue": "Bulletin des Sciences Mathématiques 14, 114–120",
+      "note": "Introduced the averaging summation method that assigns Grandi's series the value 1/2"
+    },
+    {
+      "authors": "Hardy, Godfrey Harold",
+      "title": "Divergent Series",
+      "year": "1949",
+      "venue": "Oxford University Press, Ch. I",
+      "note": "Systematic treatment of Cesàro, Abel, and other summation methods for divergent series"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Fix

Adds the missing gallery entry for `ramanujan-sum-fallacy-oq-02` — a **missing-gallery-entry gap**.

## Evidence

**Before**: `proofs/Proofs/RamanujanSumFallacyOQ02.lean` (merged research artifact, VERIFIED, 0-axiom, 5 theorems / 3 defs / 127 lines) had **no** `src/data/proofs/` directory, so the result was invisible in the gallery.

**After**: `src/data/proofs/ramanujan-sum-fallacy-oq-02/meta.json` now presents the entry.

## What the proof establishes

Answers the parent's open question **OQ-02** — *how to define Cesàro summation in Lean and show Grandi's series sums to 1/2*:

- Defines `partialSum`, `cesaroMean`, and the `CesaroSum` predicate from scratch over ℝ
- `partialSum_grandi` / `cesaro_partialsum_grandi` / `cesaroMean_grandi` — the explicit closed form $\sigma_n = \tfrac12 - (1-(-1)^n)/(4n)$ for $n \ge 1$
- `grandi_cesaroSum_half` — Grandi's series $1-1+1-1+\cdots$ is **Cesàro-summable to 1/2**, via a squeeze $0 \le (1-(-1)^n)/(4n) \le 1/n$
- `grandi_cesaroSummable` — a strict extension of ordinary convergence, which the parent proves Grandi's series lacks

## Validation

- `lake env lean Proofs/RamanujanSumFallacyOQ02.lean` against pinned Mathlib **v4.26.0** → exit 0, no drift, 0 axioms / 0 sorries
- `gallery:check-size` → passes (no oversize warning)
- `annotations build` → no new errors for this slug
- meta schema modeled on the parent `ramanujan-sum-fallacy`; status upgraded to `verified` (parent is `axiomatized`, but this file is 0-axiom)

---
Automated fix by lean-mechanic agent.