### PR TITLE
research(desargues-oq-03): follow-up over arbitrary fields — semilinear PΓL action + frame rigidity [BUILD-PENDING]

### DIFF
--- a/proofs/Proofs/DesarguesTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/DesarguesTheoremOQ03OQ01.lean
@@ -1,0 +1,308 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.Tactic
+
+/-
+# From PGL to PΓL: the semilinear group and frame rigidity (OQ-03-OQ-01)
+
+Parent: `Proofs/DesarguesTheoremOQ03.lean` — *projective invariance of the Desargues
+configuration under GL₃(ℝ)*.
+
+## The follow-up question
+
+The parent entry (OQ-03) proves the **linear** half of the algebraic engine behind the
+Fundamental Theorem of Projective Geometry (FTPG): over `ℝ`, an invertible matrix `M`
+acts on `PG(2, ℝ)` by a collineation, because
+`det [M·p, M·q, M·r] = det M · det [p, q, r]`.
+It explicitly leaves two things open:
+
+1. the **semilinear** part — the FTPG identifies the *full* collineation group with
+   `PΓL(3, K) = PGL(3, K) ⋊ Aut(K)`, not merely `PGL`; the field-automorphism twist is
+   missing from OQ-03; and
+2. the **rigidity** that gives the FTPG its force — a projective transformation is
+   determined by its action on a projective *frame*.
+
+This entry supplies both, and does so over an **arbitrary field `K`** (the coordinate
+ring produced by Hilbert's coordinatization of any Desarguesian plane), tightening the
+tie between Desargues and the FTPG.
+
+## Why this is the right generalization
+
+Desargues's theorem is exactly the synthetic hypothesis under which a projective plane
+is coordinatizable as `PG(2, K)` for a division ring `K` (Hilbert). The FTPG then
+describes the collineations of that coordinatized plane as `PΓL(3, K)`. Working over a
+general field `K` (rather than only `ℝ`) is therefore not idle generality: it is the
+natural home of the Desargues ⇒ coordinates ⇒ FTPG chain. Over `ℝ` the automorphism
+group `Aut(ℝ)` is trivial, so the semilinear phenomenon is *invisible* — one must leave
+`ℝ` to see the `Aut(K)` factor at all (e.g. `Aut(ℂ)` or `Aut(𝔽_{p^n})` are large).
+
+## What is proved here (axiom-free, `0` sorries)
+
+Points of `PG(2, K)` are nonzero vectors of `K³`; three of them are `Collinear` iff the
+matrix with those rows is singular (`det = 0`) — the same incidence predicate as the
+parent, now over `K`.
+
+* **PGL(3, K) acts by collineations** (over any field):
+  `rowMat_mulVec_det`, `collinear_mulVec`, `collinear_mulVec_iff`.
+* **Aut(K) acts by collineations — the new semilinear part:**
+  `collinear_semilinear` — a field endomorphism applied coordinatewise preserves
+  collinearity.
+* **PΓL(3, K) ⊆ Collineations — the constructive half of the FTPG:**
+  `collinear_projSemilinear` — a linear map followed by a field automorphism (a
+  projective *semilinear* map) preserves collinearity. This is the exact class of
+  transformations the FTPG names.
+* **Frame rigidity — the computational kernel of the FTPG:**
+  `frame_general_position` — the standard frame `[1:0:0], [0:1:0], [0:0:1], [1:1:1]` is
+  in general position (a genuine projective frame); and
+  `frame_stabilizer_scalar` — a linear map fixing each frame point projectively is a
+  *scalar* matrix. Equivalently the projective stabilizer of a frame in `PGL(3, K)` is
+  trivial: **a projective transformation is uniquely determined by its action on a
+  frame.**
+* **Projective invariance of Desargues over `K`:**
+  `desargues_relation_mulVec`, `desargues_relation_preserved` — the perspectivity
+  relations (both `det = 0` conditions) transport along collineations, generalizing the
+  parent's `ℝ`-only invariance to arbitrary fields.
+
+## What stays open (the deep direction)
+
+The hard converse `Collineations ⊆ PΓL(3, K)` — that *every* collineation is
+semilinear — is the substantial content of the FTPG. It reconstructs the field
+operations from incidence (again via Desargues) and is a large development; it is left
+as the contextual open direction, not axiomatized. Everything below is fully proved.
+-/
+
+set_option linter.unusedVariables false
+
+namespace DesarguesTheoremOQ03OQ01
+
+open Matrix
+
+variable {K : Type*} [Field K]
+
+-- ============================================================
+-- PART 1: The coordinatized plane PG(2,K)
+-- ============================================================
+
+/-- The 3×3 matrix formed by three vectors as its rows. -/
+def rowMat (u v w : Fin 3 → K) : Matrix (Fin 3) (Fin 3) K :=
+  Matrix.of fun i j =>
+    match i with
+    | 0 => u j
+    | 1 => v j
+    | 2 => w j
+
+/-- Explicit determinant of `rowMat`. -/
+theorem rowMat_det (u v w : Fin 3 → K) :
+    (rowMat u v w).det =
+      u 0 * (v 1 * w 2 - v 2 * w 1) -
+      u 1 * (v 0 * w 2 - v 2 * w 0) +
+      u 2 * (v 0 * w 1 - v 1 * w 0) := by
+  simp only [rowMat, Matrix.det_fin_three, Matrix.of_apply]
+  ring
+
+/-- Three projective points are **collinear** iff the determinant of the matrix with
+those points as rows vanishes.  (Dually, three projective *lines* are **concurrent**
+under the same predicate.) -/
+def Collinear (p q r : Fin 3 → K) : Prop := (rowMat p q r).det = 0
+
+-- ============================================================
+-- PART 2: PGL(3,K) acts by collineations
+-- ============================================================
+
+/-- Stacking three `M`-transformed points as rows equals stacking the original points
+and right-multiplying by `Mᵀ`. -/
+theorem rowMat_mulVec (M : Matrix (Fin 3) (Fin 3) K) (p q r : Fin 3 → K) :
+    rowMat (M.mulVec p) (M.mulVec q) (M.mulVec r) = rowMat p q r * Mᵀ := by
+  ext i j
+  fin_cases i <;>
+    simp [rowMat, Matrix.mul_apply, Matrix.transpose_apply, Matrix.mulVec,
+      dotProduct, Fin.sum_univ_three, mul_comm]
+
+/-- **Determinant multiplicativity of the linear action.**
+The signed area (determinant) of three transformed points scales by `det M`. -/
+theorem rowMat_mulVec_det (M : Matrix (Fin 3) (Fin 3) K) (p q r : Fin 3 → K) :
+    (rowMat (M.mulVec p) (M.mulVec q) (M.mulVec r)).det
+      = M.det * (rowMat p q r).det := by
+  rw [rowMat_mulVec, Matrix.det_mul, Matrix.det_transpose, mul_comm]
+
+/-- **PGL acts by collineations.** A linear map sends collinear points to collinear
+points. -/
+theorem collinear_mulVec (M : Matrix (Fin 3) (Fin 3) K) {p q r : Fin 3 → K}
+    (h : Collinear p q r) :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) := by
+  unfold Collinear at *
+  rw [rowMat_mulVec_det, h, mul_zero]
+
+/-- When `M` is invertible the linear action **reflects** collinearity as well:
+`PGL(3, K)` acts on `PG(2, K)` by collineations. -/
+theorem collinear_mulVec_iff (M : Matrix (Fin 3) (Fin 3) K) (hM : M.det ≠ 0)
+    {p q r : Fin 3 → K} :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) ↔ Collinear p q r := by
+  unfold Collinear
+  rw [rowMat_mulVec_det]
+  constructor
+  · intro h; exact (mul_eq_zero.mp h).resolve_left hM
+  · intro h; rw [h, mul_zero]
+
+-- ============================================================
+-- PART 3: Aut(K) acts by collineations — the semilinear part
+-- ============================================================
+
+/-- Applying a ring endomorphism `σ` coordinatewise to three points is the same as
+mapping the stacked matrix through `σ`. -/
+theorem rowMat_map (σ : K →+* K) (p q r : Fin 3 → K) :
+    rowMat (fun i => σ (p i)) (fun i => σ (q i)) (fun i => σ (r i))
+      = (rowMat p q r).map σ := by
+  ext i j
+  fin_cases i <;> simp [rowMat, Matrix.map_apply]
+
+/-- **Aut(K) acts by collineations.** A field endomorphism applied coordinatewise — the
+*semilinear* ingredient of `PΓL` that is invisible over `ℝ` — preserves collinearity. -/
+theorem collinear_semilinear (σ : K →+* K) {p q r : Fin 3 → K}
+    (h : Collinear p q r) :
+    Collinear (fun i => σ (p i)) (fun i => σ (q i)) (fun i => σ (r i)) := by
+  unfold Collinear at *
+  rw [rowMat_map, ← RingHom.map_det, h, map_zero]
+
+-- ============================================================
+-- PART 4: PΓL(3,K) ⊆ Collineations  (the constructive half of the FTPG)
+-- ============================================================
+
+/-- **PΓL(3, K) acts by collineations.** A projective *semilinear* map — an invertible
+linear map `M` followed by a field automorphism `σ` — preserves collinearity.
+
+This is the inclusion `PΓL(3, K) ⊆ Aut(PG(2, K))`: every transformation named by the
+Fundamental Theorem of Projective Geometry genuinely is a collineation. The FTPG's deep
+content is the converse inclusion, which requires Desargues (coordinatization). -/
+theorem collinear_projSemilinear (M : Matrix (Fin 3) (Fin 3) K) (σ : K →+* K)
+    {p q r : Fin 3 → K} (h : Collinear p q r) :
+    Collinear (fun i => σ ((M.mulVec p) i)) (fun i => σ ((M.mulVec q) i))
+      (fun i => σ ((M.mulVec r) i)) :=
+  collinear_semilinear σ (collinear_mulVec M h)
+
+-- ============================================================
+-- PART 5: The standard projective frame
+-- ============================================================
+
+/-- The standard frame of `PG(2, K)`: the three coordinate points and the unit point,
+`e₀ = [1:0:0]`, `e₁ = [0:1:0]`, `e₂ = [0:0:1]`, `u = [1:1:1]`, are in **general
+position** — every one of the four 3-point subsets has nonzero determinant, so no three
+of them are collinear.  This makes them a genuine projective frame. -/
+theorem frame_general_position :
+    (rowMat (![1, 0, 0] : Fin 3 → K) ![0, 1, 0] ![0, 0, 1]).det = 1 ∧
+    (rowMat (![1, 0, 0] : Fin 3 → K) ![0, 1, 0] ![1, 1, 1]).det = 1 ∧
+    (rowMat (![1, 0, 0] : Fin 3 → K) ![0, 0, 1] ![1, 1, 1]).det = -1 ∧
+    (rowMat (![0, 1, 0] : Fin 3 → K) ![0, 0, 1] ![1, 1, 1]).det = 1 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;>
+    · simp only [rowMat_det, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+        Matrix.cons_val_two, Matrix.tail_cons]
+      ring
+
+-- ============================================================
+-- PART 6: Frame rigidity — the computational kernel of the FTPG
+-- ============================================================
+
+/-- **Frame rigidity / uniqueness up to scalar.**
+If a linear map `M` fixes each of the four standard frame points *projectively* (sends
+each to a scalar multiple of itself), then all four scalars coincide and `M` is that
+common scalar times the identity.
+
+Equivalently: the projective stabilizer of a frame inside `PGL(3, K)` is trivial, so a
+projective transformation is **uniquely determined by its action on a frame**. This
+rigidity is the exact computational statement underlying the Fundamental Theorem of
+Projective Geometry (which upgrades "determined on a frame" to "semilinear"). -/
+theorem frame_stabilizer_scalar (M : Matrix (Fin 3) (Fin 3) K) (a b c d : K)
+    (ha : M.mulVec ![1, 0, 0] = a • (![1, 0, 0] : Fin 3 → K))
+    (hb : M.mulVec ![0, 1, 0] = b • (![0, 1, 0] : Fin 3 → K))
+    (hc : M.mulVec ![0, 0, 1] = c • (![0, 0, 1] : Fin 3 → K))
+    (hd : M.mulVec ![1, 1, 1] = d • (![1, 1, 1] : Fin 3 → K)) :
+    a = d ∧ b = d ∧ c = d ∧ M = d • (1 : Matrix (Fin 3) (Fin 3) K) := by
+  -- Extract the columns of `M` from the three coordinate-point hypotheses.
+  have e00 : M 0 0 = a := by
+    have h := congrFun ha 0
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e10 : M 1 0 = 0 := by
+    have h := congrFun ha 1
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e20 : M 2 0 = 0 := by
+    have h := congrFun ha 2
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e01 : M 0 1 = 0 := by
+    have h := congrFun hb 0
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e11 : M 1 1 = b := by
+    have h := congrFun hb 1
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e21 : M 2 1 = 0 := by
+    have h := congrFun hb 2
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e02 : M 0 2 = 0 := by
+    have h := congrFun hc 0
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e12 : M 1 2 = 0 := by
+    have h := congrFun hc 1
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  have e22 : M 2 2 = c := by
+    have h := congrFun hc 2
+    simpa [Matrix.mulVec, dotProduct, Fin.sum_univ_three] using h
+  -- The unit-point hypothesis forces the three diagonal scalars to agree with `d`.
+  have hda : a = d := by
+    have h := congrFun hd 0
+    simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
+      Pi.smul_apply, smul_eq_mul, mul_one] at h
+    rw [e00, e01, e02] at h; linarith [h]
+  have hdb : b = d := by
+    have h := congrFun hd 1
+    simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
+      Pi.smul_apply, smul_eq_mul, mul_one] at h
+    rw [e10, e11, e12] at h; linarith [h]
+  have hdc : c = d := by
+    have h := congrFun hd 2
+    simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
+      Pi.smul_apply, smul_eq_mul, mul_one] at h
+    rw [e20, e21, e22] at h; linarith [h]
+  refine ⟨hda, hdb, hdc, ?_⟩
+  -- Assemble `M = d • 1` entrywise.
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul] <;>
+    first
+      | (rw [e00, hda])
+      | (rw [e11, hdb])
+      | (rw [e22, hdc])
+      | (rw [e10]; ring)
+      | (rw [e20]; ring)
+      | (rw [e01]; ring)
+      | (rw [e21]; ring)
+      | (rw [e02]; ring)
+      | (rw [e12]; ring)
+      | simp
+
+-- ============================================================
+-- PART 7: Projective invariance of the Desargues configuration over K
+-- ============================================================
+
+/-- **Projective invariance of Desargues over any field.**
+The two relations appearing in Desargues's theorem — perspectivity from a point
+(concurrency of the three joining lines) and perspectivity from a line (collinearity of
+the three intersection points) — are both `det = 0` conditions on triples of homogeneous
+vectors, hence preserved by the collineation group. This generalizes the parent OQ-03
+invariance from `ℝ` to arbitrary `K`. -/
+theorem desargues_relation_mulVec (M : Matrix (Fin 3) (Fin 3) K) {p q r : Fin 3 → K}
+    (h : Collinear p q r) :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) :=
+  collinear_mulVec M h
+
+/-- A collineation preserves collinearity in **both directions** when invertible, so it
+carries Desargues configurations to Desargues configurations bijectively — the precise
+sense in which the Desarguesian property is intrinsic to `PG(2, K)`. -/
+theorem desargues_relation_preserved (M : Matrix (Fin 3) (Fin 3) K) (hM : M.det ≠ 0)
+    {p q r : Fin 3 → K} :
+    Collinear (M.mulVec p) (M.mulVec q) (M.mulVec r) ↔ Collinear p q r :=
+  collinear_mulVec_iff M hM
+
+end DesarguesTheoremOQ03OQ01

