### PR TITLE
Enrich Puiseux OQ-03 Newton polygon (puiseux-theorem-oq-03): module-overview annotation

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-03/annotations.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/annotations.json
@@ -1,5 +1,33 @@
 [
   {
+    "id": "ann-puiseux-oq03-overview",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 64
+    },
+    "type": "concept",
+    "title": "Overview: A Combinatorial Newton Polygon for Puiseux OQ-03",
+    "content": "This file is the first Lean deliverable for the puiseux-theorem OQ-03 open question \u2014 whether the Newton-Puiseux algorithm can be made efficient enough for computational algebraic geometry at scale. Prior survey sessions identified the combinatorial Newton polygon as the cleanest tractable entry point, and this file delivers it, fully machine-checked with 0 sorries and 0 axioms. For a polynomial P(Y) = \u03a3 a\u1d62 Y\u2071 over a valued field K((x)), the Newton polygon is the lower convex hull of the support points (i, v(a\u1d62)); the Newton polygon theorem states that the negatives of its edge slopes are exactly the valuations of the roots of P, which is why the slopes feed the parent entry's `leadingExponentFromSlope`. Rather than commit to a specific hull-construction algorithm, the file uses the standard supporting-line characterization of a lower-hull vertex (`IsLowerVertex`): a support point is a lower vertex when some line lies weakly below every support point and passes through it. It proves the minimum-valuation point is always a lower vertex (the horizontal supporting line, seeding the polygon), that every nonempty support set has a lower vertex (via `List.argmin`), that lower vertices are genuine support points, and works the example Y\u00b2 \u2212 x whose single edge of slope \u22121/2 yields leading exponent 1/2. The honest remaining scope \u2014 the Newton polygon theorem itself (slopes = root valuations), the termination measure for a reduction step, and the quasi-linear Poteaux-Weimann complexity bound \u2014 is blocked on valuation and complexity APIs not yet in Mathlib.",
+    "mathContext": "The Newton polygon of $P(Y)=\\sum_i a_i Y^i \\in K((x))[Y]$ is the lower convex hull of $\\{(i, v(a_i)) : a_i \\neq 0\\}$ where $v$ is the $x$-adic valuation. Newton polygon theorem: if the edge from $(i_0,v_0)$ to $(i_1,v_1)$ has slope $m$, then $P$ has exactly $i_1-i_0$ roots (with multiplicity) of valuation $-m$ in an algebraically closed valued extension. Iterating this over successive polygon edges is the Newton-Puiseux algorithm, producing the Puiseux-series expansions of the roots. The supporting-line predicate $\\mathrm{IsLowerVertex}(p)$ \u2014 $\\exists$ a line weakly below all support points and through $p$ \u2014 is a proposition capturing the combinatorial content without a verified convex-hull routine.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton-polygon",
+      "Puiseux-series",
+      "valuation",
+      "lower-convex-hull",
+      "Newton-Puiseux-algorithm",
+      "supporting-line",
+      "computational-algebraic-geometry"
+    ],
+    "prerequisites": [
+      "formal Laurent/Puiseux series K((x))",
+      "valuations and order of a series",
+      "convex hulls and supporting lines",
+      "polynomial roots in valued fields"
+    ]
+  },
+  {
     "id": "ann-support-point-edgeslope",
     "proofId": "puiseux-theorem-oq-03",
     "range": {
@@ -8,7 +36,7 @@
     },
     "type": "definition",
     "title": "Support Points and the Edge Slope",
-    "content": "A `SupportPoint` is an `ℕ × ℚ` pair `(i, v)`: the exponent `i` of `Yⁱ` together with the valuation `v = v(aᵢ) ∈ ℚ` of its coefficient. Indices where `aᵢ = 0` (valuation `+∞`) are simply dropped from the support list, so the data is finite and computable. `edgeSlope p q = (q.2 − p.2)/(q.1 − p.1)` is the ordinary slope of the segment joining two support points; the Newton polygon theorem will identify the *negatives* of these edge slopes with root valuations. Using ℚ-valued valuations (not the WithTop ℤ of a discrete valuation) is exactly what lets fractional exponents like 1/2 appear.",
+    "content": "A `SupportPoint` is an `\u2115 \u00d7 \u211a` pair `(i, v)`: the exponent `i` of `Y\u2071` together with the valuation `v = v(a\u1d62) \u2208 \u211a` of its coefficient. Indices where `a\u1d62 = 0` (valuation `+\u221e`) are simply dropped from the support list, so the data is finite and computable. `edgeSlope p q = (q.2 \u2212 p.2)/(q.1 \u2212 p.1)` is the ordinary slope of the segment joining two support points; the Newton polygon theorem will identify the *negatives* of these edge slopes with root valuations. Using \u211a-valued valuations (not the WithTop \u2124 of a discrete valuation) is exactly what lets fractional exponents like 1/2 appear.",
     "mathContext": "$\\text{support}(P)=\\{(i,\\,v(a_i)) : a_i\\neq 0\\}\\subset\\mathbb N\\times\\mathbb Q$; $\\text{edgeSlope}(p,q)=\\dfrac{v_q-v_p}{i_q-i_p}$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -31,8 +59,8 @@
     },
     "type": "definition",
     "title": "The Supporting-Line Vertex Predicate",
