### PR TITLE
research(catalan-numbers-oq-01-oq-04-oq-02): reciprocal Catalan log-concavity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ01OQ04OQ02.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ04OQ02.lean
@@ -1,0 +1,109 @@
+import Mathlib
+import Proofs.CatalanNumbersOQ01OQ04
+
+/-
+# Strict log-concavity of the reciprocal Catalan sequence `1/Cₙ`
+
+This is the leaf `oq-01-oq-04-oq-02` of `catalan-numbers-oq-01`, a companion to the
+parent `oq-01-oq-04`, which proves the **strict log-convexity** (Turán inequality)
+of the Catalan numbers:
+
+  `catalan_turan : catalan (n+1) ^ 2 < catalan n * catalan (n+2)`.
+
+## The mathematical content, and an honest correction
+
+The open question asks for a **derived** Catalan sequence `aₙ` that is strictly
+*log-concave*, `aₙ² > aₙ₋₁·aₙ₊₁`, and suggests `aₙ = Cₙ/(n+1)` as a candidate.
+That candidate is **false**: `n ↦ Cₙ/(n+1)` is *not* log-concave. Already at
+`n = 1`,
+
+  `a₁² = (C₁/2)² = 1/4`,   `a₀·a₂ = (C₀/1)(C₂/3) = 2/3`,   and `1/4 < 2/3`,
+
+so `a₁² > a₀·a₂` **fails** (`catalanOverSucc_not_logConcave_at_one`). The reason is
+structural: the Catalan numbers themselves are strictly log-*convex*, and dividing by
+the mildly-growing `n+1` does not reverse that.
+
+The correct, canonical derived sequence that *is* strictly log-concave is the
+**reciprocal** `aₙ = 1/Cₙ`. Indeed, for any strictly positive strictly log-convex
+sequence the pointwise reciprocal is strictly log-concave — reciprocation is an
+order-reversing multiplicative involution on the positive reals — and this instance
+is *exactly* the parent's Turán inequality read through `x ↦ 1/x`:
+
+  `(1/Cₙ)² > (1/Cₙ₋₁)(1/Cₙ₊₁)  ⟺  Cₙ² < Cₙ₋₁·Cₙ₊₁`.
+
+## What is proved
+
+* `recip_sq_gt_of_sq_lt` — the general pointwise principle: in a `LinearOrderedField`,
+  if `0 < x, y, z` and `y² < x·z` then `(1/y)² > (1/x)·(1/z)`.
+* `catalan_recip_logConcave` — its Catalan instance for every `n`:
+  `(1/catalan (n+1))² > (1/catalan n)·(1/catalan (n+2))` over `ℚ`.
+* `catalan_recip_logConcave_shift` — the same stated in the standard log-concavity
+  indexing `aₙ² > aₙ₋₁·aₙ₊₁` for `n ≥ 1`.
+* `catalanOverSucc_not_logConcave_at_one` — the counterexample refuting the suggested
+  candidate `Cₙ/(n+1)`.
+
+Mathlib has the Catalan API but neither the Turán inequality (supplied by the parent)
+nor this reciprocal log-concavity.
+-/
+
+namespace CatalanNumbersOQ01OQ04OQ02
+
+open Nat CatalanNumbersOQ01OQ04
+
+/-- **Reciprocation turns a strict Turán (log-convexity) step into a strict
+log-concavity step.** In any linearly ordered field, if `x, y, z` are positive and
+`y² < x · z`, then the reciprocals satisfy `(1/x)·(1/z) < (1/y)²`. Purely the fact
+that `t ↦ 1/t` is strictly antitone and multiplicative on the positive cone. -/
+theorem recip_sq_gt_of_sq_lt {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+    {x y z : K} (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) (h : y ^ 2 < x * z) :
+    (1 / x) * (1 / z) < (1 / y) ^ 2 := by
+  have hy2 : (0 : K) < y ^ 2 := by positivity
+  have hxz : (0 : K) < x * z := by positivity
+  -- `(1/y)^2 = 1/y^2` and `(1/x)*(1/z) = 1/(x*z)`; reciprocal reverses `y^2 < x*z`.
+  rw [div_pow, one_pow, div_mul_div_comm, one_mul]
+  exact one_div_lt_one_div_of_lt hy2 h
+
+/-- **Strict log-concavity of the reciprocal Catalan sequence.** For every `n`,
+
+  `(1 / catalan (n+1))² > (1 / catalan n) · (1 / catalan (n+2))`   over `ℚ`,
+
+obtained by reciprocating the parent's strict Turán inequality
+`catalan (n+1)² < catalan n · catalan (n+2)`. -/
+theorem catalan_recip_logConcave (n : ℕ) :
+    (1 / (catalan n : ℚ)) * (1 / (catalan (n + 2) : ℚ))
+      < (1 / (catalan (n + 1) : ℚ)) ^ 2 := by
+  have hA : (0 : ℚ) < catalan n := by exact_mod_cast catalan_pos n
+  have hB : (0 : ℚ) < catalan (n + 1) := by exact_mod_cast catalan_pos (n + 1)
+  have hC : (0 : ℚ) < catalan (n + 2) := by exact_mod_cast catalan_pos (n + 2)
+  have hT : (catalan (n + 1) : ℚ) ^ 2 < (catalan n : ℚ) * (catalan (n + 2) : ℚ) := by
+    exact_mod_cast catalan_turan n
+  exact recip_sq_gt_of_sq_lt hA hB hC hT
+
+/-- **Reciprocal Catalan log-concavity in standard indexing.** Writing
+`a n = 1 / catalan n`, for every `n ≥ 1`
+
+  `a n ^ 2 > a (n-1) * a (n+1)`,
+
+the defining strict log-concavity inequality. (This is `catalan_recip_logConcave`
+reindexed at `n = m + 1`.) -/
+theorem catalan_recip_logConcave_shift (n : ℕ) (hn : 1 ≤ n) :
+    (1 / (catalan (n - 1) : ℚ)) * (1 / (catalan (n + 1) : ℚ))
+      < (1 / (catalan n : ℚ)) ^ 2 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_lt (Nat.lt_of_lt_of_le Nat.zero_lt_one hn)
+  simp only [Nat.zero_add, Nat.add_sub_cancel]
+  have h := catalan_recip_logConcave m
+  -- `m + 1 + 1 = m + 2`
+  simpa [Nat.add_assoc] using h
+
+/-- **The suggested candidate `Cₙ/(n+1)` is NOT log-concave.** With
+`a n = catalan n / (n + 1)`, the log-concavity inequality `a 1 ^ 2 > a 0 * a 2`
+already **fails** at `n = 1`: `a 1 ^ 2 = 1/4` while `a 0 * a 2 = 2/3`, and
+`1/4 < 2/3`. This refutes the open question's proposed example and is the reason the
+reciprocal sequence, not `Cₙ/(n+1)`, is the correct log-concave derived sequence. -/
+theorem catalanOverSucc_not_logConcave_at_one :
+    ¬ (((catalan 1 : ℚ) / (1 + 1)) ^ 2
+        > ((catalan 0 : ℚ) / (0 + 1)) * ((catalan 2 : ℚ) / (2 + 1))) := by
+  rw [catalan_zero, catalan_one, catalan_two]
+  norm_num
+
+end CatalanNumbersOQ01OQ04OQ02

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-catalan-recip-overview",
+    "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Reciprocation exchanges log-convexity and log-concavity",
+    "content": "A positive sequence is log-convex when aₙ² ≤ aₙ₋₁·aₙ₊₁ and log-concave when the inequality reverses. The map t ↦ 1/t is an order-reversing multiplicative involution on the positive reals, so it swaps the two properties: the reciprocal of a strictly positive strictly log-convex sequence is strictly log-concave. The Catalan numbers are strictly log-convex (parent entry oq-01-oq-04), hence 1/Cₙ is strictly log-concave. The docstring also records an honest correction: the open question's suggested candidate Cₙ/(n+1) is NOT log-concave.",
+    "mathContext": "Parent: $C_{n+1}^2 < C_n C_{n+2}$. Reciprocal: $\\frac{1}{C_n}\\cdot\\frac{1}{C_{n+2}} < \\left(\\frac{1}{C_{n+1}}\\right)^2$."
+  },
+  {
+    "id": "ann-recip-principle",
+    "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
+    "range": { "startLine": 53, "endLine": 64 },
+    "type": "technique",
+    "title": "The field-level reciprocation principle",
+    "content": "recip_sq_gt_of_sq_lt states the exchange abstractly: in any LinearOrderedField, if 0 < x,y,z and y² < x·z then (1/x)(1/z) < (1/y)². The proof rewrites (1/y)² = 1/y² (div_pow, one_pow) and (1/x)(1/z) = 1/(x·z) (div_mul_div_comm, one_mul), reducing the goal to 1/(x·z) < 1/y², which is exactly the order-reversal one_div_lt_one_div_of_lt applied to the hypothesis y² < x·z. Stating it over an arbitrary ordered field makes it reusable for the reciprocal of any positive log-convex sequence.",
+    "mathContext": "$0<x,y,z,\\; y^2 < xz \\;\\Rightarrow\\; \\tfrac1x\\tfrac1z < \\tfrac1{y^2}$ since $t\\mapsto 1/t$ reverses order on $\\mathbb{R}_{>0}$."
+  },
+  {
+    "id": "ann-catalan-instance",
+    "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
+    "range": { "startLine": 66, "endLine": 87 },
+    "type": "key-step",
+    "title": "Applying the principle to the Catalan numbers",
+    "content": "catalan_recip_logConcave instantiates the principle over ℚ. The three positivity hypotheses 0 < Cₙ, Cₙ₊₁, Cₙ₊₂ come from casting Nat.catalan_pos, and the Turán hypothesis y² < x·z is the parent's catalan_turan cast to ℚ (exact_mod_cast). Feeding these to recip_sq_gt_of_sq_lt yields (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² for every n — no new combinatorics, just the parent inequality read through reciprocation.",
+    "mathContext": "$\\frac{1}{C_n}\\cdot\\frac{1}{C_{n+2}} < \\left(\\frac{1}{C_{n+1}}\\right)^2$ over $\\mathbb{Q}$, for all $n\\ge 0$."
+  },
+  {
+    "id": "ann-refutation",
+    "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
+    "range": { "startLine": 89, "endLine": 108 },
+    "type": "insight",
+    "title": "Standard indexing and refutation of the Cₙ/(n+1) candidate",
+    "content": "catalan_recip_logConcave_shift reindexes at n = m+1 to give the defining strict log-concavity aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1. catalanOverSucc_not_logConcave_at_one then refutes the open question's suggested candidate aₙ = Cₙ/(n+1): at n = 1, a₁² = (C₁/2)² = 1/4 while a₀·a₂ = (C₀/1)(C₂/3) = 2/3, so a₁² > a₀·a₂ FAILS. Evaluating catalan 0,1,2 and closing with norm_num makes the counterexample fully explicit — this is why the reciprocal, not Cₙ/(n+1), is the correct derived sequence.",
+    "mathContext": "$a_1^2 = \\tfrac14 < \\tfrac23 = a_0 a_2$ for $a_n = C_n/(n+1)$ — log-concavity fails."
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "catalan-numbers-oq-01-oq-04-oq-02",
+  "title": "Strict log-concavity of the reciprocal Catalan sequence 1/Cₙ (with a refutation of the Cₙ/(n+1) candidate)",
+  "slug": "catalan-numbers-oq-01-oq-04-oq-02",
+  "description": "The open question asks for a sequence derived from the Catalan numbers that is strictly log-concave, aₙ² > aₙ₋₁·aₙ₊₁, and suggests the candidate aₙ = Cₙ/(n+1). This entry does two things. First it refutes the suggestion: catalanOverSucc_not_logConcave_at_one shows n ↦ Cₙ/(n+1) already fails log-concavity at n = 1 (a₁² = 1/4 while a₀·a₂ = 2/3), because dividing the strictly log-convex Catalan numbers by the mildly growing n+1 does not reverse convexity. Second it identifies the correct canonical derived sequence, the reciprocal aₙ = 1/Cₙ, and proves it strictly log-concave. The key is a general pointwise principle recip_sq_gt_of_sq_lt: in any linearly ordered field, if 0 < x,y,z and y² < x·z then (1/x)(1/z) < (1/y)², i.e. reciprocation (an order-reversing multiplicative involution on the positive cone) turns a strict Turán / log-convexity step into a strict log-concavity step. Applying it to the parent's strict Turán inequality catalan_turan (Cₙ₊₁² < Cₙ·Cₙ₊₂) yields catalan_recip_logConcave: (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² over ℚ, restated in standard indexing (n ≥ 1) as catalan_recip_logConcave_shift. Mathlib has the Catalan API but neither the parent Turán inequality nor this reciprocal log-concavity. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Original (reciprocal log-concavity principle and Catalan instance; honest refutation of the suggested Cₙ/(n+1) candidate). Lean formalization original.",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ04OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "log-concavity",
+      "reciprocal-sequence",
+      "turan-inequality",
+      "inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "one_div_lt_one_div_of_lt",
+        "description": "0 < a → a < b → 1/b < 1/a. The order-reversal of reciprocation on the positive reals; applied to y² < x·z (after rewriting (1/y)² = 1/y² and (1/x)(1/z) = 1/(x·z)) it is the entire engine of the general principle recip_sq_gt_of_sq_lt.",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "div_pow",
+        "description": "(a/b)^n = a^n / b^n. Rewrites (1/y)² into 1/y² so the order-reversal lemma can be applied to the squared reciprocal.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.catalan_pos",
+        "description": "0 < catalan n. Cast to ℚ, it supplies the strict positivity hypotheses 0 < Cₙ, Cₙ₊₁, Cₙ₊₂ needed to invoke the reciprocation principle at the Catalan values.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      }
+    ],
+    "originalContributions": [
+      "recip_sq_gt_of_sq_lt: in any LinearOrderedField, 0 < x,y,z and y² < x·z imply (1/x)(1/z) < (1/y)² — the general statement that reciprocation converts a strict log-convexity (Turán) step into a strict log-concavity step. Not present in Mathlib as a packaged lemma.",
+      "catalan_recip_logConcave: strict log-concavity of the reciprocal Catalan sequence, (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² for every n, obtained by reciprocating the parent's strict Turán inequality catalan_turan.",
+      "catalanOverSucc_not_logConcave_at_one: an explicit refutation of the open question's suggested candidate Cₙ/(n+1), which fails log-concavity already at n = 1 (1/4 < 2/3). This corrects the problem statement and motivates the reciprocal as the correct derived sequence."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide and no decide on the substantive results. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms on all four theorems). Uses the parent entry's catalan_turan as its sole nontrivial input.",
+    "lineCount": 109,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Log-concavity (aₙ² ≥ aₙ₋₁·aₙ₊₁) and its dual log-convexity (aₙ² ≤ aₙ₋₁·aₙ₊₁) are the two-term shape underlying Turán-type inequalities across combinatorial sequences. The Catalan numbers are a canonical log-convex sequence, so the naive hope that a mild reweighting like Cₙ/(n+1) becomes log-concave is tempting but wrong. The clean structural fact is that reciprocation exchanges the two properties: for a strictly positive strictly log-convex sequence, the pointwise reciprocal is strictly log-concave. This entry makes that exchange precise and applies it to the parent's strict Turán inequality for the Catalan numbers.",
+    "problemStatement": "The parent open question (oq-01-oq-04-oq-02) asks for a sequence derived from the Catalan numbers that is strictly log-concave, aₙ² > aₙ₋₁·aₙ₊₁, and proposes aₙ = Cₙ/(n+1). The task is to either establish the candidate or supply a correct derived sequence and prove strict log-concavity by the parent's surplus method — here recast as a single reciprocation of the parent's Turán inequality.",
+    "keyIdea": "Reciprocation t ↦ 1/t is an order-reversing multiplicative involution on the positive reals, so it turns the strict Turán step y² < x·z into (1/x)(1/z) < (1/y)². Reading the parent inequality Cₙ₊₁² < Cₙ·Cₙ₊₂ through this map gives exactly strict log-concavity of 1/Cₙ, with no new combinatorics — the log-convexity of the Catalan numbers IS the log-concavity of their reciprocals.",
+    "proofStrategy": "(1) Prove the general principle recip_sq_gt_of_sq_lt over a LinearOrderedField: rewrite (1/y)² = 1/y² (div_pow) and (1/x)(1/z) = 1/(x·z), then apply the order-reversal one_div_lt_one_div_of_lt to y² < x·z. (2) Instantiate at the Catalan values over ℚ: cast catalan_pos (at n, n+1, n+2) for positivity and cast the parent's catalan_turan for the hypothesis y² < x·z, yielding catalan_recip_logConcave. (3) Reindex at n = m+1 to state it in the standard form aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1 (catalan_recip_logConcave_shift). (4) Separately, refute the suggested candidate Cₙ/(n+1) by evaluating catalan 0,1,2 and checking 1/4 < 2/3 with norm_num.",
+    "keyInsights": [
+      "The suggested candidate Cₙ/(n+1) is NOT log-concave: it fails already at n = 1, where a₁² = 1/4 but a₀·a₂ = 2/3. Dividing a strictly log-convex sequence by the slowly growing factor n+1 does not reverse convexity — the counterexample is explicit and small.",
+      "The correct derived sequence is the reciprocal 1/Cₙ: for any strictly positive strictly log-convex sequence the pointwise reciprocal is strictly log-concave, because reciprocation reverses order while preserving products on the positive cone.",
+      "The whole result is the parent's strict Turán inequality Cₙ₊₁² < Cₙ·Cₙ₊₂ read through x ↦ 1/x; no additional combinatorial input is needed, only the general field-level reciprocation principle.",
+      "recip_sq_gt_of_sq_lt is stated at the level of an arbitrary LinearOrderedField, so it is reusable for the reciprocal of any log-convex positive sequence (central binomial coefficients, factorials, Bell numbers), not just the Catalan numbers."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: reciprocal log-concavity and an honest correction",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring framing the derived-sequence question, refuting the suggested candidate Cₙ/(n+1) (fails at n=1), and identifying the reciprocal 1/Cₙ as the correct strictly log-concave derived sequence obtained by reciprocating the parent's Turán inequality."
+    },
+    {
+      "id": "recip-principle",
+      "title": "The reciprocation principle",
+      "startLine": 53,
+      "endLine": 64,
+      "summary": "recip_sq_gt_of_sq_lt: in any LinearOrderedField, 0 < x,y,z and y² < x·z imply (1/x)(1/z) < (1/y)². Proved by rewriting (1/y)² = 1/y² (div_pow) and (1/x)(1/z) = 1/(x·z), then applying the order-reversal one_div_lt_one_div_of_lt."
+    },
+    {
+      "id": "catalan-instance",
+      "title": "Strict log-concavity of the reciprocal Catalan sequence",
+      "startLine": 66,
+      "endLine": 87,
+      "summary": "catalan_recip_logConcave: (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² over ℚ for every n. Casts catalan_pos for positivity and the parent's catalan_turan for the Turán hypothesis, then applies the reciprocation principle."
+    },
+    {
+      "id": "standard-indexing",
+      "title": "Standard indexing and the refuted candidate",
+      "startLine": 89,
+      "endLine": 108,
+      "summary": "catalan_recip_logConcave_shift restates the inequality as aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1 (reindexing at n = m+1); catalanOverSucc_not_logConcave_at_one refutes the suggested candidate Cₙ/(n+1) by evaluating at n=1 (1/4 < 2/3 via norm_num)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Liu, Lily L.; Wang, Yi",
+      "title": "On the log-convexity of combinatorial sequences",
+      "year": "2007",
+      "note": "Adv. in Appl. Math. 39 — establishes log-convexity for the Catalan, Motzkin, Bell and related sequences; the reciprocal of any such positive log-convex sequence is log-concave."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Cambridge University Press — the Catalan recurrence and ratio Cₙ₊₁/Cₙ = 2(2n+1)/(n+2) underlying the parent's Turán inequality that is reciprocated here."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-01-oq-04",
+      "relationship": "parent",
+      "description": "Parent entry proving the strict Turán inequality Cₙ₊₁² < Cₙ·Cₙ₊₂ (strict log-convexity). This leaf reciprocates that inequality to obtain strict log-concavity of 1/Cₙ, and its openQuestions explicitly asked for the derived-sequence log-concavity resolved here."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "ancestor",
+      "description": "Root Catalan-numbers entry; this leaf oq-01-oq-04-oq-02 sits under the oq-04 (log-convexity) branch."
+    }
+  ],
+  "conclusion": {
+    "summary": "The derived-sequence log-concavity question is resolved by reciprocation: the suggested candidate Cₙ/(n+1) is refuted (it fails at n=1), and the reciprocal 1/Cₙ is proved strictly log-concave, (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)², directly from the parent's strict Turán inequality via the general principle recip_sq_gt_of_sq_lt. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Clarifies which Catalan-derived sequences are log-concave: not the linear reweighting Cₙ/(n+1), but the reciprocal 1/Cₙ. The field-level reciprocation principle applies verbatim to the reciprocal of any strictly positive strictly log-convex sequence.",
+    "openQuestions": [
+      "Prove reciprocal strict log-concavity for other log-convex sequences (central binomial coefficients, Bell numbers) by the same recip_sq_gt_of_sq_lt principle, packaging it as a single reusable lemma.",
+      "Quantify the log-concavity gap for 1/Cₙ: give the exact ratio (1/Cₙ₊₁)² / ((1/Cₙ)(1/Cₙ₊₂)) = Cₙ·Cₙ₊₂ / Cₙ₊₁² = (2n²+7n+6)/(2n²+7n+3)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CatalanNumbersOQ01OQ04"
+    ],
+    "opens": [
+      "Nat",
+      "CatalanNumbersOQ01OQ04"
+    ],
+    "namespace": "CatalanNumbersOQ01OQ04OQ02",
+    "lineCount": 109,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ04OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question `catalan-numbers-oq-01-oq-04-oq-02` ("strict log-concavity of a Catalan-derived sequence", the parent oq-01-oq-04's own follow-up). **New gallery entry**, verified with 0 axioms.

The question suggested the candidate $a_n = C_n/(n+1)$. This entry does two honest things:

1. **Refutes the suggested candidate.** `catalanOverSucc_not_logConcave_at_one`: $C_n/(n+1)$ fails log-concavity already at $n=1$, where $a_1^2 = 1/4$ but $a_0 a_2 = 2/3$. Dividing the strictly log-*convex* Catalan numbers by the slowly growing $n+1$ does not reverse convexity.
2. **Supplies the correct derived sequence $1/C_n$ and proves it strictly log-concave.** The engine is a general `LinearOrderedField` principle `recip_sq_gt_of_sq_lt`: if $0<x,y,z$ and $y^2 < xz$ then $(1/x)(1/z) < (1/y)^2$ — reciprocation is an order-reversing multiplicative involution on the positive cone, so it turns a strict Turán/log-convexity step into a strict log-concavity step. Applied to the parent's `catalan_turan` ($C_{n+1}^2 < C_n C_{n+2}$) it gives `catalan_recip_logConcave`, restated in standard indexing by `catalan_recip_logConcave_shift`.

## Verification

- Host-verified via `lake env lean` against the cached Mathlib olean set (repaired 12 modules left half-built by interrupted concurrent builds).
- 0 sorries, 0 `axiom` declarations, no `native_decide`/`decide` on substantive results.
- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).

## Files

- `proofs/Proofs/CatalanNumbersOQ01OQ04OQ02.lean` (109L, 4 thm, 0 def) — recovered from an abandoned session (was untracked in the main worktree, never committed) and verified.
- `src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/{meta.json,annotations.json}` — new gallery entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)