### PR TITLE
research(centered-hexagonal-sum-oq-01-oq-02): combinatorial shell-counting proof of ∑ Hₖ = n³ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CenteredHexagonalSumOQ01OQ02.lean
+++ b/proofs/Proofs/CenteredHexagonalSumOQ01OQ02.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Centered Hexagonal Sum = n³, the Combinatorial (Shell-Counting) Proof
+
+## Open Question (centered-hexagonal-sum-oq-01-oq-02)
+
+The parent entry `centered-hexagonal-sum-oq-01` proves the figurate identity
+
+    ∑_{k=1}^{n} Hₖ = n³,        Hₖ = 3k(k−1)+1
+
+*algebraically*, by telescoping / one-step induction closed with `ring`.  Its
+docstring records the geometric intuition: `Hₖ = k³ − (k−1)³`, so the `n`
+hexagonal numbers are the sizes of the `n` **cubic shells**
+
+    C_k = {0,…,k−1}³ ∖ {0,…,k−2}³,      |C_k| = k³ − (k−1)³ = Hₖ.
+
+This open question asks whether that picture can be promoted to a genuine
+**counting proof** in Lean: exhibit the cubic shells as an explicit disjoint
+decomposition of the full cube `{0,…,n−1}³` and read off `∑ Hₖ = n³` from
+`Finset.card_biUnion`, turning the algebraic identity into a structural one.
+
+## Result
+
+A fully machine-checked, self-contained combinatorial proof.
+
+* `cube n = range n ×ˢ range n ×ˢ range n` is the lattice cube, `card = n³`.
+* `cubeShell k = cube (k+1) ∖ cube k` is the `k`-th cubic shell.
+* **The mathematical heart** (`mem_cubeShell`): a lattice point `p` lies in
+  `cubeShell k` **iff its ℓ∞-radius — the maximum of its three coordinates —
+  equals `k`**.  So the shells are precisely the level sets of the Chebyshev
+  (sup-norm) radius; this *is* the explicit shell-assignment map behind the
+  identity.
+* `card_cubeShell` : `|cubeShell k| = H_{k+1}`, the per-shell match.
+* `cube_eq_biUnion` : the shells `C₁,…,Cₙ` disjointly reassemble the whole cube.
+* `sum_centeredHex_range_bijective` : the headline `∑_{k<n} H_{k+1} = n³`,
+  proved *entirely by counting* (`card_biUnion`), with no algebraic telescoping —
+  the only `ring`/`omega` steps are the elementary per-shell cardinalities.
+
+## Novelty
+
+The parent proves the identity by algebra; this file proves the *same* identity
+by a bijective/partition argument, the "proof from the book" for figurate-number
+identities.  The reusable content is the shell-decomposition template
+`∑ |shell_k| = |total|` via ℓ∞-level-sets, transferable to other
+figurate/polytopic sums.  Mathlib has neither the centered-hexagonal identity nor
+this Chebyshev-radius shell decomposition.
+
+0 sorries, 0 axioms.
+-/
+
+namespace CenteredHexagonalSumOQ01OQ02
+
+open Finset
+
+/-- The `k`-th centered hexagonal number `Hₖ = 3k(k−1)+1` (OEIS A003215),
+restated from the parent entry so this file is self-contained. -/
+def centeredHex (k : ℕ) : ℕ := 3 * k * (k - 1) + 1
+
+/-- Reindexed summand `H_{k+1} = 3(k+1)k + 1`: shifting the index turns the
+truncated ℕ subtraction `(k+1) − 1` into the honest `k`. -/
+theorem centeredHex_succ (k : ℕ) : centeredHex (k + 1) = 3 * (k + 1) * k + 1 := by
+  simp [centeredHex]
+
+/-- The lattice cube `{0,…,k−1}³ ⊆ ℕ³`, encoded as a `Finset (ℕ × ℕ × ℕ)`. -/
+def cube (k : ℕ) : Finset (ℕ × ℕ × ℕ) := range k ×ˢ (range k ×ˢ range k)
+
+/-- Membership in the cube: all three coordinates are `< k`. -/
+theorem mem_cube {k : ℕ} {p : ℕ × ℕ × ℕ} :
+    p ∈ cube k ↔ p.1 < k ∧ p.2.1 < k ∧ p.2.2 < k := by
+  simp [cube, Finset.mem_product, Finset.mem_range]
+
+/-- The cube has `k³` points. -/
+theorem card_cube (k : ℕ) : (cube k).card = k ^ 3 := by
+  simp only [cube, Finset.card_product, Finset.card_range]
+  ring
+
+/-- The cubes are nested: `{0,…,k−1}³ ⊆ {0,…,k}³`. -/
+theorem cube_subset_succ (k : ℕ) : cube k ⊆ cube (k + 1) := by
+  intro p hp
+  rw [mem_cube] at hp ⊢
+  omega
+
+/-- The `k`-th **cubic shell** `C_k = {0,…,k}³ ∖ {0,…,k−1}³` (indexed so
+`cubeShell k` has cardinality `H_{k+1}`, avoiding ℕ subtraction in the index). -/
+def cubeShell (k : ℕ) : Finset (ℕ × ℕ × ℕ) := cube (k + 1) \ cube k
+
+/-- **The combinatorial heart.**  A lattice point lies in `cubeShell k` iff its
+**ℓ∞-radius** — the maximum of its three coordinates — equals `k`.  The cubic
+shells are exactly the level sets of the sup-norm radius, which is the explicit
+map assigning each point of the cube to its shell. -/
+theorem mem_cubeShell {k : ℕ} {p : ℕ × ℕ × ℕ} :
+    p ∈ cubeShell k ↔ max p.1 (max p.2.1 p.2.2) = k := by
+  simp only [cubeShell, Finset.mem_sdiff, mem_cube]
+  omega
+
+/-- **Per-shell cardinality.**  `|cubeShell k| = H_{k+1} = 3(k+1)k + 1`, the
+`(k+1)`-st centered hexagonal number.  Immediate from `card_sdiff` on the nested
+cubes: `(k+1)³ − k³`. -/
+theorem card_cubeShell (k : ℕ) : (cubeShell k).card = centeredHex (k + 1) := by
+  rw [cubeShell, Finset.card_sdiff_of_subset (cube_subset_succ k), card_cube, card_cube,
+    centeredHex_succ]
+  have h : (k + 1) ^ 3 = k ^ 3 + (3 * (k + 1) * k + 1) := by ring
+  omega
+
+/-- **Disjointness.**  Distinct cubic shells are disjoint — a point's shell index
+is its ℓ∞-radius, which is single-valued. -/
+theorem cubeShell_disjoint {i j : ℕ} (h : i ≠ j) :
+    Disjoint (cubeShell i) (cubeShell j) := by
+  rw [Finset.disjoint_left]
+  intro p hpi hpj
+  rw [mem_cubeShell] at hpi hpj
+  omega
+
+/-- **Shell decomposition.**  The cubic shells `C₀,…,C_{n−1}` disjointly
+reassemble the full cube `{0,…,n−1}³`: every point sits in the shell of its
+ℓ∞-radius, and that radius is `< n` exactly when the point is in the cube. -/
+theorem cube_eq_biUnion (n : ℕ) :
+    cube n = (range n).biUnion cubeShell := by
+  ext p
+  simp only [Finset.mem_biUnion, Finset.mem_range, mem_cubeShell, mem_cube]
+  constructor
+  · intro hp
+    exact ⟨max p.1 (max p.2.1 p.2.2), by omega, by omega⟩
+  · rintro ⟨k, hk, hp⟩
+    omega
+
+/-- **Centered hexagonal sum, combinatorial proof.**
+
+`∑_{k<n} H_{k+1} = n³`.
+
+Proved *by counting*: the left side sums the cardinalities of the disjoint cubic
+shells (`card_cubeShell`), which by `card_biUnion` equals the cardinality of
+their union — the full cube (`cube_eq_biUnion`) — namely `n³` (`card_cube`).  No
+algebraic telescoping of the summand is used; the identity emerges purely from
+the disjoint shell decomposition of the lattice cube. -/
+theorem sum_centeredHex_range_bijective (n : ℕ) :
+    ∑ k ∈ range n, centeredHex (k + 1) = n ^ 3 := by
+  have hdisj : (↑(range n) : Set ℕ).PairwiseDisjoint cubeShell := by
+    intro i _ j _ h; exact cubeShell_disjoint h
+  calc ∑ k ∈ range n, centeredHex (k + 1)
+      = ∑ k ∈ range n, (cubeShell k).card := by
+        apply Finset.sum_congr rfl; intro k _; rw [card_cubeShell]
+    _ = ((range n).biUnion cubeShell).card := (Finset.card_biUnion hdisj).symm
+    _ = (cube n).card := by rw [← cube_eq_biUnion]
+    _ = n ^ 3 := card_cube n
+
+end CenteredHexagonalSumOQ01OQ02

