### PR TITLE
Enrich Euler Totient OQ-06: annotation coverage (37%→91%)

### DIFF
--- a/src/data/proofs/euler-totient-oq-06/annotations.json
+++ b/src/data/proofs/euler-totient-oq-06/annotations.json
@@ -1,74 +1,163 @@
 [
   {
+    "id": "ann-header-eulertotient-oq06",
+    "proofId": "euler-totient-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Parity of Euler's totient: the full odd/even classification",
+    "content": "The imports and header docstring pose OQ-06 — prove φ(n) is even for every n > 2 — and explain the file's strategy. Mathlib already supplies the one-directional `Nat.totient_even` (2 < n → Even φ(n)), proved via the unit -1 ∈ (ZMod n)ˣ having order 2 and Lagrange's `orderOf_dvd_card`. Rather than merely restate that, this file uses it as the seed for the COMPLETE parity classification Mathlib does not package: `totient_odd_iff : Odd (φ n) ↔ n = 1 ∨ n = 2` and `totient_even_iff : Even (φ n) ↔ n ≠ 1 ∧ n ≠ 2`. So φ takes an odd value at exactly n = 1 and n = 2 (φ 1 = φ 2 = 1) and is even everywhere else, including φ 0 = 0. The two small odd values are the only obstruction to 'the totient is always even', and they are pinned down exactly. Fully machine-checked: 0 sorries, 0 axioms.",
+    "mathContext": "$\\varphi(n)$ counts units of $\\mathbb{Z}/n\\mathbb{Z}$. For $n > 2$, $-1 \\ne 1$ is a unit of order $2$, so $2 \\mid |(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$ by Lagrange. The odd values occur only at $\\varphi(1) = \\varphi(2) = 1$; thus $\\mathrm{Odd}\\,\\varphi(n) \\iff n \\in \\{1,2\\}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euler's totient function",
+      "unit group (ZMod n)ˣ",
+      "Lagrange's theorem",
+      "order of an element",
+      "parity classification"
+    ],
+    "prerequisites": [
+      "Euler's totient",
+      "group theory (order, Lagrange)",
+      "units mod n"
+    ]
+  },
+  {
     "id": "ann-totient-even-of-two-lt",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 44, "endLine": 48 },
+    "range": {
+      "startLine": 44,
+      "endLine": 48
+    },
     "type": "theorem",
     "title": "The Even Direction: φ(n) Even for n > 2",
     "content": "The headline fact, delegated to Mathlib's `Nat.totient_even`. The group-theoretic reason: in the unit group (ℤ/nℤ)ˣ the element −1 satisfies (−1)² = 1, so it has order dividing 2; for n > 2 it is distinct from 1, hence order exactly 2. Lagrange's theorem (`orderOf_dvd_card`) then forces 2 ∣ |(ℤ/nℤ)ˣ| = φ(n). The proof here is a one-line re-export, with the contribution being the classification built on top of it.",
     "mathContext": "$2 < n \\implies \\mathrm{Even}\\,\\varphi(n)$. Witness: $-1 \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times$ has order $2$, so $2 \\mid |(\\mathbb{Z}/n\\mathbb{Z})^\\times| = \\varphi(n)$ by Lagrange.",
     "significance": "key",
-    "relatedConcepts": ["Euler's totient", "unit group of ℤ/nℤ", "order of an element", "Lagrange's theorem"],
-    "prerequisites": ["Euler's totient function", "group order", "Lagrange's theorem"]
+    "relatedConcepts": [
+      "Euler's totient",
+      "unit group of ℤ/nℤ",
+      "order of an element",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "Euler's totient function",
+      "group order",
+      "Lagrange's theorem"
+    ]
   },
   {
     "id": "ann-two-dvd-totient",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 50, "endLine": 52 },
+    "range": {
+      "startLine": 50,
+      "endLine": 52
+    },
     "type": "theorem",
     "title": "Divisibility Restatement: 2 ∣ φ(n)",
     "content": "Repackages the parity statement as a divisibility one via `Even.two_dvd`. Many downstream arguments want `2 ∣ φ(n)` directly rather than `Even (φ n)`; this makes the headline fact available in the form most callers need without re-deriving it.",
     "mathContext": "$2 < n \\implies 2 \\mid \\varphi(n)$, equivalent to $\\mathrm{Even}\\,\\varphi(n)$ since $\\mathrm{Even}\\,a \\iff 2 \\mid a$.",
     "significance": "supporting",
-    "relatedConcepts": ["divisibility", "even numbers", "Euler's totient"],
-    "prerequisites": ["divisibility", "parity"]
+    "relatedConcepts": [
+      "divisibility",
+      "even numbers",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "parity"
+    ]
   },
   {
     "id": "ann-even-totient-three-le",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 54, "endLine": 56 },
+    "range": {
+      "startLine": 54,
+      "endLine": 56
+    },
     "type": "theorem",
     "title": "Convenience Form: 3 ≤ n ⇒ Even φ(n)",
     "content": "A trivial restatement using `3 ≤ n` (definitionally `2 < n` on the naturals) so callers phrasing their bound as `3 ≤ n` need not convert. Pure ergonomics — the mathematical content is identical to `totient_even_of_two_lt`.",
     "mathContext": "$3 \\le n \\iff 2 < n$ over $\\mathbb{N}$, so $3 \\le n \\implies \\mathrm{Even}\\,\\varphi(n)$.",
     "significance": "supporting",
