### PR TITLE
Enrich Dirichlet OQ-04-OQ-02: inhomogeneous Kronecker / minimality

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/annotations.json
@@ -59,18 +59,37 @@
   {
     "id": "ann-dirichlet-oq04oq02-approximation",
     "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
-    "range": { "startLine": 75, "endLine": 100 },
+    "range": { "startLine": 75, "endLine": 94 },
     "type": "key-insight",
-    "title": "Inhomogeneous Approximation: the Circle Norm is Distance to ℤ",
-    "content": "exists_int_zsmul_sub_round_lt turns density into a concrete inhomogeneous bound. The ε-ball ball (↑β) ε around the target point is open (isOpen_ball) and nonempty (mem_ball_self hε), so DenseRange.exists_mem_open meets it at some ↑(k • a). Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub turns membership into ‖(↑(k·a − β) : AddCircle 1)‖ < ε. The final step reads this circle norm back as distance to the nearest integer: AddCircle.norm_eq at period 1 (with inv_one, one_mul, mul_one) gives ‖(x : AddCircle 1)‖ = |x − round x|, so the goal |k·a − β − round(k·a − β)| < ε follows with witness n = k. Setting β = 0 recovers the parent OQ-04's homogeneous one-sided bound; general β is the genuine inhomogeneous Kronecker approximation.",
-    "mathContext": "For irrational $a$, any $\\beta$, $\\varepsilon > 0$: $\\exists n,\\ |na - \\beta - \\operatorname{round}(na - \\beta)| < \\varepsilon$; the circle norm $\\|(x:\\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$.",
+    "title": "Inhomogeneous Approximation, Step 1: Density Meets the ε-Ball",
+    "content": "exists_int_zsmul_sub_round_lt turns density into a concrete inhomogeneous bound in two steps; this is the extraction step. The ε-ball ball (↑β) ε around the target point ↑β is open (isOpen_ball) and nonempty (mem_ball_self hε), so DenseRange.exists_mem_open — a dense range meets every nonempty open set — produces an integer k with ↑(k • a) inside the ball. Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub converts that ball-membership into a single circle-norm inequality ‖(↑(k·a − β) : AddCircle 1)‖ < ε. The genuinely inhomogeneous ingredient is that the ball is centred at an ARBITRARY target ↑β, not at 0 as in the parent OQ-04.",
+    "mathContext": "The ball $B(\\uparrow\\!\\beta, \\varepsilon) \\subseteq \\mathbb{R}/\\mathbb{Z}$ is open and nonempty, so density gives $k$ with $\\uparrow(k\\cdot a) \\in B$, i.e. $\\|(\\uparrow(k a - \\beta):\\mathbb{R}/\\mathbb{Z})\\| < \\varepsilon$.",
     "prerequisites": [
       "DenseRange.exists_mem_open",
-      "AddCircle.norm_eq and AddCircle.coe_sub"
+      "mem_ball / dist_eq_norm and AddCircle.coe_sub"
     ],
     "relatedConcepts": [
-      "inhomogeneous Diophantine approximation",
+      "density meets every open set",
+      "ε-ball around an arbitrary target",
+      "inhomogeneous Diophantine approximation"
+    ],
+    "significance": "central"
+  },
+  {
+    "id": "ann-dirichlet-oq04oq02-normreading",
+    "proofId": "dirichlet-approximation-theorem-oq-04-oq-02",
+    "range": { "startLine": 95, "endLine": 100 },
+    "type": "key-insight",
+    "title": "Inhomogeneous Approximation, Step 2: the Circle Norm is Distance to ℤ",
+    "content": "The extraction step leaves a bound on the abstract circle norm ‖(↑(k·a − β) : AddCircle 1)‖; this step reads it back as a concrete real inequality. AddCircle.norm_eq expresses the circle norm as distance to the nearest lattice point, and after the period-1 normalisation (inv_one, one_mul, mul_one) it becomes ‖(x : AddCircle 1)‖ = |x − round x|: the circle norm of a point is literally its distance to the nearest integer. Rewriting the Step-1 bound with this identity turns it into |k·a − β − round(k·a − β)| < ε, discharged with the witness n = k. This is the hinge that makes the topological statement (a point lies in a small ball) mean the Diophantine statement (a multiple approximates β mod 1); setting β = 0 recovers the parent OQ-04's homogeneous bound.",
+    "mathContext": "$\\|(x : \\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$, so $\\|(\\uparrow(k a - \\beta))\\| < \\varepsilon$ becomes $|k a - \\beta - \\operatorname{round}(k a - \\beta)| < \\varepsilon$.",
+    "prerequisites": [
+      "AddCircle.norm_eq at period 1",
+      "round as the nearest integer and |x − round x| as distance to ℤ"
+    ],
+    "relatedConcepts": [
       "circle norm as distance to nearest integer",
+      "topological–Diophantine dictionary",
       "Kronecker's theorem"
     ],
     "significance": "central"

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-04-oq-02/meta.json
@@ -91,7 +91,8 @@
       "**Minimality is the inhomogeneous face of Kronecker density**: OQ-04 shows the orbit of the single point 0 is dense; this entry shows the orbit of EVERY point b is dense, which is the dynamical statement that the irrational rotation x ↦ x + a has no proper closed invariant subset — strictly stronger than the homogeneous case it specialises to at b = 0.",
       "**Translation transports density for free**: the group structure of the circle means every point is a translate of 0, so post-composing the homogeneous dense orbit with the continuous surjective translation x ↦ x + b (via DenseRange.comp) upgrades density-of-one-orbit to density-of-all-orbits without any new analysis.",
       "**The circle norm IS distance to the nearest integer**: on AddCircle 1, AddCircle.norm_eq gives ‖(x : AddCircle 1)‖ = |x − round x|, so the metric statement 'some k·a lands in the ε-ball around ↑β' is literally the Diophantine statement |k·a − β − round(k·a − β)| < ε — an inhomogeneous approximation.",
-      "**Inhomogeneous ⊋ homogeneous**: setting β = 0 recovers the parent's one-sided bound and setting b = 0 recovers the parent's density, so OQ-04 sits inside this entry as the two special cases at the origin."
+      "**Inhomogeneous ⊋ homogeneous**: setting β = 0 recovers the parent's one-sided bound and setting b = 0 recovers the parent's density, so OQ-04 sits inside this entry as the two special cases at the origin.",
+      "**Minimality is exactly an irrationality test**: the irrationality hypothesis is not incidental — a rational rotation a = p/q is periodic, its every orbit being a finite set of q evenly spaced points that is closed and invariant but not dense, so the rotation is emphatically NOT minimal. Minimality of x ↦ x + a therefore holds if and only if a is irrational, and this entry's DenseRange conclusion is the crisp dynamical face of that dichotomy."
     ],
     "prerequisites": [
       "Mathlib's AddCircle API: AddCircle.denseRange_zsmul_coe_iff (multiples dense on the length-p circle ⟺ a/p irrational), the normed-group structure on AddCircle, AddCircle.norm_eq (‖(x:AddCircle p)‖ as distance to the nearest lattice point), and AddCircle.coe_sub",
@@ -126,11 +127,19 @@
     },
     {
       "id": "inhomogeneous-approximation",
-      "title": "Inhomogeneous Dirichlet Approximation from Orbit Density",
+      "title": "Inhomogeneous Approximation, Step 1: Density Meets the ε-Ball",
       "startLine": 75,
+      "endLine": 94,
+      "mathContext": "For irrational $a$, any $\\beta$, $\\varepsilon > 0$: the ball $B(\\uparrow\\!\\beta, \\varepsilon)$ on $\\mathbb{R}/\\mathbb{Z}$ is met by some $\\uparrow(k\\cdot a)$, giving $\\|(\\uparrow(k a - \\beta) : \\mathbb{R}/\\mathbb{Z})\\| < \\varepsilon$.",
+      "summary": "exists_int_zsmul_sub_round_lt begins by extracting an approximant from density. The ε-ball ball (↑β) ε around the target point is open (isOpen_ball) and nonempty (mem_ball_self hε), so DenseRange.exists_mem_open meets it at some ↑(k • a). Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub turns the ball-membership into a circle-norm bound ‖(↑(k·a − β) : AddCircle 1)‖ < ε — an inequality about the single circle point ↑(k·a − β)."
+    },
+    {
+      "id": "norm-as-distance",
+      "title": "Inhomogeneous Approximation, Step 2: the Circle Norm is Distance to ℤ",
+      "startLine": 95,
       "endLine": 100,
-      "mathContext": "For irrational $a$, any $\\beta$, and $\\varepsilon > 0$: $\\exists\\, n,\\ |n a - \\beta - \\operatorname{round}(n a - \\beta)| < \\varepsilon$.",
-      "summary": "exists_int_zsmul_sub_round_lt turns density into a concrete inhomogeneous bound. The ε-ball ball (↑β) ε is open (isOpen_ball) and nonempty (mem_ball_self); DenseRange.exists_mem_open meets it at some ↑(k • a). Unfolding mem_ball / dist_eq_norm and rewriting zsmul_eq_mul and ← AddCircle.coe_sub gives ‖(↑(k·a − β) : AddCircle 1)‖ < ε. Reading the circle norm back as distance to the nearest integer (AddCircle.norm_eq at period 1: inv_one, one_mul, mul_one) yields |k·a − β − round(k·a − β)| < ε with witness n = k. The homogeneous OQ-04 bound is the special case β = 0."
+      "mathContext": "$\\|(x : \\mathbb{R}/\\mathbb{Z})\\| = |x - \\operatorname{round} x|$ at period 1, so $\\exists n,\\ |n a - \\beta - \\operatorname{round}(n a - \\beta)| < \\varepsilon$.",
+      "summary": "The final step reads the circle norm back as the concrete Diophantine quantity. AddCircle.norm_eq at period 1 — after normalising with inv_one, one_mul, mul_one — gives ‖(x : AddCircle 1)‖ = |x − round x|, the distance from x to the nearest integer. Rewriting with this identity turns the norm bound from Step 1 into |k·a − β − round(k·a − β)| < ε, discharged with witness n = k. The homogeneous OQ-04 bound is the special case β = 0."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem-oq-04-oq-02` (quality 91 → 100).

**Improvements:**
- **Sections 4 → 5** and **annotations 4 → 5**: split the single inhomogeneous-approximation block into two granular steps that mirror the Lean proof — (1) *density meets the ε-ball* (`DenseRange.exists_mem_open` extracts an approximant, converted to a circle-norm bound), and (2) *the circle norm is distance to ℤ* (`AddCircle.norm_eq` at period 1 reads ‖·‖ back as |x − round x|). Line ranges aligned to the source.
- **KeyInsights 4 → 5**: added an insight that minimality is exactly an irrationality test — a rational rotation p/q is periodic with a finite, closed, non-dense orbit, so the `DenseRange` conclusion holds iff a is irrational.

All content is drawn from `Proofs/DirichletApproximationOQ04OQ02.lean`. meta.json is 22 KB, well under the 60 KB guardrail. JSON validated.