### PR TITLE
research(sperner-mathlib4-oq-02): raw door graph of ∂Δ^{n+1} is K_{n+2} in all dimensions [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerTuckerSimplexBoundaryDoorGraph.lean
+++ b/proofs/Proofs/SpernerTuckerSimplexBoundaryDoorGraph.lean
@@ -1,0 +1,168 @@
+/-
+# The raw door graph of `∂Δ^{n+1}` is the complete graph `K_{n+2}` — in every dimension
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's Lemma and Borsuk–Ulam from
+abstract door-counting").
+
+## Where this sits
+
+`SpernerTuckerSimplexBoundaryPseudomanifold.lean` fixes a concrete `n = 3` model of the
+boundary of the 4-simplex `∂Δ⁴` and discharges the engine's geometric inputs `hdoor`
+(pseudomanifold: each door borders `≤ 2` top cells) and `hpair` (two distinct top cells
+share `≤ 1` door) by kernel `decide`, then runs the engine's degree formula
+(`SpernerTuckerDoorGraph.doorGraph_degree_eq_shared`) to compute the raw door graph as the
+complete graph `K₅` (every tetrahedron has degree `4`).  That file *also* generalizes the
+pseudomanifold bound `hdoor` (and its sharp `= 2` closed form) to every dimension with no
+`decide` — but leaves the pairing bound `hpair` and the degree computation pinned to the
+single `n = 3` instance.
+
+This file removes that last per-dimension `decide`.  It models `∂Δ^{n+1}` for **every** `n`
+and proves `hdoor`, `hpair`, and the degree formula uniformly, showing the raw door graph of
+`∂Δ^{n+1}` is the complete graph `K_{n+2}` (`doorGraph_eq_top`, `simplex_degree : degree i
+= n + 1`).  So the whole `∂Δ⁴` computation of the sibling file is now the `n = 3` case of a
+theorem, not a stand-alone kernel check.
+
+## The model
+
+Vertices `{0,…,n+1} = Fin (n+2)`.  Top cells are the `n+2` facets `Sᵢ = {0,…,n+1} \ {i}`
+(the facet opposite vertex `i`), indexed by `Tet n := Fin (n+2)`.  Doors are the `n`-faces;
+each `n`-face omits exactly **two** vertices, so we encode a door by the 2-element set of
+vertices it omits: `Door n := {s : Finset (Fin (n+2)) // s.card = 2}`.  The incidence is
+
+> `inc i d  ⟺  i ∈ (the omitted pair of d)`,
+
+i.e. the facet `Sᵢ` opposite `i` carries the `n`-face `d` iff `i` is one of the two vertices
+`d` omits.
+
+## What this file proves (all 0 axioms — `propext` / `Classical.choice` / `Quot.sound`
+only, NO `decide`/`native_decide`/`ofReduceBool`, and no per-dimension case split)
+
+* `hdoor`             — every door borders at most two top cells (pseudomanifold), all `n`;
+* `card_incidence_eq` — in fact **exactly two** (`∂Δ^{n+1}` is closed), all `n`;
+* `hpair`             — two distinct top cells share at most one door, all `n`;
+* `doorGraph_eq_top`  — the raw door graph is the **complete graph** `⊤ = K_{n+2}`: any two
+  distinct top cells `Sᵢ, Sⱼ` share the door omitting `{i,j}`;
+* `simplex_degree`    — hence every top cell has degree `n + 1`, uniformly in `n`
+  (the sibling file's `K₅` is the `n = 3` case);
+* `card_shared_doors` — running the engine's degree formula backwards, each top cell has
+  exactly `n + 1` shared doors, all `n` — a dimension-free count obtained for free from
+  `doorGraph_degree_eq_shared` and the complete-graph degree, with no manual bijection.
+
+Self-contained: imports Mathlib and the abstract engine.  0 sorries, 0 axioms.
+-/
+import Mathlib
+import Proofs.SpernerTuckerDoorGraph
+
+namespace SpernerTuckerSimplexBoundaryDoorGraph
+
+open Finset SimpleGraph SpernerTuckerDoorGraph
+
+variable {n : ℕ}
+
+/-! ## The `∂Δ^{n+1}` incidence, uniformly in `n` -/
+
+/-- The `n+2` top cells of `∂Δ^{n+1}`, indexed by the vertex each one omits: `Sᵢ` is the
+facet opposite vertex `i`. -/
+abbrev Tet (n : ℕ) := Fin (n + 2)
+
+/-- The doors (`n`-faces) of `∂Δ^{n+1}`, encoded by the 2-element set of vertices they omit.
+Every `n`-face of the `(n+1)`-simplex boundary omits exactly two vertices. -/
+abbrev Door (n : ℕ) := {s : Finset (Fin (n + 2)) // s.card = 2}
+
+/-- **Incidence.**  The facet `Sᵢ` opposite vertex `i` carries the door `d` iff `i` is one of
+the two vertices `d` omits. -/
+def inc (i : Tet n) (d : Door n) : Prop := i ∈ d.val
+
+instance : DecidableRel (@inc n) := fun i d => by unfold inc; infer_instance
+
+/-! ## The pseudomanifold inputs, dimension-free -/
+
+/-- **Exact incidence: `∂Δ^{n+1}` is a closed pseudomanifold.**  Every door borders
+*exactly two* top cells — the two whose omitted vertices are precisely the door's pair.  In
+every dimension, no `decide`. -/
+theorem card_incidence_eq (d : Door n) : #{i | inc i d} = 2 := by
+  have he : ({i | inc i d} : Finset (Fin (n + 2))) = d.val := by
+    ext i
+    simp only [mem_filter, mem_univ, true_and, inc]
+  rw [he]; exact d.property
+
+/-- **Engine `hdoor` (the pseudomanifold `≤ 2` bound) for `∂Δ^{n+1}`, all `n`.** -/
+theorem hdoor : ∀ d : Door n, #{i | inc i d} ≤ 2 :=
+  fun d => (card_incidence_eq d).le
+
+/-- **Engine `hpair`: two distinct top cells share at most one door.**  If distinct facets
+`Sᵢ, Sⱼ` both carry doors `d` and `d'`, then `i, j` lie in both omitted pairs; two vertices
+determine a 2-element set, so `d` and `d'` both omit exactly `{i, j}` and coincide.
+Dimension-free. -/
+theorem hpair : ∀ d d' : Door n, ∀ i j : Tet n, i ≠ j →
+    inc i d → inc j d → inc i d' → inc j d' → d = d' := by
+  intro d d' i j hij hid hjd hid' hjd'
+  have hcard : ({i, j} : Finset (Fin (n + 2))).card = 2 := Finset.card_pair hij
+  have hsub : ({i, j} : Finset (Fin (n + 2))) ⊆ d.val := by
+    intro x hx
+    simp only [mem_insert, mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact hid
+    · exact hjd
+  have hsub' : ({i, j} : Finset (Fin (n + 2))) ⊆ d'.val := by
+    intro x hx
+    simp only [mem_insert, mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact hid'
+    · exact hjd'
+  have hd : d.val = ({i, j} : Finset (Fin (n + 2))) :=
+    (Finset.eq_of_subset_of_card_le hsub (by rw [hcard, d.property])).symm
+  have hd' : d'.val = ({i, j} : Finset (Fin (n + 2))) :=
+    (Finset.eq_of_subset_of_card_le hsub' (by rw [hcard, d'.property])).symm
+  exact Subtype.ext (hd.trans hd'.symm)
+
+/-! ## The raw door graph is the complete graph `K_{n+2}` -/
+
+/-- **The raw door graph of `∂Δ^{n+1}` is the complete graph.**  Any two distinct top cells
+`Sᵢ, Sⱼ` share the door omitting the pair `{i, j}`, so the almost-complementary graph on the
+top cells is `⊤ = K_{n+2}` — in every dimension.  (The sibling file computes the `n = 3`
+case, `K₅`, by `decide`.) -/
+theorem doorGraph_eq_top : doorGraph (@inc n) = ⊤ := by
+  ext i j
+  simp only [top_adj]
+  constructor
+  · rintro ⟨hne, -⟩
+    exact hne
+  · intro hne
+    refine ⟨hne, ⟨{i, j}, Finset.card_pair hne⟩, ?_, ?_⟩
+    · show i ∈ ({i, j} : Finset (Fin (n + 2)))
+      exact mem_insert_self i {j}
+    · show j ∈ ({i, j} : Finset (Fin (n + 2)))
+      exact mem_insert_of_mem (mem_singleton_self j)
+
+/-- **Every top cell of `∂Δ^{n+1}` has degree `n + 1`.**  Immediate from `doorGraph_eq_top`:
+in `K_{n+2}` each vertex is adjacent to the other `n + 1`.  This is the dimension-free lift of
+the sibling file's `simplex_degree` (`= 4` for `∂Δ⁴`). -/
+theorem simplex_degree (i : Tet n) : (doorGraph (@inc n)).degree i = n + 1 := by
+  rw [← SimpleGraph.card_neighborFinset_eq_degree]
+  have hnb : (doorGraph (@inc n)).neighborFinset i = univ.erase i := by
+    ext w
+    rw [SimpleGraph.mem_neighborFinset, mem_erase]
+    have hadj : (doorGraph (@inc n)).Adj i w ↔ i ≠ w := by
+      rw [doorGraph_eq_top]; exact top_adj i w
+    rw [hadj]
+    constructor
+    · intro h
+      exact ⟨fun hw => h hw.symm, mem_univ _⟩
+    · intro h
+      exact fun hiw => h.1 hiw.symm
+  rw [hnb, Finset.card_erase_of_mem (mem_univ i), Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- **Shared-door count, dimension-free and for free from the engine.**  Running the engine's
+sharp degree formula `doorGraph_degree_eq_shared` (which needs only `hdoor` and `hpair`)
+backwards through `simplex_degree` shows every top cell of `∂Δ^{n+1}` has exactly `n + 1`
+shared doors — every one of its `n + 1` `n`-faces is shared with the unique other top cell
+across it (`∂Δ^{n+1}` is closed).  No manual counting bijection. -/
+theorem card_shared_doors (i : Tet n) :
+    #{d : Door n | inc i d ∧ ∃ w, w ≠ i ∧ inc w d} = n + 1 := by
+  have h := doorGraph_degree_eq_shared (@inc n) hdoor hpair i
+  rw [simplex_degree] at h
+  convert h.symm using 3
+
+end SpernerTuckerSimplexBoundaryDoorGraph

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -15,10 +15,11 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "ACT: formalized the DIMENSION RECURSION of the Tucker door-counting proof (SpernerTuckerInductiveTower.lean, 0 sorries/0 axioms — propext/Classical.choice/Quot.sound only, no sorryAx/ofReduceBool). (1) odd_boundary_iff_odd_interior STRENGTHENS the path-following engine from mere existence of an interior endpoint to the parity EQUIVALENCE Odd #boundary <-> Odd #interior (the two endpoint classes partition the even-cardinality degree-1 set), the quantitative form the induction needs. (2) TuckerTower bundles per-level interior/boundary counts with step (the engine, discharged by (1)), bridge (the geometric boundary bijection: level-(n+1) boundary doors = level-n interior simplices — the SOLE remaining open input), and base (verified 1-D Tucker); tower_interior_odd : forall n, Odd (interior n) closes the induction in one line, and tower_exists_interior gives a complementary simplex in EVERY dimension. An inhabited trivialTower witnesses non-vacuity. This makes precise that, once the geometric bridge is supplied, full-dimensional Tucker is a two-hypothesis induction. Infrastructure/organizing-skeleton, not new Tucker mathematics; the geometric bridge remains the genuine frontier.",
+  "currentState": "Dimension-free door graph of boundary-Delta^{n+1} = K_{n+2} proven (0-axiom). Next: the geometric bridge (hemisphere doors <-> level-n interior simplices).",
   "knowledge": {
-    "progressSummary": "PROGRESS: hdoor machine-checked on a concrete n=2 geometry. The abstract door-counting engine had 3 black-box incidence hypotheses (hdoor, hsimplex, hpair). hsimplex (SpernerTuckerDoorLemma) and hpair (SpernerTuckerSimplexFacetPair) were discharged in prior sessions; THIS session discharges hdoor — the genuinely-geometric PSEUDOMANIFOLD property — on the standard hexagon disc B^2 by kernel `decide` (SpernerTuckerHexagonPseudomanifold), and runs the engine's degree formula on it (the hexagon almost-complementary graph = 6-cycle, every triangle degree 2). All three engine incidence hypotheses now have concrete/abstract discharges; the remaining open work is the geometric BRIDGE (hemisphere doors <-> level-n interior simplices) + the analytic mesh->0 phase. VERIFIED 0-axiom (lake env lean exit 0; #print axioms = [propext, Classical.choice, Quot.sound], no sorryAx/native_decide).",
+    "progressSummary": "PROGRESS: the raw door graph of boundary-Delta^{n+1} is proven to be the complete graph K_{n+2} in EVERY dimension (SpernerTuckerSimplexBoundaryDoorGraph.lean, VERIFIED 0-axiom, 6thm/3def/168L), removing the last per-dimension decide in the boundary-of-simplex pseudomanifold model. Remaining open work unchanged: geometric BRIDGE + analytic mesh->0.",
     "builtItems": [
+      "proofs/Proofs/SpernerTuckerSimplexBoundaryDoorGraph.lean (168 LOC, 6 thm, 3 def, 0 sorry, 0 axiom -- propext/Classical.choice/Quot.sound only, NO decide/native_decide): DIMENSION-FREE lift of the sibling n=3 file. Models the boundary of the (n+1)-simplex for ALL n (Tet n=Fin(n+2) top cells Si=facet opposite i; Door n={s:Finset(Fin(n+2))//s.card=2} encoding an n-face by its 2 OMITTED vertices; inc i d := i in d.val). Proves hdoor/card_incidence_eq (each door borders EXACTLY 2 top cells) and hpair (distinct top cells share <=1 door) WITHOUT decide, then doorGraph_eq_top: the raw door graph of boundary-Delta^{n+1} is the COMPLETE graph K_{n+2}; hence simplex_degree: every top cell has degree n+1 (the sibling's K5 is n=3). card_shared_doors: n+1 shared doors per cell, FOR FREE from the engine's doorGraph_degree_eq_shared through simplex_degree.",
       "proofs/Proofs/SpernerTuckerDoorGraph.lean (sharp degree formula, VERIFIED 0-axiom: lake env lean exit 0, #print axioms = [propext, Classical.choice, Quot.sound] only): doorGraph_degree_eq_shared — under hdoor (each door joins <=2 simplices) and hpair (two distinct simplices share <=1 door, the door-graph analogue of adj_unique_facet), (doorGraph inc).degree v = #{d | inc v d and exists w != v, inc w d} (the # of vs SHARED doors). Finset.card_bij with the neighbour->shared-door witness map: lands in shared doors, injective by hdoor (a door joining v to two neighbours touches 3 simplices), surjective by hpair (a shared doors other endpoint is a neighbour whose shared door is forced to be that door). Sharpens doorGraph_degree_le_two from a bound to an equality: a path endpoint (degree 1) is exactly a simplex with ONE shared door.",
       "proofs/Proofs/SpernerTuckerOneDim.lean — 1-D Tucker / combinatorial 1-D Borsuk–Ulam (verified, 0-axiom)",
       "TuckerOneDim.complementary_count_cast — telescoping ZMod-2 identity: #complementary-edges ≡ lam 0 + lam (last) (mod 2)",
@@ -55,7 +56,8 @@
       "hpair (two distinct simplices share <=1 facet) is provable as dimension-free finset combinatorics for SUBSET incidence: both shared facets equal v ∩ w (facet_eq_inter), hence are equal. Distinct equicardinal (n+1)-sets meet in <=n vertices (card_inter_le_of_ne). Discharges the 2nd of 3 abstract door hypotheses; with hsimplex (SpernerTuckerDoorLemma) only hdoor (pseudomanifold, genuinely geometric) + the bridge remain.",
       "hdoor (each door/facet borders <=2 simplices — the PSEUDOMANIFOLD property, genuinely geometric and FALSE for arbitrary complexes) is now machine-checked on a concrete n=2 triangulation: the standard hexagon disc B^2 (centre + 6 boundary vertices, 6 triangles T_i=(centre,v_i,v_{i+1})). Encoding triangles as Fin 6 and edges as Fin 12 (6 spokes + 6 boundary edges), hdoor and hpair both fall to kernel `decide`. Sharp counts: each spoke borders exactly 2 triangles (interior edge), each boundary edge exactly 1. Feeding hdoor+hpair to the engine's degree formula (doorGraph_degree_eq_shared) computes the hexagon's almost-complementary graph as the 6-cycle (every triangle degree 2) THROUGH the abstract engine, not by hand. This is the first concrete geometry discharging the engine's sole-remaining geometric input.",
       "hdoor (pseudomanifold) and hsimplex (complementary-door bound) are INDEPENDENT engine inputs, not conflatable: concrete witness ∂Δ⁴ (boundary of the 4-simplex = simplicial 3-sphere, 5 tetrahedra S_i={0..4}\\{i}, 10 triangle doors encoded by the omitted vertex PAIR). hdoor holds there with EXACT incidence 2 (closed manifold, no boundary) — yet the engine's raw door graph is K_5 (every tetrahedron degree 4, via doorGraph_degree_eq_shared). So the max-degree-≤2 (paths+cycles) structure the path-following engine needs does NOT follow from hdoor alone; it comes from restricting to COMPLEMENTARY doors under the labelling (hsimplex). hdoor = geometric (triangulation), hsimplex = combinatorial (colouring). In the hexagon disc the raw door graph was a 6-cycle only coincidentally.",
-      "The pseudomanifold property hdoor for the boundary of the (n+1)-simplex is dimension-free: d ⊆ univ.erase i ⟺ i ∉ d, so the cells containing an n-face d are dᶜ, of card (n+2)-n=2 — no case enumeration."
+      "The pseudomanifold property hdoor for the boundary of the (n+1)-simplex is dimension-free: d ⊆ univ.erase i ⟺ i ∉ d, so the cells containing an n-face d are dᶜ, of card (n+2)-n=2 — no case enumeration.",
+      "DIMENSION-FREE door graph = K_{n+2}: the sibling SpernerTuckerSimplexBoundaryPseudomanifold pinned hpair + degree to a single n=3 decide; the raw-door-graph-is-complete fact is uniform in n. Encode a door by its 2 OMITTED vertices (Door n = 2-subsets of Fin(n+2)); inc i d := i in d.val. hdoor/closed = d.val.card=2, hpair = two vertices pin a 2-set (Finset.eq_of_subset_of_card_le + Finset.card_pair), doorGraph inc = top since distinct Si,Sj share exactly the door omitting {i,j}. degree n+1 from (top).neighborFinset i = univ.erase i, rewriting at the Adj level to dodge the Fintype-instance-in-motive error under degree."
     ],
     "mathlibGaps": [
       "Mathlib lacks a direct free-involution => even-cardinality lemma (only the p-group card_modEq_card_fixedPoints). Proved here from Finset.sum_ninvolution + ZMod.natCast_eq_zero_iff_even.",
@@ -85,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:23.646Z",
-  "lastUpdate": "2026-06-28",
+  "lastUpdate": "2026-07-02T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/SpernerTuckerBorsukUlamOneDim.lean",
@@ -209,6 +211,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerHexagonDoorObstruction.lean"
+    },
+    {
+      "path": "Proofs/SpernerTuckerSimplexBoundaryDoorGraph.lean",
+      "filename": "SpernerTuckerSimplexBoundaryDoorGraph.lean",
+      "lineCount": 168,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerSimplexBoundaryDoorGraph.lean"
     }
   ],
   "lastVerified": "2026-06-28"


### PR DESCRIPTION
## Summary

Dimension-free lift of the sibling `SpernerTuckerSimplexBoundaryPseudomanifold`'s `n = 3` (∂Δ⁴) computation, which pinned the pairing bound `hpair` and the door-graph degree to a single kernel `decide`. The new file `SpernerTuckerSimplexBoundaryDoorGraph.lean` models the boundary of the `(n+1)`-simplex for **every** `n` and proves the engine's geometric inputs and the degree formula uniformly, with **no per-dimension `decide`**.

## Results (all VERIFIED, 0-axiom)

- `card_incidence_eq` / `hdoor` — every door (`n`-face) borders **exactly two** top cells: ∂Δ^{n+1} is a closed pseudomanifold, all `n`.
- `hpair` — two distinct top cells share at most one door, all `n`.
- `doorGraph_eq_top` — the raw almost-complementary **door graph of ∂Δ^{n+1} is the complete graph `K_{n+2}`**: any two distinct facets `Sᵢ, Sⱼ` share the door omitting the pair `{i, j}`.
- `simplex_degree` — hence every top cell has degree `n + 1` (the sibling file's `K₅` is exactly the `n = 3` case).
- `card_shared_doors` — `n + 1` shared doors per cell, obtained *for free* by running the engine's `doorGraph_degree_eq_shared` backwards through `simplex_degree` — a dimension-free count with no manual bijection.

## Method

Doors are encoded by the 2-element set of vertices they **omit** (`Door n = {s : Finset (Fin (n+2)) // s.card = 2}`, `inc i d := i ∈ d.val`). Then `hdoor`/closed reduce to `d.val.card = 2`; `hpair` is `Finset.eq_of_subset_of_card_le` + `Finset.card_pair` (two vertices pin a 2-set); `doorGraph inc = ⊤` because distinct top cells share exactly the door omitting their pair. Degree is computed via `(⊤).neighborFinset i = univ.erase i`, rewriting at the `Adj` level to dodge the `Fintype`-instance-in-motive obstruction under `degree`.

## Verification

`lake env lean` exit 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` for all six theorems — no `sorryAx`, no `native_decide`/`ofReduceBool`.

Advances the open problem `sperner-mathlib4-oq-02` (Tucker's Lemma from abstract door-counting); the remaining open work (geometric bridge + analytic mesh→0) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)