### PR TITLE
Research: puiseux-theorem-wip-01 - binomial root as Polynomial.IsRoot [VERIFIED]

### DIFF
--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -251,6 +251,28 @@ theorem puiseux_binomial_ramification (hK : IsAlgClosed K) (n : ℕ+) (c : K) (h
     rw [hexp, ha]
   · rw [HahnSeries.orderTop_single ha0]
 
+/-- **Binomial polynomial root** — the binomial Puiseux root expressed as an honest
+`Polynomial.IsRoot`.
+
+`puiseux_binomial_root` establishes the *power equation* `yⁿ = single m c`. This corollary
+restates it in the language the definition of *algebraically closed* actually uses: the
+Puiseux series `y` is a genuine root of the polynomial
+`Xⁿ - C (single m c) ∈ (HahnSeries ℚ K)[X]`. Concretely, `eval y (Xⁿ - C d) = yⁿ - d = 0`.
+
+This is the polynomial-level form of a single Newton-polygon edge: the binomial
+`Xⁿ - C(single m c)` splits off a Puiseux root. It is the honest bridge from the
+Hahn-series computation to the algebraic-closure statement (which is about roots of
+polynomials, not power equations). The full Newton–Puiseux theorem for arbitrary
+polynomials — assembling such edge roots term by term with a char-0 convergence
+argument — remains unformalized here; only this binomial edge is proved. -/
+theorem puiseux_binomial_isRoot (hK : IsAlgClosed K) (n : ℕ+) (m : ℚ) (c : K) :
+    ∃ y : HahnSeries ℚ K, IsPuiseuxSeries y ∧
+      (Polynomial.X ^ (n : ℕ) - Polynomial.C (HahnSeries.single m c)).IsRoot y := by
+  obtain ⟨y, hpu, hy⟩ := puiseux_binomial_root K hK n m c
+  refine ⟨y, hpu, ?_⟩
+  rw [Polynomial.IsRoot.def, Polynomial.eval_sub, Polynomial.eval_pow,
+      Polynomial.eval_X, Polynomial.eval_C, hy, sub_self]
+
 end MainTheorem
 
 /-! ═══════════════════════════════════════════════════════════════════════════════

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -49,14 +49,15 @@
       "Genuine ramification witnessed (puiseux_binomial_ramification): the root of Yⁿ = c·x has orderTop exactly 1/n, so for n≥2 it lies strictly outside the Laurent field",
       "isPuiseux_single helper: every single-term Hahn series is a Puiseux series",
       "Galois group Gal(Puiseux/Laurent) ≅ Ẑ described structurally",
-      "Characteristic zero requirement demonstrated via Artin-Schreier counterexample"
+      "Characteristic zero requirement demonstrated via Artin-Schreier counterexample",
+      "Binomial root lifted to an honest Polynomial.IsRoot (puiseux_binomial_isRoot): the Puiseux series c^(1/n)·x^(m/n) is a genuine root of the polynomial Xⁿ - C(single m c) over the Hahn/Puiseux field, the polynomial-level form of a single Newton-polygon edge"
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 581,
+    "lineCount": 603,
     "assumptions": "No axiom declarations, no sorries, no native_decide (all theorems depend only on propext/Classical.choice/Quot.sound). The file no longer contains any vacuous True-stub theorems: the last two placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were replaced by genuine, fully computed Hahn-series theorems puiseux_binomial_root and puiseux_binomial_ramification, which establish the binomial base case of Puiseux's theorem (every binomial Yⁿ = c·xᵐ has a Puiseux root of ramification n over an algebraically closed field). This is a rigorously verified FRAGMENT: the full Newton–Puiseux theorem for arbitrary polynomials over the Puiseux field (assembling binomial roots term by term, with its char-0 convergence argument) is not formalized here — the required infrastructure is absent from Mathlib. Badge remains 'wip' to reflect that the headline algebraic-closure theorem is not fully proven.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 2
   },
   "overview": {
@@ -171,9 +172,9 @@
       "Polynomial"
     ],
     "namespace": "PuiseuxTheorem",
-    "lineCount": 581,
+    "lineCount": 603,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 2,
     "path": "Proofs/PuiseuxTheorem.lean",
     "sorries": 0

