### PR TITLE
Enrich Erdős #1137 consecutive prime gap products (erdos-1137): module-overview annotation

### DIFF
--- a/src/data/proofs/erdos-1137/annotations.json
+++ b/src/data/proofs/erdos-1137/annotations.json
@@ -1,5 +1,31 @@
 [
   {
+    "id": "ann-erdos1137-overview",
+    "proofId": "erdos-1137",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "concept",
+    "title": "Overview: Erd\u0151s #1137 \u2014 Consecutive Prime Gap Products",
+    "content": "Erd\u0151s Problem #1137 (from Varga's survey [Va99, \u00a71.2]) asks whether large prime gaps tend NOT to occur consecutively. Writing d_n = p_{n+1} \u2212 p_n for the n-th prime gap, the question is whether the ratio (max_{n<x} d_n\u00b7d_{n-1}) / (max_{n<x} d_n)\u00b2 tends to 0 as x \u2192 \u221e \u2014 i.e. whether the largest product of two adjacent gaps grows strictly slower than the square of the largest single gap. The problem is OPEN. The file formalizes the prime gap `primeGap n = p_{n+1} \u2212 p_n` and the running maxima of gaps and adjacent-gap products. Heuristically the answer is YES: the Hardy-Littlewood k-tuples conjecture predicts that record gaps are isolated events, so two record-sized gaps almost never land side by side. This fits the broader Cram\u00e9r and Granville frameworks, under which maximal prime gaps grow like (log p)\u00b2.",
+    "mathContext": "With $d_n = p_{n+1}-p_n$, the quantity in question is $\\displaystyle \\frac{\\max_{n<x} d_n d_{n-1}}{(\\max_{n<x} d_n)^2}$. Cram\u00e9r's conjecture asserts $\\max_{p_n<x} d_n \\sim (\\log x)^2$; Granville's refinement raises the constant. Under Hardy-Littlewood k-tuples heuristics, large gaps behave like a Poisson process of isolated extremes, so a record gap being immediately preceded or followed by another record has vanishing relative frequency, forcing the ratio $\\to 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime-gaps",
+      "Cramer-conjecture",
+      "Granville-conjecture",
+      "Hardy-Littlewood-k-tuples",
+      "analytic-number-theory"
+    ],
+    "prerequisites": [
+      "prime gaps d_n = p_{n+1}-p_n",
+      "running maxima",
+      "Cram\u00e9r's conjecture on maximal gaps",
+      "k-tuples heuristics"
+    ]
+  },
+  {
     "id": "ann-e1137-primegap",
     "proofId": "erdos-1137",
     "range": {
@@ -36,7 +62,7 @@
     "relatedConcepts": [
       "maximal prime gap",
       "Finset.sup",
-      "Cramér's conjecture"
+      "Cram\u00e9r's conjecture"
     ],
     "prerequisites": [
       "supremum over finite sets",
@@ -51,8 +77,8 @@
       "endLine": 52
     },
     "type": "definition",
-    "title": "Erdős Ratio",
-    "content": "The ratio $r(x) = \\frac{\\max_{n<x} d_n \\cdot d_{n-1}}{(\\max_{n<x} d_n)^2}$ whose limiting behavior is the subject of the conjecture. Uses ℕ subtraction at $n = 0$ (yielding $d_0 \\cdot d_0 = 1$), which doesn't affect the limit. The numerator measures how large consecutive gap products can get; the denominator normalizes by the square of the maximum gap.",
+    "title": "Erd\u0151s Ratio",
+    "content": "The ratio $r(x) = \\frac{\\max_{n<x} d_n \\cdot d_{n-1}}{(\\max_{n<x} d_n)^2}$ whose limiting behavior is the subject of the conjecture. Uses \u2115 subtraction at $n = 0$ (yielding $d_0 \\cdot d_0 = 1$), which doesn't affect the limit. The numerator measures how large consecutive gap products can get; the denominator normalizes by the square of the maximum gap.",
     "mathContext": "$r(x) = \\frac{\\max_{n < x} d_n d_{n-1}}{\\left(\\max_{n < x} d_n\\right)^2} \\in [0, 1]$",
     "significance": "key",
     "relatedConcepts": [
@@ -75,7 +101,7 @@
     },
     "type": "concept",
     "title": "Gap Positivity",
-    "content": "**Verified**: Every prime gap $d_n \\geq 1$. The proof unfolds the definition and applies `omega` to the strict inequality $p_n < p_{n+1}$ (from `StrictMono`). This is the weakest useful lower bound — the parity argument later improves it to $d_n \\geq 2$ for $n \\geq 1$.",
+    "content": "**Verified**: Every prime gap $d_n \\geq 1$. The proof unfolds the definition and applies `omega` to the strict inequality $p_n < p_{n+1}$ (from `StrictMono`). This is the weakest useful lower bound \u2014 the parity argument later improves it to $d_n \\geq 2$ for $n \\geq 1$.",
     "mathContext": "$p_{n+1} > p_n \\Rightarrow p_{n+1} - p_n \\geq 1$",
     "significance": "supporting",
     "relatedConcepts": [
@@ -118,7 +144,7 @@
       "endLine": 136
     },
     "type": "concept",
-    "title": "Gap ≥ 2 for n ≥ 1",
+    "title": "Gap \u2265 2 for n \u2265 1",
     "content": "**Verified**: For $n \\geq 1$, the prime gap $d_n \\geq 2$. Combines the parity result ($d_n$ is even, so $d_n = 2k$ for some $k$) with positivity ($d_n \\geq 1$, so $k \\geq 1$), yielding $d_n \\geq 2$. This is tight: $d_1 = d_2 = 2$ (twin prime gaps).",
     "mathContext": "$d_n \\text{ even} \\wedge d_n \\geq 1 \\Rightarrow d_n \\geq 2$",
     "significance": "supporting",
@@ -142,11 +168,11 @@
     },
     "type": "concept",
     "title": "Main Conjecture (Axiom)",
-    "content": "**Axiom (OPEN)**: The ratio $\\max_{n<x} d_n d_{n-1} / (\\max_{n<x} d_n)^2 \\to 0$ as $x \\to \\infty$. Stated using `Filter.Tendsto` with target `𝓝 0`. This is the central claim of the problem: record-breaking prime gaps should not appear in consecutive pairs. The conjecture is consistent with the Cramér–Granville probabilistic model of prime distribution and supported by extensive computation.",
+    "content": "**Axiom (OPEN)**: The ratio $\\max_{n<x} d_n d_{n-1} / (\\max_{n<x} d_n)^2 \\to 0$ as $x \\to \\infty$. Stated using `Filter.Tendsto` with target `\ud835\udcdd 0`. This is the central claim of the problem: record-breaking prime gaps should not appear in consecutive pairs. The conjecture is consistent with the Cram\u00e9r\u2013Granville probabilistic model of prime distribution and supported by extensive computation.",
     "mathContext": "$\\text{Tendsto}\\left(x \\mapsto \\frac{\\sup_{n<x} d_n d_{n-1}}{(\\sup_{n<x} d_n)^2}\\right)\\; \\text{atTop}\\; (\\mathcal{N}(0))$",
     "significance": "key",
     "relatedConcepts": [
-      "Cramér's conjecture",
+      "Cram\u00e9r's conjecture",
       "Granville's model",
       "prime gap distribution",
       "Filter.Tendsto"


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 1-24) of the Erdős #1137 Lean file: the Varga/Erdős question on whether large prime gaps avoid occurring consecutively, the Cramér/Granville framework, and the Hardy-Littlewood k-tuples heuristic. Previously the first annotation started at line 35. Pure annotation addition; ranges non-overlapping.

Enrichment pass by enricher-3.