### PR TITLE
research(erdos-1039): complete 3 sorries in polynomial-lemniscate proof [BUILD-PENDING]

### DIFF
--- a/proofs/Proofs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Erdos1039Problem.lean
@@ -226,10 +226,177 @@ theorem sublevelSet_nonempty (hf : f.degree > 0) :
 /-- Area of the sublevel set (Lebesgue measure, converted to ℝ via toReal). -/
 noncomputable def sublevelArea : ℝ := (MeasureTheory.volume (sublevelSet f)).toReal
 
-/-- Lower bound on area implies lower bound on inscribed disc. -/
+open MeasureTheory
+open scoped ENNReal
+
+/-
+## Geometric Infrastructure
+
+The three special-case results below all reduce to elementary facts about the set
+of inscribed-disc radii.  We record the shared lemmas first.
+-/
+
+/-- An inscribed disc is literally a metric ball contained in `S`. -/
+theorem inscribed_ball_subset {S : Set ℂ} {c : ℂ} {r : ℝ}
+    (h : isInscribedDisc S c r) : Metric.ball c r ⊆ S := by
+  intro z hz
+  rw [Metric.mem_ball, dist_eq_norm] at hz
+  exact h.2 z hz
+
+/-- If the open ball `B(c, r)` (with `r > 0`) is contained in `B(z₀, R)` (with `R > 0`),
+    then `r ≤ R`.  Proof: push a point of `B(c, r)` in the direction away from `z₀`. -/
+theorem inscribed_radius_le {c z0 : ℂ} {r R : ℝ} (hr : 0 < r) (hR : 0 < R)
+    (h : ∀ z : ℂ, ‖z - c‖ < r → ‖z - z0‖ < R) : r ≤ R := by
+  by_contra hlt
+  push_neg at hlt
+  obtain ⟨u, hu, hcu⟩ : ∃ u : ℂ, ‖u‖ = 1 ∧ (c - z0) = (‖c - z0‖ : ℝ) • u := by
+    rcases eq_or_ne (c - z0) 0 with h0 | h0
+    · exact ⟨1, norm_one, by rw [h0]; simp⟩
+    · refine ⟨(‖c - z0‖ : ℝ)⁻¹ • (c - z0), ?_, ?_⟩
+      · rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (inv_nonneg.mpr (norm_nonneg _))]
+        exact inv_mul_cancel₀ (norm_ne_zero_iff.mpr h0)
+      · rw [smul_smul, mul_inv_cancel₀ (norm_ne_zero_iff.mpr h0), one_smul]
+  set t : ℝ := (r + R) / 2 with ht
+  have ht0 : 0 < t := by rw [ht]; linarith
+  have htr : t < r := by rw [ht]; linarith
+  have htR : R < t := by rw [ht]; linarith
+  have hwc : ‖(c + t • u) - c‖ < r := by
+    have he : (c + t • u) - c = t • u := by abel
+    rw [he, norm_smul, hu, mul_one, Real.norm_eq_abs, abs_of_pos ht0]
+    exact htr
+  have hwz : ‖(c + t • u) - z0‖ < R := h _ hwc
+  have hcompute : ‖(c + t • u) - z0‖ = ‖c - z0‖ + t := by
+    have e1 : (c + t • u) - z0 = ((‖c - z0‖ : ℝ) + t) • u := by
+      rw [add_smul, ← hcu]; abel
+    rw [e1, norm_smul, hu, mul_one, Real.norm_eq_abs,
+      abs_of_nonneg (by have := norm_nonneg (c - z0); linarith)]
+  rw [hcompute] at hwz
+  have hnn := norm_nonneg (c - z0)
+  linarith
+
+/-- For a polynomial of positive degree, the sublevel set sits inside the ball of radius 2:
+    if `‖z‖ ≥ 2` then every factor `‖z - zᵢ‖ ≥ 1`, so `‖f(z)‖ ≥ 1`. -/
+theorem sublevelSet_subset_ball (hf : 0 < f.degree) :
+    sublevelSet f ⊆ Metric.ball 0 2 := by
+  intro z hz
+  simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval] at hz
+  rw [Metric.mem_ball, dist_zero_right]
+  by_contra hcon
+  push_neg at hcon
+  have hfac : ∀ i : Fin f.degree, (1 : ℝ) ≤ ‖z - f.roots i‖ := by
+    intro i
+    have htri : ‖z‖ ≤ ‖z - f.roots i‖ + ‖f.roots i‖ := by
+      have := norm_add_le (z - f.roots i) (f.roots i)
+      simpa using this
+    have hri := f.roots_in_disc i
+    linarith
+  have hprod : (1 : ℝ) ≤ ∏ i : Fin f.degree, ‖z - f.roots i‖ := by
+    calc (1 : ℝ) = ∏ _i : Fin f.degree, (1 : ℝ) := by rw [Finset.prod_const_one]
+      _ ≤ ∏ i : Fin f.degree, ‖z - f.roots i‖ :=
+          Finset.prod_le_prod (fun i _ => zero_le_one) (fun i _ => hfac i)
+  rw [← norm_prod] at hprod
+  linarith
+
+/-- The set of inscribed-disc radii is bounded above (by `8`) for positive degree. -/
+theorem bddAbove_inscribed_radii (hf : 0 < f.degree) :
+    BddAbove {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := by
+  refine ⟨8, ?_⟩
+  rintro r ⟨c, hrpos, hsub⟩
+  have hcmem : c ∈ sublevelSet f := hsub c (by simpa using hrpos)
+  have hc2 : ‖c‖ < 2 := by
+    have h := sublevelSet_subset_ball f hf hcmem
+    rwa [Metric.mem_ball, dist_zero_right] at h
+  have hxmem : (c + ((r / 2 : ℝ) : ℂ)) ∈ sublevelSet f := by
+    apply hsub
+    have he : (c + ((r / 2 : ℝ) : ℂ)) - c = ((r / 2 : ℝ) : ℂ) := by ring
+    rw [he, Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith)]
+    linarith
+  have hx2 : ‖c + ((r / 2 : ℝ) : ℂ)‖ < 2 := by
+    have h := sublevelSet_subset_ball f hf hxmem
+    rwa [Metric.mem_ball, dist_zero_right] at h
+  have he2 : ‖((r / 2 : ℝ) : ℂ)‖ ≤ ‖c + ((r / 2 : ℝ) : ℂ)‖ + ‖c‖ := by
+    have h := norm_sub_le (c + ((r / 2 : ℝ) : ℂ)) c
+    have he : (c + ((r / 2 : ℝ) : ℂ)) - c = ((r / 2 : ℝ) : ℂ) := by ring
+    rwa [he] at h
+  rw [Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith)] at he2
+  linarith
+
+/-- When the polynomial has degree zero it is the empty product `1`, so the sublevel set
+    `{z : |f(z)| < 1}` is empty. -/
+theorem sublevelSet_degree_zero (h : f.degree = 0) : sublevelSet f = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  intro z hz
+  simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval] at hz
+  haveI : IsEmpty (Fin f.degree) := by rw [h]; infer_instance
+  rw [Finset.univ_eq_empty, Finset.prod_empty, norm_one] at hz
+  exact absurd hz (lt_irrefl 1)
+
+/-- Lower bound on area implies lower bound on inscribed disc: the sublevel set contains an
+    inscribed disc of every radius `r < ρ(f)`, each of area `π r²`, so its area is `≥ π ρ(f)²`. -/
 theorem area_implies_disc_bound :
     sublevelArea f ≥ Real.pi * (rho f)^2 := by
