### PR TITLE
research(inverse-galois-oq-04-oq-01-oq-01): compose Kummer–Dedekind Step-1 with inertia tower [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DedekindKummerToTower.lean
+++ b/proofs/Proofs/DedekindKummerToTower.lean
@@ -1,0 +1,108 @@
+import Mathlib
+import Proofs.DedekindKummerStep1
+import Proofs.DedekindInertiaTower
+
+/-!
+# Composing Kummer–Dedekind Step 1 with the inertia-tower brick (inverse-Galois A₅, OQ-04)
+
+This file closes the *gluing* half of the residual gap in the ongoing effort to discharge
+the last assumption of `Proofs.InverseGaloisA5`,
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+`Proofs.InverseGaloisA5DedekindInstantiation` reduces that axiom to the single arithmetic
+fact `3 ∣ Ideal.inertiaDegIn (7) (𝓞 q.SplittingField)` at an unramified prime over `7`, and
+its "residual gap" note lays out a three-step route:
+
+1. **Kummer–Dedekind** — the prime of `𝓞 ℚ(α)` matching an irreducible cubic factor of
+   `q mod 7` has inertia degree `3` (packaged in `Proofs.DedekindKummerStep1`);
+2. **inertia-degree multiplicativity in a tower** — lifts that to a prime of the splitting
+   field;
+3. **Galois uniformity** — spreads it to all primes over `7`
+   (steps 2–3 packaged in `Proofs.DedekindInertiaTower`).
+
+The two bricks were proved separately, `0`-axiom. This file **composes them**: given a
+tower `ℤ ⊆ 𝓞 K ⊆ T` with `T / ℤ` Galois (`T` integral over `𝓞 K`), an algebraic integer
+`θ` of `K` whose Kummer–Dedekind exponent is prime to `p`, and a monic irreducible factor
+`Q` of `minpoly ℤ θ` modulo `p` with `d ∣ Q.natDegree`, we obtain
+
+```
+d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T.
+```
+
+The only new ingredient beyond the two bricks is **going up**
+(`Ideal.exists_maximal_ideal_liesOver_of_isIntegral`): the Step-1 prime `P` of `𝓞 K` over
+`(p)` sits below *some* maximal prime `Q'` of the integral extension `T`, which is exactly
+the intermediate datum the tower brick consumes. Only the ordinary foundational axioms
+(`propext`, `Classical.choice`, `Quot.sound`) are used — no `sorry`, no new `axiom`.
+
+## Effect on the A₅ residual gap
+
+Instantiating with `K = ℚ(α)` (`α` a root of `q`), `T = 𝓞 q.SplittingField`, `G = q.Gal`,
+`p = 7`, `Q =` the irreducible cubic factor of `q mod 7`
+(`Proofs.InverseGaloisA5DedekindMod7`), and `d = 3` collapses the whole three-step route to
+a *single* statement. What remains to feed this lemma is purely the concrete number-theoretic
+wiring:
+
+* the tower/`IsGaloisGroup` instances for `ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField`;
+* `7 ∤ RingOfIntegers.exponent α` (from `7 ∤ disc q = 32000²`);
+* the identification of the cubic factor as an element of `RingOfIntegers.monicFactorsMod α 7`.
+
+None of those require any further abstract inertia/tower reasoning: that part is now fully
+machine-checked and packaged here.
+-/
+
+open Polynomial NumberField Ideal RingOfIntegers
+
+namespace DedekindKummerToTower
+
+/-- The rational prime `(p)` is a maximal ideal of `ℤ`: `span {(p : ℤ)}` is prime because
+`p` is prime (`Ideal.span_singleton_prime`), and a nonzero prime of the one-dimensional
+domain `ℤ` is maximal (`Ideal.IsPrime.isMaximal`). -/
+theorem span_p_isMaximal {p : ℕ} [Fact (Nat.Prime p)] : (span {(p : ℤ)}).IsMaximal := by
+  have hprime : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp Fact.out
+  refine ((Ideal.span_singleton_prime hprime.ne_zero).mpr hprime).isMaximal ?_
+  simpa [Ideal.span_singleton_eq_bot] using hprime.ne_zero
+
+/-- **Kummer–Dedekind Step 1 composed with the inertia tower.**
+
+Let `ℤ ⊆ 𝓞 K ⊆ T` be a tower with `T` integral over `𝓞 K` and `T / ℤ` Galois with group
+`G`. Let `θ` be an algebraic integer of the number field `K` whose Kummer–Dedekind exponent
+is not divisible by the rational prime `p`. If a natural number `d` divides the degree of a
+monic irreducible factor `Q` of `minpoly ℤ θ` modulo `p`, then
+
+```
+d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T.
+```
+
+Proof: `DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree` produces a maximal
+prime `P` of `𝓞 K` over `(p)` with `d ∣ inertiaDeg (p) P`; going up
+(`Ideal.exists_maximal_ideal_liesOver_of_isIntegral`) supplies a maximal prime `Q'` of `T`
+over `P`; and `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes
+`d ∣ inertiaDeg (p) P` to `d ∣ inertiaDegIn (p) T`. -/
+theorem dvd_inertiaDegIn_of_dvd_natDegree_factor
+    {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {p : ℕ} [Fact (Nat.Prime p)]
+    {T : Type*} [CommRing T]
+    [Algebra (𝓞 K) T] [IsScalarTower ℤ (𝓞 K) T]
+    [Algebra.IsIntegral (𝓞 K) T] [FaithfulSMul (𝓞 K) T]
+    (G : Type*) [Group G] [Finite G] [MulSemiringAction G T] [IsGaloisGroup G ℤ T]
+    (hp : ¬ p ∣ RingOfIntegers.exponent θ) {Q : (ZMod p)[X]}
+    (hQ : Q ∈ RingOfIntegers.monicFactorsMod θ p) {d : ℕ} (hd : d ∣ Q.natDegree) :
+    d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T := by
+  -- Step 1: a maximal prime `P` of `𝓞 K` over `(p)` with `d ∣ inertiaDeg (p) P`.
+  obtain ⟨P, hPmax, hPlo, hPdvd⟩ :=
+    DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree hp hQ hd
+  haveI := hPmax
+  haveI := hPlo
+  -- Going up: a maximal prime `Q'` of the integral extension `T` lying over `P`.
+  obtain ⟨Q', hQ'max, hQ'lo⟩ :=
+    Ideal.exists_maximal_ideal_liesOver_of_isIntegral (R := 𝓞 K) (S := T) P
+  haveI := hQ'max
+  haveI := hQ'lo
+  haveI : (span {(p : ℤ)}).IsMaximal := span_p_isMaximal
+  -- Tower + Galois uniformity: promote to `inertiaDegIn (p) T`.
+  exact DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg G (span {(p : ℤ)}) P Q' hPdvd
+
+end DedekindKummerToTower

--- a/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "ann-header-oq040101",
+    "proofId": "inverse-galois-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Composing the two Kummer–Dedekind bricks via going up",
+    "content": "The module docstring situates this file within OQ-04's plan to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`. That axiom was reduced to `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`, provable by a three-step Kummer–Dedekind route: (1) an irreducible cubic factor of q mod 7 gives a prime of 𝓞 ℚ(α) of inertia degree 3; (2) tower multiplicativity lifts it to the splitting field; (3) Galois uniformity spreads it to all primes over 7. Step 1 was verified in `DedekindKummerStep1`, steps 2–3 in `DedekindInertiaTower`. This file composes them: given a tower ℤ ⊆ 𝓞 K ⊆ T with T integral over 𝓞 K and T/ℤ Galois, and a factor Q of minpoly ℤ θ mod p with d ∣ deg Q, it delivers d ∣ inertiaDegIn (p) T in a single statement. The one new ingredient is going up — the Step-1 prime P of 𝓞 K sits below a prime Q' of the integral extension T.",
+    "mathContext": "The chain is $Q\\text{ irred., } d \\mid \\deg Q \\ \\xrightarrow{\\text{Step 1}}\\ \\exists P \\lhd \\mathcal{O}_K,\\ d \\mid f(P\\mid p) \\ \\xrightarrow{\\text{going up}}\\ \\exists \\mathfrak{Q} \\lhd T,\\ \\mathfrak{Q} \\mid P \\ \\xrightarrow{\\text{tower + Galois}}\\ d \\mid \\mathrm{inertiaDegIn}_{(p)}(T).$ Instantiating $K=\\mathbb{Q}(\\alpha)$, $T=\\mathcal{O}_{q.\\mathrm{SplittingField}}$, $G=q.\\mathrm{Gal}$, $p=7$, $d=3$ recovers the A₅ obstruction.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Inverse Galois problem",
+      "Kummer–Dedekind theorem",
+      "going up for integral extensions",
+      "inertia degree (residue field degree)",
+      "Galois uniformity of inertia degrees"
+    ],
+    "prerequisites": [
+      "algebraic number theory (rings of integers, primes over a rational prime)",
+      "Galois theory of number fields"
+    ]
+  },
+  {
+    "id": "ann-span-maximal-oq040101",
+    "proofId": "inverse-galois-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 67
+    },
+    "type": "technical",
+    "title": "span_p_isMaximal — the rational prime (p) is maximal in ℤ",
+    "content": "The tower brick needs the base ideal to be maximal. Here the base is ℤ and the ideal is (p) = span {(p : ℤ)}. The lemma proves it maximal in two moves: `Ideal.span_singleton_prime` turns primality of the element (p : ℤ) — obtained from `Nat.prime_iff_prime_int` applied to the ambient `[Fact (Nat.Prime p)]` — into primality of the ideal, and `Ideal.IsPrime.isMaximal` upgrades a nonzero prime ideal of the one-dimensional domain ℤ to a maximal one. The nonzero side condition is discharged by `Ideal.span_singleton_eq_bot` together with (p : ℤ) ≠ 0.",
+    "mathContext": "In a Dedekind domain (or any ring of Krull dimension $\\le 1$), every nonzero prime ideal is maximal. For $\\mathbb{Z}$ this says $(p)$ is maximal iff $p$ is prime, and $\\mathbb{Z}/(p)$ is the residue field $\\mathbb{F}_p$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "maximal ideal",
+      "prime ideal in a Dedekind domain",
+      "span of a single element",
+      "Krull dimension one"
+    ],
+    "prerequisites": [
+      "ideals of ℤ",
+      "prime versus maximal ideals"
+    ]
+  },
+  {
+    "id": "ann-composition-oq040101",
+    "proofId": "inverse-galois-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "dvd_inertiaDegIn_of_dvd_natDegree_factor — the composition",
+    "content": "The main theorem. Over a tower ℤ ⊆ 𝓞 K ⊆ T (T integral over 𝓞 K, T/ℤ Galois with group G), given θ ∈ 𝓞 K with p ∤ exponent θ and a monic irreducible factor Q of minpoly ℤ θ mod p with d ∣ Q.natDegree, it concludes d ∣ inertiaDegIn (span {(p:ℤ)}) T. The proof: (1) `DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree` yields a maximal prime P of 𝓞 K over (p) with d ∣ inertiaDeg (p) P; (2) `Ideal.exists_maximal_ideal_liesOver_of_isIntegral` supplies a maximal prime Q' of T lying over P (going up, using integrality and faithfulness of 𝓞 K → T); (3) `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes d ∣ inertiaDeg (p) P to d ∣ inertiaDegIn (p) T. A ℤ-algebra diamond is deliberately avoided by relying on the canonical `algebraInt T` rather than a free `Algebra ℤ T` binder, so the required `IsScalarTower ℤ (𝓞 K) T` matches exactly. Confirmed 0-axiom by #print axioms.",
+    "mathContext": "The statement is the abstract engine behind Dedekind's theorem 'factorization type mod p = cycle type of Frobenius': a degree-$d$ irreducible factor mod $p$ forces an inertia degree divisible by $d$ at some prime of the top field, hence a Frobenius element of order divisible by $d$. For $A_5$: $d=3$ from the irreducible cubic factor of $q \\bmod 7$ gives $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$, i.e. an order-3 element of $\\mathrm{Gal}(q)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Kummer–Dedekind Step 1",
+      "going up (exists_maximal_ideal_liesOver_of_isIntegral)",
+      "inertia-degree tower multiplicativity",
+      "Galois uniformity (inertiaDegIn)",
+      "ℤ-algebra diamond avoidance"
+    ],
+    "prerequisites": [
+      "integral ring extensions and going up",
+      "inertia degrees in towers of number rings"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "inverse-galois-oq-04-oq-01-oq-01",
+  "title": "Inverse Galois OQ-04-01-01: Composing the Kummer–Dedekind Step-1 Brick with the Inertia Tower",
+  "slug": "inverse-galois-oq-04-oq-01-oq-01",
+  "description": "Answers the first open question of the OQ-04-01 entry — 'Instantiate the concrete tower ℤ ⊆ 𝓞 K ⊆ T with a top prime over the Step-1 prime, so the Kummer–Dedekind brick and the OQ-04 tower brick compose to d ∣ inertiaDegIn (p) T.' For a tower ℤ ⊆ 𝓞 K ⊆ T with T integral over 𝓞 K and T / ℤ Galois (group G), an algebraic integer θ of the number field K whose Kummer–Dedekind exponent is prime to p, and a monic irreducible factor Q of minpoly ℤ θ modulo p with d ∣ deg Q, the composition yields d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T. The only new ingredient beyond the two previously-verified bricks is going up (Ideal.exists_maximal_ideal_liesOver_of_isIntegral): the Step-1 prime P of 𝓞 K over (p) sits below a maximal prime Q' of the integral extension T, which is exactly the intermediate datum the tower brick consumes. This collapses the whole three-step Kummer–Dedekind route for the A₅ realizability axiom three_dvd_gal_card into a single reduction, leaving only concrete number-theoretic wiring. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "number-theory",
+      "algebraic-number-theory",
+      "inverse-galois",
+      "kummer-dedekind",
+      "inertia-degree",
+      "ramification",
+      "dedekind-domain"
+    ],
+    "proofRepoPath": "Proofs/DedekindKummerToTower.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, prime factorization in extensions, inertia degree, the conductor of an order)",
+      "The Kummer–Dedekind theorem (factorization of a rational prime read off from a minimal polynomial modulo p)",
+      "Going up for integral ring extensions (a prime of the base lies below a prime of an integral extension)",
+      "Inertia-degree multiplicativity in a tower and Galois uniformity of inertia degrees"
+    ],
+    "assumptions": "None beyond the ordinary foundational axioms of Lean/Mathlib (propext, Classical.choice, Quot.sound), confirmed by #print axioms. No `axiom` declarations and no `sorry`; no `decide` or `native_decide`. The theorem is a composition of two previously-verified 0-axiom bricks — DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree (Kummer–Dedekind Step 1) and DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg (tower multiplicativity + Galois uniformity) — glued by Mathlib's going-up lemma Ideal.exists_maximal_ideal_liesOver_of_isIntegral. This entry does not by itself close the A₅ realizability axiom three_dvd_gal_card: it delivers the abstract composition d ∣ inertiaDegIn (p) T from a mod-p factorization datum, reducing the residual gap to purely concrete inputs (the tower/IsGaloisGroup instances for ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField, the exponent condition 7 ∤ exponent α, and identifying the cubic factor of q mod 7 as an element of monicFactorsMod α 7).",
+    "relatedProblems": [
+      {
+        "id": "inverse-galois-oq-04-oq-01",
+        "relationship": "Parent entry (the Kummer–Dedekind Step-1 brick); this entry answers its first open question by composing that brick with the tower brick"
+      },
+      {
+        "id": "inverse-galois-oq-04",
+        "relationship": "Grandparent entry (the inertia tower + Galois-uniformity brick, Steps 2–3); this composition consumes it"
+      },
+      {
+        "id": "inverse-galois-a5",
+        "relationship": "The A₅ realization whose sole remaining assumption three_dvd_gal_card this composition helps discharge"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Great-grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+      }
+    ],
+    "lineCount": 108,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The Inverse Galois Problem asks whether every finite group occurs as $\\mathrm{Gal}(K/\\mathbb{Q})$. The alternating group $A_5$ is realizable over $\\mathbb{Q}$, and the Lean development `Proofs.InverseGaloisA5` formalizes this down to one remaining assumption, `three_dvd_gal_card : 3 \\mid \\mathrm{card}\\,q.\\mathrm{Gal}$. A companion reduction rewrites that as the arithmetic fact $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$ at an unramified prime over $7$, provable by a three-step Kummer–Dedekind route. Steps (2)–(3) — inertia-degree tower multiplicativity and Galois uniformity — were machine-checked in the entry `inverse-galois-oq-04`; step (1) — the Kummer–Dedekind translation from a mod-$p$ factorization to an inertia degree — in `inverse-galois-oq-04-oq-01`. The latter named as its own first open question the task of *composing* the two bricks over a concrete tower with a top prime over the Step-1 prime. This entry closes exactly that gluing step.",
+    "problemStatement": "**Compose the Kummer–Dedekind Step-1 brick with the inertia-tower brick over a tower $\\mathbb{Z} \\subseteq \\mathcal{O}_K \\subseteq T$ (with $T$ integral over $\\mathcal{O}_K$ and $T/\\mathbb{Z}$ Galois), obtaining a single divisibility statement about the top inertia degree.**\n\nConcretely: given a number field $K$, an algebraic integer $\\theta \\in \\mathcal{O}_K$, and a rational prime $p$ not dividing the Kummer–Dedekind exponent of $\\theta$, if a natural number $d$ divides the degree of a monic irreducible factor $Q$ of $\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\theta \\bmod p$, then $d \\mid \\mathrm{inertiaDegIn}_{(p)}(T)$.",
+    "text": "A 108-line, 0-axiom, 2-theorem file in the namespace `DedekindKummerToTower`. The auxiliary `span_p_isMaximal` records that $(p) = \\mathrm{span}\\,\\{(p:\\mathbb{Z})\\}$ is a maximal ideal of $\\mathbb{Z}$ (a nonzero prime of the one-dimensional domain $\\mathbb{Z}$). The main theorem `dvd_inertiaDegIn_of_dvd_natDegree_factor` fixes a tower $\\mathbb{Z} \\subseteq \\mathcal{O}_K \\subseteq T$ with $T$ integral over $\\mathcal{O}_K$ and $T/\\mathbb{Z}$ Galois with group $G$, an algebraic integer $\\theta$ with $p \\nmid \\mathrm{exponent}\\,\\theta$, and a monic irreducible factor $Q \\in \\mathrm{monicFactorsMod}\\,\\theta\\,p$ with $d \\mid \\deg Q$, and concludes $d \\mid \\mathrm{inertiaDegIn}_{(p)}(T)$. In the $A_5$ application $\\theta = \\alpha$ is a root of the quintic $q$, $T = \\mathcal{O}_{q.\\mathrm{SplittingField}}$, $G = q.\\mathrm{Gal}$, $p = 7$, $Q$ is the irreducible cubic factor of $q \\bmod 7$ (verified in `Proofs.InverseGaloisA5DedekindMod7`), and $d = 3$, so the theorem yields $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$ in one step.",
+    "proofStrategy": "The proof chains three pieces:\n\n1. **Kummer–Dedekind Step 1** (`DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree`): from the factor $Q$ and $d \\mid \\deg Q$ it produces a maximal prime $P \\lhd \\mathcal{O}_K$ lying over $(p)$ with $d \\mid \\mathrm{inertiaDeg}\\,(p)\\,P$.\n\n2. **Going up** (`Ideal.exists_maximal_ideal_liesOver_of_isIntegral`): because $T$ is integral over $\\mathcal{O}_K$ with $\\mathcal{O}_K \\hookrightarrow T$ (faithful), the maximal prime $P$ lies below a maximal prime $Q'$ of $T$.\n\n3. **Tower + Galois uniformity** (`DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg`): with the intermediate prime $P$ (over $(p)$) below $Q'$ (over $P$), $d \\mid \\mathrm{inertiaDeg}\\,(p)\\,P$ promotes to $d \\mid \\mathrm{inertiaDegIn}\\,(p)\\,T$ on the Galois top field.\n\nThe maximality of $(p)$ in $\\mathbb{Z}$ needed by step (3) is supplied by `span_p_isMaximal`. A subtle point in the setup: to avoid a $\\mathbb{Z}$-algebra diamond, the file does *not* introduce a free `Algebra ℤ T` instance; the canonical `algebraInt T` is used throughout, so the required `IsScalarTower ℤ (𝒪 K) T` matches on the nose. Only foundational axioms are used.",
+    "keyInsights": [
+      "**Going up is the whole new ingredient**: Steps 1 and 2–3 were already verified as separate bricks; what was missing was the observation that the Step-1 prime $P$ of the intermediate ring $\\mathcal{O}_K$ sits below *some* prime $Q'$ of the top ring $T$. Mathlib's `exists_maximal_ideal_liesOver_of_isIntegral` (a going-up theorem for integral extensions) supplies exactly this $Q'$, which is the intermediate datum the tower brick consumes.",
+      "**Divisibility composes cleanly**: phrasing every stage in the currency $d \\mid \\mathrm{inertiaDeg}$ / $d \\mid \\mathrm{inertiaDegIn}$ lets the three lemmas snap together with no arithmetic bookkeeping — the degree of the factor never has to be tracked beyond the initial $d \\mid \\deg Q$.",
+      "**One statement replaces a three-step route**: after this composition, the residual A₅ gap is no longer 'chain Kummer–Dedekind, tower multiplicativity, and Galois uniformity' but a single application of `dvd_inertiaDegIn_of_dvd_natDegree_factor`, leaving only the concrete instantiation data.",
+      "**The ℤ-algebra diamond is a real hazard**: declaring a free `Algebra ℤ T` binder alongside the canonical `algebraInt T` makes `IsScalarTower ℤ (𝒪 K) T` unsynthesizable (the tower brick picks the canonical ℤ-action while the binder's scalar tower is stated against the free one). Dropping the free binder and relying on `algebraInt` throughout resolves it — a reusable lesson for tower lemmas with ℤ at the base.",
+      "**Honest partial progress**: this entry does not remove `three_dvd_gal_card`; it verifies, with 0 axioms, the abstract composition that reduces the residual gap to purely concrete inputs — the tower/IsGaloisGroup instances for $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$, the exponent condition $7 \\nmid \\mathrm{exponent}\\,\\alpha$, and the factor identification $\\mathrm{cubic}_7 \\in \\mathrm{monicFactorsMod}\\,\\alpha\\,7$."
+    ],
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, prime factorization in extensions, inertia degree, the conductor of an order)",
+      "The Kummer–Dedekind theorem (factorization of a rational prime read off from a minimal polynomial modulo p)",
+      "Going up for integral ring extensions",
+      "Inertia-degree multiplicativity in a tower and Galois uniformity of inertia degrees"
+    ]
+  },
+  "sections": [
+    {
+      "id": "roadmap",
+      "title": "Docstring: composing the two Kummer–Dedekind bricks",
+      "startLine": 5,
+      "endLine": 55,
+      "summary": "Frames OQ-04 and its reduction of three_dvd_gal_card to 3 ∣ inertiaDegIn (7); recalls that Step 1 (Kummer–Dedekind) and Steps 2–3 (tower + Galois uniformity) were verified as separate 0-axiom bricks, and states that this file composes them via going up, reducing the residual A₅ gap to purely concrete number-theoretic wiring."
+    },
+    {
+      "id": "span-maximal",
+      "title": "span_p_isMaximal — (p) is maximal in ℤ",
+      "startLine": 61,
+      "endLine": 67,
+      "summary": "The rational prime (p) = span {(p : ℤ)} is a maximal ideal of ℤ: it is prime by Ideal.span_singleton_prime (p prime), and a nonzero prime of the one-dimensional domain ℤ is maximal by Ideal.IsPrime.isMaximal. This is the maximality hypothesis the tower brick needs at the base of the tower."
+    },
+    {
+      "id": "composition",
+      "title": "dvd_inertiaDegIn_of_dvd_natDegree_factor — the composition",
+      "startLine": 69,
+      "endLine": 107,
+      "summary": "Given a tower ℤ ⊆ 𝓞 K ⊆ T with T integral over 𝓞 K and T / ℤ Galois (group G), an algebraic integer θ with p ∤ exponent θ, and a monic irreducible factor Q of minpoly ℤ θ mod p with d ∣ deg Q, then d ∣ inertiaDegIn (span {(p:ℤ)}) T. Proof: Step 1 gives a maximal prime P of 𝓞 K over (p) with d ∣ inertiaDeg (p) P; exists_maximal_ideal_liesOver_of_isIntegral supplies a maximal prime Q' of T over P; and the tower brick promotes to d ∣ inertiaDegIn (p) T."
+    }
+  ],
+  "conclusion": {
+    "mainResult": "For any tower ℤ ⊆ 𝓞 K ⊆ T with T integral over 𝓞 K and T / ℤ Galois (group G), any algebraic integer θ ∈ 𝓞 K with p ∤ exponent θ, and any monic irreducible factor Q of minpoly ℤ θ modulo p with d ∣ deg Q, we have d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T. The theorem is machine-checked with 0 axioms and 0 sorries, composing the Kummer–Dedekind Step-1 brick with the inertia-tower brick via Mathlib's going-up lemma, and collapsing the three-step Kummer–Dedekind route toward the A₅ realizability axiom three_dvd_gal_card into a single reduction.",
+    "openQuestions": [
+      "Supply the concrete tower ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField and the IsGaloisGroup q.Gal ℤ (𝓞 q.SplittingField) instance (lifting the field-level Galois structure to the ring-of-integers level) so this composition applies in the A₅ setting.",
+      "Verify the exponent hypothesis 7 ∤ exponent α for a root α of q (from 7 ∤ disc q = 32000²), and identify the irreducible cubic factor of q mod 7 as an element of monicFactorsMod α 7 with natDegree 3.",
+      "Combine the resulting 3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField) with InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge to fully discharge three_dvd_gal_card and make the A₅ realization 0-axiom."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Parent entry (the Kummer–Dedekind Step-1 brick); this entry answers its first open question by composing that brick with the tower brick over a concrete tower via going up"
+    },
+    {
+      "targetId": "inverse-galois-oq-04",
+      "relationship": "related",
+      "description": "Grandparent entry (the inertia tower + Galois-uniformity brick, Steps 2–3) that this composition consumes"
+    },
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "related",
+      "description": "The A₅ realization whose sole remaining axiom three_dvd_gal_card these bricks are designed to eliminate"
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Great-grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/DedekindKummerToTower.lean",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.DedekindKummerStep1",
+      "Proofs.DedekindInertiaTower"
+    ],
+    "lemmaCount": 0,
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
## Summary

New **VERIFIED, 0-axiom** gallery entry `inverse-galois-oq-04-oq-01-oq-01` answering the **first open question** of `inverse-galois-oq-04-oq-01`:

> *Instantiate the concrete tower ℤ ⊆ 𝓞 K ⊆ T with a top prime over the Step-1 prime, so this brick and the OQ-04 tower brick compose to `d ∣ inertiaDegIn (p) T`.*

## What it proves

`DedekindKummerToTower.dvd_inertiaDegIn_of_dvd_natDegree_factor`: over a tower `ℤ ⊆ 𝓞 K ⊆ T` with `T` integral over `𝓞 K` and `T / ℤ` Galois (group `G`), for an algebraic integer `θ` with `p ∤ exponent θ` and a monic irreducible factor `Q` of `minpoly ℤ θ mod p` with `d ∣ Q.natDegree`:

```
d ∣ Ideal.inertiaDegIn (span {(p : ℤ)}) T
```

This **composes the two previously-verified 0-axiom bricks** — `DedekindKummerStep1` (Kummer–Dedekind Step 1) and `DedekindInertiaTower` (tower multiplicativity + Galois uniformity) — glued by Mathlib's going-up lemma `Ideal.exists_maximal_ideal_liesOver_of_isIntegral`. It collapses the three-step Kummer–Dedekind route toward the A₅ realizability axiom `three_dvd_gal_card` into a single reduction.

## Key details

- **Going up** is the one new ingredient: the Step-1 prime `P` of `𝓞 K` over `(p)` sits below a maximal prime `Q'` of the integral extension `T`, which is exactly what the tower brick consumes.
- A **ℤ-algebra diamond** is deliberately avoided (no free `Algebra ℤ T` binder; the canonical `algebraInt T` is used throughout) so `IsScalarTower ℤ (𝓞 K) T` matches on the nose.
- `span_p_isMaximal` supplies the base maximality `(p)` in `ℤ`.

## Verification

- `#print axioms` → only `propext, Classical.choice, Quot.sound` (0 substantive axioms).
- 0 sorries, no `decide`/`native_decide`. 2 theorems, 108 lines, Mathlib 4.26.0.
- Compiled via host `lake env lean` (both dependency bricks + this file build cleanly).

## Honest scope

This does **not** by itself remove `three_dvd_gal_card`. It reduces the residual A₅ gap to purely concrete inputs: the tower/`IsGaloisGroup q.Gal ℤ (𝓞 q.SplittingField)` instances, the exponent condition `7 ∤ exponent α`, and identifying the cubic factor of `q mod 7` as an element of `monicFactorsMod α 7`. The `inverse-galois-a5` entry remains correctly `axiomatized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)