### PR TITLE
Enrich Four Color Theorem / Kempe-chain narrative (four-color-theorem-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/four-color-theorem-oq-01/annotations.json
+++ b/src/data/proofs/four-color-theorem-oq-01/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "definition",
     "title": "Kempe Chain Framework: Coloring Infrastructure",
-    "content": "Three foundational definitions: ProperColoring G k f asserts that adjacent vertices receive distinct colors from Fin k. neighborColors G f v = (G.neighborFinset v).image f computes the actual set of colors used by v's neighbors. colorFree G f v c holds when color c is absent from neighborColors \u2014 a free color allows v to be colored without changing any neighbor. These definitions are the minimum needed to state and prove the Kempe chain obstruction.",
+    "content": "Three foundational definitions: ProperColoring G k f asserts that adjacent vertices receive distinct colors from Fin k. neighborColors G f v = (G.neighborFinset v).image f computes the actual set of colors used by v's neighbors. colorFree G f v c holds when color c is absent from neighborColors — a free color allows v to be colored without changing any neighbor. These definitions are the minimum needed to state and prove the Kempe chain obstruction.",
     "mathContext": "A proper $k$-coloring $f: V \\to [k]$ satisfies $f(u) \\ne f(v)$ whenever $u \\sim v$. The neighbor color set $N_f(v) = \\{f(w) : w \\sim v\\}$ has $|N_f(v)| \\le \\deg(v)$. Color $c$ is **free** for $v$ if $c \\notin N_f(v)$; a free color enables trivial extension without chain swaps.",
     "significance": "key",
     "relatedConcepts": [
@@ -31,8 +31,8 @@
       "endLine": 113
     },
     "type": "insight",
-    "title": "Pigeonhole Free Color: deg(v) < k \u27f9 Free Color Exists",
-    "content": "The key trivial case: when G.degree v < k, the neighbor color set has at most deg(v) < k elements, so some color in Fin k is unused. Proof: card(image f (neighborFinset v)) \u2264 card(neighborFinset v) = degree v < k = card(Fin k), so the image \u2260 univ, and ne_univ_iff_exists_not_mem provides the free color. This is exactly why the Five Color Theorem's 'easy case' needs no chain swaps at all.",
+    "title": "Pigeonhole Free Color: deg(v) < k ⟹ Free Color Exists",
+    "content": "The key trivial case: when G.degree v < k, the neighbor color set has at most deg(v) < k elements, so some color in Fin k is unused. Proof: card(image f (neighborFinset v)) ≤ card(neighborFinset v) = degree v < k = card(Fin k), so the image ≠ univ, and ne_univ_iff_exists_not_mem provides the free color. This is exactly why the Five Color Theorem's 'easy case' needs no chain swaps at all.",
     "mathContext": "**Pigeonhole principle**: $|N_f(v)| \\le \\deg(v) < k$, so $N_f(v) \\subsetneq [k]$, meaning some color $c \\in [k] \\setminus N_f(v)$ exists. For the Five Color Theorem: any vertex of degree $\\le 4$ in a planar graph immediately has a free color from 5 available. The difficult case is degree-5 vertices where all 5 colors might appear.",
     "significance": "key",
     "relatedConcepts": [
@@ -56,7 +56,7 @@
     },
     "type": "definition",
     "title": "Color Swap: Kempe Chain Operation Formalized",
-    "content": "swapColors f c\u2081 c\u2082 applies Equiv.swap c\u2081 c\u2082 pointwise to f, globally swapping colors c\u2081 and c\u2082 everywhere. swapColors_proper proves this preserves proper coloring: adjacent vertices still get distinct colors because Equiv.swap is injective. In the Kempe chain argument, one would restrict this swap to a bichromatic connected component (the chain), but this global swap already shows the key algebraic structure.",
+    "content": "swapColors f c₁ c₂ applies Equiv.swap c₁ c₂ pointwise to f, globally swapping colors c₁ and c₂ everywhere. swapColors_proper proves this preserves proper coloring: adjacent vertices still get distinct colors because Equiv.swap is injective. In the Kempe chain argument, one would restrict this swap to a bichromatic connected component (the chain), but this global swap already shows the key algebraic structure.",
     "mathContext": "A **Kempe chain** $K(c_1, c_2, v)$ is the connected component of the subgraph induced by $\\{c_1, c_2\\}$-colored vertices containing $v$. Swapping $c_1 \\leftrightarrow c_2$ on $K(c_1,c_2,v)$ produces a new proper coloring (the two-color structure ensures no conflicts). The global swap Equiv.swap $c_1$ $c_2$ is the algebraic heart of this operation.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -80,7 +80,7 @@
     },
     "type": "insight",
     "title": "Chain Interference: The Core Obstruction to 4-Color Kempe Proofs",
