### PR TITLE
research(nth-root-irrational-oq-02-oq-02): general prime-exponent irrationality criterion [BUILD-BLOCKED]

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ02OQ02.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ02OQ02.lean
@@ -1,0 +1,166 @@
+/-
+  Nth Root Irrationality OQ-02-OQ-02:
+  The general prime-exponent criterion for irrationality of ⁿ√m,
+  and radicands that no "prime-appears-exactly-once" argument can reach.
+
+  The parent file `NthRootIrrationalOQ02.lean` established the uniform
+  prime-factorization criterion for *not being a perfect power*
+  (`not_perfect_pow_of_factorization`: a single prime `p` with `n ∤ m.factorization p`
+  certifies that `m` is not a perfect `n`-th power).  However, the *irrationality*
+  corollaries it exposes all flow through the special case where a prime divides
+  `m` **exactly once** (`irrational_nthRoot_of_sq_not_dvd`, hypotheses `p ∣ m`,
+  `p² ∤ m`), or where the radicand is itself prime (`irrational_nthRoot_prime`).
+
+  That "exactly once" hypothesis is *strictly weaker* than the general criterion.
+  Consider `m = 36 = 2² · 3²`.  **No** prime divides `36` exactly once — every
+  prime factor appears squared — so `not_perfect_pow_of_sq_not_dvd` (hence
+  `irrational_nthRoot_of_sq_not_dvd`) is simply inapplicable.  Yet `∛36` is
+  irrational, because `36` is not a perfect *cube*: the exponent `2` of the prime
+  `3` is not divisible by `3`.  Reaching such radicands requires the full
+  criterion `¬ n ∣ m.factorization p` with an arbitrary exponent, not just `1`.
+
+  This file supplies that missing capstone:
+
+  * `not_perfect_pow_of_pow_dvd_not_dvd` — the general "exponent `a`" criterion:
+    if `pᵃ ∣ m`, `pᵃ⁺¹ ∤ m` (so `p` appears to exponent exactly `a`) and `n ∤ a`,
+    then `m` is not a perfect `n`-th power.  Specializes to
+    `not_perfect_pow_of_sq_not_dvd` at `a = 1`, and its two divisibility
+    hypotheses are size-independent `decide`s on concrete radicands.
+  * `irrational_nthRoot_of_pow_dvd_not_dvd` — the irrationality corollary,
+    obtained by feeding the criterion through the parent's `not_perfect_pow_int`
+    and the base `irrational_nthRoot`.
+  * `irrational_nthRoot_of_factorization_not_dvd` — the same statement phrased
+    directly against `m.factorization p`, the cleanest form of the criterion.
+  * Concrete irrationalities that the "exactly once" argument cannot certify,
+    because their radicands have **no** prime factor of multiplicity `1`:
+    `∛36`, `⁴√36`, `∛100`, and `⁶√216` (note `216 = 6³` is a perfect *cube*
+    but not a perfect *sixth* power).
+  * `thirtySix_has_no_multiplicity_one_prime` — a certificate that `36` genuinely
+    lies outside the reach of the parent's exactly-once lemma, so the
+    generalization here is necessary, not cosmetic.
+
+  Results (0 axioms, 0 sorries): a strict generalization of the parent's
+  irrationality corollaries, plus witnesses separating the two.
+-/
+
+import Mathlib
+import Proofs.NthRootIrrational
+import Proofs.NthRootIrrationalOQ02
+
+set_option maxHeartbeats 1000000
+
+namespace NthRootIrrationalOQ02OQ02
+
+open NthRootIrrational NthRootIrrationalOQ02
+
+/-! ## Part 1: The General Exponent Criterion
+
+`not_perfect_pow_of_sq_not_dvd` (parent) fixes the multiplicity of the witnessing
+prime at `1`.  Here we allow an arbitrary multiplicity `a`: if `p` appears in `m`
+to exponent exactly `a` (pinned by `pᵃ ∣ m` and `pᵃ⁺¹ ∤ m`) and `n ∤ a`, then `m`
+is not a perfect `n`-th power.  The proof reads the exact exponent off the two
+`pow_dvd_iff_le_factorization` bounds and hands it to
+`not_perfect_pow_of_factorization`. -/
+
+/-- **General not-a-perfect-power criterion by pinned multiplicity.**  If the prime
+`p` divides `m` to exponent exactly `a` (`pᵃ ∣ m`, `pᵃ⁺¹ ∤ m`) and `n ∤ a`, then
+`m` is not a perfect `n`-th power.  At `a = 1` this is the parent's
+`not_perfect_pow_of_sq_not_dvd`. -/
+theorem not_perfect_pow_of_pow_dvd_not_dvd {m n p a : ℕ} (hp : p.Prime) (hm : m ≠ 0)
+    (hd : p ^ a ∣ m) (hnd : ¬ p ^ (a + 1) ∣ m) (hna : ¬ n ∣ a) :
+    ¬ ∃ k : ℕ, k ^ n = m := by
+  apply not_perfect_pow_of_factorization (p := p)
+  have hle : a ≤ m.factorization p :=
+    (hp.pow_dvd_iff_le_factorization hm).mp hd
+  have hlt : ¬ a + 1 ≤ m.factorization p := fun h =>
+    hnd ((hp.pow_dvd_iff_le_factorization hm).mpr h)
+  have heq : m.factorization p = a := by omega
+  rwa [heq]
+
+/-! ## Part 2: Irrationality Corollaries
+
+Feed the general criterion through the parent's `ℕ ⟹ ℤ` bridge and the base
+`irrational_nthRoot`. -/
+
+/-- **Irrationality of `ⁿ√m` from a pinned prime multiplicity not divisible by `n`.**
+If some prime `p` appears in `m` to exponent exactly `a` with `n ∤ a`, then `ⁿ√m`
+is irrational.  Generalizes `irrational_nthRoot_of_sq_not_dvd` (the `a = 1` case). -/
+theorem irrational_nthRoot_of_pow_dvd_not_dvd {m n p a : ℕ} (hn : 1 < n) (hp : p.Prime)
+    (hm : m ≠ 0) (hd : p ^ a ∣ m) (hnd : ¬ p ^ (a + 1) ∣ m) (hna : ¬ n ∣ a) :
+    Irrational (nthRoot n m) :=
+  irrational_nthRoot n m hn
+    (not_perfect_pow_int (not_perfect_pow_of_pow_dvd_not_dvd hp hm hd hnd hna))
+
+/-- **Irrationality of `ⁿ√m` directly from the factorization criterion.**  The
+cleanest packaging: if the exponent `m.factorization p` of some prime `p` is not
+divisible by `n`, then `ⁿ√m` is irrational.  This is the general form the parent's
+exactly-once and prime corollaries are instances of. -/
+theorem irrational_nthRoot_of_factorization_not_dvd {m n p : ℕ} (hn : 1 < n)
+    (hndvd : ¬ n ∣ m.factorization p) :
+    Irrational (nthRoot n m) :=
+  irrational_nthRoot n m hn
+    (not_perfect_pow_int (not_perfect_pow_of_factorization hndvd))
+
+/-! ## Part 3: Radicands With No Multiplicity-One Prime
+
+Each radicand below is a product of squared primes, so the parent's
+`irrational_nthRoot_of_sq_not_dvd` — which needs a prime `p` with `p ∣ m` and
+`p² ∤ m` — cannot be applied to any of them.  The general criterion certifies
+their irrationality with the same cheap, size-independent divisibility checks. -/
+
+/-- `∛36` irrational.  `36 = 2² · 3²`; witness the prime `3` at multiplicity `2`
+(`9 ∣ 36`, `27 ∤ 36`), and `3 ∤ 2`.  No prime divides `36` exactly once, so the
+parent's `sq_not_dvd` corollary does not apply. -/
+theorem irrational_cbrt_36 : Irrational (nthRoot 3 36) :=
+  irrational_nthRoot_of_pow_dvd_not_dvd (by norm_num) (p := 3) (a := 2)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-- `⁴√36` irrational.  Same radicand; the prime `2` at multiplicity `2`
+(`4 ∣ 36`, `8 ∤ 36`) works since `4 ∤ 2`. -/
+theorem irrational_fourthRoot_36 : Irrational (nthRoot 4 36) :=
+  irrational_nthRoot_of_pow_dvd_not_dvd (by norm_num) (p := 2) (a := 2)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-- `∛100` irrational.  `100 = 2² · 5²`; witness the prime `5` at multiplicity `2`
+(`25 ∣ 100`, `125 ∤ 100`), and `3 ∤ 2`.  Again no prime appears exactly once. -/
+theorem irrational_cbrt_100 : Irrational (nthRoot 3 100) :=
+  irrational_nthRoot_of_pow_dvd_not_dvd (by norm_num) (p := 5) (a := 2)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-- `⁶√216` irrational — a striking separation.  `216 = 6³ = 2³ · 3³` is a
+*perfect cube*, hence `∛216 = 6` is rational; but it is **not** a perfect sixth
+power.  Witness the prime `2` at multiplicity `3` (`8 ∣ 216`, `16 ∤ 216`), and
+`6 ∤ 3`.  A per-prime multiplicity that is a proper divisor of `n` — not `1` —
+is exactly what the general criterion is for. -/
+theorem irrational_sixthRoot_216 : Irrational (nthRoot 6 216) :=
+  irrational_nthRoot_of_pow_dvd_not_dvd (by norm_num) (p := 2) (a := 3)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-- `√72` irrational.  `72 = 2³ · 3²` — the exact radicand the parent entry's
+open-questions list named as beyond the reach of its exactly-once corollary
+(every prime exponent is `≥ 2`).  Witness the prime `2` at multiplicity `3`
+(`8 ∣ 72`, `16 ∤ 72`), and `2 ∤ 3`. -/
+theorem irrational_sqrt_72 : Irrational (nthRoot 2 72) :=
+  irrational_nthRoot_of_pow_dvd_not_dvd (by norm_num) (p := 2) (a := 3)
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-! ## Part 4: Certifying the Gap
+
+To confirm the generalization is necessary and not cosmetic, we record that `36`
+has no prime factor of multiplicity one: for every prime `p` dividing `36`, in
+fact `p² ∣ 36`.  Consequently the parent's `not_perfect_pow_of_sq_not_dvd` (which
+requires `p ∣ m` together with `p² ∤ m`) has *no* applicable witness for `36`,
+whereas `irrational_cbrt_36` above still certifies `∛36` irrational. -/
+
+/-- **`36` has no multiplicity-one prime.**  Every prime dividing `36` divides it
+at least twice, so the exactly-once hypothesis `p² ∤ 36` fails for all of them —
+the parent's `sq_not_dvd` route is unavailable for this radicand. -/
+theorem thirtySix_has_no_multiplicity_one_prime :
+    ∀ p : ℕ, p.Prime → p ∣ 36 → p ^ 2 ∣ 36 := by
+  intro p hp hd
+  -- The only primes dividing 36 = 2² · 3² are 2 and 3, each to exponent 2.
+  have h2 : 2 ≤ p := hp.two_le
+  have h36 : p ≤ 36 := Nat.le_of_dvd (by norm_num) hd
+  interval_cases p <;> revert hp hd <;> decide
+
+end NthRootIrrationalOQ02OQ02

