### PR TITLE
research(schroeder-bernstein-oq-03): computable matching-lookup evaluator (mLookup) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -680,6 +680,88 @@ theorem firstMissing_lt_cons_self (L : List ℕ) :
   omega
 
 /-!
+## Section 4f: Reading the permutation off a matching — the computable evaluator
+
+The scheduler assembles a chain of finite matchings `L₀ ⊆ L₁ ⊆ …`; the permutation
+`σ` is then read off by *looking up* the partner of `n` in the matching at the stage
+`n` enters the domain (obligation (d) of `myhill_isomorphism`). This section supplies
+that evaluator as a **total, computable** function of the matching and the argument,
+together with its correctness: on a matching it recovers the recorded partner exactly.
+
+`mLookup L n` reads the entry of `mRan L` at the position of `n` in `mDom L`
+(`List.idxOf`). Because `mDom L` and `mRan L` are the two coordinate projections of the
+same list, they are index-aligned, so this returns the second coordinate of the pair
+whose first coordinate is `n`. Off the domain (`n ∉ mDom L`) the index is out of range
+and the placeholder `0` is returned — harmless, since the read-off only queries
+`n ∈ mDom`. The two `Nodup` conditions of `IsMatching` are exactly what make the lookup
+single-valued (`matching_functional`), so `mLookup` is the computable realization of the
+finite partial bijection a matching represents.
+-/
+
+/-- **Partner lookup in a matching.** The value the finite partial map `L` associates to
+    `n`: the entry of the range list `mRan L` at the index of `n` in the domain list
+    `mDom L`. A total function; off the domain it returns the placeholder `0`. -/
+def mLookup (L : List (ℕ × ℕ)) (n : ℕ) : ℕ :=
+  (mRan L).getD (List.idxOf n (mDom L)) 0
+
+/-- **Correctness of `mLookup`.** On a matching, the lookup recovers the recorded
+    partner: if `(n, b) ∈ L` then `mLookup L n = b`. The domain-side `Nodup` (via
+    `IsMatching`) guarantees `n` occurs once in `mDom L`, so its index selects exactly
+    the aligned range entry `b`. This makes `mLookup` the evaluation of the finite
+    partial bijection a matching encodes — the read-off used to define `σ`. -/
+theorem mLookup_eq_of_mem :
+    ∀ {L : List (ℕ × ℕ)}, IsMatching L → ∀ {n b : ℕ}, (n, b) ∈ L → mLookup L n = b := by
+  intro L
+  induction L with
+  | nil => intro _ n b h; simp at h
+  | cons hd tl ih =>
+    obtain ⟨a, c⟩ := hd
+    intro hL n b h
+    have hnodupD : (a :: mDom tl).Nodup := by simpa using hL.1
+    have hnodupR : (c :: mRan tl).Nodup := by simpa using hL.2
+    have ha_notin : a ∉ mDom tl := (List.nodup_cons.mp hnodupD).1
+    have hMtl : IsMatching tl :=
+      ⟨(List.nodup_cons.mp hnodupD).2, (List.nodup_cons.mp hnodupR).2⟩
+    rw [List.mem_cons] at h
+    rcases h with h | h
+    · -- the pair is the head: `(n, b) = (a, c)`
+      have hn : n = a := congrArg Prod.fst h
+      have hb : b = c := congrArg Prod.snd h
+      subst hn; subst hb
+      simp only [mLookup, mDom_cons, mRan_cons, List.idxOf_cons_self, List.getD_cons_zero]
+    · -- the pair is in the tail: recurse, the head index is skipped
+      have hn_mem : n ∈ mDom tl := by
+        simp only [mDom, List.mem_map]; exact ⟨(n, b), h, rfl⟩
+      have hne : a ≠ n := fun heq => ha_notin (heq ▸ hn_mem)
+      simp only [mLookup, mDom_cons, mRan_cons, List.idxOf_cons_ne _ hne,
+        List.getD_cons_succ]
+      exact ih hMtl h
+
+/-- **`mLookup` is computable** (indeed primitive recursive) in both the matching and the
+    argument. The domain/range projections `mDom`, `mRan` are list maps of the coordinate
+    projections; `List.idxOf` and `List.getD` are primitive recursive (`Primrec.list_idxOf`,
+    `Primrec.list_getD`). Combined with `mLookup_eq_of_mem`, this is the computability
+    guarantee behind reading a *computable* permutation off the stage-wise matchings:
+    once the (computable) sequence of matchings is built, `σ n` is a computable lookup. -/
+theorem mLookup_computable : Computable₂ mLookup := by
+  have hmDom : Computable (fun L : List (ℕ × ℕ) => mDom L) := by
+    have h : Primrec (fun L : List (ℕ × ℕ) => L.map Prod.fst) :=
+      Primrec.list_map Primrec.id (Primrec.fst.comp Primrec.snd)
+    exact h.to_comp
+  have hmRan : Computable (fun L : List (ℕ × ℕ) => mRan L) := by
+    have h : Primrec (fun L : List (ℕ × ℕ) => L.map Prod.snd) :=
+      Primrec.list_map Primrec.id (Primrec.snd.comp Primrec.snd)
+    exact h.to_comp
+  have hIdx : Computable (fun p : List (ℕ × ℕ) × ℕ => List.idxOf p.2 (mDom p.1)) :=
+    Primrec.list_idxOf.to_comp.comp Computable.snd (hmDom.comp Computable.fst)
+  have hRanP : Computable (fun p : List (ℕ × ℕ) × ℕ => mRan p.1) :=
+    hmRan.comp Computable.fst
+  have hget : Computable (fun p : List (ℕ × ℕ) × ℕ =>
+      (mRan p.1).getD (List.idxOf p.2 (mDom p.1)) 0) :=
+    (Primrec.list_getD (0 : ℕ)).to_comp.comp hRanP hIdx
+  exact hget.of_eq (fun _ => rfl)
+
+/-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/
 


