### PR TITLE
research(cayley-hamilton-reduction-oq-02-oq-03): cyclic vector ⇒ non-derogatory [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonReductionOQ02OQ03.lean
+++ b/proofs/Proofs/CayleyHamiltonReductionOQ02OQ03.lean
@@ -1,0 +1,200 @@
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import Mathlib.FieldTheory.Minpoly.Field
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Proofs.CayleyHamiltonReductionOQ02OQ01
+import Mathlib.Tactic
+
+/-
+# Cyclic vectors and non-derogatory matrices
+
+The parent entry `cayley-hamilton-reduction-oq-02` establishes the
+**non-derogatory criterion**: an `n × n` matrix `M` satisfies
+`minpoly M = charpoly M` exactly when its minimal polynomial attains the maximal
+degree `n`.  Its sibling `oq-02-oq-01` builds the **companion matrix** `C(p)` of a
+monic polynomial and proves `minpoly (C p) = charpoly (C p) = p`, i.e. companion
+matrices are the archetypal non-derogatory matrices.
+
+This entry connects that criterion to **cyclic vectors**.  A vector `v` is *cyclic*
+for `M` when its Krylov orbit `{v, M v, M² v, …, Mⁿ⁻¹ v}` is linearly independent
+— equivalently (being `n` vectors in the `n`-dimensional space `Fin n → F`) when it
+spans the whole space.  The classical fact is:
+
+  `M` has a cyclic vector  ⟺  `M` is non-derogatory.
+
+## What is proved here
+
+* `eq_zero_of_aeval_mulVec_eq_zero` — the engine: if `v` is cyclic then no nonzero
+  polynomial of degree `< n` can send `v` to `0` under `p(M)`.  This is exactly the
+  statement that the Krylov orbit is linearly independent, read polynomially.
+* `isNonDerogatory_of_hasCyclicVector` — **the forward implication in full
+  generality**: a cyclic vector forces `minpoly M = charpoly M`.  The minimal
+  polynomial annihilates `v`, so by the engine it cannot have degree `< n`; combined
+  with `deg (minpoly) ≤ deg (charpoly) = n` this pins the degree at `n`, whence the
+  two monic polynomials coincide.
+* `span_eq_top_of_isCyclicVector` — the Krylov orbit of a cyclic vector spans the
+  whole space, matching the textbook "spanning" phrasing.
+* `companionMatrix_isCyclicVector` — **the reverse implication on the normal-form
+  representatives**: the standard basis vector `e₀` is an explicit cyclic vector for
+  every companion matrix `C(p)`, because `C(p)ᵏ · e₀ = eₖ` (from `oq-02-oq-01`'s
+  `companionMatrix_pow_basis`).
+* `companionMatrix_isNonDerogatory` — the two combine: `C(p)` is non-derogatory,
+  re-derived through its cyclic vector (consistent with the direct
+  `minpoly = charpoly = p`).
+
+## Scope
+
+The forward direction (`cyclic ⇒ non-derogatory`) is proved for an arbitrary matrix.
+The reverse direction (`non-derogatory ⇒ cyclic`) is proved here for the companion
+(rational canonical form) representatives.  Upgrading the reverse to an *arbitrary*
+non-derogatory matrix requires the rational canonical form — that every such matrix
+is *similar* to a single companion block — which is not yet available in Mathlib and
+is left as the remaining step.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open Matrix Polynomial BigOperators
+open CayleyHamiltonReductionOQ02OQ01
+
+namespace CayleyHamiltonReductionOQ02OQ03
+
+variable {F : Type*} [Field F]
+
+/-- The **Krylov orbit** of a matrix `M` at a vector `v`: the family `k ↦ Mᵏ v`
+indexed by `k : Fin n`.  These are the `n` vectors `v, M v, …, Mⁿ⁻¹ v`. -/
+def krylov {n : ℕ} (M : Matrix (Fin n) (Fin n) F) (v : Fin n → F) : Fin n → (Fin n → F) :=
+  fun k => (M ^ (k : ℕ)) *ᵥ v
+
+/-- `v` is a **cyclic vector** for `M` when its Krylov orbit is linearly independent.
+Since there are `n` vectors in the `n`-dimensional space `Fin n → F`, this is
+equivalent to the orbit spanning the whole space (`span_eq_top_of_isCyclicVector`). -/
+def IsCyclicVector {n : ℕ} (M : Matrix (Fin n) (Fin n) F) (v : Fin n → F) : Prop :=
+  LinearIndependent F (krylov M v)
+
+/-- `M` **has a cyclic vector** when some `v` is cyclic for it. -/
+def HasCyclicVector {n : ℕ} (M : Matrix (Fin n) (Fin n) F) : Prop :=
+  ∃ v, IsCyclicVector M v
+
+/-- `M` is **non-derogatory**: its minimal polynomial equals its characteristic
+polynomial (equivalently `deg (minpoly M) = n`). -/
+def IsNonDerogatory {n : ℕ} (M : Matrix (Fin n) (Fin n) F) : Prop :=
+  minpoly F M = M.charpoly
+
+/-- `mulVec` distributes over a finite sum of matrices. -/
+private theorem sum_mulVec {n : ℕ} (s : Finset ℕ)
+    (f : ℕ → Matrix (Fin n) (Fin n) F) (v : Fin n → F) :
+    (∑ i ∈ s, f i) *ᵥ v = ∑ i ∈ s, f i *ᵥ v := by
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert a s' has ih =>
+      rw [Finset.sum_insert has, Matrix.add_mulVec, ih, Finset.sum_insert has]
+
+/-- **The engine.** If `v` is a cyclic vector for `M`, then a polynomial of degree
+`< n` whose evaluation `p(M)` annihilates `v` must be the zero polynomial.
+
+Equivalently: linear independence of `{v, M v, …, Mⁿ⁻¹ v}` says that the only
+`F`-combination `∑ cₖ Mᵏ v` equal to `0` is the trivial one — and `p(M) v` is
+exactly such a combination with `cₖ = p.coeff k`. -/
+theorem eq_zero_of_aeval_mulVec_eq_zero {n : ℕ} {M : Matrix (Fin n) (Fin n) F}
+    {v : Fin n → F} (hv : IsCyclicVector M v) {p : F[X]} (hdeg : p.natDegree < n)
+    (hp : (aeval M p) *ᵥ v = 0) : p = 0 := by
+  -- Expand `p(M) v` as an `F`-combination of the Krylov orbit.
+  have hexp : (aeval M p) *ᵥ v = ∑ k : Fin n, p.coeff (k : ℕ) • krylov M v k := by
+    rw [Polynomial.aeval_eq_sum_range' (n := n) hdeg M, sum_mulVec,
+      ← Fin.sum_univ_eq_sum_range (fun k => (p.coeff k • M ^ k) *ᵥ v) n]
+    refine Finset.sum_congr rfl (fun k _ => ?_)
+    simp [krylov, Matrix.smul_mulVec]
+  have hsum : ∑ k : Fin n, p.coeff (k : ℕ) • krylov M v k = 0 := hexp ▸ hp
+  -- Linear independence forces every coefficient (up to index `n`) to vanish.
+  have hcoeff : ∀ k : Fin n, p.coeff (k : ℕ) = 0 :=
+    Fintype.linearIndependent_iff.mp hv (fun k => p.coeff (k : ℕ)) hsum
+  apply Polynomial.ext
+  intro m
+  rw [Polynomial.coeff_zero]
+  by_cases hm : m < n
+  · exact hcoeff ⟨m, hm⟩
+  · exact Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
+
+/-- **Forward implication (general).** If `M` has a cyclic vector, then `M` is
+non-derogatory: `minpoly M = charpoly M`.
+
+The minimal polynomial `μ` annihilates `M`, hence annihilates `v`; by the engine it
+cannot have degree `< n`, so `n ≤ deg μ`.  Since `μ ∣ charpoly` and
+`deg (charpoly) = n`, also `deg μ ≤ n`, so `deg μ = n`; two monic polynomials with
+`μ ∣ charpoly` and equal degree are equal. -/
+theorem isNonDerogatory_of_hasCyclicVector {n : ℕ} [NeZero n]
+    {M : Matrix (Fin n) (Fin n) F} (h : HasCyclicVector M) : IsNonDerogatory M := by
+  obtain ⟨v, hv⟩ := h
+  have hint : IsIntegral F M := Matrix.isIntegral M
+  set μ := minpoly F M with hμ
+  have hμmonic : μ.Monic := minpoly.monic hint
+  have hμ0 : μ ≠ 0 := hμmonic.ne_zero
+  have hkill : (aeval M μ) *ᵥ v = 0 := by rw [minpoly.aeval F M]; exact Matrix.zero_mulVec v
+  -- degree ≥ n
+  have hge : n ≤ μ.natDegree := by
+    by_contra hlt
+    push_neg at hlt
+    exact hμ0 (eq_zero_of_aeval_mulVec_eq_zero hv hlt hkill)
+  -- degree ≤ n via minpoly ∣ charpoly, deg charpoly = n
+  have hdvd : μ ∣ M.charpoly := Matrix.minpoly_dvd_charpoly M
+  have hcharmonic : M.charpoly.Monic := Matrix.charpoly_monic M
+  have hchardeg : M.charpoly.natDegree = n := by
+    rw [Matrix.charpoly_natDegree_eq_dim]; exact Fintype.card_fin n
+  have hle : μ.natDegree ≤ n :=
+    hchardeg ▸ Polynomial.natDegree_le_of_dvd hdvd hcharmonic.ne_zero
+  have hdegeq : μ.natDegree = n := le_antisymm hle hge
+  -- μ = charpoly: same monic, μ ∣ charpoly, equal degrees ⇒ cofactor is 1
+  obtain ⟨q, hq⟩ := hdvd
+  have hqmonic : q.Monic := Polynomial.Monic.of_mul_monic_left hμmonic (hq ▸ hcharmonic)
+  have hqdeg : q.natDegree = 0 := by
+    have hmul : M.charpoly.natDegree = μ.natDegree + q.natDegree := by
+      rw [hq, Polynomial.natDegree_mul hμmonic.ne_zero hqmonic.ne_zero]
+    omega
+  have hq1 : q = 1 := by
+    have h0 := Polynomial.eq_C_of_natDegree_eq_zero hqdeg
+    have h1 : q.coeff 0 = 1 := by
+      rw [Polynomial.Monic.def, Polynomial.leadingCoeff, hqdeg] at hqmonic; exact hqmonic
+    rw [h0, h1, map_one]
+  show μ = M.charpoly
+  rw [hq, hq1, mul_one]
+
+/-- The Krylov orbit of a cyclic vector **spans the whole space**.  This is the
+textbook "spanning" form of cyclicity: `n` linearly independent vectors in the
+`n`-dimensional space `Fin n → F` form a basis. -/
+theorem span_eq_top_of_isCyclicVector {n : ℕ} [NeZero n]
+    {M : Matrix (Fin n) (Fin n) F} {v : Fin n → F} (hv : IsCyclicVector M v) :
+    Submodule.span F (Set.range (krylov M v)) = ⊤ := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩⟩
+  refine hv.span_eq_top_of_card_eq_finrank ?_
+  rw [Module.finrank_fintype_fun_eq_card]
+
+/-- **Reverse implication on the normal forms.** For a monic polynomial `p` of
+degree `d`, the standard basis vector `e₀` is a cyclic vector for the companion
+matrix `C(p)`.
+
+Indeed `C(p)ᵏ · e₀ = eₖ` for `k < d` (`companionMatrix_pow_basis`), so the Krylov
+orbit is precisely the standard basis of `Fin d → F`, which is linearly
+independent. -/
+theorem companionMatrix_isCyclicVector {d : ℕ} [NeZero d] (p : F[X]) :
+    IsCyclicVector (companionMatrix (d := d) p) (Pi.single (0 : Fin d) 1) := by
+  -- the orbit family is the standard basis `k ↦ Pi.single k 1`
+  have hfam : krylov (companionMatrix (d := d) p) (Pi.single (0 : Fin d) 1)
+      = fun k : Fin d => (Pi.single k 1 : Fin d → F) := by
+    funext k
+    have := companionMatrix_pow_basis (F := F) p k.val k.isLt
+    simp only [krylov]
+    rw [this]
+  rw [IsCyclicVector, hfam, Fintype.linearIndependent_iff]
+  intro g hg k
+  have hk := congr_fun hg k
+  simpa [Finset.sum_apply, Pi.single_apply] using hk
+
+/-- **The two directions combine on companion matrices.** `C(p)` is non-derogatory,
+obtained here through its explicit cyclic vector `e₀`.  (This is consistent with the
+direct computation `minpoly (C p) = charpoly (C p) = p` in `oq-02-oq-01`.) -/
+theorem companionMatrix_isNonDerogatory {d : ℕ} [NeZero d] (p : F[X]) :
+    IsNonDerogatory (companionMatrix (d := d) p) :=
+  isNonDerogatory_of_hasCyclicVector ⟨_, companionMatrix_isCyclicVector p⟩
+
+end CayleyHamiltonReductionOQ02OQ03

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-definitions",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "definition",
+    "title": "Krylov Orbits, Cyclic Vectors, Non-Derogatory Matrices",
+    "content": "Four definitions set the stage. `krylov M v` is the family k ↦ Mᵏv indexed by `Fin n` — the n vectors v, Mv, …, Mⁿ⁻¹v. `IsCyclicVector M v` says this orbit is linearly independent; `HasCyclicVector M` says some v is cyclic. `IsNonDerogatory M` is `minpoly F M = M.charpoly`. Because the orbit has n vectors in the n-dimensional space `Fin n → F`, linear independence is equivalent to spanning, matching the textbook definition of a cyclic vector.",
+    "mathContext": "$v$ is cyclic iff $\\{v, Mv, \\ldots, M^{n-1}v\\}$ is a basis of $F^n$; $M$ is non-derogatory iff $\\mathrm{minpoly}(M) = \\mathrm{charpoly}(M)$, equivalently $\\deg(\\mathrm{minpoly}) = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Krylov subspace",
+      "cyclic vector",
+      "non-derogatory matrix",
+      "minimal polynomial",
+      "characteristic polynomial"
+    ],
+    "prerequisites": [
+      "linear independence in Lean 4",
+      "matrix-vector product mulVec",
+      "minimal and characteristic polynomials"
+    ]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": { "startLine": 93, "endLine": 117 },
+    "type": "theorem",
+    "title": "The Engine: Low-Degree Annihilators Vanish",
+    "content": "`eq_zero_of_aeval_mulVec_eq_zero` is the technical heart. It rewrites p(M)·v = ∑_{k<n} (p.coeff k)·(Mᵏv) using `aeval_eq_sum_range'` and a `mulVec`-over-sum helper, so a degree-<n polynomial with p(M)v = 0 becomes a vanishing F-combination of the Krylov orbit. `Fintype.linearIndependent_iff` then forces every coefficient below index n to be zero, and `coeff_eq_zero_of_natDegree_lt` handles the rest, giving p = 0. This is exactly the linear-independence hypothesis re-read as a statement about polynomials.",
+    "mathContext": "$p(M)v = \\sum_{k} p_k\\,(M^k v)$; if $\\deg p < n$ and this is $0$, linear independence of the orbit gives $p_k = 0$ for all $k$, so $p = 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "polynomial evaluation aeval",
+      "linear independence",
+      "annihilating polynomial"
+    ],
+    "prerequisites": [
+      "Polynomial.aeval_eq_sum_range'",
+      "Fintype.linearIndependent_iff"
+    ]
+  },
+  {
+    "id": "ann-forward",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": { "startLine": 119, "endLine": 160 },
+    "type": "theorem",
+    "title": "Forward Implication: Cyclic ⇒ Non-Derogatory",
+    "content": "`isNonDerogatory_of_hasCyclicVector` proves the substantive direction in full generality. The minimal polynomial μ annihilates M, hence annihilates the cyclic vector v; by the engine μ cannot have degree < n, so deg μ ≥ n. Since μ divides the characteristic polynomial and deg(charpoly) = n, also deg μ ≤ n, pinning deg μ = n. Two monic polynomials with μ ∣ charpoly and equal degree must be equal, so μ = charpoly — M is non-derogatory.",
+    "mathContext": "$\\mu(M)v = 0$ and $\\deg\\mu < n$ would force $\\mu = 0$ (impossible), so $\\deg\\mu \\ge n$; with $\\mu \\mid \\mathrm{charpoly}$ and $\\deg(\\mathrm{charpoly}) = n$, $\\mu = \\mathrm{charpoly}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "minimal polynomial divides characteristic polynomial",
+      "monic divisibility",
+      "non-derogatory criterion"
+    ],
+    "prerequisites": [
+      "Matrix.minpoly_dvd_charpoly",
+      "Matrix.charpoly_natDegree_eq_dim"
+    ]
+  },
+  {
+    "id": "ann-spanning",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": { "startLine": 162, "endLine": 170 },
+    "type": "theorem",
+    "title": "Spanning Form of Cyclicity",
+    "content": "`span_eq_top_of_isCyclicVector` recovers the textbook 'spanning' phrasing: an n-element linearly independent family in the n-dimensional space `Fin n → F` spans the whole space. The proof calls `LinearIndependent.span_eq_top_of_card_eq_finrank` together with `finrank (Fin n → F) = n`.",
+    "mathContext": "A linearly independent set of $\\dim(F^n) = n$ vectors is a basis, hence spans $F^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "basis",
+      "finrank",
+      "spanning set"
+    ],
+    "prerequisites": [
+      "LinearIndependent.span_eq_top_of_card_eq_finrank",
+      "Module.finrank_fintype_fun_eq_card"
+    ]
+  },
+  {
+    "id": "ann-companion",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": { "startLine": 172, "endLine": 199 },
+    "type": "theorem",
+    "title": "Reverse on the Normal Forms: Companion Matrices",
+    "content": "`companionMatrix_isCyclicVector` exhibits the converse witness: the standard basis vector e₀ is cyclic for every companion matrix C(p). The orbit lemma `companionMatrix_pow_basis` from the sibling entry gives C(p)ᵏ·e₀ = eₖ, so the Krylov orbit of e₀ is exactly the standard basis — trivially linearly independent. `companionMatrix_isNonDerogatory` then feeds this into the forward implication, re-deriving that companion matrices are non-derogatory (consistent with the direct minpoly = charpoly = p of oq-02-oq-01). This realizes the reverse implication on the rational-canonical-form representatives.",
+    "mathContext": "$C(p)^k e_0 = e_k$ makes the orbit of $e_0$ the standard basis of $F^d$, so $e_0$ is cyclic; the forward implication then gives $\\mathrm{minpoly}(C(p)) = \\mathrm{charpoly}(C(p))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "companion matrix",
+      "rational canonical form",
+      "standard basis orbit"
+    ],
+    "prerequisites": [
+      "companionMatrix_pow_basis",
+      "Pi.single standard basis"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "cayley-hamilton-reduction-oq-02-oq-03",
+  "title": "Cyclic Vectors and Non-Derogatory Matrices",
+  "slug": "cayley-hamilton-reduction-oq-02-oq-03",
+  "description": "A cyclic vector forces a matrix to be non-derogatory (minpoly = charpoly), proved in full generality; the companion matrices realize the converse with an explicit cyclic vector.",
+  "meta": {
+    "author": "Ferdinand Georg Frobenius (1878)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclic_module",
+    "date": "1878",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "cyclic-vector",
+      "non-derogatory",
+      "minimal-polynomial",
+      "companion-matrix",
+      "rational-canonical-form"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.minpoly_dvd_charpoly",
+        "description": "The minimal polynomial divides the characteristic polynomial",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly"
+      },
+      {
+        "theorem": "Matrix.charpoly_natDegree_eq_dim",
+        "description": "The characteristic polynomial has degree equal to the matrix dimension",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      },
+      {
+        "theorem": "Polynomial.aeval_eq_sum_range'",
+        "description": "Evaluation of a polynomial as a finite sum of coefficient-scaled powers",
+        "module": "Mathlib.Algebra.Polynomial.Eval"
+      },
+      {
+        "theorem": "Fintype.linearIndependent_iff",
+        "description": "Linear independence over a finite index in terms of vanishing coefficients",
+        "module": "Mathlib.LinearAlgebra.LinearIndependent.Defs"
+      },
+      {
+        "theorem": "LinearIndependent.span_eq_top_of_card_eq_finrank",
+        "description": "A maximal linearly independent family spans the whole finite-dimensional space",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "Definition of the Krylov orbit k ↦ Mᵏv, cyclic vectors, HasCyclicVector, and non-derogatory matrices",
+      "Engine lemma: for a cyclic vector, no nonzero polynomial of degree < n annihilates it under p(M)",
+      "Forward implication in full generality: a cyclic vector forces minpoly M = charpoly M",
+      "Spanning form: the Krylov orbit of a cyclic vector spans the whole space",
+      "Reverse implication on the normal forms: e₀ is an explicit cyclic vector for every companion matrix C(p)",
+      "Combination: companion matrices are non-derogatory, re-derived through their cyclic vector"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 200,
+    "assumptions": "Fully machine-checked over an arbitrary field F: 0 axioms, 0 sorries; #print axioms reports only propext / Classical.choice / Quot.sound on all headline results. The forward implication (cyclic ⇒ non-derogatory) is proved for an arbitrary matrix. The reverse (non-derogatory ⇒ cyclic) is proved here for the companion / rational-canonical-form representatives; upgrading it to an arbitrary non-derogatory matrix requires that every such matrix be similar to a single companion block (rational canonical form), which is not yet available in Mathlib and is noted as the remaining step.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "The equivalence between the existence of a cyclic vector and the non-derogatory condition (minimal polynomial of full degree) is a cornerstone of the Frobenius (rational canonical form) theory, codified in Frobenius's 1878 paper 'Über lineare Substitutionen und bilineare Formen'. In module-theoretic language, a matrix M has a cyclic vector precisely when the F[X]-module Fⁿ (with X acting as M) is cyclic, i.e. isomorphic to F[X]/(minpoly M); this happens exactly when deg(minpoly M) = n, the non-derogatory case. The companion matrix C(p), which is by construction the multiplication-by-X operator on F[X]/(p), is the archetypal example: its standard basis vector e₀ generates the whole space. This entry formalizes the general forward implication and the companion-matrix realization, building directly on the sibling entry oq-02-oq-01 (companion matrices) and the parent oq-02 (non-derogatory criterion).",
+    "problemStatement": "A matrix M ∈ Mₙ(F) is non-derogatory when its minimal polynomial equals its characteristic polynomial. A vector v is cyclic when its Krylov orbit {v, Mv, …, Mⁿ⁻¹v} is linearly independent (equivalently spans Fⁿ). Show that a cyclic vector forces M to be non-derogatory, and exhibit an explicit cyclic vector for the companion matrices — the rational-canonical-form representatives of every non-derogatory similarity class.",
+    "proofStrategy": "The engine reads linear independence of the Krylov orbit polynomially: since p(M)v = ∑ₖ (p.coeff k)·(Mᵏv), a degree-<n polynomial with p(M)v = 0 has all coefficients zero, hence is zero. Applying this to the minimal polynomial (which annihilates v) shows deg(minpoly) ≥ n; combined with deg(minpoly) ≤ deg(charpoly) = n and monic divisibility, minpoly = charpoly. For the converse witness, oq-02-oq-01's orbit lemma C(p)ᵏ·e₀ = eₖ shows the Krylov orbit of e₀ is exactly the standard basis, so e₀ is cyclic for every companion matrix.",
+    "keyInsights": [
+      "p(M)·v is precisely the F-linear combination ∑ₖ (p.coeff k)·(Mᵏv) of the Krylov orbit, so linear independence of the orbit is the statement that no nonzero low-degree polynomial annihilates v",
+      "The minimal polynomial always annihilates any vector, so a cyclic vector immediately bounds deg(minpoly) below by n — the only place the cyclicity hypothesis is used",
+      "Two monic polynomials with minpoly ∣ charpoly and equal degree must coincide, converting the degree bound into the non-derogatory identity minpoly = charpoly",
+      "Companion matrices realize the converse concretely: C(p)ᵏ·e₀ = eₖ makes the Krylov orbit of e₀ the standard basis, so e₀ is always cyclic",
+      "The general reverse implication (non-derogatory ⇒ cyclic vector) needs the rational canonical form — that every non-derogatory matrix is similar to a companion block — which Mathlib does not yet provide"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-imports",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Narrow Mathlib imports (charpoly/minpoly, finite-dimensional lemmas) plus the sibling companion-matrix file, the file docstring framing the cyclic-vector / non-derogatory equivalence and scope, and the namespace, opens, and field setup.",
+      "mathContext": "Works over an arbitrary field $F$. Reuses `companionMatrix` and its orbit lemma `companionMatrix_pow_basis` from `CayleyHamiltonReductionOQ02OQ01`, and Mathlib's minimal/characteristic-polynomial API and finite-dimensional linear-independence lemmas."
+    },
+    {
+      "id": "definitions",
+      "title": "Krylov Orbits, Cyclic Vectors, Non-Derogatory Matrices",
+      "startLine": 65,
+      "endLine": 82,
+      "summary": "Defines the Krylov orbit `krylov M v = (k ↦ Mᵏv)`, `IsCyclicVector` (orbit linearly independent), `HasCyclicVector`, and `IsNonDerogatory` (minpoly M = charpoly M).",
+      "mathContext": "The Krylov orbit is the family $\\{v, Mv, \\ldots, M^{n-1}v\\}$. A cyclic vector is one whose orbit is a basis; since there are $n$ vectors in the $n$-dimensional space $F^n$, linear independence and spanning are equivalent. Non-derogatory means $\\mathrm{minpoly}(M) = \\mathrm{charpoly}(M)$, i.e. $\\deg(\\mathrm{minpoly}) = n$."
+    },
+    {
+      "id": "engine",
+      "title": "The Engine: Low-Degree Annihilators Vanish",
+      "startLine": 83,
+      "endLine": 124,
+      "summary": "A private `mulVec`-over-sum helper, then `eq_zero_of_aeval_mulVec_eq_zero`: if v is cyclic and p has degree < n with p(M)v = 0, then p = 0. Expands p(M)v as an F-combination of the Krylov orbit and applies `Fintype.linearIndependent_iff`.",
+      "mathContext": "Since $p(M) = \\sum_{k} (p_k) M^k$, one has $p(M)v = \\sum_{k<n} p_k (M^k v)$, an $F$-combination of the orbit. Linear independence forces $p_k = 0$ for all $k < n$; degrees beyond $n$ vanish because $\\deg p < n$. Hence $p = 0$. This is the linear-independence hypothesis, read as a statement about polynomials."
+    },
+    {
+      "id": "forward",
+      "title": "Forward Implication: Cyclic ⇒ Non-Derogatory",
+      "startLine": 125,
+      "endLine": 163,
+      "summary": "`isNonDerogatory_of_hasCyclicVector`: a cyclic vector forces minpoly M = charpoly M. The minimal polynomial annihilates the cyclic vector, so by the engine its degree is ≥ n; with deg(minpoly) ≤ deg(charpoly) = n and monic divisibility, the two coincide.",
+      "mathContext": "The minimal polynomial $\\mu$ satisfies $\\mu(M) = 0$, hence $\\mu(M)v = 0$; by the engine $\\deg\\mu \\ge n$. Since $\\mu \\mid \\mathrm{charpoly}$ and $\\deg(\\mathrm{charpoly}) = n$, also $\\deg\\mu \\le n$, so $\\deg\\mu = n$. Two monic polynomials with $\\mu \\mid \\mathrm{charpoly}$ and equal degree are equal, giving $\\mu = \\mathrm{charpoly}$."
+    },
+    {
+      "id": "spanning",
+      "title": "Spanning Form of Cyclicity",
+      "startLine": 164,
+      "endLine": 178,
+      "summary": "`span_eq_top_of_isCyclicVector`: the Krylov orbit of a cyclic vector spans the whole space, via `LinearIndependent.span_eq_top_of_card_eq_finrank` and `finrank (Fin n → F) = n`.",
+      "mathContext": "A linearly independent family of $n = \\dim(F^n)$ vectors is a basis, hence spans. This recovers the textbook 'spanning' phrasing of a cyclic vector from the linear-independence definition."
+    },
+    {
+      "id": "companion",
+      "title": "Reverse on the Normal Forms: Companion Matrices",
+      "startLine": 179,
+      "endLine": 200,
+      "summary": "`companionMatrix_isCyclicVector`: e₀ is a cyclic vector for every companion matrix C(p) (its Krylov orbit is the standard basis, via `companionMatrix_pow_basis`). `companionMatrix_isNonDerogatory` combines with the forward direction to re-derive non-derogacy.",
+      "mathContext": "By $C(p)^k e_0 = e_k$ (oq-02-oq-01), the Krylov orbit of $e_0$ is exactly $\\{e_0, e_1, \\ldots, e_{d-1}\\}$, the standard basis of $F^d$, which is linearly independent. So $e_0$ is cyclic, and the forward implication gives $\\mathrm{minpoly}(C(p)) = \\mathrm{charpoly}(C(p))$ — consistent with the direct computation $\\mathrm{minpoly} = \\mathrm{charpoly} = p$."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **cayley-hamilton-reduction-oq-02-oq-03**, answering the open question of `cayley-hamilton-reduction-oq-02`: characterize **non-derogatory** matrices (`minpoly = charpoly`) via **cyclic vectors**.

A vector `v` is *cyclic* for `M` when its Krylov orbit `{v, Mv, …, Mⁿ⁻¹v}` is linearly independent (equivalently spans `Fⁿ`).

## Results (VERIFIED, 0-axiom, over an arbitrary field)

- `eq_zero_of_aeval_mulVec_eq_zero` — **engine**: for a cyclic vector, no nonzero polynomial of degree `< n` annihilates it under `p(M)`. This is linear independence of the orbit, read polynomially: `p(M)v = ∑ₖ (p.coeff k)·(Mᵏv)`.
- `isNonDerogatory_of_hasCyclicVector` — **forward implication, in full generality**: a cyclic vector forces `minpoly M = charpoly M`. The minimal polynomial annihilates `v`, so by the engine `deg(minpoly) ≥ n`; with `minpoly ∣ charpoly` of degree `n`, they coincide.
- `span_eq_top_of_isCyclicVector` — the textbook **spanning** form of cyclicity.
- `companionMatrix_isCyclicVector` — **reverse implication on the normal forms**: `e₀` is an explicit cyclic vector for every companion matrix `C(p)` (from `companionMatrix_pow_basis` in sibling `oq-02-oq-01`, since `C(p)ᵏ·e₀ = eₖ`).
- `companionMatrix_isNonDerogatory` — the two combine: companion matrices are non-derogatory, re-derived through their cyclic vector.

## Scope / honesty

The forward direction (`cyclic ⇒ non-derogatory`) is proved for an **arbitrary** matrix. The reverse (`non-derogatory ⇒ cyclic`) is proved for the **companion / rational-canonical-form representatives**. Upgrading the reverse to an arbitrary non-derogatory matrix requires the rational canonical form (every such matrix is *similar* to a single companion block), which Mathlib does not yet provide — noted in the file header and meta as the remaining step.

## Verification

- `lake env lean Proofs/CayleyHamiltonReductionOQ02OQ03.lean` — compiles clean, 0 sorries.
- `#print axioms` on all headline results reports only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- 200 lines, 5 theorems / 4 definitions. Narrow imports; builds on `Proofs/CayleyHamiltonReductionOQ02OQ01.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)