### PR TITLE
Enrich amgm-inequality-oq-02-oq-02-oq-02: intro annotation + keyInsight

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/annotations.json
@@ -1,74 +1,159 @@
 [
   {
+    "id": "ann-amgm020202-intro",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "Setup: the equality case of Maclaurin's inequality (sufficiency)",
+    "content": "The parent formalization amgm-inequality-oq-02-oq-02 proves Newton's log-concavity and the Maclaurin chain Mₖ(x) ≥ Mₖ₊₁(x), where Mⱼ(x) = (eⱼ(x)/C(n,j))^{1/j} and eⱼ is the j-th elementary symmetric polynomial. Its open question OQ-02 asks for the equality case: Mₖ = Mₖ₊₁ iff all nonzero inputs are equal. This file settles the sufficiency (⟸) direction in full generality — if every coordinate equals a common c ≥ 0 then every Maclaurin mean collapses to c, so the whole chain M₁ = ⋯ = Mₙ = c is equalities. The harder necessity (⟹) direction, which must track when the discriminant in the cleared-denominator induction is exactly zero, is left to a further child problem. Built directly on the parent's definitions, 0 axioms / 0 sorries.",
+    "mathContext": "$M_j(x)=\\bigl(e_j(x)/\\binom{n}{j}\\bigr)^{1/j}$; sufficiency: $x=(c,\\dots,c),\\,c\\ge0 \\Rightarrow M_1=M_2=\\cdots=M_n=c$. Necessity ($M_k=M_{k+1}\\Rightarrow$ constant up to a zero block) is open.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Maclaurin's inequality",
+      "elementary symmetric polynomials",
+      "Newton's inequalities",
+      "equality cases of symmetric-mean inequalities"
+    ],
+    "prerequisites": [
+      "elementary symmetric polynomials",
+      "Maclaurin means",
+      "AM–GM inequality"
+    ]
+  },
+  {
     "id": "ann-const-input-setup",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 44, "endLine": 50 },
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
     "type": "context",
     "title": "The constant-input strategy",
     "content": "The entire sufficiency proof rests on evaluating the symmetric machinery at a constant vector `(c,…,c)`. Two elementary observations drive everything: over a `k`-element subset the product of constant entries is `cᵏ`, and there are exactly `C(n,k)` such subsets. This section sets up that computation, which the rest of the file lifts to the Maclaurin means. The file imports the parent `Proofs.AmgmInequalityOQ02` to reuse its exact definitions of `elemSymm` and `maclaurinMean`, so these results are drop-in companions to the parent's chain M₁ ≥ ⋯ ≥ Mₙ.",
     "mathContext": "Goal: show a non-negative constant input forces $M_1 = M_2 = \\cdots = M_n = c$, the $\\Leftarrow$ half of the equality case $M_k = M_{k+1} \\iff$ inputs equal.",
     "significance": "context",
-    "relatedConcepts": ["elementary symmetric polynomial", "Maclaurin mean", "equality case", "AM-GM inequality"],
-    "prerequisites": ["symmetric functions", "finite sums and products"]
+    "relatedConcepts": [
+      "elementary symmetric polynomial",
+      "Maclaurin mean",
+      "equality case",
+      "AM-GM inequality"
+    ],
+    "prerequisites": [
+      "symmetric functions",
+      "finite sums and products"
+    ]
   },
   {
     "id": "ann-elemsymm-const",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 52, "endLine": 64 },
+    "range": {
+      "startLine": 52,
+      "endLine": 64
+    },
     "type": "technique",
     "title": "Elementary symmetric polynomial of a constant vector",
     "content": "Computes the closed form `eₖ(c,…,c) = C(n,k)·cᵏ`. After unfolding `elemSymm` (a sum over `k`-element subsets of products), each product is `cᵏ` by `Finset.prod_const` together with the cardinality fact `hs.2 : s.card = k` from `mem_powersetCard`. Summing the constant `cᵏ` over the `C(n,k)` subsets — counted by `Finset.card_powersetCard` — gives the result via `nsmul_eq_mul`.",
     "mathContext": "$e_k(c,\\dots,c) = \\sum_{|s|=k} \\prod_{i\\in s} c = \\sum_{|s|=k} c^k = \\binom{n}{k}\\, c^k.$",
     "significance": "supporting",
