### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-03-oq-03): gallery entry + build-verify covariance corollary [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "ann-cheby-cov-header",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+    "range": { "startLine": 4, "endLine": 66 },
+    "type": "concept",
+    "title": "The probabilistic reading of Chebyshev's integral inequality",
+    "content": "The docstring recasts the parent's deterministic inequality (∫f)(∫g) ≤ (b−a)∫fg as a statement about a random variable X uniform on [a,b]: monotone functions f, g of X are positively correlated, Cov(f(X),g(X)) ≥ 0. It states the plan — define the uniform-law expectation and covariance, and derive the corollary by dividing the parent inequality by (b−a)² — and explains the connection to the Harris–FKG correlation inequality, of which this is the one-dimensional (chain) case.",
+    "mathContext": "$\\mathrm{Cov}(f(X),g(X)) = E[fg] - E[f]E[g] \\ge 0$ for monotone $f,g$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "covariance",
+      "FKG inequality",
+      "Harris inequality",
+      "correlation inequality",
+      "uniform distribution"
+    ],
+    "prerequisites": [
+      "the parent continuous Chebyshev inequality",
+      "expectation and covariance"
+    ]
+  },
+  {
+    "id": "ann-cheby-cov-defs",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+    "range": { "startLine": 67, "endLine": 82 },
+    "type": "definition",
+    "title": "Uniform-law expectation, covariance, and E[1] = 1",
+    "content": "expectUnif a b h = (∫ x in a..b, h x)/(b−a) is the expectation of h(X) for X uniform on [a,b] (the average value of h over the interval); covUnif a b f g = expectUnif a b (fun x => f x * g x) − expectUnif a b f * expectUnif a b g is the covariance. expectUnif_one shows E[1] = 1 via intervalIntegral.integral_const (∫ x in a..b, 1 = (b−a)•1) and div_self, certifying the (1/(b−a))-normalised law is a genuine probability distribution.",
+    "mathContext": "$E[h] = \\tfrac{1}{b-a}\\int_a^b h(x)\\,dx,\\quad E[1] = 1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "expectation",
+      "covariance",
+      "probability distribution",
+      "interval integral"
+    ],
+    "prerequisites": [
+      "interval integrals",
+      "definition of expectation"
+    ]
+  },
+  {
+    "id": "ann-cheby-cov-positive",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "key-step",
+    "title": "Covariance ≥ 0 is the parent inequality divided by (b−a)²",
+    "content": "covUnif_nonneg_of_monotoneOn proves Cov(f(X),g(X)) ≥ 0 for f, g both monotone. After simp unfolds the definitions, div_mul_div_comm collapses E[f]E[g] into (∫f·∫g)/((b−a)(b−a)); sub_nonneg then div_le_div_iff₀ reduce the goal to (∫f·∫g)(b−a) ≤ (∫fg)((b−a)(b−a)); nlinarith closes it from the parent's chebyshev_integral_monotoneOn (∫f)(∫g) ≤ (b−a)∫fg multiplied by (b−a) ≥ 0. No new analysis — only the sign of (b−a)² and ordered-field arithmetic.",
+    "mathContext": "$\\tfrac{I_f I_g}{(b-a)^2} \\le \\tfrac{I_{fg}}{b-a} \\iff I_f I_g \\le (b-a)I_{fg}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chebyshev's sum inequality",
+      "monotone functions",
+      "covariance",
+      "rescaling"
+    ],
+    "prerequisites": [
+      "the parent integral Chebyshev inequality",
+      "ordered-field division inequalities"
+    ]
+  },
+  {
+    "id": "ann-cheby-cov-negative",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+    "range": { "startLine": 95, "endLine": 105 },
+    "type": "key-step",
+    "title": "Negative correlation for opposite monotonicity",
+    "content": "covUnif_nonpos_of_antitoneOn proves Cov(f(X),g(X)) ≤ 0 when f is monotone and g antitone, by the identical rescaling applied to the parent's reversed inequality chebyshev_integral_antitoneOn ((b−a)∫fg ≤ (∫f)(∫g)). The only change from the positive case is sub_nonpos in place of sub_nonneg and the swapped argument order to div_le_div_iff₀.",
+    "mathContext": "$f\\uparrow,\\ g\\downarrow \\;\\Rightarrow\\; \\mathrm{Cov}(f(X),g(X)) \\le 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "antitone functions",
+      "negative correlation",
+      "reverse inequality"
+    ],
+    "prerequisites": [
+      "the parent reversed inequality"
+    ]
+  },
+  {
+    "id": "ann-cheby-cov-fkg",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+    "range": { "startLine": 107, "endLine": 123 },
+    "type": "concept",
+    "title": "Correlation form: FKG on a chain",
+    "content": "expectUnif_mul_ge_of_monotoneOn (E[fg] ≥ E[f]E[g]) and expectUnif_mul_le_of_antitoneOn (E[fg] ≤ E[f]E[g]) restate the covariance bounds by unwinding covUnif with linarith. E[fg] ≥ E[f]E[g] for comonotone f, g is exactly the Harris–FKG correlation inequality specialised to a chain: on the totally ordered interval [a,b] the log-supermodularity hypothesis of FKG is automatic, so FKG collapses to this covariance statement.",
+    "mathContext": "$E[fg] \\ge E[f]\\,E[g]$ — the FKG inequality on the chain $[a,b]$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "FKG inequality",
+      "Harris inequality",
+      "positive association",
+      "distributive lattice",
+      "chain"
+    ],
+    "prerequisites": [
+      "the covariance nonnegativity result",
+      "the FKG inequality (statement)"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/index.ts
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevCovarianceOQ010303.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevSumInequalityOQ01OQ03OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevSumInequalityOQ01OQ03OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevSumInequalityOQ01OQ03OQ03Data: ProofData = {
+  proof: chebyshevSumInequalityOQ01OQ03OQ03Proof,
+  annotations: chebyshevSumInequalityOQ01OQ03OQ03Annotations,
+}

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-03-oq-03",
+  "title": "Positive Correlation of Monotone Functions: the Covariance Corollary of the Integral Chebyshev Inequality",
+  "description": "The probabilistic reading of the continuous Chebyshev inequality: for a random variable X uniform on [a,b] and monotone functions f, g, the covariance Cov(f(X),g(X)) = E[fg] − E[f]E[g] is nonnegative (and nonpositive when one function increases and the other decreases). Equivalently E[fg] ≥ E[f]E[g] — the Harris–FKG correlation inequality specialised to a chain. Derived by a single division by (b−a)² from the parent integral inequality (∫f)(∫g) ≤ (b−a)∫fg, answering the parent entry's open question #3.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevSumIntegralOQ0103"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Set"
+    ],
+    "namespace": "ChebyshevCovariance",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevCovarianceOQ010303.lean",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "meta": {
+    "author": "Classical (Chebyshev; Harris–FKG); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/FKG_inequality",
+    "date": "1960",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "probability",
+      "covariance",
+      "correlation-inequality",
+      "fkg-inequality",
+      "chebyshev-sum-inequality",
+      "monotone",
+      "measure-theory"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevCovarianceOQ010303.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 125,
+    "mathlibDependencies": [
+      {
+        "theorem": "ChebyshevIntegralMonotone.chebyshev_integral_monotoneOn",
+        "description": "The parent entry's continuous Chebyshev inequality (∫f)(∫g) ≤ (b−a)∫fg for MonotoneOn f, g — the sole analytic input; the covariance statement is a rescaling of it",
+        "module": "Proofs.ChebyshevSumIntegralOQ0103"
+      },
+      {
+        "theorem": "ChebyshevIntegralMonotone.chebyshev_integral_antitoneOn",
+        "description": "The parent's reversed inequality (b−a)∫fg ≤ (∫f)(∫g) for f monotone, g antitone — gives the negative-correlation direction",
+        "module": "Proofs.ChebyshevSumIntegralOQ0103"
+      },
+      {
+        "theorem": "intervalIntegral.integral_const",
+        "description": "∫ x in a..b, c = (b − a) • c — used to show the uniform law integrates the constant 1 to 1 (E[1] = 1), certifying it is a probability distribution",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "div_le_div_iff₀ / div_mul_div_comm / mul_le_mul_of_nonneg_right",
+        "description": "Ordered-field arithmetic turning the parent inequality (∫f)(∫g) ≤ (b−a)∫fg into (∫f∫g)/(b−a)² ≤ (∫fg)/(b−a), i.e. Cov ≥ 0",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ],
+    "originalContributions": [
+      "expectUnif / covUnif: definitions of the expectation E[h] = (1/(b−a))∫ₐᵇ h and covariance Cov(f(X),g(X)) = E[fg] − E[f]E[g] for a variable X uniform on [a,b] — a probabilistic layer Mathlib does not package for the interval-uniform law",
+      "expectUnif_one: E[1] = 1, certifying the (1/(b−a))-normalised uniform law is a genuine probability distribution",
+      "covUnif_nonneg_of_monotoneOn: Cov(f(X),g(X)) ≥ 0 for f, g both monotone — the positive-correlation statement answering open question #3 of the parent entry (chebyshev-sum-inequality-oq-01-oq-03)",
+      "covUnif_nonpos_of_antitoneOn: Cov(f(X),g(X)) ≤ 0 for f increasing, g decreasing — negative correlation",
+      "expectUnif_mul_ge_of_monotoneOn / expectUnif_mul_le_of_antitoneOn: the equivalent correlation forms E[fg] ≥ E[f]E[g] (resp. ≤), i.e. the Harris–FKG correlation inequality specialised to the chain [a,b] with the uniform (Lebesgue) measure — the one-dimensional case of FKG, which Mathlib does not have in any form"
+    ],
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That 'similarly ordered quantities are positively correlated' is the intuitive content of Chebyshev's sum inequality (1880s). Cast in probabilistic language it says: if X is a random variable and f, g are both monotone, then f(X) and g(X) are positively correlated, Cov(f(X),g(X)) ≥ 0. This one-variable correlation fact is the seed of a large family of correlation inequalities: Harris's inequality (1960) in percolation, and its far-reaching generalisation the FKG inequality of Fortuin, Kasteleyn and Ginibre (1971), which states that on a finite distributive lattice with a log-supermodular (positively associated) measure, any two increasing functions are positively correlated. On a totally ordered set — a chain — log-supermodularity is automatic, so the FKG hypothesis is vacuous and the inequality reduces exactly to the covariance statement formalised here. The parent gallery entry proved the deterministic integral inequality (∫f)(∫g) ≤ (b−a)∫fg and listed this probabilistic corollary as an explicit open question; this entry discharges it.",
+    "problemStatement": "The parent entry chebyshev-sum-inequality-oq-01-oq-03 proves the continuous Chebyshev inequality (∫ₐᵇ f)(∫ₐᵇ g) ≤ (b−a)∫ₐᵇ f·g for monotone f, g and poses as open question #3: derive the probabilistic corollary Cov(f(X),g(X)) ≥ 0 for monotone f, g and X uniform on [a,b], and connect it to the FKG inequality. This entry defines the uniform-law expectation and covariance and proves exactly this, in both directions, together with the equivalent correlation form E[fg] ≥ E[f]E[g].",
+    "proofStrategy": "For X uniform on [a,b] the expectation is the average value E[h] = (1/(b−a))∫ₐᵇ h, so Cov(f(X),g(X)) = (∫fg)/(b−a) − (∫f)(∫g)/(b−a)². The parent inequality (∫f)(∫g) ≤ (b−a)∫fg is exactly the statement that the subtracted term is ≤ the first, after dividing through by (b−a)² > 0. So the corollary is a one-line rescaling: no new analysis, only ordered-field arithmetic (div_le_div_iff₀, div_mul_div_comm) plus the sign of (b−a)². The antitone direction reuses the parent's reversed inequality; the correlation form E[fg] ≥ E[f]E[g] is the same statement with the subtraction unwound.",
+    "keyInsight": "Covariance is the parent inequality divided by (b−a)². Writing Iₕ = ∫ₐᵇ h, the covariance under the uniform law is I_{fg}/(b−a) − I_f I_g/(b−a)², and the parent supplies I_f I_g ≤ (b−a) I_{fg}, i.e. I_f I_g/(b−a)² ≤ I_{fg}/(b−a). The whole probabilistic corollary is that single division, which is why it needs no measure theory of its own.",
+    "keyInsights": [
+      "The covariance under the uniform law is literally the parent inequality after dividing by (b−a)²: Cov = I_{fg}/(b−a) − I_f I_g/(b−a)² ≥ 0 ⇔ I_f I_g ≤ (b−a) I_{fg}. Positive correlation of monotone functions and the integral Chebyshev inequality are the same statement in two normalisations.",
+      "The normalisation matters: dividing the integral once by (b−a) gives expectations (a probability average, E[1] = 1), and the covariance requires dividing the product term by (b−a)² — the extra factor is exactly what converts the deterministic bound into the mean-centred correlation.",
+      "This is the Harris–FKG inequality on a chain. FKG needs a log-supermodular measure on a distributive lattice; on the totally ordered interval [a,b] every measure is trivially log-supermodular, so the hypothesis disappears and FKG collapses to Cov(f(X),g(X)) ≥ 0 for monotone f, g — the case proved here for the uniform law.",
+      "The negative-correlation direction is not new work: applying the parent's antitone inequality gives Cov ≤ 0 when f increases and g decreases, mirroring how the parent obtained its reverse bound from f and −g.",
+      "The result is a verified, 0-axiom corollary (depends only on propext, Classical.choice, Quot.sound): its entire novelty is the probabilistic packaging (expectation, covariance, the FKG-on-a-chain reading), not new analysis."
+    ],
+    "approach": "Define expectUnif a b h = (∫ x in a..b, h x)/(b−a) and covUnif a b f g = expectUnif a b (f·g) − expectUnif a b f · expectUnif a b g. Check E[1] = 1 via integral_const. For the monotone case, unfold the definitions, rewrite the product of expectations with div_mul_div_comm into a single fraction over (b−a)², reduce Cov ≥ 0 to a division inequality with div_le_div_iff₀, and close it from the parent theorem via mul_le_mul_of_nonneg_right and nlinarith. The antitone case is identical with the parent's reversed inequality; the correlation forms follow by linarith after unfolding covUnif.",
+    "significance": "Answers the parent entry's stated open question and supplies the probabilistic/correlation reading of Chebyshev's integral inequality — the covariance nonnegativity of monotone functions and the one-dimensional (chain) case of the Harris–FKG inequality — which Mathlib does not provide in any form. Modest in mathematical depth (a rescaling of the parent), but it names and machine-certifies the statement everyone quotes when they say 'monotone functions are positively correlated', and packages a reusable uniform-law expectation/covariance layer.",
+    "difficulty": "intermediate",
+    "estimatedReadTime": 6,
+    "prerequisites": [
+      "the parent continuous Chebyshev inequality (chebyshev-sum-inequality-oq-01-oq-03)",
+      "expectation and covariance of a random variable",
+      "the FKG / Harris correlation inequality (statement)",
+      "interval integrals on ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Uniform-law expectation and covariance",
+      "startLine": 67,
+      "endLine": 82,
+      "summary": "expectUnif a b h = (1/(b−a))∫ₐᵇ h is the expectation of h(X) for X uniform on [a,b]; covUnif a b f g = E[fg] − E[f]E[g] is the covariance. expectUnif_one proves E[1] = 1 (via integral_const), certifying the uniform law is a probability distribution.",
+      "mathContext": "$E[h] = \\tfrac{1}{b-a}\\int_a^b h,\\quad \\mathrm{Cov}(f,g) = E[fg] - E[f]E[g]$."
+    },
+    {
+      "id": "positive-correlation",
+      "title": "Positive correlation of monotone functions",
+      "startLine": 84,
+      "endLine": 93,
+      "summary": "covUnif_nonneg_of_monotoneOn: for f, g both monotone on [a,b] and a < b, Cov(f(X),g(X)) ≥ 0. Unfolds the definitions, collapses E[f]E[g] into a single fraction over (b−a)² (div_mul_div_comm), reduces to a division inequality (div_le_div_iff₀), and closes it from the parent's chebyshev_integral_monotoneOn.",
+      "mathContext": "$\\mathrm{Cov}(f(X),g(X)) \\ge 0$ for monotone $f,g$."
+    },
+    {
+      "id": "negative-correlation",
+      "title": "Negative correlation for opposite monotonicity",
+      "startLine": 95,
+      "endLine": 105,
+      "summary": "covUnif_nonpos_of_antitoneOn: for f monotone and g antitone, Cov(f(X),g(X)) ≤ 0, using the parent's reversed inequality chebyshev_integral_antitoneOn in the same rescaling.",
+      "mathContext": "$f\\uparrow,\\ g\\downarrow \\;\\Rightarrow\\; \\mathrm{Cov}(f(X),g(X)) \\le 0$."
+    },
+    {
+      "id": "correlation-form",
+      "title": "Correlation form: the Harris–FKG inequality on a chain",
+      "startLine": 107,
+      "endLine": 123,
+      "summary": "expectUnif_mul_ge_of_monotoneOn and expectUnif_mul_le_of_antitoneOn restate the covariance bounds as E[fg] ≥ E[f]E[g] (resp. ≤) — the correlation inequality of Harris and FKG specialised to the chain [a,b] with the uniform measure, obtained by unwinding covUnif with linarith.",
+      "mathContext": "$E[fg] \\ge E[f]\\,E[g]$ for comonotone $f,g$ (FKG on a chain)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The covariance of monotone functions of a uniform random variable on [a,b] is proved nonnegative (nonpositive for opposite monotonicity), with no axioms or sorries, purely by rescaling the parent's integral Chebyshev inequality by (b−a)². The equivalent correlation form E[fg] ≥ E[f]E[g] is the one-dimensional case of the Harris–FKG inequality.",
+    "implications": "Completes the deterministic→probabilistic pair for Chebyshev's integral inequality and gives the gallery a machine-checked statement of 'monotone functions are positively correlated' — the FKG inequality on a chain — together with a reusable uniform-law expectation/covariance layer that later correlation-inequality entries can build on.",
+    "futureWork": "Prove the equality/rigidity case (Cov = 0 iff f or g is a.e. constant); replace the uniform law by an arbitrary probability measure on [a,b] with a comonotonicity hypothesis (the genuine measure-theoretic FKG on a chain); and pursue the finite distributive-lattice FKG inequality, which Mathlib still lacks entirely.",
+    "openQuestions": [
+      "Characterise equality: Cov(f(X),g(X)) = 0 holds iff f or g is a.e. constant on [a,b].",
+      "Generalise from the uniform law to an arbitrary probability measure μ on [a,b] with a measurable comonotonicity hypothesis — the true continuous FKG inequality on a chain.",
+      "Formalise the general FKG inequality on a finite distributive lattice with a log-supermodular measure, of which this chain case is the simplest instance."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The parent continuous (integral) Chebyshev inequality whose open question #3 (the covariance corollary and FKG connection) this entry answers, and whose theorem is the sole analytic input"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The general comonotone integral Chebyshev inequality; the correlation form proved here is its probabilistic reading for the interval-uniform law"
+    }
+  ],
+  "references": [
+    {
+      "title": "FKG inequality",
+      "url": "https://en.wikipedia.org/wiki/FKG_inequality",
+      "description": "The Fortuin–Kasteleyn–Ginibre correlation inequality, generalising Harris's inequality and (on a chain) the covariance statement proved here"
+    },
+    {
+      "title": "Chebyshev's sum inequality",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+      "description": "The classical inequality and its 'positive correlation of similarly ordered quantities' reading"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Adds the **missing gallery entry** for the covariance corollary of the continuous Chebyshev inequality, and **build-verifies** the proof that was merged BUILD-PENDING in #33799.

The Lean file `proofs/Proofs/ChebyshevCovarianceOQ010303.lean` is already on `main` (from #33799) but (a) had no gallery entry and (b) was never build-verified. This PR fills both gaps.

## Verification (this session)
- **Docker build succeeds**: both `Proofs.ChebyshevSumIntegralOQ0103` (parent) and `Proofs.ChebyshevCovarianceOQ010303` compile with **0 errors**.
- **`#print axioms`** on all 5 theorems reports only `[propext, Classical.choice, Quot.sound]` — genuinely **0-axiom**; no `sorry`, no `native_decide`, no `Lean.ofReduceBool`.

## What the proof establishes
Answers **open question #3** of the parent entry `chebyshev-sum-inequality-oq-01-oq-03`: derive the probabilistic corollary `Cov(f(X),g(X)) ≥ 0` for monotone `f, g` and `X` uniform on `[a,b]`, and connect it to the FKG inequality.

- `expectUnif` / `covUnif`: uniform-law expectation `E[h] = (1/(b−a))∫ₐᵇ h` and covariance
- `expectUnif_one`: `E[1] = 1` (the uniform law is a probability distribution)
- `covUnif_nonneg_of_monotoneOn`: `Cov(f(X),g(X)) ≥ 0` (positive correlation of monotone functions)
- `covUnif_nonpos_of_antitoneOn`: `Cov ≤ 0` for opposite monotonicity
- `expectUnif_mul_ge/le_of_...`: `E[fg] ≥ E[f]E[g]` — the **Harris–FKG correlation inequality specialised to a chain**

The proof is a single division by `(b−a)² > 0` of the parent theorem `(∫f)(∫g) ≤ (b−a)∫fg`; no new analysis, only ordered-field arithmetic. 5 theorems, 2 definitions, 125 lines.

## Files
- `src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03-oq-03/{meta.json,annotations.json,index.ts}` (new gallery entry)

The `listings.json` / `data-manifest.json` are regenerated by the deployer's sync step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)