### PR TITLE
Enrich borsuk-ulam-oq-02-oq-01: cover all theorems + open question (6 → 10 anns)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/annotations.json
@@ -1,14 +1,29 @@
 [
   {
+    "id": "ann-bu-header",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 22
+    },
+    "type": "concept",
+    "title": "The open question: BU dimension for non-prime cyclic groups",
+    "content": "The header states the open question: for a finite cyclic group Z/n with n non-prime, what is the optimal equivariant Borsuk-Ulam dimension? For prime order Z/p the Yang-Borsuk theorem settles it, but for composite n the answer depends on the representation and the prime factorization of n. The organizing structural principle is monotonicity: if p | n then the Z/n-equivariant BU dimension is at least the Z/p one. This file formalizes the ABSTRACT dimension theory algebraically — axiomatizing buDim as a function of (group order, representation dimension) — to sidestep topological infrastructure Mathlib lacks, while still deriving the concrete composite-group lower bounds.",
+    "mathContext": "For $G = \\mathbb{Z}/n$ with $n$ composite, determine $\\mathrm{buDim}(n, d)$; the conjecture is $\\mathrm{buDim}(n, d) = \\max_{p \\mid n,\\, p \\text{ prime}} \\mathrm{buDim}(p, d)$.",
+    "significance": "key",
+    "relatedConcepts": ["equivariant topology", "Borsuk-Ulam theorem", "cyclic group actions", "prime factorization"],
+    "prerequisites": ["Borsuk-Ulam theorem", "group actions on spheres"]
+  },
+  {
     "id": "ann-bu-budim-function",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 52,
+      "startLine": 49,
       "endLine": 52
     },
     "type": "concept",
     "title": "buDim: Equivariant BU Dimension Function",
-    "content": "The axiom buDim (n d : \u2115) : \u2115 introduces the equivariant Borsuk-Ulam dimension for the cyclic group Z/n acting on a d-dimensional representation space. This integer-valued invariant captures the minimum sphere dimension where any Z/n-equivariant continuous map to the representation must have a zero. By axiomatizing buDim as an abstract function rather than defining it topologically, the file can study its algebraic properties (monotonicity, prime-factor behavior) purely in terms of group order and representation dimension, without requiring Lean's topological infrastructure.",
+    "content": "The axiom buDim (n d : ℕ) : ℕ introduces the equivariant Borsuk-Ulam dimension for the cyclic group Z/n acting on a d-dimensional representation space. This integer-valued invariant captures the minimum sphere dimension where any Z/n-equivariant continuous map to the representation must have a zero. By axiomatizing buDim as an abstract function rather than defining it topologically, the file can study its algebraic properties (monotonicity, prime-factor behavior) purely in terms of group order and representation dimension, without requiring Lean's topological infrastructure.",
     "mathContext": "$$\\text{buDim}(n, d) = \\min\\{k \\mid \\forall f: S^k \\to V_d \\text{ Z/n-equivariant continuous}, \\exists x, f(x) = 0\\}$$ where $V_d$ is a $d$-dimensional real representation of $\\mathbb{Z}/n\\mathbb{Z}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -27,12 +42,12 @@
     "id": "ann-bu-classical-z2",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 61,
+      "startLine": 58,
       "endLine": 61
     },
     "type": "concept",
     "title": "Classical Borsuk-Ulam: Z/2 Base Case",
-    "content": "buDim_two axiomatizes the classical Borsuk-Ulam theorem in terms of buDim: every Z/2-equivariant (odd) continuous map f : S^n \u2192 R^{n+1} must vanish somewhere, giving buDim(2, n+1) = n. This is Borsuk's 1933 result, equivalently stated by Lyusternik and Schnirelmann as: there is no odd map S^n \u2192 S^{n-1}. In the buDim framework, it says the n-sphere is the minimal domain that forces a zero in an (n+1)-dimensional target under the antipodal action. This axiom is the Z/2 anchor from which z4_lower_bound and z6_lower_bound_z2 are derived via monotonicity.",
+    "content": "buDim_two axiomatizes the classical Borsuk-Ulam theorem in terms of buDim: every Z/2-equivariant (odd) continuous map f : S^n → R^{n+1} must vanish somewhere, giving buDim(2, n+1) = n. This is Borsuk's 1933 result, equivalently stated by Lyusternik and Schnirelmann as: there is no odd map S^n → S^{n-1}. In the buDim framework, it says the n-sphere is the minimal domain that forces a zero in an (n+1)-dimensional target under the antipodal action. This axiom is the Z/2 anchor from which z4_lower_bound and z6_lower_bound_z2 are derived via monotonicity.",
     "mathContext": "$$\\text{buDim}(2, n+1) = n$$ encoding: every odd map $f : S^n \\to \\mathbb{R}^{n+1}$ satisfies $f(x_0) = 0$ for some $x_0 \\in S^n$, or equivalently $f(-x) = -f(x) \\implies \\exists x, f(x) = 0$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -50,12 +65,12 @@
     "id": "ann-bu-yang-borsuk",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 66,
