### PR TITLE
Enrich Two-square slice of Legendre three-square (lagrange-four-squares-waring-g2-oq-03-oq-03): annotate module docstring

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/annotations.json
@@ -1,74 +1,159 @@
 [
   {
+    "id": "overview",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Overview: An Elementary, Dirichlet-Free Slice of the Three-Square Sufficiency Direction",
+    "content": "The full sufficiency ('if') half of Legendre's three-square theorem — every n outside the excluded family 4^a(8b+7) is a sum of three squares — remains open in the gallery, reducible only to an analytic Hasse–Minkowski / Dirichlet input. This file carves out a genuinely elementary, Dirichlet-free slice of it by bridging Mathlib's complete two-square theory (Fermat's Nat.Prime.sq_add_sq and the characterisation Nat.eq_sq_add_sq_iff) to the missing three-square side: since every sum of two squares is trivially a sum of three (append 0²), Mathlib's two-square results immediately yield an explicit, infinite family of three-square numbers — every prime p ≢ 3 (mod 4), and every n whose primes ≡ 3 (mod 4) all appear to even power. It then draws two structural contrasts with the two-square theory: the three-square numbers strictly contain the two-square numbers (3 = 1²+1²+1² is not a sum of two squares), and — crucially — they are NOT closed under multiplication (3 and 21 are three-square, but 3·21 = 63 = 8·7+7 is excluded). This failure of multiplicative closure is the precise reason the sufficiency direction cannot be bootstrapped from primes and genuinely needs the analytic Dirichlet input. Every result is axiom-free, using only kernel `decide` over ZMod 4 / ZMod 8.",
+    "mathContext": "Bridge: $\\mathrm{IsSumTwoSq}(n)\\Rightarrow\\mathrm{IsSumThreeSq}(n)$ via $n=x^2+y^2+0^2$; contrast: $\\{$three-square$\\}$ is not closed under $\\times$, e.g. $3,21\\in$ but $63=4^0(8\\cdot7+7)\\notin$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Legendre three-square theorem",
+      "sums of two squares",
+      "Fermat two-square theorem",
+      "multiplicative closure",
+      "quadratic forms"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "sums of squares"
+    ]
+  },
+  {
     "id": "predicates",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 54, "endLine": 60 },
+    "range": {
+      "startLine": 54,
+      "endLine": 60
+    },
     "type": "definition",
     "title": "Two- and Three-Square Predicates",
     "content": "`IsSumTwoSq n` and `IsSumThreeSq n` are the representability predicates over ℤ: n = x²+y² and n = x²+y²+z² respectively. Working over the integers (rather than ℕ) keeps the modular obstruction arguments and the embedding clean. These two predicates and the relationship between them are the subject of the whole file.",
     "mathContext": "$\\mathrm{IsSumTwoSq}(n):\\exists x,y\\in\\mathbb Z,\\ x^2+y^2=n$; $\\mathrm{IsSumThreeSq}(n):\\exists x,y,z\\in\\mathbb Z,\\ x^2+y^2+z^2=n$.",
     "significance": "supporting",
-    "relatedConcepts": ["sums of squares", "quadratic forms", "representability"],
-    "prerequisites": ["integer arithmetic"]
+    "relatedConcepts": [
+      "sums of squares",
+      "quadratic forms",
+      "representability"
+    ],
+    "prerequisites": [
+      "integer arithmetic"
+    ]
   },
   {
     "id": "modular-obstructions",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 62, "endLine": 102 },
