### PR TITLE
Enrich Logarithmic Lower Bound for Collatz Stopping Time: deepen annotations

### DIFF
--- a/src/data/proofs/collatz-structured-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-03-oq-03/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 37 },
     "type": "concept",
     "title": "Module header and setup",
-    "content": "The header states the result: for every $n$ whose Collatz orbit reaches $1$, $n \\le 2^{\\sigma(n)}$, equivalently $\\sigma(n) \\ge \\log_2 n$, with equality on powers of two ($\\sigma(2^k) = k$). This anchors the parent open question (collatz-structured-oq-03) on the growth of the average stopping time $S(N)$ from below. The file imports `Mathlib` and opens `Nat`, `Finset`, and `Classical`; the `Classical` opening supplies decidability for the undecidable predicate `reachesOne`, keeping the noncomputable `stoppingTime` definition well-formed while introducing only the foundational `Classical.choice` axiom (not a mathematical assumption)."
+    "content": "The header states the result: for every $n$ whose Collatz orbit reaches $1$, $n \\le 2^{\\sigma(n)}$, equivalently $\\sigma(n) \\ge \\log_2 n$, with equality on powers of two ($\\sigma(2^k) = k$). This anchors the parent open question (collatz-structured-oq-03) on the growth of the average stopping time $S(N)$ from below. The file imports `Mathlib` and opens `Nat`, `Finset`, and `Classical`; the `Classical` opening supplies decidability for the undecidable predicate `reachesOne`, keeping the noncomputable `stoppingTime` definition well-formed while introducing only the foundational `Classical.choice` axiom (not a mathematical assumption).",
+    "mathContext": "Main claim: $n \\le 2^{\\sigma(n)} \\iff \\sigma(n) \\ge \\log_2 n$, with equality iff $n = 2^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Collatz conjecture", "stopping time", "logarithmic bound", "Classical.choice"],
+    "prerequisites": ["Collatz conjecture", "natural number arithmetic"]
   },
   {
     "id": "ann-collatz-oq0303-definitions",
@@ -13,7 +17,11 @@
     "range": { "startLine": 39, "endLine": 65 },
     "type": "definition",
     "title": "Collatz function, iteration, and stopping time",
-    "content": "`collatz n` is $n/2$ for even $n$ and $3n+1$ for odd $n$; `collatzIter k n` applies it $k$ times; `reachesOneIn n k` says the value after $k$ steps is $1$; `reachesOne n` is $\\exists k,\\ \\text{reachesOneIn } n\\ k$. The stopping time `stoppingTime n = if h : reachesOne n then Nat.find h else 0` is the least step count reaching $1$, defaulting to $0$ on (possibly) divergent orbits. Because `reachesOne` is a halting-type predicate it is not decidable in general, so the definition is `noncomputable` and depends on classical choice. These mirror the parent entry so the file is self-contained."
+    "content": "`collatz n` is $n/2$ for even $n$ and $3n+1$ for odd $n$; `collatzIter k n` applies it $k$ times; `reachesOneIn n k` says the value after $k$ steps is $1$; `reachesOne n` is $\\exists k,\\ \\text{reachesOneIn } n\\ k$. The stopping time `stoppingTime n = if h : reachesOne n then Nat.find h else 0` is the least step count reaching $1$, defaulting to $0$ on (possibly) divergent orbits. Because `reachesOne` is a halting-type predicate it is not decidable in general, so the definition is `noncomputable` and depends on classical choice. These mirror the parent entry so the file is self-contained.",
+    "mathContext": "$\\text{collatz}(n) = \\begin{cases} n/2 & n \\text{ even} \\\\ 3n+1 & n \\text{ odd}\\end{cases}$;\\ \\ $\\sigma(n) = \\min\\{k : \\text{collatz}^k(n) = 1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Collatz function", "function iteration", "Nat.find", "noncomputable definition", "least witness"],
+    "prerequisites": ["recursive definitions", "decidability", "existential quantifiers"]
   },
   {
     "id": "ann-collatz-oq0303-monovariant",
@@ -21,7 +29,11 @@
     "range": { "startLine": 74, "endLine": 85 },
     "type": "theorem",
     "title": "The monovariant: one step loses at most a factor of two",
-    "content": "`le_two_mul_collatz`: $n \\le 2 \\cdot \\text{collatz } n$ for every $n$. Case split on parity: for even $n$, $\\text{collatz } n = n/2$ and $2\\cdot(n/2) = n$ exactly (using `Nat.mul_div_cancel'` on the divisibility $2 \\mid n$); for odd $n$, $\\text{collatz } n = 3n+1 \\ge n$, so $2(3n+1) \\ge n$ (closed by `nlinarith`). This is the engine of the whole argument: the Collatz map can never shrink a value by more than half in a single step."
+    "content": "`le_two_mul_collatz`: $n \\le 2 \\cdot \\text{collatz } n$ for every $n$. Case split on parity: for even $n$, $\\text{collatz } n = n/2$ and $2\\cdot(n/2) = n$ exactly (using `Nat.mul_div_cancel'` on the divisibility $2 \\mid n$); for odd $n$, $\\text{collatz } n = 3n+1 \\ge n$, so $2(3n+1) \\ge n$ (closed by `nlinarith`). This is the engine of the whole argument: the Collatz map can never shrink a value by more than half in a single step.",
+    "mathContext": "$n \\le 2\\,\\text{collatz}(n)$ for all $n$; even case is tight ($2(n/2)=n$), odd case slack ($3n+1 \\ge n$).",
+    "significance": "critical",
+    "relatedConcepts": ["monovariant", "parity case split", "nlinarith", "descent bound"],
+    "prerequisites": ["divisibility", "case analysis on parity"]
   },
   {
     "id": "ann-collatz-oq0303-iterated",
@@ -29,7 +41,11 @@
     "range": { "startLine": 87, "endLine": 110 },
     "type": "theorem",
     "title": "Iterated bound and specialisation to convergent orbits",
-    "content": "`le_two_pow_mul_collatzIter`: $n \\le 2^s \\cdot \\text{collatzIter } s\\ n$, by induction on $s$. The step uses $\\text{collatzIter}(s{+}1)\\,n = \\text{collatzIter}\\,s\\,(\\text{collatz } n)$, the induction hypothesis on `collatz n`, and the monovariant $n \\le 2\\cdot\\text{collatz } n$, combined by a short `calc`. `le_two_pow_of_reachesOneIn` then specialises: if the value after $s$ steps is $1$, the current factor collapses to $1$ and $n \\le 2^s$. Geometrically, the orbit cannot fall below $n/2^s$ after $s$ steps."
+    "content": "`le_two_pow_mul_collatzIter`: $n \\le 2^s \\cdot \\text{collatzIter } s\\ n$, by induction on $s$. The step uses $\\text{collatzIter}(s{+}1)\\,n = \\text{collatzIter}\\,s\\,(\\text{collatz } n)$, the induction hypothesis on `collatz n`, and the monovariant $n \\le 2\\cdot\\text{collatz } n$, combined by a short `calc`. `le_two_pow_of_reachesOneIn` then specialises: if the value after $s$ steps is $1$, the current factor collapses to $1$ and $n \\le 2^s$. Geometrically, the orbit cannot fall below $n/2^s$ after $s$ steps.",
+    "mathContext": "$n \\le 2^s\\,\\text{collatz}^s(n)$ (induction on $s$); if $\\text{collatz}^s(n)=1$ then $n \\le 2^s$.",
+    "significance": "key",
+    "relatedConcepts": ["iterated inequality", "induction on iteration count", "geometric decay bound"],
+    "prerequisites": ["induction on ℕ", "function iteration"]
   },
   {
     "id": "ann-collatz-oq0303-mainbound",
@@ -37,7 +53,11 @@
     "range": { "startLine": 112, "endLine": 125 },
     "type": "theorem",
     "title": "Main lower bound n ≤ 2^σ(n)",
-    "content": "`le_two_pow_stoppingTime`: any $n$ with `reachesOne n` satisfies $n \\le 2^{\\sigma(n)}$. Unfolding `stoppingTime` at the positive branch, `Nat.find_spec` yields `reachesOneIn n (Nat.find h)` — i.e. the orbit reaches $1$ in exactly $\\sigma(n)$ steps — and feeding this into `le_two_pow_of_reachesOneIn` gives the bound. This is the pointwise floor: reaching $1$ from $n$ costs at least $\\log_2 n$ steps."
+    "content": "`le_two_pow_stoppingTime`: any $n$ with `reachesOne n` satisfies $n \\le 2^{\\sigma(n)}$. Unfolding `stoppingTime` at the positive branch, `Nat.find_spec` yields `reachesOneIn n (Nat.find h)` — i.e. the orbit reaches $1$ in exactly $\\sigma(n)$ steps — and feeding this into `le_two_pow_of_reachesOneIn` gives the bound. This is the pointwise floor: reaching $1$ from $n$ costs at least $\\log_2 n$ steps.",
+    "mathContext": "$\\text{reachesOne}(n) \\Rightarrow n \\le 2^{\\sigma(n)}$; via $\\text{Nat.find\\_spec}$ the orbit reaches $1$ in exactly $\\sigma(n)$ steps.",
+    "significance": "critical",
+    "relatedConcepts": ["stopping time", "Nat.find_spec", "lower bound", "Collatz conjecture"],
+    "prerequisites": ["least-witness extraction", "Collatz stopping time"]
   },
   {
     "id": "ann-collatz-oq0303-realform",
@@ -45,7 +65,11 @@
     "range": { "startLine": 127, "endLine": 139 },
     "type": "theorem",
     "title": "Real-valued form: log₂ n ≤ σ(n)",
-    "content": "`logb_le_stoppingTime` restates the integer bound over the reals: $\\log_2 n \\le \\sigma(n)$ for convergent $n \\ge 1$. It casts $n \\le 2^{\\sigma(n)}$ to $\\mathbb{R}$, applies monotonicity of $\\log_2$ (`Real.logb_le_logb_of_le` with base $2 > 1$), and simplifies $\\log_2(2^{\\sigma(n)}) = \\sigma(n)$ via `Real.logb_pow` and `Real.logb_self_eq_one`. This is the statement directly comparable to the parent's heuristic $S(N) \\sim c\\log N$."
+    "content": "`logb_le_stoppingTime` restates the integer bound over the reals: $\\log_2 n \\le \\sigma(n)$ for convergent $n \\ge 1$. It casts $n \\le 2^{\\sigma(n)}$ to $\\mathbb{R}$, applies monotonicity of $\\log_2$ (`Real.logb_le_logb_of_le` with base $2 > 1$), and simplifies $\\log_2(2^{\\sigma(n)}) = \\sigma(n)$ via `Real.logb_pow` and `Real.logb_self_eq_one`. This is the statement directly comparable to the parent's heuristic $S(N) \\sim c\\log N$.",
+    "mathContext": "$\\log_2 n \\le \\sigma(n)$ for $n \\ge 1$ convergent — the real-valued form comparable to the heuristic $S(N) \\sim c\\log N$.",
+    "significance": "key",
+    "relatedConcepts": ["logarithm", "monotonicity of logb", "real cast", "asymptotic heuristic"],
+    "prerequisites": ["real logarithms", "monotone functions"]
   },
   {
     "id": "ann-collatz-oq0303-tightness",
@@ -53,7 +77,11 @@
     "range": { "startLine": 141, "endLine": 179 },
     "type": "theorem",
     "title": "Tightness: σ(2^k) = k",
-    "content": "Powers of two attain the bound. `collatz_two_pow_succ`: $\\text{collatz}(2^{k+1}) = 2^k$ (even, exact halving). `collatzIter_two_pow`: $\\text{collatzIter } k\\,(2^k) = 1$ by induction — the straight-line descent $2^k \\to 2^{k-1} \\to \\cdots \\to 1$. `stoppingTime_two_pow`: $\\sigma(2^k) = k$, via `Nat.find_eq_iff`; minimality is the elegant part — any competing witness $m$ with $\\text{collatzIter } m\\,(2^k) = 1$ forces $2^k \\le 2^m$ by the lower bound, hence $k \\le m$, so no shorter descent exists. Thus $2^k = 2^{\\sigma(2^k)}$: the floor is exactly attained."
+    "content": "Powers of two attain the bound. `collatz_two_pow_succ`: $\\text{collatz}(2^{k+1}) = 2^k$ (even, exact halving). `collatzIter_two_pow`: $\\text{collatzIter } k\\,(2^k) = 1$ by induction — the straight-line descent $2^k \\to 2^{k-1} \\to \\cdots \\to 1$. `stoppingTime_two_pow`: $\\sigma(2^k) = k$, via `Nat.find_eq_iff`; minimality is the elegant part — any competing witness $m$ with $\\text{collatzIter } m\\,(2^k) = 1$ forces $2^k \\le 2^m$ by the lower bound, hence $k \\le m$, so no shorter descent exists. Thus $2^k = 2^{\\sigma(2^k)}$: the floor is exactly attained.",
+    "mathContext": "$\\sigma(2^k) = k$: the descent $2^k \\to 2^{k-1} \\to \\cdots \\to 1$ takes exactly $k$ steps, and the lower bound $2^k \\le 2^m$ forces minimality.",
+    "significance": "key",
+    "relatedConcepts": ["tightness", "extremal case", "Nat.find_eq_iff", "power of two"],
+    "prerequisites": ["induction on ℕ", "minimality of Nat.find"]
   },
   {
     "id": "ann-collatz-oq0303-corollaries",
@@ -61,6 +89,10 @@
     "range": { "startLine": 181, "endLine": 216 },
     "type": "concept",
     "title": "Concrete stopping times of small powers of two",
-    "content": "Immediate specialisations of $\\sigma(2^k) = k$: $\\sigma(1) = 0$, $\\sigma(2) = 1$, $\\sigma(4) = 2$, $\\sigma(8) = 3$, $\\sigma(16) = 4$. These match the two values proved in the parent entry ($\\sigma(1), \\sigma(2)$) and extend them along the power-of-two family, exhibiting the exact-$\\log_2$ growth on the extremal trajectories."
+    "content": "Immediate specialisations of $\\sigma(2^k) = k$: $\\sigma(1) = 0$, $\\sigma(2) = 1$, $\\sigma(4) = 2$, $\\sigma(8) = 3$, $\\sigma(16) = 4$. These match the two values proved in the parent entry ($\\sigma(1), \\sigma(2)$) and extend them along the power-of-two family, exhibiting the exact-$\\log_2$ growth on the extremal trajectories.",
+    "mathContext": "$\\sigma(1)=0,\\ \\sigma(2)=1,\\ \\sigma(4)=2,\\ \\sigma(8)=3,\\ \\sigma(16)=4$ — the extremal $\\sigma(2^k)=k$ family.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "stopping time", "power of two", "extremal trajectory"],
+    "prerequisites": ["Collatz stopping time"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `collatz-structured-oq-03-oq-03` (quality 68, 0 prior passes).

## Gap
8 well-written annotations existed but **every one lacked `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`**.

## Changes
Added all four depth fields to all 8 annotations (module header, definitions, the monovariant, the iterated bound, the main lower bound n ≤ 2^σ(n), the real-valued log₂ form, tightness σ(2^k)=k, and the concrete power-of-two corollaries). Assigned `critical` significance to the two load-bearing steps (the monovariant and the main bound). Content preserved verbatim; types were already canonical.

## Validation
`validateLineAnnotations` against the Lean source: **8 valid, 0 misaligned.**