### PR TITLE
Enrich recursive symmetric group: add header annotation (schroeder-bernstein-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03-oq-01/annotations.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "ann-sb-oq03oq01-header",
+    "proofId": "schroeder-bernstein-oq-03-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "The Recursive Symmetric Group and Myhill's Theorem",
+    "content": "This file is a child of schroeder-bernstein-oq-03, the formalization of Myhill's isomorphism theorem — the computability-theoretic analogue of Schröder–Bernstein. Where classical Schröder–Bernstein builds a bijection from two injections A ↪ B and B ↪ A, Myhill's theorem upgrades this to the effective setting: from two computable one-one reductions it produces a computable permutation of ℕ (a bijection e with both e and e.symm computable, Mathlib's Equiv.Computable), witnessing that the two sets are recursively isomorphic. The full construction proceeds by a back-and-forth priority argument, still open in the parent file.\n\nThis entry isolates the structural fact that the priority construction silently depends on and that stands on its own: the computable permutations of ℕ form a subgroup recSym of the symmetric group Equiv.Perm ℕ — the classical recursive symmetric group of computability theory. Composition-closure is precisely what licenses a back-and-forth argument to chain finitely many computable adjustments and remain computable. The file then shows every transposition, and hence every finitely-supported permutation, lands in recSym, and that recSym is nontrivial. All results are 0-axiom (no sorry, no added axiom, no native_decide).",
+    "mathContext": "A permutation $e \\in \\operatorname{Sym}(\\mathbb{N})$ is *computable* iff both $e$ and $e^{-1}$ are computable functions $\\mathbb{N}\\to\\mathbb{N}$. Myhill: computable reductions $A \\le_1 B$ and $B \\le_1 A$ imply a computable permutation of $\\mathbb{N}$ carrying $A$ to $B$ — the effective Schröder–Bernstein. This file proves $\\mathrm{recSym} = \\{e : e,\\,e^{-1}\\text{ computable}\\}$ is a subgroup of $\\operatorname{Sym}(\\mathbb{N})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Myhill's isomorphism theorem",
+      "computability-theoretic Schröder–Bernstein",
+      "recursive permutations",
+      "one-one reductions",
+      "back-and-forth / priority construction",
+      "schroeder-bernstein-oq-03 (parent problem)"
+    ],
+    "prerequisites": [
+      "computable functions on ℕ",
+      "many-one and one-one reducibility",
+      "the symmetric group Equiv.Perm",
+      "Equiv.Computable"
+    ]
+  },
+  {
     "id": "ann-sb-oq03oq01-swap",
     "proofId": "schroeder-bernstein-oq-03-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for **schroeder-bernstein-oq-03-oq-01** (The Computable (Recursive) Symmetric Group on ℕ).

## Gap
The entry had 4 annotations — one below the 5-annotation coverage minimum — and the **module docstring (lines 5-42) was uncovered**. That header is where a reader learns what the file is *for*.

## Change
Added a 5th annotation `ann-sb-oq03oq01-header` covering lines 5-42: Myhill's isomorphism theorem as the effective analogue of Schröder–Bernstein, computable permutations / one-one reductions, and why composition-closure of `recSym` is exactly what the back-and-forth priority construction needs. Carries `mathContext` (LaTeX), `significance: key`, `relatedConcepts` (incl. cross-ref to the parent `schroeder-bernstein-oq-03`), and `prerequisites`.

The 4 existing annotations are untouched; the new range has no overlaps (5-42, 55-75, 87-112, 116-146, 147-158). `meta.json` unchanged. No axiom/status claims altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)