### PR TITLE
Enrich Erdős Problem #fermat-two-squares: add annotation prerequisites

### DIFF
--- a/src/data/proofs/fermat-two-squares/annotations.json
+++ b/src/data/proofs/fermat-two-squares/annotations.json
@@ -15,6 +15,11 @@
       "Mathlib",
       "sum of squares",
       "prime characterization"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "sums of two squares",
+      "the Lean/Mathlib library structure"
     ]
   },
   {
@@ -34,6 +39,11 @@
       "Fermat",
       "Euler",
       "Lagrange"
+    ],
+    "prerequisites": [
+      "the concept of a mathematical theorem versus a conjecture",
+      "prime numbers",
+      "Fermat's Last Theorem as historical context"
     ]
   },
   {
@@ -52,6 +62,11 @@
       "involutions",
       "combinatorial proof",
       "Zagier"
+    ],
+    "prerequisites": [
+      "involutions on finite sets",
+      "fixed points of maps",
+      "parity of set cardinality"
     ]
   },
   {
@@ -69,6 +84,11 @@
     "relatedConcepts": [
       "modular arithmetic",
       "characterization theorem"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "modular arithmetic mod 4",
+      "squares modulo an integer"
     ]
   },
   {
@@ -86,6 +106,11 @@
     "relatedConcepts": [
       "Fermat's original statement",
       "prime classification"
+    ],
+    "prerequisites": [
+      "congruence modulo 4",
+      "prime numbers",
+      "classification of odd primes"
     ]
   },
   {
@@ -103,6 +128,11 @@
     "relatedConcepts": [
       "special cases",
       "edge cases"
+    ],
+    "prerequisites": [
+      "the definition of a prime number",
+      "even and odd integers",
+      "congruence classes mod 4"
     ]
   },
   {
@@ -120,6 +150,11 @@
     "relatedConcepts": [
       "impossibility proof",
       "modular arithmetic"
+    ],
+    "prerequisites": [
+      "quadratic residues mod 4",
+      "modular arithmetic",
+      "proof by contradiction / impossibility arguments"
     ]
   },
   {
@@ -137,6 +172,11 @@
     "relatedConcepts": [
       "examples",
       "verification"
+    ],
+    "prerequisites": [
+      "perfect squares",
+      "arithmetic verification of equalities",
+      "primes congruent to 1 mod 4"
     ]
   },
   {
@@ -154,6 +194,11 @@
     "relatedConcepts": [
       "prime classification",
       "complete characterization"
+    ],
+    "prerequisites": [
+      "prime numbers",
+      "residue classes modulo 4",
+      "partitions of a set into disjoint cases"
     ]
   },
   {
@@ -172,6 +217,11 @@
       "Gaussian integers",
       "algebraic number theory",
       "quadratic reciprocity"
+    ],
+    "prerequisites": [
+      "the Gaussian integers Z[i]",
+      "quadratic residues (-1 as a residue mod p)",
+      "factorization and splitting of primes in a ring"
     ]
   }
 ]


### PR DESCRIPTION
Adds `prerequisites` (2–3 specific foundational concepts) to every annotation in `fermat-two-squares`, closing the annotation-depth gap. `significance`, `mathContext`, and `relatedConcepts` were already populated; this fills the remaining missing field so each annotation states what a reader should already know. No meta.json changes.