### PR TITLE
research(factorial-telescoping-sum-oq-01-oq-01): telescoping series ∑ k/(k+1)! = 1 [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/FactorialTelescopingSumOQ01OQ01.lean
+++ b/proofs/Proofs/FactorialTelescopingSumOQ01OQ01.lean
@@ -1,0 +1,85 @@
+/-
+  Factorial Telescoping Series Converges:  ∑_{k=1}^{∞} k / (k+1)! = 1
+
+  Follow-up (oq-01) to `factorial-telescoping-sum-oq-01`
+  (∑_{k=1}^{n} k · k! = (n+1)! − 1).
+
+  Status: VERIFIED (0 sorries, 0 axioms, no native_decide).
+
+  The parent identity is a *finite* statement over ℕ.  Dividing the telescoping
+  step by (k+1)! turns it into a genuinely analytic statement: the normalized
+  series ∑ k/(k+1)! converges, and its value is exactly 1.
+
+  Statements:
+    (1)  term_telescope :  k/(k+1)! = 1/k! − 1/(k+1)!            (over ℝ)
+    (2)  sum_Icc        :  ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!    (closed form)
+    (3)  sum_lt_one     :  every partial sum is strictly below 1
+    (4)  tendsto_one    :  the partial sums converge to 1
+
+  Key insight (telescoping in a field):
+    Because (k+1)! = (k+1)·k!, we have
+        k/(k+1)! = ((k+1) − 1)/(k+1)! = 1/k! − 1/(k+1)!,
+    so the sum telescopes to  1/1! − 1/(n+1)! = 1 − 1/(n+1)!.
+    Since (n+1)! ≥ n+1 → ∞, the tail 1/(n+1)! → 0 and the series sums to 1.
+-/
+
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Tactic
+
+open Finset Nat Filter Topology
+
+namespace FactorialTelescopingConverges
+
+/-- **Term telescoping (in ℝ).**  `k/(k+1)! = 1/k! − 1/(k+1)!`.
+
+    This is the parent's integer telescoping step `k·k! = (k+1)! − k!` divided
+    through by `(k+1)!`; it is what makes the sum collapse over ℝ. -/
+theorem term_telescope (k : ℕ) :
+    (k : ℝ) / ((k + 1)! : ℝ) = 1 / (k ! : ℝ) - 1 / ((k + 1)! : ℝ) := by
+  have h : ((k + 1)! : ℝ) = ((k : ℝ) + 1) * (k ! : ℝ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  have hk : (k ! : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos k).ne'
+  have hk1 : (k : ℝ) + 1 ≠ 0 := by positivity
+  rw [h]
+  field_simp
+  ring
+
+/-- **Closed form for the partial sums.**  `∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!`. -/
+theorem sum_Icc (n : ℕ) :
+    ∑ k ∈ Icc 1 n, (k : ℝ) / ((k + 1)! : ℝ) = 1 - 1 / ((n + 1)! : ℝ) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ m + 1), ih, term_telescope (m + 1)]
+    ring
+
+/-- **Partial sums are strictly below the limit.**  Each finite sum is `< 1`,
+    because the missing tail `1/(n+1)!` is strictly positive. -/
+theorem sum_lt_one (n : ℕ) :
+    ∑ k ∈ Icc 1 n, (k : ℝ) / ((k + 1)! : ℝ) < 1 := by
+  rw [sum_Icc]
+  have : (0 : ℝ) < 1 / ((n + 1)! : ℝ) := by positivity
+  linarith
+
+/-- **Convergence to 1.**  The partial sums `∑_{k=1}^{n} k/(k+1)!` tend to `1`,
+    i.e. the series `∑_{k≥1} k/(k+1)!` sums to `1`. -/
+theorem tendsto_one :
+    Tendsto (fun n : ℕ => ∑ k ∈ Icc 1 n, (k : ℝ) / ((k + 1)! : ℝ)) atTop (nhds 1) := by
+  have hform :
+      (fun n : ℕ => ∑ k ∈ Icc 1 n, (k : ℝ) / ((k + 1)! : ℝ))
+        = fun n : ℕ => 1 - 1 / ((n + 1)! : ℝ) := by
+    funext n; exact sum_Icc n
+  rw [hform]
+  have htail : Tendsto (fun n : ℕ => 1 / ((n + 1)! : ℝ)) atTop (nhds 0) := by
+    refine squeeze_zero (fun n => by positivity)
+      (fun n => ?_) tendsto_one_div_add_atTop_nhds_zero_nat
+    apply one_div_le_one_div_of_le
+    · positivity
+    · exact_mod_cast Nat.self_le_factorial (n + 1)
+  have h1 : Tendsto (fun n : ℕ => (1 : ℝ) - 1 / ((n + 1)! : ℝ)) atTop (nhds (1 - 0)) :=
+    Tendsto.sub tendsto_const_nhds htail
+  simpa using h1
+
+end FactorialTelescopingConverges

