### PR TITLE
research(sperner-simplicial-instance-oq-04): continuous 1-d IVT via the discrete Sperner bracket [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ04.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ04.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 RJ Walters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: researcher-8
+Authors: researcher-8, researcher-9
 -/
 import Mathlib
 import Proofs.SpernerSimplicialInstance
@@ -22,10 +22,15 @@ discrete intermediate-value theorem
 
 The output is, for **every** mesh `m > 0`, a width-`1/m` cell whose two endpoints
 straddle a sign change of `f`. This is the discrete intermediate-value theorem
-for a real-valued `f`, and it is the base from which the continuous IVT follows
-by letting `m → ∞` (Bolzano–Weierstrass + continuity); that limit step, and the
-`n`-dimensional Brouwer derivation via barycentric subdivision, are recorded as
-the open remainder in `knowledge.md` — they are not in this file.
+for a real-valued `f`, and it is the base from which the **continuous IVT** now
+follows in this file (`continuous_ivt_of_bridge`) by letting `m → ∞`: extract a
+convergent subsequence of the bracket left-endpoints via Bolzano–Weierstrass on
+the compact `[0,1]`, push it through the continuity of `f`, and read off a root
+from `f(x*)² ≤ 0`. The derivation goes *through the discrete Sperner bracket*
+(`exists_sign_change_bracket`), not through Mathlib's `intermediate_value_Icc`.
+
+The remaining `n`-dimensional Brouwer derivation via barycentric subdivision is
+recorded as the open remainder in `knowledge.md` — it is not in this file.
 
 No `sorry`, no `axiom`. Builds on the axiom-free discrete theorem.
 -/
@@ -33,6 +38,7 @@ No `sorry`, no `axiom`. Builds on the axiom-free discrete theorem.
 namespace SpernerSimplicialInstanceOQ04
 
 open SpernerSimplicialInstanceOQ05Scarf1d
+open Filter Topology
 
 /-- The `j`-th mesh point of `{0, 1/m, …, 1}`: `meshPt m j = j / m`. -/
 noncomputable def meshPt (m : ℕ) (j : ℕ) : ℝ := (j : ℝ) / (m : ℝ)
@@ -103,5 +109,80 @@ theorem exists_sign_change_bracket (f : ℝ → ℝ) {m : ℕ} (hm : 0 < m)
   rcases hi with ⟨ha, hb⟩ | ⟨ha, hb⟩
   · exact mul_nonpos_iff.mpr (Or.inr ⟨ha, hb.le⟩)
   · exact mul_nonpos_iff.mpr (Or.inl ⟨ha.le, hb⟩)
+
+/-- **Continuous intermediate-value theorem, derived from the discrete Sperner
+bracket** (interval case of Brouwer, part (b) of `oq-04`).
+
+For any continuous `f : ℝ → ℝ` with `f 0 ≤ 0 ≤ f 1` there is a point
+`x ∈ [0,1]` with `f x = 0`.
+
+The proof is the genuine `m → ∞` limit of the discrete bridge, **not** a call to
+Mathlib's `intermediate_value_Icc`:
+
+1. For each mesh `m = n+1`, `exists_sign_change_bracket` yields a width-`1/m`
+   cell `[aₙ, bₙ] ⊆ [0,1]` with `f(aₙ)·f(bₙ) ≤ 0`.
+2. `aₙ ∈ [0,1]` (compact), so Bolzano–Weierstrass (`IsCompact.tendsto_subseq`)
+   gives a subsequence `a_{φ k} → x*` with `x* ∈ [0,1]`.
+3. `bₙ - aₙ = 1/(n+1) → 0`, hence `b_{φ k} → x*` as well.
+4. Continuity of `f` passes both limits through:
+   `f(a_{φ k})·f(b_{φ k}) → f(x*)²`. Each factor product is `≤ 0`, so the limit
+   `f(x*)² ≤ 0`; with `f(x*)² ≥ 0` this forces `f(x*) = 0`. -/
+theorem continuous_ivt_of_bridge (f : ℝ → ℝ) (hf : Continuous f)
+    (h0 : f 0 ≤ 0) (h1 : 0 ≤ f 1) :
+    ∃ x ∈ Set.Icc (0 : ℝ) 1, f x = 0 := by
+  -- Degenerate case `f 1 = 0`: the right endpoint is already a root.
+  rcases eq_or_lt_of_le h1 with h1' | h1'
+  · exact ⟨1, Set.mem_Icc.mpr ⟨zero_le_one, le_refl 1⟩, h1'.symm⟩
+  -- Main case `0 < f 1`: run the mesh-refinement limit of the discrete bridge.
+  -- Package a bracket cell for every mesh `m = n+1`.
+  have bracket : ∀ n : ℕ, ∃ q : ℝ × ℝ,
+      q.1 ∈ Set.Icc (0 : ℝ) 1 ∧ q.2 ∈ Set.Icc (0 : ℝ) 1 ∧
+        q.2 - q.1 = 1 / ((n : ℝ) + 1) ∧ f q.1 * f q.2 ≤ 0 := by
+    intro n
+    obtain ⟨i, hi⟩ := exists_sign_change_bracket f (Nat.succ_pos n) h0 h1'
+    refine ⟨(meshPt (n + 1) i.val, meshPt (n + 1) (i.val + 1)), ?_, ?_, ?_, hi⟩
+    · refine ⟨?_, ?_⟩
+      · simp only [meshPt]; positivity
+      · simp only [meshPt]
+        rw [div_le_one (by exact_mod_cast Nat.succ_pos n)]
+        exact_mod_cast i.isLt.le
+    · refine ⟨?_, ?_⟩
+      · simp only [meshPt]; positivity
+      · simp only [meshPt]
+        rw [div_le_one (by exact_mod_cast Nat.succ_pos n)]
+        exact_mod_cast Nat.succ_le_of_lt i.isLt
+    · simp only [meshPt]
+      rw [div_sub_div_same]
+      push_cast
+      ring
+  -- Extract the bracket sequences.
+  choose q hq1 hq2 hdiff hprod using bracket
+  -- Bolzano–Weierstrass on the compact `[0,1]` for the left endpoints.
+  obtain ⟨x, hx, φ, hφ, hconv⟩ := isCompact_Icc.tendsto_subseq hq1
+  -- `1/(φ k + 1) → 0`, since `φ` is strictly monotone (hence `→ ∞`).
+  have hzero : Tendsto (fun k => 1 / ((φ k : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat.comp hφ.tendsto_atTop
+  -- Right endpoints converge to the same limit `x`.
+  have hconvb : Tendsto (fun k => (q (φ k)).2) atTop (𝓝 x) := by
+    have hsum := hconv.add hzero
+    rw [add_zero] at hsum
+    refine hsum.congr (fun k => ?_)
+    have hd := hdiff (φ k)
+    simp only [Function.comp]
+    linarith [hd]
+  -- Push both limits through continuity of `f`.
+  have hfa : Tendsto (fun k => f ((q (φ k)).1)) atTop (𝓝 (f x)) := by
+    have := (hf.tendsto x).comp hconv
+    simpa [Function.comp] using this
+  have hfb : Tendsto (fun k => f ((q (φ k)).2)) atTop (𝓝 (f x)) := by
+    have := (hf.tendsto x).comp hconvb
+    simpa [Function.comp] using this
+  -- The product of the (nonpositive) bracket values converges to `f x * f x`.
+  have hle : f x * f x ≤ 0 := by
+    refine le_of_tendsto (hfa.mul hfb) ?_
+    filter_upwards with k using hprod (φ k)
+  -- `f x * f x ≤ 0` and `≥ 0` force `f x = 0`.
+  have hsq : f x * f x = 0 := le_antisymm hle (mul_self_nonneg _)
+  exact ⟨x, hx, mul_self_eq_zero.mp hsq⟩
 
 end SpernerSimplicialInstanceOQ04

--- a/research/problems/sperner-simplicial-instance-oq-04/knowledge.md
+++ b/research/problems/sperner-simplicial-instance-oq-04/knowledge.md
@@ -10,14 +10,64 @@ of `|f(x₀)| → 0` for any continuous `f : [0,1] → [-1,1]` with `f(0) ≤ 0 
 
 | Part | Content | Status | Size |
 |------|---------|--------|------|
-| (a) | Discrete sign-change for real `f` (continuous-coloring → Sperner-coloring reduction) | **DONE (this session)** | ~90 lines |
-| (b) | Continuous 1-d IVT via mesh refinement + Bolzano–Weierstrass | OPEN, tractable | ~150 lines |
+| (a) | Discrete sign-change for real `f` (continuous-coloring → Sperner-coloring reduction) | **DONE (S1)** | ~90 lines |
+| (b) | Continuous 1-d IVT via mesh refinement + Bolzano–Weierstrass | **DONE (S2), VERIFIED 0-axiom** | ~86 lines |
 | (c) | `n`-d Brouwer via barycentric subdivision + `sperner-ndim` | BLOCKED | >1000 lines |
 
 The **discrete IVT itself** (`c(0) ≠ c(m) ⟹ ∃` panchromatic cell) was already
 proven in the sibling `SpernerSimplicialInstanceOQ05Scarf1d.lean`
 (`discrete_ivt_panchromatic_cell`). oq-04 only adds the real-function reduction
 layer on top of it; there is no new combinatorics in part (a).
+
+## Session 2026-07-02 (Session 2) — Continuous 1-d IVT via the discrete bridge (part b)
+
+**Mode**: REVISIT · **Outcome**: progress (ACT) · **Status**: VERIFIED, 0-axiom
+
+### What I Did
+- Added `continuous_ivt_of_bridge` to `proofs/Proofs/SpernerSimplicialInstanceOQ04.lean`
+  (part (b) of the decomposition): for continuous `f : ℝ → ℝ` with `f 0 ≤ 0 ≤ f 1`,
+  there is `x ∈ [0,1]` with `f x = 0`. **Derived through the discrete Sperner
+  bracket**, not Mathlib's `intermediate_value_Icc`:
+  1. `exists_sign_change_bracket` gives, for each mesh `m = n+1`, a bracket
+     `[aₙ, bₙ] ⊆ [0,1]` with `bₙ - aₙ = 1/(n+1)` and `f(aₙ)·f(bₙ) ≤ 0`
+     (packaged with `choose`).
+  2. `IsCompact.tendsto_subseq` on `Set.Icc 0 1` extracts `a_{φ k} → x*`.
+  3. `bₙ - aₙ → 0` (via `tendsto_one_div_add_atTop_nhds_zero_nat ∘ φ.tendsto_atTop`)
+     ⟹ `b_{φ k} → x*` (`Tendsto.congr` on the sum).
+  4. `Continuous.tendsto` passes both limits through; `le_of_tendsto` on the
+     eventually-nonpositive product forces `f(x*)² ≤ 0`, hence `f x* = 0`
+     (`mul_self_eq_zero`).
+- Degenerate `f 1 = 0` handled separately (root at `x = 1`), so the statement is
+  the clean `f 0 ≤ 0 ≤ f 1` hypothesis.
+
+### Verification
+- Compiled with `lean` (toolchain v4.26.0) against project Mathlib oleans
+  (docker/lake unusable this session: `.loom` + `/private/tmp` worktrees were
+  being reaped concurrently, and the deployer-branch `packages/mathlib` is not a
+  git repo so docker forces a destructive re-clone).
+- `#print axioms continuous_ivt_of_bridge` → `[propext, Classical.choice,
+  Quot.sound]` only. No `sorry`, no `axiom`, no `Lean.ofReduceBool`. **Genuinely
+  verified / 0-axiom.**
+
+### Key Findings
+- The whole 1-d Sperner→root chain (discrete IVT → continuous IVT) is now
+  machine-checked. The Sperner content lives entirely in part (a); part (b) is
+  the standard `m → ∞` compactness/continuity limit, but it is threaded *through*
+  the discrete bracket rather than shortcutting to `intermediate_value_Icc`.
+- `Continuous.tendsto x` (not `ContinuousAt`) composes cleanly with the
+  subsequence limit; `le_of_tendsto` + `filter_upwards` is the tidy way to pass a
+  pointwise `≤ 0` to the limit.
+
+### Files Modified
+- `proofs/Proofs/SpernerSimplicialInstanceOQ04.lean` (+86 lines: `continuous_ivt_of_bridge`)
+- `research/problems/sperner-simplicial-instance-oq-04/knowledge.md`
+- `src/data/research/problems/sperner-simplicial-instance-oq-04.json`
+
+### Next Steps
+1. Part (c) `n`-d Brouwer remains BLOCKED (>1000 lines: barycentric subdivision +
+   `sperner-ndim` d-simplex triangulation + mesh shrinking on `[0,1]^n`).
+2. Optional: a gallery entry for oq-04 (parent + oq-05 already have entries); the
+   discrete+continuous 1-d IVT is now a coherent verified deliverable.
 
 ## Session 2026-06-15 (Session 1) — Continuous-coloring reduction (interval case)
 

--- a/src/data/research/problems/sperner-simplicial-instance-oq-04.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-04.json
@@ -31,17 +31,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (S1): formalized the interval-case continuous-coloring -> Sperner-coloring reduction; discrete sign-change theorem for real f proven on top of the existing discrete IVT. Continuous limit + n-d Brouwer remain open.",
+    "progressSummary": "PROGRESS (ACT, S2): part (b) continuous 1-d IVT proven and VERIFIED 0-axiom, derived through the discrete Sperner bracket. Parts (a)+(b) machine-checked; only n-d Brouwer (c) remains BLOCKED.",
     "builtItems": [
       "signColoring/meshPt + signColoring_apply/_zero/_self (SpernerSimplicialInstanceOQ04.lean): the continuous-coloring -> Sperner-coloring reduction in 1-d",
       "exists_sign_change_cell (OQ04.lean): discrete IVT for real f -- for every mesh m>0 a width-1/m cell straddles a sign change, via OQ05Scarf1d.discrete_ivt_panchromatic_cell on the sign coloring",
-      "exists_sign_change_bracket (OQ04.lean): product form f(a)*f(b) <= 0 of the sign-change cell"
+      "exists_sign_change_bracket (OQ04.lean): product form f(a)*f(b) <= 0 of the sign-change cell",
+      "continuous_ivt_of_bridge (SpernerSimplicialInstanceOQ04.lean): continuous 1-d IVT for f:ℝ→ℝ with f0≤0≤f1, ∃x∈[0,1] f x=0, DERIVED via the discrete Sperner bracket (exists_sign_change_bracket) + IsCompact.tendsto_subseq (Bolzano-Weierstrass on [0,1]) + Continuous.tendsto + le_of_tendsto, NOT intermediate_value_Icc. VERIFIED 0-axiom (propext/Classical.choice/Quot.sound only)."
     ],
     "insights": [
       "oq-04 decomposes into (a) discrete sign-change [DONE here, corollary of OQ05 discrete_ivt], (b) continuous 1-d IVT via mesh refinement + Bolzano-Weierstrass [moderate, ~150 lines], (c) n-d Brouwer via barycentric subdivision + sperner-ndim [>1000 lines, BLOCKED].",
       "Sibling OQ05Scarf1d already proves the discrete IVT (discrete_ivt_panchromatic_cell, c0!=cm => exists panchromatic cell); oq-04 only adds the real-function reduction layer, not new combinatorics.",
       "Discrete statement needs NO continuity: sign coloring c(j)=if f(j/m)<=0 then 0 else 1 has c(0)=0,c(m)=1 from f(0)<=0<f(1), and discrete_ivt yields a sign change. Continuity is only needed for the m->inf limit to an exact root.",
-      "Cert verify_sperner_oq04_bridge.py (transcendental root x-cos x, irrational cubic root, and a multi-root cubic): sign-change cell exists & brackets a true root for every mesh; |f(midpoint)| -> 0 at rate <= L*(1/m)."
+      "Cert verify_sperner_oq04_bridge.py (transcendental root x-cos x, irrational cubic root, and a multi-root cubic): sign-change cell exists & brackets a true root for every mesh; |f(midpoint)| -> 0 at rate <= L*(1/m).",
+      "Part (b) DONE+VERIFIED (S2): the full 1-d Sperner→root chain (discrete IVT → continuous IVT) is machine-checked, 0-axiom. Sperner content is in part (a); part (b) is the m→∞ compactness/continuity limit threaded through the discrete bracket. bₙ-aₙ=1/(n+1)→0 gives b_{φk}→x* by Tendsto.congr; product f(a)·f(b)≤0 passes to f(x*)²≤0 by le_of_tendsto, forcing f x*=0."
     ],
     "mathlibGaps": [
       "No packaged Sperner->Brouwer bridge in Mathlib; Brouwer exists but is not derived from a discrete Sperner lemma.",
@@ -49,9 +51,8 @@
       "n-d barycentric subdivision / mesh-shrinking for the cube [0,1]^n is not available as reusable infra."
     ],
     "nextSteps": [
-      "ACT next: prove continuous 1-d IVT from exists_sign_change_bracket -- take a_m = meshPt m i_m (bracket left ends), extract convergent subsequence via tendsto_subseq_of_bounded on [0,1], pass continuity through to get f(x*)=0; use intermediate_value_Icc only as cross-check, not the derivation.",
-      "Then n-d: replace intervalTriangulation with sperner-ndim's d-simplex triangulation + barycentric refinement; the >1000-line blocked remainder -- keep BLOCKED until 1-d limit lands.",
-      "Build pending (docker backend blackout this session); file intentionally UNREGISTERED in Proofs.lean to avoid breaking auto-merge until CI verifies."
+      "Part (c) n-d Brouwer BLOCKED (>1000 lines: barycentric subdivision + sperner-ndim d-simplex triangulation + mesh shrinking on [0,1]^n).",
+      "Optional: create gallery entry for oq-04 (parent + oq-05 already have entries) now that discrete+continuous 1-d IVT is a coherent verified deliverable."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Advances `sperner-simplicial-instance-oq-04` (Brouwer's fixed-point theorem via Sperner coloring on `[0,1]^n`) by completing **part (b)** of the decomposition: the **continuous 1-d intermediate-value theorem**, derived through the discrete Sperner bracket.

New theorem `SpernerSimplicialInstanceOQ04.continuous_ivt_of_bridge`:
> For continuous `f : ℝ → ℝ` with `f 0 ≤ 0 ≤ f 1`, there is `x ∈ [0,1]` with `f x = 0`.

The proof is the genuine `m → ∞` limit of the discrete bridge, **not** a call to Mathlib's `intermediate_value_Icc`:
1. `exists_sign_change_bracket` (part a) gives, for each mesh `m = n+1`, a bracket `[aₙ, bₙ] ⊆ [0,1]` with `bₙ − aₙ = 1/(n+1)` and `f(aₙ)·f(bₙ) ≤ 0`.
2. Bolzano–Weierstrass (`IsCompact.tendsto_subseq` on `Set.Icc 0 1`) extracts `a_{φ k} → x*`.
3. `bₙ − aₙ → 0` ⟹ `b_{φ k} → x*`.
4. Continuity passes both limits through; `le_of_tendsto` on the eventually-nonpositive product forces `f(x*)² ≤ 0`, hence `f x* = 0`.

## Verification

- `#print axioms continuous_ivt_of_bridge` → `[propext, Classical.choice, Quot.sound]` only.
- **No `sorry`, no `axiom`, no `Lean.ofReduceBool` — genuinely verified / 0-axiom.**
- Compiled with `lean` v4.26.0 against project Mathlib oleans (docker/lake was unusable this session due to concurrent worktree reaping and a non-git `packages/mathlib` on the deployer branch that forces a destructive re-clone).

## Status of oq-04

| Part | Content | Status |
|------|---------|--------|
| (a) | Discrete sign-change IVT for real `f` | DONE (verified) |
| (b) | **Continuous 1-d IVT via mesh refinement + Bolzano–Weierstrass** | **DONE this PR (verified, 0-axiom)** |
| (c) | `n`-d Brouwer via barycentric subdivision + `sperner-ndim` | BLOCKED (>1000 lines) |

Parts (a)+(b) — the full 1-d Sperner→root chain — are now both machine-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)