### PR TITLE
Enrich Simplicity of A₅ via Sylow's Theorems: annotation coverage 21%→76%

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-04/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-04/annotations.json
@@ -28,6 +28,54 @@
     }
   },
   {
+    "id": "ann-sylow-oq04-order-factorization",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 40,
+      "endLine": 58
+    },
+    "type": "definition",
+    "title": "A₅ Has Order 60 = 2²·3·5",
+    "content": "The proof opens by fixing the object of study — `A5 := alternatingGroup (Fin 5)` — and computing the two facts that drive everything downstream: $|A_5| = 5!/2 = 60$ (`card_A5`), and the prime factorization $60 = 2^2\\cdot 3\\cdot 5$ recorded as the $p$-adic valuations $v_2(60)=2$, $v_3(60)=1$, $v_5(60)=1$. All four are settled by `native_decide` since the alternating group on `Fin 5` is a concrete finite structure. The valuations fix the *orders* of the Sylow subgroups: a Sylow 2-subgroup has order $4$, a Sylow 3-subgroup order $3$, a Sylow 5-subgroup order $5$.",
+    "mathContext": "$|A_5| = 60 = 2^2\\cdot 3\\cdot 5$; Sylow subgroup orders are $4, 3, 5$ with indices $15, 20, 12$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "alternating group",
+      "order of a group",
+      "p-adic valuation",
+      "Sylow subgroup order"
+    ],
+    "prerequisites": [
+      "group order",
+      "prime factorization",
+      "native_decide"
+    ]
+  },
+  {
+    "id": "ann-sylow-oq04-sylow3-constraints",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 60,
+      "endLine": 97
+    },
+    "type": "concept",
+    "title": "Sylow's Third Theorem: Congruence and Divisibility",
+    "content": "Part III instantiates Sylow III for each prime: the number $n_p$ of Sylow $p$-subgroups satisfies $n_p\\equiv 1\\pmod p$ (`card_sylow_modEq_one`) and $n_p \\mid [G:P]$ (`card_sylow_dvd_index`). Combined with the indices $15, 20, 12$ these pin the *candidate* values: $n_2\\in\\{1,3,5,15\\}$, $n_3\\in\\{1,4,10\\}$, $n_5\\in\\{1,6\\}$. These are the abstract constraints that hold for *any* group of order 60 — they narrow the possibilities but, on their own, do not yet force simplicity (a group of order 60 could still have a normal Sylow subgroup; the exact counts in Part IV are what rule that out for $A_5$).",
+    "mathContext": "$n_p \\equiv 1 \\pmod p$ and $n_p \\mid [G:P]$; hence $n_2\\in\\{1,3,5,15\\}$, $n_3\\in\\{1,4,10\\}$, $n_5\\in\\{1,6\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sylow's third theorem",
+      "number of Sylow subgroups",
+      "congruence conditions",
+      "index of a subgroup"
+    ],
+    "prerequisites": [
+      "Sylow theorems",
+      "modular arithmetic",
+      "divisibility"
+    ]
+  },
+  {
     "id": "ann-sylow-oq04-exact-numbers",
     "line": 99,
     "endLine": 124,
@@ -52,6 +100,29 @@
       "startLine": 99,
       "endLine": 110
     }
