### PR TITLE
research(pac-learning-bounds-wip-01-oq-01): VC dimension monotonicity [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/PACLearningBoundsWIP01OQ01.lean
+++ b/proofs/Proofs/PACLearningBoundsWIP01OQ01.lean
@@ -1,0 +1,86 @@
+import Proofs.PACLearningBoundsWIP01
+
+/-
+# PAC Learning, wip-01 · oq-01 — Monotonicity of the VC dimension
+
+The parent entry `pac-learning-bounds-wip-01` builds proper, `0`-axiom foundations for
+Vapnik–Chervonenkis theory: the **trace** `Π_H(S) = {h ∩ S : h ∈ H}`, the **shattering**
+relation `Shatters H S`, and the **VC dimension**
+
+  `VCDim H = sSup {n | ∃ S, |S| = n ∧ Shatters H S}`,
+
+the largest cardinality of a set shattered by `H`. Among its lemmas is the *set-level*
+monotonicity of shattering, `shatters_mono` : enlarging the class preserves shattering
+(`H ⊆ H'` and `Shatters H S ⟹ Shatters H' S`).
+
+This file supplies the **class-level** counterpart — monotonicity of the VC dimension
+itself as a function of the hypothesis class.
+
+## What is proved
+
+* `vcDim_mono` — **monotonicity of VC dimension**: `H ⊆ H' ⟹ VCDim H ≤ VCDim H'`.
+  A learner with access to a richer hypothesis class can only shatter more, never fewer,
+  configurations, so its capacity (measured by VC dimension) is at least as large. This is
+  the object-level statement underlying the intuition that "bigger classes are harder to
+  learn": sample-complexity bounds grow with `VCDim`.
+* `vcDim_le_of_subset` — the same fact packaged as an order-homomorphism-style consequence
+  for direct use.
+* `vcDim_union_left` / `vcDim_union_right` — immediate corollaries: the VC dimension of a
+  union dominates that of either part.
+* `vcDim_powerset_le` — since every class over `α` embeds in the full powerset class,
+  `VCDim` is dominated by that of `2^α` on any shattered witness; combined with the parent's
+  `vcDim_powerset` this recovers the ground-set ceiling in the finite case.
+
+The proof is a two-line application of `csSup_le`/`shatters_mono`, structurally identical to
+the parent's `vcDim_le_log`: every cardinality achievable by a set shattered by `H` is,
+via `shatters_mono`, achievable by `H'`, hence bounded by `VCDim H'`.
+
+Fully machine-checked; `0` axioms beyond Mathlib's foundations; no `native_decide`.
+
+Tags: pac-learning, vc-dimension, monotonicity, shattering, combinatorics, learning-theory
+-/
+
+namespace PACLearningBoundsWIP01
+
+open Finset
+
+variable {α : Type*} [DecidableEq α]
+
+/-- **Monotonicity of the VC dimension.** If `H ⊆ H'` then `VCDim H ≤ VCDim H'`.
+
+Every set shattered by the smaller class `H` is, by the parent's `shatters_mono`, also
+shattered by the larger class `H'`; hence every cardinality in the set defining `VCDim H`
+is bounded by `VCDim H'` (via `card_le_vcDim`), and the supremum inherits the bound. The
+empty-witness case (`H` shatters nothing) gives `VCDim H = 0 ≤ VCDim H'`. -/
+theorem vcDim_mono {H H' : Finset (Finset α)} (hHH : H ⊆ H') :
+    VCDim H ≤ VCDim H' := by
+  rcases Set.eq_empty_or_nonempty {n | ∃ S : Finset α, S.card = n ∧ Shatters H S} with he | hne
+  · rw [VCDim, he, csSup_empty]; exact bot_le
+  · refine csSup_le hne (fun n hn => ?_)
+    obtain ⟨S, rfl, hS⟩ := hn
+    exact card_le_vcDim H' S (shatters_mono S hHH hS)
+
+/-- Restatement of `vcDim_mono` in `⟹` form for convenient rewriting/`gcongr`-style use. -/
+theorem vcDim_le_of_subset {H H' : Finset (Finset α)} (hHH : H ⊆ H') :
+    VCDim H ≤ VCDim H' :=
+  vcDim_mono hHH
+
+/-- The VC dimension of a class is at most that of any union containing it (left). -/
+theorem vcDim_union_left (H H' : Finset (Finset α)) :
+    VCDim H ≤ VCDim (H ∪ H') :=
+  vcDim_mono Finset.subset_union_left
+
+/-- The VC dimension of a class is at most that of any union containing it (right). -/
+theorem vcDim_union_right (H H' : Finset (Finset α)) :
+    VCDim H' ≤ VCDim (H ∪ H') :=
+  vcDim_mono Finset.subset_union_right
+
+/-- **The powerset class is capacity-maximal among subfamilies of `2^α`.** Any class `H`
+whose members are all subsets of a fixed finite set `S` (i.e. `H ⊆ S.powerset`) has VC
+dimension at most `|S|`, the VC dimension of the full powerset class `2^S`
+(`vcDim_powerset`). Monotonicity turns the containment into a capacity bound. -/
+theorem vcDim_powerset_le {H : Finset (Finset α)} {S : Finset α} (hH : H ⊆ S.powerset) :
+    VCDim H ≤ S.card :=
+  (vcDim_mono hH).trans_eq (vcDim_powerset S)
+
+end PACLearningBoundsWIP01

--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-pac-wip01-oq01-01-header",
+    "proofId": "pac-learning-bounds-wip-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Class-Level Monotonicity of the VC Dimension",
+    "content": "The header recalls the parent entry's 0-axiom foundations — trace, shattering, and VCDim H = sSup{|S| : H shatters S} — and its set-level monotonicity lemma shatters_mono (enlarging the class preserves shattering). This file supplies the class-level counterpart: monotonicity of the VC dimension itself as a function of the hypothesis class, the parent entry's own first open question.",
+    "mathContext": "A richer hypothesis class can shatter at least as many configurations, so its capacity (VC dimension) is at least as large.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "VC dimension",
+      "shattering",
+      "monotonicity",
+      "PAC learning"
+    ],
+    "prerequisites": [
+      "the parent entry's definitions of shattering and VCDim",
+      "conditional suprema (sSup)"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-oq01-02-mono",
+    "proofId": "pac-learning-bounds-wip-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "vcDim_mono: H ⊆ H' ⟹ VCDim H ≤ VCDim H'",
+    "content": "The main result. VCDim H is the supremum sSup{n | ∃ S, |S| = n ∧ H shatters S}. If that set is empty, VCDim H = sSup ∅ = 0 ≤ VCDim H'. Otherwise csSup_le reduces the goal to bounding each achievable cardinality n = |S|: the parent's shatters_mono upgrades 'H shatters S' to 'H' shatters S', and card_le_vcDim then gives |S| ≤ VCDim H'. The supremum inherits the bound. vcDim_le_of_subset restates the same fact in implication form.",
+    "mathContext": "$\\dim_{VC}(H) \\le \\dim_{VC}(H')$ whenever $H \\subseteq H'$; proved by transporting the set-level $\\texttt{shatters\\_mono}$ across the supremum via $\\texttt{csSup\\_le}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "VC dimension",
+      "monotonicity",
+      "conditional supremum",
+      "shatters_mono"
+    ],
+    "prerequisites": [
+      "csSup_le and csSup_empty",
+      "the parent's shatters_mono and card_le_vcDim"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-oq01-03-corollaries",
+    "proofId": "pac-learning-bounds-wip-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Union Bounds and the Powerset Capacity Ceiling",
+    "content": "Immediate consequences of monotonicity. vcDim_union_left / vcDim_union_right give VCDim H, VCDim H' ≤ VCDim (H ∪ H') via subset_union. vcDim_powerset_le shows any class contained in a powerset, H ⊆ S.powerset, has VCDim H ≤ |S|, obtained by chaining vcDim_mono with the parent's exact value vcDim_powerset (VCDim(2^S) = |S|) — turning a class containment into a capacity ceiling.",
+    "mathContext": "$\\dim_{VC}(H), \\dim_{VC}(H') \\le \\dim_{VC}(H \\cup H')$; and $H \\subseteq 2^S \\Rightarrow \\dim_{VC}(H) \\le |S|$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "VC dimension",
+      "union bound",
+      "powerset class",
+      "capacity ceiling"
+    ],
+    "prerequisites": [
+      "vcDim_mono",
+      "Finset.subset_union_left/right",
+      "the parent's vcDim_powerset"
+    ]
+  }
+]

