### PR TITLE
Enrich Erdős #11 WIP-01 OQ-02: kernel-reducible squarefree test

### DIFF
--- a/src/data/proofs/erdos-11-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-erdos11wipoq02-range",
     "proofId": "erdos-11-wip-01-oq-02",
-    "range": { "startLine": 95, "endLine": 117 },
+    "range": { "startLine": 95, "endLine": 104 },
     "type": "insight",
-    "title": "The 0-axiom verified range by a single kernel decide",
-    "content": "repr_range proves ∀ n ∈ range 100, Odd n → 1 < n → ReprCheck n by one kernel `decide`; maxRecDepth is raised to 8000 only so the kernel can walk the nested Finset.range recursions — this does NOT enlarge the trusted axiom set. isSquarefreePlusPow2_range transports it through the iff to conclude every odd 1 < n < 100 is squarefree + a power of two. Critically this uses kernel `decide`, not `native_decide`, so #print axioms (run at the end of the file) shows only the standard propext / Classical.choice / Quot.sound triple — no Lean.ofReduceBool — keeping the verified range genuinely 0-axiom, replacing the parent's per-number hand-written witnesses.",
-    "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\text{IsSquarefreePlusPow2}\\,n$, by one kernel decide; axioms = $\\{$propext, Classical.choice, Quot.sound$\\}$ only.",
+    "title": "The verified range by a single kernel decide",
+    "content": "repr_range proves ∀ n ∈ range 100, Odd n → 1 < n → ReprCheck n by one kernel `decide`. Because ReprCheck (and through it SquarefreeCheck) is a finite conjunction/disjunction of Nat divisibility and comparison tests, the kernel can fully evaluate it for each of the 100 values. set_option maxRecDepth 8000 is raised only so the kernel can walk the nested Finset.range recursions during that evaluation — it is a proof-search recursion budget, NOT an axiom or a trust assumption, so it does not enlarge the trusted axiom set. This single decide replaces the parent's per-number hand-written squarefree witnesses for 3, …, 17.",
+    "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\mathrm{ReprCheck}\\,n$, by one kernel `decide` over `Finset.range 100`.",
     "significance": "key",
-    "relatedConcepts": ["kernel decide vs native_decide", "Lean.ofReduceBool", "maxRecDepth", "#print axioms", "0-axiom verified range"],
-    "prerequisites": ["the kernel-reducible ReprCheck", "decide on bounded ranges", "the foundational axiom triple"]
+    "relatedConcepts": ["kernel decide", "maxRecDepth as a resource knob", "decide on bounded ranges", "reflection of Prop to computable Bool"],
+    "prerequisites": ["the kernel-reducible ReprCheck", "decidability of bounded quantifiers", "decide over Finset.range"]
+  },
+  {
+    "id": "ann-erdos11wipoq02-axioms",
+    "proofId": "erdos-11-wip-01-oq-02",
+    "range": { "startLine": 105, "endLine": 117 },
+    "type": "insight",
+    "title": "Transport through the iff and the 0-axiom certificate",
+    "content": "isSquarefreePlusPow2_range transports repr_range through isSquarefreePlusPow2_iff_check (its .mpr direction) to conclude every odd 1 < n < 100 is genuinely squarefree + a power of two — not merely that it passes the computational test. The three trailing #print axioms commands (on squarefree_iff_check, isSquarefreePlusPow2_iff_check and isSquarefreePlusPow2_range) are the file's own audit: they report only the standard foundational triple propext / Classical.choice / Quot.sound, with NO Lean.ofReduceBool. That absence is the whole point of using kernel `decide` rather than `native_decide` — the latter would compile the check to native code and add Lean.ofReduceBool to the trusted base, so this file's verified range is honestly 0-axiom in a way a native_decide version would not be.",
+    "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\mathrm{IsSquarefreePlusPow2}\\,n$; $\\#\\mathrm{print\\ axioms} = \\{$propext, Classical.choice, Quot.sound$\\}$, no Lean.ofReduceBool.",
+    "significance": "key",
+    "relatedConcepts": ["kernel decide vs native_decide", "Lean.ofReduceBool", "#print axioms audit", "0-axiom verified range", "transport through an iff"],
+    "prerequisites": ["isSquarefreePlusPow2_iff_check", "the foundational axiom triple", "native_decide's Lean.ofReduceBool dependency"]
   }
 ]

