### PR TITLE
Enrich Bounding Number Lower Bound ℵ₁ ≤ 𝔟 (continuum-hypothesis-oq-02-oq-01): full section coverage

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02-oq-01/meta.json
@@ -80,6 +80,14 @@
   },
   "sections": [
     {
+      "id": "ch-oq0201-overview",
+      "title": "Overview: Discharging the ℵ₁ ≤ 𝔟 Axiom of the Parent Entry",
+      "summary": "Header, imports, and orientation. The companion continuum-hypothesis-oq-02 established the ZFC chain ℵ₁ ≤ 𝔟 ≤ 𝔡 ≤ 2^ℵ₀ but left the lower bound ℵ₁ ≤ 𝔟 as an axiom (bounding_number_uncountable). This file discharges that axiom using Mathlib alone, via the classical Hausdorff diagonalization: a countable family {f₀,f₁,…} : ℕ → ℕ is dominated by its diagonal g(k) = max_{i≤k} fᵢ(k) + 1, so no countable family is unbounded, hence every unbounded family is uncountable and 𝔟 ≥ ℵ₁. The header also records the sharp general König constraint κ < cf(2^κ) and lists the exact Mathlib lemmas consumed (lt_cof_power, countable_iff_lt_aleph_one, Set.Countable.exists_eq_range, cantor, succ_aleph0, Finset.le_sup).",
+      "startLine": 1,
+      "endLine": 68,
+      "mathContext": "Goal: $\\aleph_1 \\le \\mathfrak{b}$ where $\\mathfrak{b}$ is the least cardinality of a $\\le^*$-unbounded family in ${}^{\\mathbb N}\\mathbb N$. Diagonal witness: $g(k) = 1 + \\max_{i \\le k} f_i(k)$ eventually dominates every $f_i$, so any $\\le^*$-unbounded family is uncountable."
+    },
+    {
       "id": "ch-oq0201-defs",
       "title": "Part 0: Eventual Domination and the Cardinal Characteristics",
       "summary": "Inlines the definitions matching continuum-hypothesis-oq-02: eventuallyDominates f g (f ≤* g), IsUnbounded F (no g dominates every member), and the bounding number boundingNumber = ⨅_F (if IsUnbounded F then #F else 2^ℵ₀), whose fallback branch keeps 𝔟 ≤ 2^ℵ₀.",


### PR DESCRIPTION
## Enrichment: continuum-hypothesis-oq-02-oq-01 — full section coverage

The `sections` array began at line 70, leaving the module docstring, imports, and namespace setup (lines 1–68) with no coverage in the section-navigation panel. Added a leading **Overview** section (L1–68) summarizing the file's goal — discharging the parent entry's `bounding_number_uncountable` axiom (ℵ₁ ≤ 𝔟) via Hausdorff diagonalization — plus the sharp König constraint and the exact Mathlib lemmas used.

Sections now span the full 194-line file (5 sections). Only `meta.json` changed; Lean source untouched. JSON validated.