--- a/research/problems/centered-hexagonal-sum-oq-01-oq-02/problem.md
+++ b/research/problems/centered-hexagonal-sum-oq-01-oq-02/problem.md
@@ -1,0 +1,121 @@
+# Problem: Combinatorial bijection between hexagonal and cubic shells
+
+**Slug**: centered-hexagonal-sum-oq-01-oq-02
+**Created**: 2026-07-02
+**Status**: Active
+**Source**: proof-suggestion
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\sum_{k=1}^{n} H_k = n^3, \qquad H_k = 3k(k-1) + 1,
+$$
+
+with the goal of realizing this identity via an **explicit bijection**
+
+$$
+\Phi : \bigsqcup_{k=1}^{n} (\text{$k$-th centered hexagonal shell}) \;\xrightarrow{\ \sim\ }\; \{0,1,\dots,n-1\}^3,
+$$
+
+matching each hexagonal shell $H_k$ to the $k$-th cubic shell $C_k = \{0,\dots,k-1\}^3 \setminus \{0,\dots,k-2\}^3$, so that $|C_k| = k^3 - (k-1)^3 = 3k(k-1)+1 = H_k$.
+
+### Plain Language
+
+The parent proof (`centered-hexagonal-sum-oq-01`) establishes algebraically that the sum of the first $n$ centered hexagonal numbers equals $n^3$, via telescoping/induction on closed forms. This open question asks whether the "cube-shell" picture behind the identity can be promoted to a genuinely **combinatorial** proof in Lean: exhibit a bijection between the $n$ hexagonal shells and the $n$ cubic shells $C_k = k^3 - (k-1)^3$, turning the identity into a counting statement rather than an algebraic one.
+
+### Why This Matters
+
+- Turns a computational identity into a structural one — the pedagogically preferred "proof from the book" for figurate-number identities.
+- Establishes a reusable gallery pattern for shell-decomposition bijections ($\sum \text{shell}_k = \text{total}$), transferable to other figurate/polytopic identities (square pyramidal, octahedral).
+- Bijective proofs are more robust under generalization than closed-form telescoping.
+
+## Known Results
+
+### What's Already Proven
+
+- `centered-hexagonal-sum-oq-01` — algebraic identity $\sum_{k=1}^n H_k = n^3$ (parent, verified, 0-axiom).
+- $k^3 - (k-1)^3 = 3k(k-1) + 1 = H_k$ — per-shell cardinality match is elementary (`ring`/`omega`).
+- Mathlib `Finset.card_product`, `Finset.card_sdiff`, `Finset.card_biUnion` support the counting side.
+
+### What's Still Open
+
+- Construct the explicit map $\Phi$ (or, weakly, prove the two shell families are equinumerous shell-by-shell and assemble a global bijection).
+- Decide the right Lean encoding of a "hexagonal shell" as a `Finset` whose card is $H_k$ so the bijection is checkable.
+
+### Our Goal
+
+Prove in Lean 4 + Mathlib that each $k$-th hexagonal shell is equinumerous with the cubic shell $C_k = \{0,\dots,k-1\}^3 \setminus \{0,\dots,k-2\}^3$, and derive $\sum_{k=1}^n H_k = n^3$ as a corollary via `Finset.card_biUnion` over the disjoint cubic shells. A full explicit coordinate bijection is a stretch goal; the shell-by-shell cardinality decomposition assembling into `card ({0,...,n-1}^3) = n^3` is the primary deliverable.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| centered-hexagonal-sum-oq-01 | Parent; provides the algebraic identity to re-prove bijectively | telescoping, induction, `ring` |
+| combinations-formula-oq-10-oq-01 | Prior counting identity proved by re-indexing Finset sums | `Finset.sum_range_succ`, absorption |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Cubic-shell decomposition (recommended)**: Define $C_k = \{0,\dots,k-1\}^3 \setminus \{0,\dots,k-2\}^3$ as a `Finset (ℕ×ℕ×ℕ)`. Show the $C_k$ are pairwise disjoint with union $\{0,\dots,n-1\}^3$. Then `card` gives $n^3$, and `card C_k = H_k` by `ring`/`omega` on $k^3-(k-1)^3$.
+   - Why it might work: the hard geometric bijection is avoided; shells are literal set differences of cubes, and disjoint-union card lemmas exist in Mathlib.
+   - Risk: encoding the hexagonal side as a Finset of card exactly $H_k$ (to make the bijection literal, not just equinumerous) is fiddly.
+
+2. **Explicit coordinate bijection**: give an actual `Equiv` between an enumerated hexagonal shell and $C_k$.
+   - Why it might work: strongest form of the result.
+   - Risk: high; needs a canonical linear ordering of both shells and an index formula — likely more effort than its marginal value.
+
+### Key Difficulties
+
+- Choosing a Finset model of the hexagonal shell whose cardinality is provably $H_k$.
+- Proving disjointness and union-equals-full-cube cleanly with `Finset` set operations.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `card (range k ×ˢ range k ×ˢ range k) = k^3` via `Finset.card_product`.
+- Key lemma 2: `card (cube k \ cube (k-1)) = 3*k*(k-1)+1` — set-difference card of nested cubes, then `ring`.
+- Key lemma 3: disjoint `biUnion` of the shells reconstructs the full cube — `Finset.card_biUnion` with pairwise disjointness.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The counting side is standard `Finset` cardinality manipulation well-supported in Mathlib.
+- The per-shell cardinality equation is a one-line `ring`/`omega`.
+- Only the "literal bijection on a hexagonal model" stretch goal is genuinely tricky; the decomposition form is tractable.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–3 days
+- If hard (full explicit `Equiv`): unknown
+
+## References
+
+### Papers
+- Conway & Guy, *The Book of Numbers* (1996) — figurate numbers and shell decompositions.
+
+### Online Resources
+- OEIS A003215 (centered hexagonal numbers), A000578 (cubes).
+
+### Mathlib
+- `Mathlib.Data.Finset.Card` — `card_product`, `card_sdiff`, `card_biUnion`.
+- `Mathlib.Algebra.BigOperators.Basic` — `Finset.sum_range_succ`.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - figurate-numbers
+  - bijective-proof
+  - finset-cardinality
+related_proofs:
+  - centered-hexagonal-sum-oq-01
+  - combinations-formula-oq-10-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-07-02
+```

--- a/research/problems/centered-hexagonal-sum-oq-01-oq-02/state.md
+++ b/research/problems/centered-hexagonal-sum-oq-01-oq-02/state.md
@@ -1,0 +1,42 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-07-02
+**Iteration**: 2
+
+## Current Focus
+
+Solved. Combinatorial (shell-counting) proof of ∑_{k<n} H_{k+1} = n³ complete and
+verified.
+
+## Active Approach
+
+Disjoint ℓ∞-level-set shell decomposition of the lattice cube:
+`cubeShell k = cube(k+1) \ cube k`, characterised (`mem_cubeShell`) as the set
+`{max(a,b,c) = k}`; disjointness + total union from single-valuedness of the max;
+per-shell card `(k+1)³ − k³ = H_{k+1}` via `card_sdiff`; sum via `card_biUnion`.
+
+## Outcome
+
+- `proofs/Proofs/CenteredHexagonalSumOQ01OQ02.lean` — 149 lines, 9 theorems, 3 defs.
+- Built with `lake env lean` (v4.26.0, warm Mathlib olean): exit 0, no errors.
+- `#print axioms sum_centeredHex_range_bijective` → only propext, Classical.choice,
+  Quot.sound. **VERIFIED, 0 axioms, 0 sorries.**
+- Gallery entry `src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/meta.json`
+  created; `pnpm gallery:check-size` passes.
+
+## Blockers
+
+None.
+
+## Next Action
+
+None — PR opened. Follow-up questions recorded in meta.json `conclusion.openQuestions`
+(higher-dimensional ∑((k+1)^d−k^d)=n^d analogue; explicit pointwise hexagonal↔cubic
+shell bijection).
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/meta.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "centered-hexagonal-sum-oq-01-oq-02",
+  "title": "Centered Hexagonal Sum = n³, the Combinatorial (Shell-Counting) Proof",
+  "slug": "centered-hexagonal-sum-oq-01-oq-02",
+  "description": "Answers the parent entry's open question (centered-hexagonal-sum-oq-01): can the algebraic identity ∑_{k=1}^{n} Hₖ = n³ (Hₖ = 3k(k−1)+1 the k-th centered hexagonal number) be promoted to a genuine combinatorial counting proof? Yes. Encode the lattice cube {0,…,k−1}³ as a Finset (ℕ×ℕ×ℕ) and the k-th cubic shell as cubeShell k = cube(k+1) ∖ cube k. The mathematical heart (mem_cubeShell): a lattice point lies in cubeShell k iff its ℓ∞-radius — the maximum of its three coordinates — equals k, so the cubic shells are exactly the level sets of the Chebyshev (sup-norm) radius. This is the explicit shell-assignment map: it makes the shells disjoint (single-valued radius) and shows they reassemble the whole cube (a point is in the cube iff its radius is < n). Per-shell cardinality |cubeShell k| = (k+1)³ − k³ = H_{k+1} follows from card_sdiff on the nested cubes; then Finset.card_biUnion gives ∑_{k<n} H_{k+1} = |cube n| = n³ purely by counting, with no algebraic telescoping of the summand. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Figurate-number shell decomposition (classical 'proof from the book'); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Centered_hexagonal_number",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "figurate-numbers",
+      "bijective-proof",
+      "finset-cardinality",
+      "shell-decomposition",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CenteredHexagonalSumOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_biUnion",
+        "description": "Cardinality of a disjoint indexed union equals the sum of the cardinalities: given the cubic shells are pairwise disjoint over range n, |⋃ cubeShell k| = ∑ |cubeShell k|. This is the counting engine that turns the shell decomposition into the summation identity.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_sdiff",
+        "description": "For s ⊆ t, |t \\ s| = |t| − |s|. Applied to the nested cubes cube k ⊆ cube (k+1) it gives the per-shell cardinality |cubeShell k| = (k+1)³ − k³.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_product",
+        "description": "|s ×ˢ t| = |s|·|t|, applied twice to the triple product range k ×ˢ (range k ×ˢ range k) to obtain |cube k| = k³.",
+        "module": "Mathlib.Data.Finset.Prod"
+      }
+    ],
+    "originalContributions": [
+      "A genuinely combinatorial (counting) proof of the parent's centered hexagonal cube identity ∑ Hₖ = n³, replacing the algebraic telescoping/induction with a disjoint shell decomposition of the lattice cube",
+      "The characterization mem_cubeShell: a lattice point lies in the k-th cubic shell iff its ℓ∞-radius (maximum coordinate) equals k — the cubic shells are precisely the level sets of the Chebyshev/sup-norm radius, which is the explicit shell-assignment map behind the identity",
+      "The reusable shell-decomposition template ∑ |shellₖ| = |total| via ℓ∞-level-sets, with disjointness and total-union both reduced to a single omega call on the three coordinate inequalities, transferable to other figurate/polytopic sums",
+      "Per-shell cardinality |cubeShell k| = H_{k+1} from card_sdiff on nested cubes, matching the geometric intuition Hₖ = k³ − (k−1)³ recorded (but only used algebraically) in the parent entry"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 149,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Uses only structural Mathlib cardinality lemmas (Finset.card_biUnion, Finset.card_sdiff, Finset.card_product, Finset.card_range) with omega, ring, and simp; no native_decide and no structure-encoded hypotheses. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for the main theorem, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 3
+  },
+  "sections": [
+    {
+      "id": "centered-hex",
+      "title": "The Centered Hexagonal Number",
+      "startLine": 56,
+      "endLine": 64,
+      "summary": "centeredHex k = 3k(k−1)+1 (restated from the parent so the file is self-contained), with the reindexed form H_{k+1} = 3(k+1)k + 1 that removes truncated ℕ subtraction."
+    },
+    {
+      "id": "cube",
+      "title": "The Lattice Cube",
+      "startLine": 66,
+      "endLine": 84,
+      "summary": "cube k = range k ×ˢ (range k ×ˢ range k) : Finset (ℕ×ℕ×ℕ), the lattice cube {0,…,k−1}³. Membership mem_cube says all three coordinates are < k, |cube k| = k³ (card_cube), and the cubes are nested cube k ⊆ cube (k+1)."
+    },
+    {
+      "id": "shell",
+      "title": "Cubic Shells as ℓ∞-Level-Sets",
+      "startLine": 86,
+      "endLine": 106,
+      "summary": "cubeShell k = cube(k+1) \\ cube k. The heart mem_cubeShell: a point lies in cubeShell k iff max of its coordinates equals k — the shells are the level sets of the ℓ∞-radius. card_cubeShell: |cubeShell k| = H_{k+1} = (k+1)³ − k³ via card_sdiff on the nested cubes."
+    },
+    {
+      "id": "decomposition",
+      "title": "Disjoint Shell Decomposition",
+      "startLine": 108,
+      "endLine": 135,
+      "summary": "cubeShell_disjoint: distinct shells are disjoint (the radius is single-valued). cube_eq_biUnion: the shells C₀,…,C_{n−1} disjointly reassemble the full cube — every point sits in the shell of its radius, which is < n iff the point is in the cube. Both reduce to one omega on the coordinate inequalities."
+    },
+    {
+      "id": "counting-proof",
+      "title": "The Counting Proof of ∑ Hₖ = n³",
+      "startLine": 137,
+      "endLine": 147,
+      "summary": "sum_centeredHex_range_bijective: ∑_{k<n} H_{k+1} = n³, proved by counting — the summed shell cardinalities equal, via card_biUnion, the cardinality of their union (the full cube) = n³. No algebraic telescoping of the summand is used."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Figurate numbers and shell decompositions**\n\nThe centered hexagonal numbers $H_k = 3k(k-1)+1$ count dots in $k$ nested hexagonal rings: $1, 7, 19, 37, \\dots$ (OEIS A003215). The parent entry `centered-hexagonal-sum-oq-01` proves the classical identity $\\sum_{k=1}^{n} H_k = n^3$ *algebraically*, by telescoping $H_k = k^3 - (k-1)^3$ and a one-step induction. Its docstring records the geometric picture: the $n$ hexagonal numbers are the sizes of the $n$ *cubic shells* $C_k = \\{0,\\dots,k-1\\}^3 \\setminus \\{0,\\dots,k-2\\}^3$, with $|C_k| = k^3-(k-1)^3 = H_k$. Bijective (counting) proofs of figurate identities are the pedagogically preferred 'proofs from the book' because they expose *why* the equality holds rather than merely verifying it.",
+    "problemStatement": "**Turn the identity into a counting statement**\n\nExhibit the cubic shells as an explicit *disjoint decomposition* of the full lattice cube $\\{0,\\dots,n-1\\}^3$ and read off $\\sum_{k=1}^{n} H_k = n^3$ from a disjoint-union cardinality lemma, rather than from algebraic telescoping. This requires a Finset model of each shell whose cardinality is provably $H_k$, together with disjointness and total-union proofs.",
+    "proofStrategy": "**Shells are the level sets of the sup-norm radius.** Encode the cube as $\\texttt{cube}\\,k = \\texttt{range}\\,k \\times^s (\\texttt{range}\\,k \\times^s \\texttt{range}\\,k)$, a $\\texttt{Finset}\\,(\\mathbb{N}\\times\\mathbb{N}\\times\\mathbb{N})$ with $|\\texttt{cube}\\,k| = k^3$. Define the $k$-th shell as the set difference $\\texttt{cubeShell}\\,k = \\texttt{cube}(k{+}1)\\setminus\\texttt{cube}\\,k$. The key observation ($\\texttt{mem\\_cubeShell}$) is that a lattice point $p$ lies in $\\texttt{cubeShell}\\,k$ iff $\\max(p_1,p_2,p_3) = k$: the shells are exactly the level sets of the $\\ell^\\infty$ (Chebyshev) radius. This single fact drives everything: the radius is single-valued, so distinct shells are disjoint ($\\texttt{cubeShell\\_disjoint}$); and a point is in $\\texttt{cube}\\,n$ iff its radius is $< n$, so the shells for $k<n$ reassemble the whole cube ($\\texttt{cube\\_eq\\_biUnion}$). Per-shell cardinality $|\\texttt{cubeShell}\\,k| = (k{+}1)^3-k^3 = H_{k+1}$ follows from $\\texttt{card\\_sdiff\\_of\\_subset}$ on the nested cubes. Finally $\\texttt{Finset.card\\_biUnion}$ gives $\\sum_{k<n} H_{k+1} = |\\texttt{cube}\\,n| = n^3$ — a pure counting derivation. All the membership reasoning (disjointness, total union, characterization) collapses to a single $\\texttt{omega}$ on the three coordinate inequalities.",
+    "keyInsights": [
+      "**The shell index is the ℓ∞-radius.** A lattice point $p \\in \\{0,\\dots,n-1\\}^3$ belongs to the shell $C_k$ precisely when $\\max(p_1,p_2,p_3) = k$. The cubic shells are the level sets of the sup-norm (Chebyshev) radius — this is the explicit map assigning each point of the cube to its shell.",
+      "**One observation proves both disjointness and completeness.** Because the radius is a single-valued function, distinct shells cannot overlap; because a point is in the cube iff its radius is bounded, the shells for $k<n$ cover exactly the cube. Both facts are the *same* statement about $\\max$, discharged by $\\texttt{omega}$.",
+      "**Counting replaces telescoping.** The parent collapses $\\sum (k^3-(k-1)^3)$ algebraically; here the collapse is a genuine partition — $\\texttt{card\\_biUnion}$ over disjoint shells — so the identity emerges from the *structure* of the cube, not from ring arithmetic on the summand.",
+      "**Set difference is the right shell model.** Taking $C_k = \\texttt{cube}(k{+}1)\\setminus\\texttt{cube}\\,k$ makes each shell a literal Finset with $\\texttt{card} = H_{k+1}$ via $\\texttt{card\\_sdiff}$, sidestepping the fiddly problem of enumerating a hexagonal shell of cardinality $H_k$ directly."
+    ],
+    "prerequisites": [
+      "Centered hexagonal (figurate) numbers",
+      "Finset cardinality: products, set differences, disjoint unions",
+      "The ℓ∞ (Chebyshev / sup-norm) radius of a lattice point",
+      "Bijective vs. algebraic proofs of summation identities"
+    ]
+  },
+  "conclusion": {
+    "summary": "The centered hexagonal cube identity $\\sum_{k=1}^{n} H_k = n^3$ is proved *combinatorially*: the lattice cube $\\{0,\\dots,n-1\\}^3$ is partitioned into cubic shells $C_k$, which are exactly the level sets of the $\\ell^\\infty$-radius $\\max(p_1,p_2,p_3)$. Each shell has $|C_k| = (k+1)^3-k^3 = H_{k+1}$ points, the shells are disjoint, and they reassemble the whole cube, so $\\texttt{Finset.card\\_biUnion}$ yields $\\sum_{k<n} H_{k+1} = |\\texttt{cube}\\,n| = n^3$ by counting alone. 0 axioms, 0 sorries.",
+    "implications": [
+      "Delivers the 'proof from the book' companion to the parent's algebraic derivation, exposing why the partial sums are cubes: the hexagonal shells count the sup-norm spheres of the integer cube.",
+      "Provides a reusable shell-decomposition template ∑ |shellₖ| = |total| via ℓ∞-level-sets, directly transferable to other figurate/polytopic identities (square pyramidal, octahedral) whose shells are sup-norm or ℓ¹ spheres.",
+      "Shows that the entire partition argument — disjointness and total union — reduces to a single omega call on coordinate inequalities once shells are modeled as set differences of nested cubes."
+    ],
+    "openQuestions": [
+      "Can the equinumerosity be upgraded to an explicit coordinate Equiv between a canonically enumerated centered hexagonal shell (a Finset of card Hₖ built from the hexagonal ring geometry) and the cubic shell C_k, rather than the set-difference model used here?",
+      "Does the same ℓ∞-level-set shell decomposition give clean counting proofs for the higher-dimensional analogues ∑ ((k+1)^d − k^d) = n^d, and which figurate families arise as the d-dimensional shell sizes?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "centered-hexagonal-sum-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this answers its open question by promoting the algebraic identity ∑ Hₖ = n³ to a combinatorial counting proof via a disjoint cubic-shell decomposition of the lattice cube."
+    },
+    {
+      "targetId": "centered-hexagonal-sum-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling child of the same parent; that entry generalizes the identity across centered polygonal families algebraically, while this one re-proves the hexagonal case combinatorially."
+    }
+  ]
+}

