### PR TITLE
Enrich Frobenius imperfect-field entry (frobenius-endomorphism-oq-01-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/annotations.json
@@ -75,5 +75,27 @@
       "PerfectField ⇒ PerfectRing",
       "surjective_frobenius"
     ]
+  },
+  {
+    "id": "ann-degree-obstruction",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 60 },
+    "type": "technique",
+    "title": "The Degree Obstruction: p·deg = 1 Is Impossible",
+    "content": "A single arithmetic observation drives both halves of the file. If X were a p-th power, X = fᵖ, then taking degrees and using multiplicativity of degree under powers gives p · deg(f) = deg(X) = 1, so p ∣ 1 — impossible for a prime p ≥ 2. The elegance is that the *same* argument runs in two different degree rings: over the polynomial ring 𝔽ₚ[X] the degree is ℕ-valued (Polynomial.natDegree, natDegree_pow), while over the fraction field 𝔽ₚ(X) it becomes ℤ-valued (RatFunc.intDegree, the in-file intDegree_pow), yet both collapse to the divisibility p ∣ 1. This is why imperfectness is not an accident of one construction but a robust degree phenomenon: any characteristic-p field carrying a nonzero-degree element whose degree is coprime-obstructed cannot have that element as a p-th power. Note the contrast with Frobenius *injectivity*, which holds automatically on any reduced ring — so the entire obstruction to perfectness is concentrated in surjectivity, and surjectivity fails for exactly this degree reason.",
+    "mathContext": "$f^p = X \\Rightarrow p\\cdot\\deg f = \\deg X = 1 \\Rightarrow p \\mid 1$, contradicting $p \\ge 2$. Same argument over $\\mathbb{N}$ (\\texttt{natDegree}) and $\\mathbb{Z}$ (\\texttt{intDegree}).",
+    "significance": "key",
+    "relatedConcepts": [
+      "degree of a polynomial",
+      "intDegree of a rational function",
+      "multiplicativity of degree under powers",
+      "divisibility obstruction",
+      "Frobenius injectivity vs surjectivity"
+    ],
+    "prerequisites": [
+      "Polynomial.natDegree_pow",
+      "RatFunc.intDegree",
+      "prime divisibility (p ∣ 1 ⇒ p = 1)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `frobenius-endomorphism-oq-01-oq-02-oq-02` (𝔽ₚ(X) as an explicit imperfect field).

## Changes
- **Annotation coverage**: added a 5th annotation, `ann-degree-obstruction`, a focused *technique* callout on the arithmetic engine shared by both halves of the file — `fᵖ = X ⇒ p·deg(f) = 1 ⇒ p ∣ 1`, impossible for a prime. Highlights that the identical argument runs over both the ℕ-valued `natDegree` (polynomial ring 𝔽ₚ[X]) and the ℤ-valued `intDegree` (fraction field 𝔽ₚ(X)), and contrasts it with the automatic Frobenius *injectivity* on reduced rings — so imperfectness is concentrated entirely in surjectivity.

Reaches the ≥5-annotation quality target (keyInsights already at 5). meta.json unchanged at 23 KB (under cap). JSON validated.