### PR TITLE
Enrich PSL(2,7) order inputs (inverse-galois-oq-06-oq-02-oq-01): annotation depth + references

### DIFF
--- a/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-igpsl27-header",
+    "proofId": "inverse-galois-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "context",
+    "title": "Scope: Order Inputs for the PSL(2,7) Realization",
+    "content": "The module docstring frames the research target — realize PSL(2,7), the simple group of order 168, as a Galois group over ℚ via Trinks' degree-7 polynomial x⁷−7x+3 — and draws the honest boundary: the full Galois correspondence needs Dedekind's theorem producing the Frobenius permutation, the same Mathlib gap the sibling A₅ entry records. What is verified here, with 0 axioms and 0 sorries, is the concrete group-order input: the order of the target group (via the exceptional isomorphism PSL(2,7) ≅ PSL(3,2) = GL(3,2)), and the cycle-length divisibilities the degree-7 Frobenius cycle types impose on |Gal|.",
+    "mathContext": "Target: realize $\\mathrm{PSL}(2,7)$, $|\\mathrm{PSL}(2,7)|=168$, over $\\mathbb{Q}$ via Trinks' $x^7-7x+3$. Exceptional isomorphism $\\mathrm{PSL}(2,7)\\cong \\mathrm{PSL}(3,2)=\\mathrm{GL}(3,2)$; Dedekind: $\\bar f \\bmod p$ factorization type $\\Rightarrow$ Frobenius cycle type $\\Rightarrow$ divisor of $|\\mathrm{Gal}|$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "inverse Galois problem",
+      "PSL(2,7)",
+      "exceptional isomorphism",
+      "Trinks polynomial",
+      "Dedekind's theorem"
+    ],
+    "prerequisites": [
+      "Galois groups of polynomials over ℚ",
+      "finite simple groups of order 168",
+      "scope of current Mathlib formalization"
+    ]
+  },
+  {
+    "id": "ann-igpsl27-facts",
+    "proofId": "inverse-galois-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "Setup: 𝔽₂ and 𝔽₇ Are Fields",
+    "content": "Two instances register Fact (Nat.Prime 2) and Fact (Nat.Prime 7), each discharged by norm_num. These carry no mathematical assumption — they only unlock Lean's typeclass resolution so that ZMod 2 and ZMod 7 are recognized as finite fields, which is what Matrix.card_GL_field requires. Without them GL(Fin 3) (ZMod 2) would not even typecheck as a general linear group over a field.",
+    "mathContext": "$\\mathbb{Z}/p\\mathbb{Z}=\\mathrm{ZMod}\\,p$ is a field iff $p$ is prime; the typeclass witness is $\\mathrm{Fact}\\,(\\mathrm{Nat.Prime}\\,p)$. Needed so $\\mathrm{GL}(\\mathrm{Fin}\\,n)\\,(\\mathrm{ZMod}\\,p)$ is a general linear group over a field and $\\texttt{Matrix.card\\_GL\\_field}$ applies.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "ZMod p as a finite field",
+      "Fact typeclass",
+      "norm_num",
+      "typeclass resolution"
+    ],
+    "prerequisites": [
+      "prime fields 𝔽_p",
+      "Lean instance/Fact mechanism"
+    ]
+  },
+  {
+    "id": "ann-igpsl27-gl32",
+    "proofId": "inverse-galois-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 60
+    },
+    "type": "key-step",
+    "title": "|GL(3,2)| = 168: the Order of the Target Group",
+    "content": "card_GL_3_2 computes the order of GL(3,𝔽₂) directly from Mathlib's Matrix.card_GL_field, which gives |GL(n,𝔽_q)| = ∏ᵢ<ₙ (qⁿ − qⁱ). Here q = 2, n = 3, so the product is (2³−2⁰)(2³−2¹)(2³−2²) = 7·6·4 = 168. The two-line proof rewrites card_GL_field and ZMod.card (Fintype.card (ZMod 2) = 2), then closes the finite arithmetic with decide. Crucially, over 𝔽₂ the general linear, special linear, and projective special linear groups all coincide — the only unit is 1 so every invertible matrix already has determinant 1, and the center of SL is trivial — so this is literally |PSL(3,2)|, which the exceptional isomorphism identifies with |PSL(2,7)|, the group to be realized.",
+    "mathContext": "$|\\mathrm{GL}(n,\\mathbb{F}_q)|=\\prod_{i=0}^{n-1}(q^n-q^i)$; at $n=3,q=2$: $(2^3-1)(2^3-2)(2^3-4)=7\\cdot 6\\cdot 4=168$. Over $\\mathbb{F}_2$, $\\mathrm{GL}=\\mathrm{SL}=\\mathrm{PSL}$ (unique unit $1$, trivial center), so $|\\mathrm{GL}(3,2)|=|\\mathrm{PSL}(3,2)|=|\\mathrm{PSL}(2,7)|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "general linear group order formula",
+      "GL=SL=PSL over 𝔽₂",
+      "Matrix.card_GL_field",
+      "exceptional isomorphism PSL(3,2)≅PSL(2,7)"
+    ],
+    "prerequisites": [
+      "order of GL(n,𝔽_q)",
+      "determinant and the special linear subgroup",
+      "center of SL"
+    ]
+  },
+  {
+    "id": "ann-igpsl27-gl27",
+    "proofId": "inverse-galois-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 83
+    },
+    "type": "key-step",
+    "title": "|GL(2,7)| = 2016 and the Special-Linear/Center Arithmetic",
+    "content": "card_GL_2_7 gives |GL(2,𝔽₇)| = (7²−1)(7²−7) = 48·42 = 2016 by the same card_GL_field mechanism. This is the ambient group from which PSL(2,7) is carved: the determinant surjects GL(2,7) onto 𝔽₇^× ≅ ℤ/6, so |SL(2,7)| = 2016/6 = 336, and quotienting by the order-2 center {±I} (−1 ≠ 1 in 𝔽₇) leaves |PSL(2,7)| = 168. psl27_order_arith verifies the identity 2016/6/2 = 168, and exceptional_iso_orders_agree records that this matches |GL(3,2)| — the numerical shadow of PSL(3,2) ≅ PSL(2,7).",
+    "mathContext": "$|\\mathrm{GL}(2,\\mathbb{F}_7)|=(7^2-1)(7^2-7)=48\\cdot 42=2016$. $\\det:\\mathrm{GL}(2,7)\\twoheadrightarrow \\mathbb{F}_7^\\times\\cong \\mathbb{Z}/6$ gives $|\\mathrm{SL}(2,7)|=2016/6=336$; the center $\\{\\pm I\\}$ ($-1\\neq 1$ in $\\mathbb{F}_7$) has order $2$, so $|\\mathrm{PSL}(2,7)|=336/2=168=2016/6/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "determinant surjection onto 𝔽_q^×",
+      "special linear group SL(2,7)",
+      "projective quotient by the center",
+      "order agreement 168"
+    ],
+    "prerequisites": [
+      "|GL(2,𝔽_q)| formula",
+      "kernel of det = SL",
+      "order of the scalar center {±I}"
+    ]
+  },
+  {
+    "id": "ann-igpsl27-divis",
+    "proofId": "inverse-galois-oq-06-oq-02-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 111
+    },
+    "type": "insight",
+    "title": "Factorization and Cycle-Length Divisibilities",
+    "content": "168 = 2³·3·7 (order_168_factorization), and the divisibilities 7,3,8 ∣ 168 (plus the primes 2,3,7) are not decoration: the degree-7 permutation representation of PSL(2,7) has cycle types 1⁷, 2²1³, 3²1, 4·2·1, and 7, and Dedekind's eliminator — proved in full generality by the sibling A₅ entry (a Frobenius n-cycle on the roots forces n ∣ |Gal|) — turns each cycle length into a divisor of the Galois group's order. So a realization whose Frobenius data hits a 7-cycle, a 3²·1, and a Sylow-2 element of order 8 forces 7·3·8-worth of divisibility, consistent with the target order 168. psl27_order_input bundles the verified numerical target.",
+    "mathContext": "$168=2^3\\cdot 3\\cdot 7$. Degree-7 permutation rep of $\\mathrm{PSL}(2,7)$ has cycle types $1^7,\\,2^2 1^3,\\,3^2 1,\\,4\\!\\cdot\\!2\\!\\cdot\\!1,\\,7$; Dedekind's eliminator (Frobenius $n$-cycle $\\Rightarrow n\\mid|\\mathrm{Gal}|$) yields $7\\mid 168$, $3\\mid 168$, $8\\mid 168$ (Sylow-2 of order 8).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime factorization",
+      "Frobenius cycle types",
+      "Dedekind's eliminator",
+      "Sylow-2 subgroup",
+      "order divisibility constraints"
+    ],
+    "prerequisites": [
+      "cycle types of a degree-7 permutation group",
+      "Dedekind's theorem (background)",
+      "divisibility and Sylow subgroups"
+    ]
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "inverse-galois-oq-06-oq-02-oq-01",
+  "title": "Inverse Galois OQ-06→02→01: The Order of PSL(2,7) via the Exceptional Isomorphism GL(3,2)≅PSL(2,7)",
+  "slug": "inverse-galois-oq-06-oq-02-oq-01",
+  "description": "Isolates and fully verifies (0 axioms, 0 sorries, no native_decide) the concrete group-order input for realizing PSL(2,7) — the simple group of order 168 — as a Galois group over ℚ (the classical Trinks polynomial x⁷−7x+3 route). Using Mathlib's Matrix.card_GL_field, it computes |GL(3,2)| = 168 (the order of the group to be realized, since over 𝔽₂ one has GL(3,2)=SL(3,2)=PSL(3,2), which is exceptionally isomorphic to PSL(2,7)) and |GL(2,7)| = 2016, from which the special-linear/center arithmetic gives |PSL(2,7)| = 2016/6/2 = 168. It records the factorization 168 = 2³·3·7 and the divisibilities 2,3,7,8 ∣ 168, which are exactly the cycle-length constraints the degree-7 Frobenius cycle types (1⁷, 2²1³, 3²1, 4·2·1, 7) impose on |Gal| through Dedekind's eliminator (verified in full generality by the sibling A₅ entry).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InverseGaloisPSL27.lean",
+    "tags": [
+      "galois-theory",
+      "group-theory",
+      "inverse-galois-problem",
+      "linear-algebraic-groups",
+      "finite-fields",
+      "psl27"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "None. Every theorem is fully machine-checked with 0 axiom declarations, 0 sorries, and no native_decide (the proofs depend only on Lean's foundational propext / Classical.choice / Quot.sound). The two `instance : Fact (Nat.Prime p)` declarations are proved by norm_num — they carry no mathematical assumption, only enabling the ZMod p field instance. This file does NOT realize PSL(2,7) as a Galois group (that needs Dedekind's theorem producing the Frobenius permutation — a genuine Mathlib 4.26 gap, recorded by the parent A₅ entry); it verifies the group-order inputs that such a realization consumes.",
+    "lineCount": 112,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "originalContributions": [
+      "card_GL_3_2: |GL(3,𝔽₂)| = 168, the order of the group to be realized — GL(3,2)=SL(3,2)=PSL(3,2), exceptionally isomorphic to PSL(2,7) — computed from Matrix.card_GL_field as (8−1)(8−2)(8−4)=7·6·4",
+      "card_GL_2_7: |GL(2,𝔽₇)| = 2016 = (49−1)(49−7)=48·42, the ambient group whose special-linear subgroup and center yield PSL(2,7)",
+      "psl27_order_arith / exceptional_iso_orders_agree: the special-linear/center arithmetic |PSL(2,7)| = 2016/(7−1)/2 = 168, and its numerical agreement with |GL(3,2)| — the shadow of the exceptional isomorphism PSL(3,2)≅PSL(2,7)",
+      "order_168_factorization: 168 = 2³·3·7",
+      "seven_dvd_order / three_dvd_order / eight_dvd_order / primes_dvd_order: the degree-7 cycle-length divisibilities (7,3,8 and the primes 2,3,7) that a Frobenius cycle type forces on |Gal| via Dedekind's eliminator",
+      "psl27_order_input: the bundled fully-verified numerical target for the PSL(2,7) Galois realization"
+    ],
+    "relatedProblems": [
+      {
+        "id": "inverse-galois-oq-06-oq-02",
+        "relationship": "Parent: the A₅ Dedekind-input entry that proves the general cycle-type ⟹ order-divisibility eliminator this entry's divisibilities feed into"
+      },
+      {
+        "id": "inverse-galois-oq-06",
+        "relationship": "Grandparent: the A₅-over-ℚ realization; PSL(2,7) is the next simple group up the inverse-Galois ladder"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Extends: base inverse Galois problem"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "PSL(2,7), the simple group of order 168, is the second-smallest non-abelian simple group (after A₅ of order 60). It carries the famous exceptional isomorphism PSL(2,7) ≅ PSL(3,2) = GL(3,2) — the automorphism group of the Fano plane — one of only a handful of coincidences between the two infinite families of finite simple groups of Lie type. Realizing PSL(2,7) as a Galois group over ℚ is a classical success of the inverse Galois program: Wolfram Trinks exhibited (1968) the degree-7 polynomial x⁷−7x+3 whose Galois group is exactly PSL(2,7) acting on its seven roots, computed by Dedekind reduction modulo several primes. The full formalization of that realization is out of reach of current Mathlib (it needs Dedekind's theorem to produce the Frobenius permutation, the same gap the sibling A₅ entry records), but the group-order arithmetic — what order the target group has, and which cycle-length divisibilities constrain the Galois group — is fully elementary and axiom-free.",
+    "problemStatement": "Verify, with no axioms, the group-order inputs of the PSL(2,7) Galois realization: (A) that the order of the target group is 168, computed concretely as |GL(3,2)| = |PSL(3,2)| (the exceptional-isomorphism model of PSL(2,7)); (B) that |GL(2,7)| = 2016, whence the special-linear/center arithmetic gives |PSL(2,7)| = 2016/6/2 = 168; and (C) the factorization 168 = 2³·3·7 with the divisibilities 2,3,7,8 ∣ 168 that the degree-7 Frobenius cycle types impose on |Gal| via Dedekind's eliminator.",
+    "text": "The heart is Mathlib's Matrix.card_GL_field, which gives |GL(n,𝔽_q)| = ∏ᵢ<ₙ (qⁿ − qⁱ) over a finite field. Instantiated at n=3, q=2 it yields (8−1)(8−2)(8−4) = 7·6·4 = 168; at n=2, q=7 it yields (49−1)(49−7) = 48·42 = 2016. Over 𝔽₂ the general linear, special linear, and projective special linear groups coincide (the only unit is 1, so every invertible matrix has determinant 1, and the center of SL is trivial), so |GL(3,2)| is literally |PSL(3,2)|, which the exceptional isomorphism identifies with |PSL(2,7)|. Independently, from |GL(2,7)| = 2016 one strips the determinant surjection onto 𝔽₇^× ≅ ℤ/6 to get |SL(2,7)| = 336, then quotients by the order-2 center {±I} to get |PSL(2,7)| = 168 — verified here as the arithmetic identity 2016/6/2 = 168. The prime factorization and the individual divisibilities 7,3,8 ∣ 168 record the cycle-length data: the degree-7 permutation representation of PSL(2,7) has cycle types 1⁷, 2²1³, 3²1, 4·2·1, and 7, and Dedekind's eliminator (a Frobenius n-cycle forces n ∣ |Gal|, proved in full generality by the sibling A₅ entry) turns each into a divisor of the Galois group's order.",
+    "proofStrategy": "Everything reduces to a single Mathlib lemma (card_GL_field) plus decidable finite arithmetic. Register Fact (Nat.Prime 2) and Fact (Nat.Prime 7) so ZMod 2 and ZMod 7 are fields; rewrite the general-linear cardinality and the ZMod card, then close the numeric products with decide. The factorization and divisibility facts are all decide. No axioms, no sorries, no native_decide.",
+    "keyInsights": [
+      "The order of PSL(2,7) is most cheaply computed not through PSL(2,7) itself but through its exceptional-isomorphism twin GL(3,2)=PSL(3,2), because over 𝔽₂ the general/special/projective linear groups all coincide and Mathlib's card_GL_field applies directly.",
+      "Two independent computations pin 168: |GL(3,2)| = 168 straight from card_GL_field, and |PSL(2,7)| = |GL(2,7)|/(7−1)/2 = 2016/6/2 = 168 via the determinant surjection and the order-2 center. Their agreement is the numerical shadow of PSL(3,2)≅PSL(2,7).",
+      "The factorization 168 = 2³·3·7 and the divisibilities 7,3,8 ∣ 168 are not decoration: they are exactly the cycle-length constraints the degree-7 Frobenius cycle types (1⁷, 2²1³, 3²1, 4·2·1, 7) impose on |Gal| through Dedekind's eliminator, which the sibling A₅ entry proves in full generality.",
+      "Realizing PSL(2,7) via Trinks' x⁷−7x+3 needs the same one Mathlib gap as the A₅ case — Dedekind's theorem producing the Frobenius permutation — so isolating the axiom-free order inputs sharpens exactly where the residual work lies."
+    ],
+    "prerequisites": [
+      "Linear algebraic groups over finite fields: GL(n,𝔽_q), the order formula ∏(qⁿ−qⁱ)",
+      "The exceptional isomorphism PSL(2,7) ≅ PSL(3,2) = GL(3,2)",
+      "Finite fields: ZMod p is a field for p prime",
+      "Group theory: special linear subgroup as kernel of det, center of SL, projective quotient",
+      "Dedekind's theorem (background): mod-p factorization type ↦ Frobenius cycle type ↦ order divisibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Realizing PSL(2,7) and the Order Inputs",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Docstring framing the research target (realize PSL(2,7) over ℚ via Trinks' x⁷−7x+3), the honest scope (the Frobenius-permutation gap is out of reach, as in the A₅ sibling), and the verified deliverable (the group-order inputs |GL(3,2)|=168, |GL(2,7)|=2016, the factorization, and the cycle-length divisibilities)."
+    },
+    {
+      "id": "gl32",
+      "title": "§1 The Order of GL(3,2) = PSL(3,2) ≅ PSL(2,7)",
+      "startLine": 43,
+      "endLine": 61,
+      "summary": "Registers Fact (Nat.Prime 2) and Fact (Nat.Prime 7), then proves card_GL_3_2 : |GL(3,𝔽₂)| = 168 from Matrix.card_GL_field ((8−1)(8−2)(8−4)=7·6·4), the order of the group to be realized."
+    },
+    {
+      "id": "gl27-arith",
+      "title": "§2 The Order of GL(2,7) and the Special-Linear/Center Arithmetic",
+      "startLine": 62,
+      "endLine": 83,
+      "summary": "card_GL_2_7 : |GL(2,𝔽₇)| = 2016, psl27_order_arith : 2016/(7−1)/2 = 168, and exceptional_iso_orders_agree : |GL(3,2)| = 2016/6/2 — the two order computations agreeing at 168."
+    },
+    {
+      "id": "factorization",
+      "title": "§3 Factorization and the Degree-7 Cycle-Length Divisibilities",
+      "startLine": 84,
+      "endLine": 112,
+      "summary": "order_168_factorization : 168 = 2³·3·7, the divisibilities seven/three/eight_dvd_order and primes_dvd_order, and the bundled psl27_order_input — the cycle-length constraints a degree-7 Frobenius imposes on |Gal| via Dedekind's eliminator."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry fully verifies (0 axioms, 0 sorries, no native_decide) the group-order inputs for realizing PSL(2,7) as a Galois group over ℚ: |GL(3,2)| = 168 (the order of PSL(3,2)≅PSL(2,7)), |GL(2,7)| = 2016 with the special-linear/center arithmetic giving |PSL(2,7)| = 168, the factorization 168 = 2³·3·7, and the divisibilities 2,3,7,8 ∣ 168 that the degree-7 Frobenius cycle types impose on |Gal|.",
+    "implications": "Together with the sibling A₅ entry's fully-general Dedekind eliminator (a Frobenius n-cycle forces n ∣ |Gal|), these order facts pin the exact numerical target of the PSL(2,7) realization. The one remaining mathematical gap is the same as for A₅: Dedekind's theorem producing the Frobenius permutation from the mod-p factorization of Trinks' x⁷−7x+3, which Mathlib does not yet formalize.",
+    "openQuestions": [
+      "Verify the mod-p factorizations of Trinks' polynomial x⁷−7x+3 to read off the (1⁷, 2²1³, 3²1, 4·2·1, 7) Frobenius cycle types, mirroring the A₅ sibling's mod-7/mod-11 factorization work.",
+      "Formalize the exceptional isomorphism PSL(2,7) ≅ GL(3,2) in Lean, upgrading the numerical order agreement to a group isomorphism.",
+      "Prove |SL(2,7)| = 336 and |PSL(2,7)| = 168 directly through Nat.card of the special linear group and its center (currently only |GL| has a Mathlib cardinality formula), turning the arithmetic identity into a statement about the projective group itself."
+    ]
+  },
+  "leanFile": {
+    "namespace": "InverseGaloisPSL27",
+    "lineCount": 112,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/InverseGaloisPSL27.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "David W. Erbach, Jürgen Fischer, John McKay",
+      "title": "Polynomials with PSL(2,7) as Galois group",
+      "year": 1979,
+      "venue": "Journal of Number Theory 11(1), 69–75",
+      "note": "The standard reference for the degree-7 polynomial x⁷−7x+3 (attributed to W. Trinks, 1968) realizing PSL(2,7) over ℚ; cycle types read off via Dedekind reduction mod p."
+    },
+    {
+      "authors": "Jean-Pierre Serre",
+      "title": "Topics in Galois Theory",
+      "year": 1992,
+      "venue": "Research Notes in Mathematics 1, Jones and Bartlett (2nd ed. A K Peters, 2008)",
+      "note": "Systematic treatment of the inverse Galois problem, rigidity, and explicit realizations of small groups over ℚ."
+    },
+    {
+      "authors": "John H. Conway, Robert T. Curtis, Simon P. Norton, Richard A. Parker, Robert A. Wilson",
+      "title": "ATLAS of Finite Groups",
+      "year": 1985,
+      "venue": "Oxford University Press",
+      "note": "Records L₂(7) = L₃(2) of order 168, its exceptional isomorphism, and its permutation characters (including the degree-7 action used here)."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Matrix.card_GL_field and ZMod.card",
+      "year": 2024,
+      "venue": "Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Card, Mathlib.Data.ZMod.Basic",
+      "note": "|GL(n,𝔽_q)| = ∏ᵢ<ₙ (qⁿ − qⁱ) and Fintype.card (ZMod p) = p — the two lemmas the order computations reduce to."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-oq-06-oq-02",
+      "relationship": "extends",
+      "description": "The A₅ Dedekind-input entry whose fully-general cycle-type ⟹ order-divisibility eliminator these PSL(2,7) order divisibilities feed into."
+    },
+    {
+      "targetId": "inverse-galois-oq-06",
+      "relationship": "related",
+      "description": "The A₅-over-ℚ realization; PSL(2,7) is the next simple group up the inverse-Galois ladder."
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Base inverse Galois entry that this problem family extends."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Enrichment: Order of PSL(2,7) via GL(3,2)≅PSL(2,7)

Pass 1 enrichment of `inverse-galois-oq-06-oq-02-oq-01`. The entry already had a solid `overview`/`sections`/`conclusion` and cross-references, but two gaps remained.

### `annotations.json` — structured fields added to all 5 annotations
Each annotation previously had only `title` + `content`. Added, verified against `proofs/Proofs/InverseGaloisPSL27.lean`:
- **`mathContext`** — LaTeX for the key formulas (|GL(n,𝔽_q)| = ∏(qⁿ−qⁱ); 7·6·4=168; 48·42=2016; det surjection + order-2 center giving 2016/6/2=168; 168 = 2³·3·7 and the cycle-type divisibilities).
- **`significance`** (`context`/`technical`/`key`/`supporting`), **`relatedConcepts`**, **`prerequisites`**.

### `meta.json` — added `references` (was missing)
- Erbach–Fischer–McKay 1979 (the x⁷−7x+3 / Trinks realization of PSL(2,7)).
- Serre, *Topics in Galois Theory* (inverse Galois problem).
- Conway et al., *ATLAS of Finite Groups* (L₂(7)=L₃(2), order 168, exceptional isomorphism).
- Mathlib `Matrix.card_GL_field` / `ZMod.card`.

### Verification
- Both JSON files parse; `meta.json` is 14.2 KB (well under the 60 KB cap; `gallery:check-size` passes).
- `pnpm annotations:build` reports 0 warnings for this entry.
- Content cross-checked against the Lean source (9 theorems, 0 defs, 0 axioms, no native_decide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
