### PR TITLE
Enrich B(1/2,1/2)=π arcsine density (gamma-reflection-formula-oq-01-oq-01): bridge annotation + open question

### DIFF
--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/annotations.json
@@ -71,6 +71,30 @@
     ]
   },
   {
+    "id": "ann-gamma-refl-oq0101-arcsine-bridge",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 75
+    },
+    "type": "insight",
+    "title": "Reading the Beta Value as a Real Integral: the Arcsine Kernel",
+    "content": "This section-header commentary is the conceptual pivot of the file: it reinterprets the abstract value B(1/2,1/2) = π as a statement about a concrete real integral. The complex Beta integrand at (1/2,1/2) is x^(1/2-1)·(1-x)^(1/2-1) = x^(-1/2)·(1-x)^(-1/2), which on [0,1] is the cast of the real arcsine kernel 1/√(x(1-x)). The subtlety recorded here is the endpoint convention: at x = 0 and x = 1 the negative powers x^(-1/2) and (1-x)^(-1/2) are read as 0 (Mathlib's rpow/cpow convention for the base 0), and both sides of the identification vanish there, so the pointwise equality holds throughout the closed interval. This bridge is what lets betaIntegral_half_half be transported to arcsine_total_mass.",
+    "mathContext": "$x^{1/2-1}(1-x)^{1/2-1} = \\dfrac{1}{\\sqrt{x(1-x)}}$ on $[0,1]$; the integrable singularities at the endpoints have the convention $0^{-1/2}=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Beta integrand",
+      "arcsine distribution",
+      "improper integral",
+      "rpow endpoint convention"
+    ],
+    "prerequisites": [
+      "Beta function",
+      "real analysis",
+      "complex power functions"
+    ]
+  },
+  {
     "id": "ann-gamma-refl-oq0101-arcsine-mass",
     "proofId": "gamma-reflection-formula-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/meta.json
@@ -163,7 +163,8 @@
     "summary": "The Beta value B(1/2,1/2) = π is derived from Γ(1/2)² = π via Mathlib's Beta–Gamma relation Γ(s)Γ(t) = Γ(s+t)B(s,t) at s = t = 1/2 (with Γ(1) = 1 and Γ(1/2) = π^(1/2)). Unfolding the Beta integral and identifying its integrand with the real arcsine kernel 1/√(x(1-x)) on [0,1] transports the value to the real closed form ∫₀¹ dx/√(x(1-x)) = π, and factoring out 1/π shows the arcsine density 1/(π√(x(1-x))) integrates to 1. 119 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
     "implications": "The Beta integral and the Beta–Gamma relation are Mathlib's (used as bridges), but the special value B(1/2,1/2) = π, the real closed form ∫₀¹ dx/√(x(1-x)) = π, and the arcsine probability normalisation are new — hence the original badge. The entry exhibits the reflection-formula constant π simultaneously as a Gamma special value, a Beta integral, and the normalising constant of the arcsine distribution.",
     "openQuestions": [
-      "Compute the general symmetric Beta value B(s,1-s) = π/sin(πs) by combining the Beta–Gamma relation with Euler's reflection formula."
+      "Compute the general symmetric Beta value B(s,1-s) = π/sin(πs) by combining the Beta–Gamma relation with Euler's reflection formula.",
+      "Identify the arcsine density 1/(π√(x(1-x))) as the equilibrium (Chebyshev) measure of [0,1] and compute its moments ∫₀¹ xⁿ dμ, recovering the central binomial pattern C(2n,n)/4ⁿ and connecting this entry to the central-binomial Beta values B(n+1,n+1)."
     ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `gamma-reflection-formula-oq-01-oq-01` (B(1/2,1/2) = π and the Total Mass of the Arcsine Density).

**Gaps addressed:**
- **Annotation coverage**: the "## The arcsine total mass" bridging commentary (lines 69–75) — the conceptual pivot that reinterprets B(1/2,1/2) = π as the real integral of the arcsine kernel 1/√(x(1−x)), and records the endpoint convention 0^(−1/2)=0 — was unannotated (annotations jumped from line 67 to line 76). Added an `arcsine-bridge` insight annotation with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Now 5 fully-fielded annotations.
- **Conclusion depth**: added a second `openQuestions` item connecting the arcsine density to the equilibrium (Chebyshev) measure and central-binomial moments.

No content removed; `status`/`badge`/`axiomCount` unchanged. Both JSON files validated.
