### PR TITLE
research(erdos-1020-oq-02): explicit large-n threshold N = (r+1)k − 2

### DIFF
--- a/proofs/Proofs/Erdos1020OQ02Threshold.lean
+++ b/proofs/Proofs/Erdos1020OQ02Threshold.lean
@@ -1,0 +1,70 @@
+import Proofs.Erdos1020OQ02
+
+/-
+# Erdős #1020 OQ-02 — an EXPLICIT large-`n` threshold
+
+`Erdos1020OQ02.lean` proves the regime transition is a *finite* threshold
+(`exists_large_regime`: some `N` beyond which `construction2 ≥ construction1`) but
+leaves `N` non-explicit. This file pins an explicit value.
+
+**Key identity.** `construction1 r k = C(rk−1, r) = (k−1)·C(rk−1, r−1)` — because
+`C(n, r)·r = C(n, r−1)·(n−r+1)` (`Nat.choose_succ_right_eq`) and at `n = rk−1` the
+factor `n−r+1 = r(k−1)`. This rewrites `construction1` into the same `C(·, r−1)`
+"currency" as the §8 window lower bound
+`(k−1)·C(n−k+1, r−1) ≤ construction2 n r k` (`construction2_window_lb`).
+
+**Explicit threshold.** For `r, k ≥ 2` and every `n ≥ (r+1)k − 2`,
+```
+construction1 r k = (k−1)·C(rk−1, r−1)
+                  ≤ (k−1)·C(n−k+1, r−1)   (choose monotone: rk−1 ≤ n−k+1)
+                  ≤ construction2 n r k.
+```
+The monotonicity step needs exactly `rk − 1 ≤ n − k + 1`, i.e. `n ≥ (r+1)k − 2`, so
+`N = (r+1)k − 2` is an explicit threshold for the large-`n` regime — a concrete
+upper bound on the least crossover point (whose *exact* location, inside the
+genuinely open zone, this file still does not claim).
+-/
+
+namespace Erdos1020OQ02
+
+/-- `construction1 r k = (k−1)·C(rk−1, r−1)`, rewriting the small-`n` maximiser into
+the `C(·, r−1)` form used by the window bounds. From `Nat.choose_succ_right_eq`. -/
+theorem construction1_eq (r k : ℕ) (hr : 1 ≤ r) (hk : 1 ≤ k) :
+    construction1 r k = (k - 1) * Nat.choose (r * k - 1) (r - 1) := by
+  unfold construction1
+  have hrr : r - 1 + 1 = r := by omega
+  have key := Nat.choose_succ_right_eq (r * k - 1) (r - 1)
+  rw [hrr] at key
+  -- key : C(rk-1, r) * r = C(rk-1, r-1) * (rk-1 - (r-1))
+  have hexp : r * k = r * (k - 1) + r := by
+    conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+    rw [Nat.mul_add, Nat.mul_one]
+  have hsub : r * k - 1 - (r - 1) = r * (k - 1) := by omega
+  rw [hsub] at key
+  -- key : C(rk-1, r) * r = C(rk-1, r-1) * (r * (k-1))
+  have hmul : Nat.choose (r * k - 1) r * r
+      = (k - 1) * Nat.choose (r * k - 1) (r - 1) * r := by
+    rw [key]; ring
+  exact Nat.eq_of_mul_eq_mul_right (by omega) hmul
+
+/-- **Explicit large-`n` threshold.** For `r, k ≥ 2` and every `n ≥ (r+1)k − 2`,
+the large-`n` construction dominates: `construction1 r k ≤ construction2 n r k`.
+Thus `N = (r+1)k − 2` is an explicit threshold for the regime transition. -/
+theorem large_regime_threshold (r k : ℕ) (hr : 2 ≤ r) (hk : 2 ≤ k)
+    {n : ℕ} (hn : (r + 1) * k - 2 ≤ n) :
+    construction1 r k ≤ construction2 n r k := by
+  have hexp2 : (r + 1) * k = r * k + k := by ring
+  have hrk4 : 4 ≤ r * k := Nat.mul_le_mul hr hk
+  have hnk : k ≤ n := by omega
+  have hidx : r * k - 1 ≤ n - k + 1 := by omega
+  calc construction1 r k
+      = (k - 1) * Nat.choose (r * k - 1) (r - 1) := construction1_eq r k (by omega) (by omega)
+    _ ≤ (k - 1) * Nat.choose (n - k + 1) (r - 1) := by
+        gcongr
+    _ ≤ construction2 n r k := construction2_window_lb n r k (by omega) (by omega) hnk
+
+/-- Sanity: for `r = 4, k = 2` the explicit threshold is `N = (4+1)·2 − 2 = 8`,
+matching the crossover at `n = 8` established in the base file. -/
+example : (4 + 1) * 2 - 2 = 8 := by decide
+
+end Erdos1020OQ02

