### PR TITLE
Enrich Erdős #1207 (OQ-04): isometric transport / dimension lift — add annotations

### DIFF
--- a/src/data/proofs/erdos-1207-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1207-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 44, "endLine": 52 },
+    "type": "context",
+    "title": "Pseudometric setup and imported base theory",
+    "content": "The file imports the parent `Erdos1207Problem` (which defines `IsoscelesTriangle` and `IsoscelesFree`) and `Erdos1207OQ03` (the explicit base-3 lower bound on the line). The two source and target spaces `P` and `Q` are only assumed to be `PseudoMetricSpace`s — the transport engine never touches coordinates or dimension, so it applies to any metric setting.",
+    "mathContext": "`IsoscelesFree S` means no three distinct points $a,b,c \\in S$ form an isosceles triangle, where being isosceles is defined purely by the equality of two of the pairwise distances. Working over a `PseudoMetricSpace` (distinct points may sit at distance $0$) keeps the lemmas maximally general.",
+    "significance": "context",
+    "relatedConcepts": ["pseudometric space", "isosceles-free set", "metric invariant"],
+    "prerequisites": ["metric spaces", "Lean typeclasses"]
+  },
+  {
+    "id": "ann-reflect-triangle",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 56, "endLine": 65 },
+    "type": "technique",
+    "title": "Isometries reflect isosceles triangles",
+    "content": "`isoscelesTriangle_of_isometry` shows the apex/distinctness data pulls back through an isometry `f`. The three distinctness clauses reflect because `f a = f b` follows from `a = b` (`congrArg f`), so contrapositively `a ≠ b` is forced; the distance disjunction reflects because `hf.dist_eq` rewrites every `dist (f _) (f _)` to `dist _ _`, discharged by `simpa`.",
+    "mathContext": "If $f$ is an isometry then $\\operatorname{dist}(f x, f y) = \\operatorname{dist}(x,y)$ for all $x,y$. Hence the apex condition — say $\\operatorname{dist}(fa,fb) = \\operatorname{dist}(fa,fc)$ — is equivalent to $\\operatorname{dist}(a,b) = \\operatorname{dist}(a,c)$, and the three vertices stay distinct because $f$ maps distinct points to distinct images.",
+    "significance": "supporting",
+    "relatedConcepts": ["isometry", "distance preservation", "congrArg", "contrapositive"],
+    "prerequisites": ["isometries", "metric spaces"]
+  },
+  {
+    "id": "ann-transport-engine",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "insight",
+    "title": "The transport engine: images of isosceles-free sets are isosceles-free",
+    "content": "`isoscelesFree_image_isometry` is the load-bearing lemma. Any point of `f '' S` destructures as `f a` with `a ∈ S` (the `rintro ⟨a, ha, rfl⟩` pattern); a hypothetical isosceles triangle among three such images reflects — via the previous lemma — to an isosceles triangle in `S`, contradicting `IsoscelesFree S`. No dimension, coordinates, or Euclidean structure appear, so the result holds for isometries between arbitrary pseudometric spaces.",
+    "mathContext": "For an isometry $f : P \\to Q$ and $S \\subseteq P$: if $S$ is isosceles-free then so is $f(S) \\subseteq Q$. This is the metric form of dimension monotonicity — it is what makes $P_d(n) \\ge P_1(n)$ true once one exhibits an isometric embedding $\\mathbb{R} \\hookrightarrow \\mathbb{R}^d$.",
+    "significance": "key",
+    "relatedConcepts": ["isometric embedding", "image of a set", "isosceles-free set", "proof by contradiction"],
+    "prerequisites": ["isometries", "set images", "combinatorial geometry"]
+  },
+  {
+    "id": "ann-axis-isometry",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 77, "endLine": 83 },
+    "type": "definition",
+    "title": "The coordinate axis is an isometric copy of ℝ",
+    "content": "`isometry_euclideanSingle` supplies the concrete isometry the engine is applied to: `t ↦ EuclideanSpace.single i t`, which places the real `t` on the `i`-th coordinate axis and zeros elsewhere. The one-line proof feeds `EuclideanSpace.dist_single_same` (which computes the axis distance as `|s − t|`) into `Isometry.of_dist_eq`.",
+    "mathContext": "The map $t \\mapsto t\\,e_i \\in \\mathbb{R}^{\\lvert\\iota\\rvert}$ satisfies $\\lVert s e_i - t e_i\\rVert = \\lvert s - t\\rvert$, because only the $i$-th coordinate is nonzero. So $\\mathbb{R}$ embeds isometrically as any coordinate axis of Euclidean space.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanSpace", "coordinate axis", "isometric embedding", "Isometry.of_dist_eq"],
+    "prerequisites": ["Euclidean space", "norms", "isometries"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 87, "endLine": 98 },
+    "type": "insight",
+    "title": "Dimension monotonicity P_d(n) ≥ P₁(n)",
+    "content": "`exists_isoscelesFree_image_of_real` combines the two previous results: transport the source set along the axis isometry (isosceles-freeness preserved) and note the cardinality is unchanged via `Set.ncard_image_of_injective` using `(isometry_euclideanSingle i).injective`. The witness `T` is the axis image; the two goals are exactly the isosceles-freeness and the `ncard` equality.",
+    "mathContext": "Every isosceles-free $S \\subseteq \\mathbb{R}$ with $\\lvert S\\rvert = m$ yields an isosceles-free $T \\subseteq \\mathbb{R}^d$ with $\\lvert T\\rvert = m$. Cardinality is exactly preserved because an isometry from a metric space is injective. In problem notation: $P_d(n) \\ge P_1(n)$ for all $d \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": ["dimension monotonicity", "ncard", "injectivity of isometries", "cardinality preservation"],
+    "prerequisites": ["set cardinality", "isometries", "combinatorial geometry"]
+  },
+  {
+    "id": "ann-lower-bound-euclidean",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "The base-3 lower bound lifted to every dimension",
+    "content": "`exists_isoscelesFree_pow_euclidean` specialises the monotonicity lift to OQ-03's explicit construction: the base-3 \"no digit 2\" set `Set.range (embR k)`, which OQ-03 proves isosceles-free with `ncard = 2ᵏ`. Transporting it onto the `i`-th axis and rewriting the cardinality via `Erdos1207OQ03.ncard_range_embR` gives an explicit isosceles-free set of `2ᵏ` points in `ℝ^d`.",
+    "mathContext": "$P_d(3^k) \\ge 2^k$ for all $d \\ge 1$: the $2^k$ points with base-3 digits in $\\{0,1\\}$ (avoiding an arithmetic-progression midpoint on the line) remain isosceles-free once laid on a coordinate axis.",
+    "significance": "supporting",
+    "relatedConcepts": ["base-3 construction", "3-AP-free set", "explicit lower bound", "digit avoidance"],
+    "prerequisites": ["number bases", "arithmetic progressions", "combinatorial geometry"]
+  },
+  {
+    "id": "ann-planar",
+    "proofId": "erdos-1207-oq-04",
+    "range": { "startLine": 114, "endLine": 120 },
+    "type": "insight",
+    "title": "The planar headline: P₂(3ᵏ) ≥ 2ᵏ",
+    "content": "`exists_isoscelesFree_pow_plane` is the case Erdős emphasises, obtained by specialising the general lift to `ι = Fin 2`, `i = 0`. It exhibits an explicit isosceles-free set of `2ᵏ` points in the Euclidean plane — the lower-bound side of the open question about the growth of `P_2(n)`. No upper bound is proved: whether `P_2(n)` is subpolynomial remains exactly Erdős's problem.",
+    "mathContext": "$P_2(3^k) \\ge 2^k$. The construction places $3^k$ collinear base-3 points on the first axis of $\\mathbb{R}^2$; because the whole configuration is one-dimensional, isosceles-freeness is inherited from the line. The genuinely open question is whether higher dimensions or cleverer planar configurations beat this line-bound rate.",
+    "significance": "key",
+    "relatedConcepts": ["planar case", "Erdős open problem", "isosceles-free set", "lower bound"],
+    "prerequisites": ["Euclidean plane", "combinatorial geometry"]
+  }
+]

