### PR TITLE
Enrich Erdős #731 least non-divisor of central binomials (erdos-731): module-overview annotation

### DIFF
--- a/src/data/proofs/erdos-731/annotations.json
+++ b/src/data/proofs/erdos-731/annotations.json
@@ -1,182 +1,360 @@
 [
   {
+    "id": "ann-erdos731-overview",
+    "proofId": "erdos-731",
+    "range": {
+      "startLine": 1,
+      "endLine": 19
+    },
+    "type": "concept",
+    "title": "Overview: Erd\u0151s #731 \u2014 Least Non-Divisor of Central Binomial Coefficients",
+    "content": "Erd\u0151s Problem #731 asks for a reasonable function f(n) such that, for almost all integers n, the least integer m that does NOT divide the central binomial coefficient C(2n, n) is asymptotic to f(n). Erd\u0151s, Graham, Ruzsa and Straus (1975) answered this: for almost all n the least non-divisor m satisfies m = exp((log n)^{1/2 + o(1)}). The file formalizes the two central objects \u2014 `centralBinom n = C(2n,n)` and `leastNonDivisor m`, the least positive integer not dividing m \u2014 and organizes the number-theoretic tools behind the EGRS estimate. The key mechanism is Kummer's theorem: the exact power of a prime p dividing C(2n,n) equals the number of carries when adding n to itself in base p. Small primes almost always divide C(2n,n) (their base-p additions carry), so the least non-divisor is pushed up to a prime power of size exp(\u221alog n). The related integer sequence is OEIS A006197.",
+    "mathContext": "For the central binomial coefficient $\\binom{2n}{n}$, Kummer's theorem gives $v_p\\!\\binom{2n}{n} = $ (number of carries adding $n+n$ in base $p$), equivalently the number of indices $j$ with $\\{n/p^j\\} \\ge 1/2$. Since $\\binom{2n}{n}$ is divisible by every prime in $(n, 2n]$ and by high powers of small primes, its least non-divisor $m(n)$ is typically a prime power. EGRS (1975): for almost all $n$, $m(n) = \\exp\\!\\big((\\log n)^{1/2 + o(1)}\\big)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central-binomial-coefficient",
+      "Kummer-theorem",
+      "p-adic-valuation",
+      "least-non-divisor",
+      "Erdos-Graham-Ruzsa-Straus"
+    ],
+    "prerequisites": [
+      "central binomial coefficient C(2n,n)",
+      "p-adic valuation and Kummer's theorem",
+      "base-p digit carries",
+      "asymptotic density (almost all n)"
+    ]
+  },
+  {
     "id": "erdos-731-central-binom",
     "proofId": "erdos-731",
     "type": "definition",
-    "range": { "startLine": 27, "endLine": 28 },
+    "range": {
+      "startLine": 27,
+      "endLine": 28
+    },
     "title": "Central Binomial Coefficient",
     "content": "Defines `centralBinom n` = $\\binom{2n}{n} = (2n)!/(n!)^2$ using `Nat.choose`. This is the central entry of the $2n$-th row of Pascal's triangle, and satisfies $\\binom{2n}{n} \\sim 4^n/\\sqrt{\\pi n}$ by Stirling's approximation. Its rich divisibility structure makes it the natural object for studying non-divisors.",
     "mathContext": "$\\binom{2n}{n} = \\frac{(2n)!}{(n!)^2} \\sim \\frac{4^n}{\\sqrt{\\pi n}}$",
     "significance": "key",
-    "relatedConcepts": ["Nat.choose", "Nat.centralBinom", "Pascal's triangle", "Stirling's approximation"],
-    "prerequisites": ["binomial coefficients", "factorial"]
+    "relatedConcepts": [
+      "Nat.choose",
+      "Nat.centralBinom",
+      "Pascal's triangle",
+      "Stirling's approximation"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "factorial"
+    ]
   },
   {
     "id": "erdos-731-least-nondiv",
     "proofId": "erdos-731",
     "type": "definition",
-    "range": { "startLine": 30, "endLine": 33 },
+    "range": {
+      "startLine": 30,
+      "endLine": 33
+    },
     "title": "Least Non-Divisor",
     "content": "Defines `leastNonDivisor m` as the smallest positive integer $k$ with $k \\nmid m$, using `Nat.find` with the witness $m+1$ (since $m+1 > m$ implies $m+1 \\nmid m$ for $m > 0$). Returns 1 for $m = 0$. This is a constructive definition grounded in the well-ordering principle.",
     "mathContext": "$\\text{leastNonDivisor}(m) = \\min\\{k > 0 : k \\nmid m\\}$",
     "significance": "key",
-    "relatedConcepts": ["Nat.find", "well-ordering principle", "divisibility", "highly composite numbers"],
-    "prerequisites": ["Nat.find", "divisibility"]
+    "relatedConcepts": [
+      "Nat.find",
+      "well-ordering principle",
+      "divisibility",
+      "highly composite numbers"
+    ],
+    "prerequisites": [
+      "Nat.find",
+      "divisibility"
+    ]
   },
   {
     "id": "erdos-731-specialized",
     "proofId": "erdos-731",
     "type": "definition",
-    "range": { "startLine": 35, "endLine": 37 },
+    "range": {
+      "startLine": 35,
+      "endLine": 37
+    },
     "title": "Least Non-Divisor of C(2n,n)",
-    "content": "Defines `leastNonDivCentral n` = `leastNonDivisor (centralBinom n)`, the central object of Erdős Problem 731. This function appears as OEIS A006197. It is noncomputable because `leastNonDivisor` uses `Nat.find`.",
+    "content": "Defines `leastNonDivCentral n` = `leastNonDivisor (centralBinom n)`, the central object of Erd\u0151s Problem 731. This function appears as OEIS A006197. It is noncomputable because `leastNonDivisor` uses `Nat.find`.",
     "mathContext": "$\\text{leastNonDivCentral}(n) = \\min\\{k > 0 : k \\nmid \\binom{2n}{n}\\}$",
     "significance": "key",
-    "relatedConcepts": ["function composition", "OEIS A006197", "noncomputable"],
-    "prerequisites": ["centralBinom", "leastNonDivisor"]
+    "relatedConcepts": [
+      "function composition",
+      "OEIS A006197",
+      "noncomputable"
+    ],
+    "prerequisites": [
+      "centralBinom",
+      "leastNonDivisor"
+    ]
   },
   {
     "id": "erdos-731-conjecture",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 41, "endLine": 46 },
