### PR TITLE
research(erdos-659-oq-06): Euclidean two-distance 4-point realizations [VERIFIED, 0-axiom, NEW]

### DIFF
--- a/proofs/Proofs/Erdos659OQ06.lean
+++ b/proofs/Proofs/Erdos659OQ06.lean
@@ -1,0 +1,199 @@
+import Mathlib
+
+/-
+# Erdős #659 (OQ): Concrete Euclidean realizations of two-distance 4-point configurations
+
+Erdős problem #659 concerns point sets in the plane with few distinct pairwise
+distances. A key object in the classification underlying the problem is the family
+of **two-distance sets**: point configurations realizing exactly two distinct
+pairwise distances. On four points there are, up to similarity, exactly six such
+configurations (square, 60° rhombus, two isosceles trapezoids, a kite, and four
+vertices of a regular pentagon); these are enumerated abstractly in
+`Erdos659Problem.lean` as the inductive type `TwoDistanceConfig`.
+
+This file supplies the missing **concrete, verified** side of that picture: explicit
+four-point configurations together with machine-checked proofs of their pairwise
+distance spectra. It is fully self-contained (it imports only Mathlib), `axiom`-free
+and `sorry`-free.
+
+## The metric subtlety this file fixes
+
+`Erdos659Problem.lean` measures distances with Mathlib's default `dist` on `ℝ × ℝ`,
+which is the **Chebyshev (ℓ∞) product metric**, not the Euclidean one. Under that
+metric the unit square `{(0,0),(1,0),(0,1),(1,1)}` degenerates to a *single* distance
+(all pairwise `dist`s equal `1`), as that file's own docstring notes. Here we work
+with the genuine **Euclidean** squared distance
+
+  `sqDist p q = (p.1 - q.1)^2 + (p.2 - q.2)^2`,
+
+under which the square correctly has the two-element squared-distance spectrum
+`{1, 2}`. Working with the *squared* distance keeps every spectrum rational (even for
+the 60° rhombus, whose coordinates involve `√3`), so the classification statements are
+decided by `norm_num`/`linear_combination` rather than by reasoning about surds.
+
+## Results
+
+* `sqDist` and its basic metric properties (`sqDist_nonneg`, `sqDist_symm`,
+  `sqDist_self`, `sqDist_eq_zero_iff`).
+* `IsTwoDistance4`: the predicate "these four points realize exactly two distinct
+  positive squared distances".
+* `unitSquare_isTwoDistance`: the unit square is a two-distance set with spectrum
+  `{1, 2}`  (realizes `TwoDistanceConfig.square`).
+* `rhombus60_isTwoDistance`: the 60° rhombus (two equilateral triangles glued on an
+  edge) is a two-distance set with spectrum `{1, 3}` (realizes
+  `TwoDistanceConfig.rhombus`).
+* `rectangle_not_isTwoDistance`: a non-square `1 × 2` rectangle is **not** a
+  two-distance set — its spectrum is `{1, 4, 5}` (three distances), showing the
+  predicate genuinely discriminates.
+-/
+
+namespace Erdos659TwoDistance
+
+open scoped Finset
+
+/-- Euclidean squared distance on the plane `ℝ × ℝ`.
+
+This is the honest ℓ² squared distance, *not* the square of Mathlib's default `dist`
+on `ℝ × ℝ` (which is the Chebyshev/ℓ∞ metric). -/
+def sqDist (p q : ℝ × ℝ) : ℝ := (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2
+
+@[simp] lemma sqDist_self (p : ℝ × ℝ) : sqDist p p = 0 := by
+  unfold sqDist; ring
+
+lemma sqDist_nonneg (p q : ℝ × ℝ) : 0 ≤ sqDist p q := by
+  unfold sqDist; positivity
+
+lemma sqDist_symm (p q : ℝ × ℝ) : sqDist p q = sqDist q p := by
+  unfold sqDist; ring
+
+lemma sqDist_eq_zero_iff (p q : ℝ × ℝ) : sqDist p q = 0 ↔ p = q := by
+  unfold sqDist
+  constructor
+  · intro h
+    have hx : (p.1 - q.1) ^ 2 = 0 := by
+      linarith [sq_nonneg (p.1 - q.1), sq_nonneg (p.2 - q.2)]
+    have hy : (p.2 - q.2) ^ 2 = 0 := by
+      linarith [sq_nonneg (p.1 - q.1), sq_nonneg (p.2 - q.2)]
+    have hx' : p.1 = q.1 := sub_eq_zero.mp (pow_eq_zero_iff (by norm_num) |>.mp hx)
+    have hy' : p.2 = q.2 := sub_eq_zero.mp (pow_eq_zero_iff (by norm_num) |>.mp hy)
+    exact Prod.ext hx' hy'
+  · rintro rfl; ring
+
+/-- The (finite) set of the six unordered pairwise squared distances of four points. -/
+noncomputable def sqDistSet4 (a b c d : ℝ × ℝ) : Finset ℝ :=
+  {sqDist a b, sqDist a c, sqDist a d, sqDist b c, sqDist b d, sqDist c d}
+
+/-- Four points form a **two-distance set** when they realize exactly two distinct
+pairwise squared distances. -/
+def IsTwoDistance4 (a b c d : ℝ × ℝ) : Prop :=
+  (sqDistSet4 a b c d).card = 2
+
+/-! ### The unit square realizes `TwoDistanceConfig.square` -/
+
+/-- Vertices of the unit square. -/
+def s0 : ℝ × ℝ := (0, 0)
+def s1 : ℝ × ℝ := (1, 0)
+def s2 : ℝ × ℝ := (0, 1)
+def s3 : ℝ × ℝ := (1, 1)
+
+/-- The unit square's squared-distance spectrum is exactly `{1, 2}`: the four sides
+have squared length `1`, the two diagonals squared length `2`. -/
+theorem unitSquare_spectrum : sqDistSet4 s0 s1 s2 s3 = {1, 2} := by
+  have h01 : sqDist s0 s1 = 1 := by simp only [sqDist, s0, s1]; norm_num
+  have h02 : sqDist s0 s2 = 1 := by simp only [sqDist, s0, s2]; norm_num
+  have h03 : sqDist s0 s3 = 2 := by simp only [sqDist, s0, s3]; norm_num
+  have h12 : sqDist s1 s2 = 2 := by simp only [sqDist, s1, s2]; norm_num
+  have h13 : sqDist s1 s3 = 1 := by simp only [sqDist, s1, s3]; norm_num
+  have h23 : sqDist s2 s3 = 1 := by simp only [sqDist, s2, s3]; norm_num
+  unfold sqDistSet4
+  rw [h01, h02, h03, h12, h13, h23]
+  ext x
+  simp only [Finset.mem_insert, Finset.mem_singleton]
+  tauto
+
+/-- The unit square is a two-distance set (realizes `TwoDistanceConfig.square`). -/
+theorem unitSquare_isTwoDistance : IsTwoDistance4 s0 s1 s2 s3 := by
+  unfold IsTwoDistance4
+  rw [unitSquare_spectrum, Finset.card_insert_of_notMem (by norm_num),
+    Finset.card_singleton]
+
+/-! ### The 60° rhombus realizes `TwoDistanceConfig.rhombus`
+
+Two unit equilateral triangles glued along the edge `r0 r1`. All four sides and the
+short diagonal `r1 r3` have squared length `1`; the long diagonal `r0 r2` has squared
+length `3`. The `√3` in the coordinates cancels, leaving the rational spectrum
+`{1, 3}`. -/
+
+noncomputable def r0 : ℝ × ℝ := (0, 0)
+noncomputable def r1 : ℝ × ℝ := (1, 0)
+noncomputable def r2 : ℝ × ℝ := (3 / 2, Real.sqrt 3 / 2)
+noncomputable def r3 : ℝ × ℝ := (1 / 2, Real.sqrt 3 / 2)
+
+/-- The 60° rhombus's squared-distance spectrum is exactly `{1, 3}`. -/
+theorem rhombus60_spectrum : sqDistSet4 r0 r1 r2 r3 = {1, 3} := by
+  have hs : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have h01 : sqDist r0 r1 = 1 := by simp only [sqDist, r0, r1]; norm_num
+  have h02 : sqDist r0 r2 = 3 := by
+    simp only [sqDist, r0, r2]; linear_combination (1 / 4 : ℝ) * hs
+  have h03 : sqDist r0 r3 = 1 := by
+    simp only [sqDist, r0, r3]; linear_combination (1 / 4 : ℝ) * hs
+  have h12 : sqDist r1 r2 = 1 := by
+    simp only [sqDist, r1, r2]; linear_combination (1 / 4 : ℝ) * hs
+  have h13 : sqDist r1 r3 = 1 := by
+    simp only [sqDist, r1, r3]; linear_combination (1 / 4 : ℝ) * hs
+  have h23 : sqDist r2 r3 = 1 := by
+    simp only [sqDist, r2, r3]; ring
+  unfold sqDistSet4
+  rw [h01, h02, h03, h12, h13, h23]
+  ext x
+  simp only [Finset.mem_insert, Finset.mem_singleton]
+  tauto
+
+/-- The 60° rhombus is a two-distance set (realizes `TwoDistanceConfig.rhombus`). -/
+theorem rhombus60_isTwoDistance : IsTwoDistance4 r0 r1 r2 r3 := by
+  unfold IsTwoDistance4
+  rw [rhombus60_spectrum, Finset.card_insert_of_notMem (by norm_num),
+    Finset.card_singleton]
+
+/-! ### A non-square rectangle is not a two-distance set -/
+
+def t0 : ℝ × ℝ := (0, 0)
+def t1 : ℝ × ℝ := (2, 0)
+def t2 : ℝ × ℝ := (0, 1)
+def t3 : ℝ × ℝ := (2, 1)
+
+/-- The `1 × 2` rectangle has squared-distance spectrum `{1, 4, 5}`: short sides `1`,
+long sides `4`, diagonals `5`. Three distinct distances. -/
+theorem rectangle_spectrum : sqDistSet4 t0 t1 t2 t3 = {1, 4, 5} := by
+  have h01 : sqDist t0 t1 = 4 := by simp only [sqDist, t0, t1]; norm_num
+  have h02 : sqDist t0 t2 = 1 := by simp only [sqDist, t0, t2]; norm_num
+  have h03 : sqDist t0 t3 = 5 := by simp only [sqDist, t0, t3]; norm_num
+  have h12 : sqDist t1 t2 = 5 := by simp only [sqDist, t1, t2]; norm_num
+  have h13 : sqDist t1 t3 = 1 := by simp only [sqDist, t1, t3]; norm_num
+  have h23 : sqDist t2 t3 = 4 := by simp only [sqDist, t2, t3]; norm_num
+  unfold sqDistSet4
+  rw [h01, h02, h03, h12, h13, h23]
+  ext x
+  simp only [Finset.mem_insert, Finset.mem_singleton]
+  tauto
+
+/-- The non-square rectangle is **not** a two-distance set: its spectrum has three
+elements, so it does not satisfy `IsTwoDistance4`. -/
+theorem rectangle_not_isTwoDistance : ¬ IsTwoDistance4 t0 t1 t2 t3 := by
+  unfold IsTwoDistance4
+  rw [rectangle_spectrum]
+  have hcard : ({1, 4, 5} : Finset ℝ).card = 3 := by
+    rw [Finset.card_insert_of_notMem (by norm_num),
+        Finset.card_insert_of_notMem (by norm_num), Finset.card_singleton]
+  rw [hcard]
+  norm_num
+
+/-- Summary: a square and a 60° rhombus are both two-distance four-point sets, whereas
+a non-square rectangle is not — the three distinct realizations of the classification
+skeleton, verified. -/
+theorem two_distance_examples :
+    IsTwoDistance4 s0 s1 s2 s3 ∧ IsTwoDistance4 r0 r1 r2 r3 ∧
+      ¬ IsTwoDistance4 t0 t1 t2 t3 :=
+  ⟨unitSquare_isTwoDistance, rhombus60_isTwoDistance, rectangle_not_isTwoDistance⟩
+
+end Erdos659TwoDistance

--- a/src/data/proofs/erdos-659-oq-06/annotations.json
+++ b/src/data/proofs/erdos-659-oq-06/annotations.json
@@ -1,0 +1,156 @@
+[
+  {
+    "id": "erdos659-oq06-ann-sqdist",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 54,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "Euclidean Squared Distance sqDist",
+    "content": "sqDist(p,q) = (p₁−q₁)² + (p₂−q₂)² is the honest ℓ² (Euclidean) squared distance on the plane ℝ×ℝ. This is deliberately NOT the square of Mathlib's default `dist` on ℝ×ℝ, which is the Chebyshev/ℓ∞ product metric max(|Δx|,|Δy|) — under that metric a unit square degenerates to a single distance. Working with the SQUARED distance keeps every configuration's distance spectrum rational, even when coordinates involve √3.",
+    "mathContext": "$\\mathrm{sqDist}(p,q) = (p_1-q_1)^2 + (p_2-q_2)^2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclidean distance",
+      "ℓ² vs ℓ∞ metrics",
+      "squared distance"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "real numbers"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-metric",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 63,
+      "endLine": 80
+    },
+    "type": "lemma",
+    "title": "sqDist Is a (Squared) Metric: Positive-Definiteness",
+    "content": "The four lemmas sqDist_nonneg, sqDist_symm, sqDist_self and sqDist_eq_zero_iff certify that sqDist behaves as a genuine squared metric. The key one is positive-definiteness sqDist p q = 0 ↔ p = q: from (Δx)²+(Δy)²=0 with both squares nonnegative, each square is 0 (linarith), hence each coordinate difference is 0 (pow_eq_zero_iff), so the points coincide.",
+    "mathContext": "$\\mathrm{sqDist}(p,q)=0 \\iff p=q$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positive-definiteness",
+      "metric axioms",
+      "sum of squares"
+    ],
+    "prerequisites": [
+      "nonnegativity of squares",
+      "pow_eq_zero_iff"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-predicate",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 82,
+      "endLine": 89
+    },
+    "type": "definition",
+    "title": "Distance Spectrum and the Two-Distance Predicate",
+    "content": "sqDistSet4 a b c d is the Finset of the six unordered pairwise squared distances among four points — the configuration's squared-distance spectrum. IsTwoDistance4 a b c d holds exactly when this spectrum has cardinality 2, i.e. the four points realize precisely two distinct pairwise distances. This is the local pattern Erdős #659's four-point property forbids.",
+    "mathContext": "$\\mathrm{IsTwoDistance4}(a,b,c,d) \\iff \\#\\,\\mathrm{sqDistSet4}(a,b,c,d) = 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-distance sets",
+      "distance spectrum",
+      "four-point property"
+    ],
+    "prerequisites": [
+      "finite sets",
+      "cardinality"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-square",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 93,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "The Unit Square Is a Two-Distance Set (Spectrum {1,2})",
+    "content": "For the unit square {(0,0),(1,0),(0,1),(1,1)} the six pairwise squared distances are: four sides of squared length 1 and two diagonals of squared length 2, so the spectrum is exactly {1,2} and the square is a two-distance set — the concrete realization of TwoDistanceConfig.square. Note this is TRUE under the Euclidean metric used here, whereas under the parent file's Chebyshev metric the same square would collapse to a single distance.",
+    "mathContext": "$\\mathrm{sqDistSet4} = \\{1,2\\},\\quad \\#=2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "square",
+      "two-distance set",
+      "Euclidean vs Chebyshev metric"
+    ],
+    "prerequisites": [
+      "distance computation",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-rhombus",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 120,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "The 60° Rhombus Is a Two-Distance Set (Spectrum {1,3})",
+    "content": "The 60° rhombus consists of two unit equilateral triangles glued along an edge, with vertices (0,0),(1,0),(3/2,√3/2),(1/2,√3/2). All four sides and the short diagonal have squared length 1; the long diagonal has squared length 3. Although coordinates involve √3, the squared distances are rational: the surd cancels, and each value follows by linear_combination against (√3)²=3. The spectrum is {1,3} — realizing TwoDistanceConfig.rhombus.",
+    "mathContext": "$\\mathrm{sqDistSet4} = \\{1,3\\},\\quad (\\sqrt3)^2 = 3$",
+    "significance": "key",
+    "relatedConcepts": [
+      "60° rhombus",
+      "equilateral triangle",
+      "rational squared distances",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Real.sq_sqrt",
+      "distance computation"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-rectangle",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 158,
+      "endLine": 189
+    },
+    "type": "theorem",
+    "title": "A Non-Square Rectangle Is NOT a Two-Distance Set (Spectrum {1,4,5})",
+    "content": "The 1×2 rectangle {(0,0),(2,0),(0,1),(2,1)} has three distinct squared distances: short sides 1, long sides 4, and diagonals 5. Since its spectrum {1,4,5} has cardinality 3, IsTwoDistance4 fails. This non-example shows the two-distance predicate genuinely discriminates — it is not vacuously satisfied by any four points.",
+    "mathContext": "$\\mathrm{sqDistSet4} = \\{1,4,5\\},\\quad \\#=3 \\neq 2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rectangle",
+      "non-example",
+      "discriminating predicate"
+    ],
+    "prerequisites": [
+      "distance computation",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "erdos659-oq06-ann-summary",
+    "proofId": "erdos-659-oq-06",
+    "range": {
+      "startLine": 191,
+      "endLine": 199
+    },
+    "type": "theorem",
+    "title": "Packaged Realizations of the Classification Skeleton",
+    "content": "two_distance_examples bundles the three verified results into one statement: the square and the 60° rhombus are two-distance four-point sets, while the 1×2 rectangle is not. Together these give concrete, axiom-free Euclidean realizations of two of the six named TwoDistanceConfig cases plus a discriminating non-example, grounding the abstract classification that underlies Erdős #659's four-point obstruction.",
+    "mathContext": "$\\mathrm{IsTwoDistance4}(\\square) \\wedge \\mathrm{IsTwoDistance4}(\\lozenge) \\wedge \\neg\\,\\mathrm{IsTwoDistance4}(\\square_{1\\times2})$",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-distance classification",
+      "four-point property",
+      "Erdős 659"
+    ],
+    "prerequisites": [
+      "conjunction of results"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-659-oq-06/meta.json
+++ b/src/data/proofs/erdos-659-oq-06/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "erdos-659-oq-06",
+  "title": "Erdős #659 OQ: Euclidean Realizations of Two-Distance 4-Point Configurations",
+  "slug": "erdos-659-oq-06",
+  "description": "Erdős #659 concerns planar point sets with few distinct distances; its classification skeleton is the family of four-point two-distance sets (configurations realizing exactly two distinct pairwise distances). The parent formalization Erdos659Problem.lean enumerates the six such configurations abstractly as the inductive type TwoDistanceConfig but leaves three of them as `True` placeholders, and — because it measures distance with Mathlib's default Chebyshev (ℓ∞) metric on ℝ×ℝ — even the unit square degenerates there to a single distance. This entry supplies the missing concrete, machine-checked (0-axiom, 0-sorry) Euclidean side: an honest ℓ² squared-distance sqDist, the predicate IsTwoDistance4, and explicit realizations proving the unit square (spectrum {1,2}) and the 60° rhombus (spectrum {1,3}) ARE two-distance sets while a non-square 1×2 rectangle (spectrum {1,4,5}) is NOT.",
+  "meta": {
+    "author": "Classical (two-distance sets); formalization by researcher-7",
+    "sourceUrl": "https://erdosproblems.com/659",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/Erdos659OQ06.lean",
+    "tags": [
+      "erdos",
+      "distance-problems",
+      "two-distance-sets",
+      "four-point-property",
+      "euclidean-geometry",
+      "discrete-geometry",
+      "open-question"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Every result is machine-checked with 0 axioms and 0 sorries (depends only on the foundational propext/Classical.choice/Quot.sound). NOTE: this entry does NOT close Erdős #659; it verifies the concrete Euclidean two-distance realizations underlying the classification and fixes a metric mismatch in the parent formalization. The full six-configuration classification theorem and the Moree–Osburn density statement remain open.",
+    "erdosNumber": 659,
+    "erdosUrl": "https://erdosproblems.com/659",
+    "originalContributions": [
+      "sqDist p q = (p.1-q.1)²+(p.2-q.2)²: the honest Euclidean (ℓ²) squared distance on ℝ×ℝ, distinct from Mathlib's default Chebyshev dist",
+      "sqDist metric lemmas: nonneg, symm, self=0, and eq_zero_iff (positive-definiteness) — a genuine (squared) metric",
+      "IsTwoDistance4: predicate that four points realize exactly two distinct pairwise squared distances (card of the spectrum = 2)",
+      "unitSquare_spectrum / unitSquare_isTwoDistance: the unit square has squared-distance spectrum exactly {1,2} and is a two-distance set (realizes TwoDistanceConfig.square)",
+      "rhombus60_spectrum / rhombus60_isTwoDistance: the 60° rhombus (two equilateral triangles) has spectrum {1,3}; the √3 coordinates cancel to a rational spectrum (realizes TwoDistanceConfig.rhombus)",
+      "rectangle_spectrum / rectangle_not_isTwoDistance: a non-square 1×2 rectangle has spectrum {1,4,5} (three distances), so the predicate genuinely discriminates",
+      "two_distance_examples: packaged summary — square and rhombus are two-distance sets, rectangle is not"
+    ],
+    "lineCount": 199,
+    "theoremCount": 10,
+    "definitionCount": 15
+  },
+  "overview": {
+    "historicalContext": "A two-distance set is a set of points realizing only two distinct pairwise distances; the study of such sets goes back to work of Kelly, and Einhorn–Schoenberg (1966) classified all planar two-distance sets, finding that the maximum size in the plane is 5 (the regular pentagon) and enumerating the four-point cases. Erdős problem #659 (Moree–Osburn, 2006) is a refinement of Erdős's distinct-distances problem in which every four-point subset is forced to determine at least three distances — i.e. no four points may form a two-distance set — while the whole configuration still realizes only O(n/√log n) distinct distances. Understanding which four-point configurations ARE two-distance sets is therefore exactly the local obstruction the construction must avoid. Up to similarity there are six four-point two-distance sets: the square, the 60° rhombus (two glued equilateral triangles), two isosceles trapezoids, a kite, and four vertices of a regular pentagon.",
+    "problemStatement": "The parent gallery formalization Erdos659Problem.lean introduces the inductive type TwoDistanceConfig naming the six four-point two-distance configurations, but (a) leaves three of them (isoTrap1, isoTrap2, kite) as `True` placeholders rather than genuine geometric predicates, and (b) measures pairwise distance with Mathlib's default `dist` on ℝ×ℝ, which is the Chebyshev (ℓ∞) product metric — under which the unit square {(0,0),(1,0),(0,1),(1,1)} has all six pairwise distances equal to 1, a single distance rather than two. This entry asks: give a concrete, axiom-free Euclidean treatment that correctly certifies specific configurations as two-distance sets (or not).",
+    "proofStrategy": "Work with the honest Euclidean squared distance sqDist(p,q) = (p₁−q₁)² + (p₂−q₂)² on ℝ×ℝ, and reason about SQUARED distances so every spectrum stays rational (even for the √3 rhombus). (1) Establish sqDist's metric properties, including positive-definiteness sqDist p q = 0 ↔ p = q, via sq_nonneg + pow_eq_zero_iff. (2) Define the spectrum sqDistSet4 a b c d as the finite set of the six unordered pairwise squared distances, and IsTwoDistance4 := card of the spectrum is 2. (3) For each named configuration, compute the six pairwise squared distances by norm_num (rational coordinates) or by linear_combination against (√3)²=3 (the rhombus), then prove the spectrum equals an explicit 2- or 3-element set by Finset.ext. (4) Read off cardinality with Finset.card_insert_of_notMem. The square gives {1,2}, the 60° rhombus {1,3}, and the 1×2 rectangle {1,4,5} — the last showing IsTwoDistance4 fails, so the predicate is discriminating.",
+    "keyInsights": [
+      "The metric matters: the parent file's use of Mathlib's default ℓ∞ product metric on ℝ×ℝ makes the unit square a ONE-distance set (all pairwise dist = 1), as that file's own docstring admits; the genuine two-distance structure only appears under the Euclidean ℓ² metric that this entry uses.",
+      "Reasoning about squared distances instead of distances keeps every spectrum rational: the 60° rhombus needs √3 coordinates, yet all six squared distances are integers (1 or 3), so the classification is decided by norm_num / linear_combination rather than by manipulating surds.",
+      "IsTwoDistance4 is genuinely discriminating: the 1×2 rectangle, which looks superficially like a square, has three distinct squared distances {1,4,5}, so the predicate rejects it — the verification is not vacuous.",
+      "These configurations are exactly the local patterns Erdős #659 forbids: a construction with the four-point property must avoid every four-point two-distance set, so concretely certifying which quadruples are two-distance sets pins down the obstruction the O(n/√log n) construction is engineered around."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Scope and the metric subtlety",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring framing: the four-point two-distance classification underlying Erdős #659, and the fix for the parent file's Chebyshev-vs-Euclidean metric mismatch (why the unit square degenerates under Mathlib's default dist)."
+    },
+    {
+      "id": "sqdist",
+      "title": "Euclidean squared distance and its metric properties",
+      "startLine": 54,
+      "endLine": 80,
+      "summary": "Defines sqDist = (Δx)²+(Δy)² and proves nonnegativity, symmetry, self-distance 0, and positive-definiteness sqDist p q = 0 ↔ p = q."
+    },
+    {
+      "id": "predicate",
+      "title": "Spectrum and the two-distance predicate",
+      "startLine": 82,
+      "endLine": 89,
+      "summary": "sqDistSet4 collects the six unordered pairwise squared distances of four points; IsTwoDistance4 asserts the spectrum has exactly two elements."
+    },
+    {
+      "id": "square",
+      "title": "The unit square (spectrum {1,2})",
+      "startLine": 91,
+      "endLine": 118,
+      "summary": "Computes the square's six pairwise squared distances (four sides 1, two diagonals 2) and proves it is a two-distance set — realizing TwoDistanceConfig.square."
+    },
+    {
+      "id": "rhombus",
+      "title": "The 60° rhombus (spectrum {1,3})",
+      "startLine": 120,
+      "endLine": 156,
+      "summary": "Two equilateral triangles glued on an edge; the √3 coordinates cancel so all six squared distances are 1 or 3, giving a two-distance set — realizing TwoDistanceConfig.rhombus."
+    },
+    {
+      "id": "rectangle",
+      "title": "A non-square rectangle (spectrum {1,4,5})",
+      "startLine": 158,
+      "endLine": 189,
+      "summary": "The 1×2 rectangle has three distinct squared distances, so IsTwoDistance4 fails — demonstrating the predicate genuinely discriminates."
+    },
+    {
+      "id": "summary",
+      "title": "Packaged examples",
+      "startLine": 191,
+      "endLine": 199,
+      "summary": "two_distance_examples bundles the three results: square and rhombus are two-distance sets, the rectangle is not."
+    }
+  ],
+  "relatedProblems": [
+    {
+      "slug": "erdos-659",
+      "relationship": "Parent problem: this entry supplies concrete Euclidean realizations for the abstract TwoDistanceConfig classification in Erdos659Problem.lean."
+    },
+    {
+      "slug": "erdos-659-oq-05",
+      "relationship": "Sibling: oq-05 studies the arithmetic (x²+2y² norm form) of the Moree–Osburn distance spectrum; this entry studies the geometry of individual two-distance configurations."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `erdos-659-oq-06`: concrete, axiom-free **Euclidean** realizations of the two-distance four-point configurations underlying Erdős #659.

**Motivation / bug it fixes.** The parent formalization `Erdos659Problem.lean` (a) leaves three of its six `TwoDistanceConfig` cases as `True` placeholders, and (b) measures distance with Mathlib's *default* `dist` on `ℝ × ℝ`, which is the **Chebyshev (ℓ∞)** product metric. Under that metric the unit square `{(0,0),(1,0),(0,1),(1,1)}` has all six pairwise distances equal to 1 — a *single* distance — as the parent file's own docstring admits. This entry supplies the honest Euclidean side.

## What's proved (0 axioms, 0 sorries)

- `sqDist p q = (p₁−q₁)² + (p₂−q₂)²` — genuine ℓ² squared distance (not Mathlib's Chebyshev `dist`), with metric lemmas including positive-definiteness `sqDist p q = 0 ↔ p = q`.
- `IsTwoDistance4` — four points realize exactly two distinct pairwise squared distances.
- `unitSquare_isTwoDistance` — square spectrum `{1,2}` (realizes `TwoDistanceConfig.square`).
- `rhombus60_isTwoDistance` — 60° rhombus (two glued equilateral triangles) spectrum `{1,3}`; the `√3` coordinates cancel to a rational spectrum via `linear_combination` against `(√3)²=3`.
- `rectangle_not_isTwoDistance` — a non-square `1×2` rectangle has spectrum `{1,4,5}` (three distances), so the predicate is genuinely discriminating.
- `two_distance_examples` — packaged summary.

Working with **squared** distances keeps every spectrum rational even for the √3 rhombus, so the classification is decided by `norm_num`/`linear_combination` rather than surd manipulation.

## Verification

```
#print axioms two_distance_examples
  → [propext, Classical.choice, Quot.sound]   -- foundational only; 0 real axioms
```

Compiled clean (0 errors/warnings) with Lean v4.26.0 + Mathlib. `199` lines, 10 theorems/lemmas, 15 defs.

Scope note: this does **not** close Erdős #659 — the full six-configuration classification and the Moree–Osburn density statement remain open. It verifies the concrete realizations that ground the classification skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)