### PR TITLE
research(schroeder-bernstein-oq-03): confirm BuiltFrom/chase structural incompatibility + resolution roadmap

### DIFF
--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -28,18 +28,20 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-04-21T16:44:09+02:00",
-    "iteration": 1,
-    "focus": "Hard direction open; obstruction (Π₁ isGFree) identified; back-and-forth builder is the path.",
-    "blockers": [],
-    "nextAction": "Formalize stage-wise partial-bijection builder + invariants.",
+    "iteration": 2,
+    "focus": "CONFIRMED (r9): BuiltFrom is LOAD-BEARING for chase TERMINATION — collision_f_source uses it to prove each blocker of f(orbit_j) is exactly orbit_{j+1}=g(f(orbit_j))∈mDom L, which is what makes the orbit points distinct fresh domain elements and discharges the hchase hypothesis of fwdOrbit_prefix_distinct/fwdOrbit_chase_length_le. Yet the terminal chase edge (a, chaseTarget a k)=(a, f(orbit_k)) for k≥1 is neither an f-edge nor a g-edge, so it provably breaks BuiltFrom. Under this file's monotone-prepend design (mLookup_stable forbids removing/rotating edges) the classical chain-rotation repair is unavailable → the BuiltFrom/chase incompatibility is ARCHITECTURAL. Reconciling it, not assembling the scheduler, is the true remaining obstruction.",
+    "blockers": [
+      "Verification environment blocked 2026-07-02: mathlib olean cache incomplete (7382/7727) so host `lake env lean` fails; Docker saturated (disk 100%, 5 concurrent builds) — no build possible this session."
+    ],
+    "nextAction": "Resolve the BuiltFrom/chase tension via a generalized construction invariant (path B) that survives chase edges AND still yields collision determinacy (u=g(f a)); only then assemble the buildStage scheduler.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (researcher-7, BUILD-PENDING/UNVERIFIED — Docker VM disk full): filled the missing CORRESPONDENCE-along-the-chase invariant. Added fwdOrbit_pred_iff (p-value constant on forward orbit), chaseTarget (computable k-th green candidate) + recurrence, chaseTarget_corr (p a ↔ q(chaseTarget a k)), and matching_step_chase (general domain step at any chase depth, generalizing matching_step_f). Prior sessions had the collision SOURCE (collision_f_source) and chase TERMINATION (fwdOrbit_chase_length_le); this adds the correspondence PRESERVATION. Open caveat: matching_step_chase pairs may break the strong BuiltFrom invariant for k≥1 — must reconcile before scheduler assembly. myhill_isomorphism hard direction still has 1 sorry.",
+    "progressSummary": "ANALYSIS (researcher-9, 2026-07-02 — NO BUILD: mathlib olean cache incomplete 7382/7727 + disk 100% / 5 concurrent Docker builds, so neither host `lake env lean` nor Docker verify was possible). Converted r7's open caveat 'matching_step_chase pairs may break the strong BuiltFrom invariant for k≥1' into a CONFIRMED structural incompatibility and mapped three resolution paths (see insights / nextSteps): BuiltFrom is load-bearing for chase TERMINATION (via collision_f_source ⇒ distinct fresh blocker domain elements) yet is provably broken by the terminal chase edge (a,f(orbit_k)) under the monotone-prepend design. Recommendation: pursue a generalized invariant (path B) threading the chase history before attempting scheduler assembly. No Lean changed (0 build risk); pure ORIENT narrowing. --- PRIOR: PROGRESS (researcher-7, BUILD-PENDING/UNVERIFIED — Docker VM disk full): filled the missing CORRESPONDENCE-along-the-chase invariant. Added fwdOrbit_pred_iff (p-value constant on forward orbit), chaseTarget (computable k-th green candidate) + recurrence, chaseTarget_corr (p a ↔ q(chaseTarget a k)), and matching_step_chase (general domain step at any chase depth, generalizing matching_step_f). Prior sessions had the collision SOURCE (collision_f_source) and chase TERMINATION (fwdOrbit_chase_length_le); this adds the correspondence PRESERVATION. Open caveat: matching_step_chase pairs may break the strong BuiltFrom invariant for k≥1 — must reconcile before scheduler assembly. myhill_isomorphism hard direction still has 1 sorry.",
     "builtItems": [
       "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
       "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
@@ -65,17 +67,17 @@
       "Collision determinacy (Section 4g): under the BuiltFrom invariant (each pair is an f-edge (x,f x) or g-edge (g y,y)), a domain-side collision f a in mRan L is NECESSARILY the g-edge (g(f a), f a) — cannot be an f-edge by injectivity of f. Replaces the Pi_1 isGFree decision with a decidable membership test + explicit blocker g(f a).",
       "2026-07-02 (r11): green Docker build of SchroederBernsteinOQ03 (3065 jobs, v4.26.0) confirms Sections 4a-4f (59 thm/14 def) compile with only the known myhill_isomorphism sorry; concurrent growth did not reintroduce the post-#32332 dup-decl breakage.",
       "CHASE CORRESPONDENCE (the missing invariant): the p-value is CONSTANT along the forward orbit — p(fwdOrbit f g a k) ↔ p a for all k — because one orbit step x↦g(f x) crosses p x→q(f x) (f-reduction) then q(f x)→p(g(f x)) (g-reduction). Hence EVERY green chase candidate chaseTarget f g a k = f(fwdOrbit f g a k) corresponds to the anchor: p a ↔ q(chaseTarget f g a k). This is exactly what lets the scheduler pair (a, chaseTarget a k) while preserving MatchingCorr — the correspondence half of the domain step that was NOT yet established (only single-step matching_step_f had it).",
-      "ALGORITHM PINNED (Wikipedia/Rogers §7.4): to place fresh domain a, try f a; if taken, apply g then f REPEATEDLY (chaseTarget recurrence: chaseTarget a (k+1) = f(g(chaseTarget a k))) until a fresh green appears, then pair a with it. Membership preserved by chaseTarget_corr; termination bounded by fwdOrbit_chase_length_le (chase length ≤ mDom L length, already in file); no isGFree decision. NOTE the caveat below on BuiltFrom."
+      "ALGORITHM PINNED (Wikipedia/Rogers §7.4): to place fresh domain a, try f a; if taken, apply g then f REPEATEDLY (chaseTarget recurrence: chaseTarget a (k+1) = f(g(chaseTarget a k))) until a fresh green appears, then pair a with it. Membership preserved by chaseTarget_corr; termination bounded by fwdOrbit_chase_length_le (chase length ≤ mDom L length, already in file); no isGFree decision. NOTE the caveat below on BuiltFrom.",
+      "BUILTFROM/CHASE TENSION = STRUCTURAL INCOMPATIBILITY (r9, 2026-07-02): sharpens r7's 'matching_step_chase may break the BuiltFrom invariant for k≥1' from a caveat to a proven architectural obstruction. (1) BuiltFrom is not decoration: collision_f_source REQUIRES it to name the blocker of f(orbit_j) as (g(f(orbit_j)), f(orbit_j)), i.e. orbit_{j+1}∈mDom L; that determinacy is exactly what forces the orbit points to be distinct fresh domain elements, discharging the hchase premise of fwdOrbit_prefix_distinct / fwdOrbit_chase_length_le (chase termination). So BuiltFrom is load-bearing for TERMINATION. (2) The placed terminal edge (a, chaseTarget f g a k)=(a, f(orbit_k)) for k≥1 is neither (x,f x) nor (g y,y), so BuiltFrom fails on it — hence collision_f_source is unusable at every domain step AFTER the first k≥1 chase. (3) The obvious repair (re-pair the chain so all edges are honest f-edges) is a NON-monotone update that removes existing edges, violating the mLookup_stable read-off which this file's computability rests on. RESOLUTION PATHS (all open): A) decouple termination from BuiltFrom by a self-contained pigeonhole ∃k≤|mRan L|, chaseTarget a k∉mRan L — but orbit distinctness itself appears to need the blocker structure, so likely circular; B) generalize BuiltFrom to an invariant preserved by chase edges AND strong enough for u=g(f a) determinacy — the weak 'w∈range f ∨ u∈range g' is too weak; the right invariant must thread the chase HISTORY (record that a chase pair (a,f(orbit_k)) sits atop a fully g-edged orbit tail (orbit_{j+1},f(orbit_j)))_{j<k}); C) place the honest f-edge (orbit_k,f(orbit_k)) instead of (a,·) — blocked because orbit_k is already in mDom L (it was a blocker), so IsMatching forbids re-pairing. Path B is most promising. This is the single obstruction gating scheduler assembly."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
     ],
     "nextSteps": [
-      "CAVEAT to resolve: the naive pair (a, chaseTarget a k) added by matching_step_chase is NOT an f-edge/g-edge for k≥1, so it may VIOLATE the file's BuiltFrom invariant (every pair is (x,f x) or (g y,y)). Either (a) generalize BuiltFrom to admit these long-range orbit edges while keeping collision_f_source-style source analysis, or (b) confirm the real scheduler only ever adds edges keeping BuiltFrom and re-derive collisions. Reconcile matching_step_chase with BuiltFrom before assembling the scheduler.",
-      "Define the domain-step SEARCH: least k with chaseTarget f g a k ∉ mRan L (bounded by fwdOrbit_chase_length_le, so total+computable). Package as a Part/def with Dom proof via the chase-length bound + step_f_available_or_collision iterated.",
-      "Assemble the stage function StageMatching : ℕ → List(ℕ×ℕ) by recursion using the general domain step (even) and its swap-dual range step (odd, via builtFrom_map_swap/matchingCorr_map_swap), maintaining IsMatching+MatchingCorr+BuiltFrom(or its generalization).",
-      "Derive the total computable permutation from mLookup on the stage limit + firstMissing exhaustion (firstMissing_lt_cons_self) and close myhill_isomorphism.",
-      "BUILD BLOCKER: Docker VM cache volume full → Docker Desktop cannot start (host disk fine at 66%). This session unverified; needs a clean Docker build to confirm 0-axiom."
+      "Resolve the BuiltFrom/chase incompatibility (see r9 insight): most promising is a generalized construction invariant (path B) that, for each chase-placed pair (a, f(orbit_k)), records enough orbit history (the g-edge tail (orbit_{j+1}, f(orbit_j)) for j<k) to recover the collision_f_source determinacy while remaining preserved under prepend.",
+      "Only after (1): assemble the scheduler `buildStage : ℕ → List (ℕ×ℕ)` (even stage 2k ensures k∈mDom via the bounded chase; odd stage 2k+1 ensures k∈mRan via the swapped chase using builtFrom_map_swap/matchingCorr_map_swap).",
+      "Prove monotone sublist stability of buildStage (generalizing mLookup_stable) + domain/range exhaustion (n enters by stage 2n+1).",
+      "Define σ n := mLookup (buildStage (bound n)) n; prove Bijective (functional+cofunctional from IsMatching, surjective+injective from exhaustion) and Computable (mLookup_computable ∘ computable buildStage); package as ℕ≃ℕ and discharge the myhill_isomorphism sorry."
     ],
     "markdown": "# Knowledge Base: schroeder-bernstein-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -214,6 +216,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroederBernsteinOQ04OQ01OQ01.lean"
     }
   ],
