### PR TITLE
Enrich inverse-Galois OQ-04-02 (Kummer–Dedekind input): add annotations

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Setup: the two abstract Kummer–Dedekind bricks and the concrete quintic",
+    "content": "The file imports the verified factorization keystone `InverseGaloisA5DedekindMod7` (giving q mod 7 and `cubic7`) and the two abstract bricks `DedekindKummerStep1` and `DedekindKummerToTower`. Both bricks assume a hypothesis `Q ∈ monicFactorsMod θ p`; the whole point of this file is to discharge that hypothesis concretely for θ = α (root of the A₅ quintic), p = 7, Q = cubic7.",
+    "mathContext": "The A₅ quintic is $q = X^5 - 5X^4 + 10X^3 - 10X^2 + 25X - 5$. Its Galois-realizability reduces to $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$, provable by a Kummer–Dedekind factorization route.",
+    "significance": "context",
+    "relatedConcepts": ["inverse Galois problem", "Kummer–Dedekind theorem", "A₅ realizability", "inertia degree"],
+    "prerequisites": ["algebraic number theory", "Galois theory"]
+  },
+  {
+    "id": "ann-poly-facts",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "technique",
+    "title": "Self-contained (ZMod 7)[X] facts: monic, divides, nonzero",
+    "content": "`qInt_monic` and `cubic7_monic` are discharged by `monicity!` on the explicit polynomials. `cubic7_dvd` reads the divisibility straight off the verified factorization `q mod 7 = (X−5)(X−6)·cubic7` via `dvd_mul_left`. `qIntMap_ne_zero` uses that a monic polynomial maps to a nonzero polynomial over the nontrivial ring (ZMod 7)[X].",
+    "mathContext": "$q \\bmod 7 = (X-5)(X-6)\\,\\mathrm{cubic7}$ with $\\mathrm{cubic7} = X^3 + 6X^2 + 4X + 1$. Monicity, divisibility, and nonvanishing are the three ingredients `mem_normalizedFactors_iff` will consume.",
+    "significance": "supporting",
+    "relatedConcepts": ["monic polynomial", "polynomial divisibility", "reduction mod p", "monicity! tactic"],
+    "prerequisites": ["polynomials over finite fields"]
+  },
+  {
+    "id": "ann-normalized-factor",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "insight",
+    "title": "The arithmetic keystone: cubic7 is a normalized factor",
+    "content": "`cubic7_mem_normalizedFactors` is the mathematical crux, stated entirely inside (ZMod 7)[X] with no number field. It applies `Polynomial.mem_normalizedFactors_iff` (for a nonzero polynomial over a field, `p ∈ normalizedFactors q ↔ Irreducible p ∧ p.Monic ∧ p ∣ q`) to the irreducible/monic/divides trio. Monicity is what upgrades 'irreducible factor' to 'normalized factor' — over a field a monic polynomial is already `normalize`-fixed.",
+    "mathContext": "$\\mathrm{cubic7} \\in \\mathrm{normalizedFactors}(q \\bmod 7)$: it is irreducible (a rootless cubic over a field), monic (hence normalized), and divides $q \\bmod 7$.",
+    "significance": "key",
+    "relatedConcepts": ["normalizedFactors", "mem_normalizedFactors_iff", "unique factorization", "irreducible polynomial"],
+    "prerequisites": ["unique factorization domains", "normalization in a field"]
+  },
+  {
+    "id": "ann-monic-factors-mod",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 81, "endLine": 100 },
+    "type": "insight",
+    "title": "Lifting to the number field: cubic7 ∈ monicFactorsMod α 7",
+    "content": "`cubic7_mem_monicFactorsMod` delivers exactly the hypothesis both bricks assume. `monicFactorsMod α 7` is by definition the `toFinset` of `normalizedFactors ((minpoly ℤ α).map (ZMod 7))`, so membership is `Multiset.mem_toFinset` followed by the rewrite `minpoly ℤ α = qInt`, reducing to the self-contained keystone. `three_dvd_cubic7_natDegree` records `3 ∣ cubic7.natDegree = 3`, the degree slot the bricks need.",
+    "mathContext": "For $\\alpha$ with $\\mathrm{minpoly}_{\\mathbb Z}\\alpha = q_{\\mathbb Z}$: $\\mathrm{cubic7} \\in \\mathrm{monicFactorsMod}\\,\\alpha\\,7$. The number-field statement is one `mem_toFinset` and the substitution away from the pure polynomial fact.",
+    "significance": "key",
+    "relatedConcepts": ["monicFactorsMod", "minimal polynomial", "ring of integers", "algebraic integer"],
+    "prerequisites": ["minimal polynomials", "number fields"]
+  },
+  {
+    "id": "ann-step1-composition",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 102, "endLine": 111 },
+    "type": "insight",
+    "title": "Composing with Step 1: a prime of inertia degree divisible by 3",
+    "content": "`exists_prime_three_dvd_inertiaDeg` feeds the concrete factor through `DedekindKummerStep1`: given `minpoly ℤ α = qInt` and `7 ∤ exponent α`, it produces a maximal prime P of 𝓞 K over (7) with `3 ∣ inertiaDeg (7) P`. The degree-3 irreducible factor mechanically manufactures a prime whose residue-field extension has degree divisible by 3 — i.e. a Frobenius element of order divisible by 3.",
+    "mathContext": "$\\exists P \\lhd \\mathcal{O}_K$ maximal, $P \\mid (7)$, with $3 \\mid f(P \\mid 7)$. By Kummer–Dedekind (valid since $7 \\nmid \\mathrm{exponent}\\,\\alpha$, i.e. 7 misses the conductor of $\\mathbb{Z}[\\alpha]$), the factorization of $(7)$ mirrors that of $q \\bmod 7$, so the cubic factor gives a degree-3 prime.",
+    "significance": "key",
+    "relatedConcepts": ["inertia degree", "Frobenius element", "conductor of an order", "prime splitting"],
+    "prerequisites": ["Kummer–Dedekind theorem", "inertia and ramification"]
+  },
+  {
+    "id": "ann-tower-composition",
+    "proofId": "inverse-galois-oq-04-oq-02",
+    "range": { "startLine": 113, "endLine": 136 },
+    "type": "insight",
+    "title": "Composing with the tower brick: 3 ∣ inertiaDegIn over the Galois tower",
+    "content": "`three_dvd_inertiaDegIn_of_tower_data` feeds the same factor through `DedekindKummerToTower` over a Galois tower ℤ ⊆ 𝓞 K ⊆ T (with T integral over 𝓞 K and T/ℤ Galois via a finite group G), yielding `3 ∣ Ideal.inertiaDegIn (span {(7:ℤ)}) T`. This is the exact shape the A₅ residual gap needs at K = ℚ(α), T = 𝓞 q.SplittingField, G = q.Gal. The closing `#print axioms` audits show only propext / Classical.choice / Quot.sound.",
+    "mathContext": "Over a Galois tower, inertia degrees are multiplicative and (by Galois uniformity) uniform across primes above (7), so $3 \\mid f(P \\mid 7)$ propagates to $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(T)$ — which forces $3 \\mid |G|$ once the tower is $q.\\mathrm{SplittingField}$.",
+    "significance": "key",
+    "relatedConcepts": ["inertiaDegIn", "Galois tower", "IsGaloisGroup", "inertia multiplicativity"],
+    "prerequisites": ["Galois theory of number fields", "scalar towers", "axiom auditing"]
+  }
+]

