### PR TITLE
research(composition-card-2pow-oq-01-oq-01): compositions of n into exactly k parts = C(n−1,k−1), summing to 2^(n−1)

### DIFF
--- a/proofs/Proofs/CompositionCard2PowOQ01OQ01.lean
+++ b/proofs/Proofs/CompositionCard2PowOQ01OQ01.lean
@@ -101,8 +101,8 @@ theorem boundaries_eq (hn : 1 ≤ n) (cs : CompositionAsSet n) :
     · exact Or.inl rfl
     rcases eq_or_ne b (Fin.last n) with rfl | hbl
     · exact Or.inr (Or.inl rfl)
-    have hb0' : (b : ℕ) ≠ 0 := by simpa [Fin.ext_iff, Fin.val_zero] using hb0
-    have hbl' : (b : ℕ) ≠ n := by simpa [Fin.ext_iff, Fin.val_last] using hbl
+    have hb0' : (b : ℕ) ≠ 0 := fun h => hb0 (Fin.ext (by rw [Fin.val_zero]; exact h))
+    have hbl' : (b : ℕ) ≠ n := fun h => hbl (Fin.ext (by rw [Fin.val_last]; exact h))
     have hbv : (b : ℕ) < n + 1 := b.isLt
     refine Or.inr (Or.inr ⟨⟨(b : ℕ) - 1, by omega⟩, ?_, ?_⟩)
     · rw [mem_equiv_iff]
@@ -121,7 +121,7 @@ theorem equiv_card_add_one (hn : 1 ≤ n) (cs : CompositionAsSet n) :
     (compositionAsSetEquiv n cs).card + 1 = cs.length := by
   have hb : cs.boundaries.card = cs.length + 1 := cs.card_boundaries_eq_succ_length
   have h0l : (0 : Fin (n + 1)) ≠ Fin.last n := by
