### PR TITLE
Enrich Central Binomial Asymptotic (chebyshev-bounds-oq-06-oq-01): annotation coverage

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-01/annotations.json
@@ -24,27 +24,74 @@
     ]
   },
   {
+    "id": "ann-chebo0601-imports",
+    "proofId": "chebyshev-bounds-oq-06-oq-01",
+    "range": {
+      "startLine": 37,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Imports, namespaces, and the two load-bearing dependencies",
+    "content": "The proof rests on exactly two Mathlib modules. Mathlib.Analysis.SpecialFunctions.Stirling supplies the sole analytic input, factorial_isEquivalent_stirling (n! ~ √(2πn)·(n/e)ⁿ); Mathlib.Data.Nat.Choose.Central supplies Nat.centralBinom and the identity centralBinom n = (2n).choose n. The `open Real Filter Asymptotics` line brings π, sqrt, exp, the atTop filter, and the IsEquivalent (~[·]) notation into scope, and `open scoped Nat` enables the `n !` factorial and `!`/choose notation. No numerics, no `native_decide`, and no additional axioms are imported — everything downstream is IsEquivalent algebra over these two facts.",
+    "mathContext": "Dependencies: $n! \\sim \\sqrt{2\\pi n}\\,(n/e)^n$ (Stirling) and $\\binom{2n}{n} = \\binom{2n}{n}$ with $\\mathrm{centralBinom}\\,n = \\binom{2n}{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Mathlib.Analysis.SpecialFunctions.Stirling",
+      "Mathlib.Data.Nat.Choose.Central",
+      "Asymptotics.IsEquivalent notation ~[l]",
+      "atTop filter"
+    ],
+    "prerequisites": [
+      "Lean 4 import/open mechanics",
+      "Mathlib's Filter and Asymptotics namespaces"
+    ]
+  },
+  {
     "id": "ann-chebo0601-main",
     "proofId": "chebyshev-bounds-oq-06-oq-01",
     "range": {
       "startLine": 45,
-      "endLine": 117
+      "endLine": 77
     },
     "type": "theorem",
-    "title": "centralBinom_isEquivalent_four_pow_div_sqrt: C(2n,n) ~ 4ⁿ/√(πn)",
-    "content": "The main theorem and its proof. The strategy is transport-and-collapse. Let S(n) = √(2πn)·(n/e)ⁿ be Mathlib's Stirling approximant, so H : n! ~ S n. (1) The numerator (2n)! ~ S(2n) is obtained by IsEquivalent.comp_tendsto, transporting H along the map n ↦ 2n (which tends to ∞); no separate asymptotic for (2n)! is needed. (2) The denominator n!·n! ~ S n·S n by IsEquivalent.mul. (3) The exact cast identity C(2n,n) = (2n)!/(n!·n!) comes from Nat.choose_mul_factorial_mul_factorial (with 2n−n = n), lifted to ℝ via eq_div_iff and exact_mod_cast. (4) IsEquivalent.div chains numerator and denominator, reducing the goal to a pointwise identity S(2n)/(S n)² = 4ⁿ/√(πn) for n ≥ 1. That residual identity is pure field algebra: √(4πn) = 2√(πn) via Real.sqrt_sq on (2s)² with s = √(πn); (2n/e)^{2n} = 2^{2n}·(n/e)^{2n} = 4ⁿ·(n/e)^{2n} via mul_pow and pow_mul; and (√(2πn))² = 2πn = 2s² via Real.sq_sqrt. The exponential factor P = (n/e)^{2n} and one power of s cancel under field_simp; ring closes.",
-    "mathContext": "$\\dfrac{S(2n)}{S(n)^2}=\\dfrac{\\sqrt{4\\pi n}\\,(2n/e)^{2n}}{(2\\pi n)\\,(n/e)^{2n}}=\\dfrac{2\\sqrt{\\pi n}\\cdot 4^n}{2\\pi n}=\\dfrac{4^n}{\\sqrt{\\pi n}}.$",
+    "title": "centralBinom_isEquivalent_four_pow_div_sqrt: transport Stirling to numerator and denominator",
+    "content": "The main theorem statement and the first half of its proof — the transport-and-combine phase. Let S(n) = √(2πn)·(n/e)ⁿ be Mathlib's Stirling approximant, so H : n! ~ S n. (1) The numerator (2n)! ~ S(2n) is obtained by IsEquivalent.comp_tendsto, transporting H along the map n ↦ 2n (which tends to ∞ via hk); crucially, no separate asymptotic for (2n)! is proved — the same equivalence is re-indexed. (2) The denominator n!·n! ~ S n·S n by IsEquivalent.mul (H.mul H). (3) The exact cast identity C(2n,n) = (2n)!/(n!·n!) comes from Nat.choose_mul_factorial_mul_factorial (with 2n−n = n), lifted to ℝ via eq_div_iff and exact_mod_cast — this is an equality of naturals cast up, not an approximation. (4) IsEquivalent.div then chains numerator and denominator, and trans_eventuallyEq reduces the whole goal to a single pointwise identity S(2n)/(S n)² = 4ⁿ/√(πn) valid for n ≥ 1, discharged in the next block.",
+    "mathContext": "$\\dbinom{2n}{n} = \\dfrac{(2n)!}{(n!)^2}\\ \\sim\\ \\dfrac{S(2n)}{S(n)^2}$ where $S(n)=\\sqrt{2\\pi n}\\,(n/e)^n$; obtained from $\\text{(numerator)}\\sim S(2n)$, $\\text{(denominator)}\\sim S(n)^2$ by $\\texttt{.div}$.",
     "significance": "critical",
     "relatedConcepts": [
-      "IsEquivalent.comp_tendsto",
+      "IsEquivalent.comp_tendsto (re-indexing an equivalence)",
       "IsEquivalent.div and IsEquivalent.mul",
-      "Real.sq_sqrt / Real.sqrt_sq",
-      "field_simp / ring closing an exact identity"
+      "Nat.choose_mul_factorial_mul_factorial",
+      "trans_eventuallyEq (reduce ~ to a pointwise identity)"
     ],
     "prerequisites": [
       "Mathlib's Asymptotics.IsEquivalent algebra",
-      "Nat.choose_mul_factorial_mul_factorial",
-      "manipulating √ and integer powers over ℝ"
+      "Tendsto and the atTop filter",
+      "casting Nat identities to ℝ"
+    ]
+  },
+  {
+    "id": "ann-chebo0601-collapse",
+    "proofId": "chebyshev-bounds-oq-06-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "The algebraic collapse: S(2n)/(S n)² = 4ⁿ/√(πn)",
+    "content": "The residual pointwise identity, for n ≥ 1, is pure field algebra with no analysis left. Three cancellations do the work. (i) The numerator square-root simplifies: √(2·(2n)·π) = 2s where s = √(πn), proved by writing 2·(2n)·π = (2s)² and applying Real.sqrt_sq. (ii) The numerator exponential factors as (2n/e)^{2n} = 4ⁿ·(n/e)^{2n} = 4ⁿ·P, via (2n/e) = 2·(n/e), mul_pow, and pow_mul giving 2^{2n} = 4ⁿ. (iii) The denominator collapses: (√(2πn))² = 2s² by Real.sq_sqrt and (n/e)ⁿ·(n/e)ⁿ = P by pow_add. After rewriting, the goal is 2s·(4ⁿ·P) / (2s²·P) = 4ⁿ/s; the exponential P and one factor of s cancel, and field_simp closes it. This is where the transcendental π survives — as the lone √(πn) left after 2√(πn) from the numerator is divided by the 2πn from the squared denominator.",
+    "mathContext": "$\\dfrac{S(2n)}{S(n)^2}=\\dfrac{\\sqrt{4\\pi n}\\,(2n/e)^{2n}}{(2\\pi n)\\,(n/e)^{2n}}=\\dfrac{2\\sqrt{\\pi n}\\cdot 4^n\\,P}{2\\pi n\\,P}=\\dfrac{4^n}{\\sqrt{\\pi n}},\\quad P=(n/e)^{2n}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sq_sqrt / Real.sqrt_sq",
+      "mul_pow and pow_mul (splitting (2n/e)^{2n})",
+      "field_simp closing an exact identity",
+      "the constant π surviving as √(πn)"
+    ],
+    "prerequisites": [
+      "manipulating √ and integer powers over ℝ",
+      "field_simp / ring normalisation",
+      "positivity side goals for √ and division"
     ]
   },
   {


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-06-oq-01` (C(2n,n) ~ 4ⁿ/√(πn)).

**What changed** — `annotations.json` only (meta.json already rich and within size caps):
- Split the single 73-line main-proof annotation (45–117) into two focused, non-overlapping pieces aligned with the existing `sections`:
  - **45–77** — statement + *transport* phase (comp_tendsto re-indexes Stirling to (2n)!, .mul for the denominator, exact cast identity, .div to combine, reduction to a pointwise identity).
  - **78–117** — the *algebraic collapse* S(2n)/(S n)² = 4ⁿ/√(πn) by field algebra, including where the transcendental π survives as √(πn).
- Added a new annotation for the previously-uncovered **import/setup block (37–43)**, documenting the two load-bearing Mathlib modules (Stirling, Central binomial).

Coverage now spans the full file with **5 annotations (was 3)**, each carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. All `type`/`significance` values are canonical enums; ranges are non-overlapping. No axiom/status changes.