### PR TITLE
Research: erdos-10-wip-01-oq-02 — ORIENT: pin popcount equality characterization, refute false lower bound

### DIFF
--- a/research/problems/erdos-10-wip-01-oq-02/knowledge.md
+++ b/research/problems/erdos-10-wip-01-oq-02/knowledge.md
@@ -1,0 +1,170 @@
+# Knowledge Base: erdos-10-wip-01-oq-02
+
+ORIENT-phase analysis (researcher-9, 2026-07-02).
+
+Parent: `Erdos10WIP01.lean` proved **binary popcount is subadditive**
+
+```
+popcount (a + b) ≤ popcount a + popcount b        -- bitIndices_length_add_le
+```
+
+where `popcount n := (Nat.bitIndices n).length` is the number of binary 1-bits.
+This open question asks for a *matching lower bound* or a *characterization of
+equality* in that subadditive bound.
+
+---
+
+## Problem Understanding
+
+The seeker note proposes two alternatives:
+
+1. a matching lower bound `popcount(a+b) ≥ |popcount a − popcount b|`, **or**
+2. characterize equality (no carries) in the subadditive bound.
+
+### Alternative (1) is FALSE — do not attempt it.
+
+`popcount(a+b) ≥ |popcount a − popcount b|` is refuted by an explicit
+counterexample. Take `a = 1`, `b = 7`:
+
+```
+popcount 1 = 1,  popcount 7 = 3,  a + b = 8,  popcount 8 = 1
+|popcount 1 − popcount 7| = 2  >  1 = popcount 8.
+```
+
+An exhaustive check over `0 ≤ a,b < 64` finds **142** counterexamples; the
+lexicographically smallest is `(a,b) = (1,7)`. Adding a low bit to a
+high-popcount number can *cascade carries* and collapse popcount to `1`
+(`0b0111 + 1 = 0b1000`), so `popcount(a+b)` has **no** nontrivial general lower
+bound in terms of `popcount a`, `popcount b`. The intuition "addition can only
+lose bits by a bounded amount" is wrong: a single carry chain can annihilate an
+arbitrarily long run of 1-bits.
+
+**Conclusion:** the correct, well-posed target is alternative (2), the equality
+characterization.
+
+---
+
+## The correct target (well-posed, verified true numerically)
+
+> **Equality characterization.** For all `a b : ℕ`,
+> ```
+> popcount (a + b) = popcount a + popcount b   ↔   a &&& b = 0.
+> ```
+
+i.e. equality in the subadditive bound holds **exactly** when `a` and `b` have
+disjoint binary supports (no position where both have a 1-bit), which is exactly
+the "no carries" condition. Verified by brute force for all `a,b < 256`:
+`(popcount(a+b) = popcount a + popcount b) ↔ (a &&& b = 0)` is `True` on the
+whole square, and `a &&& b ≠ 0 ⇒ popcount(a+b) < popcount a + popcount b`
+(strict) also holds throughout.
+
+Note carries can still *propagate* through positions where only one operand has
+a bit, but a carry can only be *born* at a position where both operands have a
+1-bit; hence "no carries anywhere" ⟺ "no shared 1-bit" ⟺ `a &&& b = 0`.
+
+---
+
+## The clean engine: an exact popcount/carry identity
+
+The sharpest supporting lemma (proves both directions at once and gives the
+strict inequality for free) is the classical exact identity
+
+> **`popcount a + popcount b = popcount (a ^^^ b) + 2 · popcount (a &&& b)`.**
+
+Reason: split bit positions into three disjoint classes — *both* set
+(contributes `2` to the left, `0` to `a^^^b`, `1` to `a&&&b`), *exactly one*
+set (contributes `1` to the left, `1` to `a^^^b`, `0` to `a&&&b`), *neither*
+(contributes `0` everywhere). `a^^^b` and `a&&&b` have disjoint supports, so
+their popcounts are literal cardinalities of the "exactly-one" and "both" bit
+sets.
+
+Combined with the base recursion of binary addition
+`a + b = (a ^^^ b) + 2 · (a &&& b)` (add without carry, then the carries shifted
+up by one) and `popcount (2 * n) = popcount n`, this yields, by strong
+induction on `a + b`,
+
+> **`popcount a + popcount b − popcount (a + b) = (number of carries) ≥ 0`,**
+
+and equality `popcount(a+b) = popcount a + popcount b` iff there are zero
+carries iff `a &&& b = 0`. The strict corollary
+
+> **`a &&& b ≠ 0 ⇒ popcount (a + b) < popcount a + popcount b`**
+
+drops straight out.
+
+---
+
+## Proof plan for Lean (both directions)
+
+### Forward direction (`a &&& b = 0 ⇒ equality`) — the easy half
+
+Work through the existing representation machinery rather than raw carries:
+
+1. `S n := (Nat.bitIndices n).toFinset`. Since `Nat.bitIndices_sorted`
+   (`SortedLT`) gives `Nodup`, `popcount n = (S n).card`.
+2. `Nat.twoPowSum_bitIndices : (n.bitIndices.map (2 ^ ·)).sum = n`, so
+   `n = ∑ i ∈ S n, 2 ^ i`.
+3. `a &&& b = 0 ↔ S a ∩ S b = ∅` (via `Nat.testBit_land` + a
+   `i ∈ bitIndices n ↔ n.testBit i` membership lemma — **needs locating in
+   Mathlib**, see gaps).
+4. Disjoint ⇒ `a + b = ∑ i ∈ S a, 2^i + ∑ i ∈ S b, 2^i = ∑ i ∈ S a ∪ S b, 2^i`
+   (`Finset.sum_union` on disjoint sets).
+5. Binary-expansion uniqueness (`Nat.bitIndices_twoPowsum` for a `SortedLT`
+   list, i.e. the sorted merge of `S a ∪ S b`) gives
+   `S (a + b) = S a ∪ S b`, hence
+   `popcount (a+b) = (S a ∪ S b).card = (S a).card + (S b).card`
+   by `Finset.card_union_of_disjoint`.
+
+### Reverse direction (`equality ⇒ a &&& b = 0`) — the hard half
+
+Prove the contrapositive via the exact identity engine above. The load-bearing
+lemma is `popcount a + popcount b = popcount (a ^^^ b) + 2 · popcount (a &&& b)`
+plus `a + b = (a ^^^ b) + 2 * (a &&& b)` and strong induction on `a + b`
+(the pair `(a ^^^ b, a &&& b)` recurses on a strictly smaller sum whenever
+`a &&& b ≠ 0`, because `a + b = (a^^^b) + 2(a&&&b)` and re-adding those two is a
+smaller instance). This is the delicate part (~50–100 lines of bit
+bookkeeping); the exact identity is the right lemma to isolate and hand to
+Aristotle once the build/prover environment is back.
+
+---
+
+## Mathlib inventory
+
+Present and usable:
+- `Nat.bitIndices`, `Nat.bitIndices_sorted` (`SortedLT`), `bitIndices_zero/one`,
+  `bitIndices_two_pow`, `Nat.twoPowSum_bitIndices`, `Nat.bitIndices_twoPowsum`
+  (uniqueness for sorted lists) — `Mathlib/Data/Nat/BitIndices.lean`.
+- `Nat.testBit_land`, `Nat.testBit_lor`, `Nat.xor_eq_zero`,
+  `Nat.zero_of_testBit_eq_false`, `Nat.lor_comm/land_comm` —
+  `Mathlib/Data/Nat/Bitwise.lean`.
+- Parent lemmas `bitIndices_length_add_le`, `repWithAtMost_add`,
+  `popcount_le_iff` — `Erdos10WIP01.lean`.
+
+Gaps to fill (none look deep, all routine):
+- **`i ∈ Nat.bitIndices n ↔ n.testBit i`** — a membership↔testBit bridge. Not
+  found by name in `BitIndices.lean`; may exist elsewhere or need a short proof
+  from `Nat.twoPowSum_bitIndices` + `Nat.testBit_two_pow`.
+- **`a &&& b = 0 → a + b = a ||| b`** (disjoint add = or) — no direct lemma
+  found in `Nat/Bitwise.lean`; provable from `Nat.testBit_add`/carry lemmas.
+- **`popcount a + popcount b = popcount (a^^^b) + 2·popcount(a&&&b)`** — not in
+  Mathlib; this is the key new lemma to add (and the ideal Aristotle target).
+
+---
+
+## Dead Ends
+
+- Alternative-(1) lower bound `popcount(a+b) ≥ |popcount a − popcount b|`:
+  **false** (counterexample `(1,7)`; 142 counterexamples for `a,b<64`). Do not
+  pursue.
+
+## Environment blocker (this session)
+
+- Local Docker/`lake` build impossible: host disk at 100% (≈0.5 GiB free) — any
+  build attempt fails on `ENOSPC`.
+- Aristotle MCP unavailable this session (`prove` returns `Resource not
+  found`), so the reverse-direction lemma could not be offloaded server-side.
+- Consequence: shipped as an ORIENT-phase analysis (correct target pinned, false
+  direction refuted, full two-direction proof plan, Mathlib gaps enumerated)
+  rather than a build-verified Lean file. A follow-up session with a working
+  build should formalize the plan above; the forward direction is
+  ready-to-write, the reverse hinges on the exact popcount/carry identity.

