### PR TITLE
Enrich combinations-formula-oq-04-oq-03: full annotations.json (0→6 depth annotations, 97% coverage)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04-oq-03/annotations.json
@@ -1,0 +1,131 @@
+[
+  {
+    "id": "combformula-oq0403-overview",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "Keeping the Factor the Parent Discarded: From Log-Concavity to Ultra-Log-Concavity",
+    "content": "The parent entry proves the log-concavity inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² by clearing denominators with Mathlib's adjacent-ratio relation Nat.choose_succ_right_eq and then discarding the exact multiplicative factor. This file keeps that factor. Multiplying the two adjacent ratios yields an exact identity (★): C(n,k)·C(n,k+2)·(n−k)(k+2) = C(n,k+1)²·(k+1)(n−k−1). Reading (★) in centered form (j = k+1) gives Liggett's ultra-log-concavity (ULC) bound met with equality, so the binomial row is the extremal ULC sequence — no sequence measured against C(n,·) can do strictly better. The parent inequality drops out because (k+1)(n−k−1) ≤ (n−k)(k+2) (their difference is n+1 > 0). The file imports only Nat.Choose.Basic plus ring/linarith/positivity, keeping the argument purely arithmetic.",
+    "mathContext": "The identity behind the whole file is $$\\binom{n}{k}\\binom{n}{k+2}(n-k)(k+2)=\\binom{n}{k+1}^2(k+1)(n-k-1).\\qquad(\\star)$$ Centered at $j=k+1$ this is Liggett's ULC bound met with equality: $$\\binom{n}{j}^2=\\Bigl(1+\\tfrac1j\\Bigr)\\Bigl(1+\\tfrac1{n-j}\\Bigr)\\binom{n}{j-1}\\binom{n}{j+1}.$$ Ultra-log-concavity is strictly stronger than ordinary log-concavity $\\binom{n}{j}^2\\ge\\binom{n}{j-1}\\binom{n}{j+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "log-concavity",
+      "ultra-log-concavity",
+      "Liggett's inequality",
+      "Newton's inequalities",
+      "unimodality of Pascal rows",
+      "extremal sequences"
+    ],
+    "prerequisites": [
+      "binomial coefficients Nat.choose",
+      "Pascal's rule and adjacent-coefficient ratios",
+      "log-concave and unimodal sequences"
+    ]
+  },
+  {
+    "id": "combformula-oq0403-exact-identity",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 60, "endLine": 97 },
+    "type": "insight",
+    "title": "The Exact Adjacent-Triple Identity (★), Unconditional",
+    "content": "choose_mul_choose_mul_eq proves (★) for ALL n, k with no side conditions. The proof splits on whether the triple lies inside the row. Outside (n < k+2), C(n,k+2) = 0 kills the left side and truncated subtraction makes n−k−1 = 0 kill the right, so both sides vanish. Inside, one parametrises n = k+2+t so the natural-number subtractions n−k and n−k−1 become the honest values t+2 and t+1. Two instances of Nat.choose_succ_right_eq give the ratios a·(t+2) = b·(k+1) and c·(k+2) = b·(t+1), where a = C(n,k), b = C(n,k+1), c = C(n,k+2). Multiplying the two ratios eliminates the neighbours of b and a short calc/ring chain closes (★). The delicate step is rewriting the longer subtraction pattern (n−k−1) before the shorter (n−k) so rw does not consume it.",
+    "mathContext": "For $k+2\\le n$ write $n=k+2+t$. Mathlib's $\\texttt{Nat.choose\\_succ\\_right\\_eq}$ gives $\\binom{n}{k+1}(k+1)=\\binom{n}{k}(n-k)$, here $a(t+2)=b(k+1)$ and $c(k+2)=b(t+1)$. Then $$a\\,c\\,(t+2)(k+2)=\\bigl(a(t+2)\\bigr)\\bigl(c(k+2)\\bigr)=\\bigl(b(k+1)\\bigr)\\bigl(b(t+1)\\bigr)=b^2(k+1)(t+1),$$ which is exactly $(\\star)$ since $n-k=t+2$ and $n-k-1=t+1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_succ_right_eq",
+      "adjacent-coefficient ratio",
+      "truncated natural subtraction",
+      "ring normalization",
+      "case split on the row range"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_right_eq",
+      "Nat.choose_eq_zero_of_lt",
+      "the ring tactic over ℕ",
+      "omega for linear arithmetic on ℕ"
+    ]
+  },
+  {
+    "id": "combformula-oq0403-ulc-centered",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 99, "endLine": 116 },
+    "type": "insight",
+    "title": "Ultra-Log-Concavity Met With Equality (Centered Form)",
+    "content": "choose_ulc_equality restates (★) with the middle index j = k+1: C(n,j−1)·C(n,j+1)·(j+1)(n−j+1) = C(n,j)²·j(n−j), valid on the row 1 ≤ j ≤ n. This is Liggett's ULC bound with equality, exhibiting the Pascal row as the extremal ultra-log-concave sequence. The proof simply substitutes j = k+1 and applies choose_mul_choose_mul_eq, again rewriting the +1-length subtraction patterns before the bare ones so natural-number subtraction lines up. The hypotheses 1 ≤ j and j ≤ n ensure the centered factor n−j+1 carries its intended arithmetic value rather than truncating.",
+    "mathContext": "With $j=k+1$, $(\\star)$ becomes $$\\binom{n}{j-1}\\binom{n}{j+1}(j+1)(n-j+1)=\\binom{n}{j}^2\\,j(n-j),$$ i.e. $\\binom{n}{j}^2=\\bigl(1+\\tfrac1j\\bigr)\\bigl(1+\\tfrac1{n-j}\\bigr)\\binom{n}{j-1}\\binom{n}{j+1}$. Equality (not just $\\ge$) is what makes the binomial row the unique extremal case of Liggett's ULC inequality.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Liggett's ultra-log-concavity",
+      "extremal sequences",
+      "reindexing / centering an identity",
+      "Pascal's triangle symmetry"
+    ],
+    "prerequisites": [
+      "the exact identity (★)",
+      "index substitution j = k+1",
+      "natural-number subtraction on the row"
+    ]
+  },
+  {
+    "id": "combformula-oq0403-logconcave-corollary",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 118, "endLine": 134 },
+    "type": "technique",
+    "title": "Log-Concavity Recovered as a Corollary of the Exact Identity",
+    "content": "choose_mul_choose_le_sq re-derives the parent inequality C(n,k)·C(n,k+2) ≤ C(n,k+1)² directly from (★). Outside the row the left side is 0. Inside, one multiplies the target by the positive factor (n−k)(k+2), substitutes the exact identity, and bounds the retained factor (k+1)(n−k−1) ≤ (n−k)(k+2); cancelling the common positive factor via Nat.le_of_mul_le_mul_right yields the inequality. This shows the parent's result is strictly weaker information than (★): the exact factor is thrown away exactly when passing from equality to inequality.",
+    "mathContext": "The factor bound is $(k+1)(n-k-1)\\le (n-k)(k+2)$, whose difference expands to $n+1>0$. Multiplying the goal by $(n-k)(k+2)>0$, applying $(\\star)$, and using $\\binom{n}{k}\\binom{n}{k+2}(n-k)(k+2)=\\binom{n}{k+1}^2(k+1)(n-k-1)\\le\\binom{n}{k+1}^2(n-k)(k+2)$ gives $\\binom{n}{k}\\binom{n}{k+2}\\le\\binom{n}{k+1}^2$ after cancellation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "log-concavity",
+      "cancellation of a positive factor",
+      "Nat.le_of_mul_le_mul_right",
+      "monotonicity of multiplication (Nat.mul_le_mul)"
+    ],
+    "prerequisites": [
+      "the exact identity (★)",
+      "cancellation laws for ℕ multiplication",
+      "nlinarith for the factor inequality"
+    ]
+  },
+  {
+    "id": "combformula-oq0403-strict-interior",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 136, "endLine": 155 },
+    "type": "technique",
+    "title": "Strict Log-Concavity in the Interior of the Row",
+    "content": "choose_mul_choose_lt_sq sharpens the corollary to a strict inequality C(n,k)·C(n,k+2) < C(n,k+1)² whenever k+2 ≤ n. The argument mirrors the weak case but uses the strict factor inequality (k+1)(n−k−1) < (n−k)(k+2) together with C(n,k+1) > 0 (so its square is positive), then cancels the positive factor via Nat.lt_of_mul_lt_mul_right. Interiority is exactly the condition under which C(n,k+1) is nonzero and the factor gap n+1 is genuinely positive after cancellation, so no boundary degeneracy remains.",
+    "mathContext": "For $k+2\\le n$ the factor gap is strict: $(n-k)(k+2)-(k+1)(n-k-1)=n+1>0$, and $\\binom{n}{k+1}>0$ so $\\binom{n}{k+1}^2>0$. Hence $\\binom{n}{k}\\binom{n}{k+2}(n-k)(k+2)<\\binom{n}{k+1}^2(n-k)(k+2)$, and cancelling the positive $(n-k)(k+2)$ gives the strict bound.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict log-concavity",
+      "positivity of binomial coefficients",
+      "mul_lt_mul_of_pos_left",
+      "strict cancellation Nat.lt_of_mul_lt_mul_right"
+    ],
+    "prerequisites": [
+      "Nat.choose_pos",
+      "strict monotonicity of multiplication",
+      "the interior hypothesis k+2 ≤ n"
+    ]
+  },
+  {
+    "id": "combformula-oq0403-summary",
+    "proofId": "combinations-formula-oq-04-oq-03",
+    "range": { "startLine": 156, "endLine": 171 },
+    "type": "context",
+    "title": "What Is Proved: An Exact Identity Subsuming Its Parent",
+    "content": "The closing summary records the four results: choose_mul_choose_mul_eq (the exact identity (★), all n,k), choose_ulc_equality (centered ULC form = Liggett's bound with equality), and choose_mul_choose_le_sq / choose_mul_choose_lt_sq (the parent's weak and strict log-concavity as immediate corollaries). The entry is fully verified: 0 sorries, 0 axioms, importing only Mathlib. Conceptually it answers the parent's open question by refusing to discard the multiplicative factor: the resulting equality is strictly more information than any inequality derived from it, and it pins the Pascal row as the extremal ultra-log-concave sequence.",
+    "mathContext": "Verification status: 0 sorries, 0 axioms. The four theorems form a chain equality $(\\star)\\Rightarrow$ centered ULC $\\Rightarrow$ weak log-concavity $\\Rightarrow$ strict log-concavity, each later result a corollary of $(\\star)$ obtained by bounding $(k+1)(n-k-1)$ against $(n-k)(k+2)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "ultra-log-concavity",
+      "extremal Pascal row",
+      "corollary chain",
+      "open-question resolution"
+    ],
+    "prerequisites": [
+      "the four preceding theorems",
+      "the notion of an extremal sequence"
+    ]
+  }
+]


### PR DESCRIPTION
Fresh `annotations.json` for the ultra-log-concavity entry (verified, 0-axiom, 173L), which previously had **zero** annotations.

**6 full-depth annotations, 97% line coverage (167/173):**
1. Overview — keeping the multiplicative factor the parent discards (log-concavity → ultra-log-concavity)
2. The exact adjacent-triple identity (★), proved unconditionally via a case split + `Nat.choose_succ_right_eq`
3. Ultra-log-concavity met with equality (Liggett's bound, centered form j = k+1)
4. Log-concavity recovered as a corollary of (★)
5. Strict log-concavity in the interior of the row
6. Summary / verification status

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Content verified against the Lean source. `meta.json` left unchanged — already well-curated (13 KB, under all size caps; parent + root cross-references present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)