### PR TITLE
Enrich natural density 1/6 of non-three-square integers (lagrange-four-squares-waring-g2-oq-03-oq-05): annotate module docstring

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
@@ -1,74 +1,153 @@
 [
   {
+    "id": "overview",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Overview: The Natural Density of the Non-Three-Square Integers is 1/6",
+    "content": "By Legendre's three-square theorem the integers that are NOT sums of three squares are exactly the excluded family E = {4^a(8b+7)} — precisely the extremal numbers that require the full four squares in Lagrange's theorem (the Waring extremal case g(2) = 4). This file answers a quantitative question absent elsewhere in the gallery: how rare are they? The answer is that E has natural density 1/6. Three ingredients: (1) a 4-descent counting recursion `excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉` — an excluded number is either odd and ≡ 7 (mod 8), or 4 times a smaller excluded number, a clean self-similar decomposition; (2) an explicit logarithmic error bound `|6·excludedCount N − N| ≤ 6(log₂ N + 1)`, proved by strong induction directly from the recursion — the constant 1/6 is pinned by the geometric series implicit in the recursion, yet the proof forms no infinite sum, only a single inductive invariant; and (3) the density theorem `excludedCount N / N → 1/6`, i.e. asymptotically one integer in six is not a sum of three squares. The only number-theoretic inputs are the elementary 2-adic facts about E (re-derived from oq-03-oq-04); the rest is finite combinatorics plus a standard log N / N → 0 squeeze. All proofs are axiom-free.",
+    "significance": "critical"
+  },
+  {
     "id": "descent-facts",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 51, "endLine": 83 },
+    "range": {
+      "startLine": 51,
+      "endLine": 83
+    },
     "type": "theorem",
     "title": "2-Adic Descent Facts for the Excluded Family",
     "content": "Three elementary facts about E = {4^a(8b+7)}, reusing the predicate and decidability from the sibling oq-03-oq-04. `mod8_seven_excluded`: any n ≡ 7 (mod 8) is excluded (take a=0). `four_mul_excluded_iff`: 4k is excluded iff k is — multiplying by 4 just shifts the exponent a. `excluded_not_dvd_four_iff`: for n not divisible by 4, being excluded is the same as n ≡ 7 (mod 8). These are the self-similarity facts that power the counting recursion: the excluded set splits into a residue class plus a scaled copy of itself.",
     "mathContext": "$n\\equiv 7\\ (8)\\Rightarrow n\\in E$; $4k\\in E\\iff k\\in E$; and for $4\\nmid n$, $n\\in E\\iff n\\equiv 7\\ (8)$.",
     "significance": "key",
-    "relatedConcepts": ["self-similarity", "2-adic descent", "excluded family", "residue classes"],
-    "prerequisites": ["modular arithmetic", "divisibility"]
+    "relatedConcepts": [
+      "self-similarity",
+      "2-adic descent",
+      "excluded family",
+      "residue classes"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "divisibility"
+    ]
   },
   {
     "id": "counting-function",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 85, "endLine": 108 },
+    "range": {
+      "startLine": 85,
+      "endLine": 108
+    },
     "type": "definition",
     "title": "The Counting Function and Residue Count",
     "content": "`excludedCount N` = #{n < N : n ∈ E}, a genuine Finset.card thanks to oq-03-oq-04's computable decidability. It vanishes for N ≤ 7 (no excluded number is below 7). `card_mod8_seven` proves the exact residue count #{n < N : n ≡ 7 (mod 8)} = ⌊N/8⌋ by a clean Finset induction matching the divisibility recurrence — the elementary half of the descent.",
     "mathContext": "$\\mathrm{excludedCount}(N)=\\#\\{n<N:n\\in E\\}$; $\\#\\{n<N:n\\equiv 7\\ (8)\\}=\\lfloor N/8\\rfloor$.",
     "significance": "supporting",
-    "relatedConcepts": ["counting function", "Finset.card", "residue counting"],
-    "prerequisites": ["Finset cardinality", "induction"]
+    "relatedConcepts": [
+      "counting function",
+      "Finset.card",
+      "residue counting"
+    ],
+    "prerequisites": [
+      "Finset cardinality",
+      "induction"
+    ]
   },
   {
     "id": "bijection",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 110, "endLine": 152 },
+    "range": {
+      "startLine": 110,
+      "endLine": 152
+    },
     "type": "theorem",
     "title": "Splitting the Excluded Set: Residue Class + Scaled Copy",
     "content": "The two halves of the descent. `filter_notdvd_eq_mod8`: the part of E below N not divisible by 4 is exactly the ≡ 7 (mod 8) residue class. `excludedCount_dvd_part`: the divisible-by-4 part is in explicit bijection (via n ↦ n/4 with inverse k ↦ 4k, using `Finset.card_bij'`) with the excluded set below ⌈N/4⌉. The bijection rests on the multiply-by-4 descent four_mul_excluded_iff. Together they exhibit E ∩ [0,N) as a residue class disjointly unioned with a 1/4-scaled copy of itself.",
     "mathContext": "$E\\cap[0,N) = \\{n\\equiv 7\\,(8)\\} \\sqcup 4\\cdot\\bigl(E\\cap[0,\\lceil N/4\\rceil)\\bigr)$; the second part is in bijection with $E\\cap[0,\\lceil N/4\\rceil)$.",
     "significance": "key",
