### PR TITLE
Enrich Euclid-style infinitude of primes ≡7 (mod 8) (infinitude-primes-4k3-oq-01-oq-01): conclusion openQuestions

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-01-oq-01/meta.json
@@ -175,7 +175,11 @@
       "Demonstrates the parity-on-factorization technique for isolating a single class from a residue-pair {±1} that a quadratic-residue condition selects — reusable for other ± classes.",
       "Provides a self-contained, L-function-free instance of Dirichlet's theorem for (q, a) = (8, 7), one of the harder classes to reach elementarily."
     ],
-    "openQuestions": []
+    "openQuestions": [
+      "Map exactly which residue classes admit a Dirichlet-free Euclid/quadratic-residue proof of prime infinitude: extend the $M = a^2 - 2$ construction to the classes $\\equiv 3, 5 \\pmod 8$ and to moduli $12, 16$.",
+      "Formalize the Murty characterization — a class $a \\pmod m$ has a 'Euclidean' (single-polynomial) infinitude proof iff $a^2 \\equiv 1 \\pmod m$ — delimiting precisely the reach of this elementary method versus full Dirichlet.",
+      "Extract an explicit (if weak) lower bound on the counting function $\\pi(x; 8, 7)$ by iterating the construction, turning the qualitative infinitude into an effective density statement."
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-4k3-oq-01-oq-01`.

The `conclusion` block had `summary` and `implications` but no `openQuestions`, so the conclusion panel rendered without its Open Questions section. Added 3 mathematically-grounded open questions drawn from the entry's own scope and honest-limitations narrative.

The entry removes the Dirichlet dependence for this class; the added questions target other classes, the Murty characterization of the method's reach, and an effective counting bound.

No changes to the Lean proof, status, badge, or axiom count.