+    "range": {
+      "startLine": 41,
+      "endLine": 46
+    },
     "title": "EGRS Conjecture",
     "content": "Axiomatizes `erdos_731_conjecture`: for almost all $n$, the least non-divisor of $\\binom{2n}{n}$ equals $\\exp((\\log n)^{1/2+o(1)})$. Uses a placeholder `True` because the precise formulation requires asymptotic density and real analysis infrastructure. The problem asks for the exact function $f(n)$ refining this estimate.",
     "mathContext": "$\\text{leastNonDivCentral}(n) = \\exp\\bigl((\\log n)^{1/2+o(1)}\\bigr)$ for almost all $n$",
     "significance": "key",
-    "relatedConcepts": ["asymptotic density", "natural density", "o-notation", "almost all"],
-    "prerequisites": ["asymptotic analysis", "real logarithm"]
+    "relatedConcepts": [
+      "asymptotic density",
+      "natural density",
+      "o-notation",
+      "almost all"
+    ],
+    "prerequisites": [
+      "asymptotic analysis",
+      "real logarithm"
+    ]
   },
   {
     "id": "erdos-731-kummer",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 50, "endLine": 54 },
+    "range": {
+      "startLine": 50,
+      "endLine": 54
+    },
     "title": "Kummer's Theorem on Carries",
     "content": "Axiomatizes Kummer's theorem (1852): $v_p(\\binom{m+n}{m})$ equals the number of carries when adding $m$ and $n$ in base $p$. For $\\binom{2n}{n}$, this counts carries in $n + n$ in base $p$. A carry at position $i$ occurs iff the $i$-th base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$ (possibly with propagation from lower digits). Uses placeholder `True`.",
     "mathContext": "$v_p\\bigl(\\binom{m+n}{m}\\bigr) = \\text{number of carries in base-}p\\text{ addition of }m\\text{ and }n$",
     "significance": "key",
