### PR TITLE
research(area-of-circle-oq-05-incomplete-01-oq-01): standard normal moments (mean/variance/2nd moment/MGF) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05Incomplete01OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05Incomplete01OQ01.lean
@@ -1,0 +1,105 @@
+/-
+# Area of Circle OQ-05 (incomplete-01) → OQ-01 — Moments of the standard normal
+
+The parent `AreaOfCircleOQ05Incomplete01.lean` derives the normalization
+constants of the normal distribution from the Gaussian integral
+`∫ exp(-x²) dx = √π`, obtaining in particular the standard-normal density
+`(1/√(2π))·exp(-x²/2)` that integrates to `1`.  Its open question OQ-01 asks
+to formalize the **moments** of the standard normal:
+
+    E[X^{2k}] = (2k-1)!!   (double factorial),   E[X^{2k+1}] = 0.
+
+This file settles the first (and structurally most important) moments and
+records the moment-generating function, working with Mathlib's standard-normal
+measure `gaussianReal 0 1` and bridging back to the parent's *concrete*
+density integral.
+
+Main results (0 axioms, 0 sorries):
+
+* `stdNormal_mean`            — E[X]   = 0
+* `stdNormal_variance`        — Var[X] = 1
+* `stdNormal_second_moment`   — E[X²]  = 1
+* `stdNormal_second_moment_concrete`
+      — `∫ x², (1/√(2π))·exp(-x²/2) = 1`   (parent's density idiom)
+* `stdNormal_mgf`             — the MGF is `t ↦ exp(t²/2)`, whose Taylor
+      coefficients `[t^{2k}] = 1/(2^k k!)` encode `E[X^{2k}] = (2k-1)!!`.
+
+Every result is checked by the kernel with no axioms and no `native_decide`.
+The general even-moment formula `E[X^{2k}] = (2k-1)!!` for all `k` (by
+differentiating the MGF, or by an integration-by-parts recursion) is left as
+the remaining strand of OQ-01.
+-/
+
+import Mathlib.Probability.Distributions.Gaussian.Real
+import Mathlib.Probability.Moments.Variance
+import Mathlib.Tactic
+
+open MeasureTheory Real
+open scoped ProbabilityTheory
+
+namespace AreaOfCircleOQ05Incomplete01OQ01
+
+/-- The standard normal distribution `N(0,1)` as Mathlib's Gaussian measure
+    with mean `0` and variance `1`. -/
+noncomputable def stdNormal : Measure ℝ := ProbabilityTheory.gaussianReal 0 1
+
+instance : IsProbabilityMeasure stdNormal := by
+  unfold stdNormal; infer_instance
+
+/-- **Mean (first moment).**  `E[X] = 0` for the standard normal. -/
+theorem stdNormal_mean : ∫ x, x ∂stdNormal = 0 := by
+  unfold stdNormal
+  rw [ProbabilityTheory.integral_id_gaussianReal]
+
+/-- **Variance.**  `Var[X] = 1` for the standard normal. -/
+theorem stdNormal_variance : Var[id ; stdNormal] = 1 := by
+  unfold stdNormal
+  rw [ProbabilityTheory.variance_id_gaussianReal]
+  simp
+
+/-- **Second moment.**  `E[X²] = 1` for the standard normal.  Since the mean
+    is `0`, the variance `∫ (x - E[X])²` collapses to the raw second moment
+    `∫ x²`. -/
+theorem stdNormal_second_moment : ∫ x, x ^ 2 ∂stdNormal = 1 := by
+  have hvar : Var[id ; stdNormal] = 1 := stdNormal_variance
+  rw [ProbabilityTheory.variance_eq_integral measurable_id.aemeasurable] at hvar
+  simp only [id_eq] at hvar
+  rw [stdNormal_mean] at hvar
+  simpa using hvar
+
+/-- The Mathlib standard-normal density `gaussianPDFReal 0 1` is exactly the
+    parent file's density `(1/√(2π))·exp(-x²/2)`. -/
+theorem gaussianPDFReal_std (x : ℝ) :
+    ProbabilityTheory.gaussianPDFReal 0 1 x = (1 / Real.sqrt (2 * π)) * Real.exp (-x ^ 2 / 2) := by
+  rw [ProbabilityTheory.gaussianPDFReal]
+  push_cast
+  rw [one_div]
+  ring_nf
+
+/-- **Second moment, concrete form.**  In the parent's density idiom,
+    `∫ x²·(1/√(2π))·exp(-x²/2) dx = 1`. -/
+theorem stdNormal_second_moment_concrete :
+    ∫ x : ℝ, x ^ 2 * ((1 / Real.sqrt (2 * π)) * Real.exp (-x ^ 2 / 2)) = 1 := by
+  have h1 : (∫ x, ProbabilityTheory.gaussianPDFReal 0 1 x • (x ^ 2 : ℝ)) = 1 := by
+    rw [← ProbabilityTheory.integral_gaussianReal_eq_integral_smul (μ := 0) (v := 1) (by norm_num)]
+    exact stdNormal_second_moment
+  have hcongr :
+      (∫ x : ℝ, x ^ 2 * ((1 / Real.sqrt (2 * π)) * Real.exp (-x ^ 2 / 2)))
+        = ∫ x, ProbabilityTheory.gaussianPDFReal 0 1 x • (x ^ 2 : ℝ) := by
+    refine integral_congr_ae (Filter.Eventually.of_forall (fun x => ?_))
+    simp only [gaussianPDFReal_std, smul_eq_mul]
+    ring
+  rw [hcongr, h1]
+
+/-- **Moment-generating function.**  `M_X(t) = exp(t²/2)`.  Its Taylor
+    coefficients `[t^{2k}] M_X = 1/(2^k k!)` give the even moments
+    `E[X^{2k}] = (2k)!/(2^k k!) = (2k-1)!!` and the vanishing of the odd
+    moments. -/
+theorem stdNormal_mgf : ProbabilityTheory.mgf id stdNormal = fun t => Real.exp (t ^ 2 / 2) := by
+  unfold stdNormal
+  rw [ProbabilityTheory.mgf_id_gaussianReal]
+  funext t
+  push_cast
+  ring_nf
+
+end AreaOfCircleOQ05Incomplete01OQ01

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "area-of-circle-oq-05-incomplete-01-oq-01",
+  "title": "Moments of the Standard Normal (Mean, Variance, and the MGF)",
+  "slug": "area-of-circle-oq-05-incomplete-01-oq-01",
+  "description": "The first moments of the standard normal distribution N(0,1): mean 0, variance 1, and second moment E[X²] = 1 — both in Mathlib's gaussianReal framework and in the parent's concrete density idiom ∫ x²·(1/√(2π))·exp(-x²/2) = 1 — together with the moment-generating function M_X(t) = exp(t²/2) that generates the full even-moment sequence (2k-1)!!. Verified, 0 axioms.",
+  "meta": {
+    "author": "Gauss (normal distribution); classical moment theory — formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Normal_distribution#Moments",
+    "date": "Classical result; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "gaussian-integral",
+      "normal-distribution",
+      "moments",
+      "variance",
+      "moment-generating-function",
+      "probability"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05Incomplete01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "ProbabilityTheory.gaussianReal",
+      "ProbabilityTheory.integral_id_gaussianReal",
+      "ProbabilityTheory.variance_id_gaussianReal",
+      "ProbabilityTheory.variance_eq_integral",
+      "ProbabilityTheory.mgf_id_gaussianReal",
+      "ProbabilityTheory.integral_gaussianReal_eq_integral_smul",
+      "ProbabilityTheory.gaussianPDFReal"
+    ],
+    "originalContributions": [
+      "stdNormal: packaging of N(0,1) as gaussianReal 0 1 with its IsProbabilityMeasure instance",
+      "stdNormal_second_moment: E[X²] = 1, derived from variance_eq_integral together with the vanishing mean (the variance ∫ (x-E[X])² collapses to the raw second moment ∫ x²)",
+      "gaussianPDFReal_std: identifies Mathlib's density gaussianPDFReal 0 1 with the parent file's explicit density (1/√(2π))·exp(-x²/2)",
+      "stdNormal_second_moment_concrete: transports E[X²] = 1 to the parent's concrete Lebesgue-integral idiom via the withDensity bridge integral_gaussianReal_eq_integral_smul",
+      "stdNormal_mgf: the standard-normal MGF simplifies to t ↦ exp(t²/2), the generating function whose coefficients [t^{2k}] = 1/(2^k k!) encode E[X^{2k}] = (2k-1)!!"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 105,
+    "assumptions": "None. All 6 theorems verified with 0 sorries and 0 axioms (standard Lean axioms propext / Classical.choice / Quot.sound only, confirmed by #print axioms). Builds on Mathlib's ProbabilityTheory.gaussianReal moment API.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Once the Gaussian integral ∫ exp(-x²) dx = √π (the area-of-circle strand) is available, the normal distribution N(μ,σ²) is the rescaled density (1/(σ√(2π)))·exp(-(x-μ)²/(2σ²)). Its moments — mean μ, variance σ², and the double-factorial even moments E[(X-μ)^{2k}] = σ^{2k}(2k-1)!! — are the classical descriptors of the bell curve and the analytic backbone of the central limit theorem.",
+    "problemStatement": "The parent entry (area-of-circle-oq-05-incomplete-01) derives the normalization constants of the normal distribution from the Gaussian integral and poses as open question OQ-01 the formalization of its moments: E[X^{2k}] = (2k-1)!! and E[X^{2k+1}] = 0 for the standard normal. This entry settles the first moments — mean 0, variance 1, second moment E[X²] = 1 — and records the moment-generating function exp(t²/2) that encodes the whole even-moment sequence.",
+    "text": "Working with Mathlib's standard-normal measure gaussianReal 0 1, the mean and variance come from the library (integral_id_gaussianReal, variance_id_gaussianReal). The raw second moment follows because a vanishing mean collapses the variance integral ∫ (x - E[X])² to ∫ x². The result is then transported to the parent's concrete idiom ∫ x²·(1/√(2π))·exp(-x²/2) = 1 by identifying Mathlib's density gaussianPDFReal 0 1 with the parent's density and applying the withDensity change-of-measure bridge. Finally the MGF simplifies to exp(t²/2).",
+    "proofStrategy": "Four ingredients: (1) integral_id_gaussianReal gives E[X] = μ = 0; (2) variance_id_gaussianReal gives Var[X] = v = 1; (3) variance_eq_integral rewrites Var as ∫ (x - E[X])², and substituting E[X] = 0 yields ∫ x² = 1; (4) integral_gaussianReal_eq_integral_smul rewrites any gaussianReal integral as a density-weighted Lebesgue integral, and gaussianPDFReal_std matches that density to the parent's, giving the concrete form. The MGF is mgf_id_gaussianReal specialized to μ=0, v=1.",
+    "keyInsights": [
+      "For a mean-zero distribution the variance IS the second moment, so E[X²] = Var[X] = 1 needs no separate integral computation.",
+      "Mathlib's abstract measure gaussianReal 0 1 and the parent's concrete density (1/√(2π))·exp(-x²/2) are linked by a single withDensity bridge, letting library moment results be stated in elementary ∫ f(x) dx form.",
+      "The MGF exp(t²/2) is the compact encoding of every moment at once: its power series ∑ t^{2k}/(2^k k!) reads off E[X^{2k}] = (2k)!/(2^k k!) = (2k-1)!! and the vanishing of the odd moments."
+    ],
+    "prerequisites": [
+      "The Gaussian integral ∫ exp(-x²) dx = √π and the normal density normalization (parent entries oq-05 and oq-05-incomplete-01)",
+      "Basic probability: expectation, variance, and the moment-generating function",
+      "Mathlib's ProbabilityTheory.gaussianReal API"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The standard normal as gaussianReal 0 1",
+      "description": "`stdNormal := gaussianReal 0 1`, with its IsProbabilityMeasure instance inherited from Mathlib."
+    },
+    {
+      "title": "Mean, variance, and second moment",
+      "description": "`stdNormal_mean` (= 0) and `stdNormal_variance` (= 1) are library specializations. `stdNormal_second_moment` derives E[X²] = 1 from `variance_eq_integral` and the vanishing mean."
+    },
+    {
+      "title": "Concrete density form and the MGF",
+      "description": "`gaussianPDFReal_std` matches Mathlib's density to (1/√(2π))·exp(-x²/2); `stdNormal_second_moment_concrete` transports E[X²] = 1 to that idiom via `integral_gaussianReal_eq_integral_smul`. `stdNormal_mgf` records M_X(t) = exp(t²/2)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-05-incomplete-01",
+      "relationship": "extends",
+      "description": "Answers the first strand of open question OQ-01 (moments of the standard normal) posed by the parent normalization-family formalization."
+    },
+    {
+      "targetId": "area-of-circle-oq-05",
+      "relationship": "ancestor",
+      "description": "The Gaussian integral ∫ exp(-x²) dx = √π from which the normal density and its moments are built."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the first moments of the standard normal: mean 0, variance 1, second moment E[X²] = 1 (both abstractly and in the parent's concrete density idiom), plus the moment-generating function exp(t²/2).",
+    "implications": "This closes the mean/variance/MGF part of the parent's OQ-01. The MGF exp(t²/2) is the single object from which the full even-moment sequence E[X^{2k}] = (2k-1)!! and the vanishing odd moments follow, so it sets up the general moment computation as a Taylor-coefficient extraction.",
+    "openQuestions": [
+      "**General even moments.** Prove E[X^{2k}] = (2k-1)!! for all k, either by differentiating the MGF exp(t²/2) 2k times at 0 (extracting the Taylor coefficient 1/(2^k k!)) or by the integration-by-parts recursion E[X^{2k+2}] = (2k+1)·E[X^{2k}].",
+      "**Vanishing odd moments.** Prove E[X^{2k+1}] = 0 for all k by the symmetry of the density (odd integrand against an even weight), generalizing the mean E[X] = 0.",
+      "**Central moments of N(μ,σ²).** Extend from the standard normal to general mean and variance: E[(X-μ)^{2k}] = σ^{2k}(2k-1)!!, using the affine-transformation laws gaussianReal_map_const_add and gaussianReal_map_const_mul."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.Distributions.Gaussian.Real",
+      "Mathlib.Probability.Moments.Variance",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Real",
+      "ProbabilityTheory"
+    ],
+    "namespace": "AreaOfCircleOQ05Incomplete01OQ01",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ05Incomplete01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Theoria motus corporum coelestium",
+      "year": "1809",
+      "venue": "—",
+      "note": "Origin of the Gaussian (normal) distribution whose moments this entry formalizes."
+    },
+    {
+      "authors": "Feller, William",
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. II",
+      "year": "1971",
+      "venue": "Wiley",
+      "note": "Standard reference for the normal moments E[X^{2k}] = (2k-1)!! and the moment-generating function exp(t²/2)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "stdNormal_second_moment",
+      "type": "core",
+      "statement": "$\\int x^2 \\, d\\mathcal{N}(0,1) = 1$",
+      "significance": "**The raw second moment E[X²] = 1.** Because the mean is 0, the variance integral $\\int (x-\\mathbb{E}[X])^2$ collapses to $\\int x^2$, so the second moment equals the variance. This is the first non-trivial (even) moment of the standard normal."
+    },
+    {
+      "name": "stdNormal_second_moment_concrete",
+      "type": "core",
+      "statement": "$\\int x^2 \\cdot \\tfrac{1}{\\sqrt{2\\pi}} e^{-x^2/2} \\, dx = 1$",
+      "significance": "The second moment in the parent file's concrete density idiom, obtained from the abstract result via the withDensity change-of-measure bridge and the identification of Mathlib's density with $(1/\\sqrt{2\\pi})e^{-x^2/2}$."
+    },
+    {
+      "name": "stdNormal_mean",
+      "type": "supporting",
+      "statement": "$\\int x \\, d\\mathcal{N}(0,1) = 0$",
+      "significance": "The mean (first moment) vanishes — both the base odd moment and the fact that makes the variance equal the raw second moment."
+    },
+    {
+      "name": "stdNormal_variance",
+      "type": "supporting",
+      "statement": "$\\mathrm{Var}[X] = 1$ for $X \\sim \\mathcal{N}(0,1)$",
+      "significance": "The variance equals its parameter, specializing Mathlib's variance_id_gaussianReal."
+    },
+    {
+      "name": "stdNormal_mgf",
+      "type": "core",
+      "statement": "$M_X(t) = \\exp(t^2/2)$ for $X \\sim \\mathcal{N}(0,1)$",
+      "significance": "**The moment-generating function.** Its power series $\\sum_k t^{2k}/(2^k k!)$ encodes every moment: $\\mathbb{E}[X^{2k}] = (2k)!/(2^k k!) = (2k-1)!!$ and $\\mathbb{E}[X^{2k+1}] = 0$. This is the object that reduces the general moment formula to Taylor-coefficient extraction."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry `area-of-circle-oq-05-incomplete-01-oq-01` answering the **first strand** of open question OQ-01 (moments of the standard normal) posed by the parent `area-of-circle-oq-05-incomplete-01` (the normal-distribution normalization family built from the Gaussian integral).

Formalizes the first moments of $X \sim \mathcal{N}(0,1)$:

- `stdNormal_mean`: $\mathbb{E}[X] = 0$
- `stdNormal_variance`: $\mathrm{Var}[X] = 1$
- `stdNormal_second_moment`: $\mathbb{E}[X^2] = 1$ — since the mean is 0, the variance integral $\int (x-\mathbb{E}[X])^2$ collapses to the raw $\int x^2$
- `stdNormal_second_moment_concrete`: $\int x^2 \cdot \tfrac{1}{\sqrt{2\pi}} e^{-x^2/2}\,dx = 1$ — the same result in the **parent's concrete density idiom**, via the `withDensity` bridge and identifying Mathlib's `gaussianPDFReal 0 1` with the parent's density
- `stdNormal_mgf`: $M_X(t) = \exp(t^2/2)$ — the generating function whose coefficients $[t^{2k}] = 1/(2^k k!)$ encode $\mathbb{E}[X^{2k}] = (2k-1)!!$

## Verification

Built with `lake env lean` against Mathlib v4.26.0. `#print axioms` on all 6 theorems shows only `propext`, `Classical.choice`, `Quot.sound` → 0 axioms, 0 sorries. Badge `mathlib` (builds on Mathlib's `gaussianReal` moment API), matching the parent entry's convention.

## Scope / remaining

The general even-moment formula $\mathbb{E}[X^{2k}] = (2k-1)!!$ (by differentiating the MGF or an IBP recursion) and the vanishing odd moments $\mathbb{E}[X^{2k+1}] = 0$ are documented as open (the MGF here reduces the general computation to Taylor-coefficient extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)