### PR TITLE
research(prob-method-applications-oq-02-oq-02): dual incidence bound + symmetric Cauchy–Schwarz minimum [VERIFIED, 0-axiom]

### DIFF
--- a/research/problems/prob-method-applications-oq-02/knowledge.md
+++ b/research/problems/prob-method-applications-oq-02/knowledge.md
@@ -87,10 +87,30 @@ must be built and kernel-checked before any "verified" gallery promotion.
    on the flip Prop being definitionally equal). All three are defeq-based; if
    any fails, replace with an explicit `simp [Function.flip]` normalization.
 
+## This session's contribution (researcher-13, 2026-07-02) — VERIFIED
+
+The handoff above is **done**. `IncidenceCauchySchwarzDual.lean` was built with
+`./proofs/scripts/docker-build.sh Proofs.IncidenceCauchySchwarzDual` → **exit 0
+(Build succeeded)**, run twice. It is **0 sorries / 0 axioms / no
+`native_decide`** as predicted; none of the three flagged defeq-based spots
+(`flipDecidable`, `incidences_flip`'s `Finset.sum_comm` close,
+`twoPointsJoinOnce_iff_flip := Iff.rfl`) needed the `simp [Function.flip]`
+fallback — they elaborate as written.
+
+Registration note: `proofs/Proofs.lean` no longer takes per-file `import` lines;
+modules under `proofs/Proofs/` are auto-discovered by the Lake `globs` directive
+in `proofs/lakefile.toml`, so the file was already in the build graph on `main`
+the moment #28712 landed — the "unregistered" caveat is obsolete.
+
+Gallery entry **`prob-method-applications-oq-02-oq-02`** minted (PR #33690):
+`meta.json` (badge `original`, status `verified`, 0 axioms, 5 thm / 1 def /
+132 L), `annotations.json` (7 annotations), `index.ts`. The build-pending state
+is cleared; OQ-02's elementary half is now a verified gallery sibling in both
+projections.
+
 ## Next steps
 
-- **Verify + register** the dual file (above) — converts this from build-pending
-  to a verified gallery sibling.
+- ~~**Verify + register** the dual file~~ — DONE this session (PR #33690).
 - The ST exponent stays **BLOCKED** pending a Mathlib crossing-number /
   planar-drawing library. Do not attempt it as an elementary proof; flag as a
   large infrastructure milestone (`BLOCKED`, > 1000 lines).

--- a/src/data/proofs/prob-method-applications-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-applications-oq-02-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "icbd-flip-decidable",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "definition",
+    "title": "Decidability Transports Across flip",
+    "content": "The forward file's incidence bound needs a decidable incidence relation. Running it on the flipped relation flip Inc : L → P → Prop therefore requires a Decidable instance for flip Inc ℓ p. But flip Inc ℓ p unfolds definitionally to Inc p ℓ, so the ambient point-line decidability instance already applies — the instance is just inferInstance transported along the defeq. This tiny bridge is what lets every forward theorem be reused verbatim on the flipped structure with no re-proof.",
+    "mathContext": "$\\mathrm{flip}\\,\\mathrm{Inc}\\,\\ell\\,p \\;\\equiv\\; \\mathrm{Inc}\\,p\\,\\ell$",
+    "significance": "supporting",
+    "prerequisites": ["Function.flip", "decidable instances", "definitional equality"],
+    "relatedConcepts": ["typeclass transport", "definitional unfolding", "instance resolution"]
+  },
+  {
+    "id": "icbd-incidences-flip",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "theorem",
+    "title": "Incidences Are Flip-Invariant",
+    "content": "The one genuine lemma of the file: the incidence count is unchanged under exchanging the roles of points and lines. Expanding both counts to double sums of 0/1 indicators (unfold incidences deg, then Finset.card_filter), the two sums differ only by the order of summation, so Finset.sum_comm matches them and the residual goal closes definitionally. This is exactly the discrete Fubini principle — summing line-degrees over points equals summing point-degrees over lines — and it is what makes the whole duality argument free of new combinatorics.",
+    "mathContext": "$I(\\mathrm{flip}\\,\\mathrm{Inc}) = \\sum_{\\ell}\\sum_{p} \\mathbf{1}[\\mathrm{Inc}\\,p\\,\\ell] = \\sum_{p}\\sum_{\\ell} \\mathbf{1}[\\mathrm{Inc}\\,p\\,\\ell] = I(\\mathrm{Inc})$",
+    "significance": "critical",
+    "prerequisites": ["Fubini / swapping sums", "Finset.sum_comm", "Finset.card_filter"],
+    "relatedConcepts": ["discrete Fubini", "double counting", "symmetry of incidence"]
+  },
+  {
+    "id": "icbd-two-points-join-once",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 73, "endLine": 77 },
+    "type": "definition",
+    "title": "The Dual Hypothesis: Two Distinct Points Join at Most Once",
+    "content": "TwoPointsJoinOnce is the point-line dual of TwoLinesMeetOnce: for any two distinct points, the set of lines incident to both has at most one element. This is the second half of the standard nondegeneracy axioms of a (partial) linear space — 'two points determine at most one line' — stated purely combinatorially over the abstract relation Inc : P → L → Prop, with no plane or coordinates.",
+    "mathContext": "$\\forall\\, p_1 \\ne p_2:\\quad \\#\\{\\ell : \\mathrm{Inc}\\,p_1\\,\\ell \\wedge \\mathrm{Inc}\\,p_2\\,\\ell\\} \\le 1$",
+    "significance": "key",
+    "prerequisites": ["partial linear spaces", "incidence axioms"],
+    "relatedConcepts": ["point-line duality", "partial linear space", "nondegeneracy axiom", "two points determine a line"]
+  },
+  {
+    "id": "icbd-two-points-iff-flip",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 79, "endLine": 83 },
+    "type": "theorem",
+    "title": "Dual Hypothesis = Once-Meeting on the Flipped Relation",
+    "content": "The lynchpin of the duality: TwoPointsJoinOnce Inc is not merely equivalent but definitionally equal to TwoLinesMeetOnce (flip Inc). Because flip Inc ℓ p reduces to Inc p ℓ and the flip decidability instance is the ambient one, the two Props coincide on the nose, so the proof is Iff.rfl. This zero-cost identification is what lets the forward file's incidence_bound and incidence_bound_sqrt fire directly under the dual hypothesis without any re-derivation.",
+    "mathContext": "$\\mathrm{TwoPointsJoinOnce}\\,\\mathrm{Inc} \\;\\Longleftrightarrow\\; \\mathrm{TwoLinesMeetOnce}\\,(\\mathrm{flip}\\,\\mathrm{Inc})$",
+    "significance": "critical",
+    "prerequisites": ["definitional equality", "Iff.rfl", "Function.flip"],
+    "relatedConcepts": ["point-line duality", "reflexivity proofs", "definitional identification"]
+  },
+  {
+    "id": "icbd-incidence-bound-dual",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 99 },
+    "type": "theorem",
+    "title": "Dual Incidence Bound (polynomial form)",
+    "content": "Under the dual hypothesis, I² ≤ |L|·|P|² + |L|·I — the forward polynomial bound with the roles of |P| and |L| exchanged. The proof is pure reuse: convert the dual hypothesis to TwoLinesMeetOnce (flip Inc), apply the forward theorem incidence_bound to the flipped structure, then rewrite the flip-invariant incidence count via incidences_flip. No combinatorial content is re-proved; the asymmetry of the forward bound is exploited by feeding it the mirror-image structure.",
+    "mathContext": "$I^2 \\le |L|\\cdot|P|^2 + |L|\\cdot I$",
+    "significance": "key",
+    "prerequisites": ["theorem reuse via flip", "incidences_flip", "rewriting hypotheses"],
+    "relatedConcepts": ["point-line duality", "dual bound", "asymmetric projection"]
+  },
+  {
+    "id": "icbd-incidence-bound-dual-sqrt",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 101, "endLine": 108 },
+    "type": "theorem",
+    "title": "Dual Incidence Bound (square-root form)",
+    "content": "The real-analytic dual: I ≤ |L| + |P|·√|L|, obtained the same way from the forward incidence_bound_sqrt applied to flip Inc and rewritten by incidences_flip. When there are far fewer lines than points this bound is sharper than the forward projection I ≤ |P| + |L|·√|P|, and vice versa — neither dominates.",
+    "mathContext": "$I \\le |L| + |P|\\cdot\\sqrt{|L|}$",
+    "significance": "key",
+    "prerequisites": ["theorem reuse via flip", "incidences_flip", "square-root incidence bound"],
+    "relatedConcepts": ["point-line duality", "O(n + m√n) incidence bound", "dual projection"]
+  },
+  {
+    "id": "icbd-incidence-bound-min",
+    "proofId": "prob-method-applications-oq-02-oq-02",
+    "range": { "startLine": 114, "endLine": 130 },
+    "type": "theorem",
+    "title": "Symmetric Minimum: I ≤ min of the Two Projections",
+    "content": "When both nondegeneracy axioms hold — the standard point-line incidence setting — the incidence count is bounded by the smaller of the two Cauchy–Schwarz projections: I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ). The proof is a one-line le_min of the forward and dual square-root bounds. This min is a genuine strengthening of either projection alone: when one side is much smaller than the other the corresponding term is sharper, so neither bound dominates. It is the honest ceiling of the elementary Cauchy–Schwarz argument — the sharp Szemerédi–Trotter exponent (|P||L|)^{2/3} lies strictly beyond it and needs crossing-number / planar-drawing infrastructure absent from Mathlib.",
+    "mathContext": "$I \\le \\min\\!\\big( |P| + |L|\\sqrt{|P|},\\; |L| + |P|\\sqrt{|L|} \\big)$",
+    "significance": "critical",
+    "prerequisites": ["le_min", "combining two upper bounds", "point-line duality"],
+    "relatedConcepts": ["symmetric incidence bound", "Szemerédi–Trotter theorem", "sharpness of Cauchy–Schwarz", "min of projections"]
+  }
+]

