### PR TITLE
Enrich Maschke local-ring entry (maschke-theorem-oq-01-oq-01-oq-02): overview annotation + anchor fix

### DIFF
--- a/src/data/proofs/maschke-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/maschke-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "maschke-theorem-oq-01-oq-01-oq-02-ann-overview",
+    "proofId": "maschke-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "The local-ring picture: why Maschke fails in characteristic p",
+    "content": "The docstring frames the Jacobson-radical viewpoint on the modular failure of Maschke's theorem and previews the five results that assemble the full local structure of A = 𝔽ₚ[ℤ/p]: the augmentation ideal is principal (ker ε = (g−1)), it is nilpotent of index ≤ p ((ker ε)ᵖ = ⊥), A is a local ring whose unique maximal ideal is that augmentation ideal, the Jacobson radical equals it (and is nonzero), and — as a second, radical-theoretic proof — A is not semisimple. The structural slogan is A ≅ 𝔽ₚ[X]/((X−1)ᵖ), a local Artinian ring whose maximal ideal (g−1) is nonzero and nilpotent, so its Jacobson radical does not vanish. It then fixes the ambient setup: import Mathlib, a prime p as Fact p.Prime, and the MonoidAlgebra scope.",
+    "mathContext": "$A=\\mathbb{F}_p[\\mathbb{Z}/p]\\cong\\mathbb{F}_p[X]/((X-1)^p)$; $\\ker\\varepsilon=(g-1)$, $(\\ker\\varepsilon)^p=\\bot$, $\\operatorname{Jac}(A)=\\ker\\varepsilon\\neq\\bot$, so $A$ is not semisimple.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jacobson radical",
+      "local ring",
+      "augmentation ideal",
+      "modular representation theory",
+      "semisimplicity"
+    ],
+    "prerequisites": [
+      "group algebras",
+      "ideals and quotients",
+      "Artin–Wedderburn theory"
+    ]
+  },
+  {
     "id": "ann-setup",
     "proofId": "maschke-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 51, "endLine": 72 },
+    "range": {
+      "startLine": 52,
+      "endLine": 72
+    },
     "type": "definition",
     "title": "The Modular Group Algebra, Generator, and Augmentation Map",
     "content": "The cyclic group ℤ/p is written multiplicatively as `G = Multiplicative (ZMod p)` so its group algebra is a `MonoidAlgebra`, and `A = 𝔽_p[ℤ/p]` carries the `CharP (A p) p` instance via `charP_of_injective_algebraMap`. The generator `g = of (ofAdd 1)` is the basis element indexed by 1 ∈ ℤ/p, and the augmentation map `ε : A →ₐ[𝔽_p] 𝔽_p` is `MonoidAlgebra.lift` of the trivial monoid hom, sending every group element to 1 (so ∑ a_h h ↦ ∑ a_h). `ε_of` and `ε_g` record ε(of a) = 1 and ε(g) = 1.",
     "mathContext": "$A = \\mathbb{F}_p[\\mathbb{Z}/p]$, $g = [1]$, $\\varepsilon\\big(\\sum a_h h\\big) = \\sum a_h$.",
     "significance": "supporting",
-    "relatedConcepts": ["group algebra", "augmentation map", "MonoidAlgebra.lift", "characteristic p"],
-    "prerequisites": ["group algebras", "algebra homomorphisms"]
+    "relatedConcepts": [
+      "group algebra",
+      "augmentation map",
+      "MonoidAlgebra.lift",
+      "characteristic p"
+    ],
+    "prerequisites": [
+      "group algebras",
+      "algebra homomorphisms"
+    ]
   },
   {
     "id": "ann-nilpotent-generator",
     "proofId": "maschke-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 74, "endLine": 97 },
+    "range": {
+      "startLine": 74,
+      "endLine": 97
+    },
     "type": "tactic",
     "title": "g − 1 Is a Nonzero Nilpotent",
     "content": "`g_pow_card` shows g^p = 1 because the exponent collapses: p • (1 : ZMod p) = 0, so the basis index ofAdd 1 raised to the p-th power is ofAdd 0 = 1. In characteristic p the Frobenius collapse `sub_pow_char` then gives `g_sub_one_pow_card`: (g − 1)^p = g^p − 1^p = 1 − 1 = 0. `isNilpotent_g_sub_one` packages the nilpotency and `g_sub_one_ne_zero` shows g − 1 ≠ 0 (the generator differs from the identity, via injectivity of `of`).",
     "mathContext": "$(g-1)^p = g^p - 1 = 0$ while $g - 1 \\neq 0$.",
     "significance": "key",
-    "relatedConcepts": ["Frobenius endomorphism", "freshman's dream", "nilpotent element"],
-    "prerequisites": ["prime characteristic", "binomial theorem in characteristic p"]
+    "relatedConcepts": [
+      "Frobenius endomorphism",
+      "freshman's dream",
+      "nilpotent element"
+    ],
+    "prerequisites": [
+      "prime characteristic",
+      "binomial theorem in characteristic p"
+    ]
   },
   {
     "id": "ann-principal-augmentation",
     "proofId": "maschke-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 99, "endLine": 150 },
+    "range": {
+      "startLine": 99,
+      "endLine": 150
+    },
     "type": "insight",
     "title": "The Augmentation Ideal Is Principal: ker ε = (g − 1)",
     "content": "Because the group is cyclic, every basis element is a power of the generator: `of_eq_g_pow` proves of (ofAdd m) = g^(m.val). Hence of h − 1 is a multiple of g − 1, since g − 1 ∣ gⁿ − 1 (`sub_dvd_pow_sub_pow`) — this is `of_sub_one_mem`. `sub_smul_one_mem` propagates the statement 'y − (ε y)·1 ∈ (g − 1)' to every element by `MonoidAlgebra.induction_on` (the of/add/smul induction). For y ∈ ker ε this collapses to y ∈ (g − 1), giving `ker_eq_span`: the augmentation ideal is principal, generated by the nilpotent g − 1. `ker_pow_card` then upgrades the element nilpotency to the IDEAL nilpotency (ker ε)^p = ⊥ via `Ideal.span_singleton_pow`.",
     "mathContext": "$\\ker\\varepsilon = (g-1)$ and $(\\ker\\varepsilon)^p = 0$.",
     "significance": "key",
-    "relatedConcepts": ["augmentation ideal", "principal ideal", "nilpotent ideal", "induction on group algebra"],
-    "prerequisites": ["ideals in commutative rings", "geometric series factorization"]
+    "relatedConcepts": [
+      "augmentation ideal",
+      "principal ideal",
+      "nilpotent ideal",
+      "induction on group algebra"
+    ],
+    "prerequisites": [
+      "ideals in commutative rings",
+      "geometric series factorization"
+    ]
   },
   {
     "id": "ann-local-jacobson",
     "proofId": "maschke-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 152, "endLine": 209 },
+    "range": {
+      "startLine": 152,
+      "endLine": 209
+    },
     "type": "insight",
     "title": "Local Ring, Jacobson Radical, and Radical-Theoretic Non-Semisimplicity",
     "content": "The augmentation ε is surjective (it retracts the unit 𝔽_p ↪ A), so `ker_isMaximal` makes ker ε a maximal ideal — the kernel of a surjection onto the field 𝔽_p. `isLocalRing` proves 𝔽_p[ℤ/p] local: any maximal ideal M is prime, hence contains the nilradical, which contains the nilpotent g − 1, so ker ε = (g − 1) ⊆ M; maximality forces M = ker ε, a unique maximal ideal. `jacobson_eq_ker` then computes Ring.jacobson A = maximalIdeal = ker ε, and `jacobson_ne_bot` notes it is nonzero (it contains g − 1 ≠ 0). Finally `not_isSemisimpleRing` uses the Artinian equivalence IsSemisimpleRing ↔ Ring.jacobson = ⊥ to conclude non-semisimplicity from the nonzero radical — an independent route to the modular failure of Maschke's theorem.",
     "mathContext": "$\\mathbb{F}_p[\\mathbb{Z}/p]$ is local, $\\operatorname{Rad}(A) = \\ker\\varepsilon \\neq 0$, hence not semisimple.",
     "significance": "key",
-    "relatedConcepts": ["local ring", "Jacobson radical", "Artin–Wedderburn", "semisimplicity"],
-    "prerequisites": ["maximal ideals", "Jacobson radical", "Artinian rings"]
+    "relatedConcepts": [
+      "local ring",
+      "Jacobson radical",
+      "Artin–Wedderburn",
+      "semisimplicity"
+    ],
+    "prerequisites": [
+      "maximal ideals",
+      "Jacobson radical",
+      "Artinian rings"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `maschke-theorem-oq-01-oq-01-oq-02` (𝔽ₚ[ℤ/p] local ring, passes: 0).

**annotations.json (4 → 5 annotations):**
- Added a leading `concept` annotation covering the docstring overview (lines 3–50) — it summarizes the local-ring picture (ker ε = (g−1) principal & nilpotent, A local, Jac(A) = ker ε ≠ ⊥, non-semisimple) and the slogan A ≅ 𝔽ₚ[X]/((X−1)ᵖ). Previously the first annotation started at line 51, leaving the rich docstring uncovered.
- **Fixed a pre-existing stale anchor:** `ann-setup` `startLine` 51 (a blank line, which resolves to no Lean construct) → 52 (the `abbrev G` docComment).

All anchors validated with `validateLineAnnotations` (5 valid, 0 misaligned). Canonical type/significance enums throughout. No meta.json / status changes (verified/original/0-axiom, accurate).