### PR TITLE
Enrich standard-normal moments (area-of-circle-oq-05-incomplete-01-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/annotations.source.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/annotations.source.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-moments-overview",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "block-comment", "contains": "Moments of the standard normal" },
+    "type": "concept",
+    "title": "Moments of the Standard Normal",
+    "content": "Once the Gaussian integral $\\int e^{-x^2}\\,dx=\\sqrt\\pi$ (the parent 'area-of-circle' strand) fixes the normalization, the shape of $\\mathcal N(0,1)$ is captured by its **moments** $\\mathbb E[X^k]$. The odd moments vanish by symmetry and the even moments follow the double factorial: $\\mathbb E[X^{2k}]=(2k-1)!!$. This file settles the structurally decisive first cases — mean $0$, variance $1$, second moment $\\mathbb E[X^2]=1$ — and records the moment-generating function $\\exp(t^2/2)$ that encodes the whole sequence, answering the first strand of the parent's open question OQ-01.",
+    "mathContext": "$\\mathbb E[X^{2k}]=(2k-1)!!$, $\\mathbb E[X^{2k+1}]=0$; here $k\\le 1$ plus the MGF.",
+    "significance": "key",
+    "relatedConcepts": ["moments", "normal distribution", "Gaussian integral", "moment-generating function"],
+    "prerequisites": ["expectation and variance", "the Gaussian integral"]
+  },
+  {
+    "id": "ann-stdnormal-def",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal", "kind": "def" },
+    "type": "definition",
+    "title": "The Standard Normal Measure",
+    "content": "`stdNormal := gaussianReal 0 1` reuses Mathlib's Gaussian *measure* with mean `0` and variance `1`, rather than re-deriving the density. Working at the level of the measure (not the density) is what gives direct access to the library's moment API — `integral_id_gaussianReal`, `variance_id_gaussianReal`, `mgf_id_gaussianReal`. The accompanying `IsProbabilityMeasure` instance (total mass 1) is inherited automatically via `infer_instance`, so all expectations are genuine averages.",
+    "mathContext": "$\\mathcal N(0,1)$ as a probability measure on $\\mathbb R$.",
+    "significance": "supporting",
+    "relatedConcepts": ["gaussianReal", "probability measure", "IsProbabilityMeasure"],
+    "prerequisites": ["measure theory", "probability measures"]
+  },
+  {
+    "id": "ann-stdnormal-mean",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal_mean", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Mean = 0 (the Base Odd Moment)",
+    "content": "$\\mathbb E[X]=\\int x\\,d\\mathcal N(0,1)=0$ is a one-line specialization of `integral_id_gaussianReal` at $\\mu=0$. It plays a double role downstream: it is the $k=0$ case of the vanishing odd moments $\\mathbb E[X^{2k+1}]=0$, and — crucially — it is what makes the variance integral $\\int(x-\\mathbb E[X])^2$ collapse to the raw second moment $\\int x^2$ in the next lemma.",
+    "mathContext": "$\\mathbb E[X]=\\mu=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["first moment", "symmetry of the density"],
+    "prerequisites": ["expectation"]
+  },
+  {
+    "id": "ann-stdnormal-variance",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal_variance", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Variance = 1",
+    "content": "$\\mathrm{Var}[X]=1$ specializes `variance_id_gaussianReal` at variance parameter $v=1$; the trailing `simp` discharges the cast of the parameter. The Lean notation `Var[id ; stdNormal]` is the variance of the identity random variable under the measure. This is the raw material for the second moment: for a centered distribution, variance and second moment coincide.",
+    "mathContext": "$\\mathrm{Var}[X]=v=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["variance", "variance_id_gaussianReal"],
+    "prerequisites": ["variance"]
+  },
+  {
+    "id": "ann-stdnormal-second-moment",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal_second_moment", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Second Moment E[X²] = 1 via a Vanishing Mean",
+    "content": "The first genuinely *even* moment. The key move needs no new integral: `variance_eq_integral` rewrites $\\mathrm{Var}[X]=\\int(x-\\mathbb E[X])^2$, and substituting the just-proved $\\mathbb E[X]=0$ collapses the integrand $(x-0)^2=x^2$, so $\\int x^2=\\mathrm{Var}[X]=1$. This is the identity 'for a mean-zero variable the variance IS the second moment', and it is why $\\mathbb E[X^2]$ falls out for free rather than requiring a separate Gaussian moment integral.",
+    "mathContext": "$\\mathbb E[X^2]=\\int(x-0)^2\\,d\\mathcal N(0,1)=\\mathrm{Var}[X]=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["second moment", "variance_eq_integral", "centered random variable"],
+    "prerequisites": ["variance", "expectation"]
+  },
+  {
+    "id": "ann-gaussianpdf-std",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "gaussianPDFReal_std", "kind": "theorem" },
+    "type": "lemma",
+    "title": "Matching Mathlib's Density to the Concrete Bell Curve",
+    "content": "Identifies Mathlib's abstract `gaussianPDFReal 0 1 x` with the parent file's explicit density $\\frac{1}{\\sqrt{2\\pi}}e^{-x^2/2}$. Unfolding the library definition and normalizing ($\\mu=0$, $\\sigma^2=1$) via `push_cast`/`ring_nf` collapses the general $\\frac{1}{\\sigma\\sqrt{2\\pi}}e^{-(x-\\mu)^2/(2\\sigma^2)}$ to the standard form. This equation is the hinge that lets abstract measure-level results be restated in the parent's elementary Lebesgue-integral idiom.",
+    "mathContext": "$\\text{gaussianPDFReal }0\\ 1\\ x = \\frac{1}{\\sqrt{2\\pi}}e^{-x^2/2}$.",
+    "significance": "key",
+    "relatedConcepts": ["gaussianPDFReal", "probability density function", "normalization constant"],
+    "prerequisites": ["Gaussian density"]
+  },
+  {
+    "id": "ann-second-moment-concrete",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal_second_moment_concrete", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Second Moment in the Concrete Density Idiom",
+    "content": "Transports $\\mathbb E[X^2]=1$ from the abstract measure to the parent's concrete integral $\\int x^2\\cdot\\frac{1}{\\sqrt{2\\pi}}e^{-x^2/2}\\,dx=1$. The bridge is `integral_gaussianReal_eq_integral_smul`, the `withDensity` change-of-measure law rewriting any $\\int f\\,d\\mathcal N(0,1)$ as the density-weighted Lebesgue integral $\\int \\text{pdf}(x)\\cdot f(x)\\,dx$. Combined with `gaussianPDFReal_std` (to name the density) and a pointwise `integral_congr_ae` + `ring`, the abstract second moment becomes the classical textbook integral.",
+    "mathContext": "$\\int x^2\\cdot\\tfrac{1}{\\sqrt{2\\pi}}e^{-x^2/2}\\,dx=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["withDensity", "change of measure", "integral_gaussianReal_eq_integral_smul"],
+    "prerequisites": ["Lebesgue integral", "densities and change of measure"]
+  },
+  {
+    "id": "ann-stdnormal-mgf",
+    "proofId": "area-of-circle-oq-05-incomplete-01-oq-01",
+    "anchor": { "type": "declaration", "name": "stdNormal_mgf", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Moment-Generating Function exp(t²/2)",
+    "content": "The MGF $M_X(t)=\\mathbb E[e^{tX}]=\\exp(t^2/2)$, from `mgf_id_gaussianReal` specialized to $\\mu=0,v=1$. This single function encodes *every* moment at once: its power series $\\sum_k \\frac{t^{2k}}{2^k k!}$ has no odd-power terms (so all odd moments vanish) and coefficient extraction gives $\\mathbb E[X^{2k}]=\\frac{(2k)!}{2^k k!}=(2k-1)!!$. It reduces the remaining strand of OQ-01 — the general even-moment formula — to Taylor-coefficient bookkeeping.",
+    "mathContext": "$M_X(t)=\\exp(t^2/2)=\\sum_{k\\ge0}\\frac{t^{2k}}{2^k k!}$, giving $\\mathbb E[X^{2k}]=(2k-1)!!$.",
+    "significance": "critical",
+    "relatedConcepts": ["moment-generating function", "double factorial", "Taylor coefficients", "even moments"],
+    "prerequisites": ["moment-generating functions", "power series"]
+  }
+]


