### PR TITLE
Enrich Abel–Ruffini Obstruction OQ-06: full annotation coverage (32%→95%)

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
@@ -1,110 +1,241 @@
 [
   {
+    "id": "ann-header-abelruffini-oq06",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "The Abel–Ruffini obstruction: solvable-by-radicals ⟺ solvable Galois group",
+    "content": "The header and Part I section docstring frame the file. A polynomial is solvable by radicals exactly when its Galois group is a solvable group (Galois' theorem). Abel–Ruffini follows because the generic degree-n equation has Galois group Sₙ, and Sₙ is solvable for n ≤ 4 (giving the linear/quadratic/Cardano/Ferrari formulas) but not for n ≥ 5. This file formalizes the characteristic-independent core: the sharp non-solvability of Sₙ for ALL n ≥ 5 (generalizing Mathlib's Fin-5-only `Equiv.Perm.fin_5_not_solvable`), the easy solvable endpoints S₂/S₃/A₄/S₄, the exact threshold Sₙ solvable ⟺ n ≤ 4, and the radical criterion `not_solvableByRad_of_not_solvable_gal` (contrapositive of Mathlib's `solvableByRad.isSolvable'`). The deep characteristic-p refinements (wild ramification, Abhyankar/Raynaud/Harbater) are explicitly out of scope.",
+    "mathContext": "Galois: $q$ solvable by radicals $\\iff \\mathrm{Gal}(q)$ is a solvable group. The derived series $G \\rhd G' \\rhd G'' \\rhd \\cdots$ reaching $\\{e\\}$ defines solvability. $S_n$ is solvable for $n \\le 4$; for $n \\ge 5$ it contains $A_5$, a perfect nonabelian simple group ($A_5' = A_5$), so its derived series stalls.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "solvable group",
+      "derived series",
+      "Galois correspondence",
+      "solvability by radicals",
+      "symmetric group Sₙ"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "solvable groups",
+      "the derived/commutator series"
+    ]
+  },
+  {
     "id": "ann-symmetric-not-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 55, "endLine": 59 },
+    "range": {
+      "startLine": 46,
+      "endLine": 59
+    },
     "type": "theorem",
     "title": "Sₙ Unsolvable for n ≥ 5",
     "content": "The symmetric group on $n$ symbols is **not solvable** for every $n \\ge 5$. Mathlib supplies only the single case `Equiv.Perm.fin_5_not_solvable` (for `Fin 5`); here it is generalized to the whole range by invoking `Equiv.Perm.not_solvable`, whose hypothesis is a *cardinal* bound $5 \\le \\#X$. Rewriting $\\#(\\mathrm{Fin}\\ n) = n$ with `Cardinal.mk_fin` and casting $5 \\le n$ closes it. The mathematical reason it cannot be solvable: any such group contains $S_5$, and the alternating group $A_5$ is a nonabelian simple group equal to its own commutator subgroup, so the derived series stalls and never reaches the trivial subgroup.",
     "mathContext": "$\\neg\\,\\mathrm{IsSolvable}(S_n)$ for all $n \\ge 5$.",
     "significance": "key",
-    "relatedConcepts": ["Solvable group", "Derived series", "Simple group A₅", "Symmetric group"],
-    "prerequisites": ["group theory: derived/commutator series", "simplicity of A₅", "cardinality of finite types (Cardinal.mk_fin)"]
+    "relatedConcepts": [
+      "Solvable group",
+      "Derived series",
+      "Simple group A₅",
+      "Symmetric group"
+    ],
+    "prerequisites": [
+      "group theory: derived/commutator series",
+      "simplicity of A₅",
+      "cardinality of finite types (Cardinal.mk_fin)"
+    ]
   },
   {
     "id": "ann-s2-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 68, "endLine": 69 },
+    "range": {
+      "startLine": 61,
+      "endLine": 69
+    },
     "type": "theorem",
     "title": "S₂ Solvable (Abelian Endpoint)",
     "content": "The low endpoint of the threshold: $S_2$ is cyclic of order two, hence abelian, hence solvable, via `isSolvable_of_comm` with commutativity discharged by `decide`. Together with the $n \\ge 5$ result this pins both ends of the Abel–Ruffini frontier — solvability of $S_n$ is *exactly* what separates the radically-solvable low degrees (1–4) from the unsolvable ones. The `decide` here is *kernel* decidability (not `native_decide`), so it introduces no `Lean.ofReduceBool` and the entry remains genuinely axiom-free.",
     "mathContext": "$\\mathrm{IsSolvable}(S_2)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Abelian group", "Solvable group", "Decidability"],
