### PR TITLE
research(erdos-866-wip-01-oq-01): exact threshold g_3(N)=1 under the repeated-index config definition [VERIFIED, 0-axiom, 6thm/122L]

### DIFF
--- a/proofs/Proofs/Erdos866Wip01OQ01.lean
+++ b/proofs/Proofs/Erdos866Wip01OQ01.lean
@@ -1,0 +1,122 @@
+import Proofs.Erdos866Wip01
+
+/-
+# Erdős Problem #866 — the exact threshold `g_3(N) = 1` under the repeated-index definition
+
+## The problem
+
+For `k ≥ 3`, Erdős #866 asks for the minimal threshold `g_k(N)` such that **every**
+`A ⊆ {1,…,2N}` with `|A| ≥ N + g_k(N)` contains all pairwise sums `b_i + b_j` of some
+`k`-element family `b_1,…,b_k`.  The base file `Erdos866Problem.lean` formalizes a
+configuration as a map `b : Fin k → ℤ` (with `HasAllPairwiseSums A b` meaning every
+pairwise sum lands in `A`) and the file `Erdos866Wip01.lean` proves the lower bound
+`g_k(N) ≥ 1` uniformly in `k` via the parity construction (the `N` odd numbers force no
+configuration).
+
+## What this file proves
+
+This file establishes the **matching upper bound `g_3(N) ≤ 1`**, hence pins down the
+exact value
+
+  `g_3(N) = 1`
+
+*for the definition used in these files*, where the configuration map `b : Fin 3 → ℤ` is
+**not required to be injective**.  The mechanism is a single-element degeneracy:
+
+* `config_of_even_mem` — if `A` contains any **even** number `e`, then the constant family
+  `b ≡ e/2` has all three pairwise sums equal to `e ∈ A`, so `A` already admits a
+  3-configuration.
+* `exists_even_of_large` — any `A ⊆ {1,…,2N}` with `|A| ≥ N + 1` must contain an even
+  number (the `N` odd numbers cannot fit `N + 1` elements).
+* `config_of_large` / `guarantees_one` — combining the two, every `A ⊆ {1,…,2N}` of size
+  `≥ N + 1` admits a 3-configuration, i.e. `Guarantees N 3 1`.
+* `g_3_least_threshold` — with `Erdos866Wip01.g_k_ge_one`, the least guaranteeing
+  threshold is exactly `1`.
+
+## Honesty / scope
+
+The classical value of Erdős #866 for `k = 3` is `g_3(N) = 2`, established with a family
+of **three distinct** integers.  The value proved here is `1`, and the gap is *entirely*
+due to the relaxation in the base definition: a configuration `b : Fin 3 → ℤ` is allowed
+to be constant, so a lone even element `e` (via `b ≡ e/2`, whose three pairwise sums all
+equal `e`) is a valid — but degenerate — 3-configuration.  This file therefore does two
+honest things at once: it computes the *exact* threshold for the formalization actually in
+the gallery (`g_3 = 1`, upgrading the file's `≥ 1` to an equality), and it makes explicit,
+via `config_of_even_mem`, precisely why that formalization collapses the classical `2` to
+`1`.  Recovering the classical `g_3 = 2` requires strengthening `HasAllPairwiseSums` to
+demand an injective family; that is a genuinely harder statement and is not attempted here.
+
+Theorems: 6, Axioms: 0, Sorries: 0
+-/
+
+open Finset
+
+namespace Erdos866Wip01OQ01
+
+open Erdos866 Erdos866Wip01
+
+/-! ## The single-element degeneracy -/
+
+/-- **A lone even element already forms a 3-configuration.**  If `e ∈ A` is even, the
+constant family `b ≡ e/2 : Fin 3 → ℤ` has every pairwise sum equal to `e ∈ A`.  This is
+the mechanism collapsing the threshold to `1`: injectivity of `b` is *not* required, so no
+three *distinct* integers are needed. -/
+theorem config_of_even_mem {A : Finset ℕ} {e : ℕ} (he : e ∈ A) (heven : Even e) :
+    ∃ b : Fin 3 → ℤ, HasAllPairwiseSums A b := by
+  obtain ⟨m, hm⟩ := heven
+  refine ⟨fun _ => (m : ℤ), ?_⟩
+  intro i j _
+  have hval : ((m : ℤ) + (m : ℤ)).toNat = e := by omega
+  rw [hval]
+  exact he
+
+/-! ## Large sets contain an even number -/
+
+/-- Any `A ⊆ {1,…,2N}` with `|A| ≥ N + 1` contains an even number: otherwise `A` would be
+a subset of the `N` odd numbers and could not have `N + 1` elements. -/
+theorem exists_even_of_large {N : ℕ} {A : Finset ℕ} (hAsub : A ⊆ Erdos866.Interval N)
+    (hcard : N + 1 ≤ A.card) : ∃ e ∈ A, Even e := by
+  by_contra h
+  push_neg at h
+  have hsub : A ⊆ oddNumbers N := by
+    intro a ha
+    have haI := hAsub ha
+    have hodd : a % 2 = 1 := Nat.not_even_iff.mp (h a ha)
+    simp only [oddNumbers, Finset.mem_filter]
+    exact ⟨haI, hodd⟩
+  have hle := Finset.card_le_card hsub
+  rw [oddNumbers_card] at hle
+  omega
+
+/-! ## The upper bound `g_3(N) ≤ 1` -/
+
+/-- **Every `A ⊆ {1,…,2N}` of size `≥ N + 1` admits a 3-configuration.**  Such an `A`
+contains an even element `e` (`exists_even_of_large`), and `e` alone yields a configuration
+(`config_of_even_mem`). -/
+theorem config_of_large {N : ℕ} {A : Finset ℕ} (hAsub : A ⊆ Erdos866.Interval N)
+    (hcard : N + 1 ≤ A.card) : ∃ b : Fin 3 → ℤ, HasAllPairwiseSums A b := by
+  obtain ⟨e, he, heven⟩ := exists_even_of_large hAsub hcard
+  exact config_of_even_mem he heven
+
+/-- **`g_3(N) ≤ 1`.**  A threshold of `1` already guarantees a 3-configuration. -/
+theorem guarantees_one (N : ℕ) : Guarantees N 3 1 := by
+  intro A hAsub hcard
+  exact config_of_large hAsub (by omega)
+
+/-! ## The exact threshold `g_3(N) = 1` -/
+
+/-- **The least guaranteeing threshold for `k = 3` is exactly `1`.**  Combining the upper
+bound `guarantees_one` with the lower bound `Erdos866Wip01.g_k_ge_one`: `1` guarantees a
+configuration, and no smaller threshold does.  So `g_3(N) = 1` for the (non-injective)
+configuration definition used in these files. -/
+theorem g_3_least_threshold (N : ℕ) :
+    Guarantees N 3 1 ∧ ∀ g, Guarantees N 3 g → 1 ≤ g :=
+  ⟨guarantees_one N, fun _ hG => g_k_ge_one N (by norm_num) hG⟩
+
+/-- **`g_3(N) = 1` as a two-sided statement:** `1` guarantees a 3-configuration but `0`
+does not.  Compare the classical `g_3(N) = 2`, which requires an *injective* family; the
+drop to `1` is exactly the degeneracy exhibited by `config_of_even_mem`. -/
+theorem g_3_eq_one (N : ℕ) : Guarantees N 3 1 ∧ ¬ Guarantees N 3 0 :=
+  ⟨guarantees_one N, not_guarantees_zero N (by norm_num)⟩
+
+end Erdos866Wip01OQ01

--- a/research/problems/erdos-866-wip-01-oq-01/knowledge.md
+++ b/research/problems/erdos-866-wip-01-oq-01/knowledge.md
@@ -1,21 +1,42 @@
-# Knowledge Base: erdos-866-wip-01-oq-01
+# erdos-866-wip-01-oq-01 — exact threshold g_3(N)=1 under the repeated-index definition
 
-Insights accumulated during research on this problem.
+## Summary
 
----
+Erdős #866 threshold g_k(N): least g with |A| ≥ N+g ⇒ A ⊆ {1,…,2N} contains all
+pairwise sums of some k-family (b : Fin k → ℤ, `HasAllPairwiseSums`). The sibling
+`erdos-866-wip-01` proved the lower bound g_k(N) ≥ 1. This entry proves the matching
+UPPER bound for k=3, giving the exact value **g_3(N) = 1** — *for the gallery's
+definition*, where the family b is NOT required injective.
 
-## Problem Understanding
+## Session 2026-07-02 (Session 1) — FRESH, completed
 
-Seeker-selected OQ child of a gallery entry. See problem.md for the full statement, recommended approach, and Mathlib pointers.
+**Outcome:** completed, VERIFIED 0-axiom, 6 thm / 0 def / 122 L, new file
+`Proofs/Erdos866Wip01OQ01.lean`, new gallery entry.
 
----
+### Key mathematical finding
+The base predicate `HasAllPairwiseSums A b` uses `b : Fin k → ℤ` with **no injectivity
+requirement**, so a constant family `b ≡ e/2` is legal. Hence any even `e ∈ A` gives a
+3-configuration whose three pairwise sums all equal `e` (`config_of_even_mem`). Since
+every A ⊆ {1,…,2N} of size ≥ N+1 contains an even element (only N odds available,
+`exists_even_of_large`), the upper bound g_3 ≤ 1 follows (`guarantees_one`), and with
+`g_k_ge_one` the exact value is g_3(N) = 1 (`g_3_least_threshold`, `g_3_eq_one`).
 
-## Insights
+This is deliberately NOT the classical g_3(N) = 2 (which is defined with three DISTINCT
+integers). The entry proves the exact threshold for the gallery's own model and isolates,
+via `config_of_even_mem`, exactly why the missing injectivity collapses 2 to 1.
 
-[Insights from research attempts will be accumulated here]
+### Techniques
+- Constant/degenerate configuration to trivialize an existential.
+- Pigeonhole via `Finset.card_le_card` + `oddNumbers_card` for "large set has an even".
+- `omega` for the `Int.toNat` bookkeeping (`((m:ℤ)+(m:ℤ)).toNat = e` with `e = m+m`).
 
----
+### Files
+- proofs/Proofs/Erdos866Wip01OQ01.lean
+- src/data/proofs/erdos-866-wip-01-oq-01/{meta.json,annotations.json}
 
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+### Next steps (open questions generated)
+1. Strengthen `HasAllPairwiseSums` to require injective b; prove classical g_3(N) ≥ 2
+   (size-(N+1) construction with no injective 3-config).
+2. Prove classical upper bound g_3(N) ≤ 2 for injective families.
+3. Does the single-element degeneracy force g_k(N) = 1 for ALL k ≥ 3 under the current
+   (non-injective) definition? (Very likely yes — the same constant family works.)

--- a/src/data/proofs/erdos-866-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-866-wip-01-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-erdos866wip01oq01-header",
+    "proofId": "erdos-866-wip-01-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 3,
+      "endLine": 51
+    },
+    "title": "Erdős #866 and the exact threshold under the non-injective definition",
+    "content": "Erdős #866 asks for the least threshold g_k(N) with |A| ≥ N + g_k(N) ⇒ A ⊆ {1,…,2N} contains all pairwise sums of some k-family. The sibling entry erdos-866-wip-01 proves the lower bound g_k(N) ≥ 1. This file proves the MATCHING upper bound for k = 3, pinning g_3(N) = 1 for the configuration predicate actually used in the gallery — where the family b : Fin 3 → ℤ is NOT required to be injective. The docstring is explicit that this is NOT the classical g_3(N) = 2 (which needs three distinct integers): the drop to 1 comes entirely from a degenerate constant configuration, and the entry's job is both to compute the exact threshold for the gallery's own model AND to expose that modelling gap.",
+    "mathContext": "For $b : \\mathrm{Fin}\\,3 \\to \\mathbb{Z}$ not required injective, the exact threshold is $g_3(N) = 1$; the classical value (distinct integers) is $2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős problems",
+      "pairwise sums",
+      "threshold functions",
+      "injective vs arbitrary index families"
+    ],
+    "prerequisites": [
+      "additive combinatorics",
+      "Erdős #866 base and WIP entries"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01oq01-degeneracy",
+    "proofId": "erdos-866-wip-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 60,
+      "endLine": 71
+    },
+    "title": "config_of_even_mem: a lone even element is already a 3-configuration",
+    "content": "The technical heart of the upper bound and the entry's main mathematical observation. If e ∈ A is even, write e = m + m and take the CONSTANT family b ≡ (m : ℤ) : Fin 3 → ℤ. Every pairwise sum is b i + b j = m + m = e, and ((m:ℤ)+(m:ℤ)).toNat = e is closed by omega (which understands Int.toNat), so HasAllPairwiseSums A b holds. Crucially no three distinct integers are used — the base predicate permits b to be constant — which is exactly why a single even element suffices and the modelled threshold collapses from the classical 2 to 1.",
+    "mathContext": "$e$ even, $b_0=b_1=b_2=e/2 \\Rightarrow b_i+b_j = e \\in A$. Non-injectivity is essential.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "degenerate configuration",
+      "Int.toNat",
+      "omega",
+      "non-injective family"
+    ],
+    "prerequisites": [
+      "HasAllPairwiseSums (base file)",
+      "Even as e = m + m"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01oq01-even-large",
+    "proofId": "erdos-866-wip-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 75,
+      "endLine": 89
+    },
+    "title": "exists_even_of_large: large sets contain an even number",
+    "content": "Any A ⊆ Interval N with N + 1 ≤ |A| contains an even element. Proof by contradiction: if every a ∈ A is non-even, then a % 2 = 1 (Nat.not_even_iff), so A ⊆ oddNumbers N (the base file's odd-parity filter of the interval). Then Finset.card_le_card and oddNumbers_card give |A| ≤ N, contradicting N + 1 ≤ |A| via omega. This is the pure pigeonhole half of the upper bound: {1,…,2N} holds only N odd numbers, so any N+1 elements must include an even one.",
+    "mathContext": "$A \\subseteq \\mathrm{odd}(N) \\Rightarrow |A| \\le N$; so $|A| \\ge N+1 \\Rightarrow \\exists\\,e \\in A$ even.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole",
+      "Finset.card_le_card",
+      "Nat.not_even_iff",
+      "oddNumbers_card"
+    ],
+    "prerequisites": [
+      "oddNumbers as a filter of the interval (base file)"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01oq01-upper-bound",
+    "proofId": "erdos-866-wip-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 93,
+      "endLine": 104
+    },
+    "title": "config_of_large / guarantees_one: the upper bound g_3(N) ≤ 1",
+    "content": "config_of_large combines the two previous lemmas: a size-(N+1) set A ⊆ {1,…,2N} contains an even element (exists_even_of_large), which alone yields a 3-configuration (config_of_even_mem). guarantees_one repackages this as Guarantees N 3 1 — a threshold of 1 forces a configuration — i.e. the upper bound g_3(N) ≤ 1 in the WIP file's threshold vocabulary.",
+    "mathContext": "$|A| \\ge N+1 \\Rightarrow A$ has a 3-configuration $\\Rightarrow \\mathrm{Guarantees}\\,N\\,3\\,1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "upper bound",
+      "Guarantees predicate",
+      "configuration forcing"
+    ],
+    "prerequisites": [
+      "config_of_even_mem",
+      "exists_even_of_large"
+    ]
+  },
+  {
+    "id": "ann-erdos866wip01oq01-exact",
+    "proofId": "erdos-866-wip-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 108,
+      "endLine": 122
+    },
+    "title": "g_3_least_threshold / g_3_eq_one: the exact value g_3(N) = 1",
+    "content": "g_3_least_threshold combines the new upper bound (guarantees_one) with the WIP file's lower bound (g_k_ge_one) to state that the least guaranteeing threshold is exactly 1: Guarantees N 3 1 holds and any g with Guarantees N 3 g satisfies 1 ≤ g. g_3_eq_one gives the two-sided form: 1 forces a 3-configuration but 0 does not. Together they pin g_3(N) = 1 for the gallery's non-injective configuration model — an exact equality upgrading the sibling's '≥ 1' — explicitly contrasted with the classical g_3(N) = 2 for injective families.",
+    "mathContext": "$g_3(N) = 1$ for the non-injective definition; classical value with distinct integers is $2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exact threshold",
+      "least element",
+      "g_k_ge_one"
+    ],
+    "prerequisites": [
+      "guarantees_one",
+      "Erdos866Wip01.g_k_ge_one"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-866-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-866-wip-01-oq-01/meta.json
@@ -1,0 +1,210 @@
+{
+  "id": "erdos-866-wip-01-oq-01",
+  "title": "Erdős #866: the exact threshold g_3(N) = 1 under the repeated-index configuration definition",
+  "slug": "erdos-866-wip-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos866Wip01"
+    ],
+    "opens": [
+      "Finset",
+      "Erdos866",
+      "Erdos866Wip01"
+    ],
+    "namespace": "Erdos866Wip01OQ01",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos866Wip01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "The WIP entry erdos-866-wip-01 proves the lower bound g_k(N) ≥ 1 for the configuration predicate HasAllPairwiseSums (a family b : Fin k → ℤ whose pairwise sums all land in A). This follow-up proves the MATCHING upper bound for k = 3, pinning the exact value g_3(N) = 1 UNDER THAT DEFINITION. The mechanism is a single-element degeneracy: because b is not required to be injective, any even element e ∈ A yields the constant configuration b ≡ e/2 whose three pairwise sums all equal e (config_of_even_mem); and every A ⊆ {1,…,2N} of size ≥ N+1 must contain an even number (exists_even_of_large), so |A| ≥ N+1 already forces a 3-configuration (guarantees_one). Hence g_3(N) = 1 (g_3_least_threshold, g_3_eq_one). This is deliberately NOT the classical g_3(N) = 2, which needs three DISTINCT integers; the entry proves the exact threshold for the gallery's own (non-injective) formalization and makes explicit — via config_of_even_mem — exactly why that formalization collapses the classical 2 to 1.",
+  "meta": {
+    "author": "Lean Genius researchers (2026)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos866Wip01OQ01.lean",
+    "tags": [
+      "erdos-problems",
+      "additive-combinatorics",
+      "pairwise-sums",
+      "parity-argument",
+      "exact-threshold",
+      "upper-bound",
+      "pigeonhole",
+      "combinatorics",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "The main conjecture of Erdős #866 (the exact growth of g_k(N) for k ≥ 4) remains OPEN and is untouched here. All six Lean declarations are fully machine-checked and depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound), confirmed via #print axioms — no axiom declarations, no structure-encoded assumptions, no sorries. IMPORTANT SCOPE NOTE: the value g_3(N) = 1 proved here is the exact threshold for the configuration predicate HasAllPairwiseSums as defined in the base files, where the family b : Fin 3 → ℤ is NOT required to be injective. The CLASSICAL value from the literature is g_3(N) = 2, which is defined with three DISTINCT integers; the drop to 1 is caused entirely by the degenerate constant configuration b ≡ e/2 (its three pairwise sums all equal a single even element e), exhibited by config_of_even_mem. This entry therefore does not claim the classical 2, nor does it resolve the open problem; per gallery policy an entry attached to an open Erdős problem is marked 'axiomatized'.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.not_even_iff",
+        "description": "¬ Even n ↔ n % 2 = 1, used to place every non-even element of A into the odd numbers",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Finset.card_le_card",
+        "description": "Monotonicity of cardinality under subset (A ⊆ oddNumbers N ⇒ |A| ≤ N)",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Erdos866.oddNumbers_card",
+        "description": "The odd numbers in {1,…,2N} number exactly N (reused from the base file to bound |A|)",
+        "module": "Proofs.Erdos866Problem"
+      },
+      {
+        "theorem": "Erdos866Wip01.Guarantees",
+        "description": "Threshold predicate: every A of size ≥ N+g forces a k-configuration (reused from the WIP file)",
+        "module": "Proofs.Erdos866Wip01"
+      },
+      {
+        "theorem": "Erdos866Wip01.g_k_ge_one",
+        "description": "The lower bound g_k(N) ≥ 1, combined here with the new upper bound to obtain the exact value",
+        "module": "Proofs.Erdos866Wip01"
+      }
+    ],
+    "additionalFiles": [
+      "Proofs/Erdos866Problem.lean",
+      "Proofs/Erdos866Wip01.lean"
+    ],
+    "originalContributions": [
+      "config_of_even_mem: the single-element degeneracy — any even e ∈ A yields a 3-configuration via the constant family b ≡ e/2, whose three pairwise sums all equal e. This is the exact mechanism by which the non-injective definition collapses the classical threshold, and it is the technical heart of the upper bound.",
+      "exists_even_of_large: every A ⊆ {1,…,2N} with |A| ≥ N+1 contains an even number, proved by contradiction — otherwise A ⊆ oddNumbers N, forcing |A| ≤ N via Finset.card_le_card and oddNumbers_card.",
+      "config_of_large / guarantees_one: the matching upper bound g_3(N) ≤ 1 — every A of size ≥ N+1 admits a 3-configuration, hence Guarantees N 3 1.",
+      "g_3_least_threshold / g_3_eq_one: the exact value g_3(N) = 1 under this definition, obtained by combining the new upper bound with the WIP file's lower bound g_k_ge_one — 1 guarantees a configuration and 0 does not."
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #866 asks for the threshold g_k(N) beyond size N that forces a dense subset of {1,…,2N} to contain all pairwise sums of some k-element family. The known landscape is non-uniform: the classical value g_3 = 2, g_4 ≤ 2032, g_5 ≍ log N, g_6 ≍ √N. The sibling entry erdos-866-wip-01 proves the trivial uniform lower bound g_k ≥ 1 via the odd numbers. This entry closes the k = 3 case for the formalization actually used in the gallery — but that formalization models a k-configuration as an arbitrary map b : Fin k → ℤ, not an injective one, and this relaxation turns out to change the exact threshold.",
+    "problemStatement": "Determine the exact threshold g_3(N) for the predicate HasAllPairwiseSums used in the base files, where a 3-configuration of A is a map b : Fin 3 → ℤ (not required injective) with all three pairwise sums b_i + b_j ∈ A. Prove both the upper bound (every A ⊆ {1,…,2N} of size ≥ N+1 has such a configuration) and combine it with the known lower bound.",
+    "proofStrategy": "The upper bound rests on a degeneracy: if e ∈ A is even, the CONSTANT family b ≡ e/2 : Fin 3 → ℤ has every pairwise sum equal to e ∈ A, so A already has a 3-configuration (config_of_even_mem; the value ((e/2)+(e/2)).toNat = e is discharged by omega). Then any A ⊆ {1,…,2N} with |A| ≥ N+1 must contain an even element, since otherwise A ⊆ oddNumbers N would give |A| ≤ N (exists_even_of_large, by Finset.card_le_card and oddNumbers_card). Combining, every size-(N+1) set has a configuration (config_of_large, guarantees_one : Guarantees N 3 1). With the WIP file's g_k_ge_one, the least guaranteeing threshold is exactly 1 (g_3_least_threshold), equivalently 1 forces a configuration while 0 does not (g_3_eq_one).",
+    "keyInsights": [
+      "**Non-injectivity collapses the threshold.** The classical g_3 = 2 counts three DISTINCT integers. The base definition allows b : Fin 3 → ℤ to be constant, and a constant family b ≡ e/2 turns a single even element e into a full 3-configuration (its three pairwise sums all equal e). So the modelled threshold drops from the classical 2 to 1. This is the entry's main mathematical observation, isolated in config_of_even_mem.",
+      "**The upper bound is a counting argument.** Once one even element suffices for a configuration, forcing a configuration reduces to forcing an even element, which is pure pigeonhole: only N odd numbers live in {1,…,2N}, so any N+1 of them include an even one.",
+      "**Exactness, honestly scoped.** Combining the new upper bound with the sibling's lower bound gives an EXACT value g_3(N) = 1 for the gallery's definition — a genuine upgrade of the '≥ 1' bound to an equality — while the entry is explicit that this is not the classical 2 and does not resolve the open growth question for k ≥ 4.",
+      "**omega handles the Int.toNat bookkeeping.** Writing the even element as e = m + m, the configuration value ((m:ℤ)+(m:ℤ)).toNat = e is a linear Int/Nat fact closed in a single omega call, so config_of_even_mem is a three-line proof."
+    ],
+    "prerequisites": [
+      "Erdős Problem #866 and the threshold function g_k(N) (base entry erdos-866, sibling erdos-866-wip-01)",
+      "The distinction between injective and arbitrary index families in a combinatorial configuration",
+      "Finset cardinality/pigeonhole in Lean (Mathlib)",
+      "Int.toNat and parity as handled by omega"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "config_of_even_mem",
+      "type": "theorem",
+      "description": "If e ∈ A is even then ∃ b : Fin 3 → ℤ, HasAllPairwiseSums A b — the constant family b ≡ e/2 has all three pairwise sums equal to e. The degeneracy driving the threshold down to 1."
+    },
+    {
+      "name": "exists_even_of_large",
+      "type": "theorem",
+      "description": "Every A ⊆ Interval N with N+1 ≤ |A| contains an even number: otherwise A ⊆ oddNumbers N would force |A| ≤ N."
+    },
+    {
+      "name": "config_of_large",
+      "type": "theorem",
+      "description": "Every A ⊆ {1,…,2N} of size ≥ N+1 admits a 3-configuration, by combining exists_even_of_large with config_of_even_mem."
+    },
+    {
+      "name": "guarantees_one",
+      "type": "theorem",
+      "description": "Guarantees N 3 1 — a threshold of 1 forces a 3-configuration. The upper bound g_3(N) ≤ 1."
+    },
+    {
+      "name": "g_3_least_threshold",
+      "type": "theorem",
+      "description": "Guarantees N 3 1 ∧ ∀ g, Guarantees N 3 g → 1 ≤ g — the least guaranteeing threshold is exactly 1, i.e. g_3(N) = 1 for this configuration definition."
+    },
+    {
+      "name": "g_3_eq_one",
+      "type": "theorem",
+      "description": "Guarantees N 3 1 ∧ ¬ Guarantees N 3 0 — the two-sided statement of g_3(N) = 1: 1 forces a configuration, 0 does not. Contrast the classical g_3(N) = 2 for injective families."
+    }
+  ],
+  "references": [
+    {
+      "type": "problem-database",
+      "citation": "Erdős Problem #866, the Erdős Problems database (https://www.erdosproblems.com/866).",
+      "relevance": "The source problem, whose classical value g_3(N) = 2 is contrasted with the value g_3(N) = 1 proved here for the non-injective formalization."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Data.Finset.Card\", \"Mathlib.Algebra.Parity\", and the omega decision procedure. (accessed 2026)",
+      "relevance": "Finset cardinality/pigeonhole, Nat.not_even_iff, and omega (handling Int.toNat and parity) used for the upper-bound argument."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "File Header and Scope",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring stating Erdős #866, the threshold g_k(N), and precisely what is proved: the exact value g_3(N) = 1 for the base files' non-injective configuration predicate, with an explicit honesty note distinguishing this from the classical g_3 = 2 (which needs three distinct integers) and locating the discrepancy in the single-element degeneracy. Imports the WIP file and opens Finset, Erdos866, Erdos866Wip01.",
+      "mathContext": "For the predicate $\\mathrm{HasAllPairwiseSums}$ with $b : \\mathrm{Fin}\\,3 \\to \\mathbb{Z}$ not required injective, the exact threshold is $g_3(N) = 1$, versus the classical $2$."
+    },
+    {
+      "id": "degeneracy",
+      "title": "The single-element degeneracy",
+      "startLine": 58,
+      "endLine": 71,
+      "summary": "config_of_even_mem: any even e ∈ A yields the constant configuration b ≡ e/2 whose three pairwise sums all equal e. Writing e = m + m, the value ((m:ℤ)+(m:ℤ)).toNat = e is closed by omega.",
+      "mathContext": "A lone even element $e$ gives $b_0=b_1=b_2=e/2$ with $b_i+b_j=e\\in A$ — no distinct integers required."
+    },
+    {
+      "id": "even-large",
+      "title": "Large sets contain an even number",
+      "startLine": 73,
+      "endLine": 89,
+      "summary": "exists_even_of_large: any A ⊆ Interval N with |A| ≥ N+1 contains an even number, by contradiction — otherwise A ⊆ oddNumbers N and |A| ≤ N via Finset.card_le_card and oddNumbers_card.",
+      "mathContext": "Only $N$ odd numbers live in $\\{1,\\dots,2N\\}$, so any $N+1$ elements include an even one."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The upper bound g_3(N) ≤ 1",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "config_of_large combines the even-element lemma with the degeneracy to give a 3-configuration for any size-(N+1) set; guarantees_one packages this as Guarantees N 3 1.",
+      "mathContext": "$|A| \\ge N+1 \\Rightarrow A$ has a 3-configuration, i.e. $g_3(N) \\le 1$."
+    },
+    {
+      "id": "exact",
+      "title": "The exact threshold g_3(N) = 1",
+      "startLine": 106,
+      "endLine": 122,
+      "summary": "g_3_least_threshold and g_3_eq_one combine the new upper bound with the WIP file's g_k_ge_one to pin the least guaranteeing threshold at exactly 1 — 1 forces a configuration, 0 does not.",
+      "mathContext": "$g_3(N) = 1$ for the non-injective definition, contrasted with the classical $g_3(N) = 2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves the matching upper bound g_3(N) ≤ 1 for the configuration predicate used in erdos-866 and erdos-866-wip-01, and combines it with the sibling's lower bound to obtain the exact value g_3(N) = 1 under that definition. The upper bound hinges on a single-element degeneracy: because the configuration family b : Fin 3 → ℤ need not be injective, any even element e ∈ A gives the constant configuration b ≡ e/2, and any set of size ≥ N+1 in {1,…,2N} contains an even element. All six declarations are axiom-free and sorry-free.",
+    "implications": "The result upgrades the sibling's '≥ 1' bound to an exact equality for k = 3, and — more importantly — isolates precisely why the gallery's formalization yields 1 rather than the classical 2: the missing injectivity requirement. This is a concrete, machine-checked caveat about the modelling choice, and it points to the exact definitional change (injective families) needed to state and pursue the classical g_3 = 2.",
+    "openQuestions": [
+      "Strengthen HasAllPairwiseSums to require an injective family b and prove the classical lower bound g_3(N) ≥ 2 by exhibiting a size-(N+1) set with no injective 3-configuration.",
+      "Prove the classical upper bound g_3(N) ≤ 2 (every A ⊆ {1,…,2N} of size ≥ N+2 contains an injective 3-configuration), completing the classical g_3(N) = 2.",
+      "Characterize, for the non-injective definition, the exact threshold g_k(N) for k ≥ 4 — does the same single-element degeneracy force g_k(N) = 1 for all k ≥ 3?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-866-wip-01",
+      "relationship": "parent-problem",
+      "description": "The WIP entry proving the lower bound g_k(N) ≥ 1. Its Guarantees predicate and g_k_ge_one lemma are reused here; this entry adds the matching upper bound for k = 3."
+    },
+    {
+      "targetId": "erdos-866",
+      "relationship": "related",
+      "description": "The base Erdős #866 entry supplying the definitions Interval, oddNumbers, HasAllPairwiseSums and the count oddNumbers_card used in the upper-bound argument."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **matching upper bound `g_3(N) ≤ 1`** for the `HasAllPairwiseSums` configuration predicate used in `erdos-866` / `erdos-866-wip-01`, pinning the **exact value `g_3(N) = 1`** for that formalization. New gallery entry `erdos-866-wip-01-oq-01`, new file `Proofs/Erdos866Wip01OQ01.lean` (imports `Proofs.Erdos866Wip01`).

The sibling `erdos-866-wip-01` proved the lower bound `g_k(N) ≥ 1`; this closes the `k = 3` case to an exact equality.

## Mechanism — and an honest finding

The base predicate `HasAllPairwiseSums A b` uses `b : Fin k → ℤ` with **no injectivity requirement**. So:

- `config_of_even_mem` — any **even** `e ∈ A` yields the *constant* configuration `b ≡ e/2`, whose three pairwise sums all equal `e ∈ A`.
- `exists_even_of_large` — every `A ⊆ {1,…,2N}` of size `≥ N+1` contains an even element (only `N` odd numbers fit; pigeonhole).
- `config_of_large` / `guarantees_one` — hence every size-`(N+1)` set has a 3-configuration: `Guarantees N 3 1`.
- `g_3_least_threshold` / `g_3_eq_one` — with the sibling's `g_k_ge_one`, the least guaranteeing threshold is exactly `1`.

**Scope note (in the entry's `assumptions`):** this is deliberately **not** the classical `g_3(N) = 2`, which is defined with three **distinct** integers. The drop from `2` to `1` is caused entirely by the missing injectivity, and `config_of_even_mem` isolates exactly that degeneracy. The entry both computes the exact threshold for the gallery's own model *and* documents the modelling gap; it does not claim to resolve the open Erdős #866 growth question.

## Verification

- `#print axioms` on the headline theorems lists only `propext`, `Classical.choice`, `Quot.sound` (foundational — do not count). No `axiom` declarations, no structure-encoded assumptions, no `sorry`, no `native_decide`.
- Built via `lake env lean` against warm Mathlib oleans (v4.26.0). 6 theorems, 0 definitions, 122 lines.
- `annotations:build` resolves all 5 annotations for this slug with no errors.

Marked `axiomatized`/`badge: axiom` per gallery policy for entries attached to an open Erdős problem (consistent with the sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)