### PR TITLE
Enrich list-CRT certificate: split worked examples (chinese-remainder-constructive-oq-05-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01-oq-01/annotations.json
@@ -11,8 +11,16 @@
     "content": "#print axioms on all four theorems (crt_list_mod_iff, crt_list_existsUnique, crt_11_mod_60, crt_100_mod_210) lists only propext, Classical.choice, Quot.sound. No Lean.ofReduceBool (which native_decide would inject), no sorryAx, no axiom declarations. The list generalisation is ordinary structural induction (through Mathlib's Nat.modEq_list_map_prod_iff and Nat.chineseRemainderOfList) plus kernel decide for the numeric side conditions, so it inherits the axiom-free profile of the two- and three-modulus certificates it supersedes.",
     "mathContext": "Every theorem's axiom set $= \\{\\mathsf{propext}, \\mathsf{Classical.choice}, \\mathsf{Quot.sound}\\}$; in particular $\\mathsf{Lean.ofReduceBool} \\notin$ the set.",
     "significance": "key",
-    "relatedConcepts": ["#print axioms", "Lean.ofReduceBool", "native_decide vs kernel decide", "axiom integrity policy"],
-    "prerequisites": ["Lean's axiom tracking", "decision procedures and their trust assumptions"]
+    "relatedConcepts": [
+      "#print axioms",
+      "Lean.ofReduceBool",
+      "native_decide vs kernel decide",
+      "axiom integrity policy"
+    ],
+    "prerequisites": [
+      "Lean's axiom tracking",
+      "decision procedures and their trust assumptions"
+    ]
   },
   {
     "id": "ann-list-certificate",
@@ -26,37 +34,88 @@
     "content": "The sibling's crt_pair_iff (two moduli) and crt_triple_iff (three moduli) each folded Nat.modEq_and_modEq_iff_modEq_mul by hand — once, then twice — and the sibling explicitly 'stopped at three moduli'. crt_list_mod_iff replaces the hand-folding with induction over a list: for any pairwise-coprime ms, a witness N < ms.prod and any x < ms.prod, (∀ m ∈ ms, x % m = N % m) ↔ x = N. The forward direction instantiates Nat.modEq_list_map_prod_iff at s = id (so (ms.map id).prod = ms.prod and the (Coprime on id) hypothesis reduces to Coprime, supplied by co.imp), assembling the per-modulus congruences into a single x ≡ N [MOD ms.prod]; Nat.mod_eq_of_lt on both x and N then collapses that congruence into x = N. Setting ms = [m,n] or [m,n,p] recovers the sibling's certificates verbatim, so this is a strict generalisation.",
     "mathContext": "$\\bigl(\\forall m \\in ms,\\ x \\equiv N \\pmod m\\bigr) \\iff x \\equiv N \\pmod{\\prod ms} \\iff x = N$ on $0 \\le x, N < \\prod ms$.",
     "significance": "critical",
-    "relatedConcepts": ["Nat.modEq_list_map_prod_iff", "List.Pairwise Coprime", "List.prod", "Nat.mod_eq_of_lt", "strict generalisation of crt_pair_iff / crt_triple_iff"],
-    "prerequisites": ["structural induction over lists", "the two- and three-modulus certificates", "Nat.ModEq as residue equality"]
+    "relatedConcepts": [
+      "Nat.modEq_list_map_prod_iff",
+      "List.Pairwise Coprime",
+      "List.prod",
+      "Nat.mod_eq_of_lt",
+      "strict generalisation of crt_pair_iff / crt_triple_iff"
+    ],
+    "prerequisites": [
+      "structural induction over lists",
+      "the two- and three-modulus certificates",
+      "Nat.ModEq as residue equality"
+    ]
   },
   {
     "id": "ann-existence-uniqueness",
     "proofId": "chinese-remainder-constructive-oq-05-oq-01-oq-01",
     "range": {
       "startLine": 82,
-      "endLine": 102
+      "endLine": 97
     },
     "type": "insight",
     "title": "crt_list_existsUnique: Existence + Bound + Uniqueness as One ExistsUnique",
     "content": "Mathlib provides the CRT pieces for a list separately: Nat.chineseRemainderOfList produces a witness satisfying every congruence, chineseRemainderOfList_lt_prod bounds it below (l.map s).prod, and chineseRemainderOfList_modEq_unique shows any solution is congruent to it modulo the product. crt_list_existsUnique assembles them into a single ExistsUnique: for pairwise-coprime nonzero moduli s and arbitrary residue targets a, there is a UNIQUE x < (l.map s).prod congruent to each a i mod s i. Uniqueness is closed by noting a competing solution y is ≡ the canonical witness modulo the product (by _modEq_unique) and both lie below it, so Nat.mod_eq_of_lt forces equality. This is exactly the CRT bijection onto Fin (∏ sᵢ) stated as one theorem rather than three lemmas.",
     "mathContext": "$\\exists!\\, x < \\textstyle\\prod_i s_i,\\ \\forall i \\in l,\\ x \\equiv a_i \\pmod{s_i}$ — the isomorphism $\\mathbb{Z}/(\\prod s_i) \\cong \\prod_i \\mathbb{Z}/s_i$ read off as an in-range unique witness.",
     "significance": "critical",
-    "relatedConcepts": ["Nat.chineseRemainderOfList", "chineseRemainderOfList_modEq_unique", "chineseRemainderOfList_lt_prod", "ExistsUnique", "CRT bijection"],
-    "prerequisites": ["existence vs uniqueness of CRT solutions", "ExistsUnique introduction", "Nat.mod_eq_of_lt"]
+    "relatedConcepts": [
+      "Nat.chineseRemainderOfList",
+      "chineseRemainderOfList_modEq_unique",
+      "chineseRemainderOfList_lt_prod",
+      "ExistsUnique",
+      "CRT bijection"
+    ],
+    "prerequisites": [
+      "existence vs uniqueness of CRT solutions",
+      "ExistsUnique introduction",
+      "Nat.mod_eq_of_lt"
+    ]
   },
   {
-    "id": "ann-worked-examples",
+    "id": "ann-example-11-60",
     "proofId": "chinese-remainder-constructive-oq-05-oq-01-oq-01",
     "range": {
-      "startLine": 104,
-      "endLine": 120
+      "startLine": 99,
+      "endLine": 110
     },
     "type": "concept",
-    "title": "Three- and Four-Modulus Examples: Arity Is Now Free",
-    "content": "crt_11_mod_60 reproves the sibling's [3,4,5] example (over x < 60, x ≡ 2 (3) ∧ x ≡ 3 (4) ∧ x ≡ 1 (5) ↔ x = 11) as a one-line instance of crt_list_mod_iff, with the pairwise-coprimality and the residues N % m discharged by kernel decide and List.forall_mem_cons unfolding the membership quantifier into the explicit conjunction. crt_100_mod_210 is a genuinely NEW four-modulus example over [2,3,5,7] (x ≡ 0 (2) ∧ x ≡ 1 (3) ∧ x ≡ 0 (5) ∧ x ≡ 2 (7) ↔ x = 100 on x < 210) — the sibling's three-modulus crt_triple_iff cannot state it, but the list certificate handles four moduli with the identical one-line instantiation. Both are axiom-free.",
+    "title": "Three-Modulus Example: Reproving 11 mod 60 Through the List Machinery",
+    "content": "crt_11_mod_60 reproves the sibling's [3,4,5] certificate — over 0 ≤ x < 60, the system x ≡ 2 (3) ∧ x ≡ 3 (4) ∧ x ≡ 1 (5) holds iff x = 11 — as a one-line instance of the arbitrary-arity crt_list_mod_iff at the literal list [3, 4, 5] (product 60). The pairwise-coprimality hypothesis and the witness bound N = 11 < 60 are discharged by kernel decide (deliberately decide, not native_decide, so the example stays Lean.ofReduceBool-free), and List.forall_mem_cons unfolds the membership quantifier ∀ m ∈ [3,4,5] into the explicit three-way conjunction. This shows the general list certificate specialises back to the sibling's fixed-arity results with no loss.",
+    "mathContext": "$x \\equiv 11 \\pmod{60}$ decomposes as $(2,3,1)$ across the coprime moduli $(3,4,5)$; on $0 \\le x < 60$ the three-congruence system collapses to the single equation $x = 11$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "crt_list_mod_iff instantiation",
+      "List.forall_mem_cons",
+      "kernel decide (not native_decide)",
+      "specialisation to fixed arity"
+    ],
+    "prerequisites": [
+      "instantiating a list-indexed lemma at a literal list",
+      "coprimality of 3,4,5"
+    ]
+  },
+  {
+    "id": "ann-example-100-210",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 121
+    },
+    "type": "concept",
+    "title": "Four-Modulus Example: 100 mod 210, Beyond the Triple Certificate",
+    "content": "crt_100_mod_210 is the payoff of removing the arity ceiling: a genuinely new four-modulus example over the pairwise-coprime list [2, 3, 5, 7] (product 210). Over 0 ≤ x < 210, the four congruences x ≡ 0 (2) ∧ x ≡ 1 (3) ∧ x ≡ 0 (5) ∧ x ≡ 2 (7) hold iff x = 100. The sibling's three-modulus crt_triple_iff cannot even state this system, yet the list certificate handles four moduli with the identical one-line instantiation used for the three-modulus case — the whole point of generalising to arbitrary lists. Kernel-checked and axiom-free (decide, not native_decide).",
     "mathContext": "$x \\equiv 100 \\pmod{210}$ decomposes as $(0,1,0,2)$ across the coprime moduli $(2,3,5,7)$; the certificate makes the four-congruence system equivalent to the single equation $x = 100$ on $0 \\le x < 210$.",
     "significance": "key",
