### PR TITLE
research(shannon-source-coding-wip-01-oq-01): H(p^⊗n)=n·H(p), n-fold i.i.d. entropy rate [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingWIP01OQ01.lean
+++ b/proofs/Proofs/ShannonSourceCodingWIP01OQ01.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+  # Entropy of an `n`-fold i.i.d. source: `H(p^{⊗n}) = n · H(p)`
+
+  The parent file `ShannonSourceCodingWIP01` proves **pairwise additivity** of
+  Shannon entropy for independent sources,
+
+      H(pX ⊗ pY) = H(pX) + H(pY)      (product distribution `pXY(x,y) = pX x · pY y`).
+
+  This file **iterates** that identity to the `n`-fold i.i.d. product. For a
+  distribution `p : α → ℝ` normalised by `∑ₐ p a = 1`, the product distribution
+
+      p^{⊗n}(x) = ∏ᵢ p (xᵢ)          (`x : Fin n → α`)
+
+  has entropy
+
+      H(p^{⊗n}) = n · H(p).
+
+  This is the source-coding statement that a block of `n` i.i.d. symbols carries
+  `n · H(p)` bits — the quantitative backbone of the AEP and of the rate `H` in
+  Shannon's source coding theorem.
+
+  The proof is a clean induction on `n` along the tuple recursion
+  `Fin (n+1) → α ≃ α × (Fin n → α)` (`Fin.consEquiv`): splitting off the first
+  coordinate turns `p^{⊗(n+1)}` into the product distribution `p ⊗ p^{⊗n}`, so
+  the pairwise additivity `entropy_prod` (reproved locally to keep the file
+  self-contained) contributes one `H(p)` at each step. Normalisation of the
+  product distribution (`sum_prodDist`, `∑ₓ ∏ᵢ p (xᵢ) = (∑ₐ p a)^n`) supplies the
+  hypothesis `∑ p^{⊗n} = 1` that the additivity step consumes.
+
+  ## Results
+  * `entropy_prod`  : `H(pX ⊗ pY) = H(pX) + H(pY)` (pairwise, parent's result).
+  * `sum_prodDist`  : `∑ₓ ∏ᵢ p (xᵢ) = (∑ₐ p a)^n` (product distribution is
+    normalised when `p` is).
+  * `entropy_pow`   : **`H(p^{⊗n}) = n · H(p)`** for a normalised `p`.
+
+  `0` axioms.
+-/
+
+namespace ShannonSourceCodingWIP01OQ01
+
+open Real Finset
+
+variable {α : Type*} [Fintype α]
+
+/-- Shannon entropy in `negMulLog` form (as in the parent `ShannonSourceCodingWIP01`):
+`H(p) = ∑ₓ negMulLog (p x)`, agreeing with the standard `-∑ₓ p x · log (p x)`. -/
+noncomputable def entropy (p : α → ℝ) : ℝ := ∑ x, Real.negMulLog (p x)
+
+/-- **Pairwise additivity of entropy for independent sources.** For a product
+distribution `pXY(x,y) = pX x · pY y` with `∑ pX = ∑ pY = 1`,
+
+  `H(pX ⊗ pY) = H(pX) + H(pY)`.
+
+This is the parent file's `entropy_prod`, reproved locally so this file is
+self-contained; it is the atomic step iterated by `entropy_pow`. -/
+theorem entropy_prod {β : Type*} [Fintype β] (pX : α → ℝ) (pY : β → ℝ)
+    (hX : ∑ x, pX x = 1) (hY : ∑ y, pY y = 1) :
+    entropy (fun xy : α × β => pX xy.1 * pY xy.2) = entropy pX + entropy pY := by
+  unfold entropy
+  rw [Fintype.sum_prod_type]
+  have key : ∀ x, (∑ y, Real.negMulLog (pX x * pY y))
+      = Real.negMulLog (pX x) + pX x * ∑ y, Real.negMulLog (pY y) := by
+    intro x
+    simp_rw [Real.negMulLog_mul]
+    rw [Finset.sum_add_distrib, ← Finset.sum_mul, hY, one_mul, ← Finset.mul_sum]
+  rw [Finset.sum_congr rfl fun x _ => key x, Finset.sum_add_distrib,
+    ← Finset.sum_mul, hX, one_mul]
+
+/-- The `n`-fold i.i.d. product distribution `p^{⊗n}(x) = ∏ᵢ p (xᵢ)` on
+`Fin n → α`. -/
+noncomputable def prodDist (p : α → ℝ) (n : ℕ) : (Fin n → α) → ℝ :=
+  fun x => ∏ i, p (x i)
+
+/-- **Normalisation of the product distribution.** The total mass of `p^{⊗n}` is
+`(∑ₐ p a)^n`; in particular a normalised `p` (with `∑ₐ p a = 1`) gives a
+normalised `p^{⊗n}`. Proved by induction along the tuple recursion. -/
+theorem sum_prodDist (p : α → ℝ) (n : ℕ) :
+    ∑ x, prodDist p n x = (∑ a, p a) ^ n := by
+  induction n with
+  | zero => simp [prodDist]
+  | succ n ih =>
+      rw [← Equiv.sum_comp (Fin.consEquiv (fun _ : Fin (n + 1) => α))
+        (prodDist p (n + 1))]
+      have step : ∀ ar : α × (Fin n → α),
+          prodDist p (n + 1) (Fin.consEquiv (fun _ : Fin (n + 1) => α) ar)
+            = p ar.1 * prodDist p n ar.2 := by
+        rintro ⟨a, s⟩
+        simp only [prodDist, Fin.consEquiv_apply, Fin.prod_univ_succ,
+          Fin.cons_zero, Fin.cons_succ]
+      rw [Finset.sum_congr rfl fun ar _ => step ar, Fintype.sum_prod_type]
+      simp_rw [← Finset.mul_sum]
+      rw [← Finset.sum_mul, ih]
+      ring
+
+/-- **Entropy of an `n`-fold i.i.d. source.** For a distribution `p` with
+`∑ₐ p a = 1`, the entropy of the product distribution `p^{⊗n}` on `Fin n → α` is
+
+  `H(p^{⊗n}) = n · H(p)`.
+
+Obtained by iterating the pairwise additivity `entropy_prod` along the tuple
+recursion `Fin (n+1) → α ≃ α × (Fin n → α)`: each step splits off one coordinate,
+contributing one factor `H(p)`. -/
+theorem entropy_pow (p : α → ℝ) (hp : ∑ a, p a = 1) (n : ℕ) :
+    entropy (prodDist p n) = n * entropy p := by
+  induction n with
+  | zero => simp [entropy, prodDist]
+  | succ n ih =>
+      have hrw : entropy (prodDist p (n + 1))
+          = entropy (fun ar : α × (Fin n → α) => p ar.1 * prodDist p n ar.2) := by
+        unfold entropy
+        rw [← Equiv.sum_comp (Fin.consEquiv (fun _ : Fin (n + 1) => α))
+          (fun x => Real.negMulLog (prodDist p (n + 1) x))]
+        apply Finset.sum_congr rfl
+        rintro ⟨a, s⟩ _
+        simp only [prodDist, Fin.consEquiv_apply, Fin.prod_univ_succ,
+          Fin.cons_zero, Fin.cons_succ]
+      rw [hrw, entropy_prod p (prodDist p n) hp
+        (by rw [sum_prodDist, hp, one_pow]), ih]
+      push_cast
+      ring
+
+end ShannonSourceCodingWIP01OQ01

--- a/src/data/proofs/shannon-source-coding-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "shannon-pow-overview",
+    "proofId": "shannon-source-coding-wip-01-oq-01",
+    "range": { "startLine": 3, "endLine": 45 },
+    "type": "concept",
+    "title": "From pairwise additivity to the n·H entropy rate",
+    "content": "The docstring frames the result: the parent file proves entropy is additive across two independent sources, H(pX ⊗ pY) = H(pX) + H(pY). This file iterates that atomic identity to the n-fold i.i.d. product distribution p^⊗n(x) = ∏ᵢ p(xᵢ), obtaining H(p^⊗n) = n·H(p). This is the exact finite-block form of Shannon's entropy rate: a block of n independent symbols carries n·H(p) bits, the compression limit that typical-set coding achieves and the AEP concentrates around.",
+    "mathContext": "$H(p^{\\otimes n}) = n\\cdot H(p),\\qquad p^{\\otimes n}(x)=\\prod_i p_{x_i}$",
+    "significance": "key",
+    "relatedConcepts": ["Shannon entropy", "entropy rate", "i.i.d. source", "source coding theorem", "asymptotic equipartition property"],
+    "prerequisites": ["Shannon entropy", "product distributions", "mathematical induction"]
+  },
+  {
+    "id": "shannon-pow-entropy-def",
+    "proofId": "shannon-source-coding-wip-01-oq-01",
+    "range": { "startLine": 47, "endLine": 49 },
+    "type": "definition",
+    "title": "Entropy in negMulLog form",
+    "content": "`entropy p = ∑ₓ negMulLog (p x)`, where `negMulLog t = −t·log t` builds in the convention 0·log 0 = 0. This matches the parent's definition and agrees with the standard Shannon entropy −∑ₓ p x · log (p x). Working in negMulLog form lets the algebraic identity negMulLog(x·y) = y·negMulLog x + x·negMulLog y drive the additivity proof with no case analysis on zeros.",
+    "mathContext": "$H(p) = \\sum_x \\mathrm{negMulLog}(p_x) = -\\sum_x p_x\\log p_x$",
+    "significance": "supporting",
+    "relatedConcepts": ["Shannon entropy", "negMulLog", "logarithm"],
+    "prerequisites": ["Shannon entropy", "finite sums", "real logarithm"]
+  },
+  {
+    "id": "shannon-pow-entropy-prod",
+    "proofId": "shannon-source-coding-wip-01-oq-01",
+    "range": { "startLine": 51, "endLine": 71 },
+    "type": "theorem",
+    "title": "Pairwise additivity (the atomic step)",
+    "content": "`entropy_prod` reproves the parent's pairwise additivity: for a product distribution pXY(x,y) = pX x · pY y with ∑ pX = ∑ pY = 1, H(pX ⊗ pY) = H(pX) + H(pY). The sum over α × β factors into a double sum (Fintype.sum_prod_type); Real.negMulLog_mul linearizes each product symbol; and ∑ pX = ∑ pY = 1 collapses the cross terms. It is reproved locally so this file is self-contained, and is the single step that entropy_pow iterates n times.",
+    "mathContext": "$H(p_X \\otimes p_Y) = H(p_X) + H(p_Y)$",
+    "significance": "supporting",
+    "relatedConcepts": ["additivity", "independence", "product distribution", "negMulLog_mul"],
+    "prerequisites": ["Shannon entropy", "double sums over products", "probability normalisation"]
+  },
+  {
+    "id": "shannon-pow-normalisation",
+    "proofId": "shannon-source-coding-wip-01-oq-01",
+    "range": { "startLine": 72, "endLine": 103 },
+    "type": "theorem",
+    "title": "Normalisation of the n-fold product distribution",
+    "content": "`prodDist p n` is the n-fold product distribution `fun x => ∏ᵢ p(xᵢ)` on Fin n → α. `sum_prodDist` proves its total mass is (∑ₐ p a)^n, by induction along the tuple recursion Fin.consEquiv: splitting the first coordinate and reindexing the sum (Equiv.sum_comp) factors the product distribution as p(x₀)·(tail), and Fintype.sum_prod_type separates the two marginals. When ∑ₐ p a = 1 this gives ∑ p^⊗n = 1 — the hypothesis each additivity step consumes.",
+    "mathContext": "$\\sum_{x\\in\\alpha^n}\\prod_i p_{x_i} = \\Big(\\sum_a p_a\\Big)^n$",
+    "significance": "key",
+    "relatedConcepts": ["product distribution", "normalisation", "Fin.consEquiv", "finite products"],
+    "prerequisites": ["finite products over Fin n", "reindexing sums by equivalences", "mathematical induction"]
+  },
+  {
+    "id": "shannon-pow-main",
+    "proofId": "shannon-source-coding-wip-01-oq-01",
+    "range": { "startLine": 104, "endLine": 124 },
+    "type": "theorem",
+    "title": "H(p^⊗n) = n·H(p): the entropy rate",
+    "content": "`entropy_pow` is the main result: for ∑ₐ p a = 1, H(p^⊗n) = n·H(p). The induction step reindexes the entropy sum over Fin (n+1) → α along Fin.consEquiv : α × (Fin n → α) ≃ (Fin (n+1) → α), factoring each product symbol via Fin.prod_univ_succ so that p^⊗(n+1) becomes the pairwise product p ⊗ p^⊗n. Then entropy_prod contributes one H(p) and the induction hypothesis supplies n·H(p), giving (n+1)·H(p). Verified axiom-free (#print axioms: propext, Classical.choice, Quot.sound only). Discharges the parent entry's stated open question.",
+    "mathContext": "$H(p^{\\otimes(n+1)}) = H(p) + H(p^{\\otimes n}) = (n+1)\\,H(p)$",
+    "significance": "key",
+    "relatedConcepts": ["entropy rate", "i.i.d. source", "induction", "Fin.consEquiv", "source coding theorem"],
+    "prerequisites": ["Shannon entropy additivity", "mathematical induction", "reindexing sums by equivalences"]
+  }
+]

