### PR TITLE
research(fourth-root-2-irrational-oq-03): Galois property + |Gal(ℚ(⁴√2,i)/ℚ)|=8 [build-pending]

### DIFF
--- a/proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean
+++ b/proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean
@@ -1,0 +1,141 @@
+import Proofs.FourthRoot2GaloisClosure
+
+/-
+# The Galois closure of ℚ(⁴√2) is Galois of degree 8: |Gal(ℚ(⁴√2, i)/ℚ)| = 8
+  (fourth-root-2-irrational OQ-03)
+
+The parent entry `FourthRoot2GaloisClosure.lean` (research
+`fourth-root-2-irrational-oq-01`) builds the quadratic tower
+`ℚ ⊂ ℚ(⁴√2) ⊂ ℚ(⁴√2, i)` and secures the **degree** `[ℚ(⁴√2, i) : ℚ] = 8`, but
+it explicitly defers the *group-theoretic* content:
+
+> "The full identification of the Galois group with D₄ (constructing the 8
+> automorphisms and the group isomorphism) is left for a follow-up; here we
+> secure the degree and the tower."
+
+This file supplies the quantitative heart of that deferred step — the fact that
+`ℚ(⁴√2, i)` is a **Galois** extension of ℚ and that its automorphism group has
+**order exactly 8**:
+
+  * `isSplittingField`   — `X⁴ − 2` has `ℚ(⁴√2, i)` as its splitting field over ℚ;
+  * `isGalois`           — hence `ℚ(⁴√2, i) / ℚ` is Galois (separable + normal);
+  * `normal`             — the normality half, packaged separately;
+  * `card_gal`           — `#Gal(ℚ(⁴√2, i)/ℚ) = 8`.
+
+`card_gal` is the exact prerequisite for the D₄ identification: the Galois group
+is a group of order 8, and Galois theory now guarantees it acts faithfully with
+`ℚ` as its fixed field. Pinning `#Gal = [K : ℚ] = 8` is the step Galois theory
+adds on top of the parent's pure degree computation.
+
+## Method
+
+`ℚ(⁴√2, i)` is generated over ℚ by the four roots `±⁴√2, ±i·⁴√2` of `X⁴ − 2`:
+each satisfies `z⁴ = 2`, and conversely `z⁴ = 2 = (⁴√2)⁴` forces
+`(z / ⁴√2)⁴ = 1`, so `z / ⁴√2` is a fourth root of unity `∈ {1, −1, i, −i}` and
+`z ∈ {±⁴√2, ±i·⁴√2}` (the factorisation
+`z⁴ − a⁴ = (z−a)(z+a)(z−ia)(z+ia)`, valid because `i² = −1`).  Hence
+`adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i)`, which is Mathlib's definition of a
+splitting field; `X⁴ − 2` is separable (irreducible over the characteristic-zero
+field ℚ, being `minpoly ℚ (⁴√2)`), so the splitting field is Galois, and
+`IsGalois.card_aut_eq_finrank` turns the parent's degree `8` into `#Gal = 8`.
+
+Zero axioms; reuses only Mathlib and the parent `FourthRoot2GaloisClosure`.
+-/
+
+open Polynomial IntermediateField FourthRoot2GaloisClosure
+
+namespace FourthRoot2GaloisClosureOQ03
+
+open scoped Classical
+
+/-- The defining polynomial `X⁴ − 2 ∈ ℚ[X]`. -/
+noncomputable def p : ℚ[X] := X ^ 4 - C 2
+
+/-- `X⁴ − 2 = minpoly ℚ (⁴√2)`, hence irreducible over ℚ. -/
+theorem p_irreducible : Irreducible p := by
+  have h : p = minpoly ℚ a := minpoly_a.symm
+  rw [h]
+  exact minpoly.irreducible a_isIntegral
+
+theorem p_ne_zero : p ≠ 0 := p_irreducible.ne_zero
+
+/-- `X⁴ − 2` is separable: it is irreducible over the characteristic-zero field ℚ. -/
+theorem p_separable : p.Separable := p_irreducible.separable
+
+/-- `⁴√2 ≠ 0`, since `(⁴√2)⁴ = 2 ≠ 0`. -/
+theorem a_ne_zero : a ≠ 0 := fun h => by simpa [h] using a_pow_four
+
+/-- `⁴√2` is a root of `X⁴ − 2`. -/
+theorem a_mem_rootSet : a ∈ p.rootSet ℂ := by
+  rw [mem_rootSet]
+  refine ⟨p_ne_zero, ?_⟩
+  simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat]
+  rw [a_pow_four]; norm_num
+
+/-- `i·⁴√2` is a root of `X⁴ − 2`. -/
+theorem Ia_mem_rootSet : Complex.I * a ∈ p.rootSet ℂ := by
+  rw [mem_rootSet]
+  refine ⟨p_ne_zero, ?_⟩
+  simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat]
+  rw [I_mul_a_pow_four]; norm_num
+
+/-- The splitting set of `X⁴ − 2` in ℂ generates exactly `ℚ(⁴√2, i)`. -/
+theorem adjoin_rootSet_eq : adjoin ℚ (p.rootSet ℂ) = ℚ⟮a, Complex.I⟯ := by
+  apply le_antisymm
+  · -- `adjoin ℚ (rootSet) ≤ ℚ(⁴√2, i)`: every root `z` (`z⁴ = 2`) lies in the closure.
+    rw [adjoin_le_iff]
+    intro z hz
+    rw [mem_rootSet] at hz
+    have hz4 : z ^ 4 = 2 := by
+      have h0 := hz.2
+      simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat, sub_eq_zero] at h0
+      exact h0
+    have key : (z - a) * (z + a) * (z - Complex.I * a) * (z + Complex.I * a)
+        = z ^ 4 - a ^ 4 := by
+      have h := Complex.I_sq
+      linear_combination (a ^ 4 - a ^ 2 * z ^ 2) * h
+    have hzero : (z - a) * (z + a) * (z - Complex.I * a) * (z + Complex.I * a) = 0 := by
+      rw [key, hz4, a_pow_four]; norm_num
+    obtain ⟨hA, hnA, hIA, hnIA⟩ := roots_mem_closure
+    rcases mul_eq_zero.mp hzero with h | h4
+    · rcases mul_eq_zero.mp h with h | h3
+      · rcases mul_eq_zero.mp h with h1 | h2
+        · rw [sub_eq_zero] at h1; rw [h1]; exact hA
+        · rw [add_eq_zero_iff_eq_neg] at h2; rw [h2]; exact hnA
+      · rw [sub_eq_zero] at h3; rw [h3]; exact hIA
+    · rw [add_eq_zero_iff_eq_neg] at h4; rw [h4]; exact hnIA
+  · -- `ℚ(⁴√2, i) ≤ adjoin ℚ (rootSet)`: `⁴√2` and `i` both lie in the adjoined field.
+    have ha_mem : a ∈ adjoin ℚ (p.rootSet ℂ) := subset_adjoin ℚ _ a_mem_rootSet
+    have hIa_mem : Complex.I * a ∈ adjoin ℚ (p.rootSet ℂ) := subset_adjoin ℚ _ Ia_mem_rootSet
+    have hI_eq : Complex.I * a * a⁻¹ = Complex.I := by
+      rw [mul_assoc, mul_inv_cancel₀ a_ne_zero, mul_one]
+    have hI_mem : Complex.I ∈ adjoin ℚ (p.rootSet ℂ) :=
+      hI_eq ▸ mul_mem hIa_mem (inv_mem ha_mem)
+    rw [adjoin_le_iff, Set.insert_subset_iff, Set.singleton_subset_iff]
+    exact ⟨ha_mem, hI_mem⟩
+
+/-- `X⁴ − 2` has `ℚ(⁴√2, i)` as a splitting field over ℚ. -/
+theorem isSplittingField : p.IsSplittingField ℚ ℚ⟮a, Complex.I⟯ := by
+  have hsplit : (p.map (algebraMap ℚ ℂ)).Splits := IsAlgClosed.splits_codomain p
+  have inst : p.IsSplittingField ℚ (adjoin ℚ (p.rootSet ℂ)) :=
+    IntermediateField.adjoin_rootSet_isSplittingField hsplit
+  rwa [adjoin_rootSet_eq] at inst
+
+/-- **The Galois closure `ℚ(⁴√2, i)` is Galois over ℚ.** -/
+instance isGalois : IsGalois ℚ ℚ⟮a, Complex.I⟯ := by
+  haveI : p.IsSplittingField ℚ ℚ⟮a, Complex.I⟯ := isSplittingField
+  exact IsGalois.of_separable_splitting_field p_separable
+
+/-- The normality half of `isGalois`, packaged separately. -/
+theorem normal : Normal ℚ ℚ⟮a, Complex.I⟯ := IsGalois.to_normal
+
+/-- **The Galois group of `ℚ(⁴√2, i)` over ℚ has order 8.**
+`#Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8`.  This is the group-order input to the
+`D₄` identification, obtained by combining the parent's degree computation with
+the Galois property proved here. -/
+theorem card_gal :
+    Fintype.card (ℚ⟮a, Complex.I⟯ ≃ₐ[ℚ] ℚ⟮a, Complex.I⟯) = 8 := by
+  rw [IsGalois.card_aut_eq_finrank ℚ ℚ⟮a, Complex.I⟯]
+  exact finrank_galois_closure
+
+end FourthRoot2GaloisClosureOQ03

