### PR TITLE
Enrich Polar Decomposition A = U·√(AᴴA): add 8 annotations (0 → 8, full-file coverage)

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/annotations.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "ann-polarfactor-def",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "The Polar Factor P = √(AᴴA)",
+    "content": "**`polarFactor A = CFC.sqrt (Aᴴ * A)`.** The positive semidefinite 'modulus' `|A| = √(AᴴA)`, defined directly through Mathlib's C⋆-algebraic continuous-functional-calculus square root `CFC.sqrt`. Because `Aᴴ·A` is always positive semidefinite, its square root exists unconditionally — no hypothesis on `A` is needed to *define* the factor.\n\nThis is the matrix analogue of the modulus `r = |z|` in the complex polar form `z = r·e^{iθ}`. It is `noncomputable` because `CFC.sqrt` is built from the spectral theorem via classical choice.",
+    "mathContext": "$P = |A| = \\sqrt{A^{\\mathsf H}A} = \\operatorname{CFC.sqrt}(A^{\\mathsf H}A)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt",
+      "operator absolute value",
+      "continuous functional calculus",
+      "AᴴA is positive semidefinite"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-possemidef",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "The Polar Factor Is Positive Semidefinite",
+    "content": "**`(polarFactor A).PosSemidef`.** The CFC square root of any element is nonnegative in the C⋆-order (`CFC.sqrt_nonneg`), and `.posSemidef` transports that Loewner-order nonnegativity into the concrete `Matrix.PosSemidef` predicate. This is the property that qualifies `P` as a legitimate polar 'modulus' — the whole point is that the modulus is genuinely a PSD matrix.",
+    "mathContext": "$\\sqrt{A^{\\mathsf H}A} \\succeq 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CFC.sqrt_nonneg",
+      "Matrix.PosSemidef",
+      "Loewner order"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-mul-self",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 69
+    },
+    "type": "theorem",
+    "title": "Defining Identity: (√(AᴴA))² = AᴴA",
+    "content": "**`polarFactor A * polarFactor A = Aᴴ * A`.** The square-root property specialized to the PSD matrix `Aᴴ·A`: `CFC.sqrt_mul_sqrt_self` gives `√X · √X = X` for `X ≥ 0`, applied here with `X = Aᴴ·A` (nonnegative by `posSemidef_conjTranspose_mul_self`).\n\nThis single identity is the algebraic engine of everything downstream — it is what lets `AᴴA` be replaced by `P²` in the uniqueness argument, and what feeds the determinant computation `det(P)² = det(AᴴA)`.",
+    "mathContext": "$P^2 = A^{\\mathsf H}A,\\qquad P = \\sqrt{A^{\\mathsf H}A}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt_mul_sqrt_self",
+      "posSemidef_conjTranspose_mul_self",
+      "defining identity"
+    ]
+  },
+  {
+    "id": "ann-polar-psd-unique",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "The Modulus Is Forced — No Invertibility Needed",
+    "content": "**The structural heart of polar decomposition.** Given *any* factorization `A = U·P` with `U` unitary and `P` PSD, the PSD factor is uniquely `P = √(AᴴA)`. The proof collapses `AᴴA`: since `Uᴴ·U = 1` (`Unitary.star_mul_self_of_mem`) and `Pᴴ = P` (`PosSemidef.isHermitian`),\n\n`Aᴴ·A = (U·P)ᴴ·(U·P) = Pᴴ·(Uᴴ·U)·P = P·P`,\n\nand `CFC.sqrt_unique` then forces `P = √(AᴴA)`. **This needs no regularity of `A` whatsoever** — the modulus `|A|` is intrinsic, and only the unitary phase `U` can ever be ambiguous. Everything else in the file is the (invertible-case) recovery of that phase.",
+    "mathContext": "$A = U P,\\ U\\text{ unitary},\\ P\\succeq 0 \\ \\Longrightarrow\\ A^{\\mathsf H}A = P(U^{\\mathsf H}U)P = P^2 \\ \\Longrightarrow\\ P = \\sqrt{A^{\\mathsf H}A}$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "CFC.sqrt_unique",
+      "Unitary.star_mul_self_of_mem",
+      "PosSemidef.isHermitian",
+      "intrinsic modulus"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-isunit-det",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Invertibility Transfers Through the Determinant",
+    "content": "**When `A` is invertible, so is its polar factor.** Applying `det` to `P² = Aᴴ·A` gives `det(P)² = det(Aᴴ)·det(A) = star(det A)·det(A) = |det A|²` (via `det_mul`, `det_conjTranspose`). If `A` is a unit then `det A ≠ 0`, so `|det A|² ≠ 0`, hence `det P ≠ 0` and `P` is invertible (`isUnit_iff_isUnit_det`).\n\nThis is precisely the hypothesis needed to write the explicit unitary factor `U = A·P⁻¹` in the next theorem.",
+    "mathContext": "$\\det(P)^2 = \\overline{\\det A}\\,\\det A = |\\det A|^2 \\ne 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.det_conjTranspose",
+      "isUnit_iff_isUnit_det",
+      "isUnit_iff_ne_zero",
+      "determinant of a square root"
+    ]
+  },
+  {
+    "id": "ann-polar-right",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "Existence: A = U·√(AᴴA) with U = A·P⁻¹",
+    "content": "**The classical right polar decomposition, invertible case.** The unitary factor is given by an *explicit formula* `U := A·P⁻¹`, not an abstract existence claim. Unitarity is verified by cancellation:\n\n`star(A·P⁻¹)·(A·P⁻¹) = P⁻¹·(Aᴴ·A)·P⁻¹ = P⁻¹·P²·P⁻¹ = (P⁻¹P)(PP⁻¹) = 1`,\n\nusing `Pᴴ = P`, `(P⁻¹)ᴴ = P⁻¹`, and `noncomm_ring` for the associativity bookkeeping. For square matrices the *reverse* identity `(A·P⁻¹)·star(A·P⁻¹) = 1` comes free from `Matrix.mul_eq_one_comm` — a one-sided inverse of a square matrix is two-sided — so both unitarity conditions are paid for with one computation. Finally `A = (A·P⁻¹)·P` since `P⁻¹·P = 1`.",
+    "mathContext": "$U := A P^{-1},\\quad U^{\\mathsf H}U = P^{-1}(A^{\\mathsf H}A)P^{-1} = P^{-1}P^2P^{-1} = 1$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Matrix.mul_eq_one_comm",
+      "nonsing_inv_mul",
+      "conjTranspose_nonsing_inv",
+      "noncomm_ring",
+      "explicit unitary factor"
+    ]
+  },
+  {
+    "id": "ann-polar-right-unique",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 138,
+      "endLine": 154
+    },
+    "type": "theorem",
+    "title": "Full Uniqueness for Invertible A",
+    "content": "**Both factors are pinned, so the decomposition is unique.** For invertible `A`, any two right polar decompositions `A = U₁P₁ = U₂P₂` coincide. The PSD factors are each forced to `√(AᴴA)` by `polar_psd_unique` (giving `P₁ = P₂`), and once `Pᵢ` is invertible the unitary factor is determined as `Uᵢ = A·Pᵢ⁻¹` (from `Uᵢ·Pᵢ = A` and `Pᵢ·Pᵢ⁻¹ = 1`). No separate uniqueness argument for `U` is needed — it is a corollary of the two factor computations already established.",
+    "mathContext": "$A = U_1P_1 = U_2P_2 \\ \\Longrightarrow\\ P_1 = P_2 = \\sqrt{A^{\\mathsf H}A},\\ U_i = A P_i^{-1} \\ \\Longrightarrow\\ U_1 = U_2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness corollary",
+      "mul_nonsing_inv",
+      "polar_psd_unique"
+    ]
+  },
+  {
+    "id": "ann-polar-left",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "range": {
+      "startLine": 158,
+      "endLine": 181
+    },
+    "type": "theorem",
+    "title": "The Left Form A = √(AAᴴ)·U by Transposition",
+    "content": "**The mirror decomposition, for free.** Rather than redo the argument, one decomposes `Aᴴ = V·√(AAᴴ)` on the right (`polar_right` applied to `Aᴴ`, whose invertibility follows from `det Aᴴ = star(det A)`), then conjugate-transposes:\n\n`A = (Aᴴ)ᴴ = (V·√(AAᴴ))ᴴ = √(AAᴴ)ᴴ·Vᴴ = √(AAᴴ)·Vᴴ`,\n\nusing that the square root is Hermitian and that `Vᴴ = star V` is unitary whenever `V` is (`Unitary.star_mem`). Note `polarFactor Aᴴ = √((Aᴴ)ᴴ·Aᴴ) = √(A·Aᴴ)` after `conjTranspose_conjTranspose`. This conjugate-transpose symmetry between the left and right forms mirrors `z = r·e^{iθ} = e^{iθ}·r` in the scalar case.",
+    "mathContext": "$A = (A^{\\mathsf H})^{\\mathsf H} = \\big(V\\sqrt{AA^{\\mathsf H}}\\big)^{\\mathsf H} = \\sqrt{AA^{\\mathsf H}}\\cdot V^{\\mathsf H}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Unitary.star_mem",
+      "conjTranspose_mul",
+      "conjTranspose_conjTranspose",
+      "left/right mirror symmetry"
+    ]
+  }
+]

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/annotations.source.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01/annotations.source.json
@@ -1,0 +1,160 @@
+[
+  {
+    "id": "ann-polarfactor-def",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polarFactor",
+      "kind": "def"
+    },
+    "type": "definition",
+    "title": "The Polar Factor P = √(AᴴA)",
+    "content": "**`polarFactor A = CFC.sqrt (Aᴴ * A)`.** The positive semidefinite 'modulus' `|A| = √(AᴴA)`, defined directly through Mathlib's C⋆-algebraic continuous-functional-calculus square root `CFC.sqrt`. Because `Aᴴ·A` is always positive semidefinite, its square root exists unconditionally — no hypothesis on `A` is needed to *define* the factor.\n\nThis is the matrix analogue of the modulus `r = |z|` in the complex polar form `z = r·e^{iθ}`. It is `noncomputable` because `CFC.sqrt` is built from the spectral theorem via classical choice.",
+    "mathContext": "$P = |A| = \\sqrt{A^{\\mathsf H}A} = \\operatorname{CFC.sqrt}(A^{\\mathsf H}A)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt",
+      "operator absolute value",
+      "continuous functional calculus",
+      "AᴴA is positive semidefinite"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-possemidef",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polarFactor_posSemidef",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "The Polar Factor Is Positive Semidefinite",
+    "content": "**`(polarFactor A).PosSemidef`.** The CFC square root of any element is nonnegative in the C⋆-order (`CFC.sqrt_nonneg`), and `.posSemidef` transports that Loewner-order nonnegativity into the concrete `Matrix.PosSemidef` predicate. This is the property that qualifies `P` as a legitimate polar 'modulus' — the whole point is that the modulus is genuinely a PSD matrix.",
+    "mathContext": "$\\sqrt{A^{\\mathsf H}A} \\succeq 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CFC.sqrt_nonneg",
+      "Matrix.PosSemidef",
+      "Loewner order"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-mul-self",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polarFactor_mul_self",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Defining Identity: (√(AᴴA))² = AᴴA",
+    "content": "**`polarFactor A * polarFactor A = Aᴴ * A`.** The square-root property specialized to the PSD matrix `Aᴴ·A`: `CFC.sqrt_mul_sqrt_self` gives `√X · √X = X` for `X ≥ 0`, applied here with `X = Aᴴ·A` (nonnegative by `posSemidef_conjTranspose_mul_self`).\n\nThis single identity is the algebraic engine of everything downstream — it is what lets `AᴴA` be replaced by `P²` in the uniqueness argument, and what feeds the determinant computation `det(P)² = det(AᴴA)`.",
+    "mathContext": "$P^2 = A^{\\mathsf H}A,\\qquad P = \\sqrt{A^{\\mathsf H}A}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt_mul_sqrt_self",
+      "posSemidef_conjTranspose_mul_self",
+      "defining identity"
+    ]
+  },
+  {
+    "id": "ann-polar-psd-unique",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polar_psd_unique",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "The Modulus Is Forced — No Invertibility Needed",
+    "content": "**The structural heart of polar decomposition.** Given *any* factorization `A = U·P` with `U` unitary and `P` PSD, the PSD factor is uniquely `P = √(AᴴA)`. The proof collapses `AᴴA`: since `Uᴴ·U = 1` (`Unitary.star_mul_self_of_mem`) and `Pᴴ = P` (`PosSemidef.isHermitian`),\n\n`Aᴴ·A = (U·P)ᴴ·(U·P) = Pᴴ·(Uᴴ·U)·P = P·P`,\n\nand `CFC.sqrt_unique` then forces `P = √(AᴴA)`. **This needs no regularity of `A` whatsoever** — the modulus `|A|` is intrinsic, and only the unitary phase `U` can ever be ambiguous. Everything else in the file is the (invertible-case) recovery of that phase.",
+    "mathContext": "$A = U P,\\ U\\text{ unitary},\\ P\\succeq 0 \\ \\Longrightarrow\\ A^{\\mathsf H}A = P(U^{\\mathsf H}U)P = P^2 \\ \\Longrightarrow\\ P = \\sqrt{A^{\\mathsf H}A}$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "CFC.sqrt_unique",
+      "Unitary.star_mul_self_of_mem",
+      "PosSemidef.isHermitian",
+      "intrinsic modulus"
+    ]
+  },
+  {
+    "id": "ann-polarfactor-isunit-det",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polarFactor_isUnit_det",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Invertibility Transfers Through the Determinant",
+    "content": "**When `A` is invertible, so is its polar factor.** Applying `det` to `P² = Aᴴ·A` gives `det(P)² = det(Aᴴ)·det(A) = star(det A)·det(A) = |det A|²` (via `det_mul`, `det_conjTranspose`). If `A` is a unit then `det A ≠ 0`, so `|det A|² ≠ 0`, hence `det P ≠ 0` and `P` is invertible (`isUnit_iff_isUnit_det`).\n\nThis is precisely the hypothesis needed to write the explicit unitary factor `U = A·P⁻¹` in the next theorem.",
+    "mathContext": "$\\det(P)^2 = \\overline{\\det A}\\,\\det A = |\\det A|^2 \\ne 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.det_conjTranspose",
+      "isUnit_iff_isUnit_det",
+      "isUnit_iff_ne_zero",
+      "determinant of a square root"
+    ]
+  },
+  {
+    "id": "ann-polar-right",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polar_right",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Existence: A = U·√(AᴴA) with U = A·P⁻¹",
+    "content": "**The classical right polar decomposition, invertible case.** The unitary factor is given by an *explicit formula* `U := A·P⁻¹`, not an abstract existence claim. Unitarity is verified by cancellation:\n\n`star(A·P⁻¹)·(A·P⁻¹) = P⁻¹·(Aᴴ·A)·P⁻¹ = P⁻¹·P²·P⁻¹ = (P⁻¹P)(PP⁻¹) = 1`,\n\nusing `Pᴴ = P`, `(P⁻¹)ᴴ = P⁻¹`, and `noncomm_ring` for the associativity bookkeeping. For square matrices the *reverse* identity `(A·P⁻¹)·star(A·P⁻¹) = 1` comes free from `Matrix.mul_eq_one_comm` — a one-sided inverse of a square matrix is two-sided — so both unitarity conditions are paid for with one computation. Finally `A = (A·P⁻¹)·P` since `P⁻¹·P = 1`.",
+    "mathContext": "$U := A P^{-1},\\quad U^{\\mathsf H}U = P^{-1}(A^{\\mathsf H}A)P^{-1} = P^{-1}P^2P^{-1} = 1$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Matrix.mul_eq_one_comm",
+      "nonsing_inv_mul",
+      "conjTranspose_nonsing_inv",
+      "noncomm_ring",
+      "explicit unitary factor"
+    ]
+  },
+  {
+    "id": "ann-polar-right-unique",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polar_right_unique",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "Full Uniqueness for Invertible A",
+    "content": "**Both factors are pinned, so the decomposition is unique.** For invertible `A`, any two right polar decompositions `A = U₁P₁ = U₂P₂` coincide. The PSD factors are each forced to `√(AᴴA)` by `polar_psd_unique` (giving `P₁ = P₂`), and once `Pᵢ` is invertible the unitary factor is determined as `Uᵢ = A·Pᵢ⁻¹` (from `Uᵢ·Pᵢ = A` and `Pᵢ·Pᵢ⁻¹ = 1`). No separate uniqueness argument for `U` is needed — it is a corollary of the two factor computations already established.",
+    "mathContext": "$A = U_1P_1 = U_2P_2 \\ \\Longrightarrow\\ P_1 = P_2 = \\sqrt{A^{\\mathsf H}A},\\ U_i = A P_i^{-1} \\ \\Longrightarrow\\ U_1 = U_2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness corollary",
+      "mul_nonsing_inv",
+      "polar_psd_unique"
+    ]
+  },
+  {
+    "id": "ann-polar-left",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01",
+    "anchor": {
+      "type": "declaration",
+      "name": "polar_left",
+      "kind": "theorem"
+    },
+    "type": "theorem",
+    "title": "The Left Form A = √(AAᴴ)·U by Transposition",
+    "content": "**The mirror decomposition, for free.** Rather than redo the argument, one decomposes `Aᴴ = V·√(AAᴴ)` on the right (`polar_right` applied to `Aᴴ`, whose invertibility follows from `det Aᴴ = star(det A)`), then conjugate-transposes:\n\n`A = (Aᴴ)ᴴ = (V·√(AAᴴ))ᴴ = √(AAᴴ)ᴴ·Vᴴ = √(AAᴴ)·Vᴴ`,\n\nusing that the square root is Hermitian and that `Vᴴ = star V` is unitary whenever `V` is (`Unitary.star_mem`). Note `polarFactor Aᴴ = √((Aᴴ)ᴴ·Aᴴ) = √(A·Aᴴ)` after `conjTranspose_conjTranspose`. This conjugate-transpose symmetry between the left and right forms mirrors `z = r·e^{iθ} = e^{iθ}·r` in the scalar case.",
+    "mathContext": "$A = (A^{\\mathsf H})^{\\mathsf H} = \\big(V\\sqrt{AA^{\\mathsf H}}\\big)^{\\mathsf H} = \\sqrt{AA^{\\mathsf H}}\\cdot V^{\\mathsf H}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Unitary.star_mem",
+      "conjTranspose_mul",
+      "conjTranspose_conjTranspose",
+      "left/right mirror symmetry"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `matrix-posdef-sqrt-oq-01-oq-01` (quality 45, 0 prior passes).

**Gap addressed:** no `annotations.json`. Added 8 anchor-based annotations covering every declaration in `MatrixPosDefSqrtOQ01OQ01.lean`:

- **`polarFactor`** — the PSD modulus P = √(AᴴA) via `CFC.sqrt`
- **`polarFactor_posSemidef` / `polarFactor_mul_self`** — its PSD-ness and defining identity P² = AᴴA
- **`polar_psd_unique`** — the structural core: the PSD factor is forced with *no* invertibility hypothesis (AᴴA = P(UᴴU)P = P²)
- **`polarFactor_isUnit_det`** — invertibility transfers through det(P)² = |det A|²
- **`polar_right`** — explicit unitary U = A·P⁻¹, with the reverse unitarity free from `mul_eq_one_comm`
- **`polar_right_unique`** — full uniqueness as a corollary
- **`polar_left`** — the mirror form by conjugate transposition

Each annotation includes `mathContext` (LaTeX), `significance`, and `relatedConcepts`. Authored via `annotations.source.json` anchors and resolved with `scripts/annotations/build.ts`; all 8 resolve to correct, non-overlapping line ranges. meta.json unchanged.