### PR TITLE
Enrich Reverse Newton Identities (newton-power-sum-identities-oq-01-oq-02): annotation coverage

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "npsi-oq0102-forward-deg2",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 66, "endLine": 77 },
+    "type": "technique",
+    "title": "Unrolling the Newton recurrence at k = 2",
+    "content": "The forward identity p₂ = e₁² − 2e₂ is recovered from Mathlib's recurrence `psum_eq_mul_esymm_sub_sum`. The only work is evaluating that recurrence's inner sum, which runs over the filtered antidiagonal {a ∈ antidiagonal 2 | a.1 ∈ Ioo 0 2}. The `ext`/`simp`/`omega` block proves this index set is the singleton {(1,1)}, after which `Finset.sum_singleton` collapses the sum and `push_cast; ring` finishes. Reproving p₂ here (rather than importing it) keeps the file self-contained and supplies exactly the stepping stone the reverse identities invert.",
+    "mathContext": "$p_2 = e_1^2 - 2e_2$, with the recurrence's inner sum $\\sum_{0<i<2} (-1)^i e_i p_{2-i}$ ranging over $\\{(1,1)\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Newton's identities", "power sums", "elementary symmetric polynomials", "Finset.antidiagonal"],
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "Finset filtering", "omega decision procedure"]
+  },
+  {
+    "id": "npsi-oq0102-forward-deg3",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 91 },
+    "type": "technique",
+    "title": "The degree-3 forward identity over a two-element index set",
+    "content": "At k = 3 the recurrence's inner sum ranges over {(1,2), (2,1)} — a two-element set, so `Finset.sum_pair` replaces `Finset.sum_singleton`. `sum_pair` requires the two indices to be distinct, discharged by `decide` on (1,2) ≠ (2,1) (a kernel reduction, introducing no `Lean.ofReduceBool`, so axiom-freeness is preserved). Substituting the already-proved p₂ and p₁ then `push_cast; ring` yields p₃ = e₁³ − 3e₁e₂ + 3e₃. Note the coefficient 3 on e₃ here; the reverse direction will have to clear it to 6.",
+    "mathContext": "$p_3 = e_1^3 - 3e_1 e_2 + 3e_3$, inner sum over $\\{(1,2),(2,1)\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Newton's identities", "Finset.sum_pair", "decide", "power sums"],
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "Finset.sum_pair"]
+  },
+  {
+    "id": "npsi-oq0102-reverse-deg1",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 99, "endLine": 101 },
+    "type": "insight",
+    "title": "Degree-1 reverse identity: e₁ = p₁",
+    "content": "The first reverse identity is literally the forward one read backwards: `esymm_one_eq_psum` is just `(psum_one_eq σ R).symm`. At degree 1 the factorial normalisation is 1! = 1, so no scaling is needed and elementary symmetric polynomial e₁ equals power sum p₁ on the nose. This is the base case of the k!·eₖ pattern that the higher degrees make visible.",
+    "mathContext": "$e_1 = p_1$ (equivalently $1!\\,e_1 = p_1$).",
+    "significance": "key",
+    "relatedConcepts": ["reverse Newton identities", "power sums", "elementary symmetric polynomials"],
+    "prerequisites": ["MvPolynomial.psum_one", "MvPolynomial.esymm_one"]
+  },
+  {
+    "id": "npsi-oq0102-reverse-deg2",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 107 },
+    "type": "insight",
+    "title": "Inverting to 2·e₂ = p₁² − p₂ without division",
+    "content": "Solving the forward identity p₂ = e₁² − 2e₂ for e₂ gives e₂ = (e₁² − p₂)/2 = (p₁² − p₂)/2 over a field. Multiplying through by 2 removes the denominator: 2·e₂ = p₁² − p₂. The Lean proof rewrites e₁ to p₁ via `psum_one_eq` and closes with `linear_combination psum_two_eq σ R` — a pure ring rearrangement, so the identity holds in `MvPolynomial σ R` over ANY commutative ring, not merely a ℚ-algebra.",
+    "mathContext": "$2e_2 = p_1^2 - p_2$ (the factor 2 = 2! clears the inversion denominator).",
+    "significance": "key",
+    "relatedConcepts": ["reverse Newton identities", "linear_combination", "integrality over commutative rings"],
+    "prerequisites": ["forward degree-2 identity", "linear_combination tactic"]
+  },
+  {
+    "id": "npsi-oq0102-reverse-deg3",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 109, "endLine": 118 },
+    "type": "insight",
+    "title": "The factor 6 = 3! and the linear_combination coefficient −2",
+    "content": "Inverting the degree-3 forward identity (whose e₃ coefficient is 3) requires clearing that 3 to the normalised 3! = 6. After substituting the lower power sums via `rw [h2, h1]`, the goal is closed by `linear_combination (-2) * h3`: multiplying the forward identity p₃ = e₁³ − 3e₁e₂ + 3e₃ by −2 turns 3·e₃ into −6·e₃, which exactly balances the 6·e₃ on the goal's left with only integer arithmetic. The result 6·e₃ = p₁³ − 3p₁p₂ + 2p₃ is the entry's headline new identity, absent from Mathlib.",
+    "mathContext": "$6e_3 = p_1^3 - 3p_1 p_2 + 2p_3$; coefficient $-2$ maps $3e_3 \\mapsto -6e_3$.",
+    "significance": "key",
+    "relatedConcepts": ["reverse Newton identities", "linear_combination", "factorial normalisation"],
+    "prerequisites": ["forward degree-3 identity", "linear_combination tactic"]
+  },
+  {
+    "id": "npsi-oq0102-det-deg2",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 131, "endLine": 137 },
+    "type": "concept",
+    "title": "Toeplitz determinant, degree 2: det via det_fin_two_of",
+    "content": "The 2×2 case exhibits the classical closed form 2!·e₂ = det [[p₁, 1], [p₂, p₁]]. `Matrix.det_fin_two_of` expands the determinant to p₁·p₁ − 1·p₂ = p₁² − p₂, and `linear_combination two_esymm_two σ R` matches it to the already-proved scalar reverse identity. No general determinant theory is used — the whole equality reduces to one ring identity. The super-diagonal entry 1 is what makes the determinant equal 2!·e₂ rather than something else.",
+    "mathContext": "$2!\\,e_2 = \\det\\begin{pmatrix} p_1 & 1 \\\\ p_2 & p_1 \\end{pmatrix} = p_1^2 - p_2$.",
+    "significance": "key",
+    "relatedConcepts": ["Toeplitz matrix", "lower-Hessenberg matrix", "Le Verrier–Faddeev algorithm", "characteristic polynomial"],
+    "prerequisites": ["Matrix.det_fin_two_of", "reverse degree-2 identity"]
+  },
+  {
+    "id": "npsi-oq0102-det-deg3",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 139, "endLine": 149 },
+    "type": "concept",
+    "title": "Toeplitz determinant, degree 3: Sarrus expansion",
+    "content": "The 3×3 closed form 3!·e₃ = det [[p₁,1,0],[p₂,p₁,2],[p₃,p₂,p₁]] is proved by `Matrix.det_fin_three` (Sarrus' rule), followed by a `simp only` over the matrix cons-indexing lemmas to evaluate each `!![…]` entry, then `linear_combination six_esymm_three σ R`. The super-diagonal integers 1 and 2 encode the recurrence's k-factors; with them the determinant equals exactly 6·e₃ = p₁³ − 3p₁p₂ + 2p₃. This determinant shape is the object named in the parent's open question and is what Mathlib leaves unstated.",
+    "mathContext": "$3!\\,e_3 = \\det\\begin{pmatrix} p_1 & 1 & 0 \\\\ p_2 & p_1 & 2 \\\\ p_3 & p_2 & p_1 \\end{pmatrix} = p_1^3 - 3p_1 p_2 + 2p_3$.",
+    "significance": "key",
+    "relatedConcepts": ["Toeplitz matrix", "Sarrus' rule", "Matrix.det_fin_three", "lower-Hessenberg determinant"],
+    "prerequisites": ["Matrix.det_fin_three", "matrix cons-indexing simp lemmas", "reverse degree-3 identity"]
+  },
+  {
+    "id": "npsi-oq0102-worked-example",
+    "proofId": "newton-power-sum-identities-oq-01-oq-02",
+    "range": { "startLine": 151, "endLine": 162 },
+    "type": "context",
+    "title": "Concrete specialisation to Fin 2 over ℤ",
+    "content": "The final `example` instantiates the degree-2 determinant identity at the two-variable, integer case σ = Fin 2, R = ℤ, confirming the universal statement lands on the familiar formula 2·X₀X₁ = (X₀+X₁)² − (X₀²+X₁²). Because the general theorem already holds over an arbitrary commutative ring, this specialisation is a one-line application `two_esymm_two_det (Fin 2) ℤ` — a sanity anchor rather than new content.",
+    "mathContext": "Over $\\sigma = \\mathrm{Fin}\\,2,\\ R = \\mathbb{Z}$: $2e_2 = 2X_0X_1 = p_1^2 - p_2$.",
+    "significance": "context",
+    "relatedConcepts": ["symmetric polynomials", "specialisation", "worked example"],
+    "prerequisites": ["two_esymm_two_det"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `newton-power-sum-identities-oq-01-oq-02` (The Reverse Newton Identities and their Toeplitz-Determinant Closed Form).

**Gap addressed:** the entry had a rich `meta.json` (historicalContext, keyInsights, conclusion, sections) but **no `annotations.json`** — annotation coverage scored 0.

**Added `annotations.json` with 8 line-anchored annotations** covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- Forward degree-2 stepping stone (unrolling Mathlib's `psum_eq_mul_esymm_sub_sum` over the singleton index set {(1,1)})
- Forward degree-3 (two-element set {(1,2),(2,1)}, `Finset.sum_pair` + `decide`)
- Reverse degree-1 `e₁ = p₁` (1! base case)
- Reverse degree-2 `2·e₂ = p₁² − p₂` (division-free inversion over any commutative ring)
- Reverse degree-3 `6·e₃ = p₁³ − 3p₁p₂ + 2p₃` (the `linear_combination (-2)` clearing 3·e₃ → 6·e₃)
- Toeplitz determinant degree-2 (`det_fin_two_of`) and degree-3 (Sarrus / `det_fin_three`) closed forms
- Concrete Fin 2 / ℤ worked example

All ranges validated against the Lean source via `scripts/annotations/build.ts --strict` (0 errors for this slug). `meta.json` unchanged; `status`/`badge`/`axiomCount` (verified/mathlib/0) accurately reflect the source (single `decide` is kernel reduction, no `Lean.ofReduceBool`).
