### PR TITLE
research(matrix-posdef-sqrt-oq-01-oq-01-oq-01): operator absolute value |A|=√(AᴴA) + norm preservation [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/MatrixPosDefSqrtOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/MatrixPosDefSqrtOQ01OQ01OQ01.lean
@@ -1,0 +1,118 @@
+/-
+# The Operator Absolute Value `|A| = √(AᴴA)` and Norm Preservation
+
+Follow-up to `matrix-posdef-sqrt-oq-01-oq-01`
+(*Polar Decomposition `A = U·√(AᴴA)` from the Positive Semidefinite Square Root*).
+
+The positive semidefinite factor `√(AᴴA)` appearing in the polar decomposition
+`A = U · √(AᴴA)` is the **operator absolute value** (or *modulus*) `|A|`.  The
+single most important structural fact about the modulus is that it acts on
+lengths exactly as `A` does:
+
+    ‖A x‖ = ‖ |A| x ‖      for every vector `x`.
+
+Squaring, this is the identity of Hermitian quadratic forms
+
+    ⟨Ax, Ax⟩ = ⟨x, AᴴA x⟩ = ⟨x, |A|² x⟩ = ⟨|A|x, |A|x⟩,
+
+which uses only `|A|² = AᴴA` and the self-adjointness of `|A|`.  This is
+precisely *why* the polar decomposition `A = U|A|` can be realised with a
+genuinely **unitary** `U`: on the range of `|A|`, `A` and `|A|` have the same
+length, so the transition map `U` is an isometry.
+
+We work over an arbitrary `RCLike` field `𝕜` (so `ℝ` or `ℂ`) and prove:
+
+* the purely algebraic quadratic-form identity
+  `⟨Ax, Ax⟩ = ⟨|A|x, |A|x⟩` (`absValue_star_mulVec_dotProduct`), and
+* the honest squared-Euclidean-norm identity
+  `∑ᵢ ‖(Ax)ᵢ‖² = ∑ᵢ ‖(|A|x)ᵢ‖²` (`absValue_normSq_eq`).
+
+The modulus is defined via Mathlib's continuous functional calculus
+(`CFC.sqrt`), exactly as the polar factor of the parent entry.
+
+Self-contained: imports Mathlib only.  No axioms beyond Mathlib.
+-/
+
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import Mathlib.LinearAlgebra.Matrix.PosDef
+import Mathlib.Tactic
+
+open Matrix
+open scoped MatrixOrder ComplexOrder
+
+namespace MatrixPosDefSqrtOQ01OQ01OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : Type*} [Fintype n] [DecidableEq n]
+
+/-! ### The operator absolute value `|A| = √(AᴴA)` -/
+
+/-- The **operator absolute value** (modulus) of a matrix `A`, defined as the
+positive semidefinite square root of `Aᴴ · A`.  This is exactly the positive
+semidefinite factor of the polar decomposition `A = U · |A|`. -/
+noncomputable def absValue (A : Matrix n n 𝕜) : Matrix n n 𝕜 :=
+  CFC.sqrt (Aᴴ * A)
+
+/-- `|A|` is positive semidefinite. -/
+theorem absValue_posSemidef (A : Matrix n n 𝕜) : (absValue A).PosSemidef :=
+  (CFC.sqrt_nonneg (Aᴴ * A)).posSemidef
+
+/-- `|A|` is Hermitian. -/
+theorem absValue_isHermitian (A : Matrix n n 𝕜) : (absValue A)ᴴ = absValue A :=
+  (absValue_posSemidef A).isHermitian
+
+/-- Defining property of the modulus: `|A|² = AᴴA`. -/
+theorem absValue_mul_self (A : Matrix n n 𝕜) :
+    absValue A * absValue A = Aᴴ * A :=
+  CFC.sqrt_mul_sqrt_self (Aᴴ * A) (posSemidef_conjTranspose_mul_self A).nonneg
+
+/-- `|A|ᴴ · |A| = AᴴA`.  Since `|A|` is Hermitian this is just the defining
+property, but it is the form in which the modulus enters the quadratic form. -/
+theorem absValue_conjTranspose_mul_self (A : Matrix n n 𝕜) :
+    (absValue A)ᴴ * absValue A = Aᴴ * A := by
+  rw [absValue_isHermitian, absValue_mul_self]
+
+/-- **Characterisation of the modulus.** `|A|` is the unique positive
+semidefinite matrix `P` with `P² = AᴴA`. -/
+theorem absValue_unique (A P : Matrix n n 𝕜) (hP : P.PosSemidef)
+    (h : P * P = Aᴴ * A) : P = absValue A :=
+  (CFC.sqrt_unique h hP.nonneg).symm
+
+/-! ### The fundamental quadratic-form identity -/
+
+/-- For any matrix `M` and vector `x`, the (unconjugated) Hermitian quadratic
+form of `M x` collapses to the form of `MᴴM` on `x`:
+`⟨Mx, Mx⟩ = ⟨x, (MᴴM) x⟩`.  Purely algebraic — no analysis. -/
+theorem star_mulVec_dotProduct_self (M : Matrix n n 𝕜) (x : n → 𝕜) :
+    star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ * M) *ᵥ x) := by
+  rw [star_mulVec, ← dotProduct_mulVec, mulVec_mulVec]
+
+/-- **Norm preservation (quadratic-form version).**  `A` and its modulus `|A|`
+induce the *same* Hermitian quadratic form:
+`⟨Ax, Ax⟩ = ⟨|A|x, |A|x⟩`.  This is the algebraic heart of why the unitary
+factor of the polar decomposition is an isometry. -/
+theorem absValue_star_mulVec_dotProduct (A : Matrix n n 𝕜) (x : n → 𝕜) :
+    star (A *ᵥ x) ⬝ᵥ (A *ᵥ x)
+      = star (absValue A *ᵥ x) ⬝ᵥ (absValue A *ᵥ x) := by
+  rw [star_mulVec_dotProduct_self A x, star_mulVec_dotProduct_self (absValue A) x,
+    absValue_conjTranspose_mul_self]
+
+/-! ### The honest squared-norm identity -/
+
+/-- The unconjugated form `star y ⬝ᵥ y` is the (real) squared Euclidean length
+`∑ᵢ ‖yᵢ‖²`, transported into `𝕜`. -/
+theorem dotProduct_star_self (y : n → 𝕜) :
+    star y ⬝ᵥ y = ((∑ i, ‖y i‖ ^ 2 : ℝ) : 𝕜) := by
+  simp only [dotProduct, Pi.star_apply, RCLike.star_def, RCLike.conj_mul,
+    RCLike.ofReal_sum, RCLike.ofReal_pow]
+
+/-- **Norm preservation (Euclidean-norm version).**  `A` and its modulus `|A|`
+send every vector to vectors of equal Euclidean length:
+`∑ᵢ ‖(Ax)ᵢ‖² = ∑ᵢ ‖(|A|x)ᵢ‖²`, i.e. `‖Ax‖ = ‖|A|x‖`. -/
+theorem absValue_normSq_eq (A : Matrix n n 𝕜) (x : n → 𝕜) :
+    (∑ i, ‖(A *ᵥ x) i‖ ^ 2) = ∑ i, ‖(absValue A *ᵥ x) i‖ ^ 2 := by
+  have h := absValue_star_mulVec_dotProduct A x
+  rw [dotProduct_star_self, dotProduct_star_self] at h
+  exact_mod_cast h
+
+end MatrixPosDefSqrtOQ01OQ01OQ01