--- a/src/data/research/problems/erdos-10-wip-01-oq-02.json
+++ b/src/data/research/problems/erdos-10-wip-01-oq-02.json
@@ -1,0 +1,96 @@
+{
+  "slug": "erdos-10-wip-01-oq-02",
+  "title": "Popcount subadditivity: characterize equality — popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall a\\,b:\\mathbb{N},\\; \\operatorname{popcount}(a+b) = \\operatorname{popcount}(a) + \\operatorname{popcount}(b) \\iff a \\mathbin{\\&} b = 0, \\quad \\text{where } \\operatorname{popcount}(n) = |\\{i : n_i = 1\\}|.",
+    "plain": "Characterize equality in the (already-proved) subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b). Equality holds exactly when a and b have disjoint binary supports, i.e. a &&& b = 0 (no carries). The seeker's alternative target — a lower bound popcount(a+b) ≥ |popcount(a)−popcount(b)| — is FALSE (counterexample a=1,b=7: popcount(8)=1 < |1−3|=2).",
+    "whyMatters": [
+      "Completes the additive theory of binary popcount begun in Erdos10WIP01.lean (subadditivity) with a sharp equality/carry characterization.",
+      "The engine identity popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b) is a clean, reusable Kummer/Legendre-style carry-count fact not currently in Mathlib."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent Erdos10WIP01.bitIndices_length_add_le: popcount(a+b) ≤ popcount a + popcount b (subadditive).",
+      "Numerically verified (a,b<256): popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0.",
+      "Numerically verified (a,b<128): a &&& b ≠ 0 ⇒ popcount(a+b) < popcount a + popcount b (strict)."
+    ],
+    "open": [
+      "Lean formalization of the equality characterization (this problem). Forward direction (a&&&b=0 ⇒ equality) is ready-to-write via Finset disjoint-union + binary uniqueness; reverse direction needs the exact carry identity + strong induction."
+    ],
+    "goal": "theorem popcount_add_eq_iff (a b : ℕ) : (Nat.bitIndices (a+b)).length = (Nat.bitIndices a).length + (Nat.bitIndices b).length ↔ a &&& b = 0"
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-02T23:52:36.442Z",
+    "iteration": 2,
+    "focus": "Correct target pinned (equality characterization); seeker's lower-bound alternative refuted; full two-direction proof plan and Mathlib gap list recorded.",
+    "blockers": [
+      "Local build impossible: host disk at 100% (~0.5 GiB free), Docker/lake builds fail with ENOSPC.",
+      "Aristotle MCP unavailable this session (prove returns 'Resource not found')."
+    ],
+    "nextAction": "On a build-capable session: write Erdos10WIP01OQ02.lean. Prove forward direction via S(n)=(bitIndices n).toFinset disjoint-union route; isolate the lemma popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b) (hand to Aristotle) and derive the reverse direction + strict subadditivity from it.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: Pinned the well-posed target. The seeker's proposed lower bound popcount(a+b) ≥ |popcount a − popcount b| is FALSE — smallest counterexample (a,b)=(1,7): popcount(8)=1 < |1−3|=2 (142 counterexamples for a,b<64). Correct result is the equality characterization popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0, verified for all a,b<256. Identified the clean engine lemma popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b) and a full two-direction Lean proof plan. No Lean shipped: local build blocked (disk 100%) and Aristotle down; delivered as ORIENT analysis + proof plan.",
+    "builtItems": [
+      "research/problems/erdos-10-wip-01-oq-02/knowledge.md — full ORIENT analysis, counterexample, engine identity, two-direction proof plan, Mathlib inventory."
+    ],
+    "insights": [
+      "The seeker's alternative target popcount(a+b) ≥ |popcount a − popcount b| is FALSE: a single carry chain can annihilate an arbitrarily long run of 1-bits (0b0111 + 1 = 0b1000). Smallest counterexample (1,7); 142 counterexamples over a,b<64.",
+      "Correct characterization: popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0 (disjoint binary supports = no carries). Verified exhaustively for a,b<256.",
+      "A carry is only *born* at a position where both operands have a 1-bit (though it may propagate through single-bit positions); hence 'no carries' ⟺ a &&& b = 0.",
+      "Engine identity (not in Mathlib): popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b). Combined with a + b = (a^^^b) + 2·(a&&&b) and popcount(2n)=popcount n and strong induction on a+b, it yields both the equality characterization and the strict inequality a&&&b≠0 ⇒ popcount(a+b) < popcount a + popcount b.",
+      "Forward direction (a&&&b=0 ⇒ equality) is the easy half: S(n)=(bitIndices n).toFinset, disjoint supports ⇒ a+b = ∑_{S a ∪ S b} 2^i, then binary uniqueness (Nat.bitIndices_twoPowsum) gives S(a+b)=S a ∪ S b and card adds (Finset.card_union_of_disjoint)."
+    ],
+    "mathlibGaps": [
+      "No `i ∈ Nat.bitIndices n ↔ n.testBit i` membership↔testBit bridge found in BitIndices.lean (provable from twoPowSum_bitIndices + testBit_two_pow).",
+      "No `a &&& b = 0 → a + b = a ||| b` (disjoint add = or) lemma in Nat/Bitwise.lean.",
+      "The engine identity popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b) is not in Mathlib — the key new lemma / ideal Aristotle target."
+    ],
+    "nextSteps": [
+      "Write Erdos10WIP01OQ02.lean with theorem popcount_add_eq_iff.",
+      "Forward direction: implement the Finset disjoint-union + binary-uniqueness route (ready-to-write).",
+      "Reverse direction: prove/obtain popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b), then strong induction on a+b via a+b=(a^^^b)+2(a&&&b).",
+      "Submit the engine identity to Aristotle once the prover is reachable; build via docker-build.sh once disk is freed.",
+      "Create gallery entry only after a build-verified proof (0 sorries) exists — do NOT ship build-pending."
+    ]
+  },
+  "tags": [
+    "additive-combinatorics",
+    "binary",
+    "erdos-problem",
+    "number-theory",
+    "popcount",
+    "powers-of-two",
+    "primes",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-10-wip-01",
+    "erdos-10-oq-02"
+  ],
+  "references": {
+    "papers": [
+      "Kummer, E. E. (1852). On the 2-adic valuation of binomial coefficients (carry count = popcount a + popcount b − popcount(a+b))."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib/Data/Nat/BitIndices.lean",
+      "Mathlib/Data/Nat/Bitwise.lean"
+    ]
+  },
+  "started": "2026-07-02T23:52:36.441Z",
+  "lastUpdate": "2026-07-02T23:59:00.000Z",
+  "significance": 5,
+  "tractability": 5
+}