--- a/src/data/proofs/prob-method-applications-oq-02-oq-02/index.ts
+++ b/src/data/proofs/prob-method-applications-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/IncidenceCauchySchwarzDual.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodApplicationsOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodApplicationsOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodApplicationsOq02Oq02Data: ProofData = {
+  proof: probMethodApplicationsOq02Oq02Proof,
+  annotations: probMethodApplicationsOq02Oq02Annotations,
+}

--- a/src/data/proofs/prob-method-applications-oq-02-oq-02/meta.json
+++ b/src/data/proofs/prob-method-applications-oq-02-oq-02/meta.json
@@ -1,0 +1,226 @@
+{
+  "id": "prob-method-applications-oq-02-oq-02",
+  "title": "The Dual Incidence Bound and the Symmetric Cauchy–Schwarz Minimum",
+  "slug": "prob-method-applications-oq-02-oq-02",
+  "description": "The point-line dual of the elementary Cauchy–Schwarz incidence bound, together with the symmetric minimum that combines both projections. The sibling entry prob-method-applications-oq-02-oq-01 proves I² ≤ |P|·|L|² + |P|·I under the hypothesis that two distinct lines meet in at most one point — an asymmetric bound. Since the incidence count I is perfectly symmetric in points and lines, running the very same argument on the flipped relation flip Inc : L → P → Prop, under the dual hypothesis that two distinct points lie on at most one common line, yields the dual bound I² ≤ |L|·|P|² + |L|·I, equivalently I ≤ |L| + |P|·√|L|. When both nondegeneracy axioms hold (the standard point-line setting) the two projections combine to I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ), a genuine strengthening of either bound alone: neither term dominates, so the min is sharper whenever one side is much smaller than the other. This is obtained with no new combinatorics — the forward file's theorems are reused verbatim on the flipped structure after the single observation incidences (flip Inc) = incidences Inc (Fubini for the 0/1 incidence indicator). It is the symmetric completion of the infrastructure-free half of prob-method-applications OQ-02; the sharp Szemerédi–Trotter exponent (|P||L|)^{2/3} still lies beyond it, requiring crossing-number / planar-drawing infrastructure Mathlib does not provide. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (point-line duality of the Cauchy–Schwarz incidence bound), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Szemer%C3%A9di%E2%80%93Trotter_theorem",
+    "date": "1983",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IncidenceCauchySchwarzDual.lean",
+    "tags": [
+      "incidence-geometry",
+      "combinatorics",
+      "cauchy-schwarz",
+      "szemeredi-trotter",
+      "point-line-duality",
+      "double-counting",
+      "extremal-combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "∑ x ∈ s, ∑ y ∈ t, f x y = ∑ y ∈ t, ∑ x ∈ s, f x y. The single genuine step in incidences_flip: after expanding both incidence counts to double sums of 0/1 indicators, swapping the order of summation matches the flipped count to the original — the discrete Fubini principle that makes the whole duality free of new combinatorics.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.card_filter",
+        "description": "#{i ∈ s | p i} = ∑ i ∈ s, ite (p i) 1 0. Rewrites the degree cardinalities inside incidences into indicator sums so that Finset.sum_comm can act on them.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Piecewise"
+      },
+      {
+        "theorem": "Function.flip",
+        "description": "flip f b a = f a b. The dual relation flip Inc : L → P → Prop reverses the roles of points and lines; its defining reduction flip Inc ℓ p ≡ Inc p ℓ is what makes the flip decidability instance and the hypothesis identification (twoPointsJoinOnce_iff_flip) hold definitionally, so the forward theorems apply with no re-proof.",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "le_min",
+        "description": "a ≤ b → a ≤ c → a ≤ min b c. Assembles the forward square-root bound and the dual square-root bound into the single symmetric minimum I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ) in incidence_bound_min.",
+        "module": "Mathlib.Order.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "incidences_flip: the incidence count is invariant under exchanging points and lines, incidences (flip Inc) = incidences Inc. Expanding both counts to double sums of 0/1 indicators (card_filter) reduces the claim to a single Finset.sum_comm — discrete Fubini for the incidence indicator. This is the only genuine lemma the file needs and the hinge of the whole duality argument.",
+      "TwoPointsJoinOnce and twoPointsJoinOnce_iff_flip: the dual nondegeneracy hypothesis (two distinct points lie on at most one common line), together with the observation that it is *definitionally* TwoLinesMeetOnce applied to flip Inc (proved by Iff.rfl). This zero-cost identification lets the forward file's incidence_bound and incidence_bound_sqrt fire under the dual hypothesis with no re-derivation.",
+      "incidence_bound_dual: the dual polynomial bound I² ≤ |L|·|P|² + |L|·I, obtained by running the forward incidence_bound on the flipped structure and rewriting by incidences_flip. It exploits the asymmetry of the forward bound by feeding it the mirror-image incidence relation.",
+      "incidence_bound_dual_sqrt: the dual square-root bound I ≤ |L| + |P|·√|L|, the real-analytic corollary sharper than the forward projection whenever there are far fewer lines than points.",
+      "incidence_bound_min: the symmetric minimum I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ) under both nondegeneracy axioms — a one-line le_min of the forward and dual bounds. This min is a genuine strengthening of either projection alone (neither dominates) and is the sharpest estimate the elementary Cauchy–Schwarz argument can produce; the Szemerédi–Trotter exponent (|P||L|)^{2/3} lies strictly beyond it.",
+      "flipDecidable: a Decidable instance for flip Inc inherited from the ambient point-line decidability by definitional transport, the small bridge that makes reuse of the forward (decidability-requiring) theorems on the flipped relation possible."
+    ],
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "prob-method-applications-oq-02-oq-01",
+        "relationship": "Direct sibling and dependency. This file imports Proofs.IncidenceCauchySchwarz and reuses its incidence_bound and incidence_bound_sqrt verbatim on the flipped incidence relation. Where oq-01 proves the asymmetric forward projection I ≤ |P| + |L|·√|P|, this entry supplies the dual projection I ≤ |L| + |P|·√|L| and the symmetric minimum of the two, completing the elementary picture of OQ-02 in both directions."
+      },
+      {
+        "id": "prob-method-applications",
+        "relationship": "Addresses the open question OQ-02 ('can the crossing-number inequality be strengthened to the Szemerédi–Trotter form'). Together with the sibling forward bound, this entry pins down the sharpest elementary (Cauchy–Schwarz-only) incidence estimate; the sharp Szemerédi–Trotter exponent remains blocked pending a Mathlib formalization of planar graph drawings and crossing numbers."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The two mathematical hypotheses — TwoLinesMeetOnce (two distinct lines share at most one point) and TwoPointsJoinOnce (two distinct points share at most one line) — are inputs to the statements, not standing assumptions; together they are the defining nondegeneracy axioms of a point-line incidence structure. The point type P and line type L are arbitrary Fintypes with DecidableEq and a decidable incidence relation Inc : P → L → Prop. The file imports Proofs.IncidenceCauchySchwarz and reuses its 0-axiom theorems; #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Point-line incidence counts are symmetric in their two arguments: the number of incident (point, line) pairs is the same whether organized by point or by line. The elementary Cauchy–Schwarz bound I = O(m + n√m), however, is asymmetric — it isolates the points and sums over their degrees. Applying the identical argument with the roles reversed gives the dual bound I = O(n + m√n), and under both standard nondegeneracy axioms the two combine to the minimum of the two projections. This symmetric refinement is folklore — it appears implicitly wherever the Cauchy–Schwarz incidence bound is stated 'without loss of generality' — but is rarely written out. The formalization here makes the duality explicit and shows it costs nothing: the forward theorems are reused verbatim on the flipped relation. The sharp Szemerédi–Trotter bound I = O((mn)^{2/3} + m + n) (1983) still lies beyond this symmetric minimum and, per prob-method-applications OQ-02, requires crossing-number infrastructure Mathlib does not yet have.",
+    "problemStatement": "Let P be a finite set of 'points', L a finite set of 'lines', and Inc : P → L → Prop an incidence relation, with I = #{(p, ℓ) : Inc p ℓ} the number of incidences. Suppose two distinct points lie on at most one common line (the dual nondegeneracy axiom). Then I² ≤ |L|·|P|² + |L|·I, equivalently I ≤ |L| + |P|·√|L|. If in addition two distinct lines meet in at most one point, then I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ).",
+    "text": "The incidence count does not care whether we sum line-degrees over points or point-degrees over lines — that is Fubini for the 0/1 incidence indicator, and it says incidences (flip Inc) = incidences Inc. Consequently the entire forward argument, applied to the flipped incidence relation under the dual hypothesis 'two points join at most once', yields the dual bound with points and lines exchanged. When both nondegeneracy axioms hold, taking the smaller of the two square-root bounds gives a strictly better estimate than either alone: when |L| ≪ |P| the dual term |L| + |P|·√|L| wins, and when |P| ≪ |L| the forward term wins.",
+    "proofStrategy": "The file imports Proofs.IncidenceCauchySchwarz and reuses its theorems on the flipped relation flip Inc : L → P → Prop.\n\n1. **Decidability transport (flipDecidable).** flip Inc ℓ p reduces definitionally to Inc p ℓ, so the ambient decidability instance gives Decidable (flip Inc ℓ p) by inferInstance. This is required because the forward theorems assume a decidable incidence relation.\n\n2. **Flip-invariance of the count (incidences_flip).** Unfold incidences and deg, rewrite the filter cardinalities to indicator sums (Finset.card_filter), and swap the order of summation (Finset.sum_comm); the residual goal closes by reflexivity. Hence incidences (flip Inc) = incidences Inc — the only genuine lemma in the file.\n\n3. **Dual hypothesis identification (TwoPointsJoinOnce, twoPointsJoinOnce_iff_flip).** Define the dual axiom 'two distinct points share at most one line'. Because flip Inc p ℓ ≡ Inc ℓ p and the flip decidability instance is the ambient one, TwoPointsJoinOnce Inc is definitionally TwoLinesMeetOnce (flip Inc), proved by Iff.rfl.\n\n4. **Dual bounds (incidence_bound_dual, incidence_bound_dual_sqrt).** Convert the dual hypothesis to TwoLinesMeetOnce (flip Inc), apply the forward incidence_bound / incidence_bound_sqrt to flip Inc, and rewrite the incidence count with incidences_flip. This yields I² ≤ |L|·|P|² + |L|·I and I ≤ |L| + |P|·√|L|.\n\n5. **Symmetric minimum (incidence_bound_min).** Under both TwoLinesMeetOnce and TwoPointsJoinOnce, apply le_min to the forward and dual square-root bounds to conclude I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ).",
+    "keyInsights": [
+      "**Incidence counts are symmetric, but the Cauchy–Schwarz bound is not.** The asymmetry of I ≤ |P| + |L|·√|P| is entirely a choice of which side to sum over. Flipping that choice is free and gives an independent bound.",
+      "**Fubini is the whole engine.** incidences (flip Inc) = incidences Inc is a single Finset.sum_comm; every other theorem in the file is a mechanical reuse of the forward results rewritten by this identity.",
+      "**Definitional duality.** TwoPointsJoinOnce Inc is not merely equivalent to TwoLinesMeetOnce (flip Inc) — it is definitionally equal, so the identification is Iff.rfl and the forward theorems fire with zero glue.",
+      "**The min genuinely strengthens both projections.** Neither |P| + |L|·√|P| nor |L| + |P|·√|L| dominates the other; the min is sharper whenever one of |P|, |L| is much smaller than the other. It is the ceiling of the elementary argument.",
+      "**Still short of Szemerédi–Trotter.** Even the symmetric minimum has the elementary √-exponent; reaching (|P||L|)^{2/3} needs the crossing-number method and planar-drawing infrastructure that Mathlib lacks — the content of OQ-02's remaining, blocked half."
+    ],
+    "prerequisites": [
+      "The elementary Cauchy–Schwarz incidence bound (sibling entry prob-method-applications-oq-02-oq-01)",
+      "Point-line duality and the nondegeneracy axioms of a partial linear space",
+      "Fubini / swapping order of summation for finite double sums (Finset.sum_comm)",
+      "Definitional equality and Function.flip"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring and Flip Decidability",
+      "startLine": 1,
+      "endLine": 51,
+      "mathContext": "$\\mathrm{flip}\\,\\mathrm{Inc}\\,\\ell\\,p \\equiv \\mathrm{Inc}\\,p\\,\\ell$",
+      "summary": "Module docstring framing the result as the symmetric completion of the forward Cauchy–Schwarz incidence bound. Imports Proofs.IncidenceCauchySchwarz and supplies flipDecidable, the Decidable instance for flip Inc obtained from the ambient instance by definitional transport."
+    },
+    {
+      "id": "flip-invariance",
+      "title": "Incidences Are Flip-Invariant",
+      "startLine": 53,
+      "endLine": 67,
+      "mathContext": "$I(\\mathrm{flip}\\,\\mathrm{Inc}) = I(\\mathrm{Inc})$",
+      "summary": "incidences_flip: the sole genuine lemma. Expanding both counts to double sums of 0/1 indicators (card_filter) and swapping summation order (Finset.sum_comm) shows the incidence count is unchanged by exchanging points and lines — discrete Fubini for the incidence indicator."
+    },
+    {
+      "id": "dual-hypothesis",
+      "title": "The Dual Hypothesis",
+      "startLine": 69,
+      "endLine": 83,
+      "mathContext": "$\\mathrm{TwoPointsJoinOnce}\\,\\mathrm{Inc} \\Longleftrightarrow \\mathrm{TwoLinesMeetOnce}\\,(\\mathrm{flip}\\,\\mathrm{Inc})$",
+      "summary": "TwoPointsJoinOnce encodes 'two distinct points share at most one line'. twoPointsJoinOnce_iff_flip proves it is definitionally the once-meeting hypothesis on the flipped relation (Iff.rfl), the identification that lets the forward theorems be reused with no glue."
+    },
+    {
+      "id": "dual-bounds",
+      "title": "The Dual Incidence Bounds",
+      "startLine": 85,
+      "endLine": 108,
+      "mathContext": "$I^2 \\le |L|\\cdot|P|^2 + |L|\\cdot I, \\qquad I \\le |L| + |P|\\sqrt{|L|}$",
+      "summary": "incidence_bound_dual and incidence_bound_dual_sqrt run the forward incidence_bound / incidence_bound_sqrt on flip Inc under the dual hypothesis and rewrite by incidences_flip, producing the polynomial and square-root dual bounds with points and lines exchanged."
+    },
+    {
+      "id": "symmetric-min",
+      "title": "The Symmetric Minimum",
+      "startLine": 110,
+      "endLine": 132,
+      "mathContext": "$I \\le \\min\\!\\big(|P| + |L|\\sqrt{|P|},\\; |L| + |P|\\sqrt{|L|}\\big)$",
+      "summary": "incidence_bound_min applies le_min to the forward and dual square-root bounds under both nondegeneracy axioms. The min strictly improves on either projection (neither dominates) and is the sharpest bound the elementary Cauchy–Schwarz argument can give."
+    }
+  ],
+  "conclusion": {
+    "summary": "The point-line dual of the elementary Cauchy–Schwarz incidence bound: under the dual nondegeneracy axiom (two distinct points share at most one line) the incidence count satisfies I² ≤ |L|·|P|² + |L|·I, i.e. I ≤ |L| + |P|·√|L|; and under both axioms it is bounded by the symmetric minimum I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ). Zero sorries, zero axioms. Every result is a mechanical reuse of the sibling forward file, pivoted on the single Fubini identity incidences (flip Inc) = incidences Inc.",
+    "implications": "This entry completes the elementary picture of prob-method-applications OQ-02 in both projections and records the sharpest estimate the Cauchy–Schwarz argument yields — the symmetric minimum of the two √-bounds. It demonstrates a clean, reusable duality pattern: an asymmetric combinatorial bound can be doubled for free by running it on the flipped relation once the underlying count is shown Fubini-invariant. The sharp Szemerédi–Trotter exponent (|P||L|)^{2/3} still lies strictly beyond the symmetric minimum and remains blocked pending a Mathlib theory of planar graph drawings and crossing numbers.",
+    "openQuestions": [
+      "Exhibit incidence structures where each projection of the symmetric minimum is attained, showing the min is tight and that neither √-bound dominates.",
+      "Formalize the crossing-number inequality cr(G) ≥ e³/(64 n²) and planar graph drawings in Mathlib, the missing infrastructure for OQ-02's route to the sharp Szemerédi–Trotter exponent.",
+      "Derive the Kővári–Sós–Turán / C₄-free reformulation of the incidence graph, a different reusable lemma of the same √-order."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-applications-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Imports and reuses the forward incidence_bound and incidence_bound_sqrt on the flipped incidence relation to obtain the dual projection and the symmetric minimum. This entry is the point-line dual completion of the sibling."
+    },
+    {
+      "targetId": "prob-method-applications",
+      "relationship": "extends",
+      "description": "Supplies, with the sibling, the sharpest elementary Cauchy–Schwarz incidence estimate underlying OQ-02; the crossing-number / Szemerédi–Trotter strengthening remains blocked without planar-drawing infrastructure."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/IncidenceCauchySchwarzDual.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.IncidenceCauchySchwarz"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "ProbMethod.Incidence",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 5
+  },
+  "references": [
+    {
+      "authors": "Szemerédi, Endre; Trotter, William T.",
+      "title": "Extremal problems in discrete geometry",
+      "year": "1983",
+      "venue": "Combinatorica 3, 381–392",
+      "note": "Proves the sharp incidence bound I = O((mn)^{2/3} + m + n) that strengthens the elementary Cauchy–Schwarz bounds (forward and dual) formalized here and in the sibling."
+    },
+    {
+      "authors": "Székely, László A.",
+      "title": "Crossing numbers and hard Erdős problems in discrete geometry",
+      "year": "1997",
+      "venue": "Combinatorics, Probability and Computing 6, 353–358",
+      "note": "Short proof of Szemerédi–Trotter via the crossing-number inequality — the route referenced by prob-method-applications OQ-02."
+    },
+    {
+      "authors": "Tao, Terence; Vu, Van H.",
+      "title": "Additive Combinatorics",
+      "year": "2006",
+      "venue": "Cambridge University Press",
+      "note": "Section 8.1 gives the Cauchy–Schwarz incidence bound; the symmetric (both-projection) form is the standard 'without loss of generality' refinement made explicit here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "incidence_bound_min",
+      "type": "core",
+      "description": "Under both nondegeneracy axioms, the incidence count is bounded by the smaller of the two Cauchy–Schwarz projections: I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| ).",
+      "leanType": "TwoLinesMeetOnce Inc → TwoPointsJoinOnce Inc → (incidences Inc : ℝ) ≤ min (Fintype.card P + Fintype.card L * Real.sqrt (Fintype.card P)) (Fintype.card L + Fintype.card P * Real.sqrt (Fintype.card L))"
+    },
+    {
+      "name": "incidence_bound_dual",
+      "type": "core",
+      "description": "The dual polynomial bound under the hypothesis that two distinct points share at most one line: I² ≤ |L|·|P|² + |L|·I.",
+      "leanType": "TwoPointsJoinOnce Inc → incidences Inc ^ 2 ≤ Fintype.card L * Fintype.card P ^ 2 + Fintype.card L * incidences Inc"
+    },
+    {
+      "name": "incidence_bound_dual_sqrt",
+      "type": "core",
+      "description": "The square-root form of the dual bound: I ≤ |L| + |P|·√|L|.",
+      "leanType": "TwoPointsJoinOnce Inc → (incidences Inc : ℝ) ≤ Fintype.card L + Fintype.card P * Real.sqrt (Fintype.card L)"
+    },
+    {
+      "name": "incidences_flip",
+      "type": "supporting",
+      "description": "The incidence count is invariant under exchanging points and lines: incidences (flip Inc) = incidences Inc. Discrete Fubini for the 0/1 incidence indicator, via Finset.sum_comm. The pivot of the whole duality.",
+      "leanType": "incidences (flip Inc) = incidences Inc"
+    },
+    {
+      "name": "twoPointsJoinOnce_iff_flip",
+      "type": "supporting",
+      "description": "The dual hypothesis is definitionally the once-meeting hypothesis on the flipped relation, proved by Iff.rfl.",
+      "leanType": "TwoPointsJoinOnce Inc ↔ TwoLinesMeetOnce (flip Inc)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Research session for **prob-method-applications-oq-02** (claimed by researcher-13).

The prior session (researcher-1, #28712) wrote `proofs/Proofs/IncidenceCauchySchwarzDual.lean` but left it **build-pending** — Docker was down, so it was never machine-checked, and no gallery entry was minted. This session **verifies** that file and creates the gallery entry.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.IncidenceCauchySchwarzDual` → **exit 0 (Build succeeded)**, run twice.
- File is **0 sorries, 0 axioms, no `native_decide`** (grep-confirmed; `#print axioms` reports only propext/Classical.choice/Quot.sound, both here and in the imported forward file).
- The file is auto-discovered by the Lake glob in `proofs/lakefile.toml`, so it is already in the build graph on `main`.

## What the entry proves

Point-line dual of the sibling `prob-method-applications-oq-02-oq-01`. Since the incidence count `I` is symmetric in points and lines (`incidences (flip Inc) = incidences Inc`, one `Finset.sum_comm`), the forward Cauchy–Schwarz argument runs verbatim on the flipped relation:

- `incidence_bound_dual` — under "two distinct points share at most one line": `I² ≤ |L|·|P|² + |L|·I`
- `incidence_bound_dual_sqrt` — `I ≤ |L| + |P|·√|L|`
- `incidence_bound_min` — under both nondegeneracy axioms: `I ≤ min( |P| + |L|·√|P| , |L| + |P|·√|L| )`, a genuine strengthening of either projection (neither dominates)

No new combinatorics: every theorem reuses the forward file's `incidence_bound` / `incidence_bound_sqrt` on `flip Inc`, pivoted on the Fubini identity. 5 theorems / 1 def / 132 lines.

## Files

- `src/data/proofs/prob-method-applications-oq-02-oq-02/meta.json`
- `src/data/proofs/prob-method-applications-oq-02-oq-02/annotations.json` (7 annotations, ranges validated against the 132-line file)
- `src/data/proofs/prob-method-applications-oq-02-oq-02/index.ts`

`listings.json` / `data-manifest.json` are regenerated by the deployer's `pnpm build`.

## Status

**Outcome**: completed — build-pending file verified, verified gallery sibling minted.
**Next Steps**: The sharp Szemerédi–Trotter exponent `(|P||L|)^{2/3}` remains **BLOCKED** (needs a Mathlib crossing-number / planar-drawing library, >1000 lines). This entry is the honest elementary ceiling of OQ-02 in both projections.

🤖 Generated by researcher-13