### PR TITLE
Enrich Two-Sided Derivative Bounds Sandwich (mean-value-theorem-oq-06): add annotation coverage

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-06/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-06/annotations.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": "ann-framing-imports",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "Framing: The Signed, Two-Sided Quantitative MVT",
+    "content": "The file imports exactly three Mathlib modules — the two mean-value engines (`Deriv.MeanValue`, `MeanValue`) and `Convex.Basic` — and opens `Set` so that `Icc`, `Ioo`, and their lemmas are unqualified. The docstring pins down the contract: from a pointwise two-sided bound $m \\le f'(x) \\le M$ on the open interval $(a,b)$, conclude a linear two-sided bound on the *finite increment* $f(b)-f(a)$.\n\nThe framing deliberately contrasts three relatives. The **parent** `mean-value-theorem` gives the existence form $f'(c) = \\tfrac{f(b)-f(a)}{b-a}$. The **sibling** `mean-value-theorem-oq-03` is vector-valued and keeps only the magnitude $\\|f(b)-f(a)\\| \\le C(b-a)$, discarding sign. This entry stays on $\\mathbb{R}$ and keeps *both* bounds, so direction survives — enabling the strict-monotonicity and Lipschitz corollaries below.",
+    "mathContext": "Hypotheses: $f$ continuous on $[a,b]$, differentiable on $(a,b)$, and $m \\le f'(x) \\le M$ for all $x \\in (a,b)$. Conclusion: $m(b-a) \\le f(b)-f(a) \\le M(b-a)$. The average slope $\\frac{f(b)-f(a)}{b-a}$ inherits any two-sided bound on the instantaneous slope $f'$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Mean Value Theorem",
+      "quantitative estimates",
+      "signed vs. absolute bounds",
+      "convex domains"
+    ],
+    "prerequisites": [
+      "deriv and DifferentiableOn",
+      "ContinuousOn",
+      "Set.Icc and Set.Ioo"
+    ]
+  },
+  {
+    "id": "ann-main-sandwich",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 46, "endLine": 62 },
+    "type": "concept",
+    "title": "The Increment Sandwich: deriv_bounds_imply_increment_bounds",
+    "content": "The central theorem. Given continuity on $[a,b]$, differentiability on $(a,b)$, and the two pointwise bounds `hm : m ≤ deriv f x` and `hM : deriv f x ≤ M` on $(a,b)$, it returns the conjunction $m(b-a) \\le f(b)-f(a) \\;\\wedge\\; f(b)-f(a) \\le M(b-a)$.\n\nThe proof is a two-line delegation. `rw [← interior_Icc] at hfd hm hM` rewrites `Set.Ioo a b` to `interior (Set.Icc a b)` in every hypothesis, because that is the exact shape the Mathlib engines demand. Then each half is `(convex_Icc a b).mul_sub_le_image_sub_of_le_deriv` / `...image_sub_le_mul_sub_of_deriv_le`, instantiated at the endpoints $a$ (via `left_mem_Icc.2 hab`) and $b$ (via `right_mem_Icc.2 hab`). No arithmetic is done by hand: the engines carry the actual mean-value content.",
+    "mathContext": "$m(b-a) \\le f(b)-f(a) \\le M(b-a)$. Equivalently $m \\le \\frac{f(b)-f(a)}{b-a} \\le M$ when $a<b$: the average rate of change is trapped between the extreme instantaneous rates. The key rewrite is $\\operatorname{interior}(\\mathrm{Icc}\\,a\\,b) = \\mathrm{Ioo}\\,a\\,b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Convex.mul_sub_le_image_sub_of_le_deriv",
+      "Convex.image_sub_le_mul_sub_of_deriv_le",
+      "interior_Icc",
+      "convex_Icc"
+    ],
+    "prerequisites": [
+      "convexity of intervals",
+      "interior of a closed interval",
+      "endpoint membership lemmas"
+    ]
+  },
+  {
+    "id": "ann-lower-half",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "technique",
+    "title": "Lower Half in Isolation: le_increment_of_le_deriv",
+    "content": "The lower bound extracted as a standalone lemma, requiring only the derivative lower bound `hm`. When one already knows $m \\le f'$ and cares only about a floor on the increment, this avoids supplying an unused upper bound. It is the same `mul_sub_le_image_sub_of_le_deriv` call as the first component of the main theorem, and is reused verbatim by the strict-increase corollary.",
+    "mathContext": "$m \\le f'(x)$ on $(a,b) \\;\\Rightarrow\\; m(b-a) \\le f(b)-f(a)$. A lower bound on the slope alone yields a lower bound on the total change.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Convex.mul_sub_le_image_sub_of_le_deriv",
+      "one-sided bounds",
+      "lemma reuse"
+    ],
+    "prerequisites": [
+      "deriv",
+      "interior_Icc"
+    ]
+  },
+  {
+    "id": "ann-upper-half",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 74, "endLine": 82 },
+    "type": "technique",
+    "title": "Upper Half in Isolation: increment_le_of_deriv_le",
+    "content": "The mirror image of the lower half, requiring only the derivative upper bound `hM`. It applies `image_sub_le_mul_sub_of_deriv_le` and is reused verbatim by the strict-decrease and antitone corollaries. Splitting the sandwich into two named halves means downstream results depend on exactly the hypothesis they need — a small but real reusability win.",
+    "mathContext": "$f'(x) \\le M$ on $(a,b) \\;\\Rightarrow\\; f(b)-f(a) \\le M(b-a)$. A ceiling on the slope yields a ceiling on the total change.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Convex.image_sub_le_mul_sub_of_deriv_le",
+      "one-sided bounds",
+      "lemma reuse"
+    ],
+    "prerequisites": [
+      "deriv",
+      "interior_Icc"
+    ]
+  },
+  {
+    "id": "ann-lipschitz-recovery",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 84, "endLine": 98 },
+    "type": "insight",
+    "title": "Lipschitz Recovery: the Symmetric Special Case",
+    "content": "`abs_increment_le_of_abs_deriv_le` shows that an *absolute* derivative bound $|f'| \\le C$ yields the scalar Lipschitz estimate $|f(b)-f(a)| \\le C(b-a)$. The proof unpacks $|f'| \\le C$ into the pair $-C \\le f' \\le C$ via `abs_le.1`, feeds them as the $m=-C$, $M=C$ instance of the main sandwich, and repacks with `abs_le` + `linarith`.\n\nThis is exactly the scalar shadow of the vector-valued sibling `oq-03`: the norm bound $\\|f(b)-f(a)\\| \\le C(b-a)$ is the special case of the signed sandwich where the two bounds are symmetric about zero. Seeing it fall out as a one-line corollary is the payoff of keeping the sign in the main theorem.",
+    "mathContext": "$|f'(x)| \\le C \\iff -C \\le f'(x) \\le C$; substituting $m=-C,\\,M=C$ gives $-C(b-a) \\le f(b)-f(a) \\le C(b-a)$, i.e. $|f(b)-f(a)| \\le C(b-a)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lipschitz continuity",
+      "abs_le",
+      "vector-valued mean value inequality",
+      "mean-value-theorem-oq-03"
+    ],
+    "prerequisites": [
+      "absolute value inequalities",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-strict-increase",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 100, "endLine": 109 },
+    "type": "insight",
+    "title": "Strict Increase Gap: Positivity of the Width Upgrades to Strict",
+    "content": "`lt_of_pos_deriv_lower_bound`: a *strictly* positive lower derivative bound $0 < m$ on a genuine interval $a<b$ forces $f(a) < f(b)$. The mechanism is purely order-arithmetic: `le_increment_of_le_deriv` gives $m(b-a) \\le f(b)-f(a)$, then `mul_pos` turns $0<m$ and $0<b-a$ (from `sub_pos.2 hab`) into $0 < m(b-a)$, and `linarith` chains the two to $0 < f(b)-f(a)$.\n\nThe conceptual point: a weak inequality is upgraded to a strict one entirely because the interval has positive width. No extra analytic hypothesis is needed.",
+    "mathContext": "$0 < m$ and $a < b \\;\\Rightarrow\\; f(b)-f(a) \\ge m(b-a) > 0 \\;\\Rightarrow\\; f(a) < f(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict monotonicity",
+      "mul_pos",
+      "sub_pos",
+      "linarith"
+    ],
+    "prerequisites": [
+      "ordered field arithmetic",
+      "le_increment_of_le_deriv"
+    ]
+  },
+  {
+    "id": "ann-strict-decrease",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 111, "endLine": 120 },
+    "type": "insight",
+    "title": "Strict Decrease Gap: the Sign-Flipped Mirror",
+    "content": "`gt_of_neg_deriv_upper_bound`: a strictly negative upper derivative bound $M < 0$ on $a<b$ forces $f(b) < f(a)$. It mirrors the strict-increase result exactly, using `increment_le_of_deriv_le` for $f(b)-f(a) \\le M(b-a)$ and `mul_neg_of_neg_of_pos` to conclude $M(b-a) < 0$, then `linarith`. Together the two strict gaps show the sandwich detects direction, not just magnitude — something no absolute norm bound can do.",
+    "mathContext": "$M < 0$ and $a < b \\;\\Rightarrow\\; f(b)-f(a) \\le M(b-a) < 0 \\;\\Rightarrow\\; f(b) < f(a)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict monotonicity",
+      "mul_neg_of_neg_of_pos",
+      "sub_pos",
+      "linarith"
+    ],
+    "prerequisites": [
+      "ordered field arithmetic",
+      "increment_le_of_deriv_le"
+    ]
+  },
+  {
+    "id": "ann-monotone",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 122, "endLine": 130 },
+    "type": "concept",
+    "title": "Monotone Specialization: the m = 0 Endpoint",
+    "content": "`le_of_nonneg_deriv_lower_bound`: a nonnegative derivative $0 \\le f'$ gives ordinary monotonicity $f(a) \\le f(b)$. It is the $m=0$ instance of the lower half; after `le_increment_of_le_deriv` produces $0 \\cdot (b-a) \\le f(b)-f(a)$, `simp only [zero_mul]` clears the product and `linarith` finishes. This is the classical 'nonnegative derivative $\\Rightarrow$ nondecreasing' fact, recovered as a corollary rather than proved from scratch.",
+    "mathContext": "$0 \\le f'(x)$ on $(a,b) \\;\\Rightarrow\\; f(a) \\le f(b)$: the boundary case of the strict-increase result with the slack removed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone functions",
+      "nonnegative derivative",
+      "zero_mul"
+    ],
+    "prerequisites": [
+      "le_increment_of_le_deriv",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-antitone",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 132, "endLine": 140 },
+    "type": "concept",
+    "title": "Antitone Specialization: the M = 0 Endpoint",
+    "content": "`ge_of_nonpos_deriv_upper_bound`: a nonpositive derivative $f' \\le 0$ gives $f(b) \\le f(a)$, the classical 'nonpositive derivative $\\Rightarrow$ nonincreasing' statement. It is the $M=0$ instance of the upper half, closed identically to the monotone case via `zero_mul` and `linarith`. The two monotonicity corollaries are the non-strict endpoints of the strict-gap family above.",
+    "mathContext": "$f'(x) \\le 0$ on $(a,b) \\;\\Rightarrow\\; f(b) \\le f(a)$: the $M=0$ boundary case of the strict-decrease result.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antitone functions",
+      "nonpositive derivative",
+      "zero_mul"
+    ],
+    "prerequisites": [
+      "increment_le_of_deriv_le",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-worked-example",
+    "proofId": "mean-value-theorem-oq-06",
+    "range": { "startLine": 142, "endLine": 157 },
+    "type": "context",
+    "title": "Worked Numerical Example: 1 ≤ f' ≤ 3 on (0,2) ⟹ 2 ≤ f(2)−f(0) ≤ 6",
+    "content": "A concrete instantiation of the main sandwich that does genuine numerical work. For any $f$ continuous on $[0,2]$, differentiable on $(0,2)$, with $1 \\le f'(x) \\le 3$ throughout, the theorem pins the increment to $[2,6]$: $1 \\cdot 2 = 2 \\le f(2)-f(0) \\le 3 \\cdot 2 = 6$.\n\nThe proof calls `deriv_bounds_imply_increment_bounds` with `(by norm_num : (0:ℝ) ≤ 2)`, destructures the resulting conjunction, and lets `linarith` evaluate the two numeric products. It demonstrates the intended use of the packaged lemma: plug in constant slope bounds over a fixed window and read off the guaranteed range of total change — no reference to the interior/convexity machinery required at the call site.",
+    "mathContext": "$1 \\le f'(x) \\le 3$ on $(0,2) \\;\\Rightarrow\\; 2 \\le f(2)-f(0) \\le 6$. Illustrates how the abstract sandwich becomes a usable arithmetic bound at concrete data.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "norm_num",
+      "linarith",
+      "applied estimates"
+    ],
+    "prerequisites": [
+      "deriv_bounds_imply_increment_bounds",
+      "numerical tactics"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `mean-value-theorem-oq-06` (quality 42, pass 0).

**Gap addressed:** the entry had a rich `meta.json` but **no `annotations.json` at all** — zero inline annotation coverage.

**Added:** `annotations.json` with 10 annotations spanning the full 157-line Lean file, each carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:

- Framing + imports (context)
- The increment sandwich `deriv_bounds_imply_increment_bounds` (key)
- Both one-sided halves (`le_increment_of_le_deriv`, `increment_le_of_deriv_le`)
- Lipschitz recovery — the m=−C, M=C symmetric case matching sibling oq-03 (key)
- Strict increase / decrease gaps (insight)
- Monotone / antitone specializations (m=0, M=0 endpoints)
- Worked numerical example (1 ≤ f' ≤ 3 on (0,2) ⟹ 2 ≤ f(2)−f(0) ≤ 6)

Ranges are non-overlapping and cover lines 1–157. JSON schema, enum values, and ranges validated; `meta.json` unchanged (within size caps). Matches the hand-authored annotations pattern used by sibling `mean-value-theorem-oq-03`.