### PR TITLE
Enrich Erdős #1021 WIP-02: G_k is C₄-free

### DIFF
--- a/src/data/proofs/erdos-1021-wip-02/annotations.json
+++ b/src/data/proofs/erdos-1021-wip-02/annotations.json
@@ -26,14 +26,26 @@
   {
     "id": "ann-c4-free",
     "proofId": "erdos-1021-wip-02",
-    "range": { "startLine": 116, "endLine": 184 },
+    "range": { "startLine": 116, "endLine": 163 },
     "type": "theorem",
-    "title": "G_k is C₄-free — codegree ≤ 1 (Gk_common_neighbors_subsingleton)",
-    "content": "The heart of the file: the set of common neighbours of any two distinct vertices v ≠ w is a Set.Subsingleton (at most one element). The proof splits on the two sides of the bipartition. (1) Both primaries y_i, y_j: since G_k is bipartite, common neighbours are pair vertices; obtaining them as Sum.inr ⟨(e,f),·⟩ and rewriting through adj_primary_pair gives four membership disjunctions i ∈ {e₁,f₁}, j ∈ {e₁,f₁}, i ∈ {e₂,f₂}, j ∈ {e₂,f₂}; with i ≠ j and the orderings e < f, an rcases + omega sweep forces (e₁,f₁) = (e₂,f₂), i.e. both common neighbours are the unique pair {i,j}. (2) Mixed primary/pair: a common neighbour would have to be simultaneously a pair vertex (neighbour of a primary) and a primary (neighbour of a pair) — impossible, so the intersection is empty. (3) Both pair vertices {a,b} ≠ {c,d}: common neighbours are primaries y_m with m ∈ {a,b} ∩ {c,d}; distinctness ¬(a = c ∧ b = d) plus a < b, c < d forces m unique via rcases + omega, since two distinct 2-element sets meet in at most one point.",
-    "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$: two primaries share only $\\{i,j\\}$; two distinct pairs share $\\le 1$ primary; bipartiteness kills the mixed case.",
+    "title": "G_k is C₄-free — Statement, Two-Primaries & Mixed Cases (Gk_common_neighbors_subsingleton)",
+    "content": "The heart of the file: the set of common neighbours of any two distinct vertices v ≠ w is a Set.Subsingleton (at most one element). After rintro-ing two common neighbours u₁, u₂ and simp-ing the neighborSet memberships, rcases splits v and w on the two sides of the bipartition. This annotation covers the first three of the four resulting cases. (1) Both primaries y_i, y_j (i ≠ j from hvw): since G_k is bipartite, common neighbours must be pair vertices, so u₁, u₂ are obtained as Sum.inr ⟨(e,f),·⟩; rewriting through adj_primary_pair yields four membership disjunctions i ∈ {e₁,f₁}, j ∈ {e₁,f₁}, i ∈ {e₂,f₂}, j ∈ {e₂,f₂}, and with i ≠ j and the orderings e < f a 16-way rcases + omega sweep forces (e₁,f₁) = (e₂,f₂) — both common neighbours are the unique pair {i,j}. (2)+(3) The two mixed primary/pair cases: a common neighbour would have to be simultaneously a pair vertex (neighbour of a primary, via adj_primary_iff) and a primary (neighbour of a pair, via adj_pair_iff) — impossible, so the intersection is empty, discharged by absurd.",
+    "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$: two primaries share only the unique pair $\\{i,j\\}$; a primary and a pair share nothing (bipartiteness kills the mixed cases).",
     "significance": "key",
     "relatedConcepts": ["C₄-free / K_{2,2}-free", "codegree", "Kővári–Sós–Turán hypothesis", "Set.Subsingleton", "bipartite case analysis", "omega over Fin"],
-    "prerequisites": ["the adjacency lemmas", "Set.Subsingleton on a neighbourhood intersection", "rcases on disjunctions + omega", "distinct 2-sets meet in ≤ 1 point"]
+    "prerequisites": ["the adjacency lemmas", "Set.Subsingleton on a neighbourhood intersection", "rcases on disjunctions + omega", "bipartiteness of G_k"]
+  },
+  {
+    "id": "ann-c4-free-pairs",
+    "proofId": "erdos-1021-wip-02",
+    "range": { "startLine": 164, "endLine": 184 },
+    "type": "theorem",
+    "title": "C₄-freeness: Two Distinct Pairs Share ≤ 1 Primary",
+    "content": "The fourth and last case of Gk_common_neighbors_subsingleton: v and w are both pair vertices {a,b} ≠ {c,d}. The distinctness ¬(a = c ∧ b = d) is extracted from hvw. Since G_k is bipartite, the common neighbours u₁, u₂ must be primaries, obtained as Sum.inl m₁, Sum.inl m₂; rewriting through adj_pair_inl for both pairs gives m₁ ∈ {a,b}, m₁ ∈ {c,d}, m₂ ∈ {a,b}, m₂ ∈ {c,d}. Because two distinct 2-element subsets of Fin k intersect in at most one point, the orderings a < b, c < d together with ¬(a=c ∧ b=d) force m₁ = m₂ via the same 16-way rcases + omega sweep. This is the incidence-geometry statement that two distinct 'lines' meet in at most one 'point'.",
+    "mathContext": "$\\{a,b\\} \\ne \\{c,d\\} \\implies |\\{a,b\\} \\cap \\{c,d\\}| \\le 1$; the common primary neighbours $m \\in \\{a,b\\} \\cap \\{c,d\\}$ are therefore unique.",
+    "significance": "key",
+    "relatedConcepts": ["distinct 2-sets meet in ≤ 1 point", "partial linear space", "two lines meet in ≤ 1 point", "omega over Fin", "codegree ≤ 1"],
+    "prerequisites": ["adj_pair_inl", "the distinctness hypothesis ¬(a=c ∧ b=d)", "rcases on disjunctions + omega"]
   },
   {
     "id": "ann-corollaries",

--- a/src/data/proofs/erdos-1021-wip-02/meta.json
+++ b/src/data/proofs/erdos-1021-wip-02/meta.json
@@ -37,7 +37,8 @@
       "**C₄-freeness is the real reason for n^{3/2}**: a graph in which every pair of vertices has at most one common neighbour contains no K_{2,2}, and the Kővári–Sós–Turán / Reiman theorem then bounds its edge count by ½(1 + √(4n-3))·n = O(n^{3/2}). This file proves that hypothesis for G_k from first principles.",
       "**Two primaries share exactly one pair**: y_i and y_j (i ≠ j) have a common neighbour only at the unique pair vertex {i,j}; the a < b ordering pins the pair down uniquely.",
       "**Two distinct pairs share at most one primary**: pair vertices {a,b} ≠ {c,d} have a common primary neighbour only for m ∈ {a,b} ∩ {c,d}, and distinct 2-element sets meet in at most one point.",
-      "**Honest boundary**: this file proves only that the trivial KST bound applies; whether the exponent can be *beaten* to 3/2 − c_k (the actual Erdős #1021 question) remains open and is untouched."
+      "**Honest boundary**: this file proves only that the trivial KST bound applies; whether the exponent can be *beaten* to 3/2 − c_k (the actual Erdős #1021 question) remains open and is untouched.",
+      "**C₄-freeness is a partial-linear-space axiom**: reading primary vertices as points and pair vertices as lines (each 'line' being a 2-point set {a,b}), codegree ≤ 1 says two points lie on at most one common line and two lines meet in at most one point — exactly the incidence axioms of a partial linear space. The Kővári–Sós–Turán n^{3/2} bound is the extremal-graph face of that geometric non-degeneracy, so the elementary case analysis here is really verifying an incidence-geometry statement in disguise."
     ],
     "prerequisites": [
       "Simple graphs and neighbor sets (SimpleGraph.neighborSet)",
@@ -64,11 +65,19 @@
     },
     {
       "id": "c4-free",
-      "title": "G_k is C₄-free (codegree ≤ 1)",
+      "title": "G_k is C₄-free: Statement, Two-Primaries and Mixed Cases",
       "startLine": 116,
+      "endLine": 163,
+      "summary": "Gk_common_neighbors_subsingleton states that the neighbourhood intersection of any two distinct vertices is a subsingleton (codegree ≤ 1), and rcases splits on the bipartition. Two primaries y_i, y_j (i ≠ j): common neighbours are pair vertices, and the four adj_primary_pair disjunctions plus i ≠ j and a < b force the same pair {i,j} (a 16-way rcases + omega sweep). The two mixed primary/pair cases are impossible: a common neighbour would be both a pair vertex and a primary, contradicting bipartiteness.",
+      "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$; two primaries share only the unique pair $\\{i,j\\}$, and mixed primary/pair pairs share nothing (bipartite)."
+    },
+    {
+      "id": "c4-free-pairs",
+      "title": "C₄-freeness: Two Distinct Pairs Share ≤ 1 Primary",
+      "startLine": 164,
       "endLine": 184,
-      "summary": "Gk_common_neighbors_subsingleton: the neighbourhood intersection of any two distinct vertices is a subsingleton. Case analysis on the bipartition — two primaries share only the pair {i,j}; two distinct pairs share at most one primary; a primary and a pair share nothing.",
-      "mathContext": "$v \\ne w \\implies |N(v) \\cap N(w)| \\le 1$."
+      "summary": "The remaining case of Gk_common_neighbors_subsingleton: two distinct pair vertices {a,b} ≠ {c,d}. Their common neighbours are primaries y_m with m ∈ {a,b} ∩ {c,d}; the distinctness hypothesis ¬(a=c ∧ b=d) together with a < b and c < d forces m unique — two distinct 2-element subsets of Fin k meet in at most one point — closed by the same rcases + omega sweep over the adj_pair_inl disjunctions.",
+      "mathContext": "$\\{a,b\\} \\ne \\{c,d\\} \\implies |\\{a,b\\} \\cap \\{c,d\\}| \\le 1$, so the two pair vertices share at most one primary neighbour."
     },
     {
       "id": "corollaries",


### PR DESCRIPTION
Enrichment pass for `erdos-1021-wip-02` (quality 91 → 100).

**Improvements:**
- **Sections 4 → 5** and **annotations 4 → 5**: split the single C₄-free block (`Gk_common_neighbors_subsingleton`) into two parts that mirror the proof's case analysis — (a) statement + the two-primaries case (16-way `rcases + omega` forcing the unique pair {i,j}) and the mixed primary/pair impossibility, and (b) the two-distinct-pairs case (distinct 2-sets meet in ≤ 1 point). Line ranges aligned to the source.
- **KeyInsights 4 → 5**: added the incidence-geometry reading — codegree ≤ 1 is exactly the partial-linear-space axiom (two points on at most one line, two lines meeting in at most one point), of which the KST n^{3/2} bound is the extremal face.

All content is drawn from `Proofs/Erdos1021Wip02.lean`. meta.json is 12 KB, well under the 60 KB guardrail. JSON validated.