### PR TITLE
Enrich hilbert-17-oq-03-oq-05: module-overview annotation (59%→83%)

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-05/annotations.json
@@ -1,74 +1,158 @@
 [
   {
+    "id": "ann-h170305-overview",
+    "proofId": "hilbert-17-oq-03-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "Overview: The Sharp PSD Threshold of the Motzkin Family (c ≤ 3)",
+    "content": "The Motzkin polynomial M(x,y) = x⁴y² + x²y⁴ + 1 − 3x²y² is the canonical example of a positive-semidefinite polynomial that is NOT a sum of squares of polynomials; its parent entry establishes both facts, with the non-SOS side the deep content behind the open questions on deciding SOS membership and quantifying the PSD/SOS gap. This file isolates a complementary, fully elementary fact: the coefficient 3 in front of x²y² is SHARP. For the one-parameter family Mₐ(x,y) = x⁴y² + x²y⁴ + 1 − c·x²y², it proves the exact threshold Mₐ is PSD on ℝ² ⟺ c ≤ 3, so the Motzkin polynomial (c = 3) sits exactly on the boundary of the PSD cone for this family. This pins down WHY 3 is canonical: it is the largest constant for which non-negativity survives and the unique value at which the family is PSD but not SOS. The two directions: c ≤ 3 ⟹ PSD via the AM–GM step x⁴y² + x²y⁴ + 1 ≥ 3x²y² (an honest SOS certificate found by nlinarith) dominating (3−c)·x²y² ≥ 0; and c > 3 ⟹ not PSD by evaluating at (1,1) where Mₐ(1,1) = 3−c < 0. Everything is 0-axiom over ℝ and MvPolynomial (Fin 2) ℝ.",
+    "mathContext": "The Motzkin form's non-negativity is exactly the AM–GM inequality $\\tfrac{a+b+c}{3}\\ge\\sqrt[3]{abc}$ applied to $a=x^4y^2,b=x^2y^4,c=1$: $x^4y^2+x^2y^4+1\\ge 3x^2y^2$. Lowering the coefficient below $3$ preserves PSD; raising it above $3$ breaks it at $(1,1)$, so $c=3$ is the boundary of the PSD cone for the family.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Hilbert's 17th problem",
+      "positive semidefinite polynomial",
+      "sum of squares",
+      "Motzkin polynomial",
+      "AM–GM inequality",
+      "PSD cone"
+    ],
+    "prerequisites": [
+      "positive semidefinite polynomials",
+      "sums of squares",
+      "AM–GM inequality"
+    ]
+  },
+  {
     "id": "h17t-family-def",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 45, "endLine": 46 },
+    "range": {
+      "startLine": 45,
+      "endLine": 46
+    },
     "type": "definition",
     "title": "The Motzkin Family",
     "content": "motzkinFun c x y = x⁴y² + x²y⁴ + 1 − c·x²y² is the one-parameter Motzkin family evaluated at real arguments. At c = 3 it is the classical Motzkin polynomial; the whole point of this entry is to determine exactly which c keep it non-negative.",
     "mathContext": "$M_c(x,y) = x^4y^2 + x^2y^4 + 1 - c\\,x^2y^2$",
     "significance": "key",
-    "prerequisites": ["positive-semidefinite polynomials", "Motzkin polynomial"],
-    "relatedConcepts": ["Hilbert's 17th problem", "PSD/SOS gap", "one-parameter family"]
+    "prerequisites": [
+      "positive-semidefinite polynomials",
+      "Motzkin polynomial"
+    ],
+    "relatedConcepts": [
+      "Hilbert's 17th problem",
+      "PSD/SOS gap",
+      "one-parameter family"
+    ]
   },
   {
     "id": "h17t-amgm",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 51, "endLine": 57 },
+    "range": {
+      "startLine": 51,
+      "endLine": 57
+    },
     "type": "theorem",
     "title": "AM–GM Core: x⁴y² + x²y⁴ + 1 ≥ 3x²y²",
     "content": "The arithmetic–geometric mean inequality on the three non-negative terms x⁴y², x²y⁴, 1 (whose product is (x²y²)³) gives the bound 3x²y². This is a genuine sum-of-squares certificate — nlinarith finds it from squares like (xy−1)², (x²y−y)², (xy²−x)², (x²y²−1)². Crucially the AFFINE Motzkin form admits such a certificate even though the HOMOGENEOUS Motzkin polynomial provably does not; the dehomogenisation (setting z = 1) is what lets nlinarith succeed.",
     "mathContext": "$x^4y^2 + x^2y^4 + 1 \\ge 3x^2y^2$",
     "significance": "key",
-    "prerequisites": ["AM–GM inequality", "nlinarith", "sum-of-squares certificate"],
-    "relatedConcepts": ["arithmetic–geometric mean", "Positivstellensatz certificates", "homogenisation"]
+    "prerequisites": [
+      "AM–GM inequality",
+      "nlinarith",
+      "sum-of-squares certificate"
+    ],
+    "relatedConcepts": [
+      "arithmetic–geometric mean",
+      "Positivstellensatz certificates",
+      "homogenisation"
+    ]
   },
   {
     "id": "h17t-nonneg",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 59, "endLine": 69 },
