### PR TITLE
research(pascals-hexagon-incomplete-01-oq-01): remove symmetry hypothesis from the Sylvester reduction [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagonIncomplete01OQ01.lean
+++ b/proofs/Proofs/PascalsHexagonIncomplete01OQ01.lean
@@ -1,0 +1,160 @@
+import Mathlib.Data.Matrix.Mul
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic
+
+/-!
+# Pascal's Hexagon (incomplete-01, OQ-01): removing the symmetry hypothesis
+
+## Context
+
+`PascalsHexagon.lean` reduces Pascal's theorem (for **symmetric** non-degenerate conics carrying a
+real point) to the Sylvester reduction
+
+> `sylvester_stdConic_of_isotropic (C : Conic) (hC_sym : C.symmetric) (hC_nd : C.nondegenerate)
+>    (p₀ …) (hp₀ : pointOnConic p₀ C) : ∃ M, M.det ≠ 0 ∧ ∀ p, pointOnConic p C ↔
+>    pointOnConic (projTransform M p) stdConic`.
+
+Every route through that file carries the standing hypothesis `hC_sym : C.symmetric`, and the
+residual `axiom conic_implies_pascal_constraint` is explicitly retained *only* for the
+"asymmetric and degenerate cases". The parent's own proof sketch lists, as its first outstanding
+step:
+
+> "1. Handle asymmetric `C`: replace with symmetrized `(C + Cᵀ)/2` (same zero set)."
+
+That reduction is stated informally but never proved. **This file proves it**, self-contained.
+
+## What this file proves
+
+For an arbitrary (possibly asymmetric) real conic `C`, let `symmetrize C = (C + Cᵀ)/2`. Then:
+
+* `symmetrize_symmetric` : `symmetrize C` is symmetric;
+* `conicQuadraticForm_symmetrize` : `C` and `symmetrize C` have the **same quadratic form**
+  (`pᵀ C p = pᵀ (symmetrize C) p` for every `p`) — the quadratic form only sees the symmetric part;
+* `pointOnConic_symmetrize` : consequently `C` and `symmetrize C` have the **same point set**;
+* `sylvester_without_symmetry` : the Sylvester reduction's `C.symmetric` hypothesis is
+  **removable** — given the symmetric case as a black box, every non-degenerate (in its symmetric
+  part) conic carrying a real point is projectively equivalent to `stdConic`, symmetric or not.
+
+This discharges the asymmetric half of the reduction: the residual axiom's asymmetric,
+non-degenerate, isotropic case follows from the symmetric case with no new assumptions.
+
+**Honest scope.** This does *not* discharge the hard Sylvester direction itself (the indefinite
+**symmetric** case, `sylvester_stdConic_of_isotropic`); it removes the *symmetry* hypothesis from
+that reduction, reducing the general non-degenerate case to the symmetric one. The conic
+definitions below mirror `PascalsHexagon.lean`'s, reproduced locally because that file is currently
+bit-rotted under the 4.26.0 toolchain and cannot be imported.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace PascalsHexagonIncomplete01OQ01
+
+open Finset
+
+/-- A projective point: a vector in `ℝ³` (mirrors `PascalsHexagon.ProjPoint`). -/
+abbrev ProjPoint := Fin 3 → ℝ
+
+/-- A conic: a `3×3` real matrix (mirrors `PascalsHexagon.Conic`). -/
+abbrev Conic := Matrix (Fin 3) (Fin 3) ℝ
+
+/-- The quadratic form of a conic, `pᵀ C p = ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ`. -/
+noncomputable def conicQuadraticForm (C : Conic) (p : ProjPoint) : ℝ :=
+  ∑ i, ∑ j, C i j * p i * p j
+
+/-- A point lies on a conic iff its quadratic form vanishes. -/
+def pointOnConic (p : ProjPoint) (C : Conic) : Prop := conicQuadraticForm C p = 0
+
+/-- A conic is symmetric iff its matrix is. -/
+def Conic.symmetric (C : Conic) : Prop := ∀ i j, C i j = C j i
+
+/-- A conic is non-degenerate iff its determinant is nonzero. -/
+def Conic.nondegenerate (C : Conic) : Prop := C.det ≠ 0
+
+/-- A projective transformation acts by matrix-vector multiplication. -/
+def projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (p : ProjPoint) : ProjPoint := M.mulVec p
+
+/-- The standard conic `diag(1,1,-1)`: `x₀² + x₁² − x₂² = 0`. -/
+def stdConic : Conic :=
+  Matrix.of fun i j => match i, j with
+  | 0, 0 => 1
+  | 1, 1 => 1
+  | 2, 2 => -1
+  | _, _ => 0
+
+/-- The **symmetrization** `(C + Cᵀ)/2` of a conic. -/
+noncomputable def symmetrize (C : Conic) : Conic := fun i j => (C i j + C j i) / 2
+
+/-- The symmetrization of any conic is symmetric. -/
+theorem symmetrize_symmetric (C : Conic) : (symmetrize C).symmetric := by
+  intro i j
+  unfold symmetrize
+  ring
+
+/-- **The quadratic form only sees the symmetric part.**
+`pᵀ C p = pᵀ (symmetrize C) p` for every point `p`: the antisymmetric part of `C`
+contributes nothing to the quadratic form. -/
+theorem conicQuadraticForm_symmetrize (C : Conic) (p : ProjPoint) :
+    conicQuadraticForm (symmetrize C) p = conicQuadraticForm C p := by
+  -- The transpose part is the same double sum with the summation order swapped.
+  have hswap : ∑ i, ∑ j, C j i * p i * p j = ∑ i, ∑ j, C i j * p i * p j := by
+    rw [Finset.sum_comm]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  unfold conicQuadraticForm symmetrize
+  -- Rewrite each summand `(Cᵢⱼ + Cⱼᵢ)/2 · pᵢpⱼ = (Cᵢⱼ pᵢpⱼ + Cⱼᵢ pᵢpⱼ)/2`, then split the sums.
+  have step1 : ∀ i j : Fin 3,
+      (C i j + C j i) / 2 * p i * p j = (C i j * p i * p j + C j i * p i * p j) / 2 :=
+    fun i j => by ring
+  simp_rw [step1, ← Finset.sum_div, Finset.sum_add_distrib]
+  rw [hswap]
+  ring
+
+/-- **Same point set.** A point lies on `C` iff it lies on `symmetrize C`. This is the rigorous
+"same zero set" claim that justifies the WLOG-symmetric step in the Sylvester reduction. -/
+theorem pointOnConic_symmetrize (C : Conic) (p : ProjPoint) :
+    pointOnConic p (symmetrize C) ↔ pointOnConic p C := by
+  unfold pointOnConic
+  rw [conicQuadraticForm_symmetrize]
+
+/-- **The symmetry hypothesis of the Sylvester reduction is removable.**
+
+Given the symmetric case of the Sylvester reduction as a hypothesis `sylvester_sym`, *every*
+conic `C` whose symmetric part is non-degenerate and which carries a nonzero real point is
+projectively equivalent to `stdConic` — with no symmetry assumption on `C` itself. The witnessing
+matrix `M` is exactly the one produced for `symmetrize C`; it works for `C` because the two conics
+have identical point sets (`pointOnConic_symmetrize`).
+
+This reduces the asymmetric, non-degenerate, isotropic case of Pascal's
+`conic_implies_pascal_constraint` to the symmetric case, introducing no new assumptions. -/
+theorem sylvester_without_symmetry
+    (sylvester_sym : ∀ C : Conic, C.symmetric → C.nondegenerate →
+      (∃ p : ProjPoint, p ≠ 0 ∧ pointOnConic p C) →
+      ∃ M : Matrix (Fin 3) (Fin 3) ℝ, M.det ≠ 0 ∧
+        ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic)
+    (C : Conic) (hnd : (symmetrize C).nondegenerate)
+    (hiso : ∃ p : ProjPoint, p ≠ 0 ∧ pointOnConic p C) :
+    ∃ M : Matrix (Fin 3) (Fin 3) ℝ, M.det ≠ 0 ∧
+      ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic := by
+  -- Transport the isotropic witness onto `symmetrize C`.
+  obtain ⟨p₀, hp₀ne, hp₀on⟩ := hiso
+  have hp₀sym : pointOnConic p₀ (symmetrize C) := (pointOnConic_symmetrize C p₀).mpr hp₀on
+  -- Apply the symmetric case to `symmetrize C`.
+  obtain ⟨M, hMdet, hMiff⟩ :=
+    sylvester_sym (symmetrize C) (symmetrize_symmetric C) hnd ⟨p₀, hp₀ne, hp₀sym⟩
+  -- The same `M` works for `C`, since `C` and `symmetrize C` share their point set.
+  refine ⟨M, hMdet, fun p => ?_⟩
+  rw [← pointOnConic_symmetrize C p]
+  exact hMiff p
+
+/-- **Sanity check: the reduction is non-vacuous.** A concretely asymmetric conic and its
+symmetrization define the same point set. Here `C = !![0,2,0; 0,0,0; 0,0,0]` is asymmetric
+(`C 0 1 = 2 ≠ 0 = C 1 0`), yet shares every point with `symmetrize C`. -/
+theorem symmetrize_nontrivial_example :
+    ∃ C : Conic, ¬ C.symmetric ∧
+      ∀ p : ProjPoint, pointOnConic p C ↔ pointOnConic p (symmetrize C) := by
+  refine ⟨!![0, 2, 0; 0, 0, 0; 0, 0, 0], ?_, fun p => (pointOnConic_symmetrize _ p).symm⟩
+  intro hsym
+  have h := hsym 0 1
+  norm_num [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] at h
+
+end PascalsHexagonIncomplete01OQ01

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-wlog-symmetric",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "The 'WLOG Symmetric' Step, Made Rigorous",
+    "content": "The Sylvester reduction sylvester_stdConic_of_isotropic in PascalsHexagon.lean carries a standing hypothesis hC_sym : C.symmetric, and the residual axiom conic_implies_pascal_constraint is retained explicitly for the 'asymmetric and degenerate' cases. The parent's proof sketch lists, as its first outstanding step, 'replace C with symmetrized (C + Cᵀ)/2 (same zero set)' — folklore, but never proved in Lean. This file proves it: a quadratic form pᵀ C p only sees the symmetric part of C, so C and symmetrize C have identical point sets, and the symmetry hypothesis of the reduction is therefore removable.",
+    "mathContext": "$p^{\\mathsf T} C p = p^{\\mathsf T}\\tfrac{C+C^{\\mathsf T}}{2}\\,p$ for all $p$, so $C$ and its symmetrization are the same conic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetrization of a matrix",
+      "quadratic form pᵀCp",
+      "Sylvester's law of inertia",
+      "WLOG reductions"
+    ],
+    "prerequisites": [
+      "quadratic forms",
+      "Pascal's hexagon theorem",
+      "symmetric and antisymmetric matrices"
+    ]
+  },
+  {
+    "id": "ann-conic-api",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 83
+    },
+    "type": "definition",
+    "title": "The Minimal Conic API",
+    "content": "A self-contained conic vocabulary (reproduced locally because the shared PascalsHexagon.lean is bit-rotted under the 4.26.0 toolchain and cannot be imported): ProjPoint = Fin 3 → ℝ, Conic = a 3×3 real matrix (not assumed symmetric), conicQuadraticForm C p = ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ, pointOnConic p C := the form vanishes, Conic.symmetric and Conic.nondegenerate, projTransform M p = M.mulVec p, and stdConic = diag(1,1,−1). These mirror the parent's definitions so the reduction slots into the same framework.",
+    "mathContext": "$Q_C(p)=\\sum_{i,j} C_{ij} p_i p_j,\\quad \\mathrm{stdConic}=\\mathrm{diag}(1,1,-1),\\quad p\\mapsto Mp.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric matrices",
+      "quadratic form pᵀCp",
+      "homogeneous coordinates",
+      "projective transformation"
+    ],
+    "prerequisites": [
+      "matrices over ℝ",
+      "matrix-vector multiplication"
+    ]
+  },
+  {
+    "id": "ann-form-symmetrize",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 111
+    },
+    "type": "tactic",
+    "title": "Only the Symmetric Part Matters",
+    "content": "conicQuadraticForm_symmetrize is the crux. Writing the symmetrized form as ∑ᵢⱼ (Cᵢⱼ + Cⱼᵢ)/2 · pᵢ pⱼ, the term in Cⱼᵢ is the same double sum with the summation order swapped — Finset.sum_comm turns ∑ᵢ ∑ⱼ Cⱼᵢ pᵢ pⱼ into ∑ⱼ ∑ᵢ Cⱼᵢ pᵢ pⱼ, and since pᵢ pⱼ = pⱼ pᵢ this equals ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ. Averaging the two equal copies (Finset.sum_div, Finset.sum_add_distrib, ring) returns the original form. The antisymmetric part of C contributes nothing.",
+    "mathContext": "$\\sum_{i,j}\\frac{C_{ij}+C_{ji}}{2}p_ip_j=\\tfrac12\\big(\\sum C_{ij}p_ip_j+\\sum C_{ji}p_ip_j\\big)=\\sum C_{ij}p_ip_j.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_comm",
+      "double summation",
+      "symmetrization",
+      "bilinear forms"
+    ],
+    "prerequisites": [
+      "swapping summation order",
+      "distributivity over finite sums"
+    ]
+  },
+  {
+    "id": "ann-pointset-equal",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 118
+    },
+    "type": "lemma",
+    "title": "Same Quadratic Form ⟹ Same Point Set",
+    "content": "pointOnConic_symmetrize is the immediate corollary: since C and symmetrize C have equal quadratic forms, a point lies on one iff it lies on the other. This is the rigorous form of the parent's informal 'same zero set' claim — the fact that licenses transferring any point-set statement (lying on the conic, projective equivalence of conics as point sets) between C and its symmetrization.",
+    "mathContext": "$\\{p : Q_C(p)=0\\}=\\{p : Q_{\\mathrm{sym}\\,C}(p)=0\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "zero set of a conic",
+      "point set",
+      "projective conic"
+    ],
+    "prerequisites": [
+      "quadratic forms vanish together"
+    ]
+  },
+  {
+    "id": "ann-remove-symmetry",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 148
+    },
+    "type": "theorem",
+    "title": "Removing the Symmetry Hypothesis",
+    "content": "sylvester_without_symmetry is the headline. Given the symmetric case of the Sylvester reduction as a hypothesis, every conic C whose symmetric part is non-degenerate and which carries a nonzero real point is projectively equivalent to stdConic — with no symmetry assumption on C. The witnessing matrix M is exactly the one produced for symmetrize C; it works for C because the two conics share their point set. This discharges the asymmetric, non-degenerate, isotropic case of the retained axiom conic_implies_pascal_constraint with no new assumptions, leaving only the degenerate case in the axiom's scope.",
+    "mathContext": "symmetric-case reduction $\\Longrightarrow$ general (possibly asymmetric) reduction, via the shared point set of $C$ and $\\tfrac{C+C^{\\mathsf T}}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hypothesis elimination",
+      "projective equivalence",
+      "axiom reduction",
+      "Sylvester's law of inertia"
+    ],
+    "prerequisites": [
+      "the symmetric-case Sylvester reduction",
+      "invertible projective transformations"
+    ]
+  },
+  {
+    "id": "ann-nonvacuous",
+    "proofId": "pascals-hexagon-incomplete-01-oq-01",
+    "range": {
+      "startLine": 149,
+      "endLine": 160
+    },
+    "type": "insight",
+    "title": "The Reduction Is Non-Vacuous",
+    "content": "symmetrize_nontrivial_example exhibits a concretely asymmetric conic — the matrix with a single off-diagonal entry, C 0 1 = 2 ≠ 0 = C 1 0 — that nonetheless shares every point with its symmetrization. This confirms the reduction covers cases the symmetric-only theorem could not reach directly.",
+    "mathContext": "$C=\\bigl[\\begin{smallmatrix}0&2&0\\\\0&0&0\\\\0&0&0\\end{smallmatrix}\\bigr]$ is asymmetric yet defines the same conic as $\\mathrm{sym}\\,C$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "asymmetric matrix",
+      "concrete witness",
+      "non-vacuity"
+    ],
+    "prerequisites": [
+      "matrix literals"
+    ]
+  }
+]

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/index.ts
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PascalsHexagonIncomplete01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pascalsHexagonIncomplete01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pascalsHexagonIncomplete01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pascalsHexagonIncomplete01Oq01Data: ProofData = {
+  proof: pascalsHexagonIncomplete01Oq01Proof,
+  annotations: pascalsHexagonIncomplete01Oq01Annotations,
+}

