### PR TITLE
Enrich cubic-discriminant-as-resultant entry (solution-of-cubic-oq-01-oq-01-oq-02): overview annotation

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "solution-of-cubic-oq-01-oq-01-oq-02-ann-overview",
+    "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 5,
+      "endLine": 57
+    },
+    "type": "concept",
+    "title": "Overview: the discriminant as Res(f, f′)",
+    "content": "The docstring frames the open question inherited from the parent SolutionOfCubicOQ01OQ01, which defined the general cubic discriminant Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² by hand and asked for it to be derived as the resultant Res(f, f′). Using Mathlib's resultant theory it proves two structural identities: f.discr = Δ (identifying the parent's ad-hoc polynomial with Mathlib's intrinsic Sylvester-matrix discriminant) and Res(f, f′) = −a·Δ (the classical Res = (−1)^{n(n−1)/2}·aₙ·Δ specialized to n = 3, where the sign is −1). As a corollary the resultant vanishes exactly when the cubic has a repeated root — the eliminant characterization. It also sets up the ambient work: the parent import, Mathlib's Resultant and ComputeDegree, and the namespace/opens.",
+    "mathContext": "$f=aX^3+bX^2+cX+d$; $\\operatorname{discr}f=\\Delta$ and $\\operatorname{Res}(f,f')=-a\\,\\Delta$, so $\\operatorname{Res}(f,f')=0\\iff\\Delta=0\\iff f$ has a repeated root.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant",
+      "resultant",
+      "Sylvester matrix",
+      "repeated roots",
+      "elimination theory"
+    ],
+    "prerequisites": [
+      "polynomials over ℂ",
+      "resultants",
+      "the parent cubic discriminant"
+    ]
+  },
+  {
     "id": "ann-soc-oq010102-cubicpoly",
     "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
     "range": {
@@ -11,8 +36,17 @@
     "content": "To apply Mathlib's intrinsic resultant and discriminant, the cubic must be an honest element of ℂ[X]: cubicPoly a b c d = C a·X³ + C b·X² + C c·X + C d. Its coefficients (a, b, c, d at degrees 3, 2, 1, 0) fall out of simp with coeff_X_pow. The degree facts use compute_degree!, which proves natDegree = 3 and degree = 3 once the leading coefficient a is known nonzero. The leading coefficient is then coeff 3 = a, and the derivative is 3a·X² + 2b·X + c (combining the C-factors with C_mul before ring).",
     "mathContext": "$f(X) = aX^3 + bX^2 + cX + d \\in \\mathbb{C}[X]$, $a\\neq 0$; $\\deg f = 3$, leading coeff $a$, and $f'(X) = 3aX^2 + 2bX + c$.",
     "significance": "supporting",
-    "relatedConcepts": ["polynomial ring", "degree of a polynomial", "formal derivative", "compute_degree tactic", "leading coefficient"],
-    "prerequisites": ["polynomials over ℂ", "Lean Polynomial API"]
+    "relatedConcepts": [
+      "polynomial ring",
+      "degree of a polynomial",
+      "formal derivative",
+      "compute_degree tactic",
+      "leading coefficient"
+    ],
+    "prerequisites": [
+      "polynomials over ℂ",
+      "Lean Polynomial API"
+    ]
   },
   {
     "id": "ann-soc-oq010102-discr-bridge",
@@ -26,8 +60,16 @@
     "content": "cubic_discr_eq_generalDiscriminant identifies Mathlib's intrinsic Polynomial.discr — defined as the determinant of the (normalized) Sylvester matrix of f and f′, times a sign — with the parent's hand-written coefficient polynomial generalDiscriminant a b c d. Mathlib's discr_of_degree_eq_three gives discr f in terms of f.coeff 0..3; substituting the computed coefficients and calling ring matches it to 18abcd − 4b³d + b²c² − 4ac³ − 27a²d². The ad-hoc polynomial and the basis-free Sylvester determinant are the same object.",
     "mathContext": "$\\operatorname{disc} f = \\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2$ — Mathlib's Sylvester-determinant discriminant equals the parent's coefficient formula.",
     "significance": "key",
-    "relatedConcepts": ["discriminant", "Sylvester matrix", "resultant", "symmetric functions of roots"],
-    "prerequisites": ["discriminant of a polynomial", "determinants"]
+    "relatedConcepts": [
+      "discriminant",
+      "Sylvester matrix",
+      "resultant",
+      "symmetric functions of roots"
+    ],
+    "prerequisites": [
+      "discriminant of a polynomial",
+      "determinants"
+    ]
   },
   {
     "id": "ann-soc-oq010102-resultant",
@@ -41,8 +83,17 @@
     "content": "The headline cubic_resultant_eq_neg_smul_discriminant specializes Mathlib's resultant_deriv, Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·discr f, to the cubic. At n = natDegree = 3 the sign exponent is 3·2/2 = 3, so (−1)³ = −1; the leading coefficient aₙ is a; and discr f is Δ by the bridge. Hence Res(f, f′) = −a·Δ(a,b,c,d). For the depressed cubic X³ + p·X + q this is the textbook 4p³ + 27q² = −(−4p³ − 27q²).",
     "mathContext": "$\\operatorname{Res}(f,f') = (-1)^{n(n-1)/2} a_n \\operatorname{disc} f = -a\\,\\Delta$ at $n=3$; for $X^3+pX+q$, $\\operatorname{Res}(f,f') = 4p^3 + 27q^2$.",
     "significance": "key",
-    "relatedConcepts": ["resultant", "discriminant", "eliminant", "depressed cubic", "Sylvester matrix"],
-    "prerequisites": ["resultant of two polynomials", "discriminant"]
+    "relatedConcepts": [
+      "resultant",
+      "discriminant",
+      "eliminant",
+      "depressed cubic",
+      "Sylvester matrix"
+    ],
+    "prerequisites": [
+      "resultant of two polynomials",
+      "discriminant"
+    ]
   },
   {
     "id": "ann-soc-oq010102-eliminant",
@@ -56,7 +107,16 @@
     "content": "Because a ≠ 0, the factor −a in Res(f, f′) = −a·Δ never vanishes, so cubic_resultant_eq_zero_iff gives Res(f, f′) = 0 ⟺ Δ = 0 (mul_eq_zero plus neg_eq_zero discard the −a branch). Chaining the parent's repeated_root_iff then yields cubic_resultant_eq_zero_iff_repeated_root: for a cubic given by Vieta data on roots x₁, x₂, x₃, the resultant of f with f′ vanishes iff two of the roots coincide — the classical statement that the discriminant is the eliminant of f and its derivative.",
     "mathContext": "$\\operatorname{Res}(f,f') = 0 \\iff \\Delta = 0 \\iff x_1=x_2 \\lor x_1=x_3 \\lor x_2=x_3$ (a repeated root), since $a\\neq 0$.",
     "significance": "key",
-    "relatedConcepts": ["eliminant", "repeated root", "Vieta's formulas", "discriminant vanishing", "multiple roots"],
-    "prerequisites": ["resultant and elimination", "Vieta's formulas"]
+    "relatedConcepts": [
+      "eliminant",
+      "repeated root",
+      "Vieta's formulas",
+      "discriminant vanishing",
+      "multiple roots"
+    ],
+    "prerequisites": [
+      "resultant and elimination",
+      "Vieta's formulas"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass (passes: 0).

**annotations.json (4 → 5):** added a leading `concept` annotation covering the docstring overview (lines 5–57). Previously the first annotation started at line 59, leaving the rich docstring uncovered — it frames the parent's open question (derive Δ as a resultant) and the two structural identities proved here, `f.discr = Δ` and `Res(f, f′) = −a·Δ` (the classical Res = (−1)^{n(n−1)/2}·aₙ·Δ at n=3), plus the eliminant corollary that the resultant vanishes iff the cubic has a repeated root.

Canonical type/significance enums. `validateLineAnnotations`: 5 valid, 0 misaligned. No meta/status changes (verified, `mathlib` badge).