### PR TITLE
Enrich Cauchy xⁿ=g count (cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03): annotate headline cyclic count

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -2,49 +2,120 @@
   {
     "id": "ann-docstring",
     "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
-    "range": { "startLine": 4, "endLine": 58 },
+    "range": {
+      "startLine": 4,
+      "endLine": 58
+    },
     "type": "concept",
     "title": "From xⁿ = 1 to xⁿ = g: the Inhomogeneous Count",
     "content": "The parent pins the homogeneous count #{xⁿ = 1} = gcd(n, |G|) on a cyclic group. This file answers the parent's own third open question: for a fixed g (not necessarily the identity), how many x satisfy xⁿ = g? The answer is a Boolean dichotomy — the count is either the homogeneous count or 0 — and in the cyclic case becomes gcd(n, |G|) or 0, with solvability decided by a single power test. The structural half is valid in every finite abelian group; only the explicit value uses cyclicity.",
     "mathContext": "$$\\#\\{x : x^n = g\\} = \\begin{cases} \\gcd(n, |G|) & g \\text{ an } n\\text{-th power} \\\\ 0 & \\text{otherwise.}\\end{cases}$$",
     "significance": "supporting",
-    "relatedConcepts": ["Frobenius divisibility theorem", "n-th power residues", "cosets of the power map kernel", "cyclic groups"],
-    "prerequisites": ["finite abelian groups", "order of an element", "homomorphisms and kernels"]
+    "relatedConcepts": [
+      "Frobenius divisibility theorem",
+      "n-th power residues",
+      "cosets of the power map kernel",
+      "cyclic groups"
+    ],
+    "prerequisites": [
+      "finite abelian groups",
+      "order of an element",
+      "homomorphisms and kernels"
+    ]
   },
   {
     "id": "ann-coset-count",
     "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
-    "range": { "startLine": 66, "endLine": 87 },
+    "range": {
+      "startLine": 66,
+      "endLine": 87
+    },
     "type": "insight",
     "title": "The Whole Generalisation Is One Coset Bijection",
     "content": "In a finite abelian group the power map x ↦ xⁿ is a homomorphism, so the solutions of xⁿ = g form a coset of the kernel {x | xⁿ = 1} whenever they exist. Concretely, fixing one root a₀ (a₀ⁿ = g), left-translation x ↦ a₀⁻¹·x is a bijection onto {x | xⁿ = 1}: (a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ, which is 1 exactly when xⁿ = g. The formalization presents {x | xⁿ = g} as the image of {x | xⁿ = 1} under multiplication by a₀ and applies card_image_of_injective. The payoff: the number of n-th roots of g is the same for EVERY solvable g — it never depends on which g.",
     "mathContext": "$x \\mapsto a_0^{-1}x$ bijects $\\{x : x^n = g\\}$ with $\\{x : x^n = 1\\}$ since $(a_0^{-1}x)^n = (a_0^n)^{-1}x^n = g^{-1}x^n$.",
     "significance": "key",
-    "relatedConcepts": ["cosets", "fibres of a homomorphism", "orbit–stabiliser", "left translation"],
-    "prerequisites": ["mul_pow in commutative groups", "Finset.card_image_of_injective", "mul_left_cancel"]
+    "relatedConcepts": [
+      "cosets",
+      "fibres of a homomorphism",
+      "orbit–stabiliser",
+      "left translation"
+    ],
+    "prerequisites": [
+      "mul_pow in commutative groups",
+      "Finset.card_image_of_injective",
+      "mul_left_cancel"
+    ]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
-    "range": { "startLine": 89, "endLine": 101 },
+    "range": {
+      "startLine": 89,
+      "endLine": 101
+    },
     "type": "tactic",
     "title": "A Boolean Dichotomy: 0 or the Full Count",
     "content": "There is no intermediate possibility. If g is an n-th power, the count is #{x | xⁿ = 1}; if not, the solution Finset is empty by definition (no x even satisfies xⁿ = g), handled by filter_false_of_mem. The if-then-else packaging makes the dichotomy explicit and is what specialises cleanly to the cyclic value.",
     "mathContext": "$\\#\\{x : x^n = g\\} = \\mathbf{1}[\\exists a, a^n = g]\\cdot \\#\\{x : x^n = 1\\}.$",
     "significance": "supporting",
-    "relatedConcepts": ["solvability", "empty fibres", "indicator of membership in the image"],
-    "prerequisites": ["Finset.filter_false_of_mem", "Finset.card_eq_zero"]
+    "relatedConcepts": [
+      "solvability",
+      "empty fibres",
+      "indicator of membership in the image"
+    ],
+    "prerequisites": [
+      "Finset.filter_false_of_mem",
+      "Finset.card_eq_zero"
+    ]
   },
   {
     "id": "ann-effective-test",
     "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
-    "range": { "startLine": 124, "endLine": 188 },
+    "range": {
+      "startLine": 124,
+      "endLine": 188
+    },
     "type": "insight",
     "title": "Deciding Solvability: the (m/gcd)-Torsion Test",
     "content": "In a cyclic group of order m the n-th powers form the unique subgroup of order m/gcd(n,m), namely the (m/gcd(n,m))-torsion {x | x^(m/gcd(n,m)) = 1}. The proof identifies the image subgroup (powMonoidHom n).range with the kernel (powMonoidHom (m/d)).ker: the inclusion range ≤ ker holds because (aⁿ)^(m/d) = a^(m·n') = 1 when d ∣ n, and both subgroups have cardinality m/d by Mathlib's IsCyclic.card_powMonoidHom_range and card_powMonoidHom_ker, so Subgroup.eq_of_le_of_card_ge forces equality. Hence g is an n-th power iff g^(m/gcd(n,m)) = 1 — a decidable test that makes the entire count computable (card_pow_eq_cyclic_effective). Over a finite field's multiplicative group this is the classical n-th power residue criterion g^((q-1)/gcd(n,q-1)) = 1.",
     "mathContext": "$g \\text{ is an } n\\text{-th power} \\iff g^{\\,m/\\gcd(n,m)} = 1,\\quad m = |G|.$",
     "significance": "key",
-    "relatedConcepts": ["torsion subgroups", "unique subgroup of given order", "n-th power residues", "image of the power map"],
-    "prerequisites": ["IsCyclic.card_powMonoidHom_range", "IsCyclic.card_powMonoidHom_ker", "Subgroup.eq_of_le_of_card_ge"]
+    "relatedConcepts": [
+      "torsion subgroups",
+      "unique subgroup of given order",
+      "n-th power residues",
+      "image of the power map"
+    ],
+    "prerequisites": [
+      "IsCyclic.card_powMonoidHom_range",
+      "IsCyclic.card_powMonoidHom_ker",
+      "Subgroup.eq_of_le_of_card_ge"
+    ]
+  },
+  {
+    "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-ann-cyclic-count",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "The headline cyclic count: gcd(n, |G|) or 0",
+    "content": "The explicit count that gives the entry its title. Feeding the parent's exact solution count #{xⁿ = 1} = gcd(n, |G|) into the coset dichotomy yields, in a finite cyclic group, that #{x | xⁿ = g} equals gcd(n, |G|) when g is an n-th power and 0 otherwise (card_pow_eq_cyclic) — a value independent of which n-th power g is. The companion card_pow_eq_cyclic_one then specialises to g = 1 (always an n-th power via x = 1), recovering the parent's gcd(n, |G|) count and confirming this formula refines the original.",
+    "mathContext": "$\\#\\{x : x^n = g\\}=\\begin{cases}\\gcd(n,|G|)&g\\in G^n\\\\0&\\text{otherwise}\\end{cases}$ in a finite cyclic group; at $g=1$ this is $\\gcd(n,|G|)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclic groups",
+      "greatest common divisor",
+      "n-th powers",
+      "coset counting",
+      "Frobenius' theorem"
+    ],
+    "prerequisites": [
+      "cyclic group structure",
+      "order of a finite group",
+      "the parent xⁿ = 1 count"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass (passes: 0).

**annotations.json (4 → 5):** added an `insight` annotation covering lines 103–123 — the **headline theorem** `card_pow_eq_cyclic` (#{x : xⁿ = g} = gcd(n,|G|) if g is an n-th power, else 0, the result the entry is titled after) together with its `g = 1` specialisation `card_pow_eq_cyclic_one`. These sit between the existing 'Boolean dichotomy' (89–101) and 'effective n-th power test' (124–188) annotations and were previously uncovered.

Canonical type/significance enums. `validateLineAnnotations`: 5 valid, 0 misaligned. No meta/status changes.