### PR TITLE
Enrich König–Egerváry Hall entry (hall-marriage-theorem-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/annotations.json
@@ -46,5 +46,17 @@
     "significance": "key",
     "relatedConcepts": ["Finset.exists_min_image", "defect Hall theorem", "deficiency minimiser", "primal–dual certificate"],
     "prerequisites": ["min over a finite family", "natural-number subtraction", "le_antisymm"]
+  },
+  {
+    "id": "ann-certificate-optimality",
+    "proofId": "hall-marriage-theorem-oq-01-oq-02",
+    "range": { "startLine": 178, "endLine": 186 },
+    "type": "insight",
+    "title": "Certificate ⇒ Optimality: One Lemma, Applied Twice",
+    "content": "The two final proof obligations — that the exhibited matching is *maximum* and the exhibited cover is *minimum* — are discharged by a single reusable fact, `matching_card_le_cover` (weak duality: every matching is no larger than every cover), invoked twice in opposite directions. For maximality: any competitor matching J' satisfies #J' ≤ #(cover) = #J, so nothing beats J. For minimality: any competitor cover (A', B') satisfies #J ≤ #A' + #B', and since #J equals the exhibited cover's size, no cover is smaller. This is the abstract engine of *all* LP-duality optimality proofs: once you own a primal feasible solution and a dual feasible solution of equal objective value, weak duality alone forces both to be optimal — no separate 'maximisation' or 'minimisation' argument, and no strong-duality theorem, is ever needed. The equal-size certificate does the whole job.",
+    "mathContext": "$\\forall J',\\ \\#J' \\le \\#\\text{cover} = \\#J$ and $\\forall (A',B'),\\ \\#J = \\#\\text{cover} \\le \\#A' + \\#B'$ — optimality of both from weak duality at a shared value.",
+    "significance": "key",
+    "relatedConcepts": ["weak duality", "LP duality", "primal–dual optimality certificate", "complementary slackness"],
+    "prerequisites": ["matching_card_le_cover", "le_trans", "the certificate principle for optimality"]
   }
 ]

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/meta.json
@@ -64,7 +64,8 @@
       "**Duality without a separate min–max machine.** König is packaged in certificate form — exhibit a matching and a cover of equal size — so the 'maximum' and 'minimum' are certified by weak duality alone, sidestepping any explicit construction of the optimisation values.",
       "**The optimal cover sits at the deficiency minimiser.** Minimising the cover size #(ι \\ s) + #N(s) over subsets s simultaneously (i) produces the smallest cover and (ii) hands the defect-Hall theorem the exact deficiency parameter d = #s − #N(s) needed to match it.",
       "**Minimality kills the ℕ-subtraction trap.** A priori #N(s) − #s could truncate in ℕ; but the minimiser satisfies #N(s) ≤ #s (else s = ∅ would be a strictly smaller cover), so cover size = #ι − d is an exact identity rather than an inequality.",
-      "**Weak duality is a one-line injection.** Each matched index is covered on exactly one endpoint; sending it to that endpoint (left into A, or right through the injective f into B) is injective into A ⊕ B, giving #matching ≤ #cover with no case explosion."
+      "**Weak duality is a one-line injection.** Each matched index is covered on exactly one endpoint; sending it to that endpoint (left into A, or right through the injective f into B) is injective into A ⊕ B, giving #matching ≤ #cover with no case explosion.",
+      "**Optimality is certified, never optimised.** Both extremality clauses — the matching is maximum, the cover is minimum — are proved by invoking the single weak-duality lemma `matching_card_le_cover` twice: any matching J' obeys #J' ≤ #cover = #J, and any cover (A',B') obeys #J = #cover ≤ #A' + #B'. This is the universal primal–dual pattern: a feasible primal and feasible dual of equal value are automatically both optimal, so no strong-duality theorem is required."
     ],
     "exampleSections": [
       {


### PR DESCRIPTION
Enrichment pass for `hall-marriage-theorem-oq-01-oq-02` (König–Egerváry min–max duality from defect Hall).

## Changes
- **Annotation coverage**: added a 5th annotation, `ann-certificate-optimality`, focused on the theorem's closing move — both extremality clauses (the matching is *maximum*, the cover is *minimum*) are discharged by invoking the weak-duality lemma `matching_card_le_cover` twice in opposite directions. Frames it as the universal primal–dual certificate principle (feasible primal + feasible dual of equal value ⇒ both optimal, no strong-duality theorem needed).
- **keyInsight**: added a matching 5th keyInsight ('optimality is certified, never optimised').

Reaches the ≥5-annotation and ≥5-keyInsight quality targets. meta.json 17.4 KB (well under cap). JSON validated.