### PR TITLE
Enrich arsinh-log-formula-oq-01-oq-01-oq-02: add mathContext to 8 annotations

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/annotations.json
@@ -2,123 +2,232 @@
   {
     "id": "ann-docstring",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 1, "endLine": 37 },
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
     "type": "concept",
     "title": "Overview: logarithmic arc length and the catenoid",
     "content": "The sibling entry oq-01 built the catenary arc length ∫_0^b √(1+t²) dt = ½(b√(1+b²) + arsinh b) in arsinh notation. This module supplies the two companions it posed as open questions: (1) the purely LOGARITHMIC closed form, obtained by unfolding arsinh x = log(x + √(1+x²)), and (2) the CATENOID lateral surface area 2π ∫ cosh x √(1+sinh²x) dx = π(b + sinh b·cosh b). Both rely on antiderivatives Mathlib does not ship.",
     "mathContext": "$\\int_0^b\\sqrt{1+t^2}\\,dt=\\tfrac12(b\\sqrt{1+b^2}+\\log(b+\\sqrt{1+b^2}))$",
     "significance": "key",
-    "relatedConcepts": ["catenary", "catenoid", "arc length", "surface of revolution", "arsinh", "logarithm"],
-    "prerequisites": ["integral calculus", "hyperbolic functions", "the Fundamental Theorem of Calculus"]
+    "relatedConcepts": [
+      "catenary",
+      "catenoid",
+      "arc length",
+      "surface of revolution",
+      "arsinh",
+      "logarithm"
+    ],
+    "prerequisites": [
+      "integral calculus",
+      "hyperbolic functions",
+      "the Fundamental Theorem of Calculus"
+    ]
   },
   {
     "id": "ann-sqrt-helpers",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 46, "endLine": 52 },
+    "range": {
+      "startLine": 46,
+      "endLine": 52
+    },
     "type": "tactic",
     "title": "Radicand positivity helpers",
     "content": "√(1+t²) > 0 and (√(1+t²))² = 1+t², the two facts about the radicand used repeatedly when differentiating and simplifying. Both follow from 1 + t² > 0 by positivity.",
     "significance": "supporting",
-    "relatedConcepts": ["Real.sqrt_pos", "Real.sq_sqrt", "positivity"],
-    "prerequisites": ["properties of the real square root"]
+    "relatedConcepts": [
+      "Real.sqrt_pos",
+      "Real.sq_sqrt",
+      "positivity"
+    ],
+    "prerequisites": [
+      "properties of the real square root"
+    ],
+    "mathContext": "$\\sqrt{1+t^2}>0$ and $(\\sqrt{1+t^2})^2 = 1+t^2$ (the radicand is nonnegative)."
   },
   {
     "id": "ann-sqrt-antideriv",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 54, "endLine": 76 },
+    "range": {
+      "startLine": 54,
+      "endLine": 76
+    },
     "type": "insight",
     "title": "Antiderivative of √(1+t²)",
     "content": "d/dt [½(t√(1+t²) + arsinh t)] = √(1+t²). Mathlib supplies Real.hasDerivAt_arsinh but no antiderivative for the conjugate integrand √(1+t²), so it is assembled from the product rule on t·√(1+t²), the chain rule for √ (HasDerivAt.sqrt), and the arsinh derivative. The algebra collapses because (t²+1)/√(1+t²) = √(1+t²) doubles the leading term; field_simp + nlinarith closes the value equation.",
     "significance": "key",
-    "relatedConcepts": ["product rule", "chain rule for √", "HasDerivAt.sqrt", "Real.hasDerivAt_arsinh"],
-    "prerequisites": ["differentiation rules", "HasDerivAt in Mathlib"]
+    "relatedConcepts": [
+      "product rule",
+      "chain rule for √",
+      "HasDerivAt.sqrt",
+      "Real.hasDerivAt_arsinh"
+    ],
+    "prerequisites": [
+      "differentiation rules",
+      "HasDerivAt in Mathlib"
+    ],
+    "mathContext": "$F(t)=\\tfrac12\\bigl(t\\sqrt{1+t^2}+\\operatorname{arsinh} t\\bigr)$ satisfies $F'(t)=\\sqrt{1+t^2}$; the algebra collapses via $\\dfrac{t^2+1}{\\sqrt{1+t^2}}=\\sqrt{1+t^2}$."
   },
   {
     "id": "ann-integral-arsinh-form",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 83, "endLine": 91 },
+    "range": {
+      "startLine": 83,
+      "endLine": 91
+    },
     "type": "insight",
     "title": "FTC evaluation in arsinh form",
     "content": "∫_0^b √(1+t²) dt = ½(b√(1+b²) + arsinh b), via intervalIntegral.integral_eq_sub_of_hasDerivAt applied to the antiderivative above; the lower endpoint vanishes since arsinh 0 = 0. This is the supporting form the logarithmic result is built on.",
     "significance": "supporting",
