### PR TITLE
Enrich Bell numbers EGF: add 7 annotations

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-01/annotations.json
@@ -1,0 +1,163 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
+    "type": "concept",
+    "title": "The Bell EGF, Captured by Its Defining ODE",
+    "content": "The classical identity $\\sum_n B_n \\frac{X^n}{n!} = \\exp(\\exp X - 1)$ says the exponential generating function of the Bell numbers is the exponential of $\\exp X - 1$. Formalizing the right-hand side directly would require a **chain rule** for `PowerSeries.subst` — $\\frac{d}{dX}(f\\circ g) = (f'\\circ g)\\cdot g'$ — which pinned Mathlib does not provide. This entry sidesteps that gap honestly: rather than build $\\exp(\\exp X - 1)$ as a composition, it characterizes it by the **linear ODE it uniquely solves**, $Y' = \\exp(X)\\,Y$ with $Y(0)=1$. The file proves the Bell EGF satisfies this ODE and is its unique solution — mathematically equivalent to the EGF identity, with zero sorries and zero extra axioms. The engine underneath is that the ODE is coefficient-by-coefficient the Bell binomial recurrence $B_{n+1} = \\sum_{i+j=n}\\binom{n}{i}B_j$.",
+    "mathContext": "$\\sum_n B_n\\tfrac{X^n}{n!} = \\exp(\\exp X - 1) \\iff Y' = \\exp(X)\\,Y,\\ Y(0)=1$.",
+    "significance": "critical",
+    "prerequisites": [
+      "formal power series",
+      "generating functions",
+      "the Bell recurrence"
+    ],
+    "relatedConcepts": [
+      "exponential generating function",
+      "Bell numbers",
+      "formal power series ODE",
+      "PowerSeries.subst",
+      "chain rule obstruction"
+    ]
+  },
+  {
+    "id": "ann-bellegf-def",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 63
+    },
+    "type": "definition",
+    "title": "The Generating Function bellEGF = ∑ Bₙ Xⁿ/n!",
+    "content": "`bellEGF := mk fun n => (Nat.bell n : ℚ) / n!` is the formal power series over $\\mathbb Q$ whose $n$-th coefficient is $B_n/n!$ — an **exponential** generating function (the $1/n!$ weighting is what makes products perform binomial convolution rather than ordinary convolution). Working over $\\mathbb Q\\llbracket X\\rrbracket$ rather than $\\mathbb R$ or $\\mathbb C$ keeps everything purely algebraic: no convergence, no analysis, just coefficient identities. `Nat.bell n` is Mathlib's Bell number, the count of set partitions of an $n$-element set.",
+    "mathContext": "$\\mathrm{bellEGF} = \\sum_{n} \\tfrac{B_n}{n!} X^n \\in \\mathbb Q\\llbracket X\\rrbracket$.",
+    "significance": "key",
+    "prerequisites": [
+      "formal power series",
+      "factorials",
+      "Bell numbers"
+    ],
+    "relatedConcepts": [
+      "PowerSeries.mk",
+      "exponential generating function",
+      "Nat.bell",
+      "ℚ⟦X⟧"
+    ]
+  },
+  {
+    "id": "ann-constant-coeff",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Initial Condition bellEGF(0) = 1",
+    "content": "The constant term is $B_0/0! = 1/1 = 1$, since there is exactly one partition of the empty set. This is one of the two data that pin down $\\exp(\\exp X - 1)$ among all solutions of the ODE — the initial condition $Y(0) = 1$. Proved by rewriting the constant coefficient as the degree-0 coefficient and computing $B_0 = 1$, $0! = 1$.",
+    "mathContext": "$\\mathrm{constantCoeff}\\,\\mathrm{bellEGF} = B_0/0! = 1$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "formal power series coefficients"
+    ],
+    "relatedConcepts": [
+      "constant coefficient",
+      "initial condition",
+      "B₀ = 1"
+    ]
+  },
+  {
+    "id": "ann-convolution",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "The Convolution Step: exp·bellEGF Encodes the Bell Recurrence",
+    "content": "The heart of the argument: $[X^n](\\exp(X)\\cdot\\mathrm{bellEGF}) = B_{n+1}/n!$. Multiplying two exponential generating functions convolves coefficients over the antidiagonal $i+j=n$; here the $1/i!$ from $\\exp$ and the $B_j/j!$ from bellEGF combine, and the identity $\\binom{n}{i}\\,i!\\,j! = n!$ (`choose_mul_factorial_mul_factorial`) rewrites each term $\\frac{1}{i!}\\cdot\\frac{B_j}{j!}$ as $\\frac{\\binom{n}{i}B_j}{n!}$. Summing gives $\\frac{1}{n!}\\sum_{i+j=n}\\binom{n}{i}B_j$, which is exactly $B_{n+1}/n!$ by the **Bell binomial recurrence** $B_{n+1} = \\sum_{i+j=n}\\binom{n}{i}B_j$ (`Nat.bell_succ'`). This is where combinatorics (set partitions) meets the analytic ODE.",
+    "mathContext": "$[X^n](\\exp\\cdot\\mathrm{bellEGF}) = \\tfrac1{n!}\\sum_{i+j=n}\\binom{n}{i}B_j = \\tfrac{B_{n+1}}{n!}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "coefficient of a product of power series",
+      "the binomial Bell recurrence"
+    ],
+    "relatedConcepts": [
+      "binomial convolution",
+      "Nat.bell_succ'",
+      "choose_mul_factorial_mul_factorial",
+      "antidiagonal",
+      "Bell recurrence"
+    ]
+  },
+  {
+    "id": "ann-ode",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "The Bell EGF Solves Y' = exp(X)·Y",
+    "content": "The defining differential equation: $\\frac{d}{dX}\\mathrm{bellEGF} = \\exp(X)\\cdot\\mathrm{bellEGF}$. Coefficient-wise, the formal derivative sends $[X^{n+1}] = B_{n+1}/(n+1)!$ to $[X^n]\\,\\mathrm{bellEGF}' = (n+1)\\cdot B_{n+1}/(n+1)! = B_{n+1}/n!$, which matches $[X^n](\\exp\\cdot\\mathrm{bellEGF}) = B_{n+1}/n!$ from the convolution step. So the derivative performs the **index shift** $n\\mapsto n+1$ and the product performs the **binomial convolution**, and the recurrence makes them agree. Closed by `field_simp` after cancelling the $(n+1)$ against $(n+1)!$.",
+    "mathContext": "$[X^n]\\,\\mathrm{bellEGF}' = (n+1)\\tfrac{B_{n+1}}{(n+1)!} = \\tfrac{B_{n+1}}{n!} = [X^n](\\exp\\cdot\\mathrm{bellEGF})$.",
+    "significance": "critical",
+    "prerequisites": [
+      "derivative of a formal power series",
+      "the convolution step"
+    ],
+    "relatedConcepts": [
+      "formal derivative",
+      "coeff_derivative",
+      "linear ODE",
+      "index shift"
+    ]
+  },
+  {
+    "id": "ann-unique",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 121,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "Uniqueness: The ODE Plus f(0)=1 Determines Everything",
+    "content": "Any $f$ with $f' = \\exp(X)\\,f$ and $f(0)=1$ equals bellEGF. The proof is **strong induction on the coefficient index**: the $0$-th coefficient is fixed by the initial condition, and for $X^{m+1}$, the induction hypothesis (all lower coefficients of $f$ and bellEGF agree) forces the convolutions $\\exp\\cdot f$ and $\\exp\\cdot\\mathrm{bellEGF}$ to agree in degree $m$, hence via the ODE the derivatives agree in degree $m$, and cancelling the nonzero factor $(m+1)$ (`mul_right_cancel₀`) forces the $(m+1)$-st coefficients to agree. This is the formal-power-series analogue of Picard–Lindelöf uniqueness for a linear ODE: the recurrence propagates the initial datum to every coefficient.",
+    "mathContext": "$f' = \\exp\\cdot f,\\ f(0)=1 \\Rightarrow f = \\mathrm{bellEGF}$, by strong induction on $[X^n]$.",
+    "significance": "key",
+    "prerequisites": [
+      "strong induction on ℕ",
+      "the exponential ODE"
+    ],
+    "relatedConcepts": [
+      "strong induction",
+      "ODE uniqueness",
+      "Picard–Lindelöf analogue",
+      "mul_right_cancel₀"
+    ]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "range": {
+      "startLine": 149,
+      "endLine": 155
+    },
+    "type": "theorem",
+    "title": "The Full Statement: bellEGF Is exp(exp X − 1)",
+    "content": "Packages existence and uniqueness into one statement: bellEGF both satisfies the ODE with $f(0)=1$ **and** is the only such series. Since $\\exp(\\exp X - 1)$ is by the ordinary chain rule exactly that unique solution, this identifies $\\sum_n B_n X^n/n! = \\exp(\\exp X - 1)$ — the target EGF identity — without ever constructing the composition. It is the honest formalization advertised in the header: the mathematical substance of the identity, delivered through the ODE that both sides provably satisfy.",
+    "mathContext": "$\\mathrm{bellEGF}$ is the unique solution of $f' = \\exp\\cdot f,\\ f(0)=1$, i.e. $\\exp(\\exp X - 1)$.",
+    "significance": "key",
+    "prerequisites": [
+      "the ODE and uniqueness results"
+    ],
+    "relatedConcepts": [
+      "existence and uniqueness",
+      "EGF identity",
+      "characterization"
+    ]
+  }
+]

