### PR TITLE
Enrich dual Weyl inequality (cauchy-interlacing-theorem-oq-03-oq-02): main-theorem annotation + header coverage/anchor fix

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-02/annotations.json
@@ -2,73 +2,164 @@
   {
     "id": "ann-dualweyl-oq0302-setup",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 42, "endLine": 44 },
+    "range": {
+      "startLine": 4,
+      "endLine": 44
+    },
     "type": "concept",
     "title": "Setup: A Corollary File over the Subadditive Weyl Inequality",
     "content": "The single non-Mathlib import is `Proofs.CauchyInterlacingWeyl`, which supplies `weyl_add_le`: for `i + j ≤ k`, `ρ(k) ≤ μ(i) + ν(j)`, where μ, ν, ρ are the antitone (descending) eigenvalue enumerations of T, U, T+U — itself a 0-axiom/0-sorry corollary of the Courant–Fischer keystone. The whole dual inequality is assembled from `weyl_add_le` alone by the reflection T ↦ −T; no new spectral theory is re-derived. The file reuses the parent's `CauchyInterlacing.Weyl` namespace so that `weyl_add_ge` sits beside its dual `weyl_add_le`.",
     "mathContext": "Imports `weyl_add_le : i+j \\le k \\Rightarrow \\rho_k \\le \\mu_i + \\nu_j` and builds its mirror `\\mu_i + \\nu_j \\le \\rho_k` for `k+(n-1) \\le i+j`.",
     "significance": "supporting",
-    "relatedConcepts": ["Weyl inequalities", "Courant–Fischer min-max", "eigenvalue interlacing", "reflection T ↦ −T"],
-    "prerequisites": ["the parent weyl_add_le subadditive inequality", "antitone eigenvalue enumerations"]
+    "relatedConcepts": [
+      "Weyl inequalities",
+      "Courant–Fischer min-max",
+      "eigenvalue interlacing",
+      "reflection T ↦ −T"
+    ],
+    "prerequisites": [
+      "the parent weyl_add_le subadditive inequality",
+      "antitone eigenvalue enumerations"
+    ]
   },
   {
     "id": "ann-dualweyl-oq0302-negation-eigen",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 46, "endLine": 61 },
+    "range": {
+      "startLine": 46,
+      "endLine": 61
+    },
     "type": "tactic",
     "title": "Carrying the Spectrum Through Negation: neg_reindex_eigen",
     "content": "This lemma is the entire spectral content of the negation trick. A symmetric operator T with `T(b i) = μ i • b i` negates to −T, whose eigenvalues are −μ. But to present −T with a DESCENDING enumeration the eigenvalues must be read in reverse: the largest eigenvalue of −T is minus the smallest of T. So the eigenbasis is reindexed by `Fin.revPerm` (the order-reversing involution `i ↦ n−1−i`), giving the still-orthonormal basis `b.reindex Fin.revPerm` with `(b.reindex Fin.revPerm) t = b (Fin.rev t)` by `OrthonormalBasis.reindex_apply` (and `revPerm_symm = revPerm`). Then `LinearMap.neg_apply` turns `(−T)(b(rev t))` into `−(T(b(rev t))) = −(μ(rev t) • b(rev t))`, and `push_cast` + `neg_smul` repackage this as `(−μ(rev t)) • b(rev t)`. The result: −T is presented by the reversed basis and enumeration `t ↦ −μ(Fin.rev t)`.",
     "mathContext": "The k-th largest eigenvalue of −T is `-\\mu_{n-1-k}`: negation flips sign AND reverses order, hence reindex by `\\mathrm{rev}` and negate.",
     "significance": "critical",
-    "relatedConcepts": ["spectrum of −T", "Fin.revPerm order reversal", "OrthonormalBasis.reindex", "eigenbasis reindexing"],
-    "prerequisites": ["orthonormal eigenbasis presentation", "LinearMap.neg_apply", "neg_smul"]
+    "relatedConcepts": [
+      "spectrum of −T",
+      "Fin.revPerm order reversal",
+      "OrthonormalBasis.reindex",
+      "eigenbasis reindexing"
+    ],
+    "prerequisites": [
+      "orthonormal eigenbasis presentation",
+      "LinearMap.neg_apply",
+      "neg_smul"
+    ]
   },
   {
     "id": "ann-dualweyl-oq0302-antitone",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 63, "endLine": 73 },
