### PR TITLE
Enrich derangements one-term recurrence (derangements-convergence-oq-03-oq-02): reach annotation/section/insight minimums

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-02/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-dcoq0302-header",
     "proofId": "derangements-convergence-oq-03-oq-02",
-    "range": { "startLine": 1, "endLine": 39 },
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
     "type": "concept",
     "title": "Module Overview: One-Term Recurrence and Its Modular Shadow",
     "content": "This module restates the one-term derangement recurrence in the convention D(n+1) = (n+1)·D(n) + (-1)^(n+1) requested by the open question, and then records two consequences that Mathlib does not carry: the exact one-term remainder |D(n+1) - (n+1)·D(n)| = 1, and the congruence D(m) ≡ (-1)^m (mod m). The core recurrence is a one-line restatement of Mathlib's numDerangements_succ; the value added here is the modular consequence. The file imports all of Mathlib and works entirely over ℤ, where the alternating ±1 corrections are visible.",
@@ -23,37 +26,88 @@
   {
     "id": "ann-dcoq0302-recurrence",
     "proofId": "derangements-convergence-oq-03-oq-02",
-    "range": { "startLine": 41, "endLine": 50 },
+    "range": {
+      "startLine": 41,
+      "endLine": 50
+    },
     "type": "theorem",
     "title": "numDerangements_succ_alt: the requested sign convention",
     "content": "Proves D(n+1) = (n+1)·D(n) + (-1)^(n+1). The proof rewrites Mathlib's numDerangements_succ (which gives -(-1)^n) and pow_succ (which expands (-1)^(n+1) = (-1)^n·(-1)), then ring reconciles the two. Mathematically this is a pure restatement — its purpose is to match the open question's stated convention.",
     "mathContext": "$(-1)^{n+1} = (-1)^n \\cdot (-1) = -(-1)^n$, so $+(-1)^{n+1}$ and $-(-1)^n$ are interchangeable. The recurrence itself carries no new content beyond numDerangements_succ.",
     "significance": "supporting",
-    "relatedConcepts": ["numDerangements_succ", "pow_succ", "ring"],
-    "prerequisites": ["Mathlib numDerangements_succ"]
+    "relatedConcepts": [
+      "numDerangements_succ",
+      "pow_succ",
+      "ring"
+    ],
+    "prerequisites": [
+      "Mathlib numDerangements_succ"
+    ]
   },
   {
     "id": "ann-dcoq0302-error",
     "proofId": "derangements-convergence-oq-03-oq-02",
-    "range": { "startLine": 52, "endLine": 62 },
+    "range": {
+      "startLine": 52,
+      "endLine": 62
+    },
     "type": "theorem",
     "title": "Exact one-term remainder is ±1",
     "content": "numDerangements_sub_eq rearranges the recurrence to D(n+1) - (n+1)·D(n) = (-1)^(n+1), and numDerangements_abs_sub takes absolute values to conclude |D(n+1) - (n+1)·D(n)| = 1. This says the 'multiply by n+1' approximation to D has a remainder that is always exactly one in magnitude — the discrete analogue of the |D(n) - n!/e| < 1/2 rounding bound from the parent entry.",
     "mathContext": "$|(-1)^{n+1}| = 1$ via abs_pow / abs_neg / abs_one / one_pow. The remainder is exact, not asymptotic.",
     "significance": "supporting",
-    "relatedConcepts": ["abs_pow", "abs_neg", "one_pow"],
-    "prerequisites": ["numDerangements_succ_alt"]
+    "relatedConcepts": [
+      "abs_pow",
+      "abs_neg",
+      "one_pow"
+    ],
+    "prerequisites": [
+      "numDerangements_succ_alt"
+    ]
   },
   {
     "id": "ann-dcoq0302-modular",
     "proofId": "derangements-convergence-oq-03-oq-02",
-    "range": { "startLine": 64, "endLine": 82 },
+    "range": {
+      "startLine": 64,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "Modular consequence: D(m) ≡ (-1)^m (mod m)",
-    "content": "numDerangements_modEq proves D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. The proof rewrites with the recurrence, observes that (n+1)·D(n) is divisible by n+1 (Dvd.intro), turns that into the congruence (n+1)·D(n) ≡ 0 [ZMOD (n+1)] (Int.modEq_zero_iff_dvd), adds (-1)^(n+1) to both sides (Int.ModEq.add_right), and simplifies 0 + (-1)^(n+1). Equivalently, for every m ≥ 1, D(m) ≡ (-1)^m (mod m): the derangement count is congruent to ±1 modulo its order. A sanity check D(4) = 9 (= 4·2 + 1) closes the file. This congruence is the genuinely new content of the entry — it is not in Mathlib.",
+    "content": "numDerangements_modEq proves D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. The proof rewrites with the recurrence, observes that (n+1)·D(n) is divisible by n+1 (Dvd.intro), turns that into the congruence (n+1)·D(n) ≡ 0 [ZMOD (n+1)] (Int.modEq_zero_iff_dvd), adds (-1)^(n+1) to both sides (Int.ModEq.add_right), and simplifies 0 + (-1)^(n+1). Equivalently, for every m ≥ 1, D(m) ≡ (-1)^m (mod m): the derangement count is congruent to ±1 modulo its order. This congruence is the genuinely new content of the entry — it is not in Mathlib.",
     "mathContext": "Modulo $n+1$, the multiple $(n+1)D(n) \\equiv 0$, so the recurrence collapses to $D(n+1) \\equiv (-1)^{n+1} \\pmod{n+1}$. For even $m$, $D(m) \\equiv 1$; for odd $m$, $D(m) \\equiv -1 \\equiv m-1 \\pmod m$.",
     "significance": "key",
-    "relatedConcepts": ["Int.ModEq", "Int.modEq_zero_iff_dvd", "Int.ModEq.add_right", "Dvd.intro"],
-    "prerequisites": ["numDerangements_succ_alt", "Int.ModEq API"]
+    "relatedConcepts": [
+      "Int.ModEq",
+      "Int.modEq_zero_iff_dvd",
+      "Int.ModEq.add_right",
+      "Dvd.intro"
+    ],
+    "prerequisites": [
+      "numDerangements_succ_alt",
+      "Int.ModEq API"
+    ]
+  },
+  {
+    "id": "ann-dcoq0302-sanity",
+    "proofId": "derangements-convergence-oq-03-oq-02",
+    "range": {
+      "startLine": 78,
+      "endLine": 82
+    },
+    "type": "example",
+    "title": "Sanity check: D(4) = 9",
+    "content": "The closing example verifies numDerangements 4 = 9 by kernel `decide` (not native_decide, so no Lean.ofReduceBool axiom is introduced), grounding the recurrence numerically: 9 = 4·D(3) + (-1)^4 = 4·2 + 1. It simultaneously witnesses the ±1 remainder (9 − 8 = 1) and the modular consequence (9 ≡ 1 ≡ (-1)^4 mod 4). Concretely the derangement counts run 1, 0, 1, 2, 9, 44, 265, … (Mathlib's numDerangements), and D(4) = 9 is the first value large enough to make the +1 correction visibly nontrivial.",
+    "mathContext": "$D(4) = 9 = 4\\cdot D(3) + (-1)^4 = 4\\cdot 2 + 1$; and $9 \\equiv 1 \\equiv (-1)^4 \\pmod 4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide vs native_decide",
+      "numDerangements small values",
+      "worked example"
+    ],
+    "prerequisites": [
+      "numDerangements_succ_alt",
+      "Decidable evaluation of numDerangements"
+    ]
   }
 ]