-    "relatedConcepts": ["p-adic valuation", "carries", "base-p representation", "Kummer's theorem"],
-    "prerequisites": ["p-adic valuation", "base-p digit expansion"]
+    "relatedConcepts": [
+      "p-adic valuation",
+      "carries",
+      "base-p representation",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "base-p digit expansion"
+    ]
   },
   {
     "id": "erdos-731-prime-div",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 56, "endLine": 61 },
+    "range": {
+      "startLine": 56,
+      "endLine": 61
+    },
     "title": "Prime Divisibility Criterion",
     "content": "Axiomatizes `prime_divides_central_iff`: for prime $p \\leq 2n$, $p \\mid \\binom{2n}{n}$ iff some base-$p$ digit of $n$ is $\\geq \\lceil p/2 \\rceil$. This is the key structural criterion, translating divisibility into a digit condition. The quantifier `\\exists k, (n / p^k) \\% p \\geq (p+1)/2` extracts the $k$-th base-$p$ digit of $n$.",
     "mathContext": "$p \\mid \\binom{2n}{n} \\iff \\exists k: \\lfloor n/p^k \\rfloor \\bmod p \\geq \\lceil p/2 \\rceil$",
     "significance": "key",
-    "relatedConcepts": ["digit extraction", "modular arithmetic", "Kummer's theorem", "iff characterization"],
-    "prerequisites": ["Kummer's theorem", "base-p digits"]
+    "relatedConcepts": [
+      "digit extraction",
+      "modular arithmetic",
+      "Kummer's theorem",
+      "iff characterization"
+    ],
+    "prerequisites": [
+      "Kummer's theorem",
+      "base-p digits"
+    ]
   },
   {
     "id": "erdos-731-small-primes",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 63, "endLine": 65 },
+    "range": {
+      "startLine": 63,
+      "endLine": 65
+    },
     "title": "Small Primes Divide C(2n,n)",
     "content": "Axiomatizes `small_primes_divide`: for any fixed prime $p$, $p \\mid \\binom{2n}{n}$ for all sufficiently large $n$. The probability that all $\\log_p n$ digits are small ($< \\lceil p/2 \\rceil$) is $(\\lceil p/2 \\rceil / p)^{\\log_p n} \\to 0$, so $p \\nmid \\binom{2n}{n}$ happens for only finitely many $n$ for each fixed $p$.",
     "mathContext": "$\\forall p \\text{ prime},\\; \\exists N: \\forall n \\geq N,\\; p \\mid \\binom{2n}{n}$",
     "significance": "supporting",
-    "relatedConcepts": ["density zero", "digit independence", "Borel-Cantelli lemma"],
-    "prerequisites": ["prime divisibility criterion"]
+    "relatedConcepts": [
+      "density zero",
+      "digit independence",
+      "Borel-Cantelli lemma"
+    ],
+    "prerequisites": [
+      "prime divisibility criterion"
+    ]
   },
   {
     "id": "erdos-731-even",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 67, "endLine": 68 },
+    "range": {
+      "startLine": 67,
+      "endLine": 68
+    },
     "title": "Evenness of C(2n,n)",
     "content": "Axiomatizes `two_divides_central`: $2 \\mid \\binom{2n}{n}$ for $n \\geq 1$. This is the simplest special case of Kummer's theorem: in base 2, adding $n + n$ always produces a carry at the least significant set bit of $n$. Equivalently, $\\binom{2n}{n}$ is even because $\\binom{2n}{n} = 2\\binom{2n-1}{n-1}$.",
     "mathContext": "$2 \\mid \\binom{2n}{n}$ for $n \\geq 1$",
     "significance": "supporting",