--- a/src/data/proofs/bell-numbers-oq-01-oq-01/annotations.source.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-01/annotations.source.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "block-comment", "contains": "the exponential generating function of the Bell numbers" },
+    "type": "concept",
+    "title": "The Bell EGF, Captured by Its Defining ODE",
+    "content": "The classical identity $\\sum_n B_n \\frac{X^n}{n!} = \\exp(\\exp X - 1)$ says the exponential generating function of the Bell numbers is the exponential of $\\exp X - 1$. Formalizing the right-hand side directly would require a **chain rule** for `PowerSeries.subst` — $\\frac{d}{dX}(f\\circ g) = (f'\\circ g)\\cdot g'$ — which pinned Mathlib does not provide. This entry sidesteps that gap honestly: rather than build $\\exp(\\exp X - 1)$ as a composition, it characterizes it by the **linear ODE it uniquely solves**, $Y' = \\exp(X)\\,Y$ with $Y(0)=1$. The file proves the Bell EGF satisfies this ODE and is its unique solution — mathematically equivalent to the EGF identity, with zero sorries and zero extra axioms. The engine underneath is that the ODE is coefficient-by-coefficient the Bell binomial recurrence $B_{n+1} = \\sum_{i+j=n}\\binom{n}{i}B_j$.",
+    "mathContext": "$\\sum_n B_n\\tfrac{X^n}{n!} = \\exp(\\exp X - 1) \\iff Y' = \\exp(X)\\,Y,\\ Y(0)=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["exponential generating function", "Bell numbers", "formal power series ODE", "PowerSeries.subst", "chain rule obstruction"],
+    "prerequisites": ["formal power series", "generating functions", "the Bell recurrence"]
+  },
+  {
+    "id": "ann-bellegf-def",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "bellEGF", "kind": "def" },
+    "type": "definition",
+    "title": "The Generating Function bellEGF = ∑ Bₙ Xⁿ/n!",
+    "content": "`bellEGF := mk fun n => (Nat.bell n : ℚ) / n!` is the formal power series over $\\mathbb Q$ whose $n$-th coefficient is $B_n/n!$ — an **exponential** generating function (the $1/n!$ weighting is what makes products perform binomial convolution rather than ordinary convolution). Working over $\\mathbb Q\\llbracket X\\rrbracket$ rather than $\\mathbb R$ or $\\mathbb C$ keeps everything purely algebraic: no convergence, no analysis, just coefficient identities. `Nat.bell n` is Mathlib's Bell number, the count of set partitions of an $n$-element set.",
+    "mathContext": "$\\mathrm{bellEGF} = \\sum_{n} \\tfrac{B_n}{n!} X^n \\in \\mathbb Q\\llbracket X\\rrbracket$.",
+    "significance": "key",
+    "relatedConcepts": ["PowerSeries.mk", "exponential generating function", "Nat.bell", "ℚ⟦X⟧"],
+    "prerequisites": ["formal power series", "factorials", "Bell numbers"]
+  },
+  {
+    "id": "ann-constant-coeff",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "constantCoeff_bellEGF", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Initial Condition bellEGF(0) = 1",
+    "content": "The constant term is $B_0/0! = 1/1 = 1$, since there is exactly one partition of the empty set. This is one of the two data that pin down $\\exp(\\exp X - 1)$ among all solutions of the ODE — the initial condition $Y(0) = 1$. Proved by rewriting the constant coefficient as the degree-0 coefficient and computing $B_0 = 1$, $0! = 1$.",
+    "mathContext": "$\\mathrm{constantCoeff}\\,\\mathrm{bellEGF} = B_0/0! = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["constant coefficient", "initial condition", "B₀ = 1"],
+    "prerequisites": ["formal power series coefficients"]
+  },
+  {
+    "id": "ann-convolution",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "coeff_exp_mul_bellEGF", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Convolution Step: exp·bellEGF Encodes the Bell Recurrence",
+    "content": "The heart of the argument: $[X^n](\\exp(X)\\cdot\\mathrm{bellEGF}) = B_{n+1}/n!$. Multiplying two exponential generating functions convolves coefficients over the antidiagonal $i+j=n$; here the $1/i!$ from $\\exp$ and the $B_j/j!$ from bellEGF combine, and the identity $\\binom{n}{i}\\,i!\\,j! = n!$ (`choose_mul_factorial_mul_factorial`) rewrites each term $\\frac{1}{i!}\\cdot\\frac{B_j}{j!}$ as $\\frac{\\binom{n}{i}B_j}{n!}$. Summing gives $\\frac{1}{n!}\\sum_{i+j=n}\\binom{n}{i}B_j$, which is exactly $B_{n+1}/n!$ by the **Bell binomial recurrence** $B_{n+1} = \\sum_{i+j=n}\\binom{n}{i}B_j$ (`Nat.bell_succ'`). This is where combinatorics (set partitions) meets the analytic ODE.",
+    "mathContext": "$[X^n](\\exp\\cdot\\mathrm{bellEGF}) = \\tfrac1{n!}\\sum_{i+j=n}\\binom{n}{i}B_j = \\tfrac{B_{n+1}}{n!}$.",
+    "significance": "critical",
+    "relatedConcepts": ["binomial convolution", "Nat.bell_succ'", "choose_mul_factorial_mul_factorial", "antidiagonal", "Bell recurrence"],
+    "prerequisites": ["coefficient of a product of power series", "the binomial Bell recurrence"]
+  },
+  {
+    "id": "ann-ode",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "bellEGF_ODE", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Bell EGF Solves Y' = exp(X)·Y",
+    "content": "The defining differential equation: $\\frac{d}{dX}\\mathrm{bellEGF} = \\exp(X)\\cdot\\mathrm{bellEGF}$. Coefficient-wise, the formal derivative sends $[X^{n+1}] = B_{n+1}/(n+1)!$ to $[X^n]\\,\\mathrm{bellEGF}' = (n+1)\\cdot B_{n+1}/(n+1)! = B_{n+1}/n!$, which matches $[X^n](\\exp\\cdot\\mathrm{bellEGF}) = B_{n+1}/n!$ from the convolution step. So the derivative performs the **index shift** $n\\mapsto n+1$ and the product performs the **binomial convolution**, and the recurrence makes them agree. Closed by `field_simp` after cancelling the $(n+1)$ against $(n+1)!$.",
+    "mathContext": "$[X^n]\\,\\mathrm{bellEGF}' = (n+1)\\tfrac{B_{n+1}}{(n+1)!} = \\tfrac{B_{n+1}}{n!} = [X^n](\\exp\\cdot\\mathrm{bellEGF})$.",
+    "significance": "critical",
+    "relatedConcepts": ["formal derivative", "coeff_derivative", "linear ODE", "index shift"],
+    "prerequisites": ["derivative of a formal power series", "the convolution step"]
+  },
+  {
+    "id": "ann-unique",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "bellEGF_unique", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Uniqueness: The ODE Plus f(0)=1 Determines Everything",
+    "content": "Any $f$ with $f' = \\exp(X)\\,f$ and $f(0)=1$ equals bellEGF. The proof is **strong induction on the coefficient index**: the $0$-th coefficient is fixed by the initial condition, and for $X^{m+1}$, the induction hypothesis (all lower coefficients of $f$ and bellEGF agree) forces the convolutions $\\exp\\cdot f$ and $\\exp\\cdot\\mathrm{bellEGF}$ to agree in degree $m$, hence via the ODE the derivatives agree in degree $m$, and cancelling the nonzero factor $(m+1)$ (`mul_right_cancel₀`) forces the $(m+1)$-st coefficients to agree. This is the formal-power-series analogue of Picard–Lindelöf uniqueness for a linear ODE: the recurrence propagates the initial datum to every coefficient.",
+    "mathContext": "$f' = \\exp\\cdot f,\\ f(0)=1 \\Rightarrow f = \\mathrm{bellEGF}$, by strong induction on $[X^n]$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "ODE uniqueness", "Picard–Lindelöf analogue", "mul_right_cancel₀"],
+    "prerequisites": ["strong induction on ℕ", "the exponential ODE"]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "bell-numbers-oq-01-oq-01",
+    "anchor": { "type": "declaration", "name": "bellEGF_characterization", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Full Statement: bellEGF Is exp(exp X − 1)",
+    "content": "Packages existence and uniqueness into one statement: bellEGF both satisfies the ODE with $f(0)=1$ **and** is the only such series. Since $\\exp(\\exp X - 1)$ is by the ordinary chain rule exactly that unique solution, this identifies $\\sum_n B_n X^n/n! = \\exp(\\exp X - 1)$ — the target EGF identity — without ever constructing the composition. It is the honest formalization advertised in the header: the mathematical substance of the identity, delivered through the ODE that both sides provably satisfy.",
+    "mathContext": "$\\mathrm{bellEGF}$ is the unique solution of $f' = \\exp\\cdot f,\\ f(0)=1$, i.e. $\\exp(\\exp X - 1)$.",
+    "significance": "key",
+    "relatedConcepts": ["existence and uniqueness", "EGF identity", "characterization"],
+    "prerequisites": ["the ODE and uniqueness results"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bell-numbers-oq-01-oq-01` (quality 39, 0 prior passes).

**Gap:** rich `meta.json` (12.9 KB) but **no `annotations.json`** — zero inline coverage.

**Added:** anchor-based `annotations.source.json` (resolved to `annotations.json`) with **7 annotations** at **89% line coverage** of the 157-line proof:

| Annotation | Anchor | Significance |
|---|---|---|
| Overview (ODE-characterization strategy, chain-rule sidestep) | block comment | critical |
| `bellEGF` def | declaration | key |
| `constantCoeff_bellEGF` (initial condition) | declaration | supporting |
| `coeff_exp_mul_bellEGF` (convolution ⇒ Bell recurrence) | declaration | critical |
| `bellEGF_ODE` (Y′ = exp·Y) | declaration | critical |
| `bellEGF_unique` (strong-induction uniqueness) | declaration | key |
| `bellEGF_characterization` (= exp(exp X − 1)) | declaration | key |

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Build resolves cleanly (exit 0, all 7 ranges align). Only this slug's two files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)