### PR TITLE
Enrich cube-root-3-irrational-oq-01-oq-03: prerequisites + canonical enums

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-03/annotations.json
@@ -2,56 +2,118 @@
   {
     "id": "ann-header",
     "proofId": "cube-root-3-irrational-oq-01-oq-03",
-    "range": { "startLine": 1, "endLine": 34 },
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
     "type": "concept",
     "title": "Relaxing Eisenstein's constant: from a prime to squarefree-at-a-prime",
     "content": "The docstring frames the entry against its parent cube-root-3-irrational-oq-01, which proves Xⁿ − p irreducible for prime p and asks to relax the constant to 'a squarefree at some prime'. The key point is that Eisenstein at a prime q only needs q to divide the constant term to the FIRST power — nothing forces the whole constant a to be prime. So Xⁿ − a is irreducible over ℤ (and ℚ) whenever there is a prime q with q ∣ a and q² ∤ a. The file imports only Mathlib in namespace CubeRoot3IrrationalOQ01OQ03 with open Polynomial.",
     "mathContext": "Goal: $X^n - a$ irreducible over $\\mathbb{Z}$ and $\\mathbb{Q}$ whenever some prime $q$ satisfies $q \\mid a$ and $q^2 \\nmid a$, for $n \\ge 1$. Since $X^n - a$ is the minimal polynomial of $a^{1/n}$, irreducibility pins $[\\mathbb{Q}(a^{1/n}):\\mathbb{Q}] = n$.",
     "significance": "supporting",
-    "relatedConcepts": ["Eisenstein's criterion", "minimal polynomial", "algebraic degree", "squarefree"]
+    "relatedConcepts": [
+      "Eisenstein's criterion",
+      "minimal polynomial",
+      "algebraic degree",
+      "squarefree"
+    ],
+    "prerequisites": [
+      "Eisenstein's criterion",
+      "squarefree integers",
+      "prime ideals P = span{q}"
+    ]
   },
   {
     "id": "ann-general-int",
     "proofId": "cube-root-3-irrational-oq-01-oq-03",
-    "range": { "startLine": 42, "endLine": 80 },
-    "type": "proof-technique",
+    "range": {
+      "startLine": 42,
+      "endLine": 80
+    },
+    "type": "tactic",
     "title": "The four Eisenstein hypotheses at P = span{q}",
     "content": "irreducible_X_pow_sub_C_of_squarefree_at_prime_int applies irreducible_of_eisenstein_criterion at the prime ideal P = span{q}. The four checks: (1) leadingCoeff = 1 ∉ P since P is proper; (2) each coefficient below degree n is 0 or −a, and the m = 0 case −a ∈ P follows from q ∣ a via Ideal.mem_span_singleton.mpr then neg_mem; (3) 0 < degree = n by degree_X_pow_sub_C; (4) the constant −a ∉ P² is reduced by Ideal.neg_mem_iff, Ideal.span_singleton_pow, and Ideal.mem_span_singleton to ¬ (q² ∣ a) — exactly the hypothesis; (5) monic_X_pow_sub_C gives monic, hence primitive.",
     "mathContext": "The two divisibility hypotheses map onto the two Eisenstein sides: $q \\mid a$ is $-a \\in (q)$; $q^2 \\nmid a$ is $-a \\notin (q^2) = (q)^2$.",
     "significance": "critical",
-    "relatedConcepts": ["prime ideal", "Ideal.span_singleton_pow", "coefficient of Xⁿ − C a", "primitive polynomial"]
+    "relatedConcepts": [
+      "prime ideal",
+      "Ideal.span_singleton_pow",
+      "coefficient of Xⁿ − C a",
+      "primitive polynomial"
+    ],
+    "prerequisites": [
+      "Eisenstein's criterion",
+      "prime ideal span{q}",
+      "irreducibility over ℤ"
+    ]
   },
   {
     "id": "ann-gauss",
     "proofId": "cube-root-3-irrational-oq-01-oq-03",
-    "range": { "startLine": 87, "endLine": 98 },
-    "type": "proof-technique",
+    "range": {
+      "startLine": 87,
+      "endLine": 98
+    },
+    "type": "tactic",
     "title": "Gauss's lemma lifts ℤ-irreducibility to ℚ",
     "content": "irreducible_X_pow_sub_C_of_squarefree_at_prime_rat uses IsPrimitive.Int.irreducible_iff_irreducible_map_cast: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is. After identifying the casted polynomial with Xⁿ − C (a : ℚ) via map_sub/map_pow, the ℚ result is exactly the ℤ theorem.",
     "mathContext": "Field irreducibility (over $\\mathbb{Q}$) is what pins the algebraic degree of the radical $a^{1/n}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Gauss's lemma", "primitive polynomial", "polynomial map"]
