### PR TITLE
Enrich fourth-root-2 Galois closure (fourth-root-2-irrational-oq-03): add mathContext, significance, relatedConcepts

### DIFF
--- a/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "concept",
     "title": "Galois property and |Gal| = 8: the step deferred by the degree computation",
-    "content": "The docstring frames this entry against the sibling FourthRoot2GaloisClosure, which secured the degree [ℚ(⁴√2, i) : ℚ] = 8 but deferred the group-theoretic content. Here ℚ(⁴√2, i) is shown to be a GALOIS extension of ℚ and its automorphism group to have order exactly 8. The method: ℚ(⁴√2, i) is the splitting field of X⁴ − 2 (its four roots ±⁴√2, ±i·⁴√2 are exactly the solutions of z⁴ = 2), X⁴ − 2 is separable over ℚ (irreducible in characteristic zero), so the splitting field is Galois, and IsGalois.card_aut_eq_finrank turns the degree 8 into #Gal = 8. Zero axioms; reuses only Mathlib and the parent."
+    "content": "The docstring frames this entry against the sibling FourthRoot2GaloisClosure, which secured the degree [ℚ(⁴√2, i) : ℚ] = 8 but deferred the group-theoretic content. Here ℚ(⁴√2, i) is shown to be a GALOIS extension of ℚ and its automorphism group to have order exactly 8. The method: ℚ(⁴√2, i) is the splitting field of X⁴ − 2 (its four roots ±⁴√2, ±i·⁴√2 are exactly the solutions of z⁴ = 2), X⁴ − 2 is separable over ℚ (irreducible in characteristic zero), so the splitting field is Galois, and IsGalois.card_aut_eq_finrank turns the degree 8 into #Gal = 8. Zero axioms; reuses only Mathlib and the parent.",
+    "mathContext": "$\\mathbb{Q}(\\sqrt[4]{2}, i)$ is the splitting field of $X^4-2$ over $\\mathbb{Q}$; being separable it is Galois, and $\\#\\mathrm{Gal}(\\mathbb{Q}(\\sqrt[4]{2},i)/\\mathbb{Q}) = [\\mathbb{Q}(\\sqrt[4]{2},i):\\mathbb{Q}] = 8$. This order-8 group is the one later identified with the dihedral group $D_4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Galois-extension",
+      "splitting-field",
+      "dihedral-group",
+      "separable-polynomial",
+      "Galois-closure"
+    ],
+    "prerequisites": [
+      "field extensions and Galois theory",
+      "the parent degree computation [ℚ(⁴√2, i) : ℚ] = 8"
+    ]
   },
   {
     "id": "ann-polynomial-separable",
@@ -19,7 +32,21 @@
     },
     "type": "concept",
     "title": "X⁴ − 2 is separable, and ⁴√2, i·⁴√2 lie in its root set",
-    "content": "p = X⁴ − 2 equals minpoly ℚ (⁴√2) (parent fact), so it is irreducible and — because ℚ has characteristic zero — separable (p_separable). Separability is one of the two ingredients of the Galois property. The two theorems a_mem_rootSet and Ia_mem_rootSet certify that a = (⁴√2 : ℂ) and i·⁴√2 are roots: aeval reduces to their fourth powers, both equal to 2 by the parent's a_pow_four and I_mul_a_pow_four."
+    "content": "p = X⁴ − 2 equals minpoly ℚ (⁴√2) (parent fact), so it is irreducible and — because ℚ has characteristic zero — separable (p_separable). Separability is one of the two ingredients of the Galois property. The two theorems a_mem_rootSet and Ia_mem_rootSet certify that a = (⁴√2 : ℂ) and i·⁴√2 are roots: aeval reduces to their fourth powers, both equal to 2 by the parent's a_pow_four and I_mul_a_pow_four.",
+    "mathContext": "$p = X^4 - 2 = \\operatorname{minpoly}_{\\mathbb{Q}}(\\sqrt[4]{2})$ is irreducible, hence separable over the characteristic-zero field $\\mathbb{Q}$. Its roots include $\\sqrt[4]{2}$ and $i\\sqrt[4]{2}$, since $(\\sqrt[4]{2})^4 = 2$ and $(i\\sqrt[4]{2})^4 = i^4\\cdot 2 = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "minimal-polynomial",
+      "separable-polynomial",
+      "irreducibility",
+      "root-set",
+      "characteristic-zero"
+    ],
+    "prerequisites": [
+      "minpoly and irreducibility over ℚ",
+      "separability in characteristic zero",
+      "Polynomial.aeval and rootSet"
+    ]
   },
   {
     "id": "ann-adjoin-rootset",
@@ -30,7 +57,21 @@
     },
     "type": "insight",
     "title": "The root set generates exactly ℚ(⁴√2, i)",
