### PR TITLE
Enrich odd-abundant counting bound (abundant-number-oq-03-oq-02): add full annotation set (was unannotated)

### DIFF
--- a/src/data/proofs/abundant-number-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-02/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "abundant-number-oq-03-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "Overview: a quantitative lower bound on the odd-abundant counting function",
+    "content": "A positive integer n is abundant when σ(n) > 2n (Mathlib's Nat.Abundant); the smallest odd abundant number is 945 = 3³·5·7. The sibling entry proves there are infinitely many odd abundant numbers via the family 945·(2k+1), a qualitative statement. This file answers the parent's second open question by upgrading infinitude to a quantitative lower bound on A(x) = #{ n ∈ [1,x] : n odd and abundant }. The same odd-multiples family gives, for every x, x < 1890·A(x) + 945, equivalently A(x) > x/1890 − 1/2 — so the odd abundant numbers have positive lower density at least 1/1890. The witnesses 945·(2k+1) with 2k+1 ≤ x/945 number ⌈(x/945)/2⌉ ≥ x/1890 − 1/2, and k ↦ 945·(2k+1) is injective, so they inject into the counted set. The constant 1/1890 is the density of the odd multiples of 945 and is not optimal (other seeds 1575, 2205, … would raise it); it is the honest bound from the single seed 945. The proof is axiom-free (no sorry/axiom/native_decide): it reuses the parent's odd_abundant_945_mul and odd_mul_succ_injective, an injective-image cardinality bound, and omega for the division arithmetic.",
+    "mathContext": "$A(x)=\\#\\{n\\in[1,x]:\\text{$n$ odd},\\ \\sigma(n)>2n\\}$; the seed family gives $x<1890\\,A(x)+945$, hence $A(x)>x/1890-1/2$ and lower density $\\ge 1/1890$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "abundant numbers (Nat.Abundant)",
+      "counting functions / lower density",
+      "injective-image cardinality bound",
+      "odd abundant seeds 945, 1575, 2205"
+    ],
+    "prerequisites": [
+      "σ(n) > 2n abundance",
+      "the parent's odd_abundant_945_mul and odd_mul_succ_injective"
+    ]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "abundant-number-oq-03-oq-02",
+    "range": {
+      "startLine": 39,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "Ambient setup: classical counting filter",
+    "content": "Opens the parent namespace AbundantOddInfiniteOQ03 to reuse its witnesses. Nat.Abundant carries no registered Decidable instance, so the counting filter is defined classically (open Classical). This affects only computability, not logical content: #print axioms still lists only the standard foundational axioms (propext, Classical.choice, Quot.sound) and never sorryAx or Lean.ofReduceBool.",
+    "mathContext": "Classical decidability of the predicate $\\mathrm{Odd}\\,n\\wedge n.\\mathrm{Abundant}$ is used only to form the Finset.filter.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Decidable instances",
+      "Classical logic in Lean",
+      "foundational axioms"
+    ],
+    "prerequisites": [
+      "Finset.filter needs a decidable predicate"
+    ]
+  },
+  {
+    "id": "ann-count",
+    "proofId": "abundant-number-oq-03-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 53
+    },
+    "type": "definition",
+    "title": "The odd-abundant counting function A(x)",
+    "content": "countOddAbundant x is defined as the cardinality of the filter of Finset.Icc 1 x by the predicate Odd n ∧ n.Abundant — i.e. A(x) = #{ n ∈ [1,x] : n odd and abundant }. It is noncomputable because the abundance predicate is only classically decidable.",
+    "mathContext": "$\\mathrm{countOddAbundant}(x)=\\big|\\{n\\in\\mathrm{Icc}\\,1\\,x:\\mathrm{Odd}\\,n\\wedge n.\\mathrm{Abundant}\\}\\big|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.Icc",
+      "Finset.filter",
+      "Finset.card"
+    ],
+    "prerequisites": [
+      "Nat.Abundant"
+    ]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "abundant-number-oq-03-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Quantitative lower bound: x < 1890·A(x) + 945",
+    "content": "The headline theorem odd_abundant_counting_lower_bound: for every x, x < 1890·countOddAbundant x + 945. Proof strategy — realise the odd-multiples family k ↦ 945·(2k+1), restricted to k < K = (x/945 + 1)/2, as the image of Finset.range K, and show that image is a subset of the counted filter: each witness is odd and abundant (odd_abundant_945_mul) and lies in [1,x] since 2k+1 ≤ x/945 gives 945·(2k+1) ≤ 945·(x/945) ≤ x. Injectivity of k ↦ 945·(2k+1) (odd_mul_succ_injective) gives card(image) = K via Finset.card_image_of_injective + Finset.card_range, and Finset.card_le_card of the subset yields K ≤ countOddAbundant x. The closing inequality x < 1890·A(x) + 945 is then pure division arithmetic (omega), using x < 945·(x/945) + 945 and x/945 ≤ 2·((x/945+1)/2).",
+    "mathContext": "With $K=\\lfloor(\\lfloor x/945\\rfloor+1)/2\\rfloor$, the injective image of $\\mathrm{range}\\,K$ under $k\\mapsto 945(2k+1)$ lies in the counted set, so $K\\le A(x)$ and $x<1890\\,A(x)+945$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "injective-image cardinality (Finset.card_image_of_injective)",
+      "Finset.card_le_card",
+      "omega division arithmetic",
+      "odd multiples of 945"
+    ],
+    "prerequisites": [
+      "odd_abundant_945_mul",
+      "odd_mul_succ_injective",
+      "Finset.image_subset_iff"
+    ]
+  },
+  {
+    "id": "ann-density",
+    "proofId": "abundant-number-oq-03-oq-02",
+    "range": {
+      "startLine": 93,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "Positive lower density ≥ 1/1890, and the axiom-free check",
+    "content": "odd_abundant_density_lower recasts the integer bound over ℝ: for every x, x/1890 − 1/2 < countOddAbundant x. It follows by casting odd_abundant_counting_lower_bound to ℝ (exact_mod_cast) and linarith. So the odd abundant numbers have lower density at least the positive constant 1/1890 — the quantitative strengthening of the parent's infinitely_many_odd_abundant. The closing #print axioms commands confirm both theorems depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound) and not on Lean.ofReduceBool or sorryAx: the result is genuinely axiom-free.",
+    "mathContext": "$\\dfrac{x}{1890}-\\dfrac12< A(x)$, hence $\\liminf_{x\\to\\infty}A(x)/x\\ge \\dfrac{1}{1890}>0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "lower density",
+      "exact_mod_cast / linarith",
+      "#print axioms verification"
+    ],
+    "prerequisites": [
+      "odd_abundant_counting_lower_bound",
+      "casting ℕ inequalities to ℝ"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment: add a full annotation set to a previously-unannotated entry

**Entry:** `abundant-number-oq-03-oq-02` — a quantitative lower bound on the counting function of odd abundant numbers (quality 30, the lowest in the pool).

This entry had **no annotations** (no `annotations.json` on `main`), so the whole Lean file was uncovered. This pass adds five annotations anchored to the file's constructs:

1. `ann-overview` (concept, 1–35) — the upgrade from infinitude to a quantitative bound `A(x) > x/1890 − 1/2` via the seed family `945·(2k+1)`, and the honest non-optimality of `1/1890`.
2. `ann-setup` (context, 39–49) — the classical counting filter and why `#print axioms` stays foundational-only.
3. `ann-count` (definition, 50–53) — the counting function `countOddAbundant x`.
4. `ann-lower-bound` (theorem, 55–91) — the headline `x < 1890·A(x) + 945` via an injective-image cardinality bound and `omega`.
5. `ann-density` (theorem, 93–113) — the real-valued lower-density statement and the axiom-free `#print axioms` check.

**Coverage:** 0% → ~97% of the Lean file. All anchors validated against the parsed constructs (block-comment, namespace, doc-comments); JSON well-formed. New `annotations.json` only; `meta.json` untouched.