+  },
+  {
+    "id": "ann-sylow-oq04-exact-theorems",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 111,
+      "endLine": 131
+    },
+    "type": "technique",
+    "title": "Pinning the Exact Counts n₂=5, n₃=10, n₅=6",
+    "content": "Where the abstract constraints leave several candidates, `native_decide` settles the *exact* Sylow numbers for $A_5$ by exhaustive enumeration over the 60 elements: $n_2 = 5$ (the Klein four-groups $V_4$), $n_3 = 10$ (cyclic $\\langle(ijk)\\rangle$), $n_5 = 6$ (cyclic $\\langle(ijklm)\\rangle$). `all_sylow_numbers_gt_one` then packages the crucial consequence — every $n_p > 1$ — with a trivial `rw`+`omega`. This step is what distinguishes $A_5$ from other order-60 groups and forces non-normality.",
+    "mathContext": "$n_2 = 5,\\ n_3 = 10,\\ n_5 = 6$, all $> 1$; the Sylow 2-subgroups are $\\cong V_4$, the 3- and 5-subgroups cyclic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sylow number",
+      "Klein four-group",
+      "cyclic subgroup",
+      "native_decide enumeration"
+    ],
+    "prerequisites": [
+      "Sylow subgroups",
+      "finite group computation"
+    ]
   },
   {
     "id": "ann-sylow-oq04-nonnormal-pattern",
@@ -80,6 +151,28 @@
     }
   },
   {
+    "id": "ann-sylow-oq04-nonnormal-theorems",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 134,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "No Sylow Subgroup Is Normal",
+    "content": "The three theorems `sylow2_not_normal`, `sylow3_not_normal`, `sylow5_not_normal` share one argument: a normal Sylow $p$-subgroup would be the *unique* one (`Sylow.unique_of_normal`), forcing `Fintype.card (Sylow p A5) = 1` — directly contradicting the exact counts $5, 10, 6$ from Part IV, which `omega` closes. Normality $\\iff$ uniqueness for Sylow subgroups is the pivot; since $A_5$ has several of each, none can be normal. This already shows $A_5$ has no *Sylow* normal subgroup, though simplicity (no normal subgroup at all) needs the conjugacy-class argument that follows.",
+    "mathContext": "$P \\trianglelefteq G \\iff P$ is the unique Sylow $p$-subgroup; but $n_p>1$, so no Sylow subgroup is normal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "normal subgroup",
+      "Sylow.unique_of_normal",
+      "uniqueness iff normality"
+    ],
+    "prerequisites": [
+      "normal subgroups",
+      "Sylow uniqueness"
+    ]
+  },
+  {
     "id": "ann-sylow-oq04-conjugacy",
     "line": 182,
     "endLine": 191,
@@ -104,6 +197,53 @@
       "startLine": 182,
       "endLine": 184
     }
+  },
+  {
+    "id": "ann-sylow-oq04-decide-sum",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 185,
+      "endLine": 190
+    },
+    "type": "tactic",
+    "title": "The decide-Checked Conjugacy-Class Sum",
+    "content": "`no_intermediate_conjugacy_sum` is the arithmetic core of the second (conjugacy-class) simplicity proof, fully discharged by `decide`. A normal subgroup is a union of conjugacy classes containing the identity, so its order is $1$ plus a subset-sum of the non-identity class sizes $\\{12, 12, 15, 20\\}$. Quantifying over the four booleans (which classes are included) and checking every one of the $2^4 = 16$ subset sums, the only sums that divide 60 are $1$ (trivial subgroup) and $60$ (all of $A_5$). Hence the only possible normal subgroup orders are 1 and 60 — an independent route to simplicity.",
+    "mathContext": "For all subsets $S\\subseteq\\{12,12,15,20\\}$: $\\big(1+\\textstyle\\sum S\\big)\\mid 60 \\Rightarrow 1+\\sum S \\in \\{1,60\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conjugacy classes",
+      "class equation",
+      "subset sum",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "conjugacy class sizes",
+      "Lagrange's theorem",
+      "decidable propositions"
+    ]
+  },
+  {
+    "id": "ann-sylow-oq04-simple",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 192,
+      "endLine": 209
+    },
+    "type": "insight",
+    "title": "A₅ Is Simple",
+    "content": "`A5_isSimple` records the theorem the whole file builds toward: $A_5$ has no proper nontrivial normal subgroup. The Lean proof cites Mathlib's general `alternatingGroup.isSimpleGroup_five`, while the Sylow counting (Parts III–V) and the conjugacy-class sum (Part VI) supply two self-contained arguments for the $n=5$ case. $A_5$ is the *smallest* non-abelian simple group (order 60), the first entry in the classification of finite simple groups and the reason the general quintic has no solution in radicals.",
+    "mathContext": "$A_5$ is simple: for every normal $N\\trianglelefteq A_5$, $N=\\{e\\}$ or $N=A_5$. It is the smallest non-abelian simple group.",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple group",
+      "classification of finite simple groups",
+      "alternating group",
+      "Galois theory"
+    ],
+    "prerequisites": [
+      "normal subgroups",
+      "simple groups"
+    ]
   },
   {
     "id": "ann-sylow-oq04-not-solvable",
@@ -132,5 +272,49 @@
       "startLine": 217,
       "endLine": 220
     }
