### PR TITLE
Enrich Brahmagupta–Fibonacci / sums of two squares: add 7 annotations (was 0)

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-09/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-09/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "fts-oq09-intro",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 5,
+      "endLine": 47
+    },
+    "type": "context",
+    "title": "Brahmagupta–Fibonacci identity as Gaussian norm multiplicativity",
+    "content": "The docstring frames the entry. Fermat's two-square theorem says which *primes* are sums of two squares (p = 2 or p ≡ 1 mod 4); extending that to composites rests on one structural fact — that 'is a sum of two squares' is closed under multiplication. This file formalizes exactly that building block: the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² in both branches, the resulting closure over ℤ and ℕ, and the conceptual source — the identity *is* the multiplicativity of the Gaussian-integer norm N(a+bi) = a²+b². The two branches correspond to multiplying by w versus its conjugate w̄, explaining why a product generically has two distinct representations.",
+    "mathContext": "$(a^2+b^2)(c^2+d^2)=(ac-bd)^2+(ad+bc)^2$; equivalently $N(z)N(w)=N(zw)$ for $z=a+bi$, $w=c+di$ in $\\mathbb{Z}[i]$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Fermat's two-square theorem",
+      "Brahmagupta–Fibonacci identity",
+      "Gaussian integers",
+      "norm multiplicativity",
+      "sums of two squares"
+    ],
+    "prerequisites": [
+      "number theory",
+      "commutative rings",
+      "complex numbers"
+    ]
+  },
+  {
+    "id": "fts-oq09-identity",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 51,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "The identity itself: a pure `ring` fact in any commutative ring",
+    "content": "The Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² is stated over an arbitrary commutative ring R and proved by a single call to `ring`. Its generality is the point: nothing about integers or positivity is used — it is a polynomial identity, so it holds in ℤ, ℚ, ℝ, ℤ[i], and beyond. This one line is the algebraic engine behind everything downstream.",
+    "mathContext": "$(a^2+b^2)(c^2+d^2)=(ac-bd)^2+(ad+bc)^2$ as an identity in $R[a,b,c,d]$; discharged by `ring`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial identities",
+      "commutative rings",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "commutative ring axioms",
+      "polynomial algebra"
+    ]
+  },
+  {
+    "id": "fts-oq09-sister",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 60,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "Sister form: conjugating the second factor gives the other representation",
+    "content": "Replacing d by −d yields the sister identity (a²+b²)(c²+d²) = (ac+bd)² + (ad−bc)². Because the two branches use w and its conjugate w̄, they give the (generically two) distinct ways of writing the product as a sum of two squares — e.g. 65 = 1²+8² = 4²+7². Like the first, it is proved by `ring`.",
+    "mathContext": "$(a^2+b^2)(c^2+d^2)=(ac+bd)^2+(ad-bc)^2$, obtained via $d\\mapsto -d$; corresponds to multiplying by $\\bar w$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conjugation",
+      "distinct representations",
+      "Brahmagupta–Fibonacci identity"
+    ],
+    "prerequisites": [
+      "polynomial algebra",
+      "complex conjugation"
+    ]
+  },
+  {
+    "id": "fts-oq09-intclosure",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 67,
+      "endLine": 81
+    },
+    "type": "insight",
+    "title": "Closure over ℤ: sums of two squares form a submonoid",
+    "content": "Defining IsSumSq n := ∃ a b : ℤ, n = a² + b², the identity gives IsSumSq.mul: the product of two sums of two squares is again one — just substitute the four witnesses and apply `brahmagupta_fibonacci`. Together with IsSumSq.one (1 = 1² + 0²), this makes the sums of two integer squares a multiplicative submonoid of ℤ. This closure is the exact fact needed to lift Fermat's prime characterization to composites.",
+    "mathContext": "$m=a^2+b^2,\\ n=c^2+d^2 \\Rightarrow mn=(ac-bd)^2+(ad+bc)^2$; with $1=1^2+0^2$, closure under $\\times$ gives a submonoid.",
+    "significance": "key",
+    "relatedConcepts": [
+      "submonoid",
+      "closure under multiplication",
+      "sums of two squares",
+      "Fermat's two-square theorem"
+    ],
+    "prerequisites": [
+      "monoids",
+      "number theory",
+      "existential witnesses"
+    ]
+  },
+  {
+    "id": "fts-oq09-natbridge",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 83,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "The classical ℕ statement, bridged to ℤ via natAbs",
+    "content": "The textbook statement is about natural numbers. IsSumSqNat n := ∃ a b : ℕ, n = a² + b², and isSumSqNat_iff shows a natural number is a sum of two natural squares iff it is a sum of two integer squares — signs are immaterial since a² = |a|² (`sq_abs` after `Int.natCast_natAbs`). IsSumSqNat.mul then follows from the integer closure by rewriting through the bridge and `push_cast`. This keeps the classical statement honest while reusing the ℤ machinery.",
+    "mathContext": "$\\mathrm{IsSumSqNat}(n)\\iff\\mathrm{IsSumSq}(n:\\mathbb{Z})$ via $a^2=|a|^2$; then $\\mathbb{N}$-closure reduces to $\\mathbb{Z}$-closure.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "natural vs integer squares",
+      "absolute value",
+      "casting",
+      "closure under multiplication"
+    ],
+    "prerequisites": [
+      "natural numbers",
+      "integer casts",
+      "Int.natAbs"
+    ]
+  },
+  {
+    "id": "fts-oq09-gaussian",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 108,
+      "endLine": 132
+    },
+    "type": "insight",
+    "title": "The Gaussian-norm reading: Brahmagupta = N(zw) = N(z)·N(w)",
+    "content": "The conceptual heart. Since GaussianInt = ℤ√(−1), the norm is N(z) = z.re² + z.im² (`gaussianInt_norm_eq`, from `Zsqrtd.norm_def`). Then isSumSq_iff_gaussianNorm shows IsSumSq n ↔ ∃ z : ℤ[i], N z = n — being a sum of two squares is exactly being a Gaussian norm. Re-deriving IsSumSq.mul' from `Zsqrtd.norm_mul` (N(zw) = N(z)·N(w)) exhibits the Brahmagupta–Fibonacci identity as the coordinate expression of the norm being a monoid homomorphism. This is why the identity looks 'magical' in ℤ but is structural in ℤ[i].",
+    "mathContext": "$N(a+bi)=a^2+b^2$; $\\mathrm{IsSumSq}(n)\\iff \\exists z\\in\\mathbb{Z}[i],\\,N(z)=n$; and $N(zw)=N(z)N(w)$ *is* the identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian integers",
+      "norm form",
+      "norm multiplicativity",
+      "ring homomorphism",
+      "Zsqrtd"
+    ],
+    "prerequisites": [
+      "Gaussian integers",
+      "norms of quadratic rings",
+      "monoid homomorphisms"
+    ]
+  },
+  {
+    "id": "fts-oq09-examples",
+    "proofId": "fermat-two-squares-oq-09",
+    "range": {
+      "startLine": 134,
+      "endLine": 143
+    },
+    "type": "context",
+    "title": "Concrete verifications: 5·13 = 65 = 1²+8² = 4²+7²",
+    "content": "Machine-checked instances make the two branches tangible: 5 = 1²+2² and 13 = 2²+3² multiply to 65, which the two identity branches express as 1²+8² and 4²+7². Each is closed by `decide`. These double as regression tests and illustrate the generic 'two distinct representations' phenomenon that the sister identity produces.",
+    "mathContext": "$5\\cdot 13=65$; branch 1 $\\to 1^2+8^2$, branch 2 $\\to 4^2+7^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked examples",
+      "distinct representations",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "arithmetic",
+      "sums of two squares"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fermat-two-squares-oq-09`.

This entry had **no** `annotations.json`. Authored one covering the full file (lines 5-143):

- Docstring framing (why closure under × extends Fermat's prime characterization to composites)
- The Brahmagupta–Fibonacci identity (a pure `ring` fact over any commutative ring)
- Its sister form (conjugation → the second representation)
- Closure over ℤ (sums of two squares form a submonoid)
- The classical ℕ statement bridged to ℤ via `natAbs`
- The Gaussian-norm reading: the identity **is** N(zw) = N(z)·N(w) (`Zsqrtd.norm_mul`)
- Concrete verifications (65 = 1²+8² = 4²+7²)

All 7 annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. meta.json unchanged.