### PR TITLE
Enrich Chebyshev Tₙ degree/leading-coeff (de-moivre-oq-02-oq-03-oq-02): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
@@ -63,22 +63,42 @@
     ]
   },
   {
-    "id": "ann-dm-oq020302-corollaries",
+    "id": "ann-dm-oq020302-projections",
     "proofId": "de-moivre-oq-02-oq-03-oq-02",
-    "range": { "startLine": 111, "endLine": 126 },
+    "range": { "startLine": 111, "endLine": 117 },
     "type": "concept",
-    "title": "Extracted Theorems for Downstream Use",
-    "content": "T_natDegree and T_leadingCoeff project the two conjuncts of the induction into standalone statements. T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as the clean 2ⁿ (without truncated subtraction), which is the form the minimax/extremal theory uses when normalizing Tₙ to the monic Tₙ/2ⁿ⁻¹.",
-    "mathContext": "$\\deg T_n = n$, $\\mathrm{lc}(T_n) = 2^{n-1}$, and $\\mathrm{lc}(T_{n+1}) = 2^{n}$.",
+    "title": "Projecting the Conjunction into Standalone Theorems",
+    "content": "T_natDegree and T_leadingCoeff project the two conjuncts of the inductive result T_natDegree_leadingCoeff into separately citable statements — natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1) — each a one-line `.1` / `.2` extraction. Proving the two facts together in one induction (because each inductive step needs both) and only then splitting them is the idiomatic Lean pattern for mutually-dependent invariants: the caller sees two clean lemmas, not a conjunction.",
+    "mathContext": "$\\deg T_n = n$ and $\\mathrm{lc}(T_n) = 2^{n-1}$, the two projections of the joint induction.",
     "significance": "supporting",
     "relatedConcepts": [
+      "projecting a conjunction (.1 / .2)",
+      "natDegree",
       "leadingCoeff",
-      "monic normalization",
-      "Chebyshev minimax"
+      "mutually-dependent invariants"
     ],
     "prerequisites": [
       "projecting a conjunction",
+      "the joint induction T_natDegree_leadingCoeff"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-succ-form",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 119, "endLine": 126 },
+    "type": "concept",
+    "title": "The Minimax-Facing Leading Coefficient 2ⁿ",
+    "content": "T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as the clean 2ⁿ (indexing by n+1 so the exponent is an honest ℕ, free of the truncated subtraction n−1). This is precisely the form the minimax/extremal theory consumes: to obtain the monic Chebyshev polynomial one divides Tₙ₊₁ by its leading coefficient 2ⁿ, and the parent minimax entry normalizes by exactly this factor. Derived in one line from T_leadingCoeff by `simpa`.",
+    "mathContext": "$\\mathrm{lc}(T_{n+1}) = 2^{n}$; the monic normalization is $T_{n+1}/2^{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monic normalization",
+      "Chebyshev minimax",
       "truncated vs ordinary subtraction in exponents"
+    ],
+    "prerequisites": [
+      "T_leadingCoeff",
+      "monic polynomials"
     ]
   }
 ]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
@@ -41,7 +41,8 @@
       "Tracking natDegree and leadingCoeff together is what makes the induction go through: the leading-coefficient hypothesis (2ⁿ ≠ 0) is exactly the witness that T(n+1) ≠ 0, which the degree calculus for the product 2·X·T(n+1) requires.",
       "Working over the integral domain ℤ keeps degree additive and leading coefficient multiplicative on products (natDegree_mul / leadingCoeff_mul) with no monic hypotheses — the Chebyshev polynomials are not monic for n ≥ 2, so a monic-based argument would not apply.",
       "The subtracted lower-degree term T n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'.",
