### PR TITLE
research(euler-criterion-squares-oq-01-oq-03-oq-01): Sophie Germain primes divide Mersenne numbers [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean
@@ -1,0 +1,129 @@
+import Mathlib
+
+/-!
+# Sophie Germain primes and Mersenne divisors
+
+Follow-up (child) of `euler-criterion-squares-oq-01-oq-03`, which formalized the
+**second supplement** to quadratic reciprocity:
+`IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7`.
+
+This file draws the classical arithmetic consequence for **Mersenne numbers**.
+
+## Main result
+
+If `p` is a prime with `p ≡ 3 (mod 4)` and `q = 2p + 1` is *also* prime (a Sophie
+Germain prime of this residue class), then
+
+```
+q ∣ 2^p - 1,
+```
+
+i.e. `q` divides the Mersenne number `M_p = 2^p - 1`.
+
+## Mechanism
+
+`p ≡ 3 (mod 4)` forces `q = 2p + 1 ≡ 7 (mod 8)`, so by the second supplement `2` is a
+quadratic residue mod `q`. Writing `2 = x^2` in `ZMod q` and applying Fermat's little
+theorem,
+```
+2^p = (x^2)^p = x^(2p) = x^(q-1) = 1   in  ZMod q,
+```
+because `2p = q - 1`. Hence `q ∣ 2^p - 1`.
+
+This explains, for example, `23 ∣ 2^11 - 1`, `47 ∣ 2^23 - 1`, `167 ∣ 2^83 - 1`.
+
+## Corollary
+
+For `p ≥ 5` in this class the divisor `q` is a *proper* divisor, so the Mersenne number
+`2^p - 1` is composite.
+
+All results are fully machine-checked: 0 sorries, 0 axioms.
+-/
+
+namespace SophieGermainMersenne
+
+open ZMod
+
+/-- `p ≡ 3 (mod 4)` forces `q = 2p + 1 ≡ 7 (mod 8)`. -/
+theorem q_mod_eight (p : ℕ) (hp4 : p % 4 = 3) : (2 * p + 1) % 8 = 7 := by
+  omega
+
+/-- When `q ≡ 7 (mod 8)`, `2` is a quadratic residue mod `q` (second supplement). -/
+theorem two_isSquare_of_mod {q : ℕ} [Fact q.Prime] (hq : q % 8 = 7) :
+    IsSquare (2 : ZMod q) := by
+  have hq2 : q ≠ 2 := by omega
+  exact (ZMod.exists_sq_eq_two_iff hq2).mpr (Or.inr hq)
+
+/-- **Sophie Germain / Mersenne divisor theorem.**
+If `p` is prime with `p ≡ 3 (mod 4)` and `q = 2p + 1` is prime, then `q ∣ 2^p - 1`. -/
+theorem dvd_mersenne {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 3)
+    (hq : (2 * p + 1).Prime) : (2 * p + 1) ∣ 2 ^ p - 1 := by
+  set q := 2 * p + 1 with hq_def
+  haveI : Fact q.Prime := ⟨hq⟩
+  have hp2 := hp.two_le
+  have hqmod : q % 8 = 7 := q_mod_eight p hp4
+  -- `2` is a square in `ZMod q`; extract a square root `x`.
+  obtain ⟨x, hx⟩ := two_isSquare_of_mod hqmod
+  -- `x ≠ 0`, else `2 = 0` in `ZMod q`, forcing `q ∣ 2`, impossible since `q ≥ 5`.
+  have hx0 : x ≠ 0 := by
+    rintro rfl
+    rw [mul_zero] at hx
+    have hdvd2 : q ∣ 2 := by
+      rw [← Nat.cast_two (R := ZMod q)] at hx
+      exact (ZMod.natCast_eq_zero_iff 2 q).mp hx
+    have := Nat.le_of_dvd (by norm_num) hdvd2
+    omega
+  -- Fermat: `2^p = (x^2)^p = x^(2p) = x^(q-1) = 1`.
+  have key : (2 : ZMod q) ^ p = 1 := by
+    have hsq : (2 : ZMod q) = x ^ 2 := by rw [hx]; ring
+    have h2p : 2 * p = q - 1 := by omega
+    rw [hsq, ← pow_mul, h2p]
+    exact ZMod.pow_card_sub_one_eq_one hx0
+  -- Convert back to divisibility over `ℕ`.
+  have h1 : (1 : ℕ) ≤ 2 ^ p := Nat.one_le_two_pow
+  have hcast : ((2 ^ p - 1 : ℕ) : ZMod q) = 0 := by
+    rw [Nat.cast_sub h1, Nat.cast_pow, Nat.cast_two, Nat.cast_one, key, sub_self]
+  exact (ZMod.natCast_eq_zero_iff (2 ^ p - 1) q).mp hcast
+
+/-- Linear-vs-exponential gap: `2p + 2 < 2^p` for `p ≥ 5`. -/
+theorem lin_lt_two_pow (p : ℕ) (hp : 5 ≤ p) : 2 * p + 2 < 2 ^ p := by
+  induction p with
+  | zero => omega
+  | succ n ih =>
+    rcases Nat.lt_or_ge n 5 with h | h
+    · interval_cases n <;> first | omega | norm_num
+    · have hn := ih h
+      have : 2 ^ (n + 1) = 2 ^ n + 2 ^ n := by rw [pow_succ]; ring
+      omega
+
+/-- **Corollary.** For `p ≥ 5` prime with `p ≡ 3 (mod 4)` and `q = 2p + 1` prime, the
+Mersenne number `2^p - 1` is composite (it has the proper divisor `q`). -/
+theorem mersenne_not_prime {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 3)
+    (hq : (2 * p + 1).Prime) (hp5 : 5 ≤ p) : ¬ (2 ^ p - 1).Prime := by
+  intro hM
+  have hdvd := dvd_mersenne hp hp4 hq
+  have hgap := lin_lt_two_pow p hp5
+  rcases (hM.eq_one_or_self_of_dvd (2 * p + 1) hdvd) with h | h
+  · omega
+  · -- `2p + 1 = 2^p - 1` contradicts `2p + 2 < 2^p`.
+    omega
+
+/-! ## Concrete examples of the theorem -/
+
+-- `p = 11`:  `23 ∣ 2^11 - 1 = 2047 = 23 · 89`.
+example : (23 : ℕ) ∣ 2 ^ 11 - 1 :=
+  dvd_mersenne (by norm_num) (by norm_num) (by norm_num)
+
+-- `p = 23`:  `47 ∣ 2^23 - 1`.
+example : (47 : ℕ) ∣ 2 ^ 23 - 1 :=
+  dvd_mersenne (by norm_num) (by norm_num) (by norm_num)
+
+-- `p = 83`:  `167 ∣ 2^83 - 1`.
+example : (167 : ℕ) ∣ 2 ^ 83 - 1 :=
+  dvd_mersenne (by norm_num) (by norm_num) (by norm_num)
+
+-- The Mersenne number `2^11 - 1 = 2047` is composite.
+example : ¬ (2 ^ 11 - 1).Prime :=
+  mersenne_not_prime (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+end SophieGermainMersenne

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "euler-criterion-squares-oq-01-oq-03-oq-01",
+  "slug": "euler-criterion-squares-oq-01-oq-03-oq-01",
+  "title": "Sophie Germain Primes Divide Mersenne Numbers — 2p+1 ∣ 2^p − 1 for p ≡ 3 (mod 4)",
+  "meta": {
+    "author": "classical number theory (Euler/Lagrange); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "second-supplement",
+      "mersenne-numbers",
+      "sophie-germain-primes",
+      "fermat-little-theorem",
+      "ZMod",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.exists_sq_eq_two_iff",
+        "description": "For [Fact q.Prime] and q ≠ 2, IsSquare (2 : ZMod q) ↔ q % 8 = 1 ∨ q % 8 = 7 — the second supplement, supplied by the parent entry. Here it is invoked at q = 2p+1 in the branch q % 8 = 7.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "ZMod.pow_card_sub_one_eq_one",
+        "description": "Fermat's little theorem in ZMod form: for a prime q and a ≠ 0 in ZMod q, a^(q-1) = 1. Applied to the square root x of 2 to collapse x^(q-1) = x^(2p) to 1.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a — converts the ZMod-q identity (2^p = 1, i.e. 2^p − 1 = 0) back to the divisibility statement q ∣ 2^p − 1 over ℕ.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "dvd_mersenne: the main theorem — for a prime p with p ≡ 3 (mod 4) and q = 2p+1 prime, q ∣ 2^p − 1. The proof turns the parent's second supplement into a Mersenne-divisibility statement: p ≡ 3 (mod 4) forces q ≡ 7 (mod 8) (q_mod_eight, by omega), so 2 is a quadratic residue mod q; writing 2 = x² and applying Fermat, 2^p = (x²)^p = x^(2p) = x^(q−1) = 1, whence q ∣ 2^p − 1.",
+      "q_mod_eight / two_isSquare_of_mod: the residue-class bookkeeping (p ≡ 3 (mod 4) ⟹ 2p+1 ≡ 7 (mod 8)) and the specialization of the second supplement to q = 2p+1.",
+      "mersenne_not_prime: the compositeness corollary — for p ≥ 5 in this class, q = 2p+1 is a proper divisor of 2^p − 1, so the Mersenne number is composite. Uses lin_lt_two_pow (2p+2 < 2^p for p ≥ 5, by induction) to rule out the degenerate case 2p+1 = 2^p − 1.",
+      "Worked instances by norm_num (no native_decide): 23 ∣ 2^11 − 1, 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1, and 2^11 − 1 = 2047 composite — the smallest Sophie Germain Mersenne divisors."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries; depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms — no sorryAx, no native_decide / Lean.ofReduceBool; numerical instances use plain norm_num). The result is unconditional: given the stated primality hypotheses on p and 2p+1 and p ≡ 3 (mod 4), the divisibility q ∣ 2^p − 1 is proved outright.",
+    "lineCount": 129,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "SophieGermainMersenne",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "description": "Draws the classical Mersenne-divisor consequence of the parent's second supplement to quadratic reciprocity. If p is a prime with p ≡ 3 (mod 4) and q = 2p+1 is also prime (a Sophie Germain prime of this residue class), then q divides the Mersenne number 2^p − 1. The mechanism is a three-line application of the second supplement plus Fermat's little theorem: p ≡ 3 (mod 4) forces q ≡ 7 (mod 8), so 2 is a quadratic residue mod q; writing 2 = x² in ZMod q gives 2^p = x^(2p) = x^(q−1) = 1 because 2p = q−1, hence q ∣ 2^p − 1. A corollary records that for p ≥ 5 in this class the divisor is proper, so 2^p − 1 is composite. Worked instances (23 ∣ 2^11 − 1, 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1) are discharged by norm_num, keeping the file free of native_decide.",
+  "overview": {
+    "historicalContext": "That a Sophie Germain prime forces a divisor of a Mersenne number is one of the oldest applications of the supplementary laws of quadratic reciprocity. Euler and Lagrange knew that if q = 2p+1 is prime then 2 is a quadratic residue mod q precisely when q ≡ ±1 (mod 8), and that this pins down whether q divides 2^p − 1 or 2^p + 1. For p ≡ 3 (mod 4) one has q ≡ 7 (mod 8), landing in the residue case, so q ∣ 2^p − 1. This is exactly the reasoning behind Euler's 1750s factorizations of Mersenne numbers (e.g. 23 ∣ 2^11 − 1, 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1) and, dually, behind the observation that many Sophie Germain primes q ≡ 3 (mod 8) instead divide 2^p + 1. The result remains a staple example in elementary number theory of turning a residue-class condition into a concrete divisibility.",
+    "problemStatement": "Prove that if p is prime, p ≡ 3 (mod 4), and q = 2p+1 is prime, then q ∣ 2^p − 1; and deduce that for p ≥ 5 the Mersenne number 2^p − 1 is composite.",
+    "keyResults": [
+      "Main theorem: for prime p with p ≡ 3 (mod 4) and prime q = 2p+1, q ∣ 2^p − 1.",
+      "Residue bookkeeping: p ≡ 3 (mod 4) ⟹ q = 2p+1 ≡ 7 (mod 8), so 2 is a quadratic residue mod q.",
+      "Compositeness corollary: for p ≥ 5 in this class, 2^p − 1 has the proper divisor 2p+1, hence is composite.",
+      "Growth lemma: 2p + 2 < 2^p for p ≥ 5, ruling out the degenerate case 2p+1 = 2^p − 1.",
+      "Worked instances: 23 ∣ 2^11 − 1, 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1, and 2^11 − 1 = 2047 composite (all by norm_num)."
+    ],
+    "proofStrategy": "The core is dvd_mersenne. Set q = 2p+1 and record Fact q.Prime. From p ≡ 3 (mod 4), omega derives q ≡ 7 (mod 8) (q_mod_eight). The parent's second supplement (ZMod.exists_sq_eq_two_iff, via two_isSquare_of_mod) then yields IsSquare (2 : ZMod q), i.e. 2 = x·x for some x. One checks x ≠ 0 (else 2 = 0 in ZMod q forces q ∣ 2, impossible as q ≥ 5). Rewriting 2 = x² and using 2p = q − 1, Fermat's little theorem (ZMod.pow_card_sub_one_eq_one) collapses (2:ZMod q)^p = (x²)^p = x^(2p) = x^(q−1) = 1. Finally ZMod.natCast_eq_zero_iff converts the ZMod-q identity 2^p − 1 = 0 (via Nat.cast_sub, using 1 ≤ 2^p) into q ∣ 2^p − 1 over ℕ. The corollary mersenne_not_prime combines this with the elementary growth bound lin_lt_two_pow (2p+2 < 2^p for p ≥ 5, proved by induction with a doubling step) to exclude 2p+1 = 2^p − 1, so the prime-divisor dichotomy of a prime Mersenne number is contradicted.",
+    "keyInsights": [
+      "**The residue class p ≡ 3 (mod 4) is exactly what selects the 2^p − 1 side.** It sends q = 2p+1 to 7 (mod 8), the residue case of the second supplement; the complementary class p ≡ 1 (mod 4) sends q to 3 (mod 8), where 2 is a non-residue and q instead divides 2^p + 1.",
+      "**Euler's criterion is not even needed — a bare square root plus Fermat suffices.** Once 2 = x² in ZMod q, the exponent identity 2p = q − 1 does all the work: 2^p = x^(q−1) = 1 by Fermat's little theorem, so the second supplement enters only through the existence of the square root, not its (p−1)/2-power characterization.",
+      "**The theorem manufactures proper Mersenne divisors on demand.** Every Sophie Germain prime p ≡ 3 (mod 4) with p ≥ 5 certifies a nontrivial factor 2p+1 of 2^p − 1, so the Mersenne number is composite — a clean structural source of compositeness contrasting with case-by-case trial division.",
+      "**Nat-subtraction is handled honestly.** The passage from (2:ZMod q)^p = 1 to q ∣ 2^p − 1 uses 1 ≤ 2^p so that the truncated ℕ-subtraction 2^p − 1 casts to (2:ZMod q)^p − 1, avoiding the usual off-by-one traps of ℕ subtraction."
+    ]
+  },
+  "conclusion": {
+    "summary": "Turns the parent's second supplementary law into a concrete divisibility theorem for Mersenne numbers: a Sophie Germain prime p ≡ 3 (mod 4) (with 2p+1 prime) forces 2p+1 ∣ 2^p − 1. The proof is a short composition — the second supplement gives a square root of 2 mod q = 2p+1, and Fermat's little theorem with 2p = q − 1 collapses 2^p to 1 mod q. A corollary shows 2^p − 1 is composite for p ≥ 5. 5 theorems, 0 sorries, 0 axioms.",
+    "implications": [
+      "Provides a structural source of Mersenne-number factors, explaining Euler's classical factorizations 23 ∣ 2^11 − 1, 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1.",
+      "Demonstrates the second supplement in action: a residue-class condition (p mod 4) converts directly into an arithmetic divisibility, the intended downstream use of the parent entry.",
+      "Isolates the exact role of the second supplement — supplying a square root of 2 — showing that Fermat's little theorem, not the full Euler criterion, finishes the argument."
+    ],
+    "openQuestions": [
+      "Prove the complementary case: for p ≡ 1 (mod 4) with q = 2p+1 prime, q ≡ 3 (mod 8), 2 is a non-residue, and q ∣ 2^p + 1 (a divisor of the Fermat-style number rather than the Mersenne number).",
+      "Combine with a Sophie-Germain density heuristic or a supply of explicit Sophie Germain primes to certify an infinite explicit family of composite Mersenne numbers 2^p − 1."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The direct parent: the second supplement IsSquare (2 : ZMod q) ↔ q ≡ ±1 (mod 8). This leaf applies it at q = 2p+1 to obtain the Mersenne divisor, answering the parent's open question on Euler/Lagrange criteria for Mersenne divisors."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "related",
+      "description": "The grandparent Euler-criterion entry (IsSquare a ⟺ a^((p−1)/2) = 1). This leaf shows that for the Mersenne application a bare square root plus Fermat's little theorem suffices, without invoking the (p−1)/2-power form."
+    }
+  ],
+  "sections": [
+    {
+      "id": "residue-setup",
+      "title": "Residue-Class Setup",
+      "startLine": 47,
+      "endLine": 57,
+      "summary": "q_mod_eight: p ≡ 3 (mod 4) ⟹ 2p+1 ≡ 7 (mod 8), by omega. two_isSquare_of_mod: specializes the parent's second supplement (ZMod.exists_sq_eq_two_iff) to a prime q with q ≡ 7 (mod 8), giving IsSquare (2 : ZMod q).",
+      "mathContext": "$p \\equiv 3 \\pmod 4 \\Rightarrow q = 2p+1 \\equiv 7 \\pmod 8$, hence $2$ is a quadratic residue mod $q$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Mersenne Divisor Theorem",
+      "startLine": 59,
+      "endLine": 87,
+      "summary": "dvd_mersenne: for prime p ≡ 3 (mod 4) and prime q = 2p+1, q ∣ 2^p − 1. Extracts a square root x of 2 mod q, checks x ≠ 0, then uses 2p = q−1 and Fermat's little theorem (ZMod.pow_card_sub_one_eq_one) to get (2:ZMod q)^p = x^(q−1) = 1, converted to divisibility by ZMod.natCast_eq_zero_iff.",
+      "mathContext": "$2^p = (x^2)^p = x^{2p} = x^{q-1} = 1$ in $\\mathbb{Z}/q$, so $q \\mid 2^p - 1$."
+    },
+    {
+      "id": "compositeness",
+      "title": "Compositeness of the Mersenne Number",
+      "startLine": 89,
+      "endLine": 109,
+      "summary": "lin_lt_two_pow: 2p+2 < 2^p for p ≥ 5 (induction with a doubling step). mersenne_not_prime: for p ≥ 5 in this class, q = 2p+1 is a proper divisor of 2^p − 1, so the Mersenne number is not prime.",
+      "mathContext": "For $p \\ge 5$, $2p+1$ is a proper divisor of $2^p - 1$, hence $2^p - 1$ is composite."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples (norm_num, no native_decide)",
+      "startLine": 111,
+      "endLine": 129,
+      "summary": "Worked instances: 23 ∣ 2^11 − 1 (= 2047 = 23·89), 47 ∣ 2^23 − 1, 167 ∣ 2^83 − 1, and 2^11 − 1 composite — the smallest Sophie Germain Mersenne divisors, all via norm_num applied to dvd_mersenne / mersenne_not_prime.",
+      "mathContext": "$23 \\mid 2^{11}-1,\\; 47 \\mid 2^{23}-1,\\; 167 \\mid 2^{83}-1$; $2^{11}-1 = 2047$ is composite."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry answering the parent entry `euler-criterion-squares-oq-01-oq-03`'s open question on Euler/Lagrange criteria for Mersenne divisors.

**Main theorem** (`dvd_mersenne`): if $p$ is prime, $p \equiv 3 \pmod 4$, and $q = 2p+1$ is prime (a Sophie Germain prime of this class), then
$$q \mid 2^p - 1,$$
i.e. $q$ divides the Mersenne number $M_p$.

**Mechanism** (three lines of real content):
- $p \equiv 3 \pmod 4 \Rightarrow q \equiv 7 \pmod 8$, so by the parent's second supplement $2$ is a quadratic residue mod $q$.
- Writing $2 = x^2$ in $\mathbb{Z}/q$ and using $2p = q-1$, Fermat's little theorem gives $2^p = x^{2p} = x^{q-1} = 1$, hence $q \mid 2^p - 1$.

**Corollary** (`mersenne_not_prime`): for $p \ge 5$ in this class, $2p+1$ is a *proper* divisor, so $2^p - 1$ is composite.

**Worked instances** (by `norm_num`, no `native_decide`): $23 \mid 2^{11}-1$, $47 \mid 2^{23}-1$, $167 \mid 2^{83}-1$; $2^{11}-1 = 2047$ composite.

## Verification
- 5 theorems, 0 definitions, 129 lines
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`; no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Built against Mathlib 4.26 (`lake env lean`).

## Files
- `proofs/Proofs/EulerCriterionSquaresOQ01OQ03OQ01.lean`
- `src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)