### PR TITLE
research(happy-number-oq-01): fix descent proof — now compiles [VERIFIED build, axiomatized]

### DIFF
--- a/proofs/Proofs/HappyNumberOQ01.lean
+++ b/proofs/Proofs/HappyNumberOQ01.lean
@@ -26,11 +26,11 @@
   All numeric claims were cross-checked independently in Python
   (`research/problems/happy-number-oq-01/verify_happy.py`).
 
-  STATUS: build-pending.  This file is NOT registered in `Proofs.lean` and has
-  not been compiled this session (Docker build pool saturated / daemon
-  unresponsive).  The finite checks use `native_decide`, which introduces the
-  `Lean.ofReduceBool` axiom; the gallery status for this entry is therefore
-  `axiomatized`, NOT `verified`.
+  STATUS: compiles cleanly against Mathlib (Lean v4.26.0).  The finite checks use
+  `native_decide`, which introduces the `Lean.ofReduceBool` axiom; the gallery
+  status for this entry is therefore `axiomatized`, NOT `verified`.  There are no
+  `sorry`s and no hand-asserted mathematical axioms — the only assumption is trust
+  in the Lean compiler's kernel reduction via `native_decide`.
 -/
 import Mathlib
 
@@ -80,7 +80,14 @@ theorem descent (n : ℕ) (hn : 1000 ≤ n) : S n < n := by
       have h1000 : (10 : ℕ) ^ 3 = 1000 := by norm_num
       omega
     have hlt : (10 : ℕ) ^ 3 < 10 ^ (Nat.digits 10 n).length := lt_of_le_of_lt h3 hupper
-    have h3L : 3 < (Nat.digits 10 n).length := (pow_lt_pow_iff_right' (by norm_num)).mp hlt
+    -- From `10^3 < 10^L` conclude `3 < L` by contradiction (base-10 monotonicity),
+    -- avoiding the ordered-monoid `pow_lt_pow_iff_right'` (needs `MulLeftStrictMono ℕ`).
+    have h3L : 3 < (Nat.digits 10 n).length := by
+      by_contra h
+      push_neg at h
+      have hle : (10 : ℕ) ^ (Nat.digits 10 n).length ≤ 10 ^ 3 :=
+        Nat.pow_le_pow_right (by norm_num) h
+      omega
     omega
   -- Lower bound on `n` from its digit count.
   have hlow : 10 ^ ((Nat.digits 10 n).length - 1) ≤ n := by

--- a/src/data/proofs/happy-number-oq-01/annotations.json
+++ b/src/data/proofs/happy-number-oq-01/annotations.json
@@ -2,85 +2,161 @@
   {
     "id": "ann-definitions",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 39, "endLine": 44 },
+    "range": {
+      "startLine": 39,
+      "endLine": 44
+    },
     "type": "definition",
     "title": "The Digit-Square Map and the Absorbing Set",
     "content": "S n is defined directly from Mathlib's Nat.digits 10 n: take the decimal digits, square each, and sum. T is the finite absorbing set — the happy fixed point 1 together with the eight values of the unhappy cycle. Building S on Nat.digits (rather than a hand-rolled recursion) keeps the definition short but means the finite checks downstream are discharged by native_decide rather than kernel decide.",
     "mathContext": "$S(n) = \\sum_{d \\in \\mathrm{digits}_{10}(n)} d^2$, and $T = \\{1, 4, 16, 37, 58, 89, 145, 42, 20\\}$.",
     "significance": "key",
-    "relatedConcepts": ["digit maps", "Nat.digits", "iterated functions", "absorbing set"],
-    "prerequisites": ["decimal representation", "lists in Lean"]
+    "relatedConcepts": [
+      "digit maps",
+      "Nat.digits",
+      "iterated functions",
+      "absorbing set"
+    ],
+    "prerequisites": [
+      "decimal representation",
+      "lists in Lean"
+    ]
   },
   {
     "id": "ann-terminal-structure",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 46, "endLine": 55 },
