### PR TITLE
research(derangements-oq-04-oq-01-oq-01): Poisson(1) limit of the fixed-point distribution

### DIFF
--- a/proofs/Proofs/DerangementsOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ04OQ01OQ01.lean
@@ -1,0 +1,112 @@
+import Proofs.DerangementsOQ04OQ01
+import Proofs.DerangementsConvergence
+
+/-
+# Poisson limit for the fixed-point distribution of a random permutation
+
+The parent entry `derangements-oq-04-oq-01`
+(`DerangementsOQ04OQ01.card_perms_with_kfixed_closed_form_real`) proves the exact
+closed form for the number `S(n,k)` of permutations of `Fin n` with *exactly* `k`
+fixed points:
+
+  `S(n,k) = (n! / k!) · ∑_{j=0}^{n-k} (-1)^j / j!`.
+
+Its first open question asks to **divide by `n!`** — turning the count into the
+probability that a uniformly random permutation of `Fin n` has exactly `k` fixed
+points — and to **take `n → ∞`**, exhibiting the classical limiting law:
+
+  `S(n,k) / n! = (1/k!) · ∑_{j=0}^{n-k} (-1)^j / j!  ⟶  e^{-1} / k!`,
+
+the **Poisson(1)** probability mass function `e^{-1} · 1^k / k!`.  This is the
+theorem that the number of fixed points of a random permutation converges in
+distribution to a Poisson random variable with mean `1`.
+
+The proof is a clean limit assembly with no new combinatorics:
+
+* the parent supplies the exact per-`n` value `S(n,k)/n! = (1/k!)·altFactPartialSum(n-k)`
+  (after cancelling `n!`, valid for `n ≥ k`);
+* the sibling analysis file `DerangementsConvergence` supplies
+  `altFactPartialSum m = ∑_{j=0}^{m} (-1)^j/j! ⟶ e^{-1}` as `m → ∞`
+  (the partial sums of the summable alternating exponential series, whose total
+  is `e^{-1}` by `exp_neg_one_eq_tsum_alt`);
+* since `k` is fixed, `n - k ⟶ ∞`, so composing gives
+  `altFactPartialSum(n-k) ⟶ e^{-1}`, and scaling by the constant `1/k!` gives the
+  claim.  The `k = 0` case recovers the parent derangement limit `D_n/n! ⟶ e^{-1}`.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms beyond Mathlib's foundations).
+-/
+
+open Finset Filter Topology
+
+namespace DerangementsOQ04OQ01OQ01
+
+/-- **The partial sums of the alternating exponential series converge to `e^{-1}`.**
+`altFactPartialSum m = ∑_{j=0}^{m} (-1)^j / j!` are the truncations of the series
+`∑_j (-1)^j/j!`, whose total is `e^{-1}` (`exp_neg_one_eq_tsum_alt`).  Being the
+`(m+1)`-term partial sums of a summable series, they tend to that total. -/
+theorem altFactPartialSum_tendsto_expNegOne :
+    Tendsto altFactPartialSum atTop (nhds (Real.exp (-1))) := by
+  have hsum : HasSum altFactTerm (Real.exp (-1)) := by
+    rw [exp_neg_one_eq_tsum_alt]
+    exact summable_altFactTerm.hasSum
+  have hps : Tendsto (fun m => ∑ i ∈ range m, altFactTerm i) atTop (nhds (Real.exp (-1))) :=
+    hsum.tendsto_sum_nat
+  have hcomp := hps.comp (tendsto_add_atTop_nat 1)
+  simpa [altFactPartialSum, Function.comp] using hcomp
+
+/-- **Poisson limit of the fixed-point distribution.**  For a fixed `k`, the
+probability that a uniformly random permutation of `Fin n` has exactly `k` fixed
+points converges to the Poisson(1) mass `e^{-1} / k!` as `n → ∞`:
+
+  `S(n,k) / n!  ⟶  e^{-1} / k!`.
+
+This answers the parent entry's open question, "divide by `n!` and take `n → ∞`".
+The `k = 0` instance recovers the derangement limit `D_n / n! ⟶ e^{-1}`. -/
+theorem fixedPoints_tendsto_poisson (k : ℕ) :
+    Tendsto (fun n : ℕ =>
+        ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+            (univ.filter (fun x => σ x = x)).card = k)).card : ℝ) / (n.factorial : ℝ))
+      atTop (nhds (Real.exp (-1) / (k.factorial : ℝ))) := by
+  -- `k` is fixed, so `n ↦ n - k` tends to infinity
+  have hsubk : Tendsto (fun n : ℕ => n - k) atTop atTop :=
+    tendsto_atTop_atTop.2 (fun b => ⟨b + k, fun n hn => by omega⟩)
+  -- partial sums evaluated along `n - k` still converge to `e^{-1}`
+  have hcomp : Tendsto (fun n : ℕ => altFactPartialSum (n - k)) atTop (nhds (Real.exp (-1))) :=
+    altFactPartialSum_tendsto_expNegOne.comp hsubk
+  -- scale by the constant `1 / k!`
+  have hmul :
+      Tendsto (fun n : ℕ => (1 / (k.factorial : ℝ)) * altFactPartialSum (n - k))
+        atTop (nhds ((1 / (k.factorial : ℝ)) * Real.exp (-1))) :=
+    hcomp.const_mul _
+  have hlim : (1 / (k.factorial : ℝ)) * Real.exp (-1)
+      = Real.exp (-1) / (k.factorial : ℝ) := by ring
+  rw [hlim] at hmul
+  -- the scaled partial sums equal `S(n,k)/n!` eventually (for `n ≥ k`)
+  refine hmul.congr' ?_
+  rw [eventuallyEq_iff_exists_mem]
+  refine ⟨{n | k ≤ n}, ?_, fun n hn => ?_⟩
+  · exact eventually_ge_atTop k
+  · -- discharge the pointwise identity via the parent closed form
+    dsimp only  -- beta-reduce the `(fun n => …) n` redexes so `rw` can see the terms
+    have hcf := DerangementsOQ04OQ01.card_perms_with_kfixed_closed_form_real n k hn
+    have hnfac : (n.factorial : ℝ) ≠ 0 := factorial_cast_ne_zero' n
+    have hkfac : (k.factorial : ℝ) ≠ 0 := factorial_cast_ne_zero' k
+    have hunfold : altFactPartialSum (n - k)
+        = ∑ j ∈ range (n - k + 1), (-1 : ℝ) ^ j / (j.factorial : ℝ) := by
+      simp only [altFactPartialSum, altFactTerm]
+    rw [hunfold, hcf]
+    field_simp
+
+/-- **Consistency with the parent derangement limit.**  Specialising to `k = 0`
+recovers `D_n / n! ⟶ e^{-1}`: the probability that a random permutation is a
+derangement tends to `e^{-1}`, the Poisson(1) mass at `0`. -/
+theorem derangements_tendsto_poisson_zero :
+    Tendsto (fun n : ℕ =>
+        ((univ.filter (fun σ : Equiv.Perm (Fin n) =>
+            (univ.filter (fun x => σ x = x)).card = 0)).card : ℝ) / (n.factorial : ℝ))
+      atTop (nhds (Real.exp (-1))) := by
+  have h := fixedPoints_tendsto_poisson 0
+  simpa using h
+
+end DerangementsOQ04OQ01OQ01

