### PR TITLE
Research: sperner-simplicial-instance-oq-04 — continuous 1-d IVT derived from the 1-d Sperner lemma

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ04.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ04.lean
@@ -20,12 +20,20 @@ sign 2-coloring of the mesh `{0, 1/m, …, 1}` and feeds it to the already-prove
 discrete intermediate-value theorem
 (`SpernerSimplicialInstanceOQ05Scarf1d.discrete_ivt_panchromatic_cell`).
 
-The output is, for **every** mesh `m > 0`, a width-`1/m` cell whose two endpoints
-straddle a sign change of `f`. This is the discrete intermediate-value theorem
-for a real-valued `f`, and it is the base from which the continuous IVT follows
-by letting `m → ∞` (Bolzano–Weierstrass + continuity); that limit step, and the
-`n`-dimensional Brouwer derivation via barycentric subdivision, are recorded as
-the open remainder in `knowledge.md` — they are not in this file.
+The output of that reduction is, for **every** mesh `m > 0`, a width-`1/m` cell
+whose two endpoints straddle a sign change of `f` (`exists_sign_change_cell` /
+`exists_sign_change_bracket`) — the discrete intermediate-value theorem for a
+real-valued `f`, needing no continuity.
+
+The file then **takes the continuous limit** `m → ∞`. `ivt_of_shrinking_brackets`
+isolates the analytic content, stated independently of Sperner: a continuous `f`
+with sign-changing brackets of width `→ 0` in `[0,1]` has a root there, proved by
+Bolzano–Weierstrass (`IsCompact.tendsto_subseq`) plus continuity — *not* via
+Mathlib's `intermediate_value_Icc`. `exists_root_of_continuous` combines the two:
+for continuous `f` with `f 0 ≤ 0 < f 1` it produces an actual root `x ∈ [0,1]`,
+completing the 1-d (interval) case of Brouwer entirely on top of the 1-d Sperner
+lemma. The remaining open item is the `n`-dimensional Brouwer derivation via
+barycentric subdivision (recorded in `knowledge.md`); it is not in this file.
 
 No `sorry`, no `axiom`. Builds on the axiom-free discrete theorem.
 -/
@@ -103,5 +111,96 @@ theorem exists_sign_change_bracket (f : ℝ → ℝ) {m : ℕ} (hm : 0 < m)
   rcases hi with ⟨ha, hb⟩ | ⟨ha, hb⟩
   · exact mul_nonpos_iff.mpr (Or.inr ⟨ha, hb.le⟩)
   · exact mul_nonpos_iff.mpr (Or.inl ⟨ha.le, hb⟩)
