### PR TITLE
research(mean-value-theorem-oq-06): signed two-sided derivative-bound increment sandwich [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ06.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ06.lean
@@ -1,0 +1,157 @@
+import Mathlib.Analysis.Calculus.Deriv.MeanValue
+import Mathlib.Analysis.Calculus.MeanValue
+import Mathlib.Analysis.Convex.Basic
+
+/-
+# Two-Sided Derivative Bounds Sandwich the Increment
+
+## What This Proves
+
+This is the **signed, two-sided quantitative form of the Mean Value Theorem**.
+If `f` is continuous on `[a, b]` (with `a ≤ b`) and differentiable on `(a, b)`
+with its derivative pinned between two constants,
+
+  `m ≤ f'(x) ≤ M`  for all `x ∈ (a, b)`,
+
+then the total increment is sandwiched between the two linear predictions:
+
+  `m · (b - a) ≤ f(b) - f(a) ≤ M · (b - a)`.
+
+The parent `mean-value-theorem` gives the existence statement `f'(c) = slope`.
+The sibling `mean-value-theorem-oq-03` proves only the *absolute*, one-sided norm
+bound `‖f(b) - f(a)‖ ≤ C(b - a)`, which discards sign and gives no lower bound.
+This child keeps the sign and both bounds, and then specializes:
+
+* `m > 0` forces a strict increase (`f a < f b`);
+* `M < 0` forces a strict decrease (`f b < f a`);
+* `0 ≤ m` gives ordinary monotonicity (`f a ≤ f b`);
+* `m = -C`, `M = C` recovers the scalar Lipschitz estimate
+  `|f(b) - f(a)| ≤ C(b - a)`.
+
+## Method
+
+Both halves are direct applications of the named Mathlib engines
+`Convex.mul_sub_le_image_sub_of_le_deriv` (lower bound) and
+`Convex.image_sub_le_mul_sub_of_deriv_le` (upper bound), instantiated at the
+convex set `D = Set.Icc a b`, whose interior is `Set.Ioo a b`
+(`interior_Icc`). Everything else is `linarith` / `abs_le` bookkeeping.
+
+0 sorries, 0 axioms (only `propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+open Set
+
+namespace MeanValueTheoremOQ06
+
+/-- **Two-sided increment sandwich.** If `f` is continuous on `[a, b]`, differentiable on
+`(a, b)`, and its derivative satisfies `m ≤ f' ≤ M` throughout `(a, b)`, then the increment
+`f b - f a` is trapped between `m (b - a)` and `M (b - a)`. This is the signed, quantitative
+Mean Value Theorem. -/
+theorem deriv_bounds_imply_increment_bounds {a b m M : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hm : ∀ x ∈ Set.Ioo a b, m ≤ deriv f x)
+    (hM : ∀ x ∈ Set.Ioo a b, deriv f x ≤ M) :
+    m * (b - a) ≤ f b - f a ∧ f b - f a ≤ M * (b - a) := by
+  -- Reshape the interior of `Icc a b` into `Ioo a b`.
+  rw [← interior_Icc] at hfd hm hM
+  refine ⟨?_, ?_⟩
+  · exact (convex_Icc a b).mul_sub_le_image_sub_of_le_deriv hfc hfd hm
+      a (left_mem_Icc.2 hab) b (right_mem_Icc.2 hab) hab
+  · exact (convex_Icc a b).image_sub_le_mul_sub_of_deriv_le hfc hfd hM
+      a (left_mem_Icc.2 hab) b (right_mem_Icc.2 hab) hab
+
+/-- The lower half in isolation: a lower derivative bound gives a lower increment bound. -/
+theorem le_increment_of_le_deriv {a b m : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hm : ∀ x ∈ Set.Ioo a b, m ≤ deriv f x) :
+    m * (b - a) ≤ f b - f a := by
+  rw [← interior_Icc] at hfd hm
+  exact (convex_Icc a b).mul_sub_le_image_sub_of_le_deriv hfc hfd hm
+    a (left_mem_Icc.2 hab) b (right_mem_Icc.2 hab) hab
+
+/-- The upper half in isolation: an upper derivative bound gives an upper increment bound. -/
+theorem increment_le_of_deriv_le {a b M : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hM : ∀ x ∈ Set.Ioo a b, deriv f x ≤ M) :
+    f b - f a ≤ M * (b - a) := by
+  rw [← interior_Icc] at hfd hM
+  exact (convex_Icc a b).image_sub_le_mul_sub_of_deriv_le hfc hfd hM
+    a (left_mem_Icc.2 hab) b (right_mem_Icc.2 hab) hab
+
+/-- **Lipschitz recovery.** A two-sided *absolute* bound `|f'| ≤ C` on `(a, b)` yields the
+scalar Lipschitz estimate `|f b - f a| ≤ C (b - a)`. This is the `m = -C`, `M = C`
+specialization; it matches the magnitude bound of the vector-valued sibling `oq-03`. -/
+theorem abs_increment_le_of_abs_deriv_le {a b C : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hC : ∀ x ∈ Set.Ioo a b, |deriv f x| ≤ C) :
+    |f b - f a| ≤ C * (b - a) := by
+  have hlo : ∀ x ∈ Set.Ioo a b, -C ≤ deriv f x := fun x hx => (abs_le.1 (hC x hx)).1
+  have hhi : ∀ x ∈ Set.Ioo a b, deriv f x ≤ C := fun x hx => (abs_le.1 (hC x hx)).2
+  obtain ⟨h1, h2⟩ := deriv_bounds_imply_increment_bounds hab hfc hfd hlo hhi
+  rw [abs_le]
+  constructor
+  · linarith [h1]
+  · linarith [h2]
+
+/-- **Strict increase gap.** A strictly positive lower derivative bound on `(a, b)` with
+`a < b` forces `f a < f b` (indeed `f b - f a ≥ m (b - a) > 0`). -/
+theorem lt_of_pos_deriv_lower_bound {a b m : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hm : ∀ x ∈ Set.Ioo a b, m ≤ deriv f x) (hmpos : 0 < m) :
+    f a < f b := by
+  have h1 : m * (b - a) ≤ f b - f a := le_increment_of_le_deriv hab.le hfc hfd hm
+  have : 0 < m * (b - a) := mul_pos hmpos (sub_pos.2 hab)
+  linarith
+
+/-- **Strict decrease gap.** A strictly negative upper derivative bound on `(a, b)` with
+`a < b` forces `f b < f a`. -/
+theorem gt_of_neg_deriv_upper_bound {a b M : ℝ} (hab : a < b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hM : ∀ x ∈ Set.Ioo a b, deriv f x ≤ M) (hMneg : M < 0) :
+    f b < f a := by
+  have h2 : f b - f a ≤ M * (b - a) := increment_le_of_deriv_le hab.le hfc hfd hM
+  have : M * (b - a) < 0 := mul_neg_of_neg_of_pos hMneg (sub_pos.2 hab)
+  linarith
+
+/-- **Monotone version.** A nonnegative lower derivative bound gives `f a ≤ f b`. -/
+theorem le_of_nonneg_deriv_lower_bound {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hm : ∀ x ∈ Set.Ioo a b, 0 ≤ deriv f x) :
+    f a ≤ f b := by
+  have h1 : (0 : ℝ) * (b - a) ≤ f b - f a := le_increment_of_le_deriv hab hfc hfd hm
+  simp only [zero_mul] at h1
+  linarith
+
+/-- **Antitone version.** A nonpositive upper derivative bound gives `f b ≤ f a`. -/
+theorem ge_of_nonpos_deriv_upper_bound {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc a b))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo a b))
+    (hM : ∀ x ∈ Set.Ioo a b, deriv f x ≤ 0) :
+    f b ≤ f a := by
+  have h2 : f b - f a ≤ (0 : ℝ) * (b - a) := increment_le_of_deriv_le hab hfc hfd hM
+  simp only [zero_mul] at h2
+  linarith
+
+/-- Worked example. For any `f` continuous on `[0, 2]`, differentiable on `(0, 2)`, whose
+derivative stays in `[1, 3]` throughout, the increment `f 2 - f 0` is pinned to `[2, 6]`.
+This is the theorem doing genuine numerical work: pointwise slope bounds `1 ≤ f' ≤ 3`
+become the global two-sided increment bound `2 ≤ f(2) - f(0) ≤ 6`. -/
+example {f : ℝ → ℝ}
+    (hfc : ContinuousOn f (Set.Icc 0 2))
+    (hfd : DifferentiableOn ℝ f (Set.Ioo 0 2))
+    (h1 : ∀ x ∈ Set.Ioo (0 : ℝ) 2, 1 ≤ deriv f x)
+    (h3 : ∀ x ∈ Set.Ioo (0 : ℝ) 2, deriv f x ≤ 3) :
+    2 ≤ f 2 - f 0 ∧ f 2 - f 0 ≤ 6 := by
+  obtain ⟨lo, hi⟩ := deriv_bounds_imply_increment_bounds (by norm_num) hfc hfd h1 h3
+  constructor
+  · linarith
+  · linarith
+
+end MeanValueTheoremOQ06

