### PR TITLE
Enrich Hermite sawtooth companion (hermite-floor-identity-oq-03): full annotation coverage

### DIFF
--- a/src/data/proofs/hermite-floor-identity-oq-03/annotations.json
+++ b/src/data/proofs/hermite-floor-identity-oq-03/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-hfi03-overview",
+    "proofId": "hermite-floor-identity-oq-03",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "concept",
+    "title": "Overview: The Sawtooth Companion of Hermite's Floor Identity",
+    "content": "Hermite's floor identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ (proved in the parent entry) has an exact fractional-part twin, obtained by subtracting the floor sum from the elementary arithmetic sum. Since y = ⌊y⌋ + {y}, summing this decomposition over the uniform sample x, x+1/n, …, x+(n-1)/n gives ∑ {x+k/n} = ∑(x+k/n) − ∑⌊x+k/n⌋. The arithmetic sum evaluates to n·x + (n-1)/2 (the constant part n·x plus the Gauss sum ∑ k/n = (n-1)/2), and the floor sum collapses to ⌊n·x⌋ by Hermite's identity, so the sawtooth sum equals (n·x − ⌊n·x⌋) + (n-1)/2 = {n·x} + (n-1)/2. All of the x-dependence is concentrated in the single term {n·x}; the remaining (n-1)/2 is an x-independent constant. Two clean specialisations are recorded: at x = 0 the classical average ∑ {k/n} = (n-1)/2, and whenever n·x is an integer (so {n·x} = 0) the sawtooth sum is exactly (n-1)/2.",
+    "mathContext": "For every $x \\in \\mathbb{R}$ and $n \\ge 1$, $\\sum_{k=0}^{n-1} \\{x + k/n\\} = \\{n x\\} + \\tfrac{n-1}{2}$, where $\\{y\\} = \\operatorname{Int.fract} y = y - \\lfloor y \\rfloor$. This is the additive complement of Hermite's floor identity $\\sum_{k=0}^{n-1}\\lfloor x + k/n\\rfloor = \\lfloor n x\\rfloor$ inside the exact sum $\\sum_{k<n}(x + k/n) = n x + \\tfrac{n-1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hermite-floor-identity",
+      "fractional-part",
+      "sawtooth-function",
+      "Gauss-sum",
+      "equidistribution",
+      "Dedekind-sum"
+    ],
+    "prerequisites": [
+      "real analysis",
+      "floor and fractional part",
+      "finite sums"
+    ]
+  },
+  {
+    "id": "ann-hfi03-gauss",
+    "proofId": "hermite-floor-identity-oq-03",
+    "range": { "startLine": 37, "endLine": 45 },
+    "type": "lemma",
+    "title": "Real-Valued Gauss Sum by Induction",
+    "content": "The lemma sum_range_cast establishes ∑_{k<m} (k : ℝ) = m(m-1)/2 for every natural m, the classical Gauss triangular-number sum cast into ℝ so it composes with the later division by n. The proof is a textbook induction: the base case m = 0 is closed by simp, and the successor step peels off the top term with Finset.sum_range_succ, rewrites by the induction hypothesis, then discharges the arithmetic with push_cast (to move ℕ→ℝ casts inward) and ring. Working over ℝ from the start avoids any Nat-subtraction pitfalls in the (m-1) factor.",
+    "mathContext": "$\\sum_{k=0}^{m-1} k = \\frac{m(m-1)}{2}$, cast to $\\mathbb{R}$. The successor step uses $\\sum_{k<p+1} k = \\left(\\sum_{k<p} k\\right) + p = \\frac{p(p-1)}{2} + p = \\frac{p(p+1)}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gauss-sum",
+      "triangular-number",
+      "mathematical-induction",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "induction on natural numbers",
+      "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-hfi03-main",
+    "proofId": "hermite-floor-identity-oq-03",
+    "range": { "startLine": 47, "endLine": 60 },
+    "type": "insight",
+    "title": "The Sawtooth Companion Identity",
+    "content": "The main theorem hermite_fract_identity proves ∑_{k<n} {x + k/n} = {n·x} + (n-1)/2 for n ≥ 1. The one-line strategy is to unfold every sawtooth via {y} = y − ⌊y⌋ (simp only [Int.fract]) and split the sum additively with Finset.sum_sub_distrib and Finset.sum_add_distrib. The three resulting pieces are evaluated in a single rw chain: the constant part ∑ x = n·x (Finset.sum_const, card_range, nsmul_eq_mul), the linear part ∑ k/n = (∑ k)/n = (n-1)/2 (← Finset.sum_div then sum_range_cast), and the floor part ∑ ⌊x + k/n⌋ = ⌊n·x⌋ delegated verbatim to the parent's HermiteFloorIdentity.hermite_floor_identity (moved inside the ℤ→ℝ cast by ← Int.cast_sum). The final rearrangement (n·x + (n-1)/2) − ⌊n·x⌋ = {n·x} + (n-1)/2 is closed by field_simp; ring, with the hypothesis n ≠ 0 supplied so the division by n is legitimate.",
+    "mathContext": "$\\sum_{k=0}^{n-1}\\{x+k/n\\} = \\Big(nx + \\tfrac{n-1}{2}\\Big) - \\lfloor nx\\rfloor = (nx - \\lfloor nx\\rfloor) + \\tfrac{n-1}{2} = \\{nx\\} + \\tfrac{n-1}{2}$. The only external ingredient is the parent floor identity $\\sum_{k<n}\\lfloor x+k/n\\rfloor = \\lfloor nx\\rfloor$; everything else is finite-sum algebra.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hermite-floor-identity",
+      "fractional-part",
+      "Finset.sum_sub_distrib",
+      "Int.cast_sum",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "sum splitting lemmas over Finset",
+      "Int.fract definition",
+      "the parent Hermite floor identity"
+    ]
+  },
+  {
+    "id": "ann-hfi03-atzero",
+    "proofId": "hermite-floor-identity-oq-03",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "insight",
+    "title": "Specialisation at x = 0: Average of Fractional Parts",
+    "content": "The corollary hermite_fract_sum_at_zero specialises the main identity at x = 0 to obtain ∑_{k<n} {k/n} = (n-1)/2 — the classical statement that the evenly spaced fractional parts 0, 1/n, 2/n, …, (n-1)/n average to (n-1)/(2n). The proof simply substitutes x = 0 into hermite_fract_identity and simplifies: zero_add clears the +0 offsets, mul_zero gives n·0 = 0, and Int.fract_zero gives {0} = 0, leaving exactly (n-1)/2. This is the equidistribution seed underlying Dedekind-sum reciprocity and the Fourier expansion of the sawtooth.",
+    "mathContext": "$\\sum_{k=0}^{n-1}\\{k/n\\} = \\frac{0 + 1 + \\cdots + (n-1)}{n} = \\frac{n(n-1)/2}{n} = \\frac{n-1}{2}$; equivalently the mean of the $n$ offsets is $\\frac{n-1}{2n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "equidistribution",
+      "roots-of-unity",
+      "Dedekind-sum",
+      "Int.fract_zero"
+    ],
+    "prerequisites": [
+      "substitution into a proved identity",
+      "Int.fract_zero"
+    ]
+  },
+  {
+    "id": "ann-hfi03-mulint",
+    "proofId": "hermite-floor-identity-oq-03",
+    "range": { "startLine": 70, "endLine": 77 },
+    "type": "insight",
+    "title": "Specialisation when n·x is an Integer",
+    "content": "The corollary hermite_fract_sum_of_mul_int records the case where n·x ∈ ℤ, i.e. {n·x} = 0. Here the x-dependent term of the identity vanishes and the sawtooth sum collapses to the constant (n-1)/2. The proof is a two-step rewrite: apply hermite_fract_identity, replace {n·x} by 0 using the hypothesis hx, and clear the leading zero with zero_add. This isolates the structural fact that the entire x-dependence of the sawtooth sum lives in the single fractional part {n·x}: as soon as n·x lands on an integer, the sum is pinned to (n-1)/2 regardless of x.",
+    "mathContext": "If $\\{nx\\} = 0$ then $\\sum_{k=0}^{n-1}\\{x + k/n\\} = 0 + \\tfrac{n-1}{2} = \\tfrac{n-1}{2}$. The condition $\\{nx\\}=0$ is exactly $nx \\in \\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fractional-part",
+      "integer-part",
+      "sawtooth-function"
+    ],
+    "prerequisites": [
+      "Int.fract vanishing on integers",
+      "rewriting with a hypothesis"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hermite-floor-identity-oq-03` (quality 21, 0 passes — the lowest-quality on-main entry with **zero annotations**).

## Gap
The entry had a rich `meta.json` (overview, sections, conclusion, cross-references, references) but **no `annotations.json` file at all** — annotation coverage was 0% of the 77-line Lean proof.

## Change
Adds `annotations.json` with **5 non-overlapping line-range annotations covering lines 1–77 in full**:

| Range | Type | Title |
|-------|------|-------|
| 1–35 | concept | Overview: the sawtooth companion of Hermite's floor identity |
| 37–45 | lemma | Real-valued Gauss sum by induction (`sum_range_cast`) |
| 47–60 | insight | The sawtooth companion identity (`hermite_fract_identity`) |
| 62–68 | insight | Specialisation at x = 0 (average of fractional parts) |
| 70–77 | insight | Specialisation when n·x is an integer |

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. All `type`/`significance` values are from the canonical gallery enums.

## Scope
- Only adds `src/data/proofs/hermite-floor-identity-oq-03/annotations.json`.
- No changes to `meta.json` or the Lean source.
- `meta.json` remains well under the 60 KB size cap; annotations JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)