### PR TITLE
research(zsqrtd-neg-two-oq-03-oq-06): the unit group of the Eisenstein integers ℤ[ω] [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ03OQ06.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ03OQ06.lean
@@ -1,0 +1,123 @@
+import Mathlib
+import Proofs.ZsqrtdNegTwoOQ03
+
+/-!
+# ℤ[ω] (Eisenstein integers), child OQ-03-OQ-06: the unit group
+
+A child of `zsqrtd-neg-two-oq-03`, which builds the Eisenstein-integer ring
+`ℤ[ω]` (with `ω² + ω + 1 = 0`), its multiplicative norm `N(a + bω) = a² - ab + b²`,
+and its `EuclideanDomain` structure on the way to representing primes `p ≡ 1 mod 3`
+as `a² + 3b²`.
+
+This entry determines the **unit group of `ℤ[ω]` completely**: an element is a unit
+iff its norm is `1`, and there are **exactly six** such elements — the sixth roots
+of unity `{±1, ±ω, ±ω²}`, in coordinates
+`{⟨1,0⟩, ⟨-1,0⟩, ⟨0,1⟩, ⟨0,-1⟩, ⟨1,1⟩, ⟨-1,-1⟩}`.
+
+Results:
+* `isUnit_iff_norm_eq_one` — `IsUnit z ↔ N z = 1` (norm is multiplicative and
+  norm-1 elements are inverted by their conjugate).
+* `norm_eq_one_iff` — the exact list of the six norm-`1` elements, via
+  `4·N(z) = (2re - im)² + 3·im²` bounding both coordinates to `{-1,0,1}`.
+* `isUnit_iff` — the combined element-level classification of units.
+* `unitsFinset`, `card_unitsFinset` (`= 6`), `isUnit_iff_mem_unitsFinset`.
+
+All results are `0`-axiom (no `sorry`, no `axiom`, no `native_decide`).
+
+## References
+* The Eisenstein integers `ℤ[ω]` and their six units (sixth roots of unity).
+-/
+
+open Proofs Proofs.Eisenstein
+
+namespace ZsqrtdNegTwoOQ03OQ06
+
+/-- `ω`, the primitive cube root of unity generating `ℤ[ω]` (coordinates `⟨0,1⟩`). -/
+def omega : Eisenstein := ⟨0, 1⟩
+
+/-!
+## Section 1: Units are exactly the norm-1 elements
+-/
+
+/-- **A norm-`1` element is a unit**, inverted by its conjugate
+    (`z · conj z = ⟨N z, 0⟩ = 1`). Conversely a unit has norm dividing `1`, and
+    since the norm of a nonzero element is a positive integer, it equals `1`. -/
+theorem isUnit_iff_norm_eq_one (z : Eisenstein) : IsUnit z ↔ norm z = 1 := by
+  constructor
+  · intro h
+    obtain ⟨u, rfl⟩ := h
+    have hzw : (↑u : Eisenstein) * ↑u⁻¹ = 1 := u.mul_inv
+    have hd : norm (↑u : Eisenstein) ∣ 1 :=
+      ⟨norm (↑u⁻¹ : Eisenstein), by rw [← norm_mul, hzw, norm_one]⟩
+    have hpos : 0 < norm (↑u : Eisenstein) := norm_pos_of_ne_zero u.ne_zero
+    have hle : norm (↑u : Eisenstein) ≤ 1 := Int.le_of_dvd (by norm_num) hd
+    omega
+  · intro hz
+    have h1 : z * conj z = 1 := by rw [mul_conj, hz]; ext <;> simp
+    have h2 : conj z * z = 1 := by rw [mul_comm]; exact h1
+    exact ⟨⟨z, conj z, h1, h2⟩, rfl⟩
+
+/-!
+## Section 2: Enumerating the six units
+-/
+
+/-- **Classification of norm-`1` Eisenstein integers.** The norm equals `1` exactly
+    for the six sixth-roots of unity `{±1, ±ω, ±ω²}`. From the identity
+    `4·N(z) = (2re - im)² + 3·im²`, both coordinates are squeezed into `{-1,0,1}`,
+    leaving nine candidates of which exactly six have norm `1`. -/
+theorem norm_eq_one_iff (z : Eisenstein) :
+    norm z = 1 ↔
+      z = ⟨1, 0⟩ ∨ z = ⟨-1, 0⟩ ∨ z = ⟨0, 1⟩ ∨ z = ⟨0, -1⟩ ∨
+      z = ⟨1, 1⟩ ∨ z = ⟨-1, -1⟩ := by
+  constructor
+  · intro hz
+    obtain ⟨a, b⟩ := z
+    have hz' : a ^ 2 - a * b + b ^ 2 = 1 := hz
+    have hid1 : (2 * a - b) ^ 2 + 3 * b ^ 2 = 4 := by linear_combination 4 * hz'
+    have hid2 : (2 * b - a) ^ 2 + 3 * a ^ 2 = 4 := by linear_combination 4 * hz'
+    have htb : 3 * b ^ 2 ≤ 4 := by nlinarith [hid1, sq_nonneg (2 * a - b)]
+    have hta : 3 * a ^ 2 ≤ 4 := by nlinarith [hid2, sq_nonneg (2 * b - a)]
+    have hb2 : b ^ 2 ≤ 1 := by
+      by_contra h
+      push_neg at h
+      have : (2 : ℤ) ≤ b ^ 2 := Int.add_one_le_iff.mpr h
+      linarith
+    have ha2 : a ^ 2 ≤ 1 := by
+      by_contra h
+      push_neg at h
+      have : (2 : ℤ) ≤ a ^ 2 := Int.add_one_le_iff.mpr h
+      linarith
+    have hblo : -1 ≤ b := by nlinarith [hb2, sq_nonneg (b + 1)]
+    have hbhi : b ≤ 1 := by nlinarith [hb2, sq_nonneg (b - 1)]
+    have halo : -1 ≤ a := by nlinarith [ha2, sq_nonneg (a + 1)]
+    have hahi : a ≤ 1 := by nlinarith [ha2, sq_nonneg (a - 1)]
+    interval_cases a <;> interval_cases b <;> revert hz' <;> decide
+  · rintro (rfl | rfl | rfl | rfl | rfl | rfl) <;> decide
+
+/-- **Element-level classification of the units of `ℤ[ω]`.** `z` is a unit iff it is
+    one of the six sixth-roots of unity. -/
+theorem isUnit_iff (z : Eisenstein) :
+    IsUnit z ↔
+      z = ⟨1, 0⟩ ∨ z = ⟨-1, 0⟩ ∨ z = ⟨0, 1⟩ ∨ z = ⟨0, -1⟩ ∨
+      z = ⟨1, 1⟩ ∨ z = ⟨-1, -1⟩ :=
+  (isUnit_iff_norm_eq_one z).trans (norm_eq_one_iff z)
+
+/-!
+## Section 3: The unit group has exactly six elements
+-/
+
+/-- The six units of `ℤ[ω]` as a `Finset`: `{±1, ±ω, ±ω²}`. -/
+def unitsFinset : Finset Eisenstein :=
+  {⟨1, 0⟩, ⟨-1, 0⟩, ⟨0, 1⟩, ⟨0, -1⟩, ⟨1, 1⟩, ⟨-1, -1⟩}
+
+/-- **There are exactly six units.** -/
+theorem card_unitsFinset : unitsFinset.card = 6 := by decide
+
+/-- Membership form of the unit classification: the units of `ℤ[ω]` are exactly
+    the six elements of `unitsFinset`. -/
+theorem isUnit_iff_mem_unitsFinset (z : Eisenstein) :
+    IsUnit z ↔ z ∈ unitsFinset := by
+  rw [isUnit_iff]
+  simp only [unitsFinset, Finset.mem_insert, Finset.mem_singleton]
+
+end ZsqrtdNegTwoOQ03OQ06

--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/annotations.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-zsq-oq03oq06-isunit",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-06",
+    "range": {
+      "startLine": 42,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "IsUnit ↔ Norm = 1",
+    "content": "isUnit_iff_norm_eq_one characterises the units of ℤ[ω] by their norm. Forward: a unit u satisfies u · u⁻¹ = 1, so by multiplicativity of the norm N(u)·N(u⁻¹) = N(1) = 1, giving N(u) ∣ 1; since a unit is nonzero its norm is a positive integer, and Int.le_of_dvd + omega force N(u) = 1. Backward: if N(z) = 1 then the parent's identity z · conj z = ⟨N z, 0⟩ = 1 exhibits conj z as a two-sided inverse, so z is a unit.",
+    "mathContext": "$\\mathrm{IsUnit}(z) \\iff N(z) = 1$; forward from $N(u)\\mid 1$ and $N(u) > 0$, backward from $z\\cdot\\overline z = N(z) = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "multiplicative norm",
+      "units of a ring",
+      "conjugate inverse",
+      "norm-Euclidean domain"
+    ],
+    "prerequisites": [
+      "Units.mul_inv",
+      "Int.le_of_dvd",
+      "Proofs.Eisenstein.mul_conj",
+      "Proofs.Eisenstein.norm_mul"
+    ]
+  },
+  {
+    "id": "ann-zsq-oq03oq06-enumerate",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-06",
+    "range": {
+      "startLine": 64,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "Enumerating the Six Norm-1 Elements",
+    "content": "norm_eq_one_iff lists the norm-1 Eisenstein integers explicitly. From N(z) = 1 the identity 4·N(z) = (2·re − im)² + 3·im² (proved by linear_combination) gives 3·im² ≤ 4 and, symmetrically, 3·re² ≤ 4. Each square is then sharpened from ≤ 4/3 to ≤ 1 by an integer argument (1 < x² ⟹ 2 ≤ x²), pinning both coordinates to {−1,0,1}. interval_cases enumerates the nine candidates and decide keeps exactly the six with norm 1.",
+    "mathContext": "$4(a^2 - ab + b^2) = (2a-b)^2 + 3b^2$; integrality forces $a,b \\in \\{-1,0,1\\}$, leaving six norm-1 points.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "quadratic form bounding",
+      "integer squeeze",
+      "interval_cases enumeration",
+      "sixth roots of unity"
+    ],
+    "prerequisites": [
+      "linear_combination",
+      "nlinarith",
+      "Int.add_one_le_iff",
+      "interval_cases"
+    ]
+  },
+  {
+    "id": "ann-zsq-oq03oq06-group",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-06",
+    "range": {
+      "startLine": 97,
+      "endLine": 123
+    },
+    "type": "theorem",
+    "title": "The Unit Group has Exactly Six Elements",
+    "content": "isUnit_iff composes the norm characterisation with the enumeration to classify units at the element level. unitsFinset collects the six units as a Finset, card_unitsFinset certifies its cardinality is 6 (by decide over the derived DecidableEq), and isUnit_iff_mem_unitsFinset records the membership form — so the unit group of ℤ[ω] has exactly six elements, the sixth roots of unity.",
+    "mathContext": "$\\mathbb{Z}[\\omega]^\\times = \\{\\pm 1, \\pm\\omega, \\pm\\omega^2\\}$, a cyclic group of order 6.",
+    "significance": "key",
+    "relatedConcepts": [
+      "unit group",
+      "cardinality via decide",
+      "roots of unity",
+      "Finset membership"
+    ],
+    "prerequisites": [
+      "Finset.card",
+      "Finset.mem_insert",
+      "DecidableEq"
+    ]
+  }
+]

