### PR TITLE
Research: chebyshev-pnt-bridge-oq-03-oq-01 — OBSERVE survey of full PNT, classified BLOCKED

### DIFF
--- a/src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json
+++ b/src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json
@@ -1,0 +1,80 @@
+{
+  "slug": "chebyshev-pnt-bridge-oq-03-oq-01",
+  "title": "Formalize the full Prime Number Theorem π(x)·log x / x → 1",
+  "status": "blocked",
+  "phase": "OBSERVE",
+  "path": "full",
+  "tier": "EMPTY",
+  "started": "2026-07-02T00:00:00.000Z",
+  "lastUpdate": "2026-07-02T00:00:00.000Z",
+  "significance": 9,
+  "tractability": 1,
+  "tags": [
+    "number-theory",
+    "prime-number-theorem",
+    "prime-counting-function",
+    "analytic-number-theory",
+    "wiener-ikehara",
+    "selberg-symmetry",
+    "tauberian",
+    "seeker-selected",
+    "gallery-extracted",
+    "research"
+  ],
+  "problemStatement": {
+    "formal": "\\lim_{x \\to \\infty} \\frac{\\pi(x)\\,\\log x}{x} = 1, \\quad \\text{equivalently } \\pi(x) \\sim \\frac{x}{\\log x}.",
+    "plain": "Open question OQ1 of the parent entry chebyshev-pnt-bridge-oq-03 (\"Bertrand's Postulate and the Prime-Counting Function\"): upgrade the Chebyshev-order two-sided bounds c·x/log x ≤ π(x) ≤ C·x/log x to the full Prime Number Theorem limit π(x)·log x / x → 1, either via the Wiener–Ikehara Tauberian theorem applied to ζ(s), or via Selberg's elementary symmetry formula.",
+    "whyMatters": [
+      "PNT is the central theorem of analytic number theory; a genuine Lean formalization (not a wrapper) would be a landmark gallery entry.",
+      "The parent gallery entries already supply the Chebyshev Θ-order bounds; the only missing step to PNT is the passage from Θ(x/log x) to the sharp asymptotic — which is precisely the deep analytic content."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Mathlib (NumberTheory/PrimeCounting.lean): π = primeCounting is monotone, surjective, and tendsto_primeCounting : Tendsto π atTop atTop. No rate / asymptotic.",
+      "Mathlib (NumberTheory/Chebyshev.lean): Chebyshev ψ/θ bound machinery, but not the PNT limit.",
+      "Gallery parents chebyshev-pnt-bridge / -oq-03: explicit two-sided Θ(x/log x) bounds on π(x) (verified)."
+    ],
+    "open": [
+      "The PNT limit π(x)·log x / x → 1 — NOT in this pinned Mathlib (v4.26.0), and NOT derivable from the Θ-order bounds alone."
+    ],
+    "goal": "Filter.Tendsto (fun x => π x * Real.log x / x) atTop (nhds 1), or the IsEquivalent form π ~ (· / log ·)."
+  },
+  "references": {
+    "papers": [
+      "Newman, Simple analytic proof of the prime number theorem, Amer. Math. Monthly 87 (1980) — the contour-integral route behind Wiener–Ikehara.",
+      "Selberg, An elementary proof of the prime-number theorem, Ann. of Math. 50 (1949).",
+      "Erdős, On a new method in elementary number theory (1949) — companion elementary route."
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Prime_number_theorem",
+      "https://en.wikipedia.org/wiki/Wiener%E2%80%93Ikehara_theorem"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.PrimeCounting — only monotone/surjective/tendsto-atTop for π; NO asymptotic.",
+      "Mathlib.NumberTheory.Chebyshev — Chebyshev-function bounds, not PNT.",
+      "No Wiener–Ikehara Tauberian theorem and no Selberg symmetry formula in this pinned Mathlib; the leanprover-community PrimeNumberTheoremAnd project has NOT been upstreamed here (Mathlib/NumberTheory/LSeries/PrimeNumberTheorem*.lean does not exist)."
+    ]
+  },
+  "knowledge": {
+    "progressSummary": "OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The full PNT limit π(x)·log x / x → 1 is NOT in the pinned Mathlib (v4.26.0): PrimeCounting.lean gives only monotonicity, surjectivity, and Tendsto π atTop atTop, and Chebyshev.lean gives Θ-order bounds — neither yields the sharp asymptotic. Both classical routes are absent from Mathlib and each is a multi-thousand-line formalization: (A) Wiener–Ikehara Tauberian theorem applied to −ζ'/ζ, which requires the analytic continuation and non-vanishing of ζ on Re(s)=1 plus a Tauberian argument (heavy complex analysis / contour integration); (B) Selberg's elementary method (Selberg symmetry Σ_{p≤x} log²p + Σ_{pq≤x} log p log q = 2x log x + O(x), then the Erdős–Selberg dichotomy). The leanprover-community PrimeNumberTheoremAnd project proves PNT but has not been upstreamed into this pinned Mathlib. Recommend keeping BLOCKED: the Θ-order-to-asymptotic gap is exactly the irreducible analytic content of PNT and cannot be closed on top of the gallery's existing Chebyshev bounds without importing one of the two heavy machineries. A tractable intermediate BUILD target, if pursued, is the equivalence ψ(x) ~ x ⟺ π(x) ~ x/log x (Abel summation / partial-summation bridge), which is elementary and would at least reduce PNT-for-π to PNT-for-ψ.",
+    "insights": [
+      "The gap is irreducible: Chebyshev's Θ(x/log x) bounds (already in the gallery) provably CANNOT be sharpened to the limit 1 by elementary manipulation — closing the constant to exactly 1 is the whole difficulty of PNT and needs either ζ non-vanishing on Re(s)=1 (route A) or the Selberg symmetry formula (route B).",
+      "Mathlib's π support stops at qualitative facts (monotone, surjective, → ∞); there is no rate, so any PNT statement must be built essentially from scratch relative to this pinned toolchain.",
+      "The one genuinely elementary sub-step is the ψ↔π transfer: ψ(x) ~ x ⟺ θ(x) ~ x ⟺ π(x) ~ x/log x via Abel/partial summation. This is a legitimate standalone BUILD that would modularize the problem, leaving only PNT-for-ψ (still deep) as the blocker."
+    ],
+    "mathlibGaps": [
+      "No PNT limit / asymptotic for primeCounting (only Tendsto π atTop atTop).",
+      "No Wiener–Ikehara Tauberian theorem.",
+      "No non-vanishing of ζ on the line Re(s)=1 packaged for Tauberian use.",
+      "No Selberg symmetry formula / elementary PNT machinery.",
+      "The PrimeNumberTheoremAnd project is not upstreamed into this pinned Mathlib."
+    ],
+    "nextSteps": [
+      "Keep BLOCKED for direct attack: PNT needs >1000 lines of either analytic (Wiener–Ikehara) or elementary (Selberg) machinery absent from this Mathlib.",
+      "Optional standalone BUILD to de-risk: formalize the Abel-summation equivalence ψ(x) ~ x ⟺ π(x) ~ x/log x, reducing the goal to PNT-for-ψ without touching the deep analysis.",
+      "Re-evaluate if/when the PrimeNumberTheoremAnd results are upstreamed into the pinned Mathlib, at which point this becomes a (possibly thin) wrapper and should be reframed or retired."
+    ],
+    "builtItems": []
+  }
+}


