### PR TITLE
Enrich cauchy-interlacing-theorem-oq-01-oq-02: module-overview annotation (54%→83% coverage)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
@@ -1,50 +1,121 @@
 [
   {
+    "id": "ann-cit0102-overview",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Overview: Poincaré Separation, Self-Contained via Explicit Orthogonal Compression",
+    "content": "Two earlier research files leave a deliberate seam: CauchyInterlacingPoincare.lean proves the ABSTRACT Poincaré separation theorem — for a codimension-m compression (dim V = n+m, dim H = n) the descending eigenvalues separate as λ⟨k+m⟩ ≤ μ k ≤ λ⟨k⟩ — but it takes the compression operator T_H on H, its spectral data, AND the Rayleigh-agreement hypothesis as INPUTS. This entry closes that seam by constructing the compression explicitly via the orthogonal projection onto the subspace H, discharging the abstract theorem's hypotheses from concrete data so the separation inequalities hold self-contained. It also recovers the classical codimension-one Cauchy interlacing statement as the special case m = 1. The result assembles the abstract Poincaré framework with an honest, verified compression, giving the gallery a standalone form of the eigenvalue interlacing theorem.",
+    "mathContext": "For a Hermitian operator on $V$ and a subspace $H$ of codimension $m$, the eigenvalues $\\mu_k$ of the compression $P_H T P_H|_H$ interlace those $\\lambda_k$ of $T$: $\\lambda_{k+m}\\le \\mu_k \\le \\lambda_k$ (descending order). Cauchy interlacing is the $m=1$ case. The compression is realized here through the explicit orthogonal projection onto $H$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Poincaré separation theorem",
+      "Cauchy interlacing",
+      "eigenvalue interlacing",
+      "orthogonal compression",
+      "Rayleigh quotient",
+      "Hermitian operator"
+    ],
+    "prerequisites": [
+      "spectral theorem for Hermitian operators",
+      "orthogonal projections",
+      "min-max characterization of eigenvalues"
+    ]
+  },
+  {
     "id": "ann-setup-imports-seam",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
-    "range": { "startLine": 49, "endLine": 55 },
+    "range": {
+      "startLine": 49,
+      "endLine": 55
+    },
     "type": "concept",
     "title": "Setup: Joining the Two Gallery Files Across a Deliberate Seam",
     "content": "The two imports are the load-bearing ones: `Proofs.CauchyInterlacingPoincare` supplies the abstract codimension-m separation inequality `poincare_separation` (which takes the compression and its Rayleigh-agreement hypothesis as inputs), and `Proofs.CauchyInterlacingCompression` supplies the explicit orthogonal compression `compress T H := P_H ∘ T ∘ ι_H` together with `isSymmetric_compress` and `rayleigh_compress_eq` (which discharge that hypothesis). Opening both namespaces brings every ingredient into scope so the join is a single application with no new spectral lemmas. The `variable` block fixes an arbitrary finite-dimensional inner product space `V` over `𝕜 : RCLike` (real or complex); the dimension split `finrank V = n + m` and `finrank H = n` is introduced per-theorem rather than globally, since the codimension `m` is what varies across the three results.",
     "mathContext": "Abstract Poincaré (compression abstracted away) + explicit compression (codimension abstracted away) ⟹ both the Rayleigh hypothesis and the codimension restriction vanish.",
     "significance": "supporting",
-    "relatedConcepts": ["module imports", "namespace composition", "RCLike inner product space", "abstraction boundary"],
-    "prerequisites": ["finite-dimensional inner product spaces", "the abstract Poincaré separation file", "the orthogonal compression file"]
+    "relatedConcepts": [
+      "module imports",
+      "namespace composition",
+      "RCLike inner product space",
+      "abstraction boundary"
+    ],
+    "prerequisites": [
+      "finite-dimensional inner product spaces",
+      "the abstract Poincaré separation file",
+      "the orthogonal compression file"
+    ]
   },
   {
     "id": "ann-poincare-separation-compression",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
-    "range": { "startLine": 73, "endLine": 104 },
+    "range": {
+      "startLine": 73,
+      "endLine": 104
+    },
     "type": "theorem",
     "title": "Self-Contained Poincaré Separation via the Explicit Compression",
     "content": "`poincare_separation_compression` takes only a symmetric `T` on `V` with `finrank V = n + m` and a subspace `H` with `finrank H = n`. It sets the spectral data of `T` (eigenbasis `b`, antitone eigenvalues `lam`) and of the explicit orthogonal compression `compress T H` (symmetry from `isSymmetric_compress`, eigenbasis `bH`, antitone eigenvalues `mu`), supplies the Rayleigh-agreement hypothesis from `rayleigh_compress_eq`, and applies the gallery's abstract `poincare_separation`. The conclusion is `lam ⟨k+m⟩ ≤ mu k ∧ mu k ≤ lam ⟨k⟩` — the Poincaré separation theorem `λ_{k+m} ≤ μ_k ≤ λ_k` with NO Rayleigh side condition and NO abstract compression operator.",
     "mathContext": "For T symmetric on an (n+m)-dimensional space and μ the descending eigenvalues of the compression of T onto any n-dimensional subspace, λ_{k+m} ≤ μ_k ≤ λ_k.",
     "significance": "key",
-    "relatedConcepts": ["Poincaré separation", "orthogonal compression", "Courant–Fischer", "spectral theorem"],
-    "prerequisites": ["spectral theorem eigenbasis/eigenvalues", "Rayleigh quotient of a compression", "abstract Poincaré separation inequality"]
+    "relatedConcepts": [
+      "Poincaré separation",
+      "orthogonal compression",
+      "Courant–Fischer",
+      "spectral theorem"
+    ],
+    "prerequisites": [
+      "spectral theorem eigenbasis/eigenvalues",
+      "Rayleigh quotient of a compression",
+      "abstract Poincaré separation inequality"
+    ]
   },
   {
     "id": "ann-recover-codim-one",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
-    "range": { "startLine": 106, "endLine": 132 },
+    "range": {
+      "startLine": 106,
+      "endLine": 132
+    },
     "type": "insight",
     "title": "Recovering the Codimension-One Corollary (m = 1)",
     "content": "`cauchy_interlacing_compression_of_poincare` specialises the main theorem to `m = 1` and re-expresses the index bounds `⟨k+1⟩` and `⟨k⟩` as `k.succ` and `k.castSucc` via `Fin.ext`, reproducing the merged codimension-one compression corollary `λ_{k+1} ≤ μ_k ≤ λ_k`. This certifies that the arbitrary-codimension form is a faithful generalisation rather than a divergent statement.",
     "mathContext": "Cauchy interlacing for a hyperplane compression is exactly Poincaré separation at codimension m = 1.",
     "significance": "supporting",
-    "relatedConcepts": ["Cauchy interlacing", "Fin.succ", "Fin.castSucc", "proof irrelevance"],
-    "prerequisites": ["the main separation theorem"]
+    "relatedConcepts": [
+      "Cauchy interlacing",
+      "Fin.succ",
+      "Fin.castSucc",
+      "proof irrelevance"
+    ],
+    "prerequisites": [
+      "the main separation theorem"
+    ]
   },
   {
     "id": "ann-compression-span-frame",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
-    "range": { "startLine": 134, "endLine": 147 },
+    "range": {
+      "startLine": 134,
+      "endLine": 147
+    },
     "type": "definition",
     "title": "Compression onto the Span of an Orthonormal Frame",
     "content": "`poincare_separation_compression_span` replaces the explicit dimension hypothesis with an arbitrary orthonormal family `f : Fin n → V`, compressing onto `H = Submodule.span 𝕜 (Set.range f)`. The dimension `finrank H = n` is discharged inline by `finrank_span_eq_card hf.linearIndependent` composed with `Fintype.card_fin`. This is the literal 'eigenvalue interlacing under compression onto a k-dimensional subspace' phrasing, taking the subspace as the span of k orthonormal vectors.",
     "mathContext": "An orthonormal k-frame spans a k-dimensional subspace; compressing onto it gives μ with λ_{k+m} ≤ μ_k ≤ λ_k.",
     "significance": "supporting",
-    "relatedConcepts": ["orthonormal family", "span", "finrank_span_eq_card", "k-dimensional subspace"],
-    "prerequisites": ["the main separation theorem", "linear independence of orthonormal families"]
+    "relatedConcepts": [
+      "orthonormal family",
+      "span",
+      "finrank_span_eq_card",
+      "k-dimensional subspace"
+    ],
+    "prerequisites": [
+      "the main separation theorem",
+      "linear independence of orthonormal families"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 5-47), previously unannotated. Frames the self-contained Poincaré separation via explicit orthogonal compression, recovering Cauchy interlacing at m=1. Annotations 4→5; no Lean source changes.

Label: enrichment