--- a/research/problems/desargues-theorem-oq-03/knowledge.md
+++ b/research/problems/desargues-theorem-oq-03/knowledge.md
@@ -1,0 +1,65 @@
+# Desargues — OQ-03: Relationship to the Fundamental Theorem of Projective Geometry
+
+## Summary
+
+- **Base entry `desargues-theorem-oq-03` is already complete and merged** (#33082,
+  `VERIFIED, 0-axiom, 8thm/4def/150L`). It proves, over `ℝ`, the linear engine of the
+  FTPG: `det [M·p, M·q, M·r] = det M · det [p, q, r]`, so `GL₃(ℝ)` acts on `PG(2,ℝ)` by
+  collineations (collinearity/concurrence preserved, and reflected when `det M ≠ 0`),
+  and the Desargues configuration is projectively invariant. It explicitly leaves the
+  **semilinear part** and the abstract FTPG open.
+
+- This session authored a **follow-up**, `Proofs/DesarguesTheoremOQ03OQ01.lean`, that
+  closes the semilinear gap and adds frame rigidity, over an **arbitrary field `K`**.
+
+## Session 2026-07-02 (Session 1) — Follow-up over general fields (build-pending)
+
+**Mode**: FRESH → SOLVED(base) → follow-up
+**Outcome**: progress (new Lean file written, 0 sorry / 0 axiom by construction;
+verification blocked by infra outage)
+
+### What I did
+- Surveyed the Desargues family: base (ℝ), OQ-01 (commutative rings), OQ-01-OQ-01 /
+  OQ-02 (Moulton non-Desarguesian plane), OQ-04 (self-duality). Found the pool problem
+  `desargues-theorem-oq-03` was already solved+merged but still claimable.
+- Wrote `Proofs/DesarguesTheoremOQ03OQ01.lean` (~308 lines) generalizing the FTPG
+  relationship to any field `K`:
+  - `rowMat_mulVec_det` — determinant transformation law over `K`.
+  - `collinear_mulVec`, `collinear_mulVec_iff` — `PGL(3,K)` acts by collineations.
+  - `rowMat_map`, `collinear_semilinear` — **new**: `Aut(K)` acts by collineations
+    (the semilinear factor, invisible over `ℝ`).
+  - `collinear_projSemilinear` — **new**: `PΓL(3,K) ⊆ Collineations`, the constructive
+    half of the FTPG.
+  - `frame_general_position`, `frame_stabilizer_scalar` — **new**: the standard frame is
+    in general position, and a projective map fixing a frame is scalar (frame rigidity —
+    the computational kernel of the FTPG).
+  - `desargues_relation_mulVec`, `desargues_relation_preserved` — Desargues invariance
+    over `K`.
+
+### Key findings
+- The `Aut(K)` semilinear factor of `PΓL` cannot be seen over `ℝ` (`Aut(ℝ)` trivial);
+  the general-field formulation is the natural home of the Desargues⇒coordinates⇒FTPG
+  chain.
+- Frame rigidity (stabilizer of a frame is trivial in `PGL`) is exactly the
+  uniqueness statement that powers the FTPG.
+
+### Blockers
+- **Infrastructure outage**: local `docker-build.sh` fails — Docker VM internal disk
+  throws I/O errors (os error 5) unpacking the Mathlib cache; host data volume at 100%
+  (< 1 GiB free). Aristotle MCP returns `Resource not found` (service down). Neither
+  kernel nor server-side verification was possible this session.
+- The file is written against idioms that compile elsewhere in this repo (sibling
+  `DesarguesTheoremOQ01.lean` uses the same `det_fin_three` expansion) and standard
+  Mathlib lemmas (`det_mul`, `det_transpose`, `RingHom.map_det`, `Fin.sum_univ_three`),
+  but remains **UNVERIFIED pending build**.
+
+### Files modified
+- `proofs/Proofs/DesarguesTheoremOQ03OQ01.lean` (new, build-pending)
+- `src/data/research/problems/desargues-theorem-oq-03.json` (knowledge)
+- `research/problems/desargues-theorem-oq-03/knowledge.md` (this file)
+
+### Next steps
+- Build-verify with `./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ03OQ01`
+  when Docker/disk recover; if green, create gallery entry `desargues-theorem-oq-03-oq-01`
+  (badge `original`, `verified`, 0-axiom).
+- Do NOT treat as verified until built.

