### PR TITLE
Enrich collatz-structured-oq-01: add prerequisites to annotations

### DIFF
--- a/src/data/proofs/collatz-structured-oq-01/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-01/annotations.json
@@ -2,67 +2,136 @@
   {
     "id": "ann-collatz-oq01-header",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 1, "endLine": 53 },
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
     "type": "concept",
     "title": "Module Header: Reducing Collatz to Odd Inputs",
     "content": "The header states the goal: formalize the standard reduction of the Collatz conjecture to odd numbers. It imports `Mathlib` and `Proofs.CollatzStructured` (which supplies the Collatz map, `ReachesOne`, the powers-of-two lemma `pow_two_reaches_one`, and the doubling-closure lemma `reaches_one_double`). The parent file declares the full conjecture as an `axiom`, but every theorem in this file is proved without it — the file is genuinely axiom-free.",
     "mathContext": "The Collatz map is $T(n) = n/2$ (n even), $3n+1$ (n odd); `ReachesOne n` means some iterate $T^k(n) = 1$. The conjecture is $\\forall n \\geq 1,\\ \\text{ReachesOne } n$. This file proves it is equivalent to its restriction to odd $n$.",
     "significance": "supporting",
-    "relatedConcepts": ["Collatz conjecture", "reaching set", "odd reduction"]
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "reaching set",
+      "odd reduction"
+    ],
+    "prerequisites": [
+      "Collatz (3n+1) map",
+      "ReachesOne reachability predicate",
+      "even/odd case reduction"
+    ]
   },
   {
     "id": "ann-collatz-oq01-backward-step",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 55, "endLine": 64 },
+    "range": {
+      "startLine": 55,
+      "endLine": 64
+    },
     "type": "insight",
     "title": "Backward one-step: ReachesOne (collatz n) → ReachesOne n",
     "content": "If the successor `collatz n` reaches 1 in `k` steps, then `n` reaches 1 in `k+1` steps — prepend the first step. The proof rewrites `collatzIter (k+1) n` as `collatz^[k] (collatz n)` via `Function.iterate_succ_apply` and closes with the hypothesis. This direction is unconditional.",
     "mathContext": "The set of numbers reaching 1 is closed under taking Collatz preimages: if $T(n)$ reaches 1, so does $n$.",
     "significance": "supporting",
-    "relatedConcepts": ["forward invariance", "function iteration"]
+    "relatedConcepts": [
+      "forward invariance",
+      "function iteration"
+    ],
+    "prerequisites": [
+      "Collatz map",
+      "reachability (ReachesOne)",
+      "one-step transition lemmas"
+    ]
   },
   {
     "id": "ann-collatz-oq01-forward-step",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 66, "endLine": 95 },
+    "range": {
+      "startLine": 66,
+      "endLine": 95
+    },
     "type": "insight",
     "title": "Forward one-step and the n=1 base case",
     "content": "If `n` reaches 1, so does `collatz n`. When the witness has `k = 0` steps, `n = 1`, and `collatz 1 = 4 = 2²` reaches 1 by `pow_two_reaches_one`. For `k = j+1`, drop the first iterate via `Function.iterate_succ_apply`. Combined with the backward step, this gives the one-step invariance equivalence `reachesOne_collatz_iff : ReachesOne (collatz n) ↔ ReachesOne n`.",
     "mathContext": "The reaching set is invariant under the Collatz map in both directions. The only non-formal point is the fixed-point-adjacent base case n=1, handled by the powers-of-two lemma.",
     "significance": "critical",
-    "relatedConcepts": ["dynamical invariance", "powers of two"]
+    "relatedConcepts": [
+      "dynamical invariance",
+      "powers of two"
+    ],
+    "prerequisites": [
+      "Collatz map",
+      "reachability",
+      "base case n = 1"
+    ]
   },
   {
     "id": "ann-collatz-oq01-doubling",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 97, "endLine": 118 },
