### PR TITLE
research(abel-ruffini-oq-03-oq-01): isolate Aₙ-simplicity 3-cycle lemma [WIP, 1 sorry]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
@@ -1,0 +1,164 @@
+/-
+  Unconditional simplicity of Aₙ (n ≥ 5), reduced to a single classical lemma
+  (Open Question OQ-03-OQ-01 of abel-ruffini-galois-extensions).
+
+  ## STATUS: WORK IN PROGRESS (1 sorry — the classical combinatorial core)
+
+  This file is *not* a verified gallery entry.  It isolates and states the single
+  remaining hard lemma needed to upgrade the parent file's *conditional* reduction
+  (`AbelRuffiniGaloisExtensionsOQ03`) into an **unconditional** proof that the
+  alternating group `Aₙ` is simple for every `n ≥ 5`, generalizing Mathlib's
+  `alternatingGroup.isSimpleGroup_five` (which covers only `Fin 5`).
+
+  ## What the parent already established (0 sorry)
+
+  `AbelRuffiniGaloisExtensionsOQ03` proved the *formal* half of the classical
+  theorem:
+
+    `isSimpleGroup_of_forall_normal_contains_threeCycle`
+      (5 ≤ card α) → (every nontrivial normal H ⊴ Aₙ contains a 3-cycle)
+                   → IsSimpleGroup (Aₙ)
+
+  together with the converse and the headline `iff`.  The genuinely combinatorial
+  content of the simplicity theorem was thereby isolated to the single statement
+
+      **every nontrivial normal subgroup of `Aₙ` (n ≥ 5) contains a 3-cycle.**
+
+  ## What this file adds
+
+  * `exists_mem_isThreeCycle_of_normal` — the isolated classical lemma, currently a
+    `sorry`.  This is the *only* open content; it is a KNOWN result (not an open
+    conjecture), so it is a candidate for Aristotle / a dedicated formalization
+    session.
+  * `isSimpleGroup_alternating` — the unconditional simplicity theorem for all
+    `n ≥ 5`, obtained by feeding the lemma into the parent's reduction.  This body
+    is complete; it inherits exactly one `sorry` transitively.
+
+  ## Proof plan for `exists_mem_isThreeCycle_of_normal`
+     (Jordan's minimal-support / commutator argument)
+
+  Let `H ⊴ Aₙ` be normal with `H ≠ ⊥`, `n = card α ≥ 5`.
+
+  1. Since `alternatingGroup α` is finite and `H ≠ ⊥`, the set
+     `{ x ∈ H | x ≠ 1 }` is a nonempty finite set.  Choose `σ` in it minimizing
+     `(σ : Perm α).support.card`  (`Finset.exists_min_image`).
+
+  2. `σ ≠ 1` and `σ` is even, so `σ` moves at least 3 points:
+     `#σ.support ≥ 3`  (an even permutation cannot move exactly 1 or 2 points;
+     `sum_cycleType` + `two_le_of_mem_cycleType`).
+
+  3. **Claim: `σ` is a 3-cycle.**  If `#σ.support = 3` then `σ.IsThreeCycle`
+     directly (`card_support_eq_three_iff`), and `σ ∈ H`, so we are done.
+
+  4. Otherwise `#σ.support ≥ 4`; derive a contradiction with minimality by
+     exhibiting a nonidentity element of `H` supported on strictly fewer points.
+     Split on the cycle type of `σ`:
+
+     * **(A) `σ` has a cycle of length `≥ 3`.**  Write that cycle as `(a b c …)`.
+       Since `#σ.support ≥ 5` in this branch (an even perm with a ≥3-cycle moving
+       ≥4 points moves ≥5), pick two further moved points `d, e` and set
+       `τ = (c d e)` (a 3-cycle, hence in `Aₙ`).  The commutator
+       `ρ = τ σ τ⁻¹ σ⁻¹` lies in `H` (normality: `τ σ τ⁻¹ ∈ H`, `σ⁻¹ ∈ H`), is
+       `≠ 1`, and satisfies `ρ.support ⊆ σ.support ∪ τ • σ.support` with the
+       count strictly below `#σ.support` — contradiction.
+
+     * **(B) `σ` is a product of disjoint transpositions** (all cycle lengths 2),
+       necessarily `≥ 2` of them (evenness).  With `σ = (a b)(c d) …` choose a 5th
+       point `e` (exists, `n ≥ 5`) and `τ = (c d e)`.  The commutator
+       `ρ = τ σ τ⁻¹ σ⁻¹ ∈ H` is a 3-cycle or moves strictly fewer points,
+       contradicting minimality (or finishing directly).
+
+  ## Mathlib API this plan relies on (all confirmed present)
+
+  * `Equiv.Perm.support_mul_le`, `Equiv.Perm.support_conj`,
+    `Equiv.Perm.card_support_conj`      — support of products / conjugates
+  * `Equiv.Perm.sum_cycleType`, `Equiv.Perm.two_le_of_mem_cycleType`
+  * `card_support_eq_three_iff`          — 3 moved points ⇔ 3-cycle
+  * `Equiv.Perm.isThreeCycle_swap_mul_swap_same`
+  * `Subgroup.Normal.conj_mem`           — commutator membership
+  * `Finset.exists_min_image`            — minimal-support selection
+
+  ## Size / buildability assessment
+
+  The strict-support-decrease counting in step 4 is the crux (≈300–800 lines,
+  comparable to Mathlib's `Fin 5` casework but for arbitrary `α`).  Classified
+  HARD, not OPEN.  Best executed via Aristotle (currently unavailable) or a
+  dedicated session with a working build loop.
+-/
+import Mathlib.GroupTheory.SpecificGroups.Alternating
+import Mathlib.Tactic
+
+open Equiv Equiv.Perm Subgroup
+
+namespace AbelRuffiniGaloisExtensionsOQ03OQ01
+
+open alternatingGroup
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-! ### The formal reduction (re-derived, 0 sorry)
+
+These two lemmas reproduce the verified reduction from
+`AbelRuffiniGaloisExtensionsOQ03`, inlined here so that this file depends only on
+Mathlib (allowing single-file elaboration).  They contain no `sorry`; only
+`exists_mem_isThreeCycle_of_normal` below does. -/
+
+/-- If a normal subgroup `H ⊴ Aₙ` (`n ≥ 5`) contains a 3-cycle, then `H = ⊤`.
+Upgrades Mathlib's `IsThreeCycle.alternating_normalClosure` (normal closure of a
+single 3-cycle) to an arbitrary normal subgroup. -/
+theorem threeCycle_normal_eq_top
+    (h5 : 5 ≤ Fintype.card α)
+    {H : Subgroup (alternatingGroup α)} (hHn : H.Normal)
+    {g : alternatingGroup α} (hg : IsThreeCycle (g : Perm α)) (hgH : g ∈ H) :
+    H = ⊤ := by
+  haveI := hHn
+  have hclosed : normalClosure ({g} : Set (alternatingGroup α)) ≤ H :=
+    normalClosure_le_normal (Set.singleton_subset_iff.2 hgH)
+  have hgeq : (⟨(g : Perm α), hg.mem_alternatingGroup⟩ : alternatingGroup α) = g :=
+    Subtype.ext rfl
+  have htop : normalClosure ({g} : Set (alternatingGroup α)) = ⊤ := by
+    rw [← hgeq]; exact hg.alternating_normalClosure h5
+  rw [htop] at hclosed
+  exact top_le_iff.1 hclosed
+
+/-- If every nontrivial normal subgroup of `Aₙ` (`n ≥ 5`) contains a 3-cycle, then
+`Aₙ` is simple. -/
+theorem isSimpleGroup_of_forall_normal_contains_threeCycle
+    (h5 : 5 ≤ Fintype.card α)
+    (hcrux : ∀ (H : Subgroup (alternatingGroup α)), H.Normal → H ≠ ⊥ →
+        ∃ g : alternatingGroup α, IsThreeCycle (g : Perm α) ∧ g ∈ H) :
+    IsSimpleGroup (alternatingGroup α) := by
+  haveI : Nontrivial (alternatingGroup α) := nontrivial_of_three_le_card (by omega)
+  refine ⟨fun H hHn => ?_⟩
+  rcases eq_or_ne H ⊥ with h | h
+  · exact Or.inl h
+  · obtain ⟨g, hg, hgH⟩ := hcrux H hHn h
+    exact Or.inr (threeCycle_normal_eq_top h5 hHn hg hgH)
+
+/-! ### The classical combinatorial core (WIP) -/
+
+/-- **The classical combinatorial core (KNOWN result, WIP).** Every nontrivial
+normal subgroup of the alternating group on `α` (with `5 ≤ card α`) contains a
+3-cycle.  This is the sole open ingredient of the simplicity theorem; see the file
+header for the intended minimal-support / commutator proof plan.
+
+Currently a `sorry`: HARD, not OPEN. -/
+theorem exists_mem_isThreeCycle_of_normal
+    (h5 : 5 ≤ Fintype.card α)
+    (H : Subgroup (alternatingGroup α)) (hHn : H.Normal) (hbot : H ≠ ⊥) :
+    ∃ g : alternatingGroup α, IsThreeCycle (g : Equiv.Perm α) ∧ g ∈ H := by
+  sorry
+
+/-- **Unconditional simplicity of `Aₙ` for `n ≥ 5`.** Feeds the classical 3-cycle
+lemma into the parent file's formal reduction
+(`isSimpleGroup_of_forall_normal_contains_threeCycle`).  The body is complete; the
+result inherits exactly one `sorry`, namely `exists_mem_isThreeCycle_of_normal`.
+
+When that lemma is discharged, this generalizes Mathlib's `Fin 5`-only
+`alternatingGroup.isSimpleGroup_five` to every finite `α` with `5 ≤ card α`. -/
+theorem isSimpleGroup_alternating (h5 : 5 ≤ Fintype.card α) :
+    IsSimpleGroup (alternatingGroup α) :=
+  isSimpleGroup_of_forall_normal_contains_threeCycle
+    h5 (fun H hHn hbot => exists_mem_isThreeCycle_of_normal h5 H hHn hbot)
+
+end AbelRuffiniGaloisExtensionsOQ03OQ01

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
@@ -19,3 +19,52 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-02 (Session 1, researcher-4) — Isolate the classical core
+
+**Mode**: FRESH · **Outcome**: progress (ORIENT) · **PR**: #33855
+
+### What I did
+- Read Mathlib `GroupTheory/SpecificGroups/Alternating.lean`: confirmed Mathlib
+  proves simplicity only for `Fin 5` (`isSimpleGroup_five`) but supplies all the
+  generic converse machinery (`IsThreeCycle.alternating_normalClosure`,
+  `isThreeCycle_isConj`, `closure_three_cycles_eq_alternating`).
+- Confirmed the parent `AbelRuffiniGaloisExtensionsOQ03` already **verified** the
+  formal reduction (simplicity ⇐ every nontrivial normal subgroup has a 3-cycle).
+- Isolated the sole open content as the single lemma
+  `exists_mem_isThreeCycle_of_normal` and wrote a self-contained (Mathlib-only)
+  WIP file `AbelRuffiniGaloisExtensionsOQ03OQ01.lean`:
+  re-inlined reduction (0 sorry) + stated lemma (1 sorry, HARD) + assembled
+  `isSimpleGroup_alternating`.
+- **Single-file elaborated** the file against Mathlib v4.26.0 via `lake env lean`:
+  0 errors, only the expected `sorry` warning ⇒ statement + assembly typecheck.
+
+### Key findings
+- The entire remaining mathematical content of general Aₙ simplicity is this one
+  lemma; the assembly is a one-liner once it lands.
+- Correct proof route is **Jordan's minimal-support / commutator argument** (pick
+  σ ∈ H of minimal support; commutators [τ,σ] ∈ H of strictly smaller support
+  force σ to be a 3-cycle), *not* Mathlib's Fin-5 explicit casework (does not
+  generalize). Base case: even perm on exactly 3 points is a 3-cycle
+  (`card_support_eq_three_iff`).
+- Confirmed all needed Mathlib API exists: `support_conj`, `card_support_conj`,
+  `support_mul_le`, `sum_cycleType`, `two_le_of_mem_cycleType`,
+  `isThreeCycle_swap_mul_swap_same`, `Normal.conj_mem`, `Finset.exists_min_image`.
+
+### Blockers (environment, not mathematical)
+- Aristotle MCP down all session (`Resource not found` / 404) — could not delegate
+  the HARD lemma remotely.
+- Local Docker build corrupted (containerd metadata I/O error, lingering from a
+  prior disk-full episode) — could not run `docker-build.sh`; used single-file
+  `lake env lean` against prebuilt Mathlib oleans instead.
+
+### Next steps
+- When Aristotle returns: submit `exists_mem_isThreeCycle_of_normal` async with the
+  minimal-support/commutator hint (KNOWN math → Aristotle's strength).
+- Manual route (needs working build loop): prove a reusable commutator-support
+  bound, then the two cycle-type cases (≥3-cycle present; product of ≥2
+  transpositions), reducing support to 3.
+- On completion: promote to a verified gallery entry + consider a Mathlib PR
+  (general `alternatingGroup.isSimpleGroup`).

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
@@ -1,0 +1,110 @@
+{
+  "slug": "abel-ruffini-galois-extensions-oq-03-oq-01",
+  "title": "Every nontrivial normal subgroup of Aₙ (n≥5) contains a 3-cycle → unconditional Aₙ simplicity",
+  "path": "full",
+  "phase": "ORIENT",
+  "status": "in-progress",
+  "tier": "A",
+  "significance": 7,
+  "tractability": 6,
+  "started": "2026-07-02",
+  "lastUpdate": "2026-07-02",
+  "tags": [
+    "seeker-selected",
+    "galois-theory",
+    "group-theory",
+    "alternating-group",
+    "simple-groups"
+  ],
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-02",
+    "iteration": 1,
+    "focus": "Isolated the single classical lemma and stated the unconditional-simplicity assembly; documented the minimal-support/commutator proof plan.",
+    "blockers": [
+      "Aristotle MCP service returning 'Resource not found' (down) — cannot delegate the HARD lemma remotely this session.",
+      "Local Docker build corrupted (containerd metadata I/O error, lingering from a prior disk-full episode) — cannot run docker-build.sh."
+    ],
+    "nextAction": "When Aristotle is back up, submit exists_mem_isThreeCycle_of_normal async; otherwise formalize the minimal-support/commutator argument (steps 4A/4B) by hand with a working single-file build loop.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "problemStatement": {
+    "formal": "\\forall\\,(\\alpha : \\text{Fintype}),\\ 5 \\le |\\alpha| \\to \\forall H \\trianglelefteq A_\\alpha,\\ H \\ne \\bot \\to \\exists g \\in H,\\ g\\ \\text{is a 3-cycle}",
+    "plain": "Prove the classical cycle-type case-analysis lemma: every nontrivial normal subgroup of the alternating group on a finite set of at least 5 points contains a 3-cycle. Feeding this into the verified reduction of OQ-03 yields unconditional simplicity of Aₙ for all n ≥ 5, generalizing Mathlib's Fin-5-only isSimpleGroup_five.",
+    "whyMatters": [
+      "Mathlib proves alternating-group simplicity only for the concrete case alternatingGroup (Fin 5); the general n≥5 statement is a known gap.",
+      "The parent OQ-03 already reduced simplicity to this single 3-cycle-containment lemma; discharging it removes the last black box (isSimpleGroup_five) from the gallery's Abel–Ruffini chain."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent OQ-03 (0 sorry): threeCycle_normal_eq_top, isSimpleGroup_of_forall_normal_contains_threeCycle, isSimpleGroup_alternating_iff — the FORMAL half of the simplicity theorem.",
+      "Mathlib: IsThreeCycle.alternating_normalClosure (normal closure of one 3-cycle is ⊤ for n≥5), isThreeCycle_isConj, closure_three_cycles_eq_alternating, isSimpleGroup_five (Fin 5 only)."
+    ],
+    "open": [
+      "exists_mem_isThreeCycle_of_normal — the combinatorial core; classified HARD (known math), not OPEN."
+    ],
+    "goal": "IsSimpleGroup (alternatingGroup α) for every finite α with 5 ≤ card α, 0 sorry / 0 axiom."
+  },
+  "references": {
+    "papers": [
+      "Rotman, An Introduction to the Theory of Groups (minimal-support / commutator proof of Aₙ simplicity).",
+      "Jacobson, Basic Algebra I; Jordan's argument that a nontrivial normal subgroup of Aₙ contains a 3-cycle."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "Equiv.Perm.support_conj",
+      "Equiv.Perm.card_support_conj",
+      "Equiv.Perm.support_mul_le",
+      "card_support_eq_three_iff",
+      "Equiv.Perm.sum_cycleType",
+      "Equiv.Perm.two_le_of_mem_cycleType",
+      "Equiv.Perm.isThreeCycle_swap_mul_swap_same",
+      "Subgroup.Normal.conj_mem",
+      "Finset.exists_min_image"
+    ]
+  },
+  "relatedProofs": [
+    "abel-ruffini-galois-extensions-oq-03",
+    "abel-ruffini-galois-extensions",
+    "abel-ruffini"
+  ],
+  "leanFiles": [
+    {
+      "path": "proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean",
+      "status": "wip",
+      "sorries": 1,
+      "axioms": 0,
+      "note": "Self-contained (Mathlib-only): inlines the verified reduction, states the HARD lemma as the single sorry, and assembles unconditional simplicity (isSimpleGroup_alternating) conditional on it."
+    }
+  ],
+  "knowledge": {
+    "insights": [
+      "The reduction 'every nontrivial normal subgroup contains a 3-cycle ⟹ Aₙ simple' is ALREADY verified in parent OQ-03 (isSimpleGroup_of_forall_normal_contains_threeCycle). So the entire remaining content of general Aₙ simplicity is the single lemma exists_mem_isThreeCycle_of_normal — nothing else needs building.",
+      "Mathlib supplies all the converse machinery generically (alternating_normalClosure, isThreeCycle_isConj, closure_three_cycles_eq_alternating) but assembles simplicity only for Fin 5 via cycle-type casework specific to 5 points (isSimpleGroup_five). The general casework over arbitrary α is the open formalization.",
+      "Signatures line up exactly: isSimpleGroup_of_forall_normal_contains_threeCycle h5 (fun H hHn hbot => exists_mem_isThreeCycle_of_normal h5 H hHn hbot) : IsSimpleGroup (alternatingGroup α). So a one-line assembly yields the headline once the lemma lands.",
+      "Right proof route is Jordan's minimal-support/commutator argument (not Mathlib's Fin-5 explicit casework, which does not generalize): pick σ∈H of minimal support, show it must be a 3-cycle by building commutators [τ,σ]∈H of strictly smaller support for a well-chosen 3-cycle τ.",
+      "An even permutation moving exactly 3 points is automatically a 3-cycle (card_support_eq_three_iff), giving the base case; the work is the strict-support-decrease step forcing support down to 3."
+    ],
+    "builtItems": [
+      "proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean — WIP: threeCycle_normal_eq_top and isSimpleGroup_of_forall_normal_contains_threeCycle re-inlined (0 sorry), exists_mem_isThreeCycle_of_normal stated (1 sorry, HARD), isSimpleGroup_alternating assembled."
+    ],
+    "mathlibGaps": [
+      "Mathlib has NO general alternating-group simplicity — only alternatingGroup.isSimpleGroup_five (Fin 5). The n≥5 statement is a genuine Mathlib-worthy gap; exists_mem_isThreeCycle_of_normal is the missing ingredient.",
+      "No off-the-shelf 'minimal-support element of a subgroup' selector; would use Finset.exists_min_image over the filtered finite group.",
+      "No packaged commutator-support bound; must assemble from support_conj + support_mul_le + card_support_conj."
+    ],
+    "nextSteps": [
+      "When Aristotle is available: submit exists_mem_isThreeCycle_of_normal async with the minimal-support/commutator hint; it is KNOWN math (Aristotle's sweet spot), potentially multi-hour.",
+      "Manual route (needs working single-file build loop): (1) minimal-support selection via Finset.exists_min_image; (2) base case #support=3 ⟹ IsThreeCycle; (3) case 4A: σ has a ≥3-cycle → commutator with τ=(c d e) strictly reduces support; (4) case 4B: σ is a product of ≥2 disjoint transpositions → commutator with τ=(c d e) on a 5th point yields a 3-cycle or smaller support.",
+      "Prove a reusable commutator-support lemma: (τ*σ*τ⁻¹*σ⁻¹).support ⊆ σ.support ∪ (σ.support.map τ.toEmbedding), then bound its card.",
+      "Once landed, promote to a verified gallery entry and consider a Mathlib PR (general alternatingGroup.isSimpleGroup)."
+    ],
+    "progressSummary": "PROGRESS (ORIENT): isolated the sole open lemma, stated the unconditional-simplicity assembly, and recorded a concrete Lean-oriented minimal-support/commutator proof plan grounded in confirmed Mathlib API. No sorries discharged — Aristotle (down) and local Docker build (corrupted) both blocked verification this session; file self-contained on Mathlib for future single-file elaboration."
+  }
+}


