### PR TITLE
Enrich Lawvere Fixed-Point Theorem (Retraction Version): annotation coverage 17%→58%

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-header-lawvere",
+    "proofId": "cantor-diagonalization-oq-04",
+    "range": {
+      "startLine": 4,
+      "endLine": 36
+    },
+    "type": "context",
+    "title": "Lawvere's Theorem: One Diagonal Behind Them All",
+    "content": "The header frames the unifying thesis of the file: Lawvere's 1969 fixed-point theorem is the single categorical fact behind Cantor's theorem, Gödel's incompleteness, Turing's halting problem, and Russell's paradox. Its slogan — if the exponential $Y^Y$ retracts onto $Y$ (every endomorphism can be named by an element of $Y$ and faithfully recovered), then every endomorphism of $Y$ has a fixed point — turns each classical impossibility into the contrapositive: a type admitting a fixed-point-free endomorphism (successor on $\\mathbb{N}$, negation on Prop) cannot code its own endomorphisms. This entry gives the retraction formulation, complementing the surjection version in CantorDiagonalizationOQ03.",
+    "mathContext": "Lawvere (CCC form): if $Y^Y$ is a retract of $Y$ then every $f\\colon Y\\to Y$ has a fixed point; contrapositively, a fixed-point-free $f$ obstructs any retraction $Y^Y \\to Y$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lawvere fixed-point theorem",
+      "diagonal argument",
+      "cartesian closed category",
+      "Cantor / Gödel / Turing"
+    ],
+    "prerequisites": [
+      "function spaces",
+      "category theory basics"
+    ]
+  },
+  {
     "id": "ann-codes-endomorphisms",
     "proofId": "cantor-diagonalization-oq-04",
     "range": {
@@ -44,6 +67,28 @@
     ]
   },
   {
+    "id": "ann-contrapositive",
+    "proofId": "cantor-diagonalization-oq-04",
+    "range": {
+      "startLine": 105,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "The Impossibility Direction (Contrapositive)",
+    "content": "`no_coding_if_fixpoint_free` is the logical pivot of the whole file: it simply contraposes `lawvere_fixpoint`. If some $f\\colon Y\\to Y$ has no fixed point, then a `CodesEndomorphisms Y` instance would (via the theorem) manufacture one — contradiction. Every concrete impossibility result below (ℕ, Bool, Prop cannot code themselves; the Cantor non-surjection theorems) is obtained by feeding this lemma a specific fixed-point-free endomorphism. Isolating the contrapositive once keeps each application a one-liner.",
+    "mathContext": "$(\\exists\\,\\text{fixed-point-free } f\\colon Y\\to Y) \\Rightarrow \\lnot\\,\\mathrm{CodesEndomorphisms}(Y).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "contrapositive",
+      "proof by contradiction",
+      "fixed-point-free endomorphism"
+    ],
+    "prerequisites": [
+      "Lawvere fixed-point theorem",
+      "logical negation"
+    ]
+  },
+  {
     "id": "ann-surjection-bridge",
     "proofId": "cantor-diagonalization-oq-04",
     "range": {
@@ -64,6 +109,54 @@
     "prerequisites": [
       "surjectivity",
       "classical choice"
+    ]
+  },
+  {
+    "id": "ann-impossibility-types",
+    "proofId": "cantor-diagonalization-oq-04",
+    "range": {
+      "startLine": 148,
+      "endLine": 167
+    },
+    "type": "insight",
+    "title": "Concrete Types That Cannot Code Themselves",
+    "content": "Three familiar types are shown to admit no endomorphism coding, each by exhibiting one fixed-point-free map: successor `Nat.succ` on ℕ (`nat_cannot_code`), boolean negation `!·` on Bool (`bool_cannot_code`, closed by `decide` on two cases), and logical negation `Not` on Prop (`prop_cannot_code`). The Prop case rests on `not_no_fixpoint`, a clean formalization of Russell's paradox: from $\\lnot p = p$ one derives both $p\\to\\lnot p$ and $\\lnot p\\to p$ by `cast`, yielding a self-contradiction. So the same diagonal that powers Cantor also powers Russell.",
+    "mathContext": "$\\mathrm{succ}(n)\\ne n$, $\\lnot b \\ne b$ on Bool, and $(\\lnot p)\\ne p$ on Prop — each a fixed-point-free endomorphism obstructing self-coding.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Russell's paradox",
+      "fixed-point-free maps",
+      "successor function",
+      "logical negation"
+    ],
+    "prerequisites": [
+      "Prop and propositional logic",
+      "cast / type equality",
+      "decide tactic"
+    ]
+  },
+  {
+    "id": "ann-cantor-nonsurjection",
+    "proofId": "cantor-diagonalization-oq-04",
+    "range": {
+      "startLine": 180,
+      "endLine": 203
+    },
+    "type": "insight",
+    "title": "Cantor's Theorem as a Corollary",
+    "content": "`cantor_no_surjection` recovers Cantor's theorem in its sharpest form: whenever the codomain $B$ has a fixed-point-free endomorphism, there is no surjection $A \\to (A \\to B)$ — for *any* $A$. The proof composes `lawvere_fixpoint_of_surjection` (a surjection is a retraction by choice) with the offending endomorphism of $B$. Specializing $B$ gives the familiar instances: no surjection onto the power set $A \\to (A\\to\\mathrm{Prop})$ (`cantor_prop`), none onto $A\\to\\mathrm{Bool}$ (`cantor_bool`), and none onto $A\\to\\mathbb{N}$ (`cantor_nat`). The classical $|A| < |2^A|$ is exactly the Prop case.",
+    "mathContext": "If $\\exists f\\colon B\\to B,\\ \\forall b,\\ f(b)\\ne b$, then $\\lnot\\,\\exists\\,e\\colon A\\to(A\\to B)$ surjective; with $B=\\mathrm{Prop}$ this is $|A|<|\\mathcal{P}(A)|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "power set",
+      "cardinality",
+      "diagonal argument"
+    ],
+    "prerequisites": [
+      "surjectivity",
+      "Lawvere fixed-point theorem",
+      "power set"
     ]
   },
   {
@@ -109,6 +202,30 @@
     "prerequisites": [
       "CodesEndomorphisms",
       "retract property"
+    ]
+  },
+  {
+    "id": "ann-categorical-rightinverse",
+    "proofId": "cantor-diagonalization-oq-04",
+    "range": {
+      "startLine": 254,
+      "endLine": 292
+    },
+    "type": "concept",
+    "title": "Categorical Reading and the Right-Inverse Equivalence",
+    "content": "The closing part interprets the type-theoretic proof as Lawvere's theorem instantiated in the category **Type**: objects are types, morphisms are functions, the exponential $Y^Y$ is the function type $Y\\to Y$, and the argument uses only composition, evaluation, the diagonal $\\Delta$, and currying — all available in any cartesian closed category, so the proof transfers verbatim. `codes_iff_right_inverse` then pins down the abstraction precisely: `Nonempty (CodesEndomorphisms Y)` holds iff the decode map $Y\\to(Y\\to Y)$ has a right inverse (`Function.HasRightInverse`). Coding one's endomorphisms is *exactly* a section of evaluation.",
+    "mathContext": "$\\mathrm{Nonempty}(\\mathrm{CodesEndomorphisms}\\,Y) \\iff \\exists\\,d\\colon Y\\to Y\\to Y,\\ \\mathrm{HasRightInverse}\\,d$; i.e. $Y$ is a retract of $Y^Y$ in a CCC.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cartesian closed category",
+      "exponential object",
+      "right inverse",
+      "retract"
+    ],
+    "prerequisites": [
+      "category theory",
+      "currying and evaluation",
+      "right inverses"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-04` ("Lawvere Fixed-Point Theorem: Retraction Version").

**Gap:** the 304-line file had 5 annotations at ~17% line coverage, leaving the file header, the impossibility direction, all the concrete impossibility results, Cantor's theorem, and the categorical interpretation unannotated.

**Added 5 annotations** (5→10, ~58% coverage), preserving the existing five verbatim:
- **File header** — Lawvere as the single diagonal behind Cantor, Gödel, Turing, and Russell.
- **Contrapositive** (`no_coding_if_fixpoint_free`) — the logical pivot every impossibility result reuses.
- **Concrete non-coding types** — ℕ (successor), Bool (negation), Prop (negation), with `not_no_fixpoint` as a formalization of Russell's paradox.
- **Cantor's theorem** — `cantor_no_surjection` and its Prop/Bool/ℕ instances; the Prop case is $|A|<|\mathcal P(A)|$.
- **Categorical reading** — the CCC interpretation and the `codes_iff_right_inverse` equivalence (self-coding ⟺ decode has a right inverse).

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; ranges sorted and non-overlapping. `meta.json` unchanged.