-    "relatedConcepts": ["Fundamental Theorem of Calculus", "Real.arsinh_zero"],
-    "prerequisites": ["the Fundamental Theorem of Calculus"]
+    "relatedConcepts": [
+      "Fundamental Theorem of Calculus",
+      "Real.arsinh_zero"
+    ],
+    "prerequisites": [
+      "the Fundamental Theorem of Calculus"
+    ],
+    "mathContext": "$\\displaystyle\\int_0^b\\sqrt{1+t^2}\\,dt=\\tfrac12\\bigl(b\\sqrt{1+b^2}+\\operatorname{arsinh} b\\bigr)$ (FTC with $\\operatorname{arsinh}0=0$)."
   },
   {
     "id": "ann-integral-log-form",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 93, "endLine": 100 },
+    "range": {
+      "startLine": 93,
+      "endLine": 100
+    },
     "type": "insight",
     "title": "The logarithmic closed form (new)",
     "content": "∫_0^b √(1+t²) dt = ½(b√(1+b²) + log(b + √(1+b²))). Because Real.arsinh x is DEFINED as log(x + √(1+x²)), the rewrite from the arsinh form is closed by rfl. This is the classical tabulated form of the catenary arc length and the payoff of the arsinh-LOG lineage.",
     "mathContext": "$\\operatorname{arsinh} x=\\log(x+\\sqrt{1+x^2})$",
     "significance": "critical",
-    "relatedConcepts": ["definitional unfolding", "logarithm", "catenary arc length"],
-    "prerequisites": ["definition of arsinh"]
+    "relatedConcepts": [
+      "definitional unfolding",
+      "logarithm",
+      "catenary arc length"
+    ],
+    "prerequisites": [
+      "definition of arsinh"
+    ]
   },
   {
     "id": "ann-concrete-log",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 102, "endLine": 108 },
+    "range": {
+      "startLine": 102,
+      "endLine": 108
+    },
     "type": "insight",
     "title": "Concrete value at b = 1",
     "content": "∫_0^1 √(1+t²) dt = ½(√2 + log(1 + √2)), obtained from the logarithmic closed form by norm_num on √(1+1²) = √2.",
     "significance": "supporting",
-    "relatedConcepts": ["norm_num", "concrete evaluation"]
+    "relatedConcepts": [
+      "norm_num",
+      "concrete evaluation"
+    ],
+    "mathContext": "$\\displaystyle\\int_0^1\\sqrt{1+t^2}\\,dt=\\tfrac12\\bigl(\\sqrt2+\\log(1+\\sqrt2)\\bigr)$."
   },
   {
     "id": "ann-sqrt-sinh",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 112, "endLine": 118 },
+    "range": {
+      "startLine": 112,
+      "endLine": 118
+    },
     "type": "insight",
     "title": "Arc-length element √(1+sinh²x) = cosh x",
     "content": "The hyperbolic Pythagorean identity cosh²x = 1 + sinh²x together with cosh x > 0 simplifies the catenary arc-length element. This is what turns the surface-of-revolution integrand into 2π·cosh²x.",
     "significance": "key",
-    "relatedConcepts": ["Real.cosh_sq", "Real.cosh_pos", "hyperbolic Pythagoras"],
-    "prerequisites": ["hyperbolic function identities"]
+    "relatedConcepts": [
+      "Real.cosh_sq",
+      "Real.cosh_pos",
+      "hyperbolic Pythagoras"
+    ],
+    "prerequisites": [
+      "hyperbolic function identities"
+    ],
+    "mathContext": "$\\sqrt{1+\\sinh^2 x}=\\cosh x$, since $\\cosh^2 x = 1+\\sinh^2 x$ and $\\cosh x>0$."
   },
   {
     "id": "ann-coshsq-antideriv",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 120, "endLine": 132 },
+    "range": {
+      "startLine": 120,
+      "endLine": 132
+    },
     "type": "insight",
     "title": "Antiderivative of cosh²",
     "content": "d/dx [½(x + sinh x·cosh x)] = cosh²x. The product rule gives (sinh·cosh)' = cosh² + sinh², so the derivative is ½(1 + cosh² + sinh²); cosh² = 1 + sinh² (Real.cosh_sq) collapses this to cosh². Mathlib has the sinh/cosh derivatives but not this antiderivative.",
     "significance": "key",
