### PR TITLE
Enrich pythagorean-triples-oq-02-oq-01: module-overview annotation (57%→86% coverage)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/annotations.json
@@ -1,74 +1,165 @@
 [
   {
+    "id": "ann-pt0201-overview",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "concept",
+    "title": "Overview: Classifying Primitive Pythagorean Triples via Gaussian Integers",
+    "content": "The open question asks whether the CLASSIFICATION of all primitive Pythagorean triples can be formalized: every primitive triple has the form (m²−n², 2mn, m²+n²) with gcd(m,n)=1 and opposite parity, using the UFD property of ℤ[i]. The Gaussian-integer story behind the parametrization (developed in the parent entry) is: squaring z = m + n·i gives z² = (m²−n²) + (2mn)·i and N(z²) = N(z)² = (m²+n²)², so the two legs (m²−n², 2mn) are the real/imaginary parts of z² and the hypotenuse m²+n² is the Gaussian norm N(z). This file connects that parametrization map to the full classification. Mathlib already proves the DEEP direction — that every primitive triple arises this way — in PythagoreanTriple.coprime_classification (resting on ℤ[i] being a UFD). This entry is therefore presented honestly as a BRIDGE: the elementary forward facts (the parametrization always yields a primitive triple) are proved here, and the full biconditional classification is exported and packaged in the Gaussian-parametrization language.",
+    "mathContext": "A primitive Pythagorean triple $(a,b,c)$ with $a^2+b^2=c^2$, $\\gcd(a,b)=1$ corresponds to a Gaussian integer $z=m+ni$ with $\\gcd(m,n)=1$ and $m\\not\\equiv n\\ (\\mathrm{mod}\\ 2)$ via $a+bi=z^2$, $c=N(z)=m^2+n^2$. The classification is a consequence of unique factorization in $\\mathbb{Z}[i]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Pythagorean triples",
+      "Gaussian integers",
+      "unique factorization domain",
+      "norm form",
+      "primitive triple parametrization"
+    ],
+    "prerequisites": [
+      "Gaussian integers ℤ[i]",
+      "unique factorization",
+      "Pythagorean triples"
+    ]
+  },
+  {
     "id": "ann-param-def",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 37, "endLine": 42 },
+    "range": {
+      "startLine": 37,
+      "endLine": 42
+    },
     "type": "definition",
     "title": "The Gaussian-Square Parametrization Map",
     "content": "`paramTriple (m, n) = (m²−n², 2mn, m²+n²)` names the classical Euclid parametrization, but the Lean docstring frames it through the Gaussian integers ℤ[i]: the first two components are exactly the real and imaginary parts of the square (m+ni)² = (m²−n²) + (2mn)i, and the third is the Gaussian norm N(m+ni) = m²+n². This 'square a Gaussian integer' viewpoint is the conceptual key that makes the whole classification transparent.",
     "mathContext": "$$(m+ni)^2 = (m^2-n^2) + (2mn)i,\\qquad N(m+ni) = m^2+n^2$$",
     "significance": "key",
-    "relatedConcepts": ["Gaussian integers", "Euclid parametrization", "complex norm", "Pythagorean triples"],
-    "prerequisites": ["squaring a complex/Gaussian integer", "the norm N(a+bi)=a²+b²"]
+    "relatedConcepts": [
+      "Gaussian integers",
+      "Euclid parametrization",
+      "complex norm",
+      "Pythagorean triples"
+    ],
+    "prerequisites": [
+      "squaring a complex/Gaussian integer",
+      "the norm N(a+bi)=a²+b²"
+    ]
   },
   {
     "id": "ann-is-pythagorean",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 44, "endLine": 48 },
+    "range": {
+      "startLine": 44,
+      "endLine": 48
+    },
     "type": "tactic",
     "title": "The Parametrization Always Yields a Triple — One ring Call",
     "content": "`paramTriple_isPythagorean` proves (m²−n²)² + (2mn)² = (m²+n²)² for all integers m, n. After `delta PythagoreanTriple` unfolds the definition x·x + y·y = z·z, the goal is a polynomial identity over ℤ closed by `ring`. Conceptually this single line IS the multiplicativity of the Gaussian norm, N(z²) = N(z)²: squaring a Gaussian integer automatically produces a Pythagorean relation among the parts and the norm.",
     "mathContext": "$$(m^2-n^2)^2 + (2mn)^2 = (m^2+n^2)^2 \\;\\Longleftrightarrow\\; N(z^2) = N(z)^2$$",
     "significance": "key",
-    "relatedConcepts": ["ring tactic", "norm multiplicativity", "polynomial identity"],
-    "prerequisites": ["PythagoreanTriple definition", "the ring tactic over ℤ"]
+    "relatedConcepts": [
+      "ring tactic",
+      "norm multiplicativity",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "PythagoreanTriple definition",
+      "the ring tactic over ℤ"
+    ]
   },
   {
     "id": "ann-is-primitive",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 50, "endLine": 61 },
+    "range": {
+      "startLine": 50,
+      "endLine": 61
+    },
     "type": "insight",
     "title": "Coprime Opposite-Parity Inputs Give a Primitive Triple",
     "content": "`paramTriple_isPrimitive` shows that if gcd(m,n)=1 and m,n have opposite parity then the legs m²−n² and 2mn are coprime — i.e. the triple is primitive. Rather than reach for Mathlib's private lemma coprime_sq_sub_mul, the proof invokes the EASY (reverse) direction of the public coprime_classification: it supplies the explicit witness ⟨m, n, …⟩ to the .mpr and projects out the leg-coprimality with .2. Geometrically, opposite parity and coprimality are exactly the conditions keeping m+ni (up to units) free of the factor 1+i, so its square stays primitive.",
     "mathContext": "$$\\gcd(m,n)=1 \\ \\wedge\\ m\\not\\equiv n \\pmod 2 \\;\\implies\\; \\gcd(m^2-n^2,\\,2mn) = 1$$",
     "significance": "key",
