### PR TITLE
Enrich lagrange-four-squares-oq-03-oq-01: add annotation coverage (0 to 9)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-oq-03-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "lag4sq-oq0301-ann-header",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 7, "endLine": 41 },
+    "type": "concept",
+    "title": "Sharpening g(4) ≤ 53 to g(4) ≤ 50 by residue borrowing",
+    "content": "Waring's constant $g(4)$ is the least $k$ such that every natural number is a sum of $k$ fourth powers. The parent proves $g(4) \\le 53$ crudely: $N = 6Q + r$ costs $48$ powers for the block $6Q$ plus up to $5$ unit powers for $r = N\\bmod 6$. This file keeps the same Liouville engine but pays each residue class off by *borrowing one small fourth power* ($1^4, 2^4=16, 3^4=81$), capping every branch at $\\le 50$. The finitely many $N < 81$ use a base-16 fallback. The true value is $g(4)=19$ (Hardy–Littlewood circle method), but $50$ is the sharp bound reachable by a self-contained, axiom-free Lagrange+Liouville argument.",
+    "mathContext": "$g(4) \\le 50 < 53; \\qquad N \\equiv r \\pmod 6 \\Rightarrow N = (\\text{borrow}) + 6Q$",
+    "significance": "key",
+    "relatedConcepts": ["Waring's problem", "g(4)", "Liouville's identity", "residue classes"],
+    "prerequisites": ["sums of powers", "modular arithmetic"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-liouville",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 47, "endLine": 58 },
+    "type": "insight",
+    "title": "Liouville's identity: 6(a²+b²+c²+d²)² as 12 fourth powers",
+    "content": "The algebraic core, proved over ℤ by a single `ring` call: $6(a^2+b^2+c^2+d^2)^2$ expands into a sum of twelve fourth powers of the pairwise sums/differences $a\\pm b, a\\pm c, \\dots$. `cast_natAbs_pow4` handles the difference terms $a-b$ that may be negative: $(|z|)^4 = z^4$, so each summand is a genuine natural fourth power. This is the bridge from squares (Lagrange) to fourth powers (Waring).",
+    "mathContext": "$6(a^2+b^2+c^2+d^2)^2 = \\sum_{\\text{12 pairs}} (a\\pm b)^4 + \\cdots$",
+    "significance": "critical",
+    "relatedConcepts": ["Liouville's identity", "polynomial identity", "Int.natAbs"],
+    "prerequisites": ["ring tactic", "integer casts"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-predicate",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 60, "endLine": 97 },
+    "type": "definition",
+    "title": "The representation predicate and its closure lemmas",
+    "content": "`IsSumOfFourthPowers k n` means $n = \\sum_{i} l_i^4$ for a length-$k$ list (zero summands allowed, so it really means 'at most $k$ powers'). The namespace bundles the algebra: `zero`/`single` (base cases), `append` (concatenation gives $k_1{+}k_2$ powers for $x{+}y$), `zeros` (0 as any number of powers), `succ` (pad by one zero), and crucially `le` — monotonicity in the summand count, padding with $k'-k$ zeros. `le` is what lets every branch be inflated to exactly 50.",
+    "mathContext": "$\\texttt{IsSumOfFourthPowers}\\,k\\,n \\iff \\exists l,\\ |l|=k \\wedge \\textstyle\\sum_i l_i^4 = n$",
+    "significance": "supporting",
+    "relatedConcepts": ["existential predicate", "List.sum", "monotonicity"],
+    "prerequisites": ["Lists in Lean", "List.map / List.sum"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-sixmulsq",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 101, "endLine": 116 },
+    "type": "insight",
+    "title": "The Liouville step: 6m² as 12 fourth powers",
+    "content": "`sixMulSq_isSum` instantiates Liouville's identity with an explicit 12-element witness list, discharging the arithmetic by casting to ℤ and `linear_combination` against `liouville_identity`. Then `sixMulSq` feeds Lagrange's four-square theorem (`Nat.sum_four_squares`, writing $m = a^2+b^2+c^2+d^2$) into it, giving $6m^2$ as 12 fourth powers for every natural $m$.",
+    "mathContext": "$6m^2 = 6(a^2+b^2+c^2+d^2)^2 \\Rightarrow \\text{12 fourth powers}$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange four-square theorem", "Nat.sum_four_squares", "linear_combination"],
+    "prerequisites": ["four-square theorem", "witness lists"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-sixmul",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 118, "endLine": 126 },
+    "type": "insight",
+    "title": "The engine: every 6Q is a sum of 48 fourth powers",
+    "content": "`sixMul` is the workhorse. Applying Lagrange to $Q = a^2+b^2+c^2+d^2$ turns $6Q$ into $6a^2 + 6b^2 + 6c^2 + 6d^2$; four copies of `sixMulSq` (12 powers each) `append` to $4\\times 12 = 48$ fourth powers. Every multiple of six is thus cheaply representable — the fixed cost that all residue branches build on.",
+    "mathContext": "$6Q = 6a^2+6b^2+6c^2+6d^2 \\Rightarrow 48 \\text{ fourth powers}$",
+    "significance": "key",
+    "relatedConcepts": ["Liouville engine", "append", "four-square decomposition"],
+    "prerequisites": ["Nat.sum_four_squares"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-blocks",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 128, "endLine": 148 },
+    "type": "tactic",
+    "title": "Small-power building blocks",
+    "content": "The pieces borrowed to pay off residues: `ones k` realises $k$ as $k$ copies of $1^4=1$; `twos a` realises $16a$ as $a$ copies of $2^4=16$; `twoPow16` and `threePow81` note that $16=2^4$ and $81=3^4$ are single fourth powers. Each is a `List.replicate` witness simplified by `List.sum_replicate`. These are the cheap adjustments that shave the parent's 53 down to 50.",
+    "mathContext": "$k = \\underbrace{1^4+\\cdots+1^4}_{k}, \\quad 16a = \\underbrace{2^4+\\cdots+2^4}_{a}, \\quad 16=2^4,\\ 81=3^4$",
+    "significance": "supporting",
+    "relatedConcepts": ["List.replicate", "unit fourth powers"],
+    "prerequisites": ["List.sum_replicate"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-small",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 150, "endLine": 155 },
+    "type": "tactic",
+    "title": "Base-16 fallback for N < 81",
+    "content": "`small` handles the finitely many numbers the borrowing cannot reach. The greedy base-16 representation $N = (N/16)\\cdot 2^4 + (N\\bmod 16)\\cdot 1^4$ uses $N/16 + N\\bmod 16 \\le 5 + 15 = 20 \\le 50$ fourth powers for every $N < 81$. Built by `append`-ing `twos (N/16)` and `ones (N%16)`, then inflated to 50 via `le`.",
+    "mathContext": "$N = \\lfloor N/16\\rfloor\\, 2^4 + (N\\bmod 16)\\,1^4, \\quad \\lfloor N/16\\rfloor + N\\bmod 16 \\le 20$",
+    "significance": "supporting",
+    "relatedConcepts": ["greedy representation", "base-16", "finite fallback"],
+    "prerequisites": ["Euclidean division", "omega"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-main",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 157, "endLine": 187 },
+    "type": "insight",
+    "title": "Main theorem: g(4) ≤ 50 via a residue case split",
+    "content": "`waring_four_fifty`: every $N$ is a sum of at most 50 fourth powers. For $N < 81$ it invokes `small`; otherwise it splits on $N\\bmod 6$ (six cases via `omega`) and applies the borrowing table — $6Q$ (48), $6Q+1^4$ (49), $6Q+2\\cdot 1^4$ (50), $3^4+6Q$ (49), $2^4+6Q$ (49), $2^4+6Q+1^4$ (50) — each inflated to exactly 50 by `le`. The `omega`-verified rewrites $N = 6(N/6)+r$ (with the $\\ge 81$ threshold ensuring the borrowed power fits) drive every branch.",
+    "mathContext": "$\\forall N,\\ \\texttt{IsSumOfFourthPowers}\\,50\\,N$",
+    "significance": "critical",
+    "relatedConcepts": ["case analysis mod 6", "Waring bound", "borrowing argument"],
+    "prerequisites": ["omega", "modular case split"]
+  },
+  {
+    "id": "lag4sq-oq0301-ann-existential",
+    "proofId": "lagrange-four-squares-oq-03-oq-01",
+    "range": { "startLine": 189, "endLine": 193 },
+    "type": "concept",
+    "title": "Restatement: a bound G < 53 exists",
+    "content": "`waring_four_lt_53` repackages the result as a bare existential — there is a $G < 53$ (namely 50) with every $N$ a sum of $G$ fourth powers — making explicit that this strictly improves the parent's constant. It unfolds the representation predicate to its raw list form for a self-contained statement.",
+    "mathContext": "$\\exists G < 53,\\ \\forall N,\\ \\exists l,\\ |l| = G \\wedge \\textstyle\\sum_i l_i^4 = N$",
+    "significance": "supporting",
+    "relatedConcepts": ["existential restatement", "improvement over parent"],
+    "prerequisites": ["existential quantifiers"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-oq-03-oq-01` (Sharpening the elementary Waring bound: g(4) ≤ 50).

**Gap:** rich `meta.json` but **no `annotations.json`** — zero inline coverage of the 195-line file.

**Change:** author **9 non-overlapping annotations** covering the whole file:
- Header: the residue-borrowing sharpening strategy (53 → 50)
- Liouville identity + `cast_natAbs_pow4`
- The `IsSumOfFourthPowers` predicate and its closure lemmas (`append`, `le`, ...)
- The Liouville step (`sixMulSq`, 6m² → 12 fourth powers)
- The `sixMul` engine (6Q → 48 fourth powers)
- Small-power building blocks (`ones`, `twos`, `twoPow16`, `threePow81`)
- The base-16 fallback `small` for N < 81
- The main theorem `waring_four_fifty` (residue case split mod 6)
- The existential restatement `waring_four_lt_53`

Each carries `mathContext` (LaTeX), canonical `type`/`significance`, `relatedConcepts`, `prerequisites`; ranges anchored to declaration/section-doc lines. `meta.json` unchanged.