### PR TITLE
Fix: correct area-of-circle-oq-07-oq-03-oq-03 badge to 'mathlib' (#33810)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-03/meta.json
@@ -39,7 +39,7 @@
     "lineCount": 110,
     "theoremCount": 4,
     "definitionCount": 0,
-    "badge": "original",
+    "badge": "mathlib",
     "originalContributions": [
       "gaussian_moment_eq_gamma: the identification of the entire half-integer Gamma ladder with even Gaussian moments — ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) for every n, extending the parent's single value Γ(1/2) = √π to the whole tower.",
       "gaussian_moment_closed: the double-factorial closed form ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ, combining the ladder identity with Mathlib's Real.Gamma_nat_add_half.",


### PR DESCRIPTION
## Fix

Change `badge` from `original` to `mathlib` for area-of-circle-oq-07-oq-03-oq-03 ("The Half-Integer Gamma Ladder as Even Gaussian Moments"). Tier B — the core analytic result comes via a Mathlib bridge.

## Evidence

**Before**: `badge: "original"` — overclaims mathematical independence.
**After**: `badge: "mathlib"` — matches the honest narrative.

The main theorem `gaussian_moment_eq_gamma` (∫_ℝ x^{2n} e^{-x²} dx = Γ(n+1/2)) derives its entire analytic core from Mathlib:
- Half-line value ½·Γ(n+1/2) = `integral_rpow_mul_exp_neg_rpow` (the u=x² substitution — the hard part), at `AreaOfCircleOQ07OQ03OQ03.lean:64`.
- Double-factorial closed form = direct `rw [Real.Gamma_nat_add_half]` at line 94.

The genuine in-file contribution is only the even-symmetry doubling plus rpow↔pow form-bridging — an elementary assembly step. This is Tier B (Failure Mode #5).

`status` stays `verified` (0 sorries, 0 axioms, no `native_decide`, no `True` stubs — all confirmed). The overview/conclusion/originalContributions already transparently credit the Mathlib lemmas, so this is a one-field correction aligning the badge with the honest narrative.

Closes #33810

---
Automated fix by lean-mechanic agent.