--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "ann-programme",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "concept",
+    "title": "From a Finite ℕ Identity to a Series Limit",
+    "content": "The parent entry proves the finite identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 over ℕ. This file normalizes it: dividing the telescoping step k·k! = (k+1)! − k! by (k+1)! gives k/(k+1)! = 1/k! − 1/(k+1)!, a telescoping of reciprocals over ℝ. That single change turns a finite closed form into a convergent series with an exact rate: the partial sums equal 1 − 1/(n+1)!, so they sit strictly below 1 and converge to 1. The docstring lays out the four statements — the pointwise identity, the closed form, the strict bound, and the limit.",
+    "mathContext": "$\\frac{k}{(k+1)!} = \\frac{1}{k!} - \\frac{1}{(k+1)!}$, so $\\sum_{k=1}^{n} \\frac{k}{(k+1)!} = 1 - \\frac{1}{(n+1)!} \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping series",
+      "factorial recurrence",
+      "convergent series",
+      "normalization"
+    ],
+    "prerequisites": [
+      "factorials and Finset.sum",
+      "limits of real sequences"
+    ]
+  },
+  {
+    "id": "ann-term-telescope",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 47
+    },
+    "type": "technique",
+    "title": "Telescoping of Reciprocals",
+    "content": "term_telescope establishes k/(k+1)! = 1/k! − 1/(k+1)! over ℝ. The proof expands (k+1)! = (k+1)·k! (Nat.factorial_succ, pushed through the cast), records that k! and k+1 are nonzero, and then clears denominators with field_simp before ring finishes. This is the analytic counterpart of the parent's integer collapse k·k! = (k+1)! − k!: dividing that identity by (k+1)! is exactly what produces a difference of consecutive reciprocals, the shape that makes an infinite sum — not merely a finite one — telescope.",
+    "mathContext": "$\\frac{k}{(k+1)!} = \\frac{(k+1)-1}{(k+1)!} = \\frac{1}{k!} - \\frac{1}{(k+1)!}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping",
+      "field_simp",
+      "factorial recurrence"
+    ],
+    "prerequisites": [
+      "field arithmetic over ℝ",
+      "casting ℕ factorials to ℝ"
+    ]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 56
+    },
+    "type": "technique",
+    "title": "The Closed Form and Its Exact Error Term",
+    "content": "sum_Icc proves ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! by induction on n. Finset.sum_Icc_succ_top peels the top term, the inductive hypothesis rewrites the head, and term_telescope rewrites the new term into 1/(m+1)! − 1/(m+2)!; the consecutive boundary reciprocals cancel and ring closes (1 − 1/(m+1)!) + (1/(m+1)! − 1/(m+2)!) = 1 − 1/(m+2)!. The remaining term 1/(n+1)! is the exact truncation error after n terms — super-geometrically small.",
+    "mathContext": "$\\sum_{k=1}^{n} \\frac{k}{(k+1)!} = \\frac{1}{1!} - \\frac{1}{(n+1)!} = 1 - \\frac{1}{(n+1)!}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction",
+      "sum_Icc_succ_top",
+      "convergence rate"
+    ],
+    "prerequisites": [
+      "Finset.Icc sums",
+      "induction over ℕ"
+    ]
+  },
+  {
+    "id": "ann-strict-bound",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 64
+    },
+    "type": "observation",
+    "title": "Every Partial Sum Stays Below 1",
+    "content": "sum_lt_one records that ∑_{k=1}^{n} k/(k+1)! < 1 for all n. It is immediate from the closed form: the sum equals 1 minus the strictly positive tail 1/(n+1)!, so it never reaches 1. positivity supplies 0 < 1/(n+1)! and linarith finishes. This monotone approach-from-below is the qualitative picture behind the limit.",
+    "mathContext": "$1 - \\frac{1}{(n+1)!} < 1$ since $\\frac{1}{(n+1)!} > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity",
+      "bounded partial sums"
+    ],
+    "prerequisites": [
+      "ordered field arithmetic"
+    ]
+  },
+  {
+    "id": "ann-convergence",
+    "proofId": "factorial-telescoping-sum-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 83
+    },
+    "type": "technique",
+    "title": "Convergence to 1 by a Factorial Squeeze",
+    "content": "tendsto_one proves that the partial sums converge to 1, i.e. ∑_{k≥1} k/(k+1)! = 1. After rewriting the partial sums to their closed form 1 − 1/(n+1)!, the only work is showing the tail 1/(n+1)! → 0. This uses only the crude bound n+1 ≤ (n+1)! (Nat.self_le_factorial), which gives 0 ≤ 1/(n+1)! ≤ 1/(n+1); squeeze_zero against tendsto_one_div_add_atTop_nhds_zero_nat (1/(n+1) → 0) forces the tail to 0. Then 1 − 1/(n+1)! → 1 − 0 = 1. No sharp factorial growth estimate is needed.",
+    "mathContext": "$0 \\le \\frac{1}{(n+1)!} \\le \\frac{1}{n+1} \\to 0$, so $1 - \\frac{1}{(n+1)!} \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "sequential limits",
+      "factorial growth"
+    ],
+    "prerequisites": [
+      "squeeze_zero",
+      "limits at infinity"
+    ]
+  }
+]

