### PR TITLE
Enrich ballot-problem-oq-05: add annotation coverage (0→9)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-05/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-05/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ballot-oq05-ann-header",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "The ballot problem and the cycle-lemma engine",
+    "content": "Bertrand's ballot problem asks: if candidate $A$ gets $a$ votes and $B$ gets $b<a$, what is the probability $A$ stays strictly ahead throughout the count? The classical answer is $(a-b)/(a+b)$. The combinatorial engine is the Dvoretzky–Motzkin cycle lemma (formalized separately in `BallotProblemOQ01`): for a fixed sequence of $a$ up-steps and $b$ down-steps, exactly $a-b$ of its $a+b$ cyclic rotations stay strictly positive. This file is the *arithmetic* companion — it takes the manifestly-integral reflection form as the definition of the ballot number and derives the defining relation, the probability, and the Catalan specialisation from elementary binomial arithmetic.",
+    "mathContext": "$\\Pr[A \\text{ always ahead}] = \\dfrac{a-b}{a+b}, \\qquad BN(a,b) = \\dfrac{a-b}{a+b}\\binom{a+b}{a}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Bertrand ballot problem", "cycle lemma", "Dvoretzky–Motzkin", "reflection principle"],
+    "prerequisites": ["binomial coefficients", "lattice paths"]
+  },
+  {
+    "id": "ballot-oq05-ann-def",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 44, "endLine": 50 },
+    "type": "definition",
+    "title": "The ballot number in reflection form",
+    "content": "`ballotNumber a b = C(a+b-1, a-1) - C(a+b-1, a)`. Taking the *difference of two binomials* (the reflection form) as the definition makes it manifestly a natural number, sidestepping the division in $(a-b)/(a+b)\\cdot\\binom{a+b}{a}$. The rest of the file proves this coincides with the cycle-lemma count and recovers the probability form.",
+    "mathContext": "$BN(a,b) = \\binom{a+b-1}{a-1} - \\binom{a+b-1}{a}$",
+    "significance": "key",
+    "relatedConcepts": ["reflection form", "André's reflection method", "manifest integrality"],
+    "prerequisites": ["Nat.choose"]
+  },
+  {
+    "id": "ballot-oq05-ann-aux-up",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 52, "endLine": 59 },
+    "type": "tactic",
+    "title": "Absorption 'up': (a+b)·C(a+b−1,a−1) = a·C(a+b,a)",
+    "content": "The first of two absorption identities, written with $a = A+1$ to keep ℕ subtraction honest. It is `Nat.add_one_mul_choose_eq` ($(n+1)\\binom{n}{k} = \\binom{n+1}{k+1}(k+1)$) with $n = A+b$, after rewriting $A+b+1 = A+1+b$ and closing with `ring`.",
+    "mathContext": "$(a+b)\\binom{a+b-1}{a-1} = a\\binom{a+b}{a}$",
+    "significance": "supporting",
+    "relatedConcepts": ["absorption identity", "Nat.add_one_mul_choose_eq"],
+    "prerequisites": ["Pascal absorption rule"]
+  },
+  {
+    "id": "ballot-oq05-ann-aux-down",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 61, "endLine": 79 },
+    "type": "tactic",
+    "title": "Absorption 'down': (a+b)·C(a+b−1,a) = b·C(a+b,a)",
+    "content": "The companion identity, valid for every $b$ (including $b=0$, where both sides vanish). It combines `Nat.choose_succ_right_eq` (relating $\\binom{n}{k+1}(k+1)$ and $\\binom{n}{k}(n-k)$) with the 'up' identity through a `calc` chain, then cancels the common factor $A+1$ via `Nat.eq_of_mul_eq_mul_left`.",
+    "mathContext": "$(a+b)\\binom{a+b-1}{a} = b\\binom{a+b}{a}$",
+    "significance": "supporting",
+    "relatedConcepts": ["absorption identity", "Nat.choose_succ_right_eq", "cancellation"],
+    "prerequisites": ["Pascal absorption rule", "left cancellation in ℕ"]
+  },
+  {
+    "id": "ballot-oq05-ann-mul-aux",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "insight",
+    "title": "Combining the absorptions into the core identity",
+    "content": "`ballotNumber_mul_aux` multiplies the reflection difference by $(a+b)$ and distributes it over the subtraction (`Nat.sub_mul`), letting the two absorption lemmas rewrite each term. The truncated ℕ subtraction makes the resulting identity $\\big(\\binom{a+b}{a}-\\binom{a+b}{a+1}\\big)(a+b) = (a-b)\\binom{a+b}{a}$ hold unconditionally, with no side hypotheses on $b$.",
+    "mathContext": "$\\big(\\binom{A+b}{A}-\\binom{A+b}{A+1}\\big)(A{+}1{+}b) = (A{+}1{-}b)\\binom{A{+}1{+}b}{A{+}1}$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.sub_mul", "truncated subtraction"],
+    "prerequisites": ["distributing over ℕ subtraction"]
+  },
+  {
+    "id": "ballot-oq05-ann-mul-add",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 92, "endLine": 106 },
+    "type": "insight",
+    "title": "The defining relation of the ballot number",
+    "content": "`ballotNumber_mul_add`: for $a \\ge 1$, $BN(a,b)\\,(a+b) = (a-b)\\binom{a+b}{a}$. Writing $a = A+1$ and simplifying the reflection indices reduces it directly to `ballotNumber_mul_aux`. This is exactly the aggregate the cycle lemma produces — summed over all $\\binom{a+b}{a}$ arrangements, the strictly-positive count is $(a-b)/(a+b)\\cdot\\binom{a+b}{a}$ — and in particular it certifies that ratio is a genuine natural number.",
+    "mathContext": "$BN(a,b)\\,(a+b) = (a-b)\\binom{a+b}{a}$",
+    "significance": "critical",
+    "relatedConcepts": ["cycle lemma aggregate", "divisibility", "counting"],
+    "prerequisites": ["existential destructuring a = A+1"]
+  },
+  {
+    "id": "ballot-oq05-ann-div",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 108, "endLine": 130 },
+    "type": "insight",
+    "title": "The Bertrand ballot probability (a−b)/(a+b)",
+    "content": "`ballotNumber_div` divides the defining relation by $\\binom{a+b}{a}$ over ℚ to recover the classical probability. It casts the ℕ identity to ℚ (`push_cast` with `Nat.cast_sub` under $b \\le a$), then clears denominators with `div_eq_div_iff` — both $\\binom{a+b}{a} \\neq 0$ (`Nat.choose_pos`) and $a+b \\neq 0$ are established — and finishes with `linear_combination`.",
+    "mathContext": "$\\dfrac{BN(a,b)}{\\binom{a+b}{a}} = \\dfrac{a-b}{a+b} \\quad \\text{over } \\mathbb{Q}$",
+    "significance": "key",
+    "relatedConcepts": ["probability", "casting ℕ→ℚ", "div_eq_div_iff", "linear_combination"],
+    "prerequisites": ["rational arithmetic", "Nat.cast_sub"]
+  },
+  {
+    "id": "ballot-oq05-ann-catalan",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 132, "endLine": 160 },
+    "type": "insight",
+    "title": "The Catalan specialisation BN(n+1,n) = catalan n",
+    "content": "`ballotNumber_catalan` identifies the diagonal ballot number with the Catalan number counting Dyck paths of semilength $n$. It rewrites $BN(n+1,n) = \\binom{2n}{n} - \\binom{2n}{n+1}$, uses the central-binomial bridge $(n+1)\\,C_n = \\binom{2n}{n}$ (`catalan_eq_centralBinom_div` + `succ_dvd_centralBinom`) and the absorption step $(n+1)\\binom{2n}{n+1} = n\\binom{2n}{n}$, shows $(n+1)\\,BN(n+1,n) = \\binom{2n}{n} = (n+1)\\,C_n$, and cancels $n+1$.",
+    "mathContext": "$BN(n+1,n) = \\binom{2n}{n} - \\binom{2n}{n+1} = C_n = \\dfrac{1}{n+1}\\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "Dyck paths", "central binomial coefficient"],
+    "prerequisites": ["catalan_eq_centralBinom_div", "Nat.centralBinom"]
+  },
+  {
+    "id": "ballot-oq05-ann-examples",
+    "proofId": "ballot-problem-oq-05",
+    "range": { "startLine": 162, "endLine": 174 },
+    "type": "concept",
+    "title": "Worked examples verified by decide",
+    "content": "Four sanity checks close the file, each `decide`-checked (kernel computation, so still 0-axiom): $BN(3,1)=2$, $BN(4,3)=5=C_3$, the tie $BN(5,5)=0$ (no sequence can stay strictly positive when $a=b$), and the all-up case $BN(4,0)=1$ (the single monotone sequence). They confirm the reflection form reproduces the expected ballot counts.",
+    "mathContext": "$BN(3,1)=2,\\ BN(4,3)=5,\\ BN(5,5)=0,\\ BN(4,0)=1$",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "sanity checks", "boundary cases"],
+    "prerequisites": ["decidable equality on ℕ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-05` (Bertrand ballot number via the cycle lemma).

**Gap:** rich `meta.json` but **no `annotations.json`** — zero inline coverage of the 176-line file.

**Change:** author **9 non-overlapping annotations** covering the whole file:
- Header: the ballot problem and the Dvoretzky–Motzkin cycle-lemma engine
- `ballotNumber` reflection-form definition (manifest integrality)
- The two absorption identities `aux_up` / `aux_down`
- `ballotNumber_mul_aux` (core identity) and `ballotNumber_mul_add` (defining relation)
- `ballotNumber_div` (ballot probability over the rationals)
- `ballotNumber_catalan` (Catalan specialisation)
- The `decide`-checked worked examples

Each carries `mathContext` (LaTeX), canonical `type`/`significance`, `relatedConcepts`, `prerequisites`; ranges anchored to declaration/section-doc lines. `meta.json` unchanged.