### PR TITLE
Enrich Cauchy interlacing submatrix corollary (cauchy-interlacing-theorem-oq-01-oq-01-oq-02): basis-construction annotation + anchor fix

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -2,61 +2,139 @@
   {
     "id": "ann-eigenvalues-finrank-congr",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 63, "endLine": 72 },
+    "range": {
+      "startLine": 63,
+      "endLine": 72
+    },
     "type": "technique",
     "title": "Eigenvalues Are Independent of the Dimension Proof",
     "content": "`LinearMap.IsSymmetric.eigenvalues` is indexed by `Fin m` through a *proof* `finrank 𝕜 E = m`, so the operator statement (using `finrank_euclideanSpace_fin`) and the literal `eigenvalues₀` statement (using `finrank_euclideanSpace`) name the same list against two different indexings. `eigenvalues_finrank_congr` discharges this once: since both `m` and `m'` equal `finrank 𝕜 E`, the equality `m = m'` is forced, and after `obtain rfl` the reindexing `Fin.cast` collapses to the identity (`Fin.cast_eq_self`). This single lemma is the only bridge needed between the abstract-operator proof and Mathlib's `Matrix.IsHermitian.eigenvalues₀` indexing.",
     "mathContext": "The eigenvalue list of a symmetric operator on an $m$-dimensional space is canonical; two proofs of $\\dim E = m$ yield the same list up to the forced identity $\\mathrm{Fin}\\,m \\simeq \\mathrm{Fin}\\,m'$.",
     "significance": "supporting",
-    "relatedConcepts": ["proof irrelevance", "Fin.cast", "dependent indexing", "eigenvalues₀"],
-    "prerequisites": ["Fin.cast and dependent types", "LinearMap.IsSymmetric.eigenvalues"]
+    "relatedConcepts": [
+      "proof irrelevance",
+      "Fin.cast",
+      "dependent indexing",
+      "eigenvalues₀"
+    ],
+    "prerequisites": [
+      "Fin.cast and dependent types",
+      "LinearMap.IsSymmetric.eigenvalues"
+    ]
   },
   {
     "id": "ann-interlacing-of-intertwine",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 87, "endLine": 111 },
+    "range": {
+      "startLine": 87,
+      "endLine": 111
+    },
     "type": "insight",
     "title": "Transfer Engine: Interlacing Across an Isometric Intertwining",
     "content": "`interlacing_of_intertwine` is the reusable core. Given a symmetric operator `T` on `V` (antitone eigendata `b, lam`), a codimension-one `H ≤ V`, a model operator `T'` on `E` (antitone eigendata `b', mu`), an isometry `e : E ≃ₗᵢ H`, and the intertwining `TH (e x) = e (T' x)`, it concludes `lam k.succ ≤ mu k ≤ lam k.castSucc`. The proof simply maps `T'`'s eigenbasis through `e` (`b'.map e`) to obtain an eigenbasis of the compression with the SAME eigenvalues `mu`, then invokes the abstract `cauchy_interlacing`.",
     "mathContext": "If S = e ∘ T' ∘ e⁻¹ and b' diagonalizes T', then e∘b' diagonalizes S with identical eigenvalues; unitary equivalence preserves the spectrum.",
     "significance": "key",
-    "relatedConcepts": ["unitary equivalence", "spectral transport", "compression", "Cauchy interlacing"],
-    "prerequisites": ["orthonormal eigenbasis from the spectral theorem", "Rayleigh quotient of a compression"]
+    "relatedConcepts": [
+      "unitary equivalence",
+      "spectral transport",
+      "compression",
+      "Cauchy interlacing"
+    ],
+    "prerequisites": [
+      "orthonormal eigenbasis from the spectral theorem",
+      "Rayleigh quotient of a compression"
+    ]
   },
   {
     "id": "ann-coord-equiv",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 138, "endLine": 165 },
+    "range": {
+      "startLine": 139,
+      "endLine": 165
+    },
     "type": "definition",
     "title": "The Coordinate Isometry e_i ↦ e_{j.succAbove i}",
     "content": "The orthonormal family of standard basis vectors other than `e_j` is packaged by `OrthonormalBasis.mk` into `coordBasis`, an orthonormal basis of the coordinate hyperplane. Its inverse representation `coordEquiv := coordBasis.repr.symm` is the linear isometry equivalence `EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H` sending `e_i` to `e_{j.succAbove i}`. The helper `coordBasis_inner_coordEquiv` records that reading a coordinate of `coordEquiv x` against `coordBasis i'` returns `x i'`.",
     "mathContext": "An orthonormal basis B of an n-dimensional inner product space induces an isometry to EuclideanSpace 𝕜 (Fin n) via the coordinate representation B.repr.",
     "significance": "key",
-    "relatedConcepts": ["orthonormal basis", "linear isometry equivalence", "coordinate hyperplane", "Fin.succAbove"],
-    "prerequisites": ["OrthonormalBasis.mk", "OrthonormalBasis.repr"]
+    "relatedConcepts": [
+      "orthonormal basis",
+      "linear isometry equivalence",
+      "coordinate hyperplane",
+      "Fin.succAbove"
+    ],
+    "prerequisites": [
+      "OrthonormalBasis.mk",
+      "OrthonormalBasis.repr"
+    ]
   },
   {
     "id": "ann-compress-intertwine",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 173, "endLine": 219 },
