### PR TITLE
research(ballot-problem-oq-05): ballot number via cycle lemma — integrality, probability, Catalan [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BallotProblemOQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ05.lean
@@ -1,0 +1,176 @@
+/-
+# The Bertrand Ballot Number via the Cycle Lemma
+
+The **Bertrand ballot problem** asks: in an election where candidate `A` receives
+`a` votes and candidate `B` receives `b` votes with `a > b`, what is the probability
+that `A` is *strictly* ahead throughout the count?  The classical answer is
+`(a − b)/(a + b)`.
+
+The combinatorial engine behind this answer is the **Dvoretzky–Motzkin cycle lemma**
+(already formalised, `0`-axiom, in `Proofs.BallotProblemOQ01`): for a fixed sequence
+of `a` up-steps `(+1)` and `b` down-steps `(−1)` with `a > b`, exactly `a − b` of its
+`a + b` cyclic rotations have all partial sums positive.  Aggregating this over all
+`C(a+b, a)` arrangements — each strictly-positive sequence is hit by exactly `a + b`
+of the `(sequence, rotation)` pairs, each other by none — yields the exact count of
+strictly-positive sequences, the **ballot number**
+
+  `BN(a, b) = (a − b)/(a + b) · C(a+b, a)`.
+
+This file is the *arithmetic* companion to that combinatorial story.  We take the
+manifestly-integral **reflection form** `C(a+b−1, a−1) − C(a+b−1, a)` as the
+definition of `BN` and prove:
+
+* `ballotNumber_mul_add` — the defining relation `BN(a,b) · (a+b) = (a−b) · C(a+b, a)`.
+  This is exactly the aggregate the cycle lemma produces; in particular it shows the
+  ratio `(a−b)/(a+b) · C(a+b, a)` is a genuine natural number.
+* `ballotNumber_div` — the Bertrand ballot **probability** `(a − b)/(a + b)`,
+  as the fraction `BN(a,b) / C(a+b, a)` over `ℚ`.
+* `ballotNumber_catalan` — the **Catalan** specialisation `BN(n+1, n) = catalan n`
+  (Dyck paths).
+
+Everything is elementary binomial arithmetic: the two absorption identities
+`k · C(n,k) = n · C(n−1, k−1)` (`Nat.add_one_mul_choose_eq`, `Nat.choose_succ_right_eq`),
+plus the Catalan/central-binomial bridge from Mathlib.  No axioms, no `sorry`,
+no `native_decide`.
+
+## References
+* Dvoretzky, A. and Motzkin, Th. (1947), *A problem of arrangements*.
+* Renault, M. (2008), *Lost (and found) in translation: André's actual method*.
+-/
+import Mathlib
+
+namespace BallotProblemOQ05
+
+/-- The **ballot number** `BN(a, b)`, in reflection form.
+
+By the cycle lemma this counts the sequences of `a` up-steps and `b` down-steps whose
+every partial sum is strictly positive; equivalently `(a − b)/(a + b) · C(a+b, a)`.
+The reflection form below is manifestly a natural number. -/
+def ballotNumber (a b : ℕ) : ℕ :=
+  (a + b - 1).choose (a - 1) - (a + b - 1).choose a
+
+/-- Absorption "up": `(a+b)·C(a+b−1, a−1) = a·C(a+b, a)`, written with `a = A+1`. -/
+theorem aux_up (A b : ℕ) :
+    (A + 1 + b) * (A + b).choose A = (A + 1) * (A + 1 + b).choose (A + 1) := by
+  have h := Nat.add_one_mul_choose_eq (A + b) A
+  -- h : (A + b + 1) * (A + b).choose A = (A + b + 1).choose (A + 1) * (A + 1)
+  have e : A + b + 1 = A + 1 + b := by ring
+  rw [e] at h
+  rw [h]; ring
+
+/-- Absorption "down": `(a+b)·C(a+b−1, a) = b·C(a+b, a)`, written with `a = A+1`.
+Derived from the "up" identity via `Nat.choose_succ_right_eq`, valid for every `b`
+(including `b = 0`, where both sides vanish). -/
+theorem aux_down (A b : ℕ) :
+    (A + 1 + b) * (A + b).choose (A + 1) = b * (A + 1 + b).choose (A + 1) := by
+  have hsub : A + b - A = b := by omega
+  have hsucc : (A + b).choose (A + 1) * (A + 1) = (A + b).choose A * b := by
+    have h := Nat.choose_succ_right_eq (A + b) A
+    rw [hsub] at h
+    exact h
+  have key : (A + 1) * ((A + 1 + b) * (A + b).choose (A + 1))
+           = (A + 1) * (b * (A + 1 + b).choose (A + 1)) := by
+    calc (A + 1) * ((A + 1 + b) * (A + b).choose (A + 1))
+        = (A + 1 + b) * ((A + b).choose (A + 1) * (A + 1)) := by ring
+      _ = (A + 1 + b) * ((A + b).choose A * b) := by rw [hsucc]
+      _ = b * ((A + 1 + b) * (A + b).choose A) := by ring
+      _ = b * ((A + 1) * (A + 1 + b).choose (A + 1)) := by rw [aux_up A b]
+      _ = (A + 1) * (b * (A + 1 + b).choose (A + 1)) := by ring
+  exact Nat.eq_of_mul_eq_mul_left (by omega) key
+
+/-- Core identity in `A = a − 1` form:
+`(C(A+b, A) − C(A+b, A+1)) · (A+1+b) = (A+1−b) · C(A+1+b, A+1)`.
+Truncated `ℕ` subtraction makes this hold unconditionally. -/
+theorem ballotNumber_mul_aux (A b : ℕ) :
+    ((A + b).choose A - (A + b).choose (A + 1)) * (A + 1 + b)
+      = (A + 1 - b) * (A + 1 + b).choose (A + 1) := by
+  rw [Nat.sub_mul, Nat.sub_mul,
+      mul_comm ((A + b).choose A) (A + 1 + b),
+      mul_comm ((A + b).choose (A + 1)) (A + 1 + b),
+      aux_up A b, aux_down A b]
+
+/-- **The defining relation of the ballot number.**  For `a ≥ 1`,
+
+  `BN(a, b) · (a + b) = (a − b) · C(a+b, a)`.
+
+This is precisely the aggregate count produced by the cycle lemma: summed over all
+`C(a+b, a)` arrangements of `a` up-steps and `b` down-steps, the number that stay
+strictly positive is `(a − b)/(a + b) · C(a+b, a)`.  In particular the right-hand
+side is divisible by `a + b`. -/
+theorem ballotNumber_mul_add (a b : ℕ) (ha : 1 ≤ a) :
+    ballotNumber a b * (a + b) = (a - b) * (a + b).choose a := by
+  obtain ⟨A, rfl⟩ : ∃ A, a = A + 1 := ⟨a - 1, by omega⟩
+  have e1 : A + 1 + b - 1 = A + b := by omega
+  have e2 : A + 1 - 1 = A := by omega
+  simp only [ballotNumber, e1, e2]
+  exact ballotNumber_mul_aux A b
+
+/-- **Bertrand ballot probability.**  For `1 ≤ a` and `b ≤ a`, the fraction of
+`(a, b)`-arrangements that stay strictly positive is `(a − b)/(a + b)`:
+
+  `BN(a, b) / C(a+b, a) = (a − b)/(a + b)`   (over `ℚ`). -/
+theorem ballotNumber_div (a b : ℕ) (ha : 1 ≤ a) (hab : b ≤ a) :
+    (ballotNumber a b : ℚ) / ((a + b).choose a : ℚ)
+      = ((a : ℚ) - b) / ((a : ℚ) + b) := by
+  have hmul := ballotNumber_mul_add a b ha
+  have h2 : (ballotNumber a b : ℚ) * ((a : ℚ) + b)
+          = ((a : ℚ) - b) * ((a + b).choose a : ℚ) := by
+    have hc := congrArg (fun n : ℕ => (n : ℚ)) hmul
+    push_cast [Nat.cast_sub hab] at hc
+    linear_combination hc
+  have hC : ((a + b).choose a : ℚ) ≠ 0 := by
+    have : 0 < (a + b).choose a := Nat.choose_pos (Nat.le_add_right a b)
+    exact_mod_cast this.ne'
+  have hS : ((a : ℚ) + b) ≠ 0 := by
+    have hpos : (0 : ℚ) < (a : ℚ) + b := by
+      have : 0 < a + b := by omega
+      exact_mod_cast this
+    exact hpos.ne'
+  rw [div_eq_div_iff hC hS]
+  linear_combination h2
+
+/-- **Catalan specialisation.**  The ballot number `BN(n+1, n)` counts Dyck paths of
+semilength `n` and equals the `n`-th Catalan number. -/
+theorem ballotNumber_catalan (n : ℕ) : ballotNumber (n + 1) n = catalan n := by
+  have hBN : ballotNumber (n + 1) n = (2 * n).choose n - (2 * n).choose (n + 1) := by
+    have e1 : n + 1 + n - 1 = 2 * n := by omega
+    have e2 : n + 1 - 1 = n := by omega
+    simp only [ballotNumber, e1, e2]
+  -- (n+1) · catalan n = C(2n, n)
+  have hcat : (n + 1) * catalan n = (2 * n).choose n := by
+    rw [catalan_eq_centralBinom_div, Nat.mul_div_cancel' (Nat.succ_dvd_centralBinom n),
+        Nat.centralBinom_eq_two_mul_choose]
+  -- (n+1) · C(2n, n+1) = n · C(2n, n)
+  have hstep : (n + 1) * (2 * n).choose (n + 1) = n * (2 * n).choose n := by
+    have h := Nat.choose_succ_right_eq (2 * n) n
+    have e : 2 * n - n = n := by omega
+    rw [e] at h
+    -- h : (2*n).choose (n+1) * (n+1) = (2*n).choose n * n
+    rw [mul_comm ((2 * n).choose n) n] at h
+    rw [mul_comm (n + 1) ((2 * n).choose (n + 1))]
+    exact h
+  -- (n+1) · BN(n+1, n) = C(2n, n)
+  have hBNmul : (n + 1) * ballotNumber (n + 1) n = (2 * n).choose n := by
+    rw [hBN, mul_comm, Nat.sub_mul,
+        mul_comm ((2 * n).choose (n + 1)) (n + 1), hstep,
+        mul_comm ((2 * n).choose n) (n + 1), add_one_mul]
+    exact Nat.add_sub_cancel_left _ _
+  have hcombine : (n + 1) * ballotNumber (n + 1) n = (n + 1) * catalan n := by
+    rw [hBNmul, hcat]
+  exact Nat.eq_of_mul_eq_mul_left (by omega) hcombine
+
+/-! ### Worked examples (checked by `decide`, hence `0`-axiom) -/
+
+/-- `a = 3, b = 1`: `(3−1)/(3+1)·C(4,3) = (1/2)·4 = 2`. -/
+example : ballotNumber 3 1 = 2 := by decide
+
+/-- `a = 4, b = 3`: `(4−3)/(4+3)·C(7,4) = (1/7)·35 = 5 = catalan 3`. -/
+example : ballotNumber 4 3 = 5 := by decide
+
+/-- Tie `a = b` gives `0` strictly-positive sequences. -/
+example : ballotNumber 5 5 = 0 := by decide
+
+/-- All up-steps `b = 0`: the unique sequence is strictly positive. -/
+example : ballotNumber 4 0 = 1 := by decide
+
+end BallotProblemOQ05

--- a/src/data/proofs/ballot-problem-oq-05/meta.json
+++ b/src/data/proofs/ballot-problem-oq-05/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "ballot-problem-oq-05",
+  "title": "The Bertrand Ballot Number via the Cycle Lemma: Integrality, Probability, and the Catalan Specialisation",
+  "slug": "ballot-problem-oq-05",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BallotProblemOQ05",
+    "lineCount": 176,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BallotProblemOQ05.lean",
+    "sorries": 0
+  },
+  "description": "The arithmetic capstone of the ballot/cycle-lemma family. The Dvoretzky–Motzkin cycle lemma (formalized 0-axiom in Proofs.BallotProblemOQ01) shows each sequence of a up-steps and b down-steps contributes exactly a-b strictly-positive cyclic rotations out of a+b; aggregating over all C(a+b,a) arrangements gives the exact count of strictly-positive sequences, the ballot number BN(a,b) = (a-b)/(a+b)·C(a+b,a). This entry takes the manifestly-integral reflection form BN(a,b) = C(a+b-1,a-1) - C(a+b-1,a) as the definition and proves it satisfies the defining relation BN(a,b)·(a+b) = (a-b)·C(a+b,a) (ballotNumber_mul_add) — which is precisely the cycle-lemma aggregate and in particular shows (a+b) divides (a-b)·C(a+b,a). From it two clean corollaries follow: the Bertrand ballot probability BN(a,b)/C(a+b,a) = (a-b)/(a+b) over the rationals (ballotNumber_div), and the Catalan specialisation BN(n+1,n) = catalan n counting Dyck paths (ballotNumber_catalan). The whole development is elementary binomial arithmetic — two absorption identities (Nat.add_one_mul_choose_eq, Nat.choose_succ_right_eq) plus Mathlib's central-binomial/Catalan bridge. 6 theorems, 1 definition, 4 decide-checked worked examples, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallotProblemOQ05.lean",
+    "tags": [
+      "probability",
+      "ballot-problem",
+      "cycle-lemma",
+      "combinatorics",
+      "catalan-numbers",
+      "binomial-coefficients",
+      "ballot-number"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked against the repo's Lean v4.26.0 / Mathlib pin (compiles green via `lake env lean Proofs/BallotProblemOQ05.lean`, and `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ05`). 0 sorries, 0 axiom declarations, no native_decide; `#print axioms` for ballotNumber_mul_add, ballotNumber_div, and ballotNumber_catalan lists only the standard foundational axioms (propext / Classical.choice / Quot.sound) supplied by Mathlib. Scope is honest: this is the arithmetic identity underlying the ballot count — it takes the per-sequence rotation count of the cycle lemma (proved combinatorially in the sibling entry BallotProblemOQ01) as the mathematical input and establishes the integrality, probability ratio, and Catalan specialisation of the aggregate ballot number; it does not re-derive the cycle lemma itself.",
+    "lineCount": 176,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "originalContributions": [
+      "ballotNumber: the ballot number defined in manifestly-integral reflection form C(a+b-1,a-1) - C(a+b-1,a) — the count, guaranteed by the cycle lemma, of sequences of a up-steps and b down-steps whose every partial sum is strictly positive",
+      "aux_up: the 'up' absorption identity (a+b)·C(a+b-1,a-1) = a·C(a+b,a), obtained from Nat.add_one_mul_choose_eq",
+      "aux_down: the 'down' absorption identity (a+b)·C(a+b-1,a) = b·C(a+b,a), derived from the up identity via Nat.choose_succ_right_eq and valid for every b including b=0 (both sides vanish)",
+      "ballotNumber_mul_aux: the core identity in a-1 = A form, (C(A+b,A) - C(A+b,A+1))·(A+1+b) = (A+1-b)·C(A+1+b,A+1); truncated ℕ subtraction makes it hold unconditionally",
+      "ballotNumber_mul_add: THE defining relation of the ballot number, BN(a,b)·(a+b) = (a-b)·C(a+b,a) for a ≥ 1 — exactly the aggregate the cycle lemma produces, and a proof that a+b divides (a-b)·C(a+b,a)",
+      "ballotNumber_div: the Bertrand ballot PROBABILITY BN(a,b)/C(a+b,a) = (a-b)/(a+b) over ℚ, obtained by casting the integer identity and clearing denominators",
+      "ballotNumber_catalan: the Catalan specialisation BN(n+1,n) = catalan n, proved by showing (n+1)·BN(n+1,n) = C(2n,n) = (n+1)·catalan n via the central-binomial bridge and cancelling",
+      "Four decide-checked worked examples (BN 3 1 = 2, BN 4 3 = 5 = catalan 3, BN 5 5 = 0, BN 4 0 = 1) grounding the formula against hand computation without native_decide"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Dvoretzky, Aryeh and Motzkin, Theodore",
+      "title": "A problem of arrangements",
+      "year": "1947",
+      "venue": "Duke Mathematical Journal 14(2), 305–313"
+    },
+    {
+      "authors": "Renault, Marc",
+      "title": "Lost (and found) in translation: André's actual method and its application to the generalized ballot problem",
+      "year": "2008",
+      "venue": "American Mathematical Monthly 115(4), 358–363"
+    },
+    {
+      "authors": "Bertrand, Joseph",
+      "title": "Solution d'un problème",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris 105, 369"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Nat.add_one_mul_choose_eq, Nat.choose_succ_right_eq, Nat.centralBinom, catalan_eq_centralBinom_div",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "In 1887 Joseph Bertrand posed the ballot problem: if candidate A ends with a votes and B with b < a votes, how likely is it that A leads throughout the count? The answer, (a-b)/(a+b), was proved almost immediately by Désiré André. The cleanest modern derivation is the Dvoretzky–Motzkin cycle lemma (1947): among the a+b cyclic rotations of any fixed vote sequence, exactly a-b keep every partial lead positive. Summing this over all C(a+b,a) arrangements — a double count in which each strictly-positive sequence is reached by exactly a+b of the (sequence, rotation) pairs — turns the per-sequence count into the exact number of favourable sequences, the ballot number BN(a,b) = (a-b)/(a+b)·C(a+b,a). The same number, specialised to a = n+1, b = n, is the n-th Catalan number counting Dyck paths, one of the most ubiquitous sequences in combinatorics.",
+    "problemStatement": "OQ-05 — the Bertrand ballot problem via the cycle lemma. The sibling entry BallotProblemOQ01 formalizes the cycle lemma itself (0-axiom): |goodRotations l| = a - b for a fixed ballot sequence. What remained was the arithmetic that turns that per-sequence rotation count into the aggregate ballot count and its consequences: that (a-b)/(a+b)·C(a+b,a) is a genuine integer, equals the classical probability (a-b)/(a+b), and specialises to the Catalan numbers. This entry supplies exactly that arithmetic, self-contained over Mathlib.",
+    "proofStrategy": "Define BN(a,b) by its reflection form C(a+b-1,a-1) - C(a+b-1,a), which is manifestly a natural number. The whole engine is the binomial absorption identity k·C(n,k) = n·C(n-1,k-1): applied at the top index it gives a·C(a+b,a) = (a+b)·C(a+b-1,a-1) (aux_up), and combined with C(a+b,a) = C(a+b,b) it gives b·C(a+b,a) = (a+b)·C(a+b-1,a) (aux_down). Subtracting and using that ℕ multiplication distributes over truncated subtraction (Nat.sub_mul) yields BN(a,b)·(a+b) = (a-b)·C(a+b,a) (ballotNumber_mul_add). Casting this integer identity to ℚ and clearing the two nonzero denominators gives the probability (a-b)/(a+b) (ballotNumber_div). For Catalan, specialise to BN(n+1,n) = C(2n,n) - C(2n,n+1), show (n+1)·BN(n+1,n) = C(2n,n) using Nat.choose_succ_right_eq, compare with (n+1)·catalan n = centralBinom n = C(2n,n) from Mathlib's succ_dvd_centralBinom / catalan_eq_centralBinom_div, and cancel n+1.",
+    "keyInsights": [
+      "The reflection form C(a+b-1,a-1) - C(a+b-1,a) makes integrality of the ballot number free: it is a natural number by construction, and the content is that it satisfies the defining relation BN·(a+b) = (a-b)·C(a+b,a).",
+      "A single binomial absorption identity k·C(n,k) = n·C(n-1,k-1), applied once at the top index and once (after a symmetry step) at the bottom, produces both halves of the count; the ballot number is their difference.",
+      "Working over ℕ with truncated subtraction (Nat.sub_mul) lets the core identity hold with no case split on whether a ≥ b: the a ≤ b regime automatically gives 0, matching that a trailing candidate never leads throughout.",
+      "The Bertrand probability drops out by pure algebra: it is the integer identity BN·(a+b) = (a-b)·C(a+b,a) read as a ratio, so no measure theory is needed to state the classical (a-b)/(a+b).",
+      "The Catalan numbers are the diagonal a = n+1, b = n of the ballot number, tying the ballot count to Mathlib's central-binomial/Catalan API by a one-line cancellation.",
+      "This is the arithmetic counterpart of the cycle lemma's combinatorics: OQ01 counts rotations of one sequence, OQ05 aggregates that count across all sequences into the closed-form ballot number and its probability and Catalan forms."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Ballot Number in Reflection Form",
+      "summary": "Header motivating the cycle-lemma aggregate, and the definition BN(a,b) = C(a+b-1,a-1) - C(a+b-1,a) as a manifestly-integral natural number.",
+      "startLine": 1,
+      "endLine": 52,
+      "mathContext": "The cycle lemma gives a-b good rotations per sequence; aggregating over C(a+b,a) arrangements yields BN(a,b) = (a-b)/(a+b)·C(a+b,a), whose reflection form is taken as the definition."
+    },
+    {
+      "id": "absorption",
+      "title": "The Two Absorption Identities",
+      "summary": "aux_up: (a+b)·C(a+b-1,a-1) = a·C(a+b,a) from Nat.add_one_mul_choose_eq. aux_down: (a+b)·C(a+b-1,a) = b·C(a+b,a), derived from aux_up via Nat.choose_succ_right_eq and valid for all b.",
+      "startLine": 53,
+      "endLine": 99,
+      "mathContext": "Both come from the absorption identity k·C(n,k) = n·C(n-1,k-1); the down version is obtained from the up version by a single cancellation, so it needs no separate b=0 case."
+    },
+    {
+      "id": "defining-relation",
+      "title": "The Defining Relation and the Ballot Probability",
+      "summary": "ballotNumber_mul_aux (unconditional core identity) and ballotNumber_mul_add: BN(a,b)·(a+b) = (a-b)·C(a+b,a). Then ballotNumber_div casts to ℚ and clears denominators to give the Bertrand probability (a-b)/(a+b).",
+      "startLine": 84,
+      "endLine": 133,
+      "mathContext": "Subtracting the two absorption identities and distributing multiplication over truncated ℕ subtraction gives the integer relation; dividing by the two nonzero denominators gives the classical probability."
+    },
+    {
+      "id": "catalan",
+      "title": "The Catalan Specialisation and Worked Examples",
+      "summary": "ballotNumber_catalan: BN(n+1,n) = catalan n via (n+1)·BN(n+1,n) = C(2n,n) = (n+1)·catalan n and cancellation, using Mathlib's central-binomial/Catalan bridge; four decide-checked numerical examples.",
+      "startLine": 134,
+      "endLine": 176,
+      "mathContext": "The diagonal a = n+1, b = n gives BN = C(2n,n) - C(2n,n+1); matched against centralBinom n / (n+1) = catalan n through succ_dvd_centralBinom and catalan_eq_centralBinom_div."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Bertrand ballot problem asks for the probability that a candidate leads throughout the count; the cycle lemma answers it by counting good cyclic rotations of a single sequence, and aggregating gives the ballot number BN(a,b) = (a-b)/(a+b)·C(a+b,a). This entry supplies the arithmetic backbone of that aggregate: it defines the ballot number in manifestly-integral reflection form and proves the defining relation BN(a,b)·(a+b) = (a-b)·C(a+b,a), which both certifies that (a+b) divides (a-b)·C(a+b,a) and yields, by clearing denominators over ℚ, the classical Bertrand probability (a-b)/(a+b). Specialising to the diagonal a = n+1, b = n recovers the Catalan numbers counting Dyck paths. The proof is elementary — two binomial absorption identities and Mathlib's central-binomial/Catalan bridge — verified with 0 axioms, 0 sorries, and no native_decide.",
+    "implications": "The entry closes the arithmetic gap between the two existing pillars of the ballot family: the combinatorial cycle lemma (BallotProblemOQ01, per-sequence rotation count) and Mathlib's measure-theoretic Wiedijk-#30 ballot theorem (BallotProblem.lean, probability via condCount). It shows the same probability (a-b)/(a+b) as a purely combinatorial ratio, exhibits the ballot number as a genuine integer, and ties the family to the Catalan API. The absorption-identity technique packaged here (aux_up / aux_down) is reusable for any 'k·C(n,k) = n·C(n-1,k-1)' rearrangement, and the integrality relation is the natural hypothesis for a future aggregate double-count that would derive the ballot count directly from the cycle lemma over the Finset of all arrangements.",
+    "openQuestions": [
+      "Carry out the aggregate double-count explicitly in Lean: sum |goodRotations l| over the Finset of all C(a+b,a) arrangements and prove the total equals BN(a,b)·(a+b), deriving the ballot count from the cycle lemma end-to-end rather than taking its arithmetic as input.",
+      "Prove the reflection-principle identity BN(a,b) = C(a+b,b) - C(a+b,b-1) and reconcile the reflection and cycle-lemma derivations of the ballot number in a single file.",
+      "Connect ballotNumber_div to the measure-theoretic ballot probability of BallotProblem.lean (Wiedijk #30), giving a machine-checked equality between the combinatorial and probabilistic statements of (a-b)/(a+b)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem",
+      "relationship": "parent",
+      "description": "The base Ballot Problem entry (Wiedijk #30), which computes the probability (p-q)/(p+q) that a candidate stays ahead throughout the count via Mathlib's measure-theoretic condCount. This entry gives the same probability combinatorially, as the ratio of the ballot number to the total count of arrangements."
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "related",
+      "description": "The sibling entry that formalizes the Dvoretzky–Motzkin cycle lemma itself (0-axiom): exactly a-b of the a+b cyclic rotations of a ballot sequence are strictly positive. This entry takes that per-sequence count as its mathematical input and aggregates it into the closed-form ballot number and its probability and Catalan forms."
+    },
+    {
+      "targetId": "ballot-problem-oq-04",
+      "relationship": "related",
+      "description": "A sibling ballot/Catalan strand that introduces non-crossing partitions as the Catalan-counted target of the ballot/Dyck bijection. Both entries connect the ballot problem to the Catalan numbers; this one via the diagonal ballotNumber (n+1) n = catalan n."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`ballot-problem-oq-05`** — the *arithmetic* capstone of the Bertrand-ballot / cycle-lemma family.

The Dvoretzky–Motzkin **cycle lemma** (already formalized 0-axiom in `Proofs.BallotProblemOQ01`) shows each sequence of `a` up-steps and `b` down-steps contributes exactly `a−b` strictly-positive cyclic rotations out of `a+b`. Aggregating over all `C(a+b,a)` arrangements gives the **ballot number** `BN(a,b) = (a−b)/(a+b)·C(a+b,a)`. This entry supplies the arithmetic backbone of that aggregate.

`proofs/Proofs/BallotProblemOQ05.lean` (176 L, 6 theorems, 1 definition, 4 `decide` examples):

- **`ballotNumber`** — defined in manifestly-integral reflection form `C(a+b−1,a−1) − C(a+b−1,a)`.
- **`ballotNumber_mul_add`** — the defining relation `BN(a,b)·(a+b) = (a−b)·C(a+b,a)` (the cycle-lemma aggregate; shows `a+b ∣ (a−b)·C(a+b,a)`).
- **`ballotNumber_div`** — the Bertrand ballot **probability** `BN(a,b)/C(a+b,a) = (a−b)/(a+b)` over `ℚ`.
- **`ballotNumber_catalan`** — the **Catalan** specialisation `BN(n+1,n) = catalan n` (Dyck paths).

Engine: two binomial absorption identities (`Nat.add_one_mul_choose_eq`, `Nat.choose_succ_right_eq`) + Mathlib's central-binomial/Catalan bridge.

## Verification

- Compiles green: `lake env lean Proofs/BallotProblemOQ05.lean` (Lean v4.26.0 / repo Mathlib pin).
- `#print axioms` for `ballotNumber_mul_add`, `ballotNumber_div`, `ballotNumber_catalan` → only `propext` / `Classical.choice` / `Quot.sound`.
- **0 sorries, 0 axiom declarations, no `native_decide`.**
- Worked examples checked by `decide`: `BN 3 1 = 2`, `BN 4 3 = 5 = catalan 3`, `BN 5 5 = 0`, `BN 4 0 = 1`.

## Scope (honest)

Takes the cycle lemma's per-sequence rotation count (proved combinatorially in the sibling `BallotProblemOQ01`) as mathematical input; establishes the integrality, probability ratio, and Catalan specialisation of the aggregate ballot number. Does not re-derive the cycle lemma. Complements the measure-theoretic Wiedijk-#30 ballot theorem in `BallotProblem.lean` by giving the same probability purely combinatorially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)