--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-general-criterion",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "The General Exponent Criterion",
+    "content": "Proves `not_perfect_pow_of_pow_dvd_not_dvd`: if a prime `p` divides `m` to exponent exactly `a` and `n ∤ a`, then `m` is not a perfect `n`-th power.\n\n**Proof.** The two hypotheses `p^a ∣ m` and `p^(a+1) ∤ m` pin the p-adic valuation exactly: `Nat.Prime.pow_dvd_iff_le_factorization` turns `p^a ∣ m` into `a ≤ m.factorization p`, and the failure of `p^(a+1) ∣ m` into `¬ (a+1) ≤ m.factorization p`; `omega` concludes `m.factorization p = a`. Rewriting, the hypothesis `n ∤ a` becomes `n ∤ m.factorization p`, and the parent's `not_perfect_pow_of_factorization` finishes.\n\nAt `a = 1` this is exactly the parent's `not_perfect_pow_of_sq_not_dvd`; allowing arbitrary `a` is the whole point — it removes the artificial restriction to primes of multiplicity one.",
+    "mathContext": "From $p^a \\parallel m$ (i.e. $v_p(m) = a$) and $n \\nmid a$, the prime $p$ witnesses that $m$ is not a perfect $n$-th power. The parent's exactly-once lemma is the special case $a = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "Nat.Prime.pow_dvd_iff_le_factorization",
+      "perfect power",
+      "pinned multiplicity"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "the parent criterion not_perfect_pow_of_factorization"
+    ]
+  },
+  {
+    "id": "ann-general-irrationality",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 103
+    },
+    "type": "concept",
+    "title": "General Irrationality Corollaries",
+    "content": "Two packagings of the criterion as irrationality statements, each a single term-mode line composing the general criterion with the parent's `not_perfect_pow_int` bridge and the base `irrational_nthRoot`.\n\n`irrational_nthRoot_of_pow_dvd_not_dvd`: from a pinned multiplicity `a` with `n ∤ a`, concludes `Irrational (nthRoot n m)`. Generalizes the parent's `irrational_nthRoot_of_sq_not_dvd`.\n\n`irrational_nthRoot_of_factorization_not_dvd`: the cleanest form — states the hypothesis directly as `¬ n ∣ m.factorization p`. This is the general theorem of which the parent's prime and exactly-once corollaries are instances.",
+    "mathContext": "$n \\nmid v_p(m) \\Rightarrow \\sqrt[n]{m} \\notin \\mathbb{Q}$, for any prime $p$ and any multiplicity, obtained by feeding the criterion through the base general theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "irrational_nthRoot",
+      "Irrational",
+      "term-mode proof"
+    ],
+    "prerequisites": [
+      "the general exponent criterion",
+      "base nth-root general theorem"
+    ]
+  },
+  {
+    "id": "ann-no-mult-one",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 104,
+      "endLine": 146
+    },
+    "type": "concept",
+    "title": "Radicands With No Multiplicity-One Prime",
+    "content": "Concrete irrationalities that the parent's exactly-once corollary cannot certify, because their radicands have no prime factor of multiplicity `1`.\n\n`irrational_cbrt_36`, `irrational_fourthRoot_36`: `36 = 2² · 3²` — witnessed by a squared prime (`9 ∣ 36`, `27 ∤ 36`) with `3 ∤ 2` (resp. `2` with `4 ∤ 2`).\n`irrational_cbrt_100`: `100 = 2² · 5²`, witnessed by `5` at multiplicity `2`.\n`irrational_sqrt_72`: `72 = 2³ · 3²` — the exact radicand named in the parent's open-questions list — witnessed by `2` at multiplicity `3`.\n`irrational_sixthRoot_216`: `216 = 6³ = 2³ · 3³` is a perfect cube (`∛216 = 6` is rational) yet not a perfect sixth power; witnessed by `2` at multiplicity `3` with `6 ∤ 3`. This is the sharpest separation: the exactly-once test cannot even be stated for `216`, let alone distinguish `∛216` from `⁶√216`.\n\nAll witnessing divisibilities are size-independent `norm_num` checks.",
+    "mathContext": "$36 = 2^2 3^2$, $100 = 2^2 5^2$, $72 = 2^3 3^2$, $216 = 6^3$. None has a prime of multiplicity 1, so each requires the general criterion; each is certified by a squared or cubed prime whose exponent is not divisible by $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect power separation",
+      "composite radicands",
+      "216 = 6³"
+    ],
+    "prerequisites": [
+      "the general irrationality corollaries"
+    ]
+  },
+  {
+    "id": "ann-gap-certificate",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 147,
+      "endLine": 166
+    },
+    "type": "concept",
+    "title": "Certifying the Gap",
+    "content": "Proves `thirtySix_has_no_multiplicity_one_prime`: every prime `p` dividing `36` in fact has `p² ∣ 36`. The proof bounds `p` by `Nat.le_of_dvd` (so `2 ≤ p ≤ 36`), runs `interval_cases p`, and discharges each concrete case by `decide` after reverting the primality and divisibility hypotheses — the non-prime and non-divisor values close vacuously, and the genuine witnesses `2, 3` satisfy `p² ∣ 36`.\n\nThis certifies that the parent's `not_perfect_pow_of_sq_not_dvd` (which needs a prime with `p² ∤ m`) has no applicable witness for `36`, so the general criterion of this entry is necessary — not a cosmetic restatement.",
+    "mathContext": "$\\forall p$ prime, $p \\mid 36 \\Rightarrow p^2 \\mid 36$. The exactly-once hypothesis $p^2 \\nmid m$ fails for every prime, while the general criterion still certifies $\\sqrt[3]{36}$ irrational.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval_cases",
+      "necessity of the generalization",
+      "squarefree"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "the parent exactly-once corollary"
+    ]
+  }
+]

