### PR TITLE
research(harmonic-divergence-oq-03-oq-01): positive absolutely-convergent series ∑ 1/((2k+1)(2k+2)) = log 2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HarmonicDivergenceOQ03OQ01.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ03OQ01.lean
@@ -1,0 +1,103 @@
+import Mathlib
+import Proofs.HarmonicDivergenceOQ03
+
+/-!
+# A Positive, Absolutely Convergent Series for `log 2`
+
+The companion entry `HarmonicDivergenceOQ03` shows the **alternating** harmonic
+series `1 - 1/2 + 1/3 - 1/4 + ⋯` converges *conditionally* to `log 2` (its value
+exists only as an ordered limit of partial sums; `¬ Summable`).
+
+This file pairs consecutive terms — `(1 - 1/2) + (1/3 - 1/4) + ⋯` — to obtain a
+series of **positive** terms with the *same* sum:
+
+  `∑ₖ 1/((2k+1)(2k+2)) = log 2`.
+
+Because `1/((2k+1)(2k+2)) = O(1/k²)`, this regrouped series is **absolutely**
+convergent, so unlike its alternating parent it has an honest `HasSum` /
+`tsum` value.  This is the standard "the sum of an alternating series equals the
+sum of its consecutive pairings" phenomenon made concrete for the Mercator
+series, answering the parent entry's open question about reorganizing the
+boundary value.
+
+## Main results
+* `sum_pairTerm_eq` — the `N`-th partial sum equals the `2N`-th alternating
+  partial sum (`altPartial (2N)`).
+* `summable_pairTerm` — the positive series is (absolutely) summable.
+* `hasSum_pairTerm_log_two` / `tsum_pairTerm` — `∑ₖ 1/((2k+1)(2k+2)) = log 2`.
+
+All results are `0`-sorry, `0`-axiom, built on `altHarmonic_tendsto_log_two`.
+-/
+
+namespace HarmonicAlt
+
+open Filter Finset
+open scoped Topology
+
+/-- The `k`-th paired term `1/((2k+1)(2k+2))`, obtained by grouping the
+`2k`-th and `(2k+1)`-th terms of the alternating harmonic series:
+`(-1)^{2k}/(2k+1) + (-1)^{2k+1}/(2k+2) = 1/(2k+1) - 1/(2k+2) = 1/((2k+1)(2k+2))`. -/
+noncomputable def pairTerm (k : ℕ) : ℝ := 1 / ((2 * (k : ℝ) + 1) * (2 * (k : ℝ) + 2))
+
+theorem pairTerm_nonneg (k : ℕ) : 0 ≤ pairTerm k := by
+  rw [pairTerm]; positivity
+
+/-- Pairing identity: two consecutive alternating terms collapse to one positive term. -/
+theorem altTerm_pair (k : ℕ) : altTerm (2 * k) + altTerm (2 * k + 1) = pairTerm k := by
+  have h1 : ((-1 : ℝ)) ^ (2 * k) = 1 := by rw [pow_mul]; norm_num
+  have h2 : ((-1 : ℝ)) ^ (2 * k + 1) = -1 := by rw [pow_succ, pow_mul]; norm_num
+  simp only [altTerm, pairTerm]
+  push_cast
+  rw [h1, h2]
+  have ha : (2 * (k : ℝ) + 1) ≠ 0 := by positivity
+  have hb : (2 * (k : ℝ) + 2) ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- **The `N`-th paired partial sum equals the `2N`-th alternating partial sum.** -/
+theorem sum_pairTerm_eq (N : ℕ) :
+    ∑ k ∈ range N, pairTerm k = altPartial (2 * N) := by
+  induction N with
+  | zero => simp [altPartial]
+  | succ n ih =>
+    have hstep : altPartial (2 * (n + 1)) =
+        altPartial (2 * n) + altTerm (2 * n) + altTerm (2 * n + 1) := by
+      unfold altPartial
+      rw [show 2 * (n + 1) = (2 * n + 1) + 1 from by ring,
+        Finset.sum_range_succ, Finset.sum_range_succ]
+    rw [Finset.sum_range_succ, ih, hstep]
+    have := altTerm_pair n
+    linarith
+
+/-- The paired partial sums converge to `log 2` (a subsequence of the alternating
+partial sums along the even indices). -/
+theorem tendsto_sum_pairTerm :
+    Tendsto (fun N => ∑ k ∈ range N, pairTerm k) atTop (𝓝 (Real.log 2)) := by
+  have hfun : (fun N => ∑ k ∈ range N, pairTerm k) = (fun N => altPartial (2 * N)) :=
+    funext sum_pairTerm_eq
+  rw [hfun]
+  have h2N : Tendsto (fun N : ℕ => 2 * N) atTop atTop :=
+    tendsto_atTop_mono (fun n => by simp only [id_eq]; omega) tendsto_id
+  exact altHarmonic_tendsto_log_two.comp h2N
+
+/-- **The positive regrouped series is (absolutely) summable.** Its partial sums
+are monotone (positive terms) and bounded above by their limit `log 2`. -/
+theorem summable_pairTerm : Summable pairTerm := by
+  apply summable_of_sum_range_le pairTerm_nonneg
+  intro N
+  have hmono : Monotone (fun M => ∑ i ∈ range M, pairTerm i) :=
+    monotone_nat_of_le_succ fun m => by
+      rw [Finset.sum_range_succ]; linarith [pairTerm_nonneg m]
+  exact hmono.ge_of_tendsto tendsto_sum_pairTerm N
+
+/-- **A positive series for `log 2`:** `∑ₖ 1/((2k+1)(2k+2)) = log 2`. -/
+theorem hasSum_pairTerm_log_two : HasSum pairTerm (Real.log 2) := by
+  have hval : ∑' k, pairTerm k = Real.log 2 :=
+    tendsto_nhds_unique summable_pairTerm.hasSum.tendsto_sum_nat tendsto_sum_pairTerm
+  exact hval ▸ summable_pairTerm.hasSum
+
+/-- `tsum` form: `∑' k, 1/((2k+1)(2k+2)) = log 2`. -/
+theorem tsum_pairTerm : ∑' k, pairTerm k = Real.log 2 :=
+  hasSum_pairTerm_log_two.tsum_eq
+
+end HarmonicAlt

