### PR TITLE
research(erdos-1004-oq-02-oq-01): optimal totient-run exponent c₀ as a well-defined invariant [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/Erdos1004OQ0201.lean
+++ b/proofs/Proofs/Erdos1004OQ0201.lean
@@ -1,0 +1,145 @@
+/-
+Erdős Problem #1004 — the optimal exponent `c₀` for totient run lengths
+
+Source: https://erdosproblems.com/1004
+Parent formalization: Proofs/Erdos1004Problem.lean
+
+Erdős #1004 asks: for every `c > 0`, if `x` is large, does there exist `n ≤ x`
+such that `φ(n+1), …, φ(n+⌊(log x)^c⌋)` are all distinct?  The parent entry names
+the "optimal exponent" `c₀` only informally (a bound variable inside
+`SmallCaseConjecture`).  This file turns `c₀` into a genuine, well-defined
+invariant of the problem and reframes the two conjecture shapes as single
+quantitative statements about it:
+
+  * `Erdos1004Conjecture` (holds for every `c > 0`)  ↔  `c₀ = ⊤`
+  * `SmallCaseConjecture`  (holds on a band `0 < c < c₀`) ↔  `0 < c₀`
+
+The engine is a single elementary fact — the set of *achievable exponents* is
+an interval (downward closed): a long distinct run restricts to every shorter
+run at the same witness `n`.  Everything here is verified with **0 axioms** and
+no analytic number theory; the *value* of `c₀` (whether `> 0`, whether `= ⊤`)
+is the open analytic core of Erdős #1004 and is deliberately left out.
+-/
+import Mathlib
+import Proofs.Erdos1004Problem
+
+open Real Filter Topology
+
+namespace Erdos1004
+
+/-! ## The achievable-exponent set -/
+
+/-- `c` is an **achievable exponent** if, for all large `x`, some `n ≤ x` starts a
+distinct totient run of length `⌊(log x)^c⌋`.  This is exactly the body of
+`Erdos1004Conjecture` at a fixed `c`, and of the band in `SmallCaseConjecture`. -/
+def AchievableExponent (c : ℝ) : Prop :=
+  ∀ᶠ x : ℕ in atTop, ∃ n ≤ x, IsDistinctTotientRun n ⌊(Real.log x) ^ c⌋₊
+
+/-- A distinct totient run restricts to any shorter prefix at the same start. -/
+theorem run_prefix (n K K' : ℕ) (h : IsDistinctTotientRun n K) (hle : K' ≤ K) :
+    IsDistinctTotientRun n K' := by
+  intro i j hi hiK hj hjK hij
+  exact h i j hi (hiK.trans hle) hj (hjK.trans hle) hij
+
+/-- **Downward closure.**  If a large exponent is achievable, so is every smaller
+nonnegative one — at the *same* witness `n`, by `run_prefix`. -/
+theorem achievable_downward_closed {c c' : ℝ} (_hc' : 0 ≤ c') (hcc : c' ≤ c)
+    (h : AchievableExponent c) : AchievableExponent c' := by
+  have hlog : ∀ᶠ x : ℕ in atTop, (1 : ℝ) ≤ Real.log x :=
+    (Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop).eventually_ge_atTop 1
+  filter_upwards [h, hlog] with x hx hlogx
+  obtain ⟨n, hnx, hrun⟩ := hx
+  refine ⟨n, hnx, ?_⟩
+  refine run_prefix n _ _ hrun ?_
+  exact Nat.floor_le_floor (Real.rpow_le_rpow_of_exponent_le hlogx hcc)
+
+/-- The exponent `0` is achievable: `⌊(log x)^0⌋ = ⌊1⌋ = 1`, and every `n` starts
+a distinct run of length `1`. -/
+theorem zero_achievable : AchievableExponent 0 := by
+  refine Filter.Eventually.of_forall (fun x => ⟨0, Nat.zero_le x, ?_⟩)
+  rw [Real.rpow_zero, Nat.floor_one]
+  exact distinctRun_one 0
+
+/-! ## The optimal exponent as a supremum in `EReal` -/
+
+/-- The set of achievable exponents, coerced into `EReal`. -/
+def achievableSet : Set EReal :=
+  (fun r : ℝ => (r : EReal)) '' {r : ℝ | 0 ≤ r ∧ AchievableExponent r}
+
+/-- **The optimal exponent** `c₀ ∈ [0, ∞]`: the supremum of all achievable
+exponents.  Taken in the complete lattice `EReal` so the value is total even in
+the conjectured unbounded case (`c₀ = ⊤`), avoiding the junk value of a real
+`sSup` on an unbounded set. -/
+noncomputable def c₀ : EReal := sSup achievableSet
+
+theorem coe_mem_achievableSet {r : ℝ} (hr0 : 0 ≤ r) (hr : AchievableExponent r) :
+    ((r : ℝ) : EReal) ∈ achievableSet :=
+  Set.mem_image_of_mem _ ⟨hr0, hr⟩
+
+/-- `c₀ ≥ 0`, since `0` is achievable. -/
+theorem zero_le_c₀ : (0 : EReal) ≤ c₀ := by
+  have hmem : ((0 : ℝ) : EReal) ∈ achievableSet :=
+    coe_mem_achievableSet le_rfl zero_achievable
+  calc (0 : EReal) = ((0 : ℝ) : EReal) := (EReal.coe_zero).symm
+    _ ≤ c₀ := le_sSup hmem
+
+theorem c₀_ne_bot : c₀ ≠ ⊥ := fun hb => by
+  have := zero_le_c₀
+  rw [hb, le_bot_iff] at this
+  exact (EReal.zero_ne_bot) this
+
+/-! ## The two conjectures reframed as statements about `c₀` -/
+
+/-- **The full conjecture is exactly `c₀ = ⊤`.**  If every positive exponent is
+achievable the supremum is unbounded (`⊤`); conversely if `c₀ = ⊤`, every `c > 0`
+lies below some achievable `r`, so is itself achievable by downward closure. -/
+theorem conjecture_iff_c₀_top : Erdos1004Conjecture ↔ c₀ = ⊤ := by
+  constructor
+  · intro hconj
+    by_contra htop
+    -- `c₀` is a genuine real; pick an achievable exponent one larger, contradiction.
+    have hcoe : ((c₀.toReal : ℝ) : EReal) = c₀ := EReal.coe_toReal htop c₀_ne_bot
+    have hy0 : (0 : ℝ) ≤ c₀.toReal := by
+      have h := zero_le_c₀
+      rw [← hcoe] at h
+      exact_mod_cast h
+    have hach : AchievableExponent (c₀.toReal + 1) := hconj _ (by linarith)
+    have hle : ((c₀.toReal + 1 : ℝ) : EReal) ≤ c₀ :=
+      le_sSup (coe_mem_achievableSet (by linarith) hach)
+    rw [← hcoe] at hle
+    have : c₀.toReal + 1 ≤ c₀.toReal := by exact_mod_cast hle
+    linarith
+  · intro htop c hc
+    have hlt : ((c : ℝ) : EReal) < c₀ := by rw [htop]; exact EReal.coe_lt_top c
+    unfold c₀ achievableSet at hlt
+    rw [lt_sSup_iff] at hlt
+    obtain ⟨b, hbS, hcb⟩ := hlt
+    obtain ⟨r, ⟨hr0, hrach⟩, rfl⟩ := hbS
+    simp only at hcb
+    have hcr : c < r := by exact_mod_cast hcb
+    exact achievable_downward_closed hc.le hcr.le hrach
+
+/-- **The weak (band) conjecture is exactly `0 < c₀`.** -/
+theorem smallCase_iff_c₀_pos : SmallCaseConjecture ↔ 0 < c₀ := by
+  constructor
+  · rintro ⟨c₀', hc₀'pos, hband⟩
+    have hach : AchievableExponent (c₀' / 2) := hband (c₀' / 2) (by linarith) (by linarith)
+    have hle : ((c₀' / 2 : ℝ) : EReal) ≤ c₀ :=
+      le_sSup (coe_mem_achievableSet (by linarith) hach)
+    have hpos : (0 : EReal) < ((c₀' / 2 : ℝ) : EReal) := by
+      rw [← EReal.coe_zero]
+      exact_mod_cast (by linarith : (0 : ℝ) < c₀' / 2)
+    exact lt_of_lt_of_le hpos hle
+  · intro hpos
+    unfold c₀ achievableSet at hpos
+    rw [lt_sSup_iff] at hpos
+    obtain ⟨b, hbS, hb0⟩ := hpos
+    obtain ⟨r, ⟨hr0, hrach⟩, rfl⟩ := hbS
+    simp only at hb0
+    have hrpos : 0 < r := by
+      rw [← EReal.coe_zero] at hb0
+      exact_mod_cast hb0
+    refine ⟨r, hrpos, fun c hc0 hcr => ?_⟩
+    exact achievable_downward_closed hc0.le hcr.le hrach
+
+end Erdos1004

--- a/src/data/proofs/erdos-1004-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1004-oq-02-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-erdos-1004-oq-02-oq-01-01",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 33, "endLine": 43 },
+    "type": "definition",
+    "title": "Achievable exponents and prefix stability",
+    "content": "`AchievableExponent c` is deliberately the *exact body* of the parent's `Erdos1004Conjecture` at a fixed `c`: for all large `x`, some `n ≤ x` starts a distinct totient run of length `⌊(log x)^c⌋`. Matching it definitionally means `Erdos1004Conjecture` unfolds to `∀ c > 0, AchievableExponent c` for free, so the equivalence proofs never re-prove the unfolding. `run_prefix` records the single combinatorial fact the whole entry rests on: a distinct run of length `K` is still distinct on any shorter prefix `K' ≤ K`, since the pairwise-distinctness quantifier just restricts to the sub-block."
+  },
+  {
+    "id": "ann-erdos-1004-oq-02-oq-01-02",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 44, "endLine": 64 },
+    "type": "theorem",
+    "title": "Downward closure: the achievable set is an interval",
+    "content": "The mathematical core. Filtering to `x` large enough that `log x ≥ 1` (from `Real.tendsto_log_atTop`) AND a `c`-run exists, the base `log x ≥ 1` makes `x ↦ (log x)^·` monotone in the exponent, so `(log x)^c' ≤ (log x)^c` (`Real.rpow_le_rpow_of_exponent_le`) and hence `⌊(log x)^c'⌋₊ ≤ ⌊(log x)^c⌋₊` (`Nat.floor_le_floor`). The witness `n` of the `c`-run then yields a distinct run of the shorter length at the SAME `n` by `run_prefix`. Note the `0 ≤ c'` hypothesis is kept for the intended reading even though the proof does not need it. `zero_achievable` gives the left endpoint: `⌊(log x)^0⌋ = ⌊1⌋ = 1` and every `n` starts a length-1 run."
+  },
+  {
+    "id": "ann-erdos-1004-oq-02-oq-01-03",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 65, "endLine": 94 },
+    "type": "insight",
+    "title": "Why EReal: a total supremum in the unbounded case",
+    "content": "`c₀` is defined as `sSup` of the achievable exponents coerced into `EReal`. The point of a *complete lattice* codomain is that the supremum is total even when the set is unbounded above — which is precisely the conjectured case `c₀ = ⊤`. A real-valued `sSup` on an unbounded set returns a junk value (`0`), which would silently collapse the most interesting case. `zero_le_c₀` (0 is achievable ⇒ `c₀ ≥ 0`) and `c₀_ne_bot` pin `c₀` into `[0, ∞]`."
+  },
+  {
+    "id": "ann-erdos-1004-oq-02-oq-01-04",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 96, "endLine": 121 },
+    "type": "theorem",
+    "title": "The full conjecture is exactly c₀ = ⊤",
+    "content": "`conjecture_iff_c₀_top`. Forward (contrapositive): if `c₀ ≠ ⊤` then, being `≥ 0`, it is a genuine real `c₀ = ↑c₀.toReal` (`EReal.coe_toReal`); but the conjecture makes `c₀.toReal + 1` achievable, so `le_sSup` forces `c₀.toReal + 1 ≤ c₀.toReal`, absurd. Backward: `c₀ = ⊤` puts every `↑c` strictly below `c₀`, so `lt_sSup_iff` extracts an achievable `r > c`, and downward closure makes `c` itself achievable. This is an exact reformulation, not an approximation — the full Erdős #1004 conjecture *is* the single statement 'c₀ is infinite'."
+  },
+  {
+    "id": "ann-erdos-1004-oq-02-oq-01-05",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 145 },
+    "type": "theorem",
+    "title": "The weak band conjecture is exactly 0 < c₀",
+    "content": "`smallCase_iff_c₀_pos`. Forward: a witnessing band `0 < c < c₀'` gives an achievable `c₀'/2 > 0`, so `0 < ↑(c₀'/2) ≤ c₀` by `le_sSup`. Backward: `0 < c₀` yields, via `lt_sSup_iff`, an achievable `r > 0`, and downward closure fills the entire band `(0, r)` — exactly `SmallCaseConjecture`. Together with `conjecture_iff_c₀_top` this turns the parent's two qualitative Props into two order facts about one invariant: the conjecture is `c₀ = ∞`, the weak form is `c₀ > 0`."
+  }
+]

