### PR TITLE
Enrich complex Descartes circle theorem (descartes-circle-theorem-oq-01-oq-01): mathContext + Vieta/bridge insights

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/annotations.json
@@ -2,75 +2,131 @@
   {
     "id": "ann-docstring",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 40 },
+    "range": {
+      "startLine": 1,
+      "endLine": 40
+    },
     "type": "concept",
     "title": "Overview: the complex Descartes theorem",
     "content": "The real parent related four signed curvatures by (k₁+k₂+k₃+k₄)² = 2(∑kᵢ²), with Soddy solutions existing only when the symmetric product is nonnegative. Lagarias–Mallows–Wilks (2002) showed the SAME relation holds over ℂ for the curvature·centre products wᵢ = kᵢ·zᵢ. This module formalises that algebra; its new content is that over ℂ the fourth Soddy curvature ALWAYS exists — the algebraically-closed field always supplies the needed square root.",
     "mathContext": "$(w_1+w_2+w_3+w_4)^2 = 2\\sum w_i^2$, $w_i = k_i z_i$",
     "significance": "key",
-    "relatedConcepts": ["Descartes circle theorem", "Soddy circles", "Apollonian packing", "algebraically closed field"],
-    "prerequisites": ["complex numbers", "quadratic equations"]
+    "relatedConcepts": [
+      "Descartes circle theorem",
+      "Soddy circles",
+      "Apollonian packing",
+      "algebraically closed field"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "quadratic equations"
+    ]
   },
   {
     "id": "ann-def",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 45, "endLine": 50 },
+    "range": {
+      "startLine": 45,
+      "endLine": 50
+    },
     "type": "definition",
     "title": "The Descartes relation over ℂ",
     "content": "descartesRelC a b c d : Prop := (a+b+c+d)² = 2(a²+b²+c²+d²), the Descartes Circle relation with the four real curvatures replaced by four complex quantities — either the curvatures themselves or the LMW curvature·centre products.",
     "significance": "key",
-    "relatedConcepts": ["Descartes relation"]
+    "relatedConcepts": [
+      "Descartes relation"
+    ],
+    "mathContext": "$\\mathrm{descartesRelC}\\,a\\,b\\,c\\,d\\ :=\\ (a+b+c+d)^2 = 2(a^2+b^2+c^2+d^2)$ over $\\mathbb{C}$."
   },
   {
     "id": "ann-iff-sq",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 52, "endLine": 60 },
+    "range": {
+      "startLine": 52,
+      "endLine": 60
+    },
     "type": "insight",
     "title": "Quadratic-in-d perfect-square form",
     "content": "descartesRelC a b c d ↔ (d − (a+b+c))² = 4(ab+bc+ca). A pure ring identity (proved by linear_combination), exposing the relation as a quadratic in the fourth curvature d.",
     "significance": "key",
-    "relatedConcepts": ["linear_combination", "perfect square", "quadratic"]
+    "relatedConcepts": [
+      "linear_combination",
+      "perfect square",
+      "quadratic"
+    ],
+    "mathContext": "$\\mathrm{descartesRelC}\\,a\\,b\\,c\\,d\\iff (d-(a+b+c))^2 = 4(ab+bc+ca)$."
   },
   {
     "id": "ann-soddy-iff",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 62, "endLine": 77 },
+    "range": {
+      "startLine": 62,
+      "endLine": 77
+    },
     "type": "insight",
     "title": "Soddy parametrisation over ℂ",
     "content": "For any complex square root s of ab+bc+ca, the relation holds iff d = (a+b+c) + 2s or d = (a+b+c) − 2s. The quadratic factors as (d − (a+b+c) − 2s)(d − (a+b+c) + 2s) = 0; over ℂ no sign hypothesis on the symmetric product is needed, unlike the real parent.",
     "mathContext": "$d = (a+b+c) \\pm 2s,\\ s^2 = ab+bc+ca$",
     "significance": "critical",
-    "relatedConcepts": ["mul_eq_zero", "Soddy circles", "square root"]
+    "relatedConcepts": [
+      "mul_eq_zero",
+      "Soddy circles",
+      "square root"
+    ]
   },
   {
     "id": "ann-exists",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 79, "endLine": 83 },
+    "range": {
+      "startLine": 79,
+      "endLine": 83
+    },
     "type": "insight",
     "title": "Unconditional existence over ℂ (the new phenomenon)",
     "content": "Every triple a,b,c admits a fourth d satisfying the relation. Because ℂ is algebraically closed (IsAlgClosed.exists_pow_nat_eq), the symmetric product ab+bc+ca always has a complex square root s, so d = (a+b+c) + 2s works. The real discriminant-nonnegativity obstruction disappears entirely — this is the essential difference from the real Descartes theorem.",
     "significance": "critical",
-    "relatedConcepts": ["IsAlgClosed.exists_pow_nat_eq", "algebraically closed field", "existence"],
-    "prerequisites": ["algebraically closed fields"]
+    "relatedConcepts": [
+      "IsAlgClosed.exists_pow_nat_eq",
+      "algebraically closed field",
+      "existence"
+    ],
+    "prerequisites": [
+      "algebraically closed fields"
+    ],
+    "mathContext": "$\\forall a,b,c\\in\\mathbb{C}\\ \\exists d:\\ (d-(a+b+c))^2=4(ab+bc+ca)$, e.g. $d=(a+b+c)+2s$ with $s^2=ab+bc+ca$."
   },
   {
     "id": "ann-both-vieta",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 85, "endLine": 100 },