-  "lastWorkedBy": "researcher-11",
+  "lastWorkedBy": "researcher-9",
   "lastWorkedAt": "2026-07-02"
 }


### PR DESCRIPTION
## Summary

ORIENT-phase research update on **schroeder-bernstein-oq-03** (Myhill Isomorphism Theorem / computable Schröder–Bernstein). No Lean is changed — this records a sharpened analysis of the single remaining `sorry` (the hard direction of `myhill_isomorphism`) into the problem's research state, so the next iteration starts from the real obstruction rather than re-deriving it.

## Finding

Researcher-7 left an open caveat: *"matching_step_chase pairs may break the strong BuiltFrom invariant for k≥1 — must reconcile before scheduler assembly."* This PR confirms and sharpens it into a **structural incompatibility**:

1. **`BuiltFrom` is load-bearing for chase _termination_**, not decoration. `collision_f_source` uses it to prove the blocker of `f(orbitⱼ)` is exactly `orbitⱼ₊₁ = g(f(orbitⱼ)) ∈ mDom L`. That determinacy is precisely what makes the orbit points *distinct fresh domain elements*, which discharges the `hchase` premise of `fwdOrbit_prefix_distinct` / `fwdOrbit_chase_length_le`.
2. **The terminal chase edge `(a, chaseTarget f g a k) = (a, f(orbitₖ))` for `k ≥ 1`** is neither an `f`-edge `(x, f x)` nor a `g`-edge `(g y, y)`, so it provably breaks `BuiltFrom` — making `collision_f_source` unusable at every domain step after the first `k ≥ 1` chase.
3. **The chain-rotation repair is non-monotone** (it removes/rewrites existing edges) and violates `mLookup_stable`, on which this file's *computable* read-off rests. So under the monotone-prepend design the incompatibility cannot be sidestepped by rotation.

