### PR TITLE
Enrich ℚ(⁴√2,i) Galois closure (fourth-root-2-irrational-oq-03): split section, card_gal annotation + keyInsights

### DIFF
--- a/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/annotations.json
@@ -78,23 +78,48 @@
     "proofId": "fourth-root-2-irrational-oq-03",
     "range": {
       "startLine": 117,
-      "endLine": 146
+      "endLine": 130
     },
     "type": "insight",
-    "title": "Splitting field ⟹ Galois ⟹ |Gal| = 8",
-    "content": "With the root-set identity in hand, isSplittingField follows because X⁴ − 2 splits over the algebraically closed ℂ (adjoin_rootSet_isSplittingField, then rewrite). A separable splitting field is Galois (isGalois via IsGalois.of_separable_splitting_field), and it is finite-dimensional (finiteDimensional), which supplies the Fintype instance on the Galois group. Finally card_gal: converting Fintype.card to Nat.card and applying IsGalois.card_aut_eq_finrank equates #Gal with the finrank, which the parent computed to be 8. The order-8 Galois group is the exact prerequisite for identifying it with the dihedral group D₄.",
-    "mathContext": "Separable splitting field $\\Rightarrow$ Galois; then $\\#\\mathrm{Gal}(K/\\mathbb{Q}) = [K:\\mathbb{Q}]$ (IsGalois.card_aut_eq_finrank). With $[\\mathbb{Q}(\\sqrt[4]{2},i):\\mathbb{Q}] = 8$ this gives $\\#\\mathrm{Gal} = 8$.",
+    "title": "Splitting field ⟹ Galois",
+    "content": "With the root-set identity in hand, isSplittingField follows because X⁴ − 2 splits over the algebraically closed ℂ (adjoin_rootSet_isSplittingField, then rewrite by adjoin_rootSet_eq). A separable splitting field is automatically Galois: isGalois comes from IsGalois.of_separable_splitting_field, and normal packages the normality half of that Galois property separately. Both ingredients of 'Galois' — separability (from irreducibility over ℚ) and normality (from being a splitting field) — are now in place.",
+    "mathContext": "Separable splitting field $\\Rightarrow$ Galois. Normality is automatic for a splitting field; separability came from $X^4-2$ being irreducible over the characteristic-zero field $\\mathbb{Q}$.",
     "significance": "key",
     "relatedConcepts": [
       "Galois-extension",
       "splitting-field",
-      "finite-dimensional-extension",
-      "automorphism-group",
-      "dihedral-group"
+      "normal-extension",
+      "separable-polynomial",
+      "algebraically-closed-field"
     ],
     "prerequisites": [
       "IsGalois.of_separable_splitting_field",
+      "IntermediateField.adjoin_rootSet_isSplittingField",
+      "splitting of a polynomial over ℂ"
+    ]
+  },
+  {
+    "id": "ann-card-gal",
+    "proofId": "fourth-root-2-irrational-oq-03",
+    "range": {
+      "startLine": 132,
+      "endLine": 146
+    },
+    "type": "insight",
+    "title": "The headline: |Gal(ℚ(⁴√2, i)/ℚ)| = 8",
+    "content": "finiteDimensional records that a splitting field is finite over ℚ, supplying the Fintype instance on the automorphism group that card_gal needs. Then card_gal: converting Fintype.card to Nat.card and applying IsGalois.card_aut_eq_finrank equates #Gal with the finrank [ℚ(⁴√2, i) : ℚ], which the parent finrank_galois_closure computed to be 8. This order-8 group is exactly the input the eventual D₄ identification rests on — 8 = |D₄|, with ℚ as the fixed field.",
+    "mathContext": "For a finite Galois extension, $\\#\\mathrm{Gal}(K/\\mathbb{Q}) = [K:\\mathbb{Q}]$ (IsGalois.card_aut_eq_finrank). With $[\\mathbb{Q}(\\sqrt[4]{2},i):\\mathbb{Q}] = 8$ from the parent, $\\#\\mathrm{Gal} = 8 = |D_4|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "automorphism-group",
+      "finite-dimensional-extension",
+      "dihedral-group",
+      "Galois-correspondence",
+      "field-degree"
+    ],
+    "prerequisites": [
       "IsGalois.card_aut_eq_finrank",
+      "Polynomial.IsSplittingField.finiteDimensional",
       "Fintype/Nat.card conversions"
     ]
   }

--- a/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational-oq-03/meta.json
@@ -120,7 +120,9 @@
       "Being Galois is 'separable + splitting field'. The obstruction to normality that made ℚ(⁴√2) non-Galois disappears once the two missing roots ±i·⁴√2 are adjoined: the enlarged field ℚ(⁴√2, i) is the splitting field of X⁴ − 2, and X⁴ − 2 is separable over ℚ (characteristic zero), so the extension is automatically Galois.",
       "The splitting-field identity is the whole content. Everything downstream (Galois, finite-dimensional, #Gal = 8) is Mathlib API once adjoin ℚ (rootSet (X⁴−2)) = ℚ(⁴√2, i) is established. That identity is proved by explicit factorization of z⁴ − a⁴ into the four linear factors — the same factorization that geometrically places the roots at the vertices of a square.",
       "#Gal = degree is exactly the Galois property. For a finite separable normal extension, Nat.card of the automorphism group equals the field degree; here that converts the parent's purely field-theoretic [ℚ(⁴√2, i) : ℚ] = 8 into the group-order fact |Gal| = 8 = |D₄|, the anchor for the eventual dihedral identification.",
