### PR TITLE
Enrich erdos-700 (GCD of n with Binomial Coefficients): overview + core-lemma annotations

### DIFF
--- a/src/data/proofs/erdos-700/annotations.json
+++ b/src/data/proofs/erdos-700/annotations.json
@@ -1,134 +1,361 @@
 [
   {
+    "id": "erdos-700-ann-overview",
+    "proofId": "erdos-700",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "concept",
+    "title": "Overview: GCD of n with binomial coefficients",
+    "content": "Erdős and Szekeres study $f(n) = \\min_{1 < k \\le n/2}\\gcd(n, \\binom{n}{k})$ over composite $n$. Three questions are posed: (1) which composite $n$ satisfy $f(n) = n/P(n)$ where $P(n)$ is the largest prime factor; (2) are there infinitely many composite $n$ with $f(n) > \\sqrt{n}$; (3) is $f(n) \\ll_A n/(\\log n)^A$ for every $A>0$. The unconditional bound $f(n) \\le n/P(n)$ holds for all composite $n$; this entry formalizes that ceiling, a matching prime-factor lower bound, exact values on semiprimes and prime squares, and states the two open questions as axioms.",
+    "mathContext": "$f(n) = \\min_{1<k\\le n/2}\\gcd(n,\\binom{n}{k})$; $P(n) = $ largest prime factor. Always $f(n)\\le n/P(n)$ for composite $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial coefficients",
+      "greatest common divisor",
+      "largest prime factor",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "number theory",
+      "binomial coefficients"
+    ]
+  },
+  {
     "id": "erdos-700-largest-pf",
     "proofId": "erdos-700",
     "type": "definition",
-    "range": { "startLine": 28, "endLine": 32 },
+    "range": {
+      "startLine": 28,
+      "endLine": 32
+    },
     "title": "Largest Prime Factor P(n)",
     "content": "Defines `largestPrimeFactor n` as the supremum of prime divisors of $n$ within `Finset.range (n+1)`, returning $0$ for $n \\leq 1$. This is $P(n)$, the largest prime in the factorization of $n$. By the Hardy-Ramanujan theorem, $P(n) \\sim \\log n$ for typical $n$, but $P(n)$ can be as large as $n$ (when $n$ is prime) or as small as $O(n^{1/\\omega(n)})$.",
     "mathContext": "$P(n) = \\max\\{p \\text{ prime} : p \\mid n\\}$",
     "significance": "key",
-    "relatedConcepts": ["Finset.sup", "prime factorization", "Hardy-Ramanujan theorem", "smooth numbers"],
-    "prerequisites": ["prime numbers", "Finset operations", "supremum"]
+    "relatedConcepts": [
+      "Finset.sup",
+      "prime factorization",
+      "Hardy-Ramanujan theorem",
+      "smooth numbers"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "Finset operations",
+      "supremum"
+    ]
   },
   {
     "id": "erdos-700-smallest-pf",
     "proofId": "erdos-700",
     "type": "definition",
-    "range": { "startLine": 34, "endLine": 36 },
+    "range": {
+      "startLine": 34,
+      "endLine": 36
+    },
     "title": "Smallest Prime Factor p(n)",
     "content": "Defines `smallestPrimeFactor n` as `Nat.minFac n`, the smallest prime dividing $n$. For composite $n$, we always have $p(n) \\leq \\sqrt{n}$ since if all prime factors exceeded $\\sqrt{n}$, then $n$ would be prime. This gives the lower bound in the sandwich $p(n) \\leq f(n) \\leq n/P(n)$.",
     "mathContext": "$p(n) = \\min\\{p \\text{ prime} : p \\mid n\\} = \\texttt{Nat.minFac}(n)$",
     "significance": "key",
-    "relatedConcepts": ["Nat.minFac", "trial division", "prime factorization"],
-    "prerequisites": ["prime numbers", "divisibility"]
+    "relatedConcepts": [
+      "Nat.minFac",
+      "trial division",
+      "prime factorization"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "divisibility"
+    ]
   },
   {
     "id": "erdos-700-fbinom",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 38, "endLine": 46 },
