### PR TITLE
Enrich inductive list-CRT: annotate the existence half (chinese-remainder-constructive-oq-05-oq-02)

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-02/annotations.json
@@ -2,49 +2,166 @@
   {
     "id": "ann-setup",
     "proofId": "chinese-remainder-constructive-oq-05-oq-02",
-    "range": { "startLine": 29, "endLine": 33 },
+    "range": {
+      "startLine": 29,
+      "endLine": 33
+    },
     "type": "concept",
     "title": "Setup: Plain Mathlib, No Extra Project Imports",
     "content": "Unlike the assembly-style siblings, this file imports only `Mathlib` — the generalisation is genuinely self-contained, needing nothing from the two/three-modulus entry it answers. `open Nat` brings the coprime/list-product API (`coprime_list_prod_right_iff`, `Coprime.mul_dvd_of_dvd_of_dvd`, `modEq_iff_dvd'`, `eq_zero_of_dvd_of_lt`) into scope. The whole entry rests on a single list induction over the moduli; the inputs are a `List ℕ` of moduli carrying a `List.Pairwise Nat.Coprime` hypothesis (pairwise, not setwise, coprimality), which the induction consumes one head-relation at a time.",
     "mathContext": "Inputs: a list $ms : \\mathrm{List}\\,\\mathbb{N}$ with $\\mathrm{List.Pairwise\\ Nat.Coprime}\\ ms$; the goal is divisibility/uniqueness against $ms.\\mathrm{prod} = \\prod_{m \\in ms} m$.",
     "significance": "supporting",
-    "relatedConcepts": ["List.Pairwise", "Nat.Coprime", "list induction", "Mathlib Nat namespace"],
-    "prerequisites": ["lists and List.prod", "pairwise relations", "coprimality in ℕ"]
+    "relatedConcepts": [
+      "List.Pairwise",
+      "Nat.Coprime",
+      "list induction",
+      "Mathlib Nat namespace"
+    ],
+    "prerequisites": [
+      "lists and List.prod",
+      "pairwise relations",
+      "coprimality in ℕ"
+    ]
   },
   {
     "id": "ann-engine",
     "proofId": "chinese-remainder-constructive-oq-05-oq-02",
-    "range": { "startLine": 33, "endLine": 53 },
+    "range": {
+      "startLine": 35,
+      "endLine": 53
+    },
     "type": "theorem",
     "title": "Combination Engine: Product Divides Common Multiples",
     "content": "`prod_dvd_of_forall_dvd`: for a list `ms` of pairwise-coprime naturals, if every `m ∈ ms` divides `d` then `ms.prod ∣ d`. List induction on `a :: t`: the head `a` is coprime to the tail product `t.prod` (from the head's pairwise relations via `coprime_list_prod_right_iff`), the tail product divides `d` by the inductive hypothesis, so `(a::t).prod = a · t.prod ∣ d` by `Nat.Coprime.mul_dvd_of_dvd_of_dvd`.",
     "mathContext": "pairwise-coprime `ms`, `(∀ m ∈ ms, m ∣ d) → ms.prod ∣ d`.",
     "significance": "critical",
-    "prerequisites": ["List.Pairwise", "Nat.coprime_list_prod_right_iff", "Nat.Coprime.mul_dvd_of_dvd_of_dvd"],
-    "relatedConcepts": ["Coprimality", "List products", "Divisibility"]
+    "prerequisites": [
+      "List.Pairwise",
+      "Nat.coprime_list_prod_right_iff",
+      "Nat.Coprime.mul_dvd_of_dvd_of_dvd"
+    ],
+    "relatedConcepts": [
+      "Coprimality",
+      "List products",
+      "Divisibility"
+    ]
   },
   {
     "id": "ann-uniqueness",
     "proofId": "chinese-remainder-constructive-oq-05-oq-02",
-    "range": { "startLine": 55, "endLine": 77 },
+    "range": {
+      "startLine": 55,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "The n-Modulus Uniqueness Certificate",
     "content": "`crt_list_unique`: for pairwise-coprime `ms`, two values `a, b < ms.prod` with `a % m = b % m` for all `m ∈ ms` are equal. Equal residues give `m ∣ |a − b|` for every `m` (`Nat.modEq_iff_dvd'`), so `ms.prod ∣ |a − b|` by the combination engine; since `|a − b| < ms.prod`, `Nat.eq_zero_of_dvd_of_lt` forces the difference to be `0`. Generalises `crt_pair_iff` / `crt_triple_iff` to arbitrarily many moduli.",
     "mathContext": "a residue system has at most one solution in `[0, ms.prod)`.",
     "significance": "critical",
-    "prerequisites": ["prod_dvd_of_forall_dvd", "Nat.modEq_iff_dvd'", "Nat.eq_zero_of_dvd_of_lt"],
-    "relatedConcepts": ["Chinese Remainder Theorem", "Uniqueness", "Modular arithmetic"]
+    "prerequisites": [
+      "prod_dvd_of_forall_dvd",
+      "Nat.modEq_iff_dvd'",
+      "Nat.eq_zero_of_dvd_of_lt"
+    ],
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "Uniqueness",
+      "Modular arithmetic"
+    ]
   },
   {
     "id": "ann-example",
     "proofId": "chinese-remainder-constructive-oq-05-oq-02",
-    "range": { "startLine": 79, "endLine": 88 },
+    "range": {
+      "startLine": 79,
+      "endLine": 88
+    },
     "type": "theorem",
     "title": "Worked Instance over [3, 4, 5]",
     "content": "`crt_345_unique`: any two values below `60` with the same residues mod `3`, `4`, `5` coincide. The pairwise coprimality of `[3,4,5]` and the product `60` are `decide`d; the per-modulus residue hypotheses are dispatched by `fin_cases` on the list membership, each matching one of the supplied equalities. A concrete bridge to the sibling entry's example style.",
     "mathContext": "`[3,4,5].prod = 60`; unique solution below 60.",
     "significance": "key",
-    "prerequisites": ["crt_list_unique", "fin_cases", "decide"],
-    "relatedConcepts": ["Concrete CRT", "Pairwise coprimality"]
+    "prerequisites": [
+      "crt_list_unique",
+      "fin_cases",
+      "decide"
+    ],
+    "relatedConcepts": [
+      "Concrete CRT",
+      "Pairwise coprimality"
+    ]
+  },
+  {
+    "id": "ann-header",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "context",
+    "title": "An Inductive CRT Certificate for Arbitrary Pairwise-Coprime Moduli",
+    "content": "The sibling chinese-remainder-constructive-oq-05-oq-01 proved CRT uniqueness certificates for two moduli (crt_pair_iff) and three (crt_triple_iff), and explicitly stopped there. This entry answers that entry's open question: generalise to an arbitrary list ms of pairwise-coprime moduli by list induction, connecting to the list thread of oq-04. The file develops the combination engine prod_dvd_of_forall_dvd (pairwise-coprime moduli dividing a common d force their product to divide d), then both halves of the Chinese Remainder Theorem for a list: crt_list_unique (a solution below ms.prod is THE solution) and crt_list_exists (a simultaneous solution always exists), each exercised on the concrete [3,4,5] example. Existence plus uniqueness is the full CRT bijection ℤ/(∏mᵢ) ≃ ∏ ℤ/mᵢ. 0 sorries, 0 axioms.",
+    "mathContext": "For pairwise-coprime $m_1,\\dots,m_k$ with product $M=\\prod m_i$: the map $\\mathbb{Z}/M \\to \\prod_i \\mathbb{Z}/m_i$, $x \\mapsto (x \\bmod m_i)_i$, is a bijection. This file proves both directions — injectivity (uniqueness below $M$) and surjectivity (existence) — for an arbitrary list.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "pairwise-coprime moduli",
+      "list induction",
+      "CRT bijection",
+      "chinese-remainder-constructive-oq-05-oq-01 (sibling)"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "coprimality",
+      "induction on lists"
+    ]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "n-Modulus CRT Existence by List Induction",
+    "content": "crt_list_exists supplies the existence half absent from the uniqueness-only sibling: for pairwise-coprime ms and any target residues r, some x is simultaneously congruent to r m modulo every m ∈ ms. The proof is list induction. The nil case takes x = 0 vacuously. The cons step combines the head modulus a — coprime to the tail product by Nat.coprime_list_prod_right_iff — with the inductively obtained tail solution y via Nat.chineseRemainder, producing x with x ≡ r a (mod a) and x ≡ y (mod t.prod); the tail-product congruence is then restricted down to each individual tail modulus m by Nat.ModEq.of_dvd (using m ∣ t.prod from List.dvd_prod) and chained with the tail hypothesis. Together with crt_list_unique this is the FULL CRT for an arbitrary list: a simultaneous solution exists and is unique below ms.prod.",
+    "mathContext": "$\\exists x\\ \\forall m\\in ms,\\ x \\equiv r(m) \\pmod{m}$. Cons step: $\\gcd(a, \\prod t)=1$ and $\\texttt{Nat.chineseRemainder}$ glue the head residue to the tail solution; $x \\equiv y \\pmod{\\prod t}$ restricts to $x\\equiv y\\pmod{m}$ for each $m \\mid \\prod t$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.chineseRemainder",
+      "Nat.coprime_list_prod_right_iff",
+      "Nat.ModEq.of_dvd",
+      "List.dvd_prod",
+      "surjectivity of the CRT map"
+    ],
+    "prerequisites": [
+      "Nat.chineseRemainder for two coprime moduli",
+      "modular congruence restriction along divisibility",
+      "list induction"
+    ]
+  },
+  {
+    "id": "ann-existence-example",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 122
+    },
+    "type": "concept",
+    "title": "Worked Existence Instance: the Full ℤ/60 Bijection",
+    "content": "crt_345_exists instantiates crt_list_exists at the pairwise-coprime list [3,4,5] (product 60): every choice of residues mod 3, 4, 5 is realised by some x. Pairwise-coprimality and the membership witnesses are discharged by kernel decide. Paired with crt_345_unique from the uniqueness half, this delivers the concrete full CRT bijection ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5 — existence gives surjectivity, uniqueness (below 60) gives injectivity, and 60 = 3·4·5 equals the product of the codomain's sizes, so the map is a bijection of finite sets of equal cardinality.",
+    "mathContext": "$\\mathbb{Z}/60 \\cong \\mathbb{Z}/3 \\times \\mathbb{Z}/4 \\times \\mathbb{Z}/5$: crt_345_exists = surjectivity, crt_345_unique = injectivity, $60 = 3\\cdot4\\cdot5$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CRT bijection",
+      "kernel decide",
+      "ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5",
+      "existence + uniqueness"
+    ],
+    "prerequisites": [
+      "coprimality of 3,4,5",
+      "bijections between equinumerous finite sets"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **chinese-remainder-constructive-oq-05-oq-02** (An Inductive CRT Certificate for an Arbitrary List of Pairwise-Coprime Moduli).

## Gap
The existing 4 annotations covered **only the uniqueness half** of the file. The module header (lines 1-27) and the **entire existence half** — `crt_list_exists` (89-113) and `crt_345_exists` (114-122) — had **no annotation coverage** at all. There was also a pre-existing line-33 range overlap between `ann-setup` (29-33) and `ann-engine` (33-53).

## Changes (4 → 7 annotations)
- **`ann-header`** (1-27): the inductive CRT certificate answering the sibling's open question; existence + uniqueness = the full CRT bijection ℤ/(∏mᵢ) ≃ ∏ ℤ/mᵢ.
- **`ann-existence`** (89-113): `crt_list_exists` — existence by list induction, gluing the head modulus to the tail solution via `Nat.chineseRemainder` and restricting congruences along divisibility (`Nat.ModEq.of_dvd`).
- **`ann-existence-example`** (114-122): `crt_345_exists` — the concrete ℤ/60 ≃ ℤ/3 × ℤ/4 × ℤ/5 bijection (existence = surjectivity, uniqueness = injectivity, 60 = 3·4·5).
- Fixed the `ann-setup`/`ann-engine` overlap (now 29-33 and 35-53).

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Result: 7 annotations, no overlaps, full-file coverage. `meta.json` unchanged; no axiom/status claims altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)