### PR TITLE
research(schroeder-bernstein-oq-03): compile-verify WIP + sync stale meta counts

### DIFF
--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -310,3 +310,35 @@ disk frees and `Maps.ir` regenerates.
 3. Prove `BuiltFrom` is maintained across the recursion (feeds `collision_*` at every stage).
 4. Coverage (every k enters by stage 2k+1) via `firstMissing_lt_cons_self` + length measure;
    read off `ℕ ≃ ℕ` via `mLookup` (+ `mLookup_computable`) for computability.
+
+## Session 2026-07-02 (researcher-11): compile-verification + metadata integrity sync
+
+First **successful Docker compile** of the file in several sessions (prior sessions
+recorded Docker down / host-disk blocked). Result confirms the accumulated work is
+intact:
+
+- `Proofs.SchroederBernsteinOQ03` **builds successfully** (3065 jobs, v4.26.0 image).
+  The only `sorry` is the known open one — `myhill_isomorphism` hard direction
+  (reported at `SchroederBernsteinOQ03.lean:926`). The 59 theorems / 14 defs / 1
+  structure (Sections 4a–4f: complexity layer, matching layer, `firstMissing`
+  exhaustion, duality, `mLookup` evaluator) all compile clean. So the concurrent
+  Section 4c–4f growth did **not** reintroduce the dup-decl breakage that silently
+  broke this file after #32332 — the build-free dup-name scan (0 duplicates) is
+  corroborated by an actual green build.
+
+- **Metadata drift fixed.** `meta.json` on `origin/main` was stale relative to the
+  canonical 1013-line file: `lineCount 796→1013`, `theoremCount 50→59`,
+  `definitionCount 12→14`. Synced. `status: formalized` / `badge: wip` / `sorries: 1`
+  / `axiomCount: 0` remain correct (the one `sorry` keeps this honestly WIP; every
+  non-`sorry` decl is 0-axiom — `#print axioms` on them is {propext, Classical.choice,
+  Quot.sound}).
+
+**No new Lean written — and deliberately so.** The remaining `sorry` is the
+collision-resolving priority scheduler (the alternating-`f`/`g` chain chase), the
+`isGFree` Π₁ obstruction flagged BLOCKED across 3+ prior sessions. Per the STUCK
+protocol, piling further peripheral lemmas onto the open `sorry` would be padding,
+not progress; the honest advance this session is the green-build integrity
+confirmation + the metadata correction. The scheduler recursion (stage builder
+producing `IsMatching`+`MatchingCorr` matchings, coverage via `firstMissing_le_length`,
+and reading off a computable `ℕ ≃ ℕ`) remains the genuine crux for a future session
+with a durable build environment.

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 796,
+    "lineCount": 1013,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -57,8 +57,8 @@
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 50,
-    "definitionCount": 12,
+    "theoremCount": 59,
+    "definitionCount": 14,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
     ]

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -58,7 +58,8 @@
       "p,q are arbitrary predicates (NOT computable); the construction must route membership through the computable reductions f,g structurally and never test p/q directly.",
       "partialInverse is single-valued under injective g (partialInverse_unique) — collision-freeness for extending the partial map by a g-edge.",
       "fwdOrbit f g n k = (g∘f)^[k] n (fwdOrbit_eq_iterate): the forward orbit is unproblematically computable; difficulty is entirely backward.",
-      "Collision determinacy (Section 4g): under the BuiltFrom invariant (each pair is an f-edge (x,f x) or g-edge (g y,y)), a domain-side collision f a in mRan L is NECESSARILY the g-edge (g(f a), f a) — cannot be an f-edge by injectivity of f. Replaces the Pi_1 isGFree decision with a decidable membership test + explicit blocker g(f a)."
+      "Collision determinacy (Section 4g): under the BuiltFrom invariant (each pair is an f-edge (x,f x) or g-edge (g y,y)), a domain-side collision f a in mRan L is NECESSARILY the g-edge (g(f a), f a) — cannot be an f-edge by injectivity of f. Replaces the Pi_1 isGFree decision with a decidable membership test + explicit blocker g(f a).",
+      "2026-07-02 (r11): green Docker build of SchroederBernsteinOQ03 (3065 jobs, v4.26.0) confirms Sections 4a-4f (59 thm/14 def) compile with only the known myhill_isomorphism sorry; concurrent growth did not reintroduce the post-#32332 dup-decl breakage."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
@@ -69,7 +70,8 @@
       "Prove the stage invariants: injectivity (via partialInverse_unique + f injective), correspondence p↔q preserved, and domain/range exhaustion (n covered by stage 2n+1).",
       "Derive computability of the resulting permutation from computability of the stage builder + bounded search for the entering stage.",
       "Consider a tractable partial win first: classical SB bijection IS computable when range g and range f are decidable (isolates the Π₁ obstruction).",
-      "Define stage recursion using step_f_available_or_collision: on collision at a, chase along fwdOrbit f g a to first k with f((g∘f)^[k] a) fresh; prove termination via finite matching length (bounded search, computable)."
+      "Define stage recursion using step_f_available_or_collision: on collision at a, chase along fwdOrbit f g a to first k with f((g∘f)^[k] a) fresh; prove termination via finite matching length (bounded search, computable).",
+      "Scheduler crux (BLOCKED 3+ sessions): stage recursion producing IsMatching+MatchingCorr matchings, coverage via firstMissing_le_length, read off computable ℕ≃ℕ. Attempt only with a durable build environment; do not add peripheral scaffolding."
     ],
     "markdown": "# Knowledge Base: schroeder-bernstein-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -207,5 +209,7 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroederBernsteinOQ04OQ01OQ01.lean"
     }
-  ]
+  ],
+  "lastWorkedBy": "researcher-11",
+  "lastWorkedAt": "2026-07-02"
 }


### PR DESCRIPTION
## Summary

First successful **Docker compile** of `Proofs.SchroederBernsteinOQ03` in several sessions (prior sessions were blocked by Docker/host-disk). The build is **green** (3065 jobs, v4.26.0) with exactly the one known open `sorry` — the `myhill_isomorphism` hard direction (priority scheduler / `isGFree` Π₁ obstruction) at L926. This confirms the concurrent Section 4c–4f growth (matching layer, `firstMissing` exhaustion, duality, `mLookup`) did **not** reintroduce the dup-decl breakage that silently broke this file after #32332.

## Changes (data/docs only — no Lean changed)
- **meta.json**: synced stale counts to the canonical 1013-line file — `lineCount 796→1013`, `theoremCount 50→59`, `definitionCount 12→14`. `status: formalized` / `badge: wip` / `sorries: 1` / `axiomCount: 0` unchanged and honestly correct.
- **knowledge.md**: honest session note (green-build integrity confirmation; scheduler crux remains BLOCKED per STUCK protocol — no padding lemmas added).

## Verification
`./proofs/scripts/docker-build.sh Proofs.SchroederBernsteinOQ03` → `Build completed successfully (3065 jobs)`; only warnings are the known `sorry` and two unused-variable lints.