### PR TITLE
Enrich cassini-identity-oq-01-oq-01-oq-01: add prerequisites to annotations

### DIFF
--- a/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01-oq-01/annotations.json
@@ -16,6 +16,11 @@
       "Fibonacci addition formula",
       "Bilinear identity",
       "Cassini's identity"
+    ],
+    "prerequisites": [
+      "Fibonacci numbers",
+      "Fibonacci addition formula F(n+k)",
+      "bilinear identities / induction"
     ]
   },
   {
@@ -34,6 +39,11 @@
       "Catalan's identity",
       "Diagonal specialization",
       "Open question resolution"
+    ],
+    "prerequisites": [
+      "Vajda's identity",
+      "diagonal specialization i=j=r",
+      "Fibonacci numbers"
     ]
   },
   {
@@ -52,6 +62,11 @@
       "d'Ocagne's identity",
       "Specialization",
       "Fibonacci shift"
+    ],
+    "prerequisites": [
+      "Vajda's identity",
+      "specialization j=1",
+      "Fibonacci shift"
     ]
   },
   {
@@ -69,6 +84,11 @@
     "relatedConcepts": [
       "Cassini's identity",
       "Specialization",
+      "Fibonacci recurrence"
+    ],
+    "prerequisites": [
+      "Vajda's identity",
+      "specialization i=j=1",
       "Fibonacci recurrence"
     ]
   },
@@ -89,6 +109,11 @@
       "norm_num",
       "Bilinear off-diagonal case",
       "Parity of the Cassini sign"
+    ],
+    "prerequisites": [
+      "evaluating Fibonacci numbers",
+      "norm_num",
+      "parity of (-1)^n"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cassini-identity-oq-01-oq-01-oq-01` (Vajda master identity and its Catalan / d'Ocagne / Cassini specializations).

**Gap:** all 5 annotations carried `mathContext`, `significance`, and `relatedConcepts`, but **none had a `prerequisites` field**.

**Change:** add an accurate `prerequisites` array to each of the 5 annotations (Fibonacci addition formula, diagonal/shift specializations, Fibonacci recurrence, `norm_num`, parity of $(-1)^n$). All existing content preserved verbatim; `meta.json` unchanged.