### PR TITLE
research(erdos-286-oq-01): small-k Egyptian representations of 1 — {2,3,6} unique for k=3 [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/Erdos286OQ01.lean
+++ b/proofs/Proofs/Erdos286OQ01.lean
@@ -1,0 +1,133 @@
+import Mathlib
+
+/-!
+# Erdős #286, child OQ-01: Small-k Egyptian representations of 1
+
+A child result of `erdos-286` (Erdős Problem #286, unit fractions in short
+intervals). The parent asks, for the number `k` of terms, how narrow an interval
+of denominators can represent `1` as a sum of `k` distinct unit fractions, and
+already proves the **k = 2 impossibility** (`no_k2_representation`) via the
+identity `(x-1)(y-1) = 1`.
+
+This entry pins down the exact small-`k` picture with fully machine-checked,
+denominator-free (no interval-width) statements:
+
+* **k = 2**: there are **no** two distinct positive integers `a < b` with
+  `1/a + 1/b = 1` (`no_two_distinct_unit_fractions`).
+* **k = 3, existence**: `1/2 + 1/3 + 1/6 = 1` (`repr_236`).
+* **k = 3, uniqueness**: the **only** three distinct positive integers
+  `a < b < c` with `1/a + 1/b + 1/c = 1` are `(2, 3, 6)`
+  (`three_distinct_unit_fractions_eq_one`).
+* Combined characterisation `three_distinct_iff`.
+
+Together these say: `1` has no 2-term distinct Egyptian representation and a
+*unique* 3-term one, `{2, 3, 6}` — the smallest `k` for which a representation
+exists, matching the parent's requirement that the problem needs `k ≥ 3`.
+
+All results are `0`-axiom (no `sorry`, no `axiom`, no `native_decide`).
+
+## References
+* P. Erdős, Problem #286 (unit fractions in short intervals).
+* Egyptian fractions / the equation `1 = Σ 1/nᵢ` with distinct `nᵢ`.
+-/
+
+namespace Erdos286OQ01
+
+open Finset
+
+/-!
+## Section 1: k = 2 — no two distinct unit fractions sum to 1
+-/
+
+/-- **k = 2 impossibility.** No two *distinct* positive integers `a < b` satisfy
+    `1/a + 1/b = 1`. If `a = 1` the second term would have to vanish; if `a ≥ 2`
+    then `b ≥ 3` and `1/a + 1/b ≤ 1/2 + 1/3 = 5/6 < 1`. -/
+theorem no_two_distinct_unit_fractions (a b : ℕ) (ha : 0 < a) (hab : a < b)
+    (h : (1 : ℚ) / a + 1 / b = 1) : False := by
+  have hb : 0 < b := ha.trans hab
+  have hqb : (0 : ℚ) < b := by exact_mod_cast hb
+  have hbpos : (0 : ℚ) < 1 / b := one_div_pos.mpr hqb
+  by_cases ha1 : a = 1
+  · subst ha1
+    have h11 : (1 : ℚ) / (1 : ℕ) = 1 := by norm_num
+    linarith [h, h11, hbpos]
+  · have h2a : 2 ≤ a := by omega
+    have hb3 : 3 ≤ b := by omega
+    have hqa : (0 : ℚ) < a := by exact_mod_cast ha
+    have e1 : (1 : ℚ) / a ≤ 1 / 2 :=
+      one_div_le_one_div_of_le (by norm_num) (by exact_mod_cast h2a)
+    have e2 : (1 : ℚ) / b ≤ 1 / 3 :=
+      one_div_le_one_div_of_le (by norm_num) (by exact_mod_cast hb3)
+    linarith [h, e1, e2]
+
+/-!
+## Section 2: k = 3 — existence and uniqueness of {2, 3, 6}
+-/
+
+/-- **Existence for k = 3.** The representation `1 = 1/2 + 1/3 + 1/6`. -/
+theorem repr_236 : (1 : ℚ) / 2 + 1 / 3 + 1 / 6 = 1 := by norm_num
+
+/-- **Uniqueness for k = 3.** The only strictly increasing triple of positive
+    integers `a < b < c` with `1/a + 1/b + 1/c = 1` is `(2, 3, 6)`.
+
+    Proof: `a` is the smallest term so `1 < 3/a`, forcing `a < 3`; and `a = 1`
+    is impossible (the other two terms are positive), so `a = 2`. Then
+    `1/b + 1/c = 1/2` with `1/c < 1/b` gives `1/4 < 1/b`, i.e. `b < 4`, and
+    `b > 2`, so `b = 3`. Finally `1/c = 1/2 - 1/3 = 1/6`, so `c = 6`. -/
+theorem three_distinct_unit_fractions_eq_one (a b c : ℕ)
+    (ha : 0 < a) (hab : a < b) (hbc : b < c)
+    (h : (1 : ℚ) / a + 1 / b + 1 / c = 1) :
+    a = 2 ∧ b = 3 ∧ c = 6 := by
+  have hb : 0 < b := ha.trans hab
+  have hc : 0 < c := hb.trans hbc
+  have hqa : (0 : ℚ) < a := by exact_mod_cast ha
+  have hqb : (0 : ℚ) < b := by exact_mod_cast hb
+  have hqc : (0 : ℚ) < c := by exact_mod_cast hc
+  have hbpos : (0 : ℚ) < 1 / b := one_div_pos.mpr hqb
+  have hcpos : (0 : ℚ) < 1 / c := one_div_pos.mpr hqc
+  have hba : (1 : ℚ) / b < 1 / a := one_div_lt_one_div_of_lt hqa (by exact_mod_cast hab)
+  have hca : (1 : ℚ) / c < 1 / a := one_div_lt_one_div_of_lt hqa (by exact_mod_cast hab.trans hbc)
+  -- upper bound a < 3
+  have ha3 : a < 3 := by
+    by_contra hcon
+    push_neg at hcon
+    have e1 : (1 : ℚ) / a ≤ 1 / 3 :=
+      one_div_le_one_div_of_le (by norm_num) (by exact_mod_cast hcon)
+    linarith [h, hba, hca, e1]
+  -- rule out a = 1
+  have hane1 : a ≠ 1 := by
+    intro hcon
+    subst hcon
+    have h11 : (1 : ℚ) / (1 : ℕ) = 1 := by norm_num
+    linarith [h, h11, hbpos, hcpos]
+  have ha2 : a = 2 := by omega
+  subst ha2
+  have h2c : ((2 : ℕ) : ℚ) = 2 := by norm_num
+  rw [h2c] at h
+  have hsum2 : (1 : ℚ) / b + 1 / c = 1 / 2 := by linarith [h]
+  have hcb : (1 : ℚ) / c < 1 / b := one_div_lt_one_div_of_lt hqb (by exact_mod_cast hbc)
+  have hb4 : b < 4 := by
+    by_contra hcon
+    push_neg at hcon
+    have e : (1 : ℚ) / b ≤ 1 / 4 :=
+      one_div_le_one_div_of_le (by norm_num) (by exact_mod_cast hcon)
+    linarith [hsum2, hcb, e]
+  have hb3 : b = 3 := by omega
+  subst hb3
+  have h3c : ((3 : ℕ) : ℚ) = 3 := by norm_num
+  rw [h3c] at hsum2
+  have hc6 : (1 : ℚ) / c = 1 / 6 := by linear_combination hsum2
+  simp only [one_div] at hc6
+  have hc6' : (c : ℚ) = 6 := inv_inj.mp hc6
+  have hc6n : c = 6 := by exact_mod_cast hc6'
+  exact ⟨rfl, rfl, hc6n⟩
+
+/-- **Characterisation for k = 3 (ordered).** For strictly increasing positive
+    integers, `1/a + 1/b + 1/c = 1` holds *iff* `(a, b, c) = (2, 3, 6)`. -/
+theorem three_distinct_iff (a b c : ℕ) (ha : 0 < a) (hab : a < b) (hbc : b < c) :
+    (1 : ℚ) / a + 1 / b + 1 / c = 1 ↔ a = 2 ∧ b = 3 ∧ c = 6 := by
+  constructor
+  · exact three_distinct_unit_fractions_eq_one a b c ha hab hbc
+  · rintro ⟨rfl, rfl, rfl⟩; exact repr_236
+
+end Erdos286OQ01

--- a/src/data/proofs/erdos-286-oq-01/annotations.json
+++ b/src/data/proofs/erdos-286-oq-01/annotations.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "ann-e286oq01-k2",
+    "proofId": "erdos-286-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "k = 2 Impossibility",
+    "content": "no_two_distinct_unit_fractions shows 1 has no representation as a sum of two distinct unit fractions. The proof is a clean two-case split on the smaller denominator a: if a = 1 the equation forces 1/b = 0, impossible for b > 0; if a ≥ 2 then b > a gives b ≥ 3, so 1/a + 1/b ≤ 1/2 + 1/3 = 5/6 < 1. Each case closes with linarith after reciprocal bounds from one_div_le_one_div_of_le. This complements the parent's identity-based argument (x−1)(y−1) = 1.",
+    "mathContext": "$\\tfrac1a + \\tfrac1b = 1,\\ a < b$: $a = 1 \\Rightarrow \\tfrac1b = 0$ (impossible); $a \\ge 2 \\Rightarrow \\tfrac1a + \\tfrac1b \\le \\tfrac12 + \\tfrac13 = \\tfrac56 < 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Egyptian fractions",
+      "reciprocal monotonicity",
+      "case analysis on smallest denominator"
+    ],
+    "prerequisites": [
+      "one_div_le_one_div_of_le",
+      "one_div_pos"
+    ]
+  },
+  {
+    "id": "ann-e286oq01-uniqueness",
+    "proofId": "erdos-286-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "Uniqueness of {2, 3, 6} for k = 3",
+    "content": "three_distinct_unit_fractions_eq_one is the heart of the entry: for a < b < c the only solution of 1/a + 1/b + 1/c = 1 is (2,3,6). Since a is smallest, 1 = 1/a + 1/b + 1/c < 3/a forces a < 3 (via one_div_le_one_div_of_le + linarith in a by_contra), and a = 1 is ruled out because the other two terms are positive, so a = 2 by omega. Substituting leaves 1/b + 1/c = 1/2; with 1/c < 1/b this yields 1/4 < 1/b, hence b < 4, and b > 2, so b = 3. Then 1/c = 1/2 − 1/3 = 1/6 (linear_combination), and inv_inj converts c⁻¹ = 6⁻¹ to c = 6.",
+    "mathContext": "Squeeze: $1 < 3/a \\Rightarrow a < 3$, $a \\ne 1 \\Rightarrow a = 2$; then $\\tfrac1b + \\tfrac1c = \\tfrac12$, $\\tfrac1c < \\tfrac1b \\Rightarrow \\tfrac14 < \\tfrac1b \\Rightarrow b = 3$; then $\\tfrac1c = \\tfrac16 \\Rightarrow c = 6$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "uniqueness classification",
+      "bounding the smallest denominator",
+      "injectivity of inversion",
+      "linear_combination over ℚ"
+    ],
+    "prerequisites": [
+      "one_div_lt_one_div_of_lt",
+      "one_div_le_one_div_of_le",
+      "inv_inj",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-e286oq01-existence-iff",
+    "proofId": "erdos-286-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "Existence and the iff-Characterisation",
+    "content": "repr_236 records the existence witness 1/2 + 1/3 + 1/6 = 1 (a norm_num computation), and three_distinct_iff packages existence and uniqueness into a single equivalence: for a < b < c, the sum equals 1 exactly when (a,b,c) = (2,3,6). Together with the k = 2 impossibility, this makes k = 3 the minimal distinct-denominator representation of 1, uniquely realized.",
+    "mathContext": "$\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$; and for $a<b<c$, $\\tfrac1a+\\tfrac1b+\\tfrac1c = 1 \\iff (a,b,c) = (2,3,6)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "existence witness",
+      "iff-characterisation",
+      "minimal term count"
+    ],
+    "prerequisites": [
+      "norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-286-oq-01/meta.json
+++ b/src/data/proofs/erdos-286-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "erdos-286-oq-01",
+  "slug": "erdos-286-oq-01",
+  "title": "Small-k Egyptian Representations of 1: {2,3,6} is the Unique 3-Term Solution",
+  "description": "A child of Erdős Problem #286 (unit fractions in short intervals). The parent proves the k=2 impossibility and shows the problem needs k ≥ 3. This entry pins down the exact small-k picture with fully verified, interval-free statements: there is no representation of 1 as a sum of two distinct unit fractions; and 1 = 1/2 + 1/3 + 1/6 is the UNIQUE representation as a sum of three distinct unit fractions (for strictly increasing denominators a < b < c, the only solution is (a,b,c) = (2,3,6)). So k = 3 is the smallest number of terms for which a distinct-denominator representation of 1 exists, with a unique realizer. Machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos286OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos286OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos286OQ01.lean",
+    "tags": [
+      "number-theory",
+      "egyptian-fractions",
+      "unit-fractions",
+      "erdos-problems",
+      "diophantine",
+      "classification",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "one_div_lt_one_div_of_lt",
+        "description": "0 < a → a < b → 1/b < 1/a; monotonicity of reciprocals, used to order the three terms",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "0 < a → a ≤ b → 1/b ≤ 1/a; the ≤ variant, used in the by_contra bounds a < 3 and b < 4",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "one_div_pos",
+        "description": "0 < 1/a ↔ 0 < a; positivity of the individual terms",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "inv_inj",
+        "description": "a⁻¹ = b⁻¹ ↔ a = b; converts 1/c = 1/6 into c = 6",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Finset.card_eq_two",
+        "description": "used in the parent's k=2 argument; here the small cases are handled by omega after ℚ bounds",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "no_two_distinct_unit_fractions: a clean, self-contained proof that 1 has no representation as a sum of two distinct unit fractions (a=1 forces a vanishing term; a ≥ 2 forces the sum ≤ 1/2 + 1/3 < 1)",
+      "three_distinct_unit_fractions_eq_one: the exact classification — the only strictly increasing positive integers a < b < c with 1/a + 1/b + 1/c = 1 are (2,3,6), proved by squeezing a < 3, a ≠ 1, then b < 4, b > 2, then solving 1/c = 1/6 via inv_inj",
+      "repr_236: the existence witness 1/2 + 1/3 + 1/6 = 1",
+      "three_distinct_iff: the combined iff-characterisation packaging existence and uniqueness for k = 3",
+      "Establishes k = 3 as the minimal term count for a distinct-denominator representation of 1, with {2,3,6} the unique realizer — complementing the parent's k = 2 impossibility"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 133,
+    "mathlib_version": "4.31.0",
+    "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations. #print axioms reports only the ordinary foundational axioms propext / Classical.choice / Quot.sound for every result — no sorryAx and no Lean.ofReduceBool (no native_decide). All arithmetic is over ℚ; the classification is exact (necessary and sufficient), not asymptotic.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #286 concerns representing 1 as a sum of k distinct unit fractions whose denominators lie in a short interval; Croot (2001) showed the interval width can be taken (e − 1 + o(1))k, with (e − 1) optimal. The parent gallery entry (`erdos-286`) formalizes the asymptotic statement and proves the k = 2 impossibility via the identity (x−1)(y−1) = 1, concluding the problem genuinely needs k ≥ 3.\n\nUnderlying the interval question is the classical Egyptian-fraction problem of representing 1 as a sum of distinct unit fractions. For the smallest term counts this has a completely explicit answer, and that is what this entry verifies: no 2-term distinct representation exists, and there is exactly one 3-term distinct representation, namely 1 = 1/2 + 1/3 + 1/6.",
+    "problemStatement": "**Open Question (OQ-286.1)**: make the small-k boundary of the parent precise. For how few distinct unit fractions can 1 be represented, and how many representations are there at that threshold?\n\n**Answer**:\n- **k = 2**: none. There are no distinct positive integers a < b with $\\tfrac1a + \\tfrac1b = 1$.\n- **k = 3**: exactly one. For a < b < c, $\\tfrac1a + \\tfrac1b + \\tfrac1c = 1$ iff $(a,b,c) = (2,3,6)$, and indeed $\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$.\n\nHence k = 3 is the minimal term count for a distinct-denominator representation of 1, uniquely realized by {2, 3, 6}.",
+    "proofStrategy": "1. **k = 2 (Section 1)**: split on a = 1 (the second term must vanish, impossible) versus a ≥ 2 (then b ≥ 3 and 1/a + 1/b ≤ 1/2 + 1/3 = 5/6 < 1), each closed by `linarith` after reciprocal bounds from `one_div_le_one_div_of_le`.\n\n2. **k = 3 uniqueness (Section 2)**: since a is smallest, 1 = 1/a + 1/b + 1/c < 3/a forces (via `one_div_le_one_div_of_le` and `linarith`) a < 3; a = 1 is impossible; so a = 2 (by `omega`). Substituting, 1/b + 1/c = 1/2 with 1/c < 1/b gives 1/4 < 1/b, i.e. b < 4, and b > 2, so b = 3. Finally 1/c = 1/2 − 1/3 = 1/6 (by `linear_combination`), and `inv_inj` yields c = 6.\n\n3. **Existence & iff (Section 2)**: `repr_236` is `norm_num`; `three_distinct_iff` packages the two directions.",
+    "keyInsights": [
+      "**The threshold is exactly 3.** The parent shows k = 2 fails and the interval problem needs k ≥ 3; this entry certifies that k = 3 already succeeds and, moreover, does so uniquely — the smallest interval-representable case is a single explicit triple.",
+      "**Uniqueness is a two-step squeeze, not a search.** Ordering a < b < c turns the equation into successive reciprocal bounds: the smallest denominator is pinned to 2, then the middle to 3, leaving the largest determined algebraically. No unbounded search or decidability over ℚ is required.",
+      "**inv_inj cleanly closes the last step.** Rather than clearing denominators, rewriting 1/c = 1/6 to c⁻¹ = 6⁻¹ and applying injectivity of inversion extracts c = 6 without field_simp fragility.",
+      "**Interval-free but interval-relevant.** The {2,3,6} solution has denominators spanning width 6 − 2 = 4 < (e − 1)·3 ≈ 5.15, so it already lies in a short interval in the parent's sense — a concrete witness at the k = 3 threshold."
+    ],
+    "prerequisites": [
+      "Egyptian fractions and unit-fraction representations of 1",
+      "Elementary inequalities over ℚ (monotonicity of reciprocals)",
+      "Basic Diophantine case analysis (bounding the smallest denominator)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "k2",
+      "title": "k = 2: No Two Distinct Unit Fractions Sum to 1",
+      "startLine": 39,
+      "endLine": 62,
+      "summary": "no_two_distinct_unit_fractions rules out 1/a + 1/b = 1 for distinct a < b: a = 1 forces a vanishing term, while a ≥ 2 forces b ≥ 3 and a sum ≤ 5/6 < 1.",
+      "mathContext": "$\\tfrac1a + \\tfrac1b = 1$ with $a < b$ has no solution: $a=1 \\Rightarrow \\tfrac1b = 0$; $a \\ge 2 \\Rightarrow \\tfrac1a + \\tfrac1b \\le \\tfrac12 + \\tfrac13 = \\tfrac56 < 1$."
+    },
+    {
+      "id": "k3",
+      "title": "k = 3: Existence and Uniqueness of {2, 3, 6}",
+      "startLine": 64,
+      "endLine": 133,
+      "summary": "repr_236 gives existence; three_distinct_unit_fractions_eq_one gives uniqueness by squeezing a = 2, b = 3, then c = 6; three_distinct_iff packages both directions.",
+      "mathContext": "For $a < b < c$: $\\tfrac1a + \\tfrac1b + \\tfrac1c = 1 \\iff (a,b,c) = (2,3,6)$; and $\\tfrac12 + \\tfrac13 + \\tfrac16 = 1$."
+    }
+  ],
+  "references": [
+    {
+      "text": "P. Erdős, Problem #286 — unit fractions in short intervals (Erdős Problems database).",
+      "url": "https://www.erdosproblems.com/286"
+    },
+    {
+      "text": "E. S. Croot III, On a coloring conjecture about unit fractions, Annals of Mathematics 157 (2003), 545–556.",
+      "url": "https://doi.org/10.4007/annals.2003.157.545"
+    },
+    {
+      "text": "Egyptian fraction — representations of 1 as sums of distinct unit fractions.",
+      "url": "https://en.wikipedia.org/wiki/Egyptian_fraction"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-286",
+      "relationship": "extends",
+      "description": "The parent formalizes Erdős #286 (unit fractions in short intervals) and proves the k = 2 impossibility, concluding k ≥ 3 is required. This entry certifies the k = 3 threshold is met and uniquely realized by {2, 3, 6}."
+    },
+    {
+      "targetId": "erdos-286-oq-02",
+      "relationship": "related",
+      "description": "A sibling child of Erdős #286; both refine the small-k / monotonicity structure of the parent problem."
+    }
+  ],
+  "conclusion": {
+    "summary": "We make the parent's small-k boundary exact: 1 has no representation as a sum of two distinct unit fractions, and exactly one as a sum of three distinct unit fractions, namely 1 = 1/2 + 1/3 + 1/6 (the unique strictly increasing solution (2,3,6)). Thus k = 3 is the minimal term count for a distinct-denominator representation of 1, with a unique realizer. Fully machine-checked, 0 sorries, 0 axioms.",
+    "implications": "**Sharpens 'needs k ≥ 3' to 'k = 3 suffices, uniquely'.** The parent establishes the lower bound on the term count; this entry supplies the matching threshold and its unique solution, and notes that the {2,3,6} denominators already span a short interval (width 4 < (e−1)·3), a concrete witness at the boundary.\n\n**A verified base case for Egyptian-fraction enumeration.** The ordered squeeze argument is the k = 3 instance of the general enumeration of distinct unit-fraction representations of 1, and provides a template for larger k.",
+    "openQuestions": [
+      "Prove the Finset form: any 3-element set of positive integers whose reciprocals sum to 1 equals {2,3,6} (sorting the three distinct elements into a < b < c and invoking the ordered classification).",
+      "Enumerate the k = 4 distinct representations of 1 (there are several, e.g. {2,3,7,42}, {2,3,8,24}, {2,3,9,18}, {2,3,10,15}, {2,4,5,20}, {2,4,6,12}) and verify the count.",
+      "For each k, determine the minimal interval width among distinct-denominator representations of 1 and compare to the parent's asymptotic (e−1)k."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New **VERIFIED, 0-axiom** gallery entry `erdos-286-oq-01`, a child of **Erdős Problem #286** (unit fractions in short intervals).

The parent proves the **k = 2 impossibility** and concludes the problem needs `k ≥ 3`. This entry pins down the exact small-`k` picture with interval-free, fully machine-checked statements.

## Results (`Proofs/Erdos286OQ01.lean`, 133L, 4 theorems)

- **`no_two_distinct_unit_fractions`** — `1` has no representation as a sum of two distinct unit fractions (`a = 1` forces a vanishing term; `a ≥ 2 ⟹ 1/a + 1/b ≤ 1/2 + 1/3 = 5/6 < 1`).
- **`three_distinct_unit_fractions_eq_one`** — for `a < b < c`, `1/a + 1/b + 1/c = 1` implies `(a,b,c) = (2,3,6)`. Proof squeezes `a = 2` (from `1 < 3/a` and `a ≠ 1`), then `b = 3` (from `1/4 < 1/b < 1/2`), then `c = 6` (`1/c = 1/6` via `inv_inj`).
- **`repr_236`** — the existence witness `1/2 + 1/3 + 1/6 = 1`.
- **`three_distinct_iff`** — the combined iff-characterisation.

**Conclusion:** `k = 3` is the minimal term count for a distinct-denominator representation of `1`, uniquely realized by `{2, 3, 6}` — and those denominators already span a short interval (width `4 < (e−1)·3 ≈ 5.15`).

## Verification

- Built with `lake env lean` against warm Mathlib **v4.31** oleans (no `lake build`).
- `#print axioms` on all four results reports **only** `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuine 0-axiom.
- 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions. Classification is exact (necessary & sufficient), not asymptotic.

## Notes

Does not modify the parent file. The `Finset`-form generalisation (unordered 3-element set) is listed as an open question in the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