-    "content": "adjoin_rootSet_eq is the field-theoretic crux, proved by antisymmetry. Forward (⊆): any root z satisfies z⁴ = 2 = a⁴, and the factorization z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) — valid because i² = −1, discharged by linear_combination on Complex.I_sq — forces z ∈ {±a, ±i·a}, each already in ℚ(⁴√2, i) by the parent's roots_mem_closure. Reverse (⊇): a is a root, and i is recovered as (i·a)·a⁻¹, so both generators of ℚ(⁴√2, i) lie in the adjoined field. This identity is what lets the abstract splitting-field machinery land on the concrete field ℚ(⁴√2, i)."
+    "content": "adjoin_rootSet_eq is the field-theoretic crux, proved by antisymmetry. Forward (⊆): any root z satisfies z⁴ = 2 = a⁴, and the factorization z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) — valid because i² = −1, discharged by linear_combination on Complex.I_sq — forces z ∈ {±a, ±i·a}, each already in ℚ(⁴√2, i) by the parent's roots_mem_closure. Reverse (⊇): a is a root, and i is recovered as (i·a)·a⁻¹, so both generators of ℚ(⁴√2, i) lie in the adjoined field. This identity is what lets the abstract splitting-field machinery land on the concrete field ℚ(⁴√2, i).",
+    "mathContext": "$z^4 - a^4 = (z-a)(z+a)(z-ia)(z+ia)$ (using $i^2=-1$), so $z^4 = 2 = a^4$ forces $z \\in \\{\\pm a, \\pm ia\\}$. Conversely $i = (ia)\\cdot a^{-1}$, giving $\\operatorname{adjoin}_{\\mathbb{Q}}(\\mathrm{rootSet}) = \\mathbb{Q}(\\sqrt[4]{2}, i)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "adjoin",
+      "splitting-field",
+      "antisymmetry",
+      "linear_combination",
+      "fourth-roots-of-unity"
+    ],
+    "prerequisites": [
+      "IntermediateField.adjoin and adjoin_le_iff",
+      "the factorization of z⁴ − a⁴ over ℂ",
+      "the parent's roots_mem_closure"
+    ]
   },
   {
     "id": "ann-galois-cardinality",
@@ -41,6 +82,20 @@
     },
     "type": "insight",
     "title": "Splitting field ⟹ Galois ⟹ |Gal| = 8",
-    "content": "With the root-set identity in hand, isSplittingField follows because X⁴ − 2 splits over the algebraically closed ℂ (adjoin_rootSet_isSplittingField, then rewrite). A separable splitting field is Galois (isGalois via IsGalois.of_separable_splitting_field), and it is finite-dimensional (finiteDimensional), which supplies the Fintype instance on the Galois group. Finally card_gal: converting Fintype.card to Nat.card and applying IsGalois.card_aut_eq_finrank equates #Gal with the finrank, which the parent computed to be 8. The order-8 Galois group is the exact prerequisite for identifying it with the dihedral group D₄."
+    "content": "With the root-set identity in hand, isSplittingField follows because X⁴ − 2 splits over the algebraically closed ℂ (adjoin_rootSet_isSplittingField, then rewrite). A separable splitting field is Galois (isGalois via IsGalois.of_separable_splitting_field), and it is finite-dimensional (finiteDimensional), which supplies the Fintype instance on the Galois group. Finally card_gal: converting Fintype.card to Nat.card and applying IsGalois.card_aut_eq_finrank equates #Gal with the finrank, which the parent computed to be 8. The order-8 Galois group is the exact prerequisite for identifying it with the dihedral group D₄.",
+    "mathContext": "Separable splitting field $\\Rightarrow$ Galois; then $\\#\\mathrm{Gal}(K/\\mathbb{Q}) = [K:\\mathbb{Q}]$ (IsGalois.card_aut_eq_finrank). With $[\\mathbb{Q}(\\sqrt[4]{2},i):\\mathbb{Q}] = 8$ this gives $\\#\\mathrm{Gal} = 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Galois-extension",
+      "splitting-field",
+      "finite-dimensional-extension",
+      "automorphism-group",
+      "dihedral-group"
+    ],
+    "prerequisites": [
+      "IsGalois.of_separable_splitting_field",
+      "IsGalois.card_aut_eq_finrank",
+      "Fintype/Nat.card conversions"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fourth-root-2-irrational-oq-03` (quality 59, 0 passes).

## Gap
The four existing annotations already cover the file well (135/147 lines) but carried **no `mathContext`, `significance`, or `relatedConcepts`** — the fields that drive both the quality score and reader value.

## Change (annotations.json only)
Added to all four annotations:
- **`mathContext`** — LaTeX for the splitting-field/Galois facts, the separable minimal polynomial $X^4-2$, the factorization $z^4-a^4=(z-a)(z+a)(z-ia)(z+ia)$, and $\#\mathrm{Gal}=[K:\mathbb{Q}]=8$.
- **`significance`** (key / critical / supporting).
- **`relatedConcepts`** linking to Galois theory, splitting fields, dihedral group, etc.

No changes to `meta.json` or the Lean source. JSON validated, no range overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)