### PR TITLE
Enrich feuerbachs-theorem-defs-oq-01-oq-01-oq-02 (section coverage): head Overview

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/meta.json
@@ -64,6 +64,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: The Orthocentric System of {A, B, C, H}",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Module docstring, parent import (FeuerbachsTheoremDefs), and setup (linter option; noncomputable section; namespace FeuerbachsTheoremDefsOQ01OQ01OQ02). Building on the orthocenter H = A+B+C−2O, this file establishes the orthocentric configuration: each of A,B,C,H is the orthocenter of the triangle on the other three. It characterizes 'P is an orthocenter of XYZ' by altitude-perpendicularity (IsOrthocenterOf) and proves the three perpendicularities orthocentric_perp_a/b/c ((A−H)⊥(B−C) etc., each a linear fact in O), the four orthocenter memberships (orthocenter_of_ABC/BCH/CAH/ABH bundled as orthocentric_system), uniqueness (isOrthocenterOf_unique via a 2×2 Cramer argument whose determinant is the non-degeneracy determinant), and the structural consequence orthocentric_six_midpoints_concyclic (the midpoints of all six connectors lie on one shared nine-point circle, centre N, radius R/2). A worked acute example A=(0,0),B=(4,0),C=(1,2) with O=(2,1/4), H=(1,3/2) verifies A as orthocenter of BCH. Status: 0 sorries, 0 axioms.",
+      "mathContext": "The three 'opposite connectors are perpendicular' statements ARE the orthocentric system; it repackages the parent's six nine-point theorems as the symmetry of the four-point set {A,B,C,H} sharing a single nine-point circle."
+    },
+    {
       "id": "perp-bisectors",
       "title": "Perpendicular-bisector relations",
       "startLine": 76,


### PR DESCRIPTION
## Section coverage: head Overview for feuerbachs-theorem-defs-oq-01-oq-01-oq-02

The Lean file's opening 79 lines (module docstring + imports/setup) were not spanned by any gallery section; the first section began at line 80. This adds a head **Overview** section (lines 1–79) with a summary and mathematical context, so the sidebar section list covers the file from line 1.

- Sections/annotations only — no change to `status`, `badge`, `axiomCount`, or any proof claim.
- Section list remains contiguous and ordered.

🤖 Section-coverage enrichment (enricher-5).