--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/index.ts
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FactorialTelescopingSumOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const factorialTelescopingSumOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const factorialTelescopingSumOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const factorialTelescopingSumOq01Oq01Data: ProofData = {
+  proof: factorialTelescopingSumOq01Oq01Proof,
+  annotations: factorialTelescopingSumOq01Oq01Annotations,
+}

--- a/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "factorial-telescoping-sum-oq-01-oq-01",
+  "slug": "factorial-telescoping-sum-oq-01-oq-01",
+  "title": "Factorial Telescoping Series Converges: ∑_{k≥1} k/(k+1)! = 1",
+  "status": "verified",
+  "badge": "original",
+  "description": "The normalized companion of the parent finite identity ∑_{k=1}^{n} k·k! = (n+1)! − 1. Dividing the telescoping step by (k+1)! turns the finite ℕ statement into an analytic one over ℝ: the per-term collapse k/(k+1)! = 1/k! − 1/(k+1)! gives the closed form ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!, so every partial sum is strictly below 1, and because (n+1)! ≥ n+1 → ∞ the tail 1/(n+1)! → 0, forcing the series to converge to exactly 1. Fully verified: 4 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The parent identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 is a finite combinatorial fact underlying the factorial number system. Its analytic shadow is obtained by normalizing: dividing the telescoping step k·k! = (k+1)! − k! by (k+1)! yields k/(k+1)! = 1/k! − 1/(k+1)!, a telescoping of reciprocals. The resulting series ∑_{k≥1} k/(k+1)! is a classic example of a rapidly (super-geometrically) convergent series with an exact rational-limit value, closely related to the expansions of e and 1/(k−1)! − 1/k! telescopes used to bound factorial tails.",
+    "problemStatement": "Formalize the convergence of the normalized telescoping series: prove the closed form ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! over ℝ, and deduce that the partial sums converge to 1 (equivalently, ∑_{k≥1} k/(k+1)! = 1). This upgrades the parent's finite ℕ identity to a genuine limit statement.",
+    "proofStrategy": "Work over ℝ so that division is available and no truncated subtraction is needed. First prove the pointwise telescoping identity k/(k+1)! = 1/k! − 1/(k+1)! by expanding (k+1)! = (k+1)·k! and clearing denominators (field_simp; ring). Induct on n with Finset.sum_Icc_succ_top to collapse the sum to the boundary term 1/1! − 1/(n+1)! = 1 − 1/(n+1)!. Strict positivity of 1/(n+1)! then gives partial sums < 1. For the limit, bound 1/(n+1)! ≤ 1/(n+1) using n+1 ≤ (n+1)! (Nat.self_le_factorial) and apply squeeze_zero against tendsto_one_div_add_atTop_nhds_zero_nat, so the tail → 0 and the closed form → 1 − 0 = 1.",
+    "keyInsights": [
+      "Normalization converts telescoping in ℕ (k·k! = (k+1)! − k!) into telescoping of reciprocals over ℝ (k/(k+1)! = 1/k! − 1/(k+1)!), which is what makes the series—not just a finite sum—collapse.",
+      "The closed form 1 − 1/(n+1)! exposes both the strict bound (< 1) and the convergence rate: the error after n terms is exactly 1/(n+1)!, super-geometrically small.",
+      "Convergence needs only the crude factorial bound (n+1)! ≥ n+1; a squeeze against the harmonic-type sequence 1/(n+1) suffices, avoiding any deeper growth estimate.",
+      "The limit value 1 is the boundary term 1/1! of the telescope, the analytic reflection of the parent's ‘−1’ (= −1/1! after normalization)."
+    ],
+    "prerequisites": [
+      "The factorial recurrence (n+1)! = (n+1)·n! and the bound n ≤ n!",
+      "Finite sums over Finset.Icc with sum_Icc_succ_top, and field arithmetic over ℝ (field_simp, ring)",
+      "The squeeze theorem for sequences (squeeze_zero) and the limit 1/(n+1) → 0"
+    ]
+  },
+  "sections": [
+    {
+      "id": "term-telescope",
+      "title": "Section I: Telescoping of Reciprocals",
+      "startLine": 35,
+      "endLine": 47,
+      "summary": "term_telescope: k/(k+1)! = 1/k! − 1/(k+1)! over ℝ, the normalized form of the parent's per-term collapse k·k! = (k+1)! − k!.",
+      "mathContext": "Expand (k+1)! = (k+1)·k! and clear denominators with field_simp; ring. This reciprocal telescoping is the analytic engine of the series."
+    },
+    {
+      "id": "closed-form",
+      "title": "Section II: Closed Form for the Partial Sums",
+      "startLine": 49,
+      "endLine": 56,
+      "summary": "sum_Icc: ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!, by induction via Finset.sum_Icc_succ_top and the term identity; ring closes the telescoping step.",
+      "mathContext": "The successive boundary terms cancel, leaving 1/1! − 1/(n+1)! = 1 − 1/(n+1)!. The error term 1/(n+1)! is the exact convergence rate."
+    },
+    {
+      "id": "strict-bound",
+      "title": "Section III: Partial Sums Are Below 1",
+      "startLine": 58,
+      "endLine": 64,
+      "summary": "sum_lt_one: every partial sum ∑_{k=1}^{n} k/(k+1)! < 1, since the omitted tail 1/(n+1)! is strictly positive.",
+      "mathContext": "Immediate from the closed form and positivity of 1/(n+1)! (positivity; linarith)."
+    },
+    {
+      "id": "convergence",
+      "title": "Section IV: Convergence to 1",
+      "startLine": 66,
+      "endLine": 83,
+      "summary": "tendsto_one: the partial sums tend to 1, i.e. ∑_{k≥1} k/(k+1)! = 1, via a squeeze 0 ≤ 1/(n+1)! ≤ 1/(n+1) → 0.",
+      "mathContext": "squeeze_zero with Nat.self_le_factorial (n+1 ≤ (n+1)!) and tendsto_one_div_add_atTop_nhds_zero_nat sends the tail to 0; then 1 − 1/(n+1)! → 1 − 0 = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 84 lines and 4 theorems establishing that the normalized telescoping series ∑_{k≥1} k/(k+1)! converges to 1. The closed form ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)! (over ℝ) is proved by reciprocal telescoping, the strict bound < 1 follows from tail positivity, and convergence is obtained by squeezing the tail 1/(n+1)! between 0 and 1/(n+1). #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "implications": "This upgrades the parent's finite ℕ identity to a genuine analytic limit: the same telescoping mechanism, normalized to ℝ, yields both an exact convergence rate (error = 1/(n+1)!) and the exact limit value 1. It illustrates the standard pattern of turning a finite closed form into a series limit via a crude squeeze, and provides a reusable reciprocal-telescoping lemma. The result is elementary; its value is a clean, axiom-free analytic companion to the parent gallery entry rather than a new mathematical contribution.",
+    "openQuestions": [
+      "Package the reciprocal telescoping as a general lemma ∑_{k=1}^{n} (b_k − b_{k+1}) → b_1 for any b_k → 0, and recover this series as the instance b_k = 1/k!.",
+      "Formalize the neighbouring exact-value series ∑_{k≥0} 1/k! = e and ∑_{k≥1} 1/(k·k!) style tails using the same 1/(n+1)! error control."
+    ]
+  },
+  "references": [
+    {
+      "key": "ConcreteMath",
+      "citation": "Graham, R.L., Knuth, D.E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), Ch. 2 (sums, telescoping, and infinite sums).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factorial-telescoping-sum-oq-01",
+      "relationship": "generalizes",
+      "description": "The parent finite identity ∑_{k=1}^{n} k·k! = (n+1)! − 1; this entry normalizes its telescoping step to ℝ and upgrades it to the series limit ∑_{k≥1} k/(k+1)! = 1."
+    },
+    {
+      "targetId": "legendre-factorial-formula-oq-01",
+      "relationship": "relatedTo",
+      "description": "A neighbouring factorial-arithmetic entry sharing the recurrence (n+1)! = (n+1)·n! that drives the reciprocal telescoping here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "FactorialTelescopingConverges",
+    "lineCount": 84,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FactorialTelescopingSumOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Factorial_number_system",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorialTelescopingSumOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "number-theory",
+      "factorial",
+      "telescoping",
+      "series",
+      "convergence",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — expands the factorial to prove the reciprocal telescoping identity",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "a ≤ b+1 → ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1) — peels the top term in the induction",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.self_le_factorial",
+        "description": "n ≤ n! — the crude factorial bound used to squeeze 1/(n+1)! ≤ 1/(n+1)",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0 — the comparison sequence for the squeeze establishing the tail → 0",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "squeeze_zero",
+        "description": "0 ≤ f ≤ g with g → 0 implies f → 0 — sends the tail 1/(n+1)! to 0",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "term_telescope: the normalized pointwise identity k/(k+1)! = 1/k! − 1/(k+1)! over ℝ, the analytic engine of the series",
+      "sum_Icc: the closed form ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!, exposing the exact convergence rate 1/(n+1)!",
+      "sum_lt_one: every partial sum is strictly below the limit 1 (tail positivity)",
+      "tendsto_one: convergence of the partial sums to 1, i.e. ∑_{k≥1} k/(k+1)! = 1, via a squeeze on the factorial tail"
+    ],
+    "axiomCount": 0,
+    "lineCount": 84,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for term_telescope, sum_Icc, sum_lt_one, and tendsto_one. Compiled against Mathlib v4.26.0. The result is elementary/classical; the formalization is built from primitives (factorial_succ, sum_Icc_succ_top, squeeze_zero) rather than wrapping a single named Mathlib lemma.",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "prerequisites": [
+      "The factorial recurrence (n+1)! = (n+1)·n! and the bound n ≤ n!",
+      "Finite sums over Finset.Icc and field arithmetic over ℝ",
+      "The squeeze theorem for sequences and the limit 1/(n+1) → 0"
+    ],
+    "relatedProblems": []
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry `factorial-telescoping-sum-oq-01-oq-01`, a follow-up to the parent finite identity `factorial-telescoping-sum-oq-01` (∑_{k=1}^{n} k·k! = (n+1)! − 1).