### PR DESCRIPTION
## Summary
ORIENT-phase research on **erdos-10-wip-01-oq-02** (child of `Erdos10WIP01.lean`, which proved binary popcount is subadditive: `popcount(a+b) ≤ popcount a + popcount b`).

The open question asked for *either* a matching lower bound *or* a characterization of equality. This session pins the well-posed target and refutes the false one.

## Findings
- **The seeker's proposed lower bound `popcount(a+b) ≥ |popcount a − popcount b|` is FALSE.** Smallest counterexample `(a,b)=(1,7)`: `popcount(8)=1 < |1−3|=2`. Exhaustive check: 142 counterexamples for `a,b<64`. A single carry chain can annihilate an arbitrarily long run of 1-bits (`0b0111 + 1 = 0b1000`), so no nontrivial general lower bound exists.
- **Correct target (verified for all `a,b<256`):** `popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0` (disjoint binary supports = no carries).
- **Engine identity** (not in Mathlib): `popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b)`; with `a+b=(a^^^b)+2·(a&&&b)` and strong induction it yields both directions plus the strict inequality `a&&&b≠0 ⇒ popcount(a+b) < popcount a + popcount b`.
- Full two-direction Lean proof plan and Mathlib gap list recorded in `research/problems/erdos-10-wip-01-oq-02/knowledge.md`.

## Files
- `src/data/research/problems/erdos-10-wip-01-oq-02.json` — structured knowledge (insights, goal theorem, next steps).
- `research/problems/erdos-10-wip-01-oq-02/knowledge.md` — full ORIENT analysis.

## Status
**Outcome**: progress (ORIENT). No Lean shipped — local build blocked (host disk 100%, ENOSPC) and Aristotle MCP unavailable this session (`Resource not found`). Deliberately did **not** ship an unverified build-pending file.
**Next Steps**: On a build-capable session, write `Erdos10WIP01OQ02.lean`; forward direction is ready-to-write (Finset disjoint-union + binary uniqueness), reverse hinges on the exact carry identity (ideal Aristotle target). Create a gallery entry only after a 0-sorry build-verified proof exists.

🤖 Generated by researcher-9