### PR TITLE
research(fermat-two-squares-oq-09): Brahmagupta–Fibonacci identity + sum-of-two-squares multiplicativity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FermatTwoSquaresOQ09.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ09.lean
@@ -1,0 +1,144 @@
+import Mathlib.NumberTheory.Zsqrtd.GaussianInt
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.NormNum
+
+/-
+# Brahmagupta–Fibonacci Identity and Multiplicativity of Sums of Two Squares
+
+## Open Question OQ-09 (parent: Fermat's Two-Square Theorem)
+
+Fermat's theorem tells us *which primes* are sums of two squares
+(`p = a² + b² ↔ p = 2 ∨ p ≡ 1 mod 4`).  Extending the characterization from primes
+to composites rests on a single structural fact, flagged in the parent's open
+questions:
+
+> This requires Brahmagupta's identity `(a²+b²)(c²+d²) = (ac-bd)² + (ad+bc)²`
+> and the multiplicativity of the norm in `ℤ[i]`.
+
+This file formalizes exactly that building block: the **Brahmagupta–Fibonacci
+identity** (both branches), the resulting closure of "is a sum of two squares" under
+multiplication (over `ℤ` and over `ℕ`), and the conceptual source of the identity —
+it *is* the multiplicativity of the Gaussian-integer norm `N(a+bi) = a²+b²`.
+
+## Contribution
+
+1. `brahmagupta_fibonacci` / `brahmagupta_fibonacci'` — the two-square identity and its
+   sister form, over an arbitrary commutative ring (a pure `ring` identity).
+2. `IsSumSq` and `IsSumSq.mul` — sums of two integer squares are closed under
+   multiplication, the direct payoff of the identity.
+3. `IsSumSqNat` / `isSumSqNat_iff` / `IsSumSqNat.mul` — the classical `ℕ` statement,
+   bridged to the `ℤ` version through `Int.natAbs` (a natural number is a sum of two
+   natural squares iff it is a sum of two integer squares).
+4. `gaussianInt_norm_eq`, `isSumSq_iff_gaussianNorm`, `IsSumSq.mul'` — the identity
+   read as norm multiplicativity in `ℤ[i]`: `IsSumSq n ↔ ∃ z : ℤ[i], N z = n`, and the
+   *same* closure re-derived from `Zsqrtd.norm_mul`.  This exhibits Brahmagupta's
+   identity as the coordinate form of `N(zw) = N(z)·N(w)`.
+
+## Mathematical Context
+
+Writing `a² + b² = N(a + bi)` for the Gaussian norm, the identity
+`(a²+b²)(c²+d²) = (ac-bd)² + (ad+bc)²` is precisely `N(z)N(w) = N(zw)` with
+`z = a+bi`, `w = c+di`, since `zw = (ac-bd) + (ad+bc)i`.  The sister branch comes from
+using `w̄ = c-di` instead.  Multiplicativity of the norm is what powers the composite
+characterization of sums of two squares and, via unique factorization in `ℤ[i]`, the
+uniqueness of prime representations.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace FermatTwoSquaresOQ09
+
+/-! ### The Brahmagupta–Fibonacci identity -/
+
+/-- **Brahmagupta–Fibonacci identity.**  In any commutative ring,
+    `(a² + b²)(c² + d²) = (ac - bd)² + (ad + bc)²`.  A product of two sums of two
+    squares is again a sum of two squares. -/
+theorem brahmagupta_fibonacci {R : Type*} [CommRing R] (a b c d : R) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) = (a * c - b * d) ^ 2 + (a * d + b * c) ^ 2 := by
+  ring
+
+/-- **Sister form** of the identity, obtained by conjugating the second factor
+    (`d ↦ -d`): `(a² + b²)(c² + d²) = (ac + bd)² + (ad - bc)²`.  The two branches
+    give the (generically) two distinct representations of the product. -/
+theorem brahmagupta_fibonacci' {R : Type*} [CommRing R] (a b c d : R) :
+    (a ^ 2 + b ^ 2) * (c ^ 2 + d ^ 2) = (a * c + b * d) ^ 2 + (a * d - b * c) ^ 2 := by
+  ring
+
+/-! ### Closure over the integers -/
+
+/-- `n` is a sum of two integer squares. -/
+def IsSumSq (n : ℤ) : Prop := ∃ a b : ℤ, n = a ^ 2 + b ^ 2
+
+/-- The set of sums of two integer squares is closed under multiplication — the direct
+    consequence of the Brahmagupta–Fibonacci identity. -/
+theorem IsSumSq.mul {m n : ℤ} (hm : IsSumSq m) (hn : IsSumSq n) : IsSumSq (m * n) := by
+  obtain ⟨a, b, rfl⟩ := hm
+  obtain ⟨c, d, rfl⟩ := hn
+  exact ⟨a * c - b * d, a * d + b * c, brahmagupta_fibonacci a b c d⟩
+
+/-- `1 = 1² + 0²` is a sum of two squares, so the sums of two squares form a
+    multiplicative submonoid of `ℤ`. -/
+theorem IsSumSq.one : IsSumSq 1 := ⟨1, 0, by ring⟩
+
+/-! ### The classical statement over the naturals -/
+
+/-- `n : ℕ` is a sum of two natural squares. -/
+def IsSumSqNat (n : ℕ) : Prop := ∃ a b : ℕ, n = a ^ 2 + b ^ 2
+
+/-- A natural number is a sum of two natural squares iff, viewed in `ℤ`, it is a sum of
+    two integer squares.  (Signs are immaterial: `a² = (|a|)²`.) -/
+theorem isSumSqNat_iff (n : ℕ) : IsSumSqNat n ↔ IsSumSq (n : ℤ) := by
+  constructor
+  · rintro ⟨a, b, rfl⟩
+    exact ⟨a, b, by push_cast; ring⟩
+  · rintro ⟨a, b, h⟩
+    refine ⟨a.natAbs, b.natAbs, ?_⟩
+    have : (n : ℤ) = (a.natAbs : ℤ) ^ 2 + (b.natAbs : ℤ) ^ 2 := by
+      rw [h, Int.natCast_natAbs, Int.natCast_natAbs, sq_abs, sq_abs]
+    exact_mod_cast this
+
+/-- Sums of two *natural* squares are closed under multiplication — the classical
+    number-theoretic statement, reduced to the integer version. -/
+theorem IsSumSqNat.mul {m n : ℕ} (hm : IsSumSqNat m) (hn : IsSumSqNat n) :
+    IsSumSqNat (m * n) := by
+  rw [isSumSqNat_iff] at hm hn ⊢
+  push_cast
+  exact hm.mul hn
+
+/-! ### The Gaussian-integer norm interpretation -/
+
+/-- The Gaussian norm of `z = re + im·i` is `re² + im²`.  (`GaussianInt` is
+    `Zsqrtd (-1)`, so `Zsqrtd.norm_def` gives `re·re - (-1)·im·im`.) -/
+theorem gaussianInt_norm_eq (z : GaussianInt) :
+    Zsqrtd.norm z = z.re ^ 2 + z.im ^ 2 := by
+  rw [Zsqrtd.norm_def]; ring
+
+/-- `n` is a sum of two integer squares iff it is the norm of a Gaussian integer. -/
+theorem isSumSq_iff_gaussianNorm (n : ℤ) :
+    IsSumSq n ↔ ∃ z : GaussianInt, Zsqrtd.norm z = n := by
+  constructor
+  · rintro ⟨a, b, rfl⟩
+    exact ⟨⟨a, b⟩, by rw [gaussianInt_norm_eq]⟩
+  · rintro ⟨z, rfl⟩
+    exact ⟨z.re, z.im, (gaussianInt_norm_eq z)⟩
+
+/-- Closure under multiplication, re-derived as multiplicativity of the Gaussian norm
+    `N(zw) = N(z)·N(w)` (`Zsqrtd.norm_mul`).  This exhibits Brahmagupta's identity as
+    the coordinate expression of a ring homomorphism property. -/
+theorem IsSumSq.mul' {m n : ℤ} (hm : IsSumSq m) (hn : IsSumSq n) : IsSumSq (m * n) := by
+  rw [isSumSq_iff_gaussianNorm] at hm hn ⊢
+  obtain ⟨z, rfl⟩ := hm
+  obtain ⟨w, rfl⟩ := hn
+  exact ⟨z * w, Zsqrtd.norm_mul z w⟩
+
+/-! ### Concrete verifications -/
+
+/-- `5 = 1² + 2²`, `13 = 2² + 3²`, and their product `65 = 1² + 8² = 4² + 7²`,
+    the two branches of the identity. -/
+example : (5 : ℤ) * 13 = (1 * 2 - 2 * 3) ^ 2 + (1 * 3 + 2 * 2) ^ 2 := by decide
+example : (5 : ℤ) * 13 = (1 * 2 + 2 * 3) ^ 2 + (1 * 3 - 2 * 2) ^ 2 := by decide
+/-- `65` is genuinely a sum of two squares in two ways. -/
+example : (65 : ℤ) = 1 ^ 2 + 8 ^ 2 := by decide
+example : (65 : ℤ) = 4 ^ 2 + 7 ^ 2 := by decide
+
+end FermatTwoSquaresOQ09