-    "prerequisites": ["abelian ⟹ solvable (isSolvable_of_comm)", "kernel decidability vs native_decide"]
+    "relatedConcepts": [
+      "Abelian group",
+      "Solvable group",
+      "Decidability"
+    ],
+    "prerequisites": [
+      "abelian ⟹ solvable (isSolvable_of_comm)",
+      "kernel decidability vs native_decide"
+    ]
   },
   {
     "id": "ann-s3-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 79, "endLine": 89 },
+    "range": {
+      "startLine": 71,
+      "endLine": 89
+    },
     "type": "theorem",
     "title": "S₃ Solvable (Prime-Order Kernel)",
     "content": "$S_3$ is solvable through the one-step extension $1 \\to A_3 \\to S_3 \\xrightarrow{\\mathrm{sign}} \\mathbb{Z}^\\times \\to 1$. The kernel $A_3 = \\ker(\\mathrm{sign})$ has order $3!/2 = 3$, established via `nat_card_alternatingGroup` and `decide`; being of **prime** order it is cyclic (`isCyclic_of_prime_card`), hence abelian, hence solvable. The image sits inside the abelian $\\mathbb{Z}^\\times$, so both ends of the extension are solvable and `solvable_of_ker_le_range` (with `Subgroup.range_subtype` and `alternatingGroup_eq_sign_ker`) assembles $S_3$. This is the next rung of the solvable side above $S_2$, and the reason the general cubic has Cardano's radical formula.",
     "mathContext": "$\\mathrm{IsSolvable}(S_3)$; $A_3 \\cong \\mathbb{Z}/3$, $S_3/A_3 \\hookrightarrow \\mathbb{Z}^\\times$.",
     "significance": "supporting",
-    "relatedConcepts": ["Alternating group A₃", "Cyclic group of prime order", "Group extension", "Sign homomorphism"],
-    "prerequisites": ["prime-order ⟹ cyclic (isCyclic_of_prime_card)", "solvable_of_ker_le_range", "alternatingGroup = ker(sign)"]
+    "relatedConcepts": [
+      "Alternating group A₃",
+      "Cyclic group of prime order",
+      "Group extension",
+      "Sign homomorphism"
+    ],
+    "prerequisites": [
+      "prime-order ⟹ cyclic (isCyclic_of_prime_card)",
+      "solvable_of_ker_le_range",
+      "alternatingGroup = ker(sign)"
+    ]
   },
   {
     "id": "ann-a4-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 103, "endLine": 126 },
+    "range": {
+      "startLine": 91,
+      "endLine": 126
+    },
     "type": "theorem",
     "title": "A₄ Solvable (Klein-Four Extension)",
     "content": "The crucial non-abelian-yet-solvable case: $A_4$ is solvable through $1 \\to V_4 \\to A_4 \\to A_4/V_4 \\to 1$. The normal Klein four-subgroup $V_4 = $ `alternatingGroup.kleinFour (Fin 4)` (normality from `alternatingGroup.normal_kleinFour`) has **exponent two**, hence is abelian (`mul_comm_of_exponent_two`) and solvable. The quotient has order $|A_4|/|V_4| = 12/4 = 3$ — computed by `card_eq_card_quotient_mul_card_subgroup` and the concrete cardinalities — so it is cyclic of prime order, hence solvable. `solvable_of_ker_le_range` on $V_4 \\hookrightarrow A_4 \\twoheadrightarrow A_4/V_4$ finishes it. Since $V_4$ is exactly the commutator subgroup of $A_4$, this *is* the derived series $A_4 \\rhd V_4 \\rhd 1$ — and it is precisely why the general quartic is solvable by radicals (Ferrari's resolvent cubic).",
     "mathContext": "$\\mathrm{IsSolvable}(A_4)$; $V_4 \\lhd A_4$ with $|V_4|=4$, $[A_4:V_4]=3$.",
     "significance": "key",
-    "relatedConcepts": ["Alternating group A₄", "Klein four-group V₄", "Exponent-two group", "Derived series", "Ferrari's quartic"],
-    "prerequisites": ["exponent two ⟹ abelian", "Lagrange / card_eq_card_quotient_mul_card_subgroup", "solvable_of_ker_le_range"]
+    "relatedConcepts": [
+      "Alternating group A₄",
+      "Klein four-group V₄",
+      "Exponent-two group",
+      "Derived series",
+      "Ferrari's quartic"
+    ],
+    "prerequisites": [
+      "exponent two ⟹ abelian",
+      "Lagrange / card_eq_card_quotient_mul_card_subgroup",
+      "solvable_of_ker_le_range"
+    ]
   },
   {
     "id": "ann-s4-solvable",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 137, "endLine": 143 },