+    "range": {
+      "startLine": 59,
+      "endLine": 69
+    },
     "type": "theorem",
     "title": "Sufficiency: c ≤ 3 ⟹ PSD",
     "content": "For c ≤ 3 the AM–GM certificate dominates the parametrized deficit. Since 0 ≤ x²y² and c ≤ 3, monotonicity gives c·x²y² ≤ 3·x²y², so M_c = (x⁴y² + x²y⁴ + 1) − c·x²y² ≥ 3x²y² − c·x²y² = (3 − c)·x²y² ≥ 0. A one-line linarith combines the AM–GM bound with the deficit inequality.",
     "mathContext": "$c \\le 3 \\;\\Rightarrow\\; M_c(x,y) \\ge (3-c)x^2y^2 \\ge 0$",
     "significance": "key",
-    "prerequisites": ["mul_le_mul_of_nonneg_right", "linarith"],
-    "relatedConcepts": ["monotonicity of multiplication", "non-negativity"]
+    "prerequisites": [
+      "mul_le_mul_of_nonneg_right",
+      "linarith"
+    ],
+    "relatedConcepts": [
+      "monotonicity of multiplication",
+      "non-negativity"
+    ]
   },
   {
     "id": "h17t-neg",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 71, "endLine": 77 },
+    "range": {
+      "startLine": 71,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "Necessity Witness: M_c(1,1) = 3 − c",
     "content": "Evaluating the family at the single test point (1,1) gives 1 + 1 + 1 − c = 3 − c, which is strictly negative whenever c > 3. This one point detects the entire boundary of the PSD region — the necessary side of the threshold needs no inequality machinery at all.",
     "mathContext": "$M_c(1,1) = 3 - c < 0 \\iff c > 3$",
     "significance": "supporting",
-    "prerequisites": ["polynomial evaluation"],
-    "relatedConcepts": ["test point", "boundary detection"]
+    "prerequisites": [
+      "polynomial evaluation"
+    ],
+    "relatedConcepts": [
+      "test point",
+      "boundary detection"
+    ]
   },
   {
     "id": "h17t-iff",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 79, "endLine": 99 },
+    "range": {
+      "startLine": 79,
+      "endLine": 99
+    },
     "type": "theorem",
     "title": "Sharp PSD Threshold (Real Form)",
     "content": "The headline result: M_c is non-negative on all of ℝ² if and only if c ≤ 3. Forward direction specialises PSD to the point (1,1) (forcing 0 ≤ 3 − c); backward direction is the AM–GM sufficiency. Corollaries: motzkin_nonneg is the boundary case c = 3 (the classical Motzkin polynomial is PSD), and three_is_sharp records that 3 is the largest PSD coefficient — the Motzkin polynomial is the extremal member of the family.",
     "mathContext": "$(\\forall x,y,\\ M_c(x,y) \\ge 0) \\iff c \\le 3$",
     "significance": "key",
-    "prerequisites": ["if and only if", "specialisation to a point"],
-    "relatedConcepts": ["sharp constant", "extremal PSD polynomial", "PSD cone boundary"]
+    "prerequisites": [
+      "if and only if",
+      "specialisation to a point"
+    ],
+    "relatedConcepts": [
+      "sharp constant",
+      "extremal PSD polynomial",
+      "PSD cone boundary"
+    ]
   },
   {
     "id": "h17t-poly",
     "proofId": "hilbert-17-oq-03-oq-05",
-    "range": { "startLine": 107, "endLine": 142 },
+    "range": {
+      "startLine": 107,
+      "endLine": 142
+    },
     "type": "theorem",
     "title": "Threshold for the Genuine Polynomial Object",
     "content": "The same threshold for motzkinPoly c : MvPolynomial (Fin 2) ℝ under the PSD predicate IsPSDMv, which matches the parent entry's IsPositiveSemidefiniteMv. The simp lemma eval_motzkinPoly identifies eval v (motzkinPoly c) with motzkinFun c (v 0) (v 1) (via map_add/map_mul/map_pow/eval_X/eval_C), so motzkinPoly_psd_iff (IsPSDMv (motzkinPoly c) ⟺ c ≤ 3) transports the real-function result to the polynomial setting. motzkinPoly_three_psd records that the Motzkin polynomial is PSD as a bivariate polynomial.",
     "mathContext": "$\\mathrm{IsPSDMv}(\\mathrm{motzkinPoly}\\,c) \\iff c \\le 3$",
     "significance": "key",
-    "prerequisites": ["MvPolynomial.eval", "ring-homomorphism simp lemmas"],
-    "relatedConcepts": ["multivariate polynomial", "PSD predicate", "definitional equality with parent"]
+    "prerequisites": [
+      "MvPolynomial.eval",
+      "ring-homomorphism simp lemmas"
+    ],
+    "relatedConcepts": [
+      "multivariate polynomial",
+      "PSD predicate",
+      "definitional equality with parent"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 1-34), previously unannotated. Frames the sharp PSD threshold c ≤ 3 of the Motzkin family and the AM–GM certificate. Annotations 6→7; no Lean source changes.

Label: enrichment