### PR TITLE
Enrich schroeder-bernstein-oq-05: module-overview annotation (54%→80% coverage)

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-05/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-05/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-sb05-overview",
+    "proofId": "schroeder-bernstein-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 20
+    },
+    "type": "concept",
+    "title": "Overview: Dual Schröder–Bernstein — Mutual Surjections Imply Equinumerosity",
+    "content": "This entry proves the DUAL of the classical Cantor–Schröder–Bernstein theorem: if there exist surjections f : A ↠ B and g : B ↠ A, then A and B are equinumerous (there is a bijection A ≃ B). Whereas the injective form (mutual injections ⇒ bijection, proved in the parent SchroederBernstein.lean) is choice-free, the surjective form genuinely uses the Axiom of Choice: each surjection is split by a right inverse, which is an injection, and the classical Schröder–Bernstein theorem is then applied to the two resulting injections. In fact the dual statement for arbitrary sets is EQUIVALENT to AC; here the forward implication is formalized under Mathlib's ambient choice. Everything is a genuine theorem/def with a real proof — no sorry, no custom axioms beyond Lean/Mathlib's standard propext/Classical.choice/Quot.sound.",
+    "mathContext": "A surjection $f:A\\to B$ admits a right inverse $f':B\\to A$ (a section) by choice, and any section is injective. Splitting both surjections yields injections in both directions, so Cantor–Schröder–Bernstein produces a bijection $A\\simeq B$. The reliance on sections is why the dual form, unlike the injective form, needs the Axiom of Choice.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Schröder–Bernstein theorem",
+      "axiom of choice",
+      "surjection and section",
+      "equinumerosity",
+      "cardinality"
+    ],
+    "prerequisites": [
+      "cardinality and bijections",
+      "axiom of choice",
+      "Cantor–Schröder–Bernstein theorem"
+    ]
+  },
+  {
     "id": "ann-cbs-oq05-section",
     "proofId": "schroeder-bernstein-oq-05",
     "range": {


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 1-20), previously unannotated. Frames the dual Schröder–Bernstein (mutual surjections ⇒ bijection) and its genuine reliance on the Axiom of Choice. Annotations 4→5; no Lean source changes.

Label: enrichment