--- a/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-02/meta.json
@@ -56,7 +56,8 @@
       "The two sign conventions are the *same* recurrence: (-1)^(n+1) = -(-1)^n, so D(n+1) = (n+1)·D(n) + (-1)^(n+1) is `pow_succ` + `ring` away from Mathlib's numDerangements_succ. The mathematical content of the restatement is zero; its value is matching the open question's stated form.",
       "The genuinely new content is the modular congruence D(m) ≡ (-1)^m (mod m). Because the one-term recurrence has a single correction term of size 1, reducing mod (n+1) annihilates the (n+1)·D(n) term and leaves only the ±1. This is a clean arithmetic fact about derangement numbers that does not appear in Mathlib.",
       "The error bound |D(n+1) - (n+1)·D(n)| = 1 is exact, not asymptotic: the one-term recurrence is the tightest possible 'multiply by n+1' approximation, with a remainder that never exceeds 1 in absolute value. This is the discrete analogue of the |D(n) - n!/e| < 1/2 rounding bound proved in the sibling entry derangements-convergence-oq-03.",
-      "Working over ℤ (rather than ℕ) is essential: the corrections (-1)^(n+1) are signed, and subtraction D(n+1) - (n+1)·D(n) underflows in ℕ. The cast to ℤ is what makes the alternating structure visible."
+      "Working over ℤ (rather than ℕ) is essential: the corrections (-1)^(n+1) are signed, and subtraction D(n+1) - (n+1)·D(n) underflows in ℕ. The cast to ℤ is what makes the alternating structure visible.",
+      "The congruence D(m) ≡ (-1)^m (mod m) forces m ∤ D(m) for every m ≥ 2: since (-1)^m = ±1 and ±1 ≢ 0 (mod m) once m ≥ 2, the number of derangements is never divisible by its own order — a clean divisibility corollary of the one-term recurrence."
     ],
     "prerequisites": [
       "numDerangements_succ from Mathlib (the one-term derangement recurrence)",
@@ -93,9 +94,17 @@
       "id": "sec-modular",
       "title": "Modular Consequence: D(m) ≡ (-1)^m (mod m)",
       "startLine": 64,
-      "endLine": 82,
-      "summary": "numDerangements_modEq: D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. Reduces the recurrence mod (n+1): the term (n+1)·D(n) is divisible by n+1 hence ≡ 0, and adding (-1)^(n+1) via Int.ModEq.add_right gives the result. Closes with a sanity check D(4) = 9 = 4·2 + 1.",
+      "endLine": 77,
+      "summary": "numDerangements_modEq: D(n+1) ≡ (-1)^(n+1) [ZMOD (n+1)]. Reduces the recurrence mod (n+1): the term (n+1)·D(n) is divisible by n+1 hence ≡ 0, and adding (-1)^(n+1) via Int.ModEq.add_right gives the result — equivalently D(m) ≡ (-1)^m (mod m) for every m ≥ 1.",
       "mathContext": "Modulo $n+1$, the multiple $(n+1)D(n)$ vanishes, leaving $D(n+1) \\equiv (-1)^{n+1} \\pmod{n+1}$; equivalently $D(m) \\equiv (-1)^m \\pmod m$ for every $m \\geq 1$."
+    },
+    {
+      "id": "sec-sanity",
+      "title": "Sanity Check D(4) = 9",
+      "startLine": 78,
+      "endLine": 82,
+      "summary": "A kernel-decide example verifies numDerangements 4 = 9, matching 9 = 4·2 + (-1)^4 and witnessing both the ±1 remainder and the mod-4 congruence.",
+      "mathContext": "$D(4) = 9 = 4\\cdot 2 + 1$, with $9 \\equiv 1 \\pmod 4$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-03-oq-02` (quality 91 → 100, pass 0).

The entry sat exactly at the role's minimum thresholds (4 annotations/sections/keyInsights vs the target of at least 5). Its modular annotation and section bundled the `numDerangements_modEq` theorem with the D(4)=9 sanity check, so this pass separates the concrete verification and adds a divisibility corollary insight:

- **Annotations 4 → 5**: split off the D(4)=9 example (lines 78–82) from the modular-congruence theorem (64–77); the new annotation notes the kernel-`decide` (no Lean.ofReduceBool) check verifies 9 = 4·2 + (-1)⁴ and witnesses both the ±1 remainder and the mod-4 congruence.
- **Sections 4 → 5**: split the matching section identically.
- **keyInsights 4 → 5**: added that D(m) ≡ (-1)ᵐ (mod m) forces m ∤ D(m) for every m ≥ 2 (since ±1 ≢ 0 mod m) — the derangement count is never divisible by its own order.

meta.json well under the 60 KB cap; no content removed. `status`/`badge`/`axiomCount` unchanged (verified, 0 axioms, 0 sorries). JSON validated and quality score recomputed to 100 (`find-targets`); the gallery data-build regenerated cleanly.