### PR TITLE
research(fourth-root-2-irrational-oq-03): Galois property + |Gal(ℚ(⁴√2,i)/ℚ)|=8 [VERIFIED, 0-axiom] + gallery entry

### DIFF
--- a/proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean
+++ b/proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean
@@ -69,14 +69,14 @@ theorem a_ne_zero : a ≠ 0 := fun h => by simpa [h] using a_pow_four
 theorem a_mem_rootSet : a ∈ p.rootSet ℂ := by
   rw [mem_rootSet]
   refine ⟨p_ne_zero, ?_⟩
-  simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat]
+  simp only [p, map_sub, map_pow, aeval_X, map_ofNat]
   rw [a_pow_four]; norm_num
 
 /-- `i·⁴√2` is a root of `X⁴ − 2`. -/
 theorem Ia_mem_rootSet : Complex.I * a ∈ p.rootSet ℂ := by
   rw [mem_rootSet]
   refine ⟨p_ne_zero, ?_⟩
-  simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat]
+  simp only [p, map_sub, map_pow, aeval_X, map_ofNat]
   rw [I_mul_a_pow_four]; norm_num
 
 /-- The splitting set of `X⁴ − 2` in ℂ generates exactly `ℚ(⁴√2, i)`. -/
@@ -88,7 +88,7 @@ theorem adjoin_rootSet_eq : adjoin ℚ (p.rootSet ℂ) = ℚ⟮a, Complex.I⟯ :
     rw [mem_rootSet] at hz
     have hz4 : z ^ 4 = 2 := by
       have h0 := hz.2
-      simp only [p, map_sub, map_pow, aeval_X, aeval_C, map_ofNat, sub_eq_zero] at h0
+      simp only [p, map_sub, map_pow, aeval_X, map_ofNat, sub_eq_zero] at h0
       exact h0
     have key : (z - a) * (z + a) * (z - Complex.I * a) * (z + Complex.I * a)
         = z ^ 4 - a ^ 4 := by
@@ -129,13 +129,19 @@ instance isGalois : IsGalois ℚ ℚ⟮a, Complex.I⟯ := by
 /-- The normality half of `isGalois`, packaged separately. -/
 theorem normal : Normal ℚ ℚ⟮a, Complex.I⟯ := IsGalois.to_normal
 
+/-- `ℚ(⁴√2, i) / ℚ` is finite-dimensional: as a splitting field it is finite over ℚ.
+This supplies the `Fintype` instance on the Galois group needed by `card_gal`. -/
+instance finiteDimensional : FiniteDimensional ℚ ℚ⟮a, Complex.I⟯ := by
+  haveI := isSplittingField
+  exact Polynomial.IsSplittingField.finiteDimensional ℚ⟮a, Complex.I⟯ p
+
 /-- **The Galois group of `ℚ(⁴√2, i)` over ℚ has order 8.**
 `#Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8`.  This is the group-order input to the
 `D₄` identification, obtained by combining the parent's degree computation with
 the Galois property proved here. -/
 theorem card_gal :
     Fintype.card (ℚ⟮a, Complex.I⟯ ≃ₐ[ℚ] ℚ⟮a, Complex.I⟯) = 8 := by
-  rw [IsGalois.card_aut_eq_finrank ℚ ℚ⟮a, Complex.I⟯]
+  rw [← Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank ℚ ℚ⟮a, Complex.I⟯]
   exact finrank_galois_closure
 
 end FourthRoot2GaloisClosureOQ03

