### PR TITLE
Enrich Hilbert 13 OQ-02-01 (discrete spaces 0-dimensional): coverage (42%→87%)

### DIFF
--- a/src/data/proofs/hilbert-13-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-13-oq-02-oq-01/annotations.json
@@ -1,62 +1,170 @@
 [
   {
+    "id": "ann-header-hilbert13-oq0201",
+    "proofId": "hilbert-13-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Discrete spaces are zero-dimensional — a concrete covering dimension",
+    "content": "The header docstring frames the file within Hilbert's 13th problem. The parent `Hilbert13OQ02.lean` defines a universe-safe Lebesgue covering dimension covDimLE X n (every finite open cover admits a finite open refinement of order ≤ n+1) and proves it is a topological invariant, so the Kolmogorov–Arnold superposition term count 2·dim(X)+1 is presentation-independent — but the only space whose dimension it actually computes is a subsingleton. This file supplies the first NONTRIVIAL computation: every discrete space has covering dimension 0. The proof is a clean disjointification — replace each cover set by its 'least-index' part V i = {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j}, so x ∈ V i iff i is the SMALLEST index whose cover set contains x. The V i are pairwise disjoint (order ≤ 1 = 0+1), still cover X (least containing index via Finset.min'), and refine the cover (V i ⊆ cover i). Discreteness enters at exactly one point — openness: V i is a finite intersection of a cover set with complements of cover sets, open only because every subset of a discrete space is open (isOpen_discrete). That is precisely why the statement fails for ℝⁿ. Corollaries recover the parent's covDimLE_of_subsingleton (subsingleton ⟹ discrete) and record monotonicity covDimLE_of_le. 0 axioms, 0 sorries.",
+    "mathContext": "$\\dim_{\\mathrm{cov}} X \\le n$: every finite open cover has a finite open refinement of order $\\le n+1$. Headline: $X$ discrete $\\Rightarrow \\dim_{\\mathrm{cov}} X = 0$, via the disjointification $V_i = \\{x : x\\in \\mathrm{cover}_i \\wedge \\forall j,\\ x\\in\\mathrm{cover}_j \\Rightarrow i\\le j\\}$ (order $\\le 1$). Openness of $V_i$ needs $\\mathrm{isOpen\\_discrete}$; fails on $\\mathbb{R}^n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lebesgue covering dimension",
+      "Hilbert's 13th problem",
+      "Kolmogorov–Arnold superposition",
+      "discrete topology",
+      "disjointification",
+      "topological invariant"
+    ],
+    "prerequisites": [
+      "covering dimension",
+      "open covers and refinements",
+      "discrete spaces"
+    ]
+  },
+  {
     "id": "ann-h13oq0201-coverorderat",
     "proofId": "hilbert-13-oq-02-oq-01",
-    "range": { "startLine": 48, "endLine": 53 },
+    "range": {
+      "startLine": 45,
+      "endLine": 53
+    },
     "type": "definition",
     "title": "Cover order at a point",
-    "content": "coverOrderAt measures how many sets of a cover contain a given point, as the Set.ncard (natural-number cardinality) of the index set {i | x ∈ sets i}. coverOrderAtMost sets a uniform bound: the cover has order ≤ n+1 when no point lies in more than n+1 sets. Using ncard rather than a Finset.card avoids needing a decidability or fintype instance on the index type, keeping the definition universe- and instance-light — the same choice the parent file makes.",
+    "content": "coverOrderAt measures how many sets of a cover contain a given point, as the Set.ncard (natural-number cardinality) of the index set {i | x ∈ sets i}. coverOrderAtMost sets a uniform bound: the cover has order ≤ n+1 when no point lies in more than n+1 sets. Using ncard rather than a Finset.card avoids needing a decidability or fintype instance on the index type, keeping the definition universe- and instance-light — the same choice the parent file makes. Also covers the section header and the companion definition `coverOrderAtMost` (a cover has order ≤ n+1 when every point lies in at most n+1 of its sets).",
     "mathContext": "$\\mathrm{ord}_x(\\text{sets}) = \\bigl|\\{i : x \\in \\text{sets}_i\\}\\bigr|;\\quad \\text{order} \\le n{+}1 :\\equiv \\forall x,\\ \\mathrm{ord}_x \\le n{+}1.$",
     "significance": "supporting",
-    "relatedConcepts": ["Lebesgue covering dimension", "order of a cover", "Set.ncard", "open cover"],
-    "prerequisites": ["open covers", "cardinality of sets", "topological spaces"]
+    "relatedConcepts": [
+      "Lebesgue covering dimension",
+      "order of a cover",
+      "Set.ncard",
+      "open cover"
+    ],
+    "prerequisites": [
+      "open covers",
+      "cardinality of sets",
+      "topological spaces"
+    ]
   },
   {
     "id": "ann-h13oq0201-covdimle",
     "proofId": "hilbert-13-oq-02-oq-01",
-    "range": { "startLine": 61, "endLine": 68 },
+    "range": {
+      "startLine": 55,
+      "endLine": 68
+    },
     "type": "definition",
     "title": "Covering dimension ≤ n",
-    "content": "covDimLE X n is the universe-safe Lebesgue covering dimension predicate from the parent: every finite open cover (indexed by Fin m) admits a finite open refinement (indexed by Fin p) of order ≤ n+1. Refinement means each refining set lies inside some original cover set. This is the engine that turns the geometric notion 'dimension ≤ n' into a finitary, choice-light statement, and dim X = 0 is exactly covDimLE X 0: every finite open cover can be thinned to a pairwise-disjoint (order-1) open cover.",
+    "content": "covDimLE X n is the universe-safe Lebesgue covering dimension predicate from the parent: every finite open cover (indexed by Fin m) admits a finite open refinement (indexed by Fin p) of order ≤ n+1. Refinement means each refining set lies inside some original cover set. This is the engine that turns the geometric notion 'dimension ≤ n' into a finitary, choice-light statement, and dim X = 0 is exactly covDimLE X 0: every finite open cover can be thinned to a pairwise-disjoint (order-1) open cover. Also covers `def IsRefinement` (B refines A when every set of B sits inside some set of A) — the notion of a finite open refinement that the dimension bound quantifies over.",
     "mathContext": "$\\dim X \\le n :\\equiv \\forall\\ \\text{finite open cover}\\ \\exists\\ \\text{finite open refinement of order} \\le n{+}1.$",
     "significance": "key",
-    "relatedConcepts": ["covering dimension", "refinement of a cover", "zero-dimensional space", "finite open cover"],
-    "prerequisites": ["open covers and refinements", "Lebesgue covering dimension", "Fin-indexed families"]
+    "relatedConcepts": [
+      "covering dimension",
+      "refinement of a cover",
+      "zero-dimensional space",
+      "finite open cover"
+    ],
+    "prerequisites": [
+      "open covers and refinements",
+      "Lebesgue covering dimension",
+      "Fin-indexed families"
+    ]
   },
   {
     "id": "ann-h13oq0201-monotone",
     "proofId": "hilbert-13-oq-02-oq-01",
-    "range": { "startLine": 79, "endLine": 82 },
+    "range": {
+      "startLine": 72,
+      "endLine": 82
+    },
     "type": "tactic",
     "title": "Monotonicity of the dimension bound",
-    "content": "covDimLE_of_le establishes that the dimension bound is upward closed: if dim X ≤ n and n ≤ N then dim X ≤ N. The proof iterates the single-step covDimLE_succ (which only weakens the order bound n+1 to n+2 on the same refinement) via Nat.le_induction over the inequality n ≤ N. This is the order-theoretic housekeeping that lets later results state the sharpest bound and freely relax it.",
+    "content": "covDimLE_of_le establishes that the dimension bound is upward closed: if dim X ≤ n and n ≤ N then dim X ≤ N. The proof iterates the single-step covDimLE_succ (which only weakens the order bound n+1 to n+2 on the same refinement) via Nat.le_induction over the inequality n ≤ N. This is the order-theoretic housekeeping that lets later results state the sharpest bound and freely relax it. Also covers `covDimLE_succ` (the +1 step `dim X ≤ n ⟹ dim X ≤ n+1`), the base case iterated by the general `≤` monotonicity.",
     "mathContext": "$\\dim X \\le n \\ \\wedge\\ n \\le N \\ \\Rightarrow\\ \\dim X \\le N,\\quad \\text{by induction on}\\ n \\le N.$",
     "significance": "supporting",
-    "relatedConcepts": ["monotonicity", "Nat.le_induction", "covering dimension", "upward-closed predicate"],
-    "prerequisites": ["induction on ≤", "covering dimension bound"]
+    "relatedConcepts": [
+      "monotonicity",
+      "Nat.le_induction",
+      "covering dimension",
+      "upward-closed predicate"
+    ],
+    "prerequisites": [
+      "induction on ≤",
+      "covering dimension bound"
+    ]
   },
   {
     "id": "ann-h13oq0201-discrete",
     "proofId": "hilbert-13-oq-02-oq-01",
-    "range": { "startLine": 93, "endLine": 134 },
+    "range": {
+      "startLine": 86,
+      "endLine": 134
+    },
     "type": "insight",
     "title": "Discrete spaces are zero-dimensional (headline)",
-    "content": "The main result, by least-index disjointification. Given a finite open cover, define V i = {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j}: x ∈ V i exactly when i is the smallest index whose set covers x. Four obligations: (1) Open — each V i is open because in a discrete space every subset is open (isOpen_discrete); this is the only step that uses discreteness and exactly why the result fails for ℝⁿ. (2) Covers — every point has a least covering index, selected by Finset.min' over the nonempty filtered index set. (3) Refines — V i ⊆ cover i by construction. (4) Order ≤ 1 — if x ∈ V i and x ∈ V i' then i ≤ i' and i' ≤ i so i = i', meaning the index set {i | x ∈ V i} is a subsingleton, which Set.ncard_le_ncard bounds by the singleton's cardinality 1.",
+    "content": "The main result, by least-index disjointification. Given a finite open cover, define V i = {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j}: x ∈ V i exactly when i is the smallest index whose set covers x. Four obligations: (1) Open — each V i is open because in a discrete space every subset is open (isOpen_discrete); this is the only step that uses discreteness and exactly why the result fails for ℝⁿ. (2) Covers — every point has a least covering index, selected by Finset.min' over the nonempty filtered index set. (3) Refines — V i ⊆ cover i by construction. (4) Order ≤ 1 — if x ∈ V i and x ∈ V i' then i ≤ i' and i' ≤ i so i = i', meaning the index set {i | x ∈ V i} is a subsingleton, which Set.ncard_le_ncard bounds by the singleton's cardinality 1. Also covers the theorem's docstring, which spells out the least-index disjointification `V i = {x | x ∈ cover i ∧ ∀ j, x ∈ cover j → i ≤ j}`.",
     "mathContext": "$V_i = \\{x : x \\in \\text{cover}_i \\wedge \\forall j,\\ x \\in \\text{cover}_j \\to i \\le j\\};\\quad \\text{disjoint, open, refining, covering} \\Rightarrow \\dim X \\le 0.$",
     "significance": "key",
-    "relatedConcepts": ["disjointification", "discrete topology", "isOpen_discrete", "Finset.min'", "zero-dimensional space"],
-    "prerequisites": ["discrete topology (every subset open)", "Finset.min' for least element", "Set.ncard order lemmas", "antisymmetry of ≤"]
+    "relatedConcepts": [
+      "disjointification",
+      "discrete topology",
+      "isOpen_discrete",
+      "Finset.min'",
+      "zero-dimensional space"
+    ],
+    "prerequisites": [
+      "discrete topology (every subset open)",
+      "Finset.min' for least element",
+      "Set.ncard order lemmas",
+      "antisymmetry of ≤"
+    ]
   },
   {
     "id": "ann-h13oq0201-subsingleton",
     "proofId": "hilbert-13-oq-02-oq-01",
-    "range": { "startLine": 140, "endLine": 148 },
+    "range": {
+      "startLine": 140,
+      "endLine": 148
+    },
     "type": "concept",
     "title": "Subsingleton corollary recovers the parent's base case",
     "content": "covDimLE_of_subsingleton shows a space with at most one point is zero-dimensional, now as a one-line corollary rather than a standalone proof. The bridge: a subsingleton space is discrete — via discreteTopology_iff_forall_isOpen, every subset is either ∅ or all of univ (since all points are equal), and both are open in any topology — so covDimLE_of_discrete applies. This subsumes the parent file's isolated single-point computation into the general discrete-space result.",
     "mathContext": "$\\mathrm{Subsingleton}\\,X \\Rightarrow \\mathrm{DiscreteTopology}\\,X \\Rightarrow \\dim X \\le 0.$",
     "significance": "supporting",
-    "relatedConcepts": ["subsingleton", "discrete topology", "discreteTopology_iff_forall_isOpen", "corollary"],
-    "prerequisites": ["subsingleton types", "discrete topology characterization"]
+    "relatedConcepts": [
+      "subsingleton",
+      "discrete topology",
+      "discreteTopology_iff_forall_isOpen",
+      "corollary"
+    ],
+    "prerequisites": [
+      "subsingleton types",
+      "discrete topology characterization"
+    ]
+  },
+  {
+    "id": "ann-summary-hilbert13-oq0201",
+    "proofId": "hilbert-13-oq-02-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 161
+    },
+    "type": "context",
+    "title": "Summary and honest scope",
+    "content": "The closing summary recaps the three verified results (monotonicity covDimLE_succ/covDimLE_of_le, the headline covDimLE_of_discrete, and the recovered corollary covDimLE_of_subsingleton) and states the honest scope: the genuinely open OQ-02 — the COMPUTATIONAL complexity of producing a Kolmogorov–Arnold superposition for an effectively-presented continuous function — remains untouched. This file only adds verified structural facts about the dimension that controls the 2n+1 term count, not the computational core of the open problem.",
+    "mathContext": "Verified: monotonicity, $X$ discrete $\\Rightarrow \\dim = 0$, subsingleton corollary. Untouched: the computational complexity of KA superposition for effectively-presented $f \\in C([0,1]^n)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "honest scope",
+      "open problem",
+      "computational complexity",
+      "Kolmogorov–Arnold representation"
+    ],
+    "prerequisites": [
+      "covering dimension"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `hilbert-13-oq-02-oq-01`. The 5 existing annotations left the 37-line header docstring, the summary, and several defs unannotated — coverage 42% of 163 lines.

**Changes (annotations.json):**
- Added a header annotation (1-37) explaining the least-index disjointification proof that every discrete space has covering dimension 0, and where discreteness enters (openness via `isOpen_discrete`).
- Added a summary annotation (150-161) with the honest scope: the computational OQ-02 core remains open.
- Extended 4 def/theorem annotations to cover `coverOrderAtMost`, `IsRefinement`, `covDimLE_succ`, and the discrete-theorem docstring.
- Coverage **42% → 87%**; all annotations anchor at valid Lean constructs.

meta.json unchanged.