### PR TITLE
Enrich van Aubel square (van-aubel-theorem-oq-01-oq-01): add 9 annotations

### DIFF
--- a/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,204 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 40
+    },
+    "type": "concept",
+    "title": "Composing van Aubel with Varignon",
+    "content": "The parent entry `van-aubel-theorem-oq-01` proves that the diagonals $PR$ and $QS$ of the square-center quadrilateral $PQRS$ are equal in length and mutually perpendicular, compressed into the single complex identity $R - P = i\\,(S - Q)$. This follow-up feeds that fact into **Varignon's theorem**: the midpoints of the sides of any quadrilateral form a parallelogram whose sides are parallel to, and half the length of, the two diagonals. Applied to $PQRS$, the two adjacent Varignon side-vectors are exactly $(R-P)/2$ and $(S-Q)/2$ — the very diagonals van Aubel proved equal and perpendicular. Equal-and-perpendicular *diagonals* thus become equal-and-perpendicular *sides*, and a parallelogram with equal perpendicular adjacent sides is a square. The composition is what turns two classical theorems into one verified corollary: the 'van Aubel square'.",
+    "mathContext": "$R - P = i\\,(S - Q)$ with Varignon edges $\\tfrac{R-P}{2},\\ \\tfrac{S-Q}{2}$ $\\Rightarrow$ square.",
+    "significance": "key",
+    "prerequisites": [
+      "complex numbers as the Euclidean plane",
+      "midpoints and diagonals of quadrilaterals"
+    ],
+    "relatedConcepts": [
+      "van Aubel's theorem",
+      "Varignon's theorem",
+      "orthodiagonal quadrilateral",
+      "complex plane geometry"
+    ]
+  },
+  {
+    "id": "ann-square-center",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 48
+    },
+    "type": "definition",
+    "title": "Square Center as a Complex Rotation",
+    "content": "The center of the square erected externally on the directed edge $u\\to v$ is $\\mathrm{squareCenter}(u,v) = \\tfrac{u+v}{2} + i\\,\\tfrac{v-u}{2}$. The first term is the edge midpoint; the second pushes off that midpoint by $i\\,\\tfrac{v-u}{2}$, i.e. the half-edge vector $\\tfrac{v-u}{2}$ rotated by $+90^\\circ$ (multiplication by $i$) — precisely the perpendicular offset that lands on the square's center. Encoding the $90^\\circ$ rotation as multiplication by $i$ is the whole reason the complex model makes van Aubel a one-line identity: rotations become scalar multiplications, and the theorem's content collapses to $i^2 = -1$.",
+    "mathContext": "$\\mathrm{squareCenter}(u,v) = \\tfrac{u+v}{2} + i\\,\\tfrac{v-u}{2}$; multiplication by $i$ is a $+90^\\circ$ rotation.",
+    "significance": "supporting",
+    "prerequisites": [
+      "complex arithmetic",
+      "geometric meaning of multiplication by i"
+    ],
+    "relatedConcepts": [
+      "rotation by i",
+      "square center",
+      "directed edge"
+    ]
+  },
+  {
+    "id": "ann-vanaubel-key",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "The Parent Key Identity — One Equation Does Everything",
+    "content": "The engine of the entire file: $R - P = i\\,(S - Q)$, restated here for self-containedness. It packages both halves of van Aubel's theorem at once — equal length ($\\|R-P\\| = \\|i\\|\\,\\|S-Q\\| = \\|S-Q\\|$) and perpendicularity (multiplication by $i$ is a quarter turn) — into a single algebraic fact. The proof is a bare `linear_combination` with coefficient $-\\tfrac{a+b-c-d}{2}$ against `Complex.I_sq` ($i^2 = -1$): after unfolding the four square-centers, the desired identity is a polynomial consequence of $i^2 = -1$ alone. Every later theorem rewrites through this one equation.",
+    "mathContext": "$R - P = i\\,(S - Q)$, proved by `linear_combination` from $i^2 = -1$.",
+    "significance": "critical",
+    "prerequisites": [
+      "polynomial identities over ℂ",
+      "linear_combination tactic"
+    ],
+    "relatedConcepts": [
+      "linear_combination",
+      "Complex.I_sq",
+      "van Aubel's theorem",
+      "equidiagonal + orthodiagonal"
+    ]
+  },
+  {
+    "id": "ann-varignon-edge",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 77
+    },
+    "type": "theorem",
+    "title": "Varignon's Theorem, One Edge at a Time",
+    "content": "$M_2 - M_1 = \\tfrac{R - P}{2}$: the first directed side of the Varignon quadrilateral is exactly half the diagonal $R-P$ of $PQRS$. This is the concrete content of Varignon's theorem for one edge — 'side parallel to a diagonal, half its length' — and it is a *pure ring identity*, proved by `unfold M₂ M₁ mid; ring` with no appeal to van Aubel at all. The companions `varignon_edge23/34/41` give the other three sides as $\\tfrac{S-Q}{2}$, $-\\tfrac{R-P}{2}$, $-\\tfrac{S-Q}{2}$. This step is where 'diagonal facts' get converted into 'side facts'; van Aubel's key identity only enters afterwards, to relate those sides to each other.",
+    "mathContext": "$M_2-M_1 = \\tfrac{R-P}{2}$ (and $\\tfrac{S-Q}{2},\\, -\\tfrac{R-P}{2},\\, -\\tfrac{S-Q}{2}$ for the other edges).",
+    "significance": "key",
+    "prerequisites": [
+      "midpoints",
+      "vector edges of a polygon"
+    ],
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "midpoint quadrilateral",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-rot12",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Each Side is the Previous Rotated by -90°",
+    "content": "$M_3 - M_2 = -i\\,(M_2 - M_1)$: the second Varignon edge is the first turned by $-90^\\circ$. This single fact — a corner is a right angle *and* the two sides have equal length — is what makes the corner at $M_2$ a square corner. The proof rewrites both edges to half-diagonals (`varignon_edge23`, `varignon_edge12`) and then needs the *derived* identity $S - Q = -i\\,(R - P)$, obtained by `linear_combination I * vanAubel_key + (S-Q) * Complex.I_sq`. This is one of only **two** of the four corners (`rot12`, `rot34`) where $i^2 = -1$ is invoked a second time; the other two (`rot23`, `rot41`) fall out of the key identity by a bare `rw ... ; ring`.",
+    "mathContext": "$M_3 - M_2 = -i\\,(M_2 - M_1)$, using $S - Q = -i\\,(R - P)$ from $I\\cdot(-I)=1$.",
+    "significance": "critical",
+    "prerequisites": [
+      "multiplication by i as rotation",
+      "the van Aubel key identity"
+    ],
+    "relatedConcepts": [
+      "rotation by -i",
+      "right angle",
+      "linear_combination",
+      "Complex.I_sq"
+    ]
+  },
+  {
+    "id": "ann-rot23",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "Two Corners Come For Free",
+    "content": "$M_4 - M_3 = -i\\,(M_3 - M_2)$ needs *only* the key identity: after rewriting to half-diagonals, `rw [vanAubel_key]; ring` closes it — no second use of $i^2 = -1$. The asymmetry is structural. Edges 2→3 and 4→1 relate $\\pm\\tfrac{S-Q}{2}$ to $\\pm\\tfrac{R-P}{2}$, and $R - P = i(S-Q)$ already expresses one in terms of the other in the needed direction. Edges 1→2 and 3→4 need the *reverse* direction $S - Q = -i(R-P)$, and inverting a multiplication by $i$ is exactly where $i^2 = -1$ reappears. So the four right angles of the van Aubel square split 2+2 by which way the key identity must be read.",
+    "mathContext": "$M_4 - M_3 = -i\\,(M_3 - M_2)$ from $R - P = i(S-Q)$ directly.",
+    "significance": "supporting",
+    "prerequisites": [
+      "rewriting equalities in Lean"
+    ],
+    "relatedConcepts": [
+      "directional rewriting",
+      "van Aubel key identity",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-equal-sides",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 142
+    },
+    "type": "theorem",
+    "title": "Equilateral: All Four Sides Equal",
+    "content": "The Varignon quadrilateral is equilateral: all four side lengths coincide. Each equality is one line — rewrite the side as $-i$ times its predecessor (the rotation identity) and take norms: $\\|{-i}\\cdot z\\| = \\|{-i}\\|\\,\\|z\\| = \\|z\\|$ because $\\|{-i}\\| = 1$. In Lean this is `norm_mul, norm_neg, Complex.norm_I, one_mul`. Equal sides is *half* of squareness; the other half is the right angles from `varignon_perp`. Together, equilateral + right-angled = square.",
+    "mathContext": "$\\|M_{k+1}-M_k\\| = \\|{-i}\\,(M_k-M_{k-1})\\| = \\|M_k-M_{k-1}\\|$ since $\\|i\\| = 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "complex modulus",
+      "multiplicativity of the norm"
+    ],
+    "relatedConcepts": [
+      "norm_mul",
+      "Complex.norm_I",
+      "rhombus",
+      "isometry"
+    ]
+  },
+  {
+    "id": "ann-perp",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 144,
+      "endLine": 154
+    },
+    "type": "theorem",
+    "title": "Right Angles via a Purely Imaginary Product",
+    "content": "Perpendicularity of two complex vectors $z, w$ is detected by $\\mathrm{Re}(z\\,\\overline{w}) = 0$ (the real part of the Hermitian product is their dot product). Here the corner at $M_2$: substituting $M_3 - M_2 = -i\\,(M_2 - M_1)$ makes the product $(M_2-M_1)\\,\\overline{-i\\,(M_2-M_1)} = i\\,|M_2-M_1|^2$ — purely imaginary, so its real part vanishes. The proof pushes the conjugate through with `map_mul`, uses $\\overline{-i} = i$, and collapses $z\\bar z$ via `Complex.mul_conj` to a real, whose imaginary-part-only contribution `simp [Complex.ofReal_im]` kills. The remaining three corners are identical by their own rotation identities.",
+    "mathContext": "$\\mathrm{Re}\\big((M_2-M_1)\\,\\overline{(M_3-M_2)}\\big) = \\mathrm{Re}\\big(i\\,|M_2-M_1|^2\\big) = 0$.",
+    "significance": "critical",
+    "prerequisites": [
+      "complex conjugation",
+      "dot product as Re(z·conj w)"
+    ],
+    "relatedConcepts": [
+      "Hermitian inner product",
+      "Complex.mul_conj",
+      "orthogonality",
+      "map_mul"
+    ]
+  },
+  {
+    "id": "ann-side-length",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 156,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "The Size is Exact: Half the van Aubel Diagonal",
+    "content": "Beyond the *shape*, the *size* is pinned down: the common Varignon side length is $\\|M_2 - M_1\\| = \\tfrac{1}{2}\\|R - P\\|$, exactly half the common van Aubel diagonal length $\\|R-P\\| = \\|S-Q\\|$. It falls straight out of the edge formula $M_2 - M_1 = \\tfrac{R-P}{2}$ and `norm_div`. So the van Aubel square is fully determined by the two equal diagonals it is built on — a square of side $\\tfrac{1}{2}\\|R-P\\|$ — not merely 'some square'.",
+    "mathContext": "$\\|M_2 - M_1\\| = \\tfrac{1}{2}\\|R - P\\| = \\tfrac{1}{2}\\|S - Q\\|$.",
+    "significance": "key",
+    "prerequisites": [
+      "complex modulus",
+      "the Varignon edge formula"
+    ],
+    "relatedConcepts": [
+      "norm_div",
+      "exact side length",
+      "van Aubel diagonal"
+    ]
+  }
+]

