### PR TITLE
Enrich Erdős Problem #1035: cover hypercube proof body (n-regularity, edge count, bipartiteness)

### DIFF
--- a/src/data/proofs/erdos-1035/annotations.json
+++ b/src/data/proofs/erdos-1035/annotations.json
@@ -30,7 +30,7 @@
     "type": "definition",
     "range": {
       "startLine": 27,
-      "endLine": 38
+      "endLine": 41
     },
     "title": "Hypercube Graph Q_n",
     "content": "**hypercubeGraph n** defines Q_n as a SimpleGraph on Fin(2^n). Two vertices u and v are adjacent iff u != v and their **XOR** has exactly one bit set (i.e., u XOR v = 2^k for some k < n). Symmetry and irreflexivity are proved inline.",
@@ -56,7 +56,7 @@
     "type": "definition",
     "range": {
       "startLine": 44,
-      "endLine": 45
+      "endLine": 48
     },
     "title": "Minimum Degree Predicate",
     "content": "**HasMinDegree G d** asserts that every vertex v of G has at least d neighbours, computed as the cardinality of {w in Fin N : G.Adj v w}. This is the key parameter controlling subgraph forcing.",
@@ -81,7 +81,7 @@
     "type": "definition",
     "range": {
       "startLine": 51,
-      "endLine": 53
+      "endLine": 56
     },
     "title": "Subgraph Containment",
     "content": "**ContainsAsSubgraph G H** holds when there exists an **injective** vertex map f : Fin M → Fin N that preserves adjacency: H.Adj u v implies G.Adj (f u) (f v). This captures subgraph isomorphism (not necessarily induced).",
@@ -103,7 +103,7 @@
     "type": "definition",
     "range": {
       "startLine": 59,
-      "endLine": 63
+      "endLine": 66
     },
     "title": "ErdosProblem1035 (Main Conjecture)",
     "content": "**ErdosProblem1035**: There exists c > 0 such that for every n >= 1, any graph on 2^n vertices with minimum degree at least ⌈(1-c) · 2^n⌉ contains the hypercube **Q_n** as a subgraph. The ceiling function handles the integer rounding of the real-valued threshold.",
@@ -127,7 +127,7 @@
     "type": "definition",
     "range": {
       "startLine": 69,
-      "endLine": 74
+      "endLine": 77
     },
     "title": "Alternative 1: Relaxed Vertex Count",
     "content": "If the main conjecture fails, find the **smallest m > 2^n** such that minimum degree > (1-c) · 2^n on m vertices still forces Q_n. Adding extra vertices provides more room for the embedding but weakens the density guarantee.",
@@ -150,7 +150,7 @@
     "type": "definition",
     "range": {
       "startLine": 78,
-      "endLine": 83
+      "endLine": 86
     },
     "title": "Alternative 2: Exact Threshold Sequence",
     "content": "If the main conjecture fails, find a sequence **u_n > 0** such that minimum degree > 2^n - u_n on 2^n vertices forces Q_n. This asks for the precise gap between the vertex count and the minimum degree threshold.",