--- a/src/data/research/problems/centered-hexagonal-sum-oq-01-oq-02.json
+++ b/src/data/research/problems/centered-hexagonal-sum-oq-01-oq-02.json
@@ -1,0 +1,91 @@
+{
+  "slug": "centered-hexagonal-sum-oq-01-oq-02",
+  "title": "Combinatorial bijection between n hexagonal shells and n cubic shells (Lean)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in combinatorics: Combinatorial bijection between n hexagonal shells and n cubic shells (Lean).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-07-02T12:45:51.361Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: combinatorial (shell-counting) proof of ∑ Hₖ = n³ via ℓ∞-radius level-set decomposition of the lattice cube; verified 0-axiom.",
+    "builtItems": [
+      "CenteredHexagonalSumOQ01OQ02.lean: cube/cubeShell defs + mem_cubeShell (shell = ℓ∞-radius level set), card_cubeShell (|shell k|=H_{k+1}), cube_eq_biUnion, sum_centeredHex_range_bijective (9thm/3def/148L, VERIFIED)"
+    ],
+    "insights": [
+      "The cubic shell C_k = cube(k+1)\\cube k is exactly the set of lattice points whose max coordinate (ℓ∞/Chebyshev radius) equals k — one omega on the three coordinate inequalities proves disjointness AND total-union simultaneously.",
+      "Modeling shells as set differences of nested cubes gives card via Finset.card_sdiff_of_subset, sidestepping the need to enumerate a hexagonal Finset of card H_k directly."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Stretch: explicit coordinate Equiv between an enumerated hexagonal ring model (card H_k) and C_k.",
+      "Generalize the ℓ∞-level-set decomposition to ∑((k+1)^d − k^d)=n^d in dimension d."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "combinatorics",
+    "bijection",
+    "figurate-numbers"
+  ],
+  "relatedProofs": [
+    "centered-hexagonal-sum-oq-01",
+    "centered-hexagonal-sum-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T12:45:51.360Z",
+  "lastUpdate": "2026-07-02T12:45:51.360Z",
+  "significance": 5,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/CenteredHexagonalSum.lean",
+      "filename": "CenteredHexagonalSum.lean",
+      "lineCount": 102,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CenteredHexagonalSum.lean"
+    },
+    {
+      "path": "Proofs/CenteredHexagonalSumOQ01OQ01.lean",
+      "filename": "CenteredHexagonalSumOQ01OQ01.lean",
+      "lineCount": 97,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CenteredHexagonalSumOQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent open question **centered-hexagonal-sum-oq-01**: promotes the algebraic-induction proof of the figurate identity $\sum_{k=1}^{n} H_k = n^3$ ($H_k = 3k(k-1)+1$, the centered hexagonal numbers) to a **genuinely combinatorial counting proof** — the bijective 'proof from the book' the parent's open question asked for.

## Approach

- Model the cube as `cube n = range n ×ˢ range n ×ˢ range n : Finset (ℕ×ℕ×ℕ)`, with `card = n³`.
- The `k`-th **cubic shell** is `cubeShell k = cube (k+1) \ cube k`.
- **Combinatorial heart** (`mem_cubeShell`): a lattice point lies in `cubeShell k` **iff `max(a,b,c) = k`** — the shells are exactly the level sets of the ℓ∞ (Chebyshev / sup-norm) radius, the explicit shell-assignment map.
- Disjointness (`cubeShell_disjoint`) is free from single-valuedness of the radius; `cube_eq_biUnion` shows the shells reassemble the whole cube.
- Per-shell card `(k+1)³ − k³ = H_{k+1}` via `Finset.card_sdiff`; `Finset.card_biUnion` over the disjoint shells yields `∑_{k<n} H_{k+1} = n³` — **no induction on n, no algebraic telescoping**.

## Verification

- Built with `lake env lean` (Lean v4.26.0, Mathlib): exit 0, no errors.
- `#print axioms sum_centeredHex_range_bijective` → only `propext`, `Classical.choice`, `Quot.sound`.
- **VERIFIED, 0 axioms, 0 sorries.** 149 lines, 9 theorems, 3 definitions.
- `pnpm gallery:check-size` passes (4542 entries).

## Files

- `proofs/Proofs/CenteredHexagonalSumOQ01OQ02.lean` (new)
- `src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/meta.json` (new gallery entry)
- research problem knowledge files

🤖 Generated with [Claude Code](https://claude.com/claude-code)