### PR TITLE
research(erdos-1065-oq-01): uniqueness of the 2^k·q representation [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/Erdos1065OQ01.lean
+++ b/proofs/Proofs/Erdos1065OQ01.lean
@@ -1,0 +1,85 @@
+import Mathlib
+
+/-!
+# Erdős #1065, child OQ-01: uniqueness of the `2^k · q` representation
+
+Erdős Problem #1065 asks whether there are infinitely many primes of the form
+`2^k · q + 1` with `q` an odd prime and `k ≥ 1`. The parent files
+(`erdos-1065`, `erdos-1065-incomplete-01`) build the `twoVal`/`oddPart`
+machinery and characterise such "form-A" primes.
+
+Underpinning every such argument is a basic uniqueness fact that this entry
+isolates and fully verifies:
+
+> **Unique `2^k · q` form.** If `2^{a} · m = 2^{b} · n` with `m, n` odd, then
+> `a = b` and `m = n`.
+
+The `2`-adic valuation reads off the exponent: `v₂(2^a · m) = a` when `m` is odd
+(`factorization_two_pow_mul_odd`), so the two exponents agree and cancellation
+gives the odd parts. As a corollary, the form-A representation of a prime is
+unique (`formA_repr_unique`): the pair `(k, q)` in `p = 2^k · q + 1` (with `q`
+odd) is determined by `p`.
+
+All results are `0`-axiom (no `sorry`, no `axiom`, no `native_decide`).
+
+## References
+* Erdős Problem #1065 (primes of the form `2^k · q + 1`).
+* 2-adic valuation and `Nat.factorization`.
+-/
+
+namespace Erdos1065OQ01
+
+open Nat
+
+/-!
+## Section 1: the 2-adic valuation reads off the exponent
+-/
+
+/-- **`v₂(2^a · m) = a` for odd `m`.** The `2`-adic valuation of `2^a · m` is
+    exactly `a` when `m` is odd, since `m` contributes no factor of `2`. -/
+theorem factorization_two_pow_mul_odd {a m : ℕ} (hm : Odd m) :
+    (2 ^ a * m).factorization 2 = a := by
+  have hm0 : m ≠ 0 := by rintro rfl; rw [Nat.odd_iff] at hm; omega
+  have h2m : ¬ (2 ∣ m) := Nat.two_dvd_ne_zero.mpr (Nat.odd_iff.mp hm)
+  rw [Nat.factorization_mul (pow_ne_zero a two_ne_zero) hm0, Finsupp.add_apply,
+    Nat.factorization_eq_zero_of_not_dvd h2m, add_zero, Nat.factorization_pow,
+    Finsupp.smul_apply, Nat.Prime.factorization_self Nat.prime_two, smul_eq_mul, mul_one]
+
+/-!
+## Section 2: uniqueness of the `2^k · q` representation
+-/
+
+/-- **Uniqueness of the `2^a · m` form.** If `2^a · m = 2^b · n` with `m` and `n`
+    odd, then `a = b` and `m = n`: the exponents agree by comparing `2`-adic
+    valuations, and the odd parts agree by cancelling `2^a`. -/
+theorem two_pow_mul_odd_unique {a b m n : ℕ} (hm : Odd m) (hn : Odd n)
+    (h : 2 ^ a * m = 2 ^ b * n) : a = b ∧ m = n := by
+  have ha : a = b := by
+    have hval := congrArg (fun x => x.factorization 2) h
+    simpa [factorization_two_pow_mul_odd hm, factorization_two_pow_mul_odd hn] using hval
+  subst ha
+  exact ⟨rfl, Nat.eq_of_mul_eq_mul_left (pow_pos (by norm_num) a) h⟩
+
+/-- **The form-A representation of a prime is unique.** If `p = 2^{k₁} · q₁ + 1
+    = 2^{k₂} · q₂ + 1` with `q₁, q₂` odd, then `k₁ = k₂` and `q₁ = q₂`. So the
+    pair `(k, q)` in Erdős #1065's form `2^k · q + 1` is determined by `p`. -/
+theorem formA_repr_unique {k₁ k₂ q₁ q₂ : ℕ} (hq₁ : Odd q₁) (hq₂ : Odd q₂)
+    (h : 2 ^ k₁ * q₁ + 1 = 2 ^ k₂ * q₂ + 1) : k₁ = k₂ ∧ q₁ = q₂ :=
+  two_pow_mul_odd_unique hq₁ hq₂ (by omega)
+
+/-- The exponent `k` of a form-A number `p = 2^k · q + 1` (odd `q`) is recovered
+    as the `2`-adic valuation of `p − 1`. -/
+theorem formA_exponent_eq {k q : ℕ} (hq : Odd q) :
+    ((2 ^ k * q + 1) - 1).factorization 2 = k := by
+  simpa using factorization_two_pow_mul_odd (a := k) hq
+
+/-!
+## Section 3: a concrete instance
+-/
+
+/-- `41 = 2³ · 5 + 1` with `5` an odd prime, so `41` is a form-A prime, and by
+    `formA_repr_unique` this representation `(k, q) = (3, 5)` is the only one. -/
+theorem formA_41 : (41 : ℕ) = 2 ^ 3 * 5 + 1 ∧ Odd (5 : ℕ) ∧ Nat.Prime 5 := by
+  refine ⟨by norm_num, by decide, by norm_num⟩
+
+end Erdos1065OQ01

--- a/src/data/proofs/erdos-1065-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1065-oq-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-e1065oq01-valuation",
+    "proofId": "erdos-1065-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 47
+    },
+    "type": "theorem",
+    "title": "The 2-adic Valuation Reads Off the Exponent",
+    "content": "factorization_two_pow_mul_odd computes v₂(2^a · m) = a for odd m. The proof splits the factorization over the product (Nat.factorization_mul), extracts a from 2^a via Nat.factorization_pow and Nat.Prime.factorization_self (v₂(2) = 1), and discards m's contribution via Nat.factorization_eq_zero_of_not_dvd, since an odd m is not divisible by 2. This single evaluation is what makes the 2^k · q form rigid.",
+    "mathContext": "$v_2(2^a \\cdot m) = a$ when $m$ is odd; the odd factor contributes no power of $2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "2-adic valuation",
+      "Nat.factorization",
+      "odd numbers"
+    ],
+    "prerequisites": [
+      "Nat.factorization_mul",
+      "Nat.factorization_pow",
+      "Nat.Prime.factorization_self",
+      "Nat.factorization_eq_zero_of_not_dvd"
+    ]
+  },
+  {
+    "id": "ann-e1065oq01-uniqueness",
+    "proofId": "erdos-1065-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "Uniqueness of the 2^k · q Representation",
+    "content": "two_pow_mul_odd_unique is the core result: from 2^a·m = 2^b·n with m, n odd, comparing 2-adic valuations of both sides forces a = b, after which Nat.eq_of_mul_eq_mul_left cancels 2^a to give m = n. formA_repr_unique subtracts 1 from p = 2^k·q + 1 and applies it, so the form-A representation (k, q) of a prime is determined by p; formA_exponent_eq records k = v₂(p − 1).",
+    "mathContext": "$2^a m = 2^b n$ with $m,n$ odd $\\Rightarrow a=b \\wedge m=n$; hence $(k,q)$ in $p = 2^k q + 1$ is unique.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "representation uniqueness",
+      "cancellation",
+      "form-A primes"
+    ],
+    "prerequisites": [
+      "Nat.eq_of_mul_eq_mul_left",
+      "congrArg"
+    ]
+  },
+  {
+    "id": "ann-e1065oq01-instance",
+    "proofId": "erdos-1065-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "A Concrete Instance",
+    "content": "formA_41 exhibits 41 = 2³·5 + 1 with 5 an odd prime — a genuine form-A prime. By formA_repr_unique its representation (k, q) = (3, 5) is the only way to write 41 in Erdős #1065's form.",
+    "mathContext": "$41 = 2^3 \\cdot 5 + 1$, a form-A prime with unique representation $(3,5)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "concrete example",
+      "form-A prime"
+    ],
+    "prerequisites": [
+      "Nat.Prime"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1065-oq-01/meta.json
+++ b/src/data/proofs/erdos-1065-oq-01/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "erdos-1065-oq-01",
+  "slug": "erdos-1065-oq-01",
+  "title": "Uniqueness of the 2^k · q Representation (Erdős #1065)",
+  "description": "A child of Erdős Problem #1065 (are there infinitely many primes of the form 2^k · q + 1 with q an odd prime and k ≥ 1?). The parent files build the twoVal/oddPart machinery and characterise such 'form-A' primes. This entry isolates and fully verifies the basic uniqueness underpinning them: if 2^a · m = 2^b · n with m, n odd then a = b and m = n. The 2-adic valuation reads off the exponent (v₂(2^a·m) = a for odd m), so the exponents agree and cancellation gives the odd parts. As a corollary, the form-A representation (k, q) of a prime p = 2^k · q + 1 is unique. Machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "Erdos1065OQ01",
+    "lineCount": 85,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1065OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1065OQ01.lean",
+    "tags": [
+      "number-theory",
+      "erdos-problems",
+      "p-adic-valuation",
+      "unique-factorization",
+      "prime-forms",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_mul",
+        "description": "(a·b).factorization = a.factorization + b.factorization for nonzero a, b",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_pow",
+        "description": "(n^k).factorization = k • n.factorization; extracts the exponent from 2^a",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.factorization_self",
+        "description": "p.factorization p = 1 for a prime p; gives (2).factorization 2 = 1",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_eq_zero_of_not_dvd",
+        "description": "¬ p ∣ n → n.factorization p = 0; the odd part contributes no factor of 2",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "0 < k → k·m = k·n → m = n; cancels 2^a to recover the odd parts",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "factorization_two_pow_mul_odd: v₂(2^a · m) = a for odd m, isolating the exponent via Nat.factorization",
+      "two_pow_mul_odd_unique: the core uniqueness — 2^a · m = 2^b · n with m, n odd forces a = b (equal 2-adic valuations) and m = n (cancellation)",
+      "formA_repr_unique: the Erdős #1065 form-A representation is unique — p = 2^{k₁}·q₁ + 1 = 2^{k₂}·q₂ + 1 with q odd implies (k₁,q₁) = (k₂,q₂)",
+      "formA_exponent_eq: the exponent k of a form-A number is recovered as v₂(p − 1)",
+      "formA_41: the concrete instance 41 = 2³·5 + 1 with 5 an odd prime"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 85,
+    "mathlib_version": "4.31.0",
+    "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations. #print axioms reports only the ordinary foundational axioms propext / Classical.choice / Quot.sound for every result — no sorryAx, no Lean.ofReduceBool, no native_decide. Self-contained: imports only Mathlib.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1065 asks whether there are infinitely many primes of the form 2^k · q + 1 with q an odd prime and k ≥ 1 — a Bateman–Horn-type question closely tied to Cunningham chains and generalized Fermat structures. The parent gallery material (`erdos-1065`, `erdos-1065-incomplete-01`) sets up the 2-adic decomposition p − 1 = 2^{v₂(p−1)} · oddPart(p−1) and characterises these 'form-A' primes by primality of the odd part.\n\nEvery such argument silently relies on the fact that writing a number as 2^k times an odd number is unique. This entry makes that foundation explicit and machine-checked.",
+    "problemStatement": "**Open Question (OQ-1065.1)**: verify the uniqueness of the 2^k · q decomposition that the form-A machinery rests on.\n\n**Answer**: If 2^a · m = 2^b · n with m and n odd, then a = b and m = n. Consequently the form-A representation of a prime is unique: p = 2^{k₁}·q₁ + 1 = 2^{k₂}·q₂ + 1 with q₁, q₂ odd forces (k₁,q₁) = (k₂,q₂), and the exponent is recovered as k = v₂(p − 1).",
+    "proofStrategy": "1. **Valuation (Section 1)**: factorization_two_pow_mul_odd computes v₂(2^a · m) = a via Nat.factorization_mul, factorization_pow, Nat.Prime.factorization_self (v₂(2) = 1), and factorization_eq_zero_of_not_dvd (odd m contributes 0).\n\n2. **Uniqueness (Section 2)**: two_pow_mul_odd_unique compares the 2-adic valuations of both sides to get a = b, then cancels 2^a (Nat.eq_of_mul_eq_mul_left) to get m = n. formA_repr_unique subtracts 1 and applies it; formA_exponent_eq specialises the valuation formula.\n\n3. **Instance (Section 3)**: formA_41 exhibits 41 = 2³·5 + 1 with 5 an odd prime.",
+    "keyInsights": [
+      "**The 2-adic valuation is the whole story.** Uniqueness of the 2^k · q form is not an induction but a single evaluation: v₂ ignores the odd factor entirely, so it returns the exponent verbatim and the exponents must agree before anything is cancelled.",
+      "**Representation uniqueness makes 'the' k and q well-defined.** Because (k, q) is determined by p, the parent's oddPart/twoVal are genuine functions of the prime, and statements like 'q is an odd prime' are unambiguous.",
+      "**Self-contained and reusable.** The lemma 2^a·m = 2^b·n (odd) ⟹ a=b ∧ m=n is a general fact about the multiplicative structure of ℕ, useful well beyond Erdős #1065.",
+      "**Elementary foundation for a hard problem.** Erdős #1065's infinitude question is deep (Bateman–Horn), but the structural bookkeeping it needs — this uniqueness — is completely elementary and now verified."
+    ],
+    "prerequisites": [
+      "p-adic valuation and Nat.factorization",
+      "Odd/even numbers and divisibility by 2",
+      "Primes of the form 2^k · q + 1 (Erdős #1065)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "valuation",
+      "title": "The 2-adic Valuation Reads Off the Exponent",
+      "startLine": 33,
+      "endLine": 47,
+      "summary": "factorization_two_pow_mul_odd: v₂(2^a · m) = a for odd m, via factorization_mul + factorization_pow + Prime.factorization_self + factorization_eq_zero_of_not_dvd.",
+      "mathContext": "$v_2(2^a \\cdot m) = a$ when $m$ is odd, since $m$ contributes no factor of $2$."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the 2^k · q Representation",
+      "startLine": 49,
+      "endLine": 76,
+      "summary": "two_pow_mul_odd_unique: 2^a·m = 2^b·n with m,n odd ⟹ a=b (equal valuations) ∧ m=n (cancellation). formA_repr_unique and formA_exponent_eq specialise it to Erdős #1065's form.",
+      "mathContext": "$2^a m = 2^b n,\\ m,n\\text{ odd} \\Rightarrow a=b \\wedge m=n$; hence $(k,q)$ in $p = 2^k q + 1$ is determined by $p$."
+    },
+    {
+      "id": "instance",
+      "title": "A Concrete Instance",
+      "startLine": 77,
+      "endLine": 85,
+      "summary": "formA_41: 41 = 2³·5 + 1 with 5 an odd prime, whose form-A representation (3, 5) is unique by formA_repr_unique.",
+      "mathContext": "$41 = 2^3 \\cdot 5 + 1$, a form-A prime with unique representation $(k,q) = (3,5)$."
+    }
+  ],
+  "references": [
+    {
+      "text": "Erdős Problem #1065 — primes of the form 2^k · q + 1.",
+      "url": "https://www.erdosproblems.com/1065"
+    },
+    {
+      "text": "p-adic valuation and unique factorization by powers of a prime.",
+      "url": "https://en.wikipedia.org/wiki/P-adic_valuation"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1065",
+      "relationship": "extends",
+      "description": "The parent formalizes Erdős #1065 and the form-A machinery (twoVal/oddPart). This entry supplies the uniqueness of the 2^k · q decomposition that machinery relies on."
+    },
+    {
+      "targetId": "erdos-1065-incomplete-01",
+      "relationship": "related",
+      "description": "A sibling that characterises form-A primes via primality of oddPart(p−1); this entry certifies the representation those results implicitly assume is unique."
+    }
+  ],
+  "conclusion": {
+    "summary": "We verify the uniqueness of the 2^k · q representation underlying Erdős #1065: if 2^a · m = 2^b · n with m, n odd then a = b and m = n, proved by comparing 2-adic valuations and cancelling. Hence the form-A representation p = 2^k · q + 1 (odd q) is unique, with k = v₂(p − 1). Fully machine-checked, 0 sorries, 0 axioms.",
+    "implications": "**Well-definedness for the form-A theory.** Representation uniqueness turns twoVal/oddPart into genuine functions of the prime, so the parent's characterisations and the infinitude question are stated about unambiguous objects.\n\n**A general reusable lemma.** The uniqueness of the 2^k · q form is a basic multiplicative fact about ℕ, applicable to any argument that separates the even and odd parts of an integer.",
+    "openQuestions": [
+      "Generalise to arbitrary prime bases: p^a · m = p^b · n with p ∤ m, n implies a = b ∧ m = n, packaging the p-adic decomposition uniqueness.",
+      "Connect formA_exponent_eq to the parent's twoVal/oddPart definitions, proving they agree with Nat.factorization on p − 1.",
+      "Use the uniqueness to enumerate form-A primes up to N and compare the count to the Bateman–Horn prediction (the hard, still-open direction of Erdős #1065)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New **VERIFIED, 0-axiom** gallery entry `erdos-1065-oq-01`, a child of **Erdős Problem #1065** (are there infinitely many primes of the form `2^k · q + 1` with `q` an odd prime and `k ≥ 1`?).

It isolates and fully verifies the **uniqueness of the `2^k · q` representation** that the parent's form-A machinery relies on.

## Results (`Proofs/Erdos1065OQ01.lean`, 85L, 5 theorems)

- **`factorization_two_pow_mul_odd`** — `v₂(2^a · m) = a` for odd `m` (via `Nat.factorization`).
- **`two_pow_mul_odd_unique`** — `2^a·m = 2^b·n` with `m, n` odd ⟹ `a = b` (equal 2-adic valuations) and `m = n` (cancellation).
- **`formA_repr_unique`** — the form-A representation `(k, q)` of a prime `p = 2^k·q + 1` (odd `q`) is unique.
- **`formA_exponent_eq`** — `k = v₂(p − 1)`.
- **`formA_41`** — the concrete instance `41 = 2³·5 + 1` (5 an odd prime).

## Verification

- Built with `lake env lean` against warm Mathlib **v4.31** oleans (no `lake build`).
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`.
- 0 sorries, 0 `axiom` declarations. Self-contained: imports only Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
