### PR TITLE
research(cayley-hamilton-oq-02-oq-01): Putzer algorithm algebraic core [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
@@ -1,0 +1,125 @@
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.Tactic
+
+/-
+# Putzer's Algorithm for the Matrix Exponential — Algebraic Core
+
+Putzer's algorithm computes the matrix exponential
+
+  e^{tA} = ∑_{k=1}^n P_k(t) · ρ_{k-1}
+
+**without diagonalizing A or computing eigenvectors**, using only the eigenvalues
+λ_1, …, λ_n (the roots of the characteristic polynomial).  Here
+
+  ρ_k = (A - λ_k · I) · … · (A - λ_1 · I),        ρ_0 = I,
+
+and the scalar coefficients P_k(t) solve the triangular linear ODE system
+
+  Ṗ_1 = λ_1 P_1,      P_1(0) = 1,
+  Ṗ_k = λ_k P_k + P_{k-1},   P_k(0) = 0   (2 ≤ k ≤ n).
+
+The completed proof differentiates M(t) := ∑_k P_k(t) ρ_{k-1} and, using the
+telescoping identity below together with the ODE relations, shows Ṁ = A·M and
+M(0) = I; ODE uniqueness against `NormedSpace.exp` then gives M(t) = e^{tA}.
+
+## This file: the purely *algebraic* scaffolding
+
+Everything here requires **no analysis** — it is the algebra that drives the
+derivative computation Ṁ = A·M.  Note that `ρ_k` is an *ordered* product of the
+(mutually commuting) factors `A - λ_i • 1`; since `Matrix n n R` is not a
+`CommMonoid` we build it by the recursion `ρ_{k+1} = ρ_k · (A - λ_k • 1)`.
+
+* `rho_succ`     : ρ_{k+1} = ρ_k · (A - λ_k • 1)                (definitional)
+* `commute_A_rho`: A commutes with every ρ_k (each factor is a polynomial in A)
+* `A_mul_rho`    : A · ρ_k = ρ_{k+1} + λ_k • ρ_k               — the *key telescoping identity*
+* `rho_card`     : ρ_n = 0  when χ_A splits as ∏ (X - λ_i)     (Cayley–Hamilton truncation)
+
+`A_mul_rho` is precisely what converts the term-by-term derivative
+d/dt (P_k ρ_{k-1}) = Ṗ_k ρ_{k-1} into a multiple of A, and `rho_card` is what makes
+the boundary term P_n ρ_n vanish so the sum closes on itself.
+
+The analytic completion (constructing P_k, differentiating the finite sum, and the
+matrix-valued ODE-uniqueness step) is deferred to a companion development.
+
+## Status
+- [x] Algebraic core: complete, no sorries
+- [ ] Analytic layer (P_k construction, Ṁ = A·M, ODE uniqueness): future work
+
+## Mathlib dependencies
+- `Matrix.aeval_self_charpoly` : Cayley–Hamilton (χ_A(A) = 0)
+- `Fin.prod_univ_eq_prod_range`, `Finset.prod_range_succ`
+- `Algebra.algebraMap_eq_smul_one`
+-/
+
+namespace PutzerMatrixExp
+
+open Matrix Polynomial BigOperators
+
+variable {n : Type*} [DecidableEq n] [Fintype n]
+variable {R : Type*} [CommRing R]
+
+/-- Putzer partial product, built by the ordered recursion
+`ρ 0 = 1`, `ρ (k+1) = ρ k · (A - λ_k • 1)`.  The factors mutually commute, so this
+is the ordinary product `∏_{i<k} (A - λ_i • 1)` written in a way that does not need
+`Matrix n n R` to be a `CommMonoid`. -/
+def rho (A : Matrix n n R) (lam : ℕ → R) : ℕ → Matrix n n R
+  | 0 => 1
+  | (k + 1) => rho A lam k * (A - lam k • (1 : Matrix n n R))
+
+@[simp] lemma rho_zero (A : Matrix n n R) (lam : ℕ → R) : rho A lam 0 = 1 := rfl
+
+/-- The defining recursion: `ρ_{k+1} = ρ_k · (A - λ_k • 1)`. -/
+lemma rho_succ (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    rho A lam (k + 1) = rho A lam k * (A - lam k • (1 : Matrix n n R)) := rfl
+
+/-- `A` commutes with each factor `A - λ_i • 1`. -/
+lemma commute_A_factor (A : Matrix n n R) (lam : ℕ → R) (i : ℕ) :
+    Commute A (A - lam i • (1 : Matrix n n R)) :=
+  (Commute.refl A).sub_right ((Commute.one_right A).smul_right (lam i))
+
+/-- `A` commutes with every partial product `ρ_k` (it is a polynomial in `A`). -/
+lemma commute_A_rho (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    Commute A (rho A lam k) := by
+  induction k with
+  | zero => simp [rho]
+  | succ k ih => rw [rho_succ]; exact ih.mul_right (commute_A_factor A lam k)
+
+lemma A_comm_rho (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    A * rho A lam k = rho A lam k * A :=
+  commute_A_rho A lam k
+
+/-- **Key telescoping identity.** `A · ρ_k = ρ_{k+1} + λ_k • ρ_k`.
+
+This is the algebraic engine of Putzer's algorithm: it lets the derivative of the
+`k`-th term be re-expressed so the whole sum telescopes into `A · M`. -/
+lemma A_mul_rho (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    A * rho A lam k = rho A lam (k + 1) + lam k • rho A lam k := by
+  rw [rho_succ, A_comm_rho, mul_sub, mul_smul_comm, mul_one]
+  abel
+
+/-- Evaluation of a linear factor: `aeval A (X - C c) = A - c • 1`. -/
+lemma aeval_X_sub_C (A : Matrix n n R) (c : R) :
+    (aeval A) (X - C c) = A - c • (1 : Matrix n n R) := by
+  rw [map_sub, aeval_X, aeval_C, Algebra.algebraMap_eq_smul_one]
+
+/-- `ρ_k` is the evaluation at `A` of the (commutative, in `R[X]`) partial product
+`∏_{i<k} (X - λ_i)`. -/
+lemma rho_eq_aeval_prod (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    rho A lam k = (aeval A) (∏ i ∈ Finset.range k, (X - C (lam i))) := by
+  induction k with
+  | zero => simp [rho]
+  | succ k ih =>
+    rw [rho_succ, ih, Finset.prod_range_succ, map_mul, aeval_X_sub_C]
+
+/-- **Cayley–Hamilton truncation.** When the characteristic polynomial splits as
+`χ_A = ∏ i, (X - λ_i)`, the top partial product vanishes: `ρ_n = 0`.
+
+This is what makes Putzer's sum finite (it stops at `n` terms) and forces the
+boundary term `P_n ρ_n` to drop out of the derivative computation. -/
+lemma rho_card {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam : ℕ → R)
+    (hlam : A.charpoly = ∏ i : Fin n, (X - C (lam i))) :
+    rho A lam n = 0 := by
+  rw [rho_eq_aeval_prod, ← Fin.prod_univ_eq_prod_range (fun i => X - C (lam i)) n, ← hlam,
+      Matrix.aeval_self_charpoly]
+
+end PutzerMatrixExp

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "choq0201-rho-recursion",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 73 },
+    "type": "technique",
+    "title": "Ordered recursion instead of Finset.prod",
+    "content": "The Putzer partial product ρₖ = ∏_{i<k}(A - λᵢ•1) cannot be written with `∏` (Finset.prod), because that requires the codomain to be a `CommMonoid` and matrix multiplication is not commutative. The fix is to define ρ by the ordered recursion ρ₀ = 1, ρ_{k+1} = ρₖ·(A - λₖ•1). With this definition rho_zero and rho_succ are both `rfl`, and every later lemma proceeds by induction on k rather than by product-manipulation lemmas. This structural choice is what makes the whole file typecheck.",
+    "mathContext": "$\\rho_0 = I,\\quad \\rho_{k+1} = \\rho_k\\,(A - \\lambda_k I)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Putzer's algorithm",
+      "matrix exponential",
+      "noncommutative products"
+    ],
+    "prerequisites": [
+      "structural recursion on ℕ",
+      "Matrix as a (noncommutative) ring"
+    ]
+  },
+  {
+    "id": "choq0201-commute",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 75, "endLine": 89 },
+    "type": "technique",
+    "title": "A commutes with every partial product",
+    "content": "Each factor A - λᵢ•1 commutes with A (commute_A_factor, built from Commute.refl, Commute.sub_right, and Commute.smul_right). Commutation then propagates through the recursion: commute_A_rho does induction on k, using Commute.mul_right at the successor step, so A·ρₖ = ρₖ·A. This is the fact that lets ρₖ·A be rewritten as ρₖ·((A-λₖ•1) + λₖ•1) in the telescoping identity.",
+    "mathContext": "$A\\,\\rho_k = \\rho_k\\,A$ for all $k$, since $\\rho_k \\in R[A]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "commuting matrices",
+      "polynomials in a matrix"
+    ],
+    "prerequisites": [
+      "Commute API (Commute.mul_right, Commute.sub_right, Commute.smul_right)"
+    ]
+  },
+  {
+    "id": "choq0201-telescoping",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "key-result",
+    "title": "The key telescoping identity A·ρₖ = ρ_{k+1} + λₖ•ρₖ",
+    "content": "The algebraic engine of Putzer's algorithm. Rewriting ρ_{k+1} = ρₖ·(A - λₖ•1) and using A·ρₖ = ρₖ·A gives A·ρₖ = ρₖ·A = ρₖ·(A - λₖ•1) + λₖ•ρₖ = ρ_{k+1} + λₖ•ρₖ; the final cancellation is closed by `abel`. In the full proof this identity converts the derivative of the k-th term, d/dt(Pₖ ρ_{k-1}) = Ṗₖ ρ_{k-1}, into a multiple of A, so that after the index shift the finite sum M(t) = ∑ₖ Pₖ(t)ρ_{k-1} satisfies Ṁ = A·M.",
+    "mathContext": "$A\\,\\rho_k = \\rho_{k+1} + \\lambda_k\\,\\rho_k$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Putzer's algorithm",
+      "linear ODE ẋ = Ax",
+      "telescoping"
+    ],
+    "prerequisites": [
+      "mul_sub, mul_smul_comm",
+      "abel tactic"
+    ]
+  },
+  {
+    "id": "choq0201-truncation",
+    "proofId": "cayley-hamilton-oq-02-oq-01",
+    "range": { "startLine": 100, "endLine": 123 },
+    "type": "key-result",
+    "title": "Cayley–Hamilton truncation ρₙ = 0",
+    "content": "The bridge lemma rho_eq_aeval_prod proves ρₖ = aeval A (∏_{i<k}(X - C λᵢ)) by induction — crucially the product now lives in the COMMUTATIVE ring R[X], so Finset.prod_range_succ and map_mul apply, and matrix noncommutativity is confined to one map_mul step per stage. At k = n, converting the Fin n univ-product to a range-product and substituting the splitting hypothesis χ_A = ∏(X - C λᵢ) turns the right side into aeval A χ_A, which is 0 by Matrix.aeval_self_charpoly. Hence ρₙ = 0: Putzer's sum truncates at n terms and the boundary term Pₙρₙ vanishes.",
+    "mathContext": "$\\rho_n = (\\mathrm{aeval}\\,A)\\,\\chi_A = 0$ when $\\chi_A = \\prod_i (X - \\lambda_i)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cayley–Hamilton theorem",
+      "characteristic polynomial",
+      "aeval as an algebra homomorphism"
+    ],
+    "prerequisites": [
+      "Matrix.aeval_self_charpoly",
+      "Fin.prod_univ_eq_prod_range",
+      "Algebra.algebraMap_eq_smul_one"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "cayley-hamilton-oq-02-oq-01",
+  "slug": "cayley-hamilton-oq-02-oq-01",
+  "title": "Putzer's Algorithm: Algebraic Core (Telescoping Identity & Cayley–Hamilton Truncation)",
+  "description": "Establishes the purely algebraic scaffolding of Putzer's algorithm for the matrix exponential e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}, where ρₖ = (A-λₖI)…(A-λ₁I) is the ordered partial product of the eigenfactors. Proves the two identities that drive the (deferred) derivative computation Ṁ = A·M: the key telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0 (when χ_A splits as ∏(X-λᵢ)). Defines ρ by an ordered recursion so no CommMonoid structure on matrices is required, and proves A commutes with every ρₖ. The analytic layer (constructing the ODE coefficients Pₖ, differentiating the finite sum, and matrix-valued ODE uniqueness against NormedSpace.exp) is NOT included and is documented as future work. 9 lemmas, 1 definition, 0 axioms, 0 sorries.",
+  "problemStatement": "Formalize Putzer's algorithm: given eigenvalues λ₁,…,λₙ of A, prove e^{tA} = ∑ₖ Pₖ(t)ρₖ where ρₖ = ∏_{i<k}(A-λᵢI) and Ṗₖ = λₖPₖ + Pₖ₋₁. This entry contributes the verified algebraic core; the analytic completion remains open.",
+  "meta": {
+    "author": "Lean Genius (researcher-15)",
+    "date": "2026-07-02",
+    "dateAdded": "2026-07-02",
+    "status": "verified",
+    "badge": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ02OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "matrix-exponential",
+      "putzer-algorithm",
+      "ordinary-differential-equations"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 125,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "Derives from Mathlib's Cayley–Hamilton theorem (Matrix.aeval_self_charpoly). All results are fully machine-checked over an arbitrary CommRing R (0 sorries, 0 axiom declarations, no structure-encoded assumptions). SCOPE: this file proves only the ALGEBRAIC core of Putzer's algorithm — the telescoping identity and ρₙ = 0. It does NOT prove the full analytic identity e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}; the ODE-coefficient construction and the matrix-valued ODE-uniqueness step are deferred future work, so the parent's open question is only partially answered.",
+    "originalContributions": [
+      "rho: ordered recursion ρ₀=1, ρ_{k+1}=ρₖ·(A-λₖ•1) giving the Putzer partial product without needing a CommMonoid instance on Matrix n n R",
+      "commute_A_rho: A commutes with every partial product ρₖ (each factor is a polynomial in A)",
+      "A_mul_rho: the key telescoping identity A·ρₖ = ρ_{k+1} + λₖ•ρₖ — the algebraic engine that lets the derivative Ṁ collapse to A·M",
+      "rho_eq_aeval_prod: ρₖ = aeval A (∏_{i<k}(X - C λᵢ)), bridging the ordered matrix product to the commutative polynomial product",
+      "rho_card: Cayley–Hamilton truncation ρₙ = 0 when χ_A = ∏(X - λᵢ), making Putzer's sum finite and killing the boundary term Pₙρₙ"
+    ]
+  },
+  "leanFile": {
+    "namespace": "PutzerMatrixExp",
+    "path": "Proofs/CayleyHamiltonOQ02OQ01.lean",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "E. J. Putzer's 1966 American Mathematical Monthly note 'Avoiding the Jordan Canonical Form in the Discussion of Linear Systems with Constant Coefficients' gives a way to compute e^{tA} — the fundamental solution of ẋ = Ax — using only the eigenvalues of A (roots of the characteristic polynomial), never the eigenvectors or the Jordan form. The recipe forms the running products ρₖ = ∏_{i≤k}(A-λᵢI), solves a triangular chain of scalar first-order ODEs for coefficient functions Pₖ(t), and assembles e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}. Because ρₙ = χ_A(A) = 0 by Cayley–Hamilton, the sum truncates at n terms and always lies inside the commutative subalgebra ℂ[A]. This entry formalizes the algebraic heart of that construction; it is the direct child of cayley-hamilton-oq-02, whose leading open question asked for exactly this formalization.",
+    "problemStatement": "Prove the algebraic identities underlying Putzer's algorithm: the telescoping recursion A·ρₖ = ρ_{k+1} + λₖ·ρₖ and the vanishing ρₙ = 0.",
+    "text": "Define the ordered partial products ρ₀ = I and ρ_{k+1} = ρₖ·(A - λₖI). Since matrix multiplication is not commutative, ρ is built by recursion rather than as a Finset.prod (which would require a CommMonoid). The factors (A - λᵢI) nevertheless mutually commute and commute with A, so A·ρₖ = ρₖ·A. Writing ρₖ·A = ρₖ·((A-λₖI) + λₖI) = ρ_{k+1} + λₖρₖ gives the telescoping identity. Separately, ρₖ equals aeval A of the commutative polynomial product ∏_{i<k}(X - λᵢ); at k = n this is aeval A χ_A = 0 by Cayley–Hamilton (Matrix.aeval_self_charpoly).",
+    "proofStrategy": "For the telescoping identity: rewrite ρ_{k+1} via the recursion, use commutativity A·ρₖ = ρₖ·A, expand and cancel with abel. For ρₙ = 0: prove ρₖ = aeval A (∏_{i<k}(X - C λᵢ)) by induction (the polynomial product lives in the commutative ring R[X], so map_mul and Finset.prod_range_succ apply cleanly), convert the univ-product over Fin n to a range-product, substitute the splitting hypothesis, and apply Matrix.aeval_self_charpoly.",
+    "keyInsights": [
+      "Matrix n n R is NOT a CommMonoid under multiplication, so the partial product ρₖ must be defined by an ordered recursion, not by ∏ (Finset.prod) — this is the key structural choice that makes the whole development typecheck",
+      "The bridge lemma ρₖ = aeval A (∏_{i<k}(X - C λᵢ)) moves the product into the commutative polynomial ring R[X], where all the standard product machinery (map_mul, prod_range_succ, prod_univ_eq_prod_range) is available; the noncommutativity of matrices is confined to a single map_mul step per induction",
+      "The telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ is precisely what turns the term-by-term derivative d/dt(Pₖρ_{k-1}) = Ṗₖρ_{k-1} into a multiple of A, so that the finite sum M(t) = ∑ₖ Pₖ(t)ρ_{k-1} satisfies Ṁ = A·M",
+      "Cayley–Hamilton enters only through ρₙ = 0, which both truncates the sum to n terms and annihilates the boundary term Pₙρₙ produced by the index shift in the derivative computation",
+      "Everything holds over an arbitrary commutative ring R, not just ℂ — the analytic layer (ODEs, exp) is the only part that will require ℝ/ℂ and a normed structure"
+    ],
+    "prerequisites": [
+      "Cayley–Hamilton theorem (Matrix.aeval_self_charpoly): a matrix satisfies its characteristic polynomial",
+      "Polynomial evaluation aeval as an R-algebra homomorphism R[X] → M_n(R)",
+      "Commuting-elements API (Commute, Commute.mul_right, Commute.sub_right)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation: Putzer's Algorithm and the Algebraic Core",
+      "startLine": 4,
+      "endLine": 52,
+      "summary": "Header stating Putzer's identity e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}, the triangular ODE system for Pₖ, the four algebraic results proved here, and an explicit note that the analytic completion is deferred."
+    },
+    {
+      "id": "rho-def",
+      "title": "The Putzer partial product ρ",
+      "startLine": 61,
+      "endLine": 73,
+      "summary": "Ordered recursion ρ₀ = 1, ρ_{k+1} = ρₖ·(A - λₖ•1) (rho), with rho_zero and rho_succ. Defined recursively to avoid requiring a CommMonoid instance on matrices."
+    },
+    {
+      "id": "commutation",
+      "title": "Commutation of A with the partial products",
+      "startLine": 75,
+      "endLine": 89,
+      "summary": "commute_A_factor (A commutes with each A - λᵢ•1) and commute_A_rho (A commutes with every ρₖ, by induction), giving A·ρₖ = ρₖ·A."
+    },
+    {
+      "id": "telescoping",
+      "title": "The key telescoping identity",
+      "startLine": 91,
+      "endLine": 98,
+      "summary": "A_mul_rho: A·ρₖ = ρ_{k+1} + λₖ•ρₖ, the algebraic engine of the derivative computation Ṁ = A·M."
+    },
+    {
+      "id": "truncation",
+      "title": "Cayley–Hamilton truncation",
+      "startLine": 100,
+      "endLine": 123,
+      "summary": "aeval_X_sub_C, the bridge lemma rho_eq_aeval_prod (ρₖ = aeval A ∏(X - C λᵢ)), and rho_card (ρₙ = 0 when χ_A splits), via Matrix.aeval_self_charpoly."
+    }
+  ],
+  "conclusion": {
+    "summary": "9 lemmas, 1 definition, 125 lines, 0 axioms, 0 sorries. A verified formalization of the algebraic core of Putzer's algorithm: the ordered partial product ρₖ, its commutation with A, the telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0. Holds over any commutative ring R. This is the exact algebraic scaffolding that the derivative computation Ṁ = A·M rests on in the full proof of e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}.",
+    "implications": "The telescoping identity and the truncation ρₙ = 0 are the two facts that make Putzer's construction work: the first re-expresses each term's derivative as a multiple of A so the sum closes on itself, and the second both truncates the sum to n terms and kills the boundary term produced by the index shift. With these in hand, the remaining work is analytic: constructing the scalar coefficients Pₖ as the solutions of the triangular ODE system, differentiating the finite matrix sum term-by-term, and invoking uniqueness of the matrix-valued linear ODE Ṁ = A·M, M(0) = I against Mathlib's NormedSpace.exp.",
+    "openQuestions": [
+      "Construct the ODE coefficients Pₖ : ℝ → ℂ with HasDerivAt (P₁) (λ₁·P₁ t) t, P₁(0)=1 and HasDerivAt (Pₖ) (λₖ·Pₖ t + P_{k-1} t) t, Pₖ(0)=0, e.g. as iterated convolutions of exponentials, and prove their derivative relations.",
+      "Prove HasDerivAt (fun t => ∑ₖ Pₖ t • ρ_{k-1}) (A · M t) t by assembling HasDerivAt.sum and HasDerivAt.smul with the telescoping identity A_mul_rho and the vanishing rho_card.",
+      "Package Mathlib's ODE_solution_unique for matrix-valued functions ℝ → M_n(ℂ): the vector field M ↦ A·M is globally Lipschitz with constant ‖A‖_op, so the solution of Ṁ = A·M, M(0) = I is unique — concluding M(t) = NormedSpace.exp ℝ (t • A).",
+      "Extend from the split-characteristic-polynomial case (χ_A = ∏(X - λᵢ) over ℂ) to a general field via an algebraic closure, and relate to the minimal-polynomial variant (fewer distinct factors)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry; its leading open question asked to formalize Putzer's algorithm. This child supplies the verified algebraic core (telescoping identity + Cayley–Hamilton truncation)."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Base Cayley–Hamilton theorem (Matrix.aeval_self_charpoly), used here to prove ρₙ = 0."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Putzer, E. J.",
+      "title": "Avoiding the Jordan Canonical Form in the Discussion of Linear Systems with Constant Coefficients",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73(1), 2–7"
+    },
+    {
+      "authors": "Hirsch, M. W., Smale, S., and Devaney, R. L.",
+      "title": "Differential Equations, Dynamical Systems, and an Introduction to Chaos",
+      "year": "2013",
+      "venue": "3rd ed., Academic Press"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Matrix.aeval_self_charpoly (Cayley–Hamilton) and Polynomial.aeval; Mathlib.LinearAlgebra.Matrix.Charpoly",
+      "year": "2024",
+      "venue": "Mathlib4 (leanprover-community/mathlib4)"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New gallery entry **cayley-hamilton-oq-02-oq-01** — the verified **algebraic core** of Putzer's algorithm for the matrix exponential $e^{tA} = \sum_k P_k(t)\,\rho_{k-1}$.

This directly (and partially) answers the leading open question of the parent entry `cayley-hamilton-oq-02`: *"Formalize Putzer's algorithm: prove $e^{tA} = \sum_k P_k(t)\rho_k$ where $\rho_k = \prod_{i<k}(A-\lambda_i I)$ and $\dot P_k = \lambda_k P_k + P_{k-1}$."*

## What is proved (verified, 0 sorries, 0 axioms, over any `CommRing R`)

| Lemma | Statement |
|-------|-----------|
| `rho` | ordered recursion $\rho_0=I,\ \rho_{k+1}=\rho_k(A-\lambda_k I)$ |
| `commute_A_rho` | $A\rho_k = \rho_k A$ |
| `A_mul_rho` | **telescoping identity** $A\rho_k = \rho_{k+1} + \lambda_k\rho_k$ |
| `rho_eq_aeval_prod` | $\rho_k = \mathrm{aeval}\,A\,\prod_{i<k}(X-\lambda_i)$ |
| `rho_card` | **Cayley–Hamilton truncation** $\rho_n = 0$ when $\chi_A=\prod(X-\lambda_i)$ |

These two starred identities are exactly what the derivative computation $\dot M = A\cdot M$ rests on: the telescoping identity turns $\frac{d}{dt}(P_k\rho_{k-1})$ into a multiple of $A$, and $\rho_n=0$ truncates the sum and kills the boundary term.

### Key formalization note
`Matrix n n R` is **not** a `CommMonoid` under multiplication, so $\rho_k$ cannot be a `Finset.prod`. It is defined by an ordered recursion; the connection to the *commutative* polynomial product (where all product machinery is available) is made once, in `rho_eq_aeval_prod`.

## Scope / honesty
This file proves **only the algebraic scaffolding**. The analytic completion — constructing the ODE coefficients $P_k$, differentiating the finite matrix sum, and matrix-valued ODE uniqueness against `NormedSpace.exp` — is **not** included and is documented as future work in the entry's open questions. Status is `verified` for the lemmas actually proved; the full Putzer identity remains open.

## Verification
- Docker build **green**: `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ01`
- 9 lemmas, 1 definition, 125 lines, 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)