+    "range": {
+      "startLine": 63,
+      "endLine": 73
+    },
     "type": "tactic",
     "title": "Antitonicity Survives Both Reversals: antitone_neg_rev",
     "content": "`weyl_add_le` requires its eigenvalue enumerations to be `Antitone`, so the negated/reversed enumeration `t ↦ −μ(Fin.rev t)` must be shown antitone whenever μ is. The argument is a clean double reversal: for `a ≤ c`, `Fin.rev` reverses to `Fin.rev c ≤ Fin.rev a` (proved by rewriting through `Fin.val_rev : (Fin.rev x : ℕ) = n−(x+1)` and discharging with `omega`); applying the antitone μ gives `μ(Fin.rev a) ≤ μ(Fin.rev c)`; then `neg_le_neg` flips once more to `−μ(Fin.rev c) ≤ −μ(Fin.rev a)`. Two order reversals (the reindex and the negation) compose to the required antitone direction.",
     "mathContext": "`\\mathrm{rev}` is order-reversing and `x \\mapsto -x` is order-reversing; their composite with the antitone μ is again antitone.",
     "significance": "key",
-    "relatedConcepts": ["Antitone monotonicity", "double order reversal", "Fin.val_rev", "neg_le_neg"],
-    "prerequisites": ["Antitone hypothesis on μ", "omega on Fin index arithmetic"]
+    "relatedConcepts": [
+      "Antitone monotonicity",
+      "double order reversal",
+      "Fin.val_rev",
+      "neg_le_neg"
+    ],
+    "prerequisites": [
+      "Antitone hypothesis on μ",
+      "omega on Fin index arithmetic"
+    ]
   },
   {
     "id": "ann-dualweyl-oq0302-sum",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 96, "endLine": 105 },
+    "range": {
+      "startLine": 96,
+      "endLine": 105
+    },
     "type": "insight",
     "title": "The Negated Sum Is the Sum of Negations",
     "content": "`weyl_add_le` is applied with first two operators `−T` and `−U`, so it forms their sum `(−T) + (−U)` and demands its eigen-presentation. The identity `(−T) + (−U) = −(T + U)` (proved by `LinearMap.ext` / `simp`) lets that presentation be read straight off the GIVEN presentation of `T + U`: applying `neg_reindex_eigen` to the operator `T + U` with basis d and enumeration ρ yields `(−(T+U))((d.reindex Fin.revPerm) t) = (−ρ(Fin.rev t)) • …`, which after the rewrite is exactly the presentation of the sum operator `weyl_add_le` sees. One lemma, `neg_reindex_eigen`, thus serves all three operators T, U, T+U.",
     "mathContext": "`(-T)+(-U) = -(T+U)` so the reversed-negated presentation of the sum needs no separate spectral input.",
     "significance": "key",
-    "relatedConcepts": ["linearity of negation", "LinearMap.ext", "shared eigen-presentation", "additivity of spectra"],
-    "prerequisites": ["neg_reindex_eigen", "LinearMap arithmetic"]
+    "relatedConcepts": [
+      "linearity of negation",
+      "LinearMap.ext",
+      "shared eigen-presentation",
+      "additivity of spectra"
+    ],
+    "prerequisites": [
+      "neg_reindex_eigen",
+      "LinearMap arithmetic"
+    ]
   },
   {
     "id": "ann-dualweyl-oq0302-index-flip",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 106, "endLine": 113 },
+    "range": {
+      "startLine": 106,
+      "endLine": 113
+    },
     "type": "insight",
     "title": "Index Reversal Produces the n−1 Defect",
     "content": "Here lies the entire arithmetic content of the dual bound. `weyl_add_le` needs `(Fin.rev i) + (Fin.rev j) ≤ (Fin.rev k)`. Rewriting each `(Fin.rev x : ℕ)` to `n−(x+1)` via `Fin.val_rev`, this is `(n−1−i) + (n−1−j) ≤ (n−1−k)`, which `omega` shows equivalent (using `i, j, k < n`) to the hypothesis `k + (n−1) ≤ i + j`. The characteristic `n−1` defect of the lower Weyl inequality appears precisely because reversing three indices in `[0, n)` injects three copies of `(n−1)` that omega collapses to one. No spectral fact is touched — only counting.",
     "mathContext": "Reversing `i, j, k` turns `i'+j' \\le k'` into `k + (n-1) \\le i + j`: the lower-Weyl defect is an index-arithmetic artifact.",
     "significance": "critical",