--- a/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.source.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.source.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "section-doc", "contains": "The Varignon parallelogram of the van Aubel square-centers is a square" },
+    "type": "concept",
+    "title": "Composing van Aubel with Varignon",
+    "content": "The parent entry `van-aubel-theorem-oq-01` proves that the diagonals $PR$ and $QS$ of the square-center quadrilateral $PQRS$ are equal in length and mutually perpendicular, compressed into the single complex identity $R - P = i\\,(S - Q)$. This follow-up feeds that fact into **Varignon's theorem**: the midpoints of the sides of any quadrilateral form a parallelogram whose sides are parallel to, and half the length of, the two diagonals. Applied to $PQRS$, the two adjacent Varignon side-vectors are exactly $(R-P)/2$ and $(S-Q)/2$ — the very diagonals van Aubel proved equal and perpendicular. Equal-and-perpendicular *diagonals* thus become equal-and-perpendicular *sides*, and a parallelogram with equal perpendicular adjacent sides is a square. The composition is what turns two classical theorems into one verified corollary: the 'van Aubel square'.",
+    "mathContext": "$R - P = i\\,(S - Q)$ with Varignon edges $\\tfrac{R-P}{2},\\ \\tfrac{S-Q}{2}$ $\\Rightarrow$ square.",
+    "significance": "key",
+    "relatedConcepts": ["van Aubel's theorem", "Varignon's theorem", "orthodiagonal quadrilateral", "complex plane geometry"],
+    "prerequisites": ["complex numbers as the Euclidean plane", "midpoints and diagonals of quadrilaterals"]
+  },
+  {
+    "id": "ann-square-center",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "squareCenter", "kind": "def" },
+    "type": "definition",
+    "title": "Square Center as a Complex Rotation",
+    "content": "The center of the square erected externally on the directed edge $u\\to v$ is $\\mathrm{squareCenter}(u,v) = \\tfrac{u+v}{2} + i\\,\\tfrac{v-u}{2}$. The first term is the edge midpoint; the second pushes off that midpoint by $i\\,\\tfrac{v-u}{2}$, i.e. the half-edge vector $\\tfrac{v-u}{2}$ rotated by $+90^\\circ$ (multiplication by $i$) — precisely the perpendicular offset that lands on the square's center. Encoding the $90^\\circ$ rotation as multiplication by $i$ is the whole reason the complex model makes van Aubel a one-line identity: rotations become scalar multiplications, and the theorem's content collapses to $i^2 = -1$.",
+    "mathContext": "$\\mathrm{squareCenter}(u,v) = \\tfrac{u+v}{2} + i\\,\\tfrac{v-u}{2}$; multiplication by $i$ is a $+90^\\circ$ rotation.",
+    "significance": "supporting",
+    "relatedConcepts": ["rotation by i", "square center", "directed edge"],
+    "prerequisites": ["complex arithmetic", "geometric meaning of multiplication by i"]
+  },
+  {
+    "id": "ann-vanaubel-key",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "vanAubel_key", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Parent Key Identity — One Equation Does Everything",
+    "content": "The engine of the entire file: $R - P = i\\,(S - Q)$, restated here for self-containedness. It packages both halves of van Aubel's theorem at once — equal length ($\\|R-P\\| = \\|i\\|\\,\\|S-Q\\| = \\|S-Q\\|$) and perpendicularity (multiplication by $i$ is a quarter turn) — into a single algebraic fact. The proof is a bare `linear_combination` with coefficient $-\\tfrac{a+b-c-d}{2}$ against `Complex.I_sq` ($i^2 = -1$): after unfolding the four square-centers, the desired identity is a polynomial consequence of $i^2 = -1$ alone. Every later theorem rewrites through this one equation.",
+    "mathContext": "$R - P = i\\,(S - Q)$, proved by `linear_combination` from $i^2 = -1$.",
+    "significance": "critical",
+    "relatedConcepts": ["linear_combination", "Complex.I_sq", "van Aubel's theorem", "equidiagonal + orthodiagonal"],
+    "prerequisites": ["polynomial identities over ℂ", "linear_combination tactic"]
+  },
+  {
+    "id": "ann-varignon-edge",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_edge12", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Varignon's Theorem, One Edge at a Time",
+    "content": "$M_2 - M_1 = \\tfrac{R - P}{2}$: the first directed side of the Varignon quadrilateral is exactly half the diagonal $R-P$ of $PQRS$. This is the concrete content of Varignon's theorem for one edge — 'side parallel to a diagonal, half its length' — and it is a *pure ring identity*, proved by `unfold M₂ M₁ mid; ring` with no appeal to van Aubel at all. The companions `varignon_edge23/34/41` give the other three sides as $\\tfrac{S-Q}{2}$, $-\\tfrac{R-P}{2}$, $-\\tfrac{S-Q}{2}$. This step is where 'diagonal facts' get converted into 'side facts'; van Aubel's key identity only enters afterwards, to relate those sides to each other.",
+    "mathContext": "$M_2-M_1 = \\tfrac{R-P}{2}$ (and $\\tfrac{S-Q}{2},\\, -\\tfrac{R-P}{2},\\, -\\tfrac{S-Q}{2}$ for the other edges).",
+    "significance": "key",
+    "relatedConcepts": ["Varignon's theorem", "midpoint quadrilateral", "ring tactic"],
+    "prerequisites": ["midpoints", "vector edges of a polygon"]
+  },
+  {
+    "id": "ann-rot12",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_rot12", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Each Side is the Previous Rotated by -90°",
+    "content": "$M_3 - M_2 = -i\\,(M_2 - M_1)$: the second Varignon edge is the first turned by $-90^\\circ$. This single fact — a corner is a right angle *and* the two sides have equal length — is what makes the corner at $M_2$ a square corner. The proof rewrites both edges to half-diagonals (`varignon_edge23`, `varignon_edge12`) and then needs the *derived* identity $S - Q = -i\\,(R - P)$, obtained by `linear_combination I * vanAubel_key + (S-Q) * Complex.I_sq`. This is one of only **two** of the four corners (`rot12`, `rot34`) where $i^2 = -1$ is invoked a second time; the other two (`rot23`, `rot41`) fall out of the key identity by a bare `rw ... ; ring`.",
+    "mathContext": "$M_3 - M_2 = -i\\,(M_2 - M_1)$, using $S - Q = -i\\,(R - P)$ from $I\\cdot(-I)=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["rotation by -i", "right angle", "linear_combination", "Complex.I_sq"],
+    "prerequisites": ["multiplication by i as rotation", "the van Aubel key identity"]
+  },
+  {
+    "id": "ann-rot23",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_rot23", "kind": "theorem" },
+    "type": "insight",
+    "title": "Two Corners Come For Free",
+    "content": "$M_4 - M_3 = -i\\,(M_3 - M_2)$ needs *only* the key identity: after rewriting to half-diagonals, `rw [vanAubel_key]; ring` closes it — no second use of $i^2 = -1$. The asymmetry is structural. Edges 2→3 and 4→1 relate $\\pm\\tfrac{S-Q}{2}$ to $\\pm\\tfrac{R-P}{2}$, and $R - P = i(S-Q)$ already expresses one in terms of the other in the needed direction. Edges 1→2 and 3→4 need the *reverse* direction $S - Q = -i(R-P)$, and inverting a multiplication by $i$ is exactly where $i^2 = -1$ reappears. So the four right angles of the van Aubel square split 2+2 by which way the key identity must be read.",
+    "mathContext": "$M_4 - M_3 = -i\\,(M_3 - M_2)$ from $R - P = i(S-Q)$ directly.",
+    "significance": "supporting",
+    "relatedConcepts": ["directional rewriting", "van Aubel key identity", "ring tactic"],
+    "prerequisites": ["rewriting equalities in Lean"]
+  },
+  {
+    "id": "ann-equal-sides",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_equal_sides", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Equilateral: All Four Sides Equal",
+    "content": "The Varignon quadrilateral is equilateral: all four side lengths coincide. Each equality is one line — rewrite the side as $-i$ times its predecessor (the rotation identity) and take norms: $\\|{-i}\\cdot z\\| = \\|{-i}\\|\\,\\|z\\| = \\|z\\|$ because $\\|{-i}\\| = 1$. In Lean this is `norm_mul, norm_neg, Complex.norm_I, one_mul`. Equal sides is *half* of squareness; the other half is the right angles from `varignon_perp`. Together, equilateral + right-angled = square.",
+    "mathContext": "$\\|M_{k+1}-M_k\\| = \\|{-i}\\,(M_k-M_{k-1})\\| = \\|M_k-M_{k-1}\\|$ since $\\|i\\| = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_mul", "Complex.norm_I", "rhombus", "isometry"],
+    "prerequisites": ["complex modulus", "multiplicativity of the norm"]
+  },
+  {
+    "id": "ann-perp",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_perp", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Right Angles via a Purely Imaginary Product",
+    "content": "Perpendicularity of two complex vectors $z, w$ is detected by $\\mathrm{Re}(z\\,\\overline{w}) = 0$ (the real part of the Hermitian product is their dot product). Here the corner at $M_2$: substituting $M_3 - M_2 = -i\\,(M_2 - M_1)$ makes the product $(M_2-M_1)\\,\\overline{-i\\,(M_2-M_1)} = i\\,|M_2-M_1|^2$ — purely imaginary, so its real part vanishes. The proof pushes the conjugate through with `map_mul`, uses $\\overline{-i} = i$, and collapses $z\\bar z$ via `Complex.mul_conj` to a real, whose imaginary-part-only contribution `simp [Complex.ofReal_im]` kills. The remaining three corners are identical by their own rotation identities.",
+    "mathContext": "$\\mathrm{Re}\\big((M_2-M_1)\\,\\overline{(M_3-M_2)}\\big) = \\mathrm{Re}\\big(i\\,|M_2-M_1|^2\\big) = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Hermitian inner product", "Complex.mul_conj", "orthogonality", "map_mul"],
+    "prerequisites": ["complex conjugation", "dot product as Re(z·conj w)"]
+  },
+  {
+    "id": "ann-side-length",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_side_eq_half_diagonal", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Size is Exact: Half the van Aubel Diagonal",
+    "content": "Beyond the *shape*, the *size* is pinned down: the common Varignon side length is $\\|M_2 - M_1\\| = \\tfrac{1}{2}\\|R - P\\|$, exactly half the common van Aubel diagonal length $\\|R-P\\| = \\|S-Q\\|$. It falls straight out of the edge formula $M_2 - M_1 = \\tfrac{R-P}{2}$ and `norm_div`. So the van Aubel square is fully determined by the two equal diagonals it is built on — a square of side $\\tfrac{1}{2}\\|R-P\\|$ — not merely 'some square'.",
+    "mathContext": "$\\|M_2 - M_1\\| = \\tfrac{1}{2}\\|R - P\\| = \\tfrac{1}{2}\\|S - Q\\|$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_div", "exact side length", "van Aubel diagonal"],
+    "prerequisites": ["complex modulus", "the Varignon edge formula"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `van-aubel-theorem-oq-01-oq-01`

This entry (quality 43, 0 passes — top enrichment target) had a rich meta.json but **no `annotations.json` at all**. Authored an anchor-based `annotations.source.json` (9 anchors), resolved via `scripts/annotations/build.ts`.

**Result:** 9 annotations, all anchors resolved, non-overlapping ranges, ~57% line coverage, validation clean, only this entry's files touched.

**Coverage of the entry's distinctive angle** — composing two classical theorems:
1. **Overview** — van Aubel (equal, perpendicular diagonals of `PQRS`) fed into Varignon (midpoint parallelogram) yields a *square*
2. **squareCenter** — the `+90°` complex rotation `(u+v)/2 + i(v-u)/2`
3. **vanAubel_key** — `R - P = i(S - Q)`, the file's single algebraic engine
4. **varignon_edge12** — Varignon's theorem one edge at a time: side = half-diagonal
5. **varignon_rot12** — each side is the previous rotated by `-90°`; the derived `S - Q = -i(R-P)`
6. **varignon_rot23** — why only two of four corners re-invoke `i² = -1`
7. **varignon_equal_sides** — equilateral from `|i| = 1`
8. **varignon_perp** — right angles via a purely imaginary Hermitian product
9. **varignon_side_eq_half_diagonal** — the exact size: half the van Aubel diagonal

Axiom integrity unchanged: `status: verified`, `axiomCount: 0` accurately reflect the 0-sorry, 0-axiom Lean file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)