### PR TITLE
Enrich Erdős #76 packing upper bound: full section & annotation coverage

### DIFF
--- a/src/data/proofs/erdos-76-packing-upper-bound/annotations.json
+++ b/src/data/proofs/erdos-76-packing-upper-bound/annotations.json
@@ -48,31 +48,54 @@
     "id": "ann-erdos76pub-edgebound",
     "proofId": "erdos-76-packing-upper-bound",
     "range": {
-      "startLine": 64,
-      "endLine": 124
+      "startLine": 63,
+      "endLine": 104
     },
     "type": "tactic",
-    "title": "Double Counting: 6·|ts| ≤ n² − n ⟹ |ts| ≤ C(n,2)/3",
-    "content": "A packing is a finite set of pairwise edge-disjoint triangles. Because their edge sets are pairwise disjoint, Finset.card_biUnion equates the size of their union with the sum of the individual sizes, ∑ 6 = 6·|ts|. That union embeds in univ.offDiag — the |V|²−|V| ordered distinct pairs of the whole vertex type — so Finset.card_le_card gives packing_edge_bound: 6·|ts| ≤ |V|² − |V|. Dividing through (Nat.choose_two_right rewrites C(n,2) = n(n−1)/2, Nat.div_div_eq_div_mul collapses /2/3 into /6, and Nat.le_div_iff_mul_le converts the goal to a multiplication) yields packing_card_le_choose: |ts| ≤ C(|V|,2)/3.",
-    "mathContext": "$\\sum_{t \\in ts} |t.\\mathrm{edges}| = 6|ts| = |\\bigcup_t t.\\mathrm{edges}| \\le |\\mathrm{univ.offDiag}| = |V|^2 - |V|$, so $|ts| \\le \\binom{|V|}{2}/3$.",
+    "title": "Double Counting: 6·|ts| ≤ n² − n",
+    "content": "A packing is a finite set of pairwise edge-disjoint triangles (isPacking). Because their edge sets are pairwise disjoint, they form a PairwiseDisjoint family and Finset.card_biUnion equates the size of their union with the sum of the individual sizes, ∑ 6 = 6·|ts| (using Triangle.edges_card in each summand and Finset.sum_const). That union embeds in univ.offDiag — the |V|²−|V| ordered distinct pairs of the whole vertex type — so Finset.card_le_card gives the core packing_edge_bound: 6·|ts| ≤ |V|² − |V|. This is the single inequality that carries the entire result.",
+    "mathContext": "$\\sum_{t \\in ts} |t.\\mathrm{edges}| = 6|ts| = |\\bigcup_t t.\\mathrm{edges}| \\le |\\mathrm{univ.offDiag}| = |V|^2 - |V|$.",
     "significance": "key",
     "relatedConcepts": [
       "Finset.card_biUnion",
       "PairwiseDisjoint",
       "double counting",
-      "Nat.le_div_iff_mul_le"
+      "Finset.card_le_card"
     ],
     "prerequisites": [
       "Finset.card_biUnion for a pairwise-disjoint family",
       "Finset.card_le_card for the ambient embedding",
-      "natural-number division lemmas"
+      "PairwiseDisjoint families"
+    ]
+  },
+  {
+    "id": "ann-erdos76pub-choosebound",
+    "proofId": "erdos-76-packing-upper-bound",
+    "range": {
+      "startLine": 105,
+      "endLine": 123
+    },
+    "type": "tactic",
+    "title": "From Edges to Triangles: |ts| ≤ C(n,2)/3",
+    "content": "Converting the edge bound 6·|ts| ≤ |V|²−|V| into the headline triangle bound is pure natural-number arithmetic, but it is not automatic over ℕ. Nat.choose_two_right rewrites C(n,2) as n(n−1)/2, Nat.div_div_eq_div_mul collapses the nested /2/3 into a single /6, and Nat.le_div_iff_mul_le clears the floor division into a multiplication goal. The truncated ℕ subtraction hides the identity n(n−1) = n²−n, so a dedicated private helper mul_pred_self establishes it (by a case split on n and omega) before the final omega can close packing_card_le_choose: |ts| ≤ C(|V|,2)/3 ≈ |V|²/6.",
+    "mathContext": "$6|ts| \\le |V|(|V|-1)$ and $\\binom{|V|}{2} = |V|(|V|-1)/2$ give $|ts| \\le \\binom{|V|}{2}/3$; over $\\mathbb{N}$ this is the exact floor, not just the asymptotic $|V|^2/6$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.choose_two_right",
+      "Nat.div_div_eq_div_mul",
+      "Nat.le_div_iff_mul_le",
+      "truncated natural-number subtraction"
+    ],
+    "prerequisites": [
+      "natural-number floor division lemmas",
+      "omega for linear arithmetic over ℕ"
     ]
   },
   {
     "id": "ann-erdos76pub-maxpacking",
     "proofId": "erdos-76-packing-upper-bound",
     "range": {
-      "startLine": 125,
+      "startLine": 124,
       "endLine": 160
     },
     "type": "tactic",

--- a/src/data/proofs/erdos-76-packing-upper-bound/meta.json
+++ b/src/data/proofs/erdos-76-packing-upper-bound/meta.json
@@ -47,7 +47,8 @@
       "The upper-bound direction of Erdős #76 is elementary: it is a single application of the double-counting principle (edges used = 6 per triangle, all disjoint, all inside K_n), needing none of the regularity-method machinery behind the lower bound.",
       "Using ordered edges (offDiag) keeps the arithmetic exact: 6 edges per triangle and |V|²−|V| edges total, so the bound is literally 6·|ts| ≤ |V|²−|V| with no hidden factors, and Finset.card_biUnion converts edge-disjointness directly into a sum.",
       "The trivial upper bound is n²/6 — exactly twice the true optimum n²/12. That factor-of-2 slack is the whole difficulty of the problem: the extremal coloring can only reach half the crude edge budget because it deliberately wastes one color on a triangle-free bipartite class.",
-      "Lifting the per-packing bound to maxPackingSize needs only that the set of achievable sizes is nonempty (the empty packing witnesses 0) and bounded above, so csSup_le applies with no completeness subtleties."
+      "Lifting the per-packing bound to maxPackingSize needs only that the set of achievable sizes is nonempty (the empty packing witnesses 0) and bounded above, so csSup_le applies with no completeness subtleties.",
+      "The bound is stated as the exact natural-number floor C(n,2)/3, not merely the asymptotic n²/6, and getting there over ℕ needs a small but genuine care point: truncated ℕ subtraction hides the identity n(n−1) = n²−n, so a dedicated helper (mul_pred_self) supplies it before omega can finish — a reminder that even 'trivial' edge-counting carries real formalization overhead in a machine-checked setting."
     ],
     "prerequisites": [
       "Finset off-diagonals and their cardinality: Finset.offDiag, Finset.mem_offDiag, Finset.offDiag_card (|s.offDiag| = |s|² − |s|)",
@@ -57,27 +58,43 @@
   },
   "sections": [
     {
+      "id": "framing",
+      "title": "§0: Module Framing — the Easy Half of Erdős #76",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring and imports. Positions this file as the companion that discharges the `sorry` left in Erdos76Problem.lean, contrasts the elementary n²/6 upper bound proved here against the deep regularity-method lower bound n²/12, and fixes the ambient setup: a finite, decidable-equality vertex type V (variable {V} [Fintype V] [DecidableEq V]).",
+      "mathContext": "Target inequality: $\\mathrm{maxPackingSize}\\,c \\le \\lfloor\\binom{n}{2}/3\\rfloor \\approx n^2/6$, exactly twice the true optimum $n^2/12$."
+    },
+    {
       "id": "triangles",
       "title": "§I: Triangles and Their Six Edges",
-      "startLine": 43,
+      "startLine": 42,
       "endLine": 62,
-      "summary": "Declares the Triangle structure and its edge set (the offDiag of the vertex Finset), and proves Triangle.edges_card: every triangle carries exactly 3·3 − 3 = 6 ordered edges.",
+      "summary": "Declares the Triangle structure (a Finset of vertices with card_eq : card = 3) and its edge set Triangle.edges (the offDiag of the vertex Finset), and proves Triangle.edges_card: every triangle carries exactly 3·3 − 3 = 6 ordered edges, by simp with Finset.offDiag_card and the card_eq field.",
       "mathContext": "Ordered edges make the count exact: a 3-vertex clique has $3^2 - 3 = 6$ ordered pairs of distinct vertices."
     },
     {
       "id": "edge-bound",
-      "title": "§II: Edge-Disjoint Packings and the Double-Counting Bound",
-      "startLine": 64,
-      "endLine": 124,
-      "summary": "Defines isPacking (pairwise edge-disjoint triangles) and proves the core packing_edge_bound (6·|ts| ≤ |V|²−|V|) via Finset.card_biUnion, then packing_card_le_choose (|ts| ≤ C(|V|,2)/3 ≈ |V|²/6).",
-      "mathContext": "Disjoint edge sets of total size $6|ts|$ embed in the $|V|^2-|V|$ ordered edges of $K_{|V|}$, so $6|ts| \\le |V|^2-|V|$ and $|ts| \\le \\binom{|V|}{2}/3$."
+      "title": "§II: Edge-Disjoint Packings and the Core Double-Counting Bound",
+      "startLine": 63,
+      "endLine": 104,
+      "summary": "Defines isPacking (pairwise edge-disjoint triangles) and proves the core packing_edge_bound (6·|ts| ≤ |V|²−|V|): the packing's edge sets form a PairwiseDisjoint family, so Finset.card_biUnion turns the union's card into ∑ 6 = 6·|ts|, and Finset.card_le_card embeds that union in univ.offDiag whose card is |V|²−|V|.",
+      "mathContext": "Disjoint edge sets of total size $6|ts|$ embed in the $|V|^2-|V|$ ordered edges of $K_{|V|}$, so $6|ts| \\le |V|^2-|V|$."
+    },
+    {
+      "id": "choose-bound",
+      "title": "§III: From Edges to Triangles — the C(n,2)/3 Bound",
+      "startLine": 105,
+      "endLine": 123,
+      "summary": "A private helper mul_pred_self (n·(n−1) = n²−n over ℕ, needed because truncated ℕ subtraction hides this identity) bridges the edge bound to packing_card_le_choose: rewriting C(n,2) via Nat.choose_two_right, collapsing /2/3 to /6 via Nat.div_div_eq_div_mul, clearing the division with Nat.le_div_iff_mul_le, then closing by omega. Yields |ts| ≤ C(|V|,2)/3.",
+      "mathContext": "$6|ts| \\le |V|^2-|V| = |V|(|V|-1)$, and $\\binom{|V|}{2} = |V|(|V|-1)/2$, so $|ts| \\le \\binom{|V|}{2}/3$."
     },
     {
       "id": "maxpacking",
-      "title": "§III: Lifting to maxPackingSize — the Parent's Open Statement",
-      "startLine": 125,
+      "title": "§IV: Lifting to maxPackingSize — the Parent's Open Statement",
+      "startLine": 124,
       "endLine": 160,
-      "summary": "Re-declares the 2-coloring vocabulary (Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize) and proves maxPackingSize_le: for every coloring, the maximum monochromatic packing has ≤ C(n,2)/3 triangles — the exact bound left as a `sorry` in Erdos76Problem.lean.",
+      "summary": "Re-declares the 2-coloring vocabulary (Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize as an sSup over achievable packing sizes) and proves maxPackingSize_le: for every coloring, the maximum monochromatic packing has ≤ C(n,2)/3 triangles — the exact bound left as a `sorry` in Erdos76Problem.lean. csSup_le needs nonemptiness (the empty packing witnesses 0) and the per-packing bound from §III.",
       "mathContext": "Every achievable monochromatic-packing size is $\\le \\binom{n}{2}/3$; the set of such sizes is nonempty (empty packing), so $\\sup$ obeys the same bound via csSup_le."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `erdos-76-packing-upper-bound` (quality 89 → 100).

**Improvements:**
- **Sections 3 → 5** covering the full Lean file with corrected line ranges: §0 module framing, §I triangles & six edges, §II the core double-counting bound, §III the C(n,2)/3 division step, §IV lifting to maxPackingSize.
- **Annotations 4 → 5**: split out the natural-number arithmetic step (`packing_card_le_choose` + the `mul_pred_self` helper) as its own annotation with mathContext, significance, and relatedConcepts; tightened the double-counting annotation and aligned all ranges to the source.
- **KeyInsights 4 → 5**: added an insight on the exact ℕ-floor bound C(n,2)/3 (vs the asymptotic n²/6) and the truncated-subtraction care point that the formalization must handle.

All content is drawn directly from the Lean source (`Proofs/Erdos76PackingUpperBound.lean`). meta.json is 16 KB, well under the 60 KB guardrail. JSON validated.