### PR TITLE
Enrich baire-category-theorem-oq-01-oq-01-oq-01: add prerequisites to annotations

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -2,67 +2,149 @@
   {
     "id": "ann-baire-oq010101-docstring",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 3, "endLine": 45 },
+    "range": {
+      "startLine": 3,
+      "endLine": 45
+    },
     "type": "concept",
     "title": "Open Mapping and Closed Graph from Baire — Goal and Plan",
     "content": "The docstring fixes the objective: derive the open mapping theorem, the inverse mapping (Banach isomorphism) theorem and the closed graph theorem from the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), completing the three classical pillars of functional analysis begun with the parent's Uniform Boundedness Principle. The key structural point flagged here: all three theorems share a single Baire-theoretic engine, and that engine is invoked exactly once — in exists_approx_preimage_norm_le. Everything afterwards is metric/completeness bookkeeping with no further appeal to Baire. The argument follows the classical (and Mathlib-internal) route; the entry's contribution is making the dependency on the gallery Baire theorem explicit and machine-checked end-to-end.",
     "mathContext": "A surjective bounded linear map between Banach spaces is open; a linear map with closed graph is continuous.",
     "significance": "supporting",
-    "relatedConcepts": ["Baire category theorem", "open mapping theorem", "closed graph theorem", "Banach space", "bounded linear operator"]
+    "relatedConcepts": [
+      "Baire category theorem",
+      "open mapping theorem",
+      "closed graph theorem",
+      "Banach space",
+      "bounded linear operator"
+    ],
+    "prerequisites": [
+      "Banach spaces",
+      "bounded linear operators",
+      "Baire category theorem"
+    ]
   },
   {
     "id": "ann-baire-oq010101-approx",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 56, "endLine": 131 },
+    "range": {
+      "startLine": 56,
+      "endLine": 131
+    },
     "type": "insight",
     "title": "The Baire Step: Approximate Preimages",
     "content": "exists_approx_preimage_norm_le is the heart of the entry and the ONLY place Baire is used. Surjectivity writes F as the countable union of the closed sets closure (T '' ball 0 n); the gallery category theorem baire_nonempty_interior returns one with nonempty interior — a ball ball a ε contained in closure (T '' ball 0 n). The fixed-radius, off-centre ball is made homogeneous by rescale_to_shell together with the difference of two near-images (one near a + d·y, one near a): their difference is the image of a point of norm ≤ C‖y‖ and lands within ‖y‖/2 of y. No completeness of the source is needed yet — only that of the target F, which supplies the BaireSpace hypothesis.",
     "mathContext": "Baire ⇒ ball $a$ $\\varepsilon \\subseteq \\overline{T(B(0,n))}$; subtracting two near-images gives $\\mathrm{dist}(Tx, y) \\le \\tfrac12\\|y\\|$ with $\\|x\\| \\le C\\|y\\|$.",
     "significance": "critical",
-    "relatedConcepts": ["Baire category theorem", "rescale_to_shell", "closure of image", "nonempty interior"]
+    "relatedConcepts": [
+      "Baire category theorem",
+      "rescale_to_shell",
+      "closure of image",
+      "nonempty interior"
+    ],
+    "prerequisites": [
+      "Baire category theorem",
+      "closure and interior in metric spaces",
+      "surjectivity",
+      "rescaling to a shell"
+    ]
   },
   {
     "id": "ann-baire-oq010101-exact",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 133, "endLine": 197 },
+    "range": {
+      "startLine": 133,
+      "endLine": 197
+    },
     "type": "insight",
     "title": "Exact Preimages by Series Summation",
     "content": "exists_preimage_norm_le upgrades approximate preimages to exact ones using completeness of the SOURCE E. The approximate-preimage map h y = y − T(g y) shrinks the residual by a factor 1/2 each step, so ‖h^[n] y‖ ≤ (1/2)^n ‖y‖. The corrective terms u n = g(h^[n] y) satisfy ‖u n‖ ≤ (1/2)^n C‖y‖, a geometric bound, hence ∑ u n converges in the Banach space E. Its sum x has ‖x‖ ≤ (2C+1)‖y‖, and continuity of T lets it pass through the limit of partial sums: T x = y. This is the quantitative open mapping theorem.",
     "mathContext": "Successive approximation: $\\|h^{[n]}y\\| \\le 2^{-n}\\|y\\|$, $\\sum_n u_n$ converges, $T(\\sum_n u_n) = y$, $\\|x\\| \\le (2C+1)\\|y\\|$.",
     "significance": "critical",
