### PR TITLE
Enrich arithmetic-series: add prerequisites to all annotations

### DIFF
--- a/src/data/proofs/arithmetic-series/annotations.json
+++ b/src/data/proofs/arithmetic-series/annotations.json
@@ -14,6 +14,11 @@
     "relatedConcepts": [
       "Finset.range",
       "Finset.sum_range_id"
+    ],
+    "prerequisites": [
+      "Finset.range",
+      "Finset.sum_range_id",
+      "natural-number sums"
     ]
   },
   {
@@ -30,6 +35,11 @@
     "significance": "key",
     "relatedConcepts": [
       "Gauss schoolboy anecdote",
+      "triangular numbers"
+    ],
+    "prerequisites": [
+      "Gauss's formula (0-indexed)",
+      "exact division by 2",
       "triangular numbers"
     ]
   },
@@ -48,6 +58,11 @@
     "relatedConcepts": [
       "bijective argument",
       "symmetric sum"
+    ],
+    "prerequisites": [
+      "reindexing a sum (Finset.sum_range_reflect)",
+      "commutativity of addition",
+      "counting pairs"
     ]
   },
   {
@@ -65,6 +80,11 @@
     "relatedConcepts": [
       "arithmetic progression",
       "first term and common difference"
+    ],
+    "prerequisites": [
+      "arithmetic progression a + k·d",
+      "linearity of Finset.sum",
+      "Gauss's formula"
     ]
   },
   {
@@ -82,6 +102,10 @@
     "relatedConcepts": [
       "Gauss anecdote",
       "native_decide"
+    ],
+    "prerequisites": [
+      "decidable evaluation on ℕ",
+      "native_decide / kernel computation"
     ]
   },
   {
@@ -99,6 +123,11 @@
     "relatedConcepts": [
       "perfect squares",
       "L-shaped gnomon"
+    ],
+    "prerequisites": [
+      "odd numbers 2k+1",
+      "Finset.sum over range",
+      "induction / Finset.sum_range_succ"
     ]
   },
   {
@@ -116,6 +145,11 @@
     "relatedConcepts": [
       "even numbers",
       "arithmetic series"
+    ],
+    "prerequisites": [
+      "even numbers 2k",
+      "factoring a constant out of a sum",
+      "Gauss's formula"
     ]
   },
   {
@@ -133,6 +167,10 @@
     "relatedConcepts": [
       "figurate numbers",
       "binomial coefficients"
+    ],
+    "prerequisites": [
+      "figurate numbers",
+      "binomial coefficient C(n+1,2)"
     ]
   },
   {
@@ -150,6 +188,11 @@
     "relatedConcepts": [
       "recurrence relation",
       "inductive definition"
+    ],
+    "prerequisites": [
+      "recurrence relations",
+      "induction",
+      "Finset.sum_range_succ"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `arithmetic-series` (a landing-page classic).

**Gap:** all 9 annotations carried `mathContext`, `significance`, and `relatedConcepts`, but **none had a `prerequisites` field**.

**Change:** add an accurate `prerequisites` array to each of the 9 annotations (e.g. `Finset.sum_range_id`, sum reindexing, arithmetic progressions, `native_decide`, figurate/triangular numbers, induction via `Finset.sum_range_succ`). All existing content preserved verbatim; `meta.json` unchanged (already rich, under caps).