### PR TITLE
Enrich derangements-oq-04-oq-01-oq-01: full annotations.json (0→4 depth annotations, 94% coverage)

### DIFF
--- a/src/data/proofs/derangements-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "derangements-oq040101-overview",
+    "proofId": "derangements-oq-04-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "Poisson(1) Limit for the Fixed-Point Count of a Random Permutation",
+    "content": "The parent entry (derangements-oq-04-oq-01) supplies the exact count S(n,k) of permutations of Fin n with exactly k fixed points: S(n,k) = (n!/k!)·∑_{j=0}^{n-k} (−1)^j/j!. This file answers the parent's first open question — divide by n! to get a probability, then let n → ∞. The result is the classical theorem that the number of fixed points of a uniformly random permutation converges in distribution to a Poisson random variable of mean 1: P[exactly k fixed points] = S(n,k)/n! → e^{-1}/k!. The proof adds no new combinatorics; it is a limit assembly reusing the parent's closed form and a sibling's series-convergence lemma. It imports only DerangementsOQ04OQ01 and DerangementsConvergence and is fully verified (0 sorries, 0 axioms beyond Mathlib's foundations).",
+    "mathContext": "$$\\frac{S(n,k)}{n!}=\\frac1{k!}\\sum_{j=0}^{n-k}\\frac{(-1)^j}{j!}\\;\\xrightarrow[n\\to\\infty]{}\\;\\frac{e^{-1}}{k!},$$ the Poisson(1) pmf $p(k)=e^{-\\lambda}\\lambda^k/k!$ at $\\lambda=1$. The number of fixed points $\\to_d \\mathrm{Poisson}(1)$, so all factorial moments tend to $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Poisson limit theorem",
+      "derangements",
+      "convergence in distribution",
+      "method of moments",
+      "inclusion–exclusion",
+      "law of small numbers"
+    ],
+    "prerequisites": [
+      "the parent closed form S(n,k) = (n!/k!)·∑(−1)^j/j!",
+      "convergence of sequences of real numbers",
+      "the Poisson distribution"
+    ]
+  },
+  {
+    "id": "derangements-oq040101-partialsum-limit",
+    "proofId": "derangements-oq-04-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 56 },
+    "type": "technique",
+    "title": "Partial Sums of the Alternating Exponential Series Tend to e⁻¹",
+    "content": "altFactPartialSum_tendsto_expNegOne shows that the truncations altFactPartialSum m = ∑_{j=0}^{m} (−1)^j/j! converge to e^{-1}. The engine is HasSum: since the alternating exponential series is summable with total e^{-1} (exp_neg_one_eq_tsum_alt), its (m+1)-term partial sums converge to that total via HasSum.tendsto_sum_nat. A reindexing by tendsto_add_atTop_nat 1 aligns Mathlib's range m partial sums with the m+1-term truncations, after which simpa unfolds the definitions. This is the sole analytic input; everything downstream is bookkeeping.",
+    "mathContext": "The Maclaurin series of $e^x$ at $x=-1$ gives $e^{-1}=\\sum_{j=0}^\\infty (-1)^j/j!$. A convergent series' partial sums tend to its sum: $\\sum_{j=0}^{m}(-1)^j/j!\\to e^{-1}$. Formally, $\\texttt{HasSum}\\,f\\,S\\Rightarrow \\big(\\sum_{i<m} f(i)\\big)\\to S$ (\\texttt{HasSum.tendsto\\_sum\\_nat}).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasSum and tsum",
+      "exp_neg_one_eq_tsum_alt",
+      "partial sums of a summable series",
+      "alternating series",
+      "reindexing filters (tendsto_add_atTop_nat)"
+    ],
+    "prerequisites": [
+      "summability and HasSum in Mathlib",
+      "the exponential series",
+      "filters and Tendsto atTop"
+    ]
+  },
+  {
+    "id": "derangements-oq040101-poisson-main",
+    "proofId": "derangements-oq-04-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 99 },
+    "type": "insight",
+    "title": "Assembling the Poisson Limit from the Closed Form",
+    "content": "fixedPoints_tendsto_poisson is the main theorem: for fixed k, S(n,k)/n! → e^{-1}/k!. Because k is constant, n−k → ∞ (hsubk via omega), so composing with the partial-sum limit gives altFactPartialSum(n−k) → e^{-1}. Scaling by the constant 1/k! (const_mul) yields the target limit after a ring rewrite of (1/k!)·e^{-1} = e^{-1}/k!. The crux is a congr'/eventuallyEq step: the scaled partial sums equal S(n,k)/n! only eventually, precisely for n ≥ k. On that set the pointwise identity is discharged by substituting the parent's real closed form (card_perms_with_kfixed_closed_form_real) and clearing denominators with field_simp, using that n! and k! are nonzero.",
+    "mathContext": "For $n\\ge k$, cancelling $n!$ in $S(n,k)=(n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$ gives $S(n,k)/n!=(1/k!)\\,\\texttt{altFactPartialSum}(n-k)$. Since $k$ fixed $\\Rightarrow n-k\\to\\infty$, $\\texttt{altFactPartialSum}(n-k)\\to e^{-1}$, and multiplying by the constant $1/k!$ gives $S(n,k)/n!\\to e^{-1}/k!$. The eventual (not identical) equality is handled with $\\texttt{Tendsto.congr'}$ on $\\{n\\mid k\\le n\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "eventual equality of sequences (Tendsto.congr')",
+      "Filter.Eventually and atTop",
+      "const_mul of a limit",
+      "cancelling n! (field_simp)",
+      "composition of tendsto"
+    ],
+    "prerequisites": [
+      "the parent closed form (real version)",
+      "Tendsto.comp and Tendsto.const_mul",
+      "eventuallyEq_iff_exists_mem",
+      "field_simp / factorial_cast_ne_zero'"
+    ]
+  },
+  {
+    "id": "derangements-oq040101-k0-consistency",
+    "proofId": "derangements-oq-04-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 110 },
+    "type": "insight",
+    "title": "k = 0 Recovers the Classical Derangement Limit",
+    "content": "derangements_tendsto_poisson_zero specialises the main theorem to k = 0, recovering D_n/n! → e^{-1}: the probability that a uniformly random permutation has no fixed point (is a derangement) tends to 1/e, which is the Poisson(1) mass at 0. The proof is a one-liner — instantiate fixedPoints_tendsto_poisson at k = 0 and simplify e^{-1}/0! = e^{-1}. This provides a sanity check consistent with the well-known derangement asymptotic and ties the new distributional statement back to the classical special case.",
+    "mathContext": "At $k=0$: $e^{-1}/0!=e^{-1}$, so $D_n/n!=S(n,0)/n!\\to e^{-1}\\approx 0.3679$. This is the classical fact that the fraction of derangements tends to $1/e$, and equals the Poisson(1) probability of zero events.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "derangements",
+      "1/e asymptotic density",
+      "Poisson pmf at zero",
+      "specialisation / sanity check"
+    ],
+    "prerequisites": [
+      "the main Poisson limit theorem",
+      "the derangement number D_n = S(n,0)"
+    ]
+  }
+]


### PR DESCRIPTION
Fresh `annotations.json` for the Poisson(1) fixed-point limit entry (verified, 0-axiom, 112L), which previously had **zero** annotations.

**4 full-depth annotations, 94% line coverage (105/112):**
1. Overview — Poisson(1) limit for the fixed-point count of a random permutation
2. Partial sums of the alternating exponential series tend to e⁻¹ (`HasSum.tendsto_sum_nat`)
3. Assembling the Poisson limit from the parent closed form (eventual-equality `congr'` on n ≥ k, `field_simp`)
4. k = 0 recovers the classical derangement limit D_n/n! → e⁻¹

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, verified against the Lean source. `meta.json` left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)