### PR TITLE
Enrich Erdős #1065 uniqueness entry: 3→5 annotations, cover docstring

### DIFF
--- a/src/data/proofs/erdos-1065-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1065-oq-01/annotations.json
@@ -1,5 +1,52 @@
 [
   {
+    "id": "e1065-oq01-problem",
+    "proofId": "erdos-1065-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 16
+    },
+    "type": "context",
+    "title": "Erdős #1065 and the uniqueness fact it rests on",
+    "content": "Erdős Problem #1065 asks whether there are infinitely many primes of the form 2^k·q + 1 with q an odd prime and k ≥ 1. That question is open; the parent files (erdos-1065, erdos-1065-incomplete-01) build the twoVal/oddPart machinery for such 'form-A' primes. This child isolates and fully verifies the elementary but essential structural fact underpinning every such argument: if 2^a·m = 2^b·n with m, n odd, then a = b and m = n. In other words, the decomposition of a natural number into (power of two)·(odd part) is unique.",
+    "mathContext": "$2^a m = 2^b n$ with $m,n$ odd $\\Rightarrow a=b\\ \\wedge\\ m=n$; equivalently every $n>0$ has a unique $2^{v_2(n)}\\cdot(\\text{odd})$ form.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Erdős problems",
+      "primes of special form",
+      "2-adic decomposition",
+      "odd part"
+    ],
+    "prerequisites": [
+      "number theory",
+      "prime numbers"
+    ]
+  },
+  {
+    "id": "e1065-oq01-mechanism",
+    "proofId": "erdos-1065-oq-01",
+    "range": {
+      "startLine": 17,
+      "endLine": 28
+    },
+    "type": "insight",
+    "title": "Mechanism: the 2-adic valuation reads off the exponent",
+    "content": "The proof strategy is to extract the exponent via the 2-adic valuation. Since an odd m contributes no factor of 2, v₂(2^a·m) = a (`factorization_two_pow_mul_odd`). Applying this to both sides of 2^a·m = 2^b·n forces a = b, and cancelling the common 2^a then gives m = n. The payoff corollary formA_repr_unique states that the pair (k, q) in p = 2^k·q + 1 (with q odd) is determined by p — the representation is unique, which is exactly what the parent's counting arguments need.",
+    "mathContext": "$v_2(2^a m)=a$ for odd $m$; so $2^a m=2^b n\\Rightarrow a=b$, then cancel $2^a$ to get $m=n$. Hence $(k,q)$ in $p=2^kq+1$ is unique.",
+    "significance": "key",
+    "relatedConcepts": [
+      "2-adic valuation",
+      "Nat.factorization",
+      "cancellation",
+      "unique representation"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "factorization",
+      "divisibility"
+    ]
+  },
+  {
     "id": "ann-e1065oq01-valuation",
     "proofId": "erdos-1065-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `erdos-1065-oq-01`.

The module docstring (Erdős #1065 problem framing + the isolated 2^k·q uniqueness fact) was uncovered (3 annotations, 59%). Added two annotations:

- **Erdős #1065 and the uniqueness fact it rests on** — the open problem (infinitely many primes 2^k·q+1) and why unique (power-of-two)·(odd) decomposition matters.
- **Mechanism: the 2-adic valuation reads off the exponent** — v₂(2^a·m) = a for odd m ⟹ a=b, m=n; corollary formA_repr_unique.

Now 5 annotations, ~89% coverage; three existing annotations preserved. All carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.