### PR TITLE
Enrich Werner identities and the finite Dirichlet kernel (triangle-angle-sum-oq-04): annotate module overview

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-04/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "overview",
+    "proofId": "triangle-angle-sum-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "Overview: Werner Product-to-Sum Identities and the Finite Dirichlet Kernel",
+    "content": "The four Werner product-to-sum identities convert a product of two sinusoids into a sum (e.g. 2·cos x·cos y = cos(x−y) + cos(x+y)). These are the building blocks; the substantive content is their telescoping application — the closed forms of the finite cosine and sine sums, the Dirichlet kernel / Lagrange trigonometric identity: 2·sin(x/2)·∑_{k=1}^{n} cos(kx) = sin((n+½)x) − sin(x/2), its sine analogue, and the kernel form ½ + ∑_{k=1}^{n} cos(kx) = sin((n+½)x)/(2·sin(x/2)) when sin(x/2) ≠ 0. Mathlib supplies the Werner identities (Real.two_mul_cos_mul_cos etc.) and the sum-to-product identities, but records no finite telescoped trigonometric sums — only the infinite power series Real.cos_eq_tsum, not the finite ∑ cos(kx) closed form. Those finite identities, the heart of classical Fourier analysis (partial sums of Fourier series are convolutions with the Dirichlet kernel Dₙ), are the original content here. The crux: each summand is a telescoping difference produced by a single Werner identity, 2·sin(x/2)·cos((k+1)x) = sin((k+1+½)x) − sin((k+½)x), so summing collapses to the endpoints. Verified: 0 sorries, 0 axiom declarations, no native_decide.",
+    "significance": "critical"
+  },
+  {
     "id": "ann-werner-identities",
     "proofId": "triangle-angle-sum-oq-04",
     "range": {


### PR DESCRIPTION
## Enrichment

The module-level overview comment was **unannotated** (the first annotation began after it), so the file overview never appeared on the gallery page and annotation coverage was low. Adds **one `concept` overview annotation** paraphrasing it.

annotations.json only; validated type/significance; no range overlap; no Lean changes.