### PR TITLE
Enrich Hilbert 10 OQ-04·OQ-03·OQ-01·OQ-01: hard-direction transport annotation

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/annotations.json
@@ -63,6 +63,27 @@
     ]
   },
   {
+    "id": "ann-transport",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 86 },
+    "type": "technique",
+    "title": "Verbatim Reuse: Transport Through the Bridge",
+    "content": "The entire payoff of the bridge lives in this one-line term-mode proof. `solvable_of_finset_gcd_dvd` does **not** re-derive the extended-Euclidean witness — it hands the parent's constructive `exists_vec_combo n a c` a proof of `vecGcd n a ∣ c`, obtained from the abstract hypothesis `Finset.univ.gcd a ∣ c` by a single `rw [vecGcd_eq_finset_gcd]`. Because the bridge is a genuine **equality** rather than an associate relation, this is a plain rewrite (no `Associated`-transport, no unit-juggling), and the parent's Bézout solver runs unchanged. This is precisely what 'discharged verbatim' means: the abstract divisibility criterion is converted to the concrete one by one equation, and every line of the parent's witness construction is reused with zero modification.",
+    "mathContext": "`exists_vec_combo n a c (by rw [vecGcd_eq_finset_gcd]; exact h)`: the hypothesis $\\mathrm{Finset.univ.gcd}\\,a \\mid c$ is rewritten to $\\mathrm{vecGcd}\\,n\\,a \\mid c$, the exact input the constructive solver expects.",
+    "significance": "key",
+    "relatedConcepts": [
+      "proof transport along an equality",
+      "term-mode proof",
+      "constructive solver reuse",
+      "equality vs. associatedness"
+    ],
+    "prerequisites": [
+      "the bridge vecGcd = Finset.gcd",
+      "term-mode Lean proofs",
+      "the parent's exists_vec_combo"
+    ]
+  },
+  {
     "id": "ann-sanity",
     "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
     "range": { "startLine": 103, "endLine": 111 },


### PR DESCRIPTION
Enrichment pass for `hilbert-10-oq-04-oq-03-oq-01-oq-01` (0 prior passes, quality 91).

The meta.json was already rich (4 keyInsights, full historicalContext, conclusion with implications + 3 open questions, cross-references, references). The one gap against the quality target was annotation count: 4, target ≥5.

**Change:** added a 5th annotation `ann-transport` (`type: technique`, range 80–86) dedicated to `solvable_of_finset_gcd_dvd` — the hard direction, which is the intellectual heart of the entry (the 'verbatim reuse' claim) but previously got only one sentence inside a broader 71–101 block. The new annotation explains *how* the one-line term-mode proof works: because the bridge `vecGcd = Finset.gcd` is a genuine **equality** (not associatedness), transporting the abstract hypothesis into the parent's constructive `exists_vec_combo` is a plain `rw`, so the Bézout solver runs unchanged.

All 5 annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. meta.json untouched (14.9 KB, well under cap). `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)