### PR TITLE
research(szemeredi-counting-oq-01-oq-01): K_r packing–covering bracket ν_r ≤ ρ_r ≤ τ_r [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SzemerediCountingOQ01OQ01.lean
+++ b/proofs/Proofs/SzemerediCountingOQ01OQ01.lean
@@ -1,0 +1,307 @@
+/-
+  Packing–Covering Duality for K_r-Freeness: the bracket ν_r ≤ ρ_r ≤ τ_r
+
+  Parent entry: `szemeredi-counting-oq-01`
+  (`Proofs/SzemerediCountingOQ01.lean`) proves, for the *triangle* (K₃) case,
+  the two-sided bracket governing the triangle removal number:
+
+        ν(G)  ≤  ρ(G)  ≤  τ(G),
+
+  where ν is the maximum edge-disjoint triangle packing, ρ the minimum number of
+  edges whose deletion destroys every triangle, and τ the total triangle count.
+
+  This entry generalizes that whole bracket from K₃ to an **arbitrary clique
+  size** `K_r` (`r ≥ 2`).  For a fixed `r` we prove, for every finite graph:
+
+        ν_r(G)  ≤  ρ_r(G)  ≤  τ_r(G),
+
+  where
+    * `ρ_r(G)` (`rRemovalNumber`) is the minimum number of edges whose deletion
+      makes `G` `K_r`-free — the per-graph quantity the `K_r`-removal lemma bounds;
+    * `τ_r(G)` (`numRCliques`) is the total number of `K_r`'s;
+    * `ν_r(G)` is witnessed by any **edge-disjoint** `K_r`-packing.
+
+  ## A correction to the "shared-vertex bound"
+
+  One might be tempted (as the problem note suggests) to define edge-disjointness
+  of `K_r`'s by the shared-vertex bound `|s ∩ t| ≤ r − 2`.  That is **incorrect**
+  for `r ≥ 4`: two `r`-cliques share an *edge* iff they share **two** vertices, so
+  the genuine edge-disjointness condition is `|s ∩ t| ≤ 1`, uniformly in `r`.
+  (The two conditions coincide only at `r = 3`, where `r − 2 = 1`, which is why the
+  triangle parent could write either.)  The weak-duality injection below needs
+  exactly `|s ∩ t| ≤ 1`: two cliques assigned the same covering edge share both of
+  its endpoints, i.e. share two vertices — a contradiction only under `|s∩t| ≤ 1`.
+  Using `r − 2` for `r ≥ 4` would let two edge-sharing cliques be double-counted and
+  the bracket would be false.  We therefore adopt `|s ∩ t| ≤ 1`.
+
+  ## Main results (0 sorry, 0 axiom)
+  * `cliqueFree_deleteEdges_iff_rCovers` — the bridge: `G.deleteEdges F` is
+    `K_r`-free iff `F` contains an edge of every `K_r` of `G`.
+  * `rPacking_card_le_cover_card`        — WEAK DUALITY: |packing| ≤ |cover|.
+  * `exists_cover_card_le_numRCliques`   — greedy cover of size ≤ #`K_r`'s.
+  * `rPacking_card_le_rRemovalNumber`    — ν_r(G) ≤ ρ_r(G).
+  * `rRemovalNumber_le_numRCliques`      — ρ_r(G) ≤ τ_r(G).
+  * `rPacking_le_removal_le_numRCliques` — the headline bracket ν_r ≤ ρ_r ≤ τ_r.
+  * `rRemovalNumber_eq_zero_of_cliqueFree` — sharpness: `K_r`-free ⟹ ρ_r = 0.
+
+  Self-contained over Mathlib's `SimpleGraph`; imports only `Mathlib`.
+-/
+import Mathlib
+
+namespace Szemeredi.CliqueRemoval.Bounds
+
+open SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: r-CLIQUES, COVERS, AND PACKINGS
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- An edge set `F` *covers* a clique `s` if it contains one of `s`'s edges. -/
+def RCliqueCoveredBy (F : Finset (Sym2 V)) (s : Finset V) : Prop :=
+  ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ s(x, y) ∈ F
+
+/-- `F` is a **`K_r` edge cover** of `G` if deleting its edges makes `G`
+    `K_r`-free.  This is the quantity a `K_r`-removal lemma deletes. -/
+def IsRCliqueEdgeCover (r : ℕ) (G : SimpleGraph V) (F : Finset (Sym2 V)) : Prop :=
+  (G.deleteEdges (F : Set (Sym2 V))).CliqueFree r
+
+/-- An **edge-disjoint `K_r`-packing**: a finite family of `r`-cliques of `G`
+    no two of which share an edge.  Two distinct cliques share an edge iff they
+    share two vertices, so edge-disjointness is `|s ∩ t| ≤ 1` — for every `r`. -/
+def IsRCliquePacking (r : ℕ) (G : SimpleGraph V) (P : Finset (Finset V)) : Prop :=
+  (∀ s ∈ P, G.IsNClique r s) ∧
+    (P : Set (Finset V)).Pairwise (fun s t => (s ∩ t).card ≤ 1)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE BRIDGE — DELETING EDGES IS K_r-FREE IFF COVER
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] [DecidableEq V] in
+/-- Deleting the edge set `F` makes `G` `K_r`-free **iff** `F` contains an edge
+    of every `r`-clique of `G`.  This identifies edge covers (combinatorics)
+    with `K_r`-freeness (a removal lemma's conclusion). -/
+theorem cliqueFree_deleteEdges_iff_rCovers (r : ℕ) (G : SimpleGraph V)
+    (F : Finset (Sym2 V)) :
+    IsRCliqueEdgeCover r G F ↔ ∀ s, G.IsNClique r s → RCliqueCoveredBy F s := by
+  constructor
+  · -- Cover ⟹ every clique is met.
+    intro hCF s hs
+    by_contra hnc
+    simp only [RCliqueCoveredBy] at hnc
+    push_neg at hnc
+    apply hCF s
+    refine ⟨?_, hs.2⟩
+    intro x hx y hy hxy
+    have hGadj : G.Adj x y := hs.1 hx hy hxy
+    have hnotin : s(x, y) ∉ (F : Set (Sym2 V)) := by
+      simp only [Finset.mem_coe]
+      exact hnc x hx y hy hxy
+    rw [SimpleGraph.deleteEdges_adj]
+    exact ⟨hGadj, hnotin⟩
+  · -- Every clique met ⟹ deletion is K_r-free.
+    intro hcov s hs
+    have hsG : G.IsNClique r s := by
+      refine ⟨?_, hs.2⟩
+      intro x hx y hy hxy
+      exact (SimpleGraph.deleteEdges_adj.1 (hs.1 hx hy hxy)).1
+    obtain ⟨x, hx, y, hy, hxy, hxyF⟩ := hcov s hsG
+    have hadj : (G.deleteEdges (F : Set (Sym2 V))).Adj x y := hs.1 hx hy hxy
+    have hnot : s(x, y) ∉ (F : Set (Sym2 V)) :=
+      (SimpleGraph.deleteEdges_adj.1 hadj).2
+    exact hnot (by simpa using hxyF)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: WEAK DUALITY — |PACKING| ≤ |COVER|
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] in
+/-- **Weak duality for the `K_r` hypergraph.**  Any edge-disjoint `K_r`-packing
+    has at most as many cliques as any edge cover has edges: `|P| ≤ |F|`.
+
+    Proof: each clique in `P` is covered by some edge of `F`; assign to each
+    clique one such edge.  Two cliques assigned the same edge would share that
+    edge, i.e. share two vertices, contradicting edge-disjointness `|s∩t| ≤ 1`.
+    Hence the assignment is injective and `|P| ≤ |F|`. -/
+theorem rPacking_card_le_cover_card (r : ℕ) (G : SimpleGraph V)
+    {P : Finset (Finset V)} {F : Finset (Sym2 V)}
+    (hP : IsRCliquePacking r G P) (hF : IsRCliqueEdgeCover r G F) :
+    P.card ≤ F.card := by
+  classical
+  have hcov := (cliqueFree_deleteEdges_iff_rCovers r G F).1 hF
+  have hchoose : ∀ s, s ∈ P →
+      ∃ e, e ∈ F ∧ ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ e = s(x, y) := by
+    intro s hs
+    obtain ⟨x, hx, y, hy, hxy, hmem⟩ := hcov s (hP.1 s hs)
+    exact ⟨s(x, y), hmem, x, hx, y, hy, hxy, rfl⟩
+  set f : {s // s ∈ P} → Sym2 V :=
+    fun s => Classical.choose (hchoose s.1 s.2) with hf_def
+  have hf_spec : ∀ s : {s // s ∈ P},
+      f s ∈ F ∧ ∃ x ∈ s.1, ∃ y ∈ s.1, x ≠ y ∧ f s = s(x, y) :=
+    fun s => Classical.choose_spec (hchoose s.1 s.2)
+  rw [← Finset.card_attach (s := P)]
+  apply Finset.card_le_card_of_injOn f
+  · intro s _
+    exact (hf_spec s).1
+  · intro a _ b _ hab
+    obtain ⟨hFa, xa, hxa, ya, hya, hxya, hea⟩ := hf_spec a
+    obtain ⟨hFb, xb, hxb, yb, hyb, hxyb, heb⟩ := hf_spec b
+    have hedge : s(xa, ya) = s(xb, yb) := by rw [← hea, ← heb, hab]
+    have hxb_yb : xa ∈ b.1 ∧ ya ∈ b.1 := by
+      rcases (Sym2.eq_iff).1 hedge with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · exact ⟨h1 ▸ hxb, h2 ▸ hyb⟩
+      · exact ⟨h1 ▸ hyb, h2 ▸ hxb⟩
+    by_contra hne
+    have hab' : a.1 ≠ b.1 := fun h => hne (Subtype.ext h)
+    have hle : (a.1 ∩ b.1).card ≤ 1 :=
+      hP.2 a.2 b.2 hab'
+    have h2le : 2 ≤ (a.1 ∩ b.1).card := by
+      have hxmem : xa ∈ a.1 ∩ b.1 := Finset.mem_inter.2 ⟨hxa, hxb_yb.1⟩
+      have hymem : ya ∈ a.1 ∩ b.1 := Finset.mem_inter.2 ⟨hya, hxb_yb.2⟩
+      have : 1 < (a.1 ∩ b.1).card :=
+        Finset.one_lt_card.2 ⟨xa, hxmem, ya, hymem, hxya⟩
+      omega
+    omega
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: GREEDY UPPER BOUND — COVER OF SIZE ≤ #K_r'S
+-- ═══════════════════════════════════════════════════════════════════
+
+open Classical in
+/-- The (finite) set of all `r`-cliques of `G`. -/
+noncomputable def rCliques (r : ℕ) (G : SimpleGraph V) : Finset (Finset V) :=
+  (Finset.univ : Finset (Finset V)).filter (fun s => G.IsNClique r s)
+
+/-- The total number of `r`-cliques `τ_r(G)`. -/
+noncomputable def numRCliques (r : ℕ) (G : SimpleGraph V) : ℕ := (rCliques r G).card
+
+@[simp] theorem mem_rCliques {r : ℕ} {G : SimpleGraph V} {s : Finset V} :
+    s ∈ rCliques r G ↔ G.IsNClique r s := by
+  classical
+  simp only [rCliques, Finset.mem_filter, Finset.mem_univ, true_and]
+
+omit [Fintype V] [DecidableEq V] in
+/-- Every `r`-clique with `r ≥ 2` has an explicit edge `s(x,y)` with `x ≠ y`
+    both in it. -/
+theorem rClique_exists_edge {r : ℕ} (hr : 2 ≤ r) {G : SimpleGraph V}
+    {s : Finset V} (hs : G.IsNClique r s) : ∃ x ∈ s, ∃ y ∈ s, x ≠ y := by
+  have h2 : 1 < s.card := by rw [hs.2]; omega
+  obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.1 h2
+  exact ⟨x, hx, y, hy, hxy⟩
+
+/-- **Greedy cover.**  Selecting one edge from each `r`-clique (`r ≥ 2`) yields a
+    `K_r` edge cover of size at most the number of `r`-cliques. -/
+theorem exists_cover_card_le_numRCliques {r : ℕ} (hr : 2 ≤ r)
+    (G : SimpleGraph V) :
+    ∃ F : Finset (Sym2 V),
+      IsRCliqueEdgeCover r G F ∧ F.card ≤ numRCliques r G := by
+  classical
+  have hpick : ∀ s, s ∈ rCliques r G → ∃ e : Sym2 V,
+      ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ e = s(x, y) := by
+    intro s hs
+    obtain ⟨x, hx, y, hy, hxy⟩ := rClique_exists_edge hr (mem_rCliques.1 hs)
+    exact ⟨s(x, y), x, hx, y, hy, hxy, rfl⟩
+  set g : {s // s ∈ rCliques r G} → Sym2 V :=
+    fun s => Classical.choose (hpick s.1 s.2) with hg_def
+  have hg_spec : ∀ s : {s // s ∈ rCliques r G},
+      ∃ x ∈ s.1, ∃ y ∈ s.1, x ≠ y ∧ g s = s(x, y) :=
+    fun s => Classical.choose_spec (hpick s.1 s.2)
+  refine ⟨(rCliques r G).attach.image g, ?_, ?_⟩
+  · rw [cliqueFree_deleteEdges_iff_rCovers]
+    intro s hs
+    have hsmem : s ∈ rCliques r G := mem_rCliques.2 hs
+    obtain ⟨x, hx, y, hy, hxy, hgeq⟩ := hg_spec ⟨s, hsmem⟩
+    refine ⟨x, hx, y, hy, hxy, ?_⟩
+    rw [← hgeq]
+    exact Finset.mem_image.2 ⟨⟨s, hsmem⟩, Finset.mem_attach _ _, rfl⟩
+  · calc ((rCliques r G).attach.image g).card
+        ≤ (rCliques r G).attach.card := Finset.card_image_le
+      _ = (rCliques r G).card := Finset.card_attach
+      _ = numRCliques r G := rfl
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: THE REMOVAL NUMBER AND THE BRACKET ν_r ≤ ρ_r ≤ τ_r
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The **`K_r` removal number** `ρ_r(G)`: the minimum number of edges whose
+    deletion makes `G` `K_r`-free. -/
+noncomputable def rRemovalNumber (r : ℕ) (G : SimpleGraph V) : ℕ :=
+  sInf {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsRCliqueEdgeCover r G F}
+
+/-- The set of cover sizes is nonempty (the greedy cover is a member), so the
+    infimum defining `ρ_r(G)` is attained. -/
+theorem rRemovalNumber_mem {r : ℕ} (hr : 2 ≤ r) (G : SimpleGraph V) :
+    ∃ F : Finset (Sym2 V), F.card = rRemovalNumber r G ∧
+      IsRCliqueEdgeCover r G F := by
+  have hne : {m | ∃ F : Finset (Sym2 V), F.card = m ∧
+      IsRCliqueEdgeCover r G F}.Nonempty := by
+    obtain ⟨F, hF, _⟩ := exists_cover_card_le_numRCliques hr G
+    exact ⟨F.card, F, rfl, hF⟩
+  exact Nat.sInf_mem hne
+
+/-- **Lower bracket** `ν_r(G) ≤ ρ_r(G)`: every edge-disjoint `K_r`-packing has
+    at most `ρ_r(G)` cliques. -/
+theorem rPacking_card_le_rRemovalNumber {r : ℕ} (hr : 2 ≤ r)
+    (G : SimpleGraph V) {P : Finset (Finset V)} (hP : IsRCliquePacking r G P) :
+    P.card ≤ rRemovalNumber r G := by
+  obtain ⟨F, hFcard, hFcov⟩ := rRemovalNumber_mem hr G
+  calc P.card ≤ F.card := rPacking_card_le_cover_card r G hP hFcov
+    _ = rRemovalNumber r G := hFcard
+
+/-- **Upper bracket** `ρ_r(G) ≤ τ_r(G)`: the removal number never exceeds the
+    total number of `r`-cliques. -/
+theorem rRemovalNumber_le_numRCliques {r : ℕ} (hr : 2 ≤ r) (G : SimpleGraph V) :
+    rRemovalNumber r G ≤ numRCliques r G := by
+  obtain ⟨F, hFcov, hFle⟩ := exists_cover_card_le_numRCliques hr G
+  have hmem : F.card ∈
+      {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsRCliqueEdgeCover r G F} :=
+    ⟨F, rfl, hFcov⟩
+  calc rRemovalNumber r G ≤ F.card := Nat.sInf_le hmem
+    _ ≤ numRCliques r G := hFle
+
+/-- **The packing–covering bracket** for the `K_r` removal number of an
+    arbitrary finite graph (`r ≥ 2`):
+
+        ν_r(G)  ≤  ρ_r(G)  ≤  τ_r(G).
+
+    Every edge-disjoint `K_r`-packing lower-bounds the number of edges that must
+    be removed to destroy all `r`-cliques, and the total `K_r` count
+    upper-bounds it.  For `r = 3` this recovers the parent's triangle bracket. -/
+theorem rPacking_le_removal_le_numRCliques {r : ℕ} (hr : 2 ≤ r)
+    (G : SimpleGraph V) {P : Finset (Finset V)} (hP : IsRCliquePacking r G P) :
+    P.card ≤ rRemovalNumber r G ∧ rRemovalNumber r G ≤ numRCliques r G :=
+  ⟨rPacking_card_le_rRemovalNumber hr G hP, rRemovalNumber_le_numRCliques hr G⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: SHARPNESS — A K_r-FREE GRAPH HAS ρ_r = 0
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] [DecidableEq V] in
+/-- For a `K_r`-free graph the empty edge set is already a cover, so its removal
+    number is `0` — the bracket bottoms out at `ν_r = ρ_r = τ_r = 0`. -/
+theorem rRemovalNumber_eq_zero_of_cliqueFree (r : ℕ) (G : SimpleGraph V)
+    (hG : G.CliqueFree r) : rRemovalNumber r G = 0 := by
+  have hcov : IsRCliqueEdgeCover r G (∅ : Finset (Sym2 V)) := by
+    unfold IsRCliqueEdgeCover
+    have : G.deleteEdges (∅ : Set (Sym2 V)) = G := by
+      simp [SimpleGraph.deleteEdges_empty]
+    rw [Finset.coe_empty, this]
+    exact hG
+  have hmem : (0 : ℕ) ∈
+      {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsRCliqueEdgeCover r G F} :=
+    ⟨∅, Finset.card_empty, hcov⟩
+  exact Nat.le_zero.1 (Nat.sInf_le hmem)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VII: r = 3 RECOVERS THE TRIANGLE BRACKET
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Sanity specialization: at `r = 3` the bracket is exactly the parent's
+    triangle packing–covering bracket `ν ≤ ρ ≤ τ`. -/
+theorem triangle_bracket (G : SimpleGraph V) {P : Finset (Finset V)}
+    (hP : IsRCliquePacking 3 G P) :
+    P.card ≤ rRemovalNumber 3 G ∧ rRemovalNumber 3 G ≤ numRCliques 3 G :=
+  rPacking_le_removal_le_numRCliques (by norm_num) G hP
+
+end Szemeredi.CliqueRemoval.Bounds

--- a/src/data/proofs/szemeredi-counting-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/szemeredi-counting-oq-01-oq-01/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-header-correction",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "From K₃ to K_r — and the right edge-disjointness condition",
+    "content": "This file lifts the parent's triangle packing–covering bracket ν ≤ ρ ≤ τ to arbitrary clique size K_r. The header also flags a deliberate correction: one is tempted to define edge-disjoint r-cliques by the shared-vertex bound |s ∩ t| ≤ r − 2, but that is wrong for r ≥ 4. Two r-cliques share an *edge* iff they share *two* vertices, so genuine edge-disjointness is |s ∩ t| ≤ 1, uniformly in r. The bounds agree only at r = 3 (where r − 2 = 1), which is why the triangle parent could write either. The weak-duality injection below needs exactly |s ∩ t| ≤ 1.",
+    "mathContext": "Two $r$-cliques share an edge $\\iff |s\\cap t|\\ge 2$; edge-disjointness is $|s\\cap t|\\le 1$ for every $r$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "edge-disjoint packing",
+      "clique intersection",
+      "K_r removal lemma"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 75
+    },
+    "type": "concept",
+    "title": "Covers, K_r-covers, and edge-disjoint K_r-packings",
+    "content": "Three parametrized definitions carry the LP. `RCliqueCoveredBy F s` says the edge set F contains one of the clique s's edges. `IsRCliqueEdgeCover r G F` says deleting F makes G K_r-free — the quantity a K_r-removal lemma deletes. `IsRCliquePacking r G P` is a finite family of r-cliques that are pairwise edge-disjoint, encoded as `(s ∩ t).card ≤ 1`. These generalize the parent's IsTriangle/IsTriangleEdgeCover/IsTrianglePacking by replacing the literal 3 with an r parameter.",
+    "mathContext": "Cover $F$: $G\\setminus F$ is $K_r$-free. Packing $P$: $r$-cliques with $|s\\cap t|\\le 1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "edge cover",
+      "SimpleGraph.deleteEdges",
+      "IsNClique",
+      "hypergraph packing"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 115
+    },
+    "type": "technique",
+    "title": "The bridge ports verbatim: r is never used as a number",
+    "content": "`cliqueFree_deleteEdges_iff_rCovers` proves G.deleteEdges F is K_r-free iff F meets every r-clique. The forward direction: an uncovered clique survives deletion (all its edges stay), contradicting K_r-freeness; the reverse: a surviving clique in G−F is a clique of G that F must meet, but then that edge is gone in G−F. Crucially the parent's r = 3 proof uses only the clique's pairwise adjacency (`hs.1`) and its cardinality proof (`hs.2`), never the value 3, so it generalizes with no change to the tactics — only the statement's `3` becomes `r`.",
+    "mathContext": "$(G\\setminus F)\\text{ is }K_r\\text{-free} \\iff \\forall s,\\ G.\\mathrm{IsNClique}\\,r\\,s \\to \\exists e\\in s,\\ e\\in F$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "SimpleGraph.deleteEdges_adj",
+      "CliqueFree",
+      "proof reuse"
+    ]
+  },
+  {
+    "id": "ann-weak-duality",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 166
+    },
+    "type": "technique",
+    "title": "Weak duality via an injective covering-edge charge",
+    "content": "`rPacking_card_le_cover_card` proves |P| ≤ |F| for any edge-disjoint K_r-packing P and any cover F. Each packed clique gets a covering edge of F (Classical.choose on the bridge output); this charge P.attach → F is shown injective with `Finset.card_le_card_of_injOn`. If two cliques a, b are charged the same edge s(xa,ya) = s(xb,yb), then by `Sym2.eq_iff` both endpoints xa, ya lie in b, so |a ∩ b| ≥ 2 — contradicting the packing's |a ∩ b| ≤ 1. This is exactly where edge-disjointness (and not the false r − 2 bound) is needed.",
+    "mathContext": "König-type weak duality: $\\nu_r \\le$ (any cover size). Injectivity fails under $|s\\cap t|\\le r-2$ for $r\\ge 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_le_card_of_injOn",
+      "Sym2.eq_iff",
+      "Classical.choose",
+      "LP duality"
+    ]
+  },
+  {
+    "id": "ann-greedy-bracket",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 172,
+      "endLine": 275
+    },
+    "type": "concept",
+    "title": "Greedy cover, the removal number, and the bracket",
+    "content": "`rClique_exists_edge` needs r ≥ 2 so an r-clique actually has an edge to select; `exists_cover_card_le_numRCliques` picks one edge per r-clique, giving a cover of size ≤ τ_r (the image of an attach is no larger). `rRemovalNumber r G` is the infimum of cover sizes, attained (`rRemovalNumber_mem`) because the greedy cover is a member. Combining `rPacking_card_le_rRemovalNumber` (ν_r ≤ ρ_r, from weak duality against the minimizing cover) and `rRemovalNumber_le_numRCliques` (ρ_r ≤ τ_r, from the greedy cover) yields the headline bracket ν_r ≤ ρ_r ≤ τ_r.",
+    "mathContext": "$\\rho_r(G) = \\inf\\{|F| : G\\setminus F\\text{ is }K_r\\text{-free}\\}$, and $\\nu_r(G) \\le \\rho_r(G) \\le \\tau_r(G)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "greedy cover",
+      "Nat.sInf_mem",
+      "Nat.sInf_le",
+      "removal number"
+    ]
+  },
+  {
+    "id": "ann-sharpness-recovery",
+    "proofId": "szemeredi-counting-oq-01-oq-01",
+    "range": {
+      "startLine": 281,
+      "endLine": 307
+    },
+    "type": "concept",
+    "title": "Sharpness and recovery of the triangle bracket",
+    "content": "`rRemovalNumber_eq_zero_of_cliqueFree` shows a K_r-free graph is already covered by ∅, so ρ_r = 0 and the whole bracket collapses to ν_r = ρ_r = τ_r = 0. `triangle_bracket` instantiates the general bracket at r = 3, reproducing the parent entry's triangle packing–covering bound — confirming the generalization is faithful.",
+    "mathContext": "$G\\text{ is }K_r\\text{-free}\\Rightarrow \\rho_r(G)=0$; at $r=3$ the bracket is the parent's $\\nu\\le\\rho\\le\\tau$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sharpness",
+      "specialization",
+      "triangle removal number"
+    ]
+  }
+]

