### PR TITLE
Enrich Derangements Convergence OQ-02 (sign & bracketing of 1/e): annotation prerequisites

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-02/annotations.json
@@ -8,7 +8,8 @@
     "content": "The parent file proves only the magnitude of the approximation error, |D(n)/n! - e⁻¹| ≤ 1/(n+1)!. This module determines the error's sign. Writing a(n) = D(n)/n! = ∑_{k≤n}(-1)^k/k!, the alternating structure forces even partial sums strictly above e⁻¹ and odd ones strictly below, so consecutive derangement ratios bracket 1/e. The headline is the unified sign law (-1)^n·(D(n)/n! - e⁻¹) > 0 and the bracket D(2k+1)/(2k+1)! < e⁻¹ < D(2k)/(2k)!.",
     "mathContext": "For an alternating series $\\sum (-1)^k c_k$ with $c_k$ strictly decreasing to $0$, the partial sums oscillate around the limit: even-indexed from above, odd-indexed from below. Here $c_k = 1/k!$ and the limit is $e^{-1}$.",
     "significance": "key",
-    "relatedConcepts": ["numDerangements", "altFactPartialSum", "alternating series", "e-constant"]
+    "relatedConcepts": ["numDerangements", "altFactPartialSum", "alternating series", "e-constant"],
+    "prerequisites": ["alternating series and the Leibniz criterion", "Taylor series $e^{-1} = \\sum (-1)^k/k!$", "derangement numbers and the ratio $D(n)/n!$"]
   },
   {
     "id": "ann-dcoq02-signs",
@@ -19,7 +20,8 @@
     "content": "altFactTerm_of_even and altFactTerm_of_odd compute the k-th term (-1)^k/k! as +1/k! or -(1/k!) using Even.neg_one_pow and Odd.neg_one_pow. Producing the odd term as -(1/k!) rather than (-1)/k! is deliberate: it lets later linarith calls relate it to the positive quantity 1/k!.",
     "mathContext": "$(-1)^k = 1$ when $k$ is even and $-1$ when $k$ is odd, so the $k$-th Taylor coefficient of $e^{-1}$ has sign $(-1)^k$.",
     "significance": "supporting",
-    "relatedConcepts": ["Even.neg_one_pow", "Odd.neg_one_pow"]
+    "relatedConcepts": ["Even.neg_one_pow", "Odd.neg_one_pow"],
+    "prerequisites": ["parity of natural numbers (Even/Odd)", "signs of integer powers of $-1$", "normalising a term into $\\pm(1/k!)$ form"]
   },
   {
     "id": "ann-dcoq02-monotone",
@@ -30,7 +32,8 @@
     "content": "aSeq_add_two expresses a(n+2) - a(n) as the sum of two consecutive alternating terms. At an even index this sum is 1/(2k+2)! - 1/(2k+1)! < 0 (even ratios decrease); at an odd index it is 1/(2k+2)! - 1/(2k+3)! > 0 (odd ratios increase). The strictness comes from Nat.factorial_lt. strictAnti_nat_of_succ_lt / strictMono_nat_of_lt_succ then upgrade the one-step facts to monotonicity of the whole subsequence.",
     "mathContext": "Within an alternating series of strictly decreasing terms, $S_{n+2} - S_n = (-1)^{n+1}c_{n+1} + (-1)^{n+2}c_{n+2}$ has the sign of $(-1)^{n+1}$ because $c_{n+1} > c_{n+2}$.",
     "significance": "key",
-    "relatedConcepts": ["strictAnti_nat_of_succ_lt", "strictMono_nat_of_lt_succ", "Nat.factorial_lt"]
+    "relatedConcepts": ["strictAnti_nat_of_succ_lt", "strictMono_nat_of_lt_succ", "Nat.factorial_lt"],
+    "prerequisites": ["strict monotonicity of the factorial", "reciprocal reverses order on positives (one_div_lt_one_div_of_lt)", "succ-step criteria for StrictAnti/StrictMono on ℕ"]
   },
   {
     "id": "ann-dcoq02-converge",
@@ -41,7 +44,8 @@
     "content": "aSeq_tendsto restates the parent's limit D(n)/n! → e⁻¹ for the partial-sum function. Composing with k ↦ 2k and k ↦ 2k+1 (which tend to infinity) gives that the even- and odd-indexed subsequences both converge to e⁻¹.",
     "mathContext": "Every subsequence of a convergent sequence converges to the same limit; here both $a(2k)$ and $a(2k+1)$ tend to $e^{-1}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Filter.Tendsto.comp", "derangements_tendsto_inv_e"]
