### PR TITLE
Enrich zsqrtd-neg-two-oq-03-oq-06: annotation coverage

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/annotations.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03-oq-06/annotations.json
@@ -1,5 +1,51 @@
 [
   {
+    "id": "ann-zsq0306-intro",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-06",
+    "range": {
+      "startLine": 4,
+      "endLine": 34
+    },
+    "type": "context",
+    "title": "Setup: the Eisenstein integers ℤ[ω] and their unit group",
+    "content": "A child of zsqrtd-neg-two-oq-03, which constructs the Eisenstein-integer ring ℤ[ω] (with ω² + ω + 1 = 0), its multiplicative norm N(a + bω) = a² − ab + b², and its EuclideanDomain structure en route to representing primes p ≡ 1 mod 3 as a² + 3b². This entry determines the unit group completely: z is a unit iff N(z) = 1, and there are exactly six such elements — the sixth roots of unity {±1, ±ω, ±ω²}. The classification is packaged both element-wise (isUnit_iff) and as an explicit Finset (unitsFinset, card = 6). Everything reuses the parent's norm and is 0-axiom: no sorry, no axiom, and no native_decide.",
+    "mathContext": "$\\mathbb{Z}[\\omega]$ with $\\omega^2+\\omega+1=0$, norm $N(a+b\\omega)=a^2-ab+b^2$ multiplicative; units $=\\{z:N(z)=1\\}=\\{\\pm1,\\pm\\omega,\\pm\\omega^2\\}$, the group $\\mu_6$ of sixth roots of unity.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eisenstein integers",
+      "norm of a quadratic ring",
+      "unit group of a ring of integers",
+      "sixth roots of unity"
+    ],
+    "prerequisites": [
+      "quadratic integer rings",
+      "multiplicative norms",
+      "units and IsUnit"
+    ]
+  },
+  {
+    "id": "ann-zsq0306-omega",
+    "proofId": "zsqrtd-neg-two-oq-03-oq-06",
+    "range": {
+      "startLine": 35,
+      "endLine": 37
+    },
+    "type": "definition",
+    "title": "The generator ω = ⟨0,1⟩",
+    "content": "omega is the primitive cube root of unity ω generating ℤ[ω], given in coordinates as ⟨0,1⟩ (i.e. 0 + 1·ω). It satisfies ω² + ω + 1 = 0, so ω² = −1 − ω = ⟨-1,-1⟩ in coordinates; together with its negatives and 1 this yields the six units. Fixing ω concretely lets the later enumeration name each unit as an explicit coordinate pair.",
+    "mathContext": "$\\omega=\\langle0,1\\rangle$, a primitive cube root of unity: $\\omega^2+\\omega+1=0$, hence $\\omega^2=\\langle-1,-1\\rangle$; $\\{\\pm1,\\pm\\omega,\\pm\\omega^2\\}=\\{\\langle1,0\\rangle,\\langle-1,0\\rangle,\\langle0,1\\rangle,\\langle0,-1\\rangle,\\langle1,1\\rangle,\\langle-1,-1\\rangle\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "primitive root of unity",
+      "coordinate representation in ℤ[ω]",
+      "cyclotomic relation ω²+ω+1=0"
+    ],
+    "prerequisites": [
+      "cube roots of unity",
+      "ℤ[ω] coordinates"
+    ]
+  },
+  {
     "id": "ann-zsq-oq03oq06-isunit",
     "proofId": "zsqrtd-neg-two-oq-03-oq-06",
     "range": {


### PR DESCRIPTION
Enrichment pass for `zsqrtd-neg-two-oq-03-oq-06` (the unit group of the Eisenstein integers ℤ[ω] — exactly six units, the sixth roots of unity).

The three existing theorem annotations already had full depth fields, but lines 1–37 (header + the generator `omega`) were uncovered. This pass adds:

- A `context` annotation (4–34): the parent ℤ[ω] construction, the norm, and the six-unit classification.
- A `definition` annotation (35–37): the generator ω = ⟨0,1⟩ and how its powers/negatives give the six units.

Result: 5 non-overlapping annotations covering intro + ω + all three theorems. Validated with `validateLineAnnotations`: 5/5 valid, 0 misaligned. meta.json unchanged.