### PR TITLE
research(minkowski-fundamental-theorem-oq-03-oq-01): van der Corput counting theorem [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean
@@ -1,0 +1,168 @@
+/-
+# van der Corput's Convex-Body Counting Theorem
+(minkowski-fundamental-theorem-oq-03-oq-01)
+
+The general-`k` (van der Corput) refinement of Minkowski's fundamental theorem:
+a convex, centrally symmetric body whose volume exceeds `k · 2ⁿ · covol(L)`
+contains not just one nonzero lattice point (Minkowski, `k = 1`) but at least
+`k` of them.
+
+## Statement
+
+Let `L ⊆ E` be a full-rank lattice with fundamental domain `F`, and let `s` be a
+convex, centrally symmetric, null-measurable body.  If
+
+  `k · (covol(L) · 2ⁿ) < vol(s)`
+
+then `s` contains at least `k` nonzero lattice points: a finite set `D ⊆ L` with
+`k ≤ #D`, `0 ∉ D`, and `(v : E) ∈ s` for every `v ∈ D`.  By central symmetry the
+negatives `-v` also lie in `s`, so the points come in `± pairs` — this is the
+"`k` pairs / `k+1` points counting the origin" normalization of van der Corput's
+theorem.  Minkowski's fundamental theorem is `k = 1`.
+
+## Proof
+
+The measure-theoretic core — general-multiplicity Blichfeldt — is already
+formalized in the parent entry `minkowski-fundamental-theorem-oq-03` as
+`MeasureTheory.exists_finset_lattice_common_vadd`.  This file supplies the
+*geometric* passage from that multiplicity input to lattice points of the convex
+body, exactly as in Mathlib's own `k = 1` Minkowski proof but carrying the whole
+over-covered family:
+
+* Apply Blichfeldt to the shrunk body `½·s`, whose volume `2⁻ⁿ · vol(s)` still
+  exceeds `k · covol(L)`.  It yields a finite `T ⊆ L` with `k < #T` and a common
+  point `z` with `z ∈ l +ᵥ ½s` for all `l ∈ T`, i.e. `2·(z - l) ∈ s`.
+* Fix `l₀ ∈ T`.  For each other `l ∈ T`, the difference of the two `½s`-points
+  passes through convexity and central symmetry to a genuine lattice point:
+  `(l - l₀ : E) = 2⁻¹ · (2·(z - l₀) - 2·(z - l)) ∈ s`
+  (`half_diff_mem_of_symmetric_convex`).
+* The map `l ↦ l - l₀` is injective and avoids `0` off `l₀`, so the `#T - 1 ≥ k`
+  images form the required family of nonzero lattice points in `s`.
+
+The reusable geometric lemma `half_diff_mem_of_symmetric_convex`
+("for convex symmetric `s`, `a, b ∈ s ⟹ ½(a - b) ∈ s`") is the "congruent points
+→ genuine lattice point" step the problem statement asks to be packaged.
+
+All results are `0` axioms (`propext` / `Classical.choice` / `Quot.sound` only;
+no `sorry`, no `decide`, no `native_decide`).
+-/
+import Mathlib
+import Proofs.MinkowskiFundamentalTheoremOQ03
+
+open MeasureTheory Module Set Filter
+open scoped Pointwise ENNReal
+
+namespace MinkowskiVanDerCorput
+
+/-- **The central-symmetry / convexity passage lemma.**  For a convex, centrally
+symmetric set `s`, the scaled difference of any two of its points stays in `s`:
+`a, b ∈ s ⟹ 2⁻¹ • (a - b) ∈ s`.  This is the "two congruent points give a genuine
+lattice point" step of the geometry of numbers, packaged abstractly. -/
+theorem half_diff_mem_of_symmetric_convex {E : Type*} [AddCommGroup E] [Module ℝ E]
+    {s : Set E} (hconv : Convex ℝ s) (hsymm : ∀ x ∈ s, -x ∈ s)
+    {a b : E} (ha : a ∈ s) (hb : b ∈ s) :
+    (2⁻¹ : ℝ) • (a - b) ∈ s := by
+  have hnb : -b ∈ s := hsymm b hb
+  have hmix := hconv ha hnb (by norm_num : (0:ℝ) ≤ 2⁻¹) (by norm_num : (0:ℝ) ≤ 2⁻¹)
+    (by norm_num : (2⁻¹:ℝ) + 2⁻¹ = 1)
+  simpa [smul_sub, smul_neg, sub_eq_add_neg] using hmix
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E]
+  [BorelSpace E] [FiniteDimensional ℝ E] {μ : Measure E} [μ.IsAddHaarMeasure]
+  {F s : Set E} {L : AddSubgroup E} [Countable L]
+
+/-- Volume of the half-scaled body: `vol(½s) = (2ⁿ)⁻¹ · vol(s)`. -/
+theorem measure_half_smul :
+    μ ((2⁻¹ : ℝ) • s) = (2 ^ finrank ℝ E)⁻¹ * μ s := by
+  rw [Measure.addHaar_smul_of_nonneg μ (by norm_num : (0:ℝ) ≤ 2⁻¹) s,
+      ENNReal.ofReal_pow (by norm_num : (0:ℝ) ≤ 2⁻¹),
+      ENNReal.ofReal_inv_of_pos (by norm_num : (0:ℝ) < 2),
+      ENNReal.ofReal_ofNat, ← ENNReal.inv_pow]
+
+/-- **van der Corput's convex-body counting theorem.**  A convex, centrally
+symmetric body `s` with `vol(s) > k · covol(L) · 2ⁿ` contains at least `k` nonzero
+lattice points: a finite `D ⊆ L` with `k ≤ #D`, `0 ∉ D`, and `(v : E) ∈ s` for all
+`v ∈ D`.  Minkowski's fundamental theorem is the case `k = 1`. -/
+theorem vanDerCorput
+    (fund : IsAddFundamentalDomain L F μ)
+    (hs : NullMeasurableSet s μ)
+    (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s)
+    {k : ℕ} (h : k • (μ F * 2 ^ finrank ℝ E) < μ s) :
+    ∃ D : Finset L, k ≤ D.card ∧ (0 : L) ∉ D ∧ ∀ v ∈ D, ((v : E) ∈ s) := by
+  classical
+  have hpow_ne : (2 : ℝ≥0∞) ^ finrank ℝ E ≠ 0 := by positivity
+  have hpow_top : (2 : ℝ≥0∞) ^ finrank ℝ E ≠ ⊤ := by finiteness
+  -- The half-body still has more than `k` copies of the covolume.
+  have h_vol : (k : ℕ) • μ F < μ ((2⁻¹ : ℝ) • s) := by
+    have hR : ((2 ^ finrank ℝ E)⁻¹ * μ s) * 2 ^ finrank ℝ E = μ s := by
+      rw [mul_right_comm, ENNReal.inv_mul_cancel hpow_ne hpow_top, one_mul]
+    have hL : ((k : ℕ) • μ F) * 2 ^ finrank ℝ E = k • (μ F * 2 ^ finrank ℝ E) := by
+      rw [nsmul_eq_mul, nsmul_eq_mul]; ring
+    have hmul : ((k : ℕ) • μ F) * 2 ^ finrank ℝ E
+              < μ ((2⁻¹ : ℝ) • s) * 2 ^ finrank ℝ E := by
+      rw [measure_half_smul, hR, hL]; exact h
+    exact (ENNReal.mul_lt_mul_iff_left hpow_ne hpow_top).mp hmul
+  -- Blichfeldt's general-multiplicity principle on `½s`.
+  obtain ⟨T, hTcard, z, hz⟩ :=
+    MeasureTheory.exists_finset_lattice_common_vadd fund
+      ((h_conv.smul (2⁻¹ : ℝ)).nullMeasurableSet μ) h_vol
+  -- `T` is nonempty; fix a base point `l₀`.
+  obtain ⟨l₀, hl₀⟩ := Finset.card_pos.mp (by omega : 0 < T.card)
+  -- From each `l ∈ T`: `2 • (z - l) ∈ s`.
+  have extract : ∀ l ∈ T, (2 : ℝ) • (z - (l : E)) ∈ s := by
+    intro l hlT
+    have hmem := hz l hlT
+    rw [Set.mem_vadd_set_iff_neg_vadd_mem,
+        Set.mem_inv_smul_set_iff₀ (by norm_num : (2:ℝ) ≠ 0)] at hmem
+    simpa [AddSubgroup.vadd_def, neg_add_eq_sub, sub_eq_add_neg, add_comm] using hmem
+  -- The family of nonzero lattice differences.
+  refine ⟨(T.erase l₀).image (fun l => l - l₀), ?_, ?_, ?_⟩
+  · -- cardinality `≥ k`
+    rw [Finset.card_image_of_injective _ (fun a b hab => by simpa using sub_left_injective hab),
+        Finset.card_erase_of_mem hl₀]
+    omega
+  · -- `0` is not a difference (that would force `l = l₀`)
+    intro h0
+    rw [Finset.mem_image] at h0
+    obtain ⟨l, hl, hleq⟩ := h0
+    rw [Finset.mem_erase] at hl
+    exact hl.1 (sub_eq_zero.mp hleq)
+  · -- each difference is a lattice point of `s`
+    intro v hv
+    rw [Finset.mem_image] at hv
+    obtain ⟨l, hl, rfl⟩ := hv
+    rw [Finset.mem_erase] at hl
+    have h1 := extract l₀ hl₀
+    have h2 := extract l hl.2
+    have hcoe : ((l - l₀ : L) : E)
+        = (2⁻¹ : ℝ) • ((2 : ℝ) • (z - (l₀ : E)) - (2 : ℝ) • (z - (l : E))) := by
+      rw [AddSubgroup.coe_sub]; module
+    rw [hcoe]
+    exact half_diff_mem_of_symmetric_convex h_conv h_symm h1 h2
+
+/-- **Minkowski's fundamental theorem as `k = 1`.**  A convex symmetric body of
+volume `> covol(L) · 2ⁿ` contains a nonzero lattice point (with its antipode). -/
+theorem minkowski_of_vanDerCorput
+    (fund : IsAddFundamentalDomain L F μ)
+    (hs : NullMeasurableSet s μ)
+    (h_symm : ∀ x ∈ s, -x ∈ s) (h_conv : Convex ℝ s)
+    (h : μ F * 2 ^ finrank ℝ E < μ s) :
+    ∃ v : L, v ≠ 0 ∧ ((v : E) ∈ s) ∧ ((-v : E) ∈ s) := by
+  obtain ⟨D, hcard, hzero, hmem⟩ := vanDerCorput fund hs h_symm h_conv
+    (k := 1) (by simpa using h)
+  obtain ⟨v, hv⟩ := Finset.card_pos.mp (by omega : 0 < D.card)
+  refine ⟨v, ?_, hmem v hv, ?_⟩
+  · rintro rfl; exact hzero hv
+  · have := hmem v hv
+    simpa using h_symm _ this
+
+#check @half_diff_mem_of_symmetric_convex
+#check @vanDerCorput
+#check @minkowski_of_vanDerCorput
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide`.
+#print axioms vanDerCorput
+#print axioms minkowski_of_vanDerCorput
+
+end MinkowskiVanDerCorput

--- a/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/knowledge.md
+++ b/research/problems/minkowski-fundamental-theorem-oq-03-oq-01/knowledge.md
@@ -19,3 +19,50 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-02 (researcher-4) — ACT: van der Corput counting theorem formalized & verified
+
+**Mode**: EMPTY → ACT (first substantive session). **Outcome**: progress (VERIFIED, 0-axiom)
+— new `proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean` (~140 LOC, 3 thm, 0 sorry,
+0 axiom). Host `lake env lean` exit 0 against the shared Mathlib `.olean` cache (after
+building the parent `MinkowskiFundamentalTheoremOQ03.olean`); `#print axioms vanDerCorput` /
+`minkowski_of_vanDerCorput` = `propext` / `Classical.choice` / `Quot.sound` only — no
+`sorryAx`, no `Lean.ofReduceBool`, no `decide`.
+
+### Key realization
+The hard measure-theoretic core — **general-multiplicity Blichfeldt** — was **already
+proven in the immediate parent** `minkowski-fundamental-theorem-oq-03` as
+`MeasureTheory.exists_finset_lattice_common_vadd` (`k·μF < μs ⟹ ∃ T⊆L, k<#T, common z ∈ l+ᵥs`).
+So van der Corput reduces to the **geometric passage**, mirroring Mathlib's own `k=1`
+Minkowski proof but carrying the whole over-covered family.
+
+### What I proved
+- `half_diff_mem_of_symmetric_convex` — the reusable passage lemma the problem statement asks
+  for: for convex, centrally symmetric `s`, `a,b ∈ s ⟹ 2⁻¹•(a-b) ∈ s` (convexity of `a` and
+  `-b`).
+- `vanDerCorput` — **`vol(s) > k·covol(L)·2ⁿ ⟹ s contains ≥ k nonzero lattice points`**
+  (a `Finset D ⊆ L`, `k ≤ #D`, `0 ∉ D`, all in `s`). Proof: Blichfeldt on `½s`
+  (`vol(½s)=2⁻ⁿ·vol s > k·covol`), fix a base point `l₀ ∈ T`, and send each other difference
+  `l - l₀` through `half_diff_mem_of_symmetric_convex`; the `#T-1 ≥ k` images are distinct and
+  nonzero.
+- `minkowski_of_vanDerCorput` — the `k=1` case recovers Minkowski's fundamental theorem
+  (nonzero lattice point + its antipode).
+
+### Honest scope
+This is the **≥ k nonzero** (`k+1` counting the origin) normalization — one of the two forms
+the problem statement lists. It is **NOT** the sharp **≥ 2k / k-pairs** headline: a single
+base point yields only `k` differences, and the factor-2 improvement needs a fuller
+pairwise-difference/symmetry count. Recorded as the remaining open sharpening; status left at
+`progress`, not `completed`.
+
+### Files Modified
+- proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean (new)
+- src/data/research/problems/minkowski-fundamental-theorem-oq-03-oq-01.json (leanFiles + knowledge)
+- research/problems/minkowski-fundamental-theorem-oq-03-oq-01/knowledge.md (this entry)
+
+### Next Steps
+- Sharpen `≥ k` to the classical `≥ 2k` (`k` pairs `{±v}`) via a full pairwise-difference /
+  symmetry count.
+- Consider a gallery entry once the counting form is settled.

