### PR TITLE
research(erdos-105-oq-01): line-through-two-points reduction — collapse ∀-lines to C(|A|,2) connecting lines [VERIFIED, axiom-free §V]

### DIFF
--- a/proofs/Proofs/Erdos105OQ01.lean
+++ b/proofs/Proofs/Erdos105OQ01.lean
@@ -200,7 +200,117 @@ theorem n_minus_4_threshold_lower (h : openProblem_n_minus_4) (n : ℕ) (hn : n 
   exact le_csSup hbdd (n_minus_4_avoidable_set h n hn)
 
 -- ════════════════════════════════════════════════════════════════
--- SECTION V: Summary
+-- SECTION V: Line-through-two-points reduction (axiom-free)
+--   The first concrete step toward *discharging* the parent's
+--   `xichuan_counterexample` axiom: the blocking clause quantifies over
+--   ALL lines `L`, but a rich line is determined (as a point set) by any
+--   two distinct `A`-points it passes through. This reduces "∀ rich lines"
+--   to the finite family of C(|A|,2) connecting lines — the reduction the
+--   parent currently lacks. All of Section V is axiom-free.
+-- ════════════════════════════════════════════════════════════════
+
+/-- **A line is determined, as a point set, by any two distinct points on it.**
+    If a line `L` passes through distinct points `p ≠ q`, then a third point `r`
+    lies on `L` iff it lies on the affine line through `p` and `q`, i.e.
+    `r = p + μ·(q - p)` for some scalar `μ`. This is the key uniqueness fact for
+    lines over `ℝ²` (the `Line` structure is redundant — base point and a nonzero
+    direction up to scaling — but its *containment relation* is rigid). -/
+theorem contains_iff_of_contains_two {L : Line} {p q : Point}
+    (hp : L.contains p) (hq : L.contains q) (hpq : p ≠ q) :
+    ∀ r : Point, L.contains r ↔ ∃ μ : ℝ, r = p + μ • (q - p) := by
+  obtain ⟨s, hs⟩ := hp
+  obtain ⟨u, hu⟩ := hq
+  -- The two parameters differ, else `p = q`.
+  have hus : u ≠ s := by
+    intro h; apply hpq; rw [hs, hu, h]
+  have hc : u - s ≠ 0 := sub_ne_zero.mpr hus
+  -- The chord `q - p` is a nonzero multiple of the direction.
+  have hqp : q - p = (u - s) • L.direction := by
+    rw [hs, hu, sub_smul]; abel
+  intro r
+  constructor
+  · rintro ⟨t, ht⟩
+    refine ⟨(t - s) * (u - s)⁻¹, ?_⟩
+    rw [hqp, ht, hs, smul_smul, mul_assoc, inv_mul_cancel₀ hc, mul_one]
+    module
+  · rintro ⟨μ, hμ⟩
+    refine ⟨s + μ * (u - s), ?_⟩
+    rw [hμ, hqp, hs, smul_smul]
+    module
+
+/-- **Two lines through the same pair of distinct points agree everywhere.**
+    Immediate from `contains_iff_of_contains_two`: both containment relations
+    reduce to the same affine parametrization by `p` and `q`. -/
+theorem contains_congr_of_two {L₁ L₂ : Line} {p q : Point} (hpq : p ≠ q)
+    (h1p : L₁.contains p) (h1q : L₁.contains q)
+    (h2p : L₂.contains p) (h2q : L₂.contains q) :
+    ∀ r : Point, L₁.contains r ↔ L₂.contains r := by
+  intro r
+  rw [contains_iff_of_contains_two h1p h1q hpq r,
+      contains_iff_of_contains_two h2p h2q hpq r]
+
+/-- The canonical `Line` through two distinct points `p ≠ q`, with base point `p`
+    and direction `q - p` (nonzero because `p ≠ q`). -/
+noncomputable def lineThrough (p q : Point) (h : p ≠ q) : Line where
+  basePoint := p
+  direction := q - p
+  direction_nonzero := sub_ne_zero.mpr (Ne.symm h)
+
+theorem lineThrough_contains_left (p q : Point) (h : p ≠ q) :
+    (lineThrough p q h).contains p := by
+  refine ⟨0, ?_⟩
+  show p = p + (0 : ℝ) • (q - p)
+  module
+
+theorem lineThrough_contains_right (p q : Point) (h : p ≠ q) :
+    (lineThrough p q h).contains q := by
+  refine ⟨1, ?_⟩
+  show q = p + (1 : ℝ) • (q - p)
+  module
+
+/-- Any line through distinct `p ≠ q` has exactly the same points as the canonical
+    `lineThrough p q`. So the whole redundant `Line`-structure quotient collapses to
+    one representative per pair of points. -/
+theorem contains_eq_lineThrough {L : Line} {p q : Point} (hpq : p ≠ q)
+    (hp : L.contains p) (hq : L.contains q) :
+    ∀ r : Point, L.contains r ↔ (lineThrough p q hpq).contains r :=
+  contains_congr_of_two hpq hp hq (lineThrough_contains_left p q hpq)
+    (lineThrough_contains_right p q hpq)
+
+/-- Being unblocked by `B` depends only on a line's point set: two lines through the
+    same distinct pair `p ≠ q` are unblocked by exactly the same obstacle sets. -/
+theorem unblocked_congr_of_two {L₁ L₂ : Line} {p q : Point} (hpq : p ≠ q)
+    (h1p : L₁.contains p) (h1q : L₁.contains q)
+    (h2p : L₂.contains p) (h2q : L₂.contains q) (B : Set Point) :
+    L₁.unblocked B ↔ L₂.unblocked B := by
+  constructor
+  · intro h b hb hc
+    exact h b hb ((contains_congr_of_two hpq h1p h1q h2p h2q b).mpr hc)
+  · intro h b hb hc
+    exact h b hb ((contains_congr_of_two hpq h1p h1q h2p h2q b).mp hc)
+
+/-- **Blocking reduces to the connecting lines.**
+    Every rich line of `A` meets `B` *iff* every line through two distinct points of
+    `A` meets `B`. This replaces the quantifier over ALL lines (as in the parent's
+    `xichuan_counterexample`) by a quantifier over the C(|A|,2) connecting lines —
+    the concrete reduction a future discharge of the axiom needs. Axiom-free. -/
+theorem blocksAll_iff_connecting (A B : Set Point) :
+    (∀ L : Line, L.isRich A → ¬ L.unblocked B) ↔
+      (∀ (p q : Point) (hpq : p ≠ q), p ∈ A → q ∈ A →
+        ¬ (lineThrough p q hpq).unblocked B) := by
+  constructor
+  · intro h p q hpq hp hq
+    exact h (lineThrough p q hpq)
+      ⟨p, q, hp, hq, hpq, lineThrough_contains_left p q hpq,
+        lineThrough_contains_right p q hpq⟩
+  · intro h L hrich hub
+    obtain ⟨p, q, hp, hq, hpq, hLp, hLq⟩ := hrich
+    exact h p q hpq hp hq
+      ((unblocked_congr_of_two hpq hLp hLq (lineThrough_contains_left p q hpq)
+        (lineThrough_contains_right p q hpq) B).mp hub)
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION VI: Summary
 -- ════════════════════════════════════════════════════════════════
 
 /--

--- a/src/data/proofs/erdos-105-oq-01/annotations.json
+++ b/src/data/proofs/erdos-105-oq-01/annotations.json
@@ -95,11 +95,30 @@
     ]
   },
   {
+    "id": "ann-erdos105oq01-reduction",
+    "proofId": "erdos-105-oq-01",
+    "range": {
+      "startLine": 203,
+      "endLine": 311
+    },
+    "type": "concept",
+    "title": "Line-Through-Two-Points Reduction: Toward Discharging the Axiom",
+    "content": "The parent's xichuan_counterexample axiom quantifies over ALL lines L. But a line's containment relation is rigid: contains_iff_of_contains_two shows that if L passes through distinct p ≠ q, then r ∈ L iff r = p + μ·(q − p) — exactly the affine line through p and q. So two lines through the same pair coincide as point sets (contains_congr_of_two), and one canonical representative lineThrough p q suffices. blocksAll_iff_connecting then replaces 'every rich line of A meets B' by 'every one of the C(|A|,2) connecting lines meets B'. This finite reformulation is the first concrete step a future axiom discharge needs, and it is entirely axiom-free.",
+    "mathContext": "$r \\in L \\iff \\exists \\mu,\\ r = p + \\mu(q-p)$ for any distinct $p,q \\in L$; hence blocking all rich lines $\\iff$ blocking the $\\binom{|A|}{2}$ chords $\\overline{pq}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "incidence geometry",
+      "affine lines",
+      "quantifier reduction",
+      "axiom elimination"
+    ]
+  },
+  {
     "id": "ann-erdos105oq01-summary",
     "proofId": "erdos-105-oq-01",
     "range": {
-      "startLine": 213,
-      "endLine": 228
+      "startLine": 313,
+      "endLine": 338
     },
     "type": "concept",
     "title": "Monotonicity Localizes All Remaining Uncertainty to m = n-4",

--- a/src/data/proofs/erdos-105-oq-01/meta.json
+++ b/src/data/proofs/erdos-105-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-105-oq-01",
   "title": "Monotonicity Localizes the Open n-4 Boundary for Lines Avoiding Obstacles",
   "slug": "erdos-105-oq-01",
-  "description": "Studies the remaining open boundary of Erdős Problem #105: is every obstacle set of size n-4 avoidable by some rich line? Proves the monotone structure of the problem in the obstacle count: avoidability is antitone and blocking is monotone (axiom-free). Consequently Xichuan's n-3 disproof propagates upward to every count m ≥ n-3 — re-deriving Hickerson's n-2 failure as a corollary — while saying nothing about n-4. Conversely a positive answer at n-4 would, by antitonicity, give avoidability at every count ≤ n-4, pinning the threshold at f(n) = n-4. The structural results are axiom-free; the upward-propagation corollaries use the parent's xichuan_counterexample axiom. 0 sorries.",
+  "description": "Studies the remaining open boundary of Erdős Problem #105: is every obstacle set of size n-4 avoidable by some rich line? Proves the monotone structure of the problem in the obstacle count: avoidability is antitone and blocking is monotone (axiom-free). Consequently Xichuan's n-3 disproof propagates upward to every count m ≥ n-3 — re-deriving Hickerson's n-2 failure as a corollary — while saying nothing about n-4. Conversely a positive answer at n-4 would, by antitonicity, give avoidability at every count ≤ n-4, pinning the threshold at f(n) = n-4. A final axiom-free section proves the line-through-two-points reduction: a line's containment relation is rigid (determined by any two distinct points on it), so blocking every rich line is equivalent to blocking the finite family of C(|A|,2) connecting lines — the first concrete step toward discharging the inherited xichuan_counterexample axiom by replacing its quantifier over ALL lines. The structural results are axiom-free; the upward-propagation corollaries use the parent's xichuan_counterexample axiom. 0 sorries.",
   "meta": {
     "author": "Lean Genius Researcher",
     "date": "2026",
@@ -19,8 +19,8 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 228,
-    "assumptions": "1 inherited axiom: xichuan_counterexample (Xichuan 2024, the established n-3 disproof), imported from Erdos105Problem.lean and used only in §III (xichuan_blocks_at_all_counts, hickerson_n_minus_2) and the summary. The Section I monotonicity lemmas, the Section II fresh-point padding lemma, and the conditional Section IV n-4 results are all axiom-free.",
+    "lineCount": 338,
+    "assumptions": "1 inherited axiom: xichuan_counterexample (Xichuan 2024, the established n-3 disproof), imported from Erdos105Problem.lean and used only in §III (xichuan_blocks_at_all_counts, hickerson_n_minus_2) and the summary. The Section I monotonicity lemmas, the Section II fresh-point padding lemma, the conditional Section IV n-4 results, and the Section V line-through-two-points reduction are all axiom-free.",
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -33,10 +33,14 @@
       "xichuan_blocks_at_all_counts: the n-3 disproof forces a blocking configuration at every count m ≥ n-3",
       "hickerson_n_minus_2: re-derives Hickerson's n-2 failure as a corollary of the n-3 disproof plus monotonicity",
       "openProblem_n_minus_4_strong: a positive answer at exactly n-4 strengthens to avoidability at every count ≤ n-4 (axiom-free, conditional)",
-      "n_minus_4_avoidable_set / n_minus_4_threshold_lower: under the open hypothesis, n-4 lies in the threshold set, giving the conditional sharp bound f(n) ≥ n-4 — which with the known upper bound f(n) ≤ n-4 pins f(n) = n-4"
+      "n_minus_4_avoidable_set / n_minus_4_threshold_lower: under the open hypothesis, n-4 lies in the threshold set, giving the conditional sharp bound f(n) ≥ n-4 — which with the known upper bound f(n) ≤ n-4 pins f(n) = n-4",
+      "contains_iff_of_contains_two: a line's containment relation is rigid — if L passes through distinct p ≠ q then r lies on L iff r = p + μ·(q - p), i.e. iff r lies on the affine line through p and q (axiom-free)",
+      "contains_congr_of_two / unblocked_congr_of_two: two lines through the same distinct pair agree everywhere, so unblockedness by B depends only on the pair, not the redundant Line representative (axiom-free)",
+      "lineThrough (+ lineThrough_contains_left/right, contains_eq_lineThrough): the canonical Line through p ≠ q, giving one representative per pair; every line through p, q has exactly its point set (axiom-free)",
+      "blocksAll_iff_connecting: every rich line of A meets B iff every one of the C(|A|,2) connecting lines meets B — replaces the quantifier over ALL lines in xichuan_counterexample by a finite family, the concrete reduction a future discharge of the axiom needs (axiom-free)"
     ],
-    "theoremCount": 12,
-    "definitionCount": 2
+    "theoremCount": 19,
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Erdős Problem #105 asks: given n non-collinear points A and an obstacle set B, must some line through ≥2 points of A avoid all of B? Erdős & Purdy conjectured YES for |B| = n-3; Xichuan (2024) disproved this. Hickerson had earlier shown failure already at n-2 obstacles, and Beck / Szemerédi-Trotter (1983) proved avoidability for |B| ≤ cn. The threshold function f(n) = largest avoidable obstacle count thus satisfies cn ≤ f(n) ≤ n-4. The single boundary case |B| = n-4 is the open question this entry studies.",
@@ -47,7 +51,8 @@
       "Xichuan's disproof is a single counterexample at one cardinality, but monotonicity automatically upgrades it to failure at EVERY count m ≥ n-3. Hickerson's separately-discovered n-2 failure is therefore a free corollary.",
       "Crucially, monotonicity propagates the disproof only UPWARD (m ≥ n-3); it gives no information about n-4 < n-3, which is exactly why the n-4 question remains genuinely open.",
       "The downward direction is equally sharp: IF n-4 obstacles are always avoidable, antitonicity forces avoidability at every count ≤ n-4, so f(n) ≥ n-4. With the known upper bound f(n) ≤ n-4 this pins f(n) = n-4 — so oq-01 is precisely the question 'is f(n) = n-4?'.",
-      "Padding obstacle sets to a target cardinality only needs the plane to be infinite, supplied by an explicit injection ℝ → ℝ² via EuclideanSpace.single; no incidence geometry is required for the monotone skeleton."
+      "Padding obstacle sets to a target cardinality only needs the plane to be infinite, supplied by an explicit injection ℝ → ℝ² via EuclideanSpace.single; no incidence geometry is required for the monotone skeleton.",
+      "A line over ℝ² is redundantly encoded (base point + direction up to scaling), but its CONTAINMENT relation is rigid: any two distinct points on it pin down the whole point set. This collapses the quantifier over all lines to the finite family of C(|A|,2) connecting lines — a genuine reduction of the blocking condition that the parent's axiom statement lacks."
     ],
     "prerequisites": [
       "Erdős Problem #105 formalization (Erdos105Problem.lean): Line, isRich, unblocked, richAndUnblocked, NonCollinear, thresholdFunction, openProblem_n_minus_4, xichuan_counterexample",
@@ -90,10 +95,18 @@
       "mathContext": "$\\textsf{openProblem\\_n\\_minus\\_4} \\Rightarrow (n-4) \\in$ threshold set $\\Rightarrow f(n) \\geq n-4$, and with $f(n) \\leq n-4$ this gives $f(n) = n-4$."
     },
     {
+      "id": "reduction",
+      "title": "§V: Line-Through-Two-Points Reduction",
+      "startLine": 203,
+      "endLine": 311,
+      "summary": "A line's containment relation is rigid — determined by any two distinct points on it — so blocking every rich line of A is equivalent to blocking the finite family of C(|A|,2) connecting lines. Axiom-free; the first concrete step toward discharging the inherited xichuan_counterexample axiom.",
+      "mathContext": "If $L$ passes through distinct $p \\neq q$ then $r \\in L \\iff r = p + \\mu(q-p)$, so lines through the same pair coincide as point sets. Hence $(\\forall\\,\\text{rich } L,\\ L \\cap B \\neq \\emptyset) \\iff (\\forall\\,p \\neq q \\in A,\\ \\overline{pq} \\cap B \\neq \\emptyset)$, replacing the quantifier over all lines by the $\\binom{|A|}{2}$ connecting lines."
+    },
+    {
       "id": "summary",
-      "title": "§V: Summary",
-      "startLine": 213,
-      "endLine": 228,
+      "title": "§VI: Summary",
+      "startLine": 313,
+      "endLine": 338,
       "summary": "Packages the upward (Hickerson) and downward (conditional n-4 sharpening) directions, showing monotonicity localizes all remaining uncertainty to m = n-4.",
       "mathContext": "The open boundary is sandwiched: failure for all $m \\geq n-3$ and conditional avoidability for all $m \\leq n-4$."
     }
