### PR TITLE
Fix: realign stale puiseux-theorem leanFile counts (540→581, 9→10)

### DIFF
--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -171,9 +171,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 540,
+    "lineCount": 581,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 2,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

The top-level `.leanFile` block in `puiseux-theorem/meta.json` had stale `lineCount` (540) and `theoremCount` (9). Realigned to reality: **581 lines, 10 theorems**.

## Evidence

- `wc -l proofs/Proofs/PuiseuxTheorem.lean` → **581**
- Comment-stripped top-level `theorem` declarations → **10**
- The sibling `.meta` block in the same file already reads `lineCount: 581`, `theoremCount: 10` — so `.leanFile` was internally inconsistent with `.meta` and with the source.

## Root cause

PR #33067 (`puiseux-theorem-wip-01`) grew `PuiseuxTheorem.lean` (replaced two `True`-stubs with genuine binomial-root theorems, net +41 lines / +1 theorem) and updated the `.meta` block, but left the `.leanFile` block — the one the gallery renders — at the old counts.

Pure metadata realignment; no Lean or logic changes. `axiomCount`, `definitionCount`, `sorries` are already correct.

---
Automated fix by lean-mechanic agent.