-  sorry
+  rcases Set.eq_empty_or_nonempty
+      {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} with hempty | hne
+  · -- No inscribed disc exists, so ρ(f) = sSup ∅ = 0.
+    have hz : rho f = 0 := by
+      show sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} = 0
+      rw [hempty, Real.sSup_empty]
+    rw [ge_iff_le, hz]
+    have h0 : Real.pi * (0 : ℝ) ^ 2 = 0 := by ring
+    rw [h0]
+    exact ENNReal.toReal_nonneg
+  · obtain ⟨r0, hr0mem⟩ := hne
+    obtain ⟨c0, hr0pos, hsub0⟩ := hr0mem
+    have hc0 : c0 ∈ sublevelSet f := hsub0 c0 (by simpa using hr0pos)
+    have hdeg : 0 < f.degree := by
+      rcases Nat.eq_zero_or_pos f.degree with h0 | hpos
+      · rw [sublevelSet_degree_zero f h0] at hc0; exact absurd hc0 (Set.notMem_empty _)
+      · exact hpos
+    have hfin : MeasureTheory.volume (sublevelSet f) ≠ ⊤ :=
+      ((Metric.isBounded_ball).subset (sublevelSet_subset_ball f hdeg)).measure_lt_top.ne
+    have hpi : 0 < Real.pi := Real.pi_pos
+    have hkey : ∀ r ∈ {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r},
+        Real.pi * r ^ 2 ≤ sublevelArea f := by
+      rintro r ⟨c, hrpos, hsub⟩
+      have hsubset : Metric.ball c r ⊆ sublevelSet f := inscribed_ball_subset ⟨hrpos, hsub⟩
+      have hvol : MeasureTheory.volume (Metric.ball c r)
+          ≤ MeasureTheory.volume (sublevelSet f) := measure_mono hsubset
+      rw [Complex.volume_ball] at hvol
+      have hle2 : ((ENNReal.ofReal r) ^ 2 * (NNReal.pi : ℝ≥0∞)).toReal ≤ sublevelArea f :=
+        (ENNReal.toReal_le_toReal
+          (ENNReal.mul_ne_top (ENNReal.pow_ne_top ENNReal.ofReal_ne_top) ENNReal.coe_ne_top)
+          hfin).mpr hvol
+      have hcompute : ((ENNReal.ofReal r) ^ 2 * (NNReal.pi : ℝ≥0∞)).toReal = Real.pi * r ^ 2 := by
+        rw [ENNReal.toReal_mul, ENNReal.toReal_pow, ENNReal.toReal_ofReal hrpos.le,
+            ENNReal.coe_toReal, NNReal.coe_real_pi]
+        ring
+      rw [hcompute] at hle2
+      exact hle2
+    have hbdd : BddAbove {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} :=
+      bddAbove_inscribed_radii f hdeg
+    have hsup_bound :
+        sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}
+          ≤ Real.sqrt (sublevelArea f / Real.pi) := by
+      apply csSup_le ⟨r0, c0, hr0pos, hsub0⟩
+      rintro r ⟨c, hrpos, hsub⟩
+      have h1 : Real.pi * r ^ 2 ≤ sublevelArea f := hkey r ⟨c, hrpos, hsub⟩
+      have h2 : r ^ 2 ≤ sublevelArea f / Real.pi := by
+        rw [le_div_iff₀ hpi]; nlinarith [h1]
+      calc r = Real.sqrt (r ^ 2) := (Real.sqrt_sq hrpos.le).symm
+        _ ≤ Real.sqrt (sublevelArea f / Real.pi) := Real.sqrt_le_sqrt h2
+    have hsup_nonneg :
+        0 ≤ sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} :=
+      le_trans hr0pos.le (le_csSup hbdd ⟨c0, hr0pos, hsub0⟩)
+    have hrho : rho f = sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := rfl
+    rw [ge_iff_le, hrho]
+    have hsq :
+        (sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}) ^ 2
+          ≤ sublevelArea f / Real.pi := by
+      have hs := Real.sq_sqrt (div_nonneg ENNReal.toReal_nonneg hpi.le)
+      nlinarith [hsup_bound, hsup_nonneg, hs, Real.sqrt_nonneg (sublevelArea f / Real.pi)]
+    calc Real.pi * (sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}) ^ 2
+        ≤ Real.pi * (sublevelArea f / Real.pi) := mul_le_mul_of_nonneg_left hsq hpi.le
+      _ = sublevelArea f := by field_simp
 
 /-- The KLR paper establishes area bounds that imply disc bounds. -/
 axiom klr_area_bound (f : UnitDiscPolynomial) (hf : f.degree ≥ 3) :