+    "range": {
+      "startLine": 128,
+      "endLine": 143
+    },
     "type": "theorem",
     "title": "S₄ Solvable (Top of the Solvable Range)",
     "content": "$S_4$ is solvable via the sign sequence $1 \\to A_4 \\to S_4 \\xrightarrow{\\mathrm{sign}} \\mathbb{Z}^\\times \\to 1$: the kernel $A_4$ is solvable (`alt_fin_four_solvable`) and the image is the abelian $\\mathbb{Z}^\\times$, so `solvable_of_ker_le_range` (via `alternatingGroup_eq_sign_ker`) applies. This is the **top** of the solvable range — $S_4$ is the largest symmetric group that is solvable, which is exactly why the general quartic admits a radical formula while the general quintic does not. Structurally the full derived series is $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$, terminating at the trivial group.",
     "mathContext": "$\\mathrm{IsSolvable}(S_4)$; $S_4 \\rhd A_4 \\rhd V_4 \\rhd 1$.",
     "significance": "key",
-    "relatedConcepts": ["Symmetric group S₄", "Sign homomorphism", "Solvable extension", "Radical solvability threshold"],
-    "prerequisites": ["A₄ solvable (previous theorem)", "solvable_of_ker_le_range", "alternatingGroup = ker(sign)"]
+    "relatedConcepts": [
+      "Symmetric group S₄",
+      "Sign homomorphism",
+      "Solvable extension",
+      "Radical solvability threshold"
+    ],
+    "prerequisites": [
+      "A₄ solvable (previous theorem)",
+      "solvable_of_ker_le_range",
+      "alternatingGroup = ker(sign)"
+    ]
   },
   {
     "id": "ann-symmetric-threshold",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 153, "endLine": 157 },
+    "range": {
+      "startLine": 145,
+      "endLine": 157
+    },
     "type": "theorem",
     "title": "The Symmetric Threshold (Both Endpoints)",
     "content": "`symmetric_threshold` bundles the two endpoint facts into one statement: $S_2$ and $S_3$ are solvable while $S_n$ is not solvable for any $n \\ge 5$. This is the group-theoretic skeleton of Abel–Ruffini made explicit — solvability of the symmetric group is precisely the dividing line between the radically-solvable degrees ($n \\le 4$: linear, quadratic, Cardano, Ferrari) and the radically-unsolvable degrees ($n \\ge 5$). The proof is a trivial pairing of the preceding theorems; its value is documentary, stating the frontier as a single mathematical object.",
     "mathContext": "$\\mathrm{IsSolvable}(S_2) \\,\\wedge\\, \\mathrm{IsSolvable}(S_3) \\,\\wedge\\, \\forall n \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Solvable group", "Abel–Ruffini threshold", "Symmetric group", "Radical solvability"],
-    "prerequisites": ["the endpoint theorems above", "solvable Galois group ⟺ solvable by radicals (context)"]
+    "relatedConcepts": [
+      "Solvable group",
+      "Abel–Ruffini threshold",
+      "Symmetric group",
+      "Radical solvability"
+    ],
+    "prerequisites": [
+      "the endpoint theorems above",
+      "solvable Galois group ⟺ solvable by radicals (context)"
+    ]
   },
   {
     "id": "ann-symmetric-threshold-full",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 170, "endLine": 176 },
+    "range": {
+      "startLine": 159,
+      "endLine": 176
+    },
     "type": "theorem",
     "title": "The Full Threshold: Sₙ Solvable ⟺ n ≤ 4",
     "content": "`symmetric_threshold_full` is the sharp classification at the level of the concrete small groups: $S_2$, $S_3$, and $S_4$ are **each** solvable (the entire solvable side, now proved for every $2 \\le n \\le 4$; the cases $n \\le 1$ are trivial), while $S_n$ is not solvable for any $n \\ge 5$ (`symmetricGroup_not_solvable`). This upgrades `symmetric_threshold` from the two visible endpoints to the *complete* dividing line and is the precise group-theoretic content of Abel–Ruffini: degrees $\\le 4$ have radical formulas (quadratic, Cardano, Ferrari) exactly because $S_2, S_3, S_4$ are solvable, and degree $\\ge 5$ does not because $S_n$ is not.",
     "mathContext": "$\\mathrm{IsSolvable}(S_2)\\wedge\\mathrm{IsSolvable}(S_3)\\wedge\\mathrm{IsSolvable}(S_4)\\wedge\\forall n\\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
     "significance": "key",
