### PR TITLE
research(sum-of-divisors-oq-02): Euler's converse — every even perfect number has Mersenne form [VERIFIED, gallery entry]

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-02/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-02/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "sum-of-divisors-oq-02",
+  "title": "Euler's Converse: Every Even Perfect Number Has Mersenne Form",
+  "slug": "sum-of-divisors-oq-02",
+  "description": "Euler's half of the Euclid–Euler theorem: every even perfect number n has the form 2^k·(2^(k+1)−1) with 2^(k+1)−1 = mersenne(k+1) a Mersenne prime. Euclid (~300 BC) proved that this form always yields a perfect number; Euler (1747) proved the converse — no other even perfect numbers exist. Mathlib's Archive bundles the theorem as a single block; this entry re-derives it as six named intermediate lemmas exposing the algebraic skeleton (σ-multiplicativity over the coprime 2-adic split, σ(2^k) = 2^(k+1)−1, the perfect equation, divisibility of the odd part by the Mersenne factor, the cofactor identity σ(m) = m + c, and a two-divisor pinch forcing c = 1 and m prime). The two-divisor heart and the capstone's bound-chasing are proved from first principles; the Archive is used only for the 2-adic split and the σ(2^k) value. Verified, 0 axioms.",
+  "meta": {
+    "author": "Robb Walters (researcher-6)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ02.lean",
+    "tags": [
+      "number-theory",
+      "perfect-numbers",
+      "sum-of-divisors",
+      "mersenne-prime",
+      "euclid-euler",
+      "euler",
+      "multiplicative-function",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "No axioms or sorries. The proof depends only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions), plus results from Mathlib and its Archive (Theorems100 Euclid–Euler, itself 0-axiom): specifically the 2-adic split eq_two_pow_mul_odd and the σ(2^k) value. The mathematical result was independently cross-checked this session by a self-contained reproof whose #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "euler_converse_self_contained: Euler's converse — every even perfect number n equals 2^k·mersenne(k+1) with mersenne(k+1) prime — assembled from six named steps rather than quoted as one Archive block",
+      "cofactor_one_and_prime: the two-divisor pinch — if σ(m) = m + c with c ∣ m and c < m then c = 1 and m is prime, since the self-dividing proper-divisor sum (Nat.sum_properDivisors_dvd) must be 1 or m and the m-branch contradicts c < m",
+      "mersenne_mul_sigma_eq_two_pow_mul: the perfect equation in structural form mersenne(k+1)·σ(m) = 2^(k+1)·m, bridged from Nat.perfect_iff_sum_divisors_eq_two_mul via σ-multiplicativity",
+      "mersenne_dvd_odd_part: the Mersenne factor divides the odd part m, term-mode from coprimality (Odd.coprime_two_right.pow_right.dvd_of_dvd_mul_left)",
+      "Exposing the algebraic skeleton of Euler's argument as a reusable six-lemma decomposition (σ-multiplicativity → σ(2^k) value → perfect equation → divisibility → cofactor identity → two-divisor pinch)"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Archive.Wiedijk100Theorems.PerfectNumbers",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "SumOfDivisorsOQ02",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfDivisorsOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "A perfect number equals the sum of its proper divisors: 6 = 1+2+3, 28 = 1+2+4+7+14. In Book IX of the Elements (~300 BC) Euclid proved that whenever 2^(k+1)−1 is prime, 2^k·(2^(k+1)−1) is perfect — generating 6, 28, 496, 8128, …. Whether every perfect number arises this way stayed open for two millennia. In 1747 Leonhard Euler proved the converse for even perfect numbers: there are no others. Together these give the Euclid–Euler theorem, a bijection between even perfect numbers and Mersenne primes 2^(k+1)−1. (Whether any odd perfect number exists is still open.) Mathlib's Archive contains the full theorem as a single Theorems100 result; the gallery value of this entry is the named six-step decomposition that exposes the algebraic skeleton, with the two-divisor heart and the bound-chasing proved from first principles rather than quoted.",
+    "problemStatement": "Prove Euler's converse and expose its algebraic skeleton: for every natural number n, if n is even and perfect then there exists k with mersenne(k+1) = 2^(k+1)−1 prime and n = 2^k·mersenne(k+1). Present the argument as named intermediate lemmas — multiplicativity of σ on coprime factors, the prime-power divisor sum σ(2^k) = 2^(k+1)−1, the perfect equation, divisibility of the odd part, the cofactor identity, and the two-divisor characterization of primality.",
+    "text": "Split n = 2^k·m with m odd (Archive eq_two_pow_mul_odd); evenness forces k ≥ 1. Coprimality of 2^k and m gives σ(n) = σ(2^k)·σ(m), and σ(2^k) = mersenne(k+1). Perfectness (σ(n) = 2n) then yields mersenne(k+1)·σ(m) = 2^(k+1)·m, so mersenne(k+1) ∣ m; writing m = mersenne(k+1)·c gives σ(m) = m + c. Since σ(m) = (∑ proper divisors of m) + m, the proper-divisor sum equals c, and because c ∣ m this self-dividing sum must be 1 or m; the m-branch contradicts c < m, so c = 1 and m is prime. Hence m = mersenne(k+1) is a Mersenne prime and n = 2^k·mersenne(k+1).",
+    "proofStrategy": "1. sigma_two_pow_mul_odd: σ(2^k·m) = σ(2^k)·σ(m) for m odd, from isMultiplicative_sigma with coprimality via Odd.coprime_two_right and pow_left. 2. sigma_two_pow_eq_mersenne: σ(2^k) = mersenne(k+1), an alias of the Archive value. 3. mersenne_mul_sigma_eq_two_pow_mul: turn perfectness into mersenne(k+1)·σ(m) = 2^(k+1)·m via perfect_iff_sum_divisors_eq_two_mul, steps 1–2, and ←mul_assoc/←pow_succ'. 4. mersenne_dvd_odd_part: mersenne(k+1) ∣ m by coprimality (dvd_of_dvd_mul_left). 5. sigma_eq_self_add_cofactor: from m = mersenne(k+1)·c derive σ(m) = m + c using Nat.eq_of_mul_eq_mul_left and succ_mersenne. 6. cofactor_one_and_prime: σ(m) = m + c with c ∣ m, c < m forces the proper-divisor sum (which equals c) to be 1 (Nat.sum_properDivisors_dvd rules out m), giving c = 1 and m prime via sum_properDivisors_eq_one_iff_prime. The capstone euler_converse_self_contained chains 3–6 after the Archive 2-adic split, deriving the bounds 1 < m, k ≠ 0, and c < m in place.",
+    "keyInsights": [
+      "The whole theorem compresses to one equation, mersenne(k+1)·σ(m) = 2^(k+1)·m, obtained from σ-multiplicativity plus σ(n) = 2n; everything after is showing the cofactor c is 1.",
+      "That the cofactor is 1 is a two-divisor pinch: the proper-divisor sum of m equals c and also divides m (Nat.sum_properDivisors_dvd), so it is 1 or m; the value m is excluded because c < m.",
+      "A number whose proper divisors sum to 1 is exactly a prime (Nat.sum_properDivisors_eq_one_iff_prime), identifying m = mersenne(k+1) as a Mersenne prime.",
+      "Multiplicativity of σ across the odd/even split is the structural engine, and the power-of-two factor contributes the exact geometric value σ(2^k) = 2^(k+1)−1 = mersenne(k+1).",
+      "Euler's converse is genuinely one-directional: Euclid's forward implication (this form is always perfect) is a separate, easier fact; the content here is that no other even perfect numbers exist."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ = ArithmeticFunction.sigma 1 and its multiplicativity on coprime arguments (isMultiplicative_sigma)",
+      "Nat.Perfect and its sum form perfect_iff_sum_divisors_eq_two_mul (σ(n) = 2n)",
+      "The 2-adic factorization n = 2^k·m with m odd (Archive eq_two_pow_mul_odd) and coprimality of 2^k with an odd number",
+      "Proper divisors: Nat.sum_properDivisors_dvd and sum_properDivisors_eq_one_iff_prime",
+      "The Mersenne number mersenne(k+1) = 2^(k+1)−1 and succ_mersenne"
+    ]
+  },
+  "sections": [
+    {
+      "id": "steps-1-2-sigma-values",
+      "title": "Steps 1–2: σ-Multiplicativity and the Power-of-Two Value",
+      "startLine": 73,
+      "endLine": 89,
+      "summary": "sigma_two_pow_mul_odd gives σ(2^k·m) = σ(2^k)·σ(m) for odd m from isMultiplicative_sigma and coprimality; sigma_two_pow_eq_mersenne records σ(2^k) = mersenne(k+1). Together they compute the divisor sum of a perfect number's even/odd split."
+    },
+    {
+      "id": "steps-3-5-perfect-equation",
+      "title": "Steps 3–5: The Perfect Equation, Divisibility, and the Cofactor",
+      "startLine": 90,
+      "endLine": 157,
+      "summary": "mersenne_mul_sigma_eq_two_pow_mul turns perfectness into mersenne(k+1)·σ(m) = 2^(k+1)·m; mersenne_dvd_odd_part deduces mersenne(k+1) ∣ m; sigma_eq_self_add_cofactor writes m = mersenne(k+1)·c and derives σ(m) = m + c."
+    },
+    {
+      "id": "step-6-capstone",
+      "title": "Step 6 and Capstone: Two-Divisor Pinch to Mersenne Form",
+      "startLine": 158,
+      "endLine": 228,
+      "summary": "cofactor_one_and_prime forces c = 1 and m prime from σ(m) = m + c with c ∣ m, c < m, using that the proper-divisor sum equals c and self-divides m (so is 1 or m). euler_converse_self_contained chains all steps after the Archive 2-adic split, deriving the needed bounds, to conclude n = 2^k·mersenne(k+1) with mersenne(k+1) prime."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's converse is formalized and decomposed: every even perfect number is of Euclid's form 2^k·mersenne(k+1) with mersenne(k+1) a Mersenne prime, completing (with Euclid's forward direction) the Euclid–Euler bijection between even perfect numbers and Mersenne primes. The proof reduces perfectness plus σ-multiplicativity to a single divisor equation and pins the cofactor to 1 by an elementary two-divisor bound. Verified, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "Package both directions as the Euclid–Euler biconditional Even n ∧ Perfect n ↔ ∃ k, (mersenne (k+1)).Prime ∧ n = 2^k·mersenne(k+1), adding Euclid's forward implication.",
+      "State the resulting order-preserving bijection explicitly: the count of even perfect numbers equals the (unknown) number of Mersenne primes."
+    ],
+    "implications": "Reduces the classification of even perfect numbers entirely to the study of Mersenne primes mersenne(k+1) = 2^(k+1)−1, and isolates a reusable pattern: σ-multiplicativity plus the perfect equation σ(n) = 2n, combined with a proper-divisor-sum pinch, characterizes structured perfect-type numbers. The odd perfect number question — whether any exists — remains open and is untouched by this even-case argument."
+  },
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "extends",
+      "description": "The parent entry develops the sum-of-divisors function σ and the deficient/perfect/abundant classification; this entry proves Euler's structural theorem that every even perfect number has Mersenne form."
+    }
+  ],
+  "references": [
+    {
+      "author": "Euclid",
+      "title": "Elements, Book IX, Proposition 36",
+      "year": -300,
+      "note": "Forward direction: if 2^(k+1)−1 is prime then 2^k·(2^(k+1)−1) is perfect."
+    },
+    {
+      "author": "Leonhard Euler",
+      "title": "Tract on perfect numbers (converse direction, posthumous)",
+      "year": 1747,
+      "note": "Converse direction, formalized here: every even perfect number has the Euclid form."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Creates the missing gallery entry for **sum-of-divisors-oq-02** (Euler's converse of the Euclid–Euler theorem: *every even perfect number* `n` has the form `2^k · (2^(k+1)−1)` with `2^(k+1)−1` a Mersenne prime).

The verified Lean proof `proofs/Proofs/SumOfDivisorsOQ02.lean` (namespace `SumOfDivisorsOQ02`, 228 L, 6 lemmas + capstone) already existed on `main` but had **no `src/data/proofs/` entry**, so it was invisible in the gallery. This PR adds only the `meta.json`, filling that gap.

## The result

`euler_converse_self_contained`: `Even n → n.Perfect → ∃ k, (mersenne (k+1)).Prime ∧ n = 2^k · mersenne (k+1)`.

The proof exposes Euler's argument as six named steps — σ-multiplicativity over the coprime 2-adic split, `σ(2^k) = mersenne(k+1)`, the perfect equation `mersenne(k+1)·σ(m) = 2^(k+1)·m`, divisibility of the odd part, the cofactor identity `σ(m) = m + c`, and a two-divisor pinch forcing `c = 1` and `m` prime. The two-divisor heart and the capstone bound-chasing are proved from first principles; Mathlib's Archive is used only for the 2-adic split and the `σ(2^k)` value.

## Verification

- File committed on `main` as **VERIFIED (0 sorries, 0 axioms; Docker build clean)**.
- Its only non-core dependency is Mathlib's Archive Euclid–Euler theorem (Theorems100), itself 0-axiom.
- **Independently cross-checked this session**: I re-proved the same theorem in a self-contained file (`import Mathlib` only, no Archive) — it compiled clean and `#print axioms` reported only `propext, Classical.choice, Quot.sound`, confirming the mathematics is genuinely 0-axiom.

## Files
- `src/data/proofs/sum-of-divisors-oq-02/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)