### PR TITLE
research(erdos-1014-oq-04): k=4 Ramsey ratio convergence via Mattheus–Verstraëte [DRAFT, build-pending]

### DIFF
--- a/proofs/Proofs/Erdos1014OQ04.lean
+++ b/proofs/Proofs/Erdos1014OQ04.lean
@@ -1,0 +1,305 @@
+/-
+Erdős Problem #1014 OQ-04: The k = 4 Case via Mattheus–Verstraëte Bounds
+
+The parent problem (Erdős #1014) asks, for fixed k ≥ 3, whether
+  R(k, l+1) / R(k, l) → 1  as  l → ∞.
+OQ-01/OQ-02 handle k = 3 via the recurrence R(3,l+1) ≤ R(3,l) + (l+1)
+together with the Kim–Shearer lower bound R(3,l) ≥ c·l²/log l.
+
+This file settles the **k = 4 case** using the same "increment vs. size"
+principle, but now the increment is controlled by R(3, ·) (which is only
+O(l²/log l)) while the size R(4, l) is Ω(l³/(log l)⁴) by the celebrated
+Mattheus–Verstraëte theorem (Annals of Mathematics, 2024).
+
+Main results:
+  (1) `increment_bound_k4`: the Ramsey recurrence gives
+        R(4, l+1) ≤ R(4, l) + R(3, l+1).
+  (2) `log_cubed_le_mul`: quantitative form of (log l)³ = o(l).
+  (3) `R4_ratio_convergence`: R(4, l+1)/R(4, l) → 1 as l → ∞.
+      Proof: |R(4,l+1)/R(4,l) - 1| = (R(4,l+1)-R(4,l))/R(4,l)
+                                    ≤ R(3,l+1)/R(4,l)
+                                    ≤ (4C/c) · (log l)³ / l → 0,
+      since (log l)³ = o(l).
+  (4) `R4_rate_of_convergence`: an explicit O((log l)³ / l) rate bound.
+
+The proof is *conditional on* two deep (axiomatized) inputs that are not in
+Mathlib:
+  - Mattheus–Verstraëte lower bound  R(4, l) ≥ c·l³/(log l)⁴   (`R4_lower_MV`)
+  - Ajtai–Komlós–Szemerédi upper bound R(3, l) ≤ C·l²/log l    (`R3_upper`,
+    imported from `Proofs.Erdos1014Problem`).
+Both are established theorems in the literature; the *combination* proving
+the ratio convergence for k = 4 is carried out here in full.
+
+References:
+- Erdős [Er71], Problem 1014
+- S. Mattheus, J. Verstraëte, "The asymptotics of r(4,t)",
+  Annals of Mathematics 199 (2024): R(4,t) = Θ(t³/log⁴ t) up to the log gap.
+- Ajtai–Komlós–Szemerédi (1980): R(3,l) ≤ C·l²/log l.
+-/
+
+import Mathlib
+import Proofs.Erdos1014Problem
+
+open Real Filter Topology
+
+namespace Erdos1014OQ04
+
+-- All axioms (ramseyNumber, ramsey_monotone_right, ramsey_recurrence,
+-- R3_upper, …) and theorems (ramsey_pos) are imported from
+-- Proofs.Erdos1014Problem.
+
+/-- **Mattheus–Verstraëte (2024)**: R(4, l) = Ω(l³/(log l)⁴).
+    There exist c > 0 and L₀ with R(4, l) ≥ c·l³/(log l)⁴ for all l > L₀.
+
+    This is the lower-bound half of the Annals 2024 result
+    R(4, t) = Θ̃(t³) (with polylog gap). Not available in Mathlib, so it is
+    stated as an axiom (a hypothesis of the k = 4 argument). -/
+axiom R4_lower_MV :
+  ∃ c : ℝ, c > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+    (ramseyNumber 4 l : ℝ) ≥ c * (l : ℝ) ^ 3 / (Real.log l) ^ 4
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 1: The increment bound for k = 4
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The Ramsey recurrence R(k,l+1) ≤ R(k,l) + R(k-1,l+1) at k = 4:
+      R(4, l+1) ≤ R(4, l) + R(3, l+1).
+    Unlike the k = 3 case (where R(2,l+1) = l+1 is linear), the increment
+    here is R(3,l+1) = O(l²/log l) — still asymptotically negligible against
+    R(4, l) = Ω(l³/(log l)⁴). -/
+theorem increment_bound_k4 (l : ℕ) (hl : l ≥ 1) :
+    ramseyNumber 4 (l + 1) ≤ ramseyNumber 4 l + ramseyNumber 3 (l + 1) := by
+  have h := ramsey_recurrence 4 l (by omega) hl
+  simpa only [show (4 : ℕ) - 1 = 3 from rfl] using h
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 2: (log l)³ = o(l)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- For any target slope `m > 0`, eventually `(log l)³ ≤ m · l`.
+
+    This is the quantitative form of `(log l)³ = o(l)`. We use
+    `log x = o(x^(1/3))`: choosing the little-o constant to be `m^(1/3)`
+    gives `log l ≤ m^(1/3) · l^(1/3)`, and cubing yields
+    `(log l)³ ≤ m · (l^(1/3))³ = m · l`. -/
+theorem log_cubed_le_mul (m : ℝ) (hm : m > 0) :
+    ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      (Real.log (l : ℝ)) ^ 3 ≤ m * (l : ℝ) := by
+  set K : ℝ := m ^ ((1 : ℝ) / 3) with hK_def
+  have hK : K > 0 := by rw [hK_def]; exact Real.rpow_pos_of_pos hm _
+  -- log =o(x^(1/3))
+  have ho := Real.isLittleO_log_rpow_atTop (show (0 : ℝ) < 1 / 3 by norm_num)
+  have hev := ho.bound hK
+  obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp hev
+  refine ⟨max (⌈N⌉₊ + 1) 2, fun l hl => ?_⟩
+  have hl_pos : (0 : ℝ) < (l : ℝ) := by exact_mod_cast (show 0 < l by omega)
+  have hlog_pos : 0 < Real.log (l : ℝ) :=
+    Real.log_pos (by exact_mod_cast (show 1 < l by omega))
+  have hl_ge_N : N ≤ (l : ℝ) :=
+    le_trans (Nat.le_ceil N) (by exact_mod_cast (show ⌈N⌉₊ ≤ l by omega))
+  have hb := hN (l : ℝ) hl_ge_N
+  rw [Real.norm_eq_abs, Real.norm_eq_abs, abs_of_pos hlog_pos,
+      abs_of_pos (Real.rpow_pos_of_pos hl_pos _)] at hb
+  -- hb : log l ≤ K * l^(1/3)
+  have hb0 : (0 : ℝ) ≤ Real.log (l : ℝ) := hlog_pos.le
+  have hRHS0 : (0 : ℝ) ≤ K * (l : ℝ) ^ ((1 : ℝ) / 3) := le_trans hb0 hb
+  -- cube both sides (nonnegative), manually to avoid version-sensitive lemmas
+  have hcube : (Real.log (l : ℝ)) ^ 3 ≤ (K * (l : ℝ) ^ ((1 : ℝ) / 3)) ^ 3 := by
+    calc (Real.log (l : ℝ)) ^ 3
+        = Real.log (l : ℝ) * Real.log (l : ℝ) * Real.log (l : ℝ) := by ring
+      _ ≤ (K * (l : ℝ) ^ ((1 : ℝ) / 3)) * (K * (l : ℝ) ^ ((1 : ℝ) / 3)) *
+            (K * (l : ℝ) ^ ((1 : ℝ) / 3)) := by
+          apply mul_le_mul (mul_le_mul hb hb hb0 hRHS0) hb hb0 (mul_nonneg hRHS0 hRHS0)
+      _ = (K * (l : ℝ) ^ ((1 : ℝ) / 3)) ^ 3 := by ring
+  -- (l^(1/3))³ = l
+  have hpow : ((l : ℝ) ^ ((1 : ℝ) / 3)) ^ (3 : ℕ) = (l : ℝ) := by
+    rw [← Real.rpow_natCast ((l : ℝ) ^ ((1 : ℝ) / 3)) 3, ← Real.rpow_mul hl_pos.le,
+        show (1 : ℝ) / 3 * ((3 : ℕ) : ℝ) = 1 by push_cast; norm_num, Real.rpow_one]
+  -- K³ = m
+  have hKcube : K ^ (3 : ℕ) = m := by
+    rw [hK_def, ← Real.rpow_natCast (m ^ ((1 : ℝ) / 3)) 3, ← Real.rpow_mul hm.le,
+        show (1 : ℝ) / 3 * ((3 : ℕ) : ℝ) = 1 by push_cast; norm_num, Real.rpow_one]
+  calc (Real.log (l : ℝ)) ^ 3
+      ≤ (K * (l : ℝ) ^ ((1 : ℝ) / 3)) ^ 3 := hcube
+    _ = K ^ 3 * ((l : ℝ) ^ ((1 : ℝ) / 3)) ^ 3 := by rw [mul_pow]
+    _ = m * (l : ℝ) := by rw [hKcube, hpow]
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 3: R(4, l+1)/R(4, l) → 1  (the k = 4 case of Erdős #1014)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Erdős Problem #1014 for k = 4** (conditional on Mattheus–Verstraëte
+    and AKS bounds): R(4, l+1)/R(4, l) → 1 as l → ∞.
+
+    Proof sketch:
+    - R(4,l+1) - R(4,l) ≤ R(3,l+1) ≤ C·(l+1)²/log(l+1) ≤ 4C·l²/log l  (increment)
+    - R(4,l) ≥ c·l³/(log l)⁴                                          (M–V)
+    - hence |R(4,l+1)/R(4,l) - 1| = (R(4,l+1)-R(4,l))/R(4,l)
+                                  ≤ (4C/c)·(log l)³/l → 0. -/
+theorem R4_ratio_convergence :
+    ∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      |(ramseyNumber 4 (l + 1) : ℝ) / (ramseyNumber 4 l : ℝ) - 1| < ε := by
+  intro ε hε
+  obtain ⟨c, hc, L₁, hL₁⟩ := R4_lower_MV
+  obtain ⟨C, hC, L₂, hL₂⟩ := R3_upper
+  -- Choose the little-o slope m so that (4C/c)·m ≤ ε/2.
+  obtain ⟨L₃, hL₃⟩ := log_cubed_le_mul (c * ε / (8 * C)) (by positivity)
+  refine ⟨max (max (max L₁ L₂) L₃) 2, fun l hl => ?_⟩
+  have hl1 : l > L₁ := by omega
+  have hl2' : l + 1 > L₂ := by omega
+  have hl3 : l > L₃ := by omega
+  have hl_ge1 : l ≥ 1 := by omega
+  have hl_pos : (0 : ℝ) < (l : ℝ) := by exact_mod_cast (show 0 < l by omega)
+  have hl1r : (1 : ℝ) ≤ (l : ℝ) := by exact_mod_cast hl_ge1
+  have hlog : 0 < Real.log (l : ℝ) :=
+    Real.log_pos (by exact_mod_cast (show 1 < l by omega))
+  have hlog1 : 0 < Real.log ((l : ℝ) + 1) := Real.log_pos (by linarith)
+  set R := (ramseyNumber 4 l : ℝ) with hR_def
+  set R' := (ramseyNumber 4 (l + 1) : ℝ) with hR'_def
+  have hR_pos : R > 0 := by
+    simp only [hR_def]
+    have := ramsey_pos 4 l (by omega) hl_ge1
+    exact_mod_cast (show 0 < ramseyNumber 4 l by omega)
+  have hmon : R ≤ R' := by
+    simp only [hR_def, hR'_def]
+    exact Nat.cast_le.mpr (ramsey_monotone_right 4 l)
+  have h_diff : R' - R ≤ (ramseyNumber 3 (l + 1) : ℝ) := by
+    simp only [hR_def, hR'_def]
+    have h := increment_bound_k4 l hl_ge1
+    have : (ramseyNumber 4 (l + 1) : ℝ) ≤
+        (ramseyNumber 4 l : ℝ) + (ramseyNumber 3 (l + 1) : ℝ) := by exact_mod_cast h
+    linarith
+  -- R(3, l+1) ≤ C·(l+1)²/log(l+1) ≤ 4C·l²/log l
+  have hR3ub : (ramseyNumber 3 (l + 1) : ℝ) ≤ 4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+    have hub := hL₂ (l + 1) hl2'
+    push_cast at hub
+    have hsq : ((l : ℝ) + 1) ^ 2 ≤ 4 * (l : ℝ) ^ 2 := by
+      nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ (l:ℝ) - 1) (by linarith : (0:ℝ) ≤ 3*(l:ℝ) + 1)]
+    have hlogle : Real.log (l : ℝ) ≤ Real.log ((l : ℝ) + 1) :=
+      Real.log_le_log hl_pos (by linarith)
+    have hstep : C * ((l : ℝ) + 1) ^ 2 / Real.log ((l : ℝ) + 1) ≤
+        4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+      calc C * ((l : ℝ) + 1) ^ 2 / Real.log ((l : ℝ) + 1)
+          ≤ 4 * C * (l : ℝ) ^ 2 / Real.log ((l : ℝ) + 1) := by
+            apply div_le_div_of_nonneg_right _ hlog1.le
+            nlinarith [mul_le_mul_of_nonneg_left hsq (le_of_lt hC)]
+        _ ≤ 4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+            apply div_le_div_of_nonneg_left _ hlog hlogle
+            positivity
+    linarith [hub, hstep]
+  have h_abs : |R' / R - 1| = (R' - R) / R := by
+    have h_eq : R' / R - 1 = (R' - R) / R := by field_simp
+    rw [h_eq, abs_of_nonneg (div_nonneg (by linarith) (le_of_lt hR_pos))]
+  rw [h_abs]
+  have hlb := hL₁ l hl1
+  have hden_pos : (0 : ℝ) < c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4 := by positivity
+  have hlog3 := hL₃ l hl3
+  have hCne : C ≠ 0 := ne_of_gt hC
+  have hcne : c ≠ 0 := ne_of_gt hc
+  have hlne : (l : ℝ) ≠ 0 := ne_of_gt hl_pos
+  have hlogne : Real.log (l : ℝ) ≠ 0 := ne_of_gt hlog
+  -- Algebraic simplification of the compound fraction
+  have hkey : (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) /
+        (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4)
+      = 4 * C / c * ((Real.log (l : ℝ)) ^ 3 / (l : ℝ)) := by
+    field_simp
+    ring
+  calc (R' - R) / R
+      ≤ (ramseyNumber 3 (l + 1) : ℝ) / R :=
+        div_le_div_of_nonneg_right h_diff (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) / R :=
+        div_le_div_of_nonneg_right hR3ub (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) /
+          (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4) := by
+        apply div_le_div_of_nonneg_left _ hden_pos hlb
+        positivity
+    _ = 4 * C / c * ((Real.log (l : ℝ)) ^ 3 / (l : ℝ)) := hkey
+    _ ≤ 4 * C / c * ((c * ε / (8 * C) * (l : ℝ)) / (l : ℝ)) := by
+        apply mul_le_mul_of_nonneg_left _ (div_pos (mul_pos (by norm_num) hC) hc).le
+        exact div_le_div_of_nonneg_right hlog3 hl_pos
+    _ = ε / 2 := by field_simp; ring
+    _ < ε := by linarith
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Step 4: Explicit rate bound O((log l)³ / l)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Explicit convergence rate for k = 4**: there exist `A > 0` and `L₀`
+    with, for all `l > L₀`,
+      |R(4,l+1)/R(4,l) - 1| ≤ A · (log l)³ / l.
+    Here `A = 4C/c`, with `c` the Mattheus–Verstraëte lower constant and `C`
+    the AKS upper constant for R(3, ·). Since (log l)³ = o(l), the bound → 0. -/
+theorem R4_rate_of_convergence :
+    ∃ A : ℝ, A > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+      |(ramseyNumber 4 (l + 1) : ℝ) / (ramseyNumber 4 l : ℝ) - 1| ≤
+        A * (Real.log (l : ℝ)) ^ 3 / (l : ℝ) := by
+  obtain ⟨c, hc, L₁, hL₁⟩ := R4_lower_MV
+  obtain ⟨C, hC, L₂, hL₂⟩ := R3_upper
+  refine ⟨4 * C / c, by positivity, max (max L₁ L₂) 2, fun l hl => ?_⟩
+  have hl1 : l > L₁ := by omega
+  have hl2' : l + 1 > L₂ := by omega
+  have hl_ge1 : l ≥ 1 := by omega
+  have hl_pos : (0 : ℝ) < (l : ℝ) := by exact_mod_cast (show 0 < l by omega)
+  have hl1r : (1 : ℝ) ≤ (l : ℝ) := by exact_mod_cast hl_ge1
+  have hlog : 0 < Real.log (l : ℝ) :=
+    Real.log_pos (by exact_mod_cast (show 1 < l by omega))
+  have hlog1 : 0 < Real.log ((l : ℝ) + 1) := Real.log_pos (by linarith)
+  set R := (ramseyNumber 4 l : ℝ) with hR_def
+  set R' := (ramseyNumber 4 (l + 1) : ℝ) with hR'_def
+  have hR_pos : R > 0 := by
+    simp only [hR_def]
+    have := ramsey_pos 4 l (by omega) hl_ge1
+    exact_mod_cast (show 0 < ramseyNumber 4 l by omega)
+  have hmon : R ≤ R' := by
+    simp only [hR_def, hR'_def]
+    exact Nat.cast_le.mpr (ramsey_monotone_right 4 l)
+  have h_diff : R' - R ≤ (ramseyNumber 3 (l + 1) : ℝ) := by
+    simp only [hR_def, hR'_def]
+    have h := increment_bound_k4 l hl_ge1
+    have : (ramseyNumber 4 (l + 1) : ℝ) ≤
+        (ramseyNumber 4 l : ℝ) + (ramseyNumber 3 (l + 1) : ℝ) := by exact_mod_cast h
+    linarith
+  have hR3ub : (ramseyNumber 3 (l + 1) : ℝ) ≤ 4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+    have hub := hL₂ (l + 1) hl2'
+    push_cast at hub
+    have hsq : ((l : ℝ) + 1) ^ 2 ≤ 4 * (l : ℝ) ^ 2 := by
+      nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ (l:ℝ) - 1) (by linarith : (0:ℝ) ≤ 3*(l:ℝ) + 1)]
+    have hlogle : Real.log (l : ℝ) ≤ Real.log ((l : ℝ) + 1) :=
+      Real.log_le_log hl_pos (by linarith)
+    have hstep : C * ((l : ℝ) + 1) ^ 2 / Real.log ((l : ℝ) + 1) ≤
+        4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+      calc C * ((l : ℝ) + 1) ^ 2 / Real.log ((l : ℝ) + 1)
+          ≤ 4 * C * (l : ℝ) ^ 2 / Real.log ((l : ℝ) + 1) := by
+            apply div_le_div_of_nonneg_right _ hlog1.le
+            nlinarith [mul_le_mul_of_nonneg_left hsq (le_of_lt hC)]
+        _ ≤ 4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ) := by
+            apply div_le_div_of_nonneg_left _ hlog hlogle
+            positivity
+    linarith [hub, hstep]
+  have h_abs : |R' / R - 1| = (R' - R) / R := by
+    have h_eq : R' / R - 1 = (R' - R) / R := by field_simp
+    rw [h_eq, abs_of_nonneg (div_nonneg (by linarith) (le_of_lt hR_pos))]
+  rw [h_abs]
+  have hlb := hL₁ l hl1
+  have hden_pos : (0 : ℝ) < c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4 := by positivity
+  have hCne : C ≠ 0 := ne_of_gt hC
+  have hcne : c ≠ 0 := ne_of_gt hc
+  have hlne : (l : ℝ) ≠ 0 := ne_of_gt hl_pos
+  have hlogne : Real.log (l : ℝ) ≠ 0 := ne_of_gt hlog
+  have hkey : (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) /
+        (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4)
+      = 4 * C / c * (Real.log (l : ℝ)) ^ 3 / (l : ℝ) := by
+    field_simp
+    ring
+  calc (R' - R) / R
+      ≤ (ramseyNumber 3 (l + 1) : ℝ) / R :=
+        div_le_div_of_nonneg_right h_diff (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) / R :=
+        div_le_div_of_nonneg_right hR3ub (le_of_lt hR_pos)
+    _ ≤ (4 * C * (l : ℝ) ^ 2 / Real.log (l : ℝ)) /
+          (c * (l : ℝ) ^ 3 / (Real.log (l : ℝ)) ^ 4) := by
+        apply div_le_div_of_nonneg_left _ hden_pos hlb
+        positivity
+    _ = 4 * C / c * (Real.log (l : ℝ)) ^ 3 / (l : ℝ) := hkey
+
+end Erdos1014OQ04

--- a/src/data/proofs/erdos-1014-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1014-oq-04/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "erdos-1014-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 76
+    },
+    "type": "concept",
+    "title": "OQ-04: The k=4 Case of Erdős #1014 via Mattheus–Verstraëte",
+    "content": "Erdős #1014 asks whether R(k,l+1)/R(k,l) → 1 for fixed k ≥ 3. OQ-01/OQ-02 handled k=3 using the linear increment R(3,l+1)-R(3,l) ≤ l+1 and the Kim–Shearer lower bound R(3,l) ≥ c·l²/log l. This file settles k=4 by the same 'increment vs. size' principle. The imports from `Proofs.Erdos1014Problem` bring in 12 axioms (including the Ramsey recurrence and the AKS upper bound R3_upper) and helper theorems (ramsey_pos). The single own axiom, R4_lower_MV, encodes the Mattheus–Verstraëte (Annals 2024) lower bound R(4,l) ≥ c·l³/(log l)⁴.",
+    "mathContext": "At k=4 the increment R(4,l+1)-R(4,l) is bounded by R(3,l+1) = O(l²/log l), while the size R(4,l) = Ω(l³/(log l)⁴). Their quotient is O((log l)³ / l) → 0, so the ratio converges to 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey numbers",
+      "Mattheus–Verstraëte bound",
+      "off-diagonal Ramsey numbers",
+      "asymptotic convergence"
+    ],
+    "prerequisites": [
+      "Ramsey theory basics",
+      "asymptotic analysis",
+      "erdos-1014-oq-01"
+    ]
+  },
+  {
+    "id": "ann-increment-k4",
+    "proofId": "erdos-1014-oq-04",
+    "range": {
+      "startLine": 78,
+      "endLine": 95
+    },
+    "type": "insight",
+    "title": "Increment Bound: R(4,l+1) ≤ R(4,l) + R(3,l+1)",
+    "content": "`increment_bound_k4` specializes the imported Ramsey recurrence R(k,l+1) ≤ R(k,l) + R(k-1,l+1) to k=4 (using 4-1=3). This is the k=4 analogue of `increment_bound_k3`, but the increment term is now R(3,l+1) instead of the linear R(2,l+1)=l+1.",
+    "mathContext": "The recurrence R(s,t) ≤ R(s-1,t) + R(s,t-1) gives R(4,l+1) ≤ R(3,l+1) + R(4,l). The increment R(3,l+1) grows like l²/log l — super-linear, yet still negligible against R(4,l)=Ω(l³/(log l)⁴).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey recurrence",
+      "increment bounds"
+    ],
+    "prerequisites": [
+      "Ramsey recurrence"
+    ]
+  },
+  {
+    "id": "ann-log-cubed",
+    "proofId": "erdos-1014-oq-04",
+    "range": {
+      "startLine": 97,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "(log l)³ = o(l), Quantitatively",
+    "content": "`log_cubed_le_mul` proves that for any slope m > 0, eventually (log l)³ ≤ m·l. It uses Mathlib's `isLittleO_log_rpow_atTop` with exponent 1/3 to get log l ≤ m^(1/3)·l^(1/3), then cubes both sides. The cubing is done via an explicit `mul_le_mul` chain (rather than `pow_le_pow_left`) for robustness, and (l^(1/3))³ = l is established with `rpow_natCast`/`rpow_mul`/`rpow_one`.",
+    "mathContext": "Choosing the little-o constant to be m^(1/3) makes the cube collapse exactly: (m^(1/3)·l^(1/3))³ = m·l. This is the analogue of OQ-02's (log l)² ≤ l lemma, one power higher.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "little-o notation",
+      "logarithmic growth",
+      "rpow"
+    ],
+    "prerequisites": [
+      "asymptotic analysis"
+    ]
+  },
+  {
+    "id": "ann-ratio-k4",
+    "proofId": "erdos-1014-oq-04",
+    "range": {
+      "startLine": 154,
+      "endLine": 233
+    },
+    "type": "insight",
+    "title": "Main Theorem: R(4,l+1)/R(4,l) → 1",
+    "content": "`R4_ratio_convergence` proves ∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(4,l+1)/R(4,l) - 1| < ε. By monotonicity the absolute value equals (R(4,l+1)-R(4,l))/R(4,l). The calc chain bounds this by R(3,l+1)/R(4,l), then by (4C·l²/log l)/(c·l³/(log l)⁴) = (4C/c)·(log l)³/l, and finally by ε/2 using `log_cubed_le_mul` with slope cε/(8C).",
+    "mathContext": "The absorbing step R(3,l+1) ≤ 4C·l²/log l uses (l+1)² ≤ 4l² and log(l+1) ≥ log l. The compound-fraction identity is discharged by field_simp; ring. The slope cε/(8C) yields a final bound of ε/2 < ε.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ramsey ratio convergence",
+      "Mattheus–Verstraëte bound",
+      "AKS upper bound"
+    ],
+    "prerequisites": [
+      "asymptotic analysis",
+      "Ramsey theory basics"
+    ]
+  },
+  {
+    "id": "ann-rate-k4",
+    "proofId": "erdos-1014-oq-04",
+    "range": {
+      "startLine": 235,
+      "endLine": 305
+    },
+    "type": "insight",
+    "title": "Explicit Rate: O((log l)³ / l)",
+    "content": "`R4_rate_of_convergence` packages the same chain as an explicit rate: |R(4,l+1)/R(4,l) - 1| ≤ (4C/c)·(log l)³/l, with C the AKS upper constant and c the Mattheus–Verstraëte lower constant. Since (log l)³ = o(l), the bound tends to 0.",
+    "mathContext": "The k=4 rate O((log l)³ / l) is the analogue of the k=3 rate O(log l / l): each additional Ramsey index adds two powers of log to the numerator of the rate.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convergence rates",
+      "Ramsey numbers"
+    ],
+    "prerequisites": [
+      "asymptotic analysis"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1014-oq-04/meta.json
+++ b/src/data/proofs/erdos-1014-oq-04/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "erdos-1014-oq-04",
+  "title": "Erdős #1014 OQ-04: The k=4 Case via Mattheus–Verstraëte Bounds",
+  "slug": "erdos-1014-oq-04",
+  "description": "Settles the k=4 case of Erdős #1014 (R(k,l+1)/R(k,l) → 1), conditional on two established but non-Mathlib bounds: the Mattheus–Verstraëte (Annals 2024) lower bound R(4,l) ≥ c·l³/(log l)⁴ and the Ajtai–Komlós–Szemerédi upper bound R(3,l) ≤ C·l²/log l. The k=3 argument used the linear recurrence increment R(3,l+1)-R(3,l) ≤ l+1; here the increment is controlled by R(3,l+1)=O(l²/log l), still negligible against R(4,l)=Ω(l³/(log l)⁴). The explicit rate obtained is O((log l)³ / l).",
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 1014,
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1014OQ04.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "combinatorics",
+      "asymptotics",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1014",
+    "erdosUrl": "https://erdosproblems.com/1014",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-07-02",
+    "axiomCount": 13,
+    "lineCount": 305,
+    "assumptions": "13 axioms total. 1 own axiom in this file: R4_lower_MV (Mattheus–Verstraëte 2024 lower bound R(4,l) ≥ c·l³/(log l)⁴, not in Mathlib). 12 axioms inherited from Erdos1014Problem.lean: ramseyNumber, ramsey_symm, ramsey_upper_erdos_szekeres, ramsey_monotone_right, ramsey_recurrence, ramsey_k2, R3_lower, R3_upper (AKS upper bound R(3,l) ≤ C·l²/log l, used here), erdos_1014_conjecture, R33, R34, R35. The k=4 result genuinely uses only ramseyNumber, ramsey_symm/ramsey_k2 (via ramsey_pos), ramsey_monotone_right, ramsey_recurrence, R3_upper, and R4_lower_MV. 0 sorries. BUILD STATUS: authored following the exact lemma signatures the sibling Erdos1014OQ02.lean compiled with (Mathlib 4.26.0); local Docker/host verification was blocked by an infrastructure failure (full disk + corrupted containerd store) at authoring time — must be built before merge.",
+    "mathlib_version": "4.26.0",
+    "leanFiles": [
+      {
+        "path": "Proofs/Erdos1014OQ04.lean",
+        "filename": "Erdos1014OQ04.lean",
+        "lineCount": 305,
+        "theoremCount": 4,
+        "axiomCount": 1,
+        "defCount": 0,
+        "sorries": 0,
+        "isAristotle": false,
+        "description": "The k=4 case (4 theorems): increment_bound_k4, log_cubed_le_mul, R4_ratio_convergence, R4_rate_of_convergence. Declares 1 own axiom R4_lower_MV and imports 12 axioms from Erdos1014Problem.lean."
+      },
+      {
+        "path": "Proofs/Erdos1014Problem.lean",
+        "filename": "Erdos1014Problem.lean",
+        "lineCount": 483,
+        "theoremCount": 15,
+        "axiomCount": 12,
+        "defCount": 0,
+        "sorries": 0,
+        "isAristotle": false,
+        "description": "Parent file providing the 12 Ramsey axioms and supporting lemmas (ramsey_pos, increment_bound_general, ratio_from_asymptotics) used by Erdos1014OQ04.lean."
+      }
+    ],
+    "originalContributions": [
+      "Proved R4_ratio_convergence: R(4,l+1)/R(4,l) → 1 as l → ∞, resolving the k=4 case of Erdős #1014 conditional on the Mattheus–Verstraëte lower bound and AKS upper bound",
+      "Proved increment_bound_k4: R(4,l+1) ≤ R(4,l) + R(3,l+1) from the Ramsey recurrence at k=4",
+      "Proved log_cubed_le_mul: the quantitative form of (log l)³ = o(l), via log = o(l^(1/3)) and cubing (bulletproof manual mul_le_mul chain to avoid version-sensitive pow lemmas)",
+      "Proved R4_rate_of_convergence: explicit rate |R(4,l+1)/R(4,l) - 1| ≤ (4C/c)·(log l)³/l",
+      "Introduced the Mattheus–Verstraëte lower bound as axiom R4_lower_MV, faithfully citing the 2024 Annals result"
+    ],
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "description": "Resolves the k=4 case of the parent formalization of Erdős #1014.",
+      "targetId": "erdos-1014"
+    },
+    {
+      "relationship": "extends",
+      "description": "Parallels OQ-01's k=3 proof (recurrence + lower bound), now applied at k=4 with the increment governed by R(3,·) and the size by the Mattheus–Verstraëte bound for R(4,·).",
+      "targetId": "erdos-1014-oq-01"
+    },
+    {
+      "relationship": "related",
+      "description": "OQ-02 established the O(log l / l) rate for k=3; this file gives the analogous O((log l)³ / l) rate for k=4.",
+      "targetId": "erdos-1014-oq-02"
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports-and-setup",
+      "title": "Imports, Namespace, and the Mattheus–Verstraëte Axiom",
+      "startLine": 48,
+      "endLine": 76,
+      "summary": "Imports Mathlib and Proofs.Erdos1014Problem (12 inherited Ramsey axioms + supporting lemmas). Declares the file's single own axiom R4_lower_MV: ∃ c > 0, ∃ L₀, ∀ l > L₀, R(4,l) ≥ c·l³/(log l)⁴.",
+      "mathContext": "R4_lower_MV encodes the lower-bound half of Mattheus & Verstraëte, 'The asymptotics of r(4,t)', Annals of Mathematics 199 (2024): R(4,t) = Θ(t³/log⁴ t) up to a polylog gap. Not present in Mathlib, so stated as a hypothesis of the k=4 argument."
+    },
+    {
+      "id": "increment-k4",
+      "title": "The Increment Bound for k=4",
+      "startLine": 78,
+      "endLine": 95,
+      "summary": "Theorem increment_bound_k4: R(4,l+1) ≤ R(4,l) + R(3,l+1), obtained from the imported ramsey_recurrence at k=4 (with 4-1=3).",
+      "mathContext": "Unlike k=3, where the increment R(2,l+1)=l+1 is linear, the k=4 increment R(3,l+1) grows like l²/log l. It is still asymptotically negligible against R(4,l)=Ω(l³/(log l)⁴)."
+    },
+    {
+      "id": "log-cubed",
+      "title": "(log l)³ = o(l)",
+      "startLine": 97,
+      "endLine": 152,
+      "summary": "Theorem log_cubed_le_mul: for any slope m > 0, eventually (log l)³ ≤ m·l. Proof uses Mathlib's isLittleO_log_rpow_atTop with exponent 1/3 and constant m^(1/3), then cubes: (log l)³ ≤ (m^(1/3)·l^(1/3))³ = m·l.",
+      "mathContext": "The cubing step is done via an explicit mul_le_mul chain (avoiding version-sensitive pow_le_pow_left), and (l^(1/3))³ = l is proved through rpow_natCast/rpow_mul/rpow_one."
+    },
+    {
+      "id": "ratio-k4",
+      "title": "R(4,l+1)/R(4,l) → 1",
+      "startLine": 154,
+      "endLine": 233,
+      "summary": "Theorem R4_ratio_convergence: ∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(4,l+1)/R(4,l) - 1| < ε. The absolute value collapses to (R(4,l+1)-R(4,l))/R(4,l) by monotonicity; then chain R(3,l+1) ≤ 4C·l²/log l and R(4,l) ≥ c·l³/(log l)⁴ to bound the quotient by (4C/c)·(log l)³/l, which is < ε for l large by log_cubed_le_mul with slope cε/(8C).",
+      "mathContext": "The key ratio identity (4C·l²/log l)/(c·l³/(log l)⁴) = (4C/c)·(log l)³/l is discharged by field_simp; ring. The slope cε/(8C) makes the final bound ε/2 < ε."
+    },
+    {
+      "id": "rate-k4",
+      "title": "Explicit Rate O((log l)³ / l)",
+      "startLine": 235,
+      "endLine": 305,
+      "summary": "Theorem R4_rate_of_convergence: ∃ A > 0, ∃ L₀, ∀ l > L₀, |R(4,l+1)/R(4,l) - 1| ≤ A·(log l)³/l with A = 4C/c. Same chain as R4_ratio_convergence but stopping at the explicit rate rather than pushing to < ε.",
+      "mathContext": "A = 4C/c with c the Mattheus–Verstraëte lower constant and C the AKS upper constant. Since (log l)³ = o(l), the bound tends to 0 — an independent packaging of the convergence."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #1014 asks whether R(k,l+1)/R(k,l) → 1 as l → ∞ for fixed k ≥ 3. The k=3 case yields to an elementary argument: the recurrence R(3,l+1) ≤ R(3,l) + (l+1) bounds increments linearly, while Kim's 1995 lower bound R(3,l) ≥ c·l²/log l forces super-linear growth, so the ratio converges. The same 'small increment vs. large size' principle applies at k=4 once one has a strong enough lower bound on R(4,l): the increment R(4,l+1)-R(4,l) ≤ R(3,l+1) is only O(l²/log l), whereas Sam Mattheus and Jacques Verstraëte, in their celebrated 2024 Annals of Mathematics paper 'The asymptotics of r(4,t)', proved R(4,t) = Ω(t³/log⁴ t) (via pseudorandom algebraic — Cayley-graph — constructions), matching the classical O(t³/log²t) upper bound up to a polylog gap. Dividing the increment by the size gives O((log l)³ / l) → 0, settling the k=4 case conditional on these two established bounds.",
+    "problemStatement": "Does R(4,l+1)/R(4,l) → 1 as l → ∞ (the k=4 case of Erdős #1014)?",
+    "text": "Yes. R(4,l+1)/R(4,l) → 1, with explicit rate O((log l)³ / l), conditional on the Mattheus–Verstraëte lower bound R(4,l) ≥ c·l³/(log l)⁴ and the AKS upper bound R(3,l) ≤ C·l²/log l.",
+    "proofStrategy": "Bound the increment by R(3,l+1) via the Ramsey recurrence; bound R(3,l+1) above by the AKS estimate (≤ 4C·l²/log l after absorbing the l→l+1 factors); bound R(4,l) below by the Mattheus–Verstraëte estimate; divide to get (4C/c)·(log l)³/l and use (log l)³ = o(l).",
+    "keyInsights": [
+      "The k=4 case reduces to the same 'increment vs. size' mechanism as k=3, but now the increment is R(3,·) = O(l²/log l) rather than the linear R(2,·) = l+1",
+      "The Mattheus–Verstraëte lower bound R(4,l) = Ω(l³/(log l)⁴) is exactly the strong-enough size estimate that makes the increment negligible: (l²/log l)/(l³/(log l)⁴) = (log l)³/l → 0",
+      "The polylog gap between the O(l³/log²l) upper bound and Ω(l³/log⁴l) lower bound for R(4,l) does not obstruct the ratio argument — only a matching order of magnitude in l is needed",
+      "The rate O((log l)³ / l) for k=4 is the natural analogue of the O(log l / l) rate for k=3; each extra Ramsey index raises the power of log by two",
+      "The proof is fully modular: it reuses the imported Ramsey framework (recurrence, monotonicity, positivity) and adds only the one deep input R4_lower_MV specific to k=4"
+    ],
+    "prerequisites": [
+      "Ramsey theory",
+      "Asymptotic analysis",
+      "Real analysis (little-o notation)"
+    ]
+  },
+  "conclusion": {
+    "summary": "R(4,l+1)/R(4,l) → 1 as l → ∞, with explicit rate O((log l)³ / l). The proof combines the Ramsey recurrence increment R(4,l+1)-R(4,l) ≤ R(3,l+1) = O(l²/log l) with the Mattheus–Verstraëte lower bound R(4,l) = Ω(l³/(log l)⁴), conditional on both being taken as axioms (they are established literature results absent from Mathlib).",
+    "implications": "Combined with the k=3 result, this shows the Erdős #1014 ratio conjecture holds for k=3 and k=4 by a uniform elementary mechanism, once a lower bound of the conjectured order of magnitude is available. It highlights that the bottleneck for general k is precisely the existence of order-of-magnitude lower bounds R(k,l) = Ω(l^{k-1}/polylog) — the Mattheus–Verstraëte breakthrough supplied this for k=4.",
+    "openQuestions": [
+      "Can the k=4 case be made unconditional by formalizing the Mattheus–Verstraëte construction inside Lean/Mathlib?",
+      "Is the O((log l)³ / l) rate tight for k=4?",
+      "Does the same mechanism settle k=5 given a lower bound R(5,l) = Ω(l⁴/polylog)?",
+      "Can the polylog gap for R(4,l) be closed, sharpening the rate constant?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos1014Problem"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos1014OQ04",
+    "lineCount": 305,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "substantiveTheoremCount": 4,
+    "mainTheorems": [
+      {
+        "name": "R4_ratio_convergence",
+        "type": "core",
+        "description": "The k=4 case of Erdős #1014: R(4,l+1)/R(4,l) → 1 as l → ∞",
+        "leanType": "∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(4,l+1)/R(4,l) - 1| < ε"
+      },
+      {
+        "name": "R4_rate_of_convergence",
+        "type": "core",
+        "description": "Explicit rate bound |R(4,l+1)/R(4,l) - 1| ≤ (4C/c)·(log l)³/l",
+        "leanType": "∃ A > 0, ∃ L₀, ∀ l > L₀, |R(4,l+1)/R(4,l) - 1| ≤ A·(log l)³/l"
+      },
+      {
+        "name": "increment_bound_k4",
+        "type": "key",
+        "description": "Ramsey recurrence at k=4: R(4,l+1) ≤ R(4,l) + R(3,l+1)",
+        "leanType": "∀ l ≥ 1, R(4,l+1) ≤ R(4,l) + R(3,l+1)"
+      },
+      {
+        "name": "log_cubed_le_mul",
+        "type": "key",
+        "description": "Quantitative (log l)³ = o(l): eventually (log l)³ ≤ m·l for any m > 0",
+        "leanType": "∀ m > 0, ∃ L₀, ∀ l > L₀, (log l)³ ≤ m·l"
+      }
+    ],
+    "path": "Proofs/Erdos1014OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "key": "Er71",
+      "citation": "Erdős, P., On some extremal problems on r-graphs, Discrete Mathematics 1(1) (1971), 1–6.",
+      "type": "paper"
+    },
+    {
+      "key": "MV24",
+      "citation": "Mattheus, S. and Verstraëte, J., The asymptotics of r(4,t), Annals of Mathematics 199(2) (2024), 919–941.",
+      "type": "paper"
+    },
+    {
+      "key": "AKS80",
+      "citation": "Ajtai, M., Komlós, J., and Szemerédi, E., A note on Ramsey numbers, Journal of Combinatorial Theory Series A 29(3) (1980), 354–360.",
+      "type": "paper"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1014-oq-04.json
+++ b/src/data/research/problems/erdos-1014-oq-04.json
@@ -1,39 +1,72 @@
 {
   "slug": "erdos-1014-oq-04",
   "title": "Ramsey Ratio Convergence via Mattheus-Verstraete Bounds",
-  "phase": "NEW",
+  "phase": "FORMALIZATION",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in graph theory: Ramsey Ratio Convergence via Mattheus-Verstraete Bounds.",
-    "whyMatters": []
+    "formal": "For k = 4: \\forall \\varepsilon > 0, \\exists L_0, \\forall l > L_0, |R(4,l+1)/R(4,l) - 1| < \\varepsilon. Uses the Ramsey recurrence R(4,l+1) \\le R(4,l) + R(3,l+1), the AKS upper bound R(3,l) \\le C l^2/\\log l, and the Mattheus-Verstraete (Annals 2024) lower bound R(4,l) \\ge c l^3/(\\log l)^4.",
+    "plain": "Resolve the k=4 case of Erdos #1014 (R(k,l+1)/R(k,l) -> 1) by combining the Ramsey recurrence with the Mattheus-Verstraete lower bound R(4,l) = Omega(l^3/log^4 l) and the AKS upper bound R(3,l) = O(l^2/log l). The increment R(4,l+1)-R(4,l) <= R(3,l+1) = O(l^2/log l) is negligible against the size R(4,l), giving ratio -> 1 with rate O((log l)^3 / l).",
+    "whyMatters": [
+      "Extends the k=3 resolution (OQ-01/OQ-02) to k=4, showing a uniform 'increment vs size' mechanism",
+      "Demonstrates that the Mattheus-Verstraete 2024 breakthrough lower bound is exactly what unlocks the k=4 case",
+      "Provides an explicit convergence rate O((log l)^3 / l), the natural analogue of the k=3 rate O(log l / l)"
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "increment_bound_k4: R(4,l+1) <= R(4,l) + R(3,l+1) (from Ramsey recurrence at k=4)",
+      "log_cubed_le_mul: (log l)^3 = o(l), quantitative form",
+      "R4_ratio_convergence: R(4,l+1)/R(4,l) -> 1 as l -> infinity",
+      "R4_rate_of_convergence: |R(4,l+1)/R(4,l) - 1| <= (4C/c)(log l)^3 / l"
+    ],
+    "open": [
+      "Unconditional k=4 (formalize Mattheus-Verstraete construction in Lean)",
+      "General k given R(k,l) = Omega(l^{k-1}/polylog) lower bounds"
+    ],
+    "goal": "Prove R(4,l+1)/R(4,l) -> 1 conditional on the Mattheus-Verstraete and AKS bounds."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-03-30T22:19:31.121Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "FORMALIZATION",
+    "since": "2026-07-02T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "Lean formalization of the k=4 ratio convergence drafted (Proofs/Erdos1014OQ04.lean, 4 theorems, 1 own axiom, 0 sorries).",
+    "blockers": [
+      "Local Lean build verification blocked: Docker containerd store corrupted + data volume 100% full at authoring time. File authored against the exact lemma signatures the sibling Erdos1014OQ02.lean compiled with (Mathlib 4.26.0); must be built before merge."
+    ],
+    "nextAction": "Build Proofs.Erdos1014OQ04 via docker-build.sh once disk/Docker are healthy; fix any residual tactic errors; then mark verified/axiomatized.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Drafted a complete Lean formalization of the k=4 case of Erdos #1014 in Proofs/Erdos1014OQ04.lean (4 theorems, 1 own axiom R4_lower_MV, 0 sorries), modeled on the verified sibling Erdos1014OQ02.lean. Core argument: |R(4,l+1)/R(4,l) - 1| = (R(4,l+1)-R(4,l))/R(4,l) <= R(3,l+1)/R(4,l) <= (4C/c)(log l)^3/l -> 0. Uses the Ramsey recurrence (increment_bound_k4), the AKS upper bound R3_upper for the increment, and a new axiom R4_lower_MV for the Mattheus-Verstraete lower bound R(4,l) >= c l^3/(log l)^4. Gallery entry (meta.json + annotations.json) created. NOT yet machine-verified: build infra (Docker + disk) was down at authoring time.",
+    "builtItems": [
+      "increment_bound_k4",
+      "log_cubed_le_mul",
+      "R4_ratio_convergence",
+      "R4_rate_of_convergence",
+      "axiom R4_lower_MV (Mattheus-Verstraete lower bound)"
+    ],
+    "insights": [
+      "The k=4 case reduces to the identical 'small increment vs large size' mechanism as k=3; the only new deep input needed is a lower bound R(4,l) = Omega(l^3/polylog).",
+      "The Mattheus-Verstraete (Annals 2024) bound R(4,t) = Theta(t^3/log^4 t) supplies exactly this: increment/size = (l^2/log l)/(l^3/(log l)^4) = (log l)^3/l -> 0.",
+      "The polylog gap between the O(l^3/log^2 l) upper and Omega(l^3/log^4 l) lower bounds for R(4,l) is irrelevant to the ratio argument — only matching order in l matters.",
+      "Rate pattern: k=3 gives O(log l / l), k=4 gives O((log l)^3 / l); each Ramsey index adds two powers of log.",
+      "Cubing an inequality robustly: prefer an explicit mul_le_mul chain over pow_le_pow_left (renamed to pow_le_pow_left0 in recent Mathlib)."
+    ],
+    "mathlibGaps": [
+      "Mattheus-Verstraete lower bound R(4,t) = Omega(t^3/log^4 t) is not in Mathlib (axiomatized as R4_lower_MV).",
+      "The Ramsey number itself and its recurrence/monotonicity/AKS bounds are axiomatized in the parent Erdos1014Problem.lean."
+    ],
+    "nextSteps": [
+      "Run ./proofs/scripts/docker-build.sh Proofs.Erdos1014OQ04 once infra is healthy.",
+      "Fix any residual tactic mismatches (candidate risk points: rpow_natCast/rpow_mul exponent normalization, field_simp on compound fractions, div_le_div_of_nonneg_left/right names).",
+      "Once verified, update meta.json status if appropriate (remains axiomatized due to R4_lower_MV + inherited framework)."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Resolves the **k=4 case** of Erdős Problem #1014 — that $R(k,l+1)/R(k,l) \to 1$ as $l \to \infty$ — conditional on two established (but non-Mathlib) bounds:

- **Mattheus–Verstraëte (Annals 2024)** lower bound: $R(4,l) \ge c\,l^3/(\log l)^4$ (axiom `R4_lower_MV`)
- **Ajtai–Komlós–Szemerédi (1980)** upper bound: $R(3,l) \le C\,l^2/\log l$ (imported `R3_upper`)

### Argument
The k=3 case (OQ-01/OQ-02) used the linear increment $R(3,l+1)-R(3,l) \le l+1$. At k=4 the increment is governed by $R(3,l+1) = O(l^2/\log l)$, still negligible against $R(4,l) = \Omega(l^3/(\log l)^4)$:
$$\Big|\tfrac{R(4,l+1)}{R(4,l)} - 1\Big| = \tfrac{R(4,l+1)-R(4,l)}{R(4,l)} \le \tfrac{R(3,l+1)}{R(4,l)} \le \tfrac{4C}{c}\cdot\tfrac{(\log l)^3}{l} \to 0.$$

### New file `Proofs/Erdos1014OQ04.lean` (4 theorems, 1 own axiom, 0 sorries)
- `increment_bound_k4`: $R(4,l+1) \le R(4,l) + R(3,l+1)$
- `log_cubed_le_mul`: quantitative $(\log l)^3 = o(l)$
- `R4_ratio_convergence`: $R(4,l+1)/R(4,l) \to 1$
- `R4_rate_of_convergence`: explicit rate $O((\log l)^3 / l)$

Gallery entry (`meta.json` + `annotations.json`) added; research problem JSON updated.

## ⚠️ Build status — DRAFT
**Not locally machine-verified.** At authoring time the build environment was down: the Docker containerd store was corrupted and the data volume was 100% full, and a host Mathlib build is forbidden by repo policy. The file was authored against the exact lemma signatures the sibling `Erdos1014OQ02.lean` compiled with (Mathlib 4.26.0).

**Before un-drafting / merging:** run `./proofs/scripts/docker-build.sh Proofs.Erdos1014OQ04` and fix any residual tactic mismatches. Candidate risk points are noted in the problem JSON's `nextSteps` (rpow exponent normalization, `field_simp` on compound fractions, `div_le_div_of_nonneg_*` names).

## Status
`axiomatized` / badge `axiom` — depends on `R4_lower_MV` plus the inherited Ramsey framework axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)