### PR TITLE
Enrich sperner-ndim-mathlib-oq-02: head Overview section

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-02/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Brouwer's fixed-point theorem for the n-simplex via Sperner's lemma",
+      "startLine": 1,
+      "endLine": 69,
+      "summary": "The license header, the import of Mathlib, the module docstring with full three-step proof outline, and the namespace/variable setup. Answers OQ-02 of sperner-ndim-mathlib: Brouwer's fixed-point theorem for the standard n-simplex Δⁿ, derived from Sperner's lemma applied to grid triangulations.",
+      "mathContext": "Step 1 (proved) defines the Sperner coloring c(v) = min{i ∈ supp(v) : f(v)ᵢ ≤ vᵢ}, well-defined and satisfying the boundary condition (supp_nonempty, exists_le_of_simplex_map, colorSet_nonempty, spernerColor_in_supp, spernerColor_le, spernerColor_ne_of_zero). Step 2 is the single remaining axiom sperner_panchromatic: each N-grid triangulation of Δⁿ has a panchromatic (n+1)-tuple with f(vᵢ)ᵢ ≤ (vᵢ)ᵢ and diameter ≤ n/N (its intended proof structure — Freudenthal CellComplex, odd boundary-door count by induction, CellComplex.sperner — is documented). Step 3 (proved) extracts the exact fixed point by compactness: a convergent subsequence forces f(x*)ᵢ ≤ x*ᵢ for all i, and Σf(x*)ᵢ = 1 = Σx*ᵢ makes every inequality an equality, giving brouwer_fixed_point_simplex. Honestly axiomatized: 1 axiom (sperner_panchromatic) remains — the section annotation does not change that status."
+    },
+    {
       "id": "section-simplex-support",
       "title": "Standard Simplex and Support",
       "startLine": 70,


### PR DESCRIPTION
## Enrichment: head Overview section

Adds a `sec-overview` section covering the module docstring, imports, and setup at the head of the Lean source (lines 1–69), which previously had no section annotation. Section coverage only — no change to proof content, status, or axiom count.