### PR DESCRIPTION
## Summary

Adds **Section 4f** to `Proofs/SchroederBernsteinOQ03.lean` (Myhill Isomorphism Theorem): the **read-off evaluator** that turns the stage-wise finite matchings into the permutation $\sigma$, together with its computability. This is **obligation (d)** of the open `myhill_isomorphism` hard direction ("$\sigma(n)$ is determined by the finite stage at which $n$ enters the domain").

### New declarations (all VERIFIED, 0-axiom)
- `mLookup L n := (mRan L).getD (List.idxOf n (mDom L)) 0` — total partner lookup: reads the range entry at the position of `n` in the domain list (the two coordinate projections are index-aligned).
- `mLookup_eq_of_mem` — **correctness**: on a matching, `(n, b) ∈ L → mLookup L n = b`. The domain-side `Nodup` of `IsMatching` makes the lookup single-valued, so `mLookup` evaluates the finite partial bijection a matching encodes.
- `mLookup_computable` — `Computable₂ mLookup`, via primitive-recursive list operations (`Primrec.list_map`, `Primrec.list_idxOf`, `Primrec.list_getD`). This is the computability guarantee behind reading a *computable* permutation off the (computable) sequence of matchings.

### Status
- `#print axioms`-clean by construction: `propext` / `Classical.choice` / `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`.
- The main `myhill_isomorphism` hard-direction `sorry` is **UNCHANGED** (still the collision-chasing priority scheduler / $\Pi_1$ `isGFree` obstruction). This PR supplies the read-off primitive that scheduler will use, not the scheduler itself.

### Verification
Compiled the self-contained proof against pinned Mathlib **v4.26** oleans. The full-file host build hit memory/disk contention (SIGSEGV under load); the proof was verified by a minimal-import-closure recompile of the identical declarations (`exit 0`, 0 errors, 0 sorries) — same API, same defs (`mDom`/`mRan`/`IsMatching` are already in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)