### PR TITLE
Enrich Factor/Remainder Theorem OQ-06-OQ-01 (rational k-th roots): annotation depth

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "From a One-Off √2 Example to a General Criterion",
     "content": "The parent entry OQ-06 proved ∀ r : ℚ, r² ≠ 2 as a single worked application of the rational root theorem to the monic polynomial X² − 2. That argument never used anything special about the exponent 2 or the constant 2. Replacing X² − 2 by the general monic polynomial X^k − C n turns it into the principle behind every classical irrationality result: the k-th root of an integer is either an integer or irrational.",
-    "mathContext": "General exponent k and constant n replace the parent's fixed 2 and 2."
+    "mathContext": "$X^2 - 2 \\;\\rightsquigarrow\\; X^k - C\\,n$: the fixed square/2 become an arbitrary exponent $k\\ge 1$ and integer $n$.",
+    "significance": "context",
+    "relatedConcepts": ["rational root theorem", "irrationality", "monic polynomial", "generalization of an instance"],
+    "prerequisites": ["polynomials over ℤ", "rational numbers"]
   },
   {
     "id": "ann-monic",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "The Monic Polynomial X^k − C n",
     "content": "Mathlib's monic_X_pow_sub_C certifies that X^k − C n is monic whenever k ≠ 0 — cleaner for a general exponent than the parent's degree-argument monic_X_pow_sub. Evaluating this polynomial at a rational r gives r^k − n, so r is a root exactly when r^k = n.",
-    "mathContext": "Monicity is what lets the integral root theorem apply."
+    "mathContext": "$X^k - C\\,n$ has leading coefficient $1$, hence is monic for $k\\neq 0$; and $\\operatorname{aeval}_r(X^k - C\\,n) = r^k - n$, so $r$ is a root $\\iff r^k = n$.",
+    "significance": "technical",
+    "relatedConcepts": ["monic polynomial", "leading coefficient", "aeval (polynomial evaluation)", "integral root theorem"],
+    "prerequisites": ["polynomial ring ℤ[X]", "monic_X_pow_sub_C"]
   },
   {
     "id": "ann-integrality",
@@ -24,7 +30,10 @@
     "type": "key-step",
     "title": "A Rational k-th Root of an Integer is an Integer",
     "content": "If r^k = n, then r is a root of the monic polynomial X^k − C n, so the parent's monic_root_den_eq_one forces r.den = 1: r is an integer. Then r = r.num and the integer r.num is a genuine k-th root of n. This single structural fact is the entire engine of the criterion.",
-    "mathContext": "The integral root theorem: monic ⟹ rational roots are integers."
+    "mathContext": "$r^k = n \\;\\Rightarrow\\; \\operatorname{den}(r) = 1 \\;\\Rightarrow\\; r = r.\\mathrm{num} \\in \\mathbb{Z}$ and $r.\\mathrm{num}^{\\,k} = n$. This is $\\mathbb{Z}$ being integrally closed in $\\mathbb{Q}$, specialised to $X^k - C\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["rational root theorem", "integrally closed domain", "denominator of a rational root", "Rat.num"],
+    "prerequisites": ["monic_root_den_eq_one (parent OQ-06)", "aeval of a rational root"]
   },
   {
     "id": "ann-criterion",
@@ -33,7 +42,10 @@
     "type": "key-step",
     "title": "The Criterion and the Rational ↔ Integral Equivalence",
     "content": "Contrapositive packaging: since any rational k-th root supplies an integer k-th root r.num, an integer n with no integer k-th root has no rational k-th root either (not_rat_pow_of_not_int_pow). Equivalently, ∃ r : ℚ, r^k = n ↔ ∃ m : ℤ, m^k = n — the rational and integral k-th-power problems coincide.",
-    "mathContext": "Reduces a rational-root question to a finite integer divisor check."
+    "mathContext": "$(\\forall m\\in\\mathbb{Z},\\ m^k\\neq n) \\Rightarrow (\\forall r\\in\\mathbb{Q},\\ r^k\\neq n)$, and dually $(\\exists r\\in\\mathbb{Q},\\ r^k=n) \\iff (\\exists m\\in\\mathbb{Z},\\ m^k=n)$.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "perfect k-th power", "existential equivalence", "finite divisor check"],
+    "prerequisites": ["contrapositive reasoning", "the integrality key step"]
   },
   {
     "id": "ann-prime",
@@ -42,7 +54,10 @@
     "type": "concept",
     "title": "No Prime is a Rational k-th Power (k ≥ 2)",
     "content": "A prime p is not a nontrivial perfect power: if a^k = p then a divides p, so a is 1 or p (Nat.dvd_prime); a = 1 gives 1 = p, and a = p gives p^k = p forcing k = 1 by injectivity of k ↦ p^k (Nat.pow_right_injective). Both contradict k ≥ 2. Feeding this into the criterion shows √p, ∛p, ⁴√p, … are all irrational for every prime p — the full generalization of √2 ∉ ℚ.",
-    "mathContext": "The archetypal irrationality result, uniform in prime and exponent."
+    "mathContext": "$a^k = p,\\ k\\ge 2 \\Rightarrow a\\mid p \\Rightarrow a\\in\\{1,p\\}$; $a=1\\Rightarrow p=1$ (false) and $a=p\\Rightarrow p^k=p^1\\Rightarrow k=1$ (false). Hence $\\sqrt[k]{p}\\notin\\mathbb{Q}$ for every prime $p$, $k\\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["prime divisors", "perfect power", "Nat.pow_right_injective", "irrationality of √p"],
+    "prerequisites": ["Nat.dvd_prime", "injectivity of exponentiation", "the criterion"]
   },
   {
     "id": "ann-instances",
@@ -51,6 +66,9 @@
     "type": "example",
     "title": "Worked Instances: √2, ∛2, √3, ∛4",
     "content": "rat_sq_ne_two recovers the parent's example, and rat_cube_ne_two, rat_sq_ne_three follow immediately from the prime result. rat_cube_ne_four (∛4 ∉ ℚ) exercises the general criterion beyond the prime case: 4 is not a perfect cube, discharged by bounding |m| ≤ 4 with Int.le_of_dvd and a finite interval_cases check.",
-    "mathContext": "Both prime (√2, ∛2, √3) and non-prime (∛4) applications of the criterion."
+    "mathContext": "Prime cases $\\sqrt2,\\sqrt[3]2,\\sqrt3$ come straight from rat_prime_ne_pow; the composite case $\\sqrt[3]4$ uses $m\\mid 4\\Rightarrow|m|\\le 4$ and interval_cases to verify $m^3\\neq 4$ for all $|m|\\le 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["irrationality of √2", "interval_cases", "Int.le_of_dvd", "finite divisor check"],
+    "prerequisites": ["the prime result", "decidable finite case analysis"]
   }
 ]


### PR DESCRIPTION
## Enrichment: Factor/Remainder Theorem OQ-06-OQ-01 (Rational k-th Roots of Integers)

This entry was already at a high quality bar (comprehensive `meta.json`, full-coverage section annotations). This pass closes the one remaining gap: **annotation depth fields**.

### Changes (annotations.json only)
- Added `significance` (`key` / `technical` / `supporting` / `context`) to all 6 annotations, reflecting each section's role in the argument.
- Added `relatedConcepts` arrays (e.g. *integrally closed domain*, *Nat.pow_right_injective*, *interval_cases*, *irrationality of √p*).
- Added `prerequisites` arrays pointing to the parent's `monic_root_den_eq_one` and the supporting Mathlib lemmas.
- Upgraded every `mathContext` to real LaTeX (e.g. the criterion `(∀ m∈ℤ, mᵏ≠n) ⇒ (∀ r∈ℚ, rᵏ≠n)` and the prime argument `aᵏ=p, k≥2 ⇒ a∈{1,p}`, both impossible).

All existing annotation content is preserved; `meta.json` is unchanged. `annotations.json` is 6 KB (well under caps). JSON validated; single-file diff.
