### PR TITLE
Enrich Chebyshev θ ≤ n·log 4 (chebyshev-bounds-oq-06-oq-02): full-file section coverage

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
@@ -64,6 +64,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: θ(n) = log(n#) and the Central-Binomial Route",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "The docstring introduces Chebyshev's first function θ(n) = ∑_{p ≤ n} log p, notes that exp θ(n) is exactly the primorial n# so θ(n) = log(n#), and lays out the strategy: Mathlib's primorial_le_4_pow (n# ≤ 4ⁿ, itself the Erdős central-binomial sandwich) becomes the sharp upper bound θ(n) ≤ n·log 4 = 2n·log 2 by taking logarithms and using monotonicity of log on the positive reals. Imports Primorial and Log.Basic, opens Finset, and sets up namespace ChebyshevThetaBound.",
+      "mathContext": "$\\theta(n) = \\sum_{p \\le n} \\log p = \\log(n\\#)$, and $n\\# \\le 4^n \\Rightarrow \\theta(n) \\le n\\log 4$."
+    },
+    {
       "id": "definition-and-primorial-identity",
       "title": "θ(n) as the logarithm of the primorial",
       "startLine": 28,


### PR DESCRIPTION
Enrichment pass for **chebyshev-bounds-oq-06-oq-02** (Chebyshev's θ function is bounded by n·log 4).

## Gap addressed
The `sections` array started at line 28, leaving the opening docstring/setup (1–27) — which states the θ(n) = log(n#) identity and the central-binomial route — outside any section. The sole quality gap on this q91 entry.

## Change (meta.json only)
- Added **"Overview: θ(n) = log(n#) and the Central-Binomial Route"** section (1–27) summarizing Chebyshev's first function, the primorial identity, and the `primorial_le_4_pow` → `θ(n) ≤ n·log 4` strategy, plus imports/namespace.
- Sections now span the full file (1–74 of 76; the 75–76 tail is `end`); 3 → 4 sections.

`annotations.json` unchanged. No mathematical claims altered; `status`/`badge`/`axiomCount` untouched.
