### PR TITLE
Enrich Lagrange/Waring OQ-03 n≡3(mod 4) obstruction (lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02): add overview annotation

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02/annotations.json
@@ -1,74 +1,165 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 69
+    },
+    "type": "concept",
+    "title": "Overview: the n ≡ 3 (mod 4) obstruction to the three-square multiplier route",
+    "content": "This file answers the oq-02 follow-up to the sharp n = 3 obstruction (parent oq-03-oq-07-oq-01): it upgrades that single value into an infinite congruence family. Setup — the multiplier–quadratic-residue reduction of the three-square problem distills the residue hypothesis to a Legendre condition legendreSym p (−n) = 1 on a 'multiplier prime' p of shape p = d·n − 1, i.e. p ≡ −1 (mod n). Main result: for every n ≡ 3 (mod 4) and every odd prime p ≡ −1 (mod n), legendreSym p (−n) = −1 (legendreSym_neg_eq_neg_one_of_three_mod_four), so the multiplier route's QR hypothesis is satisfied by no multiplier prime (multiplier_route_obstructed_of_three_mod_four). The mechanism is pure quadratic reciprocity with no case enumeration in p: J(−n | p) = χ₄ p · J(n | p), and p ≡ −1 (mod n) turns J(n | p) into (sign)·χ₄ n; for n ≡ 3 (mod 4) the χ₄ factors and the reciprocity sign collapse to a single −1 regardless of p mod 4. The parent's n = 3 case is recovered as a special instance, and the modulus is sharp: n = 2 ≢ 3 (mod 4) admits a qualifying prime (p = 11, J(−2 | 11) = 1). Honest scope: a 0-axiom (no axiom / sorry / native_decide), self-contained negative structural result about one reduction route — it is route-specific, not a genus condition, and does not bear on actual representability (indeed 3 = 1²+1²+1²).",
+    "mathContext": "For $n\\equiv 3\\pmod 4$ and odd prime $p\\equiv -1\\pmod n$: $\\left(\\tfrac{-n}{p}\\right)=\\chi_4(p)\\left(\\tfrac{n}{p}\\right)=-1$, hence the multiplier hypothesis $\\left(\\tfrac{-n}{p}\\right)=1$ holds for no such $p$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "quadratic reciprocity",
+      "Jacobi and Legendre symbols",
+      "χ₄ (the mod-4 character)",
+      "sum of three squares",
+      "multiplier-prime reduction"
+    ],
+    "prerequisites": [
+      "Legendre/Jacobi symbol J(a|p)",
+      "law of quadratic reciprocity",
+      "p ≡ −1 (mod n) multiplier primes"
+    ]
+  },
+  {
     "id": "reciprocity-kernel",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 70, "endLine": 101 },
+    "range": {
+      "startLine": 70,
+      "endLine": 101
+    },
     "type": "theorem",
     "title": "The Jacobi-Symbol Reciprocity Kernel",
     "content": "`jacobiSym_neg_eq_neg_one_of_three_mod_four`: for odd naturals n, p with n ≡ 3 (mod 4) and p ≡ −1 (mod n), J(−n | p) = −1. The engine of the whole entry. It decomposes J(−n | p) = χ₄ p · J(n | p) (jacobiSym.neg), evaluates J(p | n) = J(−1 | n) = χ₄ n = −1 from p ≡ −1 (mod n) (jacobiSym.mod_left' + at_neg_one + ZMod.χ₄_nat_three_mod_four), then case-splits on p mod 4: at p ≡ 1 the χ₄ p = 1 and reciprocity is sign-free; at p ≡ 3 the χ₄ p = −1 and the reciprocity sign is −1. Both cases multiply to −1. Crucially uniform in p — no mod-12 enumeration.",
     "mathContext": "$n\\equiv 3\\,(4),\\ p\\equiv -1\\,(n)\\Rightarrow J(-n\\mid p)=\\chi_4(p)\\,J(n\\mid p)=-1$.",
     "significance": "critical",
