### PR TITLE
Enrich (ℤ/2ᵏ)ˣ direct-product structure (euler-totient-oq-01-oq-02-oq-03): full-file section coverage

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
@@ -90,6 +90,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: (ℤ/2ᵏℤ)ˣ as the Internal Direct Product ⟨-1⟩ × ⟨5⟩",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "The docstring situates this against parent EulerTotientOQ01OQ02, which records λ(2ᵏ) = 2ᵏ⁻² for k ≥ 3 from Mathlib. What Mathlib does not package — and what explains that value — is the structure theorem proved here: (ℤ/2ᵏℤ)ˣ is the internal direct product of the order-2 subgroup ⟨-1⟩ and the cyclic ⟨5⟩ of order 2ᵏ⁻², i.e. ≅ ℤ/2 × ℤ/2ᵏ⁻², from which λ(2ᵏ) = lcm(2, 2ᵏ⁻²) = 2ᵏ⁻² follows. The genuinely non-Mathlib crux is -1 ∉ ⟨5⟩, proved by reduction mod 4 (every power of 5 is ≡ 1 (mod 4), while -1 ≡ 3), plus an order count giving the IsComplement' decomposition. Exponents are kept subtraction-free by parametrising k = n + 3. Lists the seven key results (five, orderOf_five, orderOf_neg_one, neg_one_notMem_zpowers_five, disjoint_neg_one_five, isComplement'_neg_one_five, carmichael_two_pow) and references Ireland & Rosen. Imports UnitsCyclic, Carmichael, Tactic; namespace EulerTotientOQ01OQ02OQ03.",
+      "mathContext": "$(\\mathbb Z/2^k\\mathbb Z)^\\times \\cong \\langle -1\\rangle \\times \\langle 5\\rangle \\cong \\mathbb Z/2 \\times \\mathbb Z/2^{k-2}$, whose exponent recovers $\\lambda(2^k)=2^{k-2}$; the crux is $-1\\notin\\langle 5\\rangle$ via reduction mod 4."
+    },
+    {
       "id": "generators",
       "title": "Section I: The Two Generators and Their Orders",
       "startLine": 66,


### PR DESCRIPTION
Enrichment pass for **euler-totient-oq-01-oq-02-oq-03**.

## Gap addressed
The `sections` array did not span the full Lean file — the opening docstring/setup (and, where present, the trailing summary / `#check` block) were annotated but outside any section. Added accurate section(s) so `sections` now cover the whole file; the sole quality gap on this entry.

## Change (meta.json only)
- Added leading Overview (and where applicable a trailing) section summarizing the parent context, what the file proves, and the setup. Sections now cover line 1 to end.

`annotations.json` unchanged. No mathematical claims altered; `status`/`badge`/`axiomCount` untouched. meta.json well under the 60 KB cap.
