### PR TITLE
Enrich Motzkin family sharp PSD threshold (hilbert-17-oq-03-oq-05): add open questions

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/meta.json
@@ -145,7 +145,14 @@
   },
   "conclusion": {
     "summary": "A 142-line, 0-sorry, 0-axiom formalization establishing the sharp PSD threshold of the Motzkin family: x⁴y² + x²y⁴ + 1 − c·x²y² is positive-semidefinite on ℝ² if and only if c ≤ 3, in both real-function and MvPolynomial forms. The Motzkin polynomial (c = 3) is the extremal PSD member.",
-    "implications": "By exhibiting the Motzkin coefficient 3 as an exact threshold rather than a fixed constant, the entry quantifies — for the canonical example — where the PSD/SOS gap of the parent open question opens: the family stays PSD up to c = 3, and the boundary member is exactly the one that fails to be a sum of squares of polynomials. The sufficient direction is a genuine SOS certificate for the affine form, complementing the sibling non-SOS result for the homogeneous Motzkin polynomial."
+    "implications": "By exhibiting the Motzkin coefficient 3 as an exact threshold rather than a fixed constant, the entry quantifies — for the canonical example — where the PSD/SOS gap of the parent open question opens: the family stays PSD up to c = 3, and the boundary member is exactly the one that fails to be a sum of squares of polynomials. The sufficient direction is a genuine SOS certificate for the affine form, complementing the sibling non-SOS result for the homogeneous Motzkin polynomial.",
+    "openQuestions": [
+      "The sharp threshold isolates c = 3 as the PSD boundary; can it be paired with a formalized non-SOS proof AT c = 3 to certify, fully in Lean, that the boundary of the PSD cone is exactly where the family leaves the SOS cone for this family?",
+      "Does the threshold generalize to the n-variable affine Motzkin-type families x₁⁴x₂² + ⋯ + 1 − c·∏xᵢ² — is the sharp coefficient always the number of AM–GM terms, and is the boundary member always non-SOS?",
+      "The (⟸) direction is an nlinarith-found SOS certificate for the affine form; what is its explicit sum-of-squares representation and minimal length, and how does it relate to the rational (denominator) certificate of the homogeneous Motzkin polynomial in the sibling oq-03-oq-01?",
+      "For c slightly below 3, Mₐ is PSD and (being a strict perturbation) plausibly SOS; what is the exact SOS/non-SOS transition — is c = 3 the unique non-SOS PSD member of the family, or is there an interval of non-SOS PSD coefficients?",
+      "Can the MvPolynomial (Fin 2) formulation be connected to a semidefinite-programming decision procedure, giving an effective Positivstellensatz certificate whose size quantifies the parent open question's SOS-membership complexity?"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-03-oq-05` (quality 91, pass 0). The entry was fully structured (5 keyInsights, complete annotation coverage, cross-references, references, conclusion summary/implications) except for one gap: **`conclusion.openQuestions` was missing** (below the 2+ target).

Added 5 substantive, content-specific questions: formalizing non-SOS-ness exactly at the c=3 boundary, the n-variable affine-Motzkin generalization and whether the sharp coefficient is always the AM–GM term count, the explicit SOS certificate/minimal length behind the nlinarith proof and its relation to the homogeneous rational certificate in sibling oq-03-oq-01, the SOS/non-SOS transition for c just below 3, and an effective Positivstellensatz/SDP connection quantifying the parent's SOS-membership complexity.

Only `conclusion.openQuestions` added; all other content byte-identical.