+    "range": {
+      "startLine": 46,
+      "endLine": 55
+    },
     "type": "theorem",
     "title": "Fixed Point, the 8-Cycle, and Absorption",
     "content": "Three finite facts pin down the terminal behaviour: S_one (1 is a fixed point), unhappy_cycle (the explicit eight transitions 4 → 16 → ... → 20 → 4), and T_absorbing (T is closed under S, so once an orbit enters T it never leaves). All three are pure numeric verifications closed by native_decide. T_absorbing is what makes T a genuine trap rather than a way-station.",
     "mathContext": "$S(1) = 1$; \\; $4 \\to 16 \\to 37 \\to 58 \\to 89 \\to 145 \\to 42 \\to 20 \\to 4$; \\; $m \\in T \\Rightarrow S(m) \\in T$.",
     "significance": "supporting",
-    "relatedConcepts": ["fixed points", "periodic orbits", "invariant sets", "native_decide"],
-    "prerequisites": ["dynamical systems vocabulary", "decidable equality"]
+    "relatedConcepts": [
+      "fixed points",
+      "periodic orbits",
+      "invariant sets",
+      "native_decide"
+    ],
+    "prerequisites": [
+      "dynamical systems vocabulary",
+      "decidable equality"
+    ]
   },
   {
     "id": "ann-aux-exp",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 57, "endLine": 70 },
+    "range": {
+      "startLine": 57,
+      "endLine": 70
+    },
     "type": "insight",
     "title": "Exponential Beats Linear",
     "content": "aux_exp is the quantitative engine: 81·L < 10^(L-1) for every L ≥ 4. It is proved by Nat.le_induction starting at L = 4 (a norm_num base case), with the successor step rewriting 10^L = 10^(L-1)·10 and feeding nlinarith the inductive hypothesis together with 1000 ≤ 10^(L-1). This is the only place exponential growth is exploited, and it is what guarantees the digit-square map shrinks large inputs.",
     "mathContext": "$81L < 10^{L-1}$ for all $L \\ge 4$; equivalently the per-digit budget $81$ times the digit count is dwarfed by the smallest $L$-digit number.",
     "significance": "key",
-    "relatedConcepts": ["induction", "exponential vs polynomial growth", "nlinarith", "Nat.le_induction"],
-    "prerequisites": ["mathematical induction", "inequalities over ℕ"]
+    "relatedConcepts": [
+      "induction",
+      "exponential vs polynomial growth",
+      "nlinarith",
+      "Nat.le_induction"
+    ],
+    "prerequisites": [
+      "mathematical induction",
+      "inequalities over ℕ"
+    ]
   },
   {
     "id": "ann-descent",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 72, "endLine": 114 },
+    "range": {
+      "startLine": 72,
+      "endLine": 121
+    },
     "type": "insight",
     "title": "The Descent Lemma — Infinity Becomes Finite",
     "content": "descent proves S n < n for every n ≥ 1000, and this single bound carries the entire infinite content of the theorem. The proof threads three estimates: n ≥ 1000 forces at least 4 digits (Nat.lt_base_pow_length_digits), the digit count gives the lower bound 10^(L-1) ≤ n (Nat.base_pow_length_digits_le), and each squared digit ≤ 81 gives the upper bound S n ≤ 81·L (List.sum_le_card_nsmul). Chaining S n ≤ 81·L < 10^(L-1) ≤ n via aux_exp closes it. Strict decrease above 1000 is exactly what lets strong induction reduce every orbit to the finite window [1, 999].",
     "mathContext": "For $n \\ge 1000$ with $L = |\\mathrm{digits}_{10}(n)| \\ge 4$: \\; $S(n) \\le 81L < 10^{L-1} \\le n$.",
     "significance": "critical",
-    "relatedConcepts": ["descent argument", "eventual confinement", "digit-count bounds", "well-founded recursion"],
-    "prerequisites": ["real analysis intuition for growth rates", "Nat.digits API"]
+    "relatedConcepts": [
+      "descent argument",
+      "eventual confinement",
+      "digit-count bounds",
+      "well-founded recursion"
+    ],
+    "prerequisites": [
+      "real analysis intuition for growth rates",
+      "Nat.digits API"
+    ]
   },
   {
     "id": "ann-positivity",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 116, "endLine": 127 },