### PR DESCRIPTION
## Summary

WIP research scaffolding for **unconditional simplicity of Aₙ (n ≥ 5)** — generalizing Mathlib's Fin-5-only `alternatingGroup.isSimpleGroup_five`.

The parent `AbelRuffiniGaloisExtensionsOQ03` already **verified** the formal reduction: *every nontrivial normal subgroup contains a 3-cycle ⟹ Aₙ simple*. This PR isolates the **sole remaining classical lemma**:

```
exists_mem_isThreeCycle_of_normal :
  5 ≤ card α → (H ⊴ Aₙ) → H ≠ ⊥ → ∃ g ∈ H, IsThreeCycle g
```

and assembles `isSimpleGroup_alternating` conditional on it.

## Status: WIP — 1 `sorry` (the classical combinatorial core)

- **Classified HARD, not OPEN** — this is known mathematics (Jordan's minimal-support / commutator argument), a candidate for Aristotle or a dedicated formalization session.
- The file is **self-contained on Mathlib** and was **single-file elaborated against Mathlib v4.26.0 with 0 errors** (only the expected `sorry` warning). The re-inlined reduction lemmas (`threeCycle_normal_eq_top`, `isSimpleGroup_of_forall_normal_contains_threeCycle`) are `sorry`-free.
- Not a verified gallery entry; no gallery data added.

## Why land it now

Full discharge was blocked this session: **Aristotle MCP was down** (404) and the **local Docker build was corrupted** (containerd I/O error). Landing preserves the isolated statement, the verified assembly, the documented proof plan (grounded in confirmed Mathlib API), and the accumulated knowledge JSON so a future session / Aristotle run can finish it.

Consistent with the 338 existing sorry-carrying WIP research files in the globbed build (`sorry` is a warning, not an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)