### PR TITLE
Enrich Chebyshev Uₙ degree/leading-coeff (de-moivre-oq-02-oq-03-oq-02-oq-01): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/annotations.json
@@ -63,22 +63,43 @@
     ]
   },
   {
-    "id": "ann-dm-oq02030201-corollaries",
+    "id": "ann-dm-oq02030201-projections",
     "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
-    "range": { "startLine": 115, "endLine": 129 },
+    "range": { "startLine": 114, "endLine": 120 },
     "type": "concept",
-    "title": "Extracted Theorems for Downstream Use",
-    "content": "U_natDegree and U_leadingCoeff project the two conjuncts of the induction into standalone statements. U_ne_zero records that Uₙ is never the zero polynomial — an immediate consequence of leadingCoeff (U ℤ n) = 2ⁿ ≠ 0 — which downstream root-counting and derivative arguments (Tₙ′ = n·Uₙ₋₁) rely on.",
-    "mathContext": "$\\deg U_n = n$, $\\mathrm{lc}(U_n) = 2^{n}$, and $U_n \\ne 0$.",
+    "title": "Projecting the Conjunction into Standalone Theorems",
+    "content": "U_natDegree and U_leadingCoeff project the two conjuncts of the inductive result U_natDegree_leadingCoeff into separately citable statements — natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ — each a one-line `.1` / `.2` extraction. As with the first-kind entry, the two facts are proved jointly (each inductive step consumes both) and only then split, so downstream callers cite two clean lemmas rather than a conjunction. Note the second-kind leading coefficient 2ⁿ needs no truncated subtraction, unlike the first-kind 2ⁿ⁻¹.",
+    "mathContext": "$\\deg U_n = n$ and $\\mathrm{lc}(U_n) = 2^{n}$, the two projections of the joint induction.",
     "significance": "supporting",
     "relatedConcepts": [
+      "projecting a conjunction (.1 / .2)",
+      "natDegree",
       "leadingCoeff",
-      "polynomial nonvanishing",
-      "second-kind Chebyshev"
+      "mutually-dependent invariants"
     ],
     "prerequisites": [
       "projecting a conjunction",
-      "a nonzero leading coefficient forces a nonzero polynomial"
+      "the joint induction U_natDegree_leadingCoeff"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030201-nonzero",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 129 },
+    "type": "concept",
+    "title": "Nonvanishing: Uₙ ≠ 0",
+    "content": "U_ne_zero records that Uₙ is never the zero polynomial — proved by contradiction: if Uₙ = 0 its leading coefficient would be 0, but U_leadingCoeff gives 2ⁿ ≠ 0. This nonvanishing is the small but essential lemma the degree/leading-coefficient package exists to license: it is exactly the hypothesis natDegree_mul and root-counting need, and it underlies the derivative identity Tₙ′ = n·Uₙ₋₁ and the fact that Uₙ has exactly n roots (the Chebyshev nodes). Isolating it as a named lemma keeps those downstream proofs one line.",
+    "mathContext": "$U_n \\ne 0$, since $\\mathrm{lc}(U_n) = 2^{n} \\ne 0$; downstream: $T_n' = n\\,U_{n-1}$ and $U_n$ has $n$ roots.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "polynomial nonvanishing",
+      "root counting",
+      "derivative identity Tₙ′ = n·Uₙ₋₁",
+      "second-kind Chebyshev"
+    ],
+    "prerequisites": [
+      "a nonzero leading coefficient forces a nonzero polynomial",
+      "U_leadingCoeff"
     ]
   }
 ]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -42,7 +42,8 @@
       "The second-kind leading-coefficient formula 2ⁿ is uniform — no truncated subtraction is needed — because U 1 = 2·X already supplies the factor of two that T 1 = X lacks; the base value 2⁰ = 1 at n = 0 matches U 0 = 1 automatically.",
       "Tracking natDegree and leadingCoeff together is what makes the induction go through: the leading-coefficient hypothesis (2ⁿ⁺¹ ≠ 0) is exactly the witness that U(n+1) ≠ 0, which the degree calculus for the product 2·X·U(n+1) requires.",
       "Working over the integral domain ℤ keeps degree additive and leading coefficient multiplicative on products (natDegree_mul / leadingCoeff_mul) with no monic hypotheses — Uₙ is not monic for n ≥ 1, so a monic-based argument would not apply.",
