### PR TITLE
research(alternating-series-boole-summation-oq-03): quadratic alternating-sum closed form [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesBooleSummationOQ03.lean
+++ b/proofs/Proofs/AlternatingSeriesBooleSummationOQ03.lean
@@ -1,0 +1,105 @@
+/-
+# Alternating-Series Boole Summation — OQ-03
+## Exact closed form for the alternating sum of a quadratic sequence
+
+The parent entry `AlternatingSeriesBooleSummation.lean` builds the exact finite Boole
+summation engine and, as its terminal application, proves the closed form `altSum_affine`
+for the alternating sum of an *affine* sequence `a_j = α + β·j`: the order-`2` Boole formula
+terminates because `Δ²(α+βj) ≡ 0`, so the alternating sum is a pure endpoint expression.
+
+This file climbs the next rung of the polynomial ladder — a *quadratic* sequence
+`a_j = α + β·j + γ·j²`.  Its forward differences are
+
+  `Δa_j  = (β+γ) + 2γ·j`   (affine),
+  `Δ²a_j = 2γ`             (constant),
+  `Δ³a_j = 0`,
+
+so the order-`3` Boole formula `boole_exact_of_iterate_fdiff_zero` terminates and evaluates
+completely, giving the alternating sum as a pure endpoint expression with no remainder:
+
+  `∑_{j=n}^{m-1} (-1)^j (α + βj + γj²)`
+  `  = ½·((-1)^n (α+βn+γn²) - (-1)^m (α+βm+γm²))`
+  `    - ¼·((-1)^n ((β+γ)+2γn) - (-1)^m ((β+γ)+2γm))`
+  `    + ¼·γ·((-1)^n - (-1)^m)`.
+
+Everything reuses the verified parent engine (`fdiff`, `altSum`, `fdiff_affine`,
+`iterate_fdiff_two_affine`, `boole_exact_of_iterate_fdiff_zero`); the file is axiom-free
+over `ℝ`.
+
+**Category**: application / specialization of the parent's finite Boole engine.
+-/
+
+import Mathlib.Tactic
+import Proofs.AlternatingSeriesBooleSummation
+
+namespace AlternatingSeriesBooleSummationOQ03
+
+open AlternatingSeriesBooleSummation
+
+/-- The forward difference of a quadratic `a_j = α + β·j + γ·j²` is the affine sequence
+`(β+γ) + 2γ·j`: the discrete analogue of `(α+βx+γx²)' = β+2γx`, with the `γ·(2j+1)` shape of
+the finite difference regrouped as `(β+γ) + 2γ·j`. -/
+theorem fdiff_quadratic (α β γ : ℝ) :
+    fdiff (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)
+      = fun (j : ℕ) => (β + γ) + 2 * γ * (j : ℝ) := by
+  funext j; simp only [fdiff]; push_cast; ring
+
+/-- The second forward difference of a quadratic is the constant `2γ`.  Reuses the parent's
+`fdiff_affine` applied to the affine first difference. -/
+theorem fdiff_two_quadratic (α β γ : ℝ) :
+    fdiff^[2] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2) = fun _ => 2 * γ := by
+  have h1 : fdiff^[2] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)
+      = fdiff (fdiff^[1] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)) :=
+    congrFun (Function.iterate_succ' fdiff 1) _
+  rw [h1, Function.iterate_one, fdiff_quadratic]
+  exact fdiff_affine (β + γ) (2 * γ)
+
+/-- The third forward difference of a quadratic vanishes identically — `Δ³` kills degree `≤ 2`,
+so the order-`3` Boole remainder is exactly zero. -/
+theorem iterate_fdiff_three_quadratic (α β γ : ℝ) :
+    ∀ j, (fdiff^[3] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)) j = 0 := by
+  have h1 : fdiff^[3] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)
+      = fdiff (fdiff^[2] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)) :=
+    congrFun (Function.iterate_succ' fdiff 2) _
+  rw [h1, fdiff_two_quadratic]
+  intro j
+  simp only [fdiff, sub_self]
+
+/-- **Exact closed form for the alternating sum of a quadratic sequence.** Since
+`Δ³(α + β·j + γ·j²) ≡ 0`, the order-`3` Boole formula terminates and evaluates completely: the
+alternating sum of a quadratic progression is a pure endpoint expression, with no remainder.
+
+`∑_{j=n}^{m-1} (-1)^j (α + βj + γj²)`
+`  = ½·((-1)^n (α+βn+γn²) - (-1)^m (α+βm+γm²))`
+`    - ¼·((-1)^n ((β+γ)+2γn) - (-1)^m ((β+γ)+2γm))`
+`    + ¼·γ·((-1)^n - (-1)^m)`.
+
+This is the degree-`2` rung of the polynomial ladder whose degree-`0` (`altSum_const`) and
+degree-`1` (`altSum_affine`) rungs are proved in the parent. -/
+theorem altSum_quadratic (α β γ : ℝ) (n m : ℕ) (h : n ≤ m) :
+    altSum (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2) n m
+      = (1 / 2) * ((-1 : ℝ) ^ n * (α + β * (n : ℝ) + γ * (n : ℝ) ^ 2)
+            - (-1 : ℝ) ^ m * (α + β * (m : ℝ) + γ * (m : ℝ) ^ 2))
+        - (1 / 4) * ((-1 : ℝ) ^ n * ((β + γ) + 2 * γ * (n : ℝ))
+            - (-1 : ℝ) ^ m * ((β + γ) + 2 * γ * (m : ℝ)))
+        + (1 / 4) * γ * ((-1 : ℝ) ^ n - (-1 : ℝ) ^ m) := by
+  rw [boole_exact_of_iterate_fdiff_zero (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2) n m h 3
+        (iterate_fdiff_three_quadratic α β γ),
+      Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_one]
+  simp only [Function.iterate_zero, id_eq, pow_zero, pow_one, Function.iterate_one,
+    fdiff_quadratic, fdiff_two_quadratic]
+  push_cast
+  ring
+
+/-- **Closed form for the pure alternating sum of squares** `∑_{j=n}^{m-1} (-1)^j j²`, the
+`α = β = 0`, `γ = 1` specialization of `altSum_quadratic`. -/
+theorem altSum_sq (n m : ℕ) (h : n ≤ m) :
+    altSum (fun j => (j : ℝ) ^ 2) n m
+      = (1 / 2) * ((-1 : ℝ) ^ n * (n : ℝ) ^ 2 - (-1 : ℝ) ^ m * (m : ℝ) ^ 2)
+        - (1 / 4) * ((-1 : ℝ) ^ n * (1 + 2 * (n : ℝ)) - (-1 : ℝ) ^ m * (1 + 2 * (m : ℝ)))
+        + (1 / 4) * ((-1 : ℝ) ^ n - (-1 : ℝ) ^ m) := by
+  have key : (fun j : ℕ => (j : ℝ) ^ 2)
+      = (fun j : ℕ => (0 : ℝ) + 0 * (j : ℝ) + 1 * (j : ℝ) ^ 2) := by funext j; ring
+  rw [key, altSum_quadratic 0 0 1 n m h]; ring
+
+end AlternatingSeriesBooleSummationOQ03

--- a/research/problems/alternating-series-boole-summation-oq-03/knowledge.md
+++ b/research/problems/alternating-series-boole-summation-oq-03/knowledge.md
@@ -1,0 +1,58 @@
+# alternating-series-boole-summation-oq-03 — Alternating sum of a quadratic in closed form
+
+**Parent:** `alternating-series-boole-summation` — verified, 0-axiom (finite Boole summation engine).
+
+**Open question (degree-2 rung of the polynomial ladder):** The parent's `altSum_affine` gives the
+alternating sum of an affine sequence `a_j = α + β·j` as a pure endpoint expression because
+`Δ²(α+βj) ≡ 0` terminates the order-2 Boole formula. Does the degree-2 case — a quadratic
+`a_j = α + β·j + γ·j²` — likewise close exactly, via `Δ³ ≡ 0` and the order-3 formula?
+
+## Answer: YES
+
+`proofs/Proofs/AlternatingSeriesBooleSummationOQ03.lean` proves the exact closed form
+
+    ∑_{j=n}^{m-1} (-1)^j (α + βj + γj²)
+        = ½·((-1)^n a_n − (-1)^m a_m)
+          − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m)
+          + ¼·γ·((-1)^n − (-1)^m),
+
+with Δa_j = (β+γ)+2γ·j, plus a worked corollary for ∑ (-1)^j j².
+
+## Results (5 theorems, 0 sorry, 0 axiom)
+- `fdiff_quadratic`                — Δ(α+βj+γj²) = (β+γ)+2γ·j  (affine first difference)
+- `fdiff_two_quadratic`            — Δ²(quadratic) = 2γ (constant), via parent `fdiff_affine`
+- `iterate_fdiff_three_quadratic`  — Δ³(quadratic) ≡ 0
+- `altSum_quadratic`               — the exact endpoint closed form (order-3 Boole termination)
+- `altSum_sq`                      — ∑ (-1)^j j² closed form (α=β=0, γ=1 specialization)
+
+## Proof architecture
+Pure reuse of the verified parent engine. The three finite-difference lemmas feed a vanishing
+`Δ³a ≡ 0` into the parent's `boole_exact_of_iterate_fdiff_zero` at order K=3, which drops the
+remainder alternating sum; the length-3 Boole sum is unfolded with `Finset.sum_range_succ`/`_one`,
+the difference terms substituted via the `fdiff` lemmas, and `push_cast; ring` closes the endpoint
+algebra. `fdiff_two_quadratic` applies the parent's `fdiff_affine` to the affine first difference
+(no recomputation).
+
+## Gotcha (worth remembering)
+The RHS of `fdiff_quadratic` must annotate its binder as `fun (j : ℕ) => …`. Written as
+`fun j => … (j : ℝ) …`, Lean reads the `(j : ℝ)` cast as a type *ascription* on the unconstrained
+binder and infers `j : ℝ`, producing an `ℝ → ℝ` function that mismatches `fdiff`'s `ℕ → ℝ` domain.
+The LHS lambda escapes this because `fdiff` constrains its argument to `ℕ → ℝ`. This one type
+mismatch initially cascaded into `sorry` across every downstream theorem.
+
+## Build & axiom verification (researcher-11, 2026-07-02)
+- **Build VERIFIED**: `./proofs/scripts/docker-build.sh Proofs.AlternatingSeriesBooleSummationOQ03`
+  → `=== Build succeeded ===`, exit 0, zero warnings (no `sorry`/unreachable-tactic).
+- **`#print axioms` (all 5 theorems)**: `[propext, Classical.choice, Quot.sound]` only — no
+  `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuine **verified, 0-axiom**.
+- Gallery entry created: `src/data/proofs/alternating-series-boole-summation-oq-03/{meta.json,annotations.json}`
+  (status `verified`, badge `verified`, axiomCount 0, 5 theorems, 105 lines). listings.json /
+  data-manifest.json are gitignored build artifacts (regenerated at deploy) — not committed.
+
+Pool candidate → `completed`.
+
+## Follow-on open questions (recorded in meta.conclusion)
+1. Uniform `altSum_polynomial`: arbitrary degree-d polynomial alternating sum from a vanishing
+   `Δ^{d+1}` hypothesis (generalize this ladder in one theorem).
+2. Relate the collected endpoint coefficients (½, ¼, ⅛, …) to Euler polynomials / Euler numbers
+   (ties back to parent OQ-02).

--- a/research/problems/alternating-series-boole-summation-oq-03/problem.md
+++ b/research/problems/alternating-series-boole-summation-oq-03/problem.md
@@ -1,0 +1,131 @@
+# Problem: Exact Closed Form for the Alternating Sum of a Quadratic Sequence (Boole Polynomial Ladder, degree 2)
+
+**Slug**: alternating-series-boole-summation-oq-03
+**Created**: 2026-07-02
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery open-question spawned from verified parent -->
+**Parent**: alternating-series-boole-summation
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\sum_{j=n}^{m-1} (-1)^j\,(\alpha + \beta j + \gamma j^2)
+  = \tfrac12\big((-1)^n a_n - (-1)^m a_m\big)
+    - \tfrac14\big((-1)^n (\Delta a)_n - (-1)^m (\Delta a)_m\big)
+    + \tfrac14\,\gamma\big((-1)^n - (-1)^m\big),
+$$
+
+where $a_j = \alpha + \beta j + \gamma j^2$ and $\Delta a_j = (\beta+\gamma) + 2\gamma j$.
+
+### Plain Language
+
+The parent entry proves the exact finite Boole summation engine and, as its terminal
+application, `altSum_affine`: the alternating sum of an **affine** sequence $a_j=\alpha+\beta j$
+is a pure endpoint expression, because $\Delta^2(\alpha+\beta j)\equiv 0$ terminates the order-2
+Boole formula. This problem takes the next rung of the polynomial ladder — a **quadratic**
+sequence $a_j=\alpha+\beta j+\gamma j^2$. Its forward differences are $\Delta a_j=(\beta+\gamma)+2\gamma j$
+(affine), $\Delta^2 a_j=2\gamma$ (constant), $\Delta^3 a_j=0$, so the order-3 Boole formula
+`boole_exact_of_iterate_fdiff_zero` terminates and evaluates completely to a pure endpoint
+expression with no remainder. Prove this closed form and a worked instance for $\sum(-1)^j j^2$.
+
+### Why This Matters
+
+Establishes the parent's finite Boole engine as a reusable *evaluator*: any polynomial
+alternating sum collapses to endpoint difference-data once a high enough forward difference
+vanishes, with each new degree assembled by reusing lower-difference lemmas rather than
+re-deriving the engine. The Boole weights $(-1)^k/2^{k+1}$ appear concretely as $\tfrac12,\tfrac14,\tfrac18$
+closing the degree-2 sum, foreshadowing a uniform degree-$d$ closed form.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent entry `alternating-series-boole-summation` is verified (0-axiom): supplies `altSum`,
+  `fdiff`, `boole_general`, `boole_exact_of_iterate_fdiff_zero`, `fdiff_affine`,
+  `iterate_fdiff_two_affine`, and the degree-1 result `altSum_affine`.
+
+### What's Still Open (before this entry)
+
+- The degree-2 closed form and its squares corollary.
+
+### Our Goal
+
+Prove the target as a self-contained, verified (0-axiom) child of the parent. Category:
+**application / specialization**.
+
+## Target Lean Sketch
+
+```lean
+theorem fdiff_quadratic (α β γ : ℝ) :
+    fdiff (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)
+      = fun (j : ℕ) => (β + γ) + 2 * γ * (j : ℝ)
+
+theorem fdiff_two_quadratic (α β γ : ℝ) :
+    fdiff^[2] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2) = fun _ => 2 * γ
+
+theorem iterate_fdiff_three_quadratic (α β γ : ℝ) :
+    ∀ j, (fdiff^[3] (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2)) j = 0
+
+theorem altSum_quadratic (α β γ : ℝ) (n m : ℕ) (h : n ≤ m) :
+    altSum (fun j => α + β * (j : ℝ) + γ * (j : ℝ) ^ 2) n m
+      = (1/2) * ((-1:ℝ)^n * (α + β*n + γ*n^2) - (-1:ℝ)^m * (α + β*m + γ*m^2))
+        - (1/4) * ((-1:ℝ)^n * ((β+γ) + 2*γ*n) - (-1:ℝ)^m * ((β+γ) + 2*γ*m))
+        + (1/4) * γ * ((-1:ℝ)^n - (-1:ℝ)^m)
+
+theorem altSum_sq (n m : ℕ) (h : n ≤ m) :   -- α=β=0, γ=1 corollary
+    altSum (fun j => (j : ℝ) ^ 2) n m = ...
+```
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `alternating-series-boole-summation` | Parent: finite Boole engine + degree-1 `altSum_affine` | finite differences, summation by parts |
+| `alternating-series-boole-summation-oq-01` | Sibling: m→∞ limit passage | tsum, Filter.Tendsto |
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Significance**: 5/10  |  **Tractability**: 9/10  |  **Tier**: B
+
+**Justification**: Direct reuse of the verified parent engine; the only new inputs are three
+finite-difference computations, the last two of which reuse `fdiff_affine`.
+
+### Suggested First Steps
+
+1. `fdiff_quadratic` by unfolding `fdiff` and `ring` — annotate the result binder `(j : ℕ)`
+   so the inner `(j : ℝ)` cast does not make Lean infer an ℝ-domain function.
+2. `fdiff_two_quadratic` = apply parent's `fdiff_affine` to the affine first difference.
+3. `iterate_fdiff_three_quadratic` = `Δ` of the constant `2γ` is `0` (`sub_self`).
+4. `altSum_quadratic` = `boole_exact_of_iterate_fdiff_zero … 3`, unfold with
+   `Finset.sum_range_succ`/`sum_range_one`, `simp only [...fdiff lemmas...]`, `push_cast; ring`.
+
+## References
+
+### Mathlib
+- `Finset.sum_range_succ`, `Finset.sum_range_one` — unfold the length-3 Boole sum
+- `Function.iterate_succ'`, `Function.iterate_one`, `Function.iterate_zero` — iterate handling
+- `ring`, `push_cast` — close the endpoint algebra
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - series
+  - alternating-series
+  - boole-summation
+  - euler-maclaurin
+  - finite-difference
+  - closed-form
+  - polynomial
+related_proofs:
+  - alternating-series-boole-summation
+  - alternating-series-boole-summation-oq-01
+difficulty: low
+source: proof-suggestion
+created: 2026-07-02
+```

--- a/src/data/proofs/alternating-series-boole-summation-oq-03/annotations.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header-asbsoq03",
+    "proofId": "alternating-series-boole-summation-oq-03",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "The polynomial ladder of Boole summation",
+    "content": "The parent's finite Boole formula peels the leading Boole/Euler terms off an alternating sum and leaves an exact remainder that is an alternating sum of the next forward difference. When some forward difference Δᴷa vanishes identically — i.e. a is polynomial of degree < K — the remainder is exactly zero and the alternating sum equals its finite endpoint model. The parent cashes this out at degree 1 (altSum_affine, K=2). This file does degree 2: a quadratic a_j = α+β·j+γ·j² has Δa = (β+γ)+2γj (affine), Δ²a = 2γ (constant), Δ³a ≡ 0, so the order-3 formula terminates and the alternating sum is a pure endpoint expression.",
+    "mathContext": "Δ^{d+1} annihilates degree ≤ d; here d = 2 needs order K = 3.",
+    "significance": "Positions the entry as the d=2 rung of a uniform ladder above the parent's d=0 and d=1 rungs.",
+    "relatedConcepts": ["finite differences", "Boole summation", "polynomial sequences"],
+    "prerequisites": ["forward difference operator", "the parent finite Boole engine"]
+  },
+  {
+    "id": "ann-fdiff1-asbsoq03",
+    "proofId": "alternating-series-boole-summation-oq-03",
+    "range": { "startLine": 39, "endLine": 45 },
+    "type": "technique",
+    "title": "First forward difference of a quadratic",
+    "content": "fdiff_quadratic computes Δ(α+β·j+γ·j²) = (β+γ)+2γ·j. Unfolding the definition gives β·((j+1)−j) + γ·((j+1)²−j²) = β + γ·(2j+1) = (β+γ) + 2γ·j, the discrete analogue of the derivative β+2γx offset by the finite-difference correction γ·(2j+1). A subtlety worth noting: the result lambda must be annotated fun (j : ℕ) => …, otherwise the (j : ℝ) cast inside makes Lean infer the binder as ℝ and the function type mismatches fdiff's ℕ → ℝ domain.",
+    "mathContext": "$\\Delta(\\alpha+\\beta j+\\gamma j^2)=(\\beta+\\gamma)+2\\gamma j$, using $(j+1)^2-j^2=2j+1$.",
+    "significance": "The one genuinely new algebraic input; everything else reuses parent lemmas.",
+    "relatedConcepts": ["finite difference", "discrete derivative"],
+    "prerequisites": ["fdiff definition", "ring / push_cast"]
+  },
+  {
+    "id": "ann-fdiff2-asbsoq03",
+    "proofId": "alternating-series-boole-summation-oq-03",
+    "range": { "startLine": 47, "endLine": 55 },
+    "type": "technique",
+    "title": "Second difference via the parent's fdiff_affine",
+    "content": "fdiff_two_quadratic shows Δ²(quadratic) = 2γ (a constant). Rather than recompute, it peels one iterate with congrFun (Function.iterate_succ' fdiff 1), rewrites the inner Δ by fdiff_quadratic to the affine sequence (β+γ)+2γ·j, and then applies the parent's own fdiff_affine (β+γ) (2γ) — whose statement is exactly Δ(affine) = constant. This is direct reuse of verified parent infrastructure.",
+    "mathContext": "$\\Delta^2(\\alpha+\\beta j+\\gamma j^2)=\\Delta\\big((\\beta+\\gamma)+2\\gamma j\\big)=2\\gamma$.",
+    "significance": "Illustrates composing new results out of the parent's lemmas instead of re-deriving.",
+    "relatedConcepts": ["Function.iterate_succ'", "constant sequences"],
+    "prerequisites": ["fdiff_affine (parent)", "iterate unfolding"]
+  },
+  {
+    "id": "ann-fdiff3-asbsoq03",
+    "proofId": "alternating-series-boole-summation-oq-03",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "key-step",
+    "title": "Third difference vanishes",
+    "content": "iterate_fdiff_three_quadratic establishes Δ³(quadratic) ≡ 0. Peeling one iterate reduces it to Δ of the constant 2γ, which is 2γ − 2γ = 0 by sub_self. This ∀ j, Δ³a j = 0 is precisely the hypothesis the parent's boole_exact_of_iterate_fdiff_zero needs to make the order-3 remainder vanish.",
+    "mathContext": "$\\Delta^3(\\alpha+\\beta j+\\gamma j^2)\\equiv 0$.",
+    "significance": "The vanishing higher difference is what terminates the finite Boole expansion exactly.",
+    "relatedConcepts": ["constant difference", "annihilation of polynomials"],
+    "prerequisites": ["fdiff_two_quadratic", "sub_self"]
+  },
+  {
+    "id": "ann-closedform-asbsoq03",
+    "proofId": "alternating-series-boole-summation-oq-03",
+    "range": { "startLine": 68, "endLine": 105 },
+    "type": "key-step",
+    "title": "The exact closed form and its squares instance",
+    "content": "altSum_quadratic feeds Δ³a ≡ 0 into boole_exact_of_iterate_fdiff_zero at K=3, then unfolds the length-3 Boole sum with Finset.sum_range_succ (twice) and sum_range_one. The three surviving terms carry the Boole weights (-1)^k/2^{k+1} = ½, −¼, ⅛; substituting the difference values a, Δa, Δ²a = 2γ and simplifying yields ∑ (-1)^j (α+βj+γj²) = ½·((-1)^n a_n − (-1)^m a_m) − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m) + ¼·γ·((-1)^n − (-1)^m). altSum_sq specializes α=β=0, γ=1 to give the pure alternating sum of squares ∑ (-1)^j j² in closed form.",
+    "mathContext": "Weights $\\tfrac{(-1)^k}{2^{k+1}}$ for $k=0,1,2$ close the degree-2 sum with no remainder.",
+    "significance": "The payoff: an exact endpoint closed form for every quadratic alternating sum, with a concrete sanity-check instance.",
+    "relatedConcepts": ["Boole weights", "Euler numbers", "alternating power sums"],
+    "prerequisites": ["boole_exact_of_iterate_fdiff_zero (parent)", "Finset.sum_range_succ", "ring"]
+  }
+]

--- a/src/data/proofs/alternating-series-boole-summation-oq-03/meta.json
+++ b/src/data/proofs/alternating-series-boole-summation-oq-03/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "alternating-series-boole-summation-oq-03",
+  "title": "Alternating Sum of a Quadratic in Closed Form (Alternating-Series Boole OQ-03)",
+  "slug": "alternating-series-boole-summation-oq-03",
+  "description": "Climbs the next rung of the polynomial ladder opened by the parent finite Boole summation entry. The parent proves altSum_affine — the alternating sum of an affine sequence a_j = α + β·j is a pure endpoint expression because Δ²(α+βj) ≡ 0 terminates the order-2 Boole formula. This entry does the degree-2 case: for a quadratic a_j = α + β·j + γ·j² the forward differences are Δa_j = (β+γ)+2γ·j (affine), Δ²a_j = 2γ (constant), Δ³a_j = 0, so the order-3 Boole formula boole_exact_of_iterate_fdiff_zero terminates and evaluates completely, giving ∑_{j=n}^{m-1} (-1)^j (α+βj+γj²) = ½·((-1)^n a_n − (-1)^m a_m) − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m) + ¼·γ·((-1)^n − (-1)^m), a closed form in the endpoints n, m with no remainder. A worked corollary altSum_sq evaluates the pure alternating sum of squares ∑ (-1)^j j². Fully machine-checked, 0 axioms, reusing the verified parent engine.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Boole_summation",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesBooleSummationOQ03.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "alternating-series",
+      "boole-summation",
+      "euler-maclaurin",
+      "finite-difference",
+      "closed-form",
+      "polynomial"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 105,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. All five theorems depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound), confirmed by #print axioms. Imports and reuses the verified parent AlternatingSeriesBooleSummation (fdiff, altSum, fdiff_affine, iterate_fdiff_two_affine, boole_exact_of_iterate_fdiff_zero), itself 0-axiom.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Boole summation is the alternating-series analogue of the Euler–Maclaurin formula: an alternating partial sum equals boundary terms in the forward differences of the summand, with the Euler/Boole weights (-1)^k/2^{k+1}, plus an exact remainder that is one difference-order smaller. The parent entry formalizes this exact finite engine and observes that it terminates whenever a sufficiently high forward difference vanishes — i.e. on polynomial sequences. It cashes this out at degree 1 (altSum_affine, since Δ² kills affine sequences). The natural continuation is the polynomial ladder: each degree d needs the order-(d+1) formula because Δ^{d+1} annihilates degree ≤ d.",
+    "problemStatement": "Extend the parent's exact closed form from affine sequences to quadratic sequences a_j = α + β·j + γ·j². Since Δ³(α+βj+γj²) ≡ 0, the order-3 Boole formula must terminate and evaluate to a pure endpoint expression; produce and machine-check that closed form, with a worked instance for ∑ (-1)^j j².",
+    "text": "For a quadratic a_j = α + β·j + γ·j² the forward differences telescope: Δa_j = (β+γ)+2γ·j is affine, Δ²a_j = 2γ is constant, and Δ³a_j = 0. Feeding Δ³a ≡ 0 into the parent's boole_exact_of_iterate_fdiff_zero at order K = 3 makes the remainder alternating sum vanish, so the alternating sum collapses to the first three Boole endpoint terms: ∑_{j=n}^{m-1} (-1)^j (α+βj+γj²) = ½·((-1)^n a_n − (-1)^m a_m) − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m) + ¼·γ·((-1)^n − (-1)^m). The corollary altSum_sq specializes to α=β=0, γ=1.",
+    "proofStrategy": "(1) fdiff_quadratic: Δ(α+βj+γj²) = (β+γ)+2γ·j, by unfolding fdiff and ring (the (j+1)²−j² = 2j+1 finite-difference identity). (2) fdiff_two_quadratic: Δ²(quadratic) = 2γ, obtained by applying the parent's fdiff_affine to the affine first difference (Function.iterate_succ' to peel one iterate). (3) iterate_fdiff_three_quadratic: Δ³(quadratic) ≡ 0, since Δ of the constant 2γ is 0. (4) altSum_quadratic: rewrite with boole_exact_of_iterate_fdiff_zero at K=3, unfold the length-3 Boole sum with Finset.sum_range_succ/one, simplify the three difference terms via steps (1)–(2), and close with push_cast; ring. (5) altSum_sq: substitute α=β=0, γ=1 and ring.",
+    "keyInsights": [
+      "**Polynomial ⇒ finite Boole termination**: the alternating sum of a sequence is a pure endpoint expression exactly when a forward difference eventually vanishes; degree d needs order d+1 because Δ^{d+1} annihilates degree ≤ d. This entry is the d=2 rung above the parent's d=1 (altSum_affine) and d=0 (altSum_const).",
+      "**Reuse, don't re-derive**: the whole result is assembled from the parent's verified engine — the only genuinely new inputs are the three finite-difference computations Δ(quadratic), Δ²(quadratic), Δ³(quadratic), and the constant-difference step reuses the parent's fdiff_affine outright.",
+      "**Exact, no convergence**: like the parent, the identity holds on every finite window n ≤ m with no limit or convergence hypothesis — it is an algebraic closed form, not an asymptotic estimate.",
+      "**The half/quarter/eighth weights are visible**: the coefficients ½, ¼, ⅛ of the endpoint, first-difference, and second-difference terms are precisely the Boole weights (-1)^k/2^{k+1} for k = 0,1,2, made concrete on a case where they close the sum exactly.",
+      "**Worked instance**: altSum_sq gives ∑_{j=n}^{m-1} (-1)^j j² in closed form, a clean sanity check that the abstract weights reproduce a familiar alternating power sum."
+    ],
+    "prerequisites": [
+      "Finite differences and the operator Δa_j = a_{j+1} − a_j",
+      "Boole / Euler–Maclaurin summation (finite form)",
+      "The parent entry's exact finite Boole engine (boole_general, boole_exact_of_iterate_fdiff_zero)",
+      "Function.iterate and its successor unfolding",
+      "Basic algebra of alternating sums over Finset.Ico"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Frames OQ-03 as the degree-2 rung of the polynomial ladder: the parent's altSum_affine handles a_j = α + β·j via Δ² ≡ 0; here a_j = α + β·j + γ·j² is handled via Δ³ ≡ 0. States the target closed form and notes the whole proof reuses the verified parent engine.",
+      "startLine": 1,
+      "endLine": 37,
+      "mathContext": "Δa = (β+γ)+2γj, Δ²a = 2γ, Δ³a = 0 ⇒ order-3 Boole formula terminates."
+    },
+    {
+      "id": "first-difference",
+      "title": "First forward difference (fdiff_quadratic)",
+      "summary": "`fdiff_quadratic`: Δ(α + β·j + γ·j²) = (β+γ) + 2γ·j, the discrete analogue of (α+βx+γx²)' = β+2γx, with the finite-difference correction γ·(2j+1) regrouped. Proved by unfolding fdiff and ring.",
+      "startLine": 39,
+      "endLine": 45,
+      "mathContext": "$\\Delta(\\alpha+\\beta j+\\gamma j^2)=(\\beta+\\gamma)+2\\gamma j$ from $(j+1)^2-j^2=2j+1$."
+    },
+    {
+      "id": "second-difference",
+      "title": "Second forward difference (fdiff_two_quadratic)",
+      "summary": "`fdiff_two_quadratic`: Δ²(quadratic) = 2γ, a constant. Peels one iterate with Function.iterate_succ' and applies the parent's fdiff_affine to the affine first difference — direct reuse of verified parent infrastructure.",
+      "startLine": 47,
+      "endLine": 55,
+      "mathContext": "$\\Delta^2(\\alpha+\\beta j+\\gamma j^2)=2\\gamma$ (constant)."
+    },
+    {
+      "id": "third-difference",
+      "title": "Third forward difference vanishes (iterate_fdiff_three_quadratic)",
+      "summary": "`iterate_fdiff_three_quadratic`: Δ³(quadratic) ≡ 0, since Δ of the constant 2γ is 0. This is the vanishing hypothesis that terminates the order-3 Boole remainder.",
+      "startLine": 57,
+      "endLine": 66,
+      "mathContext": "$\\Delta^3(\\alpha+\\beta j+\\gamma j^2)\\equiv 0$."
+    },
+    {
+      "id": "closed-form",
+      "title": "Exact closed form (altSum_quadratic) and squares corollary",
+      "summary": "`altSum_quadratic`: feeds Δ³a ≡ 0 into the parent's boole_exact_of_iterate_fdiff_zero at K=3, unfolds the three-term Boole sum, and evaluates to ½·((-1)^n a_n − (-1)^m a_m) − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m) + ¼·γ·((-1)^n − (-1)^m). `altSum_sq` specializes to α=β=0, γ=1 for ∑ (-1)^j j².",
+      "startLine": 68,
+      "endLine": 105,
+      "mathContext": "$\\sum_{j=n}^{m-1}(-1)^j(\\alpha+\\beta j+\\gamma j^2)$ as a pure endpoint expression; weights $\\tfrac12,\\tfrac14,\\tfrac18$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The alternating sum of a quadratic sequence a_j = α + β·j + γ·j² is a pure endpoint expression, because Δ³(quadratic) ≡ 0 terminates the parent's order-3 finite Boole formula. The closed form ∑_{j=n}^{m-1} (-1)^j (α+βj+γj²) = ½·((-1)^n a_n − (-1)^m a_m) − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m) + ¼·γ·((-1)^n − (-1)^m) is machine-checked and 0-axiom, with a worked instance for ∑ (-1)^j j². It is the degree-2 rung of the polynomial ladder whose degree-0 (altSum_const) and degree-1 (altSum_affine) rungs are in the parent.",
+    "implications": "Demonstrates the parent's finite Boole engine as a reusable evaluator: any polynomial alternating sum collapses to endpoint difference-data once a high enough forward difference vanishes, and each new degree is assembled by reusing lower-difference lemmas rather than re-deriving the engine. The Boole weights (-1)^k/2^{k+1} appear concretely as ½, ¼, ⅛ closing the degree-2 sum, foreshadowing the general degree-d closed form.",
+    "openQuestions": [
+      "Package the ladder uniformly: prove a single altSum_polynomial giving the alternating sum of an arbitrary polynomial sequence of degree d as the order-(d+1) Boole endpoint expression, from a vanishing Δ^{d+1} hypothesis.",
+      "Relate the endpoint coefficients that appear after collecting (½, ¼, ⅛, …) to the Euler polynomials / Euler numbers, tying the concrete polynomial evaluations back to parent OQ-02."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-boole-summation",
+      "relationship": "extends",
+      "description": "Parent: the exact finite Boole summation engine and its degree-1 closed form altSum_affine. This OQ-03 climbs one rung to the degree-2 (quadratic) case, reusing boole_exact_of_iterate_fdiff_zero and fdiff_affine directly."
+    },
+    {
+      "targetId": "alternating-series-boole-summation-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-01 passes the finite identity to the limit m→∞; this OQ-03 instead pushes the finite identity up the polynomial ladder where it terminates exactly."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Boole, G.",
+      "title": "A Treatise on the Calculus of Finite Differences",
+      "year": "1860",
+      "venue": "Macmillan",
+      "note": "Origin of Boole summation, the alternating analogue of Euler–Maclaurin; the finite-difference calculus used here."
+    },
+    {
+      "authors": "The Mathlib Community",
+      "title": "Mathlib4 (Finset.sum_range_succ, Function.iterate)",
+      "year": "2024",
+      "venue": "leanprover-community/mathlib4",
+      "note": "Provides the finite-sum unfolding and iterate machinery used to evaluate the terminated Boole sum."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **alternating-series-boole-summation-oq-03** — the degree-2 rung of the polynomial ladder opened by the verified parent `alternating-series-boole-summation`.

The parent's `altSum_affine` gives the alternating sum of an **affine** sequence `a_j = α + β·j` as a pure endpoint expression because `Δ²(α+βj) ≡ 0` terminates the order-2 Boole formula. This entry does the **quadratic** case `a_j = α + β·j + γ·j²`:

- `Δa_j = (β+γ) + 2γ·j` (affine)
- `Δ²a_j = 2γ` (constant)
- `Δ³a_j = 0`

so the parent's order-3 `boole_exact_of_iterate_fdiff_zero` terminates and evaluates completely:

```
∑_{j=n}^{m-1} (-1)^j (α + βj + γj²)
  = ½·((-1)^n a_n − (-1)^m a_m)
    − ¼·((-1)^n (Δa)_n − (-1)^m (Δa)_m)
    + ¼·γ·((-1)^n − (-1)^m)
```

with a worked corollary `altSum_sq` for `∑ (-1)^j j²`.

## Results (5 theorems, 105 lines, 0 sorry)
- `fdiff_quadratic`, `fdiff_two_quadratic`, `iterate_fdiff_three_quadratic`
- `altSum_quadratic` — the exact endpoint closed form
- `altSum_sq` — squares corollary

Pure reuse of the verified parent engine (`fdiff`, `altSum`, `fdiff_affine`, `boole_exact_of_iterate_fdiff_zero`); the only new inputs are the three finite-difference computations.

## Verification
- **Build**: `./proofs/scripts/docker-build.sh Proofs.AlternatingSeriesBooleSummationOQ03` → `=== Build succeeded ===` (exit 0, zero warnings).
- **`#print axioms`** on all 5 theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuine **verified / 0-axiom**.

## Files
- `proofs/Proofs/AlternatingSeriesBooleSummationOQ03.lean`
- `src/data/proofs/alternating-series-boole-summation-oq-03/{meta.json,annotations.json}`
- `research/problems/alternating-series-boole-summation-oq-03/{problem.md,knowledge.md}`

(`listings.json` / `data-manifest.json` are gitignored build artifacts, regenerated at deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)