### PR TITLE
research(arsinh-log-formula-oq-01-oq-01-oq-02): catenary arc length in log form + catenoid surface area [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean
@@ -1,0 +1,173 @@
+/-
+# Catenary arc length via the `arsinh` substitution: the logarithmic closed
+# form and the catenoid surface area
+
+Research: arsinh-log-formula-oq-01-oq-01-oq-02
+Parent:   arsinh-log-formula-oq-01-oq-01 (antiderivative of `1/√(1 + t²)` is `arsinh`)
+
+The sibling `arsinh-log-formula-oq-01-oq-01-oq-01` established the arc-length
+closed form in **`arsinh`** notation:
+`∫_0^b √(1 + t²) dt = ½(b·√(1+b²) + arsinh b)` and the catenary length
+`∫_0^b √(1 + sinh²x) dx = sinh b`.
+
+This file supplies the two genuinely new companions on the same lineage — the
+whole point of the `arsinh`-**log** formula being the passage to logarithms, and
+the natural next geometric quantity being the surface of revolution:
+
+* `integral_sqrt_one_add_sq_log` — the **purely logarithmic** closed form
+  `∫_0^b √(1 + t²) dt = ½(b·√(1+b²) + log(b + √(1+b²)))`, obtained by unfolding
+  `arsinh` to its defining logarithm (`arsinh x = log(x + √(1+x²))`).  This is the
+  form in which the catenary arc length is classically tabulated.
+* `integral_sqrt_one_add_sq_zero_to_one_log` — the concrete value
+  `∫_0^1 √(1 + t²) dt = ½(√2 + log(1 + √2))`.
+* `hasDerivAt_coshSqAntideriv` — the new antiderivative
+  `d/dx [½(x + sinh x·cosh x)] = cosh²x` (product rule on `sinh·cosh`, collapsed
+  via `cosh²x = 1 + sinh²x`).
+* `integral_cosh_sq_zero_to` — `∫_0^b cosh²x dx = ½(b + sinh b·cosh b)`.
+* `catenoid_surface_area` — the headline: the lateral surface area of the
+  **catenoid** obtained by revolving the catenary `y = cosh x`, `0 ≤ x ≤ b`,
+  about the axis is
+  `∫_0^b 2π·cosh x·√(1 + sinh²x) dx = π(b + sinh b·cosh b)`,
+  since the arc-length element `√(1 + sinh²x) = cosh x` turns the integrand into
+  `2π·cosh²x`.
+* `catenoid_surface_area_zero_to_one` — the concrete value
+  `π(1 + sinh 1·cosh 1)`.
+
+All results are `0`-axiom and machine-checked.
+-/
+import Mathlib
+
+namespace ArsinhLogFormulaOQ01OQ01OQ02
+
+open Real intervalIntegral MeasureTheory
+
+/-! ## The `√(1 + t²)` antiderivative and its logarithmic evaluation -/
+
+/-- The radicand `1 + t²` is strictly positive, hence `√(1 + t²) > 0`. -/
+theorem sqrt_one_add_sq_pos (t : ℝ) : 0 < Real.sqrt (1 + t ^ 2) :=
+  Real.sqrt_pos.mpr (by positivity)
+
+/-- The square of `√(1 + t²)` is `1 + t²` (the radicand is nonnegative). -/
+theorem sq_sqrt_one_add_sq (t : ℝ) : Real.sqrt (1 + t ^ 2) ^ 2 = 1 + t ^ 2 :=
+  Real.sq_sqrt (by positivity)
+
+/-- `F(t) = ½(t·√(1 + t²) + arsinh t)` is an antiderivative of `√(1 + t²)`.
+Mathlib provides `Real.hasDerivAt_arsinh` but no antiderivative for the conjugate
+integrand `√(1 + t²)`; we build it from the product rule, the chain rule for `√`,
+and the `arsinh` derivative.  The algebra collapses because
+`(t² + 1)/√(1+t²) = √(1+t²)`, doubling the leading term. -/
+theorem hasDerivAt_sqrtAntideriv (t : ℝ) :
+    HasDerivAt (fun x : ℝ => (x * Real.sqrt (1 + x ^ 2) + Real.arsinh x) / 2)
+      (Real.sqrt (1 + t ^ 2)) t := by
+  have h1pos : (0 : ℝ) < 1 + t ^ 2 := by positivity
+  have hne : (1 + t ^ 2) ≠ 0 := ne_of_gt h1pos
+  have hquad : HasDerivAt (fun x : ℝ => 1 + x ^ 2) (2 * t) t := by
+    simpa using (hasDerivAt_pow 2 t).const_add (1 : ℝ)
+  have hsqrt : HasDerivAt (fun x : ℝ => Real.sqrt (1 + x ^ 2))
+      (2 * t / (2 * Real.sqrt (1 + t ^ 2))) t := hquad.sqrt hne
+  have hprod : HasDerivAt (fun x : ℝ => x * Real.sqrt (1 + x ^ 2))
+      (1 * Real.sqrt (1 + t ^ 2) + t * (2 * t / (2 * Real.sqrt (1 + t ^ 2)))) t :=
+    (hasDerivAt_id t).mul hsqrt
+  have hsum := (hprod.add (Real.hasDerivAt_arsinh t)).div_const 2
+  convert hsum using 1
+  have hs : Real.sqrt (1 + t ^ 2) ^ 2 = 1 + t ^ 2 := sq_sqrt_one_add_sq t
+  have hpos : 0 < Real.sqrt (1 + t ^ 2) := sqrt_one_add_sq_pos t
+  field_simp
+  nlinarith [hs, hpos]
+
+/-- The integrand `t ↦ √(1 + t²)` is interval-integrable on every `[a, b]`. -/
+theorem intervalIntegrable_sqrt_integrand (a b : ℝ) :
+    IntervalIntegrable (fun t : ℝ => Real.sqrt (1 + t ^ 2)) volume a b := by
+  apply Continuous.intervalIntegrable; fun_prop
+
+/-- FTC for `√(1 + t²)` over `[0, b]` in `arsinh` form:
+`∫_0^b √(1 + t²) dt = ½(b·√(1+b²) + arsinh b)`. -/
+theorem integral_sqrt_one_add_sq_zero_to (b : ℝ) :
+    ∫ t in (0 : ℝ)..b, Real.sqrt (1 + t ^ 2)
+      = (b * Real.sqrt (1 + b ^ 2) + Real.arsinh b) / 2 := by
+  rw [intervalIntegral.integral_eq_sub_of_hasDerivAt
+        (fun t _ => hasDerivAt_sqrtAntideriv t)
+        (intervalIntegrable_sqrt_integrand 0 b)]
+  simp [Real.arsinh_zero]
+
+/-- **Logarithmic closed form.** Unfolding `arsinh x = log(x + √(1+x²))` gives the
+classical tabulated form of the catenary arc length:
+`∫_0^b √(1 + t²) dt = ½(b·√(1+b²) + log(b + √(1+b²)))`. -/
+theorem integral_sqrt_one_add_sq_log (b : ℝ) :
+    ∫ t in (0 : ℝ)..b, Real.sqrt (1 + t ^ 2)
+      = (b * Real.sqrt (1 + b ^ 2) + Real.log (b + Real.sqrt (1 + b ^ 2))) / 2 := by
+  rw [integral_sqrt_one_add_sq_zero_to]
+  rfl
+
+/-- Concrete value in logarithmic form:
+`∫_0^1 √(1 + t²) dt = ½(√2 + log(1 + √2))`. -/
+theorem integral_sqrt_one_add_sq_zero_to_one_log :
+    ∫ t in (0 : ℝ)..1, Real.sqrt (1 + t ^ 2)
+      = (Real.sqrt 2 + Real.log (1 + Real.sqrt 2)) / 2 := by
+  rw [integral_sqrt_one_add_sq_log]
+  norm_num
+
+/-! ## The catenoid surface area -/
+
+/-- **Pythagorean simplification of the catenary arc-length element.**
+`√(1 + sinh²x) = cosh x`, since `cosh²x = 1 + sinh²x` and `cosh x > 0`. -/
+theorem sqrt_one_add_sinh_sq (x : ℝ) :
+    Real.sqrt (1 + Real.sinh x ^ 2) = Real.cosh x := by
+  have h : 1 + Real.sinh x ^ 2 = Real.cosh x ^ 2 := by
+    have := Real.cosh_sq x; linarith
+  rw [h, Real.sqrt_sq (Real.cosh_pos x).le]
+
+/-- **New antiderivative for `cosh²`.** `G(x) = ½(x + sinh x·cosh x)` satisfies
+`G'(x) = cosh²x`.  The product rule gives `(sinh·cosh)' = cosh² + sinh²`, and
+`cosh²x = 1 + sinh²x` collapses `½(1 + cosh² + sinh²) = cosh²`. -/
+theorem hasDerivAt_coshSqAntideriv (t : ℝ) :
+    HasDerivAt (fun x : ℝ => (x + Real.sinh x * Real.cosh x) / 2)
+      (Real.cosh t ^ 2) t := by
+  have hprod : HasDerivAt (fun x : ℝ => Real.sinh x * Real.cosh x)
+      (Real.cosh t * Real.cosh t + Real.sinh t * Real.sinh t) t :=
+    (Real.hasDerivAt_sinh t).mul (Real.hasDerivAt_cosh t)
+  have hsum := ((hasDerivAt_id t).add hprod).div_const 2
+  convert hsum using 1
+  have := Real.cosh_sq t
+  nlinarith [this]
+
+/-- The integrand `x ↦ cosh²x` is interval-integrable on every `[a, b]`. -/
+theorem intervalIntegrable_cosh_sq (a b : ℝ) :
+    IntervalIntegrable (fun x : ℝ => Real.cosh x ^ 2) volume a b := by
+  apply Continuous.intervalIntegrable; fun_prop
+
+/-- `∫_0^b cosh²x dx = ½(b + sinh b·cosh b)`. -/
+theorem integral_cosh_sq_zero_to (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, Real.cosh x ^ 2 = (b + Real.sinh b * Real.cosh b) / 2 := by
+  rw [intervalIntegral.integral_eq_sub_of_hasDerivAt
+        (fun x _ => hasDerivAt_coshSqAntideriv x)
+        (intervalIntegrable_cosh_sq 0 b)]
+  simp [Real.sinh_zero]
+
+/-- **Catenoid surface area.** Revolving the catenary `y = cosh x`, `0 ≤ x ≤ b`,
+about the axis produces a catenoid of lateral surface area
+
+`∫_0^b 2π·cosh x·√(1 + sinh²x) dx = π(b + sinh b·cosh b)`.
+
+The arc-length element `√(1 + (cosh)'²) = √(1 + sinh²x) = cosh x` turns the
+Pappus integrand `2π·y·ds` into `2π·cosh²x`, whose antiderivative is
+`π(x + sinh x·cosh x)`. -/
+theorem catenoid_surface_area (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, 2 * Real.pi * Real.cosh x * Real.sqrt (1 + Real.sinh x ^ 2)
+      = Real.pi * (b + Real.sinh b * Real.cosh b) := by
+  have h1 : ∀ x : ℝ,
+      2 * Real.pi * Real.cosh x * Real.sqrt (1 + Real.sinh x ^ 2)
+        = (2 * Real.pi) * Real.cosh x ^ 2 := by
+    intro x; rw [sqrt_one_add_sinh_sq]; ring
+  simp_rw [h1]
+  rw [intervalIntegral.integral_const_mul, integral_cosh_sq_zero_to]
+  ring
+
+/-- Concrete value: the catenoid over `[0, 1]` has surface area
+`π(1 + sinh 1·cosh 1)`. -/
+theorem catenoid_surface_area_zero_to_one :
+    ∫ x in (0 : ℝ)..1, 2 * Real.pi * Real.cosh x * Real.sqrt (1 + Real.sinh x ^ 2)
+      = Real.pi * (1 + Real.sinh 1 * Real.cosh 1) := by
+  rw [catenoid_surface_area]
+
+end ArsinhLogFormulaOQ01OQ01OQ02

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "Overview: logarithmic arc length and the catenoid",
+    "content": "The sibling entry oq-01 built the catenary arc length ∫_0^b √(1+t²) dt = ½(b√(1+b²) + arsinh b) in arsinh notation. This module supplies the two companions it posed as open questions: (1) the purely LOGARITHMIC closed form, obtained by unfolding arsinh x = log(x + √(1+x²)), and (2) the CATENOID lateral surface area 2π ∫ cosh x √(1+sinh²x) dx = π(b + sinh b·cosh b). Both rely on antiderivatives Mathlib does not ship.",
+    "mathContext": "$\\int_0^b\\sqrt{1+t^2}\\,dt=\\tfrac12(b\\sqrt{1+b^2}+\\log(b+\\sqrt{1+b^2}))$",
+    "significance": "key",
+    "relatedConcepts": ["catenary", "catenoid", "arc length", "surface of revolution", "arsinh", "logarithm"],
+    "prerequisites": ["integral calculus", "hyperbolic functions", "the Fundamental Theorem of Calculus"]
+  },
+  {
+    "id": "ann-sqrt-helpers",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 52 },
+    "type": "tactic",
+    "title": "Radicand positivity helpers",
+    "content": "√(1+t²) > 0 and (√(1+t²))² = 1+t², the two facts about the radicand used repeatedly when differentiating and simplifying. Both follow from 1 + t² > 0 by positivity.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sqrt_pos", "Real.sq_sqrt", "positivity"],
+    "prerequisites": ["properties of the real square root"]
+  },
+  {
+    "id": "ann-sqrt-antideriv",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 54, "endLine": 76 },
+    "type": "insight",
+    "title": "Antiderivative of √(1+t²)",
+    "content": "d/dt [½(t√(1+t²) + arsinh t)] = √(1+t²). Mathlib supplies Real.hasDerivAt_arsinh but no antiderivative for the conjugate integrand √(1+t²), so it is assembled from the product rule on t·√(1+t²), the chain rule for √ (HasDerivAt.sqrt), and the arsinh derivative. The algebra collapses because (t²+1)/√(1+t²) = √(1+t²) doubles the leading term; field_simp + nlinarith closes the value equation.",
+    "significance": "key",
+    "relatedConcepts": ["product rule", "chain rule for √", "HasDerivAt.sqrt", "Real.hasDerivAt_arsinh"],
+    "prerequisites": ["differentiation rules", "HasDerivAt in Mathlib"]
+  },
+  {
+    "id": "ann-integral-arsinh-form",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 83, "endLine": 91 },
+    "type": "insight",
+    "title": "FTC evaluation in arsinh form",
+    "content": "∫_0^b √(1+t²) dt = ½(b√(1+b²) + arsinh b), via intervalIntegral.integral_eq_sub_of_hasDerivAt applied to the antiderivative above; the lower endpoint vanishes since arsinh 0 = 0. This is the supporting form the logarithmic result is built on.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fundamental Theorem of Calculus", "Real.arsinh_zero"],
+    "prerequisites": ["the Fundamental Theorem of Calculus"]
+  },
+  {
+    "id": "ann-integral-log-form",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 100 },
+    "type": "insight",
+    "title": "The logarithmic closed form (new)",
+    "content": "∫_0^b √(1+t²) dt = ½(b√(1+b²) + log(b + √(1+b²))). Because Real.arsinh x is DEFINED as log(x + √(1+x²)), the rewrite from the arsinh form is closed by rfl. This is the classical tabulated form of the catenary arc length and the payoff of the arsinh-LOG lineage.",
+    "mathContext": "$\\operatorname{arsinh} x=\\log(x+\\sqrt{1+x^2})$",
+    "significance": "critical",
+    "relatedConcepts": ["definitional unfolding", "logarithm", "catenary arc length"],
+    "prerequisites": ["definition of arsinh"]
+  },
+  {
+    "id": "ann-concrete-log",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 108 },
+    "type": "insight",
+    "title": "Concrete value at b = 1",
+    "content": "∫_0^1 √(1+t²) dt = ½(√2 + log(1 + √2)), obtained from the logarithmic closed form by norm_num on √(1+1²) = √2.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_num", "concrete evaluation"]
+  },
+  {
+    "id": "ann-sqrt-sinh",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 118 },
+    "type": "insight",
+    "title": "Arc-length element √(1+sinh²x) = cosh x",
+    "content": "The hyperbolic Pythagorean identity cosh²x = 1 + sinh²x together with cosh x > 0 simplifies the catenary arc-length element. This is what turns the surface-of-revolution integrand into 2π·cosh²x.",
+    "significance": "key",
+    "relatedConcepts": ["Real.cosh_sq", "Real.cosh_pos", "hyperbolic Pythagoras"],
+    "prerequisites": ["hyperbolic function identities"]
+  },
+  {
+    "id": "ann-coshsq-antideriv",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 120, "endLine": 132 },
+    "type": "insight",
+    "title": "Antiderivative of cosh²",
+    "content": "d/dx [½(x + sinh x·cosh x)] = cosh²x. The product rule gives (sinh·cosh)' = cosh² + sinh², so the derivative is ½(1 + cosh² + sinh²); cosh² = 1 + sinh² (Real.cosh_sq) collapses this to cosh². Mathlib has the sinh/cosh derivatives but not this antiderivative.",
+    "significance": "key",
+    "relatedConcepts": ["product rule", "Real.hasDerivAt_sinh", "Real.hasDerivAt_cosh", "Real.cosh_sq"],
+    "prerequisites": ["differentiation rules", "HasDerivAt in Mathlib"]
+  },
+  {
+    "id": "ann-integral-coshsq",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 139, "endLine": 145 },
+    "type": "insight",
+    "title": "∫_0^b cosh²x dx = ½(b + sinh b·cosh b)",
+    "content": "FTC evaluation of the cosh² antiderivative; the lower endpoint vanishes since sinh 0 = 0. This is the core integral behind the catenoid area.",
+    "significance": "key",
+    "relatedConcepts": ["Fundamental Theorem of Calculus", "Real.sinh_zero"],
+    "prerequisites": ["the Fundamental Theorem of Calculus"]
+  },
+  {
+    "id": "ann-catenoid",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 147, "endLine": 164 },
+    "type": "insight",
+    "title": "Catenoid lateral surface area (headline)",
+    "content": "∫_0^b 2π·cosh x·√(1+sinh²x) dx = π(b + sinh b·cosh b). Rewriting √(1+sinh²x) = cosh x makes the Pappus integrand 2π·cosh²x; pulling out the constant (integral_const_mul) and applying ∫cosh² = ½(b + sinh b·cosh b) gives the closed form. This discharges the 'more ambitious' half of the sibling's open question.",
+    "mathContext": "$\\int_0^b 2\\pi\\cosh x\\,\\sqrt{1+\\sinh^2 x}\\,dx=\\pi(b+\\sinh b\\cosh b)$",
+    "significance": "critical",
+    "relatedConcepts": ["surface of revolution", "Pappus theorem", "catenoid", "intervalIntegral.integral_const_mul"],
+    "prerequisites": ["surface area of revolution", "the Fundamental Theorem of Calculus"]
+  },
+  {
+    "id": "ann-catenoid-concrete",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
+    "range": { "startLine": 166, "endLine": 172 },
+    "type": "insight",
+    "title": "Concrete catenoid over [0,1]",
+    "content": "The catenoid swept by y = cosh x over [0,1] has lateral surface area π(1 + sinh 1·cosh 1), a direct specialisation of the general formula.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete evaluation"]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arsinhLogFormulaOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arsinhLogFormulaOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arsinhLogFormulaOq01Oq01Oq02Data: ProofData = {
+  proof: arsinhLogFormulaOq01Oq01Oq02Proof,
+  annotations: arsinhLogFormulaOq01Oq01Oq02Annotations,
+}

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "arsinh-log-formula-oq-01-oq-01-oq-02",
+  "slug": "arsinh-log-formula-oq-01-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "ArsinhLogFormulaOQ01OQ01OQ02",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Catenary Arc Length via arsinh: the Logarithmic Closed Form and the Catenoid Surface Area",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "hyperbolic-functions",
+      "inverse-hyperbolic",
+      "arsinh",
+      "catenary",
+      "catenoid",
+      "surface-of-revolution",
+      "arc-length",
+      "integration",
+      "fundamental-theorem-of-calculus",
+      "antiderivative",
+      "logarithm",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 173,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "integral_sqrt_one_add_sq_log: the purely logarithmic closed form ∫_0^b √(1+t²) dt = ½(b√(1+b²) + log(b + √(1+b²))), obtained by unfolding arsinh to its defining logarithm arsinh x = log(x + √(1+x²)). This is the form in which the catenary arc length is classically tabulated, and it is the payoff of the arsinh-LOG lineage — the sibling oq-01 stopped at the arsinh form.",
+      "integral_sqrt_one_add_sq_zero_to_one_log: the concrete logarithmic value ∫_0^1 √(1+t²) dt = ½(√2 + log(1 + √2)).",
+      "hasDerivAt_coshSqAntideriv: the new antiderivative d/dx [½(x + sinh x·cosh x)] = cosh²x, built from the product rule (sinh·cosh)' = cosh² + sinh² and collapsed via cosh²x = 1 + sinh²x. Mathlib supplies the sinh/cosh derivatives but no antiderivative for cosh².",
+      "integral_cosh_sq_zero_to: the FTC evaluation ∫_0^b cosh²x dx = ½(b + sinh b·cosh b).",
+      "catenoid_surface_area: the headline geometric result — the lateral surface area of the catenoid obtained by revolving the catenary y = cosh x, 0 ≤ x ≤ b, about the axis is ∫_0^b 2π·cosh x·√(1+sinh²x) dx = π(b + sinh b·cosh b), since the arc-length element √(1+sinh²x) = cosh x turns the Pappus integrand 2π·y·ds into 2π·cosh²x. This directly answers the more ambitious half of the sibling's open question.",
+      "catenoid_surface_area_zero_to_one: the concrete value π(1 + sinh 1·cosh 1) for the catenoid over [0, 1]."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The catenary y = cosh x is the shape of a hanging chain; revolving it about its axis sweeps out the catenoid, the classical minimal surface (discovered by Euler) spanning two coaxial rings. Two closed forms make the catenary a textbook staple of the hyperbolic substitution. First, the generic arc-length integrand √(1 + t²) has antiderivative ½(t√(1+t²) + arsinh t), and because arsinh x = log(x + √(1+x²)) this reads, in the logarithmic notation of classical tables, as ½(b√(1+b²) + log(b + √(1+b²))) — the passage to logarithms is the very reason the parent chain is named the arsinh-LOG formula. Second, the arc-length element √(1 + (cosh)'²) = √(1 + sinh²x) collapses to cosh x, so the Pappus surface-of-revolution integral 2π ∫ cosh x √(1+sinh²x) dx becomes 2π ∫ cosh²x dx, whose antiderivative π(x + sinh x·cosh x) gives the catenoid lateral area π(b + sinh b·cosh b). The sibling oq-01 built the arc length in arsinh form and posed exactly these two extensions — the logarithmic re-expression and the catenoid surface area — as its open question; this entry supplies both. Mathlib provides the sinh/cosh/arsinh derivatives but no antiderivative for √(1+t²) or cosh², so those are built from scratch.",
+    "problemStatement": "Re-express the catenary arc-length closed form ∫_0^b √(1+t²) dt in purely logarithmic notation, and compute the lateral surface area of the catenoid obtained by revolving y = cosh x about its axis.",
+    "keyIdeas": [
+      "arsinh x = log(x + √(1+x²)) holds definitionally in Mathlib, so the arsinh-form integral rewrites to the classical logarithmic closed form by rfl.",
+      "The catenary arc-length element √(1 + sinh²x) = cosh x (hyperbolic Pythagoras) turns the surface-of-revolution integrand 2π·cosh x·√(1+sinh²x) into 2π·cosh²x.",
+      "cosh² has the hand-built antiderivative ½(x + sinh x·cosh x): the product rule gives (sinh·cosh)' = cosh² + sinh², and cosh² = 1 + sinh² collapses ½(1 + cosh² + sinh²) to cosh².",
+      "The Fundamental Theorem of Calculus (intervalIntegral.integral_eq_sub_of_hasDerivAt) turns each hand-built derivative into the corresponding definite-integral evaluation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Logarithmic Arc Length and the Catenoid",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Recalls the sibling's arsinh-form arc length and states this entry's two new companions: the purely logarithmic closed form of ∫_0^b √(1+t²) dt and the catenoid lateral surface area. Enumerates the supplied theorems — the √(1+t²) antiderivative and its log evaluation, the cosh² antiderivative, ∫ cosh² = ½(b + sinh b·cosh b), and the catenoid area.",
+      "mathContext": "$\\int_0^b \\sqrt{1+t^2}\\,dt = \\tfrac12\\!\\left(b\\sqrt{1+b^2} + \\log\\!\\big(b+\\sqrt{1+b^2}\\big)\\right)$ and catenoid area $\\int_0^b 2\\pi\\cosh x\\,\\sqrt{1+\\sinh^2 x}\\,dx = \\pi\\big(b + \\sinh b\\cosh b\\big)$."
+    },
+    {
+      "id": "sqrt-antideriv-log",
+      "title": "The √(1+t²) Antiderivative and its Logarithmic Evaluation",
+      "startLine": 44,
+      "endLine": 108,
+      "summary": "Rebuilds the antiderivative d/dt [½(t√(1+t²) + arsinh t)] = √(1+t²) (product rule + √-chain rule + Real.hasDerivAt_arsinh), evaluates ∫_0^b √(1+t²) dt = ½(b√(1+b²) + arsinh b) by the FTC, and then — the new content — unfolds arsinh to its defining logarithm to obtain ½(b√(1+b²) + log(b + √(1+b²))), with the concrete value ½(√2 + log(1 + √2)) at b = 1.",
+      "mathContext": "$\\frac{d}{dt}\\tfrac12\\!\\big(t\\sqrt{1+t^2}+\\operatorname{arsinh} t\\big)=\\sqrt{1+t^2}$; $\\operatorname{arsinh} x=\\log(x+\\sqrt{1+x^2})$."
+    },
+    {
+      "id": "catenoid",
+      "title": "The Catenoid Surface Area",
+      "startLine": 110,
+      "endLine": 172,
+      "summary": "Proves √(1 + sinh²x) = cosh x, builds the cosh² antiderivative d/dx [½(x + sinh x·cosh x)] = cosh²x, evaluates ∫_0^b cosh²x dx = ½(b + sinh b·cosh b), and assembles the headline catenoid_surface_area: ∫_0^b 2π·cosh x·√(1+sinh²x) dx = π(b + sinh b·cosh b), with the concrete value π(1 + sinh 1·cosh 1).",
+      "mathContext": "$\\int_0^b \\cosh^2 x\\,dx=\\tfrac12(b+\\sinh b\\cosh b)$; catenoid area $=\\pi(b+\\sinh b\\cosh b)$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "arsinh-log-formula-oq-01-oq-01-oq-02-oq-01",
+      "question": "Formalise the catenoid as a minimal surface: show that among surfaces of revolution spanning two coaxial circles the catenoid is the (locally) area-minimising one, or at least that y = cosh x satisfies the Euler–Lagrange equation for the surface-of-revolution area functional 2π ∫ y √(1 + y'²) dx. This connects the closed-form area computed here to the variational characterisation of the catenoid.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The sibling oq-01 builds the catenary arc length in arsinh form, ½(b√(1+b²) + arsinh b), and poses as its open question both the logarithmic re-expression and 'more ambitiously, the surface-area-of-revolution integral 2π ∫ cosh x √(1+sinh²x) dx for the catenoid'. This entry answers both: the log closed form and the catenoid area π(b + sinh b·cosh b)."
+    },
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-01",
+      "relationship": "grandparent",
+      "description": "The grandparent supplies the antiderivative of the conjugate integrand 1/√(1+t²) (namely arsinh) and the logarithmic closed form arsinh x = log(x + √(1+x²)) that this entry uses to convert the arc-length integral into logarithmic notation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Arsinh",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.arsinh (defined as log(x + √(1+x²))) and its derivative Real.hasDerivAt_arsinh; the definitional equality drives the passage to the logarithmic closed form."
+    },
+    {
+      "title": "Mathlib4: Analysis.Complex.Trigonometric",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.hasDerivAt_sinh, Real.hasDerivAt_cosh and the hyperbolic identity Real.cosh_sq (cosh²x = sinh²x + 1), used to build the cosh² antiderivative and simplify the arc-length element."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.IntervalIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of intervalIntegral.integral_eq_sub_of_hasDerivAt (FTC) and intervalIntegral.integral_const_mul, which turn the hand-built derivatives into the definite-integral and surface-area evaluations."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "Completes the arsinh-LOG lineage's geometric arc by supplying the two companions the sibling oq-01 posed. First, the purely logarithmic closed form ∫_0^b √(1+t²) dt = ½(b√(1+b²) + log(b + √(1+b²))), obtained because arsinh x = log(x + √(1+x²)) holds definitionally — the classical tabulated form of the catenary arc length. Second, the catenoid: the arc-length element √(1+sinh²x) = cosh x turns the Pappus integrand 2π·cosh x·√(1+sinh²x) into 2π·cosh²x, and the hand-built antiderivative ½(x + sinh x·cosh x) of cosh² (product rule + cosh² = 1 + sinh²) yields the lateral surface area π(b + sinh b·cosh b). All 11 theorems are 0-axiom and machine-checked; concrete values ½(√2 + log(1 + √2)) and π(1 + sinh 1·cosh 1) anchor both closed forms.",
+    "significance": "The logarithmic form is the shape in which the catenary arc length actually appears in engineering and classical analysis, making the abstract arsinh identity concrete. The catenoid surface area extends the chain from a 1-D length computation to a genuine 2-D surface-of-revolution, and directly discharges the 'more ambitious' half of the sibling's open question. Both rest on antiderivatives (√(1+t²) and cosh²) that Mathlib does not provide, built here from the product and chain rules."
+  },
+  "description": "The catenary arc length ∫_0^b √(1+t²) dt, tabulated classically as ½(b√(1+b²) + log(b + √(1+b²))), follows from the arsinh form because arsinh x = log(x + √(1+x²)) definitionally. Revolving the catenary y = cosh x about its axis sweeps out the catenoid, whose lateral surface area 2π ∫_0^b cosh x √(1+sinh²x) dx collapses via √(1+sinh²x) = cosh x to 2π ∫ cosh²x dx = π(b + sinh b·cosh b), using a hand-built antiderivative of cosh² that Mathlib lacks. All results are 0-axiom and machine-checked."
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `arsinh-log-formula-oq-01-oq-01-oq-02` answering the sibling **oq-01**'s own open question, which asked (verbatim) to re-express the catenary arc length and "more ambitiously, formalise the surface-area-of-revolution integral 2π ∫ cosh x √(1+sinh²x) dx for the catenoid."