--- a/src/data/research/problems/desargues-theorem-oq-03.json
+++ b/src/data/research/problems/desargues-theorem-oq-03.json
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS (build-pending): base OQ-03 (PGL-invariance over ℝ) already VERIFIED+merged (#33082). Authored follow-up OQ-03-OQ-01 extending it to arbitrary fields K with the Aut(K) semilinear action (PΓL⊆collineations) and frame-stabilizer rigidity (kernel of the FTPG). 0 sorry / 0 axiom by construction; local build + Aristotle both blocked by host Docker/disk outage — needs build verification.",
+    "builtItems": [
+      "Proofs/DesarguesTheoremOQ03OQ01.lean (build-pending, 0 sorry/0 axiom, ~308L): rowMat/Collinear over a general Field K; rowMat_mulVec_det (det law); collinear_mulVec, collinear_mulVec_iff (PGL acts by collineations); rowMat_map + collinear_semilinear (Aut(K) semilinear action); collinear_projSemilinear (PΓL(3,K)⊆Collineations); frame_general_position; frame_stabilizer_scalar (frame rigidity); desargues_relation_mulVec/_preserved (Desargues invariance over K)."
+    ],
+    "insights": [
+      "Base entry desargues-theorem-oq-03 (PROOFS/DesarguesTheoremOQ03.lean) is already complete & merged (#33082): det[M·p,M·q,M·r]=detM·det[p,q,r] over ℝ gives PGL-invariance of collinearity/concurrence; it explicitly leaves the semilinear part and abstract FTPG open.",
+      "The FTPG collineation group is PΓL(3,K)=PGL(3,K)⋊Aut(K); the Aut(K) twist is INVISIBLE over ℝ (Aut(ℝ) trivial), so extending coordinates from ℝ to a general field K is the natural setting to see the semilinear factor — motivates the follow-up over arbitrary K.",
+      "Frame rigidity is the true computational kernel of the FTPG: a linear map fixing the standard frame e0,e1,e2,e0+e1+e2 projectively (each ↦ scalar·itself) must be a scalar matrix, so the projective stabilizer of a frame in PGL(3,K) is trivial (transformation determined by its action on a frame).",
+      "Standard frame is in general position over any field: the four 3-subset determinants are 1,1,-1,1 (all nonzero)."
+    ],
+    "mathlibGaps": [
+      "Full FTPG converse (every collineation of PG(n,K), n≥2, is semilinear ⇒ PΓL) is absent from Mathlib and is a large development (reconstruct field ops from incidence via Desargues) — left as the contextual open direction, not axiomatized.",
+      "No projective-space/collineation framework in Mathlib to state the abstract FTPG directly; we work in the concrete K³ determinant model."
+    ],
+    "nextSteps": [
+      "Build-verify Proofs/DesarguesTheoremOQ03OQ01.lean once Docker/disk recovers (./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ03OQ01); if green, create gallery entry desargues-theorem-oq-03-oq-01 (badge original, verified, 0-axiom).",
+      "Possible further follow-up: state PΓL as an actual group action / Setoid on projective points and show the induced map on the projective quotient is a well-defined collineation.",
+      "Check RingHom.map_det name and simp lemmas (Matrix.cons_val_two/tail_cons) survive the current Mathlib pin during build."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Follow-up to the **already-merged** base entry `desargues-theorem-oq-03` (#33082, *PGL-invariance over ℝ*), which explicitly leaves the **semilinear part** and the abstract **Fundamental Theorem of Projective Geometry (FTPG)** open.

This PR adds `proofs/Proofs/DesarguesTheoremOQ03OQ01.lean` (~308 lines, **0 sorry / 0 axiom** by construction) extending the Desargues⇒FTPG relationship from ℝ to an **arbitrary field `K`** — the natural setting, since the `Aut(K)` semilinear factor of `PΓL(3,K)=PGL(3,K)⋊Aut(K)` is invisible over ℝ (`Aut(ℝ)` is trivial).

### New content beyond the base entry
| Theorem | Statement |
|---|---|
| `collinear_mulVec`, `collinear_mulVec_iff` | `PGL(3,K)` acts on `PG(2,K)` by collineations |
| `rowMat_map`, `collinear_semilinear` | **Aut(K) acts by collineations** — the semilinear factor |
| `collinear_projSemilinear` | **`PΓL(3,K) ⊆ Collineations`** — the constructive half of the FTPG |
| `frame_general_position` | the standard frame is in general position over any `K` |
| `frame_stabilizer_scalar` | **frame rigidity**: a map fixing a frame projectively is scalar (stabilizer of a frame in `PGL` is trivial) — the computational kernel of the FTPG |
| `desargues_relation_mulVec`, `_preserved` | Desargues invariance over `K` |

The deep converse (*every* collineation is semilinear) is the substantial content of the FTPG and is left as the contextual open direction — **not axiomatized**.

## ⚠️ BUILD-PENDING — do not treat as verified

This session could **not** kernel-verify the file: local `docker-build.sh` fails with Docker-VM I/O errors (`os error 5`) unpacking the Mathlib cache (host data volume at 100%, <1 GiB free), and the Aristotle MCP is down (`Resource not found`). The file is written against idioms known to compile in this repo (sibling `DesarguesTheoremOQ01.lean` uses the same `det_fin_three` expansion) and standard Mathlib lemmas (`det_mul`, `det_transpose`, `RingHom.map_det`, `Fin.sum_univ_three`), but **must be built before merge / before creating a gallery entry**.

```
./proofs/scripts/docker-build.sh Proofs.DesarguesTheoremOQ03OQ01
```

No gallery entry (`src/data/proofs/...`) is included, precisely because the file is unverified. Add `desargues-theorem-oq-03-oq-01` (badge `original`, `verified`, 0-axiom) only after a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)