### PR TITLE
Enrich Furstenberg Correspondence OQ-02-OQ-02: 46%→80% annotation coverage

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02-oq-02/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "furstenberg-correspondence-oq-02-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "Overview: Resolving the Ergodic-Decomposition Feasibility Question",
+    "content": "The parent entry furstenberg-correspondence-oq-02 is a feasibility survey of formalizing the ergodic decomposition theorem, and leaves open whether Mathlib's disintegration is already sufficient — in particular whether the key structural fact, that ergodic measures are exactly the extreme points of the invariant probability measures (the Choquet-simplex picture), is available. This file resolves that uncertainty in the affirmative: the characterization is in Mathlib (Ergodic.iff_mem_extremePoints), as are ergodic rigidity (Ergodic.eq_of_absolutelyContinuous) and a.e.-constancy of invariant functions (PreErgodic.ae_eq_const_of_ae_eq_comp). These are packaged as the concrete 0-axiom building blocks of ergodic decomposition. The honest residual recorded here: what remains for the FULL decomposition is the Choquet integral representation of a general invariant measure over its ergodic (extreme) components — not yet in Mathlib.",
+    "mathContext": "Ergodic $\\mu \\iff \\mu \\in \\mathrm{extremePoints}\\,\\{\\nu : \\text{invariant prob. measure}\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ergodic decomposition",
+      "extreme points",
+      "Choquet theory",
+      "invariant measures",
+      "Furstenberg correspondence"
+    ],
+    "prerequisites": [
+      "ergodic theory",
+      "invariant measure",
+      "convex geometry"
+    ]
+  },
+  {
     "id": "ann-extreme",
     "proofId": "furstenberg-correspondence-oq-02-oq-02",
     "range": {
@@ -11,8 +36,18 @@
     "content": "The parent feasibility survey was unsure whether the key structural fact — ergodic measures are exactly the extreme points of the invariant probability measures — was available in Mathlib, noting it 'might already be partially there'. ergodic_iff_extremePoint settles it: the full equivalence is Mathlib's Ergodic.iff_mem_extremePoints. This is the Choquet-simplex picture underlying ergodic decomposition: the invariant probability measures form a convex set whose extreme points are precisely the ergodic measures, and the decomposition expresses a general invariant measure as a barycentre over them.",
     "mathContext": "$\\mathrm{Ergodic}\\,f\\,\\mu \\iff \\mu \\in \\mathrm{extremePoints}\\,\\{\\nu : \\nu\\text{ is }f\\text{-invariant prob.}\\}$",
     "significance": "key",
-    "relatedConcepts": ["ergodic measure", "extreme point", "Choquet simplex", "convexity of invariant measures", "ergodic decomposition"],
-    "prerequisites": ["invariant probability measures", "extreme points of a convex set", "Ergodic.iff_mem_extremePoints"]
+    "relatedConcepts": [
+      "ergodic measure",
+      "extreme point",
+      "Choquet simplex",
+      "convexity of invariant measures",
+      "ergodic decomposition"
+    ],
+    "prerequisites": [
+      "invariant probability measures",
+      "extreme points of a convex set",
+      "Ergodic.iff_mem_extremePoints"
+    ]
   },
   {
     "id": "ann-rigidity",
@@ -26,8 +61,17 @@
     "content": "ergodic_eq_of_absolutelyContinuous (Mathlib's Ergodic.eq_of_absolutelyContinuous) shows an invariant probability measure ν absolutely continuous with respect to an ergodic measure μ must equal it. Contrapositively, two distinct ergodic measures can never be absolutely continuous with respect to one another, so they are mutually singular — the ergodic components of the decomposition occupy disjoint regions of the space and the decomposition is a genuine partition rather than an overlapping cover.",
     "mathContext": "$\\nu \\ll \\mu,\\ \\mu\\text{ ergodic} \\Rightarrow \\nu = \\mu$ — hence distinct ergodic measures are mutually singular ($\\mu_1 \\perp \\mu_2$).",
     "significance": "supporting",
-    "relatedConcepts": ["mutual singularity", "absolute continuity", "ergodic rigidity", "partition of the space"],
-    "prerequisites": ["absolute continuity ν ≪ μ", "measure-preserving maps", "Ergodic.eq_of_absolutelyContinuous"]
+    "relatedConcepts": [
+      "mutual singularity",
+      "absolute continuity",
+      "ergodic rigidity",
+      "partition of the space"
+    ],
+    "prerequisites": [
+      "absolute continuity ν ≪ μ",
+      "measure-preserving maps",
+      "Ergodic.eq_of_absolutelyContinuous"
+    ]
   },
   {
     "id": "ann-ae-const",
@@ -41,8 +85,17 @@
     "content": "ergodic_invariant_ae_const (from PreErgodic.ae_eq_const_of_ae_eq_comp) shows that under an ergodic measure every measurable function g with g ∘ f = g is almost everywhere constant. This is the well-definedness input for the decomposition map sending each point to its ergodic component: the invariant σ-algebra is a.e. trivial on each component, so 'which component a point belongs to' is determined up to a null set. It is the functional restatement of ergodicity (no nonconstant invariants) and the bridge from the measure-level extreme-point picture to the pointwise decomposition kernel.",
     "mathContext": "$g \\circ f = g \\Rightarrow g =_{\\mu\\text{-a.e.}} \\mathrm{const}$ — the invariant $\\sigma$-algebra is $\\mu$-a.e. trivial.",
     "significance": "supporting",
-    "relatedConcepts": ["invariant σ-algebra", "almost-everywhere constant functions", "ergodicity as triviality of invariants", "decomposition kernel"],
-    "prerequisites": ["invariant functions g∘f = g", "almost-everywhere equality", "PreErgodic.ae_eq_const_of_ae_eq_comp"]
+    "relatedConcepts": [
+      "invariant σ-algebra",
+      "almost-everywhere constant functions",
+      "ergodicity as triviality of invariants",
+      "decomposition kernel"
+    ],
+    "prerequisites": [
+      "invariant functions g∘f = g",
+      "almost-everywhere equality",
+      "PreErgodic.ae_eq_const_of_ae_eq_comp"
+    ]
   },
   {
     "id": "ann-answer",
@@ -56,7 +109,17 @@
     "content": "ergodic_decomposition_prerequisites bundles the three Mathlib-provided ingredients. Together with Mathlib's measure disintegration, they answer the parent's OQ: the structure for ergodic decomposition IS available — the extreme-point characterization (which the survey doubted) is in Mathlib, and disintegration supplies the kernel. The honest remaining gap for the full theorem is the Choquet integral representation, writing a general invariant measure as ∫ over its ergodic components and establishing uniqueness (the invariant simplex). Confirming an existing Mathlib result converts the survey's 'might be there' into a verified, citable fact.",
     "mathContext": "$\\mu = \\int \\mu_x \\, d\\mu(x)\\ \\text{(ergodic decomposition: target integral representation, not yet formalized)}$",
     "significance": "key",
-    "relatedConcepts": ["ergodic decomposition theorem", "measure disintegration", "barycentre / Choquet integral representation", "uniqueness of the simplex", "Furstenberg correspondence"],
-    "prerequisites": ["the three packaged prerequisites", "Mathlib measure disintegration", "Choquet theory of simplices"]
+    "relatedConcepts": [
+      "ergodic decomposition theorem",
+      "measure disintegration",
+      "barycentre / Choquet integral representation",
+      "uniqueness of the simplex",
+      "Furstenberg correspondence"
+    ],
+    "prerequisites": [
+      "the three packaged prerequisites",
+      "Mathlib measure disintegration",
+      "Choquet theory of simplices"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass

Annotation-coverage enrichment for `furstenberg-correspondence-oq-02-oq-02` (*the extreme-point structure for ergodic decomposition*).

**Coverage: 46% → 80%** of the 81-line Lean file.

Change (annotations.json only — no meta or Lean edits):
- **New module-overview annotation** (lines 5–32): the module docstring — stating the parent survey's open feasibility question and how this entry resolves it via Mathlib's extreme-point ergodic theory (`Ergodic.iff_mem_extremePoints`, rigidity, a.e.-constancy) — was previously unannotated. Records the honest residual: the Choquet integral representation for the full decomposition.
- 4 → 5 annotations; mathContext + significance + relatedConcepts + prerequisites present; ranges sorted, non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)