### PR TITLE
Enrich Erdős #1023: LYM Inequality and Antichain Extremal Value: annotation coverage 27%→73%

### DIFF
--- a/src/data/proofs/erdos-1023-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1023-oq-01-oq-01/annotations.json
@@ -1,5 +1,54 @@
 [
   {
+    "id": "ann-e1023-header",
+    "proofId": "erdos-1023-oq-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "Discharging an Axiom with LYM — and Being Honest About the Gap",
+    "content": "The header states the open question precisely: the parent entry (erdos-1023-oq-01) proves the union-free extremal value $F(n)=\\binom{n}{\\lfloor n/2\\rfloor}$ but leaves the Erdős–Kleitman upper bound as an `axiom` (`problem_447_solution`), asking whether the LYM inequality discharges it. This file's careful answer: LYM proves the complete *antichain* theorem and the matching *lower* bound for 2-union-free families axiom-free, but does **not** close the upper bound — a 2-union-free family need not be an antichain and can be strictly larger, so that half is the genuinely deeper Erdős–Kleitman content. The transparency about what is and is not proved is a model of honest formalization.",
+    "mathContext": "Open question: prove `problem_447_solution` from LYM $\\sum_{A\\in F}\\binom{n}{|A|}^{-1}\\le 1$. Answer: the antichain analogue and lower bound, yes; the 2-union-free upper bound, no.",
+    "significance": "context",
+    "relatedConcepts": [
+      "LYM inequality",
+      "Sperner's theorem",
+      "Erdős–Kleitman theorem",
+      "union-free families",
+      "axiom reduction"
+    ],
+    "prerequisites": [
+      "extremal set theory",
+      "antichains",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-e1023-definitions",
+    "proofId": "erdos-1023-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 57
+    },
+    "type": "definition",
+    "title": "Set Families, Antichains, and 2-Union-Free Families",
+    "content": "The vocabulary, kept identical to the parent's for a clean bridge: a `SetFamily n` is a `Finset (Finset (Fin n))`; `isAntichain F` says no member contains another ($A\\subseteq B \\Rightarrow A=B$); `isTwoUnionOf A F` says $A$ is the union $B\\cup C$ of two distinct members both different from $A$; and `isTwoUnionFree F` forbids any member from being such a union. The distinction between the two \"free\" notions is the crux of the whole entry — every antichain is 2-union-free, but not conversely, and that gap is exactly where LYM stops short of Erdős–Kleitman.",
+    "mathContext": "$F$ antichain: $\\forall A,B\\in F,\\ A\\subseteq B\\Rightarrow A=B$. $F$ 2-union-free: no $A\\in F$ equals $B\\cup C$ for distinct $B,C\\in F\\setminus\\{A\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antichain",
+      "union-free family",
+      "set family",
+      "subset order"
+    ],
+    "prerequisites": [
+      "Finset",
+      "subset relation",
+      "power set"
+    ]
+  },
+  {
     "id": "ann-bridge",
     "proofId": "erdos-1023-oq-01-oq-01",
     "range": {
@@ -11,8 +60,16 @@
     "content": "The parent file defines `isAntichain F` as `∀ A B ∈ F, A ⊆ B → A = B` — distinct members are incomparable. That is definitionally Mathlib's `IsAntichain (· ⊆ ·) ↑F`. `toMathlibAntichain` is the one-line term `fun _ ha _ hb hne hsub => hne (h _ ha _ hb hsub)` that performs the bridge, after which Mathlib's entire LYM/Sperner development applies verbatim. Matching the parent's vocabulary to the library's is what makes the rest of the file short.",
     "mathContext": "Parent's $\\forall A,B\\in F,\\ A\\subseteq B \\Rightarrow A=B$ is the contrapositive of Mathlib's $\\texttt{IsAntichain}(\\subseteq)$: $A\\ne B \\Rightarrow \\neg(A\\subseteq B)$. The term takes $h_{ne}:A\\ne B$ and $h_{sub}:A\\subseteq B$ and derives $\\bot$ from $h\\,A\\,B\\,h_{sub}:A=B$.",
     "significance": "key",
-    "relatedConcepts": ["IsAntichain", "order-theoretic vs combinatorial vocabulary", "definitional unfolding", "contrapositive"],
-    "prerequisites": ["Mathlib's IsAntichain on a partial order", "subset order on Finset (Fin n)"]
+    "relatedConcepts": [
+      "IsAntichain",
+      "order-theoretic vs combinatorial vocabulary",
+      "definitional unfolding",
+      "contrapositive"
+    ],
+    "prerequisites": [
+      "Mathlib's IsAntichain on a partial order",
+      "subset order on Finset (Fin n)"
+    ]
   },
   {
     "id": "ann-lym",
@@ -26,8 +83,41 @@
     "content": "`lym_inequality` is exactly the inequality the open question asks to use: for an antichain F in 2^[n], ∑_{A∈F} 1/C(n,|A|) ≤ 1. Each member A 'spends' a 1/C(n,|A|) fraction of its layer, and the layers' budgets sum to at most 1. It is the `simpa [Fintype.card_fin]` image of Mathlib's `lubell_yamamoto_meshalkin_inequality_sum_inv_choose`, rewriting Fintype.card (Fin n) = n. Summed against the largest binomial coefficient C(n,⌊n/2⌋), it collapses to Sperner's bound.",
     "mathContext": "$\\sum_{A\\in F}\\binom{n}{|A|}^{-1}\\le 1$. Probabilistic reading: a uniformly random maximal chain in $2^{[n]}$ passes through each layer-$k$ set with probability $\\binom{n}{k}^{-1}$, and an antichain meets any chain at most once, so the events are disjoint and their probabilities sum to $\\le 1$ (Lubell's double-counting proof).",
     "significance": "key",
-    "relatedConcepts": ["Lubell–Yamamoto–Meshalkin inequality", "maximal chains", "double counting", "Bollobás-type bounds"],
-    "prerequisites": ["binomial coefficients C(n,k)", "Mathlib's lubell_yamamoto_meshalkin_inequality_sum_inv_choose", "Fintype.card_fin"]
+    "relatedConcepts": [
+      "Lubell–Yamamoto–Meshalkin inequality",
+      "maximal chains",
+      "double counting",
+      "Bollobás-type bounds"
+    ],
+    "prerequisites": [
+      "binomial coefficients C(n,k)",
+      "Mathlib's lubell_yamamoto_meshalkin_inequality_sum_inv_choose",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "ann-e1023-middle-layer",
+    "proofId": "erdos-1023-oq-01-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "The Middle Layer Attains the Bound",
+    "content": "Sperner's bound is sharp because the *middle layer* — all $\\lfloor n/2\\rfloor$-element subsets — is itself an antichain of the extremal size. `middle_card` computes its size as $\\binom{n}{\\lfloor n/2\\rfloor}$ directly from `Finset.card_powersetCard`, and `middle_antichain` shows it is an antichain because distinct sets of *equal* cardinality are incomparable (`Finset.eq_of_subset_of_card_le`). This explicit witness supplies the $\\ge$ half of the extremal theorem, matching Sperner's $\\le$ half.",
+    "mathContext": "$\\mathrm{middle}(n) = \\binom{[n]}{\\lfloor n/2\\rfloor}$, $|\\mathrm{middle}(n)| = \\binom{n}{\\lfloor n/2\\rfloor}$, and it is an antichain (equal-cardinality sets are incomparable).",
+    "significance": "key",
+    "relatedConcepts": [
+      "middle layer",
+      "powersetCard",
+      "Sperner sharpness",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "antichains",
+      "binomial coefficients",
+      "Finset cardinality"
+    ]
   },
   {
     "id": "ann-middle",
@@ -41,8 +131,41 @@
     "content": "`middle n = univ.powersetCard (n/2)` is the family of all ⌊n/2⌋-element subsets. It has size C(n,⌊n/2⌋) (`card_powersetCard`), and it is an antichain because two distinct sets of equal cardinality can never satisfy A ⊆ B (`eq_of_subset_of_card_le`). This makes Sperner's upper bound tight, so the antichain maximum is an exact equality rather than just an inequality.",
     "mathContext": "$|\\,\\binom{[n]}{\\lfloor n/2\\rfloor}\\,| = \\binom{n}{\\lfloor n/2\\rfloor}$, the maximum of $k\\mapsto\\binom{n}{k}$. Equal-cardinality sets are incomparable: $A\\subseteq B$ with $|A|=|B|$ forces $A=B$ (a subset of equal size is the whole set), so the layer is an antichain attaining Sperner's bound.",
     "significance": "key",
-    "relatedConcepts": ["middle binomial layer", "powersetCard", "tightness / extremal witness", "unimodality of binomial coefficients"],
-    "prerequisites": ["Finset.powersetCard and card_powersetCard", "Finset.eq_of_subset_of_card_le", "max of the binomial coefficient at the central layer"]
+    "relatedConcepts": [
+      "middle binomial layer",
+      "powersetCard",
+      "tightness / extremal witness",
+      "unimodality of binomial coefficients"
+    ],
+    "prerequisites": [
+      "Finset.powersetCard and card_powersetCard",
+      "Finset.eq_of_subset_of_card_le",
+      "max of the binomial coefficient at the central layer"
+    ]
+  },
+  {
+    "id": "ann-e1023-antichainmax",
+    "proofId": "erdos-1023-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 142
+    },
+    "type": "concept",
+    "title": "The Extremal Value Is Exactly the Middle Binomial",
+    "content": "`antichainMax n` is the supremum of antichain sizes, and `antichainMax_eq` proves it equals $\\binom{n}{\\lfloor n/2\\rfloor}$ by `le_antisymm`. The upper direction uses `csSup_le` with `sperner_bound` on every antichain; the lower uses `le_csSup` with the middle layer as an explicit member. The two supporting lemmas — `antichain_sizes_bddAbove` (bounded by $|2^{[n]}|$) and `antichain_sizes_nonempty` (the empty family has size 0) — are the hygiene conditions a supremum over ℕ needs to behave. Together they turn Sperner's inequality into an exact identity.",
+    "mathContext": "$\\mathrm{antichainMax}(n) = \\sup\\{|F| : F \\text{ antichain}\\} = \\binom{n}{\\lfloor n/2\\rfloor}$, by $\\le$ (Sperner) and $\\ge$ (middle layer).",
+    "significance": "key",
+    "relatedConcepts": [
+      "supremum",
+      "Sperner's theorem",
+      "extremal value",
+      "le_antisymm"
+    ],
+    "prerequisites": [
+      "sSup on ℕ",
+      "bddAbove / nonempty",
+      "antichains"
+    ]
   },
   {
     "id": "ann-extremal",
@@ -56,8 +179,40 @@
     "content": "`antichainMax_eq` proves the maximum antichain size in 2^[n] is exactly C(n,⌊n/2⌋): `le_antisymm` of Sperner (every antichain is ≤ the bound) and the middle layer (an antichain achieving it). This is the axiom-free analogue of the parent's axiomatized `problem_447_solution` — but for antichains rather than the broader 2-union-free families.",
     "mathContext": "$\\max\\{|F| : F\\ \\text{antichain in } 2^{[n]}\\} = \\binom{n}{\\lfloor n/2\\rfloor}$ (Sperner's theorem). Proved by $\\texttt{le\\_antisymm}$: the $\\le$ direction is $\\texttt{csSup\\_le}$ over all antichains (each $\\le$ the bound), the $\\ge$ direction is $\\texttt{le\\_csSup}$ exhibiting the middle layer as a witness in the size set.",
     "significance": "key",
-    "relatedConcepts": ["Sperner's theorem", "extremal set theory", "sSup over a bounded family", "le_antisymm"],
-    "prerequisites": ["sSup / csSup_le / le_csSup on bounded-above subsets of ℕ", "the antichain size set is nonempty and bddAbove"]
+    "relatedConcepts": [
+      "Sperner's theorem",
+      "extremal set theory",
+      "sSup over a bounded family",
+      "le_antisymm"
+    ],
+    "prerequisites": [
+      "sSup / csSup_le / le_csSup on bounded-above subsets of ℕ",
+      "the antichain size set is nonempty and bddAbove"
+    ]
+  },
+  {
+    "id": "ann-e1023-lowerbound",
+    "proofId": "erdos-1023-oq-01-oq-01",
+    "range": {
+      "startLine": 161,
+      "endLine": 173
+    },
+    "type": "insight",
+    "title": "The Axiom-Free Lower Bound for Problem 447",
+    "content": "Because every antichain is 2-union-free (`antichain_twoUnionFree`), the middle layer is a 2-union-free family of size $\\binom{n}{\\lfloor n/2\\rfloor}$ (`middle_twoUnionFree`). Hence `twoUnionFree_max_ge_middle` gives $\\binom{n}{\\lfloor n/2\\rfloor} \\le \\sup\\{|F| : F \\text{ 2-union-free}\\}$ — the *lower-bound half* of the parent's `problem_447_solution` axiom, now proved without any axiom. What remains open is only the reverse inequality (no 2-union-free family exceeds the middle binomial), the deep Erdős–Kleitman theorem that LYM alone cannot reach.",
+    "mathContext": "$\\binom{n}{\\lfloor n/2\\rfloor} \\le \\sup\\{|F| : F \\text{ 2-union-free}\\}$, witnessed by the middle layer; the matching upper bound stays open.",
+    "significance": "key",
+    "relatedConcepts": [
+      "2-union-free families",
+      "Erdős–Kleitman theorem",
+      "lower bound",
+      "middle layer witness"
+    ],
+    "prerequisites": [
+      "antichains ⊆ 2-union-free",
+      "supremum",
+      "extremal set theory"
+    ]
   },
   {
     "id": "ann-gap",
@@ -71,7 +226,17 @@
     "content": "`antichain_twoUnionFree` shows antichains are 2-union-free: if A = B ∪ C with B ≠ A, then B ⊊ A ∈ F contradicts the antichain property. Hence `twoUnionFree_max_ge_middle`: C(n,⌊n/2⌋) ≤ sup{2-union-free sizes}, the lower-bound half of `problem_447_solution`, axiom-free. But the converse fails — a 2-union-free family may contain comparable pairs (it need not be an antichain) and can be larger. The statement that no 2-union-free family exceeds C(n,⌊n/2⌋) is the genuinely deeper Erdős–Kleitman theorem, NOT a corollary of LYM, and so remains the open analytic core of the parent axiom.",
     "mathContext": "Antichain $\\subseteq$ 2-union-free, so $\\binom{n}{\\lfloor n/2\\rfloor} \\le \\sup\\{|F| : F\\ \\text{2-union-free}\\}$ (the $\\ge$ half of Problem 447). The reverse inequality $\\sup \\le \\binom{n}{\\lfloor n/2\\rfloor}$ is Erdős–Kleitman and is strictly stronger: 2-union-free families can contain chains, so LYM/Sperner do not bound them.",
     "significance": "supporting",
-    "relatedConcepts": ["2-union-free families", "Erdős–Kleitman theorem", "Problem 447", "scope of LYM", "axiom-free lower bound"],
-    "prerequisites": ["subset_union_left and strict containment", "the parent's isTwoUnionFree definition", "why antichain ⊊ 2-union-free as classes"]
+    "relatedConcepts": [
+      "2-union-free families",
+      "Erdős–Kleitman theorem",
+      "Problem 447",
+      "scope of LYM",
+      "axiom-free lower bound"
+    ],
+    "prerequisites": [
+      "subset_union_left and strict containment",
+      "the parent's isTwoUnionFree definition",
+      "why antichain ⊊ 2-union-free as classes"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1023-oq-01-oq-01` ("The LYM Inequality and the Antichain Extremal Value").

**Gap:** the 200-line file had 5 annotations at ~27% coverage; the header, the definitions, the middle-layer construction, the `antichainMax` supremum machinery, and the lower-bound bridge were unannotated.

**Added 5 annotations** (5→10, ~73% coverage), preserving the existing five verbatim:
- **Header** — the honest LYM-vs-Erdős–Kleitman scope (what LYM discharges and what stays open).
- **Definitions** — set families, antichains, and 2-union-free families; the gap between the two "free" notions.
- **Middle layer** — the $\lfloor n/2\rfloor$-subsets attaining Sperner's bound.
- **antichainMax** — the exact extremal value $\binom{n}{\lfloor n/2\rfloor}$ via `le_antisymm`.
- **Lower bound** — the axiom-free $\ge$ half of `problem_447_solution`.

Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; ranges sorted and non-overlapping. `meta.json` unchanged.