### PR TITLE
Enrich predicative/propext-free Cantor: add annotations (7 items, full coverage)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-lawvere",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 86, "endLine": 91 },
+    "type": "insight",
+    "title": "Lawvere's fixed-point theorem (constructive)",
+    "content": "`lawvere` is the categorical heart of every diagonal argument: if `e : A → (A → B)` is surjective then every `f : B → B` has a fixed point. The proof is one line — apply surjectivity to the diagonal `fun a => f (e a a)` to get a₀ with `e a₀ = fun a => f (e a a)`, then `e a₀ a₀` is the fixed point. It eliminates a single surjectivity witness into an ∃-goal, so it uses neither `Classical.choice` nor `propext`.",
+    "mathContext": "If $e$ is point-surjective then for any $f : B \\to B$ there is $b$ with $f(b) = b$. The diagonal $d(a) = f(e(a)(a))$ is hit by some $a_0$, and $b = e(a_0)(a_0)$ satisfies $f(b) = e(a_0)(a_0) = b$.",
+    "significance": "key",
+    "relatedConcepts": ["Lawvere fixed-point theorem", "diagonal argument", "point-surjectivity", "constructive logic"],
+    "prerequisites": ["surjective functions", "fixed points", "cartesian closed structure"]
+  },
+  {
+    "id": "ann-fpf-def",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 93, "endLine": 94 },
+    "type": "definition",
+    "title": "Fixed-point-free endomorphisms",
+    "content": "`FixedPointFree g := ∀ b, g b ≠ b` isolates the single hypothesis that powers every diagonal/Cantor argument. The whole family (Cantor, Russell, Gödel, Turing) is parameterized by a choice of fixed-point-free endomorphism of the alphabet.",
+    "mathContext": "$g : B \\to B$ is fixed-point-free iff $g(b) \\neq b$ for all $b$. Contrapositive of Lawvere: a fixed-point-free $g$ certifies that no point-surjection $A \\to (A \\to B)$ exists.",
+    "significance": "supporting",
+    "relatedConcepts": ["endomorphism", "fixed point", "self-reference"],
+    "prerequisites": ["functions", "predicates"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 101, "endLine": 106 },
+    "type": "insight",
+    "title": "The contrapositive engine",
+    "content": "`no_surjection_of_fpf` is the reusable core: given any fixed-point-free `g : B → B`, no `e : A → (A → B)` can be surjective. The proof assumes a surjection, feeds it and `g` to `lawvere` to obtain a fixed point `b` with `g b = b`, then contradicts fixed-point-freeness. Every concrete Cantor-type theorem in the file is an instance obtained by picking `g`.",
+    "mathContext": "For arbitrary alphabet $B$: $\\exists g\\, \\text{FixedPointFree}(g) \\implies \\neg\\,\\text{Surjective}(e)$ for all $e : A \\to (A \\to B)$. This is the abstract statement unifying Cantor, Russell, Gödel and Turing.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "self-referential paradoxes", "universality of diagonalization"],
+    "prerequisites": ["Lawvere fixed-point theorem", "proof by contradiction"]
+  },
+  {
+    "id": "ann-bool-neg",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 113, "endLine": 121 },
+    "type": "technique",
+    "title": "Boolean negation as the predicative fixed-point-free map",
+    "content": "`not_fixedPointFree` proves boolean negation `(!·)` has no fixed point by `cases b <;> decide` — a pure two-case computation, no axiom. `no_surjection_to_bool` then instantiates the engine: no surjection `A → (A → Bool)`. Because `A → Bool : Type u` lives in the same universe as `A`, this is the predicative Cantor no-surjection direction with no impredicative `Prop` and no `propext`.",
+    "mathContext": "$!\\,b \\neq b$ for $b \\in \\{\\texttt{true}, \\texttt{false}\\}$, so negation is fixed-point-free and rules out any surjection onto $A \\to \\mathrm{Bool}$. Bool replaces Prop as the two-valued alphabet, keeping everything in $\\mathrm{Type}\\,u$.",
+    "significance": "key",
+    "relatedConcepts": ["boolean negation", "decide", "predicativity", "impredicative Prop"],
+    "prerequisites": ["Bool vs Prop", "decidability", "universes"]
+  },
+  {
+    "id": "ann-embed",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 123, "endLine": 135 },
+    "type": "insight",
+    "title": "The propext-free characteristic embedding",
+    "content": "`embed_bool a := fun x => decide (x = a)` is the decidable characteristic function of {a}, giving the injection direction. `embed_bool_injective` proves it injective purely by computation: evaluate the hypothesis at `a` to get `decide (a = a) = decide (a = a')`, rewrite via `decide_eq_decide` to `(a = a) ↔ (a = a')`, and apply `.mp rfl`. This `decide` step is the exact place the Prop version secretly used `propext` (to turn `(· = a) = (· = a')` into `a = a'`).",
+    "mathContext": "The embedding $a \\mapsto (x \\mapsto \\mathrm{decide}(x = a))$ is injective because $\\mathrm{decide}(a=a) = \\mathrm{decide}(a=a') \\iff (a=a \\leftrightarrow a=a') \\implies a = a'$ — a decidable computation, whereas the Prop embedding $a \\mapsto (\\cdot = a)$ needs propositional extensionality.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic function", "decidable equality", "decide_eq_decide", "propositional extensionality"],
+    "prerequisites": ["DecidableEq", "injectivity", "propext"]
+  },
+  {
+    "id": "ann-predicative-cantor",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 137, "endLine": 143 },
+    "type": "insight",
+    "title": "Predicative Cantor: the strict increase, both directions",
+    "content": "`predicative_cantor` bundles the two halves: for any `A` with decidable equality there exists an injection `A ↪ (A → Bool)` (via `embed_bool`) but no surjection (via `no_surjection_to_bool`). This is a genuine, constructively witnessed strict cardinality increase `A < (A → Bool)` realized by explicit maps, entirely inside `Type u`, using neither impredicative `Prop` nor `propext`.",
+    "mathContext": "$A < (A \\to \\mathrm{Bool})$ as a pair: an explicit injection exists and every map $A \\to (A \\to \\mathrm{Bool})$ fails surjectivity — a strict inequality, not merely a cardinal $\\le$, stated predicatively.",
+    "significance": "key",
+    "relatedConcepts": ["strict cardinality increase", "Cantor's theorem", "constructive witness"],
+    "prerequisites": ["injective and surjective functions", "power sets"]
+  },
+  {
+    "id": "ann-general-alphabet",
+    "proofId": "cantor-diagonalization-oq-03-oq-02",
+    "range": { "startLine": 145, "endLine": 169 },
+    "type": "insight",
+    "title": "Arbitrary decidable alphabets: two values suffice, and ℕ",
+    "content": "Part 4 abstracts the two ingredients. `embed_of_two` shows the injection needs only two distinct alphabet values `b₀ ≠ b₁` via the if-then-else characteristic function (still propext-free, discharged by `if_pos`/`if_neg` and `by_contra`). `succ_fixedPointFree` gives the successor `n ↦ n+1` as a fixed-point-free endomorphism of ℕ (`Nat.succ_ne_self`), and `no_surjection_to_nat` instantiates the engine over the infinite alphabet ℕ — showing `no_surjection_of_fpf` is uniform in the alphabet, not special to Bool.",
+    "mathContext": "Injection into $A \\to B$ needs only $b_0 \\neq b_1$ in $B$; no-surjection needs only a fixed-point-free $g : B \\to B$. Over $B = \\mathbb{N}$ the successor $n \\mapsto n+1$ works ($n+1 \\neq n$), giving $\\neg\\,\\text{Surjective}(e)$ for $e : A \\to (A \\to \\mathbb{N})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["alphabet generality", "successor function", "Nat.succ_ne_self", "if-then-else characteristic function"],
+    "prerequisites": ["decidable equality", "natural numbers", "fixed-point-free maps"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "cantor-diagonalization-oq-03-oq-02",
+  "slug": "cantor-diagonalization-oq-03-oq-02",
+  "title": "A Constructive, Predicative, Propext-Free Lawvere/Cantor Theorem",
+  "description": "The parent entry (cantor-diagonalization-oq-03) proves Cantor's theorem through Lawvere's fixed-point theorem using the impredicative power type A → Prop. Its open question 2 asks whether there is a constructive analogue of Lawvere's theorem that works in a predicative type theory without propositional extensionality. This entry answers yes and pins down the content: replacing Prop by the two-element data type Bool removes both the impredicativity (A → Bool : Type u lives in the same universe as A : Type u) and the reliance on propositional extensionality (the natural embedding A ↪ (A → Prop), a ↦ (· = a), is injective only via propext, whereas the Bool embedding a ↦ fun x => decide (x = a) is injective by a pure `decide` computation). Combined with the (already constructive) Lawvere fixed-point theorem, this gives a strict cardinality increase A < (A → Bool) that stays inside a single universe and uses neither impredicative Prop nor propext. A general engine (any fixed-point-free endomorphism of the alphabet forbids a surjection) recovers the classical statement over Bool and over ℕ. Fully verified, 0 axioms.",
+  "overview": {
+    "historicalContext": "Cantor's 1891 diagonal argument showed no set surjects onto its power set. In 1969 F. W. Lawvere recast this and its relatives (Russell's paradox, Gödel's incompleteness, Turing's halting problem) as a single categorical fact: in a cartesian closed category, if there is a 'surjective' (point-surjective) map A → Bᴬ, then every endomorphism of B has a fixed point — so a *fixed-point-free* endomorphism of B rules such a map out. Yanofsky (2003) popularized the set-theoretic reading used here, where the fixed-point-free endomorphism is the moving part shared by every diagonal argument. The parent entry formalizes this over the power type A → Prop. But Prop = Sort 0 is impredicative (a ∀ over all Props is again a Prop), so A → Prop is the 'full' power set, and the standard injection a ↦ (· = a) is injective only via propositional extensionality. Predicativity — the doctrine, traceable to Poincaré, Russell and Weyl and realized in Martin-Löf type theory, that a definition may not quantify over a totality it belongs to — and the constructive suspicion of propext (an axiom in Lean, not a theorem, and not assumed in Book HoTT) motivate asking for a diagonal argument that avoids both. This entry supplies one.",
+    "problemStatement": "Open question 2 of the parent: is there a constructive analogue of Lawvere's fixed-point theorem — and hence of Cantor's theorem — that works in a predicative type theory and does not use propositional extensionality? Concretely, can the strict inequality A < (power of A) be witnessed by an explicit injection and a no-surjection proof that (i) keep the codomain in the same universe Type u as A, and (ii) invoke neither impredicative Prop nor propext?",
+    "proofStrategy": "Keep Lawvere's diagonal proof verbatim — it eliminates a single surjectivity witness into an ∃-goal and so is already choice-free and propext-free — and isolate its engine: a fixed-point-free g : B → B forbids any surjection A → (A → B) (no_surjection_of_fpf), for an arbitrary alphabet B. Then replace the alphabet Prop by the two-element data type Bool. This kills impredicativity (A → Bool : Type u) for free, and boolean negation (!·) supplies the fixed-point-free endomorphism, giving the no-surjection direction. For the injection direction, use the decidable characteristic function a ↦ fun x => decide (x = a); its injectivity is discharged by decide_eq_decide — a pure Bool computation — replacing the propext step needed for a ↦ (· = a) over Prop. Bundle both directions into predicative_cantor, then abstract the two ingredients (two distinct decidable values for the embedding; a fixed-point-free endomorphism for the no-surjection) to arbitrary alphabets, instantiating over ℕ with the successor to show the engine is not special to Bool.",
+    "keyInsights": [
+      "The entire Cantor/Russell/Gödel/Turing phenomenon factors through one abstract hypothesis — a fixed-point-free endomorphism of the alphabet — exposed here as no_surjection_of_fpf; every concrete diagonal argument is just a choice of that endomorphism (boolean ! for Bool, successor for ℕ, the swap for the halting problem).",
+      "Swapping the alphabet Prop for Bool simultaneously removes two logical commitments: impredicativity (A → Bool lives in Type u, the same universe as A) and propositional extensionality — they are entangled in the Prop development but neither is essential to the diagonal.",
+      "Injectivity of the characteristic-function embedding is the only place the Prop version secretly used propext (to turn (· = a) = (· = a') into a = a'); over Bool the same step becomes decide (a = a) = decide (a = a') ↦ (a = a) ↔ (a = a'), a decidable computation with no extensionality axiom.",
+      "The result is a genuine strict cardinality increase A < (A → Bool) realized inside a single universe by explicit maps (an injection that exists and a surjection that cannot), rather than a mere cardinal inequality — a constructively meaningful strengthening.",
+      "Only decidable equality on A is required for the injection, and only two distinct alphabet values plus a fixed-point-free map for the no-surjection; nothing about Bool beyond these is used, which is why embed_of_two and the ℕ instance follow immediately."
+    ],
+    "prerequisites": [
+      "Cantor's diagonal argument and the notion of a power type / characteristic function",
+      "Lawvere's fixed-point theorem and the idea of a fixed-point-free endomorphism",
+      "Decidable equality, decide, and the Bool vs Prop distinction in Lean/type theory",
+      "Predicativity and the status of propositional extensionality as a non-constructive axiom",
+      "Injective / Surjective functions and universes (Type u)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Logic.Function.Basic",
+      "Mathlib.Data.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Function"
+    ],
+    "namespace": "CantorDiagonalizationOQ03OQ02",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lawvere%27s_fixed-point_theorem",
+    "date": null,
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ02.lean",
+    "tags": [
+      "cantor",
+      "lawvere-fixed-point",
+      "diagonal-argument",
+      "constructivism",
+      "predicativity",
+      "propositional-extensionality",
+      "type-theory",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Function.Surjective",
+        "description": "Surjectivity of the evaluation map e : A → (A → B), the hypothesis of Lawvere's theorem",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "Function.Injective",
+        "description": "Injectivity of the predicative embedding A ↪ (A → Bool), giving the strict-inequality direction",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "decide_eq_decide",
+        "description": "decide p = decide q ↔ (p ↔ q) — reduces injectivity of the Bool characteristic-function embedding to a decidable computation, avoiding propext",
+        "module": "Mathlib.Logic.Basic"
+      },
+      {
+        "theorem": "Nat.succ_ne_self",
+        "description": "n + 1 ≠ n — the fixed-point-free witness for the ℕ-alphabet instance of the no-surjection engine",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "lawvere: the Lawvere fixed-point theorem restated self-contained — a surjection e : A → (A → B) forces every f : B → B to have a fixed point, by the one-line diagonal argument (constructive: no Classical.choice, no propext)",
+      "FixedPointFree: the predicate that an endomorphism moves every element, isolating the exact hypothesis that drives every diagonal/Cantor argument",
+      "no_surjection_of_fpf: the contrapositive engine — any fixed-point-free g : B → B rules out every surjection A → (A → B), for an arbitrary alphabet B",
+      "not_fixedPointFree: boolean negation (! ·) has no fixed point (by decide)",
+      "no_surjection_to_bool: predicative Cantor — no surjection A → (A → Bool), with codomain A → Bool : Type u in the same universe as A (no impredicative Prop, no propext)",
+      "embed_bool / embed_bool_injective: the predicative embedding a ↦ fun x => decide (x = a) : A → (A → Bool) and its injectivity discharged by a pure decide computation — the propext-free substitute for the propext-dependent injectivity of a ↦ (· = a) : A → (A → Prop)",
+      "predicative_cantor: bundles the two directions — for A with decidable equality there is an injection A ↪ (A → Bool) but no surjection, i.e. a strict cardinality increase entirely within Type u",
+      "embed_of_two: the embedding generalized to any alphabet with two distinct decidable values (still propext-free)",
+      "succ_fixedPointFree / no_surjection_to_nat: an arbitrary-alphabet instance of the engine over ℕ via the fixed-point-free successor, showing the engine is not special to Bool"
+    ],
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axiom declarations. The Bool development is designed to avoid propositional extensionality: injectivity of the characteristic-function embedding is proved by `decide` rather than `propext`. Beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound — none of which is used in an essential, entry-specific way) the proofs introduce no assumptions. No native_decide.",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-03",
+      "relationship": "extends",
+      "description": "Parent: Lawvere fixed-point theorem and Cantor's theorem via the impredicative power type A → Prop. This entry answers the parent's open question 2 by giving the predicative, propositional-extensionality-free analogue over Bool, and isolates exactly which features of the Prop development (impredicativity of Prop, propext-dependence of the a ↦ (· = a) embedding) are removed."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling OQ in the Lawvere chain: the categorical generalization (abstract evaluation structures / topos setting, answering open question 1). Where oq-01 abstracts Lawvere upward to categorical generality, this oq-02 moves in the foundational direction — down to a predicative, propext-free type theory — so the two siblings bracket the parent from opposite sides."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "The root Cantor diagonalization entry. This entry recovers the classical 'no surjection onto the power set' as the special case where the alphabet is Bool and the fixed-point-free endomorphism is boolean negation, but strengthens it to an explicit injection-plus-no-surjection strict inequality within a single universe."
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "The halting problem is the Lawvere instance with a two-valued alphabet ({halt, loop} ≅ Bool) and the fixed-point-free swap. This entry's Bool engine (not_fixedPointFree + no_surjection_of_fpf) is exactly the diagonal core of that undecidability argument, phrased predicatively."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lawvere, F. William",
+      "title": "Diagonal arguments and cartesian closed categories",
+      "year": "1969",
+      "venue": "Category Theory, Homology Theory and their Applications II, Springer LNM 92, pp. 134-145",
+      "note": "The original categorical fixed-point theorem underlying Cantor, Russell, Gödel and Turing"
+    },
+    {
+      "authors": "Yanofsky, Noson S.",
+      "title": "A Universal Approach to Self-Referential Paradoxes, Incompleteness and Fixed Points",
+      "year": "2003",
+      "venue": "The Bulletin of Symbolic Logic, vol. 9, no. 3, pp. 362-386",
+      "note": "Unifies the diagonal arguments; the fixed-point-free-endomorphism formulation used here is its central abstraction"
+    },
+    {
+      "authors": "Univalent Foundations Program",
+      "title": "Homotopy Type Theory: Univalent Foundations of Mathematics",
+      "year": "2013",
+      "venue": "Institute for Advanced Study",
+      "note": "Discusses predicativity and the status of propositional extensionality / impredicative Prop, the foundational setting this entry's Bool development targets"
+    }
+  ],
+  "conclusion": {
+    "summary": "Open question 2 of the parent Lawvere/Cantor entry is answered affirmatively and constructively. Replacing the impredicative alphabet Prop with the two-element data type Bool yields a diagonal argument that lives entirely within a single universe (A → Bool : Type u) and uses no propositional extensionality: the injection a ↦ fun x => decide (x = a) is injective by a decide computation, and the no-surjection direction comes from the fixed-point-free boolean negation feeding Lawvere's (already choice-free) theorem. The two directions bundle into a strict, constructively witnessed cardinality increase A < (A → Bool). Fully machine-checked, 0 sorries, 0 axioms, no native_decide. 9 theorems and 2 definitions in 171 lines.",
+    "implications": "The proof identifies precisely which logical commitments the classical Cantor/Lawvere development can shed: impredicative Prop and propext are conveniences, not necessities, for the diagonal. By isolating the engine no_surjection_of_fpf — any fixed-point-free endomorphism of the alphabet forbids a surjection — the entry makes the shared core of Cantor, Russell, Gödel and Turing available in a predicative, constructive setting, and the ℕ and general two-value instances show the argument is uniform in the alphabet. This is the kind of result that transfers to predicative foundations (Martin-Löf type theory, univalent foundations without propositional resizing) where A → Prop is not the well-behaved power object.",
+    "openQuestions": [
+      "Cast the strict increase as a formal inequality of predicative cardinalities / h-levels (e.g. in a HoTT setting), rather than the injection-exists-but-no-surjection pair used here.",
+      "Characterize exactly which alphabets B admit the strengthening to an injection A ↪ (A → B): decidable equality on A plus two distinct decidable B-values suffice (embed_of_two), but is decidability of B-equality necessary?",
+      "Reconstruct the full Cantor–Schröder–Bernstein-free 'strictly increasing tower' A < (A → Bool) < ((A → Bool) → Bool) < ⋯ predicatively, tracking that each step stays in Type u.",
+      "Relate the propext-free Bool embedding to the univalence-based treatment of the power set (Ω-valued predicates) and quantify the exact use of propositional resizing avoided."
+    ]
+  },
+  "sections": [
+    {
+      "title": "The open question and why Prop is impredicative / propext-dependent",
+      "startLine": 1,
+      "endLine": 71,
+      "summary": "The docstring states open question 2 of the parent — is there a predicative, propext-free constructive Lawvere/Cantor theorem? — and diagnoses the two avoidable features of the A → Prop development: impredicativity of Prop = Sort 0, and the propext-dependence of the injection a ↦ (· = a). It explains that switching the alphabet to Bool removes both (A → Bool : Type u; injectivity by decide) and lists the results to follow."
+    },
+    {
+      "title": "Part 1 — Lawvere's fixed-point theorem (constructive)",
+      "startLine": 81,
+      "endLine": 94,
+      "summary": "lawvere: a surjection e : A → (A → B) forces every f : B → B to have a fixed point, via the one-line diagonal a₀ with e a₀ = (fun a => f (e a a)); the proof eliminates a single surjectivity witness into an ∃-goal, so it uses neither Classical.choice nor propext. FixedPointFree g := ∀ b, g b ≠ b isolates the hypothesis that drives every diagonal argument."
+    },
+    {
+      "title": "Part 2 — The contrapositive engine",
+      "startLine": 96,
+      "endLine": 106,
+      "summary": "no_surjection_of_fpf: if some g : B → B is fixed-point free then there is no surjection A → (A → B), for an arbitrary alphabet B. This is the whole Cantor/Russell phenomenon isolated — the classical statements are all instances obtained by choosing g."
+    },
+    {
+      "title": "Part 3 — The predicative alphabet Bool",
+      "startLine": 108,
+      "endLine": 143,
+      "summary": "not_fixedPointFree: boolean negation (!·) has no fixed point (by decide). no_surjection_to_bool: predicative Cantor's no-surjection direction, with codomain A → Bool in the same universe as A and no propext. embed_bool a := fun x => decide (x = a) is the decidable characteristic embedding; embed_bool_injective proves it injective via decide_eq_decide, the propext-free substitute. predicative_cantor bundles the injection-exists / no-surjection pair into a strict growth within Type u."
+    },
+    {
+      "title": "Part 4 — Arbitrary decidable alphabets",
+      "startLine": 145,
+      "endLine": 171,
+      "summary": "embed_of_two: the embedding generalized to any alphabet with two distinct values b₀ ≠ b₁ via the if-then-else characteristic function, still propext-free. succ_fixedPointFree: the successor on ℕ is fixed-point free (n + 1 ≠ n). no_surjection_to_nat: Cantor over the alphabet ℕ, an infinite-alphabet instance of the engine, demonstrating that no_surjection_of_fpf is uniform in the alphabet."
+    }
+  ]
+}


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-03-oq-02` (quality 45, pass 0).

**Gap addressed:** rich `meta.json`, but **no `annotations.json`** (0 inline coverage).

**Added:** `annotations.json` with 7 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- `lawvere` — constructive Lawvere fixed-point theorem (key)
- `FixedPointFree` — the driving hypothesis
- `no_surjection_of_fpf` — the contrapositive engine (key)
- `not_fixedPointFree` / `no_surjection_to_bool` — Bool as predicative alphabet (key)
- `embed_bool` / `embed_bool_injective` — the propext-free embedding (key)
- `predicative_cantor` — strict increase A < (A → Bool), both directions (key)
- `embed_of_two` / `succ_fixedPointFree` / `no_surjection_to_nat` — arbitrary alphabets

No changes to `meta.json` (18 KB, under caps). Axiom/status verified against the Lean source (0 axioms, 0 sorries, no native_decide, `verified`).
