### PR TITLE
Enrich Fibonacci identities OQ-03-OQ-01: fib(4n+3) as a sum of two squares

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
@@ -73,22 +73,45 @@
     "proofId": "fibonacci-identities-oq-03-oq-01",
     "range": {
       "startLine": 58,
-      "endLine": 79
+      "endLine": 74
     },
     "type": "theorem",
     "title": "Existential and Integer Forms",
-    "content": "**Packaging.** `fib_four_mul_add_three_isSumSq` gives $\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$ over $\\mathbb{N}$ with the explicit witnesses; `fib_four_mul_add_three_iterated_int` casts the decomposition to $\\mathbb{Z}$. The three `decide` checks that follow ($F_3=2$, $F_7=13$, $F_{11}=89$) confirm the $n=0,1,2$ instances by kernel reduction — `decide`, not `native_decide`, so no `Lean.ofReduceBool` and the entry stays 0-axiom.",
-    "mathContext": "$\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$; integer form via `exact_mod_cast`. Checks: $F_3=2,\\ F_7=13,\\ F_{11}=89$.",
+    "content": "**Packaging.** `fib_four_mul_add_three_isSumSq` gives $\\exists a\\,b : \\mathbb{N},\\ F_{4n+3} = a^2 + b^2$ with the explicit witnesses $a = F_{n+1}(2F_n+F_{n+1})$, $b = F_{n+1}^2+F_n^2$ (proved by handing those two values to the iterated identity). `fib_four_mul_add_three_iterated_int` casts the decomposition to $\\mathbb{Z}$ via `exact_mod_cast` — the $\\mathbb{N}$ statement already involves no subtraction, but the $\\mathbb{Z}$ form is convenient for downstream algebra (e.g. reading off a Gaussian-integer factorization).",
+    "mathContext": "$\\exists a\\,b : \\mathbb{N},\\ F_{4n+3} = a^2 + b^2$; same identity over $\\mathbb{Z}$ via `exact_mod_cast`.",
     "significance": "supporting",
     "relatedConcepts": [
       "existential quantifier",
       "ℕ→ℤ cast",
-      "decide vs native_decide",
-      "axiom hygiene"
+      "explicit witnesses",
+      "sum of two squares"
     ],
     "prerequisites": [
-      "exact_mod_cast",
-      "kernel reduction (decide)"
+      "the iterated identity",
+      "exact_mod_cast"
+    ]
+  },
+  {
+    "id": "ann-fiboq0301-5",
+    "proofId": "fibonacci-identities-oq-03-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "Numeric Sanity Checks",
+    "content": "Three `decide` examples confirm the $n = 0, 1, 2$ instances by kernel reduction: $F_3 = 2$ (index $4\\cdot0+3$), $F_7 = 13$ (index $4\\cdot1+3$), $F_{11} = 89$ (index $4\\cdot2+3$). Using kernel `decide` rather than `native_decide` means only the foundational propext / Classical.choice / Quot.sound are touched — no `Lean.ofReduceBool` — so the numeric checks do not compromise the entry's 0-axiom status. The decomposition matches: at $n=1$ the witnesses are $a = F_2(2F_1+F_2) = 3$ and $b = F_2^2+F_1^2 = 2$, giving $3^2 + 2^2 = 13 = F_7$.",
+    "mathContext": "$F_3 = 2,\\ F_7 = 13 = 3^2+2^2,\\ F_{11} = 89$ for $n = 0, 1, 2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "decide vs native_decide",
+      "axiom hygiene",
+      "kernel reduction",
+      "numeric verification"
+    ],
+    "prerequisites": [
+      "kernel reduction (decide)",
+      "Lean.ofReduceBool and native_decide"
     ]
   }
 ]

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/meta.json
@@ -56,7 +56,8 @@
       "**Doubling twice stays a sum of two squares.** The odd fast-doubling identity is the only ingredient: applied at index 2n+1 it turns fib(4n+3) into fib(2n+2)² + fib(2n+1)², and the inner odd term fib(2n+1) is itself a sum of two squares. The even term fib(2n+2) enters only as the base of one of the two outer squares, so no difference-of-squares step is needed and the result stays a clean two-square sum.",
       "**Closed form in two base values.** After substitution everything is a polynomial in a = fib(n) and b = fib(n+1): fib(4n+3) = (b(2a+b))² + (b²+a²)². The decomposition is fully explicit, not merely existential.",
       "**No truncated subtraction.** Unlike the even difference-of-squares identity of the parent (which needs ℤ to be literal), the 4n+3 form is an honest sum, so it lives in ℕ and the existential ∃ a b, fib(4n+3) = a²+b² holds over ℕ directly.",