+    "range": {
+      "startLine": 97,
+      "endLine": 118
+    },
     "type": "insight",
     "title": "Doubling and power-of-two invariance (equivalences)",
     "content": "`reachesOne_two_mul_iff : ReachesOne (2·n) ↔ ReachesOne n`. The forward direction composes forward one-step invariance with `collatz (2·n) = n`; the reverse is the parent's `reaches_one_double`. Induction on `m` lifts this to `reachesOne_pow_two_mul_iff : ReachesOne (2^m·n) ↔ ReachesOne n`. The parent file only proved the forward closure direction; the reverse is what enables the reduction.",
     "mathContext": "Multiplying by a power of two does not change whether a number reaches 1, since the extra factors of two are stripped by the first halving steps.",
     "significance": "critical",
-    "relatedConcepts": ["closure under doubling", "2-adic structure"]
+    "relatedConcepts": [
+      "closure under doubling",
+      "2-adic structure"
+    ],
+    "prerequisites": [
+      "powers of two",
+      "doubling invariance of Collatz",
+      "iff equivalences"
+    ]
   },
   {
     "id": "ann-collatz-oq01-oddpart",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 120, "endLine": 158 },
+    "range": {
+      "startLine": 120,
+      "endLine": 158
+    },
     "type": "definition",
     "title": "The odd part and equireachability",
     "content": "`oddPart n = ordCompl[2] n` strips every factor of two. For `n ≥ 1` it is odd (`oddPart_odd`, from `Nat.not_dvd_ordCompl`) and positive (`oddPart_pos`, from `Nat.ordCompl_pos`), and `2^v₂(n)·oddPart n = n` (`pow_factorization_mul_oddPart`, from `Nat.ordProj_mul_ordCompl_eq_self`). Hence `reachesOne_oddPart_iff : ReachesOne (oddPart n) ↔ ReachesOne n` via power-of-two invariance.",
     "mathContext": "Every $n \\geq 1$ factors uniquely as $2^{v_2(n)} \\cdot m$ with $m$ odd; reachability depends only on the odd part $m$.",
     "significance": "critical",
-    "relatedConcepts": ["2-adic valuation", "ordCompl", "factorization"]
+    "relatedConcepts": [
+      "2-adic valuation",
+      "ordCompl",
+      "factorization"
+    ],
+    "prerequisites": [
+      "odd part of a natural number",
+      "factoring out powers of 2 (2-adic valuation)",
+      "equireachability"
+    ]
   },
   {
     "id": "ann-collatz-oq01-reduction",
     "proofId": "collatz-structured-oq-01",
-    "range": { "startLine": 160, "endLine": 183 },
+    "range": {
+      "startLine": 160,
+      "endLine": 183
+    },
     "type": "theorem",
     "title": "Headline: reduction to odd inputs and counterexample corollary",
     "content": "`collatz_reduces_to_odd`: the Collatz conjecture for all `n ≥ 1` is equivalent to the conjecture for all odd `n ≥ 1`. Forward is immediate; backward strips powers of two via `reachesOne_oddPart_iff`. The contrapositive `collatz_counterexample_odd` shows any counterexample yields an odd counterexample. Both are proved with zero axioms; `#print axioms collatz_reduces_to_odd` lists only `propext`, `Classical.choice`, `Quot.sound`.",
     "mathContext": "$(\\forall n \\geq 1,\\ \\text{ReachesOne } n) \\iff (\\forall \\text{ odd } m \\geq 1,\\ \\text{ReachesOne } m)$. The reduction narrows the search space but leaves the open conjecture open.",
     "significance": "critical",
-    "relatedConcepts": ["Collatz conjecture", "minimal counterexample", "search-space reduction"]
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "minimal counterexample",
+      "search-space reduction"
+    ],
+    "prerequisites": [
+      "reduction to odd inputs",
+      "reachability equivalence",
+      "contrapositive counterexample corollary"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `collatz-structured-oq-01` (reducing Collatz to odd inputs).

**Gap:** all 6 annotations carried `mathContext`, `significance`, and `relatedConcepts`, but **none had a `prerequisites` field**.

**Change:** add an accurate `prerequisites` array to each of the 6 annotations (Collatz map, reachability, powers of two / doubling invariance, odd part / 2-adic valuation, reduction to odd inputs). All existing content preserved verbatim; `meta.json` unchanged.