### PR TITLE
Enrich Operator absolute value |A|=√(AᴴA) (matrix-posdef-sqrt-oq-01-oq-01-oq-01): add conclusion block

### DIFF
--- a/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-posdef-sqrt-oq-01-oq-01-oq-01/meta.json
@@ -100,5 +100,9 @@
       "question": "Can the norm-preservation identity be upgraded to a genuine EuclideanSpace statement ‖A.toEuclideanCLM x‖ = ‖|A|.toEuclideanCLM x‖, and used to construct the partial isometry realising A = U·|A| in the singular case?",
       "status": "open"
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Establishes the operator absolute value |A| = √(AᴴA) as a first-class matrix construction on top of Mathlib's continuous-functional-calculus square root (CFC.sqrt), and proves its defining structural properties — positive semidefinite, Hermitian, |A|² = AᴴA, and uniqueness as the PSD square root via CFC.sqrt_unique — together with the load-bearing norm-preservation identity ⟨Ax, Ax⟩ = ⟨|A|x, |A|x⟩, which descends to the Euclidean statement ‖Ax‖ = ‖|A|x‖ for every vector x. The proof reduces everything to a single quadratic-form collapse ⟨Mx, Mx⟩ = ⟨x, (MᴴM)x⟩, applied to both A and |A| and combined with the fact that (|A|)ᴴ·|A| = AᴴA; the abstract 𝕜-valued form identity then becomes a genuine real squared-norm identity through RCLike.conj_mul and injectivity of the coercion ℝ ↪ 𝕜. All results hold uniformly over ℝ and ℂ (RCLike 𝕜) and are 0-axiom, machine-checked.",
+    "significance": "The modulus is the intrinsic, choice-free half of the polar decomposition A = U·|A|: the phase factor U is only determined up to the kernel, but |A| is unique. Norm preservation ‖Ax‖ = ‖|A|x‖ is exactly the property that forces U to be an isometry, and it is the entry point to the singular value decomposition (the singular values of A are the eigenvalues of |A|) and to the operator- and Schatten-norm theory built on |A|. Mathlib carries the C⋆-algebraic CFC.sqrt but packages neither the matrix operator absolute value nor its isometry property; this entry supplies both, and positions the kernel identity ker A = ker |A| and the partial-isometry construction for the singular case (the listed open questions) as the natural next steps."
+  }
 }


### PR DESCRIPTION
## Enrichment

Adds a `conclusion { summary, significance }` block to `matrix-posdef-sqrt-oq-01-oq-01-oq-01`, which previously had **no** conclusion section (the field scoring 0 in the enricher quality breakdown).

- **summary** — recaps the modulus construction |A| = √(AᴴA) on Mathlib's `CFC.sqrt`, the four structural properties (PSD, Hermitian, |A|²=AᴴA, uniqueness), and the norm-preservation identity ⟨Ax,Ax⟩ = ⟨|A|x,|A|x⟩ descending to ‖Ax‖ = ‖|A|x‖; notes the single quadratic-form collapse driving the proof and the RCLike ℝ/ℂ uniformity, 0-axiom.
- **significance** — positions |A| as the intrinsic (choice-free) half of the polar decomposition A = U·|A|, the entry point to the SVD and Schatten-norm theory, and frames the listed open questions (ker A = ker |A|, partial isometry) as next steps.

No Lean or annotation changes; meta.json stays well under the ~60 KB cap.