### PR TITLE
research(fermat-two-squares-oq-04-oq-01): geometric r₂(n) + positivity bridge to δ [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/FermatTwoSquaresOQ04OQ01.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ04OQ01.lean
@@ -1,0 +1,160 @@
+/-
+  Jacobi's Two-Square Count — the geometric side r₂(n) and its positivity bridge
+  Open Question: fermat-two-squares-oq-04-oq-01
+
+  Fermat's two-squares theorem says *which* `n` are sums of two squares; Jacobi's
+  theorem says *how many*:
+
+        r₂(n) = 4 · δ(n),   δ(n) = ∑_{d ∣ n} χ₄(d),
+
+  where `χ₄` is the non-principal character mod 4 and `r₂(n)` counts the ordered,
+  signed integer pairs `(a,b)` with `a² + b² = n`.  The parent entry
+  (`fermat-two-squares-oq-04`, `FermatTwoSquaresOQ04.jacobiSum`) built and
+  verified the *arithmetic* right-hand side `δ`: multiplicative, nonnegative, with
+  explicit prime-power values and the qualitative bridge
+  `0 < δ(n) ⇔ n is a sum of two squares`.
+
+  This file opens the *geometric* left-hand side.  It defines the honest
+  representation count
+
+        r₂(n) := #{ (a,b) ∈ ℤ² : a² + b² = n }
+
+  as a `Finset.card` (finiteness is packaged into the definition via an explicit
+  bounding box `[-n, n]²`, since every solution has `|a|, |b| ≤ n`), and connects
+  it back to the parent by matching the two sides at the level of **positivity** —
+  the qualitative shadow of Jacobi's identity:
+
+        0 < r₂(n)  ⇔  n is a sum of two squares  ⇔  0 < δ(n).
+
+  This is the first rigorous bridge between the geometric and arithmetic sides of
+  Jacobi's theorem in the gallery: the lattice-point count on the circle of
+  radius √n is positive exactly when the divisor-character sum δ is.  The full
+  quantitative identity `r₂ = 4δ` (the exact count via Gaussian-integer prime
+  splitting, with the factor `4 = #{±1, ±i}` the unit group of ℤ[i]) remains
+  open; the divisibility `4 ∣ r₂(n)` is the natural next brick.
+
+  References:
+  - Jacobi (1834): r₂(n) = 4 ∑_{d∣n} χ₄(d)
+  - Parent FermatTwoSquaresOQ04.lean: the verified δ side
+  - Mathlib `Nat.eq_sq_add_sq_iff` (representability criterion)
+-/
+
+import Mathlib.Tactic
+import Proofs.FermatTwoSquaresOQ04
+
+open Finset
+
+namespace FermatTwoSquaresOQ04OQ01
+
+open FermatTwoSquaresOQ04
+
+-- ============================================================================
+-- Part I:  The geometric representation count r₂(n)
+-- ============================================================================
+
+/-- The finset of integer representations `{(a,b) ∈ ℤ² : a²+b² = n}`, cut out of
+the bounding box `[-n, n]²` (every solution has `|a|, |b| ≤ n`). -/
+def sols (n : ℕ) : Finset (ℤ × ℤ) :=
+  (Finset.Icc (-(n : ℤ)) (n : ℤ) ×ˢ Finset.Icc (-(n : ℤ)) (n : ℤ)).filter
+    fun p => p.1 ^ 2 + p.2 ^ 2 = (n : ℤ)
+
+/-- **The two-square representation count** `r₂(n) = #{(a,b) : a²+b² = n}`. -/
+def r2 (n : ℕ) : ℕ := (sols n).card
+
+/-- Membership bound: any integer with `a² ≤ n` lies in `[-n, n]`. -/
+private lemma mem_Icc_of_sq_le {a : ℤ} {n : ℕ} (h : a ^ 2 ≤ (n : ℤ)) :
+    a ∈ Finset.Icc (-(n : ℤ)) (n : ℤ) := by
+  have hn0 : (0 : ℤ) ≤ (n : ℤ) := by positivity
+  rw [Finset.mem_Icc]
+  constructor
+  · rcases le_or_gt 0 a with h1 | h1
+    · linarith
+    · have h1' : 1 ≤ -a := by omega
+      nlinarith [h1', h]
+  · rcases le_or_gt a 0 with h1 | h1
+    · linarith
+    · have h1' : 1 ≤ a := by omega
+      nlinarith [h1', h]
+
+/-- `(a,b) ∈ sols n ↔ a²+b² = n`.  The bounding box is automatic. -/
+@[simp] theorem mem_sols {n : ℕ} {p : ℤ × ℤ} :
+    p ∈ sols n ↔ p.1 ^ 2 + p.2 ^ 2 = (n : ℤ) := by
+  rw [sols, mem_filter, mem_product]
+  constructor
+  · exact fun h => h.2
+  · intro h
+    refine ⟨⟨mem_Icc_of_sq_le ?_, mem_Icc_of_sq_le ?_⟩, h⟩
+    · nlinarith [sq_nonneg p.2]
+    · nlinarith [sq_nonneg p.1]
+
+/-- `r₂(n) > 0` exactly when `n` has an integer representation as a sum of two
+squares. -/
+theorem r2_pos_iff_exists_int {n : ℕ} :
+    0 < r2 n ↔ ∃ a b : ℤ, a ^ 2 + b ^ 2 = (n : ℤ) := by
+  rw [r2, Finset.card_pos]
+  constructor
+  · rintro ⟨p, hp⟩
+    rw [mem_sols] at hp
+    exact ⟨p.1, p.2, hp⟩
+  · rintro ⟨a, b, hab⟩
+    exact ⟨(a, b), by rw [mem_sols]; exact hab⟩
+
+/-- Integer and natural-number representability agree. -/
+theorem exists_int_iff_exists_nat {n : ℕ} :
+    (∃ a b : ℤ, a ^ 2 + b ^ 2 = (n : ℤ)) ↔ ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
+  constructor
+  · rintro ⟨a, b, hab⟩
+    refine ⟨a.natAbs, b.natAbs, ?_⟩
+    have key : (n : ℤ) = (((a.natAbs ^ 2 + b.natAbs ^ 2 : ℕ)) : ℤ) := by
+      push_cast
+      rw [sq_abs, sq_abs]
+      linarith [hab]
+    exact_mod_cast key
+  · rintro ⟨x, y, hxy⟩
+    exact ⟨(x : ℤ), (y : ℤ), by rw [hxy]; push_cast; ring⟩
+
+-- ============================================================================
+-- Part II:  Positivity bridge — the qualitative Jacobi theorem, both sides
+-- ============================================================================
+
+/-- **Positivity bridge (qualitative Jacobi).**  The geometric representation
+count is positive exactly when the parent's arithmetic divisor-character sum is:
+
+      0 < r₂(n)  ⇔  0 < δ(n).
+
+Both sides equal "`n` is a sum of two squares", so this is the exact positivity
+shadow of Jacobi's identity `r₂ = 4δ`, now established across *both* sides. -/
+theorem r2_pos_iff_jacobiSum_pos {n : ℕ} (hn : n ≠ 0) :
+    0 < r2 n ↔ 0 < jacobiSum n := by
+  rw [r2_pos_iff_exists_int, exists_int_iff_exists_nat,
+    ← jacobiSum_pos_iff_sq_add_sq hn]
+
+/-- Complementary vanishing form: `n` has no representation ⇔ `δ(n) = 0`. -/
+theorem r2_eq_zero_iff_jacobiSum_eq_zero {n : ℕ} (hn : n ≠ 0) :
+    r2 n = 0 ↔ jacobiSum n = 0 := by
+  constructor
+  · intro h
+    by_contra hj
+    have hpos : 0 < jacobiSum n := lt_of_le_of_ne (jacobiSum_nonneg n) (Ne.symm hj)
+    rw [← r2_pos_iff_jacobiSum_pos hn] at hpos
+    omega
+  · intro h
+    by_contra hr
+    have hpos : 0 < r2 n := Nat.pos_of_ne_zero hr
+    rw [r2_pos_iff_jacobiSum_pos hn, h] at hpos
+    exact lt_irrefl 0 hpos
+
+/-- **Geometric Fermat criterion.**  For a prime `p`, there is a lattice point on
+the circle of radius `√p` exactly when `p ≢ 3 (mod 4)` — Fermat's two-squares
+criterion recovered from the representation count via the parent's `δ`. -/
+theorem r2_prime_pos_iff {p : ℕ} (hp : p.Prime) :
+    0 < r2 p ↔ p % 4 ≠ 3 := by
+  rw [r2_pos_iff_jacobiSum_pos hp.ne_zero]
+  have hkey := jacobiSum_prime_pow_pos_iff hp 1
+  rw [pow_one] at hkey
+  rw [hkey]
+  constructor
+  · intro h h3; exact Nat.not_even_one (h h3)
+  · intro h h3; exact absurd h3 h
+
+end FermatTwoSquaresOQ04OQ01

--- a/src/data/proofs/fermat-two-squares-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-04-oq-01/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "ann-r2-definition",
+    "proofId": "fermat-two-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "r₂(n) as an Honest Finset Count",
+    "content": "The representation count r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} is defined as `(sols n).card`, where `sols n` filters the bounding box [-n,n]² by the equation a²+b² = n. Realizing r₂ as a `Finset.card` (rather than a `Set.ncard` needing a separate finiteness proof) packages well-definedness into the definition itself: the box is finite, so the filtered set is a genuine finset. Mathlib has ℤ[i] as a Euclidean domain but no packaged 'number of representations' function, so this count is new. The box [-n,n]² is also invariant under the rotation (a,b) ↦ (-b,a), which is what makes the factor-of-4 structure visible later.",
+    "mathContext": "$r_2(n) := \\#\\{(a,b)\\in\\mathbb{Z}^2 : a^2+b^2 = n\\}$, the number of lattice points on the circle of radius $\\sqrt n$.",
+    "significance": "key",
+    "relatedConcepts": ["lattice points", "sum of two squares", "Finset cardinality", "representation count"],
+    "prerequisites": ["Finset.filter", "Finset.card", "integer bounding box"]
+  },
+  {
+    "id": "ann-bounding-box",
+    "proofId": "fermat-two-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 88
+    },
+    "type": "tactic",
+    "title": "The Bounding Box is Automatic",
+    "content": "`mem_Icc_of_sq_le` shows that any integer with a² ≤ n lies in [-n, n]: for a ≥ 1 one has a ≤ a² ≤ n (the integer inequality t ≤ t² for t ≥ 1, discharged by `nlinarith`), and the negative and zero cases are linear. Since a solution of a²+b² = n has a² ≤ n and b² ≤ n, `mem_sols` proves membership in `sols n` reduces to just the equation a²+b² = n — the box constraint carries no information and can be discharged automatically. This is what lets every later lemma reason with the clean predicate a²+b² = n rather than the box.",
+    "mathContext": "$a^2 \\le n \\implies |a| \\le n$ for integers, since $|a| \\le a^2$ once $|a| \\ge 1$; hence solutions of $a^2+b^2=n$ automatically lie in $[-n,n]^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["integer inequalities", "nlinarith", "bounding argument"],
+    "prerequisites": ["Finset.mem_Icc", "Finset.mem_filter", "nlinarith"]
+  },
+  {
+    "id": "ann-int-nat-agree",
+    "proofId": "fermat-two-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 114
+    },
+    "type": "tactic",
+    "title": "Signed and Unsigned Representability Agree",
+    "content": "`exists_int_iff_exists_nat` bridges the signed count (∃ a b : ℤ) used by r₂ with the natural-number predicate (∃ x y : ℕ, n = x²+y²) that the parent's δ bridge speaks about. Forward: given integers a,b, take absolute values — `sq_abs` gives |a|² = a², so a²+b² = |a|²+|b|² = (a.natAbs)² + (b.natAbs)², and `exact_mod_cast` transports the equation to ℕ. Backward: cast the naturals into ℤ. This tiny lemma is the hinge that lets the geometric count talk to the arithmetic side.",
+    "mathContext": "$(\\exists a,b\\in\\mathbb{Z},\\, a^2+b^2=n) \\iff (\\exists x,y\\in\\mathbb{N},\\, n=x^2+y^2)$ via $|a|^2 = a^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.natAbs", "sq_abs", "cast lemmas"],
+    "prerequisites": ["exact_mod_cast", "push_cast", "Int.natAbs"]
+  },
+  {
+    "id": "ann-positivity-bridge",
+    "proofId": "fermat-two-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 145
+    },
+    "type": "concept",
+    "title": "The Positivity Bridge: Geometry Meets Arithmetic",
+    "content": "`r2_pos_iff_jacobiSum_pos` is the headline: 0 < r₂(n) ⇔ 0 < δ(n). Its proof is a three-step rewrite chain — r₂(n) > 0 ⇔ ∃ integer solution ⇔ ∃ natural solution ⇔ 0 < δ(n) — the last step reusing the parent's `jacobiSum_pos_iff_sq_add_sq` verbatim. This is the qualitative shadow of Jacobi's full identity r₂ = 4δ: without computing either count, the geometric lattice-point count on the circle of radius √n is positive exactly when the arithmetic divisor-character sum is. `r2_eq_zero_iff_jacobiSum_eq_zero` is the complementary vanishing form, using δ ≥ 0 to convert positivity to a genuine zero/nonzero dichotomy.",
+    "mathContext": "$0 < r_2(n) \\iff 0 < \\delta(n)$, where $\\delta(n) = \\sum_{d\\mid n}\\chi_4(d)$; both sides equal '$n$ is a sum of two squares'.",
+    "significance": "key",
+    "relatedConcepts": ["Jacobi two-square theorem", "divisor-character sum", "qualitative bridge", "representability"],
+    "prerequisites": ["parent jacobiSum API", "iff rewriting"]
+  },
+  {
+    "id": "ann-geometric-fermat",
+    "proofId": "fermat-two-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 147,
+      "endLine": 158
+    },
+    "type": "concept",
+    "title": "Fermat's Criterion, Recovered Geometrically",
+    "content": "`r2_prime_pos_iff` specializes the bridge to a prime p: 0 < r₂(p) ⇔ p ≢ 3 (mod 4). The proof feeds the positivity bridge into the parent's prime-power dichotomy `jacobiSum_prime_pow_pos_iff` at k = 1, where the condition (p % 4 = 3 → Even 1) collapses (Even 1 is false) to exactly p % 4 ≠ 3. This is Fermat's two-squares criterion — a prime is a sum of two squares iff it is not ≡ 3 (mod 4) — now phrased as the existence of a lattice point on the circle of radius √p and derived through the count rather than through a direct existence argument.",
+    "mathContext": "For a prime $p$: $0 < r_2(p) \\iff p \\not\\equiv 3 \\pmod 4$, i.e. $p = 2$ or $p \\equiv 1 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["Fermat two-squares theorem", "primes mod 4", "prime-power dichotomy"],
+    "prerequisites": ["Nat.Prime", "parent prime-power values"]
+  }
+]

