### PR TITLE
Enrich Erdős #458 OQ-05: add 10 annotations (0 → 10, full-file coverage)

### DIFF
--- a/src/data/proofs/erdos-458-oq-05/annotations.json
+++ b/src/data/proofs/erdos-458-oq-05/annotations.json
@@ -1,0 +1,184 @@
+[
+  {
+    "id": "ann-lcm-upto",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 39,
+      "endLine": 40
+    },
+    "type": "definition",
+    "title": "lcm_upto: The Running Least Common Multiple",
+    "content": "**`lcm_upto n = lcm(1, 2, …, n)`,** realized as the `Finset.lcm` of the identity over `Finset.Icc 1 n`. This reproduces the parent entry's definition so the companion is self-contained and independently checkable.\n\nThis is the quantity whose growth drives Erdős #458: `lcm(1,…,m)` equals `e^{ψ(m)}` where `ψ` is the second Chebyshev function, so it grows like `e^{m}` — the reason kernel `decide` on `lcm_upto` becomes impractical for large `k`.",
+    "mathContext": "$\\operatorname{lcm\\_upto}(n) = \\operatorname{lcm}(1,2,\\dots,n) = e^{\\psi(n)}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.lcm",
+      "Chebyshev function ψ",
+      "least common multiple"
+    ]
+  },
+  {
+    "id": "ann-nthprime-def",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 42,
+      "endLine": 43
+    },
+    "type": "definition",
+    "title": "nthPrime: The k-th Prime via Nat.nth",
+    "content": "**`nthPrime k = Nat.nth Nat.Prime k`,** the `k`-th element (0-indexed) of the set of primes in increasing order. `Nat.nth p` enumerates `{n | p n}`; for the infinite predicate `Nat.Prime` it is total, giving `p_0 = 2, p_1 = 3, …`.\n\nIt is `noncomputable` because `Nat.nth` is defined by classical well-ordering rather than by an evaluable sieve — which is precisely why the value facts below must be recovered indirectly through the `Nat.nth`/`Nat.count` Galois bridge rather than by evaluation.",
+    "mathContext": "$\\operatorname{nthPrime}(k) = p_k = \\operatorname{Nat.nth}\\ \\operatorname{Nat.Prime}\\ k$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.nth",
+      "prime enumeration",
+      "noncomputable definitions"
+    ]
+  },
+  {
+    "id": "ann-nthprime-prime",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 45,
+      "endLine": 47
+    },
+    "type": "theorem",
+    "title": "Every nthPrime Is Prime",
+    "content": "**`(nthPrime k).Prime`.** Since the set of primes is infinite (`Nat.infinite_setOf_prime`), `Nat.nth_mem_of_infinite` guarantees that the `k`-th enumerated element genuinely satisfies the predicate — so `p_k` is always a prime, for every `k`.\n\nInfinitude is the essential hypothesis: for a finite predicate `Nat.nth` would return junk `0` past the last element, and membership could fail.",
+    "mathContext": "$p_k \\text{ is prime for all } k,\\quad \\text{using } |\\{n : \\text{prime}\\}| = \\infty$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_mem_of_infinite",
+      "infinitude of primes",
+      "Euclid's theorem"
+    ]
+  },
+  {
+    "id": "ann-nthprime-strictmono",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 49,
+      "endLine": 51
+    },
+    "type": "theorem",
+    "title": "nthPrime Is Strictly Increasing",
+    "content": "**`StrictMono nthPrime`.** `Nat.nth_strictMono` (again using infinitude) gives `p_i < p_j` whenever `i < j`, so the enumeration lists the primes in strictly increasing order with no repeats. This is what lets the base-case inequalities treat `p_{k+1} - 1` and `p_k` as honest, distinct bounds.",
+    "mathContext": "$i < j \\implies p_i < p_j$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_strictMono",
+      "strict monotonicity",
+      "ordered enumeration"
+    ]
+  },
+  {
+    "id": "ann-nth-count-bridge",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 53,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "The Nat.nth / Nat.count Galois Bridge",
+    "content": "**The technique that makes every prime value axiom-free.** `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` says: if `n` satisfies `p`, then the index at which `Nat.nth` returns `n` is exactly the number of earlier elements satisfying `p`, namely `Nat.count p n`.\n\nThis is a Galois-style inverse relationship between the enumeration `Nat.nth` and the counting function `Nat.count`. To pin down `p_k`, one supplies (i) a primality proof of the intended value `n` and (ii) a *decidable* evaluation `Nat.count Nat.Prime n = k`. Both discharge by kernel `decide`, so no value is ever asserted and no `native_decide`/`Lean.ofReduceBool` enters.",
+    "mathContext": "$p(n) \\implies \\operatorname{Nat.nth}\\ p\\ (\\operatorname{Nat.count}\\ p\\ n) = n$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.nth_count",
+      "Galois connection",
+      "prime-counting function",
+      "kernel decide"
+    ]
+  },
+  {
+    "id": "ann-nthprime-zero",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 62,
+      "endLine": 67
+    },
+    "type": "theorem",
+    "title": "Worked Instance: p₀ = 2",
+    "content": "**The template for all eleven value theorems.** `show Nat.nth Nat.Prime 0 = 2` unfolds the definition; `Nat.nth_count Nat.prime_two` yields `Nat.nth Nat.Prime (Nat.count Nat.Prime 2) = 2`; and `Nat.count Nat.Prime 2 = 0` (there are zero primes below 2) is closed by kernel `decide`. Rewriting the count index gives the value.\n\nEvery later theorem `nthPrime_one … nthPrime_ten` is the same three lines with the primality witness and the count literal swapped — a fully uniform, kernel-checkable pattern.",
+    "mathContext": "$\\operatorname{Nat.count}\\ \\operatorname{Nat.Prime}\\ 2 = 0 \\implies p_0 = 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.prime_two",
+      "proof template",
+      "rewriting by count"
+    ]
+  },
+  {
+    "id": "ann-nthprime-ten",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 132,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "Extending the Reach: p₁₀ = 31",
+    "content": "**The farthest new value, and the edge of kernel feasibility.** `nthPrime_ten` proves the 11th prime is 31 by evaluating `Nat.count Nat.Prime 31 = 10` in the kernel — counting the ten primes 2,3,5,7,11,13,17,19,23,29 below 31. The values `p_5 … p_10` (13,17,19,23,29,31) are new relative to the parent entry, which stopped at `p_4`.\n\nKernel `decide` on prime-counting up to 31 is comfortable; the practical ceiling for this axiom-free approach comes not from counting but from `lcm_upto` in the base cases, whose values explode exponentially.",
+    "mathContext": "$\\operatorname{Nat.count}\\ \\operatorname{Nat.Prime}\\ 31 = 10 \\implies p_{10} = 31$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime counting up to 31",
+      "extending base coverage",
+      "kernel reduction limits"
+    ]
+  },
+  {
+    "id": "ann-basecase-section",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 139,
+      "endLine": 149
+    },
+    "type": "insight",
+    "title": "Reducing the Conjecture to a Decidable Inequality",
+    "content": "**How an open conjecture yields verifiable instances.** For fixed `k` the statement `lcm_upto (p_{k+1} - 1) < p_k · lcm_upto p_k` involves the noncomputable `nthPrime`. Rewriting the two prime values to numeric literals (via the theorems above) collapses each side to a concrete natural number, turning the instance into a decidable `<` between literals that kernel `decide` closes.\n\nThis is the standard 'formalize the open statement, verify finitely many cases' pattern: the *conjecture* stays open for all `k`, but each specific `k` becomes a finite, axiom-free computation.",
+    "mathContext": "$\\operatorname{lcm\\_upto}(p_{k+1}-1) < p_k\\cdot \\operatorname{lcm\\_upto}(p_k)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "decidable inequality",
+      "finite case verification",
+      "open conjecture instances"
+    ]
+  },
+  {
+    "id": "ann-erdos458-k4",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 166,
+      "endLine": 169
+    },
+    "type": "theorem",
+    "title": "The Heaviest Case: k = 4 (27720 < 304920)",
+    "content": "**The largest kernel computation in the file.** For `k = 4` the inequality is `lcm_upto 12 < 11 · lcm_upto 11`, i.e. `27720 < 304920`. After `rw [nthPrime_four, nthPrime_five]` the goal is a `<` between these literals, and `decide` computes `lcm(1,…,12) = 27720` and `11 · lcm(1,…,11) = 11 · 27720` inside the kernel.\n\nThis is where the exponential growth of `lcm_upto` starts to bite: pushing to `k = 5` needs `lcm(1,…,16) = 720720`, and each further step roughly quadruples the numbers the kernel must reduce.",
+    "mathContext": "$\\operatorname{lcm}(1,\\dots,12) = 27720 < 11\\cdot\\operatorname{lcm}(1,\\dots,11) = 304920$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "lcm(1..12) = 27720",
+      "exponential lcm growth",
+      "kernel decide cost"
+    ]
+  },
+  {
+    "id": "ann-erdos458-base",
+    "proofId": "erdos-458-oq-05",
+    "range": {
+      "startLine": 171,
+      "endLine": 178
+    },
+    "type": "theorem",
+    "title": "Packaged Result: Erdős #458 for k ∈ {1,2,3,4}",
+    "content": "**The headline theorem.** A single statement `∀ k, 1 ≤ k → k ≤ 4 → lcm_upto (p_{k+1} - 1) < p_k · lcm_upto p_k`, proved by `interval_cases k` splitting into the four base lemmas `erdos458_k1 … erdos458_k4`. This extends the parent formalization's `k = 1, 2` to `k = 1, 2, 3, 4` and, by using only kernel `decide`, drops the parent's `native_decide` / `Lean.ofReduceBool` dependency — so these instances of the open Erdős #458 inequality are genuinely 0-axiom.",
+    "mathContext": "$\\forall k\\in\\{1,2,3,4\\}:\\ \\operatorname{lcm\\_upto}(p_{k+1}-1) < p_k\\cdot \\operatorname{lcm\\_upto}(p_k)$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "interval_cases",
+      "Erdős #458",
+      "axiom-free verification",
+      "native_decide elimination"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-458-oq-05/annotations.source.json
+++ b/src/data/proofs/erdos-458-oq-05/annotations.source.json
@@ -1,0 +1,192 @@
+[
+  {
+    "id": "ann-lcm-upto",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "lcm_upto",
+      "kind": "def"
+    },
+    "type": "definition",
+    "title": "lcm_upto: The Running Least Common Multiple",
+    "content": "**`lcm_upto n = lcm(1, 2, …, n)`,** realized as the `Finset.lcm` of the identity over `Finset.Icc 1 n`. This reproduces the parent entry's definition so the companion is self-contained and independently checkable.\n\nThis is the quantity whose growth drives Erdős #458: `lcm(1,…,m)` equals `e^{ψ(m)}` where `ψ` is the second Chebyshev function, so it grows like `e^{m}` — the reason kernel `decide` on `lcm_upto` becomes impractical for large `k`.",
+    "mathContext": "$\\operatorname{lcm\\_upto}(n) = \\operatorname{lcm}(1,2,\\dots,n) = e^{\\psi(n)}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.lcm",
+      "Chebyshev function ψ",
+      "least common multiple"
+    ]
+  },
+  {
+    "id": "ann-nthprime-def",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "nthPrime",
+      "kind": "def"
+    },
+    "type": "definition",
+    "title": "nthPrime: The k-th Prime via Nat.nth",
+    "content": "**`nthPrime k = Nat.nth Nat.Prime k`,** the `k`-th element (0-indexed) of the set of primes in increasing order. `Nat.nth p` enumerates `{n | p n}`; for the infinite predicate `Nat.Prime` it is total, giving `p_0 = 2, p_1 = 3, …`.\n\nIt is `noncomputable` because `Nat.nth` is defined by classical well-ordering rather than by an evaluable sieve — which is precisely why the value facts below must be recovered indirectly through the `Nat.nth`/`Nat.count` Galois bridge rather than by evaluation.",
+    "mathContext": "$\\operatorname{nthPrime}(k) = p_k = \\operatorname{Nat.nth}\\ \\operatorname{Nat.Prime}\\ k$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.nth",
+      "prime enumeration",
+      "noncomputable definitions"
+    ]
+  },
+  {
+    "id": "ann-nthprime-prime",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "nthPrime_prime",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Every nthPrime Is Prime",
+    "content": "**`(nthPrime k).Prime`.** Since the set of primes is infinite (`Nat.infinite_setOf_prime`), `Nat.nth_mem_of_infinite` guarantees that the `k`-th enumerated element genuinely satisfies the predicate — so `p_k` is always a prime, for every `k`.\n\nInfinitude is the essential hypothesis: for a finite predicate `Nat.nth` would return junk `0` past the last element, and membership could fail.",
+    "mathContext": "$p_k \\text{ is prime for all } k,\\quad \\text{using } |\\{n : \\text{prime}\\}| = \\infty$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_mem_of_infinite",
+      "infinitude of primes",
+      "Euclid's theorem"
+    ]
+  },
+  {
+    "id": "ann-nthprime-strictmono",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "nthPrime_strictMono",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "nthPrime Is Strictly Increasing",
+    "content": "**`StrictMono nthPrime`.** `Nat.nth_strictMono` (again using infinitude) gives `p_i < p_j` whenever `i < j`, so the enumeration lists the primes in strictly increasing order with no repeats. This is what lets the base-case inequalities treat `p_{k+1} - 1` and `p_k` as honest, distinct bounds.",
+    "mathContext": "$i < j \\implies p_i < p_j$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.nth_strictMono",
+      "strict monotonicity",
+      "ordered enumeration"
+    ]
+  },
+  {
+    "id": "ann-nth-count-bridge",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Prime-index values from"
+    },
+    "type": "insight",
+    "title": "The Nat.nth / Nat.count Galois Bridge",
+    "content": "**The technique that makes every prime value axiom-free.** `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` says: if `n` satisfies `p`, then the index at which `Nat.nth` returns `n` is exactly the number of earlier elements satisfying `p`, namely `Nat.count p n`.\n\nThis is a Galois-style inverse relationship between the enumeration `Nat.nth` and the counting function `Nat.count`. To pin down `p_k`, one supplies (i) a primality proof of the intended value `n` and (ii) a *decidable* evaluation `Nat.count Nat.Prime n = k`. Both discharge by kernel `decide`, so no value is ever asserted and no `native_decide`/`Lean.ofReduceBool` enters.",
+    "mathContext": "$p(n) \\implies \\operatorname{Nat.nth}\\ p\\ (\\operatorname{Nat.count}\\ p\\ n) = n$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.nth_count",
+      "Galois connection",
+      "prime-counting function",
+      "kernel decide"
+    ]
+  },
+  {
+    "id": "ann-nthprime-zero",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "nthPrime_zero",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Worked Instance: p₀ = 2",
+    "content": "**The template for all eleven value theorems.** `show Nat.nth Nat.Prime 0 = 2` unfolds the definition; `Nat.nth_count Nat.prime_two` yields `Nat.nth Nat.Prime (Nat.count Nat.Prime 2) = 2`; and `Nat.count Nat.Prime 2 = 0` (there are zero primes below 2) is closed by kernel `decide`. Rewriting the count index gives the value.\n\nEvery later theorem `nthPrime_one … nthPrime_ten` is the same three lines with the primality witness and the count literal swapped — a fully uniform, kernel-checkable pattern.",
+    "mathContext": "$\\operatorname{Nat.count}\\ \\operatorname{Nat.Prime}\\ 2 = 0 \\implies p_0 = 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.prime_two",
+      "proof template",
+      "rewriting by count"
+    ]
+  },
+  {
+    "id": "ann-nthprime-ten",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "nthPrime_ten",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Extending the Reach: p₁₀ = 31",
+    "content": "**The farthest new value, and the edge of kernel feasibility.** `nthPrime_ten` proves the 11th prime is 31 by evaluating `Nat.count Nat.Prime 31 = 10` in the kernel — counting the ten primes 2,3,5,7,11,13,17,19,23,29 below 31. The values `p_5 … p_10` (13,17,19,23,29,31) are new relative to the parent entry, which stopped at `p_4`.\n\nKernel `decide` on prime-counting up to 31 is comfortable; the practical ceiling for this axiom-free approach comes not from counting but from `lcm_upto` in the base cases, whose values explode exponentially.",
+    "mathContext": "$\\operatorname{Nat.count}\\ \\operatorname{Nat.Prime}\\ 31 = 10 \\implies p_{10} = 31$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime counting up to 31",
+      "extending base coverage",
+      "kernel reduction limits"
+    ]
+  },
+  {
+    "id": "ann-basecase-section",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "section-doc",
+      "contains": "Axiom-free base cases"
+    },
+    "type": "insight",
+    "title": "Reducing the Conjecture to a Decidable Inequality",
+    "content": "**How an open conjecture yields verifiable instances.** For fixed `k` the statement `lcm_upto (p_{k+1} - 1) < p_k · lcm_upto p_k` involves the noncomputable `nthPrime`. Rewriting the two prime values to numeric literals (via the theorems above) collapses each side to a concrete natural number, turning the instance into a decidable `<` between literals that kernel `decide` closes.\n\nThis is the standard 'formalize the open statement, verify finitely many cases' pattern: the *conjecture* stays open for all `k`, but each specific `k` becomes a finite, axiom-free computation.",
+    "mathContext": "$\\operatorname{lcm\\_upto}(p_{k+1}-1) < p_k\\cdot \\operatorname{lcm\\_upto}(p_k)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "decidable inequality",
+      "finite case verification",
+      "open conjecture instances"
+    ]
+  },
+  {
+    "id": "ann-erdos458-k4",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "erdos458_k4",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "The Heaviest Case: k = 4 (27720 < 304920)",
+    "content": "**The largest kernel computation in the file.** For `k = 4` the inequality is `lcm_upto 12 < 11 · lcm_upto 11`, i.e. `27720 < 304920`. After `rw [nthPrime_four, nthPrime_five]` the goal is a `<` between these literals, and `decide` computes `lcm(1,…,12) = 27720` and `11 · lcm(1,…,11) = 11 · 27720` inside the kernel.\n\nThis is where the exponential growth of `lcm_upto` starts to bite: pushing to `k = 5` needs `lcm(1,…,16) = 720720`, and each further step roughly quadruples the numbers the kernel must reduce.",
+    "mathContext": "$\\operatorname{lcm}(1,\\dots,12) = 27720 < 11\\cdot\\operatorname{lcm}(1,\\dots,11) = 304920$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "lcm(1..12) = 27720",
+      "exponential lcm growth",
+      "kernel decide cost"
+    ]
+  },
+  {
+    "id": "ann-erdos458-base",
+    "proofId": "erdos-458-oq-05",
+    "anchor": {
+      "type": "declaration",
+      "name": "erdos458_base",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Packaged Result: Erdős #458 for k ∈ {1,2,3,4}",
+    "content": "**The headline theorem.** A single statement `∀ k, 1 ≤ k → k ≤ 4 → lcm_upto (p_{k+1} - 1) < p_k · lcm_upto p_k`, proved by `interval_cases k` splitting into the four base lemmas `erdos458_k1 … erdos458_k4`. This extends the parent formalization's `k = 1, 2` to `k = 1, 2, 3, 4` and, by using only kernel `decide`, drops the parent's `native_decide` / `Lean.ofReduceBool` dependency — so these instances of the open Erdős #458 inequality are genuinely 0-axiom.",
+    "mathContext": "$\\forall k\\in\\{1,2,3,4\\}:\\ \\operatorname{lcm\\_upto}(p_{k+1}-1) < p_k\\cdot \\operatorname{lcm\\_upto}(p_k)$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "interval_cases",
+      "Erdős #458",
+      "axiom-free verification",
+      "native_decide elimination"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-458-oq-05` (quality 34, 0 prior passes).

**Gap addressed:** the entry had no `annotations.json`. Added 10 anchor-based annotations giving full-file coverage of `Erdos458OQ05.lean`:

- **Definitions** — `lcm_upto` and the noncomputable `nthPrime`
- **Structural facts** — `nthPrime_prime`, `nthPrime_strictMono`
- **Technique** — the `Nat.nth`/`Nat.count` Galois bridge (`Nat.nth_count`) that makes every prime value axiom-free
- **Worked instances** — `p₀ = 2` (the uniform template) and `p₁₀ = 31` (the extended reach + kernel-feasibility edge)
- **Base cases** — the reduction of the open conjecture to a decidable inequality, the heaviest kernel computation `erdos458_k4` (27720 < 304920), and the packaged `erdos458_base` for k∈{1,2,3,4}

Each annotation includes `mathContext` (LaTeX), `significance`, and `relatedConcepts`. Authored via `annotations.source.json` anchors and resolved with `scripts/annotations/build.ts`; all 10 anchors resolve to correct, non-overlapping line ranges. meta.json unchanged.