### PR TITLE
research(desargues-theorem-oq-03-oq-01): fix broken merged file + add gallery entry [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DesarguesTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/DesarguesTheoremOQ03OQ01.lean
@@ -163,7 +163,7 @@ theorem collinear_semilinear (σ : K →+* K) {p q r : Fin 3 → K}
     (h : Collinear p q r) :
     Collinear (fun i => σ (p i)) (fun i => σ (q i)) (fun i => σ (r i)) := by
   unfold Collinear at *
-  rw [rowMat_map, ← RingHom.map_det, h, map_zero]
+  rw [rowMat_map, ← RingHom.mapMatrix_apply, ← RingHom.map_det, h, map_zero]
 
 -- ============================================================
 -- PART 4: PΓL(3,K) ⊆ Collineations  (the constructive half of the FTPG)
@@ -252,35 +252,28 @@ theorem frame_stabilizer_scalar (M : Matrix (Fin 3) (Fin 3) K) (a b c d : K)
     simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
       Pi.smul_apply, smul_eq_mul, mul_one] at h
-    rw [e00, e01, e02] at h; linarith [h]
+    rw [e00, e01, e02] at h; linear_combination h
   have hdb : b = d := by
     have h := congrFun hd 1
     simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
       Pi.smul_apply, smul_eq_mul, mul_one] at h
-    rw [e10, e11, e12] at h; linarith [h]
+    rw [e10, e11, e12] at h; linear_combination h
   have hdc : c = d := by
     have h := congrFun hd 2
     simp only [Matrix.mulVec, dotProduct, Fin.sum_univ_three, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons,
       Pi.smul_apply, smul_eq_mul, mul_one] at h
-    rw [e20, e21, e22] at h; linarith [h]
+    rw [e20, e21, e22] at h; linear_combination h
   refine ⟨hda, hdb, hdc, ?_⟩
-  -- Assemble `M = d • 1` entrywise.
+  -- Assemble `M = d • 1` entrywise from the nine entry equations.  `fin_cases`
+  -- introduces the indices in `Fin.mk` form, so we reduce the identity matrix with
+  -- `simp only` and finish with `simp_all`, whose `Fin.isValue` normalization matches
+  -- the `Fin.mk` indices against the entry hypotheses `e..` and the scalars `hda..hdc`.
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul, mul_one, mul_zero] <;>
-    first
-      | (rw [e00, hda])
-      | (rw [e11, hdb])
-      | (rw [e22, hdc])
-      | (rw [e10]; ring)
-      | (rw [e20]; ring)
-      | (rw [e01]; ring)
-      | (rw [e21]; ring)
-      | (rw [e02]; ring)
-      | (rw [e12]; ring)
-      | simp
+    simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul] <;>
+    simp_all
 
 -- ============================================================
 -- PART 7: Projective invariance of the Desargues configuration over K

