### PR TITLE
research(derangements-convergence-oq-06-oq-01): effective two-sided sandwich on the derangement error [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ06OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ06OQ01.lean
@@ -1,0 +1,183 @@
+/-
+  Derangements: an effective TWO-SIDED sandwich on the error |D(n) − n!·e⁻¹|
+  Open question: derangements-convergence-oq-06-oq-01
+
+  ## Context
+
+  The parent chain proves the *one-sided* rate bound
+    |D(n)/n! − e⁻¹| ≤ 1/(n+1)!          (`derangements_convergence_rate`)
+  and, at integer scale, |D(n) − n!·e⁻¹| ≤ 1/(n+1), which is exactly what pins
+  down the rounding identity D(n) = round(n!/e).
+
+  ## What this file adds
+
+  We complement the upper bound with a matching LOWER bound, giving an effective
+  two-sided sandwich. The error is exactly the alternating factorial tail
+    T(m) := ∑' k, (−1)ᵏ/(m+k)!,     with   |D(n)/n! − e⁻¹| = T(n+1).
+  The single clean fact driving everything is the tail recurrence
+    T(m) = 1/m! − T(m+1),
+  obtained by peeling off the k = 0 term. Combined with the parent's envelope
+  0 ≤ T(m) ≤ 1/m! (from `alt_partial_sum_nonneg` / `alt_partial_sum_le_first`),
+  the recurrence yields
+    1/m! − 1/(m+1)! ≤ T(m) ≤ 1/m!.
+  Specialising m = n+1 and multiplying by n! gives the headline sandwich
+    1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1),      for all n,
+  since n!·(1/(n+1)! − 1/(n+2)!) = 1/(n+1) − 1/((n+1)(n+2)) = 1/(n+2).
+
+  This shows the parent's upper bound 1/(n+1) is essentially sharp: the true
+  error stays trapped in the band [1/(n+2), 1/(n+1)].
+
+  ## Main results
+  - `tailFrom`                     : the alternating factorial tail T(m)
+  - `tailFrom_succ`                : T(m) = 1/m! − T(m+1)                (recurrence)
+  - `tailFrom_le` / `tailFrom_nonneg` / `tailFrom_ge` : the two-sided envelope on T
+  - `abs_err_eq_tailFrom`          : |D(n)/n! − e⁻¹| = T(n+1)
+  - `abs_err_le` / `abs_err_ge`    : two-sided bound at the /n! scale
+  - `abs_derangements_sub_le`      : |D(n) − n!·e⁻¹| ≤ 1/(n+1)
+  - `abs_derangements_sub_ge`      : |D(n) − n!·e⁻¹| ≥ 1/(n+2)
+  - `derangements_two_sided_sandwich` : the sharp band, both bounds at once
+-/
+import Mathlib
+import Proofs.DerangementsConvergence
+
+open Finset Nat Real BigOperators Filter Topology
+
+namespace DerangementsConvergenceOQ06OQ01
+
+/-- The alternating factorial tail `T(m) = ∑' k, (−1)ᵏ/(m+k)!`. This is exactly
+    the quantity controlling the derangement error (see `abs_err_eq_tailFrom`). -/
+noncomputable def tailFrom (m : ℕ) : ℝ := ∑' k, ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ))
+
+/-- The tail summand is summable (dominated by `1/(m+k)!`). Mirrors the local
+    `hc_summable` inside the parent's `alternating_tail_bound`. -/
+lemma summable_altTail (m : ℕ) :
+    Summable (fun k => (-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+  have hbnd : Summable (fun k => (1 : ℝ) / ((m + k).factorial : ℝ)) := by
+    have h1 : Summable (fun (k : ℕ) => (1 : ℝ) / (k.factorial : ℝ)) := by
+      simpa only [one_pow] using summable_pow_div_factorial (1 : ℝ)
+    exact h1.comp_injective (fun ⦃a b⦄ (h : m + a = m + b) => by omega)
+  refine Summable.of_norm_bounded_eventually hbnd ?_
+  filter_upwards with k
+  apply le_of_eq
+  simp only [norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow, Nat.abs_cast]
+
+/-- `0 ≤ T(m)`. -/
+lemma tailFrom_nonneg (m : ℕ) : 0 ≤ tailFrom m := by
+  unfold tailFrom
+  apply le_of_tendsto_of_tendsto tendsto_const_nhds
+    ((summable_altTail m).hasSum.tendsto_sum_nat)
+  filter_upwards with N
+  exact alt_partial_sum_nonneg m N
+
+/-- `T(m) ≤ 1/m!`. -/
+lemma tailFrom_le (m : ℕ) : tailFrom m ≤ 1 / (m.factorial : ℝ) := by
+  unfold tailFrom
+  apply le_of_tendsto ((summable_altTail m).hasSum.tendsto_sum_nat)
+  filter_upwards with N
+  exact alt_partial_sum_le_first m N
+
+/-- The tail recurrence: peeling off the `k = 0` term gives `T(m) = 1/m! − T(m+1)`. -/
+lemma tailFrom_succ (m : ℕ) :
+    tailFrom m = 1 / (m.factorial : ℝ) - tailFrom (m + 1) := by
+  unfold tailFrom
+  rw [(summable_altTail m).tsum_eq_zero_add]
+  have etail : (∑' b : ℕ, (-1 : ℝ) ^ (b + 1) / ((m + (b + 1)).factorial : ℝ))
+      = - ∑' b : ℕ, (-1 : ℝ) ^ b / (((m + 1) + b).factorial : ℝ) := by
+    rw [← tsum_neg]
+    refine tsum_congr (fun b => ?_)
+    have hfac : m + (b + 1) = (m + 1) + b := by omega
+    rw [hfac, pow_succ]; ring
+  rw [etail]
+  simp only [pow_zero, Nat.add_zero, one_div]
+  ring
+
+/-- Two-sided envelope, lower half: `1/m! − 1/(m+1)! ≤ T(m)`. -/
+lemma tailFrom_ge (m : ℕ) :
+    1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) ≤ tailFrom m := by
+  rw [tailFrom_succ m]
+  have := tailFrom_le (m + 1)
+  linarith
+
+/-- The derangement error equals the tail: `|D(n)/n! − e⁻¹| = T(n+1)`. -/
+lemma abs_err_eq_tailFrom (n : ℕ) :
+    |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| = tailFrom (n + 1) := by
+  rw [derangements_div_factorial, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail n]
+  have h1 : altFactPartialSum n - (altFactPartialSum n + ∑' k, altFactTerm (n + 1 + k))
+      = -(∑' k, altFactTerm (n + 1 + k)) := by ring
+  rw [h1, abs_neg]
+  set m := n + 1 with hm
+  have hfactor : ∀ k, altFactTerm (m + k)
+      = (-1 : ℝ) ^ m * ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+    intro k; simp [altFactTerm, pow_add, mul_div_assoc]
+  have h2 : (∑' k, altFactTerm (m + k)) = (-1 : ℝ) ^ m * tailFrom m := by
+    unfold tailFrom
+    rw [← tsum_mul_left]
+    exact tsum_congr hfactor
+  rw [h2, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul,
+      abs_of_nonneg (tailFrom_nonneg _)]
+
+/-- Upper bound at the `/n!` scale (recovers the parent's rate). -/
+theorem abs_err_le (n : ℕ) :
+    |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| ≤ 1 / ((n + 1).factorial : ℝ) := by
+  rw [abs_err_eq_tailFrom]; exact tailFrom_le (n + 1)
+
+/-- Lower bound at the `/n!` scale. -/
+theorem abs_err_ge (n : ℕ) :
+    1 / ((n + 1).factorial : ℝ) - 1 / ((n + 2).factorial : ℝ)
+      ≤ |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| := by
+  rw [abs_err_eq_tailFrom]
+  have h := tailFrom_ge (n + 1)
+  have he : (n + 1 + 1) = (n + 2) := by omega
+  rw [he] at h
+  exact h
+
+/-- Rewrite the integer-scale error as `n!` times the `/n!`-scale error. -/
+lemma abs_int_eq_factorial_mul (n : ℕ) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)|
+      = (n.factorial : ℝ) * |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| := by
+  have hn : (0 : ℝ) < (n.factorial : ℝ) := factorial_cast_pos' n
+  have hrw : (numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)
+      = (n.factorial : ℝ) * ((numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)) := by
+    field_simp
+  rw [hrw, abs_mul, abs_of_pos hn]
+
+/-- Integer-scale upper bound: `|D(n) − n!·e⁻¹| ≤ 1/(n+1)`. -/
+theorem abs_derangements_sub_le (n : ℕ) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ≤ 1 / (n + 1 : ℝ) := by
+  rw [abs_int_eq_factorial_mul]
+  have hle := abs_err_le n
+  have hn : (0 : ℝ) < (n.factorial : ℝ) := factorial_cast_pos' n
+  calc (n.factorial : ℝ) * |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)|
+      ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) := by
+        apply mul_le_mul_of_nonneg_left hle hn.le
+    _ = 1 / (n + 1 : ℝ) := by
+        rw [Nat.factorial_succ]; push_cast; field_simp
+
+/-- Integer-scale lower bound: `|D(n) − n!·e⁻¹| ≥ 1/(n+2)`. -/
+theorem abs_derangements_sub_ge (n : ℕ) :
+    1 / (n + 2 : ℝ) ≤ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| := by
+  rw [abs_int_eq_factorial_mul]
+  have hge := abs_err_ge n
+  have hn : (0 : ℝ) < (n.factorial : ℝ) := factorial_cast_pos' n
+  calc 1 / (n + 2 : ℝ)
+      = (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ) - 1 / ((n + 2).factorial : ℝ)) := by
+        rw [show (n + 2).factorial = (n + 2) * (n + 1).factorial from by
+              rw [show n + 2 = (n + 1) + 1 from rfl, Nat.factorial_succ],
+            show (n + 1).factorial = (n + 1) * n.factorial from Nat.factorial_succ n]
+        push_cast
+        have h1 : (n.factorial : ℝ) ≠ 0 := factorial_cast_ne_zero' n
+        have h2 : (n : ℝ) + 1 ≠ 0 := by positivity
+        have h3 : (n : ℝ) + 2 ≠ 0 := by positivity
+        field_simp
+        ring
+    _ ≤ (n.factorial : ℝ) * |(numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1)| := by
+        apply mul_le_mul_of_nonneg_left hge hn.le
+
+/-- The sharp two-sided sandwich: the derangement error is trapped in
+    `[1/(n+2), 1/(n+1)]` for every `n`. -/
+theorem derangements_two_sided_sandwich (n : ℕ) :
+    1 / (n + 2 : ℝ) ≤ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)|
+    ∧ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ≤ 1 / (n + 1 : ℝ) :=
+  ⟨abs_derangements_sub_ge n, abs_derangements_sub_le n⟩
+
+end DerangementsConvergenceOQ06OQ01

--- a/src/data/proofs/derangements-convergence-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "derange-oq0601-header",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "An effective two-sided sandwich on the derangement error",
+    "content": "The header states the goal: complement the parent's one-sided bound |D(n) − n!·e⁻¹| ≤ 1/(n+1) with a matching lower bound, yielding 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1) for every n. This is exactly OQ-06's first open question — a Lean-verified two-sided sandwich on the exact gap. The whole argument reduces to one identity: the error equals the alternating factorial tail T(m) = ∑ (−1)^k/(m+k)!, which satisfies the recurrence T(m) = 1/m! − T(m+1). Combined with the parent's envelope 0 ≤ T(m) ≤ 1/m!, the recurrence produces 1/m! − 1/(m+1)! ≤ T(m) ≤ 1/m!.",
+    "mathContext": "$\\tfrac{1}{n+2} \\le |D(n) - n!\\,e^{-1}| \\le \\tfrac{1}{n+1}$ via $T(m) = \\tfrac{1}{m!} - T(m+1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["derangements", "alternating series", "effective bounds", "sharpness", "subfactorial"],
+    "prerequisites": ["numDerangements", "the parent one-sided rate bound"]
+  },
+  {
+    "id": "derange-oq0601-tail-def",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 49, "endLine": 63 },
+    "type": "definition",
+    "title": "tailFrom: the alternating factorial tail T(m)",
+    "content": "`tailFrom m = T(m) := ∑' k, (−1)^k/(m+k)!` is the object the whole file revolves around — it will turn out to equal the derangement error exactly (abs_err_eq_tailFrom). `summable_altTail` proves the tail is summable by dominating |(−1)^k/(m+k)!| = 1/(m+k)! with an injective reindexing (k ↦ m+k) of summable_pow_div_factorial, mirroring the local summability argument inside the parent's alternating_tail_bound.",
+    "mathContext": "$T(m) = \\sum_{k=0}^{\\infty} \\frac{(-1)^k}{(m+k)!}$, summable since $\\left|\\frac{(-1)^k}{(m+k)!}\\right| \\le \\frac{1}{(m+k)!}$ and $\\sum 1/k! = e$.",
+    "significance": "key",
+    "relatedConcepts": ["tsum", "summable_pow_div_factorial", "Summable.comp_injective", "domination"],
+    "prerequisites": ["infinite sums over ℕ", "factorial growth"]
+  },
+  {
+    "id": "derange-oq0601-envelope",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 65, "endLine": 78 },
+    "type": "theorem",
+    "title": "The one-sided envelope 0 ≤ T(m) ≤ 1/m!",
+    "content": "`tailFrom_nonneg` and `tailFrom_le` restate the parent's alternating-series partial-sum lemmas (alt_partial_sum_nonneg and alt_partial_sum_le_first) for the infinite sum. The bridge is HasSum.tendsto_sum_nat: the partial sums ∑_{k<N} converge to T(m), so bounds holding for every partial sum pass to the limit via le_of_tendsto_of_tendsto (lower) and le_of_tendsto (upper). All the alternating-series analysis is inherited from the parent.",
+    "mathContext": "$0 \\le T(m) \\le \\tfrac{1}{m!}$: the alternating series starts at $+\\tfrac{1}{m!}$ and its partial sums oscillate within $[0, \\tfrac{1}{m!}]$.",
+    "significance": "key",
+    "relatedConcepts": ["HasSum.tendsto_sum_nat", "le_of_tendsto", "alternating series estimate", "partial sums"],
+    "prerequisites": ["convergence of partial sums to a tsum"]
+  },
+  {
+    "id": "derange-oq0601-recurrence",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 80, "endLine": 99 },
+    "type": "theorem",
+    "title": "The tail recurrence T(m) = 1/m! − T(m+1)",
+    "content": "`tailFrom_succ` is the crux. Peeling off the k=0 term with `tsum_eq_zero_add` gives T(m) = 1/m! + ∑' k, (−1)^{k+1}/(m+1+k)!. Each (k+1)-term is −1 times the corresponding term of T(m+1) (pow_succ), so the remaining sum is −T(m+1), yielding T(m) = 1/m! − T(m+1). `tailFrom_ge` then feeds the upper bound tailFrom_le (m+1) into this recurrence: T(m) = 1/m! − T(m+1) ≥ 1/m! − 1/(m+1)!. This is precisely how a one-sided envelope becomes two-sided — the upper bound on T(m+1) is a lower bound on T(m).",
+    "mathContext": "$T(m) = \\tfrac{1}{m!} - T(m+1) \\ge \\tfrac{1}{m!} - \\tfrac{1}{(m+1)!}$",
+    "significance": "critical",
+    "relatedConcepts": ["tsum_eq_zero_add", "peeling the leading term", "self-referential identity", "pow_succ"],
+    "prerequisites": ["the one-sided envelope on T", "tsum splitting"]
+  },
+  {
+    "id": "derange-oq0601-bridge",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 101, "endLine": 131 },
+    "type": "theorem",
+    "title": "abs_err_eq_tailFrom: the error IS the tail",
+    "content": "`abs_err_eq_tailFrom` proves |D(n)/n! − e⁻¹| = T(n+1). Using derangements_div_factorial (D(n)/n! = partial sum), exp_neg_one_eq_tsum_alt (e⁻¹ = full sum) and the parent's tsum_eq_partial_sum_add_tail, the difference is (up to sign) ∑' k, altFactTerm(n+1+k). Factoring each term as (−1)^{n+1}·((−1)^k/(n+1+k)!) and pulling the constant out with tsum_mul_left gives (−1)^{n+1}·T(n+1); taking absolute values and using tailFrom_nonneg leaves exactly T(n+1). Theorems abs_err_le / abs_err_ge then read off the /n!-scale two-sided bound 1/(n+1)! − 1/(n+2)! ≤ |D(n)/n! − e⁻¹| ≤ 1/(n+1)!.",
+    "mathContext": "$\\left|\\tfrac{D(n)}{n!} - e^{-1}\\right| = |(-1)^{n+1} T(n+1)| = T(n+1)$",
+    "significance": "key",
+    "relatedConcepts": ["tsum_mul_left", "tsum_eq_partial_sum_add_tail", "abs_mul", "sign factoring"],
+    "prerequisites": ["the finite derangement formula", "e⁻¹ as an alternating series"]
+  },
+  {
+    "id": "derange-oq0601-integer-scale",
+    "proofId": "derangements-convergence-oq-06-oq-01",
+    "range": { "startLine": 133, "endLine": 181 },
+    "type": "theorem",
+    "title": "Integer-scale sandwich: 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1)",
+    "content": "`abs_int_eq_factorial_mul` rewrites the integer-scale error as n!·|D(n)/n! − e⁻¹| (factor out n! > 0 via abs_mul, abs_of_pos). `abs_derangements_sub_le` multiplies the /n!-upper bound by n!, simplifying n!/(n+1)! = 1/(n+1). `abs_derangements_sub_ge` multiplies the /n!-lower bound by n!: the telescoping n!·(1/(n+1)! − 1/(n+2)!) = 1/(n+1) − 1/((n+1)(n+2)) collapses to exactly 1/(n+2). `derangements_two_sided_sandwich` packages both into a single conjunction — the sharp band answering OQ-06's open question.",
+    "mathContext": "$n!\\left(\\tfrac{1}{(n+1)!} - \\tfrac{1}{(n+2)!}\\right) = \\tfrac{1}{n+1} - \\tfrac{1}{(n+1)(n+2)} = \\tfrac{1}{n+2}$",
+    "significance": "critical",
+    "relatedConcepts": ["abs_mul", "mul_le_mul_of_nonneg_left", "Nat.factorial_succ", "telescoping", "field_simp"],
+    "prerequisites": ["the /n!-scale two-sided bound", "positivity of n!"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-06-oq-01/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const derangementsConvergenceOQ06OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const derangementsConvergenceOQ06OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const derangementsConvergenceOQ06OQ01Data: ProofData = {
+  proof: derangementsConvergenceOQ06OQ01Proof,
+  annotations: derangementsConvergenceOQ06OQ01Annotations,
+}

--- a/src/data/proofs/derangements-convergence-oq-06-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-06-oq-01/meta.json
@@ -1,0 +1,239 @@
+{
+  "id": "derangements-convergence-oq-06-oq-01",
+  "title": "An Effective Two-Sided Sandwich on the Derangement Error |D(n) − n!·e⁻¹|",
+  "slug": "derangements-convergence-oq-06-oq-01",
+  "description": "Answers OQ-06's first open question with a Lean-verified two-sided sandwich on the exact derangement error: 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1) for every n. The parent proved only the upper (one-sided) rate 1/(n+1), used to pin the rounding identity D(n) = round(n!/e); this entry supplies the matching lower bound, showing the upper bound is essentially sharp. The engine is the alternating factorial tail T(m) = ∑ (−1)ᵏ/(m+k)! together with the one-line recurrence T(m) = 1/m! − T(m+1), which upgrades the parent's envelope 0 ≤ T(m) ≤ 1/m! into 1/m! − 1/(m+1)! ≤ T(m) ≤ 1/m!.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ06OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "alternating-series",
+      "exponential",
+      "effective-bounds",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked (#print axioms reports only propext, Classical.choice, Quot.sound). The proof reuses the parent's alternating-series partial-sum envelope (alt_partial_sum_nonneg, alt_partial_sum_le_first) and tsum-splitting (tsum_eq_partial_sum_add_tail) from DerangementsConvergence.lean; the new content — the tail recurrence and the lower bound — is derived from Mathlib's tsum_eq_zero_add.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 183,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "originalContributions": [
+      "derangements_two_sided_sandwich (PROVED): 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1) for all n — the effective two-sided sandwich requested by OQ-06 open question 1",
+      "abs_derangements_sub_ge (PROVED): the new lower bound |D(n) − n!·e⁻¹| ≥ 1/(n+2), complementing the parent's upper bound",
+      "tailFrom_succ (key lemma): the alternating factorial tail recurrence T(m) = 1/m! − T(m+1), obtained by peeling the k=0 term via tsum_eq_zero_add",
+      "tailFrom_ge (key lemma): the tail lower bound 1/m! − 1/(m+1)! ≤ T(m), from the recurrence plus the parent's upper envelope on T(m+1)",
+      "abs_err_eq_tailFrom (bridge lemma): identifies the derangement error exactly with the tail, |D(n)/n! − e⁻¹| = T(n+1)",
+      "abs_err_ge / abs_err_le (helpers): the two-sided bound at the /n! scale, 1/(n+1)! − 1/(n+2)! ≤ |D(n)/n! − e⁻¹| ≤ 1/(n+1)!"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "tsum_eq_zero_add",
+        "description": "∑' b, f b = f 0 + ∑' b, f (b+1) for summable f — peels the leading term, giving the tail recurrence T(m) = 1/m! − T(m+1)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "summable_pow_div_factorial",
+        "description": "Summability of x^k/k! — dominates the alternating tail, giving summability of the tail summand",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "Partial sums of a HasSum series converge to the sum — transfers the parent's partial-sum envelope to the tsum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "derangements_div_factorial",
+        "description": "D(n)/n! = Σ_{k≤n} (−1)^k/k! — the finite formula bridging derangements to the alternating series (from the parent chain)",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "alt_partial_sum_le_first",
+        "description": "Alternating partial sums are ≤ the first term 1/m! — the parent's upper-envelope lemma reused for T(m) ≤ 1/m!",
+        "module": "Proofs.DerangementsConvergence"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Derangements — permutations with no fixed points — were analysed by Pierre de Montmort (1708) and Leonhard Euler (1751), who established D(n) = n!·Σ_{k=0}^n (−1)^k/k! and the limit D(n)/n! → e⁻¹. The convergence-rate gallery entry proves the sharp one-sided bound |D(n)/n! − e⁻¹| ≤ 1/(n+1)!, and its rounding descendant OQ-06 uses the integer-scale form |D(n) − n!·e⁻¹| ≤ 1/(n+1) to prove D(n) = round(n!/e) for all n ≥ 1. That upper bound alone leaves open how large the error really is; OQ-06's first open question asks explicitly for a Lean-verified two-sided sandwich on the exact gap. The error is exactly the alternating factorial tail, whose leading term is 1/(n+1)!, so the true error is 1/(n+1)! to leading order — i.e. 1/(n+1) at integer scale. This entry makes that precise with a clean matching lower bound.",
+    "problemStatement": "**OQ-06 open question 1 of derangements-convergence.**\n\nThe parent proves only the upper bound |D(n) − n!·e⁻¹| ≤ 1/(n+1). Prove a *Lean-verified two-sided sandwich* on the exact error, showing the upper bound is essentially sharp: exhibit an explicit matching lower bound.",
+    "text": "For every n, the derangement error is trapped in a narrow band:\n\n  1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1).\n\nEquivalently, at the /n! scale, 1/(n+1)! − 1/(n+2)! ≤ |D(n)/n! − e⁻¹| ≤ 1/(n+1)!.",
+    "proofStrategy": "**The whole argument turns on one recurrence.**\n\n1. **Identify the error with a tail** (`abs_err_eq_tailFrom`): starting from D(n)/n! = Σ_{k≤n}(−1)^k/k! and e⁻¹ = Σ_{k}(−1)^k/k!, the difference is (up to sign) the tail ∑_{k>n}(−1)^k/k!. Factoring out (−1)^{n+1} and taking absolute values gives |D(n)/n! − e⁻¹| = T(n+1), where T(m) := ∑' k, (−1)^k/(m+k)! ≥ 0.\n\n2. **The tail recurrence** (`tailFrom_succ`): peel off the k=0 term with Mathlib's `tsum_eq_zero_add`. Since the (k+1)-terms are exactly −1 times the shifted tail, T(m) = 1/m! − T(m+1).\n\n3. **Reuse the parent's envelope**: `alt_partial_sum_nonneg` and `alt_partial_sum_le_first` give 0 ≤ T(m) ≤ 1/m! (via `HasSum.tendsto_sum_nat` and `le_of_tendsto`). Feeding the upper bound on T(m+1) into the recurrence yields the lower bound T(m) ≥ 1/m! − 1/(m+1)!.\n\n4. **Scale up**: specialise m = n+1 and multiply by n!. The upper bound gives n!·(1/(n+1)!) = 1/(n+1); the lower bound gives n!·(1/(n+1)! − 1/(n+2)!) = 1/(n+1) − 1/((n+1)(n+2)) = 1/(n+2).",
+    "keyInsights": [
+      "The derangement error is *exactly* an alternating factorial tail, not merely bounded by one — making 'sharpness' a precise statement rather than an asymptotic.",
+      "A single self-referential identity T(m) = 1/m! − T(m+1) converts a one-sided envelope (0 ≤ T ≤ 1/m!) into a two-sided one (1/m! − 1/(m+1)! ≤ T ≤ 1/m!): the upper bound on T(m+1) becomes a lower bound on T(m). No new alternating-series machinery is needed beyond the parent's.",
+      "At integer scale the band collapses to the clean [1/(n+2), 1/(n+1)]: n!·(1/(n+1)! − 1/(n+2)!) telescopes to exactly 1/(n+2), because (n+2)−1 = n+1 cancels a factor.",
+      "The result certifies that the parent's upper bound 1/(n+1) is sharp up to the trivial 1/(n+2)–1/(n+1) gap, and in particular that the error never vanishes — D(n) ≠ n!·e⁻¹ for any n, consistent with e being irrational.",
+      "Reusing `tsum_eq_zero_add` (peel the head) rather than re-running the alternating-series estimation keeps the new content to a few lines: all the hard analysis lives in the parent's partial-sum lemmas."
+    ],
+    "prerequisites": [
+      "DerangementsConvergence.lean: derangements_div_factorial, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail, alt_partial_sum_nonneg, alt_partial_sum_le_first",
+      "Mathlib tsum_eq_zero_add (peeling the leading term of an infinite sum)",
+      "HasSum.tendsto_sum_nat and le_of_tendsto for transferring partial-sum bounds to the sum",
+      "Basic real arithmetic and factorial identities (Nat.factorial_succ)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the two-sided sandwich 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1) and its strategy via the tail recurrence T(m) = 1/m! − T(m+1). Imports Mathlib and Proofs.DerangementsConvergence (for the parent's alternating-series envelope). Opens Finset, Nat, Real, BigOperators, Filter, Topology. Namespace DerangementsConvergenceOQ06OQ01.",
+      "mathContext": "The only new external input beyond the parent's partial-sum lemmas is $\\texttt{tsum\\_eq\\_zero\\_add}$, used to peel the $k=0$ term of the tail."
+    },
+    {
+      "id": "sec-tail-def",
+      "title": "The Alternating Factorial Tail and its Summability",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "Defines tailFrom m = T(m) = ∑' k, (−1)^k/(m+k)!, the quantity that turns out to equal the derangement error. Lemma summable_altTail dominates the tail by 1/(m+k)! (an injective reindexing of summable_pow_div_factorial), mirroring the local summability argument inside the parent's alternating_tail_bound.",
+      "mathContext": "$T(m) := \\sum_{k=0}^\\infty \\frac{(-1)^k}{(m+k)!}$, summable since $|{\\cdot}| \\le \\frac{1}{(m+k)!}$ and $\\sum 1/k! < \\infty$."
+    },
+    {
+      "id": "sec-envelope",
+      "title": "The One-Sided Envelope 0 ≤ T(m) ≤ 1/m!",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "Lemmas tailFrom_nonneg and tailFrom_le transfer the parent's partial-sum lemmas alt_partial_sum_nonneg and alt_partial_sum_le_first to the infinite sum, using HasSum.tendsto_sum_nat with le_of_tendsto_of_tendsto / le_of_tendsto. This is the parent's one-sided envelope, restated for T(m).",
+      "mathContext": "$0 \\le T(m) \\le \\tfrac{1}{m!}$: the alternating series starts at $+1/m!$ and its partial sums stay in $[0, 1/m!]$."
+    },
+    {
+      "id": "sec-recurrence",
+      "title": "The Tail Recurrence T(m) = 1/m! − T(m+1)",
+      "startLine": 80,
+      "endLine": 99,
+      "summary": "Lemma tailFrom_succ peels the k=0 term via tsum_eq_zero_add: the head is 1/m!, and the (k+1)-terms equal −1 times the shifted tail (pow_succ), giving T(m) = 1/m! − T(m+1). Lemma tailFrom_ge feeds tailFrom_le (m+1) into the recurrence to obtain the new lower bound 1/m! − 1/(m+1)! ≤ T(m).",
+      "mathContext": "$T(m) = \\tfrac{1}{m!} - T(m+1)$, so $T(m) \\ge \\tfrac{1}{m!} - \\tfrac{1}{(m+1)!}$ from $T(m+1) \\le \\tfrac{1}{(m+1)!}$."
+    },
+    {
+      "id": "sec-bridge",
+      "title": "Identifying the Error with the Tail",
+      "startLine": 101,
+      "endLine": 131,
+      "summary": "Lemma abs_err_eq_tailFrom proves |D(n)/n! − e⁻¹| = T(n+1). It rewrites via derangements_div_factorial, exp_neg_one_eq_tsum_alt and the parent's tsum_eq_partial_sum_add_tail, factors the tail terms as (−1)^{n+1}·((−1)^k/(n+1+k)!), pulls the constant out with tsum_mul_left, and simplifies |(−1)^{n+1}·T(n+1)| = T(n+1) using tailFrom_nonneg. Theorems abs_err_le and abs_err_ge give the /n!-scale two-sided bound.",
+      "mathContext": "$\\left|\\tfrac{D(n)}{n!} - e^{-1}\\right| = |(-1)^{n+1} T(n+1)| = T(n+1)$, so the error is exactly the tail."
+    },
+    {
+      "id": "sec-integer-scale",
+      "title": "Integer-Scale Sandwich: 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1)",
+      "startLine": 133,
+      "endLine": 181,
+      "summary": "Lemma abs_int_eq_factorial_mul rewrites |D(n) − n!·e⁻¹| = n!·|D(n)/n! − e⁻¹| (abs_mul, n! > 0). Theorems abs_derangements_sub_le and abs_derangements_sub_ge multiply the /n!-scale bounds by n!, simplifying n!/(n+1)! = 1/(n+1) and n!·(1/(n+1)! − 1/(n+2)!) = 1/(n+2). Theorem derangements_two_sided_sandwich packages both bounds.",
+      "mathContext": "$\\tfrac{1}{n+2} \\le |D(n) - n!\\,e^{-1}| \\le \\tfrac{1}{n+1}$, since $n!\\left(\\tfrac{1}{(n+1)!} - \\tfrac{1}{(n+2)!}\\right) = \\tfrac{1}{n+1} - \\tfrac{1}{(n+1)(n+2)} = \\tfrac{1}{n+2}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-06",
+      "relationship": "extends",
+      "description": "Parent: proves D(n) = round(n!/e) for all n ≥ 1 using the one-sided bound |D(n) − n!·e⁻¹| ≤ 1/(n+1). This entry answers its first open question by adding the matching lower bound 1/(n+2), giving a two-sided sandwich."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "uses",
+      "description": "Reuses the alternating-series partial-sum envelope (alt_partial_sum_nonneg, alt_partial_sum_le_first) and tsum-splitting (tsum_eq_partial_sum_add_tail) — all the hard analysis lives here."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Root: derangement definitions D(n) = n!·Σ(−1)^k/k! and inclusion-exclusion."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "The strict lower bound |D(n) − n!·e⁻¹| ≥ 1/(n+2) > 0 certifies the error never vanishes, consistent with e being irrational (n!/e is never an integer)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for every n, 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1). This answers OQ-06's first open question with a Lean-verified two-sided sandwich, showing the parent's one-sided upper bound is sharp up to the trivial 1/(n+2)–1/(n+1) gap. The engine is the tail recurrence T(m) = 1/m! − T(m+1), which upgrades the parent's one-sided envelope into a two-sided one at no extra analytic cost. Zero sorries, zero axioms.",
+    "implications": "**Sharpness**: the derangement error is 1/(n+1) at integer scale to leading order — the upper bound is not improvable by more than the factor (n+1)/(n+2) → 1.\\n\\n**Non-vanishing**: the strict positive lower bound shows D(n) ≠ n!·e⁻¹ for every n, the quantitative shadow of e ∉ ℚ.\\n\\n**Reusability**: the tail recurrence T(m) = 1/m! − T(m+1) is a general device for turning one-sided alternating-series bounds into two-sided ones.",
+    "openQuestions": [
+      "Sharpen the sandwich to a genuine asymptotic equivalence |D(n) − n!·e⁻¹| = 1/(n+1) − 1/((n+1)(n+2)) + O(1/n³) by iterating the tail recurrence one more step (T(m) = 1/m! − 1/(m+1)! + T(m+2)).",
+      "Prove the exact alternating expansion |D(n) − n!·e⁻¹| = Σ_{j≥1} (−1)^{j+1}·n!/(n+j)! in Lean and read off both bounds as consecutive partial sums, unifying this entry's upper and lower bounds into one identity.",
+      "Extend the two-sided sandwich to partial derangements D(n, r) (permutations with exactly r fixed points), where D(n, r)/n! → e⁻¹/r!, and determine the analogous sharp band."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "derangements_two_sided_sandwich",
+      "type": "core",
+      "description": "For all n: 1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1) — the effective two-sided sandwich",
+      "leanType": "(n : ℕ) → 1 / (n + 2 : ℝ) ≤ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ∧ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ≤ 1 / (n + 1 : ℝ)"
+    },
+    {
+      "name": "abs_derangements_sub_ge",
+      "type": "core",
+      "description": "The new lower bound: |D(n) − n!·e⁻¹| ≥ 1/(n+2)",
+      "leanType": "(n : ℕ) → 1 / (n + 2 : ℝ) ≤ |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)|"
+    },
+    {
+      "name": "tailFrom_succ",
+      "type": "key-lemma",
+      "description": "The tail recurrence T(m) = 1/m! − T(m+1) driving the whole result",
+      "leanType": "(m : ℕ) → tailFrom m = 1 / (m.factorial : ℝ) - tailFrom (m + 1)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Real",
+      "BigOperators",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ06OQ01",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsConvergenceOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "First derivation of the derangement formula D(n) = n!·Σ_{k=0}^n (−1)^k/k! via inclusion-exclusion."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Independent treatment of derangements; stated the limit D(n)/n! → e⁻¹, the analytic fact whose error term this entry sandwiches."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3",
+      "note": "Classic statement of the rounding characterization of derangement numbers and the alternating tail representation."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, 2nd edition, §2.2",
+      "note": "Exponential generating function e^{-x}/(1−x) for derangements, from which the alternating tail and its bounds follow."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry answering **OQ-06 open question 1** of `derangements-convergence`: a **Lean-verified two-sided sandwich** on the exact derangement error.

For every `n`:
```
1/(n+2) ≤ |D(n) − n!·e⁻¹| ≤ 1/(n+1)
```

The parent (`derangements-convergence-oq-06`) proved only the **one-sided** upper bound `1/(n+1)`, which it used to pin down `D(n) = round(n!/e)`. Its first open question asked explicitly for a Lean-verified two-sided sandwich showing that bound is essentially sharp. This entry supplies the matching lower bound.

## Method

The error equals the alternating factorial tail `T(m) = ∑' k, (−1)ᵏ/(m+k)!`, with `|D(n)/n! − e⁻¹| = T(n+1)`. The whole result turns on one identity:
```
T(m) = 1/m! − T(m+1)        (peel the k=0 term; tsum_eq_zero_add)
```
Fed into the parent's one-sided envelope `0 ≤ T(m) ≤ 1/m!`, the upper bound on `T(m+1)` becomes a lower bound on `T(m)`, giving `1/m! − 1/(m+1)! ≤ T(m) ≤ 1/m!`. Multiplying by `n!` telescopes the lower bound to exactly `1/(n+2)`.

## Verification

- **Build**: `./proofs/scripts/docker-build.sh Proofs.DerangementsConvergenceOQ06OQ01` — succeeds (7744 jobs).
- **Status**: VERIFIED, **0-axiom** (no `sorry`/`axiom`/`native_decide`; reuses the verified 0-axiom parent lemmas).
- **Size**: 12 theorems/lemmas, 1 definition, 181 lines.

## Files

- `proofs/Proofs/DerangementsConvergenceOQ06OQ01.lean`
- `src/data/proofs/derangements-convergence-oq-06-oq-01/{meta.json,annotations.json,index.ts}`

Key results: `derangements_two_sided_sandwich`, `abs_derangements_sub_ge` (new lower bound), `tailFrom_succ` (the recurrence), `abs_err_eq_tailFrom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)