### PR TITLE
research(schroeder-bernstein-oq-03): chase preserves correspondence + escape-existence obstruction

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -343,6 +343,42 @@ theorem fwdOrbit_chase_length_le {f g : ℕ → ℕ}
   rw [hIcc] at hcard
   exact le_trans hcard (List.toFinset_card_le D)
 
+/-- **The collision chase preserves the source predicate.** Each chase step sends `x` to
+    `g (f x)`, and the reductions give `p (g (f x)) ↔ q (f x) ↔ p x`; so the `p`-value is
+    invariant along the whole forward orbit: `p (fwdOrbit f g a k) ↔ p a` for every `k`.
+
+    This is the correspondence half of the collision step. When a fresh domain point `a`
+    cannot take its own image `f a` (already used) and the scheduler routes it instead to
+    the image `f (fwdOrbit f g a N)` of a later, *escaping* orbit point (`chase_target_corr`
+    below), the resulting edge still respects the membership condition — precisely because
+    walking the orbit never changes the `p`-value. Note this holds for *arbitrary* (not
+    necessarily computable) predicates `p, q`: the invariance is routed structurally through
+    the reductions `f, g`, never by testing `p`/`q`. -/
+theorem fwdOrbit_corr {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hfpq : ∀ n, p n ↔ q (f n)) (hgpq : ∀ n, q n ↔ p (g n)) (a : ℕ) :
+    ∀ k, p (fwdOrbit f g a k) ↔ p a := by
+  intro k
+  induction k with
+  | zero => rfl
+  | succ k ih =>
+      rw [fwdOrbit_succ]
+      -- `p (g (f xₖ)) ↔ q (f xₖ) ↔ p xₖ ↔ p a`
+      rw [← hgpq (f (fwdOrbit f g a k)), ← hfpq (fwdOrbit f g a k)]
+      exact ih
+
+/-- **Correspondence for the routed collision target.** Combining `fwdOrbit_corr` with the
+    `f`-reduction: the membership condition `p a ↔ q (f (fwdOrbit f g a N))` holds for every
+    orbit stage `N`. So routing the fresh domain point `a` to the range value
+    `f (fwdOrbit f g a N)` — the escape target the chase produces once `f` of an orbit point
+    lands outside the occupied range — records a pair `(a, f (fwdOrbit f g a N))` that
+    satisfies `MatchingCorr`. Together with `fwdOrbit_chase_length_le` (the chase is bounded,
+    hence computable) this discharges both obligations of the even-stage collision move:
+    *bounded termination* and *correspondence preservation*. -/
+theorem chase_target_corr {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hfpq : ∀ n, p n ↔ q (f n)) (hgpq : ∀ n, q n ↔ p (g n)) (a N : ℕ) :
+    p a ↔ q (f (fwdOrbit f g a N)) :=
+  (fwdOrbit_corr hfpq hgpq a N).symm.trans (hfpq (fwdOrbit f g a N))
+
 /-!
 ## Section 4a: The Σ₁ / Π₁ complexity of `range g` — machine-checked
 

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -342,3 +342,37 @@ confirmation + the metadata correction. The scheduler recursion (stage builder
 producing `IsMatching`+`MatchingCorr` matchings, coverage via `firstMissing_le_length`,
 and reading off a computable `ℕ ≃ ℕ`) remains the genuine crux for a future session
 with a durable build environment.
