### PR TITLE
Enrich Isosceles Triangle OQ-02: 53%→84% annotation coverage

### DIFF
--- a/src/data/proofs/isosceles-triangle-oq-02/annotations.json
+++ b/src/data/proofs/isosceles-triangle-oq-02/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "isosceles-triangle-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "Overview: Pons Asinorum in Hyperbolic and Spherical Geometry",
+    "content": "The parent entry isosceles-triangle proves the isosceles triangle theorem (Euclid I.5, Pons Asinorum: equal sides ⟹ equal base angles) in Euclidean geometry via Mathlib's inner-product-space machinery, and asks as an open question to prove it in hyperbolic and spherical geometry, where that structure is unavailable. This file does so with NO inner product space, working purely from the non-Euclidean laws of cosines — spherical cos a = cos b·cos c + sin b·sin c·cos A and hyperbolic cosh a = cosh b·cosh c − sinh b·sinh c·cos A. Solving each for cos A gives an expression symmetric in the two adjacent sides b, c; when the triangle is isosceles (a = b) the base-angle cosines coincide, and since cos is injective on [0, π] the base angles are equal. The same algebra with cos/sin ↦ cosh/sinh handles the hyperbolic case, and both extend to equilateral ⟹ equiangular.",
+    "mathContext": "$\\cos A = \\dfrac{\\cos a - \\cos b\\cos c}{\\sin b\\sin c}$ (spherical); injectivity of $\\cos$ on $[0,\\pi]$ closes the argument.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pons Asinorum",
+      "law of cosines",
+      "spherical geometry",
+      "hyperbolic geometry",
+      "non-Euclidean geometry"
+    ],
+    "prerequisites": [
+      "law of cosines",
+      "injectivity of cosine on [0,π]",
+      "hyperbolic trigonometric functions"
+    ]
+  },
+  {
     "id": "ann-lawofcosines-defs",
     "proofId": "isosceles-triangle-oq-02",
-    "range": { "startLine": 38, "endLine": 44 },
+    "range": {
+      "startLine": 38,
+      "endLine": 44
+    },
     "type": "definition",
     "title": "Solving the Non-Euclidean Laws of Cosines for cos A",
     "content": "sphCosA and hypCosA are the cosines of the angle opposite side a, obtained by solving each non-Euclidean law of cosines for cos A. The spherical law cos a = cos b·cos c + sin b·sin c·cos A rearranges to sphCosA = (cos a − cos b·cos c)/(sin b·sin c); the hyperbolic law cosh a = cosh b·cosh c − sinh b·sinh c·cos A rearranges to hypCosA = (cosh b·cosh c − cosh a)/(sinh b·sinh c). These two definitions are the entire bridge from side lengths to angles in constant-curvature geometry — no coordinates, metric model, or inner product appears.",
     "mathContext": "$\\cos A = \\dfrac{\\cos a - \\cos b\\cos c}{\\sin b\\sin c}\\ (\\text{sphere}),\\qquad \\cos A = \\dfrac{\\cosh b\\cosh c - \\cosh a}{\\sinh b\\sinh c}\\ (\\text{hyperbolic}).$",
     "significance": "key",
-    "relatedConcepts": ["spherical law of cosines", "hyperbolic law of cosines", "constant curvature", "trigonometric vs hyperbolic functions"],
-    "prerequisites": ["spherical trigonometry", "hyperbolic trigonometry"]
+    "relatedConcepts": [
+      "spherical law of cosines",
+      "hyperbolic law of cosines",
+      "constant curvature",
+      "trigonometric vs hyperbolic functions"
+    ],
+    "prerequisites": [
+      "spherical trigonometry",
+      "hyperbolic trigonometry"
+    ]
   },
   {
     "id": "ann-no-inner-product",
     "proofId": "isosceles-triangle-oq-02",
-    "range": { "startLine": 46, "endLine": 53 },
+    "range": {
+      "startLine": 46,
+      "endLine": 53
+    },
     "type": "insight",
     "title": "Symmetry of the Adjacent Sides Collapses the Base Cosines",
     "content": "The parent's Euclidean proof used Mathlib's inner-product-space triangle API, which is unavailable on the sphere and in the hyperbolic plane. Here the side–angle relationship is carried entirely by the laws of cosines, and the isosceles condition is purely structural: sph_isosceles_cos / hyp_isosceles_cos show that with a = b the two base-angle cosines sphCosA a b c and sphCosA b a c are definitionally equal — the proof is just subst + rfl, no analysis at all. The defining expression is symmetric in the two adjacent sides, so swapping the equal legs leaves cos A unchanged.",
     "mathContext": "$a = b \\;\\Rightarrow\\; \\mathrm{sphCosA}(a,b,c) = \\mathrm{sphCosA}(b,a,c)$ by symmetry of $(\\cos a - \\cos b\\cos c)$ under $a\\leftrightarrow b$.",
     "significance": "key",
-    "relatedConcepts": ["definitional equality", "symmetry argument", "isosceles condition", "law of cosines"],
-    "prerequisites": ["substitution in Lean", "function symmetry"]
+    "relatedConcepts": [
+      "definitional equality",
+      "symmetry argument",
+      "isosceles condition",
+      "law of cosines"
+    ],
+    "prerequisites": [
+      "substitution in Lean",
+      "function symmetry"
+    ]
   },
   {
     "id": "ann-pons",
     "proofId": "isosceles-triangle-oq-02",
-    "range": { "startLine": 55, "endLine": 68 },
+    "range": {
+      "startLine": 55,
+      "endLine": 68
+    },
     "type": "insight",
     "title": "Pons Asinorum from Equal Cosines and cos Injectivity",
     "content": "spherical_isosceles and hyperbolic_isosceles prove Euclid I.5 in each geometry: equal legs a = b imply equal base angles A = B. The proof is two steps — reduce A = B to cos A = cos B via Real.injOn_cos (cosine is injective on [0, π], exactly the range where triangle angles live), then close cos A = cos B with the equal-cosines lemma. The spherical and hyperbolic cases are byte-for-byte identical arguments differing only in cos/sin vs cosh/sinh, so one structural idea — symmetry plus injectivity — covers both non-Euclidean constant-curvature geometries with no inner product space, metric model, or coordinates.",
     "mathContext": "$A,B\\in[0,\\pi],\\ \\cos A = \\cos B \\xRightarrow{\\ \\cos\\ \\text{inj. on }[0,\\pi]\\ } A = B$; with $\\cos A = \\cos B$ from $a=b$.",
     "significance": "key",
-    "relatedConcepts": ["Pons Asinorum", "Euclid I.5", "injectivity of cosine", "non-Euclidean geometry"],
-    "prerequisites": ["injectivity on an interval", "triangle angle ranges"]
+    "relatedConcepts": [
+      "Pons Asinorum",
+      "Euclid I.5",
+      "injectivity of cosine",
+      "non-Euclidean geometry"
+    ],
+    "prerequisites": [
+      "injectivity on an interval",
+      "triangle angle ranges"
+    ]
   },
   {
     "id": "ann-equilateral",
     "proofId": "isosceles-triangle-oq-02",
-    "range": { "startLine": 70, "endLine": 87 },
+    "range": {
+      "startLine": 70,
+      "endLine": 87
+    },
     "type": "concept",
     "title": "Equilateral ⟹ Equiangular",
     "content": "spherical_equilateral and hyperbolic_equilateral specialize to all-sides-equal: applying the equal-cosines step to the pairs (A,B) and (B,C) gives A = B = C. Here the cosines coincide on the nose (all three are sphCosA a a a), so each injectivity goal closes by rw alone. A regular (equilateral) spherical or hyperbolic triangle is therefore equiangular — the natural corollary of Pons Asinorum. Note that, unlike in Euclidean geometry, the common angle is not 60°: on the sphere it exceeds π/3 (angle excess), in the hyperbolic plane it falls short (angle defect), and it varies with the side length.",
     "mathContext": "$a=b=c \\Rightarrow A=B=C$; non-Euclidean angle $\\ne \\tfrac{\\pi}{3}$ — sphere has excess, hyperbolic plane has defect, both depending on side length.",
     "significance": "supporting",
-    "relatedConcepts": ["equilateral triangle", "angle excess and defect", "regular polygons", "curvature"],
-    "prerequisites": ["isosceles theorem", "spherical/hyperbolic area-angle relations"]
+    "relatedConcepts": [
+      "equilateral triangle",
+      "angle excess and defect",
+      "regular polygons",
+      "curvature"
+    ],
+    "prerequisites": [
+      "isosceles theorem",
+      "spherical/hyperbolic area-angle relations"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass

Annotation-coverage enrichment for `isosceles-triangle-oq-02` (*Pons Asinorum in hyperbolic and spherical geometry*).

**Coverage: 53% → 84%** of the 89-line Lean file.

Change (annotations.json only):
- **New module-overview annotation** (lines 5–32, previously uncovered): explains how the isosceles theorem is proved with no inner product space, purely from the non-Euclidean laws of cosines and injectivity of cos on [0, π], in both spherical and hyperbolic geometry.
- 4 → 5 annotations; all fields present; ranges sorted, non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)