### PR TITLE
Enrich Hilbert-3 tetrahedron entry (hilbert-3-oq-04)

### DIFF
--- a/src/data/proofs/hilbert-3-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-3-oq-04/annotations.json
@@ -46,5 +46,27 @@
     "significance": "critical",
     "relatedConcepts": ["axiom elimination", "Dehn invariant", "scissors congruence"],
     "prerequisites": ["field algebra with π ≠ 0"]
+  },
+  {
+    "id": "ann-dehn-context",
+    "proofId": "hilbert-3-oq-04",
+    "range": { "startLine": 65, "endLine": 91 },
+    "type": "context",
+    "title": "Context: Why This Fact Resolves Hilbert's Third Problem",
+    "content": "The irrationality of arccos(1/3)/π is the exact arithmetic input that settles Hilbert's Third Problem for the regular tetrahedron. Hilbert (1900) asked whether two polyhedra of equal volume are always scissors-congruent (cut one into finitely many pieces and reassemble into the other). Max Dehn answered no in the same year by constructing the Dehn invariant, D(P) = Σ_edges ℓ(e) ⊗ θ(e) ∈ ℝ ⊗_ℤ (ℝ/πℚ), a scissors-congruence invariant that vanishes on the cube (all dihedral angles are π/2, a rational multiple of π, so each ⊗-factor is 0). For the regular tetrahedron every dihedral angle is θ = arccos(1/3); D ≠ 0 precisely because θ is NOT a rational multiple of π — which is what this file proves. Hence the tetrahedron and the volume-equal cube have different Dehn invariants and cannot be scissors-congruent, so Hilbert 3's answer is negative. Note the sharp contrast with the two-dimensional Bolyai–Gerwien theorem, where equal area always forces scissors-congruence: the Dehn obstruction is a genuinely three-dimensional phenomenon.",
+    "mathContext": "Dehn invariant $D(P) = \\sum_e \\ell(e) \\otimes \\theta(e) \\in \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Q})$; the tetrahedron's $\\theta = \\arccos(1/3) \\notin \\pi\\mathbb{Q}$ makes $D \\neq 0$, so it is not scissors-congruent to a cube.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's Third Problem",
+      "Dehn invariant",
+      "scissors congruence",
+      "Bolyai–Gerwien theorem",
+      "tensor product ℝ ⊗_ℤ (ℝ/πℚ)"
+    ],
+    "prerequisites": [
+      "polyhedral dihedral angles",
+      "scissors-congruence invariants",
+      "the tetrahedral angle arccos(1/3)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `hilbert-3-oq-04` (Niven's theorem ⇒ the tetrahedral dihedral angle is not a rational multiple of π).

## Changes
- **Annotation coverage**: added a 5th annotation, `ann-dehn-context`, a *context* callout explaining the geometric payoff — irrationality of `arccos(1/3)/π` is exactly what makes the regular tetrahedron's Dehn invariant nonzero, so it is not scissors-congruent to a volume-equal cube, giving Hilbert's Third Problem its negative answer (Dehn, 1900). Contrasts with the 2D Bolyai–Gerwien theorem.

Complements the existing proof-mechanics annotations with the geometric significance. Reaches the ≥5-annotation target. meta.json unchanged (14 KB, under cap). JSON validated.