### PR TITLE
Enrich Antipodal-symmetry Tucker no-go (sperner-mathlib4-oq-02-oq-02): fix crossReferences + annotation depth

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-02/annotations.json
@@ -9,7 +9,19 @@
     "type": "concept",
     "title": "Antipodal symmetry kills the door-graph endpoint parity",
     "content": "The header frames the entry against the open frontier of the whole program. The verified TuckerTower dimension recursion consumes an ODD interior-endpoint count of the almost-complementary door graph at each level and propagates it upward; the sole open input is the geometric bridge. The sibling entry found empirically that the natural door graph is often endpoint-free while Tucker still holds, so the missing input must be an oriented / antipodally-signed count, not any door-counting parity. This file proves the dimension-free structural reason: if the antipodal map σ is a free involution AND a boundary-preserving graph automorphism, both the interior and the boundary degree-1 endpoint counts are forced EVEN, so an antipodally-symmetric door graph can never be a Tucker level (which needs an ODD interior count). Hence the oddness can appear only once the symmetry is broken — on a hemisphere fundamental domain. Honest status: reusable dimension-free infrastructure, 0 sorries, 0 axioms (propext / Classical.choice / Quot.sound only — no decide, no Lean.ofReduceBool).",
-    "mathContext": "Objects: a finite door graph $G$ on the top cells, a decidable boundary predicate $B$, and the antipodal map $\\sigma$. The tower's endpoint sets are $\\mathrm{interiorEndpoints}\\,G\\,B = \\{v : G.\\deg v = 1 \\wedge \\neg B v\\}$ and $\\mathrm{boundaryEndpoints}\\,G\\,B = \\{v : G.\\deg v = 1 \\wedge B v\\}$. Hypotheses on $\\sigma$: free involution $\\sigma(\\sigma v) = v$, $\\sigma v \\neq v$; graph automorphism $G.\\mathrm{Adj}(\\sigma v)(\\sigma w) \\leftrightarrow G.\\mathrm{Adj}\\,v\\,w$; boundary-preserving $B(\\sigma v) \\leftrightarrow B v$."
+    "mathContext": "Objects: a finite door graph $G$ on the top cells, a decidable boundary predicate $B$, and the antipodal map $\\sigma$. The tower's endpoint sets are $\\mathrm{interiorEndpoints}\\,G\\,B = \\{v : G.\\deg v = 1 \\wedge \\neg B v\\}$ and $\\mathrm{boundaryEndpoints}\\,G\\,B = \\{v : G.\\deg v = 1 \\wedge B v\\}$. Hypotheses on $\\sigma$: free involution $\\sigma(\\sigma v) = v$, $\\sigma v \\neq v$; graph automorphism $G.\\mathrm{Adj}(\\sigma v)(\\sigma w) \\leftrightarrow G.\\mathrm{Adj}\\,v\\,w$; boundary-preserving $B(\\sigma v) \\leftrightarrow B v$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "door-counting program",
+      "TuckerTower dimension recursion",
+      "antipodal symmetry",
+      "Borsuk–Ulam"
+    ],
+    "prerequisites": [
+      "combinatorial topology",
+      "parity arguments"
+    ]
   },
   {
     "id": "ann-free-involution-sperner-oq02-oq02",
@@ -21,7 +33,19 @@
     "type": "technique",
     "title": "A free involution preserving a predicate forces an even fibre",
     "content": "Two lemmas. even_card_of_free_involution reproves that a fixed-point-free involution has even domain cardinality: sum the constant 1 : ZMod 2 over the universe and cancel each antipodal pair via Finset.sum_ninvolution (1 + 1 = 0), so the total — which is the cardinality reduced mod 2 — vanishes. even_card_filter_of_free_involution upgrades this to any σ-invariant decidable predicate P: restrict σ to the subtype {a // P a}, where it is still a free involution, and transport the base fact along Fintype.card_subtype to conclude Even #{a | P a}. This second lemma is the reusable engine of the whole file and a genuine Mathlib gap.",
-    "mathContext": "If $\\sigma : \\alpha \\to \\alpha$ is a free involution and $P(\\sigma a) \\leftrightarrow P(a)$ for all $a$, then $\\sigma$ restricts to a free involution on $\\{a \\mid P a\\}$, so $\\#\\{a \\mid P a\\}$ is even. The base case is the empty-predicate specialisation."
+    "mathContext": "If $\\sigma : \\alpha \\to \\alpha$ is a free involution and $P(\\sigma a) \\leftrightarrow P(a)$ for all $a$, then $\\sigma$ restricts to a free involution on $\\{a \\mid P a\\}$, so $\\#\\{a \\mid P a\\}$ is even. The base case is the empty-predicate specialisation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "free involution",
+      "fixed-point-free maps",
+      "ZMod 2 counting",
+      "even cardinality",
+      "Finset.sum"
+    ],
+    "prerequisites": [
+      "group actions on finite sets",
+      "finite combinatorics"
+    ]
   },
   {
     "id": "ann-degree-sperner-oq02-oq02",
@@ -33,7 +57,17 @@
     "type": "technique",
     "title": "A graph automorphism preserves degree",
     "content": "degree_eq_of_aut shows that an involutive graph automorphism σ preserves every vertex degree. Rewriting each degree as the cardinality of the neighbour finset, the map w ↦ σ w carries the neighbours of σ v bijectively onto the neighbours of v: it lands in the target because G.Adj (σ v) w ↔ G.Adj v (σ w) (the automorphism hypothesis with the involution), is injective because σ is injective, and is surjective with inverse again σ. A single Finset.card_bij closes it. This makes the endpoint predicates σ-invariant in the next section.",
-    "mathContext": "$G.\\deg(\\sigma v) = \\#\\,G.\\mathrm{neighborFinset}(\\sigma v) = \\#\\,G.\\mathrm{neighborFinset}(v) = G.\\deg(v)$, the middle equality by the bijection $w \\mapsto \\sigma w$ between the two neighbour finsets."
+    "mathContext": "$G.\\deg(\\sigma v) = \\#\\,G.\\mathrm{neighborFinset}(\\sigma v) = \\#\\,G.\\mathrm{neighborFinset}(v) = G.\\deg(v)$, the middle equality by the bijection $w \\mapsto \\sigma w$ between the two neighbour finsets.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "graph automorphism",
+      "vertex degree",
+      "neighbor finset",
+      "SimpleGraph"
+    ],
+    "prerequisites": [
+      "graph theory"
+    ]
   },
   {
     "id": "ann-even-endpoints-sperner-oq02-oq02",
@@ -45,7 +79,18 @@
     "type": "key-step",
     "title": "Even interior and boundary endpoint counts under symmetry",
     "content": "The interior-endpoint predicate G.degree v = 1 ∧ ¬ B v and the boundary-endpoint predicate G.degree v = 1 ∧ B v are both σ-invariant: the degree part by degree_eq_of_aut, the boundary part by the boundary-preserving hypothesis. Feeding each into even_card_filter_of_free_involution gives even_card_interiorEndpoints and even_card_boundaryEndpoints — both endpoint classes split into antipodal 2-orbits, so both counts are even. not_odd_card_interiorEndpoints records the immediate corollary that the interior count is never odd.",
-    "mathContext": "Under the symmetry hypotheses, $\\#\\,\\mathrm{interiorEndpoints}\\,G\\,B$ and $\\#\\,\\mathrm{boundaryEndpoints}\\,G\\,B$ are both even; in particular the interior count is not odd."
+    "mathContext": "Under the symmetry hypotheses, $\\#\\,\\mathrm{interiorEndpoints}\\,G\\,B$ and $\\#\\,\\mathrm{boundaryEndpoints}\\,G\\,B$ are both even; in particular the interior count is not odd.",
+    "significance": "key",
+    "relatedConcepts": [
+      "endpoint parity",
+      "σ-invariant predicate",
+      "boundary predicate",
+      "degree-one vertices"
+    ],
+    "prerequisites": [
+      "parity arguments",
+      "involutions"
+    ]
   },
   {
     "id": "ann-no-go-sperner-oq02-oq02",
@@ -57,6 +102,17 @@
     "type": "key-step",
     "title": "The no-go theorem: a symmetric door graph is never a Tucker level",
     "content": "symmetric_graph_not_tucker_level combines the previous section with the tower requirement: a free, automorphic, boundary-preserving antipodal involution together with an ODD interior-endpoint count is contradictory (the count is even). Since the verified TuckerTower.tower_interior_odd forces an odd interior count at every Tucker level, an antipodally-symmetric door graph can never be a level. The oddness can therefore appear only after the symmetry is broken — on a hemisphere fundamental domain, where σ swaps the two hemispheres and is no longer an automorphism (cf. SpernerTuckerHemisphere.card_eq_two_mul_hemisphere). The labelling-induced asymmetry of the almost-complementary door graph is essential, not incidental.",
-    "mathContext": "The verified recursion gives $\\mathrm{Odd}\\,\\#\\,\\mathrm{interiorEndpoints}$ at every level, but antipodal graph symmetry gives $\\mathrm{Even}\\,\\#\\,\\mathrm{interiorEndpoints}$; the two are incompatible, so a Tucker level's door graph must break the antipodal symmetry."
+    "mathContext": "The verified recursion gives $\\mathrm{Odd}\\,\\#\\,\\mathrm{interiorEndpoints}$ at every level, but antipodal graph symmetry gives $\\mathrm{Even}\\,\\#\\,\\mathrm{interiorEndpoints}$; the two are incompatible, so a Tucker level's door graph must break the antipodal symmetry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Tucker level",
+      "tower_interior_odd",
+      "proof by contradiction",
+      "obstruction theorem"
+    ],
+    "prerequisites": [
+      "Tucker's lemma",
+      "Sperner-type combinatorics"
+    ]
   }
 ]

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-02/meta.json
@@ -85,15 +85,18 @@
   "crossReferences": [
     {
       "targetId": "sperner-mathlib4-oq-02-oq-01",
-      "relationship": "Sibling entry: found empirically that the natural door graph produces no endpoints on many labellings while Tucker holds, concluding the remaining input must be an oriented / antipodally-signed count. This entry proves the dimension-free structural reason — antipodal symmetry forces even endpoint counts."
+      "relationship": "sibling",
+      "description": "Sibling entry: found empirically that the natural door graph produces no endpoints on many labellings while Tucker holds, concluding the remaining input must be an oriented / antipodally-signed count. This entry proves the dimension-free structural reason — antipodal symmetry forces even endpoint counts."
     },
     {
       "targetId": "sperner-mathlib4-oq-02",
-      "relationship": "Parent obstruction entry for the n = 2 door-choice failure; this entry generalizes the negative parity finding from the concrete hexagon to a dimension-free no-go theorem about antipodally-symmetric door graphs."
+      "relationship": "parent",
+      "description": "Parent obstruction entry for the n = 2 door-choice failure; this entry generalizes the negative parity finding from the concrete hexagon to a dimension-free no-go theorem about antipodally-symmetric door graphs."
     },
     {
       "targetId": "sperner-mathlib4",
-      "relationship": "Grandparent entry: supplies the verified door-counting engine and the TuckerTower dimension recursion whose odd-interior requirement (tower_interior_odd) this no-go theorem shows is incompatible with antipodal graph symmetry."
+      "relationship": "grandparent",
+      "description": "Grandparent entry: supplies the verified door-counting engine and the TuckerTower dimension recursion whose odd-interior requirement (tower_interior_odd) this no-go theorem shows is incompatible with antipodal graph symmetry."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `sperner-mathlib4-oq-02-oq-02` (Antipodal Symmetry Kills the Door-Graph Endpoint Parity).

Two genuine fixes:
- **crossReferences were malformed** — each entry stored its full descriptive sentence in the `relationship` field with **no `description` key`**. The component only rendered it via the `ref.description ?? ref.relationship` fallback, and the relationship *label* (sibling/parent/grandparent) was missing. Moved the text into `description` and set proper `relationship` labels.
- **Annotation depth** — all 5 annotations had `mathContext` but no `significance`, `relatedConcepts`, or `prerequisites`. Added all three to each (key/supporting/context tiers, with concept lists tied to free involutions, ZMod-2 counting, graph automorphisms, endpoint parity, and the `tower_interior_odd` obstruction).

Purely additive — all overview/conclusion prose, crossRef `targetId`s, and annotation core fields untouched. meta 14.2 KB → 14.3 KB, annotations 6.0 KB → 7.8 KB (well under caps). JSON validated.