### PR TITLE
Enrich Constructive Borsuk-Ulam (borsuk-ulam-oq-03): module-overview annotation

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-03/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/annotations.json
@@ -1,5 +1,32 @@
 [
   {
+    "id": "ann-buoq03-overview",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Overview: Constructive Borsuk-Ulam (borsuk-ulam-oq-03)",
+    "content": "This file addresses open question OQ-03 for the Borsuk-Ulam theorem: can the theorem be proved constructively (intuitionistically), without full classical logic? The answer splits by dimension. In 1D it is YES \u2014 a continuous f : [\u22121,1] \u2192 \u211d has an antipodal pair f(x) = f(\u2212x), proved via the Intermediate Value Theorem applied to the antisymmetric difference g(x) = f(x) \u2212 f(\u2212x), which has opposite signs at \u00b11 and hence a zero. In Bishop-style constructive analysis the IVT holds with a modulus of continuity, so the 1D result is constructively valid (even though Mathlib's IVT uses Classical.em internally). In dimension n \u2265 2, constructivity fails without heavy infrastructure: classical proofs invoke the Brouwer degree, homology, or integration, so the file axiomatizes the higher-dimensional case. The file proves the 1D interval version, the odd-function-zero lemma, the 1D circle (S\u00b9) version via trigonometric parametrization, the no-retraction corollary, and the equivalence between 1D Borsuk-Ulam and the odd-function-zero statement. Sibling questions OQ-01 (computational complexity of approximate antipodal pairs) and OQ-02 (equivariant extensions) are handled in separate files.",
+    "mathContext": "1D Borsuk-Ulam: for continuous $f:[-1,1]\\to\\mathbb{R}$, $\\exists x$ with $f(x)=f(-x)$. Proof: $g(x)=f(x)-f(-x)$ is odd, so $g(-1)=-g(1)$; the IVT yields $x_0$ with $g(x_0)=0$. Constructively (Bishop), the IVT requires a modulus of continuity but then holds, so the 1D statement is intuitionistically valid. The general Borsuk-Ulam ($S^n\\to\\mathbb{R}^n$ has an antipodal pair with equal image) for $n\\ge 2$ rests on the non-existence of an odd map $S^n\\to S^{n-1}$, proved via $\\mathbb{Z}/2$ cohomology or Brouwer degree \u2014 non-constructive with current tools.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Borsuk-Ulam-theorem",
+      "intermediate-value-theorem",
+      "constructive-analysis",
+      "Bishop-analysis",
+      "antipodal-pair",
+      "Brouwer-degree"
+    ],
+    "prerequisites": [
+      "Intermediate Value Theorem",
+      "continuous functions on intervals",
+      "odd/antisymmetric functions",
+      "constructive vs classical logic"
+    ]
+  },
+  {
     "id": "ann-bu-oq03-01-interval-bu",
     "proofId": "borsuk-ulam-oq-03",
     "range": {
@@ -8,7 +35,7 @@
     },
     "type": "concept",
     "title": "1D Borsuk-Ulam via IVT on Antisymmetric Difference",
-    "content": "borsuk_ulam_interval proves ∃ x ∈ [-1,1], f(x)=f(-x) for continuous f. The proof defines g(x)=f(x)-f(-x), observes g(-1)=-g(1) (antisymmetry), then case-splits on the sign of g(-1). In each case, IVT (intermediate_value_Icc or intermediate_value_Icc') gives a zero of g in [-1,1], and g(x₀)=0 means f(x₀)=f(-x₀). The continuity of g follows from hf.sub (hf.comp continuous_neg).",
+    "content": "borsuk_ulam_interval proves \u2203 x \u2208 [-1,1], f(x)=f(-x) for continuous f. The proof defines g(x)=f(x)-f(-x), observes g(-1)=-g(1) (antisymmetry), then case-splits on the sign of g(-1). In each case, IVT (intermediate_value_Icc or intermediate_value_Icc') gives a zero of g in [-1,1], and g(x\u2080)=0 means f(x\u2080)=f(-x\u2080). The continuity of g follows from hf.sub (hf.comp continuous_neg).",
     "mathContext": "$g(x) = f(x) - f(-x)$, $g(-1) = -g(1)$. IVT on $g$: $g(-1) \\leq 0 \\leq g(1)$ or $g(1) \\leq 0 \\leq g(-1)$ gives zero.",
     "significance": "key",
     "relatedConcepts": [
@@ -31,7 +58,7 @@
     },
     "type": "concept",
     "title": "Circle S^1 Borsuk-Ulam via Trigonometric Parametrization",
-    "content": "borsuk_ulam_circle_param proves the circle version: for continuous f: ℝ²→ℝ, ∃ θ ∈ [0,π] with f(cosθ,sinθ)=f(-cosθ,-sinθ). The proof parametrizes S^1 by θ ∈ [0,π], defines g(θ)=f(cosθ,sinθ)-f(-cosθ,-sinθ), shows g(π)=-g(0) using cos(π)=-1, sin(π)=0, cos(0)=1, sin(0)=0, then applies IVT on [0,π]. Continuity is handled by fun_prop.",
+    "content": "borsuk_ulam_circle_param proves the circle version: for continuous f: \u211d\u00b2\u2192\u211d, \u2203 \u03b8 \u2208 [0,\u03c0] with f(cos\u03b8,sin\u03b8)=f(-cos\u03b8,-sin\u03b8). The proof parametrizes S^1 by \u03b8 \u2208 [0,\u03c0], defines g(\u03b8)=f(cos\u03b8,sin\u03b8)-f(-cos\u03b8,-sin\u03b8), shows g(\u03c0)=-g(0) using cos(\u03c0)=-1, sin(\u03c0)=0, cos(0)=1, sin(0)=0, then applies IVT on [0,\u03c0]. Continuity is handled by fun_prop.",
     "mathContext": "$g(\\theta) = f(\\cos\\theta,\\sin\\theta) - f(-\\cos\\theta,-\\sin\\theta)$. $g(\\pi) = f(-1,0) - f(1,0) = -g(0)$. IVT gives zero.",
     "significance": "key",
     "relatedConcepts": [
@@ -47,26 +74,45 @@
     ]
   },
   {
-    "id": "ann-bu-oq03-03-tucker",
+    "id": "ann-bu-oq03-05-no-retraction",
     "proofId": "borsuk-ulam-oq-03",
     "range": {
-      "startLine": 470,
-      "endLine": 479
+      "startLine": 224,
+      "endLine": 229
     },
     "type": "concept",
-    "title": "Tucker's 1D Combinatorial Lemma via Fin.induction",
-    "content": "tucker_1d_sign_change proves the discrete BU: any Boolean sequence s: Fin(n+2)→Bool with s(0)≠s(last) has adjacent indices i where s(i)≠s(i+1). The proof is by contradiction: if all adjacent pairs agree, Fin.induction shows s is constant (s(i)=s(0) for all i), contradicting the endpoint hypothesis. The key Lean technique is Fin.induction with the recursive step (h i).symm.trans ih.",
-    "mathContext": "Tucker 1D: $s_0 \\neq s_{n+1}$ and $\\forall i: s_i = s_{i+1}$ is contradictory (Fin.induction shows $s$ constant).",
-    "significance": "key",
+    "title": "No Odd Continuous Map to {\u00b11} (1D No-Retraction)",
+    "content": "no_odd_map_to_pm_one proves there is no continuous odd function f: \u211d\u2192{1,-1}. By odd_continuous_has_zero, f has a zero in [-1,1], but f only takes values \u00b11, giving the contradiction 0=1 or 0=-1. This is the 1D analog of the no-retraction theorem: S^0={\u00b11} is not a retract of [-1,1] via odd maps.",
+    "mathContext": "If $f$ continuous, $f(x) \\in \\{\\pm 1\\}$, and $f(-x) = -f(x)$, then $\\exists x_0: f(x_0)=0$ (by BU), contradicting $f(x_0) \\in \\{\\pm 1\\}$.",
+    "significance": "supporting",
     "relatedConcepts": [
-      "Fin.induction",
-      "tucker_1d_iff_constant",
-      "tucker_1d_holds"
+      "odd_continuous_has_zero",
+      "borsuk_ulam_interval"
     ],
     "prerequisites": [
-      "Fin.induction",
-      "Fin.castSucc",
-      "Fin.last"
+      "odd_continuous_has_zero"
+    ]
+  },
+  {
+    "id": "ann-bu-oq03-07-structural-properties",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 232,
+      "endLine": 260
+    },
+    "type": "concept",
+    "title": "Structural Properties of Antipodal Pairs",
+    "content": "Section VI establishes algebraic closure properties of antipodal pairs: symmetry (if f(x)=f(-x) then f(-x)=f(x)), the antipodal value equals the average, and preservation under sums and scalar multiples. These formalize the algebraic structure that makes BU useful in applications \u2014 the set of functions with antipodal pairs at a given point forms an additive subspace of the function space.",
+    "mathContext": "If $f(x) = f(-x)$ and $h(x) = h(-x)$, then $(f+h)(x) = f(x)+h(x) = f(-x)+h(-x) = (f+h)(-x)$. The antipodal set $\\{f : f(x_0) = f(-x_0)\\}$ is a linear subspace.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antipodal pairs",
+      "linear subspace",
+      "algebraic closure"
+    ],
+    "prerequisites": [
+      "basic algebra",
+      "function spaces"
     ]
   },
   {
@@ -78,7 +124,7 @@
     },
     "type": "concept",
     "title": "1D Brouwer Fixed-Point Theorem (Independent Proof)",
