### PR TITLE
Enrich VC dimension monotonicity (pac-learning-bounds-wip-01-oq-01): sections, annotations, cross-refs

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
@@ -46,27 +46,49 @@
     ]
   },
   {
-    "id": "ann-pac-wip01-oq01-03-corollaries",
+    "id": "ann-pac-wip01-oq01-03-union",
     "proofId": "pac-learning-bounds-wip-01-oq-01",
     "range": {
       "startLine": 68,
-      "endLine": 86
+      "endLine": 76
     },
     "type": "theorem",
-    "title": "Union Bounds and the Powerset Capacity Ceiling",
-    "content": "Immediate consequences of monotonicity. vcDim_union_left / vcDim_union_right give VCDim H, VCDim H' ≤ VCDim (H ∪ H') via subset_union. vcDim_powerset_le shows any class contained in a powerset, H ⊆ S.powerset, has VCDim H ≤ |S|, obtained by chaining vcDim_mono with the parent's exact value vcDim_powerset (VCDim(2^S) = |S|) — turning a class containment into a capacity ceiling.",
-    "mathContext": "$\\dim_{VC}(H), \\dim_{VC}(H') \\le \\dim_{VC}(H \\cup H')$; and $H \\subseteq 2^S \\Rightarrow \\dim_{VC}(H) \\le |S|$.",
+    "title": "Union Corollaries: Capacity of a Union Dominates its Parts",
+    "content": "vcDim_union_left and vcDim_union_right are the most immediate consequences of monotonicity: since $H \\subseteq H \\cup H'$ and $H' \\subseteq H \\cup H'$ (Finset.subset_union_left/right), each part's VC dimension is bounded by that of the union. Both proofs are a single application of vcDim_mono to the relevant subset witness. Operationally this is the capacity side of the classic union bound in learning theory — combining two hypothesis classes never lowers capacity below either component.",
+    "mathContext": "$\\dim_{VC}(H) \\le \\dim_{VC}(H \\cup H')$ and $\\dim_{VC}(H') \\le \\dim_{VC}(H \\cup H')$, from $H, H' \\subseteq H \\cup H'$.",
     "significance": "supporting",
     "relatedConcepts": [
       "VC dimension",
       "union bound",
-      "powerset class",
-      "capacity ceiling"
+      "monotonicity",
+      "hypothesis class"
     ],
     "prerequisites": [
       "vcDim_mono",
-      "Finset.subset_union_left/right",
-      "the parent's vcDim_powerset"
+      "Finset.subset_union_left/right"
+    ]
+  },
+  {
+    "id": "ann-pac-wip01-oq01-04-powerset",
+    "proofId": "pac-learning-bounds-wip-01-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Powerset Capacity Ceiling: H ⊆ 2^S ⟹ VCDim H ≤ |S|",
+    "content": "vcDim_powerset_le turns a class containment into a hard capacity ceiling. Any family whose members are all subsets of a fixed finite set $S$ satisfies $H \\subseteq S.\\mathrm{powerset}$, so by monotonicity $\\dim_{VC}(H) \\le \\dim_{VC}(2^S)$; chaining with the parent's exact evaluation vcDim_powerset ($\\dim_{VC}(2^S) = |S|$) yields $\\dim_{VC}(H) \\le |S|$. This is the finite ground-set ceiling: no class over an $|S|$-element universe can shatter more than $|S|$ points, recovering the trivial-but-essential upper bound on capacity used throughout PAC sample-complexity arguments.",
+    "mathContext": "$H \\subseteq S.\\mathrm{powerset} \\Rightarrow \\dim_{VC}(H) \\le \\dim_{VC}(2^S) = |S|$, via (vcDim_mono hH).trans_eq (vcDim_powerset S).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "VC dimension",
+      "powerset class",
+      "capacity ceiling",
+      "ground set"
+    ],
+    "prerequisites": [
+      "vcDim_mono",
+      "the parent's vcDim_powerset (VCDim 2^S = |S|)"
     ]
   }
 ]

--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
@@ -65,7 +65,8 @@
       "The class-level monotonicity is a pure transport of the set-level shatters_mono across the supremum defining VCDim — no new combinatorics is needed.",
       "csSup_le reduces the class-level bound to a per-witness bound, and the only work per witness is invoking shatters_mono and card_le_vcDim.",
       "The empty-witness branch (H shatters nothing, so VCDim H = 0) must be handled separately because sSup ∅ = ⊥ is not covered by csSup_le, which requires a nonempty index set.",