--- a/src/data/proofs/harmonic-divergence-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-03-oq-01/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-harmonic-divergence-oq-03-oq-01-01",
+    "proofId": "harmonic-divergence-oq-03-oq-01",
+    "range": { "startLine": 38, "endLine": 56 },
+    "type": "definition",
+    "title": "Pairing collapses two conditional terms into one positive term",
+    "content": "The single algebraic fact behind the whole entry: the consecutive alternating pair `(-1)^{2k}/(2k+1) + (-1)^{2k+1}/(2k+2)` equals `1/(2k+1) - 1/(2k+2) = 1/((2k+1)(2k+2))`, a POSITIVE number. `altTerm_pair` proves it (the `(-1)^{2k}=1`, `(-1)^{2k+1}=-1` reductions plus `field_simp; ring`). Positivity of `pairTerm` is what later makes the partial sums monotone and unlocks a comparison-free summability argument."
+  },
+  {
+    "id": "ann-harmonic-divergence-oq-03-oq-01-02",
+    "proofId": "harmonic-divergence-oq-03-oq-01",
+    "range": { "startLine": 57, "endLine": 83 },
+    "type": "insight",
+    "title": "Pairing is a subsequence, not a rearrangement",
+    "content": "`sum_pairTerm_eq` proves by induction (peeling two terms at a time with `Finset.sum_range_succ`) that the N-th paired partial sum is EXACTLY the 2N-th alternating partial sum `altPartial (2N)`. This is the crux that makes regrouping safe for a conditionally convergent series: we are reading off a SUBSEQUENCE of the alternating partial sums, not permuting terms. Convergence and value therefore transfer for free — `tendsto_sum_pairTerm` just composes the parent's `altHarmonic_tendsto_log_two` with `N ↦ 2N → ∞`. No boundary-value/Abel argument is redone here."
+  },
+  {
+    "id": "ann-harmonic-divergence-oq-03-oq-01-03",
+    "proofId": "harmonic-divergence-oq-03-oq-01",
+    "range": { "startLine": 84, "endLine": 103 },
+    "type": "theorem",
+    "title": "Absolute convergence with no comparison series",
+    "content": "Because the terms are nonnegative the paired partial sums are monotone, so `Monotone.ge_of_tendsto` bounds each one by its own limit `log 2`; `summable_of_sum_range_le` then yields `Summable pairTerm` directly — no `1/k²` comparison or index shift needed. Finally `HasSum.tendsto_sum_nat` plus `tendsto_nhds_unique` identify `∑' pairTerm = log 2`. The upshot: unlike its `¬ Summable` alternating parent, `∑ 1/((2k+1)(2k+2))` is absolutely convergent and gives `log 2` an honest `HasSum`/`tsum` value."
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-03-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-03-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "harmonic-divergence-oq-03-oq-01",
+  "title": "A Positive, Absolutely Convergent Series for log 2: ∑ 1/((2k+1)(2k+2)) = log 2",
+  "slug": "harmonic-divergence-oq-03-oq-01",
+  "description": "Follow-up to the alternating-harmonic-series entry (harmonic-divergence-oq-03), which shows 1 − 1/2 + 1/3 − 1/4 + ⋯ converges only CONDITIONALLY to log 2 (its value exists solely as an ordered limit of partial sums; ¬ Summable). This entry pairs consecutive terms — (1 − 1/2) + (1/3 − 1/4) + ⋯ — to obtain a POSITIVE-term series with the same sum: ∑ₖ 1/((2k+1)(2k+2)) = log 2. Since 1/((2k+1)(2k+2)) = O(1/k²), the regrouped series is ABSOLUTELY convergent, so unlike its alternating parent it has an honest HasSum / tsum value. The proof is elementary and 0-axiom: the pairing identity altTerm(2k) + altTerm(2k+1) = 1/(2k+1) − 1/(2k+2) = 1/((2k+1)(2k+2)) (altTerm_pair) gives, by induction, that the N-th paired partial sum equals the 2N-th alternating partial sum altPartial(2N) (sum_pairTerm_eq); this is a subsequence of altPartial → log 2, so the paired partial sums tend to log 2 (tendsto_sum_pairTerm); being monotone (positive terms) and bounded above by their limit they are summable (summable_pairTerm via Monotone.ge_of_tendsto + summable_of_sum_range_le), and uniqueness of limits pins the value: hasSum_pairTerm_log_two / tsum_pairTerm. Fully machine-checked: 0 sorries, 0 axioms, built directly on altHarmonic_tendsto_log_two from the parent.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mercator_series",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "harmonic-series",
+      "alternating-series",
+      "logarithm",
+      "absolute-convergence",
+      "regrouping",
+      "axiom-free"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "summable_of_sum_range_le",
+        "description": "A nonneg series whose range-partial-sums are bounded above is summable — turns the log 2 bound on partial sums into Summable pairTerm",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Real"
+      },
+      {
+        "theorem": "Monotone.ge_of_tendsto",
+        "description": "A monotone sequence is ≤ its limit — bounds each paired partial sum by log 2 without a comparison series",
+        "module": "Mathlib.Topology.Order.MonotoneConvergence"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "Relates the tsum to the range-partial-sum limit, so uniqueness of limits fixes ∑' pairTerm = log 2",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Nat"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the last two terms in the induction proving the paired partial sum equals altPartial(2N)",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "pairTerm: DEFINED the k-th paired term 1/((2k+1)(2k+2)), the grouping of the 2k-th and (2k+1)-th alternating harmonic terms",
+      "altTerm_pair: PROVED the pairing identity (−1)^{2k}/(2k+1) + (−1)^{2k+1}/(2k+2) = 1/((2k+1)(2k+2))",
+      "sum_pairTerm_eq: PROVED (induction) the N-th paired partial sum equals the 2N-th alternating partial sum altPartial(2N)",
+      "tendsto_sum_pairTerm: PROVED the paired partial sums tend to log 2 (even-index subsequence of altPartial → log 2)",
+      "summable_pairTerm: PROVED the positive series is (absolutely) summable — monotone bounded partial sums",
+      "hasSum_pairTerm_log_two / tsum_pairTerm: PROVED ∑ₖ 1/((2k+1)(2k+2)) = log 2 as an honest HasSum / tsum, contrasting the parent's conditional-only value"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "The alternating harmonic series = log 2 (parent entry harmonic-divergence-oq-03)",
+      "Monotone convergence and nonnegative summability in ℝ",
+      "Finite-sum manipulation (regrouping consecutive terms)"
+    ],
+    "lineCount": 103,
+    "relatedProblems": [
+      {
+        "id": "harmonic-divergence-oq-03",
+        "relationship": "Direct parent: supplies altTerm, altPartial and altHarmonic_tendsto_log_two; this entry regroups its conditionally convergent alternating series into an absolutely convergent positive series with the same sum log 2"
+      }
+    ],
+    "assumptions": "None. 0 axioms, 0 sorries: every theorem depends only on the standard foundational axioms propext, Classical.choice, Quot.sound. The result strengthens the parent's ordered-limit value: whereas the alternating series 1 − 1/2 + 1/3 − ⋯ is NOT Summable (only conditionally convergent), its consecutive-pair regrouping ∑ 1/((2k+1)(2k+2)) IS absolutely convergent with an honest HasSum/tsum value log 2.",
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Mercator series 1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2 (Mengoli 1650, Mercator 1668) is the archetypal conditionally convergent series: rearranging or regrouping it can change its behavior. Grouping the terms in consecutive PAIRS, however, is always legitimate for a convergent series and preserves the sum — and here it produces something qualitatively better. Each pair 1/(2k+1) − 1/(2k+2) is positive and equals 1/((2k+1)(2k+2)) = O(1/k²), so the regrouped series converges ABSOLUTELY. The parent gallery entry established the delicate conditional value via Abel's limit theorem; this entry shows the robust positive-series face of the same constant.",
+    "problemStatement": "Regroup the conditionally convergent alternating harmonic series into a positive, absolutely convergent series and prove it still sums to log 2: ∑ₖ 1/((2k+1)(2k+2)) = log 2.",
+    "text": "A 103-line self-contained follow-up proving ∑ₖ 1/((2k+1)(2k+2)) = log 2 as an honest HasSum/tsum, by pairing consecutive alternating harmonic terms — 0 sorries, 0 axioms.",
+    "proofStrategy": "altTerm_pair collapses each consecutive pair to a positive term; sum_pairTerm_eq (induction, peeling two terms with Finset.sum_range_succ) shows the N-th paired partial sum is the 2N-th alternating partial sum altPartial(2N). As altPartial → log 2 (parent) and N ↦ 2N → ∞, the paired partial sums tend to log 2 (tendsto_sum_pairTerm). Being nonnegative they are monotone, hence ≤ their limit log 2 (Monotone.ge_of_tendsto), so summable_of_sum_range_le gives Summable pairTerm; HasSum.tendsto_sum_nat and uniqueness of limits then fix ∑' pairTerm = log 2.",
+    "keyInsights": [
+      "**Conditional → absolute by pairing.** The parent series is not Summable (conditional only); grouping consecutive terms yields a positive O(1/k²) series that IS absolutely summable, with the same sum.",
+      "**Pairing is a subsequence, not a rearrangement.** The N-th paired partial sum is exactly the 2N-th alternating partial sum, so convergence and value transfer for free — no re-derivation of log 2.",
+      "**Monotone + bounded, no comparison series.** Positivity makes the paired partial sums monotone; Monotone.ge_of_tendsto bounds them by their own limit log 2, feeding summable_of_sum_range_le directly.",
+      "**An honest tsum for log 2.** Unlike the alternating form, the regrouped series has a genuine HasSum/tsum value, giving log 2 a positive-series representation ∑ 1/((2k+1)(2k+2))."
+    ],
+    "prerequisites": [
+      "The alternating harmonic series = log 2 (parent)",
+      "Monotone convergence / nonnegative summability",
+      "Regrouping consecutive terms of a convergent series"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pairing",
+      "title": "The paired term and the pairing identity",
+      "startLine": 38,
+      "endLine": 56,
+      "summary": "pairTerm k := 1/((2k+1)(2k+2)) is nonnegative (pairTerm_nonneg). altTerm_pair proves the key algebraic collapse (−1)^{2k}/(2k+1) + (−1)^{2k+1}/(2k+2) = 1/(2k+1) − 1/(2k+2) = 1/((2k+1)(2k+2)), reducing two alternating terms to one positive term.",
+      "mathContext": "$\\varphi$-free: $\\frac{1}{2k+1}-\\frac{1}{2k+2}=\\frac{1}{(2k+1)(2k+2)}$."
+    },
+    {
+      "id": "partial-sums",
+      "title": "Paired partial sums = even alternating partial sums",
+      "startLine": 57,
+      "endLine": 83,
+      "summary": "sum_pairTerm_eq: by induction (peeling two terms via Finset.sum_range_succ and altTerm_pair), ∑_{k<N} pairTerm k = altPartial (2N). tendsto_sum_pairTerm then composes the parent's altHarmonic_tendsto_log_two with N ↦ 2N → ∞ to conclude the paired partial sums tend to log 2.",
+      "mathContext": "$\\sum_{k<N}\\frac{1}{(2k+1)(2k+2)} = \\mathrm{altPartial}(2N) \\to \\log 2$."
+    },
+    {
+      "id": "summability-value",
+      "title": "Absolute summability and the value log 2",
+      "startLine": 84,
+      "endLine": 103,
+      "summary": "summable_pairTerm: the paired partial sums are monotone (positive terms) and ≤ their limit log 2 (Monotone.ge_of_tendsto), so summable_of_sum_range_le gives Summable pairTerm. hasSum_pairTerm_log_two / tsum_pairTerm: HasSum.tendsto_sum_nat plus uniqueness of limits fix ∑' pairTerm = log 2 — an honest absolutely-convergent value, unlike the parent's conditional-only limit.",
+      "mathContext": "$\\sum_k \\frac{1}{(2k+1)(2k+2)} = \\log 2$ (absolutely convergent)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-03",
+      "relationship": "extends",
+      "description": "Regroups the parent's conditionally convergent alternating harmonic series into a positive, absolutely convergent series with the same sum log 2, giving log 2 an honest HasSum/tsum representation."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 103,
+    "namespace": "HarmonicAlt",
+    "opens": ["Filter", "Finset"],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": ["Mathlib", "Proofs.HarmonicDivergenceOQ03"],
+    "path": "Proofs/HarmonicDivergenceOQ03OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 1
+  },
+  "conclusion": {
+    "summary": "Pairing consecutive terms of the conditionally convergent alternating harmonic series yields a positive, absolutely convergent series with the same sum: ∑ₖ 1/((2k+1)(2k+2)) = log 2. Fully machine-checked (0 sorries, 0 axioms), the paired partial sums equal the even alternating partial sums, converge to log 2, and — being monotone and bounded — are summable, giving log 2 an honest HasSum/tsum value.",
+    "implications": "Exhibits the robust, absolutely convergent face of the Mercator constant: whereas the alternating series' value is a delicate boundary limit (Abel's theorem, ¬Summable), its consecutive-pair regrouping is an ordinary positive p-series-dominated sum. The pairing-as-subsequence technique transfers the value with no re-derivation and generalizes to any convergent alternating series with monotone terms.",
+    "openQuestions": [
+      "Give the analogous positive-series regrouping of Leibniz's series π/4 = ∑ (−1)ⁿ/(2n+1) into ∑ 1/((4k+1)(4k+3)) and prove it sums to π/8.",
+      "State the general lemma: for antitone aₙ → 0, the consecutive-pair regrouping of ∑ (−1)ⁿ aₙ is absolutely convergent with the same sum, and derive both log 2 and π/8 as instances.",
+      "Relate ∑ 1/((2k+1)(2k+2)) = log 2 to the digamma/Beta representation 1/((2k+1)(2k+2)) = ∫₀¹ x^{2k}(1−x) dx and recover log 2 = ∫₀¹ 1/(1+x) dx by interchange."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "hasSum_pairTerm_log_two",
+      "type": "core",
+      "description": "The positive series ∑ 1/((2k+1)(2k+2)) has honest HasSum value log 2 (PROVED, 0 axioms)",
+      "leanType": "HasSum pairTerm (Real.log 2)"
+    },
+    {
+      "name": "tsum_pairTerm",
+      "type": "core",
+      "description": "tsum form: ∑' k, 1/((2k+1)(2k+2)) = log 2 (PROVED, 0 axioms)",
+      "leanType": "∑' k, pairTerm k = Real.log 2"
+    },
+    {
+      "name": "sum_pairTerm_eq",
+      "type": "core",
+      "description": "The N-th paired partial sum equals the 2N-th alternating partial sum altPartial(2N) (PROVED, 0 axioms)",
+      "leanType": "∀ N : ℕ, ∑ k ∈ Finset.range N, pairTerm k = altPartial (2 * N)"
+    },
+    {
+      "name": "summable_pairTerm",
+      "type": "supporting",
+      "description": "The positive regrouped series is (absolutely) summable — monotone bounded partial sums (PROVED, 0 axioms)",
+      "leanType": "Summable pairTerm"
+    },
+    {
+      "name": "altTerm_pair",
+      "type": "supporting",
+      "description": "Pairing identity: two consecutive alternating terms collapse to one positive term (PROVED, 0 axioms)",
+      "leanType": "∀ k : ℕ, altTerm (2*k) + altTerm (2*k+1) = pairTerm k"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New child gallery entry answering an open question of `harmonic-divergence-oq-03` (the alternating harmonic series `1 − 1/2 + 1/3 − ⋯ = log 2`, which converges only **conditionally** — it is `¬ Summable`).

Pairing consecutive terms `(1 − 1/2) + (1/3 − 1/4) + ⋯` gives a **positive-term, absolutely convergent** series with the *same* sum:

$$\sum_{k} \frac{1}{(2k+1)(2k+2)} = \log 2.$$

Since `1/((2k+1)(2k+2)) = O(1/k²)`, this regrouped series has an honest `HasSum`/`tsum` value — unlike its alternating parent.

## Proof (`Proofs/HarmonicDivergenceOQ03OQ01.lean`, 103 L, 7 thm / 1 def / 0 axiom, imports the parent)

- `altTerm_pair` — the consecutive pair collapses: `(−1)^{2k}/(2k+1) + (−1)^{2k+1}/(2k+2) = 1/(2k+1) − 1/(2k+2) = 1/((2k+1)(2k+2))`.
- `sum_pairTerm_eq` (induction) — the `N`-th paired partial sum is **exactly** the `2N`-th alternating partial sum `altPartial (2N)`. Pairing is a *subsequence*, not a rearrangement, so the value transfers with no re-derivation.
- `tendsto_sum_pairTerm` — compose the parent's `altHarmonic_tendsto_log_two` with `N ↦ 2N → ∞`.
- `summable_pairTerm` — positivity makes the partial sums monotone, so `Monotone.ge_of_tendsto` bounds each by its limit `log 2` and `summable_of_sum_range_le` gives summability **with no comparison series or index shift**.
- `hasSum_pairTerm_log_two` / `tsum_pairTerm` — `HasSum.tendsto_sum_nat` + uniqueness of limits fix `∑' pairTerm = log 2`.

## Axioms

`#print axioms` on `hasSum_pairTerm_log_two`, `summable_pairTerm`, `sum_pairTerm_eq` → `[propext, Classical.choice, Quot.sound]` only. Verified with `lake env lean` against Mathlib v4.26.0 (builds clean, exit 0, no `sorry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)