-    "relatedConcepts": ["successive approximation", "geometric series", "completeness", "Summable", "tsum"]
+    "relatedConcepts": [
+      "successive approximation",
+      "geometric series",
+      "completeness",
+      "Summable",
+      "tsum"
+    ],
+    "prerequisites": [
+      "completeness of Banach spaces",
+      "geometric series / Summable",
+      "tsum",
+      "successive approximation"
+    ]
   },
   {
     "id": "ann-baire-oq010101-openmap",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 198, "endLine": 219 },
+    "range": {
+      "startLine": 198,
+      "endLine": 219
+    },
     "type": "insight",
     "title": "The Open Mapping Theorem",
     "content": "isOpenMap turns the quantitative preimage bound into the topological statement that T maps open sets to open sets. Given an open s and a point y = T x in its image, an ε-ball around x inside s is transported through the norm bound ‖preimage‖ ≤ C‖z − y‖: every z within ε/C of y has a preimage x + w with x + w ∈ ball x ε ⊆ s, so z ∈ T '' s. Hence T '' s contains a ball around each of its points and is open.",
     "mathContext": "If $T$ has $C$-controlled preimages then $T(B(x,\\varepsilon)) \\supseteq B(Tx, \\varepsilon/C)$, so $T$ is an open map.",
     "significance": "key",
-    "relatedConcepts": ["open map", "image of open set", "operator norm bound"]
+    "relatedConcepts": [
+      "open map",
+      "image of open set",
+      "operator norm bound"
+    ],
+    "prerequisites": [
+      "open maps",
+      "operator-norm bounds",
+      "images of open balls"
+    ]
   },
   {
     "id": "ann-baire-oq010101-inverse",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 220, "endLine": 237 },
+    "range": {
+      "startLine": 220,
+      "endLine": 237
+    },
     "type": "insight",
     "title": "The Inverse Mapping (Banach Isomorphism) Theorem",
     "content": "continuous_linearEquiv_symm shows the inverse of a continuous linear bijection is automatically continuous — with no separate argument. Continuity of e.symm means preimages of opens are open; but for a bijection e.symm ⁻¹' s = e '' s, and e '' s is open by the open mapping theorem applied to the continuous linear bijection. So 'open bijection' is exactly 'continuous inverse'.",
     "mathContext": "For a bijection, $e^{-1}{}^{-1}(s) = e(s)$; the open mapping theorem makes $e(s)$ open, so $e^{-1}$ is continuous.",
     "significance": "key",
-    "relatedConcepts": ["Banach isomorphism theorem", "continuous inverse", "linear equivalence", "homeomorphism"]
+    "relatedConcepts": [
+      "Banach isomorphism theorem",
+      "continuous inverse",
+      "linear equivalence",
+      "homeomorphism"
+    ],
+    "prerequisites": [
+      "bijective bounded operators",
+      "continuous inverse",
+      "linear homeomorphism"
+    ]
   },
   {
     "id": "ann-baire-oq010101-closedgraph",
     "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
-    "range": { "startLine": 238, "endLine": 255 },
+    "range": {
+      "startLine": 238,
+      "endLine": 255
+    },
     "type": "insight",
     "title": "The Closed Graph Theorem",
     "content": "continuous_of_isClosed_graph deduces continuity of a linear map g from closedness of its graph, via the inverse mapping theorem. The graph is a closed — hence complete — subspace of the Banach space E × F. The first projection restricts to a continuous linear bijection φ from E onto the graph (x ↦ (x, g x)); by continuous_linearEquiv_symm its inverse is continuous, and g is recovered as the second projection composed with that continuous inverse. So the closed graph theorem inherits exactly the same single Baire dependency as the open mapping theorem.",
     "mathContext": "Closed graph $\\Gamma_g \\subseteq E \\times F$ is complete; $\\pi_1|_{\\Gamma_g}$ is a continuous linear bijection onto $E$ with continuous inverse, and $g = \\pi_2 \\circ (\\pi_1|_{\\Gamma_g})^{-1}$.",
     "significance": "key",
-    "relatedConcepts": ["closed graph theorem", "graph of a linear map", "complete subspace", "projection"]
+    "relatedConcepts": [
+      "closed graph theorem",
+      "graph of a linear map",
+      "complete subspace",
+      "projection"
+    ],
+    "prerequisites": [
+      "graph of a linear map",
+      "closed / complete subspaces",
+      "product space E × F",
+      "continuous projections"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `baire-category-theorem-oq-01-oq-01-oq-01` (Open Mapping / Closed Graph from Baire).

**Gap:** all 6 annotations carried `mathContext`, `significance`, and `relatedConcepts`, but **none had a `prerequisites` field**.

**Change:** add an accurate `prerequisites` array to each of the 6 annotations (Banach spaces, Baire category theorem, completeness/summability, open maps, continuous inverses, graphs and product spaces). All existing content preserved verbatim; `meta.json` unchanged.