### PR TITLE
Enrich inverse-galois-oq-06-oq-02: module-overview annotation (59%→84% coverage)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-igp0602-overview",
+    "proofId": "inverse-galois-oq-06-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 60
+    },
+    "type": "concept",
+    "title": "Overview: The Arithmetic Half of the mod-7 Dedekind Route",
+    "content": "This file supplies the verified, 0-axiom algebraic input that Dedekind's theorem consumes at the prime p = 7, en route to the last open axiom of the parent A₅ realization, three_dvd_gal_card : 3 ∣ |Gal(q)|, for q = X⁵ − 5X⁴ + 10X³ − 10X² + 25X − 5. Dedekind's theorem says: if a prime p does not divide disc(q) (equivalently q mod p is squarefree) and q mod p factors into irreducibles of degrees d₁,…,dₖ, then Gal(q), viewed inside the symmetric group on the roots, contains a permutation of cycle type (d₁,…,dₖ). The sibling OQ-01 file established the factorization SHAPE mod 7 — q ≡ (X−5)(X−6)(X³+6X²+4X+1) with the cubic root-free over 𝔽₇. Here that is upgraded to the full irreducible-factorization statement Dedekind reads: (1) the cubic is irreducible, (2) the two linear factors are irreducible, (3) the three factors are pairwise non-associated (distinct primes), (4) their product is squarefree (7 unramified), and (5) the packaged '(1,1,3) into distinct irreducibles' statement tied to q itself. HONEST SCOPE: this does NOT eliminate three_dvd_gal_card — Dedekind's theorem itself (factor type ⟹ Frobenius cycle type ⟹ 3 ∣ |Gal|) is absent from Mathlib 4.26 and is the sibling Frobenius track's job. What is added is the 0-axiom arithmetic feedstock: degrees (1,1,3), distinct irreducibles, 7 unramified.",
+    "mathContext": "For $q \\in \\mathbb{Z}[X]$ and a prime $\\ell \\nmid \\operatorname{disc}(q)$, Dedekind's theorem identifies the cycle type of $\\operatorname{Frob}_\\ell \\in \\operatorname{Gal}(q)$ with the degree multiset of the factorization of $q \\bmod \\ell$ into distinct monic irreducibles. At $\\ell = 7$ that multiset is $\\{1,1,3\\}$, so $\\operatorname{Frob}_7$ contains a $3$-cycle and $3 \\mid |\\operatorname{Gal}(q)|$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dedekind's theorem",
+      "reduction mod p",
+      "Frobenius element",
+      "inverse Galois problem",
+      "cycle type"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "factorization of polynomials over finite fields",
+      "discriminant and ramification"
+    ]
+  },
+  {
     "id": "ann-igp0602-setup",
     "proofId": "inverse-galois-oq-06-oq-02",
     "range": {
@@ -11,8 +36,16 @@
     "content": "The file opens by registering Fact (Nat.Prime 7), which powers Lean's typeclass resolution: because 7 is prime, ZMod 7 is a field and (ZMod 7)[X] a Euclidean domain. Every downstream irreducibility, coprimality, and squarefreeness argument relies on working over a field, so this one instance is the quiet foundation of the whole arithmetic half. The goal of the file is to supply, with zero axioms, exactly the input Dedekind's theorem consumes at p = 7 to force 3 ∣ |Gal(q)| in the parent A₅ realization.",
     "mathContext": "$\\mathbb{Z}/7\\mathbb{Z}$ is a field since $7$ is prime, so $(\\mathbb{Z}/7\\mathbb{Z})[X]$ is a PID/Euclidean domain where irreducible $=$ prime and unique factorization holds.",
     "significance": "context",
-    "relatedConcepts": ["finite field", "prime field ZMod p", "Euclidean domain", "Dedekind's theorem"],
-    "prerequisites": ["finite fields", "polynomial rings over a field"]
+    "relatedConcepts": [
+      "finite field",
+      "prime field ZMod p",
+      "Euclidean domain",
+      "Dedekind's theorem"
+    ],
+    "prerequisites": [
+      "finite fields",
+      "polynomial rings over a field"
+    ]
   },
   {
     "id": "ann-igp0602-factors",
@@ -26,8 +59,16 @@
     "content": "The reduction of q modulo 7 is presented through three named factors over 𝔽₇: the linear factors linFactor5 = X − 5 and linFactor6 = X − 6, and the cubic cubicMod7 = X³ + 6X² + 4X + 1 (imported from the sibling OQ-01 file). Their degrees (1, 1, 3) are pinned down by compute_degree!, and each factor is shown nonzero. These degree facts are the raw data of the '(1,1,3) factor type' that Dedekind's theorem reads as a 3-cycle Frobenius.",
     "mathContext": "Over the field $\\mathbb{F}_7 = \\mathbb{Z}/7\\mathbb{Z}$, the polynomial $q = x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5$ reduces to $(X-5)(X-6)(X^3+6X^2+4X+1)$. The degree multiset $\\{1,1,3\\}$ is precisely the cycle type that the Frobenius at $p=7$ would carry.",
     "significance": "supporting",
-    "relatedConcepts": ["reduction mod p", "polynomial degree", "monic linear factor", "cycle type"],
-    "prerequisites": ["polynomial arithmetic", "degree of a polynomial"]
+    "relatedConcepts": [
+      "reduction mod p",
+      "polynomial degree",
+      "monic linear factor",
+      "cycle type"
+    ],
+    "prerequisites": [
+      "polynomial arithmetic",
+      "degree of a polynomial"
+    ]
   },
   {
     "id": "ann-igp0602-irreducible",
@@ -41,8 +82,16 @@
     "content": "The cubic is irreducible over 𝔽₇ because a degree-≤3 polynomial over a field is irreducible exactly when it has no root — the tactic applies Polynomial.irreducible_of_degree_le_three_of_not_isRoot, discharging the degree bound by decide and the no-root hypothesis from the sibling's exhaustive root check. The linear factors are irreducible by the standard irreducible_X_sub_C. This makes the arithmetic Dedekind input fully decidable and axiom-free.",
     "mathContext": "For a cubic $f$ over a field, reducibility would force a linear factor, i.e. a root; contrapositively, no root over $\\mathbb{F}_7$ (checked over all 7 residues) implies irreducibility. Linear polynomials $X - c$ are always irreducible.",
     "significance": "key",
-    "relatedConcepts": ["irreducibility", "no-root criterion", "degree ≤ 3", "irreducible_X_sub_C"],
-    "prerequisites": ["irreducible polynomials", "roots and factors over a field"]
+    "relatedConcepts": [
+      "irreducibility",
+      "no-root criterion",
+      "degree ≤ 3",
+      "irreducible_X_sub_C"
+    ],
+    "prerequisites": [
+      "irreducible polynomials",
+      "roots and factors over a field"
+    ]
   },
   {
     "id": "ann-igp0602-distinct",
@@ -56,8 +105,16 @@
     "content": "Dedekind's theorem requires the factorization be into DISTINCT irreducibles. The two linear factors are non-associated because associated monic linears would be equal, forcing 5 = 6 in 𝔽₇ (false, by decide after evaluating at 0). A linear factor cannot be associated to the cubic because association preserves degree, and 1 ≠ 3 (closed by omega on natDegree_le_of_dvd bounds). Distinctness is what guarantees the Frobenius is a single 3-cycle rather than a repeated pattern.",
     "mathContext": "Two polynomials are associated iff each divides the other, which for nonzero polynomials over a field forces equal degrees and a unit scalar. Distinct irreducible factors correspond to distinct prime ideals, i.e. distinct cycles in the Frobenius permutation.",
     "significance": "key",
-    "relatedConcepts": ["associated elements", "distinct primes", "degree preservation", "cycle structure"],
-    "prerequisites": ["unique factorization", "associates in a UFD"]
+    "relatedConcepts": [
+      "associated elements",
+      "distinct primes",
+      "degree preservation",
+      "cycle structure"
+    ],
+    "prerequisites": [
+      "unique factorization",
+      "associates in a UFD"
+    ]
   },
   {
     "id": "ann-igp0602-squarefree",
@@ -71,8 +128,17 @@
     "content": "The three factors are pairwise coprime: the two linears via isCoprime_X_sub_C_of_isUnit_sub (their difference −1 is a unit), and each linear against the cubic via the irreducible's isRelPrime_iff_not_dvd together with dvd_iff_isRoot and the no-root fact. Squarefreeness of the product then follows from squarefree_mul_iff applied twice. A squarefree reduction means 7 ∤ disc(q), i.e. 7 is unramified — exactly the hypothesis Dedekind's theorem demands.",
     "mathContext": "A prime $\\ell$ is unramified in the splitting field of $q$ iff $q \\bmod \\ell$ is squarefree iff $\\ell \\nmid \\operatorname{disc}(q)$. Pairwise coprime irreducible factors give a squarefree product, licensing the Frobenius-at-$\\ell$ interpretation.",
     "significance": "key",
-    "relatedConcepts": ["squarefree polynomial", "coprimality", "unramified prime", "discriminant"],
-    "prerequisites": ["squarefreeness", "discriminant of a polynomial", "ramification"]
+    "relatedConcepts": [
+      "squarefree polynomial",
+      "coprimality",
+      "unramified prime",
+      "discriminant"
+    ],
+    "prerequisites": [
+      "squarefreeness",
+      "discriminant of a polynomial",
+      "ramification"
+    ]
   },
   {
     "id": "ann-igp0602-factortype",
@@ -86,7 +152,16 @@
     "content": "q_mod7_factor_type bundles everything Dedekind's theorem consumes at p = 7: three irreducible factors, of degrees 1, 1, 3, pairwise non-associated, with squarefree product, whose product genuinely equals q mod 7 (q_mod7_factorization). This is the complete, 0-axiom arithmetic input. Combined with Dedekind's theorem — the one remaining Mathlib gap, owned by the sibling Frobenius track — it forces Gal(q) to contain a 3-cycle, hence 3 ∣ |Gal(q)|, which is exactly the parent A₅ entry's lone open axiom three_dvd_gal_card.",
     "mathContext": "Dedekind's theorem: for $\\ell \\nmid \\operatorname{disc}(q)$, the cycle type of the Frobenius $\\operatorname{Frob}_\\ell \\in \\operatorname{Gal}(q)$ acting on the roots equals the degree multiset of $q \\bmod \\ell$. Here $\\{1,1,3\\}$ yields a 3-cycle, so $3 \\mid |\\operatorname{Gal}(q)|$ by Lagrange.",
     "significance": "key",
-    "relatedConcepts": ["Dedekind's theorem", "Frobenius cycle type", "three_dvd_gal_card", "Lagrange's theorem"],
-    "prerequisites": ["Galois group of a polynomial", "Dedekind's theorem", "Lagrange's theorem"]
+    "relatedConcepts": [
+      "Dedekind's theorem",
+      "Frobenius cycle type",
+      "three_dvd_gal_card",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "Galois group of a polynomial",
+      "Dedekind's theorem",
+      "Lagrange's theorem"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation covering the module docstring (lines 4-60), previously unannotated (annotations began at line 71).

The docstring narrates the mod-7 Dedekind route toward the parent A₅ realization's lone open axiom `three_dvd_gal_card`. The new annotation paraphrases: what Dedekind's theorem consumes, the (1,1,3) factor type, the pairwise-distinct-irreducible + squarefree (7 unramified) conditions, and the honest scope (this file supplies 0-axiom arithmetic input but does NOT eliminate the open axiom — Dedekind's theorem is the sibling Frobenius track's job).

- Annotations: 6 → 7
- Coverage: ~59% → ~84% (190/225 lines)
- No range overlaps; no Lean source changes

Label: enrichment