### PR TITLE
Enrich cauchy-interlacing-theorem-oq-01-oq-02-oq-02: dedup + prerequisites

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02/annotations.json
@@ -2,67 +2,120 @@
   {
     "id": "ann-poincare-hypothesis-bundle",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 80, "endLine": 92 },
-    "type": "technique",
+    "range": {
+      "startLine": 80,
+      "endLine": 92
+    },
+    "type": "tactic",
     "title": "The Shared Poincaré Hypothesis Bundle and `include`",
-    "content": "The three eigenvalue corollaries all consume the *same* elaborate setup, so it is factored into a single section `variable` block rather than repeated per theorem: the operator `T` with an eigenbasis `b` and descending spectrum `lam` (`hT`, `hlam`), a codimension data `H` of dimension `n` (`hHdim`), the compression `TH` with its own eigenbasis `bH`, spectrum `mu` (`hTH`, `hmu`), and the crucial Rayleigh-agreement hypothesis `hRayleigh` linking the two quotients. Because Lean 4 only auto-includes `variable`s that appear in a theorem's *statement*, hypotheses used solely inside proof bodies (here the whole Poincaré package feeding `poincare_separation`) would be silently dropped; the explicit `include T b hT hlam hHdim TH bH hTH hmu hRayleigh` forces them into every theorem in the section. This is the same `include`-or-vanish pitfall that silently breaks proofs when a hypothesis is named but never referenced in the goal.",
+    "content": "The three eigenvalue corollaries all consume the *same* elaborate setup, so it is factored into a single section `variable` block rather than repeated per theorem: the operator `T` with an eigenbasis `b` and descending spectrum `lam` (`hT`, `hlam`), a codimension data `H` of dimension `n` (`hHdim`), the compression `TH` with its own eigenbasis `bH`, spectrum `mu` (`hTH`, `hmu`), and the crucial Rayleigh-agreement hypothesis `hRayleigh` linking the two quotients. Because Lean 4 only auto-includes `variable`s that appear in a theorem's *statement*, hypotheses used solely inside proof bodies (here the whole Poincaré package feeding `poincare_separation`) would be silently dropped; the explicit `include T b hT hlam hHdim TH bH hTH hmu hRayleigh` forces them into every theorem in the section. This is the same `include`-or-vanish pitfall that silently breaks proofs when a hypothesis is named but never referenced in the goal. Mathematically, hRayleigh (the pointwise agreement of TH's Rayleigh quotient with T's) is the ONLY link between the compression and the full operator the corollaries need; because it is passed as a hypothesis rather than derived, the file never re-opens the spectral theorem.",
     "mathContext": "All corollaries are stated for a fixed $(T, b, \\lambda)$ and its compression $(T_H, b_H, \\mu)$ satisfying the Poincaré interlacing hypotheses; the bundle is shared rather than re-declared.",
     "significance": "supporting",
-    "relatedConcepts": ["section variables", "include directive", "Poincaré separation hypotheses", "Rayleigh quotient agreement"]
+    "relatedConcepts": [
+      "section variables",
+      "include directive",
+      "Poincaré separation hypotheses",
+      "Rayleigh quotient agreement"
+    ],
+    "prerequisites": [
+      "Lean 4 section variables & include",
+      "Poincaré separation theorem",
+      "Rayleigh quotient",
+      "self-adjoint operators"
+    ]
   },
   {
     "id": "ann-compress-isPositive",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 68, "endLine": 75 },
+    "range": {
+      "startLine": 68,
+      "endLine": 75
+    },
     "type": "theorem",
     "title": "Positivity of Compressions (Operator Form)",
     "content": "`compress_isPositive` proves that the orthogonal compression `compress T H` of a positive operator `T` to ANY subspace `H` is again positive, stated with Mathlib's `LinearMap.IsPositive` (symmetric and `∀ x, 0 ≤ re ⟪T x, x⟫`). Symmetry is `isSymmetric_compress hT.isSymmetric H`. For Rayleigh nonnegativity, `⟪compress T H y, y⟫_H` rewrites to `⟪T ↑y, ↑y⟫_V` via `compress_apply` and `Submodule.inner_orthogonalProjection_eq_of_mem_right`, after which `hT.2 ↑y` closes the goal. No eigenvalues and no spectral theorem are used.",
     "mathContext": "If T ⪰ 0 then P_H T P_H ⪰ 0 for every subspace H — the orthogonal compression of a positive semidefinite operator is positive semidefinite.",
     "significance": "key",
-    "relatedConcepts": ["positive semidefinite operators", "orthogonal compression", "Rayleigh quotient", "orthogonal projection adjoint"]
-  },
-  {
-    "id": "ann-poincare-hypothesis-package",
-    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 80, "endLine": 92 },
-    "type": "technique",
-    "title": "The Shared Poincaré Hypothesis Package (Rayleigh Agreement)",
-    "content": "The three eigenvalue corollaries share one `variable` block that abstracts exactly the data of Poincaré separation: the operator `T` with antitone eigendata `(b, lam)` on `V`, a codimension-`m` subspace `H` of dimension `n`, a symmetric operator `TH` on `H` with antitone eigendata `(bH, mu)`, and — the crucial hypothesis — `hRayleigh`, stating that `TH`'s Rayleigh quotient on `H` agrees pointwise with `T`'s. This agreement is the ONLY link between the compression and the full operator that the corollaries need; because it is passed as a hypothesis rather than derived, the file never re-opens the spectral theorem. The explicit `include T b hT ... hRayleigh` forces Lean to thread these into every proof body even though several appear only through `poincare_separation`.",
-    "mathContext": "Rayleigh agreement: for all y ∈ H, re⟪TH y, y⟫/‖y‖² = re⟪T y, y⟫/‖y‖². This single identity, plus the two Poincaré bounds λ_{k+m} ≤ μ_k ≤ λ_k, yields every corollary below.",
-    "significance": "supporting",
-    "relatedConcepts": ["Poincaré separation", "Rayleigh quotient", "Lean include directive", "hypothesis abstraction"]
+    "relatedConcepts": [
+      "positive semidefinite operators",
+      "orthogonal compression",
+      "Rayleigh quotient",
+      "orthogonal projection adjoint"
+    ],
+    "prerequisites": [
+      "positive semidefinite operators",
+      "orthogonal projection & its adjoint",
+      "operator compression P_H T P_H"
+    ]
   },
   {
     "id": "ann-compress-eigenvalues-nonneg",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 98, "endLine": 101 },