+    "range": {
+      "startLine": 173,
+      "endLine": 219
+    },
     "type": "insight",
     "title": "The Compression Is the Submatrix Operator",
     "content": "`compress_coordBasis` checks the intertwining on a single coordinate vector: `coordBasis.repr.injective` reduces it to one submodule inner product, read off by the previous entry's `compress_inner_eq_principalSubmatrix` as an entry of `A' = A.submatrix j.succAbove j.succAbove`. `compress_intertwine` then extends to all `x` by expanding in the standard basis and pushing `compress`, `toEuclideanLin A'` and `coordEquiv` through the sum with `map_sum`/`map_smul`. Keeping these as rewrite lemmas (rather than linear-map-composition coercions) is essential: it leaves the `OrthonormalBasis.mk`-built isometry opaque, avoiding a definitional-unfolding blow-up.",
     "mathContext": "The orthogonal compression P_H ∘ A ∘ ι_H, conjugated by the coordinate isometry, is exactly the principal submatrix operator on the smaller space.",
     "significance": "key",
-    "relatedConcepts": ["orthogonal compression", "principal submatrix", "intertwining", "map_sum"],
-    "prerequisites": ["compress_inner_eq_principalSubmatrix (parent entry)", "linearity of toEuclideanLin and isometries"]
+    "relatedConcepts": [
+      "orthogonal compression",
+      "principal submatrix",
+      "intertwining",
+      "map_sum"
+    ],
+    "prerequisites": [
+      "compress_inner_eq_principalSubmatrix (parent entry)",
+      "linearity of toEuclideanLin and isometries"
+    ]
   },
   {
     "id": "ann-eigenvalues-corollary",
     "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 221, "endLine": 292 },
+    "range": {
+      "startLine": 221,
+      "endLine": 292
+    },
     "type": "theorem",
     "title": "The Literal Matrix Cauchy Interlacing Theorem",
     "content": "`principalSubmatrix_eigenvalues_interlacing` instantiates the transfer engine with the coordinate isometry, giving `λ_{k+1} ≤ μ_k ≤ λ_k` for the symmetric-operator eigenvalues of `A` and its principal submatrix. Because `Matrix.IsHermitian.eigenvalues₀` is by definition the operator's eigenvalues, the only remaining gap is the `Fin (card) ↔ Fin (n+1)` reindexing, discharged by `eigenvalues_finrank_congr` to yield the literal `eigenvalues₀`-level statement `eigenvalues₀_principalSubmatrix_interlacing`.",
     "mathContext": "Cauchy interlacing: for Hermitian A (size n+1) and principal submatrix A' (delete row/col j), λ_{k+1}(A) ≤ λ_k(A') ≤ λ_k(A).",
     "significance": "key",
-    "relatedConcepts": ["Cauchy interlacing theorem", "Matrix.IsHermitian.eigenvalues₀", "principal submatrix"],
-    "prerequisites": ["the transfer engine", "eigenvalues₀ as operator eigenvalues"]
+    "relatedConcepts": [
+      "Cauchy interlacing theorem",
+      "Matrix.IsHermitian.eigenvalues₀",
+      "principal submatrix"
+    ],
+    "prerequisites": [
+      "the transfer engine",
+      "eigenvalues₀ as operator eigenvalues"
+    ]
+  },
+  {
+    "id": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02-ann-hyperplane-basis",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 137
+    },
+    "type": "lemma",
+    "title": "The coordinate hyperplane has an orthonormal basis",
+    "content": "The two conditions needed to build an orthonormal basis of the coordinate hyperplane. orthonormal_hyperplaneBasis shows the natural vectors e_{j.succAbove i} are orthonormal — they are a reindexing (along the injection Fin.succAbove j) of the standard orthonormal basis of the ambient EuclideanSpace, restricted to the hyperplane. span_hyperplaneBasis_top shows they span the whole hyperplane, pushing the span forward through the injective subtype inclusion. Together they are packaged into the OrthonormalBasis coordBasis in the next definition.",
+    "mathContext": "$\\{e_{j.\\mathrm{succAbove}(i)}\\}_{i:\\mathrm{Fin}\\,n}$ is orthonormal and spans the coordinate hyperplane $\\{x : x_j = 0\\}\\subseteq\\mathbb{C}^{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orthonormal basis",
+      "coordinate hyperplane",
+      "Fin.succAbove",
+      "subspace spanning"
+    ],
+    "prerequisites": [
+      "orthonormal bases",
+      "submodule span",
+      "EuclideanSpace"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass (passes: 0).

**annotations.json (5 → 6):**
- Added a `lemma` annotation covering lines 115–137 — the previously unannotated pair `orthonormal_hyperplaneBasis` and `span_hyperplaneBasis_top` that establish the natural vectors `e_{j.succAbove i}` are orthonormal and span the coordinate hyperplane, assembled into the `coordBasis` orthonormal basis.
- **Fixed a pre-existing stale anchor:** `ann-coord-equiv` `startLine` 138 (a blank line, resolving to no Lean construct) → 139 (the `coordBasis` docComment).

Canonical type/significance enums. `validateLineAnnotations`: 6 valid, 0 misaligned. No meta/status changes (verified, `mathlib` badge).