### PR TITLE
Enrich Small-N floor of the 4-AP 3-diverse colouring number (erdos-160-incomplete-01): annotate module overview

### DIFF
--- a/src/data/proofs/erdos-160-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-160-incomplete-01/annotations.json
@@ -1,50 +1,106 @@
 [
   {
+    "id": "overview",
+    "proofId": "erdos-160-incomplete-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 26
+    },
+    "type": "concept",
+    "title": "Overview: The Exact Small-N Floor of the 4-AP 3-Diverse Colouring Number",
+    "content": "h(N) is the least number of colours needed to colour {1,…,N} so that every four-term arithmetic progression receives at least three distinct colours. Erdős #160 (OPEN) asks for the growth of h(N); the known bounds are deep (h(N) ≪ N^{2/3}, sharpened by Hunter, and h(N) ≫ exp(c(log N)^{1/9})) and appear in the parent file Erdos160Problem.lean only as axioms. This file proves, with no axioms and no sorry, the elementary but exact base of the function — the part the asymptotics build on but never state: not_achievable_le_two (two colours can never be 3-diverse once a 4-AP exists, since a 4-term progression has only 4 elements, so ≤ 2 colours give ≤ 2 distinct values < 3); h_ge_three (hence h(N) ≥ 3 for every N ≥ 4, a certain lower bound sitting below all the axiomatised asymptotics); and h_four (h(4) = 3 exactly, the first nontrivial value, attained by the colouring 1,2,3,1). Together with the parent file's h(N) ≤ 1 for N ≤ 3, this pins the function completely up to the first 4-AP: h = 0,1,1,1 on N = 0,1,2,3 and h(4) = 3. Status: 0 sorries, 0 axioms, no native_decide.",
+    "significance": "critical"
+  },
+  {
     "id": "e160i01-setup",
     "proofId": "erdos-160-incomplete-01",
-    "range": { "startLine": 27, "endLine": 32 },
+    "range": {
+      "startLine": 27,
+      "endLine": 32
+    },
     "type": "concept",
     "title": "The Predicates Reused from the Parent File",
     "content": "The file opens by importing Erdos160Problem and the Erdos160 namespace, reusing its definitions rather than redefining them. The four that matter: Is4AP n a d says positions a, a+d, a+2d, a+3d form a valid 4-term AP inside {1,…,n} (constraints a ≥ 1, d ≥ 1, a+3d ≤ n); colorCount4 c i j k l is the cardinality of the Finset {c i, c j, c k, c l} of colours on those four points; Achievable n k means some colouring c : Fin n → Fin k makes colorCount4 ≥ 3 on every 4-AP (it is '3-diverse'); and h n := sInf {k | Achievable n k} is the colouring number itself. Crucially, importing the parent does NOT import its axioms into these proofs — #print axioms confirms the three theorems below depend only on propext/Classical.choice/Quot.sound.",
     "mathContext": "$h(n) = \\inf\\{\\,k : \\exists\\,c : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,k,\\ \\forall\\ 4\\text{-AP},\\ \\mathrm{colorCount4} \\ge 3\\,\\}$",
     "significance": "supporting",
-    "prerequisites": ["the parent Erdos160Problem definitions", "Finset cardinality", "sInf over ℕ"],
-    "relatedConcepts": ["3-diverse colouring", "arithmetic progression predicate", "extremal function as an infimum", "axiom isolation across imports"]
+    "prerequisites": [
+      "the parent Erdos160Problem definitions",
+      "Finset cardinality",
+      "sInf over ℕ"
+    ],
+    "relatedConcepts": [
+      "3-diverse colouring",
+      "arithmetic progression predicate",
+      "extremal function as an infimum",
+      "axiom isolation across imports"
+    ]
   },
   {
     "id": "e160i01-not-two",
     "proofId": "erdos-160-incomplete-01",
-    "range": { "startLine": 35, "endLine": 59 },
+    "range": {
+      "startLine": 35,
+      "endLine": 59
+    },
     "type": "theorem",
     "title": "Two Colours Never Make a 4-AP 3-Diverse",
     "content": "For N ≥ 4, no ≤2-colour colouring is 3-diverse on 4-APs. The progression a=1, d=1 occupies positions 0,1,2,3 and is valid because N ≥ 4. The 3-diversity hypothesis forces colorCount4 ≥ 3 there, but colorCount4 is the cardinality of a Finset of Fin k, hence at most Fintype.card (Fin k) = k ≤ 2 (Finset.card_le_univ). 3 ≤ (something ≤ 2) is absurd — closed by omega. This is the pigeonhole core: three distinct colours need a palette of size three.",
     "mathContext": "$N \\ge 4 \\Rightarrow \\neg\\,\\mathrm{Achievable}(N,k),\\ k \\le 2$",
     "significance": "critical",
-    "prerequisites": ["Finset.card_le_univ", "Is4AP / colorCount4 definitions", "omega"],
-    "relatedConcepts": ["pigeonhole principle", "distinct colours on a progression", "palette size"]
+    "prerequisites": [
+      "Finset.card_le_univ",
+      "Is4AP / colorCount4 definitions",
+      "omega"
+    ],
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "distinct colours on a progression",
+      "palette size"
+    ]
   },
   {
     "id": "e160i01-ge-three",
     "proofId": "erdos-160-incomplete-01",
-    "range": { "startLine": 60, "endLine": 67 },
+    "range": {
+      "startLine": 60,
+      "endLine": 67
+    },
     "type": "theorem",
     "title": "The Certain Floor h(N) ≥ 3",
     "content": "An unconditional lower bound for N ≥ 4: if h(N) < 3 then h(N) ≤ 2, but the minimum is attained — Achievable N (h N) holds (the parent's h_achievable, from Nat.sInf_mem) — and not_achievable_le_two refutes a ≤2-colour 3-diverse colouring. So h(N) ≥ 3. This floor sits underneath every asymptotic bound the parent file states as an axiom (N^{2/3}, Hunter's exponent, exp(c(log N)^{1/9})).",
     "mathContext": "$h(N) \\ge 3 \\quad (N \\ge 4)$",
     "significance": "key",
-    "prerequisites": ["not_achievable_le_two", "h_achievable", "proof by contradiction"],
-    "relatedConcepts": ["extremal function lower bound", "infimum of achievable parameters"]
+    "prerequisites": [
+      "not_achievable_le_two",
+      "h_achievable",
+      "proof by contradiction"
+    ],
+    "relatedConcepts": [
+      "extremal function lower bound",
+      "infimum of achievable parameters"
+    ]
   },
   {
     "id": "e160i01-four",
     "proofId": "erdos-160-incomplete-01",
-    "range": { "startLine": 68, "endLine": 81 },
+    "range": {
+      "startLine": 68,
+      "endLine": 81
+    },
     "type": "theorem",
     "title": "The Exact First Value h(4) = 3",
     "content": "The first nontrivial value, by le_antisymm. Upper bound h(4) ≤ 3: the colouring 1,2,3,1 (![0,1,2,0] : Fin 4 → Fin 3) witnesses Achievable 4 3 (apply Nat.sInf_le). The Is4AP constraints d≥1, a≥1, a+3d≤4 force a=1, d=1 (omega), so only the single progression 1,2,3,4 must be checked; its four points get colours 0,1,2,0, a Finset of card 3 — confirmed by plain decide (not native_decide, so still axiom-free). Lower bound h(4) ≥ 3: h_ge_three. Hence h(4) = 3.",
     "mathContext": "$h(4) = 3,\\quad \\text{witness } 1,2,3,1$",
     "significance": "critical",
-    "prerequisites": ["Nat.sInf_le", "h_ge_three", "decide on a concrete Finset (Fin 3)"],
-    "relatedConcepts": ["exact extremal value", "explicit colouring witness", "kernel decision procedure"]
+    "prerequisites": [
+      "Nat.sInf_le",
+      "h_ge_three",
+      "decide on a concrete Finset (Fin 3)"
+    ],
+    "relatedConcepts": [
+      "exact extremal value",
+      "explicit colouring witness",
+      "kernel decision procedure"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment

The module-level overview comment was unannotated (the first annotation began after it), so the file overview never appeared on the gallery page and annotation coverage was low. Adds one `concept` overview annotation paraphrasing it.

annotations.json only; validated type/significance; no range overlap; no Lean changes.