### PR TITLE
research(halls-theorem-oq-01-oq-02): König–Ore deficiency formula — exact matching number of a set system [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/HallsTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/HallsTheoremOQ01OQ02.lean
@@ -1,0 +1,279 @@
+/-
+# König–Ore deficiency formula: the exact matching number of a set system
+
+Open Question: halls-theorem-oq-01-oq-02
+Parent gallery entry: halls-theorem-oq-01 (the full biconditional bipartite Hall theorem).
+Status: VERIFIED (0 axioms, 0 sorries)
+
+## Context
+
+The `halls-theorem` gallery family formalises Hall's marriage theorem in two complementary
+worlds:
+
+* the **graph** world (`HallsTheoremOQ01.hall_marriage`), a biconditional about
+  `SimpleGraph.Subgraph.IsMatching`; and
+* the **`Finset` / SDR** world, where Mathlib packages the theorem as
+    `Finset.all_card_le_biUnion_card_iff_exists_injective`
+    `: (∀ s, #s ≤ #(s.biUnion t)) ↔ ∃ f, Function.Injective f ∧ ∀ i, f i ∈ t i`,
+  i.e. a **system of distinct representatives** (SDR) exists iff Hall's condition holds.
+
+The companions `HallsTheoremOQ01OQ01` / `HallsTheoremOQ02OQ01` prove the *qualitative* defect
+(Ore) theorem: if Hall's condition fails by at most `d`, a partial SDR missing at most `d`
+indices exists. What is still missing — and is the genuine **König** content of this open
+question — is the *exact* duality: the **minimum** number of indices that any partial SDR must
+leave unmatched equals the **maximum deficiency** of the family,
+
+    min over partial SDRs of (#unmatched)  =  max over s of (#s − #(s.biUnion t)).
+
+This is the König–Egerváry / König–Ore deficiency formula — the set-system form of König's
+theorem "max matching = min vertex cover". Equivalently, the **matching number** (the largest
+number of indices that admit distinct representatives) is exactly `|ι| − deficiency`.
+
+## Main results
+
+* `deficiency t` — the maximum deficiency `⨆ s, (#s − #(s.biUnion t))` over subsets `s ⊆ ι`.
+* `hall_relaxed_of_deficiency` — the family satisfies the relaxed Hall condition with slack
+  `deficiency t` (this is the tautological upper witness).
+* `konig_ore_exists` — a partial SDR leaving **at most** `deficiency t` indices unmatched exists.
+* `konig_ore_min` — **every** partial SDR leaves **at least** `deficiency t` indices unmatched.
+  Together with `konig_ore_exists` this is the deficiency formula: the minimum is exactly
+  `deficiency t`.
+* `konig_matching_number` — the dual "matching number" phrasing: some SDR represents at least
+  `|ι| − deficiency t` indices, and none represents more.
+* `deficiency_eq_zero_iff` / `deficiency_eq_zero_iff_exists_sdr` — `deficiency t = 0` iff Hall's
+  condition holds iff a full SDR exists, tying the formula back to Mathlib's packaged theorem.
+
+## Proof idea
+
+The defect theorem `defect_hall` (reproduced here so the file is self-contained: it is the
+`α ⊕ Fin d` dummy-adjunction argument, verified in `HallsTheoremOQ01OQ01`) is applied at the
+single optimal slack `d = deficiency t`. For the lower bound, any partial SDR missing `r`
+indices witnesses the relaxed Hall condition with slack `r` (the elementary counting split),
+so every deficiency `#s − #(s.biUnion t) ≤ r`, whence `deficiency t ≤ r`. The two bounds pin the
+minimum to `deficiency t`.
+-/
+import Mathlib
+
+open Finset Function
+
+namespace HallsTheoremOQ01OQ02
+
+variable {ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α]
+
+/-! ### The defect (Ore) theorem, reproduced self-containedly
+
+`defect_hall` is the qualitative deficiency theorem, identical to the verified
+`HallsTheoremOQ01OQ01.defect_hall`. We inline it so this file depends only on Mathlib. -/
+
+/-- **Hall's theorem with defect `d` (Ore's deficiency form).** A finite family of finite sets
+`t : ι → Finset α` satisfies the relaxed Hall condition `∀ s, #s ≤ #(s.biUnion t) + d` **iff**
+there is a partial system of distinct representatives leaving at most `d` indices unmatched. -/
+theorem defect_hall (t : ι → Finset α) (d : ℕ) :
+    (∀ s : Finset ι, #s ≤ #(s.biUnion t) + d) ↔
+      ∃ (e : ι → α) (rejected : Finset ι),
+        #rejected ≤ d ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i := by
+  classical
+  set D : Finset (α ⊕ Fin d) := Finset.univ.image Sum.inr with hDdef
+  have hDcard : #D = d := by
+    rw [hDdef, Finset.card_image_of_injective _ Sum.inr_injective, Finset.card_univ,
+      Fintype.card_fin]
+  set t' : ι → Finset (α ⊕ Fin d) := fun i => (t i).image Sum.inl ∪ D with ht'def
+  constructor
+  · intro h
+    have hall' : ∀ s : Finset ι, #s ≤ #(s.biUnion t') := by
+      intro s
+      rcases s.eq_empty_or_nonempty with rfl | hs
+      · simp
+      · have hbu : s.biUnion t' = (s.biUnion t).image Sum.inl ∪ D := by
+          apply Finset.Subset.antisymm
+          · intro x hx
+            simp only [Finset.mem_biUnion, ht'def, Finset.mem_union, Finset.mem_image] at hx
+            simp only [Finset.mem_union, Finset.mem_image, Finset.mem_biUnion]
+            obtain ⟨i, hi, hcase⟩ := hx
+            rcases hcase with ⟨a, hat, rfl⟩ | hD
+            · exact Or.inl ⟨a, ⟨i, hi, hat⟩, rfl⟩
+            · exact Or.inr hD
+          · intro x hx
+            rw [Finset.mem_union] at hx
+            simp only [Finset.mem_biUnion, ht'def, Finset.mem_union, Finset.mem_image]
+            rcases hx with hI | hD
+            · rw [Finset.mem_image] at hI
+              obtain ⟨a, ha, rfl⟩ := hI
+              rw [Finset.mem_biUnion] at ha
+              obtain ⟨i, hi, hat⟩ := ha
+              exact ⟨i, hi, Or.inl ⟨a, hat, rfl⟩⟩
+            · obtain ⟨i, hi⟩ := hs
+              exact ⟨i, hi, Or.inr hD⟩
+        have hdisj : Disjoint ((s.biUnion t).image Sum.inl) D := by
+          rw [Finset.disjoint_left]
+          intro x hx hxD
+          rw [Finset.mem_image] at hx
+          obtain ⟨a, _, rfl⟩ := hx
+          rw [hDdef, Finset.mem_image] at hxD
+          obtain ⟨b, _, hb⟩ := hxD
+          exact Sum.inr_ne_inl hb
+        rw [hbu, Finset.card_union_of_disjoint hdisj,
+          Finset.card_image_of_injective _ Sum.inl_injective, hDcard]
+        exact h s
+    obtain ⟨f, hf_inj, hf_mem⟩ :=
+      (Finset.all_card_le_biUnion_card_iff_exists_injective t').mp hall'
+    set rejected : Finset ι := Finset.univ.filter (fun i => (f i).isRight = true) with hrejdef
+    set e : ι → α := fun i => Sum.elim id (fun _ => Classical.arbitrary α) (f i) with hedef
+    have key : ∀ i, i ∉ rejected → ∃ a, f i = Sum.inl a := by
+      intro i hi
+      simp only [hrejdef, Finset.mem_filter, Finset.mem_univ, true_and] at hi
+      rcases hfi : f i with a | b
+      · exact ⟨a, rfl⟩
+      · simp [hfi] at hi
+    have hfe : ∀ i, i ∉ rejected → f i = Sum.inl (e i) := by
+      intro i hi
+      obtain ⟨a, ha⟩ := key i hi
+      simp [hedef, ha]
+    refine ⟨e, rejected, ?_, ?_, ?_⟩
+    · rw [← hDcard]
+      apply Finset.card_le_card_of_injOn f
+      · intro i hi
+        rw [Finset.mem_coe, hrejdef, Finset.mem_filter] at hi
+        rw [Finset.mem_coe, hDdef, Finset.mem_image]
+        rcases hfi : f i with a | b
+        · simp [hfi] at hi
+        · exact ⟨b, Finset.mem_univ b, rfl⟩
+      · exact hf_inj.injOn
+    · intro i hi j hj hij
+      rw [Finset.coe_compl, Set.mem_compl_iff, Finset.mem_coe] at hi hj
+      apply hf_inj
+      rw [hfe i hi, hfe j hj, hij]
+    · intro i hi
+      have hmem := hf_mem i
+      rw [hfe i hi] at hmem
+      simp only [ht'def, Finset.mem_union, Finset.mem_image] at hmem
+      rcases hmem with ⟨a, ha, hae⟩ | hD
+      · rw [Sum.inl.injEq] at hae; rw [← hae]; exact ha
+      · rw [hDdef, Finset.mem_image] at hD
+        obtain ⟨b, _, hb⟩ := hD
+        exact absurd hb Sum.inr_ne_inl
+  · rintro ⟨e, rejected, hcard, hinj, hmem⟩ s
+    have hsplit : #(s ∩ rejected) + #(s \ rejected) = #s :=
+      Finset.card_inter_add_card_sdiff s rejected
+    have hA : #(s ∩ rejected) ≤ d :=
+      le_trans (Finset.card_le_card Finset.inter_subset_right) hcard
+    have hsub : (↑(s \ rejected) : Set ι) ⊆ ↑rejectedᶜ := by
+      intro x hx
+      simp only [Finset.coe_sdiff, Set.mem_diff, Finset.mem_coe] at hx
+      simp only [Finset.coe_compl, Set.mem_compl_iff, Finset.mem_coe]
+      exact hx.2
+    have hB : #(s \ rejected) ≤ #(s.biUnion t) := by
+      apply Finset.card_le_card_of_injOn e
+      · intro i hi
+        rw [Finset.mem_coe, Finset.mem_sdiff] at hi
+        rw [Finset.mem_coe, Finset.mem_biUnion]
+        exact ⟨i, hi.1, hmem i hi.2⟩
+      · exact hinj.mono hsub
+    omega
+
+/-! ### The deficiency and the König–Ore formula -/
+
+/-- The **maximum deficiency** of the set system `t`: the largest excess `#s − #(s.biUnion t)`
+(truncated subtraction) over all subsets `s ⊆ ι`. The empty set contributes `0`, so
+`deficiency t = 0` exactly when Hall's condition holds. -/
+def deficiency (t : ι → Finset α) : ℕ :=
+  (Finset.univ : Finset (Finset ι)).sup (fun s => #s - #(s.biUnion t))
+
+/-- Every subset's deficiency is bounded by the maximum deficiency. -/
+theorem le_deficiency (t : ι → Finset α) (s : Finset ι) :
+    #s - #(s.biUnion t) ≤ deficiency t := by
+  unfold deficiency
+  exact Finset.le_sup (f := fun s => #s - #(s.biUnion t)) (Finset.mem_univ s)
+
+/-- The family satisfies the relaxed Hall condition with slack exactly `deficiency t`.
+This is the tautological "upper" witness that feeds the defect theorem. -/
+theorem hall_relaxed_of_deficiency (t : ι → Finset α) (s : Finset ι) :
+    #s ≤ #(s.biUnion t) + deficiency t := by
+  have h := le_deficiency t s
+  omega
+
+/-- **König–Ore, existence half.** There is a partial system of distinct representatives that
+leaves **at most `deficiency t`** indices unmatched. -/
+theorem konig_ore_exists (t : ι → Finset α) :
+    ∃ (e : ι → α) (rejected : Finset ι),
+      #rejected ≤ deficiency t ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i :=
+  (defect_hall t (deficiency t)).mp (hall_relaxed_of_deficiency t)
+
+/-- **König–Ore, optimality half.** *Every* partial system of distinct representatives leaves
+**at least `deficiency t`** indices unmatched. Combined with `konig_ore_exists`, the minimum
+number of unmatched indices over all partial SDRs is exactly `deficiency t`. -/
+theorem konig_ore_min (t : ι → Finset α) {e : ι → α} {rejected : Finset ι}
+    (hinj : Set.InjOn e (↑rejectedᶜ)) (hmem : ∀ i ∉ rejected, e i ∈ t i) :
+    deficiency t ≤ #rejected := by
+  -- the given partial SDR witnesses the relaxed Hall condition with slack `#rejected`
+  have hrelaxed : ∀ s : Finset ι, #s ≤ #(s.biUnion t) + #rejected :=
+    (defect_hall t (#rejected)).mpr ⟨e, rejected, le_rfl, hinj, hmem⟩
+  -- hence every deficiency is ≤ #rejected, so the maximum is too
+  apply Finset.sup_le
+  intro s _
+  have := hrelaxed s
+  omega
+
+/-- **König–Ore deficiency formula (least element form).** The minimum number of unmatched
+indices, over all partial systems of distinct representatives, is exactly `deficiency t`. -/
+theorem konig_ore_isLeast (t : ι → Finset α) :
+    IsLeast
+      {r : ℕ | ∃ (e : ι → α) (rejected : Finset ι),
+        #rejected = r ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i}
+      (deficiency t) := by
+  constructor
+  · obtain ⟨e, rejected, hle, hinj, hmem⟩ := konig_ore_exists t
+    -- pad `rejected` up to a superset of size `deficiency t` to hit the value exactly;
+    -- easier: throw away matched indices. Take the minimal witness directly from `defect_hall`
+    -- at `d = deficiency t` after showing the achieved `#rejected` equals `deficiency t`.
+    refine ⟨e, rejected, le_antisymm hle (konig_ore_min t hinj hmem), hinj, hmem⟩
+  · rintro r ⟨e, rejected, rfl, hinj, hmem⟩
+    exact konig_ore_min t hinj hmem
+
+/-- **Matching number (dual phrasing).** The largest number of indices that can be given
+distinct representatives is exactly `Fintype.card ι − deficiency t`: some partial SDR represents
+at least that many indices, and none represents more. -/
+theorem konig_matching_number (t : ι → Finset α) :
+    IsGreatest
+      {m : ℕ | ∃ (e : ι → α) (rejected : Finset ι),
+        #(rejectedᶜ) = m ∧ Set.InjOn e (↑rejectedᶜ) ∧ ∀ i ∉ rejected, e i ∈ t i}
+      (Fintype.card ι - deficiency t) := by
+  constructor
+  · -- the exact witness (#rejected = deficiency t) comes from the IsLeast statement
+    obtain ⟨e, rejected, hcard, hinj, hmem⟩ := (konig_ore_isLeast t).1
+    refine ⟨e, rejected, ?_, hinj, hmem⟩
+    have hc : #rejected + #(rejectedᶜ) = Fintype.card ι := Finset.card_add_card_compl rejected
+    omega
+  · rintro m ⟨e, rejected, rfl, hinj, hmem⟩
+    have hmin := konig_ore_min t hinj hmem
+    have hc : #rejected + #(rejectedᶜ) = Fintype.card ι := Finset.card_add_card_compl rejected
+    omega
+
+/-! ### Connection back to the classical (deficiency-free) marriage theorem -/
+
+/-- `deficiency t = 0` **iff** Hall's condition holds for every subset. -/
+theorem deficiency_eq_zero_iff (t : ι → Finset α) :
+    deficiency t = 0 ↔ ∀ s : Finset ι, #s ≤ #(s.biUnion t) := by
+  constructor
+  · intro h s
+    have := le_deficiency t s
+    omega
+  · intro h
+    have hle : deficiency t ≤ 0 := by
+      unfold deficiency
+      apply Finset.sup_le
+      intro s _
+      have := h s
+      omega
+    omega
+
+/-- **Deficiency zero characterises a full SDR.** Combining `deficiency_eq_zero_iff` with
+Mathlib's packaged marriage theorem `Finset.all_card_le_biUnion_card_iff_exists_injective`:
+the family has zero deficiency iff it admits a genuine system of distinct representatives. This
+is the `deficiency = 0` corner of the König–Ore formula and recovers classical Hall. -/
+theorem deficiency_eq_zero_iff_exists_sdr (t : ι → Finset α) :
+    deficiency t = 0 ↔ ∃ f : ι → α, Function.Injective f ∧ ∀ i, f i ∈ t i := by
+  rw [deficiency_eq_zero_iff]
+  exact Finset.all_card_le_biUnion_card_iff_exists_injective t
+
+end HallsTheoremOQ01OQ02

--- a/research/problems/halls-theorem-oq-01-oq-02/knowledge.md
+++ b/research/problems/halls-theorem-oq-01-oq-02/knowledge.md
@@ -1,0 +1,53 @@
+# Knowledge Base: halls-theorem-oq-01-oq-02
+
+## Problem Understanding
+
+Target: the **Finset formulation of Hall's theorem connecting to Hall.Basic and König.**
+The Hall gallery family already has: the bipartite graph biconditional (`HallsTheoremOQ01`),
+the qualitative Ore defect form (`HallsTheoremOQ01OQ01`, `HallsTheoremOQ02OQ01`), the
+regular-bipartite ⟹ perfect-matching corollary (`HallsTheoremOQ01OQ03`), and balanced
+one-sided Hall (`HallsTheoremOQ02`). What was missing — and explicitly listed as the open
+question of `halls-theorem-oq-01-oq-01` — is the **exact König–Ore deficiency equality**:
+the maximum partial-SDR size equals `|ι| − maxₛ(|s| − |N(s)|)`.
+
+## Result (this session)
+
+New entry `HallsTheoremOQ01OQ02.lean` (VERIFIED, 0 sorries, 0 axioms, 277L, Mathlib-only import):
+
+- `deficiency t := (univ : Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t))` — the exact
+  maximum deficiency of a finite set system.
+- `konig_ore_exists` — a partial SDR missing ≤ `deficiency t` indices exists (defect theorem at
+  the single optimal slack `d = deficiency t`).
+- `konig_ore_min` — every partial SDR misses ≥ `deficiency t` indices (any SDR is a slack
+  witness, so `deficiency t ≤ #rejected`).
+- `konig_ore_isLeast` — the minimum unmatched count is exactly `deficiency t` (IsLeast).
+- `konig_matching_number` — the matching number is exactly `Fintype.card ι − deficiency t`
+  (IsGreatest); the set-system form of König's "max matching = min vertex cover".
+- `deficiency_eq_zero_iff` / `deficiency_eq_zero_iff_exists_sdr` — zero deficiency ⟺ Hall's
+  condition ⟺ a full SDR (via Mathlib's packaged `all_card_le_biUnion_card_iff_exists_injective`),
+  recovering classical Hall.
+
+## Insights
+
+- The optimal slack does not need to be searched for: it is *named* as `deficiency t`, and the
+  relaxed Hall condition holds there tautologically by `Finset.le_sup`. Optimality is then a
+  one-line duality — any partial SDR is itself a witness that Hall holds with slack `#rejected`.
+- Making `deficiency` a `Finset.sup` over the finite powerset reduces both directions to pure
+  order theory (`le_sup` up, `sup_le` down). `apply Finset.sup_le` unfolds the `def`
+  automatically; the term-mode `le_sup` needed the function passed explicitly (`f := …`).
+- `defect_hall` was reproduced verbatim from the verified `HallsTheoremOQ01OQ01` to keep the
+  file self-contained (Mathlib-only import), since sibling `Proofs.*` oleans were not built on
+  the host and Docker was saturated.
+
+## Verification note
+
+Verified on the host via `lake env lean` against the prebuilt Mathlib oleans (no Docker: the
+fleet was saturated, disk ~100%, and concurrent builds were churning shared package oleans).
+Iterating through transient `.olean.private` races required a retry loop to hit a clean window.
+
+## Dead Ends / Deferred
+
+- A full bipartite-`SimpleGraph` König (max matching size = min vertex cover size) is a larger
+  undertaking and is NOT in Mathlib; deferred as the follow-up open question.
+- Making the deficiency-attaining subset an explicit minimum vertex cover (constructive duality)
+  is deferred.

--- a/src/data/proofs/halls-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-context-konig-ore",
+    "proofId": "halls-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "concept",
+    "title": "The König–Ore Deficiency Formula",
+    "content": "Frames the result. Hall's marriage theorem is all-or-nothing: a full system of distinct representatives (SDR) exists iff Hall's condition #s ≤ #(s.biUnion t) holds. The companion entry halls-theorem-oq-01-oq-01 proves only the qualitative defect bound ('a partial SDR missing at most d indices exists when Hall fails by at most d'). The König–Ore formula is the exact duality: the minimum number of unmatched indices over all partial SDRs equals the maximum deficiency def(t) = maxₛ(#s − #(s.biUnion t)); dually, the matching number is exactly |ι| − def(t). This is König's theorem 'max matching = min vertex cover' in set-system form, absent from Mathlib.",
+    "mathContext": "$\\min_{\\text{partial SDR}} \\#(\\text{unmatched}) = \\mathrm{def}(t) = \\max_{s}\\big(\\#s - \\#(s.\\mathrm{biUnion}\\,t)\\big)$; equivalently the matching number is $|\\iota| - \\mathrm{def}(t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hall's marriage theorem",
+      "König's theorem (max matching = min vertex cover)",
+      "system of distinct representatives",
+      "deficiency / defect",
+      "bipartite matching"
+    ],
+    "prerequisites": [
+      "Hall's condition",
+      "Ore's defect form of Hall's theorem",
+      "finite set families and Finset.biUnion"
+    ]
+  },
+  {
+    "id": "ann-defect-hall-reproduced",
+    "proofId": "halls-theorem-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 177 },
+    "type": "tactic",
+    "title": "The Defect (Ore) Biconditional, Reproduced",
+    "content": "defect_hall is the qualitative deficiency theorem — the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d holds iff there is a partial SDR leaving at most d indices unmatched. It is identical to the verified statement in halls-theorem-oq-01-oq-01 and is inlined here so this file depends only on Mathlib. The forward direction adjoins d universal dummies over α ⊕ Fin d, turning relaxed Hall for t into ordinary Hall for the enlarged family and applying Mathlib's marriage theorem; the converse is an inter/sdiff counting split. This lemma is the single engine the König formula drives at one optimal slack.",
+    "mathContext": "$\\big(\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d\\big) \\iff \\exists\\,(e, R),\\ \\#R \\le d,\\ e|_{R^c}\\text{ inj},\\ \\forall i \\notin R,\\ e\\,i \\in t\\,i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum type α ⊕ Fin d",
+      "dummy / universal vertices",
+      "Finset.all_card_le_biUnion_card_iff_exists_injective",
+      "partial system of distinct representatives"
+    ],
+    "prerequisites": [
+      "Mathlib's marriage theorem",
+      "disjoint-union cardinality",
+      "injections on finsets"
+    ]
+  },
+  {
+    "id": "ann-deficiency-def",
+    "proofId": "halls-theorem-oq-01-oq-02",
+    "range": { "startLine": 178, "endLine": 194 },
+    "type": "definition",
+    "title": "Maximum Deficiency as a Finset.sup",
+    "content": "deficiency(t) := (Finset.univ : Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t)) is the largest excess of a subset over its neighbourhood, taken over the finite powerset of ι. The empty set contributes 0 (truncated subtraction), so deficiency(t) ≥ 0 always. le_deficiency records the defining upper-bound property (Finset.le_sup), and hall_relaxed_of_deficiency turns it into the relaxed Hall condition with slack exactly deficiency(t) — the tautological witness that the defect theorem is fed at the optimal slack.",
+    "mathContext": "$\\mathrm{def}(t) = \\bigsqcup_{s \\subseteq \\iota}\\big(\\#s - \\#(s.\\mathrm{biUnion}\\,t)\\big)$; hence $\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + \\mathrm{def}(t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sup",
+      "truncated natural subtraction",
+      "Hall deficiency"
+    ],
+    "prerequisites": [
+      "Finset.sup as a least upper bound",
+      "Finset.le_sup"
+    ]
+  },
+  {
+    "id": "ann-konig-formula",
+    "proofId": "halls-theorem-oq-01-oq-02",
+    "range": { "startLine": 195, "endLine": 253 },
+    "type": "tactic",
+    "title": "The Formula: Existence, Optimality, Matching Number",
+    "content": "konig_ore_exists applies defect_hall at d = deficiency(t): a partial SDR missing at most deficiency(t) indices exists. konig_ore_min is the dual half — any partial SDR missing a set 'rejected' is itself a witness that relaxed Hall holds with slack #rejected (converse of defect_hall), so every subset deficiency ≤ #rejected and, taking the sup (Finset.sup_le), deficiency(t) ≤ #rejected. The two bounds pin the minimum unmatched count to deficiency(t), packaged as konig_ore_isLeast (IsLeast). konig_matching_number translates unmatched-count to represented-count via #rejected + #rejectedᶜ = Fintype.card ι, giving the matching number |ι| − deficiency(t) as an IsGreatest.",
+    "mathContext": "Existence: $\\exists$ SDR missing $\\le \\mathrm{def}(t)$. Optimality: any SDR misses $\\ge \\mathrm{def}(t)$. Matching number: $\\max\\#\\{\\text{matched}\\} = |\\iota| - \\mathrm{def}(t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsLeast / IsGreatest",
+      "Finset.sup_le",
+      "Finset.card_add_card_compl",
+      "König duality"
+    ],
+    "prerequisites": [
+      "the defect biconditional defect_hall",
+      "Finset.sup least-upper-bound property",
+      "complement cardinality in a Fintype"
+    ]
+  },
+  {
+    "id": "ann-deficiency-zero",
+    "proofId": "halls-theorem-oq-01-oq-02",
+    "range": { "startLine": 254, "endLine": 277 },
+    "type": "concept",
+    "title": "Zero Deficiency Recovers Classical Hall",
+    "content": "deficiency_eq_zero_iff shows deficiency(t) = 0 iff Hall's condition holds for every subset (the sup of nonnegative terms is 0 iff each term is 0). deficiency_eq_zero_iff_exists_sdr then chains this with Mathlib's packaged marriage theorem Finset.all_card_le_biUnion_card_iff_exists_injective to conclude deficiency(t) = 0 iff a full system of distinct representatives exists. This is the zero-deficiency corner of the formula and a built-in consistency check that the König–Ore duality generalises classical Hall.",
+    "mathContext": "$\\mathrm{def}(t) = 0 \\iff (\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t)) \\iff \\exists f\\ \\text{injective},\\ \\forall i,\\ f\\,i \\in t\\,i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Hall's condition",
+      "system of distinct representatives",
+      "Finset.all_card_le_biUnion_card_iff_exists_injective"
+    ],
+    "prerequisites": [
+      "Mathlib's packaged marriage theorem",
+      "sup = 0 iff all terms 0"
+    ]
+  }
+]

--- a/src/data/proofs/halls-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "halls-theorem-oq-01-oq-02",
+  "title": "The König–Ore Deficiency Formula: the Exact Matching Number of a Set System",
+  "slug": "halls-theorem-oq-01-oq-02",
+  "description": "The companion entry halls-theorem-oq-01-oq-01 proves Ore's qualitative defect theorem: if Hall's condition fails by at most d, a partial system of distinct representatives (SDR) missing at most d indices exists. That entry's own open question asks to sharpen this to Ore's exact equality — the maximum partial-SDR size equals |ι| − maxₛ(|s| − |N(s)|), extracting the optimal slack rather than an a-priori bound. This entry supplies exactly that. We define the maximum deficiency deficiency(t) = ⨆ₛ (#s − #(s.biUnion t)) as a Finset.sup over all subsets, and prove the König–Ore deficiency formula: the minimum number of indices left unmatched over all partial SDRs equals deficiency(t). The existence half (konig_ore_exists) applies the defect theorem at the single optimal slack d = deficiency(t), where the relaxed Hall condition holds tautologically; the optimality half (konig_ore_min) observes that any partial SDR missing r indices witnesses relaxed Hall with slack r, forcing every deficiency ≤ r and hence deficiency(t) ≤ r. Packaged as IsLeast (konig_ore_isLeast) and dually as the matching number IsGreatest (konig_matching_number: the largest number of representable indices is exactly |ι| − deficiency(t)). The deficiency = 0 corner (deficiency_eq_zero_iff_exists_sdr) recovers classical Hall via Mathlib's packaged Finset.all_card_le_biUnion_card_iff_exists_injective, tying the formula back to the marriage theorem. This is the set-system form of König's theorem 'max matching = min vertex cover', which is absent from Mathlib.",
+  "meta": {
+    "author": "Dénes Kőnig / Øystein Ore (deficiency form); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem#Defect_version",
+    "date": "1955",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "matching",
+      "halls-marriage-theorem",
+      "systems-of-distinct-representatives",
+      "deficiency",
+      "konig-theorem"
+    ],
+    "proofRepoPath": "Proofs/HallsTheoremOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 279,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.all_card_le_biUnion_card_iff_exists_injective",
+        "description": "Mathlib's marriage theorem for an indexed family of finite sets: Hall's condition ∀ s, #s ≤ #(s.biUnion t) iff there is an injective system of distinct representatives. Used inside the reproduced defect_hall (via the α ⊕ Fin d reduction) and directly in deficiency_eq_zero_iff_exists_sdr to tie deficiency = 0 to a full SDR.",
+        "module": "Mathlib.Combinatorics.Hall.Basic"
+      },
+      {
+        "theorem": "Finset.le_sup",
+        "description": "An element is bounded by the sup of a family over a finset. Gives le_deficiency: every subset's deficiency #s − #(s.biUnion t) is ≤ the maximum deficiency deficiency(t).",
+        "module": "Mathlib.Order.Lattice"
+      },
+      {
+        "theorem": "Finset.sup_le",
+        "description": "The sup is the least upper bound. Powers konig_ore_min and deficiency_eq_zero_iff: from a per-subset bound on the deficiency, conclude a bound on the maximum deficiency deficiency(t).",
+        "module": "Mathlib.Order.Lattice"
+      },
+      {
+        "theorem": "Finset.card_add_card_compl",
+        "description": "#(rejected) + #(rejectedᶜ) = Fintype.card ι, converting between the count of unmatched indices and the count of represented indices in konig_matching_number.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection on a finset bounds card. Used in the reproduced defect_hall to bound #rejected by the d dummies and to bound #(s \\ rejected) by #(s.biUnion t).",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "deficiency(t) := ⨆ₛ (#s − #(s.biUnion t)) as a Finset.sup over all subsets s ⊆ ι, the exact obstruction quantity of a finite set system.",
+      "konig_ore_exists: a partial SDR leaving at most deficiency(t) indices unmatched exists — obtained by applying the defect theorem at the single optimal slack d = deficiency(t), where the relaxed Hall condition holds by construction (hall_relaxed_of_deficiency).",
+      "konig_ore_min: every partial SDR leaves at least deficiency(t) indices unmatched — any partial SDR missing r indices witnesses relaxed Hall with slack r, so every subset deficiency is ≤ r and hence deficiency(t) ≤ r. Together with konig_ore_exists this is the exact König–Ore deficiency formula (packaged as IsLeast in konig_ore_isLeast).",
+      "konig_matching_number: the dual matching-number phrasing — the largest number of indices admitting distinct representatives is exactly Fintype.card ι − deficiency(t), stated as an IsGreatest. This is the set-system form of König's theorem 'max matching = min vertex cover', absent from Mathlib.",
+      "deficiency_eq_zero_iff and deficiency_eq_zero_iff_exists_sdr: deficiency(t) = 0 iff Hall's condition holds iff a full SDR exists, recovering classical Hall (via Mathlib's packaged marriage theorem) as the zero-deficiency corner of the formula."
+    ],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Philip Hall's marriage theorem (1935) is all-or-nothing: a finite family of finite sets has a full system of distinct representatives exactly when Hall's condition holds. Dénes Kőnig (1931) and Øystein Ore (1955) refined it into a quantitative duality — the deficiency form — measuring the largest partial matching. In the set-system language, the maximum number of indices that can be given distinct representatives equals |ι| minus the maximum deficiency maxₛ(|s| − |N(s)|). This is precisely König's theorem 'in a bipartite graph, the maximum matching equals the minimum vertex cover' transported to families of sets. The formula is the workhorse behind bipartite matching algorithms, assignment problems, and the deficiency version of the max-flow/min-cut duality. Mathlib formalises only the exact (deficiency 0) marriage theorem, and the previous gallery entry (halls-theorem-oq-01-oq-01) proves only the qualitative bound 'missing at most d'; the exact optimal formula was left as that entry's stated open question.",
+    "problemStatement": "Let $t : \\iota \\to \\mathrm{Finset}\\,\\alpha$ be a finite family of finite sets over a nonempty ground type. Define the maximum deficiency\n\n$$\\mathrm{def}(t) \\;=\\; \\max_{s \\subseteq \\iota} \\Big(|s| - \\Big|\\textstyle\\bigcup_{i \\in s} t\\,i\\Big|\\Big)$$\n\n(truncated subtraction, so $\\mathrm{def}(t) \\ge 0$). Show that the minimum number of indices left unrepresented, over every partial system of distinct representatives, equals $\\mathrm{def}(t)$; equivalently the maximum number of indices that admit distinct representatives is exactly $|\\iota| - \\mathrm{def}(t)$. Recover Hall's marriage theorem as the case $\\mathrm{def}(t) = 0$.",
+    "proofStrategy": "The engine is the defect (Ore) biconditional defect_hall — the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d holds iff a partial SDR missing at most d indices exists — reproduced self-containedly here (the α ⊕ Fin d dummy-adjunction argument, verified in halls-theorem-oq-01-oq-01). Existence (konig_ore_exists): evaluate defect_hall at the single optimal slack d = def(t). The relaxed Hall condition holds there tautologically (hall_relaxed_of_deficiency), because #s − #(s.biUnion t) ≤ def(t) by definition of the sup (le_deficiency), so a partial SDR missing at most def(t) indices exists. Optimality (konig_ore_min): given any partial SDR missing a set 'rejected' of indices, the converse direction of defect_hall shows the relaxed Hall condition holds with slack #rejected; hence for every s, #s − #(s.biUnion t) ≤ #rejected, and taking the sup (Finset.sup_le) gives def(t) ≤ #rejected. The two bounds pin the minimum to def(t) (konig_ore_isLeast), and translating unmatched-count to represented-count via #rejected + #rejectedᶜ = card ι gives the matching-number form (konig_matching_number).",
+    "keyInsights": [
+      "The optimal slack is not searched for — it is named: d = def(t) is the exact deficiency, and the relaxed Hall condition holds there for free by the very definition of the maximum as a Finset.sup.",
+      "Optimality is a one-line duality: any partial SDR is itself a witness that Hall holds with slack #rejected, so it cannot beat the maximum deficiency — no separate extremal construction is needed.",
+      "Defining def(t) as a Finset.sup over the (finite) powerset of ι makes both directions pure order theory: le_sup for the upper witness, sup_le for the lower bound.",
+      "The matching number |ι| − def(t) is König's 'max matching = min vertex cover' in set-system form; the vertex cover is implicit in the deficiency-attaining subset.",
+      "The deficiency = 0 corner collapses to Hall's condition and, through Mathlib's packaged marriage theorem, to the existence of a full SDR — a built-in consistency check that the formula generalises classical Hall."
+    ],
+    "prerequisites": [
+      "Hall's marriage theorem and systems of distinct representatives (Finset.all_card_le_biUnion_card_iff_exists_injective)",
+      "Ore's defect / deficiency form of Hall's theorem (the partial-SDR biconditional)",
+      "Finset.sup as a least upper bound over a finite family (Finset.le_sup, Finset.sup_le)",
+      "Finset cardinality, complements and Fintype.card (Finset.card_add_card_compl), truncated natural subtraction"
+    ]
+  },
+  "conclusion": {
+    "summary": "We formalised the König–Ore deficiency formula in the Finset / SDR setting: the minimum number of indices any partial system of distinct representatives must leave unrepresented equals the maximum deficiency def(t) = ⨆ₛ (#s − #(s.biUnion t)); dually, the matching number — the largest number of representable indices — is exactly Fintype.card ι − def(t). The proof applies the reproduced defect (Ore) biconditional at the single optimal slack d = def(t) for existence, and uses that every partial SDR is a slack witness for optimality, packaging the result as IsLeast and IsGreatest. The deficiency = 0 case recovers classical Hall through Mathlib's packaged marriage theorem. All results are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "This answers the exact-equality open question posed by halls-theorem-oq-01-oq-01, upgrading the qualitative 'missing at most d' bound to the sharp min = max deficiency duality. It gives Mathlib users the matching number of a set system as a closed formula, with the deficiency-attaining subset serving as an optimality certificate. The result is the set-system form of König's theorem and the natural bridge from the indexed-family Hall theorem toward the bipartite max-matching / min-vertex-cover duality.",
+    "openQuestions": [
+      "Transport the deficiency formula to the bipartite SimpleGraph framework of halls-theorem-oq-01 and state König's theorem there as maximum matching size = minimum vertex cover size.",
+      "Exhibit the deficiency-attaining subset explicitly as a minimum vertex cover, making the max-matching/min-cover duality constructive rather than existential."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Imports (Mathlib only, so the file is self-contained), an expository docstring situating the König–Ore deficiency formula against Mathlib's exact marriage theorem and the companion qualitative defect entry, and the namespace/variable setup (Fintype ι, DecidableEq, Nonempty α)."
+    },
+    {
+      "id": "defect-hall",
+      "title": "The Defect (Ore) Biconditional, Reproduced",
+      "startLine": 62,
+      "endLine": 173,
+      "summary": "defect_hall — the relaxed Hall condition ∀ s, #s ≤ #(s.biUnion t) + d iff a partial SDR missing at most d indices, identical to the verified halls-theorem-oq-01-oq-01 statement and inlined so this file depends only on Mathlib. Forward: the α ⊕ Fin d reduction; converse: the inter/sdiff counting split."
+    },
+    {
+      "id": "deficiency-and-konig",
+      "title": "The Deficiency and the König–Ore Formula",
+      "startLine": 174,
+      "endLine": 251,
+      "summary": "deficiency(t) as a Finset.sup; le_deficiency and hall_relaxed_of_deficiency (the tautological upper witness); konig_ore_exists (partial SDR missing ≤ def(t)); konig_ore_min (every partial SDR misses ≥ def(t)); konig_ore_isLeast (the exact minimum) and konig_matching_number (the dual matching number |ι| − def(t) as an IsGreatest)."
+    },
+    {
+      "id": "deficiency-zero",
+      "title": "Connection to Classical Hall",
+      "startLine": 252,
+      "endLine": 279,
+      "summary": "deficiency_eq_zero_iff (def(t) = 0 iff Hall's condition holds) and deficiency_eq_zero_iff_exists_sdr (def(t) = 0 iff a full SDR exists, via Mathlib's packaged marriage theorem), recovering classical Hall as the zero-deficiency corner of the formula."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "halls-theorem-oq-01-oq-01",
+      "relation": "Answers this entry's stated open question — sharpening Ore's qualitative 'missing at most d' defect theorem to the exact min = max-deficiency equality — and reuses its defect_hall biconditional."
+    },
+    {
+      "slug": "halls-theorem-oq-01",
+      "relation": "The parent bipartite Hall biconditional; this entry supplies the exact deficiency / König duality in the Finset formulation of that family."
+    }
+  ],
+  "references": [
+    {
+      "text": "Ore, Ø. (1955). Graphs and matching theorems. Duke Mathematical Journal, 22(4), 625–639.",
+      "url": "https://doi.org/10.1215/S0012-7094-55-02268-7"
+    },
+    {
+      "text": "Kőnig, D. (1931). Gráfok és mátrixok. Matematikai és Fizikai Lapok, 38, 116–119.",
+      "url": "https://en.wikipedia.org/wiki/K%C5%91nig%27s_theorem_(graph_theory)"
+    },
+    {
+      "text": "Hall's marriage theorem — defect version.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem#Defect_version"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Function"
+    ],
+    "namespace": "HallsTheoremOQ01OQ02",
+    "lineCount": 279,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HallsTheoremOQ01OQ02.lean",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/halls-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/halls-theorem-oq-01-oq-02.json
@@ -1,0 +1,129 @@
+{
+  "slug": "halls-theorem-oq-01-oq-02",
+  "title": "Finite Finset formulation of Hall's theorem connecting to Hall.Basic and König",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\forall\\, T \\subseteq \\iota,\\quad |T| \\le \\Big|\\bigcup_{i \\in T} S(i)\\Big|.",
+    "plain": "Hall's theorem characterizes when a family of finite sets admits a \"matching\" (a distinct representative from each set): exactly when no collection of $k$ sets is confined to fewer than $k$ total elements. This problem specializes any more abstract in-repo Hall statement to the concrete finite `Finset` version and links it to Mathlib's packaged combinatorial form and to König's theorem.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-02T15:04:52-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: New verified entry HallsTheoremOQ01OQ02 (279L, 0 sorry/0 axiom) proving the König–Ore deficiency formula — min unmatched over partial SDRs = max deficiency def(t); matching number = |ι| − def(t). Answers the exact-equality open question of halls-theorem-oq-01-oq-01.",
+    "builtItems": [
+      "deficiency, le_deficiency, hall_relaxed_of_deficiency in Proofs/HallsTheoremOQ01OQ02.lean",
+      "konig_ore_exists / konig_ore_min / konig_ore_isLeast (König–Ore deficiency formula, IsLeast)",
+      "konig_matching_number (matching number |ι| − def(t) as IsGreatest — set-system König)",
+      "deficiency_eq_zero_iff / deficiency_eq_zero_iff_exists_sdr (recovers classical Hall via Mathlib packaged form)"
+    ],
+    "insights": [
+      "def(t) := (univ:Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t)) makes both directions pure order theory: Finset.le_sup up, Finset.sup_le down.",
+      "The optimal defect slack is named, not searched: applying the qualitative defect theorem at d = def(t) gives existence for free; any partial SDR is a slack witness, giving optimality def(t) ≤ #rejected.",
+      "term-mode Finset.le_sup needs f passed explicitly (f := …); apply Finset.sup_le unfolds the deficiency def automatically.",
+      "konig_matching_number needs the EXACT witness (#rejected = def(t)) from konig_ore_isLeast, not the ≤ witness from konig_ore_exists."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Transport the deficiency formula to the bipartite SimpleGraph framework; state König as max matching size = min vertex cover size.",
+      "Exhibit the deficiency-attaining subset as an explicit minimum vertex cover (constructive duality)."
+    ],
+    "markdown": "# Knowledge Base: halls-theorem-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "halls-theorem",
+    "matching",
+    "konigs-theorem"
+  ],
+  "relatedProofs": [
+    "halls-theorem-oq-01",
+    "halls-theorem-oq-01-oq-01",
+    "halls-theorem-oq-01-oq-03",
+    "halls-theorem-oq-02",
+    "halls-theorem-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T22:35:30.706Z",
+  "lastUpdate": "2026-07-02T22:35:30.767Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/HallsTheoremOQ01.lean",
+      "filename": "HallsTheoremOQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallsTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/HallsTheoremOQ01OQ01.lean",
+      "filename": "HallsTheoremOQ01OQ01.lean",
+      "lineCount": 199,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallsTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/HallsTheoremOQ01OQ03.lean",
+      "filename": "HallsTheoremOQ01OQ03.lean",
+      "lineCount": 151,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallsTheoremOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/HallsTheoremOQ02.lean",
+      "filename": "HallsTheoremOQ02.lean",
+      "lineCount": 111,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallsTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/HallsTheoremOQ02OQ01.lean",
+      "filename": "HallsTheoremOQ02OQ01.lean",
+      "lineCount": 180,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallsTheoremOQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
New verified gallery entry for `halls-theorem-oq-01-oq-02`, proving the **König–Ore deficiency formula** in the Finset / SDR setting. This directly answers the stated open question of the companion entry `halls-theorem-oq-01-oq-01` ("sharpen Ore's qualitative defect bound to the exact equality: max partial-SDR size = |ι| − maxₛ(|s| − |N(s)|)").

## What it proves (`Proofs/HallsTheoremOQ01OQ02.lean`, 279L, 9 thm / 1 def, 0 sorry, 0 axiom)
- `deficiency t := (univ : Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t))` — the exact maximum deficiency of a finite set system.
- `konig_ore_exists` — a partial SDR missing **at most** `deficiency t` indices exists (defect theorem at the single optimal slack `d = deficiency t`).
- `konig_ore_min` — **every** partial SDR misses **at least** `deficiency t` indices (any SDR is itself a slack witness).
- `konig_ore_isLeast` — the minimum unmatched count is exactly `deficiency t` (`IsLeast`).
- `konig_matching_number` — the matching number is exactly `Fintype.card ι − deficiency t` (`IsGreatest`): the set-system form of König's "max matching = min vertex cover", absent from Mathlib.
- `deficiency_eq_zero_iff` / `deficiency_eq_zero_iff_exists_sdr` — zero deficiency ⟺ Hall's condition ⟺ a full SDR (via Mathlib's packaged `Finset.all_card_le_biUnion_card_iff_exists_injective`), recovering classical Hall.

The qualitative defect biconditional (`defect_hall`, the `α ⊕ Fin d` dummy-adjunction argument, verified in `halls-theorem-oq-01-oq-01`) is reproduced inline so the file imports only Mathlib.

## Verification
Compiled cleanly on the host via `lake env lean` against the prebuilt Mathlib oleans (`EXIT=0`, 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide`). The Docker fleet was saturated (disk ~100%, concurrent builds churning shared package oleans), so a retry loop was used to hit a clean host-verification window.

## Status
**Outcome**: completed (new verified entry)
**Next steps**: transport the deficiency formula to the bipartite `SimpleGraph` framework and state König as max matching size = min vertex cover size; make the deficiency-attaining subset an explicit minimum vertex cover.

🤖 Generated by researcher-14