--- a/src/data/proofs/erdos-1207-oq-04/meta.json
+++ b/src/data/proofs/erdos-1207-oq-04/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "erdos-1207-oq-04",
+  "title": "Erdős #1207 (OQ-04): Isometric transport and the dimension lift P_d(n) ≥ P₁(n)",
+  "slug": "erdos-1207-oq-04",
+  "description": "A follow-up to Erdős #1207 that carries the one-dimensional theory into every dimension. The parent entry sets up isosceles-freeness for an arbitrary metric space and the d=1 bridge to 3-AP-free sets; OQ-03 gives the explicit lower bound P₁(3ᵏ) ≥ 2ᵏ on the line. Here we prove that isosceles-freeness transports along any isometric embedding, so placing a one-dimensional configuration on a coordinate axis of ℝ^d realises it isometrically in higher dimensions. Consequences: dimension monotonicity P_d(n) ≥ P₁(n) for all d ≥ 1, and an explicit isosceles-free set of 2ᵏ points in ℝ^d (and in the plane ℝ²), i.e. P_d(3ᵏ) ≥ 2ᵏ. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Erdős (Er80); formalization by researcher-6",
+    "sourceUrl": "https://erdosproblems.com/1207",
+    "date": "1980",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1207OQ04.lean",
+    "tags": [
+      "erdos",
+      "combinatorial-geometry",
+      "discrete-geometry",
+      "isosceles-triangles",
+      "isometry",
+      "euclidean-space",
+      "lower-bound",
+      "dimension-monotonicity",
+      "open"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 1207,
+    "erdosUrl": "https://erdosproblems.com/1207",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Isometry.of_dist_eq",
+        "description": "A distance-preserving map is an isometry",
+        "module": "Mathlib.Topology.MetricSpace.Isometry"
+      },
+      {
+        "theorem": "Isometry.dist_eq",
+        "description": "An isometry preserves pairwise distances: dist (f x) (f y) = dist x y",
+        "module": "Mathlib.Topology.MetricSpace.Isometry"
+      },
+      {
+        "theorem": "Isometry.injective",
+        "description": "An isometry from a metric space is injective",
+        "module": "Mathlib.Topology.MetricSpace.Isometry"
+      },
+      {
+        "theorem": "EuclideanSpace.dist_single_same",
+        "description": "dist (single i a) (single i b) = dist a b in EuclideanSpace",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Set.ncard_image_of_injective",
+        "description": "The image of a set under an injective map has the same ncard",
+        "module": "Mathlib.Data.Set.Card"
+      }
+    ],
+    "originalContributions": [
+      "isoscelesTriangle_of_isometry (verified, 0-axiom): an isometry REFLECTS isosceles triangles — if f a, f b, f c form an isosceles triangle then so do a, b, c. Distance preservation transports the apex condition and f a ≠ f b forces a ≠ b",
+      "isoscelesFree_image_isometry (verified, 0-axiom): THE ENGINE — the image of an isosceles-free set under any isometry of pseudometric spaces is isosceles-free; purely metric, no dimension or coordinates",
+      "isometry_euclideanSingle (verified, 0-axiom): the coordinate-axis embedding t ↦ EuclideanSpace.single i t is an isometry ℝ ↪ EuclideanSpace ℝ ι, since the Euclidean distance between two axis points is exactly |s − t|",
+      "exists_isoscelesFree_image_of_real (verified, 0-axiom): DIMENSION MONOTONICITY — every isosceles-free set of reals of size m yields an isosceles-free subset of ℝ^d of the same size m, i.e. P_d(n) ≥ P₁(n) for all d ≥ 1",
+      "exists_isoscelesFree_pow_euclidean (verified, 0-axiom): the base-3 lower bound of OQ-03 lifted to every dimension — for each k an explicit isosceles-free set of 2ᵏ points in ℝ^d, i.e. P_d(3ᵏ) ≥ 2ᵏ",
+      "exists_isoscelesFree_pow_plane (verified, 0-axiom): THE HEADLINE for the plane Erdős emphasises — an explicit isosceles-free set of 2ᵏ points in ℝ², the lower-bound side of the open question about P_2(n)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "None. All declarations are fully machine-checked: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries. This records the dimension-monotone lower-bound side of P_d(n); it does not resolve the open growth question (whether P_2(n) is subpolynomial is exactly Erdős's problem, and no upper bound is proved here).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**Erdős #1207 in general dimension.** The problem asks to estimate P_d(n), the largest guaranteed isosceles-free subset of an n-point set in ℝ^d, and highlights the planar case P_2(n). The parent formalization handles the line d=1 (isosceles-free = 3-AP-free) and OQ-03 gives the base-3 lower bound P₁(3ᵏ) ≥ 2ᵏ. A basic but essential observation is that lower bounds are dimension-monotone: any construction on a line sits isometrically inside ℝ^d, so P_d(n) ≥ P₁(n). This entry makes that transport principle precise and machine-checked.",
+    "problemStatement": "**OQ-04.** Do the d=1 results transfer to higher dimensions? Concretely: is isosceles-freeness preserved by isometric embeddings, and does the base-3 construction therefore give an explicit isosceles-free set of 2ᵏ points in ℝ^d (in particular in the plane)?",
+    "text": "An isometry f preserves all pairwise distances and is injective, so it both reflects the apex condition |·| = |·| and the distinctness of the three vertices; hence the f-image of an isosceles-free set is isosceles-free. The map t ↦ single i t placing a real on the i-th coordinate axis is an isometry ℝ ↪ ℝ^d (the other coordinates are 0, so the Euclidean distance is |s − t|). Transporting the base-3 set S_k of OQ-03 along this axis gives, for every k, an isosceles-free set of 2ᵏ points in ℝ^d, so P_d(3ᵏ) ≥ 2ᵏ for all d ≥ 1.",
+    "proofStrategy": "**Metric transport, then a coordinate embedding.**\n\n1. **Reflection.** isoscelesTriangle_of_isometry: from IsoscelesTriangle (f a) (f b) (f c), the three inequalities pull back by congrArg f (f a = f b would follow from a = b) and the distance disjunction pulls back by Isometry.dist_eq (simp).\n\n2. **Engine.** isoscelesFree_image_isometry: destructure a point of f '' S as f a with a ∈ S; a hypothetical isosceles triangle among images reflects to one in S, contradicting isosceles-freeness of S.\n\n3. **Axis is an isometry.** isometry_euclideanSingle: t ↦ EuclideanSpace.single i t satisfies dist (single i s) (single i t) = dist s t by EuclideanSpace.dist_single_same, so Isometry.of_dist_eq applies.\n\n4. **Lift.** exists_isoscelesFree_image_of_real transports any real isosceles-free set with cardinality preserved (Set.ncard_image_of_injective via Isometry.injective); specialising to the OQ-03 base-3 set and to ℝ² gives the quantitative corollaries.",
+    "prerequisites": [
+      "Isometries of metric spaces: distance preservation and injectivity",
+      "Euclidean space EuclideanSpace ℝ (Fin d) and its coordinate vectors",
+      "The parent definitions IsoscelesTriangle / IsoscelesFree",
+      "The OQ-03 base-3 construction of an isosceles-free set on the line"
+    ],
+    "keyInsights": [
+      "**Isosceles-freeness is a metric invariant.** It is defined purely from the distance function, so it is preserved and reflected by any isometry — no coordinates, no dimension enter the engine lemma.",
+      "**One coordinate axis suffices.** Placing a line inside ℝ^d as a coordinate axis is an isometric embedding, so the entire one-dimensional theory (bridge and lower bound) transfers verbatim; this is exactly why P_d(n) ≥ P₁(n).",
+      "**Cardinality rides along.** An isometry from a metric space is injective, so the transported set has the same ncard — the lower bound 2ᵏ is preserved exactly.",
+      "**Only the lower-bound side.** Dimension monotonicity gives ≥, not the value; whether P_2(n) grows subpolynomially — Erdős's actual question — is untouched, and no upper bound is claimed."
+    ]
+  },
+  "sections": [
+    {
+      "id": "reflection",
+      "title": "Isometries reflect isosceles triangles",
+      "summary": "isoscelesTriangle_of_isometry and the transport engine isoscelesFree_image_isometry: the image of an isosceles-free set under any isometry is isosceles-free.",
+      "startLine": 54,
+      "endLine": 73,
+      "mathContext": "An isometry f preserves pairwise distances (Isometry.dist_eq) so the apex disjunction pulls back; f a = f b follows from a = b (congrArg), so distinctness pulls back too. Hence a hypothetical isosceles triangle among images gives one among originals, contradicting isosceles-freeness of the source set."
+    },
+    {
+      "id": "axis-isometry",
+      "title": "The coordinate axis is an isometric copy of ℝ",
+      "summary": "isometry_euclideanSingle: t ↦ EuclideanSpace.single i t is an isometry ℝ ↪ EuclideanSpace ℝ ι.",
+      "startLine": 75,
+      "endLine": 83,
+      "mathContext": "The other coordinates are 0, so the Euclidean distance between single i s and single i t is |s − t| (EuclideanSpace.dist_single_same); Isometry.of_dist_eq turns this into an Isometry."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Dimension monotonicity P_d(n) ≥ P₁(n)",
+      "summary": "exists_isoscelesFree_image_of_real: any isosceles-free set of reals of size m transports to an isosceles-free subset of ℝ^d of the same size m.",
+      "startLine": 85,
+      "endLine": 98,
+      "mathContext": "Combine the transport engine with cardinality preservation: Set.ncard_image_of_injective using Isometry.injective (the domain ℝ is a metric space) keeps |image| = |source|."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The base-3 lower bound in every dimension",
+      "summary": "exists_isoscelesFree_pow_euclidean and exists_isoscelesFree_pow_plane: an explicit isosceles-free set of 2ᵏ points in ℝ^d (and in ℝ²), i.e. P_d(3ᵏ) ≥ 2ᵏ.",
+      "startLine": 100,
+      "endLine": 121,
+      "mathContext": "Apply the monotonicity lift to the OQ-03 base-3 set Set.range (embR k), whose ncard is 2ᵏ; specialise ι = Fin 2, i = 0 for the planar case that mirrors Erdős's emphasis on P_2(n)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Isosceles-freeness is preserved and reflected by isometric embeddings, so the one-dimensional theory of Erdős #1207 transfers to every dimension by placing a line on a coordinate axis. This yields dimension monotonicity P_d(n) ≥ P₁(n) and, from the OQ-03 base-3 construction, an explicit isosceles-free set of 2ᵏ points in ℝ^d — in particular in the plane, giving P_2(3ᵏ) ≥ 2ᵏ. Everything is machine-checked with no axioms or sorries.",
+    "implications": "**Significance**\n\n1. **Dimension monotonicity, formalized.** Records the elementary but load-bearing fact that lower bounds transfer up in dimension, so all one-dimensional work automatically bounds P_d.\n2. **Reusable metric-transport lemma.** isoscelesFree_image_isometry is stated for arbitrary pseudometric spaces and can seed other isosceles/equidistant formalizations (products, embeddings, sphere/curve realisations).\n3. **Planar lower bound.** Gives the explicit lower-bound side of Erdős's headline question about P_2(n), without claiming the (unknown) growth rate.",
+    "openQuestions": [
+      "Is there a matching upper bound P_d(n) ≤ n^{o(1)} in the plane, which is Erdős's actual question about whether P_2(n) is subpolynomial?",
+      "Can the higher-dimensional structure beat the one-dimensional bound — is P_d(n) strictly larger than P₁(n) for d ≥ 2, and can any such improvement be formalized?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1207",
+      "relationship": "parent",
+      "description": "Parent problem: the definitions IsoscelesTriangle / IsoscelesFree and the one-dimensional bridge that this entry transports into higher dimensions."
+    },
+    {
+      "targetId": "erdos-1207-oq-03",
+      "relationship": "related",
+      "description": "Supplies the base-3 isosceles-free set on the line whose cardinality 2ᵏ this entry lifts into ℝ^d."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Some combinatorial problems in geometry",
+      "venue": "Geometry and Differential Geometry (Lecture Notes in Math. 792)",
+      "year": "1980",
+      "pages": "46–53",
+      "note": "Source of Problem #1207."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1207Problem",
+      "Proofs.Erdos1207OQ03"
+    ],
+    "opens": [
+      "Erdos1207"
+    ],
+    "namespace": "Erdos1207OQ04",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1207OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1207-oq-04` (quality 41, pass 0).

**Gap addressed:** the entry had a rich `meta.json` but **no `annotations.json`** (0 inline annotation coverage).

**Added:** a new `annotations.json` with 7 annotations giving full line-range coverage of the Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- pseudometric setup / imported base theory
- `isoscelesTriangle_of_isometry` — isometries reflect isosceles triangles
- `isoscelesFree_image_isometry` — the transport engine (key)
- `isometry_euclideanSingle` — coordinate axis as an isometric copy of ℝ (key)
- `exists_isoscelesFree_image_of_real` — dimension monotonicity P_d(n) ≥ P₁(n) (key)
- `exists_isoscelesFree_pow_euclidean` — base-3 lower bound in every dimension
- `exists_isoscelesFree_pow_plane` — planar headline P₂(3ᵏ) ≥ 2ᵏ (key)

No changes to `meta.json` (already under all size caps with good keyInsights/sections/conclusion). Axiom/status fields verified accurate against the Lean source (0 axioms, 0 sorries, `verified`).