+    "range": {
+      "startLine": 62,
+      "endLine": 102
+    },
     "type": "theorem",
     "title": "Elementary Modular Obstructions (mod 8, mod 4)",
     "content": "The necessity-side facts, each a finite kernel `decide` check over a small ZMod. Squares in ZMod 8 lie in {0,1,4}, so no three sum to 7: a sum of three squares is never ≡ 7 (mod 8) (`sumThreeSq_ne_seven_mod_eight`, lifted to `not_isSumThreeSq_of_mod_eight`). Squares in ZMod 4 lie in {0,1}, so no two sum to 3: a sum of two squares is never ≡ 3 (mod 4) (`sumTwoSq_ne_three_mod_four`, `not_isSumTwoSq_of_mod_four`). These drive the concrete separating witness 3 and the non-closure witness 63. Using kernel `decide` (not `native_decide`) keeps the file 0-axiom.",
     "mathContext": "Squares mod 8 ∈ {0,1,4} ⟹ $x^2+y^2+z^2\\not\\equiv 7\\ (8)$; squares mod 4 ∈ {0,1} ⟹ $x^2+y^2\\not\\equiv 3\\ (4)$. The full excluded family for three squares is $4^a(8b+7)$.",
     "significance": "key",
-    "relatedConcepts": ["quadratic residues", "ZMod", "Legendre's excluded family", "kernel decide"],
-    "prerequisites": ["modular arithmetic", "quadratic residues mod 8"]
+    "relatedConcepts": [
+      "quadratic residues",
+      "ZMod",
+      "Legendre's excluded family",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "quadratic residues mod 8"
+    ]
   },
   {
     "id": "embedding",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 104, "endLine": 121 },
+    "range": {
+      "startLine": 104,
+      "endLine": 121
+    },
     "type": "theorem",
     "title": "The Embedding: Two Squares ⟹ Three Squares",
     "content": "`isSumTwoSq_imp_isSumThreeSq`: every sum of two squares is a sum of three — just append 0². Trivial in itself, but it is the bridge that turns Mathlib's complete two-square theory into unconditional progress on the OPEN three-square sufficiency direction. `isSumTwoSq_ne_seven_mod_eight` confirms consistency: a two-square number is never ≡ 7 (mod 8), so the whole two-square slice avoids Legendre's excluded family 4^a(8b+7).",
     "mathContext": "$x^2+y^2=n \\Rightarrow x^2+y^2+0^2=n$. The two-square numbers $\\subseteq$ three-square numbers, and never lie in $4^a(8b+7)$.",
     "significance": "critical",
-    "relatedConcepts": ["embedding", "Legendre three-square theorem", "open sufficiency direction"],
-    "prerequisites": ["sums of squares"]
+    "relatedConcepts": [
+      "embedding",
+      "Legendre three-square theorem",
+      "open sufficiency direction"
+    ],
+    "prerequisites": [
+      "sums of squares"
+    ]
   },
   {
     "id": "dirichlet-free-slice",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 123, "endLine": 141 },
+    "range": {
+      "startLine": 123,
+      "endLine": 141
+    },
     "type": "theorem",
     "title": "A Dirichlet-Free Infinite Slice of the Open Sufficiency Direction",
     "content": "Composing the embedding with Mathlib's two-square results yields unconditional three-square families with no appeal to Dirichlet's theorem. `prime_mod_four_ne_three_isSumThreeSq`: every prime p with p % 4 ≠ 3 is a sum of three squares (via Fermat's `Nat.Prime.sq_add_sq`). `isSumThreeSq_of_forall_threeMod_even`: every n whose primes ≡ 3 (mod 4) all occur to even power is a sum of three squares (via the full characterization `Nat.eq_sq_add_sq_iff`). These are explicit, infinite, axiom-free verifications of the open 'if' direction — exactly what the two-square theorem hands the three-square problem for free.",
     "mathContext": "$p\\not\\equiv 3\\ (4)\\Rightarrow p$ is a sum of three squares; more generally any $n$ with $v_q(n)$ even for all $q\\equiv 3\\ (4)$ is. An infinite Dirichlet-free family in the open sufficiency direction.",
     "significance": "critical",
