### PR TITLE
research(lagrange-four-squares-oq-05): Euler four-square identity multiplicative structure [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ05.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ05.lean
@@ -1,0 +1,183 @@
+/-
+# Euler's Four-Square Identity: Multiplicative Structure
+
+This file develops the *structural* consequences of Euler's four-square identity
+(1748), going beyond the raw algebraic identity itself.
+
+The parent entry `LagrangeFourSquares` records the bare identity
+`(a²+b²+c²+d²)(x²+y²+z²+w²) = A²+B²+C²+D²` and notes informally that "the set of
+sums-of-four-squares is closed under multiplication". Here we *prove* that
+structural statement and package it:
+
+1. **Multiplicative closure.** If `m` and `n` are each a sum of four integer
+   squares, then so is `m * n` — with the four squares produced *explicitly* by
+   Euler's identity (`IsSumOfFourSquares.mul`).
+2. **Monoid structure.** The sums of four squares form a `Submonoid ℤ`.
+3. **Sharp characterization.** Over `ℤ`, being a sum of four squares is exactly
+   being nonnegative (`isSumOfFourSquares_iff_nonneg`): the "≥ 0" direction is a
+   trivial positivity fact, while "0 ≤ n → sum of four squares" is Lagrange's
+   theorem. So the submonoid is precisely `{n : ℤ | 0 ≤ n}`.
+4. **Quaternion connection.** Euler's identity *is* the multiplicativity of the
+   Hamilton quaternion norm `normSq (p * q) = normSq p * normSq q`.
+
+Everything here is machine-checked with no additional axioms.
+-/
+
+import Mathlib
+
+open scoped Quaternion
+
+namespace LagrangeFourSquaresOQ05
+
+/-! ## Euler's Four-Square Identity (the engine)
+
+Stated over an arbitrary commutative ring; the specific quadruple `(A, B, C, D)`
+below is the componentwise product of the quaternions `a + bi + cj + dk` and
+`x + yi + zj + wk`. -/
+
+/-- **Euler's Four-Square Identity (1748).** The product of two sums of four
+squares is a sum of four squares, via an explicit bilinear formula. -/
+theorem euler_four_square_identity {R : Type*} [CommRing R] (a b c d x y z w : R) :
+    (a * x - b * y - c * z - d * w) ^ 2 +
+    (a * y + b * x + c * w - d * z) ^ 2 +
+    (a * z - b * w + c * x + d * y) ^ 2 +
+    (a * w + b * z - c * y + d * x) ^ 2 =
+    (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) * (x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2) := by
+  ring
+
+/-! ## The sum-of-four-squares predicate over `ℤ` -/
+
+/-- An integer is a sum of four squares. -/
+def IsSumOfFourSquares (n : ℤ) : Prop :=
+  ∃ a b c d : ℤ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n
+
+/-- `0 = 0² + 0² + 0² + 0²`. -/
+theorem IsSumOfFourSquares.zero : IsSumOfFourSquares 0 :=
+  ⟨0, 0, 0, 0, by ring⟩
+
+/-- `1 = 1² + 0² + 0² + 0²` — the multiplicative unit is a sum of four squares. -/
+theorem IsSumOfFourSquares.one : IsSumOfFourSquares 1 :=
+  ⟨1, 0, 0, 0, by ring⟩
+
+/-- Every square is (trivially) a sum of four squares. -/
+theorem IsSumOfFourSquares.sq (a : ℤ) : IsSumOfFourSquares (a ^ 2) :=
+  ⟨a, 0, 0, 0, by ring⟩
+
+/-- **Multiplicative closure.** If `m` and `n` are each a sum of four squares,
+then so is `m * n`. The witnessing quadruple for `m * n` is built *explicitly*
+from those of `m` and `n` through Euler's identity — this is the structural heart
+of the four-square theorem's reduction to primes. -/
+theorem IsSumOfFourSquares.mul {m n : ℤ}
+    (hm : IsSumOfFourSquares m) (hn : IsSumOfFourSquares n) :
+    IsSumOfFourSquares (m * n) := by
+  obtain ⟨a, b, c, d, hmeq⟩ := hm
+  obtain ⟨x, y, z, w, hneq⟩ := hn
+  refine ⟨a * x - b * y - c * z - d * w,
+          a * y + b * x + c * w - d * z,
+          a * z - b * w + c * x + d * y,
+          a * w + b * z - c * y + d * x, ?_⟩
+  rw [euler_four_square_identity, hmeq, hneq]
+
+/-! ## Monoid structure
+
+The sums of four squares form a submonoid of `(ℤ, ·)`. -/
+
+/-- The sums of four squares as a `Submonoid ℤ`. -/
+def sumOfFourSquares : Submonoid ℤ where
+  carrier := {n : ℤ | IsSumOfFourSquares n}
+  one_mem' := IsSumOfFourSquares.one
+  mul_mem' := IsSumOfFourSquares.mul
+
+@[simp]
+theorem mem_sumOfFourSquares {n : ℤ} :
+    n ∈ sumOfFourSquares ↔ IsSumOfFourSquares n := Iff.rfl
+
+/-! ## Sharp characterization: sum of four squares ⟺ nonnegative
+
+Over `ℤ` the sum-of-four-squares property is *exactly* nonnegativity. One
+direction is elementary positivity; the converse is Lagrange's theorem, applied
+to the natural number `n.toNat`. -/
+
+/-- A sum of four squares is nonnegative. -/
+theorem IsSumOfFourSquares.nonneg {n : ℤ} (h : IsSumOfFourSquares n) : 0 ≤ n := by
+  obtain ⟨a, b, c, d, rfl⟩ := h
+  positivity
+
+/-- Every nonnegative integer is a sum of four squares (Lagrange 1770, lifted to
+`ℤ`). -/
+theorem isSumOfFourSquares_of_nonneg {n : ℤ} (hn : 0 ≤ n) : IsSumOfFourSquares n := by
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares n.toNat
+  refine ⟨a, b, c, d, ?_⟩
+  have : ((a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 : ℕ) : ℤ) = ((n.toNat : ℕ) : ℤ) := by
+    exact_mod_cast congrArg (Nat.cast : ℕ → ℤ) h
+  push_cast at this
+  rw [this, Int.toNat_of_nonneg hn]
+
+/-- **Sharp characterization.** An integer is a sum of four squares iff it is
+nonnegative. Consequently `sumOfFourSquares = {n : ℤ | 0 ≤ n}` as a set. -/
+theorem isSumOfFourSquares_iff_nonneg {n : ℤ} :
+    IsSumOfFourSquares n ↔ 0 ≤ n :=
+  ⟨IsSumOfFourSquares.nonneg, isSumOfFourSquares_of_nonneg⟩
+
+/-- The submonoid of sums of four squares is exactly the nonnegative integers. -/
+theorem sumOfFourSquares_carrier :
+    (sumOfFourSquares : Set ℤ) = {n : ℤ | 0 ≤ n} := by
+  ext n
+  simp [sumOfFourSquares, isSumOfFourSquares_iff_nonneg, Set.mem_setOf_eq]
+
+/-! ## Natural-number multiplicative closure
+
+The same closure holds inside `ℕ`: a product of two sums of four natural squares
+is a sum of four natural squares. Crucially we build the representation of `m * n`
+*directly from the given representations of `m` and `n`* — casting to `ℤ`,
+applying Euler's identity, and taking absolute values (`(t.natAbs) ^ 2 = t ^ 2`).
+No appeal to Lagrange's theorem on the product is needed: this is exactly the
+elementary multiplicative closure that `IsSumOfFourSquares.mul` provides. -/
+
+/-- Multiplicativity of the sum-of-four-squares property over `ℕ`, built
+explicitly from the two input representations via Euler's identity. -/
+theorem nat_sum_four_squares_mul {m n : ℕ}
+    (hm : ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = m)
+    (hn : ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n) :
+    ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = m * n := by
+  obtain ⟨a, b, c, d, hm'⟩ := hm
+  obtain ⟨x, y, z, w, hn'⟩ := hn
+  -- Lift the two representations to `ℤ` and combine them with Euler's identity.
+  have hmZ : IsSumOfFourSquares (m : ℤ) :=
+    ⟨a, b, c, d, by exact_mod_cast hm'⟩
+  have hnZ : IsSumOfFourSquares (n : ℤ) :=
+    ⟨x, y, z, w, by exact_mod_cast hn'⟩
+  obtain ⟨p, q, r, s, hpqrs⟩ := hmZ.mul hnZ
+  -- Realise the (possibly negative) integer witnesses as naturals via natAbs.
+  refine ⟨p.natAbs, q.natAbs, r.natAbs, s.natAbs, ?_⟩
+  have hcast : ((p.natAbs ^ 2 + q.natAbs ^ 2 + r.natAbs ^ 2 + s.natAbs ^ 2 : ℕ) : ℤ)
+      = ((m * n : ℕ) : ℤ) := by
+    -- `push_cast` rewrites `(↑t.natAbs)` to `|t|`; `sq_abs` then gives `|t|² = t²`.
+    push_cast
+    rw [sq_abs, sq_abs, sq_abs, sq_abs, hpqrs]
+  exact_mod_cast hcast
+
+/-! ## The quaternion connection
+
+Euler's identity is not a coincidence: it *is* the multiplicativity of the
+Hamilton quaternion norm. For integer quaternions `p, q : ℍ[ℤ]`, the norm
+`normSq` sends products to products, and `normSq` of a quaternion is the sum of
+the squares of its four components. -/
+
+open Quaternion in
+/-- The Hamilton quaternion norm is multiplicative on `ℍ[ℤ]`; this is Euler's
+four-square identity in disguise. -/
+theorem quaternion_normSq_mul (p q : ℍ[ℤ]) :
+    Quaternion.normSq (p * q) = Quaternion.normSq p * Quaternion.normSq q :=
+  map_mul Quaternion.normSq p q
+
+/-- Euler's identity recovered from quaternion norm multiplicativity: expanding
+`normSq` of a quaternion into its four components and applying
+`quaternion_normSq_mul` reproduces the four-square identity. -/
+theorem euler_via_quaternion (a b c d x y z w : ℤ) :
+    (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) * (x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2) =
+      Quaternion.normSq ((⟨a, b, c, d⟩ : ℍ[ℤ]) * (⟨x, y, z, w⟩ : ℍ[ℤ])) := by
+  rw [quaternion_normSq_mul]
+  simp only [Quaternion.normSq_def']
+
+end LagrangeFourSquaresOQ05

--- a/src/data/proofs/lagrange-four-squares-oq-05/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-oq-05/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-euler-identity",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 38,
+      "endLine": 46
+    },
+    "type": "theorem",
+    "title": "Euler's four-square identity (the bilinear engine)",
+    "content": "The 1748 identity $(a^2+b^2+c^2+d^2)(x^2+y^2+z^2+w^2) = A^2+B^2+C^2+D^2$, stated over an arbitrary commutative ring and closed by a single `ring`. The four forms are $A = ax-by-cz-dw$, $B = ay+bx+cw-dz$, $C = az-bw+cx+dy$, $D = aw+bz-cy+dx$ — precisely the four components of the quaternion product $(a+bi+cj+dk)(x+yi+zj+wk)$. Every closure result in this file is a corollary of this one identity: it does not merely say the product is a sum of four squares, it *names* the four squares.",
+    "mathContext": "$(a^2+b^2+c^2+d^2)(x^2+y^2+z^2+w^2) = A^2+B^2+C^2+D^2$ with $A,B,C,D$ the components of a quaternion product.",
+    "significance": "critical",
+    "prerequisites": [
+      "Polynomial identities over a commutative ring",
+      "the `ring` tactic"
+    ],
+    "relatedConcepts": [
+      "Euler's four-square identity",
+      "quaternion multiplication",
+      "bilinear forms"
+    ]
+  },
+  {
+    "id": "ann-mul-closure",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 66,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Multiplicative closure by explicit construction",
+    "content": "`IsSumOfFourSquares.mul`: if $m$ and $n$ are each a sum of four integer squares, so is $m\\cdot n$. The proof destructs the witnesses $a,b,c,d$ (for $m$) and $x,y,z,w$ (for $n$) and supplies the *explicit* quadruple $(A,B,C,D)$ from Euler's identity as the witness for $m\\cdot n$, closing the goal with `rw [euler_four_square_identity, hmeq, hneq]`. This is the structural heart of Lagrange's proof strategy: once every prime is a sum of four squares, this lemma propagates the property to every product, i.e. to all naturals.",
+    "mathContext": "IsSumOfFourSquares m → IsSumOfFourSquares n → IsSumOfFourSquares (m·n), witnessed by Euler's $A,B,C,D$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Euler's four-square identity",
+      "existential witnesses"
+    ],
+    "relatedConcepts": [
+      "multiplicative closure",
+      "reduction to primes",
+      "constructive existence"
+    ]
+  },
+  {
+    "id": "ann-submonoid",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 81,
+      "endLine": 93
+    },
+    "type": "definition",
+    "title": "Sums of four squares as a submonoid of ℤ",
+    "content": "`sumOfFourSquares : Submonoid ℤ` bundles the closure results into algebraic structure: `one_mem'` is $1 = 1^2+0^2+0^2+0^2$, and `mul_mem'` is exactly `IsSumOfFourSquares.mul`. The `mem_sumOfFourSquares` simp lemma unfolds membership to the underlying predicate. Packaging the property this way makes it composable with the rest of Mathlib's monoid API.",
+    "mathContext": "$\\{n : \\mathbb{Z} \\mid \\exists a b c d,\\ a^2+b^2+c^2+d^2 = n\\}$ is a submonoid of $(\\mathbb{Z},\\cdot)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Submonoid structure",
+      "the multiplicative closure lemma"
+    ],
+    "relatedConcepts": [
+      "Submonoid",
+      "algebraic structure",
+      "multiplicative monoid"
+    ]
+  },
+  {
+    "id": "ann-sharp-characterization",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 101,
+      "endLine": 126
+    },
+    "type": "theorem",
+    "title": "Sharp characterization: sum of four squares ⟺ nonnegative",
+    "content": "Over $\\mathbb{Z}$, `IsSumOfFourSquares n ↔ 0 ≤ n`. The forward direction is immediate (`positivity`: a sum of squares is nonnegative). The converse is Lagrange's theorem in disguise: given $0 \\le n$, apply `Nat.sum_four_squares` to `n.toNat` to obtain natural witnesses, cast them to $\\mathbb{Z}$, and use `Int.toNat_of_nonneg` to identify $\\uparrow n.\\mathrm{toNat}$ with $n$. The corollary `sumOfFourSquares_carrier` reads this as an equality of sets: the submonoid is *exactly* $\\{n : \\mathbb{Z} \\mid 0 \\le n\\}$. So over $\\mathbb{Z}$ the four-square property degenerates to a sign condition — a sharp boundary invisible in the raw identity.",
+    "mathContext": "$\\text{IsSumOfFourSquares}(n) \\iff 0 \\le n$; hence $\\text{sumOfFourSquares} = \\{n \\mid 0 \\le n\\}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "Lagrange's four-square theorem (Nat.sum_four_squares)",
+      "Int.toNat_of_nonneg",
+      "the `positivity` tactic"
+    ],
+    "relatedConcepts": [
+      "sharp boundary",
+      "Lagrange's theorem",
+      "nonnegativity"
+    ]
+  },
+  {
+    "id": "ann-nat-closure",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 134,
+      "endLine": 158
+    },
+    "type": "insight",
+    "title": "Natural-number closure built honestly from the witnesses",
+    "content": "`nat_sum_four_squares_mul` proves the closure over $\\mathbb{N}$, but *without* re-invoking Lagrange on the product (which would make the input hypotheses vacuous). Instead it lifts the given natural representations of $m$ and $n$ to $\\mathbb{Z}$, combines them with `IsSumOfFourSquares.mul` to get integer witnesses $p,q,r,s$ for $m\\cdot n$, and realises them as naturals via `natAbs`, using $|t|^2 = t^2$ (`push_cast` turns $\\uparrow t.\\mathrm{natAbs}$ into $|t|$, then `sq_abs`). The proof genuinely consumes `hm` and `hn`, so Euler's identity — not Lagrange — does the work.",
+    "mathContext": "From representations of $m,n \\in \\mathbb{N}$, build one for $m\\cdot n$ via Euler over $\\mathbb{Z}$ and $|t|^2 = t^2$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "the ℤ closure lemma",
+      "Int.natAbs and sq_abs",
+      "ℕ↔ℤ casting"
+    ],
+    "relatedConcepts": [
+      "constructive closure",
+      "avoiding circularity",
+      "natAbs realisation"
+    ]
+  },
+  {
+    "id": "ann-quaternion-connection",
+    "proofId": "lagrange-four-squares-oq-05",
+    "range": {
+      "startLine": 162,
+      "endLine": 183
+    },
+    "type": "insight",
+    "title": "Euler's identity is quaternion-norm multiplicativity",
+    "content": "`quaternion_normSq_mul` states $\\mathrm{normSq}(p\\cdot q) = \\mathrm{normSq}(p)\\cdot\\mathrm{normSq}(q)$ on the Hamilton quaternions $\\mathbb{H}[\\mathbb{Z}]$, proved in one step by `map_mul` on Mathlib's *bundled* norm hom. `euler_via_quaternion` then recovers the four-square identity: expanding $\\mathrm{normSq}\\langle a,b,c,d\\rangle = a^2+b^2+c^2+d^2$ via `normSq_def'` on both sides of the multiplicativity equation reproduces $(a^2+b^2+c^2+d^2)(x^2+y^2+z^2+w^2) = \\mathrm{normSq}(pq)$. This formalizes *why* Euler's mysterious forms $A,B,C,D$ take the shape they do — they are the coordinates of a quaternion product.",
+    "mathContext": "$\\mathrm{normSq}(pq) = \\mathrm{normSq}(p)\\,\\mathrm{normSq}(q)$ on $\\mathbb{H}[\\mathbb{Z}]$; expanding by components gives Euler's identity.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Hamilton quaternions ℍ[R]",
+      "Quaternion.normSq and normSq_def'",
+      "map_mul on bundled homomorphisms"
+    ],
+    "relatedConcepts": [
+      "quaternion norm",
+      "normed division algebra",
+      "Hamilton"
+    ]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-oq-05/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-05/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "lagrange-four-squares-oq-05",
+  "title": "Euler's Four-Square Identity: Multiplicative Structure of Sums of Four Squares",
+  "slug": "lagrange-four-squares-oq-05",
+  "description": "A machine-checked, axiom-free development of the STRUCTURE that Euler's four-square identity (1748) encodes, going beyond the bare algebraic identity. The parent Lagrange entry records the one-line `ring` identity (a²+b²+c²+d²)(x²+y²+z²+w²)=A²+B²+C²+D² and remarks informally that 'sums of four squares are closed under multiplication'; here that structural claim is proved and packaged. We introduce the predicate IsSumOfFourSquares over ℤ, prove multiplicative closure by an EXPLICIT construction of the four squares of m·n from those of m and n (IsSumOfFourSquares.mul), assemble these into a genuine Submonoid ℤ, and — the sharp result — show that over ℤ being a sum of four squares is EXACTLY being nonnegative (isSumOfFourSquares_iff_nonneg), so the submonoid is precisely {n : ℤ | 0 ≤ n}. A natural-number closure theorem builds the representation of m·n directly from the input representations (no re-invocation of Lagrange on the product), and a final pair of theorems identifies Euler's identity with the multiplicativity of the Hamilton quaternion norm normSq(p·q)=normSq(p)·normSq(q) on ℍ[ℤ].",
+  "meta": {
+    "author": "Euler (identity, 1748); Hamilton (quaternion interpretation, 1843); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_four-square_identity",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "algebra",
+      "four-squares",
+      "lagrange",
+      "euler-identity",
+      "quaternions",
+      "submonoid",
+      "multiplicativity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/LagrangeFourSquaresOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_four_squares",
+        "description": "Lagrange's four-square theorem: every n : ℕ is a sum of four squares. Used once, to prove that every nonnegative integer is a sum of four squares (the hard direction of the sharp characterization).",
+        "module": "Mathlib.NumberTheory.SumFourSquares"
+      },
+      {
+        "theorem": "Quaternion.normSq",
+        "description": "The (bundled, multiplicative) quaternion norm form on ℍ[R], with normSq_def' : normSq q = q.1²+q.2²+q.3²+q.4². map_mul on it gives normSq(p·q)=normSq(p)·normSq(q), which IS Euler's four-square identity.",
+        "module": "Mathlib.Algebra.Quaternion"
+      },
+      {
+        "theorem": "Int.abs_eq_natAbs / sq_abs",
+        "description": "(↑z.natAbs) = |z| and |z|² = z². The bridge that realises the integer witnesses produced by Euler's identity as squares of natural numbers, keeping the ℕ closure theorem about natural squares.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "A machine-checked proof of MULTIPLICATIVE CLOSURE for sums of four squares over ℤ (IsSumOfFourSquares.mul), constructing the four squares of m·n explicitly from those of m and n via Euler's identity — the structural statement the parent entry only asserts informally",
+      "The packaging of sums of four squares as a genuine Submonoid ℤ (sumOfFourSquares), turning the closure lemma into algebraic structure",
+      "A SHARP characterization: over ℤ, IsSumOfFourSquares n ↔ 0 ≤ n (isSumOfFourSquares_iff_nonneg), combining an elementary positivity fact with Lagrange's theorem, hence sumOfFourSquares equals {n : ℤ | 0 ≤ n} as a set",
+      "A natural-number closure theorem (nat_sum_four_squares_mul) that builds the representation of m·n directly from the input representations of m and n (cast to ℤ, Euler identity, natAbs) rather than re-deriving it from Lagrange on the product",
+      "An explicit identification of Euler's 1748 identity with the multiplicativity of the Hamilton quaternion norm on ℍ[ℤ] (quaternion_normSq_mul, euler_via_quaternion), formalizing the 'why' behind the mysterious bilinear formula"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 183,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on IsSumOfFourSquares.mul, isSumOfFourSquares_iff_nonneg, nat_sum_four_squares_mul, euler_via_quaternion, and sumOfFourSquares_carrier reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide (so no Lean.ofReduceBool), no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 13,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "namespace": "LagrangeFourSquaresOQ05",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 2,
+    "path": "Proofs/LagrangeFourSquaresOQ05.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "euler-identity-engine",
+      "title": "Euler's Four-Square Identity (the engine)",
+      "startLine": 32,
+      "endLine": 46,
+      "summary": "The identity (a²+b²+c²+d²)(x²+y²+z²+w²) = A²+B²+C²+D² over an arbitrary commutative ring, where (A,B,C,D) is the componentwise quaternion product of (a,b,c,d) and (x,y,z,w). Closed by a single `ring`. This is the bilinear engine that powers every closure result below."
+    },
+    {
+      "id": "predicate",
+      "title": "The sum-of-four-squares predicate and its multiplicative closure",
+      "startLine": 48,
+      "endLine": 79,
+      "summary": "IsSumOfFourSquares n := ∃ a b c d : ℤ, a²+b²+c²+d² = n, with the trivial witnesses for 0, 1, and any square. The key theorem IsSumOfFourSquares.mul proves the product m·n is a sum of four squares by producing the explicit quadruple (A,B,C,D) from Euler's identity — the structural heart of the reduction to primes in Lagrange's theorem."
+    },
+    {
+      "id": "submonoid",
+      "title": "Monoid structure",
+      "startLine": 81,
+      "endLine": 93,
+      "summary": "The sums of four squares assembled into a Submonoid ℤ (sumOfFourSquares), with one_mem from 1=1²+0²+0²+0² and mul_mem from the closure theorem. mem_sumOfFourSquares records membership as the predicate."
+    },
+    {
+      "id": "sharp-characterization",
+      "title": "Sharp characterization: sum of four squares ⟺ nonnegative",
+      "startLine": 95,
+      "endLine": 126,
+      "summary": "IsSumOfFourSquares n ↔ 0 ≤ n over ℤ. The forward direction is `positivity`; the converse applies Lagrange's four-square theorem to n.toNat and casts back via Int.toNat_of_nonneg. Consequently sumOfFourSquares = {n : ℤ | 0 ≤ n} as a set — the submonoid is exactly the nonnegative integers."
+    },
+    {
+      "id": "nat-closure",
+      "title": "Natural-number multiplicative closure",
+      "startLine": 128,
+      "endLine": 158,
+      "summary": "nat_sum_four_squares_mul: a product of two sums of four NATURAL squares is again a sum of four natural squares, built directly from the input representations (cast to ℤ, combine by IsSumOfFourSquares.mul, then take natAbs of each component using |t|²=t²). No appeal to Lagrange on the product itself."
+    },
+    {
+      "id": "quaternion-connection",
+      "title": "The quaternion connection",
+      "startLine": 160,
+      "endLine": 183,
+      "summary": "quaternion_normSq_mul: normSq(p·q)=normSq(p)·normSq(q) on ℍ[ℤ], obtained from map_mul on the bundled norm. euler_via_quaternion then recovers the four-square identity by expanding normSq into its four components — exhibiting Euler's 1748 formula as quaternion-norm multiplicativity."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Euler's identity and Lagrange's theorem.** In 1748, twenty-two years before Lagrange proved that every natural number is a sum of four squares, Euler discovered the algebraic identity\n$$(a^2+b^2+c^2+d^2)(x^2+y^2+z^2+w^2) = A^2+B^2+C^2+D^2,$$\nwhere $A,B,C,D$ are explicit bilinear forms in the eight variables. This identity is the linchpin of Lagrange's 1770 proof: it reduces the four-square theorem to the case of primes, since once every prime is a sum of four squares, Euler's identity propagates the property across all products. In 1843 Hamilton discovered the quaternions and realised — as Euler could not have known — that his identity is *precisely* the multiplicativity of the quaternion norm: the four forms $A,B,C,D$ are the components of the quaternion product $(a+bi+cj+dk)(x+yi+zj+wk)$.",
+    "problemStatement": "**Make the structure explicit.** The bare identity is a one-line `ring` fact. This entry proves the *structural consequences* it encodes: (1) sums of four squares are closed under multiplication, with the product's four squares built explicitly; (2) they form a submonoid of $(\\mathbb{Z},\\cdot)$; (3) over $\\mathbb{Z}$ that submonoid is *exactly* the nonnegative integers; and (4) the identity is the multiplicativity of the Hamilton quaternion norm.",
+    "proofStrategy": "**One identity, four structural payoffs.** The predicate `IsSumOfFourSquares n := ∃ a b c d : ℤ, a²+b²+c²+d² = n` is closed under multiplication because, given representations of $m$ and $n$, Euler's identity *names* a representation of $m\\cdot n$ — this is `IsSumOfFourSquares.mul`, and everything else is bookkeeping on top of it. Closure + `1 = 1²+0²+0²+0²` gives a `Submonoid ℤ`. The sharp characterization pairs a trivial positivity fact (a sum of squares is $\\ge 0$) with Lagrange's theorem applied to `n.toNat` (every nonnegative integer is a sum of four squares). Finally, `map_mul` on Mathlib's bundled quaternion norm `Quaternion.normSq`, combined with `normSq_def'`, reproduces the identity conceptually.",
+    "keyInsights": [
+      "**Closure is a construction, not an existence proof.** `IsSumOfFourSquares.mul` does not merely assert that $m\\cdot n$ is a sum of four squares — it exhibits the four squares as explicit bilinear forms in the eight input coordinates, exactly Euler's $A,B,C,D$. This is what makes the theorem usable in the reduction to primes.",
+      "**Over ℤ the property degenerates to a sign condition.** Because a sum of four squares is automatically $\\ge 0$ and, by Lagrange, every nonnegative integer *is* a sum of four squares, `IsSumOfFourSquares n ↔ 0 ≤ n`. The rich four-square structure collapses to nonnegativity — a sharp boundary the raw identity does not reveal.",
+      "**The ℕ closure must be built from the witnesses, not re-derived.** A naïve ℕ 'closure' theorem could just quote Lagrange on $m\\cdot n$ and ignore its hypotheses — which would be circular and hide Euler's role. Here the representation of $m\\cdot n$ is assembled from those of $m$ and $n$ via Euler's identity and `natAbs`, so the hypotheses genuinely drive the proof.",
+      "**Euler's mystery formula is quaternion multiplication.** `quaternion_normSq_mul` (a one-line `map_mul`) plus `normSq_def'` recovers the four-square identity, formalizing why the specific forms $A,B,C,D$ appear: they are the real and imaginary parts of a quaternion product, so the identity is $|pq| = |p|\\,|q|$ read off componentwise."
+    ],
+    "prerequisites": [
+      "Lagrange's four-square theorem (Nat.sum_four_squares)",
+      "Polynomial identities over a commutative ring (the `ring` tactic)",
+      "Submonoids and bundled multiplicative homomorphisms (map_mul)",
+      "The Hamilton quaternions ℍ[R] and their norm form (Quaternion.normSq, normSq_def')",
+      "Natural absolute value and ℕ↔ℤ casting (Int.natAbs, sq_abs, Int.toNat_of_nonneg)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Euler's four-square identity is not just a curious `ring` fact but the carrier of real algebraic structure. This entry proves that sums of four squares are closed under multiplication with an explicit construction (IsSumOfFourSquares.mul), packages them as a Submonoid ℤ, and pins down that submonoid exactly as the nonnegative integers (isSumOfFourSquares_iff_nonneg). A natural-number closure theorem is built honestly from the input witnesses, and the identity is finally identified with the multiplicativity of the Hamilton quaternion norm. 13 theorems, 2 definitions, 183 lines, 0 axioms, 0 sorries.",
+    "implications": [
+      "Turns the parent entry's informal remark ('sums of four squares are closed under multiplication') into a proved, reusable submonoid structure with an explicit product construction.",
+      "Records a sharp boundary — over ℤ the four-square property is equivalent to nonnegativity — that clarifies exactly how much information the identity carries.",
+      "Formalizes the quaternion interpretation of Euler's identity, connecting the number-theoretic four-square world to Mathlib's quaternion algebra."
+    ],
+    "openQuestions": [
+      "Two-square and eight-square analogues: the Brahmagupta–Fibonacci identity gives multiplicative closure for sums of two squares (a Gaussian-integer norm) and Degen's eight-square identity does the same for octonions. Do the same submonoid/sharp-characterization packages go through, and where does the pattern stop (Hurwitz's 1,2,4,8 theorem)?",
+      "The sharp characterization over ℤ collapses to nonnegativity precisely because Lagrange makes the property universal on ℕ. For sums of THREE squares the analogous submonoid is only closed under multiplication in restricted cases and the image is Legendre's non-4^a(8b+7) numbers — can a comparably clean structural statement be formalized there?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "extends",
+      "description": "Parent entry, which states Euler's four-square identity as a `ring` fact and notes informally that sums of four squares are closed under multiplication. This entry proves that closure explicitly, packages it as a Submonoid ℤ, characterizes the submonoid sharply, and ties the identity to quaternion-norm multiplicativity."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **lagrange-four-squares-oq-05**: *Euler's Four-Square Identity — Multiplicative Structure of Sums of Four Squares*.

The parent `lagrange-four-squares` records Euler's 1748 identity as a one-line `ring` fact and remarks *informally* that sums of four squares are closed under multiplication. This entry **proves the structure** that remark points at:

- **`IsSumOfFourSquares.mul`** — multiplicative closure over ℤ by an **explicit construction**: the four squares of `m·n` are produced from those of `m` and `n` via Euler's bilinear forms (this is the reduction-to-primes engine of Lagrange's proof).
- **`sumOfFourSquares : Submonoid ℤ`** — packages the closure as algebraic structure.
- **`isSumOfFourSquares_iff_nonneg`** — *sharp characterization*: over ℤ, being a sum of four squares is **exactly** being nonnegative (positivity + Lagrange), so the submonoid equals `{n : ℤ | 0 ≤ n}`.
- **`nat_sum_four_squares_mul`** — ℕ closure built **honestly from the input witnesses** (cast → Euler → natAbs), not by re-quoting Lagrange on the product.
- **`quaternion_normSq_mul` / `euler_via_quaternion`** — Euler's identity **is** the multiplicativity of the Hamilton quaternion norm on ℍ[ℤ].

## Verification

- **13 theorems, 2 definitions, 183 lines**
- **0 axioms, 0 sorries** — builds under Lean 4 / Mathlib v4.26.0 (docker + `lake env lean`)
- `#print axioms` on the key results reports only `propext, Classical.choice, Quot.sound` (no assumptions, no `native_decide`/`Lean.ofReduceBool`)

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)