### PR TITLE
Enrich By-length composition count C(n−1,k−1) (composition-card-2pow-oq-01-oq-01): annotate module docstring

### DIFF
--- a/src/data/proofs/composition-card-2pow-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/composition-card-2pow-oq-01-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-overview-header",
+    "proofId": "composition-card-2pow-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Overview: the by-length count C(n−1, k−1) of compositions",
+    "content": "A *composition* of $n$ into exactly $k$ parts is an ordered $k$-tuple of positive integers summing to $n$ (`Composition n` with `length = k`). The parent counts them in total, $\\#(\\text{Composition } n) = 2^{n-1}$; this leaf proves the finer **by-length** refinement $\\#\\{c : \\text{Composition } n \\mid c.\\text{length} = k\\} = \\binom{n-1}{k-1}$, from which the parent's total is recovered by $\\sum_k \\binom{n-1}{k-1} = 2^{n-1}$. The proof uses Mathlib's \"bar or no bar in each of the $n-1$ internal gaps\" bijection, `compositionEquiv n : Composition n ≃ CompositionAsSet n` composed with `compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n-1))`. Under it the number of parts equals `(gap subset).card + 1` (a $k$-part composition has exactly $k-1$ cuts); the file proves this length/cardinality dictionary (`equiv_card_add_one`) by writing the boundaries as $\\{0,\\text{last}\\}\\uplus(\\text{shifted gap subset})$, transports \"exactly $k$ parts\" to \"gap subsets of size $k-1$\" via `Equiv.subtypeEquiv`, and reads the count off `Fintype.card_finset_len`. The sum over $k$ then follows from `Nat.sum_range_choose`. The header opens `Finset`.",
+    "mathContext": "$\\#\\{c:\\text{Composition } n \\mid c.\\text{length}=k\\}=\\binom{n-1}{k-1}$, and $\\sum_k\\binom{n-1}{k-1}=2^{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "composition of an integer",
+      "stars and bars",
+      "binomial coefficient",
+      "Fintype cardinality",
+      "subsets of fixed size"
+    ],
+    "prerequisites": [
+      "compositions of an integer",
+      "binomial coefficients",
+      "Finset cardinality"
+    ]
+  },
+  {
     "id": "ann-length-cardinality-dictionary",
     "proofId": "composition-card-2pow-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enriches **composition-card-2pow-oq-01-oq-01** by annotating its previously-unannotated module docstring.

The opening `/- … -/` header (imports + the file's motivating summary) had no annotation — annotation coverage started only at the first theorem, leaving the header uncovered. This adds one anchored `concept` overview annotation covering the header lines, with `mathContext`, `significance: key`, `relatedConcepts`, and `prerequisites`.

Coverage 72% → ~99%. The annotation paraphrases the header: the by-length count C(n−1,k−1) of compositions via the gap-subset bijection and Fintype.card_finset_len.

No existing annotations changed; the new leading range does not overlap the first theorem block. JSON validates; entry has no `annotations.source.json`, so the hand-edited `annotations.json` is authoritative.