--- a/research/problems/fourth-root-2-irrational-oq-03/knowledge.md
+++ b/research/problems/fourth-root-2-irrational-oq-03/knowledge.md
@@ -1,0 +1,91 @@
+# Knowledge: fourth-root-2-irrational-oq-03
+
+## Summary
+
+The problem as originally framed (degree `[ℚ(⁴√2, i) : ℚ] = 8`) is **already fully
+proven** in the gallery: the sibling entry `fourth-root-2-irrational-oq-01`
+(`proofs/Proofs/FourthRoot2GaloisClosure.lean`, verified, 0-axiom) builds the tower
+`ℚ ⊂ ℚ(⁴√2) ⊂ ℚ(⁴√2, i)` and proves `finrank_galois_closure : Module.finrank ℚ
+ℚ⟮a, Complex.I⟯ = 8`, together with the crux `I_not_mem_adjoin_a` (`i ∉ ℚ(⁴√2)`)
+and `roots_mem_closure` (all four roots `±⁴√2, ±i·⁴√2` lie in the closure).
+
+The genuine open increment is the piece that `FourthRoot2GaloisClosure.lean`
+**explicitly defers** in its own docstring:
+
+> "The full identification of the Galois group with D₄ (constructing the 8
+> automorphisms and the group isomorphism) is left for a follow-up; here we
+> secure the degree and the tower."
+
+This session supplies the quantitative foundation of that deferred step: that
+`ℚ(⁴√2, i) / ℚ` is a **Galois** extension and that its automorphism group has
+**order exactly 8**.
+
+## Sessions
+
+## Session 2026-07-02 (Session 1) — Galois property and |Gal| = 8
+
+**Mode**: FRESH
+**Outcome**: proof complete (written, 0-sorry / 0-axiom); build BLOCKED by
+environment disk exhaustion — needs CI verification.
+
+### What I Did
+- Screened the seeker candidate pool: the top of the "available" pool is heavily
+  **stale** — ~24/57 available candidates already have an exact-name solved Lean
+  file, and spot-checks of many "no-file" candidates (composition-card-2pow,
+  hermite-floor-identity-oq-03, derangements Poisson limit, combinations log-
+  concavity, cauchy-interlacing codim-m, pascals-hexagon sylvester) found their
+  targets already proven in differently-named sibling files. See the session
+  finding below.
+- Identified the one genuine, significant (sig 7) open increment: the Galois
+  group structure deferred by `FourthRoot2GaloisClosure.lean`.
+- Wrote `proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean`
+  (`namespace FourthRoot2GaloisClosureOQ03`), building on the parent:
+  * `p := X⁴ − 2`; `p_irreducible` (`= minpoly ℚ (⁴√2)`), `p_separable`
+    (char-zero irreducible);
+  * `adjoin_rootSet_eq : adjoin ℚ ((X⁴−2).rootSet ℂ) = ℚ⟮a, Complex.I⟯`
+    — the fourth-roots-of-unity classification `z⁴ = 2 ⟹ z ∈ {±a, ±ia}` via the
+    factorisation `z⁴ − a⁴ = (z−a)(z+a)(z−ia)(z+ia)` (uses `i² = −1`);
+  * `isSplittingField : (X⁴−2).IsSplittingField ℚ ℚ⟮a, Complex.I⟯` (splits over ℂ
+    by `IsAlgClosed.splits_codomain`, generation by `adjoin_rootSet_eq`);
+  * `isGalois : IsGalois ℚ ℚ⟮a, Complex.I⟯` via
+    `IsGalois.of_separable_splitting_field`;
+  * `normal : Normal ℚ ℚ⟮a, Complex.I⟯`;
+  * `card_gal : Fintype.card (ℚ⟮a, Complex.I⟯ ≃ₐ[ℚ] ℚ⟮a, Complex.I⟯) = 8` via
+    `IsGalois.card_aut_eq_finrank` + the parent's `finrank_galois_closure`.
+
+### Key Findings
+- All Mathlib API used was grep-confirmed against the pinned Mathlib source:
+  `IntermediateField.adjoin_rootSet_isSplittingField` (needs
+  `(p.map (algebraMap K L)).Splits`, the single-argument `Polynomial.Splits`);
+  `IsAlgClosed.splits_codomain`; `Irreducible.separable [CharZero]`;
+  `IsGalois.of_separable_splitting_field`; `IsGalois.card_aut_eq_finrank`.
+- The proof is 0-sorry / 0-axiom by construction and reuses only Mathlib + the
+  parent file.
+
+### Build blocker (why not verified locally)
+- Host disk sat at 89–96% for the whole session (≈0.5–1.5 GiB free), actively
+  shrinking under concurrent agents.
+- `docker-build.sh` failed: the Mathlib `.ltar` cache could not decompress
+  ("No space left on device", leantar error 101 on 7727 files).
+- Host `lake env lean` fallback also failed: the cached Mathlib olean tree is
+  **incomplete** (top-level `Mathlib.olean` present, but individual module oleans
+  such as `Mathlib/Algebra/Ring/Subsemiring/MulOpposite.olean` are missing), so
+  `import Mathlib` cannot resolve without rebuilding Mathlib (forbidden/impossible
+  on the available disk).
+
+### Next Steps
+- Have CI / the deployer / a mechanic build `Proofs.FourthRoot2GaloisClosureOQ03`
+  when disk is healthy; if it compiles clean, promote to a verified gallery entry
+  (meta.json, annotations) as a child of `fourth-root-2-irrational`.
+- Downstream open question (new): identify `Gal(ℚ(⁴√2, i)/ℚ) ≅ D₄` explicitly
+  (construct the 8 automorphisms / the group isomorphism). Note the abstract
+  `Gal(X⁴−2) ≅ D₄` is already handled in the `inverse-galois-d4` entry via a
+  Sylow-2 argument; the remaining work is the concrete identification for THIS
+  ℂ-model field `ℚ⟮√√2, i⟯`.
+
+### Session finding: seeker candidate pool is saturated
+Every top-of-pool candidate examined this session was already solved somewhere in
+the gallery (often in the parent or a differently-named sibling file). The pool's
+"available" status is stale relative to shipped work. Recommend the seeker re-sync
+`available` statuses against `src/data/proofs/*/meta.json` and existing
+`proofs/Proofs/*.lean` before proposing further children in saturated topics.


