### PR TITLE
research(factor-remainder-theorem-oq-06-oq-01): rational k-th roots of integers [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean
@@ -1,0 +1,185 @@
+/-
+# Factor / Remainder Theorem, OQ-06-OQ-01: rational `k`-th roots of integers
+
+This file answers the first open question left by the parent entry
+`FactorRemainderTheoremOQ06.lean` (the rational root theorem in concrete
+`num/den` form):
+
+> Generalize the `√2` application to a clean criterion: for `n : ℤ` not a
+> perfect `k`-th power, `∀ r : ℚ, rᵏ ≠ n`.
+
+The parent proved `∀ r : ℚ, r ^ 2 ≠ 2` as a one-off worked example of the
+rational root theorem applied to the monic polynomial `X² − 2`. Here we replace
+`X² − 2` by the monic polynomial `X^k − C n` for arbitrary `k ≥ 1` and arbitrary
+`n : ℤ`, obtaining the general principle that underlies **every** "`n`-th root of
+an integer is either an integer or irrational" argument:
+
+    a rational `k`-th root of an integer is itself an integer,
+
+and hence the criterion
+
+    (∀ m : ℤ, m ^ k ≠ n)  →  (∀ r : ℚ, r ^ k ≠ n),
+
+together with the clean equivalence
+
+    (∃ r : ℚ, r ^ k = n)  ↔  (∃ m : ℤ, m ^ k = n).
+
+## Main results
+
+- `rat_root_den_eq_one`  : a rational `k`-th root (`k ≥ 1`) of an integer has `den = 1`
+- `int_pow_eq_of_rat_pow`: such a root is the integer `r.num`, and `r.num ^ k = n`
+- `not_rat_pow_of_not_int_pow` : the **criterion** — `n` not a perfect `k`-th power ⟹ no rational `k`-th root
+- `exists_rat_pow_iff_exists_int_pow` : rational and integral `k`-th-power problems coincide
+- `rat_prime_ne_pow` : **no prime is a rational `k`-th power for `k ≥ 2`**
+  (generalizes `√2 ∉ ℚ` to all primes and all exponents)
+- worked instances: `rat_sq_ne_two`, `rat_cube_ne_two`, `rat_sq_ne_three`,
+  `rat_cube_ne_four` (the last via the general criterion, `4` being a non-prime
+  non-cube)
+
+## Honest scope
+
+The engine is the parent's `monic_root_den_eq_one` (itself a concrete repackaging
+of Mathlib's rational root theorem). This file supplies the *general* monic
+polynomial `X^k − C n` in place of the parent's single `X² − 2`, and packages the
+resulting number-theoretic criterion. The proofs are short; the value is turning a
+one-off example into the reusable general statement it was an instance of.
+
+## References
+
+- Parent gallery entry factor-remainder-theorem-oq-06 (rational root theorem, concrete form)
+- Serge Lang, *Algebra* (integral closure; `n`-th roots of integers)
+-/
+
+import Mathlib.RingTheory.Polynomial.RationalRoot
+import Mathlib.RingTheory.Localization.Rat
+import Mathlib.Tactic
+import Proofs.FactorRemainderTheoremOQ06
+
+open Polynomial
+
+namespace FactorRemainderTheoremOQ06OQ01
+
+open FactorRemainderTheoremOQ06
+
+variable {k : ℕ} {n : ℤ} {r : ℚ}
+
+/-! ### The monic polynomial `X^k − C n` and its evaluation -/
+
+/-- `X^k − C n ∈ ℤ[X]` is monic for every exponent `k ≥ 1`. -/
+theorem monic_X_pow_sub_C_int (hk : k ≠ 0) : (X ^ k - C n : ℤ[X]).Monic :=
+  monic_X_pow_sub_C n hk
+
+/-- Evaluating `X^k − C n` at a rational `r` gives `r^k − n`. -/
+theorem aeval_X_pow_sub_C (r : ℚ) (k : ℕ) (n : ℤ) :
+    aeval r (X ^ k - C n : ℤ[X]) = r ^ k - (n : ℚ) := by
+  simp [map_sub, map_pow, aeval_X, map_intCast]
+
+/-! ### A rational `k`-th root of an integer is an integer -/
+
+/-- **Key step.** If `r : ℚ` satisfies `r ^ k = n` for some integer `n` and `k ≥ 1`,
+then `r` is an integer: its denominator is `1`. This is the rational root theorem
+applied to the monic polynomial `X^k − C n`, generalizing the parent's `√2` step. -/
+theorem rat_root_den_eq_one (hk : k ≠ 0) (hr : r ^ k = (n : ℚ)) : r.den = 1 := by
+  have hroot : aeval r (X ^ k - C n : ℤ[X]) = 0 := by
+    rw [aeval_X_pow_sub_C, hr]; ring
+  exact monic_root_den_eq_one (monic_X_pow_sub_C_int hk) hroot
+
+/-- A rational `k`-th root of an integer equals its own numerator (it is an integer). -/
+theorem rat_root_eq_num (hk : k ≠ 0) (hr : r ^ k = (n : ℚ)) : r = (r.num : ℚ) := by
+  have hden := rat_root_den_eq_one hk hr
+  conv_lhs => rw [← Rat.num_div_den r, hden]
+  simp
+
+/-- The integer `r.num` is an actual `k`-th root of `n`: `r.num ^ k = n`. -/
+theorem int_pow_eq_of_rat_pow (hk : k ≠ 0) (hr : r ^ k = (n : ℚ)) : r.num ^ k = n := by
+  have h : (r.num : ℚ) ^ k = (n : ℚ) := by rw [← rat_root_eq_num hk hr]; exact hr
+  exact_mod_cast h
+
+/-! ### The criterion and the rational ↔ integral equivalence -/
+
+/-- **Generalized irrationality criterion.** If the integer `n` is not a perfect
+`k`-th power (`k ≥ 1`) — no integer `m` has `m ^ k = n` — then no rational number
+is a `k`-th root of `n`. This is the clean statement of which `√2 ∉ ℚ` is the
+special case `n = 2`, `k = 2`. -/
+theorem not_rat_pow_of_not_int_pow (hk : k ≠ 0)
+    (h : ∀ m : ℤ, m ^ k ≠ n) : ∀ r : ℚ, r ^ k ≠ (n : ℚ) := by
+  intro r hr
+  exact h r.num (int_pow_eq_of_rat_pow hk hr)
+
+/-- **Rational and integral `k`-th-power problems coincide** (`k ≥ 1`): an integer
+`n` has a rational `k`-th root iff it has an integer `k`-th root. -/
+theorem exists_rat_pow_iff_exists_int_pow (hk : k ≠ 0) :
+    (∃ r : ℚ, r ^ k = (n : ℚ)) ↔ (∃ m : ℤ, m ^ k = n) := by
+  constructor
+  · rintro ⟨r, hr⟩
+    exact ⟨r.num, int_pow_eq_of_rat_pow hk hr⟩
+  · rintro ⟨m, hm⟩
+    exact ⟨(m : ℚ), by exact_mod_cast hm⟩
+
+/-! ### No prime is a rational `k`-th power (`k ≥ 2`) -/
+
+/-- A prime `p : ℕ` is not a nontrivial perfect power: `a ^ k ≠ p` for all `a : ℕ`
+when `k ≥ 2`. -/
+theorem nat_prime_ne_pow {p : ℕ} (hp : p.Prime) (hk : 2 ≤ k) :
+    ∀ a : ℕ, a ^ k ≠ p := by
+  intro a ha
+  have hadvd : a ∣ p := ha ▸ dvd_pow_self a (by omega)
+  rcases (Nat.dvd_prime hp).mp hadvd with h1 | hpa
+  · rw [h1, one_pow] at ha
+    have := hp.two_le; omega
+  · rw [hpa] at ha
+    have hpow : p ^ k = p ^ 1 := by simpa using ha
+    have := Nat.pow_right_injective hp.two_le hpow
+    omega
+
+/-- The integer version: a prime is not a nontrivial perfect power in `ℤ`. -/
+theorem int_prime_ne_pow {p : ℕ} (hp : p.Prime) (hk : 2 ≤ k) :
+    ∀ m : ℤ, m ^ k ≠ (p : ℤ) := by
+  intro m hm
+  have key : m.natAbs ^ k = p := by
+    have h := congrArg Int.natAbs hm
+    rw [Int.natAbs_pow] at h
+    simpa using h
+  exact nat_prime_ne_pow hp hk m.natAbs key
+
+/-- **No prime is a rational `k`-th power for `k ≥ 2`.** The full generalization of
+the irrationality of `√2`: for every prime `p` and every exponent `k ≥ 2`, no
+rational number `r` satisfies `r ^ k = p`. In particular `√p`, `∛p`, … are all
+irrational for every prime `p`. -/
+theorem rat_prime_ne_pow {p : ℕ} (hp : p.Prime) (hk : 2 ≤ k) (r : ℚ) :
+    r ^ k ≠ (p : ℚ) := by
+  have h := not_rat_pow_of_not_int_pow (n := (p : ℤ)) (by omega) (int_prime_ne_pow hp hk) r
+  simpa using h
+
+/-! ### Worked instances -/
+
+/-- `√2 ∉ ℚ`, recovered from the general criterion (the parent's one-off example). -/
+theorem rat_sq_ne_two (r : ℚ) : r ^ 2 ≠ 2 := by
+  have h := rat_prime_ne_pow (p := 2) (by norm_num) (k := 2) (by norm_num) r
+  simpa using h
+
+/-- `∛2 ∉ ℚ`: no rational number cubes to `2`. New relative to the parent, which
+only handled the square case. -/
+theorem rat_cube_ne_two (r : ℚ) : r ^ 3 ≠ 2 := by
+  have h := rat_prime_ne_pow (p := 2) (by norm_num) (k := 3) (by norm_num) r
+  simpa using h
+
+/-- `√3 ∉ ℚ`: no rational number squares to `3`. -/
+theorem rat_sq_ne_three (r : ℚ) : r ^ 2 ≠ 3 := by
+  have h := rat_prime_ne_pow (p := 3) (by norm_num) (k := 2) (by norm_num) r
+  simpa using h
+
+/-- A **non-prime** instance of the general criterion: `4` is not a perfect cube,
+so `∛4 ∉ ℚ`. Here we discharge the integer hypothesis `∀ m : ℤ, m ^ 3 ≠ 4` by a
+finite divisor check, exercising the criterion beyond the prime case. -/
+theorem rat_cube_ne_four (r : ℚ) : r ^ 3 ≠ 4 := by
+  have hint : ∀ m : ℤ, m ^ 3 ≠ 4 := by
+    intro m hm
+    have hmdvd : m ∣ 4 := hm ▸ dvd_pow_self m (by norm_num)
+    have habs : |m| ≤ 4 := Int.le_of_dvd (by norm_num) ((abs_dvd m 4).mpr hmdvd)
+    obtain ⟨hlo, hhi⟩ := abs_le.mp habs
+    interval_cases m <;> norm_num at hm
+  have h := not_rat_pow_of_not_int_pow (n := (4 : ℤ)) (by norm_num) hint r
+  simpa using h
+
+end FactorRemainderTheoremOQ06OQ01

--- a/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 65 },
+    "type": "concept",
+    "title": "From a One-Off √2 Example to a General Criterion",
+    "content": "The parent entry OQ-06 proved ∀ r : ℚ, r² ≠ 2 as a single worked application of the rational root theorem to the monic polynomial X² − 2. That argument never used anything special about the exponent 2 or the constant 2. Replacing X² − 2 by the general monic polynomial X^k − C n turns it into the principle behind every classical irrationality result: the k-th root of an integer is either an integer or irrational.",
+    "mathContext": "General exponent k and constant n replace the parent's fixed 2 and 2."
+  },
+  {
+    "id": "ann-monic",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 66, "endLine": 76 },
+    "type": "technique",
+    "title": "The Monic Polynomial X^k − C n",
+    "content": "Mathlib's monic_X_pow_sub_C certifies that X^k − C n is monic whenever k ≠ 0 — cleaner for a general exponent than the parent's degree-argument monic_X_pow_sub. Evaluating this polynomial at a rational r gives r^k − n, so r is a root exactly when r^k = n.",
+    "mathContext": "Monicity is what lets the integral root theorem apply."
+  },
+  {
+    "id": "ann-integrality",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 77, "endLine": 97 },
+    "type": "key-step",
+    "title": "A Rational k-th Root of an Integer is an Integer",
+    "content": "If r^k = n, then r is a root of the monic polynomial X^k − C n, so the parent's monic_root_den_eq_one forces r.den = 1: r is an integer. Then r = r.num and the integer r.num is a genuine k-th root of n. This single structural fact is the entire engine of the criterion.",
+    "mathContext": "The integral root theorem: monic ⟹ rational roots are integers."
+  },
+  {
+    "id": "ann-criterion",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 98, "endLine": 118 },
+    "type": "key-step",
+    "title": "The Criterion and the Rational ↔ Integral Equivalence",
+    "content": "Contrapositive packaging: since any rational k-th root supplies an integer k-th root r.num, an integer n with no integer k-th root has no rational k-th root either (not_rat_pow_of_not_int_pow). Equivalently, ∃ r : ℚ, r^k = n ↔ ∃ m : ℤ, m^k = n — the rational and integral k-th-power problems coincide.",
+    "mathContext": "Reduces a rational-root question to a finite integer divisor check."
+  },
+  {
+    "id": "ann-prime",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 119, "endLine": 153 },
+    "type": "concept",
+    "title": "No Prime is a Rational k-th Power (k ≥ 2)",
+    "content": "A prime p is not a nontrivial perfect power: if a^k = p then a divides p, so a is 1 or p (Nat.dvd_prime); a = 1 gives 1 = p, and a = p gives p^k = p forcing k = 1 by injectivity of k ↦ p^k (Nat.pow_right_injective). Both contradict k ≥ 2. Feeding this into the criterion shows √p, ∛p, ⁴√p, … are all irrational for every prime p — the full generalization of √2 ∉ ℚ.",
+    "mathContext": "The archetypal irrationality result, uniform in prime and exponent."
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "factor-remainder-theorem-oq-06-oq-01",
+    "range": { "startLine": 154, "endLine": 185 },
+    "type": "example",
+    "title": "Worked Instances: √2, ∛2, √3, ∛4",
+    "content": "rat_sq_ne_two recovers the parent's example, and rat_cube_ne_two, rat_sq_ne_three follow immediately from the prime result. rat_cube_ne_four (∛4 ∉ ℚ) exercises the general criterion beyond the prime case: 4 is not a perfect cube, discharged by bounding |m| ≤ 4 with Int.le_of_dvd and a finite interval_cases check.",
+    "mathContext": "Both prime (√2, ∛2, √3) and non-prime (∛4) applications of the criterion."
+  }
+]

