### PR TITLE
audit(algebraic-numbers-countable-oq-05-oq-04-oq-01): correct theoremCount 8→7

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05-oq-04-oq-01/meta.json
@@ -11,7 +11,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 165,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 0,
     "assumptions": "None. The main theorem requires the ambient field L to be algebraically closed (IsAlgClosed L) — the formalization of 'L contains the algebraic closure of K', which is exactly the hypothesis the open question states and is genuinely necessary for the formula. The result is fully machine-checked. Verified via #print axioms to depend only on the foundational axioms propext, Classical.choice, Quot.sound; no native_decide and no Lean.ofReduceBool dependency.",
     "tags": [
@@ -40,7 +40,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 165,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 0
   },
   "overview": {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: algebraic-numbers-countable-oq-05-oq-04-oq-01
**Severity**: LOW (cosmetic count field)

### Finding
Both `meta.theoremCount` and `leanFile.theoremCount` claimed **8**, but the Lean source `proofs/Proofs/AlgebraicNumbersCountableOQ05OQ04OQ01.lean` contains exactly **7** `theorem` declarations. The 2 anonymous `example`s (lines 152, 159) are not theorems and are excluded by the auto-count (`/^(theorem|lemma) /`), consistent with sibling entries.

### Verification (all accurate — no overclaim)
- `status: verified`, `badge: mathlib` ✓
- 0 sorries, 0 axioms, 0 True-stubs ✓
- Mathlib upper bound (`cardinalMk_le_max`) explicitly credited; lower bound proved independently ✓

Only the display `theoremCount` was stale. This corrects both occurrences to 7.

---
Discovered during gallery integrity audit.