### PR TITLE
Enrich de Bruijn–Erdős line-count sandwich (erdos-606-oq-03-wip-01)

### DIFF
--- a/src/data/proofs/erdos-606-oq-03-wip-01/annotations.json
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/annotations.json
@@ -94,5 +94,29 @@
       "deBruijn_erdos",
       "card_le_choose_two"
     ]
+  },
+  {
+    "id": "ann-erdos606-oq03-wip01-axiom-audit",
+    "proofId": "erdos-606-oq-03-wip-01",
+    "range": {
+      "startLine": 116,
+      "endLine": 117
+    },
+    "type": "technique",
+    "title": "Axiom Audit: Confirming the 0-Axiom Claim",
+    "content": "The two `#print axioms` directives are not decoration — they are the machine-checked evidence for the entry's `status: \"verified\"` / `axiomCount: 0` claim. Running them on line_count_sandwich and card_le_choose_two reports only the three foundational axioms propext, Classical.choice, and Quot.sound, none of which counts as a mathematical assumption under the project's axiom-integrity policy. Crucially, no sorry (sorryAx) and no native_decide (Lean.ofReduceBool) appear, so the sandwich is fully kernel-checked. The only genuine mathematical hypotheses are the *typeclass* assumptions [HasLines P L] and the htwo premise ('every line meets ≥ 2 points') — these are stated as explicit binders, not hidden axioms, so they travel with the theorem statement rather than weakening its trust base. Auditing both the top result and the original lemma (not just the headline) guards against a delegated sub-proof smuggling in an axiom.",
+    "mathContext": "$\\#\\text{axioms} = \\{\\texttt{propext},\\ \\texttt{Classical.choice},\\ \\texttt{Quot.sound}\\}$; no $\\texttt{sorryAx}$, no $\\texttt{Lean.ofReduceBool}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom auditing",
+      "kernel verification",
+      "foundational axioms",
+      "typeclass hypotheses vs axioms"
+    ],
+    "prerequisites": [
+      "#print axioms",
+      "Lean's trusted kernel",
+      "the propext / Classical.choice / Quot.sound foundation"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
@@ -64,7 +64,8 @@
       "The 'at least n lines' bound is de Bruijn–Erdős (1948), not Sylvester–Gallai; Mathlib already proves it abstractly as Configuration.HasLines.card_le",
       "The abstract HasLines hypothesis ('any two points determine a unique line') is exactly the incidence axiom satisfied by a finite, not-all-collinear planar point set, so the abstract theorem specialises directly to Erdős 606",
       "The upper bound C(n,2) follows from a single observation: distinct lines carry distinct point-pairs, because two points determine at most one line — the same uniqueness axiom that powers the lower bound",
-      "Replacing prose claims with verified theorems is itself the contribution here: the parent entry only asserted these bounds in comments"
+      "Replacing prose claims with verified theorems is itself the contribution here: the parent entry only asserted these bounds in comments",
+      "The formalization is fully abstract: P and L are arbitrary types with a Membership relation, so the sandwich holds for *any* nondegenerate HasLines incidence structure — finite projective planes, generalized quadrangles, or block designs — not just points and lines in ℝ². The planar Erdős-606 statement is one specialization of a strictly more general theorem."
     ],
     "prerequisites": [
       "Incidence geometry (points, lines, and their incidence relation)",


### PR DESCRIPTION
Enrichment pass for `erdos-606-oq-03-wip-01` (The de Bruijn–Erdős Lower Bound and the Line-Count Sandwich).

## Changes
- **Annotation coverage**: added a 5th annotation covering the previously-uncovered `#print axioms` audit block (lines 116–117). It explains the machine-checked evidence behind the `status: verified` / `axiomCount: 0` claim, notes the absence of `sorryAx` / `Lean.ofReduceBool`, and clarifies that `[HasLines P L]` and the `htwo` premise are explicit typeclass/hypothesis binders rather than hidden axioms.
- **keyInsight**: added a 5th insight highlighting that the proof is fully abstract over arbitrary types `P, L` with a `Membership` relation, so the sandwich applies to any nondegenerate `HasLines` incidence structure (finite projective planes, generalized quadrangles, block designs), not just points/lines in ℝ².

Reaches the ≥5-annotation and ≥5-keyInsight quality targets. meta.json remains 12.5 KB (well under the 60 KB cap). JSON validated.