### PR TITLE
Enrich Erdős #458 OQ-05: prime-power structure insight + cross-references

### DIFF
--- a/src/data/proofs/erdos-458-oq-05/meta.json
+++ b/src/data/proofs/erdos-458-oq-05/meta.json
@@ -38,7 +38,9 @@
       "The whole account is kernel-checkable: replacing `native_decide` with `decide` throughout removes the `Lean.ofReduceBool` axiom, turning the parent's `axiomatized` base cases into genuinely `verified` (0-axiom) ones.",
       "`Nat.nth_count` is the exact tool for value facts about Nat.nth: it converts 'n is prime and there are k primes below n' into 'the k-th prime is n', so no prime-index value ever needs to be asserted.",
       "Kernel `decide` scales far enough for this range: primality and prime-counting up to 31, and lcm(1,…,12) = 27720, all reduce in the kernel without the compiler.",
-      "Kernel `decide` keeps every prime value and base case axiom-free, whereas the parent's `native_decide` pulls in `Lean.ofReduceBool`. The price is that kernel reduction of `Nat.count` and of `lcm(1..12)` is far more expensive — which is exactly what caps the verified reach at the 11th prime (31) and at k = 4."
+      "Kernel `decide` keeps every prime value and base case axiom-free, whereas the parent's `native_decide` pulls in `Lean.ofReduceBool`. The price is that kernel reduction of `Nat.count` and of `lcm(1..12)` is far more expensive — which is exactly what caps the verified reach at the 11th prime (31) and at k = 4.",
+      "The inequality's real content is about prime powers, not primes. Since no prime lies strictly between p_k and p_{k+1}, the ratio lcm(1,…,p_{k+1}−1) / lcm(1,…,p_k) gains no new prime factor: it is the product of the prime-power 'bumps' p^j with p_k < p^j ≤ p_{k+1}−1 for primes p ≤ p_k. Erdős #458 asserts this product of higher-prime-power increments stays below p_k. The verified base cases exhibit this directly — at k = 3, lcm(1,…,10) = 2520 versus 7·lcm(1,…,7) = 7·420 = 2940, i.e. the gap [7,10] contributes exactly the extra factors 2³/2² and 3²/3 = 2·3 = 6, and 6 < 7 is the razor-thin margin. At k = 2 and k = 4 the gap holds no prime power at all, so the ratio is 1.",
+      "Nat.nth and Nat.count form a Galois-style pair for any infinite decidable predicate p: `nth p` enumerates the p-satisfying naturals in increasing order while `count p n` tallies how many lie below n. The single lemma `Nat.nth_count : p n → nth p (count p n) = n` is the round-trip identity that lets a *decidable count* certify an *enumeration value* — which is why every p_k here is extracted purely by computing `count Nat.Prime n`, with no separately asserted table of primes."
     ],
     "prerequisites": [
       "The parent formalization erdos-458 (statement of the LCM inequality and the nthPrime setup)",
@@ -89,6 +91,16 @@
       "targetId": "erdos-458",
       "relationship": "extends",
       "description": "Answers OQ-05 (prime-index values from Nat.nth) and advances OQ-03 (more base cases) of the parent LCM-inequality formalization, additionally removing its native_decide / Lean.ofReduceBool dependency for the verified cases."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-06-oq-02",
+      "relationship": "related",
+      "description": "A complementary view of the same object p_k = Nat.nth Nat.Prime k: that entry pins the asymptotic size p_k ≳ n·log n via the Chebyshev upper density, whereas this entry computes the first eleven values p_0,…,p_10 = 2,…,31 exactly from the Nat.nth / Nat.count bridge."
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate (a prime in (n, 2n]) is the archetypal explicit prime-gap bound. Erdős #458's conditional route to the full conjecture instead needs the stronger Legendre-type gap (a prime between consecutive squares), because controlling lcm growth across the interval [p_k, p_{k+1}) requires bounding how large p_{k+1} can be relative to p_k."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `erdos-458-oq-05` (Prime Indices from Nat.nth, and Axiom-Free Base Cases). The entry had excellent annotations (13, all fully populated) but a thin meta overview (4 keyInsights, 1 cross-reference). Added substantive depth, staying well under all size caps.

**New keyInsights (4 → 6):**
- **Prime-power structure** — the real content of the inequality: since no prime lies between p_k and p_{k+1}, the ratio lcm(1..p_{k+1}−1)/lcm(1..p_k) is the product of prime-power *bumps* in the gap, which #458 asserts stays below p_k. Illustrated with the tight k=3 case (lcm(1..10)=2520 vs 7·420=2940, ratio 2·3 = 6 < 7) and the ratio-1 cases k=2,4. Arithmetic verified independently.
- **Galois-pair framing** — Nat.nth / Nat.count as a Galois-style pair, with `Nat.nth_count` the round-trip identity that lets a decidable count certify an enumeration value.

**New cross-references (1 → 3):**
- `chebyshev-pnt-bridge-oq-06-oq-02` — asymptotic p_k ≳ n·log n vs this entry's exact small values.
- `bertrands-postulate` — prime-gap control underlying #458's conditional (Legendre) route.

**Size:** meta.json 8.3 KB → 10.3 KB (cap 60 KB); keyInsights 6/12, crossRefs 3/20. No annotation changes. `pnpm build` passes.