-    "relatedConcepts": ["product rule", "Real.hasDerivAt_sinh", "Real.hasDerivAt_cosh", "Real.cosh_sq"],
-    "prerequisites": ["differentiation rules", "HasDerivAt in Mathlib"]
+    "relatedConcepts": [
+      "product rule",
+      "Real.hasDerivAt_sinh",
+      "Real.hasDerivAt_cosh",
+      "Real.cosh_sq"
+    ],
+    "prerequisites": [
+      "differentiation rules",
+      "HasDerivAt in Mathlib"
+    ],
+    "mathContext": "$G(x)=\\tfrac12\\bigl(x+\\sinh x\\cosh x\\bigr)$ satisfies $G'(x)=\\cosh^2 x$; uses $(\\sinh x\\cosh x)'=\\cosh^2 x+\\sinh^2 x$ and $\\cosh^2 x=1+\\sinh^2 x$."
   },
   {
     "id": "ann-integral-coshsq",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 139, "endLine": 145 },
+    "range": {
+      "startLine": 139,
+      "endLine": 145
+    },
     "type": "insight",
     "title": "∫_0^b cosh²x dx = ½(b + sinh b·cosh b)",
     "content": "FTC evaluation of the cosh² antiderivative; the lower endpoint vanishes since sinh 0 = 0. This is the core integral behind the catenoid area.",
     "significance": "key",
-    "relatedConcepts": ["Fundamental Theorem of Calculus", "Real.sinh_zero"],
-    "prerequisites": ["the Fundamental Theorem of Calculus"]
+    "relatedConcepts": [
+      "Fundamental Theorem of Calculus",
+      "Real.sinh_zero"
+    ],
+    "prerequisites": [
+      "the Fundamental Theorem of Calculus"
+    ],
+    "mathContext": "$\\displaystyle\\int_0^b\\cosh^2 x\\,dx=\\tfrac12\\bigl(b+\\sinh b\\cosh b\\bigr)$."
   },
   {
     "id": "ann-catenoid",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 147, "endLine": 164 },
+    "range": {
+      "startLine": 147,
+      "endLine": 164
+    },
     "type": "insight",
     "title": "Catenoid lateral surface area (headline)",
     "content": "∫_0^b 2π·cosh x·√(1+sinh²x) dx = π(b + sinh b·cosh b). Rewriting √(1+sinh²x) = cosh x makes the Pappus integrand 2π·cosh²x; pulling out the constant (integral_const_mul) and applying ∫cosh² = ½(b + sinh b·cosh b) gives the closed form. This discharges the 'more ambitious' half of the sibling's open question.",
     "mathContext": "$\\int_0^b 2\\pi\\cosh x\\,\\sqrt{1+\\sinh^2 x}\\,dx=\\pi(b+\\sinh b\\cosh b)$",
     "significance": "critical",
-    "relatedConcepts": ["surface of revolution", "Pappus theorem", "catenoid", "intervalIntegral.integral_const_mul"],
-    "prerequisites": ["surface area of revolution", "the Fundamental Theorem of Calculus"]
+    "relatedConcepts": [
+      "surface of revolution",
+      "Pappus theorem",
+      "catenoid",
+      "intervalIntegral.integral_const_mul"
+    ],
+    "prerequisites": [
+      "surface area of revolution",
+      "the Fundamental Theorem of Calculus"
+    ]
   },
   {
     "id": "ann-catenoid-concrete",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-02",
-    "range": { "startLine": 166, "endLine": 172 },
+    "range": {
+      "startLine": 166,
+      "endLine": 172
+    },
     "type": "insight",
     "title": "Concrete catenoid over [0,1]",
     "content": "The catenoid swept by y = cosh x over [0,1] has lateral surface area π(1 + sinh 1·cosh 1), a direct specialisation of the general formula.",
     "significance": "supporting",
-    "relatedConcepts": ["concrete evaluation"]
+    "relatedConcepts": [
+      "concrete evaluation"
+    ],
+    "mathContext": "$\\displaystyle\\int_0^1 2\\pi\\cosh x\\,\\sqrt{1+\\sinh^2 x}\\,dx=\\pi\\bigl(1+\\sinh 1\\cosh 1\\bigr)$."
   }
 ]


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01-oq-02` (logarithmic arc length & the catenoid surface area).

The 11 annotations already had rich `content`, `significance`, and `relatedConcepts`, but 8 lacked `mathContext`. Added LaTeX for each:
- radicand positivity $\sqrt{1+t^2}>0$
- antiderivatives $F'(t)=\sqrt{1+t^2}$ and $G'(x)=\cosh^2 x$
- FTC evaluations in arsinh and $\tfrac12(b+\sinh b\cosh b)$ form
- $\sqrt{1+\sinh^2 x}=\cosh x$ and the two concrete $[0,1]$ values

All 11 annotations now carry mathContext + significance. Ranges unchanged (coverage 1–172 of 173); meta.json untouched.