### PR DESCRIPTION
## Summary

Supplies the group-order structure that the parent entry
`FourthRoot2GaloisClosure.lean` (`fourth-root-2-irrational-oq-01`) **explicitly
defers** in its own docstring:

> "The full identification of the Galois group with D₄ ... is left for a
> follow-up; here we secure the degree and the tower."

The parent already proves the degree `[ℚ(⁴√2, i) : ℚ] = 8` and the tower. This PR
adds the **Galois** property and the **group order**:

- `adjoin_rootSet_eq` — `adjoin ℚ ((X⁴−2).rootSet ℂ) = ℚ⟮⁴√2, i⟯`
  (fourth-roots-of-unity classification `z⁴ = 2 ⟹ z ∈ {±⁴√2, ±i·⁴√2}`)
- `isSplittingField` — `X⁴ − 2` has `ℚ(⁴√2, i)` as its splitting field over ℚ
- `isGalois`, `normal` — the extension is Galois / normal
- `card_gal` — **`#Gal(ℚ(⁴√2, i)/ℚ) = 8`** (via `IsGalois.card_aut_eq_finrank`
  + the parent's `finrank_galois_closure`)

This is the quantitative prerequisite for the downstream `D₄` identification. The
proof is `0-sorry / 0-axiom` by construction and reuses only Mathlib + the parent
file. All Mathlib API used was grep-verified against the pinned Mathlib source.

## ⚠️ Build status: NOT machine-verified locally — needs CI verification

The proof could **not** be built in this session due to environment disk
exhaustion:
- `docker-build.sh` — Mathlib `.ltar` cache failed to decompress
  (`No space left on device`, leantar error 101).
- Host `lake env lean` fallback — the cached Mathlib olean tree is incomplete
  (individual module oleans missing), so `import Mathlib` cannot resolve.

**Please build `Proofs.FourthRoot2GaloisClosureOQ03` on a healthy-disk runner
before merge.** If it compiles clean, it can be promoted to a verified gallery
entry (meta.json/annotations) as a child of `fourth-root-2-irrational`; no gallery
`meta.json` is included here to avoid claiming a verified entry that has not been
machine-checked.

## Note on the candidate pool
The seeker "available" pool is largely stale — most top candidates examined this
session were already solved in the gallery (parent or sibling files). Details in
`research/problems/fourth-root-2-irrational-oq-03/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)