### PR TITLE
Enrich chinese-remainder-constructive-oq-03-oq-02: add head Overview section covering docstring/setup

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
@@ -40,6 +40,13 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: The Balanced Three-Moduli RNS Set {2ⁿ−1, 2ⁿ, 2ⁿ+1}",
+      "startLine": 1,
+      "endLine": 89,
+      "summary": "Module docstring, import Mathlib, and setup (namespace RNSThreeModuli, open Nat). OQ-03-OQ-02 asks which concrete RNS base is the canonical 'most efficient' choice for computer arithmetic. The parent formalizes general RNS efficiency criteria and siblings cover prime-base optimality (OQ-03-OQ-01) and a single power-of-2 channel (OQ-03-OQ-03); none formalize the single most-cited hardware base, the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1} (Soderstrand 1986) — three ~n-bit channels giving ~3n-bit dynamic range, two admitting trivial modular reduction. This file delivers, 0-axiom/0-sorry: pairwise coprimality, the exact range formula (2ⁿ−1)·2ⁿ·(2ⁿ+1)=2^(3n)−2ⁿ, a genuine RNSBase instance, a balance bound, the CRT reconstruction step, and concrete cross-checks for n=2,3,4. Section VI adds the four-moduli extension governed by a parity dichotomy: the admissible extra (n+1)-bit modulus flips with the parity of n, the obstruction being divisibility by 3 (controlled by 2ⁿ mod 3). Constructive characterization only — it does not claim global optimality (the open parent question)."
+    },
+    {
       "id": "coprimality",
       "title": "Pairwise Coprimality of the Three Moduli",
       "startLine": 90,


### PR DESCRIPTION
## Enrichment: chinese-remainder-constructive-oq-03-oq-02

The six existing sections began at Lean line 90, leaving lines 1–89 (module docstring, `import Mathlib`, `namespace RNSThreeModuli`, `open Nat`) uncovered by the section walkthrough.

This adds a head **Overview** section (lines 1–89) framing the file: OQ-03-OQ-02 formalises the balanced three-moduli RNS set `{2ⁿ−1, 2ⁿ, 2ⁿ+1}` — pairwise coprimality, the exact dynamic-range formula, an `RNSBase` instance, the CRT reconstruction step, and the four-moduli parity dichotomy — a constructive characterisation that does not claim global optimality.

No proof/source changes; sections re-sorted by `startLine`. JSON validated.
