### PR TITLE
Enrich det Mᴴ = star(det M) (det-conjugate-transpose-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
+++ b/src/data/proofs/det-conjugate-transpose-oq-01/annotations.json
@@ -1,5 +1,31 @@
 [
   {
+    "id": "det-conjtranspose-overview",
+    "proofId": "det-conjugate-transpose-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "det Mᴴ = star (det M) and its adjoint/spectral corollaries",
+    "content": "The module docstring frames the entry. The base identity det Mᴴ = star (det M) holds over any StarRing R (canonically R = ℂ with star = complex conjugation): the conjugate transpose conjugates the determinant. It is Mathlib's Matrix.det_conjTranspose, distinct from det_mul and det_transpose, and previously had no gallery entry. The substantive content is the two structural corollaries it powers, tying the adjoint structure of complex matrices to the single scalar invariant det: (1) Hermitian ⟹ self-adjoint determinant — Mᴴ = M forces star(det M) = det M, so over ℂ the determinant is real ((det M).im = 0), the scalar shadow of 'Hermitian operators have real spectrum'; (2) Unitary ⟹ determinant on the unit circle — Uᴴ U = 1 gives star(det U)·det U = 1, hence ‖det U‖ = 1, the det : U(n) → U(1) picture. The imports pull in matrix determinants, the Hermitian predicate, and the complex unit circle; verified 0-sorry, 0-axiom.",
+    "mathContext": "$\\det(M^{\\mathsf H}) = \\overline{\\det M}$. Corollaries over $\\mathbb{C}$: $M^{\\mathsf H}=M \\Rightarrow \\det M\\in\\mathbb{R}$; $U^{\\mathsf H}U=I \\Rightarrow \\lvert\\det U\\rvert=1$ (so $\\det\\colon U(n)\\to U(1)$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "conjugate transpose (adjoint)",
+      "determinant as a homomorphism",
+      "Hermitian matrices and real spectrum",
+      "unitary group U(n) → U(1)",
+      "star ring / involution"
+    ],
+    "prerequisites": [
+      "matrix determinants",
+      "conjugate transpose",
+      "complex conjugation / star rings",
+      "Hermitian and unitary matrices"
+    ]
+  },
+  {
     "id": "ann-base-identity",
     "proofId": "det-conjugate-transpose-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `det-conjugate-transpose-oq-01`. The four existing annotations covered lines 37–112, leaving the entire module docstring, imports, and `open`/`namespace` header (lines 1–36) unannotated (~65% coverage).

## Changes (annotations.json only)
- Added `det-conjtranspose-overview` (1–36): the base identity $\det(M^{\mathsf H})=\overline{\det M}$ (Mathlib `Matrix.det_conjTranspose`, distinct from `det_mul`/`det_transpose`) and the two corollaries it powers — Hermitian ⟹ real determinant (scalar shadow of real spectrum) and unitary ⟹ $\lvert\det U\rvert=1$ (the $\det\colon U(n)\to U(1)$ picture).
- Coverage rises **~65% → ~99%**; all annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

No `meta.json` change; no Lean change.