### PR TITLE
research(derangements-convergence-oq-07-oq-01): exact fixed-point count C(n,r)·D(n−r) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ07OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ07OQ01.lean
@@ -1,0 +1,136 @@
+/-
+# Counting permutations by their exact number of fixed points
+
+For a finite type `α` with `|α| = n`, the number of permutations of `α` having
+*exactly* `r` fixed points equals
+
+  `C(n, r) · D(n − r)`,
+
+where `C` is the binomial coefficient and `D = numDerangements`.  Choosing which
+`r` of the `n` points are fixed can be done in `C(n, r)` ways, and the remaining
+`n − r` points must be deranged (no further fixed points), contributing a factor
+`D(n − r)`.
+
+This is the *fine* (per-cardinality) refinement of the parent gallery entry
+`derangements-convergence-oq-07`, which proves only the aggregated convolution
+identity `n! = Σ_{k=0}^{n} C(n,k)·D(n−k)`.  Summing the theorem below over
+`r = 0, …, n` recovers that identity via `Fintype.card_perm`; here we pin down each
+individual term as an honest cardinality.
+
+The bijective heart -- that the permutations whose fixed-point set is a *specific*
+set `S` biject with the derangements of the complement of `S` -- is
+`card_fixedPointFinset_fiber` (reproved self-containedly below, matching the parent).
+The new content is the aggregation: partition `{σ : #fix σ = r}` over the `C(n,r)`
+subsets `S` of size `r`, on each of which the fiber has exactly `D(n − r)` elements.
+
+## Main results
+
+- `card_fixedPointFinset_fiber`       : `#{σ | fixSet σ = S} = D(|α| − |S|)`
+- `card_perm_fixedPoints_card_eq`     : `#{σ | (fixSet σ).card = r} = C(|α|, r)·D(|α| − r)`
+- `card_perm_fixedPoints_card_eq_fin` : the `α = Fin n` specialization
+
+All results are fully machine-checked with no axioms beyond Mathlib's foundations.
+-/
+import Mathlib.Combinatorics.Derangements.Finite
+import Mathlib.Combinatorics.Derangements.Basic
+import Mathlib.Tactic
+
+open Equiv Function Finset Nat
+open scoped BigOperators
+
+namespace DerangementsFixedPointCount
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- **Fiber lemma.**  The permutations of `α` whose fixed-point set is *exactly* the
+finset `S` biject with the derangements of the complement of `S`, of which there are
+`numDerangements (|α| − |S|)`.  (Reproved here to keep this file self-contained; it
+matches `DerangementsConvolution.card_fixedPointFinset_fiber` in the parent entry.) -/
+theorem card_fixedPointFinset_fiber (S : Finset α) :
+    (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card
+      = numDerangements (Fintype.card α - S.card) := by
+  classical
+  have hb : (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card
+      = Fintype.card {σ : Perm α // univ.filter (fun x => σ x = x) = S} := by
+    simp [Fintype.card_subtype]
+  have e1 : {σ : Perm α // univ.filter (fun x => σ x = x) = S}
+      ≃ {σ : Perm α // ∀ a, ¬ (a ∉ S) ↔ a ∈ fixedPoints σ} :=
+    Equiv.subtypeEquivRight (fun σ => by
+      rw [Finset.ext_iff]
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, not_not,
+        Function.mem_fixedPoints, Function.IsFixedPt]
+      exact ⟨fun h a => (h a).symm, fun h a => (h a).symm⟩)
+  have e2 : derangements (Subtype (fun a : α => a ∉ S))
+      ≃ {σ : Perm α // ∀ a, ¬ (a ∉ S) ↔ a ∈ fixedPoints σ} :=
+    derangements.subtypeEquiv (fun a : α => a ∉ S)
+  rw [hb, Fintype.card_congr e1, ← Fintype.card_congr e2,
+    card_derangements_eq_numDerangements, Fintype.card_subtype_compl, Fintype.card_coe]
+
+/-- **Exact fixed-point count.**  For any finite type `α` and any `r`, the number of
+permutations of `α` with exactly `r` fixed points is `C(|α|, r) · D(|α| − r)`.
+
+Proof: partition the permutations with `r` fixed points by their fixed-point set `S`,
+which ranges over the `C(|α|, r)` subsets of size `r`.  On each fiber
+`card_fixedPointFinset_fiber` gives `D(|α| − |S|) = D(|α| − r)` permutations, and there
+are `C(|α|, r)` such fibers. -/
+theorem card_perm_fixedPoints_card_eq (r : ℕ) :
+    (univ.filter
+        (fun σ : Perm α => (univ.filter (fun x => σ x = x)).card = r)).card
+      = (Fintype.card α).choose r * numDerangements (Fintype.card α - r) := by
+  classical
+  -- Partition the `r`-fixed-point permutations by their fixed-point finset, which
+  -- ranges over the size-`r` subsets of `univ`.
+  rw [Finset.card_eq_sum_card_fiberwise
+        (t := powersetCard r (univ : Finset α))
+        (f := fun σ : Perm α => univ.filter (fun x => σ x = x))
+        (fun σ hσ =>
+          Finset.mem_powersetCard.mpr
+            ⟨Finset.subset_univ _, (Finset.mem_filter.mp hσ).2⟩)]
+  -- Each fiber over a size-`r` set `S` has `D(|α| − r)` elements.
+  have hconst : ∀ S ∈ powersetCard r (univ : Finset α),
+      ((univ.filter (fun σ : Perm α => (univ.filter (fun x => σ x = x)).card = r)).filter
+          (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card
+        = numDerangements (Fintype.card α - r) := by
+    intro S hS
+    obtain ⟨_, hScard⟩ := Finset.mem_powersetCard.mp hS
+    -- Restricting to the `r`-fixed-point set is redundant: `fixSet σ = S` with `|S| = r`
+    -- already forces `(fixSet σ).card = r`, so this fiber equals the plain fiber.
+    have hset :
+        (univ.filter (fun σ : Perm α => (univ.filter (fun x => σ x = x)).card = r)).filter
+            (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)
+          = univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S) := by
+      ext σ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      constructor
+      · rintro ⟨_, h⟩; exact h
+      · intro h; exact ⟨by rw [h, hScard], h⟩
+    rw [hset, card_fixedPointFinset_fiber, hScard]
+  rw [Finset.sum_congr rfl hconst, Finset.sum_const, Finset.card_powersetCard,
+    Finset.card_univ, smul_eq_mul]
+
+/-- **Exact fixed-point count over `Fin n`.**  The number of permutations of an
+`n`-element set with exactly `r` fixed points is `C(n, r) · D(n − r)`. -/
+theorem card_perm_fixedPoints_card_eq_fin (n r : ℕ) :
+    (univ.filter
+        (fun σ : Perm (Fin n) => (univ.filter (fun x => σ x = x)).card = r)).card
+      = n.choose r * numDerangements (n - r) := by
+  have h := card_perm_fixedPoints_card_eq (α := Fin n) r
+  simpa [Fintype.card_fin] using h
+
+/-- Sanity check: on 3 points there are `C(3,1)·D(2) = 3·1 = 3` permutations with
+exactly one fixed point (the three transpositions). -/
+example :
+    (univ.filter
+        (fun σ : Perm (Fin 3) => (univ.filter (fun x => σ x = x)).card = 1)).card = 3 := by
+  rw [card_perm_fixedPoints_card_eq_fin]
+  decide
+
+/-- Sanity check: on 4 points there are `C(4,0)·D(4) = 1·9 = 9` derangements
+(permutations with no fixed points). -/
+example :
+    (univ.filter
+        (fun σ : Perm (Fin 4) => (univ.filter (fun x => σ x = x)).card = 0)).card = 9 := by
+  rw [card_perm_fixedPoints_card_eq_fin]
+  decide
+
+end DerangementsFixedPointCount

--- a/src/data/proofs/derangements-convergence-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-07-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "derangements-convergence-oq-07-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "Rencontres numbers: exactly r fixed points",
+    "content": "The docstring states the target: for a finite type $\\alpha$ with $|\\alpha| = n$ and any $r$, the number of permutations of $\\alpha$ with *exactly* $r$ fixed points is $\\binom{n}{r} D(n-r)$, where $D = \\texttt{numDerangements}$. This is the per-cardinality refinement of the parent entry $\\texttt{derangements-convergence-oq-07}$, which proves only the summed identity $n! = \\sum_{k} \\binom{n}{k} D(n-k)$; each summand is isolated here as an honest cardinality. The plan is two steps — a fiber lemma counting permutations with a *prescribed* fixed-point set, then aggregation over the $\\binom{n}{r}$ size-$r$ subsets. Imports the two Mathlib derangement modules (supplying $\\texttt{derangements.subtypeEquiv}$ and $\\texttt{card\\_derangements\\_eq\\_numDerangements}$) and $\\texttt{Mathlib.Tactic}$.",
+    "mathContext": "$\\#\\{\\sigma \\in S_\\alpha : \\#\\mathrm{Fix}(\\sigma) = r\\} = \\binom{n}{r} D(n-r)$, the rencontres number $D_{n,r}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["derangements", "rencontres numbers", "fixed points", "binomial coefficient"],
+    "prerequisites": ["permutations", "derangements"]
+  },
+  {
+    "id": "ann-fiber",
+    "proofId": "derangements-convergence-oq-07-oq-01",
+    "range": { "startLine": 45, "endLine": 67 },
+    "type": "theorem",
+    "title": "Fiber lemma: fixed-point set exactly S",
+    "content": "`card_fixedPointFinset_fiber` counts the permutations $\\sigma$ whose fixed-point finset $\\{x : \\sigma x = x\\}$ equals a prescribed set $S$: there are exactly $D(|\\alpha| - |S|)$ of them. A permutation fixing exactly $S$ is fixed-point-free on the complement of $S$, i.e. it restricts to a derangement of a set of size $|\\alpha| - |S|$. The Lean proof rewrites the filter cardinality as $\\texttt{Fintype.card}$ of a subtype, transports it along $\\texttt{Equiv.subtypeEquivRight}$ to the predicate form $(\\forall a,\\ \\neg(a \\notin S) \\leftrightarrow a \\in \\mathrm{fixedPoints}\\ \\sigma)$ — the double-negation bridge $\\neg(a \\notin S) \\leftrightarrow a \\in S$ handled by a pointwise $\\texttt{Finset.ext}$ — then applies $\\texttt{derangements.subtypeEquiv}\\ (\\cdot \\notin S)$, $\\texttt{card\\_derangements\\_eq\\_numDerangements}$, and $\\texttt{Fintype.card\\_subtype\\_compl}$. Reproved self-containedly to match the parent's lemma.",
+    "mathContext": "$\\#\\{\\sigma : \\mathrm{Fix}(\\sigma) = S\\} = D(|\\alpha| - |S|)$.",
+    "significance": "key",
+    "relatedConcepts": ["derangements.subtypeEquiv", "subtype cardinality", "complement", "fixed-point set"],
+    "prerequisites": ["derangements type", "Equiv.subtypeEquivRight", "Fintype.card_subtype_compl"]
+  },
+  {
+    "id": "ann-aggregate",
+    "proofId": "derangements-convergence-oq-07-oq-01",
+    "range": { "startLine": 69, "endLine": 109 },
+    "type": "theorem",
+    "title": "Aggregation over the size-r fixed-point sets",
+    "content": "`card_perm_fixedPoints_card_eq` is the headline result: $\\#\\{\\sigma : (\\mathrm{Fix}\\ \\sigma).\\mathrm{card} = r\\} = \\binom{|\\alpha|}{r} D(|\\alpha| - r)$. The permutations with $r$ fixed points are partitioned by their fixed-point set via $\\texttt{Finset.card\\_eq\\_sum\\_card\\_fiberwise}$; since a permutation with $r$ fixed points has a size-$r$ fixed-point set, the fibering map lands in $\\texttt{powersetCard}\\ r\\ \\texttt{univ}$. The crux is a redundancy step: on a fixed size-$r$ set $S$, the outer constraint $(\\mathrm{Fix}\\ \\sigma).\\mathrm{card} = r$ is automatic once $\\mathrm{Fix}\\ \\sigma = S$, so the restricted fiber equals the plain fiber (a short $\\texttt{Finset.ext}$), letting $\\texttt{card\\_fixedPointFinset\\_fiber}$ supply the constant value $D(|\\alpha| - r)$. Finally $\\texttt{Finset.sum\\_const}$ and $\\texttt{Finset.card\\_powersetCard}$ turn $\\sum_{|S|=r} D(|\\alpha|-r)$ into $\\binom{|\\alpha|}{r} \\cdot D(|\\alpha|-r)$.",
+    "mathContext": "$\\#\\{\\sigma : \\#\\mathrm{Fix}(\\sigma) = r\\} = \\sum_{|S| = r} D(n - r) = \\binom{n}{r} D(n - r)$.",
+    "significance": "key",
+    "relatedConcepts": ["fiberwise partition", "powersetCard", "constant sum", "double counting"],
+    "prerequisites": ["Finset.card_eq_sum_card_fiberwise", "Finset.card_powersetCard", "Finset.sum_const"]
+  },
+  {
+    "id": "ann-fin",
+    "proofId": "derangements-convergence-oq-07-oq-01",
+    "range": { "startLine": 111, "endLine": 118 },
+    "type": "theorem",
+    "title": "Specialization to Fin n",
+    "content": "`card_perm_fixedPoints_card_eq_fin` reads the general finite-type statement off at $\\alpha = \\mathrm{Fin}\\ n$: the number of permutations of an $n$-element set with exactly $r$ fixed points is $\\binom{n}{r} D(n-r)$. The proof instantiates the general theorem and rewrites $\\texttt{Fintype.card (Fin n)} = n$ via $\\texttt{Fintype.card\\_fin}$ with a single $\\texttt{simpa}$.",
+    "mathContext": "$\\#\\{\\sigma \\in S_n : \\#\\mathrm{Fix}(\\sigma) = r\\} = \\binom{n}{r} D(n - r)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.card_fin", "symmetric group", "specialization"],
+    "prerequisites": ["Fin n", "Fintype.card_fin"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "derangements-convergence-oq-07-oq-01",
+    "range": { "startLine": 120, "endLine": 136 },
+    "type": "concept",
+    "title": "Concrete sanity checks (decide)",
+    "content": "Two $\\texttt{decide}$-checked examples exercise the count at both a nonzero $r$ and the $r = 0$ boundary. On $\\mathrm{Fin}\\ 3$ there are $\\binom{3}{1} D(2) = 3 \\cdot 1 = 3$ permutations with exactly one fixed point — the three transpositions. On $\\mathrm{Fin}\\ 4$ there are $\\binom{4}{0} D(4) = 1 \\cdot 9 = 9$ permutations with no fixed points — the derangements of four elements. After rewriting by $\\texttt{card\\_perm\\_fixedPoints\\_card\\_eq\\_fin}$, both reduce to concrete $\\mathbb{N}$ equalities discharged by kernel reduction, adding no axioms.",
+    "mathContext": "$D_{3,1} = \\binom{3}{1} D(2) = 3$ and $D_{4,0} = \\binom{4}{0} D(4) = 9$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "derangement numbers", "transpositions", "numerical verification"],
+    "prerequisites": ["numDerangements", "kernel decision procedure"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-07-oq-01/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const derangementsConvergenceOQ07OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const derangementsConvergenceOQ07OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const derangementsConvergenceOQ07OQ01Data: ProofData = {
+  proof: derangementsConvergenceOQ07OQ01Proof,
+  annotations: derangementsConvergenceOQ07OQ01Annotations,
+}

--- a/src/data/proofs/derangements-convergence-oq-07-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-07-oq-01/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "derangements-convergence-oq-07-oq-01",
+  "title": "Exact fixed-point count: permutations with exactly r fixed points number C(n,r)·D(n−r)",
+  "slug": "derangements-convergence-oq-07-oq-01",
+  "description": "The per-cardinality refinement of the parent's aggregated convolution identity. For a finite type α with |α| = n and any r, the number of permutations of α having *exactly* r fixed points equals C(n,r)·D(n−r), where C is the binomial coefficient and D = numDerangements. Choose which r of the n points are fixed (C(n,r) ways) and derange the remaining n−r points (D(n−r) ways). Where the parent entry derangements-convergence-oq-07 proves only the summed identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k), this leaf pins down each individual term as an honest cardinality; summing the theorem below over r = 0,…,n recovers the parent via Fintype.card_perm. The bijective heart — permutations whose fixed-point set is a specific set S biject with the derangements of the complement of S — is derived from Mathlib's derangements.subtypeEquiv; the new content is the aggregation over the C(n,r) size-r subsets via Finset.card_eq_sum_card_fiberwise.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ07OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "fixed-points",
+      "permutations",
+      "enumerative",
+      "binomial-coefficient",
+      "bijection",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All theorems are fully machine-checked, depending only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool). The fiber bijection reuses Mathlib's derangements.subtypeEquiv and card_derangements_eq_numDerangements; the aggregation uses Finset.card_eq_sum_card_fiberwise and Finset.card_powersetCard.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 136,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "card_perm_fixedPoints_card_eq (PROVED, HEADLINE): for any finite type α and any r, the number of permutations of α with exactly r fixed points is C(|α|,r)·D(|α|−r). This is the per-cardinality refinement of the parent's aggregated convolution identity — each term of n! = Σ C(n,k)·D(n−k) isolated as an exact cardinality rather than only their sum.",
+      "card_fixedPointFinset_fiber (PROVED, BIJECTIVE CORE): the permutations of α whose fixed-point set is *exactly* the finset S biject with the derangements of the complement of S, of which there are D(|α|−|S|). Reproved self-containedly from derangements.subtypeEquiv + card_derangements_eq_numDerangements + Fintype.card_subtype_compl, matching the parent's fiber lemma.",
+      "card_perm_fixedPoints_card_eq_fin (PROVED, SPECIALIZATION): the α = Fin n instance — the number of permutations of an n-element set with exactly r fixed points is C(n,r)·D(n−r), obtained from the general statement by Fintype.card_fin.",
+      "Two decide-checked sanity examples: on 3 points there are C(3,1)·D(2) = 3 permutations with exactly one fixed point (the three transpositions), and on 4 points there are C(4,0)·D(4) = 9 derangements."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "derangements.subtypeEquiv",
+        "description": "The equivalence realizing that permutations of α fixing exactly a prescribed subset correspond to derangements of the complementary subtype. The bijective core of the fiber lemma.",
+        "module": "Mathlib.Combinatorics.Derangements.Basic"
+      },
+      {
+        "theorem": "card_derangements_eq_numDerangements",
+        "description": "Fintype.card (derangements (Fin n)) = numDerangements n — identifies the cardinality of the derangement type with the closed-form derangement number D(n).",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Partitions a finset by the value of a function into fibers and sums their cardinalities. Used to split the r-fixed-point permutations over the C(n,r) subsets of size r that can serve as fixed-point sets.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "(powersetCard r s).card = s.card.choose r — the number of size-r subsets of s is C(|s|,r). Supplies the C(n,r) factor once each fiber is shown to have D(n−r) elements.",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Fintype.card_subtype_compl",
+        "description": "Fintype.card {x // ¬ p x} = Fintype.card α − Fintype.card {x // p x} — converts the derangement count on the complement of S into D(|α|−|S|).",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The distribution of the number of fixed points of a uniform random permutation is a cornerstone of enumerative combinatorics: the count of permutations with exactly r fixed points, C(n,r)·D(n−r), is Montmort's rencontres number, and its normalization C(n,r)·D(n−r)/n! → e⁻¹/r! is the classical Poisson(1) limit. The parent entry proves only the aggregated identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k) — a single equation obtained by summing over all fixed-point counts. This leaf sharpens that to the term level, establishing each rencontres number as an exact cardinality, which is the starting point for the fixed-point distribution and its Poisson approximation.",
+    "problemStatement": "**OQ-07-OQ-01 of derangements-convergence (open question of the fixed-point convolution entry).** The parent proves the summed identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k). Prove the per-cardinality refinement: for a finite type α with |α| = n and any r, the number of permutations of α with *exactly* r fixed points equals C(n,r)·D(n−r).",
+    "text": "For any finite type α with |α| = n and any r ∈ ℕ, the number of permutations of α with exactly r fixed points is C(n,r)·D(n−r), where D = numDerangements.",
+    "proofStrategy": "**Fiber lemma (card_fixedPointFinset_fiber).** Fix a finset S ⊆ α. A permutation σ has fixed-point set exactly S iff, on the complement of S, σ has no fixed points — i.e. σ restricts to a derangement of the complementary subtype. Mathlib's derangements.subtypeEquiv realizes this bijection; card_derangements_eq_numDerangements and Fintype.card_subtype_compl then count the fiber as D(|α|−|S|).\n\n**Aggregation (card_perm_fixedPoints_card_eq).** Partition the permutations with (fixSet σ).card = r by their actual fixed-point set S, which ranges exactly over the size-r subsets of univ (powersetCard r univ). Finset.card_eq_sum_card_fiberwise turns the count into a sum over these subsets. On each subset, the constraint (fixSet σ).card = r is redundant (fixSet σ = S with |S| = r already forces it), so the fiber equals the plain fiber of the lemma, with D(|α|−r) elements. Summing the constant D(|α|−r) over the C(n,r) size-r subsets (Finset.card_powersetCard, Finset.sum_const) gives C(n,r)·D(n−r).\n\n**Specialization.** card_perm_fixedPoints_card_eq_fin reads off the α = Fin n case via Fintype.card_fin.",
+    "keyInsights": [
+      "The parent's identity is the r-summed shadow of a term-by-term truth: not merely does Σ_r C(n,r)D(n−r) = n!, but each summand C(n,r)·D(n−r) is itself the exact number of permutations with r fixed points. Isolating the individual terms is the substantive step, and it is what makes the fixed-point *distribution* (not just its total mass) available.",
+      "The fixed-point set is the right fibering variable: partitioning by the *set* S of fixed points (over the C(n,r) size-r subsets) rather than by the mere count linearizes the problem — every fiber is a plain 'fixed-point-set-equals-S' fiber, uniformly of size D(n−r), so the count is a constant sum.",
+      "On a fiber over a size-r set S, the cardinality constraint (fixSet σ).card = r is logically redundant given fixSet σ = S; recognizing this collapses the double-filtered fiber to a single-filtered one and lets the fiber lemma apply verbatim.",
+      "No new bijection is invented: the entire fiber count is inherited from Mathlib's derangements.subtypeEquiv, so the work is purely the combinatorial aggregation, kept axiom-free."
+    ],
+    "prerequisites": [
+      "Mathlib's derangements type and derangements.subtypeEquiv (fixed subset ↔ derangement of complement)",
+      "card_derangements_eq_numDerangements and numDerangements (the closed-form derangement numbers D(n))",
+      "Finset.card_eq_sum_card_fiberwise and Finset.card_powersetCard for the partition over size-r subsets",
+      "Fintype.card_subtype_compl, Fintype.card_fin for the cardinality bookkeeping"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the per-cardinality identity C(n,r)·D(n−r), its relation to the parent's summed convolution, and the two-step plan (fiber lemma then aggregation). Imports Mathlib's derangement modules and Mathlib.Tactic.",
+      "mathContext": "Sets up the refinement of the parent identity n! = Σ C(n,k)·D(n−k) to the term level."
+    },
+    {
+      "id": "sec-fiber",
+      "title": "Fiber Lemma: Fixed-Point Set Exactly S",
+      "startLine": 45,
+      "endLine": 67,
+      "summary": "card_fixedPointFinset_fiber: the permutations with fixed-point set exactly S biject with the derangements of the complement of S. Built from a subtype rewrite (fixSet σ = S ↔ the complement is exactly the moved points) composed with derangements.subtypeEquiv, then counted by card_derangements_eq_numDerangements and Fintype.card_subtype_compl.",
+      "mathContext": "$\\#\\{\\sigma : \\mathrm{Fix}(\\sigma) = S\\} = D(|\\alpha| - |S|)$."
+    },
+    {
+      "id": "sec-aggregate",
+      "title": "Aggregation over Size-r Fixed-Point Sets",
+      "startLine": 69,
+      "endLine": 109,
+      "summary": "card_perm_fixedPoints_card_eq: partition the r-fixed-point permutations by their fixed-point set (ranging over powersetCard r univ) via Finset.card_eq_sum_card_fiberwise; show each fiber's redundant cardinality filter collapses to the plain fiber (size D(n−r)); sum the constant over the C(n,r) size-r subsets with Finset.card_powersetCard and Finset.sum_const.",
+      "mathContext": "$\\#\\{\\sigma : \\#\\mathrm{Fix}(\\sigma) = r\\} = \\binom{n}{r} D(n-r)$."
+    },
+    {
+      "id": "sec-fin",
+      "title": "Specialization to Fin n and Sanity Checks",
+      "startLine": 111,
+      "endLine": 136,
+      "summary": "card_perm_fixedPoints_card_eq_fin specializes to α = Fin n via Fintype.card_fin. Two decide-checked examples confirm C(3,1)·D(2) = 3 permutations of Fin 3 with one fixed point, and C(4,0)·D(4) = 9 derangements of Fin 4.",
+      "mathContext": "$\\#\\{\\sigma \\in S_n : \\#\\mathrm{Fix}(\\sigma) = r\\} = \\binom{n}{r} D(n-r)$, with numerical checks."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-07",
+      "relationship": "parent",
+      "description": "Parent entry: proves the aggregated convolution identity n! = Σ_{k=0}^{n} C(n,k)·D(n−k) by partitioning all permutations by fixed-point-set size. This leaf refines it to the term level, proving each C(n,r)·D(n−r) is itself the exact count of permutations with r fixed points; summing over r recovers the parent."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Grand-parent: the derangement convergence D(n)/n! → e⁻¹, whose numDerangements is the D appearing in the count C(n,r)·D(n−r)."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "foundational",
+      "description": "Root derangement definitions: the derangements type and derangements.subtypeEquiv supplying the fiber bijection between fixed-subset permutations and derangements of the complement."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for any finite type α with |α| = n and any r, the number of permutations of α with exactly r fixed points is C(n,r)·D(n−r). This is the per-cardinality refinement of the parent's summed identity n! = Σ C(n,k)·D(n−k) — each rencontres number established as an exact cardinality. Zero sorries, zero extra axioms; the fiber bijection is reused from Mathlib's derangements.subtypeEquiv and the aggregation from Finset.card_eq_sum_card_fiberwise.",
+    "implications": "**The fixed-point distribution, term by term.** With each count C(n,r)·D(n−r) pinned down exactly, the full distribution of the number of fixed points of a random permutation is available — the numerators of the Poisson(1) approximation D_k(n)/n! → e⁻¹/k! studied in sibling entries. **A reusable fiber count.** The lemma that permutations with fixed-point set exactly S number D(|α|−|S|) is the natural building block for any statistic controlled by the fixed-point set.",
+    "openQuestions": [
+      "Derive the normalized masses C(n,r)·D(n−r)/n! and their Poisson(1) limit e⁻¹/r! directly from this exact count, connecting to the quantitative-rate sibling entries.",
+      "Prove the mean and variance of the number of fixed points are both 1 by summing r·C(n,r)·D(n−r) and r²·C(n,r)·D(n−r) against this exact term formula."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "card_perm_fixedPoints_card_eq",
+      "type": "core",
+      "description": "For any finite type α and any r, the number of permutations of α with exactly r fixed points is C(|α|,r)·D(|α|−r).",
+      "leanType": "(r : ℕ) → (univ.filter (fun σ : Perm α => (univ.filter (fun x => σ x = x)).card = r)).card = (Fintype.card α).choose r * numDerangements (Fintype.card α - r)"
+    },
+    {
+      "name": "card_fixedPointFinset_fiber",
+      "type": "supporting",
+      "description": "The permutations of α whose fixed-point set is exactly the finset S number D(|α|−|S|).",
+      "leanType": "(S : Finset α) → (univ.filter (fun σ : Perm α => univ.filter (fun x => σ x = x) = S)).card = numDerangements (Fintype.card α - S.card)"
+    },
+    {
+      "name": "card_perm_fixedPoints_card_eq_fin",
+      "type": "core",
+      "description": "The number of permutations of an n-element set with exactly r fixed points is C(n,r)·D(n−r).",
+      "leanType": "(n r : ℕ) → (univ.filter (fun σ : Perm (Fin n) => (univ.filter (fun x => σ x = x)).card = r)).card = n.choose r * numDerangements (n - r)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Combinatorics.Derangements.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv",
+      "Function",
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "DerangementsFixedPointCount",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ07OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "The problème des rencontres, introducing the numbers C(n,r)·D(n−r) counting permutations with exactly r coincidences (fixed points)."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd edition, §2.2",
+      "note": "The exponential-formula and inclusion–exclusion treatment of derangements and the rencontres numbers C(n,r)·D(n−r)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry `derangements-convergence-oq-07-oq-01` — the **exact rencontres count**: for any finite type $\alpha$ with $|\alpha|=n$ and any $r$, the number of permutations of $\alpha$ with **exactly $r$ fixed points** is $\binom{n}{r}\cdot D(n-r)$, where $D=\texttt{numDerangements}$.

This **answers the parent oq-07's first open question**. Where the parent (`derangements-convergence-oq-07`) proves only the summed convolution $n!=\sum_k \binom{n}{k}D(n-k)$, this leaf pins down each individual term as an honest cardinality.

## Proof

Three steps, building on the parent's fiber lemma:
1. **Partition** the $r$-fixed-point permutations by their fixed-point set via `Finset.card_eq_sum_card_fiberwise` over `powersetCard r univ` (the size-$r$ subsets).
2. **Fiber value**: on a size-$r$ set $S$ the outer count-constraint is redundant, so the fiber equals the plain fiber and `card_fixedPointFinset_fiber` gives the constant $D(n-r)$.
3. **Collapse** the constant sum with `Finset.sum_const` + `Finset.card_powersetCard` to $\binom{n}{r}\cdot D(n-r)$.

Stated for arbitrary finite $\alpha$ and for `Fin n`; two `decide`-checked instances (3 transpositions on `Fin 3`, 9 derangements on `Fin 4`).

## Verification

- **Builds**: `docker-build.sh Proofs.DerangementsConvergenceOQ07OQ01` → `✔ [3060/3060] Built`
- **0 sorries, 0 axioms** (only foundational `propext`/`Classical.choice`/`Quot.sound`; no `sorryAx`, no `native_decide`)
- 3 theorems, 0 definitions, 136 lines

## Files
- `proofs/Proofs/DerangementsConvergenceOQ07OQ01.lean`
- `src/data/proofs/derangements-convergence-oq-07-oq-01/{meta,annotations}.json`, `index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)