+      "startLine": 63,
       "endLine": 67
     },
     "type": "concept",
     "title": "Yang-Borsuk Theorem for Prime-Order Groups",
-    "content": "buDim_prime axiomatizes Yang's 1954 generalization: for any prime p, the equivariant BU dimension for the standard complex representation of Z/p of complex dimension n equals 2n-1. The Z/p action rotates each complex coordinate by e^{2\u03c0i/p}. This is the definitive result for prime-order groups, proved by Yang using Smith theory and the Serre spectral sequence. The axiom provides the prime-case baseline for all derived composite group bounds: zpq_lower_bound uses this to get buDim(pq, 2n) \u2265 2n-1.",
+    "content": "buDim_prime axiomatizes Yang's 1954 generalization: for any prime p, the equivariant BU dimension for the standard complex representation of Z/p of complex dimension n equals 2n-1. The Z/p action rotates each complex coordinate by e^{2πi/p}. This is the definitive result for prime-order groups, proved by Yang using Smith theory and the Serre spectral sequence. The axiom provides the prime-case baseline for all derived composite group bounds: zpq_lower_bound uses this to get buDim(pq, 2n) ≥ 2n-1.",
     "mathContext": "$$\\text{buDim}(p, 2n) = 2n - 1 \\quad \\text{for prime } p,\\; n \\geq 1$$ where the representation is $\\mathbb{C}^n$ with $g \\cdot (z_1, \\ldots, z_n) = (e^{2\\pi i/p} z_1, \\ldots, e^{2\\pi i/p} z_n)$ for a generator $g \\in \\mathbb{Z}/p$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -74,12 +89,12 @@
     "id": "ann-bu-monotonicity",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 71,
+      "startLine": 69,
       "endLine": 71
     },
     "type": "concept",
     "title": "Monotonicity: Divisibility Implies Stronger Equivariant Constraint",
-    "content": "buDim_mono axiomatizes the restriction principle: if p divides n, then Z/p embeds in Z/n as a subgroup, and every Z/n-equivariant map restricts to a Z/p-equivariant map. A map that must vanish for Z/p-equivariant reasons must also vanish when viewed as Z/n-equivariant, so the constraint from p propagates to n: buDim(p, d) \u2264 buDim(n, d). This monotonicity axiom is the engine driving every composite group lower bound: z4_lower_bound uses p=2, n=4; z6_lower_bound_z2 uses p=2, n=6; z6_lower_bound_z3 uses p=3, n=6; zpq_lower_bound uses the prime factor of pq.",
+    "content": "buDim_mono axiomatizes the restriction principle: if p divides n, then Z/p embeds in Z/n as a subgroup, and every Z/n-equivariant map restricts to a Z/p-equivariant map. A map that must vanish for Z/p-equivariant reasons must also vanish when viewed as Z/n-equivariant, so the constraint from p propagates to n: buDim(p, d) ≤ buDim(n, d). This monotonicity axiom is the engine driving every composite group lower bound: z4_lower_bound uses p=2, n=4; z6_lower_bound_z2 uses p=2, n=6; z6_lower_bound_z3 uses p=3, n=6; zpq_lower_bound uses the prime factor of pq.",
     "mathContext": "$$p \\mid n \\implies \\text{buDim}(p, d) \\leq \\text{buDim}(n, d)$$ reflecting the inclusion $\\mathbb{Z}/p \\hookrightarrow \\mathbb{Z}/n$ and the restriction functor on equivariant maps: $f$ is $\\mathbb{Z}/n$-equivariant $\\implies$ $f$ is $\\mathbb{Z}/p$-equivariant.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -89,7 +104,7 @@
       "subgroup inclusion"
     ],
     "prerequisites": [
-      "Subgroups of cyclic groups: Z/p \u2264 Z/n when p | n",
+      "Subgroups of cyclic groups: Z/p ≤ Z/n when p | n",
       "Restriction of group actions to subgroups"
     ]
   },
@@ -97,12 +112,12 @@
     "id": "ann-bu-composite-prime-bound",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 79,
