### PR TITLE
Enrich algebraic-reals-meager-dense-gdelta-oq-02: module-overview annotation (48%→84% coverage)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-02/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-02/annotations.json
@@ -1,50 +1,116 @@
 [
   {
+    "id": "ann-armdg02-overview",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-02",
+    "range": {
+      "startLine": 9,
+      "endLine": 53
+    },
+    "type": "concept",
+    "title": "Overview: A Fully Constructive Transcendental Gδ",
+    "content": "The parent entry proves the transcendental reals form a dense Gδ, but only ABSTRACTLY: the IsGδ witness comes from IsGδ.biInter_of_isOpen over the family of complements {a}ᶜ ranging over all algebraic reals, handing you no honest enumerable sequence. This entry answers the second open question — make it fully constructive via an explicit DECREASING sequence of dense open sets Uₙ whose intersection is exactly the transcendentals. Fix any enumeration algEnum : ℕ → ℝ of the countable, nonempty algebraic reals and set U n := (algEnum '' Set.Iic n)ᶜ (ℝ minus the first n+1 enumerated algebraics). Each U n is OPEN (finite sets are closed in the T1 space ℝ), DENSE (ℝ is a perfect Baire space, so the complement of any finite set is dense), and DECREASING (Set.Iic is monotone). Their intersection ⋂ n, U n strips out every enumerated algebraic, leaving exactly {x | ¬ IsAlgebraic ℚ x}. This upgrades the parent's bare IsGδ witness to a concrete antitone basis and re-derives the Gδ property directly.",
+    "mathContext": "A $G_\\delta$ set is a countable intersection of open sets. The transcendentals $= \\bigcap_n U_n$ with $U_n = (\\text{first } n{+}1 \\text{ algebraics})^c$, each open (finite complement) and dense (Baire), give an explicit antitone $G_\\delta$ presentation, refining the abstract existence proof.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gδ set",
+      "Baire category",
+      "transcendental numbers",
+      "dense open sets",
+      "countable set"
+    ],
+    "prerequisites": [
+      "Baire category theorem",
+      "Gδ sets",
+      "countability of the algebraic numbers"
+    ]
+  },
+  {
     "id": "ann-armdg-oq02-algenum",
     "proofId": "algebraic-reals-meager-dense-gdelta-oq-02",
-    "range": { "startLine": 64, "endLine": 76 },
+    "range": {
+      "startLine": 64,
+      "endLine": 76
+    },
     "type": "definition",
     "title": "An honest enumeration of the algebraic reals",
     "content": "The constructive ingredient the parent's argument never produces. The algebraic reals are countable (Algebraic.countable) and nonempty (0 is algebraic), so Set.Countable.exists_eq_range hands us a sequence algEnum : ℕ → ℝ whose range is exactly {x | IsAlgebraic ℚ x}. Everything downstream is built by removing finite initial segments of this single sequence.",
     "mathContext": "$\\exists\\, e : \\mathbb{N} \\to \\mathbb{R},\\ \\{x : \\mathbb{R} \\mid x\\ \\text{algebraic}/\\mathbb{Q}\\} = \\operatorname{range} e$.",
     "significance": "key",
-    "relatedConcepts": ["countable set", "enumeration", "algebraic numbers"],
-    "prerequisites": ["countability", "algebraic numbers"]
+    "relatedConcepts": [
+      "countable set",
+      "enumeration",
+      "algebraic numbers"
+    ],
+    "prerequisites": [
+      "countability",
+      "algebraic numbers"
+    ]
   },
   {
     "id": "ann-armdg-oq02-sequence",
     "proofId": "algebraic-reals-meager-dense-gdelta-oq-02",
-    "range": { "startLine": 78, "endLine": 95 },
+    "range": {
+      "startLine": 78,
+      "endLine": 95
+    },
     "type": "insight",
     "title": "U n = ℝ minus the first n+1 algebraics — open, dense, decreasing",
     "content": "U n removes the finite set algEnum '' Set.Iic n. Finite ⟹ closed in the T1 space ℝ ⟹ U n open. Finite ⟹ countable, and ℝ is a perfect Baire space, so its complement is dense (the parent's dense_compl_of_countable). Because Set.Iic n grows with n, the removed sets grow and the U n shrink — Antitone U. These are exactly the three hypotheses a Baire-category argument feeds to a countable sequence.",
     "mathContext": "$U_n = (e[\\,\\{0,\\dots,n\\}\\,])^c$; each $U_n$ open and dense, $U_{n+1} \\subseteq U_n$.",
     "significance": "key",
-    "relatedConcepts": ["Gδ set", "dense open set", "Baire category", "T1 space"],
-    "prerequisites": ["point-set topology", "Baire category theorem"]
+    "relatedConcepts": [
+      "Gδ set",
+      "dense open set",
+      "Baire category",
+      "T1 space"
+    ],
+    "prerequisites": [
+      "point-set topology",
+      "Baire category theorem"
+    ]
   },
   {
     "id": "ann-armdg-oq02-intersection",
     "proofId": "algebraic-reals-meager-dense-gdelta-oq-02",
-    "range": { "startLine": 97, "endLine": 110 },
+    "range": {
+      "startLine": 97,
+      "endLine": 110
+    },
     "type": "insight",
     "title": "The intersection is exactly the transcendentals",
     "content": "The headline. ⋃ n, algEnum '' Set.Iic n collapses to the whole range of algEnum: Set.image_iUnion pulls the union inside the image, and ⋃ n, Set.Iic n = univ because every k lies in Set.Iic k. That range is the algebraic reals, so De Morgan (Set.compl_iUnion) gives ⋂ n, U n = {x | IsAlgebraic ℚ x}ᶜ = {x | ¬ IsAlgebraic ℚ x}. Stage k deletes algEnum k and nothing survives that is algebraic.",
     "mathContext": "$\\bigcap_n U_n = \\Big(\\bigcup_n e[\\{0,\\dots,n\\}]\\Big)^c = (\\operatorname{range} e)^c = \\{x \\mid x\\ \\text{transcendental}\\}$.",
     "significance": "key",
-    "relatedConcepts": ["De Morgan laws", "transcendental numbers", "countable intersection"],
-    "prerequisites": ["De Morgan laws for sets", "image of a union"]
+    "relatedConcepts": [
+      "De Morgan laws",
+      "transcendental numbers",
+      "countable intersection"
+    ],
+    "prerequisites": [
+      "De Morgan laws for sets",
+      "image of a union"
+    ]
   },
   {
     "id": "ann-armdg-oq02-constructive-gdelta",
     "proofId": "algebraic-reals-meager-dense-gdelta-oq-02",
-    "range": { "startLine": 112, "endLine": 128 },
+    "range": {
+      "startLine": 112,
+      "endLine": 128
+    },
     "type": "insight",
     "title": "Re-deriving the transcendental Gδ from the explicit sequence",
     "content": "Where the parent invokes IsGδ.biInter_of_isOpen over the uncountable-looking family of all singleton complements, here the Gδ property falls straight out of the explicit ℕ-indexed open sequence: IsGδ.iInter_of_isOpen U_isOpen gives IsGδ (⋂ n, U n), which iInter_U identifies with the transcendentals. The packaged transcendentalReals_constructive_dense_Gδ bundles openness, density, monotonicity and the intersection identity — the fully constructive form of the parent's existence statement.",
     "mathContext": "$\\bigcap_n U_n$ with each $U_n$ open $\\Rightarrow$ the transcendentals are $G_\\delta$ (constructively).",
     "significance": "key",
-    "relatedConcepts": ["Gδ set", "countable intersection of open sets", "constructive proof"],
-    "prerequisites": ["Gδ sets", "Baire category"]
+    "relatedConcepts": [
+      "Gδ set",
+      "countable intersection of open sets",
+      "constructive proof"
+    ],
+    "prerequisites": [
+      "Gδ sets",
+      "Baire category"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 9-53), previously unannotated. Frames the constructive transcendental Gδ: explicit decreasing dense-open sequence Uₙ = (first n+1 algebraics)ᶜ with ⋂ Uₙ = transcendentals. Annotations 4→5; no Lean source changes.

Label: enrichment