### PR TITLE
Enrich Vandermonde convolution (combinations-formula-oq-07): 5th annotation, Chu–Vandermonde history, cross-refs

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "vandermonde-context",
     "proofId": "combinations-formula-oq-07",
-    "range": { "startLine": 1, "endLine": 49 },
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
     "type": "concept",
     "title": "Vandermonde's Convolution and Its Central Special Case",
     "content": "Vandermonde's identity C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j) is the discrete convolution behind the multiplicativity of the binomial theorem: it is the coefficient of xᵏ in (1+x)^m·(1+x)^n = (1+x)^{m+n}. Mathlib proves the antidiagonal form Nat.add_choose_eq; this entry reindexes it into the textbook single-sum range form and derives the famous central case C(2n,n) = ∑ C(n,i)².",
@@ -24,7 +27,10 @@
   {
     "id": "antidiagonal-anchor",
     "proofId": "combinations-formula-oq-07",
-    "range": { "startLine": 51, "endLine": 55 },
+    "range": {
+      "startLine": 51,
+      "endLine": 55
+    },
     "type": "theorem",
     "title": "Anchor: Antidiagonal Form (Mathlib)",
     "content": "add_choose_eq_antidiagonal restates Mathlib's Nat.add_choose_eq: C(m+n, k) = ∑ over p ∈ antidiagonal k of C(m, p.1)·C(n, p.2). Mathlib proves this via the polynomial identity (X+1)^{m+n} = (X+1)^m·(X+1)^n and coefficient extraction (coeff_mul). It serves as the starting point that the subsequent theorems reindex and specialize.",
@@ -43,7 +49,10 @@
   {
     "id": "range-form-theorem",
     "proofId": "combinations-formula-oq-07",
-    "range": { "startLine": 57, "endLine": 62 },
+    "range": {
+      "startLine": 57,
+      "endLine": 62
+    },
     "type": "theorem",
     "title": "Vandermonde Range Form",
     "content": "add_choose_eq_sum_range proves C(m+n, k) = ∑_{i ∈ range(k+1)} C(m,i)·C(n,k-i), the textbook single-sum statement of Vandermonde's convolution. The proof rewrites the antidiagonal sum into a range sum via Finset.Nat.sum_antidiagonal_eq_sum_range_succ, evaluating the antidiagonal pair (i,j) as (i, k-i).",
@@ -62,10 +71,13 @@
   {
     "id": "central-binom-theorem",
     "proofId": "combinations-formula-oq-07",
-    "range": { "startLine": 64, "endLine": 76 },
+    "range": {
+      "startLine": 64,
+      "endLine": 69
+    },
     "type": "theorem",
     "title": "Central Binomial Sum of Squares",
-    "content": "central_binom_eq_sum_sq proves C(2n, n) = ∑_{i ∈ range(n+1)} C(n,i)². Specializing the range form at m=n, k=n (using two_mul to rewrite 2n = n+n) yields ∑ C(n,i)·C(n,n-i); a sum_congr then applies Nat.choose_symm (C(n,n-i)=C(n,i) for i ≤ n, valid on the range) to collapse each term to a square. A worked example confirms C(6,3) = 1+9+9+1 = 20.",
+    "content": "central_binom_eq_sum_sq proves C(2n, n) = ∑_{i ∈ range(n+1)} C(n,i)². Specializing the range form at m=n, k=n (using two_mul to rewrite 2n = n+n) yields ∑ C(n,i)·C(n,n-i); a sum_congr then applies Nat.choose_symm (C(n,n-i)=C(n,i) for i ≤ n, valid on the range) to collapse each term to a square.",
     "mathContext": "$\\binom{2n}{n} = \\sum_{i=0}^{n}\\binom{n}{i}^2$ is the diagonal of Vandermonde. It counts the lattice paths from $(0,0)$ to $(n,n)$ and equals the sum of squares of the $n$-th row of Pascal's triangle. For $n=3$: $\\binom{3}{0}^2+\\binom{3}{1}^2+\\binom{3}{2}^2+\\binom{3}{3}^2 = 1+9+9+1 = 20 = \\binom{6}{3}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -77,6 +89,28 @@
     "prerequisites": [
       "choose symmetry C(n,n-k)=C(n,k)",
       "sum_congr on a summation range"
+    ]
+  },
+  {
+    "id": "sanity-check-example",
+    "proofId": "combinations-formula-oq-07",
+    "range": {
+      "startLine": 71,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "Numerical Sanity Check by Decidability",
+    "content": "A concrete instance, C(6,3) = 20, is recovered by rewriting with central_binom_eq_sum_sq 3 and then discharging the fully numeric goal ∑_{i∈range 4} C(3,i)² = 20 with `decide`. Because every quantity is a closed natural number, kernel evaluation settles it without any arithmetic lemmas — a cheap end-to-end confirmation that the general identity specializes correctly.",
+    "mathContext": "$\\binom{6}{3} = \\binom{3}{0}^2+\\binom{3}{1}^2+\\binom{3}{2}^2+\\binom{3}{3}^2 = 1+9+9+1 = 20$. `decide` evaluates both sides to the literal $20$ in the kernel.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "decidable equality",
+      "kernel reduction",
+      "native natural-number arithmetic"
+    ],
+    "prerequisites": [
+      "decide tactic",
+      "closed-form evaluation of finite sums"
     ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07/meta.json
@@ -56,14 +56,15 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "Vandermonde's identity is named for Alexandre-Théophile Vandermonde (1772), though it was known to Zhu Shijie in 14th-century China. It is the discrete convolution underlying the binomial theorem's multiplicativity: the coefficient of xᵏ in (1+x)^m(1+x)^n = (1+x)^{m+n}. The central special case C(2n,n) = ∑ C(n,i)² is one of the most-quoted binomial identities, counting lattice paths to the center of Pascal's triangle and appearing throughout enumerative combinatorics, the theory of Catalan numbers, and random-walk return probabilities.",
+    "historicalContext": "Vandermonde's identity is named for Alexandre-Théophile Vandermonde (1772), though it was known to Zhu Shijie in his 1303 *Jade Mirror of the Four Elements*, so the result is also called the Chu–Vandermonde identity. It is the discrete convolution underlying the binomial theorem's multiplicativity: the coefficient of xᵏ in (1+x)^m(1+x)^n = (1+x)^{m+n}. The central special case C(2n,n) = ∑ C(n,i)² is one of the most-quoted binomial identities, counting lattice paths to the center of Pascal's triangle and appearing throughout enumerative combinatorics, the theory of Catalan numbers, and random-walk return probabilities.",
     "problemStatement": "Open Question OQ-07: Formalize Vandermonde's convolution C(m+n, k) = ∑_{i+j=k} C(m,i)·C(n,j). Mathlib provides the antidiagonal form (Nat.add_choose_eq); the task is to reindex it into the textbook single-sum range form, and to derive the central binomial sum-of-squares identity C(2n,n) = ∑_{i=0}^{n} C(n,i)².",
     "proofStrategy": "Begin from Mathlib's Nat.add_choose_eq, expressing C(m+n,k) as a sum of C(m,i)·C(n,j) over Finset.antidiagonal k. Apply Finset.Nat.sum_antidiagonal_eq_sum_range_succ to evaluate the pair (i,j) as (i, k-i) over i ∈ range(k+1), giving the range form. For the central case, set m=n and k=n (using two_mul to write 2n = n+n); a sum_congr then rewrites each term C(n,i)·C(n,n-i) using Nat.choose_symm (C(n,n-i) = C(n,i) for i ≤ n) into C(n,i)², so the convolution collapses to a sum of squares.",
     "keyInsights": [
       "Vandermonde's convolution is the antidiagonal-indexed statement; the textbook single sum is recovered by the same antidiagonal-to-range reindexing used for any binomial convolution.",
       "The central sum-of-squares identity is not a separate theorem but a one-line specialization of Vandermonde once choose symmetry C(n,n-i)=C(n,i) is applied — exposing it as the 'diagonal' of the convolution.",
       "Nat.choose_symm requires i ≤ n, which holds automatically on the summation range range(n+1); the side condition is discharged by mem_range and Nat.lt_succ_iff.",
-      "two_mul (2n = n+n) is the small bridge that lets the m=n, k=n specialization of Vandermonde land on the central binomial coefficient C(2n,n)."
+      "two_mul (2n = n+n) is the small bridge that lets the m=n, k=n specialization of Vandermonde land on the central binomial coefficient C(2n,n).",
+      "The convolution and its diagonal admit dual combinatorial readings: C(m+n,k) counts k-subsets of m+n split by how many land in the first m, while the diagonal C(2n,n)=∑C(n,i)² counts monotone lattice paths through the center of Pascal's triangle — the same number reached two ways."
     ]
   },
   "sections": [
@@ -108,6 +109,14 @@
     {
       "targetId": "combinations-formula-oq-02",
       "relationship": "ancestor — the core combinations formula entry providing binomial coefficient context"
+    },
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "the q-binomial entry whose q-Vandermonde identity is the quantum analogue of this convolution (see open question)"
+    },
+    {
+      "targetId": "vandermonde-interpolation-oq-01",
+      "relationship": "shares the Vandermonde namesake but is a distinct result (the Vandermonde determinant / polynomial interpolation), not this convolution identity"
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07` (Vandermonde's convolution + central binomial sum-of-squares).

**Changes**
- Split the central-binomial annotation so the `C(6,3)=20` sanity check via `decide` is its own *technique* annotation — 4→5 annotations with cleaner, non-overlapping line coverage of the 76-line file.
- Named the **Chu–Vandermonde identity** and dated Zhu Shijie's 1303 *Jade Mirror of the Four Elements* in `historicalContext`.
- Added a keyInsight on the dual combinatorial reading (subset-splitting vs. monotone lattice paths through Pascal's triangle) — 4→5 insights.
- Added two cross-references: `combinations-formula-oq-03` (q-Vandermonde analogue) and `vandermonde-interpolation-oq-01` (namesake disambiguation).

**Guardrails:** meta.json 9.6 KB (≤60 KB), 5 keyInsights (≤12), 3 crossReferences (≤20). Verified with `gallery:check-size` and `annotations:normalize-check`. No status/badge/axiom changes.