-    "content": "brouwer_fixed_point_1d proves every continuous f: [-1,1]→[-1,1] has a fixed point. The proof defines g(x)=f(x)-x, observes g(-1)=f(-1)+1≥0 (since f(-1)≥-1) and g(1)=f(1)-1≤0 (since f(1)≤1), then IVT gives x₀ with g(x₀)=0, i.e., f(x₀)=x₀. This is independent of Borsuk-Ulam, demonstrating IVT as a general tool for 1D fixed-point theory.",
+    "content": "brouwer_fixed_point_1d proves every continuous f: [-1,1]\u2192[-1,1] has a fixed point. The proof defines g(x)=f(x)-x, observes g(-1)=f(-1)+1\u22650 (since f(-1)\u2265-1) and g(1)=f(1)-1\u22640 (since f(1)\u22641), then IVT gives x\u2080 with g(x\u2080)=0, i.e., f(x\u2080)=x\u2080. This is independent of Borsuk-Ulam, demonstrating IVT as a general tool for 1D fixed-point theory.",
     "mathContext": "$g(x) = f(x) - x$. $g(-1) \\geq 0$ and $g(1) \\leq 0$ (from $f: [-1,1] \\to [-1,1]$). IVT gives fixed point.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -91,48 +137,26 @@
     ]
   },
   {
-    "id": "ann-bu-oq03-05-no-retraction",
+    "id": "ann-bu-oq03-03-tucker",
     "proofId": "borsuk-ulam-oq-03",
     "range": {
-      "startLine": 224,
-      "endLine": 229
+      "startLine": 470,
+      "endLine": 479
     },
     "type": "concept",
-    "title": "No Odd Continuous Map to {±1} (1D No-Retraction)",
-    "content": "no_odd_map_to_pm_one proves there is no continuous odd function f: ℝ→{1,-1}. By odd_continuous_has_zero, f has a zero in [-1,1], but f only takes values ±1, giving the contradiction 0=1 or 0=-1. This is the 1D analog of the no-retraction theorem: S^0={±1} is not a retract of [-1,1] via odd maps.",
-    "mathContext": "If $f$ continuous, $f(x) \\in \\{\\pm 1\\}$, and $f(-x) = -f(x)$, then $\\exists x_0: f(x_0)=0$ (by BU), contradicting $f(x_0) \\in \\{\\pm 1\\}$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "odd_continuous_has_zero",
-      "borsuk_ulam_interval"
-    ],
-    "prerequisites": [
-      "odd_continuous_has_zero"
-    ]
-  },
-  {
-    "id": "ann-bu-oq03-06-axiom-reduction",
-    "proofId": "borsuk-ulam-oq-03",
-    "range": {
-      "startLine": 3300,
-      "endLine": 3317
-    },
-    "type": "concept",
-    "title": "Axiom Reduction: 4 Axioms Collapse to 1 Independent Axiom",
-    "content": "The axiom reduction chain is the architectural centerpiece of the formalization. Starting with 4 declared axioms (borsuk_ulam_general, no_retraction, brouwer_fixed_point, lusternik_schnirelmann), the file proves 3 are redundant: BU → no_retraction via hemisphere folding and radial extension, no_retraction → Brouwer FP via ball projection and ray-sphere retraction, and BU → LS via the infDist technique. The single remaining independent axiom borsuk_ulam_general requires algebraic topology (Brouwer degree or homology) for its proof, which is not yet available in Mathlib. This reduction demonstrates that all major fixed-point and covering theorems in this family are logically equivalent.",
-    "mathContext": "The equivalence chain: $\\text{BU} \\Rightarrow \\text{no-retraction} \\Rightarrow \\text{Brouwer FP}$ and $\\text{BU} \\Rightarrow \\text{LS}$. Conversely, no-retraction $\\Rightarrow$ BU and Brouwer FP $\\Rightarrow$ no-retraction, closing the cycle. The 1D cases are all provable from IVT alone (no axioms needed).",
+    "title": "Tucker's 1D Combinatorial Lemma via Fin.induction",
+    "content": "tucker_1d_sign_change proves the discrete BU: any Boolean sequence s: Fin(n+2)\u2192Bool with s(0)\u2260s(last) has adjacent indices i where s(i)\u2260s(i+1). The proof is by contradiction: if all adjacent pairs agree, Fin.induction shows s is constant (s(i)=s(0) for all i), contradicting the endpoint hypothesis. The key Lean technique is Fin.induction with the recursive step (h i).symm.trans ih.",
+    "mathContext": "Tucker 1D: $s_0 \\neq s_{n+1}$ and $\\forall i: s_i = s_{i+1}$ is contradictory (Fin.induction shows $s$ constant).",
     "significance": "key",
     "relatedConcepts": [
-      "axiom independence",
-      "theorem equivalence",
-      "algebraic topology",
-      "Brouwer degree"
+      "Fin.induction",
+      "tucker_1d_iff_constant",
+      "tucker_1d_holds"
     ],
     "prerequisites": [
-      "Borsuk-Ulam theorem",
-      "no-retraction theorem",
-      "Brouwer fixed-point theorem",
-      "Lusternik-Schnirelmann covering"
+      "Fin.induction",
+      "Fin.castSucc",
+      "Fin.last"
     ]
   },
   {
@@ -167,7 +191,7 @@
     },
     "type": "insight",
     "title": "Tucker's Parity Lemma: Sign Changes as Topological Invariant",