--- a/src/data/proofs/szemeredi-counting-oq-01-oq-01/index.ts
+++ b/src/data/proofs/szemeredi-counting-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SzemerediCountingOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const szemerediCountingOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const szemerediCountingOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const szemerediCountingOq01Oq01Data: ProofData = {
+  proof: szemerediCountingOq01Oq01Proof,
+  annotations: szemerediCountingOq01Oq01Annotations,
+}

--- a/src/data/proofs/szemeredi-counting-oq-01-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-01-oq-01/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "szemeredi-counting-oq-01-oq-01",
+  "title": "Packing–Covering Duality for K_r-Freeness: the bracket ν_r ≤ ρ_r ≤ τ_r",
+  "slug": "szemeredi-counting-oq-01-oq-01",
+  "description": "Generalizes the parent's triangle (K₃) packing–covering bracket to an arbitrary clique size K_r (r ≥ 2). For every finite graph G it proves ν_r(G) ≤ ρ_r(G) ≤ τ_r(G), where ρ_r(G) (rRemovalNumber) is the minimum number of edges whose deletion makes G K_r-free, τ_r(G) (numRCliques) is the total number of r-cliques, and ν_r(G) is witnessed by any edge-disjoint K_r-packing. The lower inequality is weak LP duality for the K_r hypergraph (rPacking_card_le_cover_card): assign to each packed r-clique a covering edge; edge-disjointness makes the assignment injective, so |packing| ≤ |cover|. The upper inequality is the greedy one-edge-per-clique cover (exists_cover_card_le_numRCliques). The bridge cliqueFree_deleteEdges_iff_rCovers identifies 'deleting F makes G K_r-free' with 'F meets every r-clique'. A deliberate correction to the problem's suggested framing: the genuine edge-disjointness condition is |s ∩ t| ≤ 1 for ALL r (two r-cliques share an edge iff they share two vertices), not the |s ∩ t| ≤ r − 2 the note proposed — the two agree only at r = 3. 10 theorems + 6 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius (K_r generalization); Ruzsa–Szemerédi (triangle removal), König (packing–covering duality)",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SzemerediCountingOQ01OQ01.lean",
+    "tags": [
+      "szemeredi",
+      "combinatorics",
+      "graph-theory",
+      "clique-removal",
+      "packing-covering",
+      "lp-duality",
+      "extremal-graph-theory",
+      "verified",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-02",
+    "lineCount": 307,
+    "theoremCount": 10,
+    "definitionCount": 6,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.deleteEdges / SimpleGraph.deleteEdges_adj",
+        "description": "Removing an edge set from a graph; the adjacency characterisation (G.deleteEdges s).Adj v w ↔ G.Adj v w ∧ s(v,w) ∉ s drives the cover ↔ K_r-free bridge.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DeleteEdges"
+      },
+      {
+        "theorem": "SimpleGraph.CliqueFree / SimpleGraph.IsNClique",
+        "description": "r-cliques are IsNClique r; K_r-freeness is CliqueFree r. The clique's card (= r) is preserved under edge deletion, and clique membership is unfolded to pairwise adjacency to test survival.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Clique"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "The weak-duality injection: P.attach injects into the cover F via the chosen covering edges, giving |P| ≤ |F|.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Sym2.eq_iff",
+        "description": "s(x,y) = s(z,w) ↔ (x=z ∧ y=w) ∨ (x=w ∧ y=z) — extracts that two cliques assigned the same covering edge share both of its endpoints.",
+        "module": "Mathlib.Data.Sym.Sym2"
+      },
+      {
+        "theorem": "Nat.sInf_mem / Nat.sInf_le",
+        "description": "The removal number ρ_r is the infimum of cover sizes; nonemptiness (the greedy cover) makes the infimum attained, feeding both brackets.",
+        "module": "Mathlib.Data.Nat.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "cliqueFree_deleteEdges_iff_rCovers: the bridge for arbitrary r — deleting an edge set F makes G K_r-free iff F contains an edge of every r-clique of G (the r=3 proof ports unchanged because it never uses the specific value 3, only the clique card equality).",
+      "rPacking_card_le_cover_card: WEAK DUALITY |packing| ≤ |cover| for the K_r hypergraph, via an injective assignment of a covering edge to each packed r-clique; the injectivity uses edge-disjointness |s∩t| ≤ 1.",
+      "The correct edge-disjointness condition |s∩t| ≤ 1 (uniform in r), correcting the problem note's |s∩t| ≤ r−2 which is false for r ≥ 4 (it would permit two edge-sharing cliques and break the injection).",
+      "exists_cover_card_le_numRCliques: greedy cover selecting one edge per r-clique, of size ≤ τ_r(G) (needs r ≥ 2 so cliques have an edge).",
+      "rRemovalNumber: the K_r removal number as sInf of cover sizes, with attainment (rRemovalNumber_mem) from the greedy cover.",
+      "rPacking_le_removal_le_numRCliques: the headline bracket ν_r ≤ ρ_r ≤ τ_r for arbitrary finite graphs and any r ≥ 2; triangle_bracket specializes it back to the parent's r = 3 case.",
+      "rRemovalNumber_eq_zero_of_cliqueFree: sharpness — a K_r-free graph has ρ_r = 0, the bracket bottoming out at ν_r = ρ_r = τ_r = 0."
+    ],
+    "prerequisites": [
+      "szemeredi-counting-oq-01 (parent: the triangle packing–covering bracket ν ≤ ρ ≤ τ)",
+      "SimpleGraph, IsNClique/CliqueFree, and deleteEdges in Mathlib",
+      "Weak LP duality / König-type packing–covering inequalities for hypergraphs"
+    ],
+    "assumptions": "None beyond r ≥ 2. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Imports only Mathlib; self-contained (does not import the parent file — the generalization is developed from scratch over Mathlib's SimpleGraph API). The K_r-packing hypothesis uses the edge-disjointness condition |s∩t| ≤ 1."
+  },
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-counting-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the triangle (K₃) packing–covering bracket ν ≤ ρ ≤ τ. This entry lifts every result — bridge, weak duality, greedy cover, removal number, and sharpness — to arbitrary clique size K_r, recovering the parent at r = 3 (triangle_bracket)."
+    },
+    {
+      "targetId": "szemeredi-counting",
+      "relationship": "related",
+      "description": "Grandparent: the quantitative K_r / triangle removal lemma. The per-graph K_r removal number ρ_r bracketed here is the quantity such a removal lemma bounds; the gap ρ_r / τ_r is the LP integrality gap governing the optimal constant."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The triangle removal lemma (Ruzsa–Szemerédi 1978) and its clique generalization state that a graph with few copies of K_r can be made K_r-free by deleting few edges; the optimal quantitative dependence is a celebrated open problem, with the only lower bounds coming from Behrend's AP-free sets through the Ruzsa–Szemerédi construction. Underlying the quantitative question is a purely combinatorial LP: minimizing edges to destroy all K_r (the covering number ρ_r) is dual to maximizing an edge-disjoint K_r-packing (ν_r), and both are sandwiched by the total count τ_r. König-type weak duality gives ν_r ≤ ρ_r for the K_r hypergraph, and the greedy cover gives ρ_r ≤ τ_r.",
+    "problemStatement": "The parent entry proves the bracket ν(G) ≤ ρ(G) ≤ τ(G) for triangles. Does the same two-sided bracket hold for arbitrary clique size K_r, and what is the correct notion of an edge-disjoint K_r-packing that makes the weak-duality injection go through?",
+    "text": "For a fixed clique size r ≥ 2 and an arbitrary finite graph G, this file proves ν_r(G) ≤ ρ_r(G) ≤ τ_r(G). The removal number ρ_r(G) is the minimum number of edges whose deletion makes G K_r-free; τ_r(G) is the number of r-cliques; ν_r(G) is the size of any edge-disjoint K_r-packing. The technical core is the bridge cliqueFree_deleteEdges_iff_rCovers — deleting F makes G K_r-free iff F meets every r-clique — from which weak duality (an injective covering-edge assignment) and the greedy cover both follow. The proof faithfully generalizes the parent's triangle argument; the only genuinely r-dependent point is the edge-disjointness condition, which is |s∩t| ≤ 1 for every r.",
+    "proofStrategy": "Port the parent's six-part development from K₃ to K_r. (I) Define RCliqueCoveredBy, IsRCliqueEdgeCover r, and IsRCliquePacking r with edge-disjointness |s∩t| ≤ 1. (II) Prove the bridge cliqueFree_deleteEdges_iff_rCovers; the parent's proof uses only the clique's pairwise-adjacency and card, never the literal 3, so it ports verbatim. (III) Weak duality: choose a covering edge per packed clique via Classical.choose and inject P.attach into F with Finset.card_le_card_of_injOn; two cliques sharing a covering edge share two vertices, contradicting |s∩t| ≤ 1. (IV) Greedy cover: one edge per r-clique (r ≥ 2 guarantees an edge) gives a cover of size ≤ τ_r. (V) Define ρ_r = sInf of cover sizes, attained by the greedy cover, and assemble ν_r ≤ ρ_r ≤ τ_r. (VI) Sharpness: a K_r-free graph is covered by ∅, so ρ_r = 0.",
+    "keyInsights": [
+      "The triangle bridge lemma never uses the number 3 — only that a clique is pairwise-adjacent with a fixed cardinality — so it generalizes to K_r with no change to the proof, just to the statement.",
+      "The right edge-disjointness condition is |s∩t| ≤ 1 for EVERY r, not |s∩t| ≤ r−2: two r-cliques share an edge exactly when they share two vertices. The r−2 bound proposed in the problem note coincides with 1 only at r = 3 and is false for r ≥ 4, where it would let two edge-sharing cliques be assigned the same covering edge and break the |packing| ≤ |cover| injection.",
+      "Weak duality is König-type LP duality for the K_r hypergraph: the covering-edge assignment P → F is injective precisely because edge-disjoint cliques cannot be charged to a common edge.",
+      "The greedy cover needs r ≥ 2 (so every r-clique contains an edge to select); for r ≥ 2 it yields ρ_r ≤ τ_r, and combined with ν_r ≤ ρ_r gives the full bracket for arbitrary finite graphs.",
+      "The bracket bottoms out correctly: on a K_r-free graph the empty edge set is already a cover, so ρ_r = 0 = ν_r = τ_r."
+    ],
+    "prerequisites": [
+      "The parent triangle bracket szemeredi-counting-oq-01",
+      "Mathlib's SimpleGraph, IsNClique/CliqueFree, deleteEdges, and Sym2 edge API",
+      "Finset cardinality and injective-image lemmas; Nat.sInf on ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "r-cliques, covers, and edge-disjoint packings",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Module header (with the |s∩t| ≤ 1 correction), then RCliqueCoveredBy (an edge set meets a clique), IsRCliqueEdgeCover r (deleting F makes G K_r-free), and IsRCliquePacking r (r-cliques pairwise edge-disjoint, |s∩t| ≤ 1).",
+      "mathContext": "For clique size $r$: a cover $F$ is an edge set with $G\\setminus F$ $K_r$-free; a packing is a family of $r$-cliques with $|s\\cap t|\\le 1$, i.e. sharing no edge."
+    },
+    {
+      "id": "bridge",
+      "title": "The bridge: deleting edges is K_r-free iff cover",
+      "startLine": 76,
+      "endLine": 117,
+      "summary": "cliqueFree_deleteEdges_iff_rCovers: G.deleteEdges F is K_r-free iff F contains an edge of every r-clique of G. The proof ports the parent's triangle argument unchanged because it uses only pairwise adjacency and the clique card.",
+      "mathContext": "$(G\\setminus F)$ is $K_r$-free $\\iff$ every $r$-clique of $G$ has one of its edges in $F$; adjacency in $G\\setminus F$ is $G.\\mathrm{Adj}\\wedge \\text{edge}\\notin F$."
+    },
+    {
+      "id": "weak-duality",
+      "title": "Weak duality |packing| ≤ |cover|",
+      "startLine": 118,
+      "endLine": 178,
+      "summary": "rPacking_card_le_cover_card: assign each packed r-clique a covering edge of F (Classical.choose) and inject P.attach into F. Two cliques charged to the same edge share both its endpoints, so |s∩t| ≥ 2, contradicting |s∩t| ≤ 1.",
+      "mathContext": "König-type weak duality for the $K_r$ hypergraph: $\\nu_r \\le$ (any cover size). Injectivity of the covering-edge charge uses edge-disjointness."
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy upper bound: cover of size ≤ #K_r",
+      "startLine": 179,
+      "endLine": 245,
+      "summary": "rCliques / numRCliques (τ_r), rClique_exists_edge (an r-clique with r ≥ 2 has an edge), and exists_cover_card_le_numRCliques: selecting one edge per r-clique yields a cover of size ≤ τ_r.",
+      "mathContext": "$\\rho_r \\le \\tau_r$ in witnessed form: the image of the per-clique edge choice is a cover no larger than the clique count."
+    },
+    {
+      "id": "removal-number-bracket",
+      "title": "The removal number and the bracket ν_r ≤ ρ_r ≤ τ_r",
+      "startLine": 246,
+      "endLine": 292,
+      "summary": "rRemovalNumber (ρ_r = sInf of cover sizes), rRemovalNumber_mem (attained), rPacking_card_le_rRemovalNumber (ν_r ≤ ρ_r), rRemovalNumber_le_numRCliques (ρ_r ≤ τ_r), and the headline rPacking_le_removal_le_numRCliques.",
+      "mathContext": "$\\nu_r(G) \\le \\rho_r(G) \\le \\tau_r(G)$ for every finite graph and every $r\\ge 2$; the gap $\\rho_r/\\tau_r$ is the LP integrality gap governing the optimal removal constant."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness and the r = 3 recovery",
+      "startLine": 293,
+      "endLine": 307,
+      "summary": "rRemovalNumber_eq_zero_of_cliqueFree (K_r-free ⟹ ρ_r = 0) and triangle_bracket: at r = 3 the bracket is exactly the parent's triangle packing–covering bracket.",
+      "mathContext": "On a $K_r$-free graph $\\emptyset$ is already a cover, so $\\rho_r = 0$; at $r=3$ the whole development is the parent's triangle bracket."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 307-line file (10 theorems, 6 definitions, 0 sorries, 0 axioms, no native_decide) generalizes the parent's triangle packing–covering bracket to arbitrary clique size: for every finite graph G and every r ≥ 2, ν_r(G) ≤ ρ_r(G) ≤ τ_r(G), where ρ_r is the minimum number of edges to delete to make G K_r-free, τ_r is the number of r-cliques, and ν_r is any edge-disjoint K_r-packing. The bridge, weak duality, greedy cover, and sharpness all lift from K₃ to K_r, recovering the parent at r = 3.",
+    "implications": "The result cleanly isolates the LP behind the K_r removal lemma at arbitrary clique size, and pins down the correct edge-disjointness condition (|s∩t| ≤ 1, uniform in r) — correcting a plausible but false |s∩t| ≤ r−2 framing. The König-type weak-duality injection and the greedy cover are reusable for other clique-hypergraph packing–covering questions.",
+    "openQuestions": [
+      "Prove strong duality gaps: exhibit graphs where ρ_r / ν_r or ρ_r / τ_r is large for r ≥ 4, generalizing the Ruzsa–Szemerédi integrality gap beyond triangles.",
+      "Relate ν_r, ρ_r, τ_r to a fractional relaxation ν_r* = ρ_r* (LP duality) and bound the integrality gap ρ_r / ρ_r*.",
+      "Extend the bracket to the induced-subgraph / arbitrary fixed-graph H removal setting, replacing K_r by an arbitrary H and edges by the appropriate covering objects."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 307,
+    "axiomCount": 0,
+    "path": "Proofs/SzemerediCountingOQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 10,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Triple systems with no six points carrying three triangles",
+      "author": "I. Z. Ruzsa, E. Szemerédi",
+      "year": "1978",
+      "venue": "Combinatorics (Keszthely 1976), Coll. Math. Soc. J. Bolyai 18, 939–945",
+      "description": "Introduces the triangle removal lemma; the edge-disjoint-clique / covering mechanism is the weak duality generalized here from K₃ to K_r."
+    },
+    {
+      "title": "A new proof of the graph removal lemma",
+      "author": "Jacob Fox",
+      "year": "2011",
+      "venue": "Annals of Mathematics 174, 561–579",
+      "description": "Best known quantitative bounds for the graph (K_r) removal lemma; the optimal dependence — governed by the integrality gap this bracket isolates — remains open."
+    },
+    {
+      "title": "Extremal Graph Theory",
+      "author": "Béla Bollobás",
+      "year": "1978",
+      "venue": "Academic Press",
+      "description": "Standard reference for cliques, packing–covering duality, and König-type inequalities underlying the ν_r ≤ ρ_r ≤ τ_r bracket."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`szemeredi-counting-oq-01-oq-01`** — generalizes the parent's triangle (K₃) packing–covering bracket to arbitrary clique size **K_r** (r ≥ 2).

For every finite graph `G` and `r ≥ 2`:

> **ν_r(G) ≤ ρ_r(G) ≤ τ_r(G)**

- `ρ_r` (`rRemovalNumber`) — minimum number of edges to delete to make `G` K_r-free
- `τ_r` (`numRCliques`) — total number of r-cliques
- `ν_r` — any edge-disjoint K_r-packing

The **bridge** (`cliqueFree_deleteEdges_iff_rCovers`), **weak duality** (König-type injective covering-edge charge), the **greedy cover**, and **sharpness** all port from the parent's triangle argument — the r=3 proof never uses the literal `3`, only clique structure — and `triangle_bracket` recovers the parent at r=3.

### Mathematical correction
The seeker's note suggested edge-disjointness of r-cliques means `|s ∩ t| ≤ r−2`. That is **false for r ≥ 4**: two r-cliques share an edge iff they share **two** vertices, so genuine edge-disjointness is `|s ∩ t| ≤ 1`, uniform in r (the two conditions coincide only at r=3). The weak-duality injection needs exactly `|s ∩ t| ≤ 1`; using `r−2` would double-charge edge-sharing cliques and make the bracket false. The file adopts and documents the correct condition.

## Verification
- **0 axioms** (`propext` / `Classical.choice` / `Quot.sound` only; no `sorryAx`, no `native_decide`), 0 sorries
- Verified with `lake env lean` against pinned Mathlib (v4.26.0)
- 10 theorems, 6 definitions, 307 lines; imports only `Mathlib` (self-contained)

## Files
- `proofs/Proofs/SzemerediCountingOQ01OQ01.lean`
- `src/data/proofs/szemeredi-counting-oq-01-oq-01/{meta.json, annotations.json, index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