+    "relatedConcepts": ["Filter.Tendsto.comp", "derangements_tendsto_inv_e"],
+    "prerequisites": ["filters and Tendsto atTop", "composition of limits with a map tending to infinity", "the parent limit $D(n)/n! \\to e^{-1}$"]
   },
   {
     "id": "ann-dcoq02-onesided",
@@ -52,7 +56,8 @@
     "content": "lt_of_strictAnti_tendsto and gt_of_strictMono_tendsto are the crux: a strictly decreasing sequence converging to L has every term strictly above L (its successor is already ≥ L by le_of_tendsto, and the term is strictly larger than its successor). This yields strictness in the bracket for free, avoiding any tail estimate.",
     "mathContext": "If $x$ is strictly antitone and $x_n \\to L$, then $L \\le x_{n+1} < x_n$, hence $x_n > L$. Symmetrically for strictly monotone sequences.",
     "significance": "key",
-    "relatedConcepts": ["le_of_tendsto", "ge_of_tendsto", "StrictAnti", "StrictMono"]
+    "relatedConcepts": ["le_of_tendsto", "ge_of_tendsto", "StrictAnti", "StrictMono"],
+    "prerequisites": ["order-limit lemmas (le_of_tendsto / ge_of_tendsto)", "monotone sequences are eventually one-sided", "combining a weak limit bound with a strict step inequality"]
   },
   {
     "id": "ann-dcoq02-main",
@@ -63,7 +68,8 @@
     "content": "Combining monotonicity with the shared limit gives e⁻¹ < a(2k) and a(2k+1) < e⁻¹ (ratio_even_gt, ratio_odd_lt), hence the bracket numDerangements_bracket. Casing on the parity of n yields the unified sign law numDerangements_error_sign: (-1)^n·(D(n)/n! - e⁻¹) > 0, and the opposite-sign product consecutive_error_opposite. nested_interval_width pins the bracket width to exactly 1/(2k+1)!.",
     "mathContext": "$D(2k+1)/(2k+1)! < e^{-1} < D(2k)/(2k)!$ with gap $a(2k) - a(2k+1) = 1/(2k+1)!$: a nested-interval construction of $e^{-1}$.",
     "significance": "key",
-    "relatedConcepts": ["numDerangements_bracket", "nested intervals", "alternating series estimation"]
+    "relatedConcepts": ["numDerangements_bracket", "nested intervals", "alternating series estimation"],
+    "prerequisites": ["nested-interval principle", "case analysis on the parity of $n$", "the one-sided bounds ratio_even_gt / ratio_odd_lt"]
   },
   {
     "id": "ann-dcoq02-integer",
@@ -74,6 +80,7 @@
     "content": "Clearing the positive denominator n! from the ratio bounds gives numDerangements_gt_of_even (D(n) > n!·e⁻¹ for even n) and numDerangements_lt_of_odd (D(n) < n!·e⁻¹ for odd n) — the signed refinement of the sibling's |D(n) - n!/e| < 1/2 rounding bound.",
     "mathContext": "Multiplying $D(n)/n! \\gtrless e^{-1}$ by $n! > 0$ locates $D(n)$ above (even $n$) or below (odd $n$) $n!/e$.",
     "significance": "supporting",
-    "relatedConcepts": ["lt_div_iff₀", "div_lt_iff₀", "n!/e rounding"]
+    "relatedConcepts": ["lt_div_iff₀", "div_lt_iff₀", "n!/e rounding"],
+    "prerequisites": ["clearing a positive denominator (lt_div_iff₀ / div_lt_iff₀)", "positivity of $n!$ over ℝ", "the ratio bounds from §5"]
   }
 ]


### PR DESCRIPTION
## Enrichment: Derangements Convergence OQ-02 (sign of the error & two-sided bracketing of 1/e)

This entry already had strong annotations (`significance`, `relatedConcepts`, LaTeX `mathContext`) and a rich `meta.json`. This pass completes the annotation depth schema by adding the one missing field.

### Changes (annotations.json only)
- Added `prerequisites` to all 7 annotations, each targeted to that section's argument (e.g. *strict monotonicity of the factorial*, *order-limit lemmas le_of_tendsto/ge_of_tendsto*, *nested-interval principle*, *clearing a positive denominator via lt_div_iff₀*).
- All existing content, `significance`, `relatedConcepts`, and `mathContext` preserved byte-for-byte; `meta.json` unchanged.

Verified programmatically that the diff is additive (only `prerequisites` inserted, every other field identical to `main`). Single-file diff; 7 KB.
