### PR TITLE
research(van-aubel-theorem-oq-01): build-verify complex-number proof [COMPLETED, 0-axiom, 3thm]

### DIFF
--- a/proofs/Proofs/VanAubelTheoremOQ01.lean
+++ b/proofs/Proofs/VanAubelTheoremOQ01.lean
@@ -60,6 +60,6 @@ theorem vanAubel_perp_diagonals (a b c d : ℂ) :
     ((squareCenter c d - squareCenter a b) *
         conj (squareCenter d a - squareCenter b c)).re = 0 := by
   rw [vanAubel_key, mul_assoc, Complex.mul_conj]
-  simp [Complex.I_mul_re, Complex.ofReal_im]
+  simp [Complex.ofReal_im]
 
 end VanAubelTheoremOQ01

--- a/research/problems/van-aubel-theorem-oq-01/knowledge.md
+++ b/research/problems/van-aubel-theorem-oq-01/knowledge.md
@@ -19,3 +19,25 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-02 (researcher-1): BUILD-VERIFIED + lint cleanup [COMPLETED]
+
+**Mode**: ACT. **Outcome**: COMPLETED. The complex-number proof shipped build-pending in
+#24989 was confirmed to compile clean in Docker (`docker-build.sh Proofs.VanAubelTheoremOQ01`,
+`Built`, exit 0) under current Mathlib — **0 sorry, 0 axiom, 3 theorems**. Gallery meta was
+already `verified`/`original`; the research tracking JSON was stale (`status: active`,
+`sorryCount: 1`) and is corrected to `completed`/`0`.
+
+**The math**: `squareCenter u v = (u+v)/2 + I*(v-u)/2` (external square center via +90 rotation).
+The single identity `vanAubel_key : R - P = I*(S - Q)` is a `linear_combination` over ℂ using
+`Complex.I_sq`. Everything follows: `‖R-P‖ = ‖S-Q‖` from `norm_mul`/`Complex.norm_I`, and
+perpendicularity as `((R-P)*conj(S-Q)).re = 0` via `Complex.mul_conj`.
+
+**Cleanup**: removed an unused simp argument (`Complex.I_mul_re`) flagged by the
+`unusedSimpArgs` linter in `vanAubel_perp_diagonals` (simp closes the goal with just
+`Complex.ofReal_im`).
+
+**Note**: shared checkout was on `chore/sync-data`; working tree reverts under concurrent
+agents/hooks, so committed via git plumbing off `origin/main`.

--- a/src/data/research/problems/van-aubel-theorem-oq-01.json
+++ b/src/data/research/problems/van-aubel-theorem-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "van-aubel-theorem-oq-01",
   "title": "van Aubel's theorem: equal perpendicular diagonals of square centers",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-06-16T12:40:00.000Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Build-verified: proof compiles clean in Docker (Mathlib 4.x), 0 sorry / 0 axiom, 3 theorems. van Aubel's key identity R-P = i*(S-Q) yields equal + perpendicular diagonals.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Done — entry is verified/original, no open work.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,9 +31,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "COMPLETED & BUILD-VERIFIED. The complex-number formalization (shipped build-pending in #24989) compiles clean in Docker: 0 sorry, 0 axiom, 3 theorems. squareCenter u v = (u+v)/2 + I*(v-u)/2; the single ring identity vanAubel_key : R-P = I*(S-Q) gives both equal-length (norm_mul + norm_I) and perpendicular (mul_conj, real part 0) diagonals.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "The entire theorem collapses to one linear_combination over C using Complex.I_sq (I^2=-1); erecting squares via the +90 rotation i*(v-u) makes R-P = i*(S-Q) an exact algebraic identity, so equal length and perpendicularity are both free.",
+      "Perpendicularity is cleanly encoded as ((R-P) * conj(S-Q)).re = 0 (vanishing Euclidean inner product), discharged by Complex.mul_conj + the real part of a purely-imaginary number.",
+      "Confirmed the build-pending entry (#24989) is genuinely verified in Docker under current Mathlib; also removed an unused simp argument (Complex.I_mul_re) flagged by the unusedSimpArgs linter."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: van-aubel-theorem-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
@@ -54,7 +58,7 @@
     "mathlib": []
   },
   "started": "2026-06-16T18:50:58.853Z",
-  "lastUpdate": "2026-06-16T18:50:58.935Z",
+  "lastUpdate": "2026-07-02T00:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -65,7 +69,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VanAubelTheoremOQ01.lean"
     }


### PR DESCRIPTION
## Summary

van Aubel's theorem (`van-aubel-theorem-oq-01`) was shipped **build-pending** in #24989. This PR confirms the complex-number formalization genuinely compiles clean in Docker under current Mathlib and closes out the entry.

- **Build-verified**: `./proofs/scripts/docker-build.sh Proofs.VanAubelTheoremOQ01` → `Built`, exit 0.
- **0 sorry, 0 axiom, 3 theorems** — status is legitimately `verified`/`original`.
- Removed an unused simp argument (`Complex.I_mul_re`) flagged by the `unusedSimpArgs` linter in `vanAubel_perp_diagonals` (simp closes the goal with just `Complex.ofReal_im`).
- Corrected stale research tracking JSON (`status: active`→`completed`, `sorryCount: 1`→`0`) and appended a session note to `knowledge.md`.

## The math

`squareCenter u v = (u+v)/2 + I*(v-u)/2` — center of the external square on directed edge `u→v` (+90° rotation `i·(v-u)`). The whole theorem collapses to one identity over ℂ:

```
vanAubel_key : R - P = I * (S - Q)        -- linear_combination via Complex.I_sq
```

Multiplication by `i` is a length-preserving 90° rotation, so this single identity yields both:
- **equal diagonals** `‖R-P‖ = ‖S-Q‖` (`norm_mul` + `Complex.norm_I`), and
- **perpendicular diagonals** `((R-P)·conj(S-Q)).re = 0` (`Complex.mul_conj`).

Not a named Mathlib result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)