-    "content": "The parity lemma strengthens Tucker: not only does a sign change exist, but the NUMBER of sign changes has the same parity as the endpoint comparison. When endpoints differ ($s(0) \\neq s(n)$), the transition count is odd — hence at least 1. This is the combinatorial analog of the topological fact that the degree of the antipodal map on $S^0$ is odd. The proof uses induction on $n$ with exhaustive Boolean case analysis (8 cases for $a, b, c \\in \\{\\text{true}, \\text{false}\\}$) handled by Lean's `decide` tactic.",
+    "content": "The parity lemma strengthens Tucker: not only does a sign change exist, but the NUMBER of sign changes has the same parity as the endpoint comparison. When endpoints differ ($s(0) \\neq s(n)$), the transition count is odd \u2014 hence at least 1. This is the combinatorial analog of the topological fact that the degree of the antipodal map on $S^0$ is odd. The proof uses induction on $n$ with exhaustive Boolean case analysis (8 cases for $a, b, c \\in \\{\\text{true}, \\text{false}\\}$) handled by Lean's `decide` tactic.",
     "mathContext": "$\\#\\{i : s(i) \\neq s(i+1)\\} \\equiv \\begin{cases} 0 \\pmod{2} & \\text{if } s(0) = s(n) \\\\ 1 \\pmod{2} & \\text{if } s(0) \\neq s(n) \\end{cases}$",
     "significance": "key",
     "relatedConcepts": [
@@ -190,8 +214,8 @@
       "endLine": 2049
     },
     "type": "insight",
