### PR TITLE
Enrich ballot-problem-oq-04-oq-01: module-overview annotation (48%→78% coverage)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-bp0401-overview",
+    "proofId": "ballot-problem-oq-04-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 20
+    },
+    "type": "concept",
+    "title": "Overview: The n = 4 Discriminator — the Unique Crossing Partition",
+    "content": "The parent entry ballot-problem-oq-04 formalizes the predicate IsNonCrossing on partitions of Fin n and proves every partition with n ≤ 3 is non-crossing. Its open questions note that the non-crossing count first DISCRIMINATES from the Bell number at n = 4: of the B₄ = 15 partitions of a 4-element set, exactly one is a genuine crossing, leaving catalan 4 = 14 non-crossing ones. This file exhibits that unique crossing partition explicitly and proves it crosses, giving the n = 4 discriminator a concrete, verified witness (0 sorry, 0 axiom). The crossing partition {{0,2},{1,3}} of Fin 4 is exactly the SAME-PARITY equivalence relation: 0,2 are the even points and 1,3 the odd points. Its two blocks interleave — 0 < 1 < 2 < 3 with 0 ~ 2 and 1 ~ 3 but ¬ 0 ~ 1 — precisely the forbidden configuration of IsNonCrossing.",
+    "mathContext": "Non-crossing partitions of $\\{1,\\dots,n\\}$ are counted by the Catalan number $C_n$, strictly below the Bell number $B_n$ for $n\\ge 4$ ($C_4=14 < 15 = B_4$). The single crossing partition at $n=4$ is $\\{\\{0,2\\},\\{1,3\\}\\}$, whose blocks interleave in the cyclic/linear order.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-crossing partition",
+      "Catalan numbers",
+      "Bell numbers",
+      "crossing configuration",
+      "ballot problem"
+    ],
+    "prerequisites": [
+      "set partitions",
+      "equivalence relations",
+      "Catalan and Bell numbers"
+    ]
+  },
+  {
     "id": "ann-crossing4-def",
     "proofId": "ballot-problem-oq-04-oq-01",
     "range": {
@@ -11,8 +36,16 @@
     "content": "crossing4 is defined as Setoid.ker (fun x : Fin 4 => x.val % 2) — the same-parity equivalence relation on Fin 4. Its even block is {0, 2} and its odd block is {1, 3}: this is the partition pairing opposite vertices of a square, the diagonal partition whose blocks must cross. Realizing it as the kernel of the parity map is the key modelling choice: it turns every membership question into a decidable arithmetic fact about x.val % 2, so the entire discriminator can be proved by decide with no manual case analysis.",
     "mathContext": "$\\mathrm{crossing4} = \\ker\\big(x \\mapsto x \\bmod 2\\big),\\quad \\text{blocks } \\{0,2\\},\\ \\{1,3\\}$",
     "significance": "key",
-    "relatedConcepts": ["non-crossing partitions", "Setoid.ker", "equivalence relation", "Catalan numbers"],
-    "prerequisites": ["Setoid and equivalence kernels", "the parent predicate IsNonCrossing (ballot-problem-oq-04)"]
+    "relatedConcepts": [
+      "non-crossing partitions",
+      "Setoid.ker",
+      "equivalence relation",
+      "Catalan numbers"
+    ],
+    "prerequisites": [
+      "Setoid and equivalence kernels",
+      "the parent predicate IsNonCrossing (ballot-problem-oq-04)"
+    ]
   },
   {
     "id": "ann-crossing4-iff",
@@ -26,8 +59,16 @@
     "content": "crossing4_iff records that crossing4 x y ↔ x.val % 2 = y.val % 2, and the proof is literally Iff.rfl: because crossing4 is a kernel Setoid, its relation unfolds definitionally to equality of the parity values. This definitional transparency is what lets every downstream fact be discharged by decide — no rewriting or unfolding lemmas are needed, the relation already IS the decidable proposition x.val % 2 = y.val % 2.",
     "mathContext": "$x \\sim y \\iff x \\bmod 2 = y \\bmod 2$",
     "significance": "supporting",
-    "relatedConcepts": ["definitional equality", "Iff.rfl", "decidable propositions", "kernel relation"],
-    "prerequisites": ["Setoid.ker unfolds to equality of images", "definitional reduction"]
+    "relatedConcepts": [
+      "definitional equality",
+      "Iff.rfl",
+      "decidable propositions",
+      "kernel relation"
+    ],
+    "prerequisites": [
+      "Setoid.ker unfolds to equality of images",
+      "definitional reduction"
+    ]
   },
   {
     "id": "ann-crossing4-blocks",
@@ -41,8 +82,16 @@
     "content": "crossing4_blocks exhibits the structure that makes the partition cross: the outer pair 0 ~ 2 and the inner pair 1 ~ 3 are each related (same parity), but they live in different blocks (¬ 0 ~ 1). Each of the three facts is discharged by decide, using show to expose the underlying kernel equality form (0).val % 2 = (2).val % 2 etc. so the decidable Nat-equality instance applies. The geometric content: reading 0 < 1 < 2 < 3 around the circle, the chord {0,2} and the chord {1,3} interleave and therefore must cross.",
     "mathContext": "$0 \\sim 2,\\quad 1 \\sim 3,\\quad \\neg\\,(0 \\sim 1)$",
     "significance": "key",
-    "relatedConcepts": ["interleaving chords", "decide tactic", "parity", "crossing condition"],
-    "prerequisites": ["decidability of Nat/Fin equality", "the show tactic to expose definitional forms"]
+    "relatedConcepts": [
+      "interleaving chords",
+      "decide tactic",
+      "parity",
+      "crossing condition"
+    ],
+    "prerequisites": [
+      "decidability of Nat/Fin equality",
+      "the show tactic to expose definitional forms"
+    ]
   },
   {
     "id": "ann-not-isnoncrossing",
@@ -56,8 +105,16 @@
     "content": "not_isNonCrossing_crossing4 proves the same-parity partition is not non-crossing. The parent's IsNonCrossing requires that any quadruple a < b < c < d with a ~ c and b ~ d must also have a ~ b; applying this hypothesis to 0 < 1 < 2 < 3 with 0 ~ 2 and 1 ~ 3 forces 0 ~ 1, contradicting crossing4_blocks. This is the unique crossing partition of Fin 4 — the single partition separating the Bell number B₄ = 15 from catalan 4 = 14, the smallest witness that non-crossing partitions are strictly fewer than all partitions.",
     "mathContext": "$\\neg\\,\\mathrm{IsNonCrossing}\\ \\mathrm{crossing4};\\qquad B_4 = 15,\\ C_4 = 14,\\ 15 - 14 = 1$",
     "significance": "key",
-    "relatedConcepts": ["Bell numbers", "Catalan numbers", "proof by contradiction", "non-crossing predicate"],
-    "prerequisites": ["the parent's IsNonCrossing definition", "Bell number B₄ = 15 and catalan 4 = 14"]
+    "relatedConcepts": [
+      "Bell numbers",
+      "Catalan numbers",
+      "proof by contradiction",
+      "non-crossing predicate"
+    ],
+    "prerequisites": [
+      "the parent's IsNonCrossing definition",
+      "Bell number B₄ = 15 and catalan 4 = 14"
+    ]
   },
   {
     "id": "ann-has-crossing",
@@ -71,7 +128,15 @@
     "content": "crossing4_has_crossing repackages the contradiction as the explicit existential ∃ a b c d, a < b ∧ b < c ∧ c < d ∧ a ~ c ∧ b ~ d ∧ ¬ a ~ b — exactly the configuration negated in the parent's isNonCrossing_iff reformulation. Supplying the witness (0, 1, 2, 3) with the order facts by decide and the relation facts from crossing4_blocks certifies the crossing positively, matching the parent's 'a partition is non-crossing iff it contains no such quadruple'. Having both the negation form and the existential form lets either parent lemma be applied directly downstream.",
     "mathContext": "$\\exists\\,a<b<c<d:\\ a \\sim c \\,\\land\\, b \\sim d \\,\\land\\, \\neg\\,(a \\sim b)$",
     "significance": "supporting",
-    "relatedConcepts": ["existential witness", "isNonCrossing_iff", "non-crossing partitions", "ballot problem"],
-    "prerequisites": ["the parent's isNonCrossing_iff reformulation", "constructing existential witnesses"]
+    "relatedConcepts": [
+      "existential witness",
+      "isNonCrossing_iff",
+      "non-crossing partitions",
+      "ballot problem"
+    ],
+    "prerequisites": [
+      "the parent's isNonCrossing_iff reformulation",
+      "constructing existential witnesses"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 3-20), previously unannotated. Frames the n=4 discriminator: the unique crossing partition {{0,2},{1,3}} (same-parity relation) witnessing C₄=14 < B₄=15. Annotations 5→6; no Lean source changes.

Label: enrichment