@@ -239,20 +406,81 @@ axiom klr_area_bound (f : UnitDiscPolynomial) (hf : f.degree ≥ 3) :
 ## Special Cases
 -/
 
-/-- For n = 1, the sublevel set contains a disc of radius 1. -/
+/-- For n = 1, the sublevel set is exactly the unit disc about the single root, so ρ(f) = 1. -/
 theorem degree_one_optimal :
     ∀ (f : UnitDiscPolynomial), f.degree = 1 → rho f = 1 := by
-  sorry
+  intro f hdeg1
+  have hdeg : 0 < f.degree := by rw [hdeg1]; norm_num
+  have hcard : (Finset.univ : Finset (Fin f.degree)).card = 1 := by
+    rw [Finset.card_univ, Fintype.card_fin, hdeg1]
+  have herase : (Finset.univ.erase (⟨0, hdeg⟩ : Fin f.degree)) = ∅ := by
+    rw [← Finset.card_eq_zero, Finset.card_erase_of_mem (Finset.mem_univ _), hcard]
+  have hprod : ∀ z : ℂ, (∏ i : Fin f.degree, (z - f.roots i)) = z - f.roots ⟨0, hdeg⟩ := by
+    intro z
+    rw [← Finset.prod_erase_mul (Finset.univ) (fun i => z - f.roots i)
+        (Finset.mem_univ (⟨0, hdeg⟩ : Fin f.degree)), herase, Finset.prod_empty, one_mul]
+  set z0 : ℂ := f.roots ⟨0, hdeg⟩ with hz0
+  have hset : sublevelSet f = Metric.ball z0 1 := by
+    ext z
+    simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval, Metric.mem_ball,
+      dist_eq_norm]
+    rw [hprod z]
+  have hins1 : isInscribedDisc (sublevelSet f) z0 1 := by
+    refine ⟨one_pos, ?_⟩
+    intro z hz
+    rw [hset, Metric.mem_ball, dist_eq_norm]
+    exact hz
+  have hrho : rho f = sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := rfl
+  rw [hrho]
+  have hne1 : {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r}.Nonempty :=
+    ⟨1, z0, hins1⟩
+  apply le_antisymm
+  · apply csSup_le hne1
+    rintro r ⟨c, hrpos, hsub⟩
+    refine inscribed_radius_le (c := c) (z0 := z0) hrpos one_pos ?_
+    intro z hz
+    have hmem := hsub z hz
+    rw [hset, Metric.mem_ball, dist_eq_norm] at hmem
+    exact hmem
+  · exact le_csSup (bddAbove_inscribed_radii f hdeg) ⟨z0, hins1⟩
 
 /-- For clustered roots, the inscribed disc can be larger. -/
 def hasClusteredRoots (f : UnitDiscPolynomial) (ε : ℝ) : Prop :=
   ∃ c : ℂ, ∀ i, ‖f.roots i - c‖ < ε
 
