### PR TITLE
research(schroeder-bernstein-oq-03): read-off coherence layer for the limit permutation [VERIFIED, 0-axiom, +3 thm]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -868,6 +868,64 @@ theorem mLookup_computable : Computable₂ mLookup := by
   exact hget.of_eq (fun _ => rfl)
 
 /-!
+## Section 4f-bis: Read-off coherence — the limit function is well-defined and injective
+
+`mLookup_eq_of_mem` reads the recorded partner off a matching. To assemble the
+stage-wise matchings into a single permutation `σ : ℕ ≃ ℕ` the assembly step needs three
+further facts about that read-off, all consequences of the matching `Nodup` conditions:
+
+* the read-off **lands on a genuine edge** (`mLookup_mem_of_mem_dom`): whenever `n` is in
+  the domain, `(n, mLookup L n) ∈ L`. This is the converse companion to
+  `mLookup_eq_of_mem` and is what lets the range/inverse be read back off the same list.
+* the read-off is **injective across the domain** (`mLookup_injOn`): distinct domain
+  points get distinct partners, from range-side `Nodup` (`matching_cofunctional`). This is
+  the finite-stage witness of injectivity of the limit `σ`.
+* the read-off is **stable along a growing chain** (`mLookup_stable`): enlarging the
+  matching does not change the value on the already-covered domain. This is exactly the
+  coherence that makes the stage-wise read-offs converge to a single well-defined limit
+  (`σ n` may be computed at *any* stage past the one where `n` enters the domain).
+
+These are the well-definedness, injectivity, and coherence obligations the assembly of
+`myhill_isomorphism` consumes; they are collision-independent, so they hold for every
+matching regardless of how the scheduler resolves collisions (Section 4g).
+-/
+
+/-- **The read-off lands on a recorded edge.** If `n` is in the domain of a matching,
+    then `(n, mLookup L n) ∈ L`: the looked-up partner is genuinely paired with `n`.
+    Converse companion to `mLookup_eq_of_mem`. -/
+theorem mLookup_mem_of_mem_dom {L : List (ℕ × ℕ)} (hL : IsMatching L)
+    {n : ℕ} (hn : n ∈ mDom L) : (n, mLookup L n) ∈ L := by
+  simp only [mDom, List.mem_map] at hn
+  obtain ⟨⟨a, b⟩, hmem, ha⟩ := hn
+  have ha' : a = n := ha
+  subst ha'
+  rw [mLookup_eq_of_mem hL hmem]
+  exact hmem
+
+/-- **The read-off is injective across the domain.** On a matching, distinct domain
+    points have distinct partners: if `m, n ∈ dom L` and `mLookup L m = mLookup L n`
+    then `m = n`. Follows from range-side `Nodup` via `matching_cofunctional`; this is the
+    finite-stage witness of injectivity of the limit permutation. -/
+theorem mLookup_injOn {L : List (ℕ × ℕ)} (hL : IsMatching L)
+    {m n : ℕ} (hm : m ∈ mDom L) (hn : n ∈ mDom L)
+    (h : mLookup L m = mLookup L n) : m = n := by
+  have hm' := mLookup_mem_of_mem_dom hL hm
+  have hn' := mLookup_mem_of_mem_dom hL hn
+  rw [h] at hm'
+  exact matching_cofunctional hL hm' hn'
+
+/-- **Read-off coherence along a growing chain.** If every pair of the matching `L₁` is
+    also a pair of the larger matching `L₂`, the two agree on `L₁`'s domain:
+    `mLookup L₁ n = mLookup L₂ n` for `n ∈ dom L₁`. This is what makes the stage-wise
+    read-offs converge to a single well-defined limit — `σ n` may be computed at any stage
+    at or beyond the one where `n` first enters the domain. -/
+theorem mLookup_stable {L₁ L₂ : List (ℕ × ℕ)} (h₁ : IsMatching L₁) (h₂ : IsMatching L₂)
+    (hsub : ∀ x ∈ L₁, x ∈ L₂) {n : ℕ} (hn : n ∈ mDom L₁) :
+    mLookup L₁ n = mLookup L₂ n := by
+  have hmem := mLookup_mem_of_mem_dom h₁ hn
+  exact (mLookup_eq_of_mem h₂ (hsub _ hmem)).symm
+
+/-!
 ## Section 4g: Collision structure — what blocks a fresh domain/range extension
 
 Sections 4c–4f supply the *collision-free* atomic steps (`matching_step_f`,

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1119,
+    "lineCount": 1177,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -53,12 +53,13 @@
       "range_firstMissing_subset: the firstMissing-covered prefix {0,…,firstMissing L−1} ⊆ L (initial-segment coverage form of minimality)",
       "firstMissing_le_length: exhaustion bound firstMissing L ≤ L.length — the quantitative termination measure guaranteeing every k enters by a bounded stage (VERIFIED, 0-axiom)",
       "Domain/range duality (Section 4e): mDom_map_swap, mRan_map_swap, isMatching_map_swap, matchingCorr_map_swap — coordinate-swap L ↦ L.map Prod.swap makes the odd (range) stage the even (domain) stage of the swapped problem (q,p), so the scheduler need define only one stage move (VERIFIED, 0-axiom)",
-      "Collision chase is a bounded forward-orbit walk (Section 4·chase): fwdOrbit_succ, fwdOrbit_prefix_distinct (acyclicity of a fresh-anchored colliding prefix via injectivity of g∘f), fwdOrbit_chase_length_le (chase length ≤ current matching size) — discharges the bounded-search obligation of the collision-resolving stage move (VERIFIED, 0-axiom)"
+      "Collision chase is a bounded forward-orbit walk (Section 4·chase): fwdOrbit_succ, fwdOrbit_prefix_distinct (acyclicity of a fresh-anchored colliding prefix via injectivity of g∘f), fwdOrbit_chase_length_le (chase length ≤ current matching size) — discharges the bounded-search obligation of the collision-resolving stage move (VERIFIED, 0-axiom)",
+      "Read-off coherence layer (Section 4f-bis): mLookup_mem_of_mem_dom (the lookup lands on a genuine recorded edge), mLookup_injOn (the read-off is injective across the domain, via range-side Nodup), and mLookup_stable (read-off values are stable as the matching grows) — the well-definedness/injectivity/coherence obligations the eventual assembly of the limit permutation consumes, collision-independent (VERIFIED, 0-axiom)"
     ],
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 62,
+    "theoremCount": 65,
     "definitionCount": 14,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
