### PR TITLE
Enrich Weyr characteristic non-increasing: annotation coverage

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-04/annotations.json
@@ -1,86 +1,191 @@
 [
   {
+    "id": "chm-oq0104-ann-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "Setup: an arbitrary field and a finite-dimensional space",
+    "content": "The header states the theorem and the quotient-free proof idea, and the declarations fix the working generality. The variable line `{K V : Type*} [Field K] [AddCommGroup V] [Module K V] [FiniteDimensional K V]` assumes only that K is an arbitrary field and V a finite-dimensional K-vector space — no algebraic closure, no perfect-field or characteristic hypothesis, and no Jordan normal form. This is exactly why the concavity comes out as a pure rank inequality valid over ANY field and machine-checked with 0 axioms: everything downstream is built from `LinearMap.ker`, `Submodule.map`, and rank–nullity, all of which live at this level of generality. `open Module LinearMap` brings `Module.End`, `finrank`, and the kernel/range API into scope; `import Mathlib` supplies the rank–nullity theorem and `genEigenspace_nat`.",
+    "mathContext": "Working over an arbitrary field $K$ with $\\dim_K V < \\infty$; the endomorphism ring is $\\operatorname{End}_K(V) = \\operatorname{Module.End}\\,K\\,V$, and $a_k = \\dim_K \\ker N^k$ for $N \\in \\operatorname{End}_K(V)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "finite-dimensional vector space",
+      "arbitrary field",
+      "endomorphism ring",
+      "generality of the argument"
+    ],
+    "prerequisites": [
+      "fields and vector spaces",
+      "Module.End and finrank",
+      "Lean variable/section declarations"
+    ]
+  },
+  {
     "id": "chm-oq0104-ann-pow-succ",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 51, "endLine": 61 },
+    "range": {
+      "startLine": 51,
+      "endLine": 61
+    },
     "type": "technique",
     "title": "Powers of N and their nested kernels",
     "content": "Two elementary facts set up the whole argument. First, pow_succ_apply factors an extra application of N out of a power: Nᵏ⁺¹ x = Nᵏ(N x). Second, ker_pow_le_succ shows the kernels of successive powers form an increasing chain: if x is killed by Nᵏ it is killed by Nᵏ⁺¹, because Nᵏ⁺¹ x = N(Nᵏ x) = N 0 = 0. This ascending kernel chain ker N⁰ ≤ ker N¹ ≤ ker N² ≤ ⋯ is exactly the generalized-eigenspace filtration once N = f − μ.",
     "mathContext": "$\\ker N^0 \\subseteq \\ker N^1 \\subseteq \\ker N^2 \\subseteq \\cdots$, with $N^{k+1}x = N^k(Nx) = N(N^k x)$; the sequence stabilizes at $\\ker N^{\\dim V}$ (the maximal generalized eigenspace).",
     "significance": "supporting",
-    "relatedConcepts": ["operator powers", "kernel filtration", "generalized eigenspaces", "nilpotent part"],
-    "prerequisites": ["linear maps", "kernels", "monoid powers of an endomorphism"]
+    "relatedConcepts": [
+      "operator powers",
+      "kernel filtration",
+      "generalized eigenspaces",
+      "nilpotent part"
+    ],
+    "prerequisites": [
+      "linear maps",
+      "kernels",
+      "monoid powers of an endomorphism"
+    ]
   },
   {
     "id": "chm-oq0104-ann-rank-nullity",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 63, "endLine": 74 },
+    "range": {
+      "startLine": 63,
+      "endLine": 74
+    },
     "type": "insight",
     "title": "Rank–nullity realizes each dimension jump as a subspace",
     "content": "This is the conceptual heart. Restrict the linear map Nᵏ to the subspace ker Nᵏ⁺¹ (formally, compose Nᵏ with the inclusion (ker Nᵏ⁺¹).subtype). Its range is the difference space Uₖ = Nᵏ(ker Nᵏ⁺¹); its kernel is {x ∈ ker Nᵏ⁺¹ : Nᵏ x = 0} = ker Nᵏ, which is legitimately a subspace of ker Nᵏ⁺¹ by the previous lemma. Mathlib's rank–nullity theorem finrank_range_add_finrank_ker then gives dim Uₖ + dim ker Nᵏ = dim ker Nᵏ⁺¹, i.e. dim Uₖ = aₖ₊₁ − aₖ. The comapSubtypeEquivOfLe rewrite is the bookkeeping that identifies the restricted map's kernel with ker Nᵏ inside the ambient space.",
     "mathContext": "$\\dim\\operatorname{ran}(N^k|_{\\ker N^{k+1}}) + \\dim\\ker(N^k|_{\\ker N^{k+1}}) = \\dim\\ker N^{k+1}$, so $\\dim U_k = a_{k+1}-a_k$ where $U_k = N^k(\\ker N^{k+1})$.",
     "significance": "key",