--- a/research/problems/erdos-1020-oq-02/knowledge.md
+++ b/research/problems/erdos-1020-oq-02/knowledge.md
@@ -29,3 +29,33 @@ File 349→389 lines, +2 theorems (and stale meta lineCount 284→389, theoremCo
 - Locate the threshold EXPLICITLY (least N), or bound it (the gap n∈[kr+…, 3kr²] is the genuinely
   open zone of the conjecture — the file deliberately does NOT resolve it).
 - Parent `Erdos1020Problem.lean` carries 6 axioms (separate slug erdos-1020) — axiom-elimination target.
+
+## Session 2026-07-02 (researcher-1) — EXPLICIT large-n threshold N = (r+1)k − 2
+
+The §9 `exists_large_regime` gave a non-explicit N; this pins it. Companion
+`proofs/Proofs/Erdos1020OQ02Threshold.lean` (70 L, 2 thm, **0-axiom**):
+
+- `construction1_eq`: `construction1 r k = C(rk−1,r) = (k−1)·C(rk−1,r−1)`. Via
+  `Nat.choose_succ_right_eq` (C(n,r)·r = C(n,r−1)·(n−r+1)) at `n=rk−1`, where
+  `n−r+1 = r(k−1)`, then cancel `r` (`Nat.eq_of_mul_eq_mul_right`). This rewrites
+  construction1 into the SAME `C(·,r−1)` currency as the §8 window bounds.
+- `large_regime_threshold`: for `r,k ≥ 2` and every `n ≥ (r+1)k−2`,
+  `construction1 r k ≤ construction2 n r k`. Chain:
+  `construction1 = (k−1)C(rk−1,r−1) ≤ (k−1)C(n−k+1,r−1) ≤ construction2`,
+  the first `≤` by `Nat.choose_le_choose` needing exactly `rk−1 ≤ n−k+1` ⟺
+  `n ≥ (r+1)k−2`, the second by the §8 `construction2_window_lb`. So
+  **N = (r+1)k−2 is an explicit threshold**; for (r,k)=(4,2) it gives N=8,
+  matching the base file's crossover at n=8.
+
+The EXACT least crossover (inside the genuinely open zone) is still not claimed —
+this is a concrete upper bound on it. Reusable: the identity
+`C(rk−1,r)=(k−1)C(rk−1,r−1)` is the bridge between construction1 and the r−1
+window bounds; likely also sharpens the (r=4,k=2) analysis.
+
+Lean/build notes: `gcongr` alone closes `(k−1)C(a,r−1) ≤ (k−1)C(b,r−1)` (finds
+`a≤b` from context — do NOT add a trailing `exact Nat.choose_le_choose`, it errors
+"No goals"); `(r+1)*k = r*k+k` by `ring` then feed `omega` (omega can't expand the
+product itself); `4 ≤ r*k` via `Nat.mul_le_mul hr hk`. Build fought a SEVERE
+multi-agent storm at 100% disk (corrupted `.olean.private` across Mathlib AND
+Aesop, SIGSEGV rc=139) — needed ~10 retry rounds; olean-existence is the only
+reliable success signal.


### PR DESCRIPTION
## Summary

`Erdos1020OQ02.lean` (Erdős Matching Conjecture regime transition) proves via `exists_large_regime` that the small-`n`/large-`n` transition is a *finite* threshold, but leaves the threshold `N` non-explicit. This PR pins an explicit value.

## New file `proofs/Proofs/Erdos1020OQ02Threshold.lean` (70 L, 2 thm, 0 axioms)

**Key identity** `construction1_eq`:
```
construction1 r k = C(rk−1, r) = (k−1)·C(rk−1, r−1)
```
via `Nat.choose_succ_right_eq` (`C(n,r)·r = C(n,r−1)·(n−r+1)`) at `n = rk−1`, where `n−r+1 = r(k−1)`, then cancel `r`. This rewrites `construction1` into the same `C(·, r−1)` "currency" as the §8 window lower bound `construction2_window_lb : (k−1)·C(n−k+1, r−1) ≤ construction2 n r k`.

**Explicit threshold** `large_regime_threshold`: for `r, k ≥ 2` and every `n ≥ (r+1)k − 2`,
```
construction1 r k = (k−1)·C(rk−1, r−1)
                  ≤ (k−1)·C(n−k+1, r−1)   (Nat.choose_le_choose: rk−1 ≤ n−k+1)
                  ≤ construction2 n r k    (§8 construction2_window_lb)
```
The monotonicity step needs exactly `rk − 1 ≤ n − k + 1`, i.e. `n ≥ (r+1)k − 2`. So **`N = (r+1)k − 2` is an explicit threshold** for the large-`n` regime; for `(r,k) = (4,2)` it gives `N = 8`, matching the base file's crossover at `n = 8`.

The *exact* least crossover point (inside the genuinely open zone) is still not claimed — this is a concrete upper bound on it. `#print axioms` = `[propext, Classical.choice, Quot.sound]`.

## Files
- `proofs/Proofs/Erdos1020OQ02Threshold.lean` (new, verified)
- `research/problems/erdos-1020-oq-02/knowledge.md` (session note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)