### PR TITLE
research(desargues-theorem-oq-03): projective invariance of the Desargues configuration under GL₃ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DesarguesTheoremOQ03.lean
+++ b/proofs/Proofs/DesarguesTheoremOQ03.lean
@@ -1,0 +1,150 @@
+import Mathlib
+
+/-!
+# Desargues's Theorem — OQ-03: Projective Invariance and the Fundamental Theorem
+
+Parent: `Proofs/DesarguesTheorem.lean` (Desargues in homogeneous ℝ³ coordinates).
+
+## Context
+
+The parent entry formalizes Desargues's theorem in homogeneous coordinates: projective
+points are nonzero vectors in ℝ³, three points are **collinear** iff the `3×3` matrix of
+their coordinates is singular (`det = 0`), and three lines are **concurrent** iff their
+coefficient vectors are singular (same `det = 0` condition).
+
+The **Fundamental Theorem of Projective Geometry** says that the incidence-preserving
+transformations of a projective space of dimension `≥ 2` are exactly the projective
+(semilinear) maps. Its full statement is far beyond current Mathlib, but its concrete
+algebraic engine — *invertible linear maps preserve the incidence relations* — is
+elementary and is what this file supplies, axiom-free:
+
+  `det [M·p, M·q, M·r] = det M · det [p, q, r]`,
+
+so a linear map `M` preserves collinearity (and concurrence, the same determinant
+condition), and when `M ∈ GL₃(ℝ)` (i.e. `det M ≠ 0`) it preserves *and reflects* them —
+it is a genuine **collineation**. Consequently the entire Desargues configuration is
+invariant under the projective linear group: this is why Desargues's theorem is a
+statement of *projective* geometry, independent of any choice of coordinates.
+
+## Results (axiom-free)
+
+* `det_rowMatrix_mulVec` — `det [M·p, M·q, M·r] = det M · det [p, q, r]`.
+* `Collinear` / `Concurrent` — the determinant incidence predicates.
+* `collinear_map`, `concurrent_map` — any linear `M` preserves collinearity/concurrence.
+* `collinear_map_iff`, `concurrent_map_iff` — an invertible `M` (`det M ≠ 0`) *reflects*
+  them: it is a collineation.
+* `collinear_self`, `collinear_comm` — basic incidence lemmas.
+* `desargues_config_invariant` — the Desargues data (three concurrent joining lines and
+  three collinear intersection points) transports along any invertible `M`.
+
+## Status
+Upper-level abstract FTPG (collineations ⇔ semilinear maps) needs projective-space
+machinery Mathlib lacks and stays open; the linear-invariance core is fully proved here,
+`0` axioms, `0` sorries.
+-/
+
+open Matrix
+
+namespace DesarguesTheoremOQ03
+
+/-- A projective point / line, as a homogeneous coordinate vector in `ℝ³`. -/
+abbrev Vec := Fin 3 → ℝ
+
+/-- The `3×3` matrix whose rows are `p`, `q`, `r`. -/
+def rowMatrix (p q r : Vec) : Matrix (Fin 3) (Fin 3) ℝ := Matrix.of ![p, q, r]
+
+/-- Three points are **collinear** iff their coordinate matrix is singular. -/
+def Collinear (p q r : Vec) : Prop := (rowMatrix p q r).det = 0
+
+/-- Three lines are **concurrent** iff their coefficient matrix is singular
+    (the same determinant condition, by projective duality). -/
+def Concurrent (l m n : Vec) : Prop := (rowMatrix l m n).det = 0
+
+-- ============================================================================
+-- The determinant transformation law (the algebraic core of FTPG)
+-- ============================================================================
+
+/-- **The determinant transformation law.** Applying a linear map `M` to each of the
+three rows scales the determinant by `det M`:
+`det [M·p, M·q, M·r] = det M · det [p, q, r]`.
+
+Proof: the matrix with rows `M·p, M·q, M·r` is `(rowMatrix p q r) · Mᵀ`, and
+`det (A · Mᵀ) = det A · det Mᵀ = det A · det M`. -/
+theorem det_rowMatrix_mulVec (M : Matrix (Fin 3) (Fin 3) ℝ) (p q r : Vec) :
+    (rowMatrix (M.mulVec p) (M.mulVec q) (M.mulVec r)).det = M.det * (rowMatrix p q r).det := by
+  have hmat : rowMatrix (M.mulVec p) (M.mulVec q) (M.mulVec r) = rowMatrix p q r * Mᵀ := by
+    ext i j
+    fin_cases i <;>
+      simp [rowMatrix, Matrix.mul_apply, Matrix.mulVec, dotProduct, Matrix.transpose_apply,
+        mul_comm]
+  rw [hmat, Matrix.det_mul, Matrix.det_transpose, mul_comm]
+
+-- ============================================================================
+-- Linear maps preserve incidence; invertible maps reflect it (collineations)
+-- ============================================================================
+
+/-- **Any linear map preserves collinearity.** -/
+theorem collinear_map (M : Matrix (Fin 3) (Fin 3) ℝ) {p q r : Vec} (h : Collinear p q r) :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) := by
+  unfold Collinear at *
+  rw [det_rowMatrix_mulVec, h, mul_zero]
+
+/-- **Any linear map preserves concurrence.** -/
+theorem concurrent_map (M : Matrix (Fin 3) (Fin 3) ℝ) {l m n : Vec} (h : Concurrent l m n) :
+    Concurrent (M.mulVec l) (M.mulVec m) (M.mulVec n) := by
+  unfold Concurrent at *
+  rw [det_rowMatrix_mulVec, h, mul_zero]
+
+/-- **An invertible map reflects collinearity** (`det M ≠ 0`): the image is collinear iff
+the source is. So `M` is a genuine collineation. -/
+theorem collinear_map_iff {M : Matrix (Fin 3) (Fin 3) ℝ} (hM : M.det ≠ 0) (p q r : Vec) :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) ↔ Collinear p q r := by
+  unfold Collinear
+  rw [det_rowMatrix_mulVec]
+  constructor
+  · intro h
+    rcases mul_eq_zero.mp h with h' | h'
+    · exact absurd h' hM
+    · exact h'
+  · intro h; rw [h, mul_zero]
+
+/-- **An invertible map reflects concurrence** (`det M ≠ 0`). -/
+theorem concurrent_map_iff {M : Matrix (Fin 3) (Fin 3) ℝ} (hM : M.det ≠ 0) (l m n : Vec) :
+    Concurrent (M.mulVec l) (M.mulVec m) (M.mulVec n) ↔ Concurrent l m n :=
+  collinear_map_iff hM l m n
+
+-- ============================================================================
+-- Basic incidence lemmas
+-- ============================================================================
+
+/-- A repeated point is always collinear with anything (a degenerate row). -/
+theorem collinear_self (p q : Vec) : Collinear p p q := by
+  simp only [Collinear, rowMatrix, Matrix.det_fin_three, Matrix.of_apply,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two,
+    Matrix.tail_cons]
+  ring
+
+/-- Collinearity is symmetric in its first two arguments (swapping two rows negates the
+determinant, and `0` is fixed). -/
+theorem collinear_comm {p q r : Vec} (h : Collinear p q r) : Collinear q p r := by
+  simp only [Collinear, rowMatrix, Matrix.det_fin_three, Matrix.of_apply,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two,
+    Matrix.tail_cons] at h ⊢
+  linear_combination -h
+
+-- ============================================================================
+-- The Desargues configuration is projectively invariant
+-- ============================================================================
+
+/-- **Projective invariance of the Desargues configuration.** For an invertible `M`
+(`det M ≠ 0`), the two incidence facts that make up Desargues's theorem — the three
+joining lines being concurrent, and the three intersection points being collinear — both
+transport along `M` in each direction. Hence Desargues's theorem, phrased in these
+coordinates, is a coordinate-free statement invariant under the projective linear group. -/
+theorem desargues_config_invariant {M : Matrix (Fin 3) (Fin 3) ℝ} (hM : M.det ≠ 0)
+    (lAA' lBB' lCC' P Q R : Vec) :
+    (Concurrent (M.mulVec lAA') (M.mulVec lBB') (M.mulVec lCC') ↔ Concurrent lAA' lBB' lCC')
+      ∧ (Collinear (M.mulVec P) (M.mulVec Q) (M.mulVec R) ↔ Collinear P Q R) :=
+  ⟨concurrent_map_iff hM lAA' lBB' lCC', collinear_map_iff hM P Q R⟩
+
+end DesarguesTheoremOQ03

--- a/src/data/proofs/desargues-theorem-oq-03/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-03/annotations.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "ann-des-oq03-header",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "concept",
+    "title": "Desargues and the Fundamental Theorem of Projective Geometry",
+    "content": "The Fundamental Theorem of Projective Geometry (FTPG) says the incidence-preserving maps of a projective space of dimension ≥ 2 are exactly the projective (semilinear) maps. Its full statement is beyond current Mathlib, but its algebraic engine is elementary: in the parent's homogeneous ℝ³ model, incidence is a determinant condition, and the identity det[M·p,M·q,M·r] = det(M)·det[p,q,r] makes linear maps preserve incidence and invertible maps genuine collineations. This is why Desargues's theorem is a coordinate-free, projective statement.",
+    "mathContext": "FTPG: collineations of ℙⁿ (n ≥ 2) ⟷ semilinear maps. Here we prove the linear-map core.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fundamental theorem of projective geometry",
+      "collineation",
+      "projective linear group",
+      "incidence"
+    ],
+    "prerequisites": [
+      "homogeneous coordinates",
+      "determinant incidence conditions"
+    ]
+  },
+  {
+    "id": "ann-des-oq03-defs",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 49,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "Incidence as a Determinant Condition",
+    "content": "Vec = Fin 3 → ℝ are homogeneous coordinates. rowMatrix p q r stacks three vectors as the rows of a 3×3 matrix, and both Collinear (points) and Concurrent (lines) are the single condition det(rowMatrix …) = 0. That the two predicates are literally identical is projective duality made concrete.",
+    "mathContext": "Collinear p q r := det(rowMatrix p q r) = 0; Concurrent l m n is the same determinant condition on line coefficients.",
+    "significance": "central",
+    "relatedConcepts": [
+      "homogeneous coordinates",
+      "projective duality",
+      "determinant",
+      "incidence predicate"
+    ],
+    "prerequisites": [
+      "Matrix.of",
+      "Matrix.det"
+    ]
+  },
+  {
+    "id": "ann-des-oq03-detlaw",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 63,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "The Determinant Transformation Law (the FTPG engine)",
+    "content": "det_rowMatrix_mulVec proves det[M·p, M·q, M·r] = det(M)·det[p,q,r]. The key move: the matrix whose rows are M·p, M·q, M·r equals (rowMatrix p q r)·Mᵀ — each output row is M applied to an input row, which in matrix form is right-multiplication by Mᵀ. Then det_mul and det_transpose give det = det(rowMatrix p q r)·det M. This single identity carries all the projective invariance below.",
+    "mathContext": "[M·p; M·q; M·r] = (rowMatrix p q r)·Mᵀ, so det = det(rowMatrix p q r)·det M.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Matrix.det_mul",
+      "Matrix.det_transpose",
+      "multilinearity",
+      "row transformation"
+    ],
+    "prerequisites": [
+      "Matrix.det_mul",
+      "Matrix.det_transpose",
+      "Matrix.mulVec"
+    ]
+  },
+  {
+    "id": "ann-des-oq03-invariance",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Linear Maps Preserve Incidence; Invertible Maps Are Collineations",
+    "content": "collinear_map and concurrent_map: ANY linear map M preserves incidence, since det scales by det M and det M · 0 = 0 — even singular M collapse things onto (still-incident) lower-dimensional sets. collinear_map_iff and concurrent_map_iff: an INVERTIBLE M (det M ≠ 0) also reflects incidence, via mul_eq_zero — the image is incident iff the source is. Reflection is exactly what makes M a collineation, and it needs precisely the GL₃ hypothesis det M ≠ 0.",
+    "mathContext": "Preserve: det M·0 = 0 (all M). Reflect: det M·X = 0 ∧ det M ≠ 0 ⟹ X = 0 (invertible M).",
+    "significance": "central",
+    "relatedConcepts": [
+      "collineation",
+      "GL₃",
+      "mul_eq_zero",
+      "preserve vs reflect"
+    ],
+    "prerequisites": [
+      "det_rowMatrix_mulVec",
+      "mul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-des-oq03-incidence",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 116,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "Basic Incidence Lemmas",
+    "content": "collinear_self: a repeated point is collinear with anything (two equal rows make the determinant vanish). collinear_comm: collinearity is symmetric in its first two arguments (swapping two rows negates the determinant, and 0 is fixed). Both are discharged by expanding the explicit 3×3 determinant (Matrix.det_fin_three) and closing with ring / linear_combination.",
+    "mathContext": "Collinear p p q always; Collinear p q r ⟹ Collinear q p r.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "degenerate configuration",
+      "Matrix.det_fin_three",
+      "antisymmetry of det"
+    ],
+    "prerequisites": [
+      "Matrix.det_fin_three"
+    ]
+  },
+  {
+    "id": "ann-des-oq03-config",
+    "proofId": "desargues-theorem-oq-03",
+    "range": {
+      "startLine": 135,
+      "endLine": 150
+    },
+    "type": "theorem",
+    "title": "The Desargues Configuration Is Projectively Invariant",
+    "content": "desargues_config_invariant: for an invertible M, both incidence facts that constitute Desargues's theorem — the three joining lines being concurrent, and the three intersection points being collinear — transport in each direction along M. So the entire configuration is invariant under the projective linear group. This is the precise sense in which Desargues's theorem belongs to projective (not affine or metric) geometry, and the reachable, axiom-free core of the FTPG.",
+    "mathContext": "det M ≠ 0 ⟹ [Concurrent(M·lines) ↔ Concurrent(lines)] ∧ [Collinear(M·pts) ↔ Collinear(pts)].",
+    "significance": "central",
+    "relatedConcepts": [
+      "projective invariance",
+      "Desargues configuration",
+      "projective linear group",
+      "coordinate-free geometry"
+    ],
+    "prerequisites": [
+      "collinear_map_iff",
+      "concurrent_map_iff"
+    ]
+  }
+]

