### PR TITLE
Enrich Cauchy Interlacing OQ-01-01 (compression = principal submatrix): coverage (38%→86%)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
@@ -1,62 +1,140 @@
 [
   {
+    "id": "ann-header-cauchyinterlacing-oq0101",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "The orthogonal compression to a coordinate hyperplane is the principal submatrix",
+    "content": "The header docstring poses the open question this file closes. The parent `CauchyInterlacingCompression.lean` builds the orthogonal compression `compress T H = P_H ∘ T ∘ ι_H` of a symmetric operator T to a codimension-one subspace H and proves its eigenvalues interlace those of T — but only ASSERTS (does not prove) that for a Hermitian matrix and a coordinate hyperplane the compression is exactly the principal submatrix obtained by deleting a row and column. This file proves that identification: viewing A as `toEuclideanLin A` on EuclideanSpace and taking H = span of the n standard basis vectors other than e_j, the sesquilinear form of the compression on the natural basis (e_{j.succAbove i}) equals A.submatrix j.succAbove j.succAbove entrywise. Two ingredients: (i) the orthogonal-projection adjoint identity collapsing the compression's inner product on H to T's on V (`inner_compress_eq`), and (ii) the entry formula ⟪e_a, toEuclideanLin A e_b⟫ = A a b. It also records that the principal submatrix stays Hermitian and that the hyperplane is genuinely n-dimensional, so the identification slots into `cauchy_interlacing_compression` to interlace the principal submatrix's eigenvalues. Holds over any RCLike field (ℝ and ℂ); absent from Mathlib.",
+    "mathContext": "$H = \\mathrm{span}_\\Bbbk\\{e_{\\hat\\jmath(i)} : i \\in \\mathrm{Fin}\\,n\\}$ (all standard basis vectors except $e_j$), and $\\langle e_{\\hat\\jmath(i')},\\, \\mathrm{compress}(\\hat A)\\,H\\, e_{\\hat\\jmath(i)}\\rangle = A(\\hat\\jmath(i'),\\hat\\jmath(i))$, i.e. the compression's Gram matrix is the principal submatrix $A[\\hat\\jmath,\\hat\\jmath]$ deleting row/column $j$. Cauchy interlacing then gives $\\lambda_k(A) \\le \\lambda_k(A[\\hat\\jmath,\\hat\\jmath]) \\le \\lambda_{k+1}(A)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Cauchy interlacing theorem",
+      "orthogonal compression",
+      "principal submatrix",
+      "Hermitian matrix",
+      "coordinate hyperplane",
+      "succAbove"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "Hermitian/self-adjoint operators",
+      "eigenvalue interlacing",
+      "EuclideanSpace"
+    ]
+  },
+  {
     "id": "ann-inner-compress-eq",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
-    "range": { "startLine": 64, "endLine": 70 },
+    "range": {
+      "startLine": 55,
+      "endLine": 70
+    },
     "type": "insight",
     "title": "The Compression's Inner Product Collapses to the Ambient One",
-    "content": "`inner_compress_eq`: for `y, z ∈ H`, `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`. The single rewrite `Submodule.inner_orthogonalProjection_eq_of_mem_left` does all the work: pairing the projected vector `P_H (T ↑z)` against `y`, which already lives in `H`, equals pairing `T ↑z` against `↑y`. The orthogonal projection is simply invisible to inner products with vectors of the subspace.",
+    "content": "`inner_compress_eq`: for `y, z ∈ H`, `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`. The single rewrite `Submodule.inner_orthogonalProjection_eq_of_mem_left` does all the work: pairing the projected vector `P_H (T ↑z)` against `y`, which already lives in `H`, equals pairing `T ↑z` against `↑y`. The orthogonal projection is simply invisible to inner products with vectors of the subspace. It also covers the self-contained definition `compress T H := P_H ∘ T ∘ ι_H` (orthogonal projection of T restricted to H) and its `@[simp]` unfolding lemma, reproduced here so the file does not depend on the parent's compression module.",
     "mathContext": "P_H is self-adjoint and fixes H pointwise, so ⟪y, P_H w⟫_H = ⟪↑y, w⟫_V for y ∈ H.",
     "significance": "key",
-    "relatedConcepts": ["orthogonal projection adjoint", "compression", "sesquilinear form"],
-    "prerequisites": ["inner product adjoint of orthogonal projection"]
+    "relatedConcepts": [
+      "orthogonal projection adjoint",
+      "compression",
+      "sesquilinear form"
+    ],
+    "prerequisites": [
+      "inner product adjoint of orthogonal projection"
+    ]
   },
   {
     "id": "ann-entry-inner",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
-    "range": { "startLine": 83, "endLine": 90 },
+    "range": {
+      "startLine": 77,
+      "endLine": 90
+    },
     "type": "insight",
     "title": "Matrix Entries Are Basis Inner Products",
-    "content": "`inner_single_toEuclideanLin_single`: `⟪e_a, (toEuclideanLin A) e_b⟫ = A a b`. `EuclideanSpace.inner_single_left` reads off coordinate `a` of the image, `Matrix.toEuclideanLin_apply` says the operator is matrix-vector multiplication, and `Matrix.mulVec_single_one` extracts the `b`-th column when the input is the standard basis vector `e_b`. The abstract operator identity becomes a one-line column lookup.",
+    "content": "`inner_single_toEuclideanLin_single`: `⟪e_a, (toEuclideanLin A) e_b⟫ = A a b`. `EuclideanSpace.inner_single_left` reads off coordinate `a` of the image, `Matrix.toEuclideanLin_apply` says the operator is matrix-vector multiplication, and `Matrix.mulVec_single_one` extracts the `b`-th column when the input is the standard basis vector `e_b`. The abstract operator identity becomes a one-line column lookup. It also covers the abbreviation `e a := EuclideanSpace.single a 1` for the standard basis vector.",
     "mathContext": "⟪e_a, A e_b⟫ = (A·e_b)_a = (column b of A)_a = A_{a b}.",
     "significance": "key",
-    "relatedConcepts": ["standard basis", "matrix-vector multiplication", "toEuclideanLin"],
-    "prerequisites": ["EuclideanSpace coordinates", "column of a matrix"]
+    "relatedConcepts": [
+      "standard basis",
+      "matrix-vector multiplication",
+      "toEuclideanLin"
+    ],
+    "prerequisites": [
+      "EuclideanSpace coordinates",
+      "column of a matrix"
+    ]
   },
   {
     "id": "ann-coordinate-hyperplane",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
-    "range": { "startLine": 100, "endLine": 113 },
+    "range": {
+      "startLine": 93,
+      "endLine": 113
+    },
     "type": "definition",
     "title": "The Coordinate Hyperplane",
-    "content": "`coordinateHyperplane j = span 𝕜 { e_{j.succAbove i} : i : Fin n }`: the span of every standard basis vector except `e_j`. `Fin.succAbove j` is the order-preserving injection `Fin n ↪ Fin (n+1)` that skips `j`, so this is exactly the codimension-one coordinate subspace `{x : x_j = 0}`. `finrank_coordinateHyperplane` confirms its dimension is `n`, because the spanning family is an orthonormal sub-family of the standard basis and hence linearly independent.",
+    "content": "`coordinateHyperplane j = span 𝕜 { e_{j.succAbove i} : i : Fin n }`: the span of every standard basis vector except `e_j`. `Fin.succAbove j` is the order-preserving injection `Fin n ↪ Fin (n+1)` that skips `j`, so this is exactly the codimension-one coordinate subspace `{x : x_j = 0}`. `finrank_coordinateHyperplane` confirms its dimension is `n`, because the spanning family is an orthonormal sub-family of the standard basis and hence linearly independent. The covered lines also include `def coordinateHyperplane j := span 𝕜 {e_{j.succAbove i}}` (the span of every standard basis vector except e_j), the membership lemma `mem_coordinateHyperplane`, and `def hyperplaneBasis` (the natural orthonormal basis of H as subspace elements).",
     "mathContext": "H = {x ∈ 𝕜^{n+1} : x_j = 0}, an n-dimensional coordinate hyperplane.",
     "significance": "key",
-    "relatedConcepts": ["coordinate subspace", "Fin.succAbove", "orthonormal family", "finrank of a span"],
-    "prerequisites": ["span and finrank", "orthonormal implies linearly independent"]
+    "relatedConcepts": [
+      "coordinate subspace",
+      "Fin.succAbove",
+      "orthonormal family",
+      "finrank of a span"
+    ],
+    "prerequisites": [
+      "span and finrank",
+      "orthonormal implies linearly independent"
+    ]
   },
   {
     "id": "ann-identification",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
-    "range": { "startLine": 115, "endLine": 130 },
+    "range": {
+      "startLine": 115,
+      "endLine": 130
+    },
     "type": "theorem",
     "title": "Compression Equals Principal Submatrix",
     "content": "`compress_inner_eq_principalSubmatrix`: `⟪e_{j.succAbove i'}, compress (toEuclideanLin A) H e_{j.succAbove i}⟫ = (A.submatrix j.succAbove j.succAbove) i' i`. One rewrite by `inner_compress_eq` reduces the compression's form to the ambient form `⟪e_{j.succAbove i'}, A e_{j.succAbove i}⟫`, which the entry lemma evaluates to `A (j.succAbove i') (j.succAbove i)` — definitionally the principal-submatrix entry. This is the textbook identification the parent file only asserted.",
     "mathContext": "The matrix of the compression in the coordinate basis of H is precisely A with row j and column j deleted.",
     "significance": "key",
-    "relatedConcepts": ["principal submatrix", "compression", "Cauchy interlacing"],
-    "prerequisites": ["Matrix.submatrix", "the two ingredient lemmas above"]
+    "relatedConcepts": [
+      "principal submatrix",
+      "compression",
+      "Cauchy interlacing"
+    ],
+    "prerequisites": [
+      "Matrix.submatrix",
+      "the two ingredient lemmas above"
+    ]
   },
   {
     "id": "ann-finrank-hyperplane",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
-    "range": { "startLine": 132, "endLine": 141 },
+    "range": {
+      "startLine": 132,
+      "endLine": 141
+    },
     "type": "theorem",
     "title": "The Hyperplane Really Is n-Dimensional",
     "content": "`finrank_coordinateHyperplane`: `Module.finrank 𝕜 (coordinateHyperplane j) = n`. Interlacing via `cauchy_interlacing_compression` only applies to a genuine codimension-one subspace, so this dimension count is not bookkeeping — it certifies the hypothesis. The argument is a clean chain: `EuclideanSpace.orthonormal_single` gives that the full standard basis `(e_a)_{a : Fin (n+1)}` is orthonormal; `Orthonormal.comp` along the *injective* deletion map `Fin.succAbove_right_injective` restricts it to the orthonormal sub-family `(e_{j.succAbove i})_{i : Fin n}`; `Orthonormal.linearIndependent` upgrades orthonormality to linear independence; and `finrank_span_eq_card` reads the dimension of the span off the cardinality `Fintype.card (Fin n) = n`. Injectivity of `succAbove` is load-bearing — orthonormality is preserved under composition only with an injection, and it is exactly what keeps the deleted index `j` from collapsing the family.",
     "mathContext": "An orthonormal sub-family of size n spans an n-dimensional subspace: dim span{e_{j◁i} : i ∈ Fin n} = |Fin n| = n.",
     "significance": "supporting",
-    "relatedConcepts": ["orthonormal family", "linear independence", "finrank of a span", "Fin.succAbove injectivity"],
-    "prerequisites": ["Orthonormal.comp and Orthonormal.linearIndependent", "finrank_span_eq_card"]
+    "relatedConcepts": [
+      "orthonormal family",
+      "linear independence",
+      "finrank of a span",
+      "Fin.succAbove injectivity"
+    ],
+    "prerequisites": [
+      "Orthonormal.comp and Orthonormal.linearIndependent",
+      "finrank_span_eq_card"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-01-oq-01`. The 5 existing annotations were deep but the 47-line header docstring and the `compress`/`e`/`coordinateHyperplane` definitions were unannotated — coverage 38% of 145 lines.

**Changes (annotations.json):**
- Added a header annotation (1-47) explaining how this file discharges the parent's open assertion that the orthogonal compression to a coordinate hyperplane equals the principal submatrix deleting row/column j.
- Extended 3 theorem annotations down to their `/--` docstrings so they also cover the preceding definitions (anchored at construct lines, not `section`/`variable`, to satisfy the annotation resolver).
- Coverage **38% → 86%**; all annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

meta.json unchanged.