--- a/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
@@ -54,7 +54,8 @@
       "The kernel does not reduce Nat.minSqFac, so Squarefree's own Decidable instance is unusable for kernel decide; but Nat divisibility d*d ∣ n IS kernel-reducible (special-cased Nat arithmetic), so a bounded conjunction of divisibility tests gives a practical kernel-reducible squarefree decision.",
       "Folding the 1 ≤ n positivity into SquarefreeCheck makes the equivalence with Squarefree hold unconditionally (both are False at n = 0), which removes a side-condition from every downstream use and keeps ReprCheck honest (it cannot accept n = 2^k via a spurious squarefree-0 summand).",
       "The bound d ≤ n in the test is sound because d*d ∣ n with n ≥ 1 forces d ∣ n hence d ≤ n; no tighter √n bound is needed for correctness, only for speed.",
-      "Staying with kernel decide (not native_decide) keeps the verified range genuinely 0-axiom: #print axioms shows only propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool."
+      "Staying with kernel decide (not native_decide) keeps the verified range genuinely 0-axiom: #print axioms shows only propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool.",
+      "Kernel-reducibility propagates up a two-layer lifting: a single primitive that the kernel can compute (bounded d*d ∣ n divisibility) makes SquarefreeCheck reducible, squarefree_iff_check transfers that to the Squarefree predicate, and simp_rw through the parent's isSquarefreePlusPow2_iff lifts it once more to ReprCheck ↔ IsSquarefreePlusPow2 — so the decidability needed for the range decide is assembled mechanically from the bottom up, never re-proving anything about minSqFac. This 'reflect a Prop as a kernel-computable Bool, then discharge a finite range by decide' pattern is reusable for any bounded verification against a Mathlib predicate whose native instance does not kernel-reduce."
     ],
     "prerequisites": [
       "Parent: erdos-11-wip-01 (IsSquarefreePlusPow2, isSquarefreePlusPow2_iff, squarefreePlusPow2_of_witness)",
@@ -89,11 +90,19 @@
     },
     {
       "id": "range",
-      "title": "The 0-Axiom Verified Range",
-      "startLine": 100,
-      "endLine": 111,
-      "summary": "repr_range and isSquarefreePlusPow2_range: every odd 1 < n < 100 is squarefree + a power of two, by a single kernel decide at 0 axioms.",
-      "mathContext": "Replaces the parent's per-number explicit witnesses with one decide over the whole odd range."
+      "title": "The Range Check by One Kernel decide",
+      "startLine": 95,
+      "endLine": 104,
+      "summary": "repr_range: ∀ n ∈ range 100, Odd n → 1 < n → ReprCheck n, discharged by a single kernel `decide`. set_option maxRecDepth 8000 lets the kernel walk the nested Finset.range recursions — a proof-search resource knob, not a trust knob, so it does not enlarge the axiom set.",
+      "mathContext": "One `decide` over the whole odd range replaces the parent's per-number explicit witnesses; maxRecDepth 8000 is a recursion-budget option, not an axiom."
+    },
+    {
+      "id": "axioms",
+      "title": "Transport to the Representation Predicate and the 0-Axiom Check",
+      "startLine": 105,
+      "endLine": 117,
+      "summary": "isSquarefreePlusPow2_range transports repr_range through isSquarefreePlusPow2_iff_check to conclude every odd 1 < n < 100 is squarefree + a power of two. The trailing #print axioms on squarefree_iff_check, isSquarefreePlusPow2_iff_check and isSquarefreePlusPow2_range confirms the genuinely 0-axiom status: only propext / Classical.choice / Quot.sound, no Lean.ofReduceBool (which native_decide would have introduced).",
+      "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\mathrm{IsSquarefreePlusPow2}\\,n$, with $\\#\\mathrm{print\\ axioms} = \\{\\mathrm{propext}, \\mathrm{Classical.choice}, \\mathrm{Quot.sound}\\}$ only."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-11-wip-01-oq-02` (quality 91 → 100).

**Improvements:**
- **Sections 4 → 5** and **annotations 4 → 5**: split the single range block into (a) the kernel `decide` (`repr_range`, with `maxRecDepth` clarified as a resource knob, not a trust knob) and (b) the transport through `isSquarefreePlusPow2_iff_check` plus the trailing `#print axioms` 0-axiom certificate (only propext/Classical.choice/Quot.sound, no `Lean.ofReduceBool`).
- **KeyInsights 4 → 5**: added the two-layer lifting architecture insight — a single kernel-computable primitive (bounded d²∣n) propagates up through `SquarefreeCheck` and `ReprCheck` mechanically, the reusable reflect-and-`decide` pattern.

All content is drawn from `Proofs/Erdos11WIP01OQ02.lean`. meta.json is 15 KB, under the 60 KB guardrail. JSON validated.