### PR TITLE
Enrich ℂ-characterization (fundamental-theorem-algebra-oq-04-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/annotations.json
@@ -1,0 +1,183 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 8,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "The Folklore Statement Is False — and How to Fix It",
+    "content": "\"ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism\" is literally false: AlgebraicClosure ℚ (the algebraic numbers) is algebraically closed of characteristic 0 yet countable, hence not isomorphic to the uncountable ℂ. Steinitz's classification supplies the fix — an algebraically closed field is determined up to isomorphism by its characteristic together with the cardinality of a transcendence basis, which for uncountable fields is the cardinality of the field itself. This file pins ℂ down exactly: an algebraically closed characteristic-0 field is isomorphic to ℂ iff its cardinality is the continuum 𝔠. Everything is 0-axiom, 0-sorry over Mathlib.",
+    "mathContext": "Naïve claim '$\\mathbb{C}$ is the unique alg. closed field of char $0$' fails: $\\overline{\\mathbb{Q}}=\\mathrm{AlgebraicClosure}\\,\\mathbb{Q}$ is alg. closed, char $0$, but $\\#\\overline{\\mathbb{Q}}=\\aleph_0\\neq \\mathfrak{c}=\\#\\mathbb{C}$. Steinitz: an alg. closed field is determined by $\\operatorname{char}$ and the transcendence degree, which for uncountable fields equals $\\#K$. So $K\\cong\\mathbb{C}\\iff \\#K=\\mathfrak c$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Steinitz classification",
+      "algebraically closed field",
+      "characteristic zero",
+      "transcendence degree",
+      "continuum 𝔠"
+    ],
+    "prerequisites": [
+      "algebraic closure",
+      "cardinal arithmetic",
+      "transcendence bases"
+    ]
+  },
+  {
+    "id": "ann-card-complex",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 49
+    },
+    "type": "lemma",
+    "title": "#ℂ = 𝔠",
+    "content": "The complex numbers have cardinality the continuum. Wraps Mathlib's Cardinal.mk_complex for reuse in both directions of the characterization: it converts the hypothesis #K = 𝔠 into the cardinal equality #K = #ℂ, and back.",
+    "mathContext": "$\\#\\mathbb{C}=\\mathfrak{c}=2^{\\aleph_0}$ (Cardinal.mk_complex). Used to convert $\\#K=\\mathfrak c$ into $\\#K=\\#\\mathbb C$ (and back) in both directions of the biconditional.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "cardinality of ℂ",
+      "continuum",
+      "Cardinal.mk_complex"
+    ],
+    "prerequisites": [
+      "cardinality of ℝ and ℂ",
+      "the continuum 𝔠"
+    ]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 51,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "Cardinality 𝔠 Forces K ≃+* ℂ",
+    "content": "The substantive direction. For an algebraically closed field K of characteristic 0, the single hypothesis #K = 𝔠 does double duty: rewriting along it against aleph0_lt_continuum yields uncountability ℵ₀ < #K, and rewriting #ℂ to 𝔠 (via card_complex) then Cardinal.eq produces a bijection K ≃ ℂ. Feeding both to Mathlib's Steinitz classification IsAlgClosed.ringEquiv_of_equiv_of_charZero delivers a ring isomorphism K ≃+* ℂ.",
+    "mathContext": "For $K$ alg. closed, char $0$, $\\#K=\\mathfrak c$: uncountability $\\aleph_0<\\#K$ (from $\\aleph_0<\\mathfrak c$) plus a bijection $K\\simeq\\mathbb C$ (from $\\#K=\\#\\mathbb C$ via $\\mathtt{Cardinal.eq}$) feed $\\mathtt{IsAlgClosed.ringEquiv\\_of\\_equiv\\_of\\_charZero}$ to give $K\\simeq_{+*}\\mathbb C$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Steinitz for char 0",
+      "IsAlgClosed.ringEquiv_of_equiv_of_charZero",
+      "Cardinal.eq",
+      "uncountability"
+    ],
+    "prerequisites": [
+      "ring isomorphism ≃+*",
+      "Cardinal.eq (equinumerosity)",
+      "aleph0_lt_continuum"
+    ]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 70
+    },
+    "type": "theorem",
+    "title": "An Isomorphism Preserves Cardinality",
+    "content": "The trivial direction: a ring isomorphism K ≃+* ℂ is in particular a bijection, so Cardinal.mk_congr on its underlying equivalence gives #K = #ℂ = 𝔠. This is what makes cardinality a genuine isomorphism invariant, and hence a legitimate characterizing datum.",
+    "mathContext": "A ring iso $e:K\\simeq_{+*}\\mathbb C$ is in particular a bijection, so $\\#K=\\#\\mathbb C=\\mathfrak c$ ($\\mathtt{Cardinal.mk\\_congr};e.\\mathrm{toEquiv}$). Cardinality is thus an isomorphism invariant.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cardinality as isomorphism invariant",
+      "Cardinal.mk_congr",
+      "ring isomorphism"
+    ],
+    "prerequisites": [
+      "equivalences preserve cardinality"
+    ]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "The Exact Characterization (Biconditional)",
+    "content": "Nonempty (K ≃+* ℂ) ↔ #K = 𝔠 for K algebraically closed of characteristic 0 — the honest form of the 'unique up to isomorphism' slogan, with the missing cardinality invariant made explicit. Assembled from the two directions above.",
+    "mathContext": "$\\mathrm{Nonempty}(K\\simeq_{+*}\\mathbb C)\\iff \\#K=\\mathfrak c$ for $K$ alg. closed, char $0$ — the honest form of 'unique up to isomorphism', with the cardinality invariant made explicit. Assembled from the two directions.",
+    "significance": "key",
+    "relatedConcepts": [
+      "biconditional characterization",
+      "isomorphism invariant",
+      "classification of fields"
+    ],
+    "prerequisites": [
+      "logical equivalence from two implications"
+    ]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Uniqueness Up to Isomorphism at Cardinality 𝔠",
+    "content": "Any two algebraically closed characteristic-0 fields K, L of cardinality 𝔠 are isomorphic, obtained by transiting through ℂ: K ≃+* ℂ ≃+* L. This is the precise sense in which ℂ is 'the' such field.",
+    "mathContext": "Any $K,L$ alg. closed, char $0$, $\\#K=\\#L=\\mathfrak c$ satisfy $K\\simeq_{+*}\\mathbb C\\simeq_{+*}L$, so $K\\simeq_{+*}L$ ($e_K.\\mathrm{trans};e_L.\\mathrm{symm}$). This is the precise 'ℂ is the such field'.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "uniqueness up to isomorphism",
+      "transitivity of ring isos",
+      "categoricity"
+    ],
+    "prerequisites": [
+      "composition/inverse of isomorphisms"
+    ]
+  },
+  {
+    "id": "ann-card-acq",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 93,
+      "endLine": 99
+    },
+    "type": "lemma",
+    "title": "AlgebraicClosure ℚ Is Countable",
+    "content": "#(AlgebraicClosure ℚ) = ℵ₀. Upper bound: an algebraic extension of ℚ has cardinality ≤ max #ℚ ℵ₀ = ℵ₀ (Algebra.IsAlgebraic.cardinalMk_le_max with Cardinal.mkRat and max_self). Lower bound: it is an infinite field, so ℵ₀ ≤ # (Cardinal.aleph0_le_mk). Antisymmetry gives equality.",
+    "mathContext": "$\\#\\overline{\\mathbb Q}=\\aleph_0$: upper bound $\\#\\overline{\\mathbb Q}\\le\\max(\\#\\mathbb Q,\\aleph_0)=\\aleph_0$ ($\\mathtt{Algebra.IsAlgebraic.cardinalMk\\_le\\_max}$, $\\#\\mathbb Q=\\aleph_0$, $\\max$ idempotent); lower bound $\\aleph_0\\le\\#\\overline{\\mathbb Q}$ (infinite field). Antisymmetry gives equality.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "algebraic numbers",
+      "cardinality of algebraic extensions",
+      "le_antisymm",
+      "aleph0"
+    ],
+    "prerequisites": [
+      "cardinality of ℚ = ℵ₀",
+      "cardinal bound for algebraic extensions",
+      "antisymmetry of ≤"
+    ]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "Necessity of the Cardinality Hypothesis",
+    "content": "¬ Nonempty (AlgebraicClosure ℚ ≃+* ℂ): the countable, algebraically closed, characteristic-0 field of algebraic numbers is NOT isomorphic to ℂ. Rewriting through the biconditional reduces the goal to ℵ₀ ≠ 𝔠, settled by aleph0_lt_continuum. This concretely proves that characteristic and algebraic closedness alone cannot pin down ℂ — the cardinality hypothesis is indispensable.",
+    "mathContext": "$\\lnot\\,\\mathrm{Nonempty}(\\overline{\\mathbb Q}\\simeq_{+*}\\mathbb C)$: via the biconditional the goal becomes $\\aleph_0\\neq\\mathfrak c$, settled by $\\aleph_0<\\mathfrak c$. So char $0$ + alg. closedness alone cannot pin down $\\mathbb C$ — the cardinality hypothesis is indispensable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counterexample to naïve uniqueness",
+      "ℵ₀ ≠ 𝔠",
+      "algebraic numbers ≇ ℂ",
+      "necessity of hypotheses"
+    ],
+    "prerequisites": [
+      "aleph0_lt_continuum",
+      "using a biconditional to rewrite a negation"
+    ]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "fundamental-theorem-algebra-oq-04-oq-02",
+  "title": "Characterizing ℂ: the Algebraically Closed Field of Characteristic 0 and Cardinality Continuum",
+  "slug": "fundamental-theorem-algebra-oq-04-oq-02",
+  "description": "The slogan \"ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism\" is, taken literally, false — the field of algebraic numbers AlgebraicClosure ℚ is also algebraically closed of characteristic 0 yet countable, hence not isomorphic to the uncountable ℂ. The correct Steinitz classification adds a cardinality constraint. This entry proves the exact characterization: an algebraically closed field K of characteristic 0 is isomorphic to ℂ if and only if #K = 𝔠 (the continuum). The substantive direction specializes Mathlib's IsAlgClosed.ringEquiv_of_equiv_of_charZero; the converse is that a ring isomorphism preserves cardinality. It also proves uniqueness up to isomorphism among all such fields, and — for honesty — that the cardinality hypothesis is genuinely necessary, exhibiting AlgebraicClosure ℚ as a countable char-0 algebraically closed field not isomorphic to ℂ. Formalized in Lean 4 over Mathlib, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ04OQ02.lean",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "algebraically-closed",
+      "complex-numbers",
+      "cardinality",
+      "transcendence-degree",
+      "steinitz",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 110,
+    "assumptions": "None. Fully machine-verified: the file builds to exit 0 against the pinned Mathlib and imports only Mathlib. #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx). The abstract field K is stated in universe Type (universe 0), matching ℂ; the classification hypothesis is exactly #K = 𝔠 (cardinality continuum). The honesty counterexample uses AlgebraicClosure ℚ with its standard Mathlib instances (Field, IsAlgClosed, CharZero, Infinite).",
+    "dateAdded": "2026-07-02",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsAlgClosed.ringEquiv_of_equiv_of_charZero",
+        "description": "Two uncountable algebraically closed fields of characteristic 0 are isomorphic if they have the same cardinality (given as Nonempty (K ≃ L)). This is the engine of the substantive direction: with L = ℂ, #K = 𝔠 supplies both the uncountability ℵ₀ < #K and the bijection K ≃ ℂ.",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Classification"
+      },
+      {
+        "theorem": "Cardinal.mk_complex",
+        "description": "#ℂ = 𝔠: the complex numbers have cardinality the continuum. Converts the hypothesis #K = 𝔠 into the cardinal equality #K = #ℂ needed to produce a bijection K ≃ ℂ.",
+        "module": "Mathlib.Analysis.Complex.Cardinality"
+      },
+      {
+        "theorem": "Cardinal.aleph0_lt_continuum",
+        "description": "ℵ₀ < 𝔠: the continuum is uncountable. Supplies the uncountability hypothesis of the classification, and separates ℵ₀ from 𝔠 in the non-uniqueness counterexample.",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Algebra.IsAlgebraic.cardinalMk_le_max",
+        "description": "An algebraic extension L of R satisfies #L ≤ max #R ℵ₀. With R = ℚ (so #ℚ = ℵ₀) this bounds #(AlgebraicClosure ℚ) ≤ ℵ₀, forcing it countable.",
+        "module": "Mathlib.RingTheory.Algebraic.Cardinality"
+      },
+      {
+        "theorem": "Cardinal.mkRat",
+        "description": "#ℚ = ℵ₀: the rationals are countable. Feeds the cardinality bound for AlgebraicClosure ℚ.",
+        "module": "Mathlib.Data.Rat.Cardinal"
+      },
+      {
+        "theorem": "Cardinal.mk_congr",
+        "description": "An equivalence α ≃ β yields #α = #β. Applied to the underlying bijection of a ring isomorphism K ≃+* ℂ, it gives the converse direction #K = #ℂ = 𝔠.",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ringEquiv_complex_iff_card_continuum: the exact characterization — for an algebraically closed field K of characteristic 0, Nonempty (K ≃+* ℂ) ↔ #K = 𝔠. This is the honest, correct form of the folklore statement 'ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism', with the missing cardinality hypothesis made explicit.",
+      "ringEquiv_complex_of_card_continuum: the substantive existence direction, specializing Mathlib's Steinitz classification to L = ℂ — cardinality 𝔠 together with algebraic closedness and characteristic 0 rigidifies K to a copy of ℂ.",
+      "ringEquiv_of_both_card_continuum: uniqueness up to isomorphism — any two algebraically closed characteristic-0 fields of cardinality 𝔠 are isomorphic, transiting through ℂ.",
+      "not_nonempty_ringEquiv_algebraicClosure_rat_complex with card_algebraicClosure_rat: the honesty statements showing the cardinality hypothesis is necessary — AlgebraicClosure ℚ is algebraically closed of characteristic 0 but countable (#=ℵ₀), hence not isomorphic to ℂ. This concretely refutes the naïve 'unique up to isomorphism' reading."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Steinitz (1910), in his foundational paper on field theory, proved that an algebraically closed field is determined up to isomorphism by two invariants: its characteristic and the cardinality of a transcendence basis over the prime field. For uncountable fields the transcendence degree equals the cardinality of the field, so an uncountable algebraically closed field is classified by (characteristic, cardinality). ℂ, being algebraically closed (the Fundamental Theorem of Algebra), of characteristic 0, and of cardinality the continuum 𝔠, is therefore the unique such field with those invariants — but only after the cardinality is pinned down. Dropping the cardinality constraint, the classification fails spectacularly: there are algebraically closed characteristic-0 fields of every infinite cardinality.",
+    "problemStatement": "Make precise, and formalize, the sense in which 'ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism'. The literal statement is false; the correct statement is a biconditional characterizing ℂ among such fields by the single extra datum #K = 𝔠.",
+    "text": "Mathlib's IsAlgClosed.ringEquiv_of_equiv_of_charZero states that two uncountable algebraically closed fields of characteristic 0 with the same cardinality are ring-isomorphic. Instantiating the second field as ℂ and using #ℂ = 𝔠 (Cardinal.mk_complex) together with ℵ₀ < 𝔠 (aleph0_lt_continuum), the hypothesis #K = 𝔠 both certifies uncountability and produces a bijection K ≃ ℂ, yielding K ≃+* ℂ. The converse is immediate: a ring isomorphism is a bijection, so Cardinal.mk_congr gives #K = #ℂ = 𝔠. Combining the two directions gives the biconditional. For non-uniqueness, AlgebraicClosure ℚ is algebraically closed and of characteristic 0, but an algebraic extension of the countable field ℚ has cardinality at most ℵ₀ (Algebra.IsAlgebraic.cardinalMk_le_max), and being an infinite field at least ℵ₀ — hence exactly ℵ₀ < 𝔠, so no isomorphism to ℂ can exist.",
+    "proofStrategy": "The core is a clean specialization of an existing deep Mathlib theorem, not a re-proof of Steinitz. The work is in wiring the cardinality bookkeeping: turning #K = 𝔠 into (i) ℵ₀ < #K via rewriting along the hypothesis, and (ii) a bijection K ≃ ℂ via Cardinal.eq after rewriting #ℂ to 𝔠. The converse uses that the underlying equiv of a RingEquiv preserves cardinality. The counterexample assembles a countability bound (≤ ℵ₀ from the algebraic-extension cardinality lemma with #ℚ = ℵ₀ and max_self) with an infinitude lower bound (ℵ₀ ≤ # from the Infinite instance on the characteristic-0 field), then contradicts ℵ₀ = 𝔠 with aleph0_lt_continuum.",
+    "keyInsights": [
+      "**The folklore statement is literally false, and honesty demands saying so.** 'ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism' omits the cardinality hypothesis. The field of algebraic numbers is a standing counterexample: algebraically closed, characteristic 0, but countable.",
+      "**Cardinality is the exact missing invariant.** Once #K = 𝔠 is assumed, the characterization becomes a genuine biconditional. The forward direction (iso ⇒ card 𝔠) is trivial because isomorphisms are bijections; the reverse direction (card 𝔠 ⇒ iso) is the deep Steinitz content, borrowed from Mathlib.",
+      "**Uncountability is what makes cardinality suffice.** For uncountable algebraically closed fields the transcendence degree over ℚ equals the field's cardinality, so cardinality alone recovers the transcendence-basis invariant. The single hypothesis #K = 𝔠 silently supplies both uncountability (ℵ₀ < 𝔠) and the matching transcendence degree.",
+      "**Necessity is provable concretely, not just by appeal.** Rather than merely asserting the cardinality hypothesis cannot be dropped, the entry produces the witness AlgebraicClosure ℚ and proves ¬ Nonempty (AlgebraicClosure ℚ ≃+* ℂ) outright."
+    ],
+    "prerequisites": [
+      "Algebraically closed fields and the Fundamental Theorem of Algebra (IsAlgClosed ℂ)",
+      "Transcendence bases and Steinitz's classification of algebraically closed fields",
+      "Cardinal arithmetic: ℵ₀, the continuum 𝔠, and the fact ℵ₀ < 𝔠",
+      "Ring isomorphisms as cardinality-preserving bijections"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cardinality-of-c",
+      "title": "The Cardinality of ℂ",
+      "summary": "card_complex: #ℂ = 𝔠, recorded from Mathlib's Cardinal.mk_complex for reuse in both directions of the characterization.",
+      "startLine": 48,
+      "endLine": 49
+    },
+    {
+      "id": "existence",
+      "title": "Cardinality Continuum Forces an Isomorphism to ℂ",
+      "summary": "ringEquiv_complex_of_card_continuum: any algebraically closed field K of characteristic 0 with #K = 𝔠 is isomorphic to ℂ. The hypothesis supplies uncountability (ℵ₀ < #K via aleph0_lt_continuum) and a bijection K ≃ ℂ (via Cardinal.eq and mk_complex); IsAlgClosed.ringEquiv_of_equiv_of_charZero finishes.",
+      "startLine": 51,
+      "endLine": 62
+    },
+    {
+      "id": "converse",
+      "title": "An Isomorphism Preserves Cardinality",
+      "summary": "card_continuum_of_ringEquiv_complex: if K ≃+* ℂ then #K = 𝔠, since the underlying equivalence gives #K = #ℂ (Cardinal.mk_congr) and #ℂ = 𝔠.",
+      "startLine": 65,
+      "endLine": 70
+    },
+    {
+      "id": "characterization",
+      "title": "The Exact Characterization (Biconditional)",
+      "summary": "ringEquiv_complex_iff_card_continuum: for K algebraically closed of characteristic 0, Nonempty (K ≃+* ℂ) ↔ #K = 𝔠 — the honest form of the 'unique up to isomorphism' slogan. Also ringEquiv_of_both_card_continuum: uniqueness up to isomorphism among all such fields of cardinality 𝔠.",
+      "startLine": 72,
+      "endLine": 91
+    },
+    {
+      "id": "necessity",
+      "title": "Necessity of the Cardinality Hypothesis",
+      "summary": "card_algebraicClosure_rat: #(AlgebraicClosure ℚ) = ℵ₀ (algebraic over ℚ, hence ≤ ℵ₀, and infinite). not_nonempty_ringEquiv_algebraicClosure_rat_complex: the countable algebraically closed characteristic-0 field AlgebraicClosure ℚ is not isomorphic to ℂ, so characteristic and algebraic closedness alone do not determine ℂ.",
+      "startLine": 93,
+      "endLine": 107
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; imports only Mathlib): the exact characterization of ℂ among algebraically closed fields of characteristic 0 — Nonempty (K ≃+* ℂ) ↔ #K = 𝔠 — together with uniqueness up to isomorphism at cardinality 𝔠, and a concrete demonstration that the cardinality hypothesis is necessary (AlgebraicClosure ℚ is countable, char 0, algebraically closed, yet not isomorphic to ℂ).",
+    "implications": "Turns the imprecise folklore statement 'ℂ is the unique algebraically closed field of characteristic 0 up to isomorphism' into a precise, machine-checked theorem by supplying the missing cardinality invariant, and demonstrates by counterexample that this invariant cannot be omitted. Specializes Steinitz's classification (via Mathlib's IsAlgClosed.ringEquiv_of_equiv_of_charZero) to the canonical case of ℂ.",
+    "openQuestions": [
+      "State the finer classification directly in terms of transcendence degree over ℚ (not merely cardinality), covering the countable case where fields of equal finite/countable transcendence degree are isomorphic.",
+      "Formalize the analogous characterization of the algebraic closure of a finite field 𝔽_p-bar, and of ℂ_p (the p-adic complexes) as an algebraically closed field of characteristic 0 and cardinality 𝔠 — hence abstractly isomorphic to ℂ.",
+      "Prove the corresponding uniqueness for real closed fields of cardinality 𝔠 (characterizing ℝ up to order-isomorphism among real closed fields)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04",
+      "relationship": "parent-problem",
+      "description": "Parent: proves ℂ is the unique algebraic closure of ℝ ([ℂ:ℝ] = 2, algebraically closed). This entry answers the parent's open question on characterizing ℂ abstractly among all algebraically closed characteristic-0 fields, showing the correct invariant is cardinality."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "related",
+      "description": "Root of the family: every non-constant complex polynomial has a root, i.e. IsAlgClosed ℂ. That algebraic closedness is a standing hypothesis throughout this entry's characterization."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ernst Steinitz"
+      ],
+      "title": "Algebraische Theorie der Körper",
+      "year": "1910",
+      "venue": "Journal für die reine und angewandte Mathematik 137, 167-309",
+      "note": "Foundational classification of fields; algebraically closed fields are determined up to isomorphism by characteristic and transcendence degree."
+    },
+    {
+      "authors": [
+        "Serge Lang"
+      ],
+      "title": "Algebra (3rd edition)",
+      "year": "2002",
+      "venue": "Graduate Texts in Mathematics 211, Springer",
+      "note": "Chapter on transcendence bases and the isomorphism classification of algebraically closed fields."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.FieldTheory.IsAlgClosed.Classification",
+      "Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure",
+      "Mathlib.Analysis.Complex.Cardinality",
+      "Mathlib.Analysis.Complex.Polynomial.Basic",
+      "Mathlib.RingTheory.Algebraic.Cardinality",
+      "Mathlib.Data.Rat.Cardinal"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "FundamentalTheoremAlgebraOQ04OQ02",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/FundamentalTheoremAlgebraOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Enrichment: Characterizing ℂ among alg. closed char-0 fields

Pass 1 enrichment of `fundamental-theorem-algebra-oq-04-oq-02`. The entry already had a complete `overview`/`sections`/`conclusion`, cross-references and references. The gap was the **annotations**: all 8 had only `title` + `content`.

### `annotations.json` — structured fields added to all 8 annotations
Verified against `proofs/Proofs/FundamentalTheoremAlgebraOQ04OQ02.lean`:
- **`mathContext`** — LaTeX for each step: #ℂ = 𝔠; the Steinitz existence direction (`IsAlgClosed.ringEquiv_of_equiv_of_charZero`); cardinality as an isomorphism invariant; the biconditional K ≃+* ℂ ↔ #K = 𝔠; uniqueness via ℂ; #(AlgebraicClosure ℚ) = ℵ₀; and the ℵ₀ ≠ 𝔠 necessity counterexample.
- **`significance`** (`key`/`supporting`/`technical`/`context`), **`relatedConcepts`**, **`prerequisites`**.

### Verification
- `annotations.json` parses; `pnpm annotations:build` reports 0 warnings for this entry.
- `meta.json` unchanged (already within caps; already had overview/conclusion/sections/refs).
- Content cross-checked against the Lean source (0 axioms, 0 sorries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