+  },
+  {
+    "id": "ann-sylow-oq04-normal-subgroups",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 232,
+      "endLine": 235
+    },
+    "type": "concept",
+    "title": "Only ⊥ and ⊤ Are Normal",
+    "content": "`A5_normal_subgroups` restates simplicity in the lattice-of-subgroups language Mathlib uses: any normal subgroup $N$ of $A_5$ equals $\\bot$ (the trivial subgroup) or $\\top$ (all of $A_5$), via `IsSimpleGroup.eq_bot_or_eq_top_of_normal`. This is the definitional unpacking of `IsSimpleGroup` and the form most convenient for downstream applications.",
+    "mathContext": "$N \\trianglelefteq A_5 \\Rightarrow N = \\bot \\lor N = \\top$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subgroup lattice",
+      "IsSimpleGroup",
+      "trivial and improper subgroups"
+    ],
+    "prerequisites": [
+      "normal subgroups",
+      "simple groups"
+    ]
+  },
+  {
+    "id": "ann-sylow-oq04-summary",
+    "proofId": "sylow-theorem-oq-04",
+    "range": {
+      "startLine": 237,
+      "endLine": 261
+    },
+    "type": "context",
+    "title": "Summary: 18 Verified Results, 0 Axioms",
+    "content": "The closing table catalogues all 18 theorems by statement and method, recording 0 axioms and 0 sorries. The methods split cleanly into three families: `native_decide` for the concrete finite facts (order, valuations, exact Sylow counts), Mathlib's Sylow-III lemmas for the abstract counting constraints, and `decide` for the conjugacy-class subset-sum. Together they give two independent proofs of simplicity — Sylow-counting and conjugacy-class — plus the headline corollaries that $A_5$ is not solvable (the Abel–Ruffini connection) and that its only normal subgroups are $\\bot$ and $\\top$.",
+    "mathContext": "18 results: $|A_5|=60$, exact Sylow numbers $5,10,6$, non-normality, simplicity, non-solvability — all machine-checked.",
+    "significance": "context",
+    "relatedConcepts": [
+      "proof catalogue",
+      "Abel-Ruffini theorem",
+      "solvability",
+      "native_decide vs decide"
+    ],
+    "prerequisites": [
+      "group theory"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-04` ("Simplicity of A₅ via Sylow's Theorems").

**Gap:** the 276-line file had 5 annotations at ~21% coverage, several of them single-line anchors; the order/factorization, Sylow-III constraints, exact-count theorems, non-normality proofs, the `decide` conjugacy sum, and the corollaries were unannotated.

**Added 8 annotations** (5→13, ~76% coverage), preserving the existing five verbatim:
- A₅ order 60 = 2²·3·5 and Sylow subgroup orders
- Sylow III congruence + divisibility → candidate counts
- Exact counts n₂=5, n₃=10, n₅=6 via `native_decide`
- The three non-normality theorems (normality ⟺ uniqueness)
- The `decide`-checked conjugacy-class subset sum (2⁴ cases)
- `A5_isSimple` (smallest non-abelian simple group)
- The ⊥/⊤ normal-subgroup corollary
- Summary table (18 results, 0 axioms)

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; ranges sorted and non-overlapping. `meta.json` unchanged.