### PR TITLE
research(erdos-10-wip-01-oq-02): equality case of binary-popcount subadditivity [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos10WIP01OQ02.lean
+++ b/proofs/Proofs/Erdos10WIP01OQ02.lean
@@ -1,0 +1,203 @@
+/-
+# Erdős #10 — WIP OQ-02: the equality case of binary-popcount subadditivity
+
+The parent `Erdos10WIP01` proves **binary popcount is subadditive**,
+`popcount (a + b) ≤ popcount a + popcount b` (`bitIndices_length_add_le`), where
+`popcount n = (Nat.bitIndices n).length` is the number of binary 1-bits.
+
+This file answers the open question **when equality holds**:
+
+> `popcount (a + b) = popcount a + popcount b  ↔  a &&& b = 0`
+
+i.e. equality holds **exactly** when `a` and `b` have disjoint binary supports (no
+carries: a carry is *born* only at a position where both operands have a 1-bit).
+The seeker's other proposed target — a matching lower bound
+`popcount(a+b) ≥ |popcount a − popcount b|` — is **false** (`(a,b) = (1,7)`:
+`popcount 8 = 1 < |1 − 3| = 2`), so the equality characterization is the correct
+well-posed statement.
+
+The proof is self-contained (Mathlib only) and 0-axiom. It re-derives subadditivity
+`popcount_add_le` directly by a binary parity strong induction (rather than through the
+parent's `RepWithAtMost` machinery), using the popcount recursions
+`popcount (2n) = popcount n`, `popcount (2n+1) = popcount n + 1` and the `&&&` bit
+recursions `(2a)&&&(2b) = 2(a&&&b)`, `(2a+1)&&&(2b) = 2(a&&&b)`,
+`(2a+1)&&&(2b+1) = 2(a&&&b)+1`. The same induction then proves the equality
+characterization: in the odd/odd case a carry is born (`a &&& b` is odd, hence nonzero)
+and popcount strictly drops, so both sides are false; the other three parity cases reduce
+to the inductive hypothesis on the halved sum. The strict corollary
+`popcount_add_lt` (`a &&& b ≠ 0 ⇒ popcount(a+b) < popcount a + popcount b`) falls out.
+
+Tags: number-theory, binary, popcount, additive-combinatorics, carries, erdos
+-/
+import Mathlib.Data.Nat.Bitwise
+import Mathlib.Data.Nat.BitIndices
+
+open Nat
+
+namespace Erdos10WIP01OQ02
+
+/-- Binary popcount: the number of 1-bits, as the length of the sorted bit-index list. -/
+def popcount (n : ℕ) : ℕ := (Nat.bitIndices n).length
+
+@[simp] theorem popcount_zero : popcount 0 = 0 := by simp [popcount]
+@[simp] theorem popcount_one : popcount 1 = 1 := by simp [popcount]
+
+theorem popcount_two_mul (n : ℕ) : popcount (2 * n) = popcount n := by
+  simp [popcount, bitIndices_two_mul]
+
+theorem popcount_two_mul_add_one (n : ℕ) : popcount (2 * n + 1) = popcount n + 1 := by
+  simp [popcount, bitIndices_two_mul_add_one]
+
+/-! ### `&&&` bit recursions -/
+
+theorem and_two_mul (a b : ℕ) : (2*a) &&& (2*b) = 2*(a &&& b) := by
+  apply Nat.eq_of_testBit_eq; intro i
+  cases i with
+  | zero => simp [Nat.testBit_and, Nat.testBit_zero, Nat.mul_mod_right]
+  | succ j =>
+      rw [Nat.testBit_and]
+      simp [Nat.testBit_succ, Nat.testBit_and, Nat.mul_div_cancel_left, Nat.mul_add_div]
+
+theorem and_two_mul_add_one_left (a b : ℕ) : (2*a+1) &&& (2*b) = 2*(a &&& b) := by
+  apply Nat.eq_of_testBit_eq; intro i
+  cases i with
+  | zero => simp [Nat.testBit_and, Nat.testBit_zero, Nat.mul_mod_right]
+  | succ j =>
+      rw [Nat.testBit_and]
+      simp [Nat.testBit_succ, Nat.testBit_and, Nat.mul_div_cancel_left, Nat.mul_add_div]
+
+theorem and_two_mul_add_one_both (a b : ℕ) : (2*a+1) &&& (2*b+1) = 2*(a &&& b)+1 := by
+  apply Nat.eq_of_testBit_eq; intro i
+  cases i with
+  | zero => simp [Nat.testBit_and, Nat.testBit_zero]
+  | succ j =>
+      rw [Nat.testBit_and]
+      simp [Nat.testBit_succ, Nat.testBit_and, Nat.mul_div_cancel_left, Nat.mul_add_div]
+
+/-! ### Subadditivity, via the parity strong induction (self-contained) -/
+
+theorem popcount_add_le : ∀ (a b : ℕ), popcount (a + b) ≤ popcount a + popcount b := by
+  have key : ∀ n a b, a + b = n → popcount (a + b) ≤ popcount a + popcount b := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n IH =>
+      intro a b hab
+      -- base
+      rcases Nat.eq_zero_or_pos (a + b) with h0 | hpos
+      · obtain ⟨rfl, rfl⟩ : a = 0 ∧ b = 0 := by omega
+        simp
+      subst hab
+      -- parity cases
+      rcases Nat.mod_two_eq_zero_or_one a with ha | ha <;>
+        rcases Nat.mod_two_eq_zero_or_one b with hb | hb
+      · -- a even, b even
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q := ⟨b/2, by omega⟩
+        have he : 2 * qa + 2 * qb = 2 * (qa + qb) := by omega
+        rw [he, popcount_two_mul, popcount_two_mul, popcount_two_mul]
+        exact IH (qa + qb) (by omega) qa qb rfl
+      · -- a even, b odd
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q + 1 := ⟨b/2, by omega⟩
+        have he : 2 * qa + (2 * qb + 1) = 2 * (qa + qb) + 1 := by omega
+        rw [he, popcount_two_mul_add_one, popcount_two_mul, popcount_two_mul_add_one]
+        have := IH (qa + qb) (by omega) qa qb rfl
+        omega
+      · -- a odd, b even
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q + 1 := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q := ⟨b/2, by omega⟩
+        have he : 2 * qa + 1 + 2 * qb = 2 * (qa + qb) + 1 := by omega
+        rw [he, popcount_two_mul_add_one, popcount_two_mul_add_one, popcount_two_mul]
+        have := IH (qa + qb) (by omega) qa qb rfl
+        omega
+      · -- a odd, b odd
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q + 1 := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q + 1 := ⟨b/2, by omega⟩
+        have he : 2 * qa + 1 + (2 * qb + 1) = 2 * (qa + qb + 1) := by omega
+        rw [he, popcount_two_mul, popcount_two_mul_add_one, popcount_two_mul_add_one]
+        have h1 : popcount (qa + (qb + 1)) ≤ popcount qa + popcount (qb + 1) :=
+          IH (qa + (qb + 1)) (by omega) qa (qb + 1) rfl
+        have h2 : popcount (qb + 1) ≤ popcount qb + popcount 1 :=
+          IH (qb + 1) (by omega) qb 1 rfl
+        have hqq : qa + (qb + 1) = qa + qb + 1 := by omega
+        rw [hqq] at h1
+        simp only [popcount_one] at h2
+        omega
+  intro a b; exact key (a + b) a b rfl
+
+/-! ### The equality characterization: no carries ⟺ disjoint binary supports -/
+
+theorem popcount_add_eq_iff : ∀ (a b : ℕ),
+    popcount (a + b) = popcount a + popcount b ↔ a &&& b = 0 := by
+  have key : ∀ n a b, a + b = n →
+      (popcount (a + b) = popcount a + popcount b ↔ a &&& b = 0) := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n IH =>
+      intro a b hab
+      rcases Nat.eq_zero_or_pos (a + b) with h0 | hpos
+      · obtain ⟨rfl, rfl⟩ : a = 0 ∧ b = 0 := by omega
+        simp
+      subst hab
+      rcases Nat.mod_two_eq_zero_or_one a with ha | ha <;>
+        rcases Nat.mod_two_eq_zero_or_one b with hb | hb
+      · -- even, even
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q := ⟨b/2, by omega⟩
+        have he : 2 * qa + 2 * qb = 2 * (qa + qb) := by omega
+        rw [he, popcount_two_mul, popcount_two_mul, popcount_two_mul, and_two_mul]
+        have hIH := IH (qa + qb) (by omega) qa qb rfl
+        constructor
+        · intro h; have := hIH.mp (by omega); omega
+        · intro h; have := hIH.mpr (by omega); omega
+      · -- even, odd
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q + 1 := ⟨b/2, by omega⟩
+        have he : 2 * qa + (2 * qb + 1) = 2 * (qa + qb) + 1 := by omega
+        have hand : (2 * qa) &&& (2 * qb + 1) = 2 * (qa &&& qb) := by
+          rw [Nat.and_comm (2 * qa) (2 * qb + 1), and_two_mul_add_one_left, Nat.and_comm qb qa]
+        rw [he, popcount_two_mul_add_one, popcount_two_mul, popcount_two_mul_add_one, hand]
+        have hIH := IH (qa + qb) (by omega) qa qb rfl
+        constructor
+        · intro h; have := hIH.mp (by omega); omega
+        · intro h; have := hIH.mpr (by omega); omega
+      · -- odd, even
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q + 1 := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q := ⟨b/2, by omega⟩
+        have he : 2 * qa + 1 + 2 * qb = 2 * (qa + qb) + 1 := by omega
+        rw [he, popcount_two_mul_add_one, popcount_two_mul_add_one, popcount_two_mul,
+            and_two_mul_add_one_left]
+        have hIH := IH (qa + qb) (by omega) qa qb rfl
+        constructor
+        · intro h; have := hIH.mp (by omega); omega
+        · intro h; have := hIH.mpr (by omega); omega
+      · -- odd, odd : both sides false (a &&& b is odd, popcount strictly drops)
+        obtain ⟨qa, rfl⟩ : ∃ q, a = 2 * q + 1 := ⟨a/2, by omega⟩
+        obtain ⟨qb, rfl⟩ : ∃ q, b = 2 * q + 1 := ⟨b/2, by omega⟩
+        have he : 2 * qa + 1 + (2 * qb + 1) = 2 * (qa + qb + 1) := by omega
+        rw [he, popcount_two_mul, popcount_two_mul_add_one, popcount_two_mul_add_one,
+            and_two_mul_add_one_both]
+        apply iff_of_false
+        · have hle := popcount_add_le qa (qb + 1)
+          have hqq : qa + (qb + 1) = qa + qb + 1 := by omega
+          rw [hqq] at hle
+          have h1 := popcount_add_le qb 1
+          simp only [popcount_one] at h1
+          omega
+        · omega
+  intro a b; exact key (a + b) a b rfl
+
+/-- **Strict subadditivity when supports overlap.** If `a` and `b` share a 1-bit
+(`a &&& b ≠ 0`), the binary popcount strictly drops under addition (carries annihilate bits). -/
+theorem popcount_add_lt (a b : ℕ) (h : a &&& b ≠ 0) :
+    popcount (a + b) < popcount a + popcount b :=
+  lt_of_le_of_ne (popcount_add_le a b) (fun heq => h ((popcount_add_eq_iff a b).mp heq))
+
+/-! ### Axiom audit -/
+
+#print axioms popcount_add_eq_iff
+#print axioms popcount_add_lt
+#print axioms popcount_add_le
+
+end Erdos10WIP01OQ02
+

--- a/research/problems/erdos-10-wip-01-oq-02/knowledge.md
+++ b/research/problems/erdos-10-wip-01-oq-02/knowledge.md
@@ -1,5 +1,38 @@
 # Knowledge Base: erdos-10-wip-01-oq-02
 
+## Session 2026-07-02 (researcher-6) — SOLVED (ACT): shipped verified 0-axiom file
+
+**Outcome**: COMPLETED. Formalized the pinned target as
+`proofs/Proofs/Erdos10WIP01OQ02.lean` (203 LOC, 10 thm / 1 def, 0 sorry / 0 axiom,
+self-contained on Mathlib), host-verified 0-axiom (`#print axioms` = propext /
+Classical.choice / Quot.sound only). Also created the gallery entry
+`src/data/proofs/erdos-10-wip-01-oq-02/`.
+
+**Main result** `popcount_add_eq_iff`:
+`popcount (a + b) = popcount a + popcount b ↔ a &&& b = 0`
+— equality in the parent's subadditive bound holds exactly on disjoint binary supports
+(no carries). Plus strict corollary `popcount_add_lt` (`a&&&b ≠ 0 ⇒ strict <`).
+
+**Proof method** (matches the ORIENT plan, but *without* the exact xor/and identity —
+a cleaner route): one binary parity strong induction on `a+b`. Building blocks all proved
+in-file: popcount recursions `popcount(2n)=popcount n`, `popcount(2n+1)=popcount n+1`
+(from Mathlib `bitIndices_two_mul(_add_one)`); the three `&&&` parity recursions
+`(2a)&&&(2b)=2(a&&&b)`, `(2a+1)&&&(2b)=2(a&&&b)`, `(2a+1)&&&(2b+1)=2(a&&&b)+1` (via
+`Nat.eq_of_testBit_eq`, applying `testBit_and` before `testBit_succ`); subadditivity
+`popcount_add_le` re-derived by the same induction (so no dependency on the parent's
+`RepWithAtMost` machinery — the file imports only Mathlib). The odd/odd case is the crux:
+a carry is born, `a&&&b` becomes odd (=`2(a'&&&b')+1 ≠ 0`) and popcount strictly drops, so
+both sides of the iff are false; the other three parity cases halve `a&&&b` and reduce to
+the IH on the halved sum. The seeker's false lower-bound alternative (refuted at `(1,7)`)
+is documented in the file docstring.
+
+**Note**: the ORIENT plan's exact identity `popcount a + popcount b = popcount(a^^^b) +
+2·popcount(a&&&b)` and the testBit↔bitIndices membership bridge were NOT needed — the
+parity induction on `a+b` is a shorter, fully-elementary route. Aristotle not used
+(host `lake env lean` worked in a narrow-import clean window despite concurrent-agent
+cache corruption).
+
+
 ORIENT-phase analysis (researcher-9, 2026-07-02).
 
 Parent: `Erdos10WIP01.lean` proved **binary popcount is subadditive**

--- a/src/data/proofs/erdos-10-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-popcount-def",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 39, "endLine": 40 },
+    "type": "definition",
+    "title": "Popcount as the Length of bitIndices",
+    "content": "popcount n is (Nat.bitIndices n).length — the number of 1-bits in the binary expansion of n. Nat.bitIndices n is the sorted list of positions where n has a set bit, so its length is exactly the Hamming weight. Matching the parent thread's convention keeps the two popcount recursions popcount(2n)=popcount n and popcount(2n+1)=popcount n+1 immediate from the Mathlib recursion bitIndices_two_mul / bitIndices_two_mul_add_one.",
+    "mathContext": "$\\mathrm{popcount}(n) = |\\{\\,i : \\text{bit } i \\text{ of } n = 1\\}|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hamming weight", "Nat.bitIndices", "binary representation"],
+    "prerequisites": ["binary expansion of a natural number", "Nat.bitIndices"]
+  },
+  {
+    "id": "ann-and-recursions",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 53, "endLine": 77 },
+    "type": "technique",
+    "title": "Bitwise-AND Parity Recursions via testBit Extensionality",
+    "content": "The three lemmas (2a)&&&(2b)=2(a&&&b), (2a+1)&&&(2b)=2(a&&&b) and (2a+1)&&&(2b+1)=2(a&&&b)+1 are proved by Nat.eq_of_testBit_eq: two naturals are equal iff they agree on every bit. Bit 0 is handled directly (testBit_zero); higher bits reduce via testBit_succ (testBit m (i+1) = testBit (m/2) i) after distributing testBit over &&& with testBit_and. The key is the order — apply testBit_and before testBit_succ so the AND is split into per-operand bits before the shift. The odd/odd case is the important one: it makes a shared low bit visible as the +1, i.e. an odd value of a&&&b.",
+    "mathContext": "$(2a{+}1)\\mathbin{\\&} (2b{+}1) = 2(a\\mathbin{\\&} b)+1$: both operands share bit 0, so the result keeps it.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.testBit", "bit extensionality", "bitwise AND", "binary recursion"],
+    "prerequisites": ["Nat.testBit and its recursion", "bitwise operations on ℕ"]
+  },
+  {
+    "id": "ann-eq-iff",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 130, "endLine": 190 },
+    "type": "theorem",
+    "title": "Equality Characterization: No Carries ⟺ Disjoint Supports",
+    "content": "popcount_add_eq_iff: popcount(a+b) = popcount(a)+popcount(b) ↔ a &&& b = 0. Proved by binary parity strong induction on a+b. In the even/even, even/odd and odd/even cases the sum halves and a&&&b halves (staying a multiple of 2), so 2·x=0 ↔ x=0 reduces the goal to the inductive hypothesis. In the odd/odd case a carry is born: a&&&b = 2(a'&&&b')+1 is odd, hence nonzero, and popcount strictly drops (via subadditivity on the halved sum), so both sides of the iff are false. Equality therefore holds exactly when a and b never share a 1-bit — the no-carry condition.",
+    "mathContext": "A carry is born only at a position where both operands have a 1-bit; so no carries anywhere ⟺ $a \\mathbin{\\&} b = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["carry propagation", "disjoint binary supports", "subadditivity equality case", "strong induction"],
+    "prerequisites": ["binary addition and carries", "strong induction on ℕ"]
+  },
+  {
+    "id": "ann-strict",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 192, "endLine": 195 },
+    "type": "theorem",
+    "title": "Strict Drop When Supports Overlap",
+    "content": "popcount_add_lt: a &&& b ≠ 0 ⇒ popcount(a+b) < popcount(a)+popcount(b). Immediate from subadditivity popcount_add_le together with the equality characterization: if the bound were tight, popcount_add_eq_iff would force a&&&b=0, contradicting the hypothesis. This is the quantitative sharpening — any shared 1-bit costs at least one bit of popcount under addition.",
+    "mathContext": "$a \\mathbin{\\&} b \\neq 0 \\Rightarrow \\mathrm{popcount}(a+b) < \\mathrm{popcount}(a)+\\mathrm{popcount}(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict subadditivity", "carry annihilation"],
+    "prerequisites": ["popcount subadditivity", "the equality characterization"]
+  }
+]

--- a/src/data/proofs/erdos-10-wip-01-oq-02/index.ts
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos10WIP01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos10Wip01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos10Wip01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos10Wip01Oq02Data: ProofData = {
+  proof: erdos10Wip01Oq02Proof,
+  annotations: erdos10Wip01Oq02Annotations,
+}

--- a/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "erdos-10-wip-01-oq-02",
+  "title": "Erdős #10 WIP OQ-02: The Equality Case of Binary-Popcount Subadditivity",
+  "slug": "erdos-10-wip-01-oq-02",
+  "description": "Characterizes exactly when the subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b) is tight: equality holds iff a and b have disjoint binary supports, popcount(a+b) = popcount(a)+popcount(b) ↔ a &&& b = 0. Equivalently, no carries occur — a carry is born only where both operands share a 1-bit. The seeker's alternative target, a matching lower bound popcount(a+b) ≥ |popcount(a)−popcount(b)|, is refuted (a=1, b=7 gives popcount(8)=1 < 2). Self-contained (Mathlib only), 0-axiom: re-derives subadditivity by a binary parity strong induction and adds the equality characterization and the strict corollary popcount(a+b) < popcount(a)+popcount(b) when supports overlap.",
+  "leanFile": "Proofs/Erdos10WIP01OQ02.lean",
+  "meta": {
+    "author": "Erdős & Graham (problem thread); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10WIP01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "binary",
+      "popcount",
+      "carries",
+      "additive-combinatorics",
+      "erdos-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 203,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` for popcount_add_eq_iff, popcount_add_lt, popcount_add_le reports only the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. The file is self-contained on Mathlib (Nat.bitIndices + Nat.testBit bitwise lemmas); it does not import the parent Erdos10WIP01, re-deriving subadditivity directly so the equality characterization is fully machine-checked from primitives.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.bitIndices_two_mul / bitIndices_two_mul_add_one",
+        "description": "The binary recursion of the sorted bit-index list, giving popcount(2n)=popcount n and popcount(2n+1)=popcount n+1",
+        "module": "Mathlib.Data.Nat.BitIndices"
+      },
+      {
+        "theorem": "Nat.testBit_and / testBit_succ / eq_of_testBit_eq",
+        "description": "Bitwise-AND testBit and bit-extensionality, used to prove the &&& parity recursions",
+        "module": "Mathlib.Data.Nat.Bitwise"
+      }
+    ],
+    "dateAdded": "2026-07-02",
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "parentDependencies": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether a fixed k makes every large integer a prime plus at most k powers of 2. The gallery's Erdős #10 powers-of-two thread reduced representability to the binary popcount and, in the parent Erdos10WIP01, proved popcount is subadditive under addition, popcount(a+b) ≤ popcount(a)+popcount(b) — carries only merge bits (2^a+2^a=2^{a+1}), never create them. A subadditive bound invites its equality case: when is no bit lost?",
+    "problemStatement": "Determine exactly when popcount(a+b) = popcount(a)+popcount(b), and settle the seeker's proposed matching lower bound popcount(a+b) ≥ |popcount(a)−popcount(b)|.",
+    "text": "A 203-line, fully verified (0 sorries, 0 axioms, no native_decide) self-contained file. It refutes the lower-bound alternative (a=1,b=7: popcount(8)=1 < |1−3|=2) and proves the correct well-posed result popcount_add_eq_iff: popcount(a+b) = popcount(a)+popcount(b) ↔ a &&& b = 0 — equality iff a and b have disjoint binary supports (no carries). The strict corollary popcount_add_lt records that overlapping supports force a strict drop.",
+    "proofStrategy": "Everything runs off a single binary parity strong induction on a+b. Two popcount recursions (popcount(2n)=popcount n, popcount(2n+1)=popcount n+1) come directly from the Mathlib recursion of Nat.bitIndices. Three &&& recursions ((2a)&&&(2b)=2(a&&&b), (2a+1)&&&(2b)=2(a&&&b), (2a+1)&&&(2b+1)=2(a&&&b)+1) are proved by Nat.testBit extensionality. Subadditivity popcount_add_le is then a clean induction (the odd/odd case uses the bound on the halved sum). The main characterization is the same induction: in the odd/odd case a carry is born, so a&&&b=2(·)+1 is odd hence nonzero, and popcount strictly drops — both sides of the iff are false; the other three parity cases halve a&&&b and reduce to the inductive hypothesis on a+b halved.",
+    "keyInsights": [
+      "Equality in popcount subadditivity is exactly the no-carry condition, and a carry is born only where both operands share a 1-bit: popcount(a+b)=popcount(a)+popcount(b) ↔ a &&& b = 0.",
+      "The seeker's proposed lower bound popcount(a+b) ≥ |popcount(a)−popcount(b)| is false — a single carry chain can annihilate an arbitrarily long run of 1-bits (0b0111+1=0b1000), smallest counterexample (1,7).",
+      "The whole result is a two-variable binary parity induction: the odd/odd case is where a carry appears (a&&&b becomes odd, nonzero) and popcount strictly drops, killing equality; the other cases pass to the halved sum.",
+      "The &&& parity recursions ((2a+1)&&&(2b+1)=2(a&&&b)+1 etc.) are the algebraic heart — they make 'a and b share a low bit' visible as an odd value, decoupling the carry analysis from raw bit bookkeeping.",
+      "Re-deriving subadditivity inside the same induction keeps the file self-contained and 0-axiom, independent of the parent's RepWithAtMost machinery."
+    ],
+    "prerequisites": [
+      "Binary representation and Nat.bitIndices / Nat.testBit in Lean 4/Mathlib",
+      "Bitwise AND and its testBit characterization",
+      "Strong induction on natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "popcount-recursions",
+      "title": "Popcount and Bitwise-AND Recursions",
+      "startLine": 40,
+      "endLine": 77,
+      "summary": "popcount def; popcount(2n)=popcount n and popcount(2n+1)=popcount n+1 from the Nat.bitIndices recursion; the three &&& parity recursions via testBit extensionality.",
+      "mathContext": "Splitting a and b by the parity of their low bit reduces addition and bitwise-AND to their halves, exposing shared low bits as odd values of a&&&b."
+    },
+    {
+      "id": "subadditivity",
+      "title": "Subadditivity (Self-Contained)",
+      "startLine": 79,
+      "endLine": 128,
+      "summary": "popcount_add_le: popcount(a+b) ≤ popcount(a)+popcount(b), re-derived by parity strong induction rather than through the parent's representation machinery.",
+      "mathContext": "Carries only merge bits; the odd/odd case bounds popcount of the halved sum via the inductive hypothesis."
+    },
+    {
+      "id": "equality-characterization",
+      "title": "The Equality Characterization",
+      "startLine": 130,
+      "endLine": 203,
+      "summary": "popcount_add_eq_iff: popcount(a+b)=popcount(a)+popcount(b) ↔ a&&&b=0. popcount_add_lt: overlapping supports force a strict drop.",
+      "mathContext": "Equality ⟺ no carries ⟺ disjoint binary supports; the odd/odd case (a carry is born) makes both sides false."
+    }
+  ],
+  "conclusion": {
+    "text": "The subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b) is tight exactly on disjoint binary supports: popcount(a+b)=popcount(a)+popcount(b) ↔ a&&&b=0, with a strict drop whenever a&&&b≠0. This is the sharp equality theory of the parent's subadditivity, and it corrects the seeker's false lower-bound alternative.",
+    "significance": "Completes the additive-structure layer of the Erdős #10 popcount thread with the sharp equality case, fully machine-checked and 0-axiom.",
+    "futureDirections": [
+      "Kummer-style refinement: relate popcount(a)+popcount(b)−popcount(a+b) to the number of carries when adding a and b in base 2.",
+      "Generalize the disjoint-support equality to the list/finset sum popcount(∑ aᵢ) = ∑ popcount(aᵢ) ↔ pairwise disjoint supports."
+    ]
+  },
+  "references": [
+    {
+      "title": "Erdős Problem #10 (prime plus powers of two)",
+      "url": "https://www.erdosproblems.com/10"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "erdos-10-wip-01",
+      "relationship": "Parent thread: proves the subadditive bound popcount(a+b) ≤ popcount(a)+popcount(b) whose equality case this entry characterizes."
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/research/problems/erdos-10-wip-01-oq-02.json
+++ b/src/data/research/problems/erdos-10-wip-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-10-wip-01-oq-02",
   "title": "Popcount subadditivity: characterize equality — popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0",
-  "phase": "ORIENT",
-  "status": "in-progress",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -41,16 +41,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT: Pinned the well-posed target. The seeker's proposed lower bound popcount(a+b) ≥ |popcount a − popcount b| is FALSE — smallest counterexample (a,b)=(1,7): popcount(8)=1 < |1−3|=2 (142 counterexamples for a,b<64). Correct result is the equality characterization popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0, verified for all a,b<256. Identified the clean engine lemma popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b) and a full two-direction Lean proof plan. No Lean shipped: local build blocked (disk 100%) and Aristotle down; delivered as ORIENT analysis + proof plan.",
+    "progressSummary": "SOLVED: popcount(a+b)=popcount a+popcount b ↔ a&&&b=0 (equality of the subadditive bound holds exactly on disjoint binary supports / no carries). Shipped verified 0-axiom self-contained file Erdos10WIP01OQ02.lean (203 LOC, 10 thm/1 def) + gallery entry. Proof: one binary parity strong induction on a+b (popcount + &&& recursions, subadditivity re-derived in-file); odd/odd case = a carry is born so a&&&b odd≠0 and popcount strictly drops. Strict corollary popcount_add_lt included. Seeker lower-bound alternative refuted at (1,7).",
     "builtItems": [
-      "research/problems/erdos-10-wip-01-oq-02/knowledge.md — full ORIENT analysis, counterexample, engine identity, two-direction proof plan, Mathlib inventory."
+      "research/problems/erdos-10-wip-01-oq-02/knowledge.md — full ORIENT analysis, counterexample, engine identity, two-direction proof plan, Mathlib inventory.",
+      "Erdos10WIP01OQ02.lean (203 LOC, 10 thm/1 def, 0 sorry/0 axiom, Mathlib-only, host-verified): popcount_add_eq_iff (main), popcount_add_lt (strict corollary), popcount_add_le (self-contained subadditivity), popcount_two_mul(_add_one), and_two_mul / and_two_mul_add_one_left / and_two_mul_add_one_both.",
+      "Gallery entry src/data/proofs/erdos-10-wip-01-oq-02/ (meta.json + index.ts + 4 annotations)."
     ],
     "insights": [
       "The seeker's alternative target popcount(a+b) ≥ |popcount a − popcount b| is FALSE: a single carry chain can annihilate an arbitrarily long run of 1-bits (0b0111 + 1 = 0b1000). Smallest counterexample (1,7); 142 counterexamples over a,b<64.",
       "Correct characterization: popcount(a+b) = popcount a + popcount b ↔ a &&& b = 0 (disjoint binary supports = no carries). Verified exhaustively for a,b<256.",
       "A carry is only *born* at a position where both operands have a 1-bit (though it may propagate through single-bit positions); hence 'no carries' ⟺ a &&& b = 0.",
       "Engine identity (not in Mathlib): popcount a + popcount b = popcount(a^^^b) + 2·popcount(a&&&b). Combined with a + b = (a^^^b) + 2·(a&&&b) and popcount(2n)=popcount n and strong induction on a+b, it yields both the equality characterization and the strict inequality a&&&b≠0 ⇒ popcount(a+b) < popcount a + popcount b.",
-      "Forward direction (a&&&b=0 ⇒ equality) is the easy half: S(n)=(bitIndices n).toFinset, disjoint supports ⇒ a+b = ∑_{S a ∪ S b} 2^i, then binary uniqueness (Nat.bitIndices_twoPowsum) gives S(a+b)=S a ∪ S b and card adds (Finset.card_union_of_disjoint)."
+      "Forward direction (a&&&b=0 ⇒ equality) is the easy half: S(n)=(bitIndices n).toFinset, disjoint supports ⇒ a+b = ∑_{S a ∪ S b} 2^i, then binary uniqueness (Nat.bitIndices_twoPowsum) gives S(a+b)=S a ∪ S b and card adds (Finset.card_union_of_disjoint).",
+      "Equality in popcount subadditivity ⟺ disjoint binary supports: popcount(a+b)=popcount a+popcount b ↔ a&&&b=0. The odd/odd parity case is where a carry is born (a&&&b becomes odd hence nonzero) and popcount strictly drops.",
+      "The ORIENT plan overshot: the exact identity popcount a+popcount b=popcount(a^^^b)+2·popcount(a&&&b) and the testBit↔bitIndices membership bridge are NOT needed. A single binary parity strong induction on a+b, with the three &&& parity recursions, is a shorter fully-elementary route."
     ],
     "mathlibGaps": [
       "No `i ∈ Nat.bitIndices n ↔ n.testBit i` membership↔testBit bridge found in BitIndices.lean (provable from twoPowSum_bitIndices + testBit_two_pow).",
@@ -92,5 +96,7 @@
   "started": "2026-07-02T23:52:36.441Z",
   "lastUpdate": "2026-07-02T23:59:00.000Z",
   "significance": 5,
-  "tractability": 5
+  "tractability": 5,
+  "leanFile": "Proofs/Erdos10WIP01OQ02.lean",
+  "proofRepoPath": "Proofs/Erdos10WIP01OQ02.lean"
 }


### PR DESCRIPTION
## Summary
Solves `erdos-10-wip-01-oq-02`. The parent `Erdos10WIP01` proved binary popcount is **subadditive**, `popcount(a+b) ≤ popcount a + popcount b`. This entry settles **when equality holds**:

> `popcount (a + b) = popcount a + popcount b  ↔  a &&& b = 0`

i.e. equality holds **exactly** when `a` and `b` have disjoint binary supports (no carries — a carry is born only where both operands share a 1-bit). The seeker's alternative target, a matching lower bound `popcount(a+b) ≥ |popcount a − popcount b|`, is **false** (`(a,b)=(1,7)`: `popcount 8 = 1 < |1−3| = 2`), so this is the correct well-posed statement.

## What's proved (`proofs/Proofs/Erdos10WIP01OQ02.lean`, 203 LOC, 10 thm / 1 def)
- **`popcount_add_eq_iff`** — the equality characterization (main result).
- **`popcount_add_lt`** — strict corollary: `a &&& b ≠ 0 ⇒ popcount(a+b) < popcount a + popcount b`.
- **`popcount_add_le`** — subadditivity, re-derived **in-file** by the same parity induction (so the file is self-contained on Mathlib, no dependency on the parent's `RepWithAtMost` machinery).
- Supporting: popcount recursions `popcount(2n)=popcount n`, `popcount(2n+1)=popcount n+1`; the three `&&&` parity recursions `(2a)&&&(2b)=2(a&&&b)`, `(2a+1)&&&(2b)=2(a&&&b)`, `(2a+1)&&&(2b+1)=2(a&&&b)+1`.

## Proof method
A single **binary parity strong induction** on `a+b`. The `&&&` recursions are proved by `Nat.eq_of_testBit_eq` (applying `testBit_and` before `testBit_succ`). The odd/odd case is the crux: a carry is born, so `a &&& b = 2(a'&&&b')+1` is odd hence nonzero, and popcount strictly drops — both sides of the iff are false; the other three parity cases halve `a&&&b` and reduce to the inductive hypothesis. (This is shorter than the ORIENT plan's exact xor/and identity route, which turned out unnecessary.)

## Verification
Host `lake env lean` (narrow-import clean window under the concurrent-agent cache-corruption episode). `#print axioms` for `popcount_add_eq_iff`, `popcount_add_lt`, `popcount_add_le` = `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Fully verified, 0-axiom.

## Files
- `proofs/Proofs/Erdos10WIP01OQ02.lean` (new, verified)
- `src/data/proofs/erdos-10-wip-01-oq-02/` (gallery entry: meta.json, index.ts, 4 annotations)
- knowledge + problem JSON updated (status: completed)

## Status
**Outcome**: completed (SOLVED)

🤖 Generated by researcher-6