### PR TITLE
Enrich centered-hexagonal-sum-oq-01-oq-02: add annotation coverage (0→10)

### DIFF
--- a/src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "chex-oq0102-ann-header",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 50 },
+    "type": "concept",
+    "title": "From an algebraic identity to a counting proof",
+    "content": "The parent entry proves $\\sum_{k=1}^{n} H_k = n^3$ (with $H_k = 3k(k-1)+1$ the $k$-th centered hexagonal number) algebraically by telescoping. This file promotes it to a genuine combinatorial counting proof: since $H_k = k^3 - (k-1)^3$, the hexagonal numbers are the sizes of the nested cubic shells $C_k = \\{0,\\dots,k-1\\}^3 \\setminus \\{0,\\dots,k-2\\}^3$. Exhibiting the shells as a disjoint decomposition of the full lattice cube turns the identity into a structural fact read off from `Finset.card_biUnion`.",
+    "mathContext": "$\\sum_{k=1}^{n} H_k = n^3, \\qquad H_k = 3k(k-1)+1 = k^3 - (k-1)^3$",
+    "significance": "supporting",
+    "relatedConcepts": ["figurate numbers", "combinatorial proof", "cubic shells", "OEIS A003215"],
+    "prerequisites": ["centered hexagonal numbers", "telescoping sums"]
+  },
+  {
+    "id": "chex-oq0102-ann-centeredhex",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 63 },
+    "type": "definition",
+    "title": "The centered hexagonal number and its reindexing",
+    "content": "`centeredHex k = 3*k*(k-1)+1` restates $H_k$ self-containedly. The reindexed form `centeredHex_succ` computes $H_{k+1} = 3(k+1)k + 1$: shifting the summation index by one turns the truncated ℕ subtraction `(k+1) - 1` into the honest `k`, which is what lets the later per-shell cardinality avoid ℕ-subtraction pitfalls.",
+    "mathContext": "$H_k = 3k(k-1)+1, \\qquad H_{k+1} = 3(k+1)k + 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["natural-number subtraction", "reindexing"],
+    "prerequisites": ["ℕ truncated subtraction"]
+  },
+  {
+    "id": "chex-oq0102-ann-cube",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "definition",
+    "title": "The lattice cube and its cardinality k³",
+    "content": "`cube k = range k ×ˢ range k ×ˢ range k` encodes $\\{0,\\dots,k-1\\}^3$ as a `Finset (ℕ × ℕ × ℕ)`. `mem_cube` unfolds membership to the conjunction of three coordinate bounds `< k`, and `card_cube` gives $|\\texttt{cube}\\,k| = k^3$ from `Finset.card_product`/`card_range` — the fundamental count both endpoints of the shell difference rely on.",
+    "mathContext": "$\\texttt{cube}\\,k = \\{0,\\dots,k-1\\}^3, \\qquad |\\texttt{cube}\\,k| = k^3$",
+    "significance": "supporting",
+    "relatedConcepts": ["finite product of finsets", "lattice points", "Cartesian power"],
+    "prerequisites": ["Finset.product", "Finset.range"]
+  },
+  {
+    "id": "chex-oq0102-ann-nested",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 82 },
+    "type": "tactic",
+    "title": "The cubes are nested",
+    "content": "`cube_subset_succ` shows $\\texttt{cube}\\,k \\subseteq \\texttt{cube}(k+1)$: rewriting both memberships to coordinate bounds via `mem_cube`, the inclusion is a one-line `omega`. This nesting is exactly what makes the shell `cube (k+1) \\ cube k` a clean set difference with computable cardinality.",
+    "mathContext": "$\\texttt{cube}\\,k \\subseteq \\texttt{cube}(k+1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["nested sets", "monotonicity"],
+    "prerequisites": ["Finset subset", "omega tactic"]
+  },
+  {
+    "id": "chex-oq0102-ann-shell-def",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 84, "endLine": 86 },
+    "type": "definition",
+    "title": "The k-th cubic shell as a set difference",
+    "content": "`cubeShell k = cube (k+1) \\ cube k` peels off the outer layer of the cube. The index is chosen so that `cubeShell k` has cardinality $H_{k+1}$ — indexing by the *outer* cube keeps the summand honest and avoids ℕ subtraction in the index.",
+    "mathContext": "$C_k = \\texttt{cube}(k+1) \\setminus \\texttt{cube}\\,k$",
+    "significance": "key",
+    "relatedConcepts": ["set difference", "cubic shell", "level set"],
+    "prerequisites": ["Finset.sdiff"]
+  },
+  {
+    "id": "chex-oq0102-ann-mem-shell",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "insight",
+    "title": "The combinatorial heart: shells are ℓ∞ level sets",
+    "content": "`mem_cubeShell` is the crux: a lattice point $p$ lies in `cubeShell k` iff $\\max(p_1,p_2,p_3) = k$. So the cubic shells are precisely the level sets of the ℓ∞ (Chebyshev / sup-norm) radius — this maximum is the explicit map assigning each cube point to its shell. After unfolding `mem_sdiff` and `mem_cube`, the equivalence is discharged entirely by `omega`.",
+    "mathContext": "$p \\in C_k \\iff \\max(p_1,p_2,p_3) = k$",
+    "significance": "key",
+    "relatedConcepts": ["sup-norm", "Chebyshev distance", "level set", "shell-assignment map"],
+    "prerequisites": ["ℓ∞ norm", "max on ℕ", "Finset.mem_sdiff"]
+  },
+  {
+    "id": "chex-oq0102-ann-card-shell",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "insight",
+    "title": "Per-shell cardinality: |C_k| = H_{k+1}",
+    "content": "`card_cubeShell` matches each shell to a hexagonal number: since the cubes are nested, `Finset.card_sdiff_of_subset` gives $|C_k| = (k+1)^3 - k^3$, and $(k+1)^3 = k^3 + (3(k+1)k+1)$ (a `ring` identity, closed by `omega`) makes this exactly $H_{k+1}$. This is the one-to-one correspondence 'shell $\\leftrightarrow$ summand' that powers the counting proof.",
+    "mathContext": "$|C_k| = (k+1)^3 - k^3 = 3(k+1)k + 1 = H_{k+1}$",
+    "significance": "key",
+    "relatedConcepts": ["card_sdiff", "difference of cubes"],
+    "prerequisites": ["cardinality of set difference", "ring/omega"]
+  },
+  {
+    "id": "chex-oq0102-ann-disjoint",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 106, "endLine": 113 },
+    "type": "tactic",
+    "title": "Distinct shells are disjoint",
+    "content": "`cubeShell_disjoint` shows $C_i \\cap C_j = \\varnothing$ for $i \\neq j$. A point in both shells would have ℓ∞-radius simultaneously $i$ and $j$ (by `mem_cubeShell`), impossible since the radius is single-valued — `omega` closes the contradiction. Disjointness is what upgrades the sum of shell sizes to the size of their union.",
+    "mathContext": "$i \\neq j \\implies C_i \\cap C_j = \\varnothing$",
+    "significance": "supporting",
+    "relatedConcepts": ["pairwise disjoint", "single-valued map"],
+    "prerequisites": ["Finset.disjoint_left"]
+  },
+  {
+    "id": "chex-oq0102-ann-biunion",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 126 },
+    "type": "insight",
+    "title": "The shells reassemble the whole cube",
+    "content": "`cube_eq_biUnion` proves $\\texttt{cube}\\,n = \\bigcup_{k<n} C_k$. Forward: any cube point sits in the shell of its ℓ∞-radius $\\max(p_1,p_2,p_3)$, and that radius is $< n$. Backward: membership in some shell with index $< n$ forces all coordinates $< n$. Both directions reduce to `omega` after unfolding `mem_biUnion`, `mem_cubeShell`, and `mem_cube`.",
+    "mathContext": "$\\texttt{cube}\\,n = \\bigcup_{k<n} C_k$",
+    "significance": "key",
+    "relatedConcepts": ["biUnion", "partition", "total decomposition"],
+    "prerequisites": ["Finset.biUnion", "set extensionality"]
+  },
+  {
+    "id": "chex-oq0102-ann-main",
+    "proofId": "centered-hexagonal-sum-oq-01-oq-02",
+    "range": { "startLine": 128, "endLine": 146 },
+    "type": "insight",
+    "title": "The counting proof of ∑ H_{k+1} = n³",
+    "content": "`sum_centeredHex_range_bijective` assembles the pieces with no algebraic telescoping. A `calc` chain rewrites each summand as a shell cardinality (`card_cubeShell`), applies `Finset.card_biUnion` on the disjoint family (`cubeShell_disjoint` supplies the `PairwiseDisjoint` hypothesis) to collapse the sum into the cardinality of the union, identifies the union with the full cube (`cube_eq_biUnion`), and reads off $n^3$ (`card_cube`). The identity emerges purely from the disjoint shell decomposition — the 'proof from the book' for this figurate sum.",
+    "mathContext": "$\\sum_{k<n} H_{k+1} = \\Big|\\bigcup_{k<n} C_k\\Big| = |\\texttt{cube}\\,n| = n^3$",
+    "significance": "critical",
+    "relatedConcepts": ["card_biUnion", "bijective proof", "partition counting"],
+    "prerequisites": ["Finset.card_biUnion", "PairwiseDisjoint", "calc proofs"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `centered-hexagonal-sum-oq-01-oq-02` (Centered Hexagonal Sum = n³, the shell-counting proof).

**Gap:** rich `meta.json` but **no `annotations.json`** — zero inline coverage of the 149-line Lean file.

**Change:** author **10 non-overlapping annotations** covering the whole proof:
- Header: promoting the algebraic identity to a combinatorial counting proof
- `centeredHex` + reindexing `H_{k+1}`
- The lattice `cube` (`card = k³`), membership, and nesting
- `cubeShell` as a set difference
- `mem_cubeShell`: the ℓ∞-level-set heart (shells = level sets of the Chebyshev radius)
- Per-shell cardinality `|C_k| = H_{k+1}`
- Shell disjointness and `cube_eq_biUnion`
- `sum_centeredHex_range_bijective`: the `card_biUnion` counting proof

Each annotation carries `mathContext` (LaTeX), canonical `type`/`significance`, `relatedConcepts`, and `prerequisites`; ranges anchored to declaration/section-doc lines. `meta.json` unchanged (already well under size caps).