--- a/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "shannon-source-coding-wip-01-oq-01",
+  "title": "Entropy of an n-fold i.i.d. Source: H(p^⊗n) = n·H(p)",
+  "slug": "shannon-source-coding-wip-01-oq-01",
+  "description": "Iterates the pairwise additivity of Shannon entropy (parent shannon-source-coding-wip-01, H(pX ⊗ pY) = H(pX) + H(pY)) to the n-fold i.i.d. product. For a normalised distribution p (∑ₐ p a = 1), the product distribution p^⊗n(x) = ∏ᵢ p(xᵢ) on Fin n → α has entropy H(p^⊗n) = n·H(p). This is the source-coding statement that a block of n i.i.d. symbols carries n·H(p) bits — the quantitative backbone of the AEP and of the rate H in Shannon's source coding theorem. Proof by induction along the tuple recursion Fin (n+1) → α ≃ α × (Fin n → α) (Fin.consEquiv), with a normalisation lemma ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n supplying the additivity step's hypothesis. 3 theorems, 2 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonSourceCodingWIP01OQ01.lean",
+    "tags": [
+      "information-theory",
+      "shannon-entropy",
+      "source-coding",
+      "iid",
+      "product-distribution",
+      "entropy-rate",
+      "induction",
+      "negMulLog"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 124,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "assumptions": "None. All 3 theorems proved, 0 axioms. Verified axiom-free: #print axioms entropy_pow reports only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool). The only hypothesis is normalisation ∑ₐ p a = 1, a defining property of a probability distribution.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.consEquiv",
+        "description": "The tuple recursion α 0 × (∀ i, α (succ i)) ≃ ∀ i, α i — splits off the first coordinate, the induction step engine",
+        "module": "Mathlib.Data.Fin.Tuple.Basic"
+      },
+      {
+        "theorem": "Equiv.sum_comp",
+        "description": "reindex a finite sum along an equivalence, transporting the (n+1)-fold sum to a product-type sum",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Fin.prod_univ_succ",
+        "description": "∏ i : Fin (n+1), f i = f 0 · ∏ i : Fin n, f i.succ — factors the product distribution symbol-by-symbol",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Real.negMulLog_mul",
+        "description": "negMulLog(x·y) = y·negMulLog x + x·negMulLog y — linearizes the entropy of a product symbol (parent additivity engine)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.NegMulLog"
+      },
+      {
+        "theorem": "Fintype.sum_prod_type",
+        "description": "∑ over α × β factors as a double sum, separating the split coordinate from the tail",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      }
+    ],
+    "dateAdded": "2026-07-02"
+  },
+  "overview": {
+    "historicalContext": "Shannon's source coding theorem identifies H(p) as the compression limit: a source emitting i.i.d. symbols with distribution p can be encoded, asymptotically, at H(p) bits per symbol and no fewer. The exact finite-block statement behind this rate is that n independent copies of the source carry n·H(p) bits of entropy. Together with the asymptotic equipartition property (AEP), this n·H scaling is what makes typical-set coding achieve the entropy rate. The parent entry proves the atomic case — entropy adds across two independent sources — and this entry iterates it to the full n-fold i.i.d. product, discharging the parent's own stated open question.",
+    "problemStatement": "For a probability distribution p : α → ℝ with ∑ₐ p a = 1, prove that the n-fold i.i.d. product distribution p^⊗n(x) = ∏ᵢ p(xᵢ) on Fin n → α satisfies H(p^⊗n) = n·H(p), where H is Shannon entropy in negMulLog form.",
+    "proofStrategy": "Induct on n. The base case n = 0 is H of the trivial one-point distribution = 0 = 0·H(p). For the step, reindex the entropy sum over Fin (n+1) → α along the equivalence Fin.consEquiv : α × (Fin n → α) ≃ (Fin (n+1) → α) (Equiv.sum_comp). Splitting the first coordinate factors each product symbol ∏_{i<n+1} p(xᵢ) = p(x₀)·∏_{i<n} p(x_{i+1}) (Fin.prod_univ_succ + Fin.cons_zero/cons_succ), turning p^⊗(n+1) into the pairwise product distribution p ⊗ p^⊗n. The pairwise additivity entropy_prod (reproved locally from the parent) then gives H(p^⊗(n+1)) = H(p) + H(p^⊗n) = H(p) + n·H(p) = (n+1)·H(p). The additivity step needs ∑ p^⊗n = 1, supplied by the normalisation lemma sum_prodDist: ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n, itself an induction along the same tuple recursion.",
+    "keyInsights": [
+      "**The tuple recursion is the induction engine.** Fin.consEquiv : α × (Fin n → α) ≃ (Fin (n+1) → α) splits off one symbol at a time, converting the n-fold product into an atomic product distribution that the parent's pairwise additivity already handles — no new analytic content, just clean reindexing.",
+      "**Normalisation must be tracked alongside entropy.** The additivity step consumes ∑ p^⊗n = 1, so the proof proves ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n as a companion induction; the two inductions run along the identical Fin.consEquiv recursion.",
+      "**Entropy-rate backbone.** H(p^⊗n) = n·H(p) is the exact finite-block form of Shannon's entropy rate: n i.i.d. symbols carry n·H(p) bits, the quantity typical-set coding compresses to and the AEP concentrates around.",
+      "**Axiom-free and hypothesis-minimal.** The only assumption is ∑ₐ p a = 1, the defining property of a probability distribution; #print axioms confirms reliance only on propext, Classical.choice, Quot.sound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "entropy-and-additivity",
+      "title": "Entropy in negMulLog form and pairwise additivity",
+      "startLine": 47,
+      "endLine": 71,
+      "summary": "entropy p := ∑ₓ negMulLog(p x). entropy_prod: H(pX ⊗ pY) = H(pX) + H(pY) for ∑ pX = ∑ pY = 1 (the parent result, reproved locally so the file is self-contained; the atomic step iterated below).",
+      "mathContext": "$H(p) = \\sum_x \\mathrm{negMulLog}(p_x), \\qquad H(p_X \\otimes p_Y) = H(p_X) + H(p_Y).$"
+    },
+    {
+      "id": "normalisation",
+      "title": "Normalisation of the product distribution",
+      "startLine": 72,
+      "endLine": 103,
+      "summary": "prodDist p n := fun x => ∏ᵢ p(xᵢ), the n-fold product. sum_prodDist: ∑ₓ prodDist p n x = (∑ₐ p a)^n, by induction along Fin.consEquiv; gives ∑ p^⊗n = 1 when ∑ p = 1.",
+      "mathContext": "$\\sum_{x \\in \\alpha^n} \\prod_{i} p_{x_i} = \\Big(\\sum_a p_a\\Big)^n.$"
+    },
+    {
+      "id": "entropy-pow",
+      "title": "Entropy of the n-fold i.i.d. source",
+      "startLine": 104,
+      "endLine": 124,
+      "summary": "entropy_pow: H(p^⊗n) = n·H(p) for ∑ₐ p a = 1, by induction — reindex via Fin.consEquiv, factor the product symbol, apply entropy_prod, and fold in the induction hypothesis.",
+      "mathContext": "$H(p^{\\otimes n}) = n \\cdot H(p).$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The Shannon entropy of an n-fold i.i.d. source equals n·H(p): H(p^⊗n) = n·H(p) for any probability distribution p. Proved by iterating the parent's pairwise additivity along the tuple recursion Fin.consEquiv, with a companion normalisation lemma. 3 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "Supplies the exact finite-block entropy rate (n i.i.d. symbols ⟹ n·H bits) that underlies the asymptotic equipartition property and Shannon's source coding theorem, and discharges the parent entry's stated open question on iterating product additivity to the n-fold product.",
+    "openQuestions": [
+      "Combine with the AEP entry to derive the typical-set size bound 2^{n(H±ε)} directly from H(p^⊗n) = n·H(p).",
+      "Extend to distinguishable but independent sources p₁, …, pₙ: H(⊗ᵢ pᵢ) = ∑ᵢ H(pᵢ), the fully heterogeneous additivity."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "ShannonSourceCodingWIP01OQ01",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/ShannonSourceCodingWIP01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-source-coding-wip-01",
+      "relationship": "extends",
+      "description": "Parent entry proves pairwise additivity H(pX ⊗ pY) = H(pX) + H(pY); this file iterates it to the n-fold i.i.d. product H(p^⊗n) = n·H(p), discharging the parent's stated open question"
+    },
+    {
+      "targetId": "shannon-source-coding",
+      "relationship": "extends",
+      "description": "Supplies the n·H entropy-rate backbone underlying the source coding theorem"
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "complements",
+      "description": "ShannonEntropy proves subadditivity H(X,Y) ≤ H(X)+H(Y); this file gives the exact additivity for n independent copies of a single source"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "entropy_pow",
+      "type": "core",
+      "statement": "∑ₐ p a = 1 → entropy (prodDist p n) = n · entropy p",
+      "description": "The Shannon entropy of an n-fold i.i.d. product source is n·H(p).",
+      "significance": "The finite-block entropy rate: n i.i.d. symbols carry n·H(p) bits — foundation of the AEP and Shannon's source coding theorem"
+    },
+    {
+      "name": "sum_prodDist",
+      "type": "lemma",
+      "statement": "∑ₓ prodDist p n x = (∑ₐ p a)^n",
+      "description": "The n-fold product distribution has total mass (∑ p)^n; normalised when p is.",
+      "significance": "Supplies the ∑ p^⊗n = 1 hypothesis consumed at each additivity step"
+    },
+    {
+      "name": "entropy_prod",
+      "type": "lemma",
+      "statement": "∑ pX = 1 → ∑ pY = 1 → entropy (fun (x,y) => pX x · pY y) = entropy pX + entropy pY",
+      "description": "Pairwise additivity of entropy for independent sources (parent result, reproved locally).",
+      "significance": "The atomic step iterated by entropy_pow"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Establishes the entropy rate: n i.i.d. symbols carry n·H bits, the compression limit of the source coding theorem."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Chapter 2–3: entropy of a stochastic process, H(X₁,…,Xₙ) = ∑ H(Xᵢ) for independent Xᵢ, and the entropy rate."
+    },
+    {
+      "authors": "Robert M. Gray",
+      "title": "Entropy and Information Theory",
+      "year": 2011,
+      "venue": "Springer, 2nd ed.",
+      "note": "Rigorous treatment of entropy additivity for product measures and the AEP."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Fin.consEquiv, Equiv.sum_comp, and the finite-product API",
+      "year": 2024,
+      "note": "Supplies the tuple recursion and finite-sum reindexing that drive the induction."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
New verified gallery entry proving the **n-fold i.i.d. entropy rate**: for a probability distribution `p` (∑ₐ p a = 1), the Shannon entropy of the product distribution `p^⊗n(x) = ∏ᵢ p(xᵢ)` on `Fin n → α` is

```
H(p^⊗n) = n · H(p)
```

This iterates the parent `shannon-source-coding-wip-01`'s pairwise additivity `H(pX⊗pY)=H(pX)+H(pY)` to the full n-fold product — **discharging the parent entry's own stated open question**. It is the exact finite-block form of Shannon's entropy rate (n i.i.d. symbols carry n·H bits), the backbone of the AEP and the source coding theorem.

## Proof
Induction on `n` along the tuple recursion `Fin.consEquiv : α × (Fin n → α) ≃ (Fin (n+1) → α)`:
- Reindex the entropy sum (`Equiv.sum_comp`); factor each product symbol via `Fin.prod_univ_succ` so `p^⊗(n+1)` becomes the pairwise product `p ⊗ p^⊗n`.
- Apply the (locally reproved) pairwise additivity `entropy_prod`; fold in the IH.
- Companion lemma `sum_prodDist : ∑ₓ ∏ᵢ p(xᵢ) = (∑ₐ p a)^n` supplies the `∑ p^⊗n = 1` hypothesis at each step.

## Verification
- **Host-verified** via `lake env lean Proofs/ShannonSourceCodingWIP01OQ01.lean` — clean compile, 0 errors, 0 warnings, 0 sorries.
- `#print axioms entropy_pow` = `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely 0-axiom.
- 124 lines, 3 theorems, 2 definitions.
- Status `verified` / badge `original`; only hypothesis is ∑ₐ p a = 1 (defining property of a probability distribution).

## Files
- `proofs/Proofs/ShannonSourceCodingWIP01OQ01.lean` (new)
- `src/data/proofs/shannon-source-coding-wip-01-oq-01/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)