### PR TITLE
research(lucas-sequence-degree2-identities-oq-02-oq-01-oq-01): U is a divisibility sequence Uₘ∣Uₘₙ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01OQ01.lean
@@ -1,0 +1,130 @@
+import Mathlib.Tactic
+import Proofs.LucasSequenceDegree2Identities
+import Proofs.LucasSequenceDegree2IdentitiesOQ02
+
+/-
+# The Fundamental Lucas Sequence is a Divisibility Sequence: `Uₘ ∣ Uₘₙ`
+
+## Open Question (answered)
+
+The sibling entry `LucasSequenceDegree2IdentitiesOQ02OQ01` (the sharp gcd bound
+`gcd(Uₙ, Vₙ) ∣ 2`) closes with the explicit open question:
+
+> Prove the multiplication-by-index divisibility `Uₘ ∣ Uₘₙ` and the strong
+> divisibility `gcd(Uₘ, Uₙ) = U_{gcd(m,n)}` for the general Lucas sequence.
+
+This entry answers the **first half**: for the fundamental Lucas sequence
+`Uₙ(P,Q)` (`U₀ = 0, U₁ = 1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`) with *arbitrary* integer
+parameters `P, Q`,
+
+  **`Uₘ ∣ Uₘₖ`  for all `m, k`**,   equivalently   **`m ∣ n ⟹ Uₘ ∣ Uₙ`**.
+
+So `U` is a *divisibility sequence*.  This generalizes the classical facts
+`Fₘ ∣ Fₙ` (Fibonacci, `(P,Q) = (1,−1)`) and `Pₘ ∣ Pₙ` (Pell, `(2,−1)`) whenever
+`m ∣ n`.
+
+## Proof architecture
+
+The engine is a **subtraction-free bilinear addition law**, genuinely new to this
+family (the parent `OQ-02` only records the factor-2 law `2·U_{m+n} = U_m V_n + V_m U_n`):
+
+  **`U_add_clean` :  `U_{m+n+1} = U_{m+1}·U_{n+1} − Q·U_m·U_n`.**
+
+It is derived purely algebraically — *no new induction* — from the parent's
+`two_U_add` together with the companion relation `V_eq` (`Vₙ = 2Uₙ₊₁ − P Uₙ`) and the
+recurrence `U_add_two`: substituting `V_{n+1} = 2U_{n+2} − P U_{n+1}`,
+`V_m = 2U_{m+1} − P U_m`, and `U_{n+2} = P U_{n+1} − Q U_n` into `2·U_{m+n+1}` and
+cancelling the factor `2` collapses everything to the clean form
+(`linear_combination` discharges the algebra).
+
+With the clean law in hand, `Uₘ ∣ Uₘₖ` is a one-line induction on `k`:
+writing `m = m'+1` and `m·(k+1) = (m·k) + m' + 1`,
+
+  `U_{m(k+1)} = U_{m·k+1}·U_m − Q·U_{m·k}·U_{m'}`,
+
+whose first summand is visibly a multiple of `Uₘ` and whose second is a multiple of
+`U_{m·k}` — divisible by `Uₘ` by the inductive hypothesis.
+
+## Results
+
+* `U_add_clean`      — the subtraction-free addition law `U_{m+n+1} = U_{m+1}U_{n+1} − Q U_m U_n`.
+* `dvd_U_mul`        — `Uₘ ∣ U_{m·k}` (divisibility-sequence property).
+* `U_dvd_of_dvd`     — `m ∣ n ⟹ Uₘ ∣ Uₙ`.
+* `fib_dvd_of_dvd`   — Fibonacci instance `m ∣ n ⟹ Fₘ ∣ Fₙ`.
+* `pell_dvd_of_dvd`  — Pell instance `m ∣ n ⟹ Pₘ ∣ Pₙ`.
+* `fib_three_dvd_six`, `fib_three_six_values` — concrete `F₃ = 2 ∣ 8 = F₆`.
+* `V_not_dvd_seq`    — sharpness: the *companion* sequence `V` is **not** a divisibility
+  sequence (`V₂ = 3 ∤ 7 = V₄` for Fibonacci/Lucas), so the property is special to `U`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSequenceDegree2IdentitiesOQ02OQ01OQ01
+
+open LucasSequenceDegree2Identities
+open LucasSequenceDegree2IdentitiesOQ02
+
+/-- **Subtraction-free bilinear addition law.**
+`U_{m+n+1} = U_{m+1}·U_{n+1} − Q·U_m·U_n`.
+
+Unlike the parent's factor-2 law `2·U_{m+n} = U_m V_n + V_m U_n`, this carries no
+factor of `2`, which is exactly what makes it usable for divisibility.  It is obtained
+without any new induction: substitute the companion relation `V_eq` for `V_{n+1}` and
+`V_m` into `two_U_add`, use the recurrence for `U_{n+2}`, and cancel the `2`. -/
+theorem U_add_clean (P Q : ℤ) (m n : ℕ) :
+    U P Q (m + n + 1) = U P Q (m + 1) * U P Q (n + 1) - Q * U P Q m * U P Q n := by
+  have h1 := two_U_add P Q m (n + 1)
+  rw [← Nat.add_assoc] at h1
+  have hVn1 := V_eq P Q (n + 1)
+  have hVm := V_eq P Q m
+  have hUn2 := U_add_two P Q n
+  have h2 : 2 * U P Q (m + n + 1)
+      = 2 * (U P Q (m + 1) * U P Q (n + 1) - Q * U P Q m * U P Q n) := by
+    linear_combination h1 + U P Q m * hVn1 + U P Q (n + 1) * hVm + 2 * U P Q m * hUn2
+  exact mul_left_cancel₀ (by norm_num : (2 : ℤ) ≠ 0) h2
+
+/-- **Divisibility-sequence property.** `Uₘ ∣ U_{m·k}` for all `m, k`.
+
+Induction on `k`.  The step writes `m = m'+1` and `m·(k+1) = (m·k) + m' + 1`, applies
+`U_add_clean`, and reads off that both summands of
+`U_{m·k+1}·U_m − Q·U_{m·k}·U_{m'}` are multiples of `Uₘ` (the first trivially, the
+second by the inductive hypothesis `Uₘ ∣ U_{m·k}`). -/
+theorem dvd_U_mul (P Q : ℤ) (m k : ℕ) : U P Q m ∣ U P Q (m * k) := by
+  induction k with
+  | zero => simp
+  | succ j ih =>
+    cases m with
+    | zero => simp
+    | succ m' =>
+      have e : (m' + 1) * (j + 1) = (m' + 1) * j + m' + 1 := by ring
+      rw [e, U_add_clean]
+      exact dvd_sub (dvd_mul_left _ _) ((ih.mul_left Q).mul_right _)
+
+/-- **`U` is a divisibility sequence.** `m ∣ n ⟹ Uₘ ∣ Uₙ`. -/
+theorem U_dvd_of_dvd (P Q : ℤ) {m n : ℕ} (h : m ∣ n) : U P Q m ∣ U P Q n := by
+  obtain ⟨k, rfl⟩ := h
+  exact dvd_U_mul P Q m k
+
+/-- **Fibonacci instance.** `m ∣ n ⟹ Fₘ ∣ Fₙ`  (`(P,Q) = (1,−1)`). -/
+theorem fib_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : U 1 (-1) m ∣ U 1 (-1) n :=
+  U_dvd_of_dvd 1 (-1) h
+
+/-- **Pell instance.** `m ∣ n ⟹ Pₘ ∣ Pₙ`  (`(P,Q) = (2,−1)`). -/
+theorem pell_dvd_of_dvd {m n : ℕ} (h : m ∣ n) : U 2 (-1) m ∣ U 2 (-1) n :=
+  U_dvd_of_dvd 2 (-1) h
+
+/-- Concrete Fibonacci divisibility `F₃ ∣ F₆`. -/
+theorem fib_three_dvd_six : U 1 (-1) 3 ∣ U 1 (-1) 6 := fib_dvd_of_dvd (by norm_num)
+
+/-- The concrete values `F₃ = 2`, `F₆ = 8`, so `fib_three_dvd_six` is the non-vacuous
+`2 ∣ 8`.  Kernel `decide` (no `native_decide`). -/
+theorem fib_three_six_values : U 1 (-1) 3 = 2 ∧ U 1 (-1) 6 = 8 := by decide
+
+/-- **Sharpness: the companion sequence is not a divisibility sequence.**
+`V₂ = 3` does not divide `V₄ = 7` for the Fibonacci/Lucas pair `(1,−1)`, even though
+`2 ∣ 4`.  Hence the divisibility-sequence property is genuinely special to the
+*fundamental* sequence `U`; the companion `V` satisfies only the weaker
+odd-index divisibility.  Kernel `decide`. -/
+theorem V_not_dvd_seq : ¬ (V 1 (-1) 2 ∣ V 1 (-1) 4) := by decide
+
+end LucasSequenceDegree2IdentitiesOQ02OQ01OQ01

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-addition-law",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 74, "endLine": 84 },
+    "type": "theorem",
+    "title": "Subtraction-Free Bilinear Addition Law",
+    "content": "`U_add_clean` proves U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ. The parent OQ-02 records only the factor-2 law two_U_add: 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, whose factor of 2 blocks divisibility arguments. Here we substitute the companion relation V_eq (Vₙ = 2·Uₙ₊₁ − P·Uₙ) for both V_{n+1} and V_m, together with the recurrence U_add_two (U_{n+2} = P·U_{n+1} − Q·U_n), into 2·U_{m+n+1}; a single `linear_combination` collapses it to 2·(U_{m+1}U_{n+1} − Q Uₘ Uₙ), and `mul_left_cancel₀` removes the 2. No new induction is required — the clean law is a pure algebraic consequence of already-proved facts.",
+    "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$; for Fibonacci $(P,Q)=(1,-1)$ this is $F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n$.",
+    "significance": "critical",
+    "relatedConcepts": ["bilinear addition law", "Lucas sequence", "linear_combination", "divisibility sequence"],
+    "prerequisites": ["two_U_add", "V_eq", "U_add_two", "mul_left_cancel₀"]
+  },
+  {
+    "id": "ann-divisibility-sequence",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 101 },
+    "type": "theorem",
+    "title": "The Divisibility-Sequence Property Uₘ ∣ Uₘₖ",
+    "content": "`dvd_U_mul` proves Uₘ ∣ U_{m·k} by induction on k. Base k=0: U_{m·0}=U₀=0, divisible by anything. Step: write m = m'+1 and m·(k+1) = m·k + m' + 1 (by ring), then rewrite with U_add_clean to get U_{m(k+1)} = U_{m·k+1}·Uₘ − Q·U_{m·k}·U_{m'}. The first summand is a multiple of Uₘ (`dvd_mul_left`); the second is a multiple of U_{m·k}, hence of Uₘ by the inductive hypothesis ((ih.mul_left Q).mul_right _); `dvd_sub` combines the two.",
+    "mathContext": "$m \\mid n \\Rightarrow U_m \\mid U_n$: the fundamental Lucas sequence is a divisibility sequence. E.g. $F_3 = 2$ divides every third Fibonacci number.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility sequence", "induction", "dvd_sub", "Lucas sequence"],
+    "prerequisites": ["U_add_clean", "dvd_mul_left", "Dvd.Dvd.mul_left"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 104, "endLine": 121 },
+    "type": "concept",
+    "title": "Divisibility Form and Fibonacci/Pell Instances",
+    "content": "`U_dvd_of_dvd` restates the property in the natural form m ∣ n ⟹ Uₘ ∣ Uₙ: destructure n = m·k and apply dvd_U_mul. `fib_dvd_of_dvd` specializes (P,Q)=(1,−1) to recover the classical Fₘ ∣ Fₙ; `pell_dvd_of_dvd` specializes (2,−1) for Pₘ ∣ Pₙ. `fib_three_dvd_six` with `fib_three_six_values` gives the concrete non-vacuous instance F₃=2 ∣ 8=F₆ by kernel `decide`.",
+    "mathContext": "Classical $F_m \\mid F_n$ and Pell $P_m \\mid P_n$ whenever $m \\mid n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci divisibility", "Pell sequence", "specialization"],
+    "prerequisites": ["dvd_U_mul", "Dvd elimination"]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 128 },
+    "type": "insight",
+    "title": "Sharpness: the Companion Sequence is Not a Divisibility Sequence",
+    "content": "`V_not_dvd_seq` is a kernel `decide` check that V₂=3 does not divide V₄=7 for the Fibonacci/Lucas pair (1,−1), even though 2 ∣ 4. This shows the divisibility-sequence property is genuinely special to the fundamental sequence U and is not a consequence of the shared recurrence alone: the companion sequence V, which differs only in its initial data (V₀=2, V₁=P), fails it. (V satisfies only the weaker odd-index divisibility Vₘ ∣ Vₙ when n/m is odd.)",
+    "mathContext": "$V_2 = 3 \\nmid 7 = V_4$: the companion Lucas sequence is not a divisibility sequence, isolating the role of the $U_0=0, U_1=1$ initial data.",
+    "significance": "key",
+    "relatedConcepts": ["sharpness", "companion Lucas sequence", "divisibility sequence", "initial conditions"],
+    "prerequisites": ["decidability of integer divisibility"]
+  }
+]

