### PR TITLE
Enrich Hermite sawtooth identity (hermite-sawtooth-identity)

### DIFF
--- a/src/data/proofs/hermite-sawtooth-identity/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity/annotations.json
@@ -92,5 +92,27 @@
       "the sawtooth identity",
       "the exact sampled sum"
     ]
+  },
+  {
+    "id": "ann-hermitesawtooth-bernoulli-context",
+    "proofId": "hermite-sawtooth-identity",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "context",
+    "title": "Context: The Distribution Relation for the Sawtooth Bernoulli Function",
+    "content": "Beyond its elementary proof, this identity is a named classical fact in disguise: the n-fold *distribution (multiplication) relation* for the first periodic Bernoulli function P₁(t) = {t} − 1/2. Subtracting 1/2 from each of the n fractional parts turns the statement ∑_{k<n} {x + k/n} = {n·x} + (n−1)/2 into ∑_{k<n} P₁(x + k/n) = P₁(n·x): the sum over the n equally spaced translates x + k/n reproduces the same function evaluated at the dilated point n·x. This is the m = 1 case of the general Bernoulli distribution relation ∑_{k<n} B_m(x + k/n) = n^{1−m} B_m(n·x) (Raabe's multiplication formula), and the periodic P_m are exactly the functions satisfying the Kubert identities. Such distribution relations are the arithmetic backbone of the Hurwitz zeta functional equation and of the theory of Bernoulli distributions on p-adic integers (Mazur measures), so this humble fractional-part identity is the ground floor of a large tower. The parent Hermite floor identity is its companion m = 1 floor face.",
+    "mathContext": "$\\sum_{k=0}^{n-1} P_1\\!\\left(x + \\tfrac{k}{n}\\right) = P_1(nx)$, where $P_1(t) = \\{t\\} - \\tfrac12$ — the $m=1$ Bernoulli distribution relation $\\sum_{k<n} B_m(x+\\tfrac{k}{n}) = n^{1-m}B_m(nx)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "periodic Bernoulli functions",
+      "Bernoulli distribution / multiplication relation",
+      "Raabe's formula",
+      "Kubert identities",
+      "Hurwitz zeta functional equation"
+    ],
+    "prerequisites": [
+      "Bernoulli polynomials",
+      "fractional part {t}",
+      "the notion of a distribution relation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `hermite-sawtooth-identity` (companion sawtooth twin of Hermite's floor identity).

## Changes
- **Annotation coverage**: added a 5th annotation, `ann-hermitesawtooth-bernoulli-context`, a *context* callout placing the identity in the broader theory. Subtracting 1/2 from each fractional part rewrites `∑ {x+k/n} = {nx} + (n-1)/2` as the distribution relation `∑ P₁(x+k/n) = P₁(nx)` for the first periodic Bernoulli function — the m=1 case of Raabe's multiplication formula `∑ Bₘ(x+k/n) = n^{1-m}Bₘ(nx)`, tied to the Kubert identities and the Hurwitz zeta functional equation.

Complements the existing proof-mechanics annotations with mathematical placement. Reaches the ≥5-annotation target (keyInsights already at 4, within range). meta.json unchanged (13 KB, under cap). JSON validated.