### PR TITLE
research(erdos-1179-oq-01-oq-02): complete second-order correction hierarchy [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/Erdos1179OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1179OQ01OQ02.lean
@@ -1,0 +1,140 @@
+/-
+Proof: Completing the second-order correction hierarchy for Erdős #1179.
+Date: 2026-07-02
+Research: erdos-1179-oq-01-oq-02 (researcher-16)
+
+Erdős Problem #1179 (PROVED, Erdős–Hall 1976) establishes that the minimal
+number `g_ε(N)` of random group elements needed for an ε-uniform subset-sum
+representation function satisfies `g_ε(N) ∼ log₂ N`.  The open question studied
+by the parent file `Proofs/Erdos1179OQ01.lean` concerns the precise second-order
+correction `corr(N) := g_ε(N) − log₂ N`, and formalizes three candidate rates:
+
+  * `CorrectionIsBounded`        —  |corr(N)| ≤ C            (the O(1) hypothesis, open)
+  * `CorrectionIsLogLog`         —  c₁·log log N ≤ corr(N) ≤ c₂·log log N   (Θ(log log N))
+  * `CorrectionIsSublinearInLog` —  |corr(N)| = o(log₂ N)    (the o(log) hypothesis, known)
+
+The parent proves `CorrectionIsBounded ⟹ CorrectionIsSublinearInLog`
+(`bounded_implies_sublinear`) and remarks that the remaining implication
+`CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog` is "straightforward but not
+formalized."  This file formalizes that remaining implication, axiom-free,
+thereby completing the correction hierarchy: BOTH the O(1) branch and the
+Θ(log log N) branch collapse into the known o(log₂ N) rate.
+
+A note on the hierarchy.  The literal chain "O(1) ⟹ Θ(log log N)" is *false*:
+a bounded correction (|corr| ≤ C) cannot satisfy the growing lower bound
+`c₁·log log N ≤ corr` for large N.  The two nontrivial hypotheses are instead
+mutually exclusive *sharpenings*, each of which independently implies the weakest
+(known) rate o(log₂ N).  What this file establishes is precisely the second of
+those two independent implications.
+
+Mathematical content.  The single analytic input is `log log N = o(log N)`:
+for every ε' > 0, `log(log N) < ε'·log N` for all large N.  This follows from
+Mathlib's `Real.isLittleO_log_id_atTop` (`log x = o(x)`) composed with
+`log x → ∞`.  Given the two-sided bound `c₁·log log N ≤ corr(N) ≤ c₂·log log N`,
+the correction is eventually non-negative (so `|corr(N)| = corr(N)`), bounded
+above by `c₂·log log N`, which is in turn `< δ·log₂ N` for any δ > 0 and all
+large N.  Hence `CorrectionIsSublinearInLog`.
+
+Zero axioms, zero sorries.
+-/
+import Mathlib
+
+open Real Filter Asymptotics
+open scoped Topology
+
+namespace Erdos1179OQ01OQ02
+
+/-! ## Correction-term definitions (restated from the parent file)
+
+These match `Proofs/Erdos1179OQ01.lean` verbatim so the file is self-contained. -/
+
+/-- The second-order correction term `g_ε(N) − log₂ N`. -/
+noncomputable def correctionTerm (gEps : ℝ → ℕ → ℕ) (ε : ℝ) (N : ℕ) : ℝ :=
+  (gEps ε N : ℝ) - Real.logb 2 ↑N
+
+/-- The correction is o(log₂ N) — the known (weakest) rate. -/
+def CorrectionIsSublinearInLog (gEps : ℝ → ℕ → ℕ) (ε : ℝ) : Prop :=
+  ∀ δ : ℝ, δ > 0 → ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+    |correctionTerm gEps ε N| < δ * Real.logb 2 ↑N
+
+/-- The correction is Θ(log log N) — conjectured by analogy with Problem #543. -/
+def CorrectionIsLogLog (gEps : ℝ → ℕ → ℕ) (ε : ℝ) : Prop :=
+  ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ 0 < c₂ ∧ ∃ N₀ : ℕ, ∀ N : ℕ, N ≥ N₀ →
+    c₁ * Real.log (Real.log ↑N) ≤ correctionTerm gEps ε N ∧
+    correctionTerm gEps ε N ≤ c₂ * Real.log (Real.log ↑N)
+
+/-! ## The analytic core: `log log x = o(log x)` -/
+
+/-- `log (log x) = o(log x)`: for every `ε' > 0`, eventually `log (log x) < ε'·log x`.
+    Derived from `Real.isLittleO_log_id_atTop` (`log = o(id)`) composed with
+    `log x → ∞`. -/
+lemma eventually_loglog_lt {ε' : ℝ} (hε' : 0 < ε') :
+    ∀ᶠ x : ℝ in atTop, Real.log (Real.log x) < ε' * Real.log x := by
+  -- `log = o(id)`, then compose with `log → atTop` to get `log ∘ log = o(log)`.
+  have h1 : (fun x : ℝ => Real.log x) =o[atTop] (fun x : ℝ => x) :=
+    Real.isLittleO_log_id_atTop
+  have h2 : (fun x : ℝ => Real.log (Real.log x)) =o[atTop] (fun x : ℝ => Real.log x) := by
+    have := h1.comp_tendsto Real.tendsto_log_atTop
+    simpa [Function.comp] using this
+  -- Extract the `≤ (ε'/2)‖·‖` bound and combine with `log x > 0`.
+  have hc : (0 : ℝ) < ε' / 2 := by positivity
+  have hbound := (Asymptotics.isLittleO_iff.mp h2) hc
+  have hpos : ∀ᶠ x : ℝ in atTop, 0 < Real.log x :=
+    Real.tendsto_log_atTop.eventually_gt_atTop 0
+  filter_upwards [hbound, hpos] with x hx hxpos
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_pos hxpos] at hx
+  calc Real.log (Real.log x)
+      ≤ |Real.log (Real.log x)| := le_abs_self _
+    _ ≤ (ε' / 2) * Real.log x := hx
+    _ < ε' * Real.log x := by nlinarith [hxpos, hε']
+
+/-! ## Main result: Θ(log log N) ⟹ o(log₂ N) -/
+
+/-- **The remaining hierarchy implication.**  If the correction term is bounded
+    both below and above by constant multiples of `log log N` (the Θ(log log N)
+    hypothesis), then it is `o(log₂ N)` (the known sublinear rate).
+
+    This is the implication the parent file (`Proofs/Erdos1179OQ01.lean`) leaves
+    "straightforward but not formalized." -/
+theorem loglog_implies_sublinear (gEps : ℝ → ℕ → ℕ) (ε : ℝ)
+    (h : CorrectionIsLogLog gEps ε) : CorrectionIsSublinearInLog gEps ε := by
+  obtain ⟨c₁, c₂, hc₁, hc₂, N₀, hN₀⟩ := h
+  intro δ hδ
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  -- The scale factor turning `log log N < ε'·log N` into `< δ·log₂ N`.
+  set ε' : ℝ := δ / (c₂ * Real.log 2) with hε'def
+  have hε' : 0 < ε' := by rw [hε'def]; exact div_pos hδ (mul_pos hc₂ hlog2)
+  -- Combined eventual fact: `log log x < ε'·log x` and `1 ≤ log x` (⇒ `log log x ≥ 0`).
+  have hev : ∀ᶠ x : ℝ in atTop,
+      Real.log (Real.log x) < ε' * Real.log x ∧ 1 ≤ Real.log x := by
+    have h1 := eventually_loglog_lt hε'
+    have h2 : ∀ᶠ x : ℝ in atTop, 1 ≤ Real.log x :=
+      Real.tendsto_log_atTop.eventually_ge_atTop 1
+    filter_upwards [h1, h2] with x ha hb using ⟨ha, hb⟩
+  obtain ⟨X, hX⟩ := Filter.eventually_atTop.mp hev
+  -- Threshold: large enough for the Θ-bounds (N₀) and for the analytic estimate (⌈X⌉₊).
+  refine ⟨max N₀ ⌈X⌉₊, fun N hN => ?_⟩
+  have hNN₀ : N ≥ N₀ := le_trans (le_max_left _ _) hN
+  have hNceil : (⌈X⌉₊ : ℕ) ≤ N := le_trans (le_max_right _ _) hN
+  have hXle : X ≤ (N : ℝ) := le_trans (Nat.le_ceil X) (by exact_mod_cast hNceil)
+  obtain ⟨hll_lt, hlogge1⟩ := hX (N : ℝ) hXle
+  obtain ⟨hlo, hhi⟩ := hN₀ N hNN₀
+  -- `log log N ≥ 0`, hence the correction is non-negative and `|corr| = corr`.
+  have hll_nonneg : 0 ≤ Real.log (Real.log (N : ℝ)) := Real.log_nonneg hlogge1
+  have hcorr_nonneg : 0 ≤ correctionTerm gEps ε N :=
+    le_trans (mul_nonneg hc₁.le hll_nonneg) hlo
+  rw [abs_of_nonneg hcorr_nonneg]
+  -- `c₂·log log N < c₂·ε'·log N = δ·log₂ N`.
+  have hchain : c₂ * Real.log (Real.log (N : ℝ)) < δ * Real.logb 2 (N : ℝ) := by
+    have step : c₂ * Real.log (Real.log (N : ℝ)) < c₂ * (ε' * Real.log (N : ℝ)) :=
+      mul_lt_mul_of_pos_left hll_lt hc₂
+    have hc₂' : c₂ ≠ 0 := ne_of_gt hc₂
+    have hlog2' : Real.log 2 ≠ 0 := ne_of_gt hlog2
+    have eq : c₂ * (ε' * Real.log (N : ℝ)) = δ * Real.logb 2 (N : ℝ) := by
+      simp only [hε'def, Real.logb]
+      field_simp
+    rw [eq] at step
+    exact step
+  linarith [hhi, hchain]
+
+end Erdos1179OQ01OQ02

--- a/research/problems/erdos-1179-oq-01-oq-02/knowledge.md
+++ b/research/problems/erdos-1179-oq-01-oq-02/knowledge.md
@@ -1,0 +1,42 @@
+# erdos-1179-oq-01-oq-02 — Completing the Second-Order Correction Hierarchy
+
+## Summary
+
+Parent `erdos-1179-oq-01` formalizes three candidate rates for the Erdős #1179
+second-order correction `corr(N) = g_ε(N) − log₂ N`:
+- `CorrectionIsBounded` — O(1) (strongest, open)
+- `CorrectionIsLogLog` — Θ(log log N) (conjectured via #543 analogy)
+- `CorrectionIsSublinearInLog` — o(log₂ N) (weakest, known)
+
+The parent proved `CorrectionIsBounded ⟹ CorrectionIsSublinearInLog`
+(`bounded_implies_sublinear`) and left `CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog`
+"straightforward but not formalized." This OQ formalizes exactly that, axiom-free.
+
+## Session 2026-07-02 (Session 1, researcher-16) — FRESH
+
+**Mode**: FRESH
+**Outcome**: completed (pending green build)
+
+### What I Did
+- Created `proofs/Proofs/Erdos1179OQ01OQ02.lean` (139L, 3 defs, 2 thms, 0 sorry/axiom).
+- Restated the three parent correction-term definitions verbatim (self-contained).
+- Proved `eventually_loglog_lt`: log log x = o(log x) via `Real.isLittleO_log_id_atTop`
+  composed with `Real.tendsto_log_atTop` (`IsLittleO.comp_tendsto`).
+- Proved `loglog_implies_sublinear`: CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog.
+- Added gallery entry `src/data/proofs/erdos-1179-oq-01-oq-02/{meta,annotations}.json`.
+
+### Key Findings
+- The parent's loosely-stated chain "O(1) ⟹ Θ(log log N)" is FALSE as a propositional
+  implication: bounded correction contradicts a growing Θ lower bound. The two sharpenings
+  are mutually exclusive; each independently implies o(log₂ N). This file supplies the
+  Θ(log log N) branch (parent supplied the O(1) branch).
+- The whole implication reduces to the single analytic fact log log N = o(log N).
+- Correction non-negativity for large N is derived (lower Θ-bound + log log N ≥ 0), not assumed.
+
+### Files Modified
+- proofs/Proofs/Erdos1179OQ01OQ02.lean (new)
+- src/data/proofs/erdos-1179-oq-01-oq-02/meta.json (new)
+- src/data/proofs/erdos-1179-oq-01-oq-02/annotations.json (new)
+
+### Next Steps
+- The open second-order dichotomy (O(1) vs Θ(log log N)) remains — genuinely open, no finite technique.

--- a/src/data/proofs/erdos-1179-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1179-oq-01-oq-02/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "e1179-oq01oq02-ann-overview",
+    "proofId": "erdos-1179-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Completing the Second-Order Correction Hierarchy",
+    "content": "Erdős #1179 (Erdős–Hall, 1976) gives g_ε(N) ∼ log₂ N for the minimal number of random abelian-group elements needed for an ε-uniform subset-sum representation. The parent open question erdos-1179-oq-01 studies the second-order correction corr(N) = g_ε(N) − log₂ N and formalizes three candidate rates: O(1) (CorrectionIsBounded, open), Θ(log log N) (CorrectionIsLogLog, conjectured), and o(log₂ N) (CorrectionIsSublinearInLog, known). The parent proves O(1) ⟹ o(log) and leaves Θ(log log N) ⟹ o(log) 'straightforward but not formalized.' This file formalizes precisely that remaining implication, completing the hierarchy so that both nontrivial candidate rates provably imply the known coarse rate.",
+    "mathContext": "$\\mathrm{corr}(N) = g_\\varepsilon(N) - \\log_2 N$; hierarchy: O(1) and $\\Theta(\\log\\log N)$ each $\\Rightarrow o(\\log_2 N)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Erdős problems",
+      "additive combinatorics",
+      "asymptotic hierarchy",
+      "little-o notation",
+      "second-order correction terms"
+    ],
+    "prerequisites": [
+      "asymptotic notation (O, o, Θ)",
+      "subset-sum representations",
+      "logarithmic growth rates"
+    ]
+  },
+  {
+    "id": "e1179-oq01oq02-ann-definitions",
+    "proofId": "erdos-1179-oq-01-oq-02",
+    "range": {
+      "startLine": 43,
+      "endLine": 67
+    },
+    "type": "definition",
+    "title": "The Correction-Term Rate Definitions",
+    "content": "Three definitions are restated verbatim from the parent so the file is self-contained (matching the sibling OQ convention). correctionTerm gEps ε N = (g_ε(N) : ℝ) − logb 2 N is the quantity of interest. CorrectionIsSublinearInLog encodes the o(log₂ N) rate: for all δ > 0, eventually |corr(N)| < δ·log₂ N. CorrectionIsLogLog encodes the two-sided Θ(log log N) rate: there exist c₁, c₂ > 0 with c₁·log log N ≤ corr(N) ≤ c₂·log log N for all large N. Note the Θ definition uses the natural logarithm log for the log log term while the sublinear rate uses logb 2; the two logarithms differ only by the constant factor log 2, absorbed into the scale ε' in the main proof.",
+    "mathContext": "$\\mathrm{CorrectionIsLogLog}:\\ \\exists c_1,c_2>0,\\ c_1\\log\\log N \\le \\mathrm{corr}(N) \\le c_2\\log\\log N$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Big-Theta bounds",
+      "little-o rate",
+      "logb versus natural log"
+    ],
+    "prerequisites": [
+      "asymptotic bound definitions",
+      "Real.logb"
+    ]
+  },
+  {
+    "id": "e1179-oq01oq02-ann-analytic-core",
+    "proofId": "erdos-1179-oq-01-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "The Analytic Core: log log x = o(log x)",
+    "content": "eventually_loglog_lt is the single analytic input: for every ε' > 0, log(log x) < ε'·log x for all large x. The proof takes Mathlib's Real.isLittleO_log_id_atTop (log x = o(x)) and composes it on the right with Real.tendsto_log_atTop (log x → ∞) via IsLittleO.comp_tendsto, yielding log ∘ log = o(log). Unpacking with isLittleO_iff at tolerance ε'/2 gives ‖log(log x)‖ ≤ (ε'/2)·‖log x‖ eventually; combined with log x > 0 (eventually) the norms drop and the strict inequality log(log x) < ε'·log x follows (the ½ slack upgrades ≤ to <). This is the log-versus-identity growth gap applied twice: log t = o(t) with t = log x.",
+    "mathContext": "$\\log t = o(t)$ with $t = \\log x$ gives $\\log\\log x = o(\\log x)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "little-o composition",
+      "IsLittleO.comp_tendsto",
+      "logarithmic growth",
+      "eventually filters"
+    ],
+    "prerequisites": [
+      "asymptotic little-o (Asymptotics.IsLittleO)",
+      "Filter.atTop and eventually",
+      "Real.isLittleO_log_id_atTop"
+    ]
+  },
+  {
+    "id": "e1179-oq01oq02-ann-main",
+    "proofId": "erdos-1179-oq-01-oq-02",
+    "range": {
+      "startLine": 97,
+      "endLine": 140
+    },
+    "type": "theorem",
+    "title": "Main Implication: Θ(log log N) ⟹ o(log₂ N)",
+    "content": "loglog_implies_sublinear proves CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog. Given the Θ-bounds with constants c₁, c₂ and threshold N₀, and a target δ > 0, set the scale ε' = δ/(c₂·log 2) > 0. A combined eventually fact supplies a real threshold X beyond which log(log N) < ε'·log N and 1 ≤ log N both hold; the latter yields log log N ≥ 0 (Real.log_nonneg). For N ≥ max(N₀, ⌈X⌉₊): the lower bound c₁·log log N ≤ corr(N) with log log N ≥ 0 forces corr(N) ≥ 0, so |corr(N)| = corr(N); the upper bound gives corr(N) ≤ c₂·log log N, and c₂·log log N < c₂·ε'·log N = δ·(log N / log 2) = δ·logb 2 N (using Real.logb 2 N = log N / log 2, closed by field_simp after simp only [Real.logb]). Chaining delivers |corr(N)| < δ·logb 2 N.",
+    "mathContext": "$|\\mathrm{corr}(N)| = \\mathrm{corr}(N) \\le c_2\\log\\log N < \\delta\\log_2 N$ for $N \\ge \\max(N_0, \\lceil X\\rceil)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "asymptotic hierarchy",
+      "epsilon-delta o(·) proof",
+      "absolute value elimination via sign",
+      "Real.logb identity"
+    ],
+    "prerequisites": [
+      "little-o threshold extraction",
+      "Nat.ceil / Nat.le_ceil",
+      "monotonicity of multiplication"
+    ]
+  },
+  {
+    "id": "e1179-oq01oq02-ann-honesty",
+    "proofId": "erdos-1179-oq-01-oq-02",
+    "range": {
+      "startLine": 27,
+      "endLine": 41
+    },
+    "type": "insight",
+    "title": "Honesty Note: the Two Sharpenings Are Mutually Exclusive",
+    "content": "The parent's narrative loosely writes the hierarchy as a chain 'O(1) ⟹ Θ(log log N) ⟹ o(log)'. Read literally as an implication between the Lean propositions, the first step is FALSE: CorrectionIsBounded (|corr| ≤ C) contradicts CorrectionIsLogLog's growing lower bound c₁·log log N ≤ corr for large N. The correct structural picture — the one this file certifies — is that O(1) and Θ(log log N) are mutually exclusive sharpenings of the correction, and EACH independently implies the coarse known rate o(log₂ N). The parent proved the O(1) branch (bounded_implies_sublinear); this file proves the Θ(log log N) branch. Neither resolves which rate actually holds; that dichotomy is the open content of erdos-1179-oq-01.",
+    "mathContext": "Bounded $\\not\\Rightarrow \\Theta(\\log\\log N)$; instead both $\\Rightarrow o(\\log_2 N)$ independently.",
+    "significance": "central",
+    "relatedConcepts": [
+      "mutually exclusive asymptotic rates",
+      "mathematical honesty",
+      "open problem framing"
+    ],
+    "prerequisites": [
+      "asymptotic rate comparison"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1179-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "erdos-1179-oq-01-oq-02",
+  "slug": "erdos-1179-oq-01-oq-02",
+  "title": "Erdős #1179 OQ-01-OQ-02: Completing the Second-Order Correction Hierarchy (Θ(log log N) ⟹ o(log₂ N))",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Asymptotics"
+    ],
+    "namespace": "Erdos1179OQ01OQ02",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1179OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "description": "The parent open question (erdos-1179-oq-01) formalizes three candidate rates for the second-order correction term corr(N) = g_ε(N) − log₂ N — O(1), Θ(log log N), and o(log₂ N) — and proves CorrectionIsBounded ⟹ CorrectionIsSublinearInLog (O(1) ⟹ o(log)), remarking that the other implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log)) is 'straightforward but not formalized.' This file formalizes exactly that remaining implication, axiom-free, completing the hierarchy: both nontrivial sharpenings collapse into the known o(log₂ N) rate. The single analytic input is log log N = o(log N), from Mathlib's Real.isLittleO_log_id_atTop. 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Erdős Problem #1179 (Erdős–Hall 1976) establishes that the minimal number g_ε(N) of random abelian-group elements needed for an ε-uniform subset-sum representation function satisfies g_ε(N) ∼ log₂ N. The parent open question erdos-1179-oq-01 studies the precise second-order correction corr(N) = g_ε(N) − log₂ N, formalizing three candidate rates as Lean propositions: CorrectionIsBounded (O(1), the strongest, open), CorrectionIsLogLog (Θ(log log N), conjectured by analogy with the disproved Problem #543), and CorrectionIsSublinearInLog (o(log₂ N), the weakest, already known). The parent proves the O(1) ⟹ o(log) implication and leaves the Θ(log log N) ⟹ o(log) implication unformalized.",
+    "problemStatement": "Formalize the remaining true implication in the correction-term hierarchy: if corr(N) is bounded on both sides by constant multiples of log log N, then it is o(log₂ N).",
+    "text": "A 140-line, axiom-free, machine-checked formalization. The three correction-term definitions are restated verbatim from the parent so the file is self-contained. The single analytic lemma eventually_loglog_lt establishes log log x = o(log x): for every ε' > 0, log(log x) < ε'·log x for all large x, obtained by composing Mathlib's Real.isLittleO_log_id_atTop (log x = o(x)) with log x → ∞. The main theorem loglog_implies_sublinear then shows CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog: the two-sided Θ(log log N) bound makes corr(N) eventually non-negative (so |corr(N)| = corr(N)) and ≤ c₂·log log N, which is < δ·log₂ N for every δ > 0 and all large N.",
+    "proofStrategy": "Fix δ > 0. Set ε' = δ/(c₂·log 2) > 0. From eventually_loglog_lt and log x → ∞, obtain a threshold X beyond which both log(log N) < ε'·log N and 1 ≤ log N hold; the latter gives log(log N) ≥ 0. For N above max(N₀, ⌈X⌉₊): the lower Θ-bound c₁·log log N ≤ corr(N) with log log N ≥ 0 forces corr(N) ≥ 0, so |corr(N)| = corr(N) ≤ c₂·log log N (upper Θ-bound). Then c₂·log log N < c₂·ε'·log N = δ·(log N/log 2) = δ·log₂ N, using Real.logb 2 N = log N / log 2. Chaining gives |corr(N)| < δ·log₂ N.",
+    "keyInsights": [
+      "The literal chain 'O(1) ⟹ Θ(log log N)' stated loosely in the parent's narrative is false: a bounded correction cannot satisfy a lower bound c₁·log log N ≤ corr that grows without bound. The O(1) and Θ(log log N) hypotheses are mutually exclusive sharpenings; the correct structural fact is that EACH independently implies the known o(log₂ N) rate.",
+      "This file supplies the second of those two independent implications (Θ(log log N) ⟹ o(log)), which the parent explicitly left unformalized, so together with the parent's bounded_implies_sublinear the hierarchy is now complete.",
+      "The whole implication reduces to a single elementary asymptotic, log log N = o(log N), i.e. log t = o(t) after the substitution t = log N — a clean instance of the log-versus-identity growth gap packaged by Mathlib as Real.isLittleO_log_id_atTop.",
+      "Non-negativity of the correction for large N is not assumed but derived: the Θ lower bound c₁·log log N with log log N ≥ 0 (valid once N ≥ e) yields corr(N) ≥ 0, which is what lets |corr(N)| be replaced by corr(N).",
+      "The result is direction-agnostic about which rate actually holds — it does not resolve the open second-order question, only certifies the logical skeleton (both sharpenings imply the coarse known bound)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "loglog_implies_sublinear",
+      "type": "core",
+      "description": "The remaining hierarchy implication: the Θ(log log N) correction bound implies the o(log₂ N) rate.",
+      "leanType": "CorrectionIsLogLog gEps ε → CorrectionIsSublinearInLog gEps ε"
+    },
+    {
+      "name": "eventually_loglog_lt",
+      "type": "supporting",
+      "description": "The analytic core: log log x = o(log x). For every ε' > 0, eventually log(log x) < ε'·log x.",
+      "leanType": "0 < ε' → ∀ᶠ x in atTop, Real.log (Real.log x) < ε' * Real.log x"
+    }
+  ],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Correction-Term Definitions (restated from the parent)",
+      "startLine": 43,
+      "endLine": 67,
+      "summary": "Restates the three parent definitions verbatim: correctionTerm gEps ε N = g_ε(N) − log₂ N; CorrectionIsSublinearInLog (the o(log₂ N) rate); and CorrectionIsLogLog (the two-sided Θ(log log N) rate, ∃ c₁,c₂ > 0 with c₁·log log N ≤ corr ≤ c₂·log log N eventually). Keeping the definitions local makes the file self-contained, matching the sibling OQ files.",
+      "mathContext": "$\\mathrm{corr}(N) = g_\\varepsilon(N) - \\log_2 N$; the Θ hypothesis is $c_1 \\log\\log N \\le \\mathrm{corr}(N) \\le c_2 \\log\\log N$ for $N \\ge N_0$."
+    },
+    {
+      "id": "analytic-core",
+      "title": "The Analytic Core: log log x = o(log x)",
+      "startLine": 68,
+      "endLine": 96,
+      "summary": "eventually_loglog_lt: for every ε' > 0, log(log x) < ε'·log x eventually. Proof composes Real.isLittleO_log_id_atTop (log = o(id)) with Real.tendsto_log_atTop via IsLittleO.comp_tendsto to get log ∘ log = o(log), extracts the ≤ (ε'/2)·‖log x‖ bound from isLittleO_iff, and upgrades ≤ to < using log x > 0 (eventually).",
+      "mathContext": "$\\log(\\log x) = o(\\log x)$, equivalently $\\log t = o(t)$ under $t = \\log x$."
+    },
+    {
+      "id": "main-implication",
+      "title": "Main Implication: Θ(log log N) ⟹ o(log₂ N)",
+      "startLine": 97,
+      "endLine": 140,
+      "summary": "loglog_implies_sublinear: given the Θ(log log N) bounds, for each δ > 0 the scale ε' = δ/(c₂·log 2) turns log log N < ε'·log N into c₂·log log N < δ·log₂ N. Non-negativity of corr(N) for large N (from the lower Θ-bound and log log N ≥ 0) removes the absolute value, and the upper Θ-bound closes |corr(N)| < δ·log₂ N.",
+      "mathContext": "$|\\mathrm{corr}(N)| = \\mathrm{corr}(N) \\le c_2 \\log\\log N < \\delta \\log_2 N$ for all large $N$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file formalizes the implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log₂ N)) that the parent erdos-1179-oq-01 identified as 'straightforward but not formalized,' completing the second-order correction hierarchy for Erdős #1179. Together with the parent's bounded_implies_sublinear, both nontrivial candidate sharpenings of the correction term are now proved to imply the coarse, known o(log₂ N) rate. Zero axioms, zero sorries.",
+    "implications": "The completed hierarchy sharpens the logical picture of the open second-order question: whatever the true rate of g_ε(N) − log₂ N is, if it is either O(1) or Θ(log log N) then it is certainly o(log₂ N) — so neither candidate can be ruled out by the coarse asymptotic alone, and distinguishing them requires genuinely finer information. The proof also isolates the single analytic fact (log log N = o(log N)) on which the whole hierarchy rests. It does NOT resolve which rate holds; the O(1) versus Θ(log log N) dichotomy remains the open content of erdos-1179-oq-01.",
+    "openQuestions": [
+      "Which rate is correct: is g_ε(N) − log₂ N bounded (O(1)), or does it genuinely grow like Θ(log log N) as the Problem #543 analogy suggests?",
+      "Can the Erdős–Hall upper bound g_ε(N) ≤ log₂ N·(1 + O_ε(log log log N / log log N)) be improved to an additive O_ε(log log N) correction, matching the conjectured Θ(log log N) rate?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Hall, Richard R.",
+      "title": "On representations of integers as sums of distinct summands taken from a sequence",
+      "year": "1976",
+      "venue": "Discrete Mathematics, vol. 16, pp. 321–328",
+      "note": "Established g_ε(N) ∼ log₂ N and the upper bound with the O(log log log N / log log N) correction that motivates the second-order question."
+    },
+    {
+      "authors": "Erdős, Paul; Rényi, Alfréd",
+      "title": "Additive properties of random sequences of positive integers",
+      "year": "1965",
+      "venue": "Acta Arithmetica, vol. 6, pp. 83–110",
+      "note": "Introduced the second-moment method for subset-sum representations in finite abelian groups."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-1179-oq-01",
+      "relationship": "parent",
+      "description": "The parent open question formalizing the correction-term hierarchy and proving CorrectionIsBounded ⟹ CorrectionIsSublinearInLog. This file supplies the companion implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog that the parent left unformalized."
+    },
+    {
+      "targetId": "erdos-1179",
+      "relationship": "ancestor",
+      "description": "The base Erdős #1179 formalization establishing the leading asymptotic g_ε(N) ∼ log₂ N."
+    },
+    {
+      "targetId": "erdos-543",
+      "relationship": "related",
+      "description": "The analogous coverage question, whose Θ(log log N) optimal correction motivates the Θ(log log N) candidate rate for #1179's uniformity correction."
+    }
+  ],
+  "sorries": [],
+  "meta": {
+    "author": "Erdős–Hall (1976); hierarchy-completion formalization in Lean 4 (researcher-16)",
+    "sourceUrl": "https://www.erdosproblems.com/1179",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1179OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "additive-combinatorics",
+      "abelian-groups",
+      "subset-sums",
+      "asymptotics",
+      "little-o",
+      "erdos-problem",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Self-contained: imports only Mathlib and restates the three parent correction-term definitions verbatim. The main theorem loglog_implies_sublinear proves the hierarchy implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log₂ N)) that the parent erdos-1179-oq-01 left unformalized. Machine-checked: `lake env lean Proofs/Erdos1179OQ01OQ02.lean` elaborates the file against prebuilt Mathlib oleans with zero errors and zero sorries, and `#print axioms` reports only [propext, Classical.choice, Quot.sound] — the foundational axioms; no Lean.ofReduceBool (no native_decide) and no sorryAx. This entry proves ONLY the logical implication between candidate rates; it does NOT resolve the open second-order question (which rate actually holds).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.isLittleO_log_id_atTop",
+        "description": "log x = o(x) as x → ∞; composed with log x → ∞ to yield log log x = o(log x), the sole analytic input.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Real.tendsto_log_atTop",
+        "description": "log x → ∞ as x → ∞; used both to compose the little-o fact and to secure log log x ≥ 0 (1 ≤ log x eventually).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Asymptotics.IsLittleO.comp_tendsto",
+        "description": "Composition of a little-o relation with a tendsto map, turning log = o(id) into log ∘ log = o(log).",
+        "module": "Mathlib.Analysis.Asymptotics.Asymptotics"
+      }
+    ],
+    "originalContributions": [
+      "loglog_implies_sublinear: the implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log₂ N)), which the parent erdos-1179-oq-01 explicitly left 'straightforward but not formalized' — completing the correction-term hierarchy so that both nontrivial candidate rates provably imply the known coarse rate.",
+      "eventually_loglog_lt: a clean, reusable packaging of log log x = o(log x) as an explicit ε'-threshold statement (∀ ε' > 0, eventually log(log x) < ε'·log x), derived by composing Real.isLittleO_log_id_atTop with log x → ∞.",
+      "A mathematical-honesty correction to the parent's narrative: the loosely-stated chain 'O(1) ⟹ Θ(log log N)' is false (a bounded correction cannot meet a growing lower bound); the two sharpenings are mutually exclusive and each independently implies o(log₂ N), which is the structure this file certifies.",
+      "Derivation (not assumption) of the correction's eventual non-negativity from the Θ lower bound together with log log N ≥ 0, which is what licenses replacing |corr(N)| by corr(N)."
+    ]
+  }
+}