-    "relatedConcepts": ["Fermat's Christmas theorem", "Dirichlet's theorem", "p-adic valuation", "two-square characterization"],
-    "prerequisites": ["two-square theorem", "prime factorization"]
+    "relatedConcepts": [
+      "Fermat's Christmas theorem",
+      "Dirichlet's theorem",
+      "p-adic valuation",
+      "two-square characterization"
+    ],
+    "prerequisites": [
+      "two-square theorem",
+      "prime factorization"
+    ]
   },
   {
     "id": "two-square-closure",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 143, "endLine": 152 },
+    "range": {
+      "startLine": 143,
+      "endLine": 152
+    },
     "type": "theorem",
     "title": "Brahmagupta–Fibonacci: Two Squares Are Multiplicatively Closed",
     "content": "`isSumTwoSq_mul`: the product of two sums of two squares is a sum of two squares, via Mathlib's `sq_add_sq_mul` (the Brahmagupta–Fibonacci two-square identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)²). This is the foil for the three-square non-closure below: it is precisely the multiplicativity that lets the two- and four-square theorems be assembled from prime cases, and which the three-square case fatally lacks.",
     "mathContext": "$(a^2+b^2)(c^2+d^2)=(ac-bd)^2+(ad+bc)^2$ — sums of two squares form a multiplicative monoid (the norm form of the Gaussian integers).",
     "significance": "key",
-    "relatedConcepts": ["Brahmagupta–Fibonacci identity", "Gaussian integers", "norm form", "multiplicativity"],
-    "prerequisites": ["polynomial identities"]
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci identity",
+      "Gaussian integers",
+      "norm form",
+      "multiplicativity"
+    ],
+    "prerequisites": [
+      "polynomial identities"
+    ]
   },
   {
     "id": "non-closure",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
-    "range": { "startLine": 154, "endLine": 187 },
+    "range": {
+      "startLine": 154,
+      "endLine": 187
+    },
     "type": "theorem",
     "title": "Three Squares Fail Multiplicative Closure — Why Analysis Is Needed",
     "content": "The structural heart of the entry. `isSumThreeSq_strictly_contains_twoSq`: 3 = 1²+1²+1² is a sum of three squares but not two (it is ≡ 3 mod 4), so three-square numbers strictly extend two-square numbers. `isSumThreeSq_not_mul_closed`: 3 and 21 = 4²+2²+1² are each sums of three squares, yet 3·21 = 63 = 8·7+7 is excluded by the mod-8 obstruction. This concrete counterexample is the precise reason the three-square sufficiency direction CANNOT be bootstrapped multiplicatively from a prime slice (as the two- and four-square theorems are) and genuinely requires the analytic Dirichlet / Hasse–Minkowski input still axiomatized in the parent entry.",
     "mathContext": "$3,\\,21$ are sums of three squares but $3\\cdot 21=63=4^0(8\\cdot 7+7)$ is excluded. The three-square representable set is not closed under multiplication — unlike two and four squares.",
     "significance": "critical",
-    "relatedConcepts": ["multiplicative closure failure", "ternary quadratic forms", "Hasse–Minkowski", "Legendre excluded family"],
-    "prerequisites": ["modular obstructions", "sums of squares"]
+    "relatedConcepts": [
+      "multiplicative closure failure",
+      "ternary quadratic forms",
+      "Hasse–Minkowski",
+      "Legendre excluded family"
+    ],
+    "prerequisites": [
+      "modular obstructions",
+      "sums of squares"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment

The entry's rich module docstring (lines 3–52) was **unannotated** — the first annotation began at line 54, so the file's overview never appeared on the page and annotation coverage sat at ~70%.

Adds **one `concept` overview annotation** (lines 1–52) paraphrasing the docstring:
- the elementary, **Dirichlet-free slice** of the open three-square sufficiency direction,
- the **two-→-three-square bridge** off Mathlib's complete two-square theory,
- **strict containment** (3 = 1²+1²+1² is three- but not two-square), and
- the **failure of multiplicative closure** (3·21 = 63 = 8·7+7 excluded) that forces the analytic input.

annotations.json only; validated types/significance; no range overlap (next annotation starts at line 54). No Lean changes.