### PR TITLE
research(chebyshev-bounds-oq-02-oq-01-oq-02): θ(x)=Θ(x) transfer [VERIFIED, 0-axiom, build-fix + new gallery entry]

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean
@@ -52,7 +52,7 @@ theorem theta_le_linear {x : ℝ} (hx : 0 ≤ x) : θ x ≤ (Real.log 4 + 4) * x
 /-- **Floor bridge.** For real `x`, `ψ(x)` equals the parent's natural-number Chebyshev sum at
 `⌊x⌋₊`, because both are `∑_{n ≤ ⌊x⌋₊} Λ(n)`. -/
 theorem psi_eq_chebyshevPsi_floor (x : ℝ) :
-    ψ x = ChebyshevBoundsOQ02OQ01.chebyshevPsi ⌊x⌋₊ := by
+    ψ x = ChebyshevBoundsOQ02.chebyshevPsi ⌊x⌋₊ := by
   rw [ChebyshevBoundsOQ02OQ01.chebyshevPsi_eq_psi, Chebyshev.psi_eq_sum_Icc,
     Chebyshev.psi_eq_sum_Icc, Nat.floor_natCast]
 
@@ -61,8 +61,8 @@ parent's `(log 2 / 3)·n ≤ ψ(n)`, and bound `n ≥ x − 1 ≥ x/2`. -/
 theorem psi_ge_linear {x : ℝ} (hx : 2 ≤ x) : Real.log 2 / 6 * x ≤ ψ x := by
   set n := ⌊x⌋₊ with hn
   have hn2 : 2 ≤ n := by rw [hn]; exact Nat.le_floor (by exact_mod_cast hx)
-  have hpsi_eq : ψ x = ChebyshevBoundsOQ02OQ01.chebyshevPsi n := psi_eq_chebyshevPsi_floor x
-  have hlow : Real.log 2 / 3 * (n : ℝ) ≤ ChebyshevBoundsOQ02OQ01.chebyshevPsi n :=
+  have hpsi_eq : ψ x = ChebyshevBoundsOQ02.chebyshevPsi n := psi_eq_chebyshevPsi_floor x
+  have hlow : Real.log 2 / 3 * (n : ℝ) ≤ ChebyshevBoundsOQ02.chebyshevPsi n :=
     ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear hn2
   have hfloor_ge : x - 1 ≤ (n : ℝ) := by
     have h := Nat.lt_floor_add_one x
@@ -71,7 +71,7 @@ theorem psi_ge_linear {x : ℝ} (hx : 2 ≤ x) : Real.log 2 / 6 * x ≤ ψ x := 
   have hlog2 : (0 : ℝ) ≤ Real.log 2 := Real.log_nonneg (by norm_num)
   calc Real.log 2 / 6 * x = Real.log 2 / 3 * (x / 2) := by ring
     _ ≤ Real.log 2 / 3 * (n : ℝ) := mul_le_mul_of_nonneg_left hxhalf (by linarith)
