### PR TITLE
Enrich Cesàro/Grandi summation (ramanujan-sum-fallacy-oq-02): annotation coverage

### DIFF
--- a/src/data/proofs/ramanujan-sum-fallacy-oq-02/annotations.json
+++ b/src/data/proofs/ramanujan-sum-fallacy-oq-02/annotations.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": "ann-cesaro-overview",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "Cesàro Summation and the Grandi Series",
+    "content": "The parent entry proves Grandi's series $1-1+1-1+\\cdots$ has no *ordinary* sum: its partial sums $s_n = 0,1,0,1,\\dots$ oscillate forever. Cesàro's idea (1890) is to sum not the terms but the **averages** of the partial sums: $\\sigma_n = \\frac1n\\sum_{k<n} s_k$. Averaging damps the oscillation — half the $s_k$ are $0$ and half are $1$, so their running mean settles at $\\tfrac12$. This file builds the definitions (`partialSum`, `cesaroMean`, `CesaroSum`) from scratch and proves `grandi_cesaroSum_half : CesaroSum grandi (1/2)`, answering the parent's open question OQ-02.",
+    "mathContext": "$\\sigma_n = \\frac{1}{n}\\sum_{k<n} s_k$, $s_k = \\sum_{j<k} a_j$; Grandi: $a_k=(-1)^k$, $\\sigma_n\\to\\tfrac12$.",
+    "significance": "key",
+    "prerequisites": [
+      "sequences and limits",
+      "infinite series"
+    ],
+    "relatedConcepts": [
+      "Cesàro summation",
+      "divergent series",
+      "Grandi's series",
+      "summability method"
+    ]
+  },
+  {
+    "id": "ann-partialsum-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 41
+    },
+    "type": "definition",
+    "title": "Partial Sums",
+    "content": "`partialSum a n = ∑_{k<n} a k` is the ordinary $n$-th partial sum, the object whose *limit* defines ordinary convergence. Cesàro summation does not discard it — it takes these partial sums as the raw sequence to be averaged. Note the half-open convention $k < n$, so `partialSum a 0 = 0` (empty sum) and the sequence is indexed to match `Finset.range`.",
+    "mathContext": "$s_n = \\sum_{k=0}^{n-1} a_k$, with $s_0 = 0$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "finite sums"
+    ],
+    "relatedConcepts": [
+      "partial sum",
+      "Finset.range"
+    ]
+  },
+  {
+    "id": "ann-cesaromean-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 43,
+      "endLine": 45
+    },
+    "type": "definition",
+    "title": "The Cesàro Mean",
+    "content": "`cesaroMean a n = (∑_{k<n} partialSum a k) / n` averages the first $n$ partial sums. It is marked `noncomputable` only because real division routes through Mathlib's classical field structure. The `/ n` uses Lean's junk-value convention: division by `0` returns `0`, so `cesaroMean a 0 = 0` harmlessly — the summability predicate only concerns the tail $n\\to\\infty$, where $n\\neq 0$, so this junk value never affects the limit.",
+    "mathContext": "$\\sigma_n = \\frac{1}{n}\\sum_{k<n} s_k$; $\\sigma_0 := 0$ by convention.",
+    "significance": "key",
+    "prerequisites": [
+      "averages",
+      "division in Lean"
+    ],
+    "relatedConcepts": [
+      "Cesàro mean",
+      "arithmetic mean",
+      "junk value convention"
+    ]
+  },
+  {
+    "id": "ann-cesarosum-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 49
+    },
+    "type": "definition",
+    "title": "Cesàro Summability, as a Filter Limit",
+    "content": "`CesaroSum a L := Tendsto (cesaroMean a) atTop (𝓝 L)` says the Cesàro means converge to `L` in the standard filter sense (`atTop` towards `𝓝 L`). This is *weaker* than ordinary summability: every ordinarily convergent series is Cesàro-summable to the same value (the mean of a convergent sequence converges to its limit), but the converse fails — Grandi's series is the canonical witness. Phrasing it as `Tendsto` lets the proof reuse Mathlib's full topology/limits library.",
+    "mathContext": "$\\text{CesaroSum } a\\ L \\iff \\sigma_n \\to L$; strictly extends $\\sum a_k = L$.",
+    "significance": "key",
+    "prerequisites": [
+      "filters",
+      "limits of sequences"
+    ],
+    "relatedConcepts": [
+      "Tendsto",
+      "filter limit",
+      "summability method",
+      "regularity"
+    ]
+  },
+  {
+    "id": "ann-grandi-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 52
+    },
+    "type": "definition",
+    "title": "Grandi's Series",
+    "content": "`grandi n = (-1)^n` is the alternating sequence $1,-1,1,-1,\\dots$ studied by Guido Grandi in 1703. Formal manipulation ($S = 1-(1-1+1-\\cdots) = 1-S \\Rightarrow S=\\tfrac12$) tempted early analysts, but the series has no ordinary sum. It is the textbook first example of a summation method precisely because the 'paradoxical' value $\\tfrac12$ turns out to be its genuine Cesàro sum.",
+    "mathContext": "$a_k = (-1)^k$, partial sums $0,1,0,1,\\dots$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "geometric-like sequences"
+    ],
+    "relatedConcepts": [
+      "Grandi's series",
+      "alternating series",
+      "divergent series"
+    ]
+  },
+  {
+    "id": "ann-partialsum-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 54,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "Partial Sums Follow the 0,1,0,1 Pattern",
+    "content": "The closed form $s_n = (1-(-1)^n)/2$ compactly encodes the pattern $0,1,0,1,\\dots$: for even $n$ the numerator is $1-1=0$, for odd $n$ it is $1-(-1)=2$, giving $1$. The proof is a one-step induction: `Finset.sum_range_succ` peels the last term $(-1)^n$, `pow_succ` rewrites $(-1)^{n+1}=(-1)^n\\cdot(-1)$, and `ring` closes the algebra. This algebraic form (rather than a case split on parity) is what makes the later inductions purely computational.",
+    "mathContext": "$s_n = \\sum_{k<n}(-1)^k = \\frac{1-(-1)^n}{2}$.",
+    "significance": "key",
+    "prerequisites": [
+      "induction",
+      "geometric series"
+    ],
+    "relatedConcepts": [
+      "telescoping",
+      "induction",
+      "sum_range_succ"
+    ]
+  },
+  {
+    "id": "ann-cesaro-partialsum-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "Cumulative Sum of Partial Sums",
+    "content": "Summing the previous closed form, $\\sum_{k<n} s_k = n/2 - (1-(-1)^n)/4$. The leading $n/2$ is exactly what makes the mean approach $\\tfrac12$: dividing by $n$ leaves $\\tfrac12$ plus an $O(1/n)$ remainder. A second `Finset.sum_range_succ` induction, feeding in `partialSum_grandi` for the new top term and closing with `push_cast`/`ring`, produces this from the first lemma.",
+    "mathContext": "$\\sum_{k<n} s_k = \\frac{n}{2} - \\frac{1-(-1)^n}{4}$.",
+    "significance": "key",
+    "prerequisites": [
+      "induction",
+      "finite sums"
+    ],
+    "relatedConcepts": [
+      "nested induction",
+      "accumulated sum"
+    ]
+  },
+  {
+    "id": "ann-cesaromean-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "Closed Form of the Cesàro Mean",
+    "content": "For $n\\ge 1$, `cesaroMean grandi n = 1/2 - (1-(-1)^n)/(4n)`. This is the crux: it exhibits the mean as its target value $\\tfrac12$ minus an explicit error term that decays like $1/n$. With $n\\neq 0$ established, `field_simp` clears the denominator and reduces to the previous lemma. Everything downstream is just bounding and squeezing this error to zero.",
+    "mathContext": "$\\sigma_n = \\tfrac12 - \\dfrac{1-(-1)^n}{4n}$ for $n\\ge 1$; error $=O(1/n)$.",
+    "significance": "critical",
+    "prerequisites": [
+      "algebraic manipulation",
+      "asymptotics"
+    ],
+    "relatedConcepts": [
+      "closed form",
+      "error term",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-grandi-cesarosum-half",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "Main Result: Grandi's Series is Cesàro-Summable to 1/2",
+    "content": "The headline `CesaroSum grandi (1/2)`. The proof squeezes the error term $(1-(-1)^n)/(4n)$ between $0$ and $1/n$: since $|(-1)^n|=1$, the numerator lies in $[0,2]$, giving $0 \\le \\text{error} \\le 2/(4n) = 1/(2n) \\le 1/n$. `squeeze_zero` against `tendsto_one_div_atTop_nhds_zero_nat` sends the error to $0$; then `herr.const_sub (1/2)` gives $\\tfrac12 - \\text{error}\\to\\tfrac12$, and `tendsto_congr'` transfers this along the eventual equality $\\sigma_n = \\tfrac12-\\text{error}$ (valid for $n\\ge1$) back to `cesaroMean grandi`.",
+    "mathContext": "$\\sigma_n \\to \\tfrac12$ via $0\\le\\frac{1-(-1)^n}{4n}\\le\\frac1n$ and the squeeze theorem.",
+    "significance": "critical",
+    "prerequisites": [
+      "squeeze theorem",
+      "limits",
+      "filters"
+    ],
+    "relatedConcepts": [
+      "squeeze theorem",
+      "squeeze_zero",
+      "tendsto_congr'",
+      "eventual equality"
+    ]
+  },
+  {
+    "id": "ann-grandi-cesarosummable",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "range": {
+      "startLine": 121,
+      "endLine": 125
+    },
+    "type": "insight",
+    "title": "Cesàro Summation Strictly Extends Ordinary Convergence",
+    "content": "The bare existence statement `∃ L, CesaroSum grandi L` is the whole point when read against the parent entry: Grandi's series **is** Cesàro-summable while it is **not** ordinarily summable, so Cesàro summation is a genuinely broader notion of 'sum'. This dissolves the apparent paradox — $1-1+1-1+\\cdots=\\tfrac12$ is false as an ordinary sum but true as a Cesàro sum. It is also the first rung of a ladder (Cesàro ⊂ Abel ⊂ Borel …) of increasingly powerful, mutually consistent summation methods.",
+    "mathContext": "Ordinary summability $\\subsetneq$ Cesàro summability; Grandi separates them.",
+    "significance": "key",
+    "prerequisites": [
+      "summability methods"
+    ],
+    "relatedConcepts": [
+      "strict extension",
+      "Abel summation",
+      "regularity of summation methods",
+      "consistency"
+    ]
+  }
+]

