### PR TITLE
Enrich Every Even Zeta Value is Irrational: add annotation coverage

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-02/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-imports",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 3 },
+    "type": "context",
+    "title": "Imports: Euler's zeta formula, irrationality, and π transcendence",
+    "content": "Three imports supply the whole proof. `Mathlib.NumberTheory.ZetaValues` provides `hasSum_zeta_nat`, Euler's closed evaluation of ζ(2n) as a rational multiple of π^(2n). `Mathlib.NumberTheory.Real.Irrational` provides the `Irrational` predicate and its closure lemmas (`Transcendental.irrational`, `Irrational.ratCast_mul`). `Proofs.PiTranscendental` is the repository-local module exposing `pi_transcendental_over_rationals`, which rests on the `hermite_lindemann` axiom — the single assumption this entry carries.",
+    "mathContext": "$\\zeta(2n) = \\sum_{k\\ge 1} k^{-2n}$; the proof chains Euler's formula with the transcendence of $\\pi$.",
+    "significance": "context",
+    "relatedConcepts": ["Riemann zeta function", "transcendence of π", "Lindemann–Weierstrass theorem"],
+    "prerequisites": ["Lean 4 imports", "Mathlib number theory library"]
+  },
+  {
+    "id": "ann-pi-pow-irrational",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 63, "endLine": 64 },
+    "type": "technique",
+    "title": "Powers of π are irrational",
+    "content": "`pi_pow_irrational` proves `Irrational (π^m)` for every `m ≥ 1`. The one-line proof `(pi_transcendental_over_rationals.pow hm).irrational` composes two facts: `Transcendental.pow` lifts transcendence of π to π^m, and `Transcendental.irrational` converts transcendence over ℚ into irrationality. This lemma fills a genuine Mathlib gap: `irrational_pi` handles only m = 1, and irrationality does NOT propagate through powers (√2 is irrational but its square is rational), so transcendence is essential — not a convenience.",
+    "mathContext": "If $\\pi$ is transcendental over $\\mathbb{Q}$ then so is $\\pi^m$; a transcendental real is irrational, hence $\\pi^m \\notin \\mathbb{Q}$ for all $m \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": ["transcendental number", "algebraic closure under powers", "irrationality"],
+    "prerequisites": ["transcendental vs algebraic numbers", "field extensions"]
+  },
+  {
+    "id": "ann-zeta-even-statement",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 76 },
+    "type": "definition",
+    "title": "Statement: every even zeta value is irrational",
+    "content": "The main theorem `zeta_even_irrational` asserts that for every `n ≥ 1`, the series `∑' k, 1/k^(2n)` — the even-argument zeta value ζ(2n) — is irrational. The hypothesis `hn : 0 < n` excludes the divergent case 2n = 0 (ζ(0) is not a convergent series). This is the tractable half of the parent open question, which asks the same for the odd values ζ(2n+1).",
+    "mathContext": "$\\zeta(2n) = \\sum_{k=1}^{\\infty} \\frac{1}{k^{2n}}$ is irrational for all $n \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": ["even zeta values", "convergence of p-series", "irrationality"],
+    "prerequisites": ["infinite series", "Riemann zeta function"]
+  },
+  {
+    "id": "ann-euler-closed-form",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 82 },
+    "type": "technique",
+    "title": "Euler's closed form: ζ(2n) = qₙ·π^(2n)",
+    "content": "`hasSum_zeta_nat` (Euler's formula) is instantiated at k = n to exhibit ζ(2n) as a rational multiple of π^(2n). The rational coefficient is collected explicitly as qₙ = (−1)^(n+1)·2^(2n−1)·B_{2n}/(2n)!, packaging the Bernoulli number B_{2n} and the sign/factorial combinatorics into a single ℚ. The identity `∑' k, 1/k^(2n) = ↑qₙ · π^(2n)` is then discharged by `rw [hS.tsum_eq]; push_cast; ring` — pure algebraic normalization once Euler's sum value is substituted.",
+    "mathContext": "$\\zeta(2n) = \\frac{(-1)^{n+1} B_{2n} (2\\pi)^{2n}}{2\\,(2n)!} = q_n\\, \\pi^{2n}, \\quad q_n = \\frac{(-1)^{n+1} 2^{2n-1} B_{2n}}{(2n)!} \\in \\mathbb{Q}.$",
+    "significance": "key",
+    "relatedConcepts": ["Bernoulli numbers", "Euler's zeta formula", "rational multiples of powers of π"],
+    "prerequisites": ["Bernoulli numbers", "factorials", "HasSum / tsum in Mathlib"]
+  },
+  {
+    "id": "ann-positivity-qne",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 83, "endLine": 89 },
+    "type": "insight",
+    "title": "Positivity forces qₙ ≠ 0 — no Bernoulli-vanishing lemma",
+    "content": "To apply the rational-scaling lemma one needs qₙ ≠ 0. Rather than invoking a theorem that B_{2n} ≠ 0, the proof gets this for free from positivity: `Summable.tsum_pos` shows ζ(2n) > 0 (every term is nonnegative and the k = 1 term equals 1). If qₙ were 0, then ζ(2n) = ↑qₙ·π^(2n) = 0 would contradict strict positivity. This is a clean, reusable template for any 'rational multiple of an irrational' argument where the value is manifestly nonzero.",
+    "mathContext": "$\\zeta(2n) > 0$ (the $k=1$ term is $1$); if $q_n = 0$ then $q_n \\pi^{2n} = 0$, contradiction, so $q_n \\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity of series", "nonvanishing of Bernoulli numbers", "proof economy"],
+    "prerequisites": ["summability", "positivity tactic"]
+  },
+  {
+    "id": "ann-finish-ratcast-mul",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 93 },
+    "type": "technique",
+    "title": "Finish: scaling an irrational by a nonzero rational",
+    "content": "The final step combines the two ingredients: `pi_pow_irrational (2*n)` gives `Irrational (π^(2n))`, and `Irrational.ratCast_mul hqne` states that a nonzero rational times an irrational is irrational. Rewriting the goal with the Euler identity `hq` turns it into `Irrational (↑qₙ · π^(2n))`, which is exactly what `ratCast_mul` supplies. The irrationality of ζ(2n) is thus reduced entirely to the irrationality of π^(2n).",
+    "mathContext": "$x \\notin \\mathbb{Q},\\ q \\in \\mathbb{Q}\\setminus\\{0\\} \\implies qx \\notin \\mathbb{Q}$; here $x = \\pi^{2n}$ and $q = q_n$.",
+    "significance": "key",
+    "relatedConcepts": ["irrationality under rational scaling", "field of rationals", "closure properties"],
+    "prerequisites": ["rational and irrational numbers", "closure lemmas"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 95, "endLine": 108 },
+    "type": "concept",
+    "title": "Concrete Basel values ζ(2), ζ(4), ζ(6)",
+    "content": "The three corollaries specialize `zeta_even_irrational` to n = 1, 2, 3, recovering that the classical Basel value ζ(2) = π²/6 and its successors ζ(4) = π⁴/90 and ζ(6) = π⁶/945 are each irrational. Each proof is a one-liner (`simpa using zeta_even_irrational …`), with `simpa` reconciling `2*n` in the general statement with the literal exponents 2, 4, 6. These make the abstract theorem tangible and directly answer the most-asked instances.",
+    "mathContext": "$\\zeta(2) = \\frac{\\pi^2}{6},\\ \\zeta(4) = \\frac{\\pi^4}{90},\\ \\zeta(6) = \\frac{\\pi^6}{945}$ — all irrational.",
+    "significance": "supporting",
+    "relatedConcepts": ["Basel problem", "particular zeta values", "specialization of theorems"],
+    "prerequisites": ["Basel problem ζ(2) = π²/6"]
+  },
+  {
+    "id": "ann-open-odd",
+    "proofId": "basel-problem-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 117 },
+    "type": "context",
+    "title": "The open odd case (documentation only)",
+    "content": "This closing docstring deliberately states NO theorem about ζ(2n+1). The irrationality of any individual odd value past Apéry's ζ(3) — ζ(5), ζ(7), … — is a genuine open problem in mathematics, not merely unformalized: Ball–Rivoal (2001) proved infinitely many ζ(2n+1) are irrational and Rivoal–Zudilin pinned at least one of ζ(5), ζ(7), ζ(9), ζ(11), but no single value with n ≥ 2 is known. The even-case theorem above marks the exact boundary of what is provable today, which is the entry's whole point.",
+    "mathContext": "Irrationality of $\\zeta(2n+1)$ for $n \\ge 2$ (e.g. $\\zeta(7)$) is open; only $\\zeta(3)$ (Apéry, 1979) is known among odd values.",
+    "significance": "context",
+    "relatedConcepts": ["Apéry's theorem", "Ball–Rivoal theorem", "open problems in irrationality"],
+    "prerequisites": ["odd zeta values", "state of the art in irrationality theory"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-01-oq-02`.

**Gap addressed:** `annotations.json` was empty (`[]`). The meta.json is already rich (overview, sections, crossReferences, conclusion, references all high quality), so the highest-impact improvement was full inline annotation coverage.

**Added 8 annotations** spanning the whole 119-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. Imports — Euler's zeta formula, irrationality library, and the `hermite_lindemann`-backed π transcendence module
2. `pi_pow_irrational` — powers of π are irrational (fills a real Mathlib gap; irrationality does not lift through powers)
3. Main theorem statement `zeta_even_irrational`
4. Euler's closed form ζ(2n) = qₙ·π^(2n)
5. The positivity trick forcing qₙ ≠ 0 (no Bernoulli-vanishing lemma needed)
6. The `ratCast_mul` finish reducing to irrationality of π^(2n)
7. Concrete corollaries ζ(2)=π²/6, ζ(4)=π⁴/90, ζ(6)=π⁶/945
8. The open odd-case documentation section (ζ(2n+1) genuinely open past Apéry's ζ(3))

Annotation line ranges validated against the Lean file by the gallery annotation build (no 'No Lean construct found' warnings for this entry). No changes to meta.json; axiom/status fields untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)