### PR TITLE
Enrich Lucas Divisibility Sequence OQ-02-OQ-01-OQ-01: 35%→88% annotation coverage

### DIFF
--- a/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sequence-degree2-identities-oq-02-oq-01-oq-01/annotations.json
@@ -1,50 +1,142 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 60
+    },
+    "type": "concept",
+    "title": "Overview: Divisibility Sequences and the Subtraction-Free Engine",
+    "content": "This entry answers the first half of the open question posed by the sibling gcd-bound entry OQ-02-OQ-01: for the fundamental Lucas sequence Uₙ(P,Q) with U₀=0, U₁=1, Uₙ₊₂ = P·Uₙ₊₁ − Q·Uₙ and arbitrary integer parameters P, Q, one has Uₘ ∣ U_{m·k}, equivalently m ∣ n ⟹ Uₘ ∣ Uₙ — i.e. U is a divisibility sequence. This generalizes the classical Fibonacci fact Fₘ ∣ Fₙ and Pell fact Pₘ ∣ Pₙ. The whole proof rests on one new ingredient absent from the parent OQ-02 (which records only the factor-2 law 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ): a subtraction-free bilinear addition law U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ, derived algebraically with no new induction. With it, the divisibility property is a one-line induction on k. The entry closes with a sharpness result: the companion sequence V is NOT a divisibility sequence, so the property is genuinely special to the fundamental sequence U.",
+    "mathContext": "$U_0=0,\\; U_1=1,\\; U_{n+2}=P\\,U_{n+1}-Q\\,U_n$; goal $m \\mid n \\Rightarrow U_m \\mid U_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisibility sequence",
+      "Lucas sequence",
+      "Fibonacci numbers",
+      "Pell numbers",
+      "strong divisibility"
+    ],
+    "prerequisites": [
+      "Lucas sequence recurrence",
+      "divisibility",
+      "mathematical induction"
+    ]
+  },
+  {
     "id": "ann-addition-law",
     "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
-    "range": { "startLine": 74, "endLine": 84 },
+    "range": {
+      "startLine": 67,
+      "endLine": 84
+    },
     "type": "theorem",
     "title": "Subtraction-Free Bilinear Addition Law",
     "content": "`U_add_clean` proves U_{m+n+1} = U_{m+1}·U_{n+1} − Q·Uₘ·Uₙ. The parent OQ-02 records only the factor-2 law two_U_add: 2·U_{m+n} = Uₘ·Vₙ + Vₘ·Uₙ, whose factor of 2 blocks divisibility arguments. Here we substitute the companion relation V_eq (Vₙ = 2·Uₙ₊₁ − P·Uₙ) for both V_{n+1} and V_m, together with the recurrence U_add_two (U_{n+2} = P·U_{n+1} − Q·U_n), into 2·U_{m+n+1}; a single `linear_combination` collapses it to 2·(U_{m+1}U_{n+1} − Q Uₘ Uₙ), and `mul_left_cancel₀` removes the 2. No new induction is required — the clean law is a pure algebraic consequence of already-proved facts.",
     "mathContext": "$U_{m+n+1} = U_{m+1}U_{n+1} - Q\\,U_m U_n$; for Fibonacci $(P,Q)=(1,-1)$ this is $F_{m+n+1} = F_{m+1}F_{n+1} + F_m F_n$.",
     "significance": "critical",
-    "relatedConcepts": ["bilinear addition law", "Lucas sequence", "linear_combination", "divisibility sequence"],
-    "prerequisites": ["two_U_add", "V_eq", "U_add_two", "mul_left_cancel₀"]
+    "relatedConcepts": [
+      "bilinear addition law",
+      "Lucas sequence",
+      "linear_combination",
+      "divisibility sequence"
+    ],
+    "prerequisites": [
+      "two_U_add",
+      "V_eq",
+      "U_add_two",
+      "mul_left_cancel₀"
+    ]
   },
   {
     "id": "ann-divisibility-sequence",
     "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
-    "range": { "startLine": 92, "endLine": 101 },
+    "range": {
+      "startLine": 86,
+      "endLine": 101
+    },
     "type": "theorem",
     "title": "The Divisibility-Sequence Property Uₘ ∣ Uₘₖ",
     "content": "`dvd_U_mul` proves Uₘ ∣ U_{m·k} by induction on k. Base k=0: U_{m·0}=U₀=0, divisible by anything. Step: write m = m'+1 and m·(k+1) = m·k + m' + 1 (by ring), then rewrite with U_add_clean to get U_{m(k+1)} = U_{m·k+1}·Uₘ − Q·U_{m·k}·U_{m'}. The first summand is a multiple of Uₘ (`dvd_mul_left`); the second is a multiple of U_{m·k}, hence of Uₘ by the inductive hypothesis ((ih.mul_left Q).mul_right _); `dvd_sub` combines the two.",
     "mathContext": "$m \\mid n \\Rightarrow U_m \\mid U_n$: the fundamental Lucas sequence is a divisibility sequence. E.g. $F_3 = 2$ divides every third Fibonacci number.",
     "significance": "critical",
-    "relatedConcepts": ["divisibility sequence", "induction", "dvd_sub", "Lucas sequence"],
-    "prerequisites": ["U_add_clean", "dvd_mul_left", "Dvd.Dvd.mul_left"]
+    "relatedConcepts": [
+      "divisibility sequence",
+      "induction",
+      "dvd_sub",
+      "Lucas sequence"
+    ],
+    "prerequisites": [
+      "U_add_clean",
+      "dvd_mul_left",
+      "Dvd.Dvd.mul_left"
+    ]
   },
   {
     "id": "ann-instances",
     "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
-    "range": { "startLine": 104, "endLine": 121 },
+    "range": {
+      "startLine": 103,
+      "endLine": 114
+    },
     "type": "concept",
-    "title": "Divisibility Form and Fibonacci/Pell Instances",
-    "content": "`U_dvd_of_dvd` restates the property in the natural form m ∣ n ⟹ Uₘ ∣ Uₙ: destructure n = m·k and apply dvd_U_mul. `fib_dvd_of_dvd` specializes (P,Q)=(1,−1) to recover the classical Fₘ ∣ Fₙ; `pell_dvd_of_dvd` specializes (2,−1) for Pₘ ∣ Pₙ. `fib_three_dvd_six` with `fib_three_six_values` gives the concrete non-vacuous instance F₃=2 ∣ 8=F₆ by kernel `decide`.",
-    "mathContext": "Classical $F_m \\mid F_n$ and Pell $P_m \\mid P_n$ whenever $m \\mid n$.",
+    "title": "The Divisibility Sequence and its Fibonacci/Pell Instances",
+    "content": "`U_dvd_of_dvd` upgrades the multiplicative statement Uₘ ∣ U_{m·k} to the index-divisibility form m ∣ n ⟹ Uₘ ∣ Uₙ: writing n = m·k via the hypothesis and applying `dvd_U_mul`. Specializing (P,Q) gives the classical corollaries `fib_dvd_of_dvd` (Fibonacci, (1,−1): m ∣ n ⟹ Fₘ ∣ Fₙ) and `pell_dvd_of_dvd` (Pell, (2,−1): m ∣ n ⟹ Pₘ ∣ Pₙ) — both immediate instances of the same general theorem, showing the divisibility-sequence property is a parameter-free structural fact.",
+    "mathContext": "$m \\mid n \\Rightarrow U_m \\mid U_n$; Fibonacci $F_m \\mid F_n$ and Pell $P_m \\mid P_n$ when $m \\mid n$.",
     "significance": "supporting",
-    "relatedConcepts": ["Fibonacci divisibility", "Pell sequence", "specialization"],
-    "prerequisites": ["dvd_U_mul", "Dvd elimination"]
+    "relatedConcepts": [
+      "Fibonacci divisibility",
+      "Pell sequence",
+      "specialization"
+    ],
+    "prerequisites": [
+      "dvd_U_mul",
+      "Dvd elimination"
+    ]
+  },
+  {
+    "id": "ann-concrete-values",
+    "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 116,
+      "endLine": 121
+    },
+    "type": "insight",
+    "title": "Non-Vacuous Concrete Instance: F₃ = 2 ∣ 8 = F₆",
+    "content": "`fib_three_dvd_six` instantiates the general theorem at 3 ∣ 6, and `fib_three_six_values` pins the actual values F₃ = 2 and F₆ = 8 by kernel `decide` (not `native_decide`, so the proof stays fully within the trusted kernel). Together they witness that the divisibility 2 ∣ 8 is genuine and non-vacuous, guarding against a vacuously-true reading of the abstract statement.",
+    "mathContext": "$F_3 = 2,\\; F_6 = 8,\\; 2 \\mid 8$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fibonacci numbers",
+      "decidability",
+      "kernel computation"
+    ],
+    "prerequisites": [
+      "fib_dvd_of_dvd",
+      "decide"
+    ]
   },
   {
     "id": "ann-sharpness",
     "proofId": "lucas-sequence-degree2-identities-oq-02-oq-01-oq-01",
-    "range": { "startLine": 123, "endLine": 128 },
+    "range": {
+      "startLine": 123,
+      "endLine": 128
+    },
     "type": "insight",
     "title": "Sharpness: the Companion Sequence is Not a Divisibility Sequence",
     "content": "`V_not_dvd_seq` is a kernel `decide` check that V₂=3 does not divide V₄=7 for the Fibonacci/Lucas pair (1,−1), even though 2 ∣ 4. This shows the divisibility-sequence property is genuinely special to the fundamental sequence U and is not a consequence of the shared recurrence alone: the companion sequence V, which differs only in its initial data (V₀=2, V₁=P), fails it. (V satisfies only the weaker odd-index divisibility Vₘ ∣ Vₙ when n/m is odd.)",
     "mathContext": "$V_2 = 3 \\nmid 7 = V_4$: the companion Lucas sequence is not a divisibility sequence, isolating the role of the $U_0=0, U_1=1$ initial data.",
     "significance": "key",
-    "relatedConcepts": ["sharpness", "companion Lucas sequence", "divisibility sequence", "initial conditions"],
-    "prerequisites": ["decidability of integer divisibility"]
+    "relatedConcepts": [
+      "sharpness",
+      "companion Lucas sequence",
+      "divisibility sequence",
+      "initial conditions"
+    ],
+    "prerequisites": [
+      "decidability of integer divisibility"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass

Annotation-coverage enrichment for `lucas-sequence-degree2-identities-oq-02-oq-01-oq-01` (*The Fundamental Lucas Sequence is a Divisibility Sequence: Uₘ ∣ Uₘₙ*).

**Coverage: 35% → 88%** of the 130-line Lean file.

Changes (annotations.json only — no meta or Lean edits):
- **New module-overview annotation** (lines 5–60): the entire 56-line module docstring — the open question, proof architecture, and results — was previously unannotated. This is the whole coverage gap.
- **Extended** the two theorem annotations (`U_add_clean`, `dvd_U_mul`) to absorb their preceding docstrings (67–84, 86–101).
- **Split** the lumped 104–121 corollary block into a distinct *Fibonacci/Pell instances* annotation (103–114) and a *concrete non-vacuous values* insight (116–121, F₃=2 ∣ 8=F₆ via kernel `decide`).
- 4 → 6 annotations; every annotation carries mathContext + significance + relatedConcepts + prerequisites; ranges sorted and non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)