### PR TITLE
Enrich Hilbert-10 OQ-04·03·01·01: cross-reference sibling entries

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
@@ -151,6 +151,16 @@
       "targetId": "hilbert-10-oq-04-oq-03",
       "relationship": "extends",
       "description": "Recasts the grandparent's gcd-divisibility decision criterion as an explicit biconditional against Mathlib's abstract Finset.gcd."
+    },
+    {
+      "targetId": "hilbert-10-oq-04-oq-03-oq-02",
+      "relationship": "related",
+      "description": "The sibling systems direction named in this entry's open questions: it generalizes the single-equation Finset.gcd criterion to a full linear Diophantine system A·x = b, reducing solvability to membership of b in the ℤ-span of the columns of A (the invariant-factor / Smith-normal-form criterion). This entry is that program's single-equation base case."
+    },
+    {
+      "targetId": "hilbert-10-oq-04-oq-03-oq-03",
+      "relationship": "related",
+      "description": "The constructive companion at the two-variable level: supplies an explicit solution witness for a·x + b·y = c, mirroring how this entry's hard direction reuses the parent's exists_vec_combo to carry an actual solution vector alongside the abstract gcd-divisibility criterion."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: cross-reference gaps

Entry `hilbert-10-oq-04-oq-03-oq-01-oq-01` (quality 91, 0 prior passes) is already richly annotated and well under size caps. Its `openQuestions` explicitly point to the sibling systems direction, and a constructive two-variable companion exists in the gallery, but neither was linked in `crossReferences`.

Added two `related` cross-references (crossReferences now 4/20, meta ~15.7 KB ≤ 60 KB cap):

- `hilbert-10-oq-04-oq-03-oq-02` — the systems generalization (A·x = b via column-lattice / Smith-normal-form), of which this entry is the single-equation base case.
- `hilbert-10-oq-04-oq-03-oq-03` — the explicit two-variable solution witness, the constructive companion mirroring this entry's exists_vec_combo reuse.

No content inflation; pure navigation improvement resolving the entry's own dangling references.
