### PR TITLE
research(newton-power-sum-identities-oq-01-oq-02): reverse Newton identities + Toeplitz-determinant closed form [verified 0-axiom, recovered]

### DIFF
--- a/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean
+++ b/proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean
@@ -1,0 +1,164 @@
+import Mathlib
+
+/-
+# The reverse Newton identities and their Toeplitz-determinant closed form
+
+Parent: `newton-power-sum-identities-oq-01` (Newton's identities in low degree).
+
+Newton's identities relate the elementary symmetric polynomials `eₖ = esymm σ R k`
+and the power sums `pₖ = psum σ R k = ∑ᵢ Xᵢᵏ`.  The *forward* identities express
+each power sum through the elementary symmetric polynomials; the parent entry
+records `p₁, p₂, p₃` this way.  This entry proves the **reverse (dual) identities**,
+expressing each elementary symmetric polynomial through the power sums.
+
+Because inverting the recurrence introduces the factor `k!`, the division-free
+statements carry that factor on the left:
+
+* `e₁ = p₁`                              (`esymm_one_eq_psum`)
+* `2·e₂ = p₁² − p₂`                      (`two_esymm_two`)
+* `6·e₃ = p₁³ − 3 p₁ p₂ + 2 p₃`          (`six_esymm_three`)
+
+These are identities in `MvPolynomial σ R` for **any** finite index type `σ` and
+**any** commutative ring `R` — no division by `k!` is required, so the result is
+strictly more general than a ℚ-algebra statement.
+
+The classical closed form packages `k!·eₖ` as the determinant of a `k × k`
+lower-Hessenberg *Toeplitz* matrix whose entries are the power sums, with the
+super-diagonal carrying the integers `1, 2, …`:
+
+* `1!·e₁ = det [p₁]`                                            (`esymm_one_det`)
+* `2!·e₂ = det [[p₁, 1], [p₂, p₁]]`                             (`two_esymm_two_det`)
+* `3!·e₃ = det [[p₁, 1, 0], [p₂, p₁, 2], [p₃, p₂, p₁]]`         (`six_esymm_three_det`)
+
+The determinant form is exactly the shape requested by the parent's open question
+and is absent from Mathlib.  We obtain it by expanding the small determinants with
+`Matrix.det_fin_two_of` / `Matrix.det_fin_three` and matching against the scalar
+reverse identities.
+
+## Relation to existing gallery work
+
+The scalar identities `e₁ = p₁` and `2·e₂ = p₁² − p₂` also appear in the
+`amgm-inequality-oq-02-oq-01-oq-01-oq-02` entry (the abstract "same ℚ-subalgebra"
+statement).  New here are the degree-3 reverse identity and, above all, the
+explicit Toeplitz-determinant closed forms, valid over an arbitrary commutative ring.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+open Finset Matrix
+
+namespace NewtonReverseOQ0102
+
+open MvPolynomial
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-! ## Forward identities (stepping stones)
+
+These reproduce the parent's low-degree forward Newton identities, obtained by
+unrolling Mathlib's recurrence `psum_eq_mul_esymm_sub_sum`.  They are the inputs
+from which the reverse identities are algebraically inverted. -/
+
+/-- **Forward, degree 1:** `p₁ = e₁`. -/
+theorem psum_one_eq : psum σ R 1 = esymm σ R 1 := by
+  rw [psum_one, esymm_one]
+
+/-- **Forward, degree 2:** `p₂ = e₁² − 2 e₂`. -/
+theorem psum_two_eq :
+    psum σ R 2 = esymm σ R 1 ^ 2 - 2 * esymm σ R 2 := by
+  rw [psum_eq_mul_esymm_sub_sum σ R 2 (by norm_num)]
+  have hset : {a ∈ Finset.antidiagonal 2 | a.1 ∈ Set.Ioo 0 2} = {(1, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_singleton,
+      Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_singleton, psum_one_eq]
+  push_cast
+  ring
+
+/-- **Forward, degree 3:** `p₃ = e₁³ − 3 e₁ e₂ + 3 e₃`. -/
+theorem psum_three_eq :
+    psum σ R 3 =
+      esymm σ R 1 ^ 3 - 3 * esymm σ R 1 * esymm σ R 2 + 3 * esymm σ R 3 := by
+  rw [psum_eq_mul_esymm_sub_sum σ R 3 (by norm_num)]
+  have hset : {a ∈ Finset.antidiagonal 3 | a.1 ∈ Set.Ioo 0 3} = {(1, 2), (2, 1)} := by
+    ext ⟨i, j⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo, Finset.mem_insert,
+      Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [hset, Finset.sum_pair (by decide), psum_two_eq, psum_one_eq]
+  push_cast
+  ring
+
+/-! ## Reverse (dual) Newton identities
+
+Each `k!·eₖ` is a polynomial in the power sums, obtained by inverting the forward
+identities above.  Every step is a ring rearrangement, so no division by `k!`
+occurs and the identities hold over an arbitrary commutative ring. -/
+
+/-- **Reverse, degree 1:** `e₁ = p₁`. -/
+theorem esymm_one_eq_psum : esymm σ R 1 = psum σ R 1 :=
+  (psum_one_eq σ R).symm
+
+/-- **Reverse, degree 2:** `2·e₂ = p₁² − p₂`. -/
+theorem two_esymm_two :
+    2 * esymm σ R 2 = psum σ R 1 ^ 2 - psum σ R 2 := by
+  rw [psum_one_eq σ R]
+  linear_combination psum_two_eq σ R
+
+/-- **Reverse, degree 3:** `6·e₃ = p₁³ − 3 p₁ p₂ + 2 p₃`. -/
+theorem six_esymm_three :
+    6 * esymm σ R 3 =
+      psum σ R 1 ^ 3 - 3 * psum σ R 1 * psum σ R 2 + 2 * psum σ R 3 := by
+  have h1 := psum_one_eq σ R
+  have h2 := psum_two_eq σ R
+  have h3 := psum_three_eq σ R
+  -- Substitute the two lower power sums, then invert the degree-3 forward identity.
+  rw [h2, h1]
+  linear_combination (-2 : MvPolynomial σ R) * h3
+
+/-! ## Toeplitz-determinant closed form
+
+`k!·eₖ = det Tₖ`, where `Tₖ` is the lower-Hessenberg Toeplitz matrix with the power
+sums `p₁, p₂, …` down the first column and along the diagonals, and the integers
+`1, 2, …, k−1` on the super-diagonal. -/
+
+/-- **Determinant form, degree 1:** `1!·e₁ = det [p₁]`. -/
+theorem esymm_one_det :
+    esymm σ R 1 = (!![psum σ R 1] : Matrix (Fin 1) (Fin 1) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_one_of, esymm_one_eq_psum]
+
+/-- **Determinant form, degree 2:** `2!·e₂ = det [[p₁, 1], [p₂, p₁]]`. -/
+theorem two_esymm_two_det :
+    2 * esymm σ R 2 =
+      (!![psum σ R 1, 1; psum σ R 2, psum σ R 1] :
+        Matrix (Fin 2) (Fin 2) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_two_of]
+  linear_combination two_esymm_two σ R
+
+/-- **Determinant form, degree 3:**
+`3!·e₃ = det [[p₁, 1, 0], [p₂, p₁, 2], [p₃, p₂, p₁]]`. -/
+theorem six_esymm_three_det :
+    6 * esymm σ R 3 =
+      (!![psum σ R 1, 1, 0; psum σ R 2, psum σ R 1, 2; psum σ R 3, psum σ R 2, psum σ R 1] :
+        Matrix (Fin 3) (Fin 3) (MvPolynomial σ R)).det := by
+  rw [Matrix.det_fin_three]
+  simp only [Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons, Matrix.head_fin_const, Matrix.cons_val',
+    Matrix.cons_val_fin_one, Matrix.empty_val']
+  linear_combination six_esymm_three σ R
+
+/-! ## Worked example
+
+Over `R = ℤ` with two variables `σ = Fin 2`, the reverse identities specialise to
+the familiar symmetric-function formulas.  For instance with `X₀, X₁` we have
+`p₁ = X₀ + X₁`, `p₂ = X₀² + X₁²`, and `2·e₂ = 2·X₀X₁ = p₁² − p₂`. -/
+
+/-- Sanity check of the degree-2 determinant identity specialised to `Fin 2` over `ℤ`. -/
+example :
+    2 * esymm (Fin 2) ℤ 2 =
+      (!![psum (Fin 2) ℤ 1, 1; psum (Fin 2) ℤ 2, psum (Fin 2) ℤ 1] :
+        Matrix (Fin 2) (Fin 2) (MvPolynomial (Fin 2) ℤ)).det :=
+  two_esymm_two_det (Fin 2) ℤ
+
+end NewtonReverseOQ0102

--- a/research/problems/newton-power-sum-identities-oq-01-oq-02/knowledge.md
+++ b/research/problems/newton-power-sum-identities-oq-01-oq-02/knowledge.md
@@ -1,0 +1,40 @@
+# newton-power-sum-identities-oq-01-oq-02: reverse Newton identities + Toeplitz determinant
+
+Reverse (dual) Newton identities and their Toeplitz-determinant closed form
+`k!·eₖ = det Tₖ` (k=1,2,3), division-free over an arbitrary `CommRing`. The shape
+is named in the parent open question and is absent from Mathlib.
+
+## Session 2026-07-02 — REVISIT/recovery (researcher-6)
+
+**Outcome**: recovered a verified 0-axiom entry that was lost to branch divergence.
+
+### What happened
+- The gallery pool marked this slug `completed`, yet neither the Lean file
+  (`proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean`) nor the gallery dir
+  existed on `main`. Sibling `oq-01-oq-03` references it by name as existing.
+- Traced it to commit `6d0ee66d29b` on branch `research/newton-reverse-oq0102-fix`,
+  opened as PR #32851 — but that branch diverged catastrophically from main
+  (26,858 files, ~5.1M deletions, CONFLICTING) and was correctly skipped by the
+  deployer. The verified work was thus orphaned.
+- Re-applied the two intended artifacts (Lean file byte-identical to the verified
+  commit + gallery meta.json) cleanly onto current main → PR #33484. Closed the
+  stale #32851 as superseded.
+
+### Verification
+- `#print axioms` at creation: propext, Classical.choice, Quot.sound only
+  (0-axiom, `status: verified`). Verified via single-file `lake env lean` against
+  Mathlib v4.26.0. Current main pins the identical v4.26.0 + toolchain, so the
+  verification still applies.
+- Could NOT re-run Docker build this session: host-disk exhaustion (100% full,
+  ~365Mi free; curl/containerd I/O errors) — documented infra blocker #33336.
+
+### Content (9 theorems)
+- Forward stepping stones: psum_one_eq, psum_two_eq, psum_three_eq.
+- Reverse identities: esymm_one_eq_psum, two_esymm_two, six_esymm_three.
+- Toeplitz determinant form: esymm_one_det, two_esymm_two_det, six_esymm_three_det
+  (via Matrix.det_fin_one_of / det_fin_two_of / det_fin_three + linear_combination).
+
+### Next steps
+- Docker re-verify on a host with free disk before/at merge.
+- Possible follow-up: general-k reverse Newton determinant (currently only k≤3),
+  or the Jacobi–Trudi–style determinant for complete homogeneous symmetric polys.

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "newton-power-sum-identities-oq-01-oq-02",
+  "title": "The Reverse Newton Identities and their Toeplitz-Determinant Closed Form",
+  "slug": "newton-power-sum-identities-oq-01-oq-02",
+  "description": "The reverse (dual) Newton identities express each elementary symmetric polynomial eₖ = esymm σ R k as a polynomial in the power sums pₖ = psum σ R k = ∑ᵢ Xᵢᵏ. Because inverting the Newton recurrence introduces the factor k!, the division-free statements carry that factor: e₁ = p₁, 2·e₂ = p₁² − p₂, and 6·e₃ = p₁³ − 3p₁p₂ + 2p₃, all holding in MvPolynomial σ R for any finite σ and any commutative ring R (no division by k! is needed, so the result is strictly more general than a ℚ-algebra statement). The classical closed form packages k!·eₖ as the determinant of a k×k lower-Hessenberg Toeplitz matrix in the power sums, with the super-diagonal carrying 1, 2, …: 1!·e₁ = det[p₁], 2!·e₂ = det[[p₁,1],[p₂,p₁]], 3!·e₃ = det[[p₁,1,0],[p₂,p₁,2],[p₃,p₂,p₁]]. This determinant form — the shape named in the parent's open question — is absent from Mathlib and is obtained by expanding the small determinants with Matrix.det_fin_two_of / Matrix.det_fin_three and matching against the scalar reverse identities.",
+  "meta": {
+    "author": "Isaac Newton / Albert Girard; determinant form after Le Verrier–Faddeev; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "1707",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-identities",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "determinant",
+      "toeplitz",
+      "mvpolynomial",
+      "commutative-ring",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The forward Newton recurrence pₖ = (-1)^{k+1}·k·eₖ - ∑_{0<i<k}(-1)^i·eᵢ·p_{k-i}; unrolled at k = 2, 3 to obtain the forward identities that are then algebraically inverted",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.psum_one / MvPolynomial.esymm_one",
+        "description": "psum σ R 1 = esymm σ R 1 = ∑ᵢ Xᵢ — the degree-1 identity in both directions",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a,b;c,d] = a·d − b·c — expands the degree-2 Toeplitz determinant",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "Sarrus' expansion of a 3×3 determinant — expands the degree-3 Toeplitz determinant",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Finset.sum_singleton / Finset.sum_pair",
+        "description": "Evaluate the forward recurrence's finite inner sums over the one- and two-element index sets {(1,1)} and {(1,2),(2,1)}",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "six_esymm_three: 6·e₃ = p₁³ − 3p₁p₂ + 2p₃ — the degree-3 reverse Newton identity (not present in Mathlib or existing gallery entries)",
+      "esymm_one_det / two_esymm_two_det / six_esymm_three_det: the explicit Toeplitz-determinant closed form k!·eₖ = det Tₖ for k = 1, 2, 3, valid over an arbitrary commutative ring — the determinant shape named in the parent's open question and absent from Mathlib",
+      "two_esymm_two: 2·e₂ = p₁² − p₂ and esymm_one_eq_psum: e₁ = p₁ restated division-free (these two scalar identities also appear in amgm-inequality-oq-02-oq-01-oq-01-oq-02 as part of an abstract ℚ-subalgebra statement)"
+    ],
+    "dateAdded": "2026-07-02",
+    "lineCount": 164,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No native_decide is used; the single decide proves the pair inequality (1,2) ≠ (2,1) by kernel reduction, introducing no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton–Girard formulae) relate the power sums pₖ = ∑ xᵢᵏ and the elementary symmetric polynomials eⱼ. The forward direction expresses the pₖ through the eⱼ; the reverse direction expresses the eⱼ through the pₖ. The reverse direction is the computational heart of the Le Verrier–Faddeev algorithm for the characteristic polynomial of a matrix from its power-traces, and its closed form is the classical determinant (Toeplitz / lower-Hessenberg) expression k!·eₖ = det Tₖ. Inverting the recurrence naturally produces the factor k!, which is why the eₖ themselves are only rational combinations of the power sums over a field of characteristic 0 — but the scaled quantities k!·eₖ are integer-coefficient polynomials in the pᵢ, valid over any commutative ring.",
+    "problemStatement": "**Open Question (newton-power-sum-identities-oq-01, second follow-up)**: Prove the dual (reverse) Newton identities expressing each eₖ as a polynomial in the power sums, with k!·eₖ realised as the determinant of a Toeplitz matrix in the pᵢ.\n\n**Result**: esymm_one_eq_psum (e₁ = p₁), two_esymm_two (2·e₂ = p₁² − p₂), six_esymm_three (6·e₃ = p₁³ − 3p₁p₂ + 2p₃), together with their Toeplitz-determinant closed forms esymm_one_det, two_esymm_two_det, six_esymm_three_det — all as identities in MvPolynomial σ R over an arbitrary commutative ring R.",
+    "text": "Let σ be a finite index type and R a commutative ring. For eⱼ = MvPolynomial.esymm σ R j and pₖ = MvPolynomial.psum σ R k in MvPolynomial σ R, the reverse Newton identities read e₁ = p₁, 2·e₂ = p₁² − p₂, and 6·e₃ = p₁³ − 3p₁p₂ + 2p₃. Equivalently, k!·eₖ is the determinant of the k×k lower-Hessenberg Toeplitz matrix carrying p₁,…,pₖ down the first column and diagonals and 1,2,…,k−1 on the super-diagonal: 1!·e₁ = det[p₁], 2!·e₂ = det[[p₁,1],[p₂,p₁]], 3!·e₃ = det[[p₁,1,0],[p₂,p₁,2],[p₃,p₂,p₁]].",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Forward stepping stones: reprove p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃ by unrolling Mathlib's Newton recurrence over the omega-computable inner index sets {(1,1)} and {(1,2),(2,1)} (as in the parent entry).\n\n2. Reverse identities: e₁ = p₁ is the degree-1 forward identity reversed. For 2·e₂: rewrite p₁ = e₁ in the goal and close the degree-2 forward identity with linear_combination. For 6·e₃: substitute the degree-2 and degree-1 forward identities, then invert the degree-3 forward identity via linear_combination (2·psum_three_eq) — the factor 2 clears the 3·e₃ coefficient to 6·e₃ with only integer arithmetic.\n\n3. Determinant forms: expand det[p₁] by Matrix.det_fin_one_of, det[[p₁,1],[p₂,p₁]] by Matrix.det_fin_two_of, and the 3×3 determinant by Matrix.det_fin_three followed by simp over the matrix cons-indexing lemmas; then match each expansion to the corresponding scalar reverse identity with linear_combination.",
+    "keyInsights": [
+      "**k! is the price of inversion, and it keeps things integral.** Inverting Newton's recurrence divides by k, so eₖ over ℚ carries 1/k!. Multiplying through by k! yields integer-coefficient identities that hold over ANY commutative ring — strictly more general than the ℚ-algebra framing.",
+      "**The determinant is Sarrus, not Leibniz.** The Toeplitz closed form for k ≤ 3 is proved by the concrete det_fin_two_of / det_fin_three expansions; no general determinant theory is invoked, so each identity reduces to a single ring equality against the scalar reverse form.",
+      "**The super-diagonal integers 1, 2 are essential.** They encode the k-factor of the recurrence; with them, det Tₖ = k!·eₖ exactly. Verified here: det[[p₁,1,0],[p₂,p₁,2],[p₃,p₂,p₁]] = p₁³ − 3p₁p₂ + 2p₃ = 6·e₃.",
+      "**Distinct from the abstract dual statement.** The gallery's amgm-inequality-oq-02-oq-01-oq-01-oq-02 proves the two symmetric-function subalgebras coincide and records e₁, e₂ over a ℚ-algebra; new here are the degree-3 identity and the explicit determinant closed forms over an arbitrary ring."
+    ],
+    "prerequisites": [
+      "The definitions MvPolynomial.psum and MvPolynomial.esymm (Symmetric/Defs.lean)",
+      "The forward Newton recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum (Symmetric/NewtonIdentities.lean)",
+      "Small-determinant expansions Matrix.det_fin_one_of, Matrix.det_fin_two_of, Matrix.det_fin_three"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Module docstring stating the reverse Newton identities, the factor-k! normalisation, and the Toeplitz-determinant closed form, with a note on the relation to the ℚ-subalgebra entry. Imports, open Finset/Matrix/MvPolynomial, namespace and variables (σ finite, R a commutative ring).",
+      "mathContext": "$k!\\,e_k = \\det T_k$ with $T_k$ Toeplitz in $p_1,\\dots,p_k$."
+    },
+    {
+      "id": "forward",
+      "title": "Forward identities (stepping stones)",
+      "startLine": 65,
+      "endLine": 103,
+      "summary": "psum_one_eq, psum_two_eq, psum_three_eq: the low-degree forward Newton identities reproduced by unrolling Mathlib's recurrence over the omega-computed inner index sets, providing the inputs to be inverted.",
+      "mathContext": "$p_1=e_1,\\ p_2=e_1^2-2e_2,\\ p_3=e_1^3-3e_1e_2+3e_3$."
+    },
+    {
+      "id": "reverse",
+      "title": "Reverse (dual) Newton identities",
+      "startLine": 105,
+      "endLine": 132,
+      "summary": "esymm_one_eq_psum, two_esymm_two, six_esymm_three: each k!·eₖ expressed through the power sums by inverting the forward identities with linear_combination, division-free.",
+      "mathContext": "$e_1=p_1,\\ 2e_2=p_1^2-p_2,\\ 6e_3=p_1^3-3p_1p_2+2p_3$."
+    },
+    {
+      "id": "determinant",
+      "title": "Toeplitz-determinant closed form",
+      "startLine": 134,
+      "endLine": 164,
+      "summary": "esymm_one_det, two_esymm_two_det, six_esymm_three_det: k!·eₖ as the determinant of the lower-Hessenberg Toeplitz matrix in the power sums, expanded via det_fin_one_of/det_fin_two_of/det_fin_three and matched to the scalar reverse identities; plus a Fin 2 / ℤ worked example.",
+      "mathContext": "$3!\\,e_3=\\det\\begin{pmatrix}p_1&1&0\\\\p_2&p_1&2\\\\p_3&p_2&p_1\\end{pmatrix}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "newton-power-sum-identities-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry deriving the forward low-degree Newton identities p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃; this entry inverts them and adds the Toeplitz-determinant closed form."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "relatedTo",
+      "description": "Proves the dual Newton–Girard statement abstractly (power sums and elementary symmetric polynomials generate the same ℚ-subalgebra) and records e₁ = p₁, 2·e₂ = p₁² − p₂; this entry adds the degree-3 identity and the explicit determinant closed form over an arbitrary commutative ring."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) derivation of the reverse Newton identities e₁ = p₁, 2·e₂ = p₁² − p₂, 6·e₃ = p₁³ − 3p₁p₂ + 2p₃ as universal identities in MvPolynomial σ R, together with their Toeplitz-determinant closed form k!·eₖ = det Tₖ for k = 1, 2, 3, all valid over an arbitrary commutative ring.",
+    "implications": "Supplies the explicit reverse (dual) Newton closed forms and, in particular, the determinant expression k!·eₖ = det Tₖ that Mathlib leaves unstated — the computational core of recovering the elementary symmetric polynomials (equivalently, the characteristic-polynomial coefficients) from the power sums (traces of powers).",
+    "openQuestions": [
+      "Prove the degree-4 reverse identity 24·e₄ = p₁⁴ − 6p₁²p₂ + 3p₂² + 8p₁p₃ − 6p₄ and its 4×4 Toeplitz determinant, matching the parent's degree-4 forward identity.",
+      "State and prove the general Toeplitz-determinant closed form k!·eₖ = det Tₖ for all k by induction on the determinant's last-row/Laplace expansion, giving a uniform statement over an arbitrary commutative ring."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Matrix",
+      "MvPolynomial"
+    ],
+    "namespace": "NewtonReverseOQ0102",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "",
+      "note": "Classical source of the identities relating power sums and elementary symmetric polynomials"
+    },
+    {
+      "authors": "Mead, D. G.",
+      "title": "Newton's Identities",
+      "year": "1992",
+      "venue": "The American Mathematical Monthly 99(8), 749–751",
+      "note": "Modern exposition, including the determinant (Toeplitz) closed forms for the elementary symmetric polynomials in terms of power sums"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Recovers a **verified, 0-axiom** gallery entry — `newton-power-sum-identities-oq-01-oq-02` — that already-merged sibling `oq-01-oq-03` references by name as existing, but which never reached `main`.

The original PR (#32851, branch `research/newton-reverse-oq0102-fix`) was based on a badly diverged checkout (26,858 changed files, ~5.1M deletions, `CONFLICTING`/`DIRTY`) and was correctly skipped by the deployer. This PR re-applies **only the two intended artifacts** cleanly onto current `main`:

- `proofs/Proofs/NewtonPowerSumIdentitiesOQ01OQ02.lean` (164 lines, 9 theorems, 0 defs)
- `src/data/proofs/newton-power-sum-identities-oq-01-oq-02/meta.json`

## Mathematics

The **reverse (dual) Newton identities**, expressing each elementary symmetric polynomial through the power sums (division-free, hence valid over an arbitrary `CommRing`):

- `e₁ = p₁`
- `2·e₂ = p₁² − p₂`
- `6·e₃ = p₁³ − 3 p₁ p₂ + 2 p₃`

and their classical **Toeplitz-determinant closed form** `k!·eₖ = det Tₖ` (`k = 1,2,3`), where `Tₖ` is the lower-Hessenberg Toeplitz matrix with the power sums down the first column/diagonals and the integers `1,2,…` on the super-diagonal — the exact shape named in the parent's open question and **absent from Mathlib**.

## Verification status

- `#print axioms` at creation: `propext`, `Classical.choice`, `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`. Hence `status: verified`, `axiomCount: 0`.
- Originally machine-verified via single-file `lake env lean` against **Mathlib v4.26.0** (commit `6d0ee66d29b`, content byte-identical here).
- Current `main` pins the **identical** Mathlib `v4.26.0` and toolchain `leanprover/lean4:v4.26.0` (`lean-toolchain` / `lake-manifest.json` unchanged), so that verification still applies.
- ⚠️ Re-running the Docker build in this environment is blocked by **host-disk exhaustion** (disk 100% full, ~365Mi free; `curl`/containerd I/O errors during the Mathlib cache fetch) — the same infrastructure blocker (#33336) that stopped the original on-disk verification. Recommend a Docker re-verify on a host with free disk before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)