### PR TITLE
Enrich erdos-458-oq-05: annotation coverage + prerequisites

### DIFF
--- a/src/data/proofs/erdos-458-oq-05/meta.json
+++ b/src/data/proofs/erdos-458-oq-05/meta.json
@@ -37,7 +37,8 @@
     "keyInsights": [
       "The whole account is kernel-checkable: replacing `native_decide` with `decide` throughout removes the `Lean.ofReduceBool` axiom, turning the parent's `axiomatized` base cases into genuinely `verified` (0-axiom) ones.",
       "`Nat.nth_count` is the exact tool for value facts about Nat.nth: it converts 'n is prime and there are k primes below n' into 'the k-th prime is n', so no prime-index value ever needs to be asserted.",
-      "Kernel `decide` scales far enough for this range: primality and prime-counting up to 31, and lcm(1,…,12) = 27720, all reduce in the kernel without the compiler."
+      "Kernel `decide` scales far enough for this range: primality and prime-counting up to 31, and lcm(1,…,12) = 27720, all reduce in the kernel without the compiler.",
+      "Kernel `decide` keeps every prime value and base case axiom-free, whereas the parent's `native_decide` pulls in `Lean.ofReduceBool`. The price is that kernel reduction of `Nat.count` and of `lcm(1..12)` is far more expensive — which is exactly what caps the verified reach at the 11th prime (31) and at k = 4."
     ],
     "prerequisites": [
       "The parent formalization erdos-458 (statement of the LCM inequality and the nthPrime setup)",


### PR DESCRIPTION
Enrichment pass for `erdos-458-oq-05` (nth primes from `Nat.nth`, and axiom-free base cases for Erdős #458).

Biggest gap: **the entire `nthPrime_one`…`nthPrime_nine` block (lines 69–131) was unannotated**, and all 10 existing annotations lacked `prerequisites`.

- **Coverage fill** — added a `technique` annotation (69–131) documenting the uniform `Nat.nth_count` + kernel-`decide` template these nine theorems share (only the pair `(p, k)` changes).
- Added a `context` annotation (1–38) for the header/setup (parent LCM inequality, OQ-05/OQ-03).
- Added `prerequisites` to all 10 pre-existing annotations.
- Added a 4th keyInsight: kernel `decide` keeps results axiom-free (vs the parent's `native_decide`/`Lean.ofReduceBool`), at the cost of reduction expense that caps the reach at the 11th prime / k=4.

Result: 12 non-overlapping annotations spanning lines 1–178. Validated: 12/12 valid, 0 misaligned. meta.json 8.3 KB.