### PR TITLE
Enrich Alternating Series Boole Summation OQ-02: add full annotation coverage

### DIFF
--- a/src/data/proofs/alternating-series-boole-summation-oq-02/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 3, "endLine": 40 },
+    "type": "concept",
+    "title": "Porting Boole summation from ℝ to a normed real vector space",
+    "content": "The docstring frames the child's contribution: the parent `alternating-series-boole-summation` proved the first-order Boole summation identity and its total-variation remainder bound for real sequences; this file re-establishes both for sequences valued in an arbitrary normed real vector space E (so E = ℂ, an operator algebra, or any Banach space). The 'Honest Scope' paragraph is the key qualification: the algebraic identity and the norm bound are domain-agnostic and generalize verbatim, but the antitone/telescoping monotonicity refinement of the real parent does NOT port — it relies on the order of ℝ, which a general normed space lacks. So this entry delivers precisely the order-free core.",
+    "mathContext": "Boole summation is the alternating-series analogue of Abel/Euler–Maclaurin summation. Over a normed ℝ-module $E$: $\\mathrm{altSum}\\,a\\,n\\,m = \\sum_{j=n}^{m-1} (-1)^j\\, a_j$, and the first-order identity expresses it via a two-point boundary term plus the alternating sum of the forward differences $\\Delta a_j$.",
+    "significance": "context",
+    "relatedConcepts": ["Boole summation", "Abel summation", "Euler–Maclaurin formula", "alternating series", "normed vector space", "total variation"],
+    "prerequisites": ["normed vector spaces", "finite sums over intervals", "alternating series"]
+  },
+  {
+    "id": "ann-defs-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 42, "endLine": 53 },
+    "type": "definition",
+    "title": "altSum and fdiff — the alternating partial sum and forward difference",
+    "content": "Over the ambient `[NormedAddCommGroup E] [NormedSpace ℝ E]`, two definitions carry the whole development. `altSum a n m := ∑ j ∈ Finset.Ico n m, (-1)^j • a j` is the alternating partial sum over the half-open index range [n, m); the scalar `(-1)^j : ℝ` acts by the ℝ-module structure. `fdiff a j := a (j+1) - a j` is the forward (first) difference operator. The `@[simp]` lemma `altSum_self : altSum a n n = 0` records that an empty index range sums to zero — the base case for every subsequent induction. Working over a general E means every algebraic manipulation must be module-linear rather than field arithmetic.",
+    "mathContext": "$\\mathrm{altSum}\\,a\\,n\\,m = \\sum_{j \\in [n,m)} (-1)^j \\bullet a_j \\in E$, and $\\Delta a_j = a_{j+1} - a_j$. Empty range: $\\mathrm{altSum}\\,a\\,n\\,n = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["forward difference operator", "Finset.Ico", "scalar action on modules", "finite difference calculus"],
+    "prerequisites": ["module scalar multiplication (•)", "Finset intervals"]
+  },
+  {
+    "id": "ann-peeling-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 55, "endLine": 58 },
+    "type": "technique",
+    "title": "altSum_succ_top — peeling the top index",
+    "content": "`altSum_succ_top` extends the range by one: `altSum a n (m+1) = altSum a n m + (-1)^m • a m` for `n ≤ m`. The proof unfolds `altSum` and applies Mathlib's `Finset.sum_Ico_succ_top h`, the lemma that splits a sum over `Ico n (m+1)` into the sum over `Ico n m` plus the top term. This single peeling step is the engine of the induction that proves the Boole identity — it is what lets a statement about the range [n, m+1) be reduced to the same statement about [n, m).",
+    "mathContext": "$\\sum_{j \\in [n,m+1)} f(j) = \\sum_{j \\in [n,m)} f(j) + f(m)$ for $n \\le m$; here $f(j) = (-1)^j \\bullet a_j$, giving $\\mathrm{altSum}\\,a\\,n\\,(m+1) = \\mathrm{altSum}\\,a\\,n\\,m + (-1)^m \\bullet a_m$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.sum_Ico_succ_top", "telescoping", "induction on the upper bound"],
+    "prerequisites": ["sums over half-open intervals", "Nat.le_induction"]
+  },
+  {
+    "id": "ann-identity-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "theorem",
+    "title": "boole_first_normed — the first-order Boole summation identity",
+    "content": "The main structural theorem: for `n ≤ m`, `altSum a n m = ½•((-1)^n•a n - (-1)^m•a m) - ½•altSum (fdiff a) n m`. It re-expresses an alternating sum as a two-point boundary model minus half the alternating sum of the forward differences — the discrete analogue of integration by parts. The proof is a one-step `Nat.le_induction` on m: the base case `m = n` closes by `simp` (both sides collapse via `altSum_self`); the successor step rewrites both alternating sums with `altSum_succ_top`, substitutes the inductive hypothesis `ih`, unfolds `fdiff` and `pow_succ`, then discharges the purely module-linear goal with the `module` tactic. The `module` tactic is essential — over a general E there is no `ring`, so linear combinations of scalar-multiples must be normalized module-theoretically.",
+    "mathContext": "$\\mathrm{altSum}\\,a\\,n\\,m = \\tfrac{1}{2}\\bullet\\big((-1)^n\\bullet a_n - (-1)^m\\bullet a_m\\big) - \\tfrac{1}{2}\\bullet \\mathrm{altSum}\\,(\\Delta a)\\,n\\,m$. This is 'summation by parts' for alternating signs: the boundary term $\\tfrac12((-1)^n a_n - (-1)^m a_m)$ plays the role of $[uv]$, and the difference sum plays the role of $\\int v\\,du$.",
+    "significance": "key",
+    "relatedConcepts": ["summation by parts", "Abel summation", "Nat.le_induction", "module tactic", "discrete integration by parts"],
+    "prerequisites": ["induction on naturals", "module linearity", "pow_succ"]
+  },
+  {
+    "id": "ann-remainder-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 73, "endLine": 91 },
+    "type": "theorem",
+    "title": "altSum_sub_model_norm_le — the total-variation remainder bound",
+    "content": "The analytic payoff: the alternating sum differs from its two-point model `½•((-1)^n•a n - (-1)^m•a m)` by at most half the total variation `∑ ‖fdiff a j‖`. This is the order-free norm form of the parent's total-variation bound — the estimate that makes alternating sums (Fourier/Dirichlet partial sums) tractable. Proof: the identity `boole_first_normed` rewrites the difference as exactly `-(½ • altSum (fdiff a) n m)` (via `abel`); `norm_neg` and `norm_smul` peel the `½` (using `‖½‖ = ½`), reducing to bounding `‖altSum (fdiff a)‖`. A `calc` chain then applies the triangle inequality `norm_sum_le` and cancels each `‖(-1)^j • fdiff a j‖ = ‖fdiff a j‖` because `‖(-1)^j‖ = 1`. Every step is norm-monotone; no order on E is used.",
+    "mathContext": "$\\big\\| \\mathrm{altSum}\\,a\\,n\\,m - \\tfrac12\\bullet\\big((-1)^n\\bullet a_n - (-1)^m\\bullet a_m\\big) \\big\\| \\le \\tfrac12 \\sum_{j\\in[n,m)} \\|\\Delta a_j\\|$. Key norm facts: $\\|(-1)^j \\bullet v\\| = \\|v\\|$ since $|(-1)^j| = 1$, and the triangle inequality $\\|\\sum v_j\\| \\le \\sum \\|v_j\\|$.",
+    "significance": "key",
+    "relatedConcepts": ["total variation", "triangle inequality", "norm_sum_le", "Dirichlet test", "bounded variation sequences"],
+    "prerequisites": ["norm of a scalar multiple", "triangle inequality for finite sums", "abel tactic"]
+  },
+  {
+    "id": "ann-complex-boole-oq02",
+    "proofId": "alternating-series-boole-summation-oq-02",
+    "range": { "startLine": 93, "endLine": 98 },
+    "type": "context",
+    "title": "Instantiation at E = ℂ — complex alternating sums for free",
+    "content": "The closing `example` specializes E = ℂ and applies `altSum_sub_model_norm_le` verbatim: complex-valued alternating sums — the shape of Fourier and Dirichlet partial sums — inherit the identity and remainder bound with no extra work. This is the concrete dividend of proving everything over an abstract normed ℝ-space: because ℂ is a normed ℝ-vector space, the general theorem instantiates directly. It also demonstrates that the generalization was not gratuitous — the most common application (complex partial sums) is a one-line corollary.",
+    "mathContext": "$\\mathbb{C}$ is a normed $\\mathbb{R}$-vector space, so the general bound applies to $a : \\mathbb{N} \\to \\mathbb{C}$ directly. This covers partial sums $\\sum (-1)^j a_j$ arising in Fourier/Dirichlet series analysis.",
+    "significance": "supporting",
+    "relatedConcepts": ["complex numbers as ℝ-vector space", "Fourier partial sums", "Dirichlet series", "instantiation of abstract theorems"],
+    "prerequisites": ["ℂ as a normed space over ℝ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `alternating-series-boole-summation-oq-02` (quality 45, 0 prior passes).

**Gap:** meta.json was already rich (15.6 KB), but the entry had **no annotations.json** at all.

**Changes (new annotations.json, 6 annotations covering the full 100-line file):**
- header (port of Boole summation from ℝ to a normed real vector space + honest scope on the non-porting monotonicity refinement)
- definitions (`altSum`, `fdiff`, `altSum_self`)
- `altSum_succ_top` peeling technique
- `boole_first_normed` — the first-order Boole summation identity (discrete integration by parts, `module` tactic)
- `altSum_sub_model_norm_le` — total-variation remainder bound
- `E = ℂ` instantiation

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. meta.json unchanged. `pnpm build` passes; size check within caps.