-    "relatedConcepts": ["Jacobi symbol", "quadratic reciprocity", "quartic character χ₄", "jacobiSym.neg", "sign computation"],
-    "prerequisites": ["quadratic reciprocity", "Jacobi symbol", "Dirichlet characters"]
+    "relatedConcepts": [
+      "Jacobi symbol",
+      "quadratic reciprocity",
+      "quartic character χ₄",
+      "jacobiSym.neg",
+      "sign computation"
+    ],
+    "prerequisites": [
+      "quadratic reciprocity",
+      "Jacobi symbol",
+      "Dirichlet characters"
+    ]
   },
   {
     "id": "legendre-obstruction",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 104, "endLine": 113 },
+    "range": {
+      "startLine": 104,
+      "endLine": 113
+    },
     "type": "theorem",
     "title": "The n ≡ 3 (mod 4) Obstruction (Legendre Form)",
     "content": "`legendreSym_neg_eq_neg_one_of_three_mod_four`: for every n ≡ 3 (mod 4) and every odd prime p with p ≡ −1 (mod n), legendreSym p (−n) = −1. This is the generalisation of the parent's single n = 3 computation to the entire congruence class. It is the kernel lifted to the Legendre symbol via legendreSym.to_jacobiSym, which identifies legendreSym p a = J(a | p) for primes p.",
     "mathContext": "$n\\equiv 3\\,(4),\\ p\\ \\text{odd prime},\\ p\\equiv -1\\,(n)\\Rightarrow \\left(\\tfrac{-n}{p}\\right)=-1$.",
     "significance": "critical",
-    "relatedConcepts": ["Legendre symbol", "legendreSym.to_jacobiSym", "congruence family", "quadratic non-residue"],
-    "prerequisites": ["Legendre symbol", "quadratic reciprocity"]
+    "relatedConcepts": [
+      "Legendre symbol",
+      "legendreSym.to_jacobiSym",
+      "congruence family",
+      "quadratic non-residue"
+    ],
+    "prerequisites": [
+      "Legendre symbol",
+      "quadratic reciprocity"
+    ]
   },
   {
     "id": "route-obstructed",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 115, "endLine": 139 },
+    "range": {
+      "startLine": 115,
+      "endLine": 139
+    },
     "type": "theorem",
     "title": "The Multiplier Route Fails for the Whole Family",
     "content": "`intMod_neg_one_of_multiplier` turns the multiplier shape p + 1 = d·n into the congruence p ≡ −1 (mod n) over ℤ. `multiplier_route_obstructed_of_three_mod_four` and `multiplier_route_qr_fails_of_three_mod_four` then state the structural payload requested by the parent's oq-02: for every n ≡ 3 (mod 4), the route's QR hypothesis legendreSym p (−n) = 1 fails for EVERY multiplier prime (odd prime p with p + 1 = d·n), its value forced to −1. This is the parent's multiplier_route_incomplete statement proved once for an infinite family rather than the single value n = 3.",
     "mathContext": "$p+1=d\\,n\\Rightarrow p\\equiv -1\\,(n)$; so for $n\\equiv 3\\,(4)$, $\\left(\\tfrac{-n}{p}\\right)=-1\\neq 1$ for every multiplier prime.",
     "significance": "key",
-    "relatedConcepts": ["multiplier prime", "structural obstruction", "infinite family", "route incompleteness"],
-    "prerequisites": ["modular arithmetic", "Legendre symbols"]
+    "relatedConcepts": [
+      "multiplier prime",
+      "structural obstruction",
+      "infinite family",
+      "route incompleteness"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "Legendre symbols"
+    ]
   },
   {
     "id": "n3-recovery",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 143, "endLine": 151 },
+    "range": {
+      "startLine": 143,
+      "endLine": 151
+    },
     "type": "concept",
     "title": "Recovering the Parent's n = 3 Case",
     "content": "`legendreSym_neg_three_eq_neg_one'`: every odd prime p ≡ 2 (mod 3) has legendreSym p (−3) = −1. This is the parent slice's original obstruction, now DERIVED from the general congruence theorem (3 ≡ 3 mod 4, and p ≡ 2 ≡ −1 mod 3) rather than proved by the parent's explicit mod-12 enumeration — confirming the general result subsumes the special case.",
     "mathContext": "$p\\equiv 2\\,(3)\\Rightarrow \\left(\\tfrac{-3}{p}\\right)=-1$, recovered from the $n\\equiv 3\\,(4)$ theorem.",
     "significance": "supporting",
