### PR TITLE
Enrich denumerability via localization (denumerability-rationals-oq-05-oq-01-oq-01-oq-01): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/annotations.json
@@ -2,49 +2,117 @@
   {
     "id": "denum-loc-ann-header",
     "proofId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 42 },
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
     "type": "concept",
     "title": "Localization Preserves Denumerability",
     "content": "The root of this family is Cantor's denumerability of ℚ. Since ℚ is by construction the field of fractions of ℤ, this entry asks whether the construction that builds ℚ — inverting a multiplicative set — can ever escape countability. The answer is no: a localization is always a surjective image of R × M, so countability is automatic. The file delivers the denumerable analogue of Mathlib's `IsLocalization.fintype'` (which Mathlib notes 'cannot be an instance') and closes the loop by recovering #ℚ = ℵ₀ as a corollary. Imports Mathlib, opens Cardinal.",
     "mathContext": "$\\mathbb{Q} = \\mathrm{Frac}(\\mathbb{Z}), \\qquad \\#(\\mathrm{FractionRing}\\,R) = \\aleph_0,\\ \\#\\mathbb{Q} = \\aleph_0.$",
     "significance": "key",
-    "relatedConcepts": ["denumerability", "localization", "fraction field", "cardinal ℵ₀"],
-    "prerequisites": ["countable types", "localization of rings", "cardinal arithmetic"]
+    "relatedConcepts": [
+      "denumerability",
+      "localization",
+      "fraction field",
+      "cardinal ℵ₀"
+    ],
+    "prerequisites": [
+      "countable types",
+      "localization of rings",
+      "cardinal arithmetic"
+    ]
   },
   {
     "id": "denum-loc-ann-countable",
     "proofId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
-    "range": { "startLine": 43, "endLine": 65 },
+    "range": {
+      "startLine": 43,
+      "endLine": 65
+    },
     "type": "theorem",
     "title": "Localizations Preserve Countability",
     "content": "`countable_of_isLocalization` is the headline: for a countable commutative semiring R and any localization S of R at a submonoid M (`[IsLocalization M S]`), S is countable. The one-line proof uses `IsLocalization.mk'_surjective` — every z : S is `mk' S r m` for some (r, m) ∈ R × M — so S is a surjective image of the countable type R × M, and `Function.Surjective.countable` finishes. The concrete `Localization.instCountable` and `instCountableFractionRing` then register countability as honest instances (the latter using `IsFractionRing R (FractionRing R)` = localization at the nonzero divisors).",
     "mathContext": "$R \\text{ countable},\\ [IsLocalization\\,M\\,S] \\implies S \\text{ countable}; \\qquad R \\times M \\twoheadrightarrow S.$",
     "significance": "critical",
-    "relatedConcepts": ["mk'_surjective", "surjective image of countable", "IsLocalization", "instance"],
-    "prerequisites": ["IsLocalization.mk'", "Function.Surjective.countable"]
+    "relatedConcepts": [
+      "mk'_surjective",
+      "surjective image of countable",
+      "IsLocalization",
+      "instance"
+    ],
+    "prerequisites": [
+      "IsLocalization.mk'",
+      "Function.Surjective.countable"
+    ]
   },
   {
     "id": "denum-loc-ann-cardinality",
     "proofId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
-    "range": { "startLine": 67, "endLine": 84 },
+    "range": {
+      "startLine": 67,
+      "endLine": 84
+    },
     "type": "theorem",
     "title": "Cardinality Bounds",
     "content": "`mk_le_aleph0_of_isLocalization`: any localization of a countable ring has #S ≤ ℵ₀ (countability + `Cardinal.mk_le_aleph0`). `mk_fractionRing_eq_aleph0`: for an infinite countable integral domain the fraction field is countably infinite, #(FractionRing R) = ℵ₀. Countability comes from the instance; infinitude from the injective `algebraMap R (FractionRing R)` (`IsFractionRing.injective`) via `Infinite.of_injective`, and `Cardinal.mk_eq_aleph0` pins the value at ℵ₀.",
     "mathContext": "$\\#S \\le \\aleph_0; \\qquad R \\text{ infinite countable domain} \\implies \\#(\\mathrm{FractionRing}\\,R) = \\aleph_0.$",
     "significance": "key",
-    "relatedConcepts": ["mk_le_aleph0", "mk_eq_aleph0", "Infinite.of_injective", "IsFractionRing.injective"],
-    "prerequisites": ["countability ⟹ #S ≤ ℵ₀", "injective coefficient map"]
+    "relatedConcepts": [
+      "mk_le_aleph0",
+      "mk_eq_aleph0",
+      "Infinite.of_injective",
+      "IsFractionRing.injective"
+    ],
+    "prerequisites": [
+      "countability ⟹ #S ≤ ℵ₀",
+      "injective coefficient map"
+    ]
   },
   {
     "id": "denum-loc-ann-rationals",
     "proofId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
-    "range": { "startLine": 85, "endLine": 100 },
+    "range": {
+      "startLine": 85,
+      "endLine": 92
+    },
     "type": "theorem",
     "title": "Closing the Loop: the Rationals",
-    "content": "`mk_rat_eq_aleph0` re-derives #ℚ = ℵ₀ — not by an explicit enumeration but by feeding `Rat.isFractionRing` (`IsFractionRing ℤ ℚ` = localization of ℤ at its nonzero divisors) into the general principle: ℚ is countable by `countable_of_isLocalization`, infinite, hence ℵ₀ via `mk_eq_aleph0`. `mk_nnrat_eq_aleph0` does the same for ℚ≥0 via `NNRat.isFractionRing` over ℕ. This exhibits Cantor's denumerability of the rationals as one instance of 'localizations of countable rings stay countable', closing the loop back to the family's root.",
-    "mathContext": "$\\#\\mathbb{Q} = \\aleph_0 \\text{ via } IsFractionRing\\,\\mathbb{Z}\\,\\mathbb{Q}; \\qquad \\#\\mathbb{Q}_{\\ge 0} = \\aleph_0.$",
+    "content": "`mk_rat_eq_aleph0` re-derives #ℚ = ℵ₀ — not by an explicit enumeration but by feeding `Rat.isFractionRing` (`IsFractionRing ℤ ℚ` = localization of ℤ at its nonzero divisors) into the general principle: ℚ is countable by `countable_of_isLocalization`, infinite, hence ℵ₀ via `mk_eq_aleph0`. This exhibits Cantor's denumerability of the rationals as one instance of 'localizations of countable rings stay countable', closing the loop back to the family's root — the abstract localization argument reproving the concrete classical fact.",
+    "mathContext": "$\\#\\mathbb{Q} = \\aleph_0 \\text{ via } IsFractionRing\\,\\mathbb{Z}\\,\\mathbb{Q}.$",
     "significance": "critical",
-    "relatedConcepts": ["Rat.isFractionRing", "denumerability of ℚ", "specialization", "NNRat"],
-    "prerequisites": ["countable_of_isLocalization", "Rat.isFractionRing / NNRat.isFractionRing"]
+    "relatedConcepts": [
+      "Rat.isFractionRing",
+      "denumerability of ℚ",
+      "specialization",
+      "fraction field of ℤ"
+    ],
+    "prerequisites": [
+      "countable_of_isLocalization",
+      "Rat.isFractionRing"
+    ]
+  },
+  {
+    "id": "denum-loc-ann-nnrat",
+    "proofId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "The Non-Negative Rationals ℚ≥0",
+    "content": "`mk_nnrat_eq_aleph0` runs the identical argument for the non-negative rationals: ℚ≥0 is the fraction object of ℕ (`NNRat.isFractionRing : IsFractionRing ℕ ℚ≥0`), so `countable_of_isLocalization (nonZeroDivisors ℕ) ℚ≥0` gives countability and `mk_eq_aleph0` pins #ℚ≥0 = ℵ₀. The point is generality: the localization principle is not special to the ℤ → ℚ construction — a different base ring (ℕ) and a different fraction object (ℚ≥0, which is not even a field) fall out of exactly the same one-line proof, underscoring that only countability of the base is used.",
+    "mathContext": "$\\#\\mathbb{Q}_{\\ge 0} = \\aleph_0 \\text{ via } IsFractionRing\\,\\mathbb{N}\\,\\mathbb{Q}_{\\ge 0}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "NNRat.isFractionRing",
+      "non-negative rationals",
+      "generality of the principle",
+      "semiring localization"
+    ],
+    "prerequisites": [
+      "countable_of_isLocalization",
+      "NNRat.isFractionRing"
+    ]
   }
 ]