--- a/src/data/proofs/desargues-theorem-oq-03/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "desargues-theorem-oq-03",
+  "title": "Projective Invariance of the Desargues Configuration under GL₃",
+  "slug": "desargues-theorem-oq-03",
+  "description": "The Fundamental Theorem of Projective Geometry says the incidence-preserving maps of a projective space (dim ≥ 2) are exactly the projective (semilinear) maps. Its full statement is beyond current Mathlib, but its algebraic engine is elementary and is proved here axiom-free: in the parent's homogeneous ℝ³ model, det[M·p, M·q, M·r] = det(M)·det[p,q,r], so a linear map M preserves collinearity and concurrence, and an invertible M (det M ≠ 0) preserves AND reflects them — a genuine collineation. Consequently the entire Desargues configuration (three concurrent joining lines, three collinear intersection points) is invariant under the projective linear group, explaining why Desargues's theorem is coordinate-free. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_projective_geometry",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/DesarguesTheoremOQ03.lean",
+    "tags": [
+      "projective-geometry",
+      "desargues",
+      "fundamental-theorem-projective-geometry",
+      "collineation",
+      "linear-algebra",
+      "determinant",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_mul",
+        "description": "det(A·B) = det A · det B — the multiplicativity that turns row-transformation into a det-scaling",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_transpose",
+        "description": "det Aᵀ = det A — used since the row-image matrix equals (rowMatrix p q r) · Mᵀ",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "explicit 3×3 determinant expansion — closes the incidence lemmas collinear_self / collinear_comm by ring",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "mul_eq_zero",
+        "description": "a·b = 0 ↔ a = 0 ∨ b = 0 — reflects incidence back through det M ≠ 0",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "det_rowMatrix_mulVec: the determinant transformation law det[M·p, M·q, M·r] = det(M)·det[p,q,r], proved by rewriting the row-image matrix as (rowMatrix p q r)·Mᵀ and applying det_mul / det_transpose.",
+      "Collinear / Concurrent: the determinant incidence predicates (three coordinate vectors are dependent) in the parent's homogeneous ℝ³ model.",
+      "collinear_map, concurrent_map: any linear map preserves collinearity and concurrence (det scales by det M, and det M · 0 = 0).",
+      "collinear_map_iff, concurrent_map_iff: an invertible map (det M ≠ 0) also reflects them — it is a collineation, preserving incidence in both directions.",
+      "collinear_self, collinear_comm: basic incidence lemmas (a repeated point is collinear with anything; collinearity is symmetric in its first two arguments), via the 3×3 determinant.",
+      "desargues_config_invariant: the two incidence facts of Desargues's theorem — three concurrent joining lines, three collinear intersection points — both transport (in each direction) along any invertible M, so the configuration is projectively invariant."
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via a clean `lake env lean` build and #print axioms on the main theorems. No native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Desargues's theorem holds in a projective plane exactly when the plane is coordinatized by a division ring — the 'Desarguesian' planes. The Fundamental Theorem of Projective Geometry (von Staudt; Veblen–Young) makes the converse structural statement precise: for projective spaces of dimension ≥ 2 over a field, the bijections preserving collinearity (collineations) are precisely the projective transformations induced by semilinear maps. The parent gallery entry proves Desargues's theorem itself in homogeneous ℝ³ coordinates, where incidence is a determinant condition. This entry formalizes the reachable algebraic heart of the FTPG in that same model: invertible linear maps are collineations, and Desargues's configuration is therefore a projective invariant.",
+    "problemStatement": "How is Desargues's theorem related to the Fundamental Theorem of Projective Geometry? Concretely, in the homogeneous ℝ³ model, do the linear maps preserve the incidence structure (collinearity, concurrence) in which Desargues's theorem is stated, and does an invertible map act as a genuine collineation?",
+    "text": "Yes, and it reduces to one determinant identity. Because det[M·p, M·q, M·r] = det(M)·det[p,q,r], every linear map M sends collinear triples to collinear triples and concurrent line-triples to concurrent ones; when det M ≠ 0 the converse also holds, so M preserves incidence in both directions — it is a collineation. The full FTPG (every incidence-preserving bijection arises this way, and semilinearly over general fields) needs projective-space machinery Mathlib does not yet have and remains open; but the linear-map direction — the reason Desargues's theorem is coordinate-free and holds throughout the projective linear group's orbit — is proved here in full.",
+    "proofStrategy": "The single lemma det_rowMatrix_mulVec does all the work. The matrix whose rows are M·p, M·q, M·r equals (rowMatrix p q r) · Mᵀ (each output row is M applied to an input row, which in matrix form is right-multiplication by Mᵀ). Then det = det(rowMatrix p q r) · det Mᵀ = det(rowMatrix p q r) · det M by det_mul and det_transpose. Preservation (collinear_map) is det M · 0 = 0; reflection (collinear_map_iff) uses mul_eq_zero together with det M ≠ 0. Concurrence is the identical determinant predicate, so its lemmas are the same statements. The incidence lemmas collinear_self / collinear_comm expand the 3×3 determinant and close by ring / linear_combination.",
+    "keyInsights": [
+      "Incidence in the homogeneous model is a single determinant condition (det = 0), so both collinearity of points and concurrence of lines are the *same* predicate — projective duality is literal here.",
+      "The row-image matrix [M·p; M·q; M·r] factors as (rows) · Mᵀ; this one observation converts a geometric transformation into a clean determinant multiplication.",
+      "Preservation of incidence holds for *every* linear map (even singular ones), but reflection — and hence being a collineation — requires invertibility, exactly the GL₃ hypothesis det M ≠ 0.",
+      "Because the whole Desargues configuration is a conjunction of these determinant conditions, it is invariant under GL₃; this is the precise sense in which Desargues's theorem belongs to projective (not affine or metric) geometry.",
+      "This is the linear, fully-formalizable core of the Fundamental Theorem of Projective Geometry; the hard converse (all collineations are semilinear) needs projective-space foundations Mathlib lacks."
+    ],
+    "prerequisites": [
+      "homogeneous coordinates: projective points/lines as vectors in ℝ³",
+      "the determinant incidence conditions for collinearity and concurrence (parent entry)",
+      "Matrix.det_mul and Matrix.det_transpose",
+      "the projective linear group GL₃ and the notion of a collineation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-defs",
+      "title": "Incidence Predicates",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "Vec = Fin 3 → ℝ (homogeneous coordinates), rowMatrix p q r stacks three vectors as rows, and Collinear/Concurrent are the determinant-zero conditions on points / line coefficients — the same predicate, by duality.",
+      "mathContext": "Collinear p q r := det(rowMatrix p q r) = 0; Concurrent shares the identical form."
+    },
+    {
+      "id": "sec-detlaw",
+      "title": "The Determinant Transformation Law",
+      "startLine": 63,
+      "endLine": 81,
+      "summary": "det_rowMatrix_mulVec: det[M·p, M·q, M·r] = det(M)·det[p,q,r]. Proof rewrites the row-image matrix as (rowMatrix p q r)·Mᵀ (each output row is M applied to an input row) and applies det_mul and det_transpose.",
+      "mathContext": "det[Mp, Mq, Mr] = det M · det[p,q,r] via [Mp;Mq;Mr] = [p;q;r]·Mᵀ."
+    },
+    {
+      "id": "sec-invariance",
+      "title": "Linear Maps Preserve Incidence; Invertible Maps Are Collineations",
+      "startLine": 82,
+      "endLine": 115,
+      "summary": "collinear_map / concurrent_map: any linear M preserves incidence (det M · 0 = 0). collinear_map_iff / concurrent_map_iff: an invertible M (det M ≠ 0) also reflects incidence (mul_eq_zero), hence is a genuine collineation preserving the structure in both directions.",
+      "mathContext": "M preserves incidence for all M; det M ≠ 0 ⟹ M reflects it ⟹ M is a collineation."
+    },
+    {
+      "id": "sec-incidence",
+      "title": "Basic Incidence Lemmas",
+      "startLine": 116,
+      "endLine": 134,
+      "summary": "collinear_self (a repeated point is collinear with anything — a degenerate row) and collinear_comm (collinearity is symmetric in its first two arguments — swapping rows negates the determinant), both via the explicit 3×3 determinant.",
+      "mathContext": "Collinear p p q always; Collinear p q r ⟹ Collinear q p r."
+    },
+    {
+      "id": "sec-config",
+      "title": "Projective Invariance of the Desargues Configuration",
+      "startLine": 135,
+      "endLine": 150,
+      "summary": "desargues_config_invariant: for invertible M, both incidence facts of Desargues's theorem — three concurrent joining lines and three collinear intersection points — transport in each direction, so the configuration is invariant under the projective linear group.",
+      "mathContext": "For det M ≠ 0: Concurrent(M·lines) ↔ Concurrent(lines) and Collinear(M·pts) ↔ Collinear(pts)."
+    }
+  ],
+  "conclusion": {
+    "summary": "In the parent's homogeneous ℝ³ model, the determinant law det[M·p, M·q, M·r] = det(M)·det[p,q,r] makes every linear map preserve incidence and every invertible map a collineation that both preserves and reflects it. Hence the Desargues configuration is invariant under GL₃, the algebraic reason Desargues's theorem is a projective (coordinate-free) statement. This is the reachable, axiom-free core of the Fundamental Theorem of Projective Geometry.",
+    "implications": "The FTPG's deep content — that every collinearity-preserving bijection of a projective space (dim ≥ 2) is semilinear — is what upgrades this linear picture to a characterization; it needs abstract projective-space and semilinear-map machinery Mathlib does not have. What this entry pins down precisely is the half that is elementary and unconditional: invertible linear maps ARE collineations, so working in one coordinate frame loses no generality for Desargues-type incidence theorems. The determinant law and the preserve/reflect split (any M preserves, only invertible M reflects) are reusable for any incidence result in this model.",
+    "openQuestions": [
+      "Formalize the converse direction of the FTPG: every collinearity-preserving bijection of the ℝ³-projective plane is induced by an invertible linear map (over ℝ there are no nontrivial field automorphisms, so semilinear = linear).",
+      "Build the abstract projective-plane structure (points, lines, incidence axioms) in Mathlib and show the ℝ³ model satisfies it, giving Desargues's theorem as an incidence-axiom consequence.",
+      "Extend the invariance from GL₃ to the projective linear group PGL₃ by quotienting out scalar matrices, matching the true group of the projective plane."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix"
+    ],
+    "namespace": "DesarguesTheoremOQ03",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 4,
+    "path": "Proofs/DesarguesTheoremOQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "desargues-theorem",
+      "relationship": "parent",
+      "description": "Proves Desargues's theorem in homogeneous ℝ³ coordinates with the determinant incidence conditions. This entry shows that incidence structure — and hence the whole theorem — is invariant under the projective linear group."
+    },
+    {
+      "targetId": "desargues-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "Another follow-up in the Desargues family; this entry treats the projective-invariance / Fundamental-Theorem-of-Projective-Geometry angle."
+    }
+  ],
+  "references": [
+    {
+      "author": "Oswald Veblen and John Wesley Young",
+      "title": "Projective Geometry, Vol. 1",
+      "year": "1910",
+      "note": "Classical development of projective geometry and the fundamental theorem; collineations and the role of Desargues's theorem."
+    },
+    {
+      "author": "Emil Artin",
+      "title": "Geometric Algebra",
+      "year": "1957",
+      "note": "The correspondence between the projective linear group, collineations, and coordinatization by a division ring."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **desargues-theorem-oq-03**, answering the problem *"Desargues: Relationship to the Fundamental Theorem of Projective Geometry."*

The **Fundamental Theorem of Projective Geometry (FTPG)** says the incidence-preserving maps of a projective space (dim ≥ 2) are exactly the projective (semilinear) maps. Its full statement is beyond current Mathlib, but its **algebraic engine is elementary** and is proved here axiom-free, in the parent entry's homogeneous ℝ³ model (where incidence = a determinant-zero condition):

> **det[M·p, M·q, M·r] = det(M)·det[p, q, r]**

so a linear map preserves incidence, and an **invertible** map (`det M ≠ 0`) preserves *and reflects* it — a genuine **collineation**.

## Results (8 theorems, 4 defs, 150 lines, 0 axioms)

| Name | Statement |
|---|---|
| `det_rowMatrix_mulVec` | `det[M·p, M·q, M·r] = det(M)·det[p, q, r]` (via `[Mp;Mq;Mr] = [p;q;r]·Mᵀ`) |
| `collinear_map`, `concurrent_map` | **any** linear `M` preserves incidence (`det M · 0 = 0`) |
| `collinear_map_iff`, `concurrent_map_iff` | an **invertible** `M` reflects incidence → a collineation |
| `collinear_self`, `collinear_comm` | basic incidence lemmas (via `det_fin_three`) |
| `desargues_config_invariant` | the Desargues data (3 concurrent joining lines, 3 collinear intersection points) transports along any invertible `M`, in each direction |

**The point:** preservation holds for *every* `M` (even singular), but *reflection* — being a collineation — needs exactly the `GL₃` hypothesis `det M ≠ 0`. Hence the whole Desargues configuration is invariant under the projective linear group, which is why Desargues's theorem is a *projective* (coordinate-free) statement.

## Scope / honesty

- This is the **linear-map core** of the FTPG. The deep converse — every collinearity-preserving bijection is semilinear — needs abstract projective-space and semilinear-map machinery that Mathlib does not have, and is left as an open question.

## Verification

- Self-contained (`import Mathlib`); **0 axioms** (`#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`); 0 sorries; no `native_decide`.
- Verified with `lake env lean` against Mathlib 4.26.0.
- Gallery `meta.json` (status `verified`) + 6 annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)