### PR TITLE
Enrich Hall's Theorem OQ-01-01 (defect form): proof-body coverage (37%→93%)

### DIFF
--- a/src/data/proofs/halls-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-01/annotations.json
@@ -2,61 +2,193 @@
   {
     "id": "ann-context-deficiency",
     "proofId": "halls-theorem-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 32 },
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
     "type": "concept",
     "title": "Ore's Deficiency Version of the Marriage Theorem",
     "content": "Frames the result: the classical marriage theorem (Mathlib's `all_card_le_biUnion_card_iff_exists_injective`) gives a full system of distinct representatives iff Hall's condition #s ≤ #(s.biUnion t) holds. Ore's deficiency form measures how far a family is from a full SDR by a slack parameter d: relaxing the condition to #s ≤ #(s.biUnion t) + d corresponds to a partial SDR that leaves at most d indices unrepresented. Mathlib has only the d = 0 case; `defect_hall` supplies the general equivalence.",
     "mathContext": "Ordinary: $(\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t)) \\iff \\exists$ SDR. Defect-$d$: $(\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d) \\iff \\exists$ partial SDR missing $\\le d$ indices.",
     "significance": "supporting",
-    "relatedConcepts": ["Hall's marriage theorem", "system of distinct representatives", "deficiency / defect", "bipartite matching"],
-    "prerequisites": ["Hall's condition", "finite set families", "Finset.biUnion"]
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "system of distinct representatives",
+      "deficiency / defect",
+      "bipartite matching"
+    ],
+    "prerequisites": [
+      "Hall's condition",
+      "finite set families",
+      "Finset.biUnion"
+    ]
   },
   {
     "id": "ann-strategy-forward",
     "proofId": "halls-theorem-oq-01-oq-01",
-    "range": { "startLine": 34, "endLine": 41 },
+    "range": {
+      "startLine": 34,
+      "endLine": 41
+    },
     "type": "tactic",
     "title": "Reduction Strategy: Adjoin d Universal Dummies",
     "content": "The forward direction's engine. Work over α ⊕ Fin d and enlarge each set to t' i = (t i).image inl ∪ (all d dummies). For nonempty s the enlarged neighbourhood is the old one disjointly unioned with the d dummies, so #(s.biUnion t') = #(s.biUnion t) + d; the relaxed condition for t becomes ordinary Hall for t'. Mathlib's marriage theorem then yields an injective f : ι → α ⊕ Fin d; since f is injective and there are only d dummies, at most d indices land on a dummy — those are the `rejected` ones — and the rest map injectively into α, giving the partial SDR.",
     "mathContext": "$t'\\,i = (t\\,i).\\mathrm{image}\\,\\mathrm{inl} \\cup D,\\ \\#D=d$; for nonempty $s$, $\\#(s.\\mathrm{biUnion}\\,t') = \\#(s.\\mathrm{biUnion}\\,t)+d$, so defect-$d$ Hall for $t$ $\\Rightarrow$ ordinary Hall for $t'$.",
     "significance": "key",
-    "relatedConcepts": ["sum type α ⊕ Fin d", "dummy vertices", "reduction to ordinary Hall", "injective SDR extraction"],
-    "prerequisites": ["sum types", "Finset cardinality of disjoint unions", "Mathlib marriage theorem"]
+    "relatedConcepts": [
+      "sum type α ⊕ Fin d",
+      "dummy vertices",
+      "reduction to ordinary Hall",
+      "injective SDR extraction"
+    ],
+    "prerequisites": [
+      "sum types",
+      "Finset cardinality of disjoint unions",
+      "Mathlib marriage theorem"
+    ]
   },
   {
     "id": "ann-strategy-converse",
     "proofId": "halls-theorem-oq-01-oq-01",
-    "range": { "startLine": 42, "endLine": 46 },
+    "range": {
+      "startLine": 42,
+      "endLine": 46
+    },
     "type": "insight",
     "title": "Converse: An Elementary Counting Split",
     "content": "The easy direction needs no dummy machinery. Given a partial SDR, split any s as (s ∩ rejected) ⊎ (s \\ rejected). The rejected part has size ≤ #rejected ≤ d; the rest injects via e into s.biUnion t, so its size is ≤ #(s.biUnion t). Summing the two pieces yields the relaxed Hall bound #s ≤ #(s.biUnion t) + d. The nonemptiness of α is the standard hypothesis ensuring representatives exist.",
     "mathContext": "$\\#s = \\#(s\\cap\\mathrm{rejected}) + \\#(s\\setminus\\mathrm{rejected}) \\le d + \\#(s.\\mathrm{biUnion}\\,t)$.",
     "significance": "supporting",
-    "relatedConcepts": ["counting argument", "Finset partition", "injective image bound", "InjOn"],
-    "prerequisites": ["card_inter_add_card_sdiff", "injective functions on finite sets"]
+    "relatedConcepts": [
+      "counting argument",
+      "Finset partition",
+      "injective image bound",
+      "InjOn"
+    ],
+    "prerequisites": [
+      "card_inter_add_card_sdiff",
+      "injective functions on finite sets"
+    ]
   },
   {
     "id": "ann-defect-hall-statement",
     "proofId": "halls-theorem-oq-01-oq-01",
-    "range": { "startLine": 56, "endLine": 64 },
+    "range": {
+      "startLine": 56,
+      "endLine": 74
+    },
     "type": "theorem",
     "title": "defect_hall: The Deficiency Equivalence",
-    "content": "The main theorem. The relaxed Hall condition with slack d is equivalent to a partial system of distinct representatives: a `rejected` set with #rejected ≤ d, an assignment e injective off `rejected` (`Set.InjOn e rejectedᶜ`), and e i ∈ t i for every i ∉ rejected. This is the precise quantitative refinement of the parent entry's qualitative `exists_violating_of_no_matching`.",
+    "content": "The main theorem. The relaxed Hall condition with slack d is equivalent to a partial system of distinct representatives: a `rejected` set with #rejected ≤ d, an assignment e injective off `rejected` (`Set.InjOn e rejectedᶜ`), and e i ∈ t i for every i ∉ rejected. This is the precise quantitative refinement of the parent entry's qualitative `exists_violating_of_no_matching`. The proof opens `classical`, then sets up the reduction machinery: `D` (the d 'universal dummy' points living in the right summand of α ⊕ Fin d, with #D = d) and the enlarged family `t' i = (t i).image Sum.inl ∪ D` in which every set gains all d dummies, before splitting the ⟺ with `constructor`.",
     "mathContext": "$\\big(\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d\\big) \\iff \\exists\\,e,\\,\\mathrm{rejected}:\\ \\#\\mathrm{rejected}\\le d \\,\\land\\, \\mathrm{InjOn}\\,e\\,\\mathrm{rejected}^c \\,\\land\\, \\forall i\\notin\\mathrm{rejected},\\ e\\,i\\in t\\,i.$",
     "significance": "key",
-    "relatedConcepts": ["Hall's marriage theorem", "partial SDR", "Set.InjOn", "Finset.biUnion"],
-    "prerequisites": ["Hall's condition", "injective assignments", "Finset operations"]
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "partial SDR",
+      "Set.InjOn",
+      "Finset.biUnion"
+    ],
+    "prerequisites": [
+      "Hall's condition",
+      "injective assignments",
+      "Finset operations"
+    ]
   },
   {
     "id": "ann-defect-hall-zero",
     "proofId": "halls-theorem-oq-01-oq-01",
-    "range": { "startLine": 178, "endLine": 196 },
+    "range": {
+      "startLine": 178,
+      "endLine": 196
+    },
     "type": "theorem",
     "title": "defect_hall_zero: d = 0 Recovers the Classical Theorem",
     "content": "Specializing to d = 0 collapses the defect form to Hall's original marriage theorem. With slack 0, #rejected ≤ 0 forces rejected = ∅, so `InjOn e ∅ᶜ` (= InjOn e univ) becomes ordinary injectivity and 'represented off rejected' becomes 'represented everywhere'. This confirms the deficiency theorem genuinely generalizes the SDR theorem, with the classical statement as its boundary case.",
     "mathContext": "At $d=0$: $\\#\\mathrm{rejected}\\le 0 \\Rightarrow \\mathrm{rejected}=\\varnothing$, recovering $(\\forall s,\\ \\#s\\le\\#(s.\\mathrm{biUnion}\\,t)) \\iff \\exists\\,e\\text{ injective},\\ \\forall i,\\ e\\,i\\in t\\,i.$",
     "significance": "supporting",
-    "relatedConcepts": ["Hall's marriage theorem", "specialization", "empty rejected set", "Set.injOn_univ"],
-    "prerequisites": ["Hall's theorem", "Finset.card_eq_zero", "complement of empty set"]
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "specialization",
+      "empty rejected set",
+      "Set.injOn_univ"
+    ],
+    "prerequisites": [
+      "Hall's theorem",
+      "Finset.card_eq_zero",
+      "complement of empty set"
+    ]
+  },
+  {
+    "id": "ann-defect-hall-forward-enlarged",
+    "proofId": "halls-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "(⟹) The enlarged family t′ satisfies ordinary Hall",
+    "content": "Forward direction, first half: the relaxed Hall condition for t (slack d) is upgraded to the EXACT Hall condition for the dummy-augmented family t′. For nonempty s, the enlarged neighbourhood s.biUnion t′ equals (s.biUnion t).image Sum.inl ∪ D — the original neighbourhood embedded via inl, disjointly union'd with all d dummies. Because inl is injective and the two pieces are disjoint, its cardinality is #(s.biUnion t) + d, so #s ≤ #(s.biUnion t) + d (the hypothesis) becomes #s ≤ #(s.biUnion t′). Feeding that into Mathlib's classical marriage theorem `Finset.all_card_le_biUnion_card_iff_exists_injective` yields a genuine injective SDR f for t′.",
+    "mathContext": "$s.\\mathrm{biUnion}\\,t' = \\big(s.\\mathrm{biUnion}\\,t\\big).\\mathrm{image}\\,\\mathrm{inl} \\sqcup D$, so $\\#(s.\\mathrm{biUnion}\\,t') = \\#(s.\\mathrm{biUnion}\\,t) + d$. Hall for $t'$: $\\#s \\le \\#(s.\\mathrm{biUnion}\\,t')$ follows from the deficiency hypothesis, and Hall's theorem produces an injective $f$ with $f\\,i \\in t'\\,i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "disjoint union cardinality",
+      "Sum.inl injectivity",
+      "system of distinct representatives",
+      "reduction to a solved case"
+    ],
+    "prerequisites": [
+      "Hall's theorem (exact form)",
+      "Finset.card_union_of_disjoint",
+      "biUnion"
+    ]
+  },
+  {
+    "id": "ann-defect-hall-forward-extract",
+    "proofId": "halls-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 157
+    },
+    "type": "technique",
+    "title": "(⟹) Extract the representative and reject the dummies",
+    "content": "Forward direction, second half: convert the SDR f : ι → α ⊕ Fin d into a partial SDR into α. The `rejected` set is exactly the indices f sends to a dummy (f i).isRight; the representative e i extracts the α-component (Sum.elim id …), arbitrary on rejected indices. Three obligations close the goal: (1) #rejected ≤ d because f restricted to rejected injects into the d dummies D (`card_le_card_of_injOn`); (2) e is injective off rejected because there f i = inl (e i) and f is globally injective; (3) every non-rejected i is represented since f i = inl (e i) ∈ t′ i must land in the inl-image of t i (it cannot be a dummy).",
+    "mathContext": "$\\mathrm{rejected} = \\{i : (f\\,i).\\mathrm{isRight}\\}$, $e\\,i = \\mathrm{Sum.elim}\\,\\mathrm{id}\\,(\\ast)\\,(f\\,i)$. Off rejected, $f\\,i = \\mathrm{inl}(e\\,i)$, so injectivity of $f$ gives $\\mathrm{InjOn}\\,e\\,\\mathrm{rejected}^c$ and membership $f\\,i \\in t'\\,i$ forces $e\\,i \\in t\\,i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial SDR extraction",
+      "Sum.elim",
+      "card_le_card_of_injOn",
+      "injective restriction",
+      "dummy rejection"
+    ],
+    "prerequisites": [
+      "Sum type elimination",
+      "injectivity on a subset",
+      "Finset.filter"
+    ]
+  },
+  {
+    "id": "ann-defect-hall-backward",
+    "proofId": "halls-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 158,
+      "endLine": 176
+    },
+    "type": "technique",
+    "title": "(⟸) A partial SDR forces the deficiency condition (counting split)",
+    "content": "Converse, an elementary counting argument. Given a partial SDR (e, rejected) with #rejected ≤ d, split any s as (s ∩ rejected) ⊎ (s \\ rejected). The intersection has ≤ d elements (it sits inside rejected). On the difference s \\ rejected, e is injective (it lies in rejectedᶜ) and lands in s.biUnion t, so #(s \\ rejected) ≤ #(s.biUnion t) by `card_le_card_of_injOn`. Adding the two bounds, #s = #(s ∩ rejected) + #(s \\ rejected) ≤ d + #(s.biUnion t) — the relaxed Hall condition — closed by `omega`.",
+    "mathContext": "$\\#s = \\#(s\\cap R) + \\#(s\\setminus R) \\le d + \\#(s.\\mathrm{biUnion}\\,t)$, using $\\#(s\\cap R)\\le \\#R \\le d$ and the injection $e : s\\setminus R \\hookrightarrow s.\\mathrm{biUnion}\\,t$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "counting / double counting",
+      "card_inter_add_card_sdiff",
+      "injective restriction",
+      "omega"
+    ],
+    "prerequisites": [
+      "cardinality of a partition",
+      "injective maps and cardinality"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-01-oq-01`. The 5 existing annotations were deep but left the 115-line `defect_hall` proof body almost entirely unannotated — coverage 37% of 198 lines.

**Changes (annotations.json):**
- Added **3 substantive proof-phase annotations** decomposing the two-direction iff proof:
  - (⟹) the dummy-augmented family t′ satisfies ordinary Hall, feeding Mathlib's marriage theorem;
  - (⟹) extracting the α-representative e and rejecting the dummy-valued indices to build the partial SDR;
  - (⟸) the elementary counting split (s ∩ rejected) ⊎ (s ∖ rejected) forcing the deficiency condition.
- Extended the statement annotation to cover the `classical`/dummy-construction setup.
- Coverage **37% → 93%**; all 8 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

meta.json unchanged. `pnpm build` passes.