### PR TITLE
Enrich Schur–Horn Majorization (cauchy-interlacing OQ chain): annotation prerequisites

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -8,7 +8,8 @@
     "content": "`dsWeight` defines `D i j = ‖⟪v j, e i⟫‖²`, the squared moduli of the inner products between the orthonormal eigenbasis `v = hT.eigenvectorBasis hn` of `T` and the chosen orthonormal basis `e`. `dsWeight_nonneg` is `sq_nonneg`. `dsWeight_row_sum` (∑ j, D i j = 1) and `dsWeight_col_sum` (∑ i, D i j = 1) are Parseval's identity: `OrthonormalBasis.sum_sq_norm_inner_right` for the eigenbasis (rows, ‖e i‖² = 1) and `sum_sq_norm_inner_left` for `e` (columns, ‖v j‖² = 1). Thus `D` is doubly stochastic.",
     "mathContext": "The matrix D_ij = |⟨vⱼ, eᵢ⟩|² of overlap probabilities between two orthonormal bases is doubly stochastic — the bridge from the spectral theorem to majorization, requiring no Birkhoff theorem.",
     "significance": "key",
-    "relatedConcepts": ["doubly stochastic matrix", "Parseval identity", "orthonormal basis", "change of basis"]
+    "relatedConcepts": ["doubly stochastic matrix", "Parseval identity", "orthonormal basis", "change of basis"],
+    "prerequisites": ["spectral theorem for Hermitian operators (eigenvectorBasis)", "Parseval's identity for orthonormal bases", "definition of a doubly stochastic matrix"]
   },
   {
     "id": "ann-diag-decomp",
@@ -19,7 +20,8 @@
     "content": "`diag_decomp` proves `re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ · D i j`. The expansion `⟪T(e i), e i⟫ = ∑ⱼ ⟪T(e i), v j⟫ · ⟪v j, e i⟫` comes from `OrthonormalBasis.sum_inner_mul_inner`. Each cross term is collapsed using `eigenvectorBasis_apply_self_apply` (⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫), `inner_conj_symm`, `RCLike.conj_ofReal` (the eigenvalue is real), and `RCLike.conj_mul` (conj z · z = ‖z‖²), giving (λ j)·‖⟪v j, e i⟫‖²; taking real parts term by term (`map_sum`, `RCLike.ofReal_re`) yields the identity.",
     "mathContext": "Each diagonal entry re⟪T eᵢ, eᵢ⟫ of a Hermitian operator is the convex combination ∑ⱼ λⱼ |⟨vⱼ, eᵢ⟩|² of its eigenvalues — the single nontrivial step from which majorization follows by Jensen.",
     "significance": "key",
-    "relatedConcepts": ["spectral theorem", "resolution of identity", "convex combination", "eigenvalues"]
+    "relatedConcepts": ["spectral theorem", "resolution of identity", "convex combination", "eigenvalues"],
+    "prerequisites": ["resolution of identity (OrthonormalBasis.sum_inner_mul_inner)", "eigenvalues of a Hermitian operator are real", "RCLike conjugation identities (conj z · z = ‖z‖²)"]
   },
   {
     "id": "ann-schur-majorization-convexOn",
@@ -30,7 +32,8 @@
     "content": "`schur_majorization_convexOn` is the headline: for every convex `φ` on a set `s` containing the spectrum, `∑ᵢ φ(re ⟪T (e i), e i⟫) ≤ ∑ⱼ φ(λⱼ)` — the forward direction of Schur–Horn, diag(T) ≺ spec(T). Row-by-row, `ConvexOn.map_sum_le` (Jensen) bounds `φ(d i) ≤ ∑ⱼ D i j • φ(λ j)` using the nonnegative weights `D i j` summing to 1 (`dsWeight_row_sum`) at points `λ j ∈ s`; summing over `i` (`Finset.sum_le_sum`), swapping (`Finset.sum_comm`, `Finset.sum_smul`), and collapsing each column with `dsWeight_col_sum` and `one_smul` finishes.",
     "mathContext": "The Hardy–Littlewood–Pólya / Karamata characterization: a tuple is majorized by another iff ∑φ(dᵢ) ≤ ∑φ(λⱼ) for all convex φ. Proved here for the diagonal versus the spectrum of any Hermitian operator.",
     "significance": "key",
-    "relatedConcepts": ["majorization", "Jensen inequality", "Schur–Horn theorem", "convex function", "Karamata inequality"]
+    "relatedConcepts": ["majorization", "Jensen inequality", "Schur–Horn theorem", "convex function", "Karamata inequality"],
+    "prerequisites": ["Jensen's inequality for convex functions (ConvexOn.map_sum_le)", "the majorization order and Schur–Horn / Karamata theorem", "double sums and reindexing (Finset.sum_comm)"]
   },
   {
     "id": "ann-schur-trace-eq",
@@ -41,7 +44,8 @@
     "content": "`schur_trace_eq` is the equality (k=n) case of majorization, needing no convexity: `∑ᵢ re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ`. It follows from `diag_decomp` summed over `i`, a swap (`Finset.sum_comm`, `Finset.mul_sum`), and the column sums `∑ᵢ D i j = 1` (`dsWeight_col_sum`, `mul_one`).",
     "mathContext": "The trace of a Hermitian operator equals the sum of its eigenvalues regardless of the orthonormal basis — the equality constraint that distinguishes majorization from weak majorization.",
     "significance": "key",
-    "relatedConcepts": ["trace", "majorization equality case", "basis independence"]
+    "relatedConcepts": ["trace", "majorization equality case", "basis independence"],
+    "prerequisites": ["trace as the sum of diagonal entries", "column sums of a doubly stochastic matrix", "linearity and reindexing of finite sums"]
   },
   {
     "id": "ann-schur-sum-sq-le",
@@ -52,6 +56,7 @@
     "content": "`schur_sum_sq_le` instantiates the master theorem at `φ = (·)²` (convex on all of ℝ by `Even.convexOn_pow` at n=2): `∑ᵢ (re ⟪T (e i), e i⟫)² ≤ ∑ⱼ λⱼ²`. The diagonal of a Hermitian operator is no larger in Euclidean (Hilbert–Schmidt) norm than its spectrum.",
     "mathContext": "The Schur inequality ∑ dᵢ² ≤ ∑ λⱼ²: the diagonal vector has Euclidean length at most that of the eigenvalue vector — a direct consequence of majorization with the convex function x².",
     "significance": "supporting",
-    "relatedConcepts": ["sum of squares", "convex function", "majorization", "Hilbert–Schmidt norm"]
+    "relatedConcepts": ["sum of squares", "convex function", "majorization", "Hilbert–Schmidt norm"],
+    "prerequisites": ["convexity of x² (Even.convexOn_pow)", "the majorization master theorem schur_majorization_convexOn", "Hilbert–Schmidt / Frobenius norm"]
   }
 ]


### PR DESCRIPTION
## Enrichment: Schur–Horn Majorization (cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01)

Strong existing annotations (`significance`, `relatedConcepts`, detailed LaTeX `mathContext`) — this pass completes the annotation depth schema.

### Changes (annotations.json only)
- Added `prerequisites` to all 5 annotations, each specific to the section (e.g. *spectral theorem / eigenvectorBasis*, *Parseval's identity*, *Jensen's inequality (ConvexOn.map_sum_le)*, *majorization / Schur–Horn / Karamata*, *convexity of x² (Even.convexOn_pow)*).
- All existing content preserved; `meta.json` unchanged.

Verified additive-only (only `prerequisites` inserted, every other field byte-identical to `main`). Single-file diff.
