### PR TITLE
Enrich Maclaurin chain over NNReal: add annotations (7 items, full coverage)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 54, "endLine": 62 },
+    "type": "context",
+    "title": "Imports and the NNReal scope",
+    "content": "The file imports only `AmgmInequalityOQ02OQ03` (which supplies the de-axiomatized step `maclaurin_step_proved`) plus `Mathlib.Tactic`, and opens `scoped NNReal` to bring the `ℝ≥0` notation into scope. Crucially it does NOT import the axiom-based parent chain — this deliberate choice is what keeps the NNReal result axiom-free.",
+    "mathContext": "The whole development lives over the ordered subsemiring $\\mathbb{R}_{\\ge 0} = \\mathbb{R}\\!\\ge\\!0$, embedded into $\\mathbb{R}$ by the order-preserving ring homomorphism $(\\uparrow) : \\mathbb{R}_{\\ge 0} \\hookrightarrow \\mathbb{R}$.",
+    "significance": "context",
+    "relatedConcepts": ["NNReal", "ordered semiring", "axiom hygiene"],
+    "prerequisites": ["Lean imports", "Mathlib NNReal"]
+  },
+  {
+    "id": "ann-chain-aux",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 66, "endLine": 80 },
+    "type": "technique",
+    "title": "Gap-induction on the axiom-free step",
+    "content": "`maclaurin_chain_aux_proved` proves Mⱼ ≥ Mⱼ₊ₐ by induction on the gap `d`. The base case `d = 0` is `simp`; the successor case chains the inductive hypothesis with one application of the de-axiomatized single step `maclaurin_step_proved`. Reducing the whole chain to repeated single steps is what lets the axiom-free step propagate to the full ordering.",
+    "mathContext": "Telescoping: $M_j \\ge M_{j+1} \\ge \\cdots \\ge M_{j+d}$ is assembled from $d$ consecutive one-step inequalities $M_{j+m} \\ge M_{j+m+1}$, each supplied by the Newton/Cauchy–Schwarz step. The `omega` side goals discharge the arithmetic bounds $j+m \\le n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["induction on the gap", "telescoping inequalities", "maclaurin_step_proved"],
+    "prerequisites": ["induction", "Maclaurin means"]
+  },
+  {
+    "id": "ann-full-chain-real",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 90 },
+    "type": "insight",
+    "title": "Step 1 — the real chain, rebuilt axiom-free",
+    "content": "`maclaurin_full_chain_proved` restates the parent's chain Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n, but with no dependence on the `newton_log_concavity` axiom. It writes `k = j + d` via `Nat.exists_eq_add_of_le` and hands off to the gap-induction lemma. This axiom-free real chain is the object that will be transferred to ℝ≥0.",
+    "mathContext": "For $0 < j \\le k \\le n$ and non-negative reals $x_i$: $M_j(x) \\ge M_k(x)$. Identical statement to the parent, but its proof term mentions only `propext`/`Classical.choice`/`Quot.sound` — no `maclaurin_step` axiom.",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin chain", "axiom-free proof", "de-axiomatization"],
+    "prerequisites": ["Maclaurin means", "elementary symmetric polynomials"]
+  },
+  {
+    "id": "ann-nnreal-defs",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 94, "endLine": 100 },
+    "type": "definition",
+    "title": "Step 2 — the NNReal definitions",
+    "content": "`elemSymmNN k x` is the k-th elementary symmetric polynomial over ℝ≥0, summed over `powersetCard k` of the index set; `maclaurinMeanNN k x` normalizes by the binomial coefficient C(n,k) and takes the outer 1/k power using NNReal division and `NNReal.rpow`. Both are `noncomputable` (rpow is). These mirror the real `elemSymm` / `maclaurinMean` verbatim on ℝ≥0.",
+    "mathContext": "$e_k(x) = \\sum_{|s|=k} \\prod_{i \\in s} x_i$ and $M_k(x) = \\left(e_k(x)/\\binom{n}{k}\\right)^{1/k}$, now with $x : \\mathrm{Fin}\\,n \\to \\mathbb{R}_{\\ge 0}$ and all operations taken in $\\mathbb{R}_{\\ge 0}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["elementary symmetric polynomial", "Maclaurin mean", "NNReal.rpow", "powersetCard"],
+    "prerequisites": ["symmetric polynomials", "NNReal arithmetic"]
+  },
+  {
+    "id": "ann-coe-intertwiners",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "The coercion intertwiners",
+    "content": "`coe_elemSymmNN` and `coe_maclaurinMeanNN` are the heart of the transfer: they show the coercion (↑) : ℝ≥0 → ℝ commutes with both constructions. Each is a one-line `simp` that pushes the cast through finite sums/products (`NNReal.coe_sum`, `NNReal.coe_prod`), division (`NNReal.coe_div`), natural-number cast (`NNReal.coe_natCast`) and rpow (`NNReal.coe_rpow`). The result `↑(maclaurinMeanNN k x) = maclaurinMean k (↑∘x)` turns the whole transfer into a rewrite.",
+    "mathContext": "$\\uparrow(M_k^{\\mathbb{R}_{\\ge0}}(x)) = M_k^{\\mathbb{R}}(\\uparrow \\circ\\, x)$. Because the coercion is a ring homomorphism commuting with rpow, applying $M_k$ then coercing equals coercing then applying $M_k$ — the mean construction is natural in the base semiring.",
+    "significance": "key",
+    "relatedConcepts": ["coercion lemmas", "norm_cast", "naturality", "ring embedding"],
+    "prerequisites": ["NNReal coercion", "simp lemmas"]
+  },
+  {
+    "id": "ann-transfer-chain",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 116, "endLine": 124 },
+    "type": "insight",
+    "title": "Step 3 — transferring the chain to NNReal",
+    "content": "`maclaurinMeanNN_chain` proves Mⱼ ≥ Mₖ over ℝ≥0. It rewrites the goal through `NNReal.coe_le_coe` (which reflects ≤) and the two intertwiners, reducing to the real chain on the coerced inputs; the non-negativity hypothesis is supplied automatically by `(x i).coe_nonneg`, and `maclaurin_full_chain_proved` closes it. No inequality is re-proved — the order fact simply pulls back along the embedding.",
+    "mathContext": "$M_j^{\\mathbb{R}_{\\ge0}}(x) \\ge M_k^{\\mathbb{R}_{\\ge0}}(x) \\iff M_k^{\\mathbb{R}}(\\uparrow\\!x) \\le M_j^{\\mathbb{R}}(\\uparrow\\!x)$, and every $x_i \\ge 0$ automatically, so the real chain applies verbatim.",
+    "significance": "key",
+    "relatedConcepts": ["order embedding", "NNReal.coe_le_coe", "transfer principle", "coe_nonneg"],
+    "prerequisites": ["order-preserving embeddings", "Maclaurin chain"]
+  },
+  {
+    "id": "ann-am-gm",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 126, "endLine": 130 },
+    "type": "insight",
+    "title": "Endpoint corollary: AM ≥ GM over NNReal",
+    "content": "`maclaurinMeanNN_am_ge_gm` specialises the chain to j = 1, k = n, recovering the classical arithmetic-mean–geometric-mean inequality over ℝ≥0: the first Maclaurin mean (the arithmetic mean) dominates the n-th (the geometric mean). It is a direct instance of `maclaurinMeanNN_chain`.",
+    "mathContext": "$M_1(x) \\ge M_n(x)$, i.e. $\\frac{1}{n}\\sum x_i \\ge \\left(\\prod x_i\\right)^{1/n}$, now for $x : \\mathrm{Fin}\\,n \\to \\mathbb{R}_{\\ge 0}$ — the endpoints of the Maclaurin ladder are exactly AM and GM.",
+    "significance": "key",
+    "relatedConcepts": ["AM-GM inequality", "arithmetic mean", "geometric mean", "Maclaurin endpoints"],
+    "prerequisites": ["AM-GM inequality", "Maclaurin means"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+  "title": "The Maclaurin Chain Extends to NNReal: M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ over ℝ≥0",
+  "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+  "description": "Resolves the parent's open question 'Does the Maclaurin chain extend to NNReal with suitable mean definitions?' Answer: Yes, and axiom-free. Defines the NNReal elementary symmetric polynomial and Maclaurin mean, shows the coercion ℝ≥0 ↪ ℝ intertwines them with the real definitions, and transfers a freshly rebuilt 0-axiom real chain (via the de-axiomatized maclaurin_step_proved) to ℝ≥0. Yields Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n and the endpoint AM ≥ GM over NNReal.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "inequalities",
+      "maclaurin",
+      "symmetric-functions",
+      "nnreal",
+      "am-gm"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "assumptions": "0 axioms, 0 sorries. The NNReal chain is proved without routing through the parent AmgmInequalityOQ02OQ03OQ03.maclaurin_full_chain (which sits on the maclaurin_step axiom); instead the real chain is rebuilt in-file (maclaurin_full_chain_proved) by gap-induction on the de-axiomatized AmgmInequalityOQ02OQ03.maclaurin_step_proved — proved from first principles (Newton log-concavity via Cauchy-Schwarz) in AmgmInequalityOQ02OQ02.lean — and then transferred to ℝ≥0. #print axioms lists only the foundational propext / Classical.choice / Quot.sound.",
+    "originalContributions": [
+      "Answers the open question affirmatively for NNReal: the Maclaurin chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ extends verbatim to ℝ≥0, and the extension is axiom-free",
+      "Defines the NNReal elementary symmetric polynomial elemSymmNN and Maclaurin mean maclaurinMeanNN = (elemSymmNN k x / C(n,k))^{1/k} using NNReal division and NNReal.rpow",
+      "Proves the coercion intertwiners coe_elemSymmNN and coe_maclaurinMeanNN: the ring embedding (↑) : ℝ≥0 → ℝ commutes with the symmetric-polynomial and Maclaurin-mean constructions, so ↑(maclaurinMeanNN k x) = maclaurinMean k (fun i => ↑(x i))",
+      "Transfers the chain along the order-embedding via NNReal.coe_le_coe (which reflects ≤), avoiding any re-proof of the underlying inequality; the endpoint corollary maclaurinMeanNN_am_ge_gm gives AM ≥ GM over NNReal",
+      "Rebuilds the real Maclaurin chain 0-axiom (maclaurin_full_chain_proved) from the de-axiomatized step, so the NNReal result never inherits the newton_log_concavity axiom of the original parent chain"
+    ],
+    "prerequisites": [
+      "Elementary symmetric polynomials e_k and the normalized Maclaurin means M_k = (e_k/C(n,k))^{1/k} (from AmgmInequalityOQ02)",
+      "The de-axiomatized Maclaurin step maclaurin_step_proved and its Cauchy-Schwarz-based log-concavity engine (AmgmInequalityOQ02OQ02, AmgmInequalityOQ02OQ03)",
+      "The NNReal type ℝ≥0, its order-preserving ring embedding into ℝ, and the coercion lemmas for sums, products, division, natCast and rpow",
+      "NNReal.rpow and its coercion to Real.rpow"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "NNReal.coe_le_coe",
+        "description": "The coercion ℝ≥0 → ℝ reflects and preserves the order: (↑a ≤ ↑b) ↔ (a ≤ b). This is the order-embedding property that lets the real chain transfer to NNReal without re-proving the inequality.",
+        "module": "Mathlib.Data.NNReal.Defs"
+      },
+      {
+        "theorem": "NNReal.coe_rpow",
+        "description": "↑(x ^ y) = (↑x) ^ y for x : ℝ≥0, y : ℝ — the coercion commutes with NNReal.rpow, giving the outer 1/k power of the Maclaurin mean.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "NNReal.coe_sum / NNReal.coe_prod / NNReal.coe_div / NNReal.coe_natCast",
+        "description": "The coercion ℝ≥0 → ℝ commutes with finite sums, finite products, division, and natural-number casts. Together these make coe_elemSymmNN and coe_maclaurinMeanNN one-line simp calls.",
+        "module": "Mathlib.Data.NNReal.Defs"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Colin Maclaurin (1729) stated the mean chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, interpolating between the arithmetic mean (M₁) and the geometric mean (Mₙ), on top of Newton's log-concavity inequalities e_k² ≥ e_{k-1}e_{k+1}. Hardy-Littlewood-Pólya (Inequalities, 1934, §2.22) give the canonical proof. In a formal library one naturally wants the chain not only for real inputs but for the non-negative reals ℝ≥0 (NNReal), the type on which means, norms, and measure-theoretic quantities most often live. Because ℝ≥0 embeds into ℝ as an ordered subsemiring, the passage is a transfer question rather than a fresh analytic one — the content is entirely in checking that the mean construction commutes with the coercion.",
+    "problemStatement": "The parent chain theorem maclaurin_full_chain is stated for x : Fin n → ℝ with 0 ≤ x i. Does it extend to x : Fin n → ℝ≥0 with a suitable NNReal Maclaurin mean, and can the extension be made axiom-free (the parent chain depends transitively on the newton_log_concavity axiom)?",
+    "proofStrategy": "Three steps. (1) Rebuild the real chain axiom-free: maclaurin_full_chain_proved re-runs the parent's gap-induction but on the de-axiomatized step maclaurin_step_proved (whose engine is Cauchy-Schwarz, proved in AmgmInequalityOQ02OQ02), so it depends on no axiom. (2) Define the NNReal analogues elemSymmNN and maclaurinMeanNN, and prove the coercion intertwiners coe_elemSymmNN and coe_maclaurinMeanNN by pushing the ℝ≥0 → ℝ coercion through sums, products, division, natCast and rpow. (3) Transfer: rewrite the NNReal goal maclaurinMeanNN j x ≥ maclaurinMeanNN k x through NNReal.coe_le_coe and the intertwiners into the real chain on the coerced inputs (each x i casting to a non-negative real via NNReal.coe_nonneg), then close with maclaurin_full_chain_proved. The endpoint M₁ ≥ Mₙ (AM ≥ GM over NNReal) follows as a corollary.",
+    "keyInsights": [
+      "ℝ≥0 ↪ ℝ is an order-preserving ring embedding, so an inequality between two NNReal quantities is equivalent (via NNReal.coe_le_coe) to the same inequality between their real coercions — no re-proof needed",
+      "The mean construction commutes with the coercion: (↑) pushes through Σ, Π, /, natCast and rpow, so ↑(maclaurinMeanNN k x) = maclaurinMean k (↑∘x). This single equation is what turns the transfer into a rewrite",
+      "Every NNReal input casts to a non-negative real (NNReal.coe_nonneg), which is exactly the hypothesis the real chain requires — the non-negativity side condition is automatic on ℝ≥0",
+      "To keep the result axiom-free, one must NOT reuse the parent's maclaurin_full_chain (built on the maclaurin_step axiom); rebuilding the chain on maclaurin_step_proved costs one short induction and eliminates the axiom entirely",
+      "ENNReal is genuinely harder: the point ∞, indeterminate products 0·∞, and the ENNReal.rpow conventions at 0 and ∞ break the clean coercion, so the same transfer does not apply verbatim"
+    ],
+    "prerequisites": [
+      "Maclaurin means and elementary symmetric polynomials",
+      "The de-axiomatized Maclaurin step (Cauchy-Schwarz log-concavity)",
+      "The NNReal type and its order-embedding into ℝ",
+      "Coercion (norm_cast) lemmas for NNReal"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: The Question and Its Answer",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States the parent's open question — does the Maclaurin chain extend to NNReal? — and answers Yes, axiom-free, via the order-embedding ℝ≥0 ↪ ℝ. Explains why the transfer must rebuild the chain on the de-axiomatized step rather than reuse the parent's axiom-based maclaurin_full_chain, and flags ENNReal as harder future work.",
+      "mathContext": "M_k = (e_k/C(n,k))^{1/k}; the coercion ℝ≥0 → ℝ is an order-preserving ring embedding."
+    },
+    {
+      "id": "real-chain",
+      "title": "Step 1: The Real Chain, Rebuilt Axiom-Free",
+      "startLine": 64,
+      "endLine": 90,
+      "summary": "maclaurin_chain_aux_proved re-runs the parent's gap-induction on the de-axiomatized maclaurin_step_proved; maclaurin_full_chain_proved packages it as Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n with no axiom dependence.",
+      "mathContext": "Same statement as the parent's maclaurin_full_chain, but reducing to newton_log_concavity_proved (theorem) instead of newton_log_concavity (axiom)."
+    },
+    {
+      "id": "nnreal-defs",
+      "title": "Step 2: NNReal Definitions and Coercion Intertwiners",
+      "startLine": 92,
+      "endLine": 113,
+      "summary": "Defines elemSymmNN and maclaurinMeanNN over ℝ≥0, then proves coe_elemSymmNN and coe_maclaurinMeanNN — the coercion (↑) : ℝ≥0 → ℝ commutes with the symmetric-polynomial and Maclaurin-mean constructions (one-line simp calls pushing casts through Σ, Π, /, natCast, rpow).",
+      "mathContext": "↑(maclaurinMeanNN k x) = maclaurinMean k (fun i => ↑(x i))."
+    },
+    {
+      "id": "transfer",
+      "title": "Step 3: Transferring the Chain to NNReal",
+      "startLine": 114,
+      "endLine": 132,
+      "summary": "maclaurinMeanNN_chain rewrites the NNReal goal through NNReal.coe_le_coe and the intertwiners into the real chain on coerced inputs and closes with maclaurin_full_chain_proved. maclaurinMeanNN_am_ge_gm derives the endpoint M₁ ≥ Mₙ (AM ≥ GM over NNReal).",
+      "mathContext": "maclaurinMeanNN j x ≥ maclaurinMeanNN k x ⟺ maclaurinMean k (↑∘x) ≤ maclaurinMean j (↑∘x)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Maclaurin inequality chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ extends to NNReal with 0 axioms. Suitable NNReal definitions elemSymmNN and maclaurinMeanNN are given, the coercion ℝ≥0 ↪ ℝ is shown to intertwine them with the real definitions, and the chain transfers via NNReal.coe_le_coe from a freshly rebuilt axiom-free real chain. The corollary maclaurinMeanNN_am_ge_gm records AM ≥ GM over NNReal.",
+    "implications": "Confirms that the Maclaurin hierarchy is a property of the ordered semiring structure, not an artifact of working in ℝ: because ℝ≥0 is an ordered subsemiring, any order fact about non-negative real inputs pulls back to NNReal for free once the constructions are shown to commute with the coercion. This is the pattern by which many analytic inequalities (means, norms, measures) are best stated on ℝ≥0. The axiom-free rebuild also demonstrates that the NNReal statement need not inherit the maclaurin_step axiom of the original chain.",
+    "openQuestions": [
+      "Extend the chain to ENNReal (ℝ≥0∞). The obstructions are the point ∞, indeterminate products 0·∞ inside the symmetric polynomials, and the ENNReal.rpow conventions at 0 and ∞; a correct statement likely needs finiteness/positivity side conditions or a different mean normalization",
+      "State and prove the NNReal chain for the weighted Maclaurin means, matching the weighted power-mean development in the sibling AmgmInequalityOQ02OQ03OQ03OQ03",
+      "Provide a strict version over NNReal: M_j > M_k unless all x i are equal, transferring the equality-case analysis along the coercion"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "Parent full-chain file (over ℝ) whose openQuestions asked whether the chain extends to NNReal/ENNReal; this file answers the NNReal half affirmatively and axiom-free."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03",
+      "relationship": "derives-from",
+      "description": "Supplies maclaurin_step_proved, the de-axiomatized Maclaurin step on which the axiom-free real chain (and hence the NNReal transfer) is built."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Proves newton_log_concavity_proved and maclaurin_step_derived from first principles via Cauchy-Schwarz + induction — the axiom-free engine ultimately underlying this NNReal chain."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "derives-from",
+      "description": "Grandparent providing elemSymm, maclaurinMean, and the definitions mirrored on ℝ≥0 here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "maclaurin_full_chain_proved",
+      "type": "supporting",
+      "description": "The real Maclaurin chain Mⱼ ≥ Mₖ for 0 < j ≤ k ≤ n, rebuilt by gap-induction on the de-axiomatized maclaurin_step_proved so that it carries no axiom dependence.",
+      "leanType": "(x : Fin n → ℝ) → (∀ i, 0 ≤ x i) → (j k : ℕ) → 0 < j → j ≤ k → k ≤ n → maclaurinMean j x ≥ maclaurinMean k x"
+    },
+    {
+      "name": "coe_maclaurinMeanNN",
+      "type": "core",
+      "description": "The coercion intertwiner: ↑(maclaurinMeanNN k x) = maclaurinMean k (fun i => ↑(x i)). Pushes the ℝ≥0 → ℝ coercion through division, natCast, rpow and the symmetric polynomial — the equation that turns the transfer into a rewrite.",
+      "leanType": "(k : ℕ) (x : Fin n → ℝ≥0) → ((maclaurinMeanNN k x : ℝ≥0) : ℝ) = maclaurinMean k (fun i => (x i : ℝ))"
+    },
+    {
+      "name": "maclaurinMeanNN_chain",
+      "type": "core",
+      "description": "The Maclaurin chain over ℝ≥0: for 0 < j ≤ k ≤ n, maclaurinMeanNN j x ≥ maclaurinMeanNN k x. Proved axiom-free by transferring maclaurin_full_chain_proved along NNReal.coe_le_coe and the coercion intertwiners.",
+      "leanType": "(x : Fin n → ℝ≥0) → (j k : ℕ) → 0 < j → j ≤ k → k ≤ n → maclaurinMeanNN j x ≥ maclaurinMeanNN k x"
+    },
+    {
+      "name": "maclaurinMeanNN_am_ge_gm",
+      "type": "core",
+      "description": "The endpoint corollary M₁ ≥ Mₙ over ℝ≥0: the arithmetic mean dominates the n-th Maclaurin mean (the geometric mean) for NNReal inputs.",
+      "leanType": "(hn : 1 ≤ n) (x : Fin n → ℝ≥0) → maclaurinMeanNN 1 x ≥ maclaurinMeanNN n x"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Maclaurin, Colin",
+      "title": "A Second Letter to Martin Folkes, Esq.; concerning the Roots of Equations",
+      "year": "1729",
+      "venue": "Philosophical Transactions of the Royal Society, Vol. 36, pp. 59–96",
+      "doi": "10.1098/rstl.1729.0011",
+      "note": "Original statement of the Maclaurin mean chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ, here extended to ℝ≥0."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "§2.22 (Theorem 52): the canonical means proof of the Maclaurin chain via the power inequality a_k^{k+1} ≥ a_{k+1}^k; the engine is Cauchy-Schwarz log-concavity."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "NNReal and its order-embedding into ℝ (Mathlib.Data.NNReal.Defs)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/NNReal/Defs.html",
+      "note": "NNReal.coe_le_coe, NNReal.coe_sum, NNReal.coe_prod, NNReal.coe_div, NNReal.coe_natCast: the order-embedding and coercion lemmas driving the transfer."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "NNReal.rpow and its coercion (Mathlib.Analysis.SpecialFunctions.Pow.NNReal)",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.html",
+      "note": "NNReal.coe_rpow: ↑(x ^ y) = (↑x) ^ y, used to coerce the 1/k power of the NNReal Maclaurin mean."
+    }
+  ],
+  "leanFile": {
+    "namespace": "AmgmInequalityOQ02OQ03OQ03OQ02",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean",
+    "sorries": 0,
+    "imports": [
+      "Proofs.AmgmInequalityOQ02OQ03"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-03-oq-03-oq-02` (quality 43, pass 0).

**Gap addressed:** the entry had a very rich `meta.json` but **no `annotations.json`** (0 inline annotation coverage).

**Added:** a new `annotations.json` with 7 annotations giving full line-range coverage of the Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- imports / NNReal scope and axiom hygiene
- `maclaurin_chain_aux_proved` — gap-induction on the axiom-free step
- `maclaurin_full_chain_proved` — Step 1, real chain rebuilt axiom-free (key)
- `elemSymmNN` / `maclaurinMeanNN` — Step 2 NNReal definitions
- `coe_elemSymmNN` / `coe_maclaurinMeanNN` — the coercion intertwiners (key)
- `maclaurinMeanNN_chain` — Step 3 transfer along ℝ≥0 ↪ ℝ (key)
- `maclaurinMeanNN_am_ge_gm` — endpoint AM ≥ GM over NNReal (key)

No changes to `meta.json` (already under all size caps). Axiom/status fields verified accurate against the Lean source (0 axioms, 0 sorries, `verified`).
