### PR TITLE
Enrich van Aubel–Varignon square: fill annotation coverage gaps

### DIFF
--- a/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.json
@@ -68,6 +68,28 @@
     ]
   },
   {
+    "id": "ann-varignon-mids",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 65
+    },
+    "type": "definition",
+    "title": "The Varignon Midpoints of PQRS",
+    "content": "With $\\mathrm{mid}(x,y) = \\tfrac{x+y}{2}$ the ordinary segment midpoint, the four Varignon vertices are $M_1 = \\mathrm{mid}(P,Q)$, $M_2 = \\mathrm{mid}(Q,R)$, $M_3 = \\mathrm{mid}(R,S)$, $M_4 = \\mathrm{mid}(S,P)$ — the midpoints of the four sides of the square-center quadrilateral $PQRS$, taken in cyclic order. Varignon's construction is deliberately blind to the shape of $PQRS$: for *any* quadrilateral these midpoints form a parallelogram. All of the square-ness proved downstream is therefore imported entirely from van Aubel's special diagonal relation $R - P = i(S-Q)$, not from the midpoint construction itself. Each $M_k$ is `noncomputable` only because the parent square-centers $P,Q,R,S$ are.",
+    "mathContext": "$M_1=\\tfrac{P+Q}{2},\\ M_2=\\tfrac{Q+R}{2},\\ M_3=\\tfrac{R+S}{2},\\ M_4=\\tfrac{S+P}{2}$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "midpoint of a segment",
+      "the square centers P, Q, R, S"
+    ],
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "midpoint quadrilateral",
+      "cyclic side order"
+    ]
+  },
+  {
     "id": "ann-varignon-edge",
     "proofId": "van-aubel-theorem-oq-01-oq-01",
     "range": {
@@ -131,6 +153,28 @@
       "directional rewriting",
       "van Aubel key identity",
       "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-varignon-closes",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 131
+    },
+    "type": "insight",
+    "title": "The Polygon Closes — It Really Is a Parallelogram",
+    "content": "The four directed edges sum to zero: $(M_2-M_1)+(M_3-M_2)+(M_4-M_3)+(M_1-M_4) = 0$. This is a telescoping triviality (`ring` alone, no geometry), but it carries the essential bookkeeping that $M_1M_2M_3M_4$ is a genuine *closed* quadrilateral rather than an open chain — and, combined with the rotation identities, that opposite edges are negatives of each other, i.e. a parallelogram. Varignon's classical statement is exactly 'the midpoint figure is a parallelogram'; this lemma is that statement's algebraic residue. Everything sharper (equilateral, right-angled) then upgrades the parallelogram to a square.",
+    "mathContext": "$\\sum_{k}(M_{k+1}-M_k) = 0$; opposite edges $M_2-M_1 = -(M_4-M_3)$, $M_3-M_2 = -(M_1-M_4)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "directed edges of a polygon"
+    ],
+    "relatedConcepts": [
+      "parallelogram",
+      "telescoping sum",
+      "closed polygon",
+      "Varignon's theorem"
     ]
   },
   {

--- a/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.source.json
+++ b/src/data/proofs/van-aubel-theorem-oq-01-oq-01/annotations.source.json
@@ -36,6 +36,18 @@
     "prerequisites": ["polynomial identities over ℂ", "linear_combination tactic"]
   },
   {
+    "id": "ann-varignon-mids",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "mid", "kind": "def" },
+    "type": "definition",
+    "title": "The Varignon Midpoints of PQRS",
+    "content": "With $\\mathrm{mid}(x,y) = \\tfrac{x+y}{2}$ the ordinary segment midpoint, the four Varignon vertices are $M_1 = \\mathrm{mid}(P,Q)$, $M_2 = \\mathrm{mid}(Q,R)$, $M_3 = \\mathrm{mid}(R,S)$, $M_4 = \\mathrm{mid}(S,P)$ — the midpoints of the four sides of the square-center quadrilateral $PQRS$, taken in cyclic order. Varignon's construction is deliberately blind to the shape of $PQRS$: for *any* quadrilateral these midpoints form a parallelogram. All of the square-ness proved downstream is therefore imported entirely from van Aubel's special diagonal relation $R - P = i(S-Q)$, not from the midpoint construction itself. Each $M_k$ is `noncomputable` only because the parent square-centers $P,Q,R,S$ are.",
+    "mathContext": "$M_1=\\tfrac{P+Q}{2},\\ M_2=\\tfrac{Q+R}{2},\\ M_3=\\tfrac{R+S}{2},\\ M_4=\\tfrac{S+P}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Varignon's theorem", "midpoint quadrilateral", "cyclic side order"],
+    "prerequisites": ["midpoint of a segment", "the square centers P, Q, R, S"]
+  },
+  {
     "id": "ann-varignon-edge",
     "proofId": "van-aubel-theorem-oq-01-oq-01",
     "anchor": { "type": "declaration", "name": "varignon_edge12", "kind": "theorem" },
@@ -70,6 +82,18 @@
     "significance": "supporting",
     "relatedConcepts": ["directional rewriting", "van Aubel key identity", "ring tactic"],
     "prerequisites": ["rewriting equalities in Lean"]
+  },
+  {
+    "id": "ann-varignon-closes",
+    "proofId": "van-aubel-theorem-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "varignon_closes", "kind": "theorem" },
+    "type": "insight",
+    "title": "The Polygon Closes — It Really Is a Parallelogram",
+    "content": "The four directed edges sum to zero: $(M_2-M_1)+(M_3-M_2)+(M_4-M_3)+(M_1-M_4) = 0$. This is a telescoping triviality (`ring` alone, no geometry), but it carries the essential bookkeeping that $M_1M_2M_3M_4$ is a genuine *closed* quadrilateral rather than an open chain — and, combined with the rotation identities, that opposite edges are negatives of each other, i.e. a parallelogram. Varignon's classical statement is exactly 'the midpoint figure is a parallelogram'; this lemma is that statement's algebraic residue. Everything sharper (equilateral, right-angled) then upgrades the parallelogram to a square.",
+    "mathContext": "$\\sum_{k}(M_{k+1}-M_k) = 0$; opposite edges $M_2-M_1 = -(M_4-M_3)$, $M_3-M_2 = -(M_1-M_4)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["parallelogram", "telescoping sum", "closed polygon", "Varignon's theorem"],
+    "prerequisites": ["directed edges of a polygon"]
   },
   {
     "id": "ann-equal-sides",


### PR DESCRIPTION
Enrichment pass for `van-aubel-theorem-oq-01-oq-01` (quality 43, 0 prior passes).

The entry already had a strong `meta.json` (14 KB, full conclusion, 8 sections) and 9 rich annotations — but annotation **coverage was only 57%**, with three declaration regions left unannotated.

**What this adds:** 2 targeted annotations on genuinely uncovered declarations (coverage 57% → 62%, 9 → 11 annotations):

- **`ann-varignon-mids`** (`mid` + `M₁`…`M₄`): the Varignon midpoint construction, emphasizing that all squareness is imported from van Aubel's diagonal relation $R-P = i(S-Q)$ — the midpoint construction itself is shape-blind.
- **`ann-varignon-closes`** (`varignon_closes`): the parallelogram-closure lemma (edges sum to zero), the algebraic residue of Varignon's classical 'midpoints form a parallelogram'.

Both carry `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. The repetitive sibling edge/rotation lemmas (`varignon_edge23/34/41`, `varignon_rot34/41`) are deliberately left unannotated — they are conceptually covered by their annotated counterparts, and annotating each would be inflation. Build resolves cleanly (exit 0, both new ranges align). Only this slug's two files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)