### PR TITLE
Enrich Erdős 396 OQ-04-OQ-01: 64%→87% annotation coverage

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
@@ -1,9 +1,34 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "erdos-396-oq-04-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Overview: Asymptotics of the Catalan Recurrence Ratio",
+    "content": "The parent Erdos396OQ04 proves the two-term Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n, i.e. catalan(n+1) = (4n+2)/(n+2)·catalan n. This follow-up reads the exact multiplicative step r n = (4n+2)/(n+2) and extracts its asymptotics from one algebraic observation — the partial-fraction identity r n = 4 − 6/(n+2) — which gives three facts Mathlib does not record: r n < 4 always (ratio_lt_four), r strictly increasing (ratio_strictMono), and r n → 4 (ratio_tendsto_four). Combined with the recurrence this yields the classical growth bounds catalan(n+1) < 4·catalan n and catalan n < 4^n (n ≥ 1) WITHOUT Stirling's formula or any central-binomial estimate. The limit r n → 4 is the discrete shadow of the exponential growth rate 4 of the Catalan numbers (catalan n ∼ 4^n/(n^{3/2}√π)), proved directly from the integer recurrence.",
+    "mathContext": "$r_n = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2} \\uparrow 4$; hence $\\mathrm{catalan}\\,n < 4^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "recurrence relations",
+      "partial fractions",
+      "asymptotic growth",
+      "Erdős problem 396"
+    ],
+    "prerequisites": [
+      "Catalan numbers",
+      "limits of sequences",
+      "partial-fraction decomposition"
+    ]
+  },
+  {
     "id": "ann-e396oq04oq01-recurrence",
     "proofId": "erdos-396-oq-04-oq-01",
     "range": {
-      "startLine": 51,
+      "startLine": 45,
       "endLine": 75
     },
     "type": "insight",
@@ -11,8 +36,17 @@
     "content": "The file re-derives the closed form $C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ and the recurrence $(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ directly from Mathlib's `Nat.succ_mul_centralBinom_succ` and `succ_mul_catalan_eq_centralBinom`, so it does not depend on the parent build. It also supplies `catalan_pos`, which Mathlib lacks, from $(n+1)\\,\\mathrm{catalan}\\,n = C(2n,n) > 0$.",
     "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{4n+2}{n+2}\\,C_n$.",
     "significance": "key",
-    "relatedConcepts": ["Catalan recurrence", "central binomial coefficient", "catalan_pos", "self-contained derivation", "Catalan numbers"],
-    "prerequisites": ["combinatorics", "recurrence relations"]
+    "relatedConcepts": [
+      "Catalan recurrence",
+      "central binomial coefficient",
+      "catalan_pos",
+      "self-contained derivation",
+      "Catalan numbers"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "recurrence relations"
+    ]
   },
   {
     "id": "ann-e396oq04oq01-partialfraction",
@@ -26,8 +60,17 @@
     "content": "The multiplicative step is `catalanRatio n = (4n+2)/(n+2)`. The single identity $r(n) = 4 - \\frac{6}{n+2}$ (proved by `field_simp; ring`, using $4(n+2) - (4n+2) = 6$) encodes the whole asymptotic story: the constant $4$ is the limit, and the positive tail $\\frac{6}{n+2}$ forces both $r(n) < 4$ and strict growth of $r$. The step is the genuine quotient of consecutive Catalan numbers: $(\\mathrm{catalan}(n+1):\\mathbb{R}) = r(n)\\cdot\\mathrm{catalan}\\,n$.",
     "mathContext": "$r(n) = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2}$.",
     "significance": "critical",
-    "relatedConcepts": ["partial fractions", "Catalan ratio", "asymptotic constant", "field_simp", "consecutive ratio"],
-    "prerequisites": ["real analysis", "algebraic manipulation"]
+    "relatedConcepts": [
+      "partial fractions",
+      "Catalan ratio",
+      "asymptotic constant",
+      "field_simp",
+      "consecutive ratio"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "algebraic manipulation"
+    ]
   },
   {
     "id": "ann-e396oq04oq01-limit",
@@ -41,8 +84,18 @@
     "content": "From the partial-fraction form: `ratio_lt_four` ($r(n) < 4$, the step never reaches $4$); `ratio_strictMono` ($r$ strictly increases, since $\\frac{6}{n+2}$ strictly decreases — via `div_lt_div_iff₀`); and `ratio_tendsto_four` ($r(n) \\to 4$), proved by sending $n+2 \\to \\infty$ with `Tendsto.inv_tendsto_atTop` so that $\\frac{6}{n+2} \\to 0$. This is the recurrence-level shadow of the exponential growth rate $4$ in $\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$.",
     "mathContext": "$r(n) < 4$, $r$ strictly increasing, $\\lim_{n\\to\\infty} r(n) = 4$.",
     "significance": "critical",
-    "relatedConcepts": ["limit of a sequence", "monotone convergence", "Tendsto.inv_tendsto_atTop", "Catalan asymptotics", "growth rate 4"],
-    "prerequisites": ["real analysis", "limits", "monotonicity"]
+    "relatedConcepts": [
+      "limit of a sequence",
+      "monotone convergence",
+      "Tendsto.inv_tendsto_atTop",
+      "Catalan asymptotics",
+      "growth rate 4"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "limits",
+      "monotonicity"
+    ]
   },
   {
     "id": "ann-e396oq04oq01-growth",
@@ -56,7 +109,17 @@
     "content": "Because $4n+2 < 4(n+2)$, the recurrence gives `catalan_succ_lt_four_mul`: $\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$, by cancelling the positive factor $n+2$ with `Nat.lt_of_mul_lt_mul_left`. Induction then yields `catalan_le_four_pow`: $\\mathrm{catalan}\\,n \\le 4^n$ for all $n$ (and the strict `catalan_lt_four_pow`: $\\mathrm{catalan}\\,n < 4^n$ for $n \\ge 1$) — the standard upper bound, obtained purely from the recurrence with no Stirling estimate.",
     "mathContext": "$\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$ and $\\mathrm{catalan}\\,n \\le 4^n$.",
     "significance": "key",
-    "relatedConcepts": ["growth bound", "induction", "exponential bound 4^n", "Catalan numbers", "Stirling-free estimate"],
-    "prerequisites": ["combinatorics", "induction", "inequalities"]
+    "relatedConcepts": [
+      "growth bound",
+      "induction",
+      "exponential bound 4^n",
+      "Catalan numbers",
+      "Stirling-free estimate"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "induction",
+      "inequalities"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass

Annotation-coverage enrichment for `erdos-396-oq-04-oq-01` (*asymptotics of the Catalan recurrence ratio*).

**Coverage: 64% → 87%** of the 187-line Lean file.

Changes (annotations.json only):
- **New module-overview annotation** (lines 1–37): the previously unannotated docstring — the recurrence-ratio r n = 4 − 6/(n+2), the three asymptotic facts, and the resulting catalan n < 4^n growth bounds proved without Stirling.
- **Extended** the first annotation to absorb the self-contained re-derivation section header.
- 4 → 5 annotations; all fields present; ranges sorted, non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)