### PR TITLE
Enrich Maclaurin equality-case sufficiency (amgm-inequality-oq-02-oq-02-oq-02): Newton's inequalities reference

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-02/meta.json
@@ -48,6 +48,13 @@
   },
   "references": [
     {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge",
+      "note": "Origin of Newton's inequalities p_k² ≥ p_{k-1}·p_{k+1} on the normalized elementary symmetric means; these force the Maclaurin chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, and their equality case — all coordinates equal — is exactly the sufficiency direction formalized here."
+    },
+    {
       "authors": "Maclaurin, Colin",
       "title": "A Treatise of Algebra",
       "year": "1748",


### PR DESCRIPTION
Enrichment pass on `amgm-inequality-oq-02-oq-02-oq-02` (Maclaurin's inequality, equality-case sufficiency direction).

**Gap:** entry is well-curated (7 full annotations, 3 sections, 4 keyInsights) but carried only **2 references** — both about Maclaurin's inequality itself, with no citation of its direct mathematical precursor.

**Change:** references 2 → 3. Add **Newton, *Arithmetica Universalis* (1707)**. Newton's inequalities p_k² ≥ p_{k−1}·p_{k+1} on the normalized elementary symmetric means are exactly what force the Maclaurin chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, and their equality case (all coordinates equal) is precisely the sufficiency direction this entry formalizes — so it is the single most directly-relevant missing reference, not padding.

meta.json 11.8 → 12.2 KB (well under caps). No fields deepened beyond the reference gap.