### PR TITLE
research(hermite-floor-identity-oq-03): sawtooth companion ∑{x+k/n}={nx}+(n−1)/2 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteFloorIdentityOQ03.lean
+++ b/proofs/Proofs/HermiteFloorIdentityOQ03.lean
@@ -1,0 +1,77 @@
+/-
+# Hermite's Sawtooth Companion Identity  (hermite-floor-identity, OQ-03 #1)
+
+The parent `HermiteFloorIdentity.lean` proves Hermite's floor identity
+  ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋.
+Its first open question asks for the **companion fractional-part (sawtooth)
+identity**
+  ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2,
+where `{y} = Int.fract y = y - ⌊y⌋` is the sawtooth function.
+
+This file proves exactly that.  The derivation is a one-line consequence of the
+parent identity together with the Gauss sum `∑_{k<n} k = n(n-1)/2`:
+  ∑ {x+k/n} = ∑ (x + k/n) − ∑ ⌊x+k/n⌋
+            = (n·x + (n-1)/2) − ⌊n·x⌋       (Hermite for the floor sum)
+            = (n·x − ⌊n·x⌋) + (n-1)/2
+            = {n·x} + (n-1)/2.
+
+We also record two clean specialisations:
+
+* `hermite_fract_sum_at_zero` : ∑_{k<n} {k/n} = (n-1)/2   (the classical fact
+  that the fractional parts `0, 1/n, …, (n-1)/n` average to `(n-1)/(2n)`);
+* `hermite_fract_sum_of_mul_int` : if `n·x ∈ ℤ` (so `{n·x} = 0`) then the sawtooth
+  sum is exactly `(n-1)/2`.
+
+## Main results
+- `hermite_fract_identity`        : ∑_{k<n} {x+k/n} = {n·x} + (n-1)/2   (n ≥ 1)
+- `hermite_fract_sum_at_zero`     : ∑_{k<n} {k/n}   = (n-1)/2
+- `hermite_fract_sum_of_mul_int`  : n·x ∈ ℤ ⇒ ∑_{k<n} {x+k/n} = (n-1)/2
+-/
+import Mathlib
+import Proofs.HermiteFloorIdentity
+
+open Finset
+
+namespace HermiteFloorIdentityOQ03
+
+/-- Gauss sum, real-valued: `∑_{k<m} k = m(m-1)/2` for every `m`. -/
+lemma sum_range_cast (m : ℕ) :
+    ∑ k ∈ Finset.range m, (k : ℝ) = (m : ℝ) * ((m : ℝ) - 1) / 2 := by
+  induction m with
+  | zero => simp
+  | succ p ih =>
+    rw [Finset.sum_range_succ, ih]
+    push_cast
+    ring
+
+/-- **Hermite's sawtooth (fractional-part) companion identity.**  For every real
+    `x` and every `n ≥ 1`,
+      `∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n-1)/2`,
+    the additive twin of the floor identity `∑ ⌊x + k/n⌋ = ⌊n·x⌋`. -/
+theorem hermite_fract_identity (x : ℝ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ Finset.range n, Int.fract (x + (k : ℝ) / (n : ℝ))
+      = Int.fract ((n : ℝ) * x) + ((n : ℝ) - 1) / 2 := by
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  simp only [Int.fract]
+  rw [Finset.sum_sub_distrib, Finset.sum_add_distrib, Finset.sum_const, Finset.card_range,
+      nsmul_eq_mul, ← Finset.sum_div, sum_range_cast n, ← Int.cast_sum,
+      HermiteFloorIdentity.hermite_floor_identity x n hn]
+  field_simp
+  ring
+
+/-- **Specialisation at `x = 0`.**  The fractional parts `0, 1/n, 2/n, …, (n-1)/n`
+    sum to `(n-1)/2`: `∑_{k=0}^{n-1} {k/n} = (n-1)/2`. -/
+theorem hermite_fract_sum_at_zero (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ Finset.range n, Int.fract ((k : ℝ) / (n : ℝ)) = ((n : ℝ) - 1) / 2 := by
+  have h := hermite_fract_identity 0 n hn
+  simp only [zero_add, mul_zero, Int.fract_zero] at h
+  exact h
+
+/-- **Specialisation when `n·x` is an integer.**  If `{n·x} = 0` (equivalently
+    `n·x ∈ ℤ`), the sawtooth sum is exactly `(n-1)/2`. -/
+theorem hermite_fract_sum_of_mul_int (x : ℝ) (n : ℕ) (hn : 0 < n)
+    (hx : Int.fract ((n : ℝ) * x) = 0) :
+    ∑ k ∈ Finset.range n, Int.fract (x + (k : ℝ) / (n : ℝ)) = ((n : ℝ) - 1) / 2 := by
+  rw [hermite_fract_identity x n hn, hx, zero_add]
+
+end HermiteFloorIdentityOQ03

--- a/src/data/proofs/hermite-floor-identity-oq-03/meta.json
+++ b/src/data/proofs/hermite-floor-identity-oq-03/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "hermite-floor-identity-oq-03",
+  "title": "Hermite's Sawtooth Companion Identity: ∑ {x + k/n} = {n·x} + (n−1)/2",
+  "slug": "hermite-floor-identity-oq-03",
+  "description": "Answers the first open question of the parent Hermite floor-identity entry by proving the companion fractional-part (sawtooth) identity: for every real x and every n ≥ 1, ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2, where {y} = Int.fract y = y − ⌊y⌋. Together with the parent's floor identity ∑ ⌊x + k/n⌋ = ⌊n·x⌋ this gives the complete floor + fractional decomposition of the uniformly sampled sum ∑_{k<n}(x + k/n) = n·x + (n−1)/2. The derivation is a one-line consequence of Hermite's floor identity and the Gauss sum ∑_{k<n} k = n(n−1)/2. Two specialisations are recorded: at x = 0 the classical average ∑_{k<n} {k/n} = (n−1)/2, and whenever n·x is an integer the sawtooth sum is exactly (n−1)/2.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HermiteFloorIdentityOQ03.lean",
+    "tags": [
+      "number-theory",
+      "floor-function",
+      "fractional-part",
+      "sawtooth",
+      "real-analysis",
+      "gauss-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 77,
+    "assumptions": "No assumptions. Fully machine-checked: docker Lean build exits 0, and `#print axioms` on all three theorems (hermite_fract_identity, hermite_fract_sum_at_zero, hermite_fract_sum_of_mul_int) lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy. The floor half of the decomposition is delegated to the parent's `HermiteFloorIdentity.hermite_floor_identity`; the Gauss sum ∑_{k<n} k = n(n−1)/2 is re-derived here in real form (`sum_range_cast`) by induction.",
+    "dateAdded": "2026-07-02",
+    "originalContributions": [
+      "hermite_fract_identity: the sawtooth companion ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2 over ℝ for every n ≥ 1 — the additive twin of Hermite's floor identity, absent from Mathlib.",
+      "hermite_fract_sum_at_zero: the classical fact ∑_{k=0}^{n-1} {k/n} = (n−1)/2 (the fractional parts 0, 1/n, …, (n−1)/n average to (n−1)/(2n)), obtained by specialising x = 0.",
+      "hermite_fract_sum_of_mul_int: whenever n·x ∈ ℤ (so {n·x} = 0) the sawtooth sum collapses to exactly (n−1)/2.",
+      "sum_range_cast: the real-valued Gauss sum ∑_{k<n} (k : ℝ) = n(n−1)/2 for every n, proved by induction with push_cast/ring."
+    ],
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Charles Hermite recorded, in the 1880s, the floor-summation identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ (see the parent gallery entry hermite-floor-identity). Every floor identity has a fractional-part twin, because y decomposes as ⌊y⌋ + {y} with {y} = Int.fract y the sawtooth function. Summing that decomposition over the uniform sample x, x + 1/n, …, x + (n−1)/n and comparing with the exact arithmetic sum ∑_{k<n}(x + k/n) = n·x + (n−1)/2 turns Hermite's floor identity into the sawtooth companion ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2. The x = 0 case, ∑_{k<n} {k/n} = (n−1)/2, is a staple of Concrete Mathematics (Graham–Knuth–Patashnik, Ch. 3) and underlies the theory of Dedekind sums and the sawtooth Fourier series.",
+    "problemStatement": "**OQ-03 (#1) of hermite-floor-identity**\n\nProve the two-variable / sawtooth companion of Hermite's identity: relate ∑_{k=0}^{n-1} ⌊x + k/n⌋ to the fractional-part sum via the identity\n\n  ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2,\n\nfor {y} = y − ⌊y⌋, for every real x and every n ≥ 1.",
+    "text": "For every real x and every n ≥ 1, ∑_{k=0}^{n-1} Int.fract (x + k/n) = Int.fract (n·x) + (n−1)/2.",
+    "proofStrategy": "**One-line reduction, three ingredients.** Write each sawtooth as {y} = y − ⌊y⌋ (`Int.fract` unfolded by `simp only [Int.fract]`), split the sum additively (`Finset.sum_sub_distrib`, `Finset.sum_add_distrib`), and evaluate the three resulting pieces:\n1. **Constant part** ∑_{k<n} x = n·x (`Finset.sum_const`, `Finset.card_range`, `nsmul_eq_mul`).\n2. **Linear part** ∑_{k<n} (k/n) = (∑_{k<n} k)/n = (n(n−1)/2)/n = (n−1)/2, using the real Gauss sum `sum_range_cast` (induction + push_cast/ring).\n3. **Floor part** ∑_{k<n} ⌊x + k/n⌋ = ⌊n·x⌋, exactly the parent's `HermiteFloorIdentity.hermite_floor_identity` (via `Int.cast_sum` to move the sum inside the ℤ→ℝ cast).\nCombining, ∑ {x+k/n} = (n·x + (n−1)/2) − ⌊n·x⌋ = (n·x − ⌊n·x⌋) + (n−1)/2 = {n·x} + (n−1)/2, closed by `field_simp; ring`. The two specialisations follow by substituting x = 0 (with `Int.fract_zero`) and by using {n·x} = 0.",
+    "keyInsights": [
+      "The sawtooth identity carries no more content than the floor identity — it is the *complement* of it inside the exact arithmetic sum ∑_{k<n}(x + k/n) = n·x + (n−1)/2. Proving both makes the floor/fractional decomposition of a uniformly sampled arithmetic progression fully explicit.",
+      "The (n−1)/2 term is precisely the average of the offsets 0, 1/n, …, (n−1)/n rescaled: ∑_{k<n} k/n = (n−1)/2, a Gauss sum. It is x-independent, so the entire x-dependence of the sawtooth sum lives in the single term {n·x}.",
+      "At x = 0 the identity reads ∑_{k=0}^{n-1} {k/n} = (n−1)/2, the equidistribution/average statement for the n-th roots-of-unity phases on the sawtooth — the seed of Dedekind-sum reciprocity.",
+      "Unfolding `Int.fract` to `y − ⌊y⌋` up front reduces an analytic-looking statement about a discontinuous sawtooth to pure finite-sum algebra plus one appeal to the parent's integer identity."
+    ],
+    "prerequisites": [
+      "HermiteFloorIdentity.hermite_floor_identity (the parent floor identity ∑ ⌊x + k/n⌋ = ⌊n·x⌋)",
+      "Int.fract y = y − ⌊y⌋ and Int.fract_zero from Mathlib",
+      "Finset.sum_sub_distrib, Finset.sum_add_distrib, Finset.sum_const, Finset.sum_div, Int.cast_sum",
+      "The Gauss sum ∑_{k<n} k = n(n−1)/2 (re-derived in real form)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-gauss",
+      "title": "Real Gauss Sum",
+      "startLine": 40,
+      "endLine": 47,
+      "summary": "Lemma sum_range_cast: ∑_{k<m} (k : ℝ) = m(m−1)/2 for every m, by induction on m (Finset.sum_range_succ then push_cast; ring). Supplies the x-independent (n−1)/2 term.",
+      "mathContext": "The Gauss sum $\\sum_{k=0}^{m-1} k = \\frac{m(m-1)}{2}$, cast to $\\mathbb{R}$ so it composes with the division by $n$ appearing in the linear part of the sawtooth sum."
+    },
+    {
+      "id": "sec-main",
+      "title": "The Sawtooth Companion Identity",
+      "startLine": 49,
+      "endLine": 64,
+      "summary": "Theorem hermite_fract_identity: ∑_{k<n} {x + k/n} = {n·x} + (n−1)/2 for n ≥ 1. Unfolds Int.fract, splits the sum, evaluates the constant/linear/floor parts (the last via the parent's Hermite floor identity), and closes with field_simp; ring.",
+      "mathContext": "$\\sum_{k=0}^{n-1}\\{x+k/n\\} = \\big(nx + \\tfrac{n-1}{2}\\big) - \\lfloor nx\\rfloor = \\{nx\\} + \\tfrac{n-1}{2}$, using $\\sum_{k<n}\\lfloor x+k/n\\rfloor=\\lfloor nx\\rfloor$."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Specialisations",
+      "startLine": 66,
+      "endLine": 77,
+      "summary": "hermite_fract_sum_at_zero: at x = 0, ∑_{k<n} {k/n} = (n−1)/2. hermite_fract_sum_of_mul_int: if {n·x} = 0 (n·x integral) then the sawtooth sum is exactly (n−1)/2.",
+      "mathContext": "The x = 0 case $\\sum_{k=0}^{n-1}\\{k/n\\}=\\frac{n-1}{2}$ is the average of the offsets; the integral-$nx$ case is where the x-dependent term vanishes."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for every real x and every n ≥ 1, ∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2, the sawtooth companion of Hermite's floor identity, plus the specialisations ∑_{k<n} {k/n} = (n−1)/2 (x = 0) and the exact value (n−1)/2 when n·x is an integer. Zero sorries, zero axioms.",
+    "implications": "**Complete decomposition**: with the parent floor identity, the uniformly sampled sum ∑_{k<n}(x + k/n) = n·x + (n−1)/2 is now split explicitly into its integer part ⌊n·x⌋ and its total fractional part {n·x} + (n−1)/2.\n\n**Equidistribution seed**: the x = 0 case ∑_{k<n} {k/n} = (n−1)/2 is the elementary average behind Dedekind-sum reciprocity and the sawtooth Fourier expansion.",
+    "openQuestions": [
+      "Derive Legendre's formula v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋ from Hermite's identity, exhibiting the floor identity as the additive backbone of the prime-exponent count in factorials (the parent's OQ-03 #2).",
+      "Prove the Bernoulli-polynomial refinement / higher sawtooth moments ∑_{k<n} {x + k/n}^m and relate them to Dedekind sums.",
+      "Establish reciprocity for the associated Dedekind sums s(h, k) = ∑_{r<k} ((r/k))((hr/k)) using the sawtooth ((·)) built from Int.fract."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "hermite-floor-identity",
+      "relationship": "extends",
+      "description": "The parent entry proving Hermite's floor identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋. This entry is its fractional-part companion; the parent's `hermite_floor_identity` is the single external ingredient used here."
+    }
+  ],
+  "references": [
+    {
+      "author": "Hermite, C.",
+      "title": "Sur quelques conséquences arithmétiques des formules de la théorie des fonctions elliptiques",
+      "year": 1884,
+      "note": "Period in which Hermite recorded the floor-summation identity underlying this companion."
+    },
+    {
+      "author": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "note": "Chapter 3 (Integer Functions): the floor/fractional identities and ∑_{k<n} {k/n} = (n−1)/2."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.HermiteFloorIdentity"
+    ],
+    "namespace": "HermiteFloorIdentityOQ03",
+    "lineCount": 77,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/HermiteFloorIdentityOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent `hermite-floor-identity` entry: the **fractional-part (sawtooth) companion** of Hermite's floor identity.

For every real `x` and every `n ≥ 1`:

  **∑_{k=0}^{n-1} {x + k/n} = {n·x} + (n−1)/2**,  where `{y} = Int.fract y = y − ⌊y⌋`.

This is the additive twin of the parent's `∑ ⌊x + k/n⌋ = ⌊n·x⌋`. Together they give the complete floor + fractional decomposition of the uniformly-sampled sum `∑_{k<n}(x + k/n) = n·x + (n−1)/2`.

## Contents

- `hermite_fract_identity` — the sawtooth companion identity (main result).
- `hermite_fract_sum_at_zero` — `∑_{k<n} {k/n} = (n−1)/2` (the classical average of `0, 1/n, …, (n−1)/n`).
- `hermite_fract_sum_of_mul_int` — when `n·x ∈ ℤ`, the sawtooth sum is exactly `(n−1)/2`.
- `sum_range_cast` — the real-valued Gauss sum `∑_{k<n} k = n(n−1)/2`.

## Proof

One-line reduction: unfold `Int.fract`, split the sum, evaluate the constant part (`n·x`), the linear part (`(n−1)/2` via the Gauss sum), and the floor part (`⌊n·x⌋` via the parent's `hermite_floor_identity`); close with `field_simp; ring`.

## Verification

- Docker Lean build exits 0 (`Proofs.HermiteFloorIdentityOQ03`).
- `#print axioms` on all three theorems lists only `propext / Classical.choice / Quot.sound` — **0 custom axioms, 0 sorries**.
- New gallery entry `src/data/proofs/hermite-floor-identity-oq-03/meta.json` (77L, 4 thm/lemma, 0 def).

🤖 Generated with [Claude Code](https://claude.com/claude-code)