### PR TITLE
Enrich Dobiński's formula for Bell numbers (bell-numbers-oq-01-oq-02): full annotation set

### DIFF
--- a/src/data/proofs/bell-numbers-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bell-numbers-oq-01-oq-02/annotations.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "ann-bell0102-header",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Dobiński's Formula: the Bell number as a Poisson moment",
+    "content": "The module docstring lays out the whole argument. Dobiński's formula (1877) evaluates the n-th Bell number Bₙ — the number of partitions of an n-element set — as an infinite series Bₙ = (1/e)·Σ_{k≥0} kⁿ/k!, equivalently as e⁻¹ times the n-th moment of a unit-mean Poisson random variable. The file proves the product form e·Bₙ = Σ_k kⁿ/k! (exp_mul_bell) and divides through to get the classical statement (dobinski). The combinatorial engine — absent from pinned Mathlib and rebuilt here — is the Stirling/falling-factorial expansion kⁿ = Σ_{j≤n} S(n,j)·(k)_j. Dividing by k! and summing over k, each falling-factorial series telescopes to e, and the finite j-sum of Stirling numbers collapses to Bₙ via the row-sum identity Bₙ = Σ_j S(n,j) from the parent entry. Fully machine-checked: 6 theorems, 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "$B_n = e^{-1}\\displaystyle\\sum_{k=0}^{\\infty}\\frac{k^n}{k!}$, i.e. $B_n = e^{-1}\\,\\mathbb{E}[K^n]$ for $K\\sim\\mathrm{Poisson}(1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bell numbers (set partitions)",
+      "Stirling numbers of the second kind",
+      "Poisson distribution moments",
+      "Dobiński's formula (1877)"
+    ],
+    "prerequisites": [
+      "Bell numbers Bₙ count set partitions",
+      "convergence of Σ kⁿ/k!",
+      "the exponential series e = Σ 1/k!"
+    ]
+  },
+  {
+    "id": "ann-bell0102-pow-expansion",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 121
+    },
+    "type": "theorem",
+    "title": "pow_eq_sum_stirlingSecond_descFactorial: kⁿ = Σ_{j≤n} S(n,j)·(k)_j",
+    "content": "The combinatorial bridge, and the file's longest proof. It expresses an ordinary power kⁿ in the falling-factorial basis, with Stirling numbers of the second kind S(n,j) = Nat.stirlingSecond n j as coefficients and (k)_j = k.descFactorial j the falling factorial. Combinatorially: a function from k points into n labelled cells is the same data as a partition of the points into j nonempty blocks (S(n,j) ways) plus an injection of the blocks into the cells ((k)_j ways). The proof is by induction on n. The successor step rests on the pointwise recurrence k·(k)_j = (k)_{j+1} + j·(k)_j (from Nat.descFactorial_succ, split on j ≤ k vs j > k where the falling factorial vanishes), combined with the Stirling recurrence S(n+1,j) via Nat.stirlingSecond_succ_succ. The two shifted sum-blocks are reindexed (Finset.sum_range_succ / sum_range_succ') and reassembled, the boundary terms vanishing because S(n,n+1)=0 and S(n+1,0)=0. A final calc chain multiplies the inductive hypothesis by k and matches the reassembled target.",
+    "mathContext": "$k^n=\\displaystyle\\sum_{j=0}^{n}S(n,j)\\,(k)_j,\\qquad k\\,(k)_j=(k)_{j+1}+j\\,(k)_j,\\qquad S(n{+}1,j)=S(n,j{-}1)+j\\,S(n,j).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.stirlingSecond and its recurrence",
+      "falling factorial Nat.descFactorial",
+      "Nat.descFactorial_succ",
+      "induction with reindexed Finset sums"
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind",
+      "the falling-factorial recurrence",
+      "manipulating and reindexing finite sums"
+    ]
+  },
+  {
+    "id": "ann-bell0102-descfact-div",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "descFactorial_add_div_factorial: (m+j)_j / (m+j)! = 1/m!",
+    "content": "The pointwise identity powering the telescoping. Because m!·(m+j)_j = (m+j)! (Nat.factorial_mul_descFactorial, with the subtraction (m+j)−j simplifying to m), dividing the falling factorial (m+j)_j by the factorial (m+j)! leaves exactly 1/m!. Cast to ℝ, it is proved by clearing denominators (div_eq_div_iff, both factorials nonzero via Nat.factorial_ne_zero) and discharging the resulting natural-number identity with exact_mod_cast. This is the shifted-index form: writing k = m + j exposes that (k)_j/k! depends only on k − j.",
+    "mathContext": "$m!\\cdot (m+j)_j=(m+j)!\\ \\Longrightarrow\\ \\dfrac{(m+j)_j}{(m+j)!}=\\dfrac{1}{m!}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.factorial_mul_descFactorial",
+      "falling factorial vs factorial",
+      "div_eq_div_iff and exact_mod_cast"
+    ],
+    "prerequisites": [
+      "the identity m!·(m+j)_j = (m+j)!",
+      "casting a Nat identity to ℝ"
+    ]
+  },
+  {
+    "id": "ann-bell0102-hassum",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 136,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "hasSum_descFactorial_div_factorial: Σ_k (k)_j/k! = e (as a HasSum)",
+    "content": "The telescoping step, stated as a HasSum so summability travels with the value. For fixed j, the series Σ_k (k)_j/k! sums to e. Three ingredients: (1) the base series Σ_m 1/m! HasSum e, obtained from Real.summable_pow_div_factorial 1 and the tsum expansion of Real.exp; (2) the low terms k < j vanish, since (k)_j = 0 for k < j (Nat.descFactorial_eq_zero_iff_lt); (3) the index shift k = m + j, under which the summand becomes 1/m! by the previous lemma. The tail-after-j series is peeled off with hasSum_nat_add_iff', and the fact that the first j terms are zero lets the shifted series carry the value e back to the full series.",
+    "mathContext": "$\\displaystyle\\sum_{k=0}^{\\infty}\\frac{(k)_j}{k!}=\\sum_{m=0}^{\\infty}\\frac{1}{m!}=e,$ the low terms $k<j$ vanishing because $(k)_j=0$ there.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "HasSum and hasSum_nat_add_iff'",
+      "Real.summable_pow_div_factorial",
+      "Nat.descFactorial_eq_zero_iff_lt",
+      "index-shift of an infinite series"
+    ],
+    "prerequisites": [
+      "HasSum / Summable in a normed field",
+      "the exponential series Σ 1/m! = e",
+      "splitting a tsum into a finite head and a shifted tail"
+    ]
+  },
+  {
+    "id": "ann-bell0102-tsum",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 164,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "tsum_descFactorial_div_factorial: the telescoping as a tsum equation",
+    "content": "The value form of the previous result: the unconditional sum ∑' k, (k)_j/k! equals e, obtained immediately from the HasSum version via .tsum_eq. This is the shape actually consumed inside the main assembly, where the inner k-series is pulled out of the finite j-sum.",
+    "mathContext": "$\\displaystyle\\sum_{k}{}'\\ \\frac{(k)_j}{k!}=e\\quad\\text{for every }j.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasSum.tsum_eq",
+      "unconditional (tsum) summation"
+    ],
+    "prerequisites": [
+      "a HasSum determines its tsum"
+    ]
+  },
+  {
+    "id": "ann-bell0102-exp-mul-bell",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 169,
+      "endLine": 201
+    },
+    "type": "theorem",
+    "title": "exp_mul_bell: the product form e·Bₙ = Σ_k kⁿ/k!",
+    "content": "The main assembly, a calc chain that fuses the three ingredients. Starting from Σ_k kⁿ/k!, substitute the Stirling expansion of kⁿ (cast to ℝ) so each term becomes a finite j-sum of S(n,j)·(k)_j/k!. The crucial move is interchanging the infinite k-sum with the finite j-sum — legitimate here via Summable.tsum_finsetSum, using that each inner series is summable (from hasSum_descFactorial_div_factorial) with a scalar S(n,j) pulled through by tsum_mul_left. Each inner k-series collapses to e by tsum_descFactorial_div_factorial, leaving (Σ_j S(n,j))·e. The row-sum identity Bₙ = Σ_j S(n,j) — imported from the parent entry BellNumbersOQ01.bell_eq_sum_stirlingSecond — finishes it as Bₙ·e = e·Bₙ. This is the substantive theorem; dobinski is a one-liner on top.",
+    "mathContext": "$\\displaystyle\\sum_{k}\\frac{k^n}{k!}=\\sum_{k}\\sum_{j\\le n}\\frac{S(n,j)(k)_j}{k!}=\\sum_{j\\le n}S(n,j)\\!\\sum_{k}\\frac{(k)_j}{k!}=\\Big(\\sum_{j\\le n}S(n,j)\\Big)e=B_n\\,e.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Summable.tsum_finsetSum (sum interchange)",
+      "tsum_mul_left",
+      "BellNumbersOQ01.bell_eq_sum_stirlingSecond (row-sum identity)",
+      "the Poisson-moment interpretation of Σ kⁿ/k!"
+    ],
+    "prerequisites": [
+      "interchanging a finite and an infinite sum",
+      "the Bell/Stirling row-sum identity Bₙ = Σ_j S(n,j)",
+      "the three lemmas above combined"
+    ]
+  },
+  {
+    "id": "ann-bell0102-dobinski",
+    "proofId": "bell-numbers-oq-01-oq-02",
+    "range": {
+      "startLine": 203,
+      "endLine": 207
+    },
+    "type": "theorem",
+    "title": "dobinski: the classical statement Bₙ = e⁻¹·Σ_k kⁿ/k!",
+    "content": "Dobiński's formula in its usual form, deduced in two lines from the product form. Rewriting back through exp_mul_bell and using e⁻¹·e = 1 (Real.exp(-1)·Real.exp 1 = Real.exp(-1+1) = Real.exp 0 = 1, via Real.exp_add and norm_num) isolates Bₙ. This is the headline result: the transcendental e⁻¹ times the n-th moment of the unit-mean Poisson distribution recovers the purely combinatorial Bell number exactly.",
+    "mathContext": "$B_n=e^{-1}\\displaystyle\\sum_{k=0}^{\\infty}\\frac{k^n}{k!}$, obtained from $e\\cdot B_n=\\sum_k k^n/k!$ by multiplying through by $e^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.exp_add (e⁻¹·e = 1)",
+      "Dobiński's formula",
+      "combinatorial identity from an analytic one"
+    ],
+    "prerequisites": [
+      "the product form exp_mul_bell",
+      "e⁻¹·e = 1"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Adds `annotations.json` **from scratch** for `bell-numbers-oq-01-oq-02` (Dobiński's formula, `Bₙ = e⁻¹·Σ_k kⁿ/k!`). The entry had rich narrative sections and a conclusion but **zero annotations** (quality 39).

Seven annotations now cover the module docstring and all six theorems of the 209-line verified proof:
- **header** — the Poisson-moment reading of Dobiński's formula
- **pow_eq_sum_stirlingSecond_descFactorial** — the Stirling/falling-factorial expansion `kⁿ = Σ_{j≤n} S(n,j)·(k)_j` (the combinatorial engine, absent from pinned Mathlib)
- **descFactorial_add_div_factorial** — `(m+j)_j/(m+j)! = 1/m!`
- **hasSum_descFactorial_div_factorial** — the telescoping `Σ_k (k)_j/k! = e`
- **tsum_descFactorial_div_factorial** — its tsum form
- **exp_mul_bell** — the assembly `e·Bₙ = Σ_k kⁿ/k!` via a finite/infinite sum interchange + the parent's row-sum identity `Bₙ = Σ_j S(n,j)`
- **dobinski** — the classical statement

Each annotation carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Validation
- All 7 annotations anchor to a valid Lean construct (verified against the on-main source via `findConstructAtLine`).
- Ranges are disjoint and in-bounds (file is 209 lines).
- Quality score **39 → 94** (annotations 0→25, mathContext 0→10, significance 0→10, crossRefs 0→10).
- No changes to the Lean proof; annotation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)