### PR TITLE
Enrich Lp Restriction Map (cauchy-schwarz-…-incomplete-01-oq-01): surface hidden conclusion field

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01/meta.json
@@ -95,7 +95,9 @@
   ],
   "conclusion": {
     "summary": "This entry answers the parent's open question oq-01 by constructing the restriction map restrictToLpCLM : Lp(μ) →L[ℝ] Lp(μ.restrict S) and proving it is an explicit norm-1 left inverse of extension-by-zero. The retraction identity restrictToLpCLM ∘ extByZeroCLM = id (as classes and as continuous linear maps) exhibits Lp(μ.restrict S) as an isometrically embedded, 1-complemented subspace of Lp(μ), and yields injectivity of extension-by-zero as a corollary. The file is self-contained (imports only Mathlib), fully machine-checked with 0 axioms and 0 sorries against Lean 4 / Mathlib v4.26.0.",
-    "significance": "Completes the dual pair of localization maps underlying the σ-finite Lᵖ Riesz representation theorem: extension-by-zero was enough to prove the parent theorem, but the restriction map is the conceptually natural companion, and making it a genuine retraction is what justifies calling the local Lᵖ space a complemented subspace of the global one.",
+    "implications": [
+      "Completes the dual pair of localization maps underlying the σ-finite Lᵖ Riesz representation theorem: extension-by-zero was enough to prove the parent theorem, but the restriction map is the conceptually natural companion, and making it a genuine retraction is what justifies calling the local Lᵖ space a complemented subspace of the global one."
+    ],
     "openQuestions": [
       "Is the composite in the other order, extByZeroCLM ∘ restrictToLpCLM, equal to multiplication by the indicator of S — the conditional-expectation-style projection onto functions supported in S — and is it idempotent (a genuine projection)? This would need a multiplication-by-indicator continuous linear map on Lp(μ).",
       "Does the restriction map generalize to a norm-nonincreasing continuous linear map Lp(μ) →L[ℝ] Lp(ν) for an arbitrary ν ≤ μ (not just ν = μ.restrict S), and is the assignment functorial in ν? This needs the absolute-continuity / measure-monotonicity API for MemLp and eLpNorm.",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01` (The Lᵖ Restriction Map and the Splitting of Extension-by-Zero). Quality 91 → 96.

**Dead-field defect:** `conclusion.significance` is never rendered — `ProofConclusion.tsx` reads `implications` and `openQuestions`, so the *Implications* section was displaying empty. Moved the significance text into `conclusion.implications` (the rendered field, as an array), preserving the existing `summary` and 3 `openQuestions`.

No Lean, annotation, or status/axiom changes. meta.json 12.3 KB (within the 60 KB cap).