--- a/src/data/proofs/mean-value-theorem-oq-06/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-06/meta.json
@@ -1,0 +1,228 @@
+{
+  "id": "mean-value-theorem-oq-06",
+  "title": "Two-Sided Derivative Bounds Sandwich the Increment",
+  "slug": "mean-value-theorem-oq-06",
+  "description": "The signed, two-sided quantitative Mean Value Theorem: if f is continuous on [a,b] (a ≤ b), differentiable on (a,b), and m ≤ f'(x) ≤ M throughout, then m·(b-a) ≤ f(b)-f(a) ≤ M·(b-a). Unlike the sibling oq-03 vector-valued inequality (which gives only the absolute magnitude bound ‖f(b)-f(a)‖ ≤ C(b-a)), this keeps the sign and both bounds. Proves 8 theorems: the sandwich, its two one-sided halves, Lipschitz recovery |f(b)-f(a)| ≤ C(b-a), strict increase/decrease gaps, and monotone/antitone specializations, plus a worked numerical example. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lagrange (formalized in Lean 4 with Mathlib)",
+    "date": "1801",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "calculus",
+      "real-analysis",
+      "mean-value-theorem",
+      "derivative-bounds",
+      "monotonicity",
+      "Lipschitz",
+      "extension"
+    ],
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ06.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axioms": 0,
+    "theorems": 8,
+    "lines": 157,
+    "mathlibDependencies": [
+      {
+        "theorem": "Convex.mul_sub_le_image_sub_of_le_deriv",
+        "description": "If C ≤ f' on the interior of a convex set D, then C·(y-x) ≤ f(y)-f(x) for x ≤ y in D. Supplies the lower half of the sandwich.",
+        "module": "Mathlib.Analysis.Calculus.Deriv.MeanValue"
+      },
+      {
+        "theorem": "Convex.image_sub_le_mul_sub_of_deriv_le",
+        "description": "If f' ≤ C on the interior of a convex set D, then f(y)-f(x) ≤ C·(y-x) for x ≤ y in D. Supplies the upper half of the sandwich.",
+        "module": "Mathlib.Analysis.Calculus.Deriv.MeanValue"
+      },
+      {
+        "theorem": "interior_Icc",
+        "description": "interior (Set.Icc a b) = Set.Ioo a b, used to convert the (a,b)-hypotheses into the interior form the Convex.* engines expect.",
+        "module": "Mathlib.Topology.Order.DenselyOrdered"
+      },
+      {
+        "theorem": "convex_Icc",
+        "description": "The closed interval Set.Icc a b is convex, the domain D for the mean-value engines.",
+        "module": "Mathlib.Analysis.Convex.Basic"
+      },
+      {
+        "theorem": "abs_le",
+        "description": "|x| ≤ y ↔ -y ≤ x ∧ x ≤ y, used to package/unpack the absolute (Lipschitz) form.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "The signed two-sided increment sandwich m·(b-a) ≤ f(b)-f(a) ≤ M·(b-a) from pointwise bounds m ≤ f' ≤ M (not present as a single packaged lemma in Mathlib)",
+      "The two one-sided halves stated as reusable named lemmas over Icc/Ioo",
+      "Lipschitz recovery: |f'| ≤ C ⇒ |f(b)-f(a)| ≤ C(b-a) as the m=-C, M=C specialization, matching the magnitude bound of sibling oq-03",
+      "Strict increase gap: 0 < m ⇒ f(a) < f(b) on a<b",
+      "Strict decrease gap: M < 0 ⇒ f(b) < f(a) on a<b",
+      "Monotone and antitone specializations (0 ≤ f' ⇒ f a ≤ f b; f' ≤ 0 ⇒ f b ≤ f a)",
+      "Worked numerical example turning 1 ≤ f' ≤ 3 on (0,2) into 2 ≤ f(2)-f(0) ≤ 6"
+    ],
+    "historicalContext": "Lagrange (1801), building on Rolle (1691), stated the Mean Value Theorem as the existence of a point c ∈ (a,b) with f'(c) = (f(b)-f(a))/(b-a). A pervasive corollary in analysis textbooks is the quantitative sandwich form: bounding f' pointwise between two constants bounds the finite increment linearly. Where the sibling entry oq-03 pushes the MVT into vector-valued and Banach settings — where only the absolute inequality ‖f(b)-f(a)‖ ≤ C(b-a) survives — this entry stays on the real line and keeps the full signed information, recovering direction (strict monotonicity) and the scalar Lipschitz estimate as the symmetric special case.",
+    "dateAdded": "2026-07-02",
+    "parentProof": "mean-value-theorem",
+    "axiomCount": 0,
+    "lineCount": 157,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (dependency closure: propext, Classical.choice, Quot.sound only).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Mean Value Theorem, stated by **Lagrange** (1801) after **Rolle** (1691), asserts a point $c \\in (a,b)$ with $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Its most-used consequence in practice is not the existence of $c$ but the **quantitative sandwich**: if the slope $f'$ is trapped between constants $m$ and $M$, then so is the average slope $\\frac{f(b)-f(a)}{b-a}$, hence $m(b-a) \\le f(b)-f(a) \\le M(b-a)$. This is how one bounds a function's total change from bounds on its rate of change.",
+    "problemStatement": "**Open Question #6** from the MVT gallery: state and verify the signed, two-sided quantitative form of the Mean Value Theorem. Given $f$ continuous on $[a,b]$, differentiable on $(a,b)$, with $m \\le f'(x) \\le M$ throughout, prove $m(b-a) \\le f(b)-f(a) \\le M(b-a)$, and derive the direction-sensitive corollaries (strict monotonicity, Lipschitz recovery) that the sibling oq-03 norm inequality cannot express.",
+    "text": "If m ≤ f'(x) ≤ M on (a,b), the increment f(b)-f(a) is sandwiched between m(b-a) and M(b-a). This signed two-sided bound specializes to strict monotonicity when the derivative keeps a sign and to the scalar Lipschitz estimate |f(b)-f(a)| ≤ C(b-a) when m=-C, M=C.",
+    "proofStrategy": "Both halves reduce to named Mathlib mean-value engines once the interval is set up. We work over the convex set $D = \\mathrm{Icc}\\,a\\,b$; since $\\mathrm{interior}(\\mathrm{Icc}\\,a\\,b) = \\mathrm{Ioo}\\,a\\,b$ (`interior_Icc`), the pointwise hypotheses on $(a,b)$ are exactly the interior hypotheses the engines want. `Convex.mul_sub_le_image_sub_of_le_deriv` delivers the lower bound and `Convex.image_sub_le_mul_sub_of_deriv_le` the upper bound, both instantiated at the endpoints $a, b$. The corollaries follow by `linarith`/`abs_le`: the absolute (Lipschitz) form from $m=-C, M=C$; the strict gaps from multiplying a strict derivative bound by $b-a>0$; the monotone versions from $m=0$ or $M=0$.",
+    "keyInsights": [
+      "**Sign is the whole point.** The vector-valued sibling oq-03 gives only $\\|f(b)-f(a)\\| \\le C(b-a)$ — a magnitude with no direction. On $\\mathbb{R}$ the ordering lets us keep both a lower and an upper bound, so we learn not just how big the change is but which way it goes.",
+      "**Interior bookkeeping.** The Mathlib engines phrase their hypotheses on $\\mathrm{interior}\\,D$. For a closed interval that interior is exactly the open interval, so `rw [← interior_Icc]` turns the natural $(a,b)$ hypotheses into the required form with no loss.",
+      "**Lipschitz is the symmetric case.** Setting $m=-C$ and $M=C$ collapses the two-sided sandwich to $-C(b-a) \\le f(b)-f(a) \\le C(b-a)$, i.e. $|f(b)-f(a)| \\le C(b-a)$ — the scalar shadow of oq-03's norm bound.",
+      "**Strict from non-strict.** A strictly positive lower bound $m>0$ on a genuine interval $a<b$ makes $m(b-a)>0$, forcing $f(a)<f(b)$: the sandwich upgrades a weak inequality to strict monotonicity purely by positivity of the width.",
+      "**One theorem, many corollaries.** Monotone ($0 \\le f'$), antitone ($f' \\le 0$), strictly increasing, strictly decreasing, and Lipschitz are all one-line specializations of the single sandwich, illustrating how a well-chosen quantitative statement subsumes a family of qualitative ones."
+    ],
+    "prerequisites": [
+      "Derivatives on the real line (deriv, DifferentiableOn)",
+      "Continuity on a set (ContinuousOn) and closed/open intervals (Icc, Ioo)",
+      "Convex sets and interior of an interval (convex_Icc, interior_Icc)",
+      "Basic order arithmetic (linarith, abs_le, mul_pos)",
+      "Parent proof: Mean Value Theorem (scalar existence form)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview — The Increment Sandwich",
+      "summary": "Imports, file docstring, and namespace: states the signed two-sided MVT, contrasts it with the sibling oq-03 absolute norm bound, and lists the specializations (strict monotonicity, Lipschitz recovery).",
+      "startLine": 1,
+      "endLine": 45,
+      "mathContext": "Goal: from $m \\le f'(x) \\le M$ on $(a,b)$ deduce $m(b-a) \\le f(b)-f(a) \\le M(b-a)$. Everything is delegated to two Mathlib Convex.* mean-value engines over $D = \\mathrm{Icc}\\,a\\,b$."
+    },
+    {
+      "id": "main-sandwich",
+      "title": "Two-Sided Increment Sandwich",
+      "summary": "The central theorem deriv_bounds_imply_increment_bounds: continuity on [a,b], differentiability on (a,b), and m ≤ f' ≤ M give m(b-a) ≤ f(b)-f(a) ≤ M(b-a). Proof rewrites interior (Icc a b) = Ioo a b and applies the two Convex.* engines at the endpoints.",
+      "startLine": 46,
+      "endLine": 63,
+      "mathContext": "$m(b-a) \\le f(b)-f(a) \\le M(b-a)$: the average slope $\\frac{f(b)-f(a)}{b-a}$ inherits the pointwise bounds on $f'$ via the mean value theorem."
+    },
+    {
+      "id": "one-sided-halves",
+      "title": "The Two One-Sided Halves",
+      "summary": "le_increment_of_le_deriv (lower bound alone) and increment_le_of_deriv_le (upper bound alone), each stated as a reusable lemma so that only one derivative bound is needed when only one side is of interest.",
+      "startLine": 64,
+      "endLine": 83,
+      "mathContext": "Lower: $m \\le f' \\Rightarrow m(b-a) \\le f(b)-f(a)$. Upper: $f' \\le M \\Rightarrow f(b)-f(a) \\le M(b-a)$."
+    },
+    {
+      "id": "lipschitz-recovery",
+      "title": "Lipschitz Recovery",
+      "summary": "abs_increment_le_of_abs_deriv_le: an absolute derivative bound |f'| ≤ C on (a,b) yields |f(b)-f(a)| ≤ C(b-a), the m=-C, M=C specialization matching the magnitude bound of the vector-valued sibling oq-03.",
+      "startLine": 84,
+      "endLine": 99,
+      "mathContext": "$|f'| \\le C \\Rightarrow |f(b)-f(a)| \\le C(b-a)$: the symmetric special case, giving the scalar Lipschitz estimate."
+    },
+    {
+      "id": "strict-gaps",
+      "title": "Strict Increase and Decrease Gaps",
+      "summary": "lt_of_pos_deriv_lower_bound (0 < m ⇒ f a < f b) and gt_of_neg_deriv_upper_bound (M < 0 ⇒ f b < f a) on a genuine interval a < b: a strict derivative sign forces strict monotonic change, obtained by multiplying the bound by the positive width b-a.",
+      "startLine": 100,
+      "endLine": 121,
+      "mathContext": "$0 < m \\Rightarrow f(b)-f(a) \\ge m(b-a) > 0$; $M < 0 \\Rightarrow f(b)-f(a) \\le M(b-a) < 0$."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotone and Antitone Specializations",
+      "summary": "le_of_nonneg_deriv_lower_bound (0 ≤ f' ⇒ f a ≤ f b) and ge_of_nonpos_deriv_upper_bound (f' ≤ 0 ⇒ f b ≤ f a): the non-strict monotonicity corollaries as the m=0 and M=0 cases of the sandwich.",
+      "startLine": 122,
+      "endLine": 141,
+      "mathContext": "$0 \\le f' \\Rightarrow f(a) \\le f(b)$ and $f' \\le 0 \\Rightarrow f(b) \\le f(a)$: the endpoints of the family, with the derivative bound taken at zero."
+    },
+    {
+      "id": "worked-example",
+      "title": "Worked Numerical Example",
+      "summary": "For any f with 1 ≤ f' ≤ 3 on (0,2), the theorem pins 2 ≤ f(2)-f(0) ≤ 6 — pointwise slope bounds becoming a concrete global two-sided increment bound, closed by linarith.",
+      "startLine": 142,
+      "endLine": 157,
+      "mathContext": "$1 \\le f' \\le 3$ on $(0,2) \\Rightarrow 2 = 1\\cdot 2 \\le f(2)-f(0) \\le 3\\cdot 2 = 6$."
+    }
+  ],
+  "conclusion": {
+    "summary": "A compact, fully verified formalization (8 theorems, 0 sorries, 0 axioms) of the signed two-sided quantitative Mean Value Theorem, together with its one-sided halves, Lipschitz recovery, strict increase/decrease gaps, monotone/antitone specializations, and a worked numerical example. The core reduces to two named Mathlib mean-value engines; the corollaries are order-arithmetic.",
+    "implications": "**Complementary to oq-03.** Where the vector-valued sibling keeps only the magnitude $\\|f(b)-f(a)\\| \\le C(b-a)$, this scalar entry keeps the sign and both bounds, recovering direction and strict monotonicity that a norm bound cannot express.\n\nThe packaged sandwich and its named corollaries are directly reusable: bounding a real function's total change from bounds on its derivative is one of the most frequent estimates in analysis, and having it as a single lemma (plus its strict and Lipschitz variants) saves re-deriving the interior/convexity bookkeeping each time.",
+    "openQuestions": [
+      "Can the sandwich be stated in centered form, |f(b)-f(a) - ((m+M)/2)(b-a)| ≤ ((M-m)/2)(b-a), as a single symmetric bound?",
+      "Does the same two-sided packaging extend to bounds on higher derivatives via the Taylor–Lagrange remainder (sibling oq-02)?",
+      "Can the strict-gap corollaries be strengthened to a quantitative modulus of strict monotonicity over subintervals?"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "mean-value-theorem",
+        "relationship": "Parent proof — the scalar Mean Value Theorem whose quantitative two-sided corollary this entry formalizes."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Calculus.Deriv.MeanValue",
+      "Mathlib.Analysis.Calculus.MeanValue",
+      "Mathlib.Analysis.Convex.Basic"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "MeanValueTheoremOQ06",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/MeanValueTheoremOQ06.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "foundational",
+      "description": "The scalar Mean Value Theorem (existence of c with f'(c) = slope) is the engine behind the sandwich: bounding f' pointwise bounds the average slope f'(c), hence the increment."
+    },
+    {
+      "targetId": "mean-value-theorem-oq-03",
+      "relationship": "related",
+      "description": "Sibling: the vector-valued mean value INEQUALITY gives only the absolute magnitude bound ‖f(b)-f(a)‖ ≤ C(b-a). This entry is the signed scalar counterpart, and oq-03's norm bound is the m=-C, M=C special case of this sandwich."
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "related",
+      "description": "Taylor's theorem with the Lagrange remainder generalizes the increment sandwich to higher order; the two-sided bound here is the first-order (mean value) instance."
+    },
+    {
+      "targetId": "fundamental-theorem-calculus",
+      "relationship": "related",
+      "description": "Via FTC, f(b)-f(a) = ∫ f'; the sandwich m(b-a) ≤ f(b)-f(a) ≤ M(b-a) is the elementary bound ∫ of a function pinned between m and M."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Joseph-Louis Lagrange",
+      "title": "Leçons sur le calcul des fonctions",
+      "year": "1801",
+      "venue": "Paris",
+      "note": "Original statement of the (scalar) Mean Value Theorem underlying the increment sandwich."
+    },
+    {
+      "authors": "Walter Rudin",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "Theorem 5.10 and its corollaries: bounds on the derivative give two-sided bounds on the increment, and sign of the derivative gives monotonicity."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Mathematical Analysis",
+      "year": "1974",
+      "venue": "Addison-Wesley",
+      "note": "Section 5.9: quantitative consequences of the Mean Value Theorem, including Lipschitz and monotonicity estimates."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`mean-value-theorem-oq-06`** — "Two-Sided Derivative Bounds Sandwich the Increment", answering open question #6 of the Mean Value Theorem gallery.

**Result.** For `f` continuous on `[a,b]` (`a ≤ b`), differentiable on `(a,b)`, with `m ≤ f'(x) ≤ M` throughout,
$$m\,(b-a) \le f(b)-f(a) \le M\,(b-a).$$
This is the **signed, two-sided** quantitative form of the MVT. It complements sibling **oq-03** (the vector-valued mean value *inequality*, which keeps only the absolute magnitude `‖f(b)-f(a)‖ ≤ C(b-a)`): the scalar entry keeps the sign and both bounds, and recovers oq-03's estimate as the `m=-C, M=C` special case.

## Theorems (8, all 0-axiom)

| Theorem | Statement |
|---------|-----------|
| `deriv_bounds_imply_increment_bounds` | the sandwich `m(b-a) ≤ f(b)-f(a) ≤ M(b-a)` |
| `le_increment_of_le_deriv` / `increment_le_of_deriv_le` | the two one-sided halves |
| `abs_increment_le_of_abs_deriv_le` | Lipschitz recovery `|f'| ≤ C ⇒ |f(b)-f(a)| ≤ C(b-a)` |
| `lt_of_pos_deriv_lower_bound` / `gt_of_neg_deriv_upper_bound` | strict increase / decrease gaps |
| `le_of_nonneg_deriv_lower_bound` / `ge_of_nonpos_deriv_upper_bound` | monotone / antitone specializations |

Plus a worked numerical example: `1 ≤ f' ≤ 3` on `(0,2)` ⟹ `2 ≤ f(2)-f(0) ≤ 6`.

## Proof method

The core reduces to two named Mathlib engines — `Convex.mul_sub_le_image_sub_of_le_deriv` (lower) and `Convex.image_sub_le_mul_sub_of_deriv_le` (upper) — over the convex set `Icc a b`, using `interior_Icc` to turn the `(a,b)` hypotheses into the interior form the engines expect. Corollaries are `linarith` / `abs_le`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on all 8 theorems reports only `[propext, Classical.choice, Quot.sound]`.
- Built with `lake env lean`, Mathlib **v4.26.0**. `pnpm gallery:check-size` passes.
- `leanFile`: `Proofs/MeanValueTheoremOQ06.lean`, 157 lines, 8 theorems, 0 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)