### PR TITLE
Enrich Sharp Viviani Constant: add 8 annotations

### DIFF
--- a/src/data/proofs/viviani-theorem-oq-01-oq-02/annotations.source.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-02/annotations.source.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "block-comment", "contains": "the sharp constant for regular polygons and simplices" },
+    "type": "concept",
+    "title": "One Identity Behind Every Viviani Theorem",
+    "content": "Viviani's classical theorem says that inside an equilateral triangle the sum of perpendicular distances from any interior point to the three sides is constant (the altitude). This entry proves the **sharp generalization** to all dimensions — regular $n$-gons and regular $n$-simplices — and pins down the exact constant. The unifying observation: a facet with unit outward normal $u_i$ at offset $c_i$ contributes signed distance $c_i - \\langle u_i, P\\rangle$, so the total is $\\sum_i c_i - \\langle \\sum_i u_i, P\\rangle$. **Whenever the outward unit normals sum to zero**, the $P$-dependent term vanishes and the distance sum is the constant $\\sum_i c_i$. That single fact (`sum_signedDist_eq`) is the entire content of every Viviani-type theorem; the polygon ($n\\cdot$apothem) and simplex ($(n{+}1)\\cdot$inradius) results are corollaries, one via roots of unity summing to zero, the other via the centroid.",
+    "mathContext": "$\\sum_i (c_i - \\langle u_i,P\\rangle) = \\sum_i c_i - \\langle\\textstyle\\sum_i u_i, P\\rangle$; normals sum to $0 \\Rightarrow$ constant.",
+    "significance": "critical",
+    "relatedConcepts": ["Viviani's theorem", "regular polygon", "regular simplex", "outward normals", "roots of unity"],
+    "prerequisites": ["inner product spaces", "hyperplane distance", "regular polytopes"]
+  },
+  {
+    "id": "ann-master-identity",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "sum_signedDist_eq", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Master Identity: Normals Summing to Zero ⇒ Constant Distance Sum",
+    "content": "The one theorem everything reduces to. In any real inner-product space, if the unit facet normals $u_i$ satisfy $\\sum_i u_i = 0$, then $\\sum_i (c_i - \\langle u_i, P\\rangle) = \\sum_i c_i$ for every $P$ — the distance sum is independent of the point. The proof is three rewrites: distribute the sum, pull the sum inside the inner product ($\\sum_i \\langle u_i, P\\rangle = \\langle \\sum_i u_i, P\\rangle$ by `sum_inner`), then $\\sum_i u_i = 0$ kills it via `inner_zero_left`. Its abstractness is the point — it is stated for an arbitrary finite index and arbitrary real inner-product space, so both the planar polygon and the high-dimensional simplex are the same theorem specialized.",
+    "mathContext": "$\\sum_i u_i = 0 \\Rightarrow \\sum_i(c_i - \\langle u_i,P\\rangle) = \\sum_i c_i$, all $P$.",
+    "significance": "critical",
+    "relatedConcepts": ["sum_inner", "inner_zero_left", "linearity of the inner product", "hyperplane"],
+    "prerequisites": ["real inner product spaces", "signed distance to a hyperplane"]
+  },
+  {
+    "id": "ann-rdot",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "rdot", "kind": "def" },
+    "type": "definition",
+    "title": "The Plane as ℂ with Its Real Inner Product",
+    "content": "`rdot z w = z.re·w.re + z.im·w.im` is the standard Euclidean dot product on the plane, modeled as $\\mathbb C$. Using $\\mathbb C$ rather than $\\mathbb R^2$ lets the $n$ outward normals of a regular polygon be written as the $n$-th roots of unity $\\zeta^k$ — turning 'the normals sum to zero' into the clean algebraic fact $\\sum_k \\zeta^k = 0$. The small helper lemmas `rdot_add_left` and `rdot_sum` establish that `rdot` is additive in its left argument over finite sums, which is exactly the `sum_inner` step the master identity needs, transcribed to this concrete pairing.",
+    "mathContext": "$\\mathrm{rdot}(z,w) = \\operatorname{Re}(z)\\operatorname{Re}(w) + \\operatorname{Im}(z)\\operatorname{Im}(w) = \\langle z,w\\rangle_{\\mathbb R^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclidean dot product", "ℂ as ℝ²", "bilinearity"],
+    "prerequisites": ["complex numbers", "real and imaginary parts"]
+  },
+  {
+    "id": "ann-roots-sum-zero",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "sum_primitiveRoot_pow_eq_zero", "kind": "lemma" },
+    "type": "lemma",
+    "title": "The n-th Roots of Unity Sum to Zero",
+    "content": "For $n\\ge 2$ and $\\zeta$ a primitive $n$-th root of unity, $\\sum_{k=0}^{n-1}\\zeta^k = 0$ — the geometric heart of the polygon case, since these are exactly the outward normals. The proof is the finite geometric series $\\sum_{k<n}\\zeta^k = \\frac{\\zeta^n - 1}{\\zeta - 1}$ (`geom_sum_eq`, valid as $\\zeta\\neq 1$), whose numerator vanishes because $\\zeta^n = 1$. Geometrically: the vertices/normals of a regular polygon are symmetric about the center, so their vector sum is zero — the centroid condition in disguise.",
+    "mathContext": "$\\zeta^n = 1,\\ \\zeta\\neq 1 \\Rightarrow \\sum_{k<n}\\zeta^k = \\tfrac{\\zeta^n-1}{\\zeta-1} = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["primitive root of unity", "geom_sum_eq", "geometric series", "central symmetry"],
+    "prerequisites": ["roots of unity", "finite geometric series"]
+  },
+  {
+    "id": "ann-unit-normals",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "primitiveRoot_pow_norm", "kind": "lemma" },
+    "type": "lemma",
+    "title": "The Root-of-Unity Normals Are Genuine Unit Vectors",
+    "content": "$\\|\\zeta^k\\| = 1$ for each $k$, so $c - \\mathrm{rdot}(\\zeta^k, P)$ really is a Euclidean perpendicular distance and not merely a linear functional. This legitimizes calling the polygon result a *distance*-sum theorem: $\\|\\zeta\\| = 1$ (a root of unity lies on the unit circle) gives $\\|\\zeta^k\\| = \\|\\zeta\\|^k = 1$. Without unit normals the identity would still hold algebraically but would lose its metric meaning.",
+    "mathContext": "$\\|\\zeta\\| = 1 \\Rightarrow \\|\\zeta^k\\| = \\|\\zeta\\|^k = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit vector", "norm_pow", "unit circle", "perpendicular distance"],
+    "prerequisites": ["complex modulus", "roots of unity on the unit circle"]
+  },
+  {
+    "id": "ann-polygon",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "regularPolygon_viviani", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Regular n-Gon: Distance Sum = n × Apothem",
+    "content": "The sharp planar result: for a regular $n$-gon ($n\\ge 2$) with each side at distance $a$ (the apothem/inradius) from the center, the sum of perpendicular distances from *any* point $P$ to the $n$ sides is exactly $n\\cdot a$. It is `sum_signedDist_eq` instantiated with $u_k = \\zeta^k$ and $c_k = a$: the normals sum to zero (`sum_primitiveRoot_pow_eq_zero`), so the sum collapses to $\\sum_k a = n\\cdot a$ (`sum_const` over `Fin n`). The classical equilateral-triangle Viviani ($n=3$, sum $=$ altitude $= 3a$) is the special case.",
+    "mathContext": "$\\sum_{k<n}(a - \\mathrm{rdot}(\\zeta^k,P)) = n\\cdot a$ for $n\\ge 2$.",
+    "significance": "critical",
+    "relatedConcepts": ["apothem", "inradius", "regular polygon", "sum_signedDist_eq", "roots of unity"],
+    "prerequisites": ["the master identity", "roots of unity sum to zero"]
+  },
+  {
+    "id": "ann-polygon-exists",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "regularPolygon_viviani_exists", "kind": "theorem" },
+    "type": "theorem",
+    "title": "A Genuine Regular n-Gon Realizing the Constant Exists",
+    "content": "Guards against vacuity: an actual primitive $n$-th root — hence a genuine regular $n$-gon — attaining $n\\cdot a$ always exists, realized concretely by $\\zeta = \\exp(2\\pi i/n)$ (`Complex.isPrimitiveRoot_exp`). This turns the conditional 'if $\\zeta$ is a primitive root' into an unconditional existence statement, confirming the theorem is not vacuously true for lack of a valid configuration.",
+    "mathContext": "$\\exists\\,\\zeta = \\exp(2\\pi i/n)$ primitive with $\\sum_k(a-\\mathrm{rdot}(\\zeta^k,P)) = n\\cdot a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.isPrimitiveRoot_exp", "existence", "non-vacuity"],
+    "prerequisites": ["the complex exponential", "primitive roots of unity"]
+  },
+  {
+    "id": "ann-simplex",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "anchor": { "type": "declaration", "name": "regularSimplex_viviani", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Regular n-Simplex: Distance Sum = (n+1) × Inradius",
+    "content": "The high-dimensional counterpart: for a simplex with vertices $v_i$, centroid $g$ (encoded by $\\sum_i v_i = (n{+}1)\\,g$) and circumradius $R\\neq 0$, the outward unit normal to the facet opposite $v_i$ is $R^{-1}(g - v_i)$. These sum to zero **because of the centroid**: $\\sum_i (g - v_i) = (n{+}1)g - (n{+}1)g = 0$. The master identity then gives the distance sum $= \\sum_i a = (n{+}1)\\cdot a$, the sharp constant $(n{+}1)\\times$ inradius. The polygon and simplex thus share one mechanism — normals summing to zero — realized by roots of unity in the plane and by the centroid in general dimension.",
+    "mathContext": "$\\sum_i(g - v_i) = (n{+}1)g - (n{+}1)g = 0 \\Rightarrow \\sum_i(a - \\langle R^{-1}(g-v_i),P\\rangle) = (n{+}1)a$.",
+    "significance": "critical",
+    "relatedConcepts": ["regular simplex", "centroid", "inradius", "sum_signedDist_eq", "outward normal"],
+    "prerequisites": ["the master identity", "centroid of a simplex", "inner product spaces"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `viviani-theorem-oq-01-oq-02` (fresh new entry, no prior annotations).

**Gap:** `meta.json` present but **no `annotations.json`** — one of only two no-annotation entries remaining gallery-wide.

**Added:** anchor-based `annotations.source.json` (resolved to `annotations.json`), **61% line coverage**, 8 annotations across all three parts:

| Annotation | Anchor | Significance |
|---|---|---|
| Overview (normals-sum-to-zero unifying principle) | block comment | critical |
| `sum_signedDist_eq` (master identity) | declaration | critical |
| `rdot` (plane as ℂ) | declaration | supporting |
| `sum_primitiveRoot_pow_eq_zero` | declaration | key |
| `primitiveRoot_pow_norm` (unit normals) | declaration | supporting |
| `regularPolygon_viviani` (n × apothem) | declaration | critical |
| `regularPolygon_viviani_exists` | declaration | supporting |
| `regularSimplex_viviani` ((n+1) × inradius) | declaration | critical |

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Trivial helper/const-form lemmas left unannotated (conceptually covered). Build resolves cleanly (exit 0, all 8 ranges align). Only this slug's two files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)