### PR TITLE
Enrich Ladyzhenskaya/Navier-Stokes (navier-stokes-oq-01-oq-01): add references

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
@@ -109,5 +109,35 @@
   },
   "crossReferences": [
     "navier-stokes-oq-01"
+  ],
+  "references": [
+    {
+      "authors": "Ladyzhenskaya, Olga A.",
+      "title": "The Mathematical Theory of Viscous Incompressible Flow (2nd ed.)",
+      "year": "1969",
+      "venue": "Gordon and Breach, New York",
+      "note": "Source of the 2D interpolation inequality ‖u‖_{L⁴}² ≤ C‖u‖_{L²}‖∇u‖_{L²} and its use in 2D Navier–Stokes global regularity"
+    },
+    {
+      "authors": "Nirenberg, Louis",
+      "title": "On elliptic partial differential equations",
+      "year": "1959",
+      "venue": "Ann. Scuola Norm. Sup. Pisa 13, 115–162",
+      "note": "The Gagliardo–Nirenberg interpolation inequalities, of which Ladyzhenskaya's L⁴ estimate is the 2D endpoint case"
+    },
+    {
+      "authors": "Constantin, Peter; Foias, Ciprian",
+      "title": "Navier–Stokes Equations",
+      "year": "1988",
+      "venue": "University of Chicago Press, Chicago Lectures in Mathematics",
+      "note": "Modern treatment of 2D global regularity via the enstrophy estimate that the Ladyzhenskaya inequality closes"
+    },
+    {
+      "authors": "Fefferman, Charles L.",
+      "title": "Existence and smoothness of the Navier–Stokes equation",
+      "year": "2006",
+      "venue": "The Millennium Prize Problems, Clay Mathematics Institute, 57–67",
+      "note": "Official statement of the Clay Millennium problem; 3D regularity is open while the 2D case (this inequality) is classical"
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `navier-stokes-oq-01-oq-01` (Verified Algebraic Assembly of Ladyzhenskaya's 2D Interpolation Inequality). The entry was missing a `references` list.

**Added references (was absent; no other field changed, no Lean change):**
- Ladyzhenskaya 1969, *The Mathematical Theory of Viscous Incompressible Flow* — origin of the L⁴ interpolation inequality and its role in 2D global regularity.
- Nirenberg 1959 — the Gagliardo–Nirenberg interpolation inequalities, of which this L⁴ estimate is the 2D endpoint.
- Constantin–Foias 1988, *Navier–Stokes Equations* — the enstrophy estimate the inequality closes.
- Fefferman 2006 (Clay Millennium Problems) — the official problem statement; 3D open, 2D classical.

status/badge/axiomCount unchanged.