### PR TITLE
Enrich inverse-galois-oq-04 (Dedekind A₅ axiom elimination): annotation prerequisites

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04/annotations.json
@@ -8,7 +8,8 @@
     "content": "The docstring frames the parent's open question OQ-04 — can Dedekind's theorem be formalized to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309)? The companion file `InverseGaloisA5DedekindInstantiation` already reduces that axiom to a single sharp arithmetic fact, `3 ∣ inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)` at an unramified prime Q over 7, and its 'residual gap' note lays out a three-step Kummer–Dedekind route: (1) the prime of 𝓞 ℚ(α) matching the irreducible cubic factor of q mod 7 has inertia degree 3 (`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`); (2) inertia degrees multiply in a tower (`inertiaDeg_algebra_tower`, needing NO Galois hypothesis on the non-normal middle field ℚ(α)); (3) Galois uniformity spreads the degree to all primes of the splitting field over 7 (`inertiaDegIn_eq_inertiaDeg`). This file machine-checks the abstract heart — steps (2) and (3) — with only the foundational axioms (propext, Classical.choice, Quot.sound): no sorry, no new axiom.",
     "mathContext": "Inertia (residue) degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. For a Galois extension all primes over $p$ share one inertia degree, denoted $\\mathrm{inertiaDegIn}\\,p\\,T$. The route factors the target $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$ through the tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$.",
     "significance": "critical",
-    "relatedConcepts": ["inverse Galois problem", "inertia degree", "Kummer–Dedekind", "residual gap reduction", "residue field degree"]
+    "relatedConcepts": ["inverse Galois problem", "inertia degree", "Kummer–Dedekind", "residual gap reduction", "residue field degree"],
+    "prerequisites": ["the inverse Galois problem and Galois groups over ℚ", "Dedekind's factorization / Kummer–Dedekind theorem", "inertia (residue) degree of a prime in a number field"]
   },
   {
     "id": "ann-tower-setup",
@@ -19,7 +20,8 @@
     "content": "The variable block fixes a scalar tower R ⊆ S ⊆ T (`IsScalarTower R S T` gluing the three algebra instances) with a finite group G making T/R Galois via `IsGaloisGroup G R T`, together with a compatible chain of maximal ideals p ⊲ R, P ⊲ S, Q ⊲ T and lying-over instances `P.LiesOver p`, `Q.LiesOver P`. Critically S carries NO normality or Galois hypothesis — in the A₅ application the middle field ℚ(α) is not Galois over ℚ, so demanding normality there would break the argument. The `include G Q` directive is a genuine formalization subtlety: because G and Q occur only in the *proofs* below (not in the theorem *statements*, whose conclusions mention only p, P, T), Lean would otherwise omit them from the theorem signatures; `include` forces them to remain as explicit quantified arguments so callers can supply the intermediate prime Q and Galois group G.",
     "mathContext": "$R \\subseteq S \\subseteq T$ with $T/R$ Galois (group $G$), and $p \\lhd R$, $P \\lhd S$, $Q \\lhd T$ maximal with $P \\mid p$ and $Q \\mid P$. Transitivity $Q \\mid p$ is recovered inside the proof, not assumed.",
     "significance": "supporting",
-    "relatedConcepts": ["scalar tower", "non-normal extension", "lying-over relation", "Lean include directive", "quantified context variables"]
+    "relatedConcepts": ["scalar tower", "non-normal extension", "lying-over relation", "Lean include directive", "quantified context variables"],
+    "prerequisites": ["scalar towers of ring/field extensions", "lying-over of prime ideals in an extension", "Galois extensions and their Galois group"]
   },
   {
     "id": "ann-tower-brick",
@@ -30,7 +32,8 @@
     "content": "inertiaDeg_dvd_inertiaDegIn is the core theorem. Its proof is a two-line assembly: `inertiaDeg_algebra_tower` gives the multiplicativity inertiaDeg p Q = inertiaDeg p P · inertiaDeg P Q (no Galois hypothesis on S), and `inertiaDegIn_eq_inertiaDeg` uses the Galois action to identify inertiaDegIn p T with inertiaDeg p Q. Rewriting with both and applying `dvd_mul_right` exhibits inertiaDeg p P as a factor. Transitivity of lying-over (Q lies over p) comes from `LiesOver.trans`.",
     "mathContext": "$\\mathrm{inertiaDegIn}\\,p\\,T = f(Q\\mid p) = f(P\\mid p)\\,f(Q\\mid P)$, so $f(P\\mid p) \\mid \\mathrm{inertiaDegIn}\\,p\\,T$.",
     "significance": "critical",
-    "relatedConcepts": ["inertia degree multiplicativity", "Galois uniformity", "divisibility"]
+    "relatedConcepts": ["inertia degree multiplicativity", "Galois uniformity", "divisibility"],
+    "prerequisites": ["multiplicativity of inertia degree in a tower", "Galois uniformity of inertia degrees over a prime", "divisibility and dvd_mul_right"]
   },
   {
     "id": "ann-reduction-form",
@@ -41,6 +44,7 @@
     "content": "dvd_inertiaDegIn_of_dvd_inertiaDeg restates the brick in the shape the A₅ realization needs: to prove d ∣ inertiaDegIn p T it suffices to exhibit ONE intermediate prime P (over p, below a chosen top prime Q) with d ∣ inertiaDeg p P. The proof is `hd.trans (inertiaDeg_dvd_inertiaDegIn G p P Q)`. In the application, Kummer–Dedekind produces a prime P of 𝒪(ℚ(α)) with inertiaDeg (7) P = 3, and this lemma promotes 3 ∣ inertiaDeg (7) P to 3 ∣ inertiaDegIn (7) (𝒪 q.SplittingField).",
     "mathContext": "$d \\mid f(P\\mid p) \\Rightarrow d \\mid \\mathrm{inertiaDegIn}\\,p\\,T$, applied with $d = 3$, $p = (7)$.",
     "significance": "critical",
-    "relatedConcepts": ["reduction lemma", "Kummer–Dedekind", "three_dvd_gal_card", "A₅ realizability"]
+    "relatedConcepts": ["reduction lemma", "Kummer–Dedekind", "three_dvd_gal_card", "A₅ realizability"],
+    "prerequisites": ["transitivity of divisibility", "Kummer–Dedekind factorization at an unramified prime", "realizing A₅ as a Galois group (three_dvd_gal_card)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04`.

All 4 annotations already had `mathContext`, `significance`, and `relatedConcepts` but were missing `prerequisites`. Added 3 specific prerequisites to each, matched to the content (inverse Galois problem / Kummer–Dedekind / inertia degree; scalar towers + lying-over + Galois; inertia-degree multiplicativity + Galois uniformity; divisibility transitivity + A₅ realizability).

`meta.json` untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)