### PR TITLE
research(erdos-458-oq-05): prime indices from Nat.nth + axiom-free base cases [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos458OQ05.lean
+++ b/proofs/Proofs/Erdos458OQ05.lean
@@ -1,0 +1,180 @@
+/-
+# Erdős #458 OQ-05 — Prime-index values from `Nat.nth`, and axiom-free base cases
+
+The parent `Erdos458Problem.lean` studies the LCM inequality
+
+    lcm(1, …, p_{k+1} - 1) < p_k · lcm(1, …, p_k)      (Erdős #458, OPEN)
+
+with `p_k = nthPrime k = Nat.nth Nat.Prime k`.  Its open question OQ-05 asks
+whether the prime-index *value* facts (`nthPrime 0 = 2`, …) can be obtained
+directly from the `Nat.nth` definition rather than asserted, and OQ-03 asks
+for verification of the conjecture for more values of `k`.
+
+This companion answers both, and additionally removes the `native_decide`
+dependency of the parent's base cases:
+
+* The prime-index values are extended to `nthPrime 5 = 13, …, nthPrime 10 = 31`,
+  each proved from `Nat.nth_count` (the `Nat.nth`/`Nat.count` Galois bridge)
+  together with kernel `decide`.  No `native_decide`, hence **no
+  `Lean.ofReduceBool`** — these are axiom-free.
+
+* The conjecture's base cases `k = 1, 2, 3, 4` are verified with kernel
+  `decide` (again avoiding `native_decide`), extending the parent's `k = 1, 2`
+  and making the verified instances genuinely axiom-free.
+
+Everything is self-contained (imports only Mathlib) and reproves `lcm_upto`
+and `nthPrime` so that each result is independently checkable and 0-axiom.
+
+Main results (0 axioms, 0 sorries, no `native_decide`):
+* `nthPrime_five … nthPrime_ten` — the 6th through 11th primes, from `Nat.nth`
+* `erdos458_base` — the conjecture instance holds for `k = 1, 2, 3, 4`
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos458OQ05
+
+/-- `lcm_upto n = lcm(1, 2, …, n)` (matches the parent definition). -/
+def lcm_upto (n : ℕ) : ℕ := (Finset.Icc 1 n).lcm id
+
+/-- The `k`-th prime, `p_k = Nat.nth Nat.Prime k` (matches the parent). -/
+noncomputable def nthPrime (k : ℕ) : ℕ := Nat.nth Nat.Prime k
+
+/-- Every `nthPrime` is prime. -/
+theorem nthPrime_prime (k : ℕ) : (nthPrime k).Prime :=
+  Nat.nth_mem_of_infinite Nat.infinite_setOf_prime k
+
+/-- `nthPrime` is strictly increasing. -/
+theorem nthPrime_strictMono : StrictMono nthPrime := fun _ _ hij =>
+  Nat.nth_strictMono Nat.infinite_setOf_prime hij
+
+/-!
+## Prime-index values from `Nat.nth`
+
+`Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` turns a proof that `n`
+is the `(Nat.count p n)`-th element of `p` into the value of `Nat.nth`.  With
+`Nat.count Nat.Prime n` (the number of primes `< n`) evaluated by `decide`,
+each prime index is pinned down without `native_decide`.
+-/
+
+/-- The 0th prime is `2` (included for a self-contained account). -/
+theorem nthPrime_zero : nthPrime 0 = 2 := by
+  show Nat.nth Nat.Prime 0 = 2
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_two
+  have hc : Nat.count Nat.Prime 2 = 0 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 1 = 3`. -/
+theorem nthPrime_one : nthPrime 1 = 3 := by
+  show Nat.nth Nat.Prime 1 = 3
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_three
+  have hc : Nat.count Nat.Prime 3 = 1 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 2 = 5`. -/
+theorem nthPrime_two : nthPrime 2 = 5 := by
+  show Nat.nth Nat.Prime 2 = 5
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 5 by decide)
+  have hc : Nat.count Nat.Prime 5 = 2 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 3 = 7`. -/
+theorem nthPrime_three : nthPrime 3 = 7 := by
+  show Nat.nth Nat.Prime 3 = 7
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 7 by decide)
+  have hc : Nat.count Nat.Prime 7 = 3 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 4 = 11`. -/
+theorem nthPrime_four : nthPrime 4 = 11 := by
+  show Nat.nth Nat.Prime 4 = 11
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 11 by decide)
+  have hc : Nat.count Nat.Prime 11 = 4 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 5 = 13`. -/
+theorem nthPrime_five : nthPrime 5 = 13 := by
+  show Nat.nth Nat.Prime 5 = 13
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 13 by decide)
+  have hc : Nat.count Nat.Prime 13 = 5 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 6 = 17`. -/
+theorem nthPrime_six : nthPrime 6 = 17 := by
+  show Nat.nth Nat.Prime 6 = 17
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 17 by decide)
+  have hc : Nat.count Nat.Prime 17 = 6 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 7 = 19`. -/
+theorem nthPrime_seven : nthPrime 7 = 19 := by
+  show Nat.nth Nat.Prime 7 = 19
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 19 by decide)
+  have hc : Nat.count Nat.Prime 19 = 7 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 8 = 23`. -/
+theorem nthPrime_eight : nthPrime 8 = 23 := by
+  show Nat.nth Nat.Prime 8 = 23
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 23 by decide)
+  have hc : Nat.count Nat.Prime 23 = 8 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 9 = 29`. -/
+theorem nthPrime_nine : nthPrime 9 = 29 := by
+  show Nat.nth Nat.Prime 9 = 29
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 29 by decide)
+  have hc : Nat.count Nat.Prime 29 = 9 := by decide
+  rwa [hc] at h
+
+/-- **New:** `nthPrime 10 = 31`. -/
+theorem nthPrime_ten : nthPrime 10 = 31 := by
+  show Nat.nth Nat.Prime 10 = 31
+  have h := Nat.nth_count (p := Nat.Prime) (show Nat.Prime 31 by decide)
+  have hc : Nat.count Nat.Prime 31 = 10 := by decide
+  rwa [hc] at h
+
+/-!
+## Axiom-free base cases of Erdős #458
+
+The conjecture instance for a given `k` is
+
+    lcm_upto (nthPrime (k+1) - 1) < nthPrime k * lcm_upto (nthPrime k).
+
+Rewriting the two prime values to literals reduces each instance to a decidable
+inequality between concrete naturals, closed by kernel `decide` (no
+`native_decide`).  This extends the parent's `k = 1, 2` to `k = 1, 2, 3, 4`.
+-/
+
+/-- Base case `k = 1`: `lcm_upto 4 < 3 · lcm_upto 3`  (12 < 18). -/
+theorem erdos458_k1 :
+    lcm_upto (nthPrime 2 - 1) < nthPrime 1 * lcm_upto (nthPrime 1) := by
+  rw [nthPrime_one, nthPrime_two]; decide
+
+/-- Base case `k = 2`: `lcm_upto 6 < 5 · lcm_upto 5`  (60 < 300). -/
+theorem erdos458_k2 :
+    lcm_upto (nthPrime 3 - 1) < nthPrime 2 * lcm_upto (nthPrime 2) := by
+  rw [nthPrime_two, nthPrime_three]; decide
+
+/-- Base case `k = 3`: `lcm_upto 10 < 7 · lcm_upto 7`  (2520 < 2940). -/
+theorem erdos458_k3 :
+    lcm_upto (nthPrime 4 - 1) < nthPrime 3 * lcm_upto (nthPrime 3) := by
+  rw [nthPrime_three, nthPrime_four]; decide
+
+/-- Base case `k = 4`: `lcm_upto 12 < 11 · lcm_upto 11`  (27720 < 304920). -/
+theorem erdos458_k4 :
+    lcm_upto (nthPrime 5 - 1) < nthPrime 4 * lcm_upto (nthPrime 4) := by
+  rw [nthPrime_four, nthPrime_five]; decide
+
+/-- **Packaged base cases.**  Erdős #458 holds for `k ∈ {1, 2, 3, 4}`. -/
+theorem erdos458_base (k : ℕ) (hk : 1 ≤ k) (hk4 : k ≤ 4) :
+    lcm_upto (nthPrime (k + 1) - 1) < nthPrime k * lcm_upto (nthPrime k) := by
+  interval_cases k
+  · exact erdos458_k1
+  · exact erdos458_k2
+  · exact erdos458_k3
+  · exact erdos458_k4
+
+end Erdos458OQ05

--- a/src/data/proofs/erdos-458-oq-05/meta.json
+++ b/src/data/proofs/erdos-458-oq-05/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "erdos-458-oq-05",
+  "title": "Erdős #458: Prime Indices from Nat.nth, and Axiom-Free Base Cases",
+  "slug": "erdos-458-oq-05",
+  "description": "Answers OQ-05 of Erdős #458 (LCM inequality for primes): the prime-index values p_k = Nat.nth Nat.Prime k are proved directly from the Nat.nth/Nat.count Galois bridge — extended here to the 11th prime (p_10 = 31) — using kernel `decide` with no `native_decide`, hence no `Lean.ofReduceBool`. The conjecture's base cases k = 1,2,3,4 are likewise verified axiom-free, extending the parent's k = 1,2. Verified, 0 axioms.",
+  "meta": {
+    "author": "Erdős–Graham (problem); Lean formalization by Lean Genius Research Agent",
+    "sourceUrl": "https://erdosproblems.com/458",
+    "date": "Problem: Erdős–Graham (1980); formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos458OQ05.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "lcm",
+      "primes",
+      "nth-prime",
+      "axiom-free"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 458,
+    "erdosUrl": "https://erdosproblems.com/458",
+    "erdosProblemStatus": "open",
+    "axiomCount": 0,
+    "lineCount": 180,
+    "assumptions": "None. All 18 theorems verified with 0 sorries and 0 axioms — crucially with kernel `decide` only (no `native_decide`), so #print axioms shows only propext / Classical.choice / Quot.sound and NOT `Lean.ofReduceBool`. Self-contained: reproves lcm_upto and nthPrime, importing only Mathlib.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 18,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Erdős #458 asks whether lcm(1,…,p_{k+1}-1) < p_k · lcm(1,…,p_k) for every k ≥ 1, where p_k is the k-th prime — an open problem in combinatorial number theory. The parent formalization erdos-458 sets up the statement with p_k = Nat.nth Nat.Prime k and verifies the first base cases, but relies on `native_decide` (which trusts compiled evaluation via the `Lean.ofReduceBool` axiom) and asks in OQ-05 whether the prime-index values can instead be obtained purely from the `Nat.nth` definition.",
+    "problemStatement": "OQ-05 of the parent entry: eliminate the reliance on asserted / compiler-trusted prime-index facts by deriving p_k = Nat.nth Nat.Prime k from the definition, and (OQ-03) verify the conjecture for more k. This entry does both with kernel `decide` only, so every result is genuinely axiom-free (no `Lean.ofReduceBool`).",
+    "text": "The bridge is `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n`: knowing that n satisfies p and that exactly `Nat.count p n` elements below n satisfy p pins Nat.nth p at that index to n. Instantiating p = Nat.Prime at each prime n ∈ {2,3,5,7,11,13,17,19,23,29,31} and evaluating `Nat.count Nat.Prime n` by kernel `decide` yields p_0 = 2, …, p_10 = 31. The conjecture instances for k = 1,2,3,4 then rewrite the two prime values to literals and reduce to a decidable inequality between concrete naturals, closed by kernel `decide`.",
+    "proofStrategy": "For each prime value: `show Nat.nth Nat.Prime k = n`, obtain `Nat.nth_count` at a primality proof of n, evaluate `Nat.count Nat.Prime n = k` by `decide`, and rewrite. For each base case k: state the parent's conjecture instance `lcm_upto (nthPrime (k+1) - 1) < nthPrime k * lcm_upto (nthPrime k)`, rewrite the two nthPrime values to literals, and close by `decide`. A single `interval_cases` packages k = 1,2,3,4 into `erdos458_base`.",
+    "keyInsights": [
+      "The whole account is kernel-checkable: replacing `native_decide` with `decide` throughout removes the `Lean.ofReduceBool` axiom, turning the parent's `axiomatized` base cases into genuinely `verified` (0-axiom) ones.",
+      "`Nat.nth_count` is the exact tool for value facts about Nat.nth: it converts 'n is prime and there are k primes below n' into 'the k-th prime is n', so no prime-index value ever needs to be asserted.",
+      "Kernel `decide` scales far enough for this range: primality and prime-counting up to 31, and lcm(1,…,12) = 27720, all reduce in the kernel without the compiler."
+    ],
+    "prerequisites": [
+      "The parent formalization erdos-458 (statement of the LCM inequality and the nthPrime setup)",
+      "Mathlib's Nat.nth / Nat.count API, in particular Nat.nth_count",
+      "Decidability of Nat.Prime and Finset.lcm evaluation"
+    ]
+  },
+  "sections": [
+    {
+      "title": "Definitions and basic prime-index facts",
+      "description": "`lcm_upto n = (Finset.Icc 1 n).lcm id` and `nthPrime k = Nat.nth Nat.Prime k`, with `nthPrime_prime` and `nthPrime_strictMono` from Mathlib's infinitude of primes."
+    },
+    {
+      "title": "Prime-index values from Nat.nth (p_0 … p_10)",
+      "description": "`nthPrime_zero … nthPrime_ten` derive the first eleven primes 2,3,5,7,11,13,17,19,23,29,31 from `Nat.nth_count`, evaluating the prime counts with kernel `decide`. The values p_5 … p_10 are new relative to the parent."
+    },
+    {
+      "title": "Axiom-free base cases of Erdős #458 (k = 1,2,3,4)",
+      "description": "`erdos458_k1 … erdos458_k4` verify the conjecture instance for each k by rewriting prime values and applying kernel `decide`; `erdos458_base` packages them via interval_cases. This extends the parent's k = 1,2 and drops the `native_decide` dependency."
+    }
+  ],
+  "conclusion": {
+    "summary": "A self-contained, fully axiom-free (0 sorries, 0 axioms, no native_decide) formalization: the first eleven prime indices p_0 … p_10 = 2 … 31 derived from Nat.nth via Nat.nth_count, and the base cases k = 1,2,3,4 of the open Erdős #458 LCM inequality verified by kernel decide.",
+    "implications": "This settles OQ-05 (prime-index values from Nat.nth, no asserted facts) and advances OQ-03 (more verified k), while showing the base-case verification can be done with the kernel alone — removing the Lean.ofReduceBool axiom that native_decide introduces in the parent.",
+    "openQuestions": [
+      "**Push kernel verification further.** Extend the axiom-free base cases beyond k = 4; each larger k requires kernel `decide` on lcm(1,…,p_{k+1}-1), whose growth (~e^{p_k}) eventually makes kernel reduction impractical without a certified fast-computation approach.",
+      "**The conjecture itself (still OPEN).** Erdős #458 for all k remains open; the conditional route via Legendre's conjecture (a prime between n² and (n+1)²) is recorded in the parent as the natural line of attack.",
+      "**Faster certified prime counting.** Replace `decide` on Nat.count with a certified sieve so that many more prime indices p_k can be pinned down cheaply, supporting large-k verification."
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/Erdos458OQ05.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos458OQ05",
+    "lineCount": 180,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 18
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-458",
+      "relationship": "extends",
+      "description": "Answers OQ-05 (prime-index values from Nat.nth) and advances OQ-03 (more base cases) of the parent LCM-inequality formalization, additionally removing its native_decide / Lean.ofReduceBool dependency for the verified cases."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "L'Enseignement Mathématique, Monographie No. 28, Université de Genève",
+      "note": "The source of Problem #458 on the LCM inequality for consecutive primes."
+    },
+    {
+      "authors": "—",
+      "title": "Erdős Problems: Problem 458",
+      "year": "2024",
+      "venue": "erdosproblems.com/458",
+      "note": "Online catalogue entry for the problem, listed as open."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry `erdos-458-oq-05` answering **OQ-05** of the parent `erdos-458` (the LCM inequality for primes, Erdős #458), and advancing **OQ-03**.

Erdős #458 asks whether $\mathrm{lcm}(1,\dots,p_{k+1}-1) < p_k \cdot \mathrm{lcm}(1,\dots,p_k)$ for all $k \ge 1$ (with $p_k = \texttt{Nat.nth Nat.Prime } k$). The parent sets this up but relies on `native_decide` (which trusts the compiler via the `Lean.ofReduceBool` axiom) and asks in OQ-05 whether the prime-index *values* can be derived directly from `Nat.nth`.

This entry does both, **using kernel `decide` only (zero `native_decide`)**, so every result is genuinely axiom-free:

- `nthPrime_zero … nthPrime_ten`: the first eleven primes $p_0,\dots,p_{10} = 2,\dots,31$, each from `Nat.nth_count` (the `Nat.nth`/`Nat.count` bridge) with `decide`-evaluated prime counts. Values $p_5,\dots,p_{10}$ are **new** relative to the parent.
- `erdos458_k1 … erdos458_k4` and `erdos458_base`: the conjecture instances for $k = 1,2,3,4$ by kernel `decide`, **extending the parent's $k = 1,2$** and dropping its `native_decide` dependency.

## Verification

Self-contained (imports only Mathlib; reproves `lcm_upto` and `nthPrime`). Clean `lake env lean` build (18 theorems / 2 defs / 180 lines, 0 sorries). Every proof uses **kernel `decide`, never `native_decide`** — grep-confirmed — so no proof carries `Lean.ofReduceBool`; the axiom set is provably ⊆ {`propext`, `Classical.choice`, `Quot.sound`}. This is the point of OQ-05: the parent's base cases are `axiomatized` (native_decide → `Lean.ofReduceBool`), whereas these are genuinely `verified` / 0-axiom.

## Scope

Erdős #458 itself remains **open**; only finitely many base cases are (and can feasibly be) machine-verified, since $\mathrm{lcm}(1,\dots,n) \sim e^n$ makes kernel `decide` impractical for large $k$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)