--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "pac-learning-bounds-wip-01-oq-01",
+  "title": "Monotonicity of the VC Dimension: H ⊆ H' ⟹ VCDim H ≤ VCDim H'",
+  "slug": "pac-learning-bounds-wip-01-oq-01",
+  "description": "Answers the parent entry pac-learning-bounds-wip-01's own first open question: the class-level monotonicity of the VC dimension. Building directly on the parent's 0-axiom definitions of shattering and VCDim H = sSup{|S| : H shatters S}, and its set-level lemma shatters_mono, this entry proves that enlarging a hypothesis class can only increase its VC dimension: H ⊆ H' ⟹ VCDim H ≤ VCDim H'. It packages the fact into corollaries for unions (VCDim H, VCDim H' ≤ VCDim (H ∪ H')) and, via the parent's vcDim_powerset, a ground-set capacity ceiling (H ⊆ S.powerset ⟹ VCDim H ≤ |S|). Fully verified: 0 sorries, 0 axioms, no native_decide (clean docker lake build).",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/PACLearningBoundsWIP01OQ01.lean",
+    "tags": [
+      "pac-learning",
+      "vc-dimension",
+      "monotonicity",
+      "shattering",
+      "combinatorics",
+      "learning-theory",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "csSup_le",
+        "description": "For a nonempty set bounded above, x ≤ a for all x ⟹ sSup s ≤ a — bounds VCDim H (a supremum) by VCDim H'",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "csSup_empty",
+        "description": "sSup ∅ = ⊥ — the empty-witness case where H shatters nothing gives VCDim H = 0",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "Finset.subset_union_left",
+        "description": "s ⊆ s ∪ t — feeds vcDim_mono to give the union corollaries",
+        "module": "Mathlib.Data.Finset.Union"
+      }
+    ],
+    "originalContributions": [
+      "vcDim_mono: monotonicity of the VC dimension itself — H ⊆ H' ⟹ VCDim H ≤ VCDim H' (answers the parent entry's first open question). Proved by csSup_le: every cardinality achievable by a set shattered by H is, via the parent's shatters_mono, achievable by H', hence ≤ VCDim H'; the empty-witness case gives 0.",
+      "vcDim_le_of_subset: the same statement in implication form for convenient reuse",
+      "vcDim_union_left / vcDim_union_right: VCDim H, VCDim H' ≤ VCDim (H ∪ H') — immediate corollaries via subset_union",
+      "vcDim_powerset_le: H ⊆ S.powerset ⟹ VCDim H ≤ |S| — monotonicity plus the parent's vcDim_powerset turns a class-containment into a capacity ceiling"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 86,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axioms beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound); verified via a clean docker lake build. No native_decide.",
+    "mathlib_version": "4.26.0",
+    "relatedProblems": [
+      {
+        "id": "pac-learning-bounds-wip-01",
+        "relationship": "Parent entry. Defines trace/shattering/VCDim and proves the set-level shatters_mono; explicitly poses VC-dimension monotonicity as its first open question, which this entry answers."
+      }
+    ],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The VC dimension (Vapnik–Chervonenkis, 1971) measures the capacity of a hypothesis class by the size of the largest set it can shatter, and it governs PAC-learnability and sample complexity. A basic structural property, used implicitly throughout learning theory, is that capacity is monotone: a learner with a richer hypothesis class can shatter at least as many configurations, so its VC dimension is at least as large. The parent gallery entry builds proper 0-axiom foundations for shattering and VC dimension and lists this monotonicity as its first open question.",
+    "problemStatement": "The parent entry proves set-level monotonicity of shattering (H ⊆ H' and H shatters S ⟹ H' shatters S) but leaves the class-level statement — monotonicity of the VC dimension as a function of the class — open. This entry proves H ⊆ H' ⟹ VCDim H ≤ VCDim H'.",
+    "proofStrategy": "VCDim H is the supremum sSup{n | ∃ S, |S| = n ∧ H shatters S}. If this set is empty, VCDim H = sSup ∅ = 0 ≤ VCDim H'. Otherwise, apply csSup_le: for each achievable cardinality n witnessed by a shattered set S, the parent's shatters_mono upgrades 'H shatters S' to 'H' shatters S', and card_le_vcDim then gives n = |S| ≤ VCDim H'. The supremum inherits the bound. The proof is structurally identical to the parent's vcDim_le_log, with shatters_mono replacing shatters_card_le_log.",
+    "keyInsights": [
+      "The class-level monotonicity is a pure transport of the set-level shatters_mono across the supremum defining VCDim — no new combinatorics is needed.",
+      "csSup_le reduces the class-level bound to a per-witness bound, and the only work per witness is invoking shatters_mono and card_le_vcDim.",
+      "The empty-witness branch (H shatters nothing, so VCDim H = 0) must be handled separately because sSup ∅ = ⊥ is not covered by csSup_le, which requires a nonempty index set.",
+      "Monotonicity immediately yields the union bounds and, composed with the parent's exact value VCDim(2^S) = |S|, a capacity ceiling for any subfamily of a powerset."
+    ],
+    "prerequisites": [
+      "Finsets, shattering, and the VC dimension as defined in the parent entry",
+      "the conditional supremum sSup and csSup_le / csSup_empty"
+    ],
+    "text": "A short, fully verified (0 sorries, 0 axioms, no native_decide) formalization answering the parent entry's first open question: the VC dimension is monotone in the hypothesis class, H ⊆ H' ⟹ VCDim H ≤ VCDim H'. The proof transports the parent's set-level shatters_mono across the supremum defining VCDim via csSup_le, and the result is packaged into union corollaries and a powerset capacity ceiling."
+  },
+  "sections": [
+    {
+      "id": "sec-mono",
+      "title": "Monotonicity of the VC Dimension",
+      "startLine": 49,
+      "endLine": 66,
+      "summary": "vcDim_mono: H ⊆ H' ⟹ VCDim H ≤ VCDim H'. Case split on whether H shatters any set: the empty case gives sSup ∅ = 0; otherwise csSup_le reduces to bounding each witness cardinality, and shatters_mono + card_le_vcDim supply the bound. vcDim_le_of_subset restates it in implication form.",
+      "mathContext": "The core statement: enlarging the hypothesis class cannot decrease its VC dimension."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Union Bounds and the Powerset Ceiling",
+      "startLine": 68,
+      "endLine": 86,
+      "summary": "vcDim_union_left / vcDim_union_right: VCDim H, VCDim H' ≤ VCDim (H ∪ H') via subset_union. vcDim_powerset_le: any H ⊆ S.powerset has VCDim H ≤ |S|, obtained by chaining vcDim_mono with the parent's exact value vcDim_powerset (VCDim(2^S) = |S|).",
+      "mathContext": "Consequences: capacity of a union dominates its parts; any subfamily of 2^S has VC dimension at most |S|."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified formalization (0 sorries, 0 axioms, no native_decide) proving that the VC dimension is monotone in the hypothesis class — H ⊆ H' ⟹ VCDim H ≤ VCDim H' — answering the parent entry pac-learning-bounds-wip-01's first open question, together with union and powerset-ceiling corollaries.",
+    "implications": "**Theoretical significance**: Monotonicity of VC dimension is the structural fact underlying the intuition that richer hypothesis classes are harder to learn (larger sample complexity). It is used implicitly whenever one bounds a class's capacity by that of a larger, more tractable class — exactly what vcDim_powerset_le makes explicit. The proof also demonstrates the payoff of the parent's careful definitions: the class-level result is a two-line transport of the set-level shatters_mono.",
+    "openQuestions": [
+      "Prove the Sauer–Shelah lemma: |Π_H(S)| ≤ Σ_{i≤d} C(|S|,i) where d = VCDim H — the polynomial growth bound, the remaining open question of the parent entry.",
+      "Establish a strict-monotonicity or gap criterion: conditions on H ⊊ H' under which VCDim H < VCDim H'."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pac-learning-bounds-wip-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question by lifting its set-level shatters_mono to class-level monotonicity of the VC dimension, and reuses the parent's vcDim_powerset for the capacity ceiling."
+    }
+  ],
+  "references": [
+    {
+      "authors": "V. N. Vapnik, A. Ya. Chervonenkis",
+      "title": "On the uniform convergence of relative frequencies of events to their probabilities",
+      "year": "1971",
+      "venue": "Theory Probab. Appl.",
+      "note": "Origin of VC dimension and shattering"
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Proofs.PACLearningBoundsWIP01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "PACLearningBoundsWIP01",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/PACLearningBoundsWIP01OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent entry `pac-learning-bounds-wip-01`'s **first open question**: the class-level monotonicity of the VC dimension.

**Main result** (`vcDim_mono`): `H ⊆ H' ⟹ VCDim H ≤ VCDim H'`.

Building on the parent's 0-axiom definitions (`trace`, `Shatters`, `VCDim H = sSup{|S| : H shatters S}`) and its set-level lemma `shatters_mono`, the proof transports set-level shattering monotonicity across the supremum via `csSup_le` (with the empty-witness case handled by `csSup_empty`). It is structurally identical to the parent's `vcDim_le_log`.

Corollaries:
- `vcDim_union_left` / `vcDim_union_right`: `VCDim H, VCDim H' ≤ VCDim (H ∪ H')`
- `vcDim_powerset_le`: `H ⊆ S.powerset ⟹ VCDim H ≤ |S|` (via the parent's exact `vcDim_powerset`)

## Verification
- **0 sorries, 0 axioms, no native_decide** — clean `docker-build.sh Proofs.PACLearningBoundsWIP01OQ01` (7744 jobs, success)
- 5 theorems, 86 lines
- Annotation build (`--strict`): new entry clean

## Files
- `proofs/Proofs/PACLearningBoundsWIP01OQ01.lean` (new)
- `src/data/proofs/pac-learning-bounds-wip-01-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)