### PR TITLE
Enrich Ladyzhenskaya assembly (navier-stokes-oq-01-oq-01): full-file section coverage

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview-scope",
+      "title": "Overview: The Honest Algebra/Analysis Split",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "The docstring states the parent problem navier-stokes-oq-01 — can the Ladyzhenskaya interpolation inequality ‖u‖_{L⁴(ℝ²)} ≤ C·‖u‖_{L²}^{1/2}·‖∇u‖_{L²}^{1/2} be formalized — and honestly scopes what Mathlib v4.26 does and does not provide (no Gagliardo–Nirenberg–Sobolev, no Ladyzhenskaya, no adequate weak-derivative API). Ladyzhenskaya's classical proof is factored into (A) three analytic facts, exposed here as explicit hypotheses that double as a specification of the missing Mathlib API, and (B) a purely algebraic assembly with the sharp constant, verified in full (0 axioms, 0 sorries). The namespace, open scoped Real, and norm notation (n2, n4, d1, d2, ng with ng² = d1²+d2²) set up the elementary working context.",
+      "mathContext": "Scope: prove part (B), the elementary algebraic assembly of Ladyzhenskaya's inequality with sharp constant √2, taking the three analytic facts (part A) as hypotheses."
+    },
+    {
       "id": "sharp-amgm-step",
       "title": "The Sharp AM–GM Step",
       "startLine": 51,
@@ -96,6 +104,14 @@
       "endLine": 112,
       "mathContext": "$n_4^2 \\le \\sqrt{2}\\,n_2\\,n_g$ from $n_4^4 \\le 2 n_2^2 n_g^2$, i.e. $\\|u\\|_4^2 \\le \\sqrt2\\,\\|u\\|_2\\,\\|\\nabla u\\|_2$.",
       "summary": "ladyzhenskaya_sq_form takes square roots of the quartic bound to the clean norm form, comparing squares via Real.sq_sqrt (√2²=2) and monotone Real.sqrt_le_sqrt / Real.sqrt_sq. One further root recovers ‖u‖₄ ≤ 2^{1/4}‖u‖₂^{1/2}‖∇u‖₂^{1/2}."
+    },
+    {
+      "id": "sec-final-verification",
+      "title": "Final Verification",
+      "startLine": 114,
+      "endLine": 122,
+      "summary": "A #check block re-exhibiting the three exported results — cross_le_grad_sq, ladyzhenskaya_assembly, and ladyzhenskaya_sq_form — confirming their fully-elaborated types, followed by end NavierStokes.OQ0101.",
+      "mathContext": "Type-level confirmation that the sharp AM–GM step and both assembled forms of the inequality are available for downstream use."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **navier-stokes-oq-01-oq-01** (Ladyzhenskaya's 2D interpolation inequality — verified algebraic assembly).

## Gap addressed
The `sections` array covered only lines 51–112 of the 122-line Lean file, leaving the opening docstring/setup (1–50) and the final `#check` verification block (113–122) outside any section — the sole quality gap on this otherwise-complete q89 entry.

## Change (meta.json only)
- Added **"Overview: The Honest Algebra/Analysis Split"** section (1–50) summarizing the parent problem, the honest scoping of what Mathlib v4.26 lacks (no Gagliardo–Nirenberg–Sobolev / Ladyzhenskaya), the (A) analytic-hypotheses / (B) verified-algebraic-assembly split, and the norm notation.
- Added **"Final Verification"** section (114–122) covering the `#check` block that re-exhibits the three exported results.
- Sections now span the full file (1–122); 3 → 5 sections.

`annotations.json` unchanged. No mathematical claims altered; `status`/`badge`/`axiomCount` untouched (verified, original, 0). meta.json 13.8 KB → 15.4 KB (well under the 60 KB cap).