-    "content": "The central theorem: if vertex w lies in both the (c\u2081,c\u2083)-Kempe chain and the (c\u2082,c\u2083)-Kempe chain (with distinct colors c\u2081, c\u2082, c\u2083), and w has color c\u2083, then after swapping c\u2081 \u2194 c\u2083 on the first chain, w gets color c\u2081. But w was needed as a c\u2083-colored vertex in the second chain \u2014 its new color c\u2081 \u2209 {c\u2082, c\u2083} breaks the bichromatic property. Proof: Equiv.swap_apply_right and the distinctness hypotheses.",
+    "content": "The central theorem: if vertex w lies in both the (c₁,c₃)-Kempe chain and the (c₂,c₃)-Kempe chain (with distinct colors c₁, c₂, c₃), and w has color c₃, then after swapping c₁ ↔ c₃ on the first chain, w gets color c₁. But w was needed as a c₃-colored vertex in the second chain — its new color c₁ ∉ {c₂, c₃} breaks the bichromatic property. Proof: Equiv.swap_apply_right and the distinctness hypotheses.",
     "mathContext": "After the $(c_1, c_3)$-swap, $w$ gets color $c_1$. For the $(c_2, c_3)$-chain, we need $w$ to have color $c_2$ or $c_3$, but $c_1 \\ne c_2$ and $c_1 \\ne c_3$. So $K(c_2, c_3)$ through $w$ is broken. This is **Heawood's 1890 observation**: Kempe's proof assumed the two chains were vertex-disjoint, but in planar graphs they need not be. The graph Heawood constructed forces intersection.",
     "significance": "key",
     "relatedConcepts": [
@@ -103,8 +103,8 @@
       "endLine": 251
     },
     "type": "insight",
-    "title": "The 5\u21924 Gap: Why Color Pairs Matter",
-    "content": "five_color_no_double_swap proves C(5,2) = 10 > 6 = C(4,2) via decide. This encodes the structural reason 5 colors succeed: with 5 colors and 5 neighbors all using different colors, there are 10 color pairs. By planarity (K\u2085 is non-planar), two neighbors are non-adjacent; their colors form a Kempe chain that can be swapped without interference. With 4 colors and 5 neighbors, only 6 pairs exist, and the Jordan curve theorem forces chain crossings.",
+    "title": "The 5→4 Gap: Why Color Pairs Matter",
+    "content": "five_color_no_double_swap proves C(5,2) = 10 > 6 = C(4,2) via decide. This encodes the structural reason 5 colors succeed: with 5 colors and 5 neighbors all using different colors, there are 10 color pairs. By planarity (K₅ is non-planar), two neighbors are non-adjacent; their colors form a Kempe chain that can be swapped without interference. With 4 colors and 5 neighbors, only 6 pairs exist, and the Jordan curve theorem forces chain crossings.",
     "mathContext": "$\\binom{5}{2} = 10 > 6 = \\binom{4}{2}$. For the 5-color case with a degree-5 vertex: among 5 neighbors using all 5 colors, by the non-planarity of $K_5$, some two neighbors are non-adjacent. One Kempe chain swap on those two frees a color. For 4 colors: all 5 neighbors use 4 colors (two share a color), but the same planarity argument gives fewer color pairs, and chains can be forced to cross.",
     "significance": "key",
     "relatedConcepts": [
@@ -128,7 +128,7 @@
     },
     "type": "insight",
     "title": "Human-Readable Special Case: Small Graphs are k-Colorable",