-      "The subtracted lower-degree term U n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'."
+      "The subtracted lower-degree term U n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'.",
+      "The real downstream payload is the nonvanishing Uₙ ≠ 0, a free corollary of leadingCoeff = 2ⁿ ≠ 0: it is precisely the hypothesis that root-counting, natDegree_mul, and the derivative identity Tₙ′ = n·Uₙ₋₁ need, so the degree/leading-coefficient package pays off exactly by licensing that one-line lemma."
     ],
     "prerequisites": [
       "The second-kind Chebyshev polynomials and their recurrence U(n+2) = 2·X·U(n+1) − U n (Mathlib's Polynomial.Chebyshev.U)",
@@ -76,12 +77,20 @@
       "mathContext": "Inductive step: $U_{n+2} = 2X\\,U_{n+1} - U_n$, with $\\deg(2X\\,U_{n+1}) = n+2 > n = \\deg U_n$."
     },
     {
-      "id": "corollaries",
-      "title": "Extracted Degree, Leading-Coefficient, and Nonvanishing Theorems",
-      "startLine": 115,
+      "id": "projections",
+      "title": "Projected Degree and Leading-Coefficient Theorems",
+      "startLine": 114,
+      "endLine": 120,
+      "summary": "U_natDegree and U_leadingCoeff project the two halves of the joint induction into separately citable one-line lemmas (natDegree = n; leadingCoeff = 2ⁿ, uniform with no truncated subtraction).",
+      "mathContext": "$\\deg U_n = n$; $\\mathrm{lc}(U_n) = 2^{n}$."
+    },
+    {
+      "id": "nonvanishing",
+      "title": "Nonvanishing Uₙ ≠ 0",
+      "startLine": 122,
       "endLine": 129,
-      "summary": "U_natDegree and U_leadingCoeff project the two halves of the induction; U_ne_zero deduces that Uₙ is never the zero polynomial from the nonzero leading coefficient 2ⁿ.",
-      "mathContext": "$\\deg U_n = n$; $\\mathrm{lc}(U_n) = 2^{n}$; $U_n \\ne 0$."
+      "summary": "U_ne_zero deduces that Uₙ is never the zero polynomial from its nonzero leading coefficient 2ⁿ — the lemma downstream root-counting, natDegree_mul, and the derivative identity Tₙ′ = n·Uₙ₋₁ actually consume.",
+      "mathContext": "$U_n \\ne 0$ since $\\mathrm{lc}(U_n) = 2^{n} \\ne 0$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-02-oq-03-oq-02-oq-01` (quality 91 → 100, pass 0), the second-kind (Uₙ) companion to `de-moivre-oq-02-oq-03-oq-02`.

The entry sat exactly at the role's minimum thresholds (4 annotations/sections/keyInsights vs the target of at least 5). Its corollaries annotation and section bundled two genuinely distinct things — the raw conjunct projections and the nonvanishing lemma — so this pass separates them and adds the missing downstream-significance insight:

- **Annotations 4 → 5**: split the corollaries annotation into the conjunct projections `U_natDegree`/`U_leadingCoeff` (lines 114–120) and the nonvanishing `U_ne_zero` (122–129).
- **Sections 4 → 5**: split the matching section identically, preserving contiguous full-file coverage.
- **keyInsights 4 → 5**: added that Uₙ ≠ 0 is the real downstream payload (the hypothesis root-counting, `natDegree_mul`, and the derivative identity Tₙ′ = n·Uₙ₋₁ consume).

meta.json ~12.7 KB → ~13.7 KB (far under the 60 KB cap); no content removed. `status`/`badge`/`axiomCount` unchanged (verified, 0 axioms, 0 sorries). `pnpm build` passes; recomputed quality score is 100.