-    "relatedConcepts": ["natural number ordering", "Euler's totient"],
-    "prerequisites": ["natural number inequalities"]
+    "relatedConcepts": [
+      "natural number ordering",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "natural number inequalities"
+    ]
   },
   {
     "id": "ann-le-two-of-odd-totient",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 60, "endLine": 65 },
+    "range": {
+      "startLine": 58,
+      "endLine": 65
+    },
     "type": "theorem",
     "title": "The New Direction: Odd φ(n) Forces n ≤ 2",
     "content": "The genuinely new direction Mathlib does not provide, obtained as the contrapositive of the even theorem. The proof assumes `¬ n ≤ 2` (so `2 < n`), derives `Even (φ n)`, and contradicts oddness via `Nat.not_odd_iff_even`. This is the half that converts the one-directional Mathlib lemma into a biconditional classification.",
     "mathContext": "$\\mathrm{Odd}\\,\\varphi(n) \\implies n \\le 2$, the contrapositive of $2 < n \\implies \\mathrm{Even}\\,\\varphi(n)$, using $\\neg\\,\\mathrm{Odd}\\,m \\iff \\mathrm{Even}\\,m$.",
     "significance": "key",
-    "relatedConcepts": ["contrapositive", "parity", "Euler's totient", "case analysis"],
-    "prerequisites": ["contrapositive reasoning", "parity"]
+    "relatedConcepts": [
+      "contrapositive",
+      "parity",
+      "Euler's totient",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "contrapositive reasoning",
+      "parity"
+    ]
   },
   {
     "id": "ann-totient-odd-iff",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 67, "endLine": 75 },
+    "range": {
+      "startLine": 67,
+      "endLine": 75
+    },
     "type": "theorem",
     "title": "Full Odd Classification: Odd φ(n) ↔ n ∈ {1,2}",
     "content": "The capstone biconditional. Forward: an odd totient gives `n ≤ 2` (previous theorem), then `interval_cases n` splits into n ∈ {0,1,2} and `decide` evaluates φ at each concrete value (φ 0 = 0 even, φ 1 = φ 2 = 1 odd) to pin the answer. Backward: substitute n = 1 or n = 2 and `decide`. The `decide` calls are kernel reductions over small naturals — not `native_decide` — so no extra axioms enter.",
     "mathContext": "$\\mathrm{Odd}\\,\\varphi(n) \\iff n = 1 \\lor n = 2$. The only odd values are $\\varphi(1)=\\varphi(2)=1$; $\\varphi(0)=0$ is even.",
     "significance": "key",
-    "relatedConcepts": ["biconditional classification", "interval_cases", "kernel decide", "Euler's totient"],
-    "prerequisites": ["finite case analysis", "decidable evaluation", "parity"]
+    "relatedConcepts": [
+      "biconditional classification",
+      "interval_cases",
+      "kernel decide",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "finite case analysis",
+      "decidable evaluation",
+      "parity"
+    ]
   },
   {
     "id": "ann-totient-even-iff",
     "proofId": "euler-totient-oq-06",
-    "range": { "startLine": 77, "endLine": 80 },
+    "range": {
+      "startLine": 77,
+      "endLine": 80
+    },
     "type": "theorem",
     "title": "Even Classification: Even φ(n) ↔ n ∉ {1,2}",
     "content": "The De Morgan complement of the odd classification: rewrite `Even` as `¬ Odd` (`Nat.not_odd_iff_even`), substitute `totient_odd_iff`, and distribute the negation over the disjunction with `not_or`. This yields the cleanest global statement — φ is even except at exactly 1 and 2 — correct even at the degenerate n = 0 (φ 0 = 0, even).",
     "mathContext": "$\\mathrm{Even}\\,\\varphi(n) \\iff n \\ne 1 \\land n \\ne 2$, via $\\mathrm{Even}\\,m \\iff \\neg\\,\\mathrm{Odd}\\,m$ and $\\neg(a \\lor b) \\iff \\neg a \\land \\neg b$.",
     "significance": "supporting",
-    "relatedConcepts": ["De Morgan's laws", "negation of disjunction", "parity", "Euler's totient"],
-    "prerequisites": ["propositional logic", "parity"]
+    "relatedConcepts": [
+      "De Morgan's laws",
+      "negation of disjunction",
+      "parity",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "propositional logic",
+      "parity"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-06`. The 6 existing annotations already included their theorem docstrings, but the header docstring (the OQ statement, strategy, and full parity classification) was unannotated — coverage 37% of 82 lines.

**Changes (annotations.json):**
- Added a header annotation (1-43) explaining the odd/even totient classification (`Odd φ(n) ⟺ n ∈ {1,2}`), the `-1` unit-of-order-2 / Lagrange mechanism, and that φ is even everywhere except n = 1, 2.
- Folded the mid-file section header into the odd-direction annotation.
- Coverage **37% → 91%**; all 7 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

meta.json unchanged. `pnpm build` passes.