--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -78,7 +78,8 @@
       "**Localization preserves denumerability.** The construction that builds ℚ from ℤ — inverting a multiplicative set — only ever forms a surjective image of R × M. Countability is therefore automatic; no fraction is ever 'new' from a cardinality standpoint.",
       "**The denumerable analogue of a Fintype result Mathlib left open.** Mathlib has `IsLocalization.fintype'` with the note that it 'cannot be an instance'. The countable version `countable_of_isLocalization` is not in Mathlib; here it is supplied and, for the canonical `Localization M` and `FractionRing R`, packaged as honest instances.",
       "**The loop closes on the root problem.** #ℚ = ℵ₀ is re-derived not by an explicit enumeration but as `IsFractionRing ℤ ℚ` plugged into the general principle — exhibiting Cantor's denumerability of the rationals as one instance of 'localizations of countable rings stay countable'.",
-      "**Only countability and injectivity are used.** The multiplicative structure of M and the ring axioms of S play no role in the count; the argument is purely the surjection R × M ↠ S plus, for infinitude, one injective coefficient map R ↪ FractionRing R."
+      "**Only countability and injectivity are used.** The multiplicative structure of M and the ring axioms of S play no role in the count; the argument is purely the surjection R × M ↠ S plus, for infinitude, one injective coefficient map R ↪ FractionRing R.",
+      "**The same one-line proof handles ℚ and ℚ≥0 over different base rings.** #ℚ = ℵ₀ comes from IsFractionRing ℤ ℚ and #ℚ≥0 = ℵ₀ from IsFractionRing ℕ ℚ≥0; that a non-field fraction object over a semiring base falls out of the identical argument shows the count depends only on countability of the base, not on any field or characteristic-zero structure."
     ],
     "prerequisites": [
       "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types, mk_le_aleph0)",
@@ -115,9 +116,17 @@
       "id": "rationals",
       "title": "Closing the Loop: the Rationals",
       "startLine": 85,
+      "endLine": 92,
+      "summary": "mk_rat_eq_aleph0 re-derives #ℚ = ℵ₀ by feeding Rat.isFractionRing (IsFractionRing ℤ ℚ) into countable_of_isLocalization, then mk_eq_aleph0 — the abstract localization principle reproving Cantor's classical fact.",
+      "mathContext": "$\\#\\mathbb{Q} = \\aleph_0$ via $IsFractionRing\\,\\mathbb{Z}\\,\\mathbb{Q}$."
+    },
+    {
+      "id": "nnrat",
+      "title": "The Non-Negative Rationals ℚ≥0",
+      "startLine": 94,
       "endLine": 100,
-      "summary": "mk_rat_eq_aleph0 (#ℚ = ℵ₀ via IsFractionRing ℤ ℚ) and mk_nnrat_eq_aleph0 (#ℚ≥0 = ℵ₀ via IsFractionRing ℕ ℚ≥0).",
-      "mathContext": "$\\mathbb{Q} = \\mathrm{Frac}(\\mathbb{Z})$, so $\\#\\mathbb{Q} = \\aleph_0$ is the general principle specialized."
+      "summary": "mk_nnrat_eq_aleph0 runs the identical one-line proof for ℚ≥0 = Frac(ℕ) (NNRat.isFractionRing), showing the principle is not special to ℤ→ℚ: a different base ring and a non-field fraction object fall out unchanged.",
+      "mathContext": "$\\#\\mathbb{Q}_{\\ge 0} = \\aleph_0$ via $IsFractionRing\\,\\mathbb{N}\\,\\mathbb{Q}_{\\ge 0}$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-05-oq-01-oq-01-oq-01` (quality 91 → 100, pass 0).

The entry sat exactly at the role's minimum thresholds (4 annotations/sections/keyInsights vs the target of at least 5). Its Part-3 annotation and section bundled two genuinely distinct results — the headline ℚ theorem and the ℚ≥0 variant over a different base ring — so this pass separates them and adds the generality insight:

- **Annotations 4 → 5**: split the Part-3 annotation into `mk_rat_eq_aleph0` (ℚ from IsFractionRing ℤ ℚ; lines 85–92) and `mk_nnrat_eq_aleph0` (ℚ≥0 from IsFractionRing ℕ ℚ≥0; lines 94–100).
- **Sections 4 → 5**: split the matching section identically, preserving contiguous coverage.
- **keyInsights 4 → 5**: added that the same one-line proof handles ℚ and ℚ≥0 over different base rings (ℤ, ℕ), so the count depends only on countability of the base — not on any field/characteristic-zero structure.

meta.json well under the 60 KB cap; no content removed. `status`/`badge`/`axiomCount` unchanged. `pnpm build` passes; recomputed quality score is 100.