### PR TITLE
Enrich conjugacy class equation (conjugacy-class-equation-oq-01): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/conjugacy-class-equation-oq-01/annotations.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01/annotations.json
@@ -36,15 +36,27 @@
     "prerequisites": ["the orbit/stabilizer/centralizer bridges"]
   },
   {
-    "id": "conjclass-oq01-ann-dvd-instance",
+    "id": "conjclass-oq01-ann-dvd",
     "proofId": "conjugacy-class-equation-oq-01",
-    "range": { "startLine": 65, "endLine": 79 },
+    "range": { "startLine": 65, "endLine": 69 },
     "type": "theorem",
-    "title": "Per-Class Divisibility and the S₃ Witness",
-    "content": "`conjClass_card_dvd_card`: |class(g)| ∣ |G|, immediate from the product identity (the centralizer order is the explicit cofactor `⟨_, …⟩`). This per-class divisibility — not the summed class equation — is what Mathlib leaves implicit and is the key step in, e.g., proving a nontrivial p-group has nontrivial center. The closing example specializes to S₃ = Equiv.Perm (Fin 3): computing Nat.card = 3! = 6 by kernel `decide` (no native_decide), every conjugacy class size divides 6. Stated with Nat.card and Subgroup.index, the identities hold for any group and recover the classical finite statements without a Fintype instance.",
-    "mathContext": "$|\\mathrm{class}(g)| \\mid |G|; \\qquad |S_3| = 3! = 6,\\ \\text{every class size} \\mid 6.$",
+    "title": "Per-Class Divisibility |class(g)| ∣ |G|",
+    "content": "`conjClass_card_dvd_card`: |class(g)| ∣ |G|, immediate from the product identity — the divisibility witness is the anonymous constructor `⟨_, (conjClass_card_mul_card_centralizer g).symm⟩`, with the centralizer order supplied as the explicit cofactor. This per-class divisibility — not the summed class equation — is what Mathlib leaves implicit, and it is the arithmetic engine behind the standard corollaries: it is the step that forces a nontrivial p-group to have nontrivial center and underlies Sylow counting. Stated with Nat.card and Subgroup.index, it holds for any group and recovers the classical finite statement without needing a Fintype instance.",
+    "mathContext": "$|\\mathrm{class}(g)| \\mid |G|$, with cofactor $|C_G(g)|$ from $|\\mathrm{class}(g)|\\cdot|C_G(g)| = |G|$.",
     "significance": "critical",
-    "relatedConcepts": ["divisibility", "p-group center", "Sylow theory", "kernel decide"],
-    "prerequisites": ["the product identity", "Nat.card of a permutation group"]
+    "relatedConcepts": ["divisibility", "p-group center", "Sylow theory", "class equation"],
+    "prerequisites": ["the product identity", "Dvd via an explicit cofactor"]
+  },
+  {
+    "id": "conjclass-oq01-ann-s3",
+    "proofId": "conjugacy-class-equation-oq-01",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "example",
+    "title": "Concrete Witness: Classes of S₃ Divide 6",
+    "content": "The closing `example` grounds the abstract identity in S₃ = Equiv.Perm (Fin 3): every conjugacy class of S₃ has size dividing |S₃| = 6. The order is computed by reducing Nat.card to Fintype.card and then Fintype.card_perm/Fintype.card_fin to 3!, discharged by kernel `decide` (not native_decide, so no Lean.ofReduceBool axiom enters), and the general theorem `conjClass_card_dvd_card` is specialized via `simpa`. Concretely the three classes of S₃ — the identity (size 1), the three transpositions (size 2), and the two 3-cycles (size 3) — have sizes 1, 2, 3, each dividing 6.",
+    "mathContext": "$|S_3| = 3! = 6$; class sizes $1 + 2 + 3 = 6$, each dividing $6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetric group S₃", "kernel decide vs native_decide", "cycle type", "worked example"],
+    "prerequisites": ["Nat.card of a permutation group", "Fintype.card_perm"]
   }
 ]