+    "relatedConcepts": [
+      "Gauss's lemma",
+      "primitive polynomial",
+      "polynomial map"
+    ],
+    "prerequisites": [
+      "Gauss's lemma",
+      "primitive polynomials",
+      "ℤ-irreducibility ⇒ ℚ-irreducibility"
+    ]
   },
   {
     "id": "ann-prime-case",
     "proofId": "cube-root-3-irrational-oq-01-oq-03",
-    "range": { "startLine": 104, "endLine": 114 },
+    "range": {
+      "startLine": 104,
+      "endLine": 114
+    },
     "type": "concept",
     "title": "The parent's prime case is the corollary q = p",
     "content": "irreducible_X_pow_sub_C_prime_int recovers the parent theorem: for prime p take the witnessing prime q = p. Then p ∣ p is dvd_refl, and p² ∤ p because p² ∣ p would cancel one factor (mul_dvd_mul_iff_left) to give p ∣ 1, contradicting primality. So the new criterion strictly subsumes the prime-only parent.",
     "mathContext": "$p$ prime $\\Rightarrow p \\mid p$ and $p^2 \\nmid p$, so every prime radicand is a special case.",
     "significance": "supporting",
-    "relatedConcepts": ["dvd_refl", "mul_dvd_mul_iff_left", "prime"]
+    "relatedConcepts": [
+      "dvd_refl",
+      "mul_dvd_mul_iff_left",
+      "prime"
+    ],
+    "prerequisites": [
+      "Eisenstein at a prime",
+      "specialization q = p",
+      "irrationality of ⁿ√p"
+    ]
   },
   {
     "id": "ann-composite",
     "proofId": "cube-root-3-irrational-oq-01-oq-03",
-    "range": { "startLine": 120, "endLine": 142 },
-    "type": "example",
+    "range": {
+      "startLine": 120,
+      "endLine": 142
+    },
+    "type": "concept",
     "title": "Composite (and non-squarefree) radicands: √6, ∛12, √24",
     "content": "Three specializations the prime-only parent cannot reach. X² − 6 (6 = 2·3, squarefree at 2), X³ − 12 (12 = 2²·3, non-squarefree but squarefree at 3), X² − 24 (24 = 2³·3, squarefree at 3) are all irreducible over ℚ; the divisibility side-goals q ∣ a and ¬ (q² ∣ a) are closed by norm_num. Hence √6, ∛12, √24 have algebraic degree exactly 2, 3, 2 — a single simple prime factor is all Eisenstein needs, even when a itself is not squarefree.",
     "mathContext": "$12 = 2^2 \\cdot 3$ fails global squarefreeness, yet $3 \\mid 12$ and $9 \\nmid 12$, so Eisenstein at $q = 3$ still certifies $X^3 - 12$ irreducible.",
     "significance": "critical",
-    "relatedConcepts": ["algebraic degree of radicals", "non-squarefree radicand", "norm_num"]
+    "relatedConcepts": [
+      "algebraic degree of radicals",
+      "non-squarefree radicand",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "squarefree part of an integer",
+      "irrationality of √6 / ∛12 / √24",
+      "composite radicands"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-01-oq-03` (relaxing Eisenstein from a prime to squarefree-at-a-prime).

**Gaps fixed** (content preserved verbatim):
1. **Missing `prerequisites`** — added an accurate array to all 5 annotations (Eisenstein criterion, squarefree parts, Gauss's lemma, composite radicands).
2. **Non-canonical `type`** — normalized `proof-technique` → `tactic` and `example` → `concept`.

`meta.json` unchanged.