### PR TITLE
Enrich Lagrange/Waring OQ-03 Dirichlet selection + n=3 obstruction (lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01): add overview annotation

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/annotations.json
@@ -1,74 +1,167 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "Overview: fixed-target Dirichlet selection and the sharp n = 3 obstruction",
+    "content": "Follow-up to the multiplier–quadratic-residue reduction (parent oq-03-oq-07). §1 (a Mathlib gap): Mathlib's jacobiSym.mod_right says J(a | b) depends on b only through b mod 4|a|, but there is no Legendre-symbol version in the prime; legendreSym_eq_of_prime_modeq fills it — odd primes p ≡ q (mod 4|a|) give legendreSym p a = legendreSym q a, so the QR condition legendreSym p (−n) = 1 is constant on each residue class of p mod 4n, exactly as the parent claimed. §2 (unconditional supply): given a single residue r with gcd(r,4n)=1, r ≡ −1 (mod n) and J(−n | r) = 1, Dirichlet's theorem (Nat.forall_exists_prime_gt_and_modEq, modulus 4n) supplies arbitrarily large primes p ≡ r (mod 4n); by §1 the value legendreSym p (−n) = 1 holds unconditionally and p ≡ −1 (mod n) gives the multiplier shape p = d·n − 1, forcing (not merely reducing) the geometry's QR hypothesis (exists_qr_qualified_multiplier_prime); for n = 2 the residue r = 3 qualifies, so the supply is non-empty. §3 (sharp obstruction at n = 3): the qualifying class need not exist — every multiplier prime has p ≡ −1 (mod n), which for n = 3 forces p ≡ 2 (mod 3), and every such odd prime has legendreSym p (−3) = −1, so the QR hypothesis holds for no multiplier prime even though 3 = 1²+1²+1² (multiplier_route_incomplete_at_three). More generally a qualifying class exists iff n is not of Legendre's excluded form 4^a(8b+7), so §2's residue existence is exactly the genus condition. Honest scope: 0-axiom and self-contained (imports Mathlib and the parent slice); it does not discharge the sufficiency axiom not_excluded_form_is_sum_three_sq — indeed §3 documents why the −n-multiplier route alone is insufficient. No axiom, sorry, or native_decide.",
+    "mathContext": "$p\\equiv q\\!\\!\\pmod{4|a|}\\Rightarrow\\left(\\tfrac{a}{p}\\right)=\\left(\\tfrac{a}{q}\\right)$; a class $r\\equiv -1\\pmod n,\\ \\left(\\tfrac{-n}{r}\\right)=1$ exists $\\iff n\\neq 4^a(8b+7)$. At $n=3$ every prime $p\\equiv 2\\pmod 3$ has $\\left(\\tfrac{-3}{p}\\right)=-1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "quadratic reciprocity",
+      "Legendre/Jacobi symbol periodicity",
+      "Dirichlet's theorem on primes in AP",
+      "sum of three squares / genus condition",
+      "Legendre's excluded form 4^a(8b+7)"
+    ],
+    "prerequisites": [
+      "jacobiSym.mod_right",
+      "Nat.forall_exists_prime_gt_and_modEq (Dirichlet)",
+      "multiplier-prime reduction p = d·n − 1"
+    ]
+  },
+  {
     "id": "periodicity-in-prime",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 87, "endLine": 109 },
+    "range": {
+      "startLine": 87,
+      "endLine": 109
+    },
     "type": "theorem",
     "title": "Periodicity of the Legendre Symbol in the Prime",
     "content": "`legendreSym_eq_of_prime_modeq`: for odd primes p ≡ q (mod 4|a|), legendreSym p a = legendreSym q a. Mathlib packages jacobiSym.mod_right (J(a|b) depends on b only mod 4|a|) but NOT its Legendre-symbol-in-the-prime counterpart; the proof bridges the two by rewriting both Legendre symbols as Jacobi symbols (legendreSym.to_jacobiSym) and applying mod_right. `qr_condition_class_invariant` is the iff form; specialized to a = −n it is exactly the statement that the geometry's QR hypothesis legendreSym p (−n) = 1 depends only on p mod 4n — the parent's prose-only claim, now proved.",
     "mathContext": "$p\\equiv q\\ (\\mathrm{mod}\\ 4|a|)\\Rightarrow\\left(\\tfrac{a}{p}\\right)=\\left(\\tfrac{a}{q}\\right)$; the QR condition is constant on residue classes $p\\bmod 4n$.",
     "significance": "key",
-    "relatedConcepts": ["Legendre symbol", "Jacobi symbol", "quadratic reciprocity", "jacobiSym.mod_right", "residue-class invariance"],
-    "prerequisites": ["quadratic reciprocity", "modular arithmetic", "Legendre/Jacobi symbols"]
+    "relatedConcepts": [
+      "Legendre symbol",
+      "Jacobi symbol",
+      "quadratic reciprocity",
+      "jacobiSym.mod_right",
+      "residue-class invariance"
+    ],
+    "prerequisites": [
+      "quadratic reciprocity",
+      "modular arithmetic",
+      "Legendre/Jacobi symbols"
+    ]
   },
   {
     "id": "value-transport",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 111, "endLine": 141 },