@@ -248,9 +249,9 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 1119,
+    "lineCount": 1177,
     "axiomCount": 0,
-    "theoremCount": 62,
+    "theoremCount": 65,
     "definitionCount": 14,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",


### PR DESCRIPTION
## Summary

Advances the **hard direction of Myhill's Isomorphism Theorem** (schroeder-bernstein-oq-03) by adding the *read-off coherence layer* (new Section 4f-bis) — three collision-independent lemmas about the computable matching evaluator `mLookup` that the eventual assembly of the limit permutation $\sigma : \mathbb{N} \simeq \mathbb{N}$ consumes.

The remaining `sorry` in `myhill_isomorphism` (the back-and-forth priority construction) is **unchanged** — this is verified supporting infrastructure, not a closure of the open direction.

## New theorems (all VERIFIED, 0 axioms, 0 sorries)

- **`mLookup_mem_of_mem_dom`** — the read-off lands on a genuine recorded edge: `n ∈ dom L → (n, mLookup L n) ∈ L`. Converse companion to `mLookup_eq_of_mem`; lets the range/inverse be read back off the same list.
- **`mLookup_injOn`** — the read-off is injective across the domain, from the range-side `Nodup` of a matching (`matching_cofunctional`). Finite-stage witness of injectivity of the limit $\sigma$.
- **`mLookup_stable`** — read-off values are stable as the matching grows (agreement on the shared domain of a sublist matching). The coherence that makes the stage-wise read-offs converge to a single well-defined limit.

These are exactly the well-definedness / injectivity / coherence obligations the limit assembly needs, and are collision-independent (hold for every matching regardless of how the scheduler resolves collisions in Section 4g).

## Verification

Built with `./proofs/scripts/docker-build.sh Proofs.SchroederBernsteinOQ03` — **build succeeded**. Only the pre-existing `sorry` warning (hard-direction, line ~1032) and two pre-existing unused-variable warnings remain; no new sorries or axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)