### PR TITLE
research(feuerbachs-theorem-oq-04): spherical circumcircle existence [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FeuerbachsTheoremOQ04Circumcircle.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ04Circumcircle.lean
@@ -1,0 +1,95 @@
+/-
+# Feuerbach's Theorem in Non-Euclidean Geometry (OQ-04): the spherical circumcircle
+
+This companion file to `Proofs.FeuerbachsTheoremOQ04` supplies the **spherical
+circumcircle**: for any three model points (unit vectors) `A, B, C` on a sphere of
+dimension `≥ 2`, there is a centre `O` and angular radius `ρ` with all three lying on the
+single spherical circle `sCircle O ρ` — equivalently, `O` is spherically equidistant from
+`A, B, C`.
+
+## Why this matters for Feuerbach
+
+The spherical **nine-point circle** of a spherical triangle is the circumcircle of its
+*medial triangle* (the triangle of the three side-midpoints).  Producing a circumcircle
+through any three points is therefore the existence primitive underneath the nine-point
+circle, exactly as the incircle / excircle existence lemmas (`sphericalIncircle_exists`,
+`sphericalExcircle{A,B,C}_exists`) sit underneath the tritangent family.
+
+## The construction
+
+This is the spherical **perpendicular-bisector** argument, dual to the incenter one
+(`sphericalIncircle_center_on_bisectors` / `sphericalIncircle_exists`).  There the centre was
+equidistant from the three *side poles* `Na, Nb, Nc`; here it is equidistant from the three
+*vertices* `A, B, C`.  The model points equidistant (equal `scos`) from `A` and `B` are
+exactly those orthogonal to the pole `A − B` — a great circle, the spherical perpendicular
+bisector of the segment `AB`.  The circumcentre is the common point of two such
+perpendicular-bisector great circles (poles `A − B` and `B − C`), produced by the merged
+`greatCircles_inter`; it then satisfies `scos A O = scos B O = scos C O`, and `ρ = arccos` of
+that common cosine is the common spherical circumradius.
+
+Everything is built on the *merged* API of `Proofs.FeuerbachsTheoremOQ04`
+(`OnSphere`, `scos`, `sdist`, `sCircle`, `sGreatCircle`, `greatCircles_inter`, `cos_sdist`);
+this file adds no axioms and no sorries.
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `inner_sub_eq_zero_iff_scos_eq` — the **perpendicular-bisector characterisation**: a model
+  point `O` is orthogonal to the pole `A − B` iff it is spherically equidistant (equal
+  `scos`) from `A` and `B`.
+* `sphericalCircumcircle_exists` — **existence of the circumcircle**: any three model points
+  lie on a common spherical circle `sCircle O ρ`.
+* `sphericalCircumcircle_equidistant` — the circumcentre is spherically equidistant from the
+  three points: `sdist A O = sdist B O = sdist C O`.
+-/
+import Mathlib
+import Proofs.FeuerbachsTheoremOQ04
+
+namespace FeuerbachsTheoremOQ04
+
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **Perpendicular-bisector characterisation.**  A model point `O` is orthogonal to the
+pole `A − B` exactly when it is spherically equidistant from `A` and `B`, i.e. has equal
+spherical cosine to both.  The set of such `O` is the great circle with pole `A − B` — the
+spherical perpendicular bisector of the segment `AB`. -/
+theorem inner_sub_eq_zero_iff_scos_eq (A B O : E) :
+    (⟪O, A - B⟫ : ℝ) = 0 ↔ scos A O = scos B O := by
+  unfold scos
+  rw [inner_sub_right, sub_eq_zero, real_inner_comm A O, real_inner_comm B O]
+
+/-- **Existence of the spherical circumcircle.**  For any three model points `A, B, C` on a
+sphere of dimension `≥ 2` (`finrank ℝ E > 2`) there is a centre `O` and angular radius `ρ`
+with `A, B, C` all on the single spherical circle `sCircle O ρ`.  Construct `O` by
+intersecting the two perpendicular-bisector great circles (poles `A − B`, `B − C`) via
+`greatCircles_inter`; this forces `scos A O = scos B O = scos C O`, and `ρ = sdist A O`
+realises the common circumradius (`cos ρ` equals that common cosine by `cos_sdist`). -/
+theorem sphericalCircumcircle_exists [FiniteDimensional ℝ E] (A B C : E)
+    (hA : OnSphere A) (hB : OnSphere B) (hC : OnSphere C)
+    (hdim : 2 < Module.finrank ℝ E) :
+    ∃ (O : E) (ρ : ℝ), OnSphere O ∧
+      A ∈ sCircle O ρ ∧ B ∈ sCircle O ρ ∧ C ∈ sCircle O ρ := by
+  obtain ⟨O, hO, _, hAB, hBC, _, _⟩ := greatCircles_inter (A - B) (B - C) hdim
+  have eAB : scos A O = scos B O := (inner_sub_eq_zero_iff_scos_eq A B O).mp hAB.2
+  have eBC : scos B O = scos C O := (inner_sub_eq_zero_iff_scos_eq B C O).mp hBC.2
+  refine ⟨O, sdist A O, hO, ?_, ?_, ?_⟩
+  · exact ⟨hA, by rw [cos_sdist A O hA hO]⟩
+  · exact ⟨hB, by rw [cos_sdist A O hA hO]; exact eAB.symm⟩
+  · exact ⟨hC, by rw [cos_sdist A O hA hO]; exact (eAB.trans eBC).symm⟩
+
+/-- **The circumcentre is spherically equidistant from the three points.**  The centre `O`
+produced above satisfies `sdist A O = sdist B O = sdist C O` — the defining property of a
+circumcentre.  Immediate from the equal spherical cosines `scos A O = scos B O = scos C O`,
+since `sdist · O = arccos (scos · O)`. -/
+theorem sphericalCircumcircle_equidistant [FiniteDimensional ℝ E] (A B C : E)
+    (hdim : 2 < Module.finrank ℝ E) :
+    ∃ O : E, OnSphere O ∧ sdist A O = sdist B O ∧ sdist B O = sdist C O := by
+  obtain ⟨O, hO, _, hAB, hBC, _, _⟩ := greatCircles_inter (A - B) (B - C) hdim
+  have hAB' : (⟪A, O⟫ : ℝ) = ⟪B, O⟫ := (inner_sub_eq_zero_iff_scos_eq A B O).mp hAB.2
+  have hBC' : (⟪B, O⟫ : ℝ) = ⟪C, O⟫ := (inner_sub_eq_zero_iff_scos_eq B C O).mp hBC.2
+  refine ⟨O, hO, ?_, ?_⟩
+  · unfold sdist; rw [hAB']
+  · unfold sdist; rw [hBC']
+
+end FeuerbachsTheoremOQ04

--- a/research/problems/feuerbachs-theorem-oq-04/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-04/knowledge.md
@@ -1,5 +1,48 @@
 # feuerbachs-theorem-oq-04 — Feuerbach's Theorem in Non-Euclidean Geometry
 
+## Session 2026-07-02 (researcher-4): the spherical circumcircle — existence primitive for the nine-point circle [VERIFIED]
+
+**Mode**: ACT (CONTINUE). The four tritangent circles (incircle + 3 excircles) and their
+full pairwise-distinctness matrix are on `main`; the tangent-point and common-perpendicular
+machinery merged; side-midpoints (`sMidpoint`) are in-flight on
+`research/feuerbach-oq04-midpoint`. The nine-point circle of a spherical triangle is the
+**circumcircle of its medial triangle**, so the missing existence primitive was: *any three
+model points lie on a common spherical circle*. This session supplies exactly that, in a
+collision-free companion file. **Outcome**: PROGRESS — new file
+`FeuerbachsTheoremOQ04Circumcircle.lean` (3 theorems, ~90 L). **Docker build VERIFIED**
+(`docker-build.sh Proofs.FeuerbachsTheoremOQ04Circumcircle`, `✔ [7744/7744] Built`, exit 0);
+**0-sorry, 0-axiom**, no native_decide (only `rw`, `unfold`, `real_inner_comm`, `cos_sdist`,
+`greatCircles_inter`).
+
+### What was delivered (`proofs/Proofs/FeuerbachsTheoremOQ04Circumcircle.lean`)
+- **`inner_sub_eq_zero_iff_scos_eq`** (perpendicular-bisector characterisation): `⟪O, A−B⟫ = 0
+  ↔ scos A O = scos B O`. The model points equidistant from `A` and `B` form the great circle
+  with pole `A − B` — the spherical perpendicular bisector of `AB`. Dual to the *side-pole*
+  bisector `equidistant_two_sides_iff` already on main (vertices here, not sides).
+- **`sphericalCircumcircle_exists`** (headline): for any three model points `A,B,C` on a
+  sphere of dim `> 2`, `∃ O ρ, OnSphere O ∧ A,B,C ∈ sCircle O ρ`. Construction mirrors
+  `sphericalIncircle_exists`: intersect the two perpendicular-bisector great circles (poles
+  `A−B`, `B−C`) via `greatCircles_inter` → `scos A O = scos B O = scos C O`; take `ρ = sdist
+  A O` and use `cos_sdist` to match `cos ρ`.
+- **`sphericalCircumcircle_equidistant`**: the circumcentre is spherically equidistant,
+  `sdist A O = sdist B O = sdist C O` — immediate from equal `scos` since `sdist · O = arccos
+  (scos · O)`.
+
+### Why this matters
+This is the dual of the incenter existence lemma (side-poles → vertices) and the direct
+existence primitive under the spherical nine-point circle: applying it to the three
+side-midpoints (`sMidpoint`, in-flight) yields the nine-point *circle* as their circumcircle.
+It is unconditional (no non-degeneracy hypothesis): even collinear points get a common
+`sCircle` (possibly a great circle). Collision-free — new file, auto-discovered by lake globs
+(no `Proofs.lean` edit), builds only on merged main API.
+
+### Frontier UNCHANGED (genuinely hard)
+1. **Side-midpoints** (`sMidpoint`) — in-flight `research/feuerbach-oq04-midpoint`; combine
+   with `sphericalCircumcircle_exists` to *define* the spherical nine-point circle.
+2. **The Feuerbach tangency** (nine-point circle tangent to all four tritangent circles).
+   Genuinely hard; not attempted.
+
+
 ## Session 2026-07-01 (researcher-7): completed the pairwise-distinctness matrix [VERIFIED]
 
 **Mode**: ACT (CONTINUE). The prior session (researcher-1) proved only `incircle_excircleAB_distinct`

--- a/src/data/research/problems/feuerbachs-theorem-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-04.json
@@ -32,7 +32,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: circle-to-great-circle tangency + spherical incircle scaffolding (FeuerbachsTheoremOQ04.lean, 894L, 0-axiom/0-sorry, VERIFIED docker [7743/7743]). sGreatCircle/greatCircleFoot/TangentToGreatCircle + greatCircleFoot_mem + circle_tangent_greatCircle_inter (singleton intersection) + sdist_greatCircleFoot_center establish the incircle-to-side tangency primitive. sGreatCircle_eq_sCircle shows great circles are the radius-π/2 circles (unifying the two tangency notions). SphericalIncircle (tangent to 3 side poles) + sphericalIncircle_contact_points (incircle meets each side in exactly one point, explicit feet) package the first Feuerbach ingredient. REMAINING HARD STEP: existence/uniqueness of the incenter O for a given triangle (angle-bisector argument); then spherical nine-point circle + Feuerbach tangency.",
+    "progressSummary": "PROGRESS: added the spherical circumcircle existence primitive (three points -> common sCircle) underneath the nine-point circle; Feuerbach tangency still the hard frontier.",
     "builtItems": [
       "FeuerbachsTheoremOQ04.chord_sq (Proofs/FeuerbachsTheoremOQ04.lean) — chord-cosine bridge: for unit vectors, ||P-Q||^2 = 2 - 2*scos P Q; turns spherical tangency into an inner-product equation. 0-axiom.",
       "FeuerbachsTheoremOQ04.abs_scos_le_one/scos_le_one/neg_one_le_scos — spherical cosine in [-1,1] (Cauchy-Schwarz on unit vectors)",
@@ -53,7 +53,9 @@
       "inner_orthoComp_self / inner_orthoComp_left — ⟪O⊥,·⟫ = 1-⟪O,N⟫² helper lemmas",
       "sGreatCircle_eq_sCircle — great circle = sCircle N (π/2), unifies great-circle & circle-circle tangency",
       "SphericalIncircle Na Nb Nc O ρ — circle tangent to all 3 side poles of a spherical triangle",
-      "sphericalIncircle_contact_points — incircle meets each of the 3 sides in exactly one point (explicit feet)"
+      "sphericalIncircle_contact_points — incircle meets each of the 3 sides in exactly one point (explicit feet)",
+      "sphericalCircumcircle_exists in FeuerbachsTheoremOQ04Circumcircle.lean: any three model points lie on a common sCircle O rho (circumcircle), via greatCircles_inter on poles A-B, B-C. [VERIFIED, 0-axiom]",
+      "sphericalCircumcircle_equidistant + inner_sub_eq_zero_iff_scos_eq in FeuerbachsTheoremOQ04Circumcircle.lean: circumcentre is spherically equidistant sdist A O = sdist B O = sdist C O. [VERIFIED, 0-axiom]"
     ],
     "insights": [
       "Mathlib has clean spherical geometry for free (unit vectors of any InnerProductSpace R E; geodesic distance = arccos of inner product) but essentially no hyperbolic metric, so the spherical model is the tractable non-Euclidean route for Feuerbach.",
@@ -61,7 +63,8 @@
       "Spherical circle tangency target: internal iff sdist(O1,O2)=|rho1-rho2|, external iff sdist(O1,O2)=rho1+rho2 — the non-Euclidean analog of the Euclidean d=|r1-r2| / r1+r2 used in the verified Euclidean Feuerbach gallery files.",
       "Spherical common tangent at a contact point is captured coordinate-free: since P ∈ span{O₁,O₂}, any T ⟂ {O₁,O₂} is simultaneously in the tangent space at P and tangent to both circles — no explicit geodesic parametrisation needed.",
       "Circle-to-great-circle tangency is the exact primitive a spherical INCIRCLE construction needs: the incircle is tangent to the three side-geodesics (great circles), not to other circles. Distance from a point to a great circle with unit pole N is arcsin|⟪O,N⟫|, so tangency criterion is |⟪O,N⟫| = sin ρ (spherical shadow of Euclidean distance-to-line = radius).",
-      "The contact point of a tangent circle and a side is the FOOT OF THE PERPENDICULAR (O - ⟪O,N⟫•N)/cos ρ; it is pure inner-product algebra (no infimum/analysis): ⟪foot,N⟫=0, ⟪foot,O⟫=cos ρ, ‖foot‖=1 via ‖O⊥‖²=1-⟪O,N⟫²=cos²ρ under the criterion. Uniqueness via ⟪Q,foot⟫=1 ⟹ Q=foot (scos_eq_one_iff)."
+      "The contact point of a tangent circle and a side is the FOOT OF THE PERPENDICULAR (O - ⟪O,N⟫•N)/cos ρ; it is pure inner-product algebra (no infimum/analysis): ⟪foot,N⟫=0, ⟪foot,O⟫=cos ρ, ‖foot‖=1 via ‖O⊥‖²=1-⟪O,N⟫²=cos²ρ under the criterion. Uniqueness via ⟪Q,foot⟫=1 ⟹ Q=foot (scos_eq_one_iff).",
+      "Spherical perpendicular bisector of a segment AB is the great circle with pole A-B: model points equidistant (equal scos) from A and B are exactly those orthogonal to A-B (inner_sub_eq_zero_iff_scos_eq). Dual to the side-pole bisector equidistant_two_sides_iff."
     ],
     "mathlibGaps": [
       "No developed hyperbolic-geometry metric (hyperboloid / Poincare disk distance) in Mathlib — blocks an axiom-free hyperbolic Feuerbach without building the model first.",
@@ -71,7 +74,8 @@
       "Bundle (S^n, sdist) as an actual Mathlib MetricSpace instance on the sphere subtype (sdist_isMetric supplies all four axioms; the remaining work is the subtype packaging).",
       "Tangent-point existence for tangent spherical circles (slerp midpoint on the geodesic between centres), using sdist_triangle for the betweenness/uniqueness argument.",
       "Construct the spherical incircle and nine-point circle for a spherical triangle, then attempt the tangency conclusion.",
-      "Relate the common tangent direction to a spherical Feuerbach configuration (incircle/nine-point-analogue tangency) building on the contact-point tangent structure."
+      "Relate the common tangent direction to a spherical Feuerbach configuration (incircle/nine-point-analogue tangency) building on the contact-point tangent structure.",
+      "Combine sphericalCircumcircle_exists with the in-flight side-midpoints (sMidpoint) to DEFINE the spherical nine-point circle as the circumcircle of the medial triangle."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds the **spherical circumcircle** to `feuerbachs-theorem-oq-04` (Feuerbach's Theorem in Non-Euclidean Geometry, spherical model) — the existence primitive underneath the spherical **nine-point circle**, which is the circumcircle of the medial triangle. New collision-free companion file `proofs/Proofs/FeuerbachsTheoremOQ04Circumcircle.lean` building only on the merged main API.

## What's proved (3 theorems, ~90 L, 0-axiom / 0-sorry)

- **`inner_sub_eq_zero_iff_scos_eq`** — perpendicular-bisector characterisation: `⟪O, A−B⟫ = 0 ↔ scos A O = scos B O`. The model points equidistant from `A` and `B` form the great circle with pole `A − B` (spherical perpendicular bisector of `AB`). Dual to the side-pole bisector `equidistant_two_sides_iff` already on main.
- **`sphericalCircumcircle_exists`** — for any three model points `A, B, C` on a sphere of dim `> 2`, `∃ O ρ, OnSphere O ∧ A, B, C ∈ sCircle O ρ`. Construction mirrors `sphericalIncircle_exists`: intersect the two perpendicular-bisector great circles (poles `A−B`, `B−C`) via `greatCircles_inter`, forcing `scos A O = scos B O = scos C O`; take `ρ = sdist A O` and match `cos ρ` via `cos_sdist`. Unconditional (no non-degeneracy hypothesis).
- **`sphericalCircumcircle_equidistant`** — the circumcentre is spherically equidistant: `sdist A O = sdist B O = sdist C O`.

## Why it matters

Dual of the incenter existence lemma (side-poles → vertices) and the direct existence primitive under the spherical nine-point circle: applied to the three side-midpoints (`sMidpoint`, in-flight on `research/feuerbach-oq04-midpoint`) it yields the nine-point circle as their circumcircle. Collision-free — new file, auto-discovered by lake globs (no `Proofs.lean` edit).

## Verification

Docker build **VERIFIED**: `docker-build.sh Proofs.FeuerbachsTheoremOQ04Circumcircle` → `✔ [7744/7744] Built`, exit 0. **0-sorry, 0-axiom**, no `native_decide` (tactics: `rw`, `unfold`, `real_inner_comm`, `cos_sdist`, `greatCircles_inter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)