### PR TITLE
Enrich Cyclic Vectors & Non-Derogatory Matrices (cayley-hamilton-reduction-oq-02-oq-03): conclusion + docstring annotation

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/annotations.json
@@ -1,8 +1,35 @@
 [
   {
+    "id": "ann-overview-roadmap",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Roadmap: cyclic vector ⟺ non-derogatory, and the scope boundary",
+    "content": "The imports and module docstring frame the entry. It sits in the Cayley–Hamilton reduction family: the parent oq-02 proves the non-derogatory criterion (minpoly M = charpoly M iff deg minpoly = n), and the sibling oq-02-oq-01 builds the companion matrix C(p) with minpoly = charpoly = p. The classical fact linked here is: M has a cyclic vector ⟺ M is non-derogatory. The docstring lists the five results — the engine (low-degree annihilators vanish), the forward implication in full generality (cyclic ⇒ non-derogatory), the spanning reformulation, e₀ as an explicit cyclic vector for companion matrices, and the resulting non-derogacy of companion matrices. Crucially it states the scope boundary: the forward direction is proved for an arbitrary matrix, but the reverse (non-derogatory ⇒ cyclic) is proved only on the companion / rational-canonical-form representatives, because upgrading it to an arbitrary matrix needs the rational canonical form (every non-derogatory matrix similar to a single companion block), which Mathlib lacks. The narrow imports and the note 'Research file — intentionally NOT registered in Proofs.lean' are also set here.",
+    "mathContext": "The correspondence is module-theoretic: $M$ has a cyclic vector iff $F^n$, viewed as an $F[X]$-module with $X$ acting as $M$, is cyclic, i.e. $F^n \\cong F[X]/(\\mathrm{minpoly}\\,M)$ — which happens exactly when $\\deg(\\mathrm{minpoly}\\,M) = n$, the non-derogatory case. The companion matrix $C(p)$ is by construction multiplication-by-$X$ on $F[X]/(p)$, so $e_0$ generates it.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic vector",
+      "non-derogatory matrix",
+      "rational canonical form",
+      "companion matrix",
+      "cyclic F[X]-module"
+    ],
+    "prerequisites": [
+      "minimal and characteristic polynomials of a matrix",
+      "modules over a polynomial ring F[X]"
+    ]
+  },
+  {
     "id": "ann-definitions",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
-    "range": { "startLine": 64, "endLine": 82 },
+    "range": {
+      "startLine": 64,
+      "endLine": 82
+    },
     "type": "definition",
     "title": "Krylov Orbits, Cyclic Vectors, Non-Derogatory Matrices",
     "content": "Four definitions set the stage. `krylov M v` is the family k ↦ Mᵏv indexed by `Fin n` — the n vectors v, Mv, …, Mⁿ⁻¹v. `IsCyclicVector M v` says this orbit is linearly independent; `HasCyclicVector M` says some v is cyclic. `IsNonDerogatory M` is `minpoly F M = M.charpoly`. Because the orbit has n vectors in the n-dimensional space `Fin n → F`, linear independence is equivalent to spanning, matching the textbook definition of a cyclic vector.",
@@ -24,7 +51,10 @@
   {
     "id": "ann-engine",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
-    "range": { "startLine": 93, "endLine": 117 },
+    "range": {
+      "startLine": 93,
+      "endLine": 117
+    },
     "type": "theorem",
     "title": "The Engine: Low-Degree Annihilators Vanish",
     "content": "`eq_zero_of_aeval_mulVec_eq_zero` is the technical heart. It rewrites p(M)·v = ∑_{k<n} (p.coeff k)·(Mᵏv) using `aeval_eq_sum_range'` and a `mulVec`-over-sum helper, so a degree-<n polynomial with p(M)v = 0 becomes a vanishing F-combination of the Krylov orbit. `Fintype.linearIndependent_iff` then forces every coefficient below index n to be zero, and `coeff_eq_zero_of_natDegree_lt` handles the rest, giving p = 0. This is exactly the linear-independence hypothesis re-read as a statement about polynomials.",
@@ -43,7 +73,10 @@
   {
     "id": "ann-forward",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
-    "range": { "startLine": 119, "endLine": 160 },
+    "range": {
+      "startLine": 119,
+      "endLine": 160
+    },
     "type": "theorem",
     "title": "Forward Implication: Cyclic ⇒ Non-Derogatory",
     "content": "`isNonDerogatory_of_hasCyclicVector` proves the substantive direction in full generality. The minimal polynomial μ annihilates M, hence annihilates the cyclic vector v; by the engine μ cannot have degree < n, so deg μ ≥ n. Since μ divides the characteristic polynomial and deg(charpoly) = n, also deg μ ≤ n, pinning deg μ = n. Two monic polynomials with μ ∣ charpoly and equal degree must be equal, so μ = charpoly — M is non-derogatory.",
@@ -62,7 +95,10 @@
   {
     "id": "ann-spanning",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
-    "range": { "startLine": 162, "endLine": 170 },
+    "range": {
+      "startLine": 162,
+      "endLine": 170
+    },
     "type": "theorem",
     "title": "Spanning Form of Cyclicity",
     "content": "`span_eq_top_of_isCyclicVector` recovers the textbook 'spanning' phrasing: an n-element linearly independent family in the n-dimensional space `Fin n → F` spans the whole space. The proof calls `LinearIndependent.span_eq_top_of_card_eq_finrank` together with `finrank (Fin n → F) = n`.",
@@ -81,7 +117,10 @@
   {
     "id": "ann-companion",
     "proofId": "cayley-hamilton-reduction-oq-02-oq-03",
-    "range": { "startLine": 172, "endLine": 199 },
+    "range": {
+      "startLine": 172,
+      "endLine": 199
+    },
     "type": "theorem",
     "title": "Reverse on the Normal Forms: Companion Matrices",
     "content": "`companionMatrix_isCyclicVector` exhibits the converse witness: the standard basis vector e₀ is cyclic for every companion matrix C(p). The orbit lemma `companionMatrix_pow_basis` from the sibling entry gives C(p)ᵏ·e₀ = eₖ, so the Krylov orbit of e₀ is exactly the standard basis — trivially linearly independent. `companionMatrix_isNonDerogatory` then feeds this into the forward implication, re-deriving that companion matrices are non-derogatory (consistent with the direct minpoly = charpoly = p of oq-02-oq-01). This realizes the reverse implication on the rational-canonical-form representatives.",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-03/meta.json
@@ -124,5 +124,15 @@
       "summary": "`companionMatrix_isCyclicVector`: e₀ is a cyclic vector for every companion matrix C(p) (its Krylov orbit is the standard basis, via `companionMatrix_pow_basis`). `companionMatrix_isNonDerogatory` combines with the forward direction to re-derive non-derogacy.",
       "mathContext": "By $C(p)^k e_0 = e_k$ (oq-02-oq-01), the Krylov orbit of $e_0$ is exactly $\\{e_0, e_1, \\ldots, e_{d-1}\\}$, the standard basis of $F^d$, which is linearly independent. So $e_0$ is cyclic, and the forward implication gives $\\mathrm{minpoly}(C(p)) = \\mathrm{charpoly}(C(p))$ — consistent with the direct computation $\\mathrm{minpoly} = \\mathrm{charpoly} = p$."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Establishes the cyclic-vector / non-derogatory correspondence in the direction that admits a fully general proof: over an arbitrary field F, any cyclic vector for M forces minpoly F M = charpoly M (0 axioms, 0 sorries). The converse is realized concretely on the companion — i.e. rational-canonical-form — representatives, where the standard basis vector e₀ is an explicit cyclic vector, so every companion matrix is non-derogatory.",
+    "implications": "Completes the cyclic-vector layer of the Cayley–Hamilton reduction family, joining the parent oq-02 (the non-derogatory criterion deg minpoly = n) and the sibling oq-02-oq-01 (companion matrices as the archetypal non-derogatory matrices). The engine lemma — reading linear independence of a Krylov orbit as 'no nonzero polynomial of degree < n annihilates v under p(M)' — is the reusable bridge between the linear-algebraic and polynomial pictures, and is exactly the mechanism behind the module isomorphism Fⁿ ≅ F[X]/(minpoly M) in the non-derogatory case. Because the reverse direction is fully settled on the normal forms, the sole remaining ingredient for the general equivalence is the rational canonical form.",
+    "mainResult": "Over any field F: a cyclic vector for M ∈ Mₙ(F) forces minpoly F M = charpoly M (isNonDerogatory_of_hasCyclicVector), and e₀ is an explicit cyclic vector for every companion matrix C(p) (companionMatrix_isCyclicVector), whence companion matrices are non-derogatory (companionMatrix_isNonDerogatory). Machine-checked with 0 axioms and 0 sorries over an arbitrary field.",
+    "openQuestions": [
+      "Upgrade the reverse implication (non-derogatory ⇒ has a cyclic vector) from the companion representatives to an arbitrary non-derogatory matrix. This needs the rational canonical form — that every non-derogatory matrix is similar to a single companion block — which Mathlib does not yet provide.",
+      "Formalize the correspondence in its native module-theoretic form: M has a cyclic vector iff the F[X]-module Fⁿ (with X acting as M) is cyclic, i.e. Fⁿ ≅ F[X]/(minpoly M) as F[X]-modules, making the linear-algebraic cyclicity literally module cyclicity.",
+      "Extend the framework beyond fields to a PID base, where the structure theorem for finitely generated modules (invariant factors / Smith normal form) governs the analogue of the companion decomposition and the notion of a cyclic generator."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-reduction-oq-02-oq-03` (quality 85, 0 prior passes). Targeted, bounded pass filling two genuine gaps — no deepening of already-rich fields.

## Changes

**1. Add the missing `conclusion` block (meta.json).** The entry had *no* conclusion at all (hence 0 open questions). Added `summary`, `implications`, `mainResult`, and 3 `openQuestions`:
- upgrade the reverse implication (non-derogatory ⇒ cyclic) from companion representatives to arbitrary matrices via rational canonical form (not yet in Mathlib);
- formalize the native module-theoretic form Fⁿ ≅ F[X]/(minpoly M);
- generalize the framework to a PID base (invariant factors / Smith normal form).

**2. Fill the uncovered docstring (annotations.json).** Annotations previously started at line 64; added `ann-overview-roadmap` (lines 1–63) for the "Overview and Imports" section — frames the oq-02 reduction family, the cyclic ⟺ non-derogatory correspondence, the five results, and the **scope boundary** (forward direction general; reverse proved only on companion normal forms). Coverage now runs from line 1.

## Verification
- JSON well-formed; semantic diff confirms **only** the added `conclusion` key (meta) and the single added annotation — no existing content, titles, ranges, or enum values altered.
- meta.json 13 KB, within the 60 KB cap.
- New annotation uses canonical enum values (`type: concept`, `significance: supporting`).
- `status`/`badge`/`axiomCount` (verified / original / 0) unchanged and accurate.