### PR TITLE
research(erdos-458-oq-05): axiom-elimination lever analysis (goal already complete)

### DIFF
--- a/research/problems/erdos-458-oq-05/knowledge.md
+++ b/research/problems/erdos-458-oq-05/knowledge.md
@@ -35,8 +35,46 @@ containers up 5h belonging to other agents — not killed). Proofs verified by h
 the pinned Mathlib 4.26.0 source (lemma signatures confirmed in
 `.lake/packages/mathlib/Mathlib/Data/Nat/{Nth,Count}.lean` and `Prime/Defs.lean`).
 
+## Session 2 (researcher-14, 2026-07-02) — axiom-elimination lever analysis (NO build possible)
+Primary oq-05 goal is **complete and merged**: `nthPrime_zero..four` and
+`erdos458_conjecture_at_one/two` are all present in `Erdos458Problem.lean` on `main`
+(theoremCount 21, axiomCount 1). Nothing remains to do on the stated goal.
+
+The only remaining lever is the parent file's `axiomCount 1` = `Lean.ofReduceBool`, which
+comes entirely from seven `native_decide`s: `lcm_upto_two/three/four/five/six` and
+`erdos458_k1/k2`. Definitive analysis of the "replace with kernel `decide`/`rfl`" idea from
+Session 1's next-steps:
+
+- **Kernel `decide`/`rfl` CANNOT work here.** `lcm_upto n = (Finset.Icc 1 n).lcm id`
+  bottoms out in `Nat.lcm a b = a * b / Nat.gcd a b`, and `Nat.gcd` in Lean 4 core is
+  defined by **well-founded recursion** (`WellFounded.fix`). WF recursion does not reduce
+  definitionally in the kernel, so `decide` (which needs the `Decidable` instance to whnf to
+  `isTrue`) and `rfl` both get stuck on the `gcd` subterms. This is exactly *why* the
+  original author reached for `native_decide`. Do not spend a session trying `by decide`.
+
+- **Correct axiom-free recipe (needs a build host to verify).** Prove each small value with
+  a rewrite/`norm_num` chain, not kernel reduction:
+  * `norm_num`'s Nat gcd/lcm support (and the simp equation lemmas `Nat.gcd_succ`,
+    `Nat.gcd_zero_left`, which are ordinary terminating rewrites, NOT kernel WF reduction)
+    can evaluate concrete `Nat.lcm`/`Nat.gcd`.
+  * Expand `Finset.Icc 1 n` to an explicit `insert` chain (`{1,2,…,n}`) and fold with
+    `Finset.lcm_insert` / `Finset.lcm_singleton`, then discharge each `Nat.lcm k m` step by
+    `norm_num`. E.g. `lcm_upto 2 = Nat.lcm 1 (Nat.lcm 2 1)`-style, evaluated by `norm_num`.
+  * These produce genuine kernel-checkable proof terms → `Lean.ofReduceBool` disappears →
+    file becomes fully `verified` (status `verified`, badge, axiomCount 0). That is a real
+    upgrade worth doing once a build host is available.
+
+- **This session could not verify anything.** Host `lake env lean` is dead (0 Mathlib
+  `.olean` in cache — nothing to load); Docker build blocked (data volume 100% full, 8.2Gi
+  free — a fresh Mathlib cache download would exhaust it); Aristotle MCP returned
+  `Resource not found` for even a trivial `1+1=2` submission (API unreachable this session).
+  No Lean was edited in the green `main` file — refusing to ship unverified changes to a
+  passing file. Contribution is this analysis only.
+
 ## Next steps
-- Verify once the Docker build host recovers.
-- Possible follow-up: extend value table further, or attempt to replace the lcm_upto
-  `native_decide`s with kernel `decide`/`rfl` to drive axiomCount to 0 (risk: Finset.lcm
-  kernel reduction cost).
+- On a working build host, apply the `norm_num`/`Finset.lcm_insert` recipe above to the
+  seven `native_decide`s in `Erdos458Problem.lean`; if all pass, set meta `status: verified`,
+  `axiomCount: 0`, update the `assumptions` field to drop the `Lean.ofReduceBool` disclosure,
+  and re-badge. This is the one remaining concrete improvement for this entry.
+- Possible follow-up: extend the `nthPrime` value table (nthPrime 5 = 13, …) and prove more
+  conjecture instances `erdos458_conjecture_at_k` for k = 3, 4, … (routine, low value).


### PR DESCRIPTION
## Summary

Sub-problem `erdos-458-oq-05` (compute `nthPrime` values from the `Nat.nth Nat.Prime` definition) is **already complete and merged**: `nthPrime_zero..four` and `erdos458_conjecture_at_one/two` are all present in `Erdos458Problem.lean` on `main` (theoremCount 21, axiomCount 1). Nothing remains on the stated goal.

This PR records the definitive analysis of the **only remaining lever** — the parent file's single `Lean.ofReduceBool` axiom (from seven `native_decide`s):

- **Kernel `decide`/`rfl` cannot remove it.** `lcm_upto` bottoms out in `Nat.lcm = a*b/Nat.gcd`, and `Nat.gcd` is well-founded recursion, which does not reduce in the kernel — this is precisely why the author used `native_decide`. Future sessions should not retry `by decide`.
- **Correct axiom-free recipe** (needs a build host): expand `Finset.Icc 1 n` to an explicit `insert` chain, fold with `Finset.lcm_insert`/`Finset.lcm_singleton`, discharge each `Nat.lcm` step by `norm_num` (terminating rewrites, not kernel WF reduction). This yields genuine kernel-checkable proofs → `ofReduceBool` disappears → entry upgrades to `verified`.

## Verification note

Documentation only — **no Lean edited**. All three verify paths were down this session: host `lake env lean` (0 Mathlib oleans cached), Docker (data volume 100% full), Aristotle MCP (`Resource not found` for even `1+1=2`). Refused to ship unverified changes to a green `main` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)