-    "relatedConcepts": ["binary representation", "Kummer's theorem base 2", "parity"],
-    "prerequisites": ["basic binomial identities"]
+    "relatedConcepts": [
+      "binary representation",
+      "Kummer's theorem base 2",
+      "parity"
+    ],
+    "prerequisites": [
+      "basic binomial identities"
+    ]
   },
   {
     "id": "erdos-731-primorial",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 70, "endLine": 73 },
+    "range": {
+      "startLine": 70,
+      "endLine": 73
+    },
     "title": "Primorial Asymptotic (PNT)",
     "content": "Axiomatizes the prime number theorem in product form: the primorial $\\prod_{p \\leq x} p = e^{x(1+o(1))}$ as $x \\to \\infty$. This is equivalent to $\\theta(x) := \\sum_{p \\leq x} \\log p \\sim x$ (Chebyshev's theta function). For this problem, it controls the product of small primes dividing $\\binom{2n}{n}$: since all primes up to $\\sim \\exp((\\log n)^{1/2})$ divide $\\binom{2n}{n}$ for most $n$, the primorial of the threshold governs the total divisor contribution.",
     "mathContext": "$\\prod_{p \\leq x} p = e^{\\theta(x)}$ where $\\theta(x) \\sim x$ by the prime number theorem",
     "significance": "supporting",
-    "relatedConcepts": ["prime number theorem", "Chebyshev theta function", "primorial", "prime product"],
-    "prerequisites": ["prime number theorem", "Chebyshev functions"]
-  },
-  {
-    "id": "erdos-731-lower-most",
-    "proofId": "erdos-731",
-    "type": "concept",
-    "range": { "startLine": 94, "endLine": 101 },
-    "title": "Lower Bound for Most n",
-    "content": "Axiomatizes `lower_bound_most_n`: for any threshold $P$, there is a positive density $D$ such that for at least a $(1 - 1/D)$ fraction of $n \\leq N$, the least non-divisor exceeds $P$. This captures the fact that small primes almost always divide $\\binom{2n}{n}$: for fixed $p$, the set of $n$ with $p \\nmid \\binom{2n}{n}$ has density $(\\lceil p/2 \\rceil / p)^{1/(\\log p)} \\to 0$, so by union bound, the least non-divisor exceeds any fixed $P$ for almost all $n$. Uses placeholder `True`.",
-    "mathContext": "$\\forall P,\\; \\exists D > 0: \\#\\{n \\leq N : \\text{leastNonDivCentral}(n) > P\\} \\geq (1 - 1/D) \\cdot N$",
-    "significance": "supporting",
-    "relatedConcepts": ["natural density", "union bound", "digit independence"],
-    "prerequisites": ["small_primes_divide", "natural density"]
-  },
-  {
-    "id": "erdos-731-egrs",
-    "proofId": "erdos-731",
-    "type": "concept",
-    "range": { "startLine": 82, "endLine": 90 },
-    "title": "EGRS Typical Behavior",
-    "content": "Axiomatizes `egrs_typical_behavior`: $\\log(\\text{leastNonDivCentral}(n))$ is within $(\\log n)^{1/2 \\pm \\varepsilon}$ for a density-1 set of $n$. The heuristic: $p \\nmid \\binom{2n}{n}$ requires all $\\sim \\log n / \\log p$ digits of $n$ in base $p$ to be small, with probability $\\sim (1/2)^{\\log n / \\log p}$. This becomes non-negligible when $\\log p \\approx (\\log n)^{1/2}$, giving the threshold. Uses placeholder `True`.",
-    "mathContext": "$(\\log n)^{1/2 - \\varepsilon} \\leq \\log(\\text{leastNonDivCentral}(n)) \\leq (\\log n)^{1/2 + \\varepsilon}$ for almost all $n$",
-    "significance": "key",
-    "relatedConcepts": ["probabilistic heuristic", "digit independence", "threshold phenomenon"],
-    "prerequisites": ["digit structure", "probability theory"]
+    "relatedConcepts": [
+      "prime number theorem",
+      "Chebyshev theta function",
+      "primorial",
+      "prime product"
+    ],
+    "prerequisites": [
+      "prime number theorem",
+      "Chebyshev functions"
+    ]
   },
   {
     "id": "erdos-731-least-prime",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 77, "endLine": 80 },
