### PR TITLE
research(cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01): Reflexive objects & the fixed-point property [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01OQ01.lean
@@ -1,0 +1,235 @@
+/-
+  Reflexive Objects and the Fixed-Point Property
+  Open Question: cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01
+  (an OQ extension of the completed categorical Lawvere theorem)
+
+  ## Background
+
+  The parent file CantorDiagonalizationOQ03OQ01Incomplete01.lean completes the
+  categorical Lawvere fixed-point theorem: if `e : Pt A → Pt(B^A)` is point-
+  surjective, then every endomorphism `f : Pt B → Pt B` has a fixed point.
+
+  This file pursues a specialization the parent did not explore: **the diagonal
+  case `B = A`**. An object `A` equipped with a point-surjection `e : A → (A → A)`
+  is exactly a *reflexive object* — the categorical structure underlying every
+  model of the untyped λ-calculus (a term `M` acts both as a function `e M` and
+  as an argument, so `A` is "isomorphic to its own function space" at the level
+  of points).
+
+  ## Main results
+
+  1. `reflexive_hasFixedPointProperty` — every reflexive object has the fixed-
+     point property: *every* self-map `f : A → A` has a fixed point. (This is
+     Lawvere with `B = A`, and it is precisely why an untyped λ-model interprets
+     the `Y`-combinator: `Y f` is a fixed point of `f`.)
+
+  2. `reflexive_subsingleton` — in **Set**, a reflexive object must be a
+     subsingleton: no self-map can be fixed-point-free, but a two-element type
+     always admits one (the "swap-to-`a`" map). Hence the only reflexive objects
+     in Set are singletons.
+
+  3. `reflexive_iff_subsingleton_nonempty` — the sharp characterization:
+     `A` is reflexive ⟺ `A` is a nonempty subsingleton (a one-point type).
+
+  This is the categorical reason the untyped λ-calculus has **no** set-theoretic
+  model: one must pass to a category (Scott domains, complete lattices, ...) where
+  "point-surjection" is weakened to a *retraction* `A ⟶ (A ⇒ A)` and the fixed-
+  point argument no longer forces triviality.
+
+  We also record the general Lawvere–Cantor obstruction (`B` with a fixed-point-
+  free endo ⟹ no point-surjection `A → (A → B)`) and recover Cantor's theorem
+  (`B = Prop`, `f = Not`) and Mathlib's `Function.cantor_surjective`.
+
+  ## Axioms and Sorries
+
+  0 sorries, 0 axioms (uses only `Classical` for a decidability instance inside a
+  `by_cases`; no `axiom` declarations and no assumption-carrying structure fields).
+-/
+
+import Mathlib.Logic.Function.Basic
+import Mathlib.Tactic
+
+namespace CantorDiagonalizationOQ03OQ01Incomplete01OQ01
+
+-- ============================================================
+-- SECTION I: The abstract Lawvere theorem (self-contained)
+-- ============================================================
+
+/-- An evaluation structure: codes `Ob`, values `Val`, and an evaluation map. -/
+structure EvalStructure where
+  Ob : Type*
+  Val : Type*
+  eval : Ob → Ob → Val
+
+/-- Point-surjectivity: every function `Ob → Val` is represented by some code. -/
+def EvalStructure.IsPointSurjective (E : EvalStructure) : Prop :=
+  ∀ g : E.Ob → E.Val, ∃ a : E.Ob, ∀ x : E.Ob, E.eval a x = g x
+
+/-- **Lawvere Fixed-Point Theorem (abstract)**: a point-surjective evaluation
+    structure has the property that every endomorphism of its values has a fixed
+    point. -/
+theorem lawvere_abstract (E : EvalStructure) (hE : E.IsPointSurjective)
+    (f : E.Val → E.Val) : ∃ v : E.Val, f v = v := by
+  obtain ⟨a₀, ha₀⟩ := hE (fun a => f (E.eval a a))
+  exact ⟨E.eval a₀ a₀, (ha₀ a₀).symm⟩
+
+-- ============================================================
+-- SECTION II: Reflexive objects and the fixed-point property
+-- ============================================================
+
+/-- The **fixed-point property**: every self-map of `A` has a fixed point. -/
+def HasFixedPointProperty (A : Type*) : Prop :=
+  ∀ f : A → A, ∃ a : A, f a = a
+
+/-- `A` is a **reflexive object** (in Set) when some `e : A → (A → A)` is point-
+    surjective: every self-map `g : A → A` equals `e a` for some `a`. This is the
+    diagonal case `B = A` of the categorical Lawvere hypothesis, and the defining
+    feature of a model of the untyped λ-calculus. -/
+def IsReflexiveObject (A : Type*) : Prop :=
+  ∃ e : A → (A → A), ∀ g : A → A, ∃ a : A, ∀ x : A, e a x = g x
+
+/-- **Reflexive ⟹ fixed-point property.** Lawvere's theorem with `B = A`:
+    if `A` is reflexive then *every* endomorphism `f : A → A` has a fixed point.
+    In an untyped λ-model this is exactly the existence of the `Y`-combinator. -/
+theorem reflexive_hasFixedPointProperty {A : Type*}
+    (h : IsReflexiveObject A) : HasFixedPointProperty A := by
+  obtain ⟨e, he⟩ := h
+  intro f
+  -- Package `e` into an evaluation structure with `Ob = Val = A`.
+  let E : EvalStructure := { Ob := A, Val := A, eval := fun a x => e a x }
+  have hE : E.IsPointSurjective := he
+  exact lawvere_abstract E hE f
+
+/-- Any type with two distinct elements admits a **fixed-point-free** self-map:
+    the map sending `a ↦ b` and everything else `↦ a`. -/
+theorem exists_fixedPointFree_of_ne {A : Type*} {a b : A} (hab : a ≠ b) :
+    ∃ f : A → A, ∀ x : A, f x ≠ x := by
+  classical
+  refine ⟨fun x => if x = a then b else a, ?_⟩
+  intro x
+  by_cases hx : x = a
+  · subst hx
+    simpa using hab.symm
+  · simp only [if_neg hx]
+    exact fun h => hx h.symm
+
+/-- **The fixed-point property forces a subsingleton** (in Set): if every self-map
+    of `A` has a fixed point, then `A` has at most one element, because two distinct
+    elements would furnish a fixed-point-free map. -/
+theorem subsingleton_of_hasFixedPointProperty {A : Type*}
+    (h : HasFixedPointProperty A) : Subsingleton A := by
+  refine ⟨fun a b => ?_⟩
+  by_contra hab
+  obtain ⟨f, hf⟩ := exists_fixedPointFree_of_ne hab
+  obtain ⟨a₀, ha₀⟩ := h f
+  exact hf a₀ ha₀
+
+/-- A reflexive object is nonempty (take `g = id`). -/
+theorem nonempty_of_reflexive {A : Type*} (h : IsReflexiveObject A) :
+    Nonempty A := by
+  obtain ⟨e, he⟩ := h
+  obtain ⟨a, _⟩ := he id
+  exact ⟨a⟩
+
+/-- **Main theorem: in Set, a reflexive object is a subsingleton.**
+    Combining Lawvere (`reflexive ⟹ fixed-point property`) with the fact that
+    only subsingletons have the fixed-point property. -/
+theorem reflexive_subsingleton {A : Type*} (h : IsReflexiveObject A) :
+    Subsingleton A :=
+  subsingleton_of_hasFixedPointProperty (reflexive_hasFixedPointProperty h)
+
+/-- **Converse: a one-point type is reflexive.** When `A` is a nonempty
+    subsingleton, any `e` works, so `A` is reflexive. -/
+theorem reflexive_of_subsingleton_nonempty {A : Type*}
+    [Subsingleton A] [Nonempty A] : IsReflexiveObject A := by
+  refine ⟨fun _ => id, ?_⟩
+  intro g
+  obtain ⟨a⟩ := ‹Nonempty A›
+  exact ⟨a, fun x => Subsingleton.elim x (g x)⟩
+
+/-- **Sharp characterization of reflexive objects in Set.**
+    `A` is reflexive ⟺ `A` is a nonempty subsingleton (a one-point type).
+    Equivalently: the terminal object is the only reflexive object of **Set**. -/
+theorem reflexive_iff_subsingleton_nonempty {A : Type*} :
+    IsReflexiveObject A ↔ (Subsingleton A ∧ Nonempty A) := by
+  constructor
+  · intro h
+    exact ⟨reflexive_subsingleton h, nonempty_of_reflexive h⟩
+  · rintro ⟨hs, hn⟩
+    exact @reflexive_of_subsingleton_nonempty A hs hn
+
+-- ============================================================
+-- SECTION III: Concrete non-reflexive types
+-- ============================================================
+
+/-- `Bool` is not reflexive: it has two distinct elements. Concretely there is no
+    point-surjection `Bool → (Bool → Bool)`, blocked by the fixed-point-free map
+    `not`. -/
+theorem not_reflexive_bool : ¬ IsReflexiveObject Bool := by
+  intro h
+  have hsub : Subsingleton Bool := reflexive_subsingleton h
+  exact absurd (hsub.elim true false) (by decide)
+
+/-- `ℕ` is not reflexive (blocked by the fixed-point-free successor map). -/
+theorem not_reflexive_nat : ¬ IsReflexiveObject ℕ := by
+  intro h
+  have hsub : Subsingleton ℕ := reflexive_subsingleton h
+  exact absurd (hsub.elim 0 1) (by decide)
+
+-- ============================================================
+-- SECTION IV: General Lawvere–Cantor obstruction & Cantor's theorem
+-- ============================================================
+
+/-- **Generalized Lawvere–Cantor obstruction.** If `B` admits a fixed-point-free
+    self-map `f`, then no `e : A → (A → B)` is point-surjective. Cantor's theorem,
+    Russell's paradox, Gödel incompleteness and the halting problem are all
+    instances (varying `B` and `f`). The reflexive case is `B = A`. -/
+theorem no_pointSurjection_of_fixedPointFree {A B : Type*}
+    (f : B → B) (hf : ∀ b : B, f b ≠ b) (e : A → (A → B)) :
+    ¬ ∀ g : A → B, ∃ a : A, ∀ x : A, e a x = g x := by
+  intro he
+  let E : EvalStructure := { Ob := A, Val := B, eval := fun a x => e a x }
+  have hE : E.IsPointSurjective := he
+  obtain ⟨v, hv⟩ := lawvere_abstract E hE f
+  exact hf v hv
+
+/-- **Cantor's theorem (point form).** No `e : A → (A → Prop)` is point-surjective;
+    the obstruction is `Not : Prop → Prop`, which is fixed-point-free
+    (`¬P = P` is impossible). -/
+theorem cantor_no_surjection_prop {A : Type*} (e : A → (A → Prop)) :
+    ¬ ∀ g : A → Prop, ∃ a : A, ∀ x : A, e a x = g x := by
+  apply no_pointSurjection_of_fixedPointFree Not
+  intro P h
+  -- `h : (¬P) = P` gives both `P → ¬P` and `¬P → P`, hence a contradiction.
+  have hpn : P → ¬P := cast h.symm
+  have hnp : ¬P → P := cast h
+  have np : ¬P := fun p => hpn p p
+  exact np (hnp np)
+
+/-- **Recovering Mathlib-style Cantor**: no `e : A → (A → Prop)` is surjective.
+    Since `Set A` is definitionally `A → Prop`, this is `Function.cantor_surjective`. -/
+theorem cantor_surjective_recovered {A : Type*} (e : A → (A → Prop)) :
+    ¬ Function.Surjective e := by
+  intro hsurj
+  apply cantor_no_surjection_prop e
+  intro g
+  obtain ⟨a, ha⟩ := hsurj g
+  exact ⟨a, fun x => congrFun ha x⟩
+
+/-- Sanity check: our recovered statement matches Mathlib's `cantor_surjective`
+    on power sets (`Set A = A → Prop`). -/
+example {A : Type*} (f : A → Set A) : ¬ Function.Surjective f :=
+  cantor_surjective_recovered f
+
+-- ============================================================
+-- Summary checks
+-- ============================================================
+
+#check @reflexive_hasFixedPointProperty
+#check @reflexive_subsingleton
+#check @reflexive_iff_subsingleton_nonempty
+#check @not_reflexive_bool
+#check @no_pointSurjection_of_fixedPointFree
+#check @cantor_surjective_recovered
+
+end CantorDiagonalizationOQ03OQ01Incomplete01OQ01

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-cd-oq030101-inc01-oq01-01-header",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
+    "type": "concept",
+    "title": "The Diagonal Case of Lawvere: Reflexive Objects",
+    "content": "The parent entry completes the categorical Lawvere fixed-point theorem for general B; this file specializes to the diagonal case B = A. An object A carrying a point-surjection e : A → (A → A) — every self-map g : A → A equals e a for some code a — is a reflexive object, the structure underlying every model of the untyped λ-calculus (a term acts both as function and as argument). The header previews the three main results: reflexive ⟹ fixed-point property, reflexive ⟹ subsingleton in Set, and the sharp iff reflexive ⟺ nonempty subsingleton.",
+    "mathContext": "$A$ reflexive means $\\exists\\, e : A \\to (A \\to A)$ point-surjective. Lawvere with $B = A$ gives: every $f : A \\to A$ has a fixed point — the categorical $Y$-combinator.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lawvere fixed-point theorem",
+      "reflexive object",
+      "untyped λ-calculus",
+      "Y-combinator"
+    ],
+    "prerequisites": [
+      "point-surjectivity",
+      "fixed-point property"
+    ]
+  },
+  {
+    "id": "ann-cd-oq030101-inc01-oq01-02-abstract-lawvere",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "The Abstract Lawvere Lemma (One Diagonal Argument)",
+    "content": "EvalStructure bundles codes Ob, values Val, and eval : Ob → Ob → Val; IsPointSurjective asks that every g : Ob → Val be represented by some code. lawvere_abstract is the whole engine: given point-surjectivity, take the code a₀ representing a ↦ f (eval a a), then eval a₀ a₀ is a fixed point of f. Every later result — the reflexive fixed-point property, the subsingleton collapse, and Cantor — is an instantiation of this single lemma.",
+    "mathContext": "If $\\forall g\\, \\exists a\\, \\forall x,\\ \\mathrm{eval}\\,a\\,x = g\\,x$, apply it to $g = \\lambda a.\\ f(\\mathrm{eval}\\,a\\,a)$ to get $a_0$ with $\\mathrm{eval}\\,a_0\\,a_0 = f(\\mathrm{eval}\\,a_0\\,a_0)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "diagonalization",
+      "self-application",
+      "cartesian closed category"
+    ],
+    "prerequisites": [
+      "EvalStructure",
+      "point-surjectivity"
+    ]
+  },
+  {
+    "id": "ann-cd-oq030101-inc01-oq01-03-reflexive-subsingleton",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 148
+    },
+    "type": "technique",
+    "title": "Reflexive ⟹ Fixed-Point Property ⟹ Subsingleton",
+    "content": "reflexive_hasFixedPointProperty packages e into an EvalStructure with Ob = Val = A and applies lawvere_abstract, so every self-map has a fixed point. The converse direction is the collapse: exists_fixedPointFree_of_ne builds the fixed-point-free swap x ↦ if x = a then b else a from any two distinct points, and subsingleton_of_hasFixedPointProperty contraposes it — the fixed-point property forbids two distinct points. reflexive_of_subsingleton_nonempty supplies the easy converse for one-point types.",
+    "mathContext": "Swap map: for $a \\neq b$, $s(x) = b$ if $x = a$ else $a$ is fixed-point-free. Hence 'every self-map has a fixed point' $\\Rightarrow$ $A$ is a subsingleton.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fixed-point-free map",
+      "subsingleton",
+      "contrapositive"
+    ],
+    "prerequisites": [
+      "lawvere_abstract",
+      "Subsingleton"
+    ]
+  },
+  {
+    "id": "ann-cd-oq030101-inc01-oq01-04-sharp-iff",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 177
+    },
+    "type": "insight",
+    "title": "Sharp Characterization: Only the Terminal Object is Reflexive in Set",
+    "content": "reflexive_iff_subsingleton_nonempty proves A is reflexive ⟺ (Subsingleton A ∧ Nonempty A) — i.e. A is a one-point type. This is the categorical reason the untyped λ-calculus has NO set-theoretic model: Set's only reflexive object is the terminal one, so nontrivial λ-models must move to categories of domains where point-surjection weakens to a retraction. Section III makes it concrete: not_reflexive_bool and not_reflexive_nat rule out Bool and ℕ via their fixed-point-free swap / successor maps.",
+    "mathContext": "$A$ reflexive $\\iff$ $A \\cong 1$ (terminal). In a CCC one instead asks for a retraction $A \\lhd (A \\Rightarrow A)$, under which the Lawvere argument still yields $Y$ without forcing $A \\cong 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "terminal object",
+      "no set-theoretic λ-model",
+      "Scott domains",
+      "retraction"
+    ],
+    "prerequisites": [
+      "reflexive_subsingleton",
+      "reflexive_of_subsingleton_nonempty"
+    ]
+  },
+  {
+    "id": "ann-cd-oq030101-inc01-oq01-05-cantor-recovery",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+    "range": {
+      "startLine": 183,
+      "endLine": 235
+    },
+    "type": "insight",
+    "title": "General Obstruction and Recovery of Cantor",
+    "content": "no_pointSurjection_of_fixedPointFree lifts the argument back to general B: a fixed-point-free f : B → B blocks every point-surjection A → (A → B). The reflexive case is B = A; Cantor is B = Prop with the fixed-point-free negation Not (¬P = P is impossible, proved by casting the equality both ways). cantor_surjective_recovered rederives Mathlib's Function.cantor_surjective from this obstruction, and an example confirms the match on power sets (Set A ≡ A → Prop). One lemma thus unifies reflexive objects, Cantor, Russell, Gödel, and the halting problem.",
+    "mathContext": "$B = \\mathrm{Prop}$, $f = \\lnot$: no $e : A \\to (A \\to \\mathrm{Prop})$ is point-surjective, hence $A \\to \\mathcal P(A)$ is never surjective — Cantor's theorem as a Lawvere instance.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "Lawvere–Cantor obstruction",
+      "Russell's paradox",
+      "Function.cantor_surjective"
+    ],
+    "prerequisites": [
+      "no_pointSurjection_of_fixedPointFree",
+      "fixed-point-free negation"
+    ]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+  "title": "Reflexive Objects and the Fixed-Point Property",
+  "slug": "cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01",
+  "description": "The diagonal case B = A of the categorical Lawvere fixed-point theorem. An object A with a point-surjection e : A → (A → A) is a reflexive object — the structure underlying every model of the untyped λ-calculus. Main results: (1) every reflexive object has the fixed-point property (every self-map has a fixed point — the categorical Y-combinator); (2) in Set a reflexive object must be a subsingleton; (3) the sharp characterization A reflexive ⟺ A is a nonempty subsingleton (a one-point type). Also records the general Lawvere–Cantor obstruction and recovers Cantor's theorem (B = Prop, f = Not) and Mathlib's Function.cantor_surjective.",
+  "meta": {
+    "author": "researcher-1",
+    "sourceUrl": "https://ncatlab.org/nlab/show/Lawvere%27s+fixed+point+theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01Incomplete01OQ01.lean",
+    "tags": [
+      "logic",
+      "category-theory",
+      "cantor-diagonalization",
+      "lawvere-fixed-point",
+      "reflexive-object",
+      "lambda-calculus",
+      "fixed-point-property",
+      "extension",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No axioms, no sorries. All 13 theorems fully proved. Uses only Classical (for a decidability instance inside a by_cases in exists_fixedPointFree_of_ne); no axiom declarations and no assumption-carrying structure fields. #print axioms reports only [propext, Classical.choice, Quot.sound] (several theorems depend on no axioms at all).",
+    "originalContributions": "The sharp characterization reflexive_iff_subsingleton_nonempty (A is reflexive ⟺ A is a nonempty subsingleton) packages the diagonal case of Lawvere's theorem as an iff, making explicit that the terminal object is the only reflexive object of Set — the categorical reason the untyped λ-calculus has no set-theoretic model. The abstract EvalStructure packaging unifies Lawvere, Cantor, and the fixed-point-free obstruction under one lemma.",
+    "mathlib_version": "4.26.0",
+    "lineCount": 235,
+    "theoremCount": 13,
+    "defCount": 3,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Lawvere's 1969 fixed-point theorem gives a single categorical statement subsuming Cantor's theorem, Russell's paradox, Gödel's incompleteness, and the halting problem: if there is a point-surjection A → (A ⇒ B), then every endomorphism of B has a fixed point. The diagonal case B = A gives the notion of a reflexive object — an A that surjects (on points) onto its own function space A → A. Reflexive objects are exactly the models of Dana Scott's untyped λ-calculus: a term acts both as function and as argument, and the fixed-point combinator Y arises directly from the Lawvere argument. In the category Set the hypothesis is too strong (it forces triviality), which is precisely why λ-models live in categories of domains rather than in Set.",
+    "problemStatement": "This entry (the OQ-01 extension of the completed categorical Lawvere theorem, CantorDiagonalizationOQ03OQ01Incomplete01) asks what the Lawvere hypothesis says in the diagonal case B = A. What structure is an object A equipped with a point-surjection e : A → (A → A), and which objects of Set admit one?",
+    "proofStrategy": "Section I packages the Lawvere argument abstractly: an EvalStructure (Ob, Val, eval) that is point-surjective forces every f : Val → Val to have a fixed point (evaluate the code for a ↦ f (eval a a) at itself). Section II specializes to Ob = Val = A: IsReflexiveObject A ⟹ HasFixedPointProperty A (reflexive_hasFixedPointProperty), and conversely the fixed-point property forces a subsingleton because two distinct points give a fixed-point-free swap map (exists_fixedPointFree_of_ne, subsingleton_of_hasFixedPointProperty). Combining yields reflexive_subsingleton and, with the easy converse for one-point types, the iff reflexive_iff_subsingleton_nonempty. Section III instantiates on Bool and ℕ. Section IV lifts back to general B: a fixed-point-free f : B → B blocks any point-surjection A → (A → B), which for B = Prop, f = Not recovers Cantor and Mathlib's Function.cantor_surjective.",
+    "keyInsights": [
+      "A reflexive object (point-surjection A → (A → A)) is exactly the diagonal case B = A of Lawvere's hypothesis; the resulting fixed-point property is the categorical origin of the untyped λ-calculus Y-combinator.",
+      "In Set the reflexive hypothesis collapses: reflexive ⟹ fixed-point property ⟹ subsingleton, because any two distinct elements furnish the fixed-point-free swap map (x ↦ if x = a then b else a).",
+      "The sharp characterization reflexive_iff_subsingleton_nonempty shows the terminal object is the ONLY reflexive object in Set — the precise categorical reason λ-models must leave Set for domains/complete lattices, where point-surjection weakens to a retraction.",
+      "One abstract lemma (lawvere_abstract on EvalStructure) yields both the reflexive fixed-point property and the general Lawvere–Cantor obstruction; Cantor's theorem is the instance B = Prop with the fixed-point-free negation Not.",
+      "cantor_surjective_recovered rederives Mathlib's Function.cantor_surjective from the same obstruction, confirming the abstraction is faithful (Set A ≡ A → Prop)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring: the diagonal case B = A of the categorical Lawvere theorem defines a reflexive object, the structure underlying every untyped λ-model. States the three main results (fixed-point property, subsingleton in Set, sharp iff), notes the recovery of Cantor, and records 0 sorries / 0 axioms. Imports only Logic.Function.Basic and Tactic."
+    },
+    {
+      "id": "abstract-lawvere",
+      "title": "Section I: The Abstract Lawvere Theorem",
+      "startLine": 54,
+      "endLine": 74,
+      "summary": "EvalStructure bundles codes Ob, values Val, and eval : Ob → Ob → Val. IsPointSurjective: every g : Ob → Val is represented by some code. lawvere_abstract: a point-surjective EvalStructure forces every f : Val → Val to have a fixed point, via the diagonal code for a ↦ f (eval a a). This single lemma drives every later result."
+    },
+    {
+      "id": "reflexive-objects",
+      "title": "Section II: Reflexive Objects and the Fixed-Point Property",
+      "startLine": 76,
+      "endLine": 159,
+      "summary": "IsReflexiveObject A: some e : A → (A → A) is point-surjective. reflexive_hasFixedPointProperty: reflexive ⟹ every self-map has a fixed point (Lawvere with B = A). exists_fixedPointFree_of_ne + subsingleton_of_hasFixedPointProperty: two distinct points give a fixed-point-free swap, so the fixed-point property forces a subsingleton. reflexive_subsingleton and the converse reflexive_of_subsingleton_nonempty combine into the sharp iff reflexive_iff_subsingleton_nonempty."
+    },
+    {
+      "id": "concrete",
+      "title": "Section III: Concrete Non-Reflexive Types",
+      "startLine": 161,
+      "endLine": 177,
+      "summary": "not_reflexive_bool and not_reflexive_nat: Bool and ℕ are not reflexive (each has two distinct elements, blocked by not / succ respectively), instantiating the general obstruction on familiar types."
+    },
+    {
+      "id": "obstruction-cantor",
+      "title": "Section IV: General Obstruction and Cantor's Theorem",
+      "startLine": 179,
+      "endLine": 222,
+      "summary": "no_pointSurjection_of_fixedPointFree: a fixed-point-free f : B → B blocks any point-surjection A → (A → B) — the unified Lawvere–Cantor obstruction. cantor_no_surjection_prop: instance B = Prop, f = Not (¬P = P is impossible). cantor_surjective_recovered: rederives Mathlib's Function.cantor_surjective; an example confirms it matches cantor_surjective on power sets."
+    },
+    {
+      "id": "summary",
+      "title": "Summary Checks",
+      "startLine": 224,
+      "endLine": 235,
+      "summary": "#check statements confirming the signatures of the main theorems: the reflexive fixed-point property, the subsingleton collapse, the sharp iff, the concrete Bool case, the general obstruction, and the recovered Cantor surjectivity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The diagonal case of the categorical Lawvere theorem is fully formalized with 0 sorries and 0 axioms. A reflexive object — a point-surjection A → (A → A) — has the fixed-point property, and in Set this forces A to be a nonempty subsingleton; the iff reflexive_iff_subsingleton_nonempty makes the collapse sharp. The same abstract lemma yields the general Lawvere–Cantor obstruction and recovers Cantor's theorem and Mathlib's Function.cantor_surjective.",
+    "implications": "The sharp characterization is the categorical explanation for why the untyped λ-calculus has no set-theoretic model: Set's only reflexive object is the terminal one. To obtain nontrivial λ-models one weakens 'point-surjection' to a retraction A ⟶ (A ⇒ A) in a category of domains (Scott's D∞, complete lattices, coherent domains), where the Lawvere argument still produces fixed points (giving Y) but no longer forces triviality. The EvalStructure abstraction also exhibits Cantor, Russell, Gödel and the halting problem as one theorem parameterized by the choice of fixed-point-free endomorphism.",
+    "openQuestions": [
+      "Retraction weakening: formalize the domain-theoretic setting where point-surjection is relaxed to a retraction A ⟶ (A ⇒ A), and derive the fixed-point combinator without forcing subsingleton — the actual construction of a nontrivial λ-model.",
+      "Categorical generality: restate lawvere_abstract in a cartesian closed category with a chosen point functor, so the Set-level results become instances of a genuinely categorical theorem.",
+      "Quantitative Cantor: extend cantor_surjective_recovered to a cardinality gap statement (|A| < |A → Prop|) rather than mere non-surjectivity."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Logic.Function.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CantorDiagonalizationOQ03OQ01Incomplete01OQ01",
+    "lineCount": 235,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ01Incomplete01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01-incomplete-01",
+      "relationship": "extends",
+      "description": "The parent completes the categorical Lawvere fixed-point theorem for general B. This entry pursues the diagonal case B = A that the parent did not explore, giving the theory of reflexive objects and their sharp characterization in Set."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "uses",
+      "description": "Recovers Cantor's theorem (cantor_surjective_recovered / Function.cantor_surjective) as the instance B = Prop, f = Not of the general Lawvere–Cantor obstruction."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lawvere, F. William",
+      "title": "Diagonal arguments and cartesian closed categories",
+      "year": "1969",
+      "venue": "Lecture Notes in Mathematics 92, Springer, 134–145 (reprinted in TAC Reprints 15, 2006)",
+      "note": "The original fixed-point theorem unifying Cantor, Russell, Gödel, and Tarski"
+    },
+    {
+      "authors": "Yanofsky, Noson S.",
+      "title": "A universal approach to self-referential paradoxes, incompleteness and fixed points",
+      "year": "2003",
+      "venue": "Bulletin of Symbolic Logic 9(3), 362–386",
+      "note": "Modern exposition of Lawvere's theorem and its instances, including reflexive objects and λ-calculus"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry for the **diagonal case B = A** of the categorical Lawvere fixed-point theorem (OQ-01 extension of `cantor-diagonalization-oq-03-oq-01-incomplete-01`). An object with a point-surjection `e : A → (A → A)` is a **reflexive object** — the structure underlying every model of the untyped λ-calculus.

Salvages a complete, verified, but **orphaned/uncommitted** Lean file (no open PR, no active claim) that was sitting untracked in the shared tree, and adds the missing gallery entry (`meta.json` + `annotations.json`).

## Theorems (13, 235 lines, 0 sorries, 0 axioms)
- `lawvere_abstract` — the one diagonal lemma driving everything (point-surjective `EvalStructure` ⟹ every endomorphism of values has a fixed point).
- `reflexive_hasFixedPointProperty` — reflexive ⟹ every self-map has a fixed point (the categorical Y-combinator).
- `exists_fixedPointFree_of_ne`, `subsingleton_of_hasFixedPointProperty`, `reflexive_subsingleton` — in **Set** a reflexive object collapses to a subsingleton.
- `reflexive_iff_subsingleton_nonempty` — **sharp characterization**: reflexive ⟺ nonempty subsingleton (the terminal object is the only reflexive object of Set; why the untyped λ-calculus has no set-theoretic model).
- `not_reflexive_bool`, `not_reflexive_nat` — concrete non-reflexive types.
- `no_pointSurjection_of_fixedPointFree` — general Lawvere–Cantor obstruction.
- `cantor_no_surjection_prop`, `cantor_surjective_recovered` — recovers Cantor's theorem and Mathlib's `Function.cantor_surjective` (B = Prop, f = Not).

## Verification
Built with `lake env lean` (Mathlib 4.26.0). `#print axioms` on the main theorems reports only `[propext, Classical.choice, Quot.sound]` (several are axiom-free); no `sorryAx`. `annotations:validate` passes for the new slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)