### PR TITLE
Enrich property-b-first-moment-oq-03-oq-01: module-overview annotation (42%→78% coverage)

### DIFF
--- a/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/property-b-first-moment-oq-03-oq-01/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "ann-pbfm0301-overview",
+    "proofId": "property-b-first-moment-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "Overview: Asymmetry Alone Cannot Beat Erdős's 2^(k−1)",
+    "content": "The open question property-b-first-moment-oq-03 asks to sharpen Erdős's 1963 bound m(k) ≥ 2^(k−1) to the Radhakrishnan–Srinivasan bound m(k) = Ω(2^k·√(k/log k)) via an 'asymmetric / recoloring' refinement of the first-moment argument. That refinement names two ingredients: asymmetry of the random coloring, and a recoloring repair step. This file isolates the FIRST and settles it NEGATIVELY: asymmetry alone yields no improvement. In the model, each vertex of a k-uniform hypergraph is colored Red independently with probability p (Blue with 1−p), so a fixed k-edge is monochromatic with probability monoProb k p = p^k + (1−p)^k, and the first-moment threshold (largest edge count keeping expected monochromatic edges below 1) is 1/monoProb k p. The results, all 0-axiom over the real first-moment model: monoProb k p ≥ 2·(1/2)^k for every p (monoProb_ge); p = 1/2 minimizes it (monoProb_half_le); for k ≥ 2 it is the UNIQUE minimizer (monoProb_half_lt); and the symmetric threshold is exactly 2^(k−1) (threshold_half). Conclusion: biasing the colors never raises the threshold above Erdős's 2^(k−1), so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come ENTIRELY from the recoloring step. This is a structural ORIENT result that scopes the remaining oq-03 work, not the RS bound itself.",
+    "mathContext": "For a fixed bias $p$, the monochromatic probability is $f(p)=p^k+(1-p)^k$, a strictly convex function on $[0,1]$ (for $k\\ge 2$) symmetric about $p=1/2$, so it is uniquely minimized there with $f(1/2)=2^{1-k}$. The first-moment threshold $1/f(p)$ is therefore maximized at $p=1/2$, giving exactly $2^{k-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "probabilistic method",
+      "first moment method",
+      "property B",
+      "Radhakrishnan–Srinivasan bound",
+      "convexity"
+    ],
+    "prerequisites": [
+      "probabilistic method",
+      "hypergraph coloring",
+      "expectation and the union bound"
+    ]
+  },
+  {
     "id": "ann-pbfm-oq03oq01-monoprob",
     "proofId": "property-b-first-moment-oq-03-oq-01",
-    "range": { "startLine": 55, "endLine": 61 },
+    "range": {
+      "startLine": 55,
+      "endLine": 61
+    },
     "type": "definition",
     "title": "The p-Biased Monochromatic Probability",
     "content": "`monoProb k p := p^k + (1-p)^k` models the probability that a fixed edge of size `k` is monochromatic when each vertex is colored Red independently with probability `p` (and Blue with probability `1-p`): one of the two colors must hit all `k` vertices, contributing `p^k` (all Red) and `(1-p)^k` (all Blue). This generalizes the parent file's symmetric count, where every edge is monochromatic with probability `2·2^(-k) = 2^(1-k)`. The simp lemma `monoProb_half` evaluates the symmetric case `monoProb k (1/2) = 2·(1/2)^k`.",
     "mathContext": "$\\mathrm{monoProb}(k,p) = p^k + (1-p)^k$, with $\\mathrm{monoProb}(k,\\tfrac12) = 2\\cdot(\\tfrac12)^k = 2^{1-k}$.",
     "significance": "supporting",
-    "relatedConcepts": ["independent vertex coloring", "monochromatic edge", "Bernoulli(p) model", "Property B"],
-    "prerequisites": ["independent events and product probabilities", "the parent symmetric first-moment bound"]
+    "relatedConcepts": [
+      "independent vertex coloring",
+      "monochromatic edge",
+      "Bernoulli(p) model",
+      "Property B"
+    ],
+    "prerequisites": [
+      "independent events and product probabilities",
+      "the parent symmetric first-moment bound"
+    ]
   },
   {
     "id": "ann-pbfm-oq03oq01-ge",
     "proofId": "property-b-first-moment-oq-03-oq-01",
-    "range": { "startLine": 63, "endLine": 77 },
+    "range": {
+      "startLine": 63,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "Asymmetry Never Helps (monoProb_ge)",
     "content": "`monoProb_ge` is the crux: for `k ≥ 1` and any bias `p ∈ [0,1]`, `2·(1/2)^k ≤ monoProb k p`. The proof is one application of `convexOn_pow` (convexity of `x ↦ x^k` on `[0,∞)`): with `p` and `1-p` both in `Ici 0` and weights `a = b = 1/2`, convexity gives `((1/2)p + (1/2)(1-p))^k ≤ (1/2)p^k + (1/2)(1-p)^k`. The argument collapses to `(1/2)^k` (via `ring`), yielding `(1/2)^k ≤ (1/2)·monoProb k p`, i.e. `2·(1/2)^k ≤ monoProb k p`. Since `2·(1/2)^k = 2^(1-k)`, the symmetric value is a global lower bound — biasing the coloring can only raise the monochromatic probability.",
     "mathContext": "By convexity of $x\\mapsto x^k$: $\\left(\\tfrac{p+(1-p)}2\\right)^k \\le \\tfrac{p^k+(1-p)^k}2$, i.e. $2\\,(\\tfrac12)^k \\le \\mathrm{monoProb}(k,p)$ — Jensen at the midpoint.",
     "significance": "key",
-    "relatedConcepts": ["convexity / Jensen's inequality", "convexOn_pow", "midpoint inequality", "first-moment method"],
-    "prerequisites": ["convexity of x ↦ x^k on [0,∞)", "ConvexOn.2 / midpoint instantiation"]
+    "relatedConcepts": [
+      "convexity / Jensen's inequality",
+      "convexOn_pow",
+      "midpoint inequality",
+      "first-moment method"
+    ],
+    "prerequisites": [
+      "convexity of x ↦ x^k on [0,∞)",
+      "ConvexOn.2 / midpoint instantiation"
+    ]
   },
   {
     "id": "ann-pbfm-oq03oq01-lt",
     "proofId": "property-b-first-moment-oq-03-oq-01",
-    "range": { "startLine": 87, "endLine": 104 },
+    "range": {
+      "startLine": 87,
+      "endLine": 104
+    },
     "type": "theorem",
     "title": "Symmetry is the Unique Optimum for k ≥ 2 (monoProb_half_lt)",
     "content": "`monoProb_half_lt` upgrades optimality to uniqueness: for `k ≥ 2` and `p ∈ [0,1]` with `p ≠ 1/2`, `monoProb k (1/2) < monoProb k p`. The bias condition `p ≠ 1/2` is exactly `p ≠ 1-p`, the distinctness needed to apply `strictConvexOn_pow` (strict convexity of `x ↦ x^k` for `k ≥ 2`) at the points `p` and `1-p`. The strict midpoint inequality then gives `(1/2)^k < (1/2)·monoProb k p`. So any nonzero bias *strictly* increases the monochromatic probability, hence strictly *lowers* the first-moment threshold `1/monoProb k p`.",
     "mathContext": "Strict convexity for $k\\ge 2$ and $p \\neq 1-p$: $\\left(\\tfrac{p+(1-p)}2\\right)^k < \\tfrac{p^k+(1-p)^k}2$, so $\\mathrm{monoProb}(k,\\tfrac12) < \\mathrm{monoProb}(k,p)$ — equality iff $p=\\tfrac12$.",
     "significance": "key",
-    "relatedConcepts": ["strict convexity", "strictConvexOn_pow", "uniqueness of optimum", "p ≠ 1/2 ⟺ p ≠ 1−p"],
-    "prerequisites": ["strict convexity of x ↦ x^k for k ≥ 2", "the distinctness hypothesis p ≠ 1−p"]
+    "relatedConcepts": [
+      "strict convexity",
+      "strictConvexOn_pow",
+      "uniqueness of optimum",
+      "p ≠ 1/2 ⟺ p ≠ 1−p"
+    ],
+    "prerequisites": [
+      "strict convexity of x ↦ x^k for k ≥ 2",
+      "the distinctness hypothesis p ≠ 1−p"
+    ]
   },
   {
     "id": "ann-pbfm-oq03oq01-threshold",
     "proofId": "property-b-first-moment-oq-03-oq-01",
-    "range": { "startLine": 106, "endLine": 118 },
+    "range": {
+      "startLine": 106,
+      "endLine": 118
+    },
     "type": "theorem",
     "title": "The Symmetric Threshold is Exactly 2^(k-1) (threshold_half)",
     "content": "`threshold_half` anchors the optimum to Erdős' original bound: `1 / monoProb k (1/2) = 2^(k-1)` for `k ≥ 1`. Rewriting `monoProb k (1/2) = 2·(1/2)^k` and `(1/2)^k = 1/2^k` (`one_div_pow`), then clearing denominators (`field_simp`) reduces the claim to `2·2^(k-1) = 2^k` (`pow_succ`). Combined with `monoProb_half_le`, this shows no bias `p` raises the threshold above `2^(k-1)`: the asymmetric first moment cannot beat Erdős, so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step. `expected_mono_half_le` records the expectation form: an m-edge hypergraph's expected monochromatic-edge count `m·monoProb k p` is minimized at `p = 1/2`.",
     "mathContext": "$\\dfrac{1}{\\mathrm{monoProb}(k,\\tfrac12)} = \\dfrac{1}{2^{1-k}} = 2^{k-1}$, and $\\mathbb{E}[\\#\\text{mono edges}] = m\\cdot\\mathrm{monoProb}(k,p)$ is minimized at $p=\\tfrac12$.",
     "significance": "key",
-    "relatedConcepts": ["Erdős 2^(k-1) bound", "Property B threshold", "Radhakrishnan–Srinivasan recoloring", "linearity of expectation"],
-    "prerequisites": ["monoProb_half and monoProb_half_le", "field_simp / pow_succ arithmetic"]
+    "relatedConcepts": [
+      "Erdős 2^(k-1) bound",
+      "Property B threshold",
+      "Radhakrishnan–Srinivasan recoloring",
+      "linearity of expectation"
+    ],
+    "prerequisites": [
+      "monoProb_half and monoProb_half_le",
+      "field_simp / pow_succ arithmetic"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation covering the module docstring (lines 1-44), previously unannotated (annotations began at line 55).

The docstring frames open question property-b-first-moment-oq-03 and the negative result: biasing the coloring never raises the first-moment threshold above Erdős's 2^(k-1), so the Radhakrishnan–Srinivasan gain of order √(k/log k) must come entirely from the recoloring step.

- Annotations: 4 → 5
- Coverage: ~42% → ~78%
- No range overlaps; no Lean source changes

Label: enrichment