### PR TITLE
Enrich Sophie Germain / Mersenne divisor entry: add 7 annotations (was 0)

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "ecs-oq010301-intro",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "Sophie Germain primes and Mersenne divisors",
+    "content": "The module docstring states the goal: if p ≡ 3 (mod 4) is prime and q = 2p+1 is also prime (making p a Sophie Germain prime of this residue class), then q divides the Mersenne number M_p = 2^p − 1. The mechanism chains three classical facts: a residue computation (p ≡ 3 mod 4 ⟹ q ≡ 7 mod 8), the second supplement to quadratic reciprocity (q ≡ 7 mod 8 ⟹ 2 is a square mod q), and Fermat's little theorem (2^p = x^(q−1) = 1 in ZMod q). This is the classical reason 23 ∣ 2^11−1, 47 ∣ 2^23−1, etc., and shows those Mersenne numbers are composite.",
+    "mathContext": "$p\\equiv 3\\pmod 4,\\ q=2p+1\\text{ prime}\\ \\Rightarrow\\ q\\mid 2^p-1$. Here $2p=q-1$, so a square root $x$ of $2$ mod $q$ gives $2^p=(x^2)^p=x^{q-1}=1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Sophie Germain prime",
+      "Mersenne number",
+      "quadratic residue",
+      "quadratic reciprocity",
+      "Fermat's little theorem"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "primes",
+      "quadratic residues"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-qmod8",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 49
+    },
+    "type": "technique",
+    "title": "Residue step: p ≡ 3 (mod 4) forces q ≡ 7 (mod 8)",
+    "content": "The first link in the chain is pure arithmetic: if p ≡ 3 (mod 4) then q = 2p+1 ≡ 2·3+1 = 7 (mod 8). Lean discharges this entirely with `omega`, the linear-arithmetic decision procedure, which handles the mod-4-to-mod-8 lifting without any manual case analysis. Landing q in the residue class 7 mod 8 is exactly what the next step needs.",
+    "mathContext": "$p\\equiv 3\\pmod 4\\Rightarrow 2p+1\\equiv 7\\pmod 8$ (since $2\\cdot 3+1=7$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "modular arithmetic",
+      "residue classes",
+      "Presburger arithmetic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "the omega tactic"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-twosq",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 55
+    },
+    "type": "technique",
+    "title": "Second supplement: 2 is a quadratic residue mod q",
+    "content": "This applies the second supplement to quadratic reciprocity, IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 — the very result formalized in the parent entry euler-criterion-squares-oq-01-oq-03. Since q ≡ 7 (mod 8) lands in the right branch, `ZMod.exists_sq_eq_two_iff` yields that 2 is a square in ZMod q. The side condition q ≠ 2 (needed because the criterion is stated for odd primes) again falls to `omega`.",
+    "mathContext": "$2\\text{ is a QR mod }q \\iff q\\equiv \\pm 1\\pmod 8$; here $q\\equiv 7\\equiv -1\\pmod 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "second supplement",
+      "quadratic reciprocity",
+      "Legendre symbol",
+      "quadratic residues"
+    ],
+    "prerequisites": [
+      "quadratic residues",
+      "ZMod",
+      "Legendre symbol"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-main",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "Main theorem: q divides the Mersenne number 2^p − 1",
+    "content": "The heart of the argument. Having a square root x with 2 = x² in ZMod q, the proof first shows x ≠ 0 (otherwise 2 = 0 in ZMod q, forcing q ∣ 2, impossible for q ≥ 5). Then Fermat's little theorem in the form `ZMod.pow_card_sub_one_eq_one` gives x^(q−1) = 1 for the nonzero x. Since 2p = q − 1, we get 2^p = (x²)^p = x^(2p) = x^(q−1) = 1 in ZMod q. Finally the ℕ-level divisibility q ∣ 2^p − 1 is recovered by casting: (2^p − 1 : ZMod q) = 0 via `ZMod.natCast_eq_zero_iff`, with `Nat.cast_sub` handling the truncated subtraction.",
+    "mathContext": "$2=x^2$ in $\\mathbb{Z}/q$, $x\\neq 0$; Fermat gives $x^{q-1}=1$, and $2p=q-1$ yields $2^p=x^{2p}=1$, so $q\\mid 2^p-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "cyclic group of units",
+      "quadratic residues",
+      "natural-number casts"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Fermat's little theorem",
+      "group theory"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-gap",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 97
+    },
+    "type": "technique",
+    "title": "Linear-vs-exponential gap: 2p + 2 < 2^p for p ≥ 5",
+    "content": "A supporting lemma establishing that the candidate divisor q = 2p+1 is strictly smaller than the Mersenne number 2^p − 1 once p ≥ 5. The bound 2p + 2 < 2^p is proved by induction on p: base cases p < 5 are checked directly (`interval_cases` + `norm_num`/`omega`), and the inductive step uses 2^(n+1) = 2^n + 2^n so that the exponential outruns the linear term. This is what makes q a *proper* divisor.",
+    "mathContext": "$2p+2<2^p$ for $p\\ge 5$, proved by induction using $2^{n+1}=2^n+2^n$; hence $q=2p+1<2^p-1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "mathematical induction",
+      "exponential growth",
+      "interval_cases"
+    ],
+    "prerequisites": [
+      "induction",
+      "inequalities",
+      "natural-number arithmetic"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-corollary",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 99,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "Corollary: the Mersenne number is composite",
+    "content": "Combining the divisibility theorem with the size gap shows 2^p − 1 is composite for p ≥ 5 in this class. If 2^p − 1 were prime, then its divisor q = 2p+1 would have to equal 1 or 2^p − 1 (by `Nat.Prime.eq_one_or_self_of_dvd`); the first is absurd (q ≥ 11) and the second contradicts 2p + 2 < 2^p. Both branches close by `omega`. This gives an infinite family of provably composite Mersenne numbers, conditional only on q = 2p+1 being prime.",
+    "mathContext": "If $2^p-1$ prime and $q\\mid 2^p-1$ then $q\\in\\{1,2^p-1\\}$; both fail for $p\\ge 5$, so $2^p-1$ is composite.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Mersenne primes",
+      "compositeness",
+      "proper divisor",
+      "Sophie Germain prime"
+    ],
+    "prerequisites": [
+      "primes",
+      "divisibility",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "ecs-oq010301-examples",
+    "proofId": "euler-criterion-squares-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 128
+    },
+    "type": "context",
+    "title": "Concrete instances: 23 ∣ 2^11−1, 47 ∣ 2^23−1, 167 ∣ 2^83−1",
+    "content": "The file closes with machine-checked instances: 23 ∣ 2^11−1 (= 2047 = 23·89), 47 ∣ 2^23−1, and 167 ∣ 2^83−1, plus a compositeness witness ¬Prime(2^11−1). Each is discharged by applying `dvd_mersenne`/`mersenne_not_prime` with `norm_num` verifying the three primality/residue hypotheses. These make the abstract theorem tangible and double as regression tests for the general result.",
+    "mathContext": "$p=11\\Rightarrow 23\\mid 2^{11}-1$; $p=23\\Rightarrow 47\\mid 2^{23}-1$; $p=83\\Rightarrow 167\\mid 2^{83}-1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Mersenne numbers",
+      "worked examples",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "primes"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-03-oq-01`.

This entry had **no** `annotations.json`. Authored one covering the full file (lines 3-128):

- Docstring framing (Sophie Germain primes → Mersenne divisors)
- Residue step `p ≡ 3 (mod 4) ⟹ q ≡ 7 (mod 8)`
- Second-supplement application (`2` is a QR mod `q`)
- Main theorem `q ∣ 2^p − 1` via Fermat's little theorem
- Linear-vs-exponential gap lemma (`2p+2 < 2^p`)
- Compositeness corollary
- Concrete examples (23 ∣ 2^11−1, etc.)

All 7 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. meta.json unchanged.