### PR TITLE
Enrich spectral-trace-det-eigenvalues-oq-02: module-overview annotation (64%→90%)

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/annotations.json
@@ -1,50 +1,122 @@
 [
   {
+    "id": "ann-stde02-overview",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Overview: Cyclic Invariance of the Trace and Its Eigenvalue Consequences",
+    "content": "The trace of a product is unchanged by cyclically permuting the factors — the workhorse behind similarity-invariance of the trace, the trace as a conjugacy-class function (well defined on endomorphisms, not just matrices), the Killing/trace form in Lie theory, and the vanishing trace of any commutator. Mathlib proves the headline identities (Matrix.trace_mul_comm, even for rectangular A and B living in different matrix algebras; Matrix.trace_mul_cycle), re-exported here under self-documenting names. The file adds content the gallery (and Mathlib's elementary surface) lacks: trace_commutator_eq_zero (tr(A·B − B·A) = 0 with honest subtraction, not just via the Lie bracket); trace_conj_of_isUnit_det (similarity invariance tr(P⁻¹·A·P) = tr(A) stated with the determinant hypothesis IsUnit P.det, the form verified in practice, tying to the spectral det=0 singularity picture of oq-01); and trace_eq_of_conj (similar matrices have equal trace, a class-function statement). Finally it connects cyclic invariance to the EIGENVALUE picture: conjugation leaves the characteristic polynomial unchanged, so over any field similar matrices share their ENTIRE eigenvalue multiset (eigenvalues_units_conj) — strictly stronger than sharing trace and determinant — with sum/product specialisations recovering trace and det invariance. Closing examples over ℤ include a cross-dimension witness (A·B is 1×1, B·A is 2×2, both traces 11) and a non-commuting pair. All 0-axiom, no sorry.",
+    "mathContext": "Cyclic invariance $\\operatorname{tr}(AB)=\\operatorname{tr}(BA)$ (holding even for rectangular $A,B$) makes the trace a conjugacy-class function: $\\operatorname{tr}(P^{-1}AP)=\\operatorname{tr}(A)$. More strongly, conjugation fixes the characteristic polynomial, so similar matrices share the full eigenvalue multiset, of which $\\operatorname{tr}=\\sum\\lambda_i$ and $\\det=\\prod\\lambda_i$ are the elementary-symmetric shadows.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "trace of a matrix",
+      "cyclic invariance",
+      "similarity invariance",
+      "characteristic polynomial",
+      "eigenvalues",
+      "commutator"
+    ],
+    "prerequisites": [
+      "matrix trace and determinant",
+      "similar matrices",
+      "characteristic polynomial and eigenvalues"
+    ]
+  },
+  {
     "id": "spectrace-ann-cyclic",
     "proofId": "spectral-trace-det-eigenvalues-oq-02",
-    "range": { "startLine": 65, "endLine": 79 },
+    "range": {
+      "startLine": 65,
+      "endLine": 79
+    },
     "type": "concept",
     "title": "Cyclic Invariance of the Trace, Including the Rectangular Case",
     "content": "The headline identities, re-exported from Mathlib under self-documenting names. trace_mul_comm states tr(A·B) = tr(B·A) even when A·B and B·A live in DIFFERENT matrix algebras — A is m×l and B is l×m, so A·B is m×m while B·A is l×l, yet the traces agree. trace_mul_cycle gives the three-factor form tr(A·B·C) = tr(C·A·B). Both reduce to reindexing a double sum ∑ᵢⱼ Aᵢⱼ Bⱼᵢ, which is symmetric under swapping the roles of the two index types.",
     "mathContext": "$\\operatorname{tr}(AB) = \\sum_{i,j} A_{ij}B_{ji} = \\operatorname{tr}(BA)$, valid for $A\\in M_{m\\times l},\\ B\\in M_{l\\times m}$; and $\\operatorname{tr}(ABC)=\\operatorname{tr}(CAB)$.",
     "significance": "key",
-    "relatedConcepts": ["Matrix.trace", "cyclic invariance", "rectangular matrices", "Matrix.trace_mul_comm", "double-sum reindexing"],
-    "prerequisites": ["matrix multiplication", "trace as the diagonal sum"]
+    "relatedConcepts": [
+      "Matrix.trace",
+      "cyclic invariance",
+      "rectangular matrices",
+      "Matrix.trace_mul_comm",
+      "double-sum reindexing"
+    ],
+    "prerequisites": [
+      "matrix multiplication",
+      "trace as the diagonal sum"
+    ]
   },
   {
     "id": "spectrace-ann-commutator-similarity",
     "proofId": "spectral-trace-det-eigenvalues-oq-02",
-    "range": { "startLine": 80, "endLine": 108 },
+    "range": {
+      "startLine": 80,
+      "endLine": 108
+    },
     "type": "insight",
     "title": "The Commutator Trace Vanishes; the Trace Is a Class Function",
     "content": "Content Mathlib states only obliquely. trace_commutator_eq_zero writes tr(A·B − B·A) = 0 with an HONEST subtraction (Mathlib has it only via the Lie bracket ⁅A,B⁆), an immediate consequence of cyclic invariance. trace_conj_of_isUnit_det gives similarity invariance in the practically-checkable determinant form: tr(P⁻¹·A·P) = tr(A) under IsUnit P.det (not requiring P to be a bundled unit), by cycling P⁻¹·A·P to A·P·P⁻¹ = A. trace_eq_of_conj packages this as the conjugacy-class-function statement: similar matrices have equal trace.",
     "mathContext": "$\\operatorname{tr}(AB - BA) = 0$; and $\\det P$ a unit $\\Rightarrow \\operatorname{tr}(P^{-1}AP) = \\operatorname{tr}(A)$.",
     "significance": "key",
-    "relatedConcepts": ["commutator", "Lie bracket", "similarity invariance", "IsUnit P.det", "conjugacy class invariant"],
-    "prerequisites": ["cyclic invariance of the trace", "invertibility via unit determinant"]
+    "relatedConcepts": [
+      "commutator",
+      "Lie bracket",
+      "similarity invariance",
+      "IsUnit P.det",
+      "conjugacy class invariant"
+    ],
+    "prerequisites": [
+      "cyclic invariance of the trace",
+      "invertibility via unit determinant"
+    ]
   },
   {
     "id": "spectrace-ann-eigenvalues",
     "proofId": "spectral-trace-det-eigenvalues-oq-02",
-    "range": { "startLine": 109, "endLine": 148 },
+    "range": {
+      "startLine": 109,
+      "endLine": 148
+    },
     "type": "insight",
     "title": "Similar Matrices Share Their Entire Eigenvalue Multiset",
     "content": "The bridge to the eigenvalue picture, strictly stronger than sharing trace and determinant. eigenvalues A := A.charpoly.roots is the multiset of roots of the characteristic polynomial (algebraic multiplicity). eigenvalues_units_conj shows conjugation by a unit P preserves the WHOLE multiset, because conjugation preserves the characteristic polynomial itself (Matrix.charpoly_units_conj'). sum_eigenvalues_units_conj and prod_eigenvalues_units_conj then recover trace and determinant invariance respectively, by routing through the oq-01 identities tr A = Σ eigenvalues, det A = Π eigenvalues — exhibiting trace/det invariance as shadows of the full spectral invariance.",
     "mathContext": "Conjugation fixes $\\chi_A$, so similar matrices have equal eigenvalue multisets; $\\sum$ recovers $\\operatorname{tr}$, $\\prod$ recovers $\\det$.",
     "significance": "key",
-    "relatedConcepts": ["characteristic polynomial", "Matrix.charpoly_units_conj'", "eigenvalue multiset", "trace = sum of eigenvalues", "det = product of eigenvalues"],
-    "prerequisites": ["characteristic polynomial and its roots", "the oq-01 trace/det-eigenvalue identities"]
+    "relatedConcepts": [
+      "characteristic polynomial",
+      "Matrix.charpoly_units_conj'",
+      "eigenvalue multiset",
+      "trace = sum of eigenvalues",
+      "det = product of eigenvalues"
+    ],
+    "prerequisites": [
+      "characteristic polynomial and its roots",
+      "the oq-01 trace/det-eigenvalue identities"
+    ]
   },
   {
     "id": "spectrace-ann-examples",
     "proofId": "spectral-trace-det-eigenvalues-oq-02",
-    "range": { "startLine": 150, "endLine": 196 },
+    "range": {
+      "startLine": 150,
+      "endLine": 196
+    },
     "type": "concept",
     "title": "Concrete ℤ Witnesses",
     "content": "Worked integer examples making the phenomena tangible. trace_mul_comm_cross_dim(_value): a 1×2 and a 2×1 matrix whose products A·B (1×1) and B·A (2×2) have different SIZES yet both trace 11 — the rectangular case in action. trace_mul_comm_noncomm_example with mul_comm_noncomm_example_ne and _value: a non-commuting pair (A·B ≠ B·A as matrices) whose two products nonetheless share trace 3 — equal traces do not imply equal products. trace_commutator_example: that pair's commutator A·B − B·A has trace 0, the general vanishing made concrete.",
     "mathContext": "Cross-dim: $\\operatorname{tr}(AB)=\\operatorname{tr}(BA)=11$ with $AB\\in M_1,\\ BA\\in M_2$. Non-commuting: $AB\\neq BA$ but both trace $3$; $\\operatorname{tr}(AB-BA)=0$.",
     "significance": "supporting",
-    "relatedConcepts": ["concrete witnesses", "rectangular products", "non-commuting matrices", "decide/norm_num evaluation"],
-    "prerequisites": ["the cyclic-invariance and commutator identities"]
+    "relatedConcepts": [
+      "concrete witnesses",
+      "rectangular products",
+      "non-commuting matrices",
+      "decide/norm_num evaluation"
+    ],
+    "prerequisites": [
+      "the cyclic-invariance and commutator identities"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 3-54), previously unannotated. Frames cyclic trace invariance, similarity invariance, and the stronger shared-eigenvalue-multiset consequence. Annotations 4→5; no Lean source changes.

Label: enrichment