@@ -102,8 +115,8 @@
     "summary": "The single open boundary of Erdős #105 — is every n-4 obstacle set avoidable? — is sandwiched by monotonicity. Upward, Xichuan's n-3 disproof forces failure at every count m ≥ n-3 (re-deriving Hickerson's n-2 case for free). Downward, a positive answer at n-4 would give avoidability at every count ≤ n-4, pinning the threshold at f(n) = n-4. Monotonicity therefore localizes the entire remaining uncertainty to the single value m = n-4. The monotone skeleton and the conditional n-4 results are axiom-free; the upward corollaries depend on the parent's xichuan_counterexample (Xichuan 2024). 0 sorries.",
     "openQuestions": [
       "Is every obstacle set of size n-4 avoidable (the core open question, equivalently f(n) = n-4)?",
-      "Can the avoidability set be shown bounded above for every n (not just the specific n in Xichuan's counterexample), making the conditional bound f(n) ≥ n-4 unconditional in its boundedness hypothesis?",
-      "Does an analogous monotone localization hold for the higher-dimensional k-flat generalization (oq-05)?"
+      "Building on the §V connecting-line reduction: can the finiteness of the C(|A|,2) connecting lines be combined with a fresh-point construction to prove the avoidability set is bounded above for every n (not just Xichuan's specific n), making the conditional bound f(n) ≥ n-4 unconditional in its boundedness hypothesis?",
+      "Does an analogous monotone localization and connecting-line reduction hold for the higher-dimensional k-flat generalization (oq-05)?"
     ],
     "implications": "Monotonicity reduces the entire open region of Erdős #105 to a single cardinality and shows that resolving oq-01 either way determines the threshold f(n) exactly. It also demonstrates that the historically separate Hickerson (n-2) and Xichuan (n-3) results are not independent: the stronger n-3 disproof subsumes the n-2 failure via a one-line monotonicity argument."
   },