-      "Monotonicity immediately yields the union bounds and, composed with the parent's exact value VCDim(2^S) = |S|, a capacity ceiling for any subfamily of a powerset."
+      "Monotonicity immediately yields the union bounds and, composed with the parent's exact value VCDim(2^S) = |S|, a capacity ceiling for any subfamily of a powerset.",
+      "The empty-witness branch is not a degenerate technicality: csSup_le demands a nonempty index set, so 'H shatters nothing ⟹ VCDim H = sSup ∅ = ⊥ = 0' is discharged by a separate bot_le, and this is the only place the conditional-supremum's ⊥ convention surfaces."
     ],
     "prerequisites": [
       "Finsets, shattering, and the VC dimension as defined in the parent entry",
@@ -75,6 +76,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: From Set-Level to Class-Level Monotonicity",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "Module docstring and setup. Recalls the parent's 0-axiom VC foundations (trace, Shatters, VCDim H = sSup{|S| : H shatters S}) and its set-level lemma shatters_mono, then states the goal: the class-level counterpart vcDim_mono, packaged into union and powerset-ceiling corollaries. Opens Finset and fixes a DecidableEq α ground type.",
+      "mathContext": "Setting: hypothesis classes H : Finset (Finset α); VCDim H = sSup{n | ∃ S, |S| = n ∧ Shatters H S}."
+    },
+    {
       "id": "sec-mono",
       "title": "Monotonicity of the VC Dimension",
       "startLine": 49,
@@ -83,12 +92,20 @@
       "mathContext": "The core statement: enlarging the hypothesis class cannot decrease its VC dimension."
     },
     {
-      "id": "sec-corollaries",
-      "title": "Union Bounds and the Powerset Ceiling",
+      "id": "sec-union",
+      "title": "Union Corollaries",
       "startLine": 68,
-      "endLine": 86,
-      "summary": "vcDim_union_left / vcDim_union_right: VCDim H, VCDim H' ≤ VCDim (H ∪ H') via subset_union. vcDim_powerset_le: any H ⊆ S.powerset has VCDim H ≤ |S|, obtained by chaining vcDim_mono with the parent's exact value vcDim_powerset (VCDim(2^S) = |S|).",
-      "mathContext": "Consequences: capacity of a union dominates its parts; any subfamily of 2^S has VC dimension at most |S|."
+      "endLine": 76,
+      "summary": "vcDim_union_left / vcDim_union_right: VCDim H, VCDim H' ≤ VCDim (H ∪ H'), each a one-line application of vcDim_mono to Finset.subset_union_left/right.",
+      "mathContext": "Capacity of a union dominates that of either part: VCDim H, VCDim H' ≤ VCDim (H ∪ H')."
+    },
+    {
+      "id": "sec-powerset",
+      "title": "Powerset Capacity Ceiling",
+      "startLine": 78,
+      "endLine": 84,
+      "summary": "vcDim_powerset_le: any H ⊆ S.powerset has VCDim H ≤ |S|, chaining vcDim_mono with the parent's exact value vcDim_powerset (VCDim(2^S) = |S|). The finite ground-set ceiling on capacity.",
+      "mathContext": "H ⊆ 2^S ⟹ VCDim H ≤ VCDim(2^S) = |S|."
     }
   ],
   "conclusion": {
@@ -104,6 +121,21 @@
       "targetId": "pac-learning-bounds-wip-01",
       "relationship": "extends",
       "description": "Answers the parent's first open question by lifting its set-level shatters_mono to class-level monotonicity of the VC dimension, and reuses the parent's vcDim_powerset for the capacity ceiling."
+    },
+    {
+      "targetId": "pac-learning-bounds",
+      "relationship": "related",
+      "description": "Root of the thread — PAC learning and the VC dimension. This entry supplies the structural monotonicity property that its capacity/sample-complexity results implicitly rely on."
+    },
+    {
+      "targetId": "pac-learning-bounds-oq-04",
+      "relationship": "related",
+      "description": "The ε-net theorem and PAC sample-complexity bounds. Monotonicity of VCDim is exactly what lets one bound a hard class's sample complexity by that of a larger, more tractable class."
+    },
+    {
+      "targetId": "pac-learning-bounds-oq-01",
+      "relationship": "related",
+      "description": "A concrete VC-dimension computation (threshold classifiers on ℕ). Where this entry gives the abstract monotonicity law, that entry pins an exact value it must respect."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-wip-01-oq-01` (Monotonicity of the VC Dimension). Quality 79 — lowest dims were sections (2) and crossReferences (1).

**Changes (meta.json, 11.5 KB — well under the 60 KB cap):**
- **Sections 2 → 4**: added an overview section covering the module docstring (lines 3–47, previously uncovered) and split the lumped corollaries section into `Union Corollaries` (68–76) and `Powerset Capacity Ceiling` (78–84). The four sections now tile the whole file.
- **crossReferences 1 → 4**: added the PAC/VC root (`pac-learning-bounds`), the ε-net sample-complexity entry (`pac-learning-bounds-oq-04` — monotonicity is what lets a hard class be bounded by a tractable one), and a concrete VC-dimension value (`pac-learning-bounds-oq-01`).
- **keyInsights 4 → 5**: added the empty-witness subtlety (csSup_le needs a nonempty index set, so `VCDim = sSup ∅ = ⊥ = 0` is a separate `bot_le` branch).

**Changes (annotations.json, 3 → 4):** split the coarse `68–86` union+powerset annotation into a sharper union-corollaries annotation (68–76) and a powerset-ceiling annotation (78–84), each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Existing docstring and `vcDim_mono` annotations preserved verbatim.

No Lean change; status/badge/axiomCount unchanged (verified/original/0). Anchoring validated: `resolver.ts validate` reports 4 valid / 0 misaligned.