### PR TITLE
research(chebyshev-bounds-oq-06-oq-01): central binomial asymptotic C(2n,n) ~ 4ⁿ/√(πn) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ0601.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ0601.lean
@@ -1,0 +1,126 @@
+/-
+# Central Binomial Coefficient Asymptotics: C(2n,n) ~ 4ⁿ / √(πn)
+
+This file answers the open question `chebyshev-bounds-oq-06-oq-01`:
+
+> Can the upper bound be sharpened to the standard C(2n,n) ≤ 4ⁿ/√(πn) (Stirling)
+> within Mathlib, giving the matching asymptotic C(2n,n) ~ 4ⁿ/√(πn)?
+
+We establish the **asymptotic equivalence**
+
+    (2n).choose n  ~[atTop]  4ⁿ / √(π n)
+
+as `n → ∞`, derived entirely from Mathlib's Stirling approximation
+`Stirling.factorial_isEquivalent_stirling`, namely `n! ~ √(2πn)·(n/e)ⁿ`.
+
+## Method
+
+Writing `C(2n,n) = (2n)! / (n!)²` and applying the Stirling equivalence to the
+numerator (at index `2n`) and denominator, algebra collapses the Stirling factors:
+
+    √(4πn)·(2n/e)^{2n} / ((2πn)·(n/e)^{2n})
+      = √(4πn)·4ⁿ / (2πn)                 [since (2n/e)^{2n} = 4ⁿ·(n/e)^{2n}]
+      = 2√(πn)·4ⁿ / (2πn)
+      = 4ⁿ / √(πn).
+
+This is a **0-axiom** result: it is a pure consequence of the already-formalised
+Stirling asymptotic and elementary `IsEquivalent` algebra (`.mul`, `.div`,
+`.comp_tendsto`).
+
+Note the *effective* one-sided inequality `C(2n,n) ≤ 4ⁿ/√(πn)` for every `n`
+requires an effective **upper** bound on `n!` (Robbins' bounds), which is not yet
+in Mathlib (see the comment in `Mathlib/Analysis/SpecialFunctions/Stirling.lean`).
+The asymptotic equivalence proved here is the achievable, and mathematically
+substantive, part of the open question.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Stirling
+import Mathlib.Data.Nat.Choose.Central
+
+open Real Filter Asymptotics
+open scoped Nat
+
+namespace ChebyshevBoundsOQ0601
+
+/-- **Central binomial asymptotic.**
+The central binomial coefficient `C(2n,n) = (2n).choose n` is asymptotically
+equivalent to `4ⁿ / √(π n)`.  Derived from Mathlib's Stirling approximation. -/
+theorem centralBinom_isEquivalent_four_pow_div_sqrt :
+    (fun n : ℕ => (n.centralBinom : ℝ)) ~[atTop]
+      (fun n : ℕ => (4 : ℝ) ^ n / Real.sqrt (π * n)) := by
+  -- Stirling: `n! ~ √(2πn)·(n/e)ⁿ`.  After `set S`, `H : (fun n => n!) ~ S`.
+  have H := Stirling.factorial_isEquivalent_stirling
+  set S : ℕ → ℝ := fun n => Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n with hS
+  -- `n ↦ 2 * n` tends to infinity.
+  have hk : Tendsto (fun n : ℕ => 2 * n) atTop atTop :=
+    tendsto_atTop_atTop.2 fun b => ⟨b, fun a ha => by omega⟩
+  -- Numerator asymptotic: `(2n)! ~ S (2n)`.
+  have h2n : (fun n : ℕ => ((2 * n)! : ℝ)) ~[atTop] (fun n : ℕ => S (2 * n)) := by
+    have := H.comp_tendsto hk
+    simpa [Function.comp] using this
+  -- Denominator asymptotic: `n! · n! ~ S n · S n`.
+  have hmul : (fun n : ℕ => (n ! : ℝ) * (n ! : ℝ)) ~[atTop] (fun n : ℕ => S n * S n) :=
+    H.mul H
+  -- Exact cast identity: `C(2n,n) = (2n)! / (n! · n!)`.
+  have e1 : (fun n : ℕ => (n.centralBinom : ℝ)) =ᶠ[atTop]
+      (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ))) := by
+    filter_upwards with n
+    have h := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+    rw [show 2 * n - n = n by omega] at h
+    rw [Nat.centralBinom_eq_two_mul_choose, eq_div_iff (by positivity)]
+    have hcast : ((2 * n).choose n) * (n ! * n !) = (2 * n)! := by rw [← h]; ring
+    exact_mod_cast hcast
+  -- Chain the equivalences: `C(2n,n) ~ (2n)!/(n!·n!) ~ S(2n)/(S n · S n)`.
+  have hdiv : (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ))) ~[atTop]
+      (fun n : ℕ => S (2 * n) / (S n * S n)) := h2n.div hmul
+  refine (e1.isEquivalent.trans hdiv).trans_eventuallyEq ?_
+  -- Remaining: `S(2n)/(S n · S n) = 4ⁿ/√(π n)` for `n ≥ 1`.
+  filter_upwards [eventually_ge_atTop 1] with n hn
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hepos : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  set s := Real.sqrt (π * (n : ℝ)) with hs_def
+  have hspos : 0 < s := Real.sqrt_pos.mpr (by positivity)
+  have hsne : s ≠ 0 := hspos.ne'
+  have hs2 : s ^ 2 = π * (n : ℝ) := Real.sq_sqrt (by positivity)
+  set P := ((n : ℝ) / Real.exp 1) ^ (2 * n) with hP_def
+  have hPpos : 0 < P := by rw [hP_def]; positivity
+  have hPne : P ≠ 0 := hPpos.ne'
+  -- Unfold `S` into the concrete Stirling expression.
+  simp only [hS]
+  -- √(2·(2n)·π) = 2s.
+  have hnum_sqrt : Real.sqrt (2 * ((2 * n : ℕ) : ℝ) * π) = 2 * s := by
+    have h4 : (2 : ℝ) * ((2 * n : ℕ) : ℝ) * π = (2 * s) ^ 2 := by
+      push_cast; rw [mul_pow, hs2]; ring
+    rw [h4, Real.sqrt_sq (by linarith)]
+  -- ((2n)/e)^{2n} = 4ⁿ · P.
+  have hnum_pow : (((2 * n : ℕ) : ℝ) / Real.exp 1) ^ (2 * n) = 4 ^ n * P := by
+    have h1 : ((2 * n : ℕ) : ℝ) / Real.exp 1 = 2 * ((n : ℝ) / Real.exp 1) := by
+      push_cast; ring
+    rw [h1, mul_pow, hP_def]
+    congr 1
+    rw [pow_mul]; norm_num
+  -- √(2nπ)·√(2nπ) = 2s².
+  have hAA : Real.sqrt (2 * (n : ℝ) * π) * Real.sqrt (2 * (n : ℝ) * π) = 2 * s ^ 2 := by
+    rw [← pow_two, Real.sq_sqrt (by positivity), hs2]; ring
+  -- (n/e)ⁿ·(n/e)ⁿ = P.
+  have hBB : ((n : ℝ) / Real.exp 1) ^ n * ((n : ℝ) / Real.exp 1) ^ n = P := by
+    rw [← pow_add, hP_def, two_mul]
+  rw [hnum_sqrt, hnum_pow]
+  rw [show (Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n) *
+          (Real.sqrt (2 * (n : ℝ) * π) * ((n : ℝ) / Real.exp 1) ^ n)
+        = (Real.sqrt (2 * (n : ℝ) * π) * Real.sqrt (2 * (n : ℝ) * π)) *
+          (((n : ℝ) / Real.exp 1) ^ n * ((n : ℝ) / Real.exp 1) ^ n) from by ring]
+  rw [hAA, hBB]
+  -- Final algebra: 2s·(4ⁿ·P) / (2s²·P) = 4ⁿ/s.
+  rw [pow_two]
+  field_simp
+
+/-- Restatement in terms of `Nat.choose`: `C(2n,n) ~ 4ⁿ / √(π n)`. -/
+theorem choose_two_mul_isEquivalent_four_pow_div_sqrt :
+    (fun n : ℕ => ((2 * n).choose n : ℝ)) ~[atTop]
+      (fun n : ℕ => (4 : ℝ) ^ n / Real.sqrt (π * n)) := by
+  have h := centralBinom_isEquivalent_four_pow_div_sqrt
+  simpa [Nat.centralBinom_eq_two_mul_choose] using h
+
+end ChebyshevBoundsOQ0601

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/annotations.json
@@ -1,0 +1,70 @@
+[
+  {
+    "id": "ann-chebo0601-header",
+    "proofId": "chebyshev-bounds-oq-06-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "The Sharp Stirling Asymptotic for the Central Binomial Coefficient",
+    "content": "The module docstring frames the goal: sharpen the parent's elementary polynomial-factor sandwich 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ to the true leading-order asymptotic C(2n,n) ~ 4ⁿ/√(πn). The whole file is built on a single analytic input — Mathlib's Stirling equivalence n! ~ √(2πn)·(n/e)ⁿ (Stirling.factorial_isEquivalent_stirling) — plus elementary algebra of the Asymptotics.IsEquivalent (Landau ~) relation. Writing C(2n,n) = (2n)!/(n!)², the Stirling factors collapse: the (n/e)^{2n} exponential cancels between numerator and denominator and the square-root factors combine to leave exactly 4ⁿ/√(πn). The docstring is explicit about scope: the effective *inequality* C(2n,n) ≤ 4ⁿ/√(πn) for every n needs an effective upper bound on n! (Robbins' bounds), not yet in Mathlib — so the asymptotic equivalence is the achievable, substantive part of the open question.",
+    "mathContext": "$\\binom{2n}{n}\\sim\\dfrac{4^n}{\\sqrt{\\pi n}}$ as $n\\to\\infty$, i.e. the ratio of the two sides tends to $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "Stirling's approximation",
+      "asymptotic equivalence (Landau ~)",
+      "the constant π from combinatorics"
+    ],
+    "prerequisites": [
+      "asymptotic equivalence of sequences",
+      "Stirling's formula n! ~ √(2πn)(n/e)ⁿ",
+      "C(2n,n) = (2n)!/(n!)²"
+    ]
+  },
+  {
+    "id": "ann-chebo0601-main",
+    "proofId": "chebyshev-bounds-oq-06-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "centralBinom_isEquivalent_four_pow_div_sqrt: C(2n,n) ~ 4ⁿ/√(πn)",
+    "content": "The main theorem and its proof. The strategy is transport-and-collapse. Let S(n) = √(2πn)·(n/e)ⁿ be Mathlib's Stirling approximant, so H : n! ~ S n. (1) The numerator (2n)! ~ S(2n) is obtained by IsEquivalent.comp_tendsto, transporting H along the map n ↦ 2n (which tends to ∞); no separate asymptotic for (2n)! is needed. (2) The denominator n!·n! ~ S n·S n by IsEquivalent.mul. (3) The exact cast identity C(2n,n) = (2n)!/(n!·n!) comes from Nat.choose_mul_factorial_mul_factorial (with 2n−n = n), lifted to ℝ via eq_div_iff and exact_mod_cast. (4) IsEquivalent.div chains numerator and denominator, reducing the goal to a pointwise identity S(2n)/(S n)² = 4ⁿ/√(πn) for n ≥ 1. That residual identity is pure field algebra: √(4πn) = 2√(πn) via Real.sqrt_sq on (2s)² with s = √(πn); (2n/e)^{2n} = 2^{2n}·(n/e)^{2n} = 4ⁿ·(n/e)^{2n} via mul_pow and pow_mul; and (√(2πn))² = 2πn = 2s² via Real.sq_sqrt. The exponential factor P = (n/e)^{2n} and one power of s cancel under field_simp; ring closes.",
+    "mathContext": "$\\dfrac{S(2n)}{S(n)^2}=\\dfrac{\\sqrt{4\\pi n}\\,(2n/e)^{2n}}{(2\\pi n)\\,(n/e)^{2n}}=\\dfrac{2\\sqrt{\\pi n}\\cdot 4^n}{2\\pi n}=\\dfrac{4^n}{\\sqrt{\\pi n}}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "IsEquivalent.comp_tendsto",
+      "IsEquivalent.div and IsEquivalent.mul",
+      "Real.sq_sqrt / Real.sqrt_sq",
+      "field_simp / ring closing an exact identity"
+    ],
+    "prerequisites": [
+      "Mathlib's Asymptotics.IsEquivalent algebra",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "manipulating √ and integer powers over ℝ"
+    ]
+  },
+  {
+    "id": "ann-chebo0601-corollary",
+    "proofId": "chebyshev-bounds-oq-06-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "choose_two_mul_isEquivalent_four_pow_div_sqrt: the Nat.choose phrasing",
+    "content": "A one-line restatement of the main result with the raw binomial coefficient (2*n).choose n in place of Nat.centralBinom n, obtained by rewriting with Nat.centralBinom_eq_two_mul_choose. This gives downstream users whichever of the two equivalent notations they prefer.",
+    "mathContext": "$\\left(\\displaystyle\\binom{2n}{n}\\right)_{n}\\ \\sim_{atTop}\\ \\left(\\dfrac{4^n}{\\sqrt{\\pi n}}\\right)_{n}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.centralBinom_eq_two_mul_choose",
+      "central binomial coefficient notation"
+    ],
+    "prerequisites": [
+      "the definition centralBinom n = (2n).choose n"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevBoundsOQ0601.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevBoundsOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevBoundsOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevBoundsOq06Oq01Data: ProofData = {
+  proof: chebyshevBoundsOq06Oq01Proof,
+  annotations: chebyshevBoundsOq06Oq01Annotations,
+}

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "chebyshev-bounds-oq-06-oq-01",
+  "title": "Central Binomial Asymptotic: C(2n,n) ~ 4ⁿ/√(πn)",
+  "slug": "chebyshev-bounds-oq-06-oq-01",
+  "description": "A fully machine-checked, axiom-free proof that the central binomial coefficient is asymptotically equivalent to 4ⁿ/√(πn): (2n).choose n ~[atTop] 4ⁿ/√(π·n). This answers the first open question of the parent chebyshev-bounds-oq-06 (the two-sided sandwich 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ), which asked for the sharp Stirling asymptotic. The proof is derived entirely from Mathlib's Stirling approximation Stirling.factorial_isEquivalent_stirling (n! ~ √(2πn)·(n/e)ⁿ) via elementary IsEquivalent algebra: writing C(2n,n) = (2n)!/(n!)², the Stirling factors collapse to 4ⁿ/√(πn). Honest scope: the effective one-sided inequality C(2n,n) ≤ 4ⁿ/√(πn) for every n requires an effective upper bound on n! (Robbins' bounds), which is not yet in Mathlib; the asymptotic equivalence proved here is the achievable and mathematically substantive part of the open question.",
+  "meta": {
+    "author": "Researcher agent (Lean Genius); derived from Mathlib's Stirling asymptotic",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Central_binomial_coefficient",
+    "date": "2026-07-02",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "central-binomial-coefficient",
+      "chebyshev-bounds",
+      "asymptotics",
+      "stirling-approximation",
+      "binomial-coefficients",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ0601.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Stirling.factorial_isEquivalent_stirling",
+        "description": "n! ~[atTop] √(2πn)·(n/e)ⁿ. The single analytic input: Mathlib's formalisation of Stirling's approximation as an asymptotic equivalence. Everything else is elementary algebra on IsEquivalent.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Stirling"
+      },
+      {
+        "theorem": "Asymptotics.IsEquivalent.comp_tendsto",
+        "description": "If f ~ g along l' and k → l', then f∘k ~ g∘k along l. Used to transport the Stirling equivalence from index n to index 2n for the numerator (2n)!.",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      },
+      {
+        "theorem": "Asymptotics.IsEquivalent.div",
+        "description": "u ~ v and w ~ z ⟹ u/w ~ v/z in a normed field. Combines the numerator equivalence (2n)! ~ S(2n) with the denominator equivalence (n!)² ~ (S n)² to get C(2n,n) ~ S(2n)/(S n)².",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "choose n k · k! · (n-k)! = n!. At n = 2n, k = n this gives the exact cast identity C(2n,n) = (2n)!/(n!·n!) used to express the central binomial coefficient as a ratio of factorials over ℝ.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n, used to phrase the result in both centralBinom and raw binomial notation.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Real.sq_sqrt / Real.sqrt_sq",
+        "description": "(√x)² = x and √(x²) = x for x ≥ 0. Used to eliminate the square roots √(2πn) and √(4πn) = 2√(πn) in the algebraic collapse of the Stirling ratio.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      }
+    ],
+    "originalContributions": [
+      "centralBinom_isEquivalent_four_pow_div_sqrt: the asymptotic equivalence (fun n => (n.centralBinom : ℝ)) ~[atTop] (fun n => 4ⁿ/√(π·n)), the sharp Stirling asymptotic for the central binomial coefficient — not present in Mathlib, which records only elementary polynomial-factor bounds (Bertrand.lean) and the exact factorial identity",
+      "choose_two_mul_isEquivalent_four_pow_div_sqrt: the same statement phrased with Nat.choose directly, (fun n => ((2*n).choose n : ℝ)) ~[atTop] (fun n => 4ⁿ/√(π·n))",
+      "A clean derivation pattern: transport Stirling from index n to 2n with IsEquivalent.comp_tendsto, combine numerator and denominator with .div and .mul, then discharge the residual pointwise identity S(2n)/(S n)² = 4ⁿ/√(πn) by field algebra (the Stirling exponential and √ factors cancel exactly)"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide (hence no Lean.ofReduceBool), no structure-encoded hypotheses. Honest framing: the single mathematical input is Mathlib's already-formalised Stirling equivalence; this entry contributes the elementary but previously-unformalised consequence for the central binomial coefficient.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "parentProof": "chebyshev-bounds-oq-06"
+  },
+  "sections": [
+    {
+      "id": "statement",
+      "title": "The asymptotic equivalence",
+      "startLine": 45,
+      "endLine": 51,
+      "summary": "centralBinom_isEquivalent_four_pow_div_sqrt states (fun n => (n.centralBinom : ℝ)) ~[atTop] (fun n => 4ⁿ/√(π·n)). The tilde is Mathlib's Asymptotics.IsEquivalent: the ratio of the two sides tends to 1 as n → ∞."
+    },
+    {
+      "id": "stirling-transport",
+      "title": "Transporting Stirling to the numerator and denominator",
+      "startLine": 52,
+      "endLine": 77,
+      "summary": "From H : n! ~ S n (Stirling), the numerator (2n)! ~ S(2n) is obtained by IsEquivalent.comp_tendsto along n ↦ 2n → ∞, and the denominator n!·n! ~ S n·S n by IsEquivalent.mul. The exact identity C(2n,n) = (2n)!/(n!·n!) comes from Nat.choose_mul_factorial_mul_factorial, cast to ℝ. Chaining with IsEquivalent.div reduces the goal to a pointwise identity."
+    },
+    {
+      "id": "algebraic-collapse",
+      "title": "Collapsing the Stirling ratio to 4ⁿ/√(πn)",
+      "startLine": 78,
+      "endLine": 117,
+      "summary": "For n ≥ 1, the residual identity S(2n)/(S n)² = 4ⁿ/√(πn) is proved by field algebra: √(4πn) = 2√(πn) (Real.sqrt_sq), (2n/e)^{2n} = 4ⁿ·(n/e)^{2n} (mul_pow, pow_mul), and (√(2πn))² = 2πn (Real.sq_sqrt). The common exponential factor (n/e)^{2n} and one factor of √(πn) cancel, leaving exactly 4ⁿ/√(πn)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**From the polynomial-factor sandwich to the sharp constant**\n\nThe parent entry `chebyshev-bounds-oq-06` packages the elementary two-sided estimate $\\frac{4^n}{2n+1}\\le\\binom{2n}{n}\\le 4^n$, which pins the central binomial coefficient down to within a polynomial factor and drives Chebyshev-type prime-counting bounds. The *sharp* behaviour, however, is governed by a square-root — not a linear — correction: Stirling's approximation gives\n$$\\binom{2n}{n}\\sim\\frac{4^n}{\\sqrt{\\pi n}}.$$\nThis is the classical refinement asked for by the parent's first open question. The $\\sqrt{\\pi n}$ denominator — with the transcendental constant $\\pi$ emerging from a purely combinatorial quantity — is the same phenomenon that makes the Wallis product and the Gaussian integral appear in the analysis of the binomial distribution.",
+    "problemStatement": "**Central binomial asymptotic**\n\nAs $n\\to\\infty$,\n$$\\binom{2n}{n}\\sim\\frac{4^n}{\\sqrt{\\pi n}},$$\ni.e. the ratio of the two sides tends to $1$. The goal is a fully machine-checked, axiom-free statement of this asymptotic equivalence, built on Mathlib's formalisation of Stirling's approximation.",
+    "proofStrategy": "**Elementary `IsEquivalent` algebra over Stirling.**\n\nMathlib provides $n!\\sim\\sqrt{2\\pi n}\\,(n/e)^n$ as `Stirling.factorial_isEquivalent_stirling`. Write $S(n)=\\sqrt{2\\pi n}\\,(n/e)^n$ and $\\binom{2n}{n}=(2n)!/(n!)^2$ (exact, from `Nat.choose_mul_factorial_mul_factorial`).\n\n1. *Numerator.* $(2n)!\\sim S(2n)$ by `IsEquivalent.comp_tendsto` along $n\\mapsto 2n\\to\\infty$.\n2. *Denominator.* $(n!)^2\\sim S(n)^2$ by `IsEquivalent.mul`.\n3. *Ratio.* $\\binom{2n}{n}\\sim S(2n)/S(n)^2$ by `IsEquivalent.div`.\n4. *Collapse.* Pointwise for $n\\ge 1$, $S(2n)/S(n)^2=\\dfrac{\\sqrt{4\\pi n}\\,(2n/e)^{2n}}{(2\\pi n)(n/e)^{2n}}=\\dfrac{2\\sqrt{\\pi n}\\cdot 4^n}{2\\pi n}=\\dfrac{4^n}{\\sqrt{\\pi n}}$, since $(2n/e)^{2n}=4^n(n/e)^{2n}$ and $\\sqrt{4\\pi n}=2\\sqrt{\\pi n}$; the exponential factor and one power of $\\sqrt{\\pi n}$ cancel.",
+    "keyInsights": [
+      "**The transcendental $\\pi$ is inherited from Stirling.** The $\\sqrt{\\pi n}$ denominator does not come from the combinatorics directly; it is the residue of the $\\sqrt{2\\pi n}$ factor in $n!$ after the numerator's $\\sqrt{4\\pi n}=2\\sqrt{\\pi n}$ is divided by the denominator's $(\\sqrt{2\\pi n})^2=2\\pi n$.",
+      "**The exponential factor cancels identically.** Both $(2n)!$ and $(n!)^2$ carry the factor $(n/e)^{2n}$ (via $(2n/e)^{2n}=2^{2n}(n/e)^{2n}=4^n(n/e)^{2n}$), so it drops out exactly, leaving only the algebraic $4^n$ and the square-root correction.",
+      "**Transport, don't re-prove.** The numerator is handled by transporting the *same* Stirling equivalence from index $n$ to index $2n$ with `comp_tendsto`, rather than proving a separate asymptotic for $(2n)!$.",
+      "**Effective vs. asymptotic.** The matching *inequality* $\\binom{2n}{n}\\le 4^n/\\sqrt{\\pi n}$ for all $n$ would need an effective upper bound on $n!$ (Robbins), absent from Mathlib; the equivalence proved here is the part reachable from current Mathlib."
+    ],
+    "prerequisites": [
+      "Asymptotic equivalence (Landau ~, Mathlib's Asymptotics.IsEquivalent)",
+      "Stirling's approximation as an asymptotic equivalence",
+      "The central binomial coefficient and the identity C(2n,n) = (2n)!/(n!)²"
+    ]
+  },
+  "conclusion": {
+    "summary": "The central binomial coefficient satisfies $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$. Starting from Mathlib's Stirling equivalence $n!\\sim\\sqrt{2\\pi n}\\,(n/e)^n$, the numerator $(2n)!$ is transported to index $2n$ by `comp_tendsto`, the denominator $(n!)^2$ handled by `mul`, and the ratio by `div`; the residual pointwise identity collapses the Stirling factors to $4^n/\\sqrt{\\pi n}$ by field algebra. 2 theorems (centralBinom and Nat.choose phrasings), 0 sorries, 0 axioms.",
+    "implications": [
+      "Answers the first open question of chebyshev-bounds-oq-06: the sharp Stirling asymptotic matching the elementary two-sided sandwich there.",
+      "Provides a reusable, axiom-free asymptotic for downstream analytic-number-theory entries (e.g. the normalisation of the binomial distribution, Wallis-product-adjacent estimates).",
+      "Isolates the exact obstruction to the effective inequality C(2n,n) ≤ 4ⁿ/√(πn): a Mathlib upper bound on n! (Robbins' refinement of Stirling)."
+    ],
+    "openQuestions": [
+      "Can Robbins' effective bounds √(2πn)·(n/e)ⁿ·e^{1/(12n+1)} ≤ n! ≤ √(2πn)·(n/e)ⁿ·e^{1/(12n)} be formalised in Mathlib, upgrading this asymptotic to an effective two-sided sandwich around 4ⁿ/√(πn)?",
+      "Does the sharp constant 1/√(πn) let the parent chebyshev-bounds sharpen its prime-counting estimates θ(n), ψ(n) beyond the crude n·log 4 bound?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "venue": "London",
+      "note": "The origin of Stirling's approximation n! ~ √(2πn)(n/e)ⁿ, the single analytic input that produces the √(πn) correction and the constant π in the central binomial asymptotic."
+    },
+    {
+      "authors": "Robbins, Herbert",
+      "title": "A Remark on Stirling's Formula",
+      "year": "1955",
+      "venue": "The American Mathematical Monthly, vol. 62, no. 1",
+      "note": "Effective two-sided bounds on n! sharpening Stirling; formalising these would upgrade the asymptotic equivalence proved here to an effective inequality C(2n,n) ≤ 4ⁿ/√(πn) valid for every n."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib.Analysis.SpecialFunctions.Stirling",
+      "year": "2024",
+      "venue": "Lean 4 mathematical library (mathlib4)",
+      "note": "Source of factorial_isEquivalent_stirling, the formalised Stirling asymptotic on which this entry's derivation rests entirely."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers (6th ed.)",
+      "year": "2008",
+      "venue": "Oxford University Press",
+      "note": "Standard reference for the asymptotics of binomial coefficients and Chebyshev's functions, the setting in which C(2n,n) ~ 4ⁿ/√(πn) is the sharp form of the elementary sandwich."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-06",
+      "relationship": "related",
+      "description": "Parent entry packaging the elementary two-sided central-binomial sandwich 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ; this child answers its first open question by proving the sharp Stirling asymptotic C(2n,n) ~ 4ⁿ/√(πn)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent `chebyshev-bounds-oq-06` (the elementary two-sided sandwich `4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ`), which asked for the sharp Stirling asymptotic:

$$\binom{2n}{n} \sim \frac{4^n}{\sqrt{\pi n}} \qquad (n \to \infty).$$

Formalised over ℝ as `Asymptotics.IsEquivalent`, **fully verified, 0 axioms, 0 sorries** (2 theorems, 126 lines).

## Method

Derived entirely from Mathlib's `Stirling.factorial_isEquivalent_stirling` (`n! ~ √(2πn)·(n/e)ⁿ`) via elementary `IsEquivalent` algebra. Writing `C(2n,n) = (2n)!/(n!)²`:

1. **Numerator** `(2n)! ~ S(2n)` — transport Stirling from index `n` to `2n` with `IsEquivalent.comp_tendsto`.
2. **Denominator** `(n!)² ~ (S n)²` — `IsEquivalent.mul`.
3. **Ratio** — `IsEquivalent.div`, using the exact cast identity `C(2n,n) = (2n)!/(n!·n!)` from `Nat.choose_mul_factorial_mul_factorial`.
4. **Collapse** — the residual pointwise identity `S(2n)/(S n)² = 4ⁿ/√(πn)` for `n ≥ 1`: the exponential factor `(n/e)^{2n}` cancels, `√(4πn) = 2√(πn)`, `(√(2πn))² = 2πn`, leaving exactly `4ⁿ/√(πn)`.

## Honest scope

The *effective* one-sided inequality `C(2n,n) ≤ 4ⁿ/√(πn)` for **every** `n` requires an effective upper bound on `n!` (Robbins' bounds), which is not yet in Mathlib (see the comment in `Mathlib/Analysis/SpecialFunctions/Stirling.lean`). The **asymptotic equivalence** proved here is the achievable and mathematically substantive part of the open question.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ChebyshevBoundsOQ0601` → `✔ Built ... Build completed successfully`
- 0 `sorry`, 0 `axiom` declarations, no `native_decide` — 0-axiom by construction (only `propext`/`Classical.choice`/`Quot.sound`).
- `pnpm gallery:check-size` and `annotations:validate` clean for this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)