+
+## Session 2026-07-02 (researcher-9): correspondence half of the collision step + escape-existence obstruction
+
+Added 2 VERIFIED lemmas (`#print axioms` = `[propext]` only — no `sorryAx`, no
+`ofReduceBool`, not even `Classical.choice`; green build via pinned toolchain
+`elan run leanprover/lean4:v4.26.0 lake env lean`, Docker Desktop was crashed):
+
+- `fwdOrbit_corr` — **the collision chase preserves the source predicate**:
+  `p (fwdOrbit f g a k) ↔ p a` for all `k`, given the reductions `hfpq`/`hgpq`.
+  Clean induction: `p (g (f x)) ↔ q (f x) ↔ p x` per step. Holds for *arbitrary*
+  (non-computable) `p, q` — routed structurally through `f, g`, never testing `p`/`q`.
+- `chase_target_corr` — corollary `p a ↔ q (f (fwdOrbit f g a N))` for every `N`.
+  So routing a blocked fresh domain point `a` to the escape target `f (fwdOrbit f g a N)`
+  records a pair satisfying `MatchingCorr`. This is the **correspondence obligation** of
+  the even-stage collision move; the *bounded-termination* obligation was already covered
+  by `fwdOrbit_chase_length_le`. Modest (both are short), but a genuinely-absent
+  ingredient rather than a restatement.
+
+**Obstruction found (important for future sessions).** `fwdOrbit_chase_length_le` does
+**not** by itself give escape-existence (`∃ N ≤ L.length, f (fwdOrbit f g a N) ∉ mRan L`).
+Its hypothesis — *every* chase point `fwdOrbit f g a k` (`1 ≤ k ≤ N`) lies in `mDom L` —
+is exactly the gap, and the naive "keep colliding ⟹ stay in mDom L" induction **fails**:
+from `f x ∈ mRan L` and `BuiltFrom`, the blocking pair is an `f`-edge OR a `g`-edge
+(generalizing `collision_f_source` by dropping the freshness hypothesis):
+  - `g`-edge ⟹ `g (f x) = fwdOrbit …(k+1) ∈ mDom L` (chain continues, good);
+  - `f`-edge ⟹ only `x ∈ mDom L` (no control on the *next* point `g (f x)`).
+So once the orbit re-enters an `f`-edge domain point, the counting bound no longer forces
+the successor into `mDom L`, and escape-existence is not free. Establishing escape (hence
+that the even-stage collision move is total) likely needs a **stronger construction
+invariant** than `BuiltFrom` — e.g. one guaranteeing the matched domain is closed under
+the relevant orbit step, or a different chase that stops at the first `f`-edge re-entry.
+This is the residual crux, and it is finer than the earlier "`isGFree` Π₁" framing:
+the `isGFree` obstruction is avoided (blockers are named), but *termination of the
+routing* is the real open point. `myhill_isomorphism` → sorry UNCHANGED.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -1,29 +1,31 @@
 # Research State: schroeder-bernstein-oq-03
 
 ## Current State
-**Phase**: ACT
+**Phase**: DEVELOP
 **Path**: full
 **Since**: 2026-07-02
 **Iteration**: 2
 
 ## Current Focus
-Collision resolution for the back-and-forth (the crux). Section 4g added: names the
-collision blocker via the `BuiltFrom` invariant, replacing the Π₁ `isGFree` decision
-with a decidable membership test + explicit orbit point `g (f a)`.
+Even-stage collision move of the Myhill priority scheduler: routing a blocked fresh
+domain point along the forward orbit to an escaping target.
 
 ## Active Approach
-Stage-wise finite priority construction (Rogers §7.4). Atomic steps (4c), exhaustion
-(4d/4e), evaluator (4f), and now collision structure (4g) are all in place. Remaining:
-the stage recursion + termination/coverage/computability.
+Stage-wise finite back-and-forth (Rogers §7.4). Collision step obligations:
+(1) bounded termination — DONE (`fwdOrbit_chase_length_le`);
+(2) correspondence preservation — DONE this session (`fwdOrbit_corr`/`chase_target_corr`);
+(3) escape-existence (a fresh target actually exists) — OPEN, and found to be the real
+    crux (see knowledge.md 07-02: naive counting fails on f-edge orbit re-entry; likely
+    needs a stronger construction invariant than `BuiltFrom`).
 
 ## Attempt Count
-- Total attempts: 2
-- Approaches tried: 1 (stage-wise back-and-forth; classical orbit approach rejected as Π₁)
+- Approaches tried: 1 (stage-wise back-and-forth), in progress across sessions.
 
 ## Blockers