--- a/src/data/proofs/erdos-1004-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1004-oq-02-oq-01/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "erdos-1004-oq-02-oq-01",
+  "title": "Erdős #1004: The Optimal Totient-Run Exponent c₀ as a Well-Defined Invariant (c₀ = ⊤ ⇔ conjecture, 0 < c₀ ⇔ weak form)",
+  "slug": "erdos-1004-oq-02-oq-01",
+  "description": "Erdős #1004 asks, for every c > 0 and large x, whether some n ≤ x starts a distinct totient run φ(n+1),…,φ(n+⌊(log x)^c⌋). The parent entry names the 'optimal exponent' c₀ only informally (a bound variable inside SmallCaseConjecture). This entry makes c₀ a genuine, well-defined invariant of the problem and reframes both conjecture shapes as single quantitative statements about it. The engine is one elementary fact — the set of achievable exponents is an interval (downward closed): a length-K distinct run restricts to every shorter prefix at the SAME witness n (run_prefix), so via (log x)^c' ≤ (log x)^c (base log x ≥ 1) and floor monotonicity, achievability at c descends to every 0 ≤ c' ≤ c (achievable_downward_closed). Defining c₀ := sSup of the achievable exponents in the complete lattice EReal (total even in the unbounded conjectured case, avoiding a real-sSup junk value), the two parent Props become exact order statements: conjecture_iff_c₀_top (Erdos1004Conjecture ↔ c₀ = ⊤) and smallCase_iff_c₀_pos (SmallCaseConjecture ↔ 0 < c₀). Fully machine-checked: 0 sorries, 0 axioms — crucially INDEPENDENT of the parent's axiomatized EPS bound. The VALUE of c₀ (whether > 0, whether = ⊤) is the open analytic core of Erdős #1004 and is deliberately not claimed.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://erdosproblems.com/1004",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1004OQ0201.lean",
+    "erdosNumber": 1004,
+    "erdosUrl": "https://erdosproblems.com/1004",
+    "erdosProblemStatus": "open",
+    "erdosPrizeValue": null,
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "distinct-totient-runs",
+      "optimal-exponent",
+      "order-theory",
+      "supremum",
+      "ereal",
+      "erdos",
+      "axiom-free"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_le_rpow_of_exponent_le",
+        "description": "For base ≥ 1, x^c is monotone in the exponent — turns c' ≤ c into (log x)^c' ≤ (log x)^c, the analytic step of downward closure",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Nat.floor_le_floor",
+        "description": "Monotonicity of ⌊·⌋₊, lifting the rpow inequality to run lengths ⌊(log x)^c'⌋₊ ≤ ⌊(log x)^c⌋₊",
+        "module": "Mathlib.Algebra.Order.Floor.Semiring"
+      },
+      {
+        "theorem": "Real.tendsto_log_atTop",
+        "description": "log → ∞, giving the eventual tail log x ≥ 1 on which rpow is monotone",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "lt_sSup_iff",
+        "description": "a < sSup s ↔ ∃ b ∈ s, a < b in the complete lattice EReal — the order engine of both iff directions",
+        "module": "Mathlib.Order.CompleteLattice.Defs"
+      },
+      {
+        "theorem": "EReal.coe_toReal",
+        "description": "For x ≠ ⊤, ⊥, ↑x.toReal = x — recovers a real value of c₀ to derive the contradiction in the c₀ = ⊤ direction",
+        "module": "Mathlib.Data.EReal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "AchievableExponent: DEFINED the exponent c as achievable when ∀ᶠ x, ∃ n ≤ x, a distinct totient run of length ⌊(log x)^c⌋ exists — exactly the body of Erdos1004Conjecture at a fixed c",
+      "run_prefix: PROVED a distinct totient run restricts to every shorter prefix at the same start (K' ≤ K)",
+      "achievable_downward_closed: PROVED the achievable set is downward closed (0 ≤ c' ≤ c, achievable c ⇒ achievable c'), via rpow-exponent monotonicity on the log x ≥ 1 tail and floor monotonicity",
+      "zero_achievable: PROVED exponent 0 is achievable (⌊(log x)^0⌋ = 1, every n starts a length-1 run)",
+      "c₀: DEFINED the optimal exponent as sSup of achievable exponents in the complete lattice EReal (total in the unbounded case), with zero_le_c₀ and c₀_ne_bot establishing it lies in [0, ∞]",
+      "conjecture_iff_c₀_top: PROVED Erdos1004Conjecture ↔ c₀ = ⊤ — the full conjecture is exactly 'c₀ is infinite'",
+      "smallCase_iff_c₀_pos: PROVED SmallCaseConjecture ↔ 0 < c₀ — the weak band form is exactly 'c₀ is positive'"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Erdős #1004 parent (distinct totient runs, Erdos1004Conjecture, SmallCaseConjecture)",
+      "Real rpow exponent monotonicity and Nat.floor",
+      "Suprema in the complete lattice EReal"
+    ],
+    "lineCount": 145,
+    "relatedProblems": [
+      {
+        "id": "erdos-1004",
+        "relationship": "Direct parent: supplies IsDistinctTotientRun, Erdos1004Conjecture and SmallCaseConjecture, whose two shapes this entry reframes as c₀ = ⊤ and 0 < c₀"
+      },
+      {
+        "id": "erdos-1004-oq-03",
+        "relationship": "Sibling: an unconditional 0-axiom per-n run-length bound K ≤ n−1; this entry instead organizes the per-x reachability scale into the invariant c₀"
+      }
+    ],
+    "assumptions": "None. 0 axioms, 0 sorries: conjecture_iff_c₀_top, smallCase_iff_c₀_pos, achievable_downward_closed and zero_achievable each depend only on the standard foundational axioms propext, Classical.choice, Quot.sound — and NOT on the parent's axiomatized Erdős–Pomerance–Sárközy bound (eps87_theorem). The entry establishes only the WELL-DEFINEDNESS of the optimal exponent c₀ and the equivalence of the two conjecture forms with c₀ = ⊤ and 0 < c₀. The VALUE of c₀ is left open: 0 < c₀ (SmallCaseConjecture) needs distribution-of-totient-values / sieve input (EPS 1987), absent from Mathlib, and c₀ = ⊤ IS the open Erdős #1004.",
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1004 asks how long a run of consecutive integers can have pairwise-distinct Euler totients: for c > 0 and large x, does some n ≤ x give φ(n+1),…,φ(n+⌊(log x)^c⌋) all distinct? The natural summary of the answer is a single number — the largest exponent c for which this holds, the 'optimal exponent' c₀. The parent gallery entry states the two standard shapes of the question (the full conjecture 'holds for every c > 0' and the weak form 'holds on a band 0 < c < c₀') but treats c₀ only as an informal bound variable, never as a defined quantity. Turning c₀ into a genuine invariant requires exactly one structural fact — that the achievable exponents form an interval — after which the two Props collapse into two order statements about one number.",
+    "problemStatement": "Make the optimal totient-run exponent c₀ a well-defined invariant of Erdős #1004 and reframe the parent's two conjecture Props (Erdos1004Conjecture, SmallCaseConjecture) as single quantitative statements about c₀ — all without invoking the parent's axiomatized EPS bound.",
+    "text": "A 145-line self-contained file defining the achievable-exponent set, proving it downward closed (a long run restricts to every shorter prefix), defining c₀ := sSup in EReal, and proving Erdos1004Conjecture ↔ c₀ = ⊤ and SmallCaseConjecture ↔ 0 < c₀ — 0 sorries, 0 axioms, independent of EPS.",
+    "proofStrategy": "run_prefix gives prefix stability of distinct runs. For downward closure, filter to x with log x ≥ 1 (Real.tendsto_log_atTop) and a c-run; then (log x)^c' ≤ (log x)^c (Real.rpow_le_rpow_of_exponent_le) and ⌊·⌋₊ monotone shrink the length, and run_prefix reuses the SAME witness n. With 0 achievable and the set downward closed, c₀ := sSup (achievable exponents, coerced to EReal) is a well-defined element of [0, ∞]. The equivalences are pure order theory on EReal: le_sSup places any achievable exponent below c₀; lt_sSup_iff extracts an achievable exponent above any c < c₀, whence downward closure gives achievability of c; and EReal.coe_toReal turns 'c₀ ≠ ⊤' into a finite real to contradict against an achievable exponent one larger.",
+    "keyInsights": [
+      "**One structural fact does all the work.** Downward closure of the achievable set — a length-K run restricts to every shorter prefix at the same n — is the only mathematics; everything else is order theory.",
+      "**c₀ = ⊤ IS the full conjecture.** 'Every c > 0 is achievable' is precisely 'the supremum of achievable exponents is infinite', so conjecture_iff_c₀_top is an exact reformulation, not an approximation.",
+      "**0 < c₀ IS the weak form.** A positive supremum means some positive exponent is achievable, and downward closure fills in the whole band (0, that exponent) — exactly SmallCaseConjecture.",
+      "**EReal is the right codomain.** Working in a complete lattice makes the supremum total even in the conjectured unbounded case (c₀ = ⊤); a real sSup would silently collapse the unbounded case to a junk value 0.",
+      "**Independent of EPS.** The invariant and both equivalences rest on nothing beyond the foundational axioms; the parent's deep Erdős–Pomerance–Sárközy bound (an axiom there) is not used, keeping this a genuinely 0-axiom reorganization.",
+      "**The value of c₀ is the open problem.** 0 < c₀ needs sieve input (EPS 1987, absent from Mathlib); c₀ = ⊤ is Erdős #1004 itself. The entry cleanly separates the well-posedness (done, verified) from the analytic value (open)."
+    ],
+    "prerequisites": [
+      "Euler totient and distinct totient runs (parent entry)",
+      "Real rpow exponent monotonicity and Nat.floor",
+      "Suprema in the complete lattice EReal"
+    ]
+  },
+  "sections": [
+    {
+      "id": "achievable",
+      "title": "The achievable-exponent set and prefix stability",
+      "startLine": 33,
+      "endLine": 56,
+      "summary": "AchievableExponent c is the body of Erdos1004Conjecture at a fixed c: for all large x, some n ≤ x starts a distinct totient run of length ⌊(log x)^c⌋. run_prefix proves a distinct run restricts to any shorter prefix K' ≤ K at the same start — the one combinatorial fact behind everything.",
+      "mathContext": "$\\mathrm{Achievable}(c) \\equiv \\forall^\\infty x,\\ \\exists n \\le x,\\ \\varphi$ distinct on a block of length $\\lfloor(\\log x)^c\\rfloor$; runs are prefix-stable."
+    },
+    {
+      "id": "downward",
+      "title": "Downward closure and 0 achievable",
+      "startLine": 44,
+      "endLine": 64,
+      "summary": "achievable_downward_closed: for 0 ≤ c' ≤ c, achievability descends. On the tail log x ≥ 1, (log x)^c' ≤ (log x)^c (rpow exponent monotonicity) and floor monotonicity shrink the run length, and run_prefix reuses the same witness n. zero_achievable: exponent 0 is achievable since ⌊(log x)^0⌋ = ⌊1⌋ = 1 and every n starts a length-1 run.",
+      "mathContext": "$0 \\le c' \\le c,\\ \\mathrm{Achievable}(c) \\Rightarrow \\mathrm{Achievable}(c')$;\\quad $\\mathrm{Achievable}(0)$."
+    },
+    {
+      "id": "invariant",
+      "title": "The optimal exponent c₀ in EReal",
+      "startLine": 66,
+      "endLine": 94,
+      "summary": "achievableSet coerces the achievable exponents into EReal; c₀ := sSup achievableSet lives in the complete lattice so it is total even when unbounded. zero_le_c₀ (0 is achievable, so c₀ ≥ 0) and c₀_ne_bot place c₀ in [0, ∞].",
+      "mathContext": "$c_0 := \\sup\\,\\{\\,c \\ge 0 : \\mathrm{Achievable}(c)\\,\\} \\in [0,\\infty]$ (in $\\overline{\\mathbb{R}}$)."
+    },
+    {
+      "id": "equivalences",
+      "title": "The two conjectures as statements about c₀",
+      "startLine": 96,
+      "endLine": 145,
+      "summary": "conjecture_iff_c₀_top: Erdos1004Conjecture ↔ c₀ = ⊤. Forward, if c₀ ≠ ⊤ then c₀ = ↑(c₀.toReal) is a real and an achievable exponent one larger contradicts le_sSup; backward, c₀ = ⊤ puts every c above nothing yet below c₀, and lt_sSup_iff + downward closure make c achievable. smallCase_iff_c₀_pos: SmallCaseConjecture ↔ 0 < c₀, by the same le_sSup / lt_sSup_iff pair.",
+      "mathContext": "$\\mathrm{Conjecture} \\Leftrightarrow c_0 = \\top$;\\quad $\\mathrm{SmallCase} \\Leftrightarrow 0 < c_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1004",
+      "relationship": "extends",
+      "description": "Reframes the parent's two conjecture Props (Erdos1004Conjecture, SmallCaseConjecture) as the single-invariant statements c₀ = ⊤ and 0 < c₀, without using the parent's axiomatized EPS bound."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 145,
+    "namespace": "Erdos1004",
+    "opens": ["Real", "Filter", "Topology"],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": ["Mathlib", "Proofs.Erdos1004Problem"],
+    "path": "Proofs/Erdos1004OQ0201.lean",
+    "sorries": 0,
+    "definitionCount": 3
+  },
+  "conclusion": {
+    "summary": "The optimal totient-run exponent c₀ is made a well-defined invariant of Erdős #1004 (a supremum of achievable exponents in EReal), and the parent's two conjecture Props are proved equivalent to single order statements about it: Erdos1004Conjecture ↔ c₀ = ⊤ and SmallCaseConjecture ↔ 0 < c₀. Fully machine-checked at 0 sorries, 0 axioms, independent of the parent's axiomatized EPS bound.",
+    "implications": "Gives Erdős #1004 a clean quantitative target: the full conjecture is 'c₀ = ∞' and the weak form is 'c₀ > 0'. The reorganization is powered entirely by the interval structure of the achievable set, isolating the genuinely open content (the VALUE of c₀) from the now-settled well-posedness. Any future analytic lower bound on achievable exponents (e.g. via the Erdős–Pomerance–Sárközy circle of ideas) plugs directly into 0 < c₀ through le_sSup.",
+    "openQuestions": [
+      "Prove 0 < c₀ (SmallCaseConjecture): exhibit a fixed c > 0 with distinct totient runs of length (log x)^c below x — needs distribution-of-totient-values / sieve input absent from Mathlib.",
+      "Decide c₀ = ⊤ (the full Erdős #1004 conjecture), or refute it via Erdos1004Negation.",
+      "Locate c₀ numerically: is there any provable finite upper bound on c₀, or a heuristic value (the 1/3 in EPS is on the absolute run-length scale, not the (log x)^c scale, so does not cap c₀)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "conjecture_iff_c₀_top",
+      "type": "core",
+      "description": "The full Erdős #1004 conjecture is exactly 'c₀ = ⊤' (PROVED, 0 axioms, independent of EPS)",
+      "leanType": "Erdos1004Conjecture ↔ c₀ = ⊤"
+    },
+    {
+      "name": "smallCase_iff_c₀_pos",
+      "type": "core",
+      "description": "The weak band conjecture is exactly '0 < c₀' (PROVED, 0 axioms)",
+      "leanType": "SmallCaseConjecture ↔ 0 < c₀"
+    },
+    {
+      "name": "achievable_downward_closed",
+      "type": "core",
+      "description": "The achievable-exponent set is an interval: 0 ≤ c' ≤ c and achievable c imply achievable c' (PROVED, 0 axioms)",
+      "leanType": "∀ {c c' : ℝ}, 0 ≤ c' → c' ≤ c → AchievableExponent c → AchievableExponent c'"
+    },
+    {
+      "name": "c₀",
+      "type": "definition",
+      "description": "The optimal exponent as a supremum of achievable exponents in the complete lattice EReal",
+      "leanType": "EReal"
+    },
+    {
+      "name": "zero_achievable",
+      "type": "supporting",
+      "description": "Exponent 0 is achievable (⌊(log x)^0⌋ = 1; every n starts a length-1 run) (PROVED, 0 axioms)",
+      "leanType": "AchievableExponent 0"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New child gallery entry for **Erdős #1004** (distinct consecutive totient values). It turns the informally-named "optimal exponent" `c₀` into a genuine, well-defined invariant and proves that the parent's two conjecture Props are **exactly** single order statements about it — fully machine-checked, **0 sorries, 0 axioms, and independent of the parent's axiomatized EPS bound**.

This implements the verified-design deliverable that research problem `erdos-1004-oq-02` had previously only produced as a feasibility map (no build available then). It ships under the fresh slug `erdos-1004-oq-02-oq-01` to avoid clobbering the existing, *different* `erdos-1004-oq-02` gallery entry (totient-fiber finiteness).

## The result (`Proofs/Erdos1004OQ0201.lean`, 145 L, 8 thm / 3 def / 0 axiom)

The engine is one elementary fact — the achievable-exponent set is an **interval** (downward closed):

- `AchievableExponent c` := the body of `Erdos1004Conjecture` at fixed `c` (definitional match ⇒ the conjecture unfolds to `∀ c>0, AchievableExponent c` for free).
- `run_prefix` — a distinct totient run restricts to every shorter prefix at the **same** witness `n`.
- `achievable_downward_closed` — `0 ≤ c' ≤ c` and achievable `c` ⇒ achievable `c'`. On the `log x ≥ 1` tail, `(log x)^c' ≤ (log x)^c` (`Real.rpow_le_rpow_of_exponent_le`) and `Nat.floor_le_floor` shrink the run length; `run_prefix` reuses the same `n`.
- `zero_achievable` — `⌊(log x)^0⌋ = 1`, every `n` starts a length-1 run.
- `c₀ : EReal := sSup` of achievable exponents. The complete-lattice codomain keeps the supremum **total in the conjectured unbounded case** (`c₀ = ⊤`), avoiding a real-`sSup` junk value. `zero_le_c₀`, `c₀_ne_bot` pin `c₀ ∈ [0, ∞]`.

**The two conjectures as one invariant:**

| Theorem | Statement |
|---|---|
| `conjecture_iff_c₀_top` | `Erdos1004Conjecture ↔ c₀ = ⊤` |
| `smallCase_iff_c₀_pos` | `SmallCaseConjecture ↔ 0 < c₀` |

(`EReal.coe_toReal` gives the finite-value contradiction in the `⊤` direction; `lt_sSup_iff` + downward closure supplies the converse and both `smallCase` directions.)

## Axioms

`#print axioms` on `conjecture_iff_c₀_top`, `smallCase_iff_c₀_pos`, `achievable_downward_closed`, `zero_achievable` → `[propext, Classical.choice, Quot.sound]` only — **not** the parent's `eps87_theorem`. The entry establishes only the *well-definedness* of `c₀` and the equivalences; the **value** of `c₀` (whether `> 0`, whether `= ⊤`) is the open analytic core of Erdős #1004 (needs sieve / totient-distribution input absent from Mathlib) and is deliberately not claimed.

Verified with `lake env lean` against the pinned Mathlib v4.26.0 olean (builds clean, exit 0, no `sorry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)