-    _ ≤ ChebyshevBoundsOQ02OQ01.chebyshevPsi n := hlow
+    _ ≤ ChebyshevBoundsOQ02.chebyshevPsi n := hlow
     _ = ψ x := hpsi_eq.symm
 
 /-- The prime-power correction is `o(x)`: `2√x·log x = o(x)` as `x → ∞`. -/

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,238 @@
+{
+  "id": "chebyshev-bounds-oq-02-oq-01-oq-02",
+  "title": "Transferring Chebyshev's Bounds from ψ to θ: θ(x) = Θ(x)",
+  "slug": "chebyshev-bounds-oq-02-oq-01-oq-02",
+  "description": "Transfers the explicit two-sided estimate (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for the second Chebyshev function ψ (proved in the parent chebyshev-bounds-oq-02-oq-01) to the FIRST Chebyshev function θ(x) = ∑_{p ≤ x} log p, establishing θ(x) = Θ(x). The upper bound is immediate from θ ≤ ψ. The lower bound is the new content: neither Mathlib nor the sibling ψ-chain contains any lower bound on θ. Using Mathlib's gap estimate |ψ(x) − θ(x)| ≤ 2√x·log x together with 2√x·log x = o(x) (from log = o(√x), isLittleO_log_rpow_atTop), the parent's ψ lower bound passes to θ: θ(x) = ψ(x) − (ψ(x) − θ(x)) ≥ (log 2/6)·x − 2√x·log x ≥ (log 2/12)·x eventually. Packaged as Asymptotics.IsTheta, θ =Θ[atTop] id. Answers the parent chebyshev-bounds-oq-02-oq-01's second open question ('Transfer the bounds to θ(n) using ψ(n) − θ(n) = o(n), giving θ(n) = Θ(n)').",
+  "meta": {
+    "author": "Pafnuty Chebyshev (1852); formalized in Lean 4",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "chebyshev",
+      "prime-counting",
+      "analytic-number-theory",
+      "asymptotics",
+      "big-theta"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms theta_isTheta_id` reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. Builds on the parent ChebyshevBoundsOQ02OQ01 (the explicit ψ = Θ(n) estimate) and Mathlib's Chebyshev development (theta_le_psi, abs_psi_sub_theta_le_sqrt_mul_log, isLittleO_log_rpow_atTop); all results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.theta_le_psi",
+        "description": "θ(x) ≤ ψ(x) — θ counts only primes, ψ counts prime powers; gives the free upper bound θ ≤ ψ ≤ (log 4 + 4)·x",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log",
+        "description": "|ψ(x) − θ(x)| ≤ 2√x·log x — the quantitative closeness of ψ and θ that carries the ψ lower bound to θ",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.psi_le_const_mul_self",
+        "description": "ψ(x) ≤ (log 4 + 4)·x — Mathlib's explicit Chebyshev upper bound, composed with θ ≤ ψ for the θ upper bound",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "isLittleO_log_rpow_atTop",
+        "description": "log x = o(x^r) for r > 0 — with r = 1/2 gives log x = o(√x), hence 2√x·log x = o(x), the negligibility of the ψ−θ gap",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
+      },
+      {
+        "theorem": "Nat.lt_floor_add_one",
+        "description": "x < ⌊x⌋₊ + 1 — the floor bridge bounding ⌊x⌋₊ ≥ x − 1 when passing the natural-number ψ bound to real x",
+        "module": "Mathlib.Algebra.Order.Floor.Semiring"
+      }
+    ],
+    "dateAdded": "2026-07-02",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 theorem bounds both prime-power and prime sums: the second Chebyshev function ψ(x) = ∑_{p^k ≤ x} log p and the first θ(x) = ∑_{p ≤ x} log p both satisfy c₁·x ≤ · ≤ c₂·x. Historically ψ is the more convenient function to bound directly (its von Mangoldt sum telescopes cleanly against the central binomial coefficient), and θ is then recovered from ψ by discarding the higher prime-power contributions, whose total is ψ(x) − θ(x) = ∑_{k ≥ 2} θ(x^{1/k}) = O(√x log x) — negligible compared to the linear main term. This θ = Θ(x) estimate is equivalent, by partial summation, to π(x) = Θ(x/log x), Chebyshev's celebrated approximation to the Prime Number Theorem, and θ(x) ∼ x is the cleanest analytic form of PNT. Mathlib defines both ψ and θ and proves the upper bound θ ≤ log 4·x and the gap estimate |ψ − θ| ≤ 2√x·log x, but supplies no lower bound for either function (its NumberTheory/Chebyshev.lean carries the explicit TODO 'Prove Chebyshev's lower bound').",
+    "problemStatement": "**Open Question (parent chebyshev-bounds-oq-02-oq-01, second open direction)**: Transfer the explicit ψ = Θ(x) bounds to θ(x) = ∑_{p ≤ x} log p using the fact that ψ and θ differ by o(x), obtaining θ(x) = Θ(x).\n\n**Result**: θ =Θ[atTop] id, i.e. θ(x) = Θ(x), with explicit constants: eventually (log 2/12)·x ≤ θ(x) ≤ (log 4 + 4)·x. The lower bound is new — Mathlib and the ψ-chain provide only upper bounds on θ.",
+    "text": "A 148-line, fully verified (0 sorries, 0 axioms, no native_decide) file. The headline theta_isTheta_id gives θ =Θ[atTop] (fun x => x). The lower bound theta_ge_eventually — eventually (log 2/12)·x ≤ θ(x) — is the new mathematical content; the upper bound theta_le_linear is a one-line consequence of θ ≤ ψ and Mathlib's ψ upper bound.",
+    "proofStrategy": "The transfer runs in four steps. (1) theta_le_linear gives the upper bound θ(x) ≤ (log 4 + 4)·x directly from Chebyshev.theta_le_psi composed with Mathlib's ψ upper bound psi_le_const_mul_self. (2) psi_ge_linear lifts the parent's natural-number lower bound (log 2/3)·n ≤ ψ(n) to real x: the floor bridge psi_eq_chebyshevPsi_floor identifies ψ(x) with the parent's chebyshevPsi ⌊x⌋₊ (both are ∑_{n ≤ ⌊x⌋₊} Λ(n)), and ⌊x⌋₊ ≥ x − 1 ≥ x/2 for x ≥ 2 gives (log 2/6)·x ≤ ψ(x). (3) two_sqrt_mul_log_isLittleO shows the ψ−θ correction 2√x·log x is o(x): dividing by x and rewriting √x·√x = x reduces this to 2 log x/√x → 0, i.e. log = o(√x) via isLittleO_log_rpow_atTop with exponent 1/2; two_sqrt_mul_log_le_eventually then bounds it by (log 2/12)·x eventually. (4) theta_ge_eventually combines them: θ(x) = ψ(x) − (ψ(x) − θ(x)) ≥ (log 2/6)·x − 2√x·log x ≥ (log 2/6)·x − (log 2/12)·x = (log 2/12)·x eventually, using the Mathlib gap bound |ψ − θ| ≤ 2√x·log x one-sidedly. Finally theta_isBigO_id and id_isBigO_theta cast the two linear bounds as Asymptotics.IsBigO statements, and theta_isTheta_id pairs them into θ =Θ[atTop] id.",
+    "keyInsights": [
+      "The upper bound on θ is free: θ ≤ ψ (θ counts primes, ψ counts prime powers) composes with any upper bound on ψ, so no new work is needed for the ceiling.",
+      "The entire difficulty is the lower bound, and it reduces to a single quantitative input from Mathlib — the gap estimate |ψ(x) − θ(x)| ≤ 2√x·log x — plus the fact that this gap is o(x).",
+      "2√x·log x = o(x) is exactly log x = o(√x): dividing by x and using √x·√x = x turns the correction into 2 log x/√x → 0, which is isLittleO_log_rpow_atTop at exponent 1/2 — no bespoke prime-power counting is required.",
+      "The real-variable ψ lower bound is obtained from the parent's natural-number bound purely by a floor bridge: ψ(x) = ψ(⌊x⌋₊) and ⌊x⌋₊ ≥ x − 1 ≥ x/2, absorbing the floor loss into the constant (log 2/3 → log 2/6).",
+      "Neither Mathlib nor the sibling ψ-chain contains any lower bound on θ; combining the ψ lower bound with Mathlib's ψ−θ gap estimate produces the first machine-checked θ = Θ(x) in the gallery."
+    ],
+    "prerequisites": [
+      "The explicit two-sided estimate (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for the second Chebyshev function ψ (parent chebyshev-bounds-oq-02-oq-01)",
+      "The first Chebyshev function θ(x) = ∑_{p ≤ x} log p and Mathlib's relations θ ≤ ψ and |ψ − θ| ≤ 2√x·log x",
+      "Landau asymptotic notation and the fact that log grows slower than any positive power (log = o(x^r))"
+    ]
+  },
+  "sections": [
+    {
+      "id": "log-sqrt-limit",
+      "title": "log x / √x → 0",
+      "startLine": 37,
+      "endLine": 45,
+      "summary": "log_div_sqrt_tendsto_zero: log x / √x → 0, from isLittleO_log_rpow_atTop at exponent 1/2 rewritten through √x = x^(1/2).",
+      "mathContext": "The Mathlib-only limit behind the o(x) negligibility of the ψ−θ correction."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper Bound θ ≤ (log 4 + 4)·x",
+      "startLine": 47,
+      "endLine": 50,
+      "summary": "theta_le_linear: θ(x) ≤ (log 4 + 4)·x for x ≥ 0, from θ ≤ ψ (Chebyshev.theta_le_psi) and Mathlib's ψ upper bound.",
+      "mathContext": "The free ceiling: the higher prime powers only make ψ larger than θ."
+    },
+    {
+      "id": "psi-lower-real",
+      "title": "Real ψ Lower Bound via the Floor Bridge",
+      "startLine": 52,
+      "endLine": 75,
+      "summary": "psi_eq_chebyshevPsi_floor identifies ψ(x) with the parent's chebyshevPsi ⌊x⌋₊; psi_ge_linear lifts the natural-number bound to (log 2/6)·x ≤ ψ(x) for x ≥ 2 using ⌊x⌋₊ ≥ x/2.",
+      "mathContext": "Transports the parent's ℕ-indexed ψ lower bound to a real-variable statement."
+    },
+    {
+      "id": "gap-little-o",
+      "title": "The ψ−θ Gap is o(x)",
+      "startLine": 77,
+      "endLine": 111,
+      "summary": "two_sqrt_mul_log_isLittleO: 2√x·log x = o(x), reduced to 2 log x/√x → 0 via √x·√x = x; two_sqrt_mul_log_le_eventually bounds it by (log 2/12)·x eventually.",
+      "mathContext": "Makes the prime-power correction negligible against the linear main term."
+    },
+    {
+      "id": "theta-lower",
+      "title": "θ Lower Bound",
+      "startLine": 113,
+      "endLine": 121,
+      "summary": "theta_ge_eventually: eventually (log 2/12)·x ≤ θ(x), from θ ≥ ψ − 2√x·log x, the real ψ lower bound, and the o(x) gap bound.",
+      "mathContext": "The new content: a linear lower bound on θ, absent from Mathlib and the ψ-chain."
+    },
+    {
+      "id": "big-theta",
+      "title": "Packaging θ = Θ(x)",
+      "startLine": 123,
+      "endLine": 146,
+      "summary": "theta_isBigO_id and id_isBigO_theta cast the two linear bounds as Asymptotics.IsBigO; theta_isTheta_id pairs them into θ =Θ[atTop] (fun x => x).",
+      "mathContext": "The headline asymptotic: θ has the exact linear growth rate of the identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file transfers the explicit ψ = Θ(x) estimate to the first Chebyshev function, proving θ(x) = Θ(x) (theta_isTheta_id). The upper bound θ(x) ≤ (log 4 + 4)·x is immediate from θ ≤ ψ. The lower bound — new, since neither Mathlib nor the ψ-chain bounds θ below — combines the parent's ψ lower bound (lifted to real x by a floor bridge) with Mathlib's gap estimate |ψ(x) − θ(x)| ≤ 2√x·log x and the fact that this gap is o(x), yielding eventually (log 2/12)·x ≤ θ(x).",
+    "implications": "θ(x) = Θ(x) is equivalent (by partial summation) to π(x) = Θ(x/log x), Chebyshev's approximation to the Prime Number Theorem, and θ(x) ∼ x is the form in which PNT is usually stated. It completes the gallery's Chebyshev thread from the ψ estimate through to the θ estimate and connects to the PNT bridge. The reduction also isolates exactly what an unconditional PNT would need to sharpen: the constants log 2/12 and log 4 + 4, not the shape of the bound.",
+    "openQuestions": [
+      "Sharpen the constants toward the optimal Chebyshev values (θ(x)/x → 1 under PNT) by improving the ψ estimate and tightening the ψ−θ gap handling.",
+      "Combine θ(x) = Θ(x) with partial summation to derive explicit bounds c₁·x/log x ≤ π(x) ≤ c₂·x/log x on the prime-counting function.",
+      "Upstream the θ lower bound to Mathlib, closing the other half of its 'Prove Chebyshev's lower bound' TODO for both ψ and θ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the explicit two-sided ψ = Θ(n) estimate. This entry answers its second open question — transferring the growth rate to θ."
+    },
+    {
+      "targetId": "chebyshev-bounds-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: the second Chebyshev function ψ and Legendre's identity."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "related",
+      "description": "Root: explicit Chebyshev bounds on π(n) and θ(n) via central binomial coefficients."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "related",
+      "description": "θ(x) = Θ(x) is equivalent to π(x) = Θ(x/log x), the Prime Number Theorem form this thread works toward."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevBoundsOQ02OQ01"
+    ],
+    "opens": [
+      "Filter",
+      "Asymptotics",
+      "Chebyshev"
+    ],
+    "namespace": "ChebyshevBoundsOQ02OQ01OQ02",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "theta_isTheta_id",
+        "type": "core",
+        "description": "θ(x) = Θ(x): the first Chebyshev function has the exact linear growth rate of the identity",
+        "leanType": "(fun x : ℝ => Chebyshev.theta x) =Θ[Filter.atTop] (fun x : ℝ => x)"
+      },
+      {
+        "name": "theta_ge_eventually",
+        "type": "key",
+        "description": "Eventually (log 2/12)·x ≤ θ(x) — the new linear lower bound on θ",
+        "leanType": "∀ᶠ x : ℝ in Filter.atTop, Real.log 2 / 12 * x ≤ Chebyshev.theta x"
+      },
+      {
+        "name": "theta_le_linear",
+        "type": "key",
+        "description": "θ(x) ≤ (log 4 + 4)·x for x ≥ 0, from θ ≤ ψ and Mathlib's ψ upper bound",
+        "leanType": "{x : ℝ} → 0 ≤ x → Chebyshev.theta x ≤ (Real.log 4 + 4) * x"
+      }
+    ],
+    "path": "Proofs/ChebyshevBoundsOQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "theta_isTheta_id",
+      "type": "core",
+      "description": "θ(x) = Θ(x): the first Chebyshev function has the exact linear growth rate of the identity",
+      "leanType": "(fun x : ℝ => Chebyshev.theta x) =Θ[Filter.atTop] (fun x : ℝ => x)"
+    },
+    {
+      "name": "theta_ge_eventually",
+      "type": "key",
+      "description": "Eventually (log 2/12)·x ≤ θ(x) — the new linear lower bound on θ absent from Mathlib and the ψ-chain",
+      "leanType": "∀ᶠ x : ℝ in Filter.atTop, Real.log 2 / 12 * x ≤ Chebyshev.theta x"
+    },
+    {
+      "name": "two_sqrt_mul_log_isLittleO",
+      "type": "key",
+      "description": "2√x·log x = o(x): the ψ−θ correction is negligible against the linear main term",
+      "leanType": "(fun x : ℝ => 2 * Real.sqrt x * Real.log x) =o[Filter.atTop] (fun x : ℝ => x)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Chebyshev, Pafnuty L.",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées 17, 366–390",
+      "note": "The original two-sided bounds c₁·x ≤ θ(x), ψ(x) ≤ c₂·x"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer UTM",
+      "note": "Chapter 4: the Chebyshev functions ψ, θ, their Θ(x) bounds, and the estimate ψ(x) − θ(x) = O(√x log² x)"
+    },
+    {
+      "authors": "Montgomery, Hugh L.; Vaughan, Robert C.",
+      "title": "Multiplicative Number Theory I: Classical Theory",
+      "year": "2007",
+      "venue": "Cambridge Studies in Advanced Mathematics 97",
+      "note": "The equivalence of ψ(x) = Θ(x), θ(x) = Θ(x), and π(x) = Θ(x/log x) via partial summation"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Transfers the explicit two-sided Chebyshev estimate for the **second** Chebyshev function ψ (proved in the sibling `chebyshev-bounds-oq-02-oq-01`) to the **first** Chebyshev function θ(x) = ∑_{p ≤ x} log p, establishing **θ(x) = Θ(x)** (`theta_isTheta_id`).

This answers the sibling entry's own registered open question: *"Transfer the bounds to θ(n) using ψ(n) − θ(n) = o(n), giving θ(n) = Θ(n)."*

## What this PR does

- **Build-fix**: the draft `ChebyshevBoundsOQ02OQ01OQ02.lean` (merged unbuilt in #32564) referenced `chebyshevPsi` under the wrong namespace (`ChebyshevBoundsOQ02OQ01` instead of `ChebyshevBoundsOQ02`), so it did not compile. Fixes the 4 references; the file now builds.
- **New gallery entry**: adds `src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/meta.json` (the entry was missing).

## Mathematical content

- Upper bound is free: θ ≤ ψ (Mathlib `Chebyshev.theta_le_psi`) composed with the ψ upper bound.
- Lower bound is **new** — neither Mathlib nor the ψ-chain bounds θ below (Mathlib's `NumberTheory/Chebyshev.lean` carries the explicit TODO *"Prove Chebyshev's lower bound"*). It combines the sibling's ψ lower bound (lifted to real x by a floor bridge) with Mathlib's gap estimate `|ψ(x) − θ(x)| ≤ 2√x·log x` and the fact that 2√x·log x = o(x) (from `isLittleO_log_rpow_atTop` at exponent 1/2): θ(x) = ψ(x) − (ψ(x) − θ(x)) ≥ (log 2/6)·x − 2√x·log x ≥ (log 2/12)·x eventually.

## Verification

Built via docker (`LEAN_SKIP_CACHE=true`): clean compile, and

```
#print axioms theta_isTheta_id
  → [propext, Classical.choice, Quot.sound]
```

0 sorries, 0 `axiom` declarations, no `native_decide` → **verified, 0-axiom**. 10 theorems / 148 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)