### PR TITLE
Enrich Neumann series for (1−t)⁻¹ (geometric-series-oq-02-oq-03-oq-01): annotate module docstring

### DIFF
--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
@@ -1,50 +1,125 @@
 [
   {
+    "id": "ann-overview-header",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Overview: the Neumann series for (1 − t)⁻¹",
+    "content": "The scalar geometric series $\\sum r^n = 1/(1-r)$ for $|r|<1$ generalises to any Banach algebra (complete normed ring): if $\\lVert t\\rVert < 1$ then $1-t$ is invertible with inverse given by the convergent **Neumann series** $(1-t)^{-1} = \\sum_{n} t^n$. This is the cornerstone of perturbation theory — a small perturbation of the identity stays invertible, with an inverse computable to any order by truncation — and it underlies the openness of the unit group, the holomorphy of the resolvent, and the convergence of iterative solvers (Jacobi / Gauss–Seidel). The file packages this over a normed ring with `HasSummableGeomSeries` (which holds for every Banach algebra), exposing a named API: `neumann_series` (`Ring.inverse (1 - t) = ∑' n, tⁿ`), its `HasSum` form, `isUnit_one_sub`, the two-sided-inverse lemmas `neumann_mul_left`/`neumann_mul_right`, and `neumann_partial_remainder` (finite truncation with explicit remainder). Each result is a thin, named wrapper around Mathlib's `geom_series_eq_inverse`, `hasSum_geom_series_inverse`, and `NormedRing.inverse_one_sub_nth_order'`; the header also opens the `Topology` scope and `Finset`, and fixes the ambient normed ring `R`.",
+    "mathContext": "For $\\lVert t\\rVert<1$ in a Banach algebra, $(1-t)^{-1}=\\sum_{n\\ge 0} t^n$ (Neumann series).",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric series",
+      "Banach algebra",
+      "Neumann series",
+      "invertible operators",
+      "resolvent",
+      "perturbation theory"
+    ],
+    "prerequisites": [
+      "normed rings",
+      "summable series",
+      "units in a ring"
+    ]
+  },
+  {
     "id": "ann-gs0201-identity",
     "proofId": "geometric-series-oq-02-oq-03-oq-01",
-    "range": { "startLine": 39, "endLine": 62 },
+    "range": {
+      "startLine": 39,
+      "endLine": 62
+    },
     "type": "concept",
     "title": "The Neumann Series Identity",
     "content": "neumann_series is the operator-theoretic geometric series: in a normed ring with summable geometric series (any Banach algebra), ‖t‖ < 1 gives (1 − t)⁻¹ = ∑' n, tⁿ. It is Mathlib's geom_series_eq_inverse read in the natural direction. hasSum_neumann_series records the same fact as a HasSum (the partial sums converge to the inverse), and summable_neumann_series notes the series converges because ‖tⁿ‖ ≤ ‖t‖ⁿ is geometrically dominated.",
     "mathContext": "$\\|t\\| < 1 \\;\\Rightarrow\\; (1-t)^{-1} = \\sum_{n=0}^{\\infty} t^n$, generalizing $\\frac{1}{1-r} = \\sum_n r^n$ to a Banach algebra.",
     "significance": "critical",
-    "relatedConcepts": ["Neumann series", "geometric series", "Banach algebra", "tsum / HasSum", "geometric domination"],
-    "prerequisites": ["normed rings", "summability in complete spaces", "geometric series"]
+    "relatedConcepts": [
+      "Neumann series",
+      "geometric series",
+      "Banach algebra",
+      "tsum / HasSum",
+      "geometric domination"
+    ],
+    "prerequisites": [
+      "normed rings",
+      "summability in complete spaces",
+      "geometric series"
+    ]
   },
   {
     "id": "ann-gs0201-invertibility",
     "proofId": "geometric-series-oq-02-oq-03-oq-01",
-    "range": { "startLine": 63, "endLine": 86 },
+    "range": {
+      "startLine": 63,
+      "endLine": 86
+    },
     "type": "tactic",
     "title": "Invertibility and the Two-Sided Inverse",
     "content": "isUnit_one_sub captures the qualitative heart: a perturbation of the identity by anything of norm < 1 stays invertible — the reason the unit group of a Banach algebra is open. neumann_mul_left and neumann_mul_right then verify the series really is a two-sided inverse of 1 − t: each rewrites ∑' n, tⁿ back to Ring.inverse (1 − t) and applies Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness from isUnit_one_sub.",
     "mathContext": "$1-t \\in R^{\\times}$ when $\\|t\\|<1$; $\\;(1-t)\\sum_n t^n = \\sum_n t^n\\,(1-t) = 1$.",
     "significance": "key",
-    "relatedConcepts": ["unit group", "open set of invertibles", "two-sided inverse", "Ring.inverse", "perturbation of the identity"],
-    "prerequisites": ["units in a ring", "Ring.inverse API"]
+    "relatedConcepts": [
+      "unit group",
+      "open set of invertibles",
+      "two-sided inverse",
+      "Ring.inverse",
+      "perturbation of the identity"
+    ],
+    "prerequisites": [
+      "units in a ring",
+      "Ring.inverse API"
+    ]
   },
   {
     "id": "ann-gs0201-truncation",
     "proofId": "geometric-series-oq-02-oq-03-oq-01",
-    "range": { "startLine": 87, "endLine": 104 },
+    "range": {
+      "startLine": 87,
+      "endLine": 104
+    },
     "type": "tactic",
     "title": "Finite Truncation with Explicit Remainder",
     "content": "neumann_partial_remainder (Mathlib's inverse_one_sub_nth_order') gives (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ·(1 − t)⁻¹. The remainder term tᴺ·(1 − t)⁻¹ has norm at most ‖t‖ᴺ·‖(1 − t)⁻¹‖, which decays geometrically, so truncating after N terms yields an inverse to any prescribed accuracy. This is exactly the convergence mechanism of stationary iterative solvers and of successive approximation for integral equations.",
     "mathContext": "$(1-t)^{-1} = \\sum_{i<N} t^i + t^N (1-t)^{-1}, \\quad \\|t^N(1-t)^{-1}\\| \\le \\|t\\|^N \\,\\|(1-t)^{-1}\\| \\to 0.$",
     "significance": "key",
-    "relatedConcepts": ["truncation error", "geometric convergence", "iterative inversion", "stationary iterative methods", "successive approximation"],
-    "prerequisites": ["partial sums", "operator norm estimates"]
+    "relatedConcepts": [
+      "truncation error",
+      "geometric convergence",
+      "iterative inversion",
+      "stationary iterative methods",
+      "successive approximation"
+    ],
+    "prerequisites": [
+      "partial sums",
+      "operator norm estimates"
+    ]
   },
   {
     "id": "ann-gs0201-summary",
     "proofId": "geometric-series-oq-02-oq-03-oq-01",
-    "range": { "startLine": 105, "endLine": 129 },
+    "range": {
+      "startLine": 105,
+      "endLine": 129
+    },
     "type": "concept",
     "title": "Summary: From Scalars to Operators",
     "content": "The closing table pairs each result with its Mathlib backing. The scalar geometric series 1/(1 − r) = ∑ rⁿ is the R = ℝ case; abstracting to a normed ring makes the one identity cover scalars, matrices, and bounded operators at once. Downstream it yields the openness of the unit group, the analyticity of inversion and of the resolvent (λ − T)⁻¹, and the spectral theory built on them.",
     "mathContext": "$R = \\mathbb{R}$ recovers $\\tfrac{1}{1-r}=\\sum_n r^n$; general $R$ covers matrices and bounded operators, underpinning the resolvent $(\\lambda - T)^{-1}$.",
     "significance": "supporting",
-    "relatedConcepts": ["spectral theory", "resolvent", "holomorphic functional calculus", "operator algebras", "abstraction over normed rings"],
-    "prerequisites": ["functional analysis", "spectral theory basics"]
+    "relatedConcepts": [
+      "spectral theory",
+      "resolvent",
+      "holomorphic functional calculus",
+      "operator algebras",
+      "abstraction over normed rings"
+    ],
+    "prerequisites": [
+      "functional analysis",
+      "spectral theory basics"
+    ]
   }
 ]


### PR DESCRIPTION
Enriches **geometric-series-oq-02-oq-03-oq-01** by annotating its previously-unannotated module docstring.

The opening `/- … -/` header (imports + the file's motivating summary) had no annotation — annotation coverage started only at the first theorem, leaving the header uncovered. This adds one anchored `concept` overview annotation covering the header lines, with `mathContext`, `significance: key`, `relatedConcepts`, and `prerequisites`.

Coverage 71% → ~99%. The annotation paraphrases the Neumann-series API: (1−t)⁻¹ = ∑ tⁿ in a Banach algebra, and the named wrappers over Mathlib's geom-series lemmas.

No existing annotations changed; the new leading range does not overlap the first theorem block. JSON validates; entry has no `annotations.source.json`, so the hand-edited `annotations.json` is authoritative.
