### PR TITLE
research(sperner-mathlib4-oq-02-oq-04): odd hemisphere sign-degree — the oriented boundary seed for n=2 Tucker [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/SpernerTuckerHexagonSignDegree.lean
+++ b/proofs/Proofs/SpernerTuckerHexagonSignDegree.lean
@@ -1,0 +1,147 @@
+/-
+# The oriented boundary seed on the hexagon is the hemisphere sign-degree (ODD)
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's lemma and Borsuk–Ulam
+from abstract door-counting").
+
+## Where this sits — closing a gap left open by two negative results
+
+The abstract path-following engine (`SpernerTuckerPathFollowing.exists_interior_degree_one`)
+produces an interior complementary simplex from an **odd** count of boundary path
+endpoints.  The whole n ≥ 2 program hinges on supplying that odd boundary seed for a
+concrete triangulation.
+
+Two prior sessions established, on the standard hexagon + centre triangulation of `B²`
+(labels `{±1,±2}` encoded as `Fin 4`, antipodal on the boundary), that the seed is **not**
+any unsigned complementary-edge count:
+
+* `SpernerTuckerHexagonFullDoorGraph.boundary_door_count_even` — the number of
+  complementary *boundary* edges is always **even**; and
+* `SpernerTuckerHexagonFullDoorGraph.half_boundary_parity_not_invariant` — even passing
+  to a fundamental domain of the antipodal action does not fix a parity: the half-ring
+  complementary-edge count is even on some labellings and odd on others.
+
+Those sessions concluded — but did **not** construct — that the missing input must be an
+*oriented / antipodally-signed* count (a discrete Borsuk–Ulam degree on `S¹`), not a
+door-counting parity.  This file supplies exactly that count and proves it is odd.
+
+## What this file proves (all by kernel `decide`, 0 axioms)
+
+The correct oriented object is obtained by pushing the labelling through the **sign map**
+`sgn : Fin 4 → ZMod 2` collapsing `{+1,+2} ↦ 0` and `{-1,-2} ↦ 1`.  This map is the
+`ZMod 2` reduction underlying the antipodal action:
+
+* `sgn_negL` — `sgn (negL x) = sgn x + 1` for every label: the sign map is **antipodal**
+  (label negation flips the sign bit), so a hemisphere arc `v₀ → v₁ → v₂ → v₃ = -v₀`
+  becomes a `ZMod 2` path with **distinct endpoints** — precisely the boundary condition
+  of the already-verified one-dimensional Tucker lemma (`SpernerTuckerOneDim`).
+
+Hence the **hemisphere sign-degree** — the number of edges of that arc across which the
+sign bit flips — is odd, exactly by the telescoping ("discrete FTC") argument of n = 1
+Tucker, now realised on the boundary of real n = 2 geometry:
+
+* `arc_sign_changes_odd` — the hemisphere-arc sign-change count is **ODD** for **every**
+  antipodal labelling (verified over all `4³ = 64` free labellings).  This is the first
+  **positive** odd boundary seed for the hexagon; every prior boundary result was negative
+  (even, or not parity-invariant).
+* `full_sign_changes_even` — the sign-change count around the **whole** boundary ring is
+  always **even**: the odd seed lives on the antipodal *fundamental domain* (a hemisphere),
+  not on the full circle — the discrete analogue of "the degree is read off half the loop".
+
+## Why the sign-degree, and not the complementary-edge count
+
+The two objects genuinely differ, which is why the earlier unsigned counts failed:
+
+* `sign_change_not_complementary_witness` — there is a boundary edge whose two labels have
+  **opposite signs** (a sign-degree edge, e.g. `+2` then `-1`) yet are **not complementary**
+  (`λ(v_{i+1}) ≠ -λ(v_i)`).  So a sign flip need not be a complementary edge; the
+  complementary-edge count misses exactly these, which is why it is even / non-invariant
+  while the sign-degree is odd.
+
+## Honest status
+
+A **positive scoping result**: it constructs the odd oriented boundary seed the previous
+two negative results only pointed at, and pins it to the hemisphere sign-degree, connecting
+the n = 2 boundary directly to the verified n = 1 Tucker via the sign-reduction map.  It is
+**not** a full proof of n = 2 Tucker: the odd sign-degree counts boundary *sign flips*,
+whereas the interior target is a *complementary* simplex; bridging the two is the 2-D
+almost-complementary path-following (the genuine open lever every prior session flagged).
+This result identifies the seed that path-following must consume.
+
+Self-contained.  0 sorries, 0 axioms
+(`propext` / `Classical.choice` / `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`).
+-/
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Algebra.Group.Nat.Even
+
+namespace SpernerTuckerHexagonSignDegree
+
+open Finset
+
+/-! ## Labelling model (same encoding as `SpernerTuckerHexagon` / `…FullDoorGraph`) -/
+
+/-- Label negation on `{+1,+2,-1,-2}` encoded as `Fin 4` (`0↦+1,1↦+2,2↦-1,3↦-2`). -/
+def negL : Fin 4 → Fin 4 := ![2, 3, 0, 1]
+
+/-- The six boundary labels from three free labels `a,b,c` on `v0,v1,v2`, with the
+antipodal condition `v(i+3) = -v(i)` built in. -/
+def V (a b c : Fin 4) : Fin 6 → Fin 4 := ![a, b, c, negL a, negL b, negL c]
+
+/-- Cyclic successor around the hexagon boundary. -/
+def rot (i : Fin 6) : Fin 6 := i + 1
+
+/-- **Sign map** `sgn : Fin 4 → ZMod 2` collapsing magnitude: `{+1,+2} ↦ 0`,
+`{-1,-2} ↦ 1`.  This is the `ZMod 2` reduction underlying the antipodal action. -/
+def sgn : Fin 4 → ZMod 2 := ![0, 0, 1, 1]
+
+/-- **The sign map is antipodal.**  Label negation flips the sign bit:
+`sgn (negL x) = sgn x + 1` for every label.  Hence a hemisphere arc
+`v₀ → … → v₃ = -v₀` has sign-distinct endpoints — the n = 1 Tucker boundary condition. -/
+theorem sgn_negL : ∀ x : Fin 4, sgn (negL x) = sgn x + 1 := by decide
+
+/-! ## The hemisphere sign-degree is odd -/
+
+/-- **Hemisphere sign-degree.**  The number of edges of the fundamental-domain arc
+`v₀ → v₁ → v₂ → v₃` (three consecutive boundary edges, `v₃ = -v₀`) across which the sign
+bit flips. -/
+def arcSignChanges (a b c : Fin 4) : ℕ :=
+  (([0, 1, 2] : List (Fin 6)).filter
+    (fun i => decide (sgn (V a b c (rot i)) ≠ sgn (V a b c i)))).length
+
+/-- **The hemisphere sign-degree is ODD** for every antipodal labelling.  This is the
+positive odd boundary seed the path-following engine needs — obtained as the n = 1 Tucker
+count of the sign-reduced labelling on the antipodal arc, whose endpoints `sgn v₀` and
+`sgn v₃ = sgn v₀ + 1` differ (`sgn_negL`).  Verified over all `4³ = 64` free labellings
+(the centre label is irrelevant to the boundary). -/
+theorem arc_sign_changes_odd : ∀ a b c : Fin 4, Odd (arcSignChanges a b c) := by decide
+
+/-- Sign flips around the **whole** boundary ring `v₀ → v₁ → ⋯ → v₅ → v₀`. -/
+def fullSignChanges (a b c : Fin 4) : ℕ :=
+  ((List.finRange 6).filter
+    (fun i => decide (sgn (V a b c (rot i)) ≠ sgn (V a b c i)))).length
+
+/-- **The full-ring sign-change count is EVEN.**  The odd seed lives on the antipodal
+fundamental domain (a hemisphere arc), not on the whole circle: the loop returns to its
+starting sign, so its total sign-change count is even.  The discrete analogue of reading
+the degree off half the loop. -/
+theorem full_sign_changes_even : ∀ a b c : Fin 4, Even (fullSignChanges a b c) := by decide
+
+/-! ## The sign-degree is a genuinely different object from the complementary count -/
+
+/-- **A sign flip need not be a complementary edge.**  There is a boundary edge whose two
+labels have opposite signs (`sgn (V (rot i)) ≠ sgn (V i)`) yet are **not** complementary
+(`V (rot i) ≠ negL (V i)`) — e.g. `+2` followed by `-1`.  This is exactly the discrepancy
+that makes the unsigned complementary-edge count even / non-parity-invariant while the
+signed sign-degree is odd. -/
+theorem sign_change_not_complementary_witness :
+    ∃ a b c : Fin 4, ∃ i : Fin 6,
+      sgn (V a b c (rot i)) ≠ sgn (V a b c i) ∧
+      V a b c (rot i) ≠ negL (V a b c i) := by decide
+
+#print axioms sgn_negL
+#print axioms arc_sign_changes_odd
+#print axioms full_sign_changes_even
+#print axioms sign_change_not_complementary_witness
+
+end SpernerTuckerHexagonSignDegree

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-04/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-header-sperner-oq02-oq04",
+    "proofId": "sperner-mathlib4-oq-02-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "The oriented boundary seed for n = 2 Tucker is the hemisphere sign-degree",
+    "content": "The header frames the entry against the open frontier of the whole door-counting program. The path-following engine turns an ODD count of boundary path endpoints into an interior complementary simplex, so n ≥ 2 Tucker hinges on supplying that odd seed for a concrete triangulation. On the hexagon triangulation of B², two sibling entries proved only NEGATIVE facts: the complementary boundary-edge count is always EVEN, and its antipodal-quotient half-ring is NOT parity-invariant — concluding, but never constructing, that the seed must be an oriented / antipodally-signed count. This file constructs it: push the {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2, which is antipodal, so a hemisphere arc becomes a ZMod-2 antipodal-boundary path whose sign-change count — the hemisphere sign-degree — is ODD, while the full ring is EVEN. Honest status: the first positive odd boundary seed for the hexagon, identifying the oriented input path-following must consume; 0 sorries, 0 axioms (propext / Classical.choice / Quot.sound only — plain decide, no Lean.ofReduceBool). It is not a full n = 2 Tucker proof.",
+    "mathContext": "Boundary labelling $V\\,a\\,b\\,c : \\mathrm{Fin}\\,6 \\to \\mathrm{Fin}\\,4$ with the antipodal condition $v_{i+3} = -v_i$, encoding $\\{+1,+2,-1,-2\\}$ as $\\mathrm{Fin}\\,4$ and negation $\\mathrm{negL} = [2,3,0,1]$. The sign map $\\mathrm{sgn} : \\mathrm{Fin}\\,4 \\to \\mathbb{Z}/2$ sends $\\{+1,+2\\}\\mapsto 0$, $\\{-1,-2\\}\\mapsto 1$. The hemisphere sign-degree is $\\#\\{i \\in \\{0,1,2\\} : \\mathrm{sgn}\\,v_{i+1} \\neq \\mathrm{sgn}\\,v_i\\}$ along the arc $v_0 \\to v_1 \\to v_2 \\to v_3 = -v_0$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "door-counting program",
+      "oriented boundary seed",
+      "discrete Borsuk–Ulam degree",
+      "hemisphere fundamental domain"
+    ],
+    "prerequisites": [
+      "combinatorial topology",
+      "parity arguments"
+    ]
+  },
+  {
+    "id": "ann-signmap-sperner-oq02-oq04",
+    "proofId": "sperner-mathlib4-oq-02-oq-04",
+    "range": {
+      "startLine": 82,
+      "endLine": 101
+    },
+    "type": "technique",
+    "title": "The sign map is the antipodal ZMod-2 reduction",
+    "content": "Reuses the hexagon encoding of the sibling entries — negL is label negation on {+1,+2,-1,-2} = Fin 4, V a b c produces the six antipodal boundary labels from three free labels a,b,c, and rot is the cyclic successor around the boundary. The new ingredient is the sign map sgn : Fin 4 → ZMod 2 that collapses magnitude ({+1,+2} ↦ 0, {-1,-2} ↦ 1). sgn_negL proves sgn (negL x) = sgn x + 1 by decide: label negation flips the sign bit, so sgn is the ZMod 2 reduction underlying the antipodal action. The immediate consequence — used implicitly by the next section — is that a hemisphere arc v₀ → ⋯ → v₃ = -v₀ has sign-distinct endpoints sgn v₀ and sgn v₃ = sgn v₀ + 1, exactly the boundary condition of the one-dimensional Tucker lemma.",
+    "mathContext": "$\\mathrm{sgn}(\\mathrm{negL}\\,x) = \\mathrm{sgn}\\,x + 1$ in $\\mathbb{Z}/2$ for every $x \\in \\mathrm{Fin}\\,4$; hence for the arc endpoints $\\mathrm{sgn}\\,v_3 = \\mathrm{sgn}(\\mathrm{negL}\\,a) = \\mathrm{sgn}\\,a + 1 = \\mathrm{sgn}\\,v_0 + 1 \\neq \\mathrm{sgn}\\,v_0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sign map",
+      "antipodal action",
+      "ZMod 2 reduction",
+      "label negation involution"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "finite labellings"
+    ]
+  },
+  {
+    "id": "ann-arcodd-sperner-oq02-oq04",
+    "proofId": "sperner-mathlib4-oq-02-oq-04",
+    "range": {
+      "startLine": 103,
+      "endLine": 128
+    },
+    "type": "theorem",
+    "title": "The hemisphere sign-degree is odd; the full ring is even",
+    "content": "arcSignChanges counts the edges of the fundamental-domain arc v₀ → v₁ → v₂ → v₃ across which the sign bit flips. arc_sign_changes_odd proves this hemisphere sign-degree is ODD for every antipodal labelling — verified by kernel decide over all 4³ = 64 free boundary labellings (the centre label does not affect the boundary). Mathematically this is the one-dimensional Tucker lemma applied to the sign-reduced labelling: a ZMod-2 path with distinct endpoints has an odd number of sign changes by a telescoping (discrete-FTC) argument, since the changes sum to sgn v₃ − sgn v₀ = 1 mod 2. This is the first POSITIVE odd boundary seed for the hexagon. fullSignChanges counts sign flips around the whole ring, and full_sign_changes_even proves it is always EVEN: the loop returns to its starting sign, so the oddness is a fundamental-domain phenomenon — read off half the loop, not the whole circle.",
+    "mathContext": "$\\sum_{i=0}^{2} (\\mathrm{sgn}\\,v_{i+1} - \\mathrm{sgn}\\,v_i) = \\mathrm{sgn}\\,v_3 - \\mathrm{sgn}\\,v_0 = 1$ in $\\mathbb{Z}/2$, so the number of sign changes on the arc is odd; the analogous full-ring sum telescopes to $0$, so its count is even.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sign-degree",
+      "one-dimensional Tucker lemma",
+      "telescoping / discrete FTC",
+      "fundamental domain",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "parity of sums in ZMod 2",
+      "finite case analysis"
+    ]
+  },
+  {
+    "id": "ann-signvscompl-sperner-oq02-oq04",
+    "proofId": "sperner-mathlib4-oq-02-oq-04",
+    "range": {
+      "startLine": 130,
+      "endLine": 147
+    },
+    "type": "insight",
+    "title": "A sign flip is weaker than a complementary edge",
+    "content": "sign_change_not_complementary_witness exhibits, by decide, an antipodal labelling and a boundary edge whose two labels have opposite signs (a sign-degree edge) yet are NOT complementary — for instance +2 immediately followed by -1, which flips the sign bit but has V (rot i) ≠ negL (V i). This is the exact discrepancy explaining the sibling entries' negative results: the unsigned complementary-edge count omits these opposite-sign-but-not-complementary edges, which is why that count is even / non-parity-invariant while the signed hemisphere sign-degree is odd. It also isolates the remaining work: the 2-D interior path-following must reconcile the odd count of boundary sign flips with the interior complementary simplices, turning the correct oriented seed into Tucker's conclusion.",
+    "mathContext": "There exist $a,b,c$ and an index $i$ with $\\mathrm{sgn}(V\\,(rot\\,i)) \\neq \\mathrm{sgn}(V\\,i)$ but $V\\,(rot\\,i) \\neq \\mathrm{negL}(V\\,i)$: opposite sign does not imply complementary, e.g. $+2$ then $-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complementary edge",
+      "sign flip",
+      "path-following",
+      "almost-complementary simplex"
+    ],
+    "prerequisites": [
+      "the Tucker complementary-edge condition"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-04/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-04/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "sperner-mathlib4-oq-02-oq-04",
+  "title": "The Odd Boundary Seed for n = 2 Tucker is the Hemisphere Sign-Degree",
+  "slug": "sperner-mathlib4-oq-02-oq-04",
+  "description": "The door-counting path-following engine for Tucker's lemma produces an interior complementary simplex from an ODD count of boundary path endpoints, so the whole n ≥ 2 program hinges on supplying that odd boundary seed for a concrete triangulation. Sibling entries established, on the standard hexagon + centre triangulation of B² (labels {±1,±2} encoded as Fin 4, antipodal on the boundary), only NEGATIVE facts: the number of complementary boundary edges is always EVEN (boundary_door_count_even), and its antipodal-quotient half-ring count is NOT parity-invariant (half_boundary_parity_not_invariant). They concluded — but never constructed — that the missing input must be an oriented / antipodally-signed count (a discrete Borsuk–Ulam degree on S¹), not a door-counting parity. This entry supplies exactly that count and proves it is odd. The correct oriented object is obtained by pushing the labelling through the sign map sgn : Fin 4 → ZMod 2 collapsing magnitude ({+1,+2} ↦ 0, {−1,−2} ↦ 1). This map is antipodal: sgn (negL x) = sgn x + 1 (sgn_negL), so a hemisphere arc v₀ → v₁ → v₂ → v₃ = −v₀ becomes a ZMod-2 path with DISTINCT endpoints — precisely the boundary condition of the verified one-dimensional Tucker lemma. Hence the hemisphere sign-degree — the number of arc edges across which the sign bit flips — is ODD for every antipodal labelling (arc_sign_changes_odd, over all 4³ = 64 free labellings), the first POSITIVE odd boundary seed for the hexagon, while the full-ring sign-change count is always EVEN (full_sign_changes_even): the seed lives on the antipodal fundamental domain, not the whole circle. Finally sign_change_not_complementary_witness exhibits a boundary edge whose two labels have opposite signs yet are NOT complementary (e.g. +2 then −1), the exact discrepancy that makes the unsigned complementary-edge count even / non-invariant while the signed sign-degree is odd. Honest status: a positive scoping result identifying and verifying the oriented boundary seed the two prior negative results only pointed at; it is not a full n = 2 Tucker proof — bridging the odd sign-degree to an interior complementary simplex is the 2-D almost-complementary path-following (the open geometric lever). 0 axioms, 0 sorries (propext / Classical.choice / Quot.sound only — plain decide, no Lean.ofReduceBool).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tucker%27s_lemma",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/SpernerTuckerHexagonSignDegree.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 6,
+    "lineCount": 147,
+    "tags": [
+      "topology",
+      "tucker-lemma",
+      "borsuk-ulam",
+      "sperner-lemma",
+      "combinatorial-topology",
+      "door-counting",
+      "freund-todd",
+      "sign-degree",
+      "parity"
+    ],
+    "assumptions": [],
+    "imports": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Fin.VecNotation",
+      "Mathlib.Algebra.Group.Nat.Even"
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Tucker's lemma (Albert W. Tucker, 1945) is the combinatorial heart of the Borsuk–Ulam theorem; its constructive proofs (Freund–Todd 1981; Prescott–Su 2005) follow a path along the almost-complementary simplices from a forced boundary endpoint to an interior complementary one. The grandparent entry sperner-mathlib4 verifies the abstract door-counting engine and its dimension recursion (TuckerTower), whose path-following step consumes an ODD count of boundary path endpoints at each level. On the concrete hexagon triangulation of B² the sibling entries sperner-mathlib4-oq-02 and sperner-mathlib4-oq-02-oq-01 proved only that no UNSIGNED door count supplies that odd seed (the complementary boundary-edge count is even; its half-ring is not parity-invariant), and sperner-mathlib4-oq-02-oq-02 gave the dimension-free structural reason (antipodal symmetry forces even endpoint counts). All conjectured the seed must be an oriented / antipodally-signed count. This entry constructs that count and proves it odd.",
+    "problemStatement": "On the hexagon + centre triangulation of B², label the six boundary vertices v₀..v₅ by {+1,+2,-1,-2} = Fin 4 with the antipodal condition v(i+3) = -v(i) (three free labels a,b,c). Define the sign map sgn : Fin 4 → ZMod 2 by {+1,+2} ↦ 0 and {-1,-2} ↦ 1. Prove: (i) sgn is antipodal, sgn (negL x) = sgn x + 1; (ii) the hemisphere sign-degree — the number of edges of the fundamental-domain arc v₀ → v₁ → v₂ → v₃ across which sgn flips — is ODD for every antipodal labelling; (iii) the full-ring sign-change count is EVEN; (iv) a sign flip need not be a complementary edge (a boundary edge can have opposite signs yet not be complementary).",
+    "proofStrategy": "Everything is finite and decidable, so each statement is discharged by kernel decide over the 4³ = 64 free boundary labellings (the centre label is irrelevant to the boundary), giving genuinely 0-axiom certificates (plain decide, not native_decide, so no Lean.ofReduceBool). The mathematical content is the choice of object: the sign map sgn is the ZMod 2 reduction underlying label negation, so sgn (negL x) = sgn x + 1 makes the arc endpoints sgn v₀ and sgn v₃ = sgn v₀ + 1 distinct; the hemisphere sign-degree is then exactly the number of ZMod-2 sign changes along an antipodal-boundary path, which the one-dimensional Tucker lemma (verified in SpernerTuckerOneDim by a telescoping / discrete-FTC argument) makes odd. The full-ring count is even because the loop returns to its starting sign. The witness lemma separates the sign-degree from the complementary-edge count that the sibling entries showed even.",
+    "keyInsights": [
+      "The oriented boundary seed the whole n ≥ 2 program was missing is the hemisphere SIGN-degree: push the {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2 and count sign flips along an antipodal-boundary arc. This is the first POSITIVE odd boundary seed on the hexagon — every prior boundary result (even ring, non-invariant half-ring) was negative.",
+      "The sign map is the ZMod 2 reduction of the antipodal action (sgn (negL x) = sgn x + 1), so a hemisphere arc v₀ → ⋯ → v₃ = −v₀ has sign-distinct endpoints — exactly the boundary condition of the verified one-dimensional Tucker lemma. The odd hemisphere sign-degree is therefore n = 1 Tucker applied to the sign-reduced labelling, connecting the n = 2 boundary directly to the already-verified base case.",
+      "The seed lives on the antipodal fundamental domain, not the whole circle: the full-ring sign-change count is EVEN (the loop returns to its starting sign), so the oddness is read off half the loop — the discrete analogue of reading a degree off a fundamental domain. This is why the sibling entries' full-ring and symmetric counts had to be even.",
+      "A sign flip is a genuinely weaker event than a complementary edge: a boundary edge can have opposite signs (e.g. +2 then −1) yet not be complementary (λ(v_{i+1}) ≠ −λ(v_i)). The complementary-edge count misses exactly these edges, which is precisely why it is even / non-parity-invariant while the sign-degree is odd. Bridging the odd sign flips to an interior complementary simplex is the remaining 2-D path-following."
+    ]
+  },
+  "sections": [
+    {
+      "id": "labelling-and-sign-map",
+      "title": "The Antipodal Labelling and the Sign Map",
+      "startLine": 82,
+      "endLine": 101,
+      "summary": "Reuses the hexagon encoding of the sibling entries: negL is label negation on {+1,+2,-1,-2} = Fin 4, V a b c gives the six antipodal boundary labels from three free labels, rot is the cyclic successor. Introduces the sign map sgn : Fin 4 → ZMod 2 collapsing magnitude ({+1,+2} ↦ 0, {-1,-2} ↦ 1) and proves sgn_negL: sgn (negL x) = sgn x + 1, i.e. the sign map is antipodal (label negation flips the sign bit). This is what makes a hemisphere arc have sign-distinct endpoints — the n = 1 Tucker boundary condition."
+    },
+    {
+      "id": "hemisphere-sign-degree-odd",
+      "title": "The Hemisphere Sign-Degree is Odd, the Full Ring Even",
+      "startLine": 103,
+      "endLine": 128,
+      "summary": "arcSignChanges counts the edges of the fundamental-domain arc v₀ → v₁ → v₂ → v₃ across which the sign bit flips, and arc_sign_changes_odd proves this hemisphere sign-degree is ODD for every antipodal labelling (all 4³ = 64 cases by decide) — the positive odd boundary seed, obtained as n = 1 Tucker of the sign-reduced labelling whose arc endpoints sgn v₀ and sgn v₃ = sgn v₀ + 1 differ. fullSignChanges counts sign flips around the whole ring, and full_sign_changes_even proves it is always EVEN: the odd seed lives on the antipodal fundamental domain, not the whole circle."
+    },
+    {
+      "id": "sign-vs-complementary",
+      "title": "The Sign-Degree is Not the Complementary-Edge Count",
+      "startLine": 130,
+      "endLine": 147,
+      "summary": "sign_change_not_complementary_witness exhibits an antipodal labelling and a boundary edge whose two labels have opposite signs (a sign-degree edge) yet are NOT complementary (V (rot i) ≠ negL (V i)) — e.g. +2 followed by −1. This is the exact discrepancy that makes the unsigned complementary-edge count of the sibling entries even / non-parity-invariant while the signed hemisphere sign-degree is odd, and it isolates what the 2-D interior path-following must reconcile."
+    }
+  ],
+  "conclusion": {
+    "summary": "On the concrete hexagon triangulation of B², the entry constructs the oriented boundary seed the door-counting program needs and proves it odd: pushing the antipodal {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2 (which is antipodal, sgn (negL x) = sgn x + 1) turns a hemisphere fundamental-domain arc into a ZMod-2 antipodal-boundary path, whose sign-change count — the hemisphere sign-degree — is ODD for every one of the 4³ = 64 labellings, while the full-ring count is EVEN. A witness lemma separates this sign-degree from the complementary-edge count the sibling entries showed even. Four theorems, six definitions, 0 axioms, 0 sorries (plain decide, no Lean.ofReduceBool).",
+    "implications": "This supplies the first POSITIVE odd boundary seed for the n = 2 hexagon, completing the picture the two prior negative results (even complementary ring; non-invariant half-ring) and the no-go theorem (symmetric graphs force even endpoints) only pointed at: the seed is the hemisphere sign-degree, an oriented ZMod-2 count read off the antipodal fundamental domain, and it equals n = 1 Tucker of the sign-reduced labelling. The remaining open lever is unchanged — the 2-D almost-complementary path-following that turns this odd count of boundary sign flips into an interior complementary simplex — but the input that path-following must consume is now explicitly identified and verified, not conjectural.",
+    "openQuestions": [
+      "Build the 2-D almost-complementary door graph on the hexagon whose degree-1 boundary endpoints are exactly the hemisphere sign-flip edges counted here, and verify by path-following (not decide) that the odd sign-degree forces an interior complementary simplex — the end-to-end n = 2 validation of the engine thesis.",
+      "Generalise the hemisphere sign-degree to ∂B^{n} in all dimensions and identify it with the inductive (n−1)-Tucker count, supplying the TuckerTower.bridge input as an oriented sign-degree rather than an unsigned door parity."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry: proved the complementary boundary-edge count is even and its half-ring not parity-invariant, concluding the seed must be oriented/signed. This entry constructs that oriented seed — the hemisphere sign-degree — and proves it odd."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry: the dimension-free no-go theorem that antipodal symmetry forces even endpoint counts, so the odd seed needs the symmetry broken on a hemisphere. This entry realises that hemisphere seed concretely on the hexagon as the sign-degree."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02",
+      "relationship": "parent",
+      "description": "Parent problem entry for n = 2 Tucker from door-counting; this entry supplies the positive odd boundary seed on the hexagon that the parent and its obstruction siblings established could not come from any unsigned door count."
+    },
+    {
+      "targetId": "sperner-mathlib4",
+      "relationship": "grandparent",
+      "description": "Grandparent entry: the verified door-counting engine and TuckerTower dimension recursion whose path-following step consumes the odd boundary-endpoint count that this entry identifies with the hemisphere sign-degree."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SpernerTuckerHexagonSignDegree.lean",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 6,
+    "imports": [
+      "import Mathlib.Data.ZMod.Basic",
+      "import Mathlib.Data.Fin.VecNotation",
+      "import Mathlib.Algebra.Group.Nat.Even"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Albert W. Tucker",
+      "title": "Some topological properties of disk and sphere",
+      "year": 1945,
+      "venue": "Proc. First Canadian Math. Congress, Montreal, 285–309",
+      "note": "The original combinatorial lemma equivalent to the Borsuk–Ulam theorem."
+    },
+    {
+      "authors": "Robert M. Freund and Michael J. Todd",
+      "title": "A constructive proof of Tucker's combinatorial lemma",
+      "year": 1981,
+      "venue": "Journal of Combinatorial Theory, Series A 30(3), 321–325",
+      "note": "The path-following / door-counting construction whose odd boundary seed this entry identifies with the hemisphere sign-degree."
+    },
+    {
+      "authors": "Timothy Prescott and Francis Edward Su",
+      "title": "A constructive proof of Ky Fan's generalization of Tucker's lemma",
+      "year": 2005,
+      "venue": "Journal of Combinatorial Theory, Series A 111(2), 257–265",
+      "note": "The oriented Ky Fan count; the hemisphere sign-degree verified here is the n = 2 realisation of that signed input on the fundamental domain."
+    },
+    {
+      "authors": "Jiří Matoušek",
+      "title": "Using the Borsuk–Ulam Theorem",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Tucker's lemma, the antipodal action, hemisphere fundamental domains, and combinatorial degrees on the boundary sphere."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified research artifact for **`sperner-mathlib4-oq-02`** (Tucker's lemma / Borsuk–Ulam from abstract door-counting). Supplies the **positive odd oriented boundary seed** that two prior sibling entries established was needed but only pointed at with negative results.

- **File**: `proofs/Proofs/SpernerTuckerHexagonSignDegree.lean` (147 L, 4 thm, 6 def)
- **Gallery**: `src/data/proofs/sperner-mathlib4-oq-02-oq-04/`
- **Status**: VERIFIED, **0 axioms**, 0 sorries — `#print axioms` = `propext`/`Classical.choice`/`Quot.sound` only (plain `decide`, **no** `Lean.ofReduceBool`). Host `lean v4.26.0`.

## The gap this closes

The path-following engine turns an **odd** count of boundary path endpoints into an interior complementary simplex, so n≥2 Tucker hinges on that odd boundary seed. On the hexagon triangulation of B², prior siblings proved only **negative** facts:

- `…FullDoorGraph.boundary_door_count_even` — complementary boundary-edge count always **even**;
- `…FullDoorGraph.half_boundary_parity_not_invariant` — its antipodal-quotient half-ring is **not parity-invariant**;
- `…AntipodalSymmetry.symmetric_graph_not_tucker_level` — antipodal symmetry forces **even** endpoint counts.

They concluded — but never constructed — that the seed must be an *oriented / antipodally-signed* count. This entry constructs it and proves it odd.

## What is proved

Push the `{±1,±2}` labelling through the magnitude-collapsing **sign map** `sgn : Fin 4 → ZMod 2`:

- `sgn_negL` — `sgn (negL x) = sgn x + 1`: the sign map is **antipodal** (the ZMod-2 reduction of label negation), so a hemisphere arc `v₀→v₁→v₂→v₃ = −v₀` has **sign-distinct endpoints** — the n=1 Tucker boundary condition.
- `arc_sign_changes_odd` — the **hemisphere sign-degree** (sign flips along the fundamental-domain arc) is **ODD** for every antipodal labelling (all 4³=64 by `decide`). The first *positive* odd boundary seed on the hexagon; it is n=1 Tucker of the sign-reduced labelling.
- `full_sign_changes_even` — the **full-ring** sign-change count is always **EVEN**: the seed lives on the antipodal fundamental domain, not the whole circle.
- `sign_change_not_complementary_witness` — a sign flip need **not** be complementary (`+2` then `−1`): exactly why the unsigned complementary count was even/non-invariant while the signed degree is odd.

## Honest status

A **positive scoping result**: it identifies and verifies the oriented boundary seed the engine consumes, connecting the n=2 boundary to the verified n=1 Tucker via sign-reduction. It is **not** a full n=2 Tucker proof — bridging the odd boundary sign flips to an interior complementary simplex is the 2-D almost-complementary path-following (the open geometric lever). Purely additive: one new Lean file + one new gallery entry (`oq-04`), no shared-file edits (distinct from the concurrent `oq-03`/`SpernerTuckerFixedPointParity` work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)