**Result.** Normalizing the parent's integer telescoping step by (k+1)! upgrades the finite ℕ identity into an analytic limit over ℝ:

- `term_telescope`: k/(k+1)! = 1/k! − 1/(k+1)!  (reciprocal telescoping)
- `sum_Icc`: ∑_{k=1}^{n} k/(k+1)! = 1 − 1/(n+1)!  (closed form; exact error 1/(n+1)!)
- `sum_lt_one`: every partial sum is strictly below 1
- `tendsto_one`: the partial sums converge to 1, i.e. ∑_{k≥1} k/(k+1)! = 1

**Why it's a genuine follow-up (not a cosmetic variant).** The parent is a finite ℕ statement; this is a *series convergence* result. The normalization is exactly what makes an infinite sum telescope, and it yields both the exact convergence rate (error = 1/(n+1)!) and the exact limit value 1.

**Proof.** Reciprocal telescoping (field_simp/ring) + induction (sum_Icc_succ_top) for the closed form; convergence via a crude squeeze 0 ≤ 1/(n+1)! ≤ 1/(n+1) → 0 (Nat.self_le_factorial + tendsto_one_div_add_atTop_nhds_zero_nat). No sharp growth estimate needed.

## Verification

- Builds against Mathlib v4.26.0 (host `lake env lean`, exit 0, 0 errors)
- `#print axioms` for all four theorems: `[propext, Classical.choice, Quot.sound]` — **0-axiom**, no `native_decide`, 0 sorries
- 4 theorems, 84 lines

## Files

- `proofs/Proofs/FactorialTelescopingSumOQ01OQ01.lean` (new)
- `src/data/proofs/factorial-telescoping-sum-oq-01-oq-01/{meta.json,index.ts,annotations.json}` (new)

Honest assessment: the result is elementary/classical; its value is a clean, axiom-free analytic companion to the parent entry, not a new mathematical contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)