--- a/src/data/proofs/ramanujan-sum-fallacy-oq-02/annotations.source.json
+++ b/src/data/proofs/ramanujan-sum-fallacy-oq-02/annotations.source.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-cesaro-overview",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "block-comment", "contains": "Cesàro summation" },
+    "type": "concept",
+    "title": "Cesàro Summation and the Grandi Series",
+    "content": "The parent entry proves Grandi's series $1-1+1-1+\\cdots$ has no *ordinary* sum: its partial sums $s_n = 0,1,0,1,\\dots$ oscillate forever. Cesàro's idea (1890) is to sum not the terms but the **averages** of the partial sums: $\\sigma_n = \\frac1n\\sum_{k<n} s_k$. Averaging damps the oscillation — half the $s_k$ are $0$ and half are $1$, so their running mean settles at $\\tfrac12$. This file builds the definitions (`partialSum`, `cesaroMean`, `CesaroSum`) from scratch and proves `grandi_cesaroSum_half : CesaroSum grandi (1/2)`, answering the parent's open question OQ-02.",
+    "mathContext": "$\\sigma_n = \\frac{1}{n}\\sum_{k<n} s_k$, $s_k = \\sum_{j<k} a_j$; Grandi: $a_k=(-1)^k$, $\\sigma_n\\to\\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["Cesàro summation", "divergent series", "Grandi's series", "summability method"],
+    "prerequisites": ["sequences and limits", "infinite series"]
+  },
+  {
+    "id": "ann-partialsum-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "partialSum", "kind": "def" },
+    "type": "definition",
+    "title": "Partial Sums",
+    "content": "`partialSum a n = ∑_{k<n} a k` is the ordinary $n$-th partial sum, the object whose *limit* defines ordinary convergence. Cesàro summation does not discard it — it takes these partial sums as the raw sequence to be averaged. Note the half-open convention $k < n$, so `partialSum a 0 = 0` (empty sum) and the sequence is indexed to match `Finset.range`.",
+    "mathContext": "$s_n = \\sum_{k=0}^{n-1} a_k$, with $s_0 = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partial sum", "Finset.range"],
+    "prerequisites": ["finite sums"]
+  },
+  {
+    "id": "ann-cesaromean-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "cesaroMean", "kind": "def" },
+    "type": "definition",
+    "title": "The Cesàro Mean",
+    "content": "`cesaroMean a n = (∑_{k<n} partialSum a k) / n` averages the first $n$ partial sums. It is marked `noncomputable` only because real division routes through Mathlib's classical field structure. The `/ n` uses Lean's junk-value convention: division by `0` returns `0`, so `cesaroMean a 0 = 0` harmlessly — the summability predicate only concerns the tail $n\\to\\infty$, where $n\\neq 0$, so this junk value never affects the limit.",
+    "mathContext": "$\\sigma_n = \\frac{1}{n}\\sum_{k<n} s_k$; $\\sigma_0 := 0$ by convention.",
+    "significance": "key",
+    "relatedConcepts": ["Cesàro mean", "arithmetic mean", "junk value convention"],
+    "prerequisites": ["averages", "division in Lean"]
+  },
+  {
+    "id": "ann-cesarosum-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "CesaroSum", "kind": "def" },
+    "type": "definition",
+    "title": "Cesàro Summability, as a Filter Limit",
+    "content": "`CesaroSum a L := Tendsto (cesaroMean a) atTop (𝓝 L)` says the Cesàro means converge to `L` in the standard filter sense (`atTop` towards `𝓝 L`). This is *weaker* than ordinary summability: every ordinarily convergent series is Cesàro-summable to the same value (the mean of a convergent sequence converges to its limit), but the converse fails — Grandi's series is the canonical witness. Phrasing it as `Tendsto` lets the proof reuse Mathlib's full topology/limits library.",
+    "mathContext": "$\\text{CesaroSum } a\\ L \\iff \\sigma_n \\to L$; strictly extends $\\sum a_k = L$.",
+    "significance": "key",
+    "relatedConcepts": ["Tendsto", "filter limit", "summability method", "regularity"],
+    "prerequisites": ["filters", "limits of sequences"]
+  },
+  {
+    "id": "ann-grandi-def",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "grandi", "kind": "def" },
+    "type": "definition",
+    "title": "Grandi's Series",
+    "content": "`grandi n = (-1)^n` is the alternating sequence $1,-1,1,-1,\\dots$ studied by Guido Grandi in 1703. Formal manipulation ($S = 1-(1-1+1-\\cdots) = 1-S \\Rightarrow S=\\tfrac12$) tempted early analysts, but the series has no ordinary sum. It is the textbook first example of a summation method precisely because the 'paradoxical' value $\\tfrac12$ turns out to be its genuine Cesàro sum.",
+    "mathContext": "$a_k = (-1)^k$, partial sums $0,1,0,1,\\dots$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Grandi's series", "alternating series", "divergent series"],
+    "prerequisites": ["geometric-like sequences"]
+  },
+  {
+    "id": "ann-partialsum-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "partialSum_grandi", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Partial Sums Follow the 0,1,0,1 Pattern",
+    "content": "The closed form $s_n = (1-(-1)^n)/2$ compactly encodes the pattern $0,1,0,1,\\dots$: for even $n$ the numerator is $1-1=0$, for odd $n$ it is $1-(-1)=2$, giving $1$. The proof is a one-step induction: `Finset.sum_range_succ` peels the last term $(-1)^n$, `pow_succ` rewrites $(-1)^{n+1}=(-1)^n\\cdot(-1)$, and `ring` closes the algebra. This algebraic form (rather than a case split on parity) is what makes the later inductions purely computational.",
+    "mathContext": "$s_n = \\sum_{k<n}(-1)^k = \\frac{1-(-1)^n}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping", "induction", "sum_range_succ"],
+    "prerequisites": ["induction", "geometric series"]
+  },
+  {
+    "id": "ann-cesaro-partialsum-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "cesaro_partialsum_grandi", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Cumulative Sum of Partial Sums",
+    "content": "Summing the previous closed form, $\\sum_{k<n} s_k = n/2 - (1-(-1)^n)/4$. The leading $n/2$ is exactly what makes the mean approach $\\tfrac12$: dividing by $n$ leaves $\\tfrac12$ plus an $O(1/n)$ remainder. A second `Finset.sum_range_succ` induction, feeding in `partialSum_grandi` for the new top term and closing with `push_cast`/`ring`, produces this from the first lemma.",
+    "mathContext": "$\\sum_{k<n} s_k = \\frac{n}{2} - \\frac{1-(-1)^n}{4}$.",
+    "significance": "key",
+    "relatedConcepts": ["nested induction", "accumulated sum"],
+    "prerequisites": ["induction", "finite sums"]
+  },
+  {
+    "id": "ann-cesaromean-grandi",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "cesaroMean_grandi", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Closed Form of the Cesàro Mean",
+    "content": "For $n\\ge 1$, `cesaroMean grandi n = 1/2 - (1-(-1)^n)/(4n)`. This is the crux: it exhibits the mean as its target value $\\tfrac12$ minus an explicit error term that decays like $1/n$. With $n\\neq 0$ established, `field_simp` clears the denominator and reduces to the previous lemma. Everything downstream is just bounding and squeezing this error to zero.",
+    "mathContext": "$\\sigma_n = \\tfrac12 - \\dfrac{1-(-1)^n}{4n}$ for $n\\ge 1$; error $=O(1/n)$.",
+    "significance": "critical",
+    "relatedConcepts": ["closed form", "error term", "field_simp"],
+    "prerequisites": ["algebraic manipulation", "asymptotics"]
+  },
+  {
+    "id": "ann-grandi-cesarosum-half",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "grandi_cesaroSum_half", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Main Result: Grandi's Series is Cesàro-Summable to 1/2",
+    "content": "The headline `CesaroSum grandi (1/2)`. The proof squeezes the error term $(1-(-1)^n)/(4n)$ between $0$ and $1/n$: since $|(-1)^n|=1$, the numerator lies in $[0,2]$, giving $0 \\le \\text{error} \\le 2/(4n) = 1/(2n) \\le 1/n$. `squeeze_zero` against `tendsto_one_div_atTop_nhds_zero_nat` sends the error to $0$; then `herr.const_sub (1/2)` gives $\\tfrac12 - \\text{error}\\to\\tfrac12$, and `tendsto_congr'` transfers this along the eventual equality $\\sigma_n = \\tfrac12-\\text{error}$ (valid for $n\\ge1$) back to `cesaroMean grandi`.",
+    "mathContext": "$\\sigma_n \\to \\tfrac12$ via $0\\le\\frac{1-(-1)^n}{4n}\\le\\frac1n$ and the squeeze theorem.",
+    "significance": "critical",
+    "relatedConcepts": ["squeeze theorem", "squeeze_zero", "tendsto_congr'", "eventual equality"],
+    "prerequisites": ["squeeze theorem", "limits", "filters"]
+  },
+  {
+    "id": "ann-grandi-cesarosummable",
+    "proofId": "ramanujan-sum-fallacy-oq-02",
+    "anchor": { "type": "declaration", "name": "grandi_cesaroSummable", "kind": "theorem" },
+    "type": "insight",
+    "title": "Cesàro Summation Strictly Extends Ordinary Convergence",
+    "content": "The bare existence statement `∃ L, CesaroSum grandi L` is the whole point when read against the parent entry: Grandi's series **is** Cesàro-summable while it is **not** ordinarily summable, so Cesàro summation is a genuinely broader notion of 'sum'. This dissolves the apparent paradox — $1-1+1-1+\\cdots=\\tfrac12$ is false as an ordinary sum but true as a Cesàro sum. It is also the first rung of a ladder (Cesàro ⊂ Abel ⊂ Borel …) of increasingly powerful, mutually consistent summation methods.",
+    "mathContext": "Ordinary summability $\\subsetneq$ Cesàro summability; Grandi separates them.",
+    "significance": "key",
+    "relatedConcepts": ["strict extension", "Abel summation", "regularity of summation methods", "consistency"],
+    "prerequisites": ["summability methods"]
+  }
+]