--- a/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fourth-root-2-irrational-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Galois property and |Gal| = 8: the step deferred by the degree computation",
+    "content": "The docstring frames this entry against the sibling FourthRoot2GaloisClosure, which secured the degree [ℚ(⁴√2, i) : ℚ] = 8 but deferred the group-theoretic content. Here ℚ(⁴√2, i) is shown to be a GALOIS extension of ℚ and its automorphism group to have order exactly 8. The method: ℚ(⁴√2, i) is the splitting field of X⁴ − 2 (its four roots ±⁴√2, ±i·⁴√2 are exactly the solutions of z⁴ = 2), X⁴ − 2 is separable over ℚ (irreducible in characteristic zero), so the splitting field is Galois, and IsGalois.card_aut_eq_finrank turns the degree 8 into #Gal = 8. Zero axioms; reuses only Mathlib and the parent."
+  },
+  {
+    "id": "ann-polynomial-separable",
+    "proofId": "fourth-root-2-irrational-oq-03",
+    "range": {
+      "startLine": 51,
+      "endLine": 80
+    },
+    "type": "concept",
+    "title": "X⁴ − 2 is separable, and ⁴√2, i·⁴√2 lie in its root set",
+    "content": "p = X⁴ − 2 equals minpoly ℚ (⁴√2) (parent fact), so it is irreducible and — because ℚ has characteristic zero — separable (p_separable). Separability is one of the two ingredients of the Galois property. The two theorems a_mem_rootSet and Ia_mem_rootSet certify that a = (⁴√2 : ℂ) and i·⁴√2 are roots: aeval reduces to their fourth powers, both equal to 2 by the parent's a_pow_four and I_mul_a_pow_four."
+  },
+  {
+    "id": "ann-adjoin-rootset",
+    "proofId": "fourth-root-2-irrational-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 115
+    },
+    "type": "insight",
+    "title": "The root set generates exactly ℚ(⁴√2, i)",
+    "content": "adjoin_rootSet_eq is the field-theoretic crux, proved by antisymmetry. Forward (⊆): any root z satisfies z⁴ = 2 = a⁴, and the factorization z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) — valid because i² = −1, discharged by linear_combination on Complex.I_sq — forces z ∈ {±a, ±i·a}, each already in ℚ(⁴√2, i) by the parent's roots_mem_closure. Reverse (⊇): a is a root, and i is recovered as (i·a)·a⁻¹, so both generators of ℚ(⁴√2, i) lie in the adjoined field. This identity is what lets the abstract splitting-field machinery land on the concrete field ℚ(⁴√2, i)."
+  },
+  {
+    "id": "ann-galois-cardinality",
+    "proofId": "fourth-root-2-irrational-oq-03",
+    "range": {
+      "startLine": 117,
+      "endLine": 146
+    },
+    "type": "insight",
+    "title": "Splitting field ⟹ Galois ⟹ |Gal| = 8",
+    "content": "With the root-set identity in hand, isSplittingField follows because X⁴ − 2 splits over the algebraically closed ℂ (adjoin_rootSet_isSplittingField, then rewrite). A separable splitting field is Galois (isGalois via IsGalois.of_separable_splitting_field), and it is finite-dimensional (finiteDimensional), which supplies the Fintype instance on the Galois group. Finally card_gal: converting Fintype.card to Nat.card and applying IsGalois.card_aut_eq_finrank equates #Gal with the finrank, which the parent computed to be 8. The order-8 Galois group is the exact prerequisite for identifying it with the dihedral group D₄."
+  }
+]

--- a/src/data/proofs/fourth-root-2-irrational-oq-03/index.ts
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourthRoot2IrrationalOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourthRoot2IrrationalOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourthRoot2IrrationalOq03Data: ProofData = {
+  proof: fourthRoot2IrrationalOq03Proof,
+  annotations: fourthRoot2IrrationalOq03Annotations,
+}