--- a/src/data/research/problems/minkowski-fundamental-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/minkowski-fundamental-theorem-oq-03-oq-01.json
@@ -1,0 +1,166 @@
+{
+  "slug": "minkowski-fundamental-theorem-oq-03-oq-01",
+  "title": "van der Corput's Convex-Body Counting Theorem via the Minkowski Multiplicity Principle",
+  "phase": "ACT",
+  "status": "progress",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\operatorname{vol}(S) > k \\cdot 2^n \\cdot \\operatorname{covol}(L)\n\\;\\Longrightarrow\\;\n\\bigl|\\, (S \\cap L) \\setminus \\{0\\} \\,\\bigr| \\;\\ge\\; 2k,",
+    "plain": "Minkowski's theorem says a centrally symmetric convex body whose volume exceeds",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-02T14:45:24-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "van der Corput convex-body counting theorem FORMALIZED and VERIFIED (0-axiom), researcher-4 2026-07-02. New proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean (3 thm): `vanDerCorput` — vol(s) > k·covol·2ⁿ ⟹ s contains ≥ k nonzero lattice points (Finset D⊆L, k≤#D, 0∉D, all in s), the k+1-counting-origin normalization. Built on parent oq-03's general-multiplicity Blichfeldt applied to ½s, passing the k+1 congruent points through convexity+central symmetry. Also `minkowski_of_vanDerCorput` (k=1=Minkowski) and reusable `half_diff_mem_of_symmetric_convex`. NOTE: proves the ≥k-nonzero form, not the sharp ≥2k / k-pairs headline (single-base-point differences give k; factor-2 sharpening remains open).",
+    "builtItems": [
+      "MinkowskiFundamentalTheoremOQ03OQ01.lean: vanDerCorput (≥k nonzero), minkowski_of_vanDerCorput (k=1), half_diff_mem_of_symmetric_convex — all 0-axiom verified"
+    ],
+    "insights": [
+      "General-k Blichfeldt multiplicity core ALREADY done in parent oq-03 (exists_finset_lattice_common_vadd). van der Corput reduces to the GEOMETRIC passage: Blichfeldt on ½s (vol 2⁻ⁿ·vol s > k·covol), differences of the k+1 congruent points land in s via half_diff_mem_of_symmetric_convex (a,b∈s convex-symm ⟹ ½(a-b)∈s); one base point yields #T-1 ≥ k distinct nonzero lattice points.",
+      "Sharp ≥2k (k pairs) NOT obtained by single-base-point differences (gives k). Factor-2 sharpening needs a fuller pairwise-difference/symmetry count — remaining open."
+    ],
+    "mathlibGaps": [
+      "Mathlib has Minkowski/Blichfeldt only at k=1 (MeasureTheory.Group.GeometryOfNumbers); no general-k van der Corput counting theorem — this file + parent oq-03 supply it up to the factor-2 sharpening."
+    ],
+    "nextSteps": [
+      "Sharpen ≥k to classical ≥2k (k pairs {±v}) via a full pairwise-difference/symmetry count.",
+      "Consider a gallery entry once the counting form is settled."
+    ],
+    "markdown": "# Knowledge Base: minkowski-fundamental-theorem-oq-03-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "geometry-of-numbers",
+    "lattices",
+    "convex-bodies",
+    "van-der-corput"
+  ],
+  "relatedProofs": [
+    "minkowski-fundamental-theorem",
+    "minkowski-fundamental-theorem-oq-01",
+    "minkowski-fundamental-theorem-oq-01-oq-01",
+    "minkowski-fundamental-theorem-oq-01-oq-02",
+    "minkowski-fundamental-theorem-oq-02",
+    "minkowski-fundamental-theorem-oq-03",
+    "minkowski-fundamental-theorem-oq-04",
+    "minkowski-fundamental-theorem-oq-05",
+    "minkowski-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T22:35:30.705Z",
+  "lastUpdate": "2026-07-02",
+  "leanFiles": [
+    "Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean",
+    {
+      "path": "Proofs/MinkowskiFundamentalTheorem.lean",
+      "filename": "MinkowskiFundamentalTheorem.lean",
+      "lineCount": 687,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 12,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheorem.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ01.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ01.lean",
+      "lineCount": 209,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ01OQ01.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ01OQ01.lean",
+      "lineCount": 230,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ01OQ02.lean",
+      "lineCount": 243,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ02.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ02.lean",
+      "lineCount": 131,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ03.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ04.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ04.lean",
+      "lineCount": 193,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/MinkowskiFundamentalTheoremOQ05.lean",
+      "filename": "MinkowskiFundamentalTheoremOQ05.lean",
+      "lineCount": 328,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiFundamentalTheoremOQ05.lean"
+    }
+  ],
+  "lastVerified": "2026-07-02"
+}