-      "The result is the launch pad for D₄. A group of order 8 acting faithfully as the Galois group, together with the square arrangement of the four roots, pins the group down to D₄ once the eight automorphisms are exhibited — the natural next entry."
+      "The result is the launch pad for D₄. A group of order 8 acting faithfully as the Galois group, together with the square arrangement of the four roots, pins the group down to D₄ once the eight automorphisms are exhibited — the natural next entry.",
+      "Adjoining i does double duty. ℚ(⁴√2) is the real field ℝ ∩ ℚ(⁴√2, i): it is degree 4 but NOT normal, because it contains only the two real roots ±⁴√2 and misses the complex pair ±i·⁴√2. Adjoining i simultaneously supplies those two missing roots AND, via i² = −1, licenses the factorization z⁴ − a⁴ = (z−a)(z+a)(z−i·a)(z+i·a) that fails over ℝ — the same i that repairs normality repairs the factorization.",
+      "The doubling [ℚ(⁴√2, i) : ℚ(⁴√2)] = 2 is exactly the index of the fixed field of complex conjugation. Since ℚ(⁴√2) is real, complex conjugation restricts to a nontrivial order-2 element of Gal(ℚ(⁴√2, i)/ℚ) fixing ℚ(⁴√2) pointwise; it is the reflection generator of D₄, while ⁴√2 ↦ i·⁴√2 is the order-4 rotation — the concrete automorphisms whose existence |Gal| = 8 now guarantees."
     ]
   },
   "sections": [
@@ -141,12 +143,20 @@
       "mathContext": "The field-theoretic crux identifying the splitting field with ℚ(⁴√2, i)."
     },
     {
-      "id": "galois-cardinality",
-      "title": "Splitting Field, Galois Property, and |Gal| = 8",
+      "id": "splitting-field-galois",
+      "title": "Splitting Field ⟹ Galois",
       "startLine": 117,
+      "endLine": 130,
+      "summary": "isSplittingField upgrades adjoin_rootSet_eq to p.IsSplittingField ℚ ℚ(⁴√2, i) (using that p splits over the algebraically closed ℂ); isGalois then follows from IsGalois.of_separable_splitting_field applied to the separable X⁴ − 2, and normal packages the normality half separately.",
+      "mathContext": "A separable splitting field is Galois: separability came from irreducibility over the characteristic-zero ℚ, and normality is automatic for a splitting field."
+    },
+    {
+      "id": "order-of-galois-group",
+      "title": "Finite-Dimensionality and |Gal| = 8",
+      "startLine": 132,
       "endLine": 146,
-      "summary": "isSplittingField (from adjoin_rootSet_eq + p splits over ℂ), isGalois (separable splitting field), normal, finiteDimensional, and card_gal: #Gal(ℚ(⁴√2, i)/ℚ) = [ℚ(⁴√2, i) : ℚ] = 8 via IsGalois.card_aut_eq_finrank and the parent's degree.",
-      "mathContext": "Assembles the Galois property and converts the parent's degree into the group order 8."
+      "summary": "finiteDimensional records that a splitting field is finite over ℚ (supplying the Fintype on the automorphism group); card_gal then applies IsGalois.card_aut_eq_finrank to equate #Gal(ℚ(⁴√2, i)/ℚ) with [ℚ(⁴√2, i) : ℚ], which the parent computed to be 8.",
+      "mathContext": "For a finite Galois extension #Aut = [E : F]; here the parent's degree 8 becomes the group order |Gal| = 8 = |D₄|."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `fourth-root-2-irrational-oq-03` (on-main quality 89, weakest dims: sections=3, keyInsights=4).

## Changes (all additive/curation, meta 16.0KB→17.6KB, well under caps)
- **sections 3→4**: split the lumped final section (117–146, which covered five distinct theorems) into *Splitting field ⟹ Galois* (117–130) and *Finite-dimensionality and |Gal|=8* (132–146).
- **annotations 4→5**: narrowed the prior 117–146 annotation to the Galois-property lines and added `ann-card-gal` (132–146, anchored on the `finiteDimensional` doc-comment) spotlighting the headline `card_gal` theorem. All 5 annotations retain mathContext/significance/relatedConcepts/prerequisites.
- **keyInsights 4→6**: added two mathematically substantive insights — (a) adjoining `i` does double duty (supplies the missing complex roots ±i·⁴√2 *and*, via i²=−1, licenses the factorization z⁴−a⁴=(z−a)(z+a)(z−ia)(z+ia) that fails over ℝ); (b) complex conjugation restricts to the order-2 D₄ reflection generator fixing the real subfield ℚ(⁴√2).

JSON validated; annotation anchors verified against the Lean source on main.