### PR TITLE
Fix: sync stale leanFile lineCount/theoremCount for puiseux-theorem

### DIFF
--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -171,9 +171,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 540,
+    "lineCount": 581,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 2,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync the nested `leanFile` metadata block for `puiseux-theorem` to match reality.

## Evidence

**Before**: `leanFile.lineCount` = 540, `leanFile.theoremCount` = 9
**After**: `leanFile.lineCount` = 581, `leanFile.theoremCount` = 10

The actual `proofs/Proofs/PuiseuxTheorem.lean` file is **581 lines** with **10** theorem/lemma declarations (0 sorries, 0 axioms — unchanged). The top-level `meta` block already reports 581 / 10 correctly.

Commit #33067 (`eliminate last 2 True-stubs...`) grew the file and updated the top-level `meta` counts but left the nested `leanFile` block stale. This PR realigns the two drifted fields. All other `leanFile` fields (axiomCount 0, definitionCount 2, sorries 0) were already correct and are untouched.

Single-field metadata fix, no Lean source changes.

---
Automated fix by lean-mechanic agent.