### PR TITLE
Enrich Potter's Bound & Karamata's Theorem: add 9 annotations

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Discharging Two Axioms of Regular Variation Theory",
+    "content": "The parent domain-of-attraction formalization left **Potter's bound** and **Karamata's integral theorem** as `axiom`s. This file discharges the hard half — Potter's bound — with a fully `axiom`-free derivation, and proves the base case of Karamata's theorem unconditionally. The honest move is to isolate the *one* genuinely measure-theoretic input, the **Uniform Convergence Theorem** (UCT) for slowly varying functions, as an explicit hypothesis `UniformSV` (it holds for every measurable slowly varying $L$; a full Mathlib development would derive it from measurability). Everything downstream is then elementary: a dyadic doubling induction amplifies the UCT's single-scale bound into Potter's global two-sided inequality $L(y)/L(x) \\le 2^\\delta\\max((y/x)^\\delta,(y/x)^{-\\delta})$. Karamata's power case $\\int_1^x t^\\rho\\,dt/(x\\cdot x^\\rho)\\to 1/(\\rho+1)$ is proved directly from Mathlib's `integral_rpow`.",
+    "mathContext": "UCT (hypothesis) $\\Rightarrow$ Potter: $L(y)/L(x) \\le 2^\\delta\\max((y/x)^{\\pm\\delta})$; and $\\int_1^x t^\\rho dt/(x\\,x^\\rho)\\to\\tfrac1{\\rho+1}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "slowly varying functions",
+      "asymptotic analysis",
+      "measure theory (for the UCT)"
+    ],
+    "relatedConcepts": [
+      "regular variation",
+      "Potter's bound",
+      "Karamata's theorem",
+      "uniform convergence theorem",
+      "axiom discharge"
+    ]
+  },
+  {
+    "id": "ann-slowly-varying",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 48,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "Slowly and Regularly Varying Functions",
+    "content": "$L$ is *slowly varying* at infinity if it is positive on $(0,\\infty)$ and $L(cx)/L(x)\\to 1$ as $x\\to\\infty$ for every $c>0$ — 'asymptotically scale-invariant' (e.g. $\\log x$, iterated logs, powers of logs). *Regularly varying* with index $\\alpha$ relaxes the limit to $c^\\alpha$; the companion `slowlyVarying_iff_regularlyVarying_zero` records that slow variation is exactly regular variation of index $0$. Positivity is built into the definition because Potter's multiplicative bounds divide by $L$. These are the objects governing the tails of distributions in the domain-of-attraction problem.",
+    "mathContext": "$L$ slowly varying: $L(cx)/L(x)\\to 1$; regularly varying index $\\alpha$: $\\to c^\\alpha$.",
+    "significance": "key",
+    "prerequisites": [
+      "limits at infinity",
+      "filters (atTop)"
+    ],
+    "relatedConcepts": [
+      "slowly varying function",
+      "regularly varying function",
+      "scale invariance",
+      "heavy tails"
+    ]
+  },
+  {
+    "id": "ann-uniformsv",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 71,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "The Uniform Convergence Theorem, Isolated as a Hypothesis",
+    "content": "`UniformSV L` asserts that the convergence $L(\\lambda x)/L(x)\\to 1$ is **uniform** in $\\lambda$ over every compact subinterval $[a,b]\\subset(0,\\infty)$. This is the single deep analytic input to regular variation theory — Karamata's UCT, which holds for every *measurable* slowly varying $L$. Rather than smuggle it in as an axiom, the file states it as an explicit assumption and derives Potter's bound from it by elementary means. This is what makes the entry an honest 'axiom discharge': the parent's Potter axiom is replaced by a named, well-understood, provable-in-principle hypothesis, and the reduction to it is fully machine-checked.",
+    "mathContext": "$\\forall [a,b]\\subset(0,\\infty),\\ \\forall\\varepsilon>0,\\ \\text{eventually}\\ |L(\\lambda x)/L(x)-1|<\\varepsilon\\ \\text{for all }\\lambda\\in[a,b]$.",
+    "significance": "critical",
+    "prerequisites": [
+      "uniform convergence",
+      "compact intervals",
+      "the atTop filter"
+    ],
+    "relatedConcepts": [
+      "uniform convergence theorem",
+      "Karamata's theorem",
+      "measurable functions",
+      "honest hypothesis"
+    ]
+  },
+  {
+    "id": "ann-step",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 90,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "The Single-Scale Seed",
+    "content": "From the UCT, for any $\\delta>0$ there is a threshold $X$ beyond which $L(\\lambda w)\\le 2^\\delta L(w)$ for all $\\lambda\\in[1,2]$. This is the seed the dyadic induction amplifies. The trick: apply uniformity on $[1,2]$ with $\\varepsilon = 2^\\delta - 1 > 0$, so $|L(\\lambda w)/L(w)-1| < 2^\\delta-1$ forces the ratio below $2^\\delta$. A dual `uniformSV_step_lower` gives the matching lower seed $2^{-\\delta}L(w)\\le L(\\lambda w)$.",
+    "mathContext": "$\\exists X,\\ \\forall w\\ge X,\\ \\lambda\\in[1,2]:\\ L(\\lambda w)\\le 2^\\delta L(w)$, via $\\varepsilon = 2^\\delta-1$.",
+    "significance": "key",
+    "prerequisites": [
+      "the UCT hypothesis",
+      "rpow monotonicity"
+    ],
+    "relatedConcepts": [
+      "uniform convergence theorem",
+      "single-scale bound",
+      "dyadic seed"
+    ]
+  },
+  {
+    "id": "ann-pow-bound",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 119,
+      "endLine": 145
+    },
+    "type": "theorem",
+    "title": "Dyadic Amplification: L(2ⁿw) ≤ 2^(δn)·L(w)",
+    "content": "The doubling engine: iterating the single-scale bound $n$ times gives $L(2^n w)\\le 2^{\\delta n}L(w)$, by induction on $n$. Each step applies the seed at $\\lambda=2$ to $2^n w$ (which still exceeds the threshold $X$ since $2^n\\ge 1$), then chains with the inductive bound, using $2^\\delta\\cdot 2^{\\delta n} = 2^{\\delta(n+1)}$ (`Real.rpow_add`). This converts a bound that holds only for scale factors in $[1,2]$ into one valid for all powers of two — the discrete backbone of Potter's inequality.",
+    "mathContext": "$L(2^n w)\\le 2^{\\delta n}L(w)$ by induction; step: $2^\\delta\\cdot 2^{\\delta n} = 2^{\\delta(n+1)}$.",
+    "significance": "key",
+    "prerequisites": [
+      "induction on ℕ",
+      "the single-scale seed"
+    ],
+    "relatedConcepts": [
+      "dyadic induction",
+      "Real.rpow_add",
+      "doubling argument"
+    ]
+  },
+  {
+    "id": "ann-potter-upper",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 147,
+      "endLine": 216
+    },
+    "type": "theorem",
+    "title": "Potter's Upper Bound",
+    "content": "The full continuous bound $L(y)/L(x)\\le 2^\\delta(y/x)^\\delta$ for $X\\le x\\le y$. The dyadic bound only reaches powers-of-two ratios; the gap is filled by writing $r = y/x$, taking $n=\\lfloor\\log_2 r\\rfloor$ so $2^n\\le r<2^{n+1}$, and setting the anchor $M=2^n x$. Then $y/M=\\lambda\\in[1,2]$, so one more single-scale step on top of the $n$-fold dyadic bound covers the fractional part. Finally $2^{\\delta n}=(2^n)^\\delta\\le r^\\delta$ collapses the estimate to $2^\\delta r^\\delta$. This 'floor + one fractional step' pattern is the standard way to upgrade a doubling bound to a continuous power law.",
+    "mathContext": "$L(y)/L(x)\\le 2^\\delta(y/x)^\\delta$; split $y/x = 2^n\\cdot\\lambda$, $\\lambda\\in[1,2]$, $n=\\lfloor\\log_2(y/x)\\rfloor$.",
+    "significance": "critical",
+    "prerequisites": [
+      "the dyadic amplification",
+      "logarithms base 2",
+      "rpow inequalities"
+    ],
+    "relatedConcepts": [
+      "Potter's bound",
+      "floor of a logarithm",
+      "dyadic-to-continuous",
+      "Real.logb"
+    ]
+  },
+  {
+    "id": "ann-potter-lower",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 271,
+      "endLine": 339
+    },
+    "type": "theorem",
+    "title": "Potter's Lower Bound (Dual Construction)",
+    "content": "The mirror inequality $2^{-\\delta}(y/x)^{-\\delta}\\le L(y)/L(x)$, built from the lower single-scale seed and lower dyadic core (`uniformSV_step_lower`, `potter_pow_bound_lower`) by the identical floor-plus-step construction, with the negative exponent reversing the direction of the rpow monotonicity (`inv_anti₀`). Together with `potter_upper` it two-sidedly pins the ratio, which is exactly what makes $L$ 'nearly constant on multiplicative scales'.",
+    "mathContext": "$2^{-\\delta}(y/x)^{-\\delta}\\le L(y)/L(x)$, dual to the upper bound.",
+    "significance": "key",
+    "prerequisites": [
+      "the upper bound construction",
+      "monotonicity of rpow with negative exponent"
+    ],
+    "relatedConcepts": [
+      "Potter's bound",
+      "duality",
+      "inv_anti₀",
+      "negative exponents"
+    ]
+  },
+  {
+    "id": "ann-max-form",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 341,
+      "endLine": 387
+    },
+    "type": "theorem",
+    "title": "Potter's Theorem, Classical Two-Sided Form",
+    "content": "The textbook statement: for all $x,y\\ge X$ (either order), $L(y)/L(x)\\le 2^\\delta\\max((y/x)^\\delta,(y/x)^{-\\delta})$. It merges the upper and lower bounds by cases on $x\\le y$ vs $y\\le x$: when $y\\ge x$ the upper bound and $(y/x)^\\delta\\le\\max$ suffice; when $y\\le x$ the lower bound is applied to the swapped pair $(y,x)$ and inverted, using $(x/y)^{-\\delta}=(y/x)^\\delta$ and $((2^{-\\delta}(y/x)^\\delta)^{-1}=2^\\delta(y/x)^{-\\delta}$. The $\\max$ makes the bound symmetric in the roles of $x$ and $y$ — the form used to control ratios of tail functions regardless of which argument is larger.",
+    "mathContext": "$L(y)/L(x)\\le 2^\\delta\\max\\big((y/x)^\\delta,\\,(y/x)^{-\\delta}\\big)$ for all $x,y\\ge X$.",
+    "significance": "critical",
+    "prerequisites": [
+      "the upper and lower bounds",
+      "properties of max"
+    ],
+    "relatedConcepts": [
+      "Potter's theorem",
+      "two-sided bound",
+      "case analysis",
+      "symmetry in x and y"
+    ]
+  },
+  {
+    "id": "ann-karamata",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 393,
+      "endLine": 418
+    },
+    "type": "theorem",
+    "title": "Karamata's Integral Theorem, Power Case",
+    "content": "The archetypal Karamata asymptotic with $L\\equiv 1$: for $\\rho>-1$, $\\big(\\int_1^x t^\\rho\\,dt\\big)/(x\\cdot x^\\rho)\\to 1/(\\rho+1)$ as $x\\to\\infty$. Proved unconditionally (no UCT needed) from Mathlib's closed form `integral_rpow`: $\\int_1^x t^\\rho\\,dt = (x^{\\rho+1}-1)/(\\rho+1)$, so the ratio equals $\\tfrac1{\\rho+1}(1 - x^{-(\\rho+1)})$, and $x^{-(\\rho+1)}\\to 0$ since $\\rho+1>0$ (`tendsto_rpow_neg_atTop`). This is the base case of the general Karamata theorem $\\int_1^x t^\\rho L(t)\\,dt\\sim x^{\\rho+1}L(x)/(\\rho+1)$.",
+    "mathContext": "$\\int_1^x t^\\rho dt = \\tfrac{x^{\\rho+1}-1}{\\rho+1}\\Rightarrow \\tfrac{\\int_1^x t^\\rho dt}{x\\,x^\\rho} = \\tfrac1{\\rho+1}(1-x^{-(\\rho+1)})\\to\\tfrac1{\\rho+1}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "interval integrals",
+      "the power rule ∫tᵖ",
+      "limits at infinity"
+    ],
+    "relatedConcepts": [
+      "Karamata's theorem",
+      "integral_rpow",
+      "tendsto_rpow_neg_atTop",
+      "asymptotic integral"
+    ]
+  }
+]

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/annotations.source.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-03/annotations.source.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "block-comment", "contains": "Potter's Bound and Karamata's Integral Theorem" },
+    "type": "concept",
+    "title": "Discharging Two Axioms of Regular Variation Theory",
+    "content": "The parent domain-of-attraction formalization left **Potter's bound** and **Karamata's integral theorem** as `axiom`s. This file discharges the hard half — Potter's bound — with a fully `axiom`-free derivation, and proves the base case of Karamata's theorem unconditionally. The honest move is to isolate the *one* genuinely measure-theoretic input, the **Uniform Convergence Theorem** (UCT) for slowly varying functions, as an explicit hypothesis `UniformSV` (it holds for every measurable slowly varying $L$; a full Mathlib development would derive it from measurability). Everything downstream is then elementary: a dyadic doubling induction amplifies the UCT's single-scale bound into Potter's global two-sided inequality $L(y)/L(x) \\le 2^\\delta\\max((y/x)^\\delta,(y/x)^{-\\delta})$. Karamata's power case $\\int_1^x t^\\rho\\,dt/(x\\cdot x^\\rho)\\to 1/(\\rho+1)$ is proved directly from Mathlib's `integral_rpow`.",
+    "mathContext": "UCT (hypothesis) $\\Rightarrow$ Potter: $L(y)/L(x) \\le 2^\\delta\\max((y/x)^{\\pm\\delta})$; and $\\int_1^x t^\\rho dt/(x\\,x^\\rho)\\to\\tfrac1{\\rho+1}$.",
+    "significance": "critical",
+    "relatedConcepts": ["regular variation", "Potter's bound", "Karamata's theorem", "uniform convergence theorem", "axiom discharge"],
+    "prerequisites": ["slowly varying functions", "asymptotic analysis", "measure theory (for the UCT)"]
+  },
+  {
+    "id": "ann-slowly-varying",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "SlowlyVarying", "kind": "def" },
+    "type": "definition",
+    "title": "Slowly and Regularly Varying Functions",
+    "content": "$L$ is *slowly varying* at infinity if it is positive on $(0,\\infty)$ and $L(cx)/L(x)\\to 1$ as $x\\to\\infty$ for every $c>0$ — 'asymptotically scale-invariant' (e.g. $\\log x$, iterated logs, powers of logs). *Regularly varying* with index $\\alpha$ relaxes the limit to $c^\\alpha$; the companion `slowlyVarying_iff_regularlyVarying_zero` records that slow variation is exactly regular variation of index $0$. Positivity is built into the definition because Potter's multiplicative bounds divide by $L$. These are the objects governing the tails of distributions in the domain-of-attraction problem.",
+    "mathContext": "$L$ slowly varying: $L(cx)/L(x)\\to 1$; regularly varying index $\\alpha$: $\\to c^\\alpha$.",
+    "significance": "key",
+    "relatedConcepts": ["slowly varying function", "regularly varying function", "scale invariance", "heavy tails"],
+    "prerequisites": ["limits at infinity", "filters (atTop)"]
+  },
+  {
+    "id": "ann-uniformsv",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "UniformSV", "kind": "def" },
+    "type": "definition",
+    "title": "The Uniform Convergence Theorem, Isolated as a Hypothesis",
+    "content": "`UniformSV L` asserts that the convergence $L(\\lambda x)/L(x)\\to 1$ is **uniform** in $\\lambda$ over every compact subinterval $[a,b]\\subset(0,\\infty)$. This is the single deep analytic input to regular variation theory — Karamata's UCT, which holds for every *measurable* slowly varying $L$. Rather than smuggle it in as an axiom, the file states it as an explicit assumption and derives Potter's bound from it by elementary means. This is what makes the entry an honest 'axiom discharge': the parent's Potter axiom is replaced by a named, well-understood, provable-in-principle hypothesis, and the reduction to it is fully machine-checked.",
+    "mathContext": "$\\forall [a,b]\\subset(0,\\infty),\\ \\forall\\varepsilon>0,\\ \\text{eventually}\\ |L(\\lambda x)/L(x)-1|<\\varepsilon\\ \\text{for all }\\lambda\\in[a,b]$.",
+    "significance": "critical",
+    "relatedConcepts": ["uniform convergence theorem", "Karamata's theorem", "measurable functions", "honest hypothesis"],
+    "prerequisites": ["uniform convergence", "compact intervals", "the atTop filter"]
+  },
+  {
+    "id": "ann-step",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "uniformSV_step", "kind": "theorem" },
+    "type": "theorem",
+    "title": "The Single-Scale Seed",
+    "content": "From the UCT, for any $\\delta>0$ there is a threshold $X$ beyond which $L(\\lambda w)\\le 2^\\delta L(w)$ for all $\\lambda\\in[1,2]$. This is the seed the dyadic induction amplifies. The trick: apply uniformity on $[1,2]$ with $\\varepsilon = 2^\\delta - 1 > 0$, so $|L(\\lambda w)/L(w)-1| < 2^\\delta-1$ forces the ratio below $2^\\delta$. A dual `uniformSV_step_lower` gives the matching lower seed $2^{-\\delta}L(w)\\le L(\\lambda w)$.",
+    "mathContext": "$\\exists X,\\ \\forall w\\ge X,\\ \\lambda\\in[1,2]:\\ L(\\lambda w)\\le 2^\\delta L(w)$, via $\\varepsilon = 2^\\delta-1$.",
+    "significance": "key",
+    "relatedConcepts": ["uniform convergence theorem", "single-scale bound", "dyadic seed"],
+    "prerequisites": ["the UCT hypothesis", "rpow monotonicity"]
+  },
+  {
+    "id": "ann-pow-bound",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "potter_pow_bound", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Dyadic Amplification: L(2ⁿw) ≤ 2^(δn)·L(w)",
+    "content": "The doubling engine: iterating the single-scale bound $n$ times gives $L(2^n w)\\le 2^{\\delta n}L(w)$, by induction on $n$. Each step applies the seed at $\\lambda=2$ to $2^n w$ (which still exceeds the threshold $X$ since $2^n\\ge 1$), then chains with the inductive bound, using $2^\\delta\\cdot 2^{\\delta n} = 2^{\\delta(n+1)}$ (`Real.rpow_add`). This converts a bound that holds only for scale factors in $[1,2]$ into one valid for all powers of two — the discrete backbone of Potter's inequality.",
+    "mathContext": "$L(2^n w)\\le 2^{\\delta n}L(w)$ by induction; step: $2^\\delta\\cdot 2^{\\delta n} = 2^{\\delta(n+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["dyadic induction", "Real.rpow_add", "doubling argument"],
+    "prerequisites": ["induction on ℕ", "the single-scale seed"]
+  },
+  {
+    "id": "ann-potter-upper",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "potter_upper", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Potter's Upper Bound",
+    "content": "The full continuous bound $L(y)/L(x)\\le 2^\\delta(y/x)^\\delta$ for $X\\le x\\le y$. The dyadic bound only reaches powers-of-two ratios; the gap is filled by writing $r = y/x$, taking $n=\\lfloor\\log_2 r\\rfloor$ so $2^n\\le r<2^{n+1}$, and setting the anchor $M=2^n x$. Then $y/M=\\lambda\\in[1,2]$, so one more single-scale step on top of the $n$-fold dyadic bound covers the fractional part. Finally $2^{\\delta n}=(2^n)^\\delta\\le r^\\delta$ collapses the estimate to $2^\\delta r^\\delta$. This 'floor + one fractional step' pattern is the standard way to upgrade a doubling bound to a continuous power law.",
+    "mathContext": "$L(y)/L(x)\\le 2^\\delta(y/x)^\\delta$; split $y/x = 2^n\\cdot\\lambda$, $\\lambda\\in[1,2]$, $n=\\lfloor\\log_2(y/x)\\rfloor$.",
+    "significance": "critical",
+    "relatedConcepts": ["Potter's bound", "floor of a logarithm", "dyadic-to-continuous", "Real.logb"],
+    "prerequisites": ["the dyadic amplification", "logarithms base 2", "rpow inequalities"]
+  },
+  {
+    "id": "ann-potter-lower",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "potter_lower", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Potter's Lower Bound (Dual Construction)",
+    "content": "The mirror inequality $2^{-\\delta}(y/x)^{-\\delta}\\le L(y)/L(x)$, built from the lower single-scale seed and lower dyadic core (`uniformSV_step_lower`, `potter_pow_bound_lower`) by the identical floor-plus-step construction, with the negative exponent reversing the direction of the rpow monotonicity (`inv_anti₀`). Together with `potter_upper` it two-sidedly pins the ratio, which is exactly what makes $L$ 'nearly constant on multiplicative scales'.",
+    "mathContext": "$2^{-\\delta}(y/x)^{-\\delta}\\le L(y)/L(x)$, dual to the upper bound.",
+    "significance": "key",
+    "relatedConcepts": ["Potter's bound", "duality", "inv_anti₀", "negative exponents"],
+    "prerequisites": ["the upper bound construction", "monotonicity of rpow with negative exponent"]
+  },
+  {
+    "id": "ann-max-form",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "potter_max_form", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Potter's Theorem, Classical Two-Sided Form",
+    "content": "The textbook statement: for all $x,y\\ge X$ (either order), $L(y)/L(x)\\le 2^\\delta\\max((y/x)^\\delta,(y/x)^{-\\delta})$. It merges the upper and lower bounds by cases on $x\\le y$ vs $y\\le x$: when $y\\ge x$ the upper bound and $(y/x)^\\delta\\le\\max$ suffice; when $y\\le x$ the lower bound is applied to the swapped pair $(y,x)$ and inverted, using $(x/y)^{-\\delta}=(y/x)^\\delta$ and $((2^{-\\delta}(y/x)^\\delta)^{-1}=2^\\delta(y/x)^{-\\delta}$. The $\\max$ makes the bound symmetric in the roles of $x$ and $y$ — the form used to control ratios of tail functions regardless of which argument is larger.",
+    "mathContext": "$L(y)/L(x)\\le 2^\\delta\\max\\big((y/x)^\\delta,\\,(y/x)^{-\\delta}\\big)$ for all $x,y\\ge X$.",
+    "significance": "critical",
+    "relatedConcepts": ["Potter's theorem", "two-sided bound", "case analysis", "symmetry in x and y"],
+    "prerequisites": ["the upper and lower bounds", "properties of max"]
+  },
+  {
+    "id": "ann-karamata",
+    "proofId": "central-limit-theorem-oq-01-oq-01-oq-03",
+    "anchor": { "type": "declaration", "name": "karamata_pow", "kind": "theorem" },
+    "type": "theorem",
+    "title": "Karamata's Integral Theorem, Power Case",
+    "content": "The archetypal Karamata asymptotic with $L\\equiv 1$: for $\\rho>-1$, $\\big(\\int_1^x t^\\rho\\,dt\\big)/(x\\cdot x^\\rho)\\to 1/(\\rho+1)$ as $x\\to\\infty$. Proved unconditionally (no UCT needed) from Mathlib's closed form `integral_rpow`: $\\int_1^x t^\\rho\\,dt = (x^{\\rho+1}-1)/(\\rho+1)$, so the ratio equals $\\tfrac1{\\rho+1}(1 - x^{-(\\rho+1)})$, and $x^{-(\\rho+1)}\\to 0$ since $\\rho+1>0$ (`tendsto_rpow_neg_atTop`). This is the base case of the general Karamata theorem $\\int_1^x t^\\rho L(t)\\,dt\\sim x^{\\rho+1}L(x)/(\\rho+1)$.",
+    "mathContext": "$\\int_1^x t^\\rho dt = \\tfrac{x^{\\rho+1}-1}{\\rho+1}\\Rightarrow \\tfrac{\\int_1^x t^\\rho dt}{x\\,x^\\rho} = \\tfrac1{\\rho+1}(1-x^{-(\\rho+1)})\\to\\tfrac1{\\rho+1}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Karamata's theorem", "integral_rpow", "tendsto_rpow_neg_atTop", "asymptotic integral"],
+    "prerequisites": ["interval integrals", "the power rule ∫tᵖ", "limits at infinity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem-oq-01-oq-01-oq-03` (no prior annotations).

**Gap:** `meta.json` present but **no `annotations.json`** — the last of the two no-annotation entries remaining gallery-wide.

**Added:** anchor-based `annotations.source.json` (resolved to `annotations.json`), **77% line coverage** of the 420-line proof, 9 annotations:

| Annotation | Anchor | Significance |
|---|---|---|
| Overview (discharging Potter/Karamata axioms via UCT) | block comment | critical |
| `SlowlyVarying` / `RegularlyVarying` defs | declaration | key |
| `UniformSV` (UCT as honest hypothesis) | declaration | critical |
| `uniformSV_step` (single-scale seed) | declaration | key |
| `potter_pow_bound` (dyadic amplification) | declaration | key |
| `potter_upper` (floor + fractional step) | declaration | critical |
| `potter_lower` (dual construction) | declaration | key |
| `potter_max_form` (classical two-sided) | declaration | critical |
| `karamata_pow` (power case via integral_rpow) | declaration | critical |

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Dual lemmas left unannotated (covered by `potter_lower`). Build resolves cleanly (exit 0, all 9 ranges align). Only this slug's two files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)