-    "relatedConcepts": ["specialization", "consistency check", "subsumption"],
-    "prerequisites": ["Legendre symbol"]
+    "relatedConcepts": [
+      "specialization",
+      "consistency check",
+      "subsumption"
+    ],
+    "prerequisites": [
+      "Legendre symbol"
+    ]
   },
   {
     "id": "sharpness",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 153, "endLine": 162 },
+    "range": {
+      "startLine": 153,
+      "endLine": 162
+    },
     "type": "concept",
     "title": "Sharpness of the Modulus Hypothesis",
     "content": "`sharpness_n_two`: for n = 2 (which is ≢ 3 mod 4) the prime p = 11 satisfies (11 : ℤ) ≡ −1 (mod 2) yet J(−2 | 11) = 1 — the exact opposite of the kernel's conclusion. So a qualifying multiplier prime DOES exist for n = 2, proving the congruence hypothesis n ≡ 3 (mod 4) is necessary and cannot be weakened to merely 'n odd' or 'n even but ≢ 3 mod 4'. Discharged by omega/norm_num.",
     "mathContext": "$n=2\\not\\equiv 3\\,(4)$: $11\\equiv -1\\,(2)$ but $J(-2\\mid 11)=1$ — hypothesis necessary.",
     "significance": "supporting",
-    "relatedConcepts": ["sharpness", "necessity of hypothesis", "counterexample", "Jacobi symbol evaluation"],
-    "prerequisites": ["Jacobi symbol"]
+    "relatedConcepts": [
+      "sharpness",
+      "necessity of hypothesis",
+      "counterexample",
+      "Jacobi symbol evaluation"
+    ],
+    "prerequisites": [
+      "Jacobi symbol"
+    ]
   },
   {
     "id": "route-specific-capstone",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02",
-    "range": { "startLine": 164, "endLine": 176 },
+    "range": {
+      "startLine": 164,
+      "endLine": 176
+    },
     "type": "insight",
     "title": "Honest Capstone: the Obstruction Is Route-Specific",
     "content": "`obstruction_is_route_specific`: 3 = 1²+1²+1² is plainly a sum of three squares, yet the −3-multiplier route is fully obstructed; since many n ≡ 3 (mod 4) are sums of three squares, the obstruction is route-specific bookkeeping, NOT a genuine obstruction to representability and NOT the genus condition n ≠ 4^a(8b+7). This is the honest scope: the entry is a negative structural result about one particular reduction route, complementing the parent's positive supply theorem (which works exactly when a qualifying residue class exists).",
     "mathContext": "$3=1^2+1^2+1^2$ yet the $-3$-route is obstructed; route-specific, distinct from $n\\neq 4^a(8b+7)$.",
     "significance": "critical",
-    "relatedConcepts": ["honest scope", "route-specific obstruction", "genus condition", "negative result", "method limits"],
-    "prerequisites": ["Legendre's three-square theorem", "quadratic residues"]
+    "relatedConcepts": [
+      "honest scope",
+      "route-specific obstruction",
+      "genus condition",
+      "negative result",
+      "method limits"
+    ],
+    "prerequisites": [
+      "Legendre's three-square theorem",
+      "quadratic residues"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotate the uncovered module overview

**Entry:** `lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02` — the `n ≡ 3 (mod 4)` congruence-family generalization of the sharp `n = 3` three-square multiplier obstruction.

The entry annotated all six declarations (the reciprocity kernel, the two obstruction theorems, the parent-case recovery, the sharpness witness, and the honest capstone) but left the **entire leading module docstring uncovered** (lines 3–69: statement of the open question, background on the multiplier–QR reduction, the reciprocity mechanism, and the honest-scope caveats).

This pass adds one `concept` overview annotation (`ann-overview`, lines 3–69) paraphrasing that docstring: the open-question setup, the main result `legendreSym p (−n) = −1` for every odd prime `p ≡ −1 (mod n)`, the pure-reciprocity mechanism (`J(−n | p) = χ₄ p · J(n | p)` collapsing to `−1`), recovery of the `n = 3` case, sharpness of the `mod 4` modulus, and the honest scope (0-axiom, route-specific, not a genus condition).

**Coverage:** annotated lines rise from 55% to ~92% of the Lean file. Overview anchors on the section-doc block (validated); JSON well-formed; `meta.json` unchanged.
