### PR TITLE
Enrich Undecidability of the Totality Problem (Rice's Theorem): annotation coverage 20%→79%

### DIFF
--- a/src/data/proofs/halting-problem-oq-02/annotations.json
+++ b/src/data/proofs/halting-problem-oq-02/annotations.json
@@ -1,8 +1,35 @@
 [
   {
+    "id": "ann-header-rice",
+    "proofId": "halting-problem-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 50
+    },
+    "type": "context",
+    "title": "Rice's Theorem and the Totality Problem",
+    "content": "The header states the open question and its answer: the totality set $\\mathrm{TOT}=\\{c \\mid \\forall n,\\ \\text{program } c \\text{ halts on } n\\}$ is not computable. It is the archetypal application of Rice's theorem (1953): *every* nontrivial semantic (extensional) property of the partial function computed by a program is undecidable. Totality qualifies because it depends only on $\\mathrm{eval}\\,c$ (not on the code) and is nontrivial (some programs are total, some are not). The file works in Mathlib's standard model `Nat.Partrec.Code` with universal evaluator `Code.eval`, where \"halts on $n$\" is `(eval c n).Dom`. The honesty note records what is *not* proved: totality is $\\Pi_2$-complete (neither c.e. nor co-c.e.), a sharper classification left open here.",
+    "mathContext": "$\\mathrm{TOT}=\\{c \\mid \\forall n,\\ (\\mathrm{eval}\\,c\\,n).\\mathrm{Dom}\\}$ is undecidable; it is in fact $\\Pi_2$-complete.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Rice's theorem",
+      "halting problem",
+      "semantic property",
+      "arithmetical hierarchy"
+    ],
+    "prerequisites": [
+      "computability theory",
+      "partial recursive functions",
+      "decidability"
+    ]
+  },
+  {
     "id": "ann-totality-property",
     "proofId": "halting-problem-oq-02",
-    "range": { "startLine": 59, "endLine": 61 },
+    "range": {
+      "startLine": 59,
+      "endLine": 61
+    },
     "type": "definition",
     "title": "Totality as a Semantic Property",
     "content": "`totalFns` is the set of partial functions defined on **every** input. It is a property of the *function* `eval c`, not of the code `c` — this extensionality is what makes Rice's theorem applicable. A code is total exactly when its evaluated partial function lies in this set.",
@@ -21,7 +48,10 @@
   {
     "id": "ann-nontriviality-witnesses",
     "proofId": "halting-problem-oq-02",
-    "range": { "startLine": 63, "endLine": 70 },
+    "range": {
+      "startLine": 63,
+      "endLine": 70
+    },
     "type": "insight",
     "title": "Two Witnesses Make the Property Nontrivial",
     "content": "Rice's theorem needs the property to be **neither always true nor always false**. Two witnesses supply exactly this: the identity function `fun n => Part.some n` is total, and the everywhere-divergent function `fun _ => Part.none` is not. Both are partial recursive, so by `exists_code` each is `eval` of some code — giving a total code and a non-total code.",
@@ -40,7 +70,10 @@
   {
     "id": "ann-main-rice",
     "proofId": "halting-problem-oq-02",
-    "range": { "startLine": 82, "endLine": 85 },
+    "range": {
+      "startLine": 82,
+      "endLine": 85
+    },
     "type": "insight",
     "title": "Undecidability via Rice's Theorem",
     "content": "The main theorem: no algorithm decides totality. `ComputablePred.rice` says a computable extensional property holding of *some* partial function holds of *every* one. Applied with the total witness as `f ∈ C`, it would force the everywhere-divergent function into `totalFns` — i.e. `(Part.none).Dom`, which is `False`. That contradiction refutes decidability.",
@@ -57,9 +90,36 @@
     ]
   },
   {
+    "id": "ann-totalcodes-machinery",
+    "proofId": "halting-problem-oq-02",
+    "range": {
+      "startLine": 87,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "Code-Level Extensionality and Nontriviality",
+    "content": "To apply `rice₂` (the code-set form of Rice's theorem) the file must show `TotalCodes` is extensional and nontrivial. Extensionality (`totalCodes_extensional`) is immediate: membership is defined through `eval c`, so equal evaluators give equal membership — a one-line `simp` rewriting by the hypothesis `eval cf = eval cg`. Nontriviality (`totalCodes_nontrivial`) is the substantive step: it must exhibit an actual total *code* and an actual non-total *code*, which it does by pulling the two function-level witnesses (`Nat.Partrec.some`, `Nat.Partrec.none`) back through `exists_code`, the theorem that every partial recursive function has an index. This is where the abstract function-level property is grounded in the concrete indexing.",
+    "mathContext": "$\\mathrm{eval}\\,cf=\\mathrm{eval}\\,cg \\Rightarrow (cf\\in\\mathrm{TotalCodes}\\iff cg\\in\\mathrm{TotalCodes})$; and $\\mathrm{TotalCodes}\\ne\\varnothing,\\ \\ne\\mathrm{univ}$ via `exists_code`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "extensional set of codes",
+      "exists_code",
+      "index invariance",
+      "rice₂ hypotheses"
+    ],
+    "prerequisites": [
+      "Nat.Partrec.Code",
+      "partial recursive functions",
+      "set extensionality"
+    ]
+  },
+  {
     "id": "ann-code-level-rice2",
     "proofId": "halting-problem-oq-02",
-    "range": { "startLine": 116, "endLine": 123 },
+    "range": {
+      "startLine": 116,
+      "endLine": 123
+    },
     "type": "tactic",
     "title": "Code-Level Form via rice₂",
     "content": "`ComputablePred.rice₂` characterises the computable extensional code-sets as **exactly** `∅` and `Set.univ`. So proving `TotalCodes` undecidable reduces to showing it is extensional (`totalCodes_extensional`, by `simp` with the eval-equality) and neither trivial (`totalCodes_nontrivial`, from the two witnesses via `exists_code`). The `rcases` on the disjunction discharges both trivial cases.",
@@ -76,9 +136,35 @@
     ]
   },
   {
+    "id": "ann-emptyfns-witnesses",
+    "proofId": "halting-problem-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 135
+    },
+    "type": "definition",
+    "title": "The Emptiness Property and Its Witnesses",
+    "content": "The dual construction: `emptyFns` is the property that $f$ diverges *everywhere* (`∀ n, ¬(f n).Dom`). Its two nontriviality witnesses are the mirror image of totality's — the everywhere-divergent function `Part.none` *is* empty (`none_mem_emptyFns`), while the identity function is *not* empty since it halts (`some_notMem_emptyFns`). Swapping the roles of `some` and `none` is exactly what turns the totality argument into the emptiness argument in the next theorem.",
+    "mathContext": "$\\mathrm{emptyFns}=\\{f \\mid \\forall n,\\ \\lnot(f\\,n).\\mathrm{Dom}\\}$; witnessed satisfiable by $n\\mapsto\\bot$ and non-universal by the identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "duality",
+      "divergence",
+      "nontriviality",
+      "Rice's theorem"
+    ],
+    "prerequisites": [
+      "partial functions",
+      "Part.none / Part.some"
+    ]
+  },
+  {
     "id": "ann-emptiness-dual",
     "proofId": "halting-problem-oq-02",
-    "range": { "startLine": 137, "endLine": 142 },
+    "range": {
+      "startLine": 137,
+      "endLine": 142
+    },
     "type": "concept",
     "title": "The Dual: the Emptiness Problem",
     "content": "Swapping the two witnesses gives the dual Rice instance: deciding whether a program halts on **no** input is also undecidable. The everywhere-divergent function witnesses satisfiability and the identity function witnesses non-triviality — the mirror image of the totality argument.",


### PR DESCRIPTION
Enrichment pass for `halting-problem-oq-02` ("Undecidability of the Totality Problem, a Rice's Theorem Instance").

**Gap:** the 144-line file had 5 annotations at ~20% coverage; the header, the code-level `rice₂` machinery, and the emptiness-dual definitions were unannotated.

**Added 3 annotations** (5→8, ~79% coverage), preserving the existing five verbatim:
- **File header** — Rice's theorem framing, the totality set $\mathrm{TOT}$, and the honesty note that totality is $\Pi_2$-complete (not established here).
- **Code-level machinery** — extensionality (one-line `simp`) and nontriviality (pulling the function-level witnesses back through `exists_code`) that feed `rice₂`.
- **Emptiness property** — the dual definitions `emptyFns` and its two witnesses, mirroring totality with `some`/`none` swapped.

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; ranges sorted and non-overlapping. `meta.json` unchanged.