-    "relatedConcepts": ["crt_list_mod_iff instantiation", "List.forall_mem_cons", "kernel decide on Nat.Coprime and residues", "four pairwise-coprime moduli"],
-    "prerequisites": ["instantiating a list-indexed lemma at a literal list", "coprimality of 2,3,5,7"]
+    "relatedConcepts": [
+      "arbitrary-arity CRT",
+      "four pairwise-coprime moduli",
+      "crt_list_mod_iff instantiation",
+      "beyond crt_triple_iff"
+    ],
+    "prerequisites": [
+      "instantiating a list-indexed lemma at a literal list",
+      "coprimality of 2,3,5,7"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **chinese-remainder-constructive-oq-05-oq-01-oq-01** (Constructive CRT certificate for a list of pairwise-coprime moduli).

## Gap
The entry sat at 4 annotations (below the 5-annotation minimum), with both worked examples — a three-modulus reproof and the file's *headline* four-modulus example — crammed into a single `ann-worked-examples` block. It also had a pre-existing range overlap risk: `ann-existence-uniqueness` spanned 82-102, over-extending well past its theorem (ends line 97) into the example docstrings.

## Change
- Split the combined annotation into **`ann-example-11-60`** (the [3,4,5] reproof through the list machinery, showing the general certificate specialises back to fixed arity) and **`ann-example-100-210`** (the genuinely new [2,3,5,7] example the sibling's `crt_triple_iff` cannot state — the payoff of removing the arity ceiling). Each gets focused `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Tightened `ann-existence-uniqueness` to 82-97 to sit exactly on `crt_list_existsUnique`.

Result: 5 annotations, no overlaps, full-file coverage (1-56, 59-80, 82-97, 99-110, 112-121). `meta.json` unchanged; no axiom/status claims altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)