### PR TITLE
research(bell-numbers-oq-01-oq-02): Dobiński's formula Bₙ = e⁻¹·∑ kⁿ/k! [VERIFIED, 0-axiom, 6thm/209L, new entry]

### DIFF
--- a/proofs/Proofs/BellNumbersOQ01OQ02.lean
+++ b/proofs/Proofs/BellNumbersOQ01OQ02.lean
@@ -1,0 +1,209 @@
+/-
+# Dobiński's formula for the Bell numbers
+
+The Bell number `Bₙ` counts the partitions of an `n`-element set.  Dobiński's
+formula (1877) evaluates it as an infinite series,
+
+    Bₙ = (1/e) · Σ_{k=0}^{∞} kⁿ / k!.
+
+This file proves the formula in the equivalent product form
+
+    e · Bₙ = Σ_{k=0}^{∞} kⁿ / k!          (`exp_mul_bell`)
+
+and then divides through to obtain the classical statement (`dobinski`).
+
+## The bridge: the Stirling / falling-factorial expansion of powers
+
+The combinatorial engine is the identity, itself absent from pinned Mathlib,
+
+    kⁿ = Σ_{j=0}^{n} S(n, j) · (k)_j          (`pow_eq_sum_stirlingSecond_descFactorial`)
+
+where `S(n, j) = Nat.stirlingSecond n j` and `(k)_j = k.descFactorial j` is the
+falling factorial.  It is the defining property of the Stirling numbers of the
+second kind: a function from `k` points into `n` labelled cells is the same data
+as a partition of the `k` points into `j` nonempty blocks (`S(n,j)` ways) together
+with an injection of the blocks into the `n` cells (`(k)_j` ways).
+
+Dividing by `k!` and summing over `k`, the falling factorial telescopes:
+
+    Σ_{k} (k)_j / k! = Σ_{m} 1 / m! = e          (`tsum_descFactorial_div_factorial`)
+
+because `(k)_j / k! = 1/(k-j)!` for `k ≥ j` and vanishes below.  Hence
+
+    Σ_{k} kⁿ / k! = Σ_{j} S(n,j) · e = e · Σ_{j} S(n,j) = e · Bₙ,
+
+the last step being the row-sum identity `Bₙ = Σ_j S(n,j)` proved in
+`Proofs.BellNumbersOQ01` (`BellNumbersOQ01.bell_eq_sum_stirlingSecond`).
+
+## Main results (0 sorry, 0 axiom)
+* `pow_eq_sum_stirlingSecond_descFactorial` — `kⁿ = Σ_{j≤n} S(n,j)·(k)_j`.
+* `tsum_descFactorial_div_factorial` — `Σ_k (k)_j / k! = e`.
+* `exp_mul_bell` — `e · Bₙ = Σ_k kⁿ / k!`.
+* `dobinski` — `Bₙ = e⁻¹ · Σ_k kⁿ / k!`.
+
+Fully machine-checked, no extra axioms, no `native_decide`.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Exponential
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+import Proofs.BellNumbersOQ01
+
+namespace BellNumbersOQ01OQ02
+
+open Finset
+open scoped Nat
+
+/-- **The Stirling / falling-factorial expansion of a power.**
+`kⁿ = Σ_{j ≤ n} S(n,j)·(k)_j`, where `(k)_j = k.descFactorial j`.  The defining
+combinatorial property of the Stirling numbers of the second kind, absent from
+pinned Mathlib. -/
+theorem pow_eq_sum_stirlingSecond_descFactorial (k n : ℕ) :
+    k ^ n = ∑ j ∈ range (n + 1), Nat.stirlingSecond n j * k.descFactorial j := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    -- Pointwise:  k·(k)_j = (k)_{j+1} + j·(k)_j.
+    have key : ∀ j : ℕ,
+        k * k.descFactorial j = k.descFactorial (j + 1) + j * k.descFactorial j := by
+      intro j
+      rw [Nat.descFactorial_succ]
+      rcases le_or_gt j k with h | h
+      · have hcollect : (k - j) * k.descFactorial j + j * k.descFactorial j
+              = ((k - j) + j) * k.descFactorial j := by ring
+        rw [hcollect]
+        congr 1
+        omega
+      · have hz : k.descFactorial j = 0 := Nat.descFactorial_eq_zero_iff_lt.mpr h
+        simp [hz]
+    -- Reassemble the target from the two shifted blocks.
+    have step :
+        (∑ j ∈ range (n + 1), Nat.stirlingSecond n j * k.descFactorial (j + 1))
+          + (∑ j ∈ range (n + 1), Nat.stirlingSecond n j * (j * k.descFactorial j))
+        = ∑ j ∈ range (n + 2), Nat.stirlingSecond (n + 1) j * k.descFactorial j := by
+      rw [Finset.sum_range_succ'
+            (fun j => Nat.stirlingSecond (n + 1) j * k.descFactorial j) (n + 1)]
+      rw [Nat.stirlingSecond_succ_zero]
+      simp only [zero_mul, add_zero]
+      have hexp : ∀ i ∈ range (n + 1),
+          Nat.stirlingSecond (n + 1) (i + 1) * k.descFactorial (i + 1)
+            = Nat.stirlingSecond n i * k.descFactorial (i + 1)
+              + (i + 1) * Nat.stirlingSecond n (i + 1) * k.descFactorial (i + 1) := by
+        intro i _
+        rw [Nat.stirlingSecond_succ_succ]
+        ring
+      rw [Finset.sum_congr rfl hexp, Finset.sum_add_distrib]
+      -- Reindex the second block up by one; the tail term vanishes since S(n,n+1)=0.
+      have hB : (∑ j ∈ range (n + 1), Nat.stirlingSecond n j * (j * k.descFactorial j))
+          = ∑ i ∈ range (n + 1),
+              (i + 1) * Nat.stirlingSecond n (i + 1) * k.descFactorial (i + 1) := by
+        rw [Finset.sum_range_succ'
+              (fun j => Nat.stirlingSecond n j * (j * k.descFactorial j)) n]
+        rw [Finset.sum_range_succ
+              (fun i => (i + 1) * Nat.stirlingSecond n (i + 1) * k.descFactorial (i + 1)) n]
+        rw [Nat.stirlingSecond_eq_zero_of_lt (Nat.lt_succ_self n)]
+        simp only [mul_zero, zero_mul, add_zero]
+        apply Finset.sum_congr rfl
+        intro i _
+        ring
+      rw [hB]
+    calc
+      k ^ (n + 1) = k * k ^ n := by ring
+      _ = k * ∑ j ∈ range (n + 1), Nat.stirlingSecond n j * k.descFactorial j := by rw [ih]
+      _ = ∑ j ∈ range (n + 1), Nat.stirlingSecond n j * (k * k.descFactorial j) := by
+            rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro j _; ring
+      _ = ∑ j ∈ range (n + 1),
+            Nat.stirlingSecond n j * (k.descFactorial (j + 1) + j * k.descFactorial j) := by
+            apply Finset.sum_congr rfl; intro j _; rw [key j]
+      _ = (∑ j ∈ range (n + 1), Nat.stirlingSecond n j * k.descFactorial (j + 1))
+            + (∑ j ∈ range (n + 1), Nat.stirlingSecond n j * (j * k.descFactorial j)) := by
+            rw [← Finset.sum_add_distrib]; apply Finset.sum_congr rfl; intro j _; ring
+      _ = ∑ j ∈ range (n + 2), Nat.stirlingSecond (n + 1) j * k.descFactorial j := step
+
+/-- The falling factorial `(m+j)_j` divided by `(m+j)!` is `1/m!`, because
+`m! · (m+j)_j = (m+j)!`. -/
+theorem descFactorial_add_div_factorial (m j : ℕ) :
+    ((m + j).descFactorial j : ℝ) / ((m + j)! : ℝ) = 1 / (m ! : ℝ) := by
+  have hle : j ≤ m + j := Nat.le_add_left j m
+  have hnat : (m !) * (m + j).descFactorial j = (m + j)! := by
+    have h := Nat.factorial_mul_descFactorial hle
+    simpa [Nat.add_sub_cancel] using h
+  have hm : (m ! : ℝ) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero m
+  have hmj : ((m + j)! : ℝ) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero (m + j)
+  rw [div_eq_div_iff hmj hm, one_mul, mul_comm]
+  exact_mod_cast hnat
+
+/-- `Σ_k (k)_j / k! = e` as a `HasSum`: the low terms `k < j` vanish and the
+shift `k = m + j` turns the summand into `1/m!`, whose sum is `e`. -/
+theorem hasSum_descFactorial_div_factorial (j : ℕ) :
+    HasSum (fun k : ℕ => (k.descFactorial j : ℝ) / (k ! : ℝ)) (Real.exp 1) := by
+  have hb : HasSum (fun m : ℕ => (1 : ℝ) / (m ! : ℝ)) (Real.exp 1) := by
+    have hsum : Summable (fun m : ℕ => (1 : ℝ) ^ m / (m ! : ℝ)) :=
+      Real.summable_pow_div_factorial 1
+    have hval : Real.exp 1 = ∑' n : ℕ, (1 : ℝ) ^ n / (n ! : ℝ) := by
+      rw [Real.exp_eq_exp_ℝ, NormedSpace.exp_eq_tsum_div]
+    rw [hval]
+    simpa using hsum.hasSum
+  have hzero : ∑ i ∈ range j, (fun k : ℕ => (k.descFactorial j : ℝ) / (k ! : ℝ)) i = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    rw [Finset.mem_range] at hi
+    have hz : i.descFactorial j = 0 := Nat.descFactorial_eq_zero_iff_lt.mpr hi
+    simp [hz]
+  have hshift :
+      HasSum (fun m : ℕ => ((m + j).descFactorial j : ℝ) / ((m + j)! : ℝ)) (Real.exp 1) := by
+    have hcongr : (fun m : ℕ => ((m + j).descFactorial j : ℝ) / ((m + j)! : ℝ))
+        = (fun m : ℕ => (1 : ℝ) / (m ! : ℝ)) := by
+      funext m; exact descFactorial_add_div_factorial m j
+    rw [hcongr]; exact hb
+  refine (hasSum_nat_add_iff'
+    (f := fun k : ℕ => (k.descFactorial j : ℝ) / (k ! : ℝ)) j).mp ?_
+  rw [hzero, sub_zero]
+  exact hshift
+
+/-- `Σ_k (k)_j / k! = e`. -/
+theorem tsum_descFactorial_div_factorial (j : ℕ) :
+    ∑' k : ℕ, (k.descFactorial j : ℝ) / (k ! : ℝ) = Real.exp 1 :=
+  (hasSum_descFactorial_div_factorial j).tsum_eq
+
+/-- **Dobiński's formula, product form.**  `e · Bₙ = Σ_k kⁿ / k!`. -/
+theorem exp_mul_bell (n : ℕ) :
+    Real.exp 1 * (Nat.bell n : ℝ) = ∑' k : ℕ, (k : ℝ) ^ n / (k ! : ℝ) := by
+  have hpow : ∀ k : ℕ,
+      (k : ℝ) ^ n = ∑ j ∈ range (n + 1),
+        (Nat.stirlingSecond n j : ℝ) * (k.descFactorial j : ℝ) := by
+    intro k
+    exact_mod_cast pow_eq_sum_stirlingSecond_descFactorial k n
+  symm
+  calc
+    ∑' k : ℕ, (k : ℝ) ^ n / (k ! : ℝ)
+        = ∑' k : ℕ, ∑ j ∈ range (n + 1),
+            (Nat.stirlingSecond n j : ℝ) * ((k.descFactorial j : ℝ) / (k ! : ℝ)) := by
+          apply tsum_congr; intro k
+          rw [hpow k, Finset.sum_div]
+          apply Finset.sum_congr rfl; intro j _; ring
+      _ = ∑ j ∈ range (n + 1), ∑' k : ℕ,
+            (Nat.stirlingSecond n j : ℝ) * ((k.descFactorial j : ℝ) / (k ! : ℝ)) :=
+          Summable.tsum_finsetSum (fun j _ =>
+            ((hasSum_descFactorial_div_factorial j).summable).mul_left _)
+      _ = ∑ j ∈ range (n + 1),
+            (Nat.stirlingSecond n j : ℝ) * ∑' k : ℕ, ((k.descFactorial j : ℝ) / (k ! : ℝ)) := by
+          apply Finset.sum_congr rfl; intro j _; rw [tsum_mul_left]
+      _ = ∑ j ∈ range (n + 1), (Nat.stirlingSecond n j : ℝ) * Real.exp 1 := by
+          apply Finset.sum_congr rfl; intro j _
+          rw [tsum_descFactorial_div_factorial j]
+      _ = (∑ j ∈ range (n + 1), (Nat.stirlingSecond n j : ℝ)) * Real.exp 1 := by
+          rw [Finset.sum_mul]
+      _ = (Nat.bell n : ℝ) * Real.exp 1 := by
+          congr 1
+          rw [← Nat.cast_sum]
+          exact_mod_cast (BellNumbersOQ01.bell_eq_sum_stirlingSecond n).symm
+      _ = Real.exp 1 * (Nat.bell n : ℝ) := by ring
+
+/-- **Dobiński's formula.**  `Bₙ = e⁻¹ · Σ_k kⁿ / k!`. -/
+theorem dobinski (n : ℕ) :
+    (Nat.bell n : ℝ) = Real.exp (-1) * ∑' k : ℕ, (k : ℝ) ^ n / (k ! : ℝ) := by
+  rw [← exp_mul_bell n, ← mul_assoc,
+    show Real.exp (-1) * Real.exp 1 = 1 from by rw [← Real.exp_add]; norm_num, one_mul]
+
+end BellNumbersOQ01OQ02

