### PR TITLE
Enrich Friendship Theorem (infinite case): annotation coverage 5→17

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-04/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-04/annotations.json
@@ -2,61 +2,384 @@
   {
     "id": "friendship-oq04-ann-overview",
     "proofId": "friendship-theorem-oq-04",
-    "range": { "startLine": 8, "endLine": 43 },
+    "range": {
+      "startLine": 8,
+      "endLine": 43
+    },
     "type": "concept",
     "title": "The Friendship Theorem in the Infinite Case",
     "content": "The finite Friendship Theorem (Erdős–Rényi–Sós, 1966): if every two distinct vertices of a finite graph have exactly one common neighbour, some vertex is adjacent to all others (a windmill). It is false for infinite graphs — the C₅ free-amalgamation construction (Chvátal–Kotzig–Rosenberg–Davies, 1976) gives a countable friendship graph with no universal vertex, in which every vertex has infinite degree. This file pins down the sharp restoring hypothesis without the spectral argument (which has no infinite analogue): every friendship graph has diameter ≤ 2 (purely local), so a locally finite one is finite and hence has a universal vertex. Local finiteness is therefore exactly the restoring condition — the sole obstruction to finiteness is an infinite-degree vertex.",
     "mathContext": "Finite friendship $\\Rightarrow$ universal vertex; infinite counterexample exists $\\Rightarrow$ extra hypothesis needed. Sharp condition: local finiteness.",
     "significance": "supporting",
-    "relatedConcepts": ["Friendship theorem", "windmill graph", "infinite graphs", "spectral graph theory", "free amalgamation"],
-    "prerequisites": ["graph theory", "common neighbours", "finiteness of sets"]
+    "relatedConcepts": [
+      "Friendship theorem",
+      "windmill graph",
+      "infinite graphs",
+      "spectral graph theory",
+      "free amalgamation"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "common neighbours",
+      "finiteness of sets"
+    ]
   },
   {
     "id": "friendship-oq04-ann-defs",
     "proofId": "friendship-theorem-oq-04",
-    "range": { "startLine": 51, "endLine": 70 },
+    "range": {
+      "startLine": 51,
+      "endLine": 70
+    },
     "type": "definition",
     "title": "Friendship Graphs and Common Neighbours (Fintype-Free)",
     "content": "IsFriendshipGraph is defined without a [Fintype V] assumption — every pair of distinct vertices has exactly one common neighbour ((G.commonNeighbors u v).ncard = 1) — so it applies to infinite vertex types while being definitionally identical to the finite gallery version. exists_common_neighbor extracts that unique common neighbour from the ncard = 1 condition via Set.ncard_eq_one.",
     "mathContext": "$\\forall u \\ne v,\\ |N(u) \\cap N(v)| = 1$ (using ncard, valid for infinite $V$).",
     "significance": "supporting",
-    "relatedConcepts": ["common neighbours", "Set.ncard", "Fintype-free formalization", "SimpleGraph.commonNeighbors"],
-    "prerequisites": ["simple graphs", "set cardinality (ncard)"]
+    "relatedConcepts": [
+      "common neighbours",
+      "Set.ncard",
+      "Fintype-free formalization",
+      "SimpleGraph.commonNeighbors"
+    ],
+    "prerequisites": [
+      "simple graphs",
+      "set cardinality (ncard)"
+    ]
   },
   {
     "id": "friendship-oq04-ann-diameter",
     "proofId": "friendship-theorem-oq-04",
-    "range": { "startLine": 68, "endLine": 95 },
+    "range": {
+      "startLine": 71,
+      "endLine": 95
+    },
     "type": "insight",
     "title": "Diameter ≤ 2 Survives Infinity",
     "content": "friendship_diameter_two proves that for any base vertex v and any other u, either u is adjacent to v or they share a common neighbour x — so u is within distance 2 of v, with no finiteness used. univ_subset_two_ball packages this as a covering: the whole vertex set is contained in {v} ∪ N(v) ∪ (⋃_{x ∈ N(v)} N(x)), the 2-ball around v. This purely local covering is the key structural fact the rest of the file leverages.",
     "mathContext": "$V \\subseteq \\{v\\} \\cup N(v) \\cup \\bigcup_{x \\in N(v)} N(x)$ — every vertex lies in the 2-ball of any fixed $v$.",
     "significance": "key",
-    "relatedConcepts": ["graph diameter", "2-ball covering", "neighbourhood", "local argument"],
-    "prerequisites": ["graph distance", "neighbourhoods", "set union"]
+    "relatedConcepts": [
+      "graph diameter",
+      "2-ball covering",
+      "neighbourhood",
+      "local argument"
+    ],
+    "prerequisites": [
+      "graph distance",
+      "neighbourhoods",
+      "set union"
+    ]
   },
   {
     "id": "friendship-oq04-ann-finiteness",
     "proofId": "friendship-theorem-oq-04",
-    "range": { "startLine": 92, "endLine": 126 },
+    "range": {
+      "startLine": 96,
+      "endLine": 126
+    },
     "type": "concept",
     "title": "Local Finiteness Forces Finiteness (the Sharp Obstruction)",
     "content": "univ_finite_of_locallyFinite shows that if every neighbourhood is finite, the 2-ball covering exhibits V as a finite union of finite sets (singleton, N(v), and a finite biUnion of finite N(x)), so V is finite; locally_finite_is_finite restates this as Finite V. The contrapositive infinite_friendship_has_infinite_degree is the direct OQ-04 answer: every infinite friendship graph has a vertex of infinite degree — exactly the feature of the C₅ counterexample. No spectral input is used.",
     "mathContext": "all $N(w)$ finite $\\Rightarrow V$ finite; contrapositive: $V$ infinite $\\Rightarrow \\exists w,\\ |N(w)| = \\infty$.",
     "significance": "key",
-    "relatedConcepts": ["local finiteness", "finite union of finite sets", "contrapositive", "infinite degree"],
-    "prerequisites": ["finiteness of unions", "Set.Finite.biUnion"]
+    "relatedConcepts": [
+      "local finiteness",
+      "finite union of finite sets",
+      "contrapositive",
+      "infinite degree"
+    ],
+    "prerequisites": [
+      "finiteness of unions",
+      "Set.Finite.biUnion"
+    ]
   },
   {
     "id": "friendship-oq04-ann-universal",
     "proofId": "friendship-theorem-oq-04",
-    "range": { "startLine": 128, "endLine": 145 },
+    "range": {
+      "startLine": 128,
+      "endLine": 145
+    },
     "type": "concept",
     "title": "Recovering a Universal Vertex",
     "content": "locally_finite_friendship_has_universal combines the finiteness result with the finite gallery theorem FriendshipTheorem.friendship_theorem to recover a universal vertex for any locally finite friendship graph with at least three vertices. The proof derives Finite V, equips it with a Fintype, establishes 3 ≤ card V from the three distinct vertices a, b, c (via card_eq_three), and applies the finite theorem. This closes the loop: local finiteness restores the full Friendship conclusion.",
     "mathContext": "locally finite friendship graph with $|V| \\ge 3 \\Rightarrow \\exists z$ universal.",
     "significance": "supporting",
-    "relatedConcepts": ["universal vertex", "reduction to finite case", "Fintype.ofFinite", "windmill"],
-    "prerequisites": ["finite Friendship theorem", "Fintype / Finite"]
+    "relatedConcepts": [
+      "universal vertex",
+      "reduction to finite case",
+      "Fintype.ofFinite",
+      "windmill"
+    ],
+    "prerequisites": [
+      "finite Friendship theorem",
+      "Fintype / Finite"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-local-finiteness",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 151,
+      "endLine": 185
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Local Finiteness Is the Sharp Restoring Condition",
+    "content": "The diameter-2 covering exhibits the whole vertex set as a finite union of finite sets, so a locally finite friendship graph has a finite vertex type (`univ_finite_of_locallyFinite`, `locally_finite_is_finite`). Contrapositively (`infinite_friendship_has_infinite_degree`), the *sole* obstruction to the finite theorem on infinite graphs is a vertex of infinite degree — exactly the feature of the C5 free-amalgamation counterexample, obtained with no spectral input.",
+    "mathContext": "$V \\subseteq \\{v\\} \\cup N(v) \\cup \\bigcup_{x \\in N(v)} N(x)$; local finiteness $\\Rightarrow |V| < \\infty$; contrapositive $|V| = \\infty \\Rightarrow \\exists w,\\ |N(w)| = \\infty$.",
+    "relatedConcepts": [
+      "local finiteness",
+      "finite union of finite sets",
+      "graph diameter",
+      "contrapositive"
+    ],
+    "prerequisites": [
+      "set theory",
+      "graph theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-recover-universal",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 187,
+      "endLine": 202
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Recovering the Universal Vertex",
+    "content": "Combining the finiteness above with the finite gallery theorem `FriendshipTheorem.friendship_theorem` recovers a universal vertex (a windmill hub) for any locally finite friendship graph with at least three vertices — with no spectral input on the infinite side. The `Finite V` instance is obtained from `locally_finite_is_finite`, and three distinct vertices supply the `3 <= card V` hypothesis.",
+    "mathContext": "locally finite $\\wedge\\ |V| \\ge 3 \\Rightarrow \\exists z\\ \\forall u \\ne z,\\ z \\sim u$.",
+    "relatedConcepts": [
+      "universal vertex",
+      "windmill graph",
+      "Erdos-Renyi-Sos theorem"
+    ],
+    "prerequisites": [
+      "finite friendship theorem"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-windmill-structure",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 204,
+      "endLine": 244
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "The Infinite Windmill: N(u) = {centre, partner}",
+    "content": "In *any* friendship graph with a universal vertex `c` (finite or infinite), every non-centre vertex `u` has exactly two neighbours — the centre and a unique partner `w` — so `N(u) = {c, w}` (`universal_noncentral_neighborSet`) and `|N(u)| = 2` (`universal_noncentral_ncard_two`). This is the finiteness-free analogue of the finite gallery's `friendship_noncentral_degree` (a `Fintype` degree statement), showing the recovered conclusion is genuinely a windmill even on infinite vertex types.",
+    "mathContext": "$\\forall u \\ne c,\\ \\exists! w,\\ N(u) = \\{c,w\\}$, hence $|N(u)| = 2$; triangles $\\{c,u,w\\}$ share the hub $c$.",
+    "relatedConcepts": [
+      "windmill graph",
+      "neighbour set",
+      "common neighbours",
+      "set cardinality (ncard)"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "set theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-unique-hub",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 246,
+      "endLine": 283
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Exactly One Infinite-Degree Vertex: the Hub",
+    "content": "A non-centre vertex sits in a single triangle (`ncard = 2`), so any infinite-degree vertex must be the hub `c` (`infinite_degree_vertex_eq_universal`); on an infinite graph the hub itself has infinite degree (`universal_vertex_infinite_degree`). Together these give the sharp count `(N(w) infinite) <-> (w = c)` (`unique_infinite_degree_vertex`): the infinite windmill is as infinite as the finite theorem permits — one infinite-degree hub, every other vertex of degree two.",
+    "mathContext": "$(N(w)\\ \\text{infinite}) \\iff w = c$; hub has $|N(c)| = \\infty$, all others $|N(u)| = 2$.",
+    "relatedConcepts": [
+      "infinite degree",
+      "windmill hub",
+      "cardinality dichotomy"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "graph theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-nonadjacent-equinum",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 285,
+      "endLine": 345
+    },
+    "type": "theorem",
+    "significance": "critical",
+    "title": "Regularity Engine: Non-Adjacent Neighbourhoods Are Equinumerous",
+    "content": "Any two *non-adjacent* vertices `u`, `v` have equinumerous neighbourhoods: the map sending each neighbour `w` of `u` to the unique common neighbour of `w` and `v` is a bijection `N(u) -> N(v)` (`nonadjacent_neighborSet_equinum`). This is the infinite analogue of the classical 'non-adjacent vertices have equal degree' lemma — the step the finite proof uses before invoking the spectral argument. Stated as a `Set.BijOn`, it retains content on infinite neighbourhoods where `ncard` collapses to 0; no finiteness is used.",
+    "mathContext": "$u \\not\\sim v \\Rightarrow \\exists f,\\ f: N(u) \\xrightarrow{\\sim} N(v)$ (a $\\mathrm{Set.BijOn}$), $w \\mapsto$ unique common neighbour of $w$ and $v$.",
+    "relatedConcepts": [
+      "regular graph",
+      "bijection",
+      "Set.BijOn",
+      "equinumerosity"
+    ],
+    "prerequisites": [
+      "set theory",
+      "axiom of choice"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-perfect-matching",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 347,
+      "endLine": 406
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "The Windmill Off the Hub Is a Perfect Matching",
+    "content": "The 'partner' relation on non-centre vertices is an involution: `N(u) = {c, w}` forces `N(w) = {c, u}` (`universal_partner_symm`), each non-centre vertex has a *unique* partner (`universal_noncentral_unique_partner`), and off-centre adjacency *is* partnership (`universal_noncentral_adj_iff`). Deleting the hub therefore leaves a disjoint union of edges — the windmill spokes — each triangle meeting the others only at `c`.",
+    "mathContext": "$N(u) = \\{c,w\\} \\Rightarrow N(w) = \\{c,u\\}$ (involution); off-hub edges pair partners.",
+    "relatedConcepts": [
+      "perfect matching",
+      "involution",
+      "windmill spokes",
+      "edge set"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-conditional-regular",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 408,
+      "endLine": 459
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Two-Step Bijections and Unique Common Neighbours",
+    "content": "A common *non-neighbour* `z` of `u`, `v` bridges the *adjacent* case of regularity: composing the two non-adjacent bijections `N(u) ~ N(z) ~ N(v)` gives `N(u) ~ N(v)` (`neighborSet_equinum_of_common_nonneighbor`), packaged with the non-adjacent case in `neighborSet_equinum_of_nonadj_or_common_nonneighbor`. The reusable `exists-unique` form `common_neighbor_unique` upgrades mere existence of a common neighbour to full unique-existence directly from `ncard = 1`.",
+    "mathContext": "common non-neighbour $z$: $N(u) \\xrightarrow{\\sim} N(z) \\xrightarrow{\\sim} N(v)$; every distinct pair has $\\exists!$ common neighbour.",
+    "relatedConcepts": [
+      "bijection composition",
+      "unique existence",
+      "common neighbours"
+    ],
+    "prerequisites": [
+      "set theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-edge-triangle",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 461,
+      "endLine": 472
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Every Edge Lies in a Unique Triangle",
+    "content": "For an adjacent pair `u`, `v` there is a unique vertex adjacent to both — the apex of the one triangle on the edge (`edge_unique_triangle`). Equivalently the subgraph induced on `N(u)` is a perfect matching. This holds *unconditionally* (with or without a hub), so it is the residual windmill trace surviving in the hub-free C5 counterexample; it is a direct corollary of `common_neighbor_unique`.",
+    "mathContext": "$u \\sim v \\Rightarrow \\exists! w,\\ w \\sim u \\wedge w \\sim v$; $N(u)$ induces a perfect matching.",
+    "relatedConcepts": [
+      "triangle",
+      "perfect matching",
+      "friendship property"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-bridge-lemma",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 474,
+      "endLine": 532
+    },
+    "type": "theorem",
+    "significance": "critical",
+    "title": "The Bridge Lemma: a Dominating Edge Forces a Hub",
+    "content": "If an adjacent pair `u`, `v` *dominates* the graph (every vertex is adjacent to one of them) then `u` or `v` is universal (`adjacent_dominating_implies_universal`): otherwise a common neighbour of two non-adjacent witnesses would violate uniqueness. Contrapositively, in a *hub-free* graph every edge admits a common non-neighbour (`no_universal_adjacent_has_common_nonneighbor`) — the input the regularity engine needs to reach the adjacent case unconditionally.",
+    "mathContext": "edge $\\{u,v\\}$ dominates $\\Rightarrow u$ or $v$ universal; hub-free $\\Rightarrow$ every edge has a common non-neighbour.",
+    "relatedConcepts": [
+      "dominating set",
+      "universal vertex",
+      "contrapositive",
+      "uniqueness of common neighbour"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-hubfree-regular",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 534,
+      "endLine": 579
+    },
+    "type": "theorem",
+    "significance": "critical",
+    "title": "Hub-Free implies Aleph-0-Regular (the Counterexample Shape)",
+    "content": "A friendship graph with *no* universal vertex is regular: every pair of vertices — adjacent or not — has equinumerous neighbourhoods (`no_universal_regular`), routing adjacent pairs through the common non-neighbour. On an *infinite* hub-free graph this forces every neighbourhood to be infinite and all pairwise equinumerous — Aleph-0-regularity (`no_universal_infinite_aleph0_regular`), the exact shape of the C5 free-amalgamation counterexample. Where the finite proof would invoke the spectral argument, the structure stops here; no finiteness is used.",
+    "mathContext": "no hub $\\Rightarrow$ all $N(u),N(v)$ equinumerous; infinite + hub-free $\\Rightarrow \\forall w,\\ |N(w)| = \\aleph_0$.",
+    "relatedConcepts": [
+      "regular graph",
+      "aleph-null-regular",
+      "C5 free-amalgamation",
+      "cardinal arithmetic"
+    ],
+    "prerequisites": [
+      "set theory",
+      "cardinal arithmetic"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-exclusivity",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 581,
+      "endLine": 604
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "The Windmill Case Is Not Regular (Exclusivity)",
+    "content": "An infinite friendship graph with a universal vertex fails to be regular (`universal_infinite_not_regular`): the hub has infinite degree while every off-hub vertex has exactly two neighbours, so no bijection `N(c) -> N(u)` can exist (an injection out of an infinite set has infinite image, but `N(u)` is a two-element set). This supplies the *exclusivity* half of the dichotomy — the 'has a hub' and 'regular' branches are genuinely disjoint, not merely jointly exhaustive.",
+    "mathContext": "windmill: $|N(c)| = \\infty$ but $|N(u)| = 2$, so no $\\mathrm{BijOn}\\ N(c) \\to N(u)$.",
+    "relatedConcepts": [
+      "cardinal injection",
+      "regularity",
+      "exclusive dichotomy"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic"
+    ]
+  },
+  {
+    "id": "friendship-oq04-ann-dichotomy",
+    "proofId": "friendship-theorem-oq-04",
+    "range": {
+      "startLine": 606,
+      "endLine": 625
+    },
+    "type": "theorem",
+    "significance": "critical",
+    "title": "Capstone: Exclusive Structural Dichotomy (Xor')",
+    "content": "Every *infinite* friendship graph satisfies exactly one of: it has a universal vertex (an infinite windmill with a single infinite-degree hub and every other vertex of degree two), or it is hub-free and regular (Aleph-0-regular, the C5 free-amalgamation shape). Exhaustiveness is `no_universal_regular` (excluded middle on the hub); exclusivity is `universal_infinite_not_regular`. The finite theorem's 'universal or k-regular' dichotomy, transported to infinite graphs, becomes a genuine `Xor'` — with no spectral argument.",
+    "mathContext": "$\\mathrm{Xor'}\\big(\\exists c\\ \\text{universal},\\ \\text{regular}\\big)$: windmill-with-hub XOR hub-free-$\\aleph_0$-regular.",
+    "relatedConcepts": [
+      "exclusive or (Xor')",
+      "structural dichotomy",
+      "spectral argument",
+      "open question OQ-04"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "cardinal arithmetic"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `friendship-theorem-oq-04` ("Friendship Theorem: The Infinite Case").

## Problem
The entry's Lean file is 627 lines with 27 declarations, but only the header and first 4 declarations (lines 8–145) were annotated. The entire second half — the heart of the infinite-case dichotomy (lines 151–625, 22 theorems) — had **zero** annotation coverage (~21%).

## Changes
- **+12 annotations** covering the uncovered declarations, grouped into meaningful mathematical sections:
  - Local finiteness as the sharp restoring condition (diameter-2 covering ⇒ finite)
  - Recovering the universal vertex from the finite gallery theorem
  - The infinite windmill structure `N(u) = {centre, partner}`
  - Exactly one infinite-degree vertex (the hub)
  - The non-adjacent regularity engine (`Set.BijOn` bijections)
  - The windmill off the hub as a perfect matching
  - Two-step bijections & unique common neighbours
  - Every edge in a unique triangle
  - The bridge lemma (dominating edge forces a hub)
  - Hub-free ⟹ ℵ₀-regular (the C₅ free-amalgamation shape)
  - The windmill case is not regular (exclusivity)
  - Capstone: the exclusive `Xor'` structural dichotomy
- Fixed two pre-existing overlapping header ranges (ann-diameter, ann-finiteness).
- Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`; all ranges non-overlapping.

Coverage rises from ~21% to ~96%. `meta.json` untouched (already ~20 KB, well under the 60 KB cap).