-    "content": "colorable_of_card_le_k proves that any graph on \u2264 k vertices is k-colorable: just assign each vertex its own color via Fintype.equivFin. This is the simplest human-readable 4-colorability result, and illustrates the general strategy for restricted graph classes (outerplanar, series-parallel, etc.) that avoid the computational case explosion. The key Lean construction uses Coloring.mk with the bijection as coloring function.",
+    "content": "colorable_of_card_le_k proves that any graph on ≤ k vertices is k-colorable: just assign each vertex its own color via Fintype.equivFin. This is the simplest human-readable 4-colorability result, and illustrates the general strategy for restricted graph classes (outerplanar, series-parallel, etc.) that avoid the computational case explosion. The key Lean construction uses Coloring.mk with the bijection as coloring function.",
     "mathContext": "For $|V| \\le k$: define $f(v) = $ index of $v$ in some enumeration. Adjacent vertices $u \\ne v$ get distinct indices $f(u) \\ne f(v)$ by injectivity. Thus $\\chi(G) \\le |V| \\le k$. More generally: outerplanar graphs are 3-colorable (by induction on ear decompositions), and Brooks' theorem gives $\\chi(G) \\le \\Delta(G)$ for non-complete non-odd-cycle graphs.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -152,7 +152,7 @@
     },
     "type": "insight",
     "title": "Minimum Counterexample Has Degree 4 or 5",
-    "content": "min_counterexample_has_low_degree proves the structural constraint: any minimum counterexample to 4CT has minimum degree exactly 4 or 5. Lower bound: removing a degree-\u2264-3 vertex, 4-coloring the rest by minimality, and extending (by free_color_of_degree_lt with 3 < 4 colors) shows G was not a minimum counterexample. Upper bound: Euler's formula for planar graphs gives average degree < 6, so some vertex has degree \u2264 5.",
+    "content": "min_counterexample_has_low_degree proves the structural constraint: any minimum counterexample to 4CT has minimum degree exactly 4 or 5. Lower bound: removing a degree-≤-3 vertex, 4-coloring the rest by minimality, and extending (by free_color_of_degree_lt with 3 < 4 colors) shows G was not a minimum counterexample. Upper bound: Euler's formula for planar graphs gives average degree < 6, so some vertex has degree ≤ 5.",
     "mathContext": "In a planar triangulation: $|E| \\le 3|V| - 6$, so $\\sum \\deg(v) = 2|E| \\le 6|V| - 12$, giving average degree $< 6$. Therefore $\\delta(G) \\le 5$. Combined with $\\delta(G) \\ge 4$ (by minimality argument), every minimum counterexample has a vertex of degree 4 or 5. This is why the 633 configurations only cover neighborhoods of degree-4 and degree-5 vertices.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -175,9 +175,9 @@
       "endLine": 418
     },
     "type": "insight",
-    "title": "Configuration Reduction: 1936 \u2192 633",
+    "title": "Configuration Reduction: 1936 → 633",
     "content": "config_reduction proves 633 < 1936 by omega, encoding the historical progress: Appel-Haken (1976) checked 1,936 configurations using computer; Robertson-Sanders-Seymour-Thomas (1997) reduced to 633 with cleaner discharging rules. Each configuration is a local planar pattern around a degree-4 or degree-5 vertex. 'Reducible' means: if G contains this configuration, it cannot be a minimum non-4-colorable graph. The computer checks reducibility by exhausting all boundary colorings.",