+    "range": {
+      "startLine": 123,
+      "endLine": 134
+    },
     "type": "theorem",
     "title": "Positivity Keeps Orbits Away from Zero",
     "content": "S_pos shows S n > 0 whenever n ≠ 0. The leading decimal digit is nonzero (Nat.getLast_digit_ne_zero), it is a member of the digit list, so its square is a positive summand and bounds the whole sum below. Without positivity the strong-induction step could in principle land on 0, where the descent machinery and the base-case enumeration (which starts at 1) say nothing.",
     "mathContext": "$n \\ne 0 \\Rightarrow S(n) \\ge (\\text{leading digit})^2 > 0$.",
     "significance": "supporting",
-    "relatedConcepts": ["leading digit", "list membership", "lower bounds"],
-    "prerequisites": ["Nat.digits API", "ordering on ℕ"]
+    "relatedConcepts": [
+      "leading digit",
+      "list membership",
+      "lower bounds"
+    ],
+    "prerequisites": [
+      "Nat.digits API",
+      "ordering on ℕ"
+    ]
   },
   {
     "id": "ann-confinement",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 129, "endLine": 155 },
+    "range": {
+      "startLine": 136,
+      "endLine": 162
+    },
     "type": "insight",
     "title": "Bounded Reachability and the Strong-Induction Confinement",
     "content": "reachesT n is a Boolean checker: does the orbit of n hit T within 15 iterations? reachesT_below verifies (by native_decide) that this holds for every 1 ≤ n < 1000, and base_reaches unpacks the Boolean into an existential. reaches_T then closes the loop with strong induction (Nat.strongRecOn): for n ≥ 1000 the descent lemma yields a strictly smaller S n, the induction hypothesis supplies a witness for it, and Function.iterate_succ_apply prepends one step; for n < 1000 the base case applies directly. The 15-step bound comfortably covers the empirical worst case of 11 iterations.",
     "mathContext": "Confinement: $\\forall n \\ge 1,\\ \\exists k,\\ S^{[k]}(n) \\in T$, obtained from descent + a $15$-step check on $[1, 999]$.",
     "significance": "key",
-    "relatedConcepts": ["strong induction", "bounded model checking", "decidable predicates", "orbit witnesses"],
-    "prerequisites": ["strong recursion", "function iteration"]
+    "relatedConcepts": [
+      "strong induction",
+      "bounded model checking",
+      "decidable predicates",
+      "orbit witnesses"
+    ],
+    "prerequisites": [
+      "strong recursion",
+      "function iteration"
+    ]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "happy-number-oq-01",
-    "range": { "startLine": 157, "endLine": 175 },
+    "range": {
+      "startLine": 164,
+      "endLine": 182
+    },
     "type": "theorem",
     "title": "The Happy / Unhappy Dichotomy",
     "content": "reaches_one_or_four is the human-readable payoff: every positive integer reaches 1 (happy) or 4 (unhappy). It case-splits on the nine members of T returned by reaches_T. The fixed point 1 gives happiness immediately; each of the eight cycle values is advanced forward to 4 using Function.iterate_add_apply (to splice the known number of cycle steps onto the orbit) with native_decide certifying the splice. Because 4 lies on the unique nontrivial cycle, reaching any cycle element is equivalent to being unhappy.",
     "mathContext": "$\\forall n \\ge 1:\\ (\\exists k,\\ S^{[k]}(n) = 1) \\;\\lor\\; (\\exists k,\\ S^{[k]}(n) = 4)$.",
     "significance": "critical",
-    "relatedConcepts": ["happy numbers", "OEIS A007770", "case analysis", "cycle splicing"],
-    "prerequisites": ["function iteration", "logical disjunction"]
+    "relatedConcepts": [
+      "happy numbers",
+      "OEIS A007770",
+      "case analysis",
+      "cycle splicing"
+    ],
+    "prerequisites": [
+      "function iteration",
+      "logical disjunction"
+    ]
   }
 ]

--- a/src/data/proofs/happy-number-oq-01/meta.json
+++ b/src/data/proofs/happy-number-oq-01/meta.json
@@ -8,8 +8,8 @@
     ],
     "opens": [],
     "namespace": "HappyNumberOQ01",
