### PR TITLE
research(chebyshev-bounds-oq-06-oq-02): θ(n) ≤ n·log 4 via primorial bound [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevThetaFourPow.lean
+++ b/proofs/Proofs/ChebyshevThetaFourPow.lean
@@ -1,0 +1,76 @@
+/-
+# Chebyshev's θ function is bounded by n · log 4
+
+Chebyshev's first function is
+  θ(n) = ∑_{p ≤ n, p prime} log p .
+The exponential of θ(n) is exactly the primorial `n# = ∏_{p ≤ n} p`, so
+  θ(n) = log(n#).
+Mathlib packages the central-binomial sandwich argument as
+`primorial_le_4_pow : n# ≤ 4ⁿ`.  Taking logarithms and using monotonicity of
+`log` on the positive reals turns that bound into the sharp Chebyshev estimate
+  θ(n) ≤ n · log 4 = 2 n · log 2 .
+
+This is the upper half of the classical Chebyshev bounds on θ, obtained here
+directly from the primorial bound (whose proof is the Erdős central-binomial
+sandwich `n# ∣ m# · C(m+n, m)`).
+
+Reference: parent gallery entry "Two-Sided Central Binomial Bound
+4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ" (chebyshev-bounds-oq-06).
+-/
+import Mathlib.NumberTheory.Primorial
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+open Finset
+
+namespace ChebyshevThetaBound
+
+/-- Chebyshev's first function `θ(n) = ∑_{p ≤ n, p prime} log p`, as a real number. -/
+noncomputable def chebyshevTheta (n : ℕ) : ℝ :=
+  ∑ p ∈ range (n + 1) with p.Prime, Real.log p
+
+/-- `θ(n)` is the logarithm of the primorial `n#`: exponentiating the Chebyshev
+sum recovers the product of primes up to `n`. -/
+theorem chebyshevTheta_eq_log_primorial (n : ℕ) :
+    chebyshevTheta n = Real.log (primorial n) := by
+  rw [chebyshevTheta, primorial, Nat.cast_prod, Real.log_prod]
+  intro p hp
+  exact_mod_cast (mem_filter.1 hp).2.pos.ne'
+
+/-- Every summand `log p` (with `p` prime, hence `p ≥ 2`) is nonnegative, so
+`θ(n) ≥ 0`. -/
+theorem chebyshevTheta_nonneg (n : ℕ) : 0 ≤ chebyshevTheta n := by
+  apply Finset.sum_nonneg
+  intro p hp
+  exact Real.log_nonneg (by exact_mod_cast (mem_filter.1 hp).2.one_lt.le)
+
+/-- `θ` is monotone: adjoining more primes only adds nonnegative terms. -/
+theorem chebyshevTheta_mono {m n : ℕ} (h : m ≤ n) :
+    chebyshevTheta m ≤ chebyshevTheta n := by
+  apply Finset.sum_le_sum_of_subset_of_nonneg
+  · intro x hx
+    rw [mem_filter] at hx ⊢
+    exact ⟨mem_range.mpr (lt_of_lt_of_le (mem_range.mp hx.1) (by omega)), hx.2⟩
+  · intro p hp _
+    exact Real.log_nonneg (by exact_mod_cast (mem_filter.1 hp).2.one_lt.le)
+
+/-- **Chebyshev upper bound.** `θ(n) ≤ n · log 4`, obtained by taking logarithms
+in the primorial bound `n# ≤ 4ⁿ` (the central-binomial sandwich). -/
+theorem chebyshevTheta_le (n : ℕ) : chebyshevTheta n ≤ n * Real.log 4 := by
+  rw [chebyshevTheta_eq_log_primorial]
+  calc
+    Real.log (primorial n) ≤ Real.log ((4 : ℝ) ^ n) := by
+      apply Real.log_le_log (by exact_mod_cast primorial_pos n)
+      exact_mod_cast primorial_le_4_pow n
+    _ = n * Real.log 4 := by rw [Real.log_pow]
+
+/-- Restated with `log 4 = 2 · log 2`: `θ(n) ≤ 2 n · log 2`. -/
+theorem chebyshevTheta_le_two_mul (n : ℕ) :
+    chebyshevTheta n ≤ 2 * n * Real.log 2 := by
+  have h4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]
+    push_cast; ring
+  calc
+    chebyshevTheta n ≤ n * Real.log 4 := chebyshevTheta_le n
+    _ = 2 * n * Real.log 2 := by rw [h4]; ring
+
+end ChebyshevThetaBound

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-chebo0602-header",
+    "proofId": "chebyshev-bounds-oq-06-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
+    "type": "concept",
+    "title": "θ(n) = log(primorial n): the log-side of the central-binomial sandwich",
+    "content": "Chebyshev's first function θ(n) = ∑_{p ≤ n, p prime} log p is the additive prime-counting weight behind the prime number theorem. The single idea driving this entry is that exponentiating θ collapses the sum of logs into a product of primes — the primorial n# = ∏_{p ≤ n} p — so θ(n) = log(n#). Mathlib already proves the arithmetic bound n# ≤ 4ⁿ (primorial_le_4_pow), and its proof is precisely the Erdős central-binomial argument that the parent entry chebyshev-bounds-oq-06 packages. Taking logarithms of n# ≤ 4ⁿ and using that log is increasing on the positive reals gives θ(n) ≤ n·log 4 for free. Nothing arithmetic is new here; the value is bridging Mathlib's primorial bound to the standard analytic statement about θ.",
+    "mathContext": "$\\theta(n) = \\sum_{p \\le n} \\log p = \\log\\!\\Big(\\prod_{p \\le n} p\\Big) = \\log(n\\#) \\le \\log(4^n) = n\\log 4$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chebyshev theta function",
+      "primorial",
+      "central binomial coefficient",
+      "prime number theorem"
+    ],
+    "prerequisites": [
+      "logarithm of a product",
+      "primorial n# = product of primes ≤ n",
+      "monotonicity of log"
+    ]
+  },
+  {
+    "id": "ann-chebo0602-def",
+    "proofId": "chebyshev-bounds-oq-06-oq-02",
+    "range": {
+      "startLine": 27,
+      "endLine": 39
+    },
+    "type": "definition",
+    "title": "Defining θ and identifying it with log(n#)",
+    "content": "chebyshevTheta n is defined over exactly the primorial's index set — range(n+1) filtered by p.Prime — so the two objects line up definitionally. chebyshevTheta_eq_log_primorial then proves θ(n) = log(n#): rewrite primorial as the ℕ-product ∏ p, push the cast inside with Nat.cast_prod to get a product of reals, and apply Real.log_prod to split log of the product into the sum of logs. Real.log_prod needs each factor nonzero, discharged because a prime p satisfies 0 < p, hence (p:ℝ) ≠ 0.",
+    "mathContext": "$\\log\\prod_{p} p = \\sum_p \\log p$ requires every $p \\ne 0$, true since primes are $\\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "Nat.cast_prod",
+      "primorial"
+    ],
+    "prerequisites": [
+      "finite products",
+      "casting ℕ products to ℝ"
+    ]
+  },
+  {
+    "id": "ann-chebo0602-structure",
+    "proofId": "chebyshev-bounds-oq-06-oq-02",
+    "range": {
+      "startLine": 41,
+      "endLine": 56
+    },
+    "type": "technique",
+    "title": "θ is nonnegative and monotone",
+    "content": "Two elementary structural facts. chebyshevTheta_nonneg: each summand log p is ≥ 0 because a prime p is ≥ 2 > 1, so Real.log_nonneg applies and Finset.sum_nonneg finishes. chebyshevTheta_mono: enlarging n from m ≤ n only enlarges the prime index set (range(m+1) ⊆ range(n+1), hence the same containment after filtering by primality), and the newly adjoined summands are again nonnegative, so Finset.sum_le_sum_of_subset_of_nonneg gives θ(m) ≤ θ(n).",
+    "mathContext": "$\\theta$ is a sum of nonnegative terms indexed by a monotone family of finite sets, hence nondecreasing and $\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_nonneg",
+      "Finset.sum_le_sum_of_subset_of_nonneg",
+      "monotonicity"
+    ],
+    "prerequisites": [
+      "log p ≥ 0 for p ≥ 1",
+      "subset monotonicity of sums of nonnegative terms"
+    ]
+  },
+  {
+    "id": "ann-chebo0602-main",
+    "proofId": "chebyshev-bounds-oq-06-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 74
+    },
+    "type": "key-step",
+    "title": "The upper Chebyshev bound θ(n) ≤ n·log 4",
+    "content": "The main result. Rewrite θ(n) = log(n#), then apply Real.log_le_log (log is increasing on the positive reals) to Mathlib's primorial bound n# ≤ 4ⁿ, giving log(n#) ≤ log(4ⁿ); positivity of n# comes from primorial_pos. Finish with Real.log_pow: log(4ⁿ) = n·log 4. The companion chebyshevTheta_le_two_mul rewrites log 4 = 2·log 2 to present the bound as θ(n) ≤ 2n·log 2, the form usually quoted in the Chebyshev estimates.",
+    "mathContext": "$\\theta(n) = \\log(n\\#) \\le \\log(4^n) = n\\log 4 = 2n\\log 2$, using $n\\# \\le 4^n$ and monotone $\\log$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "primorial_le_4_pow",
+      "Real.log_le_log",
+      "Real.log_pow",
+      "Chebyshev bounds"
+    ],
+    "prerequisites": [
+      "monotonicity of log",
+      "log of a power",
+      "primorial bound n# ≤ 4ⁿ"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevThetaFourPow.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevBoundsOq06Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevBoundsOq06Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevBoundsOq06Oq02Data: ProofData = {
+  proof: chebyshevBoundsOq06Oq02Proof,
+  annotations: chebyshevBoundsOq06Oq02Annotations,
+}

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "chebyshev-bounds-oq-06-oq-02",
+  "title": "Chebyshev's θ function bounded: θ(n) ≤ n·log 4 via the primorial / central-binomial sandwich",
+  "slug": "chebyshev-bounds-oq-06-oq-02",
+  "description": "A fully machine-checked, axiom-free derivation of the upper Chebyshev bound on the first Chebyshev function θ(n) = ∑_{p ≤ n, p prime} log p. The key observation is that the exponential of θ(n) is exactly the primorial n# = ∏_{p ≤ n} p, so θ(n) = log(n#). Mathlib packages the Erdős central-binomial sandwich as Nat.primorial_le_4_pow : n# ≤ 4ⁿ; taking logarithms and using monotonicity of log on the positive reals turns this into θ(n) ≤ n·log 4 = 2n·log 2, the upper half of the classical Chebyshev estimates on θ. This is the θ-level companion to the parent's central-binomial coefficient sandwich (chebyshev-bounds-oq-06): where the parent bounds C(2n,n), this entry bounds the prime-log sum θ that C(2n,n) controls.",
+  "meta": {
+    "author": "Classical (bound due to Chebyshev/Erdős); assembled in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev-bounds",
+      "chebyshev-function",
+      "primorial",
+      "central-binomial-coefficient",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevThetaFourPow.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "primorial_le_4_pow",
+        "description": "n# ≤ 4ⁿ, the Erdős central-binomial sandwich bound on the primorial (proved in Mathlib from n# ∣ m#·C(m+n,m)). This IS the arithmetic core; the entry only takes its logarithm.",
+        "module": "Mathlib.NumberTheory.Primorial"
+      },
+      {
+        "theorem": "primorial_pos",
+        "description": "0 < n#, positivity of the primorial, needed to take logarithms.",
+        "module": "Mathlib.NumberTheory.Primorial"
+      },
+      {
+        "theorem": "Real.log_prod",
+        "description": "log(∏ f) = ∑ log f for nonzero factors, used to identify θ(n) = ∑ log p with log(n#).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_le_log",
+        "description": "Monotonicity of log on the positive reals, turning n# ≤ 4ⁿ into log(n#) ≤ log(4ⁿ).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(xⁿ) = n·log x, giving log(4ⁿ) = n·log 4.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevTheta: a definition of the first Chebyshev function θ(n) = ∑_{p ≤ n, p prime} log p as a real number, matching the primorial's index set range(n+1) with p.Prime",
+      "chebyshevTheta_eq_log_primorial: the identity θ(n) = log(n#) obtained by casting the ℕ-product to ℝ and applying Real.log_prod, the bridge that lets the primorial bound act on the log-sum",
+      "chebyshevTheta_le: the upper Chebyshev bound θ(n) ≤ n·log 4, the main result, derived by taking logarithms in Nat.primorial_le_4_pow",
+      "chebyshevTheta_le_two_mul: the equivalent form θ(n) ≤ 2n·log 2 using log 4 = 2·log 2",
+      "chebyshevTheta_nonneg and chebyshevTheta_mono: θ is nonnegative and monotone (each summand log p ≥ 0 since p ≥ 2), the elementary structural facts about θ"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 76,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide (hence no Lean.ofReduceBool), no structure-encoded hypotheses. Honest framing: the arithmetic content is entirely Mathlib's primorial_le_4_pow (the central-binomial sandwich); the contribution is the log-side packaging identifying θ(n) with log(n#) and reading off the Chebyshev bound.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "definition-and-primorial-identity",
+      "title": "θ(n) as the logarithm of the primorial",
+      "startLine": 28,
+      "endLine": 39,
+      "summary": "chebyshevTheta n = ∑_{p ≤ n, p prime} log p. chebyshevTheta_eq_log_primorial proves θ(n) = log(n#): cast the ℕ-product primorial n = ∏ p to ℝ with Nat.cast_prod, then Real.log_prod turns log of the product into the sum of logs (each factor p ≥ 2 is nonzero)."
+    },
+    {
+      "id": "positivity-and-monotonicity",
+      "title": "θ is nonnegative and monotone",
+      "startLine": 41,
+      "endLine": 56,
+      "summary": "chebyshevTheta_nonneg: every summand log p ≥ 0 since a prime p ≥ 2 > 1, so the sum is nonnegative. chebyshevTheta_mono: m ≤ n adjoins only nonnegative terms (Finset.sum_le_sum_of_subset_of_nonneg over the nested prime filters range(m+1) ⊆ range(n+1))."
+    },
+    {
+      "id": "chebyshev-upper-bound",
+      "title": "The upper Chebyshev bound θ(n) ≤ n·log 4",
+      "startLine": 58,
+      "endLine": 74,
+      "summary": "chebyshevTheta_le rewrites θ(n) = log(n#), applies Real.log_le_log to the primorial bound n# ≤ 4ⁿ (Nat.primorial_le_4_pow), and finishes with Real.log_pow: log(4ⁿ) = n·log 4. chebyshevTheta_le_two_mul restates this as θ(n) ≤ 2n·log 2 via log 4 = 2·log 2."
+    }
+  ],
+  "overview": "Chebyshev's first function θ(x) = ∑_{p ≤ x} log p is the additive prime-counting weight underlying the prime number theorem; the classical Chebyshev bounds sandwich θ(x) between two constant multiples of x. This entry formalizes the upper half, θ(n) ≤ n·log 4, in its cleanest form. The engine is a single identity: exponentiating θ(n) gives the primorial n# = ∏_{p ≤ n} p, so θ(n) = log(n#). Mathlib already contains the arithmetic heart — primorial_le_4_pow : n# ≤ 4ⁿ, whose own proof is the Erdős argument bounding the primorial by a central binomial coefficient. Taking logarithms of that bound and using that log is increasing on the positive reals yields θ(n) ≤ log(4ⁿ) = n·log 4 immediately. The entry is an honest assembly: no new arithmetic, but the log-side packaging (defining θ, proving θ = log(n#), and reading off the Chebyshev estimate) is what connects Mathlib's primorial bound to the standard analytic-number-theory statement about θ.",
+  "conclusion": "The upper Chebyshev bound θ(n) ≤ n·log 4 = 2n·log 2 is verified with 0 axioms and 0 sorries. It sits directly above the parent central-binomial sandwich (chebyshev-bounds-oq-06): the primorial bound n# ≤ 4ⁿ that this entry logarithmizes is proved in Mathlib from exactly the central binomial coefficient estimate the parent packages. A natural next step is the matching lower bound θ(n) ≥ c·n for a constant c (harder — it requires a positive-density input such as a lower bound on the number of primes up to n, e.g. via the central binomial coefficient's prime factorization), which together would give the full two-sided Chebyshev estimate θ(n) = Θ(n).",
+  "crossReferences": [
+    "chebyshev-bounds-oq-06"
+  ],
+  "references": [
+    {
+      "title": "Chebyshev function (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev_function"
+    },
+    {
+      "title": "Primorial (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Primorial"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry answering open question **chebyshev-bounds-oq-06-oq-02**: a fully machine-checked, 0-axiom derivation of the upper Chebyshev bound on the first Chebyshev function θ(n) = ∑_{p ≤ n, p prime} log p.

**Key identity:** exponentiating θ collapses the sum of logs into the primorial n# = ∏_{p≤n} p, so θ(n) = log(n#). Mathlib packages the Erdős central-binomial sandwich as `primorial_le_4_pow : n# ≤ 4ⁿ`; taking logarithms and using monotonicity of log on the positive reals gives the sharp bound

  θ(n) ≤ n·log 4 = 2n·log 2.

This is the θ-level companion to the parent entry chebyshev-bounds-oq-06 (which bounds the central binomial coefficient C(2n,n) that θ controls).

## Contents (`proofs/Proofs/ChebyshevThetaFourPow.lean`, 76L, 5 thm / 1 def)
- `chebyshevTheta` — θ(n) as a real number over the primorial's index set
- `chebyshevTheta_eq_log_primorial` — θ(n) = log(n#)
- `chebyshevTheta_nonneg`, `chebyshevTheta_mono` — structural facts
- `chebyshevTheta_le` — **main:** θ(n) ≤ n·log 4
- `chebyshevTheta_le_two_mul` — θ(n) ≤ 2n·log 2

## Verification
- Compiles clean under host Lean **v4.26.0** (`lake env lean`, exit 0).
- `#print axioms` on all three main theorems: only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **0 axioms, 0 sorries → status: verified.**

## Honest framing
The arithmetic content is entirely Mathlib's `primorial_le_4_pow` (the central-binomial sandwich). The contribution is the log-side packaging that identifies θ(n) with log(n#) and reads off the classical Chebyshev estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)