+
+open Filter Topology Set in
+/-- **The continuous limit step, stated independently of Sperner.**
+
+If a continuous `f : ℝ → ℝ` admits, for every index `n`, a bracket
+`[a n, b n] ⊆ [0,1]` of width `≤ 1/(n+1)` across which it changes sign
+(`f (a n) · f (b n) ≤ 0`), then `f` has a root in `[0,1]`.
+
+This is the analytic content of turning the discrete sign-change cells of
+`exists_sign_change_bracket` into an exact root: pass to the limit `m → ∞`.
+The proof uses Bolzano–Weierstrass (`IsCompact.tendsto_subseq` on the compact
+`[0,1]`) to extract a convergent subsequence `a ∘ φ → x`; the widths vanishing
+forces `b ∘ φ → x` too, and continuity carries the termwise sign condition
+`f(a)·f(b) ≤ 0` to the limit `(f x)² ≤ 0`, whence `f x = 0`. It does **not**
+invoke Mathlib's `intermediate_value_Icc`. -/
+theorem ivt_of_shrinking_brackets (f : ℝ → ℝ) (hf : Continuous f)
+    (a b : ℕ → ℝ)
+    (ha : ∀ n, a n ∈ Set.Icc (0 : ℝ) 1)
+    (hwidth : ∀ n, |a n - b n| ≤ 1 / ((n : ℝ) + 1))
+    (hsign : ∀ n, f (a n) * f (b n) ≤ 0) :
+    ∃ x ∈ Set.Icc (0 : ℝ) 1, f x = 0 := by
+  -- Bolzano–Weierstrass on the compact interval `[0,1]`.
+  obtain ⟨x, hx_mem, φ, hφ_mono, hφ_tend⟩ := isCompact_Icc.tendsto_subseq ha
+  refine ⟨x, hx_mem, ?_⟩
+  -- The bracket widths along the subsequence tend to `0`.
+  have hbase : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)
+  have hg0 : Tendsto (fun n => 1 / ((φ n : ℝ) + 1)) atTop (𝓝 0) :=
+    hbase.comp hφ_mono.tendsto_atTop
+  have hd0 : Tendsto (fun n => b (φ n) - a (φ n)) atTop (𝓝 0) :=
+    squeeze_zero_norm (fun n => by
+      rw [Real.norm_eq_abs, abs_sub_comm]; exact hwidth (φ n)) hg0
+  -- Hence `b ∘ φ → x` as well.
+  have hb_tend : Tendsto (fun n => b (φ n)) atTop (𝓝 x) := by
+    have heq : (fun n => b (φ n)) = fun n => a (φ n) + (b (φ n) - a (φ n)) := by
+      funext n; ring
+    rw [heq]
+    simpa using hφ_tend.add hd0
+  -- Continuity carries both subsequences into `f x`.
+  have hfa : Tendsto (fun n => f (a (φ n))) atTop (𝓝 (f x)) :=
+    (hf.tendsto x).comp hφ_tend
+  have hfb : Tendsto (fun n => f (b (φ n))) atTop (𝓝 (f x)) :=
+    (hf.tendsto x).comp hb_tend
+  have hprod : Tendsto (fun n => f (a (φ n)) * f (b (φ n))) atTop (𝓝 (f x * f x)) :=
+    hfa.mul hfb
+  -- The termwise sign condition passes to the limit: `(f x)² ≤ 0`.
+  have hle : f x * f x ≤ 0 := le_of_tendsto' hprod (fun n => hsign (φ n))
+  have hsq : f x * f x = 0 := le_antisymm hle (mul_self_nonneg (f x))
+  exact mul_self_eq_zero.mp hsq
+
+open Set in
+/-- **Continuous intermediate-value theorem, derived from the 1-d Sperner
+lemma.** For continuous `f : ℝ → ℝ` with `f 0 ≤ 0 < f 1`, there is a root
+`x ∈ [0,1]`.
+
+The derivation is `discrete Sperner ⇒ sign-change brackets ⇒ limit`: for each
+mesh `m = n+1`, `exists_sign_change_bracket` (a corollary of the 1-d Sperner
+lemma `discrete_ivt_panchromatic_cell`) yields a width-`1/(n+1)` bracket across
+a sign change; `ivt_of_shrinking_brackets` then passes to the limit. Mathlib's
+own `intermediate_value_Icc` is deliberately **not** used. -/
+theorem exists_root_of_continuous (f : ℝ → ℝ) (hf : Continuous f)
+    (h0 : f 0 ≤ 0) (h1 : 0 < f 1) :
+    ∃ x ∈ Set.Icc (0 : ℝ) 1, f x = 0 := by
+  have hbr : ∀ n : ℕ, ∃ i : Fin (n + 1),
+      f (meshPt (n + 1) i.val) * f (meshPt (n + 1) (i.val + 1)) ≤ 0 :=
+    fun n => exists_sign_change_bracket f n.succ_pos h0 h1
+  choose i hi using hbr
+  refine ivt_of_shrinking_brackets f hf
+    (fun n => meshPt (n + 1) (i n).val)
+    (fun n => meshPt (n + 1) ((i n).val + 1)) ?_ ?_ ?_
+  · -- left endpoints lie in `[0,1]`
+    intro n
+    dsimp only
+    rw [Set.mem_Icc]
+    simp only [meshPt]
+    refine ⟨by positivity, ?_⟩
+    rw [div_le_one (by positivity)]
+    exact_mod_cast (i n).isLt.le
+  · -- bracket width is exactly `1/(n+1)`
+    intro n
+    dsimp only
+    have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+    have hab : meshPt (n + 1) (i n).val - meshPt (n + 1) ((i n).val + 1)
+        = -(1 / ((n : ℝ) + 1)) := by
+      simp only [meshPt]; push_cast; field_simp; ring
+    have hval : |meshPt (n + 1) (i n).val - meshPt (n + 1) ((i n).val + 1)|
+        = 1 / ((n : ℝ) + 1) := by
+      rw [hab, abs_neg]; exact abs_of_pos (by positivity)
+    exact le_of_eq hval
+  · -- opposite signs across the bracket
+    exact fun n => hi n
 
 end SpernerSimplicialInstanceOQ04