-    "relatedConcepts": ["elementary symmetric polynomial", "binomial coefficient", "powersetCard", "prod_const"],
-    "prerequisites": ["finite products over subsets", "binomial coefficients"]
+    "relatedConcepts": [
+      "elementary symmetric polynomial",
+      "binomial coefficient",
+      "powersetCard",
+      "prod_const"
+    ],
+    "prerequisites": [
+      "finite products over subsets",
+      "binomial coefficients"
+    ]
   },
   {
     "id": "ann-maclaurinmean-const",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 66, "endLine": 88 },
+    "range": {
+      "startLine": 66,
+      "endLine": 88
+    },
     "type": "insight",
     "title": "Each Maclaurin mean of a constant vector equals the constant",
     "content": "The computational heart: `Mₖ(c,…,c) = c` for `c ≥ 0` and `1 ≤ k ≤ n`. Unfolding `maclaurinMean = (eₖ / C(n,k))^(1/k)` and substituting `elemSymm_const`, the normalizing `C(n,k)` cancels (`div_self`, positive by `Nat.choose_pos` for `k ≤ n`), leaving `cᵏ`. The outer exponent `1/k` then inverts it: `(cᵏ)^(1/k) = c^(k·(1/k)) = c^1 = c`, established through `Real.rpow_natCast`, `Real.rpow_mul` (needs `c ≥ 0`), and `div_self` on `k ≠ 0`. Non-negativity of `c` is essential — real `rpow` is only well-behaved for non-negative bases.",
     "mathContext": "$M_k(c,\\dots,c) = \\left(\\frac{\\binom{n}{k} c^k}{\\binom{n}{k}}\\right)^{1/k} = (c^k)^{1/k} = c, \\quad c \\ge 0,\\ 1 \\le k \\le n.$",
     "significance": "key",
-    "relatedConcepts": ["Maclaurin mean", "real power (rpow)", "Nat.choose_pos", "normalization"],
-    "prerequisites": ["real exponentiation", "Maclaurin means"]
+    "relatedConcepts": [
+      "Maclaurin mean",
+      "real power (rpow)",
+      "Nat.choose_pos",
+      "normalization"
+    ],
+    "prerequisites": [
+      "real exponentiation",
+      "Maclaurin means"
+    ]
   },
   {
     "id": "ann-maclaurin-eq-consecutive",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 90, "endLine": 96 },
+    "range": {
+      "startLine": 90,
+      "endLine": 96
+    },
     "type": "insight",
     "title": "Sufficiency, consecutive step",
     "content": "The ⟸ direction of open question OQ-02 for a single step: on a non-negative constant input the Maclaurin step `Mₖ = Mₖ₊₁` is an equality. The proof simply rewrites both sides to `c` using `maclaurinMean_const` (with the index shift `k → k+1` requiring `k+1 ≤ n`). This is the exact companion to the parent's strict-inequality chain: where the parent shows `Mₖ ≥ Mₖ₊₁`, this pins the equality case for constant data.",
     "mathContext": "$c \\ge 0,\\ 1 \\le k,\\ k+1 \\le n \\;\\Rightarrow\\; M_k(c,\\dots,c) = M_{k+1}(c,\\dots,c) = c.$",
     "significance": "key",
-    "relatedConcepts": ["Maclaurin mean", "equality case", "Newton's inequalities"],
-    "prerequisites": ["Maclaurin means"]
+    "relatedConcepts": [
+      "Maclaurin mean",
+      "equality case",
+      "Newton's inequalities"
+    ],
+    "prerequisites": [
+      "Maclaurin means"
+    ]
   },
   {
     "id": "ann-maclaurin-all-eq",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 98, "endLine": 104 },
+    "range": {
+      "startLine": 98,
+      "endLine": 104
+    },
     "type": "insight",
     "title": "Sufficiency, full chain collapse",
     "content": "Generalizes from consecutive steps to arbitrary pairs: every two Maclaurin means with indices in `1..n` agree on a constant input, so the entire chain `M₁ = M₂ = ⋯ = Mₙ = c` collapses to one value. Both means rewrite to `c` via `maclaurinMean_const`, so no induction along the chain is needed — the constant-value lemma is uniform in the index.",
     "mathContext": "$c \\ge 0 \\;\\Rightarrow\\; M_j(c,\\dots,c) = M_k(c,\\dots,c) = c \\text{ for all } 1 \\le j,k \\le n.$",
     "significance": "supporting",