+    "range": {
+      "startLine": 111,
+      "endLine": 141
+    },
     "type": "tactic",
     "title": "Transporting the QR Value Across a Dirichlet Residue Class",
     "content": "`legendreSym_neg_eq_of_modEq`: if p is an odd prime and r is any ODD natural with p ≡ r (mod 4n), then legendreSym p (−n) = J(−n | r). Crucially the second argument r need not be prime — only odd — which is what lets it stand for a Dirichlet residue class rather than a specific prime. The helper `odd_of_coprime_four_mul` supplies that oddness: gcd(r,4n)=1 forces r odd since 2 ∣ 4n. Both Legendre and Jacobi sides are reduced mod 4n via jacobiSym.mod_right and matched.",
     "mathContext": "$p\\equiv r\\ (\\mathrm{mod}\\ 4n),\\ r\\ \\text{odd}\\Rightarrow \\left(\\tfrac{-n}{p}\\right)=J(-n\\mid r)$; $\\gcd(r,4n)=1\\Rightarrow r$ odd.",
     "significance": "supporting",
-    "relatedConcepts": ["Jacobi symbol", "residue class", "coprimality", "modular reduction"],
-    "prerequisites": ["Jacobi symbol", "modular arithmetic"]
+    "relatedConcepts": [
+      "Jacobi symbol",
+      "residue class",
+      "coprimality",
+      "modular reduction"
+    ],
+    "prerequisites": [
+      "Jacobi symbol",
+      "modular arithmetic"
+    ]
   },
   {
     "id": "unconditional-supply",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 143, "endLine": 192 },
+    "range": {
+      "startLine": 143,
+      "endLine": 192
+    },
     "type": "theorem",
     "title": "Unconditional Multiplier-Prime Supply via Dirichlet",
     "content": "`exists_qr_qualified_multiplier_prime`: given a residue r with gcd(r,4n)=1, r ≡ −1 (mod n) and J(−n|r)=1, then for every bound N there is a prime p > N of multiplier shape p = d·n − 1 (d ≥ 1) with legendreSym p (−n) = 1 holding UNCONDITIONALLY. Dirichlet's theorem (Nat.forall_exists_prime_gt_and_modEq, modulus 4n) supplies p ≡ r (mod 4n); p inherits oddness and the residue −1 (mod n) for the multiplier shape, while §1 forces the QR value to J(−n|r) = 1. `exists_qr_qualified_multiplier_prime_full` additionally forces legendreSym p (−d) = 1 by routing through the parent reduction legendreSym_neg_n_one_imp_neg_d_one. The parent's CONDITIONAL reduction becomes an unconditional supply.",
     "mathContext": "$\\exists r$ qualifying $\\Rightarrow \\forall N\\,\\exists$ prime $p>N,\\ p=dn-1,\\ \\left(\\tfrac{-n}{p}\\right)=\\left(\\tfrac{-d}{p}\\right)=1$.",
     "significance": "critical",
-    "relatedConcepts": ["Dirichlet's theorem", "primes in arithmetic progressions", "multiplier prime", "unconditional reduction"],
-    "prerequisites": ["Dirichlet's theorem", "arithmetic progressions", "Legendre symbols"]
+    "relatedConcepts": [
+      "Dirichlet's theorem",
+      "primes in arithmetic progressions",
+      "multiplier prime",
+      "unconditional reduction"
+    ],
+    "prerequisites": [
+      "Dirichlet's theorem",
+      "arithmetic progressions",
+      "Legendre symbols"
+    ]
   },
   {
     "id": "non-vacuous-two",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 194, "endLine": 201 },
+    "range": {
+      "startLine": 194,
+      "endLine": 201
+    },
     "type": "concept",
     "title": "Non-Vacuousness at n = 2",
     "content": "`qr_qualified_multiplier_prime_two`: for n = 2 the residue r = 3 qualifies — gcd(3,8)=1, 3 ≡ −1 (mod 2), J(−2 | 3) = 1 — all discharged by decide/norm_num. So the unconditional supply of §2 is genuinely populated: for every N there is a prime p > N with p = 2d − 1 and legendreSym p (−2) = 1. This confirms the §2 hypothesis is satisfiable and the theorem non-trivial before §3 shows it can fail.",
     "mathContext": "$n=2,\\ r=3$: $\\gcd(3,8)=1,\\ 3\\equiv-1\\ (2),\\ J(-2\\mid 3)=1$ — the supply is non-empty.",
     "significance": "supporting",
