### PR TITLE
research(cauchy-interlacing-theorem-oq-02-oq-02): principal-submatrix Poincaré separation bridge [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareSubmatrix.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareSubmatrix.lean
@@ -1,0 +1,302 @@
+import Mathlib
+import Proofs.CauchyInterlacingPoincare
+
+/-
+# Poincaré separation, the literal principal-submatrix form
+
+`CauchyInterlacingPoincare.lean` (#27247) proves the **abstract** Poincaré
+separation theorem `poincare_separation`: for a symmetric operator `T` on an
+`(n+m)`-dimensional inner product space `V` with descending eigenvalues `lam`,
+and a subspace `H ≤ V` of dimension `n` carrying a symmetric operator `TH`
+(descending eigenvalues `mu`) whose Rayleigh quotient agrees with `T`'s on `H`,
+the eigenvalues separate as `lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩`.
+
+This file answers the parent entry's second open question: bridge that abstract
+statement to the **literal matrix form**.  Let `A` be a Hermitian
+`(n+m) × (n+m)` matrix and let `e : Fin n → Fin (n+m)` be an injective choice of
+`n` retained coordinates (equivalently, delete the `m` complementary rows and
+columns).  The **principal submatrix** `A.submatrix e e` is Hermitian, and its
+eigenvalues `μ` interlace those `λ` of `A`:
+
+  `λ ⟨k+m⟩ ≤ μ k`   and   `μ k ≤ λ ⟨k⟩`   for every `k : Fin n`.
+
+## The bridge
+
+We realise the matrix as the operator `T := toEuclideanLin A` on
+`V := EuclideanSpace 𝕜 (Fin (n+m))`.  The retained coordinates span the subspace
+`H := span {eₑ₍ⱼ₎}`.  There is a linear isometry
+`L : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H` sending the `j`-th standard basis vector to
+the `(e j)`-th coordinate vector; it is the "zero-padding" embedding.  We push
+the submatrix operator `Tsub := toEuclideanLin (A.submatrix e e)` through `L` to
+get the compression operator `TH := L ∘ Tsub ∘ L⁻¹` on `H`, whose eigenvalues are
+*by construction* the submatrix eigenvalues.
+
+The only genuine computation is the **Rayleigh agreement**: for `y = L x ∈ H`,
+the quadratic form of `A` on the zero-padded vector `↑y` equals the quadratic
+form of `A.submatrix e e` on `x`.  This is `quad_form_submatrix` /
+`quad_form_submatrix'`, an elementary `Finset`-sum identity: only the retained
+coordinates carry mass, and the double sum collapses to
+`∑ᵢⱼ conj(xᵢ) A₍ₑᵢ,ₑⱼ₎ xⱼ` on both sides.  Feeding this into `poincare_separation`
+yields the matrix statement with no new spectral theory.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace Matrix
+open Matrix WithLp CauchyInterlacing.Poincare
+
+namespace CauchyInterlacing.PoincareSubmatrix
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n m : ℕ}
+
+/-! ### The zero-padding embedding at the level of coordinate functions -/
+
+/-- Zero-pad a length-`n` coordinate vector into a length-`(n+m)` one supported on
+the image of `e`. -/
+def pad (e : Fin n → Fin (n + m)) (xf : Fin n → 𝕜) : Fin (n + m) → 𝕜 :=
+  fun p => ∑ j, if e j = p then xf j else 0
+
+@[simp] lemma pad_apply_embed (e : Fin n → Fin (n + m)) (he : Function.Injective e)
+    (xf : Fin n → 𝕜) (i : Fin n) : pad e xf (e i) = xf i := by
+  unfold pad
+  rw [Finset.sum_eq_single i]
+  · simp
+  · intro j _ hj; simp [he.ne hj]
+  · simp
+
+lemma mulVec_pad (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜) (e : Fin n → Fin (n + m))
+    (xf : Fin n → 𝕜) (p : Fin (n + m)) :
+    (A *ᵥ pad e xf) p = ∑ j, A p (e j) * xf j := by
+  unfold pad Matrix.mulVec dotProduct
+  simp only [Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  simp only [mul_ite, mul_zero]
+  rw [Finset.sum_ite_eq Finset.univ (e j) (fun q => A p q * xf j)]
+  simp
+
+lemma star_pad_apply (e : Fin n → Fin (n + m)) (xf : Fin n → 𝕜) (p : Fin (n + m)) :
+    (star (pad e xf) p : 𝕜) = ∑ i, if e i = p then star (xf i) else 0 := by
+  simp only [Pi.star_apply, pad, star_sum]
+  exact Finset.sum_congr rfl fun i _ => by rw [apply_ite star, star_zero]
+
+/-- **The key quadratic-form identity.** The quadratic form of `A` on a zero-padded
+vector equals the quadratic form of the principal submatrix `A.submatrix e e` on
+the original vector. -/
+lemma quad_form_submatrix (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜)
+    (e : Fin n → Fin (n + m)) (xf : Fin n → 𝕜) :
+    star (pad e xf) ⬝ᵥ (A *ᵥ pad e xf) = star xf ⬝ᵥ (A.submatrix e e *ᵥ xf) := by
+  have hLHS : star (pad e xf) ⬝ᵥ (A *ᵥ pad e xf)
+      = ∑ i, ∑ j, star (xf i) * A (e i) (e j) * xf j := by
+    rw [dotProduct]
+    simp only [star_pad_apply, mulVec_pad]
+    simp only [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Finset.sum_eq_single (e i)]
+    · rw [if_pos rfl, Finset.mul_sum]
+      exact Finset.sum_congr rfl (fun j _ => by ring)
+    · intro p _ hp; rw [if_neg (Ne.symm hp)]; simp
+    · simp
+  have hRHS : star xf ⬝ᵥ (A.submatrix e e *ᵥ xf)
+      = ∑ i, ∑ j, star (xf i) * A (e i) (e j) * xf j := by
+    rw [dotProduct]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Pi.star_apply, mulVec, dotProduct, Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun j _ => by rw [submatrix_apply]; ring)
+  rw [hLHS, hRHS]
+
+/-- The conjugate-transposed variant, matching the `⟪T x, x⟫ = ofLp x ⬝ᵥ star (…)`
+shape of `EuclideanSpace.inner_eq_star_dotProduct`. -/
+lemma quad_form_submatrix' (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜)
+    (e : Fin n → Fin (n + m)) (xf : Fin n → 𝕜) :
+    pad e xf ⬝ᵥ star (A *ᵥ pad e xf) = xf ⬝ᵥ star (A.submatrix e e *ᵥ xf) := by
+  have hLHS : pad e xf ⬝ᵥ star (A *ᵥ pad e xf)
+      = ∑ i, ∑ j, xf i * star (A (e i) (e j)) * star (xf j) := by
+    rw [dotProduct]
+    simp only [Pi.star_apply, mulVec_pad, star_sum, star_mul', pad]
+    simp only [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Finset.sum_eq_single (e i)]
+    · rw [if_pos rfl, Finset.mul_sum]
+      exact Finset.sum_congr rfl (fun j _ => by ring)
+    · intro p _ hp; rw [if_neg (Ne.symm hp)]; simp
+    · simp
+  have hRHS : xf ⬝ᵥ star (A.submatrix e e *ᵥ xf)
+      = ∑ i, ∑ j, xf i * star (A (e i) (e j)) * star (xf j) := by
+    rw [dotProduct]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [Pi.star_apply, mulVec, dotProduct, star_sum, Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun j _ => by rw [star_mul', submatrix_apply]; ring)
+  rw [hLHS, hRHS]
+
+/-- **Rayleigh agreement, matrix form.** The quadratic form of `A` on the zero-padded
+Euclidean vector `toLp (pad e (ofLp x))` equals the quadratic form of the principal
+submatrix on `x`.  Stated as an equality of inner products; it feeds the abstract
+Poincaré separation's Rayleigh side condition. -/
+lemma rayleigh_pad_eq (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜)
+    (e : Fin n → Fin (n + m)) (x : EuclideanSpace 𝕜 (Fin n)) :
+    (@inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) _
+        ((toEuclideanLin A) (toLp 2 (pad e (ofLp x)))) (toLp 2 (pad e (ofLp x))))
+      = @inner 𝕜 (EuclideanSpace 𝕜 (Fin n)) _ ((toEuclideanLin (A.submatrix e e)) x) x := by
+  rw [EuclideanSpace.inner_eq_star_dotProduct, EuclideanSpace.inner_eq_star_dotProduct,
+    ofLp_toEuclideanLin_apply, ofLp_toEuclideanLin_apply, WithLp.ofLp_toLp]
+  exact quad_form_submatrix' A e (ofLp x)
+
+/-- Zero-padding preserves the dot product (it is the isometric coordinate embedding).
+Injectivity of `e` is what forces the off-diagonal terms to cancel. -/
+lemma pad_dot (e : Fin n → Fin (n + m)) (he : Function.Injective e) (u v : Fin n → 𝕜) :
+    pad e v ⬝ᵥ star (pad e u) = v ⬝ᵥ star u := by
+  rw [dotProduct]
+  have hstep : (∑ p, pad e v p * star (pad e u) p)
+      = ∑ j, v j * star (u j) := by
+    simp only [star_pad_apply, pad]
+    simp only [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    rw [Finset.sum_eq_single (e j)]
+    · rw [if_pos rfl]
+      rw [Finset.mul_sum, Finset.sum_eq_single j]
+      · rw [if_pos rfl]
+      · intro i _ hi; rw [if_neg (fun h => hi (he h))]; simp
+      · simp
+    · intro p _ hp; rw [if_neg (Ne.symm hp)]; simp
+    · simp
+  rw [hstep, dotProduct]
+  exact Finset.sum_congr rfl (fun j _ => by rw [Pi.star_apply])
+
+/-- Zero-padding preserves the inner product: `⟪pad a, pad b⟫ = ⟪a, b⟫`.  This gives the
+H-side numerator of the Rayleigh identity without invoking `inner_map_map` on `↥H` (which
+trips the `Submodule.module` vs `InnerProductSpace.toNormedSpace.toModule` diamond). -/
+lemma pad_preserves_inner (e : Fin n → Fin (n + m)) (he : Function.Injective e)
+    (a b : EuclideanSpace 𝕜 (Fin n)) :
+    (@inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) _
+        (toLp 2 (pad e (ofLp a))) (toLp 2 (pad e (ofLp b))))
+      = @inner 𝕜 (EuclideanSpace 𝕜 (Fin n)) _ a b := by
+  rw [EuclideanSpace.inner_eq_star_dotProduct, EuclideanSpace.inner_eq_star_dotProduct,
+    WithLp.ofLp_toLp, WithLp.ofLp_toLp]
+  exact pad_dot e he (ofLp a) (ofLp b)
+
+/-! ### The matrix Poincaré separation theorem -/
+
+set_option maxHeartbeats 4000000 in
+set_option synthInstance.maxHeartbeats 4000000 in
+/-- **Poincaré separation theorem — principal-submatrix form.**
+
+Let `A` be a Hermitian `(n+m) × (n+m)` matrix over `𝕜`, with `T := toEuclideanLin A`
+and descending eigenvalues `lam := hT.eigenvalues`.  Let `e : Fin n → Fin (n+m)`
+be an injective choice of retained coordinates, so `A.submatrix e e` is the
+principal submatrix obtained by deleting the `m` complementary rows and columns;
+its descending eigenvalues are `mu := (toEuclideanLin (A.submatrix e e)).eigenvalues`.
+
+Then for every `k : Fin n`,
+
+  `lam ⟨k+m⟩ ≤ mu k`   and   `mu k ≤ lam ⟨k⟩`,
+
+the Poincaré separation / Cauchy interlacing inequalities for a principal
+submatrix. -/
+theorem poincare_separation_submatrix
+    (A : Matrix (Fin (n + m)) (Fin (n + m)) 𝕜) (hA : A.IsHermitian)
+    (e : Fin n → Fin (n + m)) (he : Function.Injective e) (k : Fin n) :
+    (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin
+        ⟨(k : ℕ) + m, by have := k.isLt; omega⟩
+      ≤ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix e)).eigenvalues
+          finrank_euclideanSpace_fin k
+    ∧ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix e)).eigenvalues
+          finrank_euclideanSpace_fin k
+      ≤ (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin
+          ⟨(k : ℕ), by have := k.isLt; omega⟩ := by
+  classical
+  -- Spectral data for `T := toEuclideanLin A` on `V := EuclideanSpace 𝕜 (Fin (n+m))`.
+  have hT : (toEuclideanLin A).IsSymmetric := Matrix.isHermitian_iff_isSymmetric.1 hA
+  have hb : ∀ i, (toEuclideanLin A) ((hT.eigenvectorBasis finrank_euclideanSpace_fin) i)
+      = ((hT.eigenvalues finrank_euclideanSpace_fin i : ℝ) : 𝕜) •
+        (hT.eigenvectorBasis finrank_euclideanSpace_fin) i :=
+    hT.apply_eigenvectorBasis finrank_euclideanSpace_fin
+  have hlam : Antitone (hT.eigenvalues finrank_euclideanSpace_fin) :=
+    hT.eigenvalues_antitone finrank_euclideanSpace_fin
+  -- Spectral data for `Tsub := toEuclideanLin (A.submatrix e e)`.
+  have hTsub : (toEuclideanLin (A.submatrix e e)).IsSymmetric :=
+    Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix e)
+  have hbsub : ∀ i, (toEuclideanLin (A.submatrix e e))
+      ((hTsub.eigenvectorBasis finrank_euclideanSpace_fin) i)
+      = ((hTsub.eigenvalues finrank_euclideanSpace_fin i : ℝ) : 𝕜) •
+        (hTsub.eigenvectorBasis finrank_euclideanSpace_fin) i :=
+    hTsub.apply_eigenvectorBasis finrank_euclideanSpace_fin
+  have hmu : Antitone (hTsub.eigenvalues finrank_euclideanSpace_fin) :=
+    hTsub.eigenvalues_antitone finrank_euclideanSpace_fin
+  -- The orthonormal frame spanning the coordinate subspace `H`.
+  set f : Fin n → EuclideanSpace 𝕜 (Fin (n + m)) :=
+    fun j => EuclideanSpace.single (e j) (1 : 𝕜) with hf_def
+  have hf : Orthonormal 𝕜 f := EuclideanSpace.orthonormal_single.comp e he
+  set H : Submodule 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) := Submodule.span 𝕜 (Set.range f) with hH_def
+  have hHdim : Module.finrank 𝕜 H = n :=
+    (finrank_span_eq_card hf.linearIndependent).trans (Fintype.card_fin n)
+  -- The corestricted frame is an orthonormal basis of `H`.
+  set g : Fin n → H := fun j => ⟨f j, Submodule.subset_span (Set.mem_range_self j)⟩ with hg_def
+  have hg_coe : ∀ j, (↑(g j) : EuclideanSpace 𝕜 (Fin (n + m))) = f j := fun _ => rfl
+  have hg_on : Orthonormal 𝕜 g := orthonormal_span hf
+  have hg_sp : ⊤ ≤ Submodule.span 𝕜 (Set.range g) :=
+    (hg_on.linearIndependent.span_eq_top_of_card_eq_finrank'
+      (by rw [Fintype.card_fin, hHdim])).ge
+  set Lb : OrthonormalBasis (Fin n) 𝕜 H := OrthonormalBasis.mk hg_on hg_sp with hLb_def
+  have hLb_apply : ∀ j, Lb j = g j := fun j => by rw [hLb_def, OrthonormalBasis.coe_mk]
+  -- The zero-padding isometry `L : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`.
+  set L : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ[𝕜] H := Lb.repr.symm with hL_def
+  -- Coordinate description of `L`: `↑(L x)` is the zero-padding of `x`.
+  have hL_ofLp : ∀ x : EuclideanSpace 𝕜 (Fin n),
+      ofLp (↑(L x) : EuclideanSpace 𝕜 (Fin (n + m))) = pad e (ofLp x) := by
+    intro x
+    have hLx : (↑(L x) : EuclideanSpace 𝕜 (Fin (n + m))) = ∑ j, (x j) • f j := by
+      rw [hL_def, ← Lb.sum_repr_symm x, Submodule.coe_sum]
+      exact Finset.sum_congr rfl fun j _ => by rw [Submodule.coe_smul, hLb_apply, hg_coe]
+    funext p
+    rw [hLx, WithLp.ofLp_sum]
+    simp only [hf_def, WithLp.ofLp_smul, EuclideanSpace.ofLp_single, Finset.sum_apply,
+      Pi.smul_apply, Pi.single_apply, smul_eq_mul, mul_ite, mul_one, mul_zero, pad]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rcases eq_or_ne (e j) p with h | h
+    · subst h; simp
+    · rw [if_neg (Ne.symm h), if_neg h]
+  -- The transported eigenbasis and compression operator on `H`.
+  set bH : OrthonormalBasis (Fin n) 𝕜 H :=
+    (hTsub.eigenvectorBasis finrank_euclideanSpace_fin).map L with hbH_def
+  set TH : H →ₗ[𝕜] H := (L.toLinearEquiv.conj (toEuclideanLin (A.submatrix e e))) with hTH_def
+  have hTHL : ∀ z, TH (L z) = L ((toEuclideanLin (A.submatrix e e)) z) := by
+    intro z
+    have hstep : TH (L z)
+        = L ((toEuclideanLin (A.submatrix e e)) (L.symm (L z))) := by
+      rw [hTH_def, LinearEquiv.conj_apply_apply]; rfl
+    rw [hstep, L.symm_apply_apply]
+  have hbH_eig : ∀ i, TH (bH i)
+      = ((hTsub.eigenvalues finrank_euclideanSpace_fin i : ℝ) : 𝕜) • bH i := by
+    intro i
+    rw [hbH_def, OrthonormalBasis.map_apply, hTHL, hbsub i, map_smul]
+  -- `L` as a zero-padding at the coordinate level.
+  have hLpad : ∀ z : EuclideanSpace 𝕜 (Fin n),
+      (↑(L z) : EuclideanSpace 𝕜 (Fin (n + m))) = toLp 2 (pad e (ofLp z)) :=
+    fun z => by rw [← hL_ofLp z, WithLp.toLp_ofLp]
+  -- Rayleigh agreement.  We convert the `↥H` inner product to the ambient one via
+  -- `Submodule.coe_inner` (definitional), transport `TH` by `hTHL`, and zero-pad by `hLpad`;
+  -- then both numerators land at `⟪A.submatrix e e • x, x⟫` (H-side by `pad_preserves_inner`,
+  -- V-side by `rayleigh_pad_eq`) and both denominators at `‖pad x‖`.  This route sidesteps
+  -- `inner_map_map` on `↥H`, whose `Submodule.module` vs `InnerProductSpace` diamond blocks
+  -- unification.
+  have hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + m))) _
+            ((toEuclideanLin A) (y : EuclideanSpace 𝕜 (Fin (n + m)))) (y : EuclideanSpace 𝕜 (Fin (n + m)))) /
+          ‖(y : EuclideanSpace 𝕜 (Fin (n + m)))‖ ^ 2 := by
+    intro y _
+    obtain ⟨x, rfl⟩ : ∃ x, y = L x := ⟨L.symm y, (L.apply_symm_apply y).symm⟩
+    have hnc : ‖(↑(L x) : EuclideanSpace 𝕜 (Fin (n + m)))‖ = ‖L x‖ := rfl
+    rw [Submodule.coe_inner, hTHL, ← hnc,
+      hLpad ((toEuclideanLin (A.submatrix e e)) x), hLpad x,
+      pad_preserves_inner e he, rayleigh_pad_eq A e x]
+  -- Assemble via the abstract Poincaré separation theorem.
+  exact poincare_separation (toEuclideanLin A) (hT.eigenvectorBasis finrank_euclideanSpace_fin)
+    (hT.eigenvalues finrank_euclideanSpace_fin) hb hlam H hHdim TH bH
+    (hTsub.eigenvalues finrank_euclideanSpace_fin) hbH_eig hmu hRayleigh k
+
+end CauchyInterlacing.PoincareSubmatrix

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02",
+    "range": { "startLine": 4, "endLine": 51 },
+    "type": "concept",
+    "title": "From Abstract Compression to a Principal Submatrix",
+    "content": "The parent entry (oq-02) proved the abstract Poincaré separation λ(k+m) ≤ μ(k) ≤ λ(k) for a symmetric operator and a codimension-m compression, taking the compression and its Rayleigh-agreement as inputs. This file supplies the parent's second open question: the literal matrix statement. For a Hermitian matrix A and its principal submatrix A.submatrix e e (deleting m rows/columns via an injective coordinate map e), the submatrix eigenvalues interlace A's. The matrix is realised as toEuclideanLin A; the retained coordinates span a subspace H; a zero-padding isometry L transports the submatrix operator to the orthogonal compression on H, whose eigenvalues are the submatrix's by construction.",
+    "mathContext": "$A \\in \\mathrm{Herm}_{n+m}(\\mathbb{K})$, $e:\\mathrm{Fin}\\,n\\hookrightarrow\\mathrm{Fin}(n{+}m)$: $\\lambda_{k+m} \\le \\mu_k \\le \\lambda_k$ where $\\mu$ are the eigenvalues of $A_{e,e}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Poincaré separation theorem", "principal submatrix", "orthogonal compression", "toEuclideanLin", "eigenvalue interlacing"],
+    "prerequisites": ["Hermitian matrices", "eigenvalues of self-adjoint operators", "the abstract Poincaré separation (oq-02)"]
+  },
+  {
+    "id": "ann-pad",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 85 },
+    "type": "definition",
+    "title": "The Zero-Padding Embedding",
+    "content": "`pad e xf` zero-pads a length-n coordinate vector onto the coordinates in the image of e (xf_j lands at position e j, all other positions 0). This is the coordinate-level description of the isometric embedding EuclideanSpace 𝕜 (Fin n) ↪ EuclideanSpace 𝕜 (Fin (n+m)) whose range is the retained-coordinate subspace. pad_apply_embed evaluates it on e i, mulVec_pad computes A *ᵥ pad e xf = ∑ⱼ A_{·,e j} xf_j, and star_pad_apply expands the conjugate — the building blocks for the quadratic-form collapse.",
+    "mathContext": "$(\\mathrm{pad}\\,e\\,x)_p = \\sum_j [e j = p]\\, x_j$; $(A \\cdot \\mathrm{pad}\\,e\\,x)_p = \\sum_j A_{p,\\,e j}\\, x_j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isometric coordinate embedding", "Matrix.mulVec", "indicator sums"],
+    "prerequisites": ["Finset sums", "Matrix dot product and mulVec"]
+  },
+  {
+    "id": "ann-quadform",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 137 },
+    "type": "theorem",
+    "title": "The Quadratic-Form Submatrix Identity",
+    "content": "quad_form_submatrix (and its conjugate-transposed variant quad_form_submatrix') is the mathematical heart: star(pad e x) ⬝ᵥ (A *ᵥ pad e x) = star x ⬝ᵥ (A.submatrix e e *ᵥ x). The quadratic form of A on the zero-padded vector equals the quadratic form of the principal submatrix on the original. Both sides expand to ∑ᵢⱼ conj(xᵢ) A_{e i, e j} xⱼ — on the left the ambient double sum over Fin (n+m) collapses (Finset.sum_eq_single) because pad is supported on the retained coordinates; on the right submatrix_apply rewrites the entries. Remarkably, this needs no injectivity of e.",
+    "mathContext": "$\\overline{\\mathrm{pad}\\,x}^{\\mathsf T} A\\, \\mathrm{pad}\\,x = \\sum_{i,j} \\overline{x_i}\\, A_{e i,\\,e j}\\, x_j = \\overline{x}^{\\mathsf T} A_{e,e}\\, x$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic form", "principal submatrix", "compression is not an operator identity", "Finset.sum_eq_single"],
+    "prerequisites": ["Matrix.dotProduct and mulVec", "Finset double sums", "submatrix_apply"]
+  },
+  {
+    "id": "ann-inner",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02",
+    "range": { "startLine": 138, "endLine": 180 },
+    "type": "theorem",
+    "title": "Rayleigh Numerators as Inner Products",
+    "content": "rayleigh_pad_eq lifts the quadratic-form identity to the EuclideanSpace inner product via EuclideanSpace.inner_eq_star_dotProduct and ofLp_toEuclideanLin_apply — this is the V-side Rayleigh numerator ⟪toEuclideanLin A (pad x), pad x⟫ = ⟪(A.submatrix e e)•x, x⟫. pad_dot / pad_preserves_inner show the padding is inner-product preserving (⟪pad a, pad b⟫ = ⟪a, b⟫); here injectivity of e forces the off-diagonal terms [e i = e j] to vanish for i ≠ j. This supplies the H-side numerator through Submodule.coe_inner, deliberately avoiding LinearIsometryEquiv.inner_map_map on ↥H (whose Submodule.module vs InnerProductSpace instance diamond blocks unification).",
+    "mathContext": "$\\langle \\mathrm{pad}\\,a, \\mathrm{pad}\\,b\\rangle = \\langle a,b\\rangle$ (needs $e$ injective); $\\langle T\\,\\mathrm{pad}\\,x, \\mathrm{pad}\\,x\\rangle = \\langle T_{\\mathrm{sub}} x, x\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": ["Rayleigh quotient", "inner product preservation", "Submodule.coe_inner", "instance diamond avoidance"],
+    "prerequisites": ["EuclideanSpace inner product as dot product", "the quadratic-form identity", "injective coordinate maps"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "cauchy-interlacing-theorem-oq-02-oq-02",
+    "range": { "startLine": 181, "endLine": 302 },
+    "type": "theorem",
+    "title": "The Matrix Poincaré Separation Theorem",
+    "content": "poincare_separation_submatrix assembles the bridge: build the orthonormal frame f j = single (e j) 1, the coordinate subspace H = span (range f) (dimension n by finrank_span_eq_card), the zero-padding isometry L = (OrthonormalBasis.mk …).repr.symm, and the transported compression TH = L.conj (toEuclideanLin (A.submatrix e e)) — whose eigenbasis and eigenvalues are the submatrix's, transported through L. The Rayleigh agreement is discharged from the padding lemmas, and poincare_separation delivers λ(⟨k+m⟩) ≤ μ(k) ∧ μ(k) ≤ λ(⟨k⟩). The eigenvalues are LinearMap.IsSymmetric.eigenvalues of toEuclideanLin A and toEuclideanLin (A.submatrix e e), which are exactly Matrix.IsHermitian.eigenvalues₀ by Mathlib's definition.",
+    "mathContext": "Eigenvalues of a principal submatrix (delete $m$ rows/columns) interlace those of the Hermitian matrix: $\\lambda_{k+m} \\le \\mu_k \\le \\lambda_k$.",
+    "significance": "key",
+    "relatedConcepts": ["OrthonormalBasis.mk / repr", "LinearEquiv.conj", "operator transport", "Matrix.IsHermitian.eigenvalues₀", "abstract Poincaré separation"],
+    "prerequisites": ["the padding inner-product lemmas", "the abstract poincare_separation", "orthonormal bases of a spanned subspace"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-02-oq-02",
+  "title": "Poincaré Separation: the Principal-Submatrix Bridge",
+  "slug": "cauchy-interlacing-theorem-oq-02-oq-02",
+  "description": "Bridges the abstract Poincaré separation theorem (parent oq-02) to the literal matrix statement. For a Hermitian (n+m)×(n+m) matrix A and an injective choice e : Fin n → Fin (n+m) of retained coordinates — equivalently, deleting the m complementary rows and columns — the principal submatrix A.submatrix e e has descending eigenvalues μ that interlace those λ of A: λ(k+m) ≤ μ(k) ≤ λ(k) for every k (ascending: λ_k ≤ μ_k ≤ λ_{k+m}). The eigenvalues are those of the self-adjoint operators toEuclideanLin A and toEuclideanLin (A.submatrix e e) — i.e. Matrix.IsHermitian.eigenvalues₀ up to the finrank reindexing. This answers the parent entry's second open question by realising the coordinate subspace as the span of a zero-padding isometry and identifying its orthogonal compression with the principal submatrix at the quadratic-form level.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingPoincareSubmatrix.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "cauchy-interlacing",
+      "poincare-separation",
+      "hermitian-matrix",
+      "principal-submatrix",
+      "rayleigh-quotient",
+      "euclidean-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 302,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "None. The theorem is stated and proved for an arbitrary Hermitian matrix A : Matrix (Fin (n+m)) (Fin (n+m)) 𝕜 (𝕜 an RCLike field) and an arbitrary injective coordinate map e : Fin n → Fin (n+m); no side hypotheses. #print axioms reports only [propext, Classical.choice, Quot.sound] — a fully verified, 0-axiom, 0-sorry result, as is its import chain (CauchyInterlacingPoincare.lean #27247 and CauchyInterlacingKeystone.lean, both 0-sorry/0-axiom). The eigenvalues used are LinearMap.IsSymmetric.eigenvalues of toEuclideanLin A and toEuclideanLin (A.submatrix e e); these are exactly Matrix.IsHermitian.eigenvalues₀ by that definition (Mathlib defines the matrix eigenvalues as the operator eigenvalues of toEuclideanLin), so the statement is the literal principal-submatrix interlacing.",
+    "originalContributions": [
+      "poincare_separation_submatrix: the principal-submatrix Poincaré separation / Cauchy interlacing inequalities λ(k+m) ≤ μ(k) ∧ μ(k) ≤ λ(k) for a Hermitian matrix A and its principal submatrix A.submatrix e e (deleting m rows/columns via an injective e), with λ, μ the descending operator eigenvalues of toEuclideanLin A and toEuclideanLin (A.submatrix e e). Discharges the parent entry's second open question.",
+      "quad_form_submatrix / quad_form_submatrix': the elementary Finset identity star(pad e x) ⬝ᵥ (A *ᵥ pad e x) = star x ⬝ᵥ (A.submatrix e e *ᵥ x) (and its conjugate-transposed variant matching EuclideanSpace.inner_eq_star_dotProduct). The quadratic form of A on the zero-padded vector collapses — via injectivity-free double-sum manipulation — to the quadratic form of the principal submatrix. This is the mathematical heart of the compression↔submatrix identification.",
+      "pad_dot / pad_preserves_inner: the zero-padding embedding is inner-product preserving (⟪pad a, pad b⟫ = ⟪a, b⟫), here injectivity of e forces the off-diagonal cancellation. Supplies the H-side numerator of the Rayleigh identity through Submodule.coe_inner, deliberately bypassing LinearIsometryEquiv.inner_map_map on the subspace ↥H (whose Submodule.module vs InnerProductSpace.toNormedSpace.toModule instance diamond blocks unification).",
+      "The construction that makes the bridge work: realise the retained coordinates as an orthonormal frame f j = EuclideanSpace.single (e j) 1, take H = span (range f) (dimension n by finrank_span_eq_card), build the zero-padding isometry L = (OrthonormalBasis.mk …).repr.symm, and transport the submatrix operator to TH = L.conj (toEuclideanLin (A.submatrix e e)) on H so that TH's eigenvalues are the submatrix eigenvalues by construction — then feed the discharged Rayleigh agreement into the abstract poincare_separation."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.isHermitian_iff_isSymmetric",
+        "description": "A.IsHermitian ↔ (toEuclideanLin A).IsSymmetric — turns the Hermitian matrix hypothesis into the symmetric-operator hypothesis that the abstract Poincaré separation and Mathlib's eigenvalue machinery consume; Matrix.IsHermitian.eigenvalues₀ is defined as the resulting operator's eigenvalues",
+        "module": "Mathlib.Analysis.Matrix.Spectrum"
+      },
+      {
+        "theorem": "EuclideanSpace.inner_eq_star_dotProduct",
+        "description": "⟪x, y⟫ = ofLp y ⬝ᵥ star (ofLp x) — the definitional bridge from the EuclideanSpace inner product to matrix dot products, converting the Rayleigh quotients into the quad_form / pad_dot identities",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "OrthonormalBasis.mk",
+        "description": "A finite orthonormal family whose span is ⊤ is an orthonormal basis — builds the orthonormal basis of the coordinate subspace H from the zero-padding frame, whose repr gives the zero-padding isometry L",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "LinearEquiv.conj",
+        "description": "Conjugation e.conj f = e ∘ f ∘ e.symm of an endomorphism by a linear equivalence — transports the submatrix operator toEuclideanLin (A.submatrix e e) through L to the compression operator TH on H, so TH's eigenbasis and eigenvalues are the submatrix's transported through the isometry",
+        "module": "Mathlib.Algebra.Module.Equiv.Basic"
+      },
+      {
+        "theorem": "Submodule.coe_inner",
+        "description": "⟪x, y⟫ on a submodule equals ⟪↑x, ↑y⟫ in the ambient space — used to reduce the H-side Rayleigh numerator to an ambient inner product, avoiding inner_map_map on ↥H",
+        "module": "Mathlib.Analysis.InnerProductSpace.Subspace"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Cauchy's 1829 interlacing theorem bounds the eigenvalues of a principal submatrix obtained by deleting one row and column; the general delete-m statement is the Poincaré separation theorem (Poincaré 1890; Horn–Johnson Thm 4.3.17 & 4.3.28, Bhatia §III). The parent gallery entry (oq-02) proves the abstract operator form of the delete-m inequality but leaves the Rayleigh-agreement hypothesis and the abstract compression operator as inputs, and explicitly lists — as its second open question — the bridge to the literal matrix statement in terms of Matrix.IsHermitian eigenvalues. This entry supplies that bridge, closing the loop from the variational keystone all the way down to a concrete Hermitian matrix and its principal submatrix.",
+    "problemStatement": "Prove the principal-submatrix Poincaré separation theorem: for a Hermitian matrix A : Matrix (Fin (n+m)) (Fin (n+m)) 𝕜 with descending eigenvalues λ, and an injective coordinate map e : Fin n → Fin (n+m) selecting the retained rows/columns, the principal submatrix A.submatrix e e has descending eigenvalues μ satisfying λ(⟨k+m⟩) ≤ μ(k) and μ(k) ≤ λ(⟨k⟩) for every k : Fin n. In ascending textbook notation this is λ_k ≤ μ_k ≤ λ_{k+m}.",
+    "text": "The matrix A is realised as the self-adjoint operator T = toEuclideanLin A on V = EuclideanSpace 𝕜 (Fin (n+m)). The retained coordinates span the subspace H = span {e_{e(j)}} of dimension n, carried by an orthonormal frame f j = EuclideanSpace.single (e j) 1. A zero-padding linear isometry L : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sends the j-th standard basis vector to the (e j)-th coordinate vector; pushing the submatrix operator Tsub = toEuclideanLin (A.submatrix e e) through L gives the compression TH = L ∘ Tsub ∘ L⁻¹ on H, whose eigenvalues are, by construction, the submatrix eigenvalues. Feeding this into the abstract poincare_separation reduces the whole theorem to one genuine computation: the Rayleigh agreement, that the quadratic form of A on a zero-padded vector equals the quadratic form of A.submatrix e e on the original vector.",
+    "proofStrategy": "The crux is quad_form_submatrix': pad e x ⬝ᵥ star (A *ᵥ pad e x) = x ⬝ᵥ star (A.submatrix e e *ᵥ x), where pad e x zero-pads x onto the coordinates e(0),…,e(n-1). Both sides expand to ∑ᵢⱼ xᵢ · conj(A_{e i, e j}) · conj(xⱼ): on the left only the retained coordinates carry mass, so the ambient double sum over Fin (n+m) collapses (Finset.sum_eq_single) to the retained index range; on the right submatrix_apply rewrites the entries. This scalar identity, transported through EuclideanSpace.inner_eq_star_dotProduct and Matrix.ofLp_toEuclideanLin_apply, is precisely the Rayleigh-agreement side condition. The H-side of the Rayleigh quotient is handled by Submodule.coe_inner together with the inner-preserving pad_preserves_inner (⟪pad a, pad b⟫ = ⟪a, b⟫, using injectivity of e), avoiding the LinearIsometryEquiv.inner_map_map instance diamond on ↥H. The eigenbasis/eigenvalue data of T and TH come from LinearMap.IsSymmetric.eigenvectorBasis / eigenvalues (antitone), and poincare_separation delivers the two inequalities, indexed by explicit Fin (n+m) elements ⟨k+m⟩ and ⟨k⟩.",
+    "keyInsights": [
+      "**The compression↔submatrix identification is a quadratic-form fact, not an operator identity.** The full operator T = toEuclideanLin A does NOT preserve the coordinate subspace H, so there is no intertwining T ∘ ι = ι ∘ Tsub. What DOES hold is the equality of quadratic forms on H: ⟪T (pad x), pad x⟫ = ⟪Tsub x, x⟫ (quad_form_submatrix'). This is exactly the Rayleigh-agreement the abstract theorem needs, and it is the reason the orthogonal compression — not A itself — has the principal submatrix as its matrix.",
+      "**Zero-padding is the isometric coordinate embedding.** pad_preserves_inner shows ⟪pad a, pad b⟫ = ⟪a, b⟫; injectivity of e is precisely what makes the off-diagonal terms [e i = e j] vanish for i ≠ j. Transporting the submatrix operator through this isometry gives a compression on H whose spectrum is the submatrix spectrum by construction, so no separate 'eigenvalues are equal' argument is needed.",
+      "**Instance-diamond avoidance.** LinearIsometryEquiv.inner_map_map does not apply to an isometry onto a submodule ↥H: the ≃ₗᵢ records Submodule.module while the lemma expects InnerProductSpace.toNormedSpace.toModule, and the elaborator will not unify them (and comparing EuclideanSpace InnerProductSpace instances triggers an expensive norm defeq). The proof routes the H-side numerator through Submodule.coe_inner (definitional) and the dot-product-level pad_preserves_inner instead, keeping every inner product either on EuclideanSpace or reduced to matrix dot products.",
+      "**Only the matrix layer is new.** All spectral content — the bound-form Courant–Fischer max–min characterisation and the codimension-m dimension count — is inherited verbatim from the parent oq-02 and its keystone. This entry adds exactly the Matrix ⇄ EuclideanSpace plumbing (toEuclideanLin, the zero-padding isometry, the quadratic-form collapse), and nothing more."
+    ],
+    "prerequisites": [
+      "The parent entry oq-02 (abstract Poincaré separation): λ(k+m) ≤ μ(k) ≤ λ(k) for a symmetric operator and a codimension-m compression with agreeing Rayleigh quotient",
+      "Matrix.IsHermitian and toEuclideanLin: Mathlib's identification of a Hermitian matrix with a self-adjoint operator on EuclideanSpace, and its eigenvalues₀",
+      "The dot-product form of the EuclideanSpace inner product (EuclideanSpace.inner_eq_star_dotProduct) and Matrix.mulVec / submatrix",
+      "Orthonormal bases of a spanned subspace (OrthonormalBasis.mk, OrthonormalBasis.repr) and transport of operators by a linear equivalence (LinearEquiv.conj)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pad",
+      "title": "The Zero-Padding Embedding",
+      "startLine": 52,
+      "endLine": 85,
+      "summary": "def pad e xf zero-pads a length-n coordinate vector onto the coordinates in the image of e; pad_apply_embed evaluates it on e i, mulVec_pad computes A *ᵥ pad, and star_pad_apply expands the conjugate.",
+      "mathContext": "The coordinate-level description of the isometric embedding EuclideanSpace 𝕜 (Fin n) ↪ EuclideanSpace 𝕜 (Fin (n+m)) whose range is the retained-coordinate subspace."
+    },
+    {
+      "id": "quad-form",
+      "title": "The Quadratic-Form Submatrix Identity",
+      "startLine": 86,
+      "endLine": 137,
+      "summary": "quad_form_submatrix and quad_form_submatrix': star(pad x) ⬝ᵥ (A *ᵥ pad x) = star x ⬝ᵥ (A.submatrix e e *ᵥ x) and its conjugate variant. The ambient double sum collapses to ∑ᵢⱼ conj(xᵢ) A_{e i, e j} xⱼ on both sides.",
+      "mathContext": "The heart of the compression↔submatrix identification: the quadratic form of A restricted to the coordinate subspace IS the quadratic form of the principal submatrix."
+    },
+    {
+      "id": "inner",
+      "title": "Rayleigh Numerators as Inner Products",
+      "startLine": 138,
+      "endLine": 180,
+      "summary": "rayleigh_pad_eq lifts quad_form_submatrix' to the EuclideanSpace inner product (V-side numerator); pad_dot / pad_preserves_inner show the padding preserves the inner product (H-side numerator), using injectivity of e for the off-diagonal cancellation.",
+      "mathContext": "Converts the matrix dot-product identities into the ⟪T•, •⟫ Rayleigh quotients the abstract Poincaré separation consumes, while sidestepping the ↥H inner_map_map instance diamond."
+    },
+    {
+      "id": "main",
+      "title": "The Matrix Poincaré Separation Theorem",
+      "startLine": 199,
+      "endLine": 302,
+      "summary": "poincare_separation_submatrix: builds the orthonormal frame, the coordinate subspace H, the zero-padding isometry L, the transported compression TH; discharges the Rayleigh agreement from the padding lemmas; and feeds everything into poincare_separation to obtain λ(⟨k+m⟩) ≤ μ(k) ≤ λ(⟨k⟩) for the Hermitian matrix A and its principal submatrix.",
+      "mathContext": "The literal matrix statement: eigenvalues of a principal submatrix (delete m rows/columns) interlace those of the full Hermitian matrix."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of the principal-submatrix Poincaré separation theorem — for a Hermitian matrix A and the principal submatrix A.submatrix e e obtained by deleting m rows/columns, the submatrix eigenvalues μ interlace the matrix eigenvalues λ as λ(k+m) ≤ μ(k) ≤ λ(k). The file is 0-axiom, 0-sorry (#print axioms lists only propext / Classical.choice / Quot.sound), as is its import chain. It answers the parent entry oq-02's second open question by realising the coordinate subspace via a zero-padding isometry and identifying its orthogonal compression with the principal submatrix at the quadratic-form level (quad_form_submatrix').",
+    "implications": "Closes the chain from the abstract Courant–Fischer keystone to the concrete matrix statement, giving a self-contained, hypothesis-free interlacing theorem for principal submatrices of Hermitian matrices. The reusable pieces — the zero-padding isometry, the quadratic-form collapse quad_form_submatrix', and the inner-product-preserving pad_preserves_inner — are exactly what is needed to state other matrix corollaries of the min-max principle (Weyl monotonicity, interlacing for bordered matrices) directly on Matrix.IsHermitian eigenvalues.",
+    "openQuestions": [
+      "Restate the conclusion with Matrix.IsHermitian.eigenvalues₀ / eigenvalues directly (rather than the definitionally-equal LinearMap.IsSymmetric.eigenvalues of toEuclideanLin), threading the Fintype.card (Fin (n+m)) = n+m reindexing, for a fully matrix-facing signature.",
+      "Specialise e to a monotone embedding (a genuine contiguous or index-ordered principal submatrix) and derive the classical bordered-matrix interlacing λ_k ≤ μ_k ≤ λ_{k+1} (the m = 1, delete-last-row case) directly in matrix form."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "cauchy-interlacing-theorem-oq-02",
+      "relation": "Parent entry — proves the abstract Poincaré separation λ(k+m) ≤ μ(k) ≤ λ(k) for a symmetric operator and a codimension-m compression with agreeing Rayleigh quotient, and lists the principal-submatrix bridge as its second open question. This entry supplies that bridge by realising the compression as toEuclideanLin of a principal submatrix."
+    },
+    {
+      "slug": "cauchy-interlacing-theorem",
+      "relation": "Root entry — the codimension-one Cauchy interlacing theorem and the Courant–Fischer keystone on which the entire chain rests."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Theorem 4.3.17 (Cauchy interlacing) and Theorem 4.3.28 / §4.3 (Poincaré separation for general principal submatrices)"
+    },
+    {
+      "authors": [
+        "Bhatia, R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "Corollary III.1.5 and §III (Poincaré separation and interlacing via the min-max principle)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingPoincare"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "Matrix",
+      "WithLp",
+      "CauchyInterlacing.Poincare"
+    ],
+    "namespace": "CauchyInterlacing.PoincareSubmatrix",
+    "lineCount": 302,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/CauchyInterlacingPoincareSubmatrix.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **cauchy-interlacing-theorem-oq-02**'s second open question: bridges the *abstract* Poincaré separation theorem to the **literal matrix statement**.

For a Hermitian matrix `A : Matrix (Fin (n+m)) (Fin (n+m)) 𝕜` and an injective coordinate map `e : Fin n → Fin (n+m)` (i.e. deleting the `m` complementary rows and columns), the **principal submatrix** `A.submatrix e e` has descending eigenvalues `μ` interlacing those `λ` of `A`:

```
λ(⟨k+m⟩) ≤ μ(k)   and   μ(k) ≤ λ(⟨k⟩)      (ascending: λ_k ≤ μ_k ≤ λ_{k+m})
```

Eigenvalues are those of `toEuclideanLin A` / `toEuclideanLin (A.submatrix e e)` = `Matrix.IsHermitian.eigenvalues₀` by Mathlib's definition.

## Approach

- **Crux** `quad_form_submatrix'`: the quadratic form of `A` on the zero-padded vector equals that of the principal submatrix — `star(pad e x) ⬝ᵥ (A *ᵥ pad e x) = star x ⬝ᵥ (A.submatrix e e *ᵥ x)`. The compression↔submatrix identification is a *quadratic-form* fact, not an operator identity (`A` does not preserve the coordinate subspace).
- Zero-padding isometry `L : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H` onto `H = span {e_{e(j)}}`; transported compression `TH = L.conj (toEuclideanLin (A.submatrix e e))` has the submatrix spectrum by construction.
- Rayleigh agreement discharged via `Submodule.coe_inner` + `pad_preserves_inner`, avoiding the `↥H` `inner_map_map` `Submodule.module`/`InnerProductSpace` instance diamond. Fed into the abstract `poincare_separation`.

## Verification

- **0 axioms, 0 sorries.** `#print axioms poincare_separation_submatrix` → `[propext, Classical.choice, Quot.sound]` only.
- 9 theorems/lemmas, 1 definition, 302 lines. Import chain (`CauchyInterlacingPoincare`, `CauchyInterlacingKeystone`) is 0-sorry/0-axiom.
- New gallery entry `src/data/proofs/cauchy-interlacing-theorem-oq-02-oq-02/` (meta + annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)