### PR TITLE
Enrich Ramsey's Theorem: annotation coverage 8→18

### DIFF
--- a/src/data/proofs/ramseys-theorem/annotations.json
+++ b/src/data/proofs/ramseys-theorem/annotations.json
@@ -21,6 +21,28 @@
     ]
   },
   {
+    "id": "ramsey-ann-color-graphs",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 66,
+      "endLine": 84
+    },
+    "type": "definition",
+    "significance": "key",
+    "title": "From Coloring to Red and Blue Graphs",
+    "content": "The 2-coloring is turned into two `SimpleGraph` structures: the red graph (edges colored `true`) and the blue graph (edges colored `false`). A red clique / blue clique is then just a clique in the corresponding graph (`IsRedClique`, `IsBlueClique`). This reframes Ramsey's theorem as: any 2-coloring's red or blue graph contains a large clique.",
+    "mathContext": "red graph $R$: $x \\sim_R y \\iff c(x,y) = \\text{true} \\wedge x \\ne y$; blue graph $B$ is the complement; a red $r$-clique is an $r$-clique of $R$.",
+    "relatedConcepts": [
+      "edge coloring",
+      "simple graph",
+      "clique",
+      "graph complement"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
     "id": "ramsey-property-def",
     "proofId": "ramseys-theorem",
     "range": {
@@ -42,6 +64,27 @@
     ]
   },
   {
+    "id": "ramsey-ann-singletons",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 95,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Singleton Base Cases",
+    "content": "Any single vertex is vacuously both a red and a blue clique (`Set.pairwise_singleton`), since there are no pairs to check. These trivial base cases anchor the induction and give `R(1, s) = R(r, 1) = 1`.",
+    "mathContext": "$\\{x\\}$ is a monochromatic clique for both colors; base for $R(1,s) = R(r,1) = 1$.",
+    "relatedConcepts": [
+      "clique",
+      "base case",
+      "vacuous truth"
+    ],
+    "prerequisites": [
+      "set theory"
+    ]
+  },
+  {
     "id": "base-case-r1",
     "proofId": "ramseys-theorem",
     "range": {
@@ -59,6 +102,49 @@
     "relatedConcepts": [
       "base-case",
       "induction"
+    ]
+  },
+  {
+    "id": "ramsey-ann-small-cases",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 115,
+      "endLine": 160
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "R(r, 1) = 1 and R(2, s) = s",
+    "content": "The one-sided cases: `ramsey_one_right` gives a blue 1-clique in any nonempty type. `ramsey_two_s` handles `R(2, s) = s` by dichotomy — either some edge is red (a red 2-clique) or *every* edge is blue, making the whole vertex set a blue s-clique. This is the first genuinely combinatorial base case.",
+    "mathContext": "$R(r,1) = 1$; $R(2,s) = s$: a 2-coloring of $K_s$ has a red edge or is entirely blue.",
+    "relatedConcepts": [
+      "Ramsey number",
+      "clique",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "finite combinatorics"
+    ]
+  },
+  {
+    "id": "ramsey-ann-neighborhoods",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 163,
+      "endLine": 177
+    },
+    "type": "definition",
+    "significance": "supporting",
+    "title": "Red and Blue Neighborhoods Are Disjoint",
+    "content": "For a vertex `v`, the red (resp. blue) neighborhood collects the vertices joined to `v` by a red (resp. blue) edge. These two sets are disjoint (`neighborhoods_disjoint`): an edge has exactly one color, so no vertex is both a red and a blue neighbor of `v`.",
+    "mathContext": "$N_R(v) = \\{w \\ne v : c(v,w) = \\text{true}\\}$, $N_B(v)$ dually; $N_R(v) \\cap N_B(v) = \\varnothing$.",
+    "relatedConcepts": [
+      "neighborhood",
+      "disjointness",
+      "two-coloring"
+    ],
+    "prerequisites": [
+      "finite sets"
     ]
   },
   {
@@ -83,6 +169,27 @@
     ]
   },
   {
+    "id": "ramsey-ann-neighborhood-sum",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 195,
+      "endLine": 211
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "Neighborhoods Sum to n − 1 (the Pigeonhole)",
+    "content": "The red and blue neighborhoods of `v` partition the other `n-1` vertices, so their sizes add to `n - 1` (`neighborhood_card_sum`, via `card_filter_ne_self`). When `n-1` is large enough, one neighborhood must exceed a threshold by pigeonhole — the engine of the recurrence `R(r,s) <= R(r-1,s) + R(r,s-1)`.",
+    "mathContext": "$|N_R(v)| + |N_B(v)| = |\\alpha| - 1$; largeness of one side drives $R(r,s) \\le R(r{-}1,s) + R(r,s{-}1)$.",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "cardinality",
+      "partition"
+    ],
+    "prerequisites": [
+      "finite combinatorics"
+    ]
+  },
+  {
     "id": "clique-extension-red",
     "proofId": "ramseys-theorem",
     "range": {
@@ -104,6 +211,27 @@
     ]
   },
   {
+    "id": "ramsey-ann-blue-extend",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 232,
+      "endLine": 247
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Blue Clique Extension",
+    "content": "The mirror of the covered red-clique extension: a blue clique living inside `v`'s blue neighborhood grows by adding `v` itself (`extend_blue_clique`), since `v` is blue-adjacent to every member. This is the inductive growth step that lifts a clique found in a neighborhood back to the whole graph.",
+    "mathContext": "$s \\subseteq N_B(v)$ and $s$ a blue clique $\\Rightarrow s \\cup \\{v\\}$ a blue clique.",
+    "relatedConcepts": [
+      "clique extension",
+      "induction",
+      "monochromatic neighborhood"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
     "id": "ramsey-bound",
     "proofId": "ramseys-theorem",
     "range": {
@@ -122,6 +250,28 @@
     "relatedConcepts": [
       "ramsey-numbers",
       "upper-bounds"
+    ]
+  },
+  {
+    "id": "ramsey-ann-bounds-embedding",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 258,
+      "endLine": 289
+    },
+    "type": "theorem",
+    "significance": "supporting",
+    "title": "Concrete Bounds and the Embedding Lemma",
+    "content": "The classical bound `R(r,s) <= C(r+s-2, r-1)` is computed for small cases by `native_decide`: `R(3,3) <= 6`, `R(3,4) <= 10`, `R(4,4) <= 20`. (These `native_decide` checks rely on the kernel-reduction axiom `Lean.ofReduceBool`.) The helper `exists_embedding_of_card_ge` selects `n` distinct vertices from any sufficiently large finset, packaging the pigeonhole count as an actual embedding.",
+    "mathContext": "$R(r,s) \\le \\binom{r+s-2}{r-1}$: $R(3,3)\\le 6,\\ R(3,4)\\le 10,\\ R(4,4)\\le 20$; embedding $\\mathrm{Fin}\\,n \\hookrightarrow s$ when $n \\le |s|$.",
+    "relatedConcepts": [
+      "binomial coefficient",
+      "native_decide",
+      "embedding",
+      "Ramsey bound"
+    ],
+    "prerequisites": [
+      "binomial coefficients"
     ]
   },
   {
@@ -167,6 +317,72 @@
     "relatedConcepts": [
       "counting-argument",
       "induction"
+    ]
+  },
+  {
+    "id": "ramsey-ann-pentagon",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 448,
+      "endLine": 521
+    },
+    "type": "concept",
+    "significance": "key",
+    "title": "The Pentagon (C5) Lower-Bound Construction",
+    "content": "The lower bound needs an explicit triangle-free 2-coloring of K_5. The pentagon coloring makes an edge red exactly when its endpoints are cyclically adjacent (`|i - j| in {1,4} mod 5`), so the red graph is the 5-cycle and the blue graph is the complementary 5-cycle — both triangle-free. `pentagon_no_red_triangle_at` / `pentagon_no_blue_triangle_at` verify this by exhaustive `fin_cases` over all ordered triples of `Fin 5`.",
+    "mathContext": "color $(i,j)$ red $\\iff |i-j| \\in \\{1,4\\} \\pmod 5$; red graph $= C_5$, blue graph $= \\overline{C_5} \\cong C_5$, neither containing a triangle.",
+    "relatedConcepts": [
+      "pentagon graph C5",
+      "triangle-free graph",
+      "self-complementary graph",
+      "exhaustive case analysis"
+    ],
+    "prerequisites": [
+      "graph theory",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "ramsey-ann-lower-bound",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 523,
+      "endLine": 562
+    },
+    "type": "theorem",
+    "significance": "key",
+    "title": "No Monochromatic Triangle implies R(3,3) > 5",
+    "content": "Lifting the triangle-free property to cliques: the pentagon coloring has no red 3-clique (`pentagon_no_red_clique`) and no blue 3-clique (`pentagon_no_blue_clique`), because any 3-set would induce a monochromatic triangle. Hence `Fin 5` fails the Ramsey property (`ramsey_3_3_lower_bound`), i.e. `R(3,3) > 5`.",
+    "mathContext": "the pentagon coloring of $K_5$ has no monochromatic 3-clique, so $\\neg\\,\\mathrm{HasRamseyProperty}(\\mathrm{Fin}\\,5)\\,3\\,3$, i.e. $R(3,3) > 5$.",
+    "relatedConcepts": [
+      "Ramsey lower bound",
+      "monochromatic clique",
+      "witness construction"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
+  },
+  {
+    "id": "ramsey-ann-exact-and-multicolor",
+    "proofId": "ramseys-theorem",
+    "range": {
+      "startLine": 564,
+      "endLine": 625
+    },
+    "type": "concept",
+    "significance": "key",
+    "title": "R(3,3) = 6 and the Multicolor Extension",
+    "content": "Combining the lower bound `R(3,3) > 5` (pentagon) with the upper bound `R(3,3) <= 6` (`ramseyBound 3 3 = 6`) pins the exact value `R(3,3) = 6`; `ramsey_3_3_at_least_6` restates the lower bound as an explicit witness coloring. Part XII adds the multicolor Ramsey theorem as an explicit `axiom` (`multicolor_ramsey_exists`) for use downstream (e.g. Schur's theorem) — which is why the entry is correctly marked `axiomatized` (axiomCount 1).",
+    "mathContext": "$R(3,3) = 6$ (lower $>5$ from the pentagon, upper $\\le 6$ from the recurrence bound); the multicolor $R_c(k)$ is assumed as an axiom.",
+    "relatedConcepts": [
+      "Ramsey number",
+      "multicolor Ramsey",
+      "Schur's theorem",
+      "axiomatization"
+    ],
+    "prerequisites": [
+      "combinatorics"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ramseys-theorem` (Wiedijk #31).

## Problem
The 627-line proof had 8 annotations covering only the definitions, the neighborhood partition, and the main existence theorem. Roughly half the file — including the **entire pentagon (C₅) lower-bound construction** proving `R(3,3) = 6` — had zero coverage (~40%).

## Changes
**+10 annotations** for the uncovered sections:
- From coloring to red/blue graphs (`redGraph`, `blueGraph`, `IsRedClique`/`IsBlueClique`)
- Singleton base cases (`R(1,s) = R(r,1) = 1`)
- `R(r,1) = 1` and `R(2,s) = s`
- Red/blue neighborhoods and their disjointness
- The neighborhood-sum pigeonhole `|N_R(v)| + |N_B(v)| = n − 1` driving the recurrence
- Blue clique extension (mirror of the covered red case)
- Concrete binomial bounds `R(3,3)≤6, R(3,4)≤10, R(4,4)≤20` + the embedding lemma
- **The pentagon (C₅) construction**: red iff cyclically adjacent, both color classes triangle-free
- No monochromatic 3-clique ⟹ `R(3,3) > 5`
- `R(3,3) = 6` and the multicolor Ramsey axiom (`multicolor_ramsey_exists`)

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`; all ranges non-overlapping with the existing 8. Coverage ~40% → ~86%.

## Axiom integrity
`meta.json` is left unchanged and is **correct**: `status: axiomatized`, `badge: axiom`, `axiomCount: 1` matching the single literal `axiom multicolor_ramsey_exists`. Noted in the annotations that the concrete-bound `native_decide` checks rely on `Lean.ofReduceBool`; the main results do not use them.