### PR TITLE
Enrich Euler's converse (even perfect numbers): add 8 annotations (was 0)

### DIFF
--- a/src/data/proofs/sum-of-divisors-oq-02/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-02/annotations.json
@@ -1,0 +1,186 @@
+[
+  {
+    "id": "sod-oq02-intro",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "context",
+    "title": "Euler's converse for even perfect numbers: the six-step skeleton",
+    "content": "The docstring lays out the goal and strategy. Euler (1747) proved the converse of Euclid's construction: every even perfect number n has the form 2^k·(2^(k+1)−1) with 2^(k+1)−1 a Mersenne prime. Mathlib's Archive proves this in one block; the gallery value here is a named six-step decomposition exposing the algebraic skeleton — σ-multiplicativity, σ(2^k)=M_{k+1}, the perfect equation M_{k+1}·σ(m)=2^(k+1)·m, the divisibility M_{k+1}∣m, the identity σ(m)=m+c, and a two-divisor argument forcing c=1 and m prime. The Archive is used only for the 2-adic split and σ(2^k); Step 6 and the capstone's bound-chasing are self-contained.",
+    "mathContext": "Perfect: $\\sigma(n)=2n$. Euclid–Euler: $n$ even perfect $\\iff n=2^k(2^{k+1}-1)$ with $2^{k+1}-1$ (a Mersenne number $M_{k+1}$) prime.",
+    "significance": "context",
+    "relatedConcepts": [
+      "perfect numbers",
+      "Mersenne primes",
+      "Euclid–Euler theorem",
+      "sum-of-divisors function",
+      "multiplicative functions"
+    ],
+    "prerequisites": [
+      "number theory",
+      "divisor functions",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "sod-oq02-step1",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "Step 1: σ is multiplicative on the coprime split 2^k · m",
+    "content": "Because m is odd, gcd(2^k, m) = 1, so the multiplicativity of σ gives σ(2^k·m) = σ(2^k)·σ(m). The proof is term-mode: `isMultiplicative_sigma.map_mul_of_coprime` needs a coprimality proof, built from `Odd.coprime_two_right hm_odd : Coprime m 2`, symmetrized to `Coprime 2 m`, then raised by `.pow_left k` to `Coprime (2^k) m`. σ being multiplicative (not completely multiplicative) is exactly why the coprime hypothesis is required.",
+    "mathContext": "$\\gcd(2^k,m)=1\\Rightarrow \\sigma(2^k m)=\\sigma(2^k)\\sigma(m)$; multiplicativity of $\\sigma$ over coprime arguments.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative functions",
+      "coprimality",
+      "sum-of-divisors function"
+    ],
+    "prerequisites": [
+      "arithmetic functions",
+      "gcd and coprimality"
+    ]
+  },
+  {
+    "id": "sod-oq02-step2",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 83
+    },
+    "type": "definition",
+    "title": "Step 2: σ(2^k) = M_{k+1} = 2^(k+1) − 1",
+    "content": "The sum of divisors of a power of two is a Mersenne number: σ(2^k) = 1 + 2 + ⋯ + 2^k = 2^(k+1) − 1 = M_{k+1} (a finite geometric series). This step is a direct alias of the Archive lemma `Theorems100.Nat.sigma_two_pow_eq_mersenne_succ`. It is the algebraic bridge that makes Mersenne numbers appear in the even-perfect classification at all.",
+    "mathContext": "$\\sigma(2^k)=\\sum_{j=0}^{k}2^j=2^{k+1}-1=M_{k+1}$ (geometric series).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Mersenne numbers",
+      "geometric series",
+      "sum-of-divisors function"
+    ],
+    "prerequisites": [
+      "geometric series",
+      "divisor functions"
+    ]
+  },
+  {
+    "id": "sod-oq02-step3",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Step 3: the perfect equation becomes M_{k+1}·σ(m) = 2^(k+1)·m",
+    "content": "This turns the definition of perfection into a usable identity. Bridging `Perfect` to σ(2^k·m) = 2·(2^k·m) via `Nat.perfect_iff_sum_divisors_eq_two_mul` and `sigma_one_apply`, then substituting Steps 1 and 2 on the left, and collapsing 2·2^k = 2^(k+1) with `← mul_assoc; ← pow_succ'`, yields M_{k+1}·σ(m) = 2^(k+1)·m. This single equation drives the remaining structural deductions.",
+    "mathContext": "$\\sigma(2^k m)=2\\cdot 2^k m$ and $\\sigma(2^k m)=M_{k+1}\\sigma(m)$ give $M_{k+1}\\,\\sigma(m)=2^{k+1}m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect numbers",
+      "Mersenne numbers",
+      "algebraic manipulation"
+    ],
+    "prerequisites": [
+      "divisor functions",
+      "natural-number arithmetic"
+    ]
+  },
+  {
+    "id": "sod-oq02-step4",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 122
+    },
+    "type": "technique",
+    "title": "Step 4: the Mersenne factor divides the odd part, M_{k+1} ∣ m",
+    "content": "Since M_{k+1} = 2^(k+1) − 1 is odd, it is coprime to 2^(k+1). From M_{k+1}·σ(m) = 2^(k+1)·m we read off M_{k+1} ∣ 2^(k+1)·m, and coprimality lets us cancel the 2-power: M_{k+1} ∣ m. Term-mode: `mersenne_odd` (via simp) gives oddness, `Odd.coprime_two_right` then `.pow_right (k+1)` builds `Coprime (M_{k+1}) (2^(k+1))`, `Dvd.intro` packages the divisibility, and `.dvd_of_dvd_mul_left` finishes.",
+    "mathContext": "$M_{k+1}$ odd $\\Rightarrow \\gcd(M_{k+1},2^{k+1})=1$; with $M_{k+1}\\mid 2^{k+1}m$ this forces $M_{k+1}\\mid m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprimality",
+      "divisibility",
+      "Mersenne numbers",
+      "Euclid's lemma"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "gcd and coprimality"
+    ]
+  },
+  {
+    "id": "sod-oq02-step5",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 150
+    },
+    "type": "technique",
+    "title": "Step 5: substituting m = M_{k+1}·c gives σ(m) = m + c",
+    "content": "Writing m = M_{k+1}·c (from Step 4) and using 2^(k+1) = M_{k+1} + 1, the right side 2^(k+1)·m = (M_{k+1}+1)·m = M_{k+1}·m + m, where the trailing m equals M_{k+1}·c. So the Step-3 equation reads M_{k+1}·σ(m) = M_{k+1}·(m + c); cancelling the positive factor M_{k+1} (`Nat.eq_of_mul_eq_mul_left`, positivity from `mersenne_pos`) yields σ(m) = m + c. The cofactor c is the seed of the two-divisor endgame.",
+    "mathContext": "$m=M_{k+1}c$, $2^{k+1}=M_{k+1}+1$; then $M_{k+1}\\sigma(m)=M_{k+1}(m+c)$, so $\\sigma(m)=m+c$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cancellation",
+      "Mersenne numbers",
+      "sum-of-divisors function"
+    ],
+    "prerequisites": [
+      "natural-number arithmetic",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "sod-oq02-step6",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 152,
+      "endLine": 173
+    },
+    "type": "insight",
+    "title": "Step 6: two-divisor analysis forces c = 1 and m prime",
+    "content": "The heart of the argument. Splitting σ(m) = (sum of proper divisors) + m against σ(m) = m + c shows the proper-divisor sum equals c. Because c ∣ m, that proper-divisor sum divides m, and `Nat.sum_properDivisors_dvd` forces a self-dividing proper-divisor sum to be either 1 or m. The m-branch would give c = m, contradicting c < m; the 1-branch gives c = 1, and `Nat.sum_properDivisors_eq_one_iff_prime` characterizes proper-divisor-sum-one as exactly the primes, so m is prime.",
+    "mathContext": "$\\sum_{d\\mid m,\\,d<m}d=c$; a divisor of $m$ equal to this sum is $1$ or $m$. $c<m$ rules out $m$, so $c=1$ and $m$ prime ($\\sum_{d<m}d=1$).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "proper divisors",
+      "primality",
+      "perfect numbers",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "divisor functions",
+      "primality",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "sod-oq02-capstone",
+    "proofId": "sum-of-divisors-oq-02",
+    "range": {
+      "startLine": 175,
+      "endLine": 226
+    },
+    "type": "insight",
+    "title": "Capstone: assembling Steps 1–6 into Euler's converse",
+    "content": "The top-level theorem chains everything. The Archive's `eq_two_pow_mul_odd` performs the 2-adic split n = 2^k·m with m odd; the proof then derives the bounds Step 6 needs — m > 1 (else σ(m) = 1 forces c = 0, so m = 0), k ≠ 0 (else n = m is odd, contradicting evenness), M_{k+1} > 1 (since 2^(k+1) ≥ 4), and c < m — before invoking Steps 3–6 to conclude m = M_{k+1} is prime and n = 2^k·M_{k+1}. This is Euclid's construction run in reverse.",
+    "mathContext": "Even perfect $n=2^k m$ ($m$ odd) $\\Rightarrow k\\ge 1$, $m>1$, $m=M_{k+1}$ prime, so $n=2^k(2^{k+1}-1)$ with $2^{k+1}-1$ a Mersenne prime.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euclid–Euler theorem",
+      "perfect numbers",
+      "Mersenne primes",
+      "2-adic valuation"
+    ],
+    "prerequisites": [
+      "number theory",
+      "perfect numbers",
+      "primality"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sum-of-divisors-oq-02`.

This entry had **no** `annotations.json`. Authored one covering the full file (lines 1-226), one annotation per element of the named six-step decomposition of Euler's converse for even perfect numbers, plus the docstring overview and the capstone:

1. σ-multiplicativity on the coprime split 2^k·m
2. σ(2^k) = M_{k+1} = 2^(k+1)−1
3. Perfect equation → M_{k+1}·σ(m) = 2^(k+1)·m
4. M_{k+1} ∣ m (Mersenne factor divides odd part)
5. σ(m) = m + c via substitution
6. Two-divisor analysis forces c = 1 and m prime
7. Capstone assembling the Euclid–Euler converse

All 8 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. meta.json unchanged.