### PR TITLE
Enrich synthesis-curvature-ptolemy-oq-03: module-overview annotation (64%→91%)

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-03/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-03/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "ann-scp03-overview",
+    "proofId": "synthesis-curvature-ptolemy-oq-03",
+    "range": {
+      "startLine": 8,
+      "endLine": 75
+    },
+    "type": "concept",
+    "title": "Overview: Joint Continuity of curvatureSin in Curvature K and Parameter t",
+    "content": "The parent defines the curvature-parametrized sine curvatureSin K t (equal to t for K=0 Euclidean, sin(√K·t)/√K for K>0 spherical, sinh(√(−K)·t)/√(−K) for K<0 hyperbolic), unifying the three constant-curvature geometries; it proves properties for FIXED K. This entry proves the JOINT continuity of (K,t) ↦ curvatureSin K t as ℝ×ℝ → ℝ — the precise sense in which the three geometries vary continuously with curvature, with no discontinuity at the Euclidean seam K=0 even though the FORMULA switches there between sin and sinh. The argument factors the seam into a single real variable: define the curvature sinc curvatureSinc x (=1 at 0, sin(√x)/√x for x>0, sinh(√(−x))/√(−x) for x<0) and prove the identity curvatureSin K t = t·curvatureSinc(K·t²), collapsing the branches (with their ± sign bookkeeping from oddness) onto the EVEN function curvatureSinc via √(Kt²) = √K·|t|. Continuity then reduces to curvatureSinc being continuous away from 0 (a quotient of continuous functions) and at the seam x=0, where both one-sided limits are 1 (sin'0 = cos 0 = 1, sinh'0 = cosh 0 = 1 via HasDerivAt.tendsto_slope), glued through 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0. Joint continuity of t·curvatureSinc(Kt²) is then immediate. 0 sorry, 0 axiom.",
+    "mathContext": "The generalized sine $\\operatorname{sn}_K(t)$ of constant-curvature geometry equals $t\\cdot\\operatorname{sinc}_K(Kt^2)$ where $\\operatorname{sinc}_K$ is even; continuity across the Euclidean seam $K=0$ follows from $\\lim_{u\\to 0}\\sin(\\sqrt u)/\\sqrt u = \\lim_{u\\to 0}\\sinh(\\sqrt u)/\\sqrt u = 1$, i.e. $\\sin'(0)=\\sinh'(0)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "constant curvature geometry",
+      "curvature-parametrized sine",
+      "joint continuity",
+      "one-sided limits",
+      "derivative as slope limit",
+      "sinc function"
+    ],
+    "prerequisites": [
+      "continuity in metric spaces",
+      "derivatives and slope limits",
+      "spherical and hyperbolic trigonometry"
+    ]
+  },
+  {
     "id": "ann-scp-oq03-defs",
     "proofId": "synthesis-curvature-ptolemy-oq-03",
-    "range": { "startLine": 88, "endLine": 116 },
+    "range": {
+      "startLine": 88,
+      "endLine": 116
+    },
     "type": "concept",
     "title": "curvatureSin and the curvature sinc",
     "content": "`curvatureSin K t` is the constant-curvature sine: `sin(√K·t)/√K` for `K>0`, the identity `t` for `K=0`, and `sinh(√(−K)·t)/√(−K)` for `K<0`. It is reproduced verbatim from the parent entry so this development depends only on Mathlib.\n\nThe **curvature sinc** `curvatureSinc x` is the even companion: `sin(√x)/√x` for `x>0`, `1` at `x=0`, and `sinh(√(−x))/√(−x)` for `x<0`. It carries the entire seam analysis on a single real variable.",
     "mathContext": "curvatureSin K is the unique solution of the Jacobi equation y'' + K·y = 0 with y(0)=0, y'(0)=1. The curvature sinc is the entire function ∑ₙ (−x)ⁿ/(2n+1)!, equal to sin(√x)/√x for x>0 and sinh(√(−x))/√(−x) for x<0.",
     "significance": "supporting",
-    "relatedConcepts": ["Jacobi field", "Cardinal sine", "Constant curvature"],
-    "prerequisites": ["Real sin and sinh", "Real.sqrt"]
+    "relatedConcepts": [
+      "Jacobi field",
+      "Cardinal sine",
+      "Constant curvature"
+    ],
+    "prerequisites": [
+      "Real sin and sinh",
+      "Real.sqrt"
+    ]
   },
   {
     "id": "ann-scp-oq03-factorization",
     "proofId": "synthesis-curvature-ptolemy-oq-03",
-    "range": { "startLine": 118, "endLine": 144 },
+    "range": {
+      "startLine": 118,
+      "endLine": 144
+    },
     "type": "tactic",
     "title": "One-variable factorization curvatureSin K t = t·curvatureSinc(K·t²)",
     "content": "The key identity that makes the proof tractable. It folds the three sign-laden branches of `curvatureSin` onto the three branches of the **even** `curvatureSinc`, using `√(K·t²) = √K·|t|` and the oddness of `sin` and `sinh` to absorb the sign of `t` against the leading factor `t`.\n\nProof is by cases on `K = 0`, `t = 0`, and the signs of `K` and `t`; each leaf closes by `field_simp` after rewriting the absolute value and the relevant odd-function identity.",
     "mathContext": "Because u ↦ sin(u)/u and u ↦ sinh(u)/u are even, sin(√K·t)/√K = t·(sin(√K·|t|)/(√K·|t|)) regardless of the sign of t. The two-variable seam line K=0 is thereby reduced to the single seam point x=0 of curvatureSinc.",
     "significance": "key",
-    "relatedConcepts": ["Even and odd functions", "Absolute value", "Square root of a product"],
-    "prerequisites": ["Real.sqrt_mul", "Real.sqrt_sq_eq_abs", "sin_neg / sinh_neg"]
+    "relatedConcepts": [
+      "Even and odd functions",
+      "Absolute value",
+      "Square root of a product"
+    ],
+    "prerequisites": [
+      "Real.sqrt_mul",
+      "Real.sqrt_sq_eq_abs",
+      "sin_neg / sinh_neg"
+    ]
   },
   {
     "id": "ann-scp-oq03-sinc-limits",
     "proofId": "synthesis-curvature-ptolemy-oq-03",
-    "range": { "startLine": 146, "endLine": 189 },
+    "range": {
+      "startLine": 146,
+      "endLine": 189
+    },
     "type": "tactic",
     "title": "Cardinal-sine limits from the slope characterization",
     "content": "`sin(u)/u → 1` and `sinh(u)/u → 1` over the punctured neighbourhood of `0` are obtained directly from `HasDerivAt.tendsto_slope`: the slope `(f(u) − f(0))/(u − 0)` of `sin` (resp. `sinh`) at `0` tends to the derivative `cos 0 = 1` (resp. `cosh 0 = 1`). Companion lemmas show `√` and `x ↦ √(−x)` carry the right/left punctured neighbourhood of 0 into the punctured neighbourhood of 0, so the limits transport to the curvature sinc.",
     "mathContext": "Avoiding any explicit cubic Taylor estimate: the cardinal-sine limit is literally the definition of the derivative at 0, packaged by Mathlib's slope-to-derivative equivalence.",
     "significance": "key",
-    "relatedConcepts": ["Slope of the derivative", "Punctured neighbourhood", "Cardinal sine"],
-    "prerequisites": ["HasDerivAt.tendsto_slope", "Real.hasDerivAt_sin / Real.hasDerivAt_sinh", "tendsto_nhdsWithin_iff"]
+    "relatedConcepts": [
+      "Slope of the derivative",
+      "Punctured neighbourhood",
+      "Cardinal sine"
+    ],
+    "prerequisites": [
+      "HasDerivAt.tendsto_slope",
+      "Real.hasDerivAt_sin / Real.hasDerivAt_sinh",
+      "tendsto_nhdsWithin_iff"
+    ]
   },
   {
     "id": "ann-scp-oq03-joint",
     "proofId": "synthesis-curvature-ptolemy-oq-03",
-    "range": { "startLine": 190, "endLine": 247 },
+    "range": {
+      "startLine": 190,
+      "endLine": 247
+    },
     "type": "theorem",
     "title": "Continuity of the curvature sinc and joint continuity of curvatureSin",
     "content": "Away from `0`, `curvatureSinc` is a quotient of continuous functions with nonzero denominator. At the seam `x = 0`, the two one-sided limits both equal the value `1`, so gluing them via `𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0` and `continuousAt_iff_punctured_nhds` gives `ContinuousAt curvatureSinc 0`. Joint continuity of `(K,t) ↦ curvatureSin K t = t·curvatureSinc(K·t²)` then follows from the ring operations. A `Function.uncurry` restatement is also provided.",
     "mathContext": "The seam value 1 is forced as the common value of both one-sided limits and of the Euclidean branch curvatureSin 0 t = t — it is the normalization y'(0)=1 of the Jacobi equation. The three constant-curvature geometries glue continuously across K=0.",
     "significance": "key",
-    "relatedConcepts": ["Joint continuity", "Order-topology gluing", "Comparison geometry"],
-    "prerequisites": ["continuousAt_iff_punctured_nhds", "nhdsLT_sup_nhdsGT", "ContinuousAt.div"]
+    "relatedConcepts": [
+      "Joint continuity",
+      "Order-topology gluing",
+      "Comparison geometry"
+    ],
+    "prerequisites": [
+      "continuousAt_iff_punctured_nhds",
+      "nhdsLT_sup_nhdsGT",
+      "ContinuousAt.div"
+    ]
   }
 ]


### PR DESCRIPTION
Adds one overview `concept` annotation over the module docstring (lines 8-75), previously unannotated. Frames joint continuity of curvatureSin across the Euclidean seam via the curvatureSinc factorization. Annotations 4→5; no Lean source changes.

Label: enrichment