--- a/src/data/proofs/inverse-galois-oq-04-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "inverse-galois-oq-04-oq-02",
+  "title": "Inverse Galois OQ-04-02: The Concrete Kummer–Dedekind Input for the A₅ Quintic at p = 7",
+  "slug": "inverse-galois-oq-04-oq-02",
+  "description": "Answers the second open question of the OQ-04 route — matching the irreducible cubic factor of q mod 7 to the monicFactorsMod input the Kummer–Dedekind bricks consume. The verified arithmetic keystone InverseGaloisA5DedekindMod7 gives q ≡ (X−5)(X−6)·cubic7 (mod 7) with cubic7 = X³+6X²+4X+1 irreducible of degree 3. This entry turns that factorization into the membership currency the abstract bricks require: cubic7 ∈ normalizedFactors (q mod 7) as a self-contained (ZMod 7)[X] fact, then cubic7 ∈ RingOfIntegers.monicFactorsMod α 7 for any algebraic integer α with minpoly ℤ α = qInt. Feeding this through the Step-1 brick yields a prime P of 𝓞 K over (7) with 3 ∣ inertiaDeg (7) P, and through the tower brick yields 3 ∣ Ideal.inertiaDegIn (span {(7:ℤ)}) T over a Galois tower ℤ ⊆ 𝓞 K ⊆ T — leaving only the concrete tower instances, minpoly ℤ α = qInt, and 7 ∤ exponent α as inputs. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "number-theory",
+      "algebraic-number-theory",
+      "inverse-galois",
+      "kummer-dedekind",
+      "inertia-degree",
+      "finite-fields",
+      "polynomial-factorization"
+    ],
+    "proofRepoPath": "Proofs/InverseGaloisA5DedekindKummerInput.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, inertia degree, the Kummer–Dedekind theorem and the conductor of an order)",
+      "Unique factorization in polynomial rings over a field (normalizedFactors, monic irreducible factors)",
+      "Polynomials over finite fields (irreducibility of a rootless cubic, reduction modulo a prime)"
+    ],
+    "assumptions": "None beyond the ordinary foundational axioms of Lean/Mathlib (propext, Classical.choice, Quot.sound). No `axiom` declarations and no `sorry`. The self-contained polynomial facts follow from `Polynomial.mem_normalizedFactors_iff` and the previously verified `InverseGaloisA5DedekindMod7` (factorization, irreducibility, degree — all 0-axiom, `decide`-free in the parts consumed here); the composed inertia statements reuse the 0-axiom sibling bricks `DedekindKummerStep1` and `DedekindKummerToTower`. This entry does not by itself close the A₅ realizability axiom `three_dvd_gal_card`; it supplies the concrete monicFactorsMod input those bricks assume, leaving the concrete tower/IsGaloisGroup instances, the identification minpoly ℤ α = qInt, and 7 ∤ RingOfIntegers.exponent α (from 7 ∤ disc q = 32000²) as the remaining hypotheses.",
+    "relatedProblems": [
+      {
+        "id": "inverse-galois-oq-04-oq-01",
+        "relationship": "Sibling Step-1 brick; this entry supplies the concrete monicFactorsMod membership that instantiates its exists_prime_dvd_inertiaDeg_of_dvd_natDegree at θ = α, p = 7, Q = cubic7"
+      },
+      {
+        "id": "inverse-galois-oq-04",
+        "relationship": "Parent entry (the inertia tower + Galois uniformity brick, Steps 2–3); this entry provides the arithmetic factor input its route names as an open question"
+      },
+      {
+        "id": "inverse-galois-a5",
+        "relationship": "The A₅ realization whose sole remaining assumption three_dvd_gal_card these bricks are designed to help discharge"
+      },
+      {
+        "id": "inverse-galois",
+        "relationship": "Grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+      }
+    ],
+    "lineCount": 138,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The Inverse Galois Problem asks whether every finite group occurs as $\\mathrm{Gal}(K/\\mathbb{Q})$. The alternating group $A_5$ — the smallest non-solvable group — is realizable over $\\mathbb{Q}$, and the Lean development `Proofs.InverseGaloisA5` formalizes this down to one remaining assumption, `three_dvd_gal_card : 3 \\mid \\mathrm{card}\\,q.\\mathrm{Gal}$, for the quintic $q = X^5 - 5X^4 + 10X^3 - 10X^2 + 25X - 5$. A companion reduction rewrites that as $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$, provable by a three-step Kummer–Dedekind route. Two abstract bricks already machine-checked the inertia reasoning: `inverse-galois-oq-04-oq-01` (Step 1: an irreducible factor mod $p$ yields a prime of that inertia degree) and `inverse-galois-oq-04` (Steps 2–3: inertia-degree tower multiplicativity and Galois uniformity). Both take as a hypothesis that a chosen polynomial is a monic irreducible factor of the minimal polynomial mod $p$. This entry supplies that hypothesis concretely for the $A_5$ quintic at $p = 7$.",
+    "problemStatement": "**Produce the concrete Kummer–Dedekind input for the $A_5$ quintic: the irreducible cubic factor of $q \\bmod 7$ is a monic irreducible factor of $\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\alpha$ modulo $7$, i.e. an element of $\\mathrm{monicFactorsMod}\\,\\alpha\\,7$.**\n\nThe verified keystone `InverseGaloisA5DedekindMod7` gives $q \\equiv (X-5)(X-6)\\,\\mathrm{cubic7} \\pmod 7$ with $\\mathrm{cubic7} = X^3 + 6X^2 + 4X + 1$ irreducible of degree $3$. Turn this into $\\mathrm{cubic7} \\in \\mathrm{monicFactorsMod}\\,\\alpha\\,7$ for a root $\\alpha$ of $q$, and feed it through the Step-1 and tower bricks to obtain $3 \\mid \\mathrm{inertiaDeg}_{(7)}\\,P$ and $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$.",
+    "text": "A 138-line, 0-axiom, 8-theorem file in the namespace `InverseGaloisA5DedekindKummerInput`. It first records the self-contained $(ZMod 7)[X]$ facts: `qInt_monic`, `cubic7_monic`, `cubic7_dvd` (cubic7 divides $q \\bmod 7$), and `qIntMap_ne_zero`. Their combination gives the headline polynomial lemma `cubic7_mem_normalizedFactors` : $\\mathrm{cubic7} \\in \\mathrm{normalizedFactors}(q \\bmod 7)$, via `Polynomial.mem_normalizedFactors_iff` and the irreducible/monic/divides trio. Lifting through the definition of `monicFactorsMod`, `cubic7_mem_monicFactorsMod` shows $\\mathrm{cubic7} \\in \\mathrm{monicFactorsMod}\\,\\alpha\\,7$ for any $\\alpha$ with $\\mathrm{minpoly}_{\\mathbb{Z}}\\,\\alpha = q_{\\mathbb{Z}}$. Two composed capstones then discharge the abstract bricks: `exists_prime_three_dvd_inertiaDeg` (Step 1 — a prime $P$ over $(7)$ with $3 \\mid \\mathrm{inertiaDeg}\\,(7)\\,P$) and `three_dvd_inertiaDegIn_of_tower_data` (the tower brick — $3 \\mid \\mathrm{inertiaDegIn}(\\mathrm{span}\\{7\\})\\,T$ over a Galois tower $\\mathbb{Z} \\subseteq \\mathcal{O}_K \\subseteq T$).",
+    "proofStrategy": "The core is `Polynomial.mem_normalizedFactors_iff`, which for a nonzero polynomial over a field says $p \\in \\mathrm{normalizedFactors}\\,q \\iff \\mathrm{Irreducible}\\,p \\wedge p.\\mathrm{Monic} \\wedge p \\mid q$.\n\n1. **Irreducibility** is `InverseGaloisA5DedekindMod7.cubic7_irreducible` (a rootless cubic over a field is irreducible), and **monicity** is `monicity!` on the explicit cubic; a monic polynomial over a field is already `normalize`-fixed, which is what pins it as a *normalized* factor.\n\n2. **Divisibility** reads off the verified factorization $q \\bmod 7 = (X-5)(X-6)\\,\\mathrm{cubic7}$ by `dvd_mul_left`, and **nonvanishing** of $q \\bmod 7$ is `Monic.map … |>.ne_zero`.\n\n3. **Membership in `monicFactorsMod`** is definitional: `monicFactorsMod α 7` is the `toFinset` of `normalizedFactors ((minpoly ℤ α).map (ZMod 7))`, so `Multiset.mem_toFinset` plus the rewrite `minpoly ℤ α = qInt` reduces it to `cubic7_mem_normalizedFactors`.\n\n4. **Composition**: with $3 \\mid \\mathrm{cubic7.natDegree} = 3$ (`three_dvd_cubic7_natDegree`), the sibling bricks `DedekindKummerStep1.exists_prime_dvd_inertiaDeg_of_dvd_natDegree` and `DedekindKummerToTower.dvd_inertiaDegIn_of_dvd_natDegree_factor` apply verbatim. Only foundational axioms are used throughout.",
+    "keyInsights": [
+      "**The bricks' one hypothesis, delivered concretely**: both Kummer–Dedekind bricks assume `Q ∈ monicFactorsMod θ p`. This entry produces exactly that for the A₅ quintic — no abstract inertia reasoning, just the arithmetic that cubic7 is a genuine monic irreducible factor of q mod 7 — turning the abstract composition into a statement with only number-theoretic inputs (tower instances, minpoly, exponent) left.",
+      "**A field-level fact under a number-field wrapper**: `monicFactorsMod α 7` is by definition the finset of normalized factors of `minpoly ℤ α mod 7`, so the entire content is the self-contained `(ZMod 7)[X]` lemma `cubic7 ∈ normalizedFactors (q mod 7)`; the number-field statement is one `Multiset.mem_toFinset` and the substitution `minpoly ℤ α = qInt` away.",
+      "**Monic ⇒ normalized**: `mem_normalizedFactors_iff` requires the factor to be `normalize`-fixed, which over a field means monic. Proving `cubic7.Monic` (via `monicity!`) is what upgrades 'irreducible factor' to 'normalized factor' and lets it sit in the multiset `monicFactorsMod` returns.",
+      "**Divisibility that composes**: pairing `cubic7 ∈ monicFactorsMod α 7` with `3 ∣ cubic7.natDegree = 3` matches the `d ∣ Q.natDegree` slot of both bricks with `d = 3`, so the degree-3 irreducible factor mechanically forces `3 ∣ inertiaDeg (7) P` and, up the Galois tower, `3 ∣ inertiaDegIn (7)`.",
+      "**Honest partial progress**: this entry does not on its own remove `three_dvd_gal_card`; combined with the two verified inertia bricks it reduces the residual gap to purely the concrete tower/IsGaloisGroup instances for ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField, the identification minpoly ℤ α = qInt, and 7 ∤ exponent α (from 7 ∤ disc q = 32000²)."
+    ],
+    "prerequisites": [
+      "Algebraic number theory (rings of integers, inertia degree, the Kummer–Dedekind theorem and the conductor of an order)",
+      "Unique factorization in polynomial rings over a field (normalizedFactors, monic irreducible factors)",
+      "Polynomials over finite fields (irreducibility of a rootless cubic, reduction modulo a prime)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "roadmap",
+      "title": "Docstring: the concrete Kummer–Dedekind input at p = 7",
+      "startLine": 6,
+      "endLine": 46,
+      "summary": "Frames OQ-04 and its reduction of three_dvd_gal_card to 3 ∣ inertiaDegIn (7); recalls the two abstract bricks (Step 1, and the tower + Galois uniformity brick) and states that this file supplies the monicFactorsMod hypothesis they assume, in the concrete A₅ setting θ = α, p = 7, Q = cubic7, with only foundational axioms."
+    },
+    {
+      "id": "polynomial-facts",
+      "title": "Self-contained (ZMod 7)[X] facts: monic, divides, nonzero",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "qInt_monic and cubic7_monic (via monicity!), cubic7_dvd (cubic7 divides q mod 7, from the verified factorization q mod 7 = (X−5)(X−6)·cubic7 by dvd_mul_left), and qIntMap_ne_zero (a monic polynomial maps to a nonzero polynomial)."
+    },
+    {
+      "id": "normalized-factor",
+      "title": "cubic7_mem_normalizedFactors — the arithmetic keystone",
+      "startLine": 75,
+      "endLine": 87,
+      "summary": "cubic7 ∈ normalizedFactors (q mod 7), purely inside (ZMod 7)[X], from Polynomial.mem_normalizedFactors_iff applied to the irreducible/monic/divides trio and nonvanishing of q mod 7."
+    },
+    {
+      "id": "monic-factors-mod",
+      "title": "cubic7_mem_monicFactorsMod — lifting to the number field",
+      "startLine": 89,
+      "endLine": 103,
+      "summary": "For a number field K and algebraic integer α with minpoly ℤ α = qInt, cubic7 ∈ RingOfIntegers.monicFactorsMod α 7. Membership is definitional (Multiset.mem_toFinset) after rewriting minpoly ℤ α = qInt, reducing to cubic7_mem_normalizedFactors. Also three_dvd_cubic7_natDegree : 3 ∣ cubic7.natDegree."
+    },
+    {
+      "id": "composition",
+      "title": "Composing with the Step-1 and tower bricks",
+      "startLine": 105,
+      "endLine": 138,
+      "summary": "exists_prime_three_dvd_inertiaDeg feeds the concrete factor through DedekindKummerStep1 to obtain a prime P of 𝓞 K over (7) with 3 ∣ inertiaDeg (7) P; three_dvd_inertiaDegIn_of_tower_data feeds it through DedekindKummerToTower to obtain 3 ∣ Ideal.inertiaDegIn (span {(7:ℤ)}) T over a Galois tower ℤ ⊆ 𝓞 K ⊆ T. An axiom audit prints only the three foundational axioms."
+    }
+  ],
+  "conclusion": {
+    "mainResult": "For the A₅ quintic q, the irreducible cubic factor cubic7 = X³+6X²+4X+1 of q mod 7 is a normalized factor of q mod 7, and hence — for any number field K and algebraic integer α ∈ 𝓞 K with minpoly ℤ α = qInt — a monic irreducible factor of minpoly ℤ α modulo 7, i.e. cubic7 ∈ RingOfIntegers.monicFactorsMod α 7. Composing with the Step-1 brick yields a prime P of 𝓞 K over (7) with 3 ∣ inertiaDeg (7) P; composing with the tower brick yields 3 ∣ Ideal.inertiaDegIn (span {(7:ℤ)}) T over a Galois tower ℤ ⊆ 𝓞 K ⊆ T. All eight theorems are machine-checked with 0 axioms and 0 sorries.",
+    "significance": "This entry supplies the single concrete hypothesis both abstract Kummer–Dedekind bricks assume — that a chosen polynomial is a monic irreducible factor of the minimal polynomial mod p — for the A₅ quintic at p = 7. It thereby collapses the residual OQ-04 gap from 'wire up the abstract inertia machinery' to 'construct the concrete number field tower and verify minpoly ℤ α = qInt and 7 ∤ exponent α'. The mathematical crux is that the verified factorization q mod 7 = (X−5)(X−6)·cubic7, with cubic7 an irreducible degree-3 monic, is exactly a normalized factor — so the degree-3 factor mechanically manufactures a prime of inertia degree divisible by 3, hence a Frobenius element of order 3 and 3 ∣ |Gal|. Delivering this input with 0 axioms keeps the eventual A₅ realization on track for an unconditional Dedekind-factorization proof.",
+    "openQuestions": [
+      "Construct the concrete scalar tower ℤ ⊆ 𝓞 ℚ(α) ⊆ 𝓞 q.SplittingField with the IsGaloisGroup q.Gal ℤ (𝓞 q.SplittingField) and integrality instances that three_dvd_inertiaDegIn_of_tower_data consumes, for a root α of q.",
+      "Verify minpoly ℤ α = qInt for a root α of q (q is monic irreducible over ℚ, so its integer model is the minimal polynomial of any root).",
+      "Verify the exponent hypothesis 7 ∤ RingOfIntegers.exponent α via 7 ∤ disc q = 32000², so 7 misses the conductor and Kummer–Dedekind applies.",
+      "Identify Ideal.inertiaDegIn (span {(7:ℤ)}) (𝓞 q.SplittingField) with the inertiaDegIn (Q.under ℤ) form of InverseGaloisA5DedekindInstantiation.three_dvd_gal_card_of_bridge and supply unramifiedness of 7, fully discharging three_dvd_gal_card."
+    ],
+    "summary": "The verified factorization q ≡ (X−5)(X−6)·cubic7 (mod 7), with cubic7 = X³+6X²+4X+1 irreducible of degree 3, is turned into the membership cubic7 ∈ normalizedFactors (q mod 7) and hence cubic7 ∈ RingOfIntegers.monicFactorsMod α 7 for any algebraic integer α with minpoly ℤ α = qInt. Feeding this through the sibling Step-1 and tower bricks gives a prime P of 𝓞 K over (7) with 3 ∣ inertiaDeg (7) P and, over a Galois tower ℤ ⊆ 𝓞 K ⊆ T, 3 ∣ Ideal.inertiaDegIn (span {(7:ℤ)}) T. Eight theorems, 0 axioms, 0 sorries. This supplies the concrete monicFactorsMod input the abstract OQ-04 bricks assume, leaving only the concrete tower instances, minpoly ℤ α = qInt, and 7 ∤ exponent α.",
+    "implications": "The entry closes the arithmetic-input half of the OQ-04 residual gap: what remains between the machine-checked bricks and the A₅ axiom three_dvd_gal_card is now purely the construction of the concrete number-field tower and two standard facts (minpoly ℤ α = qInt and 7 ∤ exponent α). More broadly, the pattern — reduce 'Q is a monic irreducible factor of the minimal polynomial mod p' to the self-contained (ZMod p)[X] fact 'Q ∈ normalizedFactors (defining polynomial mod p)' via mem_normalizedFactors_iff — is reusable for any Dedekind-factorization / Frobenius-cycle-type argument built on Mathlib's Kummer–Dedekind bijection."
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Sibling Step-1 brick; this entry supplies the concrete monicFactorsMod membership instantiating its exists_prime_dvd_inertiaDeg_of_dvd_natDegree at θ = α, p = 7, Q = cubic7"
+    },
+    {
+      "targetId": "inverse-galois-oq-04",
+      "relationship": "related",
+      "description": "Parent entry (the inertia tower + Galois uniformity brick, Steps 2–3); this entry provides the arithmetic factor input its route names as an open question"
+    },
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "related",
+      "description": "The A₅ realization whose sole remaining axiom three_dvd_gal_card these bricks are designed to help eliminate"
+    },
+    {
+      "targetId": "inverse-galois",
+      "relationship": "related",
+      "description": "Grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/InverseGaloisA5DedekindKummerInput.lean",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "imports": [
+      "Mathlib",
+      "Proofs.InverseGaloisA5DedekindMod7",
+      "Proofs.DedekindKummerStep1",
+      "Proofs.DedekindKummerToTower"
+    ],
+    "lemmaCount": 0,
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04-oq-02` (quality 45, pass 0).

**Gap addressed:** rich `meta.json`, but **no `annotations.json`** (0 inline coverage).

**Added:** `annotations.json` with 6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- imports / the two abstract Kummer–Dedekind bricks and the A₅ quintic setup
- `qInt_monic` / `cubic7_monic` / `cubic7_dvd` / `qIntMap_ne_zero` — (ZMod 7)[X] facts
- `cubic7_mem_normalizedFactors` — the arithmetic keystone (key)
- `cubic7_mem_monicFactorsMod` — lifting to the number field (key)
- `exists_prime_three_dvd_inertiaDeg` — Step-1 composition (key)
- `three_dvd_inertiaDegIn_of_tower_data` — tower-brick composition (key)

No changes to `meta.json` (18 KB, under caps). Axiom/status verified against the Lean source (0 axioms, 0 sorries, `verified`/`original`).
