### PR TITLE
research(minkowski-fundamental-theorem-oq-03): general-k Blichfeldt theorem [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ03.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ03.lean
@@ -1,0 +1,136 @@
+/-
+Blichfeldt's Generalization of Minkowski's Fundamental Theorem
+(minkowski-fundamental-theorem-oq-03)
+
+This file formalizes the *general-multiplicity* form of Blichfeldt's principle,
+the honest generalization of Minkowski's fundamental theorem to a lattice of
+arbitrary "packing multiplicity".
+
+## Statement
+
+Let `L` be a countable subgroup acting on a measure space `E` with an additive
+fundamental domain `F` of covolume `μ F`, and let `s` be any null-measurable set.
+If
+
+  `k · μ F < μ s`
+
+then there exist more than `k` lattice elements `l` and a common point `z` with
+`z ∈ l +ᵥ s` for every such `l`.  Equivalently (in a group), there are `k + 1`
+points of `s` that are pairwise congruent modulo `L`.
+
+At `k = 1` this is exactly Mathlib's
+`MeasureTheory.exists_pair_mem_lattice_not_disjoint_vadd` (Blichfeldt's principle,
+two points), and it is the multiplicity input from which the general-`k`
+(van der Corput) refinement of Minkowski's convex-body theorem is derived.
+
+Unlike the parent entry's `blichfeldt_statement` (which is really *van der Corput*:
+convexity, symmetry, and a `2ⁿ` factor produce `k + 1` *lattice points* of a
+convex body), the statement here is the true Blichfeldt theorem: an arbitrary
+bounded measurable set and no `2ⁿ` factor, producing points of `s` congruent mod
+`L`.
+
+## Proof
+
+A measure-theoretic pigeonhole ("multiplicity averaging"):
+
+* The covering-count `g z = ∑' l, 𝟙_{l +ᵥ s}(z)` integrates over the fundamental
+  domain to `μ s` (Tonelli + translation of the fundamental domain).
+* If `g z ≤ k` everywhere, then `μ s = ∫_F g ≤ k · μ F`, contradicting the
+  hypothesis.  Hence some `z` is covered more than `k` times.
+* Extracting a finite over-covered subfamily gives `T` with `k < #T` and
+  `z ∈ l +ᵥ s` for all `l ∈ T`.
+
+The `k = 1` case recovers `exists_pair_mem_lattice_not_disjoint_vadd`.
+-/
+import Mathlib.MeasureTheory.Group.GeometryOfNumbers
+import Mathlib.MeasureTheory.Integral.Lebesgue.Add
+import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
+
+open MeasureTheory ENNReal Set Filter
+open scoped Pointwise ENNReal
+
+namespace Blichfeldt
+
+/-!
+### Finite extraction from an over-large `tsum`
+
+If a `[0,1]`-valued family sums (as a `tsum` in `ℝ≥0∞`) to something exceeding a
+natural number `k`, then more than `k` of its terms are nonzero.  This is the
+combinatorial core of the pigeonhole.
+-/
+
+/-- If each `f i ≤ 1` and `k < ∑' i, f i` in `ℝ≥0∞`, there is a finite set `T`
+with more than `k` elements on each of which `f` is nonzero. -/
+theorem exists_finset_card_lt_of_lt_tsum {ι : Type*} [Countable ι] {f : ι → ℝ≥0∞}
+    (hf : ∀ i, f i ≤ 1) {k : ℕ} (h : (k : ℝ≥0∞) < ∑' i, f i) :
+    ∃ T : Finset ι, k < T.card ∧ ∀ i ∈ T, f i ≠ 0 := by
+  classical
+  rw [ENNReal.tsum_eq_iSup_sum] at h
+  obtain ⟨u, hu⟩ := lt_iSup_iff.mp h
+  refine ⟨u.filter (fun i => f i ≠ 0), ?_, ?_⟩
+  · -- `k < #(filtered set)`
+    have hsum : ∑ i ∈ u.filter (fun i => f i ≠ 0), f i = ∑ i ∈ u, f i :=
+      Finset.sum_filter_of_ne (fun x _ hx => hx)
+    have hcard : ∑ i ∈ u.filter (fun i => f i ≠ 0), f i
+        ≤ (u.filter (fun i => f i ≠ 0)).card := by
+      calc ∑ i ∈ u.filter (fun i => f i ≠ 0), f i
+          ≤ ∑ _i ∈ u.filter (fun i => f i ≠ 0), (1 : ℝ≥0∞) :=
+            Finset.sum_le_sum (fun i _ => hf i)
+        _ = (u.filter (fun i => f i ≠ 0)).card := by simp
+    have : (k : ℝ≥0∞) < ((u.filter (fun i => f i ≠ 0)).card : ℝ≥0∞) :=
+      lt_of_lt_of_le (hsum ▸ hu) hcard
+    exact_mod_cast this
+  · intro i hi
+    exact (Finset.mem_filter.mp hi).2
+
+end Blichfeldt
+
+namespace MeasureTheory
+
+variable {E L : Type*} [MeasurableSpace E] {μ : Measure E} {F s : Set E}
+
+/-- **Blichfeldt's Theorem (general multiplicity).**  If the volume of `s`
+exceeds `k` times the covolume `μ F` of the countable subgroup `L`, then there is
+a point `z` covered by more than `k` translates of `s` by `L`: a finite set
+`T ⊆ L` with `k < #T` and `z ∈ l +ᵥ s` for every `l ∈ T`.
+
+Equivalently, the `#T` points `{z} - T ⊆ s` are pairwise congruent modulo `L`.
+
+At `k = 1` this specializes to
+`exists_pair_mem_lattice_not_disjoint_vadd`. -/
+theorem exists_finset_lattice_common_vadd [AddGroup L] [Countable L] [AddAction L E]
+    [MeasurableSpace L] [MeasurableVAdd L E] [VAddInvariantMeasure L E μ]
+    (fund : IsAddFundamentalDomain L F μ) (hs : NullMeasurableSet s μ) {k : ℕ}
+    (h : k • μ F < μ s) :
+    ∃ T : Finset L, k < T.card ∧ ∃ z, ∀ l ∈ T, z ∈ (l +ᵥ s) := by
+  classical
+  -- Each translate of `s` is null-measurable (invariance of `μ`).
+  have hnull : ∀ l : L, NullMeasurableSet (l +ᵥ s) μ := fun l => hs.vadd l
+  have hnullr : ∀ l : L, NullMeasurableSet (l +ᵥ s) (μ.restrict F) := fun l =>
+    (hnull l).mono_ac Measure.restrict_le_self.absolutelyContinuous
+  -- Key averaging identity: the covering count integrates over `F` to `μ s`.
+  have key : ∫⁻ z in F, (∑' l : L, (l +ᵥ s).indicator (1 : E → ℝ≥0∞) z) ∂μ = μ s := by
+    rw [lintegral_tsum (f := fun (l : L) (z : E) => (l +ᵥ s).indicator (1 : E → ℝ≥0∞) z)
+      (fun l => (aemeasurable_indicator_iff₀ (hnullr l)).mpr aemeasurable_const),
+      fund.measure_eq_tsum s]
+    refine tsum_congr (fun l => ?_)
+    rw [lintegral_indicator_one₀ (hnullr l), Measure.restrict_apply₀' fund.nullMeasurableSet]
+  -- Pigeonhole: some point is covered more than `k` times.
+  have hz : ∃ z, (k : ℝ≥0∞) < ∑' l : L, (l +ᵥ s).indicator (1 : E → ℝ≥0∞) z := by
+    by_contra hall
+    push_neg at hall
+    have hle : ∫⁻ z in F, (∑' l : L, (l +ᵥ s).indicator (1 : E → ℝ≥0∞) z) ∂μ
+        ≤ ∫⁻ _ in F, (k : ℝ≥0∞) ∂μ := lintegral_mono hall
+    rw [key, setLIntegral_const] at hle
+    rw [nsmul_eq_mul] at h
+    exact absurd (lt_of_lt_of_le h hle) (lt_irrefl _)
+  obtain ⟨z, hz⟩ := hz
+  -- Extract a finite over-covered subfamily.
+  have hbound : ∀ l : L, (l +ᵥ s).indicator (1 : E → ℝ≥0∞) z ≤ 1 := by
+    intro l; rw [Set.indicator_apply]; split <;> simp
+  obtain ⟨T, hcard, hne⟩ :=
+    Blichfeldt.exists_finset_card_lt_of_lt_tsum hbound hz
+  refine ⟨T, hcard, z, fun l hl => ?_⟩
+  exact (Set.indicator_apply_ne_zero.mp (hne l hl)).1
+
+end MeasureTheory

--- a/research/problems/minkowski-fundamental-theorem-oq-03/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03/knowledge.md
@@ -105,3 +105,38 @@ dedicated to the measure-multiplicity pigeonhole; not a spare-cycle task.
 - H. F. Blichfeldt (1914), *A new principle in the geometry of numbers*, Trans. AMS 15.
 - J. G. van der Corput (1936), generalization counting lattice points in convex bodies.
 - Mathlib `MeasureTheory.Group.GeometryOfNumbers` (`exists_pair_mem_lattice_not_disjoint_vadd`).
+
+---
+
+## Session 2026-07-02 (Session 2) — SOLVED (researcher-4)
+
+**Mode**: FRESH (executed Route A from Session 1's survey)
+**Outcome**: completed — 0-axiom verified
+
+### What I Did
+- Formalized **Route A** exactly as the Session-1 survey recommended: true general-`k`
+  Blichfeldt over Mathlib's `IsAddFundamentalDomain` API, self-contained.
+- New file `proofs/Proofs/MinkowskiFundamentalTheoremOQ03.lean` (136 L, 2 thm, 0 def).
+- New gallery entry `src/data/proofs/minkowski-fundamental-theorem-oq-03/`.
+
+### Theorems
+- `MeasureTheory.exists_finset_lattice_common_vadd` — `k • μF < μs ⇒ ∃ T:Finset L, k<#T ∧ ∃ z, ∀ l∈T, z ∈ l+ᵥs`.
+- `Blichfeldt.exists_finset_card_lt_of_lt_tsum` — reusable finite-extraction lemma.
+
+### Proof (measure-multiplicity pigeonhole)
+1. `key`: `∫⁻ z in F, (∑' l, (l+ᵥs).indicator 1 z) ∂μ = μ s` via `lintegral_tsum` (Tonelli)
+   + per-term `lintegral_indicator_one₀` / `restrict_apply₀'` + `fund.measure_eq_tsum s`.
+2. If `∀ z, g z ≤ k` then `μs = ∫_F g ≤ ∫_F k = k·μF` (`lintegral_mono`, `setLIntegral_const`,
+   `nsmul_eq_mul`), contradicting `h`. So `∃ z, k < g z`.
+3. Extract `T` from `k < ∑' l, indicator` via `tsum_eq_iSup_sum` + `lt_iSup_iff` + filter-to-support;
+   `Set.indicator_apply_ne_zero` gives `z ∈ l+ᵥs`.
+
+### Key API gotcha
+`lintegral_tsum` HOU on `indicator 1` fails; pass `(f := fun l z => (l+ᵥs).indicator 1 z)` explicitly.
+
+### Verification
+`lake env lean` (v4.26.0, warm Mathlib) EXIT 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` only ⇒ **0-axiom**.
+
+### Next Steps
+- Route B: general-`k` Minkowski / van der Corput by applying to `(1/2)•s` + convex counting.
+- Optional `k=1` sanity corollary recovering `exists_pair_mem_lattice_not_disjoint_vadd`.

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "minkowski-fundamental-theorem-oq-03",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "True Blichfeldt versus the parent's van der Corput statement",
+    "content": "The header states the honest general-multiplicity Blichfeldt theorem and flags a correction to the parent entry. Blichfeldt (1914): for ANY bounded measurable set s with μs > k·covolume there are k+1 points of s pairwise congruent mod the lattice L — no convexity, no symmetry, no 2ⁿ factor. The parent's blichfeldt_statement instead assumes s convex and symmetric with μs > k·2ⁿ·covolume and concludes k+1 LATTICE POINTS lie in s; that is van der Corput's theorem, a distinct result. At k = 1 the theorem here is exactly Mathlib's exists_pair_mem_lattice_not_disjoint_vadd.",
+    "mathContext": "$k\\cdot\\mu F < \\mu s \\Rightarrow \\exists\\,T\\subseteq L,\\ k<\\#T,\\ \\exists z\\ \\forall l\\in T,\\ z\\in l+ᵥs.$",
+    "significance": "supporting",
+    "relatedConcepts": ["geometry of numbers", "Blichfeldt principle", "van der Corput theorem", "fundamental domain", "covolume"],
+    "prerequisites": ["lattices and covolume", "measure of a set", "congruence modulo a subgroup"]
+  },
+  {
+    "id": "ann-extraction",
+    "proofId": "minkowski-fundamental-theorem-oq-03",
+    "range": { "startLine": 54, "endLine": 86 },
+    "type": "tactic",
+    "title": "Finite extraction from an over-large tsum",
+    "content": "The combinatorial pigeonhole core. Given a family f : ι → ℝ≥0∞ with every f i ≤ 1 and k < ∑' i, f i, we produce a finite set with more than k nonzero terms. Rewriting the tsum as the supremum of its finite partial sums (ENNReal.tsum_eq_iSup_sum) and using lt_iSup_iff yields a finite u with k < ∑_{i∈u} f i. Filtering u to the support {i : f i ≠ 0} preserves the sum (Finset.sum_filter_of_ne), and the filtered sum is bounded by its cardinality because each term is ≤ 1. Hence k < #T with f nonzero on all of T; a cast (exact_mod_cast) transfers the strict inequality from ℝ≥0∞ back to ℕ.",
+    "mathContext": "$k<\\sum_{i\\in u} f_i = \\sum_{i\\in T} f_i \\le \\#T$ where $T=\\{i\\in u: f_i\\ne 0\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "unconditional sums in ℝ≥0∞", "supremum of partial sums", "Finset.filter"],
+    "prerequisites": ["tsum as iSup of finite sums", "sum bounded by cardinality"]
+  },
+  {
+    "id": "ann-averaging",
+    "proofId": "minkowski-fundamental-theorem-oq-03",
+    "range": { "startLine": 108, "endLine": 118 },
+    "type": "tactic",
+    "title": "The covering-count averaging identity",
+    "content": "The measure-theoretic heart: the covering count g(z) = ∑' l, 𝟙_{l+ᵥs}(z) integrates over the fundamental domain F to exactly μ s. Tonelli for nonnegative functions (lintegral_tsum) swaps ∫_F and ∑'; each translate l +ᵥ s is null-measurable by invariance of μ (NullMeasurableSet.vadd), transferred to μ.restrict F via mono_ac. The integral of a {0,1}-indicator over F is the restricted measure (lintegral_indicator_one₀, restrict_apply₀'), i.e. μ((l+ᵥs)∩F), and summing these is μ s by the fundamental-domain decomposition IsAddFundamentalDomain.measure_eq_tsum.",
+    "mathContext": "$\\int_F \\sum_{l}\\mathbf 1_{l+ᵥs}\\,d\\mu = \\sum_l \\mu((l+ᵥs)\\cap F) = \\mu s.$",
+    "significance": "key",
+    "relatedConcepts": ["Tonelli theorem", "fundamental domain decomposition", "translation-invariant measure", "indicator integral"],
+    "prerequisites": ["Lebesgue integral of a countable sum", "measure of translates", "null-measurable sets"]
+  },
+  {
+    "id": "ann-pigeonhole",
+    "proofId": "minkowski-fundamental-theorem-oq-03",
+    "range": { "startLine": 119, "endLine": 136 },
+    "type": "tactic",
+    "title": "Pigeonhole and extraction of the over-covered family",
+    "content": "If g(z) ≤ k for every z, then μ s = ∫_F g ≤ ∫_F k = k·μF (lintegral_mono, setLIntegral_const, nsmul_eq_mul), contradicting the hypothesis k • μF < μs; so some z has k < g(z). Since each indicator is ≤ 1 (Set.indicator_apply), the finite-extraction lemma yields a finite T ⊆ L with k < #T and every term nonzero. A nonzero indicator value forces membership (Set.indicator_apply_ne_zero), giving z ∈ l +ᵥ s for all l ∈ T — the required over-covering family.",
+    "mathContext": "$\\forall z,\\ g(z)\\le k \\Rightarrow \\mu s \\le k\\mu F$; contradiction $\\Rightarrow \\exists z,\\ k<g(z)$.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity of the Lebesgue integral", "constant integral over a set", "proof by contradiction", "indicator support"],
+    "prerequisites": ["∫_F c = c·μF", "indicator nonzero ⇒ membership"]
+  }
+]

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "minkowski-fundamental-theorem-oq-03",
+  "title": "Blichfeldt's Generalization of Minkowski's Fundamental Theorem",
+  "slug": "minkowski-fundamental-theorem-oq-03",
+  "description": "The general-multiplicity form of Blichfeldt's principle over Mathlib's abstract fundamental-domain API. If a null-measurable set s has volume exceeding k times the covolume μF of a countable subgroup L, then some point z is covered by more than k translates of s by L: there is a finite T ⊆ L with k < #T and z ∈ l +ᵥ s for every l ∈ T. Equivalently, s contains more than k points that are pairwise congruent modulo L. At k = 1 this is exactly Mathlib's exists_pair_mem_lattice_not_disjoint_vadd (Blichfeldt's two-point principle); Mathlib has no general-k version. This is the honest Blichfeldt theorem — an arbitrary bounded measurable set and no 2ⁿ factor — as opposed to the parent entry's blichfeldt_statement, which is really van der Corput's convex-body counting theorem.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ03.lean",
+    "author": "Lean Genius",
+    "date": "2026",
+    "tags": [
+      "number-theory",
+      "geometry-of-numbers",
+      "blichfeldt",
+      "lattices",
+      "measure-theory",
+      "pigeonhole",
+      "minkowski-theorem"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 136,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "dateAdded": "2026-07-02",
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.IsAddFundamentalDomain.measure_eq_tsum",
+        "description": "μ t = ∑' g, μ (g +ᵥ t ∩ F): decomposing the measure of a set through the translates of a fundamental domain",
+        "module": "Mathlib.MeasureTheory.Group.FundamentalDomain"
+      },
+      {
+        "theorem": "MeasureTheory.lintegral_tsum",
+        "description": "Tonelli for a countable sum of nonnegative measurable functions: ∫⁻ ∑' = ∑' ∫⁻",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.Add"
+      },
+      {
+        "theorem": "MeasureTheory.lintegral_indicator_one₀",
+        "description": "∫⁻ of the {0,1}-indicator of a null-measurable set equals its measure",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.exists_pair_mem_lattice_not_disjoint_vadd",
+        "description": "Mathlib's Blichfeldt principle (k = 1): two distinct lattice translates of s overlap when μ F < μ s — the special case recovered here",
+        "module": "Mathlib.MeasureTheory.Group.GeometryOfNumbers"
+      },
+      {
+        "theorem": "ENNReal.tsum_eq_iSup_sum",
+        "description": "A tsum in ℝ≥0∞ is the supremum of its finite partial sums — the engine of the finite-extraction lemma",
+        "module": "Mathlib.Topology.Instances.ENNReal.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "exists_finset_lattice_common_vadd: the general-k Blichfeldt theorem over Mathlib's IsAddFundamentalDomain API — k • μF < μs yields a point covered by more than k translates of s, with no convexity, symmetry, or 2ⁿ factor. Mathlib only has the k = 1 case.",
+      "exists_finset_card_lt_of_lt_tsum: a reusable finite-extraction lemma — if a [0,1]-valued family sums (as an ℝ≥0∞ tsum) to more than a natural number k, then more than k of its terms are nonzero.",
+      "The measure-multiplicity averaging identity: the covering count g(z) = ∑' l, 𝟙_{l+ᵥs}(z) integrates over the fundamental domain to exactly μ s (Tonelli plus translation of the fundamental domain), turning the covolume comparison into a pointwise pigeonhole.",
+      "Correcting the parent: documents that the parent entry's blichfeldt_statement (convex, symmetric, 2ⁿ·covolume ⇒ k+1 lattice points) is van der Corput's theorem, not Blichfeldt's, and formalizes the genuine Blichfeldt statement instead."
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1914 H. F. Blichfeldt gave a strengthening of Minkowski's fundamental theorem that dispenses entirely with convexity and symmetry: any bounded measurable set whose volume exceeds the covolume of a lattice must contain two points differing by a lattice vector. Iterating the volume hypothesis to k·covolume produces k+1 points pairwise congruent modulo the lattice. This 'multiplicity' principle is one of the pillars of the geometry of numbers and the source from which van der Corput's k-fold refinement of Minkowski's convex-body theorem is derived. Mathlib formalizes only the two-point (k = 1) case as exists_pair_mem_lattice_not_disjoint_vadd; this entry supplies the general-k statement.",
+    "problemStatement": "Formalize Blichfeldt's general-multiplicity theorem over Mathlib's abstract fundamental-domain API: for a countable subgroup L acting on a measure space E with additive fundamental domain F and any null-measurable s, if k • μF < μs then there exist a finite T ⊆ L with k < #T and a common point z ∈ ⋂_{l ∈ T} (l +ᵥ s).",
+    "proofStrategy": "A measure-theoretic pigeonhole. Consider the covering count g(z) = ∑' l, 𝟙_{l+ᵥs}(z). Tonelli (lintegral_tsum) plus the fundamental-domain decomposition (measure_eq_tsum) give ∫_F g dμ = μ s. If g(z) ≤ k for every z, then μ s = ∫_F g ≤ ∫_F k = k·μF, contradicting k • μF < μs; hence some z is covered more than k times. Since each translate contributes 0 or 1, a finite subfamily of size > k witnesses z ∈ l +ᵥ s — extracted by exists_finset_card_lt_of_lt_tsum from tsum_eq_iSup_sum.",
+    "keyInsights": [
+      "Averaging over the fundamental domain converts a global volume inequality into a pointwise multiplicity statement: the mean number of translates covering a point of F is exactly μs / μF, so exceeding k forces some point to be covered more than k times.",
+      "Working with the abstract IsAddFundamentalDomain API (rather than a concrete ℝⁿ lattice) makes the theorem apply to any countable subgroup with an invariant measure, and collapses to Mathlib's k = 1 lemma with no extra hypotheses.",
+      "The finite-extraction step is purely order-theoretic: an ℝ≥0∞ tsum of {0,1}-terms exceeding k, written as a supremum of finite partial sums, must already exceed k on some finite set, whose nonzero part has cardinality > k.",
+      "The parent's blichfeldt_statement carries convexity, symmetry, and a 2ⁿ factor and concludes with k+1 LATTICE POINTS — that is van der Corput's theorem. True Blichfeldt needs none of these and concludes with congruent points of s; conflating the two is a common textbook error that this entry avoids."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-extraction",
+      "title": "Finite Extraction from an Over-Large tsum",
+      "startLine": 54,
+      "endLine": 86,
+      "summary": "The combinatorial core: if each term of a family is ≤ 1 and the ℝ≥0∞ tsum exceeds a natural number k, then more than k terms are nonzero. Proved by writing the tsum as a supremum of finite partial sums (tsum_eq_iSup_sum), picking a finite set on which the partial sum exceeds k, and filtering to its nonzero support."
+    },
+    {
+      "id": "sec-blichfeldt",
+      "title": "Blichfeldt's General-Multiplicity Theorem",
+      "startLine": 90,
+      "endLine": 136,
+      "summary": "The main result. Builds the covering-count identity ∫_F (∑' l, 𝟙_{l+ᵥs}) dμ = μs via Tonelli and the fundamental-domain measure decomposition, runs the pigeonhole to find a point covered more than k times, and extracts the finite over-covering family."
+    }
+  ]
+}

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-03.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "minkowski-fundamental-theorem-oq-03",
   "title": "Blichfeldt's Generalization of Minkowski's Fundamental Theorem",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-22T12:51:58.295Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved general-k Blichfeldt theorem, 0-axiom verified.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "COMPLETE: general-k Blichfeldt (measure-multiplicity pigeonhole) formalized 0-axiom over Mathlib IsAddFundamentalDomain; k=1 recovers exists_pair_mem_lattice_not_disjoint_vadd.",
+    "builtItems": [
+      "exists_finset_lattice_common_vadd (MinkowskiFundamentalTheoremOQ03.lean): general-k Blichfeldt over IsAddFundamentalDomain",
+      "exists_finset_card_lt_of_lt_tsum: finite extraction from ℝ≥0∞ tsum of [0,1] terms > k"
+    ],
+    "insights": [
+      "Averaging g(z)=∑ 𝟙_{l+ᵥs}(z) over F integrates to μs (Tonelli + measure_eq_tsum); g(z)≤k everywhere ⇒ μs≤k·μF contradiction",
+      "Parent blichfeldt_statement is van der Corput (convex+symmetric+2ⁿ), not Blichfeldt — this entry states the honest Blichfeldt"
+    ],
+    "mathlibGaps": [
+      "Mathlib has only k=1 Blichfeldt (exists_pair_mem_lattice_not_disjoint_vadd); no general-multiplicity or van der Corput version"
+    ],
+    "nextSteps": [
+      "Derive general-k Minkowski / van der Corput by applying to (1/2)•s with convex counting (Route B)",
+      "Add k=1 sanity corollary explicitly recovering exists_pair_mem_lattice_not_disjoint_vadd"
+    ]
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

Formalizes the **general-multiplicity Blichfeldt theorem** — the honest generalization of Minkowski's fundamental theorem — over Mathlib's abstract `IsAddFundamentalDomain` API, answering research problem `minkowski-fundamental-theorem-oq-03`.

**Statement.** For a countable subgroup `L` acting on a measure space `E` with additive fundamental domain `F`, and any null-measurable `s`:
```
k • μF < μs  ⇒  ∃ T : Finset L, k < #T ∧ ∃ z, ∀ l ∈ T, z ∈ l +ᵥ s
```
i.e. some point is covered by more than `k` translates of `s` — equivalently, `s` contains `k+1` points pairwise congruent modulo `L`.

At `k = 1` this is exactly Mathlib's `exists_pair_mem_lattice_not_disjoint_vadd`. **Mathlib has no general-`k` version.**

## Proof — measure-multiplicity pigeonhole
1. The covering count `g(z) = ∑' l, 𝟙_{l+ᵥs}(z)` integrates over `F` to exactly `μ s` (Tonelli via `lintegral_tsum` + `IsAddFundamentalDomain.measure_eq_tsum`).
2. If `g(z) ≤ k` everywhere then `μs = ∫_F g ≤ k·μF`, contradicting the hypothesis; so some `z` is covered more than `k` times.
3. Finite extraction from the `ℝ≥0∞` tsum (`tsum_eq_iSup_sum` + filter-to-support) yields the over-covered family `T`.

## Contents
- `exists_finset_lattice_common_vadd` — the general-`k` Blichfeldt theorem.
- `exists_finset_card_lt_of_lt_tsum` — reusable: a `[0,1]`-valued family whose `ℝ≥0∞` tsum exceeds `k` has more than `k` nonzero terms.

## Correction to the parent
The parent entry's `blichfeldt_statement` (convex + symmetric + `2ⁿ·covolume ⇒ k+1` *lattice points*) is **van der Corput's theorem**, not Blichfeldt's. This entry formalizes the genuine Blichfeldt statement (arbitrary measurable set, no `2ⁿ` factor, congruent points of `s`). Documented in the header and overview.

## Verification
`lake env lean` (Lean v4.26.0, warm Mathlib) exits 0; `#print axioms` on both theorems returns only `[propext, Classical.choice, Quot.sound]` ⇒ **0-axiom, 0 sorries**. 136 lines, 2 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)