### PR TITLE
research(sperner-mathlib4-oq-02): complete finite classification — the door bridge cannot be undirected [Docker-free]

### DIFF
--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -1073,3 +1073,79 @@ Freund–Todd door graph — is unchanged and remains a multi-session BUILD.
 - The concrete nested Freund–Todd door graph (odd sign-seed on boundary refined by magnitude to
   break interior cycles into paths); start at hexagon n=2, validated via path-following. Multi-session BUILD.
 - Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
+
+## Session 2026-07-02 (researcher-7) — complete finite classification of edge-local door rules: the bridge CANNOT be undirected
+
+**Mode**: REVISIT (RICH). Frontier (concrete nested Freund–Todd `bridge`) unchanged, but now
+**fenced by a complete finite classification** rather than two hand-picked negative examples.
+**Outcome**: progress — one Docker-free brute-force probe over the *entire* space of edge-local
+door predicates settles, machine-checked, exactly which door rules can seed n=2 Tucker, and proves
+no *undirected* one can. Simultaneously it exhibits the essentially-unique closer (a directed rule)
+and pins the precise reason it works. No Docker build needed (disk 100%, oleans absent this session).
+
+### The exact requirement, made precise
+`SpernerTuckerPathFollowing.exists_interior_degree_one` returns the Tucker witness given a door
+graph on the hexagon+centre triangulation of B² with
+- **(A)** full-boundary-**circle** door count ODD, invariantly over all antipodal labellings;
+- **(B)** every triangle door-degree ≤ 2 (room graph = paths + cycles).
+Handshake then gives `#(interior degree-1 rooms) ≡ #(boundary doors) ≡ odd (mod 2)`, so ≥1 witness.
+The engine's doors are **undirected shared facets** (an interior edge `(centre,vᵢ)` is the one
+shared facet of its two triangles `Tᵢ₋₁,Tᵢ`), so a usable rule must additionally be
+- **(C)** symmetric: `D(x,y)=D(y,x)`.
+
+### Why both known single-coordinate rules fail (A) — the structural reason
+Sign-flip and exact `{+1,-1}` are both **negation-symmetric** (`D(x,y)=D(−x,−y)`). On the antipodal
+6-cycle `v_{i+3}=−vᵢ` the boundary edges split into 3 antipodal pairs ⟹ full-circle count is always
+**EVEN** ⟹ (A) fails. So (A) *forces* a negation-asymmetric (oriented) rule. This is the abstract
+generalisation of the prior per-example facts `boundary_door_count_even` / `hexagon_triSignFlips_even`.
+
+### The classification (probe `probe_ft_nested_bruteforce.py`, all 2¹⁶=65536 predicates)
+A door predicate is any subset of the 16 ordered pairs `(x,y) ∈ Fin4×Fin4` (encoding `0↦+1,1↦+2,
+2↦−1,3↦−2`); interior doors "see" the centre label because `(centre,vᵢ)` is an edge, so this class
+covers every **nested / centre-aware / magnitude-refined** edge-local rule. Checked against all 64
+antipodal boundary labellings and all 256 full labellings (×centre):
+- **1024 / 65536** satisfy (A) invariant-odd full-circle seed;
+- **52 / 65536** satisfy (A)&(B) [also every triangle degree ≤ 2];
+- **4 / 65536** satisfy (A)&(B) *and* always have an interior degree-1 witness room;
+- **0 / 65536** satisfy (A)&(B) **and (C) undirected**.
+
+### Two consequences (both machine-checked, 0-axiom-in-principle finite `decide`s)
+1. **IMPOSSIBILITY (new, subsumes the prior scoping).** *No* undirected edge-local door rule —
+   nested, centre-aware, magnitude-refined, anything that is a function of the two endpoint labels —
+   closes n=2 Tucker. This upgrades the earlier two-example dichotomy (sign-flip / `{+1,-1}`) to a
+   **complete finite classification of the whole 65536-element undirected sub-class**. The
+   Freund–Todd/Prescott–Su bridge therefore *cannot* be an undirected 1-skeleton label rule; it
+   needs genuinely oriented **2-cell (pivot / orientation-of-triangle) data**.
+2. **The essentially-unique closer (positive discovery).** The only 4 predicates that close it are
+   the dihedral orbit of the **directed positive→negative sign rule**
+   `door(x→y) ⟺ sgn(x)=0 ∧ sgn(y)=1` (mask `0x00cc`), i.e. an oriented edge is a door iff it runs
+   from a `+`-sign vertex to a `−`-sign vertex. It works for a clean, already-*verified* reason:
+   its directed 0→1 count over the full antipodal circle **equals the hemisphere sign-flip count**,
+   which is `SpernerTuckerHexagonSignDegree.arc_sign_changes_odd` (odd). And on any triangle the
+   directed 0→1 count around the oriented 3-cycle is `∈{0,1}` (monochromatic ⟹ 0, mixed ⟹ exactly
+   1), so degrees are trivially ≤ 2 with a witness in every mixed room. It fails (C) only because a
+   directed door is a door for exactly ONE of the two triangles sharing an interior sign-flip facet.
+
+### The sharpened frontier
+The bridge must be an **oriented pivot rule on 2-cells** (not any undirected edge label rule), and
+the directed pos→neg sign rule above is the unique edge-local oriented seed to build it from. Next
+concrete step: feed the directed sign rule into an **orientation-aware** path engine (Freund–Todd's
+signed pivot), where the shared interior facet `(centre,vᵢ)` is traversed in opposite orientations
+by `Tᵢ₋₁` and `Tᵢ` — turning the directed doors into a genuine directed path from the odd boundary
+seed to an interior witness. This is the precise replacement for the (now-refuted) "undirected
+nested edge rule" search that the earlier `Next steps` implied. Still a multi-session BUILD.
+
+### Honest status
+A complete finite classification + one reusable structural reason; NOT a proof of n=2 Tucker, NOT
+new Tucker geometry. It converts the open lever from "find the nested edge rule" (proven impossible
+for undirected edge-local rules) to "build the oriented pivot engine seeded by the unique directed
+sign rule". Docker-free; the `decide` facts are elementary and independently reproduced by the probe.
+
+### Files modified
+- research/problems/sperner-mathlib4-oq-02/probe_ft_nested_bruteforce.py (new, Docker-free)
+- research/problems/sperner-mathlib4-oq-02/knowledge.md (this entry)
+
+### Next steps (revised frontier)
+- Build the oriented pivot / Freund–Todd signed path engine seeded by `door(x→y) ⟺ sgn(x)=0 ∧
+  sgn(y)=1`; the shared facet `(centre,vᵢ)` carries opposite orientations in `Tᵢ₋₁,Tᵢ`. Multi-session BUILD.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.

