### PR TITLE
Enrich Heine–Cantor via Lebesgue number (compactness-finite-subcover-oq-02-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-01/annotations.json
@@ -1,10 +1,57 @@
 [
   {
+    "id": "lebesgue-route-overview",
+    "proofId": "compactness-finite-subcover-oq-02-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 48
+    },
+    "type": "concept",
+    "title": "The Lebesgue-Number Route to Heine–Cantor",
+    "content": "The module docstring frames the whole file. Heine–Cantor states that a continuous map f : X → Y from a compact metric space to a metric space is uniformly continuous — one δ works simultaneously at every point. Rather than invoke Mathlib's packaged CompactSpace.uniformContinuous_of_continuous, this entry deliberately REPROVES uniform continuity along the route singled out by the parent (compactness-finite-subcover-oq-02): cover X by the preimage sets U z = f⁻¹(ball (f z) ε/2), extract a single Lebesgue number δ, and read that δ off as a global modulus of continuity. The 'Results' list names the four theorems — the ε–δ engine heine_cantor_dist, the packaged heine_cantor, the equivalence continuous_iff_uniformContinuous, and the Cauchy-preservation corollary. Because the one non-trivial ingredient (lebesgue_number_lemma_of_metric) and the headline are both already in Mathlib, the formalized content is the self-contained Lebesgue-number derivation itself, hence the mathlib badge.",
+    "mathContext": "$f\\colon X\\to Y$ continuous, $X$ compact metric $\\Longrightarrow$ $f$ uniformly continuous. Route: $\\{U_z=f^{-1}(B(fz,\\varepsilon/2))\\}_{z\\in X}$ is an open cover; its Lebesgue number $\\delta$ satisfies $\\forall x\\,\\exists z:\\ B(x,\\delta)\\subseteq U_z$, which IS a uniform modulus.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Heine–Cantor theorem",
+      "Lebesgue number lemma",
+      "uniform continuity",
+      "compactness via open covers",
+      "modulus of continuity"
+    ],
+    "prerequisites": [
+      "compact metric spaces",
+      "open covers and continuity",
+      "uniform continuity"
+    ]
+  },
+  {
+    "id": "ambient-setup",
+    "proofId": "compactness-finite-subcover-oq-02-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 55
+    },
+    "type": "definition",
+    "title": "Ambient data: compact metric domain, metric codomain",
+    "content": "The setup fixes the exact hypotheses Heine–Cantor needs. The domain X carries [MetricSpace X] together with [CompactSpace X] — compactness of the domain is what powers the Lebesgue number lemma (applied to isCompact_univ) and is indispensable: uniform continuity can fail for continuous maps off a compact domain (e.g. x ↦ x² on ℝ, or x ↦ 1/x on (0,1]). The codomain Y is only [MetricSpace Y]; no compactness or completeness is assumed there, since the argument controls distances in Y purely through ε/2-balls and the triangle inequality. 'open Set Metric' brings ball, preimage, iUnion, and mem_ball into scope.",
+    "mathContext": "$X$: compact metric space (`[MetricSpace X] [CompactSpace X]`); $Y$: metric space (`[MetricSpace Y]`). Compactness of the domain, not the codomain, is the essential hypothesis.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "compact metric space",
+      "metric space typeclasses",
+      "essential role of domain compactness",
+      "counterexamples off compacta"
+    ],
+    "prerequisites": [
+      "metric space and compactness typeclasses in Mathlib"
+    ]
+  },
+  {
     "id": "epsilon-delta-engine",
     "proofId": "compactness-finite-subcover-oq-02-oq-01",
     "range": {
-      "startLine": 61,
-      "endLine": 84
+      "startLine": 57,
+      "endLine": 77
     },
     "type": "insight",
     "title": "The Lebesgue Number of the Preimage Cover Is the Modulus",


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-02-oq-01`. The four existing annotations were already deep, but they covered only lines 61–104 — the entire top of the file (module docstring, the `open`/`namespace`/`variable` setup, and the first theorem's docstring, lines 3–60) had **no** annotation coverage (~40% of the 105-line file). There was also a pre-existing range overlap.

## Changes (annotations.json only)
- **Filled the uncovered top** with two new deep annotations: `lebesgue-route-overview` (3–48, the What-This-Proves/Results/Provenance docstring and the deliberate Lebesgue-number route vs. Mathlib's packaged `CompactSpace.uniformContinuous_of_continuous`) and `ambient-setup` (50–55, why **domain** compactness is the essential hypothesis, with the standard off-compacta counterexamples $x\mapsto x^2$, $x\mapsto 1/x$).
- **Fixed the 61–84 / 78–84 overlap**: narrowed `epsilon-delta-engine` to 57–77 (now also picking up the theorem docstring) so it no longer overlaps the ε/2-triangle-close annotation at 78–84.
- Coverage rises **~40% → ~97%**; all 6 annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

No `meta.json` change (already comprehensive); no Lean change.