### PR TITLE
Fix: disclose Lean.ofReduceBool + correct sorry count (erdos-678)

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -55,7 +55,7 @@
         "relationship": "Related Erdős problem on factorial divisibility and prime power structure"
       }
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Least common multiple (LCM) of natural numbers",
       "Finite sets and fold operations (Finset.fold)",
@@ -65,7 +65,7 @@
       "Native decision procedures in Lean 4"
     ],
     "lineCount": 275,
-    "assumptions": "0 axiom(s) and 4 sorry(s). See the Lean source for details.",
+    "assumptions": "0 explicit `axiom` declarations and 3 sorries. The concrete Selfridge examples (`selfridge_example_1`, `selfridge_example_2`, `lcm_comparison_96_104`) are discharged by `native_decide`, which depends on the `Lean.ofReduceBool` axiom (kernel/compiler reduction). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Metadata-only repair of `src/data/proofs/erdos-678/meta.json` to match the Lean source, per the Axiom Integrity Policy.

## Evidence

**Before**:
- `meta.axiomCount: 0`
- `meta.assumptions: "0 axiom(s) and 4 sorry(s). See the Lean source for details."`

The Lean file uses `native_decide` 3× to discharge the substantive Selfridge counterexamples (`selfridge_example_1/2`, `lcm_comparison_96_104`) — presented as computationally verified — which depends on the `Lean.ofReduceBool` axiom. The old text disclosed neither this dependency nor the correct sorry count (actual 3; the 4th grep hit is inside a code comment).

**After**:
- `meta.axiomCount: 1` (reflects `Lean.ofReduceBool`; `leanFile.axiomCount` stays 0 — literal `axiom` declarations only)
- `meta.assumptions` now names the three `native_decide` theorems and the `Lean.ofReduceBool` dependency, and states 3 sorries.

Badge (`wip`) and status (`formalized`) unchanged — the main conjecture (`erdos_678_infinitely_many`, `cambie_2024`) still has sorries.

Closes #33095

---
Automated fix by lean-mechanic agent.