### PR TITLE
research(composition-card-2pow-oq-01-oq-01): add gallery annotations (by-length composition count)

### DIFF
--- a/src/data/proofs/composition-card-2pow-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/composition-card-2pow-oq-01-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-length-cardinality-dictionary",
+    "proofId": "composition-card-2pow-oq-01-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 132
+    },
+    "type": "theorem",
+    "title": "The Length ↔ Subset-Cardinality Dictionary (equiv_card_add_one)",
+    "content": "This block establishes the one ingredient absent from Mathlib: that the number of parts of a composition is exactly one more than the cardinality of the gap subset it corresponds to under compositionAsSetEquiv. gapEmb : Fin (n−1) ↪ Fin (n+1) shifts an internal gap i to the boundary position i+1. mem_equiv_iff identifies membership in the attached gap subset with membership of the shifted position in cs.boundaries. zero_not_mem_map and last_not_mem_map show the endpoints 0 and last n are never internal cuts. boundaries_eq (for n ≥ 1) then writes cs.boundaries = insert 0 (insert (last n) (gapSubset.map gapEmb)). Since the three pieces are disjoint, the boundary count is (gap-subset card) + 2; combined with Mathlib's card_boundaries_eq_succ_length (boundary card = length + 1), equiv_card_add_one concludes gap-subset card + 1 = length via omega.",
+    "mathContext": "$c.\\mathrm{length} = \\#(\\text{gap subset}) + 1$, from $\\mathrm{boundaries} = \\{0, \\mathrm{last}\\} \\uplus (\\text{shifted cuts})$.",
+    "prerequisites": [
+      "The boundary-set model CompositionAsSet n and card_boundaries_eq_succ_length",
+      "compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n−1))",
+      "Finset.card_insert_of_notMem and Finset.card_map"
+    ],
+    "relatedConcepts": [
+      "boundary-set model of compositions",
+      "internal cuts and parts",
+      "cardinality bookkeeping"
+    ],
+    "significance": "foundational"
+  },
+  {
+    "id": "ann-fixed-cardinality-subsets",
+    "proofId": "composition-card-2pow-oq-01-oq-01",
+    "range": {
+      "startLine": 134,
+      "endLine": 139
+    },
+    "type": "theorem",
+    "title": "Counting Subsets of a Fixed Cardinality (card_finset_card_eq)",
+    "content": "card_finset_card_eq specialises Mathlib's Fintype.card_finset_len to Fin m, recording that the number of j-element subsets of an m-element type is the binomial coefficient C(m, j): Fintype.card {s : Finset (Fin m) // s.card = j} = m.choose j. This is the combinatorial engine onto which the length-k stratum of compositions is transported.",
+    "mathContext": "$\\#\\{s : \\mathrm{Finset}\\,(\\mathrm{Fin}\\ m) \\mid s.\\mathrm{card} = j\\} = \\binom{m}{j}$.",
+    "prerequisites": [
+      "Fintype.card_finset_len (count of fixed-size subsets is a binomial coefficient)",
+      "Fintype.card_fin"
+    ],
+    "relatedConcepts": [
+      "binomial coefficients",
+      "subset counting",
+      "finite type cardinality"
+    ],
+    "significance": "supporting"
+  },
+  {
+    "id": "ann-by-length-count",
+    "proofId": "composition-card-2pow-oq-01-oq-01",
+    "range": {
+      "startLine": 141,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "The By-Length Count: C(n−1, k−1) (card_composition_length_eq)",
+    "content": "The main theorem: for n ≥ 1 and k ≥ 1, the number of compositions of n into exactly k parts is C(n−1, k−1). Using equiv_card_add_one it rewrites the condition c.length = k as 'the attached gap subset has cardinality k−1', then builds the equivalence {c : Composition n // c.length = k} ≃ {s : Finset (Fin (n−1)) // s.card = k−1} by Equiv.subtypeEquiv over the composite (compositionEquiv n).trans (compositionAsSetEquiv n). Fintype.card_congr transports the count across this equivalence and card_finset_card_eq reads it off as (n−1).choose (k−1).",
+    "mathContext": "$\\#\\{c : \\mathrm{Composition}\\ n \\mid c.\\mathrm{length} = k\\} = \\binom{n-1}{k-1}$ for $n, k \\ge 1$.",
+    "prerequisites": [
+      "equiv_card_add_one (the length↔cardinality dictionary)",
+      "Equiv.subtypeEquiv and Fintype.card_congr for transporting subtype cardinalities",
+      "card_finset_card_eq"
+    ],
+    "relatedConcepts": [
+      "enumerative refinement",
+      "transport of structure",
+      "compositions by number of parts"
+    ],
+    "significance": "foundational"
+  },
+  {
+    "id": "ann-sum-over-parts",
+    "proofId": "composition-card-2pow-oq-01-oq-01",
+    "range": {
+      "startLine": 163,
+      "endLine": 189
+    },
+    "type": "theorem",
+    "title": "Summing Over the Number of Parts (sum_choose_shift, sum_card_composition_length)",
+    "content": "sum_choose_shift proves ∑_{k=1}^{n} C(n−1, k−1) = 2^(n−1): it reindexes Finset.Icc 1 n to Finset.range n via the shift embedding k ↦ k−1 (Finset.sum_map), rewrites range n as range ((n−1)+1), and applies Nat.sum_range_choose (∑_{j≤m} C(m,j) = 2^m). sum_card_composition_length then chains this with card_composition_length_eq to prove ∑_{k=1}^{n} Fintype.card {c : Composition n // c.length = k} = 2^(n−1), recovering the parent entry's total count as a sum of binomial coefficients and answering its first open question.",
+    "mathContext": "$\\sum_{k=1}^{n} \\binom{n-1}{k-1} = 2^{n-1}$, recovering the parent total.",
+    "prerequisites": [
+      "Nat.sum_range_choose (∑_{k≤m} C(m,k) = 2^m)",
+      "Finset.sum_map for reindexing the sum",
+      "card_composition_length_eq"
+    ],
+    "relatedConcepts": [
+      "binomial theorem",
+      "reindexing sums",
+      "powers of two as sums of binomial coefficients"
+    ],
+    "significance": "foundational"
+  }
+]


### PR DESCRIPTION
## Summary

The gallery entry for `composition-card-2pow-oq-01-oq-01` (compositions of $n$ into exactly $k$ parts number $\binom{n-1}{k-1}$) was merged in #33228 with `meta.json` but **no `annotations.json`**. This PR fills that gap.

Adds 4 section annotations whose line ranges exactly match the merged `meta.json` sections:

| Range | Annotation |
|-------|------------|
| 51–132 | Length ↔ subset-cardinality dictionary (`equiv_card_add_one`) |
| 134–139 | Fixed-cardinality subset counting (`card_finset_card_eq`) |
| 141–161 | The by-length count $\binom{n-1}{k-1}$ (`card_composition_length_eq`) |
| 163–189 | Sum over parts recovering $2^{n-1}$ (`sum_card_composition_length`) |

## Verification
- Lean file `Proofs/CompositionCard2PowOQ01OQ01.lean` already on main (#33207).
- **Docker build VERIFIED**: 3058 jobs, EXIT=0. No `axiom`/`sorry`/`native_decide` → 0-axiom.
- `pnpm gallery:check-size` ✓ (all 4568 entries within caps).
- `pnpm annotations:validate` ✓ (no errors for this slug).

Answers the parent entry's first open question: refining the total count $2^{n-1}$ by number of parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)