### PR TITLE
research(abundant-number-oq-03-oq-02): positive lower density of odd abundant numbers [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/AbundantOddCountingOQ0302.lean
+++ b/proofs/Proofs/AbundantOddCountingOQ0302.lean
@@ -1,0 +1,114 @@
+/-
+  A quantitative lower bound on the counting function of ODD abundant numbers.
+
+  A positive integer `n` is *abundant* when `σ(n) > 2n` (Mathlib's
+  `Nat.Abundant`). The smallest odd abundant number is `945 = 3³·5·7`, and the
+  sibling entry `AbundantOddInfiniteOQ03.lean` proves there are infinitely many
+  odd abundant numbers by exhibiting the family
+
+      945·1, 945·3, 945·5, 945·7, …  =  945·(2k+1)
+
+  of odd abundant witnesses. Infinitude is a *qualitative* statement. This file
+  answers the parent entry's SECOND open question by turning it into a
+  *quantitative* lower bound on the counting function
+
+      A(x) := #{ n ∈ [1, x] : n is odd and abundant }.
+
+  The same odd-multiples family gives, for every `x`,
+
+      x  <  1890 · A(x) + 945,
+
+  equivalently `A(x) > x/1890 − 1/2`: the odd abundant numbers have positive
+  lower density, at least `1/1890`. The witnesses `945·(2k+1)` with
+  `2k+1 ≤ x/945` are `⌈(x/945)/2⌉ ≥ x/1890 − 1/2` distinct odd abundant numbers
+  in `[1, x]`, and the map `k ↦ 945·(2k+1)` is injective, so they inject into
+  the counted set.
+
+  The constant `1/1890` is the density of the odd multiples of `945` and is not
+  optimal (accounting for the other odd abundant seeds `1575`, `2205`, … and
+  their overlaps would raise it); it is the honest bound obtained from the single
+  seed `945`. The proof is axiom-free (no `sorry`, no `axiom`, no
+  `native_decide`): it reuses the parent's `odd_abundant_945_mul` and
+  `odd_mul_succ_injective`, an injective-image cardinality bound
+  (`Finset.card_image_of_injective` + `Finset.card_le_card`), and `omega` for
+  the division arithmetic.
+-/
+import Mathlib
+import Proofs.AbundantOddInfiniteOQ03
+
+namespace AbundantOddCountingOQ0302
+
+open AbundantOddInfiniteOQ03
+
+-- `Nat.Abundant` carries no registered `Decidable` instance, so the counting
+-- filter below is defined classically. This only affects computability, not the
+-- logical content: `#print axioms` still lists only the standard foundational
+-- axioms (propext, Classical.choice, Quot.sound), never `sorryAx` or
+-- `Lean.ofReduceBool`.
+open Classical
+
+/-- The counting function of odd abundant numbers up to `x`:
+`A(x) = #{ n ∈ [1, x] : Odd n ∧ n.Abundant }`. -/
+noncomputable def countOddAbundant (x : ℕ) : ℕ :=
+  ((Finset.Icc 1 x).filter (fun n => Odd n ∧ n.Abundant)).card
+
+/-- **Quantitative lower bound on the odd-abundant counting function.**
+
+For every `x`,
+
+  `x < 1890 · countOddAbundant x + 945`,
+
+i.e. the number of odd abundant integers in `[1, x]` is at least `x/1890 − 1/2`.
+
+The proof injects the odd-multiples family `k ↦ 945·(2k+1)` restricted to
+`k < (x/945 + 1)/2`. Each such witness is odd and abundant (`odd_abundant_945_mul`)
+and lies in `[1, x]` because `2k+1 ≤ x/945`, so `945·(2k+1) ≤ 945·(x/945) ≤ x`.
+The map is injective (`odd_mul_succ_injective`), so `(x/945 + 1)/2 ≤ countOddAbundant x`;
+the closing inequality is division arithmetic (`omega`). -/
+theorem odd_abundant_counting_lower_bound (x : ℕ) :
+    x < 1890 * countOddAbundant x + 945 := by
+  set M := x / 945 with hM
+  set K := (M + 1) / 2 with hK
+  -- The odd-multiples family `k ↦ 945·(2k+1)`, restricted to `k < K`, injects
+  -- `Finset.range K` into the counted set. We realise it as an image.
+  have hsub :
+      (Finset.range K).image (fun k => 945 * (2 * k + 1)) ⊆
+        (Finset.Icc 1 x).filter (fun n => Odd n ∧ n.Abundant) := by
+    rw [Finset.image_subset_iff]
+    intro k hk
+    rw [Finset.mem_range] at hk
+    obtain ⟨hodd, habun⟩ := odd_abundant_945_mul k
+    rw [Finset.mem_filter, Finset.mem_Icc]
+    -- `945·(2k+1) ≤ x`: from `k < K = (x/945+1)/2` and `945·(x/945) ≤ x`.
+    exact ⟨⟨by omega, by omega⟩, hodd, habun⟩
+  have hcardimg : ((Finset.range K).image (fun k => 945 * (2 * k + 1))).card = K := by
+    rw [Finset.card_image_of_injective _ odd_mul_succ_injective, Finset.card_range]
+  have hinj : K ≤ countOddAbundant x := by
+    have h1 : ((Finset.range K).image (fun k => 945 * (2 * k + 1))).card
+        ≤ countOddAbundant x := Finset.card_le_card hsub
+    rwa [hcardimg] at h1
+  -- Division arithmetic: `x < 945·(x/945) + 945` and `x/945 ≤ 2·((x/945+1)/2)`.
+  omega
+
+/-- **Positive lower density of the odd abundant numbers.**
+
+Recasting `odd_abundant_counting_lower_bound` over `ℝ`: for every `x`,
+
+  `x / 1890 − 1/2 < countOddAbundant x`.
+
+So the odd abundant numbers have lower density at least `1/1890` — a positive
+constant. This is the quantitative strengthening of the parent's infinitude
+result `infinitely_many_odd_abundant`. -/
+theorem odd_abundant_density_lower (x : ℕ) :
+    (x : ℝ) / 1890 - 1 / 2 < countOddAbundant x := by
+  have h := odd_abundant_counting_lower_bound x
+  have hR : (x : ℝ) < 1890 * (countOddAbundant x : ℝ) + 945 := by exact_mod_cast h
+  linarith
+
+-- Confirms the result depends only on the standard foundational axioms
+-- (propext, Classical.choice, Quot.sound) and NOT on `Lean.ofReduceBool`
+-- (which `native_decide` would introduce) or `sorryAx`: the proof is axiom-free.
+#print axioms odd_abundant_counting_lower_bound
+#print axioms odd_abundant_density_lower
+
+end AbundantOddCountingOQ0302

--- a/src/data/proofs/abundant-number-oq-03-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "abundant-number-oq-03-oq-02",
+  "title": "Positive Lower Density of Odd Abundant Numbers",
+  "slug": "abundant-number-oq-03-oq-02",
+  "description": "A positive integer n is abundant when σ(n) > 2n (Mathlib's Nat.Abundant). The parent entry abundant-number-oq-03 proves there are infinitely many ODD abundant numbers via the family 945·(2k+1). This entry sharpens that QUALITATIVE infinitude into a QUANTITATIVE lower bound on the counting function A(x) := #{ n ∈ [1, x] : Odd n ∧ Nat.Abundant n }: for every x, x < 1890·A(x) + 945, equivalently A(x) > x/1890 − 1/2. Hence the odd abundant numbers have positive lower density, at least 1/1890. The proof reuses the same odd-multiples family: the witnesses 945·(2k+1) with 2k+1 ≤ x/945 are (x/945+1)/2 ≥ x/1890 − 1/2 distinct odd abundant numbers in [1, x], and the injective image bound (Finset.card_image_of_injective + Finset.card_le_card) converts injectivity of k ↦ 945·(2k+1) into the cardinality lower bound; omega discharges the division arithmetic. Fully machine-checked with 0 axioms and 0 sorries, reusing the parent's odd_abundant_945_mul and odd_mul_succ_injective with no new computation.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A005231 (odd abundant numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantOddCountingOQ0302.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "counting-function",
+      "density",
+      "odd-numbers",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms odd_abundant_counting_lower_bound` and `#print axioms odd_abundant_density_lower` report only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no native_decide, hence no Lean.ofReduceBool, and no sorryAx. The counting filter is defined classically (Nat.Abundant carries no registered Decidable instance), which affects only computability, not logical content. The proof reuses the parent's odd_abundant_945_mul and odd_mul_succ_injective (themselves reducing to the kernel-reducible abundant_945), composing them with an injective-image cardinality bound and omega arithmetic; no new computation is performed.",
+    "originalContributions": [
+      "Proves `odd_abundant_counting_lower_bound : ∀ x, x < 1890 · countOddAbundant x + 945` — a quantitative lower bound on the odd-abundant counting function A(x) = #{ n ∈ [1, x] : Odd n ∧ Nat.Abundant n }, equivalently A(x) > x/1890 − 1/2. This settles the quantitative-counting open question recorded in the parent abundant-number-oq-03 entry, strengthening its qualitative infinitude result.",
+      "Establishes positive lower density: `odd_abundant_density_lower : ∀ x, (x : ℝ)/1890 − 1/2 < countOddAbundant x`, exhibiting the explicit density constant 1/1890 > 0 for the odd abundant numbers — the c·x form of the counting bound with c = 1/1890.",
+      "Realises the odd-multiples family k ↦ 945·(2k+1), restricted to k < (x/945 + 1)/2, as a Finset image and converts injectivity into a cardinality lower bound: the image lies inside the counted set (each witness is odd and abundant by odd_abundant_945_mul and lies in [1, x] since 2k+1 ≤ x/945 forces 945·(2k+1) ≤ 945·(x/945) ≤ x), so Finset.card_image_of_injective (via odd_mul_succ_injective) plus Finset.card_le_card yields (x/945+1)/2 ≤ A(x); omega closes the division arithmetic.",
+      "Documents that the constant 1/1890 is the honest density obtained from the single seed 945 and is not optimal — accounting for the other odd abundant seeds 1575, 2205, … and their overlaps would raise it — separating the provable explicit bound from the true (larger) density."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The deficient/perfect/abundant classification (σ(n) < 2n, = 2n, > 2n) dates to Nicomachus of Gerasa (~100 CE). Abundant numbers (OEIS A005101) have natural density ≈ 0.2476; odd abundant numbers (OEIS A005231: 945, 1575, 2205, 2835, …) are far rarer but also have positive density among the integers. The smallest, 945 = 3³·5·7, was found by direct computation. The parent entry established that there are infinitely many odd abundant numbers using the odd-multiples family 945·(2k+1). Infinitude, however, is only a qualitative statement — it says nothing about how many odd abundant numbers lie below a given bound. The natural quantitative refinement is a lower bound on the counting function A(x), which is exactly what a positive-density statement provides: the odd multiples of the seed 945 already form an arithmetic-progression-like family of density 1/1890 within the integers, giving A(x) ≥ x/1890 − O(1).",
+    "problemStatement": "Working with Mathlib's Nat.Abundant, sharpen the parent entry's infinitude of odd abundant numbers into a quantitative lower bound on the counting function A(x) := #{ n ∈ [1, x] : Odd n ∧ n.Abundant }: prove A(x) ≥ c·x − O(1) for an explicit constant c > 0, keeping the result axiom-free by reusing the odd-multiples witnesses rather than recomputing divisor sums.",
+    "text": "A short Lean 4 / Mathlib formalization (114 lines, 0 sorries, 0 axioms) that turns the parent's qualitative infinitude of odd abundant numbers into the quantitative bound x < 1890·A(x) + 945, i.e. A(x) > x/1890 − 1/2, and recasts it over ℝ as the positive-density statement (x:ℝ)/1890 − 1/2 < A(x). The engine is the same odd-multiples family 945·(2k+1) reused verbatim from the parent, now counted: restricting to k < (x/945 + 1)/2 gives that many distinct odd abundant numbers inside [1, x], and the injective-image cardinality bound converts injectivity into the count. No new computation is performed beyond the parent's kernel-reducible abundant seed.",
+    "proofStrategy": "1. **Counting function.** `countOddAbundant x := ((Finset.Icc 1 x).filter (fun n => Odd n ∧ n.Abundant)).card`, defined classically (Nat.Abundant has no registered Decidable instance).\n\n2. **Restricted witness family as an image.** For M = x/945 and K = (M+1)/2, the map k ↦ 945·(2k+1) sends Finset.range K into the counted set: each value is odd and abundant (odd_abundant_945_mul k), and lies in [1, x] because k < K forces 2k+1 ≤ M = x/945, hence 945·(2k+1) ≤ 945·(x/945) ≤ x. Membership is Finset.mem_filter + Finset.mem_Icc with the two bounds discharged by omega.\n\n3. **Injectivity ⇒ cardinality.** The image has card K by Finset.card_image_of_injective (odd_mul_succ_injective) + Finset.card_range, and the image is a subset of the counted set, so Finset.card_le_card gives K ≤ countOddAbundant x.\n\n4. **Division arithmetic.** From K = (x/945 + 1)/2 ≤ countOddAbundant x, the facts x < 945·(x/945) + 945 and x/945 ≤ 2·((x/945+1)/2) (both pure ℕ division identities) give x < 1890·countOddAbundant x + 945 by omega.\n\n5. **Real recast.** Casting the ℕ bound to ℝ and using linarith yields (x:ℝ)/1890 − 1/2 < countOddAbundant x.",
+    "keyInsights": [
+      "**Infinitude → positive density is a counting refinement, not a new construction.** The same family 945·(2k+1) that proves infinitude, once *counted* below x, already delivers density 1/1890: the whole content is packaging injectivity as a cardinality lower bound via Finset.card_image_of_injective and Finset.card_le_card.",
+      "**Only the odd multipliers 2k+1 up to x/945 fit in [1, x].** The bound 2k+1 ≤ x/945 (equivalently 945·(2k+1) ≤ x) is what turns 'infinitely many witnesses' into 'roughly x/1890 witnesses below x'; the count of such k is (x/945 + 1)/2.",
+      "**All the arithmetic is ℕ floor-division, handled by omega.** The two floor identities x < 945·(x/945) + 945 and x/945 ≤ 2·((x/945+1)/2) are exactly what omega needs to convert the cardinality bound K ≤ A(x) into x < 1890·A(x) + 945 — no manual estimate.",
+      "**The constant 1/1890 is honest but not optimal.** It is the density of the odd multiples of the single seed 945 = 2·945. Adding the other odd abundant seeds (1575, 2205, …) and correcting for overlaps would raise the constant; the entry proves the clean single-seed bound rather than the true density.",
+      "**Density separates rarity from finiteness quantitatively.** The parent showed odd abundant numbers are infinite despite being rare; this entry pins the rarity to a *positive* density floor 1/1890, so 'rare' here means 'small positive density', not 'vanishing'."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and the abundant / deficient / perfect classification",
+      "The odd-multiples witness family 945·(2k+1) and its oddness+abundance (abundant-number-oq-03)",
+      "Injectivity of k ↦ 945·(2k+1) (odd_mul_succ_injective) and closure under positive multiples",
+      "Finset cardinality of injective images (Finset.card_image_of_injective, Finset.card_le_card) and ℕ floor-division arithmetic (omega)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Module docstring: the quantitative sharpening x < 1890·A(x) + 945 of the parent's infinitude of odd abundant numbers, giving lower density ≥ 1/1890. Explains that the witnesses 945·(2k+1) with 2k+1 ≤ x/945 are (x/945+1)/2 ≥ x/1890 − 1/2 distinct odd abundant numbers in [1, x], injecting into the counted set, and notes the constant 1/1890 is the honest single-seed bound.",
+      "mathContext": "Count the parent's odd-multiples family below x: density 1/1890 is the density of the odd multiples of the seed 945."
+    },
+    {
+      "id": "counting-function",
+      "title": "The Odd-Abundant Counting Function",
+      "startLine": 39,
+      "endLine": 53,
+      "summary": "`countOddAbundant x := ((Finset.Icc 1 x).filter (fun n => Odd n ∧ n.Abundant)).card`, defined classically (open Classical) because Nat.Abundant carries no registered Decidable instance — affecting computability only, not the axiom profile.",
+      "mathContext": "A(x) = #{ n ∈ [1, x] : Odd n ∧ Nat.Abundant n }."
+    },
+    {
+      "id": "counting-bound",
+      "title": "Quantitative Lower Bound on the Counting Function",
+      "startLine": 55,
+      "endLine": 91,
+      "summary": "`odd_abundant_counting_lower_bound : ∀ x, x < 1890·countOddAbundant x + 945`. The restricted family k ↦ 945·(2k+1) on Finset.range ((x/945+1)/2) injects into the counted set (each witness odd, abundant, and ≤ x since 2k+1 ≤ x/945), so Finset.card_image_of_injective + Finset.card_le_card give (x/945+1)/2 ≤ A(x); omega closes with the floor identities x < 945·(x/945)+945 and x/945 ≤ 2·((x/945+1)/2).",
+      "mathContext": "Injectivity of the witness family, counted below x, becomes the cardinality lower bound A(x) > x/1890 − 1/2."
+    },
+    {
+      "id": "density",
+      "title": "Positive Lower Density",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "`odd_abundant_density_lower : ∀ x, (x:ℝ)/1890 − 1/2 < countOddAbundant x`, the ℝ recast of the counting bound via exact_mod_cast + linarith, exhibiting the explicit positive density constant 1/1890. Closes with `#print axioms` on both theorems confirming the result is axiom-free (no native_decide, no sorryAx).",
+      "mathContext": "The odd abundant numbers have lower density at least 1/1890 > 0 — the c·x form with c = 1/1890."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "odd_abundant_counting_lower_bound",
+      "type": "core",
+      "description": "∀ x, x < 1890·countOddAbundant x + 945 — a quantitative lower bound on the number of odd abundant integers in [1, x], equivalently A(x) > x/1890 − 1/2. Proved by injecting the restricted odd-multiples family 945·(2k+1) (k < (x/945+1)/2) into the counted set and converting injectivity into a cardinality bound, with omega for the division arithmetic. Axiom-free.",
+      "leanType": "∀ (x : ℕ), x < 1890 * countOddAbundant x + 945"
+    },
+    {
+      "name": "odd_abundant_density_lower",
+      "type": "core",
+      "description": "∀ x, (x : ℝ)/1890 − 1/2 < countOddAbundant x — the real-valued positive-density recast of the counting bound, exhibiting the explicit density constant 1/1890 > 0 for the odd abundant numbers.",
+      "leanType": "∀ (x : ℕ), (x : ℝ) / 1890 - 1 / 2 < ↑(countOddAbundant x)"
+    },
+    {
+      "name": "countOddAbundant",
+      "type": "supporting",
+      "description": "The counting function A(x) = #{ n ∈ [1, x] : Odd n ∧ Nat.Abundant n }, the cardinality of the filter of odd abundant numbers in Finset.Icc 1 x (defined classically).",
+      "leanType": "ℕ → ℕ"
+    }
+  ],
+  "conclusion": {
+    "summary": "Using Mathlib's Nat.Abundant, the entry proves x < 1890·countOddAbundant x + 945 for every x — a quantitative lower bound on the counting function of odd abundant numbers, equivalently A(x) > x/1890 − 1/2 — and recasts it over ℝ as the positive-density statement (x:ℝ)/1890 − 1/2 < A(x). Fully machine-checked with 0 axioms and 0 sorries. The proof reuses the parent's odd-multiples witnesses 945·(2k+1) and their injectivity, counting them below x via an injective-image cardinality bound and discharging the ℕ floor-division arithmetic with omega; no new computation is performed.",
+    "implications": "The result settles the quantitative-counting open question of abundant-number-oq-03, upgrading qualitative infinitude to a positive lower density 1/1890. It illustrates the standard route from an explicit injective witness family to a counting/density bound: restrict the family to the values below x, count them via Finset.card_image_of_injective, and read off the density from the family's spacing. The constant 1/1890 is the honest single-seed bound; the true density is larger once the other odd abundant seeds are included.",
+    "openQuestions": [
+      "Improve the density constant beyond 1/1890 by combining several odd abundant seeds (945, 1575, 2205, …) with inclusion–exclusion over their overlaps, or by using primitive odd abundant numbers to avoid double counting.",
+      "Prove a matching upper bound A(x) ≤ C·x (odd abundant numbers have density strictly below 1/2), pinning the counting function between two linear bounds and establishing that the natural density exists.",
+      "Formalize the analogous density lower bound for abundant numbers overall (density ≈ 0.2476) and compare, quantifying how much rarer the odd abundant numbers are."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005231: Odd abundant numbers (odd n with σ(n) > 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The sequence 945, 1575, 2205, 2835, … of odd abundant numbers, whose counting function this entry bounds below linearly."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-03",
+      "relationship": "extends",
+      "description": "The parent oq-03 entry proves {n | Odd n ∧ Nat.Abundant n}.Infinite via the odd-multiples family 945·(2k+1), and records as an open question the quantitative strengthening 'the number of odd abundant numbers below x is at least c·x for an explicit constant c'. This entry settles exactly that, reusing the parent's odd_abundant_945_mul and odd_mul_succ_injective to prove x < 1890·A(x) + 945, i.e. density ≥ 1/1890."
+    },
+    {
+      "targetId": "abundant-number-oq-02",
+      "relationship": "extends",
+      "description": "The oq-02 entry proves 945 = 3³·5·7 is the smallest odd abundant number, supplying the axiom-free abundant seed abundant_945 that (via the parent) underlies every witness 945·(2k+1) counted here."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantOddCountingOQ0302.lean",
+    "namespace": "AbundantOddCountingOQ0302",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantOddInfiniteOQ03"
+    ],
+    "lineCount": 114,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 2,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry **abundant-number-oq-03** (infinitely many odd abundant numbers) into a **quantitative counting / density** bound, answering its `openQuestions[1]` verbatim.

**Main results** (`Proofs/AbundantOddCountingOQ0302.lean`, namespace `AbundantOddCountingOQ0302`):

- `odd_abundant_counting_lower_bound : ∀ x, x < 1890 * countOddAbundant x + 945` — for the counting function `A(x) = #{ n ∈ [1,x] : Odd n ∧ Nat.Abundant n }`, equivalently `A(x) > x/1890 − 1/2`.
- `odd_abundant_density_lower : ∀ x, (x:ℝ)/1890 − 1/2 < countOddAbundant x` — positive lower **density ≥ 1/1890**.

## Proof

Reuses the parent's odd-multiples witnesses `945·(2k+1)` and their injectivity (`odd_abundant_945_mul`, `odd_mul_succ_injective`). Restricting to `k < (x/945+1)/2` gives that many distinct odd abundant numbers in `[1,x]`; `Finset.card_image_of_injective` + `Finset.card_le_card` convert injectivity into the cardinality lower bound, and `omega` discharges the ℕ floor-division arithmetic. The constant `1/1890` is the honest single-seed bound (density of the odd multiples of 945).

## Verification

Docker build succeeds (7746 jobs). `#print axioms` on both theorems reports only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**, no `native_decide`. Fully machine-checked: 0 sorries, 0 axioms.

New gallery entry: `src/data/proofs/abundant-number-oq-03-oq-02/meta.json` (status `verified`, badge `verified`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)