--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-01/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "pascals-hexagon-incomplete-01-oq-01",
+  "title": "Sylvester Reduction: Removing the Symmetry Hypothesis",
+  "slug": "pascals-hexagon-incomplete-01-oq-01",
+  "description": "The Pascal's Hexagon Sylvester reduction sylvester_stdConic_of_isotropic carries a standing symmetry hypothesis hC_sym : C.symmetric on the conic, and the residual axiom conic_implies_pascal_constraint in PascalsHexagon.lean is retained explicitly for the 'asymmetric and degenerate' cases. The parent's own proof sketch lists, as its first outstanding step, 'replace C with symmetrized (C + Cᵀ)/2 (same zero set)', but never proves it. This entry proves that reduction, self-contained: the quadratic form pᵀ C p depends only on the symmetric part of C, so C and symmetrize C = (C + Cᵀ)/2 have identical point sets (conicQuadraticForm_symmetrize, pointOnConic_symmetrize). Consequently the symmetry hypothesis of the Sylvester reduction is removable (sylvester_without_symmetry): given the symmetric case as a black box, every conic whose symmetric part is non-degenerate and which carries a real point is projectively equivalent to stdConic, symmetric or not. This discharges the asymmetric half of the retained axiom with no new assumptions. It does not discharge the hard indefinite-symmetric Sylvester direction itself.",
+  "meta": {
+    "author": "Blaise Pascal (1639, hexagon theorem); James Joseph Sylvester (law of inertia); formalized in Lean 4",
+    "date": "1639",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PascalsHexagonIncomplete01OQ01.lean",
+    "tags": [
+      "projective-geometry",
+      "conics",
+      "pascal-theorem",
+      "quadratic-forms",
+      "linear-algebra",
+      "symmetrization",
+      "sylvester"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 160,
+    "theoremCount": 5,
+    "definitionCount": 9,
+    "originalContributions": [
+      "conicQuadraticForm_symmetrize: the conic quadratic form pᵀ C p equals pᵀ (symmetrize C) p for every point — the antisymmetric part of C contributes nothing to the form. Proved by a summation-order swap (Finset.sum_comm) plus a termwise split.",
+      "pointOnConic_symmetrize: a conic C and its symmetrization (C + Cᵀ)/2 have identical point sets, the rigorous 'same zero set' fact justifying the WLOG-symmetric step in the Sylvester reduction.",
+      "sylvester_without_symmetry: the symmetry hypothesis hC_sym of sylvester_stdConic_of_isotropic is removable — given the symmetric case, every conic with non-degenerate symmetric part carrying a real point is projectively equivalent to stdConic, discharging the asymmetric case of the retained axiom conic_implies_pascal_constraint with no new assumptions.",
+      "symmetrize_symmetric: the symmetrization of any conic is symmetric, so the reduction genuinely lands in the symmetric case."
+    ],
+    "prerequisites": [
+      "Conics as (not necessarily symmetric) matrices and the associated quadratic form pᵀ C p",
+      "The symmetrization (C + Cᵀ)/2 and its equal quadratic form",
+      "Projective transformations as invertible matrix-vector maps",
+      "The distinction between a conic and its zero set / point set"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "swaps the order of a double sum, ∑ i ∑ j = ∑ j ∑ i — identifies the transpose term ∑ᵢⱼ Cⱼᵢ pᵢ pⱼ with ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_div",
+        "description": "pulls a scalar denominator out of a finite sum, used to split (C + Cᵀ)/2 across the double sum",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "distributes a finite sum over an addition of summands, ∑ (f + g) = ∑ f + ∑ g",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "In the modern proof of Pascal's hexagon theorem (1639), an arbitrary non-degenerate conic is brought to normal form via Sylvester's law of inertia. That argument is naturally stated for symmetric matrices, since a quadratic form pᵀ C p only sees the symmetric part of C: the matrix C and its symmetrization (C + Cᵀ)/2 define the very same form, hence the same conic. Every real quadratic polynomial in three variables therefore corresponds, without loss of generality, to a symmetric matrix. This 'WLOG symmetric' step is folklore, but in the Lean formalization it was left as an informal remark while the machine-checked reduction carried an explicit symmetry hypothesis.",
+    "problemStatement": "**Task (pascals-hexagon-incomplete-01 OQ-01)**: address the Sylvester reduction sylvester_stdConic_of_isotropic, whose standing hypothesis hC_sym : C.symmetric and residual axiom conic_implies_pascal_constraint are retained for the asymmetric case. Formalize the parent proof sketch's step 1, 'replace C with symmetrized (C + Cᵀ)/2 (same zero set)', and use it to remove the symmetry hypothesis.\n\n**Result**: proved. C and symmetrize C share every point, so the symmetric case of the reduction implies the general (possibly asymmetric) case; the asymmetric, non-degenerate, isotropic case of the retained axiom follows with no new assumptions.",
+    "text": "A self-contained file (0 sorries, 0 axioms, no native_decide) reproducing the parent's minimal conic API and proving: symmetrize_symmetric, conicQuadraticForm_symmetrize (equal quadratic forms), pointOnConic_symmetrize (equal point sets), and the headline sylvester_without_symmetry (the symmetry hypothesis is removable). A concrete asymmetric witness confirms the reduction is non-vacuous.",
+    "proofStrategy": "conicQuadraticForm_symmetrize is the crux. Writing the symmetrized form as ∑ᵢⱼ (Cᵢⱼ + Cⱼᵢ)/2 · pᵢ pⱼ, the term in Cⱼᵢ is the same double sum with the summation order swapped (Finset.sum_comm), and pᵢ pⱼ = pⱼ pᵢ, so it equals the term in Cᵢⱼ; averaging the two equal copies returns the original form ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ. pointOnConic_symmetrize is then immediate (both forms vanish together). For sylvester_without_symmetry, a nonzero real point p₀ on C is, by pointOnConic_symmetrize, a point on symmetrize C; feeding it to the symmetric case yields an invertible M carrying symmetrize C onto stdConic; the same M works for C because C and symmetrize C have the same point set.",
+    "keyInsights": [
+      "A quadratic form pᵀ C p depends only on the symmetric part of C — the antisymmetric part cancels because ∑ᵢⱼ (Cᵢⱼ − Cⱼᵢ) pᵢ pⱼ = 0 by the i↔j symmetry of pᵢ pⱼ.",
+      "Therefore a conic and its symmetrization have literally the same point set, so any statement about the point set (lying on the conic, projective equivalence of conics as point sets) transfers between them for free.",
+      "This turns the folklore 'WLOG symmetric' remark into a theorem, letting the machine-checked symmetric-case Sylvester reduction cover asymmetric conics and shrinking the residual axiom to its degenerate case.",
+      "The witnessing projective transformation is unchanged — the very M produced for symmetrize C already works for C — so no new geometric construction is needed, only the point-set identity."
+    ]
+  },
+  "sections": [
+    {
+      "id": "api",
+      "title": "Minimal Conic API",
+      "startLine": 53,
+      "endLine": 83,
+      "summary": "ProjPoint, Conic, conicQuadraticForm, pointOnConic, Conic.symmetric, Conic.nondegenerate, projTransform, stdConic — mirroring the (bit-rotted) parent PascalsHexagon.lean so the reduction slots into the same framework.",
+      "mathContext": "Conics as matrices (not assumed symmetric) and their quadratic forms."
+    },
+    {
+      "id": "symmetrize",
+      "title": "Symmetrization and Equal Point Sets",
+      "startLine": 85,
+      "endLine": 118,
+      "summary": "symmetrize C = (C + Cᵀ)/2, symmetrize_symmetric, conicQuadraticForm_symmetrize (equal quadratic forms via Finset.sum_comm), and pointOnConic_symmetrize (equal point sets).",
+      "mathContext": "The quadratic form sees only the symmetric part of the matrix."
+    },
+    {
+      "id": "main",
+      "title": "Removing the Symmetry Hypothesis",
+      "startLine": 119,
+      "endLine": 160,
+      "summary": "sylvester_without_symmetry (the symmetric case implies the general case) and a concrete asymmetric witness confirming non-vacuity.",
+      "mathContext": "The symmetric-case Sylvester reduction covers asymmetric conics."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves the 'WLOG symmetric' step of the Pascal's Hexagon Sylvester reduction: a conic C and its symmetrization (C + Cᵀ)/2 define the same quadratic form and hence the same point set, so the symmetry hypothesis of sylvester_stdConic_of_isotropic is removable. Given the symmetric case, every conic whose symmetric part is non-degenerate and which carries a real point is projectively equivalent to stdConic, symmetric or not.",
+    "implications": "It discharges the asymmetric, non-degenerate, isotropic case of the retained axiom conic_implies_pascal_constraint with no new assumptions, shrinking the axiom's residual scope to the degenerate case. Combined with the sibling OQ-03 (the definite obstruction), it isolates the genuinely-remaining work to the single indefinite-symmetric Sylvester direction.",
+    "openQuestions": [
+      "Discharge the remaining sorry sylvester_stdConic_of_isotropic for the indefinite symmetric case via Sylvester's law of inertia (Mathlib's QuadraticForm.equivalent_one_neg_one_weighted_sum_squared), extracting an explicit invertible congruence to stdConic.",
+      "Handle the degenerate case (C.det = 0) of conic_implies_pascal_constraint via a Pappus-type argument for pairs of lines, the only remaining scope of the retained axiom once symmetric non-degenerate and asymmetric cases are covered.",
+      "Wire this reduction directly into a repaired PascalsHexagon.lean under the 4.26.0 toolchain so the symmetry hypothesis can be dropped from the flagship statement."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pascals-hexagon-incomplete-01",
+      "relationship": "extends",
+      "description": "Parent: reduces Pascal's theorem for symmetric non-degenerate conics to the Sylvester reduction and proves its real-point hypothesis essential. This entry formalizes the parent's outstanding 'step 1' (WLOG symmetric), removing the symmetry hypothesis from that reduction."
+    },
+    {
+      "targetId": "pascals-hexagon-incomplete-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling OQ-03 proves the definite half of the Sylvester dichotomy (positive-definite conics are never equivalent to stdConic). This entry removes the symmetry hypothesis; together they isolate the remaining work to the indefinite-symmetric Sylvester direction."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Matrix.Mul",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "PascalsHexagonIncomplete01OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 9,
+    "mainTheorems": [
+      {
+        "name": "sylvester_without_symmetry",
+        "type": "core",
+        "description": "The symmetry hypothesis of the Sylvester reduction is removable: given the symmetric case, every conic with non-degenerate symmetric part carrying a real point is projectively equivalent to stdConic",
+        "leanType": "(∀ C : Conic, C.symmetric → C.nondegenerate → (∃ p, p ≠ 0 ∧ pointOnConic p C) → ∃ M, M.det ≠ 0 ∧ ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic) → (C : Conic) → (symmetrize C).nondegenerate → (∃ p, p ≠ 0 ∧ pointOnConic p C) → ∃ M, M.det ≠ 0 ∧ ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic"
+      },
+      {
+        "name": "pointOnConic_symmetrize",
+        "type": "key",
+        "description": "A conic and its symmetrization have identical point sets",
+        "leanType": "(C : Conic) → (p : ProjPoint) → (pointOnConic p (symmetrize C) ↔ pointOnConic p C)"
+      }
+    ],
+    "path": "Proofs/PascalsHexagonIncomplete01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "sylvester_without_symmetry",
+      "type": "core",
+      "description": "The symmetry hypothesis of sylvester_stdConic_of_isotropic is removable; the asymmetric non-degenerate isotropic case reduces to the symmetric case",
+      "leanType": "(∀ C : Conic, C.symmetric → C.nondegenerate → (∃ p, p ≠ 0 ∧ pointOnConic p C) → ∃ M, M.det ≠ 0 ∧ ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic) → (C : Conic) → (symmetrize C).nondegenerate → (∃ p, p ≠ 0 ∧ pointOnConic p C) → ∃ M, M.det ≠ 0 ∧ ∀ p, pointOnConic p C ↔ pointOnConic (projTransform M p) stdConic"
+    },
+    {
+      "name": "conicQuadraticForm_symmetrize",
+      "type": "key",
+      "description": "The conic quadratic form depends only on the symmetric part of the matrix",
+      "leanType": "(C : Conic) → (p : ProjPoint) → conicQuadraticForm (symmetrize C) p = conicQuadraticForm C p"
+    },
+    {
+      "name": "pointOnConic_symmetrize",
+      "type": "key",
+      "description": "A conic and its symmetrization have identical point sets",
+      "leanType": "(C : Conic) → (p : ProjPoint) → (pointOnConic p (symmetrize C) ↔ pointOnConic p C)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Pascal, Blaise",
+      "title": "Essai pour les coniques",
+      "year": "1640",
+      "venue": "Paris",
+      "note": "The hexagon (mystic hexagram) theorem"
+    },
+    {
+      "authors": "Sylvester, James Joseph",
+      "title": "A demonstration of the theorem that every homogeneous quadratic polynomial is reducible by real orthogonal substitutions to the form of a sum of positive and negative squares",
+      "year": "1852",
+      "venue": "Philosophical Magazine 4(23), 138–142",
+      "note": "Sylvester's law of inertia; the symmetric-matrix normal form these reductions target"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **`pascals-hexagon-incomplete-01-oq-01`** — *Sylvester Reduction: Removing the Symmetry Hypothesis*.

The Pascal's Hexagon Sylvester reduction `sylvester_stdConic_of_isotropic` (in `PascalsHexagon.lean`) carries a standing hypothesis `hC_sym : C.symmetric`, and the residual `axiom conic_implies_pascal_constraint` is retained explicitly for the **"asymmetric and degenerate" cases**. The parent's own proof sketch lists, as its first outstanding step:

> "1. Handle asymmetric `C`: replace with symmetrized `(C + Cᵀ)/2` (same zero set)."

That reduction was stated informally but **never proved in Lean**. This entry proves it, self-contained.

## What is proved (0 sorries, 0 axioms, no `native_decide`)

- `conicQuadraticForm_symmetrize` — the conic quadratic form `pᵀ C p` depends only on the symmetric part of `C`: it equals `pᵀ (symmetrize C) p` for every `p`. The antisymmetric part cancels because `∑ᵢⱼ Cⱼᵢ pᵢ pⱼ = ∑ᵢⱼ Cᵢⱼ pᵢ pⱼ` by a summation-order swap (`Finset.sum_comm`) and `pᵢ pⱼ = pⱼ pᵢ`.
- `pointOnConic_symmetrize` — consequently `C` and `symmetrize C = (C + Cᵀ)/2` have **identical point sets** (the rigorous "same zero set" claim).
- `sylvester_without_symmetry` — the **symmetry hypothesis is removable**: given the symmetric case of the Sylvester reduction as a black box, *every* conic whose symmetric part is non-degenerate and which carries a real point is projectively equivalent to `stdConic`, symmetric or not. The witnessing matrix is exactly the one produced for `symmetrize C`; it works for `C` because the two conics share their point set.

This **discharges the asymmetric, non-degenerate, isotropic case** of the retained axiom `conic_implies_pascal_constraint` with no new assumptions, shrinking the axiom's residual scope to the degenerate case.

## Honest scope

This does **not** discharge the hard indefinite-**symmetric** Sylvester direction itself (`sylvester_stdConic_of_isotropic`). It removes the *symmetry* hypothesis, reducing the general non-degenerate case to the symmetric one. Combined with the sibling `pascals-hexagon-incomplete-01-oq-03` (the definite obstruction), this isolates the remaining work to the single indefinite-symmetric Sylvester reduction.

The conic API mirrors the parent's, reproduced locally because `PascalsHexagon.lean` is currently bit-rotted under the 4.26.0 toolchain and cannot be imported.

## Verification

`lake env lean Proofs/PascalsHexagonIncomplete01OQ01.lean` → **EXIT 0** (clean). The file contains no `axiom`, `sorry`, or `native_decide`, and depends only on pure Mathlib lemmas (`Finset.sum_comm`, `Finset.sum_div`, `Finset.sum_add_distrib`, `ring`), so it is 0-axiom.

## Files

- `proofs/Proofs/PascalsHexagonIncomplete01OQ01.lean` (160L, 5 theorems, 9 definitions)
- `src/data/proofs/pascals-hexagon-incomplete-01-oq-01/{meta.json,annotations.json,index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)