+    "range": {
+      "startLine": 77,
+      "endLine": 80
+    },
     "title": "Least Non-Divisor is Prime",
     "content": "Axiomatizes `least_nondiv_is_prime`: the least non-divisor of $\\binom{2n}{n}$ is either prime or 1. If composite $m = ab$ doesn't divide $\\binom{2n}{n}$, then either $a$ or $b$ doesn't either (since $\\binom{2n}{n}$ has rich factorization). So the first failure occurs at a prime.",
     "mathContext": "$\\text{leastNonDivCentral}(n) \\in \\{1\\} \\cup \\{p : p \\text{ prime}\\}$",
     "significance": "supporting",
-    "relatedConcepts": ["prime elements", "divisibility chains", "fundamental theorem of arithmetic"],
-    "prerequisites": ["prime factorization", "divisibility"]
+    "relatedConcepts": [
+      "prime elements",
+      "divisibility chains",
+      "fundamental theorem of arithmetic"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "erdos-731-egrs",
+    "proofId": "erdos-731",
+    "type": "concept",
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
+    "title": "EGRS Typical Behavior",
+    "content": "Axiomatizes `egrs_typical_behavior`: $\\log(\\text{leastNonDivCentral}(n))$ is within $(\\log n)^{1/2 \\pm \\varepsilon}$ for a density-1 set of $n$. The heuristic: $p \\nmid \\binom{2n}{n}$ requires all $\\sim \\log n / \\log p$ digits of $n$ in base $p$ to be small, with probability $\\sim (1/2)^{\\log n / \\log p}$. This becomes non-negligible when $\\log p \\approx (\\log n)^{1/2}$, giving the threshold. Uses placeholder `True`.",
+    "mathContext": "$(\\log n)^{1/2 - \\varepsilon} \\leq \\log(\\text{leastNonDivCentral}(n)) \\leq (\\log n)^{1/2 + \\varepsilon}$ for almost all $n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "probabilistic heuristic",
+      "digit independence",
+      "threshold phenomenon"
+    ],
+    "prerequisites": [
+      "digit structure",
+      "probability theory"
+    ]
+  },
+  {
+    "id": "erdos-731-lower-most",
+    "proofId": "erdos-731",
+    "type": "concept",
+    "range": {
+      "startLine": 94,
+      "endLine": 101
+    },
+    "title": "Lower Bound for Most n",
+    "content": "Axiomatizes `lower_bound_most_n`: for any threshold $P$, there is a positive density $D$ such that for at least a $(1 - 1/D)$ fraction of $n \\leq N$, the least non-divisor exceeds $P$. This captures the fact that small primes almost always divide $\\binom{2n}{n}$: for fixed $p$, the set of $n$ with $p \\nmid \\binom{2n}{n}$ has density $(\\lceil p/2 \\rceil / p)^{1/(\\log p)} \\to 0$, so by union bound, the least non-divisor exceeds any fixed $P$ for almost all $n$. Uses placeholder `True`.",
+    "mathContext": "$\\forall P,\\; \\exists D > 0: \\#\\{n \\leq N : \\text{leastNonDivCentral}(n) > P\\} \\geq (1 - 1/D) \\cdot N$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "natural density",
+      "union bound",
+      "digit independence"
+    ],
+    "prerequisites": [
+      "small_primes_divide",
+      "natural density"
+    ]
   },
   {
     "id": "erdos-731-upper",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 103, "endLine": 106 },