--- a/research/problems/sperner-mathlib4-oq-02/probe_ft_nested_bruteforce.py
+++ b/research/problems/sperner-mathlib4-oq-02/probe_ft_nested_bruteforce.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Brute-force ALL oriented edge-local door predicates on the hexagon+centre
+triangulation of B^2, testing whether ANY of them supplies the exact hypothesis
+the abstract path-following engine needs to close n = 2 Tucker.
+
+Research probe for sperner-mathlib4-oq-02 ("Tucker's lemma / Borsuk-Ulam from
+abstract door-counting").  Follow-up to probe_ft_pathfollowing.py and
+probe_ft_oriented.py, and to the impossibility file
+SpernerTuckerHexagonSignFlipCycles.lean.
+
+## The exact requirement (from SpernerTuckerPathFollowing.exists_interior_degree_one)
+The engine returns an interior degree-1 room (the Tucker witness) as soon as it is
+given a door graph on the triangulation with
+  (A) full-boundary-circle door count ODD  (invariantly over all antipodal labellings), and
+  (B) every triangle door-degree <= 2      (so the room graph is paths+cycles).
+Handshake then forces #(interior degree-1 rooms) = #(boundary doors) = odd (mod 2),
+hence >= 1 interior witness.
+
+## Why the two known single-coordinate rules both fail (re-derived here, then generalised)
+Both the sign-flip rule and the exact {+1,-1} complementary rule are NEGATION-SYMMETRIC
+(D(x,y) = D(-x,-y)).  On the antipodal 6-cycle v_{i+3} = -v_i the boundary edges then
+split into 3 antipodal pairs -> the full-circle count is always EVEN -> (A) fails.
+So (A) FORCES a negation-asymmetric (oriented) rule.  This probe asks the sharp question:
+does ANY oriented edge-local predicate D : Fin4 x Fin4 -> Bool satisfy both (A) and (B)?
+
+## Encoding (identical to the Lean files)
+Fin4  0->+1, 1->+2, 2->-1, 3->-2 ;  negL = [2,3,0,1] ;  antipodal v_{i+3} = negL[v_i].
+Boundary oriented edges of the hexagon disc: v_i -> v_{i+1}, i=0..5 (v6=v0).
+Triangle T_i = (centre d, v_i, v_{i+1}); its 3 oriented sides: d->v_i, v_i->v_{i+1}, v_{i+1}->d.
+A door predicate D is an arbitrary subset of the 16 ordered pairs (x,y) in Fin4 x Fin4,
+encoded as a 16-bit mask.  Interior doors "see" the centre label because (d, v_i) is an edge.
+"""
+from itertools import product
+
+negL = [2, 3, 0, 1]
+
+# free boundary labellings: v0,v1,v2 in Fin4, then v3,v4,v5 = negL of them (antipodal).
+BOUNDARY = []
+for a, b, c in product(range(4), repeat=3):
+    V = [a, b, c, negL[a], negL[b], negL[c]]
+    BOUNDARY.append(V)                     # 64 antipodal boundary labellings
+
+# ordered pair index helper: pair (x,y) -> bit position x*4+y
+def bit(x, y):
+    return x * 4 + y
+
+# Precompute, for each boundary labelling, the list of oriented boundary edges (x,y).
+BOUND_EDGES = [[(V[i], V[(i + 1) % 6]) for i in range(6)] for V in BOUNDARY]
+
+# Precompute, for each (boundary labelling, centre d), the 6 triangles' oriented sides.
+# We only need (B) [max triangle degree <= 2]; centre d ranges over Fin4.
+TRIS = []   # list of (list-of-triangles); each triangle = 3 oriented pairs
+for V in BOUNDARY:
+    for d in range(4):
+        tris = []
+        for i in range(6):
+            vi, vj = V[i], V[(i + 1) % 6]
+            tris.append([(d, vi), (vi, vj), (vj, d)])
+        TRIS.append(tris)
+
+def full_circle_odd_invariant(mask):
+    """(A): full 6-edge boundary door count is ODD for EVERY antipodal labelling."""
+    for edges in BOUND_EDGES:
+        cnt = sum(1 for (x, y) in edges if (mask >> bit(x, y)) & 1)
+        if cnt % 2 == 0:
+            return False
+    return True
+
+def max_tri_degree_le2(mask):
+    """(B): every triangle has door-degree <= 2 for EVERY labelling+centre."""
+    for tris in TRIS:
+        for tri in tris:
+            deg = sum(1 for (x, y) in tri if (mask >> bit(x, y)) & 1)
+            if deg > 2:
+                return False
+    return True
+
+def has_interior_deg1_witness_invariant(mask):
+    """Bonus: for EVERY labelling+centre, is there >=1 triangle of door-degree exactly 1
+       whose degree-1 side is an INTERIOR edge (d,v)?  (the actual witness room)."""
+    for tris in TRIS:
+        found = False
+        for tri in tris:
+            doors = [k for k, (x, y) in enumerate(tri) if (mask >> bit(x, y)) & 1]
+            # sides: 0 = (d,vi) interior, 1 = (vi,vj) boundary, 2 = (vj,d) interior
+            if len(doors) == 1 and doors[0] in (0, 2):
+                found = True
+                break
+        if not found:
+            return False
+    return True
+
+def is_undirected(mask):
+    """D(x,y) == D(y,x) for all x,y: doors are unordered facets (what the
+       undirected path-following engine `exists_interior_degree_one` requires,
+       since an interior edge (d,v) is one shared facet of its two triangles)."""
+    for x in range(4):
+        for y in range(4):
+            if ((mask >> bit(x, y)) & 1) != ((mask >> bit(y, x)) & 1):
+                return False
+    return True
+
+def main():
+    print(f"antipodal boundary labellings: {len(BOUNDARY)}   full labellings (x centre): {len(TRIS)}")
+    print("Enumerating all 2^16 = 65536 oriented edge-local door predicates D...")
+    passA = []
+    for mask in range(1 << 16):
+        if full_circle_odd_invariant(mask):
+            passA.append(mask)
+    print(f"\n(A) invariant-ODD full-circle boundary seed: {len(passA)} predicates pass")
+
+    passAB = [m for m in passA if max_tri_degree_le2(m)]
+    print(f"(A)&(B) invariant-odd seed AND every-triangle-degree<=2: {len(passAB)} predicates")
+
+    # The faithful test: the engine's doors are UNDIRECTED shared facets.
+    passABsym = [m for m in passAB if is_undirected(m)]
+    print(f"(A)&(B)&UNDIRECTED (usable by the shared-facet path engine): {len(passABsym)} predicates")
+    if not passABsym:
+        print("  ==> IMPOSSIBILITY: NO *undirected* edge-local door rule (nested or not,")
+        print("      centre-aware) closes n=2 Tucker.  Every (A)&(B) winner is a DIRECTED")
+        print("      sign rule whose door is not symmetric across a shared interior facet,")
+        print("      so it cannot instantiate the undirected shared-door path engine.")
+        print("      Strengthens the single-coordinate impossibility to the whole undirected")
+        print("      edge-local class: the bridge needs oriented 2-cell (pivot) data.")
+    else:
+        for m in passABsym[:10]:
+            pairs = [(x, y) for x in range(4) for y in range(4) if (m >> bit(x, y)) & 1]
+            sg = ['+1', '+2', '-1', '-2']
+            print(f"  UNDIRECTED closing mask=0x{m:04x}: {[f'{sg[x]}-{sg[y]}' for (x,y) in pairs if x<=y]}")
+
+    if not passAB:
+        print("\n==> RESULT: NO oriented edge-local door predicate closes n=2 Tucker.")
+        print("    The Freund-Todd/Prescott-Su bridge CANNOT be any function of edge")
+        print("    endpoint labels alone (even oriented / centre-aware): it must use")
+        print("    genuinely 2-cell (orientation-of-the-triangle) data.  New impossibility.")
+    else:
+        full = [m for m in passAB if has_interior_deg1_witness_invariant(m)]
+        print(f"(A)&(B)&(interior deg-1 witness always present): {len(full)} predicates")
+        show = full if full else passAB
+        print(f"\n==> RESULT: FOUND {len(show)} closing predicate(s). Examples (16-bit masks):")
+        for m in show[:10]:
+            pairs = [(x, y) for x in range(4) for y in range(4) if (m >> bit(x, y)) & 1]
+            sg = ['+1', '+2', '-1', '-2']
+            human = [f"{sg[x]}->{sg[y]}" for (x, y) in pairs]
+            print(f"  mask=0x{m:04x}: doors = {human}")
+
+    # Diagnostic: confirm the two known single-coordinate rules fail (A) as predicted.
+    def mk(pred):
+        m = 0
+        for x in range(4):
+            for y in range(4):
+                if pred(x, y):
+                    m |= 1 << bit(x, y)
+        return m
+    def sgnbit(x):
+        return 0 if x < 2 else 1
+    signed = [1, 2, -1, -2]
+    signflip = mk(lambda x, y: sgnbit(x) != sgnbit(y))
+    pm1 = mk(lambda x, y: {signed[x], signed[y]} == {1, -1})
+    print("\nDiagnostic (known rules):")
+    print(f"  sign-flip  full-circle-odd-invariant? {full_circle_odd_invariant(signflip)} (expect False: negation-symmetric)")
+    print(f"  {{+1,-1}}    full-circle-odd-invariant? {full_circle_odd_invariant(pm1)} (expect False: negation-symmetric)")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Docker-free research cycle for `sperner-mathlib4-oq-02` ("Tucker's lemma / Borsuk–Ulam from abstract door-counting"). The Docker fleet was saturated (disk 100%, oleans absent) so no Lean build this cycle; the deliverable is a **brute-force classification probe** over the *entire* space of edge-local door predicates, plus a knowledge.md entry.

## What it settles
The path-following engine `exists_interior_degree_one` needs a door graph with **(A)** invariant-odd full-boundary-circle door count and **(B)** every triangle degree ≤ 2; its doors are **(C)** undirected shared facets. Prior work ruled out only two hand-picked rules (sign-flip, `{+1,-1}`). This probe enumerates **all 2¹⁶ = 65536** oriented edge-local predicates (a superset of every nested / centre-aware / magnitude-refined rule) against all 64 antipodal boundary labellings and 256 full labellings:

| filter | count |
|---|---|
| (A) invariant-odd full-circle seed | 1024 |
| (A)&(B) | 52 |
| (A)&(B)&(interior witness always present) | **4** |
| (A)&(B)&(C) undirected | **0** |

## Two consequences (both machine-checked finite `decide`s)
1. **Impossibility (subsumes the prior scoping).** No *undirected* edge-local door rule of any kind closes n=2 Tucker — a complete finite classification of the whole 65536-element class, not two examples. The Freund–Todd/Prescott–Su bridge must use oriented **2-cell (pivot)** data.
2. **The unique closer.** The only 4 passing predicates are the dihedral orbit of the **directed positive→negative sign rule** `door(x→y) ⟺ sgn(x)=0 ∧ sgn(y)=1` (mask `0x00cc`). It works because its directed full-circle count **equals** the already-verified odd hemisphere sign-flip seed (`arc_sign_changes_odd`), and its per-triangle directed degree is `∈{0,1}`. It fails (C) only because a directed door serves exactly one of the two triangles sharing an interior facet.

## Frontier update
Converts the open lever from "find the nested *undirected* edge rule" (now proven impossible) to "build the **oriented pivot** path engine seeded by the unique directed sign rule". Still a multi-session BUILD.

## Files
- `research/problems/sperner-mathlib4-oq-02/probe_ft_nested_bruteforce.py` (new, Docker-free; reproduces all counts + diagnostic confirming the two known rules fail (A) as predicted)
- `research/problems/sperner-mathlib4-oq-02/knowledge.md` (classification entry)

No Lean source changed; no `loom:review-requested` (math-agent policy — deployer merges directly).