### PR TITLE
Enrich F₂₀ as an Explicit Permutation Group (inverse-galois-f20-oq-02): add annotations

### DIFF
--- a/src/data/proofs/inverse-galois-f20-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-f20-oq-02/annotations.json
@@ -1,0 +1,221 @@
+[
+  {
+    "id": "ann-igf20oq02-overview",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 32
+    },
+    "type": "concept",
+    "title": "The Concrete Permutation Model of F₂₀ = AGL(1, 𝔽₅)",
+    "content": "The Galois group of X⁵−2 acts on the five roots α·ζ₅ᵏ; labelling each root by its exponent k ∈ Fin 5 = 𝔽₅ turns that action into the affine group AGL(1,𝔽₅) = {x ↦ a·x + b : a ∈ 𝔽₅ˣ, b ∈ 𝔽₅}, the Frobenius group F₂₀ = C₅ ⋊ C₄. This file makes that abstract description literal: it exhibits two explicit permutations of Fin 5 — the translation σ : x ↦ x+1 and the multiplication τ : x ↦ 2x — and proves entirely by `decide` and elementary group calculation that ⟨σ,τ⟩ has order exactly 20 and acts transitively. It is the concrete counterpart to the sibling entry `inverse-galois-f20`, which computes |Gal(X⁵−2/ℚ)| = 20 abstractly through Galois theory.",
+    "mathContext": "\\mathrm{AGL}(1,\\mathbb{F}_5) = \\{x \\mapsto ax+b : a \\in \\mathbb{F}_5^\\times,\\ b \\in \\mathbb{F}_5\\} \\cong C_5 \\rtimes C_4 = F_{20}, \\qquad |F_{20}| = 5 \\cdot 4 = 20.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Frobenius group",
+      "affine group AGL(1,q)",
+      "semidirect product",
+      "inverse Galois problem",
+      "group action on roots"
+    ],
+    "prerequisites": [
+      "Galois theory of radical extensions",
+      "semidirect products",
+      "permutation groups"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-sigma",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 38,
+      "endLine": 40
+    },
+    "type": "technical",
+    "title": "σ: The Translation x ↦ x+1 as an Explicit 5-Cycle",
+    "content": "σ is built directly as an `Equiv.Perm (Fin 5)` from its one-line table ![1,2,3,4,0] and inverse ![4,0,1,2,3], with the two round-trip identities discharged by `decide`. As a permutation it is the 5-cycle (0 1 2 3 4). On the roots of X⁵−2 this is multiplication by the primitive 5th root of unity ζ₅ (it sends α·ζ₅ᵏ to α·ζ₅ᵏ⁺¹), the generator of the normal cyclic subgroup C₅ of the Frobenius group. Encoding the map by its explicit array is what makes every downstream relation decidable.",
+    "mathContext": "\\sigma : x \\mapsto x + 1 \\pmod 5, \\qquad \\sigma = (0\\ 1\\ 2\\ 3\\ 4), \\qquad \\text{on roots: } \\alpha\\zeta_5^k \\mapsto \\alpha\\zeta_5^{k+1}.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic permutation",
+      "primitive root of unity",
+      "Equiv.Perm",
+      "one-line notation"
+    ],
+    "prerequisites": [
+      "permutations of a finite set",
+      "roots of unity",
+      "decidable equality on Fin n"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-tau",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 44
+    },
+    "type": "technical",
+    "title": "τ: Multiplication by 2 as an Explicit 4-Cycle",
+    "content": "τ is the permutation x ↦ 2x on Fin 5 = 𝔽₅, with table ![0,2,4,1,3]: it fixes 0 and cycles the four nonzero residues as (1 2 4 3), since 2 is a primitive root modulo 5 (its powers 2,4,3,1 run through 𝔽₅ˣ). This is the Frobenius/Galois automorphism ζ₅ ↦ ζ₅² acting on the exponents, and it generates the complementary cyclic group C₄ acting on C₅. The choice of the multiplier 2 (rather than 3) is exactly the choice of a generator of the cyclic group 𝔽₅ˣ ≅ C₄.",
+    "mathContext": "\\tau : x \\mapsto 2x \\pmod 5, \\qquad \\tau = (1\\ 2\\ 4\\ 3), \\qquad \\langle 2 \\rangle = \\mathbb{F}_5^\\times \\cong C_4.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative group of a finite field",
+      "primitive root modulo p",
+      "Frobenius automorphism",
+      "4-cycle"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "cyclic structure of 𝔽ₚˣ",
+      "permutations"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-rel",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 46,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "The Defining Relation τστ⁻¹ = σ² and the Generator Powers",
+    "content": "The four `decide` lemmas (sigma_pow_five, sigma_ne_one, tau_sq_ne_one, tau_pow_four) pin down that σ⁵ = 1 with σ ≠ 1, and τ⁴ = 1 with τ² ≠ 1. The centerpiece is `rel : τ * σ * τ⁻¹ = σ²`: conjugating the translation by the multiplier squares it, because (2x) ↦ conjugation by ‘×2’ turns ‘+1’ into ‘+2’ = ‘+1’ twice. This single relation is the entire content of the semidirect product C₅ ⋊ C₄: it says C₄ acts on C₅ through the automorphism x ↦ 2x of ℤ/5, whose multiplicative order is 4. Everything about the group's size flows from it.",
+    "mathContext": "\\tau\\sigma\\tau^{-1} = \\sigma^2, \\qquad \\sigma^5 = 1,\\ \\tau^4 = 1, \\qquad \\text{the action } C_4 \\to \\operatorname{Aut}(C_5),\\ \\tau \\mapsto (x \\mapsto 2x),\\ \\text{ord} = 4.",
+    "significance": "key",
+    "relatedConcepts": [
+      "semidirect product",
+      "conjugation and normal subgroups",
+      "group presentation",
+      "Aut(C₅) ≅ C₄",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "conjugation in groups",
+      "automorphisms of cyclic groups",
+      "order of a group element"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-orders",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 71
+    },
+    "type": "technical",
+    "title": "orderOf σ = 5 and orderOf τ = 4 from Prime-Power Order Lemmas",
+    "content": "Rather than compute orders by brute enumeration, the proof upgrades the `decide` facts through Mathlib's prime-order machinery. `orderOf_eq_prime` turns σ⁵ = 1 together with σ ≠ 1 into orderOf σ = 5 (a nonidentity element whose p-th power is 1 has order exactly the prime p). For τ, `orderOf_eq_prime_pow` uses τ^(2²) = 1 with τ^(2¹) ≠ 1 to conclude orderOf τ = 2² = 4. These two coprime orders 5 and 4 are precisely what forces |⟨σ,τ⟩| to be divisible by 20.",
+    "mathContext": "\\text{orderOf }\\sigma = 5 \\text{ (prime, } \\sigma^5=1,\\ \\sigma\\neq 1), \\qquad \\text{orderOf }\\tau = 4 = 2^2 \\text{ (prime power, } \\tau^{4}=1,\\ \\tau^{2}\\neq 1).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "order of an element",
+      "orderOf_eq_prime",
+      "orderOf_eq_prime_pow",
+      "coprimality"
+    ],
+    "prerequisites": [
+      "Lagrange's theorem",
+      "prime and prime-power orders",
+      "Fact typeclass for primality"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-commutation",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 105
+    },
+    "type": "insight",
+    "title": "The Semidirect Commutation Law τⁿ σᵐ = σ^(2ⁿ·m) τⁿ",
+    "content": "This is the algebraic engine that later bounds the group's size. The base case `tau_sigma_pow` rewrites the defining relation as τσ = σ²τ and inducts on m to get τσᵐ = σ^(2m)τ. Then `tau_pow_sigma_pow` inducts on n: moving τⁿ to the right past σᵐ multiplies the exponent of σ by 2ⁿ, giving τⁿσᵐ = σ^(2ⁿ·m)τⁿ — exactly the multiplication rule of the semidirect product C₅ ⋊ C₄ where C₄ acts by ×2. Because it lets any word in σ and τ be rewritten into normal form σⁱτʲ, this law makes the subgroup a finite, enumerable set.",
+    "mathContext": "\\tau^n \\sigma^m = \\sigma^{2^n m}\\, \\tau^n, \\qquad \\text{so } (\\sigma^i\\tau^j)(\\sigma^k\\tau^l) = \\sigma^{i + 2^j k}\\,\\tau^{j+l}.",
+    "significance": "key",
+    "relatedConcepts": [
+      "normal form in a semidirect product",
+      "induction on exponents",
+      "conjugation action",
+      "group multiplication rule"
+    ],
+    "prerequisites": [
+      "induction",
+      "manipulating group words",
+      "semidirect product multiplication"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-subgroup",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 149
+    },
+    "type": "technical",
+    "title": "F20 as the Explicit Set {σⁱτʲ} and Its Closure Property",
+    "content": "F20 is defined as a genuine `Subgroup (Perm (Fin 5))` whose carrier is {g | ∃ i j, g = σⁱτʲ}. Verifying it is a subgroup is where the commutation law pays off: closure under multiplication reduces (σⁱτʲ)(σᵏτˡ) = σ^(i+2ʲk) τ^(j+l) via `tau_pow_sigma_pow`, and closure under inverses uses σ⁻¹ = σ⁴ and τ⁻¹ = τ³ (from σ⁵ = 1, τ⁴ = 1) to write the inverse again in σⁱτʲ form. The lemma `closure_eq` then proves F20 = Subgroup.closure {σ,τ}: every generator lies in F20, and every σⁱτʲ lies in the abstract closure, so the concrete set and the generated subgroup coincide.",
+    "mathContext": "F_{20} = \\{\\sigma^i\\tau^j : i,j \\in \\mathbb{N}\\} = \\langle \\sigma, \\tau\\rangle, \\qquad \\sigma^{-1} = \\sigma^4,\\ \\tau^{-1} = \\tau^3.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subgroup generated by a set",
+      "Subgroup.closure",
+      "normal form",
+      "closure under products and inverses"
+    ],
+    "prerequisites": [
+      "subgroup axioms",
+      "Subgroup.closure in Mathlib",
+      "inverses via finite order"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-card",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 151,
+      "endLine": 182
+    },
+    "type": "insight",
+    "title": "Main Result: |F₂₀| = 20 via a Two-Sided Bound",
+    "content": "The order is squeezed to exactly 20. Upper bound: the surjection (i,j) ↦ σⁱτʲ from Fin 5 × Fin 4 onto F20 — well-defined because σ and τ have orders 5 and 4, so exponents reduce mod 5 and mod 4 (`pow_mod_orderOf`) — gives |F20| ≤ |Fin 5 × Fin 4| = 20. Lower bound: σ ∈ F20 forces 5 ∣ |F20| and τ ∈ F20 forces 4 ∣ |F20| (via `Subgroup.orderOf_dvd_natCard`), and since gcd(5,4)=1, their product 20 ∣ |F20|. Combining, 20 ≤ |F20| ≤ 20. `card_closure_eq_20` restates this for Subgroup.closure {σ,τ}.",
+    "mathContext": "|F_{20}| \\le |\\mathrm{Fin}\\,5 \\times \\mathrm{Fin}\\,4| = 20 \\quad\\text{and}\\quad 5 \\mid |F_{20}|,\\ 4 \\mid |F_{20}|,\\ \\gcd(5,4)=1 \\Rightarrow 20 \\mid |F_{20}| \\;\\Rightarrow\\; |F_{20}| = 20.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "counting via surjection",
+      "coprime divisibility",
+      "Nat.card of a subgroup",
+      "pow_mod_orderOf"
+    ],
+    "prerequisites": [
+      "cardinality bounds from surjections",
+      "order divides group order",
+      "coprime integers"
+    ]
+  },
+  {
+    "id": "ann-igf20oq02-transitive",
+    "proofId": "inverse-galois-f20-oq-02",
+    "range": {
+      "startLine": 184,
+      "endLine": 192
+    },
+    "type": "insight",
+    "title": "Transitivity: The Translation Alone Reaches Every Root",
+    "content": "The action of F20 on the five roots is transitive: for any target x ∈ Fin 5, the element σˣ ∈ F20 already sends 0 to x, since σ is the translation +1 and σˣ(0) = x. The proof supplies the explicit witness σ^(x) with membership certificate ⟨x,0,rfl⟩ and finishes with `fin_cases x <;> decide`. Transitivity confirms this is the full geometric symmetry group of the five roots of X⁵−2, not a smaller intransitive subgroup — consistent with F₂₀ being the Galois group of an irreducible quintic.",
+    "mathContext": "\\forall x \\in \\mathrm{Fin}\\,5,\\ \\exists g \\in F_{20},\\ g(0) = x; \\quad \\text{take } g = \\sigma^x,\\ \\sigma^x(0) = x.",
+    "significance": "key",
+    "relatedConcepts": [
+      "transitive group action",
+      "orbit of a point",
+      "irreducibility and transitivity",
+      "fin_cases"
+    ],
+    "prerequisites": [
+      "group actions and orbits",
+      "transitivity",
+      "Galois group of an irreducible polynomial"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment: inverse-galois-f20-oq-02

Added `annotations.json` (was absent on `main`) — 9 inline annotations giving full line coverage (L3–192) of `InverseGaloisF20OQ02.lean`, the explicit permutation model of the Frobenius group F₂₀ = AGL(1,𝔽₅) on the five roots of X⁵−2.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Overview — the AGL(1,𝔽₅) = C₅⋊C₄ model
2. σ — translation x↦x+1 as the 5-cycle (0 1 2 3 4)
3. τ — multiplication x↦2x as the 4-cycle (1 2 4 3)
4. The defining relation τστ⁻¹ = σ² and generator powers
5. orderOf σ = 5, orderOf τ = 4 via prime/prime-power lemmas
6. The semidirect commutation law τⁿσᵐ = σ^(2ⁿm)τⁿ
7. F20 as the explicit set {σⁱτʲ} and closure_eq
8. Main result |F₂₀| = 20 via a two-sided (surjection + coprime-divisibility) bound
9. Transitivity of the action on the five roots

No changes to `meta.json` or the Lean source. JSON validated; ranges within the 194-line file.
