### PR TITLE
Enrich Gauss-identity uniqueness of φ (euler-totient-oq-02-oq-04): full-file section coverage

### DIFF
--- a/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
@@ -4,8 +4,14 @@
   "title": "The Gauss Divisor-Sum Identity Characterizes φ Uniquely",
   "description": "Answers the open question of euler-totient-oq-02 — 'the divisor sum n = Σ_{d|n} φ(d) is dual to multiplicativity; how do these two properties together characterize the totient among multiplicative functions?' — with a sharp, fully verified result that is stronger than asked: the divisor-sum identity ALONE characterizes φ. We prove that any function f : ℕ → ℤ satisfying Σ_{d|n} f(d) = n for all n > 0 must agree with the totient on the positive integers (eq_totient_of_sum_eq); multiplicativity is not even needed for uniqueness. Consequently φ is the unique multiplicative function satisfying Gauss's identity (eq_totient_of_multiplicative_of_sum_eq, the exact form the question asks for), and more precisely the solution set of the identity is exactly {φ}: for any f, the divisor-sum identity holds iff f = φ on the positive integers (sum_eq_iff_eq_totient). The witness that the characterization is non-vacuous is included — φ satisfies both the divisor-sum identity (totient_sum_eq, from Nat.sum_totient) and multiplicativity (totient_multiplicative, from Nat.totient_mul). The uniqueness rests on the invertibility of ζ in the Dirichlet ring (μ ∗ ζ = ε), packaged by Mathlib as Möbius inversion (sum_eq_iff_sum_mul_moebius_eq): both f and φ have the same divisor-sum g = id, so they share the same Möbius-inverse expression and hence coincide. Machine-checked, 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound).",
   "leanFile": {
-    "imports": ["Mathlib.NumberTheory.ArithmeticFunction.Moebius", "Mathlib.Data.Nat.Totient"],
-    "opens": ["Nat", "ArithmeticFunction"],
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Moebius",
+      "Mathlib.Data.Nat.Totient"
+    ],
+    "opens": [
+      "Nat",
+      "ArithmeticFunction"
+    ],
     "namespace": "EulerTotientOQ02OQ04",
     "lineCount": 118,
     "axiomCount": 0,
@@ -56,7 +62,12 @@
     ],
     "mathlib_version": "4.26.0",
     "lineCount": 118,
-    "relatedProblems": ["euler-totient", "euler-totient-oq-02", "euler-totient-oq-04", "euler-totient-oq-04-oq-02"],
+    "relatedProblems": [
+      "euler-totient",
+      "euler-totient-oq-02",
+      "euler-totient-oq-04",
+      "euler-totient-oq-04-oq-02"
+    ],
     "theoremCount": 5,
     "definitionCount": 0
   },
@@ -90,6 +101,14 @@
     }
   ],
   "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: The Gauss Divisor-Sum Determines φ Uniquely",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "The docstring states the two structural properties of Euler's totient — Gauss's divisor-sum identity Σ_{d|n} φ(d) = n (i.e. φ∗ζ = id) and multiplicativity φ(mn)=φ(m)φ(n) for coprime m,n — and sharpens the open question: the divisor-sum identity ALONE pins the function down. Any f:ℕ→ℤ with Σ_{d|n} f(d) = n must equal φ on the positive integers, so φ is the unique multiplicative (indeed unique arbitrary) function satisfying Gauss's identity. The proof instantiates Mathlib's Möbius-inversion equivalence sum_eq_iff_sum_mul_moebius_eq at g = id: both f and φ share the divisor-sum id, so both equal the single Möbius-inverted expression. Imports Moebius and Totient, opens Nat/ArithmeticFunction, sets up namespace EulerTotientOQ02OQ04.",
+      "mathContext": "$\\big(\\forall n>0,\\ \\sum_{d\\mid n} f(d)=n\\big) \\Rightarrow f=\\varphi$ on positives, via $\\mu\\ast\\zeta=\\varepsilon$ (Möbius inversion)."
+    },
     {
       "id": "witness",
       "title": "φ Realizes Both Characterizing Properties",


### PR DESCRIPTION
Enrichment pass for **euler-totient-oq-02-oq-04**.

## Gap addressed
The `sections` array left the opening docstring/setup (the file's context, statement, and imports) outside any section — the sole quality gap on this q91 entry. Added an accurate leading **Overview** section so `sections` now span the full Lean file.

## Change (meta.json only)
- Added a leading "Overview" section summarizing the parent context, what the file proves, and the setup. Sections: 3 → 4, now covering line 1 onward.

`annotations.json` unchanged. No mathematical claims altered; `status`/`badge`/`axiomCount` untouched. meta.json well under the 60 KB cap.