+    "range": {
+      "startLine": 85,
+      "endLine": 100
+    },
     "type": "insight",
     "title": "Both solutions and Vieta relations",
     "content": "Both Soddy values are solutions (descartes_soddy_both). Their Vieta sum is 2(a+b+c) (soddy_sumC, a ring identity) and their product is (a+b+c)² − 4(ab+bc+ca) (soddy_prodC, using s² = ab+bc+ca).",
     "significance": "supporting",
-    "relatedConcepts": ["Vieta's formulas", "sum and product of roots"]
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "sum and product of roots"
+    ],
+    "mathContext": "$d_\\pm=(a+b+c)\\pm 2s$ satisfy $d_++d_-=2(a+b+c)$ and $d_+d_-=(a+b+c)^2-4(ab+bc+ca)$."
   },
   {
     "id": "ann-bridge",
     "proofId": "descartes-circle-theorem-oq-01-oq-01",
-    "range": { "startLine": 102, "endLine": 112 },
+    "range": {
+      "startLine": 102,
+      "endLine": 112
+    },
     "type": "insight",
     "title": "Bridge to the real theorem and a concrete case",
     "content": "descartesRelC_ofReal: restricted to real arguments (cast into ℂ) the complex relation is exactly the parent's real Descartes relation (closed by norm_cast). descartes_soddy_exists_unit is the concrete instance a = b = c = 1: three unit curvatures admit a fourth complex Soddy curvature.",
     "significance": "supporting",
-    "relatedConcepts": ["norm_cast", "real embedding"]
+    "relatedConcepts": [
+      "norm_cast",
+      "real embedding"
+    ],
+    "mathContext": "Real $a,b,c,d\\hookrightarrow\\mathbb{C}$: $\\mathrm{descartesRelC}$ reduces to the real relation; for $a=b=c=1$, $ab+bc+ca=3$ and $d=3\\pm2\\sqrt3$."
   }
 ]

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-01/meta.json
@@ -2,7 +2,9 @@
   "id": "descartes-circle-theorem-oq-01-oq-01",
   "slug": "descartes-circle-theorem-oq-01-oq-01",
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "namespace": "DescartesCircleTheoremOQ01OQ01",
     "lineCount": 113,
@@ -50,7 +52,9 @@
     "keyInsights": [
       "The Descartes relation (a+b+c+d)² = 2(a²+b²+c²+d²) is a ring identity equivalent to the quadratic-in-d perfect square (d − (a+b+c))² = 4(ab+bc+ca), valid over any commutative ring, in particular ℂ.",
       "For any complex square root s of ab+bc+ca, the relation factors as (d − (a+b+c) − 2s)(d − (a+b+c) + 2s) = 0, giving exactly the two Soddy solutions d = (a+b+c) ± 2s.",
-      "ℂ is algebraically closed, so ab+bc+ca always has a square root (IsAlgClosed.exists_pow_nat_eq): the fourth Soddy curvature exists unconditionally, unlike the real case."
+      "ℂ is algebraically closed, so ab+bc+ca always has a square root (IsAlgClosed.exists_pow_nat_eq): the fourth Soddy curvature exists unconditionally, unlike the real case.",
+      "The two Soddy curvatures are the roots of a single monic quadratic determined symmetrically by a, b, c: by Vieta they satisfy d₊ + d₋ = 2(a+b+c) (soddy_sumC) and d₊·d₋ = (a+b+c)² − 4(ab+bc+ca) (soddy_prodC), so the unordered pair {d₊, d₋} is intrinsic to the triple.",
+      "The complex relation is a faithful generalization of the real one: for real curvatures cast into ℂ, descartesRelC is exactly the parent’s real Descartes relation (descartesRelC_ofReal, by norm_cast). The symmetric instance a = b = c = 1 recovers three mutually tangent unit circles with fourth curvature d = 3 ± 2√3."
     ]
   },
   "sections": [


### PR DESCRIPTION
## Summary
Two focused enrichments to the complex Descartes Circle Theorem entry (`descartesRelC`, the Lagarias–Mallows–Wilks generalization over ℂ):

**mathContext filled on 5 annotations** that previously had none — the definition `(a+b+c+d)²=2(a²+b²+c²+d²)`, the perfect-square form `(d−(a+b+c))²=4(ab+bc+ca)`, unconditional existence over ℂ, the Vieta sum/product, and the real-restriction bridge with the `a=b=c=1` case.

**Two key insights added** (3→5):
- The two Soddy curvatures `d± = (a+b+c)±2s` are the roots of a single quadratic determined symmetrically by `a,b,c` (Vieta: sum `2(a+b+c)`, product `(a+b+c)²−4(ab+bc+ca)`).
- The complex relation reduces to the parent's real Descartes relation under `norm_cast` (`descartesRelC_ofReal`); the symmetric instance `a=b=c=1` gives `d = 3 ± 2√3`.

## Validation
- Annotation **ranges unchanged**; all 7 anchors re-validated against the on-main Lean source.
- Quality **88 → 96** (mathContext 6→10, keyInsights 6→10).
- No Lean changes; metadata/annotation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)