+    "range": {
+      "startLine": 103,
+      "endLine": 106
+    },
     "title": "Trivial Upper Bound",
     "content": "Axiomatizes `upper_bound_trivial`: $\\text{leastNonDivCentral}(n) \\leq 2n+1$ for $n \\geq 1$. This follows because $2n+1 > 2n$ implies $2n+1 \\nmid \\binom{2n}{n}$ when $2n+1$ is prime (it appears in $(2n+1)!/(2n)!$ but $\\binom{2n}{n}$ doesn't contain this factor).",
     "mathContext": "$\\text{leastNonDivCentral}(n) \\leq 2n+1$",
     "significance": "supporting",
-    "relatedConcepts": ["trivial bounds", "linear upper bound"],
-    "prerequisites": ["divisibility"]
+    "relatedConcepts": [
+      "trivial bounds",
+      "linear upper bound"
+    ],
+    "prerequisites": [
+      "divisibility"
+    ]
   },
   {
     "id": "erdos-731-bertrand",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 108, "endLine": 111 },
+    "range": {
+      "startLine": 108,
+      "endLine": 111
+    },
     "title": "Bertrand's Postulate Applied",
     "content": "Axiomatizes `bertrand_central`: for $n \\geq 1$, there exists a prime $p$ with $n < p \\leq 2n$ dividing $\\binom{2n}{n}$. Such a prime $p$ appears exactly once in the factorization of $(2n)!$ (in the range $(n, 2n]$) but not at all in $(n!)^2$, so $v_p(\\binom{2n}{n}) = 1$. This is the classical proof of Bertrand's postulate via central binomials.",
     "mathContext": "$\\forall n \\geq 1,\\; \\exists p \\text{ prime}: n < p \\leq 2n \\wedge p \\mid \\binom{2n}{n}$",
     "significance": "key",
-    "relatedConcepts": ["Bertrand's postulate", "Legendre's formula", "prime gaps"],
-    "prerequisites": ["Bertrand's postulate", "Legendre's formula for v_p(n!)"]
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "Legendre's formula",
+      "prime gaps"
+    ],
+    "prerequisites": [
+      "Bertrand's postulate",
+      "Legendre's formula for v_p(n!)"
+    ]
   },
   {
     "id": "erdos-731-lower-bound",
     "proofId": "erdos-731",
     "type": "concept",
-    "range": { "startLine": 113, "endLine": 115 },
+    "range": {
+      "startLine": 113,
+      "endLine": 115
+    },
     "title": "Exponential Lower Bound",
     "content": "Axiomatizes `central_binom_lower`: $\\binom{2n}{n} \\cdot (2n+1) \\geq 4^n$. This follows from the identity $\\sum_{k=0}^{2n} \\binom{2n}{k} = 4^n$ with $\\binom{2n}{n}$ being the largest term. The bound implies $\\binom{2n}{n} \\geq 4^n/(2n+1)$, showing exponential growth and hence many prime divisors.",
     "mathContext": "$\\binom{2n}{n} \\geq \\frac{4^n}{2n+1}$",
     "significance": "supporting",
-    "relatedConcepts": ["binomial sum", "exponential growth", "divisor count"],
-    "prerequisites": ["binomial theorem", "central entry is maximum"]
+    "relatedConcepts": [
+      "binomial sum",
+      "exponential growth",
+      "divisor count"
+    ],
+    "prerequisites": [
+      "binomial theorem",
+      "central entry is maximum"
+    ]
   }
 ]


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 1-19) of `Erdos731Problem.lean`: the EGRS (1975) asymptotic m ~ exp((log n)^{1/2+o(1)}), Kummer's carry criterion for p-adic valuation of C(2n,n), and the `centralBinom`/`leastNonDivisor` definitions. Previously the first annotation started at line 27. Pure annotation addition; ranges non-overlapping.

Enrichment pass by enricher-3.