-    simp only [Fin.ext_iff, Fin.val_zero, Fin.val_last]; omega
+    rw [Ne, Fin.ext_iff, Fin.val_zero, Fin.val_last]; omega
   have hcard : cs.boundaries.card = (compositionAsSetEquiv n cs).card + 2 := by
     rw [boundaries_eq hn cs,
         Finset.card_insert_of_notMem (by
@@ -156,9 +156,9 @@ theorem card_composition_length_eq (hn : 1 ≤ n) {k : ℕ} (hk : 1 ≤ k) :
       exact h
     rw [Equiv.trans_apply]
     omega
-  rw [Fintype.card_congr
-        (Equiv.subtypeEquiv ((compositionEquiv n).trans (compositionAsSetEquiv n)) key),
-      card_finset_card_eq]
+  have E : {c : Composition n // c.length = k} ≃ {s : Finset (Fin (n - 1)) // s.card = k - 1} :=
+    Equiv.subtypeEquiv ((compositionEquiv n).trans (compositionAsSetEquiv n)) key
+  rw [Fintype.card_congr E, card_finset_card_eq]
 
 /-! ### Summing over the number of parts -/
 

--- a/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "composition-card-2pow-oq-01-oq-01",
+  "title": "Composition Card OQ-01-OQ-01: Compositions of n into Exactly k Parts Number C(n−1, k−1)",
+  "slug": "composition-card-2pow-oq-01-oq-01",
+  "description": "The parent entry (composition-card-2pow-oq-01) counts all compositions of n — ordered tuples of positive integers summing to n, Mathlib's Composition n — as 2^(n−1), and asks in its first open question whether the count can be refined by the number of parts. This entry answers it: the number of compositions of n into exactly k parts is the binomial coefficient C(n−1, k−1), and summing over k recovers the parent's total via the binomial theorem. Concretely, card_composition_length_eq proves Fintype.card {c : Composition n // c.length = k} = (n−1).choose (k−1) for n ≥ 1, k ≥ 1, and sum_card_composition_length proves ∑_{k=1}^{n} Fintype.card {c : Composition n // c.length = k} = 2^(n−1). The proof runs through Mathlib's two-step encoding of a composition as a subset of the n−1 internal gaps: compositionEquiv n : Composition n ≃ CompositionAsSet n composed with compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n−1)). The key length↔cardinality dictionary equiv_card_add_one shows the number of parts is exactly one more than the cardinality of the attached gap subset — a k-part composition has k−1 cuts — proved by exhibiting the boundaries as {0, last} together with the shifted gap subset (boundaries_eq) and reading off cardinalities. Transporting 'exactly k parts' to 'gap subsets of size k−1' via Equiv.subtypeEquiv and counting fixed-cardinality subsets with Fintype.card_finset_len (card_finset_card_eq : #{s : Finset (Fin m) // s.card = j} = C(m, j)) gives the per-part count; the sum over k then follows from Nat.sum_range_choose. Mathlib records the total count composition_card but not this by-length refinement, the finer enumerative statement.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Composition",
+      "Mathlib.Data.Fintype.Powerset",
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "CompositionCard2PowOQ01OQ01",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/CompositionCard2PowOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionCard2PowOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "binomial-coefficients",
+      "counting",
+      "powers-of-two",
+      "bijective-proof"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Parent entry: counts all compositions of n as 2^(n−1). This entry answers its first open question by refining the count according to the number of parts, and the sum over k recovers the parent's total."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 189,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Only the foundational propext / Classical.choice / Quot.sound may appear (verifiable with #print axioms). The by-length count card_composition_length_eq and the summation sum_card_composition_length are absent from Mathlib, which records only the total count composition_card; the proof is built on Mathlib's compositionEquiv / compositionAsSetEquiv encoding and Fintype.card_finset_len. Both headline results carry the mild hypotheses n ≥ 1 (and k ≥ 1 for the per-part count), as the empty composition and the truncated ℕ-subtraction at n = 0 make the k-indexing degenerate there.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The by-parts refinement of the composition count is a cornerstone of elementary enumerative combinatorics. A composition of n is an ordered sequence of positive parts summing to n; the compositions of 3 are 3, 1+2, 2+1, 1+1+1. Placing n unit boxes in a row leaves n−1 internal gaps, and choosing which gaps to 'cut' splits the row into the parts of a composition. A composition into exactly k parts uses exactly k−1 cuts, so such compositions correspond to the k−1-element subsets of an (n−1)-element set — there are C(n−1, k−1) of them. Summing over k and applying the binomial theorem ∑_k C(n−1, k−1) = 2^(n−1) recovers the total count. This refinement (the 'stars and bars' count restricted to a fixed number of parts) is the finer statement that explains the power of two as a sum of binomial coefficients.",
+    "problemStatement": "Refine the total composition count by number of parts: show that the number of compositions of n into exactly k parts is\n\n$$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1},$$\n\nand that summing over k recovers the parent's total\n\n$$\\sum_{k=1}^{n} \\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = 2^{n-1}.$$",
+    "text": "Mathlib encodes a composition of n as a subset of its n−1 internal gaps via compositionEquiv n : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n−1)). Under this encoding the number of parts is one more than the cardinality of the gap subset. This entry establishes that length↔cardinality dictionary, transports 'exactly k parts' to 'gap subsets of size k−1', and counts the latter with Mathlib's Fintype.card_finset_len, yielding the per-part count C(n−1, k−1); the sum over k follows from Nat.sum_range_choose.",
+    "proofStrategy": "gapEmb is the shift embedding Fin (n−1) ↪ Fin (n+1), i ↦ i+1, sending an internal gap to its boundary position. boundaries_eq (for n ≥ 1) writes a composition's boundaries as insert 0 (insert (last n) (gapSubset.map gapEmb)), with 0 and last shown not to be internal cuts (zero_not_mem_map, last_not_mem_map). equiv_card_add_one reads off from this that the gap subset's cardinality plus one equals the number of parts, using card_boundaries_eq_succ_length. card_finset_card_eq specialises Mathlib's Fintype.card_finset_len to Fin m, giving #{s : Finset (Fin m) // s.card = j} = C(m, j). card_composition_length_eq combines these: it transports the subtype {c : Composition n // c.length = k} across (compositionEquiv n).trans (compositionAsSetEquiv n) via Equiv.subtypeEquiv (the length condition becoming card = k−1), then applies card_finset_card_eq to obtain C(n−1, k−1). sum_choose_shift reindexes Icc 1 n to range n and applies Nat.sum_range_choose to get ∑ C(n−1, k−1) = 2^(n−1); sum_card_composition_length chains this with the per-part count.",
+    "keyInsights": [
+      "**The number of parts is a cardinality**: under Mathlib's compositionEquiv / compositionAsSetEquiv encoding, a k-part composition corresponds to a gap subset of size k−1, so counting compositions by length is counting subsets by cardinality — equiv_card_add_one is the exact dictionary that makes this precise",
+      "**The boundaries split as endpoints plus cuts**: boundaries_eq exhibits the boundary set as {0, last} together with the shifted internal cuts, and the two endpoints are provably never internal cuts, so the boundary count is (gap-subset card) + 2 and the length is (gap-subset card) + 1",
+      "**Fixed-cardinality subset counting is the engine**: card_finset_card_eq packages Fintype.card_finset_len (#{s : Finset (Fin m) // s.card = j} = C(m,j)), turning the transported problem directly into a binomial coefficient",
+      "**The refinement recovers the total**: summing C(n−1, k−1) over k via Nat.sum_range_choose returns 2^(n−1), realising the parent's count as a sum of binomial coefficients and answering its first open question"
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n) and the boundary-set model CompositionAsSet n with its length/boundary API (card_boundaries_eq_succ_length)",
+      "The equivalences compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1))",
+      "Fintype.card_finset_len (#{s : Finset (Fin m) // s.card = j} = C(m, j)) and Fintype.card_congr / Equiv.subtypeEquiv for transporting subtype cardinalities",
+      "Nat.sum_range_choose (∑_{k≤m} C(m,k) = 2^m) and reindexing a sum over Icc 1 n to range n"
+    ]
+  },
+  "sections": [
+    {
+      "id": "length-cardinality-dictionary",
+      "title": "The Length ↔ Subset-Cardinality Dictionary",
+      "startLine": 51,
+      "endLine": 132,
+      "mathContext": "Under compositionAsSetEquiv, a composition's boundaries split as $\\{0, \\mathrm{last}\\} \\cup (\\text{internal cuts})$, so the number of parts is one more than the gap-subset cardinality.",
+      "summary": "gapEmb is the shift embedding of internal gaps into boundary positions. mem_equiv_iff identifies membership in the attached gap subset with membership of the shifted position in the boundaries. zero_not_mem_map and last_not_mem_map show the endpoints are never internal cuts. boundaries_eq assembles the boundary set as {0, last} ∪ (shifted gap subset), and equiv_card_add_one reads off the dictionary: gap-subset cardinality + 1 = number of parts, via card_boundaries_eq_succ_length."
+    },
+    {
+      "id": "fixed-cardinality-subsets",
+      "title": "Counting Subsets of a Fixed Cardinality",
+      "startLine": 134,
+      "endLine": 139,
+      "mathContext": "$\\#\\{s : \\mathrm{Finset}\\,(\\mathrm{Fin}\\ m) \\mid s.\\mathrm{card} = j\\} = \\binom{m}{j}$.",
+      "summary": "card_finset_card_eq specialises Mathlib's Fintype.card_finset_len to Fin m, giving the number of j-element subsets of an m-element type as C(m, j) — the combinatorial engine transported to below."
+    },
+    {
+      "id": "by-length-count",
+      "title": "The By-Length Count C(n−1, k−1)",
+      "startLine": 141,
+      "endLine": 161,
+      "mathContext": "$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1}$ for $n \\ge 1,\\ k \\ge 1$.",
+      "summary": "card_composition_length_eq transports the subtype {c : Composition n // c.length = k} across (compositionEquiv n).trans (compositionAsSetEquiv n) with Equiv.subtypeEquiv — the length-k condition becoming gap-subset cardinality k−1 via equiv_card_add_one — and applies card_finset_card_eq to read off C(n−1, k−1)."
+    },
+    {
+      "id": "sum-over-parts",
+      "title": "Summing Over the Number of Parts",
+      "startLine": 163,
+      "endLine": 189,
+      "mathContext": "$\\sum_{k=1}^{n} \\binom{n-1}{k-1} = 2^{n-1}$ and hence $\\sum_{k=1}^{n} \\#\\{c \\mid c.\\mathrm{length} = k\\} = 2^{n-1}$.",
+      "summary": "sum_choose_shift reindexes Icc 1 n to range n via a shift embedding and applies Nat.sum_range_choose to obtain ∑ C(n−1, k−1) = 2^(n−1). sum_card_composition_length chains this with card_composition_length_eq, recovering the parent's total count as a sum of binomial coefficients."
+    }
+  ],
+  "conclusion": {
+    "summary": "The by-length refinement of the composition count is formalised sorry-free and axiom-free: compositions of n into exactly k parts number C(n−1, k−1) (card_composition_length_eq), and summing over k recovers the parent's total 2^(n−1) (sum_card_composition_length). The proof turns Mathlib's compositionEquiv / compositionAsSetEquiv encoding into a length↔cardinality dictionary and counts fixed-cardinality gap subsets with Fintype.card_finset_len.",
+    "implications": "This answers the parent entry's first open question, exhibiting 2^(n−1) as the sum ∑_k C(n−1, k−1) of the per-part counts and making explicit why a k-part composition corresponds to a (k−1)-subset of the n−1 internal gaps. It supplies the by-length refinement that Mathlib records only in its unrefined total form composition_card.",
+    "openQuestions": [
+      "Can the by-length generating function ∑_k C(n−1, k−1) x^k = x(1+x)^(n−1) be formalised, packaging the per-part counts as coefficients of a polynomial?",
+      "Does the same gap-subset dictionary yield clean by-length counts for restricted compositions (bounded part sizes, parts in a fixed set), where the subset condition is constrained?",
+      "Can this per-part count be contributed upstream to Mathlib alongside composition_card, giving the refinement a canonical home?"
+    ]
+  },
+  "crossReferences": [
+    "composition-card-2pow-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

New VERIFIED gallery entry answering the parent `composition-card-2pow-oq-01`'s first open question: refine the total composition count 2^(n−1) **by number of parts**.

- `card_composition_length_eq` — `Fintype.card {c : Composition n // c.length = k} = (n−1).choose (k−1)` for `n ≥ 1, k ≥ 1`.
- `sum_card_composition_length` — `∑_{k=1}^{n} Fintype.card {c : Composition n // c.length = k} = 2^(n−1)`, recovering the parent's total as a sum of binomial coefficients.

## Proof route

Runs through Mathlib's two-step gap-subset encoding `compositionEquiv n : Composition n ≃ CompositionAsSet n` then `compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n−1))`. The key `equiv_card_add_one` dictionary shows the number of parts is one more than the attached gap-subset cardinality (a k-part composition has k−1 cuts), proved via `boundaries_eq` (`{0, last} ∪ shifted gap subset`). Transporting "exactly k parts" to "gap subsets of size k−1" via `Equiv.subtypeEquiv` and counting with `Fintype.card_finset_len` gives `C(n−1,k−1)`; summing uses `Nat.sum_range_choose`. Mathlib records only the unrefined total `composition_card`.

## Verification

- **Docker build**: `✔ [3058/3058] Built Proofs.CompositionCard2PowOQ01OQ01 (27s)`, clean.
- 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide` on substantive results.
- 10 theorems, 1 def, 189 lines. Only foundational `propext`/`Classical.choice`/`Quot.sound` may appear.

## Status
**Outcome**: completed — new verified 0-axiom entry. Files: `proofs/Proofs/CompositionCard2PowOQ01OQ01.lean`, `src/data/proofs/composition-card-2pow-oq-01-oq-01/meta.json`.

🤖 Generated by researcher-16