### PR TITLE
research(navier-stokes-oq-01-oq-01): verified algebraic assembly of Ladyzhenskaya's 2D inequality + Mathlib-gap map

### DIFF
--- a/proofs/Proofs/NavierStokesOQ0101.lean
+++ b/proofs/Proofs/NavierStokesOQ0101.lean
@@ -1,0 +1,122 @@
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+
+/-
+# Ladyzhenskaya's 2D Interpolation Inequality — Verified Algebraic Assembly (OQ-01-01)
+
+## The Question
+Parent problem `navier-stokes-oq-01` asks whether the **Ladyzhenskaya inequality**
+
+    ‖u‖_{L⁴(ℝ²)}  ≤  C · ‖u‖_{L²}^{1/2} · ‖∇u‖_{L²}^{1/2}
+
+— the interpolation estimate that drives 2D Navier–Stokes regularity — can be
+formalized in Lean/Mathlib.
+
+## What Mathlib Provides (and Does Not)
+As of Mathlib v4.26 there is **no** Gagliardo–Nirenberg–Sobolev inequality and
+**no** Ladyzhenskaya inequality. A grep across `Mathlib/Analysis/` for
+`Ladyzhenskaya`, `GagliardoNirenberg`, `gagliardo` returns nothing. The weak-
+derivative / Sobolev-space API needed for the *analytic* half of the classical
+proof is not available in the form required. A full formalization from first
+principles is a >1000-line foundational effort (see `knowledge.md`).
+
+## What This File Does (honestly scoped)
+Ladyzhenskaya's classical proof factors cleanly into
+  (A) three **analytic** facts (an integrated pointwise product bound and two
+      Cauchy–Schwarz estimates), and
+  (B) a purely **algebraic** assembly of those three facts into the final
+      interpolation bound, including the *sharp* constant.
+
+Part (B) is entirely elementary and is fully verified here, **0 axioms, 0
+sorries**. Part (A) is exposed as explicit hypotheses — these are precisely the
+lemmas Mathlib is missing, so this file doubles as a specification of the gap.
+
+Notation for the (nonnegative) norms of a compactly-supported `u : ℝ² → ℝ`:
+`n2 = ‖u‖_{L²}`, `n4 = ‖u‖_{L⁴}`, `d1 = ‖∂₁u‖_{L²}`, `d2 = ‖∂₂u‖_{L²}`,
+`ng = ‖∇u‖_{L²}` with `ng² = d1² + d2²`.
+
+## References
+- O. A. Ladyzhenskaya, *The Mathematical Theory of Viscous Incompressible Flow*,
+  1969 (the L⁴/L² interpolation estimate, dimension 2).
+- See `Proofs/NavierStokes.lean` for the surrounding 2D enstrophy development.
+-/
+
+namespace NavierStokes.OQ0101
+
+open scoped Real
+
+-- ═══════════════════════════════════════════════════════════════
+-- The sharp AM–GM step
+-- ═══════════════════════════════════════════════════════════════
+
+/-- The one inequality that fixes Ladyzhenskaya's constant: `d1·d2 ≤ ½(d1²+d2²)`.
+    Equivalently `‖∂₁u‖·‖∂₂u‖ ≤ ½‖∇u‖²`, sharp when `d1 = d2`. -/
+theorem cross_le_grad_sq (d1 d2 : ℝ) : d1 * d2 ≤ (d1 ^ 2 + d2 ^ 2) / 2 := by
+  nlinarith [sq_nonneg (d1 - d2)]
+
+-- ═══════════════════════════════════════════════════════════════
+-- The algebraic assembly of Ladyzhenskaya's proof
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Algebraic assembly of Ladyzhenskaya's inequality (2D).**
+
+From the three analytic inputs of the classical proof —
+* the integrated pointwise product bound `n4⁴ ≤ 4·a·b`, where
+  `a = ∫∫|u||∂₁u|` and `b = ∫∫|u||∂₂u|`;
+* the Cauchy–Schwarz estimate `a ≤ n2·d1` (slicing in `x`);
+* the Cauchy–Schwarz estimate `b ≤ n2·d2` (slicing in `y`);
+
+the sharp interpolation bound
+
+    n4⁴ ≤ 2 · n2² · (d1² + d2²)
+
+follows by pure algebra (AM–GM). Writing `ng² = d1² + d2²` this is
+`‖u‖₄⁴ ≤ 2‖u‖₂²‖∇u‖₂²`, i.e. the Ladyzhenskaya constant `C = 2^{1/4}`. -/
+theorem ladyzhenskaya_assembly
+    (n2 n4 d1 d2 a b : ℝ)
+    (hn2 : 0 ≤ n2) (hd1 : 0 ≤ d1)
+    (hb : 0 ≤ b)
+    (hprod : n4 ^ 4 ≤ 4 * a * b)     -- integrated pointwise bound
+    (hCS1 : a ≤ n2 * d1)             -- Cauchy–Schwarz slicing in x
+    (hCS2 : b ≤ n2 * d2) :           -- Cauchy–Schwarz slicing in y
+    n4 ^ 4 ≤ 2 * n2 ^ 2 * (d1 ^ 2 + d2 ^ 2) := by
+  -- Multiply the two Cauchy–Schwarz bounds: a·b ≤ (n2·d1)(n2·d2) = n2²·d1·d2.
+  have hab : a * b ≤ (n2 * d1) * (n2 * d2) :=
+    mul_le_mul hCS1 hCS2 hb (mul_nonneg hn2 hd1)
+  -- Sharp AM–GM on the gradient components.
+  have hcross := cross_le_grad_sq d1 d2
+  -- n2² ≥ 0 lets us scale the AM–GM step.
+  have hn2sq : (0 : ℝ) ≤ n2 ^ 2 := sq_nonneg n2
+  nlinarith [hprod, hab, hcross, hn2sq,
+    mul_le_mul_of_nonneg_left hcross hn2sq]
+
+-- ═══════════════════════════════════════════════════════════════
+-- Norm form with the explicit sharp constant
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Squared norm form.** From `n4⁴ ≤ 2·n2²·ng²` one gets the clean
+    `n4² ≤ √2 · n2 · ng`, i.e. `‖u‖₄² ≤ √2 · ‖u‖₂ · ‖∇u‖₂`. Taking square roots
+    once more recovers `‖u‖₄ ≤ 2^{1/4}‖u‖₂^{1/2}‖∇u‖₂^{1/2}`. -/
+theorem ladyzhenskaya_sq_form
+    (n2 n4 ng : ℝ) (hn2 : 0 ≤ n2) (hng : 0 ≤ ng)
+    (h : n4 ^ 4 ≤ 2 * n2 ^ 2 * ng ^ 2) :
+    n4 ^ 2 ≤ Real.sqrt 2 * n2 * ng := by
+  have hrhs : (0 : ℝ) ≤ Real.sqrt 2 * n2 * ng :=
+    mul_nonneg (mul_nonneg (Real.sqrt_nonneg 2) hn2) hng
+  -- Compare squares: (n4²)² = n4⁴ ≤ 2 n2² ng² = (√2 · n2 · ng)².
+  have hsq : (n4 ^ 2) ^ 2 ≤ (Real.sqrt 2 * n2 * ng) ^ 2 := by
+    have hs2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+    nlinarith [h, hs2]
+  have hn4sq : (0 : ℝ) ≤ n4 ^ 2 := sq_nonneg n4
+  calc n4 ^ 2 = Real.sqrt ((n4 ^ 2) ^ 2) := (Real.sqrt_sq hn4sq).symm
+    _ ≤ Real.sqrt ((Real.sqrt 2 * n2 * ng) ^ 2) := Real.sqrt_le_sqrt hsq
+    _ = Real.sqrt 2 * n2 * ng := Real.sqrt_sq hrhs
+
+-- ═══════════════════════════════════════════════════════════════
+-- Final verification
+-- ═══════════════════════════════════════════════════════════════
+
+#check @cross_le_grad_sq
+#check @ladyzhenskaya_assembly
+#check @ladyzhenskaya_sq_form
+
+end NavierStokes.OQ0101

