### PR TITLE
Enrich Cramer-vs-Gauss exact flop model (cramers-rule-oq-02-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/cramers-rule-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-02-oq-01/annotations.json
@@ -2,85 +2,261 @@
   {
     "id": "ann-cramer-oq0201-01-imports",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 1, "endLine": 2 },
+    "range": {
+      "startLine": 1,
+      "endLine": 2
+    },
     "type": "concept",
     "title": "Building on the Parent Cramer-vs-Gauss File",
     "content": "Imports all of Mathlib (for `Finset.sum`, `Finset.sum_range_succ`, and the `omega`/`ring`/`norm_num` tactics) and the parent entry `Proofs.CramersRuleOQ02`. The parent supplies `CramersComplexity.cramersRuleMuls n` (the Cramer's-rule multiplication count) and `CramersComplexity.gauss_beats_cramer` (Gaussian elimination beats Cramer's rule for n ≥ 4 under the loose n³ model). This file reuses those results unchanged and only tightens the Gaussian cost model, so the parent's comparison conclusion is inherited rather than re-proved.",
     "mathContext": "Parent model: $\\texttt{gaussMuls}\\,n = n^3$, $\\texttt{cramersRuleMuls}\\,n = (n+1)\\,n\\,n!$, with $\\texttt{gaussMuls}\\,n < \\texttt{cramersRuleMuls}\\,n$ for $n \\ge 4$.",
     "significance": "supporting",
-    "relatedConcepts": ["Gaussian-elimination", "Cramer's-rule", "computational-complexity", "code-reuse"],
-    "prerequisites": ["Lean-imports", "Mathlib"]
+    "relatedConcepts": [
+      "Gaussian-elimination",
+      "Cramer's-rule",
+      "computational-complexity",
+      "code-reuse"
+    ],
+    "prerequisites": [
+      "Lean-imports",
+      "Mathlib"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-02-exact-model",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 57, "endLine": 61 },
+    "range": {
+      "startLine": 57,
+      "endLine": 61
+    },
     "type": "definition",
     "title": "The Exact Per-Step Cost Model",
     "content": "`gaussExactOps n = ∑_{j ∈ range n} (j² + j)` is the exact multiplication-plus-division count for forward elimination of an n×n system. The summation index `j` is the number of rows beneath the current pivot: clearing that column costs `j` divisions (one multiplier per row) and `j²` multiplications (updating the `j` trailing entries of each of the `j` rows). Summing `j² + j` as `j` ranges over `0, …, n−1` recovers the per-step total; the `j = 0` term vanishes, so this equals the textbook `∑_{j=1}^{n−1} (j² + j)`.",
     "mathContext": "$\\texttt{gaussExactOps}(n) = \\sum_{j=0}^{n-1} (j^2 + j) = \\sum_{j=1}^{n-1}(j^2 + j)$, where step $k$ (with $j = n-k$ rows below the pivot) contributes $j$ divisions and $j^2$ multiplications.",
     "significance": "key",
-    "relatedConcepts": ["Finset.sum", "flop-count", "forward-elimination", "pivot"],
-    "prerequisites": ["finite-sums", "Gaussian-elimination", "algorithm-complexity"]
+    "relatedConcepts": [
+      "Finset.sum",
+      "flop-count",
+      "forward-elimination",
+      "pivot"
+    ],
+    "prerequisites": [
+      "finite-sums",
+      "Gaussian-elimination",
+      "algorithm-complexity"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-03-succ",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 63, "endLine": 67 },
+    "range": {
+      "startLine": 63,
+      "endLine": 67
+    },
     "type": "tactic",
     "title": "Peeling One Elimination Step",
     "content": "`gaussExactOps_succ` unfolds the sum by one term: `gaussExactOps (n+1) = gaussExactOps n + (n² + n)`. This is a direct application of `Finset.sum_range_succ`, which splits `∑_{x < n+1} f x` into `∑_{x < n} f x + f n`. This one-step recurrence is the engine of the inductive closed-form proof that follows — it expresses the cost of an (n+1)×(n+1) system as the n×n cost plus the new outermost elimination step.",
     "mathContext": "$\\sum_{x<n+1} f(x) = \\left(\\sum_{x<n} f(x)\\right) + f(n)$, here with $f(j) = j^2 + j$ so the new term is $n^2 + n$.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_range_succ", "recurrence", "telescoping"],
-    "prerequisites": ["finite-sums", "induction"]
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "recurrence",
+      "telescoping"
+    ],
+    "prerequisites": [
+      "finite-sums",
+      "induction"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-04-closed-form",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 69, "endLine": 81 },
+    "range": {
+      "startLine": 69,
+      "endLine": 81
+    },
     "type": "insight",
     "title": "Subtraction-Free Closed Form: 3·ops + n = n³",
     "content": "The central theorem `gaussExactOps_closed` proves `3 · gaussExactOps n + n = n³` by induction on n. The key design choice is to state the identity in the additive, subtraction-free form `3·ops + n = n³` rather than the division form `ops = (n³ − n)/3`. Because ℕ is a commutative *semiring* (no subtraction, no division), the entire successor step closes with `ring`: the calc block rewrites with `gaussExactOps_succ`, substitutes the induction hypothesis `3·gaussExactOps m + m = m³`, and lets `ring` verify `m³ + (3(m² + m) + 1) = (m+1)³`. Phrasing it with truncated subtraction would have forced `linear_combination` over a ring, which ℕ is not.",
     "mathContext": "$3\\sum_{j=1}^{n-1}(j^2+j) + n = n^3$, equivalently $\\sum_{j=1}^{n-1}(j^2+j) = \\tfrac{(n-1)n(n+1)}{3} = \\tfrac{n^3-n}{3}$. Successor identity: $m^3 + \\bigl(3(m^2+m)+1\\bigr) = (m+1)^3$.",
     "significance": "key",
-    "relatedConcepts": ["mathematical-induction", "commutative-semiring", "ring-tactic", "closed-form", "truncated-subtraction"],
-    "prerequisites": ["induction", "semiring-vs-ring", "polynomial-identities"]
+    "relatedConcepts": [
+      "mathematical-induction",
+      "commutative-semiring",
+      "ring-tactic",
+      "closed-form",
+      "truncated-subtraction"
+    ],
+    "prerequisites": [
+      "induction",
+      "semiring-vs-ring",
+      "polynomial-identities"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-05-div-form",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 83, "endLine": 88 },
+    "range": {
+      "startLine": 83,
+      "endLine": 88
+    },
     "type": "tactic",
     "title": "Recovering the Textbook (n³ − n)/3 Form",
     "content": "`gaussExactOps_eq_div` converts the additive closed form into the headline division form `gaussExactOps n = (n³ − n)/3`. From `3·gaussExactOps n + n = n³`, `omega` derives `3·gaussExactOps n = n³ − n` (now legitimate in ℕ since `n ≤ n³`), and `Nat.mul_div_cancel_left` cancels the exact factor of 3. Because the division is exact — `3` genuinely divides `n³ − n = (n−1)n(n+1)`, a product of three consecutive integers — no rounding or floor appears, and the result is the literal `n³/3` flop count of numerical linear algebra.",
     "mathContext": "$3 \\mid n^3 - n = (n-1)\\,n\\,(n+1)$ (three consecutive integers), so $\\texttt{gaussExactOps}\\,n = \\dfrac{n^3 - n}{3}$ exactly in $\\mathbb{N}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Nat.mul_div_cancel_left", "exact-division", "omega", "consecutive-integers"],
-    "prerequisites": ["natural-number-division", "divisibility"]
+    "relatedConcepts": [
+      "Nat.mul_div_cancel_left",
+      "exact-division",
+      "omega",
+      "consecutive-integers"
+    ],
+    "prerequisites": [
+      "natural-number-division",
+      "divisibility"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-06-bounds",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 90, "endLine": 113 },
+    "range": {
+      "startLine": 90,
+      "endLine": 113
+    },
     "type": "insight",
     "title": "The Tightening Is Genuine, Not Just Asymptotic",
     "content": "Two bounds quantify the gap against the parent's loose model. `gaussExactOps_le_cube` proves `gaussExactOps n ≤ n³` (consistency with the n³ upper model), and `gaussExactOps_lt_cube` proves the inequality is *strict* for n ≥ 2 — the exact count is provably below n³ for every system of size ≥ 2, so the factor-3 improvement is real rather than merely asymptotic. Both are discharged by `omega` treating `n³` and `gaussExactOps n` as opaque atoms linked only by the linear closed-form hypothesis. The lemma `gaussExactOps_small` sanity-checks the formula against hand computation: n = 2,3,4,5 give 2, 8, 20, 40.",
     "mathContext": "$\\texttt{gaussExactOps}\\,n \\le n^3$ always; strictly $< n^3$ for $n \\ge 2$. The overcount of the loose model is $n^3 - \\tfrac{n^3-n}{3} = \\tfrac{2n^3+n}{3} \\approx \\tfrac{2}{3}n^3$.",
     "significance": "key",
-    "relatedConcepts": ["omega", "strict-inequality", "asymptotics", "leading-constant", "sanity-check"],
-    "prerequisites": ["inequalities", "Presburger-arithmetic"]
+    "relatedConcepts": [
+      "omega",
+      "strict-inequality",
+      "asymptotics",
+      "leading-constant",
+      "sanity-check"
+    ],
+    "prerequisites": [
+      "inequalities",
+      "Presburger-arithmetic"
+    ]
   },
   {
     "id": "ann-cramer-oq0201-07-comparison",
     "proofId": "cramers-rule-oq-02-oq-01",
-    "range": { "startLine": 115, "endLine": 131 },
+    "range": {
+      "startLine": 115,
+      "endLine": 131
+    },
     "type": "concept",
     "title": "A Tighter Cost Cannot Overturn the Verdict",
     "content": "`gaussExact_beats_cramer` shows the exact model still beats Cramer's rule for n ≥ 4, obtained a fortiori by chaining `gaussExactOps n ≤ n³` (this file) with the parent's `gaussMuls n < cramersRuleMuls n` (i.e. `gauss_beats_cramer`) through `lt_of_le_of_lt`. The logic is structural: lowering the *winner's* cost estimate can never reverse a comparison it already won, so every conclusion of the parent survives the tightening unchanged. `gauss_exact_summary` bundles all five facts — closed form, division form, the ≤ and < bounds, and the preserved comparison — into a single citable theorem.",
     "mathContext": "Since $\\texttt{gaussExactOps}\\,n \\le n^3 = \\texttt{gaussMuls}\\,n < \\texttt{cramersRuleMuls}\\,n$ for $n \\ge 4$, transitivity gives $\\texttt{gaussExactOps}\\,n < \\texttt{cramersRuleMuls}\\,n$.",
     "significance": "key",
-    "relatedConcepts": ["lt_of_le_of_lt", "transitivity", "a-fortiori", "monotone-comparison", "proof-reuse"],
-    "prerequisites": ["order-relations", "transitivity"]
+    "relatedConcepts": [
+      "lt_of_le_of_lt",
+      "transitivity",
+      "a-fortiori",
+      "monotone-comparison",
+      "proof-reuse"
+    ],
+    "prerequisites": [
+      "order-relations",
+      "transitivity"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq0201-08-subs-flops",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 193
+    },
+    "type": "insight",
+    "title": "Subtractions and the full ≈2n³/3 elimination flop count",
+    "content": "Forward elimination also performs subtractions: clearing a column with j rows below the pivot costs j² multiply–subtracts, so the subtraction total is gaussExactSubs n = ∑_{j<n} j² = (2n³−3n²+n)/6 ≈ n³/3 (proved subtraction-free over ℕ as 6·subs + 3n² = 2n³ + n by induction). Adding the equal-order multiplication/division count gives the total flop count gaussExactFlops n = (4n³−3n²−n)/6, whose leading term is exactly the textbook 2n³/3 for dense Gaussian elimination / LU factorization. The closed form 6·flops + 3n² + n = 4n³ follows by omega from the two component identities.",
+    "mathContext": "$\\text{subs}(n)=\\sum_{j<n} j^2=\\tfrac{2n^3-3n^2+n}{6}\\sim\\tfrac{n^3}{3}$, so $\\text{flops}(n)=\\tfrac{4n^3-3n^2-n}{6}\\sim\\tfrac{2n^3}{3}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares",
+      "LU factorization",
+      "Gaussian elimination flop count",
+      "2n³/3"
+    ],
+    "prerequisites": [
+      "∑ j² closed form",
+      "induction over ℕ",
+      "omega arithmetic"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq0201-09-backsub",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": {
+      "startLine": 195,
+      "endLine": 261
+    },
+    "type": "insight",
+    "title": "Back-substitution costs exactly n²",
+    "content": "Solving the upper-triangular system after elimination: the row with j solved unknowns to its right costs j+1 operations (a j-term dot product plus one division) and j subtractions. Summing gives backSubOps n = ∑(j+1) = n(n+1)/2 and backSubSubs n = ∑ j = n(n−1)/2, each with a clean induction closed form. Their sum is the strikingly exact backSubFlops n = n² — the two triangular-number halves combine with no truncated subtraction. This O(n²) cost is an order below the ≈n³/3 of forward elimination.",
+    "mathContext": "$\\text{backOps}=\\tfrac{n(n+1)}2,\\ \\text{backSubs}=\\tfrac{n(n-1)}2,\\ \\text{backFlops}(n)=\\tfrac{n(n+1)}2+\\tfrac{n(n-1)}2=n^2.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "back-substitution",
+      "triangular number",
+      "upper-triangular solve",
+      "O(n²)"
+    ],
+    "prerequisites": [
+      "∑ j and ∑ (j+1) closed forms",
+      "induction over ℕ"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq0201-10-fullsolve",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": {
+      "startLine": 263,
+      "endLine": 331
+    },
+    "type": "insight",
+    "title": "Full solve cost: leading term 2n³/3, still beats Cramer",
+    "content": "Combining elimination and back-substitution gives the total cost to solve a dense n×n system: fullSolveFlops n = gaussExactFlops n + n², with closed form 6·flops + n = 4n³ + 3n² (leading term 2n³/3). Back-substitution's n² is asymptotically negligible — dominated by forward elimination for n ≥ 3 (backSubFlops ≤ gaussExactFlops via 3n² ≤ n³) — and the full solve stays below the parent's conservative n³ model for n ≥ 2. Hence, a fortiori, the full solve still beats Cramer's rule for n ≥ 4, reusing the parent's gauss_beats_cramer. fullSolve_summary packages the four facts.",
+    "mathContext": "$\\text{fullFlops}(n)=\\tfrac{4n^3+3n^2-n}{6}\\sim\\tfrac{2n^3}{3}\\le n^3$ (for $n\\ge2$); $\\text{fullFlops}(n)<\\text{cramersRuleMuls}(n)$ for $n\\ge4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cramer's rule",
+      "computational complexity crossover",
+      "dominant term",
+      "LU solve"
+    ],
+    "prerequisites": [
+      "gaussExactFlops closed form",
+      "backSubFlops = n²",
+      "parent gauss_beats_cramer"
+    ]
+  },
+  {
+    "id": "ann-cramer-oq0201-11-sharp",
+    "proofId": "cramers-rule-oq-02-oq-01",
+    "range": {
+      "startLine": 333,
+      "endLine": 369
+    },
+    "type": "insight",
+    "title": "Sharp crossover: Gauss beats Cramer for every n ≥ 1",
+    "content": "The parent's n ≥ 4 threshold is an artifact of the loose n³ model. With the honest ≈2n³/3 cost — a constant factor below n³ — Gaussian elimination uses strictly fewer multiplications than Cramer's rule for every n ≥ 1. The proof splits: n ≥ 4 reuses fullSolve_beats_cramer, while the three small cases n ∈ {1,2,3} are decided directly (1<2, 7<12, 22<72) by interval_cases + norm_num on the factorial. The bound 1 ≤ n is sharp: at n = 0 both costs are 0, so strict inequality fails — captured by fullSolve_beats_cramer_sharp. The n ≥ 4 threshold thus collapses to the smallest nontrivial dimension.",
+    "mathContext": "$\\forall n\\ge1:\\ \\text{fullFlops}(n)<n!\\cdot(\\text{Cramer cost})$, and the bound is sharp (fails at $n=0$ where both are $0$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "sharp threshold",
+      "interval_cases",
+      "factorial growth",
+      "asymptotic vs exact bounds"
+    ],
+    "prerequisites": [
+      "case analysis n<4 vs n≥4",
+      "fullSolveFlops closed form",
+      "cramersRuleMuls_eq"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-02-oq-01`.

**Gap:** the existing 7 annotations covered only the first section (forward-elimination multiplication count, lines 1–131, ~19% of 379 lines). The entire second half — subtraction counts, back-substitution, full-solve cost, and the sharp crossover — was unannotated proven content.

**This PR** adds 4 grouped section annotations (7 → 11), covering lines 133–369:
- **Subtractions + total flop count** — `gaussExactSubs = ∑ j² ~ n³/3`, total `gaussExactFlops ~ 2n³/3`.
- **Back-substitution = n² exactly** — `backSubFlops_eq`, the two triangular halves combining cleanly.
- **Full solve cost** — leading term `2n³/3`, dominated back-sub, still beats Cramer for `n ≥ 4`.
- **Sharp crossover** — `fullSolve_beats_cramer_all`: beats Cramer for every `n ≥ 1`, bound sharp at `n=0`.

Each carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Coverage ~19% → ~90%. Existing 7 annotations preserved.