### PR TITLE
Enrich Descartes Parity with Multiplicity: annotation coverage (4→8)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/annotations.json
@@ -24,6 +24,30 @@
     "prerequisites": ["Polynomial.eq_rootMultiplicity_map", "Complex.conj_ofReal"]
   },
   {
+    "id": "ann-drs010101oq03-realcoeff",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 52, "endLine": 58 },
+    "type": "insight",
+    "title": "Where Real Coefficients Enter: the Single Load-Bearing Equation",
+    "content": "toC_map_conj is the only place the hypothesis 'p has real coefficients' is used. It proves (toC p).map conj = toC p by first checking that conj ∘ (algebraMap ℝ ℂ) = algebraMap ℝ ℂ pointwise — conjugation fixes the image of every real number (Complex.conj_ofReal) — and then pushing this through Polynomial.map_map, which composes the two coefficient maps. Every downstream result (equal multiplicities, multiset invariance, the half-plane bijection, the parity) is a formal consequence of this one fixed-point equation.",
+    "mathContext": "$\\overline{\\iota(r)} = \\iota(r)$ for all $r\\in\\mathbb{R}$, where $\\iota=$ algebraMap ℝ ℂ; hence $\\overline{q}=q$ for $q=p.\\mathrm{map}\\,\\iota$.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.conj_ofReal", "Polynomial.map_map", "real coefficients", "ring hom composition"],
+    "prerequisites": ["functoriality of Polynomial.map", "ext on ring homomorphisms"]
+  },
+  {
+    "id": "ann-drs010101oq03-selfinverse",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 77, "endLine": 87 },
+    "type": "technique",
+    "title": "From Pointwise Counts to Multiset Equality via a Self-Inverse Map",
+    "content": "roots_map_conj upgrades the pointwise count identity to full multiset equality map conj q.roots = q.roots. The engine is Multiset.count_map_eq_count', which for an injective map f gives count (map f s) (f w) = count s w. Because conjugation is its own inverse (starRingEnd_self_apply rewrites conj (conj w) back to w), the index f w can be normalized so the goal collapses to the already-established count_roots_conj. Multiset.ext then lifts the equality of all counts to equality of the multisets.",
+    "mathContext": "$\\mathrm{count}_w(\\mathrm{map}\\,\\mathrm{conj}\\,S) = \\mathrm{count}_{\\overline w}(S) = \\mathrm{count}_w(S)$, using $\\overline{\\overline w}=w$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.count_map_eq_count'", "involution", "Multiset.ext", "starRingEnd_self_apply"],
+    "prerequisites": ["multiset extensionality", "injective self-inverse maps"]
+  },
+  {
     "id": "ann-drs010101oq03-invariance",
     "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
     "range": { "startLine": 91, "endLine": 116 },
@@ -36,6 +60,18 @@
     "prerequisites": ["Multiset.count_map_eq_count'", "Multiset.filter_map"]
   },
   {
+    "id": "ann-drs010101oq03-trichotomy",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 104, "endLine": 121 },
+    "type": "technique",
+    "title": "Half-Plane Trichotomy Makes the Count Manifestly Even",
+    "content": "nonreal_roots_card_even splits the non-real roots by lt_trichotomy on the imaginary part into the strict upper (0 < im) and lower (im < 0) half-planes; the case im = 0 is excluded by the filter itself. Comparing multiset counts case-by-case (Multiset.count_filter) yields card(im ≠ 0) = card(0 < im) + card(im < 0). The half-plane bijection then rewrites the lower count as card(map conj (0 < im)) = card(0 < im) (Multiset.card_map), so the total is exactly 2·card(0 < im) — even by construction, discharged with the witness ⟨_, rfl⟩.",
+    "mathContext": "$\\#\\{\\Im\\ne 0\\} = \\#\\{\\Im>0\\} + \\#\\{\\Im<0\\} = 2\\,\\#\\{\\Im>0\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["lt_trichotomy", "Multiset.count_filter", "Multiset.card_map", "Even"],
+    "prerequisites": ["multiset filter counting", "trichotomy of a linear order"]
+  },
+  {
     "id": "ann-drs010101oq03-parity",
     "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
     "range": { "startLine": 117, "endLine": 147 },
@@ -46,5 +82,17 @@
     "significance": "key",
     "relatedConcepts": ["parity", "algebraically closed fields", "root counting"],
     "prerequisites": ["IsAlgClosed.card_roots_eq_natDegree", "Multiset.filter_add_not"]
+  },
+  {
+    "id": "ann-drs010101oq03-degcount",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 127, "endLine": 145 },
+    "type": "technique",
+    "title": "From Even Non-Real Count to Degree Parity",
+    "content": "realRoots_card_parity combines three facts. (1) Over the algebraically closed field ℂ the entire root multiset has cardinality deg p (IsAlgClosed.card_roots_eq_natDegree, with natDegree_map_eq_of_injective ensuring the degree survives the map into ℂ[X]). (2) Filtering by im = 0 and its negation partitions the roots (Multiset.filter_add_not), so realCount + nonrealCount = deg p. (3) The previous theorem writes nonrealCount = 2m. Hence realCount = deg p − 2m, and the modular congruence realCount ≡ deg p (mod 2) is closed by Nat.modEq_iff_dvd' followed by omega.",
+    "mathContext": "$\\mathrm{real} + \\mathrm{nonreal} = \\deg p$ and $\\mathrm{nonreal} = 2m \\Rightarrow \\mathrm{real} \\equiv \\deg p \\pmod 2$.",
+    "significance": "key",
+    "relatedConcepts": ["IsAlgClosed.card_roots_eq_natDegree", "Multiset.filter_add_not", "Nat.ModEq", "natDegree_map_eq_of_injective"],
+    "prerequisites": ["algebraically closed fields", "Nat.modEq_iff_dvd'"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `descartes-rule-of-signs-oq-01-oq-01-oq-03` (Descartes Parity with Multiplicity).

## What changed
Deepened **annotation coverage** from 4 broad section annotations to 8, adding 4 finer-grained technique/insight annotations nested within the existing sections. Each new annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- **realcoeff** (`toC_map_conj`, L52–58) — pinpoints the *single* place the real-coefficient hypothesis is used: `conj ∘ algebraMap = algebraMap` (via `Complex.conj_ofReal`), pushed through `Polynomial.map_map`. Everything downstream follows from this one fixed-point equation.
- **selfinverse** (`roots_map_conj`, L77–87) — how pointwise count equality is lifted to multiset equality via `Multiset.count_map_eq_count'` plus conjugation being its own inverse.
- **trichotomy** (`nonreal_roots_card_even`, L104–121) — the `lt_trichotomy` half-plane split yielding `2·card(upper)`, manifestly even.
- **degcount** (`realRoots_card_parity`, L127–145) — assembling `card_roots = natDegree` (algebraic closure), `filter_add_not`, and the even non-real count, closed by `omega`.

## Not changed
`meta.json` is already accurate and within all size caps (11.7 KB), so it was left untouched — no accretion.

## Integrity
No change to `status` / `badge` / `axiomCount` (verified / original / 0). Annotations describe the existing machine-checked Lean file; no mathematical claims altered.
