### PR TITLE
Enrich q-binomial extended identities: add 8 annotations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-03/annotations.json
@@ -1,0 +1,187 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 4,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Lifting Two Binomial Identities to Gaussian q-Binomials",
+    "content": "This entry closes the last two gaps in the q-analogue program of `combinations-formula-oq-03`: the **subset-of-a-subset** (trinomial-revision) product rule and the **alternating row sum**, now for Gaussian binomial coefficients $\\binom{n}{k}_q$. The mathematical subtlety is that the classical proofs *cancel factorials*, which is illegitimate over a general commutative ring where q-factorials can vanish (e.g. $q$ a root of unity). Two devices resolve this: an honest **multiplied form** that never divides, and the **universal polynomial identity** method — prove the cancelled identity over the integral domain $\\mathbb Z[X]$ (where q-factorials are genuinely nonzero) and transport it to any $(R,q)$ along the ring homomorphism $X\\mapsto q$. Each q-identity comes with its $q=1$ specialization recovering the classical statement.",
+    "mathContext": "$\\binom{n}{k}_q\\binom{k}{j}_q = \\binom{n}{j}_q\\binom{n-j}{k-j}_q$ and $\\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = 0$.",
+    "significance": "critical",
+    "prerequisites": [
+      "binomial coefficient identities",
+      "commutative rings",
+      "polynomial rings"
+    ],
+    "relatedConcepts": [
+      "Gaussian binomial coefficient",
+      "q-analogue",
+      "universal polynomial identity",
+      "roots of unity obstruction"
+    ]
+  },
+  {
+    "id": "ann-qnumber-map",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 54,
+      "endLine": 59
+    },
+    "type": "theorem",
+    "title": "q-Quantities Commute with Ring Homomorphisms",
+    "content": "The foundational infrastructure (absent from the earlier q-files): a ring homomorphism $f\\colon R\\to S$ commutes with the q-number, $f([n]_q) = [n]_{f(q)}$. The proof is a clean induction on $n$ using $[n+1]_q = 1 + q\\,[n]_q$ (`qNumber_succ`) and that $f$ preserves $+,\\,\\cdot,\\,1$. Its companions `qFactorial_map` and `qBinom_map` lift the same commutation to q-factorials and q-binomials by the analogous inductions. This trio is precisely what makes the universal-polynomial-identity transport legal: any polynomial identity in q-binomials, once proved over $\\mathbb Z[X]$, pushes forward along $X\\mapsto q$.",
+    "mathContext": "$f([n]_q) = [n]_{f(q)}$, by induction on $[n+1]_q = 1 + q[n]_q$.",
+    "significance": "key",
+    "prerequisites": [
+      "ring homomorphisms",
+      "q-numbers"
+    ],
+    "relatedConcepts": [
+      "ring homomorphism",
+      "qNumber_succ",
+      "naturality",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-qbinom-map",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "The Transport Lemma: f[n,k]_q = [n,k]_{f q}",
+    "content": "A ring homomorphism commutes with the Gaussian binomial coefficient, $f(\\binom{n}{k}_q) = \\binom{n}{k}_{f(q)}$. The induction runs on the **q-Pascal recurrence** $\\binom{n+1}{k+1}_q = \\binom{n}{k}_q + q^{k+1}\\binom{n}{k+1}_q$ (`qBinom_pascal`), so it needs no q-factorials and works over any commutative ring — crucial, since the whole point is to avoid division. This is the engine of the universal-identity method: it is the map along which an identity proved over $\\mathbb Z[X]$ is evaluated at $X\\mapsto q$ to land in an arbitrary ring.",
+    "mathContext": "$f\\!\\left(\\binom{n}{k}_q\\right) = \\binom{n}{k}_{f(q)}$, by induction on q-Pascal.",
+    "significance": "critical",
+    "prerequisites": [
+      "q-Pascal recurrence",
+      "ring homomorphisms"
+    ],
+    "relatedConcepts": [
+      "qBinom_pascal",
+      "ring homomorphism",
+      "transport",
+      "universal polynomial identity"
+    ]
+  },
+  {
+    "id": "ann-subset-mul",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 87,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "Subset-of-a-Subset, Honest Multiplied Form",
+    "content": "The division-free version, valid over **any** commutative ring: $\\binom{n}{k}_q\\binom{k}{j}_q\\cdot M = \\binom{n}{j}_q\\binom{n-j}{k-j}_q\\cdot M$ where $M = [j]_q![k-j]_q![n-k]_q!$. Both sides equal $[n]_q!$, shown by two applications of the q-factorial product formula $\\binom{n}{k}_q[k]_q![n-k]_q! = [n]_q!$ (`qBinom_product`) via `calc`. Because nothing is cancelled, the equation holds even when $M$ vanishes — this is the mathematically honest statement over a general ring, and the seed from which the cancelled form is extracted over $\\mathbb Z[X]$.",
+    "mathContext": "$\\binom{n}{k}_q\\binom{k}{j}_q\\,M = \\binom{n}{j}_q\\binom{n-j}{k-j}_q\\,M = [n]_q!$, $M=[j]_q![k-j]_q![n-k]_q!$.",
+    "significance": "key",
+    "prerequisites": [
+      "q-factorials",
+      "the q-binomial product formula"
+    ],
+    "relatedConcepts": [
+      "qBinom_product",
+      "q-factorial",
+      "no-division identity",
+      "calc proof"
+    ]
+  },
+  {
+    "id": "ann-subset-cancelled",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 137,
+      "endLine": 176
+    },
+    "type": "theorem",
+    "title": "The Cancelled Form via the Universal Polynomial Identity",
+    "content": "The clean identity $\\binom{n}{k}_q\\binom{k}{j}_q = \\binom{n}{j}_q\\binom{n-j}{k-j}_q$ over any commutative ring — **not** obtainable from the multiplied form by dividing (the q-factorials may be zero). The trick: work over $\\mathbb Z[X]$, an integral domain, where the q-factorial product $F = [j]_X![k-j]_X![n-k]_X!$ is provably nonzero (evaluate at $X=1$: it becomes the strictly positive product of ordinary factorials, so $F\\neq 0$). There cancellation is legal (`mul_right_cancel₀`), yielding the identity over $\\mathbb Z[X]$; then `congrArg` along the evaluation homomorphism $X\\mapsto q$ (with `qBinom_map`) transports it to the target ring. This is a textbook instance of the **universal identity** principle: a polynomial identity true over $\\mathbb Z[X]$ is true after any specialization.",
+    "mathContext": "Prove over $\\mathbb Z[X]$ (domain, $F\\neq 0$ ⇒ cancel), then evaluate $X\\mapsto q$.",
+    "significance": "critical",
+    "prerequisites": [
+      "polynomial rings as integral domains",
+      "the transport lemma qBinom_map"
+    ],
+    "relatedConcepts": [
+      "universal polynomial identity",
+      "integral domain",
+      "mul_right_cancel₀",
+      "evaluation homomorphism",
+      "specialization"
+    ]
+  },
+  {
+    "id": "ann-choose-subset",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 178,
+      "endLine": 185
+    },
+    "type": "theorem",
+    "title": "Classical Recovery at q = 1",
+    "content": "Setting $q=1$ over $\\mathbb Q$ collapses $\\binom{n}{k}_q$ to the ordinary $\\binom{n}{k}$ (`qBinom_at_one`), recovering the classical subset-of-a-subset rule $\\binom{n}{k}\\binom{k}{j} = \\binom{n}{j}\\binom{n-j}{k-j}$ — 'choosing a $k$-subset then a $j$-subset of it equals choosing the $j$-subset first then the rest'. The natural-number statement follows by `exact_mod_cast`. This sanity check confirms the q-identity genuinely generalizes the classical one.",
+    "mathContext": "$q=1$: $\\binom{n}{k}\\binom{k}{j} = \\binom{n}{j}\\binom{n-j}{k-j}$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "binomial coefficients",
+      "the q=1 specialization"
+    ],
+    "relatedConcepts": [
+      "qBinom_at_one",
+      "classical binomial identity",
+      "trinomial revision"
+    ]
+  },
+  {
+    "id": "ann-alt-sum",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 191,
+      "endLine": 202
+    },
+    "type": "theorem",
+    "title": "Alternating Row Sum from the Gauss q-Binomial Theorem",
+    "content": "$\\sum_{k=0}^{n}\\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = 0$ for $n\\ge 1$. This is the value at $x=-1$ of the finite q-binomial theorem $\\prod_{i<n}(1+q^i x) = \\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}} x^k$ (`qBinom_gauss`). The point: at $x=-1$ the $i=0$ factor is $1 + q^0(-1) = 0$, so the entire product vanishes (`Finset.prod_eq_zero`) — and with it the sum. The extra weight $q^{\\binom{k}{2}}$, invisible at $q=1$, is exactly what the Gauss form requires; dropping it would break the identity over a general ring.",
+    "mathContext": "$\\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = \\prod_{i<n}(1+q^i(-1)) = 0$ (the $i=0$ factor is $0$).",
+    "significance": "key",
+    "prerequisites": [
+      "the finite q-binomial theorem",
+      "products over Finset"
+    ],
+    "relatedConcepts": [
+      "Gauss q-binomial theorem",
+      "qBinom_gauss",
+      "Finset.prod_eq_zero",
+      "alternating sum"
+    ]
+  },
+  {
+    "id": "ann-choose-alt",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 204,
+      "endLine": 209
+    },
+    "type": "theorem",
+    "title": "Classical Alternating Row Sum at q = 1",
+    "content": "At $q=1$ the weight $q^{\\binom{k}{2}}$ becomes $1$ and the identity collapses to the classical $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k} = 0$ for $n\\ge 1$ — the statement that a nonempty finite set has equally many even and odd subsets, or the $n$-th finite difference of the constant sequence. Recovered by `simpa` with `qBinom_at_one` from the q-version.",
+    "mathContext": "$q=1$: $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k} = 0$ for $n\\ge 1$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "binomial coefficients",
+      "the q=1 specialization"
+    ],
+    "relatedConcepts": [
+      "alternating binomial sum",
+      "even/odd subsets",
+      "finite differences",
+      "qBinom_at_one"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-03/annotations.source.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-03/annotations.source.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "block-comment", "contains": "q-binomial analogues of the extended identities" },
+    "type": "concept",
+    "title": "Lifting Two Binomial Identities to Gaussian q-Binomials",
+    "content": "This entry closes the last two gaps in the q-analogue program of `combinations-formula-oq-03`: the **subset-of-a-subset** (trinomial-revision) product rule and the **alternating row sum**, now for Gaussian binomial coefficients $\\binom{n}{k}_q$. The mathematical subtlety is that the classical proofs *cancel factorials*, which is illegitimate over a general commutative ring where q-factorials can vanish (e.g. $q$ a root of unity). Two devices resolve this: an honest **multiplied form** that never divides, and the **universal polynomial identity** method — prove the cancelled identity over the integral domain $\\mathbb Z[X]$ (where q-factorials are genuinely nonzero) and transport it to any $(R,q)$ along the ring homomorphism $X\\mapsto q$. Each q-identity comes with its $q=1$ specialization recovering the classical statement.",
+    "mathContext": "$\\binom{n}{k}_q\\binom{k}{j}_q = \\binom{n}{j}_q\\binom{n-j}{k-j}_q$ and $\\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Gaussian binomial coefficient", "q-analogue", "universal polynomial identity", "roots of unity obstruction"],
+    "prerequisites": ["binomial coefficient identities", "commutative rings", "polynomial rings"]
+  },
+  {
+    "id": "ann-qnumber-map",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "qNumber_map", "kind": "theorem" },
+    "type": "theorem",
+    "title": "q-Quantities Commute with Ring Homomorphisms",
+    "content": "The foundational infrastructure (absent from the earlier q-files): a ring homomorphism $f\\colon R\\to S$ commutes with the q-number, $f([n]_q) = [n]_{f(q)}$. The proof is a clean induction on $n$ using $[n+1]_q = 1 + q\\,[n]_q$ (`qNumber_succ`) and that $f$ preserves $+,\\,\\cdot,\\,1$. Its companions `qFactorial_map` and `qBinom_map` lift the same commutation to q-factorials and q-binomials by the analogous inductions. This trio is precisely what makes the universal-polynomial-identity transport legal: any polynomial identity in q-binomials, once proved over $\\mathbb Z[X]$, pushes forward along $X\\mapsto q$.",
+    "mathContext": "$f([n]_q) = [n]_{f(q)}$, by induction on $[n+1]_q = 1 + q[n]_q$.",
+    "significance": "key",
+    "relatedConcepts": ["ring homomorphism", "qNumber_succ", "naturality", "induction on ℕ"],
+    "prerequisites": ["ring homomorphisms", "q-numbers"]
+  },
+  {
+    "id": "ann-qbinom-map",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "qBinom_map", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Transport Lemma: f[n,k]_q = [n,k]_{f q}",
+    "content": "A ring homomorphism commutes with the Gaussian binomial coefficient, $f(\\binom{n}{k}_q) = \\binom{n}{k}_{f(q)}$. The induction runs on the **q-Pascal recurrence** $\\binom{n+1}{k+1}_q = \\binom{n}{k}_q + q^{k+1}\\binom{n}{k+1}_q$ (`qBinom_pascal`), so it needs no q-factorials and works over any commutative ring — crucial, since the whole point is to avoid division. This is the engine of the universal-identity method: it is the map along which an identity proved over $\\mathbb Z[X]$ is evaluated at $X\\mapsto q$ to land in an arbitrary ring.",
+    "mathContext": "$f\\!\\left(\\binom{n}{k}_q\\right) = \\binom{n}{k}_{f(q)}$, by induction on q-Pascal.",
+    "significance": "critical",
+    "relatedConcepts": ["qBinom_pascal", "ring homomorphism", "transport", "universal polynomial identity"],
+    "prerequisites": ["q-Pascal recurrence", "ring homomorphisms"]
+  },
+  {
+    "id": "ann-subset-mul",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "qBinom_subset_of_subset_mul", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Subset-of-a-Subset, Honest Multiplied Form",
+    "content": "The division-free version, valid over **any** commutative ring: $\\binom{n}{k}_q\\binom{k}{j}_q\\cdot M = \\binom{n}{j}_q\\binom{n-j}{k-j}_q\\cdot M$ where $M = [j]_q![k-j]_q![n-k]_q!$. Both sides equal $[n]_q!$, shown by two applications of the q-factorial product formula $\\binom{n}{k}_q[k]_q![n-k]_q! = [n]_q!$ (`qBinom_product`) via `calc`. Because nothing is cancelled, the equation holds even when $M$ vanishes — this is the mathematically honest statement over a general ring, and the seed from which the cancelled form is extracted over $\\mathbb Z[X]$.",
+    "mathContext": "$\\binom{n}{k}_q\\binom{k}{j}_q\\,M = \\binom{n}{j}_q\\binom{n-j}{k-j}_q\\,M = [n]_q!$, $M=[j]_q![k-j]_q![n-k]_q!$.",
+    "significance": "key",
+    "relatedConcepts": ["qBinom_product", "q-factorial", "no-division identity", "calc proof"],
+    "prerequisites": ["q-factorials", "the q-binomial product formula"]
+  },
+  {
+    "id": "ann-subset-cancelled",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "qBinom_subset_of_subset", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Cancelled Form via the Universal Polynomial Identity",
+    "content": "The clean identity $\\binom{n}{k}_q\\binom{k}{j}_q = \\binom{n}{j}_q\\binom{n-j}{k-j}_q$ over any commutative ring — **not** obtainable from the multiplied form by dividing (the q-factorials may be zero). The trick: work over $\\mathbb Z[X]$, an integral domain, where the q-factorial product $F = [j]_X![k-j]_X![n-k]_X!$ is provably nonzero (evaluate at $X=1$: it becomes the strictly positive product of ordinary factorials, so $F\\neq 0$). There cancellation is legal (`mul_right_cancel₀`), yielding the identity over $\\mathbb Z[X]$; then `congrArg` along the evaluation homomorphism $X\\mapsto q$ (with `qBinom_map`) transports it to the target ring. This is a textbook instance of the **universal identity** principle: a polynomial identity true over $\\mathbb Z[X]$ is true after any specialization.",
+    "mathContext": "Prove over $\\mathbb Z[X]$ (domain, $F\\neq 0$ ⇒ cancel), then evaluate $X\\mapsto q$.",
+    "significance": "critical",
+    "relatedConcepts": ["universal polynomial identity", "integral domain", "mul_right_cancel₀", "evaluation homomorphism", "specialization"],
+    "prerequisites": ["polynomial rings as integral domains", "the transport lemma qBinom_map"]
+  },
+  {
+    "id": "ann-choose-subset",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "choose_subset_of_subset", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Classical Recovery at q = 1",
+    "content": "Setting $q=1$ over $\\mathbb Q$ collapses $\\binom{n}{k}_q$ to the ordinary $\\binom{n}{k}$ (`qBinom_at_one`), recovering the classical subset-of-a-subset rule $\\binom{n}{k}\\binom{k}{j} = \\binom{n}{j}\\binom{n-j}{k-j}$ — 'choosing a $k$-subset then a $j$-subset of it equals choosing the $j$-subset first then the rest'. The natural-number statement follows by `exact_mod_cast`. This sanity check confirms the q-identity genuinely generalizes the classical one.",
+    "mathContext": "$q=1$: $\\binom{n}{k}\\binom{k}{j} = \\binom{n}{j}\\binom{n-j}{k-j}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["qBinom_at_one", "classical binomial identity", "trinomial revision"],
+    "prerequisites": ["binomial coefficients", "the q=1 specialization"]
+  },
+  {
+    "id": "ann-alt-sum",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "qBinom_alternating_sum", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Alternating Row Sum from the Gauss q-Binomial Theorem",
+    "content": "$\\sum_{k=0}^{n}\\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = 0$ for $n\\ge 1$. This is the value at $x=-1$ of the finite q-binomial theorem $\\prod_{i<n}(1+q^i x) = \\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}} x^k$ (`qBinom_gauss`). The point: at $x=-1$ the $i=0$ factor is $1 + q^0(-1) = 0$, so the entire product vanishes (`Finset.prod_eq_zero`) — and with it the sum. The extra weight $q^{\\binom{k}{2}}$, invisible at $q=1$, is exactly what the Gauss form requires; dropping it would break the identity over a general ring.",
+    "mathContext": "$\\sum_k \\binom{n}{k}_q q^{\\binom{k}{2}}(-1)^k = \\prod_{i<n}(1+q^i(-1)) = 0$ (the $i=0$ factor is $0$).",
+    "significance": "key",
+    "relatedConcepts": ["Gauss q-binomial theorem", "qBinom_gauss", "Finset.prod_eq_zero", "alternating sum"],
+    "prerequisites": ["the finite q-binomial theorem", "products over Finset"]
+  },
+  {
+    "id": "ann-choose-alt",
+    "proofId": "combinations-formula-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "choose_alternating_sum", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Classical Alternating Row Sum at q = 1",
+    "content": "At $q=1$ the weight $q^{\\binom{k}{2}}$ becomes $1$ and the identity collapses to the classical $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k} = 0$ for $n\\ge 1$ — the statement that a nonempty finite set has equally many even and odd subsets, or the $n$-th finite difference of the constant sequence. Recovered by `simpa` with `qBinom_at_one` from the q-version.",
+    "mathContext": "$q=1$: $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k} = 0$ for $n\\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["alternating binomial sum", "even/odd subsets", "finite differences", "qBinom_at_one"],
+    "prerequisites": ["binomial coefficients", "the q=1 specialization"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-01-oq-03` (quality 43, 0 prior passes).

**Gap:** substantial `meta.json` (21 KB) but **no `annotations.json`** — zero inline coverage of an 8-theorem, 211-line proof.

**Added:** anchor-based `annotations.source.json` (resolved to `annotations.json`), **78% line coverage**, 8 annotations:

| Annotation | Anchor | Significance |
|---|---|---|
| Overview (q-lift + cancellation obstruction) | block comment | critical |
| `qNumber_map` (q-quantities ∘ ring homs) | declaration | key |
| `qBinom_map` (transport lemma) | declaration | critical |
| `qBinom_subset_of_subset_mul` (multiplied form) | declaration | key |
| `qBinom_subset_of_subset` (universal identity over ℤ[X]) | declaration | critical |
| `choose_subset_of_subset` (q=1) | declaration | supporting |
| `qBinom_alternating_sum` (Gauss theorem at x=−1) | declaration | key |
| `choose_alternating_sum` (q=1) | declaration | supporting |

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Build resolves cleanly (exit 0, all 8 ranges align). Only this slug's two files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)