### PR TITLE
Enrich Chebyshev θ = Θ(x) transfer (chebyshev-bounds-oq-02-oq-01-oq-02): add annotations

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,243 @@
+[
+  {
+    "id": "ann-cb-oq020102-overview",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 30
+    },
+    "type": "concept",
+    "title": "Transferring the Growth Rate from ψ to θ",
+    "content": "The module docstring frames the task. The parent entry proves the *second* Chebyshev function is $\\Theta$-linear, $\\frac{\\log 2}{3}m \\le \\psi(m) \\le (\\log 4 + 4)m$. This file carries that growth rate to the *first* Chebyshev function $\\theta(x) = \\sum_{p \\le x} \\log p$. The transfer rests on exactly two Mathlib inputs: $\\theta(x) \\le \\psi(x)$ (since $\\theta$ sums only over primes while $\\psi$ sums over prime powers) and the gap estimate $|\\psi(x) - \\theta(x)| \\le 2\\sqrt{x}\\,\\log x$. The upper bound on $\\theta$ is then free; the lower bound is the genuinely new content and is obtained by subtracting the negligible $o(x)$ gap from the parent's $\\psi$ lower bound.",
+    "mathContext": "$\\theta(x) = \\psi(x) - \\bigl(\\psi(x) - \\theta(x)\\bigr) \\ge \\psi(x) - 2\\sqrt{x}\\,\\log x$, and since $2\\sqrt{x}\\,\\log x = o(x)$ the linear $\\psi$ bound survives in $\\theta$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Chebyshev function θ",
+      "Chebyshev function ψ",
+      "Prime Number Theorem",
+      "Θ asymptotics"
+    ],
+    "prerequisites": [
+      "analytic number theory",
+      "asymptotic notation"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-log-sqrt",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 37,
+      "endLine": 45
+    },
+    "type": "technique",
+    "title": "log x / √x → 0 via a Mathlib little-o Fact",
+    "content": "log_div_sqrt_tendsto_zero establishes the single analytic input behind the negligible gap: $\\log x / \\sqrt{x} \\to 0$. It is derived from Mathlib's isLittleO_log_rpow_atTop — $\\log x = o(x^r)$ for every $r > 0$ — specialized to $r = 1/2$, then converted to a limit of the quotient via tendsto_div_nhds_zero. The rewrite $\\sqrt{x} = x^{1/2}$ (Real.sqrt_eq_rpow) reconciles the square-root notation with the real-power form Mathlib's lemma is stated in. This is inlined here so the file's only build dependencies are Mathlib and the parent.",
+    "mathContext": "$\\displaystyle\\lim_{x\\to\\infty}\\frac{\\log x}{\\sqrt{x}} = 0$, i.e. $\\log x = o(x^{1/2})$; logarithms grow slower than any positive power.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "little-o notation",
+      "logarithmic growth",
+      "real powers (rpow)"
+    ],
+    "prerequisites": [
+      "limits and filters",
+      "Landau notation"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-upper",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 50
+    },
+    "type": "insight",
+    "title": "The Upper Bound is Free: θ ≤ ψ",
+    "content": "theta_le_linear gives $\\theta(x) \\le (\\log 4 + 4)x$ for $x \\ge 0$ in a single line. Because $\\theta$ counts $\\log p$ only over primes while $\\psi$ additionally counts the higher prime powers $p^k$, we always have $\\theta(x) \\le \\psi(x)$ (Chebyshev.theta_le_psi). Composing this with Mathlib's explicit ceiling $\\psi(x) \\le (\\log 4 + 4)x$ (psi_le_const_mul_self) yields the $\\theta$ upper bound with no extra work — the entire ceiling is inherited from $\\psi$.",
+    "mathContext": "$\\theta(x) \\le \\psi(x) \\le (\\log 4 + 4)\\,x$. The added prime-power terms $\\sum_{k\\ge 2}\\theta(x^{1/k})$ only make $\\psi$ larger than $\\theta$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev function θ",
+      "Chebyshev function ψ",
+      "prime powers",
+      "von Mangoldt function"
+    ],
+    "prerequisites": [
+      "prime counting",
+      "monotonicity of sums"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-floor-bridge",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 58
+    },
+    "type": "technique",
+    "title": "Floor Bridge: ψ(x) = chebyshevPsi ⌊x⌋₊",
+    "content": "psi_eq_chebyshevPsi_floor is the connective tissue between the parent's natural-number world and this file's real-variable world. Mathlib's real $\\psi(x)$ and the parent's chebyshevPsi are both the sum $\\sum_{n \\le \\lfloor x\\rfloor} \\Lambda(n)$ of the von Mangoldt function, so they agree once the real argument is replaced by its floor. The proof simply rewrites both sides to the shared Icc-sum form (psi_eq_sum_Icc) and cancels via Nat.floor_natCast. This identity lets the parent's discrete lower bound be quoted verbatim.",
+    "mathContext": "$\\psi(x) = \\sum_{n \\le \\lfloor x\\rfloor_+} \\Lambda(n) = \\mathrm{chebyshevPsi}(\\lfloor x\\rfloor_+)$, where $\\Lambda$ is the von Mangoldt function.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "floor function",
+      "von Mangoldt function",
+      "real vs. natural indexing"
+    ],
+    "prerequisites": [
+      "floor and ceiling",
+      "finite sums over intervals"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-psi-lower",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 75
+    },
+    "type": "key-step",
+    "title": "Real ψ Lower Bound: (log 2 / 6)·x ≤ ψ(x)",
+    "content": "psi_ge_linear lifts the parent's discrete bound $\\frac{\\log 2}{3}n \\le \\psi(n)$ to a statement about real $x \\ge 2$. Setting $n = \\lfloor x\\rfloor_+$, we have $n \\ge 2$ and, crucially, $n \\ge x - 1 \\ge x/2$ (from Nat.lt_floor_add_one). The floor loss is absorbed into the constant, halving it from $\\log 2/3$ to $\\log 2/6$. The calc block chains $\\frac{\\log 2}{6}x = \\frac{\\log 2}{3}\\cdot\\frac{x}{2} \\le \\frac{\\log 2}{3}n \\le \\mathrm{chebyshevPsi}(n) = \\psi(x)$, using $\\log 2 \\ge 0$ for the monotonicity step.",
+    "mathContext": "For $x \\ge 2$: $\\dfrac{\\log 2}{6}\\,x = \\dfrac{\\log 2}{3}\\cdot\\dfrac{x}{2} \\le \\dfrac{\\log 2}{3}\\,\\lfloor x\\rfloor_+ \\le \\psi(x)$, since $\\lfloor x\\rfloor_+ \\ge x - 1 \\ge x/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev function ψ",
+      "floor bounds",
+      "constant tracking"
+    ],
+    "prerequisites": [
+      "inequalities",
+      "floor function"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-gap-littleo",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 100
+    },
+    "type": "technique",
+    "title": "The ψ − θ Correction is o(x)",
+    "content": "two_sqrt_mul_log_isLittleO proves $2\\sqrt{x}\\,\\log x = o(x)$, the fact that makes the prime-power gap negligible. Unwinding isLittleO_iff to an $\\varepsilon$-$N$ statement, the goal $2\\sqrt{x}\\,\\log x \\le c\\,x$ is reduced by dividing through by $\\sqrt{x} > 0$: from $2\\log x/\\sqrt{x} \\le c$ (which holds eventually because $2\\log x/\\sqrt{x} \\to 0$ by the earlier limit) multiply back by $\\sqrt{x}$ and use $\\sqrt{x}\\cdot\\sqrt{x} = x$ (Real.mul_self_sqrt). So the whole $o(x)$ claim is just $\\log = o(\\sqrt{x})$ in disguise — no bespoke prime-power counting is needed.",
+    "mathContext": "$2\\sqrt{x}\\,\\log x = o(x) \\iff \\dfrac{2\\sqrt{x}\\,\\log x}{x} = \\dfrac{2\\log x}{\\sqrt{x}} \\to 0$, using $\\sqrt{x}\\cdot\\sqrt{x} = x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "little-o notation",
+      "Chebyshev functions ψ and θ",
+      "prime powers"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "limits and filters"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-gap-eventually",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "Bounding the Gap by (log 2 / 12)·x",
+    "content": "two_sqrt_mul_log_le_eventually turns the qualitative $o(x)$ statement into the quantitative bound eventually needed for the lower bound: since the gap is $o(x)$, for the specific positive constant $c = \\log 2/12$ we have $2\\sqrt{x}\\,\\log x \\le \\frac{\\log 2}{12}x$ for all large $x$. It applies isLittleO_iff at $c = \\log 2/12 > 0$ and strips the absolute value using $x \\ge 0$. This is exactly half of the parent's real $\\psi$-constant $\\log 2/6$, leaving the other half as the surviving $\\theta$ bound.",
+    "mathContext": "Eventually $2\\sqrt{x}\\,\\log x \\le \\dfrac{\\log 2}{12}\\,x$, chosen so that $\\dfrac{\\log 2}{6}x - \\dfrac{\\log 2}{12}x = \\dfrac{\\log 2}{12}x$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "little-o to explicit bound",
+      "constant selection"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "eventually filters"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-theta-lower",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 113,
+      "endLine": 121
+    },
+    "type": "key-step",
+    "title": "The New Content: (log 2 / 12)·x ≤ θ(x)",
+    "content": "theta_ge_eventually assembles the lower bound on $\\theta$, the result absent from both Mathlib and the $\\psi$-chain. On the region where all three inputs hold, write $\\theta(x) = \\psi(x) - (\\psi(x) - \\theta(x))$. The one-sided gap bound $\\psi(x) - \\theta(x) \\le |\\psi(x) - \\theta(x)| \\le 2\\sqrt{x}\\,\\log x$ (Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log) combined with the real $\\psi$ lower bound and the eventual gap bound gives $\\theta(x) \\ge \\frac{\\log 2}{6}x - \\frac{\\log 2}{12}x = \\frac{\\log 2}{12}x$, closed by linarith.",
+    "mathContext": "$\\theta(x) \\ge \\psi(x) - 2\\sqrt{x}\\,\\log x \\ge \\dfrac{\\log 2}{6}x - \\dfrac{\\log 2}{12}x = \\dfrac{\\log 2}{12}\\,x$ eventually.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev function θ",
+      "ψ − θ gap estimate",
+      "linear lower bound"
+    ],
+    "prerequisites": [
+      "inequalities",
+      "eventually filters"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-bigO-theta",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 130
+    },
+    "type": "technique",
+    "title": "θ = O(x)",
+    "content": "theta_isBigO_id repackages the upper bound theta_le_linear as an Asymptotics.IsBigO statement with explicit constant $\\log 4 + 4$. After isBigO_iff, the norms are removed using $x \\ge 0$ and $\\theta(x) \\ge 0$ (Chebyshev.theta_nonneg), leaving exactly the pointwise inequality theta_le_linear supplies.",
+    "mathContext": "$\\theta =_O[\\mathrm{atTop}] (x \\mapsto x)$ with witness constant $\\log 4 + 4$: $\\theta(x) \\le (\\log 4 + 4)|x|$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "big-O notation",
+      "nonnegativity of θ"
+    ],
+    "prerequisites": [
+      "asymptotic notation"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-bigO-id",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 132,
+      "endLine": 141
+    },
+    "type": "technique",
+    "title": "x = O(θ)",
+    "content": "id_isBigO_theta is the reverse domination, encoding the lower bound as an IsBigO with constant $12/\\log 2$. From the eventual bound $\\frac{\\log 2}{12}x \\le \\theta(x)$, dividing by $\\log 2 > 0$ gives $x \\le \\frac{12}{\\log 2}\\theta(x)$; nlinarith discharges the arithmetic after clearing the norms via nonnegativity. Together with the previous lemma this pins $\\theta$ between two positive multiples of the identity.",
+    "mathContext": "$(x \\mapsto x) =_O[\\mathrm{atTop}] \\theta$ with witness $12/\\log 2$: $x \\le \\dfrac{12}{\\log 2}\\,\\theta(x)$ eventually.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "big-O notation",
+      "two-sided domination"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "linear inequalities"
+    ]
+  },
+  {
+    "id": "ann-cb-oq020102-theta-theta",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 146
+    },
+    "type": "main-result",
+    "title": "Main Result: θ(x) = Θ(x)",
+    "content": "theta_isTheta_id is the headline: $\\theta =_\\Theta[\\mathrm{atTop}] (x \\mapsto x)$, the first Chebyshev function has the exact linear growth rate of the identity. It is the anonymous constructor pairing the two IsBigO bounds. By partial summation this is equivalent to $\\pi(x) = \\Theta(x/\\log x)$ — Chebyshev's 1852 approximation to the Prime Number Theorem — and $\\theta(x) \\sim x$ is the standard analytic form of PNT itself. This completes the gallery's Chebyshev thread from the $\\psi$ estimate through to $\\theta$.",
+    "mathContext": "$\\theta(x) = \\Theta(x)$: $\\exists\\, c_1, c_2 > 0$ with $c_1 x \\le \\theta(x) \\le c_2 x$ eventually; here $c_1 = \\log 2/12$, $c_2 = \\log 4 + 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Θ asymptotics",
+      "Prime Number Theorem",
+      "prime counting function π",
+      "partial summation"
+    ],
+    "prerequisites": [
+      "asymptotic notation",
+      "prime counting"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-02-oq-01-oq-02` (Transferring Chebyshev's Bounds from ψ to θ).

**Gap addressed:** the entry had a rich `meta.json` (16 KB overview/sections/conclusion) but **no `annotations.json`** — quality score 45 with 0 annotation coverage.

**Change:** added a full 11-annotation `annotations.json` covering the entire 148-line proof. Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

Coverage:
- Module docstring — the ψ→θ transfer strategy (θ = ψ − (ψ−θ), gap is o(x))
- `log_div_sqrt_tendsto_zero` — log x/√x → 0 via `isLittleO_log_rpow_atTop`
- `theta_le_linear` — the free upper bound from θ ≤ ψ
- `psi_eq_chebyshevPsi_floor` — the floor bridge to the parent's ℕ-indexed ψ
- `psi_ge_linear` — real ψ lower bound (log 2/6)·x
- `two_sqrt_mul_log_isLittleO` / `_le_eventually` — the o(x) gap
- `theta_ge_eventually` — the new θ lower bound (log 2/12)·x
- `theta_isBigO_id` / `id_isBigO_theta` / `theta_isTheta_id` — Θ(x) packaging

Anchoring validated: `resolver.ts validate` reports 11 valid / 0 misaligned. No `meta.json` change; no size-cap concerns.