### PR TITLE
Enrich hilbert-15-oq-01: head Overview section

### DIFF
--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -67,6 +67,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Chow Ring of Gr(2,4) and the Four Lines",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Imports and module docstring for the Chow (intersection) ring of the Grassmannian Gr(2,4) of lines in P³, given by six Schubert-class generators and an explicit Pieri/Littlewood–Richardson multiplication table. These head lines present the graded basis (σ_∅, σ₁, σ₂, σ₁₁, σ₂₁, σ₂₂), the full product table, and the four-lines computation σ₁²=σ₂+σ₁₁, σ₁³=2σ₂₁, σ₁⁴=2σ₂₂ — i.e. exactly 2 lines meet 4 general lines in P³ — before the Hilbert15OQ01 namespace opens.",
+      "mathContext": "The Chow ring A*(Gr(k,n)) is algebraic cycles modulo rational equivalence; for Gr(2,4) it has ℤ-rank 6 with Schubert basis σ_λ (λ ⊆ 2×2 box) and structure constants from the Littlewood–Richardson rule. Enderton's four-lines problem (a case of Hilbert's 15th, rigorous Schubert calculus) is σ₁⁴ = 2·[point], obtained by iterating the explicit multiplication table. The entry is recorded axiomatized (the finite Chow-ring computation is discharged by decide, i.e. the ofReduceBool assumption)."
+    },
+    {
       "id": "chow-ring",
       "title": "Part I: The Chow Ring of Gr(2,4)",
       "startLine": 66,


### PR DESCRIPTION
## Enrichment: head Overview section

Adds a `sec-overview` section covering the module docstring, imports, and setup at the head of the Lean source (lines 1–65), which previously had no section annotation. Section coverage only — no change to proof content, status, or axiom count.
