### PR TITLE
Enrich Vandermonde diagonal (combinations-formula-oq-10): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/combinations-formula-oq-10/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-10/annotations.json
@@ -2,10 +2,10 @@
   {
     "id": "ann-combo10-header",
     "proofId": "combinations-formula-oq-10",
-    "range": { "startLine": 1, "endLine": 52 },
+    "range": { "startLine": 1, "endLine": 36 },
     "type": "concept",
     "title": "The Diagonal of Vandermonde's Convolution",
-    "content": "The header frames OQ-10. The gallery already holds the general Vandermonde convolution C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r-k) (OQ-01) and its Chu–Vandermonde polynomial generalizations (OQ-01-OQ-02). This file proves the convolution's most celebrated *specialization* — the diagonal m=n, where the second factor C(n,r-k) folds back onto C(n,k) by the symmetry of Pascal's triangle.\n\nThe headline consequence is the sum-of-squares identity ∑_{k=0}^{n} C(n,k)² = C(2n,n): the sum of the squares of a row of Pascal's triangle is the central binomial coefficient. The gallery previously recorded only the bound C(2n,n) ≤ 4ⁿ and the log-concavity of a row (OQ-04), not this exact value. The shifted generalization ∑_{k=0}^{n-d} C(n,k)·C(n,k+d) = C(2n,n+d) is the off-diagonal version, equivalently the coefficient [x^{n+d}] of (1+x)ⁿ·(1+x)ⁿ. `import Mathlib` supplies Nat.add_choose_eq (Vandermonde), the antidiagonal-to-range converter, and Nat.choose_symm_of_eq_add.",
+    "content": "The header frames OQ-10. The gallery already holds the general Vandermonde convolution C(m+n,r) = ∑_{k=0}^{r} C(m,k)·C(n,r-k) (OQ-01) and its Chu–Vandermonde polynomial generalizations (OQ-01-OQ-02). This file proves the convolution's most celebrated *specialization* — the diagonal m=n, where the second factor C(n,r-k) folds back onto C(n,k) by the symmetry of Pascal's triangle.\n\nThe headline consequence is the sum-of-squares identity ∑_{k=0}^{n} C(n,k)² = C(2n,n): the sum of the squares of a row of Pascal's triangle is the central binomial coefficient. The gallery previously recorded only the bound C(2n,n) ≤ 4ⁿ and the log-concavity of a row (OQ-04), not this exact value. The shifted generalization ∑_{k=0}^{n-d} C(n,k)·C(n,k+d) = C(2n,n+d) is the off-diagonal version, equivalently the coefficient [x^{n+d}] of (1+x)ⁿ·(1+x)ⁿ.",
     "mathContext": "Vandermonde: $\\binom{m+n}{r} = \\sum_{k=0}^{r}\\binom{m}{k}\\binom{n}{r-k}$. Diagonal at $m=n$, $r=n$: $\\sum_{k=0}^{n}\\binom{n}{k}\\binom{n}{n-k} = \\binom{2n}{n}$, and since $\\binom{n}{n-k}=\\binom{n}{k}$ this is $\\sum_{k=0}^{n}\\binom{n}{k}^2 = \\binom{2n}{n}$. Shifted: $\\sum_{k=0}^{n-d}\\binom{n}{k}\\binom{n}{k+d} = \\binom{2n}{n+d}$ for $d \\le n$.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -20,6 +20,27 @@
       "the general Vandermonde convolution",
       "the symmetry C(n,k) = C(n,n-k)",
       "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-combo10-method",
+    "proofId": "combinations-formula-oq-10",
+    "range": { "startLine": 38, "endLine": 52 },
+    "type": "technique",
+    "title": "Proof method: a subtraction-free ℕ specialization",
+    "content": "The `## Method` block records the single strategy behind both theorems. Rather than proving the sum-of-squares identity directly, the file specializes Mathlib's Vandermonde `Nat.add_choose_eq` at m=n, r=n-d, then routes every rewrite through one lemma, `Nat.choose_symm_of_eq_add` (n = a+b ⟹ C(n,a) = C(n,b)): once to fold the inner coefficient C(n,(n-d)-k) into C(n,k+d), and once to flip the closed form C(2n,n-d) into C(2n,n+d). The design deliberately avoids reasoning about truncated ℕ-subtraction — the two index splits n = ((n-d)-k)+(k+d) and 2n = (n-d)+(n+d) are each a one-line `omega` fact under the hypothesis d ≤ n, so the subtraction never underflows. `import Mathlib` and `open Nat Finset` bring the Vandermonde, antidiagonal-to-range, and `choose`-symmetry API into scope.",
+    "mathContext": "Every subtraction is an additive split validated by omega: $n = ((n-d)-k) + (k+d)$ and $2n = (n-d) + (n+d)$, both under $d \\le n$. The lone tool is $n = a+b \\Rightarrow \\binom{n}{a} = \\binom{n}{b}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization of a general identity",
+      "Nat.choose_symm_of_eq_add",
+      "subtraction-free ℕ arithmetic via omega",
+      "proof-engineering with a single symmetry lemma"
+    ],
+    "prerequisites": [
+      "Nat.add_choose_eq (Vandermonde in ℕ)",
+      "truncated subtraction on ℕ",
+      "the omega decision procedure"
     ]
   },
   {

--- a/src/data/proofs/combinations-formula-oq-10/meta.json
+++ b/src/data/proofs/combinations-formula-oq-10/meta.json
@@ -46,7 +46,8 @@
       "The squares in ∑ C(n,k)² are not intrinsic: they arise purely from the symmetry C(n,n-k) = C(n,k) applied to the second factor of Vandermonde's diagonal — the identity is really a self-convolution, not a sum of squares.",
       "Working with the single symmetry lemma Nat.choose_symm_of_eq_add (n = a + b ⟹ C(n,a) = C(n,b)) keeps every step free of truncated ℕ-subtraction: each subtraction equality (n = ((n-d)-k)+(k+d) and 2n = (n-d)+(n+d)) is a one-line omega fact under d ≤ n.",
       "Proving the shifted diagonal first and recovering the sum-of-squares as the d=0 corollary is strictly more general than proving the squares directly, at no extra cost — the same Vandermonde specialization handles both.",
-      "Stating the closed form as C(2n,n+d) rather than C(2n,n-d) (the two are equal by symmetry) makes the d=0 case land exactly on the central binomial coefficient C(2n,n)."
+      "Stating the closed form as C(2n,n+d) rather than C(2n,n-d) (the two are equal by symmetry) makes the d=0 case land exactly on the central binomial coefficient C(2n,n).",
+      "The shifted diagonal has a clean double-counting reading: to select n+d objects from 2n split into two blocks of n, take k from the first block and n+d-k from the second; summing C(n,k)·C(n,n+d-k) = C(n,k)·C(n,k+d) over k recounts C(2n,n+d) — the algebraic Vandermonde specialization is the bijective count made formal."
     ]
   },
   "sections": [
@@ -54,8 +55,15 @@
       "id": "header",
       "title": "Open Question and Mathematical Context",
       "startLine": 1,
-      "endLine": 52,
+      "endLine": 36,
       "summary": "Header stating OQ-10: the diagonal specialization of Vandermonde. Notes that the general convolution and Chu–Vandermonde generalizations are already in the gallery, and that this file adds the self-convolution diagonal and the central-binomial sum-of-squares identity."
+    },
+    {
+      "id": "method",
+      "title": "Proof Method Overview",
+      "startLine": 38,
+      "endLine": 52,
+      "summary": "The `## Method` block: specialize Vandermonde's Nat.add_choose_eq at m=n, r=n-d and route every rewrite through the single symmetry lemma Nat.choose_symm_of_eq_add, keeping the whole argument free of truncated ℕ-subtraction (each index split discharged by omega under d ≤ n). Sets up imports and the Nat/Finset API."
     },
     {
       "id": "shifted-diagonal",


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-10` (quality 91 → 100, pass 0).

The entry sat exactly at the role's minimum thresholds (4 annotations, 4 sections, 4 keyInsights, where the target is 'at least 5'). The Lean docstring cleanly separates a **statement** block (OQ + Results, lines 1–36) from a **Method** block (lines 38–52), previously lumped into one annotation/section. This pass separates the *what* from the *how* and adds the combinatorial reading the insights lacked:

- **Annotations 4 → 5**: split `ann-combo10-header` (now lines 1–36, the identities) and added `ann-combo10-method` (lines 38–52) explaining the subtraction-free ℕ strategy — the single-symmetry-lemma design and `omega`-discharged index splits.
- **Sections 4 → 5**: split the header section into *Open Question and Mathematical Context* (1–36) and *Proof Method Overview* (38–52), keeping contiguous full-file coverage.
- **keyInsights 4 → 5**: added the double-counting interpretation of the shifted diagonal (choose n+d from two blocks of n), complementing the four algebraic/symmetry insights.

meta.json 9.9 KB → 10.7 KB (far under the 60 KB cap); no content removed. `status`/`badge`/`axiomCount` unchanged and accurate (verified, 0 axioms, 0 sorries). `pnpm build` passes; recomputed quality score is 100.