+    "range": {
+      "startLine": 38,
+      "endLine": 46
+    },
     "title": "The Function f(n)",
     "content": "Defines `fBinom n` as $f(n) = \\min_{1 < k \\leq n/2} \\gcd(n, \\binom{n}{k})$ using `Finset.min'` over `Finset.Icc 2 (n/2)`. The range is proved nonempty for $n \\geq 4$ (since $2 \\leq n/2$). Returns $0$ for $n < 4$. Previously axiomatized; now a proper definition that captures the mathematical content directly.",
     "mathContext": "$f(n) = \\min_{1 < k \\leq n/2} \\gcd\\bigl(n, \\binom{n}{k}\\bigr)$",
     "significance": "key",
-    "relatedConcepts": ["gcd", "binomial coefficients", "Nat.choose", "Pascal's triangle"],
-    "prerequisites": ["gcd", "binomial coefficients", "well-ordering"]
+    "relatedConcepts": [
+      "gcd",
+      "binomial coefficients",
+      "Nat.choose",
+      "Pascal's triangle"
+    ],
+    "prerequisites": [
+      "gcd",
+      "binomial coefficients",
+      "well-ordering"
+    ]
   },
   {
     "id": "erdos-700-upper",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 44, "endLine": 46 },
+    "range": {
+      "startLine": 44,
+      "endLine": 46
+    },
     "title": "Upper Bound f(n) ≤ n/P(n)",
     "content": "Axiomatizes `f_upper_bound`: $f(n) \\leq n/P(n)$ for composite $n \\geq 2$. This follows from Kummer's theorem: for $k = n/P(n)$, the base-$P(n)$ addition of $k$ and $n-k$ has exactly one carry, so $v_{P(n)}(\\binom{n}{k}) = 1$, giving $\\gcd(n, \\binom{n}{k}) \\leq n/P(n)$.",
     "mathContext": "$f(n) \\leq n/P(n)$ for composite $n$, since $v_{P(n)}\\bigl(\\binom{n}{n/P(n)}\\bigr) = 1$",
     "significance": "key",
-    "relatedConcepts": ["Kummer's theorem", "p-adic valuation", "carries in base-p addition"],
-    "prerequisites": ["Kummer's theorem", "p-adic valuation", "prime factorization"]
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "p-adic valuation",
+      "carries in base-p addition"
+    ],
+    "prerequisites": [
+      "Kummer's theorem",
+      "p-adic valuation",
+      "prime factorization"
+    ]
   },
   {
     "id": "erdos-700-lower",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 48, "endLine": 50 },
+    "range": {
+      "startLine": 48,
+      "endLine": 50
+    },
     "title": "Lower Bound f(n) ≥ p(n)",
     "content": "Axiomatizes `f_lower_bound`: $f(n) \\geq p(n)$ for $n \\geq 2$. The smallest prime factor $p(n)$ divides both $n$ and every $\\binom{n}{k}$ for $0 < k < n$ (since $p(n) \\mid n$ implies $p(n) \\mid n \\cdot \\binom{n-1}{k-1}/k$, and careful analysis shows $p(n) \\mid \\gcd(n, \\binom{n}{k})$).",
     "mathContext": "$p(n) \\leq f(n)$ for $n \\geq 2$, establishing the lower bound of the sandwich",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.minFac", "divisibility of binomial coefficients", "Vandermonde identity"],
-    "prerequisites": ["prime divisibility", "binomial coefficient properties"]
+    "relatedConcepts": [
+      "Nat.minFac",
+      "divisibility of binomial coefficients",
+      "Vandermonde identity"
+    ],
+    "prerequisites": [
+      "prime divisibility",
+      "binomial coefficient properties"
+    ]
   },
   {
     "id": "erdos-700-semiprime",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 54, "endLine": 56 },
+    "range": {
+      "startLine": 54,
+      "endLine": 56
+    },
     "title": "Semiprime Exact Value",
     "content": "Axiomatizes `f_semiprime`: $f(pq) = p$ for primes $p \\leq q$. When $n = pq$, the upper bound gives $f(n) \\leq n/P(n) = pq/q = p$, and the lower bound gives $f(n) \\geq p(n) = p$, so $f(pq) = p$. This is the simplest nontrivial exact computation, showing the sandwich is tight for semiprimes.",
     "mathContext": "$f(pq) = p = pq/q = n/P(n)$ for primes $p \\leq q$",
     "significance": "key",
