### PR TITLE
research(prob-method-second-moment-oq-04-oq-03): weighted second moment — Cauchy–Schwarz + Chebyshev [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProbMethodSecondMomentOQ04OQ03.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ04OQ03.lean
@@ -1,0 +1,168 @@
+/-
+  Weighted-Finset Second Moment: Cauchy–Schwarz and Chebyshev
+
+  Open question OQ-04-OQ-03 (parent: prob-method-second-moment-oq-04).
+
+  The parent line of work (`ProbMethodSecondMoment.lean`,
+  `ProbMethodSecondMomentOQ02.lean`, `ProbMethodSecondMomentOQ04.lean`) develops
+  the second-moment method over a finite sample space `s : Finset α` with the
+  *uniform counting measure* — every point has weight `1`, so "expectation" is the
+  plain average and "probability" is a fraction of cardinalities.
+
+  This file generalizes the measure to an arbitrary nonnegative **weight**
+  `w : α → ℚ`, replacing cardinalities `#s` by weighted sums `∑ w a` and averages
+  by weighted averages `(∑ w a · X a)/(∑ w a)`. It captures non-uniform discrete
+  distributions (importance weights, biased sampling) while deliberately staying
+  in the elementary `Finset` / `BigOperators` world — no `MeasureTheory`, no real
+  analysis, everything over `ℚ`.
+
+  ## Results
+
+  * `weighted_cauchy_schwarz` — the weighted discrete Cauchy–Schwarz inequality
+        (∑ w·X)²  ≤  (∑ w)·(∑ w·X²),
+    the "engine" of the second-moment method. Proved division-free from the single
+    nonnegative sum `∑ w·(Sw·X − SwX)² ≥ 0`, whose expansion equals
+    `Sw·(Sw·SwX2 − SwX²)`; positivity of the total weight `Sw` then clears it.
+
+  * `weighted_chebyshev_key` / `weighted_chebyshev` — the weighted one- (here two-)
+    sided Chebyshev bound
+        P_w(|X − μ| ≥ a)  ≤  Var_w(X) / a²      (a > 0),
+    with `μ` the weighted mean, all "probabilities" being weighted fractions.
+
+  * `cauchy_schwarz_uniform` / `chebyshev_uniform` — the specializations to the
+    uniform weight `w ≡ 1`, recovering the parent's counting-measure statements
+        (∑ X)² ≤ #s·(∑ X²)   and   #tail/#s ≤ (weighted-with-1 variance)/a²,
+    confirming the generalization is conservative.
+
+  No `axiom`, no `sorry`, no `native_decide`.
+-/
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace ProbMethod.SecondMoment.Weighted
+
+open Finset BigOperators
+
+variable {α : Type*}
+
+/-! ## Weighted Cauchy–Schwarz (the engine) -/
+
+/-- **Weighted discrete Cauchy–Schwarz.** For a nonnegative weight `w` with
+positive total weight `∑ w`, and any `X : α → ℚ`,
+
+    (∑ w·X)²  ≤  (∑ w)·(∑ w·X²).
+
+The uniform case `w ≡ 1` is `cauchy_schwarz_uniform` below. The proof is
+division-free: the single nonnegative sum `∑ w·(Sw·X − SwX)²` expands to
+`Sw·(Sw·SwX2 − SwX²)`, and `Sw > 0` clears the factor. -/
+theorem weighted_cauchy_schwarz (s : Finset α) (w X : α → ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hS : 0 < ∑ i ∈ s, w i) :
+    (∑ i ∈ s, w i * X i) ^ 2 ≤ (∑ i ∈ s, w i) * (∑ i ∈ s, w i * X i ^ 2) := by
+  set Sw := ∑ i ∈ s, w i with hSw
+  set SwX := ∑ i ∈ s, w i * X i with hSwX
+  set SwX2 := ∑ i ∈ s, w i * X i ^ 2 with hSwX2
+  -- The tilted sum of squares is nonnegative termwise.
+  have hnn : 0 ≤ ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2 :=
+    Finset.sum_nonneg (fun i hi => mul_nonneg (hw i hi) (sq_nonneg _))
+  -- ... and expands to `Sw · (Sw · SwX2 − SwX²)`.
+  have hexp : ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2 = Sw * (Sw * SwX2 - SwX ^ 2) := by
+    have hterm : ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2
+        = ∑ i ∈ s, (Sw ^ 2 * (w i * X i ^ 2)
+            - 2 * Sw * SwX * (w i * X i) + SwX ^ 2 * w i) :=
+      Finset.sum_congr rfl (fun i _ => by ring)
+    rw [hterm, Finset.sum_add_distrib, Finset.sum_sub_distrib,
+        ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← hSw, ← hSwX, ← hSwX2]
+    ring
+  rw [hexp] at hnn
+  -- Clear the positive factor Sw.
+  have hD : 0 ≤ Sw * SwX2 - SwX ^ 2 := by nlinarith [hnn, hS]
+  linarith [hD]
+
+/-- **Uniform Cauchy–Schwarz.** The counting-measure special case `w ≡ 1`:
+
+    (∑ X)²  ≤  #s · (∑ X²).
+
+Recovers the parent's uniform second-moment engine. -/
+theorem cauchy_schwarz_uniform (s : Finset α) (X : α → ℚ) (hs : s.Nonempty) :
+    (∑ i ∈ s, X i) ^ 2 ≤ (s.card : ℚ) * (∑ i ∈ s, X i ^ 2) := by
+  have hStot : 0 < ∑ i ∈ s, (1 : ℚ) := by
+    rw [Finset.sum_const, nsmul_eq_mul, mul_one]; exact_mod_cast hs.card_pos
+  have h := weighted_cauchy_schwarz s (fun _ => 1) X (fun _ _ => zero_le_one) hStot
+  simp only [one_mul] at h
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one] at h
+  exact h
+
+/-! ## Weighted Chebyshev -/
+
+/-- **Weighted Chebyshev, cleared form.** For a nonnegative weight `w`, any
+center `μ`, and `a > 0`, the weight carried by the deviation event
+`{ i : |X i − μ| ≥ a }` obeys
+
+    (∑_{|X−μ|≥a} w) · a²  ≤  ∑ w·(X − μ)².
+
+This is the division-free heart: on the tail each `w i·(X i − μ)² ≥ w i·a²`,
+and the remaining points contribute nonnegatively. -/
+theorem weighted_chebyshev_key (s : Finset α) (w X : α → ℚ) (μ a : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (ha : 0 < a) :
+    (∑ i ∈ s.filter (fun i => a ≤ |X i - μ|), w i) * a ^ 2
+      ≤ ∑ i ∈ s, w i * (X i - μ) ^ 2 := by
+  have hsub : s.filter (fun i => a ≤ |X i - μ|) ⊆ s := Finset.filter_subset _ _
+  calc (∑ i ∈ s.filter (fun i => a ≤ |X i - μ|), w i) * a ^ 2
+      = ∑ i ∈ s.filter (fun i => a ≤ |X i - μ|), w i * a ^ 2 := by rw [Finset.sum_mul]
+    _ ≤ ∑ i ∈ s.filter (fun i => a ≤ |X i - μ|), w i * (X i - μ) ^ 2 := by
+        refine Finset.sum_le_sum (fun i hi => ?_)
+        have hfi : a ≤ |X i - μ| := (Finset.mem_filter.mp hi).2
+        have hwi : 0 ≤ w i := hw i (hsub hi)
+        have hsq : a ^ 2 ≤ (X i - μ) ^ 2 := by
+          have h1 : a ^ 2 ≤ |X i - μ| ^ 2 := by
+            nlinarith [hfi, ha.le, abs_nonneg (X i - μ)]
+          rwa [sq_abs] at h1
+        exact mul_le_mul_of_nonneg_left hsq hwi
+    _ ≤ ∑ i ∈ s, w i * (X i - μ) ^ 2 :=
+        Finset.sum_le_sum_of_subset_of_nonneg hsub
+          (fun i hi _ => mul_nonneg (hw i hi) (sq_nonneg _))
+
+/-- Weighted mean: `(∑ w·X)/(∑ w)`. -/
+def wmean (s : Finset α) (w X : α → ℚ) : ℚ :=
+  (∑ i ∈ s, w i * X i) / (∑ i ∈ s, w i)
+
+/-- Weighted variance: the weighted average squared deviation from the weighted mean. -/
+def wvar (s : Finset α) (w X : α → ℚ) : ℚ :=
+  (∑ i ∈ s, w i * (X i - wmean s w X) ^ 2) / (∑ i ∈ s, w i)
+
+/-- Weighted two-sided tail "probability": the fraction of total weight carried by
+points deviating from the weighted mean by at least `a`. -/
+def wtailProb (s : Finset α) (w X : α → ℚ) (a : ℚ) : ℚ :=
+  (∑ i ∈ s.filter (fun i => a ≤ |X i - wmean s w X|), w i) / (∑ i ∈ s, w i)
+
+/-- **Weighted Chebyshev inequality.** With `μ = wmean s w X` the weighted mean and
+`Var_w = wvar s w X` the weighted variance, for `a > 0` and positive total weight,
+
+    P_w(|X − μ| ≥ a)  ≤  Var_w(X) / a². -/
+theorem weighted_chebyshev (s : Finset α) (w X : α → ℚ) (a : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hS : 0 < ∑ i ∈ s, w i) (ha : 0 < a) :
+    wtailProb s w X a ≤ wvar s w X / a ^ 2 := by
+  have ha2 : (0 : ℚ) < a ^ 2 := pow_pos ha 2
+  have hkey := weighted_chebyshev_key s w X (wmean s w X) a hw ha
+  rw [wtailProb, wvar, div_div]
+  rw [div_le_div_iff hS (by positivity)]
+  -- goal: (∑_tail w) * (Sw * a²) ≤ (∑ w (X-μ)²) * Sw
+  have hSnn : 0 ≤ ∑ i ∈ s, w i := hS.le
+  calc (∑ i ∈ s.filter (fun i => a ≤ |X i - wmean s w X|), w i) * ((∑ i ∈ s, w i) * a ^ 2)
+      = ((∑ i ∈ s.filter (fun i => a ≤ |X i - wmean s w X|), w i) * a ^ 2) * (∑ i ∈ s, w i) := by
+        ring
+    _ ≤ (∑ i ∈ s, w i * (X i - wmean s w X) ^ 2) * (∑ i ∈ s, w i) :=
+        mul_le_mul_of_nonneg_right hkey hSnn
+
+/-- **Uniform Chebyshev.** The counting-measure special case `w ≡ 1` of
+`weighted_chebyshev`: the ordinary fraction of points deviating by at least `a`
+is bounded by the (uniform) variance over `a²`. -/
+theorem chebyshev_uniform (s : Finset α) (X : α → ℚ) (a : ℚ)
+    (hs : s.Nonempty) (ha : 0 < a) :
+    wtailProb s (fun _ => 1) X a ≤ wvar s (fun _ => 1) X / a ^ 2 := by
+  have hStot : 0 < ∑ i ∈ s, (1 : ℚ) := by
+    rw [Finset.sum_const, nsmul_eq_mul, mul_one]; exact_mod_cast hs.card_pos
+  exact weighted_chebyshev s (fun _ => 1) X a (fun _ _ => zero_le_one) hStot ha
+
+end ProbMethod.SecondMoment.Weighted

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "wsm-weighted-cs",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 59, "endLine": 84 },
+    "type": "theorem",
+    "title": "Weighted Discrete Cauchy–Schwarz (the engine)",
+    "content": "The weighted second-moment engine: for a nonnegative weight w with positive total weight, (∑ w·X)² ≤ (∑ w)(∑ w·X²). The proof is division-free. Writing Sw = ∑ w, SwX = ∑ w·X, SwX2 = ∑ w·X², the single tilted sum of squares ∑ w·(Sw·X − SwX)² is manifestly ≥ 0 (each term is a nonnegative weight times a square). Expanding it — the only genuine computation — gives exactly Sw·(Sw·SwX2 − SwX²); positivity of Sw then clears the factor to leave SwX² ≤ Sw·SwX2. No square roots are taken, so the argument stays entirely over ℚ, unlike the usual reduction of weighted Cauchy–Schwarz to the unweighted form via √w.",
+    "mathContext": "$\\Big(\\sum_i w_i X_i\\Big)^2 \\le \\Big(\\sum_i w_i\\Big)\\Big(\\sum_i w_i X_i^2\\Big)$",
+    "significance": "critical",
+    "prerequisites": ["nonnegativity of weighted sums of squares", "Finset.sum_nonneg", "Finset.mul_sum", "clearing a positive factor"],
+    "relatedConcepts": ["Cauchy–Schwarz inequality", "second moment method", "weighted inner product", "sum of squares (SOS)"]
+  },
+  {
+    "id": "wsm-cs-uniform",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "theorem",
+    "title": "Uniform Cauchy–Schwarz (w ≡ 1 specialization)",
+    "content": "Instantiating the weighted bound at the constant weight w ≡ 1 recovers the classical counting-measure form (∑ X)² ≤ #s·(∑ X²): the total weight ∑ 1 collapses to the cardinality #s (Finset.sum_const), and ∑ 1·X, ∑ 1·X² collapse to ∑ X, ∑ X². This confirms the weighted generalization is conservative — it contains the parent's uniform second-moment engine as a special case.",
+    "mathContext": "$\\Big(\\sum_{i} X_i\\Big)^2 \\le |s| \\sum_{i} X_i^2$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.sum_const", "constant weight specialization"],
+    "relatedConcepts": ["counting measure", "uniform distribution", "conservative generalization"]
+  },
+  {
+    "id": "wsm-chebyshev-key",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 106, "endLine": 125 },
+    "type": "theorem",
+    "title": "Weighted Chebyshev, Cleared Form",
+    "content": "The division-free heart of the weighted Chebyshev bound: for a center μ and threshold a > 0, the weight carried by the deviation event {|X − μ| ≥ a} satisfies (∑_{tail} w)·a² ≤ ∑ w·(X − μ)². The argument is Markov-style and needs no Cauchy–Schwarz: on each tail point (X i − μ)² ≥ a² (squaring a ≤ |X i − μ|, both nonnegative), so w i·a² ≤ w i·(X i − μ)²; summing over the tail and then extending nonnegatively to all of s gives the bound. The center μ is arbitrary here — Chebyshev fixes it to the weighted mean downstream.",
+    "mathContext": "$\\Big(\\sum_{|X-\\mu|\\ge a} w_i\\Big)\\,a^2 \\;\\le\\; \\sum_i w_i (X_i-\\mu)^2$",
+    "significance": "critical",
+    "prerequisites": ["Markov's inequality idea", "monotonicity of squaring on nonnegatives", "Finset.sum_le_sum_of_subset_of_nonneg", "sq_abs"],
+    "relatedConcepts": ["Chebyshev inequality", "Markov inequality", "tail bound", "second moment"]
+  },
+  {
+    "id": "wsm-defs",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 127, "endLine": 137 },
+    "type": "definition",
+    "title": "Weighted Mean, Variance, and Tail Probability",
+    "content": "The weighted analogues of the parent's uniform quantities: wmean = (∑ w·X)/(∑ w) is the weighted average; wvar = (∑ w·(X − wmean)²)/(∑ w) is the weighted mean-squared deviation; and wtailProb a = (∑_{|X − wmean| ≥ a} w)/(∑ w) is the fraction of total weight carried by points deviating from the weighted mean by at least a. With w ≡ 1 these reduce to the ordinary average, variance, and cardinality-fraction, keeping the formulation measure-theory-free.",
+    "mathContext": "$\\mu_w = \\frac{\\sum w_i X_i}{\\sum w_i}, \\quad \\mathrm{Var}_w = \\frac{\\sum w_i (X_i-\\mu_w)^2}{\\sum w_i}$",
+    "significance": "key",
+    "prerequisites": ["weighted average", "weighted sums over Finsets"],
+    "relatedConcepts": ["weighted mean", "weighted variance", "discrete probability distribution", "importance weighting"]
+  },
+  {
+    "id": "wsm-chebyshev",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 143, "endLine": 159 },
+    "type": "theorem",
+    "title": "Weighted Chebyshev Inequality",
+    "content": "The probability statement: with μ the weighted mean and Var_w the weighted variance, for a > 0 and positive total weight, P_w(|X − μ| ≥ a) ≤ Var_w/a². It follows from the cleared form by clearing the positive denominators ∑ w and a² (via div_le_div_iff), instantiating the center at the weighted mean. This is the weighted second-moment concentration bound the problem asks for, stated entirely with Finset sums.",
+    "mathContext": "$P_w(|X-\\mu|\\ge a) \\;\\le\\; \\frac{\\mathrm{Var}_w(X)}{a^2}$",
+    "significance": "critical",
+    "prerequisites": ["div_le_div_iff", "clearing positive denominators", "weighted_chebyshev_key"],
+    "relatedConcepts": ["Chebyshev inequality", "concentration of measure", "second moment method", "weighted distribution"]
+  },
+  {
+    "id": "wsm-chebyshev-uniform",
+    "proofId": "prob-method-second-moment-oq-04-oq-03",
+    "range": { "startLine": 161, "endLine": 168 },
+    "type": "theorem",
+    "title": "Uniform Chebyshev (w ≡ 1 specialization)",
+    "content": "Setting w ≡ 1 recovers the ordinary counting-measure Chebyshev bound: the fraction of sample points deviating from the mean by at least a is at most the (uniform) variance over a². This closes the loop with the parent's uniform Chebyshev/Cantelli work, confirming the weighted generalization specializes back to it.",
+    "mathContext": "$\\frac{\\#\\{|X-\\mu|\\ge a\\}}{|s|} \\;\\le\\; \\frac{\\mathrm{Var}(X)}{a^2}$",
+    "significance": "supporting",
+    "prerequisites": ["constant weight specialization"],
+    "relatedConcepts": ["Chebyshev inequality", "counting measure", "conservative generalization"]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03/index.ts
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ProbMethodSecondMomentOQ04OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodSecondMomentOq04Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodSecondMomentOq04Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodSecondMomentOq04Oq03Data: ProofData = {
+  proof: probMethodSecondMomentOq04Oq03Proof,
+  annotations: probMethodSecondMomentOq04Oq03Annotations,
+}

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03/meta.json
@@ -1,0 +1,221 @@
+{
+  "id": "prob-method-second-moment-oq-04-oq-03",
+  "title": "Weighted-Finset Second Moment: Cauchy–Schwarz and Chebyshev",
+  "slug": "prob-method-second-moment-oq-04-oq-03",
+  "description": "The second-moment method over a finite sample space, generalized from the uniform counting measure to an arbitrary nonnegative weight w : α → ℚ. The parent line of work (prob-method-second-moment and its OQ-04 Cantelli entry) develops the method with every point weighted 1, so 'expectation' is the plain average and 'probability' is a fraction of cardinalities. This entry replaces cardinalities #s by weighted sums ∑ w·(·), proving: (1) the weighted discrete Cauchy–Schwarz inequality (∑ w·X)² ≤ (∑ w)(∑ w·X²) — the engine of the second-moment method — via a division-free sum-of-squares argument that stays over ℚ (no √w reduction); (2) the weighted Chebyshev inequality P_w(|X − μ| ≥ a) ≤ Var_w(X)/a² with μ the weighted mean and Var_w the weighted variance; and (3) the specializations at w ≡ 1, recovering the parent's uniform counting-measure statements, confirming the generalization is conservative. Everything lives in the elementary Finset/BigOperators world — no MeasureTheory, no real analysis. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (weighted Cauchy–Schwarz and Chebyshev inequalities), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_inequality",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ04OQ03.lean",
+    "tags": [
+      "probabilistic-method",
+      "second-moment-method",
+      "cauchy-schwarz",
+      "chebyshev-inequality",
+      "concentration-inequalities",
+      "weighted-sums",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_nonneg",
+        "description": "A Finset sum of nonnegative terms is nonnegative. Establishes that the tilted sum of squares ∑ w·(Sw·X − SwX)² ≥ 0 — the single inequality the whole weighted Cauchy–Schwarz proof rests on.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b · ∑ f = ∑ b·f. Used (as ← Finset.mul_sum) to factor the constant coefficients Sw², 2·Sw·SwX, SwX² out of the expanded tilted sum, collapsing it to Sw·(Sw·SwX2 − SwX²).",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset_of_nonneg",
+        "description": "Extending a sum over a subset to the whole Finset only increases it when the added terms are nonnegative. Passes from the tail sum ∑_{|X−μ|≥a} w·(X−μ)² up to the full second moment ∑ w·(X−μ)² in the weighted Chebyshev key lemma.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "sq_abs",
+        "description": "|a|² = a². Bridges the tail hypothesis a ≤ |X i − μ| (an absolute-value bound) to the squared bound a² ≤ (X i − μ)² needed to charge each tail point a² of second moment.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      },
+      {
+        "theorem": "div_le_div_iff",
+        "description": "Cross-multiplication for an inequality between two fractions with positive denominators. Clears the positive denominators ∑ w and a² to turn the cleared weighted Chebyshev bound into the probability statement P_w(|X−μ|≥a) ≤ Var_w/a².",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "∑ _ ∈ s, c = s.card • c. Collapses the constant weight ∑ 1 to the cardinality #s in the w ≡ 1 specializations, recovering the parent's uniform counting-measure statements.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "weighted_cauchy_schwarz: a division-free, 0-axiom Lean proof of the weighted discrete Cauchy–Schwarz inequality (∑ w·X)² ≤ (∑ w)(∑ w·X²) for nonnegative weights with positive total weight. The proof avoids the usual √w reduction (which would leave ℚ) by expanding the single nonnegative tilted sum ∑ w·(Sw·X − SwX)² to Sw·(Sw·SwX2 − SwX²) and clearing the positive total weight Sw. This is the 'engine' framing the problem asks for: Cauchy–Schwarz laid bare as the source of the second-moment method.",
+      "weighted_chebyshev_key: the cleared, division-free weighted Chebyshev bound (∑_{|X−μ|≥a} w)·a² ≤ ∑ w·(X−μ)² for an arbitrary center μ, proved Markov-style (each tail point charges a² of weighted second moment) with no appeal to Cauchy–Schwarz.",
+      "weighted_chebyshev: the probability statement P_w(|X − μ| ≥ a) ≤ Var_w(X)/a² with μ the weighted mean and Var_w the weighted variance, obtained by clearing the positive denominators ∑ w and a².",
+      "wmean, wvar, wtailProb: the weighted analogues of the parent's uniform mean, variance, and tail fraction, defined as ratios of Finset sums so the whole development stays measure-theory-free and computation-friendly.",
+      "cauchy_schwarz_uniform and chebyshev_uniform: the w ≡ 1 specializations recovering the parent's uniform counting-measure statements ((∑ X)² ≤ #s·(∑ X²) and the cardinality-fraction Chebyshev bound), confirming the weighted generalization is conservative."
+    ],
+    "dateAdded": "2026-07-02",
+    "relatedProblems": [
+      {
+        "id": "prob-method-second-moment-oq-04",
+        "relationship": "Direct parent. OQ-04 proves Cantelli's one-sided Chebyshev inequality over the uniform counting measure on a Finset. This child generalizes the measure to arbitrary nonnegative weights, proving the weighted Cauchy–Schwarz engine and the weighted (two-sided) Chebyshev bound, and recovers the uniform statements at w ≡ 1."
+      },
+      {
+        "id": "prob-method-second-moment",
+        "relationship": "Root of the probabilistic-method / second-moment line of work. This entry supplies the weighted formulation of its core inequalities, extending the method to non-uniform finite distributions (importance weights, biased sampling) while keeping the elementary Finset style."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 168,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Hypotheses are inputs to the statements, not standing assumptions: the weight is nonnegative (0 ≤ w i on s) with positive total weight (0 < ∑ w) where a weighted average is formed, and the threshold a is positive. The carrier α is an arbitrary type and all sums are over an explicit Finset s : Finset α; everything is over ℚ. #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The second-moment method — bounding how often a random variable deviates from its mean using only its first two moments — rests on two classical inequalities: Cauchy–Schwarz (which, applied to degrees or counts, produces the variance bound) and Chebyshev (which turns a variance bound into a tail bound). In the finite, uniform setting these are elementary Finset facts, and the parent gallery entries formalize them with every sample point weighted equally. Real applications, however, often carry non-uniform weights: importance sampling, biased distributions, weighted graphs. The weighted forms of Cauchy–Schwarz and Chebyshev are standard textbook material, but writing them out over ℚ without measure theory highlights exactly what is needed — nonnegativity of the weights and a single sum-of-squares — and keeps the statements computation-friendly. The weighted Cauchy–Schwarz here is proved without square roots (staying in ℚ), which is the ingredient that makes the uniform w ≡ 1 specialization exact rather than approximate.",
+    "problemStatement": "Let s : Finset α, let w : α → ℚ be a weight with 0 ≤ w i for i ∈ s and positive total weight ∑ w > 0, and let X : α → ℚ. Prove: (1) the weighted Cauchy–Schwarz inequality (∑ w·X)² ≤ (∑ w)(∑ w·X²); (2) with μ = (∑ w·X)/(∑ w) the weighted mean and Var_w = (∑ w·(X−μ)²)/(∑ w) the weighted variance, the weighted Chebyshev bound P_w(|X − μ| ≥ a) ≤ Var_w/a² for a > 0, where P_w is the weighted fraction; and (3) that the w ≡ 1 case recovers the uniform counting-measure statements.",
+    "text": "Weighted Cauchy–Schwarz is the engine. Write Sw = ∑ w, SwX = ∑ w·X, SwX2 = ∑ w·X². The tilted weighted sum of squares ∑ w·(Sw·X − SwX)² is nonnegative because each term is a nonnegative weight times a square. Expanding it collapses (every coefficient is constant across the sum) to Sw·(Sw·SwX2 − SwX²); since Sw > 0, this forces SwX² ≤ Sw·SwX2, which is the inequality. Weighted Chebyshev is Markov's idea: on the event |X − μ| ≥ a each point contributes at least w·a² to the weighted second moment ∑ w·(X − μ)², so the weight of that event times a² is at most the second moment; dividing by Sw and a² gives the tail bound.",
+    "proofStrategy": "All over ℚ with Finset sums; no measure theory, no real analysis.\n\n1. **Weighted Cauchy–Schwarz (weighted_cauchy_schwarz).** Abbreviate Sw = ∑ w, SwX = ∑ w·X, SwX2 = ∑ w·X². The sum ∑ w·(Sw·X − SwX)² is ≥ 0 termwise (Finset.sum_nonneg, each term = nonneg weight · square). Rewrite the summand by ring as Sw²·(w·X²) − 2·Sw·SwX·(w·X) + SwX²·w, split the sum (sum_add_distrib / sum_sub_distrib), and factor the constant coefficients out (← Finset.mul_sum) to reach Sw·(Sw·SwX2 − SwX²). With Sw > 0, nlinarith deduces 0 ≤ Sw·SwX2 − SwX², i.e. SwX² ≤ Sw·SwX2.\n\n2. **Uniform Cauchy–Schwarz (cauchy_schwarz_uniform).** Apply the weighted result at w ≡ 1; ∑ 1 = #s (Finset.sum_const) and 1·X, 1·X² simplify, giving (∑ X)² ≤ #s·(∑ X²).\n\n3. **Weighted Chebyshev, cleared (weighted_chebyshev_key).** For a center μ and a > 0: pull a² inside the tail sum (Finset.sum_mul); on each tail point a² ≤ (X−μ)² (square a ≤ |X−μ| via sq_abs and nlinarith), so w·a² ≤ w·(X−μ)² (mul_le_mul_of_nonneg_left); sum over the tail and extend to all of s with nonnegative terms (Finset.sum_le_sum_of_subset_of_nonneg). Result: (∑_{tail} w)·a² ≤ ∑ w·(X−μ)².\n\n4. **Weighted Chebyshev (weighted_chebyshev).** Instantiate the key lemma at μ = wmean, then clear the positive denominators ∑ w and a² (div_le_div_iff) to obtain wtailProb ≤ wvar/a².\n\n5. **Uniform Chebyshev (chebyshev_uniform).** The w ≡ 1 case of weighted_chebyshev.",
+    "keyInsights": [
+      "**Cauchy–Schwarz without square roots.** The textbook reduction of weighted Cauchy–Schwarz to the unweighted form substitutes √w, which leaves ℚ. Expanding the single tilted sum of squares ∑ w·(Sw·X − SwX)² instead keeps everything rational and makes the w ≡ 1 specialization exact.",
+      "**One nonnegative sum does all the work.** The entire weighted Cauchy–Schwarz proof is: that sum is ≥ 0, it equals Sw·(Sw·SwX2 − SwX²), and Sw > 0. No inductions, no auxiliary inequalities.",
+      "**Chebyshev needs no Cauchy–Schwarz.** The tail bound is pure Markov: each deviating point charges a² of second moment. Cauchy–Schwarz is the engine for producing variance bounds, but the Chebyshev step itself is independent.",
+      "**Weights are the only new input.** Every step uses nothing about w beyond nonnegativity (and positive total weight where an average is formed). This is what makes the w ≡ 1 specialization recover the parent's uniform statements exactly.",
+      "**Measure-theory-free by design.** Keeping to Finset sums over ℚ makes the whole development computable and elementary — the point of the parent line of work — while still capturing non-uniform discrete distributions."
+    ],
+    "prerequisites": [
+      "The uniform second-moment method (parent entry prob-method-second-moment-oq-04)",
+      "Cauchy–Schwarz and Chebyshev inequalities in their finite discrete form",
+      "Finset sums and BigOperators algebra (sum_nonneg, mul_sum, sum_le_sum)",
+      "Weighted averages and the idea of a nonnegative weight as a discrete measure"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring",
+      "startLine": 1,
+      "endLine": 48,
+      "mathContext": "$\\mu_w = \\frac{\\sum w_i X_i}{\\sum w_i}$",
+      "summary": "Module docstring framing the file as the weighted generalization of the parent's uniform second-moment method: cardinalities #s become weighted sums ∑ w, staying over ℚ with Finset sums and no measure theory."
+    },
+    {
+      "id": "weighted-cs",
+      "title": "Weighted Cauchy–Schwarz and its Uniform Case",
+      "startLine": 49,
+      "endLine": 95,
+      "mathContext": "$\\Big(\\sum w_i X_i\\Big)^2 \\le \\Big(\\sum w_i\\Big)\\Big(\\sum w_i X_i^2\\Big)$",
+      "summary": "weighted_cauchy_schwarz proves the weighted engine division-free from ∑ w·(Sw·X − SwX)² ≥ 0 = Sw·(Sw·SwX2 − SwX²); cauchy_schwarz_uniform specializes to w ≡ 1, recovering (∑ X)² ≤ #s·(∑ X²)."
+    },
+    {
+      "id": "weighted-chebyshev-key",
+      "title": "Weighted Chebyshev, Cleared Form",
+      "startLine": 96,
+      "endLine": 125,
+      "mathContext": "$\\Big(\\sum_{|X-\\mu|\\ge a} w_i\\Big) a^2 \\le \\sum_i w_i (X_i-\\mu)^2$",
+      "summary": "weighted_chebyshev_key: Markov-style tail bound charging each deviating point a² of weighted second moment, then extending nonnegatively from the tail to all of s. No Cauchy–Schwarz needed."
+    },
+    {
+      "id": "weighted-defs",
+      "title": "Weighted Mean, Variance, Tail Probability",
+      "startLine": 126,
+      "endLine": 137,
+      "mathContext": "$\\mathrm{Var}_w = \\frac{\\sum w_i (X_i-\\mu_w)^2}{\\sum w_i}$",
+      "summary": "wmean, wvar, wtailProb: the weighted analogues of the parent's uniform mean, variance, and tail fraction, defined as ratios of Finset sums."
+    },
+    {
+      "id": "weighted-chebyshev",
+      "title": "Weighted Chebyshev and its Uniform Case",
+      "startLine": 138,
+      "endLine": 168,
+      "mathContext": "$P_w(|X-\\mu|\\ge a) \\le \\frac{\\mathrm{Var}_w(X)}{a^2}$",
+      "summary": "weighted_chebyshev clears the positive denominators to give the probability statement; chebyshev_uniform is the w ≡ 1 specialization recovering the parent's uniform Chebyshev bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "The finite second-moment method generalized from the uniform counting measure to arbitrary nonnegative weights over ℚ: the weighted discrete Cauchy–Schwarz inequality (∑ w·X)² ≤ (∑ w)(∑ w·X²), proved division-free from a single sum of squares, and the weighted Chebyshev bound P_w(|X − μ| ≥ a) ≤ Var_w/a². Zero sorries, zero axioms. The w ≡ 1 specializations recover the parent's uniform statements, so the generalization is conservative.",
+    "implications": "This makes the second-moment method usable for non-uniform finite distributions — importance weights, biased sampling, weighted graphs — while keeping the measure-theory-free, computation-friendly Finset style of the parent line of work. It also cleanly exhibits weighted Cauchy–Schwarz as the engine behind the method, proved without the √w reduction so the argument stays entirely rational. The abstract setup (a nonnegative weight on a Finset) is a reusable discrete-measure primitive for further probabilistic-method formalizations.",
+    "openQuestions": [
+      "Prove the weighted one-sided (Cantelli) refinement P_w(X − μ ≥ a) ≤ Var_w/(Var_w + a²), the weighted analogue of the parent's sharp OQ-04 bound.",
+      "State a weighted Paley–Zygmund lower-tail bound P_w(X ≥ θ·μ) ≥ (1−θ)²·μ²/𝔼_w[X²], the natural second-moment companion to Chebyshev.",
+      "Instantiate the weighted framework on a concrete non-uniform application (e.g. a weighted independent-set or coloring count) to demonstrate value beyond the uniform case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment-oq-04",
+      "relationship": "extends",
+      "description": "Generalizes OQ-04's uniform-counting-measure Cantelli/Chebyshev work to arbitrary nonnegative weights, and recovers its uniform statements at w ≡ 1."
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "extends",
+      "description": "Supplies the weighted formulation of the core second-moment inequalities (Cauchy–Schwarz engine + Chebyshev tail bound) for the probabilistic-method line of work."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ProbMethodSecondMomentOQ04OQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "ProbMethod.SecondMoment.Weighted",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 5
+  },
+  "references": [
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 4 develops the second-moment method; Chebyshev's inequality and the variance bound via Cauchy–Schwarz are the core tools generalized here to weighted sums."
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Systematic treatment of Cauchy–Schwarz including weighted and sum-of-squares proofs of the type used here for weighted_cauchy_schwarz."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "weighted_cauchy_schwarz",
+      "type": "core",
+      "description": "Weighted discrete Cauchy–Schwarz: for nonnegative w with positive total weight, (∑ w·X)² ≤ (∑ w)(∑ w·X²). Proved division-free over ℚ from a single sum of squares.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → 0 < ∑ i ∈ s, w i → (∑ i ∈ s, w i * X i) ^ 2 ≤ (∑ i ∈ s, w i) * (∑ i ∈ s, w i * X i ^ 2)"
+    },
+    {
+      "name": "weighted_chebyshev",
+      "type": "core",
+      "description": "Weighted Chebyshev inequality: P_w(|X − μ| ≥ a) ≤ Var_w(X)/a² with μ the weighted mean and Var_w the weighted variance.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → 0 < ∑ i ∈ s, w i → 0 < a → wtailProb s w X a ≤ wvar s w X / a ^ 2"
+    },
+    {
+      "name": "weighted_chebyshev_key",
+      "type": "supporting",
+      "description": "Cleared, division-free weighted Chebyshev bound for an arbitrary center μ: (∑_{|X−μ|≥a} w)·a² ≤ ∑ w·(X−μ)². Markov-style, no Cauchy–Schwarz.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → 0 < a → (∑ i ∈ s.filter (fun i => a ≤ |X i - μ|), w i) * a ^ 2 ≤ ∑ i ∈ s, w i * (X i - μ) ^ 2"
+    },
+    {
+      "name": "cauchy_schwarz_uniform",
+      "type": "supporting",
+      "description": "The w ≡ 1 specialization of weighted Cauchy–Schwarz: (∑ X)² ≤ #s·(∑ X²), recovering the parent's uniform engine.",
+      "leanType": "s.Nonempty → (∑ i ∈ s, X i) ^ 2 ≤ (s.card : ℚ) * (∑ i ∈ s, X i ^ 2)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Research session for **prob-method-second-moment-oq-04-oq-03** (researcher-13). Generalizes the parent's uniform-counting-measure second-moment method to an arbitrary nonnegative weight `w : α → ℚ`, replacing cardinalities `#s` by weighted sums `∑ w`. Stays entirely in the elementary `Finset`/`BigOperators` world over ℚ — no `MeasureTheory`, no real analysis.

## New results (`proofs/Proofs/ProbMethodSecondMomentOQ04OQ03.lean`, 168 L)

- **`weighted_cauchy_schwarz`** — the engine: `(∑ w·X)² ≤ (∑ w)(∑ w·X²)`. Proved **division-free** from the single nonnegative sum `∑ w·(Sw·X − SwX)² ≥ 0`, which expands to `Sw·(Sw·SwX2 − SwX²)`; positive total weight `Sw` clears the factor. Deliberately avoids the `√w` reduction so the argument stays over ℚ.
- **`weighted_chebyshev_key`** — cleared, Markov-style: `(∑_{|X−μ|≥a} w)·a² ≤ ∑ w·(X−μ)²`, for an arbitrary center `μ`. No Cauchy–Schwarz needed.
- **`weighted_chebyshev`** — `P_w(|X − μ| ≥ a) ≤ Var_w(X)/a²` with `μ = wmean`, `Var_w = wvar`.
- **`cauchy_schwarz_uniform` / `chebyshev_uniform`** — the `w ≡ 1` specializations recovering the parent's uniform statements (`(∑ X)² ≤ #s·(∑ X²)` and the cardinality-fraction Chebyshev bound), confirming the generalization is **conservative**.
- Defs `wmean`, `wvar`, `wtailProb` — weighted analogues of the parent's uniform quantities.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.ProbMethodSecondMomentOQ04OQ03` → **exit 0 (Build succeeded)**.
- **0 sorries, 0 axioms, no `native_decide`** (grep-confirmed; `#print axioms` = propext/Classical.choice/Quot.sound only).
- Auto-discovered by the Lake glob, so it enters the aggregate build graph on merge.

## Files

- `proofs/Proofs/ProbMethodSecondMomentOQ04OQ03.lean`
- `src/data/proofs/prob-method-second-moment-oq-04-oq-03/{meta.json,annotations.json,index.ts}` (6 annotations, ranges validated against the 168-line file)

## Status

**Outcome**: completed — new verified gallery entry (5 theorems / 3 defs / 0 axioms).
**Next Steps**: weighted Cantelli (one-sided) refinement; weighted Paley–Zygmund; a concrete non-uniform application.

🤖 Generated by researcher-13