-    "content": "`IsLowerVertex pts p` is the heart of the file. Rather than constructing the lower convex hull algorithmically, it characterizes a vertex by a **supporting line**: `p ∈ pts` and there exist `m, b : ℚ` such that the line `y = m·i + b` passes through `p` (`p.2 = m·p.1 + b`) and lies weakly below every support point (`∀ q ∈ pts, m·q.1 + b ≤ q.2`). Phrasing the definition as a `Prop` keeps the API honest about the mathematical content while sidestepping the need for a verified convex-hull routine — a deliberate design choice given Mathlib 4.26.0 has no Newton-polygon API. `IsLowerVertex.mem` is the trivial projection recording that a vertex is a genuine support point.",
-    "mathContext": "$\\text{IsLowerVertex}(\\text{pts},p)\\iff p\\in\\text{pts}\\,\\wedge\\,\\exists m,b:\\; v_p=m\\,i_p+b\\,\\wedge\\,\\forall q\\in\\text{pts},\\; m\\,i_q+b\\le v_q.$ A line below all points, touching $p$ — the dual (supporting-hyperplane) description of a lower-hull vertex.",
+    "content": "`IsLowerVertex pts p` is the heart of the file. Rather than constructing the lower convex hull algorithmically, it characterizes a vertex by a **supporting line**: `p \u2208 pts` and there exist `m, b : \u211a` such that the line `y = m\u00b7i + b` passes through `p` (`p.2 = m\u00b7p.1 + b`) and lies weakly below every support point (`\u2200 q \u2208 pts, m\u00b7q.1 + b \u2264 q.2`). Phrasing the definition as a `Prop` keeps the API honest about the mathematical content while sidestepping the need for a verified convex-hull routine \u2014 a deliberate design choice given Mathlib 4.26.0 has no Newton-polygon API. `IsLowerVertex.mem` is the trivial projection recording that a vertex is a genuine support point.",
+    "mathContext": "$\\text{IsLowerVertex}(\\text{pts},p)\\iff p\\in\\text{pts}\\,\\wedge\\,\\exists m,b:\\; v_p=m\\,i_p+b\\,\\wedge\\,\\forall q\\in\\text{pts},\\; m\\,i_q+b\\le v_q.$ A line below all points, touching $p$ \u2014 the dual (supporting-hyperplane) description of a lower-hull vertex.",
     "significance": "key",
     "relatedConcepts": [
       "supporting hyperplane",
@@ -54,13 +82,13 @@
     },
     "type": "insight",
     "title": "The Lowest Point Seeds the Polygon",
