### PR TITLE
Enrich Factor–remainder OQ-01 (multiplicity via derivatives): annotation coverage

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "oq01-docstring-overview",
+    "proofId": "factor-remainder-theorem-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 30
+    },
+    "type": "concept",
+    "title": "OQ-01: the multiplicity version of the Factor Theorem",
+    "content": "The docstring states the open question and the strategy. The parent entry proves the ordinary Factor Theorem (X − a) ∣ p ↔ p(a) = 0; OQ-01 asks for its multiplicity refinement — (X − a)ᵏ ∣ p iff p and its first k−1 derivatives all vanish at a — which is exactly the algebraic shadow of Taylor's theorem (a root of order k kills the first k Taylor coefficients). The formalization routes entirely through Mathlib's rootMultiplicity: (X − a)ᵏ ∣ p ↔ k ≤ rootMultiplicity a p (le_rootMultiplicity_iff), and n < rootMultiplicity a p ↔ the first n iterated derivatives vanish at a (lt_rootMultiplicity_iff_isRoot_iterate_derivative_of_mem_nonZeroDivisors). Composing the two yields the multiplicity factor theorem with 0 axioms. The three named results are the general statement, the k = 1 base case (the classical Factor Theorem), and the k = 2 double-root criterion. `open Polynomial` brings X, C, derivative, eval, rootMultiplicity into scope.",
+    "mathContext": "$(X-a)^k \\mid p \\iff p(a)=p'(a)=\\cdots=p^{(k-1)}(a)=0.$ Via $\\ (X-a)^k\\mid p \\iff k\\le \\operatorname{mult}_a(p)\\ $ and $\\ n<\\operatorname{mult}_a(p)\\iff \\forall m\\le n,\\ p^{(m)}(a)=0.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "root multiplicity",
+      "Taylor expansion of polynomials",
+      "iterated formal derivative",
+      "Factor Theorem",
+      "order of vanishing"
+    ],
+    "prerequisites": [
+      "polynomials over a field",
+      "formal derivative of a polynomial",
+      "divisibility of polynomials"
+    ]
+  },
+  {
     "id": "ann-charzero",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": { "startLine": 31, "endLine": 38 },
+    "range": {
+      "startLine": 31,
+      "endLine": 38
+    },
     "type": "concept",
     "title": "Why Characteristic Zero Is Essential",
     "content": "factorial_mem_nonZeroDivisors supplies the hypothesis the derivative characterization needs: in a characteristic-zero field every factorial (n! : K) is nonzero, hence a nonzerodivisor. This is not a technicality — in characteristic p the derivative of Xᵖ is zero, so a polynomial can have vanishing derivatives at a without a being a high-multiplicity root, and the equivalence fails. The correct positive-characteristic statement uses Hasse (divided-power) derivatives instead, where p^{(m)}/m! is replaced by a derivation that does not introduce the factorial denominators.",
     "mathContext": "$n! \\ne 0$ in $K$ when $\\mathrm{char}\\,K = 0$; in $\\mathrm{char}\\,p$, $\\frac{d}{dX}X^p = pX^{p-1} = 0$, so derivatives lose multiplicity information.",
     "significance": "key",
-    "relatedConcepts": ["characteristic of a field", "nonzerodivisor", "Hasse derivative", "formal derivative"],
-    "prerequisites": ["field characteristic", "polynomial derivatives"]
+    "relatedConcepts": [
+      "characteristic of a field",
+      "nonzerodivisor",
+      "Hasse derivative",
+      "formal derivative"
+    ],
+    "prerequisites": [
+      "field characteristic",
+      "polynomial derivatives"
+    ]
   },
   {
     "id": "ann-main",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": { "startLine": 40, "endLine": 55 },
+    "range": {
+      "startLine": 40,
+      "endLine": 52
+    },
     "type": "insight",
     "title": "Multiplicity Is the Order of Vanishing of the Taylor Expansion",
     "content": "pow_dvd_iff_iterate_derivative_eval_eq_zero is the OQ's target: over a characteristic-zero field, (X − a)ᵏ ∣ p iff p and its first k − 1 derivatives all vanish at a. The proof factors through rootMultiplicity: writing k = n + 1, divisibility ↔ n + 1 ≤ rootMultiplicity a p (le_rootMultiplicity_iff) ↔ n < rootMultiplicity a p ↔ all iterated derivatives up to order n vanish at a (Mathlib's lt_rootMultiplicity_iff_isRoot_iterate_derivative...). This is exactly the statement that the Taylor expansion of p at a begins at order k — the analytic reading of the algebraic multiplicity the parent's OQ asked to connect. The final `simp` just unfolds IsRoot and rewrites n < k as m ≤ n, m < k.",
     "mathContext": "$(X-a)^k \\mid p \\iff p(a)=p'(a)=\\cdots=p^{(k-1)}(a)=0$; equivalently the Taylor expansion $p(X)=\\sum_m \\frac{p^{(m)}(a)}{m!}(X-a)^m$ has its first $k$ coefficients zero.",
     "significance": "key",
-    "relatedConcepts": ["root multiplicity", "Taylor expansion", "iterated derivative", "order of vanishing"],
-    "prerequisites": ["polynomial division", "formal derivatives", "Taylor's theorem for polynomials"]
+    "relatedConcepts": [
+      "root multiplicity",
+      "Taylor expansion",
+      "iterated derivative",
+      "order of vanishing"
+    ],
+    "prerequisites": [
+      "polynomial division",
+      "formal derivatives",
+      "Taylor's theorem for polynomials"
+    ]
   },
   {
     "id": "ann-factor",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": { "startLine": 53, "endLine": 55 },
+    "range": {
+      "startLine": 53,
+      "endLine": 55
+    },
     "type": "definition",
     "title": "The Factor Theorem as the k = 1 Base Case",
     "content": "factor_theorem is the classical k = 1 instance, (X − a) ∣ p ↔ p(a) = 0 — exactly Mathlib's dvd_iff_isRoot. It is the parent entry's headline result, recovered here as the bottom rung of the multiplicity ladder: zero-th order vanishing (the value alone) detects a simple root. Stating it alongside the general theorem makes explicit that pow_dvd_iff... at k = 1 collapses to the original Factor Theorem.",
     "mathContext": "$(X-a)\\mid p \\iff p(a)=0$ — the $k=1$ case of $(X-a)^k\\mid p \\iff \\forall m<k,\\ p^{(m)}(a)=0$.",
     "significance": "supporting",
-    "relatedConcepts": ["factor theorem", "polynomial roots", "dvd_iff_isRoot"],
-    "prerequisites": ["polynomial evaluation", "divisibility of polynomials"]
+    "relatedConcepts": [
+      "factor theorem",
+      "polynomial roots",
+      "dvd_iff_isRoot"
+    ],
+    "prerequisites": [
+      "polynomial evaluation",
+      "divisibility of polynomials"
+    ]
   },
   {
     "id": "ann-double-root",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": { "startLine": 57, "endLine": 69 },
+    "range": {
+      "startLine": 57,
+      "endLine": 69
+    },
     "type": "concept",
     "title": "The Repeated-Root Criterion (k = 2)",
     "content": "double_root_iff is the k = 2 workhorse: (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — a has multiplicity at least two iff both p and its derivative vanish there. The proof specializes the main theorem and discharges the two-element ∀ m < 2 by interval_cases. This is the standard test for repeated roots, behind discriminant criteria and the fact that a polynomial is squarefree iff it shares no root with its derivative, i.e. gcd(p, p′) = 1. It also underlies the Newton's-method observation that double roots slow quadratic convergence to linear.",
     "mathContext": "$(X-a)^2 \\mid p \\iff p(a)=0 \\wedge p'(a)=0$; squarefree $\\iff \\gcd(p,p')=1$.",
     "significance": "supporting",
-    "relatedConcepts": ["repeated roots", "discriminant", "squarefree polynomial", "gcd of polynomial and derivative"],
-    "prerequisites": ["polynomial derivatives", "greatest common divisor of polynomials"]
+    "relatedConcepts": [
+      "repeated roots",
+      "discriminant",
+      "squarefree polynomial",
+      "gcd of polynomial and derivative"
+    ],
+    "prerequisites": [
+      "polynomial derivatives",
+      "greatest common divisor of polynomials"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01`. The four existing annotations covered only lines 31–69; the entire module docstring and `namespace`/`open` header (lines 4–30) were unannotated (~52% coverage), and there was a pre-existing range overlap.

## Changes (annotations.json only)
- **Filled the uncovered docstring** (4–30) with `oq01-docstring-overview`: states the OQ-01 multiplicity refinement $(X-a)^k\mid p \iff p(a)=\cdots=p^{(k-1)}(a)=0$, its reading as the algebraic shadow of Taylor's theorem, and the two-lemma `rootMultiplicity` route (`le_rootMultiplicity_iff` + `lt_rootMultiplicity_iff_isRoot_iterate_derivative...`).
- **Fixed the 40–55 / 53–55 overlap**: narrowed the multiplicity-theorem insight to 40–52 so it no longer overlaps the k=1 factor-theorem annotation.
- Coverage rises **~52% → ~93%**; all annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

No `meta.json` change; no Lean change.