### PR TITLE
research(matrix-posdef-sqrt-oq-01-oq-01): polar decomposition A = U·√(AᴴA) from PSD square root [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MatrixPosDefSqrtOQ01OQ01.lean
+++ b/proofs/Proofs/MatrixPosDefSqrtOQ01OQ01.lean
@@ -1,0 +1,183 @@
+/-
+  Polar decomposition of a matrix from the positive semidefinite square root.
+
+  This entry answers the first open question of the PSD-square-root entry
+  (`matrix-posdef-sqrt-oq-01`): *"Can the polar decomposition `A = U · P` be
+  formalised, with `P = √(AᴴA)` positive semidefinite and `U` unitary?"*
+
+  Working over `𝕜 = ℝ` or `ℂ` (`RCLike 𝕜`), we build the **right polar
+  factor** `P = √(AᴴA)` from the continuous-functional-calculus square root
+  `CFC.sqrt` and package the polar decomposition:
+
+    * **Uniqueness of the PSD factor (no hypothesis on `A`).**  If `A = U · P`
+      with `U` unitary and `P` positive semidefinite, then necessarily
+      `P = √(AᴴA)`.  This is the structural heart: it follows purely from
+      `AᴴA = Pᴴ (UᴴU) P = P²` and the uniqueness of the PSD square root, and it
+      needs *no* invertibility of `A`.
+
+    * **Existence (invertible `A`).**  For an invertible matrix `A` the factor
+      `P = √(AᴴA)` is itself invertible, and `U := A · P⁻¹` is unitary with
+      `A = U · P`.  This is the classical polar decomposition in the regular
+      (generic) case, where both factors are honestly recovered.
+
+    * **Full uniqueness (invertible `A`).**  For invertible `A` the pair
+      `(U, P)` is unique: any two right polar decompositions coincide.
+
+    * **Left polar decomposition.**  Applying the right decomposition to `Aᴴ`
+      and transposing yields `A = P' · U'` with `P' = √(A Aᴴ)` positive
+      semidefinite and `U'` unitary — the mirror form.
+
+  The unitary factor is expressed as membership in `unitary (Matrix n n 𝕜)`,
+  i.e. `star U * U = 1 ∧ U * star U = 1` with `star` the conjugate transpose.
+
+  Scope note: only the *invertible* case is claimed for existence.  The general
+  (possibly singular) square-matrix polar decomposition additionally requires
+  extending a partial isometry supported on `range Aᴴ` to a full unitary, which
+  is not developed here.  The uniqueness-of-`P` statement, however, is fully
+  general.
+
+  Verified: 0 sorries, 0 axioms beyond the foundational `propext` /
+  `Classical.choice` / `Quot.sound`; no `native_decide`, no `Lean.ofReduceBool`.
+-/
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Tactic
+
+open Matrix
+open scoped MatrixOrder ComplexOrder
+
+namespace MatrixPosDefSqrtOQ01OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n] [DecidableEq n]
+
+/-! ### The positive semidefinite polar factor `√(AᴴA)` -/
+
+/-- The right polar factor of `A`, the positive semidefinite square root of
+`Aᴴ · A`. -/
+noncomputable def polarFactor (A : Matrix n n 𝕜) : Matrix n n 𝕜 :=
+  CFC.sqrt (Aᴴ * A)
+
+/-- The polar factor is positive semidefinite. -/
+theorem polarFactor_posSemidef (A : Matrix n n 𝕜) : (polarFactor A).PosSemidef :=
+  (CFC.sqrt_nonneg (Aᴴ * A)).posSemidef
+
+/-- The defining property of the polar factor: `(√(AᴴA))² = AᴴA`. -/
+theorem polarFactor_mul_self (A : Matrix n n 𝕜) :
+    polarFactor A * polarFactor A = Aᴴ * A :=
+  CFC.sqrt_mul_sqrt_self (Aᴴ * A) (posSemidef_conjTranspose_mul_self A).nonneg
+
+/-! ### Uniqueness of the PSD factor (fully general) -/
+
+/-- **Uniqueness of the positive semidefinite polar factor.**  If `A = U · P`
+with `U` unitary and `P` positive semidefinite, then `P` is forced to be the
+polar factor `√(AᴴA)`.  No invertibility of `A` is required. -/
+theorem polar_psd_unique (A U P : Matrix n n 𝕜)
+    (hU : U ∈ unitary (Matrix n n 𝕜)) (hP : P.PosSemidef) (h : A = U * P) :
+    P = polarFactor A := by
+  have huu : Uᴴ * U = 1 := by
+    have := Unitary.star_mul_self_of_mem hU
+    rwa [star_eq_conjTranspose] at this
+  have hAHA : Aᴴ * A = P * P := by
+    subst h
+    rw [conjTranspose_mul, hP.isHermitian]
+    rw [mul_assoc, ← mul_assoc Uᴴ U P, huu, one_mul]
+  exact (CFC.sqrt_unique hAHA.symm hP.nonneg).symm
+
+/-! ### Invertibility of the polar factor for invertible `A` -/
+
+/-- For an invertible matrix `A`, the polar factor `√(AᴴA)` is invertible. -/
+theorem polarFactor_isUnit_det (A : Matrix n n 𝕜) (hA : IsUnit A) :
+    IsUnit (polarFactor A).det := by
+  have hdetA : A.det ≠ 0 :=
+    isUnit_iff_ne_zero.mp ((isUnit_iff_isUnit_det A).mp hA)
+  have key : (polarFactor A).det * (polarFactor A).det = star A.det * A.det := by
+    have h := congrArg det (polarFactor_mul_self A)
+    rwa [det_mul, det_mul, det_conjTranspose] at h
+  have hRHS : star A.det * A.det ≠ 0 :=
+    mul_ne_zero (star_ne_zero.mpr hdetA) hdetA
+  have hne : (polarFactor A).det ≠ 0 := by
+    intro h
+    rw [h, zero_mul] at key
+    exact hRHS key.symm
+  exact isUnit_iff_ne_zero.mpr hne
+
+/-! ### Existence: the right polar decomposition `A = U · √(AᴴA)` -/
+
+/-- **Right polar decomposition (invertible case).**  Every invertible matrix
+`A` factors as `A = U · P` with `U` unitary and `P = √(AᴴA)` positive
+semidefinite (and invertible). -/
+theorem polar_right (A : Matrix n n 𝕜) (hA : IsUnit A) :
+    ∃ U : Matrix n n 𝕜, U ∈ unitary (Matrix n n 𝕜) ∧ A = U * polarFactor A := by
+  set P := polarFactor A with hPdef
+  have hPpsd : P.PosSemidef := polarFactor_posSemidef A
+  have hPsq : P * P = Aᴴ * A := polarFactor_mul_self A
+  have hPunit : IsUnit P.det := polarFactor_isUnit_det A hA
+  have hinvmul : P⁻¹ * P = 1 := nonsing_inv_mul P hPunit
+  have hmulinv : P * P⁻¹ = 1 := mul_nonsing_inv P hPunit
+  have hPinv_herm : (P⁻¹)ᴴ = P⁻¹ := by
+    rw [conjTranspose_nonsing_inv, hPpsd.isHermitian]
+  refine ⟨A * P⁻¹, ?_, ?_⟩
+  · -- `A · P⁻¹` is unitary
+    have hstarU : star (A * P⁻¹) = P⁻¹ * Aᴴ := by
+      rw [Matrix.star_mul, star_eq_conjTranspose, star_eq_conjTranspose, hPinv_herm]
+    have h1 : star (A * P⁻¹) * (A * P⁻¹) = 1 := by
+      rw [hstarU]
+      have e1 : P⁻¹ * Aᴴ * (A * P⁻¹) = P⁻¹ * (Aᴴ * A) * P⁻¹ := by noncomm_ring
+      rw [e1, ← hPsq]
+      have e2 : P⁻¹ * (P * P) * P⁻¹ = (P⁻¹ * P) * (P * P⁻¹) := by noncomm_ring
+      rw [e2, hinvmul, hmulinv, one_mul]
+    have h2 : (A * P⁻¹) * star (A * P⁻¹) = 1 := Matrix.mul_eq_one_comm.mp h1
+    exact Unitary.mem_iff.mpr ⟨h1, h2⟩
+  · -- `A = (A · P⁻¹) · P`
+    rw [mul_assoc, hinvmul, mul_one]
+
+/-! ### Full uniqueness (invertible case) -/
+
+/-- **Uniqueness of the right polar decomposition.**  For an invertible matrix
+`A`, any two right polar decompositions `A = U₁ · P₁ = U₂ · P₂` (with the `Uᵢ`
+unitary and `Pᵢ` positive semidefinite) coincide. -/
+theorem polar_right_unique (A U₁ P₁ U₂ P₂ : Matrix n n 𝕜) (hA : IsUnit A)
+    (hU1 : U₁ ∈ unitary (Matrix n n 𝕜)) (hP1 : P₁.PosSemidef) (h1 : A = U₁ * P₁)
+    (hU2 : U₂ ∈ unitary (Matrix n n 𝕜)) (hP2 : P₂.PosSemidef) (h2 : A = U₂ * P₂) :
+    U₁ = U₂ ∧ P₁ = P₂ := by
+  have hPeq1 : P₁ = polarFactor A := polar_psd_unique A U₁ P₁ hU1 hP1 h1
+  have hPeq2 : P₂ = polarFactor A := polar_psd_unique A U₂ P₂ hU2 hP2 h2
+  have hPeq : P₁ = P₂ := hPeq1.trans hPeq2.symm
+  have hP1u : IsUnit P₁.det := by rw [hPeq1]; exact polarFactor_isUnit_det A hA
+  have hu1 : U₁ = A * P₁⁻¹ := by
+    rw [h1, mul_assoc, mul_nonsing_inv P₁ hP1u, mul_one]
+  have hP2u : IsUnit P₂.det := by rw [hPeq2]; exact polarFactor_isUnit_det A hA
+  have hu2 : U₂ = A * P₂⁻¹ := by
+    rw [h2, mul_assoc, mul_nonsing_inv P₂ hP2u, mul_one]
+  exact ⟨by rw [hu1, hu2, hPeq], hPeq⟩
+
+/-! ### The left polar decomposition `A = √(AAᴴ) · U` -/
+
+/-- **Left polar decomposition (invertible case).**  Every invertible matrix
+`A` factors as `A = P · U` with `P = √(A Aᴴ)` positive semidefinite and `U`
+unitary — the mirror image of the right decomposition, obtained by transposing
+the right decomposition of `Aᴴ`. -/
+theorem polar_left (A : Matrix n n 𝕜) (hA : IsUnit A) :
+    ∃ P U : Matrix n n 𝕜,
+      P.PosSemidef ∧ U ∈ unitary (Matrix n n 𝕜) ∧
+        P = CFC.sqrt (A * Aᴴ) ∧ A = P * U := by
+  have hAH : IsUnit Aᴴ := by
+    refine (isUnit_iff_isUnit_det Aᴴ).mpr ?_
+    rw [det_conjTranspose]
+    exact ((isUnit_iff_isUnit_det A).mp hA).star
+  obtain ⟨V, hV, hVeq⟩ := polar_right Aᴴ hAH
+  refine ⟨polarFactor Aᴴ, Vᴴ, polarFactor_posSemidef Aᴴ, ?_, ?_, ?_⟩
+  · -- `Vᴴ` is unitary
+    rw [← star_eq_conjTranspose]
+    exact Unitary.star_mem hV
+  · -- `polarFactor Aᴴ = √(A Aᴴ)`
+    rw [polarFactor, conjTranspose_conjTranspose]
+  · -- `A = polarFactor Aᴴ · Vᴴ`
+    have := congrArg conjTranspose hVeq
+    rw [conjTranspose_conjTranspose, conjTranspose_mul,
+      (polarFactor_posSemidef Aᴴ).isHermitian] at this
+    exact this
+
+end MatrixPosDefSqrtOQ01OQ01

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "matrix-posdef-sqrt-oq-01-oq-01",
+  "slug": "matrix-posdef-sqrt-oq-01-oq-01",
+  "title": "Polar Decomposition A = U·√(AᴴA) from the Positive Semidefinite Square Root",
+  "description": "Building the polar decomposition of a matrix from the PSD square root: the positive semidefinite factor P = √(AᴴA) is forced by any decomposition A = U·P with U unitary (uniqueness of P, no invertibility needed); for invertible A the unitary factor U = A·P⁻¹ is recovered and the pair (U, P) is unique; and transposing gives the left form A = √(AAᴴ)·U.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Matrix.Order",
+      "Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic",
+      "Mathlib.LinearAlgebra.Matrix.NonsingularInverse",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "MatrixOrder",
+      "ComplexOrder"
+    ],
+    "namespace": "MatrixPosDefSqrtOQ01OQ01",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/MatrixPosDefSqrtOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polar_decomposition",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MatrixPosDefSqrtOQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "polar-decomposition",
+      "positive-semidefinite",
+      "square-root",
+      "unitary",
+      "continuous-functional-calculus"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "matrix-posdef-sqrt-oq-01",
+        "relationship": "Direct parent: this entry answers its first open question, 'Can the polar decomposition A = U·P be formalised, with P = √(AᴴA) positive semidefinite and U unitary?', reusing the PSD-square-root triad (CFC.sqrt existence, structure, uniqueness) established there."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 183,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All four packaged theorems (polar_psd_unique, polar_right, polar_right_unique, polar_left) depend only on the foundational propext / Classical.choice / Quot.sound. The square root is Mathlib's C⋆-algebraic CFC.sqrt; the PSD polar factor is defined as polarFactor A = CFC.sqrt (Aᴴ · A), positive semidefinite via CFC.sqrt_nonneg with LE.le.posSemidef and satisfying polarFactor A · polarFactor A = Aᴴ · A via CFC.sqrt_mul_sqrt_self applied to Matrix.posSemidef_conjTranspose_mul_self. Uniqueness of the PSD factor is fully general (no invertibility of A): from A = U·P with U unitary and P PSD one computes Aᴴ·A = Pᴴ·(Uᴴ·U)·P = P·P using Matrix.PosSemidef.isHermitian and Unitary.star_mul_self_of_mem, and CFC.sqrt_unique forces P = √(AᴴA). Existence and full uniqueness are stated only for invertible A (hypothesis IsUnit A): the polar factor is then invertible because det(√(AᴴA))² = det(Aᴴ·A) = star(det A)·det A ≠ 0 (Matrix.det_conjTranspose, Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero), so U := A·P⁻¹ is unitary via Matrix.nonsing_inv_mul / Matrix.mul_nonsing_inv / Matrix.conjTranspose_nonsing_inv and Matrix.mul_eq_one_comm. The left form A = √(AAᴴ)·U is obtained by applying the right decomposition to Aᴴ and transposing (Matrix.conjTranspose_mul, Unitary.star_mem). The genuine hypotheses are P.PosSemidef, U ∈ unitary, and IsUnit A where stated.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The polar decomposition is the matrix analogue of the polar form z = r·e^{iθ} of a complex number: every square matrix A factors as a positive semidefinite 'modulus' times a unitary 'phase'. It is one of the direct payoffs of the positive semidefinite square root — the modulus is exactly the operator absolute value |A| = √(AᴴA) — and it underlies the singular value decomposition, the operator geometric mean, and orthogonal Procrustes / whitening problems in statistics. For invertible A the decomposition is unique; in the general singular case the unitary factor is only determined up to its action on ker A (and one must extend a partial isometry to a full unitary). This entry builds the decomposition on top of the PSD-square-root entry and isolates exactly which part needs invertibility.",
+    "problemStatement": "Over $\\mathbb R$ or $\\mathbb C$, given the positive semidefinite square root $\\sqrt{\\cdot}$, formalise the (right) polar decomposition $A = U\\cdot P$ with $P = \\sqrt{A^{\\mathsf H}A}$ positive semidefinite and $U$ unitary. Show that the PSD factor $P$ is uniquely determined by any such decomposition (no invertibility of $A$ needed); that for invertible $A$ the unitary factor $U = A\\,P^{-1}$ exists and the pair $(U,P)$ is unique; and that transposing yields the left form $A = \\sqrt{AA^{\\mathsf H}}\\cdot U$.",
+    "proofStrategy": "The PSD factor is defined directly as `polarFactor A = CFC.sqrt (Aᴴ·A)`, inheriting positive semidefiniteness and the defining identity `polarFactor A · polarFactor A = Aᴴ·A` from the parent square-root theory. Uniqueness of the PSD factor is the structural core and needs no invertibility: if `A = U·P` with `U` unitary and `P` PSD, then `Aᴴ·A = Pᴴ·(Uᴴ·U)·P = P·P` (using `Pᴴ = P` and `Uᴴ·U = 1`), so `P = √(AᴴA)` by uniqueness of the PSD square root. Existence for invertible `A` recovers the unitary factor explicitly as `U := A·P⁻¹`: the polar factor is invertible because `det(√(AᴴA))² = det(Aᴴ·A) = |det A|² ≠ 0`, and then `(A·P⁻¹)ᴴ·(A·P⁻¹) = P⁻¹·(Aᴴ·A)·P⁻¹ = P⁻¹·P²·P⁻¹ = 1`, with the second unitary identity following from `Matrix.mul_eq_one_comm`. Full uniqueness follows since both factors are then pinned: `P = √(AᴴA)` and `U = A·P⁻¹`. The left decomposition is the right decomposition of `Aᴴ` read backwards through conjugate transposition.",
+    "text": "Mathlib carries the C⋆-algebraic square root CFC.sqrt but no polar decomposition of matrices. This entry supplies the right polar decomposition A = U·√(AᴴA) and its mirror A = √(AAᴴ)·U, and — the mathematically load-bearing part — proves that the positive semidefinite factor is forced by the decomposition without any regularity hypothesis on A. Existence of the unitary factor and full uniqueness of the pair are proved in the invertible (generic) case, where U = A·√(AᴴA)⁻¹ is honestly recovered. The general singular case, which requires extending a partial isometry on range Aᴴ to a full unitary, is left out of scope and flagged as such.",
+    "keyInsights": [
+      "**The PSD factor is forced with no invertibility hypothesis.** From any A = U·P with U unitary and P positive semidefinite, the product AᴴA collapses: AᴴA = Pᴴ·(Uᴴ·U)·P = P·(1)·P = P·P, because P is Hermitian and Uᴴ·U = 1. Uniqueness of the PSD square root (CFC.sqrt_unique) then forces P = √(AᴴA). This is the structural heart of polar decomposition and it is completely general — the modulus |A| = √(AᴴA) is intrinsic, only the phase U can be ambiguous.",
+      "**Invertibility of A transfers to its polar factor through the determinant.** Applying det to (√(AᴴA))² = Aᴴ·A gives det(√(AᴴA))² = det Aᴴ · det A = star(det A)·det A = |det A|². When A is invertible this is nonzero, so the polar factor has nonzero determinant and is invertible — exactly the hypothesis needed to write U = A·P⁻¹.",
+      "**The unitary factor is an explicit formula, not an abstract existence.** For invertible A one simply sets U := A·√(AᴴA)⁻¹ and checks UᴴU = 1 by cancelling: P⁻¹·(AᴴA)·P⁻¹ = P⁻¹·P²·P⁻¹ = 1. For square matrices a single one-sided identity suffices (Matrix.mul_eq_one_comm), so the two unitarity conditions come for the price of one.",
+      "**Full uniqueness is a corollary of the two factor computations.** Once P = √(AᴴA) is forced and P is invertible, U = A·P⁻¹ is determined; hence any two right polar decompositions of an invertible matrix coincide in both factors. No separate argument is required.",
+      "**Left and right decompositions are conjugate-transpose reflections of each other.** The left form A = √(AAᴴ)·U is obtained by decomposing Aᴴ = V·√(AAᴴ) on the right and transposing: A = (Aᴴ)ᴴ = √(AAᴴ)ᴴ·Vᴴ = √(AAᴴ)·Vᴴ, using that the square root is Hermitian and that the conjugate transpose of a unitary is unitary."
+    ],
+    "prerequisites": [
+      "The positive semidefinite square root CFC.sqrt and its lemmas CFC.sqrt_nonneg, CFC.sqrt_mul_sqrt_self, CFC.sqrt_unique (parent entry matrix-posdef-sqrt-oq-01)",
+      "Positive semidefinite matrices and the Loewner order: Matrix.PosSemidef, Matrix.posSemidef_conjTranspose_mul_self, Matrix.PosSemidef.isHermitian, LE.le.posSemidef under scoped MatrixOrder",
+      "The unitary submonoid unitary (Matrix n n 𝕜) with Unitary.mem_iff, Unitary.star_mul_self_of_mem, Unitary.star_mem, and star = conjugate transpose (Matrix.star_eq_conjTranspose)",
+      "Nonsingular inverse API: Matrix.isUnit_iff_isUnit_det, Matrix.nonsing_inv_mul, Matrix.mul_nonsing_inv, Matrix.conjTranspose_nonsing_inv, Matrix.mul_eq_one_comm, Matrix.det_conjTranspose"
+    ]
+  },
+  "sections": [
+    {
+      "id": "polar-factor",
+      "title": "The positive semidefinite polar factor √(AᴴA)",
+      "startLine": 55,
+      "endLine": 69,
+      "summary": "Defines polarFactor A = CFC.sqrt (Aᴴ·A) and records its two basic properties: it is positive semidefinite, and its square is Aᴴ·A. These are immediate specializations of the parent square-root theory to the always-PSD matrix Aᴴ·A.",
+      "mathContext": "polarFactor_posSemidef uses CFC.sqrt_nonneg together with LE.le.posSemidef; polarFactor_mul_self uses CFC.sqrt_mul_sqrt_self on Matrix.posSemidef_conjTranspose_mul_self A."
+    },
+    {
+      "id": "psd-uniqueness",
+      "title": "Uniqueness of the PSD factor (fully general)",
+      "startLine": 71,
+      "endLine": 86,
+      "summary": "The structural core: if A = U·P with U unitary and P positive semidefinite, then P = √(AᴴA), with no hypothesis on A. Proof collapses Aᴴ·A to P·P using Pᴴ = P and Uᴴ·U = 1, then invokes uniqueness of the PSD square root.",
+      "mathContext": "polar_psd_unique. Uses Unitary.star_mul_self_of_mem, Matrix.star_eq_conjTranspose, Matrix.PosSemidef.isHermitian, and CFC.sqrt_unique."
+    },
+    {
+      "id": "polar-invertible",
+      "title": "Invertibility of the polar factor for invertible A",
+      "startLine": 88,
+      "endLine": 105,
+      "summary": "For invertible A the polar factor √(AᴴA) is invertible: det(√(AᴴA))² = star(det A)·det A ≠ 0, so its determinant is a unit.",
+      "mathContext": "polarFactor_isUnit_det. Uses Matrix.isUnit_iff_isUnit_det, isUnit_iff_ne_zero, Matrix.det_mul, Matrix.det_conjTranspose, and star_ne_zero."
+    },
+    {
+      "id": "polar-right",
+      "title": "Existence: the right polar decomposition A = U·√(AᴴA)",
+      "startLine": 106,
+      "endLine": 135,
+      "summary": "For invertible A, U := A·√(AᴴA)⁻¹ is unitary and A = U·√(AᴴA). Unitarity is checked by cancellation P⁻¹·(AᴴA)·P⁻¹ = 1, with the reverse identity from Matrix.mul_eq_one_comm.",
+      "mathContext": "polar_right. Uses nonsing_inv_mul, mul_nonsing_inv, conjTranspose_nonsing_inv, Matrix.star_mul, Matrix.mul_eq_one_comm, Unitary.mem_iff, and noncomm_ring for the associativity bookkeeping."
+    },
+    {
+      "id": "polar-right-unique",
+      "title": "Full uniqueness (invertible case)",
+      "startLine": 136,
+      "endLine": 155,
+      "summary": "For invertible A any two right polar decompositions coincide: the PSD factor is forced to √(AᴴA) by polar_psd_unique, and the unitary factor is then determined as A·P⁻¹.",
+      "mathContext": "polar_right_unique. Combines polar_psd_unique with polarFactor_isUnit_det and Matrix.mul_nonsing_inv."
+    },
+    {
+      "id": "polar-left",
+      "title": "The left polar decomposition A = √(AAᴴ)·U",
+      "startLine": 156,
+      "endLine": 183,
+      "summary": "The mirror form: for invertible A there is a PSD P = √(AAᴴ) and unitary U with A = P·U, obtained by decomposing Aᴴ on the right and transposing.",
+      "mathContext": "polar_left. Uses polar_right on Aᴴ, Matrix.conjTranspose_mul, conjTranspose_conjTranspose, IsUnit.star, and Unitary.star_mem."
+    }
+  ],
+  "conclusion": {
+    "summary": "The polar decomposition is formalised sorry-free and axiom-free on top of the PSD square root. The positive semidefinite factor P = √(AᴴA) is proved to be uniquely determined by any decomposition A = U·P with U unitary and P PSD, with no invertibility hypothesis; for invertible A the unitary factor U = A·P⁻¹ is recovered explicitly and the pair (U, P) is unique; and the left form A = √(AAᴴ)·U is obtained by transposition.",
+    "implications": "The original content is the matrix-level assembly of the polar decomposition from Mathlib's C⋆-algebraic square root, and in particular the observation that the modulus |A| = √(AᴴA) is intrinsic — forced with no regularity assumption — while only the unitary phase can be ambiguous. Existence and full uniqueness are proved in the invertible (generic) case, giving the classical polar decomposition where both factors are honestly recovered.",
+    "openQuestions": [
+      "Can the existence half be extended to singular square matrices, where the unitary factor requires extending a partial isometry on range Aᴴ to a full unitary?",
+      "Can the operator absolute value |A| = √(AᴴA) and the norm identity ‖A x‖ = ‖|A| x‖ be derived directly from polar_psd_unique?",
+      "Does uniqueness of the unitary factor fail exactly on the kernel of A, and can that failure be characterised (U determined up to a unitary on ker A)?"
+    ]
+  },
+  "crossReferences": [
+    "matrix-posdef-sqrt-oq-01"
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **open question 1** of `matrix-posdef-sqrt-oq-01`:
*"Can the polar decomposition A = U·P be formalised, with P = √(AᴴA) positive semidefinite and U unitary?"*

Builds the polar decomposition on top of the parent's PSD-square-root theory (Mathlib `CFC.sqrt`), over `𝕜 = ℝ` or `ℂ` (`RCLike`).

## Theorems (7 thm / 1 def / 183 L)

- **`polar_psd_unique`** — the PSD factor is *forced*: any `A = U·P` with `U` unitary and `P` PSD has `P = √(AᴴA)`. **Fully general — no invertibility of `A`.** This is the structural heart (the modulus `|A| = √(AᴴA)` is intrinsic; only the unitary phase can be ambiguous).
- **`polar_right`** — existence for invertible `A`: `U := A·√(AᴴA)⁻¹` is unitary and `A = U·√(AᴴA)`.
- **`polar_right_unique`** — the pair `(U, P)` is unique for invertible `A`.
- **`polar_left`** — mirror form `A = √(AAᴴ)·U`, obtained by decomposing `Aᴴ` and transposing.
- Plus `polarFactor` (def), `polarFactor_posSemidef`, `polarFactor_mul_self`, `polarFactor_isUnit_det`.

## Verification

`#print axioms` on all four packaged theorems: `[propext, Classical.choice, Quot.sound]` only. **0 sorries, 0 axioms**, no `native_decide`, no `Lean.ofReduceBool`. Compiled against Mathlib v4.26.0.

## Scope / honesty

Existence and full uniqueness are claimed **only for invertible `A`** (the classical regular case, where both factors are honestly recovered). The general singular case additionally needs extending a partial isometry on `range Aᴴ` to a full unitary — explicitly left out of scope and flagged in the entry. The uniqueness-of-`P` statement, however, is fully general.

🤖 Generated with [Claude Code](https://claude.com/claude-code)