### PR TITLE
audit(basel-problem-oq-03-oq-02): badge original→mathlib (Tier B — core zeta values via Mathlib)

### DIFF
--- a/src/data/proofs/basel-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "infinite-series",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `basel-problem-oq-03-oq-02` (How Far Does the Even-Zeta Product-Reduction Extend? ζ(10), ζ(12), and the Prime 691)
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Problem

The entry's **main results** — the closed forms ζ(10) = π¹⁰/93555 and ζ(12) = 691·π¹²/638512875 — are obtained by directly instantiating Mathlib's `hasSum_zeta_nat` (Euler's even-zeta formula). The weight-10/12 product-reduction identities then follow by a single `ring` step. This is the auditor's **Tier B / Mathlib-wrapper** case (skill failure mode #5, "0 sorries with hidden imports"): the core result comes from a deep Mathlib theorem, so the badge should be `mathlib`, not `original`.

**Consistency evidence**: the **parent** entry `basel-problem-oq-03` does structurally identical work (zeta closed forms via `hasSum_zeta_nat` + Bernoulli recursion + product reductions) and correctly carries badge **`mathlib`**. This child diverged to `original` for the same construction.

## Evidence

`proofs/Proofs/BaselProblemOQ03OQ02.lean`:
```
hasSum_zeta_ten    := by have h := hasSum_zeta_nat (k := 5) ... 
hasSum_zeta_twelve := by have h := hasSum_zeta_nat (k := 6) ...
```
Product reductions are `rw [tsum_...]; ring`.

## Fix

`meta.json`: `"badge": "original"` → `"badge": "mathlib"`.

No other change. The description, `mathlibDependencies`, `originalContributions`, and the Lean docstring **already** credit `hasSum_zeta_nat` transparently and correctly scope the genuinely original content (B₁₀ = 5/66 and B₁₂ = -691/2730 computed from the recursion, the 691 anomaly analysis, the product-reduction identities). Only the badge was misaligned.

## Verification (unchanged, re-confirmed against source)

- 0 sorries ✓
- 0 `axiom` declarations ✓
- No `native_decide` (8 plain `decide` uses, kernel-checked, no `Lean.ofReduceBool`) ✓
- 30 theorems, 0 defs, 259 lines — matches meta.json ✓
- No `True` stubs ✓
- `status: verified` retained (0-axiom, 0-sorry is legitimate) ✓

---
Discovered during gallery integrity audit.