### PR TITLE
Enrich graded Nakayama lemma (nakayama-lemma-oq-01-oq-02): add full annotation set (was empty annotations)

### DIFF
--- a/src/data/proofs/nakayama-lemma-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/nakayama-lemma-oq-01-oq-02/annotations.json
@@ -1,1 +1,134 @@
-{"annotations":[]}
+[
+  {
+    "id": "ann-overview",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 6,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "Overview: the graded Nakayama lemma via the irrelevant ideal",
+    "content": "The parent entry formalises the local-ring Nakayama lemma: for a finitely generated module M over a local ring (R, 𝔪), 𝔪M = M ⟹ M = 0. Its second open question asks for the graded analogue, where the irrelevant ideal R₊ = ⨁_{i>0} Rᵢ of an ℕ-graded ring plays the role of the maximal ideal: for an ℕ-graded ring R and ℕ-graded R-module M, if R₊M = M then M = 0. The key point is that the graded case is FREE and in fact STRONGER: the local lemma genuinely needs finite generation (its engine is the determinant trick / Jacobson radical), but the graded statement needs no finite generation at all — it follows from a one-line degree argument. If M ≠ 0, the set of degrees carrying a nonzero homogeneous element is a nonempty subset of ℕ, so it has a least element d; pick 0 ≠ x ∈ M_d. Writing x ∈ M = R₊M as Σ rⱼ • mⱼ with rⱼ ∈ R₊, every rⱼ has zero degree-0 component, so each product (rⱼ)_i • (mⱼ)_e with i ≥ 1 lives in M_{i+e}, whose degree-d part is nonzero only if e = d − i < d — but M_e = 0 below d by minimality, so x_d = 0, contradiction. Only the additive degree-d projection projM, the graded compatibility Rᵢ • Mₑ ⊆ M_{i+e} (SetLike.GradedSMul), and Nat.find for the minimal degree are used. It is a research file, intentionally not registered in Proofs.lean.",
+    "mathContext": "$R_+M=M\\Rightarrow M=0$ for $\\mathbb N$-graded $R,M$: take the least degree $d$ with $M_d\\neq 0$, $0\\neq x\\in M_d$; every term of $x\\in R_+M$ shifts degree up by $i\\ge 1$, so its degree-$d$ part needs $M_{d-i}=0$ — contradiction.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nakayama's lemma",
+      "graded rings and modules",
+      "irrelevant ideal R₊",
+      "minimal-degree argument",
+      "SetLike.GradedSMul"
+    ],
+    "prerequisites": [
+      "ℕ-graded ring / module (GradedRing, DirectSum.Decomposition)",
+      "the local Nakayama lemma (parent entry)"
+    ]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "The internally-graded ring and module setup",
+    "content": "𝒜 : ℕ → σA is an internally graded ring (GradedRing 𝒜) and 𝓜 : ℕ → σM an internal graded module over it (SetLike.GradedSMul 𝒜 𝓜 with DirectSum.Decomposition 𝓜). The graded pieces 𝓜 n are additive submonoids of M (AddSubmonoidClass), NOT R-submodules — the faithful model, in which degree shifting Rᵢ • Mₑ ⊆ M_{i+e} is nontrivial. In this encoding the hypothesis R₊M = M is (HomogeneousIdeal.irrelevant 𝒜).toIdeal • ⊤ = ⊤ in Submodule R M, and the conclusion M = 0 is Subsingleton M (equivalently ⊤ = ⊥).",
+    "mathContext": "$\\mathcal A:\\mathbb N\\to\\sigma A$ a GradedRing, $\\mathcal M:\\mathbb N\\to\\sigma M$ with $\\mathcal A_i\\cdot\\mathcal M_e\\subseteq\\mathcal M_{i+e}$; pieces are additive submonoids of $M$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "GradedRing",
+      "DirectSum.Decomposition",
+      "AddSubmonoidClass",
+      "HomogeneousIdeal.irrelevant"
+    ],
+    "prerequisites": [
+      "internal gradings via SetLike"
+    ]
+  },
+  {
+    "id": "ann-projM",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 73
+    },
+    "type": "definition",
+    "title": "projM: the additive degree-i projection M →+ M",
+    "content": "projM 𝓜 i is the degree-i projection of the graded module M, packaged as an ADDITIVE homomorphism M →+ M (built from the decomposition equivalence composed with DFinsupp.evalAddMonoidHom i and the submonoid subtype). Crucially it is NOT R-linear: R acts by shifting degrees, so projecting onto a fixed degree does not commute with the R-action — this is exactly what makes the degree argument work. Modelled on GradedRing.proj. The simp lemma projM_apply unfolds it to (decompose 𝓜 m i : M).",
+    "mathContext": "$\\mathrm{projM}\\,i:M\\to_+ M,\\ m\\mapsto (\\mathrm{decompose}\\,\\mathcal M\\,m)_i$; additive but not $R$-linear.",
+    "significance": "key",
+    "relatedConcepts": [
+      "graded projection GradedRing.proj",
+      "DirectSum.decompose",
+      "AddMonoidHom"
+    ],
+    "prerequisites": [
+      "DirectSum.Decomposition 𝓜"
+    ]
+  },
+  {
+    "id": "ann-vanishing",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 104
+    },
+    "type": "lemma",
+    "title": "Key vanishing lemma: positive-degree action kills the bottom projection",
+    "content": "projM_smul_deg is the technical heart. If every graded piece below degree d is trivial (hmin), then for a homogeneous ring element a ∈ 𝒜 i of POSITIVE degree i ≠ 0 and any n : M, the degree-d component of a • n vanishes: projM 𝓜 d (a • n) = 0. Proof: expand n = Σ nₑ over its homogeneous support (DirectSum.sum_support_decompose), distribute the projection over the sum, and for each piece note a • nₑ ∈ M_{i+e} (SetLike.GradedSMul.smul_mem); its degree-d component is nonzero only when i + e = d, i.e. e = d − i < d, where nₑ = 0 by hmin, and otherwise decompose_of_mem_ne makes the off-diagonal component vanish. The omit clause drops the unused GradedRing 𝒜 / AddSubmonoidClass σA instances.",
+    "mathContext": "If $M_e=0\\ \\forall e<d$, $a\\in\\mathcal A_i$, $i\\neq 0$, then $\\big(a\\cdot n\\big)_d=0$: each $a\\cdot n_e\\in M_{i+e}$ meets degree $d$ only at $e=d-i<d$, where $n_e=0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "degree shifting Rᵢ • Mₑ ⊆ M_{i+e}",
+      "homogeneous decomposition",
+      "decompose_of_mem_ne"
+    ],
+    "prerequisites": [
+      "projM and projM_apply",
+      "SetLike.GradedSMul.smul_mem"
+    ]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 161
+    },
+    "type": "theorem",
+    "title": "graded_nakayama: the main theorem (M = 0), no finite generation",
+    "content": "The headline graded_nakayama: for an ℕ-graded ring 𝒜 and ℕ-graded module 𝓜, if the irrelevant ideal satisfies 𝒜₊ • ⊤ = ⊤ then M is Subsingleton (M = 0). Proof by contradiction from Nontrivial M: (1) the set of degrees carrying a nonzero homogeneous element is nonempty — otherwise every homogeneous piece is zero and the decomposition forces every m = 0; (2) let d = Nat.find of that set and pick a nonzero homogeneous witness x ∈ 𝓜 d, with hmin giving M_e = 0 for e < d (Nat.find_min); (3) since x ∈ M = 𝒜₊ • ⊤, apply Submodule.smul_induction_on — for a generator r • n with r ∈ 𝒜₊ the degree-0 component of r vanishes (mem_irrelevant_iff), so every homogeneous slice r_i has i ≠ 0 and projM_smul_deg kills its degree-d projection; the additive case closes under addition — hence projM 𝓜 d x = 0; (4) but projM at the same degree fixes the homogeneous x (decompose_of_mem_same), so x = 0, contradicting the choice of x.",
+    "mathContext": "Least degree $d$ with $M_d\\neq0$, $0\\neq x\\in M_d$; $x\\in\\mathcal A_+M$ gives $(x)_d=0$ by the vanishing lemma, yet $(x)_d=x$ — contradiction, so $M=0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.find / least degree",
+      "Submodule.smul_induction_on",
+      "HomogeneousIdeal.mem_irrelevant_iff",
+      "decompose_of_mem_same"
+    ],
+    "prerequisites": [
+      "projM_smul_deg (key vanishing lemma)",
+      "DirectSum.sum_support_decompose"
+    ]
+  },
+  {
+    "id": "ann-submodule",
+    "proofId": "nakayama-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 164,
+      "endLine": 171
+    },
+    "type": "theorem",
+    "title": "Submodule form: ⊤ = ⊥ under the graded Nakayama hypothesis",
+    "content": "graded_nakayama_top_eq_bot restates the conclusion at the level of submodules: under the same hypothesis 𝒜₊ • ⊤ = ⊤, the whole module is the zero submodule, (⊤ : Submodule R M) = ⊥. It is an immediate corollary — graded_nakayama gives Subsingleton M, and any two elements of a subsingleton (here ⊤ and ⊥) are equal by Subsingleton.elim.",
+    "mathContext": "$\\mathcal A_+\\cdot\\top=\\top\\Rightarrow (\\top:\\mathrm{Submodule}\\,R\\,M)=\\bot$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Subsingleton.elim",
+      "submodule lattice ⊤/⊥"
+    ],
+    "prerequisites": [
+      "graded_nakayama"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment: populate an empty annotation set

**Entry:** `nakayama-lemma-oq-01-oq-02` — the graded Nakayama lemma via the irrelevant ideal (quality 41).

The entry's `annotations.json` was the empty stub `{"annotations": []}`, so the whole Lean file was uncovered (and the stub was also the wrong shape — the schema is a flat array). This pass replaces it with six annotations anchored to the file's constructs:

1. `ann-overview` (concept, 6–52) — why the graded case is *free and stronger* than the local lemma: a one-line minimal-degree argument replacing the determinant trick / Jacobson radical, with no finite-generation hypothesis.
2. `ann-setup` (context, 56–62) — the internally-graded ring/module encoding (additive-submonoid pieces; `R₊M = M` as `irrelevant.toIdeal • ⊤ = ⊤`).
3. `ann-projM` (definition, 64–73) — the additive, deliberately *non*-`R`-linear degree projection `projM`.
4. `ann-vanishing` (lemma, 76–104) — `projM_smul_deg`, the key vanishing lemma (positive-degree action kills the bottom projection).
5. `ann-main` (theorem, 106–161) — `graded_nakayama`, the full minimal-degree contradiction proof.
6. `ann-submodule` (theorem, 164–171) — the `⊤ = ⊥` submodule restatement.

**Coverage:** 0% → ~90% of the Lean file. All anchors validated against the parsed constructs; JSON well-formed. `annotations.json` only; `meta.json` untouched.
