### PR TITLE
Fix: correct stale 'minimality is open' header in AbundantNumberOQ02OQ01.lean

### DIFF
--- a/proofs/Proofs/AbundantNumberOQ02OQ01.lean
+++ b/proofs/Proofs/AbundantNumberOQ02OQ01.lean
@@ -16,8 +16,8 @@
   an abundance margin of only 16486750 (the ratio σ(n)/n ≈ 2.00306 barely
   clears 2 — odd numbers coprime to 3 are "only just" abundant).
 
-  What this file proves (the **witness / membership** half of the open
-  question).  We establish, axiom-free, that 5391411025 genuinely is
+  What this file proves (the **witness / membership** half of the full
+  resolution).  We establish, axiom-free, that 5391411025 genuinely is
 
     * odd,
     * not divisible by 3, and
@@ -35,14 +35,26 @@
   σ(29)`, each of which *is* a trivial divisor-sum computation.  No
   `native_decide` is used, so the result carries no `Lean.ofReduceBool`.
 
-  What is NOT proved (the genuine blocker).  The *minimality* half — that no odd
-  `m < 5391411025` coprime to 3 is abundant — is a bounded statement over a range
-  of ~5.4 billion.  This is far beyond any kernel or compiled enumeration
-  (the `sigmaFast` O(n)-per-number kernel reduction used for the 945 bound would
-  require ~10¹⁹ kernel operations here).  A genuine proof needs the structural
-  number theory of abundancy (density / Erdős-style sieve arguments on the
-  abundancy index of 3-free odd integers), not brute force.  It is recorded as
-  an open follow-up rather than attempted by enumeration.
+  The *minimality* half (the lower bound).  That no odd `m < 5391411025`
+  coprime to 3 is abundant is a bounded statement over a range of ~5.4 billion,
+  far beyond any kernel or compiled enumeration (the `sigmaFast` O(n)-per-number
+  kernel reduction used for the 945 bound would require ~10¹⁹ kernel operations
+  here).  It is therefore proved *structurally* rather than by brute force, and
+  now lives in the companion files accompanying this one:
+
+    * `…SevenPrimeExponents.lean` assembles the capstone
+      `odd_abundant_coprime_three_ge_witness : Odd n → ¬ 3 ∣ n → Abundant n →
+      5391411025 ≤ n` from three exhaustive shapes for an odd abundant `n`
+      coprime to 3 lying below the witness;
+    * `…GeneralBound.lean`, `…Squarefree.lean`, `…OmegaSevenPrimes.lean` and the
+      other companions dispatch the squarefree, `ω(n) ≥ 8`, and residual
+      `ω(n) = 7` cases via the abundancy-index / prime-exponent structural
+      argument (no enumeration).
+
+  Combined with the membership certificate below, this establishes that
+  5391411025 is *exactly* the least odd abundant number coprime to 3.  All nine
+  files are axiom-free (foundational axioms only; no `native_decide`, no
+  `sorryAx`).  This file itself contributes only the witness / membership half.
 -/
 import Mathlib
 
@@ -101,7 +113,8 @@ theorem not_three_dvd_N : ¬ (3 ∣ N) := by decide
 
 /-- **Membership / upper-bound certificate.**  5391411025 is an odd abundant
 number coprime to 3, hence belongs to the set whose least element the open
-question identifies.  (Minimality is the open half; see the file header.) -/
+question identifies.  (Minimality — the matching lower bound — is proved in the
+companion files; see the file header.) -/
 theorem mem_odd_three_free_abundant :
     N ∈ {n : ℕ | Odd n ∧ ¬ (3 ∣ n) ∧ Nat.Abundant n} :=
   ⟨odd_N, not_three_dvd_N, abundant_N⟩


### PR DESCRIPTION
## Fix

The primary Lean file for `abundant-number-oq-02-oq-01` (linked from the gallery) had a stale docstring header claiming minimality was an unproved open follow-up. That paragraph predates the 8 companion files that now prove minimality.

## Evidence

**Before**: `proofs/Proofs/AbundantNumberOQ02OQ01.lean` header said:
> What is NOT proved (the genuine blocker). The *minimality* half ... is recorded as an open follow-up rather than attempted by enumeration.

**After**: header explains minimality (the lower bound) is proved *structurally* in the companion files — capstone `odd_abundant_coprime_three_ge_witness : Odd n → ¬ 3 ∣ n → Abundant n → 5391411025 ≤ n` (`…SevenPrimeExponents.lean`), assembled from the squarefree / `ω(n) ≥ 8` / residual `ω(n) = 7` cases — so 5391411025 is *exactly* the least odd abundant number coprime to 3.

Verified the capstone exists and is axiom-free (foundational axioms only; no `native_decide`, no `sorryAx`) across all nine files; `meta.json` already accurately claims full resolution (`status: verified`, `sorries: 0`, `axiomCount: 0`). This edit removes the internal inconsistency between the (accurate) gallery entry and the (stale) linked source.

Also updated the matching inline remark on `mem_odd_three_free_abundant`.

**Comment-only change** — all edits are inside `/- -/` docstrings; no rebuild-affecting change.

Closes #33252

---
Automated fix by lean-mechanic agent.