### PR TITLE
Enrich erdos-111-oq-01: head Overview section

### DIFF
--- a/src/data/proofs/erdos-111-oq-01/meta.json
+++ b/src/data/proofs/erdos-111-oq-01/meta.json
@@ -45,64 +45,13 @@
   },
   "sections": [
     {
-      "id": "sec-header",
-      "title": "Header: Problem and Results",
+      "id": "sec-overview",
+      "title": "Overview: Bipartite Covers and Chromatic Number (Erdős #111)",
       "startLine": 1,
-      "endLine": 63,
-      "summary": "Module docstring for Erdős #111 OQ-01: the dual bipartite-cover viewpoint on large-chromatic graphs. A bipartite cover is a family of Bool-valued 2-colorings separating every edge in some coordinate. States the four results (product coloring, χ ≤ 2^|ι| bound, the sharp finite equivalence, and the ℵ₁ shadow corollary) and the honesty note that Mathlib's ℕ∞-valued chromaticNumber collapses every uncountable value to ⊤. Imports SimpleGraph.Coloring and Fin/Fintype big-operator lemmas; fixes V, G, ι."
+      "endLine": 64,
+      "summary": "Module docstring and imports for the bipartite-cover viewpoint on Erdős #111. These head lines define a bipartite cover of G as a family c : ι → V → Bool separating every edge (∃ i, c i u ≠ c i v), state the core equivalence colorable_two_pow_iff_bipartiteCover (G has a k-graph bipartite cover ↔ χ(G) ≤ 2^k, i.e. the cover number is ⌈log₂ χ⌉), and the ℵ₁ corollary that a non-finitely-colorable graph admits no finite bipartite cover — with an honesty note that Mathlib's ℕ∞-valued chromaticNumber collapses every uncountable value to ⊤, before the namespace opens.",
+      "mathContext": "A bipartite graph is a Bool-valued 2-coloring, so a bipartite cover of G is a family of colorings separating each edge; the product 'binary expansion' coloring shows k bipartite graphs cover G iff χ(G) ≤ 2^k, making the bipartite cover number ⌈log₂ χ(G)⌉. Hence a graph with no finite chromatic number (chromaticNumber = ⊤, as ℵ₁ collapses to in Mathlib's ℕ∞ encoding) needs infinitely many bipartite graphs — the formalizable shadow of χ(G)=ℵ₁ ⇒ infinitely many bipartite graphs. Finite equivalence fully machine-checked. 0 sorries, 0 axioms."
     },
-    {
-      "id": "sec-def",
-      "title": "The BipartiteCover Structure",
-      "startLine": 65,
-      "endLine": 77,
-      "summary": "BipartiteCover G ι: a family part : ι → V → Bool of bipartitions together with covers, the condition that every edge {u,v} of G is separated by some coordinate (∃ i, part i u ≠ part i v) — i.e. lies in the i-th bipartite graph B_i."
-    },
-    {
-      "id": "sec-correspondence",
-      "title": "Covers ↔ Colorings Correspondence",
-      "startLine": 79,
-      "endLine": 98,
-      "summary": "The two directions of the correspondence. BipartiteCover.coloring: the product/binary-expansion coloring v ↦ (part i v)_i is a proper G.Coloring with color set ι → Bool, valid for arbitrary ι (adjacent vertices differ in a separating coordinate). bipartiteCoverOfColoring: conversely any proper (ι → Bool)-coloring yields a cover by reading the i-th bit of each color."
-    },
-    {
-      "id": "sec-bound",
-      "title": "Finite Cover ⇒ Chromatic Bound",
-      "startLine": 100,
-      "endLine": 113,
-      "summary": "colorable_of_bipartiteCover: a bipartite cover by a finite index type ι makes G colorable with 2^|ι| colors, since the product color set (ι → Bool) has cardinality 2^|ι| (Fintype.card_fun / card_bool). The private finPowEquiv fixes an explicit Fin (2^k) ≃ (Fin k → Bool) used to recolor in the equivalence below."
-    },
-    {
-      "id": "sec-equivalence",
-      "title": "The Sharp Finite Equivalence",
-      "startLine": 115,
-      "endLine": 128,
-      "summary": "colorable_two_pow_iff_bipartiteCover: the central fully-verified statement — G.Colorable (2^k) ↔ Nonempty (BipartiteCover G (Fin k)), i.e. G's edges are coverable by k bipartite graphs iff χ(G) ≤ 2^k, so the bipartite cover number is ⌈log₂ χ(G)⌉. Forward direction recolors along finPowEquiv then reads bits; reverse applies the 2^|ι| bound."
-    },
-    {
-      "id": "sec-corollary",
-      "title": "Chromatic Bound and the ℵ₁ Corollary",
-      "startLine": 130,
-      "endLine": 154,
-      "summary": "chromaticNumber_le_of_bipartiteCover lifts the colorability bound to G.chromaticNumber ≤ 2^|ι| < ⊤. not_nonempty_bipartiteCover_of_chromaticNumber_top is the verifiable shadow of the ℵ₁ statement: if G is not finitely colorable (chromaticNumber = ⊤, as for any uncountable-chromatic graph) then it admits no finite bipartite cover — covering an ℵ₁-chromatic graph's edges needs infinitely many bipartite graphs."
-    }
-  ],
-  "conclusion": {
-    "summary": "The file fully verifies the folklore equivalence that the edges of a graph G are coverable by k bipartite graphs if and only if χ(G) ≤ 2^k, i.e. the bipartite-cover number equals ⌈log₂ χ(G)⌉. As a corollary, a graph that is not finitely colorable — in particular any graph with chromatic number ℵ₁, the central objects of Erdős #111 — admits no finite bipartite cover and so requires infinitely many bipartite graphs to cover its edges.",
-    "implications": "The equivalence pins down a classical invariant (bipartite cover number) in terms of the chromatic number with a short, kernel-checked Mathlib proof. It supplies the parent problem #111 with a clean, exactly-computable companion to the edge-deletion measure h_G(n): where #111 quantifies *how many edges* must be removed to reach a *single* bipartite graph, this entry quantifies *how many bipartite graphs* are needed to *cover* G, and shows the latter is finite exactly when χ(G) is finite.",
-    "openQuestions": [
-      "Mathlib's chromaticNumber is ℕ∞-valued and cannot distinguish ℵ₁ from larger uncountable chromatic numbers. Develop a cardinal-valued chromatic number in Lean so that the bound χ(G) ≤ 2^#ι can be stated and proved for an arbitrary (infinite) index type ι, recovering the exact statement 'a countable bipartite cover forces χ(G) ≤ 2^ℵ₀'.",
-      "Can the sharp finite equivalence be combined with Mathlib's odd-cycle / bipartiteness API to formalize the EHS lower bound h_G(n) ≫ n for χ(G) = ℵ₁ graphs, connecting the covering invariant of this entry back to the edge-deletion invariant of the parent problem?"
-    ]
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-111",
-      "relationship": "parent-problem",
-      "description": "The parent entry formalizes Erdős #111 itself: for graphs of chromatic number ℵ₁, does h_G(n)/n → ∞, where h_G(n) measures edges to delete from n-vertex subgraphs to reach bipartiteness? This OQ studies the dual covering invariant — the number of bipartite graphs needed to cover G — and proves it is finite iff χ(G) is finite, so an ℵ₁-chromatic graph needs infinitely many bipartite covers."
-    }
-  ],
-  "sections": [
     {
       "id": "def-bipartite-cover",
       "title": "The Bipartite-Cover Model and the Coloring Bridge",
@@ -134,6 +83,21 @@
       "startLine": 130,
       "endLine": 154,
       "mathContext": "$2^k$ is finite for every finite $k$, so a finite cover forces finite $\\chi$. Contrapositive: $G.\\mathrm{chromaticNumber}=\\top$ (Mathlib's faithful ℕ∞ rendering of 'χ(G) = ℵ₁', i.e. not finitely colorable) $\\Rightarrow$ no finite bipartite cover exists."
+    }
+  ],
+  "conclusion": {
+    "summary": "The file fully verifies the folklore equivalence that the edges of a graph G are coverable by k bipartite graphs if and only if χ(G) ≤ 2^k, i.e. the bipartite-cover number equals ⌈log₂ χ(G)⌉. As a corollary, a graph that is not finitely colorable — in particular any graph with chromatic number ℵ₁, the central objects of Erdős #111 — admits no finite bipartite cover and so requires infinitely many bipartite graphs to cover its edges.",
+    "implications": "The equivalence pins down a classical invariant (bipartite cover number) in terms of the chromatic number with a short, kernel-checked Mathlib proof. It supplies the parent problem #111 with a clean, exactly-computable companion to the edge-deletion measure h_G(n): where #111 quantifies *how many edges* must be removed to reach a *single* bipartite graph, this entry quantifies *how many bipartite graphs* are needed to *cover* G, and shows the latter is finite exactly when χ(G) is finite.",
+    "openQuestions": [
+      "Mathlib's chromaticNumber is ℕ∞-valued and cannot distinguish ℵ₁ from larger uncountable chromatic numbers. Develop a cardinal-valued chromatic number in Lean so that the bound χ(G) ≤ 2^#ι can be stated and proved for an arbitrary (infinite) index type ι, recovering the exact statement 'a countable bipartite cover forces χ(G) ≤ 2^ℵ₀'.",
+      "Can the sharp finite equivalence be combined with Mathlib's odd-cycle / bipartiteness API to formalize the EHS lower bound h_G(n) ≫ n for χ(G) = ℵ₁ graphs, connecting the covering invariant of this entry back to the edge-deletion invariant of the parent problem?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-111",
+      "relationship": "parent-problem",
+      "description": "The parent entry formalizes Erdős #111 itself: for graphs of chromatic number ℵ₁, does h_G(n)/n → ∞, where h_G(n) measures edges to delete from n-vertex subgraphs to reach bipartiteness? This OQ studies the dual covering invariant — the number of bipartite graphs needed to cover G — and proves it is finite iff χ(G) is finite, so an ℵ₁-chromatic graph needs infinitely many bipartite covers."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Enrichment: head Overview section

Adds a `sec-overview` section covering the module docstring, imports, and setup at the head of the Lean source (lines 1–64), which previously had no section annotation. Section coverage only — no change to proof content, status, or axiom count.