-    "mathContext": "A configuration $C$ is **reducible** if every 4-coloring of its boundary extends to its interior. **Unavoidable set**: every planar triangulation contains at least one configuration from the set. By construction: any minimum counterexample contains a configuration from the unavoidable set, but each configuration is reducible, so the minimum counterexample can be simplified \u2014 contradiction. The 633-configuration proof uses a clever discharging argument to prove unavoidability.",
+    "mathContext": "A configuration $C$ is **reducible** if every 4-coloring of its boundary extends to its interior. **Unavoidable set**: every planar triangulation contains at least one configuration from the set. By construction: any minimum counterexample contains a configuration from the unavoidable set, but each configuration is reducible, so the minimum counterexample can be simplified — contradiction. The 633-configuration proof uses a clever discharging argument to prove unavoidability.",
     "significance": "supporting",
     "relatedConcepts": [
       "Appel-Haken 1976 proof",
@@ -189,6 +189,169 @@
       "reducibility of configurations",
       "discharging argument",
       "planar triangulations"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-counting-lemma",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 94
+    },
+    "type": "technique",
+    "title": "Counting lemma: #neighbor-colors ≤ degree",
+    "content": "The elementary counting fact underpinning every greedy/Kempe argument: the neighbors of v use at most deg(v) distinct colors, because neighborColors is the image of the neighbor finset under the coloring f, and an image never grows a set (Finset.card_image_le). This is the hypothesis that feeds the degree-based pigeonhole in the next lemma.",
+    "mathContext": "$|\\{f(u): u \\sim v\\}| \\le |\\{u : u \\sim v\\}| = \\deg(v)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "greedy coloring",
+      "image cardinality",
+      "vertex degree",
+      "pigeonhole"
+    ],
+    "prerequisites": [
+      "Finset.image",
+      "Finset.card_image_le",
+      "SimpleGraph.degree"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-easy-hard-case",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 115,
+      "endLine": 147
+    },
+    "type": "concept",
+    "title": "Five colors easy, four colors hard (degree 5)",
+    "content": "Contrasts why the Five Color Theorem is elementary while the Four Color Theorem is not. With 5 colors a degree-≤4 vertex always has a free color (five_color_degree_four, a direct corollary of the degree<k pigeonhole). The obstruction appears only at degree 5: with exactly 5 colors all colors may appear among the 5 neighbors (degree_five_all_colors_possible), and with 4 colors at most min(5,4)=4 distinct colors appear yet all 4 may be used (four_color_degree_five_pigeonhole), leaving no immediately free color. The two lemmas here are deliberately toy arithmetic (5≤5, min 5 4 = 4) whose docstrings carry the structural narrative that pins down the single hard configuration.",
+    "mathContext": "5 colors, $\\deg \\le 4 \\Rightarrow$ free color; the sole hard case is $\\deg = 5$ with all colors used, where $\\min(5,4)=4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Five Color Theorem",
+      "Kempe chains",
+      "pigeonhole principle",
+      "degree-5 vertex"
+    ],
+    "prerequisites": [
+      "free_color_of_degree_lt",
+      "min on ℕ"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-one-swap",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 165,
+      "endLine": 181
+    },
+    "type": "insight",
+    "title": "Why one Kempe swap suffices for 5 colors",
+    "content": "The crux of the Five Color Theorem's Kempe argument: at a degree-5 vertex using all 5 colors, K₅'s non-planarity forces two neighbors to be non-adjacent; a single Kempe (c₁,c₂)-chain swap recolors one of them, dropping the count of distinct neighbor colors from 5 to 4 and freeing a color. The formal statement (five_color_one_swap_suffices) abstracts this to the arithmetic 5−1 ≤ 4, with the docstring supplying the planarity/K₅ reasoning that justifies why exactly one swap always works — the feature the 4-color case lacks.",
+    "mathContext": "$\\text{usedColors}=5,\\ \\text{afterSwap}=5-1=4\\le4$ — one swap frees a color.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kempe chain swap",
+      "K₅ non-planarity",
+      "Five Color Theorem",
+      "non-adjacent neighbors"
+    ],
+    "prerequisites": [
+      "Kempe chains",
+      "planarity of the neighbor configuration"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-kempe-fails",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 183,
+      "endLine": 206
+    },
+    "type": "insight",
+    "title": "Why Kempe's 4-color argument fails",
+    "content": "At a degree-5 vertex with only 4 colors, pigeonhole forces exactly one repeated color (kempe_four_color_structure: 5−4=1), but all 4 colors can still appear, so no color is free. Unlike the 5-color case a single swap merely rearranges colors without freeing one — two simultaneous Kempe swaps on different color pairs are needed, and in a planar graph those two chains can cross. This is precisely the gap in Kempe's 1879 'proof', exposed by Heawood in 1890.",
+    "mathContext": "$\\deg=5,\\ 4$ colors $\\Rightarrow$ one collision ($5-4=1$) but possibly all 4 colors used $\\Rightarrow$ no free color; two swaps required.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kempe's flawed proof",
+      "Heawood 1890",
+      "two-swap interference",
+      "planar chain crossing"
+    ],
+    "prerequisites": [
+      "pigeonhole",
+      "Kempe chains"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-heawood",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 265,
+      "endLine": 286
+    },
+    "type": "context",
+    "title": "The Heawood obstruction: chains must cross",
+    "content": "Formalizes the shape of Heawood's counterexample to Kempe's argument: when both bichromatic chains for the two color pairs are connected, in a planar drawing they are forced to cross (a Jordan-curve-theorem phenomenon), sharing a vertex whose recoloring under the first swap invalidates the second. The Lean statement (heawood_crossing_forced) is a placeholder capturing the logical shape (both-connected ⇒ crossing) with the topological content stated as a hypothesis (paths_in_plane), honestly signaling that the planar-crossing fact is assumed rather than derived here.",
+    "mathContext": "Two connected bichromatic chains linking opposite sides of a cycle must share a vertex (Jordan curve theorem), so simultaneous swaps interfere.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Heawood obstruction",
+      "Jordan curve theorem",
+      "bichromatic chains",
+      "planar graphs"
+    ],
+    "prerequisites": [
+      "Kempe chains",
+      "planarity",
+      "Jordan curve theorem (assumed)"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-human-readable",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 288,
+      "endLine": 323
+    },
+    "type": "context",
+    "title": "Toward a human-readable 4CT: flows and open approaches",
+    "content": "Surveys why no case-check-free proof of the Four Color Theorem is known: algebraic reformulations have no reduction; Hadwiger's conjecture for t=5 implies 4CT but its own proof uses 4CT (circular); Tutte's flow–coloring duality reduces 4CT to the nowhere-zero 4-flow theorem for planar graphs, but 4-flow there again follows only from 4CT. The flow_coloring_equivalence statement records the duality reformulation (as k≥2 arithmetic) with the docstring giving the status of Tutte's 6-flow (Seymour 1981) and 5-flow theorems and the still-open 4-flow question.",
+    "mathContext": "Planar $k$-colorability $\\Leftrightarrow$ nowhere-zero $k$-flow (Tutte); 6-flow and 5-flow proved, 4-flow $\\Leftrightarrow$ 4CT.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tutte flow conjectures",
+      "nowhere-zero flows",
+      "Hadwiger's conjecture",
+      "flow–coloring duality"
+    ],
+    "prerequisites": [
+      "planar duality",
+      "nowhere-zero flows"
+    ]
+  },
+  {
+    "id": "ann-4ct-oq01-min-degree",
+    "proofId": "four-color-theorem-oq-01",
+    "range": {
+      "startLine": 373,
+      "endLine": 378
+    },
+    "type": "technique",
+    "title": "Minimum counterexample has minimum degree ≥ 4",
+    "content": "The first discharging step of the classical reduction: in a minimal non-4-colorable planar graph no vertex has degree ≤ 3, since deleting such a vertex leaves a smaller graph 4-colorable by minimality, and a degree-≤3 vertex sees fewer than 4 colors so the coloring extends (the degree<k free-color lemma). Formally min_counterexample_degree reduces to d < 4 for d ≤ 3; combined with the planar edge bound E ≤ 3V−6 it forces a vertex of degree exactly 4 or 5, the configurations analyzed above.",
+    "mathContext": "$\\deg(v)\\le3 < 4 \\Rightarrow$ a free color exists on deletion, so a minimum counterexample has $\\delta \\ge 4$; with $E\\le 3V-6$ some vertex has degree 4 or 5.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discharging method",
+      "minimum counterexample",
+      "planar edge bound",
+      "reducible configuration"
+    ],
+    "prerequisites": [
+      "free_color_of_degree_lt",
+      "Euler's formula E ≤ 3V−6"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `four-color-theorem-oq-01`.

**Gap:** the existing 8 annotations covered the substantive lemmas (counting, swap-proper, small-graph colorability, config reduction) but left the *pedagogical* sections — which carry most of the file's mathematical narrative — unannotated.

**This PR** adds 7 section annotations (8 → 15):
- counting lemma `#neighbor-colors ≤ degree`
- five colors easy vs. four colors hard at degree 5
- why one Kempe swap suffices for 5 colors (K₅ non-planarity)
- why Kempe's 4-color argument fails (two-swap chain interference)
- the **Heawood** chain-crossing obstruction (Jordan-curve forced crossing)
- Tutte **flow–coloring duality** and the open human-readable approaches
- minimum counterexample has minimum degree ≥ 4 (discharging)

Several of these theorems are deliberately illustrative arithmetic (e.g. `5 ≤ 5`, `min 5 4 = 4`) whose docstrings carry the real content — the annotations frame them honestly as narrative scaffolding rather than overclaiming. Each new annotation has `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Existing 8 annotations preserved unchanged.