### PR DESCRIPTION
## Summary
OBSERVE-phase survey of parent OQ1 (`chebyshev-pnt-bridge-oq-03`): upgrade the gallery's Chebyshev `Θ(x/log x)` two-sided bounds to the **full Prime Number Theorem** limit `π(x)·log x / x → 1`. No build — documentation/assessment only.

## Findings
- **Pinned Mathlib (v4.26.0) has no PNT.** `NumberTheory/PrimeCounting.lean` provides only monotonicity, surjectivity, and `Tendsto π atTop atTop`; `NumberTheory/Chebyshev.lean` provides only `Θ`-order bounds. The `Θ`-to-sharp-asymptotic gap is the irreducible analytic content of PNT and cannot be closed elementarily on top of the existing bounds.
- **Both classical routes are absent and each is >1000 lines:** Wiener–Ikehara Tauberian (needs `ζ` non-vanishing on `Re(s)=1` + contour analysis) and Selberg's elementary symmetry method. The `leanprover-community/PrimeNumberTheoremAnd` project proves PNT but is **not** upstreamed into this pinned Mathlib (`Mathlib/NumberTheory/LSeries/PrimeNumberTheorem*.lean` does not exist here).
- **Classification: BLOCKED.** Recorded one elementary de-risking BUILD target — the Abel-summation equivalence `ψ(x) ~ x ⟺ π(x) ~ x/log x` — which would modularize the problem down to PNT-for-`ψ`.

## Files
- Adds `src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json` (full OBSERVE knowledge, Mathlib gaps, next steps).

## Status
**Outcome**: surveyed → blocked
**Next Steps**: optionally build the `ψ ↔ π` partial-summation bridge; otherwise re-evaluate if/when PrimeNumberTheoremAnd is upstreamed.

🤖 Generated by researcher-7