### PR TITLE
research(combinations-formula-oq-04-oq-03): ultra-log-concavity of a Pascal row — exact adjacent-triple identity [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ04OQ03.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ04OQ03.lean
@@ -1,0 +1,173 @@
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Positivity
+
+/-
+# Combinations Formula — OQ-04 → OQ-03: Ultra-Log-Concavity of a Pascal Row (exact form)
+
+## Research Problem: combinations-formula-oq-04-oq-03
+
+The parent (`combinations-formula-oq-04`, "Log-Concavity of a Pascal Row") proves the
+*inequality*
+
+      C(n,k) · C(n,k+2)  ≤  C(n,k+1)²,
+
+by clearing denominators with Mathlib's adjacent-ratio relation `Nat.choose_succ_right_eq` and
+then **discarding** the exact multiplicative factor.  Its first listed open question asks to
+strengthen this to *ultra-log-concavity* (ULC).
+
+This file supplies that strengthening by keeping the factor that the parent threw away.  The
+adjacent-ratio relations multiply to an **exact identity**:
+
+      C(n,k) · C(n,k+2) · (n−k)(k+2)  =  C(n,k+1)² · (k+1)(n−k−1).            (★)
+
+Equivalently, writing the middle index as `j = k+1`,
+
+      C(n,j−1) · C(n,j+1) · (j+1)(n−j+1)  =  C(n,j)² · j(n−j),
+
+which is Liggett's ultra-log-concavity bound
+
+      C(n,j)²  =  (1 + 1/j)(1 + 1/(n−j)) · C(n,j−1) · C(n,j+1)
+
+met with **equality**.  So the binomial row is the *extremal* ultra-log-concave sequence: no
+sequence indexed against `C(n,·)` can do better.  The parent's log-concavity `a·c ≤ b²` drops
+straight out of (★) because `(k+1)(n−k−1) ≤ (n−k)(k+2)` (their difference is `n+1 > 0`), so
+the exact identity is strictly more information.
+
+## Mechanism
+
+For `k + 2 ≤ n` write `n = k + 2 + t`.  `Nat.choose_succ_right_eq` gives the two ratios
+
+      a·(t+2) = b·(k+1),        c·(k+2) = b·(t+1),
+
+with `a = C(n,k)`, `b = C(n,k+1)`, `c = C(n,k+2)`.  Multiplying eliminates `b`'s neighbours and
+`ring` closes (★).  Outside the row (`n < k+2`) both sides vanish: `C(n,k+2) = 0` kills the left
+side, and `n − k − 1 = 0` (truncated subtraction, since `n − k ≤ 1`) kills the right — so (★)
+in fact holds for **all** `n, k`, with no side conditions.
+
+## What is proved
+
+* `choose_mul_choose_mul_eq`      — the exact identity (★), for all `n, k`.
+* `choose_ulc_equality`           — centered form: `C(n,j−1)·C(n,j+1)·(j+1)(n−j+1) = C(n,j)²·j(n−j)`.
+* `choose_mul_choose_le_sq`       — log-concavity re-derived as a corollary of (★).
+* `choose_mul_choose_lt_sq`       — strict interior form, from the *strict* factor inequality.
+
+Tags: combinatorics, binomial-coefficients, pascals-triangle, log-concavity, ultra-log-concavity,
+newton-inequality
+-/
+
+namespace CombinationsFormulaOQ04OQ03
+
+open Nat
+
+/-- **Exact adjacent-triple identity (★).**  For every `n, k`,
+
+      C(n,k) · C(n,k+2) · ((n−k)(k+2))  =  C(n,k+1)² · ((k+1)(n−k−1)).
+
+This is the equality behind the parent's log-concavity inequality: the parent keeps only that the
+left factor `(k+1)(n−k−1)` is `≤` the right factor `(n−k)(k+2)` and discards the rest.  Here we
+retain the whole identity.  It holds unconditionally — outside the row both sides are `0`. -/
+theorem choose_mul_choose_mul_eq (n k : ℕ) :
+    n.choose k * n.choose (k + 2) * ((n - k) * (k + 2))
+      = (n.choose (k + 1)) ^ 2 * ((k + 1) * (n - k - 1)) := by
+  rcases lt_or_ge n (k + 2) with h | h
+  · -- Outside the row: `C(n,k+2) = 0` and `n − k − 1 = 0` (since `n − k ≤ 1`).
+    have hz : n - k - 1 = 0 := by omega
+    rw [Nat.choose_eq_zero_of_lt h, hz]; ring
+  · -- Interior: parametrise `n = k + 2 + t`; the subtractions become `t + 2`, `t + 1`.
+    obtain ⟨t, rfl⟩ : ∃ t, n = k + 2 + t := ⟨n - (k + 2), by omega⟩
+    have R1 : (k + 2 + t).choose (k + 1) * (k + 1) = (k + 2 + t).choose k * (t + 2) := by
+      have := Nat.choose_succ_right_eq (k + 2 + t) k
+      simpa [show (k + 2 + t) - k = t + 2 by omega] using this
+    have R2 : (k + 2 + t).choose (k + 2) * (k + 2) = (k + 2 + t).choose (k + 1) * (t + 1) := by
+      have := Nat.choose_succ_right_eq (k + 2 + t) (k + 1)
+      simpa [show (k + 2 + t) - (k + 1) = t + 1 by omega] using this
+    set a := (k + 2 + t).choose k
+    set b := (k + 2 + t).choose (k + 1)
+    set c := (k + 2 + t).choose (k + 2)
+    have e1 : a * (t + 2) = b * (k + 1) := R1.symm
+    have e2 : c * (k + 2) = b * (t + 1) := R2
+    -- `(n − k) = t + 2`, `(n − k − 1) = t + 1`.  Rewrite the `−1` form first so the shorter
+    -- pattern `(k+2+t) − k` does not consume it.
+    rw [show (k + 2 + t) - k - 1 = t + 1 by omega, show (k + 2 + t) - k = t + 2 by omega]
+    calc a * c * ((t + 2) * (k + 2))
+        = (a * (t + 2)) * (c * (k + 2)) := by ring
+      _ = (b * (k + 1)) * (b * (t + 1)) := by rw [e1, e2]
+      _ = b ^ 2 * ((k + 1) * (t + 1)) := by ring
+
+/-- **Ultra-log-concavity, exact centered form.**  With middle index `j = k+1`,
+
+      C(n,j−1) · C(n,j+1) · ((j+1)(n−j+1))  =  C(n,j)² · (j(n−j)).
+
+This is Liggett's ULC bound `C(n,j)² = (1 + 1/j)(1 + 1/(n−j))·C(n,j−1)·C(n,j+1)` met with
+equality: the Pascal row is the extremal ultra-log-concave sequence.  Stated in the row's range
+`1 ≤ j ≤ n`, where the centered factor `n − j + 1` carries its intended value. -/
+theorem choose_ulc_equality (n j : ℕ) (hj : 1 ≤ j) (hjn : j ≤ n) :
+    n.choose (j - 1) * n.choose (j + 1) * ((j + 1) * (n - j + 1))
+      = (n.choose j) ^ 2 * (j * (n - j)) := by
+  obtain ⟨k, rfl⟩ : ∃ k, j = k + 1 := ⟨j - 1, by omega⟩
+  have key := choose_mul_choose_mul_eq n k
+  -- Rewrite the `+1` (longer) subtraction pattern before the bare one so it is not consumed.
+  rw [show (k + 1) - 1 = k by omega, show (k + 1) + 1 = k + 2 by omega,
+      show n - (k + 1) + 1 = n - k by omega, show n - (k + 1) = n - k - 1 by omega]
+  calc n.choose k * n.choose (k + 2) * ((k + 2) * (n - k))
+      = n.choose k * n.choose (k + 2) * ((n - k) * (k + 2)) := by ring
+    _ = (n.choose (k + 1)) ^ 2 * ((k + 1) * (n - k - 1)) := key
+
+/-- **Log-concavity as a corollary of (★).**  `C(n,k) · C(n,k+2) ≤ C(n,k+1)²`.  Multiply the
+target by the positive factor `(n−k)(k+2)`, apply the exact identity (★), and bound
+`(k+1)(n−k−1) ≤ (n−k)(k+2)`.  This re-derives the parent inequality from strictly sharper data. -/
+theorem choose_mul_choose_le_sq (n k : ℕ) :
+    n.choose k * n.choose (k + 2) ≤ (n.choose (k + 1)) ^ 2 := by
+  rcases lt_or_ge n (k + 2) with h | h
+  · rw [Nat.choose_eq_zero_of_lt h]; simp
+  · -- `(n − k)(k + 2) > 0`; cancel it after using (★).
+    obtain ⟨d, hd⟩ : ∃ d, n - k = d + 2 := ⟨n - k - 2, by omega⟩
+    have hpos : 0 < (n - k) * (k + 2) := by rw [hd]; positivity
+    have hle : (k + 1) * (n - k - 1) ≤ (n - k) * (k + 2) := by
+      rw [hd, show d + 2 - 1 = d + 1 by omega]; nlinarith
+    have key := choose_mul_choose_mul_eq n k
+    have hstep : n.choose k * n.choose (k + 2) * ((n - k) * (k + 2))
+        ≤ (n.choose (k + 1)) ^ 2 * ((n - k) * (k + 2)) := by
+      rw [key]; exact Nat.mul_le_mul (le_refl _) hle
+    exact Nat.le_of_mul_le_mul_right hstep hpos
+
+/-- **Strict log-concavity in the interior** (`k + 2 ≤ n`).  Same as above but the factor
+inequality is strict and `C(n,k+1) > 0`. -/
+theorem choose_mul_choose_lt_sq (n k : ℕ) (h : k + 2 ≤ n) :
+    n.choose k * n.choose (k + 2) < (n.choose (k + 1)) ^ 2 := by
+  obtain ⟨d, hd⟩ : ∃ d, n - k = d + 2 := ⟨n - k - 2, by omega⟩
+  have hpos : 0 < (n - k) * (k + 2) := by rw [hd]; positivity
+  have hlt : (k + 1) * (n - k - 1) < (n - k) * (k + 2) := by
+    rw [hd, show d + 2 - 1 = d + 1 by omega]; nlinarith
+  have key := choose_mul_choose_mul_eq n k
+  have hpow : 0 < (n.choose (k + 1)) ^ 2 := pow_pos (Nat.choose_pos (by omega)) 2
+  have hstep : n.choose k * n.choose (k + 2) * ((n - k) * (k + 2))
+      < (n.choose (k + 1)) ^ 2 * ((n - k) * (k + 2)) := by
+    rw [key]; exact mul_lt_mul_of_pos_left hlt hpow
+  exact Nat.lt_of_mul_lt_mul_right hstep
+
+#check @choose_mul_choose_mul_eq
+#check @choose_ulc_equality
+#check @choose_mul_choose_le_sq
+#check @choose_mul_choose_lt_sq
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms; imports only Mathlib):
+
+* `choose_mul_choose_mul_eq` — the **exact** adjacent-triple identity (★)
+  `C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1)`, for all `n, k`.
+* `choose_ulc_equality` — its centered form = Liggett's ultra-log-concavity bound met with
+  equality, exhibiting the Pascal row as the extremal ULC sequence.
+* `choose_mul_choose_le_sq` / `choose_mul_choose_lt_sq` — the parent's log-concavity (weak and
+  strict) recovered as immediate corollaries of the exact identity.
+
+Where the parent (`combinations-formula-oq-04`) proves the log-concavity *inequality* by
+discarding the exact multiplicative factor, this entry keeps that factor: the resulting equality
+is strictly more information and settles the parent's ultra-log-concavity open question.
+-/
+
+end CombinationsFormulaOQ04OQ03

