### PR TITLE
Enrich Triangle Inequality: add annotation prerequisites

### DIFF
--- a/src/data/proofs/triangle-inequality/annotations.json
+++ b/src/data/proofs/triangle-inequality/annotations.json
@@ -14,6 +14,11 @@
     "relatedConcepts": [
       "abs_add",
       "metric axioms"
+    ],
+    "prerequisites": [
+      "absolute value on ℝ",
+      "case analysis on signs",
+      "order properties of ℝ"
     ]
   },
   {
@@ -31,6 +36,11 @@
     "relatedConcepts": [
       "Lipschitz continuity",
       "abs_abs_sub_abs_le_abs_sub"
+    ],
+    "prerequisites": [
+      "the triangle inequality |x+y| ≤ |x|+|y|",
+      "absolute value",
+      "subtraction and rearrangement"
     ]
   },
   {
@@ -48,6 +58,11 @@
     "relatedConcepts": [
       "SeminormedAddCommGroup",
       "norm_add_le"
+    ],
+    "prerequisites": [
+      "normed vector spaces",
+      "the norm axioms",
+      "seminormed additive groups"
     ]
   },
   {
@@ -65,6 +80,11 @@
     "relatedConcepts": [
       "PseudoMetricSpace",
       "dist_triangle"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "the distance function d(x,y)",
+      "the metric axioms"
     ]
   },
   {
@@ -82,6 +102,10 @@
     "relatedConcepts": [
       "path length",
       "iterated inequality"
+    ],
+    "prerequisites": [
+      "the triangle inequality for three points",
+      "iterating an inequality"
     ]
   },
   {
@@ -99,6 +123,11 @@
     "relatedConcepts": [
       "collinearity",
       "degenerate triangle"
+    ],
+    "prerequisites": [
+      "the triangle inequality",
+      "strict vs non-strict order",
+      "sign analysis"
     ]
   },
   {
@@ -116,6 +145,11 @@
     "relatedConcepts": [
       "Lipschitz continuity",
       "uniform continuity"
+    ],
+    "prerequisites": [
+      "the reverse triangle inequality",
+      "Lipschitz continuity",
+      "the definition of a Lipschitz constant"
     ]
   },
   {
@@ -133,6 +167,11 @@
     "relatedConcepts": [
       "functional analysis",
       "continuous functions"
+    ],
+    "prerequisites": [
+      "norms and the reverse triangle inequality in normed spaces",
+      "Lipschitz continuity",
+      "continuity of the norm"
     ]
   },
   {
@@ -150,6 +189,11 @@
     "relatedConcepts": [
       "series convergence",
       "error bounds"
+    ],
+    "prerequisites": [
+      "the triangle inequality in a normed space",
+      "induction over a finite index set",
+      "Finset sums"
     ]
   }
 ]

--- a/src/data/proofs/triangle-inequality/annotations.source.json
+++ b/src/data/proofs/triangle-inequality/annotations.source.json
@@ -15,6 +15,11 @@
     "relatedConcepts": [
       "abs_add",
       "metric axioms"
+    ],
+    "prerequisites": [
+      "absolute value on \u211d",
+      "case analysis on signs",
+      "order properties of \u211d"
     ]
   },
   {
@@ -33,6 +38,11 @@
     "relatedConcepts": [
       "Lipschitz continuity",
       "abs_abs_sub_abs_le_abs_sub"
+    ],
+    "prerequisites": [
+      "the triangle inequality |x+y| \u2264 |x|+|y|",
+      "absolute value",
+      "subtraction and rearrangement"
     ]
   },
   {
@@ -51,6 +61,11 @@
     "relatedConcepts": [
       "SeminormedAddCommGroup",
       "norm_add_le"
+    ],
+    "prerequisites": [
+      "normed vector spaces",
+      "the norm axioms",
+      "seminormed additive groups"
     ]
   },
   {
@@ -69,6 +84,11 @@
     "relatedConcepts": [
       "PseudoMetricSpace",
       "dist_triangle"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "the distance function d(x,y)",
+      "the metric axioms"
     ]
   },
   {
@@ -87,6 +107,10 @@
     "relatedConcepts": [
       "path length",
       "iterated inequality"
+    ],
+    "prerequisites": [
+      "the triangle inequality for three points",
+      "iterating an inequality"
     ]
   },
   {
@@ -105,6 +129,11 @@
     "relatedConcepts": [
       "collinearity",
       "degenerate triangle"
+    ],
+    "prerequisites": [
+      "the triangle inequality",
+      "strict vs non-strict order",
+      "sign analysis"
     ]
   },
   {
@@ -123,6 +152,11 @@
     "relatedConcepts": [
       "Lipschitz continuity",
       "uniform continuity"
+    ],
+    "prerequisites": [
+      "the reverse triangle inequality",
+      "Lipschitz continuity",
+      "the definition of a Lipschitz constant"
     ]
   },
   {
@@ -141,6 +175,11 @@
     "relatedConcepts": [
       "functional analysis",
       "continuous functions"
+    ],
+    "prerequisites": [
+      "norms and the reverse triangle inequality in normed spaces",
+      "Lipschitz continuity",
+      "continuity of the norm"
     ]
   },
   {
@@ -159,6 +198,11 @@
     "relatedConcepts": [
       "series convergence",
       "error bounds"
+    ],
+    "prerequisites": [
+      "the triangle inequality in a normed space",
+      "induction over a finite index set",
+      "Finset sums"
     ]
   }
 ]


### PR DESCRIPTION
## Enrichment: annotation depth (prerequisites)

The `triangle-inequality` landing-page entry's 9 annotations carried content, mathContext, significance, and relatedConcepts but **no `prerequisites`** — the one missing depth dimension.

Added a short, specific `prerequisites` array (2–3 items) to each annotation in both `annotations.source.json` and the compiled `annotations.json`. Examples: the normed-space form lists "normed vector spaces / the norm axioms / seminormed additive groups"; the Lipschitz application lists "the reverse triangle inequality / Lipschitz continuity / the definition of a Lipschitz constant".

Pure additions — 88 inserted lines, 0 deletions, no content or anchor/range changes.