-    "relatedConcepts": ["rank–nullity theorem", "restriction of a linear map", "Submodule.map (image)", "difference space"],
-    "prerequisites": ["rank–nullity theorem", "images and preimages of submodules", "finite-dimensional linear algebra"]
+    "relatedConcepts": [
+      "rank–nullity theorem",
+      "restriction of a linear map",
+      "Submodule.map (image)",
+      "difference space"
+    ],
+    "prerequisites": [
+      "rank–nullity theorem",
+      "images and preimages of submodules",
+      "finite-dimensional linear algebra"
+    ]
   },
   {
     "id": "chm-oq0104-ann-diff-antitone",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 76, "endLine": 87 },
+    "range": {
+      "startLine": 76,
+      "endLine": 87
+    },
     "type": "insight",
     "title": "The quotient-free crux: the difference spaces nest",
     "content": "The whole monotonicity collapses to one inclusion, Uₖ₊₁ ⊆ Uₖ. Take y ∈ Uₖ₊₁, so y = Nᵏ⁺¹ x with Nᵏ⁺² x = 0. Rewrite y = Nᵏ(N x); the witness N x lies in ker Nᵏ⁺¹ because Nᵏ⁺¹(N x) = Nᵏ⁺² x = 0. Hence y ∈ Nᵏ(ker Nᵏ⁺¹) = Uₖ. This one-line preimage computation replaces the usual construction of an injection between successive quotients ker Nᵏ⁺¹ / ker Nᵏ ↪ ker Nᵏ / ker Nᵏ⁻¹ — no quotient spaces are ever formed.",
     "mathContext": "$y = N^{k+1}x = N^k(Nx)$ with $Nx \\in \\ker N^{k+1}$ (since $N^{k+1}(Nx)=N^{k+2}x=0$), so $U_{k+1} = N^{k+1}(\\ker N^{k+2}) \\subseteq N^k(\\ker N^{k+1}) = U_k$.",
     "significance": "key",
-    "relatedConcepts": ["subspace inclusion", "preimage witness", "quotient-free argument", "Jordan chains"],
-    "prerequisites": ["image of a submodule under a linear map", "membership in ker and map"]
+    "relatedConcepts": [
+      "subspace inclusion",
+      "preimage witness",
+      "quotient-free argument",
+      "Jordan chains"
+    ],
+    "prerequisites": [
+      "image of a submodule under a linear map",
+      "membership in ker and map"
+    ]
   },
   {
     "id": "chm-oq0104-ann-concave",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 89, "endLine": 98 },
+    "range": {
+      "startLine": 89,
+      "endLine": 98
+    },
     "type": "concept",
     "title": "Concavity of the kernel-dimension sequence",
     "content": "Assembling the pieces: dim Uₖ = aₖ₊₁ − aₖ and dim Uₖ₊₁ = aₖ₊₂ − aₖ₊₁ (two instances of finrank_diff_space), while Uₖ₊₁ ⊆ Uₖ gives dim Uₖ₊₁ ≤ dim Uₖ by finrank monotonicity. Therefore aₖ₊₂ − aₖ₊₁ ≤ aₖ₊₁ − aₖ, which omega rearranges into aₖ + aₖ₊₂ ≤ 2·aₖ₊₁. This is the discrete concavity (second difference ≤ 0) of the dimension sequence aₖ = dim ker Nᵏ, valid for any endomorphism N over any field.",
     "mathContext": "$a_{k+2}-a_{k+1} \\le a_{k+1}-a_k \\;\\Longleftrightarrow\\; a_k + a_{k+2} \\le 2a_{k+1}$; equivalently the second difference $\\Delta^2 a_k \\le 0$.",
     "significance": "key",
-    "relatedConcepts": ["concave sequence", "second difference", "monotonicity of dimension", "Weyr characteristic"],
-    "prerequisites": ["Submodule.finrank_mono", "integer arithmetic (omega)"]
+    "relatedConcepts": [
+      "concave sequence",
+      "second difference",
+      "monotonicity of dimension",
+      "Weyr characteristic"
+    ],
+    "prerequisites": [
+      "Submodule.finrank_mono",
+      "integer arithmetic (omega)"
+    ]
   },
   {
     "id": "chm-oq0104-ann-geneig",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 100, "endLine": 106 },
+    "range": {
+      "startLine": 100,
+      "endLine": 106
+    },
     "type": "technique",
     "title": "Transporting concavity to generalized eigenspaces",
     "content": "The abstract concavity is stated for an arbitrary N; specializing N = f − μ·1 gives the spectral version. Mathlib's genEigenspace_nat identifies the generalized eigenspace genEigenspace μ k with ker (f − μ·1)ᵏ, so rewriting all three terms reduces the eigenspace concavity to finrank_ker_pow_concave applied to f − μ•1. Nothing about μ being an actual eigenvalue is needed: if μ is not in the spectrum every aₖ is 0 and the inequality holds trivially.",
     "mathContext": "$\\operatorname{genEigenspace}(\\mu,k) = \\ker(f-\\mu\\cdot 1)^k$, so $\\dim\\operatorname{genEig}(\\mu,k) + \\dim\\operatorname{genEig}(\\mu,k{+}2) \\le 2\\dim\\operatorname{genEig}(\\mu,k{+}1)$.",
     "significance": "supporting",