@@ -156,10 +169,10 @@
       "Mathlib"
     ],
     "namespace": "Erdos105OQ01",
-    "lineCount": 228,
+    "lineCount": 338,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 2,
+    "theoremCount": 19,
+    "definitionCount": 3,
     "path": "Proofs/Erdos105OQ01.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Erdős #105, OQ-01 — Line-Through-Two-Points Reduction

Extends the existing (axiom-free monotonicity + conditional-threshold) entry with a new **axiom-free Section V** that takes the first concrete step toward *discharging* the inherited `xichuan_counterexample` axiom.

### The problem with the axiom
`xichuan_counterexample` (and the whole blocking predicate) quantifies over **all** lines `L`. That universal quantifier is what a future axiom-free discharge must tame.

### What this section proves (all axiom-free, Docker-verified on Mathlib 4.26.0)
- **`contains_iff_of_contains_two`** — a line's containment relation is *rigid*: if `L` passes through distinct `p ≠ q`, then `r ∈ L ↔ r = p + μ·(q − p)`, i.e. `r` lies on the affine line through `p` and `q`. The `Line` structure (base point + direction up to scaling) is redundant, but its point set is pinned by any two of its points.
- **`contains_congr_of_two` / `unblocked_congr_of_two`** — two lines through the same distinct pair agree everywhere, so (un)blockedness by `B` depends only on the pair, not the representative.
- **`lineThrough`** (+ `lineThrough_contains_left/right`, `contains_eq_lineThrough`) — the canonical `Line` per pair; every line through `p, q` has exactly its point set. Marked `noncomputable` (`EuclideanSpace`).
- **`blocksAll_iff_connecting`** — *every rich line of `A` meets `B` iff every one of the `C(|A|,2)` connecting lines meets `B`*. This replaces the quantifier over ALL lines by the finite family of connecting lines — the reduction a future discharge of the axiom needs.

### Status
- **Axiom footprint unchanged**: still exactly 1 inherited axiom (`xichuan_counterexample`), used only in §III. The entire new Section V is axiom-free.
- 0 sorries. Build: `./proofs/scripts/docker-build.sh Proofs.Erdos105OQ01` → `Build completed successfully`.
- Counts: 19 theorems / 3 definitions / 338 lines (was 12 / 2 / 228).
- Gallery `meta.json` + `annotations.json` updated (new §V section/annotation; §VI summary renumbered and line ranges corrected).

The core n-4 question itself remains **open** — this is honest structural groundwork, not a resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)