### PR TITLE
Enrich fundamental-theorem-calculus: prerequisites for all 9 annotations

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus/annotations.json
@@ -15,6 +15,11 @@
       "definite integral",
       "area under curve",
       "accumulation function"
+    ],
+    "prerequisites": [
+      "the definite integral ∫ₐˣ f(t) dt",
+      "area under a curve",
+      "functions of a variable upper limit"
     ]
   },
   {
@@ -33,6 +38,11 @@
       "antiderivative",
       "HasDerivAt",
       "differentiability"
+    ],
+    "prerequisites": [
+      "derivatives and HasDerivAt",
+      "the integral as an accumulation function",
+      "continuity of the integrand"
     ]
   },
   {
@@ -51,6 +61,11 @@
       "continuity",
       "ContinuousAt",
       "limit definition"
+    ],
+    "prerequisites": [
+      "continuity at a point (ContinuousAt)",
+      "limits and average value on shrinking intervals",
+      "why discontinuities break differentiability of F"
     ]
   },
   {
@@ -69,6 +84,11 @@
       "antiderivative",
       "evaluation",
       "net change"
+    ],
+    "prerequisites": [
+      "antiderivatives",
+      "the definite integral as net change",
+      "evaluating F(b) − F(a)"
     ]
   },
   {
@@ -87,6 +107,11 @@
       "differentiability",
       "ContinuousOn",
       "interval conditions"
+    ],
+    "prerequisites": [
+      "differentiability on an interval",
+      "continuity/integrability of F′ (ContinuousOn)",
+      "ordered integration bounds a ≤ b"
     ]
   },
   {
@@ -105,6 +130,11 @@
       "derivative",
       "indefinite integral",
       "primitive function"
+    ],
+    "prerequisites": [
+      "the derivative F′ = f",
+      "indefinite integrals and the constant of integration",
+      "primitive / antiderivative"
     ]
   },
   {
@@ -123,6 +153,11 @@
       "mean value theorem",
       "constant function",
       "uniqueness"
+    ],
+    "prerequisites": [
+      "the mean value theorem",
+      "a function with zero derivative is constant",
+      "antiderivatives differ by a constant"
     ]
   },
   {
@@ -141,6 +176,11 @@
       "mean value theorem",
       "constant function",
       "convexity"
+    ],
+    "prerequisites": [
+      "the mean value theorem",
+      "constant functions",
+      "F′ = 0 ⟹ F constant"
     ]
   },
   {
@@ -160,6 +200,11 @@
       "Newton",
       "Leibniz",
       "calculus unification"
+    ],
+    "prerequisites": [
+      "FTC Parts 1 and 2",
+      "differentiation and integration as inverse operations",
+      "the history of Newton and Leibniz"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for the `fundamental-theorem-calculus` classic.

None of the 9 annotations had `prerequisites`. Added 3 content-specific prerequisites to each — matched to the annotation (the accumulation function, FTC Part 1 / continuity, FTC Part 2 / its conditions, antiderivatives + the constant of integration, uniqueness via MVT, zero-derivative⟹constant, and the inverse-operations unity of calculus).

Additions only — no `type`/`content`/range changes. `meta.json` untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)