Two genuinely new companions on the arsinh-**log** lineage (the sibling stopped at the arsinh form):

1. **Logarithmic closed form** — `integral_sqrt_one_add_sq_log`:
   `∫_0^b √(1+t²) dt = ½(b√(1+b²) + log(b + √(1+b²)))`, obtained because `Real.arsinh x` is *defined* as `log(x + √(1+x²))`, so the rewrite from the arsinh form closes by `rfl`. This is the form in which the catenary arc length is classically tabulated. Concrete value `½(√2 + log(1 + √2))` at `b = 1`.

2. **Catenoid surface area** — `catenoid_surface_area`:
   `∫_0^b 2π·cosh x·√(1+sinh²x) dx = π(b + sinh b·cosh b)`. The arc-length element `√(1+sinh²x) = cosh x` turns the Pappus integrand into `2π·cosh²x`; a hand-built antiderivative `½(x + sinh x·cosh x)` of `cosh²` (product rule + `cosh² = 1 + sinh²`, which Mathlib does not provide) gives the closed form. Concrete value `π(1 + sinh 1·cosh 1)` over `[0,1]`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.ArsinhLogFormulaOQ01OQ01OQ02` → **Build succeeded**
- 0 `axiom` declarations, 0 structure-encoded assumptions, 0 `sorry`, no `native_decide`. Status: `verified`, badge `original`.
- 11 theorems / 0 defs / 173 lines.

## Gallery
- `src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/` — meta.json, annotations.json (11 annotations), index.ts.
- `gallery:check-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)