-    "relatedConcepts": ["Finset.card_bij'", "explicit bijection", "self-similar set", "disjoint partition"],
-    "prerequisites": ["Finset bijections", "divisibility"]
+    "relatedConcepts": [
+      "Finset.card_bij'",
+      "explicit bijection",
+      "self-similar set",
+      "disjoint partition"
+    ],
+    "prerequisites": [
+      "Finset bijections",
+      "divisibility"
+    ]
   },
   {
     "id": "recursion",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 154, "endLine": 164 },
+    "range": {
+      "startLine": 154,
+      "endLine": 164
+    },
     "type": "theorem",
     "title": "The 4-Descent Counting Recursion",
     "content": "`excludedCount_rec`: excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉. Assembled from the residue count and the bijection via `Finset.filter_card_add_filter_neg_card_eq_card` (split by divisibility-by-4) and omega. This self-similar recursion is the engine of the entire density computation — it encodes the geometric series Σ 1/(8·4^a) = 1/6 without ever forming an infinite sum.",
     "mathContext": "$\\mathrm{excludedCount}(N)=\\lfloor N/8\\rfloor + \\mathrm{excludedCount}(\\lceil N/4\\rceil)$; unrolling gives $\\sum_a \\frac{N}{8\\cdot 4^a}=\\frac{N}{6}$.",
     "significance": "critical",
-    "relatedConcepts": ["recursion", "geometric series", "self-similarity", "Waring g(2)=4"],
-    "prerequisites": ["counting recursions"]
+    "relatedConcepts": [
+      "recursion",
+      "geometric series",
+      "self-similarity",
+      "Waring g(2)=4"
+    ],
+    "prerequisites": [
+      "counting recursions"
+    ]
   },
   {
     "id": "error-bound",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 166, "endLine": 206 },
+    "range": {
+      "startLine": 166,
+      "endLine": 206
+    },
     "type": "theorem",
     "title": "Logarithmic Error Bound by Strong Induction",
     "content": "`excludedCount_error_bound`: |6·excludedCount N − N| ≤ 6·(log₂ N + 1). Proved by strong induction directly from the recursion. Each descent step perturbs the error 6·excludedCount N − N by a bounded amount (the per-step δ = 6⌊N/8⌋ + ⌈N/4⌉ − N is ≤ 6 in absolute value, via the division identities), and the descent depth is log₂-controlled (each step at most halves N, so log₂ M + 1 ≤ log₂ N). This pins the constant 1/6 as a single inductive invariant rather than through an infinite sum.",
     "mathContext": "$|6\\,\\mathrm{excludedCount}(N)-N|\\le 6(\\log_2 N+1)$: the deviation from $N/6$ is only logarithmic, established by a bounded per-step perturbation over a log-depth descent.",
     "significance": "critical",
-    "relatedConcepts": ["strong induction", "error term", "Nat.log", "inductive invariant"],
-    "prerequisites": ["strong induction", "logarithms", "integer arithmetic"]
+    "relatedConcepts": [
+      "strong induction",
+      "error term",
+      "Nat.log",
+      "inductive invariant"
+    ],
+    "prerequisites": [
+      "strong induction",
+      "logarithms",
+      "integer arithmetic"
+    ]
   },
   {
     "id": "density",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 208, "endLine": 284 },
+    "range": {
+      "startLine": 208,
+      "endLine": 284
+    },
     "type": "theorem",
     "title": "The Density Theorem: Exactly 1/6 (Headline)",
     "content": "`excludedCount_density`: excludedCount N / N → 1/6 — asymptotically one integer in six is NOT a sum of three squares (equivalently requires all four squares of Lagrange's theorem, the extremal numbers for Waring's g(2)=4). It follows by a squeeze: the deviation |excludedCount N / N − 1/6| equals |6·excludedCount N − N| / (6N) ≤ (log₂ N + 1)/N, and the helper lemmas (natLog2_le_realLog, tendsto_logBound_zero) drive that to 0 using the standard Real.log N / N → 0 (`Real.isLittleO_log_id_atTop`). Sanity checks confirm excludedCount 8 = 1, 16 = 2, 32 = 5.",
     "mathContext": "$\\frac{\\mathrm{excludedCount}(N)}{N}\\to\\frac16$. The non-three-square integers have natural density exactly $1/6$.",
     "significance": "critical",
-    "relatedConcepts": ["natural density", "squeeze theorem", "asymptotic density", "log N / N → 0", "Lagrange four-square theorem"],
-    "prerequisites": ["limits", "asymptotic analysis", "little-o notation"]
+    "relatedConcepts": [
+      "natural density",
+      "squeeze theorem",
+      "asymptotic density",
+      "log N / N → 0",
+      "Lagrange four-square theorem"
+    ],
+    "prerequisites": [
+      "limits",
+      "asymptotic analysis",
+      "little-o notation"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment

The module docstring was **unannotated** (first annotation began after it), so the file overview never appeared on the gallery page and annotation coverage was low. Adds **one `concept` overview annotation** paraphrasing the docstring.

annotations.json only; validated types/significance; no range overlap; no Lean changes.