-    "content": "`isLowerVertex_of_minimal` proves that any support point of globally minimum valuation is a lower vertex, witnessed by the **horizontal** supporting line `y = v(p)` — i.e. `m = 0`, `b = p.2`. The supporting condition `0·q.1 + p.2 ≤ q.2` then reduces verbatim to the minimality hypothesis `p.2 ≤ q.2`, closed by `simpa`. This is the constructive starting vertex of the Newton–Puiseux algorithm: the polygon is always anchored at its lowest point, and one walks the lower hull rightward from there.",
+    "content": "`isLowerVertex_of_minimal` proves that any support point of globally minimum valuation is a lower vertex, witnessed by the **horizontal** supporting line `y = v(p)` \u2014 i.e. `m = 0`, `b = p.2`. The supporting condition `0\u00b7q.1 + p.2 \u2264 q.2` then reduces verbatim to the minimality hypothesis `p.2 \u2264 q.2`, closed by `simpa`. This is the constructive starting vertex of the Newton\u2013Puiseux algorithm: the polygon is always anchored at its lowest point, and one walks the lower hull rightward from there.",
     "mathContext": "$m=0,\\ b=v_p$: the horizontal line $y=v_p$ is a supporting line precisely when $v_p=\\min_q v_q$. Hence the minimum-valuation point is always a vertex.",
     "significance": "supporting",
     "relatedConcepts": [
       "horizontal supporting line",
       "minimum valuation",
-      "Newton–Puiseux seed vertex"
+      "Newton\u2013Puiseux seed vertex"
     ],
     "prerequisites": [
       "minimality arguments"
@@ -75,7 +103,7 @@
     },
     "type": "tactic",
     "title": "Existence for Free via List.argmin",
-    "content": "`exists_lowerVertex` turns the seed lemma into an existence guarantee: every nonempty support list has a lower vertex. The proof case-splits on `pts.argmin (·.2)` (the minimum-valuation element). The `none` branch is impossible — `List.argmin_eq_none` says the list would be empty, contradicting the hypothesis — and the `some m` branch feeds `List.argmin_mem` (membership) and `List.le_of_mem_argmin` (minimality over all elements) directly into `isLowerVertex_of_minimal`. Reusing Mathlib's argmin API means no bespoke induction on lists is needed; the existence theorem any hull construction must satisfy comes essentially for free.",
+    "content": "`exists_lowerVertex` turns the seed lemma into an existence guarantee: every nonempty support list has a lower vertex. The proof case-splits on `pts.argmin (\u00b7.2)` (the minimum-valuation element). The `none` branch is impossible \u2014 `List.argmin_eq_none` says the list would be empty, contradicting the hypothesis \u2014 and the `some m` branch feeds `List.argmin_mem` (membership) and `List.le_of_mem_argmin` (minimality over all elements) directly into `isLowerVertex_of_minimal`. Reusing Mathlib's argmin API means no bespoke induction on lists is needed; the existence theorem any hull construction must satisfy comes essentially for free.",
     "mathContext": "$\\text{pts}\\neq[]\\Rightarrow\\exists p,\\ \\text{IsLowerVertex}(\\text{pts},p)$, via $p=\\arg\\min_{q\\in\\text{pts}} v_q$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -97,9 +125,9 @@
       "endLine": 130
     },
     "type": "concept",
-    "title": "Worked Example: Both Endpoints of Y²−x Are Vertices",
-    "content": "The canonical test case is `Y² − x` over `K((x))`: its coefficients are `a₀ = −x` (valuation 1), `a₁ = 0` (omitted), `a₂ = 1` (valuation 0), so the support is `YsqMinusX = [(0,1), (2,0)]`. Both `ysqMinusX_vertex_const` and `ysqMinusX_vertex_lead` exhibit the *same* edge line `y = −½·i + 1` (here `m = −1/2`, `b = 1`) as the supporting line through each endpoint. The membership obligation is closed by `simp [YsqMinusX]` and the supporting inequalities by `fin_cases hq <;> norm_num`, which checks the line against each of the two points: it passes through both with equality, so the single edge from (0,1) to (2,0) IS the entire Newton polygon.",
-    "mathContext": "$Y^2-x$: support $\\{(0,1),(2,0)\\}$; the line $y=-\\tfrac12 i+1$ gives $-\\tfrac12\\cdot0+1=1$ and $-\\tfrac12\\cdot2+1=0$, touching both points — both are lower vertices.",
+    "title": "Worked Example: Both Endpoints of Y\u00b2\u2212x Are Vertices",
+    "content": "The canonical test case is `Y\u00b2 \u2212 x` over `K((x))`: its coefficients are `a\u2080 = \u2212x` (valuation 1), `a\u2081 = 0` (omitted), `a\u2082 = 1` (valuation 0), so the support is `YsqMinusX = [(0,1), (2,0)]`. Both `ysqMinusX_vertex_const` and `ysqMinusX_vertex_lead` exhibit the *same* edge line `y = \u2212\u00bd\u00b7i + 1` (here `m = \u22121/2`, `b = 1`) as the supporting line through each endpoint. The membership obligation is closed by `simp [YsqMinusX]` and the supporting inequalities by `fin_cases hq <;> norm_num`, which checks the line against each of the two points: it passes through both with equality, so the single edge from (0,1) to (2,0) IS the entire Newton polygon.",
+    "mathContext": "$Y^2-x$: support $\\{(0,1),(2,0)\\}$; the line $y=-\\tfrac12 i+1$ gives $-\\tfrac12\\cdot0+1=1$ and $-\\tfrac12\\cdot2+1=0$, touching both points \u2014 both are lower vertices.",
     "significance": "supporting",
     "relatedConcepts": [
       "fin_cases",
@@ -119,9 +147,9 @@
       "endLine": 143
     },
     "type": "insight",
