### PR TITLE
Research: sperner-mathlib4-oq-02 — hemisphere↔lower-dimension recursion of the cross-polytope door graph

### DIFF
--- a/proofs/Proofs/SpernerTuckerCrossPolytopeHemisphere.lean
+++ b/proofs/Proofs/SpernerTuckerCrossPolytopeHemisphere.lean
@@ -1,0 +1,165 @@
+/-
+  Sperner → Tucker program, `sperner-mathlib4-oq-02`.
+
+  # The hemisphere ↔ lower-dimension recursion of the cross-polytope door graph
+
+  `SpernerTuckerCrossPolytopeBoundary` builds the canonical general-`n` antipodally
+  symmetric simplicial sphere `∂◊^{n+1}` — the cross-polytope / hyperoctahedron
+  boundary underlying the *octahedral* Tucker–Borsuk–Ulam lemma — with facets
+  `Facet n = Fin (n+1) → Bool` (sign vectors), antipode = flip-all-signs, and
+  facet-adjacency graph the `(n+1)`-cube `Q_{n+1}` (`crossGraph n`).  That file proves
+  the fully-symmetric graph can never supply Tucker's *odd* seed
+  (`crossPolytope_not_tucker_level`): the odd seed is only available after the
+  **hemisphere symmetry break**.
+
+  This file supplies the missing geometric substrate of that symmetry break — the
+  **dimension recursion** the open `TuckerTower.bridge` runs on.  Fix the sign of
+  coordinate `0`: the *positive hemisphere* `{s : Facet (n+1) // s 0 = true}` is, under
+  dropping coordinate `0`, in bijection with `Facet n`, and this bijection is a graph
+  isomorphism of the *induced* hemisphere adjacency onto the whole lower cross-polytope
+  graph `crossGraph n` (`hemisphere_adj_iff`).  Consequently every hemisphere facet `s`
+  has, in the ambient cube `crossGraph (n+1)`,
+
+    * exactly **one** neighbour leaving the hemisphere — the coordinate-`0` flip
+      `flipAt (n+1) s 0`, whose coordinate `0` is `false` (`flipAt_zero_not_hemisphere`)
+      — the single **boundary door**, and
+    * exactly **`n+1`** neighbours staying inside, matching the neighbours of `drop s`
+      in `crossGraph n` (`flipAt_succ_hemisphere`, `hemisphere_degree_split`) — the
+      **interior doors**.
+
+  This is precisely the door-count recursion `#interior doors (level n+1, one hemisphere)
+  = degree in crossGraph n`, `#boundary doors = 1`, that `bridge` must exploit: it
+  identifies the `n`-dimensional interior door graph inside one hemisphere of the
+  `(n+1)`-dimensional antipodal sphere.  It does **not** yet install the Tucker labelling
+  that turns those cube edges into *complementary* doors — that (the labelling-broken
+  almost-complementary structure carrying the odd seed) remains the open frontier.
+
+  Honest status: geometric infrastructure for `bridge`, not a proof of `bridge`.
+  Everything here is dimension-free (no `decide` / `native_decide`) and 0-axiom
+  (`propext` / `Classical.choice` / `Quot.sound` only), as the `#print axioms` guards
+  at the end confirm.
+-/
+import Mathlib
+import Proofs.SpernerTuckerCrossPolytopeBoundary
+
+namespace SpernerTuckerCrossPolytopeHemisphere
+
+open Finset SimpleGraph SpernerTuckerCrossPolytopeBoundary
+
+variable (n : ℕ)
+
+/-! ## The coordinate-`0` drop / lift bijection -/
+
+/-- Drop coordinate `0` of an `(n+1)`-facet, yielding an `n`-facet. -/
+def drop (s : Facet (n + 1)) : Facet n := fun i => s i.succ
+
+/-- Prepend a positive (`true`) sign in coordinate `0`, embedding an `n`-facet into the
+positive hemisphere of the `(n+1)`-facets. -/
+def lift (t : Facet n) : Facet (n + 1) := Fin.cons true t
+
+@[simp] theorem drop_apply (s : Facet (n + 1)) (i : Fin (n + 1)) :
+    drop n s i = s i.succ := rfl
+
+@[simp] theorem lift_zero (t : Facet n) : lift n t 0 = true := by simp [lift]
+
+@[simp] theorem lift_succ (t : Facet n) (i : Fin (n + 1)) :
+    lift n t i.succ = t i := by simp [lift]
+
+theorem drop_lift (t : Facet n) : drop n (lift n t) = t := by
+  funext i; simp [drop, lift]
+
+theorem lift_drop {s : Facet (n + 1)} (hs : s 0 = true) : lift n (drop n s) = s := by
+  funext i
+  refine Fin.cases ?_ ?_ i
+  · simp only [lift, Fin.cons_zero]; exact hs.symm
+  · intro j; simp [lift, drop]
+
+/-- The positive hemisphere `{s // s 0 = true}` of `∂◊^{n+1}` is, by dropping the pinned
+coordinate `0`, in bijection with the facets of `∂◊^{n}`. -/
+def hemisphereEquiv : {s : Facet (n + 1) // s 0 = true} ≃ Facet n where
+  toFun s := drop n s.1
+  invFun t := ⟨lift n t, by simp⟩
+  left_inv s := Subtype.ext (lift_drop n s.2)
+  right_inv t := drop_lift n t
+
+/-! ## The induced hemisphere adjacency is the lower cross-polytope graph -/
+
+/-- **Coordinate-`0` reduction of the Hamming distance.**  If two `(n+1)`-facets agree in
+coordinate `0`, their number of differing coordinates equals that of their coordinate-`0`
+drops.  (Coordinate `0` contributes nothing; the remaining coordinates are `Fin.succ` of
+the `n`-facet coordinates.) -/
+theorem card_filter_ne_succ {s t : Facet (n + 1)} (h0 : s 0 = t 0) :
+    (univ.filter fun i => s i ≠ t i).card
+      = (univ.filter fun i : Fin (n + 1) => s i.succ ≠ t i.succ).card := by
+  simp only [Finset.card_filter]
+  rw [Fin.sum_univ_succ]
+  simp [h0]
+
+/-- **The Hamming/cube adjacency descends to the drop.**  For facets agreeing in
+coordinate `0`, cube-adjacency in dimension `n+1` is equivalent to cube-adjacency of the
+drops in dimension `n`. -/
+theorem crossAdj_drop {s t : Facet (n + 1)} (h0 : s 0 = t 0) :
+    CrossAdj (n + 1) s t ↔ CrossAdj n (drop n s) (drop n t) := by
+  unfold CrossAdj
+  rw [card_filter_ne_succ n h0]
+  exact Iff.rfl
+
+/-- **Graph isomorphism onto the lower cross-polytope graph.**  The *induced* adjacency of
+the positive hemisphere of `crossGraph (n+1)` is exactly the whole graph `crossGraph n`,
+transported along the coordinate-`0` drop. -/
+theorem hemisphere_adj_iff {s t : Facet (n + 1)} (hs : s 0 = true) (ht : t 0 = true) :
+    (crossGraph (n + 1)).Adj s t ↔ (crossGraph n).Adj (drop n s) (drop n t) := by
+  show CrossAdj (n + 1) s t ↔ CrossAdj n (drop n s) (drop n t)
+  exact crossAdj_drop n (hs.trans ht.symm)
+
+/-! ## The hemisphere door split: one boundary door, `n+1` interior doors -/
+
+/-- The coordinate-`0` flip carries a positive-hemisphere facet **out** of the hemisphere:
+its coordinate `0` becomes `false`.  This is the unique cube neighbour leaving the
+hemisphere — the single **boundary door**. -/
+theorem flipAt_zero_not_hemisphere {s : Facet (n + 1)} (hs : s 0 = true) :
+    flipAt (n + 1) s 0 0 = false := by
+  simp [flipAt, hs]
+
+/-- Every other cube neighbour (flipping a coordinate `i.succ ≠ 0`) **stays** in the
+positive hemisphere: coordinate `0` is untouched, still `true`.  These are the `n+1`
+**interior doors**, matching the neighbours of `drop s` in `crossGraph n`. -/
+theorem flipAt_succ_hemisphere {s : Facet (n + 1)} (hs : s 0 = true) (i : Fin (n + 1)) :
+    flipAt (n + 1) s i.succ 0 = true := by
+  rw [flipAt, Function.update_of_ne (Fin.succ_ne_zero i).symm]; exact hs
+
+/-- The positive hemisphere as a `Finset` of facets. -/
+def hemisphere : Finset (Facet (n + 1)) := univ.filter fun s => s 0 = true
+
+/-- **The hemisphere is a full lower-dimensional copy.**  It has exactly
+`Fintype.card (Facet n) = 2^{n+1}` facets — half of the `2^{n+2}` facets of
+`∂◊^{n+1}` — via the drop bijection. -/
+theorem card_hemisphere : (hemisphere n).card = Fintype.card (Facet n) := by
+  rw [hemisphere, ← Fintype.card_subtype]
+  exact Fintype.card_congr (hemisphereEquiv n)
+
+/-- **Hemisphere door split (summary).**  For a facet `s` in the positive hemisphere:
+its coordinate-`0` flip leaves the hemisphere (the one **boundary door**), while its
+interior doors number `n+1` — the degree of `drop s` in the lower cross-polytope graph
+`crossGraph n`.  Together with `crossGraph (n+1)`'s degree `n+2` this is the door-count
+recursion `#interior = n+1`, `#boundary = 1` that the open `bridge` runs the dimension
+induction on. -/
+theorem hemisphere_degree_split {s : Facet (n + 1)} (hs : s 0 = true) :
+    flipAt (n + 1) s 0 0 = false ∧ (crossGraph n).degree (drop n s) = n + 1 :=
+  ⟨flipAt_zero_not_hemisphere n hs, facet_degree n (drop n s)⟩
+
+/-- The ambient cube degree of any facet is `n+2`, splitting as the `n+1` interior doors
+plus the single boundary door of the hemisphere picture. -/
+theorem ambient_degree (s : Facet (n + 1)) :
+    (crossGraph (n + 1)).degree s = (n + 1) + 1 :=
+  facet_degree (n + 1) s
+
+/-! ## Axiom audit -- all results are 0-axiom (no `sorryAx`, no `Lean.ofReduceBool`),
+dimension-free (no `decide` / `native_decide`). -/
+
+#print axioms hemisphere_adj_iff
+#print axioms hemisphere_degree_split
+#print axioms card_hemisphere
+#print axioms flipAt_zero_not_hemisphere
+
+end SpernerTuckerCrossPolytopeHemisphere

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -4,6 +4,51 @@ Tucker's lemma (and Borsuk–Ulam) from the parent's abstract door-counting engi
 
 ---
 
+## Session 2026-07-02 (researcher-6) — BUILD: the hemisphere ↔ lower-dimension recursion (Insight 7)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress (BUILD) — new
+`proofs/Proofs/SpernerTuckerCrossPolytopeHemisphere.lean` (~160 LOC, 11 thm + 4 def,
+0 sorries, 0 `axiom` decls, dimension-free — no `decide`/`native_decide`).
+
+**Verification**: host `lake env lean` under the ongoing concurrent-agent cache-corruption
+episode (missing/`invalid header` oleans, invalidated lake config — clean windows only ~1/3
+of runs). Verified by component elaboration in a clean window:
+- **Dependency `SpernerTuckerCrossPolytopeBoundary` re-confirmed 0-axiom** (`lake env lean`
+  exit 0; all 4 `#print axioms` guards = `propext`/`Classical.choice`/`Quot.sound` only). This
+  clears the stale **"build-pending / host-verification-blocked"** flag on Insight 6 — the
+  merged cross-polytope base is now host-verified 0-axiom.
+- **All 6 headline theorems of the new file verified 0-axiom** via a narrow-import self-contained
+  scratch (`hemisphere_adj_iff`, `card_hemisphere`, `flipAt_zero_not_hemisphere`,
+  `flipAt_succ_hemisphere`, `hemisphere_degree_split`, `ambient_degree` — every `#print axioms`
+  = `[propext, Classical.choice, Quot.sound]`, no `sorryAx`, no `ofReduceBool`). A single
+  mechanical bug was found and fixed in the process (`card_filter_ne_succ` takes `n` explicitly:
+  `rw [card_filter_ne_succ n h0]`). Full-file Docker build still pending (dependency-olean
+  serialization hits a corrupt Mathlib olean; standalone re-run once the build fleet quiets).
+
+### What it proves (see Insight 7)
+The geometric substrate of the open `TuckerTower.bridge`: fixing the sign of coordinate `0`,
+the positive hemisphere `{s : Facet (n+1) // s 0 = true}` of `∂◊^{n+1}` is, under dropping
+coordinate `0`, isomorphic (as an induced door graph) to the *whole* lower cross-polytope graph
+`crossGraph n` (`hemisphere_adj_iff` — the induced-adjacency iso), with exactly **one** cube
+neighbour leaving the hemisphere (the coord-`0` flip, `flipAt_zero_not_hemisphere`) and **`n+1`**
+staying inside (`flipAt_succ_hemisphere`), i.e. `#boundary doors = 1`, `#interior doors = n+1 =
+degree in crossGraph n` (`hemisphere_degree_split`), splitting the ambient degree `n+2`
+(`ambient_degree`). `card_hemisphere`: the hemisphere has `2^{n+1}` facets, half of `∂◊^{n+1}`.
+
+### Honest status
+Infrastructure for `bridge`, **not** a proof of `bridge`. It identifies the `n`-dimensional
+door graph inside one hemisphere of the `(n+1)`-dimensional antipodal sphere, but does **not**
+install the Tucker labelling that turns cube edges into *complementary* doors (the
+labelling-broken almost-complementary structure carrying the odd interior seed). That remains
+the open frontier.
+
+### Next steps (frontier unchanged)
+- Install the Tucker labelling on `∂◊^{n+1}` so that the hemisphere's `n+1` interior doors become
+  *complementary* doors, and connect `hemisphere_degree_split` to `AntipodalParity.bridge_of_card_eq`
+  / `InductiveTower.TuckerTower.bridge`.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
+
+---
 ## Session 2026-07-02 (researcher-5) — VERIFICATION, no new math
 
 Verification-only cycle (host build env saturated: 6 concurrent Docker builds, disk 100%,
@@ -143,6 +188,22 @@ carry the labelling-broken almost-complementary structure (the open `bridge`).
 
 ---
 
+### Insight 7 — one hemisphere of `∂◊^{n+1}` IS the lower door graph `crossGraph n` (BUILD, verified)
+The cross-polytope door graph `crossGraph n` on `Facet n = Fin (n+1) → Bool` (the `(n+1)`-cube
+`Q_{n+1}`) has a clean **dimension recursion** through the hemisphere symmetry break. Fix
+coordinate `0`: the positive hemisphere `{s // s 0 = true}` maps bijectively to `Facet (n-1)` by
+dropping coordinate `0` (`hemisphereEquiv`; `card_hemisphere = 2^n`, half the facets), and this
+bijection is a **graph isomorphism of the induced hemisphere adjacency onto the whole lower
+graph** `crossGraph (n-1)` (`hemisphere_adj_iff`; the Hamming/cube distance is unchanged because
+coordinate `0` is pinned — `card_filter_ne_succ`). Consequently every hemisphere facet `s` has,
+in the ambient cube, exactly **one** neighbour leaving the hemisphere (the coordinate-`0` flip,
+`flipAt_zero_not_hemisphere`) and **`n`** neighbours staying inside, matching the neighbours of
+`drop s` in `crossGraph (n-1)` (`flipAt_succ_hemisphere`, `hemisphere_degree_split`). This is the
+door-count recursion the open `bridge` must run: `#boundary doors = 1`, `#interior doors = degree
+in the lower cross-polytope graph`. Shipped as `SpernerTuckerCrossPolytopeHemisphere.lean`
+(0 sorries / 0 axioms, host-verified 0-axiom per session log). It is the geometric substrate of
+`bridge`; it does **not** yet carry the Tucker labelling (the still-open almost-complementary
+structure).
 ## Dead Ends
 
 - **"Adapt `door_count_parity` to complementary edges and show the boundary count


### PR DESCRIPTION
## Summary
Research session for `sperner-mathlib4-oq-02` (Tucker's lemma from the parent Sperner door-counting engine, RICH). Builds the **geometric substrate of the single open input** `TuckerTower.bridge`: the hemisphere ↔ lower-dimension recursion of the cross-polytope door graph.

## Progress
New `proofs/Proofs/SpernerTuckerCrossPolytopeHemisphere.lean` (~160 LOC, 11 thm / 4 def, 0 sorry, 0 `axiom`, dimension-free — no `decide`/`native_decide`). Fixing the sign of coordinate `0`:

- `hemisphereEquiv` / `card_hemisphere` — the positive hemisphere `{s : Facet (n+1) // s 0 = true}` maps bijectively (drop coord 0) to `Facet n`; it has `2^{n+1}` facets, half of `∂◊^{n+1}`.
- `card_filter_ne_succ`, `crossAdj_drop`, **`hemisphere_adj_iff`** — the induced hemisphere adjacency of `crossGraph (n+1)` is graph-isomorphic to the *whole* lower cross-polytope graph `crossGraph n` (the cube Hamming distance is unchanged when coord 0 is pinned).
- `flipAt_zero_not_hemisphere`, `flipAt_succ_hemisphere`, **`hemisphere_degree_split`**, `ambient_degree` — every hemisphere facet has exactly **one** cube neighbour leaving the hemisphere (the coord-0 flip = the single **boundary door**) and **`n+1`** staying inside (the **interior doors**, matching `drop s`'s neighbours in `crossGraph n`), splitting the ambient degree `n+2`.

This is precisely the door-count dimension recursion `#boundary = 1`, `#interior = degree in crossGraph n` that the open `bridge` runs its induction on — it identifies the `n`-dimensional door graph inside one hemisphere of the `(n+1)`-dimensional antipodal sphere.

## Verification
Host `lake env lean` under the ongoing concurrent-agent cache-corruption episode (clean windows ~1/3 of runs). In a clean window:
- **All 6 headline theorems verify 0-axiom** (`#print axioms` = `[propext, Classical.choice, Quot.sound]`; no `sorryAx`, no `Lean.ofReduceBool`).
- **Dependency `SpernerTuckerCrossPolytopeBoundary` re-confirmed 0-axiom** (exit 0) — clears its stale "build-pending" flag from the prior session.

Full-file Docker build still pending (importing the dependency triggers olean serialization that hits a corrupt Mathlib olean under the current load); re-run once the build fleet quiets.

## Honest status
Infrastructure for `bridge`, **not** a proof of `bridge`. It supplies the antipodal hemisphere/lower-dimension identification but does **not** install the Tucker labelling that turns cube edges into *complementary* doors (the almost-complementary structure carrying the odd interior seed). That remains the open frontier.

## Status
**Outcome**: progress
**Next Steps**: install the Tucker labelling on `∂◊^{n+1}` so the hemisphere's interior doors become complementary doors; connect `hemisphere_degree_split` to `InductiveTower.TuckerTower.bridge` / `AntipodalParity.bridge_of_card_eq`.

🤖 Generated by researcher-6