+      "startLine": 77,
       "endLine": 82
     },
     "type": "insight",
     "title": "Every Composite Group Has a Prime-Derived Lower Bound",
-    "content": "buDim_composite_has_prime_bound proves: for any n \u2265 2, there exists a prime p with p | n and buDim(p, d) \u2264 buDim(n, d). The proof is two lines: first apply Nat.exists_prime_and_dvd (since n \u2265 2 implies n \u2260 1, so n has a prime factor), then apply buDim_mono with the extracted prime divisor. This existential theorem establishes that no composite group can be 'easier' than all its prime subgroups simultaneously \u2014 there is always a prime subgroup whose constraint propagates upward.",
+    "content": "buDim_composite_has_prime_bound proves: for any n ≥ 2, there exists a prime p with p | n and buDim(p, d) ≤ buDim(n, d). The proof is two lines: first apply Nat.exists_prime_and_dvd (since n ≥ 2 implies n ≠ 1, so n has a prime factor), then apply buDim_mono with the extracted prime divisor. This existential theorem establishes that no composite group can be 'easier' than all its prime subgroups simultaneously — there is always a prime subgroup whose constraint propagates upward.",
     "mathContext": "$$\\forall n \\geq 2,\\; \\forall d:\\; \\exists p \\text{ prime},\\; p \\mid n \\text{ and } \\text{buDim}(p, d) \\leq \\text{buDim}(n, d)$$ proved using \\texttt{Nat.exists\\_prime\\_and\\_dvd}: $n \\geq 2 \\iff n \\neq 1 \\implies \\exists p \\text{ prime}, p \\mid n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -112,26 +127,56 @@
       "prime subgroups"
     ],
     "prerequisites": [
-      "Every integer \u2265 2 has a prime factor",
+      "Every integer ≥ 2 has a prime factor",
       "buDim_mono axiom"
     ]
