### PR TITLE
Enrich Euler totient OQ-09: φ(n^k) = n^{k-1}·φ(n)

### DIFF
--- a/src/data/proofs/euler-totient-oq-09/annotations.json
+++ b/src/data/proofs/euler-totient-oq-09/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "totient-oq09-ann-dvd-dichotomy",
     "proofId": "euler-totient-oq-09",
-    "range": { "startLine": 101, "endLine": 121 },
+    "range": { "startLine": 101, "endLine": 110 },
     "type": "theorem",
-    "title": "Divisibility and the n ↦ 2n Dichotomy",
-    "content": "Two divisibility facts read straight off the power law: `pow_pred_dvd_totient_pow` (nᵏ⁻¹ ∣ φ(nᵏ), the leading power factor survives) and `totient_dvd_totient_pow` (φ(n) ∣ φ(nᵏ)). The doubling dichotomy specializes the p = 2 prime-scaling lemmas: `totient_two_mul_of_even` (φ(2n) = 2φ(n) when 2 ∣ n, from `Nat.totient_mul_of_prime_of_dvd`) and `totient_two_mul_of_odd` (φ(2n) = φ(n) when n is odd, from `Nat.totient_mul_of_prime_of_not_dvd`). These refine how doubling interacts with the parity of φ.",
-    "mathContext": "$n^{k-1} \\mid \\varphi(n^k),\\ \\varphi(n) \\mid \\varphi(n^k); \\qquad \\varphi(2n) = \\begin{cases} 2\\varphi(n) & 2 \\mid n \\\\ \\varphi(n) & 2 \\nmid n \\end{cases}.$",
+    "title": "Divisibility Consequences of the Power Law",
+    "content": "Two divisibility facts read straight off the factored power law φ(nᵏ) = nᵏ⁻¹·φ(n). `pow_pred_dvd_totient_pow`: nᵏ⁻¹ ∣ φ(nᵏ) — the leading power factor survives the totient — proved by rewriting with `totient_pow` and taking `dvd_mul_right`. `totient_dvd_totient_pow`: φ(n) ∣ φ(nᵏ), the other factor, by `dvd_mul_left`. Together they express that φ(nᵏ) sits in the divisibility chain φ(n) ∣ φ(n²) ∣ φ(n³) ∣ … with each successive quotient equal to n.",
+    "mathContext": "$n^{k-1} \\mid \\varphi(n^k)$ and $\\varphi(n) \\mid \\varphi(n^k)$ for every $k \\ge 1$.",
     "significance": "key",
-    "relatedConcepts": ["divisibility", "parity dichotomy", "totient_mul_of_prime_of_dvd", "doubling map"],
-    "prerequisites": ["the power law", "single-prime scaling lemmas"]
+    "relatedConcepts": ["divisibility", "dvd_mul_right / dvd_mul_left", "totient divisibility chain"],
+    "prerequisites": ["the power law totient_pow", "elementary divisibility of products"]
+  },
+  {
+    "id": "totient-oq09-ann-dichotomy",
+    "proofId": "euler-totient-oq-09",
+    "range": { "startLine": 112, "endLine": 121 },
+    "type": "theorem",
+    "title": "The n ↦ 2n Parity Dichotomy",
+    "content": "The doubling map splits according to the parity of n, specializing the p = 2 prime-scaling lemmas. `totient_two_mul_of_even`: when 2 ∣ n, φ(2n) = 2φ(n) — this is literally the p = 2 case of `Nat.totient_mul_of_prime_of_dvd` (2's only prime already divides n, so the prime-saturated scaling applies). `totient_two_mul_of_odd`: when 2 ∤ n, φ(2n) = φ(n), from `Nat.totient_mul_of_prime_of_not_dvd` (which scales by p − 1 = 1) closed by norm_num. The dichotomy refines how doubling interacts with the parity classification of φ studied in the sibling oq-06.",
+    "mathContext": "$\\varphi(2n) = \\begin{cases} 2\\varphi(n) & 2 \\mid n \\\\ \\varphi(n) & 2 \\nmid n \\end{cases}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["parity dichotomy", "totient_mul_of_prime_of_dvd", "totient_mul_of_prime_of_not_dvd", "doubling map"],
+    "prerequisites": ["single-prime scaling lemmas", "the prime-saturated vs non-dividing split"]
   }
 ]

--- a/src/data/proofs/euler-totient-oq-09/meta.json
+++ b/src/data/proofs/euler-totient-oq-09/meta.json
@@ -95,7 +95,8 @@
       "**The product ∏(1 − 1/p) is a function of the prime support only.** Since n and n^k share every prime factor, φ(n^k)/n^k = φ(n)/n, and the power law is just clearing the n^k versus n factor — no induction on the exponent is needed.",
       "**The right level of generality is 'prime-saturated multiplier', not 'power'.** The single lemma φ(m·n) = m·φ(n) for m.primeFactors ⊆ n.primeFactors subsumes the power law, the recurrence, the square case, and Mathlib's single-prime φ(p·n) = p·φ(n) all at once.",
       "**The coprime multiplicative law is the wrong tool here.** `Nat.totient_mul` needs gcd(m, n) = 1, but n and n^k are maximally non-coprime; the product-formula route sidesteps coprimality entirely and works precisely because the prime supports coincide.",
