### PR TITLE
Enrich Erdős #76 packing upper bound: conclusion, references, crossReferences

### DIFF
--- a/src/data/proofs/erdos-76-packing-upper-bound/annotations.json
+++ b/src/data/proofs/erdos-76-packing-upper-bound/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-erdos76pub-header",
+    "proofId": "erdos-76-packing-upper-bound",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "The Easy Half of Erdős #76: the n²/6 Packing Upper Bound",
+    "content": "Erdős Problem #76 (Gruslys–Letzter, 2020) asks for the maximum number of edge-disjoint monochromatic triangles guaranteed in a 2-coloring of K_n; the answer is (1+o(1))·n²/12. The parent entry Erdos76Problem.lean axiomatizes that deep lower bound and leaves the matching upper bound — no coloring can pack more than about n²/6 edge-disjoint monochromatic triangles — as a `sorry`. This file discharges that obligation with elementary double counting: each triangle uses 6 ordered edges, the triangles of a packing are edge-disjoint, and there are only n(n−1) ordered edges in K_n, so at most n(n−1)/6 = C(n,2)/3 ≈ n²/6 triangles fit.",
+    "mathContext": "The crude edge budget gives $6\\,|ts| \\le n^2 - n$, hence $|ts| \\le \\binom{n}{2}/3 \\approx n^2/6$ — exactly twice the true optimum $n^2/12$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "edge-disjoint monochromatic triangles",
+      "triangle packing upper bound",
+      "double counting",
+      "extremal graph theory"
+    ],
+    "prerequisites": [
+      "edge-disjoint triangle packings in K_n",
+      "double counting / the pigeonhole edge budget",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "ann-erdos76pub-triangles",
+    "proofId": "erdos-76-packing-upper-bound",
+    "range": {
+      "startLine": 43,
+      "endLine": 62
+    },
+    "type": "tactic",
+    "title": "Six Edges per Triangle via offDiag",
+    "content": "A triangle is a Finset of exactly three vertices; its edge set is taken to be the offDiag of the vertex set — every ordered pair (u,v) of distinct vertices inside it. Using ordered pairs keeps the count exact: Finset.offDiag_card gives |s.offDiag| = |s|·|s| − |s|, so with |s| = 3 each triangle carries 3·3 − 3 = 6 edges. This '6' is the per-triangle edge cost that drives the whole bound.",
+    "mathContext": "$|t.\\mathrm{offDiag}| = 3^2 - 3 = 6$; ordered edges avoid the factor-of-2 bookkeeping of unordered pairs.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.offDiag",
+      "Finset.offDiag_card",
+      "ordered edges of a clique"
+    ],
+    "prerequisites": [
+      "Finset.offDiag and offDiag_card"
+    ]
+  },
+  {
+    "id": "ann-erdos76pub-edgebound",
+    "proofId": "erdos-76-packing-upper-bound",
+    "range": {
+      "startLine": 64,
+      "endLine": 124
+    },
+    "type": "tactic",
+    "title": "Double Counting: 6·|ts| ≤ n² − n ⟹ |ts| ≤ C(n,2)/3",
+    "content": "A packing is a finite set of pairwise edge-disjoint triangles. Because their edge sets are pairwise disjoint, Finset.card_biUnion equates the size of their union with the sum of the individual sizes, ∑ 6 = 6·|ts|. That union embeds in univ.offDiag — the |V|²−|V| ordered distinct pairs of the whole vertex type — so Finset.card_le_card gives packing_edge_bound: 6·|ts| ≤ |V|² − |V|. Dividing through (Nat.choose_two_right rewrites C(n,2) = n(n−1)/2, Nat.div_div_eq_div_mul collapses /2/3 into /6, and Nat.le_div_iff_mul_le converts the goal to a multiplication) yields packing_card_le_choose: |ts| ≤ C(|V|,2)/3.",
+    "mathContext": "$\\sum_{t \\in ts} |t.\\mathrm{edges}| = 6|ts| = |\\bigcup_t t.\\mathrm{edges}| \\le |\\mathrm{univ.offDiag}| = |V|^2 - |V|$, so $|ts| \\le \\binom{|V|}{2}/3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_biUnion",
+      "PairwiseDisjoint",
+      "double counting",
+      "Nat.le_div_iff_mul_le"
+    ],
+    "prerequisites": [
+      "Finset.card_biUnion for a pairwise-disjoint family",
+      "Finset.card_le_card for the ambient embedding",
+      "natural-number division lemmas"
+    ]
+  },
+  {
+    "id": "ann-erdos76pub-maxpacking",
+    "proofId": "erdos-76-packing-upper-bound",
+    "range": {
+      "startLine": 125,
+      "endLine": 160
+    },
+    "type": "tactic",
+    "title": "Lifting to maxPackingSize — the Statement the Parent Left Open",
+    "content": "Re-declaring the parent's 2-coloring vocabulary (Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize = sSup of achievable monochromatic-packing sizes), maxPackingSize_le proves that for every coloring c, maxPackingSize c ≤ C(n,2)/3 — the exact inequality left as a `sorry` in Erdos76Problem.lean. The set of achievable sizes is nonempty (the empty packing realizes 0) and every element is bounded by packing_card_le_choose, so csSup_le lifts the bound to the supremum.",
+    "mathContext": "Every $k$ with a monochromatic packing of size $k$ satisfies $k \\le \\binom{n}{2}/3$; nonemptiness (empty packing) plus this upper bound give $\\sup \\le \\binom{n}{2}/3$ by csSup_le.",
+    "significance": "key",
+    "relatedConcepts": [
+      "maxPackingSize",
+      "csSup_le",
+      "supremum of achievable packing sizes",
+      "monochromatic packing"
+    ],
+    "prerequisites": [
+      "sSup on ℕ and csSup_le",
+      "the parent entry's maxPackingSize definition"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-76-packing-upper-bound/meta.json
+++ b/src/data/proofs/erdos-76-packing-upper-bound/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "erdos-76-packing-upper-bound",
+  "title": "Erdős #76: The Elementary n²/6 Upper Bound on Monochromatic Triangle Packings",
+  "slug": "erdos-76-packing-upper-bound",
+  "description": "Discharges, unconditionally and without axioms, the packing upper bound left as a `sorry` in the parent entry Erdős Problem #76 (Erdos76Problem.lean). The parent formalizes the Erdős–Faudree–Ordman conjecture — solved by Gruslys & Letzter (2020) — that every 2-coloring of K_n contains at least (1+o(1))·n²/12 edge-disjoint monochromatic triangles, and leaves the matching upper bound maxPackingSize c ≤ C(n,2)/3 (≈ n²/6) unproven. That upper bound is pure edge counting: each triangle occupies exactly 6 ordered edges (its offDiag), the triangles of a packing are pairwise edge-disjoint, so their edge sets sit disjointly inside the n(n−1) ordered edges of K_n; hence 6·(packing size) ≤ n²−n and (packing size) ≤ C(n,2)/3. This entry re-declares the triangle/packing machinery locally and proves the bound in full — for arbitrary packings (packing_card_le_choose) and for the maximum monochromatic packing of any coloring (maxPackingSize_le), the exact statement the parent leaves open. The factor-of-2 gap between this trivial upper bound n²/6 and the true optimum n²/12 is precisely what makes Erdős #76 deep: the extremal coloring sacrifices half its edges on a triangle-free red bipartite subgraph. Fully verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos76PackingUpperBound.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "ramsey-theory",
+      "extremal-graph-theory",
+      "triangle-packing",
+      "edge-colorings",
+      "double-counting",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "None. All results are axiom-free and self-contained: the Triangle structure, its edge set (t.vertices.offDiag), edge-disjoint packings, the 2-coloring, and maxPackingSize are all re-declared locally, so nothing depends on the parent entry's three research axioms (gruslys_letzter, balanced_achieves_bound, extremal_uniqueness). No native_decide is used. `#print axioms` on the four public results (Triangle.edges_card, packing_edge_bound, packing_card_le_choose, maxPackingSize_le) reports only [propext, Classical.choice, Quot.sound]. Mathlib lemmas used: Finset.offDiag_card, Finset.card_biUnion, Finset.mem_offDiag, Finset.card_le_card, Finset.card_univ, Nat.choose_two_right, Nat.div_div_eq_div_mul, Nat.le_div_iff_mul_le, csSup_le. Kernel-verified against Mathlib v4.26.0.",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "erdosNumber": 76,
+    "erdosUrl": "https://erdosproblems.com/76",
+    "erdosProblemStatus": "solved",
+    "originalContributions": [
+      "Triangle.edges_card: every triangle occupies exactly six ordered edges, |t.vertices.offDiag| = 3·3 − 3 = 6, via Finset.offDiag_card.",
+      "packing_edge_bound: THE DOUBLE-COUNTING CORE — for any edge-disjoint packing ts of triangles in a finite vertex type V, 6·|ts| ≤ |V|² − |V|. Proof: the edge sets are pairwise disjoint, so Finset.card_biUnion turns the total edge count into ∑ 6 = 6·|ts|, and the union embeds in univ.offDiag whose card is |V|²−|V|.",
+      "packing_card_le_choose: the headline bound — any edge-disjoint packing has at most C(|V|,2)/3 triangles (≈ |V|²/6). Derived from the edge bound by Nat.choose_two_right, Nat.div_div_eq_div_mul and Nat.le_div_iff_mul_le.",
+      "maxPackingSize_le: DISCHARGES THE PARENT'S sorry — for every 2-coloring c of K_n, maxPackingSize c ≤ C(n,2)/3, i.e. the maximum monochromatic triangle packing is at most ≈ n²/6. Proved with csSup_le over the (nonempty, via the empty packing) set of achievable packing sizes.",
+      "A fully local, axiom-free re-declaration of the triangle-packing vocabulary (Triangle, Triangle.edges as offDiag, isPacking, Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize) matching the parent Erdos76Problem.lean so the result drops directly into its narrative."
+    ],
+    "theoremCount": 4,
+    "definitionCount": 8
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #76 (conjectured by Erdős, Faudree and Ordman; resolved by Gruslys and Letzter, 2020) asks how many edge-disjoint monochromatic triangles every 2-coloring of the edges of K_n must contain. The answer is (1+o(1))·n²/12, achieved by the balanced bipartition: split the vertices into two equal halves, color within-half edges blue (two K_{n/2} cliques, each packing ≈ n²/24 triangles via Steiner triple systems) and between-half edges red. The red class K_{n/2,n/2} is triangle-free, so it contributes nothing — the count comes entirely from the two blue cliques, giving 2·n²/24 = n²/12. The genuinely hard content is the matching lower bound (every coloring achieves ≥ n²/12), which Gruslys and Letzter proved via the Szemerédi regularity lemma and a greedy-absorption method.",
+    "problemStatement": "The parent formalization Erdos76Problem.lean states the deep lower bound as an axiom (gruslys_letzter) and leaves the complementary upper bound — maxPackingSize c ≤ totalEdges n / 3, i.e. no coloring can pack more than about n²/6 edge-disjoint monochromatic triangles — as a `sorry`. This entry proves that upper bound outright, and in fact the stronger fact that it holds for arbitrary (not necessarily monochromatic) edge-disjoint packings.",
+    "proofStrategy": "Pure double counting. A triangle is a set of three vertices; model its edge set as the offDiag of its vertex Finset, so it carries exactly 3·3 − 3 = 6 ordered edges (Triangle.edges_card, via Finset.offDiag_card). In an edge-disjoint packing the triangles' edge sets are pairwise disjoint, so Finset.card_biUnion equates the size of their union with ∑ 6 = 6·|ts|. That union sits inside univ.offDiag, the |V|² − |V| ordered distinct pairs of the whole vertex type, so 6·|ts| ≤ |V|² − |V| (packing_edge_bound). Dividing (Nat.choose_two_right, Nat.div_div_eq_div_mul, Nat.le_div_iff_mul_le) yields |ts| ≤ C(|V|,2)/3 (packing_card_le_choose). Finally, since every achievable monochromatic-packing size satisfies this bound and the set of such sizes is nonempty (the empty packing), csSup_le lifts the bound to the supremum maxPackingSize (maxPackingSize_le), matching the parent's open statement verbatim.",
+    "keyInsights": [
+      "The upper-bound direction of Erdős #76 is elementary: it is a single application of the double-counting principle (edges used = 6 per triangle, all disjoint, all inside K_n), needing none of the regularity-method machinery behind the lower bound.",
+      "Using ordered edges (offDiag) keeps the arithmetic exact: 6 edges per triangle and |V|²−|V| edges total, so the bound is literally 6·|ts| ≤ |V|²−|V| with no hidden factors, and Finset.card_biUnion converts edge-disjointness directly into a sum.",
+      "The trivial upper bound is n²/6 — exactly twice the true optimum n²/12. That factor-of-2 slack is the whole difficulty of the problem: the extremal coloring can only reach half the crude edge budget because it deliberately wastes one color on a triangle-free bipartite class.",
+      "Lifting the per-packing bound to maxPackingSize needs only that the set of achievable sizes is nonempty (the empty packing witnesses 0) and bounded above, so csSup_le applies with no completeness subtleties."
+    ],
+    "prerequisites": [
+      "Finset off-diagonals and their cardinality: Finset.offDiag, Finset.mem_offDiag, Finset.offDiag_card (|s.offDiag| = |s|² − |s|)",
+      "Cardinality of a disjoint biUnion: Finset.card_biUnion for a PairwiseDisjoint family, plus Finset.card_le_card for the ambient embedding",
+      "Natural-number division facts: Nat.choose_two_right, Nat.div_div_eq_div_mul, Nat.le_div_iff_mul_le, and csSup_le for the supremum over achievable packing sizes"
+    ]
+  },
+  "sections": [
+    {
+      "id": "triangles",
+      "title": "§I: Triangles and Their Six Edges",
+      "startLine": 43,
+      "endLine": 62,
+      "summary": "Declares the Triangle structure and its edge set (the offDiag of the vertex Finset), and proves Triangle.edges_card: every triangle carries exactly 3·3 − 3 = 6 ordered edges.",
+      "mathContext": "Ordered edges make the count exact: a 3-vertex clique has $3^2 - 3 = 6$ ordered pairs of distinct vertices."
+    },
+    {
+      "id": "edge-bound",
+      "title": "§II: Edge-Disjoint Packings and the Double-Counting Bound",
+      "startLine": 64,
+      "endLine": 124,
+      "summary": "Defines isPacking (pairwise edge-disjoint triangles) and proves the core packing_edge_bound (6·|ts| ≤ |V|²−|V|) via Finset.card_biUnion, then packing_card_le_choose (|ts| ≤ C(|V|,2)/3 ≈ |V|²/6).",
+      "mathContext": "Disjoint edge sets of total size $6|ts|$ embed in the $|V|^2-|V|$ ordered edges of $K_{|V|}$, so $6|ts| \\le |V|^2-|V|$ and $|ts| \\le \\binom{|V|}{2}/3$."
+    },
+    {
+      "id": "maxpacking",
+      "title": "§III: Lifting to maxPackingSize — the Parent's Open Statement",
+      "startLine": 125,
+      "endLine": 160,
+      "summary": "Re-declares the 2-coloring vocabulary (Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize) and proves maxPackingSize_le: for every coloring, the maximum monochromatic packing has ≤ C(n,2)/3 triangles — the exact bound left as a `sorry` in Erdos76Problem.lean.",
+      "mathContext": "Every achievable monochromatic-packing size is $\\le \\binom{n}{2}/3$; the set of such sizes is nonempty (empty packing), so $\\sup$ obeys the same bound via csSup_le."
+    }
+  ],
+  "relatedProofs": [
+    "erdos-76",
+    "erdos-76-oq-02",
+    "erdos-7"
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-76",
+      "relationship": "extends",
+      "description": "Parent entry: the full Erdős #76 formalization (Erdos76Problem.lean), which states the deep lower bound (1+o(1))·n²/12 as the axiom gruslys_letzter and leaves the matching upper bound maxPackingSize c ≤ C(n,2)/3 as a `sorry`. This entry discharges exactly that `sorry`, axiom-free."
+    },
+    {
+      "targetId": "erdos-76-oq-02",
+      "relationship": "related",
+      "description": "Sibling open-question entry in the Erdős #76 family; both refine the edge-disjoint monochromatic triangle-packing problem."
+    },
+    {
+      "targetId": "erdos-7",
+      "relationship": "related",
+      "description": "Another Erdős combinatorics entry; shares the double-counting / extremal edge-counting toolkit."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Vytautas Gruslys, Shoham Letzter",
+      "title": "Monochromatic triangle packings in red-blue graphs",
+      "year": 2020,
+      "venue": "arXiv:2008.05311",
+      "note": "Resolves the Erdős–Faudree–Ordman conjecture: every 2-coloring of K_n contains (1/12 + o(1))·n² edge-disjoint monochromatic triangles, with a matching stability result (near-extremal colorings have a near-bipartite color class). This is the deep lower bound that the crude n²/6 upper bound proved here complements."
+    },
+    {
+      "authors": "Paul Erdős, Ralph J. Faudree, Ronald J. Gould, Michael S. Jacobson, Jenő Lehel",
+      "title": "Edge disjoint monochromatic triangles in 2-colored graphs",
+      "year": 2001,
+      "venue": "Discrete Mathematics 231(1–3), 135–141",
+      "note": "First quantitative progress toward the conjecture, establishing a lower bound of (1+o(1))·3n²/55 edge-disjoint monochromatic triangles."
+    },
+    {
+      "authors": "Thomas F. Bloom",
+      "title": "Erdős Problem #76",
+      "year": 2024,
+      "venue": "erdosproblems.com/76",
+      "note": "Catalogue entry for the problem, its status (solved), and the balanced-bipartition extremal construction."
+    }
+  ],
+  "conclusion": {
+    "summary": "The upper-bound direction of Erdős #76 — that no 2-coloring of K_n packs more than about n²/6 edge-disjoint monochromatic triangles — is proved outright, axiom-free, discharging the `sorry` left in the parent Erdos76Problem.lean. The argument is a single double-count: each triangle uses exactly 6 ordered edges (Triangle.edges_card), the triangles of a packing are pairwise edge-disjoint (Finset.card_biUnion), and their edge sets embed in the |V|²−|V| ordered edges of K_n, giving 6·|ts| ≤ |V|²−|V| (packing_edge_bound), hence |ts| ≤ C(|V|,2)/3 (packing_card_le_choose), lifted to the supremum via csSup_le (maxPackingSize_le). 4 theorems, 8 definitions, 160 lines, 0 sorries, 0 axioms.",
+    "implications": "The result cleanly separates the trivial half of Erdős #76 from the hard half: the crude edge budget gives n²/6, exactly twice the true optimum n²/12, and the entire depth of the Gruslys–Letzter theorem lies in showing the lower bound reaches only half of that budget (the extremal coloring wastes one color on a triangle-free bipartite class). Because the triangle/packing vocabulary is re-declared locally and axiom-free, the bound drops directly into the parent narrative without inheriting its three research axioms.",
+    "openQuestions": [
+      "Formalize the matching lower bound (1+o(1))·n²/12 (Gruslys–Letzter), replacing the parent's gruslys_letzter axiom — the genuinely deep direction requiring the regularity method and greedy absorption.",
+      "Verify the extremal balanced-bipartition construction achieves n²/12 (two blue K_{n/2} cliques packed via Steiner triple systems, red K_{n/2,n/2} triangle-free), pinning the optimum from above at the extremal coloring.",
+      "Sharpen the elementary upper bound below the crude n²/6 using structural constraints (e.g. that not all 6-edge budgets can be simultaneously saturated across colors), narrowing the factor-of-2 gap by elementary means.",
+      "Extend the double-counting bound to r-colorings and to K_n-free host graphs, where the per-triangle edge count and the ambient edge total change."
+    ]
+  }
+}