-    "relatedConcepts": ["primitivity", "coprimality", "opposite parity", "PythagoreanTriple.coprime_classification", "the prime 1+i in ℤ[i]"],
-    "prerequisites": ["gcd over ℤ", "the reverse direction of the classification", "parity"]
+    "relatedConcepts": [
+      "primitivity",
+      "coprimality",
+      "opposite parity",
+      "PythagoreanTriple.coprime_classification",
+      "the prime 1+i in ℤ[i]"
+    ],
+    "prerequisites": [
+      "gcd over ℤ",
+      "the reverse direction of the classification",
+      "parity"
+    ]
   },
   {
     "id": "ann-classification",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 63, "endLine": 80 },
+    "range": {
+      "startLine": 63,
+      "endLine": 80
+    },
     "type": "concept",
     "title": "The Complete Classification — Bridged from Mathlib",
     "content": "`primitive_classification` is the headline biconditional: (x,y,z) is a primitive Pythagorean triple iff it arises from paramTriple for some coprime opposite-parity (m,n), up to swapping legs and the sign of z. The entry is honest that the HARD direction — every primitive triple has this shape — is precisely Mathlib's PythagoreanTriple.coprime_classification, which rests on unique factorization in ℤ[i]. The theorem here is definitionally that import, repackaged in the Gaussian-parametrization language; hence the `mathlib` badge.",
     "mathContext": "$$(x^2+y^2=z^2 \\wedge \\gcd(x,y)=1) \\iff \\exists\\,m,n\\ \\text{coprime, opp. parity},\\ (x,y,z) = \\pm\\,\\mathrm{paramTriple}(m,n)$$",
     "significance": "critical",
-    "relatedConcepts": ["unique factorization in ℤ[i]", "complete classification", "Mathlib bridge", "biconditional"],
-    "prerequisites": ["ℤ[i] is a UFD", "PythagoreanTriple.coprime_classification"]
+    "relatedConcepts": [
+      "unique factorization in ℤ[i]",
+      "complete classification",
+      "Mathlib bridge",
+      "biconditional"
+    ],
+    "prerequisites": [
+      "ℤ[i] is a UFD",
+      "PythagoreanTriple.coprime_classification"
+    ]
   },
   {
     "id": "ann-standard-form",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 82, "endLine": 90 },
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
     "type": "tactic",
     "title": "The Sign/Order-Free Standard Form",
     "content": "`primitive_classification_pos` removes the leg-swap and sign ambiguity: when the odd leg x and the hypotenuse z are positive, there exist m ≥ 0 and n with exactly x = m²−n², y = 2mn, z = m²+n², coprime and of opposite parity. This is the textbook parametrization with no qualifiers, obtained directly from Mathlib's sharper coprime_classification'. It is the form most useful for downstream numeric work.",
     "mathContext": "$$x \\text{ odd},\\ z>0 \\implies \\exists\\,m\\ge 0,n:\\ x=m^2-n^2,\\ y=2mn,\\ z=m^2+n^2$$",
     "significance": "supporting",
-    "relatedConcepts": ["standard form", "PythagoreanTriple.coprime_classification'", "positive parametrization"],
-    "prerequisites": ["the biconditional classification", "positivity normalization"]
+    "relatedConcepts": [
+      "standard form",
+      "PythagoreanTriple.coprime_classification'",
+      "positive parametrization"
+    ],
+    "prerequisites": [
+      "the biconditional classification",
+      "positivity normalization"
+    ]
   },
   {
     "id": "ann-sum-of-squares",
     "proofId": "pythagorean-triples-oq-02-oq-01",
-    "range": { "startLine": 92, "endLine": 99 },
+    "range": {
+      "startLine": 92,
+      "endLine": 99
+    },
     "type": "insight",
     "title": "Corollary: the Hypotenuse Is a Sum of Two Squares",
     "content": "`hypotenuse_sum_of_squares` extracts a clean number-theoretic fact: the hypotenuse of any positive primitive triple (with odd leg) is a sum of two squares, z = m²+n². It follows immediately by destructuring the witness from primitive_classification_pos and keeping the z = m²+n² component. In Gaussian terms this is z = N(m+ni) made explicit, and it connects directly to Fermat's two-squares theorem (the sibling open question OQ-02 #2 of the parent).",
     "mathContext": "$$z = m^2 + n^2 = N(m+ni)$$",
     "significance": "key",
-    "relatedConcepts": ["sum of two squares", "Fermat's two-squares theorem", "Gaussian norm", "corollary"],
-    "prerequisites": ["primitive_classification_pos", "destructuring an existential witness"]
+    "relatedConcepts": [
+      "sum of two squares",
+      "Fermat's two-squares theorem",
+      "Gaussian norm",
+      "corollary"
+    ],
+    "prerequisites": [
+      "primitive_classification_pos",
+      "destructuring an existential witness"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 1-29), previously unannotated. Frames the Gaussian-integer classification of primitive Pythagorean triples via z², norm, and the ℤ[i]-UFD bridge to Mathlib's coprime_classification. Annotations 6→7; no Lean source changes.

Label: enrichment