### PR TITLE
Enrich Inverse Galois OQ-04-01 (Kummer–Dedekind Step-1 brick): annotation depth

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01/annotations.json
@@ -2,34 +2,125 @@
   {
     "id": "ann-header-oq0401",
     "proofId": "inverse-galois-oq-04-oq-01",
-    "range": {
-      "startLine": 3,
-      "endLine": 62
-    },
+    "range": { "startLine": 3, "endLine": 46 },
     "type": "concept",
     "title": "Step 1 of the three-step Kummer–Dedekind route",
-    "content": "The docstring situates this file within OQ-04's plan to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309). The companion `InverseGaloisA5DedekindInstantiation` reduces that axiom to the arithmetic fact `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`, provable by a three-step route: (1) Kummer–Dedekind turns an irreducible cubic factor of q mod 7 into a prime of 𝓞 ℚ(α) of inertia degree 3; (2) inertia-degree tower multiplicativity lifts it to the splitting field; (3) Galois uniformity spreads it to all primes over 7. The sibling entry `Proofs.DedekindInertiaTower` machine-checked steps (2)–(3); this file packages step (1) in full generality, for an arbitrary number field K, algebraic integer θ, and prime p not dividing the Kummer–Dedekind exponent of θ, using only foundational axioms."
+    "content": "The docstring situates this file within OQ-04's plan to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309). The companion `InverseGaloisA5DedekindInstantiation` reduces that axiom to the arithmetic fact `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`, provable by a three-step route: (1) Kummer–Dedekind turns an irreducible cubic factor of q mod 7 into a prime of 𝓞 ℚ(α) of inertia degree 3; (2) inertia-degree tower multiplicativity lifts it to the splitting field; (3) Galois uniformity spreads it to all primes over 7. The sibling entry `Proofs.DedekindInertiaTower` machine-checked steps (2)–(3); this file packages step (1) in full generality, for an arbitrary number field K, algebraic integer θ, and prime p not dividing the Kummer–Dedekind exponent of θ, using only foundational axioms.",
+    "mathContext": "The realizability obstruction is $3 \\mid \\lvert \\mathrm{Gal}(q)\\rvert$. A Frobenius/Chebotarev reading turns this into a statement about a residue-field degree: it suffices to exhibit an unramified prime of $\\mathcal{O}_{q.\\mathrm{SplittingField}}$ over $7$ whose inertia degree is divisible by $3$, i.e. $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$. The three-step chain is $Q \\text{ irreducible cubic} \\bmod 7 \\ \\xrightarrow{(1)\\ \\text{Kummer–Dedekind}}\\ \\exists P \\lhd \\mathcal{O}_{\\mathbb{Q}(\\alpha)},\\ f(P\\mid 7)=3 \\ \\xrightarrow{(2)\\ \\text{tower}}\\ 3 \\mid f(\\mathfrak{P}\\mid 7) \\ \\xrightarrow{(3)\\ \\text{Galois}}\\ 3 \\mid \\mathrm{inertiaDegIn}_{(7)}.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Inverse Galois problem",
+      "Frobenius element and Chebotarev density",
+      "inertia degree (residue field degree)",
+      "Kummer–Dedekind theorem",
+      "splitting of primes in number fields"
+    ],
+    "prerequisites": [
+      "algebraic number theory (rings of integers, primes over a rational prime)",
+      "Galois theory of number fields"
+    ]
+  },
+  {
+    "id": "ann-setup-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": { "startLine": 48, "endLine": 52 },
+    "type": "definition",
+    "title": "Ambient data: an arbitrary number field, algebraic integer, and rational prime",
+    "content": "The `variable` block fixes the fully general setting: a number field `K` (`[Field K] [NumberField K]`), an algebraic integer `θ : 𝓞 K` of its ring of integers, and a rational prime `p : ℕ` carried as a typeclass fact `[Fact (Nat.Prime p)]` (so that `ZMod p` is a field and `(ZMod p)[X]` a UFD, letting `minpoly ℤ θ mod p` factor into monic irreducibles). Nothing here is specialized to A₅ or to p = 7 — the two theorems hold for every such K, θ, p, which is exactly what makes the brick reusable. The `open Polynomial NumberField Ideal RingOfIntegers` line brings the Kummer–Dedekind vocabulary (`inertiaDeg`, `span`, `primesOverSpanEquivMonicFactorsMod`, `exponent`, `monicFactorsMod`) into scope.",
+    "mathContext": "The relevant objects are $\\mathcal{O}_K$ (the ring of integers, a Dedekind domain), the minimal polynomial $\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\theta \\in \\mathbb{Z}[X]$, and its reduction $\\overline{\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\theta} \\in (\\mathbb{Z}/p)[X]$. The prime-power fact `[Fact (Nat.Prime p)]` is what makes $\\mathbb{Z}/p\\mathbb{Z}$ a field, so $(\\mathbb{Z}/p)[X]$ is a PID and the factorization into monic irreducibles that Kummer–Dedekind reads is well defined.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "ring of integers 𝓞 K",
+      "Dedekind domain",
+      "minimal polynomial over ℤ",
+      "polynomials over a finite field",
+      "typeclass hypothesis Fact (Nat.Prime p)"
+    ],
+    "prerequisites": [
+      "field and ring typeclasses in Lean/Mathlib",
+      "unique factorization of polynomials over a field"
+    ]
   },
   {
     "id": "ann-existence-oq0401",
     "proofId": "inverse-galois-oq-04-oq-01",
-    "range": {
-      "startLine": 64,
-      "endLine": 84
-    },
+    "range": { "startLine": 54, "endLine": 71 },
     "type": "theorem",
     "title": "exists_prime_inertiaDeg_eq_natDegree — splitting datum ⇒ inertia degree",
-    "content": "The main theorem: for a number field K, an algebraic integer θ ∈ 𝓞 K, and a rational prime p with p ∤ exponent θ (equivalently p ∤ the conductor [𝓞 K : ℤ[θ]]), every monic irreducible factor Q of minpoly ℤ θ modulo p is matched by a maximal prime P of 𝓞 K lying over (p) with inertiaDeg (p) P = Q.natDegree. The witness is `(primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩`, the inverse image of Q under Mathlib's Kummer–Dedekind bijection between primes over (p) and monic factors of minpoly θ mod p. Primality and lying-over are the `primesOver`-membership components `.2.1` / `.2.2`; maximality is `Ideal.isMaximal_of_mem_primesOver`; and the inertia-degree value is Mathlib's `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, which computes it as exactly the degree of Q. In the A₅ application θ = α (a root of q), p = 7, and Q is the irreducible cubic factor of q mod 7, so P has inertia degree 3."
+    "content": "The main theorem (statement and docstring). For a number field K, an algebraic integer θ ∈ 𝓞 K, and a rational prime p with p ∤ exponent θ (equivalently p ∤ the conductor [𝓞 K : ℤ[θ]]), every monic irreducible factor Q of minpoly ℤ θ modulo p is matched by a maximal prime P of 𝓞 K lying over (p) with inertiaDeg (p) P = Q.natDegree. This is the concrete 'splitting datum ⇒ inertia degree' translation Kummer–Dedekind provides: the shape of the factorization of minpoly θ mod p literally is the shape of how (p) splits in 𝓞 K, factor degree by factor degree. In the A₅ application θ = α (a root of q), p = 7, and Q is the irreducible cubic factor of q mod 7, so the produced P has inertia degree exactly 3 — a prime whose Frobenius has order 3.",
+    "mathContext": "$\\forall Q \\in \\mathrm{monicFactorsMod}\\,\\theta\\,p,\\ \\exists\\, P \\lhd \\mathcal{O}_K$ maximal with $P \\mid (p)$ and $\\mathrm{inertiaDeg}_{(p)}\\,P = \\deg Q.$ Equivalently, writing $\\overline{\\mathrm{minpoly}\\,\\theta} = \\prod_i \\overline{Q_i}^{e_i}$ over $\\mathbb{Z}/p$, the prime factorization is $(p)\\,\\mathcal{O}_K = \\prod_i \\mathfrak{p}_i^{e_i}$ with $f(\\mathfrak{p}_i \\mid p) = \\deg Q_i$ — Dedekind's classical dictionary, valid because $p \\nmid [\\mathcal{O}_K : \\mathbb{Z}[\\theta]]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer–Dedekind factorization theorem",
+      "inertia degree / residue field degree",
+      "conductor of the order ℤ[θ]",
+      "primesOverSpanEquivMonicFactorsMod bijection",
+      "monicFactorsMod"
+    ],
+    "prerequisites": [
+      "factorization of ideals in Dedekind domains",
+      "residue fields and inertia degree",
+      "the conductor–exponent condition for Kummer–Dedekind"
+    ]
+  },
+  {
+    "id": "ann-witness-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": { "startLine": 72, "endLine": 77 },
+    "type": "technique",
+    "title": "Constructing the witness prime from the Kummer–Dedekind bijection",
+    "content": "The proof exhibits the prime explicitly rather than asserting mere existence: P := (primesOverSpanEquivMonicFactorsMod hp).symm ⟨Q, hQ⟩ is the inverse image of the factor Q under Mathlib's Kummer–Dedekind equivalence, an Equiv between the primes of 𝓞 K over (p) and the monic irreducible factors of minpoly θ mod p (defined precisely when p ∤ exponent θ, supplied by hp). The three obligations of the ∃-goal are then discharged from the structure of that inverse image: primality and lying-over come free as the two components of its `primesOver`-membership proof, accessed as `.2` and `.2.2`; maximality is `Ideal.isMaximal_of_mem_primesOver` (a prime over a maximal ideal of a ring of integers is itself maximal); and the inertia-degree value is Mathlib's computation lemma `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply'`, plugged straight into the `refine` as the fourth component.",
+    "mathContext": "$P := \\Phi^{-1}\\langle Q, hQ\\rangle$ where $\\Phi : \\{\\mathfrak{p} : \\mathfrak{p} \\text{ prime},\\ \\mathfrak{p} \\mid (p)\\} \\xrightarrow{\\ \\sim\\ } \\{\\text{monic irreducible } Q \\mid \\overline{\\mathrm{minpoly}\\,\\theta}\\}$ is the Kummer–Dedekind bijection. Membership $P \\in \\mathrm{primesOver}\\,(p)$ unpacks to $P.\\mathrm{IsPrime} \\wedge P.\\mathrm{LiesOver}\\,(p)$ (the `.2.1`/`.2.2` projections), and $\\mathrm{inertiaDeg}_{(p)}\\,P = \\deg Q$ is the equivalence's residual-degree identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Equiv.symm (inverse of a bijection)",
+      "subtype membership projections (.2 / .2.2)",
+      "isMaximal_of_mem_primesOver",
+      "constructive existence proofs",
+      "primesOver subtype"
+    ],
+    "prerequisites": [
+      "working with Equiv and subtypes in Lean",
+      "structure projections for And / dependent pairs"
+    ]
   },
   {
     "id": "ann-divisibility-oq0401",
     "proofId": "inverse-galois-oq-04-oq-01",
-    "range": {
-      "startLine": 86,
-      "endLine": 95
-    },
+    "range": { "startLine": 79, "endLine": 91 },
     "type": "theorem",
     "title": "exists_prime_dvd_inertiaDeg_of_dvd_natDegree — the composable form",
-    "content": "The divisibility corollary, phrased in the currency the OQ-04 tower brick consumes: if a natural number d divides Q.natDegree, then some maximal prime P of 𝓞 K over (p) has d ∣ inertiaDeg (p) P. The proof `obtain`s the prime and its inertia-degree equality from the existence theorem and rewrites by the hypothesis d ∣ Q.natDegree. Feeding such a P into `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes d ∣ inertiaDeg (p) P to d ∣ inertiaDegIn (p) on the Galois splitting field — so with d = 3 and Q the cubic factor of q mod 7, the two bricks compose to 3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)."
+    "content": "The divisibility corollary (statement and docstring), phrased in the currency the OQ-04 tower brick consumes: if a natural number d divides Q.natDegree, then some maximal prime P of 𝓞 K over (p) has d ∣ inertiaDeg (p) P. Weakening the exact equality inertiaDeg (p) P = deg Q to the divisibility d ∣ inertiaDeg (p) P is deliberate — it is exactly the hypothesis shape of `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg`, so this theorem is the socket into which Steps 2–3 plug. With d = 3 and Q the irreducible cubic factor of q mod 7, the two bricks compose to 3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField).",
+    "mathContext": "$d \\mid \\deg Q \\ \\Longrightarrow\\ \\exists\\, P \\lhd \\mathcal{O}_K \\text{ maximal},\\ P \\mid (p),\\ d \\mid \\mathrm{inertiaDeg}_{(p)}\\,P.$ Divisibility, not equality, is the right invariant because inertia degrees multiply along a tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$: if $d \\mid f(P \\mid p)$ and $f(\\mathfrak{P} \\mid P)$ is arbitrary, then $d \\mid f(\\mathfrak{P}\\mid p) = f(\\mathfrak{P}\\mid P)\\,f(P\\mid p)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisibility as a composable invariant",
+      "inertia degree multiplicativity in towers",
+      "dvd_inertiaDegIn_of_dvd_inertiaDeg",
+      "interface design for proof composition"
+    ],
+    "prerequisites": [
+      "basic divisibility in ℕ",
+      "multiplicativity of inertia degree in extensions"
+    ]
+  },
+  {
+    "id": "ann-divisibility-proof-oq0401",
+    "proofId": "inverse-galois-oq-04-oq-01",
+    "range": { "startLine": 92, "endLine": 93 },
+    "type": "technique",
+    "title": "Two-line derivation: obtain the prime, rewrite the equality into the divisibility",
+    "content": "The corollary's proof is a single reduction to the existence theorem: `obtain ⟨P, hPmax, hPlo, hPdeg⟩ := exists_prime_inertiaDeg_eq_natDegree hp hQ` produces the prime P together with hPdeg : inertiaDeg (p) P = Q.natDegree, and then `hPdeg ▸ hd` rewrites the hypothesis hd : d ∣ Q.natDegree along that equality to the desired d ∣ inertiaDeg (p) P. The `▸` (subst/rewrite) operator transports the divisibility across the extracted equality with no further tactic work, so the whole corollary is one obtain plus one term-mode rewrite.",
+    "mathContext": "From $\\mathrm{inertiaDeg}_{(p)}\\,P = \\deg Q$ and $d \\mid \\deg Q$, substitution gives $d \\mid \\mathrm{inertiaDeg}_{(p)}\\,P$. In Lean, `hPdeg ▸ hd : d ∣ inertiaDeg (span {(p:ℤ)}) P` rewrites `hd` right-to-left along `hPdeg`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "obtain / rcases destructuring",
+      "the ▸ rewrite (Eq.mpr) operator",
+      "term-mode proof",
+      "deriving corollaries from a general lemma"
+    ],
+    "prerequisites": [
+      "Lean tactic basics (obtain, term-mode ▸)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04-oq-01` (quality 41, pass 1). The meta.json is already comprehensive (13.5 KB, deep keyInsights/sections/conclusion/cross-references — under all size caps), so this pass targets the sole real gap: the annotations, which had 3 entries with **no** `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`.

## Changes (annotations.json only)
- **All annotations enriched** with `mathContext` (LaTeX: the axiom→inertiaDegIn reduction, the Kummer–Dedekind dictionary $(p)\mathcal{O}_K = \prod \mathfrak{p}_i^{e_i}$ with $f(\mathfrak{p}_i\mid p)=\deg Q_i$, the witness $P=\Phi^{-1}\langle Q,hQ\rangle$, and the divisibility-in-a-tower rationale), plus `significance`, `relatedConcepts`, and `prerequisites`.
- **Re-aligned line ranges** to the actual file structure (the old ranges 3-62 / 64-84 / 86-95 straddled boundaries; the real structure is docstring 3-46, setup 48-52, thm1 54-77, thm2 79-93).
- **Finer coverage** — grew 3 → 6 non-overlapping annotations: roadmap docstring, ambient-data setup (`variable` block), existence theorem statement, the witness-construction technique (`primesOverSpanEquivMonicFactorsMod.symm`, `.2/.2.2` membership, `isMaximal_of_mem_primesOver`), the divisibility corollary, and its two-line `obtain`+`▸` proof.

No `meta.json` change; no Lean change. Verified 0-axiom/0-sorry status is unchanged and accurate.