### PR TITLE
Enrich Beta at half-integers (beta-integral-recurrence-oq-01-oq-02): add second open question

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
@@ -157,7 +157,8 @@
     "summary": "The half-integer values of the Euler Beta function are evaluated from Mathlib's Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v) and the Gauss value Γ(1/2) = π^(1/2). The centerpiece betaIntegral_half_half proves B(1/2,1/2) = π (via gamma_half_sq: Γ(1/2)² = π and Γ(1) = 1), and betaIntegral_three_half_three_half proves B(3/2,3/2) = π/8 by one step of the Gamma functional equation Γ(3/2) = (1/2)·Γ(1/2) with Γ(3) = 2. 99 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
     "implications": "The Beta–Gamma relation, the Gauss value, and the functional equation are delegated to Mathlib (hence the mathlib badge); the genuine new content is their assembly into the named half-integer Beta evaluations B(1/2,1/2) = π and B(3/2,3/2) = π/8, which Mathlib does not state. Where the parent entry shows the integer lattice is factorial, this entry shows the half-integer lattice is π-driven, the crossover being the single value Γ(1/2) = √π.",
     "openQuestions": [
-      "Establish the general diagonal half-integer closed form B(n+1/2, n+1/2) and connect it to the volume of the n-ball."
+      "Establish the general diagonal half-integer closed form B(n+1/2, n+1/2) and connect it to the volume of the n-ball.",
+      "Derive Wallis's product for π by iterating the Beta recurrence B(s+1,t) = B(s,t)·s/(s+t) starting from B(1/2,1/2) = π, exhibiting π as the limit of the Wallis ratios ∏ (2k)²/((2k−1)(2k+1))."
     ]
   },
   "description": "An assembly of half-integer Euler Beta values that Mathlib has the pieces for but never derives: B(1/2,1/2)=π and B(3/2,3/2)=π/8. Using the Beta–Gamma relation B(u,v)=Γ(u)Γ(v)/Γ(u+v), the Gauss value Γ(1/2)=π^(1/2), and one step of the functional equation Γ(3/2)=(1/2)·Γ(1/2), the proof recombines the two half-powers π^(1/2)·π^(1/2)=π to evaluate the central value B(1/2,1/2)=π and climbs one rung to B(3/2,3/2)=π/8. Answers open question oq-02 of the parent recurrence entry. 4 theorems, 0 sorries, 0 axioms."


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02`.

**Gap addressed:** the conclusion listed only one open question (target is 2+). Added a second substantive open question. No other content changed; `status`/`badge`/`axiomCount` unchanged; JSON validated.
