### PR TITLE
research(seeker): replenish pool with 2 diverse OQ children

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: abel-ruffini-galois-extensions-oq-03-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/literature/README.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for abel-ruffini-galois-extensions-oq-03-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/problem.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/problem.md
@@ -1,0 +1,162 @@
+# Problem: Every Nontrivial Normal Subgroup of Aₙ (n ≥ 5) Contains a 3-Cycle
+
+**Slug**: abel-ruffini-galois-extensions-oq-03-oq-01
+**Created**: 2026-07-02
+**Status**: Active
+**Source**: proof-suggestion (open question `abel-ruffini-galois-extensions-oq-03`)
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\, \alpha \text{ a finite type with } 5 \le |\alpha|,\quad
+\forall\, N \trianglelefteq \mathrm{Alt}(\alpha),\ N \ne \{1\}
+\;\Longrightarrow\; \exists\, \sigma \in N,\ \sigma \text{ is a 3-cycle.}
+$$
+
+Consequently, via Mathlib's
+`isSimpleGroup_of_forall_normal_contains_threeCycle`, one obtains
+`IsSimpleGroup (alternatingGroup α)` for every `α` with `5 ≤ Fintype.card α`.
+
+### Plain Language
+
+The alternating group Aₙ (even permutations of n letters) is simple for every
+n ≥ 5 — it has no normal subgroups other than the trivial one and the whole
+group. Mathlib already reduces this fact to a single combinatorial lemma: any
+normal subgroup that contains more than the identity must contain a 3-cycle
+(and since the 3-cycles generate Aₙ and are all conjugate in Aₙ for n ≥ 5, that
+forces the subgroup to be everything). The goal here is to supply that lemma for
+general n, removing the current file's reliance on the black-box
+`alternatingGroup.isSimpleGroup_five` (the n = 5 special case).
+
+### Why This Matters
+
+Simplicity of Aₙ for n ≥ 5 is the group-theoretic heart of the Abel–Ruffini
+theorem: because Aₙ (hence Sₙ) is not solvable for n ≥ 5, the general polynomial
+of degree ≥ 5 is not solvable by radicals. The parent gallery entry proves
+Abel–Ruffini using only the n = 5 instance; generalizing simplicity to all
+n ≥ 5 makes the unsolvability argument uniform in the degree and provides a
+reusable Mathlib-style lemma about the alternating group.
+
+## Known Results
+
+### What's Already Proven
+
+- `isSimpleGroup_of_forall_normal_contains_threeCycle` (Mathlib) — reduces
+  simplicity of `alternatingGroup α` to: every nontrivial normal subgroup
+  contains a 3-cycle.
+- `alternatingGroup.isSimpleGroup_five` (Mathlib) — the n = 5 base case, used as
+  a black box by the parent entry `abel-ruffini-galois-extensions-oq-03`.
+- 3-cycles generate `alternatingGroup α` and are a single conjugacy class in
+  `Alt(α)` once `5 ≤ |α|` (standard; available in Mathlib's `AlternatingGroup`
+  development to varying degrees).
+
+### What's Still Open
+
+- The uniform-in-n proof of the 3-cycle containment lemma is not yet present in
+  the gallery; the parent entry only invokes the n = 5 result.
+- Whether the cleanest formalization proceeds by the classical commutator
+  cycle-type case analysis or by an induction/stabilizer reduction.
+
+### Our Goal
+
+Prove the containment lemma "every nontrivial normal subgroup N of Alt(α)
+contains a 3-cycle" for `5 ≤ card α`, then package
+`IsSimpleGroup (alternatingGroup α)` for all n ≥ 5 and use it to discharge the
+black box in the parent Abel–Ruffini file.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| abel-ruffini-galois-extensions-oq-03 | Direct parent; currently uses the n=5 black box | Galois solvability, Aₙ simplicity |
+| abel-ruffini-galois-extensions | Abel–Ruffini via solvability of the Galois group | Solvable groups, radical towers |
+| abel-ruffini-oq-06 | Contrasting small-n structure: A₄ is NOT simple | Composition series A₄ ▷ V₄ ▷ 1 |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Classical cycle-type case analysis.** Take a non-identity
+   element sigma of N; by considering the cycle type of sigma and forming a
+   commutator with a well-chosen 3-cycle tau, manufacture a nontrivial element
+   of N of smaller/bounded support, and iterate down to a 3-cycle.
+   - Why it might work: it is the standard textbook proof and every step is
+     elementary permutation algebra that `Equiv.Perm` and `decide` can support
+     on bounded support.
+   - Risk: the case split on cycle type is fiddly to formalize cleanly; keeping
+     the "manufacture a shorter element" bookkeeping Lean-friendly is the crux.
+
+2. **Approach B — Reduction/induction on n via point stabilizers.** Use that a
+   normal subgroup meeting the stabilizer of a point non-trivially descends to
+   Aₙ₋₁, plus a transitivity/base-case argument, to reduce to n = 5.
+   - Why it might work: turns the problem into a clean induction anchored at the
+     Mathlib n = 5 result.
+   - Risk: requires careful handling of the primitivity/transitivity of the
+     Aₙ-action and the descent to `Alt(Fin (n-1))`.
+
+### Key Difficulties
+
+- Formalizing "manufacture a 3-cycle from a commutator with a well-chosen
+  3-cycle" without an unwieldy explicit case analysis.
+- Bridging between abstract `alternatingGroup α` statements and concrete
+  `Equiv.Perm (Fin n)` computations for the small-support base cases.
+
+### What Would a Proof Need?
+
+- Key lemma 1: from any non-identity element of N, a nontrivial element of N of
+  strictly smaller support (or of bounded support) via commutators with
+  3-cycles.
+- Key lemma 2: 3-cycles are conjugate in `Alt(α)` for `5 ≤ |α|`, so one 3-cycle
+  in N forces all of them (hence N is the whole group).
+- Technical requirements: Mathlib's `Equiv.Perm.IsThreeCycle`, cycle-type API,
+  `alternatingGroup`, and `isSimpleGroup_of_forall_normal_contains_threeCycle`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematics is classical and completely standard (undergraduate algebra).
+- Mathlib already provides the reduction lemma and the n = 5 base case, so the
+  scope is one well-identified combinatorial lemma rather than the whole theorem.
+- Related permutation-group case analyses have been formalized in the gallery
+  (A₄/V₄ composition series), showing the tooling is adequate.
+
+**Estimated Effort**:
+- Exploration: 1–2 days (survey Mathlib's alternating-group API, choose approach)
+- If tractable: 1–2 weeks
+- If hard: unknown (if the cycle-type case analysis resists clean formalization)
+
+## References
+
+### Papers
+- E. Galois, foundational work on solvability by radicals (historical context).
+
+### Online Resources
+- Standard algebra texts (Dummit & Foote, chapter on the alternating group) —
+  the 3-cycle containment argument for simplicity of Aₙ.
+
+### Mathlib
+- `Mathlib.GroupTheory.SpecificGroups.Alternating` — `alternatingGroup`,
+  `isSimpleGroup_of_forall_normal_contains_threeCycle`,
+  `alternatingGroup.isSimpleGroup_five`.
+- `Mathlib.GroupTheory.Perm.Cycle.Type` — cycle-type API, `IsThreeCycle`.
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - group-theory
+  - alternating-group
+  - simple-groups
+  - galois-theory
+related_proofs:
+  - abel-ruffini-galois-extensions-oq-03
+  - abel-ruffini-galois-extensions
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-02
+```

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: abel-ruffini-galois-extensions-oq-03-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-02T14:45:23-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: minkowski-fundamental-theorem-oq-03-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/literature/README.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for minkowski-fundamental-theorem-oq-03-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/problem.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/problem.md
@@ -1,0 +1,173 @@
+# Problem: van der Corput's Convex-Body Counting Theorem via the Minkowski Multiplicity Principle
+
+**Slug**: minkowski-fundamental-theorem-oq-03-oq-01
+**Created**: 2026-07-02
+**Status**: Active
+**Source**: proof-suggestion (open question `minkowski-fundamental-theorem-oq-03`)
+
+## Problem Statement
+
+### Formal Statement
+
+Let $L \subset \mathbb{R}^n$ be a full-rank lattice and let $S \subset \mathbb{R}^n$ be a
+convex, centrally symmetric body. For an integer $k \ge 1$,
+
+$$
+\operatorname{vol}(S) > k \cdot 2^n \cdot \operatorname{covol}(L)
+\;\Longrightarrow\;
+\bigl|\, (S \cap L) \setminus \{0\} \,\bigr| \;\ge\; 2k,
+$$
+
+i.e. $S$ contains at least $k$ pairs $\{\pm v\}$ of nonzero lattice points
+(equivalently, at least $k+1$ lattice points counting the origin, in the
+"$2k+1$ points" normalization). Minkowski's fundamental theorem is the case
+$k = 1$.
+
+### Plain Language
+
+Minkowski's theorem says a centrally symmetric convex body whose volume exceeds
+$2^n$ times the lattice covolume must contain a nonzero lattice point. van der
+Corput's refinement says that if the volume exceeds $k$ times that threshold,
+the body contains not just one but at least $k$ independent pairs of nonzero
+lattice points. The proof is the same pigeonhole ("multiplicity") principle used
+for Minkowski's theorem, pushed one step further: scaling $S$ by $1/2$ and
+reducing mod $L$, a volume bound forces $k+1$ points of $\tfrac12 S$ to be
+congruent mod $L$, and central symmetry plus convexity turns each coincidence
+into a genuine lattice point of $S$.
+
+### Why This Matters
+
+van der Corput's theorem is the natural quantitative strengthening of the single
+most-used result in the geometry of numbers. It underlies counting arguments for
+lattice points in convex bodies and sharper forms of Minkowski's linear-forms
+and successive-minima results. The parent gallery entry
+(`minkowski-fundamental-theorem`) already formalizes the $k = 1$ pigeonhole
+machinery; this problem asks to reuse that infrastructure to obtain the general
+$k$ multiplicity statement, demonstrating that the formalized proof scales.
+
+## Known Results
+
+### What's Already Proven
+
+- Minkowski's fundamental theorem ($k = 1$) — formalized in the parent gallery
+  entry `minkowski-fundamental-theorem`, and available in Mathlib as
+  `MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`
+  / the `ZLattice` / `Zspan` fundamental-domain API.
+- The Blichfeldt / pigeonhole "multiplicity principle": if
+  $\operatorname{vol}(T) > k \cdot \operatorname{covol}(L)$ then some fibre of the
+  quotient map $T \to \mathbb{R}^n / L$ has at least $k+1$ preimages in $T$.
+
+### What's Still Open
+
+- The general-$k$ (van der Corput) statement is not yet in the gallery; only the
+  $k = 1$ Minkowski case is formalized.
+- The clean "congruent points → genuine lattice points" passage under central
+  symmetry and convexity, packaged as a reusable lemma, has to be written.
+
+### Our Goal
+
+State and prove the van der Corput counting theorem for general $k$ by feeding a
+$k+1$-fold Blichfeldt/pigeonhole coincidence in $\tfrac12 S$ through central
+symmetry and convexity to produce $\ge k$ distinct pairs $\{\pm v\}$ of nonzero
+lattice points in $S$, reusing the parent entry's Minkowski infrastructure.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| minkowski-fundamental-theorem | Direct parent; provides the k=1 pigeonhole machinery | Fundamental domain, measure comparison |
+| minkowski-fundamental-theorem-oq-03 | Immediate parent open question (Blichfeldt-style generalization) | Convex-body lattice counting |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Blichfeldt multiplicity + symmetrization.** Apply the
+   pigeonhole/Blichfeldt principle to $T = \tfrac12 S$: since
+   $\operatorname{vol}(T) = 2^{-n}\operatorname{vol}(S) > k\cdot\operatorname{covol}(L)$,
+   some coset of $L$ has $\ge k+1$ representatives $x_0,\dots,x_k \in T$. For each
+   $i \ge 1$, $x_i - x_0 \in L\setminus\{0\}$, and $x_i - x_0 \in \tfrac12 S -
+   \tfrac12 S = S$ by convexity + central symmetry. Show the resulting points
+   give $\ge k$ distinct $\pm$-pairs.
+   - Why it might work: it is exactly the parent's $k = 1$ argument with the
+     pigeonhole strengthened to multiplicity $k+1$; the geometric step is reused
+     verbatim.
+   - Risk: bookkeeping that the $k$ differences $x_i - x_0$ yield $k$ *distinct*
+     unordered pairs (not collapsing) needs care.
+
+2. **Approach B — Induction on k via excision.** Obtain one pair from Minkowski,
+   excise a small symmetric neighbourhood, and re-apply the volume bound with
+   $k-1$.
+   - Why it might work: reduces to repeated use of the already-formalized $k=1$
+     case.
+   - Risk: controlling volumes after excision is measure-theoretically delicate
+     and likely messier than Approach A.
+
+### Key Difficulties
+
+- Formalizing the "at least $k+1$ congruent points" pigeonhole in Mathlib's
+  measure/quotient framework at multiplicity $k$ (vs. the plain $k=1$ Minkowski
+  statement).
+- Proving the $k$ differences are pairwise distinct as $\pm$-pairs to reach the
+  full count $2k$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a multiplicity Blichfeldt lemma — volume $> k\cdot\operatorname{covol}$
+  forces a fibre with $\ge k+1$ points.
+- Key lemma 2: central symmetry + convexity gives $\tfrac12 S - \tfrac12 S = S$,
+  so differences of points of $\tfrac12 S$ land in $S$.
+- Technical requirements: Mathlib `ZLattice` / `Zspan` fundamental domain,
+  measure of scaled sets ($\operatorname{vol}(cS) = c^n \operatorname{vol}(S)$),
+  and a finite pigeonhole with multiplicity.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The $k = 1$ case is already formalized in the parent entry, so the geometric
+  core exists; the task is a quantitative upgrade of the pigeonhole step.
+- The mathematics is classical (van der Corput, 1930s) and short on paper.
+- The main formalization risk is the multiplicity pigeonhole and distinctness
+  bookkeeping, not any deep new theory.
+
+**Estimated Effort**:
+- Exploration: 1–2 days (review the parent formalization and Mathlib lattice API)
+- If tractable: 1–2 weeks
+- If hard: unknown (if the multiplicity pigeonhole is awkward in Mathlib's
+  measure framework)
+
+## References
+
+### Papers
+- J. G. van der Corput, "Verallgemeinerung einer Mordellschen Beweismethode in
+  der Geometrie der Zahlen" (1930s) — the multiplicity generalization.
+- H. Minkowski, *Geometrie der Zahlen* (1896) — the k = 1 fundamental theorem.
+
+### Online Resources
+- Cassels, *An Introduction to the Geometry of Numbers* — van der Corput's
+  theorem and Blichfeldt's principle.
+
+### Mathlib
+- `Mathlib.Algebra.Module.ZLattice.Basic` / `Mathlib.LinearAlgebra.FreeModule.PID`
+  — lattices and covolume.
+- `Mathlib.MeasureTheory.Group.FundamentalDomain` — fundamental domains and the
+  measure-comparison pigeonhole underlying Minkowski's theorem.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - geometry-of-numbers
+  - lattices
+  - convex-bodies
+  - van-der-corput
+related_proofs:
+  - minkowski-fundamental-theorem
+  - minkowski-fundamental-theorem-oq-03
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-02
+```

--- a/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/state.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: minkowski-fundamental-theorem-oq-03-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-02T14:45:24-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Seeker replenishment: the candidate pool had fallen to **14 available**
(below the 15 threshold). This PR adds two fresh, concrete, distinct-domain
open-question children to bring the pool to **16 available**.

Both candidates pass the OQ-chain guardrails (depth 2; no repeated `-oq-NN`
index; no sibling duplicate) and the seeker stub validator
(`scripts/research/validate-seeker-stubs.ts` — PASS, no template placeholders).

## Selected problems

### `abel-ruffini-galois-extensions-oq-03-oq-01` — algebra (Tier A, sig 7, tract 6)
Prove the classical cycle-type lemma: **every nontrivial normal subgroup of
`alternatingGroup α` (`5 ≤ card α`) contains a 3-cycle**, discharging Mathlib's
`isSimpleGroup_of_forall_normal_contains_threeCycle` to obtain unconditional
simplicity of Aₙ for all n ≥ 5 — replacing the parent file's `isSimpleGroup_five`
(n = 5) black box. The group-theoretic heart of Abel–Ruffini, made uniform in n.

### `minkowski-fundamental-theorem-oq-03-oq-01` — geometry of numbers (Tier B, sig 6, tract 6)
Derive **van der Corput's convex-body counting theorem** (a symmetric convex body
of volume > k·2ⁿ·covolume contains ≥ k+1 lattice points) from the
Minkowski multiplicity/pigeonhole principle already formalized in the parent
entry — a quantitative upgrade reusing the k = 1 infrastructure.

## Notes

- DB + `.lean/state/candidate-pool.json` (both gitignored/live-only) already updated
  at REPO_ROOT so running researchers see the 16 available problems immediately;
  this PR carries the tracked workspace files (`research/problems/<slug>/`).
- No `loom:review-requested` (math agent PR; deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)