### PR TITLE
research(erdos-490-oq-01): eliminate maxProd_exists axiom (3→2) + v4.26 drift repair

### DIFF
--- a/proofs/Proofs/Erdos490OQ01.lean
+++ b/proofs/Proofs/Erdos490OQ01.lean
@@ -18,7 +18,11 @@
   5. Structural analysis: cardinality bounds, trivial bound (§6)
 
   Sorry count: 0
-  Axiom count: 3 (Szemerédi bound, optimal example lower bound, maxProd existence)
+  Axiom count: 2 (Szemerédi bound, optimal example lower bound). `maxProd_exists` is now
+  a proved theorem: the maximum ranges over subsets of the finite set {1,...,N}, so the
+  achievable-value set is a nonempty finite set of naturals and we take its `Finset.max'`.
+  (Also repaired Mathlib v4.26 API drift: div_le_iff→div_le_iff₀, le_div_iff→le_div_iff₀,
+  Finset.card_Icc→Nat.card_Icc, Nat.cast_nonneg now needs its explicit argument.)
 -/
 
 import Mathlib
@@ -42,13 +46,62 @@ def HasDistinctProducts' (A B : Finset ℕ) : Prop :=
 -- § 2. The Maximum Product Size
 -- ============================================================================
 
-/-- The maximum of |A|·|B| over all valid pairs with distinct products in {1,...,N}.
-    We axiomatize its existence since the optimization is over finite sets. -/
-axiom maxProd_exists (N : ℕ) (hN : 2 ≤ N) :
-  ∃ M : ℕ, (∀ A B : Finset ℕ, IsSubsetUpTo' A N → IsSubsetUpTo' B N →
+/-- Membership bridge: `IsSubsetUpTo' A N` is exactly `A ∈ (Icc 1 N).powerset`. -/
+theorem isSubsetUpTo_iff_mem_powerset (A : Finset ℕ) (N : ℕ) :
+    IsSubsetUpTo' A N ↔ A ∈ (Finset.Icc 1 N).powerset := by
+  rw [Finset.mem_powerset, Finset.subset_iff]
+  constructor
+  · intro h a ha; exact Finset.mem_Icc.mpr (h a ha)
+  · intro h a ha; exact Finset.mem_Icc.mp (h ha)
+
+/-- The maximum of |A|·|B| over all valid pairs with distinct products in {1,...,N}
+    **exists** (previously an axiom). The optimization ranges over subsets of the finite
+    set `{1,...,N}`, so the value set is a nonempty finite set of naturals and we take its
+    `Finset.max'`. Nonemptiness comes from the valid pair `A = B = {1}`. -/
+theorem maxProd_exists (N : ℕ) (hN : 2 ≤ N) :
+    ∃ M : ℕ, (∀ A B : Finset ℕ, IsSubsetUpTo' A N → IsSubsetUpTo' B N →
       HasDistinctProducts' A B → A.card * B.card ≤ M) ∧
     (∃ A B : Finset ℕ, IsSubsetUpTo' A N ∧ IsSubsetUpTo' B N ∧
-      HasDistinctProducts' A B ∧ A.card * B.card = M)
+      HasDistinctProducts' A B ∧ A.card * B.card = M) := by
+  classical
+  -- All valid pairs live in the finite family of subsets of `{1,...,N}`.
+  set 𝒜 : Finset (Finset ℕ) := (Finset.Icc 1 N).powerset with h𝒜
+  -- The finite set of achievable products `|A|·|B|`.
+  set V : Finset ℕ :=
+    (((𝒜 ×ˢ 𝒜).filter (fun p => HasDistinctProducts' p.1 p.2)).image
+      (fun p => p.1.card * p.2.card)) with hV
+  -- `A = B = {1}` is a valid pair, so the value `1` is achievable and `V` is nonempty.
+  have h1mem : ({1} : Finset ℕ) ∈ 𝒜 := by
+    rw [h𝒜, ← isSubsetUpTo_iff_mem_powerset]
+    intro a ha
+    simp only [Finset.mem_singleton] at ha
+    subst ha; exact ⟨le_refl 1, by omega⟩
+  have hdist11 : HasDistinctProducts' ({1} : Finset ℕ) ({1} : Finset ℕ) := by
+    intro a₁ a₂ b₁ b₂ ha₁ ha₂ hb₁ hb₂ _
+    simp only [Finset.mem_singleton] at ha₁ ha₂ hb₁ hb₂
+    omega
+  have hVne : V.Nonempty := by
+    refine ⟨1, ?_⟩
+    rw [hV, Finset.mem_image]
+    refine ⟨({1}, {1}), ?_, by simp⟩
+    rw [Finset.mem_filter, Finset.mem_product]
+    exact ⟨⟨h1mem, h1mem⟩, hdist11⟩
+  refine ⟨V.max' hVne, ?_, ?_⟩
+  · -- upper bound: every valid pair contributes an element of `V`, hence ≤ max'
+    intro A B hA hB hd
+    refine Finset.le_max' V _ ?_
+    rw [hV, Finset.mem_image]
+    refine ⟨(A, B), ?_, rfl⟩
+    rw [Finset.mem_filter, Finset.mem_product]
+    exact ⟨⟨(isSubsetUpTo_iff_mem_powerset A N).mp hA,
+            (isSubsetUpTo_iff_mem_powerset B N).mp hB⟩, hd⟩
+  · -- achieved: `max'` is itself a member of `V`, coming from some valid pair
+    have hmax : V.max' hVne ∈ V := Finset.max'_mem V hVne
+    obtain ⟨⟨A, B⟩, hpmem, hval⟩ := Finset.mem_image.mp hmax
+    rw [Finset.mem_filter, Finset.mem_product] at hpmem
+    obtain ⟨⟨hA𝒜, hB𝒜⟩, hd⟩ := hpmem
+    exact ⟨A, B, (isSubsetUpTo_iff_mem_powerset A N).mpr hA𝒜,
+      (isSubsetUpTo_iff_mem_powerset B N).mpr hB𝒜, hd, hval⟩
 
 /-- The maximum product size for parameter N. -/
 noncomputable def maxProd (N : ℕ) (hN : 2 ≤ N) : ℕ :=
@@ -93,7 +146,7 @@ theorem productRatio_bounded_above :
   unfold productRatio'
   have hlog_pos : 0 < Real.log (N : ℝ) := Real.log_pos (by exact_mod_cast (show 1 < N by omega))
   have hN2_pos : (0 : ℝ) < (N : ℝ)^2 := by positivity
-  rw [div_le_iff hN2_pos]
+  rw [div_le_iff₀ hN2_pos]
   calc (maxProd N hN : ℝ) * Real.log ↑N
       = Real.log ↑N * (maxProd N hN : ℝ) := by ring
     _ ≤ Real.log ↑N * (C * ↑N ^ 2 / Real.log ↑N) := by
@@ -108,7 +161,7 @@ theorem productRatio_bounded_below :
   unfold productRatio'
   have hlog_pos : 0 < Real.log (N : ℝ) := Real.log_pos (by exact_mod_cast (show 1 < N by omega))
   have hN2_pos : (0 : ℝ) < (N : ℝ)^2 := by positivity
-  rw [le_div_iff hN2_pos]
+  rw [le_div_iff₀ hN2_pos]
   calc c * ↑N ^ 2
       = Real.log ↑N * (c * ↑N ^ 2 / Real.log ↑N) := by field_simp
     _ ≤ Real.log ↑N * (maxProd N hN : ℝ) := by
@@ -165,7 +218,7 @@ theorem productRatio_nonneg (N : ℕ) (hN : 2 ≤ N) :
   unfold productRatio'
   apply div_nonneg
   · apply mul_nonneg
-    · exact Nat.cast_nonneg
+    · exact Nat.cast_nonneg _
     · exact (Real.log_pos (by exact_mod_cast (show 1 < N by omega))).le
   · positivity
 
@@ -176,7 +229,7 @@ theorem card_le_of_subset_upto (A : Finset ℕ) (N : ℕ) (hA : IsSubsetUpTo' A 
         apply Finset.card_le_card
         intro a ha
         exact Finset.mem_Icc.mpr (hA a ha)
-    _ = N := by simp [Finset.card_Icc]
+    _ = N := by rw [Nat.card_Icc]; omega
 
 /-- maxProd(N) ≤ N² (trivial bound). -/
 theorem maxProd_le_sq (N : ℕ) (hN : 2 ≤ N) :

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -43,11 +43,11 @@
       "Proved: maxProd(N) ≤ N² (trivial bound from cardinality)",
       "Proved: full sandwich — positive constants c ≤ C bracket all ratios"
     ],
-    "axiomCount": 3,
-    "lineCount": 215,
-    "assumptions": "3 axioms: Szemerédi upper bound, optimal example lower bound, maxProd existence. All encode deep number-theoretic results.",
+    "axiomCount": 2,
+    "lineCount": 268,
+    "assumptions": "2 axioms (both deep number-theoretic results): the Szemerédi upper bound maxProd(N) ≤ C·N²/log N and the optimal-example lower bound maxProd(N) ≥ c·N²/log N. The former existence axiom `maxProd_exists` (that the maximum of |A||B| over valid pairs is attained) is now a proved theorem — the optimization ranges over subsets of the finite set {1,...,N}, so the achievable-value set is a nonempty finite Finset of naturals and the maximum is its Finset.max'. Fully machine-checked apart from the 2 stated axioms (#print axioms lists only those two plus propext/Classical.choice/Quot.sound).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 11,
     "definitionCount": 5
   },
   "sections": [
@@ -132,9 +132,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 215,
-    "axiomCount": 3,
-    "theoremCount": 9,
+    "lineCount": 268,
+    "axiomCount": 2,
+    "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos490OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Advances the gallery entry **erdos-490-oq-01** ("Does lim max|A||B|·log N/N² exist?") by **eliminating one axiom** and **repairing Mathlib v4.26 API drift** that had silently broken the file's build.

### Axiom eliminated: `maxProd_exists` (3 → 2 axioms)

The maximum of `|A|·|B|` over all valid pairs `A, B ⊆ {1,...,N}` with distinct products was previously **axiomatized** ("existence over finite sets"). It is now a **proved theorem**:

- Every valid `A` satisfies `IsSubsetUpTo' A N`, i.e. `A ∈ (Finset.Icc 1 N).powerset` — new bridge lemma `isSubsetUpTo_iff_mem_powerset`.
- The achievable-value set `V = image (|·₁|·|·₂|) (filter HasDistinctProducts' (𝒜 ×ˢ 𝒜))` is a nonempty finite `Finset ℕ`; the maximum is `V.max' hVne`.
- Nonemptiness from the valid pair `A = B = {1}`; upper bound via `Finset.le_max'`; attainment via `Finset.max'_mem`.

`#print axioms maxProd_exists = [propext, Classical.choice, Quot.sound]` — **0 problem axioms**.

### Mathlib v4.26 drift repair

The file did **not** compile on the current pin (gallery claimed it verified). Fixed:
- `div_le_iff` → `div_le_iff₀`, `le_div_iff` → `le_div_iff₀`
- `Finset.card_Icc` (unknown) → `rw [Nat.card_Icc]; omega`
- `Nat.cast_nonneg` now requires its explicit argument

### Remaining (correctly axiomatized, not touched)

- `szemeredi_upper` (Szemerédi 1976 upper bound) — genuinely deep.
- `optimal_lower` — needs a Chebyshev prime-count lower bound `π(N)−π(N/2) ≳ N/log N`, absent from the Mathlib pin (only an upper bound exists). Multi-session infra.

`productRatio_sandwich` now depends only on those two axioms.

## Verification

`lake env lean Proofs/Erdos490OQ01.lean` (Lean 4.26.0, warm Mathlib) → **EXIT 0**.
File 215 → 268 lines, axioms 3 → 2, theorems 9 → 11, sorries 0. Status remains `axiomatized` (2 deep axioms). Gallery meta updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)