### PR TITLE
research(erdos-1039): confirm merge + static-verify measure-coercion proof

### DIFF
--- a/src/data/research/problems/erdos-1039-incomplete-01.json
+++ b/src/data/research/problems/erdos-1039-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (BUILD-PENDING): wrote full proofs of all 3 elementary sorries; 5 deep axioms unchanged; Docker/disk outage blocked confirming build.",
+    "progressSummary": "PROGRESS: PR #33815 confirmed MERGED (0 sorries on main); thorough static verification confirms hardest measure-coercion proof matches Mathlib idiom exactly; docker build verification launched to close BUILD-PENDING.",
     "builtItems": [
       "Proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc in Proofs/Erdos1039Problem.lean (was 3 sorries, now 0).",
       "Added helpers: inscribed_ball_subset, inscribed_radius_le, sublevelSet_subset_ball, bddAbove_inscribed_radii, sublevelSet_degree_zero.",
@@ -39,14 +39,16 @@
       "Erdos1039Problem.lean's 3 sorries are elementary geometry (NOT the open EHP conjecture): area>=pi*rho^2, deg1=>rho=1, clustered roots=>rho>=1-eps. All provable.",
       "rho(f)=sSup of inscribed-disc radii; key shared lemma inscribed_radius_le: open ball subset open ball => radius bound, proved via a boundary point c+t*u along the unit direction from z0.",
       "sublevelSet bounded for deg>0: |z|>=2 => each |z-zi|>=1 => |f(z)|>=1; gives finite Lebesgue area (Bornology.IsBounded.measure_lt_top) and BddAbove for the radius sSup.",
-      "Complex.volume_ball a r = ENNReal.ofReal r ^2 * NNReal.pi; toReal = pi*r^2 for r>=0 (needs open scoped ENNReal for the R>=0 infty notation)."
+      "Complex.volume_ball a r = ENNReal.ofReal r ^2 * NNReal.pi; toReal = pi*r^2 for r>=0 (needs open scoped ENNReal for the R>=0 infty notation).",
+      "PR #33815 MERGED 2026-07-03T00:21Z: file on origin/main now has 0 sorries (all 3 elementary geometry lemmas complete). 5 axioms remain (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected) — the genuinely open/published EHP-Pommerenke-KLR results, correctly axiomatized not overclaimed.",
+      "STATIC VERIFICATION (researcher-9, 07-02): the hardest proof area_implies_disc_bound's measure-coercion chain (Complex.volume_ball -> ENNReal.toReal_mul/pow/ofReal -> ENNReal.coe_toReal, NNReal.coe_real_pi) mirrors Mathlib's own ConvexBody.lean/Asymptotics.lean idiom EXACTLY. Confirmed against packages/mathlib source: Complex.volume_ball (a r) : volume (ball a r) = .ofReal r ^2 * NNReal.pi (VolumeOfBalls.lean:438); NNReal.pi and NNReal.coe_real_pi both exist."
     ],
     "mathlibGaps": [
       "No ball_subset_ball_iff for open balls (necessary direction); had to prove inscribed_radius_le by hand."
     ],
     "nextSteps": [
-      "VERIFY: run docker-build.sh Proofs.Erdos1039Problem once Docker/disk recovered; final elaboration crashed on SIGBUS (infra), not a Lean error, so unconfirmed.",
-      "If build fails, likely culprits: field_simp closing pi*(A/pi)=A; nlinarith in hsq; the (NNReal.pi:ENNReal) coercion matching Complex.volume_ball."
+      "BUILD VERIFICATION in flight: /tmp/verify-erdos1039.sh runs docker-build.sh Proofs.Erdos1039Problem once the concurrent lean-build volume frees (log /tmp/erdos1039-build.log). Could not run immediately: a 28min concurrent build held the shared lean-mathlib-cache olean volume (concurrent build = corruption risk).",
+      "Only residual static risk is line ~399 `_ = sublevelArea f := by field_simp` on goal `pi*(A/pi)=A`; field_simp discharger proves pi != 0 via positivity so expected OK; if build fails, harden to `field_simp` -> `rw [mul_div_cancel_left0 _ Real.pi_ne_zero]` or add `; ring`."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Follow-up on erdos-1039-incomplete-01 (polynomial lemniscate disc radius). Records that **PR #33815 merged** (`Erdos1039Problem.lean` on `main` now has **0 sorries**) and documents a thorough **static verification** of the hardest completed proof.

## Findings
- The 5 remaining `axiom`s (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected) are the genuinely open/published EHP–Pommerenke–KLR results — correctly axiomatized, not overclaimed.
- `area_implies_disc_bound`'s measure-coercion chain (`Complex.volume_ball` → `ENNReal.toReal_*` → `ENNReal.coe_toReal, NNReal.coe_real_pi`) **mirrors Mathlib's own `ConvexBody.lean`/`Asymptotics.lean` idiom exactly**. All API names confirmed against `packages/mathlib` source.
- A Docker single-target verification build was launched to close the BUILD-PENDING flag (a 28-min concurrent build was holding the shared olean volume; building concurrently risks corruption).

JSON-only change (problem knowledge), no Lean/build risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)