### PR TITLE
Enrich synthesis-curvature-ptolemy-oq-03: add head Overview section covering imports/docstring

### DIFF
--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-03/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-03/meta.json
@@ -40,6 +40,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Joint Continuity of curvatureSin Across the Curvature Seam",
+      "startLine": 1,
+      "endLine": 87,
+      "summary": "Imports (trig/hyperbolic derivatives, slope, order topology, Real.sqrt, Mathlib.Tactic) and module docstring. The parent SynthesisCurvaturePtolemy.lean defines curvatureSin K t — equal to t (Euclidean K=0), sin(√K·t)/√K (spherical K>0), sinh(√(−K)·t)/√(−K) (hyperbolic K<0) — unifying the three constant-curvature geometries, and proves properties for fixed K. This OQ-03 entry proves the JOINT continuity of (K,t) ↦ curvatureSin K t as ℝ×ℝ → ℝ: there is no discontinuity at the Euclidean seam K=0, even though the formula switches there between sin and sinh. The proof factors the seam into one real variable via the even curvature sinc and the identity curvatureSin K t = t·curvatureSinc(K·t²), then handles the seam by gluing the two one-sided limits (both →1, from HasDerivAt.tendsto_slope for sin/sinh at 0) via 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0. 0 sorries, 0 axioms.",
+      "mathContext": "Mathlib supplies continuous_sin, continuous_sinh, Real.continuous_sqrt, the slope characterisation, and the order-topology gluing lemmas, but has no curvatureSin/curvatureSinc; the new content is the single-variable factorisation curvatureSin_eq, continuity of curvatureSinc (seam included), and the joint continuity continuous_curvatureSin."
+    },
+    {
       "title": "curvatureSin and the curvature sinc",
       "startLine": 88,
       "endLine": 144,


### PR DESCRIPTION
## Enrichment: synthesis-curvature-ptolemy-oq-03

The existing sections began at Lean line 88, leaving lines 1–87 (imports and the module docstring) uncovered by the section walkthrough.

This adds a head **Overview** section (lines 1–87) framing the file: OQ-03 proves the *joint* continuity of `(K,t) ↦ curvatureSin K t` across the Euclidean seam `K = 0`, via the single-variable factorisation `curvatureSin K t = t·curvatureSinc(K·t²)` and a slope-to-derivative gluing of the two one-sided limits.

No proof/source changes; sections re-sorted by `startLine`. JSON validated.
