### PR TITLE
Enrich Multivariate Bézout Identity in Bézout Rings: add annotation coverage

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-familygcd-def",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 83 },
+    "type": "definition",
+    "title": "familyGcd: the gcd as a principal-ideal generator",
+    "content": "Defines `familyGcd a` as the generator of `Ideal.span (Set.range a)`. The definition is well-posed precisely because the ring is Bézout: the index type is `Finite`, so `Submodule.fg_span (Set.finite_range a)` makes the span finitely generated, and `IsBezout.isPrincipal_of_FG` turns 'finitely generated' into 'principal'. The generator exists by that principality. `span_range_eq_span_familyGcd` records that the whole span equals `span {familyGcd a}`, and `familyGcd_mem_span` places the generator inside its own ideal — the two facts every later step uses. It is `noncomputable` because the generator is extracted non-constructively.",
+    "mathContext": "Over a Bézout ring, $\\operatorname{span}(\\{a_i\\})$ is finitely generated $\\Rightarrow$ principal; $d := \\text{familyGcd}\\,a$ is its generator, so $\\operatorname{span}(\\{a_i\\}) = (d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Bézout ring", "principal ideal", "finitely generated ideal", "IsBezout"],
+    "prerequisites": ["ideals and spans", "principal ideal domains", "commutative algebra"]
+  },
+  {
+    "id": "ann-bezout-coeffs",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 102 },
+    "type": "insight",
+    "title": "Extracting the Bézout coefficient vector",
+    "content": "The multivariate generalization of `u·a + v·b = gcd a b`: there is a coefficient function `u : ι → R` with `∑ i, u i * a i = familyGcd a`. The bridge from the abstract 'the generator lies in the span' to a concrete coefficient vector is `Submodule.mem_span_range_iff_exists_fun`, which unpacks span membership into an explicit finite linear combination; `smul_eq_mul` converts the module scalar action `•` into ring multiplication `*`. This is the heart of the affirmative answer — the identity is produced, not just asserted to exist.",
+    "mathContext": "$d \\in \\operatorname{span}(\\{a_i\\}) \\iff \\exists u,\\ \\sum_i u_i \\cdot a_i = d$; here $d = \\text{familyGcd}\\,a$.",
+    "significance": "key",
+    "relatedConcepts": ["Bézout identity", "span membership", "linear combination", "mem_span_range_iff_exists_fun"],
+    "prerequisites": ["module spans", "finite sums"]
+  },
+  {
+    "id": "ann-familygcd-dvd",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 108, "endLine": 115 },
+    "type": "technique",
+    "title": "The generator divides every member",
+    "content": "`familyGcd a ∣ a i` for each `i`: since `a i ∈ span (range a) = span {familyGcd a}`, membership of a single-generator ideal is exactly divisibility (`Ideal.mem_span_singleton`). This is the 'common divisor' half of the gcd property, and it follows purely from the span equality with no arithmetic.",
+    "mathContext": "$a_i \\in (\\text{familyGcd}\\,a) \\iff \\text{familyGcd}\\,a \\mid a_i.$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility", "principal ideal", "mem_span_singleton"],
+    "prerequisites": ["ideals and divisibility"]
+  },
+  {
+    "id": "ann-dvd-familygcd",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 117, "endLine": 125 },
+    "type": "insight",
+    "title": "Universal property: every common divisor divides the gcd",
+    "content": "The 'greatest' half of the gcd property, and the point where the linear combination pays off: a common divisor `c` of all `a i` divides `familyGcd a` because it divides each term `u i * a i` of the Bézout combination, hence their sum (`Finset.dvd_sum`). No integral-domain hypothesis is needed — divisibility and the universal property both fall out of the identity itself, which is exactly why the result lives at the level of a general `IsBezout` ring rather than a PID.",
+    "mathContext": "$c \\mid a_i\\ \\forall i \\;\\Rightarrow\\; c \\mid \\sum_i u_i a_i = \\text{familyGcd}\\,a.$",
+    "significance": "key",
+    "relatedConcepts": ["gcd universal property", "Finset.dvd_sum", "Bézout combination", "greatest common divisor"],
+    "prerequisites": ["divisibility", "finite sums"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 134, "endLine": 160 },
+    "type": "insight",
+    "title": "The assembled multivariate Bézout theorem",
+    "content": "`multivariate_bezout` packages the identity and both divisibility directions into one statement over an arbitrary Bézout ring: there exist `d` and `u` with `∑ u i * a i = d`, `d ∣ a i` for all `i`, and `d` divisible by every common divisor. `gcd_witness_unique` then shows any two such greatest common divisors are associated (each divides the other), i.e. the gcd is unique up to units — this one holds over any `CommRing`, needing no Bézout hypothesis since it is pure from the universal property.",
+    "mathContext": "$\\exists d\\, u,\\ (\\sum_i u_i a_i = d) \\wedge (\\forall i,\\ d \\mid a_i) \\wedge (\\forall c,\\ (\\forall i,\\ c \\mid a_i) \\Rightarrow c \\mid d)$; witnesses are associated.",
+    "significance": "key",
+    "relatedConcepts": ["Bézout identity", "greatest common divisor", "unique up to units", "associates"],
+    "prerequisites": ["divisibility", "units in a ring"]
+  },
+  {
+    "id": "ann-specialization",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 170, "endLine": 188 },
+    "type": "technique",
+    "title": "One-line specialization to F[X] and ℤ",
+    "content": "The open question asked specifically about polynomial rings. `multivariate_bezout_polynomial` (over `F[X]` for a field `F`) and `multivariate_bezout_int` (over `ℤ`) are proved by directly reusing `multivariate_bezout` — no separate argument. Both rings satisfy `IsBezout` for free: `F[X]` is Euclidean ⇒ PID ⇒ Bézout, and `ℤ` is a PID. This is the payoff of choosing the right hypothesis: the polynomial case the question named is a corollary, not new work.",
+    "mathContext": "$F[X]$ Euclidean $\\Rightarrow$ PID $\\Rightarrow$ Bézout; $\\mathbb{Z}$ a PID $\\Rightarrow$ Bézout. Both inherit the multivariate identity verbatim.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclidean domain", "principal ideal domain", "polynomial ring", "typeclass instance chain"],
+    "prerequisites": ["polynomial rings over fields", "PIDs"]
+  },
+  {
+    "id": "ann-computational",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 198, "endLine": 207 },
+    "type": "context",
+    "title": "Concrete three-element identities",
+    "content": "The abstract generator is `noncomputable`, so these worked examples exhibit explicit Bézout combinations verified by `norm_num` / `ring`: `1·6 + (-2)·10 + 1·15 = 1` and `1·4 + (-2)·6 + 1·9 = 1` over ℤ (both gcd 1), and `(-1)·X + 1·(X+1) = 1` over ℚ[X] (coprime polynomials with 1 as gcd). They make the multivariate identity tangible past the existence statement.",
+    "mathContext": "$\\gcd(6,10,15) = 1 = 1\\cdot 6 - 2\\cdot 10 + 1\\cdot 15$;\\ \\ $-X + (X+1) = 1$ in $\\mathbb{Q}[X]$.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "coprimality", "extended Euclidean algorithm"],
+    "prerequisites": ["gcd of integers"]
+  },
+  {
+    "id": "ann-boundary",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 222, "endLine": 258 },
+    "type": "insight",
+    "title": "The sharp boundary: F[x,y] is not Bézout",
+    "content": "The affirmative answer is exactly as wide as `IsBezout`, and no wider. In `F[x,y] = MvPolynomial (Fin 2) F` the ideal `(X, Y)` sits inside the kernel of the constant-coefficient homomorphism (`span_X_le_ker_constantCoeff`), because `constantCoeff (X i) = 0`. Since `constantCoeff 1 = 1 ≠ 0`, the constant `1` cannot lie in `(X, Y)` (`one_not_mem_span_X_Y`), so there are no cofactors with `f·X + g·Y = 1` (`no_bezout_identity_X_Y`). This is a one-line certificate that the extended Euclidean/Bézout construction genuinely fails past one variable — `X` and `Y` are coprime yet admit no Bézout identity.",
+    "mathContext": "Every element of $(X, Y)$ has zero constant term, but $\\text{constantCoeff}(1) = 1 \\ne 0$, so $1 \\notin (X, Y)$ and $\\nexists f, g:\\ fX + gY = 1$ in $F[x,y]$.",
+    "significance": "key",
+    "relatedConcepts": ["multivariate polynomial ring", "constant coefficient homomorphism", "non-Bézout ring", "coprimality without Bézout identity", "Nullstellensatz"],
+    "prerequisites": ["multivariate polynomials", "ring homomorphism kernels", "ideals"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-02-oq-01-oq-02`.

## Gap
Rich `meta.json` (detailed sections, insights) but **no `annotations.json`** — zero inline coverage of the 260-line Lean file.

## Changes
Added `annotations.json` with **8 annotations**, one per part of the file:
- `familyGcd` — the gcd as a principal-ideal generator (Part I)
- `exists_bezout_coeffs` — extracting the coefficient vector (Part II)
- `familyGcd_dvd` / `dvd_familyGcd` — both divisibility directions (Part III)
- `multivariate_bezout` + `gcd_witness_unique` — assembled theorem, uniqueness (Part IV)
- `multivariate_bezout_polynomial` / `_int` — F[X] and ℤ specializations (Part V)
- concrete three-element identities (Part VI)
- the sharp boundary: F[x,y] is not Bézout, 1 ∉ (X,Y) (Part VII)

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
`validateLineAnnotations` against the Lean source: **8 valid, 0 misaligned.**