### PR TITLE
research(abundant-number-oq-01-oq-04): infinitely many primitive abundant numbers via 2^k·p + Bertrand [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbundantPrimitiveInfiniteOQ0104.lean
+++ b/proofs/Proofs/AbundantPrimitiveInfiniteOQ0104.lean
@@ -1,0 +1,197 @@
+/-
+# Infinitely Many Primitive Abundant Numbers
+
+A **primitive abundant number** is an abundant number all of whose proper
+divisors are deficient -- i.e. a minimal abundant number under divisibility.
+The sibling entry `abundant-number-oq-04-oq-01-oq-02` defines these and proves
+that `20` is the least one. This entry proves the classical fact that there are
+**infinitely many** of them.
+
+## The construction
+
+For an integer `k ≥ 2` and an odd prime `p` in the window
+`2^k - 1 < p < 2^(k+1) - 1`, the number `n = 2^k · p` is primitive abundant:
+
+* **Abundance.** Since `p` is coprime to `2^k`, the divisor sum is multiplicative,
+  `σ(2^k·p) = (2^(k+1) - 1)(p + 1)`, and the abundance inequality `2n < σ(n)`
+  reduces to exactly `p < 2^(k+1) - 1`.
+* **Primitivity.** Every proper divisor of `2^k·p` is either a power of two
+  `2^a` (always deficient, `Nat.Prime.deficient_pow`) or `2^a·p` with `a < k`;
+  in the latter case `σ(2^a·p) < 2·2^a·p` reduces to `p > 2^(a+1) - 1`, which
+  holds because `a + 1 ≤ k` gives `2^(a+1) - 1 ≤ 2^k - 1 < p`.
+
+## Infinitude via Bertrand's postulate
+
+Applying Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) to the base
+`2^k - 1` yields a prime `p` with `2^k - 1 < p ≤ 2·(2^k - 1) = 2^(k+1) - 2`,
+which lands strictly inside the required window (and, by choosing the base to be
+`2^k - 1` rather than `2^k`, dodges the perfect-number boundary `p = 2^(k+1) - 1`
+entirely -- no Mersenne-prime special-casing needed). Since `2^k·p ≥ 2^k` grows
+without bound, the primitive abundant numbers are unbounded, hence infinite.
+
+All results are elementary and axiom-free.
+-/
+import Mathlib.NumberTheory.FactorisationProperties
+import Mathlib.NumberTheory.Bertrand
+import Mathlib.NumberTheory.ArithmeticFunction.Misc
+import Mathlib.Tactic
+
+namespace AbundantPrimitiveInfiniteOQ0104
+
+open Finset Nat
+
+/-- A **primitive abundant number**: abundant, yet every proper divisor is
+deficient. (Same definition as the sibling `abundant-number-oq-04-oq-01-oq-02`,
+restated here so this file is self-contained.) -/
+abbrev IsPrimitiveAbundant (n : ℕ) : Prop :=
+  n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient
+
+/-! ### Elementary reformulations of abundance / deficiency via the divisor sum -/
+
+/-- `n` is abundant iff `2n < σ(n)` where `σ(n) = ∑_{d ∣ n} d`. -/
+theorem abundant_iff_two_mul_lt_sum_divisors {n : ℕ} :
+    n.Abundant ↔ 2 * n < ∑ d ∈ n.divisors, d := by
+  simp only [Nat.Abundant, Nat.sum_divisors_eq_sum_properDivisors_add_self]; omega
+
+/-- `n` is deficient iff `σ(n) < 2n`. -/
+theorem deficient_iff_sum_divisors_lt_two_mul {n : ℕ} :
+    n.Deficient ↔ ∑ d ∈ n.divisors, d < 2 * n := by
+  simp only [Nat.Deficient, Nat.sum_divisors_eq_sum_properDivisors_add_self]; omega
+
+/-! ### The divisor sum of `2^a · p` -/
+
+/-- Geometric sum in `ℕ`: `∑_{i<n} 2^i = 2^n - 1`. -/
+theorem two_pow_geom (n : ℕ) : ∑ i ∈ Finset.range n, 2 ^ i = 2 ^ n - 1 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    have h2 : 2 ^ (m + 1) = 2 ^ m + 2 ^ m := by rw [pow_succ]; ring
+    have h1 : 1 ≤ 2 ^ m := Nat.one_le_two_pow
+    rw [Finset.sum_range_succ, ih]; omega
+
+/-- **Divisor sum of `2^a · p`** for an odd prime `p`:
+`σ(2^a·p) = (2^(a+1) - 1)(p + 1)`, from multiplicativity of `σ` on the coprime
+factorisation `2^a · p`. -/
+theorem sum_divisors_two_pow_mul_prime {a p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) :
+    ∑ d ∈ (2 ^ a * p).divisors, d = (2 ^ (a + 1) - 1) * (p + 1) := by
+  have hcop : Nat.Coprime (2 ^ a) p :=
+    ((Nat.coprime_primes Nat.prime_two hp).mpr (Ne.symm hp2)).pow_left a
+  rw [hcop.sum_divisors_mul]
+  have e1 : ∑ d ∈ (2 ^ a).divisors, d = 2 ^ (a + 1) - 1 := by
+    rw [Nat.sum_divisors_prime_pow Nat.prime_two]
+    exact two_pow_geom (a + 1)
+  have e2 : ∑ d ∈ p.divisors, d = p + 1 := by
+    rw [hp.divisors, Finset.sum_pair hp.one_lt.ne]; omega
+  rw [e1, e2]
+
+/-! ### The core construction -/
+
+/-- For an odd prime `p` with `2^(a+1) - 1 < p`, the number `2^a · p` is
+deficient. (Reduces to `2^(a+1) - 1 < p` after the divisor-sum formula.) -/
+theorem deficient_two_pow_mul_prime {a p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hlt : 2 ^ (a + 1) - 1 < p) : (2 ^ a * p).Deficient := by
+  rw [deficient_iff_sum_divisors_lt_two_mul, sum_divisors_two_pow_mul_prime hp hp2]
+  have hrw : 2 * (2 ^ a * p) = 2 ^ (a + 1) * p := by rw [pow_succ]; ring
+  rw [hrw]
+  have h1 : 1 ≤ 2 ^ (a + 1) := Nat.one_le_two_pow
+  obtain ⟨c, hc⟩ : ∃ c, 2 ^ (a + 1) = c + 1 := ⟨2 ^ (a + 1) - 1, by omega⟩
+  rw [hc]; simp only [Nat.add_sub_cancel]
+  -- goal: c * (p + 1) < (c + 1) * p
+  have hcp : c < p := by omega
+  nlinarith [hcp]
+
+/-- For `k ≥ 2` and an odd prime `p` with `p < 2^(k+1) - 1`, the number
+`2^k · p` is abundant. (Reduces to `p < 2^(k+1) - 1` after the divisor-sum
+formula.) -/
+theorem abundant_two_pow_mul_prime {k p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hhi : p < 2 ^ (k + 1) - 1) : (2 ^ k * p).Abundant := by
+  rw [abundant_iff_two_mul_lt_sum_divisors, sum_divisors_two_pow_mul_prime hp hp2]
+  have hrw : 2 * (2 ^ k * p) = 2 ^ (k + 1) * p := by rw [pow_succ]; ring
+  rw [hrw]
+  have h1 : 1 ≤ 2 ^ (k + 1) := Nat.one_le_two_pow
+  obtain ⟨c, hc⟩ : ∃ c, 2 ^ (k + 1) = c + 1 := ⟨2 ^ (k + 1) - 1, by omega⟩
+  rw [hc]; simp only [Nat.add_sub_cancel]
+  -- goal: (c + 1) * p < c * (p + 1)
+  have hcp : p < c := by omega
+  nlinarith [hcp]
+
+/-- **Core theorem.** For `k ≥ 2` and a prime `p` in the window
+`2^k - 1 < p < 2^(k+1) - 1`, the number `2^k · p` is primitive abundant. -/
+theorem isPrimitiveAbundant_two_pow_mul_prime {k p : ℕ} (hk : 2 ≤ k) (hp : p.Prime)
+    (hlo : 2 ^ k - 1 < p) (hhi : p < 2 ^ (k + 1) - 1) :
+    IsPrimitiveAbundant (2 ^ k * p) := by
+  -- `p` is an odd prime: `p > 2^k - 1 ≥ 3`.
+  have hp2 : p ≠ 2 := by
+    have h4 : (4 : ℕ) ≤ 2 ^ k := by
+      calc (4 : ℕ) = 2 ^ 2 := by norm_num
+        _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+    omega
+  refine ⟨abundant_two_pow_mul_prime hp hp2 hhi, ?_⟩
+  intro d hd
+  rw [Nat.mem_properDivisors] at hd
+  obtain ⟨hdvd, hdlt⟩ := hd
+  by_cases hpd : p ∣ d
+  · -- `p ∣ d`: then `d = 2^a · p` with `a < k`.
+    obtain ⟨e, rfl⟩ := hpd
+    rw [mul_comm p e] at hdvd
+    have hediv : e ∣ 2 ^ k := (mul_dvd_mul_iff_right hp.pos.ne').mp hdvd
+    obtain ⟨a, hak, rfl⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hediv
+    -- `d = p * 2^a`; show it is deficient.
+    rw [mul_comm p (2 ^ a)]
+    have h2a : 2 ^ a < 2 ^ k := by
+      have hmul : p * 2 ^ a < p * 2 ^ k := by
+        rw [mul_comm (2 ^ k) p] at hdlt; exact hdlt
+      exact lt_of_mul_lt_mul_left hmul (Nat.zero_le p)
+    have hak2 : a < k := by
+      by_contra h
+      push_neg at h
+      have : 2 ^ k ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) h
+      omega
+    have hbound : 2 ^ (a + 1) - 1 < p := by
+      have hle : 2 ^ (a + 1) ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) (by omega)
+      omega
+    exact deficient_two_pow_mul_prime hp hp2 hbound
+  · -- `p ∤ d`: then `d ∣ 2^k`, a power of two, hence deficient.
+    have hcop : Nat.Coprime p d := (hp.coprime_iff_not_dvd).mpr hpd
+    have hd2k : d ∣ 2 ^ k := hcop.symm.dvd_of_dvd_mul_right hdvd
+    obtain ⟨a, hak, rfl⟩ := (Nat.dvd_prime_pow Nat.prime_two).mp hd2k
+    exact Nat.prime_two.deficient_pow
+
+/-- Consistency check against the sibling entry: the least primitive abundant
+number `20 = 2^2 · 5` arises from the construction with `k = 2`, `p = 5`. -/
+example : IsPrimitiveAbundant 20 := by
+  have h : IsPrimitiveAbundant (2 ^ 2 * 5) :=
+    isPrimitiveAbundant_two_pow_mul_prime (by norm_num) (by norm_num)
+      (by norm_num) (by norm_num)
+  norm_num at h; exact h
+
+/-! ### Infinitude -/
+
+/-- **There are infinitely many primitive abundant numbers.**
+
+Given any bound `a`, take `k = a + 2` and apply Bertrand's postulate to
+`2^k - 1` to obtain a prime `p` with `2^k - 1 < p ≤ 2^(k+1) - 2`. Then
+`2^k · p` is primitive abundant (core theorem) and exceeds `a`. -/
+theorem infinite_primitiveAbundant : {n : ℕ | IsPrimitiveAbundant n}.Infinite := by
+  rw [Set.infinite_iff_exists_gt]
+  intro a
+  set k := a + 2 with hk
+  have hk2 : 2 ≤ k := by omega
+  have hm : 2 ^ k - 1 ≠ 0 := by
+    have h4 : (4 : ℕ) ≤ 2 ^ k := by
+      calc (4 : ℕ) = 2 ^ 2 := by norm_num
+        _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hk2
+    omega
+  obtain ⟨p, hp, hlo, hhi'⟩ := Nat.exists_prime_lt_and_le_two_mul (2 ^ k - 1) hm
+  -- Translate the Bertrand upper bound into the required strict window.
+  have hhi : p < 2 ^ (k + 1) - 1 := by
+    have hpow : 2 ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+    have h1 : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+    omega
+  refine ⟨2 ^ k * p, isPrimitiveAbundant_two_pow_mul_prime hk2 hp hlo hhi, ?_⟩
+  -- `2^k · p > a`.
+  have hk_lt : k < 2 ^ k := k.lt_two_pow_self
+  have hbig : 2 ^ k ≤ 2 ^ k * p := le_mul_of_one_le_right (Nat.zero_le _) hp.one_lt.le
+  omega
+
+end AbundantPrimitiveInfiniteOQ0104

