### PR TITLE
research(alternating-series-boole-summation-oq-02): Boole summation over a normed vector space [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ02.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ02.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-
+# Boole Summation over a Normed Vector Space
+
+## What This Proves
+
+The parent `alternating-series-boole-summation` establishes the finite **Boole summation
+identity** and its total-variation remainder bound for *real* sequences. This child ports
+both to sequences valued in an arbitrary normed real vector space `E` (so `E = ℂ`, an
+operator algebra, or any Banach space).
+
+Writing the alternating partial sum and the forward difference as
+
+  `altSum a n m = ∑_{j ∈ [n, m)} (-1)^j • a j`,   `fdiff a j = a (j+1) - a j`,
+
+the **first-order Boole identity** is
+
+  `altSum a n m = ½ • ((-1)^n • a n - (-1)^m • a m) - ½ • altSum (fdiff a) n m`,
+
+and the associated **remainder bound** is
+
+  `‖altSum a n m - ½ • ((-1)^n • a n - (-1)^m • a m)‖ ≤ ½ · ∑_{j ∈ [n, m)} ‖fdiff a j‖`.
+
+## Honest Scope
+
+The algebraic identity and the norm bound are domain-agnostic: they need only that `E` is a
+normed ℝ-module, and they are proved here in that generality. What does **not** port is the
+antitone/telescoping *monotonicity* refinement of the real parent — it uses the order on ℝ,
+which a general normed space lacks. This entry therefore delivers exactly the order-free core.
+
+## Method
+
+The identity is a one-step induction (`Nat.le_induction`) peeling the top index with
+`Finset.sum_Ico_succ_top`; the algebraic step closes with the `module` tactic after
+`pow_succ`. The remainder bound rewrites the difference via the identity (`abel`) and then
+applies `norm_smul` and `norm_sum_le`, using `‖(-1)^j‖ = 1`.
+
+0 sorries, 0 axioms (only `propext` / `Classical.choice` / `Quot.sound`).
+-/
+
+namespace AlternatingSeriesBooleSummationOQ02
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The alternating partial sum `∑_{j ∈ [n, m)} (-1)^j • a j` of an `E`-valued sequence. -/
+def altSum (a : ℕ → E) (n m : ℕ) : E := ∑ j ∈ Finset.Ico n m, (-1 : ℝ) ^ j • a j
+
+/-- The forward difference `a (j+1) - a j`. -/
+def fdiff (a : ℕ → E) (j : ℕ) : E := a (j + 1) - a j
+
+@[simp] theorem altSum_self (a : ℕ → E) (n : ℕ) : altSum a n n = 0 := by
+  simp [altSum]
+
+/-- Peeling the top index of an `altSum`. -/
+theorem altSum_succ_top (a : ℕ → E) {n m : ℕ} (h : n ≤ m) :
+    altSum a n (m + 1) = altSum a n m + (-1 : ℝ) ^ m • a m := by
+  simp only [altSum]; rw [Finset.sum_Ico_succ_top h]
+
+/-- **First-order Boole summation identity over a normed ℝ-vector space.**
+`altSum a n m = ½·((-1)^n•a n - (-1)^m•a m) - ½·altSum(Δa) n m`, valid for any `n ≤ m`
+and any sequence into a normed real vector space. -/
+theorem boole_first_normed (a : ℕ → E) {n m : ℕ} (h : n ≤ m) :
+    altSum a n m
+      = (1 / 2 : ℝ) • ((-1 : ℝ) ^ n • a n - (-1 : ℝ) ^ m • a m)
+        - (1 / 2 : ℝ) • altSum (fdiff a) n m := by
+  induction m, h using Nat.le_induction with
+  | base => simp
+  | succ m hm ih =>
+      rw [altSum_succ_top a hm, altSum_succ_top (fdiff a) hm, ih, fdiff, pow_succ]
+      module
+
+/-- **Boole remainder bound over a normed ℝ-vector space.**
+The alternating sum differs from its two-point model `½·((-1)^n•a n - (-1)^m•a m)` by at
+most half the total variation `∑ ‖Δa j‖`. This is the order-free norm form of the parent's
+total-variation bound. -/
+theorem altSum_sub_model_norm_le (a : ℕ → E) {n m : ℕ} (h : n ≤ m) :
+    ‖altSum a n m - (1 / 2 : ℝ) • ((-1 : ℝ) ^ n • a n - (-1 : ℝ) ^ m • a m)‖
+      ≤ (1 / 2 : ℝ) * ∑ j ∈ Finset.Ico n m, ‖fdiff a j‖ := by
+  have key := boole_first_normed a h
+  have hrw : altSum a n m - (1 / 2 : ℝ) • ((-1 : ℝ) ^ n • a n - (-1 : ℝ) ^ m • a m)
+      = -((1 / 2 : ℝ) • altSum (fdiff a) n m) := by rw [key]; abel
+  have hhalf : ‖(1 / 2 : ℝ)‖ = 1 / 2 := by rw [Real.norm_eq_abs]; norm_num
+  rw [hrw, norm_neg, norm_smul, hhalf]
+  refine mul_le_mul_of_nonneg_left ?_ (by norm_num : (0 : ℝ) ≤ 1 / 2)
+  calc ‖altSum (fdiff a) n m‖
+      = ‖∑ j ∈ Finset.Ico n m, (-1 : ℝ) ^ j • fdiff a j‖ := by rw [altSum]
+    _ ≤ ∑ j ∈ Finset.Ico n m, ‖(-1 : ℝ) ^ j • fdiff a j‖ := norm_sum_le _ _
+    _ = ∑ j ∈ Finset.Ico n m, ‖fdiff a j‖ := by
+        refine Finset.sum_congr rfl fun j _ => ?_
+        simp [norm_smul]
+
+/-- Instantiation at `E = ℂ`: the identity and remainder bound cover complex-valued
+alternating sums (Fourier / Dirichlet partial sums) with no extra work. -/
+example (a : ℕ → ℂ) {n m : ℕ} (h : n ≤ m) :
+    ‖altSum a n m - (1 / 2 : ℝ) • ((-1 : ℝ) ^ n • a n - (-1 : ℝ) ^ m • a m)‖
+      ≤ (1 / 2 : ℝ) * ∑ j ∈ Finset.Ico n m, ‖fdiff a j‖ :=
+  altSum_sub_model_norm_le a h
+
+end AlternatingSeriesBooleSummationOQ02

--- a/src/data/proofs/alternating-series-boole-summation-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-02/meta.json
@@ -1,0 +1,210 @@
+{
+  "id": "alternating-series-boole-summation-oq-02",
+  "title": "Boole Summation over a Normed Vector Space",
+  "slug": "alternating-series-boole-summation-oq-02",
+  "description": "Generalizes the parent's finite Boole summation identity and total-variation remainder bound from real sequences to sequences valued in an arbitrary normed real vector space E (E = ℂ, an operator algebra, or any Banach space). Proves the first-order identity altSum a n m = ½·((-1)^n·a n − (-1)^m·a m) − ½·altSum(Δa) n m and the remainder bound ‖altSum a n m − ½·((-1)^n·a n − (-1)^m·a m)‖ ≤ ½·∑‖Δa j‖, both order-free. 4 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "George Boole (formalized in Lean 4 with Mathlib)",
+    "date": "1860",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "summation-by-parts",
+      "alternating-series",
+      "normed-space",
+      "generalization",
+      "total-variation",
+      "Boole-summation",
+      "Banach-space"
+    ],
+    "proofRepoPath": "Proofs/AlternatingSeriesBooleSummationOQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axioms": 0,
+    "theorems": 4,
+    "lines": 100,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_Ico_succ_top",
+        "description": "∑_{Ico a (b+1)} f = ∑_{Ico a b} f + f b (for a ≤ b): peels the top index of the alternating partial sum in the induction step.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction principle starting at a base n: proves ∀ m ≥ n, P m from P n and the step P m → P (m+1). Drives the one-step Boole identity proof.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "norm_sum_le",
+        "description": "‖∑ f‖ ≤ ∑ ‖f‖: the triangle inequality for finite sums, turning the identity into the total-variation remainder bound.",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      },
+      {
+        "theorem": "norm_smul",
+        "description": "‖c • x‖ = ‖c‖·‖x‖ over a normed space; combined with ‖(-1)^j‖ = 1 to discard the alternating sign inside the norm.",
+        "module": "Mathlib.Analysis.Normed.Module.Basic"
+      },
+      {
+        "theorem": "module",
+        "description": "Tactic normalizing ℝ-linear combinations in a module; closes the algebraic induction step after pow_succ.",
+        "module": "Mathlib.Tactic.Module"
+      }
+    ],
+    "originalContributions": [
+      "Definition of the E-valued alternating partial sum altSum a n m = ∑_{[n,m)} (-1)^j • a j over any normed ℝ-vector space",
+      "First-order Boole summation identity over a normed ℝ-module (order-free), proved by one-step Nat.le_induction closed with the module tactic",
+      "Total-variation remainder bound ‖altSum − model‖ ≤ ½·∑‖Δa j‖ via norm_sum_le and norm_smul",
+      "altSum_succ_top peeling lemma and the altSum_self = 0 simp lemma as reusable API",
+      "Explicit ℂ-valued instantiation (Fourier / Dirichlet partial sums) obtained with no extra work",
+      "Honest scoping: identifies that the parent's antitone/telescoping monotonicity refinement does NOT port (E is unordered), so only the order-free core is claimed"
+    ],
+    "historicalContext": "Boole summation (George Boole, mid-19th century, in his Treatise on the Calculus of Finite Differences) is the alternating-series analogue of the Euler–Maclaurin formula: it expresses an alternating partial sum through boundary terms plus a remainder built from finite differences. The parent gallery entry formalizes the finite first-order identity and its total-variation bound for real sequences. Because the algebraic identity is a summation-by-parts manipulation that never uses the order of ℝ, it extends verbatim to sequences valued in any normed real vector space — the setting relevant to complex Fourier and Dirichlet partial sums and to operator-valued series. This entry makes that generalization precise and machine-checked, while noting that the sharper monotonicity estimates of the ordered case genuinely require ℝ and do not carry over.",
+    "dateAdded": "2026-07-02",
+    "parentProof": "alternating-series-boole-summation",
+    "axiomCount": 0,
+    "lineCount": 100,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (dependency closure: propext, Classical.choice, Quot.sound only).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Boole summation** is to alternating series what **Euler–Maclaurin** is to ordinary series: it rewrites $\\sum (-1)^j a_j$ over an index window as a two-point boundary model plus a remainder governed by the forward differences $\\Delta a_j = a_{j+1} - a_j$. Introduced by **George Boole** in his *Calculus of Finite Differences* (1860), it is the workhorse behind sharp estimates for alternating partial sums, including complex Fourier and Dirichlet sums. The parent entry proves the finite first-order identity for real sequences; the manipulation is pure summation-by-parts and uses no order, so it lifts to any normed real vector space.",
+    "problemStatement": "**Open Question #2** from the Boole-summation gallery: generalize the finite Boole identity and its total-variation remainder bound from $a : \\mathbb{N} \\to \\mathbb{R}$ to $a : \\mathbb{N} \\to E$ with $E$ a normed real vector space (e.g. $E = \\mathbb{C}$ or a Banach space). Establish the first-order identity and the norm remainder bound, and delineate honestly which parts of the real theory port (the identity and the bound) and which do not (the order-dependent monotonicity refinement).",
+    "text": "The finite Boole summation identity altSum a n m = ½·((-1)^n·a n − (-1)^m·a m) − ½·altSum(Δa) n m, and its remainder bound ‖altSum − model‖ ≤ ½·∑‖Δa j‖, hold for sequences valued in any normed ℝ-vector space — covering complex and operator-valued alternating sums. Only the order-dependent monotonicity refinement of the real parent fails to generalize.",
+    "proofStrategy": "Two definitions set the stage: altSum a n m = ∑_{[n,m)} (-1)^j • a j and fdiff a j = a(j+1) − a j. The identity `boole_first_normed` is proved by `Nat.le_induction`: the base case is the empty sum (`simp`), and the step peels the top index of both alternating sums with `altSum_succ_top` (a wrapper over `Finset.sum_Ico_succ_top`), substitutes the induction hypothesis, rewrites (-1)^(m+1) via `pow_succ`, and closes the ℝ-linear identity with the `module` tactic. The remainder bound `altSum_sub_model_norm_le` rewrites the difference to −½·altSum(Δa) using the identity (`abel`), then bounds its norm with `norm_smul` (‖½‖ = ½) and `norm_sum_le`, discarding the sign since ‖(-1)^j‖ = 1.",
+    "keyInsights": [
+      "**The identity is order-free.** Summation by parts is an algebraic manipulation of the module structure; it never compares elements. So the first-order Boole identity holds verbatim over any ℝ-module, and the `module` tactic verifies the inductive step mechanically.",
+      "**One tactic for the algebra.** After peeling the top index and applying `pow_succ`, both sides are ℝ-linear combinations of the atoms a n, a m, a(m+1), and altSum(Δa) n m with scalar coefficients built from (-1)^n, (-1)^m; the `module` tactic normalizes these and closes the goal without hand-computation.",
+      "**Sign vanishes in the norm.** Because ‖(-1)^j • x‖ = ‖(-1)^j‖·‖x‖ = ‖x‖, the alternating sign contributes nothing to the remainder bound — the total variation ∑‖Δa j‖ is the only quantity that survives.",
+      "**Complex sums for free.** Instantiating E = ℂ recovers a total-variation bound for complex Fourier and Dirichlet partial sums with no additional proof, illustrating the payoff of the order-free generalization.",
+      "**Honest scope beats overclaiming.** The parent's antitone/telescoping monotonicity refinement genuinely requires the order of ℝ. Rather than force a false generalization, this entry states precisely the order-free core that does port."
+    ],
+    "prerequisites": [
+      "Normed real vector spaces (NormedAddCommGroup, NormedSpace ℝ E)",
+      "Finite sums over integer intervals (Finset.Ico, Finset.sum_Ico_succ_top)",
+      "Summation by parts / finite differences",
+      "The norm of a scalar multiple (norm_smul) and the triangle inequality for sums (norm_sum_le)",
+      "Parent proof: A Finite Boole Summation Formula for Alternating Sums (real case)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview — Boole Summation in a Normed Space",
+      "summary": "Imports, file docstring, and the normed-ℝ-vector-space setup. States the two target results (the first-order identity and the total-variation remainder bound) and the honest scope: the identity and bound port, the order-dependent monotonicity refinement does not.",
+      "startLine": 1,
+      "endLine": 45,
+      "mathContext": "For a : ℕ → E with E a normed ℝ-vector space, generalize the real Boole identity and its remainder bound. Everything reduces to summation by parts plus norm_smul / norm_sum_le."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions and the Empty Sum",
+      "summary": "altSum a n m = ∑_{[n,m)} (-1)^j • a j and fdiff a j = a(j+1) − a j, plus the simp lemma altSum_self : altSum a n n = 0.",
+      "startLine": 46,
+      "endLine": 54,
+      "mathContext": "altSum a n m = ∑_{j=n}^{m-1} (-1)^j • a j; fdiff a j = Δa_j = a_{j+1} − a_j; altSum over an empty window is 0."
+    },
+    {
+      "id": "peeling",
+      "title": "Peeling the Top Index",
+      "summary": "altSum_succ_top: altSum a n (m+1) = altSum a n m + (-1)^m • a m for n ≤ m, a thin wrapper over Finset.sum_Ico_succ_top used in both inductive proofs.",
+      "startLine": 55,
+      "endLine": 61,
+      "mathContext": "∑_{[n,m+1)} = ∑_{[n,m)} + (last term at index m). The single algebraic move behind the induction."
+    },
+    {
+      "id": "boole-identity",
+      "title": "The First-Order Boole Identity",
+      "summary": "boole_first_normed: altSum a n m = ½·((-1)^n•a n − (-1)^m•a m) − ½·altSum(Δa) n m. Proved by Nat.le_induction; the base case is simp, the step peels both sums, applies the IH, rewrites (-1)^(m+1) via pow_succ, and closes with the module tactic.",
+      "startLine": 62,
+      "endLine": 75,
+      "mathContext": "Summation by parts: altSum a n m = ½·((-1)^n a_n − (-1)^m a_m) − ½·altSum(Δa) n m, an exact finite identity over any ℝ-module."
+    },
+    {
+      "id": "remainder-bound",
+      "title": "The Total-Variation Remainder Bound",
+      "summary": "altSum_sub_model_norm_le: ‖altSum a n m − ½·((-1)^n•a n − (-1)^m•a m)‖ ≤ ½·∑‖Δa j‖. The difference equals −½·altSum(Δa) (abel from the identity); its norm is bounded by norm_smul and norm_sum_le, using ‖(-1)^j‖ = 1.",
+      "startLine": 76,
+      "endLine": 93,
+      "mathContext": "‖altSum − model‖ = ½·‖altSum(Δa)‖ ≤ ½·∑‖Δa_j‖. The alternating sign drops out because ‖(-1)^j • x‖ = ‖x‖."
+    },
+    {
+      "id": "complex-instantiation",
+      "title": "Complex-Valued Instantiation",
+      "summary": "Example at E = ℂ: the identity and remainder bound apply directly to complex-valued (Fourier / Dirichlet) alternating partial sums with no extra work.",
+      "startLine": 94,
+      "endLine": 100,
+      "mathContext": "E = ℂ is a normed ℝ-vector space, so the general bound specializes immediately to complex alternating sums."
+    }
+  ],
+  "conclusion": {
+    "summary": "A self-contained, fully verified generalization (4 theorems, 2 definitions, 0 sorries, 0 axioms) of the finite first-order Boole summation identity and its total-variation remainder bound from real sequences to sequences in any normed ℝ-vector space. The identity is a one-step induction closed by the module tactic; the bound follows from norm_smul and norm_sum_le. An explicit ℂ instantiation shows the immediate reach to complex partial sums.",
+    "implications": "**Order-free core, honestly scoped.** By separating the algebraic identity and norm bound (which port to any normed ℝ-module) from the monotonicity refinement (which needs the order of ℝ), this entry gives a reusable engine covering complex-, operator-, and Banach-valued alternating sums while avoiding an overclaim. The `altSum` / `fdiff` API and the two headline theorems are directly applicable to Fourier and Dirichlet partial-sum estimates.",
+    "openQuestions": [
+      "Can higher-order Boole summation (iterated finite differences, Euler-number coefficients) be formalized over a normed ℝ-vector space in the same order-free style?",
+      "Does the remainder bound sharpen to ‖altSum − model‖ ≤ ½·‖∑ ± Δa j‖ ≤ ½·∑‖Δa j‖ with a useful middle term for specific sign patterns?",
+      "Can the ℂ instantiation be pushed to a convergence criterion for complex alternating series with summable total variation (a normed Dirichlet test)?"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "alternating-series-boole-summation",
+        "relationship": "Parent proof — the real-valued finite Boole summation identity and total-variation bound that this entry generalizes to normed vector spaces."
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "AlternatingSeriesBooleSummationOQ02",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/AlternatingSeriesBooleSummationOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-boole-summation",
+      "relationship": "foundational",
+      "description": "Parent: the finite Boole summation identity and total-variation remainder bound for real sequences. This entry ports the order-free core (identity + norm bound) to normed ℝ-vector spaces."
+    },
+    {
+      "targetId": "alternating-series-boole-summation-oq-01",
+      "relationship": "related",
+      "description": "Sibling open-question child of the same Boole-summation parent."
+    },
+    {
+      "targetId": "triangle-inequality",
+      "relationship": "foundational",
+      "description": "The remainder bound is the triangle inequality for finite sums (norm_sum_le) applied to the alternating-sum remainder, with the sign discarded via ‖(-1)^j • x‖ = ‖x‖."
+    }
+  ],
+  "references": [
+    {
+      "authors": "George Boole",
+      "title": "A Treatise on the Calculus of Finite Differences",
+      "year": "1860",
+      "venue": "Macmillan",
+      "note": "Original development of Boole summation, the alternating-series analogue of the Euler–Maclaurin formula."
+    },
+    {
+      "authors": "Ronald L. Graham, Donald E. Knuth, Oren Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "note": "Summation by parts / Abel summation for finite differences, the mechanism behind the first-order Boole identity."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer",
+      "note": "Abel summation and partial-summation estimates for (complex) Dirichlet partial sums, the setting the normed generalization targets."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`alternating-series-boole-summation-oq-02`** — "Boole Summation over a Normed Vector Space", answering open question #2 of the Boole-summation gallery.

**Result.** The parent proves the finite first-order **Boole summation identity** and its total-variation remainder bound for *real* sequences. This child ports both to sequences valued in an arbitrary **normed ℝ-vector space** `E` (so `E = ℂ`, an operator algebra, or any Banach space):

- **Identity** — `altSum a n m = ½ • ((-1)^n • a n − (-1)^m • a m) − ½ • altSum (Δa) n m`
- **Remainder bound** — `‖altSum a n m − ½ • ((-1)^n • a n − (-1)^m • a m)‖ ≤ ½ · ∑_{j ∈ [n,m)} ‖Δa j‖`

where `altSum a n m = ∑_{[n,m)} (-1)^j • a j` and `Δa j = a(j+1) − a j`.

## Theorems (4) + definitions (2)

| Name | Statement |
|------|-----------|
| `altSum`, `fdiff` | the E-valued alternating partial sum and forward difference |
| `altSum_self` | `altSum a n n = 0` (simp) |
| `altSum_succ_top` | peel the top index: `altSum a n (m+1) = altSum a n m + (-1)^m • a m` |
| `boole_first_normed` | the first-order Boole identity |
| `altSum_sub_model_norm_le` | the total-variation remainder bound |

Plus an explicit **`E = ℂ` instantiation** (Fourier / Dirichlet partial sums) obtained with no extra work.

## Proof method

The identity is a one-step `Nat.le_induction`: base case `simp`, step peels both alternating sums with `Finset.sum_Ico_succ_top`, substitutes the IH, rewrites `(-1)^(m+1)` via `pow_succ`, and closes the ℝ-linear goal with the **`module`** tactic. The remainder bound rewrites the difference to `−½ • altSum (Δa)` (`abel`) and bounds its norm with `norm_smul` and `norm_sum_le`, using `‖(-1)^j‖ = 1`.

## Honest scope

The algebraic identity and the norm bound are order-free and port in full. The parent's **antitone/telescoping monotonicity refinement does NOT generalize** — it uses the order of ℝ, which a general normed space lacks. Only the order-free core is claimed.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on all theorems reports only `[propext, Classical.choice, Quot.sound]`.
- Built with `lake env lean`, Mathlib **v4.26.0**. `pnpm gallery:check-size` passes.
- `leanFile`: `Proofs/AlternatingSeriesBooleSummationOQ02.lean`, 100 lines, 4 theorems, 2 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)