-    "relatedConcepts": ["generalized eigenspace", "eigenvalue", "spectral decomposition", "genEigenspace_nat"],
-    "prerequisites": ["generalized eigenspaces", "operator f − μ·1"]
+    "relatedConcepts": [
+      "generalized eigenspace",
+      "eigenvalue",
+      "spectral decomposition",
+      "genEigenspace_nat"
+    ],
+    "prerequisites": [
+      "generalized eigenspaces",
+      "operator f − μ·1"
+    ]
   },
   {
     "id": "chm-oq0104-ann-weyr-def",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 108, "endLine": 111 },
+    "range": {
+      "startLine": 108,
+      "endLine": 111
+    },
     "type": "definition",
     "title": "The Weyr number wₖ",
     "content": "The k-th Weyr number is the jump wₖ = aₖ₊₁ − aₖ = dim genEigenspace μ (k+1) − dim genEigenspace μ k. Geometrically it counts the Jordan blocks for μ of size at least k+1: each such block contributes exactly one new dimension when passing from ker Nᵏ to ker Nᵏ⁺¹. The subtraction is truncated natural-number subtraction, but ker_pow_le_succ guarantees aₖ ≤ aₖ₊₁, so it agrees with genuine subtraction. The sequence (w₀, w₁, w₂, …) is the Weyr characteristic of f at μ.",
     "mathContext": "$w_k = a_{k+1} - a_k = \\#\\{\\text{Jordan blocks for }\\mu\\text{ of size} \\ge k+1\\}$; the Weyr characteristic $(w_0,w_1,\\dots)$ is the conjugate partition of the Segre characteristic (the block-size multiset).",
     "significance": "key",
-    "relatedConcepts": ["Weyr characteristic", "Segre characteristic", "Jordan block sizes", "conjugate partition"],
-    "prerequisites": ["partitions and Young diagrams", "generalized eigenspace dimensions"]
+    "relatedConcepts": [
+      "Weyr characteristic",
+      "Segre characteristic",
+      "Jordan block sizes",
+      "conjugate partition"
+    ],
+    "prerequisites": [
+      "partitions and Young diagrams",
+      "generalized eigenspace dimensions"
+    ]
   },
   {
     "id": "chm-oq0104-ann-weyr-antitone",
     "proofId": "cayley-hamilton-minpoly-oq-01-oq-04",
-    "range": { "startLine": 113, "endLine": 130 },
+    "range": {
+      "startLine": 113,
+      "endLine": 130
+    },
     "type": "insight",
     "title": "Main result: the Weyr characteristic is non-increasing",
     "content": "The payoff: w₀ ≥ w₁ ≥ w₂ ≥ ⋯. Because natural-number subtraction is involved, the proof also feeds omega the two monotonicity facts aₖ ≤ aₖ₊₁ ≤ aₖ₊₂ (each from ker_pow_le_succ) alongside the concavity aₖ + aₖ₊₂ ≤ 2·aₖ₊₁; together these force (aₖ₊₂ − aₖ₊₁) ≤ (aₖ₊₁ − aₖ). Interpreted through the block count, this is the statement that the number of Jordan blocks of size ≥ k+1 never exceeds the number of size ≥ k — precisely what makes the Weyr characteristic a partition and the conjugate of the Segre characteristic.",
     "mathContext": "$w_{k+1} \\le w_k$ for all $k$, i.e. $w_0 \\ge w_1 \\ge w_2 \\ge \\cdots$; equivalently the dot diagram's column heights are non-increasing, so it is the transpose of the Jordan-block Young diagram.",
     "significance": "key",
-    "relatedConcepts": ["antitone sequence", "Weyr characteristic", "Jordan/Weyr dot diagram", "conjugate partition", "Cayley–Hamilton theory"],
-    "prerequisites": ["truncated natural subtraction", "monotonicity of finrank", "omega arithmetic"]
+    "relatedConcepts": [
+      "antitone sequence",
+      "Weyr characteristic",
+      "Jordan/Weyr dot diagram",
+      "conjugate partition",
+      "Cayley–Hamilton theory"
+    ],
+    "prerequisites": [
+      "truncated natural subtraction",
+      "monotonicity of finrank",
+      "omega arithmetic"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-01-oq-04` (The Weyr Characteristic is Non-Increasing).

The entry was already deep (7 fully-fielded annotations, rich overview/conclusion/cross-refs) but annotations covered only lines 51–130, leaving the file preamble (lines 1–49) uncovered.

**Change:** added one `context` annotation (lines 1–49) covering the header and the `variable` declaration that fixes the working generality — an arbitrary field `K` and a finite-dimensional `K`-vector space `V`. This is precisely what substantiates the entry's headline claim (concavity as a pure rank inequality, valid over *any* field, 0 axioms, no Jordan normal form / algebraic closure). Coverage now spans setup + all 7 lemmas/def.

Validated with `validateLineAnnotations`: 8/8 annotations valid, 0 misaligned. meta.json unchanged (11.6 KB, well under caps).