-    "relatedConcepts": ["semiprimes", "sandwich theorem", "Kummer's theorem"],
-    "prerequisites": ["prime factorization of semiprimes", "upper and lower bounds for f"]
+    "relatedConcepts": [
+      "semiprimes",
+      "sandwich theorem",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "prime factorization of semiprimes",
+      "upper and lower bounds for f"
+    ]
   },
   {
     "id": "erdos-700-f30",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 58, "endLine": 59 },
+    "range": {
+      "startLine": 58,
+      "endLine": 59
+    },
     "title": "f(30) = 6",
     "content": "Axiomatizes `f_30`: $f(30) = 6 = 30/5$. Since $30 = 2 \\cdot 3 \\cdot 5$ is not a semiprime, this shows that $f(n) = n/P(n)$ can hold beyond the semiprime case. One verifies $\\gcd(30, \\binom{30}{k}) \\geq 6$ for all $1 < k \\leq 15$ and equality holds for some $k$.",
     "mathContext": "$f(30) = 6 = 30/5 = n/P(n)$, where $30 = 2 \\cdot 3 \\cdot 5$",
     "significance": "supporting",
-    "relatedConcepts": ["explicit computation", "non-semiprime examples", "gcd computation"],
-    "prerequisites": ["binomial coefficient computation", "gcd"]
+    "relatedConcepts": [
+      "explicit computation",
+      "non-semiprime examples",
+      "gcd computation"
+    ],
+    "prerequisites": [
+      "binomial coefficient computation",
+      "gcd"
+    ]
+  },
+  {
+    "id": "erdos-700-ann-minfac",
+    "proofId": "erdos-700",
+    "range": {
+      "startLine": 60,
+      "endLine": 89
+    },
+    "type": "technique",
+    "title": "Prime-factor lemmas",
+    "content": "Supporting arithmetic on smallest/largest prime factors: $\\mathrm{minFac}(pq) = p$ for primes $p \\le q$, every prime divisor of $n$ is at most the largest prime factor $P(n)$, and the binomial absorption identity $n \\mid k\\binom{n}{k}$ (for $1\\le k\\le n$). These feed the gcd estimates: the absorption identity forces divisibility relations between $n$ and $\\binom{n}{k}$ that control the gcd from both sides.",
+    "mathContext": "$\\mathrm{minFac}(pq)=p$ ($p\\le q$ prime); $r\\mid n,\\ r$ prime $\\Rightarrow r\\le P(n)$; $n \\mid k\\binom{n}{k}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "minFac",
+      "absorption identity",
+      "divisibility"
+    ],
+    "prerequisites": [
+      "number theory"
+    ]
   },
   {
     "id": "erdos-700-q1",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 90, "endLine": 98 },
+    "range": {
+      "startLine": 90,
+      "endLine": 98
+    },
     "title": "Question 1: Characterization Problem (OPEN)",
     "content": "Documents the open characterization problem: which composite $n$ satisfy $f(n) = n/P(n)$? Known examples: all semiprimes $pq$ and $n = 30$. A previous axiom falsely claimed this held for ALL composite $n$ (using a placeholder $\\leftrightarrow \\text{True}$); this has been corrected by removing the false axiom and replacing it with a comment documenting the open status.",
     "mathContext": "$\\{n \\text{ composite} : f(n) = n/P(n)\\} \\supseteq \\{pq : p, q \\text{ prime}\\} \\cup \\{30\\}$",
     "significance": "key",
-    "relatedConcepts": ["characterization theorem", "digit structure", "Kummer's theorem"],
-    "prerequisites": ["upper bound for f", "semiprime result"]
+    "relatedConcepts": [
+      "characterization theorem",
+      "digit structure",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "upper bound for f",
+      "semiprime result"
+    ]
   },
   {
     "id": "erdos-700-prime-sq",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 102, "endLine": 112 },
