### PR TITLE
Enrich viviani-theorem-oq-01-oq-02: add annotation coverage (0→13)

### DIFF
--- a/src/data/proofs/viviani-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,283 @@
+[
+  {
+    "id": "viviani-oq0102-ann-header",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "The unifying principle behind every Viviani theorem",
+    "content": "The header frames the whole file around one observation. A facet with unit outward normal $u$ at offset $c$ is the hyperplane $\\{x : \\langle u, x\\rangle = c\\}$, and the signed perpendicular distance from a point $P$ to it is $c - \\langle u, P\\rangle$. Summing over facets gives $\\sum_i (c_i - \\langle u_i, P\\rangle) = (\\sum_i c_i) - \\langle \\sum_i u_i, P\\rangle$, so the distance sum is constant in $P$ exactly when the outward unit normals cancel. The regular $n$-gon and the regular $n$-simplex are then the two most symmetric instances of the vanishing-normal condition.",
+    "mathContext": "$\\sum_i (c_i - \\langle u_i, P\\rangle) = \\big(\\sum_i c_i\\big) - \\big\\langle \\textstyle\\sum_i u_i, P\\big\\rangle$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "hyperplane",
+      "signed distance",
+      "outward normal",
+      "Viviani's theorem"
+    ],
+    "prerequisites": [
+      "real inner-product space",
+      "affine hyperplanes"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-partA-doc",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "Part A: the abstract Viviani identity",
+    "content": "Part A works in an arbitrary real inner-product space $V$, with no reference to any particular figure. The signed perpendicular distance to a facet with unit normal $u$ at offset $c$ is $c - \\langle u, P\\rangle$; the entire remaining content of the file is showing that two classical figures satisfy the hypothesis $\\sum_i u_i = 0$.",
+    "mathContext": "$d_i(P) = c_i - \\langle u_i, P\\rangle$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "inner-product space",
+      "facet normal"
+    ],
+    "prerequisites": [
+      "bilinearity of the inner product"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-sum-signeddist-eq",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 72
+    },
+    "type": "insight",
+    "title": "sum_signedDist_eq — the single algebraic identity",
+    "content": "This is the heart of the file. The proof is one `rw` chain: `Finset.sum_sub_distrib` splits the sum, `← sum_inner` pulls the linear part into $\\langle \\sum_i u_i, P\\rangle$, the hypothesis `hu : ∑ i, u i = 0` collapses it, and `inner_zero_left`/`sub_zero` finish. The distance sum equals $\\sum_i c_i$, visibly independent of $P$. Every Viviani-type constancy theorem is a corollary of this line.",
+    "mathContext": "$\\sum_i (c_i - \\langle u_i, P\\rangle) = \\sum_i c_i \\quad\\text{when}\\quad \\sum_i u_i = 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "linearity of inner product",
+      "sum_inner",
+      "Finset.sum_sub_distrib"
+    ],
+    "prerequisites": [
+      "Finset sums",
+      "additivity of ⟪·,·⟫ in the left argument"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-sum-signeddist-const",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 80
+    },
+    "type": "tactic",
+    "title": "Constancy form: equal sums at any two points",
+    "content": "A direct restatement: since $\\sum_i (c_i - \\langle u_i, P\\rangle) = \\sum_i c_i$ is point-free, the distance sums at any $P$ and $Q$ agree. Proved by rewriting both sides with `sum_signedDist_eq`. This is the shape most recognizable as 'Viviani's theorem': the perpendicular-distance sum does not depend on where you stand.",
+    "mathContext": "$\\sum_i (c_i - \\langle u_i, P\\rangle) = \\sum_i (c_i - \\langle u_i, Q\\rangle)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "point-independence",
+      "invariant"
+    ],
+    "prerequisites": [
+      "equational rewriting"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-partB-doc",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 85
+    },
+    "type": "concept",
+    "title": "Part B: modeling the plane as ℂ",
+    "content": "To reach the regular polygon's roots-of-unity normals, Part B models the Euclidean plane as $\\mathbb{C}$ equipped with the explicit real inner product `rdot`. Working in $\\mathbb{C}$ (rather than an abstract 2-dimensional space) makes the outward normals literally the powers $\\zeta^k$ of a primitive root of unity.",
+    "mathContext": "plane $\\cong \\mathbb{C}$, normals $= \\zeta^0, \\zeta^1, \\dots, \\zeta^{n-1}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "complex plane",
+      "roots of unity",
+      "regular polygon"
+    ],
+    "prerequisites": [
+      "complex numbers as ℝ²"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-rdot",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 102
+    },
+    "type": "definition",
+    "title": "rdot: the real inner product on ℂ and its additivity",
+    "content": "`rdot z w = z.re * w.re + z.im * w.im` is the standard dot product under the identification $\\mathbb{C} \\cong \\mathbb{R}^2$. The key structural fact is `rdot_sum`: `rdot` is additive over finite sums in the left argument, proved by `Finset.induction` from the two-term `rdot_add_left`. This additivity is exactly what lets the vanishing normal sum kill the linear term in the polygon case.",
+    "mathContext": "$\\mathrm{rdot}(z,w) = \\Re z\\,\\Re w + \\Im z\\,\\Im w, \\quad \\mathrm{rdot}\\!\\big(\\textstyle\\sum_i f_i,\\, w\\big) = \\sum_i \\mathrm{rdot}(f_i, w)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dot product",
+      "bilinearity",
+      "Finset.induction"
+    ],
+    "prerequisites": [
+      "real/imaginary parts",
+      "induction over finite sets"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-sum-roots-zero",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 104,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "The n-th roots of unity sum to zero",
+    "content": "The polygon's vanishing-normal condition. Converting the `Fin n` sum to a range sum, `geom_sum_eq` evaluates $\\sum_{k=0}^{n-1} \\zeta^k = (\\zeta^n - 1)/(\\zeta - 1)$; since $\\zeta$ is a primitive $n$-th root, $\\zeta^n = 1$ makes the numerator vanish, while $\\zeta \\neq 1$ (from `IsPrimitiveRoot.ne_one`, valid because $n \\ge 2$) keeps the denominator nonzero. Hence the sum is $0$.",
+    "mathContext": "$\\sum_{k=0}^{n-1} \\zeta^k = \\dfrac{\\zeta^n - 1}{\\zeta - 1} = 0 \\quad (n \\ge 2,\\ \\zeta^n = 1,\\ \\zeta \\neq 1)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric series",
+      "primitive root of unity",
+      "geom_sum_eq"
+    ],
+    "prerequisites": [
+      "roots of unity",
+      "geometric-series formula"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-unit-norm",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 111,
+      "endLine": 116
+    },
+    "type": "tactic",
+    "title": "The normals are genuine unit vectors",
+    "content": "For $c - \\mathrm{rdot}(\\zeta^k, P)$ to be a true Euclidean perpendicular distance, each normal must have length one. Since $\\zeta^n = 1$ forces $\\|\\zeta\\| = 1$ (`Complex.norm_eq_one_of_pow_eq_one`), `norm_pow` gives $\\|\\zeta^k\\| = \\|\\zeta\\|^k = 1$. This justifies calling the constant 'n × apothem' rather than an arbitrary scaling.",
+    "mathContext": "$\\|\\zeta^k\\| = \\|\\zeta\\|^k = 1^k = 1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unit vector",
+      "norm of a power",
+      "apothem"
+    ],
+    "prerequisites": [
+      "complex modulus",
+      "‖·‖ multiplicativity"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-polygon-main",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 118,
+      "endLine": 128
+    },
+    "type": "insight",
+    "title": "regularPolygon_viviani — the sharp constant n · apothem",
+    "content": "The main polygon theorem. Expanding $\\sum_k (a - \\mathrm{rdot}(\\zeta^k, P))$ via `Finset.sum_sub_distrib` and `← rdot_sum`, the normal sum $\\sum_k \\zeta^k = 0$ kills the $P$-dependent term (`rdot_zero_left`), and the constant part collapses via `Finset.sum_const`/`Fintype.card_fin`/`nsmul_eq_mul` to $n \\cdot a$. So for any point $P$, the sum of perpendicular distances to the $n$ sides of a regular $n$-gon with apothem $a$ is exactly $n a$.",
+    "mathContext": "$\\sum_{k} \\big(a - \\mathrm{rdot}(\\zeta^k, P)\\big) = n \\cdot a$",
+    "significance": "key",
+    "relatedConcepts": [
+      "regular polygon",
+      "apothem",
+      "roots of unity"
+    ],
+    "prerequisites": [
+      "Finset.sum_const",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-polygon-exists-const",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 130,
+      "endLine": 145
+    },
+    "type": "tactic",
+    "title": "Existence and point-independence for the polygon",
+    "content": "`regularPolygon_viviani_exists` witnesses the theorem concretely: the roots $\\exp(2\\pi i k / n)$ form a primitive $n$-th root system (`Complex.isPrimitiveRoot_exp`), so an actual regular $n$-gon attaining $n a$ exists. `regularPolygon_viviani_const` restates the sharp constant as point-independence — the distance sum is the same at any two points $P, Q$.",
+    "mathContext": "$\\zeta = \\exp(2\\pi i / n), \\quad \\sum_k(a - \\mathrm{rdot}(\\zeta^k,P)) = \\sum_k(a - \\mathrm{rdot}(\\zeta^k,Q))$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "existence witness",
+      "Complex.exp",
+      "point-independence"
+    ],
+    "prerequisites": [
+      "complex exponential",
+      "primitive roots via exp"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-partC-doc",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 147,
+      "endLine": 151
+    },
+    "type": "concept",
+    "title": "Part C: the regular simplex in arbitrary dimension",
+    "content": "Part C returns to an abstract real inner-product space $V$. The outward unit normal to the facet opposite vertex $v_i$ points along $g - v_i$ where $g$ is the centroid. The centroid identity $\\sum_i (g - v_i) = 0$ is the simplex analogue of $\\sum_k \\zeta^k = 0$, so the general principle of Part A applies with no dimension restriction.",
+    "mathContext": "normals $\\propto g - v_i, \\quad \\sum_i (g - v_i) = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "regular simplex",
+      "centroid",
+      "inradius"
+    ],
+    "prerequisites": [
+      "centroid of a point set",
+      "arbitrary-dimensional inner-product space"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-simplex-main",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 153,
+      "endLine": 175
+    },
+    "type": "insight",
+    "title": "regularSimplex_viviani — the sharp constant (n+1) · inradius",
+    "content": "The main simplex theorem, with the centroid encoded as $\\sum_i v_i = (n+1) \\bullet g$ and $R \\neq 0$ the common circumradius. First `hu` shows the normals sum to zero: $\\sum_i R^{-1} \\bullet (g - v_i) = R^{-1} \\bullet \\sum_i (g - v_i)$, and $\\sum_i (g - v_i) = (n+1)\\bullet g - \\sum_i v_i = 0$ by the centroid identity. Then `sum_signedDist_eq` gives the distance sum $= \\sum_i a$, which `Finset.sum_const`/`nsmul_eq_mul`/`push_cast`/`ring` collapse to $(n+1) a$. The $n+1$ facets of a regular $n$-simplex with inradius $a$ contribute total distance $(n+1) a$ from any point.",
+    "mathContext": "$\\sum_i \\big(a - \\langle R^{-1}\\!\\bullet(g - v_i), P\\rangle\\big) = (n+1)\\cdot a$",
+    "significance": "key",
+    "relatedConcepts": [
+      "regular simplex",
+      "centroid identity",
+      "inradius",
+      "Finset.smul_sum"
+    ],
+    "prerequisites": [
+      "scalar multiplication in normed spaces",
+      "centroid encoding ∑ vᵢ = (n+1)•g"
+    ]
+  },
+  {
+    "id": "viviani-oq0102-ann-simplex-const",
+    "proofId": "viviani-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 177,
+      "endLine": 184
+    },
+    "type": "tactic",
+    "title": "Point-independence for the simplex",
+    "content": "The constancy form for the simplex: rewriting both sides with `regularSimplex_viviani`, the perpendicular-distance sum to the $n+1$ facets is the same at any two points $P, Q$ — the arbitrary-dimensional Viviani statement in its most classical shape.",
+    "mathContext": "$\\sum_i (a - \\langle R^{-1}\\!\\bullet(g - v_i), P\\rangle) = \\sum_i (a - \\langle R^{-1}\\!\\bullet(g - v_i), Q\\rangle)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "point-independence",
+      "invariant"
+    ],
+    "prerequisites": [
+      "equational rewriting"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `viviani-theorem-oq-01-oq-02` (Sharp Viviani Constant for Regular Polygons and Simplices).

**Gap:** the entry had a rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage of the 186-line Lean file.

**Change:** author **13 non-overlapping annotations** spanning the whole file:
- Header: the unifying vanishing-normal principle
- Part A: `sum_signedDist_eq` (the single algebraic identity) + constancy form
- Part B: `rdot` inner product, roots-of-unity sum = 0, unit-norm normals, `regularPolygon_viviani` + exists/const variants
- Part C: `regularSimplex_viviani` (centroid identity → (n+1)·inradius) + constancy form

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; `type`/`significance` use canonical enum values. Ranges are non-overlapping and anchored to declaration/section-doc lines. `meta.json` unchanged (already well under size caps).