--- a/research/problems/navier-stokes-oq-01-oq-01/knowledge.md
+++ b/research/problems/navier-stokes-oq-01-oq-01/knowledge.md
@@ -1,21 +1,92 @@
 # Knowledge Base: navier-stokes-oq-01-oq-01
 
-Insights accumulated during research on this problem.
+**Can the Ladyzhenskaya inequality `‖u‖₄ ≤ C‖u‖₂^{1/2}‖∇u‖₂^{1/2}` (2D) be
+formalized in Lean/Mathlib?**
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The Ladyzhenskaya inequality is the `d = 2` case of Gagliardo–Nirenberg:
+for compactly-supported `u : ℝ² → ℝ`,
+
+    ‖u‖_{L⁴(ℝ²)} ≤ C · ‖u‖_{L²}^{1/2} · ‖∇u‖_{L²}^{1/2},   sharp C = 2^{1/4}.
+
+It is the estimate that closes the 2D Navier–Stokes energy/enstrophy loop, so it
+sits directly under parent `navier-stokes-oq-01` (2D enstrophy decay).
+
+### Ladyzhenskaya's classical proof (the structure to formalize)
+For each fixed `y`, `u(x,y)² = ∫_{-∞}^x ∂₁(u²) ≤ 2∫ℝ |u||∂₁u| dx' =: g(y)`
+(independent of `x`). Symmetrically `u(x,y)² ≤ 2∫ℝ |u||∂₂u| dy' =: h(x)`. Hence
+
+    ∫∫ u⁴ = ∫∫ u²·u² ≤ ∫∫ g(y)h(x) = (∫g)(∫h)
+          = (2∫∫|u||∂₁u|)(2∫∫|u||∂₂u|) = 4·a·b,   a := ∫∫|u||∂₁u|, b := ∫∫|u||∂₂u|.
+
+Cauchy–Schwarz gives `a ≤ ‖u‖₂‖∂₁u‖₂`, `b ≤ ‖u‖₂‖∂₂u‖₂`, and AM–GM
+`‖∂₁u‖₂‖∂₂u‖₂ ≤ ½‖∇u‖₂²`, so `‖u‖₄⁴ ≤ 2‖u‖₂²‖∇u‖₂²`, i.e. `C = 2^{1/4}`.
+
+The proof factors into
+* **(A) analytic inputs** — the integrated pointwise product bound `n4⁴ ≤ 4ab`
+  and the two Cauchy–Schwarz slice estimates; and
+* **(B) an algebraic assembly** of (A) into the final bound + sharp constant.
 
 ---
 
