### PR TITLE
Enrich A total, executable binary GCD for ℤ[i]: add annotation coverage

### DIFF
--- a/src/data/proofs/binary-gcd-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-04-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 73, "endLine": 78 },
+    "type": "context",
+    "title": "Imports and namespace: reusing the parent's correctness layer",
+    "content": "The file imports `Mathlib` (for `EuclideanDomain.gcd`, `Associated`, and the Gaussian integers `GaussianInt = ℤ[i]`) and `Proofs.BinaryGcdOQ04`, the parent entry that established the arithmetic of the ramified prime π = 1+i: the divide-by-π map `divPi`, the parity dichotomy ℤ[i]/(π) ≅ 𝔽₂, and the three reduction identities `gcd_pi_mul`, `gcd_pi_mul_odd`, `gcd_sub`. `open Zsqrtd BinaryGcdOQ04` brings those names into scope. This entry adds no new number theory — it packages the parent's algebra into a running algorithm.",
+    "mathContext": "$\\mathbb{Z}[i]$ with the prime $\\pi = 1+i$, $N(\\pi)=2$; the parent supplies $\\gcd$ reductions up to $\\mathrm{Associated}$.",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian integers", "Euclidean domain", "Stein's binary GCD"],
+    "prerequisites": ["Lean 4 imports", "Mathlib EuclideanDomain API"]
+  },
+  {
+    "id": "ann-pieven",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 91, "endLine": 103 },
+    "type": "definition",
+    "title": "The decidable π-parity test PiEven",
+    "content": "`PiEven z := 2 ∣ (z.re + z.im)` is the concrete, decidable form of 'π divides z'. The parent's dichotomy ℤ[i]/(π) ≅ 𝔽₂ says π ∣ z iff z.re + z.im is even, so `piEven_iff : PiEven z ↔ pi ∣ z` bridges the executable ℤ-test to the abstract divisibility. The explicit `DecidablePred PiEven` instance is what makes every branch of the driver actually run (and lets kernel `decide` check the sanity examples). The helper lemmas `piEven_of` and `not_pi_dvd_of_not_piEven` unpack the equivalence in each direction.",
+    "mathContext": "$\\pi \\mid z \\iff 2 \\mid (\\Re z + \\Im z)$, since $\\mathbb{Z}[i]/(\\pi) \\cong \\mathbb{F}_2$.",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "quotient ring ℤ[i]/(π)", "parity"],
+    "prerequisites": ["divisibility in ℤ[i]", "decidable predicates in Lean"]
+  },
+  {
+    "id": "ann-driver",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 111, "endLine": 124 },
+    "type": "technique",
+    "title": "The fuel-indexed driver binaryGcdAux",
+    "content": "`binaryGcdAux : ℕ → ℤ[i] → ℤ[i] → Option ℤ[i]` performs one Stein-style reduction per unit of fuel, structurally recursing on the fuel argument. Six branches: `u = 0 → some v`, `v = 0 → some u` (base cases); both π-even → recurse on `(divPi u, divPi v)` and rescale the result by π; one π-even → strip a π from that argument via `divPi`; both π-odd → Euclidean subtraction `(u - v, v)`. Fuel makes the function total with NO well-foundedness proof, sidestepping the fact that the subtraction step is not norm-decreasing over ℤ[i]; `none` (fuel 0) signals an exhausted budget rather than a wrong answer.",
+    "mathContext": "One reduction per fuel unit: $\\gcd(\\pi a,\\pi b)\\sim\\pi\\gcd(a,b)$, $\\gcd(\\pi a,v)\\sim\\gcd(a,v)$, $\\gcd(u,v)\\sim\\gcd(u-v,v)$.",
+    "significance": "key",
+    "relatedConcepts": ["fuel-indexed recursion", "structural recursion", "totality without well-foundedness"],
+    "prerequisites": ["Option type", "recursive definitions in Lean"]
+  },
+  {
+    "id": "ann-gcd-comm",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 134, "endLine": 140 },
+    "type": "technique",
+    "title": "gcd is commutative up to associates",
+    "content": "`gcd_associated_comm` proves `Associated (gcd a b) (gcd b a)` by mutual divisibility (`associated_of_dvd_dvd` fed the two `dvd_gcd`/`gcd_dvd` directions). Its purpose is narrow but essential: the parent's one-π-even reduction `gcd_pi_mul_odd` strips a π from the FIRST argument only, so to handle the mirror case (π-even second argument) the correctness proof swaps the two arguments, which is valid exactly because the Euclidean gcd is unique only up to a unit.",
+    "mathContext": "$\\gcd(a,b) \\sim \\gcd(b,a)$ — equality holds only up to a unit since $\\mathbb{Z}[i]$ has no canonical gcd representative.",
+    "significance": "supporting",
+    "relatedConcepts": ["associated elements", "units of ℤ[i]", "universal property of gcd"],
+    "prerequisites": ["Associated relation", "divisibility"]
+  },
+  {
+    "id": "ann-correctness",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 152, "endLine": 213 },
+    "type": "insight",
+    "title": "Partial correctness: the algorithm never lies",
+    "content": "`binaryGcdAux_correct` proves `binaryGcdAux fuel u v = some g → Associated g (gcd u v)` — whenever the driver returns a value, it is an associate of the Euclidean gcd. The proof is a single `induction fuel`: the zero case returns `none` (vacuous), and the successor case is `split_ifs` into the six leaves, each closed by exactly one ingredient — the base cases by `gcd_zero_left`/`gcd_zero_right`, both-even by `gcd_pi_mul` + `Associated.mul_left`, the two one-even cases by `gcd_pi_mul_odd` (the mirror via `gcd_associated_comm`), and both-odd by `gcd_sub`. The whole correctness argument is thus a dispatch table from the recursion's syntactic cases to the parent's identities.",
+    "mathContext": "$\\text{binaryGcdAux}\\ f\\ u\\ v = \\text{some } g \\implies g \\sim \\gcd(u,v)$ — partial correctness, proved by induction on $f$.",
+    "significance": "key",
+    "relatedConcepts": ["partial correctness", "induction on fuel", "case analysis (split_ifs)"],
+    "prerequisites": ["structural induction", "the parent's reduction identities"]
+  },
+  {
+    "id": "ann-total-wrapper",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 227, "endLine": 244 },
+    "type": "technique",
+    "title": "A total wrapper, unconditionally an associate of gcd",
+    "content": "`binaryGcdGaussian u v` runs the driver with a concrete norm-based fuel budget `N(u).natAbs + N(v).natAbs + 1` and, via `Option.getD`, falls back to `EuclideanDomain.gcd u v` if that budget is exhausted. `binaryGcdGaussian_associated` then holds unconditionally: on the `some` branch it is `binaryGcdAux_correct`, on the `none` branch it is reflexivity against the fallback. `binaryGcdGaussian_spec` records the honesty caveat — whenever the driver halts, the wrapper returns exactly the driver's output, so the fallback is a formal totality device, not a computational shortcut that could mask a wrong answer.",
+    "mathContext": "$\\text{binaryGcdGaussian}(u,v) \\sim \\gcd(u,v)$ holds for all $u,v$, with a $\\gcd$ fallback if the fuel budget $N(u)+N(v)+1$ is exhausted.",
+    "significance": "key",
+    "relatedConcepts": ["total functions", "Option.getD fallback", "norm of a Gaussian integer"],
+    "prerequisites": ["Zsqrtd.norm", "Option elimination"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "binary-gcd-oq-04-oq-01",
+    "range": { "startLine": 246, "endLine": 266 },
+    "type": "insight",
+    "title": "Executable checks and the termination witness (kernel decide)",
+    "content": "Four closed evaluations by kernel `decide` (NOT native_decide, so no `Lean.ofReduceBool` axiom): the driver halts on (6, 4); the parity test matches the parent's dichotomy on concrete values. The pivotal one is `binaryGcdAux 40 (5) (2+i) = none` — on this genuinely Gaussian input 40 units of fuel are exhausted, a machine-checked witness that the naive both-π-odd subtraction u ↦ u − v is NOT Gaussian-norm-decreasing (the norm is not totally ordered, so 'subtract the smaller' has no analogue). This is the concrete face of the deferred termination subtlety that Weilert's refined (1+i)-ary step resolves; partial correctness holds regardless, since the driver returns `none` rather than a wrong value.",
+    "mathContext": "$\\text{binaryGcdAux}\\ 40\\ (5)\\ (2+i) = \\text{none}$: the subtraction step need not decrease $N(z)$, so fuel can run out — termination is genuinely harder over $\\mathbb{Z}[i]$ than over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["kernel decide vs native_decide", "termination", "Weilert (1+i)-ary GCD"],
+    "prerequisites": ["decidable evaluation in Lean", "Gaussian norm"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-04-oq-01`.

**Gap addressed:** the entry had **no `annotations.json` at all**. The meta.json is already very rich (overview, keyInsights, sections, references, crossReferences, conclusion), so the highest-impact improvement was full inline annotation coverage.

**Added 7 annotations** spanning the whole 268-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line ranges are anchored on the actual Lean constructs (verified against the source):

1. **Imports / parent reuse** (73–78) — Mathlib + `Proofs.BinaryGcdOQ04`; no new number theory, just packaging the parent's algebra
2. **`PiEven` parity test** (91–103) — the decidable ℤ-predicate `2 ∣ (z.re + z.im)` = π ∣ z via ℤ[i]/(π) ≅ 𝔽₂
3. **`binaryGcdAux` driver** (111–124) — fuel-indexed, six branches, total without well-foundedness
4. **`gcd_associated_comm`** (134–140) — gcd commutative up to a unit, for the mirrored one-even case
5. **`binaryGcdAux_correct`** (152–213) — partial correctness by induction on fuel; dispatch table to the parent's three identities
6. **`binaryGcdGaussian` + spec** (227–244) — total wrapper, unconditionally an associate of the Euclidean gcd, with the honesty caveat
7. **Sanity checks / termination witness** (246–266) — kernel `decide` (no native_decide); the (5, 2+i) fuel-exhaustion example witnessing that the naive subtraction step is not Gaussian-norm-decreasing

No changes to meta.json; the `verified`/0-axiom status is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)