### PR DESCRIPTION
## Enrichment: Erdős #76 — the n²/6 packing upper bound

Pass 1 enrichment of `erdos-76-packing-upper-bound`. The annotations were already fully enriched (mathContext/significance/relatedConcepts/prerequisites on all 4), and the `overview`/`sections` were strong. The gaps were in `meta.json`:

### Added to `meta.json`
- **`conclusion`** — `summary`, `implications` (why the crude n²/6 is exactly twice the true n²/12 optimum), and 4 `openQuestions` (formalizing the Gruslys–Letzter lower bound, the extremal construction, sharpening the bound, r-coloring extensions).
- **`references`** (was missing) — Gruslys & Letzter, *Monochromatic triangle packings in red-blue graphs* (arXiv:2008.05311, 2020); Erdős–Faudree–Gould–Jacobson–Lehel, *Edge disjoint monochromatic triangles in 2-colored graphs* (Discrete Math. 231, 2001); Bloom, Erdős Problem #76. Citations verified via web search — no fabricated titles.
- **`crossReferences`** — descriptive objects for `erdos-76` (parent, whose `sorry` this discharges), `erdos-76-oq-02`, `erdos-7` (previously only bare `relatedProofs` strings, which are retained).

### Verification
- `meta.json` parses; 14.1 KB (well under the 60 KB cap; `gallery:check-size` passes).
- All cross-reference targets exist; `pnpm annotations:build` reports 0 warnings.
- Content cross-checked against the entry's existing description/overview (0 axioms, 0 sorries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
