### PR TITLE
Enrich Binomial Theorem OQ-01-01-02: full annotation coverage (28%→92%)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,8 +1,20 @@
 [
   {
+    "id": "ann-header-binom-oq010102",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "The analytic side of the generalized binomial theorem",
+    "content": "The header docstring frames this child within the binomial-theorem tower. The parent `binomial-theorem-oq-01-oq-01` supplied the *coefficient-level* data: the generalized coefficient `genBinom α k = (∏ j ∈ range k, (α-j))/k!`, the `absorption` identity `α·C(α-1,k) = (k+1)·C(α,k+1)`, and the analytic framework `binomial_series_analytic : HasFPowerSeriesOnBall (fun y => (1+y)^α) (binomialSeries ℝ α) 0 1`. This OQ closes the *analytic* side: that `d/dx (1+x)^α = α(1+x)^(α-1)`, and that this is exactly the absorption identity read off term by term. The whole file is 0-sorry, 0-axiom (only `propext`/`Classical.choice`/`Quot.sound`), and its technical engine is the single Mathlib lemma `HasDerivAt.rpow_const` (Pow/Deriv.lean:668).",
+    "mathContext": "Two viewpoints on the same fact. Analytic: $\\frac{d}{dx}(1+x)^\\alpha = \\alpha(1+x)^{\\alpha-1}$. Algebraic: differentiating $\\sum_k \\binom{\\alpha}{k}x^k$ term by term gives $\\sum_k (k+1)\\binom{\\alpha}{k+1}x^k = \\alpha\\sum_k \\binom{\\alpha-1}{k}x^k$, using absorption $(k+1)\\binom{\\alpha}{k+1} = \\alpha\\binom{\\alpha-1}{k}$. The file proves both sides agree.",
+    "significance": "context",
+    "relatedConcepts": ["generalized binomial theorem", "Newton's binomial series", "term-by-term differentiation", "absorption identity", "HasFPowerSeriesOnBall"],
+    "prerequisites": ["power series", "real exponentiation (rpow)", "the parent binomial-theorem-oq-01-oq-01 entry"]
+  },
+  {
     "id": "ann-hasderivat-one-add-rpow",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 37, "endLine": 43 },
+    "range": { "startLine": 34, "endLine": 43 },
     "type": "theorem",
     "title": "Pointwise derivative d/dx (1+x)^α = α(1+x)^(α-1)",
     "content": "The closed-form derivative for x > -1. The inner map `y ↦ 1+y` has derivative `1` everywhere (`(hasDerivAt_id x).const_add 1`), and `1+x ≠ 0` follows from `-1 < x`. Mathlib's `HasDerivAt.rpow_const` then gives derivative `1·α·(1+x)^(α-1)`, and `simpa` collapses `1·α` to `α`. The exponent `α` is supplied explicitly as `(p := α)` because it cannot be inferred from the goal's elaboration order.",
@@ -14,7 +26,7 @@
   {
     "id": "ann-deriv-coeff-eq-absorption",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 50, "endLine": 53 },
+    "range": { "startLine": 45, "endLine": 53 },
     "type": "theorem",
     "title": "Absorption identity as the derivative coefficient",
     "content": "The coefficient of x^k in d/dx Σ C(α,j) x^j is (k+1)·C(α,k+1); the coefficient of x^k in α(1+x)^(α-1) = α Σ C(α-1,j) x^j is α·C(α-1,k). The parent proof's `absorption` says these agree, so this theorem is just `(BinomialTheoremOQ01OQ01.absorption α k).symm`, presenting the identity in the suggestive 'coefficient of derivative' direction.",
@@ -26,7 +38,7 @@
   {
     "id": "ann-hasderivat-one-add-rpow-zero",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 58, "endLine": 61 },
+    "range": { "startLine": 55, "endLine": 61 },
     "type": "theorem",
     "title": "Derivative at the basepoint equals the linear coefficient α",
     "content": "Specializing the pointwise derivative to x = 0 gives d/dx (1+x)^α |₀ = α·(1+0)^(α-1) = α. This matches genBinom α 1 = α, the linear (k=1) coefficient of the binomial series — a sanity check linking the analytic derivative to the k=0 case of the absorption identity. Proof: `hasDerivAt_one_add_rpow α 0` followed by `simpa` to evaluate (1+0)^(α-1) = 1.",
@@ -38,7 +50,7 @@
   {
     "id": "ann-deriv-one-add-rpow",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 65, "endLine": 67 },
+    "range": { "startLine": 63, "endLine": 67 },
     "type": "theorem",
     "title": "The pointwise derivative restated as a deriv value",
     "content": "Converts the `HasDerivAt` statement into the functional `deriv` form `deriv (fun y => (1+y)^α) x = α(1+x)^(α-1)` for x > -1, via `(hasDerivAt_one_add_rpow α x hx).deriv`. This `deriv`-level restatement is the bridge used by `fderiv_one_add_rpow_apply_one`: it is what `fderiv_deriv` rewrites the Fréchet derivative into.",
@@ -50,7 +62,7 @@
   {
     "id": "ann-binomial-derivseries-analytic",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 78, "endLine": 81 },
+    "range": { "startLine": 69, "endLine": 81 },
     "type": "theorem",
     "title": "Term-by-term differentiation of the binomial power series (headline)",
     "content": "Applying `HasFPowerSeriesOnBall.fderiv` to the parent's `binomial_series_analytic` shows that the formal `derivSeries` of `binomialSeries ℝ α` is the power series of the Fréchet derivative `fderiv ℝ (fun y => (1+y)^α)` on the *same* open unit ball. This is the literal term-by-term differentiation that the parent proof listed as an open question: no new convergence work is required because `derivSeries` inherits the radius. ℝ being complete supplies the `CompleteSpace` instance the lemma needs.",
@@ -62,7 +74,7 @@
   {
     "id": "ann-fderiv-apply-one",
     "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 88, "endLine": 91 },
+    "range": { "startLine": 83, "endLine": 91 },
     "type": "theorem",
     "title": "Series derivative agrees with the closed form",
     "content": "Closes the loop between the series side and the closed-form side. `fderiv_deriv` rewrites `fderiv ℝ f x 1` to `deriv f x`, and `deriv_one_add_rpow` (itself `(hasDerivAt_one_add_rpow …).deriv`) evaluates it to `α(1+x)^(α-1)`. So the Fréchet derivative produced by term-by-term differentiation, applied to the tangent vector 1, returns exactly the pointwise binomial derivative.",


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-01-oq-01-oq-02`.

**Gap:** the 6 existing annotations were deep (full depth fields) but only tagged theorem *statements* — coverage was 28% of the 93-line file, leaving the entire framing docstring (lines 1-33) and every theorem's own docstring unannotated.

**Changes (annotations.json):**
- Added a header annotation (lines 1-33) explaining the analytic side of the generalized binomial theorem, its relation to the parent's coefficient-level `absorption` identity and `binomial_series_analytic` framework.
- Extended all 6 theorem annotations down to include their docstrings, giving contiguous coverage 1-91.
- Coverage: **28% → 92%**. All 7 annotations carry `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

meta.json unchanged (already rich). `pnpm build` passes.