### PR TITLE
research(sperner-mathlib4-oq-02): antipodal sign-degree is odd in every dimension — the n=1 telescoping engine over any alphabet [VERIFIED, 0-axiom, new entry oq-02-oq-05]

### DIFF
--- a/proofs/Proofs/SpernerTuckerSignDegreeOneDim.lean
+++ b/proofs/Proofs/SpernerTuckerSignDegreeOneDim.lean
@@ -1,0 +1,175 @@
+/-
+# The antipodal sign-degree is odd in every dimension (the n = 1 telescoping engine,
+# applied to a sign-reduced boundary arc over any label alphabet)
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's lemma and Borsuk–Ulam
+from abstract door-counting").
+
+## Where this sits — generalizing oq-04 from n = 2 / `decide` to all dimensions
+
+Iteration 15 (`SpernerTuckerHexagonSignDegree`, gallery child `oq-02-oq-04`) identified
+the odd oriented boundary seed the n ≥ 2 program needs: on the hexagon + centre
+triangulation of `B²` it pushed the labelling through an antipodal **sign map**
+`sgn : Fin 4 → ZMod 2` and proved the hemisphere-arc **sign-degree** (number of edges
+across which the sign bit flips) is **odd** — but only for `n = 2`, `α = Fin 4`, and only
+by kernel `decide` over all `4³ = 64` boundary labellings.  Its docstring claimed the
+oddness holds "by the telescoping (discrete FTC) argument of n = 1 Tucker … realised on
+the boundary of real n = 2 geometry", but never actually ran that argument: it re-decided
+the count.
+
+The already-verified `TuckerOneDim.tucker_one_dim` runs the telescoping over a `ZMod 2`
+path of any length with antipodal endpoints.  What was missing is the **sign-reduction
+map** turning a labelling over a rich Tucker alphabet `{±1, …, ±n}` (any dimension, any
+alphabet) into that telescoping engine.  This file supplies it — the same discrete-FTC
+telescoping, now stated once, dimension-free and alphabet-free, and applied through `sgn`.
+
+## What this file proves (0 sorries, 0 axioms; `decide` only on the finite alphabet's
+antipodal property `sgn_negL`, never on the count)
+
+* `changes_cast` / `odd_changes_iff` — the **discrete intermediate-value theorem mod 2**:
+  along any `ZMod 2` path `f : ℕ → ZMod 2`, the number of sign-change edges over
+  `range N`, cast to `ZMod 2`, is `f N - f 0`; hence it is **odd iff the endpoints
+  differ**.  The telescoping engine, stated abstractly over `ℕ`-indexed paths.
+* `antipodal_signDegree_odd` — **dimension-free, alphabet-free.**  For ANY label type `α`
+  with an antipodal map `neg` and an antipodal sign map `sgn : α → ZMod 2`
+  (`sgn (neg x) = sgn x + 1`), and ANY vertex path `μ : ℕ → α` with antipodal endpoints
+  (`μ N = neg (μ 0)`), the **sign-degree is odd** — because `sgn` sends antipodal labels
+  to distinct `ZMod 2` values, so the reduced path `sgn ∘ μ` has distinct endpoints.  No
+  dimension bound, no `decide` over the alphabet or the count.  This is the general odd
+  boundary seed; oq-04's hexagon result is the `N = 3`, `α = Fin 4` instance.
+* `loop_signDegree_even` — the companion: a **closed** antipodal loop
+  (`sgn (μ N) = sgn (μ 0)`) has **even** sign-degree in every dimension — the abstract form
+  of oq-04's `full_sign_changes_even` ("read the degree off half the loop").
+* `HexagonInstance.hexagon_arc_signDegree_odd` — oq-04's hexagon hemisphere-arc oddness,
+  re-derived as a **corollary of the telescoping engine** rather than by `decide` over the
+  count.  Only the alphabet's antipodal property `sgn_negL` and the boundary condition
+  `arc_bdry` are decided (finite facts about `Fin 4`); the oddness itself now flows from
+  the dimension-free `antipodal_signDegree_odd`.  Realizes in Lean the n = 2 → n = 1
+  connection oq-04 asserted in prose.
+
+## Honest status
+
+A **unification / scoping result**, not a proof of n ≥ 2 Tucker.  It shows the odd oriented
+boundary seed is dimension-free and factors through the n = 1 telescoping engine for every
+label alphabet — removing oq-04's dimension restriction and its brute-force `decide` on the
+count.  The genuine open lever remains the 2-D almost-complementary path-following that
+turns this odd **boundary sign-degree** into an **interior complementary simplex**.
+
+Self-contained (narrow imports; the telescoping is the same `Finset.sum_range_sub` /
+`ZMod 2` mod-reduction the n = 1 file uses).  0 sorries, 0 axioms
+(`propext` / `Classical.choice` / `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`).
+-/
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Ring.Parity
+
+open Finset
+
+namespace SpernerTuckerSignDegreeOneDim
+
+variable {α : Type*}
+
+/-! ## The discrete intermediate-value theorem mod 2 (the telescoping engine) -/
+
+/-- The complementarity indicator in `ZMod 2`: the difference of two labels is `1` when
+they differ and `0` when they agree. -/
+private lemma edge : ∀ a b : ZMod 2, (if a ≠ b then (1 : ZMod 2) else 0) = a - b := by decide
+
+/-- In `ZMod 2`, `x + 1 ≠ x`. -/
+private lemma add_one_ne : ∀ x : ZMod 2, x + 1 ≠ x := by decide
+
+/-- **Sign-change count** of a `ZMod 2` path `f` over its first `N` edges. -/
+def changes (f : ℕ → ZMod 2) (N : ℕ) : ℕ := (Finset.range N).filter (fun i => f (i + 1) ≠ f i) |>.card
+
+/-- **Telescoping identity (discrete FTC mod 2).**  The number of sign-change edges of a
+`ZMod 2` path, cast into `ZMod 2`, equals the net endpoint difference `f N - f 0`.  Proved
+by turning the filter cardinality into a `ZMod 2` sum of indicators and telescoping. -/
+theorem changes_cast (f : ℕ → ZMod 2) (N : ℕ) :
+    (changes f N : ZMod 2) = f N - f 0 := by
+  unfold changes
+  rw [← Finset.sum_boole, ← Finset.sum_range_sub f N]
+  apply Finset.sum_congr rfl
+  intro i _
+  exact edge (f (i + 1)) (f i)
+
+/-- **Discrete intermediate-value theorem mod 2.**  The sign-change count over `range N`
+is **odd iff the endpoints differ** (`f N ≠ f 0`). -/
+theorem odd_changes_iff (f : ℕ → ZMod 2) (N : ℕ) :
+    Odd (changes f N) ↔ f N ≠ f 0 := by
+  rw [← Nat.not_even_iff_odd, ← ZMod.natCast_eq_zero_iff_even, changes_cast, sub_eq_zero]
+
+/-! ## The antipodal sign-degree, dimension-free and alphabet-free -/
+
+/-- **Sign-degree** of a vertex path `μ : ℕ → α` under a sign map `sgn`: the number of
+edges (over the first `N`) across which the sign bit flips. -/
+def signDegree (sgn : α → ZMod 2) (μ : ℕ → α) (N : ℕ) : ℕ := changes (fun i => sgn (μ i)) N
+
+/-- **Dimension-free antipodal sign-degree (odd).**  Let `neg` be an antipodal map on a
+label alphabet `α` and `sgn : α → ZMod 2` an antipodal sign map
+(`sgn (neg x) = sgn x + 1`).  For any vertex path `μ` whose endpoints are antipodal
+(`μ N = neg (μ 0)`), the sign-degree is **odd**.  The reduced labelling `sgn ∘ μ` has
+distinct endpoints (`sgn (μ 0) + 1 ≠ sgn (μ 0)`), so `odd_changes_iff` fires.  No dimension
+bound, no `decide` over the alphabet. -/
+theorem antipodal_signDegree_odd
+    (neg : α → α) (sgn : α → ZMod 2) (hsgn : ∀ x, sgn (neg x) = sgn x + 1)
+    (μ : ℕ → α) (N : ℕ) (hbdry : μ N = neg (μ 0)) :
+    Odd (signDegree sgn μ N) := by
+  unfold signDegree
+  rw [odd_changes_iff]
+  show sgn (μ N) ≠ sgn (μ 0)
+  rw [hbdry, hsgn]
+  exact add_one_ne (sgn (μ 0))
+
+/-- **Dimension-free antipodal sign-degree (even, closed loop).**  If the sign path is
+**closed** (`sgn (μ N) = sgn (μ 0)`) then the sign-degree is **even**.  The odd seed lives
+on the antipodal fundamental domain (a hemisphere arc), not on the whole boundary loop. -/
+theorem loop_signDegree_even
+    (sgn : α → ZMod 2) (μ : ℕ → α) (N : ℕ) (hloop : sgn (μ N) = sgn (μ 0)) :
+    Even (signDegree sgn μ N) := by
+  unfold signDegree
+  rw [← ZMod.natCast_eq_zero_iff_even, changes_cast]
+  show sgn (μ N) - sgn (μ 0) = 0
+  rw [hloop, sub_self]
+
+/-! ## Concrete instance: oq-04's hexagon hemisphere arc, from the engine (not `decide`) -/
+
+namespace HexagonInstance
+
+/-- Label negation on `{+1,+2,-1,-2}` encoded as `Fin 4` (same as
+`SpernerTuckerHexagonSignDegree.negL`). -/
+def negL : Fin 4 → Fin 4 := ![2, 3, 0, 1]
+
+/-- Sign map collapsing magnitude, `{+1,+2} ↦ 0`, `{-1,-2} ↦ 1` (same as
+`SpernerTuckerHexagonSignDegree.sgn`). -/
+def sgn : Fin 4 → ZMod 2 := ![0, 0, 1, 1]
+
+/-- The sign map is antipodal (label negation flips the sign bit).  This finite fact about
+the `Fin 4` alphabet is the sole `decide`; it discharges the hypothesis `hsgn`. -/
+theorem sgn_negL : ∀ x : Fin 4, sgn (negL x) = sgn x + 1 := by decide
+
+/-- The four vertices `v₀, v₁, v₂, v₃ = -v₀` of the antipodal fundamental-domain arc
+(a hemisphere of the hexagon boundary), from three free boundary labels `a, b, c`. -/
+def arc (a b c : Fin 4) : ℕ → Fin 4 := fun i => [a, b, c, negL a].getD i a
+
+/-- The arc has antipodal endpoints: `v₃ = -v₀`.  A finite fact about `Fin 4`. -/
+theorem arc_bdry : ∀ a b c : Fin 4, arc a b c 3 = negL (arc a b c 0) := by decide
+
+/-- **oq-04's hexagon hemisphere-arc sign-degree is ODD — now from the telescoping engine.**
+`SpernerTuckerHexagonSignDegree.arc_sign_changes_odd` established this by `decide` over all
+64 labellings; here the oddness is a corollary of the dimension-free
+`antipodal_signDegree_odd`, with only the alphabet's antipodal property (`sgn_negL`) and the
+boundary condition (`arc_bdry`) decided.  Realizes in Lean the "= n = 1 Tucker count of the
+sign-reduced labelling" connection oq-04 asserted in prose. -/
+theorem hexagon_arc_signDegree_odd (a b c : Fin 4) :
+    Odd (signDegree sgn (arc a b c) 3) :=
+  antipodal_signDegree_odd negL sgn sgn_negL (arc a b c) 3 (arc_bdry a b c)
+
+end HexagonInstance
+
+#print axioms antipodal_signDegree_odd
+#print axioms loop_signDegree_even
+#print axioms HexagonInstance.hexagon_arc_signDegree_odd
+
+end SpernerTuckerSignDegreeOneDim

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -4,7 +4,47 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-27T16:10:00-07:00
-**Iteration**: 14
+**Iteration**: 16
+
+## Iteration 16 addition (researcher-7, verified 0-axiom — host `lean v4.26.0`, `#print axioms` clean; PR #33477)
+Added `proofs/Proofs/SpernerTuckerSignDegreeOneDim.lean` (175 LOC, 7 thm / 5 def,
+0 sorries, 0 axioms; `#print axioms` = propext/Classical.choice/Quot.sound only — no
+sorryAx, no `Lean.ofReduceBool`). New gallery child `sperner-mathlib4-oq-02-oq-05`.
+
+**Generalizes iteration 15 (oq-04) from n=2/`decide` to dimension-free/from-the-engine.**
+Iteration 15 (`SpernerTuckerHexagonSignDegree`) identified the odd oriented boundary seed
+as the hemisphere **sign-degree** but proved it only for the hexagon (`α = Fin 4`, n = 2)
+by kernel `decide` over all 4³ = 64 labellings — asserting, but never running, the "= n = 1
+Tucker count of the sign-reduced labelling" connection. This session supplies the missing
+**sign-reduction map** and states the telescoping engine once, dimension-free and
+alphabet-free:
+- `changes_cast` / `odd_changes_iff` — the **discrete intermediate-value theorem mod 2**:
+  along any `f : ℕ → ZMod 2`, `(#sign-changes over range N : ZMod 2) = f N - f 0`, so the
+  count is **odd iff the endpoints differ**. The same `Finset.sum_range_sub` telescoping the
+  n=1 file (`SpernerTuckerOneDim.complementary_count_cast`) uses, now over ℕ-indexed paths.
+- `antipodal_signDegree_odd` — **dimension-free, alphabet-free**: for ANY label type `α`
+  with an antipodal map `neg` and antipodal sign map `sgn : α → ZMod 2`
+  (`sgn (neg x) = sgn x + 1`), and ANY path `μ : ℕ → α` with antipodal endpoints
+  (`μ N = neg (μ 0)`), the sign-degree is **odd** — `sgn ∘ μ` inherits distinct endpoints
+  (`sgn(μ 0)+1 ≠ sgn(μ 0)`), firing `odd_changes_iff`. No dimension bound, no `decide` on
+  the alphabet or the count.
+- `loop_signDegree_even` — closed antipodal loop ⟹ **even** sign-degree, every dimension
+  (the abstract form of oq-04's `full_sign_changes_even`; seed lives on the fundamental
+  domain).
+- `HexagonInstance.hexagon_arc_signDegree_odd` — oq-04's `arc_sign_changes_odd` **recovered
+  as a one-line corollary** of `antipodal_signDegree_odd`, deciding only the finite Fin-4
+  facts `sgn_negL` and `arc_bdry` (not the count). Realizes in Lean the n=2 → n=1 connection
+  oq-04 asserted only in prose.
+
+Net effect: the odd oriented boundary seed is now available in **every dimension and for
+every Tucker label alphabet** `{±1,…,±n}`, factored through the verified n = 1 telescoping
+engine rather than a triangulation-specific `decide`. Honest status: a unification / scoping
+result, NOT a proof of n ≥ 2 Tucker — the open lever remains the 2-D almost-complementary
+path-following that turns this odd boundary sign-degree into an interior complementary
+simplex. Self-contained narrow imports (`Mathlib.Data.ZMod.Basic`,
+`Mathlib.Data.Fin.VecNotation`, `Mathlib.Algebra.BigOperators.Ring.Finset`,
+`…Group.Finset.Basic`, `Mathlib.Algebra.Ring.Parity`); verified via host `lake env lean`
+(docker cache download corrupts under sub-15Gi disk).
 
 ## Iteration 14 addition (researcher-5, verified 0-axiom — host `lean v4.26.0`, `#print axioms` clean)
 Added `proofs/Proofs/SpernerTuckerFixedPointParity.lean` (253 LOC, 7 thm, 0 def,

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-05/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-header-sperner-oq02-oq05",
+    "proofId": "sperner-mathlib4-oq-02-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 61
+    },
+    "type": "concept",
+    "title": "From the hexagon decide to the dimension-free telescoping engine",
+    "content": "The header frames the entry against sibling sperner-mathlib4-oq-02-oq-04. That entry identified the odd boundary seed the n ≥ 2 door-counting program needs as the hemisphere SIGN-degree — push the {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2 and count sign flips along an antipodal-boundary arc — and proved it odd, but only for the hexagon (n = 2, α = Fin 4) and only by kernel decide over all 4³ = 64 labellings. Its docstring claimed the oddness holds 'by the telescoping (discrete-FTC) argument of n = 1 Tucker' but never ran that argument. This file supplies the missing sign-reduction map and states the telescoping engine once, dimension-free and alphabet-free, then recovers the hexagon result as a corollary. Honest status: a unification / scoping result, 0 sorries and 0 axioms (propext / Classical.choice / Quot.sound only — plain decide only on the finite alphabet, no Lean.ofReduceBool); it is not a full n = 2 Tucker proof.",
+    "mathContext": "Tucker's lemma: for an antipodally symmetric triangulation of $B^n$ and a labelling $\\lambda : V \\to \\{\\pm1,\\dots,\\pm n\\}$ antipodal on $\\partial B^n$, some edge is complementary. The door-counting engine forces an interior complementary simplex from an odd count of boundary path endpoints; this entry supplies that odd seed as $\\#\\{i < N : \\mathrm{sgn}(\\mu_{i+1}) \\neq \\mathrm{sgn}(\\mu_i)\\}$ for an antipodal boundary arc $\\mu$, in every dimension.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "door-counting program",
+      "oriented boundary seed",
+      "hemisphere sign-degree",
+      "sign-reduction map"
+    ],
+    "prerequisites": [
+      "combinatorial topology",
+      "parity arguments"
+    ]
+  },
+  {
+    "id": "ann-telescoping-sperner-oq02-oq05",
+    "proofId": "sperner-mathlib4-oq-02-oq-05",
+    "range": {
+      "startLine": 74,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "The discrete intermediate-value theorem mod 2 (telescoping engine)",
+    "content": "changes counts the sign-change edges of a ZMod-2 path f : ℕ → ZMod 2 over range N. changes_cast is the telescoping identity — the discrete fundamental theorem of calculus mod 2 — proving the cardinality cast into ZMod 2 equals the net endpoint difference f N − f 0. The proof rewrites the filter cardinality as a ZMod-2 sum of indicators (Finset.sum_boole), rewrites each indicator (if f (i+1) ≠ f i then 1 else 0) as the difference f (i+1) − f i in ZMod 2 (a four-case decide, edge, valid because in ZMod 2 the two distinct elements differ by 1), then telescopes via Finset.sum_range_sub. odd_changes_iff converts this into the parity equivalence: the sign-change count is ODD iff the endpoints differ (f N ≠ f 0), using ZMod.natCast_eq_zero_iff_even (a ZMod-2 cardinality vanishes iff the count is even) and sub_eq_zero. This is the abstract n = 1 telescoping engine over ℕ-indexed paths, the same argument SpernerTuckerOneDim runs over Fin (N+1).",
+    "mathContext": "$\\big(\\#\\{i \\in \\mathrm{range}\\,N : f(i+1) \\neq f(i)\\} \\bmod 2\\big) = \\sum_{i<N}(f(i+1)-f(i)) = f(N)-f(0)$ in $\\mathbb{Z}/2$; hence the count is odd $\\iff f(N)\\neq f(0)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescoping sum",
+      "discrete fundamental theorem of calculus",
+      "intermediate value theorem mod 2",
+      "sign changes",
+      "Finset.sum_range_sub"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "finite sums",
+      "parity"
+    ]
+  },
+  {
+    "id": "ann-antipodal-sperner-oq02-oq05",
+    "proofId": "sperner-mathlib4-oq-02-oq-05",
+    "range": {
+      "startLine": 103,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "The antipodal sign-degree is odd, dimension-free and alphabet-free",
+    "content": "signDegree sgn μ N is the sign-change count of the reduced path sgn ∘ μ. antipodal_signDegree_odd is the main result: for ANY label type α with an antipodal map neg and an antipodal sign map sgn : α → ZMod 2 (sgn (neg x) = sgn x + 1), and ANY vertex path μ : ℕ → α with antipodal endpoints (μ N = neg (μ 0)), the sign-degree is ODD. The reduced path sgn ∘ μ has distinct endpoints — sgn (μ N) = sgn (neg (μ 0)) = sgn (μ 0) + 1 ≠ sgn (μ 0) — so odd_changes_iff fires. There is no dimension bound and no decide over the alphabet or the count. loop_signDegree_even is the companion: when the sign path is closed (sgn (μ N) = sgn (μ 0)), changes_cast gives endpoint difference 0, so the sign-degree is EVEN in every dimension — the odd seed lives on the antipodal fundamental domain (a hemisphere arc), not the whole boundary loop.",
+    "mathContext": "If $\\mathrm{sgn}(\\mathrm{neg}\\,x) = \\mathrm{sgn}\\,x + 1$ and $\\mu_N = \\mathrm{neg}\\,\\mu_0$, then $\\mathrm{sgn}(\\mu_N) = \\mathrm{sgn}(\\mu_0)+1 \\neq \\mathrm{sgn}(\\mu_0)$, so the reduced path has distinct endpoints and its sign-degree is odd; if instead $\\mathrm{sgn}(\\mu_N)=\\mathrm{sgn}(\\mu_0)$ the difference is $0$ and the count is even.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sign-degree",
+      "antipodal sign map",
+      "dimension-free reduction",
+      "fundamental domain",
+      "one-dimensional Tucker lemma"
+    ],
+    "prerequisites": [
+      "involutions",
+      "modular arithmetic",
+      "parity"
+    ]
+  },
+  {
+    "id": "ann-hexagon-sperner-oq02-oq05",
+    "proofId": "sperner-mathlib4-oq-02-oq-05",
+    "range": {
+      "startLine": 136,
+      "endLine": 169
+    },
+    "type": "technique",
+    "title": "oq-04's hexagon arc, re-derived from the engine (not decide)",
+    "content": "HexagonInstance re-supplies oq-04's concrete Fin-4 data: negL = [2,3,0,1] (label negation on {+1,+2,-1,-2}), sgn = [0,0,1,1] (magnitude collapse), and the hemisphere fundamental-domain arc v₀,v₁,v₂,v₃ = negL v₀ from three free labels. sgn_negL (the sign map is antipodal) and arc_bdry (the arc endpoints are antipodal) are the ONLY decides here — finite facts about the Fin-4 alphabet, not about the count. hexagon_arc_signDegree_odd then obtains oq-04's arc_sign_changes_odd as a one-line corollary of the dimension-free antipodal_signDegree_odd: the oddness is inherited from the telescoping engine rather than re-decided over all 64 labellings. This concretely realizes in Lean the '= n = 1 Tucker count of the sign-reduced labelling' connection that oq-04 asserted only in prose.",
+    "mathContext": "Applying $\\mathtt{antipodal\\_signDegree\\_odd}$ with $\\alpha = \\mathrm{Fin}\\,4$, $\\mathrm{neg} = \\mathrm{negL}$, and the arc $\\mu = [a,b,c,\\mathrm{negL}\\,a]$ (so $\\mu_3 = \\mathrm{negL}\\,\\mu_0$) yields $\\mathrm{Odd}\\,(\\mathtt{signDegree}\\;\\mathrm{sgn}\\,\\mu\\,3)$, oq-04's hemisphere-arc oddness, with only $\\mathrm{sgn}(\\mathrm{negL}\\,x)=\\mathrm{sgn}\\,x+1$ and $\\mu_3=\\mathrm{negL}\\,\\mu_0$ decided.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hexagon triangulation",
+      "concrete instantiation",
+      "corollary from a general theorem",
+      "label negation involution"
+    ],
+    "prerequisites": [
+      "finite labellings",
+      "Fin n encodings"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-05/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-05/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "sperner-mathlib4-oq-02-oq-05",
+  "title": "The Antipodal Sign-Degree is Odd in Every Dimension — the n = 1 Engine over Any Alphabet",
+  "slug": "sperner-mathlib4-oq-02-oq-05",
+  "description": "The door-counting path-following engine for Tucker's lemma produces an interior complementary simplex from an ODD count of boundary path endpoints, so the whole n ≥ 2 program hinges on supplying that odd boundary seed. Sibling entry sperner-mathlib4-oq-02-oq-04 identified the seed on the concrete hexagon (n = 2) as the hemisphere SIGN-degree — push the {±1,±2} labelling through the magnitude-collapsing sign map sgn : Fin 4 → ZMod 2 and count sign flips along an antipodal-boundary arc — and proved it odd, but only for that single triangulation and only by kernel decide over all 4³ = 64 labellings. Its docstring claimed the oddness holds 'by the telescoping (discrete-FTC) argument of n = 1 Tucker', yet it never ran that argument: it re-decided the count. This entry supplies the missing sign-reduction map and states the telescoping engine once, dimension-free and alphabet-free. changes_cast / odd_changes_iff give the discrete intermediate-value theorem mod 2: along ANY ZMod-2 path f : ℕ → ZMod 2, the number of sign-change edges over range N, cast to ZMod 2, is f N − f 0, hence ODD iff the endpoints differ — the same Finset.sum_range_sub telescoping the n = 1 file uses. antipodal_signDegree_odd is then the general result: for ANY label type α with an antipodal map neg and an antipodal sign map sgn : α → ZMod 2 (sgn (neg x) = sgn x + 1), and ANY vertex path μ : ℕ → α with antipodal endpoints (μ N = neg (μ 0)), the sign-degree is ODD — because sgn sends antipodal labels to distinct ZMod-2 values, so sgn ∘ μ has distinct endpoints. loop_signDegree_even is the companion: a closed antipodal loop has EVEN sign-degree, in every dimension (the seed lives on the fundamental domain, read off half the loop). Finally HexagonInstance.hexagon_arc_signDegree_odd re-derives oq-04's hexagon hemisphere-arc oddness as a corollary of the dimension-free theorem: only the alphabet's antipodal property sgn_negL and the boundary condition arc_bdry are decided (finite facts about Fin 4); the oddness itself now flows from antipodal_signDegree_odd, realizing in Lean the n = 2 → n = 1 connection oq-04 asserted in prose. Honest status: a unification / scoping result, not a proof of n ≥ 2 Tucker — it shows the odd oriented boundary seed is dimension-free and factors through the n = 1 telescoping engine for every label alphabet, removing oq-04's dimension restriction and its brute-force decide on the count; the open lever remains the 2-D almost-complementary path-following that turns this odd boundary sign-degree into an interior complementary simplex. 0 axioms, 0 sorries (propext / Classical.choice / Quot.sound only — plain decide only on the finite alphabet, no Lean.ofReduceBool).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Tucker%27s_lemma",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/SpernerTuckerSignDegreeOneDim.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "lineCount": 175,
+    "tags": [
+      "topology",
+      "tucker-lemma",
+      "borsuk-ulam",
+      "sperner-lemma",
+      "combinatorial-topology",
+      "door-counting",
+      "sign-degree",
+      "telescoping",
+      "parity"
+    ],
+    "assumptions": [],
+    "imports": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Fin.VecNotation",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Algebra.Ring.Parity"
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Tucker's lemma (Albert W. Tucker, 1945) is the combinatorial heart of the Borsuk–Ulam theorem; its constructive proofs (Freund–Todd 1981; Prescott–Su 2005) follow a path along the almost-complementary simplices from a forced boundary endpoint to an interior complementary one. The grandparent entry sperner-mathlib4 verifies the abstract door-counting engine and its dimension recursion (TuckerTower), whose path-following step consumes an ODD count of boundary path endpoints at each level. The sibling SpernerTuckerOneDim proves the n = 1 case by a telescoping / discrete fundamental-theorem-of-calculus argument over a ZMod-2 path with antipodal endpoints. Sibling entry sperner-mathlib4-oq-02-oq-04 identified the odd boundary seed on the concrete hexagon (n = 2) as the hemisphere sign-degree of the sign-reduced labelling, but proved it only for that triangulation and only by kernel decide over all 64 boundary labellings — asserting, but not running, the n = 1 telescoping connection. This entry supplies the missing sign-reduction map and states the telescoping engine once, dimension-free and for any label alphabet.",
+    "problemStatement": "Prove, without a dimension bound and without decide on the count: (i) discrete intermediate-value theorem mod 2 — for any f : ℕ → ZMod 2 and any N, the number of edges i < N with f (i+1) ≠ f i, cast into ZMod 2, equals f N − f 0, so it is odd iff f N ≠ f 0; (ii) dimension-free antipodal sign-degree — for any label type α with an antipodal map neg, any antipodal sign map sgn : α → ZMod 2 (sgn (neg x) = sgn x + 1), and any path μ : ℕ → α with μ N = neg (μ 0), the sign-degree (number of sign-flip edges) is odd; (iii) the closed-loop companion (sgn (μ N) = sgn (μ 0) ⟹ even sign-degree); and (iv) recover oq-04's hexagon hemisphere-arc oddness as a corollary of (ii), deciding only the finite alphabet's antipodal property and boundary condition, not the count.",
+    "proofStrategy": "The engine is the telescoping identity changes_cast: rewrite the filter cardinality as a ZMod-2 sum of indicators (Finset.sum_boole), rewrite each indicator (if f (i+1) ≠ f i then 1 else 0) as the difference f (i+1) − f i in ZMod 2 (a four-case decide, edge), then telescope via Finset.sum_range_sub to f N − f 0. odd_changes_iff turns this into a parity equivalence by ZMod.natCast_eq_zero_iff_even (a ZMod-2 cardinality is 0 iff the count is even) together with sub_eq_zero. antipodal_signDegree_odd instantiates the ZMod-2 path as sgn ∘ μ: the antipodal boundary condition μ N = neg (μ 0) and the antipodal sign map give sgn (μ N) = sgn (μ 0) + 1 ≠ sgn (μ 0), so odd_changes_iff fires — no decide over the alphabet or the count. loop_signDegree_even uses changes_cast directly: a closed loop makes the endpoint difference sgn (μ 0) − sgn (μ 0) = 0, an even cardinality. The hexagon corollary supplies negL, sgn, and the arc as concrete Fin-4 data, discharges sgn_negL and arc_bdry by decide over the finite alphabet, and hands them to antipodal_signDegree_odd; the oddness is inherited from the engine, not re-decided.",
+    "keyInsights": [
+      "The odd oriented boundary seed the n ≥ 2 program needs is dimension-free and alphabet-free: it is just the discrete intermediate-value theorem mod 2 — along any ZMod-2 path the number of sign changes has the parity of the endpoint difference — applied to the antipodal boundary arc through a sign map. oq-04's hexagon result is the N = 3, α = Fin 4 instance of a single general theorem.",
+      "The crucial ingredient is the sign-REDUCTION map, not a new count. Any antipodal sign map sgn : α → ZMod 2 (sgn (neg x) = sgn x + 1) collapses a rich Tucker alphabet {±1,…,±n} onto ZMod 2 while turning antipodal boundary endpoints into DISTINCT ZMod-2 endpoints, so the already-verified one-dimensional telescoping engine fires directly. This is exactly the reduction oq-04's docstring named but never executed.",
+      "The oddness is genuinely a theorem, not a finite computation: antipodal_signDegree_odd derives it from the Finset.sum_range_sub telescoping for every dimension at once, so the hexagon corollary decides only the finite facts sgn (negL x) = sgn x + 1 and arc_bdry (properties of the Fin-4 alphabet), never the count. This removes oq-04's brute-force decide over all 64 labellings from the oddness proof.",
+      "The even closed-loop companion pins the seed to the antipodal fundamental domain in every dimension: a closed sign path has endpoint difference 0, hence even sign-degree, so the odd count is read off a hemisphere arc, not the whole boundary — the abstract form of oq-04's full_sign_changes_even and the discrete analogue of reading a Borsuk–Ulam degree off a fundamental domain."
+    ]
+  },
+  "sections": [
+    {
+      "id": "motivation",
+      "title": "From the Hexagon Decide to the Dimension-Free Engine",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "The header frames the entry against oq-04: that sibling identified the odd boundary seed as the hemisphere sign-degree but proved it only for the hexagon (n = 2, α = Fin 4) by kernel decide over all 64 labellings, asserting yet never running the n = 1 telescoping connection. This file supplies the missing sign-reduction map and states the telescoping engine once, dimension-free and alphabet-free, then recovers the hexagon result as a corollary. Honest status: a unification / scoping result, not a proof of n ≥ 2 Tucker; the open lever remains the 2-D almost-complementary path-following that turns the odd boundary sign-degree into an interior complementary simplex."
+    },
+    {
+      "id": "telescoping-engine",
+      "title": "The Discrete Intermediate-Value Theorem mod 2",
+      "startLine": 74,
+      "endLine": 101,
+      "summary": "changes counts the sign-change edges of a ZMod-2 path f : ℕ → ZMod 2 over range N. changes_cast is the telescoping identity (discrete FTC mod 2): the cardinality cast into ZMod 2 equals the net endpoint difference f N − f 0 — proved by rewriting the filter cardinality as a ZMod-2 sum of indicators (Finset.sum_boole), each indicator as f (i+1) − f i (the four-case decide edge), and telescoping via Finset.sum_range_sub. odd_changes_iff turns this into the parity equivalence: the sign-change count is ODD iff the endpoints differ (f N ≠ f 0), via ZMod.natCast_eq_zero_iff_even and sub_eq_zero. This is the abstract n = 1 telescoping engine, stated over ℕ-indexed paths."
+    },
+    {
+      "id": "antipodal-sign-degree",
+      "title": "The Antipodal Sign-Degree, Dimension-Free and Alphabet-Free",
+      "startLine": 103,
+      "endLine": 134,
+      "summary": "signDegree sgn μ N is the sign-change count of the reduced path sgn ∘ μ. antipodal_signDegree_odd is the general result: for any label type α, antipodal map neg, antipodal sign map sgn (sgn (neg x) = sgn x + 1), and any path μ with antipodal endpoints (μ N = neg (μ 0)), the sign-degree is ODD — because sgn (μ N) = sgn (μ 0) + 1 ≠ sgn (μ 0) makes the reduced path's endpoints distinct, firing odd_changes_iff. No dimension bound, no decide over the alphabet or the count. loop_signDegree_even is the companion: a closed antipodal loop (sgn (μ N) = sgn (μ 0)) has EVEN sign-degree in every dimension, so the odd seed lives on the antipodal fundamental domain."
+    },
+    {
+      "id": "hexagon-instance",
+      "title": "oq-04's Hexagon Arc, Re-Derived from the Engine",
+      "startLine": 136,
+      "endLine": 169,
+      "summary": "HexagonInstance re-supplies oq-04's Fin-4 data: negL = [2,3,0,1] (label negation), sgn = [0,0,1,1] (magnitude collapse), and the hemisphere arc v₀,v₁,v₂,v₃ = negL v₀. sgn_negL (the sign map is antipodal) and arc_bdry (the arc endpoints are antipodal) are the only decides — finite facts about the Fin-4 alphabet, not the count. hexagon_arc_signDegree_odd then obtains oq-04's arc_sign_changes_odd as a one-line corollary of the dimension-free antipodal_signDegree_odd, realizing in Lean the '= n = 1 Tucker count of the sign-reduced labelling' connection oq-04 asserted only in prose."
+    }
+  ],
+  "conclusion": {
+    "summary": "The entry lifts oq-04's hexagon-only, decide-proved hemisphere sign-degree to a dimension-free, alphabet-free theorem. changes_cast / odd_changes_iff state the discrete intermediate-value theorem mod 2 — the number of sign changes along any ZMod-2 path has the parity of its endpoint difference — by the same Finset.sum_range_sub telescoping the n = 1 file uses. antipodal_signDegree_odd applies it through any antipodal sign map sgn : α → ZMod 2 to conclude that any antipodal boundary arc, in any dimension and over any label alphabet, has odd sign-degree; loop_signDegree_even gives the even closed-loop companion. hexagon_arc_signDegree_odd then recovers oq-04's result as a corollary, deciding only the finite Fin-4 alphabet's antipodal property. Seven theorems, five definitions, 0 axioms, 0 sorries (plain decide only on the finite alphabet, no Lean.ofReduceBool).",
+    "implications": "The odd oriented boundary seed the door-counting program was missing is now available in every dimension and for every Tucker label alphabet, factored through the verified n = 1 telescoping engine rather than a triangulation-specific decide. This removes oq-04's two restrictions (n = 2 only; oddness re-decided over 64 labellings) and makes explicit that the seed is precisely one-dimensional Tucker applied to the sign-reduced antipodal boundary arc. The remaining open lever is unchanged — the 2-D (and n-dimensional) almost-complementary path-following that turns this odd count of boundary sign flips into an interior complementary simplex — but the input that path-following must consume is now a single dimension-free theorem, not a family of finite computations.",
+    "openQuestions": [
+      "Instantiate antipodal_signDegree_odd on the boundary of ∂B^n for a concrete antipodally symmetric triangulation in each dimension, and feed the resulting odd sign-degree as the TuckerTower.bridge input (an oriented sign-degree rather than an unsigned door parity).",
+      "Build the almost-complementary door graph whose degree-1 boundary endpoints are exactly the sign-flip edges counted by signDegree, and verify by path-following (not decide) that the odd sign-degree forces an interior complementary simplex — the end-to-end n ≥ 2 validation of the engine thesis."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-04",
+      "relationship": "sibling",
+      "description": "Direct predecessor: identified the odd boundary seed as the hemisphere sign-degree on the hexagon (n = 2) and proved it by decide over 64 labellings. This entry generalises that result to all dimensions and all label alphabets, and recovers the hexagon case as a corollary of the dimension-free theorem."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry: the dimension-free no-go theorem that antipodal symmetry forces even endpoint counts, so the odd seed needs the symmetry broken on a hemisphere. loop_signDegree_even here is the sign-degree form of that even-on-the-full-loop phenomenon, in every dimension."
+    },
+    {
+      "targetId": "sperner-mathlib4-oq-02",
+      "relationship": "parent",
+      "description": "Parent problem entry for n = 2 Tucker from door-counting; this entry supplies the odd boundary seed dimension-free, factored through the verified one-dimensional telescoping engine."
+    },
+    {
+      "targetId": "sperner-mathlib4",
+      "relationship": "grandparent",
+      "description": "Grandparent entry: the verified door-counting engine and TuckerTower dimension recursion whose path-following step consumes the odd boundary-endpoint count that this entry identifies, dimension-free, with the antipodal sign-degree."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SpernerTuckerSignDegreeOneDim.lean",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 7,
+    "definitionCount": 5,
+    "imports": [
+      "import Mathlib.Data.ZMod.Basic",
+      "import Mathlib.Data.Fin.VecNotation",
+      "import Mathlib.Algebra.BigOperators.Ring.Finset",
+      "import Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "import Mathlib.Algebra.Ring.Parity"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Albert W. Tucker",
+      "title": "Some topological properties of disk and sphere",
+      "year": 1945,
+      "venue": "Proc. First Canadian Math. Congress, Montreal, 285–309",
+      "note": "The original combinatorial lemma equivalent to the Borsuk–Ulam theorem."
+    },
+    {
+      "authors": "Robert M. Freund and Michael J. Todd",
+      "title": "A constructive proof of Tucker's combinatorial lemma",
+      "year": 1981,
+      "venue": "Journal of Combinatorial Theory, Series A 30(3), 321–325",
+      "note": "The path-following / door-counting construction whose odd boundary seed this entry supplies dimension-free as the antipodal sign-degree."
+    },
+    {
+      "authors": "Timothy Prescott and Francis Edward Su",
+      "title": "A constructive proof of Ky Fan's generalization of Tucker's lemma",
+      "year": 2005,
+      "venue": "Journal of Combinatorial Theory, Series A 111(2), 257–265",
+      "note": "The oriented Ky Fan count; the dimension-free sign-degree verified here is the general form of that signed boundary input on a fundamental domain."
+    },
+    {
+      "authors": "Jiří Matoušek",
+      "title": "Using the Borsuk–Ulam Theorem",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Tucker's lemma, the antipodal action, hemisphere fundamental domains, and combinatorial degrees on the boundary sphere."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **`sperner-mathlib4-oq-02-oq-05`** for the open problem *Tucker's lemma and Borsuk–Ulam from abstract door-counting*.

Iteration 15 (sibling `oq-02-oq-04`) identified the odd oriented boundary seed the n ≥ 2 door-counting program needs as the **hemisphere sign-degree**, but proved it only for the hexagon (n = 2, `α = Fin 4`) and only by kernel `decide` over all 4³ = 64 labellings. Its docstring claimed the oddness holds "by the telescoping (discrete-FTC) argument of n = 1 Tucker" — but never ran that argument.

This entry supplies the missing **sign-reduction map** and states the telescoping engine once, **dimension-free and alphabet-free**:

- **`changes_cast` / `odd_changes_iff`** — the discrete intermediate-value theorem mod 2: along any `ZMod 2` path, the number of sign-change edges has the parity of the endpoint difference (`Finset.sum_range_sub` telescoping).
- **`antipodal_signDegree_odd`** — for ANY label type `α` with an antipodal map `neg` and an antipodal sign map `sgn : α → ZMod 2` (`sgn (neg x) = sgn x + 1`), and ANY path `μ : ℕ → α` with antipodal endpoints (`μ N = neg (μ 0)`), the **sign-degree is odd**. No dimension bound, no `decide` over the alphabet or the count.
- **`loop_signDegree_even`** — closed antipodal loop ⟹ even sign-degree in every dimension (the seed lives on the antipodal fundamental domain).
- **`HexagonInstance.hexagon_arc_signDegree_odd`** — oq-04's hexagon hemisphere-arc oddness recovered as a one-line corollary of the engine, deciding only the finite `Fin 4` alphabet's antipodal property; realizes in Lean the n = 2 → n = 1 connection oq-04 asserted only in prose.

## Verification

- `proofs/Proofs/SpernerTuckerSignDegreeOneDim.lean`: 175 LOC, 7 theorems, 5 definitions, **0 sorries, 0 axioms**.
- Verified with host `lean v4.26.0`: `#print axioms` = `propext / Classical.choice / Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool` (plain `decide`, used only on finite `Fin 4` facts, never on the count).
- Self-contained (narrow imports); annotation resolver validates clean.

## Honest status

A **unification / scoping result**, not a proof of n ≥ 2 Tucker. It shows the odd oriented boundary seed is dimension-free and factors through the n = 1 telescoping engine for every label alphabet, removing oq-04's dimension restriction and its brute-force `decide` on the count. The open lever remains the 2-D almost-complementary path-following that turns this odd boundary sign-degree into an interior complementary simplex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)