--- a/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "bell-numbers-oq-01-oq-02",
+  "slug": "bell-numbers-oq-01-oq-02",
+  "title": "Dobiński's Formula for the Bell Numbers",
+  "status": "verified",
+  "badge": "original",
+  "description": "A machine-checked formalization of Dobiński's formula (1877): the n-th Bell number equals e⁻¹ times the n-th moment of the unit-mean Poisson distribution, Bₙ = e⁻¹·∑_{k≥0} kⁿ/k!. This answers the second open question of the parent entry bell-numbers-oq-01 (and the follow-up posed by bell-numbers-oq-01-oq-01). Neither the analytic identity nor its combinatorial engine is in pinned Mathlib. The proof is built on the falling-factorial expansion of a power, kⁿ = ∑_{j≤n} S(n,j)·(k)_j (pow_eq_sum_stirlingSecond_descFactorial), where S(n,j) = Nat.stirlingSecond n j and (k)_j = k.descFactorial j — the defining property of the Stirling numbers of the second kind, proved here by induction from the Stirling recurrence. Dividing by k! and summing over k, each falling-factorial series telescopes to e because (k)_j/k! = 1/(k−j)! for k ≥ j and vanishes below (tsum_descFactorial_div_factorial, via a HasSum index shift). Interchanging the finite j-sum with the infinite k-sum then gives ∑_k kⁿ/k! = e·∑_j S(n,j) = e·Bₙ, the last step invoking the row-sum identity Bₙ = ∑_j S(n,j) from the parent entry (BellNumbersOQ01.bell_eq_sum_stirlingSecond). Dividing by e yields the classical statement. Fully verified: 6 theorems, 0 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The Bell numbers 1, 1, 2, 5, 15, 52, … (OEIS A000110) count the partitions of a finite set. Dobiński's formula (G. Dobiński, 1877) gives the striking closed form Bₙ = e⁻¹·∑_{k≥0} kⁿ/k!, expressing a purely combinatorial integer as an infinite analytic series — equivalently, Bₙ is the n-th moment of a Poisson random variable of mean 1. It is one of the classical bridges between enumerative combinatorics and analysis, and the fastest route to Bell-number asymptotics. Mathlib provides the Bell numbers (Nat.bell) and the Stirling numbers of the second kind (Nat.stirlingSecond) but neither the falling-factorial expansion of powers nor Dobiński's identity; the sibling gallery entry bell-numbers-oq-01-oq-01 (the exponential generating function) explicitly lists 'derive Dobiński's formula' as its open question.",
+    "problemStatement": "Formalize Dobiński's formula Bₙ = e⁻¹·∑_{k≥0} kⁿ/k! in Lean over ℝ, with the Bell numbers taken as Mathlib's Nat.bell. This requires establishing the convergence of the moment series, the combinatorial expansion of kⁿ in terms of Stirling numbers and falling factorials, and the summation/telescoping that produces the factor e.",
+    "proofStrategy": "Avoid any generating-function machinery and work directly with the moment series. (1) pow_eq_sum_stirlingSecond_descFactorial: prove kⁿ = ∑_{j≤n} S(n,j)·(k)_j by induction on n, using k·(k)_j = (k)_{j+1} + j·(k)_j and the Stirling recurrence S(n+1,j+1) = (j+1)·S(n,j+1) + S(n,j) to reassemble the shifted blocks. (2) descFactorial_add_div_factorial: (m+j)_j/(m+j)! = 1/m! from Nat.factorial_mul_descFactorial. (3) hasSum_descFactorial_div_factorial: ∑_k (k)_j/k! = e as a HasSum — the low terms k < j vanish (Nat.descFactorial_eq_zero_iff_lt) and the shift k = m+j (hasSum_nat_add_iff') turns the tail into ∑_m 1/m! = e (NormedSpace.exp_eq_tsum_div at 1). (4) exp_mul_bell: substitute the expansion into ∑_k kⁿ/k!, distribute over k!, interchange the finite sum with the tsum (Summable.tsum_finsetSum), pull out constants (tsum_mul_left), replace each inner series by e, and collapse ∑_j S(n,j) to Bₙ via the parent's row-sum identity — giving e·Bₙ = ∑_k kⁿ/k!. (5) dobinski: multiply by e⁻¹ using e⁻¹·e = 1.",
+    "keyInsights": [
+      "The combinatorial engine is the falling-factorial expansion kⁿ = ∑_{j≤n} S(n,j)·(k)_j, the defining property of the Stirling numbers of the second kind; it is proved cleanly by induction from the Stirling recurrence, with the pointwise identity k·(k)_j = (k)_{j+1} + j·(k)_j reassembling the two shifted blocks.",
+      "Dividing by k! makes each falling-factorial series telescope: (k)_j/k! = 1/(k−j)! for k ≥ j (and 0 below), so ∑_k (k)_j/k! is a reindexed copy of ∑_m 1/m! = e, independent of j.",
+      "Once each inner sum is the same constant e, the outer sum ∑_j S(n,j)·e factors as e·∑_j S(n,j), and the finite row-sum identity Bₙ = ∑_j S(n,j) (proved in the parent entry) closes the argument — Dobiński's formula is thus the analytic shadow of a finite combinatorial identity.",
+      "The whole proof is elementary and generating-function-free: convergence is handled by Real.summable_pow_div_factorial and a HasSum index shift, and the double sum is interchanged with Summable.tsum_finsetSum since the j-index ranges over a finite set."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind Nat.stirlingSecond and their recurrence (stirlingSecond_succ_succ, stirlingSecond_eq_zero_of_lt)",
+      "Falling factorials Nat.descFactorial: descFactorial_succ, factorial_mul_descFactorial, descFactorial_eq_zero_iff_lt",
+      "Infinite sums over ℝ: HasSum, tsum, hasSum_nat_add_iff', Summable.tsum_finsetSum, tsum_mul_left, Real.summable_pow_div_factorial",
+      "The exponential series NormedSpace.exp_eq_tsum_div and Real.exp_eq_exp_ℝ, and the row-sum identity Bₙ = ∑_j S(n,j) from bell-numbers-oq-01"
+    ]
+  },
+  "sections": [
+    {
+      "id": "power-expansion",
+      "title": "Section I: The Stirling / Falling-Factorial Expansion of a Power",
+      "startLine": 56,
+      "endLine": 121,
+      "summary": "pow_eq_sum_stirlingSecond_descFactorial: kⁿ = ∑_{j≤n} S(n,j)·(k)_j, proved by induction on n from the Stirling recurrence.",
+      "mathContext": "The defining combinatorial property of the Stirling numbers of the second kind (absent from pinned Mathlib). The induction uses the pointwise identity k·(k)_j = (k)_{j+1} + j·(k)_j and reassembles the two shifted summation blocks, the tail vanishing because S(n,n+1) = 0."
+    },
+    {
+      "id": "telescoping-to-e",
+      "title": "Section II: The Falling-Factorial Series Telescopes to e",
+      "startLine": 123,
+      "endLine": 167,
+      "summary": "descFactorial_add_div_factorial and hasSum_descFactorial_div_factorial: ∑_k (k)_j/k! = e, then tsum_descFactorial_div_factorial packages it as a tsum.",
+      "mathContext": "(m+j)_j/(m+j)! = 1/m! via Nat.factorial_mul_descFactorial; the terms below k = j vanish, and the shift k = m+j (hasSum_nat_add_iff') turns the series into ∑_m 1/m! = e, evaluated with NormedSpace.exp_eq_tsum_div."
+    },
+    {
+      "id": "dobinski",
+      "title": "Section III: Assembling Dobiński's Formula",
+      "startLine": 169,
+      "endLine": 207,
+      "summary": "exp_mul_bell: e·Bₙ = ∑_k kⁿ/k!; dobinski: Bₙ = e⁻¹·∑_k kⁿ/k!.",
+      "mathContext": "Substitute the power expansion, interchange the finite j-sum with the infinite k-sum (Summable.tsum_finsetSum), replace each inner series by e (tsum_mul_left), and collapse ∑_j S(n,j) to Bₙ via BellNumbersOQ01.bell_eq_sum_stirlingSecond; dividing by e uses e⁻¹·e = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 209 lines with 6 theorems and 0 definitions. It proves Dobiński's formula Bₙ = e⁻¹·∑_{k≥0} kⁿ/k! (dobinski) and its product form e·Bₙ = ∑_k kⁿ/k! (exp_mul_bell), together with the two ingredients absent from pinned Mathlib: the falling-factorial power expansion kⁿ = ∑_j S(n,j)·(k)_j and the telescoping sum ∑_k (k)_j/k! = e. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "implications": "Answers the second open question of bell-numbers-oq-01 and the follow-up posed by the exponential-generating-function entry bell-numbers-oq-01-oq-01. The falling-factorial expansion pow_eq_sum_stirlingSecond_descFactorial and the telescoping lemma tsum_descFactorial_div_factorial are reusable: the former is the standard change of basis between ordinary powers and falling factorials (the connection coefficients being the Stirling numbers), and the latter is the moment computation for the unit Poisson distribution.",
+    "openQuestions": [
+      "Generalize to the Bell-polynomial / Touchard identity ∑_k kⁿ xᵏ/k! = eˣ·∑_j S(n,j)·xʲ (Dobiński being the case x = 1), giving the moments of a Poisson distribution of arbitrary mean x.",
+      "Formalize the falling-factorial expansion pow_eq_sum_stirlingSecond_descFactorial as the inverse of the Stirling-number-of-the-first-kind expansion of the falling factorial, exhibiting the two triangles as mutually inverse."
+    ]
+  },
+  "references": [
+    {
+      "key": "Dobinski_1877",
+      "citation": "Dobiński, G., Summirung der Reihe ∑ nᵐ/n! für m = 1, 2, 3, 4, 5, …, Grunert's Archiv 61 (1877), 333–336.",
+      "type": "article"
+    },
+    {
+      "key": "OEIS_A000110",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A000110 (Bell numbers).",
+      "type": "web"
+    },
+    {
+      "key": "Stanley_EC1",
+      "citation": "Stanley, R. P., Enumerative Combinatorics, Volume 1, 2nd ed., Cambridge University Press (2011), Chapter 1 (set partitions, Stirling and Bell numbers).",
+      "type": "book"
+    },
+    {
+      "key": "Wilf_generatingfunctionology",
+      "citation": "Wilf, H. S., generatingfunctionology, 3rd ed., A K Peters (2006), Chapter 1.",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "bell-numbers-oq-01",
+      "relationship": "Parent problem",
+      "description": "The parent entry proves the finite row-sum Bₙ = ∑_k S(n,k), which is the final step of this proof; its second open question asks for exactly this Dobiński formula."
+    },
+    {
+      "proofId": "bell-numbers-oq-01-oq-01",
+      "relationship": "Sibling",
+      "description": "The exponential-generating-function entry ∑ Bₙ Xⁿ/n! = exp(eˣ − 1); its conclusion explicitly lists deriving Dobiński's formula as an open question, which the present entry supplies by an independent, generating-function-free route."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Exponential",
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic",
+      "Proofs.BellNumbersOQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BellNumbersOQ01OQ02",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BellNumbersOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://oeis.org/A000110",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BellNumbersOQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "bell-numbers",
+      "stirling-numbers",
+      "dobinski",
+      "falling-factorial",
+      "infinite-series",
+      "exponential",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "S(n+1,j+1) = (j+1)·S(n,j+1) + S(n,j) — the Stirling recurrence driving the induction for the power expansion.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.factorial_mul_descFactorial",
+        "description": "(n−k)!·(n)_k = n! for k ≤ n — gives (m+j)_j/(m+j)! = 1/m!, the telescoping step.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "hasSum_nat_add_iff'",
+        "description": "Shifts a HasSum by a finite offset; used with k = m+j to reduce ∑_k (k)_j/k! to ∑_m 1/m!.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "NormedSpace.exp_eq_tsum_div",
+        "description": "exp x = ∑ₙ xⁿ/n!; at x = 1 (with Real.exp_eq_exp_ℝ) evaluates ∑_m 1/m! = e.",
+        "module": "Mathlib.Analysis.Normed.Algebra.Exponential"
+      },
+      {
+        "theorem": "Summable.tsum_finsetSum",
+        "description": "Interchanges a finite sum with a tsum; moves the finite j-sum outside the infinite k-sum.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Constructions"
+      },
+      {
+        "theorem": "BellNumbersOQ01.bell_eq_sum_stirlingSecond",
+        "description": "The row-sum identity Bₙ = ∑_j S(n,j) from the parent gallery entry — the final collapse of ∑_j S(n,j) to Bₙ.",
+        "module": "Proofs.BellNumbersOQ01"
+      }
+    ],
+    "originalContributions": [
+      "pow_eq_sum_stirlingSecond_descFactorial: the falling-factorial expansion kⁿ = ∑_{j≤n} S(n,j)·(k)_j (the defining property of the Stirling numbers of the second kind), absent from pinned Mathlib",
+      "tsum_descFactorial_div_factorial: the telescoping moment computation ∑_k (k)_j/k! = e",
+      "exp_mul_bell / dobinski: Dobiński's formula Bₙ = e⁻¹·∑_{k≥0} kⁿ/k!, verified by a generating-function-free route reusing the parent's row-sum identity"
+    ],
+    "axiomCount": 0,
+    "lineCount": 209,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for the main results. Compiled against Mathlib v4.26.0. Dobiński's formula is classical; the contribution is the verified formalization, including the two supporting facts absent from pinned Mathlib (the falling-factorial expansion of powers and the telescoping falling-factorial series).",
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Stirling numbers of the second kind and their recurrence",
+      "Falling factorials and Nat.factorial_mul_descFactorial",
+      "Infinite sums over ℝ (HasSum, tsum, hasSum_nat_add_iff', Summable.tsum_finsetSum, tsum_mul_left)",
+      "The exponential series and the row-sum identity Bₙ = ∑_j S(n,j)"
+    ],
+    "relatedProblems": [
+      "bell-numbers-oq-01",
+      "bell-numbers-oq-01-oq-01"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Formalizes **Dobiński's formula** (1877) for the Bell numbers over ℝ:
```
Bₙ = e⁻¹ · ∑_{k≥0} kⁿ/k!        (dobinski)
e · Bₙ = ∑_{k≥0} kⁿ/k!          (exp_mul_bell)
```
This answers the **second open question** of `bell-numbers-oq-01` and the follow-up explicitly listed by the EGF entry `bell-numbers-oq-01-oq-01`. New gallery entry (no prior dir / lean on main).

## Approach (generating-function-free)
- **`pow_eq_sum_stirlingSecond_descFactorial`** — the falling-factorial expansion `kⁿ = ∑_{j≤n} S(n,j)·(k)_j` (defining property of the Stirling numbers of the second kind, **absent from pinned Mathlib**), proved by induction from the Stirling recurrence.
- **`tsum_descFactorial_div_factorial`** — `∑_k (k)_j/k! = e`: the low terms vanish and the shift `k = m+j` telescopes the series to `∑_m 1/m! = e`.
- **`exp_mul_bell`** — substitute the expansion, interchange the finite `j`-sum with the `tsum` (`Summable.tsum_finsetSum`), replace each inner series by `e`, and collapse `∑_j S(n,j)` to `Bₙ` via the parent's row-sum identity `BellNumbersOQ01.bell_eq_sum_stirlingSecond`.

## Verification
- `#print axioms` for `dobinski` and `exp_mul_bell`: `[propext, Classical.choice, Quot.sound]`
- **0 axioms, 0 sorries, no native_decide**; 6 theorems / 0 definitions / 209 lines
- Compiled against Mathlib v4.26.0 (host `lean`, exit 0; docker cache thrashing under low disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)