### PR TITLE
Enrich Inverse Galois OQ-04-01-01 (Kummer–Dedekind composition): +1 annotation, canonicalize enums

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-imports-oq040101",
+    "proofId": "inverse-galois-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 3
+    },
+    "type": "concept",
+    "title": "Imports encode the composition architecture",
+    "content": "For a proof whose entire content is *gluing two verified bricks*, the imports are the mathematical structure. `import Mathlib` brings in the one genuinely new ingredient — the going-up lemma `Ideal.exists_maximal_ideal_liesOver_of_isIntegral` — together with the ideal/inertia-degree API. `import Proofs.DedekindKummerStep1` supplies brick 1, `exists_prime_dvd_inertiaDeg_of_dvd_natDegree` (Kummer–Dedekind: a mod-p factor of degree divisible by d yields a prime of 𝓞 K with d ∣ inertia degree). `import Proofs.DedekindInertiaTower` supplies brick 2, `dvd_inertiaDegIn_of_dvd_inertiaDeg` (tower multiplicativity + Galois uniformity). Both imported bricks were independently machine-checked at 0 axioms, so the composition inherits their trust base without re-deriving them.",
+    "mathContext": "Dependency structure mirrors the proof: $\\texttt{Step1} \\;\\oplus\\; \\texttt{going up (Mathlib)} \\;\\oplus\\; \\texttt{Tower} \\;=\\; \\texttt{this file}$. No mathematical content lives outside these three imports — the file only wires them together.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "modular proof architecture",
+      "Kummer–Dedekind Step 1 brick",
+      "inertia-degree tower brick",
+      "going up for integral extensions"
+    ],
+    "prerequisites": [
+      "Lean 4 module imports",
+      "how Mathlib namespaces expose lemmas"
+    ]
+  },
+  {
     "id": "ann-header-oq040101",
     "proofId": "inverse-galois-oq-04-oq-01-oq-01",
     "range": {
@@ -10,7 +33,7 @@
     "title": "Composing the two Kummer–Dedekind bricks via going up",
     "content": "The module docstring situates this file within OQ-04's plan to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal`. That axiom was reduced to `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`, provable by a three-step Kummer–Dedekind route: (1) an irreducible cubic factor of q mod 7 gives a prime of 𝓞 ℚ(α) of inertia degree 3; (2) tower multiplicativity lifts it to the splitting field; (3) Galois uniformity spreads it to all primes over 7. Step 1 was verified in `DedekindKummerStep1`, steps 2–3 in `DedekindInertiaTower`. This file composes them: given a tower ℤ ⊆ 𝓞 K ⊆ T with T integral over 𝓞 K and T/ℤ Galois, and a factor Q of minpoly ℤ θ mod p with d ∣ deg Q, it delivers d ∣ inertiaDegIn (p) T in a single statement. The one new ingredient is going up — the Step-1 prime P of 𝓞 K sits below a prime Q' of the integral extension T.",
     "mathContext": "The chain is $Q\\text{ irred., } d \\mid \\deg Q \\ \\xrightarrow{\\text{Step 1}}\\ \\exists P \\lhd \\mathcal{O}_K,\\ d \\mid f(P\\mid p) \\ \\xrightarrow{\\text{going up}}\\ \\exists \\mathfrak{Q} \\lhd T,\\ \\mathfrak{Q} \\mid P \\ \\xrightarrow{\\text{tower + Galois}}\\ d \\mid \\mathrm{inertiaDegIn}_{(p)}(T).$ Instantiating $K=\\mathbb{Q}(\\alpha)$, $T=\\mathcal{O}_{q.\\mathrm{SplittingField}}$, $G=q.\\mathrm{Gal}$, $p=7$, $d=3$ recovers the A₅ obstruction.",
-    "significance": "context",
+    "significance": "supporting",
     "relatedConcepts": [
       "Inverse Galois problem",
       "Kummer–Dedekind theorem",
@@ -30,11 +53,11 @@
       "startLine": 61,
       "endLine": 67
     },
-    "type": "technical",
+    "type": "lemma",
     "title": "span_p_isMaximal — the rational prime (p) is maximal in ℤ",
     "content": "The tower brick needs the base ideal to be maximal. Here the base is ℤ and the ideal is (p) = span {(p : ℤ)}. The lemma proves it maximal in two moves: `Ideal.span_singleton_prime` turns primality of the element (p : ℤ) — obtained from `Nat.prime_iff_prime_int` applied to the ambient `[Fact (Nat.Prime p)]` — into primality of the ideal, and `Ideal.IsPrime.isMaximal` upgrades a nonzero prime ideal of the one-dimensional domain ℤ to a maximal one. The nonzero side condition is discharged by `Ideal.span_singleton_eq_bot` together with (p : ℤ) ≠ 0.",
     "mathContext": "In a Dedekind domain (or any ring of Krull dimension $\\le 1$), every nonzero prime ideal is maximal. For $\\mathbb{Z}$ this says $(p)$ is maximal iff $p$ is prime, and $\\mathbb{Z}/(p)$ is the residue field $\\mathbb{F}_p$.",
-    "significance": "technical",
+    "significance": "supporting",
     "relatedConcepts": [
       "maximal ideal",
       "prime ideal in a Dedekind domain",
@@ -57,7 +80,7 @@
     "title": "dvd_inertiaDegIn_of_dvd_natDegree_factor — the composition",
     "content": "The main theorem. Over a tower ℤ ⊆ 𝓞 K ⊆ T (T integral over 𝓞 K, T/ℤ Galois with group G), given θ ∈ 𝓞 K with p ∤ exponent θ and a monic irreducible factor Q of minpoly ℤ θ mod p with d ∣ Q.natDegree, it concludes d ∣ inertiaDegIn (span {(p:ℤ)}) T. The proof: (1) `DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree` yields a maximal prime P of 𝓞 K over (p) with d ∣ inertiaDeg (p) P; (2) `Ideal.exists_maximal_ideal_liesOver_of_isIntegral` supplies a maximal prime Q' of T lying over P (going up, using integrality and faithfulness of 𝓞 K → T); (3) `DedekindInertiaTower.dvd_inertiaDegIn_of_dvd_inertiaDeg` promotes d ∣ inertiaDeg (p) P to d ∣ inertiaDegIn (p) T. A ℤ-algebra diamond is deliberately avoided by relying on the canonical `algebraInt T` rather than a free `Algebra ℤ T` binder, so the required `IsScalarTower ℤ (𝓞 K) T` matches exactly. Confirmed 0-axiom by #print axioms.",
     "mathContext": "The statement is the abstract engine behind Dedekind's theorem 'factorization type mod p = cycle type of Frobenius': a degree-$d$ irreducible factor mod $p$ forces an inertia degree divisible by $d$ at some prime of the top field, hence a Frobenius element of order divisible by $d$. For $A_5$: $d=3$ from the irreducible cubic factor of $q \\bmod 7$ gives $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$, i.e. an order-3 element of $\\mathrm{Gal}(q)$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Kummer–Dedekind Step 1",
       "going up (exists_maximal_ideal_liesOver_of_isIntegral)",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04-oq-01-oq-01` (quality 83, 0 prior passes). Already a well-curated 16 KB entry that meets all quality minimums, so this is a bounded, targeted pass — **no deepening of an already-rich page**.

## Changes (annotations.json only; meta.json untouched)

**1. Fill the only uncovered range.** Added `ann-imports-oq040101` for lines 1–3. For a proof whose entire content is *gluing two verified bricks*, the imports **are** the mathematical structure: `import Mathlib` supplies the one new ingredient (the going-up lemma `Ideal.exists_maximal_ideal_liesOver_of_isIntegral`), and the two `Proofs.Dedekind*` imports supply the 0-axiom bricks being composed. Previously lines 1–3 had no annotation; the file now has full coverage.

**2. Canonicalize non-conforming enum values so badges render.** Three annotations used values outside the gallery's `AnnotationType` / `AnnotationSignificance` unions. `AnnotationPanel.tsx` and `ProofLine.tsx` badge styling exact-matches `critical | key | supporting`, so the prior values rendered as **unstyled badges**:
- `ann-header`: significance `context` → `supporting`
- `ann-span-maximal`: type `technical` (invalid `AnnotationType`, silently defaulted to `concept`) → `lemma`; significance `technical` → `supporting`
- `ann-composition`: significance `central` → `critical`

## Verification
- JSON well-formed; semantic diff confirms **only** the 1 added annotation + 4 enum fixes (no existing content/titles/ranges altered).
- `check-meta-size.ts`: within caps (meta.json 16.3 KB ≤ 60 KB).
- Annotation build stage processed the files without schema errors.

No math claims changed; `status`/`badge`/`axiomCount` (verified / original / 0) untouched and accurate.