### PR DESCRIPTION
## Summary

Adds line-by-line annotation coverage to **area-of-circle-oq-05-incomplete-01-oq-01** (*Moments of the Standard Normal: Mean, Variance, and the MGF*), which had a detailed `meta.json` but **no `annotations.json`** — the gap holding its quality score at 34.

Authored an anchor-based `annotations.source.json` (declaration/block-comment anchors) resolving to 8 annotations that cover the full 105-line proof:

- **Concept**: moments of $\mathcal N(0,1)$, the double-factorial even moments $(2k-1)!!$, and how this file settles the decisive first cases.
- **Definition**: `stdNormal` as Mathlib's `gaussianReal 0 1` and why working at the measure level unlocks the library moment API.
- **Theorems**: mean $=0$, variance $=1$, the second moment $\mathbb E[X^2]=1$ via the vanishing-mean collapse of the variance integral, the density-matching lemma `gaussianPDFReal_std`, the concrete-idiom transport via the `withDensity` bridge, and the MGF $\exp(t^2/2)$ that encodes the whole moment sequence.

Each annotation carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Verification

- `annotations:build` resolves all 8 anchors with **0 errors for this slug** (only pre-existing baseline errors in unrelated entries).
- Full-file coverage: ranges span lines 1–103 of 105.
- No changes to the Lean source; entry remains verified/0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)