### PR TITLE
Enrich Gödel First Incompleteness OQ-02 (godel-first-incompleteness-oq01-oq-02): annotate the closing summary block

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-02/annotations.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-module-header",
     "proofId": "godel-first-incompleteness-oq01-oq-02",
-    "range": { "startLine": 3, "endLine": 52 },
+    "range": {
+      "startLine": 3,
+      "endLine": 52
+    },
     "type": "concept",
     "title": "A Consistent Repair of the Parent's Axiomatization",
     "content": "The sibling analysis …OQ01OQ03 proved the parent's five-axiom formalization of First Incompleteness is jointly inconsistent — its axiom set has no model, so the theorem holds only vacuously — and diagnosed the cause: the meta-level self-reference '⊢G iff ¬⊢Prov⌜G⌝' was taken as an axiom, whereas only the object-level fixed point F ⊢ (G ↔ ¬Prov⌜G⌝) is legitimate. This file performs the repair OQ-03 asked for: replace the meta equivalence by the two object-level implications the proof actually uses, and show the resulting clause set is both consistent (has a model) and sufficient (entails G's undecidability).",
@@ -22,7 +25,10 @@
   {
     "id": "ann-clauses",
     "proofId": "godel-first-incompleteness-oq01-oq-02",
-    "range": { "startLine": 54, "endLine": 80 },
+    "range": {
+      "startLine": 54,
+      "endLine": 80
+    },
     "type": "definition",
     "title": "The Five Repaired Clauses",
     "content": "Over an arbitrary provability predicate P : ℕ → Prop and four codes (G=42, Prov⌜G⌝=84, ¬G=43, ¬Prov⌜G⌝=85), the clauses are: D1G (P G → P provG, derivability), FixG (P G → P negProvG, the object-level G→¬Prov⌜G⌝ replacing the meta self-reference), Consistent (¬(P provG ∧ P negProvG)), NegGProv (P negG → P provG, the object-level ¬G→Prov⌜G⌝), and OmegaCons (¬P G → ¬P provG, ω-consistency). Working abstractly over P means nothing imports the parent's inconsistent global axioms.",
@@ -40,7 +46,10 @@
   {
     "id": "ann-incompleteness",
     "proofId": "godel-first-incompleteness-oq01-oq-02",
-    "range": { "startLine": 82, "endLine": 110 },
+    "range": {
+      "startLine": 82,
+      "endLine": 110
+    },
     "type": "theorem",
     "title": "First Incompleteness from Consistent Clauses",
     "content": "godel_not_provable proves ¬P(G): if P(G) held, D1G gives P(Prov⌜G⌝) and FixG gives P(¬Prov⌜G⌝), contradicting Consistent (closed by tauto). neg_godel_not_provable proves ¬P(¬G): if P(¬G) held, NegGProv gives P(Prov⌜G⌝), but ¬P(G) plus OmegaCons gives ¬P(Prov⌜G⌝) — contradiction. first_incompleteness bundles these: G is undecidable. The consistency half needs D1G+FixG+Consistent; the ω-consistency half adds NegGProv+OmegaCons, matching the two directions of Gödel's argument.",
@@ -58,7 +67,10 @@
   {
     "id": "ann-satisfiable",
     "proofId": "godel-first-incompleteness-oq01-oq-02",
-    "range": { "startLine": 112, "endLine": 148 },
+    "range": {
+      "startLine": 112,
+      "endLine": 148
+    },
     "type": "insight",
     "title": "The Hypotheses Are Satisfiable — Genuine Non-Vacuity",
     "content": "has_model exhibits a model (P := fun _ => False satisfies all five clauses), so — unlike the parent's set, which …OQ01OQ03.no_model_of_all_axioms shows has no model — the incompleteness conclusion is drawn from consistent, not contradictory, hypotheses. has_nontrivial_model sharpens this: taking ¬Prov⌜G⌝ as the one provable sentence (P := (· = negProvGCode)) still satisfies all five clauses while being non-empty, so a genuine theory (something is a theorem) can be incomplete — the point the parent's Provable := fun _ => False failed to make. provG_not_provable notes that in every model Prov(⌜G⌝) is unprovable too. The model goals are finite decidable checks over the four codes, closed by decide.",
@@ -72,6 +84,31 @@
     "prerequisites": [
       "consistency as the existence of a model",
       "the parent's no-model result in …OQ01OQ03"
+    ]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "godel-first-incompleteness-oq01-oq-02",
+    "range": {
+      "startLine": 150,
+      "endLine": 167
+    },
+    "type": "concept",
+    "title": "Summary: the consistent, non-vacuous First Incompleteness fix",
+    "content": "Closing recap of how the file answers OQ-02 (is there a consistent axiom set giving First Incompleteness non-vacuously?). The repair is exactly the one OQ-03 pointed to: drop the illegitimate meta self-reference P G ↔ ¬P provG and instead use the object-level fixed-point clauses FixG (P G → P negProvG) and NegGProv (P negG → P provG), together with derivability D1G, Consistent, and OmegaCons. Results: godel_not_provable, neg_godel_not_provable, and first_incompleteness show G is undecidable for every P satisfying the five clauses; has_model and has_nontrivial_model show the five clauses are satisfiable (and by a non-empty theory), so the conclusion is drawn from consistent hypotheses — the honest, non-vacuous First Incompleteness the parent aimed for, fixing the vacuity found in …OQ01OQ03; provG_not_provable adds that Prov(⌜G⌝) is likewise unprovable in every such model. Status: 0 sorries, 0 axiom declarations, no native_decide.",
+    "mathContext": "Five clauses (FixG, NegGProv, D1G, Consistent, OmegaCons) $\\Rightarrow$ $G$ undecidable; the clauses are satisfiable, so incompleteness is drawn non-vacuously from consistent hypotheses.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gödel's First Incompleteness Theorem",
+      "object-level fixed points vs meta self-reference",
+      "ω-consistency",
+      "satisfiability / non-vacuity",
+      "derivability conditions"
+    ],
+    "prerequisites": [
+      "the five repaired clauses",
+      "undecidability of G (first_incompleteness)",
+      "existence of a model (has_model)"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotate the closing summary block

**Entry:** `godel-first-incompleteness-oq01-oq-02` — a consistent, non-vacuous repair of the parent's First Incompleteness axiomatization.

The four core declarations were annotated, but the **closing `## Summary` docstring (lines 150–167)** — which recaps exactly how the file answers OQ-02 — was left uncovered.

This pass adds one `concept` annotation (`ann-summary`, lines 150–167) paraphrasing it: the repair drops the illegitimate meta self-reference in favor of the object-level fixed-point clauses `FixG`/`NegGProv` plus `D1G`/`Consistent`/`OmegaCons`; `first_incompleteness` gives undecidability of `G` for every such `P`; `has_model`/`has_nontrivial_model` establish satisfiability (hence genuine non-vacuity); `provG_not_provable` closes the loop. Honest status (0 sorries, 0 axioms, no `native_decide`) preserved.

**Coverage:** annotated lines rise from 85% to ~98% of the Lean file. Anchors on the section-doc block (validated); JSON well-formed; `meta.json` unchanged.
