### PR TITLE
Enrich three-square density 1/6 (lagrange-four-squares-waring-g2-oq-03-oq-05): add overview + sanity-check annotations

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
@@ -1,74 +1,187 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": {
+      "startLine": 4,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "Overview: the non-three-square integers have natural density 1/6",
+    "content": "By Legendre's three-square theorem the integers that are NOT sums of three squares are exactly the excluded family E = { 4^a(8b+7) : a,b ≥ 0 } — precisely the numbers that need all four squares in Lagrange's theorem, i.e. the extremal numbers for Waring's g(2) = 4. This file quantifies how rare they are: E has natural density 1/6. Three new ingredients: (1) a 4-descent counting recursion excludedCount N = N/8 + excludedCount ⌈N/4⌉ (an excluded number is either odd and ≡ 7 (mod 8) — exactly ⌊N/8⌋ below N — or divisible by 4 with excluded quotient), a clean self-similar decomposition; (2) an explicit logarithmic error bound |6·excludedCount N − N| ≤ 6·(log₂ N + 1), proved by strong induction directly from the recursion — the constant 1/6 is pinned by the geometric series implicit in the recursion, but the proof forms no infinite sum, using a single inductive invariant; (3) the density theorem excludedCount N / N → 1/6, so asymptotically one integer in six is not a sum of three squares. The only nontrivial inputs are elementary 2-adic facts about E (re-derived from the oq-03-oq-04 normal form); the rest is finite combinatorics plus a standard log N / N → 0 squeeze. All proofs are axiom-free.",
+    "mathContext": "$E=\\{4^a(8b+7)\\}$, $\\ \\mathrm{excludedCount}\\,N=\\#\\{n<N:n\\in E\\}$ satisfies $\\mathrm{excludedCount}\\,N=\\lfloor N/8\\rfloor+\\mathrm{excludedCount}\\,\\lceil N/4\\rceil$ and $|6\\,\\mathrm{excludedCount}\\,N-N|\\le 6(\\log_2 N+1)$, whence $\\mathrm{excludedCount}\\,N/N\\to \\tfrac16$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Legendre's three-square theorem",
+      "natural density",
+      "self-similar / 4-adic descent recursion",
+      "Waring's problem g(2) = 4",
+      "geometric series constant"
+    ],
+    "prerequisites": [
+      "excluded family E = 4^a(8b+7)",
+      "strong induction",
+      "log N / N → 0 squeeze"
+    ]
+  },
+  {
     "id": "descent-facts",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 51, "endLine": 83 },
+    "range": {
+      "startLine": 51,
+      "endLine": 83
+    },
     "type": "theorem",
     "title": "2-Adic Descent Facts for the Excluded Family",
     "content": "Three elementary facts about E = {4^a(8b+7)}, reusing the predicate and decidability from the sibling oq-03-oq-04. `mod8_seven_excluded`: any n ≡ 7 (mod 8) is excluded (take a=0). `four_mul_excluded_iff`: 4k is excluded iff k is — multiplying by 4 just shifts the exponent a. `excluded_not_dvd_four_iff`: for n not divisible by 4, being excluded is the same as n ≡ 7 (mod 8). These are the self-similarity facts that power the counting recursion: the excluded set splits into a residue class plus a scaled copy of itself.",
     "mathContext": "$n\\equiv 7\\ (8)\\Rightarrow n\\in E$; $4k\\in E\\iff k\\in E$; and for $4\\nmid n$, $n\\in E\\iff n\\equiv 7\\ (8)$.",
     "significance": "key",
-    "relatedConcepts": ["self-similarity", "2-adic descent", "excluded family", "residue classes"],
-    "prerequisites": ["modular arithmetic", "divisibility"]
+    "relatedConcepts": [
+      "self-similarity",
+      "2-adic descent",
+      "excluded family",
+      "residue classes"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "divisibility"
+    ]
   },
   {
     "id": "counting-function",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 85, "endLine": 108 },
+    "range": {
+      "startLine": 85,
+      "endLine": 108
+    },
     "type": "definition",
     "title": "The Counting Function and Residue Count",
     "content": "`excludedCount N` = #{n < N : n ∈ E}, a genuine Finset.card thanks to oq-03-oq-04's computable decidability. It vanishes for N ≤ 7 (no excluded number is below 7). `card_mod8_seven` proves the exact residue count #{n < N : n ≡ 7 (mod 8)} = ⌊N/8⌋ by a clean Finset induction matching the divisibility recurrence — the elementary half of the descent.",
     "mathContext": "$\\mathrm{excludedCount}(N)=\\#\\{n<N:n\\in E\\}$; $\\#\\{n<N:n\\equiv 7\\ (8)\\}=\\lfloor N/8\\rfloor$.",
     "significance": "supporting",