+    "range": {
+      "startLine": 98,
+      "endLine": 101
+    },
     "type": "theorem",
     "title": "Nonnegative Compression Eigenvalues",
     "content": "`compress_eigenvalues_nonneg` is the eigenvalue form of positivity: if every eigenvalue `lam i` of `T` is nonnegative, then for each `k` the chain `0 ≤ lam ⟨k+m⟩ ≤ mu k` (the nonnegativity hypothesis composed with the lower Poincaré bound) gives `0 ≤ mu k`. Proved by a single `le_trans (hpos _) (poincare_separation ...).1`.",
     "mathContext": "A PSD operator's compression has nonnegative eigenvalues, read off the Poincaré lower bound 0 ≤ λ_{k+m} ≤ μ_k.",
     "significance": "key",
-    "relatedConcepts": ["Poincaré separation", "eigenvalues", "positive semidefinite"]
+    "relatedConcepts": [
+      "Poincaré separation",
+      "eigenvalues",
+      "positive semidefinite"
+    ],
+    "prerequisites": [
+      "Poincaré separation",
+      "eigenvalues of self-adjoint operators",
+      "positive semidefiniteness"
+    ]
   },
   {
     "id": "ann-compress-eigenvalue-mem-Icc",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 108, "endLine": 123 },
+    "range": {
+      "startLine": 108,
+      "endLine": 123
+    },
     "type": "theorem",
     "title": "Spectral-Range Containment",
     "content": "`compress_eigenvalue_mem_Icc` sandwiches every compression eigenvalue inside the spectral range of `T`: `mu k ∈ Set.Icc (lam ⟨n+m-1⟩) (lam ⟨0⟩) = [λ_min, λ_max]`. The lower endpoint chains `lam ⟨n+m-1⟩ ≤ lam ⟨k+m⟩` (antitonicity on the Fin indices `⟨k+m⟩ ≤ ⟨n+m-1⟩`) with the lower Poincaré bound; the upper chains the upper Poincaré bound with `lam ⟨k⟩ ≤ lam ⟨0⟩` (antitonicity on `⟨0⟩ ≤ ⟨k⟩`). Both endpoint comparisons reduce to `Fin.le_def` plus `omega`.",
     "mathContext": "Every eigenvalue of a compression lies between the smallest and largest eigenvalues of the full operator: λ_min ≤ μ_k ≤ λ_max.",
     "significance": "key",
-    "relatedConcepts": ["Poincaré separation", "antitone eigenvalues", "spectral range", "interlacing"]
+    "relatedConcepts": [
+      "Poincaré separation",
+      "antitone eigenvalues",
+      "spectral range",
+      "interlacing"
+    ],
+    "prerequisites": [
+      "Poincaré separation",
+      "antitone eigenvalue ordering",
+      "spectral range (min/max eigenvalue)"
+    ]
   },
   {
     "id": "ann-trace-compress-nonneg",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
-    "range": { "startLine": 125, "endLine": 128 },
+    "range": {
+      "startLine": 125,
+      "endLine": 128
+    },
     "type": "theorem",
     "title": "Nonnegative Trace of a PSD Compression",
     "content": "`trace_compress_nonneg` lifts eigenvalue nonnegativity through `Finset.sum_nonneg`: if every `lam i ≥ 0` then the trace `∑_k mu k` of the compression is nonnegative, since each summand `mu k ≥ 0` by `compress_eigenvalues_nonneg`.",
     "mathContext": "A positive semidefinite compression has nonnegative trace, the eigenvalue-side companion of tr(P_H T P_H) ≥ 0.",
     "significance": "supporting",
-    "relatedConcepts": ["trace", "positive semidefinite", "finite sums"]
+    "relatedConcepts": [
+      "trace",
+      "positive semidefinite",
+      "finite sums"
+    ],
+    "prerequisites": [
+      "trace as a sum of eigenvalues",
+      "positive semidefinite operators",
+      "finite sums of nonnegatives"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-02-oq-02` (Poincaré separation corollaries).

**Gaps found & fixed** (content otherwise preserved verbatim):
1. **Duplicate annotation** — two cards covered the *exact* same range 80–92 (the shared Poincaré hypothesis bundle). Kept the `include`-pitfall one and folded the other's unique mathematical insight (hRayleigh is the only link between compression and full operator, so the file never re-opens the spectral theorem) into it, then removed the redundant card.
2. **Missing `prerequisites`** — added an accurate `prerequisites` array to all 5 annotations.
3. **Non-canonical `type`** — normalized `technique` → `tactic`.

Result: 5 non-overlapping annotations, canonical `type`/`significance`, each with full metadata. `meta.json` unchanged.