--- a/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/index.ts
+++ b/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const factorRemainderTheoremOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const factorRemainderTheoremOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const factorRemainderTheoremOq06Oq01Data: ProofData = {
+  proof: factorRemainderTheoremOq06Oq01Proof,
+  annotations: factorRemainderTheoremOq06Oq01Annotations,
+}

--- a/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "factor-remainder-theorem-oq-06-oq-01",
+  "title": "Factor/Remainder Theorem OQ-06-OQ-01: Rational k-th Roots of Integers",
+  "slug": "factor-remainder-theorem-oq-06-oq-01",
+  "description": "Generalizes the parent's one-off √2 example to a clean number-theoretic criterion: a rational k-th root of an integer is itself an integer, so if n : ℤ is not a perfect k-th power then no rational number is a k-th root of n. Includes the rational↔integral equivalence and the full generalization of √2 ∉ ℚ — no prime is a rational k-th power for any exponent k ≥ 2.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ06OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "number-theory",
+      "rational-root-theorem",
+      "irrationality"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "monic_X_pow_sub_C",
+        "description": "X^k − C a is monic whenever k ≠ 0 — certifies the monicity of X^k − C n directly for the general exponent",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For 2 ≤ b the map k ↦ b^k is injective — rules out p^k = p for k ≥ 2, so a prime is not a nontrivial perfect power",
+        "module": "Mathlib.Algebra.GroupPower.Order"
+      },
+      {
+        "theorem": "Nat.dvd_prime",
+        "description": "The divisors of a prime p are exactly 1 and p — used to enumerate the integer base of a would-be prime power",
+        "module": "Mathlib.Data.Nat.Prime.Defs"
+      },
+      {
+        "theorem": "Int.le_of_dvd",
+        "description": "A positive divisor bound, used in the finite divisor check for the non-prime example ∛4 ∉ ℚ",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "not_rat_pow_of_not_int_pow: the general criterion — if the integer n is not a perfect k-th power (no integer m has m^k = n), then no rational number r satisfies r^k = n. This is the clean statement of which the parent's sq_ne_two (√2 ∉ ℚ) is the single instance n = 2, k = 2.",
+      "rat_root_den_eq_one: the key structural fact that a rational k-th root of an integer is itself an integer (its denominator is 1), obtained by applying the parent's monic_root_den_eq_one to the general monic polynomial X^k − C n.",
+      "exists_rat_pow_iff_exists_int_pow: the rational and integral k-th-power problems coincide — n has a rational k-th root iff it has an integer one.",
+      "rat_prime_ne_pow: no prime is a rational k-th power for any exponent k ≥ 2 — the full generalization of the irrationality of √2 to all primes and all powers (√p, ∛p, … are irrational for every prime p).",
+      "Worked instances rat_sq_ne_two (recovering the parent), rat_cube_ne_two (∛2 ∉ ℚ), rat_sq_ne_three, and the non-prime rat_cube_ne_four (∛4 ∉ ℚ) obtained from the general criterion by a finite divisor check."
+    ],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 185,
+    "assumptions": "0 axioms, 0 sorries; only Lean/Mathlib foundational axioms (propext, Classical.choice, Quot.sound). HONEST SCOPE: the engine is the parent entry's monic_root_den_eq_one (itself a concrete repackaging of Mathlib's rational root theorem). This file replaces the parent's single polynomial X² − 2 by the general monic polynomial X^k − C n and packages the resulting criterion; the prime case additionally uses Nat.pow_right_injective and Nat.dvd_prime. The individual proofs are short — the value is turning a one-off example into the reusable general statement it was an instance of.",
+    "theoremCount": 14,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The irrationality of √2 is the archetypal irrationality proof; its standard modern packaging is the rational root theorem applied to X² − 2. The same argument works verbatim for any integer polynomial: a rational root of a monic integer polynomial is an integer. Specializing that monic polynomial to X^k − C n turns the √2 argument into the general statement that the k-th root of an integer is either an integer or irrational — the fact that underlies every classical irrationality result of the form 'ⁿ√m is irrational unless m is a perfect n-th power'. The parent entry OQ-06 proved only the single instance ∀ r : ℚ, r² ≠ 2; this entry extracts the general criterion it was an example of.",
+    "problemStatement": "**Open Question (from parent OQ-06)**: Generalize the √2 application to a clean criterion — for n : ℤ not a perfect k-th power, ∀ r : ℚ, rᵏ ≠ n.\n\n**Answer**: A rational k-th root of an integer is an integer (its denominator is 1), because it is a root of the monic polynomial X^k − C n and the parent's integral root theorem applies. Hence if no integer m satisfies m^k = n, no rational r satisfies r^k = n; equivalently the rational and integral k-th-power problems coincide. As a corollary, no prime is a rational k-th power for any k ≥ 2.",
+    "text": "A rational k-th root of an integer is itself an integer, yielding the criterion that an integer with no integer k-th root has no rational k-th root, the rational↔integral equivalence, and the irrationality of every prime's k-th root (k ≥ 2).",
+    "proofStrategy": "1. **Monic polynomial** (monic_X_pow_sub_C_int): X^k − C n is monic for k ≥ 1, and evaluates at a rational r to r^k − n.\n2. **Integrality** (rat_root_den_eq_one, int_pow_eq_of_rat_pow): if r^k = n then r is a root of X^k − C n, so by the parent's monic_root_den_eq_one its denominator is 1; hence r = r.num and the integer r.num is a genuine k-th root of n.\n3. **Criterion** (not_rat_pow_of_not_int_pow, exists_rat_pow_iff_exists_int_pow): contrapositive packaging — the integer witness r.num shows the rational and integral k-th-power problems are equivalent.\n4. **Prime generalization** (rat_prime_ne_pow): a prime p is not a nontrivial perfect power (a^k = p forces the base to be 1 or p, both impossible for k ≥ 2 via Nat.pow_right_injective), so p has no rational k-th root.\n5. **Instances**: √2, ∛2, √3 are irrational (from the prime result) and ∛4 is irrational (from the general criterion by a finite divisor check).",
+    "keyInsights": [
+      "The √2 argument never used anything special about the exponent 2 or the constant 2: replacing X² − 2 by the monic X^k − C n turns it into the general 'k-th root of an integer is an integer or irrational'.",
+      "A rational root of a monic integer polynomial is an integer — this single fact (the parent's monic_root_den_eq_one) is the whole engine; everything else is contrapositive packaging.",
+      "The criterion reduces an irrationality question to a finite check: n fails to have a rational k-th root exactly when the finitely many integer candidates dividing n all fail.",
+      "For a prime p, a^k = p is impossible for k ≥ 2 because the base would have to be 1 or p, and p^k already exceeds p — so √p, ∛p, ⁴√p, … are all irrational.",
+      "The rational and integral k-th-power problems coincide: ∃ r : ℚ, r^k = n ↔ ∃ m : ℤ, m^k = n."
+    ],
+    "prerequisites": [
+      "Polynomials over ℤ evaluated at a rational point (aeval)",
+      "The rational root / integral root theorem (parent entry OQ-06)",
+      "Divisibility and prime factorization in ℤ and ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: generalizing the parent's √2 example from X² − 2 to the monic polynomial X^k − C n",
+      "startLine": 1,
+      "endLine": 65,
+      "mathContext": "The parent proved only ∀ r : ℚ, r² ≠ 2; this file supplies the general criterion for k-th roots of integers."
+    },
+    {
+      "id": "monic-poly",
+      "title": "Part I: The Monic Polynomial X^k − C n",
+      "summary": "monic_X_pow_sub_C_int (monicity for k ≥ 1) and aeval_X_pow_sub_C (evaluation gives r^k − n)",
+      "startLine": 66,
+      "endLine": 76,
+      "mathContext": "X^k − C n is monic for every exponent k ≥ 1, the general replacement for the parent's X² − 2."
+    },
+    {
+      "id": "integrality",
+      "title": "Part II: A Rational k-th Root of an Integer is an Integer",
+      "summary": "rat_root_den_eq_one (denominator is 1), rat_root_eq_num (r equals its numerator), int_pow_eq_of_rat_pow (the integer r.num is a k-th root of n)",
+      "startLine": 77,
+      "endLine": 97,
+      "mathContext": "Applies the parent's monic_root_den_eq_one to X^k − C n: a rational root of this monic polynomial is an integer."
+    },
+    {
+      "id": "criterion",
+      "title": "Part III: The Criterion and the Rational ↔ Integral Equivalence",
+      "summary": "not_rat_pow_of_not_int_pow (n not a perfect k-th power ⟹ no rational k-th root) and exists_rat_pow_iff_exists_int_pow",
+      "startLine": 98,
+      "endLine": 118,
+      "mathContext": "The contrapositive packaging: the integer witness r.num equates the rational and integral k-th-power problems."
+    },
+    {
+      "id": "prime",
+      "title": "Part IV: No Prime is a Rational k-th Power (k ≥ 2)",
+      "summary": "nat_prime_ne_pow, int_prime_ne_pow, rat_prime_ne_pow — the full generalization of √2 ∉ ℚ to all primes and all exponents",
+      "startLine": 119,
+      "endLine": 153,
+      "mathContext": "A prime is not a nontrivial perfect power (Nat.pow_right_injective, Nat.dvd_prime), so it has no rational k-th root for k ≥ 2."
+    },
+    {
+      "id": "instances",
+      "title": "Part V: Worked Instances",
+      "summary": "rat_sq_ne_two (recovering the parent), rat_cube_ne_two, rat_sq_ne_three, and the non-prime rat_cube_ne_four",
+      "startLine": 154,
+      "endLine": 185,
+      "mathContext": "√2, ∛2, √3 from the prime result; ∛4 from the general criterion via a finite divisor check."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry generalizes the parent's single worked example ∀ r : ℚ, r² ≠ 2 into the clean criterion it was an instance of: a rational k-th root of an integer is itself an integer, so an integer with no integer k-th root has no rational k-th root. It records the rational↔integral equivalence ∃ r : ℚ, r^k = n ↔ ∃ m : ℤ, m^k = n, and the full generalization of the irrationality of √2 — no prime is a rational k-th power for any exponent k ≥ 2 (√p, ∛p, … all irrational). All results are verified with 0 sorries and 0 axioms beyond Lean's foundations.",
+    "implications": "The general criterion is the reusable statement behind every 'ⁿ√m is irrational unless m is a perfect n-th power' argument; the parent's √2 example is the special case n = 2, k = 2. Reducing rational-root existence to a finite integer divisor check makes such irrationality facts routine.",
+    "openQuestions": [
+      "Extend the criterion from single powers x^k = n to arbitrary monic integer polynomials: a rational algebraic integer is a rational integer (the integrally-closed statement).",
+      "Give a squarefree/valuation characterization: n : ℤ has a rational k-th root iff every prime in its factorization occurs to a multiple-of-k exponent.",
+      "Quantify: for non-perfect-power n, lower-bound the distance from ⁿ√n to ℚ (an effective irrationality-measure statement)."
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "factor-remainder-theorem-oq-06",
+      "relationship": "Parent: the rational root theorem in concrete num/den form, whose √2 worked example this entry generalizes."
+    },
+    {
+      "id": "factor-remainder-theorem-oq-02",
+      "relationship": "Sibling: the rational root theorem in abstract IsFractionRing.num/den form."
+    },
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "Ancestor: the factor/remainder theorem (X − a) ∣ p ⟺ p(a) = 0."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.RationalRoot",
+      "Mathlib.RingTheory.Localization.Rat",
+      "Mathlib.Tactic",
+      "Proofs.FactorRemainderTheoremOQ06"
+    ],
+    "opens": [
+      "Polynomial",
+      "FactorRemainderTheoremOQ06"
+    ],
+    "namespace": "FactorRemainderTheoremOQ06OQ01",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (integral closure; n-th roots of integers)",
+      "year": "2002",
+      "venue": "Springer GTM 211"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "RingTheory.Polynomial.RationalRoot and Algebra.Polynomial.Monic",
+      "year": "2025",
+      "venue": "Mathlib4"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem-oq-06",
+      "relationship": "extends",
+      "description": "Generalizes the parent's single √2 example to the criterion for k-th roots of arbitrary integers, and to all primes and exponents."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/factor-remainder-theorem-oq-06-oq-01.json
+++ b/src/data/research/problems/factor-remainder-theorem-oq-06-oq-01.json
@@ -1,0 +1,238 @@
+{
+  "slug": "factor-remainder-theorem-oq-06-oq-01",
+  "title": "A clean k-th-power irrationality criterion via the rational root theorem",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall\\, n \\in \\mathbb{Z},\\ \\forall\\, k \\in \\mathbb{N}_{\\ge 1},\\quad\n\\big(\\nexists\\, m \\in \\mathbb{Z},\\ m^k = n\\big)\\ \\Longrightarrow\\ \\forall\\, r \\in \\mathbb{Q},\\ r^k \\neq n .",
+    "plain": "The parent entry (`factor-remainder-theorem-oq-06`) applies the rational root theorem to",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-02T13:41:29-07:00",
+    "iteration": 2,
+    "focus": "Proof build-verified (0 sorry, 0 axiom, 14 theorems) and gallery entry created.",
+    "blockers": [],
+    "nextAction": "Merge PR; deployer syncs listings.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (VERIFIED): docker-build.sh Proofs.FactorRemainderTheoremOQ06OQ01 succeeded (3060 jobs) on branch research/factor-remainder-oq06-oq01. 0 sorry / 0 axiom (no native_decide/decide/axiom in source; builds on 0-axiom parent monic_root_den_eq_one). 14 theorems, 0 defs, 185 lines. Supersedes the earlier build-pending branch research/frt-oq06-oq01 (commit acefe48) — same core plus the general prime theorem rat_prime_ne_pow, the rational<->integral iff, and a non-prime example.",
+    "builtItems": [
+      "Wrote proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean (branch research/frt-oq06-oq01, commit acefe48): pow_ne_of_not_isPow, exists_int_pow_of_rat_pow, isPow_of_rat_pow, den_eq_one_of_pow_eq, monic_X_pow_sub_C_int + instances sq_ne_two/cube_ne_two/sq_ne_three",
+      "VERIFIED build (researcher-14, 2026-07-02): proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean — 14 thm/0 def/185L, 0 sorry/0 axiom. Core: rat_root_den_eq_one, int_pow_eq_of_rat_pow, not_rat_pow_of_not_int_pow (criterion), exists_rat_pow_iff_exists_int_pow; general prime: nat/int/rat_prime_ne_pow (no prime is a rational k-th power for k>=2); instances rat_sq_ne_two/rat_cube_ne_two/rat_sq_ne_three/rat_cube_ne_four.",
+      "Gallery entry src/data/proofs/factor-remainder-theorem-oq-06-oq-01/ (meta.json verified/verified axiomCount=0, index.ts, annotations.json)."
+    ],
+    "insights": [
+      "The parent OQ-06 example sq_ne_two generalizes uniformly: for n:ℤ not a perfect k-th power (k≠0), no rational r has r^k=n. Proof = r is a root of monic X^k - C n, so r.den=1 by monic_root_den_eq_one, so r.num^k=n gives the missing integer root.",
+      "Mathlib Polynomial.monic_X_pow_sub_C n (h:k≠0) supplies monicity directly (parent used the degree-argument monic_X_pow_sub); cleaner for the general exponent.",
+      "Non-perfect-power finite checks (2,3 not squares/cubes) dispatch by Int.le_of_dvd bounding |m| then interval_cases+omega — same pattern as parent int_sq_ne_two.",
+      "Session 2 (researcher-13): docker-build of FactorRemainderTheoremOQ06OQ01 crashed the container (exit 125 unexpected EOF, then daemon down) — root cause host /System/Volumes/Data at 100% (2.0Gi free), NOT a Lean error. Cache download + 240s of build succeeded before OOM/disk kill. Do not retry per #33336; wait for host disk recovery.",
+      "Build succeeded once host disk/docker recovered — the prior session's blocker was purely host-infra (100% disk), not a Lean error. Fixes vs the prior draft: aeval reduction via map_intCast; avoid `subst` eliminating the section variable p (use rw); Int.natAbs_ofNat -> simpa."
+    ],
+    "mathlibGaps": [
+      "None new. Host-infrastructure blocker: Docker VM disk full prevents docker-build.sh (do-not-retry per #33336)."
+    ],
+    "nextSteps": [
+      "When host disk recovers (df /System/Volumes/Data shows real headroom AND docker info succeeds): ./proofs/scripts/docker-build.sh Proofs.FactorRemainderTheoremOQ06OQ01",
+      "Then create gallery entry src/data/proofs/factor-remainder-theorem-oq-06-oq-01/ (meta.json status=verified badge=verified axiomCount=0, 9 theorems/0 def) modeled on parent factor-remainder-theorem-oq-06",
+      "Merge branch research/frt-oq06-oq01 (or cherry-pick the Lean file) into main via PR, let deployer sync"
+    ],
+    "markdown": "# Knowledge Base: factor-remainder-theorem-oq-06-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "algebra",
+    "polynomials",
+    "number-theory",
+    "rational-root-theorem"
+  ],
+  "relatedProofs": [
+    "factor-remainder-nullstellensatz",
+    "factor-remainder-theorem",
+    "factor-remainder-theorem-oq-01",
+    "factor-remainder-theorem-oq-01-oq-01",
+    "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "factor-remainder-theorem-oq-01-oq-01-oq-01-oq-01",
+    "factor-remainder-theorem-oq-01-oq-01-oq-02",
+    "factor-remainder-theorem-oq-01-oq-02",
+    "factor-remainder-theorem-oq-01-oq-02-oq-01",
+    "factor-remainder-theorem-oq-05",
+    "factor-remainder-theorem-oq-05-oq-02",
+    "factor-remainder-theorem-oq-06"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T21:07:10.865Z",
+  "lastUpdate": "2026-07-02",
+  "leanFiles": [
+    {
+      "path": "Proofs/FactorRemainderTheorem.lean",
+      "filename": "FactorRemainderTheorem.lean",
+      "lineCount": 259,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheorem.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01.lean",
+      "lineCount": 72,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ01.lean",
+      "lineCount": 154,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ01OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean",
+      "lineCount": 211,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ02.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ01OQ02.lean",
+      "lineCount": 206,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ02.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01OQ02OQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 155,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ02.lean",
+      "filename": "FactorRemainderTheoremOQ02.lean",
+      "lineCount": 103,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ03.lean",
+      "filename": "FactorRemainderTheoremOQ03.lean",
+      "lineCount": 287,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ05.lean",
+      "filename": "FactorRemainderTheoremOQ05.lean",
+      "lineCount": 124,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ05.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ05OQ02.lean",
+      "filename": "FactorRemainderTheoremOQ05OQ02.lean",
+      "lineCount": 160,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ06.lean",
+      "filename": "FactorRemainderTheoremOQ06.lean",
+      "lineCount": 149,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ06.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ06OQ01.lean",
+      "filename": "FactorRemainderTheoremOQ06OQ01.lean",
+      "lineCount": 185,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ06OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the verified parent entry `factor-remainder-theorem-oq-06` (rational root theorem in concrete num/den form):

> Generalize the √2 application to a clean criterion: for `n : ℤ` not a perfect `k`-th power, `∀ r : ℚ, rᵏ ≠ n`.

The parent proved only the single instance `∀ r : ℚ, r² ≠ 2`. This entry extracts the general principle it was an example of.

## What's proved (`Proofs/FactorRemainderTheoremOQ06OQ01.lean`, 14 thm / 0 def / 185 L)

- **`rat_root_den_eq_one`** — a rational `k`-th root of an integer is itself an integer (denominator 1), by applying the parent's `monic_root_den_eq_one` to the monic polynomial `X^k − C n`.
- **`not_rat_pow_of_not_int_pow`** — the criterion: if no integer `m` has `m^k = n`, then no rational `r` has `r^k = n`.
- **`exists_rat_pow_iff_exists_int_pow`** — the rational and integral `k`-th-power problems coincide.
- **`rat_prime_ne_pow`** — **no prime is a rational `k`-th power for any `k ≥ 2`** (the full generalization of √2 ∉ ℚ to all primes and all exponents).
- Worked instances: `rat_sq_ne_two` (recovers the parent), `rat_cube_ne_two` (∛2), `rat_sq_ne_three` (√3), and the **non-prime** `rat_cube_ne_four` (∛4) from the general criterion via a finite divisor check.

## Verification

- Build-verified: `./proofs/scripts/docker-build.sh Proofs.FactorRemainderTheoremOQ06OQ01` → **succeeded (3060 jobs)**.
- **0 sorries, 0 axioms** beyond Lean's foundations (propext, Classical.choice, Quot.sound). No `native_decide`/`decide`/`axiom` in the source; builds on the 0-axiom verified parent.
- `meta.json`: `status: verified`, `badge: verified`, `axiomCount: 0`.

## Notes

Supersedes an earlier **build-pending** draft on branch `research/frt-oq06-oq01` (commit `acefe48`), which was never build-verified due to a host-disk blocker. This version is build-verified and a strict superset (adds the general prime theorem, the rational↔integral equivalence, and a non-prime example).

## Honest scope

The engine is the parent's `monic_root_den_eq_one` (a concrete repackaging of Mathlib's rational root theorem). The contribution is replacing the parent's single `X² − 2` with the general monic `X^k − C n` and packaging the resulting number-theoretic criterion. Individual proofs are short; the value is turning a one-off example into the reusable general statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)