### PR TITLE
research(van-aubel-theorem-oq-01-oq-01): the van Aubel square — Varignon parallelogram of square-centers is a square [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/VanAubelTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/VanAubelTheoremOQ01OQ01.lean
@@ -1,0 +1,163 @@
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+
+/-!
+# The Varignon parallelogram of the van Aubel square-centers is a square
+(van-aubel-theorem-oq-01-oq-01)
+
+van Aubel's theorem (parent entry `van-aubel-theorem-oq-01`) takes an arbitrary planar
+quadrilateral with vertices `a, b, c, d : ℂ`, erects a square externally on each directed
+side, and shows that the two diagonals `PR` and `QS` of the resulting square-center
+quadrilateral `P, Q, R, S` are equal in length and perpendicular — all packaged in the single
+identity
+
+    R - P = i · (S - Q).                                     (`vanAubel_key`)
+
+This entry pushes one step further and applies **Varignon's theorem** to the square-center
+quadrilateral `PQRS`. Varignon's theorem says the midpoints of the sides of *any*
+quadrilateral form a parallelogram whose sides are parallel to, and half the length of, the
+diagonals. Since the diagonals `PR` and `QS` of `PQRS` are equal and perpendicular, the
+Varignon parallelogram of `PQRS` is in fact a **square**.
+
+Concretely, let
+
+* `M₁ = midpoint P Q`,  `M₂ = midpoint Q R`,  `M₃ = midpoint R S`,  `M₄ = midpoint S P`.
+
+The four directed edges `eₖ` of `M₁M₂M₃M₄` satisfy `e_{k+1} = -i · eₖ`, i.e. each side is a
+`90°` rotation of the previous one (`varignon_rot12`, `_rot23`, `_rot34`, `_rot41`). A closed
+polygon whose consecutive edges are exact `90°` rotations of one another is a square, so we
+obtain:
+
+* all four sides have equal length (`varignon_equal_sides`),
+* consecutive sides are perpendicular (`varignon_perp`),
+* the common side length is exactly half the common van Aubel diagonal length
+  (`varignon_side_eq_half_diagonal`).
+
+Everything descends from the parent's key identity `R - P = i·(S - Q)`, which itself is a
+one-line `linear_combination` using `i² = -1`. No axioms, no `sorry`.
+
+Not a named Mathlib result.
+-/
+
+namespace VanAubelTheoremOQ01OQ01
+
+open Complex ComplexConjugate
+
+/-- Center of the square erected externally on the directed edge `u → v`, using the `+90°`
+rotation convention `i · (v - u)` (identical to the parent entry's `squareCenter`). -/
+noncomputable def squareCenter (u v : ℂ) : ℂ := (u + v) / 2 + I * (v - u) / 2
+
+/-- The four square centers `P, Q, R, S` of the quadrilateral `a, b, c, d`. -/
+noncomputable def P (a b c d : ℂ) : ℂ := squareCenter a b
+noncomputable def Q (a b c d : ℂ) : ℂ := squareCenter b c
+noncomputable def R (a b c d : ℂ) : ℂ := squareCenter c d
+noncomputable def S (a b c d : ℂ) : ℂ := squareCenter d a
+
+/-- **Parent key identity** (restated for self-containedness): the diagonal `R - P` of the
+square-center quadrilateral equals `i` times the diagonal `S - Q`. Proved by
+`linear_combination` from `i² = -1`. -/
+theorem vanAubel_key (a b c d : ℂ) :
+    R a b c d - P a b c d = I * (S a b c d - Q a b c d) := by
+  unfold R P S Q squareCenter
+  linear_combination (-(a + b - c - d) / 2) * Complex.I_sq
+
+/-- Midpoint of two complex points. -/
+noncomputable def mid (x y : ℂ) : ℂ := (x + y) / 2
+
+/-- The four Varignon midpoints of the square-center quadrilateral `PQRS`. -/
+noncomputable def M₁ (a b c d : ℂ) : ℂ := mid (P a b c d) (Q a b c d)
+noncomputable def M₂ (a b c d : ℂ) : ℂ := mid (Q a b c d) (R a b c d)
+noncomputable def M₃ (a b c d : ℂ) : ℂ := mid (R a b c d) (S a b c d)
+noncomputable def M₄ (a b c d : ℂ) : ℂ := mid (S a b c d) (P a b c d)
+
+/-- Edge `M₁ → M₂` of the Varignon quadrilateral equals half the diagonal `R - P`. This is the
+content of Varignon's theorem for this edge: the side is parallel to a diagonal, half length. -/
+theorem varignon_edge12 (a b c d : ℂ) :
+    M₂ a b c d - M₁ a b c d = (R a b c d - P a b c d) / 2 := by
+  unfold M₂ M₁ mid; ring
+
+/-- Edge `M₂ → M₃` equals half the diagonal `S - Q`. -/
+theorem varignon_edge23 (a b c d : ℂ) :
+    M₃ a b c d - M₂ a b c d = (S a b c d - Q a b c d) / 2 := by
+  unfold M₃ M₂ mid; ring
+
+/-- Edge `M₃ → M₄` equals `-(R - P)/2` (the reverse of the first edge). -/
+theorem varignon_edge34 (a b c d : ℂ) :
+    M₄ a b c d - M₃ a b c d = -(R a b c d - P a b c d) / 2 := by
+  unfold M₄ M₃ mid; ring
+
+/-- Edge `M₄ → M₁` equals `-(S - Q)/2` (the reverse of the second edge). -/
+theorem varignon_edge41 (a b c d : ℂ) :
+    M₁ a b c d - M₄ a b c d = -(S a b c d - Q a b c d) / 2 := by
+  unfold M₁ M₄ mid; ring
+
+/-- **Rotation, edge 1 → edge 2.** The second Varignon edge is the first rotated by `-90°`
+(`-i`). This is the square-ness of the corner at `M₂`. Follows from the parent key identity. -/
+theorem varignon_rot12 (a b c d : ℂ) :
+    M₃ a b c d - M₂ a b c d = -I * (M₂ a b c d - M₁ a b c d) := by
+  rw [varignon_edge23, varignon_edge12]
+  -- R - P = I·(S - Q) ⟹ S - Q = -I·(R - P), since I·(-I) = 1.
+  have hSQ : S a b c d - Q a b c d = -I * (R a b c d - P a b c d) := by
+    linear_combination I * vanAubel_key a b c d
+      + (S a b c d - Q a b c d) * Complex.I_sq
+  rw [hSQ]; ring
+
+/-- **Rotation, edge 2 → edge 3.** Needs only the key identity (no `i² = -1`). -/
+theorem varignon_rot23 (a b c d : ℂ) :
+    M₄ a b c d - M₃ a b c d = -I * (M₃ a b c d - M₂ a b c d) := by
+  rw [varignon_edge34, varignon_edge23]
+  rw [vanAubel_key a b c d]; ring
+
+/-- **Rotation, edge 3 → edge 4.** -/
+theorem varignon_rot34 (a b c d : ℂ) :
+    M₁ a b c d - M₄ a b c d = -I * (M₄ a b c d - M₃ a b c d) := by
+  rw [varignon_edge41, varignon_edge34]
+  have hSQ : S a b c d - Q a b c d = -I * (R a b c d - P a b c d) := by
+    linear_combination I * vanAubel_key a b c d
+      + (S a b c d - Q a b c d) * Complex.I_sq
+  rw [hSQ]; ring
+
+/-- **Rotation, edge 4 → edge 1.** Closes the loop. Needs only the key identity. -/
+theorem varignon_rot41 (a b c d : ℂ) :
+    M₂ a b c d - M₁ a b c d = -I * (M₁ a b c d - M₄ a b c d) := by
+  rw [varignon_edge12, varignon_edge41]
+  rw [vanAubel_key a b c d]; ring
+
+/-- **Varignon is a parallelogram** (opposite edges are equal and opposite): the four edges
+sum to zero, so the polygon closes. Automatic for any quadrilateral's midpoints. -/
+theorem varignon_closes (a b c d : ℂ) :
+    (M₂ a b c d - M₁ a b c d) + (M₃ a b c d - M₂ a b c d)
+      + (M₄ a b c d - M₃ a b c d) + (M₁ a b c d - M₄ a b c d) = 0 := by
+  ring
+
+/-- **Equal sides.** All four sides of the Varignon quadrilateral have the same length: it is
+equilateral. Immediate from the `-i` rotation identities, since `|-i| = 1`. -/
+theorem varignon_equal_sides (a b c d : ℂ) :
+    ‖M₂ a b c d - M₁ a b c d‖ = ‖M₃ a b c d - M₂ a b c d‖
+      ∧ ‖M₃ a b c d - M₂ a b c d‖ = ‖M₄ a b c d - M₃ a b c d‖
+      ∧ ‖M₄ a b c d - M₃ a b c d‖ = ‖M₁ a b c d - M₄ a b c d‖ := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [varignon_rot12, norm_mul, norm_neg, Complex.norm_I, one_mul]
+  · rw [varignon_rot23, norm_mul, norm_neg, Complex.norm_I, one_mul]
+  · rw [varignon_rot34, norm_mul, norm_neg, Complex.norm_I, one_mul]
+
+/-- **Perpendicular consecutive sides.** Each corner of the Varignon quadrilateral is a right
+angle: the real part of `edgeₖ · conj(edge_{k+1})` vanishes. Together with equal sides this
+makes it a square. Shown here at the corner `M₂` (edge 1 vs edge 2); the other corners are
+identical by the analogous rotation identities. -/
+theorem varignon_perp (a b c d : ℂ) :
+    ((M₂ a b c d - M₁ a b c d) *
+        conj (M₃ a b c d - M₂ a b c d)).re = 0 := by
+  rw [varignon_rot12, map_mul]
+  rw [show conj (-I) = I by simp, ← mul_assoc, mul_comm _ I, mul_assoc,
+    Complex.mul_conj]
+  simp [Complex.ofReal_im]
+
+/-- **Side length is half the diagonal.** The common Varignon side length equals half the
+common van Aubel diagonal length `‖R - P‖ = ‖S - Q‖`. This pins down the size of the square. -/
+theorem varignon_side_eq_half_diagonal (a b c d : ℂ) :
+    ‖M₂ a b c d - M₁ a b c d‖ = ‖R a b c d - P a b c d‖ / 2 := by
+  rw [varignon_edge12, norm_div]
+  simp
+
+end VanAubelTheoremOQ01OQ01

--- a/src/data/proofs/van-aubel-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "van-aubel-theorem-oq-01-oq-01",
+  "title": "The van Aubel Square: the Varignon Parallelogram of the Square-Centers is a Square",
+  "slug": "van-aubel-theorem-oq-01-oq-01",
+  "description": "Follow-up to van Aubel's theorem (van-aubel-theorem-oq-01). The parent shows that the diagonals PR and QS of the square-center quadrilateral PQRS are equal and perpendicular, packaged as R - P = i·(S - Q). Applying Varignon's theorem to PQRS: the midpoints of its sides form a parallelogram whose adjacent side-vectors are exactly (R - P)/2 and (S - Q)/2. Because these are equal in length and perpendicular, the Varignon parallelogram of PQRS is a SQUARE, with side equal to half the common van Aubel diagonal length. Formalized over ℂ: each consecutive Varignon edge is a 90° rotation (-i) of the previous one, giving equal sides, right angles, and the exact side length. 13 theorems, 10 definitions, 0 axioms, 0 sorries.",
+  "references": [
+    {
+      "authors": "Henricus Hubertus van Aubel",
+      "title": "Note concernant les centres de carrés construits sur les côtés d'un polygone quelconque (Nouvelle Correspondance Mathématique 4)",
+      "year": 1878,
+      "note": "The original van Aubel theorem on square-centers of a quadrilateral; parent entry."
+    },
+    {
+      "authors": "Pierre Varignon",
+      "title": "Éléments de mathématique",
+      "year": 1731,
+      "note": "Varignon's theorem: the midpoints of the sides of any quadrilateral form a parallelogram whose sides are parallel to, and half the length of, the diagonals. Applied here to the square-center quadrilateral PQRS."
+    },
+    {
+      "authors": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Mathematical Association of America. Varignon parallelogram; a quadrilateral with equal, perpendicular diagonals has a square Varignon parallelogram."
+    },
+    {
+      "authors": "Liang-shin Hahn",
+      "title": "Complex Numbers and Geometry",
+      "year": 1994,
+      "note": "Mathematical Association of America. Complex-identity proofs of van Aubel/Varignon-type theorems via multiplication by i."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Van_Aubel%27s_theorem",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanAubelTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "quadrilateral",
+      "van-aubel",
+      "varignon",
+      "complex-numbers",
+      "coordinate-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (no sorry, no additional axioms).",
+    "lineCount": 163,
+    "theoremCount": 13,
+    "definitionCount": 10,
+    "originalContributions": [
+      "varignon_rot12 / _rot23 / _rot34 / _rot41: each consecutive edge of the Varignon quadrilateral of the square-centers PQRS is the previous edge rotated by -90° (multiplied by -i), the defining property that makes PQRS's Varignon parallelogram a square",
+      "varignon_equal_sides: all four sides of the Varignon quadrilateral have equal length (equilateral), immediate from |-i| = 1",
+      "varignon_perp: consecutive sides of the Varignon quadrilateral are perpendicular (right-angled corners), from (-i·z)·conj(z) purely imaginary",
+      "varignon_side_eq_half_diagonal: the common Varignon side length equals half the common van Aubel diagonal length ‖R - P‖/2, pinning down the size of the square",
+      "varignon_edge12 / _edge23 / _edge34 / _edge41: the four Varignon side-vectors are exactly ±(R - P)/2 and ±(S - Q)/2, the concrete content of Varignon's theorem for PQRS",
+      "vanAubel_key (restated): the parent identity R - P = i·(S - Q), the single algebraic fact from which the square-ness of the Varignon parallelogram is derived"
+    ]
+  },
+  "overview": {
+    "historicalContext": "van Aubel's theorem (1878) erects squares externally on the four sides of an arbitrary planar quadrilateral and asserts that the two segments joining the centers of opposite squares — the diagonals PR and QS of the square-center quadrilateral PQRS — are equal in length and perpendicular. Varignon's theorem (published posthumously in 1731) is even older: the midpoints of the sides of ANY quadrilateral form a parallelogram whose sides are parallel to and half the length of the two diagonals. Combining the two gives a striking corollary: since the diagonals of PQRS are equal AND perpendicular, its Varignon parallelogram is not merely a parallelogram but a genuine square. This 'van Aubel square' packages both classical theorems into a single verified statement.",
+    "problemStatement": "Let a, b, c, d ∈ ℂ be the vertices of an arbitrary quadrilateral, and let P, Q, R, S be the centers of the squares erected externally on the sides a→b, b→c, c→d, d→a. Let M₁, M₂, M₃, M₄ be the midpoints of the sides PQ, QR, RS, SP of the square-center quadrilateral. Prove that M₁M₂M₃M₄ is a square: its four sides are equal in length, its corners are right angles, and its side length equals half the common van Aubel diagonal length ‖R - P‖ = ‖S - Q‖.",
+    "proofStrategy": "Work in ℂ. Varignon's edges are computed directly: M₂ - M₁ = (R - P)/2, M₃ - M₂ = (S - Q)/2, M₄ - M₃ = -(R - P)/2, M₁ - M₄ = -(S - Q)/2 (each a pure ring identity). The parent van Aubel identity R - P = i·(S - Q) — proved by a one-line linear_combination from i² = -1 — is then used to show each consecutive edge is the previous one rotated by -90°: M_{k+1}-M_k = -i·(M_k - M_{k-1}). For the two corners needing i² = -1, the identity S - Q = -i·(R - P) is obtained by linear_combination I·(vanAubel_key) + (S-Q)·(i²+1). Equal side lengths follow from |-i| = 1 (norm_mul, norm_neg, ‖i‖ = 1); perpendicularity follows because (-i·z)·conj(z) = -i·|z|² is purely imaginary; and the side length ‖M₂-M₁‖ = ‖R-P‖/2 follows directly from the edge formula and norm_div.",
+    "keyInsights": [
+      "**Varignon converts a diagonal fact into a side fact.** The adjacent side-vectors of the Varignon parallelogram of PQRS are exactly the two van Aubel diagonals scaled by 1/2. So 'diagonals equal and perpendicular' becomes 'adjacent sides equal and perpendicular' — the definition of a square.",
+      "**One identity does all the work, twice.** The single equation R - P = i·(S - Q) is the parent's entire content. Here it is reused to rotate each Varignon edge onto the next, so the square-ness of the Varignon quadrilateral inherits directly from van Aubel.",
+      "**Only two of the four corners need i² = -1.** The edges M₂→M₃ and M₄→M₁ are related to their neighbours by the key identity alone (a bare rw + ring); the edges M₁→M₂ and M₃→M₄ need the derived S - Q = -i·(R - P), whose proof is the only place i² = -1 enters.",
+      "**The size is exact, not just the shape.** Beyond 'it is a square', the common side length is pinned to half the van Aubel diagonal length, so the van Aubel square is fully determined by the two equal diagonals it is built on."
+    ],
+    "prerequisites": [
+      "van Aubel's theorem (parent entry): R - P = i·(S - Q) for the square-centers of a quadrilateral",
+      "Varignon's theorem: midpoints of a quadrilateral's sides form a parallelogram with sides half the diagonals",
+      "Complex numbers as the Euclidean plane; multiplication by i (and -i) as ±90° rotation, |i| = 1",
+      "Lean 4 linear_combination, ring, and norm lemmas (norm_mul, norm_neg, norm_div, Complex.norm_I)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "square-centers",
+      "title": "Square Centers and the Parent Key Identity",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "Recaps squareCenter and names the four square-centers P, Q, R, S, then restates the parent van Aubel identity R - P = i·(S - Q), proved by linear_combination from i² = -1. Everything else descends from this one equation.",
+      "mathContext": "$R - P = i\\,(S - Q)$, with $\\mathrm{squareCenter}(u,v) = \\tfrac{u+v}{2} + i\\,\\tfrac{v-u}{2}$."
+    },
+    {
+      "id": "varignon-midpoints",
+      "title": "Varignon Midpoints of PQRS",
+      "startLine": 64,
+      "endLine": 71,
+      "summary": "Defines the four Varignon midpoints M₁ = mid(P,Q), M₂ = mid(Q,R), M₃ = mid(R,S), M₄ = mid(S,P) of the square-center quadrilateral.",
+      "mathContext": "$M_1 = \\tfrac{P+Q}{2},\\; M_2 = \\tfrac{Q+R}{2},\\; M_3 = \\tfrac{R+S}{2},\\; M_4 = \\tfrac{S+P}{2}$."
+    },
+    {
+      "id": "varignon-edges",
+      "title": "Varignon Side-Vectors are Half the Diagonals",
+      "startLine": 73,
+      "endLine": 93,
+      "summary": "The four directed edges of M₁M₂M₃M₄ equal ±(R - P)/2 and ±(S - Q)/2 — the concrete content of Varignon's theorem for PQRS. Each is a pure ring identity.",
+      "mathContext": "$M_2-M_1 = \\tfrac{R-P}{2},\\; M_3-M_2 = \\tfrac{S-Q}{2},\\; M_4-M_3 = -\\tfrac{R-P}{2},\\; M_1-M_4 = -\\tfrac{S-Q}{2}$."
+    },
+    {
+      "id": "rotation-identities",
+      "title": "Each Edge is the Previous Rotated by -90°",
+      "startLine": 95,
+      "endLine": 126,
+      "summary": "varignon_rot12/23/34/41: each consecutive Varignon edge is the previous edge multiplied by -i. rot23 and rot41 need only the key identity; rot12 and rot34 use the derived S - Q = -i·(R - P) (the sole appearance of i² = -1). This is the square-ness of every corner.",
+      "mathContext": "$M_{k+1}-M_k = -i\\,(M_k - M_{k-1})$ for each $k$, obtained from $R-P = i(S-Q)$ and $S-Q = -i(R-P)$."
+    },
+    {
+      "id": "closes",
+      "title": "The Varignon Quadrilateral Closes",
+      "startLine": 128,
+      "endLine": 133,
+      "summary": "varignon_closes: the four edge-vectors sum to zero, so M₁M₂M₃M₄ is a genuine closed quadrilateral (a parallelogram). Automatic for any quadrilateral's midpoints.",
+      "mathContext": "$(M_2-M_1)+(M_3-M_2)+(M_4-M_3)+(M_1-M_4) = 0$."
+    },
+    {
+      "id": "equal-sides",
+      "title": "Equilateral: All Four Sides Equal",
+      "startLine": 135,
+      "endLine": 146,
+      "summary": "varignon_equal_sides: all four side lengths coincide, immediate from the -i rotation identities and |-i| = 1 (norm_mul, norm_neg, ‖i‖ = 1).",
+      "mathContext": "$\\lVert M_{k+1}-M_k\\rVert = \\lVert -i\\,(M_k-M_{k-1})\\rVert = \\lVert M_k-M_{k-1}\\rVert$."
+    },
+    {
+      "id": "perp",
+      "title": "Right Angles: Consecutive Sides Perpendicular",
+      "startLine": 148,
+      "endLine": 156,
+      "summary": "varignon_perp: the real part of edge₁·conj(edge₂) vanishes, so the corner at M₂ is a right angle; the other corners are identical by the analogous rotation identities. Equilateral + right-angled = square.",
+      "mathContext": "$\\big((M_2-M_1)\\,\\overline{(M_3-M_2)}\\big) = -i\\,\\lVert M_3-M_2\\rVert^2$ is purely imaginary, so its real part is $0$."
+    },
+    {
+      "id": "side-length",
+      "title": "Side Length is Half the van Aubel Diagonal",
+      "startLine": 158,
+      "endLine": 161,
+      "summary": "varignon_side_eq_half_diagonal: the common side length equals ‖R - P‖/2, half the common van Aubel diagonal length, pinning down the exact size of the square.",
+      "mathContext": "$\\lVert M_2 - M_1\\rVert = \\tfrac{1}{2}\\lVert R - P\\rVert = \\tfrac{1}{2}\\lVert S - Q\\rVert$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves that the Varignon parallelogram of the van Aubel square-center quadrilateral PQRS is a square, and pins its side length to half the common van Aubel diagonal. The whole result descends from the parent identity R - P = i·(S - Q) combined with Varignon's midpoint theorem: the adjacent Varignon side-vectors are (R - P)/2 and (S - Q)/2, so equal-and-perpendicular diagonals become equal-and-perpendicular sides. 13 theorems, 10 definitions, 0 axioms, 0 sorries.",
+    "implications": "The van Aubel square shows how two classical planar theorems compose cleanly in the complex model: van Aubel supplies equal, perpendicular diagonals for PQRS, and Varignon converts them into the equal, perpendicular sides of a square. More generally, a quadrilateral has a square Varignon parallelogram exactly when its diagonals are equal and perpendicular — an orthodiagonal, equidiagonal condition that PQRS satisfies for every quadrilateral by van Aubel.",
+    "openQuestions": [
+      "Where is the center of the van Aubel square located relative to the original quadrilateral a, b, c, d, and does it admit a closed-form expression in ℂ?",
+      "Iterating the construction (take the square-centers of PQRS, then their Varignon square, and so on) — does the sequence of squares converge, and to what point?",
+      "Does the analogous inward-square construction (rotation by -i) produce a second van Aubel square, and how is it related to the outward one?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "van-aubel-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: van Aubel's theorem, which proves the diagonals PR and QS of PQRS are equal and perpendicular via R - P = i·(S - Q). This follow-up applies Varignon's theorem to conclude PQRS's Varignon parallelogram is a square."
+    },
+    {
+      "proofId": "napoleons-theorem",
+      "relationship": "related",
+      "description": "Napoleon's theorem, the triangle analogue (equilateral triangles on the sides), proved by the same complex-number / root-of-unity technique."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/VanAubelTheoremOQ01OQ01.lean",
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+    ],
+    "opens": [
+      "Complex",
+      "ComplexConjugate"
+    ],
+    "namespace": "VanAubelTheoremOQ01OQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 10,
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **van-aubel-theorem-oq-01-oq-01**, a theory-level follow-up to the completed parent **van-aubel-theorem-oq-01** (van Aubel's theorem).

**Result.** Given an arbitrary planar quadrilateral `a,b,c,d : ℂ` with square-centers `P,Q,R,S`, the **Varignon parallelogram of `PQRS` is a square**: the midpoints `M₁,M₂,M₃,M₄` of the sides `PQ, QR, RS, SP` form a square whose side length is exactly half the common van Aubel diagonal length `‖R-P‖ = ‖S-Q‖`.

**Why it works.** The adjacent Varignon side-vectors of `PQRS` are `(R-P)/2` and `(S-Q)/2`. The parent's key identity `R - P = i·(S - Q)` says these are equal in length and perpendicular — exactly the condition for the Varignon parallelogram to be a square. Concretely, each consecutive Varignon edge is the previous one rotated by `-i`:
- equal sides from `|-i| = 1`,
- right angles from `(-i·z)·conj(z)` being purely imaginary,
- exact side length from `norm_div`.

Two of the four corners use only the parent identity (`rw + ring`); the other two use the derived `S - Q = -i·(R - P)`, the sole appearance of `i² = -1` (via `linear_combination`).

## Verification

- Built with `lake env lean` against warm Mathlib — **compiles clean** (only harmless unused-variable linter warnings).
- `#print axioms` on the four headline theorems: **`[propext, Classical.choice, Quot.sound]` only** — no `sorry`, no `Lean.ofReduceBool`. Legitimately **0-axiom, verified**.
- **13 theorems, 10 definitions, 163 lines, 0 sorries.**

## Files
- `proofs/Proofs/VanAubelTheoremOQ01OQ01.lean` (new)
- `src/data/proofs/van-aubel-theorem-oq-01-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)