### PR TITLE
research(three-place-identity-oq-01): verify 0-axiom + global Foundation sharpness

### DIFF
--- a/proofs/Proofs/ThreePlaceIdentityOQ01.lean
+++ b/proofs/Proofs/ThreePlaceIdentityOQ01.lean
@@ -135,6 +135,20 @@ theorem roundtrip_fails_example :
   rw [derivedMem_of_not_foundation (fun _ _ => True) () () trivial]
   simp
 
+/-- **Global sharpness.** Quantifying over every viewpoint, the round-trip
+    recovers `mem` everywhere **iff** `mem` satisfies Foundation everywhere.
+    The right-hand side is *exactly* the `WellFoundedMembership.foundation`
+    field the base file's `roundtrip` assumes — so this closes the loop: the
+    global hypothesis of `ThreePlaceIdentity.roundtrip` is not merely sufficient
+    but necessary. -/
+theorem global_roundtrip_iff_foundation (mem : U → U → Prop) :
+    (∀ x y, derivedMem mem y x ↔ mem y x) ↔ (∀ x, ¬ mem x x) := by
+  constructor
+  · intro h x
+    exact (roundtrip_iff_foundation mem x).mp (fun y => h x y)
+  · intro hx x y
+    exact derivedMem_of_foundation mem y x (hx x)
+
 -- ═══════════════════════════════════════════════════════════════
 -- PART V: Self-Regularization and Idempotence
 -- ═══════════════════════════════════════════════════════════════
@@ -158,6 +172,7 @@ theorem derivedMem_idempotent (mem : U → U → Prop) (y x : U) :
 
 #check @derivedMem_iff
 #check @roundtrip_iff_foundation
+#check @global_roundtrip_iff_foundation
 #check @derivedMem_of_not_foundation
 #check @derivedMem_idempotent
 

--- a/research/problems/three-place-identity-oq-01/knowledge.md
+++ b/research/problems/three-place-identity-oq-01/knowledge.md
@@ -84,3 +84,34 @@ Proofs.ThreePlaceIdentityOQ01` before any gallery promotion to `verified`.
   `IdFromMem.toRelativeIdentity`, `RelativeIdentity.fromMembership`, `WellFoundedMembership`).
 - Sibling: `proofs/Proofs/ThreePlaceIdentityOQ02.lean` (stereo equality).
 - Etter, "Three-place Identity," Boundary Institute, 2006.
+
+---
+
+## Session 2026-07-02 (researcher-1): VERIFIED + global sharpness added
+
+**Build status: NOW VERIFIED.** Built with the warm Mathlib olean cache via
+`lake env lean` (toolchain v4.26.0) from the main `proofs/` tree:
+
+- `Proofs.ThreePlaceIdentity` (base) compiles clean.
+- `Proofs.ThreePlaceIdentityOQ01` compiles clean, exit 0, all `#check`s print.
+- `#print axioms` on every theorem (`derivedMem_iff`, `derivedMem_irrefl`,
+  `derivedMem_of_foundation`, `roundtrip_iff_foundation`,
+  `global_roundtrip_iff_foundation`, `derivedMem_of_not_foundation`,
+  `roundtrip_fails_example`, `derivedMem_idempotent`) reports only
+  `[propext, Classical.choice, Quot.sound]` — genuinely **0-axiom, 0-sorry**.
+  The gallery's prior `status: verified` claim (shipped UNVERIFIED in #30801)
+  is now backed by an actual build.
+
+**New theorem this session — `global_roundtrip_iff_foundation`:**
+
+> `(∀ x y, derivedMem mem y x ↔ mem y x) ↔ (∀ x, ¬ mem x x)`
+
+This is the *global* form of the pointwise `roundtrip_iff_foundation`. Its RHS is
+exactly the `WellFoundedMembership.foundation` field that the base file's
+`ThreePlaceIdentity.roundtrip` assumes, so it closes the loop: the base theorem's
+global Foundation hypothesis is not merely sufficient but **necessary**. Proof is
+a one-line quantifier-lift of the pointwise result (forward via
+`roundtrip_iff_foundation.mp`, backward via `derivedMem_of_foundation`).
+
+File now: 8 theorems + 2 defs, 179 lines. `meta.json` leanFile counts updated
+(lineCount 164→179, theoremCount 7→8).

--- a/src/data/proofs/three-place-identity-oq-01/meta.json
+++ b/src/data/proofs/three-place-identity-oq-01/meta.json
@@ -100,9 +100,9 @@
       "ThreePlaceIdentity"
     ],
     "namespace": "ThreePlaceIdentity.OQ01",
-    "lineCount": 164,
+    "lineCount": 179,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/ThreePlaceIdentityOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`three-place-identity-oq-01` (sharp round-trip: is the Foundation axiom necessary?) was shipped **UNVERIFIED** in #30801 because the build host was down, yet its gallery entry already claimed `status: verified`. This PR backs that claim with a real build and adds one genuinely new theorem.

## Verification

Built both files with the warm Mathlib olean cache (`lake env lean`, toolchain v4.26.0) from the main `proofs/` tree:

- `Proofs.ThreePlaceIdentity` (base) — compiles clean.
- `Proofs.ThreePlaceIdentityOQ01` — compiles clean, all `#check`s print.
- `#print axioms` on **every** theorem reports only `[propext, Classical.choice, Quot.sound]` → genuinely **0-axiom, 0-sorry, verified** (matches the existing meta claim).

## New theorem: `global_roundtrip_iff_foundation`

```
(∀ x y, derivedMem mem y x ↔ mem y x) ↔ (∀ x, ¬ mem x x)
```

The **global** form of the existing pointwise `roundtrip_iff_foundation`. Its RHS is exactly the `WellFoundedMembership.foundation` field that the base file's `ThreePlaceIdentity.roundtrip` assumes — so it closes the loop: the base theorem's global Foundation hypothesis is **necessary**, not merely sufficient. Proof is a one-line quantifier-lift of the pointwise result. 0-axiom.

## Files
- `proofs/Proofs/ThreePlaceIdentityOQ01.lean` — +1 theorem (7→8 thm, 164→179 L)
- `src/data/proofs/three-place-identity-oq-01/meta.json` — leanFile counts updated
- `research/problems/three-place-identity-oq-01/knowledge.md` — verification note

🤖 Generated with [Claude Code](https://claude.com/claude-code)