## Resolution paths recorded (all open)

- **(A)** Decouple termination from `BuiltFrom` via a self-contained pigeonhole `∃ k ≤ |mRan L|, chaseTarget a k ∉ mRan L` — but orbit distinctness itself seems to need the blocker structure, so likely circular.
- **(B, most promising)** Generalize `BuiltFrom` to an invariant preserved by chase edges *and* strong enough for the `u = g(f a)` determinacy — the weak `w ∈ range f ∨ u ∈ range g` is too weak; the right invariant must thread the chase **history** (the `g`-edge tail `(orbitⱼ₊₁, f(orbitⱼ))` for `j < k`).
- **(C)** Place the honest `f`-edge `(orbitₖ, f(orbitₖ))` instead of `(a, ·)` — blocked because `orbitₖ` is already in `mDom L` (it was a blocker), so `IsMatching` forbids re-pairing.

The downstream scheduler-assembly roadmap (`buildStage` recursion, monotone stability, domain/range exhaustion, `σ := mLookup ∘ buildStage`, `Bijective` + `Computable` → `ℕ ≃ ℕ`) is recorded in `knowledge.nextSteps`, gated on resolving the above.

## Verification note

No build was possible this session: the vendored mathlib olean cache is incomplete (7382/7727), so host `lake env lean` fails, and Docker is saturated (disk 100%, 5 concurrent builds). Since only the research-state JSON changes, there is **zero build risk** and this does not touch the green-building Lean file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)