-`myhill_isomorphism` → sorry: the stage recursion (collision-chase) + its computability.
-Section 4g reduces this to a *bounded* search (no `isGFree`). Not yet closed.
+Escape-existence / termination of the collision routing. Finer than the earlier
+`isGFree` Π₁ framing — blockers are named, but routing-termination is unproven.
 
 ## Next Action
-Define the stage recursion using `step_f_available_or_collision`; chase along
-`fwdOrbit f g a` to the first fresh f-image; prove termination via finite matching length.
+Prove escape-existence for the collision step, or find the stronger stage invariant
+that makes the chase stay in `mDom L` until escape. Then assemble the stage recursion
+(matching chain + `firstMissing` coverage + read-off computable `ℕ ≃ ℕ`).

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1177,
+    "lineCount": 1213,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -59,7 +59,7 @@
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 65,
+    "theoremCount": 67,
     "definitionCount": 14,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
@@ -249,9 +249,9 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 1177,
+    "lineCount": 1213,
     "axiomCount": 0,
-    "theoremCount": 65,
+    "theoremCount": 67,
     "definitionCount": 14,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",


### PR DESCRIPTION
## Summary

Advances the Myhill isomorphism theorem formalization (`schroeder-bernstein-oq-03`,
`SchroederBernsteinOQ03.lean`) by supplying the **correspondence half** of the even-stage
collision move in the priority scheduler, and documents a precise **obstruction** that
redirects the remaining work.

The main `myhill_isomorphism` → sorry (the open crux) is **unchanged** — this is
supporting infrastructure, honestly modest in size.

## New lemmas (both VERIFIED, `#print axioms` = `[propext]` only — no `sorryAx`, no `ofReduceBool`, no `Classical.choice`)

- **`fwdOrbit_corr`** — the collision chase preserves the source predicate:
  `p (fwdOrbit f g a k) ↔ p a` for all `k`. Each step `x ↦ g (f x)` gives
  `p (g (f x)) ↔ q (f x) ↔ p x`, so the `p`-value is invariant along the whole forward
  orbit. Holds for *arbitrary* (non-computable) `p, q`: routed structurally through the
  reductions `f, g`, never testing `p`/`q`.
- **`chase_target_corr`** — corollary `p a ↔ q (f (fwdOrbit f g a N))`. Routing a blocked
  fresh domain point `a` to the escape target `f (fwdOrbit f g a N)` records a pair
  satisfying `MatchingCorr`.

Together these discharge the *correspondence-preservation* obligation of the even-stage
collision move; the *bounded-termination* obligation was already covered by the existing
`fwdOrbit_chase_length_le`.

## Obstruction documented (the honest part)

`fwdOrbit_chase_length_le` does **not** by itself yield escape-existence
(`∃ N ≤ L.length, f (fwdOrbit f g a N) ∉ mRan L`). Its hypothesis — every chase point
lands in `mDom L` — is exactly the gap: from `f x ∈ mRan L` + `BuiltFrom`, the blocker is
an `f`-edge **or** a `g`-edge; only the `g`-edge case forces the *successor* orbit point
into `mDom L`. Once the orbit re-enters an `f`-edge domain point the counting bound breaks,
so escape-existence (hence totality of the collision move) is not free and likely needs a
stronger construction invariant than `BuiltFrom`. This is finer than the earlier
`isGFree` Π₁ framing: blockers are named, but *routing termination* is the real open point.
Recorded in `knowledge.md` / `state.md` for future sessions.

## Build

Compiled clean with the pinned toolchain (`elan run leanprover/lean4:v4.26.0 lake env lean`)
against prebuilt Mathlib oleans — Docker Desktop was crashed this session. Only pre-existing
warnings remain (the `myhill_isomorphism` sorry + pre-existing unused-variable lints).

## Meta

`meta.json` counts synced: lineCount 1177→1213, theoremCount 65→67. Status remains
`formalized`/`wip` (the open sorry keeps it honestly WIP); `axiomCount` remains 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)