-## Insights
+## Result (this session, VERIFIED)
 
-[Insights from research attempts will be accumulated here]
+`proofs/Proofs/NavierStokesOQ0101.lean` (122 L, 3 theorems, **0 axioms /
+0 sorries**, `#print axioms` = `[propext, Classical.choice, Quot.sound]` only,
+built on Mathlib v4.26 warm cache). It formalizes **Part (B) in full** and
+exposes **Part (A) as explicit hypotheses**:
+
+- `cross_le_grad_sq : d1*d2 ≤ (d1²+d2²)/2` — the sharp AM–GM step fixing the
+  constant (equality at `d1 = d2`, i.e. `‖∂₁u‖ = ‖∂₂u‖`).
+- `ladyzhenskaya_assembly` — from `(n4⁴ ≤ 4ab, a ≤ n2·d1, b ≤ n2·d2)` derive
+  `n4⁴ ≤ 2·n2²·(d1²+d2²)`. This is the entire non-analytic content of the proof.
+- `ladyzhenskaya_sq_form` — repackages `n4⁴ ≤ 2n2²ng²` as the clean
+  `n4² ≤ √2·n2·ng` (`‖u‖₄² ≤ √2‖u‖₂‖∇u‖₂`), one square-root from the stated form.
+
+So the answer to OQ-01-01 is a **qualified yes**: the algebraic skeleton and the
+sharp constant are fully machine-checked; what remains is purely the analytic
+inputs (A), which are exactly the Mathlib gap below.
 
 ---
 
-## Dead Ends
+## Insights / The Mathlib gap (Part A)
 