-      "**The identity holds for every base, including 0.** φ(0^k) = φ(0) = 0 = 0^{k−1}·φ(0), so no positivity hypothesis on n is required — only k ≥ 1, which is genuinely necessary (the k = 0 statement φ(1) = n^{−1}·φ(n) is meaningless)."
+      "**The identity holds for every base, including 0.** φ(0^k) = φ(0) = 0 = 0^{k−1}·φ(0), so no positivity hypothesis on n is required — only k ≥ 1, which is genuinely necessary (the k = 0 statement φ(1) = n^{−1}·φ(n) is meaningless).",
+      "**φ(nᵏ)/nᵏ is a k-invariant of the base.** Because the ratio equals ∏_{p∣n}(1 − 1/p), which depends only on the radical (squarefree kernel) of n, every power of n — and indeed any two numbers with the same prime support — share the same totient density. This reframes the power law as the statement that powering moves along a level set of the density functional, and it is the structural reason the divisibility chain φ(n) ∣ φ(n²) ∣ φ(n³) ∣ … holds with each quotient exactly n."
     ],
     "prerequisites": [
       "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",
@@ -136,11 +137,20 @@
       "summary": "`totient_pow` (φ(n^k) = n^(k−1)·φ(n) for k ≥ 1, via n^k = n^(k−1)·n and `Nat.primeFactors_pow`), `totient_pow_succ` (the recurrence φ(n^{k+1}) = n·φ(n^k) via n^{k+1} = n·n^k), and `totient_sq` (the k = 2 specialization φ(n²) = n·φ(n))."
     },
     {
-      "id": "divisibility-and-dichotomy",
-      "title": "Divisibility Consequences and the n ↦ 2n Dichotomy",
+      "id": "divisibility",
+      "title": "Divisibility Consequences of the Power Law",
       "startLine": 101,
+      "endLine": 110,
+      "summary": "`pow_pred_dvd_totient_pow` (n^{k−1} ∣ φ(n^k), the leading power factor survives the totient) and `totient_dvd_totient_pow` (φ(n) ∣ φ(n^k)) both read straight off `totient_pow` by rewriting and taking `dvd_mul_right` / `dvd_mul_left` on the factored form n^{k−1}·φ(n).",
+      "mathContext": "$n^{k-1} \\mid \\varphi(n^k)$ and $\\varphi(n) \\mid \\varphi(n^k)$ for every $k \\ge 1$."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The n ↦ 2n Parity Dichotomy",
+      "startLine": 112,
       "endLine": 121,
-      "summary": "`pow_pred_dvd_totient_pow` (n^{k−1} ∣ φ(n^k)) and `totient_dvd_totient_pow` (φ(n) ∣ φ(n^k)) read off the power law; `totient_two_mul_of_even` (φ(2n) = 2φ(n) for 2 ∣ n, the p = 2 case of `Nat.totient_mul_of_prime_of_dvd`) and `totient_two_mul_of_odd` (φ(2n) = φ(n) for n odd) record the doubling dichotomy."
+      "summary": "`totient_two_mul_of_even` (φ(2n) = 2φ(n) when 2 ∣ n, exactly the p = 2 case of `Nat.totient_mul_of_prime_of_dvd`) and `totient_two_mul_of_odd` (φ(2n) = φ(n) when 2 ∤ n, from `Nat.totient_mul_of_prime_of_not_dvd` then norm_num) record how the doubling map acts on the totient according to the parity of n.",
+      "mathContext": "$\\varphi(2n) = 2\\varphi(n)$ if $2 \\mid n$, and $\\varphi(2n) = \\varphi(n)$ if $2 \\nmid n$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-09` (quality 91 → 100).

**Improvements:**
- **Sections 4 → 5** and **annotations 4 → 5**: split the combined divisibility-and-dichotomy block into (a) the two divisibility consequences (n^{k−1} ∣ φ(n^k), φ(n) ∣ φ(n^k)) read off the factored power law, and (b) the n ↦ 2n parity dichotomy (φ(2n) = 2φ(n) vs φ(n) as the p = 2 cases of the prime-scaling lemmas). Ranges aligned to the source.
- **KeyInsights 4 → 5**: added that φ(n^k)/n^k = ∏_{p∣n}(1 − 1/p) is a k-invariant depending only on the radical of n — the structural reason powering stays on a level set of the totient density and the divisibility chain φ(n) ∣ φ(n²) ∣ … has each quotient exactly n.

All content is drawn from `Proofs/EulerTotientOQ09.lean`. meta.json is 17 KB, under the 60 KB guardrail. JSON validated.