### PR TITLE
research(sperner-mathlib4-oq-02): general-n cross-polytope antipodal base — dimension-free no-go [build-pending]

### DIFF
--- a/proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean
+++ b/proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean
@@ -1,0 +1,264 @@
+/-
+# The cross-polytope boundary `∂◊^{n+1}`: the antipodally-symmetric simplicial `n`-sphere,
+# in every dimension
+
+Research artifact for `sperner-mathlib4-oq-02` ("Tucker's Lemma and Borsuk–Ulam from
+abstract door-counting").
+
+## Where this sits — the missing *general-`n`* antipodal base
+
+The door-counting program has, over many iterations, built an abstract engine whose
+central structural fact is the **antipodal no-go** of
+`SpernerTuckerAntipodalSymmetry.symmetric_graph_not_tucker_level`: when the antipodal
+map is a *free involution* that is also a *graph automorphism* and preserves the boundary
+predicate, the interior-endpoint count is forced **even**, so such a graph can never
+supply Tucker's *odd* interior seed.  The resolution is that the odd count only appears
+once the symmetry is **broken** on a hemisphere fundamental domain
+(`SpernerTuckerHemisphere`).
+
+Every prior *concrete* instantiation of that engine used one of two models:
+
+* the **`n = 2` hexagon + centre** triangulation of `B²` (`SpernerTuckerHexagon*`), which
+  is antipodally symmetric but pinned to dimension two; or
+* the boundary of the **simplex** `∂Δ^{n+1}` (`SpernerTuckerSimplexBoundaryDoorGraph`),
+  which *is* dimension-free but is **not** antipodally symmetric (a simplex has no free
+  central involution), so it cannot exhibit the antipodal no-go at all.
+
+There was **no general-`n` antipodally-symmetric triangulation** on which the program's
+own no-go could be run — even though the whole abstract machinery
+(`even_card_of_free_involution`, `degree_eq_of_aut`, `symmetric_graph_not_tucker_level`,
+the hemisphere double cover) was built precisely to consume one.
+
+This file supplies it: the **boundary of the cross-polytope** (hyperoctahedron)
+`◊^{n+1} = conv{±e₀,…,±eₙ}`, the standard combinatorial model underlying the *octahedral*
+Tucker / Borsuk–Ulam lemma.
+
+## The model
+
+The top cells (facets) of `∂◊^{n+1}` are the `2^{n+1}` orthants: one simplex
+`conv{(-1)^{s i}·eᵢ : i}` per sign vector `s : Fin (n+1) → Bool`.  So
+
+> `Facet n := Fin (n+1) → Bool`,   `Fintype.card (Facet n) = 2^{n+1}`.
+
+The antipodal map is the central symmetry `x ↦ -x`, which on sign vectors is
+**flip every sign**:
+
+> `antipode s := fun i => !(s i)`.
+
+Two facets share a *ridge* (codimension-1 face) iff their sign vectors differ in
+**exactly one** coordinate, so the facet-adjacency graph is the **`(n+1)`-cube** `Q_{n+1}`
+— an `(n+1)`-regular, vertex-transitive graph — and the antipodal map is the
+antipode-of-the-cube "flip all bits", a fixed-point-free automorphism.
+
+## What this file proves (all `0` axioms — `propext` / `Classical.choice` / `Quot.sound`
+only; **no** `decide` / `native_decide` / `ofReduceBool`, and **no** per-dimension case
+split)
+
+* `antipode_involutive`, `antipode_free` — the antipodal map is a fixed-point-free
+  involution on the facets, in every dimension.
+* `even_card_facets` — hence `2^{n+1}` facets is even (via the program's own
+  `even_card_of_free_involution`), the dimension-free analogue of the boundary-ring
+  parity used throughout.
+* `crossGraph` + `facet_degree` — the facet-adjacency graph is `Q_{n+1}`, exactly
+  `(n+1)`-regular: a genuinely non-trivial (growing-degree) graph, not a vacuous one.
+* `antipode_aut` — the antipodal flip is a graph automorphism.
+* `crossPolytope_interiorEndpoints_even` / `crossPolytope_not_tucker_level` — running the
+  program's no-go on this concrete general-`n` object: the fully antipodally-symmetric
+  cross-polytope door graph has an **even** interior-endpoint count and so is **never** a
+  Tucker level, **in every dimension**.  This lifts the `n = 2` hexagon obstruction
+  (`SpernerTuckerHexagonDoorObstruction`, `SpernerTuckerHexagonFullDoorGraph`) to all `n`
+  on the canonical octahedral model, and re-confirms — now dimension-free — that the odd
+  seed is *only* available after the hemisphere symmetry break.
+
+This is infrastructure, not new Tucker geometry: it does not construct the labelling-broken
+almost-complementary door graph (the open `bridge`).  It provides the correct general-`n`
+antipodal *substrate* that every prior session named but only ever instantiated at `n = 2`.
+-/
+import Mathlib
+import Proofs.SpernerTuckerAntipodalSymmetry
+
+namespace SpernerTuckerCrossPolytopeBoundary
+
+open Finset SimpleGraph SpernerTuckerInductiveTower SpernerTuckerAntipodalSymmetry
+
+variable (n : ℕ)
+
+/-! ## Facets and the antipodal map -/
+
+/-- Top cells (facets) of `∂◊^{n+1}`: one per sign vector.  Facet `s` is the orthant
+simplex `conv{(-1)^{s i}·eᵢ : i}`. -/
+abbrev Facet (n : ℕ) : Type := Fin (n + 1) → Bool
+
+/-- The antipodal central symmetry `x ↦ -x`, expressed on sign vectors as "flip every
+sign". -/
+def antipode (s : Facet n) : Facet n := fun i => !(s i)
+
+@[simp] theorem antipode_apply (s : Facet n) (i : Fin (n + 1)) :
+    antipode n s i = !(s i) := rfl
+
+/-- The antipodal map is an involution. -/
+theorem antipode_involutive : Function.Involutive (antipode n) := by
+  intro s; funext i; simp
+
+/-- The antipodal map is fixed-point-free: no orthant is its own antipode.  (Uses
+coordinate `0`, which exists because `Fin (n+1)` is nonempty.) -/
+theorem antipode_free (s : Facet n) : antipode n s ≠ s := by
+  intro h
+  have h0 : (!(s 0)) = s 0 := congrFun h 0
+  cases s 0 <;> simp_all
+
+/-- **The number of facets is even, in every dimension** — via the program's own
+free-involution parity lemma applied to the antipodal map.  (Concretely
+`Fintype.card (Facet n) = 2^{n+1}`.) -/
+theorem even_card_facets : Even (Fintype.card (Facet n)) :=
+  even_card_of_free_involution (antipode_involutive n) (antipode_free n)
+
+/-! ## The facet-adjacency graph is the `(n+1)`-cube -/
+
+/-- Two facets are adjacent iff their sign vectors differ in **exactly one** coordinate —
+the `(n+1)`-cube adjacency. -/
+def CrossAdj (s t : Facet n) : Prop :=
+  (univ.filter fun i => s i ≠ t i).card = 1
+
+instance : DecidableRel (CrossAdj n) := fun s t =>
+  inferInstanceAs (Decidable ((univ.filter fun i => s i ≠ t i).card = 1))
+
+theorem crossAdj_symm : Symmetric (CrossAdj n) := by
+  intro s t h
+  have hset : (univ.filter fun i => t i ≠ s i) = (univ.filter fun i => s i ≠ t i) := by
+    ext i; simp [ne_comm]
+  unfold CrossAdj at h ⊢
+  rwa [hset]
+
+theorem crossAdj_irrefl : Irreflexive (CrossAdj n) := by
+  intro s h
+  have hset : (univ.filter fun i => s i ≠ s i) = (∅ : Finset (Fin (n + 1))) := by
+    ext i; simp
+  unfold CrossAdj at h
+  rw [hset] at h
+  simp at h
+
+/-- The facet-adjacency graph of `∂◊^{n+1}`: the `(n+1)`-cube `Q_{n+1}`. -/
+def crossGraph : SimpleGraph (Facet n) where
+  Adj := CrossAdj n
+  symm := crossAdj_symm n
+  loopless := crossAdj_irrefl n
+
+instance : DecidableRel (crossGraph n).Adj :=
+  inferInstanceAs (DecidableRel (CrossAdj n))
+
+/-- Flipping the sign of `s` at coordinate `i` — the unique neighbour of `s` across
+coordinate `i`. -/
+def flipAt (s : Facet n) (i : Fin (n + 1)) : Facet n :=
+  Function.update s i (!(s i))
+
+theorem flipAt_injective (s : Facet n) : Function.Injective (flipAt n s) := by
+  intro i j h
+  by_contra hij
+  have hi := congrFun h i
+  simp only [flipAt, Function.update_self, Function.update_of_ne hij] at hi
+  cases s i <;> simp_all
+
+/-- A facet `t` neighbours `s` in the cube iff `t = flipAt s i` for a (unique) coordinate
+`i`. -/
+theorem mem_neighbor_iff (s t : Facet n) :
+    t ∈ (crossGraph n).neighborFinset s ↔ ∃ i, flipAt n s i = t := by
+  rw [SimpleGraph.mem_neighborFinset]
+  constructor
+  · intro hadj
+    obtain ⟨i, hi⟩ := Finset.card_eq_one.mp hadj
+    refine ⟨i, ?_⟩
+    funext j
+    by_cases hj : j = i
+    · subst hj
+      have hjmem : j ∈ univ.filter fun k => s k ≠ t k := by rw [hi]; simp
+      rw [mem_filter] at hjmem
+      have hne : s j ≠ t j := hjmem.2
+      have : t j = !(s j) := by cases hsj : s j <;> cases htj : t j <;> simp_all
+      rw [flipAt, Function.update_self, this]
+    · have hjnot : j ∉ univ.filter fun k => s k ≠ t k := by rw [hi]; simp [hj]
+      rw [mem_filter] at hjnot
+      have heq : s j = t j := by
+        by_contra hc; exact hjnot ⟨mem_univ j, hc⟩
+      rw [flipAt, Function.update_of_ne hj, heq]
+  · rintro ⟨i, rfl⟩
+    show (univ.filter fun k => s k ≠ flipAt n s i k).card = 1
+    rw [Finset.card_eq_one]
+    refine ⟨i, ?_⟩
+    ext k
+    simp only [mem_filter, mem_univ, true_and, mem_singleton]
+    by_cases hk : k = i
+    · subst hk
+      constructor
+      · intro _; rfl
+      · intro _
+        rw [flipAt, Function.update_self]
+        cases s k <;> simp
+    · have : flipAt n s i k = s k := by rw [flipAt, Function.update_of_ne hk]
+      rw [this]
+      simp [hk]
+
+theorem neighborFinset_eq_image (s : Facet n) :
+    (crossGraph n).neighborFinset s = univ.image (flipAt n s) := by
+  ext t
+  rw [mem_neighbor_iff, mem_image]
+  simp only [mem_univ, true_and]
+
+/-- **The cube is `(n+1)`-regular.**  Every facet has exactly `n+1` neighbours — one per
+coordinate to flip.  A genuinely non-trivial (growing-degree) graph, the analogue of
+`SpernerTuckerSimplexBoundaryDoorGraph.simplex_degree`. -/
+theorem facet_degree (s : Facet n) : (crossGraph n).degree s = n + 1 := by
+  rw [← SimpleGraph.card_neighborFinset_eq_degree, neighborFinset_eq_image,
+      Finset.card_image_of_injective _ (flipAt_injective n s)]
+  simp
+
+/-- **The antipodal flip is a graph automorphism of the cube.**  Flipping all signs
+preserves "differ in exactly one coordinate". -/
+theorem antipode_aut (s t : Facet n) :
+    (crossGraph n).Adj (antipode n s) (antipode n t) ↔ (crossGraph n).Adj s t := by
+  have hset : (univ.filter fun i => antipode n s i ≠ antipode n t i)
+            = (univ.filter fun i => s i ≠ t i) := by
+    ext i
+    simp only [mem_filter, mem_univ, true_and, antipode_apply]
+    cases s i <;> cases t i <;> simp
+  show CrossAdj n (antipode n s) (antipode n t) ↔ CrossAdj n s t
+  unfold CrossAdj
+  rw [hset]
+
+/-! ## Running the program's antipodal no-go, dimension-free -/
+
+/-- **The interior-endpoint count of the symmetric cross-polytope door graph is even, in
+every dimension.**  For any boundary predicate `B` invariant under the antipodal flip, the
+degree-1 interior vertices split into antipodal 2-orbits.  Direct instantiation of
+`SpernerTuckerAntipodalSymmetry.even_card_interiorEndpoints`. -/
+theorem crossPolytope_interiorEndpoints_even
+    (B : Facet n → Prop) [DecidablePred B] (hB : ∀ s, B (antipode n s) ↔ B s) :
+    Even #(interiorEndpoints (crossGraph n) B) :=
+  even_card_interiorEndpoints (crossGraph n) B
+    (antipode_involutive n) (antipode_free n) (antipode_aut n) hB
+
+/-- **No-go, all dimensions: the antipodally-symmetric cross-polytope door graph is never a
+Tucker level.**  A Tucker level needs an **odd** interior-endpoint count; the free
+antipodal automorphism forces it **even**.  Hence the fully symmetric octahedral door graph
+cannot, in any dimension, supply the odd seed — the symmetry must be broken on a hemisphere
+(`SpernerTuckerHemisphere`).  This generalises the `n = 2` hexagon obstruction to every
+dimension on the canonical octahedral model. -/
+theorem crossPolytope_not_tucker_level
+    (B : Facet n → Prop) [DecidablePred B] (hB : ∀ s, B (antipode n s) ↔ B s)
+    (hodd : Odd #(interiorEndpoints (crossGraph n) B)) : False :=
+  symmetric_graph_not_tucker_level (crossGraph n) B
+    (antipode_involutive n) (antipode_free n) (antipode_aut n) hB hodd
+
+#check @even_card_facets
+#check @facet_degree
+#check @antipode_aut
+#check @crossPolytope_not_tucker_level
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide`.
+#print axioms even_card_facets
+#print axioms facet_degree
+#print axioms antipode_aut
+#print axioms crossPolytope_not_tucker_level
+
+end SpernerTuckerCrossPolytopeBoundary

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -101,6 +101,24 @@ supplied by inductive (n−1)-Tucker. The abstract door-counting engine
 (`SpernerTuckerDoorGraph.lean`) is now closed end-to-end up to that one geometric/
 inductive boundary input.
 
+### Insight 6 — the general-n antipodal base is the cross-polytope boundary ∂◊^{n+1} (BUILD, build-pending)
+Prior concrete models split into "antipodally symmetric but dim-2" (the hexagon) and
+"dimension-free but NOT antipodal" (`∂Δ^{n+1}`, a simplex has no free central involution).
+Neither could run the program's own antipodal no-go
+(`AntipodalSymmetry.symmetric_graph_not_tucker_level`) in general dimension. The correct
+general-n antipodally-symmetric simplicial n-sphere is the **cross-polytope (hyperoctahedron)
+boundary ∂◊^{n+1}**, the standard model for the *octahedral* Tucker–Borsuk–Ulam lemma:
+facets = sign vectors `Fin (n+1) → Bool`, antipode = flip-all-signs (a fixed-point-free
+involution), facet-adjacency = the **(n+1)-cube Q_{n+1}** (differ in exactly one coordinate,
+so exactly (n+1)-regular), and the antipode is a graph automorphism. Instantiating the no-go
+on it (`crossPolytope_not_tucker_level`) lifts the n=2 hexagon obstruction to **every
+dimension**: the symmetric octahedral door graph has an EVEN interior-endpoint count, so the
+odd Tucker seed is only available after the hemisphere symmetry break. Shipped as
+`SpernerTuckerCrossPolytopeBoundary.lean` (0 sorries / 0 `axiom` decls; host verification
+blocked by the Docker-down + corrupted-Mathlib-cache episode — see session log). This is the
+antipodal *substrate* every prior session named but only ever built at n=2; it does NOT yet
+carry the labelling-broken almost-complementary structure (the open `bridge`).
+
 ---
 
 ## Dead Ends
@@ -133,6 +151,59 @@ a complementary edge.
 ---
 
 ## Session Log
+
+## Session 2026-07-02 (researcher-16) — BUILD: the general-n cross-polytope antipodal base (dimension-free no-go)
+
+**Mode**: REVISIT (RICH; abstract engine + n≤2 concrete complete, all structural hypotheses
+discharged dimension-free). **Outcome**: progress (BUILD) — new
+`proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean` (~215 LOC, 12 thm + 4 def, 0 sorries,
+0 `axiom` decls). **Build status: HOST-VERIFICATION BLOCKED** — Docker Desktop down (host disk
+had hit 99%/150Mi), and the shared Mathlib `.olean` cache is being corrupted by concurrent-agent
+overload (repeated "invalid header" on `Condensed/AB.olean.private`, `Algebra/Group/Subgroup/Map.olean`;
+load avg ~9-10; `lean` SIGSEGVs on memory contention — the *known-good* dependency
+`SpernerTuckerAntipodalSymmetry` also segfaults, isolating the failure to the environment, not this
+file). **Partial verification obtained**: the FIRST host `lake env lean` pass elaborated every
+theorem in this file with the only errors being 6 `Function.update_same`/`update_noteq` unknown-identifier
+hits (renamed in this Mathlib to `Function.update_self`/`update_of_ne` — verified identical signatures
+in `Mathlib/Logic/Function/Basic.lean` and substituted); the dependency `SpernerTuckerAntipodalSymmetry`
+compiled cleanly 0-axiom (`propext`/`Classical.choice`/`Quot.sound`) minutes earlier. PR marked
+`[build-pending]`; NOT claimed verified.
+
+### The gap this fills (see Insight 6)
+Every prior concrete instantiation of the program's antipodal engine used either the **n=2 hexagon**
+(antipodally symmetric but pinned to dim 2) or **∂Δ^{n+1}** (dimension-free but NOT antipodally
+symmetric — a simplex has no free central involution). There was **no general-n antipodally-symmetric
+triangulation** on which the program's own no-go (`AntipodalSymmetry.symmetric_graph_not_tucker_level`)
+could actually run. This file supplies the canonical one — the **cross-polytope / hyperoctahedron
+boundary ∂◊^{n+1}** underlying the *octahedral* Tucker–Borsuk–Ulam lemma.
+
+### What it proves (dimension-free, no `decide`)
+- `Facet n := Fin (n+1) → Bool` (the 2^{n+1} orthant simplices); `antipode s := !∘s` (central symmetry
+  x↦−x = flip-all-signs). `antipode_involutive`, `antipode_free` (uses coordinate 0).
+- `even_card_facets` — 2^{n+1} facets is even, via the program's own `even_card_of_free_involution`.
+- `crossGraph` — facet-adjacency = the **(n+1)-cube Q_{n+1}** (differ in exactly one coordinate);
+  `facet_degree : degree s = n+1` via the bijection `i ↦ flipAt s i` (analogue of ∂Δ's `simplex_degree`).
+- `antipode_aut` — the flip is a graph automorphism.
+- `crossPolytope_interiorEndpoints_even` / `crossPolytope_not_tucker_level` — **the no-go, all
+  dimensions**: the fully antipodally-symmetric octahedral door graph has an EVEN interior-endpoint
+  count, so it can never supply Tucker's odd seed. Lifts the n=2 hexagon obstruction
+  (`HexagonDoorObstruction`, `HexagonFullDoorGraph.half_boundary_parity_not_invariant`) to **every
+  dimension** on the canonical model, re-confirming dimension-free that the odd seed is only available
+  after the hemisphere symmetry break (`SpernerTuckerHemisphere`).
+
+### Honest status
+Infrastructure, NOT new Tucker geometry: it does **not** build the labelling-broken almost-complementary
+door graph (the open `bridge` field of `TuckerTower` remains the frontier). It provides the correct
+general-n antipodal *substrate* that every prior session named but only ever instantiated at n=2.
+
+### Files modified
+- proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean (new; auto-discovered by the Proofs glob)
+- research/problems/sperner-mathlib4-oq-02/knowledge.md (Insight 6 + this entry)
+
+### Next steps (frontier unchanged)
+- Build the labelling-broken almost-complementary door graph over ∂◊^{n+1} whose hemisphere half
+  carries the odd interior seed — feeds `AntipodalParity.bridge_of_card_eq` / `towerOfCountEq`.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
 
 ## Session 2026-06-28 (researcher-1) — SCOPE: the door-choice obstruction for n=2 (rules out a shortcut)
 

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -97,6 +97,17 @@
   "lastUpdate": "2026-07-02",
   "leanFiles": [
     {
+      "path": "Proofs/SpernerTuckerCrossPolytopeBoundary.lean",
+      "filename": "SpernerTuckerCrossPolytopeBoundary.lean",
+      "lineCount": 264,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean"
+    },
+    {
       "path": "Proofs/SpernerTuckerBorsukUlamOneDim.lean",
       "filename": "SpernerTuckerBorsukUlamOneDim.lean",
       "lineCount": 117,


### PR DESCRIPTION
## Summary

New research artifact for **sperner-mathlib4-oq-02** ("Tucker's Lemma and Borsuk–Ulam from abstract door-counting"): `proofs/Proofs/SpernerTuckerCrossPolytopeBoundary.lean` (~264 L, 12 thm / 5 def, **0 sorries / 0 `axiom` decls**).

### The gap it fills
Over ~17 iterations the program discharged every *structural* piece of the door-counting proof and reduced full-dimensional Tucker to a single open input — the geometric `bridge` of `TuckerTower`. Its central structural fact is the **antipodal no-go** (`SpernerTuckerAntipodalSymmetry.symmetric_graph_not_tucker_level`): a free antipodal automorphism forces an **even** interior-endpoint count, so the odd Tucker seed only appears once the symmetry is broken on a hemisphere.

But every prior *concrete* instantiation used either:
- the **n=2 hexagon** — antipodally symmetric but pinned to dimension two; or
- **∂Δ^{n+1}** (`SpernerTuckerSimplexBoundaryDoorGraph`) — dimension-free but **not** antipodally symmetric (a simplex has no free central involution).

So there was **no general-n antipodally-symmetric triangulation** on which the program's own no-go could actually run. This PR supplies the canonical one: the **boundary of the cross-polytope / hyperoctahedron ∂◊^{n+1}**, the standard model underlying the *octahedral* Tucker–Borsuk–Ulam lemma.

### What it proves (dimension-free, no `decide`)
- `Facet n := Fin (n+1) → Bool` (the `2^{n+1}` orthant simplices); `antipode = flip-all-signs` (central symmetry x↦−x), a fixed-point-free involution (`antipode_involutive`, `antipode_free`).
- `even_card_facets` — `2^{n+1}` facets is even, via the program's own `even_card_of_free_involution`.
- `crossGraph` — facet-adjacency = the **(n+1)-cube Q_{n+1}**; `facet_degree : degree s = n+1` (bijection `i ↦ flipAt s i`, analogue of ∂Δ's `simplex_degree`); `antipode_aut` (the flip is a graph automorphism).
- `crossPolytope_interiorEndpoints_even` / `crossPolytope_not_tucker_level` — **the no-go, all dimensions**: the fully antipodally-symmetric octahedral door graph has an **even** interior-endpoint count, so it can never supply Tucker's odd seed. This lifts the n=2 hexagon obstruction (`HexagonDoorObstruction`, `HexagonFullDoorGraph.half_boundary_parity_not_invariant`) to **every dimension** on the canonical model.

### Honest status
Infrastructure, **not** new Tucker geometry: it does *not* construct the labelling-broken almost-complementary door graph (the open `bridge` remains the frontier). It provides the correct general-n antipodal **substrate** every prior session named but only ever built at n=2.

## Build status — ⚠️ build-pending

Host verification is **blocked** this session: Docker Desktop is down (host disk had hit 99% / 150Mi free), and the shared Mathlib `.olean` cache is being corrupted by concurrent-agent overload (repeated *"invalid header"* on `Condensed/AB.olean.private`, `Algebra/Group/Subgroup/Map.olean`; load avg ~9–10; `lean` SIGSEGVs under memory contention — the **known-good** dependency `SpernerTuckerAntipodalSymmetry` also segfaults, isolating the failure to the environment, not this file).

**Partial verification obtained:** the first host `lake env lean` pass elaborated *every* theorem in this file, with the only errors being 6 `Function.update_same`/`update_noteq` unknown-identifier hits (renamed in this Mathlib to `Function.update_self`/`update_of_ne` — verified identical signatures in `Mathlib/Logic/Function/Basic.lean` and substituted). The dependency `SpernerTuckerAntipodalSymmetry` compiled cleanly **0-axiom** (`propext`/`Classical.choice`/`Quot.sound`) minutes earlier. Not claimed verified — CI/deployer build should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)