-    "relatedConcepts": ["worked instance", "non-vacuousness", "Jacobi symbol evaluation"],
-    "prerequisites": ["Jacobi symbol"]
+    "relatedConcepts": [
+      "worked instance",
+      "non-vacuousness",
+      "Jacobi symbol evaluation"
+    ],
+    "prerequisites": [
+      "Jacobi symbol"
+    ]
   },
   {
     "id": "obstruction-value",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 203, "endLine": 229 },
+    "range": {
+      "startLine": 203,
+      "endLine": 229
+    },
     "type": "theorem",
     "title": "The QR Value Is Forced to −1 at n = 3",
     "content": "`legendreSym_neg_three_eq_neg_one`: every odd prime p ≡ 2 (mod 3) has legendreSym p (−3) = −1. By jacobiSym.mod_right the value depends only on p mod 12, and the constraints (p odd, p ≡ 2 mod 3) force p mod 12 ∈ {5, 11}, on both of which norm_num's reciprocity extension evaluates J(−3 | ·) = −1. `multiplier_prime_neg_three_qr_fails` applies this to multiplier primes p = 3d − 1 (which satisfy p ≡ 2 mod 3 by omega). The 0-axiom symbol evaluation uses norm_num, not native_decide, preserving the clean axiom profile.",
     "mathContext": "$p\\ \\text{odd},\\ p\\equiv 2\\ (3)\\Rightarrow p\\bmod 12\\in\\{5,11\\}\\Rightarrow \\left(\\tfrac{-3}{p}\\right)=-1$.",
     "significance": "key",
-    "relatedConcepts": ["quadratic reciprocity", "case analysis mod 12", "norm_num LegendreSymbol", "forced symbol value"],
-    "prerequisites": ["quadratic reciprocity", "modular arithmetic"]
+    "relatedConcepts": [
+      "quadratic reciprocity",
+      "case analysis mod 12",
+      "norm_num LegendreSymbol",
+      "forced symbol value"
+    ],
+    "prerequisites": [
+      "quadratic reciprocity",
+      "modular arithmetic"
+    ]
   },
   {
     "id": "honest-capstone",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
-    "range": { "startLine": 231, "endLine": 242 },
+    "range": {
+      "startLine": 231,
+      "endLine": 242
+    },
     "type": "insight",
     "title": "Honest Capstone: the −n-Route Cannot Certify n = 3",
     "content": "`multiplier_route_incomplete_at_three`: 3 = 1²+1²+1² is plainly a sum of three squares, yet NO multiplier prime for n = 3 satisfies the geometry's QR hypothesis legendreSym p (−3) = 1 — equivalently, the qualifying-residue hypothesis of §2 fails at n = 3. This is a genuine negative result documenting why the −n-multiplier development of oq-03-oq-07 is only established for the small multipliers d ∈ {1,2}: the naive −n-residue condition cannot on its own certify representability. A qualifying class exists iff n is not of Legendre's excluded form 4^a(8b+7), so the existence of r in §2 is exactly the genus condition — the actual open content of the parent umbrella, here exhibited concretely failing.",
     "mathContext": "$3=1^2+1^2+1^2$ but $\\nexists$ multiplier prime $p$ with $\\left(\\tfrac{-3}{p}\\right)=1$; qualifying $r$ exists $\\iff n\\neq 4^a(8b+7)$.",
     "significance": "critical",
-    "relatedConcepts": ["honest scope", "negative result", "genus condition", "Legendre excluded form", "limits of a method"],
-    "prerequisites": ["Legendre's three-square theorem", "quadratic residues"]
+    "relatedConcepts": [
+      "honest scope",
+      "negative result",
+      "genus condition",
+      "Legendre excluded form",
+      "limits of a method"
+    ],
+    "prerequisites": [
+      "Legendre's three-square theorem",
+      "quadratic residues"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotate the uncovered module overview

**Entry:** `lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01` — fixed-target Dirichlet selection for the three-square multiplier prime, plus the sharp `n = 3` obstruction.

All six declarations were annotated (Legendre-symbol periodicity, QR transport across a Dirichlet residue, unconditional multiplier-prime supply, non-vacuousness at `n = 2`, the forced `−1` at `n = 3`, and the honest capstone), but the **entire leading module docstring was uncovered** (lines 4–86: the open-question setup and the §1/§2/§3 roadmap).

This pass adds one `concept` overview annotation (`ann-overview`, lines 4–86) paraphrasing that docstring: §1 fills a Mathlib gap (Legendre-symbol periodicity in the prime, `legendreSym_eq_of_prime_modeq`); §2 upgrades the parent's conditional reduction to an unconditional supply via Dirichlet's theorem once a qualifying residue class exists; §3 exhibits the sharp `n = 3` obstruction and identifies the residue-class existence with Legendre's genus condition `n ≠ 4^a(8b+7)`. Honest scope (0-axiom, self-contained, does not discharge the sufficiency axiom) preserved.

**Coverage:** annotated lines rise from 61% to ~95% of the Lean file. Overview anchors on the section-doc block (validated); JSON well-formed; `meta.json` unchanged.