--- a/src/data/proofs/fermat-two-squares-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-04-oq-01/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "fermat-two-squares-oq-04-oq-01",
+  "title": "Jacobi's Two-Square Count: the Geometric Side r₂(n) and its Positivity Bridge to δ",
+  "slug": "fermat-two-squares-oq-04-oq-01",
+  "description": "Jacobi's theorem counts representations as r₂(n) = 4 ∑_{d∣n} χ₄(d). The parent entry (fermat-two-squares-oq-04) verified the arithmetic right-hand side δ(n) = ∑_{d∣n} χ₄(d). This entry opens the geometric left-hand side: it defines the honest representation count r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n} as a Finset.card (finiteness packaged via an explicit bounding box [-n,n]²) and connects it back to the parent by matching the two sides at the level of positivity — 0 < r₂(n) ⇔ n is a sum of two squares ⇔ 0 < δ(n) — the qualitative shadow of Jacobi's identity, now established across both sides. As a corollary it recovers Fermat's criterion geometrically: for a prime p, 0 < r₂(p) ⇔ p ≢ 3 (mod 4). The full quantitative identity r₂ = 4δ (the exact count via Gaussian-integer prime splitting) remains open. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Jacobi (1834) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sum_of_two_squares_theorem",
+    "date": "1834",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "dirichlet-character",
+      "gaussian-integers",
+      "lattice-points",
+      "jacobi",
+      "representation-count",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.eq_sq_add_sq_iff",
+        "description": "n is a sum of two squares iff every prime q ≡ 3 (mod 4) divides n to an even power (reached via the parent's δ bridge)",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Int.natCast_natAbs",
+        "description": "(↑a.natAbs : ℤ) = |a|, used to convert integer representations to natural-number ones",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "sq_abs",
+        "description": "|a|² = a², bridging signed integer squares with natural-number squares",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      },
+      {
+        "theorem": "Finset.card_pos",
+        "description": "0 < s.card ↔ s.Nonempty, turning the representation count's positivity into existence of a solution",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "parentDependencies": [
+      {
+        "theorem": "FermatTwoSquaresOQ04.jacobiSum",
+        "description": "The Jacobi divisor-character sum δ(n) = ∑_{d∣n} χ₄(d), the arithmetic right-hand side reused verbatim"
+      },
+      {
+        "theorem": "FermatTwoSquaresOQ04.jacobiSum_pos_iff_sq_add_sq",
+        "description": "0 < δ(n) ⇔ ∃ x y, n = x² + y² — the parent's qualitative bridge, composed here with the geometric count"
+      },
+      {
+        "theorem": "FermatTwoSquaresOQ04.jacobiSum_nonneg",
+        "description": "0 ≤ δ(n) for all n, used for the vanishing form"
+      },
+      {
+        "theorem": "FermatTwoSquaresOQ04.jacobiSum_prime_pow_pos_iff",
+        "description": "0 < δ(p^k) ⇔ (p % 4 = 3 → Even k), specialized at k = 1 for the geometric Fermat criterion"
+      }
+    ],
+    "originalContributions": [
+      "sols / r2: the geometric representation count r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n}, defined as an honest Finset.card with finiteness packaged into the definition via an explicit σ-invariant bounding box [-n,n]² (not available in Mathlib)",
+      "mem_sols: the bounding box is automatic — every solution satisfies |a|,|b| ≤ n — so membership in sols n is exactly a²+b² = n",
+      "r2_pos_iff_exists_int / exists_int_iff_exists_nat: r₂(n) > 0 ⇔ ∃ integer (a,b), and integer representability agrees with the natural-number predicate used by the parent",
+      "r2_pos_iff_jacobiSum_pos: the positivity bridge 0 < r₂(n) ⇔ 0 < δ(n) — the first rigorous connection between the geometric (lattice-point) and arithmetic (divisor-character) sides of Jacobi's theorem in the gallery",
+      "r2_eq_zero_iff_jacobiSum_eq_zero: complementary vanishing form, no lattice point ⇔ δ(n) = 0",
+      "r2_prime_pos_iff: the geometric Fermat criterion — for a prime p, 0 < r₂(p) ⇔ p ≢ 3 (mod 4), recovered from the representation count"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FermatTwoSquaresOQ04OQ01",
+    "lineCount": 160,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/FermatTwoSquaresOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "C. G. J. Jacobi",
+      "title": "Fundamenta Nova Theoriae Functionum Ellipticarum",
+      "year": "1829",
+      "venue": "Königsberg",
+      "note": "Source of the two-square counting theorem r₂(n) = 4 ∑_{d∣n} χ₄(d) via theta-function identities"
+    },
+    {
+      "authors": "G. H. Hardy, E. M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Chapter 16 (arithmetic functions) and Chapter 20 (sums of squares), including r₂(n) and the χ₄ divisor sum"
+    },
+    {
+      "authors": "K. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig",
+      "note": "Sums of two squares and the arithmetic of Z[i] underlying the count; the factor 4 = #{±1,±i} is the unit group"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Opens the **geometric left-hand side** of Jacobi's two-square theorem `r₂(n) = 4·δ(n)`. The parent entry `fermat-two-squares-oq-04` verified the arithmetic right-hand side `δ(n) = ∑_{d∣n} χ₄(d)`. This entry defines the representation count and rigorously bridges the two sides at the level of positivity.

## What's proved (all 0-axiom, 0-sorry)

- **`r2` / `sols`** — `r₂(n) = #{(a,b) ∈ ℤ² : a²+b² = n}` as an honest `Finset.card`, with finiteness packaged into the definition via the σ-invariant bounding box `[-n,n]²`.
- **`mem_sols`** — the box constraint is automatic (`|a|,|b| ≤ n` for any solution), so membership reduces to `a²+b² = n`.
- **`r2_pos_iff_jacobiSum_pos`** (headline) — `0 < r₂(n) ⇔ 0 < δ(n)`: the first rigorous connection between the geometric (lattice-point) and arithmetic (divisor-character) sides of Jacobi in the gallery.
- **`r2_eq_zero_iff_jacobiSum_eq_zero`** — complementary vanishing form.
- **`r2_prime_pos_iff`** — geometric Fermat criterion: `0 < r₂(p) ⇔ p ≢ 3 (mod 4)` for primes.

The full quantitative identity `r₂ = 4δ` (exact count via Gaussian-integer prime splitting; the factor `4 = #{±1,±i}`) **remains open** — the divisibility `4 ∣ r₂(n)` is the natural next brick.

## Verification

- 160 lines, 6 theorems + 1 private lemma, 2 defs, **0 sorries**.
- Verified on host via `lake env lean` (Docker image currently corrupted by disk-full I/O error; host build reuses the cached Mathlib + freshly-built parent olean).
- `#print axioms` on all headline theorems: `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuine `verified` / 0-axiom.

New gallery entry: `src/data/proofs/fermat-two-squares-oq-04-oq-01/` (meta.json + annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)