+    "range": {
+      "startLine": 102,
+      "endLine": 112
+    },
     "title": "Prime Square Lower Bound (PROVED)",
     "content": "PROVES `f_prime_square`: $f(p^2) \\geq p = \\sqrt{p^2}$ for primes $p$, using `f_lower_bound` and the helper lemma `minFac_prime_sq`. The proof chain: $\\text{minFac}(p^2) = p$ (by `dvd_of_dvd_pow` and prime uniqueness), then $p = \\text{minFac}(p^2) \\leq f(p^2)$ (by `f_lower_bound`). Previously axiomatized; now machine-checked.",
     "mathContext": "$f(p^2) \\geq p = \\sqrt{p^2}$ for prime $p$",
     "significance": "supporting",
-    "relatedConcepts": ["Lucas' theorem", "prime squares", "base-p representation"],
-    "prerequisites": ["Lucas' theorem", "prime squares"]
+    "relatedConcepts": [
+      "Lucas' theorem",
+      "prime squares",
+      "base-p representation"
+    ],
+    "prerequisites": [
+      "Lucas' theorem",
+      "prime squares"
+    ]
   },
   {
     "id": "erdos-700-q2",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 114, "endLine": 120 },
+    "range": {
+      "startLine": 114,
+      "endLine": 120
+    },
     "title": "Question 2: Infinitely Many Large Values",
     "content": "Formalizes `erdos_700_question2`: for every $N$, there exists composite $n \\geq N$ with $f(n) > \\sqrt{n}$. The prime square result provides infinitely many examples ($n = p^2$ for arbitrarily large primes $p$), so the deeper open content is whether non-prime-square composites can also achieve $f(n) > \\sqrt{n}$. Uses `Real.sqrt` for the comparison.",
     "mathContext": "$\\forall N,\\; \\exists n \\geq N \\text{ composite}: f(n) > \\sqrt{n}$",
     "significance": "key",
