### PR TITLE
Enrich Sperner–Mathlib4 OQ-02 (Tucker door obstructions): coverage (37%→90%)

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02/annotations.json
@@ -1,50 +1,120 @@
 [
   {
+    "id": "ann-header-sperner-oq02",
+    "proofId": "sperner-mathlib4-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "Two machine-checked obstructions to naive door choices for n = 2 Tucker",
+    "content": "The header docstring frames this negative/scoping result. The door-counting program for Tucker's lemma is abstractly complete up to ONE geometric input: the single-level path-following engine and the dimension recursion are fully verified, leaving only the geometric construction of the door graph (Freund–Todd 1981 / Prescott–Su). A tempting shortcut is to fix one sign k, declare doors to be the complementary {+k,-k} edges, and run the engine. The companion `SpernerTuckerHexagon` already killed the FIRST naive simplification (the complementary-edge count is not a parity invariant for n = 2). THIS file kills the SECOND: on the same concrete hexagon+centre triangulation of B², entirely by kernel `decide`, a door graph built from one fixed complementary sign is not a complete certificate — for a suitable antipodal labelling the whole 'complementary spoke' door graph is empty (every triangle has door-degree 0) yet Tucker's conclusion still holds, because the complementary edge lives on the boundary, invisible to that door choice. Conclusion: the correct door structure must range over ALL signs and account for boundary edges. Honest status: a scoping/negative result, fully concrete, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only — kernel `decide`, no `Lean.ofReduceBool`).",
+    "mathContext": "Model: hexagon + centre triangulation of $B^2$, boundary vertices $v_0,\\dots,v_5$ in antipodal pairs $v_{i+3} = -v_i$, labels in $\\{+1,+2,-1,-2\\} \\cong \\mathrm{Fin}\\,4$ with negation $\\mathrm{negL}$. Triangles $T_i = (\\text{centre}, v_i, v_{i+1})$. The spoke-door graph takes centre-incident edges complementary to the centre label $d$; door-degree $\\le 2$ always, but can be $\\equiv 0$ while a complementary boundary edge still exists.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "Borsuk–Ulam theorem",
+      "door-counting / path-following",
+      "antipodal labelling",
+      "Freund–Todd construction",
+      "negative result / obstruction"
+    ],
+    "prerequisites": [
+      "combinatorial topology",
+      "Tucker's lemma",
+      "triangulations of the disk"
+    ]
+  },
+  {
     "id": "sperner-oq02-encoding",
     "proofId": "sperner-mathlib4-oq-02",
-    "range": { "startLine": 80, "endLine": 96 },
+    "range": {
+      "startLine": 80,
+      "endLine": 96
+    },
     "type": "definition",
     "title": "Labels, complementarity, and the antipodal hexagon",
     "content": "The four Tucker labels {+1,+2,-1,-2} are encoded as Fin 4 (0↦+1, 1↦+2, 2↦-1, 3↦-2) with negation negL = ![2,3,0,1], an involution. Two labels are complementary, Compl x y := x = negL y, with a Decidable instance so the whole model is checkable by decide. V a b c gives the six boundary labels from three free labels a,b,c of v0,v1,v2, with the antipodal condition v(i+3) = -v i built in as negL a, negL b, negL c. rot i = i+1 is the cyclic successor around the hexagon.",
     "mathContext": "$\\mathrm{negL}:\\mathbb{F}_4\\to\\mathbb{F}_4,\\quad \\mathrm{Compl}(x,y)\\iff x=\\mathrm{negL}(y),\\quad V(a,b,c)=(a,b,c,-a,-b,-c)$",
     "significance": "supporting",
-    "relatedConcepts": ["Tucker labelling", "antipodal symmetry", "Fin 4", "involution", "Decidable"],
-    "prerequisites": ["Tucker's lemma setup", "the hexagon-plus-centre triangulation of B²"]
+    "relatedConcepts": [
+      "Tucker labelling",
+      "antipodal symmetry",
+      "Fin 4",
+      "involution",
+      "Decidable"
+    ],
+    "prerequisites": [
+      "Tucker's lemma setup",
+      "the hexagon-plus-centre triangulation of B²"
+    ]
   },
   {
     "id": "sperner-oq02-degree-bound",
     "proofId": "sperner-mathlib4-oq-02",
-    "range": { "startLine": 98, "endLine": 109 },
+    "range": {
+      "startLine": 98,
+      "endLine": 109
+    },
     "type": "theorem",
     "title": "The spoke-door graph has max degree ≤ 2",
     "content": "degSpoke a b c d i counts how many of triangle Ti's two spokes (centre—v i and centre—v(i+1)) are complementary to the centre label d. degSpoke_le_two proves this is always ≤ 2, over all 4⁴ = 256 antipodal labellings and 6 triangles, by kernel decide. This is the crucial point of the obstruction: the naive door graph is a legal input to the path-following engine — it genuinely satisfies the paths-and-cycles hypothesis ∀ v, degree v ≤ 2 — so its failure is not a matter of ill-formedness.",
     "mathContext": "$\\forall a,b,c,d,i:\\ \\deg_{\\mathrm{spoke}}(a,b,c,d,i)\\le 2$",
     "significance": "central",
-    "relatedConcepts": ["door graph", "maximum degree", "path-following engine", "decide"],
-    "prerequisites": ["degSpoke definition", "the engine's structural hypothesis"]
+    "relatedConcepts": [
+      "door graph",
+      "maximum degree",
+      "path-following engine",
+      "decide"
+    ],
+    "prerequisites": [
+      "degSpoke definition",
+      "the engine's structural hypothesis"
+    ]
   },
   {
     "id": "sperner-oq02-obstruction",
     "proofId": "sperner-mathlib4-oq-02",
-    "range": { "startLine": 111, "endLine": 127 },
+    "range": {
+      "startLine": 111,
+      "endLine": 127
+    },
     "type": "theorem",
     "title": "A single-sign door graph is not a complete certificate",
     "content": "spoke_graph_empty_yet_complementary exhibits an antipodal labelling on which no spoke is complementary to the centre — every triangle has door-degree 0, so the path-following engine produces nothing — yet a boundary edge is complementary, so Tucker's conclusion still holds. Witness: centre d = +2 with all boundary vertices labelled ±1; then negL(+2) = -2 appears on no boundary vertex (no spoke door) while a boundary edge with labels +1,-1 is complementary. The single fixed interior door type is blind to the boundary-living complementary edge.",
     "mathContext": "$\\exists a,b,c,d:\\ (\\forall i,\\ \\neg\\,\\mathrm{Compl}(d,V_i))\\ \\wedge\\ (\\exists i,\\ \\mathrm{Compl}(V_i,V_{\\mathrm{rot}\\,i}))$",
     "significance": "central",
-    "relatedConcepts": ["obstruction", "complete certificate", "boundary edge", "Freund–Todd construction"],
-    "prerequisites": ["degSpoke_le_two", "the reproduced Tucker conclusion"]
+    "relatedConcepts": [
+      "obstruction",
+      "complete certificate",
+      "boundary edge",
+      "Freund–Todd construction"
+    ],
+    "prerequisites": [
+      "degSpoke_le_two",
+      "the reproduced Tucker conclusion"
+    ]
   },
   {
     "id": "sperner-oq02-reference-tucker",
     "proofId": "sperner-mathlib4-oq-02",
-    "range": { "startLine": 129, "endLine": 138 },
+    "range": {
+      "startLine": 129,
+      "endLine": 138
+    },
     "type": "theorem",
     "title": "n = 2 Tucker on the hexagon (reference conclusion)",
     "content": "hexagon_tucker reproduces the n = 2 Tucker conclusion on the same hexagon: for every antipodal labelling a,b,c and every centre label d, there is a complementary edge — either a boundary edge v i — v(i+1) or a spoke centre — v i — verified exhaustively over all 256 labellings by decide. Stating this alongside the obstruction makes the negative result meaningful: the empty single-sign door graph fails to certify a conclusion that genuinely holds.",
     "mathContext": "$\\forall a,b,c,d:\\ (\\exists i,\\ \\mathrm{Compl}(V_i,V_{\\mathrm{rot}\\,i}))\\ \\vee\\ (\\exists i,\\ \\mathrm{Compl}(d,V_i))$",
     "significance": "supporting",
-    "relatedConcepts": ["Tucker's lemma", "complementary edge", "exhaustive verification"],
-    "prerequisites": ["the hexagon model", "SpernerTuckerHexagon reference"]
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "complementary edge",
+      "exhaustive verification"
+    ],
+    "prerequisites": [
+      "the hexagon model",
+      "SpernerTuckerHexagon reference"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sperner-mathlib4-oq-02`. The 4 existing annotations already covered the defs and theorems (lines 80-138); the 75-line framing docstring — explaining *why* this is a negative/scoping result about naive n = 2 Tucker door choices — was unannotated. Coverage 37% of 150 lines.

**Changes (annotations.json):**
- Added a header annotation (1-79) explaining the two machine-checked obstructions: the complementary-edge count is not a parity invariant (companion file) and a single-fixed-sign spoke-door graph can be empty while Tucker still holds (this file). Notes the honest status and that the correct Freund–Todd door structure must range over all signs and account for boundary edges.
- Coverage **37% → 90%**; all 5 annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.
- Verified the 0-axiom claim: kernel `decide` (not `native_decide`), no `Lean.ofReduceBool`.

meta.json unchanged. (Note: a full `pnpm build` in the shared tree currently errors on an unrelated stray `chebyshev-bounds-oq-06-oq-02/index.ts` from another agent — not on `main` and not part of this PR; this entry's JSON is schema-valid.)