-    "relatedConcepts": ["Maclaurin mean", "equality case", "AM-GM equality"],
-    "prerequisites": ["Maclaurin means"]
+    "relatedConcepts": [
+      "Maclaurin mean",
+      "equality case",
+      "AM-GM equality"
+    ],
+    "prerequisites": [
+      "Maclaurin means"
+    ]
   },
   {
     "id": "ann-not-const-contrapositive",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-02",
-    "range": { "startLine": 106, "endLine": 122 },
+    "range": {
+      "startLine": 106,
+      "endLine": 122
+    },
     "type": "insight",
     "title": "Contrapositive: differing means detect non-constant data",
     "content": "The logically equivalent restatement: if two consecutive Maclaurin means of `x` differ, then `x` cannot be a non-negative constant vector. Proved by assuming `x = (c,…,c)` with `c ≥ 0` and deriving the equality `Mₖ = Mₖ₊₁` (from `maclaurin_eq_of_const`), contradicting the hypothesis. This is the practically useful shape: applying Maclaurin's inequality to observed data, a strict gap between consecutive means certifies that the data is not constant.",
     "mathContext": "$M_k(x) \\ne M_{k+1}(x) \\;\\Rightarrow\\; \\neg\\,\\exists c \\ge 0,\\ x = (c,\\dots,c).$",
     "significance": "supporting",
-    "relatedConcepts": ["contrapositive", "Maclaurin mean", "equality case"],
-    "prerequisites": ["logical negation", "Maclaurin means"]
+    "relatedConcepts": [
+      "contrapositive",
+      "Maclaurin mean",
+      "equality case"
+    ],
+    "prerequisites": [
+      "logical negation",
+      "Maclaurin means"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
@@ -41,7 +41,8 @@
     "keyInsights": [
       "The equality case splits into an easy sufficiency direction (constant ⟹ equality) and a hard necessity direction (equality ⟹ constant). This entry closes the sufficiency direction cleanly and generally.",
       "The whole sufficiency argument reduces to two facts: the closed form eₖ(c,…,c) = C(n,k)·cᵏ and the rpow identity (cᵏ)^(1/k) = c for c ≥ 0.",
-      "Working with the parent's exact definitions of elemSymm and maclaurinMean (rather than a restatement) makes the result a drop-in companion to the Maclaurin chain, usable wherever the parent's inequality is applied."
+      "Working with the parent's exact definitions of elemSymm and maclaurinMean (rather than a restatement) makes the result a drop-in companion to the Maclaurin chain, usable wherever the parent's inequality is applied.",
+      "Maclaurin's means interpolate between the arithmetic mean M₁ = (∑xᵢ)/n and the geometric mean Mₙ = (∏xᵢ)^{1/n}, so the sufficiency direction proved here simultaneously realizes the 'equality holds when all inputs coincide' half of AM–GM and of every intermediate Newton inequality — one constant-input computation covers the whole chain."
     ],
     "historicalContext": "Colin Maclaurin stated his mean inequalities in *A Treatise of Algebra* (1748, posthumous), sharpening Newton's inequalities on the elementary symmetric functions of the roots of a polynomial. The equality analysis — that the chain of Maclaurin means is constant exactly when the inputs are equal — is the natural companion to the inequality and mirrors the AM ≥ GM equality case (AM = GM iff all terms equal), which is itself the extreme M₁ = Mₙ instance of this chain."
   },


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-02-oq-02` (equality case of Maclaurin's inequality, sufficiency direction).

The six existing annotations already had full depth fields, but the header (lines 1–43) was uncovered and `keyInsights` had only 3 (below the target of 4).

- Added a `context` annotation (1–42): the parent Maclaurin chain, the OQ-02 equality question, and the sufficiency-proven / necessity-open split.
- Added a 4th keyInsight: Maclaurin means interpolate the arithmetic mean M₁ and geometric mean Mₙ, so the single constant-input computation realizes the equality half of AM–GM and of every intermediate Newton inequality.

7 non-overlapping annotations, full coverage. Validated: 7/7 valid, 0 misaligned. meta.json 11.8 KB (well under caps).