-    "relatedConcepts": ["Real.sqrt", "prime squares", "density of composites"],
-    "prerequisites": ["prime square lower bound", "real-valued comparisons"]
+    "relatedConcepts": [
+      "Real.sqrt",
+      "prime squares",
+      "density of composites"
+    ],
+    "prerequisites": [
+      "prime square lower bound",
+      "real-valued comparisons"
+    ]
   },
   {
     "id": "erdos-700-q3",
     "proofId": "erdos-700",
     "type": "concept",
-    "range": { "startLine": 122, "endLine": 128 },
+    "range": {
+      "startLine": 122,
+      "endLine": 128
+    },
     "title": "Question 3: Upper Bound Conjecture",
     "content": "Formalizes `erdos_700_question3`: for every $A > 0$, there exists $C > 0$ such that $f(n) \\leq C \\cdot n / (\\log n)^A$ for all composite $n \\geq 4$. This is a strong growth restriction: it implies $f(n) = o(n/P(n))$ for typical $n$ (since $P(n) \\sim \\log n$ for most $n$ by the Hardy-Ramanujan theorem). The formalization uses `Real.log` and casts `fBinom n` to $\\mathbb{R}$.",
     "mathContext": "$\\forall A > 0,\\; \\exists C > 0,\\; \\forall n \\geq 4 \\text{ composite}: f(n) \\leq \\frac{Cn}{(\\log n)^A}$",
     "significance": "key",
-    "relatedConcepts": ["asymptotic bounds", "Real.log", "Hardy-Ramanujan theorem", "typical order"],
-    "prerequisites": ["real analysis", "logarithmic bounds", "casting to reals"]
+    "relatedConcepts": [
+      "asymptotic bounds",
+      "Real.log",
+      "Hardy-Ramanujan theorem",
+      "typical order"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "logarithmic bounds",
+      "casting to reals"
+    ]
+  },
+  {
+    "id": "erdos-700-ann-gcd-structure",
+    "proofId": "erdos-700",
+    "range": {
+      "startLine": 129,
+      "endLine": 272
+    },
+    "type": "technique",
+    "title": "gcd structure and non-divisibility",
+    "content": "The technical heart controls $\\gcd(n, \\binom{n}{k})$ prime-power by prime-power. Key inputs: the non-divisibility $p \\nmid \\binom{p^a m - 1}{p^a - 1}$ (a Kummer/Lucas-type carry computation); the absorption identity $\\binom{n}{k} = (n/k)\\binom{n-1}{k-1}$ when $k\\mid n$; and, for a prime power $p^a$ with $p\\nmid x$, that $\\gcd(p^a, x)=1$. Together these give the exact evaluation $\\gcd(p^a m, \\binom{p^a m}{p^a}) = m$ at the distinguished index $k=p^a$, which pins down $f$ on prime-power-times-$m$ shapes.",
+    "mathContext": "$p\\nmid\\binom{p^a m-1}{p^a-1}$; $\\binom{n}{k}=(n/k)\\binom{n-1}{k-1}$ for $k\\mid n$; $\\gcd(p^a m,\\binom{p^a m}{p^a})=m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kummer's theorem",
+      "Lucas' theorem",
+      "prime-power gcd",
+      "carry counting"
+    ],
+    "prerequisites": [
+      "number theory",
+      "p-adic valuation"
+    ]
+  },
+  {
+    "id": "erdos-700-ann-bounds",
+    "proofId": "erdos-700",
+    "range": {
+      "startLine": 273,
+      "endLine": 411
+    },
+    "type": "insight",
+    "title": "The bounds on f(n)",
+    "content": "The main quantitative results bracket $f$: the upper bound $f(n)\\le n/P(n)$ (choose $k=P(n)$), the lower bound $f(n)\\ge p(n)$ (smallest prime factor, $n\\ge 4$), and the exact semiprime value $f(pq)=p$ for primes $p\\le q$. A worked computation gives $f(30)=30/5=6$, and for prime squares $f(p^2)\\ge p=\\sqrt{n}$ — the family that motivates Question 2, since these are composite $n$ attaining $f(n)\\ge\\sqrt n$.",
+    "mathContext": "$p(n)\\le f(n)\\le n/P(n)$; $f(pq)=p$ ($p\\le q$); $f(30)=6$; $f(p^2)\\ge p=\\sqrt{p^2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "semiprime",
+      "prime square",
+      "extremal values",
+      "square-root threshold"
+    ],
+    "prerequisites": [
+      "number theory"
+    ]
+  },
+  {
+    "id": "erdos-700-ann-open",
+    "proofId": "erdos-700",
+    "range": {
+      "startLine": 412,
+      "endLine": 427
+    },
+    "type": "context",
+    "title": "The open questions (Q2, Q3)",
+    "content": "The two hard questions are recorded as axioms marking them open. Question 2 asks whether infinitely many composite $n$ satisfy $f(n) > \\sqrt{n}$ (strictly beyond the prime-square lower bound). Question 3 asks whether $f(n) \\ll_A n/(\\log n)^A$ for every $A>0$ — an upper bound far stronger than the trivial $n/P(n)$ when $P(n)$ is small. Both remain unresolved.",
+    "mathContext": "Q2: $|\\{n$ composite$: f(n)>\\sqrt n\\}| = \\infty$? Q3: $\\forall A>0,\\ f(n)\\ll_A n/(\\log n)^A$?",
+    "significance": "context",
+    "relatedConcepts": [
+      "open conjecture",
+      "axiom",
+      "asymptotic bound"
+    ],
+    "prerequisites": [
+      "analytic number theory"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for **erdos-700** (GCD of n with Binomial Coefficients).

Coverage was 14% — the existing annotations covered scattered definitions/lemmas up to line 128, leaving the docstring and the entire quantitative core (prime-factor lemmas, gcd/non-divisibility machinery, the f-bounds, and the open questions) unannotated.

Added 5 annotations (coverage 14% → 97%):
- **Overview** (1–27): f(n) = min gcd(n, C(n,k)), the three Erdős–Szekeres questions, and the ceiling f(n) ≤ n/P(n).
- **Prime-factor lemmas** (60–89): minFac(pq)=p, largest-prime-factor bound, absorption identity.
- **gcd structure and non-divisibility** (129–272): the Kummer/Lucas-type p ∤ C(p^a·m−1, p^a−1) and the exact gcd(p^a·m, C(p^a·m, p^a)) = m.
- **The bounds on f(n)** (273–411): f(n) ≤ n/P(n), f(n) ≥ p(n), f(pq)=p, f(30)=6, f(p²) ≥ √n.
- **The open questions (Q2, Q3)** (412–427): the two axioms marking the open square-root and (log n)^A bounds.

Each carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. No content removed; ranges validated non-overlapping (relative to the new annotations) and within the 427-line file.