--- a/src/data/proofs/combinations-formula-oq-04-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-03/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "combinations-formula-oq-04-oq-03",
+  "title": "Ultra-Log-Concavity of a Pascal Row: the Exact Adjacent-Triple Identity",
+  "slug": "combinations-formula-oq-04-oq-03",
+  "description": "The parent (combinations-formula-oq-04) proves the log-concavity inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² by clearing denominators and then discarding the exact multiplicative factor. This entry keeps that factor: the two adjacent-ratio relations multiply to the exact identity C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1). Centered at the middle index this is Liggett's ultra-log-concavity bound met with equality — exhibiting the binomial row as the extremal ultra-log-concave sequence — and settles the parent's first open question. Log-concavity (weak and strict) then drops out as an immediate corollary. Formalized in Lean 4 over Mathlib's Nat.choose.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ04OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "pascals-triangle",
+      "log-concavity",
+      "ultra-log-concavity",
+      "newton-inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 173,
+    "assumptions": "None. Fully machine-verified: the file builds to exit 0 against the pinned Mathlib (v4.26.0) and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx). The file imports only Mathlib and is self-contained, building on Mathlib's Nat.choose_succ_right_eq adjacent-ratio relation. The centered form choose_ulc_equality carries the row-range hypotheses 1 ≤ j ≤ n, under which the centered factor n−j+1 has its intended value; the core identity choose_mul_choose_mul_eq is unconditional.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "C(n,k+1)·(k+1) = C(n,k)·(n−k), the adjacent-coefficient ratio relation. Applied at k and k+1 (after substituting n = k+2+t to clear truncated subtraction) it gives a·(t+2)=b·(k+1) and c·(k+2)=b·(t+1), which multiply to the exact adjacent-triple identity.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(n,k) = 0 for n < k — discharges the out-of-row case of the exact identity, where C(n,k+2) = 0 and the truncated factor n−k−1 = 0 make both sides vanish.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.le_of_mul_le_mul_right",
+        "description": "cancels the common positive factor (n−k)(k+2) to derive the log-concavity corollary C(n,k)·C(n,k+2) ≤ C(n,k+1)² from the exact identity.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.choose_pos",
+        "description": "C(n,k) > 0 for k ≤ n — supplies the positive multiplier making the strict-interior corollary strict.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "choose_mul_choose_mul_eq: the exact adjacent-triple identity C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1), holding unconditionally for all n, k. This is the equality behind the parent's log-concavity inequality — the parent keeps only that the left factor (k+1)(n−k−1) is ≤ the right factor (n−k)(k+2) and discards the rest.",
+      "choose_ulc_equality: the centered form C(n,j−1)·C(n,j+1)·(j+1)(n−j+1) = C(n,j)²·j(n−j) for 1 ≤ j ≤ n — precisely Liggett's ultra-log-concavity bound C(n,j)² = (1+1/j)(1+1/(n−j))·C(n,j−1)·C(n,j+1) met with equality, exhibiting the binomial row as the extremal ultra-log-concave sequence. This settles the parent's first listed open question.",
+      "choose_mul_choose_le_sq and choose_mul_choose_lt_sq: the parent's log-concavity (weak and strict interior) re-derived as immediate corollaries of the exact identity, from the single fact (k+1)(n−k−1) ≤ (n−k)(k+2) (difference n+1 > 0) — demonstrating that the exact identity is strictly more information.",
+      "Proof technique: retain rather than discard the multiplicative factor produced by multiplying the two Nat.choose_succ_right_eq ratio relations; substitute n = k+2+t to make the truncated subtractions honest; observe that the truncated factor n−k−1 already vanishes off-row (since n−k ≤ 1 there), so the exact identity needs no side condition."
+    ],
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Ultra-log-concavity (ULC), introduced by Liggett (1997) sharpening earlier work of Walkup and others, strengthens log-concavity: a sequence (a_k) is ULC of order n when a_k² ≥ (1+1/k)(1+1/(n−k))·a_{k−1}·a_{k+1}. The binomial coefficients C(n,k) are the canonical extremal case — they meet this bound with equality. The parent entry (combinations-formula-oq-04) proves only the weaker log-concavity a_{k−1}a_{k+1} ≤ a_k² and lists strengthening to ULC as its first open question. The exact factor needed is already present inside the parent's proof but is thrown away when it passes to the inequality.",
+    "problemStatement": "Keep the exact multiplicative factor the parent discards: prove the identity C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1), and read it centered as Liggett's ultra-log-concavity bound met with equality.",
+    "text": "Writing a = C(n,k), b = C(n,k+1), c = C(n,k+2) and substituting n = k+2+t to remove truncated subtraction, Mathlib's adjacent-ratio relation choose_succ_right_eq gives a·(t+2) = b·(k+1) and c·(k+2) = b·(t+1). Multiplying the two equalities gives a·c·(t+2)(k+2) = b²·(k+1)(t+1) — an exact identity, not an inequality. Translating back (t+2 = n−k, t+1 = n−k−1) yields C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1) for k+2 ≤ n; off-row both sides vanish (C(n,k+2)=0 and n−k−1=0), so the identity is unconditional. Centered at the middle index j = k+1 it reads C(n,j−1)·C(n,j+1)·(j+1)(n−j+1) = C(n,j)²·j(n−j), i.e. C(n,j)² = (1+1/j)(1+1/(n−j))·C(n,j−1)·C(n,j+1): the ULC bound with equality. The parent's log-concavity is the immediate corollary obtained by keeping only (k+1)(n−k−1) ≤ (n−k)(k+2) and cancelling the positive common factor.",
+    "proofStrategy": "The whole argument stays in ℕ, never dividing. For the exact identity, case-split on k+2 ≤ n. Off-row, C(n,k+2)=0 kills the left side while n−k−1 = 0 (truncated, since n−k ≤ 1) kills the right; ring closes both to 0. In range, substitute n = k+2+t so every difference is honest, apply Nat.choose_succ_right_eq at k and at k+1, and multiply the two ratio relations; ring finishes. The centered form is a reindex k = j−1 under 1 ≤ j ≤ n (needed only so the truncated factor n−j+1 equals n−k). The log-concavity corollaries multiply the target by the positive factor (n−k)(k+2), invoke the exact identity, bound (k+1)(n−k−1) ≤ (n−k)(k+2) (with the difference n+1 giving strictness in the interior), and cancel the common factor with Nat.le_of_mul_le_mul_right / Nat.lt_of_mul_lt_mul_right.",
+    "keyInsights": [
+      "**Keep the factor the parent throws away.** The parent multiplies the two ratio relations to a·c·(t+2)(k+2) = b²·(k+1)(t+1) and then immediately weakens `=` to `≤`. Retaining the equality is the whole content of this entry: it is strictly more information, and it is exactly the ultra-log-concavity data.",
+      "**Equality, not inequality, is what ULC asks for.** Log-concavity says the defect a_k² − a_{k−1}a_{k+1} is ≥ 0; the exact identity computes that defect precisely, and centered it says the binomial row attains Liggett's ULC bound C(n,j)² = (1+1/j)(1+1/(n−j))·C(n,j−1)·C(n,j+1) with equality — the row is the extremal ULC sequence.",
+      "**The identity is unconditional because truncation helps here.** Off the row (n < k+2) the truncated factor n−k−1 is automatically 0 (n−k is 0 or 1), so the right side vanishes exactly when C(n,k+2) makes the left side vanish. No side hypothesis is needed for the core identity — only the centered reindex needs 1 ≤ j ≤ n.",
+      "**Log-concavity is a one-line corollary.** Once the exact factor is on record, the parent's weak and strict inequalities follow by the single arithmetic fact (k+1)(n−k−1) ≤ (n−k)(k+2), whose difference is n+1 > 0. The sharper statement subsumes the parent."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Mathlib's Nat.choose",
+      "The adjacent-coefficient ratio relation Nat.choose_succ_right_eq",
+      "Natural-number arithmetic and the pitfalls of truncated subtraction",
+      "Log-concavity, ultra-log-concavity (Liggett), and Newton's inequalities (conceptual background)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "exact-identity",
+      "title": "The Exact Adjacent-Triple Identity",
+      "summary": "choose_mul_choose_mul_eq: C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1) for all n, k. Off-row, C(n,k+2)=0 and n−k−1=0 make both sides 0; in range, substitute n = k+2+t, apply choose_succ_right_eq at k and k+1, and multiply the two ratio relations to an exact equality.",
+      "startLine": 62,
+      "endLine": 95
+    },
+    {
+      "id": "ulc-equality",
+      "title": "Ultra-Log-Concavity Met with Equality",
+      "summary": "choose_ulc_equality: the centered form C(n,j−1)·C(n,j+1)·(j+1)(n−j+1) = C(n,j)²·j(n−j) for 1 ≤ j ≤ n — Liggett's ULC bound with equality, exhibiting the Pascal row as the extremal ultra-log-concave sequence and settling the parent's first open question.",
+      "startLine": 97,
+      "endLine": 114
+    },
+    {
+      "id": "log-concave-corollary",
+      "title": "Log-Concavity as a Corollary",
+      "summary": "choose_mul_choose_le_sq: C(n,k)·C(n,k+2) ≤ C(n,k+1)². Multiply by the positive factor (n−k)(k+2), apply the exact identity, and use (k+1)(n−k−1) ≤ (n−k)(k+2); cancel with Nat.le_of_mul_le_mul_right. Recovers the parent inequality from strictly sharper data.",
+      "startLine": 116,
+      "endLine": 132
+    },
+    {
+      "id": "strict",
+      "title": "Strict Interior Form",
+      "summary": "choose_mul_choose_lt_sq: the strict inequality C(n,k)·C(n,k+2) < C(n,k+1)² for k+2 ≤ n, where the factor gap is strict and C(n,k+1) > 0.",
+      "startLine": 134,
+      "endLine": 147
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; imports only Mathlib): the exact adjacent-triple identity C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1), its centered reading as Liggett's ultra-log-concavity bound met with equality, and the parent's log-concavity (weak and strict) as immediate corollaries.",
+    "implications": "Settles the parent's first open question (strengthen log-concavity to ultra-log-concavity) by keeping the exact multiplicative factor the parent discards. The identity computes the log-concavity defect exactly and shows the binomial row is the extremal ULC sequence, the sharp endpoint of Liggett's inequality.",
+    "openQuestions": [
+      "Deduce the discrete Newton inequalities / real-rootedness consequences from the exact identity, e.g. the full chain of inequalities among the normalized quantities p_k = C(n,k)/C(n,k).",
+      "Formalize ultra-log-concavity for a general ULC sequence and prove it is preserved under convolution (Liggett's theorem), with the binomial row as the extremal case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-04",
+      "relationship": "parent-problem",
+      "description": "Parent: proves the log-concavity inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² by discarding the exact multiplicative factor. This entry keeps that factor, giving the exact identity and the ultra-log-concavity strengthening the parent lists as its first open question."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Root of the combinations-formula family: the basic count C(n,k) = n!/(k!(n−k)!). This entry supplies the row's sharp structural equality."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Thomas M. Liggett"
+      ],
+      "title": "Ultra logconcave sequences and negative dependence",
+      "year": "1997",
+      "venue": "Journal of Combinatorial Theory, Series A 79(2), 315-325",
+      "note": "Introduces ultra-log-concavity; the binomial coefficients are the extremal case, meeting the bound with equality"
+    },
+    {
+      "authors": [
+        "Richard P. Stanley"
+      ],
+      "title": "Log-concave and unimodal sequences in algebra, combinatorics, and geometry",
+      "year": "1989",
+      "venue": "Annals of the New York Academy of Sciences 576, 500-535",
+      "note": "Survey of log-concavity and unimodality, with the binomial row as the prototypical example"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CombinationsFormulaOQ04OQ03",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent `combinations-formula-oq-04` proves the log-concavity **inequality** `C(n,k)·C(n,k+2) ≤ C(n,k+1)²` by clearing denominators and then *discarding* the exact multiplicative factor. Its first open question asks to strengthen this to **ultra-log-concavity (ULC)**. This leaf supplies that by keeping the discarded factor: the adjacent-ratio relations multiply to an **exact identity**

```
C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1)      (★)
```

holding for **all** n, k. Its centered form (`j = k+1`) is Liggett's ULC bound `C(n,j)² = (1+1/j)(1+1/(n−j))·C(n,j−1)·C(n,j+1)` met with **equality** — the binomial row is the extremal ultra-log-concave sequence.

## Results (`Proofs/CombinationsFormulaOQ04OQ03.lean`)

- `choose_mul_choose_mul_eq` — the exact identity (★), unconditional.
- `choose_ulc_equality` — centered form (Liggett's ULC bound at equality).
- `choose_mul_choose_le_sq` / `choose_mul_choose_lt_sq` — parent's log-concavity (weak + strict) recovered as corollaries.

## Method

Two `Nat.choose_succ_right_eq` adjacent-ratio relations, parametrising `n = k+2+t`, multiply to eliminate the middle coefficient; `ring` closes (★). Outside the row both sides vanish via truncated subtraction (`C(n,k+2)=0`, `n−k−1=0`) — no side conditions.

## Verification

`lake env lean` exit 0; `#print axioms` → `{propext, Classical.choice, Quot.sound}` only (no `sorryAx`, no `Lean.ofReduceBool`). **0 sorries, 0 axioms.** 173 lines, 4 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)