### PR TITLE
Enrich Blichfeldt/Minkowski OQ-03 (minkowski-fundamental-theorem-oq-03): annotate flagship theorem statement

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03/annotations.json
@@ -2,49 +2,123 @@
   {
     "id": "ann-header",
     "proofId": "minkowski-fundamental-theorem-oq-03",
-    "range": { "startLine": 1, "endLine": 43 },
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
     "type": "concept",
     "title": "True Blichfeldt versus the parent's van der Corput statement",
     "content": "The header states the honest general-multiplicity Blichfeldt theorem and flags a correction to the parent entry. Blichfeldt (1914): for ANY bounded measurable set s with μs > k·covolume there are k+1 points of s pairwise congruent mod the lattice L — no convexity, no symmetry, no 2ⁿ factor. The parent's blichfeldt_statement instead assumes s convex and symmetric with μs > k·2ⁿ·covolume and concludes k+1 LATTICE POINTS lie in s; that is van der Corput's theorem, a distinct result. At k = 1 the theorem here is exactly Mathlib's exists_pair_mem_lattice_not_disjoint_vadd.",
     "mathContext": "$k\\cdot\\mu F < \\mu s \\Rightarrow \\exists\\,T\\subseteq L,\\ k<\\#T,\\ \\exists z\\ \\forall l\\in T,\\ z\\in l+ᵥs.$",
     "significance": "supporting",
-    "relatedConcepts": ["geometry of numbers", "Blichfeldt principle", "van der Corput theorem", "fundamental domain", "covolume"],
-    "prerequisites": ["lattices and covolume", "measure of a set", "congruence modulo a subgroup"]
+    "relatedConcepts": [
+      "geometry of numbers",
+      "Blichfeldt principle",
+      "van der Corput theorem",
+      "fundamental domain",
+      "covolume"
+    ],
+    "prerequisites": [
+      "lattices and covolume",
+      "measure of a set",
+      "congruence modulo a subgroup"
+    ]
   },
   {
     "id": "ann-extraction",
     "proofId": "minkowski-fundamental-theorem-oq-03",
-    "range": { "startLine": 54, "endLine": 86 },
+    "range": {
+      "startLine": 54,
+      "endLine": 86
+    },
     "type": "tactic",
     "title": "Finite extraction from an over-large tsum",
     "content": "The combinatorial pigeonhole core. Given a family f : ι → ℝ≥0∞ with every f i ≤ 1 and k < ∑' i, f i, we produce a finite set with more than k nonzero terms. Rewriting the tsum as the supremum of its finite partial sums (ENNReal.tsum_eq_iSup_sum) and using lt_iSup_iff yields a finite u with k < ∑_{i∈u} f i. Filtering u to the support {i : f i ≠ 0} preserves the sum (Finset.sum_filter_of_ne), and the filtered sum is bounded by its cardinality because each term is ≤ 1. Hence k < #T with f nonzero on all of T; a cast (exact_mod_cast) transfers the strict inequality from ℝ≥0∞ back to ℕ.",
     "mathContext": "$k<\\sum_{i\\in u} f_i = \\sum_{i\\in T} f_i \\le \\#T$ where $T=\\{i\\in u: f_i\\ne 0\\}$.",
     "significance": "key",
-    "relatedConcepts": ["pigeonhole principle", "unconditional sums in ℝ≥0∞", "supremum of partial sums", "Finset.filter"],
-    "prerequisites": ["tsum as iSup of finite sums", "sum bounded by cardinality"]
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "unconditional sums in ℝ≥0∞",
+      "supremum of partial sums",
+      "Finset.filter"
+    ],
+    "prerequisites": [
+      "tsum as iSup of finite sums",
+      "sum bounded by cardinality"
+    ]
+  },
+  {
+    "id": "ann-statement",
+    "proofId": "minkowski-fundamental-theorem-oq-03",
+    "range": {
+      "startLine": 92,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "exists_finset_lattice_common_vadd: the general-multiplicity Blichfeldt theorem",
+    "content": "The flagship statement this entry contributes — the honest general-k Blichfeldt principle. Hypotheses: L is a countable additive group acting on the measure space E with a measure-invariant action (VAddInvariantMeasure), F is an additive fundamental domain for L, s is null-measurable, and the volume beats k copies of the covolume, k • μ F < μ s. Conclusion: there is a finite set T ⊆ L with k < #T and a single point z lying in every translate l +ᵥ s for l ∈ T. Equivalently the #T points {z} − T all sit in s and are pairwise congruent modulo L, i.e. more than k points of s are congruent mod L. Specializing to k = 1 recovers Mathlib's exists_pair_mem_lattice_not_disjoint_vadd (the two-point Blichfeldt principle). Unlike the parent entry's van der Corput form (convex, symmetric, 2ⁿ factor, producing lattice points), this needs no convexity, symmetry, or 2ⁿ factor — only measurability — which is what makes it the true Blichfeldt theorem.",
+    "mathContext": "$k\\cdot\\mu F<\\mu s\\ \\Longrightarrow\\ \\exists\\,T\\subseteq L,\\ k<\\#T\\ \\wedge\\ \\exists z,\\ \\forall l\\in T,\\ z\\in l+_{v}s$; equivalently more than $k$ points of $s$ are congruent mod $L$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Blichfeldt's theorem",
+      "geometry of numbers",
+      "fundamental domain and covolume",
+      "lattice packing multiplicity",
+      "VAddInvariantMeasure",
+      "Minkowski's convex-body theorem"
+    ],
+    "prerequisites": [
+      "additive fundamental domains (IsAddFundamentalDomain)",
+      "null-measurable sets",
+      "measure of a set as a tsum over the lattice (measure_eq_tsum)",
+      "translation-invariant measures"
+    ]
   },
   {
     "id": "ann-averaging",
     "proofId": "minkowski-fundamental-theorem-oq-03",
-    "range": { "startLine": 108, "endLine": 118 },
+    "range": {
+      "startLine": 108,
+      "endLine": 118
+    },
     "type": "tactic",
     "title": "The covering-count averaging identity",
     "content": "The measure-theoretic heart: the covering count g(z) = ∑' l, 𝟙_{l+ᵥs}(z) integrates over the fundamental domain F to exactly μ s. Tonelli for nonnegative functions (lintegral_tsum) swaps ∫_F and ∑'; each translate l +ᵥ s is null-measurable by invariance of μ (NullMeasurableSet.vadd), transferred to μ.restrict F via mono_ac. The integral of a {0,1}-indicator over F is the restricted measure (lintegral_indicator_one₀, restrict_apply₀'), i.e. μ((l+ᵥs)∩F), and summing these is μ s by the fundamental-domain decomposition IsAddFundamentalDomain.measure_eq_tsum.",
     "mathContext": "$\\int_F \\sum_{l}\\mathbf 1_{l+ᵥs}\\,d\\mu = \\sum_l \\mu((l+ᵥs)\\cap F) = \\mu s.$",
     "significance": "key",
-    "relatedConcepts": ["Tonelli theorem", "fundamental domain decomposition", "translation-invariant measure", "indicator integral"],
-    "prerequisites": ["Lebesgue integral of a countable sum", "measure of translates", "null-measurable sets"]
+    "relatedConcepts": [
+      "Tonelli theorem",
+      "fundamental domain decomposition",
+      "translation-invariant measure",
+      "indicator integral"
+    ],
+    "prerequisites": [
+      "Lebesgue integral of a countable sum",
+      "measure of translates",
+      "null-measurable sets"
+    ]
   },
   {
     "id": "ann-pigeonhole",
     "proofId": "minkowski-fundamental-theorem-oq-03",
-    "range": { "startLine": 119, "endLine": 136 },
+    "range": {
+      "startLine": 119,
+      "endLine": 136
+    },
     "type": "tactic",
     "title": "Pigeonhole and extraction of the over-covered family",
     "content": "If g(z) ≤ k for every z, then μ s = ∫_F g ≤ ∫_F k = k·μF (lintegral_mono, setLIntegral_const, nsmul_eq_mul), contradicting the hypothesis k • μF < μs; so some z has k < g(z). Since each indicator is ≤ 1 (Set.indicator_apply), the finite-extraction lemma yields a finite T ⊆ L with k < #T and every term nonzero. A nonzero indicator value forces membership (Set.indicator_apply_ne_zero), giving z ∈ l +ᵥ s for all l ∈ T — the required over-covering family.",
     "mathContext": "$\\forall z,\\ g(z)\\le k \\Rightarrow \\mu s \\le k\\mu F$; contradiction $\\Rightarrow \\exists z,\\ k<g(z)$.",
     "significance": "key",
-    "relatedConcepts": ["monotonicity of the Lebesgue integral", "constant integral over a set", "proof by contradiction", "indicator support"],
-    "prerequisites": ["∫_F c = c·μF", "indicator nonzero ⇒ membership"]
+    "relatedConcepts": [
+      "monotonicity of the Lebesgue integral",
+      "constant integral over a set",
+      "proof by contradiction",
+      "indicator support"
+    ],
+    "prerequisites": [
+      "∫_F c = c·μF",
+      "indicator nonzero ⇒ membership"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotate the flagship theorem statement

**Entry:** `minkowski-fundamental-theorem-oq-03` — Blichfeldt's general-multiplicity generalization of Minkowski's fundamental theorem.

The gallery entry previously annotated the module overview and the three proof-internal tactic steps, but the **statement of the flagship theorem this entry contributes — `exists_finset_lattice_common_vadd`** — was left uncovered (lines 88–107, the `namespace MeasureTheory` re-entry, `variable` block, the theorem's doc-comment, and its full signature).

This pass adds one `theorem`-type annotation (`ann-statement`, lines 92–107) covering that statement:
- Spells out the hypotheses (countable additive group `L`, measure-invariant action, additive fundamental domain `F`, null-measurable `s`, and the volume hypothesis `k • μ F < μ s`) and the conclusion (finite `T ⊆ L` with `k < #T` and a common covered point `z`).
- Notes the `k = 1` specialization to Mathlib's `exists_pair_mem_lattice_not_disjoint_vadd`.
- Contrasts with the parent entry's van der Corput form (no convexity/symmetry/`2ⁿ` factor here).

**Coverage:** annotated lines rise from 77% to ~91% of the Lean file. Annotation anchors on the theorem's doc-comment (validated); JSON is well-formed. `meta.json` unchanged.