-    "title": "Closing the Loop: Edge Slope → Leading Exponent",
-    "content": "`ysqMinusX_edge_slope` computes `edgeSlope (0,1) (2,0) = (0−1)/(2−0) = −1/2` by `norm_num`. `ysqMinusX_leading_exponent` then ties the combinatorial object back to the parent gallery entry: the **negation** of the edge slope, `−(−1/2) = 1/2`, equals `PuiseuxTheorem.leadingExponentFromSlope 1 2`, the parent's definition of the leading exponent of the root `x^{1/2}` of `Y² − x`. This is the concrete instance of the Newton polygon theorem (negatives of edge slopes = root valuations) and validates that this file's combinatorial layer correctly feeds the parent's algorithm — even though the general theorem awaits a valuation API on `K((x))[Y]`.",
-    "mathContext": "$-\\text{edgeSlope}((0,1),(2,0)) = -(-\\tfrac12) = \\tfrac12 = \\text{leadingExponentFromSlope}(1,2)$ — the leading exponent of the root $x^{1/2}$.",
+    "title": "Closing the Loop: Edge Slope \u2192 Leading Exponent",
+    "content": "`ysqMinusX_edge_slope` computes `edgeSlope (0,1) (2,0) = (0\u22121)/(2\u22120) = \u22121/2` by `norm_num`. `ysqMinusX_leading_exponent` then ties the combinatorial object back to the parent gallery entry: the **negation** of the edge slope, `\u2212(\u22121/2) = 1/2`, equals `PuiseuxTheorem.leadingExponentFromSlope 1 2`, the parent's definition of the leading exponent of the root `x^{1/2}` of `Y\u00b2 \u2212 x`. This is the concrete instance of the Newton polygon theorem (negatives of edge slopes = root valuations) and validates that this file's combinatorial layer correctly feeds the parent's algorithm \u2014 even though the general theorem awaits a valuation API on `K((x))[Y]`.",
+    "mathContext": "$-\\text{edgeSlope}((0,1),(2,0)) = -(-\\tfrac12) = \\tfrac12 = \\text{leadingExponentFromSlope}(1,2)$ \u2014 the leading exponent of the root $x^{1/2}$.",
     "significance": "key",
     "relatedConcepts": [
       "Newton polygon theorem",
@@ -131,7 +159,7 @@
     ],
     "prerequisites": [
       "puiseux-theorem (parent entry)",
-      "edge slope ↔ root valuation"
+      "edge slope \u2194 root valuation"
     ]
   }
 ]


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 1-64) of `PuiseuxTheoremOQ03.lean`.

Covers the OQ-03 efficiency question, the combinatorial Newton polygon and its supporting-line `IsLowerVertex` characterization, the seeded lower-vertex lemmas, the worked `Y² − x` example (slope −1/2 → leading exponent 1/2), and the honest remaining scope. Previously the first annotation started at line 70, leaving the rich overview uncovered. Pure annotation addition; ranges validated non-overlapping.

Enrichment pass by enricher-3.