--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "nth-root-irrational-oq-02-oq-02",
+  "title": "Nth Root Irrationality: The General Prime-Exponent Criterion",
+  "slug": "nth-root-irrational-oq-02-oq-02",
+  "description": "Answers an open question of the parent entry: exposes the general prime-exponent criterion for irrationality of the nth root of m, reaching radicands all of whose prime factors have multiplicity at least 2 (e.g. 36 = 2²·3², 72 = 2³·3², 216 = 6³). These lie strictly beyond the parent's 'a prime divides m exactly once' corollary, since no prime divides them exactly once, yet their nth roots are irrational because some prime exponent is not divisible by n.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "generalization",
+      "prime-factorization",
+      "research"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/NthRootIrrationalOQ02OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "p^k ∣ m ↔ k ≤ m.factorization p, for prime p and m ≠ 0 — reads the exact prime multiplicity off two divisibility bounds",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "irrational_nthRoot",
+        "description": "Base-file general theorem: not a perfect nth power over ℤ implies the nth root is irrational",
+        "module": "Proofs.NthRootIrrational"
+      },
+      {
+        "theorem": "not_perfect_pow_of_factorization",
+        "description": "Parent criterion: a prime exponent not divisible by n certifies m is not a perfect nth power",
+        "module": "Proofs.NthRootIrrationalOQ02"
+      },
+      {
+        "theorem": "not_perfect_pow_int",
+        "description": "Parent ℕ⟹ℤ bridge: ruling out natural nth roots rules out integer nth roots via Int.natAbs",
+        "module": "Proofs.NthRootIrrationalOQ02"
+      }
+    ],
+    "originalContributions": [
+      "not_perfect_pow_of_pow_dvd_not_dvd: the general pinned-multiplicity criterion — a prime of exponent exactly a with n ∤ a certifies m is not a perfect nth power, strictly generalizing the parent's exactly-once (a = 1) lemma",
+      "irrational_nthRoot_of_pow_dvd_not_dvd and irrational_nthRoot_of_factorization_not_dvd: the general irrationality corollaries, phrased both via pinned multiplicity and directly against m.factorization p",
+      "Concrete irrationalities of radicands with no multiplicity-one prime, unreachable by the parent's sq_not_dvd corollary: cbrt(36), fourthRoot(36), cbrt(100), sixthRoot(216), sqrt(72)",
+      "sixthRoot(216): 216 = 6³ is a perfect cube (∛216 = 6 is rational) yet not a perfect sixth power — a striking separation certified by the exponent-3 witness with 6 ∤ 3",
+      "thirtySix_has_no_multiplicity_one_prime: a machine-checked certificate that 36 lies outside the reach of the parent's exactly-once corollary, so the generalization is necessary"
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 166,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Builds on the parent entry's verified criterion (not_perfect_pow_of_factorization, not_perfect_pow_int) and the base file's verified general theorem irrational_nthRoot.",
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean",
+      "Proofs/NthRootIrrationalOQ02.lean"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry nth-root-irrational-oq-02 introduced the uniform prime-factorization criterion for 'not a perfect nth power' (a prime p with n ∤ v_p(m) certifies it), but its irrationality corollaries only exposed the special case where a prime divides the radicand exactly once (p ∣ m, p² ∤ m). Its own open-questions list asked whether the general criterion 'can be exposed ergonomically for radicands all of whose prime exponents are ≥ 2 but not all divisible by n (e.g. 72 = 2³·3²)'. This entry answers that question, exposing the full pinned-multiplicity criterion and certifying exactly such radicands.",
+    "problemStatement": "The parent's ergonomic irrationality corollary requires a prime dividing the radicand exactly once. But radicands like $36 = 2^2\\cdot 3^2$ have no such prime — every prime factor is squared — so the corollary does not apply, even though $\\sqrt[3]{36}$ is irrational ($3 \\nmid v_3(36) = 2$). Expose the general criterion:\n\n$$\\exists p \\text{ prime},\\; p^a \\parallel m \\text{ and } n \\nmid a \\;\\Longrightarrow\\; \\sqrt[n]{m}\\notin\\mathbb{Q},$$\n\nfor an arbitrary multiplicity $a$, and certify radicands with no multiplicity-one prime.",
+    "text": "The general prime-exponent criterion for irrationality of nth roots, reaching radicands whose every prime factor has multiplicity at least two — strictly beyond the parent's exactly-once corollary.",
+    "proofStrategy": "1. **General criterion** (`not_perfect_pow_of_pow_dvd_not_dvd`): from `p^a ∣ m` and `p^(a+1) ∤ m`, `Nat.Prime.pow_dvd_iff_le_factorization` pins `m.factorization p = a`; if `n ∤ a` the parent's `not_perfect_pow_of_factorization` applies. This specializes to the parent's `not_perfect_pow_of_sq_not_dvd` at `a = 1`.\n\n2. **Irrationality** (`irrational_nthRoot_of_pow_dvd_not_dvd`, `irrational_nthRoot_of_factorization_not_dvd`): compose with the parent's `not_perfect_pow_int` bridge and the base `irrational_nthRoot`.\n\n3. **Concrete radicands**: for `36, 72, 100, 216`, the witnessing divisibilities (`8 ∣ 216`, `16 ∤ 216`, etc.) are size-independent `norm_num` checks; the multiplicity is `2` or `3`, never `1`.\n\n4. **Gap certificate** (`thirtySix_has_no_multiplicity_one_prime`): every prime dividing `36` has its square dividing `36`, so the parent's exactly-once route has no applicable witness.",
+    "keyInsights": [
+      "The parent's exactly-once corollary is a proper special case: pinning the witnessing prime's multiplicity at 1 is a convenience, not a necessity. Allowing an arbitrary exponent a (with n ∤ a) recovers the full strength of the factorization criterion.",
+      "Radicands like 36 = 2²·3² have no prime of multiplicity one, so they are provably outside the parent corollary's reach, yet their nth roots are irrational — a concrete separation between the two criteria.",
+      "216 = 6³ is a perfect cube but not a perfect sixth power: ∛216 = 6 is rational while ⁶√216 is irrational. The general criterion detects this via the exponent-3 witness (6 ∤ 3), whereas 'exactly once' can say nothing.",
+      "The exact multiplicity a is read off two cheap divisibility facts (p^a ∣ m, p^(a+1) ∤ m) via pow_dvd_iff_le_factorization, so certifying any concrete radicand remains a size-independent computation."
+    ],
+    "prerequisites": [
+      "The parent entry nth-root-irrational-oq-02 (uniform prime-factorization criterion, not_perfect_pow_of_factorization, not_perfect_pow_int)",
+      "The base entry nth-root-irrational (general theorem irrational_nthRoot)",
+      "Number theory (p-adic valuation / Nat.factorization, perfect powers)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup and Motivation",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module documentation isolating the gap in the parent's irrationality corollaries (exactly-once vs. general multiplicity), imports, and namespace opening the base and parent files.",
+      "mathContext": "Reuses nthRoot, irrational_nthRoot (base) and not_perfect_pow_of_factorization, not_perfect_pow_int (parent). The target is the criterion $n \\nmid v_p(m)$ for arbitrary $v_p(m)$, not only $v_p(m) = 1$."
+    },
+    {
+      "id": "criterion",
+      "title": "The General Exponent Criterion",
+      "startLine": 56,
+      "endLine": 79,
+      "summary": "not_perfect_pow_of_pow_dvd_not_dvd: a prime of exponent exactly a with n ∤ a certifies m is not a perfect nth power.",
+      "mathContext": "From $p^a \\mid m$ and $p^{a+1} \\nmid m$, `Nat.Prime.pow_dvd_iff_le_factorization` gives $v_p(m) = a$; with $n \\nmid a$ the parent criterion applies. At $a = 1$ this is `not_perfect_pow_of_sq_not_dvd`."
+    },
+    {
+      "id": "irrationality",
+      "title": "General Irrationality Corollaries",
+      "startLine": 80,
+      "endLine": 103,
+      "summary": "irrational_nthRoot_of_pow_dvd_not_dvd and irrational_nthRoot_of_factorization_not_dvd, composing the criterion with the parent bridge and base theorem.",
+      "mathContext": "Feeding the general criterion through `not_perfect_pow_int` and `irrational_nthRoot` yields $\\sqrt[n]{m}\\notin\\mathbb{Q}$ from any pinned prime multiplicity $a$ with $n \\nmid a$, or directly from $n \\nmid v_p(m)$."
+    },
+    {
+      "id": "concrete",
+      "title": "Radicands With No Multiplicity-One Prime",
+      "startLine": 104,
+      "endLine": 146,
+      "summary": "Irrationality of cbrt(36), fourthRoot(36), cbrt(100), sixthRoot(216), sqrt(72) — radicands whose prime factors are all squared or cubed, unreachable by the parent's exactly-once corollary.",
+      "mathContext": "$36 = 2^2\\cdot3^2$, $100 = 2^2\\cdot5^2$, $72 = 2^3\\cdot3^2$, $216 = 6^3 = 2^3\\cdot3^3$. None has a prime of multiplicity 1; each is certified by a squared or cubed prime whose exponent is not divisible by $n$."
+    },
+    {
+      "id": "gap",
+      "title": "Certifying the Gap",
+      "startLine": 147,
+      "endLine": 166,
+      "summary": "thirtySix_has_no_multiplicity_one_prime: every prime dividing 36 has its square dividing 36, so the parent's exactly-once route is unavailable — the generalization is necessary.",
+      "mathContext": "For all primes $p \\mid 36$, in fact $p^2 \\mid 36$. Hence the parent's hypothesis $p^2 \\nmid m$ fails for every prime, while the general criterion still certifies $\\sqrt[3]{36}$ irrational."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers open question 2 of the parent nth-root-irrational-oq-02: the ergonomic irrationality corollary is generalized from the exactly-once case (a prime dividing m precisely once) to an arbitrary pinned multiplicity a with n ∤ a. This exposes the full strength of the prime-factorization criterion and certifies the irrationality of nth roots of radicands all of whose prime factors have multiplicity ≥ 2 — 36, 72, 100, 216 — which the parent's corollary cannot reach.",
+    "implications": "**Completeness**: The general criterion closes the ergonomic gap between the abstract not-a-perfect-power theorem and its applicable irrationality corollaries. Any radicand with a mismatched prime exponent is now handled by one lemma, regardless of whether some prime happens to appear exactly once.\n\n**Separation**: 216 = 6³ shows the criterion is genuinely finer than the exactly-once test — ∛216 is rational while ⁶√216 is irrational, a distinction the exactly-once corollary cannot express.",
+    "openQuestions": [
+      "Can the criterion be lifted to rational radicands a/b, certifying irrationality of the nth root of a reduced fraction from the prime exponents of numerator and denominator?",
+      "Is there an ergonomic decision procedure that, given m and n, either exhibits the witnessing prime and exponent or produces the exact nth root — packaging the criterion as a complete perfect-power test?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "nth-root-irrational-oq-02",
+      "relationship": "extends",
+      "description": "Directly answers the parent's open question 2 (exposing the general criterion for radicands like 72 = 2³·3² whose prime exponents are all ≥ 2). Reuses not_perfect_pow_of_factorization and not_perfect_pow_int, and generalizes not_perfect_pow_of_sq_not_dvd."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "foundational",
+      "description": "Ultimately rests on the base entry's general theorem irrational_nthRoot: not a perfect nth power over ℤ implies the nth root is irrational."
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "A direct application of unique factorization: m is a perfect nth power iff every prime exponent is divisible by n. The general criterion witnesses failure at a single prime of arbitrary multiplicity."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.NthRootIrrational",
+      "Proofs.NthRootIrrationalOQ02"
+    ],
+    "opens": [
+      "NthRootIrrational",
+      "NthRootIrrationalOQ02"
+    ],
+    "namespace": "NthRootIrrationalOQ02OQ02",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/NthRootIrrationalOQ02OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean",
+      "Proofs/NthRootIrrationalOQ02.lean"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hardy, G.H.; Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "The unique-factorization characterization of perfect powers: m is a perfect nth power iff every prime exponent is divisible by n."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "not_perfect_pow_of_pow_dvd_not_dvd",
+      "type": "core",
+      "description": "A prime of exponent exactly a in m with n ∤ a certifies m is not a perfect nth power — the general pinned-multiplicity criterion",
+      "leanType": "{m n p a : Nat} -> p.Prime -> m ≠ 0 -> p^a ∣ m -> not (p^(a+1) ∣ m) -> not (n ∣ a) -> not (exists k : Nat, k^n = m)"
+    },
+    {
+      "name": "irrational_nthRoot_of_factorization_not_dvd",
+      "type": "core",
+      "description": "If a prime exponent m.factorization p is not divisible by n, then the nth root of m is irrational — the cleanest general form",
+      "leanType": "{m n p : Nat} -> 1 < n -> not (n ∣ m.factorization p) -> Irrational (nthRoot n m)"
+    },
+    {
+      "name": "irrational_sixthRoot_216",
+      "type": "application",
+      "description": "The sixth root of 216 = 6³ is irrational, even though 216 is a perfect cube — a separation the exactly-once corollary cannot express",
+      "leanType": "Irrational (nthRoot 6 216)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## ⚠️ DRAFT — NOT YET MACHINE-VERIFIED (host disk exhaustion)

The Lean proof and gallery entry are complete and logically reviewed, but the
**docker Lean build could not be run** because the host disk
(`/System/Volumes/Data`) is at **100%** (≈200Mi free), see #33336.

- `lake exe cache get` → `No space left on device (os error 28)`
- skip-cache path → docker daemon `input/output error` (containerd metadata), exit 125

Both failures are infrastructure-level, not proof errors. **Do not merge until a
clean `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ02OQ02` passes**
and `meta.status` is confirmed `verified`. Kept as a draft so the deployer will
not auto-merge it.

## What this adds

Answers **open question #2** of the parent entry `nth-root-irrational-oq-02`,
which explicitly asked to expose the general prime-exponent criterion for
radicands "all of whose prime exponents are ≥ 2 but not all divisible by n
(e.g. 72 = 2³·3²)". The parent only exposed the *exactly-once* case
(`p ∣ m`, `p² ∤ m`), which cannot apply to such radicands.

`proofs/Proofs/NthRootIrrationalOQ02OQ02.lean` (9 theorems, 0 sorries, 0 `axiom` declarations by inspection):

- **`not_perfect_pow_of_pow_dvd_not_dvd`** — general pinned-multiplicity criterion:
  `p^a ‖ m` with `n ∤ a` ⟹ `m` is not a perfect `n`-th power. The parent's
  `not_perfect_pow_of_sq_not_dvd` is the `a = 1` case. Reads the exact exponent
  off two `pow_dvd_iff_le_factorization` bounds.
- **`irrational_nthRoot_of_pow_dvd_not_dvd`**, **`irrational_nthRoot_of_factorization_not_dvd`**
  — the general irrationality corollaries (via the parent's `not_perfect_pow_int`
  bridge and the base `irrational_nthRoot`).
- **Concrete separations** the exactly-once corollary cannot certify (no prime of
  multiplicity 1): `∛36`, `⁴√36`, `∛100`, `√72`, `⁶√216`. Notably `216 = 6³` is a
  *perfect cube* (`∛216 = 6` rational) yet **not** a perfect sixth power.
- **`thirtySix_has_no_multiplicity_one_prime`** — machine-checkable certificate
  that `36` lies outside the parent's exactly-once reach, so the generalization
  is necessary.

Gallery entry: `src/data/proofs/nth-root-irrational-oq-02-oq-02/{meta.json,annotations.json}`
(badge `mathlib`, status `verified` **pending the build above**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)