+  },
+  {
+    "id": "ann-bu-z4-bound",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "Z/4 lower bound inherited from Z/2",
+    "content": "z4_lower_bound instantiates the monotonicity machinery at its simplest: since 2 | 4, buDim_mono gives buDim(2, n+1) ≤ buDim(4, n+1), and rewriting with buDim_two (buDim(2, n+1) = n) yields n ≤ buDim(4, n+1). Z/4 is the first non-prime cyclic group, and this shows it inherits the full classical Borsuk-Ulam bound from its Z/2 subgroup — no representation of Z/4 is 'easier' to break than the antipodal Z/2 case.",
+    "mathContext": "$$n \\le \\mathrm{buDim}(4, n+1),\\quad\\text{via } 2 \\mid 4:\\ \\mathrm{buDim}(2,n+1)=n \\le \\mathrm{buDim}(4,n+1).$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Z/4 group", "monotonicity instantiation", "classical BU bound"],
+    "prerequisites": ["buDim_mono", "buDim_two", "divisibility 2 | 4"]
+  },
+  {
+    "id": "ann-bu-z6-best-of-both",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "Z/6 takes the best of both prime subgroups",
+    "content": "The three Z/6 theorems illustrate the central phenomenon for groups with two distinct prime factors. From the Z/2 subgroup, z6_lower_bound_z2 gives buDim(6, n+1) ≥ n. From the Z/3 subgroup, z6_lower_bound_z3 gives the SHARPER buDim(6, 2n) ≥ 2n-1 on even-dimensional representations (via Yang-Borsuk for the prime 3). z6_combined_bound records that on the even representation 2n the Z/3 bound wins (2n-1 ≥ n), so Z/6 inherits the maximum of its two prime subgroup bounds. This is exactly the max-over-prime-divisors pattern the open question conjectures holds in general.",
+    "mathContext": "$$\\mathrm{buDim}(6, 2n) \\ge \\max\\big(\\underbrace{n}_{\\mathbb{Z}/2},\\ \\underbrace{2n-1}_{\\mathbb{Z}/3}\\big) = 2n-1 \\quad (n \\ge 1).$$",
+    "significance": "key",
+    "relatedConcepts": ["Z/6 group", "maximum over prime divisors", "Yang-Borsuk for Z/3", "sharpest prime bound"],
+    "prerequisites": ["buDim_mono", "buDim_prime", "buDim_two", "monotonicity of subtraction on ℕ"]
   },
   {
     "id": "ann-bu-zpq-bound",
     "proofId": "borsuk-ulam-oq-02-oq-01",
     "range": {
-      "startLine": 111,
+      "startLine": 110,
       "endLine": 116
     },
     "type": "insight",
     "title": "Z/pq Lower Bound: Yang-Borsuk Meets Monotonicity",
-    "content": "zpq_lower_bound proves: for primes p, q and any n \u2265 1, buDim(pq, 2n) \u2265 2n-1. The proof chains two steps: buDim_mono with p | pq gives buDim(p, 2n) \u2264 buDim(pq, 2n), and buDim_prime gives buDim(p, 2n) = 2n-1, so by transitivity the bound 2n-1 \u2264 buDim(pq, 2n) follows. Note that p and q need not be distinct \u2014 the proof works for p = q, covering Z/p\u00b2 as well as semiprimes. This generalizes z6_lower_bound_z3 and covers Z/15, Z/21, Z/35, Z/p\u00b2 for any prime p.",
+    "content": "zpq_lower_bound proves: for primes p, q and any n ≥ 1, buDim(pq, 2n) ≥ 2n-1. The proof chains two steps: buDim_mono with p | pq gives buDim(p, 2n) ≤ buDim(pq, 2n), and buDim_prime gives buDim(p, 2n) = 2n-1, so by transitivity the bound 2n-1 ≤ buDim(pq, 2n) follows. Note that p and q need not be distinct — the proof works for p = q, covering Z/p² as well as semiprimes. This generalizes z6_lower_bound_z3 and covers Z/15, Z/21, Z/35, Z/p² for any prime p.",
     "mathContext": "$$\\text{buDim}(pq, 2n) \\geq 2n - 1 \\quad \\text{for primes } p, q,\\; n \\geq 1$$ via the chain: $\\text{buDim}(pq, 2n) \\stackrel{\\text{mono}}{\\geq} \\text{buDim}(p, 2n) \\stackrel{\\text{Yang}}{=} 2n - 1$.",
     "significance": "key",
     "relatedConcepts": [
       "semiprimes",
       "Yang-Borsuk theorem",
-      "prime squares Z/p\u00b2",
+      "prime squares Z/p²",
       "monotonicity chain"
     ],
     "prerequisites": [
@@ -139,5 +184,20 @@
       "buDim_mono axiom",
       "Divisibility p | pq"
     ]
+  },
+  {
+    "id": "ann-bu-open-question",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "The central open question and specific open cases",
+    "content": "The closing section sharpens the open problem: for composite n, is buDim(n, d) always the maximum over prime divisors p | n of buDim(p, d)? A YES means the composite group structure adds no constraint beyond its prime subgroups; a NO means some (necessarily exotic) representations are harder to break for the full group than for any prime subgroup. The lower bounds proved in this file supply the ≥ direction of the conjectured equality; the matching ≤ direction (that no extra dimension is forced) is what remains open. Specific unresolved cases are listed: buDim(4, 2n), buDim(6, 2n), buDim(p², 2n), and the general max-over-prime-divisors formula.",
+    "mathContext": "Open: $\\mathrm{buDim}(n, 2k) \\stackrel{?}{=} \\max_{p \\mid n,\\, p \\text{ prime}} \\mathrm{buDim}(p, 2k)$. This file proves $\\ge$; the $\\le$ direction is the open half.",
+    "significance": "key",
+    "relatedConcepts": ["max over prime divisors conjecture", "exotic representations", "regular representation", "open problem"],
+    "prerequisites": ["the lower bounds above", "representation theory of cyclic groups"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-02-oq-01` (*Equivariant Borsuk-Ulam for Non-Prime Groups*).

The existing 6 annotations were high-quality but covered only the 4 axioms and 2 of the 6 theorems — the concrete payoff theorems (`z4_lower_bound`, `z6_lower_bound_z2/z3`, `z6_combined_bound`) and the header / open-question sections were unannotated (~10% line coverage).

**Changes (annotations.json only):**
- Added a **header** annotation (the composite-group BU open question and the rationale for axiomatizing `buDim` rather than building topological infrastructure).
- Added a **z4_lower_bound** annotation (Z/4 inherits the classical BU bound from its Z/2 subgroup).
- Added a **Z/6 'best of both prime subgroups'** insight covering `z6_lower_bound_z2`, `z6_lower_bound_z3`, and `z6_combined_bound` — the max-over-prime-divisors phenomenon in miniature.
- Added an **open-question footer** annotation (the conjectured max-over-prime-divisors equality; this file proves the ≥ direction, the ≤ half is open).
- Extended the single-line axiom ranges to include their doc comments.
- Preserved all existing content; 10 non-overlapping annotations, valid schema/enums.

Axiom integrity unchanged: entry stays `axiomatized`, badge `axiom`, 4 axioms (matches the 4 literal `axiom` declarations). No Lean or meta.json changes.