--- a/src/data/proofs/abundant-number-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-abund0104-overview",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Infinitely many primitive abundant numbers via 2^k·p",
+    "content": "The docstring lays out the whole argument. A primitive abundant number is abundant but has only deficient proper divisors — the minimal abundant numbers under divisibility (OEIS A091191: 20, 70, 88, 104, ...). The sibling entry pinned the least one at 20 and left infinitude open; this entry settles it with the explicit family 2^k·p. Two features make the family tractable: coprimality gives the exact multiplicative divisor sum σ(2^k·p) = (2^(k+1) − 1)(p + 1), and taking Bertrand's postulate on the base 2^k − 1 (rather than 2^k) keeps p strictly below the perfect-number boundary 2^(k+1) − 1, so no Mersenne/Euclid special cases arise.",
+    "mathContext": "Primitive abundant $n$: $\\sigma(n)>2n$ and every proper divisor $d\\mid n$ has $\\sigma(d)<2d$. Family: $n=2^k p$ with $2^k-1<p<2^{k+1}-1$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["primitive abundant numbers", "abundancy index", "Bertrand's postulate", "Euclid perfect numbers"],
+    "prerequisites": ["divisor functions", "divisibility"]
+  },
+  {
+    "id": "ann-abund0104-reformulations",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 43, "endLine": 59 },
+    "type": "tactic",
+    "title": "Restating abundance/deficiency through the full divisor sum σ",
+    "content": "Nat.Abundant and Nat.Deficient are defined via the sum over PROPER divisors, but multiplicativity is a fact about the FULL divisor sum σ(n) = ∑_{d ∣ n} d. abundant_iff_two_mul_lt_sum_divisors and deficient_iff_sum_divisors_lt_two_mul bridge the two using Nat.sum_divisors_eq_sum_properDivisors_add_self (σ(n) = properSum(n) + n): abundant ⇔ 2n < σ(n) and deficient ⇔ σ(n) < 2n. Each is closed by `simp only [...]; omega`. IsPrimitiveAbundant itself is restated here so the file stands alone.",
+    "mathContext": "$\\sigma(n)=\\sum_{d\\mid n}d=\\big(\\sum_{d\\in\\mathrm{proper}(n)}d\\big)+n$, so $n<\\mathrm{properSum}(n)\\iff 2n<\\sigma(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum-of-divisors function", "Nat.Abundant / Nat.Deficient", "proper vs full divisor sum"],
+    "prerequisites": ["Finset sums", "ℕ arithmetic"]
+  },
+  {
+    "id": "ann-abund0104-divisor-sum",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 61, "endLine": 85 },
+    "type": "insight",
+    "title": "The exact multiplicative divisor sum σ(2^a·p) = (2^(a+1) − 1)(p + 1)",
+    "content": "This is the engine of the entry. For an odd prime p, 2^a and p are coprime (coprime_primes together with Coprime.pow_left), so Nat.Coprime.sum_divisors_mul splits σ(2^a·p) = σ(2^a)·σ(p). The first factor σ(2^a) = ∑_{i<a+1} 2^i is evaluated by Nat.sum_divisors_prime_pow followed by the geometric-sum lemma two_pow_geom (∑_{i<n} 2^i = 2^n − 1, proved by a two-line induction with omega closing the successor step). The second factor σ(p) = p + 1 comes from Nat.Prime.divisors (divisors p = {1, p}) and Finset.sum_pair. Multiplying yields (2^(a+1) − 1)(p + 1).",
+    "mathContext": "$\\sigma$ multiplicative on coprimes; $\\sigma(2^a)=\\sum_{i=0}^{a}2^i=2^{a+1}-1$; $\\sigma(p)=p+1$ for prime $p$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["multiplicativity of σ", "geometric series", "prime-power divisor sum", "Nat.Coprime.sum_divisors_mul"],
+    "prerequisites": ["coprimality", "Finset.sum_pair", "induction"]
+  },
+  {
+    "id": "ann-abund0104-window",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 87, "endLine": 116 },
+    "type": "insight",
+    "title": "Both properties collapse to one inequality on p",
+    "content": "With the σ formula in hand, abundant_two_pow_mul_prime and deficient_two_pow_mul_prime reduce the entire behaviour of the family to a single-variable inequality. Writing 2^(k+1) = c + 1 clears the truncated ℕ subtraction, so abundance 2·(2^k·p) < (2^(k+1) − 1)(p + 1) becomes (c+1)·p < c·(p+1), i.e. p < c = 2^(k+1) − 1; deficiency of 2^a·p is the mirror image c·(p+1) < (c+1)·p, i.e. c < p, i.e. 2^(a+1) − 1 < p. Each is a linear product inequality dispatched by nlinarith. Thus n = 2^k·p is abundant exactly when p < 2^(k+1) − 1, and each smaller-power divisor 2^a·p (a < k) is deficient exactly when p > 2^(a+1) − 1.",
+    "mathContext": "Abundant $\\iff p<2^{k+1}-1$; $2^a p$ deficient $\\iff p>2^{a+1}-1$. Window: $2^k-1<p<2^{k+1}-1$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["abundancy threshold", "ℕ truncated subtraction", "nlinarith"],
+    "prerequisites": ["divisor-sum inequalities", "linear arithmetic"]
+  },
+  {
+    "id": "ann-abund0104-core",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 118, "endLine": 166 },
+    "type": "insight",
+    "title": "Every proper divisor is a power of two or 2^a·p with a < k",
+    "content": "isPrimitiveAbundant_two_pow_mul_prime assembles the family. Abundance is immediate from abundant_two_pow_mul_prime. For primitivity, take a proper divisor d of 2^k·p and split on whether p ∣ d. If p ∤ d then d is coprime to p (Nat.Prime.coprime_iff_not_dvd), so d ∣ 2^k, hence d = 2^a is a power of two — deficient for free by Nat.Prime.deficient_pow. If p ∣ d then cancelling p (mul_dvd_mul_iff_right) gives d = 2^a·p, and d < 2^k·p forces a < k; then a + 1 ≤ k yields 2^(a+1) − 1 ≤ 2^k − 1 < p, so the window deficiency lemma applies. A consistency check recovers the known least value 20 = 2^2·5 from the construction (k = 2, p = 5).",
+    "mathContext": "Divisors of $2^k p$ are $2^a$ ($a\\le k$) and $2^a p$ ($a\\le k$); properness removes $2^k p$, leaving $a<k$ in the $p\\mid d$ case.",
+    "significance": "fundamental",
+    "relatedConcepts": ["divisor structure of 2^k·p", "Nat.Prime.deficient_pow", "Nat.dvd_prime_pow", "mul_dvd_mul_iff_right"],
+    "prerequisites": ["prime divisibility", "coprimality"]
+  },
+  {
+    "id": "ann-abund0104-infinitude",
+    "proofId": "abundant-number-oq-01-oq-04",
+    "range": { "startLine": 168, "endLine": 197 },
+    "type": "insight",
+    "title": "Bertrand on base 2^k − 1, then unboundedness",
+    "content": "infinite_primitiveAbundant uses Set.infinite_iff_exists_gt: for any bound a, produce a primitive abundant number > a. Take k = a + 2 (so k ≥ 2) and apply Nat.exists_prime_lt_and_le_two_mul to 2^k − 1, obtaining a prime p with 2^k − 1 < p ≤ 2·(2^k − 1) = 2^(k+1) − 2, which is strictly below the boundary 2^(k+1) − 1 — this is precisely why the base is 2^k − 1 and not 2^k: it keeps p out of the perfect-number value that would make 2^k·p a Euclid perfect number rather than abundant. The core theorem makes 2^k·p primitive abundant, and 2^k·p ≥ 2^k > k > a gives the required strict inequality. No injectivity bookkeeping is needed — unboundedness alone yields infinitude.",
+    "mathContext": "Bertrand: $\\exists p$ prime, $m<p\\le 2m$. With $m=2^k-1$: $2^k-1<p\\le 2^{k+1}-2<2^{k+1}-1$. And $2^k p\\ge 2^k>k>a$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["Bertrand's postulate", "Set.infinite_iff_exists_gt", "Euclid perfect numbers", "unboundedness ⇒ infinite"],
+    "prerequisites": ["Bertrand's postulate", "Set.Infinite"]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-01-oq-04/meta.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-04/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "abundant-number-oq-01-oq-04",
+  "title": "Infinitely Many Primitive Abundant Numbers, via 2^k·p and Bertrand's Postulate",
+  "slug": "abundant-number-oq-01-oq-04",
+  "description": "A primitive abundant number is an abundant number all of whose proper divisors are deficient — the minimal abundant numbers under divisibility (OEIS A091191: 20, 70, 88, 104, ...). The sibling entry abundant-number-oq-04-oq-01-oq-02 defines IsPrimitiveAbundant and certifies 20 as the least; its open question asks to prove there are infinitely many. This entry does so, with an explicit construction. For k ≥ 2 and any prime p in the window 2^k − 1 < p < 2^(k+1) − 1, the number 2^k·p is primitive abundant: coprimality gives the multiplicative divisor sum σ(2^k·p) = (2^(k+1) − 1)(p + 1), the abundance inequality 2n < σ(n) collapses to exactly p < 2^(k+1) − 1, and every proper divisor is either a power of two (always deficient) or 2^a·p with a < k (deficient because a + 1 ≤ k forces 2^(a+1) − 1 ≤ 2^k − 1 < p). Bertrand's postulate applied to the base 2^k − 1 supplies a prime p with 2^k − 1 < p ≤ 2·(2^k − 1) = 2^(k+1) − 2, which lands strictly inside the window and — by using the base 2^k − 1 rather than 2^k — dodges the perfect-number boundary p = 2^(k+1) − 1 (the Euclid perfect numbers 2^k·(2^(k+1) − 1)) with no Mersenne-prime case analysis. Since 2^k·p ≥ 2^k grows without bound the primitive abundant numbers are unbounded, hence infinite. Fully machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A091191 (primitive abundant numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantPrimitiveInfiniteOQ0104.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "deficient-numbers",
+      "primitive-abundant",
+      "bertrand-postulate",
+      "divisibility",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 197,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms` on both infinite_primitiveAbundant and isPrimitiveAbundant_two_pow_mul_prime reports only the standard foundational axioms (propext, Classical.choice, Quot.sound). No `axiom` declarations, no `sorry`, and no `native_decide` — the only `decide`-style step is `norm_num` on the concrete 20 = 2^2·5 consistency check, which is kernel-checked (no Lean.ofReduceBool).",
+    "originalContributions": [
+      "Proves `infinite_primitiveAbundant : {n | IsPrimitiveAbundant n}.Infinite` — there are infinitely many primitive abundant numbers. This answers the standing open question of the sibling entry abundant-number-oq-04-oq-01-oq-02 (which certified 20 as the least primitive abundant number but left infinitude open), and the notion of primitive abundant number is absent from Mathlib.",
+      "Proves the explicit core construction `isPrimitiveAbundant_two_pow_mul_prime : 2 ≤ k → p.Prime → 2^k − 1 < p → p < 2^(k+1) − 1 → IsPrimitiveAbundant (2^k · p)` — a fully parametric family of primitive abundant numbers, sharper than a bare existence statement.",
+      "Proves the multiplicative divisor-sum formula `sum_divisors_two_pow_mul_prime : p.Prime → p ≠ 2 → ∑_{d ∣ 2^a·p} d = (2^(a+1) − 1)(p + 1)`, from coprimality of 2^a and p and the geometric-sum evaluation ∑_{i<a+1} 2^i = 2^(a+1) − 1 (two_pow_geom).",
+      "Isolates the two window inequalities as reusable lemmas `abundant_two_pow_mul_prime` (abundance ⇔ p < 2^(k+1) − 1) and `deficient_two_pow_mul_prime` (2^a·p deficient ⇐ 2^(a+1) − 1 < p), each obtained by feeding the divisor-sum formula to the σ-reformulations abundant_iff_two_mul_lt_sum_divisors / deficient_iff_sum_divisors_lt_two_mul.",
+      "Uses Bertrand's postulate on the base 2^k − 1 to keep the prime strictly inside the abundance window and thereby avoid the perfect-number boundary p = 2^(k+1) − 1 entirely — no special-casing of Mersenne primes or Euclid perfect numbers is needed."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Every abundant number is a multiple of a primitive abundant number — an abundant number all of whose proper divisors are deficient — so the primitive abundant numbers (OEIS A091191: 20, 70, 88, 104, 272, ...) are the multiplicative building blocks of the abundant numbers. That there are infinitely many of them is classical: any abundant-number-generating family that avoids proper multiples of earlier terms works. The clean elementary route used here — 2^k·p with p a prime just above 2^k — makes the abundancy computation exact (σ is multiplicative on the coprime factorisation) and reduces both the abundance of the number and the deficiency of each proper divisor to a single-variable inequality on p, with Bertrand's postulate guaranteeing a suitable p at every scale.",
+    "problemStatement": "Prove that the set of primitive abundant numbers {n | n is abundant and every proper divisor of n is deficient} is infinite, answering the open question left by the sibling entry that certified 20 as the least such number.",
+    "text": "A self-contained Lean 4 / Mathlib formalization (197 lines, 0 sorries, 0 axioms) proving infinite_primitiveAbundant : {n | IsPrimitiveAbundant n}.Infinite. The heart is the parametric theorem isPrimitiveAbundant_two_pow_mul_prime: for k ≥ 2 and a prime p with 2^k − 1 < p < 2^(k+1) − 1, the number 2^k·p is primitive abundant. Its proof rests on the exact multiplicative divisor sum σ(2^k·p) = (2^(k+1) − 1)(p + 1) (sum_divisors_two_pow_mul_prime, from coprimality plus the geometric sum two_pow_geom), which turns abundance into p < 2^(k+1) − 1 and the deficiency of each proper divisor 2^a·p (a < k) into 2^(a+1) − 1 < p. Bertrand's postulate applied to 2^k − 1 then delivers such a p in the strict window at every k, and since 2^k·p ≥ 2^k is unbounded the set is infinite (via Set.infinite_iff_exists_gt).",
+    "proofStrategy": "1. **σ-reformulations.** abundant_iff_two_mul_lt_sum_divisors and deficient_iff_sum_divisors_lt_two_mul rewrite Nat.Abundant / Nat.Deficient (defined via the proper-divisor sum) into statements about the full divisor sum σ, using Nat.sum_divisors_eq_sum_properDivisors_add_self and omega.\n\n2. **Divisor sum of 2^a·p (sum_divisors_two_pow_mul_prime).** For an odd prime p, 2^a and p are coprime (coprime_primes + pow_left), so Nat.Coprime.sum_divisors_mul gives σ(2^a·p) = σ(2^a)·σ(p). Then σ(2^a) = ∑_{i<a+1} 2^i = 2^(a+1) − 1 (Nat.sum_divisors_prime_pow + the geometric sum two_pow_geom proved by induction) and σ(p) = p + 1 (Nat.Prime.divisors + Finset.sum_pair).\n\n3. **Window inequalities.** abundant_two_pow_mul_prime: after the σ formula, 2·(2^k·p) < (2^(k+1) − 1)(p + 1) simplifies (write 2^(k+1) = c+1) to (c+1)·p < c·(p+1), i.e. p < c = 2^(k+1) − 1; nlinarith closes it. deficient_two_pow_mul_prime is the mirror image giving c·(p+1) < (c+1)·p ⇔ c < p, i.e. 2^(a+1) − 1 < p.\n\n4. **Core construction (isPrimitiveAbundant_two_pow_mul_prime).** Abundance is abundant_two_pow_mul_prime. For primitivity, take a proper divisor d of 2^k·p. If p ∤ d then d ∣ 2^k, so d = 2^a is a power of two, deficient by Nat.Prime.deficient_pow. If p ∣ d then cancelling p (mul_dvd_mul_iff_right) gives d = 2^a·p with a < k (from d < 2^k·p), and a + 1 ≤ k yields 2^(a+1) − 1 ≤ 2^k − 1 < p, so deficient_two_pow_mul_prime applies.\n\n5. **Infinitude (infinite_primitiveAbundant).** By Set.infinite_iff_exists_gt it suffices, for each a, to exhibit a primitive abundant number > a. Take k = a + 2 (so k ≥ 2), apply Nat.exists_prime_lt_and_le_two_mul to 2^k − 1 to get a prime p with 2^k − 1 < p ≤ 2·(2^k − 1) = 2^(k+1) − 2 < 2^(k+1) − 1, then 2^k·p is primitive abundant and 2^k·p ≥ 2^k > k > a."
+    ,
+    "keyInsights": [
+      "**The whole problem collapses to one inequality on p.** Because 2^a and p are coprime, σ(2^a·p) = (2^(a+1) − 1)(p + 1) exactly, so 'abundant' and 'each proper divisor deficient' both become single-variable inequalities: n = 2^k·p is abundant ⇔ p < 2^(k+1) − 1, and 2^a·p (a < k) is deficient ⇔ p > 2^(a+1) − 1. The window 2^k − 1 < p < 2^(k+1) − 1 is precisely the intersection.",
+      "**Choosing Bertrand's base as 2^k − 1 (not 2^k) is what dodges the perfect numbers.** Bertrand on 2^k − 1 returns a prime p ≤ 2·(2^k − 1) = 2^(k+1) − 2, strictly below the boundary value 2^(k+1) − 1. Hitting that boundary would make 2^k·p a Euclid perfect number (σ = 2n), not abundant; the shifted base rules it out uniformly, so no Mersenne-prime case analysis is ever needed.",
+      "**Only the two maximal proper divisors matter — and both are handled uniformly.** Every proper divisor of 2^k·p divides either 2^k (a power of two, deficient for free by Nat.Prime.deficient_pow) or 2^(k−1)·p; the monotone chain 2^(a+1) − 1 ≤ 2^k − 1 < p makes the single hypothesis p > 2^k − 1 propagate deficiency to all of them at once.",
+      "**Infinitude is unboundedness.** No injectivity bookkeeping is required: 2^k·p ≥ 2^k already exceeds any prescribed bound once k is large, so Set.infinite_iff_exists_gt turns the parametric construction directly into infinitude."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ(n) = ∑_{d ∣ n} d and the abundant / deficient classification (Nat.Abundant, Nat.Deficient) defined via the proper-divisor sum, with Nat.sum_divisors_eq_sum_properDivisors_add_self",
+      "Multiplicativity of σ on coprime factors (Nat.Coprime.sum_divisors_mul), the prime-power divisor sum (Nat.sum_divisors_prime_pow), and Nat.Prime.deficient_pow (every prime power is deficient)",
+      "Bertrand's postulate in the form Nat.exists_prime_lt_and_le_two_mul (a prime strictly between n and 2n)",
+      "Elementary Finset / Nat facts: Nat.dvd_prime_pow, mul_dvd_mul_iff_right, Nat.Prime.coprime_iff_not_dvd, and Set.infinite_iff_exists_gt for the unboundedness argument"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring: the 2^k·p construction, the window 2^k − 1 < p < 2^(k+1) − 1 in which it is primitive abundant, and the Bertrand-on-2^k−1 argument for infinitude that avoids the perfect-number boundary.",
+      "mathContext": "Primitive abundant numbers are the minimal abundant numbers under divisibility; the goal is to prove there are infinitely many."
+    },
+    {
+      "id": "reformulations",
+      "title": "σ-Reformulations of Abundance and Deficiency",
+      "startLine": 43,
+      "endLine": 59,
+      "summary": "IsPrimitiveAbundant restated, then abundant_iff_two_mul_lt_sum_divisors and deficient_iff_sum_divisors_lt_two_mul convert the proper-divisor-sum definitions of Nat.Abundant / Nat.Deficient into full-divisor-sum inequalities 2n < σ(n) / σ(n) < 2n.",
+      "mathContext": "Working with σ(n) = ∑_{d ∣ n} d rather than the proper-divisor sum makes multiplicativity directly usable."
+    },
+    {
+      "id": "divisor-sum",
+      "title": "The Divisor Sum of 2^a·p",
+      "startLine": 61,
+      "endLine": 85,
+      "summary": "two_pow_geom evaluates the geometric sum ∑_{i<n} 2^i = 2^n − 1 by induction; sum_divisors_two_pow_mul_prime then combines coprimality (Nat.Coprime.sum_divisors_mul), the prime-power divisor sum for 2^a, and σ(p) = p + 1 to give σ(2^a·p) = (2^(a+1) − 1)(p + 1).",
+      "mathContext": "Exact multiplicative evaluation of the divisor sum on the coprime factorisation 2^a · p."
+    },
+    {
+      "id": "window",
+      "title": "The Window Inequalities",
+      "startLine": 87,
+      "endLine": 116,
+      "summary": "deficient_two_pow_mul_prime and abundant_two_pow_mul_prime feed the divisor-sum formula to the σ-reformulations: 2^a·p is deficient ⇔ 2^(a+1) − 1 < p, and 2^k·p is abundant ⇔ p < 2^(k+1) − 1. Each reduces (writing 2^m = c + 1) to a linear product inequality closed by nlinarith.",
+      "mathContext": "Both properties of the family are governed by the single window 2^k − 1 < p < 2^(k+1) − 1."
+    },
+    {
+      "id": "core",
+      "title": "The Core Construction",
+      "startLine": 118,
+      "endLine": 166,
+      "summary": "isPrimitiveAbundant_two_pow_mul_prime: for k ≥ 2 and a prime p in the window, 2^k·p is primitive abundant. Abundance is direct; for primitivity a proper divisor is either a power of two (deficient by Nat.Prime.deficient_pow) or 2^a·p with a < k (deficient by the window lemma). A consistency check recovers the least value 20 = 2^2·5.",
+      "mathContext": "A fully parametric family of primitive abundant numbers, one for every prime in each dyadic window."
+    },
+    {
+      "id": "infinitude",
+      "title": "Infinitude via Bertrand's Postulate",
+      "startLine": 168,
+      "endLine": 197,
+      "summary": "infinite_primitiveAbundant: for any bound a, take k = a + 2 and apply Bertrand (Nat.exists_prime_lt_and_le_two_mul) to 2^k − 1 to obtain a prime p in the strict window; then 2^k·p is primitive abundant and exceeds a, so by Set.infinite_iff_exists_gt the set is infinite.",
+      "mathContext": "Bertrand guarantees a suitable prime at every scale; unboundedness of 2^k·p yields infinitude."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "infinite_primitiveAbundant",
+      "type": "core",
+      "description": "{n | IsPrimitiveAbundant n}.Infinite: there are infinitely many primitive abundant numbers. Answers the standing open question of abundant-number-oq-04-oq-01-oq-02.",
+      "leanType": "{n : ℕ | IsPrimitiveAbundant n}.Infinite"
+    },
+    {
+      "name": "isPrimitiveAbundant_two_pow_mul_prime",
+      "type": "core",
+      "description": "For k ≥ 2 and a prime p with 2^k − 1 < p < 2^(k+1) − 1, the number 2^k·p is primitive abundant — the explicit construction driving the infinitude result.",
+      "leanType": "2 ≤ k → p.Prime → 2 ^ k - 1 < p → p < 2 ^ (k + 1) - 1 → IsPrimitiveAbundant (2 ^ k * p)"
+    },
+    {
+      "name": "sum_divisors_two_pow_mul_prime",
+      "type": "supporting",
+      "description": "For an odd prime p, σ(2^a·p) = (2^(a+1) − 1)(p + 1), the exact multiplicative divisor sum underlying both window inequalities.",
+      "leanType": "p.Prime → p ≠ 2 → ∑ d ∈ (2 ^ a * p).divisors, d = (2 ^ (a + 1) - 1) * (p + 1)"
+    },
+    {
+      "name": "abundant_two_pow_mul_prime",
+      "type": "supporting",
+      "description": "For an odd prime p with p < 2^(k+1) − 1, the number 2^k·p is abundant.",
+      "leanType": "p.Prime → p ≠ 2 → p < 2 ^ (k + 1) - 1 → (2 ^ k * p).Abundant"
+    },
+    {
+      "name": "deficient_two_pow_mul_prime",
+      "type": "supporting",
+      "description": "For an odd prime p with 2^(a+1) − 1 < p, the number 2^a·p is deficient — applied to the proper divisors of 2^k·p.",
+      "leanType": "p.Prime → p ≠ 2 → 2 ^ (a + 1) - 1 < p → (2 ^ a * p).Deficient"
+    }
+  ],
+  "conclusion": {
+    "summary": "Constructs, for every k ≥ 2 and every prime p in the dyadic window 2^k − 1 < p < 2^(k+1) − 1, a primitive abundant number 2^k·p (isPrimitiveAbundant_two_pow_mul_prime), using the exact multiplicative divisor sum σ(2^k·p) = (2^(k+1) − 1)(p + 1). Bertrand's postulate on the base 2^k − 1 supplies such a p at every scale while avoiding the perfect-number boundary, and unboundedness of 2^k·p then yields infinite_primitiveAbundant: the primitive abundant numbers form an infinite set. Fully machine-checked, 0 axioms and 0 sorries.",
+    "implications": "Answers the infinitude open question left by the sibling entry abundant-number-oq-04-oq-01-oq-02 (which pinned 20 as the least primitive abundant number). Mathlib records the abundant/deficient/perfect predicates but neither the notion of primitive abundant number nor any infinitude result about them; this entry supplies an explicit, elementary infinite family and the exact divisor-sum formula σ(2^a·p) = (2^(a+1) − 1)(p + 1) as a reusable lemma. The construction also cleanly separates the abundant/deficient thresholds from the perfect-number boundary, illustrating how a shifted Bertrand base removes Mersenne-prime edge cases.",
+    "openQuestions": [
+      "Show that every abundant number is divisible by a primitive abundant number (well-founded descent on the divisor order), so that this infinite family genuinely generates the abundant numbers.",
+      "Prove there are infinitely many ODD primitive abundant numbers (the smallest is 945), where the 2^k·p construction no longer applies and the abundancy computation must control an odd prime factorisation."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Joseph Bertrand; Pafnuty Chebyshev",
+      "title": "Bertrand's postulate: a prime between n and 2n",
+      "year": "1845/1852",
+      "venue": "—",
+      "note": "Supplies a prime in each dyadic window; used here in the form Nat.exists_prime_lt_and_le_two_mul applied to 2^k − 1."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A091191: Primitive abundant numbers (abundant numbers with no abundant proper divisor)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "Begins 20, 70, 88, 104, 272, ...; this entry proves the sequence is infinite via the family 2^k·p."
+    },
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-04-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Sibling entry defining IsPrimitiveAbundant and certifying 20 as the least primitive abundant number. Its open question — 'show there are infinitely many' — is exactly what this entry proves, via the explicit family 2^k·p rather than the odd primitive abundant numbers it suggested."
+    },
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "related",
+      "description": "Parent entry: 12 is the least abundant number and there are infinitely many abundant numbers (family 12·(k+1)). This entry proves the sharper statement that the MINIMAL (primitive) abundant numbers are already infinite, so the infinitude of abundant numbers is not merely due to closure under multiples."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **`abundant-number-oq-01-oq-04`** proving there are **infinitely many primitive abundant numbers** — answering the open question left by sibling `abundant-number-oq-04-oq-01-oq-02` (which certified 20 as the *least* primitive abundant number but left infinitude open).

A **primitive abundant number** is abundant with only deficient proper divisors — the minimal abundant numbers under divisibility (OEIS A091191: 20, 70, 88, 104, …).

## The construction

For `k ≥ 2` and any prime `p` in the window `2^k − 1 < p < 2^(k+1) − 1`, the number `2^k·p` is primitive abundant:

- **Exact divisor sum.** Coprimality gives `σ(2^k·p) = (2^(k+1) − 1)(p + 1)`.
- **Abundance** `2n < σ(n)` collapses to exactly `p < 2^(k+1) − 1`.
- **Primitivity.** Every proper divisor is either a power of two (deficient for free via `Nat.Prime.deficient_pow`) or `2^a·p` with `a < k` (deficient because `a+1 ≤ k ⟹ 2^(a+1) − 1 ≤ 2^k − 1 < p`).

## Infinitude

Bertrand's postulate (`Nat.exists_prime_lt_and_le_two_mul`) on the base `2^k − 1` yields a prime with `2^k − 1 < p ≤ 2^(k+1) − 2`, strictly inside the window. Using base `2^k − 1` rather than `2^k` dodges the perfect-number boundary `p = 2^(k+1) − 1` (the Euclid perfect numbers) — **no Mersenne-prime case analysis**. Unboundedness of `2^k·p` then gives `infinite_primitiveAbundant`.

## Verification

- **0 axioms**: `#print axioms` on `infinite_primitiveAbundant` and `isPrimitiveAbundant_two_pow_mul_prime` reports only `propext, Classical.choice, Quot.sound`. No `sorry`, no `axiom`, no `native_decide`.
- **0 sorries**, 197 lines, 8 theorems + 1 def. Builds via `./proofs/scripts/docker-build.sh Proofs.AbundantPrimitiveInfiniteOQ0104`.
- Consistency check: the construction recovers the known least value `20 = 2^2·5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)