### PR TITLE
Enrich Norm-Rigidity of the Complex Inner Product: deepen annotations

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08-oq-01/annotations.json
@@ -9,19 +9,40 @@
     "type": "concept",
     "title": "Module Header: why the complex case needs rotated diagonals",
     "content": "The parent cauchy-schwarz-oq-08 shows that over a *real* inner-product space the norm determines the inner product (polarization $\\langle x,y\\rangle=(\\|x+y\\|^2-\\|x-y\\|^2)/4$), so norm-preservation forces inner-product-preservation. Over $\\mathbb{C}$ this fails for the norm alone: the real diagonals $\\|x\\pm y\\|$ recover only $\\mathrm{Re}\\langle x,y\\rangle$, and complex conjugation on $\\mathbb{C}$ preserves the norm while conjugating $\\langle\\cdot,\\cdot\\rangle$. The imaginary part is pinned by the *rotated* diagonals $\\|x\\pm i\\,y\\|$, which the four-term complex polarization identity consumes. The file works over an arbitrary RCLike field $\\mathbb{K}$ (so $\\mathbb{R}$ and $\\mathbb{C}$ at once), with $i=$ `RCLike.I`.",
-    "mathContext": "Complex polarization: $\\langle x,y\\rangle=\\big(\\|x+y\\|^2-\\|x-y\\|^2+(\\|x-i y\\|^2-\\|x+i y\\|^2)\\,i\\big)/4$ over any RCLike field."
+    "mathContext": "Complex polarization: $\\langle x,y\\rangle=\\big(\\|x+y\\|^2-\\|x-y\\|^2+(\\|x-i y\\|^2-\\|x+i y\\|^2)\\,i\\big)/4$ over any RCLike field.",
+    "significance": "context",
+    "relatedConcepts": ["polarization identity", "inner product space", "RCLike field", "complex conjugation", "norm"],
+    "prerequisites": ["complex inner product spaces", "norms and metrics"]
   },
   {
     "id": "csoq0801-rigidity",
     "proofId": "cauchy-schwarz-oq-08-oq-01",
     "range": {
       "startLine": 60,
+      "endLine": 79
+    },
+    "type": "insight",
+    "title": "Norm-Rigidity of the Complex Inner Product",
+    "content": "`inner_map_eq` is the core result: an $\\mathbb{R}$-additive map $f$ preserving the norm ($\\|f x\\|=\\|x\\|$) and the rotated diagonal ($\\|f x + i\\,f y\\|=\\|x+i\\,y\\|$) satisfies $\\langle f x, f y\\rangle=\\langle x,y\\rangle$. A single rotated-diagonal hypothesis suffices: applying it at $-y$ and using additivity ($i\\cdot f(-y)=-(i\\cdot f y)$) yields the minus-diagonal $\\|f x - i\\,f y\\|=\\|x-i\\,y\\|$. The proof is then a rewrite chain — apply complex polarization (`inner_eq_sum_norm_sq_div_four`), turn $f x\\pm f y$ into $f(x\\pm y)$ via `← map_add`/`← map_sub`, collapse the four norms by the two hypotheses, and fold back. Notably *only additivity* is used — no $\\mathbb{K}$-linearity.",
+    "mathContext": "For $\\mathbb{R}$-additive $f$ with $\\|f x\\|=\\|x\\|$ and $\\|f x+i f y\\|=\\|x+i y\\|$: $\\langle f x,f y\\rangle=\\langle x,y\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": ["polarization identity", "additive map", "rotated diagonal", "inner product preservation"],
+    "prerequisites": ["additive group homomorphisms", "complex inner product spaces", "polarization identity"]
+  },
+  {
+    "id": "csoq0801-corollaries",
+    "proofId": "cauchy-schwarz-oq-08-oq-01",
+    "range": {
+      "startLine": 81,
       "endLine": 95
     },
-    "type": "theorem",
-    "title": "Norm-Rigidity of the Complex Inner Product",
-    "content": "`inner_map_eq` is the core result: an $\\mathbb{R}$-additive map $f$ preserving the norm ($\\|f x\\|=\\|x\\|$) and the rotated diagonal ($\\|f x + i\\,f y\\|=\\|x+i\\,y\\|$) satisfies $\\langle f x, f y\\rangle=\\langle x,y\\rangle$. A single rotated-diagonal hypothesis suffices: applying it at $-y$ and using additivity ($i\\cdot f(-y)=-(i\\cdot f y)$) yields the minus-diagonal $\\|f x - i\\,f y\\|=\\|x-i\\,y\\|$. The proof is then a rewrite chain — apply complex polarization, turn $f x\\pm f y$ into $f(x\\pm y)$ via `← map_add`/`← map_sub`, collapse the four norms by the two hypotheses, and fold back. `inner_map_eq_zero_iff` and `injective_of_norm_preserving` follow (the latter from the norm hypothesis alone).",
-    "mathContext": "For $\\mathbb{R}$-additive $f$ with $\\|f x\\|=\\|x\\|$ and $\\|f x+i f y\\|=\\|x+i y\\|$: $\\langle f x,f y\\rangle=\\langle x,y\\rangle$, hence $f x\\perp f y\\iff x\\perp y$ and $f$ is injective."
+    "type": "technique",
+    "title": "Orthogonality preservation and injectivity",
+    "content": "Two immediate corollaries. `inner_map_eq_zero_iff` rewrites through `inner_map_eq` to show such maps preserve orthogonality: $f x \\perp f y \\iff x \\perp y$. `injective_of_norm_preserving` needs *only* the norm hypothesis (the inner-product structure is `omit`ted): if $\\|f a\\| = \\|a\\|$ then $f a = 0$ forces $\\|a\\| = 0$, hence $a = 0$, so $f$ is injective. This separates the two consequences — orthogonality rigidity needs the full inner-product-preservation, injectivity does not.",
+    "mathContext": "$f x \\perp f y \\iff x \\perp y$; and $\\|f\\,\\cdot\\| = \\|\\cdot\\| \\Rightarrow f$ injective (via $\\|a\\|=0 \\Rightarrow a=0$).",
+    "significance": "supporting",
+    "relatedConcepts": ["orthogonality", "injectivity", "kernel of an additive map", "norm-preserving map"],
+    "prerequisites": ["orthogonality in inner product spaces", "injective homomorphisms"]
   },
   {
     "id": "csoq0801-specializations",
@@ -30,10 +51,13 @@
       "startLine": 97,
       "endLine": 118
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Real Collapse and Complex Specialization",
     "content": "Because the result is stated over RCLike $\\mathbb{K}$, it specializes both ways. `inner_map_eq_real`: when $\\mathbb{K}=\\mathbb{R}$, `RCLike.I` $=0$, so the rotated-diagonal hypothesis becomes $\\|f x\\|=\\|x\\|$ — automatic — and the theorem reduces to the parent's real rigidity result. `inner_map_eq_complex`: when $\\mathbb{K}=\\mathbb{C}$, the RCLike instance sets $I:=$ `Complex.I` definitionally, so the concrete complex statement (with `Complex.I`) is a zero-cost specialization of `inner_map_eq`. The single theorem thus subsumes the real parent and answers the complex open question simultaneously.",
-    "mathContext": "$\\mathbb{K}=\\mathbb{R}$: rotated hypothesis vacuous, real parent recovered. $\\mathbb{K}=\\mathbb{C}$: $\\mathrm{RCLike.}I=\\mathrm{Complex.}I$, concrete complex rigidity."
+    "mathContext": "$\\mathbb{K}=\\mathbb{R}$: rotated hypothesis vacuous, real parent recovered. $\\mathbb{K}=\\mathbb{C}$: $\\mathrm{RCLike.}I=\\mathrm{Complex.}I$, concrete complex rigidity.",
+    "significance": "key",
+    "relatedConcepts": ["RCLike field", "real vs complex inner product", "definitional specialization", "generalization"],
+    "prerequisites": ["real and complex inner product spaces", "RCLike typeclass"]
   },
   {
     "id": "csoq0801-isometry",
@@ -42,9 +66,12 @@
       "startLine": 120,
       "endLine": 131
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Linear-Isometry Corollary",
     "content": "`inner_linearIsometry_eq`: a bundled $\\mathbb{K}$-linear isometry $f:E\\to_{\\ell i}E'$ preserves the inner product. Both hypotheses of `inner_map_eq` are automatic here — the norm hypothesis is the isometry's `norm_map`, and the rotated-diagonal hypothesis holds because $\\mathbb{K}$-linearity commutes with $i\\cdot(\\cdot)$: $f x + i\\,f y = f(x+i\\,y)$, whose norm is $\\|x+i\\,y\\|$ by the isometry property. This is the elementary, polarization-only reason complex Hilbert-space isometries are unitary, obtained without Mathlib's bundled `inner_map_map` machinery.",
-    "mathContext": "A bundled $\\mathbb{K}$-linear isometry satisfies $\\langle f x,f y\\rangle=\\langle x,y\\rangle$; complex isometries are unitary."
+    "mathContext": "A bundled $\\mathbb{K}$-linear isometry satisfies $\\langle f x,f y\\rangle=\\langle x,y\\rangle$; complex isometries are unitary.",
+    "significance": "supporting",
+    "relatedConcepts": ["linear isometry", "unitary operator", "Hilbert space", "norm_map"],
+    "prerequisites": ["linear isometries", "Hilbert spaces"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-08-oq-01` (quality 73, 0 prior passes).

## Gap
The 4 existing annotations had only `mathContext` — missing `significance`, `relatedConcepts`, and `prerequisites` on every one.

## Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all annotations.
- Split the rigidity block (which spanned three theorems) so the orthogonality-preservation and injectivity corollaries get their own annotation: **4 → 5 annotations**, now meeting the ≥5 coverage target.
- Retyped the theorem-level annotations as `insight` where they carry the mathematical idea.

## Validation
`validateLineAnnotations` against the Lean source: **5 valid, 0 misaligned.**