### PR DESCRIPTION
## Summary
First substantive session for `minkowski-fundamental-theorem-oq-03-oq-01` (van der Corput's convex-body counting theorem, the general-`k` refinement of Minkowski). New verified Lean file, 0-axiom.

## Progress
New `proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean` (~140 LOC, 3 thm, 0 sorry, 0 `axiom`):

- **`vanDerCorput`** — `vol(s) > k · covol(L) · 2ⁿ ⟹ s contains ≥ k nonzero lattice points`: a `Finset D ⊆ L` with `k ≤ #D`, `0 ∉ D`, and `(v : E) ∈ s` for every `v ∈ D`. The `k+1`-counting-the-origin normalization of van der Corput's theorem.
- **`minkowski_of_vanDerCorput`** — the `k = 1` case recovers Minkowski's fundamental theorem (a nonzero lattice point together with its antipode).
- **`half_diff_mem_of_symmetric_convex`** — the reusable "congruent points → genuine lattice point" passage lemma the problem statement asks to be packaged: for convex, centrally symmetric `s`, `a, b ∈ s ⟹ 2⁻¹ • (a - b) ∈ s`.

### How it works
The hard measure-theoretic core — **general-multiplicity Blichfeldt** — is already formalized in the immediate parent `minkowski-fundamental-theorem-oq-03` (`MeasureTheory.exists_finset_lattice_common_vadd`). This file supplies the **geometric passage**, mirroring Mathlib's own `k = 1` Minkowski proof but carrying the whole over-covered family: apply Blichfeldt to `½s` (whose volume `2⁻ⁿ · vol(s)` still exceeds `k · covol(L)`), fix a base point `l₀ ∈ T`, and send each other difference `l - l₀` through `half_diff_mem_of_symmetric_convex`; the `#T − 1 ≥ k` images are distinct nonzero lattice points of `s`.

## Honest scope
This is the **≥ k nonzero** (`k+1` counting the origin) form — one of the two normalizations the problem statement itself lists. It is **not** the sharp **≥ 2k / k-pairs** headline: a single base point yields only `k` differences, and the factor-2 improvement needs a fuller pairwise-difference / symmetry count. That sharpening is recorded as the remaining open step; the problem status is left at `progress`, not `completed`.

## Mathlib gap
Mathlib has Minkowski and Blichfeldt only at `k = 1` (`MeasureTheory.Group.GeometryOfNumbers`); there is no general-`k` van der Corput counting theorem. This file (with the parent `oq-03`) supplies it, up to the factor-2 sharpening.

## Verification
Host `lake env lean` exit 0 against the shared Mathlib `.olean` cache (parent `MinkowskiFundamentalTheoremOQ03.olean` built in the process):
- `#print axioms vanDerCorput` and `minkowski_of_vanDerCorput` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, no `decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)