-    "relatedConcepts": ["Solvable group", "Abel–Ruffini classification", "Symmetric group", "Radical solvability"],
-    "prerequisites": ["all four small-group theorems above", "symmetricGroup_not_solvable"]
+    "relatedConcepts": [
+      "Solvable group",
+      "Abel–Ruffini classification",
+      "Symmetric group",
+      "Radical solvability"
+    ],
+    "prerequisites": [
+      "all four small-group theorems above",
+      "symmetricGroup_not_solvable"
+    ]
   },
   {
     "id": "ann-radical-criterion",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 197, "endLine": 200 },
+    "range": {
+      "startLine": 178,
+      "endLine": 200
+    },
     "type": "theorem",
     "title": "Abel–Ruffini Criterion",
     "content": "The Galois bridge from groups to equations: if $\\alpha$ is a root of an **irreducible** polynomial $q \\in F[X]$ whose Galois group $\\mathrm{Gal}(q)$ is **not solvable**, then $\\alpha$ is **not solvable by radicals** over $F$. This is the contrapositive of Mathlib's `solvableByRad.isSolvable'` (radicals $\\Rightarrow$ solvable Galois group) and is the precise implication used to certify a concrete unsolvable quintic: exhibit an irreducible degree-5 polynomial with Galois group $S_5$ (unsolvable by the theorem above), and its roots provably cannot be written with radicals.",
     "mathContext": "$\\neg\\,\\mathrm{IsSolvable}(q.\\mathrm{Gal}) \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\ F\\ \\alpha$ for irreducible $q$ with $q(\\alpha)=0$.",
     "significance": "key",
-    "relatedConcepts": ["Galois group", "Solvability by radicals", "Irreducible polynomial", "Contrapositive"],
-    "prerequisites": ["Galois theory: Gal(q) and the fundamental correspondence", "solvable group ⟺ radical solvability", "irreducibility in F[X]"]
+    "relatedConcepts": [
+      "Galois group",
+      "Solvability by radicals",
+      "Irreducible polynomial",
+      "Contrapositive"
+    ],
+    "prerequisites": [
+      "Galois theory: Gal(q) and the fundamental correspondence",
+      "solvable group ⟺ radical solvability",
+      "irreducibility in F[X]"
+    ]
   },
   {
     "id": "ann-converse-criterion",
     "proofId": "abel-ruffini-obstruction-oq-06",
-    "range": { "startLine": 210, "endLine": 213 },
+    "range": {
+      "startLine": 202,
+      "endLine": 213
+    },
     "type": "theorem",
     "title": "Converse: Radicals Force a Solvable Galois Group",
     "content": "`solvable_gal_of_solvableByRad` re-exposes the forward direction of Galois' theorem under a local name: a root $\\alpha$ that *is* solvable by radicals, being a root of irreducible $q$, forces $\\mathrm{Gal}(q)$ to be solvable. It is definitionally Mathlib's `solvableByRad.isSolvable'`; stating it here lets the criterion and its converse sit side by side, making the underlying equivalence (radical solvability $\\Leftrightarrow$ solvable Galois group) visible as two implications used for opposite purposes — one to *prove impossibility*, the other to *extract structure*.",
     "mathContext": "$\\mathrm{IsSolvableByRad}\\ F\\ \\alpha \\Rightarrow \\mathrm{IsSolvable}(q.\\mathrm{Gal})$ for irreducible $q$ with $q(\\alpha)=0$.",
     "significance": "supporting",
-    "relatedConcepts": ["Galois group", "Solvability by radicals", "Logical equivalence", "Galois correspondence"],
-    "prerequisites": ["Galois theory", "solvableByRad.isSolvable'", "contrapositive vs direct implication"]
+    "relatedConcepts": [
+      "Galois group",
+      "Solvability by radicals",
+      "Logical equivalence",
+      "Galois correspondence"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "solvableByRad.isSolvable'",
+      "contrapositive vs direct implication"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-obstruction-oq-06`. The 9 existing annotations were deep but tagged only theorem statements/proofs; coverage was 32% of 215 lines, skipping the header docstring and every theorem's own docstring.

**Changes (annotations.json):**
- Added a header annotation (1-45) framing Galois' solvable-by-radicals ⟺ solvable-Galois-group and the file's characteristic-independent scope.
- Extended all 9 theorem annotations down to include their `/--` docstrings (and the Part II section header into the radical-criterion annotation).
- Coverage **32% → 95%**. All 10 annotations keep `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

meta.json unchanged. `pnpm build` passes.