-      "**Answers the parent's open question.** The parent (fibonacci-identities-oq-03) explicitly asks to iterate the doubling to write fib(4n+3) as a sum of squares; this entry supplies exactly that, in named, iterated, existential, and integer forms."
+      "**Answers the parent's open question.** The parent (fibonacci-identities-oq-03) explicitly asks to iterate the doubling to write fib(4n+3) as a sum of squares; this entry supplies exactly that, in named, iterated, existential, and integer forms.",
+      "**Being a sum of two squares is an arithmetic constraint.** By the sum-of-two-squares theorem, fib(4n+3) = a² + b² forces every prime ≡ 3 (mod 4) to divide fib(4n+3) to an even power — equivalently fib(4n+3) is a norm from the Gaussian integers ℤ[i]. So the identity is not just algebraic bookkeeping: it pins down a genuine divisibility restriction on the Fibonacci numbers at indices 4n+3, and the explicit witnesses (b(2a+b), b²+a²) give the Gaussian factorization directly."
     ],
     "prerequisites": [
       "The fast-doubling Fibonacci identities Nat.fib_two_mul_add_one and Nat.fib_two_mul_add_two",
@@ -93,9 +94,17 @@
       "id": "existential-int",
       "title": "Existential and Integer Forms",
       "startLine": 59,
+      "endLine": 74,
+      "summary": "fib_four_mul_add_three_isSumSq packages the existential reading ∃ a b : ℕ, fib(4n+3) = a²+b² with the explicit witnesses a = fib(n+1)·(2·fib n + fib(n+1)), b = fib(n+1)²+fib n². fib_four_mul_add_three_iterated_int casts the iterated decomposition to ℤ by exact_mod_cast (the ℕ statement already has no subtraction, but the ℤ form is convenient downstream).",
+      "mathContext": "$\\exists a\\,b : \\mathbb{N},\\ F_{4n+3} = a^2 + b^2$; the same over $\\mathbb{Z}$ via exact_mod_cast."
+    },
+    {
+      "id": "numeric-checks",
+      "title": "Numeric Sanity Checks",
+      "startLine": 76,
       "endLine": 79,
-      "summary": "fib_four_mul_add_three_isSumSq (every fib(4n+3) is a sum of two squares, explicit witnesses) and fib_four_mul_add_three_iterated_int (the same decomposition over ℤ), plus decide sanity checks for n = 0, 1, 2.",
-      "mathContext": "$\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$."
+      "summary": "Three `decide` examples confirm the n = 0, 1, 2 instances by kernel reduction: fib 3 = 2, fib 7 = 13, fib 11 = 89 (indices 4·0+3, 4·1+3, 4·2+3). Using kernel `decide` rather than `native_decide` keeps the entry free of Lean.ofReduceBool.",
+      "mathContext": "$F_3 = 2,\\ F_7 = 13,\\ F_{11} = 89$ for $n = 0, 1, 2$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-01` (quality 91 → 100).

**Improvements:**
- **Sections 4 → 5** and **annotations 4 → 5**: split the combined existential/integer block into (a) the existential `fib_four_mul_add_three_isSumSq` and integer `fib_four_mul_add_three_iterated_int` forms and (b) the three `decide` numeric sanity checks (fib 3/7/11). Ranges aligned to the source.
- **KeyInsights 4 → 5**: added that being a sum of two squares is a genuine arithmetic constraint — every prime ≡ 3 (mod 4) divides fib(4n+3) to an even power, i.e. it is a norm from ℤ[i], and the explicit witnesses give the Gaussian factorization directly.

All content is drawn from `Proofs/FibonacciIdentitiesOQ03OQ01.lean`. meta.json is 13 KB, under the 60 KB guardrail. JSON validated.