### PR TITLE
Fix: correct stale lineCount 482→485 for erdos-100

### DIFF
--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/100",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 482,
+    "lineCount": 485,
     "assumptions": "2 axioms: guthKatz_distinct_distances (Guth-Katz 2015: at least cn/log n distinct distances), piepmeyer_construction (9-point integer-distance set with diameter < 5). All other named results are theorems proved from these axioms plus the bridge lemma distinctDistances_le_diam. Kanold's n^(3/4) bound is referenced in commentary only (not formally declared); the Erdős-Anning theorem is motivated via the IsCollinear definition but its proof is outside scope. 0 sorries.",
     "mathlibDependencies": [
       {
@@ -287,7 +287,7 @@
       "Topology"
     ],
     "namespace": "Erdos100",
-    "lineCount": 482,
+    "lineCount": 485,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Correct the stale `lineCount` for `erdos-100` in both the top-level `meta` block and the nested `leanFile` block.

## Evidence

**Before**: `lineCount` = 482 (both `meta` and `leanFile`)
**After**: `lineCount` = 485 (`wc -l proofs/Proofs/Erdos100Problem.lean` = 485)

Commit #33019 (`repair broken parent + child, add gap-separation theorem`) grew the file by 3 lines but did not update `lineCount`. All other counts already match the source and are untouched: theoremCount 14, definitionCount 9, axiomCount 2, sorries 0.

Single-value metadata fix, no Lean source changes.

---
Automated fix by lean-mechanic agent.