-    "relatedConcepts": ["counting function", "Finset.card", "residue counting"],
-    "prerequisites": ["Finset cardinality", "induction"]
+    "relatedConcepts": [
+      "counting function",
+      "Finset.card",
+      "residue counting"
+    ],
+    "prerequisites": [
+      "Finset cardinality",
+      "induction"
+    ]
   },
   {
     "id": "bijection",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 110, "endLine": 152 },
+    "range": {
+      "startLine": 110,
+      "endLine": 152
+    },
     "type": "theorem",
     "title": "Splitting the Excluded Set: Residue Class + Scaled Copy",
     "content": "The two halves of the descent. `filter_notdvd_eq_mod8`: the part of E below N not divisible by 4 is exactly the ≡ 7 (mod 8) residue class. `excludedCount_dvd_part`: the divisible-by-4 part is in explicit bijection (via n ↦ n/4 with inverse k ↦ 4k, using `Finset.card_bij'`) with the excluded set below ⌈N/4⌉. The bijection rests on the multiply-by-4 descent four_mul_excluded_iff. Together they exhibit E ∩ [0,N) as a residue class disjointly unioned with a 1/4-scaled copy of itself.",
     "mathContext": "$E\\cap[0,N) = \\{n\\equiv 7\\,(8)\\} \\sqcup 4\\cdot\\bigl(E\\cap[0,\\lceil N/4\\rceil)\\bigr)$; the second part is in bijection with $E\\cap[0,\\lceil N/4\\rceil)$.",
     "significance": "key",
-    "relatedConcepts": ["Finset.card_bij'", "explicit bijection", "self-similar set", "disjoint partition"],
-    "prerequisites": ["Finset bijections", "divisibility"]
+    "relatedConcepts": [
+      "Finset.card_bij'",
+      "explicit bijection",
+      "self-similar set",
+      "disjoint partition"
+    ],
+    "prerequisites": [
+      "Finset bijections",
+      "divisibility"
+    ]
   },
   {
     "id": "recursion",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 154, "endLine": 164 },
+    "range": {
+      "startLine": 154,
+      "endLine": 164
+    },
     "type": "theorem",
     "title": "The 4-Descent Counting Recursion",
     "content": "`excludedCount_rec`: excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉. Assembled from the residue count and the bijection via `Finset.filter_card_add_filter_neg_card_eq_card` (split by divisibility-by-4) and omega. This self-similar recursion is the engine of the entire density computation — it encodes the geometric series Σ 1/(8·4^a) = 1/6 without ever forming an infinite sum.",
     "mathContext": "$\\mathrm{excludedCount}(N)=\\lfloor N/8\\rfloor + \\mathrm{excludedCount}(\\lceil N/4\\rceil)$; unrolling gives $\\sum_a \\frac{N}{8\\cdot 4^a}=\\frac{N}{6}$.",
     "significance": "critical",
-    "relatedConcepts": ["recursion", "geometric series", "self-similarity", "Waring g(2)=4"],
-    "prerequisites": ["counting recursions"]
+    "relatedConcepts": [
+      "recursion",
+      "geometric series",
+      "self-similarity",
+      "Waring g(2)=4"
+    ],
+    "prerequisites": [
+      "counting recursions"
+    ]
   },
   {
     "id": "error-bound",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 166, "endLine": 206 },
+    "range": {
+      "startLine": 166,
+      "endLine": 206
+    },
     "type": "theorem",
     "title": "Logarithmic Error Bound by Strong Induction",
     "content": "`excludedCount_error_bound`: |6·excludedCount N − N| ≤ 6·(log₂ N + 1). Proved by strong induction directly from the recursion. Each descent step perturbs the error 6·excludedCount N − N by a bounded amount (the per-step δ = 6⌊N/8⌋ + ⌈N/4⌉ − N is ≤ 6 in absolute value, via the division identities), and the descent depth is log₂-controlled (each step at most halves N, so log₂ M + 1 ≤ log₂ N). This pins the constant 1/6 as a single inductive invariant rather than through an infinite sum.",
     "mathContext": "$|6\\,\\mathrm{excludedCount}(N)-N|\\le 6(\\log_2 N+1)$: the deviation from $N/6$ is only logarithmic, established by a bounded per-step perturbation over a log-depth descent.",
     "significance": "critical",