--- a/src/data/proofs/conjugacy-class-equation-oq-01/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01/meta.json
@@ -71,7 +71,8 @@
       "**A conjugacy class is an orbit.** The single conceptual move is to view the conjugacy class of g as the orbit of g under the conjugation action ConjAct G ↷ G; every arithmetic property then follows from orbit–stabilizer.",
       "**Stabilizer = centralizer.** Under conjugation the stabilizer of g is exactly its centralizer C_G(g), so the orbit–stabilizer product |orbit|·|stabilizer| = |G| becomes |class(g)|·|C_G(g)| = |G|.",
       "**Per-class divisibility is the missing piece.** Mathlib records the orbit–stabilizer theorem and the *summed* class equation, but not the clean per-class statement |class(g)| ∣ |G| nor |class(g)| = [G : C_G(g)]; these are the lemmas one actually cites when applying the class equation.",
-      "**Stated with Nat.card, valid generally.** Using Nat.card and Subgroup.index, the identities hold for any group (vacuously when infinite) and recover the classical finite statements without carrying a Fintype instance — the concrete S₃ example supplies finiteness only where a numeric value is needed."
+      "**Stated with Nat.card, valid generally.** Using Nat.card and Subgroup.index, the identities hold for any group (vacuously when infinite) and recover the classical finite statements without carrying a Fintype instance — the concrete S₃ example supplies finiteness only where a numeric value is needed.",
+      "**Divisibility, not the summed identity, is the corollary engine.** The classical applications — a nontrivial p-group has nontrivial center, and the Sylow existence/counting arguments — turn on each summand [G : C_G(gᵢ)] being a divisor of |G|, i.e. on the per-class statement |class(g)| ∣ |G| rather than on the aggregate |G| = |Z(G)| + Σ[G : C_G(gᵢ)]. Isolating the per-class divisibility is exactly what makes those corollaries one-liners."
     ],
     "prerequisites": [
       "The conjugation action ConjAct G ↷ G and ConjClasses (GroupAction/ConjAct.lean)",
@@ -106,11 +107,19 @@
     },
     {
       "id": "divisibility",
-      "title": "Per-Class Divisibility and a Concrete Instance",
-      "startLine": 68,
+      "title": "Per-Class Divisibility",
+      "startLine": 65,
+      "endLine": 69,
+      "summary": "conjClass_card_dvd_card: |class(g)| ∣ |G| as an immediate corollary of the product identity, the divisibility witness being the centralizer order as explicit cofactor. This is the per-class form Mathlib leaves implicit and the engine behind the p-group-center and Sylow corollaries.",
+      "mathContext": "$|\\mathrm{class}(g)| \\mid |G|$, with cofactor $|C_G(g)|$."
+    },
+    {
+      "id": "s3-example",
+      "title": "Concrete Instance: S₃",
+      "startLine": 71,
       "endLine": 79,
-      "summary": "conjClass_card_dvd_card: |class(g)| ∣ |G| as a corollary of the product identity. The closing example specializes to Equiv.Perm (Fin 3) (order 6), showing every conjugacy class size divides 6.",
-      "mathContext": "$|\\mathrm{class}(g)| \\mid |G|$; in $S_3$ every class size divides $6$."
+      "summary": "The closing example specializes to S₃ = Equiv.Perm (Fin 3) (order 3! = 6 by kernel decide), showing every conjugacy class size divides 6 — the three classes have sizes 1, 2, 3.",
+      "mathContext": "$|S_3| = 6$; class sizes $1, 2, 3$ each divide $6$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `conjugacy-class-equation-oq-01` (quality 91 → 100, pass 0).

The entry sat exactly at the role's minimum thresholds (4 annotations, 4 sections, 4 keyInsights, where the target is 'at least 5'). Its final annotation and section each bundled two genuinely distinct things — the general per-class divisibility theorem and the concrete S₃ verification — so this pass separates them and adds the corollary-significance insight the keyInsights lacked:

- **Annotations 4 → 5**: split the divisibility annotation into `conjClass_card_dvd_card` (lines 65–69, the general theorem + its cofactor witness) and a new S₃ example annotation (71–79, the kernel-`decide` order computation and the class sizes 1+2+3=6).
- **Sections 4 → 5**: split *Per-Class Divisibility and a Concrete Instance* into *Per-Class Divisibility* (65–69) and *Concrete Instance: S₃* (71–79), keeping contiguous coverage.
- **keyInsights 4 → 5**: added why per-class divisibility — not the summed class equation — is the engine behind the p-group-center and Sylow corollaries.

meta.json 13.5 KB → 14.4 KB (far under the 60 KB cap); no content removed. `status`/`badge`/`axiomCount` unchanged and accurate. `pnpm build` passes; recomputed quality score is 100.