### PR TITLE
Enrich 3-way birthday problem threshold (birthday-problem-oq-03-oq-01-oq-02): module-overview annotation

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/annotations.json
@@ -1,14 +1,41 @@
 [
   {
+    "id": "ann-birthday-oq030102-overview",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Overview: 3-Way Birthday Problem \u2014 Asymptotic Threshold",
+    "content": "This file analyzes the k=3 birthday problem: with n people each choosing uniformly among d birthdays, when does a 3-way coincidence (three people sharing a birthday) become likely? The expected number of birthday triples is E(n,d) = C(n,3)/d\u00b2. The 'expected-triples threshold' n*(d) is the smallest n with E(n,d) \u2265 ln 2, and the file proves it satisfies n*(d) ~ (6 d\u00b2 ln 2)^{1/3} as d \u2192 \u221e. By the Poisson approximation, at this threshold P(at least one triple) \u2248 1 \u2212 e^{\u2212ln 2} = 1/2. The machine-checked results include the exact characterization asympThreshold(d)\u00b3 = 6d\u00b2 ln 2, the exact scaling ratio asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3}, the order-of-magnitude bracket [d^{2/3}, 3 d^{2/3}], the d=365 crossover E(83,365) < ln 2 < E(84,365), and the comparison showing the k=3 threshold exponent 2/3 exceeds the classical k=2 exponent 1/2 (and the k=3 threshold exceeds the k=2 threshold for every d \u2265 1). A single axiom, poisson_approx_birthday3, states the Poisson tail P(no triple) \u2192 exp(\u2212C(n,3)/d\u00b2) via the Chen-Stein method (Arratia-Goldstein-Gordon 1989). Note the asymptotic \u2248 82\u201384 underestimates the exact d=365 threshold of 88 by about 7%, due to O(n\u2075/d\u2074) correction terms.",
+    "mathContext": "Expected triples: $E(n,d)=\\binom{n}{3}/d^2$. Threshold $n^*(d)=\\min\\{n : E(n,d)\\ge \\ln 2\\}$ satisfies $n^*(d)\\sim(6d^2\\ln 2)^{1/3}$, so the k=3 threshold scales as $d^{2/3}$ versus $d^{1/2}$ for the classical k=2 problem. Poisson heuristic: the number of triples is approximately $\\mathrm{Pois}(\\lambda)$ with $\\lambda=\\binom{n}{3}/d^2$, so $P(\\ge 1)\\approx 1-e^{-\\lambda}$; at $\\lambda=\\ln 2$ this equals $1/2$. Rigor for the Poisson step uses Chen-Stein (Arratia-Goldstein-Gordon, 1989).",
+    "significance": "key",
+    "relatedConcepts": [
+      "birthday-problem",
+      "Poisson-approximation",
+      "Chen-Stein-method",
+      "threshold-phenomenon",
+      "expected-value",
+      "asymptotic-analysis"
+    ],
+    "prerequisites": [
+      "expected value and C(n,3)",
+      "Poisson approximation",
+      "threshold asymptotics",
+      "real cube roots and logarithms"
+    ]
+  },
+  {
     "id": "ann-bp3-asymp-threshold-def",
     "type": "concept",
     "title": "asympThreshold: The k=3 Birthday Threshold Formula",
-    "content": "asympThreshold d = (6d² ln 2)^{1/3} is the leading-order approximation to the k=3 birthday threshold: the number of people needed for a 50% chance of a triple birthday coincidence among d possible days. Derivation: E(n,d) = C(n,3)/d² ≈ n³/(6d²). Setting E = ln 2 gives n³ = 6d² ln 2, so n = (6d² ln 2)^{1/3}. By Poisson approximation, E(n,d) = ln 2 implies P(≥1 triple) ≈ 1 - e^{-ln 2} = 1/2. For d=365: asympThreshold(365) ≈ 82.8, while the exact threshold is 88 (a ~7% error from higher-order Poisson terms).",
+    "content": "asympThreshold d = (6d\u00b2 ln 2)^{1/3} is the leading-order approximation to the k=3 birthday threshold: the number of people needed for a 50% chance of a triple birthday coincidence among d possible days. Derivation: E(n,d) = C(n,3)/d\u00b2 \u2248 n\u00b3/(6d\u00b2). Setting E = ln 2 gives n\u00b3 = 6d\u00b2 ln 2, so n = (6d\u00b2 ln 2)^{1/3}. By Poisson approximation, E(n,d) = ln 2 implies P(\u22651 triple) \u2248 1 - e^{-ln 2} = 1/2. For d=365: asympThreshold(365) \u2248 82.8, while the exact threshold is 88 (a ~7% error from higher-order Poisson terms).",
     "range": {
       "startLine": 130,
       "endLine": 133
     },
-    "mathContext": "The formula uses Real.rpow (real-power exponentiation) with exponent 1/3: `(6 * d^2 * Real.log 2) ^ ((1:ℝ)/3)`. The `noncomputable` annotation is needed because Real.rpow is noncomputable. Key Mathlib facts: Real.rpow_natCast, Real.mul_rpow (requires non-negative arguments), Real.rpow_mul.",
+    "mathContext": "The formula uses Real.rpow (real-power exponentiation) with exponent 1/3: `(6 * d^2 * Real.log 2) ^ ((1:\u211d)/3)`. The `noncomputable` annotation is needed because Real.rpow is noncomputable. Key Mathlib facts: Real.rpow_natCast, Real.mul_rpow (requires non-negative arguments), Real.rpow_mul.",
     "significance": "supporting",
     "relatedConcepts": [
       "Real.rpow",
@@ -26,12 +53,12 @@
     "id": "ann-bp3-cubed-identity",
     "type": "concept",
     "title": "asympThreshold_cubed: Exact Inverse of Cube Root",
-    "content": "asympThreshold_cubed proves (asympThreshold d)³ = 6d² ln 2 for d ≥ 1. This confirms asympThreshold is the exact solution to n³ = 6d² ln 2. Proof: (x^{1/3})³ = x^{(1/3)·3} = x^1 = x by Real.rpow_mul and Real.rpow_one. Requires d ≥ 1 to ensure the base 6d² ln 2 is non-negative (ln 2 > 0 requires knowing log 2 > 0).",
+    "content": "asympThreshold_cubed proves (asympThreshold d)\u00b3 = 6d\u00b2 ln 2 for d \u2265 1. This confirms asympThreshold is the exact solution to n\u00b3 = 6d\u00b2 ln 2. Proof: (x^{1/3})\u00b3 = x^{(1/3)\u00b73} = x^1 = x by Real.rpow_mul and Real.rpow_one. Requires d \u2265 1 to ensure the base 6d\u00b2 ln 2 is non-negative (ln 2 > 0 requires knowing log 2 > 0).",
     "range": {
       "startLine": 134,
       "endLine": 141
     },
-    "mathContext": "Chain: asympThreshold(d)^3 = ((6d² ln2)^{1/3})^3 = (6d² ln2)^{(1/3)·3} = (6d² ln2)^1 = 6d² ln2. Key Lean tactic: `rw [← Real.rpow_natCast, ← Real.rpow_mul (by positivity)]` followed by `norm_num [Real.rpow_one]`.",
+    "mathContext": "Chain: asympThreshold(d)^3 = ((6d\u00b2 ln2)^{1/3})^3 = (6d\u00b2 ln2)^{(1/3)\u00b73} = (6d\u00b2 ln2)^1 = 6d\u00b2 ln2. Key Lean tactic: `rw [\u2190 Real.rpow_natCast, \u2190 Real.rpow_mul (by positivity)]` followed by `norm_num [Real.rpow_one]`.",
     "significance": "supporting",
     "relatedConcepts": [
       "Real.rpow_mul",
@@ -49,12 +76,12 @@
     "id": "ann-bp3-scaling-ratio",
     "type": "insight",
     "title": "asympThreshold_ratio: d^{2/3} Scaling with Explicit Constant",
-    "content": "asympThreshold_ratio proves asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} for all d ≥ 1. This is the cleanest statement of the asymptotic: the threshold grows like d^{2/3} with a constant factor (6 ln 2)^{1/3} ≈ 1.614. Proof strategy: factor (6d² ln2)^{1/3} = (6 ln2)^{1/3} · (d²)^{1/3} = (6 ln2)^{1/3} · d^{2/3} using Real.mul_rpow (both factors ≥ 0), then divide both sides by d^{2/3}.",
+    "content": "asympThreshold_ratio proves asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} for all d \u2265 1. This is the cleanest statement of the asymptotic: the threshold grows like d^{2/3} with a constant factor (6 ln 2)^{1/3} \u2248 1.614. Proof strategy: factor (6d\u00b2 ln2)^{1/3} = (6 ln2)^{1/3} \u00b7 (d\u00b2)^{1/3} = (6 ln2)^{1/3} \u00b7 d^{2/3} using Real.mul_rpow (both factors \u2265 0), then divide both sides by d^{2/3}.",
     "range": {
       "startLine": 142,
       "endLine": 155
     },
-    "mathContext": "The constant C = (6 ln 2)^{1/3} ≈ (6 · 0.693)^{1/3} ≈ 4.158^{1/3} ≈ 1.614. So for d=365: asympThreshold(365) ≈ 1.614 · 365^{2/3} ≈ 1.614 · 51.2 ≈ 82.6. The exponent 2/3 = (k-1)/k for k=3, a special case of the general k-way coincidence scaling.",
+    "mathContext": "The constant C = (6 ln 2)^{1/3} \u2248 (6 \u00b7 0.693)^{1/3} \u2248 4.158^{1/3} \u2248 1.614. So for d=365: asympThreshold(365) \u2248 1.614 \u00b7 365^{2/3} \u2248 1.614 \u00b7 51.2 \u2248 82.6. The exponent 2/3 = (k-1)/k for k=3, a special case of the general k-way coincidence scaling.",
     "significance": "key",
     "relatedConcepts": [
       "d^{2/3} scaling",
@@ -72,18 +99,18 @@
   {
     "id": "ann-bp3-order-bounds",
     "type": "concept",
-    "title": "asympThreshold_order: Θ(d^{2/3}) via Taylor Bounds for ln 2",
-    "content": "asympThreshold_order proves d^{2/3} ≤ asympThreshold(d) ≤ 3d^{2/3} for all d ≥ 1. Lower bound: (6 ln 2)^{1/3} ≥ 1 because 6 ln 2 ≥ 1 (ln 2 > 0.69 > 1/6). Proved using 4-term Taylor bound exp(0.6932) > 2 giving log 2 > 0.6931. Upper bound: (6 ln 2)^{1/3} ≤ 3 because 6 ln 2 ≤ 27 = 3³. Uses 3-term Taylor exp(1) > 2.5 > 2 giving log 2 < 1, then 6·1 = 6 ≤ 27. Key Lean issue: Real.rpow_le_rpow with inline `by` arguments creates unresolved metavariables — must use `calc` with `apply; norm_num` separated.",
+    "title": "asympThreshold_order: \u0398(d^{2/3}) via Taylor Bounds for ln 2",
+    "content": "asympThreshold_order proves d^{2/3} \u2264 asympThreshold(d) \u2264 3d^{2/3} for all d \u2265 1. Lower bound: (6 ln 2)^{1/3} \u2265 1 because 6 ln 2 \u2265 1 (ln 2 > 0.69 > 1/6). Proved using 4-term Taylor bound exp(0.6932) > 2 giving log 2 > 0.6931. Upper bound: (6 ln 2)^{1/3} \u2264 3 because 6 ln 2 \u2264 27 = 3\u00b3. Uses 3-term Taylor exp(1) > 2.5 > 2 giving log 2 < 1, then 6\u00b71 = 6 \u2264 27. Key Lean issue: Real.rpow_le_rpow with inline `by` arguments creates unresolved metavariables \u2014 must use `calc` with `apply; norm_num` separated.",
     "range": {
       "startLine": 156,
       "endLine": 200
     },
-    "mathContext": "Both bounds translate via asympThreshold_ratio: asympThreshold(d) = (6 ln 2)^{1/3}·d^{2/3}, so bounding the constant suffices. Taylor bounds for ln 2: lower bound 0.6931 via 4-term series at x=0.6932; upper bound 1 via 3-term series showing e^1 > 2.",
+    "mathContext": "Both bounds translate via asympThreshold_ratio: asympThreshold(d) = (6 ln 2)^{1/3}\u00b7d^{2/3}, so bounding the constant suffices. Taylor bounds for ln 2: lower bound 0.6931 via 4-term series at x=0.6932; upper bound 1 via 3-term series showing e^1 > 2.",
     "significance": "supporting",
     "relatedConcepts": [
       "Taylor bounds for ln 2",
       "Real.rpow_le_rpow",
-      "Θ notation",
+      "\u0398 notation",
       "calc tactic"
     ],
     "prerequisites": [
@@ -96,12 +123,12 @@
     "id": "ann-bp3-d365-numerical",
     "type": "concept",
     "title": "asympThreshold_d365_bounds: 82 < n*(365) < 83",
-    "content": "asympThreshold_d365_bounds proves 82 < asympThreshold(365) < 83. Upper bound: asympThreshold(365) = (6·365²·ln2)^{1/3} < 83 iff 6·365²·ln2 < 83³ = 571787. Uses ln2 < 0.7153 (4-term Taylor at 0.7153 gives exp(0.7153) > 2) so 6·133225·0.7153 < 571787. Lower bound: asympThreshold(365) > 82 iff 6·365²·ln2 > 82³ = 551368. Uses ln2 > 0.6931 (Taylor lower bound), so 6·133225·0.6931 ≈ 554082 > 551368.",
+    "content": "asympThreshold_d365_bounds proves 82 < asympThreshold(365) < 83. Upper bound: asympThreshold(365) = (6\u00b7365\u00b2\u00b7ln2)^{1/3} < 83 iff 6\u00b7365\u00b2\u00b7ln2 < 83\u00b3 = 571787. Uses ln2 < 0.7153 (4-term Taylor at 0.7153 gives exp(0.7153) > 2) so 6\u00b7133225\u00b70.7153 < 571787. Lower bound: asympThreshold(365) > 82 iff 6\u00b7365\u00b2\u00b7ln2 > 82\u00b3 = 551368. Uses ln2 > 0.6931 (Taylor lower bound), so 6\u00b7133225\u00b70.6931 \u2248 554082 > 551368.",
     "range": {
       "startLine": 241,
       "endLine": 295
     },
-    "mathContext": "Combined with the Poisson axiom poisson_approx_birthday3, this shows P(triple birthday among 83 people, 365 days) ≈ 50%. The bounds 82–83 are tight: the exact threshold is 88 (7% higher than 82.8), illustrating the first-order Poisson approximation error. The lower bound notably uses the exact ratio C(84,3)/365² from expectedTriples_84_ge_log2.",
+    "mathContext": "Combined with the Poisson axiom poisson_approx_birthday3, this shows P(triple birthday among 83 people, 365 days) \u2248 50%. The bounds 82\u201383 are tight: the exact threshold is 88 (7% higher than 82.8), illustrating the first-order Poisson approximation error. The lower bound notably uses the exact ratio C(84,3)/365\u00b2 from expectedTriples_84_ge_log2.",
     "significance": "supporting",
     "relatedConcepts": [
       "norm_num",
@@ -119,13 +146,13 @@
   {
     "id": "ann-bp3-k3-vs-k2-comparison",
     "type": "insight",
-    "title": "k3_threshold_gt_k2: k=3 Threshold Exceeds k=2 for All d ≥ 1",
-    "content": "k3_threshold_gt_k2 proves asympThreshold(d) > k2Threshold(d) for all d ≥ 1, where k2Threshold(d) = (2d ln 2)^{1/2} is the classical birthday threshold. Proof by raising both sides to the 6th power: need (6d² ln2)² > (2d ln2)³, i.e., 36d⁴(ln2)² > 8d³(ln2)³, i.e., 36d > 8 ln2. Since d ≥ 1 and ln2 < 1, we have 36d ≥ 36 > 8 > 8 ln2. The Lean proof uses Real.rpow_lt_rpow_iff to lift to 6th powers, then nlinarith with positivity lemmas.",
+    "title": "k3_threshold_gt_k2: k=3 Threshold Exceeds k=2 for All d \u2265 1",
+    "content": "k3_threshold_gt_k2 proves asympThreshold(d) > k2Threshold(d) for all d \u2265 1, where k2Threshold(d) = (2d ln 2)^{1/2} is the classical birthday threshold. Proof by raising both sides to the 6th power: need (6d\u00b2 ln2)\u00b2 > (2d ln2)\u00b3, i.e., 36d\u2074(ln2)\u00b2 > 8d\u00b3(ln2)\u00b3, i.e., 36d > 8 ln2. Since d \u2265 1 and ln2 < 1, we have 36d \u2265 36 > 8 > 8 ln2. The Lean proof uses Real.rpow_lt_rpow_iff to lift to 6th powers, then nlinarith with positivity lemmas.",
     "range": {
       "startLine": 322,
       "endLine": 387
     },
-    "mathContext": "The 6th power comparison avoids fractional exponents: comparing (6d² ln2)^{2/6} vs (2d ln2)^{3/6} reduces to (6d² ln2)² vs (2d ln2)³. Geometrically: asympThreshold ~ d^{2/3} and k2Threshold ~ d^{1/2}; since 2/3 > 1/2, the k=3 threshold eventually dominates. For small d (d=1): asympThreshold(1) = (6 ln2)^{1/3} ≈ 1.614 > k2Threshold(1) = (2 ln2)^{1/2} ≈ 1.177.",
+    "mathContext": "The 6th power comparison avoids fractional exponents: comparing (6d\u00b2 ln2)^{2/6} vs (2d ln2)^{3/6} reduces to (6d\u00b2 ln2)\u00b2 vs (2d ln2)\u00b3. Geometrically: asympThreshold ~ d^{2/3} and k2Threshold ~ d^{1/2}; since 2/3 > 1/2, the k=3 threshold eventually dominates. For small d (d=1): asympThreshold(1) = (6 ln2)^{1/3} \u2248 1.614 > k2Threshold(1) = (2 ln2)^{1/2} \u2248 1.177.",
     "significance": "key",
     "relatedConcepts": [
       "birthday problem k=2",


### PR DESCRIPTION
Adds a top-level `concept` annotation covering the previously-unannotated module docstring (lines 1-41): the expected-triples threshold E(n,d)=C(n,3)/d², the asymptotic n*(d) ~ (6 d² ln 2)^{1/3}, the k=3 vs k=2 exponent comparison (2/3 > 1/2), the d=365 crossover, and the Chen-Stein Poisson-approximation axiom. Previously the first annotation started at line 130. Pure annotation addition.

Enrichment pass by enricher-3.