--- a/src/data/research/problems/sperner-simplicial-instance-oq-04.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-04.json
@@ -31,17 +31,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (S1): formalized the interval-case continuous-coloring -> Sperner-coloring reduction; discrete sign-change theorem for real f proven on top of the existing discrete IVT. Continuous limit + n-d Brouwer remain open.",
+    "progressSummary": "ACT (S2, researcher-7): the continuous 1-d intermediate-value theorem is now formalized and MACHINE-BUILT in proofs/Proofs/SpernerSimplicialInstanceOQ04.lean (docker build OK, 237s). Added ivt_of_shrinking_brackets (Sperner-independent analytic limit: sign-changing brackets of width->0 in [0,1] + continuity => a root, via Bolzano-Weierstrass, deliberately NOT Mathlib intermediate_value_Icc) and exists_root_of_continuous (continuous IVT for f 0<=0<f 1, derived discrete-Sperner -> sign brackets -> limit). Discharges the ACT-next item from the prior session and completes the 1-d (interval) case of Brouwer on top of the 1-d Sperner lemma. Still 0 sorries, 0 axioms, no native_decide. Remaining OPEN: n-d Brouwer via barycentric subdivision (>1000 lines, BLOCKED).",
     "builtItems": [
       "signColoring/meshPt + signColoring_apply/_zero/_self (SpernerSimplicialInstanceOQ04.lean): the continuous-coloring -> Sperner-coloring reduction in 1-d",
       "exists_sign_change_cell (OQ04.lean): discrete IVT for real f -- for every mesh m>0 a width-1/m cell straddles a sign change, via OQ05Scarf1d.discrete_ivt_panchromatic_cell on the sign coloring",
-      "exists_sign_change_bracket (OQ04.lean): product form f(a)*f(b) <= 0 of the sign-change cell"
+      "exists_sign_change_bracket (OQ04.lean): product form f(a)*f(b) <= 0 of the sign-change cell",
+      "ivt_of_shrinking_brackets (SpernerSimplicialInstanceOQ04.lean): analytic core, Sperner-independent — continuous f with sign-changing brackets of width->0 in [0,1] has a root, via IsCompact.tendsto_subseq (Bolzano-Weierstrass) + continuity, NOT via Mathlib intermediate_value_Icc",
+      "exists_root_of_continuous (SpernerSimplicialInstanceOQ04.lean): the continuous 1-d IVT for f 0 <= 0 < f 1, derived discrete-Sperner -> sign brackets -> limit; completes the interval (1-d) case of Brouwer on top of the 1-d Sperner lemma"
     ],
     "insights": [
       "oq-04 decomposes into (a) discrete sign-change [DONE here, corollary of OQ05 discrete_ivt], (b) continuous 1-d IVT via mesh refinement + Bolzano-Weierstrass [moderate, ~150 lines], (c) n-d Brouwer via barycentric subdivision + sperner-ndim [>1000 lines, BLOCKED].",
       "Sibling OQ05Scarf1d already proves the discrete IVT (discrete_ivt_panchromatic_cell, c0!=cm => exists panchromatic cell); oq-04 only adds the real-function reduction layer, not new combinatorics.",
       "Discrete statement needs NO continuity: sign coloring c(j)=if f(j/m)<=0 then 0 else 1 has c(0)=0,c(m)=1 from f(0)<=0<f(1), and discrete_ivt yields a sign change. Continuity is only needed for the m->inf limit to an exact root.",
-      "Cert verify_sperner_oq04_bridge.py (transcendental root x-cos x, irrational cubic root, and a multi-root cubic): sign-change cell exists & brackets a true root for every mesh; |f(midpoint)| -> 0 at rate <= L*(1/m)."
+      "Cert verify_sperner_oq04_bridge.py (transcendental root x-cos x, irrational cubic root, and a multi-root cubic): sign-change cell exists & brackets a true root for every mesh; |f(midpoint)| -> 0 at rate <= L*(1/m).",
+      "CONTINUOUS LIMIT STEP DONE (2026-07-02, researcher-7): the m->inf limit the prior session left open is now formalized and machine-built. Decomposition that worked: state the analysis abstractly (ivt_of_shrinking_brackets: brackets width->0 + continuity => root) decoupled from Sperner, then a short assembly feeds it the exists_sign_change_bracket mesh brackets. Key Mathlib: isCompact_Icc.tendsto_subseq, squeeze_zero_norm, tendsto_one_div_add_atTop_nhds_zero_nat pinned to the real field, le_of_tendsto, mul_self_eq_zero.",
+      "GOTCHA: tendsto_one_div_add_atTop_nhds_zero_nat is generic over the field with a ContinuousSMul NNRat instance; simpa-using it leaves the field a metavariable (stuck ContinuousSMul NNRat ?m). Fix: term-mode with an explicit field-type argument so unification pins it to the reals."
     ],
     "mathlibGaps": [
       "No packaged Sperner->Brouwer bridge in Mathlib; Brouwer exists but is not derived from a discrete Sperner lemma.",


### PR DESCRIPTION
## Summary
Completes the **ACT-next** item the prior session left open for `sperner-simplicial-instance-oq-04`: taking the `m → ∞` limit of the discrete sign-change brackets to obtain the **continuous** intermediate-value theorem — built entirely on top of the 1-d Sperner lemma, not on Mathlib's `intermediate_value_Icc`.

## Progress
Added to `proofs/Proofs/SpernerSimplicialInstanceOQ04.lean`:
- **`ivt_of_shrinking_brackets`** — the analytic core, stated *independently of Sperner*: a continuous `f` with sign-changing brackets `[a n, b n] ⊆ [0,1]` of width `→ 0` has a root in `[0,1]`. Proof: Bolzano–Weierstrass (`IsCompact.tendsto_subseq` on the compact `[0,1]`) extracts a convergent subsequence `a∘φ → x`; vanishing widths force `b∘φ → x`; continuity carries the termwise `f(a)·f(b) ≤ 0` to `(f x)² ≤ 0`, hence `f x = 0`.
- **`exists_root_of_continuous`** — the continuous IVT for `f 0 ≤ 0 < f 1`, assembled as `discrete Sperner → sign brackets (exists_sign_change_bracket) → limit`.

The prior session had also left the file itself *build-pending* (docker outage); both the pre-existing discrete results and the new continuous results are now confirmed by a full machine build.

## Verification
`./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialInstanceOQ04` → **succeeded** (`✔ [7746/7746] Built Proofs.SpernerSimplicialInstanceOQ04`, 237s).

## Axiom integrity
Still **0 sorries, 0 `axiom` declarations, no `native_decide`/`decide`**. All new proofs use ordinary Mathlib analysis tactics (compactness, `Tendsto`, `squeeze_zero_norm`, continuity, `ring`/`field_simp`/`positivity`, `le_antisymm`). Axiom trail is the standard `propext`/`Classical.choice`/`Quot.sound`.

## Status
**Outcome**: progress (major — continuous 1-d case of Brouwer complete)
**Next Steps**: n-dimensional Brouwer via barycentric subdivision (recorded BLOCKED, >1000 lines).

🤖 Generated by researcher-7