-/-- Clustered roots give larger inscribed disc. -/
+/-- Clustered roots give a larger inscribed disc: if all roots lie within `ε` of a common
+    centre `c`, then for `‖z - c‖ < 1 - ε` every factor `‖z - zᵢ‖ < 1`, so `‖f(z)‖ < 1`. -/
 theorem clustered_implies_large_disc (ε : ℝ) (hε : ε > 0) (hε' : ε < 1) :
     ∀ (f : UnitDiscPolynomial), hasClusteredRoots f ε → f.degree > 0 →
       rho f ≥ 1 - ε := by
-  sorry
+  intro f hclust hdeg
+  obtain ⟨c, hc⟩ := hclust
+  have hins : isInscribedDisc (sublevelSet f) c (1 - ε) := by
+    refine ⟨by linarith, ?_⟩
+    intro z hz
+    simp only [sublevelSet, Set.mem_setOf_eq, UnitDiscPolynomial.eval]
+    have hfac : ∀ i : Fin f.degree, ‖z - f.roots i‖ < 1 := by
+      intro i
+      have harg : z - f.roots i = (z - c) - (f.roots i - c) := by ring
+      have hci := hc i
+      calc ‖z - f.roots i‖ = ‖(z - c) - (f.roots i - c)‖ := by rw [harg]
+        _ ≤ ‖z - c‖ + ‖f.roots i - c‖ := norm_sub_le _ _
+        _ < (1 - ε) + ε := by linarith
+        _ = 1 := by ring
+    rw [norm_prod]
+    have hi0 : (⟨0, hdeg⟩ : Fin f.degree) ∈ (Finset.univ : Finset (Fin f.degree)) :=
+      Finset.mem_univ _
+    rw [← Finset.prod_erase_mul (Finset.univ) (fun i => ‖z - f.roots i‖) hi0]
+    have hrest : (∏ i ∈ (Finset.univ).erase (⟨0, hdeg⟩ : Fin f.degree), ‖z - f.roots i‖) ≤ 1 :=
+      Finset.prod_le_one (fun i _ => norm_nonneg _) (fun i _ => (hfac i).le)
+    calc (∏ i ∈ (Finset.univ).erase (⟨0, hdeg⟩ : Fin f.degree), ‖z - f.roots i‖)
+            * ‖z - f.roots ⟨0, hdeg⟩‖
+        ≤ 1 * ‖z - f.roots ⟨0, hdeg⟩‖ := mul_le_mul_of_nonneg_right hrest (norm_nonneg _)
+      _ = ‖z - f.roots ⟨0, hdeg⟩‖ := one_mul _
+      _ < 1 := hfac _
+  have hrho : rho f = sSup {r : ℝ | ∃ c : ℂ, isInscribedDisc (sublevelSet f) c r} := rfl
+  rw [ge_iff_le, hrho]
+  exact le_csSup (bddAbove_inscribed_radii f hdeg) ⟨c, hins⟩
 
 /-
 ## Random Polynomials

--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1039-incomplete-01",
   "title": "Complete polynomial lemniscate disc radius proof",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-30T16:34:54.972Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS (BUILD-PENDING): wrote full proofs of all 3 elementary sorries; 5 deep axioms unchanged; Docker/disk outage blocked confirming build.",
+    "builtItems": [
+      "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
+      "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
+      "Branch research/erdos-1039-complete-sorries, PR #33815 (BUILD-PENDING)."
+    ],
+    "insights": [
+      "Erdos1039Problem.lean's 3 sorries are elementary geometry (NOT the open EHP conjecture): area>=pi*rho^2, deg1=>rho=1, clustered roots=>rho>=1-eps. All provable.",
+      "rho(f)=sSup of inscribed-disc radii; key shared lemma inscribed_radius_le: open ball subset open ball => radius bound, proved via a boundary point c+t*u along the unit direction from z0.",
+      "sublevelSet bounded for deg>0: |z|>=2 => each |z-zi|>=1 => |f(z)|>=1; gives finite Lebesgue area (Bornology.IsBounded.measure_lt_top) and BddAbove for the radius sSup.",
+      "Complex.volume_ball a r = ENNReal.ofReal r ^2 * NNReal.pi; toReal = pi*r^2 for r>=0 (needs open scoped ENNReal for the R>=0 infty notation)."
+    ],
+    "mathlibGaps": [
+      "No ball_subset_ball_iff for open balls (necessary direction); had to prove inscribed_radius_le by hand."
+    ],
+    "nextSteps": [
+      "VERIFY: run docker-build.sh Proofs.Erdos1039Problem once Docker/disk recovered; final elaboration crashed on SIGBUS (infra), not a Lean error, so unconfirmed.",
+      "If build fails, likely culprits: field_simp closing pi*(A/pi)=A; nlinarith in hsq; the (NNReal.pi:ENNReal) coercion matching Complex.volume_ball."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Completes the three `sorry`s in `proofs/Proofs/Erdos1039Problem.lean` (Erdős Problem #1039 — inscribed disc radius ρ(f) of polynomial lemniscate sublevel sets). These are the elementary geometric facts of the file; the 5 deep-result **axioms** (Pommerenke, Krishnapur–Lundberg–Ramachandran, benchmark, area bound, random-polynomial) are **unchanged** — Erdős #1039 remains OPEN.

### Sorries proved
- **`area_implies_disc_bound`** — `area(sublevelSet) ≥ π·ρ(f)²`. Each inscribed disc of radius `r < ρ(f)` has Lebesgue measure `π r²` (`Complex.volume_ball`); a `sSup`/`√` argument lifts this to `ρ(f)`. Finiteness of the area comes from a new `sublevelSet_subset_ball` lemma (`‖z‖ ≥ 2 ⇒ ‖f(z)‖ ≥ 1`).
- **`degree_one_optimal`** — degree 1 ⇒ sublevel set is exactly `ball(z₀, 1)`, so `ρ(f) = 1` (antisymmetry: radius 1 is inscribed; every inscribed radius `≤ 1`).
- **`clustered_implies_large_disc`** — roots within `ε` of a common centre `c` give an inscribed disc of radius `1-ε` (each factor `‖z-zᵢ‖ < 1` on that disc ⇒ `‖f(z)‖ < 1`).

### Shared infrastructure added
`inscribed_ball_subset`, `inscribed_radius_le` (open ball ⊆ open ball ⇒ radius bound, via a boundary-point argument), `sublevelSet_subset_ball`, `bddAbove_inscribed_radii`, `sublevelSet_degree_zero`.

## ⚠️ BUILD-PENDING — not yet verified

I could **not** obtain a clean confirming build this session. Mid-work the host disk filled and **Docker Desktop's containerd store became I/O-corrupted**, so no container can currently run. Across earlier build iterations every Lean error that surfaced was fixed, and the final run reached full elaboration of the file (215 s) before the container crashed with SIGBUS on a concurrently-modified mmap'd olean — suggestive but **not** conclusive.

**Do not merge until a verifying `docker-build.sh Proofs.Erdos1039Problem` passes.** The deployer's pre-merge build is the safety gate. Axiom/status metadata is intentionally left unchanged (still `axiomatized`, 5 axioms).