-    "relatedConcepts": ["strong induction", "error term", "Nat.log", "inductive invariant"],
-    "prerequisites": ["strong induction", "logarithms", "integer arithmetic"]
+    "relatedConcepts": [
+      "strong induction",
+      "error term",
+      "Nat.log",
+      "inductive invariant"
+    ],
+    "prerequisites": [
+      "strong induction",
+      "logarithms",
+      "integer arithmetic"
+    ]
   },
   {
     "id": "density",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
-    "range": { "startLine": 208, "endLine": 284 },
+    "range": {
+      "startLine": 208,
+      "endLine": 284
+    },
     "type": "theorem",
     "title": "The Density Theorem: Exactly 1/6 (Headline)",
     "content": "`excludedCount_density`: excludedCount N / N → 1/6 — asymptotically one integer in six is NOT a sum of three squares (equivalently requires all four squares of Lagrange's theorem, the extremal numbers for Waring's g(2)=4). It follows by a squeeze: the deviation |excludedCount N / N − 1/6| equals |6·excludedCount N − N| / (6N) ≤ (log₂ N + 1)/N, and the helper lemmas (natLog2_le_realLog, tendsto_logBound_zero) drive that to 0 using the standard Real.log N / N → 0 (`Real.isLittleO_log_id_atTop`). Sanity checks confirm excludedCount 8 = 1, 16 = 2, 32 = 5.",
     "mathContext": "$\\frac{\\mathrm{excludedCount}(N)}{N}\\to\\frac16$. The non-three-square integers have natural density exactly $1/6$.",
     "significance": "critical",
-    "relatedConcepts": ["natural density", "squeeze theorem", "asymptotic density", "log N / N → 0", "Lagrange four-square theorem"],
-    "prerequisites": ["limits", "asymptotic analysis", "little-o notation"]
+    "relatedConcepts": [
+      "natural density",
+      "squeeze theorem",
+      "asymptotic density",
+      "log N / N → 0",
+      "Lagrange four-square theorem"
+    ],
+    "prerequisites": [
+      "limits",
+      "asymptotic analysis",
+      "little-o notation"
+    ]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": {
+      "startLine": 286,
+      "endLine": 305
+    },
+    "type": "concept",
+    "title": "Sanity checks: small-N verification of the count and the recursion",
+    "content": "Concrete `example`s that discharge the counting function at small N and confirm the descent recursion. excludedCount 8 = 1 (only 7 is excluded below 8); excludedCount 16 = 2 (7 and 15); excludedCount 32 = 5 (7, 15, 23, 28, 31 = 32/8 + excludedCount 8 = 4 + 1); and the recursion identity excludedCount 32 = 32/8 + excludedCount ((32+3)/4) checks out directly from excludedCount_rec. Each reduces by rewriting with excludedCount_rec and the base case excludedCount_zero_of_le, giving auditable ground-truth values for the headline density result.",
+    "mathContext": "$\\mathrm{excludedCount}\\,8=1,\\ \\mathrm{excludedCount}\\,16=2,\\ \\mathrm{excludedCount}\\,32=5=32/8+\\mathrm{excludedCount}\\,8$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked examples",
+      "excludedCount_rec",
+      "base case verification"
+    ],
+    "prerequisites": [
+      "the 4-descent recursion excludedCount_rec"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: cover the overview and the sanity-check block

**Entry:** `lagrange-four-squares-waring-g2-oq-03-oq-05` — the natural density of the non-three-square integers is `1/6`.

The six core declarations were annotated, but two substantial regions were uncovered:
- the **leading module docstring** (lines 4–49): the statement that the excluded family `E = { 4^a(8b+7) }` has density `1/6`, and the three new ingredients (the 4-descent recursion, the logarithmic error bound, the density theorem);
- the **`Sanity checks` block** (lines 286–305): the worked `example`s pinning `excludedCount 8 = 1`, `16 = 2`, `32 = 5`, and the recursion identity.

This pass adds two annotations:
- `ann-overview` (concept, 4–49): paraphrases the docstring — the link to Legendre's theorem and Waring's `g(2) = 4`, the self-similar recursion `excludedCount N = N/8 + excludedCount ⌈N/4⌉`, the error bound `|6·excludedCount N − N| ≤ 6·(log₂ N + 1)`, and the density limit `→ 1/6`, all axiom-free.
- `ann-sanity` (concept, 286–305): explains the small-`N` ground-truth checks and the recursion verification.

**Coverage:** annotated lines rise from 75% to ~99% of the Lean file. Anchors on the section-doc blocks (validated); JSON well-formed; `meta.json` unchanged.
