### PR TITLE
Enrich erdos-1004-oq-02-oq-01: deepen annotations (add mathContext + metadata)

### DIFF
--- a/src/data/proofs/erdos-1004-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1004-oq-02-oq-01/annotations.json
@@ -1,11 +1,27 @@
 [
   {
+    "id": "ann-erdos-1004-oq-02-oq-01-00",
+    "proofId": "erdos-1004-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Turning the informal exponent c₀ into a genuine invariant",
+    "content": "Erdős #1004 asks whether, for every $c > 0$ and all large $x$, some $n \\le x$ starts a run $\\varphi(n+1), \\dots, \\varphi(n+\\lfloor(\\log x)^c\\rfloor)$ of distinct totient values. The parent entry names the 'optimal exponent' $c_0$ only informally — as a bound variable inside `SmallCaseConjecture`. This file promotes $c_0$ to a well-defined invariant (a supremum in `EReal`) and reframes the two conjecture shapes as single order statements about it: the full conjecture is $c_0 = \\top$, the weak band form is $c_0 > 0$. The entire reduction is elementary (0 axioms, no analytic number theory); the *value* of $c_0$ is the open analytic core, deliberately left out.",
+    "mathContext": "$\\texttt{Conjecture} \\iff c_0 = \\top, \\qquad \\texttt{SmallCase} \\iff 0 < c_0$",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős problem 1004", "Euler totient", "distinct runs", "well-defined invariant"],
+    "prerequisites": ["Euler's totient function φ", "asymptotic (eventually) statements", "extended reals"]
+  },
+  {
     "id": "ann-erdos-1004-oq-02-oq-01-01",
     "proofId": "erdos-1004-oq-02-oq-01",
     "range": { "startLine": 33, "endLine": 43 },
     "type": "definition",
     "title": "Achievable exponents and prefix stability",
-    "content": "`AchievableExponent c` is deliberately the *exact body* of the parent's `Erdos1004Conjecture` at a fixed `c`: for all large `x`, some `n ≤ x` starts a distinct totient run of length `⌊(log x)^c⌋`. Matching it definitionally means `Erdos1004Conjecture` unfolds to `∀ c > 0, AchievableExponent c` for free, so the equivalence proofs never re-prove the unfolding. `run_prefix` records the single combinatorial fact the whole entry rests on: a distinct run of length `K` is still distinct on any shorter prefix `K' ≤ K`, since the pairwise-distinctness quantifier just restricts to the sub-block."
+    "content": "`AchievableExponent c` is deliberately the *exact body* of the parent's `Erdos1004Conjecture` at a fixed `c`: for all large `x`, some `n ≤ x` starts a distinct totient run of length `⌊(log x)^c⌋`. Matching it definitionally means `Erdos1004Conjecture` unfolds to `∀ c > 0, AchievableExponent c` for free, so the equivalence proofs never re-prove the unfolding. `run_prefix` records the single combinatorial fact the whole entry rests on: a distinct run of length `K` is still distinct on any shorter prefix `K' ≤ K`, since the pairwise-distinctness quantifier just restricts to the sub-block.",
+    "mathContext": "$\\texttt{AchievableExponent}\\,c \\iff \\forall^\\infty x,\\ \\exists n \\le x,\\ \\texttt{IsDistinctTotientRun}\\,n\\,\\lfloor(\\log x)^c\\rfloor$",
+    "significance": "key",
+    "relatedConcepts": ["eventually filter (atTop)", "distinct totient run", "definitional unfolding"],
+    "prerequisites": ["Filter.Eventually", "floor function", "pairwise distinctness"]
   },
   {
     "id": "ann-erdos-1004-oq-02-oq-01-02",
@@ -13,7 +29,11 @@
     "range": { "startLine": 44, "endLine": 64 },
     "type": "theorem",
     "title": "Downward closure: the achievable set is an interval",
-    "content": "The mathematical core. Filtering to `x` large enough that `log x ≥ 1` (from `Real.tendsto_log_atTop`) AND a `c`-run exists, the base `log x ≥ 1` makes `x ↦ (log x)^·` monotone in the exponent, so `(log x)^c' ≤ (log x)^c` (`Real.rpow_le_rpow_of_exponent_le`) and hence `⌊(log x)^c'⌋₊ ≤ ⌊(log x)^c⌋₊` (`Nat.floor_le_floor`). The witness `n` of the `c`-run then yields a distinct run of the shorter length at the SAME `n` by `run_prefix`. Note the `0 ≤ c'` hypothesis is kept for the intended reading even though the proof does not need it. `zero_achievable` gives the left endpoint: `⌊(log x)^0⌋ = ⌊1⌋ = 1` and every `n` starts a length-1 run."
+    "content": "The mathematical core. Filtering to `x` large enough that `log x ≥ 1` (from `Real.tendsto_log_atTop`) AND a `c`-run exists, the base `log x ≥ 1` makes `x ↦ (log x)^·` monotone in the exponent, so `(log x)^c' ≤ (log x)^c` (`Real.rpow_le_rpow_of_exponent_le`) and hence `⌊(log x)^c'⌋₊ ≤ ⌊(log x)^c⌋₊` (`Nat.floor_le_floor`). The witness `n` of the `c`-run then yields a distinct run of the shorter length at the SAME `n` by `run_prefix`. Note the `0 ≤ c'` hypothesis is kept for the intended reading even though the proof does not need it. `zero_achievable` gives the left endpoint: `⌊(log x)^0⌋ = ⌊1⌋ = 1` and every `n` starts a length-1 run.",
+    "mathContext": "$0 \\le c' \\le c,\\ \\texttt{Achievable}\\,c \\Rightarrow \\texttt{Achievable}\\,c'; \\quad (\\log x)^{c'} \\le (\\log x)^{c} \\text{ when } \\log x \\ge 1$",
+    "significance": "critical",
+    "relatedConcepts": ["downward-closed set", "monotonicity of rpow", "Nat.floor_le_floor", "filter_upwards"],
+    "prerequisites": ["Real.rpow_le_rpow_of_exponent_le", "Real.tendsto_log_atTop", "eventual filters"]
   },
   {
     "id": "ann-erdos-1004-oq-02-oq-01-03",
@@ -21,7 +41,11 @@
     "range": { "startLine": 65, "endLine": 94 },
     "type": "insight",
     "title": "Why EReal: a total supremum in the unbounded case",
-    "content": "`c₀` is defined as `sSup` of the achievable exponents coerced into `EReal`. The point of a *complete lattice* codomain is that the supremum is total even when the set is unbounded above — which is precisely the conjectured case `c₀ = ⊤`. A real-valued `sSup` on an unbounded set returns a junk value (`0`), which would silently collapse the most interesting case. `zero_le_c₀` (0 is achievable ⇒ `c₀ ≥ 0`) and `c₀_ne_bot` pin `c₀` into `[0, ∞]`."
+    "content": "`c₀` is defined as `sSup` of the achievable exponents coerced into `EReal`. The point of a *complete lattice* codomain is that the supremum is total even when the set is unbounded above — which is precisely the conjectured case `c₀ = ⊤`. A real-valued `sSup` on an unbounded set returns a junk value (`0`), which would silently collapse the most interesting case. `zero_le_c₀` (0 is achievable ⇒ `c₀ ≥ 0`) and `c₀_ne_bot` pin `c₀` into `[0, ∞]`.",
+    "mathContext": "$c_0 := \\sup\\{\\,(r : \\overline{\\mathbb{R}}) : 0 \\le r \\wedge \\texttt{Achievable}\\,r\\,\\} \\in [0, \\infty]$",
+    "significance": "key",
+    "relatedConcepts": ["complete lattice", "EReal", "supremum", "junk values"],
+    "prerequisites": ["order-theoretic sSup", "extended real line ⊤/⊥", "le_sSup"]
   },
   {
     "id": "ann-erdos-1004-oq-02-oq-01-04",
@@ -29,7 +53,11 @@
     "range": { "startLine": 96, "endLine": 121 },
     "type": "theorem",
     "title": "The full conjecture is exactly c₀ = ⊤",
-    "content": "`conjecture_iff_c₀_top`. Forward (contrapositive): if `c₀ ≠ ⊤` then, being `≥ 0`, it is a genuine real `c₀ = ↑c₀.toReal` (`EReal.coe_toReal`); but the conjecture makes `c₀.toReal + 1` achievable, so `le_sSup` forces `c₀.toReal + 1 ≤ c₀.toReal`, absurd. Backward: `c₀ = ⊤` puts every `↑c` strictly below `c₀`, so `lt_sSup_iff` extracts an achievable `r > c`, and downward closure makes `c` itself achievable. This is an exact reformulation, not an approximation — the full Erdős #1004 conjecture *is* the single statement 'c₀ is infinite'."
+    "content": "`conjecture_iff_c₀_top`. Forward (contrapositive): if `c₀ ≠ ⊤` then, being `≥ 0`, it is a genuine real `c₀ = ↑c₀.toReal` (`EReal.coe_toReal`); but the conjecture makes `c₀.toReal + 1` achievable, so `le_sSup` forces `c₀.toReal + 1 ≤ c₀.toReal`, absurd. Backward: `c₀ = ⊤` puts every `↑c` strictly below `c₀`, so `lt_sSup_iff` extracts an achievable `r > c`, and downward closure makes `c` itself achievable. This is an exact reformulation, not an approximation — the full Erdős #1004 conjecture *is* the single statement 'c₀ is infinite'.",
+    "mathContext": "$\\texttt{Erdos1004Conjecture} \\iff c_0 = \\top$",
+    "significance": "critical",
+    "relatedConcepts": ["contrapositive", "EReal.coe_toReal", "lt_sSup_iff", "exact reformulation"],
+    "prerequisites": ["le_sSup / lt_sSup_iff", "EReal ↔ ℝ coercions", "downward closure"]
   },
   {
     "id": "ann-erdos-1004-oq-02-oq-01-05",
@@ -37,6 +65,10 @@
     "range": { "startLine": 122, "endLine": 145 },
     "type": "theorem",
     "title": "The weak band conjecture is exactly 0 < c₀",
-    "content": "`smallCase_iff_c₀_pos`. Forward: a witnessing band `0 < c < c₀'` gives an achievable `c₀'/2 > 0`, so `0 < ↑(c₀'/2) ≤ c₀` by `le_sSup`. Backward: `0 < c₀` yields, via `lt_sSup_iff`, an achievable `r > 0`, and downward closure fills the entire band `(0, r)` — exactly `SmallCaseConjecture`. Together with `conjecture_iff_c₀_top` this turns the parent's two qualitative Props into two order facts about one invariant: the conjecture is `c₀ = ∞`, the weak form is `c₀ > 0`."
+    "content": "`smallCase_iff_c₀_pos`. Forward: a witnessing band `0 < c < c₀'` gives an achievable `c₀'/2 > 0`, so `0 < ↑(c₀'/2) ≤ c₀` by `le_sSup`. Backward: `0 < c₀` yields, via `lt_sSup_iff`, an achievable `r > 0`, and downward closure fills the entire band `(0, r)` — exactly `SmallCaseConjecture`. Together with `conjecture_iff_c₀_top` this turns the parent's two qualitative Props into two order facts about one invariant: the conjecture is `c₀ = ∞`, the weak form is `c₀ > 0`.",
+    "mathContext": "$\\texttt{SmallCaseConjecture} \\iff 0 < c_0$",
+    "significance": "key",
+    "relatedConcepts": ["order band (0, r)", "lt_sSup_iff", "downward closure", "qualitative → quantitative"],
+    "prerequisites": ["le_sSup / lt_sSup_iff", "positivity in EReal"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1004-oq-02-oq-01` (Erdős #1004: the optimal totient-run exponent c₀ as a well-defined invariant).

**Gap:** the 5 existing annotations had strong `content` but **no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`** fields, and lines 1–29 (intro) were uncovered.

**Change:**
- Add `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 existing annotations (content preserved verbatim).
- Add a header annotation covering the intro (turning the informal c₀ into a genuine invariant).

Now 6 annotations, canonical `type`/`significance`. `meta.json` unchanged (already rich, under caps).