--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,104 @@
+{
+  "id": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+  "slug": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+  "title": "The Operator Absolute Value |A| = √(AᴴA) and Norm Preservation ‖Ax‖ = ‖|A|x‖",
+  "description": "The positive semidefinite factor √(AᴴA) of the polar decomposition is the operator absolute value (modulus) |A|. Its defining structural property is that it acts on lengths exactly as A does: the Hermitian quadratic forms agree, ⟨Ax, Ax⟩ = ⟨x, AᴴA x⟩ = ⟨x, |A|² x⟩ = ⟨|A|x, |A|x⟩, and hence ∑ᵢ ‖(Ax)ᵢ‖² = ∑ᵢ ‖(|A|x)ᵢ‖², i.e. ‖Ax‖ = ‖|A|x‖. This is the reason the polar decomposition A = U·|A| can be realised with a genuinely unitary (isometric) U. Also proves |A| is PSD, Hermitian, satisfies |A|² = AᴴA, and is the unique PSD square root of AᴴA.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Matrix.Order",
+      "Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic",
+      "Mathlib.LinearAlgebra.Matrix.PosDef",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "MatrixOrder",
+      "ComplexOrder"
+    ],
+    "namespace": "MatrixPosDefSqrtOQ01OQ01OQ01",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/MatrixPosDefSqrtOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Polar_decomposition#Bounded_operators_on_Hilbert_space",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MatrixPosDefSqrtOQ01OQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "polar-decomposition",
+      "operator-absolute-value",
+      "positive-semidefinite",
+      "square-root",
+      "isometry",
+      "continuous-functional-calculus"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "matrix-posdef-sqrt-oq-01-oq-01",
+        "relationship": "Direct parent: this entry answers its open question 'derive the operator absolute value |A| = √(AᴴA) and ‖Ax‖ = ‖|A|x‖ from the polar factor'. It reuses the PSD-square-root triad (CFC.sqrt existence/structure/uniqueness) and identifies the parent's polarFactor A with the modulus |A|."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 118,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All nine theorems depend only on the foundational propext / Classical.choice / Quot.sound. The modulus is defined as absValue A = CFC.sqrt (Aᴴ · A) (Mathlib's C⋆-algebraic square root), positive semidefinite via CFC.sqrt_nonneg with LE.le.posSemidef, Hermitian via Matrix.PosSemidef.isHermitian, and satisfies absValue A · absValue A = Aᴴ · A via CFC.sqrt_mul_sqrt_self applied to Matrix.posSemidef_conjTranspose_mul_self; uniqueness as the PSD square root of AᴴA is CFC.sqrt_unique. The quadratic-form collapse star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ*M) *ᵥ x) is pure matrix algebra (Matrix.star_mulVec, Matrix.dotProduct_mulVec, Matrix.mulVec_mulVec). Norm preservation ⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩ then follows because (absValue A)ᴴ · absValue A = Aᴴ · A. The Euclidean-norm form ∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖² is obtained from the identity star y ⬝ᵥ y = ↑(∑ᵢ‖yᵢ‖²) (RCLike.conj_mul, RCLike.star_def, RCLike.ofReal_sum) and RCLike coercion injectivity. Everything holds over an arbitrary RCLike field 𝕜 (real or complex); there are no additional hypotheses beyond the finiteness of the index type.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "For a complex number z = r·e^{iθ}, the modulus is r = √(z̄z); the operator absolute value |A| = √(AᴴA) is the matrix (and Hilbert-space operator) analogue, and it is the positive semidefinite factor of the polar decomposition A = U·|A|. The defining feature of the modulus is that it has the same length-action as A: ‖Ax‖ = ‖|A|x‖ for every x. This is exactly what forces the phase factor U to be a genuine isometry, and it is the starting point of the singular value decomposition (the singular values of A are the eigenvalues of |A|) and of the theory of the operator norm and Schatten norms, all of which are computed through |A|.",
+    "problemStatement": "Over $\\mathbb R$ or $\\mathbb C$, define the operator absolute value $|A| = \\sqrt{A^{\\mathsf H}A}$ using the positive semidefinite square root, and prove its basic structure ($|A|$ positive semidefinite and Hermitian, $|A|^2 = A^{\\mathsf H}A$, uniqueness as the PSD square root of $A^{\\mathsf H}A$). Then prove the norm-preservation identity: the Hermitian quadratic forms of $A$ and $|A|$ agree, $\\langle Ax, Ax\\rangle = \\langle |A|x, |A|x\\rangle$, and consequently $\\sum_i \\lVert (Ax)_i\\rVert^2 = \\sum_i \\lVert (|A|x)_i\\rVert^2$, i.e. $\\lVert Ax\\rVert = \\lVert |A|x\\rVert$.",
+    "proofStrategy": "The modulus is defined as `absValue A = CFC.sqrt (Aᴴ·A)`, inheriting positive semidefiniteness, self-adjointness and the identity `absValue A · absValue A = Aᴴ·A` from the parent square-root theory, and being the unique PSD square root by `CFC.sqrt_unique`. The quadratic-form heart is a one-line matrix identity: for any `M`, `star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ·M) *ᵥ x)`, via `Matrix.star_mulVec`, `Matrix.dotProduct_mulVec` and `Matrix.mulVec_mulVec`. Applying this to both `A` and `|A|` and using `(|A|)ᴴ·|A| = Aᴴ·A` (self-adjointness plus `|A|²=AᴴA`) gives `⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩`. Finally, `star y ⬝ᵥ y` equals the real quantity `∑ᵢ‖yᵢ‖²` transported into `𝕜` (using `RCLike.conj_mul`), so the two-sided form identity descends to the real squared-norm identity by injectivity of the coercion `ℝ ↪ 𝕜`.",
+    "text": "Mathlib carries the C⋆-algebraic square root CFC.sqrt but does not package the matrix operator absolute value or its norm-preservation property. This entry defines |A| = √(AᴴA), records that it is the unique positive semidefinite square root of AᴴA, and proves the mathematically load-bearing fact that A and |A| are isometric: they induce the same Hermitian quadratic form and send every vector to a vector of the same Euclidean length. This is the precise sense in which the modulus captures 'the size of A', and it is what makes the unitary phase in the polar decomposition A = U·|A| an honest isometry.",
+    "keyInsights": [
+      "**The modulus is intrinsic; only the phase is ambiguous.** `|A| = √(AᴴA)` is defined without any choice and is the unique positive semidefinite matrix whose square is `AᴴA` (`CFC.sqrt_unique`). Unlike the unitary factor `U`, which is only determined up to its action on `ker A`, the modulus is completely canonical.",
+      "**Norm preservation is a two-line quadratic-form collapse.** For any matrix `M`, `⟨Mx, Mx⟩ = star(M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((MᴴM) *ᵥ x) = ⟨x, MᴴM x⟩` — pure matrix algebra using `star_mulVec`, `dotProduct_mulVec`, `mulVec_mulVec`. So the form of `Mx` depends on `M` only through `MᴴM`.",
+      "**A and |A| have the same MᴴM, hence the same length-action.** Because `|A|` is Hermitian and `|A|² = AᴴA`, we get `(|A|)ᴴ·|A| = |A|·|A| = AᴴA = Aᴴ·A`. Feeding this into the quadratic-form collapse gives `⟨Ax, Ax⟩ = ⟨|A|x, |A|x⟩` at once, with no analysis.",
+      "**The abstract form identity descends to genuine Euclidean norms.** The unconjugated dot product `star y ⬝ᵥ y` equals `∑ᵢ conj(yᵢ)·yᵢ = ∑ᵢ ‖yᵢ‖²` transported into `𝕜` (`RCLike.conj_mul`). Injectivity of `ℝ ↪ 𝕜` then converts `⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩` into the honest real identity `∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖²`, i.e. `‖Ax‖ = ‖|A|x‖`.",
+      "**This is why the polar phase is unitary.** Since `A` and `|A|` are isometric, the map sending `|A|x ↦ Ax` preserves lengths; extending it gives the unitary factor `U` with `A = U·|A|`. The norm-preservation identity is the conceptual reason the polar decomposition's phase is an isometry rather than merely invertible."
+    ],
+    "prerequisites": [
+      "The positive semidefinite square root CFC.sqrt and its lemmas CFC.sqrt_nonneg, CFC.sqrt_mul_sqrt_self, CFC.sqrt_unique (parent chain matrix-posdef-sqrt-oq-01, matrix-posdef-sqrt-oq-01-oq-01)",
+      "Positive semidefinite matrices: Matrix.PosSemidef, Matrix.posSemidef_conjTranspose_mul_self, Matrix.PosSemidef.isHermitian, LE.le.posSemidef under scoped MatrixOrder",
+      "Matrix–vector algebra: Matrix.star_mulVec, Matrix.dotProduct_mulVec, Matrix.mulVec_mulVec, and the dot product ⬝ᵥ on n → 𝕜",
+      "RCLike scalar identities: RCLike.conj_mul (conj z · z = ‖z‖²), RCLike.star_def, RCLike.ofReal_sum, RCLike.ofReal_pow, and injectivity of ℝ ↪ 𝕜"
+    ]
+  },
+  "sections": [
+    {
+      "id": "operator-absolute-value",
+      "title": "The operator absolute value |A| = √(AᴴA)",
+      "description": "Defines the modulus absValue A = CFC.sqrt (Aᴴ·A) and records its structure: positive semidefinite (absValue_posSemidef), Hermitian (absValue_isHermitian), the defining identity |A|² = AᴴA (absValue_mul_self), the form |A|ᴴ·|A| = AᴴA (absValue_conjTranspose_mul_self), and uniqueness as the PSD square root of AᴴA (absValue_unique)."
+    },
+    {
+      "id": "quadratic-form",
+      "title": "The fundamental quadratic-form identity",
+      "description": "For any matrix M and vector x, the Hermitian quadratic form of Mx collapses to the form of MᴴM on x: star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ·M) *ᵥ x) (star_mulVec_dotProduct_self), a pure matrix-algebra computation."
+    },
+    {
+      "id": "norm-preservation",
+      "title": "Norm preservation ‖Ax‖ = ‖|A|x‖",
+      "description": "A and its modulus induce the same quadratic form ⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩ (absValue_star_mulVec_dotProduct); via star y ⬝ᵥ y = ∑ᵢ‖yᵢ‖² (dotProduct_star_self) this descends to the Euclidean-norm identity ∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖² (absValue_normSq_eq)."
+    }
+  ],
+  "openQuestions": [
+    {
+      "question": "Does the kernel identity ker A = ker |A| hold, i.e. A *ᵥ x = 0 ↔ |A| *ᵥ x = 0, as a direct corollary of ‖Ax‖ = ‖|A|x‖?",
+      "status": "open"
+    },
+    {
+      "question": "Can the norm-preservation identity be upgraded to a genuine EuclideanSpace statement ‖A.toEuclideanCLM x‖ = ‖|A|.toEuclideanCLM x‖, and used to construct the partial isometry realising A = U·|A| in the singular case?",
+      "status": "open"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to `matrix-posdef-sqrt-oq-01-oq-01` (polar decomposition `A = U·√(AᴴA)`). Names the positive-semidefinite factor `√(AᴴA)` as the **operator absolute value** (modulus) `|A|` and proves its defining structural property: it preserves lengths,

```
‖A x‖ = ‖ |A| x ‖   for every vector x,
```

which is precisely why the polar unitary `U` can be taken genuinely unitary (an isometry on the range of `|A|`). Works over any `RCLike` field 𝕜 (ℝ or ℂ).

## Results (`Proofs/MatrixPosDefSqrtOQ01OQ01OQ01.lean`, 9 thm / 1 def)

- `absValue A := CFC.sqrt (Aᴴ * A)`; PSD, Hermitian, and `|A|² = AᴴA`.
- `absValue_unique` — `|A|` is the unique PSD `P` with `P² = AᴴA`.
- `absValue_star_mulVec_dotProduct` — quadratic-form identity `⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩` (purely algebraic).
- `absValue_normSq_eq` — Euclidean-norm version `∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖²`.

## Note — corrected a latent false-verified claim

The authored file's `absValue_unique` passed `CFC.sqrt_unique` the *flipped* equality `h.symm : Aᴴ*A = P*P`, where the lemma expects `h : P*P = Aᴴ*A`. Lean error-recovered that mismatch with a **sorry**, so the entry's prior "verified / 0-axiom" claim was false (`#print axioms` reported `sorryAx`). Corrected to pass `h` directly; the entry is now genuinely sorry-free.

## Verification

`lean` exit 0; `#print axioms` → `{propext, Classical.choice, Quot.sound}` only (no `sorryAx`, no `Lean.ofReduceBool`). **0 sorries, 0 axioms.** 118 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)