### PR TITLE
Enrich Erdős #40 representation function (erdos-40): module-overview annotation

### DIFF
--- a/src/data/proofs/erdos-40/annotations.json
+++ b/src/data/proofs/erdos-40/annotations.json
@@ -1,5 +1,31 @@
 [
   {
+    "id": "ann-erdos40-overview",
+    "proofId": "erdos-40",
+    "range": {
+      "startLine": 1,
+      "endLine": 19
+    },
+    "type": "concept",
+    "title": "Overview: Erd\u0151s #40 \u2014 Representation Function and Dense Sets",
+    "content": "Erd\u0151s Problem #40 (a $500 problem) asks: for which growth functions g(N) \u2192 \u221e does the density bound |A \u2229 {1,...,N}| \u226b N^{1/2}/g(N) force the representation function to be unbounded, limsup_n r_A(n) = \u221e? Here r_A(n) = |{(a,b) \u2208 A\u00b2 : a+b = n}| counts the ways to write n as an ordered sum of two elements of A. This is a quantitative strengthening of the Erd\u0151s-Tur\u00e1n conjecture (Problem #28): every additive basis of order 2 has unbounded representation function. A positive answer for ANY single g(N) \u2192 \u221e would already imply Problem #28. The file formalizes the representation count `repCount`, the counting function `countingFn = |A \u2229 {1,...,N}|`, and the additive-basis-of-order-2 predicate; the conjecture itself is open.",
+    "mathContext": "For $A \\subseteq \\mathbb{N}$, the representation function is $r_A(n) = \\#\\{(a,b) \\in A^2 : a+b=n\\}$ (here counted with $a \\le b$). The threshold $N^{1/2}$ is natural: a set with $r_A(n)$ bounded by $B$ can have at most $\\sim \\sqrt{BN}$ elements in $\\{1,\\dots,N\\}$, so density above $\\sqrt N$ heuristically forces representations to pile up. Erd\u0151s-Tur\u00e1n (Problem #28): if $A$ is a basis of order 2 (every large $n$ has $r_A(n) \\ge 1$) then $\\limsup r_A(n) = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "representation-function",
+      "additive-basis",
+      "Erdos-Turan-conjecture",
+      "Sidon-set",
+      "additive-combinatorics"
+    ],
+    "prerequisites": [
+      "representation function r_A(n)",
+      "additive basis of order 2",
+      "set density in {1,...,N}",
+      "limsup"
+    ]
+  },
+  {
     "id": "ann-40-imports",
     "proofId": "erdos-40",
     "range": {
@@ -30,7 +56,7 @@
     },
     "type": "definition",
     "title": "Representation Count $r_A(n)$",
-    "content": "The number of ways to write $n = a + b$ with $a, b \\in A$ and $a \\leq b$. This is the sumset representation function, central to additive combinatorics. The ordering $a \\leq b$ avoids double-counting. For an additive basis, $r_A(n) \\geq 1$ for all large $n$. Erdős and Turán conjectured (1941) that $\\limsup r_A(n) = \\infty$ for every basis.",
+    "content": "The number of ways to write $n = a + b$ with $a, b \\in A$ and $a \\leq b$. This is the sumset representation function, central to additive combinatorics. The ordering $a \\leq b$ avoids double-counting. For an additive basis, $r_A(n) \\geq 1$ for all large $n$. Erd\u0151s and Tur\u00e1n conjectured (1941) that $\\limsup r_A(n) = \\infty$ for every basis.",
     "mathContext": "$r_A(n) = |\\{(a,b) \\in A^2 : a \\leq b,\\; a + b = n\\}|$. Equivalently, $r_A(n) = \\frac{1}{2}(R_A(n) + \\chi_A(n/2))$ where $R_A(n) = |\\{(a,b) \\in A^2 : a + b = n\\}|$.",
     "significance": "key",
     "relatedConcepts": [
@@ -98,7 +124,7 @@
     },
     "type": "definition",
     "title": "Unbounded Representation Function",
-    "content": "The property $\\limsup_{n \\to \\infty} r_A(n) = \\infty$, formalized as: for every $M$, there exists $n$ with $r_A(n) \\geq M$. This is the conclusion that both Problem #28 and Problem #40 aim to establish. Note that this is weaker than $\\lim r_A(n) = \\infty$ — it allows $r_A(n)$ to fluctuate.",
+    "content": "The property $\\limsup_{n \\to \\infty} r_A(n) = \\infty$, formalized as: for every $M$, there exists $n$ with $r_A(n) \\geq M$. This is the conclusion that both Problem #28 and Problem #40 aim to establish. Note that this is weaker than $\\lim r_A(n) = \\infty$ \u2014 it allows $r_A(n)$ to fluctuate.",
     "mathContext": "$\\forall M \\in \\mathbb{N},\\; \\exists n \\in \\mathbb{N},\\; r_A(n) \\geq M$.",
     "significance": "key",
     "relatedConcepts": [
@@ -119,13 +145,13 @@
       "endLine": 53
     },
     "type": "concept",
-    "title": "Erdős-Turan Conjecture (Problem #28)",
-    "content": "Every additive basis of order 2 has $\\limsup r_A(n) = \\infty$. This 1941 conjecture by Erdős and Pál Turán is one of the most famous open problems in additive combinatorics. It asserts that being an additive basis forces the representation function to be unbounded. The conjecture has been verified for structured sets but remains open in general.",
+    "title": "Erd\u0151s-Turan Conjecture (Problem #28)",
+    "content": "Every additive basis of order 2 has $\\limsup r_A(n) = \\infty$. This 1941 conjecture by Erd\u0151s and P\u00e1l Tur\u00e1n is one of the most famous open problems in additive combinatorics. It asserts that being an additive basis forces the representation function to be unbounded. The conjecture has been verified for structured sets but remains open in general.",
     "mathContext": "$\\forall A \\subseteq \\mathbb{N},\\; A \\text{ is a basis of order 2} \\Rightarrow \\limsup r_A(n) = \\infty$.",
     "significance": "key",
     "relatedConcepts": [
       "erdos-28",
-      "Erdős-Turán conjecture",
+      "Erd\u0151s-Tur\u00e1n conjecture",
       "additive bases"
     ],
     "prerequisites": [
@@ -164,18 +190,18 @@
     },
     "type": "concept",
     "title": "Problem #40: Strongest Form ($500 Bounty)",
-    "content": "The strongest form of Problem #40: for ALL functions $g(N) \\to \\infty$, the density condition $A(N) \\gg \\sqrt{N}/g(N)$ implies $\\limsup r_A(n) = \\infty$. This is strictly stronger than the Erdős-Turán conjecture. Erdős offered $500 for a solution. The conjecture quantifies over all divergent $g$, making it a statement about the minimal density threshold for unbounded representations.",
+    "content": "The strongest form of Problem #40: for ALL functions $g(N) \\to \\infty$, the density condition $A(N) \\gg \\sqrt{N}/g(N)$ implies $\\limsup r_A(n) = \\infty$. This is strictly stronger than the Erd\u0151s-Tur\u00e1n conjecture. Erd\u0151s offered $500 for a solution. The conjecture quantifies over all divergent $g$, making it a statement about the minimal density threshold for unbounded representations.",
     "mathContext": "$\\forall g : \\mathbb{N} \\to \\mathbb{R},\\; g(N) \\to \\infty \\Rightarrow \\left(A(N) \\gg \\frac{\\sqrt{N}}{g(N)} \\Rightarrow \\limsup r_A(n) = \\infty\\right)$.",
     "significance": "key",
     "relatedConcepts": [
-      "Erdős bounty problems",
+      "Erd\u0151s bounty problems",
       "density thresholds",
       "additive combinatorics conjectures"
     ],
     "prerequisites": [
       "density condition",
       "representation function",
-      "Erdős-Turán conjecture"
+      "Erd\u0151s-Tur\u00e1n conjecture"
     ]
   },
   {
@@ -187,7 +213,7 @@
     },
     "type": "concept",
     "title": "Problem #40 Implies Problem #28",
