### PR TITLE
Enrich cayley-hamilton-oq-01-oq-01-oq-01-oq-01: module-overview annotation (43%→84% coverage)

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,50 +1,121 @@
 [
   {
+    "id": "ann-ch01010101-overview",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Overview: Cyclic Vector ⟺ Non-Derogatory (Full Equivalence)",
+    "content": "For an n×n matrix M over a field K, view Kⁿ as a K[X]-module via M (the parent's Module.AEval' framework). A vector v is CYCLIC when no nonzero polynomial of degree < n annihilates it (IsCyclicVector). This entry completes a three-generation development: the parent proved the easy direction, the grandparent proved the converse existence direction (minpoly K M = charpoly → ∃ cyclic v), and this file supplies the missing FORWARD direction and assembles the full equivalence (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly ↔ (minpoly K M).natDegree = n. The forward argument is a clean degree squeeze: deg(minpoly) ≤ n always (minpoly ∣ charpoly by Cayley–Hamilton, deg(charpoly) = n), while deg(minpoly) ≥ n from cyclicity (the minimal polynomial annihilates every vector, in particular the cyclic v; a degree < n would force minpoly = 0, impossible for the minimal polynomial of an integral element). Equal degree + monic + divisibility gives minpoly = charpoly (Polynomial.eq_of_monic_of_dvd_of_natDegree_le). Fully machine-checked, 0 sorries, 0 extra axioms, reusing the grandparent's aeval_eq_zero_iff_mem_vecAnnIdeal bridge.",
+    "mathContext": "A matrix is non-derogatory iff its minimal and characteristic polynomials coincide, iff its rational canonical form is a single companion block, iff $K^n$ is a cyclic $K[X]$-module. The equivalence with the existence of a cyclic vector is the module-theoretic form of this classical fact.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic vector",
+      "non-derogatory matrix",
+      "minimal polynomial",
+      "characteristic polynomial",
+      "Cayley–Hamilton theorem",
+      "K[X]-module structure"
+    ],
+    "prerequisites": [
+      "minimal and characteristic polynomials",
+      "module over a polynomial ring",
+      "Cayley–Hamilton theorem"
+    ]
+  },
+  {
     "id": "ann-degree-squeeze",
     "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 68, "endLine": 91 },
+    "range": {
+      "startLine": 68,
+      "endLine": 91
+    },
     "type": "insight",
     "title": "The degree squeeze: deg(minpoly) = n from one cyclic vector",
     "content": "The crux theorem. The minimal polynomial's degree is squeezed to exactly n from two sides. Upper bound: M is integral (witnessed by its monic charpoly via Cayley–Hamilton), so minpoly ∣ charpoly (`minpoly.dvd`), and `natDegree_le_of_dvd` with `charpoly_natDegree_eq_dim` gives deg(minpoly) ≤ n. Lower bound: the minimal polynomial annihilates the cyclic vector v — established by `minpoly_mem_vecAnnIdeal` (parent) routed through the `aeval_eq_zero_iff_mem_vecAnnIdeal` bridge (grandparent) — so if deg(minpoly) were < n, the IsCyclicVector property (no nonzero low-degree annihilator) would force minpoly = 0, contradicting `minpoly.ne_zero`. `le_antisymm` then gives equality. No construction or counting — a single cyclic vector pins a global invariant.",
     "mathContext": "$\\deg(\\mu_M) \\le n$ from $\\mu_M \\mid \\chi_M,\\ \\deg \\chi_M = n$; $\\deg(\\mu_M) \\ge n$ since $\\mu_M$ annihilates the cyclic $v$ and $\\mu_M \\ne 0$.",
     "significance": "key",
-    "relatedConcepts": ["minimal polynomial", "characteristic polynomial", "Cayley–Hamilton", "cyclic vector", "annihilator ideal", "le_antisymm squeeze"],
-    "prerequisites": ["minpoly ∣ charpoly", "degree of polynomials", "the parent/grandparent vecAnnIdeal framework"]
+    "relatedConcepts": [
+      "minimal polynomial",
+      "characteristic polynomial",
+      "Cayley–Hamilton",
+      "cyclic vector",
+      "annihilator ideal",
+      "le_antisymm squeeze"
+    ],
+    "prerequisites": [
+      "minpoly ∣ charpoly",
+      "degree of polynomials",
+      "the parent/grandparent vecAnnIdeal framework"
+    ]
   },
   {
     "id": "ann-forward-equality",
     "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 95, "endLine": 107 },
+    "range": {
+      "startLine": 95,
+      "endLine": 107
+    },
     "type": "tactic",
     "title": "Forward direction: minpoly = charpoly from equal degree + divisibility",
     "content": "Upgrades the degree equality of Part I to polynomial equality. Both minpoly and charpoly are monic (minpoly via `minpoly.monic`, charpoly via `charpoly_monic`), and minpoly ∣ charpoly; with deg(charpoly) = n = deg(minpoly) the lemma `Polynomial.eq_of_monic_of_dvd_of_natDegree_le` forces them equal. The general principle: two monic polynomials with one dividing the other and equal degree must coincide, because the cofactor is a degree-0 monic, i.e. 1. The `.symm` orients the equation as minpoly = charpoly.",
     "mathContext": "Monic $p, q$ with $p \\mid q$ and $\\deg q \\le \\deg p \\Rightarrow p = q$; here $p = \\mu_M$, $q = \\chi_M$.",
     "significance": "key",
-    "relatedConcepts": ["monic polynomials", "divisibility forces equality", "non-derogatory matrix", "Polynomial.eq_of_monic_of_dvd_of_natDegree_le"],
-    "prerequisites": ["the degree-squeeze theorem above", "monic polynomial basics"]
+    "relatedConcepts": [
+      "monic polynomials",
+      "divisibility forces equality",
+      "non-derogatory matrix",
+      "Polynomial.eq_of_monic_of_dvd_of_natDegree_le"
+    ],
+    "prerequisites": [
+      "the degree-squeeze theorem above",
+      "monic polynomial basics"
+    ]
   },
   {
     "id": "ann-equivalence-main",
     "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 111, "endLine": 121 },
+    "range": {
+      "startLine": 111,
+      "endLine": 121
+    },
     "type": "insight",
     "title": "The full equivalence: cyclic vector ⟺ non-derogatory",
     "content": "Assembles the biconditional (∃ v, IsCyclicVector M v) ↔ minpoly K M = M.charpoly. The forward arrow destructures a cyclic vector and applies Part II; the reverse arrow is exactly the grandparent's `exists_cyclicVector_of_minpoly_eq_charpoly` (proved there via Mathlib's PID structure theorem). This is the single-companion-block case of the rational canonical form — a matrix is similar to the companion matrix of its characteristic polynomial precisely when it is non-derogatory.",
     "mathContext": "$(\\exists v,\\ \\mathrm{IsCyclicVector}\\,M\\,v) \\iff \\mu_M = \\chi_M$.",
     "significance": "key",
-    "relatedConcepts": ["rational canonical form", "companion matrix", "non-derogatory matrices", "biconditional assembly"],
-    "prerequisites": ["the forward direction (Parts I–II)", "the grandparent's reverse direction"]
+    "relatedConcepts": [
+      "rational canonical form",
+      "companion matrix",
+      "non-derogatory matrices",
+      "biconditional assembly"
+    ],
+    "prerequisites": [
+      "the forward direction (Parts I–II)",
+      "the grandparent's reverse direction"
+    ]
   },
   {
     "id": "ann-equivalence-degree",
     "proofId": "cayley-hamilton-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 123, "endLine": 131 },
+    "range": {
+      "startLine": 123,
+      "endLine": 131
+    },
     "type": "concept",
     "title": "Degree form of the equivalence",
     "content": "Restates the equivalence in terms of degree: (∃ v, IsCyclicVector M v) ↔ (minpoly K M).natDegree = n. This is the most directly usable form for downstream callers, since 'non-derogatory' is most often phrased as 'the minimal polynomial has full degree'. Forward via the Part I degree squeeze, reverse via the grandparent's `exists_cyclicVector_of_minpoly_natDegree_eq`.",
     "mathContext": "$(\\exists v,\\ \\mathrm{IsCyclicVector}\\,M\\,v) \\iff \\deg(\\mu_M) = n$.",
     "significance": "supporting",
-    "relatedConcepts": ["full-degree minimal polynomial", "non-derogatory criterion", "degree characterisation"],
-    "prerequisites": ["the main equivalence above"]
+    "relatedConcepts": [
+      "full-degree minimal polynomial",
+      "non-derogatory criterion",
+      "degree characterisation"
+    ],
+    "prerequisites": [
+      "the main equivalence above"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation covering the module docstring (lines 1-55), previously unannotated (annotations began at line 68). It frames the cyclic-vector ⟺ non-derogatory equivalence and the degree-squeeze forward direction. Annotations 4→5; no Lean source changes.

Label: enrichment