### PR TITLE
Enrich conjugacy-class size formula (lagrange-theorem-oq-02-...-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-lag02020101-context",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 8,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "Conjugation Is a Group Action — So Orbit-Stabilizer Is the Class Equation",
+    "content": "The open question asks to specialise the parent's orbit-counting index identity `Nat.card (orbit G x) = [G : stabilizer G x]` to the conjugation action `ConjAct G ↷ G`. The payoff is the **conjugacy-class size formula** `Nat.card (class(g)) = [G : C_G(g)]`, the single-orbit heart of the class equation `|G| = Σ_classes [G : C_G(g)]`. Everything rests on one dictionary: under conjugation the **orbit** of `g` is its **conjugacy class** (`orbit_eq_carrier_conjClasses`) and the **stabilizer** of `g` is its **centralizer**. Because the parent's identity is proved from the finiteness-free orbit/coset bijection, the size formula inherits that generality — it needs **no** `Finite`/`Fintype` instance.",
+    "mathContext": "Conjugation action $\\mathrm{ConjAct}\\,G\\curvearrowright G$: $\\mathrm{orbit}(g)=$ conjugacy class of $g$ ($\\mathtt{orbit\\_eq\\_carrier\\_conjClasses}$), $\\mathrm{stab}(g)=C_G(g)$. Orbit–stabilizer $\\#\\mathrm{orbit}(g)=[G:\\mathrm{stab}(g)]$ specializes to the class-size formula $\\#\\mathrm{cl}(g)=[G:C_G(g)]$, the single-orbit heart of the class equation $|G|=\\sum_{\\text{classes}}[G:C_G(g)]$. No finiteness needed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conjugation action",
+      "conjugacy class",
+      "centralizer",
+      "orbit-stabilizer theorem",
+      "class equation"
+    ],
+    "prerequisites": [
+      "group actions and orbits/stabilizers",
+      "conjugation and conjugacy classes",
+      "Nat.card"
+    ]
+  },
+  {
+    "id": "ann-lag02020101-indexmatch",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 93
+    },
+    "type": "tactic",
+    "title": "Centralizer Index = Stabilizer Index (via a Surjection)",
+    "content": "`index_centralizer_eq_index_stabilizer` matches the two indices that live in the two isomorphic copies of the group. The centralizer `C_G(g)` sits in `G`, while the conjugation stabilizer sits in `ConjAct G`. Mathlib's `Subgroup.centralizer_eq_comap_stabilizer` exhibits `centralizer {g}` as the pullback (`comap`) of `stabilizer (ConjAct G) g` along the isomorphism `ConjAct.toConjAct`. Since that map is **surjective**, `Subgroup.index_comap_of_surjective` says pulling back preserves the index, so `(centralizer {g}).index = (stabilizer (ConjAct G) g).index`. No finiteness is used — index is a `Nat.card` of a quotient, and the surjection identifies the two quotients.",
+    "mathContext": "$C_G(g)=\\mathrm{comap}\\,\\mathrm{ConjAct.toConjAct}\\,(\\mathrm{stab}_{\\mathrm{ConjAct}\\,G}(g))$ ($\\mathtt{centralizer\\_eq\\_comap\\_stabilizer}$); since $\\mathrm{ConjAct.toConjAct}:G\\simeq^* \\mathrm{ConjAct}\\,G$ is surjective, $\\mathtt{index\\_comap\\_of\\_surjective}$ gives $[G:C_G(g)]=[\\mathrm{ConjAct}\\,G:\\mathrm{stab}(g)]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subgroup index",
+      "comap along a homomorphism",
+      "surjective homomorphism preserves index",
+      "ConjAct.toConjAct"
+    ],
+    "prerequisites": [
+      "Subgroup.index",
+      "comap/pullback of subgroups",
+      "index invariance under surjections"
+    ]
+  },
+  {
+    "id": "ann-lag02020101-sizeformula",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 105
+    },
+    "type": "main-result",
+    "title": "The Conjugacy-Class Size Formula, Unconditional",
+    "content": "`card_conjugacyClass_eq_index_centralizer` is the main result: `Nat.card (orbit (ConjAct G) g) = (centralizer {g}).index`. After matching the centralizer index to the stabilizer index, the proof unfolds `Subgroup.index_eq_card` (index `=` `Nat.card` of the coset space) and transports the finiteness-free bijection `orbitEquivQuotientStabilizer (ConjAct G) g` through `Nat.card_congr`. The bijection — not any cardinal arithmetic — does the work, so the identity holds for **every** group `G` with no finiteness hypothesis. This is `|class(g)| = [G : C_G(g)]` over the total `Nat.card`.",
+    "mathContext": "$\\#\\mathrm{orbit}_{\\mathrm{ConjAct}\\,G}(g)=[G:C_G(g)]$. Proof: match centralizer/stabilizer indices, unfold $[G:H]=\\#(G/H)$ ($\\mathtt{index\\_eq\\_card}$), transport the finiteness-free bijection $\\mathtt{orbitEquivQuotientStabilizer}$ through $\\mathtt{Nat.card\\_congr}$. Holds for every group — no $\\mathrm{Finite}$ hypothesis.",
+    "significance": "key",
+    "relatedConcepts": [
+      "conjugacy-class size formula",
+      "orbitEquivQuotientStabilizer",
+      "index_eq_card",
+      "unconditional (no finiteness)"
+    ],
+    "prerequisites": [
+      "orbit–quotient bijection",
+      "Subgroup.index_eq_card",
+      "Nat.card_congr"
+    ]
+  },
+  {
+    "id": "ann-lag02020101-product",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 116
+    },
+    "type": "tactic",
+    "title": "The Product Form |class(g)|·|C_G(g)| = |G|",
+    "content": "`card_conjugacyClass_mul_card_centralizer` gives the multiplicative companion. `Group.nat_card_centralizer_nat_card_stabilizer` swaps `Nat.card (centralizer {g})` for `Nat.card (stabilizer (ConjAct G) g)`; then `← Nat.card_prod` and `Nat.card_congr (orbitProdStabilizerEquivGroup (ConjAct G) g)` collapse the product of orbit and stabilizer cardinalities to `Nat.card (ConjAct G)`; finally `ConjAct.toConjAct.toEquiv` identifies `Nat.card (ConjAct G)` with `Nat.card G`. The result `|class(g)|·|C_G(g)| = |G|` is the conjugation instance of `|orbit|·|Stab| = |G|`.",
+    "mathContext": "$\\#\\mathrm{orbit}(g)\\cdot\\#C_G(g)=\\#G$. Swap $\\#C_G(g)=\\#\\mathrm{stab}(g)$ ($\\mathtt{nat\\_card\\_centralizer\\_nat\\_card\\_stabilizer}$), then $\\mathtt{Nat.card\\_prod}+\\mathtt{orbitProdStabilizerEquivGroup}$ collapse $\\#(\\mathrm{orbit}\\times\\mathrm{stab})=\\#\\mathrm{ConjAct}\\,G=\\#G$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orbit–stabilizer product form",
+      "orbitProdStabilizerEquivGroup",
+      "Nat.card_prod",
+      "|orbit|·|Stab|=|G|"
+    ],
+    "prerequisites": [
+      "product of cardinalities",
+      "orbit×stabilizer ≃ G bijection"
+    ]
+  },
+  {
+    "id": "ann-lag02020101-carrier",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 130
+    },
+    "type": "concept",
+    "title": "Restated Over the Honest Conjugacy-Class Carrier",
+    "content": "`card_conjClasses_carrier_eq_index_centralizer` and `card_conjClasses_carrier_mul_card_centralizer` re-express both identities over `(ConjClasses.mk g).carrier` — the genuine set `{ y | IsConj g y }` of elements conjugate to `g` — rather than the `ConjAct`-orbit. The bridge is a single `rw [← MulAction.orbit_eq_carrier_conjClasses]`, which rewrites the carrier back to the orbit and defers to the orbit-level theorems. This is what makes the statement read as an honest fact about conjugacy classes.",
+    "mathContext": "Restated over $(\\mathrm{ConjClasses.mk}\\,g).\\mathrm{carrier}=\\{y\\mid \\mathrm{IsConj}\\,g\\,y\\}$: a single $\\mathtt{rw}[\\leftarrow \\mathtt{orbit\\_eq\\_carrier\\_conjClasses}]$ rewrites the carrier to the orbit and defers to the orbit-level theorems, making the statement an honest fact about conjugacy classes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ConjClasses carrier",
+      "IsConj",
+      "honest conjugacy-class statement",
+      "orbit = carrier"
+    ],
+    "prerequisites": [
+      "ConjClasses.mk and its carrier set",
+      "rewriting a definitional bridge"
+    ]
+  },
+  {
+    "id": "ann-lag02020101-center",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 149
+    },
+    "type": "insight",
+    "title": "Central Elements: Singleton Classes",
+    "content": "`card_conjugacyClass_center_eq_one` checks the degenerate stratum: if `g ∈ Z(G)` then everything commutes with `g`, so `centralizer {g} = ⊤`, its index is `1` (`Subgroup.index_top`), and the class of `g` is a singleton. This is exactly the `|Z(G)|` term of the class equation `|G| = |Z(G)| + Σ_{noncentral} [G : C_G(g)]`, recovered as a limiting case of the size formula. It also confirms the formula degrades correctly: central elements are fixed points of conjugation.",
+    "mathContext": "For $g\\in Z(G)$: everything commutes with $g$ so $C_G(g)=\\top$, $[G:\\top]=1$ ($\\mathtt{index\\_top}$), hence $\\#\\mathrm{cl}(g)=1$. This is the $|Z(G)|$ term of the class equation $|G|=|Z(G)|+\\sum_{\\text{noncentral}}[G:C_G(g)]$, recovered as the degenerate stratum (central elements are conjugation fixed points).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "center Z(G)",
+      "singleton conjugacy classes",
+      "class equation Z(G) term",
+      "Subgroup.index_top",
+      "fixed points of conjugation"
+    ],
+    "prerequisites": [
+      "center of a group",
+      "centralizer = ⊤ for central elements",
+      "index of the top subgroup"
+    ]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "slug": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.ConjAct",
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.GroupTheory.Rank",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction",
+      "Subgroup"
+    ],
+    "namespace": "ConjugacyClassSizeFormula",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Conjugacy-Class Size Formula over Nat.card",
+  "description": "Specialises the orbit-counting index identity to the conjugation action ConjAct G on G, proving the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Mathlib's total cardinal Nat.card — the single-orbit heart of the class equation. Under conjugation the orbit of g is its conjugacy class (orbit_eq_carrier_conjClasses) and the stabilizer is its centralizer; feeding these into the parent's orbit-stabilizer identities gives the size formula, unconditionally (no Finite/Fintype hypothesis), because the underlying orbit-quotient bijection needs none and the centralizer/stabilizer index match transports through the surjective isomorphism ConjAct.toConjAct. The product form |class(g)|·|C_G(g)| = |G| and restatements over the honest ConjClasses carrier are also given, together with the degenerate central-element case [G : C_G(g)] = 1. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "group-theory",
+      "group-action",
+      "conjugacy-class",
+      "centralizer",
+      "class-equation",
+      "orbit-stabilizer",
+      "subgroup-index",
+      "nat-card",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 149,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "card_conjugacyClass_eq_index_centralizer: Nat.card (orbit (ConjAct G) g) = (centralizer {g}).index — the conjugacy-class size formula, proved unconditionally (no Finite/Fintype) by transporting orbitEquivQuotientStabilizer through Nat.card and matching the centralizer index to the stabilizer index",
+      "index_centralizer_eq_index_stabilizer: (centralizer {g}).index = (stabilizer (ConjAct G) g).index — the centralizer is the comap of the conjugation stabilizer along the surjective isomorphism ConjAct.toConjAct, and comap along a surjection preserves index",
+      "card_conjugacyClass_mul_card_centralizer: Nat.card (orbit (ConjAct G) g) * Nat.card (centralizer {g}) = Nat.card G — the product form from the finiteness-free orbitProdStabilizerEquivGroup, |C_G(g)| = |stabilizer|, and |ConjAct G| = |G|",
+      "card_conjClasses_carrier_eq_index_centralizer / card_conjClasses_carrier_mul_card_centralizer: both identities restated over the honest conjugacy-class carrier (ConjClasses.mk g).carrier via orbit_eq_carrier_conjClasses",
+      "card_conjugacyClass_center_eq_one: the conjugacy class of a central element is a singleton ([G : C_G(g)] = 1), a sanity check that the size formula degenerates correctly on the center"
+    ],
+    "prerequisites": [
+      "The conjugation action ConjAct G on G; orbit = conjugacy class, stabilizer = centralizer",
+      "Subgroup index as Nat.card (G ⧸ H); the orbit-counting index identity Nat.card (orbit) = [G : stabilizer] (parent entry)",
+      "Mathlib's finiteness-free bijections orbitEquivQuotientStabilizer and orbitProdStabilizerEquivGroup",
+      "Index under comap along a surjection (Subgroup.index_comap_of_surjective)",
+      "Parent: lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01 (orbit-counting index identity over Nat.card)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.orbit_eq_carrier_conjClasses",
+        "description": "orbit (ConjAct G) g = (ConjClasses.mk g).carrier — the orbit of g under conjugation is exactly its conjugacy class, the geometric side of the dictionary.",
+        "module": "Mathlib.GroupTheory.GroupAction.ConjAct"
+      },
+      {
+        "theorem": "Subgroup.centralizer_eq_comap_stabilizer",
+        "description": "centralizer {g} = comap ConjAct.toConjAct.toMonoidHom (stabilizer (ConjAct G) g) — the centralizer is the pullback of the conjugation stabilizer along the isomorphism ConjAct.toConjAct.",
+        "module": "Mathlib.GroupTheory.GroupAction.ConjAct"
+      },
+      {
+        "theorem": "Subgroup.index_comap_of_surjective",
+        "description": "(H.comap f).index = H.index for surjective f — pulling a subgroup back along a surjection preserves its index; applied to the surjective ConjAct.toConjAct it identifies the centralizer index with the stabilizer index.",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "MulAction.orbitEquivQuotientStabilizer",
+        "description": "orbit G x ≃ G ⧸ stabilizer G x — the finiteness-free orbit/coset bijection; transported through Nat.card it gives the size formula unconditionally.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Group.nat_card_centralizer_nat_card_stabilizer",
+        "description": "Nat.card (centralizer {g}) = Nat.card (stabilizer (ConjAct G) g) — matches the centralizer cardinality to the conjugation stabilizer cardinality, used in the product form.",
+        "module": "Mathlib.GroupTheory.Rank"
+      }
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. That entry proved the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] over Nat.card. This entry specialises it to the conjugation action ConjAct G, turning orbits into conjugacy classes and stabilizers into centralizers, to obtain the conjugacy-class size formula."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Grandparent family. The conjugacy-class size formula |class(g)| = [G : C_G(g)] is the conjugation instance of the orbit-theoretic form of Lagrange's theorem, and summing it over the conjugacy classes gives the class equation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: GroupTheory.GroupAction.ConjAct",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of orbit_eq_carrier_conjClasses (orbit = conjugacy class) and Subgroup.centralizer_eq_comap_stabilizer (stabilizer = centralizer)."
+    },
+    {
+      "title": "Mathlib4: GroupTheory.Index and GroupTheory.Rank",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Subgroup.index_comap_of_surjective and Group.nat_card_centralizer_nat_card_stabilizer."
+    }
+  ],
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The class equation |G| = |Z(G)| + Σ [G : C_G(g)], summed over representatives of the non-central conjugacy classes, is one of the most productive counting tools in finite group theory: it powers Cauchy's theorem, the fact that p-groups have nontrivial center, and Sylow theory. Each term [G : C_G(g)] is the size of a conjugacy class, and that single-class fact — |class(g)| = [G : C_G(g)] — is nothing but orbit-stabilizer applied to the conjugation action of G on itself. This entry closes the orbit-stabilizer-over-Nat.card lineage by making that specialisation explicit and, following the parent's emphasis, keeping it finiteness-free wherever possible.",
+    "problemStatement": "Specialise the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] to the conjugation action ConjAct G on G, obtaining the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Nat.card, together with the product form |class(g)|·|C_G(g)| = |G|.",
+    "proofStrategy": "Assemble the ConjAct dictionary and feed it into the parent's identities. (1) index_centralizer_eq_index_stabilizer: rewrite centralizer {g} as the comap of the conjugation stabilizer along ConjAct.toConjAct (Subgroup.centralizer_eq_comap_stabilizer), then apply Subgroup.index_comap_of_surjective for the surjective ConjAct.toConjAct, giving (centralizer {g}).index = (stabilizer (ConjAct G) g).index. (2) card_conjugacyClass_eq_index_centralizer: unfold the stabilizer index to Nat.card (G ⧸ stabilizer) and transport the finiteness-free bijection orbitEquivQuotientStabilizer through Nat.card_congr — unconditional. (3) card_conjugacyClass_mul_card_centralizer: use Group.nat_card_centralizer_nat_card_stabilizer to swap centralizer for stabilizer, then the product bijection orbitProdStabilizerEquivGroup and |ConjAct G| = |G|. Finally restate both over (ConjClasses.mk g).carrier via orbit_eq_carrier_conjClasses, and record the central-element degeneracy.",
+    "keyInsights": [
+      "**Conjugation is a group action, so orbit-stabilizer *is* the class equation.** The conjugacy class of g is the ConjAct-orbit of g and its centralizer is the ConjAct-stabilizer, so |class(g)| = [G : C_G(g)] is a pure instance of orbit-stabilizer — no separate combinatorics needed.",
+      "**The size formula is finiteness-free.** As in the parent, the orbit/coset bijection carries the whole proof, so Nat.card (class(g)) = [G : C_G(g)] holds with no Finite/Fintype instance — the total Nat.card and Subgroup.index are the right objects.",
+      "**Centralizer and stabilizer live in two isomorphic copies of the group, and index is transported by the isomorphism.** The centralizer is the comap of the conjugation stabilizer along ConjAct.toConjAct; because that map is surjective, comap preserves the index, so the two indices agree without any finiteness assumption.",
+      "**The center is the degenerate stratum.** For g ∈ Z(G) the centralizer is the whole group, so [G : C_G(g)] = 1 and the class is a singleton — exactly the |Z(G)| term of the class equation, recovered as a limiting case of the size formula."
+    ],
+    "prerequisites": [
+      "The conjugation action ConjAct G on G; orbit = conjugacy class, stabilizer = centralizer",
+      "Subgroup index as Nat.card (G ⧸ H) and the parent's orbit-counting index identity",
+      "Mathlib's finiteness-free bijections orbitEquivQuotientStabilizer and orbitProdStabilizerEquivGroup",
+      "Index under comap along a surjection (Subgroup.index_comap_of_surjective)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the ConjAct ↔ conjugacy dictionary",
+      "startLine": 1,
+      "endLine": 80,
+      "summary": "Docstring stating the goal — the conjugacy-class size formula Nat.card (class(g)) = [G : C_G(g)] over Nat.card — and the dictionary under the conjugation action ConjAct G: orbit = conjugacy class (orbit_eq_carrier_conjClasses), stabilizer = centralizer. Both identities specialise the parent's orbit-stabilizer identities and stay finiteness-free.",
+      "mathContext": "$|\\mathrm{class}(g)| = [G : C_G(g)]$ over `Nat.card`, as the conjugation instance of orbit-stabilizer."
+    },
+    {
+      "id": "index-match",
+      "title": "Centralizer index = stabilizer index",
+      "startLine": 82,
+      "endLine": 93,
+      "summary": "index_centralizer_eq_index_stabilizer: the centralizer is the comap of the conjugation stabilizer along ConjAct.toConjAct (Subgroup.centralizer_eq_comap_stabilizer); since that isomorphism is surjective, Subgroup.index_comap_of_surjective preserves the index, so (centralizer {g}).index = (stabilizer (ConjAct G) g).index.",
+      "mathContext": "$[G : C_G(g)] = [\\,\\mathrm{ConjAct}\\,G : \\mathrm{Stab}(g)]$ via the surjective iso $\\mathrm{toConjAct}$."
+    },
+    {
+      "id": "size-formula",
+      "title": "The conjugacy-class size formula (index form)",
+      "startLine": 95,
+      "endLine": 105,
+      "summary": "card_conjugacyClass_eq_index_centralizer proves Nat.card (orbit (ConjAct G) g) = (centralizer {g}).index unconditionally: match the centralizer index to the stabilizer index, unfold Subgroup.index_eq_card, and transport orbitEquivQuotientStabilizer through Nat.card_congr — no finiteness hypothesis.",
+      "mathContext": "$|\\mathrm{orbit}_{\\mathrm{ConjAct}}(g)| = \\mathrm{Nat.card}(G/\\mathrm{Stab}) = [G : C_G(g)]$."
+    },
+    {
+      "id": "product-form",
+      "title": "The product form |class(g)|·|C_G(g)| = |G|",
+      "startLine": 107,
+      "endLine": 116,
+      "summary": "card_conjugacyClass_mul_card_centralizer: swap centralizer for stabilizer via Group.nat_card_centralizer_nat_card_stabilizer, apply ← Nat.card_prod and Nat.card_congr (orbitProdStabilizerEquivGroup (ConjAct G) g), and finish with |ConjAct G| = |G| via ConjAct.toConjAct.toEquiv.",
+      "mathContext": "$|\\mathrm{class}(g)|\\cdot|C_G(g)| = |G|$ from $\\mathrm{orbit}\\times\\mathrm{Stab} \\cong \\mathrm{ConjAct}\\,G \\cong G$."
+    },
+    {
+      "id": "carrier-restatements",
+      "title": "Restatements over the ConjClasses carrier",
+      "startLine": 118,
+      "endLine": 131,
+      "summary": "card_conjClasses_carrier_eq_index_centralizer and card_conjClasses_carrier_mul_card_centralizer restate the index and product forms over (ConjClasses.mk g).carrier — the honest set {y | IsConj g y} — by rewriting orbit_eq_carrier_conjClasses.",
+      "mathContext": "The same two identities phrased over $\\{\\,y \\mid y \\sim g\\,\\}$, the set of elements conjugate to $g$."
+    },
+    {
+      "id": "center-degeneracy",
+      "title": "Central elements: singleton classes",
+      "startLine": 133,
+      "endLine": 149,
+      "summary": "card_conjugacyClass_center_eq_one: for g ∈ Z(G) the centralizer is ⊤, so its index is 1 and the class is a singleton — the |Z(G)| stratum of the class equation as a degenerate case of the size formula. Closes namespace ConjugacyClassSizeFormula after signature #checks.",
+      "mathContext": "$g \\in Z(G) \\Rightarrow C_G(g) = G \\Rightarrow [G : C_G(g)] = 1$: the class is $\\{g\\}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] is obtained by specialising the parent's orbit-counting index identity to the conjugation action ConjAct G on G. Under conjugation the orbit is the conjugacy class and the stabilizer is the centralizer; the centralizer index equals the stabilizer index because the centralizer is the comap of the stabilizer along the surjective isomorphism ConjAct.toConjAct, and comap along a surjection preserves index. The size formula is proved unconditionally (no Finite/Fintype), the product form |class(g)|·|C_G(g)| = |G| is given, both are restated over the honest ConjClasses carrier, and the central-element case [G : C_G(g)] = 1 is recorded. 149 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This is the single-orbit heart of the class equation |G| = Σ_classes [G : C_G(g)]: each term is a conjugacy-class size, and this entry certifies each such size as a centralizer index over Nat.card with no finiteness assumption. It completes the orbit-stabilizer-over-Nat.card lineage by exhibiting its most important concrete instance — conjugation — and shows the whole dictionary (orbit ↔ conjugacy class, stabilizer ↔ centralizer, index preserved by the ConjAct isomorphism) is available finiteness-free.",
+    "openQuestions": [
+      "Sum the size formula over conjugacy-class representatives to re-derive the class equation Group.nat_card_center_add_sum_card_noncenter_eq_card directly from this single-class identity.",
+      "Specialise further to concrete groups (e.g. Equiv.Perm) where centralizer cardinalities are computable, recovering explicit conjugacy-class sizes."
+    ]
+  }
+}


### PR DESCRIPTION
## Enrichment: Conjugacy-Class Size Formula over Nat.card

Pass 1 enrichment of `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01`. The entry already had a complete `overview`/`sections`/`conclusion`, cross-references and references. The gap was the **annotations**: all 6 had only `title` + `content`.

### `annotations.json`
Verified against `proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01OQ01.lean`:
- **`mathContext`** added to all 6 — the ConjAct dictionary (orbit = conjugacy class, stabilizer = centralizer), the centralizer/stabilizer index match via the surjective `ConjAct.toConjAct`, the unconditional size formula `#cl(g) = [G:C_G(g)]`, the product form `|cl(g)|·|C_G(g)| = |G|`, the ConjClasses-carrier restatements, and the central-element singleton case (the `|Z(G)|` term of the class equation).
- **`significance`** (`key`/`supporting`), **`relatedConcepts`**, **`prerequisites`** added to all 6.
- Fixed a range overlap: `carrier` annotation now ends at line 130 (was 131), so it no longer overlaps the `center` annotation.

### Verification
- `annotations.json` parses; `pnpm annotations:build` reports 0 warnings for this entry.
- Content cross-checked against the Lean source (0 axioms, 0 sorries, no finiteness hypothesis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
