### PR TITLE
Enrich Gram/Gramian entry (gram-linear-independence-iff-oq-01): overview annotation

### DIFF
--- a/src/data/proofs/gram-linear-independence-iff-oq-01/annotations.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01/annotations.json
@@ -1,50 +1,119 @@
 [
   {
+    "id": "gram-linear-independence-iff-oq-01-ann-overview",
+    "proofId": "gram-linear-independence-iff-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "Overview: Gram matrix, positive definiteness, and the Gramian test",
+    "content": "The docstring sets up the Gram matrix gram 𝕜 v with entries ⟪vᵢ, vⱼ⟫ for a finite family of vectors in an inner product space over 𝕜 (ℝ or ℂ). It re-exports Mathlib's headline characterisation — the Gram matrix is positive definite iff the family is linearly independent — together with the structural facts that it is Hermitian and positive semidefinite (hence the 'mathlib' badge on those). It then previews the genuine content absent from Mathlib: the classical Gramian determinant test, via gram_det_nonneg (Gramian ≥ 0), the kernel identity gram 𝕜 v *ᵥ g = 0 ⟺ ∑ gⱼ•vⱼ = 0, singularity for dependent families, and finally linearIndependent_iff_gram_det_pos with its ne-zero corollaries. Everything is stated over an arbitrary RCLike field, so it applies uniformly to real and complex spaces. The block also fixes the ambient typeclass setup (RCLike 𝕜, InnerProductSpace, Fintype/DecidableEq on the index).",
+    "mathContext": "$G(v)_{ij}=\\langle v_i,v_j\\rangle$; $G(v)\\succ0\\iff v\\text{ lin. indep.}$, and $\\det G(v)\\ge 0$ with $\\det G(v)>0\\iff v\\text{ lin. indep.}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gram matrix",
+      "Gramian determinant",
+      "positive definite matrix",
+      "inner product space",
+      "linear independence"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "positive semidefinite matrices",
+      "determinants"
+    ]
+  },
+  {
     "id": "gram-posdef",
     "proofId": "gram-linear-independence-iff-oq-01",
-    "range": { "startLine": 47, "endLine": 61 },
+    "range": {
+      "startLine": 47,
+      "endLine": 61
+    },
     "type": "concept",
     "title": "The Gram Positive-Definiteness Criterion",
     "content": "posDef_gram_iff_linearIndependent re-exports Mathlib's headline: the Gram matrix gram 𝕜 v (entries ⟪v i, v j⟫) is positive definite iff the family v is linearly independent. gram_isHermitian and gram_posSemidef record the always-true structural facts — a Gram matrix is Hermitian and positive semidefinite for ANY family. So the only variable is strictness: definiteness (no nonzero null vector) is exactly the absence of a linear dependence. This is the spectral form of the criterion; the rest of the file converts it to a determinant test.",
     "mathContext": "$\\mathrm{Gram}(v) \\succ 0 \\iff v$ linearly independent; $\\mathrm{Gram}(v) \\succeq 0$ and Hermitian always.",
     "significance": "key",
-    "relatedConcepts": ["Gram matrix", "positive definite matrix", "inner product space", "linear independence"],
-    "prerequisites": ["inner product spaces", "Hermitian matrices"]
+    "relatedConcepts": [
+      "Gram matrix",
+      "positive definite matrix",
+      "inner product space",
+      "linear independence"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "Hermitian matrices"
+    ]
   },
   {
     "id": "det-nonneg",
     "proofId": "gram-linear-independence-iff-oq-01",
-    "range": { "startLine": 63, "endLine": 68 },
+    "range": {
+      "startLine": 63,
+      "endLine": 68
+    },
     "type": "tactic",
     "title": "The Gramian Is Always Nonnegative",
     "content": "gram_det_nonneg: det(gram 𝕜 v) ≥ 0 for every family, being the determinant of a positive semidefinite matrix (PosSemidef.det_nonneg). This is the determinant shadow of positive semidefiniteness and the starting point of the numerical test: the Gramian can never be negative, so the only question is whether it is strictly positive (independent) or zero (dependent). The 2×2 case det = ‖v₀‖²‖v₁‖² − |⟪v₀,v₁⟫|² ≥ 0 is precisely the Cauchy–Schwarz inequality.",
     "mathContext": "$\\det \\mathrm{Gram}(v) \\ge 0$; for two vectors this is $\\|u\\|^2\\|w\\|^2 - |\\langle u,w\\rangle|^2 \\ge 0$ (Cauchy–Schwarz).",
     "significance": "supporting",
-    "relatedConcepts": ["Gram determinant", "positive semidefinite", "Cauchy–Schwarz inequality", "determinant"],
-    "prerequisites": ["determinants", "positive semidefinite matrices"]
+    "relatedConcepts": [
+      "Gram determinant",
+      "positive semidefinite",
+      "Cauchy–Schwarz inequality",
+      "determinant"
+    ],
+    "prerequisites": [
+      "determinants",
+      "positive semidefinite matrices"
+    ]
   },
   {
     "id": "kernel-identity",
     "proofId": "gram-linear-independence-iff-oq-01",
-    "range": { "startLine": 70, "endLine": 87 },
+    "range": {
+      "startLine": 70,
+      "endLine": 87
+    },
     "type": "insight",
     "title": "Kernel Identity: Dependence = Null Vector of the Gram Matrix",
     "content": "gram_mulVec_eq_zero_of_dependent is the elementary bridge to the determinant: a linear dependence ∑ g j • v j = 0 is exactly a null vector of the Gram matrix, gram 𝕜 v *ᵥ g = 0. The one-line computation (gram 𝕜 v *ᵥ g) i = ⟪v i, ∑ j g j • v j⟫ uses linearity of the inner product in its second argument, so the right side is ⟪v i, 0⟫ = 0. gram_det_eq_zero_of_not_linearIndependent then feeds this through Matrix.exists_mulVec_eq_zero_iff (a square matrix has a nonzero null vector iff its determinant vanishes) to conclude a dependent family has a singular Gram matrix.",
     "mathContext": "$\\sum_j g_j v_j = 0 \\iff \\mathrm{Gram}(v)\\,g = 0$, since $(\\mathrm{Gram}(v)\\,g)_i = \\langle v_i, \\sum_j g_j v_j\\rangle$. A nonzero such $g$ forces $\\det = 0$.",
     "significance": "key",
-    "relatedConcepts": ["kernel of a matrix", "linearity of inner product", "singular matrix", "exists_mulVec_eq_zero_iff"],
-    "prerequisites": ["matrix-vector product", "linear dependence"]
+    "relatedConcepts": [
+      "kernel of a matrix",
+      "linearity of inner product",
+      "singular matrix",
+      "exists_mulVec_eq_zero_iff"
+    ],
+    "prerequisites": [
+      "matrix-vector product",
+      "linear dependence"
+    ]
   },
   {
     "id": "criterion",
     "proofId": "gram-linear-independence-iff-oq-01",
-    "range": { "startLine": 89, "endLine": 114 },
+    "range": {
+      "startLine": 89,
+      "endLine": 114
+    },
     "type": "concept",
     "title": "The Gramian Determinant Criterion",
     "content": "linearIndependent_iff_gram_det_pos is the headline numerical test: v is linearly independent iff det(gram 𝕜 v) > 0. Forward uses PosDef.det_pos on the positive-definite Gram matrix; backward is the contrapositive of the singularity result. gram_det_eq_zero_iff_not_linearIndependent and linearIndependent_iff_gram_det_ne_zero package the three equivalent phrasings (>0, =0, ≠0). Because everything is stated over an arbitrary RCLike field, the criterion holds uniformly for real and complex inner product spaces — the classical Gram determinant test, machine-checked.",
     "mathContext": "$v$ linearly independent $\\iff \\det\\mathrm{Gram}(v) > 0 \\iff \\det\\mathrm{Gram}(v) \\ne 0$; dependent $\\iff \\det\\mathrm{Gram}(v) = 0$.",
     "significance": "key",
-    "relatedConcepts": ["Gram determinant test", "PosDef.det_pos", "linear independence", "RCLike fields"],
-    "prerequisites": ["determinants", "the kernel identity"]
+    "relatedConcepts": [
+      "Gram determinant test",
+      "PosDef.det_pos",
+      "linear independence",
+      "RCLike fields"
+    ],
+    "prerequisites": [
+      "determinants",
+      "the kernel identity"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `gram-linear-independence-iff-oq-01` (passes: 0).

**annotations.json (4 → 5):** added a leading `concept` annotation covering the docstring overview (lines 3–46). Previously the first annotation started at line 47, leaving the rich docstring uncovered — it sets up the Gram matrix `⟪vᵢ,vⱼ⟫`, re-exports Mathlib's positive-definite ⟺ linearly-independent headline (the `mathlib`-badged part), and previews the original Gramian determinant test (`det G ≥ 0`, kernel identity, `det G > 0 ⟺ lin. indep.`), all over an arbitrary RCLike field.

Canonical type/significance enums. `validateLineAnnotations`: 5 valid, 0 misaligned. No meta/status changes (verified, `mathlib` badge accurate for the re-exported headline).