--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "zsqrtd-neg-two-oq-03-oq-06",
+  "slug": "zsqrtd-neg-two-oq-03-oq-06",
+  "title": "The Unit Group of the Eisenstein Integers ℤ[ω]",
+  "description": "A child of zsqrtd-neg-two-oq-03, which builds the Eisenstein-integer ring ℤ[ω] (ω² + ω + 1 = 0), its multiplicative norm N(a+bω) = a² − ab + b², and its EuclideanDomain structure toward representing primes p ≡ 1 mod 3 as a² + 3b². This entry determines the unit group of ℤ[ω] completely: an element is a unit iff its norm is 1, and there are exactly six such elements — the sixth roots of unity {±1, ±ω, ±ω²}, in coordinates {⟨1,0⟩,⟨-1,0⟩,⟨0,1⟩,⟨0,-1⟩,⟨1,1⟩,⟨-1,-1⟩}. Fully machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ZsqrtdNegTwoOQ03"
+    ],
+    "opens": [
+      "Proofs",
+      "Proofs.Eisenstein"
+    ],
+    "namespace": "ZsqrtdNegTwoOQ03OQ06",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/ZsqrtdNegTwoOQ03OQ06.lean",
+    "additionalFiles": [
+      "Proofs/ZsqrtdNegTwoOQ03.lean"
+    ],
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ZsqrtdNegTwoOQ03OQ06.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-number-theory",
+      "eisenstein-integers",
+      "unit-group",
+      "quadratic-fields",
+      "roots-of-unity",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.le_of_dvd",
+        "description": "0 < n → m ∣ n → m ≤ n; bounds a unit's norm above by 1",
+        "module": "Mathlib.Data.Int.Init"
+      },
+      {
+        "theorem": "Int.add_one_le_iff",
+        "description": "a + 1 ≤ b ↔ a < b; upgrades 1 < x² to 2 ≤ x² for the integer squeeze",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "Units.mul_inv",
+        "description": "↑u * ↑u⁻¹ = 1; multiplicativity of the norm then forces N(u) ∣ 1",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "Units.ne_zero",
+        "description": "a unit is nonzero (needs Nontrivial ℤ[ω], provided by the parent)",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      },
+      {
+        "theorem": "Proofs.Eisenstein.mul_conj",
+        "description": "z · conj z = ⟨N z, 0⟩; the conjugate inverts a norm-1 element (from the parent)",
+        "module": "Proofs.ZsqrtdNegTwoOQ03"
+      },
+      {
+        "theorem": "Proofs.Eisenstein.norm_mul",
+        "description": "N(xy) = N(x)·N(y); multiplicativity of the Eisenstein norm (from the parent)",
+        "module": "Proofs.ZsqrtdNegTwoOQ03"
+      }
+    ],
+    "originalContributions": [
+      "isUnit_iff_norm_eq_one: IsUnit z ↔ N z = 1 for ℤ[ω] — forward via multiplicativity (N z ∣ 1, positive) and backward via the conjugate inverse z · conj z = 1",
+      "norm_eq_one_iff: the exact enumeration of the six norm-1 Eisenstein integers, squeezing both coordinates into {-1,0,1} through 4·N(z) = (2re − im)² + 3·im² and an integer bound, then a 9-case decide",
+      "isUnit_iff: the element-level classification — the units of ℤ[ω] are exactly {±1, ±ω, ±ω²}",
+      "unitsFinset and card_unitsFinset: the units form a 6-element Finset (card = 6 by decide)",
+      "isUnit_iff_mem_unitsFinset: the membership form, certifying the unit group of ℤ[ω] has exactly six elements"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 123,
+    "mathlib_version": "4.31.0",
+    "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations. #print axioms reports only the ordinary foundational axioms propext / Classical.choice / Quot.sound for every result (card_unitsFinset needs only propext / Quot.sound) — no sorryAx and no Lean.ofReduceBool. The finite classifications use `decide` (kernel Decidable evaluation), NOT `native_decide`, so no Lean.ofReduceBool is introduced. Builds on the parent zsqrtd-neg-two-oq-03, which is itself verified and 0-axiom.",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Eisenstein integers ℤ[ω] = ℤ[e^{2πi/3}], with ω² + ω + 1 = 0, are the ring of integers of ℚ(√−3) and one of the classical Euclidean imaginary quadratic rings. The parent gallery entry (`zsqrtd-neg-two-oq-03`) constructs ℤ[ω] from scratch (Mathlib's Zsqrtd does not apply, since the maximal order is ℤ[ω] rather than ℤ[√−3]), together with its norm N(a+bω) = a² − ab + b² and Euclidean structure, en route to the n = 3 Heegner-number theorem p ≡ 1 mod 3 ⟹ p = a² + 3b².\n\nA basic structural invariant of any such ring is its unit group. For ℤ[ω] the units are the sixth roots of unity — six elements — reflecting the extra symmetry of the hexagonal lattice (compared to the four units of the Gaussian integers ℤ[i]). This entry certifies that count and the exact list.",
+    "problemStatement": "**Open Question (OQ-03.6)**: determine the unit group of the Eisenstein integers ℤ[ω] built in the parent.\n\n**Answer**: An element z ∈ ℤ[ω] is a unit iff N(z) = 1, and the norm-1 elements are exactly the six sixth-roots of unity\n$$\\{1,\\ -1,\\ \\omega,\\ -\\omega,\\ \\omega^2,\\ -\\omega^2\\} = \\{\\langle 1,0\\rangle, \\langle -1,0\\rangle, \\langle 0,1\\rangle, \\langle 0,-1\\rangle, \\langle 1,1\\rangle, \\langle -1,-1\\rangle\\}.$$\nHence ℤ[ω] has exactly six units.",
+    "proofStrategy": "1. **IsUnit ↔ N = 1 (Section 1)**: forward, a unit u satisfies u · u⁻¹ = 1, so N(u)·N(u⁻¹) = N(1) = 1 by multiplicativity, giving N(u) ∣ 1; with N(u) > 0 (units are nonzero) and Int.le_of_dvd, `omega` forces N(u) = 1. Backward, if N(z) = 1 then z · conj z = ⟨N z, 0⟩ = 1 (parent's `mul_conj`), so z is a unit with inverse conj z.\n\n2. **Enumeration (Section 2)**: from N(z) = 1, the identity 4·N(z) = (2·re − im)² + 3·im² gives 3·im² ≤ 4 and (symmetrically) 3·re² ≤ 4; an integer argument sharpens each square to ≤ 1, so both coordinates lie in {−1,0,1}. `interval_cases` on the nine candidates, then `decide`, leaves exactly the six norm-1 points.\n\n3. **Group size (Section 3)**: `isUnit_iff` composes the two; `unitsFinset` lists the six and `card_unitsFinset` (`decide`) certifies card = 6; `isUnit_iff_mem_unitsFinset` is the membership form.",
+    "keyInsights": [
+      "**Norm-1 characterises units in any norm-multiplicative domain, but the count is lattice-specific.** The IsUnit ↔ N = 1 step is generic; what is special to ℤ[ω] is that N(a+bω) = a² − ab + b² = 1 has six integer solutions (versus four for the Gaussian norm a² + b²), reflecting the 6-fold symmetry of the Eisenstein lattice.",
+      "**The squeeze needs integrality once.** Over the reals 3·im² ≤ 4 only gives |im| ≤ 2/√3 ≈ 1.15; the step to |im| ≤ 1 uses that im² is an integer (1 < im² ⟹ 2 ≤ im²), after which the finite case-check is purely mechanical.",
+      "**decide, not native_decide.** The nine-candidate check and the card computation are discharged by kernel `decide`, keeping the proof genuinely axiom-free (no Lean.ofReduceBool), unlike a native_decide shortcut.",
+      "**Reuses the parent's algebra wholesale.** Multiplicativity of the norm and the conjugate-inverse identity z · conj z = ⟨N z, 0⟩ come straight from the parent, so the unit group falls out of already-verified infrastructure."
+    ],
+    "prerequisites": [
+      "Algebraic number theory (rings of integers of imaginary quadratic fields)",
+      "The Eisenstein integers ℤ[ω] and their norm (see the parent entry)",
+      "Units of a commutative ring; the correspondence unit ↔ norm 1 in a Euclidean domain"
+    ]
+  },
+  "sections": [
+    {
+      "id": "isunit-norm",
+      "title": "Units are Exactly the Norm-1 Elements",
+      "startLine": 38,
+      "endLine": 58,
+      "summary": "isUnit_iff_norm_eq_one: forward from multiplicativity (N u ∣ 1, positive ⟹ N u = 1); backward from the conjugate inverse z · conj z = 1.",
+      "mathContext": "$\\mathrm{IsUnit}(z) \\iff N(z) = 1$; the conjugate supplies the inverse of any norm-1 element."
+    },
+    {
+      "id": "enumerate",
+      "title": "Enumerating the Six Units",
+      "startLine": 60,
+      "endLine": 103,
+      "summary": "norm_eq_one_iff bounds both coordinates to {-1,0,1} via 4·N = (2re-im)²+3im² plus an integer squeeze, then decides the nine candidates; isUnit_iff composes it with the norm characterisation.",
+      "mathContext": "$N(a+b\\omega)=a^2-ab+b^2=1$ has exactly the six solutions $\\{(1,0),(-1,0),(0,1),(0,-1),(1,1),(-1,-1)\\}$."
+    },
+    {
+      "id": "group-size",
+      "title": "The Unit Group has Exactly Six Elements",
+      "startLine": 105,
+      "endLine": 123,
+      "summary": "unitsFinset lists the six units; card_unitsFinset = 6 (by decide); isUnit_iff_mem_unitsFinset gives the membership form of the classification.",
+      "mathContext": "$|\\mathbb{Z}[\\omega]^\\times| = 6$, the sixth roots of unity."
+    }
+  ],
+  "references": [
+    {
+      "text": "Eisenstein integers — the ring ℤ[ω], its norm, and its six units (sixth roots of unity).",
+      "url": "https://en.wikipedia.org/wiki/Eisenstein_integer"
+    },
+    {
+      "text": "Ring of integers of ℚ(√−3) and units of imaginary quadratic fields.",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_integer"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "zsqrtd-neg-two-oq-03",
+      "relationship": "extends",
+      "description": "The parent constructs ℤ[ω], its norm, conjugate, and Euclidean structure toward p ≡ 1 mod 3 ⟹ p = a² + 3b². This entry uses that norm and conjugate to determine the unit group of ℤ[ω] completely."
+    },
+    {
+      "targetId": "zsqrtd-neg-two-oq-03-oq-01",
+      "relationship": "related",
+      "description": "A sibling child completing the parent's headline theorem (primes p ≡ 1 mod 3 are x² + 3y²); this entry instead pins down the ambient ring's unit group."
+    }
+  ],
+  "conclusion": {
+    "summary": "We determine the unit group of the Eisenstein integers ℤ[ω] built in the parent: an element is a unit iff its norm is 1, and the norm-1 elements are exactly the six sixth-roots of unity {±1, ±ω, ±ω²}. Thus ℤ[ω] has exactly six units. Fully machine-checked, 0 sorries, 0 axioms (decide, not native_decide).",
+    "implications": "**A verified structural invariant of the parent's ring.** The unit count 6 (versus 4 for the Gaussian integers) is the algebraic fingerprint of the hexagonal Eisenstein lattice, and having it verified lets downstream work on ℤ[ω] (e.g. associate classes, factorisation up to units) quotient by a known, finite unit group.\n\n**Norm-1 ↔ unit, reusably.** The IsUnit ↔ N = 1 equivalence is exactly the tool needed to identify associates when proving uniqueness of the a² + 3b² representation up to the parent's symmetries.",
+    "openQuestions": [
+      "Promote unitsFinset to a Fintype/Group instance on ℤ[ω]ˣ and prove ℤ[ω]ˣ ≃ ZMod 6 (cyclic of order 6 generated by −ω).",
+      "Use the unit group to state and prove uniqueness (up to units and conjugation) of the representation p = a² + 3b² for primes p ≡ 1 mod 3, sharpening the sibling entry's existence result.",
+      "Formalise the analogous unit-group computations for the other norm-Euclidean imaginary quadratic rings and compare unit counts."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New **VERIFIED, 0-axiom** gallery entry `zsqrtd-neg-two-oq-03-oq-06`, a child of **`zsqrtd-neg-two-oq-03`** (which builds the Eisenstein-integer ring `ℤ[ω]`, `ω²+ω+1=0`, its norm `N(a+bω)=a²−ab+b²`, and its Euclidean structure toward `p ≡ 1 mod 3 ⟹ p = a²+3b²`).

This entry **determines the unit group of `ℤ[ω]` completely**.

## Results (`Proofs/ZsqrtdNegTwoOQ03OQ06.lean`, 123L, 5 thm / 2 def)

- **`isUnit_iff_norm_eq_one`** — `IsUnit z ↔ N z = 1`. Forward: `u·u⁻¹=1 ⟹ N(u)∣1`, and `N(u)>0` ⟹ `N(u)=1`. Backward: `z·conj z = ⟨N z,0⟩ = 1` (parent's `mul_conj`) makes `conj z` a two-sided inverse.
- **`norm_eq_one_iff`** — the six norm-`1` elements are exactly `{±1, ±ω, ±ω²}` = `{⟨1,0⟩,⟨-1,0⟩,⟨0,1⟩,⟨0,-1⟩,⟨1,1⟩,⟨-1,-1⟩}`. Both coordinates are squeezed into `{-1,0,1}` via `4·N(z) = (2·re−im)² + 3·im²` plus an integer bound, then `interval_cases`/`decide` over the 9 candidates.
- **`isUnit_iff`**, **`unitsFinset`**, **`card_unitsFinset` (= 6)**, **`isUnit_iff_mem_unitsFinset`**.

**Conclusion:** `ℤ[ω]` has **exactly six units** (the sixth roots of unity) — the algebraic fingerprint of the hexagonal Eisenstein lattice (vs. four units for `ℤ[i]`).

## Verification

- Built with `lake env lean` against warm Mathlib **v4.31** oleans (no `lake build`).
- `#print axioms` on all results reports only `propext / Classical.choice / Quot.sound` (`card_unitsFinset`: `propext / Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`. Uses kernel **`decide`**, not `native_decide`.
- 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions. Builds on the parent's verified, 0-axiom infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
