### PR TITLE
Enrich harmonic-divergence-oq-03-oq-01: annotation depth + coverage

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-03-oq-01/annotations.json
@@ -1,26 +1,117 @@
 [
   {
+    "id": "ann-hdoq0301-intro",
+    "proofId": "harmonic-divergence-oq-03-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Setup: from conditional to absolute convergence for log 2",
+    "content": "The companion entry HarmonicDivergenceOQ03 proves the alternating harmonic series 1 − 1/2 + 1/3 − 1/4 + ⋯ converges conditionally to log 2 — its value exists only as an ordered limit of partial sums (¬ Summable). This file groups consecutive terms, (1 − 1/2) + (1/3 − 1/4) + ⋯, producing a series of positive terms 1/((2k+1)(2k+2)) with the same sum log 2. Because each term is O(1/k²), the regrouped series is absolutely summable and so has an honest HasSum/tsum value. This is the classic 'the sum of an alternating series equals the sum of its consecutive pairings' made concrete for the Mercator series, and it imports altHarmonic_tendsto_log_two from the parent rather than reproving convergence — keeping the file 0-sorry and 0-axiom.",
+    "mathContext": "Parent: $\\sum_{n\\ge1}\\frac{(-1)^{n+1}}{n}=\\log 2$ conditionally ($\\neg\\,\\mathrm{Summable}$). Here: $\\sum_{k\\ge0}\\frac1{(2k+1)(2k+2)}=\\log2$ absolutely, since $\\frac1{(2k+1)(2k+2)}=O(k^{-2})$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "conditional vs absolute convergence",
+      "Mercator/Newton series for log 2",
+      "regrouping vs rearrangement",
+      "alternating harmonic series"
+    ],
+    "prerequisites": [
+      "series convergence",
+      "the value of the alternating harmonic series"
+    ]
+  },
+  {
     "id": "ann-harmonic-divergence-oq-03-oq-01-01",
     "proofId": "harmonic-divergence-oq-03-oq-01",
-    "range": { "startLine": 38, "endLine": 56 },
+    "range": {
+      "startLine": 38,
+      "endLine": 56
+    },
     "type": "definition",
     "title": "Pairing collapses two conditional terms into one positive term",
-    "content": "The single algebraic fact behind the whole entry: the consecutive alternating pair `(-1)^{2k}/(2k+1) + (-1)^{2k+1}/(2k+2)` equals `1/(2k+1) - 1/(2k+2) = 1/((2k+1)(2k+2))`, a POSITIVE number. `altTerm_pair` proves it (the `(-1)^{2k}=1`, `(-1)^{2k+1}=-1` reductions plus `field_simp; ring`). Positivity of `pairTerm` is what later makes the partial sums monotone and unlocks a comparison-free summability argument."
+    "content": "The single algebraic fact behind the whole entry: the consecutive alternating pair `(-1)^{2k}/(2k+1) + (-1)^{2k+1}/(2k+2)` equals `1/(2k+1) - 1/(2k+2) = 1/((2k+1)(2k+2))`, a POSITIVE number. `altTerm_pair` proves it (the `(-1)^{2k}=1`, `(-1)^{2k+1}=-1` reductions plus `field_simp; ring`). Positivity of `pairTerm` is what later makes the partial sums monotone and unlocks a comparison-free summability argument.",
+    "mathContext": "$\\mathrm{pairTerm}(k)=\\frac1{(2k+1)(2k+2)}=\\frac1{2k+1}-\\frac1{2k+2}$; and $\\mathrm{altTerm}(2k)+\\mathrm{altTerm}(2k+1)=\\frac{(-1)^{2k}}{2k+1}+\\frac{(-1)^{2k+1}}{2k+2}=\\mathrm{pairTerm}(k)\\ge0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial fractions",
+      "telescoping-style collapse",
+      "positivity (positivity tactic)",
+      "field_simp/ring normalization"
+    ],
+    "prerequisites": [
+      "parity of (−1)^n",
+      "algebra of rationals over ℝ"
+    ]
   },
   {
     "id": "ann-harmonic-divergence-oq-03-oq-01-02",
     "proofId": "harmonic-divergence-oq-03-oq-01",
-    "range": { "startLine": 57, "endLine": 83 },
+    "range": {
+      "startLine": 57,
+      "endLine": 83
+    },
     "type": "insight",
     "title": "Pairing is a subsequence, not a rearrangement",
-    "content": "`sum_pairTerm_eq` proves by induction (peeling two terms at a time with `Finset.sum_range_succ`) that the N-th paired partial sum is EXACTLY the 2N-th alternating partial sum `altPartial (2N)`. This is the crux that makes regrouping safe for a conditionally convergent series: we are reading off a SUBSEQUENCE of the alternating partial sums, not permuting terms. Convergence and value therefore transfer for free — `tendsto_sum_pairTerm` just composes the parent's `altHarmonic_tendsto_log_two` with `N ↦ 2N → ∞`. No boundary-value/Abel argument is redone here."
+    "content": "`sum_pairTerm_eq` proves by induction (peeling two terms at a time with `Finset.sum_range_succ`) that the N-th paired partial sum is EXACTLY the 2N-th alternating partial sum `altPartial (2N)`. This is the crux that makes regrouping safe for a conditionally convergent series: we are reading off a SUBSEQUENCE of the alternating partial sums, not permuting terms. Convergence and value therefore transfer for free — `tendsto_sum_pairTerm` just composes the parent's `altHarmonic_tendsto_log_two` with `N ↦ 2N → ∞`. No boundary-value/Abel argument is redone here.",
+    "mathContext": "$\\sum_{k<N}\\mathrm{pairTerm}(k)=\\mathrm{altPartial}(2N)$, so the paired partial sums are the \\emph{even-indexed subsequence} of the alternating partial sums; hence $\\to\\log2$ by composing $\\mathrm{altHarmonic\\_tendsto\\_log\\_two}$ with $N\\mapsto 2N\\to\\infty$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subsequence of a convergent sequence",
+      "regrouping (not Riemann rearrangement)",
+      "Tendsto.comp",
+      "induction on partial sums"
+    ],
+    "prerequisites": [
+      "limits of subsequences",
+      "Finset.sum_range_succ induction"
+    ]
   },
   {
-    "id": "ann-harmonic-divergence-oq-03-oq-01-03",
+    "id": "ann-hdoq0301-summable",
     "proofId": "harmonic-divergence-oq-03-oq-01",
-    "range": { "startLine": 84, "endLine": 103 },
+    "range": {
+      "startLine": 84,
+      "endLine": 91
+    },
     "type": "theorem",
-    "title": "Absolute convergence with no comparison series",
-    "content": "Because the terms are nonnegative the paired partial sums are monotone, so `Monotone.ge_of_tendsto` bounds each one by its own limit `log 2`; `summable_of_sum_range_le` then yields `Summable pairTerm` directly — no `1/k²` comparison or index shift needed. Finally `HasSum.tendsto_sum_nat` plus `tendsto_nhds_unique` identify `∑' pairTerm = log 2`. The upshot: unlike its `¬ Summable` alternating parent, `∑ 1/((2k+1)(2k+2))` is absolutely convergent and gives `log 2` an honest `HasSum`/`tsum` value."
+    "title": "Absolute summability from monotone bounded partial sums",
+    "content": "summable_pairTerm establishes Summable pairTerm without naming a comparison series. Since every term is nonneg (pairTerm_nonneg), the partial sums are monotone; and they are bounded above by their own limit log 2 (Monotone.ge_of_tendsto against tendsto_sum_pairTerm). summable_of_sum_range_le turns 'nonneg terms with partial sums bounded above' directly into summability. This is exactly where the regrouped series improves on its conditionally-convergent parent: positivity + boundedness gives absolute convergence.",
+    "mathContext": "Nonneg terms + $\\sum_{k<N}\\mathrm{pairTerm}(k)\\le\\log2$ for all $N$ $\\Rightarrow$ $\\mathrm{Summable}\\,\\mathrm{pairTerm}$ (monotone bounded $\\Rightarrow$ convergent).",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone convergence for series",
+      "summable_of_sum_range_le",
+      "absolute convergence",
+      "order limit of monotone sequence"
+    ],
+    "prerequisites": [
+      "monotone bounded sequences converge",
+      "nonnegative series"
+    ]
+  },
+  {
+    "id": "ann-hdoq0301-value",
+    "proofId": "harmonic-divergence-oq-03-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Evaluating the positive series: the sum is log 2",
+    "content": "With summability in hand, hasSum_pairTerm_log_two pins the value. The summable series' partial sums converge to its tsum (Summable.hasSum.tendsto_sum_nat) and also to log 2 (tendsto_sum_pairTerm); tendsto_nhds_unique identifies the two limits, so ∑' k, pairTerm k = log 2, giving both the HasSum and tsum forms. Unlike the parent's ordered-limit-only value, this is a genuine unconditional sum: ∑ₖ 1/((2k+1)(2k+2)) = log 2.",
+    "mathContext": "$\\sum_{k=0}^{\\infty}\\frac1{(2k+1)(2k+2)}=\\log 2$ as an honest $\\mathrm{HasSum}$/$\\mathrm{tsum}$ (limit of a summable, hence order-independent, series).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "HasSum vs tsum",
+      "uniqueness of limits (tendsto_nhds_unique)",
+      "unconditional sum",
+      "Mercator series value"
+    ],
+    "prerequisites": [
+      "tsum of a summable series",
+      "uniqueness of sequential limits in a Hausdorff space"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-03-oq-01` (a positive, absolutely convergent series for log 2).

The three existing annotations were **missing every depth field** — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. This pass:

- Adds all four depth fields to every annotation (LaTeX `mathContext`, significance tiers, related concepts, prerequisites).
- Adds a `context` annotation (lines 4–37) covering the intro/setup: the conditional-vs-absolute convergence contrast with the parent alternating-harmonic entry and the consecutive-pairing idea.
- Splits the coarse final annotation (was 84–103, two distinct theorems) into `summability` (84–91) and the `log 2` evaluation (93–103).

Result: 5 non-overlapping annotations with full depth, covering intro + every declaration. Validated with `validateLineAnnotations`: 5/5 valid, 0 misaligned. meta.json unchanged.