-    "content": "If Problem #40 holds for ANY $g \\to \\infty$, then the Erdős-Turán conjecture follows. An additive basis of order 2 has $A(N) \\geq c\\sqrt{N}$ (since $A + A$ must cover $\\{1, \\ldots, 2N\\}$, requiring $|A|^2/2 \\geq N$). Choosing any divergent $g$ then places the basis within Problem #40's scope.",
+    "content": "If Problem #40 holds for ANY $g \\to \\infty$, then the Erd\u0151s-Tur\u00e1n conjecture follows. An additive basis of order 2 has $A(N) \\geq c\\sqrt{N}$ (since $A + A$ must cover $\\{1, \\ldots, 2N\\}$, requiring $|A|^2/2 \\geq N$). Choosing any divergent $g$ then places the basis within Problem #40's scope.",
     "mathContext": "$\\text{Problem 40} \\Rightarrow \\text{Problem 28}$. The key: basis density $A(N) \\geq c\\sqrt{N} \\geq c\\sqrt{N}/g(N)$ for any $g \\to \\infty$.",
     "significance": "key",
     "relatedConcepts": [
@@ -209,13 +235,13 @@
     },
     "type": "concept",
     "title": "Sidon Set Density Bound",
-    "content": "If $r_A(n) \\leq 1$ for all $n$ ($A$ is a Sidon or $B_2$ set), then $A(N) \\leq (1+o(1))\\sqrt{N}$. This classical result (Erdős-Turán 1941, sharp constant by Lindström 1969) shows $\\sqrt{N}$ is the natural threshold: Sidon sets have bounded representation and sit exactly at this density. The proof counts pairs: all $\\binom{|A|}{2}$ pairwise sums are distinct, so $\\binom{|A|}{2} \\leq 2N$.",
+    "content": "If $r_A(n) \\leq 1$ for all $n$ ($A$ is a Sidon or $B_2$ set), then $A(N) \\leq (1+o(1))\\sqrt{N}$. This classical result (Erd\u0151s-Tur\u00e1n 1941, sharp constant by Lindstr\u00f6m 1969) shows $\\sqrt{N}$ is the natural threshold: Sidon sets have bounded representation and sit exactly at this density. The proof counts pairs: all $\\binom{|A|}{2}$ pairwise sums are distinct, so $\\binom{|A|}{2} \\leq 2N$.",
     "mathContext": "$r_A(n) \\leq 1 \\;\\forall n \\Rightarrow |A \\cap [1,N]| \\leq (1+o(1))\\sqrt{N}$. Proof: $\\binom{|A|}{2} \\leq 2N$.",
     "significance": "key",
     "relatedConcepts": [
       "Sidon sets",
       "B_2 sets",
-      "Lindström's theorem",
+      "Lindstr\u00f6m's theorem",
       "pairwise distinct sums"
     ],
     "prerequisites": [


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 1-19) of the Erdős #40 Lean file: the $500 density-threshold question, the representation function r_A(n), and the strengthening of the Erdős-Turán conjecture (Problem #28). Previously the first annotation started at line 22. Pure annotation addition; ranges non-overlapping.

Enrichment pass by enricher-3.