### PR TITLE
Fix schur-lemma-oq-01-02 annotation anchoring (section → docstring)

### DIFF
--- a/src/data/proofs/schur-lemma-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/schur-lemma-oq-01-oq-02/annotations.json
@@ -126,7 +126,7 @@
     "id": "ann-abelian-group",
     "proofId": "schur-lemma-oq-01-oq-02",
     "range": {
-      "startLine": 135,
+      "startLine": 145,
       "endLine": 152
     },
     "type": "concept",
@@ -150,7 +150,7 @@
     "id": "ann-complex-case",
     "proofId": "schur-lemma-oq-01-oq-02",
     "range": {
-      "startLine": 155,
+      "startLine": 164,
       "endLine": 169
     },
     "type": "insight",


### PR DESCRIPTION
Follow-up to #33249. Two annotations (`ann-irreducible-rep-abelian`, `ann-headline-complex`) were anchored at `section` lines (135, 155), which the annotation resolver rejects with "No Lean construct found" (only `import`/`namespace`/doc-comment/declaration lines are valid anchors). This reverts their `startLine` to the theorem `/--` docstring lines (145, 164), leaving the `section`/`variable` setup uncovered as intended. No content change; removes 2 resolver warnings.