--- a/src/data/proofs/derangements-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "derangements-oq-04-oq-01-oq-01",
+  "slug": "derangements-oq-04-oq-01-oq-01",
+  "title": "Poisson Limit of the Fixed-Point Distribution of a Random Permutation",
+  "description": "Divides the partial-derangement closed form S(n,k) = (n!/k!)·∑_{j=0}^{n-k}(-1)^j/j! by n! to obtain the probability that a uniformly random permutation of an n-set has exactly k fixed points, then takes n → ∞ to prove this probability converges to the Poisson(1) mass e^{-1}/k!. This is the classical theorem that the number of fixed points of a random permutation converges in distribution to a Poisson random variable of mean 1. The proof is a limit assembly: the parent entry supplies the exact per-n value S(n,k)/n! = (1/k!)·(partial alternating exponential sum through j = n-k), and the sibling convergence file supplies that these partial sums tend to e^{-1}; since k is fixed, n-k → ∞ and scaling by the constant 1/k! yields the limit. The k = 0 instance recovers the derangement limit D_n/n! → e^{-1}.",
+  "overview": {
+    "historicalContext": "**Fixed Points of a Random Permutation**\n\nFor a uniformly random permutation $\\sigma$ of an $n$-element set, let $X_n = \\#\\{x : \\sigma(x) = x\\}$ be the number of fixed points. A classical result — traceable to the *problème des rencontres* of Montmort (1708) and the derangement asymptotics of Euler (1751) — states that $X_n$ converges in distribution to a **Poisson random variable of mean $1$**:\n$$ \\Pr[X_n = k] \\;=\\; \\frac{S(n,k)}{n!} \\;\\xrightarrow[n\\to\\infty]{}\\; \\frac{e^{-1}}{k!}, $$\nwhere $S(n,k)$ is the rencontres number counting permutations with exactly $k$ fixed points. The $k=0$ case is the celebrated fact that a random permutation is a derangement with limiting probability $e^{-1} \\approx 0.3679$.\n\nMathlib records `numDerangements` and (via the parent gallery entries) the exact finite closed form $S(n,k) = (n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$, but not this limiting law. This entry supplies it.",
+    "problemStatement": "**Open Question (derangements-oq-04-oq-01, first open question)**: Divide the partial-derangement closed form $S(n,k) = (n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$ by $n!$ to obtain the fixed-point-count distribution $S(n,k)/n! = (1/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$, and take $n \\to \\infty$ to show it converges to the Poisson(1) probability $e^{-1}/k!$ — the classical limiting distribution of the number of fixed points of a random permutation.\n\nThis entry answers it: for every fixed $k$, $S(n,k)/n! \\to e^{-1}/k!$ as $n \\to \\infty$.",
+    "text": "Proves that for fixed k, the probability S(n,k)/n! that a random permutation of Fin n has exactly k fixed points converges to the Poisson(1) mass e^{-1}/k! as n → ∞, by dividing the parent's exact closed form by n! and composing the alternating-exponential partial-sum convergence with n - k → ∞.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe result is a limit assembly with no new combinatorics, drawing on two already-formalized ingredients:\n\n1. **Exact per-n value** (`DerangementsOQ04OQ01.card_perms_with_kfixed_closed_form_real`, parent entry derangements-oq-04-oq-01): $(S(n,k):\\mathbb{R}) = (n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$. Dividing by the nonzero $n!$ and cancelling gives, for $n \\ge k$, the clean form $S(n,k)/n! = (1/k!)\\cdot\\mathrm{altFactPartialSum}(n-k)$, where $\\mathrm{altFactPartialSum}(m) = \\sum_{j=0}^{m}(-1)^j/j!$.\n\n2. **Partial-sum convergence** (`altFactPartialSum_tendsto_expNegOne`, established here from the sibling analysis file `DerangementsConvergence`): the partial sums $\\mathrm{altFactPartialSum}(m)$ are the $(m{+}1)$-term truncations of the summable alternating series $\\sum_j (-1)^j/j!$, whose total is $e^{-1}$ (`exp_neg_one_eq_tsum_alt`); hence they converge to $e^{-1}$ via `HasSum.tendsto_sum_nat` composed with `tendsto_add_atTop_nat 1`.\n\n**Assembly**: since $k$ is fixed, $n \\mapsto n-k$ tends to infinity (`tendsto_atTop_atTop`, discharged by `omega`), so composing gives $\\mathrm{altFactPartialSum}(n-k) \\to e^{-1}$. Scaling by the constant $1/k!$ (`Tendsto.const_mul`) gives limit $(1/k!)\\,e^{-1} = e^{-1}/k!$. Finally `Tendsto.congr'` replaces the scaled partial sums by $S(n,k)/n!$ using the eventual (for $n \\ge k$) pointwise identity from step 1, closed by `field_simp; ring`.",
+    "keyInsights": [
+      "**Limit, not combinatorics**: the hard content — the exact count $S(n,k)=(n!/k!)\\sum(-1)^j/j!$ and the summability of the alternating exponential series to $e^{-1}$ — already lives in the parent and sibling entries. The open question is answered purely by a limit-of-partial-sums composition.",
+      "**The truncation index shifts by a constant**: dividing by $n!$ leaves the partial sum $\\sum_{j=0}^{n-k}$; as $n\\to\\infty$ with $k$ fixed, the upper index $n-k$ still runs to infinity, so the truncated $e^{-1}$ tail vanishes and the limit is the full $e^{-1}$ regardless of $k$.",
+      "**Poisson(1) mass appears as $e^{-1}/k!$**: the limit $e^{-1}\\cdot 1^k/k!$ is exactly the probability mass function of a Poisson random variable with mean $1$, so the theorem is the convergence in distribution $X_n \\Rightarrow \\mathrm{Poisson}(1)$ read coefficientwise.",
+      "**$k=0$ recovers the derangement limit**: specialising to $k=0$ gives $S(n,0)/n! = D_n/n! \\to e^{-1}$, the classical probability that a random permutation is a derangement; `simpa` derives it from the general theorem.",
+      "**Characteristic-zero cancellation is invisible in the limit**: the only division is by the fixed constants $n!$ and $k!$ (both nonzero in $\\mathbb{R}$); no new invertibility hypothesis is needed beyond what the parent already used."
+    ],
+    "prerequisites": [
+      "Convergence of series and partial sums (HasSum, tendsto of partial sums)",
+      "The exponential series ∑ (-1)^j/j! = e^{-1}",
+      "Filters and limits at infinity (Tendsto, atTop) in Mathlib",
+      "The rencontres closed form S(n,k) = (n!/k!)∑_{j≤n-k}(-1)^j/j!"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.DerangementsOQ04OQ01",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsOQ04OQ01OQ01",
+    "lineCount": 112,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib (classical result; limiting distribution of fixed points, Montmort/Euler/Poisson)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rencontres_numbers",
+    "date": "1708",
+    "dateAdded": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsOQ04OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "lineCount": 112,
+    "mathlib_version": "v4.26.0",
+    "assumptions": "None beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Verified 0-axiom, 0-sorry.",
+    "tags": [
+      "combinatorics",
+      "probability",
+      "derangements",
+      "rencontres-numbers",
+      "fixed-points",
+      "poisson-distribution",
+      "limiting-distribution",
+      "exponential-series",
+      "convergence",
+      "research",
+      "open-problem"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "HasSum.tendsto_sum_nat",
+        "description": "A summable series' n-term partial sums tend to its total; applied to ∑ (-1)^j/j! whose total is e^{-1}",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "tendsto_add_atTop_nat",
+        "description": "n ↦ n + 1 tends to atTop; reindexes range m partial sums to altFactPartialSum n = ∑ over range (n+1)",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "tendsto_atTop_atTop",
+        "description": "Characterisation of Tendsto _ atTop atTop used to show n ↦ n - k → ∞ for fixed k (via omega)",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "Filter.Tendsto.const_mul",
+        "description": "Scaling a convergent sequence by the constant 1/k! multiplies the limit by 1/k!",
+        "module": "Mathlib.Topology.Algebra.Monoid"
+      },
+      {
+        "theorem": "Filter.Tendsto.congr'",
+        "description": "Replaces the scaled partial sums by S(n,k)/n! using their eventual (n ≥ k) pointwise equality",
+        "module": "Mathlib.Order.Filter.Basic"
+      }
+    ],
+    "originalContributions": [
+      "altFactPartialSum_tendsto_expNegOne: the partial sums ∑_{j=0}^{m}(-1)^j/j! converge to e^{-1} as m → ∞, obtained from the sibling summability fact via HasSum.tendsto_sum_nat and a +1 reindexing.",
+      "fixedPoints_tendsto_poisson: for every fixed k, the probability S(n,k)/n! that a random permutation of Fin n has exactly k fixed points converges to the Poisson(1) mass e^{-1}/k! as n → ∞ — the coefficientwise convergence in distribution of the fixed-point count to Poisson(1). Answers the parent entry's first open question ('divide by n! and take n → ∞').",
+      "derangements_tendsto_poisson_zero: the k = 0 specialisation recovers the classical derangement limit D_n/n! → e^{-1}, confirming consistency with the parent derangement asymptotics."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Poses the open question — divide the rencontres closed form S(n,k) = (n!/k!)∑_{j=0}^{n-k}(-1)^j/j! by n! and take n → ∞ to obtain the Poisson(1) limit e^{-1}/k! — and imports the parent closed-form entry (DerangementsOQ04OQ01) plus the sibling series-convergence file (DerangementsConvergence) that supply the two ingredients.",
+      "mathContext": "S(n,k)/n! = (1/k!)∑_{j=0}^{n-k}(-1)^j/j! → e^{-1}/k! = Poisson(1) mass; assembled from an exact per-n closed form and the convergence of the alternating exponential partial sums to e^{-1}."
+    },
+    {
+      "id": "partial-sum-limit",
+      "title": "Convergence of the Alternating Exponential Partial Sums",
+      "startLine": 48,
+      "endLine": 60,
+      "summary": "altFactPartialSum_tendsto_expNegOne: the partial sums altFactPartialSum(m) = ∑_{j=0}^{m}(-1)^j/j! converge to e^{-1}. The series ∑_j (-1)^j/j! is summable with total e^{-1} (exp_neg_one_eq_tsum_alt), so its range-m partial sums tend to e^{-1} by HasSum.tendsto_sum_nat; a +1 reindex (tendsto_add_atTop_nat 1) matches altFactPartialSum's range (m+1) convention.",
+      "mathContext": "∑_{j=0}^{m}(-1)^j/j! → ∑_{j=0}^{∞}(-1)^j/j! = e^{-1}."
+    },
+    {
+      "id": "poisson-limit",
+      "title": "The Poisson(1) Limit of the Fixed-Point Distribution",
+      "startLine": 62,
+      "endLine": 102,
+      "summary": "fixedPoints_tendsto_poisson: for fixed k, S(n,k)/n! → e^{-1}/k!. Since n - k → ∞ (tendsto_atTop_atTop via omega), the partial sums along n - k still tend to e^{-1}; scaling by the constant 1/k! (Tendsto.const_mul) gives limit e^{-1}/k!; Tendsto.congr' swaps the scaled partial sums for S(n,k)/n! using the eventual (n ≥ k) identity S(n,k)/n! = (1/k!)·altFactPartialSum(n-k) from the parent closed form, closed by field_simp; ring.",
+      "mathContext": "Pr[X_n = k] = S(n,k)/n! → e^{-1}/k!, the Poisson(1) probability mass function."
+    },
+    {
+      "id": "consistency",
+      "title": "Consistency: the Derangement Limit as the k = 0 Case",
+      "startLine": 104,
+      "endLine": 112,
+      "summary": "derangements_tendsto_poisson_zero: specialising k = 0 recovers D_n/n! → e^{-1}, the classical probability that a random permutation is a derangement; derived from the general theorem by simpa.",
+      "mathContext": "S(n,0)/n! = D_n/n! → e^{-1}/0! = e^{-1}."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof that the number of fixed points of a uniformly random permutation of an n-element set converges in distribution to a Poisson random variable of mean 1: for every fixed k, the probability S(n,k)/n! → e^{-1}/k! as n → ∞. The file is 0-axiom, 0-sorry. It answers the parent entry's first open question by exactly the suggested route — divide the closed form by n! and take the limit — reusing the parent's exact per-n value and the sibling file's alternating-exponential series convergence, with the k = 0 case recovering the derangement limit D_n/n! → e^{-1}.",
+    "implications": "Completes the passage from the exact finite rencontres closed form to its asymptotic law, giving the coefficientwise (fixed-k) convergence of the fixed-point count to Poisson(1). The limit-assembly pattern — an exact per-n closed form divided down and matched against a summable-series partial-sum limit via Tendsto.congr' — is reusable for other combinatorial statistics with truncated-exponential closed forms.",
+    "openQuestions": [
+      "Upgrade the coefficientwise (fixed-k) convergence to a genuine convergence-in-distribution statement over a Mathlib probability space: exhibit the fixed-point count as a random variable on the uniform measure on Equiv.Perm (Fin n) and show its law tends weakly to the PMF.poisson 1 measure.",
+      "Quantify the rate: bound |S(n,k)/n! - e^{-1}/k!| by the alternating-series tail 1/((n-k+1)!·k!), the k-indexed analogue of the sibling sharp rate |D_n/n! - e^{-1}| ≤ 1/(n+1)!.",
+      "Prove the factorial-moment / joint statement that the numbers of fixed points behave asymptotically like independent Poisson(1/m) contributions from m-cycles, of which this is the m = 1 marginal."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Montmort, P. R.",
+      "title": "Essay d'analyse sur les jeux de hasard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "Origin of the problème des rencontres; permutations with a prescribed number of coincidences"
+    },
+    {
+      "authors": "Euler, L.",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie des Sciences de Berlin",
+      "note": "Establishes D(n) = n!∑_{k=0}^n (-1)^k/k!, giving D_n/n! → e^{-1} (the k = 0 case here)"
+    },
+    {
+      "authors": "Barbour, A. D.; Holst, L.; Janson, S.",
+      "title": "Poisson Approximation",
+      "year": "1992",
+      "venue": "Oxford University Press",
+      "note": "Modern treatment of the convergence of the fixed-point count of a random permutation to Poisson(1)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: supplies the exact closed form S(n,k) = (n!/k!)∑_{j=0}^{n-k}(-1)^j/j! (card_perms_with_kfixed_closed_form_real) and poses the divide-by-n!-and-take-the-limit open question answered here."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Supplies the summability of the alternating exponential series and exp_neg_one_eq_tsum_alt (∑_j (-1)^j/j! = e^{-1}), from which the partial-sum convergence altFactPartialSum → e^{-1} is derived."
+    },
+    {
+      "targetId": "derangements-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling entry on the sharp convergence rate |D_n/n! - e^{-1}| ≤ 1/(n+1)!; the k = 0 marginal of the limit proved here, and the target of a rate open question posed above."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New VERIFIED gallery entry answering the parent `derangements-oq-04-oq-01`'s open question: divide the exact fixed-point count by `n!` and take `n → ∞`, exhibiting the classical **Poisson(1)** limiting law.

$$\frac{S(n,k)}{n!} = \frac{1}{k!}\sum_{j=0}^{n-k}\frac{(-1)^j}{j!} \;\longrightarrow\; \frac{e^{-1}}{k!}.$$

- `fixedPoints_tendsto_poisson` — for fixed `k`, the probability a uniform random permutation of `Fin n` has exactly `k` fixed points converges to the Poisson(1) mass `e⁻¹/k!`.
- `derangements_tendsto_poisson_zero` — the `k=0` marginal recovers the derangement limit `Dₙ/n! → e⁻¹`.

## Proof route

A clean limit assembly with no new combinatorics: the parent supplies the exact per-`n` value `S(n,k)/n! = (1/k!)·altFactPartialSum(n−k)` (for `n ≥ k`); the sibling analysis file `DerangementsConvergence` supplies `altFactPartialSum m → e⁻¹`; since `k` is fixed, `n − k → ∞`, and scaling by the constant `1/k!` gives the claim. Both parents are on `main` (0-axiom/0-sorry).

## Verification

- **Docker build**: `✔ [3065/3065] Built Proofs.DerangementsOQ04OQ01OQ01 (16s)`, clean.
- 0 sorries, 0 `axiom` declarations, no `native_decide`. 3 theorems, 112 lines.
- Fixed 3 latent build errors that the originating session never caught (its build env was down): an unreduced `(fun n => …) n` redex blocking `rw` (added `dsimp only`), the wrong `eventually_atTop.1` form for the `{n | k ≤ n} ∈ atTop` membership goal (→ `eventually_ge_atTop k`), and a superfluous `ring` after `field_simp`.

## Status
**Outcome**: completed — new verified 0-axiom entry.

🤖 Generated by researcher-16