### PR TITLE
Enrich matrix operator absolute value |A|=√(AᴴA): annotation coverage

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,203 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "The Operator Absolute Value |A| = √(AᴴA) and Why It Preserves Length",
+    "content": "This entry isolates the positive semidefinite factor `√(AᴴA)` of the polar decomposition `A = U·|A|` and studies it in its own right: the **operator absolute value**, or **modulus**, `|A|`. Its single load-bearing property is that it acts on lengths exactly as `A` does — `‖Ax‖ = ‖|A|x‖` for every vector `x`. Squaring turns this into an identity of Hermitian quadratic forms, `⟨Ax, Ax⟩ = ⟨x, AᴴA x⟩ = ⟨x, |A|² x⟩ = ⟨|A|x, |A|x⟩`, using only `|A|² = AᴴA` and self-adjointness of `|A|` — no analysis. The file proves both the abstract quadratic-form version (`absValue_star_mulVec_dotProduct`) and the honest squared-Euclidean-norm version `∑ᵢ‖(Ax)ᵢ‖² = ∑ᵢ‖(|A|x)ᵢ‖²` (`absValue_normSq_eq`), over an arbitrary `RCLike` field `𝕜` (so `ℝ` or `ℂ`). This length preservation is precisely why the polar phase `U` can be chosen genuinely unitary, and it is the starting point of the singular value decomposition (the singular values of `A` are the eigenvalues of `|A|`).",
+    "mathContext": "$|A| = \\sqrt{A^{\\mathsf H}A}$, \\quad $\\lVert Ax\\rVert = \\lVert |A|x\\rVert$",
+    "significance": "key",
+    "relatedConcepts": [
+      "operator absolute value / modulus",
+      "polar decomposition A = U·|A|",
+      "positive semidefinite square root (CFC.sqrt)",
+      "Hermitian quadratic forms",
+      "singular value decomposition",
+      "isometry / norm preservation"
+    ]
+  },
+  {
+    "id": "ann-absvalue-def",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "The Operator Absolute Value |A| = √(AᴴA)",
+    "content": "**`absValue A = CFC.sqrt (Aᴴ * A)`.** The modulus of a matrix, defined through Mathlib's C⋆-algebraic continuous-functional-calculus square root. Because `Aᴴ·A` is always positive semidefinite, its square root exists unconditionally, so `|A|` is defined for every matrix `A` with no hypothesis. This is the matrix analogue of the modulus `r = |z| = √(z̄z)` in the complex polar form `z = r·e^{iθ}`, and it coincides with the positive semidefinite factor `polarFactor A` of the parent polar-decomposition entry.",
+    "mathContext": "$|A| = \\sqrt{A^{\\mathsf H}A} = \\operatorname{CFC.sqrt}(A^{\\mathsf H}A)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt",
+      "operator absolute value",
+      "modulus",
+      "polar decomposition"
+    ]
+  },
+  {
+    "id": "ann-absvalue-possemidef",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "|A| Is Positive Semidefinite",
+    "content": "**`(absValue A).PosSemidef`.** The CFC square root of any element is nonnegative in the Loewner order (`CFC.sqrt_nonneg`), and `.posSemidef` transports that into the concrete `Matrix.PosSemidef` predicate. A legitimate 'modulus' must be a genuinely PSD matrix — this is that guarantee.",
+    "mathContext": "$|A| \\succeq 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CFC.sqrt_nonneg",
+      "Matrix.PosSemidef",
+      "Loewner order"
+    ]
+  },
+  {
+    "id": "ann-absvalue-hermitian",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "|A| Is Hermitian",
+    "content": "**`(absValue A)ᴴ = absValue A`.** Immediate from positive semidefiniteness via `Matrix.PosSemidef.isHermitian`. Self-adjointness of the modulus is exactly what makes the quadratic-form computation collapse `(|A|)ᴴ·|A|` to `|A|·|A|` in the norm-preservation proof.",
+    "mathContext": "$|A|^{\\mathsf H} = |A|$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.PosSemidef.isHermitian",
+      "self-adjoint"
+    ]
+  },
+  {
+    "id": "ann-absvalue-mul-self",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "Defining Identity |A|² = AᴴA",
+    "content": "**`absValue A * absValue A = Aᴴ * A`.** The square-root property `√X·√X = X` (`CFC.sqrt_mul_sqrt_self`) specialized to `X = Aᴴ·A ≥ 0` (`posSemidef_conjTranspose_mul_self`). This is the algebraic engine: it lets `AᴴA` be replaced by `|A|²` wherever it appears, and drives the norm-preservation identity.",
+    "mathContext": "$|A|^2 = A^{\\mathsf H}A$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt_mul_sqrt_self",
+      "posSemidef_conjTranspose_mul_self"
+    ]
+  },
+  {
+    "id": "ann-absvalue-conjtranspose-mul-self",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "|A|ᴴ · |A| = AᴴA",
+    "content": "**`(absValue A)ᴴ * absValue A = Aᴴ * A`.** Combining self-adjointness `|A|ᴴ = |A|` with the defining identity `|A|² = AᴴA`. This is the precise form in which the modulus enters the quadratic-form collapse: it is the `MᴴM` of `M = |A|`, and it equals the `MᴴM` of `M = A`.",
+    "mathContext": "$|A|^{\\mathsf H}\\,|A| = A^{\\mathsf H}A$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "self-adjoint",
+      "defining identity"
+    ]
+  },
+  {
+    "id": "ann-absvalue-unique",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "|A| Is the Unique PSD Square Root of AᴴA",
+    "content": "**`P.PosSemidef → P·P = Aᴴ·A → P = absValue A`.** Uniqueness of the positive semidefinite square root (`CFC.sqrt_unique`) makes the modulus completely canonical: unlike the unitary phase in the polar decomposition, which is only determined up to its action on `ker A`, `|A|` is intrinsic — there is exactly one PSD matrix squaring to `AᴴA`.",
+    "mathContext": "$P \\succeq 0,\\ P^2 = A^{\\mathsf H}A \\ \\Longrightarrow\\ P = |A|$",
+    "significance": "key",
+    "relatedConcepts": [
+      "CFC.sqrt_unique",
+      "uniqueness",
+      "canonical"
+    ]
+  },
+  {
+    "id": "ann-quadform-collapse",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "Quadratic-Form Collapse ⟨Mx, Mx⟩ = ⟨x, MᴴM x⟩",
+    "content": "**`star (M *ᵥ x) ⬝ᵥ (M *ᵥ x) = star x ⬝ᵥ ((Mᴴ*M) *ᵥ x)`.** A pure matrix-algebra identity: `star_mulVec` turns `star(Mx)` into `star x ᵥ* Mᴴ`, `dotProduct_mulVec` moves the `Mᴴ` across the dot product, and `mulVec_mulVec` fuses `Mᴴ·(M·x)` into `(MᴴM)·x`. The upshot is that the length of `Mx` depends on `M` only through `MᴴM` — no analysis, no norms.",
+    "mathContext": "$\\langle Mx, Mx\\rangle = \\langle x, M^{\\mathsf H}M\\,x\\rangle$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.star_mulVec",
+      "Matrix.dotProduct_mulVec",
+      "Matrix.mulVec_mulVec",
+      "quadratic form"
+    ]
+  },
+  {
+    "id": "ann-norm-preservation-form",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 97
+    },
+    "type": "theorem",
+    "title": "Norm Preservation ⟨Ax, Ax⟩ = ⟨|A|x, |A|x⟩",
+    "content": "**`star (A *ᵥ x) ⬝ᵥ (A *ᵥ x) = star (|A| *ᵥ x) ⬝ᵥ (|A| *ᵥ x)`.** Apply the quadratic-form collapse to both `A` and `|A|`: the two sides reduce to `⟨x, AᴴA x⟩` and `⟨x, (|A|ᴴ|A|) x⟩`, and these are equal because `|A|ᴴ·|A| = AᴴA`. This is the algebraic heart of why the unitary phase of the polar decomposition is a genuine isometry.",
+    "mathContext": "$\\langle Ax, Ax\\rangle = \\langle |A|x, |A|x\\rangle$",
+    "significance": "key",
+    "relatedConcepts": [
+      "isometry",
+      "polar decomposition",
+      "Hermitian quadratic form"
+    ]
+  },
+  {
+    "id": "ann-dotproduct-star-self",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "star y ⬝ᵥ y Is the Squared Euclidean Length",
+    "content": "**`star y ⬝ᵥ y = ↑(∑ᵢ ‖yᵢ‖²)`.** The unconjugated dot product of `y` with its star is `∑ᵢ conj(yᵢ)·yᵢ = ∑ᵢ ‖yᵢ‖²` (`RCLike.conj_mul`), a real quantity transported into `𝕜`. This is the bridge that turns the abstract quadratic-form identity into a statement about honest Euclidean norms.",
+    "mathContext": "$\\bar y \\cdot y = \\sum_i \\lVert y_i\\rVert^2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "RCLike.conj_mul",
+      "RCLike.star_def",
+      "Euclidean norm"
+    ]
+  },
+  {
+    "id": "ann-normsq-eq",
+    "proofId": "matrix-posdef-sqrt-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "Euclidean-Norm Preservation ‖Ax‖ = ‖|A|x‖",
+    "content": "**`∑ᵢ ‖(Ax)ᵢ‖² = ∑ᵢ ‖(|A|x)ᵢ‖²`.** The quadratic-form identity `⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩`, rewritten via `star y ⬝ᵥ y = ↑(∑ᵢ‖yᵢ‖²)`, becomes an equality of two coerced reals; injectivity of `ℝ ↪ 𝕜` (`exact_mod_cast`) yields the genuine real identity. This is `‖Ax‖ = ‖|A|x‖` — the modulus preserves lengths exactly.",
+    "mathContext": "$\\sum_i \\lVert (Ax)_i\\rVert^2 = \\sum_i \\lVert (|A|x)_i\\rVert^2,\\qquad \\lVert Ax\\rVert = \\lVert |A|x\\rVert$",
+    "significance": "key",
+    "relatedConcepts": [
+      "exact_mod_cast",
+      "RCLike coercion",
+      "isometry",
+      "Euclidean norm"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment: matrix-posdef-sqrt-oq-01-oq-01-oq-01

Adds annotation coverage to *The Operator Absolute Value |A| = √(AᴴA) and Norm Preservation ‖Ax‖ = ‖|A|x‖*, which previously had **no annotations.json** on `main`.

- Authored **11 annotations** covering the module docstring (lines 1–34) and every declaration through line 116 (~90% of the 118-line file).
- New top-level `concept` overview annotation paraphrasing the module docstring (the operator absolute value, its length-preservation property, and why it forces the polar phase to be unitary).
- Ten declaration-level annotations for `absValue`, its PSD/Hermitian/`|A|²=AᴴA`/uniqueness structure, the quadratic-form collapse, and the descent to honest Euclidean norms — each with `mathContext`, `significance`, and `relatedConcepts`.
- No overlaps; ranges strictly ordered and within `leanFile.lineCount`.

`meta.json` unchanged. Annotations-only enrichment.
