### PR TITLE
Enrich area-of-circle OQ-05-OQ-03-OQ-02 (Gaussian convolution): annotation prerequisites

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
@@ -17,6 +17,11 @@
       "heat kernel",
       "central limit theorem",
       "characteristic function"
+    ],
+    "prerequisites": [
+      "convolution of functions / probability densities",
+      "the normal (Gaussian) density and its variance",
+      "Lebesgue integration over ℝ"
     ]
   },
   {
@@ -35,6 +40,11 @@
       "completing the square",
       "Gaussian integral",
       "field_simp"
+    ],
+    "prerequisites": [
+      "completing the square in a quadratic",
+      "the Gaussian integral ∫ e^{-Au²} du = √(π/A)",
+      "algebraic normalization (field_simp, ring)"
     ]
   },
   {
@@ -53,6 +63,11 @@
       "translation invariance",
       "Bochner integral",
       "Gaussian integral"
+    ],
+    "prerequisites": [
+      "translation invariance of Lebesgue measure",
+      "pulling constants out of an integral",
+      "the Gaussian integral ∫ e^{-Au²} du = √(π/A)"
     ]
   },
   {
@@ -71,6 +86,11 @@
       "characteristic function",
       "convolution theorem",
       "probability density"
+    ],
+    "prerequisites": [
+      "characteristic functions / Fourier transform",
+      "the convolution theorem (transform of a convolution is a product)",
+      "probability densities integrate to 1"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-oq-03-oq-02` (Gaussian convolution / variance-addition, density form).

All 4 annotations already had `mathContext`, `significance`, and `relatedConcepts` but were missing `prerequisites`. Added 3 specific prerequisites to each, matched to the content (convolution + Gaussian density; completing the square + the Gaussian integral; translation invariance + integral_gaussian; characteristic functions + the convolution theorem).

`meta.json` untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)