### PR TITLE
research(descartes-circle-theorem-oq-01-oq-01): complex Descartes theorem over ℂ, unconditional Soddy solutions [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/DescartesCircleTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/DescartesCircleTheoremOQ01OQ01.lean
@@ -1,0 +1,113 @@
+/-
+# The complex (extended) Descartes Circle Theorem over ℂ
+
+Research: descartes-circle-theorem-oq-01-oq-01
+Parent:   descartes-circle-theorem-oq-01 (real curvature relation and Soddy circles)
+
+The parent file established the **real** Descartes Circle Theorem: four signed
+curvatures `k₁,k₂,k₃,k₄` of mutually tangent circles satisfy
+`(k₁+k₂+k₃+k₄)² = 2(k₁²+k₂²+k₃²+k₄²)`, and the two Soddy solutions
+`k₄ = (k₁+k₂+k₃) ± 2√(k₁k₂+k₂k₃+k₃k₁)` exist precisely when the symmetric
+product is *nonnegative* (so the real square root is defined).
+
+The Lagarias–Mallows–Wilks "complex Descartes theorem" (2002) observes that the
+*same* quadratic relation holds over `ℂ` — for the curvatures themselves and,
+more strikingly, for the **curvature·centre products** `wᵢ = kᵢ·zᵢ` (with `zᵢ ∈ ℂ`
+the circle centres):
+`(w₁+w₂+w₃+w₄)² = 2(w₁²+w₂²+w₃²+w₄²)`.
+
+This file formalises the algebraic core of that complex theory.  Its genuinely new
+content, absent in the real parent, is that **over `ℂ` the fourth solution always
+exists unconditionally** — the nonnegativity hypothesis on the discriminant
+disappears because `ℂ` is algebraically closed, so the symmetric product always has
+a (complex) square root.
+
+Contributions:
+
+* `descartesRelC` — the Descartes relation over `ℂ`.
+* `descartesRelC_iff_sq` — the quadratic-in-`d` rewriting (a ring identity).
+* `descartes_soddy_iff` — for *any* complex square root `s` of the symmetric
+  product, the relation holds iff `d = (a+b+c) ± 2s`.
+* `descartes_soddy_exists` — **unconditional existence** of a fourth solution over
+  `ℂ`; the algebraically-closed phenomenon with no real analogue.
+* `descartes_soddy_both`, `soddy_sumC`, `soddy_prodC` — both Soddy solutions and
+  their Vieta sum/product.
+* `descartesRelC_ofReal` — the bridge: restricted to real arguments the complex
+  relation is exactly the parent's real Descartes relation.
+
+Everything here is `sorry`-free and `axiom`-free (only the foundational
+`propext`/`Classical.choice`/`Quot.sound`; no `Lean.ofReduceBool`).
+-/
+import Mathlib
+
+namespace DescartesCircleTheoremOQ01OQ01
+
+/-- The Descartes Circle relation over `ℂ`, among four complex "curvatures"
+(or curvature·centre products) `a, b, c, d`. -/
+def descartesRelC (a b c d : ℂ) : Prop :=
+  (a + b + c + d) ^ 2 = 2 * (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2)
+
+/-- The complex Descartes relation is the quadratic-in-`d` perfect-square condition
+`(d - (a+b+c))² = 4(ab+bc+ca)`. A ring identity, valid over any commutative ring. -/
+theorem descartesRelC_iff_sq (a b c d : ℂ) :
+    descartesRelC a b c d ↔
+      (d - (a + b + c)) ^ 2 = 4 * (a * b + b * c + c * a) := by
+  unfold descartesRelC
+  constructor <;> intro h <;> linear_combination -h
+
+/-- **Soddy solutions over `ℂ`.** For *any* complex square root `s` of the symmetric
+product `ab+bc+ca`, the relation `descartesRelC a b c d` holds iff
+`d = (a+b+c) + 2s` or `d = (a+b+c) - 2s`.  Unlike the real case this needs no sign
+hypothesis: `s` exists for every `a,b,c` because `ℂ` is algebraically closed. -/
+theorem descartes_soddy_iff {a b c d s : ℂ} (hs : s ^ 2 = a * b + b * c + c * a) :
+    descartesRelC a b c d ↔ d = (a + b + c) + 2 * s ∨ d = (a + b + c) - 2 * s := by
+  rw [descartesRelC_iff_sq]
+  constructor
+  · intro h
+    have hfac :
+        (d - (a + b + c) - 2 * s) * (d - (a + b + c) + 2 * s) = 0 := by
+      linear_combination h - 4 * hs
+    rcases mul_eq_zero.mp hfac with h' | h'
+    · left; linear_combination h'
+    · right; linear_combination h'
+  · rintro (h | h) <;> subst h <;> linear_combination 4 * hs
+
+/-- **Unconditional existence over `ℂ`.** Every triple of complex curvatures
+`a, b, c` admits a fourth `d` satisfying the Descartes relation — the symmetric
+product always has a complex square root, so no discriminant-nonnegativity is
+required (contrast the real parent, which needs `0 ≤ ab+bc+ca`). -/
+theorem descartes_soddy_exists (a b c : ℂ) : ∃ d : ℂ, descartesRelC a b c d := by
+  obtain ⟨s, hs⟩ := IsAlgClosed.exists_pow_nat_eq (a * b + b * c + c * a) (n := 2) (by norm_num)
+  exact ⟨(a + b + c) + 2 * s, (descartes_soddy_iff hs).mpr (Or.inl rfl)⟩
+
+/-- Both Soddy values satisfy the relation, for any complex square root `s` of the
+symmetric product. -/
+theorem descartes_soddy_both {a b c s : ℂ} (hs : s ^ 2 = a * b + b * c + c * a) :
+    descartesRelC a b c ((a + b + c) + 2 * s) ∧
+      descartesRelC a b c ((a + b + c) - 2 * s) :=
+  ⟨(descartes_soddy_iff hs).mpr (Or.inl rfl), (descartes_soddy_iff hs).mpr (Or.inr rfl)⟩
+
+/-- **Vieta (sum).** The two Soddy curvatures sum to twice the outer-curvature sum. -/
+theorem soddy_sumC (a b c s : ℂ) :
+    ((a + b + c) + 2 * s) + ((a + b + c) - 2 * s) = 2 * (a + b + c) := by ring
+
+/-- **Vieta (product).** The product of the two Soddy curvatures. -/
+theorem soddy_prodC {a b c s : ℂ} (hs : s ^ 2 = a * b + b * c + c * a) :
+    ((a + b + c) + 2 * s) * ((a + b + c) - 2 * s) =
+      (a + b + c) ^ 2 - 4 * (a * b + b * c + c * a) := by
+  linear_combination -4 * hs
+
+/-- **Bridge to the real theorem.** Restricted to real arguments (cast into `ℂ`),
+the complex Descartes relation is exactly the parent's real Descartes relation. -/
+theorem descartesRelC_ofReal (k₁ k₂ k₃ k₄ : ℝ) :
+    descartesRelC (k₁ : ℂ) k₂ k₃ k₄ ↔
+      (k₁ + k₂ + k₃ + k₄) ^ 2 = 2 * (k₁ ^ 2 + k₂ ^ 2 + k₃ ^ 2 + k₄ ^ 2) := by
+  unfold descartesRelC
+  norm_cast
+
+/-- Concrete existence: three unit "curvatures" `a = b = c = 1` admit a fourth
+complex Soddy curvature. -/
+theorem descartes_soddy_exists_unit : ∃ d : ℂ, descartesRelC 1 1 1 d :=
+  descartes_soddy_exists 1 1 1
+
+end DescartesCircleTheoremOQ01OQ01

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Overview: the complex Descartes theorem",
+    "content": "The real parent related four signed curvatures by (k₁+k₂+k₃+k₄)² = 2(∑kᵢ²), with Soddy solutions existing only when the symmetric product is nonnegative. Lagarias–Mallows–Wilks (2002) showed the SAME relation holds over ℂ for the curvature·centre products wᵢ = kᵢ·zᵢ. This module formalises that algebra; its new content is that over ℂ the fourth Soddy curvature ALWAYS exists — the algebraically-closed field always supplies the needed square root.",
+    "mathContext": "$(w_1+w_2+w_3+w_4)^2 = 2\\sum w_i^2$, $w_i = k_i z_i$",
+    "significance": "key",
+    "relatedConcepts": ["Descartes circle theorem", "Soddy circles", "Apollonian packing", "algebraically closed field"],
+    "prerequisites": ["complex numbers", "quadratic equations"]
+  },
+  {
+    "id": "ann-def",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 50 },
+    "type": "definition",
+    "title": "The Descartes relation over ℂ",
+    "content": "descartesRelC a b c d : Prop := (a+b+c+d)² = 2(a²+b²+c²+d²), the Descartes Circle relation with the four real curvatures replaced by four complex quantities — either the curvatures themselves or the LMW curvature·centre products.",
+    "significance": "key",
+    "relatedConcepts": ["Descartes relation"]
+  },
+  {
+    "id": "ann-iff-sq",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 52, "endLine": 60 },
+    "type": "insight",
+    "title": "Quadratic-in-d perfect-square form",
+    "content": "descartesRelC a b c d ↔ (d − (a+b+c))² = 4(ab+bc+ca). A pure ring identity (proved by linear_combination), exposing the relation as a quadratic in the fourth curvature d.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination", "perfect square", "quadratic"]
+  },
+  {
+    "id": "ann-soddy-iff",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 77 },
+    "type": "insight",
+    "title": "Soddy parametrisation over ℂ",
+    "content": "For any complex square root s of ab+bc+ca, the relation holds iff d = (a+b+c) + 2s or d = (a+b+c) − 2s. The quadratic factors as (d − (a+b+c) − 2s)(d − (a+b+c) + 2s) = 0; over ℂ no sign hypothesis on the symmetric product is needed, unlike the real parent.",
+    "mathContext": "$d = (a+b+c) \\pm 2s,\\ s^2 = ab+bc+ca$",
+    "significance": "critical",
+    "relatedConcepts": ["mul_eq_zero", "Soddy circles", "square root"]
+  },
+  {
+    "id": "ann-exists",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 83 },
+    "type": "insight",
+    "title": "Unconditional existence over ℂ (the new phenomenon)",
+    "content": "Every triple a,b,c admits a fourth d satisfying the relation. Because ℂ is algebraically closed (IsAlgClosed.exists_pow_nat_eq), the symmetric product ab+bc+ca always has a complex square root s, so d = (a+b+c) + 2s works. The real discriminant-nonnegativity obstruction disappears entirely — this is the essential difference from the real Descartes theorem.",
+    "significance": "critical",
+    "relatedConcepts": ["IsAlgClosed.exists_pow_nat_eq", "algebraically closed field", "existence"],
+    "prerequisites": ["algebraically closed fields"]
+  },
+  {
+    "id": "ann-both-vieta",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 100 },
+    "type": "insight",
+    "title": "Both solutions and Vieta relations",
+    "content": "Both Soddy values are solutions (descartes_soddy_both). Their Vieta sum is 2(a+b+c) (soddy_sumC, a ring identity) and their product is (a+b+c)² − 4(ab+bc+ca) (soddy_prodC, using s² = ab+bc+ca).",
+    "significance": "supporting",
+    "relatedConcepts": ["Vieta's formulas", "sum and product of roots"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "descartes-circle-theorem-oq-01-oq-01",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "Bridge to the real theorem and a concrete case",
+    "content": "descartesRelC_ofReal: restricted to real arguments (cast into ℂ) the complex relation is exactly the parent's real Descartes relation (closed by norm_cast). descartes_soddy_exists_unit is the concrete instance a = b = c = 1: three unit curvatures admit a fourth complex Soddy curvature.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_cast", "real embedding"]
+  }
+]

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DescartesCircleTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const descartesCircleTheoremOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const descartesCircleTheoremOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const descartesCircleTheoremOq01Oq01Data: ProofData = {
+  proof: descartesCircleTheoremOq01Oq01Proof,
+  annotations: descartesCircleTheoremOq01Oq01Annotations,
+}

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "descartes-circle-theorem-oq-01-oq-01",
+  "slug": "descartes-circle-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "DescartesCircleTheoremOQ01OQ01",
+    "lineCount": 113,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DescartesCircleTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Complex (Extended) Descartes Circle Theorem: Unconditional Soddy Solutions over ℂ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DescartesCircleTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "complex-analysis",
+      "algebra",
+      "descartes-circle-theorem",
+      "soddy-circles",
+      "curvature",
+      "vieta",
+      "algebraically-closed",
+      "quadratic",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 113,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "descartesRelC: the Descartes Circle relation formalised over ℂ, for four complex curvatures (or Lagarias–Mallows–Wilks curvature·centre products wᵢ = kᵢ·zᵢ).",
+      "descartes_soddy_iff: for any complex square root s of the symmetric product ab+bc+ca, the relation holds iff d = (a+b+c) ± 2s — the Soddy parametrisation over ℂ requiring no sign hypothesis.",
+      "descartes_soddy_exists: the genuinely new phenomenon absent in the real parent — over ℂ a fourth Soddy curvature ALWAYS exists, unconditionally, because ℂ is algebraically closed (the symmetric product always has a complex square root, so the real discriminant-nonnegativity hypothesis disappears).",
+      "descartes_soddy_both / soddy_sumC / soddy_prodC: both Soddy solutions and their Vieta sum (= 2(a+b+c)) and product (= (a+b+c)² − 4(ab+bc+ca)).",
+      "descartesRelC_ofReal: the compatibility bridge showing the complex relation restricted to real arguments is exactly the parent's real Descartes relation."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Descartes' Circle Theorem (1643, in a letter to Princess Elisabeth of Bohemia; rediscovered by Soddy in his 1936 poem 'The Kiss Precise') relates the signed curvatures of four mutually tangent circles by (k₁+k₂+k₃+k₄)² = 2(k₁²+k₂²+k₃²+k₄²). Lagarias, Mallows and Wilks (2002) proved the striking 'complex Descartes theorem': if one encodes each circle's centre as a complex number zᵢ, then the curvature·centre products wᵢ = kᵢ·zᵢ satisfy the very same quadratic relation (w₁+w₂+w₃+w₄)² = 2(w₁²+w₂²+w₃²+w₄²). The parent entry formalised the real curvature relation, where the two Soddy solutions k₄ = (k₁+k₂+k₃) ± 2√(k₁k₂+k₂k₃+k₃k₁) exist only when the symmetric product is nonnegative (so the real square root is defined). This entry develops the same algebra over ℂ. The organising new fact is that over the algebraically closed field ℂ the symmetric product always has a square root, so the fourth solution exists unconditionally — the discriminant-sign obstruction of the real theory simply vanishes.",
+    "problemStatement": "Formalise the Descartes Circle relation over ℂ (as in the Lagarias–Mallows–Wilks complex Descartes theorem) and its Soddy solutions, and show that over ℂ the fourth curvature always exists — no discriminant-nonnegativity required.",
+    "keyIdeas": [
+      "The Descartes relation (a+b+c+d)² = 2(a²+b²+c²+d²) is a ring identity equivalent to the quadratic-in-d perfect square (d − (a+b+c))² = 4(ab+bc+ca), valid over any commutative ring, in particular ℂ.",
+      "For any complex square root s of ab+bc+ca, the relation factors as (d − (a+b+c) − 2s)(d − (a+b+c) + 2s) = 0, giving exactly the two Soddy solutions d = (a+b+c) ± 2s.",
+      "ℂ is algebraically closed, so ab+bc+ca always has a square root (IsAlgClosed.exists_pow_nat_eq): the fourth Soddy curvature exists unconditionally, unlike the real case."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: the Complex Descartes Theorem",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Recalls the real parent and the Lagarias–Mallows–Wilks complex Descartes theorem, and states that the new content is the unconditional existence of the fourth Soddy curvature over the algebraically closed field ℂ. Enumerates the contributions.",
+      "mathContext": "$(w_1+w_2+w_3+w_4)^2 = 2(w_1^2+w_2^2+w_3^2+w_4^2)$ with $w_i = k_i z_i$."
+    },
+    {
+      "id": "relation-soddy",
+      "title": "The Complex Relation and its Soddy Solutions",
+      "startLine": 43,
+      "endLine": 89,
+      "summary": "Defines descartesRelC over ℂ, proves its quadratic-in-d perfect-square form descartesRelC_iff_sq (a ring identity), and the Soddy parametrisation descartes_soddy_iff: for any complex square root s of ab+bc+ca, the relation holds iff d = (a+b+c) ± 2s. Then descartes_soddy_exists gives the unconditional existence over ℂ, and descartes_soddy_both records that both Soddy values are solutions.",
+      "mathContext": "$(d-(a+b+c))^2 = 4(ab+bc+ca)$; $d = (a+b+c) \\pm 2s$, $s^2 = ab+bc+ca$."
+    },
+    {
+      "id": "vieta-bridge",
+      "title": "Vieta Relations and the Real Bridge",
+      "startLine": 90,
+      "endLine": 112,
+      "summary": "The two Soddy solutions have Vieta sum 2(a+b+c) (soddy_sumC) and product (a+b+c)² − 4(ab+bc+ca) (soddy_prodC). descartesRelC_ofReal shows the complex relation restricted to real arguments is exactly the parent's real Descartes relation, and descartes_soddy_exists_unit is the concrete case a = b = c = 1.",
+      "mathContext": "sum $= 2(a+b+c)$, product $= (a+b+c)^2 - 4(ab+bc+ca)$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "descartes-circle-theorem-oq-01-oq-01-oq-01",
+      "question": "Derive the complex Descartes relation on the curvature·centre products wᵢ = kᵢ·zᵢ from the metric tangency conditions |zᵢ − zⱼ| = rᵢ + rⱼ (external tangency), completing the geometric half of the Lagarias–Mallows–Wilks theorem that this entry treats only algebraically.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "descartes-circle-theorem-oq-01",
+      "relationship": "parent",
+      "description": "The parent formalises the real Descartes curvature relation and its Soddy solutions, which exist only when the symmetric product is nonnegative. This entry lifts the algebra to ℂ (the Lagarias–Mallows–Wilks setting) where, ℂ being algebraically closed, the fourth Soddy curvature exists unconditionally; descartesRelC_ofReal certifies the two relations agree on real arguments."
+    }
+  ],
+  "references": [
+    {
+      "title": "Beyond the Descartes Circle Theorem",
+      "author": "J. C. Lagarias, C. L. Mallows, A. R. Wilks",
+      "year": "2002",
+      "venue": "American Mathematical Monthly 109(4), 338–361",
+      "description": "The complex Descartes theorem: the curvature·centre products wᵢ = kᵢ·zᵢ of four mutually tangent circles satisfy the same quadratic Descartes relation as the curvatures; the source of the complex formulation formalised here."
+    },
+    {
+      "title": "The Kiss Precise",
+      "author": "Frederick Soddy",
+      "year": "1936",
+      "venue": "Nature 137, 1021",
+      "description": "Soddy's verse rediscovery of Descartes' Circle Theorem, giving the Soddy circles and the ± square-root structure of the fourth curvature that this entry mirrors over ℂ."
+    },
+    {
+      "title": "Mathlib4: FieldTheory.IsAlgClosed.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of IsAlgClosed.exists_pow_nat_eq, giving a complex square root of the symmetric product and hence the unconditional existence of the fourth Soddy curvature over ℂ."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "Formalises the algebraic core of the Lagarias–Mallows–Wilks complex Descartes theorem: the Descartes relation (a+b+c+d)² = 2(a²+b²+c²+d²) over ℂ, its quadratic-in-d perfect-square form, and the Soddy parametrisation d = (a+b+c) ± 2s for any complex square root s of the symmetric product ab+bc+ca. The distinctive new result over the real parent is descartes_soddy_exists: over the algebraically closed field ℂ the fourth Soddy curvature always exists, with no discriminant-nonnegativity hypothesis, since the symmetric product always has a square root. The Vieta sum/product and the real-compatibility bridge descartesRelC_ofReal complete the package. All 8 theorems are 0-axiom and machine-checked.",
+    "significance": "The complex Descartes theorem underlies the theory of Apollonian circle packings and the integrality of curvature·centre 'Descartes quadruples'. Formalising the relation over ℂ and isolating the unconditional-existence phenomenon (a clean consequence of ℂ being algebraically closed) turns the real parent's sign-constrained Soddy theory into its complex counterpart, and scopes precisely the remaining geometric step — deriving the relation from metric tangency — as the follow-up open question."
+  },
+  "description": "The Lagarias–Mallows–Wilks complex Descartes theorem carries the curvature relation (a+b+c+d)² = 2(a²+b²+c²+d²) over to ℂ, where it governs the curvature·centre products wᵢ = kᵢ·zᵢ of four mutually tangent circles. This entry formalises the relation over ℂ, its Soddy solutions d = (a+b+c) ± 2s (s² = ab+bc+ca), and the Vieta relations. The new phenomenon over the real parent: because ℂ is algebraically closed the fourth Soddy curvature always exists, with no discriminant-sign hypothesis. All results are 0-axiom and machine-checked."
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `descartes-circle-theorem-oq-01-oq-01` formalising the algebraic core of the **Lagarias–Mallows–Wilks complex Descartes theorem** (2002), the ℂ counterpart of the real parent `descartes-circle-theorem-oq-01`.

The Descartes relation `(a+b+c+d)² = 2(a²+b²+c²+d²)` is carried over to ℂ, where it governs the curvature·centre products `wᵢ = kᵢ·zᵢ` of four mutually tangent circles.

**Genuinely new over the real parent:** in the real theory the two Soddy solutions `k₄ = (k₁+k₂+k₃) ± 2√(k₁k₂+k₂k₃+k₃k₁)` exist only when the symmetric product is *nonnegative* (so the real √ is defined). Over ℂ — being algebraically closed — the symmetric product **always** has a square root, so:

- `descartes_soddy_exists`: a fourth Soddy curvature exists **unconditionally** for every `a,b,c ∈ ℂ` (via `IsAlgClosed.exists_pow_nat_eq`). The discriminant-sign obstruction of the real case disappears.

Other contributions:
- `descartesRelC` / `descartesRelC_iff_sq`: the relation over ℂ and its quadratic-in-`d` perfect-square form.
- `descartes_soddy_iff`: for any complex √`s` of `ab+bc+ca`, the relation holds iff `d = (a+b+c) ± 2s`.
- `descartes_soddy_both`, `soddy_sumC` (Vieta sum `= 2(a+b+c)`), `soddy_prodC` (Vieta product `= (a+b+c)² − 4(ab+bc+ca)`).
- `descartesRelC_ofReal`: the complex relation restricted to real arguments **is** the parent's real Descartes relation.

Scope note: this treats the **algebraic** content; deriving the relation from metric tangency `|zᵢ − zⱼ| = rᵢ + rⱼ` is recorded as the follow-up open question.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.DescartesCircleTheoremOQ01OQ01` → **Build succeeded**
- 0 `axiom` declarations, 0 structure-encoded assumptions, 0 `sorry`, no `native_decide`. Status `verified`, badge `original`.
- 8 theorems / 1 def / 113 lines. `gallery:check-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)