### PR TITLE
Enrich Moments of the Standard Normal: add annotation coverage

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "aoc-oq05-scope",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "concept",
+    "title": "Scope: the first moments of the standard normal",
+    "content": "The parent `AreaOfCircleOQ05Incomplete01` derived the normal density `(1/√(2π))·exp(-x²/2)` from the Gaussian integral `∫ exp(-x²) = √π`, and asked (OQ-01) for the moments `E[X^{2k}] = (2k-1)!!`, `E[X^{2k+1}] = 0`. This file settles the structurally central cases — mean, variance, second moment — over Mathlib's `gaussianReal 0 1`, bridges the abstract measure to the parent's concrete density integral, and records the moment-generating function `M_X(t) = exp(t²/2)` whose Taylor coefficients encode the full even-moment sequence. Everything is kernel-checked with 0 axioms and no `native_decide`; the general even-moment formula is the remaining strand.",
+    "mathContext": "Standard normal $N(0,1)$: $E[X^{2k}] = (2k-1)!! = \\tfrac{(2k)!}{2^k k!}$, $E[X^{2k+1}] = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["standard normal distribution", "moments", "double factorial", "Gaussian integral"],
+    "prerequisites": ["probability measures", "Lebesgue integration"]
+  },
+  {
+    "id": "aoc-oq05-def",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 42, "endLine": 47 },
+    "type": "definition",
+    "title": "The standard normal as a Gaussian measure",
+    "content": "`stdNormal` is defined as Mathlib's `ProbabilityTheory.gaussianReal 0 1` — the Gaussian measure with mean `0` and variance `1`. The accompanying `IsProbabilityMeasure` instance (proved by unfolding and `infer_instance`) records that it is a genuine probability measure, so every moment integral below is against total mass 1. Working in the measure framework rather than the raw density lets the proofs reuse Mathlib's Gaussian lemmas directly.",
+    "mathContext": "$\\text{stdNormal} := \\mathcal{N}(0,1)$, with $\\int_{\\mathbb{R}} d\\,\\text{stdNormal} = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian measure", "probability measure", "gaussianReal"],
+    "prerequisites": ["measure theory", "probability distributions"]
+  },
+  {
+    "id": "aoc-oq05-mean-var",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 49, "endLine": 58 },
+    "type": "theorem",
+    "title": "Mean 0 and variance 1",
+    "content": "`stdNormal_mean` (`E[X] = 0`) and `stdNormal_variance` (`Var[X] = 1`) are direct specializations of Mathlib's Gaussian facts `integral_id_gaussianReal` and `variance_id_gaussianReal`. They are the defining first- and second-order data of the standard normal, and — because the mean is `0` — they are exactly what collapses the variance into the raw second moment in the next step.",
+    "mathContext": "$E[X] = \\int x\\,d\\mathcal{N}(0,1) = 0$;\\ \\ $\\operatorname{Var}[X] = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["expectation", "variance", "standard normal distribution"],
+    "prerequisites": ["expectation and variance", "Gaussian measures"]
+  },
+  {
+    "id": "aoc-oq05-second-moment",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 60, "endLine": 68 },
+    "type": "insight",
+    "title": "Second moment E[X²] = 1 via variance = mean-square",
+    "content": "`stdNormal_second_moment` derives `∫ x² = 1` from `Var[X] = E[X²] − (E[X])²`: rewriting the variance as an integral (`variance_eq_integral`) and substituting `E[X] = 0` collapses `Var[X] = 1` directly to the raw second moment. This is the `k = 1` case of the general even-moment formula, since `(2·1−1)!! = 1`.",
+    "mathContext": "$\\operatorname{Var}[X] = E[X^2] - (E[X])^2$, and $E[X] = 0 \\Rightarrow E[X^2] = \\operatorname{Var}[X] = 1 = 1!!$.",
+    "significance": "key",
+    "relatedConcepts": ["second moment", "variance identity", "double factorial"],
+    "prerequisites": ["variance-mean-square identity"]
+  },
+  {
+    "id": "aoc-oq05-concrete",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 70, "endLine": 92 },
+    "type": "tactic",
+    "title": "Bridging the measure to the parent's concrete density",
+    "content": "Two theorems tie the abstract measure back to the parent's explicit integral. `gaussianPDFReal_std` proves Mathlib's `gaussianPDFReal 0 1` equals the parent's density `(1/√(2π))·exp(-x²/2)` (by `push_cast`/`ring_nf`). `stdNormal_second_moment_concrete` then rewrites the measure integral `∫ x² ∂stdNormal` as a density integral via `integral_gaussianReal_eq_integral_smul` and applies `integral_congr_ae` with that density identity, yielding the concrete `∫ x²·(1/√(2π))·exp(-x²/2) = 1`. This makes the result usable in the parent's idiom without re-deriving anything.",
+    "mathContext": "$\\int x^2 \\, d\\mathcal{N}(0,1) = \\int x^2 \\cdot \\tfrac{1}{\\sqrt{2\\pi}} e^{-x^2/2}\\,dx = 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["probability density function", "change of representation", "integral_congr_ae", "gaussianPDFReal"],
+    "prerequisites": ["densities vs measures", "Lebesgue integration"]
+  },
+  {
+    "id": "aoc-oq05-mgf",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "range": { "startLine": 94, "endLine": 104 },
+    "type": "insight",
+    "title": "The moment-generating function exp(t²/2)",
+    "content": "`stdNormal_mgf` shows the MGF is `t ↦ exp(t²/2)` (from Mathlib's `mgf_id_gaussianReal`). This single object encodes every moment: expanding `exp(t²/2) = ∑ t^{2k}/(2^k k!)` and matching against `∑ E[X^n] t^n/n!` gives `E[X^{2k}] = (2k)!/(2^k k!) = (2k-1)!!` and `E[X^{2k+1}] = 0`. The MGF is thus the compact generator of the full moment sequence OQ-01 asks for — differentiating it (or an integration-by-parts recursion) yields the general formula left as the remaining strand.",
+    "mathContext": "$M_X(t) = e^{t^2/2} = \\sum_{k\\ge 0} \\frac{t^{2k}}{2^k k!}$, so $E[X^{2k}] = \\frac{(2k)!}{2^k k!} = (2k-1)!!$.",
+    "significance": "key",
+    "relatedConcepts": ["moment-generating function", "Taylor series", "even moments", "double factorial"],
+    "prerequisites": ["moment-generating functions", "power series"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-incomplete-01-oq-01` (quality 34, 0 prior passes).

## Gap
Verified entry with rich `meta.json` but **no `annotations.json`** — zero inline coverage of the 105-line Lean file.

## Changes
Added `annotations.json` with **6 annotations**:
- Scope (module header: moments of N(0,1))
- `stdNormal` — the standard normal as a Gaussian measure
- `stdNormal_mean` / `stdNormal_variance` — mean 0, variance 1
- `stdNormal_second_moment` — E[X²]=1 via the variance identity
- `gaussianPDFReal_std` + `stdNormal_second_moment_concrete` — bridge to the parent's density integral
- `stdNormal_mgf` — the MGF exp(t²/2) generating the even-moment sequence (2k−1)!!

Canonical enum types/significance; every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
`validateLineAnnotations` against the Lean source: **6 valid, 0 misaligned.**