-    "lineCount": 175,
-    "axiomCount": 1,
+    "lineCount": 182,
+    "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 3,
     "path": "Proofs/HappyNumberOQ01.lean",
@@ -90,7 +90,7 @@
     "dateAdded": "2026-06-16",
     "axiomCount": 1,
     "lineCount": 175,
-    "assumptions": "Build-pending: the file is not yet registered in Proofs.lean and has not been compiled this session. The finite checks (S_one, unhappy_cycle, T_absorbing, reachesT_below, and the 8-cycle splices) use native_decide, which introduces the Lean.ofReduceBool axiom — so the entry is axiomatized (axiomCount 1), not axiom-free. There are no sorries and no hand-asserted mathematical axioms; the single assumption is trust in the Lean compiler's reduction via native_decide.",
+    "assumptions": "The file compiles cleanly against Mathlib (Lean v4.26.0). The finite checks (S_one, unhappy_cycle, T_absorbing, reachesT_below, and the 8-cycle splices) use native_decide, which introduces the Lean.ofReduceBool axiom — so the entry is axiomatized (axiomCount 1), not axiom-free. There are no literal axiom declarations and no sorries; the single assumption is trust in the Lean compiler's kernel reduction via native_decide.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 3
@@ -120,7 +120,7 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 37,
-      "summary": "The module docstring states the happy/unhappy dichotomy, the absorbing set T, and the descent-plus-enumeration strategy, and flags the build-pending / native_decide status. Imports Mathlib and opens the HappyNumberOQ01 namespace.",
+      "summary": "The module docstring states the happy/unhappy dichotomy, the absorbing set T, and the descent-plus-enumeration strategy, and flags the native_decide (axiomatized) status. Imports Mathlib and opens the HappyNumberOQ01 namespace.",
       "mathContext": "$T = \\{1\\} \\cup \\{4, 16, 37, 58, 89, 145, 42, 20\\}$; every $n \\ge 1$ satisfies $\\exists k,\\ S^{[k]}(n) = 1$ or $\\exists k,\\ S^{[k]}(n) = 4$."
     },
     {


### PR DESCRIPTION
## Summary

The **Happy / unhappy dichotomy** entry (`happy-number-oq-01`) was merged in #25222 as an explicitly *build-pending orphan* that had **never actually compiled**. This PR makes it build.

### The bug
`descent` used `pow_lt_pow_iff_right'` to derive `3 < L` from `10^3 < 10^L`. Under current Mathlib (Lean v4.26.0) that lemma fails to synthesize `MulLeftStrictMono ℕ`:
```
error: HappyNumberOQ01.lean:83:48: failed to synthesize MulLeftStrictMono ℕ
error: HappyNumberOQ01.lean:76:45: unsolved goals ... ⊢ MulLeftStrictMono ℕ
```

### The fix
Derive `3 < L` by contradiction using `Nat.pow_le_pow_right` (base-10 monotonicity), avoiding the ordered-monoid lemma. The whole file now builds cleanly in Docker (**7743 jobs, exit 0**).

### Verification
- Docker build `Proofs.HappyNumberOQ01` → success.
- Numeric claims independently re-checked in Python: `T` absorbing, the 8-cycle, base window `[1,999]` reaches `T` (max 11 steps at `n=269`, well within the 15-step budget), descent `S(n)<n` for `n≥1000`, and `81·L < 10^{L-1}` for `L≥4`.

### Metadata cleanup
- Module docstring `STATUS`: *build-pending* → *compiles cleanly*.
- `meta.json`: `leanFile.axiomCount` 1 → 0 (no literal `axiom` declarations; `meta.axiomCount` stays **1** for the `native_decide` `Lean.ofReduceBool`, per the axiom-integrity policy), `lineCount` 175 → 182, assumptions/section text de-staled.
- `annotations.json`: line ranges shifted +7 for the enlarged `descent` block.

**Status unchanged: `axiomatized` / badge `axiom`** — `native_decide` introduces `Lean.ofReduceBool`; this is disclosed, not claimed away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)