@@ -168,67 +168,149 @@
     ]
   },
   {
-    "id": "erdos-1035-self",
+    "id": "erdos1035-basic-containment",
     "proofId": "erdos-1035",
-    "type": "concept",
     "range": {
       "startLine": 88,
-      "endLine": 89
+      "endLine": 114
     },
-    "title": "hypercube_self_subgraph",
-    "content": "**Q_n contains itself** as a subgraph via the identity embedding. This basic sanity check confirms the ContainsAsSubgraph definition admits the trivial case.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "identity embedding",
-      "reflexivity"
-    ],
-    "prerequisites": [
-      "ContainsAsSubgraph",
-      "hypercubeGraph"
-    ],
-    "mathContext": "See annotation content for formal details of hypercube_self_subgraph"
-  },
-  {
-    "id": "erdos-1035-complete",
-    "proofId": "erdos-1035",
     "type": "concept",
-    "range": {
-      "startLine": 92,
-      "endLine": 95
-    },
-    "title": "complete_contains_hypercube",
-    "content": "Any **complete graph** on 2^n vertices contains Q_n, since every pair is adjacent. This shows the conjecture is vacuously true for the densest possible graph and establishes an upper bound on the difficulty.",
-    "mathContext": "The complete graph has minimum degree 2^n - 1. The conjecture asks whether we can reduce the minimum degree to (1-c) · 2^n — i.e., whether we can remove a **constant fraction** of edges from each vertex and still find Q_n.",
+    "title": "Basic Containment Lemmas and Q_1 = K_2",
+    "content": "Three warm-up facts about `ContainsAsSubgraph`. `hypercube_self_subgraph`: $Q_n$ contains itself via the identity embedding. `complete_contains_hypercube`: any graph in which all distinct pairs are adjacent (the complete graph on $2^n$ vertices) contains $Q_n$ — the identity map works since $Q_n$-adjacency implies distinctness. `hypercube_one_is_edge`: $Q_1$ is exactly $K_2$ — its two vertices are adjacent iff distinct (`fin_cases` on `Fin 2`). These fix the boundary behaviour of the containment relation used throughout the file.",
     "significance": "supporting",
     "relatedConcepts": [
-      "complete graph",
-      "upper bound",
-      "edge removal"
-    ],
-    "prerequisites": [
       "ContainsAsSubgraph",
-      "hypercubeGraph"
+      "identity embedding",
+      "complete graph",
+      "$Q_1=K_2$"
     ]
   },
   {
-    "id": "erdos-1035-q1",
+    "id": "erdos1035-decide-smallcases",
     "proofId": "erdos-1035",
-    "type": "concept",
     "range": {
-      "startLine": 98,
-      "endLine": 99
+      "startLine": 116,
+      "endLine": 173
     },
-    "title": "hypercube_one_is_edge",
-    "content": "**Q_1** has exactly 2 vertices (Fin 2) and they are adjacent iff they are distinct — making Q_1 isomorphic to **K_2**, the single-edge graph. This base case shows the conjecture holds trivially for n = 1.",
+    "type": "technique",
+    "title": "Decidability and Computational Checks for Q_1, Q_2, Q_3",
+    "content": "`hypercubeAdj` is `Decidable` (it unfolds to a decidable proposition), giving `DecidableRel (hypercubeGraph n).Adj` and enabling `decide`/`native_decide`. These power a battery of concrete verifications: $Q_2$ is the 4-cycle with its six specific adjacencies (`hypercube_two_edges`), and $Q_1,Q_2,Q_3$ are $1$-, $2$-, $3$-regular with $4,8,24$ directed edges respectively — all discharged by `fin_cases`+`native_decide`. **Note (axiom honesty):** `native_decide` trusts kernel compilation and so relies on `Lean.ofReduceBool`; here it only certifies these small *supporting* checks, each of which is subsumed by the general theorems proved below for all $n$.",
     "significance": "supporting",
     "relatedConcepts": [
-      "base case",
-      "K_2",
-      "complete graph"
-    ],
-    "prerequisites": [
-      "hypercubeGraph"
-    ],
-    "mathContext": "See annotation content for formal details of hypercube_one_is_edge"
+      "Decidable / DecidableRel",
+      "native_decide (Lean.ofReduceBool)",
+      "regularity of small hypercubes",
+      "$Q_2$ as the 4-cycle"
+    ]
+  },
+  {
+    "id": "erdos1035-adj-xor",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 175,
+      "endLine": 191
+    },
+    "type": "technique",
+    "title": "Adjacency via XOR and the Bit-Flip Obstruction",
+    "content": "`hypercube_adj_iff` restates adjacency in explicit bit terms: $u\\sim v$ iff $u\\ne v$ and $u\\oplus v = 2^k$ for some bit position $k$ (`Iff.rfl` — it is the definition). `xor_pow2_ne_self` proves $v\\oplus 2^k\\ne v$: if they were equal then $2^k=0$ (cancel $v$ by `Nat.xor_assoc`/`Nat.xor_self`), contradicting $2^k>0$. This is the key arithmetic fact that flipping a bit genuinely moves to a different vertex.",
+    "mathContext": "$u\\sim v \\iff u\\ne v \\wedge \\exists k,\\ u\\oplus v = 2^k$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bitwise XOR (Nat.xor)",
+      "Nat.xor_self / xor_assoc",
+      "powers of two are nonzero"
+    ]
+  },
+  {
+    "id": "erdos1035-flip-bijection",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 193,
+      "endLine": 242
+    },
+    "type": "technique",
+    "title": "The Bit-Flip Map: Neighbors of v Are Exactly Its n Bit-Flips",
+    "content": "The neighbor structure of $Q_n$ is captured by `hypercubeFlip n v k = v \\oplus 2^k` (well-defined: `hypercube_flip_lt` shows $v\\oplus 2^k<2^n$ via `Nat.xor_lt_two_pow`). Three lemmas make it a clean bijection onto the neighborhood: `hypercube_flip_adj` (each flip is a neighbor), `hypercube_adj_of_flip` (every neighbor is *some* flip), and `hypercube_flip_injective` (distinct bit positions give distinct neighbors, since $2^i=2^j\\Rightarrow i=j$). Together they identify $N(v)$ with $\\mathrm{Fin}\\,n$ via bit position — the combinatorial engine for the counting results that follow.",
+    "significance": "central",
+    "relatedConcepts": [
+      "hypercubeFlip = $v\\oplus 2^k$",
+      "neighborhood as bit positions",
+      "injectivity of flips",
+      "Nat.xor_lt_two_pow"
+    ]
+  },
+  {
+    "id": "erdos1035-n-regular",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 244,
+      "endLine": 263
+    },
+    "type": "theorem",
+    "title": "Q_n Is n-Regular (All n)",
+    "content": "`hypercube_n_regular_general`: every vertex of $Q_n$ has exactly $n$ neighbors, for all $n$ — subsuming the earlier `native_decide` checks for $n\\le 3$. The neighbor set equals the image of the injective flip map `hypercubeFlip n v` over `Fin n`, so `card_image_of_injective` + `Fintype.card_fin` give $|N(v)| = |\\mathrm{Fin}\\,n| = n$. This is the first fully general (axiom-free, no `native_decide`) structural theorem.",
+    "mathContext": "$\\deg_{Q_n}(v) = n$ for every vertex $v$",
+    "significance": "central",
+    "relatedConcepts": [
+      "n-regularity",
+      "card_image_of_injective",
+      "the flip bijection",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "erdos1035-n-edge-count",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 265,
+      "endLine": 299
+    },
+    "type": "theorem",
+    "title": "Q_n Has n·2^n Directed Edges (All n)",
+    "content": "`hypercube_n_edge_count`: the number of ordered adjacent pairs in $Q_n$ is $n\\cdot 2^n$ (so $n\\cdot 2^{n-1}$ undirected edges), generalizing the $n=2,3$ computational checks. The proof builds an explicit bijection $(v,k)\\mapsto(v, v\\oplus 2^k)$ from $\\mathrm{Fin}(2^n)\\times\\mathrm{Fin}\\,n$ onto the directed-edge set — injective by `hypercube_flip_injective`, surjective by `hypercube_adj_of_flip` — then counts the domain with `Fintype.card_prod`.",
+    "mathContext": "$|\\{(u,v): u\\sim v\\}| = n\\cdot 2^n$",
+    "significance": "central",
+    "relatedConcepts": [
+      "edge counting by bijection",
+      "Fintype.card_prod",
+      "directed vs. undirected edges"
+    ]
+  },
+  {
+    "id": "erdos1035-handshaking",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 301,
+      "endLine": 316
+    },
+    "type": "theorem",
+    "title": "Handshaking Lemma for Q_n",
+    "content": "`hypercube_handshaking`: $2\\,|E(Q_n)| = n\\cdot 2^n$, i.e. twice the number of undirected edges equals the degree sum. It applies Mathlib's `sum_degrees_eq_twice_card_edges` to $Q_n$ and substitutes the constant degree $n$ (from `hypercube_n_regular_general`), collapsing the degree sum to $2^n\\cdot n$ via `Finset.sum_const`. A textbook handshaking instance made precise for the regular graph $Q_n$.",
+    "mathContext": "$2\\,|E(Q_n)| = \\sum_v \\deg(v) = 2^n\\cdot n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "handshaking lemma",
+      "sum_degrees_eq_twice_card_edges",
+      "regular-graph degree sum"
+    ]
+  },
+  {
+    "id": "erdos1035-bipartite",
+    "proofId": "erdos-1035",
+    "range": {
+      "startLine": 318,
+      "endLine": 379
+    },
+    "type": "theorem",
+    "title": "Q_n Is Bipartite via Popcount Parity",
+    "content": "`hypercube_bipartite`: $Q_n$ is 2-colorable, colored by the parity of the number of set bits (`hypercubeBitCount`/`hypercubeColor`). The heart is the private lemma `hypercubeBitCount_xor_pow_parity`: flipping bit $k$ ($v\\mapsto v\\oplus 2^k$) changes the popcount parity, because all bits $j\\ne k$ are unchanged (`Nat.testBit_two_pow_of_ne`) while bit $k$ flips (`Nat.testBit_two_pow_self`), so the isolated $k$-term shifts the sum by exactly $\\pm 1$ (case split + `omega`). Since adjacent vertices differ in exactly one bit, they get different colors — a `SimpleGraph.Coloring` into `Fin 2`, hence bipartiteness.",
+    "mathContext": "color$(v) = \\mathrm{popcount}(v)\\bmod 2$; adjacent $\\Rightarrow$ different parity",
+    "significance": "central",
+    "relatedConcepts": [
+      "bipartite / 2-coloring",
+      "popcount parity",
+      "Nat.testBit of powers of two",
+      "SimpleGraph.Coloring"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: erdos-1035 (Erdős Problem #1035)

Covers the large uncovered proof body of the formalization of **Erdős Problem #1035** (hypercube subgraphs in dense graphs, OPEN conjecture).

**Problem:** the existing 10 annotations covered lines 1–99 (overview + definitions + a shifted "basic properties" trio). The entire proof body — lines 100–379, ~74% of the file — was **uncovered**: decidability infrastructure, the $Q_1/Q_2/Q_3$ computational checks, the XOR/bit-flip neighbor machinery, and the general theorems ($Q_n$ is $n$-regular, has $n\cdot 2^n$ directed edges, the handshaking lemma, and bipartiteness via popcount parity). Coverage was ~15%.

**This PR** rebuilds `annotations.json` to **15 annotations (~92% coverage)**:
- Kept the well-aligned overview + definition annotations (ranges extended to full declaration spans).
- Replaced the shifted "basic properties" trio with a correctly-ranged containment annotation.
- Added 8 new annotations for the verified proof body, including an honest note that the small-case `native_decide` checks rely on `Lean.ofReduceBool` and are subsumed by the general axiom-free theorems.

No overlaps; ranges strictly ordered and within `leanFile.lineCount` (379). `meta.json` unchanged (entry remains `axiomatized`: the main conjecture is an open `Prop`).