--- a/src/data/research/problems/erdos-1179-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1179-oq-01-oq-02.json
@@ -1,0 +1,23 @@
+{
+  "id": "erdos-1179-oq-01-oq-02",
+  "title": "Completing the second-order correction hierarchy for Erdős #1179",
+  "status": "in-progress",
+  "phase": "ACT",
+  "knowledge": {
+    "insights": [
+      "The parent's loosely-stated chain 'O(1) ⟹ Θ(log log N)' is false as a propositional implication: a bounded correction contradicts the growing Θ lower bound. The two sharpenings are mutually exclusive; each independently implies o(log₂ N).",
+      "The remaining true hierarchy implication CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog reduces entirely to the single analytic fact log log N = o(log N).",
+      "Correction non-negativity for large N need not be assumed: it follows from the Θ lower bound c₁·log log N ≤ corr together with log log N ≥ 0 (valid once N ≥ e)."
+    ],
+    "builtItems": [
+      "eventually_loglog_lt in proofs/Proofs/Erdos1179OQ01OQ02.lean: log log x = o(log x) as explicit ε'-threshold statement, via Real.isLittleO_log_id_atTop composed with Real.tendsto_log_atTop",
+      "loglog_implies_sublinear in proofs/Proofs/Erdos1179OQ01OQ02.lean: CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog (Θ(log log N) ⟹ o(log₂ N)), 0 axioms/0 sorries",
+      "Gallery entry src/data/proofs/erdos-1179-oq-01-oq-02/{meta,annotations}.json"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "The O(1) vs Θ(log log N) dichotomy (which rate actually holds) remains open with no known finite technique — this is the genuine research frontier of erdos-1179-oq-01."
+    ],
+    "progressSummary": "COMPLETE: formalized the remaining hierarchy implication Θ(log log N) ⟹ o(log₂ N) that the parent left unformalized, completing the correction-term hierarchy. Axiom-free."
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-1179-oq-01-oq-02** formalizing the remaining implication in the Erdős #1179 second-order correction hierarchy.

The parent **erdos-1179-oq-01** formalizes three candidate rates for the correction term `corr(N) = g_ε(N) − log₂ N`:
- `CorrectionIsBounded` — O(1) (open)
- `CorrectionIsLogLog` — Θ(log log N) (conjectured, #543 analogy)
- `CorrectionIsSublinearInLog` — o(log₂ N) (known)

It proved `CorrectionIsBounded ⟹ CorrectionIsSublinearInLog` and left `CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog` **"straightforward but not formalized."** This PR formalizes exactly that, completing the hierarchy.

## Content (`proofs/Proofs/Erdos1179OQ01OQ02.lean`, 140L, 3 def / 2 thm)

- `eventually_loglog_lt` — the sole analytic input, `log log x = o(log x)`, via Mathlib's `Real.isLittleO_log_id_atTop` composed with `log x → ∞` (`IsLittleO.comp_tendsto`).
- `loglog_implies_sublinear` — `CorrectionIsLogLog ⟹ CorrectionIsSublinearInLog`. Correction non-negativity for large N is **derived** (lower Θ-bound + `log log N ≥ 0`), not assumed.

## Honesty note

The parent's loosely-stated chain "O(1) ⟹ Θ(log log N)" is **false** as a propositional implication (a bounded correction cannot meet a growing lower bound). The two sharpenings are mutually exclusive; each independently implies `o(log₂ N)`. This entry certifies only that logical skeleton — it does **not** resolve which rate holds (the open content of the parent).

## Verification

- `lake env lean Proofs/Erdos1179OQ01OQ02.lean` → zero errors, zero sorries (elaborated against prebuilt Mathlib oleans).
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only. No `Lean.ofReduceBool` (no `native_decide`), no `sorryAx`. ⇒ `status: verified`, `axiomCount: 0`.
- Docker build was unavailable this session (containerd/cache I/O corruption from a concurrent disk-full event on the host); verified via host single-file elaboration instead. A confirming green docker build can be run once infra recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)