--- a/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "fourth-root-2-irrational-oq-03",
+  "slug": "fourth-root-2-irrational-oq-03",
+  "title": "ℚ(⁴√2, i) is Galois over ℚ with |Gal(ℚ(⁴√2, i)/ℚ)| = 8",
+  "description": "Answers the follow-up left open by the sibling entry fourth-root-2-irrational-oq-01, which secured the DEGREE [ℚ(⁴√2, i) : ℚ] = 8 but explicitly deferred the group-theoretic content. This entry supplies the quantitative heart of that deferred step: that ℚ(⁴√2, i) is a GALOIS extension of ℚ (normal + separable) and that its automorphism group has order exactly 8. Working inside ℂ with ⁴√2 modeled as the real √√2 and i = Complex.I, it identifies ℚ(⁴√2, i) as the splitting field of X⁴ − 2 over ℚ: the polynomial's four roots ±⁴√2, ±i·⁴√2 are exactly the solutions of z⁴ = 2 (via the factorization z⁴ − a⁴ = (z−a)(z+a)(z−ia)(z+ia), valid because i² = −1), so adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i). Since X⁴ − 2 = minpoly ℚ (⁴√2) is irreducible and hence separable over the characteristic-zero field ℚ, the splitting field is Galois; IsGalois.card_aut_eq_finrank turns the parent's degree 8 into #Gal = 8. Zero axioms, zero sorries, no native_decide. Reuses only Mathlib and the parent FourthRoot2GaloisClosure. card_gal is the exact group-order prerequisite for the D₄ identification.",
+  "meta": {
+    "author": "formalized in Lean 4 (classical Galois theory: Dedekind, Galois)",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourthRoot2GaloisClosureOQ03.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "splitting-field",
+      "field-extension",
+      "galois-group",
+      "separable",
+      "minimal-polynomial",
+      "dihedral-group"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 147,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "originalContributions": [
+      "card_gal: the headline result #Gal(ℚ(⁴√2, i)/ℚ) = 8. Obtained by combining the parent's degree computation [ℚ(⁴√2, i) : ℚ] = 8 with the Galois property proved here, via IsGalois.card_aut_eq_finrank (with the Fintype/Nat.card bookkeeping). This is the group-order input on which the D₄ identification rests.",
+      "isGalois: ℚ(⁴√2, i) is a Galois extension of ℚ, obtained from IsGalois.of_separable_splitting_field applied to the separable splitting field of X⁴ − 2.",
+      "isSplittingField: X⁴ − 2 has ℚ(⁴√2, i) as its splitting field over ℚ, reduced to the field identity adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i).",
+      "adjoin_rootSet_eq: the field-theoretic crux — the splitting set of X⁴ − 2 in ℂ generates exactly ℚ(⁴√2, i). The forward inclusion factors z⁴ − a⁴ over the four roots ±a, ±i·a; the reverse recovers i as (i·a)·a⁻¹.",
+      "finiteDimensional: ℚ(⁴√2, i)/ℚ is finite-dimensional as a splitting field, supplying the Fintype instance on the Galois group that card_gal needs.",
+      "p_separable / p_irreducible: X⁴ − 2 = minpoly ℚ (⁴√2) is irreducible, hence separable over the characteristic-zero field ℚ — the separability half of the Galois property."
+    ],
+    "prerequisites": [
+      "The sibling fourth-root-2-irrational-oq-01 (parent FourthRoot2GaloisClosure): [ℚ(⁴√2, i) : ℚ] = 8, minpoly ℚ (⁴√2) = X⁴ − 2, and roots_mem_closure (the four roots lie in ℚ(⁴√2, i))",
+      "IsGalois.of_separable_splitting_field: the splitting field of a separable polynomial is a Galois extension",
+      "IsGalois.card_aut_eq_finrank: for a finite Galois extension, #Aut = [E : F]",
+      "IntermediateField.adjoin_rootSet_isSplittingField: adjoin F (rootSet f) is a splitting field of f when f splits over the ambient algebraically closed field",
+      "Polynomial.IsSplittingField.finiteDimensional: a splitting field is finite-dimensional over the base"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsGalois.of_separable_splitting_field",
+        "description": "If E is the splitting field of a separable polynomial p over F, then E/F is a Galois extension.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IsGalois.card_aut_eq_finrank",
+        "description": "For a finite-dimensional Galois extension E/F, Nat.card (E ≃ₐ[F] E) = finrank F E.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IntermediateField.adjoin_rootSet_isSplittingField",
+        "description": "If p splits over an algebraically closed extension, then adjoin F (p.rootSet) is a splitting field of p over F.",
+        "module": "Mathlib.FieldTheory.SplittingField.Construction"
+      },
+      {
+        "theorem": "Polynomial.IsSplittingField.finiteDimensional",
+        "description": "A splitting field of a polynomial is finite-dimensional over the base field.",
+        "module": "Mathlib.FieldTheory.SplittingField.IsSplittingField"
+      },
+      {
+        "theorem": "Irreducible.separable",
+        "description": "Over a field of characteristic zero, an irreducible polynomial is separable.",
+        "module": "Mathlib.FieldTheory.Separable"
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.FourthRoot2GaloisClosure"
+    ],
+    "opens": [
+      "Polynomial",
+      "IntermediateField",
+      "FourthRoot2GaloisClosure",
+      "scoped Classical"
+    ],
+    "namespace": "FourthRoot2GaloisClosureOQ03",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "card_gal",
+        "type": "core",
+        "description": "The Galois group of ℚ(⁴√2, i) over ℚ has order 8: #Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8.",
+        "leanType": "Fintype.card (ℚ⟮a, Complex.I⟯ ≃ₐ[ℚ] ℚ⟮a, Complex.I⟯) = 8"
+      },
+      {
+        "name": "isGalois",
+        "type": "key",
+        "description": "ℚ(⁴√2, i) is a Galois extension of ℚ (normal + separable), as the splitting field of the separable X⁴ − 2.",
+        "leanType": "IsGalois ℚ ℚ⟮a, Complex.I⟯"
+      },
+      {
+        "name": "isSplittingField",
+        "type": "key",
+        "description": "X⁴ − 2 has ℚ(⁴√2, i) as its splitting field over ℚ.",
+        "leanType": "p.IsSplittingField ℚ ℚ⟮a, Complex.I⟯"
+      },
+      {
+        "name": "adjoin_rootSet_eq",
+        "type": "supporting",
+        "description": "The splitting set of X⁴ − 2 in ℂ generates exactly ℚ(⁴√2, i): adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i).",
+        "leanType": "adjoin ℚ (p.rootSet ℂ) = ℚ⟮a, Complex.I⟯"
+      }
+    ],
+    "path": "Proofs/FourthRoot2GaloisClosureOQ03.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The sibling entry fourth-root-2-irrational-oq-01 proves the DEGREE of the Galois closure of ℚ(⁴√2): [ℚ(⁴√2, i) : ℚ] = 8, via the tower ℚ ⊂ ℚ(⁴√2) ⊂ ℚ(⁴√2, i). But it explicitly defers the group-theoretic content — 'the full identification of the Galois group with D₄ is left for a follow-up; here we secure the degree and the tower.' The missing piece has two levels: first, that the extension is actually Galois (normal + separable) and that its automorphism group has the expected order 8; second, the concrete identification of that group with the dihedral group D₄ (the symmetries of the square formed by the four roots ±⁴√2, ±i·⁴√2 in ℂ). This entry supplies the first level — the Galois property and #Gal = 8 — the exact prerequisite on which the D₄ identification rests.",
+    "problemStatement": "**Deferred by fourth-root-2-irrational-oq-01**: prove ℚ(⁴√2, i) is Galois over ℚ (normal + separable) and derive card(Gal) = 8 from IsGalois.card_aut_eq_finrank, as the group-order foundation for the eventual Gal ≅ D₄ identification.\n\n**This entry**: identifies ℚ(⁴√2, i) as the splitting field of X⁴ − 2 over ℚ, deduces it is Galois (X⁴ − 2 is separable over ℚ), and turns the parent's degree 8 into #Gal(ℚ(⁴√2, i)/ℚ) = 8.",
+    "text": "A 147-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing Mathlib through the parent FourthRoot2GaloisClosure. It reuses the parent's real model a = (⁴√2 : ℂ), the fact minpoly ℚ a = X⁴ − 2, and roots_mem_closure. The main work is the field identity adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i), from which the splitting-field, Galois, and cardinality facts follow from Mathlib's Galois-theory API.",
+    "proofStrategy": "(1) Set p = X⁴ − 2. From the parent, p = minpoly ℚ (⁴√2), so p is irreducible and — over the characteristic-zero field ℚ — separable. (2) Show adjoin ℚ (p.rootSet ℂ) = ℚ(⁴√2, i). Forward: any root z satisfies z⁴ = 2 = a⁴, and the factorization z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) (which uses i² = −1) forces z ∈ {±a, ±i·a}, each already in ℚ(⁴√2, i) by the parent's roots_mem_closure. Reverse: a is a root (so a is in the adjoined field) and i = (i·a)·a⁻¹ is recovered from the roots a and i·a. (3) Since p splits over the algebraically closed ℂ, adjoin ℚ (p.rootSet ℂ) is a splitting field of p; rewriting by the identity gives isSplittingField : p.IsSplittingField ℚ ℚ(⁴√2, i). (4) A separable splitting field is Galois (IsGalois.of_separable_splitting_field), and it is finite-dimensional. (5) IsGalois.card_aut_eq_finrank equates #Gal with the finrank, which the parent computed to be 8 — giving card_gal.",
+    "keyInsights": [
+      "Being Galois is 'separable + splitting field'. The obstruction to normality that made ℚ(⁴√2) non-Galois disappears once the two missing roots ±i·⁴√2 are adjoined: the enlarged field ℚ(⁴√2, i) is the splitting field of X⁴ − 2, and X⁴ − 2 is separable over ℚ (characteristic zero), so the extension is automatically Galois.",
+      "The splitting-field identity is the whole content. Everything downstream (Galois, finite-dimensional, #Gal = 8) is Mathlib API once adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i) is established. That identity is proved by explicit factorization of z⁴ − a⁴ into the four linear factors — the same factorization that geometrically places the roots at the vertices of a square.",
+      "#Gal = degree is exactly the Galois property. For a finite separable normal extension, Nat.card of the automorphism group equals the field degree; here that converts the parent's purely field-theoretic [ℚ(⁴√2, i) : ℚ] = 8 into the group-order fact |Gal| = 8 = |D₄|, the anchor for the eventual dihedral identification.",
+      "The result is the launch pad for D₄. A group of order 8 acting faithfully as the Galois group, together with the square arrangement of the four roots, pins the group down to D₄ once the eight automorphisms are exhibited — the natural next entry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "polynomial-separable",
+      "title": "The Defining Polynomial X⁴ − 2 and its Separability",
+      "startLine": 51,
+      "endLine": 80,
+      "summary": "p = X⁴ − 2 = minpoly ℚ (⁴√2), so it is irreducible (p_irreducible) and separable over ℚ (p_separable); a = (⁴√2 : ℂ) and i·⁴√2 are roots (a_mem_rootSet, Ia_mem_rootSet).",
+      "mathContext": "Establishes the separability half of the Galois property and identifies members of the root set."
+    },
+    {
+      "id": "adjoin-rootset",
+      "title": "The Root Set Generates ℚ(⁴√2, i)",
+      "startLine": 82,
+      "endLine": 115,
+      "summary": "adjoin_rootSet_eq: every root z (z⁴ = 2) factors through ±a, ±i·a via z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) and lies in the closure; conversely a and i = (i·a)·a⁻¹ both lie in adjoin ℚ (rootSet).",
+      "mathContext": "The field-theoretic crux identifying the splitting field with ℚ(⁴√2, i)."
+    },
+    {
+      "id": "galois-cardinality",
+      "title": "Splitting Field, Galois Property, and |Gal| = 8",
+      "startLine": 117,
+      "endLine": 146,
+      "summary": "isSplittingField (from adjoin_rootSet_eq + p splits over ℂ), isGalois (separable splitting field), normal, finiteDimensional, and card_gal: #Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8 via IsGalois.card_aut_eq_finrank and the parent's degree.",
+      "mathContext": "Assembles the Galois property and converts the parent's degree into the group order 8."
+    }
+  ],
+  "conclusion": {
+    "summary": "ℚ(⁴√2, i) is the splitting field of X⁴ − 2 over ℚ, hence a Galois extension (X⁴ − 2 is separable over the characteristic-zero field ℚ), and its Galois group has order exactly 8: #Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8. The proof reduces to the field identity adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i) — proved by factoring z⁴ − a⁴ over the four roots ±⁴√2, ±i·⁴√2 — after which Mathlib's Galois-theory API delivers the splitting-field, Galois, and cardinality facts. Zero axioms, zero sorries.",
+    "implications": "This completes the group-order half of the deferred D₄ analysis for the classic non-normal radical extension ℚ(⁴√2)/ℚ. Combined with the sibling's degree computation, it establishes that Gal(ℚ(⁴√2, i)/ℚ) is a group of order 8 = |D₄| acting faithfully with ℚ as its fixed field — the precise foundation on which the explicit identification Gal ≅ D₄ (constructing the eight automorphisms) is built.",
+    "openQuestions": [
+      "Identify Gal(ℚ(⁴√2, i)/ℚ) explicitly with the dihedral group D₄: construct the 8 field automorphisms (generated by the order-4 map ⁴√2 ↦ i·⁴√2, i ↦ i and the order-2 complex conjugation) and prove the group isomorphism, now that |Gal| = 8 is available.",
+      "Compute the intermediate-field lattice of ℚ(⁴√2, i)/ℚ and match it against the subgroup lattice of D₄ via the Galois correspondence, exhibiting the non-normal intermediate field ℚ(⁴√2).",
+      "Abstractly, the isomorphism Gal(X⁴ − 2) ≅ D₄ is already handled in the inverse-galois-d4 entry via a Sylow-2 argument; the remaining task is the concrete identification for THIS ℂ-model field ℚ(⁴√2, i)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §14.2 (The Fundamental Theorem of Galois Theory), Example on ℚ(⁴√2, i)",
+      "note": "The standard textbook treatment of ℚ(⁴√2, i)/ℚ as the splitting field of X⁴ − 2 with Galois group D₄"
+    },
+    {
+      "authors": "Stewart, Ian",
+      "title": "Galois Theory",
+      "year": "2015",
+      "venue": "CRC Press, 4th ed.",
+      "note": "Splitting fields, normality, separability, and the dihedral Galois group of X⁴ − 2"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fourth-root-2-irrational-oq-01",
+      "relationship": "extends",
+      "description": "Sibling that secured the degree [ℚ(⁴√2, i) : ℚ] = 8 and explicitly deferred the group-theoretic content. This entry supplies that deferred step: the Galois property and #Gal = 8, reusing the sibling's degree, minpoly, and roots_mem_closure."
+    },
+    {
+      "targetId": "fourth-root-2-irrational",
+      "relationship": "related",
+      "description": "Grandparent: proves [ℚ(⁴√2):ℚ] = 4 via Eisenstein on X⁴ − 2. Its irreducibility of X⁴ − 2 underlies the separability used here to conclude ℚ(⁴√2, i)/ℚ is Galois."
+    },
+    {
+      "targetId": "inverse-galois-d4",
+      "relationship": "related",
+      "description": "Handles the abstract isomorphism Gal(X⁴ − 2) ≅ D₄ via a Sylow-2 argument; this entry provides the group-order fact |Gal| = 8 for the concrete ℂ-model field ℚ(⁴√2, i)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Build-verifies and completes `fourth-root-2-irrational-oq-03`. The Lean file landed via #33209 marked **"proof written, build-blocked"** (host disk exhaustion prevented verification). This PR fixes the two genuine build errors, verifies the proof compiles **0-axiom / 0-sorry**, and adds the **missing gallery entry** (meta.json, annotations.json, index.ts) so the result is visible.

## The result

ℚ(⁴√2, i) is the **splitting field** of X⁴ − 2 over ℚ, hence a **Galois** extension (X⁴ − 2 is separable over the characteristic-zero field ℚ), and its Galois group has order exactly 8:

```
card_gal : Fintype.card (ℚ⟮a, Complex.I⟯ ≃ₐ[ℚ] ℚ⟮a, Complex.I⟯) = 8
```

This answers the follow-up **explicitly deferred** by the sibling `fourth-root-2-irrational-oq-01`, which secured the degree `[ℚ(⁴√2,i):ℚ] = 8` but left the group-theoretic content open. `|Gal| = 8` is the group-order prerequisite for the eventual `Gal ≅ D₄` identification.

## Build fixes applied to the merged `.lean`

- Added `instance finiteDimensional` (a splitting field is `FiniteDimensional`), which supplies the `Fintype` instance the Galois-group cardinality statement requires — this was the original blocker (`failed to synthesize Fintype Gal(...)`).
- `card_gal`: current Mathlib states `IsGalois.card_aut_eq_finrank` with `Nat.card`, so convert `Fintype.card → Nat.card` via `← Nat.card_eq_fintype_card` before rewriting.
- Dropped unused `aeval_C` simp arguments (linter).

## Verification

Built locally with `lake env lean` on the warm Mathlib olean tree (host, retrying through concurrent-build memory pressure). Compiles clean (only a `splits_codomain` deprecation warning).

```
#print axioms card_gal        ⇒ [propext, Classical.choice, Quot.sound]
#print axioms isGalois        ⇒ [propext, Classical.choice, Quot.sound]
#print axioms isSplittingField ⇒ [propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no `Lean.ofReduceBool`, no `axiom` declarations, no structure-encoded assumptions ⇒ **status: verified, badge: verified, axiomCount: 0**.

## Files

- `proofs/Proofs/FourthRoot2GaloisClosureOQ03.lean` — 3 build fixes (12 thm+inst / 1 def / 147 L)
- `src/data/proofs/fourth-root-2-irrational-oq-03/{meta.json,annotations.json,index.ts}` — new gallery entry (listings regenerate on sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)