--- a/src/data/proofs/fermat-two-squares-oq-09/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-09/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "fermat-two-squares-oq-09",
+  "title": "The Brahmagupta–Fibonacci Identity: Sums of Two Squares are Closed Under Multiplication",
+  "slug": "fermat-two-squares-oq-09",
+  "description": "The structural engine behind the composite two-squares theory: the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² (both branches), the resulting closure of 'sum of two squares' under multiplication over ℤ and ℕ, and the identity's origin as the multiplicativity of the Gaussian-integer norm N(a+bi) = a²+b².",
+  "meta": {
+    "author": "Brahmagupta / Fibonacci (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brahmagupta%E2%80%93Fibonacci_identity",
+    "date": "628",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "gaussian-integers",
+      "brahmagupta",
+      "norm-multiplicativity",
+      "fermat",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ09.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Zsqrtd.norm_mul",
+        "description": "Multiplicativity of the norm on ℤ√d: norm (z*w) = norm z * norm w. For d = -1 this is the Gaussian norm and yields Brahmagupta's identity as its coordinate form.",
+        "module": "Mathlib.NumberTheory.Zsqrtd.Basic"
+      },
+      {
+        "theorem": "Zsqrtd.norm_def",
+        "description": "norm z = z.re·z.re − d·z.im·z.im; specialized to GaussianInt (d = -1) gives re² + im².",
+        "module": "Mathlib.NumberTheory.Zsqrtd.Basic"
+      },
+      {
+        "theorem": "GaussianInt",
+        "description": "The Gaussian integers ℤ[i] as Zsqrtd (-1), with norm N(a+bi) = a²+b².",
+        "module": "Mathlib.NumberTheory.Zsqrtd.GaussianInt"
+      },
+      {
+        "theorem": "Int.natCast_natAbs",
+        "description": "(a.natAbs : ℤ) = |a| — the bridge for reducing the ℕ statement to the ℤ statement (a² = |a|²).",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "sq_abs",
+        "description": "|a|² = a² — signs are immaterial when passing between natural and integer squares.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "brahmagupta_fibonacci / brahmagupta_fibonacci': the two-square identity and its conjugate sister form, stated over an ARBITRARY commutative ring (a pure `ring` identity), so it applies to ℤ, ℕ-casts, polynomial rings, etc.",
+      "IsSumSq.mul: sums of two integer squares are closed under multiplication — the direct payoff of the identity, with explicit witnesses (ac−bd, ad+bc)",
+      "isSumSqNat_iff + IsSumSqNat.mul: the classical ℕ statement, bridged to the ℤ version via Int.natAbs (a natural is a sum of two natural squares iff it is a sum of two integer squares), so closure descends to ℕ with no sign bookkeeping",
+      "isSumSq_iff_gaussianNorm: IsSumSq n ↔ ∃ z : ℤ[i], N z = n — identifying sums of two squares with Gaussian norms",
+      "IsSumSq.mul': the SAME closure re-derived from Zsqrtd.norm_mul, exhibiting Brahmagupta's identity as the coordinate expression of N(zw) = N(z)·N(w) — the conceptual origin the parent open question named",
+      "Concrete witnesses: 5·13 = 65 = 1²+8² = 4²+7², both branches of the identity realized"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 144,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (no sorryAx, no Lean.ofReduceBool). The Brahmagupta–Fibonacci identities are proved by `ring`; the Gaussian-integer connection uses Mathlib's Zsqrtd.norm_def and Zsqrtd.norm_mul.",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² appears in Brahmagupta's Brāhmasphuṭasiddhānta (628 CE) and reappears in Fibonacci's Liber Quadratorum (1225). It says that a product of two sums of two squares is again a sum of two squares — the multiplicative backbone of the theory. Centuries later this became the statement that the Gaussian integers ℤ[i] carry a multiplicative norm N(a+bi) = a²+b², and it is exactly this multiplicativity that lifts Fermat's prime-only two-squares theorem to arbitrary composites: knowing which primes are sums of two squares, the identity assembles the representation for any product.",
+    "problemStatement": "**Open question (fermat-two-squares-oq-09)**: Prove the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² (and the sister form with ac+bd, ad−bc), establishing that the set of sums of two squares is closed under multiplication, and connect it to the multiplicativity of the norm in ℤ[i].\n\n**Result**: A fully verified (0 sorries, 0 axioms) development: both branches of the identity over an arbitrary commutative ring; closure of 'sum of two squares' under multiplication over ℤ and over ℕ; and the identification IsSumSq n ↔ ∃ z : ℤ[i], N z = n, with closure re-derived from Zsqrtd.norm_mul so that Brahmagupta's identity is displayed as the coordinate form of N(zw) = N(z)·N(w).",
+    "text": "A product of two sums of two squares is a sum of two squares, via (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)². The identity is the coordinate form of the multiplicativity of the Gaussian norm N(a+bi) = a²+b² in ℤ[i].",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **The identity (both branches)**: `brahmagupta_fibonacci` and `brahmagupta_fibonacci'` are pure polynomial identities in a commutative ring, discharged by `ring`. The primed version is the conjugate branch (replace d by −d), giving the second representation of the product.\n\n2. **Closure over ℤ**: define `IsSumSq n := ∃ a b : ℤ, n = a² + b²`. Given m = a²+b² and n = c²+d², the identity exhibits m·n = (ac−bd)² + (ad+bc)², so `IsSumSq.mul` holds. With `IsSumSq.one` (1 = 1²+0²) the sums of two squares form a multiplicative submonoid of ℤ.\n\n3. **Descent to ℕ**: `isSumSqNat_iff` proves n : ℕ is a sum of two natural squares iff (n : ℤ) is a sum of two integer squares, using Int.natAbs and |a|² = a². Closure over ℕ (`IsSumSqNat.mul`) then follows by casting and applying the ℤ result — no case analysis on the signs of ac−bd, ad+bc.\n\n4. **Gaussian-norm interpretation**: `gaussianInt_norm_eq` computes N z = z.re² + z.im² from Zsqrtd.norm_def (d = −1). Then `isSumSq_iff_gaussianNorm` identifies IsSumSq n with the existence of a Gaussian integer of norm n, and `IsSumSq.mul'` re-derives closure directly from `Zsqrtd.norm_mul`, revealing the identity as N(zw) = N(z)·N(w).\n\n5. **Witnesses**: 5·13 = 65 = 1²+8² = 4²+7², both branches realized concretely by `decide`.",
+    "keyInsights": [
+      "**One `ring` call is the whole identity**: over any commutative ring, (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² is a polynomial identity — no number theory needed to state closure; the content is what the identity is FOR.",
+      "**Two branches, two representations**: the sister form (ac+bd, ad−bc) is the conjugate branch. Generically the two give distinct representations of the product, which is the source of a composite having multiple two-square representations (e.g. 65 = 1²+8² = 4²+7²).",
+      "**Brahmagupta = norm multiplicativity in ℤ[i]**: writing a²+b² = N(a+bi), the identity is precisely N(z)·N(w) = N(zw) with zw = (ac−bd) + (ad+bc)i. `IsSumSq.mul'` proves closure this way, from Zsqrtd.norm_mul, making the conceptual origin explicit rather than incidental.",
+      "**ℕ reduces to ℤ through natAbs**: rather than track the signs of ac−bd and ad+bc to stay within ℕ, cast to ℤ, apply the identity, and take |·|. The bridge `isSumSqNat_iff` isolates this once so the ℕ closure is a two-line corollary.",
+      "**This is the composite theorem's engine**: Fermat classifies which PRIMES are sums of two squares; multiplicativity (this identity) is exactly what promotes that to arbitrary products, and hence to the full factorization criterion (sibling oq-08)."
+    ],
+    "prerequisites": [
+      "Elementary algebra of polynomial identities in a commutative ring",
+      "The Gaussian integers ℤ[i] and their norm N(a+bi) = a²+b²",
+      "Integer/natural casting and natAbs",
+      "Fermat's two-squares theorem for primes (parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "File header framing the entry as the multiplicative engine behind the composite two-squares theory, and the connection to the Gaussian norm. Imports Zsqrtd.GaussianInt plus the Ring/NormNum tactics; opens the FermatTwoSquaresOQ09 namespace.",
+      "mathContext": "The parent classifies primes; this file supplies the closure-under-multiplication that lifts the prime classification to composites, and identifies it with ℤ[i] norm multiplicativity."
+    },
+    {
+      "id": "identity",
+      "title": "The Brahmagupta–Fibonacci Identity",
+      "startLine": 51,
+      "endLine": 66,
+      "summary": "brahmagupta_fibonacci and its conjugate sister form brahmagupta_fibonacci', over an arbitrary commutative ring, each by `ring`.",
+      "mathContext": "(a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² and = (ac+bd)² + (ad−bc)². Pure polynomial identities; the two branches give the two representations of the product."
+    },
+    {
+      "id": "closure-int",
+      "title": "Closure over the Integers",
+      "startLine": 67,
+      "endLine": 82,
+      "summary": "Defines IsSumSq and proves IsSumSq.mul (closure under multiplication) and IsSumSq.one, making sums of two squares a multiplicative submonoid of ℤ.",
+      "mathContext": "Given m = a²+b², n = c²+d², the identity gives m·n = (ac−bd)²+(ad+bc)². With 1 = 1²+0², closure and the unit make a submonoid."
+    },
+    {
+      "id": "closure-nat",
+      "title": "The Classical Statement over the Naturals",
+      "startLine": 83,
+      "endLine": 107,
+      "summary": "isSumSqNat_iff bridges the ℕ predicate to the ℤ one via Int.natAbs and |a|²=a²; IsSumSqNat.mul is then the ℕ closure by casting to ℤ.",
+      "mathContext": "A natural is a sum of two natural squares iff it is a sum of two integer squares. Signs are immaterial, so the ℤ identity yields the ℕ closure without sign case analysis."
+    },
+    {
+      "id": "gaussian-norm",
+      "title": "The Gaussian-Integer Norm Interpretation",
+      "startLine": 108,
+      "endLine": 133,
+      "summary": "gaussianInt_norm_eq (N z = re²+im²), isSumSq_iff_gaussianNorm (sums of two squares are exactly Gaussian norms), and IsSumSq.mul' re-deriving closure from Zsqrtd.norm_mul.",
+      "mathContext": "a²+b² = N(a+bi). Since zw = (ac−bd)+(ad+bc)i, the identity is N(z)N(w)=N(zw); closure is norm multiplicativity."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete Verifications",
+      "startLine": 134,
+      "endLine": 144,
+      "summary": "5·13 = 65 realized by both branches of the identity, and 65 = 1²+8² = 4²+7² by decide.",
+      "mathContext": "The two branches of Brahmagupta's identity produce the two distinct two-square representations of 65."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "Supplies the multiplicativity the parent flagged as needed to lift the prime-only two-squares theorem to composites."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-08",
+      "relationship": "related",
+      "description": "The 'only if'/assembly steps of the sibling's all-naturals factorization criterion rest on exactly this closure (Brahmagupta–Fibonacci / ℤ[i] norm multiplicativity)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the Brahmagupta–Fibonacci identity and its consequences: both branches of the identity over an arbitrary commutative ring, closure of 'sum of two squares' under multiplication over ℤ and ℕ, and the identification of sums of two squares with Gaussian norms — with closure re-derived from Zsqrtd.norm_mul to display the identity as the coordinate form of N(zw) = N(z)·N(w).",
+    "implications": "**Theoretical Significance**: Multiplicativity of the norm form is the pivot from the prime theory (Fermat) to the composite theory (the factorization criterion, sibling oq-08). It is also the shadow of unique factorization in ℤ[i]: the same norm that is multiplicative here controls the uniqueness of prime two-square representations. The two-branch structure of the identity is the arithmetic origin of a number having several two-square representations, foreshadowing the representation-counting theory (r₂(n) and theta functions).",
+    "openQuestions": [
+      "Can the analogous norm-form identities for x²+2y² (norm of ℤ[√−2]) and x²+3y² be formalized the same way, giving closure-under-multiplication for those forms from Zsqrtd.norm_mul?",
+      "Can multiplicativity be upgraded to count representations, deriving r₂(mn) relations from the two-branch structure toward the Jacobi two-square theorem r₂(n) = 4∑_{d∣n} χ(d)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Zsqrtd.GaussianInt",
+      "Mathlib.Tactic.Ring",
+      "Mathlib.Tactic.NormNum"
+    ],
+    "opens": [],
+    "namespace": "FermatTwoSquaresOQ09",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/FermatTwoSquaresOQ09.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": "628",
+      "venue": "",
+      "note": "Original appearance of the two-square multiplication identity"
+    },
+    {
+      "authors": "L. Fibonacci",
+      "title": "Liber Quadratorum",
+      "year": "1225",
+      "venue": "",
+      "note": "The Book of Squares; reintroduces the identity to European mathematics"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **fermat-two-squares-oq-09**, answering the parent open question: prove the Brahmagupta–Fibonacci identity `(a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)²` (both branches), establish that sums of two squares are closed under multiplication, and connect it to the multiplicativity of the norm in `ℤ[i]`.

## Contents (`Proofs/FermatTwoSquaresOQ09.lean`, 144 L, 9 thm / 2 def)

- `brahmagupta_fibonacci` / `brahmagupta_fibonacci'` — both branches of the identity over an **arbitrary commutative ring** (pure `ring`).
- `IsSumSq` / `IsSumSq.mul` / `IsSumSq.one` — sums of two integer squares form a multiplicative submonoid of ℤ.
- `isSumSqNat_iff` / `IsSumSqNat.mul` — the classical ℕ statement, bridged to ℤ via `Int.natAbs` (no sign case-analysis).
- `gaussianInt_norm_eq` / `isSumSq_iff_gaussianNorm` / `IsSumSq.mul'` — the identity re-derived as `N(zw) = N(z)·N(w)` from `Zsqrtd.norm_mul`, exhibiting Brahmagupta's identity as the coordinate form of Gaussian-norm multiplicativity (the origin the parent OQ named).
- Concrete witnesses: `5·13 = 65 = 1²+8² = 4²+7²`, both branches realized.

## Verification

- Compiles clean under Mathlib v4.26 (host `lean`, exit 0, no warnings).
- `#print axioms` on the key theorems: only `propext` / `Classical.choice` / `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- **0 sorries, 0 axioms** → `status: verified`, `badge: verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)