### PR TITLE
Enrich lagrange-theorem-oq-01-oq-03-oq-01: head Overview section

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03-oq-01/meta.json
@@ -52,6 +52,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Hall's theorem — the Schur–Zassenhaus lifting step (0 axioms)",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "The group-theory imports (SchurZassenhaus, Solvable, Sylow, Tactic) and the module docstring. Settles OQ-01 of the parent: rather than rebuild Schur–Zassenhaus from scratch, it corrects the parent's factually wrong justification (Mathlib 4.26 does contain Schur–Zassenhaus as Subgroup.exists_right_complement'_of_coprime) and isolates the genuine remaining obstacle — the minimal normal subgroup machinery — proving the precise inductive mechanism the parent axiomatized away, with 0 axioms.",
+      "mathContext": "Hall's proof inducts on |G|; in the branch where the chosen normal subgroup N has order coprime to the target d, a subgroup of order d in G/N lifts to one in G — exactly Schur–Zassenhaus inside the preimage. Results (all 0-axiom): hall_lift_of_coprime (the lifting step) and hall_lift_of_coprime_subgroup (the lift can be taken inside the preimage); schur_zassenhaus_available (witnessing Mathlib's theorem exists); exists_minimal_normal / exists_minimal_normal_atom (every nontrivial finite group has a minimal nontrivial normal subgroup, stated as a lattice atom); minimal_normal_abelian_of_solvable (a minimal normal subgroup of a solvable group is abelian) assembled as exists_abelian_minimal_normal. What remains for a full 0-axiom hall_solvable is only that an abelian minimal normal subgroup is a p-group (its p-torsion is characteristic, hence normal, hence all of N by minimality) plus the induction bookkeeping — a refinement, not a new obstruction."
+    },
+    {
       "id": "schur-zassenhaus-available",
       "title": "Schur–Zassenhaus Is Available in Mathlib",
       "startLine": 68,


### PR DESCRIPTION
## Enrichment: head Overview section

Adds a `sec-overview` section covering the module docstring, imports, and setup at the head of the Lean source (lines 1–67), which previously had no section annotation. Section coverage only — no change to proof content, status, or axiom count.