### PR DESCRIPTION
## Summary

Adds line-by-line annotation coverage to **ramanujan-sum-fallacy-oq-02** (*Cesàro Summation: Grandi's Series Sums to ½*), which previously had rich `meta.json` but **no `annotations.json`** — the sole gap dragging its quality score to 34.

Authored an anchor-based `annotations.source.json` (declaration/block-comment anchors, stable across source edits) resolving to 10 annotations that cover the whole 127-line proof:

- **Concept**: Cesàro summation vs. ordinary convergence; why averaging tames the $0,1,0,1,\dots$ oscillation.
- **Definitions**: `partialSum`, `cesaroMean` (incl. the `noncomputable`/junk-value-at-0 subtleties), `CesaroSum` as a `Tendsto` filter limit, and `grandi`.
- **Theorems**: the two closed-form inductions (`partialSum_grandi`, `cesaro_partialsum_grandi`), the critical Cesàro-mean closed form `cesaroMean_grandi`, and the main squeeze argument `grandi_cesaroSum_half`.
- **Insight**: `grandi_cesaroSummable` framed as the strict extension of ordinary convergence — the resolution of the parent's fallacy.

Each annotation carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Verification

- `annotations:build` resolves all 10 anchors with **0 errors for this slug** (only pre-existing baseline errors in unrelated entries).
- Full-file coverage: ranges span lines 1–125 of 127.
- No changes to the Lean source; entry remains verified/0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)