--- a/src/data/proofs/desargues-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,220 @@
+{
+  "id": "desargues-theorem-oq-03-oq-01",
+  "title": "From PGL to PΓL: the Semilinear Group and Frame Rigidity over an Arbitrary Field",
+  "slug": "desargues-theorem-oq-03-oq-01",
+  "description": "The parent (OQ-03) proves the linear half of the algebraic engine behind the Fundamental Theorem of Projective Geometry (FTPG) over ℝ: an invertible matrix acts on PG(2, ℝ) by a collineation because det[M·p, M·q, M·r] = det M · det[p, q, r]. This follow-up supplies the two pieces OQ-03 left open, and does so over an arbitrary field K — the natural home of the Desargues ⇒ coordinatization ⇒ FTPG chain. (1) The semilinear part: a field endomorphism applied coordinatewise preserves collinearity (collinear_semilinear), so PΓL(3, K) = PGL(3, K) ⋊ Aut(K) acts by collineations (collinear_projSemilinear) — a phenomenon invisible over ℝ where Aut(ℝ) is trivial. (2) Frame rigidity: the standard frame [1:0:0], [0:1:0], [0:0:1], [1:1:1] is in general position (frame_general_position), and a linear map fixing every frame point projectively is a scalar matrix (frame_stabilizer_scalar) — the projective stabilizer of a frame is trivial, i.e. a projective transformation is determined by its action on a frame. Both perspectivity relations of Desargues transport along collineations over any K. The deep converse Collineations ⊆ PΓL is left as the contextual open direction, not axiomatized. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_projective_geometry",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/DesarguesTheoremOQ03OQ01.lean",
+    "tags": [
+      "projective-geometry",
+      "desargues",
+      "fundamental-theorem-projective-geometry",
+      "collineation",
+      "semilinear-map",
+      "projective-frame",
+      "PGL",
+      "PGamL",
+      "linear-algebra",
+      "determinant",
+      "field-automorphism",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_mul",
+        "description": "det(A·B) = det A · det B — turns the row-transformation [M·p; M·q; M·r] = [p;q;r]·Mᵀ into a determinant scaling by det M",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_transpose",
+        "description": "det Aᵀ = det A — needed because the row-image matrix equals (rowMat p q r)·Mᵀ",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "RingHom.map_det",
+        "description": "f(det M) = det(f.mapMatrix M) — carries a coordinatewise field endomorphism through the determinant, the crux of the semilinear collineation lemma collinear_semilinear",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "RingHom.mapMatrix_apply",
+        "description": "f.mapMatrix M = M.map f — bridges the (rowMat ·).map σ term produced by rowMat_map to the mapMatrix form expected by RingHom.map_det",
+        "module": "Mathlib.Data.Matrix.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "explicit 3×3 determinant expansion — closes rowMat_det and the frame general-position determinants by ring",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "mul_eq_zero",
+        "description": "a·b = 0 ↔ a = 0 ∨ b = 0 (in a field, no zero divisors) — reflects collinearity back through det M ≠ 0 in collinear_mulVec_iff",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The whole development is carried out over an arbitrary field K (not only ℝ), which is the natural setting of the Desargues ⇒ coordinatization (Hilbert) ⇒ FTPG chain; over ℝ the semilinear phenomenon is invisible because Aut(ℝ) is trivial.",
+      "collinear_semilinear: a field endomorphism σ applied coordinatewise preserves collinearity, proved by carrying σ through the determinant via RingHom.mapMatrix_apply and RingHom.map_det — the semilinear ingredient of PΓL absent from the parent's ℝ-only picture.",
+      "collinear_projSemilinear: PΓL(3, K) ⊆ collineations — a projective semilinear map (invertible linear M followed by a field automorphism σ) preserves collinearity; the constructive half of the FTPG, stated exactly for the class the theorem names.",
+      "frame_general_position: the standard projective frame [1:0:0], [0:1:0], [0:0:1], [1:1:1] is in general position — all four 3-point determinants are ±1, so no three are collinear.",
+      "frame_stabilizer_scalar: frame rigidity — a linear map fixing each frame point projectively (up to scalars a, b, c, d) forces a = b = c = d and M = d·1; equivalently the projective stabilizer of a frame in PGL(3, K) is trivial, so a projective transformation is uniquely determined by its action on a frame. This is the computational kernel of the FTPG.",
+      "collinear_mulVec / collinear_mulVec_iff / rowMat_mulVec_det: PGL(3, K) acts by collineations over any field — the parent's ℝ-only determinant transformation law generalized to K, with the invertible case both preserving and reflecting incidence.",
+      "desargues_relation_mulVec / desargues_relation_preserved: both perspectivity relations of Desargues's theorem (concurrency of joining lines, collinearity of intersection points) transport along collineations over an arbitrary K, generalizing the parent OQ-03 invariance from ℝ."
+    ],
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 301,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axiom declarations; no native_decide and no decide on any substantive result, so the trusted axioms are exactly Mathlib's foundational propext / Classical.choice / Quot.sound. Verified via a clean `lake env lean` build (exit 0, no errors, no warnings, no sorries). The deep converse of the FTPG (every collineation is semilinear) is discussed as the open direction and is NOT assumed anywhere in the Lean development.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "By Hilbert's coordinatization theorem, a projective plane satisfies Desargues's theorem exactly when it can be coordinatized as PG(2, K) for a division ring K. The Fundamental Theorem of Projective Geometry (von Staudt; Veblen–Young) then characterizes the collineations of that coordinatized plane as the projective semilinear group PΓL(3, K) = PGL(3, K) ⋊ Aut(K): every collinearity-preserving bijection is an invertible linear map twisted by a field automorphism. The parent gallery entry (OQ-03) formalized the reachable linear core over ℝ. This entry pushes that core to an arbitrary field K and adds the two ingredients the FTPG genuinely turns on: the field-automorphism (semilinear) twist, which cannot even be seen over ℝ, and the frame-rigidity computation that gives the theorem its uniqueness content.",
+    "problemStatement": "OQ-03 proves, over ℝ, that invertible linear maps act on PG(2, ℝ) by collineations, but explicitly leaves two things open: (1) the semilinear part — the FTPG names PΓL(3, K), not merely PGL, and the field-automorphism factor is missing; and (2) the rigidity — a projective transformation should be determined by its action on a frame. Can both be formalized, and over an arbitrary field K where the automorphism factor Aut(K) is actually nontrivial?",
+    "text": "Yes. Working over any field K with points of PG(2, K) as nonzero vectors of K³ and collinearity as the determinant-zero condition, an invertible matrix acts by a collineation (det multiplicativity, as in the parent). Applying a field endomorphism σ coordinatewise also preserves collinearity, because σ carries through the determinant (RingHom.map_det); composing the two gives the projective semilinear maps of PΓL(3, K) acting as collineations — the constructive inclusion PΓL ⊆ Aut(PG(2, K)). For rigidity, the standard frame is shown to be in general position, and a linear map fixing every frame point projectively is forced to be a single scalar times the identity, so the projective stabilizer of a frame is trivial. The hard converse PΓL ⊇ collineations — that every collineation is semilinear — is the deep content of the FTPG; it reconstructs the field from incidence (again via Desargues) and is left as the contextual open direction, not axiomatized.",
+    "proofStrategy": "PGL half: as in the parent, [M·p; M·q; M·r] = (rowMat p q r)·Mᵀ, so det scales by det M (det_mul, det_transpose); collinearity is preserved always and reflected when det M ≠ 0 (mul_eq_zero). Semilinear half: rowMat_map shows applying σ coordinatewise equals mapping the stacked matrix through σ; then RingHom.mapMatrix_apply rewrites (rowMat ·).map σ to σ.mapMatrix (rowMat ·) and RingHom.map_det pulls σ outside the determinant, so σ 0 = 0 finishes. Composing gives collinear_projSemilinear. Frame general position is four explicit 3×3 determinants (±1) by rowMat_det and ring. Frame rigidity extracts the nine entries of M from the three coordinate-point hypotheses (each column read off a single mulVec equation), then the unit-point hypothesis forces the three diagonal scalars to a common value d by linear_combination (valid over any commutative ring), and the matrix is assembled entrywise as d·1.",
+    "keyInsights": [
+      "Over ℝ the semilinear part of the FTPG is invisible because Aut(ℝ) is trivial (semilinear = linear); one must leave ℝ — to ℂ or 𝔽_{pⁿ} — to see the Aut(K) factor at all. This is why the generalization to an arbitrary field is not idle: it is where the theorem's true group appears.",
+      "A field endomorphism preserves collinearity for a purely algebraic reason: it commutes with the determinant (RingHom.map_det), so the det = 0 incidence condition is carried to det = 0.",
+      "Frame rigidity is a finite linear-algebra computation, not a deep fact: fixing the three coordinate points pins M to a diagonal matrix, and fixing the unit point [1:1:1] collapses the diagonal to a single scalar — the projective stabilizer of a frame is trivial.",
+      "Generalizing the parent from ℝ to K exposes a subtle tactic dependency: the diagonal-scalar equalities cannot use linarith (K is unordered) and must use linear_combination, and the entrywise assembly must reconcile fin_cases' Fin.mk indices with the literal entry hypotheses (simp_all / Fin.isValue).",
+      "This entry is the exact constructive half of the FTPG (PΓL ⊆ collineations) plus its uniqueness kernel (frame rigidity); the remaining open half (collineations ⊆ PΓL) is what the whole theorem is really about."
+    ],
+    "prerequisites": [
+      "homogeneous coordinates over a field: projective points as nonzero vectors in K³",
+      "the determinant incidence condition for collinearity (parent entry, now over K)",
+      "ring/field homomorphisms and RingHom.mapMatrix / RingHom.map_det",
+      "the projective linear group PGL, the semilinear group PΓL = PGL ⋊ Aut(K), and the notion of a projective frame"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-plane",
+      "title": "The Coordinatized Plane PG(2, K)",
+      "startLine": 83,
+      "endLine": 108,
+      "summary": "rowMat u v w stacks three vectors of K³ as rows; rowMat_det is its explicit 3×3 expansion; Collinear p q r := det(rowMat p q r) = 0 is the incidence predicate — the same determinant condition as the parent, now over an arbitrary field K (dually, three lines are concurrent).",
+      "mathContext": "Collinear p q r := (rowMat p q r).det = 0 over any field K."
+    },
+    {
+      "id": "sec-pgl",
+      "title": "PGL(3, K) Acts by Collineations",
+      "startLine": 109,
+      "endLine": 147,
+      "summary": "rowMat_mulVec factors [M·p; M·q; M·r] as (rowMat p q r)·Mᵀ; rowMat_mulVec_det gives det = det M · det[p,q,r]; collinear_mulVec preserves collinearity for any M, and collinear_mulVec_iff reflects it when det M ≠ 0 — PGL acts by collineations over any field.",
+      "mathContext": "det[Mp, Mq, Mr] = det M · det[p,q,r]; det M ≠ 0 ⟹ M preserves and reflects incidence."
+    },
+    {
+      "id": "sec-semilinear",
+      "title": "Aut(K) Acts by Collineations — the Semilinear Part",
+      "startLine": 148,
+      "endLine": 167,
+      "summary": "rowMat_map: applying a ring endomorphism σ coordinatewise equals mapping the stacked matrix through σ. collinear_semilinear: σ preserves collinearity, since it carries through the determinant (RingHom.mapMatrix_apply then RingHom.map_det, and σ 0 = 0). This is the semilinear ingredient of PΓL, invisible over ℝ.",
+      "mathContext": "σ (det(rowMat p q r)) = det(σ.mapMatrix (rowMat p q r)); σ preserves det = 0."
+    },
+    {
+      "id": "sec-pgammal",
+      "title": "PΓL(3, K) ⊆ Collineations — the Constructive Half of the FTPG",
+      "startLine": 168,
+      "endLine": 183,
+      "summary": "collinear_projSemilinear: a projective semilinear map — an invertible linear M followed by a field automorphism σ — preserves collinearity. This is the inclusion PΓL(3, K) ⊆ Aut(PG(2, K)), the exact class of transformations the Fundamental Theorem names; the deep converse is what the theorem is really about.",
+      "mathContext": "σ ∘ (M ·) preserves collinearity: collinear_semilinear σ (collinear_mulVec M h)."
+    },
+    {
+      "id": "sec-frame",
+      "title": "The Standard Projective Frame",
+      "startLine": 184,
+      "endLine": 201,
+      "summary": "frame_general_position: the three coordinate points and the unit point [1:0:0], [0:1:0], [0:0:1], [1:1:1] are in general position — every one of the four 3-point subsets has determinant ±1, so no three are collinear, making them a genuine projective frame.",
+      "mathContext": "The four 3-point determinants of the standard frame are 1, 1, −1, 1."
+    },
+    {
+      "id": "sec-rigidity",
+      "title": "Frame Rigidity — the Computational Kernel of the FTPG",
+      "startLine": 202,
+      "endLine": 277,
+      "summary": "frame_stabilizer_scalar: if a linear map fixes each frame point projectively (M·eᵢ = scalar·eᵢ and M·u = d·u), then all scalars coincide and M = d·1. The three coordinate points pin M to diagonal; the unit point collapses the diagonal to one scalar (linear_combination, over any field). Hence the projective stabilizer of a frame is trivial: a projective transformation is determined by its action on a frame.",
+      "mathContext": "M·eᵢ = ·eᵢ and M·[1:1:1] = d·[1:1:1] ⟹ M = d·1."
+    },
+    {
+      "id": "sec-invariance",
+      "title": "Projective Invariance of Desargues over K",
+      "startLine": 278,
+      "endLine": 301,
+      "summary": "desargues_relation_mulVec and desargues_relation_preserved: both perspectivity relations of Desargues's theorem (concurrency of the joining lines, collinearity of the intersection points) are det = 0 conditions and hence transport along collineations — preserved by any linear map and reflected by invertible ones — generalizing the parent OQ-03 invariance from ℝ to an arbitrary field K.",
+      "mathContext": "For det M ≠ 0: Collinear(M·p, M·q, M·r) ↔ Collinear(p, q, r) over any K."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over an arbitrary field K, invertible matrices and field automorphisms both act on PG(2, K) by collineations, so the projective semilinear group PΓL(3, K) is contained in the collineation group — the constructive half of the Fundamental Theorem of Projective Geometry. The standard frame is in general position and its projective stabilizer in PGL(3, K) is trivial, so a projective transformation is determined by its action on a frame. Both perspectivity relations of Desargues's theorem transport along collineations over any K. This supplies exactly the two pieces the parent OQ-03 left open — the semilinear twist (invisible over ℝ) and the frame rigidity — while keeping the development axiom-free.",
+    "implications": "The FTPG's deep content is the converse inclusion — that every collinearity-preserving bijection of a projective space (dim ≥ 2) is semilinear — which reconstructs the field operations from incidence (again via Desargues) and needs projective-space foundations Mathlib does not yet have. What this entry pins down precisely is the elementary, unconditional half: PΓL ⊆ collineations, together with the finite computation (frame rigidity) that gives the theorem its uniqueness content. Carrying everything over an arbitrary K makes the Aut(K) factor visible for the first time in this family (it is trivial over ℝ), locating the semilinear phenomenon exactly where it lives.",
+    "openQuestions": [
+      "Formalize the converse of the FTPG over K: every collinearity-preserving bijection of PG(2, K) is a projective semilinear map (an element of PΓL(3, K)) — the substantial content, which reconstructs the field from incidence.",
+      "Upgrade frame rigidity from PGL to a full 'four points in general position map to any four in general position by a unique projective map' statement, giving the sharp uniqueness form of the theorem.",
+      "Build the abstract projective-plane structure (points, lines, incidence axioms) in Mathlib, show PG(2, K) models it, and recover Desargues's theorem and coordinatization as incidence-axiom consequences.",
+      "Instantiate the semilinear factor on concrete fields with nontrivial automorphism group (ℂ, 𝔽_{pⁿ}) to exhibit collineations that are not induced by any linear map."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.LinearAlgebra.Matrix.NonsingularInverse",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix"
+    ],
+    "namespace": "DesarguesTheoremOQ03OQ01",
+    "lineCount": 301,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/DesarguesTheoremOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "desargues-theorem-oq-03",
+      "relationship": "parent",
+      "description": "Proves the linear half of the algebraic engine of the FTPG over ℝ (invertible maps are collineations, Desargues configuration is GL₃-invariant). This entry supplies the two pieces it left open — the semilinear (Aut(K)) part and frame rigidity — over an arbitrary field K."
+    },
+    {
+      "targetId": "desargues-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "Another follow-up in the Desargues family; this entry treats the PΓL / frame-rigidity content behind the Fundamental Theorem of Projective Geometry over general fields."
+    },
+    {
+      "targetId": "desargues-theorem",
+      "relationship": "ancestor",
+      "description": "Desargues's theorem in homogeneous ℝ³ coordinates; by Hilbert's coordinatization it is exactly the synthetic hypothesis making a projective plane coordinatizable as PG(2, K), the setting in which this entry works."
+    }
+  ],
+  "references": [
+    {
+      "author": "Oswald Veblen and John Wesley Young",
+      "title": "Projective Geometry, Vol. 1",
+      "year": "1910",
+      "note": "Classical development of projective geometry, collineations, and the fundamental theorem; the role of Desargues's theorem in coordinatization."
+    },
+    {
+      "author": "Emil Artin",
+      "title": "Geometric Algebra",
+      "year": "1957",
+      "note": "The correspondence between the projective (semi)linear group, collineations, and coordinatization by a division ring; PΓL = PGL ⋊ Aut(K)."
+    },
+    {
+      "author": "Robin Hartshorne",
+      "title": "Foundations of Projective Geometry",
+      "year": "1967",
+      "note": "The Fundamental Theorem of Projective Geometry and the determination of a projective transformation by its action on a frame."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

The file \`Proofs/DesarguesTheoremOQ03OQ01.lean\` was merged into \`main\` via #33720 and #33734 **BUILD-PENDING and never actually compiled**. A host \`lake env lean\` verify shows it had **three real errors**, all introduced when the parent OQ-03 (stated over ℝ) was generalized to an arbitrary field \`K\`. This PR fixes all three, verifies the file cleanly, and adds the missing gallery entry.

## The three bugs (root causes)

1. **\`collinear_semilinear\` (L166)** — \`rw [← RingHom.map_det]\` failed: \`Did not find an occurrence of the pattern\`. \`RingHom.map_det\`'s RHS is \`(f.mapMatrix M).det\`, but \`rowMat_map\` produces \`(rowMat p q r).map σ\`. These are defeq but not syntactically equal. **Fix:** insert \`← RingHom.mapMatrix_apply\` first — the exact idiom Mathlib itself uses in \`Adjugate.lean\` / \`MvPolynomial.lean\`.

2. **\`frame_stabilizer_scalar\` diagonal scalars (L255/261/267)** — \`linarith\` failed: it needs a \`LinearOrderedField\`, but \`K\` is an arbitrary \`Field\`. **Fix:** \`linear_combination h\` (valid over any commutative ring; the hypotheses are linear equations).

3. **\`frame_stabilizer_scalar\` final assembly (L220)** — the \`first | rw [...] | ...\` cascade left cells unsolved because \`fin_cases\` emits indices in \`Fin.mk\` form (\`M ⟨2,_⟩ ⟨2,_⟩\`) which \`simp only\`/\`rw\` cannot match against the \`e.. : M 2 2\` literal hypotheses. **Fix:** finish with \`simp_all\`, whose \`Fin.isValue\` normalization bridges \`Fin.mk\` indices to the literals.

Net diff: **+10 / −17** lines, three localized tactic fixes; all mathematical content unchanged.

## Verification

Host \`lake env lean Proofs/DesarguesTheoremOQ03OQ01.lean\`:
- **exit 0, 0 errors, 0 warnings, 0 sorries.**
- Source: 0 \`axiom\` declarations, no \`native_decide\`, no \`decide\` → trusted axioms are exactly the foundational \`propext\` / \`Classical.choice\` / \`Quot.sound\`.
- 12 theorems / 2 defs / 301 lines.

(Verified on host against the restored Mathlib/deps oleans; the Docker path was unavailable due to a disk-100% + concurrent-build environment.)

## Gallery entry

Adds \`src/data/proofs/desargues-theorem-oq-03-oq-01/meta.json\` — **status verified / badge original / 0 axioms**. Documents the PGL→PΓL semilinear generalization (\`collinear_semilinear\`, \`collinear_projSemilinear\`) and frame rigidity (\`frame_general_position\`, \`frame_stabilizer_scalar\`) over an arbitrary field \`K\` — the two pieces the parent OQ-03 (over ℝ) explicitly left open. The deep converse \`Collineations ⊆ PΓL\` is documented as the open direction, not axiomatized.

## Note

A concurrent agent (branch \`fix/desargues-oq0301-build\`) had an **incomplete** fix touching only bug #3; it leaves bugs #1 and #2 unfixed, so that version does not compile. This PR is the complete, verified fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)