-    "relatedConcepts": ["lower Weyl inequality defect", "index arithmetic", "Fin.val_rev", "omega decision procedure"],
-    "prerequisites": ["the reversed-index hypothesis k+(n−1) ≤ i+j", "i,j,k < n bounds"]
+    "relatedConcepts": [
+      "lower Weyl inequality defect",
+      "index arithmetic",
+      "Fin.val_rev",
+      "omega decision procedure"
+    ],
+    "prerequisites": [
+      "the reversed-index hypothesis k+(n−1) ≤ i+j",
+      "i,j,k < n bounds"
+    ]
   },
   {
     "id": "ann-dualweyl-oq0302-finish",
     "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
-    "range": { "startLine": 114, "endLine": 126 },
+    "range": {
+      "startLine": 114,
+      "endLine": 126
+    },
     "type": "insight",
     "title": "Applying weyl_add_le and Unwinding the Reversal",
     "content": "With the three negated presentations, the three antitone facts, and the reversed-index hypothesis in hand, `weyl_add_le` is applied to `−T`, `−U` at the reversed indices `Fin.rev i, Fin.rev j, Fin.rev k`. Its conclusion is `(−ρ∘rev)(Fin.rev k) ≤ (−μ∘rev)(Fin.rev i) + (−ν∘rev)(Fin.rev j)`, i.e. `−ρ(rev(rev k)) ≤ −μ(rev(rev i)) − ν(rev(rev j))`. `simp [Fin.rev_rev]` collapses every `rev(rev x)` to `x`, leaving `−ρ(k) ≤ −μ(i) − ν(j)`, and `linarith` rearranges this to the goal `μ(i) + ν(j) ≤ ρ(k)`. The subadditive inequality, reflected, IS the superadditive one.",
     "mathContext": "`\\mathrm{rev}\\,\\mathrm{rev}\\,x = x` collapses the doubly-reversed indices; `-\\rho_k \\le -\\mu_i-\\nu_j` is `\\mu_i+\\nu_j \\le \\rho_k`.",
     "significance": "key",
-    "relatedConcepts": ["Fin.rev_rev involution", "linarith rearrangement", "superadditive Weyl inequality", "reflection duality"],
-    "prerequisites": ["weyl_add_le", "the antitone facts and negated presentations above"]
+    "relatedConcepts": [
+      "Fin.rev_rev involution",
+      "linarith rearrangement",
+      "superadditive Weyl inequality",
+      "reflection duality"
+    ],
+    "prerequisites": [
+      "weyl_add_le",
+      "the antitone facts and negated presentations above"
+    ]
+  },
+  {
+    "id": "cauchy-interlacing-theorem-oq-03-oq-02-ann-main-theorem",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "The dual Weyl inequality μ i + ν j ≤ ρ k",
+    "content": "The file's headline result, weyl_add_ge. For self-adjoint operators T, U, and T + U on a finite-dimensional inner product space, presented by descending (antitone) eigenvalue enumerations μ, ν, ρ in orthonormal bases, whenever the indices satisfy k + (n−1) ≤ i + j one has μ i + ν j ≤ ρ k. This is the superadditive companion of weyl_add_le; in classical 1-based descending notation it reads λ_{i+1}(A) + λ_{j+1}(B) ≤ λ_{i+j+1−(n−1)}(A+B). The proof (annotated below) applies weyl_add_le to −T, −U, −(T+U) in the reversed eigenbases and at the reversed indices, so the negation flips both the index hypothesis and the inequality.",
+    "mathContext": "$\\mu_i+\\nu_j\\le\\rho_k$ whenever $k+(n-1)\\le i+j$; classically $\\lambda_{i+1}(A)+\\lambda_{j+1}(B)\\le\\lambda_{i+j+1-(n-1)}(A+B)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Weyl inequalities",
+      "eigenvalue interlacing",
+      "self-adjoint operators",
+      "spectral duality by negation"
+    ],
+    "prerequisites": [
+      "spectral theorem",
+      "antitone eigenvalue enumeration",
+      "the companion weyl_add_le"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass (passes: 0).

**annotations.json (6 → 7):**
- Added a `theorem` annotation covering the headline result `weyl_add_ge` (lines 73–95) — the dual Weyl inequality μ i + ν j ≤ ρ k under k+(n−1) ≤ i+j, the superadditive companion of `weyl_add_le`. Previously only the setup and proof-body steps were annotated; the main theorem statement itself was uncovered.
- Broadened the `setup` annotation to cover the file header docstring (lines 4–44, the negation-duality overview) which was uncovered, and **re-anchored** it from line 42 (`open scoped`, which resolves to no Lean construct) to line 4 (the header block comment).

Canonical type/significance enums. `validateLineAnnotations`: 7 valid, 0 misaligned. No meta/status changes (verified/original/0-axiom).