### PR TITLE
research(erdos-1002-oq-01): mark verified (0-axiom/0-sorry, was mislabeled wip)

### DIFF
--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1002",
     "date": "",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1002OQ01.lean",
     "tags": [
       "analysis",
@@ -16,7 +16,7 @@
       "distribution-functions",
       "axiom-elimination"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",


### PR DESCRIPTION
## Summary

`Erdos1002OQ01.lean` proves two standalone supporting lemmas of the Erdős #1002 program — the Cauchy CDF is a valid distribution function (monotone, correct ±∞ limits) and inner-sum periodicity for rational argument — with **0 axioms and 0 sorries** (10 theorems / 4 definitions), already in `main`. It does **not** contain the open `erdos_1002_conjecture` axiom (that lives only in the parent `Erdos1002Problem.lean`).

Yet the gallery entry was left at `status: axiomatized` / `badge: wip`, while its identical 0-axiom/0-sorry siblings are all marked verified:

| entry | leanFile axioms/sorries | status | badge |
|-------|------------------------|--------|-------|
| oq-01 (this) | 0 / 0 | ~~axiomatized~~ → **verified** | ~~wip~~ → **verified** |
| oq-02 | 0 / 0 | verified | original |
| oq-03 | 0 / 0 | verified | verified |
| oq-04 | 0 / 0 | verified | verified |
| oq-01-oq-01 | 1 / 1 | axiomatized | axiom (correctly stays WIP) |

## Change
Two-line `meta.json` edit: `meta.status` axiomatized→verified, `meta.badge` wip→verified. `meta.axiomCount` (0) and `meta.sorries` (0) already agreed with `leanFile`; only the labels were stale. No Lean changes.

Per the Axiom Integrity Policy, a fully machine-checked file with 0 axiom declarations and 0 structure-encoded assumptions is `verified`; the underlying open Erdős problem remains recorded via `erdosProblemStatus: open`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)