--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+  "title": "The Fundamental Lucas Sequence is a Divisibility Sequence: Uₘ ∣ Uₘₙ",
+  "slug": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+  "description": "For the fundamental Lucas sequence Uₙ(P,Q) (U₀=0, U₁=1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ) with arbitrary integer parameters P, Q, this entry proves that U is a divisibility sequence: Uₘ ∣ Uₘₖ for all m, k, equivalently m ∣ n ⟹ Uₘ ∣ Uₙ. This answers the first half of the open question posed by the sibling entry lucas-sequence-degree2-identities-oq-02-oq-01. The engine is a new subtraction-free bilinear addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, derived algebraically (no new induction) from the parent's factor-2 law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ. Recovers the classical Fₘ ∣ Fₙ (Fibonacci) and Pₘ ∣ Pₙ (Pell). A companion sharpness result shows V is not a divisibility sequence (V₂=3 ∤ 7=V₄). Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lucas (1878) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_sequence",
+    "date": "1878",
+    "status": "verified",
+    "tags": ["number-theory", "lucas-sequences", "divisibility", "divisibility-sequence", "fibonacci", "pell", "induction", "research"],
+    "proofRepoPath": "Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {"theorem": "mul_left_cancel₀", "description": "Cancels the factor 2 from 2·U_{m+n+1} = 2·(U_{m+1}U_{n+1} − Q Uₘ Uₙ) to obtain the subtraction-free addition law over ℤ", "module": "Mathlib.Algebra.GroupWithZero.Basic"},
+      {"theorem": "dvd_sub", "description": "In a commutative ring, a ∣ b and a ∣ c give a ∣ b − c — combines the two divisible summands of U_add_clean in the inductive step", "module": "Mathlib.Algebra.Ring.Basic"},
+      {"theorem": "dvd_mul_left", "description": "a ∣ b · a — shows Uₘ divides the leading term U_{m·k+1}·Uₘ of the addition law", "module": "Mathlib.Algebra.Divisibility.Basic"},
+      {"theorem": "Dvd.Dvd.mul_left / Dvd.Dvd.mul_right", "description": "Propagate the inductive hypothesis Uₘ ∣ U_{m·k} through the product Q·U_{m·k}·U_{m'}", "module": "Mathlib.Algebra.Divisibility.Basic"},
+      {"theorem": "linear_combination", "description": "Discharges the algebraic collapse of 2·U_{m+n+1} to the clean form after substituting V_eq and the recurrence", "module": "Mathlib.Tactic.LinearCombination"}
+    ],
+    "originalContributions": [
+      "U_add_clean: a subtraction-free bilinear addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ for the general two-parameter Lucas sequence, obtained without new induction from the parent's factor-2 law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, the companion relation V_eq, and the recurrence",
+      "dvd_U_mul: the divisibility-sequence property Uₘ ∣ U_{m·k} for all m, k, by a one-line induction on k using U_add_clean",
+      "U_dvd_of_dvd: the equivalent statement m ∣ n ⟹ Uₘ ∣ Uₙ for arbitrary integer parameters P, Q",
+      "fib_dvd_of_dvd / pell_dvd_of_dvd: Fibonacci Fₘ ∣ Fₙ (P,Q)=(1,−1) and Pell Pₘ ∣ Pₙ (2,−1) instances",
+      "V_not_dvd_seq: sharpness — the companion sequence V is not a divisibility sequence (V₂=3 does not divide V₄=7 for the Fibonacci/Lucas pair), so the property is genuinely special to the fundamental sequence U"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 130,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms); no sorryAx and no Lean.ofReduceBool — the numerical checks (fib_three_six_values, V_not_dvd_seq) use kernel `decide`, not `native_decide`. Builds on the base entry LucasSequenceDegree2Identities (definitions of U, V and the relations V_eq, U_add_two) and the sibling entry LucasSequenceDegree2IdentitiesOQ02 (the factor-2 addition law two_U_add).",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "For fixed integer parameters (P, Q) the fundamental Lucas sequence Uₙ(P,Q) is defined by U₀=0, U₁=1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ; the Fibonacci sequence is (P,Q)=(1,−1) and the Pell sequence is (2,−1). Édouard Lucas (1878) proved that these sequences are divisibility sequences: whenever m divides n, Uₘ divides Uₙ. For Fibonacci this is the classical Fₘ ∣ Fₙ (so, e.g., F₃=2 divides every third Fibonacci number). The property is the arithmetic backbone of Lucas's primality theory and of the strong-divisibility law gcd(Uₘ, Uₙ) = U_{gcd(m,n)}.",
+    "problemStatement": "**Open question (lucas-sequence-degree2-identities-oq-02-oq-01)**: The sibling entry (sharp bound gcd(Uₙ,Vₙ) ∣ 2) closes by asking to prove the multiplication-by-index divisibility Uₘ ∣ Uₘₙ and the strong divisibility gcd(Uₘ,Uₙ)=U_{gcd(m,n)} for the general Lucas sequence.\n\n**Result**: A fully verified (0 sorries, 0 axioms) proof of the first half — U is a divisibility sequence, Uₘ ∣ Uₘₖ for all m,k, equivalently m ∣ n ⟹ Uₘ ∣ Uₙ — for arbitrary integer parameters (P,Q), with Fibonacci and Pell instances and a sharpness result showing the companion sequence V is not a divisibility sequence.",
+    "text": "U is a divisibility sequence: Uₘ ∣ Uₘₖ for all m,k. The proof turns on a new subtraction-free bilinear addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, from which the divisibility follows by a single induction.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **Subtraction-free addition law** (`U_add_clean`): the parent entry OQ-02 records only the factor-2 law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, whose factor of 2 obstructs divisibility. Substituting the companion relation V_eq (Vₙ = 2·Uₙ₊₁ − P·Uₙ) for both V_{n+1} and V_m, and the recurrence U_add_two (U_{n+2} = P·U_{n+1} − Q·U_n), into 2·U_{m+n+1} and cancelling the 2 via mul_left_cancel₀ collapses everything (one `linear_combination`) to the clean law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ. No new induction is needed.\n\n2. **Divisibility-sequence property** (`dvd_U_mul`): induction on k. Base k=0 gives U_{m·0}=U₀=0, divisible by anything. Step: write m = m'+1 and m·(k+1) = m·k + m' + 1, apply U_add_clean to get U_{m(k+1)} = U_{m·k+1}·Uₘ − Q·U_{m·k}·U_{m'}. The first summand is a multiple of Uₘ (dvd_mul_left); the second is a multiple of U_{m·k}, hence of Uₘ by the inductive hypothesis. dvd_sub combines them.\n\n3. **Divisibility form and instances** (`U_dvd_of_dvd`, `fib_dvd_of_dvd`, `pell_dvd_of_dvd`): rewrite n = m·k and specialize (P,Q) to (1,−1) and (2,−1).\n\n4. **Sharpness** (`V_not_dvd_seq`): a kernel `decide` check that V₂=3 does not divide V₄=7 for the Fibonacci/Lucas pair, even though 2 ∣ 4 — so divisibility is special to U, not shared by the companion V.",
+    "keyInsights": [
+      "**The factor of 2 is the whole obstruction**: the parent's addition law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ cannot prove divisibility because 2·U_{m(k+1)} being a multiple of Uₘ does not force U_{m(k+1)} to be. Deriving the subtraction-free law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ removes it and the divisibility becomes immediate.",
+      "**No new induction for the addition law**: the clean law is a pure algebraic consequence (a single linear_combination) of already-proved facts — the factor-2 law, the companion relation V_eq, and the recurrence — rather than a fresh consecutive-pair induction. This is the economical route the parent chain sets up.",
+      "**Divisibility is a one-line induction once the algebra is right**: with U_add_clean in hand, both summands of U_{m(k+1)} are visibly divisible by Uₘ (one directly, one by the inductive hypothesis), so the entire number-theoretic content collapses to dvd_sub of two obvious divisibilities.",
+      "**The fundamental sequence is special**: V is not a divisibility sequence (V₂ ∤ V₄), so the divisibility-sequence property distinguishes U from V — it is a genuine feature of the U₀=0, U₁=1 initial data, not of the shared recurrence."
+    ],
+    "prerequisites": [
+      "The fundamental and companion Lucas sequences Uₙ, Vₙ and their common recurrence",
+      "The parent factor-2 addition law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ and the companion relation V_eq",
+      "The divisibility API over a commutative ring (dvd_sub, dvd_mul_left, Dvd.Dvd.mul_left/right)"
+    ]
+  },
+  "sections": [
+    {"id": "addition-law", "title": "Subtraction-Free Bilinear Addition Law", "startLine": 1, "endLine": 84, "summary": "Module docstring and imports (Mathlib.Tactic, the base entry, and the OQ-02 sibling for two_U_add). U_add_clean derives U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ without new induction: substitute V_eq for V_{n+1}, V_m and the recurrence for U_{n+2} into 2·U_{m+n+1} = Uₘ·V_{n+1} + V_m·U_{n+1}, then cancel the 2 by mul_left_cancel₀; linear_combination discharges the algebra.", "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$, the general-parameter analogue of $F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n$."},
+    {"id": "divisibility-sequence", "title": "The Divisibility-Sequence Property Uₘ ∣ Uₘₖ", "startLine": 86, "endLine": 106, "summary": "dvd_U_mul proves Uₘ ∣ U_{m·k} by induction on k. Writing m = m'+1 and m·(k+1) = m·k + m' + 1, U_add_clean gives U_{m(k+1)} = U_{m·k+1}·Uₘ − Q·U_{m·k}·U_{m'}; the first term is divisible by Uₘ (dvd_mul_left), the second by U_{m·k} hence by Uₘ (inductive hypothesis), and dvd_sub combines them. U_dvd_of_dvd restates this as m ∣ n ⟹ Uₘ ∣ Uₙ.", "mathContext": "$m \\mid n \\Rightarrow U_m \\mid U_n$: the fundamental Lucas sequence is a divisibility sequence."},
+    {"id": "instances", "title": "Fibonacci and Pell Instances", "startLine": 108, "endLine": 121, "summary": "fib_dvd_of_dvd specializes to (P,Q)=(1,−1): m ∣ n ⟹ Fₘ ∣ Fₙ; pell_dvd_of_dvd to (2,−1): m ∣ n ⟹ Pₘ ∣ Pₙ. fib_three_dvd_six and fib_three_six_values give the concrete non-vacuous instance F₃=2 ∣ 8=F₆ (kernel decide).", "mathContext": "Classical corollaries $F_m \\mid F_n$ and $P_m \\mid P_n$ whenever $m \\mid n$."},
+    {"id": "sharpness", "title": "Sharpness: V is Not a Divisibility Sequence", "startLine": 123, "endLine": 130, "summary": "V_not_dvd_seq is a kernel `decide` check that V₂=3 does not divide V₄=7 for the Fibonacci/Lucas pair (1,−1), even though 2 ∣ 4. This shows the divisibility-sequence property is special to the fundamental sequence U and fails for the companion V (which satisfies only the weaker odd-index divisibility).", "mathContext": "$V_2 = 3 \\nmid 7 = V_4$: the companion Lucas sequence is not a divisibility sequence."}
+  ],
+  "crossReferences": [
+    {"targetId": "lucas-sequence-degree2-identities-oq-02-oq-01", "relationship": "extends", "description": "Answers the first half of the open question stated in this sibling entry (prove Uₘ ∣ Uₘₙ and the strong divisibility gcd(Uₘ,Uₙ)=U_{gcd(m,n)}); reuses its context of consecutive-term coprimality."},
+    {"targetId": "lucas-sequence-degree2-identities-oq-02", "relationship": "depends-on", "description": "Uses the parent's factor-2 bilinear addition law two_U_add (2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ), from which the subtraction-free law U_add_clean is derived algebraically."},
+    {"targetId": "lucas-sequence-degree2-identities", "relationship": "depends-on", "description": "Imports the base entry's definitions of the fundamental and companion Lucas sequences U, V and the relations V_eq (Vₙ = 2Uₙ₊₁ − P Uₙ) and U_add_two used throughout."}
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that the fundamental Lucas sequence Uₙ(P,Q) is a divisibility sequence — Uₘ ∣ Uₘₖ for all m,k, equivalently m ∣ n ⟹ Uₘ ∣ Uₙ — for arbitrary integer parameters (P,Q). The proof introduces a subtraction-free bilinear addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ (derived without new induction from the parent's factor-2 law), reduces the divisibility to a one-step induction, gives Fibonacci and Pell instances, and shows by a sharpness check that the companion sequence V is not a divisibility sequence.",
+    "implications": "**Theoretical Significance**: This closes the first half of the open question posed by the sibling gcd entry and supplies the arithmetic backbone of Lucas-sequence divisibility theory in the general two-parameter setting. Methodologically it shows how removing the factor of 2 from the family's existing addition law — a one-line algebraic derivation rather than a fresh induction — turns the divisibility into a triviality, and it isolates precisely where the fundamental sequence's U₀=0, U₁=1 initial data matters (the companion V fails the same property).",
+    "openQuestions": [
+      "Prove the strong divisibility law gcd(Uₘ, Uₙ) = U_{gcd(m,n)} (the second half of the parent open question), using the divisibility-sequence property here together with the coprimality of consecutive terms and a Euclidean-algorithm induction on the indices.",
+      "Formalize the sharp companion statement Vₘ ∣ Vₙ if and only if m ∣ n and n/m is odd, quantifying exactly how the companion sequence fails to be a divisibility sequence."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib.Tactic", "Proofs.LucasSequenceDegree2Identities", "Proofs.LucasSequenceDegree2IdentitiesOQ02"],
+    "opens": ["LucasSequenceDegree2Identities", "LucasSequenceDegree2IdentitiesOQ02"],
+    "namespace": "LucasSequenceDegree2IdentitiesOQ02OQ01OQ01",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LucasSequenceDegree2IdentitiesOQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {"authors": "Édouard Lucas", "title": "Théorie des fonctions numériques simplement périodiques", "year": "1878", "venue": "American Journal of Mathematics", "note": "Introduction of the general Lucas sequences Uₙ, Vₙ and their divisibility theory, including that Uₙ is a divisibility sequence"},
+    {"authors": "Paulo Ribenboim", "title": "The New Book of Prime Number Records", "year": "1996", "venue": "Springer", "note": "Divisibility properties of Lucas sequences, including Uₘ ∣ Uₙ for m ∣ n and the strong divisibility law"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering the **first half** of the open question posed by the sibling entry `lucas-sequence-degree2-identities-oq-02-oq-01` (the sharp gcd bound), which asked to *"prove the multiplication-by-index divisibility Uₘ ∣ Uₘₙ ... for the general Lucas sequence."*

For the fundamental Lucas sequence `Uₙ(P,Q)` (`U₀=0, U₁=1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ`) with **arbitrary** integer parameters, this proves **U is a divisibility sequence**:

> `Uₘ ∣ Uₘₖ` for all m,k  ⟺  `m ∣ n ⟹ Uₘ ∣ Uₙ`.

Recovers the classical `Fₘ ∣ Fₙ` (Fibonacci) and `Pₘ ∣ Pₙ` (Pell).

## Key idea

The parent OQ-02 records only the **factor-2** addition law `2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ`, whose factor of 2 blocks divisibility. This entry derives the **subtraction-free** law

```
U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ    (U_add_clean)
```

*algebraically* — a single `linear_combination` from `two_U_add`, the companion relation `V_eq`, and the recurrence, with no new induction. The divisibility `Uₘ ∣ Uₘₖ` is then a one-step induction on k (both summands of `U_{m(k+1)} = U_{m·k+1}·Uₘ − Q·U_{m·k}·U_{m'}` are divisible by Uₘ).

## Contents (8 theorems, 0 defs, 130 lines)

- `U_add_clean` — subtraction-free bilinear addition law (new to the family)
- `dvd_U_mul` — `Uₘ ∣ U_{m·k}`
- `U_dvd_of_dvd` — `m ∣ n ⟹ Uₘ ∣ Uₙ`
- `fib_dvd_of_dvd`, `pell_dvd_of_dvd` — Fibonacci/Pell instances
- `fib_three_dvd_six`, `fib_three_six_values` — concrete `F₃=2 ∣ 8=F₆`
- `V_not_dvd_seq` — **sharpness**: the companion V is *not* a divisibility sequence (`V₂=3 ∤ 7=V₄`), isolating the role of U's `U₀=0, U₁=1` initial data

## Verification

Built with `lake env lean` against warm Mathlib (Docker unavailable — host disk at 100%). `#print axioms` on all main theorems shows only the foundational trio `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (numerical checks use kernel `decide`, not `native_decide`). 0 axioms, 0 sorries.

## Follow-up

The **second half** of the parent open question — strong divisibility `gcd(Uₘ, Uₙ) = U_{gcd(m,n)}` — remains open and is recorded as a follow-up open question in this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)