### PR TITLE
Enrich napoleons-theorem-oq-02: head Overview section

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -51,6 +51,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: Napoleon's Theorem via the Discrete Fourier Transform",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Imports and module docstring showing the Napoleon construction is the 3-point DFT of the triangle vertices with specific frequency components negated or zeroed. These head lines define the DFT X₀ (centroid), X₁, X₂ with ω=e^{2πi/3}, give the outer Napoleon spectrum Y₀=X₀, Y₁=−X₁, Y₂=0 and the inner spectrum Y₁'=0, Y₂'=−X₂, and explain WHY the theorem holds — the construction acts diagonally in the DFT basis, and X₂=0 characterizes equilateral triangles, so the outer Napoleon triangle is always equilateral — before the proof section.",
+      "mathContext": "Napoleon's theorem (the centers of equilateral triangles erected on a triangle's sides form an equilateral triangle) becomes transparent in the DFT basis: the linear Napoleon map is diagonal, X₀↦X₀, X₁↦−X₁, X₂↦0 (outer), and vanishing of the frequency-2 component X₂=0 is exactly the equilateral condition. The key identity G_k = z_{k-1}(1−ω)/3 + z_{k+1}(1−ω²)/3, with 1+ω+ω²=0 and ω³=1, gives Y₁=−X₁ and Y₂=0. 0 axioms, 0 sorries; builds on the base NapoleonsTheorem entry."
+    },
+    {
       "title": "Primitive Cube Root of Unity",
       "startLine": 65,
       "endLine": 116,


### PR DESCRIPTION
## Enrichment: head Overview section

Adds a `sec-overview` section covering the module docstring, imports, and setup at the head of the Lean source (lines 1–64), which previously had no section annotation. Section coverage only — no change to proof content, status, or axiom count.