-    "title": "BU ↔ Brouwer FP Equivalence in 1D",
-    "content": "The logical equivalence of Borsuk-Ulam and Brouwer's Fixed Point theorem in 1D is proved in both directions. BU → Brouwer: given $f: [-1,1] \\to [-1,1]$, define $h(x) = f(x) - x$. Then $h(-1) \\geq 0$ (since $f(-1) \\geq -1$) and $h(1) \\leq 0$ (since $f(1) \\leq 1$), so IVT gives a zero $x_0$ with $f(x_0) = x_0$. Brouwer → BU: in 1D both reduce to IVT, so the reverse direction is immediate. In higher dimensions, the equivalence passes through the no-retraction theorem, forming a cycle BU → no-retraction → Brouwer FP → BU.",
+    "title": "BU \u2194 Brouwer FP Equivalence in 1D",
+    "content": "The logical equivalence of Borsuk-Ulam and Brouwer's Fixed Point theorem in 1D is proved in both directions. BU \u2192 Brouwer: given $f: [-1,1] \\to [-1,1]$, define $h(x) = f(x) - x$. Then $h(-1) \\geq 0$ (since $f(-1) \\geq -1$) and $h(1) \\leq 0$ (since $f(1) \\leq 1$), so IVT gives a zero $x_0$ with $f(x_0) = x_0$. Brouwer \u2192 BU: in 1D both reduce to IVT, so the reverse direction is immediate. In higher dimensions, the equivalence passes through the no-retraction theorem, forming a cycle BU \u2192 no-retraction \u2192 Brouwer FP \u2192 BU.",
     "mathContext": "BU$_1 \\Leftrightarrow$ Brouwer$_1$: both are IVT. For $n \\geq 2$: BU$_n \\Rightarrow$ no-retraction$_n \\Rightarrow$ Brouwer$_n$ and Brouwer$_n \\Rightarrow$ no-retraction$_n \\Rightarrow$ BU$_n$.",
     "significance": "key",
     "relatedConcepts": [
@@ -230,6 +254,31 @@
     ]
   },
   {
+    "id": "ann-bu-oq03-06-axiom-reduction",
+    "proofId": "borsuk-ulam-oq-03",
+    "range": {
+      "startLine": 3300,
+      "endLine": 3317
+    },
+    "type": "concept",
+    "title": "Axiom Reduction: 4 Axioms Collapse to 1 Independent Axiom",
+    "content": "The axiom reduction chain is the architectural centerpiece of the formalization. Starting with 4 declared axioms (borsuk_ulam_general, no_retraction, brouwer_fixed_point, lusternik_schnirelmann), the file proves 3 are redundant: BU \u2192 no_retraction via hemisphere folding and radial extension, no_retraction \u2192 Brouwer FP via ball projection and ray-sphere retraction, and BU \u2192 LS via the infDist technique. The single remaining independent axiom borsuk_ulam_general requires algebraic topology (Brouwer degree or homology) for its proof, which is not yet available in Mathlib. This reduction demonstrates that all major fixed-point and covering theorems in this family are logically equivalent.",
+    "mathContext": "The equivalence chain: $\\text{BU} \\Rightarrow \\text{no-retraction} \\Rightarrow \\text{Brouwer FP}$ and $\\text{BU} \\Rightarrow \\text{LS}$. Conversely, no-retraction $\\Rightarrow$ BU and Brouwer FP $\\Rightarrow$ no-retraction, closing the cycle. The 1D cases are all provable from IVT alone (no axioms needed).",
+    "significance": "key",
+    "relatedConcepts": [
+      "axiom independence",
+      "theorem equivalence",
+      "algebraic topology",
+      "Brouwer degree"
+    ],
+    "prerequisites": [
+      "Borsuk-Ulam theorem",
+      "no-retraction theorem",
+      "Brouwer fixed-point theorem",
+      "Lusternik-Schnirelmann covering"
+    ]
+  },
+  {
     "id": "ann-bu-oq03-12-ray-sphere",
     "proofId": "borsuk-ulam-oq-03",
     "range": {
@@ -237,7 +286,7 @@
       "endLine": 3578
     },
     "type": "concept",
-    "title": "Ray-Sphere Intersection: No-Retraction → Brouwer FP Architecture",
+    "title": "Ray-Sphere Intersection: No-Retraction \u2192 Brouwer FP Architecture",
     "content": "The proof that no-retraction implies Brouwer FP uses the ray-sphere intersection technique: given $f: B^{n+1} \\to B^{n+1}$ with no fixed point, define the ray from $f(x)$ through $x$ and intersect it with $S^n$. This gives a retraction $r: B^{n+1} \\to S^n$ that fixes $S^n$ (since on the sphere, the retraction parameter $t = 1$ makes $r(x) = f(x) + 1 \\cdot (x - f(x)) = x$). The construction uses the quadratic formula for ray-sphere intersection: solve $|f(x) + t(x - f(x))|^2 = 1$ for $t$ via the discriminant $\\Delta = (A + B)^2 \\geq 0$ where $A = |x - f(x)|^2$ and $B = \\langle f(x), x - f(x) \\rangle$.",
     "mathContext": "Retraction: $r(x) = f(x) + t_+(x) \\cdot (x - f(x))$ where $t_+ = \\frac{-B + \\sqrt{B^2 - AC}}{A}$, $A = |d|^2$, $B = \\langle a, d \\rangle$, $C = |a|^2 - 1$, $a = f(x)$, $d = x - f(x)$.",
     "significance": "key",
@@ -252,28 +301,6 @@
       "ip (inner product)",
       "Real.sqrt",
       "div_eq_iff"
-    ]
-  },
-  {
-    "id": "ann-bu-oq03-07-structural-properties",
-    "proofId": "borsuk-ulam-oq-03",
-    "range": {
-      "startLine": 232,
-      "endLine": 260
-    },
-    "type": "concept",
-    "title": "Structural Properties of Antipodal Pairs",
-    "content": "Section VI establishes algebraic closure properties of antipodal pairs: symmetry (if f(x)=f(-x) then f(-x)=f(x)), the antipodal value equals the average, and preservation under sums and scalar multiples. These formalize the algebraic structure that makes BU useful in applications — the set of functions with antipodal pairs at a given point forms an additive subspace of the function space.",
-    "mathContext": "If $f(x) = f(-x)$ and $h(x) = h(-x)$, then $(f+h)(x) = f(x)+h(x) = f(-x)+h(-x) = (f+h)(-x)$. The antipodal set $\\{f : f(x_0) = f(-x_0)\\}$ is a linear subspace.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "antipodal pairs",
-      "linear subspace",
-      "algebraic closure"
-    ],
-    "prerequisites": [
-      "basic algebra",
-      "function spaces"
     ]
   }
 ]


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 3-58) of `BorsukUlamOQ03.lean`: the OQ-03 constructivity question, the 1D proof via the IVT on the antisymmetric difference, Bishop-style constructive validity, the n ≥ 2 obstacle (Brouwer degree / homology), and the file's proved results. Previously the first annotation started at line 83. Pure annotation addition; ranges non-overlapping.

Enrichment pass by enricher-3.