-      "Writing the leading coefficient as 2^(n−1) with truncated natural subtraction absorbs the n = 0 base case (2⁰ = 1) into the same formula used for all n, avoiding a separate statement for T₀."
+      "Writing the leading coefficient as 2^(n−1) with truncated natural subtraction absorbs the n = 0 base case (2⁰ = 1) into the same formula used for all n, avoiding a separate statement for T₀.",
+      "The degree and leading coefficient are the unstated prerequisites of Mathlib's own Chebyshev TODOs: 'compute zeroes and extrema' and the minimax property both presuppose deg Tₙ = n and the 2ⁿ⁻¹ normalization, yet Mathlib records neither. Supplying them — especially the subtraction-free T_leadingCoeff_succ (lc Tₙ₊₁ = 2ⁿ) that yields the monic Tₙ₊₁/2ⁿ — is exactly the missing hinge for the extremal/minimax theory the parent entry pursues."
     ],
     "prerequisites": [
       "The first-kind Chebyshev polynomials and their recurrence T(n+2) = 2·X·T(n+1) − T n (Mathlib's Polynomial.Chebyshev.T)",
@@ -75,12 +76,20 @@
       "mathContext": "Inductive step: $T_{n+2} = 2X\\,T_{n+1} - T_n$, with $\\deg(2X\\,T_{n+1}) = n+2 > n = \\deg T_n$."
     },
     {
-      "id": "corollaries",
-      "title": "Extracted Degree and Leading-Coefficient Theorems",
+      "id": "projections",
+      "title": "Projected Degree and Leading-Coefficient Theorems",
       "startLine": 111,
+      "endLine": 117,
+      "summary": "T_natDegree and T_leadingCoeff project the two halves of the joint induction into separately citable one-line lemmas (natDegree = n; leadingCoeff = 2^(n−1)) — the idiomatic way to expose two mutually-dependent invariants proved together.",
+      "mathContext": "$\\deg T_n = n$; $\\mathrm{lc}(T_n) = 2^{n-1}$."
+    },
+    {
+      "id": "succ-form",
+      "title": "Minimax-Facing Leading Coefficient 2ⁿ",
+      "startLine": 119,
       "endLine": 126,
-      "summary": "T_natDegree and T_leadingCoeff project the two halves of the induction; T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as 2ⁿ (no truncated subtraction), the form most convenient for downstream minimax/extremal use.",
-      "mathContext": "$\\deg T_n = n$; $\\mathrm{lc}(T_n) = 2^{n-1}$; $\\mathrm{lc}(T_{n+1}) = 2^{n}$."
+      "summary": "T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as the clean 2ⁿ (indexing by n+1, no truncated subtraction) — the exact factor the minimax/extremal theory divides by to normalize Tₙ₊₁ to a monic polynomial.",
+      "mathContext": "$\\mathrm{lc}(T_{n+1}) = 2^{n}$; monic normalization $T_{n+1}/2^{n}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-02-oq-03-oq-02` (quality 91 → 100, pass 0).

The entry sat exactly at the role's minimum thresholds (4 annotations, 4 sections, 4 keyInsights vs the target of at least 5). Its corollaries annotation and section each bundled two genuinely distinct things — the raw conjunct projections and the downstream-normalized leading-coefficient form — so this pass separates them and adds the missing significance insight:

- **Annotations 4 → 5**: split the corollaries annotation into the conjunct projections `T_natDegree`/`T_leadingCoeff` (lines 111–117) and the minimax-facing `T_leadingCoeff_succ` (lc Tₙ₊₁ = 2ⁿ, no truncated subtraction; lines 119–126).
- **Sections 4 → 5**: split the matching section identically, preserving contiguous full-file coverage.
- **keyInsights 4 → 5**: added that deg Tₙ = n and the 2ⁿ⁻¹ normalization are the unstated prerequisites of Mathlib's own Chebyshev 'zeroes and extrema' / minimax TODOs.

meta.json 12.6 KB → 13.6 KB (far under the 60 KB cap); no content removed. `status`/`badge`/`axiomCount` unchanged (verified, 0 axioms, 0 sorries). `pnpm build` passes; recomputed quality score is 100.