### PR TITLE
Enrich Desargues OQ-03-OQ-01 (PGL→PΓL): add full annotations.json

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,167 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 6, "endLine": 70 },
+    "type": "context",
+    "title": "PGL to PΓL: What the Parent Left Open",
+    "content": "The parent entry (OQ-03) proved the **linear** half of the algebraic engine behind the Fundamental Theorem of Projective Geometry (FTPG) over $\\mathbb{R}$: an invertible matrix $M$ acts on $PG(2,\\mathbb{R})$ by a collineation because $\\det[Mp, Mq, Mr] = \\det M \\cdot \\det[p,q,r]$. It left two gaps, which this file fills over an **arbitrary field** $K$. (1) The *semilinear* part: the FTPG names $P\\Gamma L(3,K) = PGL(3,K) \\rtimes \\mathrm{Aut}(K)$, not merely $PGL$, and the field-automorphism twist is invisible over $\\mathbb{R}$ because $\\mathrm{Aut}(\\mathbb{R})$ is trivial. (2) *Frame rigidity*: a projective transformation should be determined by its action on a frame. Working over general $K$ is the natural home of the Desargues $\\Rightarrow$ coordinatization (Hilbert) $\\Rightarrow$ FTPG chain, since a Desarguesian plane is exactly one coordinatizable as $PG(2,K)$.",
+    "mathContext": "$P\\Gamma L(3,K) = PGL(3,K) \\rtimes \\mathrm{Aut}(K)$; over $\\mathbb{R}$, $\\mathrm{Aut}(\\mathbb{R}) = 1$ so semilinear $=$ linear.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Fundamental Theorem of Projective Geometry",
+      "Desargues's theorem",
+      "Hilbert coordinatization",
+      "projective semilinear group PΓL"
+    ],
+    "prerequisites": [
+      "projective plane PG(2, K)",
+      "collineations",
+      "field automorphisms"
+    ]
+  },
+  {
+    "id": "ann-plane",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 83, "endLine": 108 },
+    "type": "definition",
+    "title": "The Coordinatized Plane and the Incidence Predicate",
+    "content": "Points of $PG(2,K)$ are nonzero vectors of $K^3$. The helper `rowMat u v w` stacks three such vectors as the rows of a $3\\times 3$ matrix, and `rowMat_det` records its explicit expansion (closed by `Matrix.det_fin_three` + `ring`). The core definition is `Collinear p q r := (rowMat p q r).det = 0`: three projective points are collinear exactly when the matrix with those rows is singular. This is the same determinant incidence condition as the parent entry, now stated over an arbitrary field $K$. By projective duality the identical predicate expresses concurrency of three lines.",
+    "mathContext": "$\\mathrm{Collinear}(p,q,r) \\iff \\det \\begin{pmatrix} p \\\\ q \\\\ r \\end{pmatrix} = 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "homogeneous coordinates",
+      "determinant as signed volume",
+      "collinearity",
+      "projective duality"
+    ],
+    "prerequisites": [
+      "3×3 determinants",
+      "vectors in K³",
+      "matrices over a field"
+    ]
+  },
+  {
+    "id": "ann-pgl",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 109, "endLine": 147 },
+    "type": "concept",
+    "title": "PGL(3, K) Acts by Collineations",
+    "content": "The linear action is analyzed by the factorization `rowMat_mulVec`: stacking the transformed points $Mp, Mq, Mr$ as rows equals $(\\mathrm{rowMat}\\,p\\,q\\,r)\\cdot M^\\top$. Taking determinants (`Matrix.det_mul`, `Matrix.det_transpose`) gives the scaling law `rowMat_mulVec_det`: $\\det[Mp,Mq,Mr] = \\det M \\cdot \\det[p,q,r]$. Hence `collinear_mulVec` — **any** matrix preserves collinearity (the $\\det = 0$ side is sent to $0$) — and, when $\\det M \\neq 0$, `collinear_mulVec_iff` shows the action also **reflects** collinearity (via `mul_eq_zero`, valid since a field has no zero divisors). So $PGL(3,K)$ acts on $PG(2,K)$ by collineations over any field.",
+    "mathContext": "$\\det[Mp, Mq, Mr] = \\det M \\cdot \\det[p,q,r]$; $\\det M \\neq 0 \\Rightarrow M$ preserves *and* reflects incidence.",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective linear group PGL",
+      "determinant multiplicativity",
+      "Matrix.det_mul",
+      "no zero divisors in a field"
+    ],
+    "prerequisites": [
+      "matrix–vector multiplication",
+      "transpose and det identities",
+      "the incidence predicate above"
+    ]
+  },
+  {
+    "id": "ann-semilinear",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 148, "endLine": 167 },
+    "type": "insight",
+    "title": "Aut(K) Acts by Collineations — the Semilinear Ingredient",
+    "content": "The genuinely new phenomenon, absent from the parent's $\\mathbb{R}$-only picture. `rowMat_map` observes that applying a ring endomorphism $\\sigma$ coordinatewise to the three points equals mapping the whole stacked matrix through $\\sigma$. Then `collinear_semilinear` proves $\\sigma$ preserves collinearity for a purely algebraic reason: it **commutes with the determinant**. Concretely `RingHom.mapMatrix_apply` rewrites `(rowMat ...).map σ` into `σ.mapMatrix (rowMat ...)`, `RingHom.map_det` pulls $\\sigma$ outside the determinant, and $\\sigma(0) = 0$ finishes. This is the semilinear factor of $P\\Gamma L$ — invisible over $\\mathbb{R}$ (where $\\mathrm{Aut}(\\mathbb{R})$ is trivial) but large over $\\mathbb{C}$ or $\\mathbb{F}_{p^n}$.",
+    "mathContext": "$\\sigma(\\det(\\mathrm{rowMat}\\,p\\,q\\,r)) = \\det(\\sigma.\\mathrm{mapMatrix}(\\mathrm{rowMat}\\,p\\,q\\,r))$, so $\\det = 0 \\Rightarrow \\det = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "field endomorphism",
+      "semilinear map",
+      "RingHom.map_det",
+      "Aut(ℂ), Aut(𝔽_pⁿ)"
+    ],
+    "prerequisites": [
+      "ring homomorphisms",
+      "RingHom.mapMatrix",
+      "det commutes with ring maps"
+    ]
+  },
+  {
+    "id": "ann-pgammal",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 168, "endLine": 183 },
+    "type": "concept",
+    "title": "PΓL(3, K) ⊆ Collineations — the Constructive Half of the FTPG",
+    "content": "Composing the two ingredients: `collinear_projSemilinear` shows a projective **semilinear** map — an invertible linear $M$ followed by a field automorphism $\\sigma$ — preserves collinearity, simply as `collinear_semilinear σ (collinear_mulVec M h)`. This is the inclusion $P\\Gamma L(3,K) \\subseteq \\mathrm{Aut}(PG(2,K))$: every transformation the FTPG names genuinely is a collineation. It is the *constructive* half of the theorem. The deep converse — that **every** collineation is semilinear — reconstructs the field from incidence (again via Desargues) and is left as the contextual open direction, not axiomatized.",
+    "mathContext": "$\\sigma \\circ (M\\cdot)$ preserves collinearity; $P\\Gamma L(3,K) \\subseteq \\mathrm{Aut}(PG(2,K))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "PΓL as semidirect product",
+      "collineation group",
+      "constructive vs. converse inclusion",
+      "composition of collineations"
+    ],
+    "prerequisites": [
+      "the PGL and semilinear lemmas above",
+      "semidirect product PGL ⋊ Aut(K)"
+    ]
+  },
+  {
+    "id": "ann-frame",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 184, "endLine": 201 },
+    "type": "concept",
+    "title": "The Standard Frame Is in General Position",
+    "content": "`frame_general_position` verifies that the standard frame — the three coordinate points $[1{:}0{:}0], [0{:}1{:}0], [0{:}0{:}1]$ and the unit point $[1{:}1{:}1]$ — is in **general position**: each of the four 3-point subsets has determinant $\\pm 1$ ($1, 1, -1, 1$), so no three of the four are collinear. The proof is four explicit $3\\times 3$ determinants closed by `rowMat_det` and `ring`. General position is exactly what makes these four points a genuine *projective frame*, the reference object against which rigidity is measured in the next part.",
+    "mathContext": "The four 3-point determinants of $[1{:}0{:}0],[0{:}1{:}0],[0{:}0{:}1],[1{:}1{:}1]$ are $1, 1, -1, 1$ — all nonzero.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "projective frame",
+      "general position",
+      "coordinate points and unit point",
+      "no three collinear"
+    ],
+    "prerequisites": [
+      "the incidence predicate",
+      "explicit 3×3 determinants"
+    ]
+  },
+  {
+    "id": "ann-rigidity",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 202, "endLine": 277 },
+    "type": "insight",
+    "title": "Frame Rigidity — the Computational Kernel of the FTPG",
+    "content": "The uniqueness heart of the theorem. `frame_stabilizer_scalar`: if a linear map $M$ fixes each of the four frame points **projectively** ($M e_i = (\\text{scalar})\\, e_i$ and $M u = d\\, u$), then all four scalars coincide and $M = d\\cdot 1$. The proof reads off the nine entries of $M$ from the three coordinate-point hypotheses (each column comes from one `mulVec` equation via `congrFun` + `Fin.sum_univ_three`), pinning $M$ to a diagonal matrix; the unit-point hypothesis then forces the three diagonal scalars to a common $d$ — using `linear_combination` (not `linarith`, since $K$ is unordered) — and the matrix is assembled entrywise as $d\\cdot 1$. Equivalently: the projective stabilizer of a frame in $PGL(3,K)$ is trivial, so **a projective transformation is uniquely determined by its action on a frame**.",
+    "mathContext": "$M e_i = \\lambda_i e_i \\ (i=0,1,2)$ and $M[1{:}1{:}1] = d[1{:}1{:}1] \\Rightarrow \\lambda_0 = \\lambda_1 = \\lambda_2 = d$ and $M = d\\cdot I$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective stabilizer of a frame",
+      "scalar matrix",
+      "linear_combination over an unordered field",
+      "uniqueness up to scalar"
+    ],
+    "prerequisites": [
+      "reading matrix entries from mulVec",
+      "diagonal matrices",
+      "Fin.sum_univ_three / congrFun"
+    ]
+  },
+  {
+    "id": "ann-invariance",
+    "proofId": "desargues-theorem-oq-03-oq-01",
+    "range": { "startLine": 278, "endLine": 301 },
+    "type": "concept",
+    "title": "Projective Invariance of Desargues over K",
+    "content": "The payoff for Desargues's theorem itself. Both perspectivity relations in Desargues's configuration — perspectivity from a point (concurrency of the three joining lines) and perspectivity from a line (collinearity of the three intersection points) — are $\\det = 0$ conditions on triples of homogeneous vectors. So `desargues_relation_mulVec` shows they are preserved by any collineation, and `desargues_relation_preserved` shows an invertible map preserves them in **both** directions, carrying Desargues configurations to Desargues configurations bijectively. This generalizes the parent OQ-03 invariance from $\\mathbb{R}$ to an arbitrary field $K$ — the precise sense in which the Desarguesian property is intrinsic to $PG(2,K)$.",
+    "mathContext": "For $\\det M \\neq 0$: $\\mathrm{Collinear}(Mp, Mq, Mr) \\iff \\mathrm{Collinear}(p, q, r)$ over any $K$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perspectivity from a point / line",
+      "Desargues configuration",
+      "projective invariance",
+      "incidence geometry"
+    ],
+    "prerequisites": [
+      "Desargues's theorem statement",
+      "the PGL collineation lemmas above"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `desargues-theorem-oq-03-oq-01` (quality **45**, 0 prior passes — the top-priority target).

**Root cause of the low score:** the entry had a rich, complete `meta.json` (7 curated sections, full overview/conclusion/references) but **no `annotations.json` at all** — so the proof page carried zero inline commentary.

**Change:** created `annotations.json` with 8 annotations covering the full 301-line file, each aligned to the meta's existing section ranges and carrying `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:

| id | lines | focus |
|----|-------|-------|
| ann-header | 6–70 | what the parent (ℝ-only) left open; why arbitrary K |
| ann-plane | 83–108 | `rowMat` / `Collinear` determinant incidence predicate |
| ann-pgl | 109–147 | PGL acts by collineations (det scaling; preserves + reflects) |
| ann-semilinear | 148–167 | Aut(K) acts by collineations — σ commutes with det, invisible over ℝ |
| ann-pgammal | 168–183 | PΓL ⊆ collineations, the constructive half of the FTPG |
| ann-frame | 184–201 | standard frame in general position |
| ann-rigidity | 202–277 | frame_stabilizer_scalar — trivial projective stabilizer of a frame |
| ann-invariance | 278–301 | Desargues perspectivity relations transport over any K |

Content verified against the actual Lean source (lemma names, tactics, the four ±1 frame determinants, the `linear_combination`-over-unordered-K point). `meta.json` untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)