### PR TITLE
Enrich Fundamental Theorem of Calculus: add annotation prerequisites

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -11,6 +11,11 @@
     "content": "We define **F(x) = ∫ₐˣ f(t) dt**, the cumulative integral from a fixed starting point $a$ to a variable endpoint $x$.\n\nThis function measures the 'accumulated area' under $f$ from $a$ to $x$. As $x$ increases, more area is accumulated (if $f$ is positive).\n\nThe key insight: F is constructed from f via integration, and we'll prove F' = f.",
     "mathContext": "$F : \\mathbb{R} \\to \\mathbb{R}$\n\n$F(x) = \\int_a^x f(t)\\,dt$\n\nF(a) = 0 (integral over an empty interval)",
     "significance": "key",
+    "prerequisites": [
+      "definite (Riemann) integral",
+      "functions of a real variable",
+      "interval [a,x]"
+    ],
     "relatedConcepts": [
       "definite integral",
       "area under curve",
@@ -29,6 +34,11 @@
     "content": "**The derivative of the integral function equals the integrand.**\n\nIf $F(x) = \\int_a^x f(t)\\,dt$, then $F'(x) = f(x)$.\n\nThis is profound: integration 'builds' an antiderivative of any continuous function. Even if we can't write ∫f in closed form, the integral function exists and has f as its derivative.",
     "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$\n\nIn Leibniz notation: $\\frac{d}{dx}F(x) = f(x)$",
     "significance": "key",
+    "prerequisites": [
+      "the integral function F(x) = ∫ₐˣ f",
+      "derivative as a limit",
+      "HasDerivAt in Mathlib"
+    ],
     "relatedConcepts": [
       "antiderivative",
       "HasDerivAt",
@@ -47,6 +57,11 @@
     "content": "The theorem requires **continuity at x** (for the pointwise statement) or **continuity on [a,b]** (for the global statement).\n\nWhy? The proof relies on limits: as the integration interval shrinks, the average value approaches f(x). This requires continuity.\n\nFor discontinuous functions, we need the more sophisticated Lebesgue-Stieltjes integral and almost-everywhere differentiability.",
     "mathContext": "$f$ continuous at $x$ means:\n\n$\\lim_{h \\to 0} f(x+h) = f(x)$\n\nThis ensures $\\lim_{h \\to 0} \\frac{1}{h}\\int_x^{x+h} f(t)\\,dt = f(x)$",
     "significance": "key",
+    "prerequisites": [
+      "continuity at a point",
+      "limits of average values over shrinking intervals",
+      "ContinuousAt / ContinuousOn"
+    ],
     "relatedConcepts": [
       "continuity",
       "ContinuousAt",
@@ -65,6 +80,11 @@
     "content": "**The integral of a derivative equals the net change.**\n\n$\\int_a^b F'(x)\\,dx = F(b) - F(a)$\n\nThis is the 'computational' part of FTC: it reduces the problem of integration (infinite sums) to simple evaluation at two points.\n\nEvery integral table and integration technique is ultimately about finding antiderivatives to apply this theorem.",
     "mathContext": "$\\int_a^b f(x)\\,dx = F(b) - F(a)$\n\nwhere $F' = f$ on $[a, b]$\n\nOften written: $\\left[F(x)\\right]_a^b = F(b) - F(a)$",
     "significance": "key",
+    "prerequisites": [
+      "antiderivatives",
+      "FTC Part 1",
+      "net-change interpretation of the integral"
+    ],
     "relatedConcepts": [
       "antiderivative",
       "evaluation",
@@ -83,6 +103,11 @@
     "content": "The theorem requires:\n\n1. **F is differentiable** on [a, b]\n2. **F' is continuous** on [a, b] (or at least integrable)\n3. **a ≤ b** (the integration bounds are in order)\n\nThe continuity of F' is crucial: if F' has 'bad' discontinuities, the integral may not equal F(b) - F(a).\n\nCounterexamples exist for merely differentiable F with discontinuous derivative.",
     "mathContext": "We need:\n- $\\forall x \\in [a,b], \\text{HasDerivAt } F (F'(x)) x$\n- $F' \\in C([a,b])$ (continuous on closed interval)",
     "significance": "key",
+    "prerequisites": [
+      "differentiability on a closed interval",
+      "continuous or integrable derivatives",
+      "ordered bounds a ≤ b"
+    ],
     "relatedConcepts": [
       "differentiability",
       "ContinuousOn",
@@ -101,6 +126,10 @@
     "content": "**F is an antiderivative of f** if $F'(x) = f(x)$ for all $x$.\n\nAlso called a **primitive** or **indefinite integral** of f.\n\nThe key property: if F is an antiderivative of f, then so is F + C for any constant C. This is why indefinite integrals always have the '+C'.",
     "mathContext": "$F$ is an antiderivative of $f$ means:\n\n$\\forall x, \\frac{d}{dx}F(x) = f(x)$\n\nNotation: $\\int f(x)\\,dx = F(x) + C$",
     "significance": "key",
+    "prerequisites": [
+      "the derivative of a function",
+      "indefinite integrals and the constant of integration"
+    ],
     "relatedConcepts": [
       "derivative",
       "indefinite integral",
@@ -119,6 +148,11 @@
     "content": "**If F and G are both antiderivatives of f, then F - G is constant.**\n\nThis explains the '+C' in indefinite integrals:\n- F and G both satisfy F' = f and G' = f\n- So (F - G)' = 0\n- A function with zero derivative is constant (by MVT)\n- Therefore F = G + C\n\nThis means antiderivatives are 'unique up to a constant'.",
     "mathContext": "$F' = G' = f \\Rightarrow (F - G)' = 0$\n\n$\\Rightarrow F - G = C$ (constant)\n\nSo $\\int f\\,dx$ represents a *family* of functions differing by constants.",
     "significance": "key",
+    "prerequisites": [
+      "antiderivative definition",
+      "the mean value theorem",
+      "zero-derivative-implies-constant"
+    ],
     "relatedConcepts": [
       "mean value theorem",
       "constant function",
@@ -132,11 +166,16 @@
       "startLine": 124,
       "endLine": 128
     },
-    "type": "tactic",
+    "type": "technique",
     "title": "Zero Derivative Implies Constant",
     "content": "**If F'(x) = 0 for all x, then F is constant.**\n\nThis is a consequence of the Mean Value Theorem:\n\nFor any two points x and y, there exists c between them with\n$F(y) - F(x) = F'(c)(y - x) = 0 \\cdot (y - x) = 0$\n\nSo F(y) = F(x) for all x, y.\n\nThis lemma is essential for proving uniqueness of antiderivatives.",
     "mathContext": "Mean Value Theorem: $F(y) - F(x) = F'(c)(y - x)$ for some $c \\in (x, y)$\n\nIf $F' \\equiv 0$, then $F(y) = F(x)$ for all $x, y$.",
     "significance": "key",
+    "prerequisites": [
+      "the mean value theorem",
+      "constant functions",
+      "derivative equal to zero"
+    ],
     "relatedConcepts": [
       "mean value theorem",
       "constant function",
@@ -155,6 +194,11 @@
     "content": "**Differentiation and integration are inverse operations.**\n\nIntegrate then differentiate: $\\frac{d}{dx}\\int_a^x f = f$ (FTC Part 1)\n\nDifferentiate then integrate: $\\int_a^x F' = F - F(a)$ (FTC Part 2)\n\nThis 'almost inverse' relationship (up to the constant F(a)) unifies the two branches of calculus that Newton and Leibniz developed from completely different perspectives.\n\nNewton saw derivatives as velocities and integrals as areas. Leibniz saw both through infinitesimals. FTC shows they were studying the same thing.",
     "mathContext": "$D$ = differentiation, $I_a$ = integration from $a$\n\n$D \\circ I_a = \\text{id}$ (FTC Part 1)\n\n$I_a \\circ D = \\text{id} + \\text{const}$ (FTC Part 2, roughly)",
     "significance": "key",
+    "prerequisites": [
+      "FTC Part 1 and Part 2",
+      "function composition",
+      "the historical Newton/Leibniz development"
+    ],
     "relatedConcepts": [
       "inverse functions",
       "Newton",

--- a/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.source.json
@@ -8,13 +8,18 @@
     },
     "type": "definition",
     "title": "The Integral Function F(x)",
-    "content": "We define **F(x) = \u222b\u2090\u02e3 f(t) dt**, the cumulative integral from a fixed starting point $a$ to a variable endpoint $x$.\n\nThis function measures the 'accumulated area' under $f$ from $a$ to $x$. As $x$ increases, more area is accumulated (if $f$ is positive).\n\nThe key insight: F is constructed from f via integration, and we'll prove F' = f.",
+    "content": "We define **F(x) = ∫ₐˣ f(t) dt**, the cumulative integral from a fixed starting point $a$ to a variable endpoint $x$.\n\nThis function measures the 'accumulated area' under $f$ from $a$ to $x$. As $x$ increases, more area is accumulated (if $f$ is positive).\n\nThe key insight: F is constructed from f via integration, and we'll prove F' = f.",
     "mathContext": "$F : \\mathbb{R} \\to \\mathbb{R}$\n\n$F(x) = \\int_a^x f(t)\\,dt$\n\nF(a) = 0 (integral over an empty interval)",
     "significance": "key",
     "relatedConcepts": [
       "definite integral",
       "area under curve",
       "accumulation function"
+    ],
+    "prerequisites": [
+      "definite (Riemann) integral",
+      "functions of a real variable",
+      "interval [a,x]"
     ]
   },
   {
@@ -26,13 +31,18 @@
     },
     "type": "insight",
     "title": "FTC Part 1: Derivative of an Integral",
-    "content": "**The derivative of the integral function equals the integrand.**\n\nIf $F(x) = \\int_a^x f(t)\\,dt$, then $F'(x) = f(x)$.\n\nThis is profound: integration 'builds' an antiderivative of any continuous function. Even if we can't write \u222bf in closed form, the integral function exists and has f as its derivative.",
+    "content": "**The derivative of the integral function equals the integrand.**\n\nIf $F(x) = \\int_a^x f(t)\\,dt$, then $F'(x) = f(x)$.\n\nThis is profound: integration 'builds' an antiderivative of any continuous function. Even if we can't write ∫f in closed form, the integral function exists and has f as its derivative.",
     "mathContext": "$\\frac{d}{dx}\\int_a^x f(t)\\,dt = f(x)$\n\nIn Leibniz notation: $\\frac{d}{dx}F(x) = f(x)$",
     "significance": "key",
     "relatedConcepts": [
       "antiderivative",
       "HasDerivAt",
       "differentiability"
+    ],
+    "prerequisites": [
+      "the integral function F(x) = ∫ₐˣ f",
+      "derivative as a limit",
+      "HasDerivAt in Mathlib"
     ]
   },
   {
@@ -51,6 +61,11 @@
       "continuity",
       "ContinuousAt",
       "limit definition"
+    ],
+    "prerequisites": [
+      "continuity at a point",
+      "limits of average values over shrinking intervals",
+      "ContinuousAt / ContinuousOn"
     ]
   },
   {
@@ -70,6 +85,11 @@
       "antiderivative",
       "evaluation",
       "net change"
+    ],
+    "prerequisites": [
+      "antiderivatives",
+      "FTC Part 1",
+      "net-change interpretation of the integral"
     ]
   },
   {
@@ -82,13 +102,18 @@
     },
     "type": "concept",
     "title": "Conditions for FTC Part 2",
-    "content": "The theorem requires:\n\n1. **F is differentiable** on [a, b]\n2. **F' is continuous** on [a, b] (or at least integrable)\n3. **a \u2264 b** (the integration bounds are in order)\n\nThe continuity of F' is crucial: if F' has 'bad' discontinuities, the integral may not equal F(b) - F(a).\n\nCounterexamples exist for merely differentiable F with discontinuous derivative.",
+    "content": "The theorem requires:\n\n1. **F is differentiable** on [a, b]\n2. **F' is continuous** on [a, b] (or at least integrable)\n3. **a ≤ b** (the integration bounds are in order)\n\nThe continuity of F' is crucial: if F' has 'bad' discontinuities, the integral may not equal F(b) - F(a).\n\nCounterexamples exist for merely differentiable F with discontinuous derivative.",
     "mathContext": "We need:\n- $\\forall x \\in [a,b], \\text{HasDerivAt } F (F'(x)) x$\n- $F' \\in C([a,b])$ (continuous on closed interval)",
     "significance": "key",
     "relatedConcepts": [
       "differentiability",
       "ContinuousOn",
       "interval conditions"
+    ],
+    "prerequisites": [
+      "differentiability on a closed interval",
+      "continuous or integrable derivatives",
+      "ordered bounds a ≤ b"
     ]
   },
   {
@@ -108,6 +133,10 @@
       "derivative",
       "indefinite integral",
       "primitive function"
+    ],
+    "prerequisites": [
+      "the derivative of a function",
+      "indefinite integrals and the constant of integration"
     ]
   },
   {
@@ -126,6 +155,11 @@
       "mean value theorem",
       "constant function",
       "uniqueness"
+    ],
+    "prerequisites": [
+      "antiderivative definition",
+      "the mean value theorem",
+      "zero-derivative-implies-constant"
     ]
   },
   {
@@ -145,6 +179,11 @@
       "mean value theorem",
       "constant function",
       "convexity"
+    ],
+    "prerequisites": [
+      "the mean value theorem",
+      "constant functions",
+      "derivative equal to zero"
     ]
   },
   {
@@ -164,6 +203,11 @@
       "Newton",
       "Leibniz",
       "calculus unification"
+    ],
+    "prerequisites": [
+      "FTC Part 1 and Part 2",
+      "function composition",
+      "the historical Newton/Leibniz development"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotation depth (prerequisites)

The `fundamental-theorem-calculus` landing-page entry had 9 rich annotations (content, mathContext, significance, relatedConcepts) but **none carried a `prerequisites` field** — the one missing depth dimension of the enricher spec.

Added a focused `prerequisites` array to each of the 9 annotations in `annotations.source.json` (the anchor-based source of truth) and regenerated the compiled `annotations.json`. Each list is short (2–3 items) and specific to that annotation — e.g. the uniqueness insight lists "antiderivative definition", "the mean value theorem", "zero-derivative-implies-constant".

Also syncs one stale compiled field: `ann-zero-derivative` type `tactic` → `technique`, matching the source (the compiled file on main had drifted).

Scope: only the FTC annotation files; anchor ranges are unchanged.