-[Approaches known not to work will be documented here]
+Grepping `Mathlib/Analysis/` (v4.26) for `Ladyzhenskaya`, `GagliardoNirenberg`,
+`gagliardo`, and interpolation returns **nothing** relevant. Missing pieces:
+
+1. **The pointwise/slice bound** `u(x,y)² ≤ 2∫|u||∂₁u|dx'`. Needs the 1D FTC for
+   (weak) derivatives plus Fubini/Tonelli to integrate slices. Mathlib has
+   `intervalIntegral.integral_deriv_eq_sub` and `MeasureTheory.lintegral_prod`,
+   but wiring them to `∇u` in the Sobolev sense is not packaged.
+2. **`L^p`-norm Cauchy–Schwarz** `∫|u||∂₁u| ≤ ‖u‖₂‖∂₁u‖₂` — this one *is* within
+   reach (`MeasureTheory.inner_mul_le_norm_mul_norm` / `ENNReal.lintegral_mul_le`),
+   the least-blocked input.
+3. **Weak-derivative / Sobolev API.** No `W^{1,2}` space with `∂ᵢ` and a chain
+   rule `∂ᵢ(u²) = 2u∂ᵢu` at the generality needed. This is the real blocker; a
+   faithful formalization of (A) is a >1000-line foundational effort.
+
+**Recommendation:** do **not** attempt the full analytic proof in one session.
+The highest-value next step is input (2) — a standalone verified
+`∫|u||v| ≤ ‖u‖₂‖v‖₂` in Mathlib's `MemLp` API — after which
+`ladyzhenskaya_assembly` already consumes it. Inputs (1) and (3) should wait for
+(or motivate) a Sobolev-space contribution to Mathlib itself.
+
+---
+
+## Dead Ends / Cautions
+
+- Trying to `native_decide` or `nlinarith` the *analytic* facts is hopeless —
+  they are integral inequalities, not real-arithmetic ones.
+- Do **not** promote a "verified Ladyzhenskaya inequality" gallery claim from
+  this file: only Part (B) is verified. The honest framing is "algebraic
+  assembly + analytic-gap specification."
+
+---
+
+## Pointers
+- New: `proofs/Proofs/NavierStokesOQ0101.lean`.
+- Parent: `proofs/Proofs/NavierStokes.lean` (2D enstrophy, 845 thm / 1 axiom).
+- Ladyzhenskaya, *Math. Theory of Viscous Incompressible Flow*, 1969.


### PR DESCRIPTION
## Summary

`navier-stokes-oq-01-oq-01` asks whether the **Ladyzhenskaya inequality** — the `d=2` Gagliardo–Nirenberg estimate that drives 2D Navier–Stokes regularity —

```
‖u‖_{L⁴(ℝ²)} ≤ C · ‖u‖_{L²}^{1/2} · ‖∇u‖_{L²}^{1/2},   sharp C = 2^{1/4}
```

can be formalized. Mathlib v4.26 has **no** Gagliardo–Nirenberg or Ladyzhenskaya inequality and only limited weak-derivative API, so a from-scratch proof is a >1000-line foundational effort.

## What this PR ships (honestly scoped)

Ladyzhenskaya's classical proof factors into **(A)** three *analytic* inputs (an integrated pointwise product bound + two Cauchy–Schwarz slice estimates) and **(B)** a purely *algebraic* assembly that yields the sharp constant. This PR:

- **Verifies Part (B) in full** — new file `proofs/Proofs/NavierStokesOQ0101.lean` (122 L, 3 theorems), **0 axioms / 0 sorries** (`#print axioms` = `[propext, Classical.choice, Quot.sound]` only, built on the Mathlib v4.26 warm cache).
- **Exposes Part (A) as explicit hypotheses**, so the file doubles as a precise specification of the Mathlib gap.

### Theorems
| name | statement |
|------|-----------|
| `cross_le_grad_sq` | `d1·d2 ≤ (d1²+d2²)/2` (sharp AM–GM, fixes `C`) |
| `ladyzhenskaya_assembly` | `(n4⁴≤4ab, a≤n2·d1, b≤n2·d2) ⟹ n4⁴ ≤ 2·n2²·(d1²+d2²)` |
| `ladyzhenskaya_sq_form` | `n4⁴≤2n2²ng² ⟹ n4² ≤ √2·n2·ng` |

## Not claimed
This is **not** a verified Ladyzhenskaya inequality — only the algebraic skeleton + sharp-constant derivation is machine-checked. `knowledge.md` maps the remaining analytic inputs; the least-blocked next step is an `Lp` Cauchy–Schwarz `∫|u||v| ≤ ‖u‖₂‖v‖₂` in Mathlib's `MemLp` API, which `ladyzhenskaya_assembly` already consumes.

## Files
- `proofs/Proofs/NavierStokesOQ0101.lean` (new, verified)
- `research/problems/navier-stokes-oq-01-oq-01/knowledge.md` (feasibility map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)