--- a/src/data/research/problems/puiseux-theorem-wip-01.json
+++ b/src/data/research/problems/puiseux-theorem-wip-01.json
@@ -1,18 +1,33 @@
 {
   "slug": "puiseux-theorem-wip-01",
   "title": "Complete Puiseux's Theorem (WIP — 5 True-stubs)",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{Replace True-stubs: puiseux\\_theorem, puiseux\\_is\\_algebraic\\_closure, newton\\_puiseux\\_terminates, square\\_root\\_puiseux, cusp\\_parameterization}",
     "plain": "PuiseuxTheorem.lean (Wiedijk #41) has badge=wip because 5 main theorems are implemented as True-stubs instead of actual proofs. Replace them with real Lean 4 proofs using HahnSeries and IsAlgClosed.",
-    "whyMatters": ["Wiedijk #41 foundational to algebraic geometry", "Constructive algebraic closure via Newton polygon algorithm", "Bridge between algebra (Galois theory), analysis (convergent series), geometry (curve singularities)"]
+    "whyMatters": [
+      "Wiedijk #41 foundational to algebraic geometry",
+      "Constructive algebraic closure via Newton polygon algorithm",
+      "Bridge between algebra (Galois theory), analysis (convergent series), geometry (curve singularities)"
+    ]
   },
   "knownResults": {
-    "proven": ["IsPuiseuxSeries predicate", "leadingExponentFromSlope for Newton polygon", "PuiseuxField and LaurentField as HahnSeries", "Galois group Gal(Puiseux/Laurent) ≅ Ẑ described structurally"],
-    "open": ["puiseux_theorem (algebraic closure)", "puiseux_is_algebraic_closure", "newton_puiseux_terminates", "square_root_puiseux", "cusp_parameterization"],
+    "proven": [
+      "IsPuiseuxSeries predicate",
+      "leadingExponentFromSlope for Newton polygon",
+      "PuiseuxField and LaurentField as HahnSeries",
+      "Galois group Gal(Puiseux/Laurent) ≅ Ẑ described structurally"
+    ],
+    "open": [
+      "puiseux_theorem (algebraic closure)",
+      "puiseux_is_algebraic_closure",
+      "newton_puiseux_terminates",
+      "square_root_puiseux",
+      "cusp_parameterization"
+    ],
     "goal": "Replace all 5 True-stubs with actual Lean proofs or sorry for Aristotle"
   },
   "currentState": {
@@ -29,11 +44,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE (verified fragment). All 5 original True-stubs are gone: square_root_puiseux/cusp_parameterization are computed Hahn-series proofs, newton_puiseux_terminates is now prose, and the two main placeholders (puiseux_theorem, puiseux_is_algebraic_closure) were already replaced on main by puiseux_binomial_root + puiseux_binomial_ramification. This session added puiseux_binomial_isRoot lifting the binomial power-equation yⁿ=single m c to a genuine Polynomial.IsRoot of Xⁿ-C(single m c) — the polynomial-level single Newton-edge. File is 0-sorry/0-axiom (only propext/Classical.choice/Quot.sound). Full Newton–Puiseux (arbitrary polynomials + char-0 convergence) is NOT in Mathlib and remains unformalized; it is the genuine open remainder.",
+    "builtItems": [
+      "puiseux_binomial_isRoot in proofs/Proofs/PuiseuxTheorem.lean (binomial Puiseux root as Polynomial.IsRoot of Xⁿ-C(single m c); verified, 0 substantive axioms)"
+    ],
+    "insights": [
+      "The binomial/single-Newton-edge case is the entire algebraic content available without convergence machinery: y=single(m/n)a with aⁿ=c gives yⁿ=single m c via HahnSeries.single_pow; IsAlgClosed only supplies the n-th root a of c (char 0 NOT needed for this fragment).",
+      "puiseux_binomial_isRoot bridges the Hahn-series power equation to Polynomial.IsRoot: eval y (Xⁿ - C d) = yⁿ - d = 0 by eval_sub/eval_pow/eval_X/eval_C — the faithful 'algebraically closed' framing (roots of polynomials).",
+      "Mathlib has NO Puiseux content and LaurentSeries.lean does not prove algebraic closure, so the full theorem cannot be discharged from Mathlib; honest status is a verified FRAGMENT, not the complete theorem.",
+      "IsPuiseuxSeries(single m a) holds with ramification m.den via Rat.num_div_den (isPuiseux_single); PNat coercion ((⟨d,h⟩:ℕ+):ℚ) is defeq (d:ℚ) so use `exact (Rat.num_div_den _).symm` rather than `rw` (rw fails on the anonymous-constructor proof term)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Full Newton–Puiseux for arbitrary polynomials requires: (1) Puiseux subfield as a Subfield of HahnSeries ℚ K, (2) Newton polygon / lower-hull construction, (3) term-by-term iteration with char-0 convergence. None are in Mathlib — large (>1000L) foundational build; leave as documented open remainder."
+    ],
     "markdown": "# Knowledge Base: puiseux-theorem-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for `puiseux-theorem-wip-01` (Complete Puiseux's Theorem, Wiedijk #41).

**Key finding:** the problem's 5 original `True`-stubs were **already eliminated on main** — `square_root_puiseux`/`cusp_parameterization` are computed Hahn-series proofs, `newton_puiseux_terminates` is prose, and the two main placeholders were replaced by `puiseux_binomial_root` + `puiseux_binomial_ramification`. An independent re-derivation confirmed the merged binomial proof is correct. So no vacuous stubs remain.

## Progress
- **`puiseux_binomial_isRoot`** (new, verified, 0 substantive axioms): lifts the binomial *power equation* `yⁿ = single m c` to a genuine `Polynomial.IsRoot` — the Puiseux series `c^(1/n)·x^(m/n)` is an honest root of `Xⁿ - C(single m c) ∈ (HahnSeries ℚ K)[X]`. This is the polynomial-level form of a single Newton-polygon edge and the faithful "algebraically closed" framing (roots of polynomials, not power equations).
- `meta.json`: theoremCount 10→11, lineCount refreshed, contribution added.
- Problem knowledge updated with fragment status and the concrete open remainder.

## Verification
Full file compiled via host `lake env lean` against the built Mathlib (v4.26.0) toolchain: 0 errors, 0 sorries. `#print axioms puiseux_binomial_isRoot` → `[propext, Classical.choice, Quot.sound]` (no substantive axioms).

## Findings
- Mathlib has **no** Puiseux content and `LaurentSeries.lean` does not prove algebraic closure — so the full theorem cannot be discharged from Mathlib. The file is honestly a **verified fragment** (the binomial / single Newton-edge base case), not the complete Newton–Puiseux theorem.
- The full theorem (arbitrary polynomials over the Puiseux field + char-0 convergence) needs substantial new infrastructure (Puiseux subfield, Newton polygon, term-by-term iteration) — >1000 lines, none in Mathlib. Documented as the open remainder.

## Status
**Outcome**: completed (verified fragment; genuine open remainder documented — not overclaimed)
**Next Steps**: full Newton–Puiseux iteration is a large foundational build, left for future work.

🤖 Generated by researcher-5