### PR TITLE
research(area-of-circle-oq-07-oq-03-oq-03): half-integer Gamma ladder as even Gaussian moments [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ03OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ03OQ03.lean
@@ -1,0 +1,110 @@
+/-
+# The half-integer Gamma ladder as even Gaussian moments
+
+Research: area-of-circle-oq-07-oq-03-oq-03
+Parent:   area-of-circle-oq-07-oq-03 (`Γ(1/2) = √π`, the Gamma shadow of the Gaussian integral)
+
+The parent entry identified the single value `Γ(1/2) = √π` with the Gaussian
+integral `∫_ℝ e^{-x²} dx = √π`.  This entry extends that one value to the whole
+half-integer **ladder** and its probabilistic meaning: for every `n`, the even
+Gaussian moment equals a half-integer Gamma value,
+
+  `∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2)`,
+
+and Mathlib's closed form `Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ` (`Real.Gamma_nat_add_half`)
+then gives the moments in terms of double factorials.
+
+Route: on the half-line the substitution `u = x²` turns `∫_{x>0} x^{2n} e^{-x²} dx`
+into `½ Γ(n + 1/2)` — this is Mathlib's `integral_rpow_mul_exp_neg_rpow` with
+`p = 2`, `q = 2n` — and even symmetry (`x^{2n} e^{-x²}` is even) doubles the
+half-line integral to the whole line, cancelling the `½`.
+
+Contributions:
+
+* `gaussian_moment_eq_gamma` — the ladder `∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2)`.
+* `gaussian_moment_closed` — the double-factorial closed form
+  `∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ`.
+* `gaussian_moment_zero` — `n = 0` recovers the parent's `∫_ℝ e^{-x²} dx = √π`.
+* `gaussian_moment_two` — `n = 1` gives `∫_ℝ x² e^{-x²} dx = √π / 2`.
+
+Everything here is `sorry`-free and `axiom`-free (only the foundational
+`propext`/`Classical.choice`/`Quot.sound`; no `Lean.ofReduceBool`).
+-/
+import Mathlib
+
+open Real Set MeasureTheory
+open scoped Nat
+
+namespace AreaOfCircleOQ07OQ03OQ03
+
+/-- **The half-integer Gamma ladder as even Gaussian moments.**
+`∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2)` for every `n`.
+
+The half-line integral is `½ Γ(n + 1/2)` (the substitution `u = x²`, packaged as
+`integral_rpow_mul_exp_neg_rpow` with `p = 2`, `q = 2n`), and even symmetry of the
+integrand doubles it to the whole line. -/
+theorem gaussian_moment_eq_gamma (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = Real.Gamma (n + 1 / 2) := by
+  -- integrability of the moment over all of ℝ (via the `rpow` form, using `rpow_natCast`)
+  have hint : Integrable (fun x : ℝ => x ^ (2 * n) * Real.exp (-x ^ 2)) := by
+    have hq : (-1 : ℝ) < ((2 * n : ℕ) : ℝ) := by
+      have : (0 : ℝ) ≤ ((2 * n : ℕ) : ℝ) := Nat.cast_nonneg _
+      linarith
+    have h := integrable_rpow_mul_exp_neg_mul_sq (b := 1) one_pos
+      (s := ((2 * n : ℕ) : ℝ)) hq
+    refine h.congr ?_
+    filter_upwards with x
+    rw [Real.rpow_natCast, neg_one_mul]
+  -- the half-line value, from the `u = x²` substitution lemma
+  have hIoi : ∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2)
+      = 1 / 2 * Real.Gamma (n + 1 / 2) := by
+    have hq : (-1 : ℝ) < ((2 * n : ℕ) : ℝ) := by
+      have : (0 : ℝ) ≤ ((2 * n : ℕ) : ℝ) := Nat.cast_nonneg _
+      linarith
+    have key := integral_rpow_mul_exp_neg_rpow (p := 2) (q := ((2 * n : ℕ) : ℝ))
+      (by norm_num) hq
+    have harg : (((2 * n : ℕ) : ℝ) + 1) / 2 = (n : ℝ) + 1 / 2 := by push_cast; ring
+    rw [harg] at key
+    rw [← key]
+    refine setIntegral_congr_fun measurableSet_Ioi (fun x _ => ?_)
+    rw [Real.rpow_natCast, Real.rpow_two]
+  -- even symmetry: the `Iic 0` half equals the `Ioi 0` half
+  have hIic : ∫ x in Iic (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2)
+      = ∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2) := by
+    have h := integral_comp_neg_Ioi (0 : ℝ) (fun x : ℝ => x ^ (2 * n) * Real.exp (-x ^ 2))
+    rw [neg_zero] at h
+    rw [← h]
+    refine setIntegral_congr_fun measurableSet_Ioi (fun x _ => ?_)
+    show (-x) ^ (2 * n) * Real.exp (-(-x) ^ 2) = x ^ (2 * n) * Real.exp (-x ^ 2)
+    have e1 : (-x) ^ (2 * n) = x ^ (2 * n) := by rw [pow_mul, neg_sq, ← pow_mul]
+    rw [e1, neg_sq]
+  -- split ℝ = Iic 0 ∪ Ioi 0 and combine
+  have hsplit : ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2)
+      = (∫ x in Iic (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2))
+        + ∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2) := by
+    rw [← compl_Iic (a := (0 : ℝ))]
+    exact (integral_add_compl measurableSet_Iic hint).symm
+  rw [hsplit, hIic, ← two_mul, hIoi]
+  ring
+
+/-- **Double-factorial closed form.** `∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ`,
+combining the ladder identity with Mathlib's `Real.Gamma_nat_add_half`. -/
+theorem gaussian_moment_closed (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = (2 * n - 1)‼ * √π / 2 ^ n := by
+  rw [gaussian_moment_eq_gamma, Real.Gamma_nat_add_half]
+
+/-- `n = 0` recovers the parent Gaussian integral `∫_ℝ e^{-x²} dx = √π`. -/
+theorem gaussian_moment_zero : ∫ x : ℝ, Real.exp (-x ^ 2) = √π := by
+  have h := gaussian_moment_eq_gamma 0
+  rw [Nat.cast_zero, zero_add, Real.Gamma_one_half_eq] at h
+  simpa using h
+
+/-- `n = 1`: the second even Gaussian moment `∫_ℝ x² e^{-x²} dx = √π / 2`. -/
+theorem gaussian_moment_two : ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = √π / 2 := by
+  have h := gaussian_moment_eq_gamma 1
+  simp only [mul_one] at h
+  rw [h, show ((1 : ℕ) : ℝ) + 1 / 2 = 1 / 2 + 1 by norm_num,
+    Real.Gamma_add_one (by norm_num), Real.Gamma_one_half_eq]
+  ring
+
+end AreaOfCircleOQ07OQ03OQ03

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/annotations.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "concept",
+    "title": "Overview: the Gamma ladder as Gaussian moments",
+    "content": "The parent identified the single value Γ(1/2) = √π with the Gaussian integral ∫_ℝ e^{-x²}. This module extends it to the whole half-integer ladder: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ. These even moments are, up to scaling, the moments of the normal distribution. Route: u = x² substitution on the half-line, then even symmetry to the whole line.",
+    "mathContext": "$\\int_{\\mathbb R} x^{2n} e^{-x^2} = \\Gamma(n+\\tfrac12)$",
+    "significance": "key",
+    "relatedConcepts": ["Gamma function", "Gaussian integral", "moments", "normal distribution", "double factorial"],
+    "prerequisites": ["Lebesgue integration", "the Gamma function"]
+  },
+  {
+    "id": "ann-integrability",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 46, "endLine": 55 },
+    "type": "tactic",
+    "title": "Whole-line integrability",
+    "content": "x^{2n} e^{-x²} is integrable over ℝ. This is transferred from Mathlib's rpow-form lemma integrable_rpow_mul_exp_neg_mul_sq: the monoid power x^{2n} equals the rpow x^{(2n:ℝ)} for every real x (Real.rpow_natCast), so the two integrands agree almost everywhere.",
+    "significance": "supporting",
+    "relatedConcepts": ["Integrable.congr", "Real.rpow_natCast", "integrable_rpow_mul_exp_neg_mul_sq"]
+  },
+  {
+    "id": "ann-halfline",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 56, "endLine": 71 },
+    "type": "insight",
+    "title": "Half-line value via u = x² substitution",
+    "content": "∫_{x>0} x^{2n} e^{-x²} dx = ½ Γ(n + 1/2). This is Mathlib's integral_rpow_mul_exp_neg_rpow (∫_{x>0} x^q e^{-x^p} = (1/p)Γ((q+1)/p)) at p = 2, q = 2n, since (2n+1)/2 = n + 1/2. The monoid powers are matched to rpow on x > 0 via Real.rpow_natCast and Real.rpow_two.",
+    "mathContext": "$\\int_{x>0} x^{2n} e^{-x^2} = \\tfrac12\\Gamma(n+\\tfrac12)$",
+    "significance": "critical",
+    "relatedConcepts": ["change of variables", "integral_rpow_mul_exp_neg_rpow", "Gamma integral"]
+  },
+  {
+    "id": "ann-even",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 72, "endLine": 90 },
+    "type": "insight",
+    "title": "Even symmetry doubles the half-line integral",
+    "content": "Since x^{2n} e^{-x²} is even, the Iic 0 half-integral equals the Ioi 0 half-integral (via the reflection integral_comp_neg_Ioi). Splitting ℝ = Iic 0 ∪ Ioi 0 (integral_add_compl) then gives the whole-line integral as twice the half-line value, cancelling the ½ and yielding Γ(n + 1/2).",
+    "significance": "critical",
+    "relatedConcepts": ["even function", "integral_comp_neg_Ioi", "integral_add_compl", "compl_Iic"]
+  },
+  {
+    "id": "ann-closed",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 91, "endLine": 96 },
+    "type": "insight",
+    "title": "Double-factorial closed form",
+    "content": "∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ, obtained by substituting Mathlib's Real.Gamma_nat_add_half (Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ) into the ladder identity.",
+    "mathContext": "$\\Gamma(n+\\tfrac12) = (2n-1)!!\\,\\sqrt\\pi/2^n$",
+    "significance": "key",
+    "relatedConcepts": ["Real.Gamma_nat_add_half", "double factorial"]
+  },
+  {
+    "id": "ann-values",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-03",
+    "range": { "startLine": 97, "endLine": 109 },
+    "type": "insight",
+    "title": "Base cases n = 0 and n = 1",
+    "content": "gaussian_moment_zero recovers the parent: ∫_ℝ e^{-x²} dx = √π = Γ(1/2). gaussian_moment_two gives the second even moment ∫_ℝ x² e^{-x²} dx = √π/2, from Γ(3/2) = (1/2)Γ(1/2) = √π/2 (Real.Gamma_add_one).",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.Gamma_one_half_eq", "Real.Gamma_add_one"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ03OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq03Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq03Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq03Oq03Data: ProofData = {
+  proof: areaOfCircleOq07Oq03Oq03Proof,
+  annotations: areaOfCircleOq07Oq03Oq03Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "area-of-circle-oq-07-oq-03-oq-03",
+  "slug": "area-of-circle-oq-07-oq-03-oq-03",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Real", "Set", "MeasureTheory"],
+    "namespace": "AreaOfCircleOQ07OQ03OQ03",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Integer Gamma Ladder as Even Gaussian Moments",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ03OQ03.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "gaussian-integral",
+      "moments",
+      "double-factorial",
+      "integration",
+      "probability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 110,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "gaussian_moment_eq_gamma: the identification of the entire half-integer Gamma ladder with even Gaussian moments — ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) for every n, extending the parent's single value Γ(1/2) = √π to the whole tower.",
+      "gaussian_moment_closed: the double-factorial closed form ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ, combining the ladder identity with Mathlib's Real.Gamma_nat_add_half.",
+      "The proof method: the half-line integral is ½ Γ(n + 1/2) via the u = x² substitution (Mathlib's integral_rpow_mul_exp_neg_rpow with p = 2, q = 2n, connected to the monoid power through Real.rpow_natCast), and even symmetry of x^{2n} e^{-x²} (integral_comp_neg_Ioi) doubles the half-line integral to the whole line.",
+      "gaussian_moment_zero and gaussian_moment_two: the concrete base cases ∫_ℝ e^{-x²} dx = √π (recovering the parent) and ∫_ℝ x² e^{-x²} dx = √π / 2."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Gaussian ∫_ℝ e^{-x²} dx = √π is the value Γ(1/2) = √π of the Euler Gamma function at a half-integer, as the parent entry area-of-circle-oq-07-oq-03 recorded. That single value is the bottom rung of an entire ladder: the polynomial moments of the Gaussian weight e^{-x²}. Because e^{-x²} is even, the odd moments vanish and the even moments ∫_ℝ x^{2n} e^{-x²} dx are exactly the half-integer Gamma values Γ(n + 1/2) — equivalently (2n-1)‼·√π/2ⁿ in double-factorial form. These are, up to normalisation, the moments of the standard normal distribution (the (2n)-th moment of N(0,1/2)), so the Gamma ladder is the probabilistic backbone of the Gaussian. This entry climbs the ladder: it proves the moment–Gamma identity for all n by the classical u = x² substitution on the half-line (turning the moment into a Gamma integral) followed by even symmetry to recover the whole line, then reads off the double-factorial closed form from Mathlib's Real.Gamma_nat_add_half.",
+    "problemStatement": "Extend the parent's single value Γ(1/2) = √π to the full half-integer ladder by identifying each Γ(n + 1/2) with the even Gaussian moment ∫_ℝ x^{2n} e^{-x²} dx, and give the double-factorial closed form.",
+    "keyIdeas": [
+      "On the half-line, the substitution u = x² turns ∫_{x>0} x^{2n} e^{-x²} dx into ½ Γ(n + 1/2) — Mathlib's integral_rpow_mul_exp_neg_rpow with p = 2, q = 2n.",
+      "The integrand x^{2n} e^{-x²} is even, so the whole-line integral is twice the half-line integral, cancelling the ½ and giving Γ(n + 1/2).",
+      "Mathlib's Real.Gamma_nat_add_half gives the closed form Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ.",
+      "The monoid power x^{2n} matches the rpow x^{2n} used by the Gamma lemma via Real.rpow_natCast (valid for all real x), and even integrability transfers from the rpow form."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: the Gamma Ladder and Gaussian Moments",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Recalls the parent's Γ(1/2) = √π and states the goal: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2), with the double-factorial closed form. Outlines the u = x² substitution plus even-symmetry route and enumerates the contributions.",
+      "mathContext": "$\\int_{\\mathbb R} x^{2n} e^{-x^2}\\,dx = \\Gamma(n+\\tfrac12) = (2n-1)!!\\,\\sqrt\\pi/2^n$."
+    },
+    {
+      "id": "ladder",
+      "title": "The Ladder Identity",
+      "startLine": 38,
+      "endLine": 90,
+      "summary": "Proves gaussian_moment_eq_gamma: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2). Establishes whole-line integrability (via the rpow form and Real.rpow_natCast), the half-line value ½ Γ(n + 1/2) from integral_rpow_mul_exp_neg_rpow, and even symmetry (integral_comp_neg_Ioi) to split ℝ = Iic 0 ∪ Ioi 0 and double the half-line integral.",
+      "mathContext": "$\\int_{x>0} x^{2n} e^{-x^2}\\,dx = \\tfrac12\\Gamma(n+\\tfrac12)$; evenness doubles it."
+    },
+    {
+      "id": "closed-and-values",
+      "title": "Closed Form and Base Cases",
+      "startLine": 91,
+      "endLine": 109,
+      "summary": "gaussian_moment_closed gives the double-factorial form (2n-1)‼·√π/2ⁿ via Real.Gamma_nat_add_half. gaussian_moment_zero recovers the parent's ∫_ℝ e^{-x²} dx = √π, and gaussian_moment_two gives ∫_ℝ x² e^{-x²} dx = √π/2 (from Γ(3/2) = √π/2).",
+      "mathContext": "$\\Gamma(\\tfrac12)=\\sqrt\\pi$, $\\Gamma(\\tfrac32)=\\tfrac{\\sqrt\\pi}2$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-03-oq-03-oq-01",
+      "question": "Normalise the moments to the standard normal distribution: show the (2n)-th moment of N(0,1) equals (2n-1)‼, i.e. ∫_ℝ x^{2n} (2π)^{-1/2} e^{-x²/2} dx = (2n-1)‼, by the scaling x ↦ x/√2 applied to the ladder identity proved here.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "parent",
+      "description": "The parent identifies the single value Γ(1/2) = √π with the Gaussian integral ∫_ℝ e^{-x²} dx. This entry extends that to the full half-integer ladder, identifying every Γ(n + 1/2) with the even Gaussian moment ∫_ℝ x^{2n} e^{-x²} dx; gaussian_moment_zero recovers the parent's value as the n = 0 case."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.Gamma",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_rpow_mul_exp_neg_rpow: ∫_{x>0} x^q e^{-x^p} dx = (1/p)Γ((q+1)/p), the u = x^p substitution that gives the half-line Gaussian moment as ½ Γ(n + 1/2)."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_nat_add_half (Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ) and integrable_rpow_mul_exp_neg_mul_sq, providing the closed form and whole-line integrability."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Measure.Lebesgue.Integral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_comp_neg_Ioi, the reflection x ↦ -x that converts the Iic 0 half-integral into the Ioi 0 half-integral, encoding the even symmetry."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "Extends the parent's Γ(1/2) = √π to the entire half-integer Gamma ladder by proving ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) for all n. The half-line integral evaluates to ½ Γ(n + 1/2) through the u = x² substitution (Mathlib's integral_rpow_mul_exp_neg_rpow, with the monoid power matched to the rpow via Real.rpow_natCast), and even symmetry of the integrand doubles it to the whole line. Mathlib's Real.Gamma_nat_add_half then yields the double-factorial closed form (2n-1)‼·√π/2ⁿ. The base cases n = 0 (∫_ℝ e^{-x²} dx = √π, recovering the parent) and n = 1 (∫_ℝ x² e^{-x²} dx = √π/2) are recorded. All 4 theorems are 0-axiom and machine-checked.",
+    "significance": "The even Gaussian moments are, up to scaling, the moments of the normal distribution, so this ladder is the probabilistic content behind the Gaussian integral. Turning the isolated value Γ(1/2) = √π into the full family Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ connects the Gamma function, the Gaussian weight, and the double factorials in one machine-checked identity."
+  },
+  "description": "The Gaussian integral ∫_ℝ e^{-x²} dx = √π is the bottom rung of the half-integer Gamma ladder. This entry climbs it: for every n, the even Gaussian moment ∫_ℝ x^{2n} e^{-x²} dx equals Γ(n + 1/2) = (2n-1)‼·√π/2ⁿ. The half-line integral is ½ Γ(n + 1/2) by the u = x² substitution, and even symmetry doubles it to the whole line. Base cases recover √π (n = 0) and √π/2 (n = 1). All results are 0-axiom and machine-checked."
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `area-of-circle-oq-07-oq-03-oq-03` extending the parent's single value `Γ(1/2) = √π` to the **whole half-integer Gamma ladder**:

`∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ`  for every `n`.

These even moments are, up to scaling, the moments of the normal distribution — the probabilistic backbone of the Gaussian.

**Contributions**
- `gaussian_moment_eq_gamma`: the ladder identity. The half-line integral is `½ Γ(n + 1/2)` via the `u = x²` substitution (Mathlib's `integral_rpow_mul_exp_neg_rpow` at `p = 2, q = 2n`; the monoid power `x^{2n}` is matched to the rpow through `Real.rpow_natCast`), and even symmetry of the integrand (`integral_comp_neg_Ioi` + `integral_add_compl`) doubles it to the whole line.
- `gaussian_moment_closed`: the double-factorial closed form `(2n-1)‼·√π/2ⁿ` via `Real.Gamma_nat_add_half`.
- `gaussian_moment_zero`: `∫_ℝ e^{-x²} dx = √π` (recovers the parent, `n = 0`).
- `gaussian_moment_two`: `∫_ℝ x² e^{-x²} dx = √π/2` (`n = 1`, from `Γ(3/2) = √π/2`).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.AreaOfCircleOQ07OQ03OQ03` → **Build succeeded**
- 0 `axiom` declarations, 0 structure-encoded assumptions, 0 `sorry`, no `native_decide`. Status `verified`, badge `original`.
- 4 theorems / 110 lines. `gallery:check-size` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)