### PR TITLE
research(markov-equation-oq-06-oq-01): Vieta ascent grows at least geometrically, 2ⁿ ≤ top [VERIFIED, 0-axiom, new entry]

### DIFF
--- a/proofs/Proofs/MarkovEquationOQ06OQ01.lean
+++ b/proofs/Proofs/MarkovEquationOQ06OQ01.lean
@@ -1,0 +1,93 @@
+/-
+# Markov Equation — the Vieta ascent grows at least geometrically (OQ-06-OQ-01)
+
+The parent leaf `Proofs.MarkovEquationOQ06` builds the canonical **ascent
+sequence** of Markov triples rooted at `(1,1,1)`,
+
+  `(1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯`,
+
+by Vieta-jumping the smallest coordinate of a sorted triple
+(`ascent (a,b,c) = (b, c, 3bc − a)`), and proves the top coordinate is *strictly*
+increasing (`seq_top_strictMono`), whence the Markov solution set is infinite
+(`markov_infinite`).
+
+Strict monotonicity alone is only a `+1`-per-step bound. This file supplies the
+**quantitative** refinement flagged as an open question on the parent entry: the
+ascent does not merely increase the top coordinate, it **at least doubles** it,
+so the top coordinate of `seq n` is at least `2 ^ n`.
+
+## The doubling step
+
+On a sorted Markov triple `1 ≤ a ≤ b ≤ c` the new top coordinate is `3bc − a`,
+and
+
+  `3bc − a  ≥  3bc − c  =  3c(b − 1) + 2c  ≥  2c`,
+
+using `a ≤ c`, `b ≥ 1`, `c ≥ 1`.  Hence each step multiplies the maximum by at
+least `2` (`two_mul_top_le_succ`), and an easy induction from `(seq 0).2.2 = 1`
+gives the geometric lower bound
+
+  `2 ^ n ≤ (seq n).2.2`        (`seq_top_ge_two_pow`).
+
+As an immediate consequence the top coordinates are **unbounded**
+(`seq_top_unbounded`): for every bound `B` some Markov triple in the ascent
+sequence has top coordinate exceeding `B`.  This is the elementary growth input
+underlying quantitative statements about Markov numbers (e.g. that there are only
+finitely many below any bound, the starting point of Zagier's asymptotic count).
+
+Everything is axiom-free over `ℤ` and reuses the parent's `seq`/`seq_spec`.
+-/
+import Mathlib
+import Proofs.MarkovEquationOQ06
+
+namespace MarkovEquationOQ06OQ01
+
+open MarkovEquationOQ06 MarkovEquation
+
+/-- **The ascent at least doubles the top coordinate.** For every `n`,
+
+  `2 · (seq n).2.2 ≤ (seq (n+1)).2.2`.
+
+On the sorted Markov triple `(seq n) = (a,b,c)` the successor's top coordinate is
+`3bc − a`, and `3bc − a ≥ 2c` because `a ≤ c`, `b ≥ 1`, `c ≥ 1`
+(`3bc − a − 2c ≥ 3c(b−1) ≥ 0`). -/
+theorem two_mul_top_le_succ (n : ℕ) :
+    2 * (seq n).2.2 ≤ (seq (n + 1)).2.2 := by
+  obtain ⟨_, h1, hab, hbc⟩ := seq_spec n
+  -- abbreviations for the three coordinates of `seq n`
+  have hb1 : (1 : ℤ) ≤ (seq n).2.1 := le_trans h1 hab
+  have hac : (seq n).1 ≤ (seq n).2.2 := le_trans hab hbc
+  have hc0 : (0 : ℤ) ≤ (seq n).2.2 := le_trans (by norm_num) (le_trans hb1 hbc)
+  -- the successor's top coordinate is `3·b·c − a`, definitionally
+  have hval : (seq (n + 1)).2.2
+      = 3 * (seq n).2.1 * (seq n).2.2 - (seq n).1 := rfl
+  rw [hval]
+  -- `3bc − a − 2c ≥ 3c(b−1) ≥ 0`
+  nlinarith [mul_nonneg hc0 (by linarith : (0 : ℤ) ≤ (seq n).2.1 - 1), hac]
+
+/-- **Geometric lower bound.** The top coordinate of the `n`-th ascent triple is
+at least `2 ^ n`:
+
+  `(2 : ℤ) ^ n ≤ (seq n).2.2`.
+
+Immediate induction from `(seq 0).2.2 = 1` using the doubling step
+`two_mul_top_le_succ`. -/
+theorem seq_top_ge_two_pow (n : ℕ) : (2 : ℤ) ^ n ≤ (seq n).2.2 := by
+  induction n with
+  | zero => rw [seq_zero]; norm_num
+  | succ n ih =>
+    have hstep := two_mul_top_le_succ n
+    have hdouble : (2 : ℤ) * 2 ^ n ≤ 2 * (seq n).2.2 :=
+      mul_le_mul_of_nonneg_left ih (by norm_num)
+    calc (2 : ℤ) ^ (n + 1) = 2 * 2 ^ n := by ring
+      _ ≤ 2 * (seq n).2.2 := hdouble
+      _ ≤ (seq (n + 1)).2.2 := hstep
+
+/-- **The top coordinates are unbounded.** For every bound `B` there is an ascent
+triple whose top coordinate exceeds `B`.  (Consequence of the geometric bound and
+archimedeanity of `ℤ`.) -/
+theorem seq_top_unbounded (B : ℤ) : ∃ n, B < (seq n).2.2 := by
+  obtain ⟨n, hn⟩ := pow_unbounded_of_one_lt B (by norm_num : (1 : ℤ) < 2)
+  exact ⟨n, lt_of_lt_of_le hn (seq_top_ge_two_pow n)⟩
+
+end MarkovEquationOQ06OQ01

--- a/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "markov-oq0601-ann-header",
+    "proofId": "markov-equation-oq-06-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "From Strict Growth to Geometric Growth",
+    "content": "The parent Proofs.MarkovEquationOQ06 builds the Vieta ascent sequence of Markov triples rooted at (1,1,1) and proves its top coordinate strictly increases. Strict monotonicity over ℕ only gives top(seq n) ≥ n + 1. This file upgrades that to an exponential bound. The extra observation is quantitative: on a sorted Markov triple a ≤ b ≤ c the ascent's new top coordinate is 3bc − a, and 3bc − a ≥ 2c, so each step at least doubles the maximum. Iterating from (seq 0).top = 1 gives top(seq n) ≥ 2ⁿ, and hence the top coordinates are unbounded.",
+    "mathContext": "$3bc - a \\ge 3bc - c = 3c(b-1) + 2c \\ge 2c, \\qquad 2^n \\le (\\mathrm{seq}\\ n).\\text{top}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Markov equation",
+      "Vieta jumping",
+      "geometric growth",
+      "Markov numbers"
+    ],
+    "prerequisites": [
+      "the parent ascent sequence seq and seq_spec",
+      "induction",
+      "archimedean order"
+    ]
+  },
+  {
+    "id": "markov-oq0601-ann-doubling",
+    "proofId": "markov-equation-oq-06-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "Each Ascent Step At Least Doubles the Maximum",
+    "content": "two_mul_top_le_succ is the engine. The parent's seq_spec hands over a sorted Markov triple 1 ≤ a ≤ b ≤ c for seq n, and the successor's top coordinate is 3bc − a — read off definitionally by rfl from the ascent map. The inequality 2c ≤ 3bc − a is exactly 3bc − a − 2c ≥ 0, and 3bc − a − 2c ≥ 3c(b − 1) ≥ 0 since c ≥ 0 and b − 1 ≥ 0. A single nlinarith fed the nonnegative product c·(b − 1) together with a ≤ c closes it — no case split on whether b = 1 or b > 1.",
+    "mathContext": "$2\\,(\\mathrm{seq}\\,n)_3 \\le (\\mathrm{seq}\\,(n{+}1))_3 = 3bc - a, \\qquad 3bc - a - 2c \\ge 3c(b-1) \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vieta jumping",
+      "sorted triple invariant",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "seq_spec (sorted Markov triple)",
+      "definitional unfolding of ascent"
+    ]
+  },
+  {
+    "id": "markov-oq0601-ann-geometric",
+    "proofId": "markov-equation-oq-06-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 85
+    },
+    "type": "key-step",
+    "title": "The Geometric Lower Bound 2ⁿ",
+    "content": "seq_top_ge_two_pow packages the doubling step into an induction. The base case is (seq 0).top = 1 = 2⁰. The inductive step chains 2^(n+1) = 2·2ⁿ ≤ 2·(seq n).top ≤ (seq (n+1)).top: the first inequality is the induction hypothesis multiplied by the nonnegative constant 2 (mul_le_mul_of_nonneg_left), and the second is the doubling lemma. So the maximal coordinate of the n-th ascent triple is at least 2ⁿ — an exponential lower bound obtained from one linear inequality on a sorted triple.",
+    "mathContext": "$(2:\\mathbb{Z})^n \\le (\\mathrm{seq}\\ n)_3, \\qquad 2^{n+1} = 2\\cdot 2^n \\le 2\\,(\\mathrm{seq}\\,n)_3 \\le (\\mathrm{seq}\\,(n{+}1))_3.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction",
+      "geometric growth",
+      "monotone multiplication"
+    ],
+    "prerequisites": [
+      "two_mul_top_le_succ",
+      "mul_le_mul_of_nonneg_left"
+    ]
+  },
+  {
+    "id": "markov-oq0601-ann-unbounded",
+    "proofId": "markov-equation-oq-06-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 93
+    },
+    "type": "key-step",
+    "title": "Unboundedness of the Markov Numbers on the Ascent",
+    "content": "seq_top_unbounded turns the geometric bound into unboundedness. Given any bound B, archimedeanity of ℤ (pow_unbounded_of_one_lt with base 2 > 1) produces n with B < 2ⁿ, and 2ⁿ ≤ (seq n).top by the geometric bound, so B < (seq n).top. The top coordinates of the ascent sequence therefore exceed every bound — a second, quantitative route to the parent's infinitude conclusion, now phrased about the Markov numbers themselves rather than the set of triples.",
+    "mathContext": "$\\forall B\\ \\exists n,\\ B < (\\mathrm{seq}\\ n)_3, \\qquad B < 2^n \\le (\\mathrm{seq}\\ n)_3.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "archimedean order",
+      "unboundedness",
+      "Markov numbers"
+    ],
+    "prerequisites": [
+      "seq_top_ge_two_pow",
+      "pow_unbounded_of_one_lt"
+    ]
+  }
+]

--- a/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "markov-equation-oq-06-oq-01",
+  "title": "The Markov Vieta Ascent Grows at Least Geometrically: 2ⁿ ≤ (seq n).top",
+  "slug": "markov-equation-oq-06-oq-01",
+  "description": "The parent entry markov-equation-oq-06 builds the canonical Vieta ascent sequence of Markov triples rooted at (1,1,1) — (1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯ — and proves its top coordinate is strictly increasing (seq_top_strictMono), whence the Markov solution set is infinite. Strict monotonicity is only a +1-per-step bound. This child supplies the quantitative refinement listed as an open question on the parent: the ascent does not merely increase the top coordinate, it at least DOUBLES it. On a sorted Markov triple 1 ≤ a ≤ b ≤ c the successor's top coordinate is 3bc − a, and 3bc − a ≥ 3bc − c = 3c(b−1) + 2c ≥ 2c because a ≤ c, b ≥ 1, c ≥ 1 — so each step multiplies the maximum by at least 2 (two_mul_top_le_succ). An immediate induction from (seq 0).top = 1 gives the geometric lower bound 2ⁿ ≤ (seq n).top (seq_top_ge_two_pow), and archimedeanity of ℤ then yields that the top coordinates are unbounded (seq_top_unbounded): for every bound B some ascent triple has top coordinate exceeding B. This is the elementary growth input underlying quantitative statements about Markov numbers, e.g. that only finitely many lie below any bound — the starting point of Zagier's asymptotic count. Fully machine-checked over ℤ, 0 sorries and 0 axioms, reusing the parent's seq / seq_spec.",
+  "meta": {
+    "author": "Markov theory (classical); formalization original to Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MarkovEquationOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "markov-equation",
+      "vieta-jumping",
+      "markov-tree",
+      "growth-bound",
+      "geometric-growth"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-02",
+    "lineCount": 93,
+    "originalContributions": [
+      "two_mul_top_le_succ: the ascent step at least doubles the top coordinate, 2·(seq n).2.2 ≤ (seq (n+1)).2.2 — the successor's top is 3bc − a and 3bc − a − 2c ≥ 3c(b − 1) ≥ 0 on a sorted triple (a ≤ c, b ≥ 1, c ≥ 1), discharged by one nlinarith with the product c·(b−1) ≥ 0",
+      "seq_top_ge_two_pow: the geometric lower bound (2 : ℤ)^n ≤ (seq n).2.2, by induction from (seq 0).2.2 = 1 using the doubling step and mul_le_mul_of_nonneg_left",
+      "seq_top_unbounded: the top coordinates are unbounded — for every B there is n with B < (seq n).2.2, via pow_unbounded_of_one_lt (archimedeanity of ℤ) composed with the geometric bound"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms seq_top_ge_two_pow / two_mul_top_le_succ / seq_top_unbounded reports only the foundational propext / Classical.choice / Quot.sound. No native_decide is used. The proof imports the verified parent entry Proofs/MarkovEquationOQ06.lean (reusing seq, seq_spec, seq_zero) and through it Proofs/MarkovEquation.lean.",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "markov-equation-oq-06",
+      "relationship": "extends",
+      "description": "Sharpens the parent's qualitative growth statement. The parent proves the ascent sequence's top coordinate is strictly increasing (seq_top_strictMono, a +1-per-step bound) and concludes the solution set is infinite; this child proves each step at least doubles the top coordinate, giving the geometric bound 2ⁿ ≤ (seq n).top and unboundedness, and reuses the parent's seq and seq_spec directly."
+    },
+    {
+      "targetId": "markov-equation",
+      "relationship": "related",
+      "description": "The grandparent development runs the Markov tree downward (descent decreases the coordinate sum); this entry quantifies the upward direction, showing the ascent grows the maximal coordinate geometrically."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The positive solutions of the Markov equation x² + y² + z² = 3xyz form the Markov tree rooted at (1,1,1); the Markov numbers are the coordinates that appear. A basic quantitative question is how fast these numbers grow along the tree. The ascent sequence formalized by the parent reproduces the textbook head (1,1,1), (1,1,2), (1,2,5), (2,5,29), (5,29,433), … whose maximal coordinates 1, 2, 5, 29, 433, … grow super-geometrically. The clean, fully elementary lower bound is that each ascent step at least doubles the maximum, so the n-th maximum is at least 2ⁿ; this is the growth input behind counting results such as Zagier's asymptotic M(N) ∼ C(log N)² for the number of Markov numbers below N.",
+    "problemStatement": "Quantify the growth of the Vieta ascent sequence of Markov triples. Prove that each ascent step at least doubles the top coordinate, deduce the geometric lower bound 2ⁿ ≤ (seq n).top, and conclude that the sequence of top coordinates is unbounded.",
+    "proofStrategy": "One sorted-triple inequality, then induction and archimedeanity. (1) two_mul_top_le_succ: on the sorted Markov triple (seq n) = (a,b,c) supplied by the parent's seq_spec, the successor's top coordinate is 3bc − a (definitionally, via rfl), and 3bc − a − 2c ≥ 3c(b − 1) ≥ 0 using a ≤ c, b ≥ 1, c ≥ 1 — a single nlinarith fed the nonnegative product c·(b − 1). (2) seq_top_ge_two_pow: induct on n; the base is (seq 0).top = 1 = 2⁰, and the step chains 2^(n+1) = 2·2ⁿ ≤ 2·(seq n).top ≤ (seq (n+1)).top via mul_le_mul_of_nonneg_left and the doubling lemma. (3) seq_top_unbounded: given B, pow_unbounded_of_one_lt gives n with B < 2ⁿ ≤ (seq n).top.",
+    "keyInsights": [
+      "Strict monotonicity is qualitative; doubling is quantitative. The parent's seq_top_strictMono only gives top(seq n) ≥ n + 1. The single extra observation 3bc − a ≥ 2c upgrades this to top(seq n) ≥ 2ⁿ — an exponential lower bound from one linear inequality on a sorted triple.",
+      "The doubling reduces to one nonnegative product. 3bc − a − 2c ≥ 3c(b − 1) ≥ 0 because c ≥ 0 and b − 1 ≥ 0 on a sorted triple with b ≥ 1; feeding nlinarith the product c·(b − 1) ≥ 0 together with a ≤ c closes it with no case analysis.",
+      "No new arithmetic beyond the parent. The proof consumes the parent's seq (the iterated ascent map) and seq_spec (every term is a sorted Markov triple) as black boxes; the successor's top coordinate is read off definitionally by rfl, so the whole geometric bound is a two-line induction on top of existing infrastructure.",
+      "Geometric growth immediately gives unboundedness, hence infinitely many Markov numbers by a second route: the top coordinates already exhaust every bound, complementing the parent's Set.Infinite conclusion about triples."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-doubling",
+      "title": "The Doubling Step",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "two_mul_top_le_succ proves that one ascent step at least doubles the top coordinate: 2·(seq n).2.2 ≤ (seq (n+1)).2.2. Using the parent's seq_spec to get a sorted Markov triple 1 ≤ a ≤ b ≤ c, the successor's top coordinate 3bc − a (obtained by rfl) satisfies 3bc − a − 2c ≥ 3c(b − 1) ≥ 0, discharged by nlinarith with the nonnegative product c·(b − 1)."
+    },
+    {
+      "id": "sec-geometric",
+      "title": "The Geometric Lower Bound and Unboundedness",
+      "startLine": 74,
+      "endLine": 93,
+      "summary": "seq_top_ge_two_pow proves (2 : ℤ)^n ≤ (seq n).2.2 by induction from (seq 0).2.2 = 1, chaining 2^(n+1) = 2·2ⁿ ≤ 2·(seq n).2.2 ≤ (seq (n+1)).2.2 through the doubling step. seq_top_unbounded then uses pow_unbounded_of_one_lt (archimedeanity of ℤ) to show the top coordinates exceed every bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 0-axiom, 0-sorry formalization (93 lines, 3 theorems) proving that the Vieta ascent sequence of Markov triples grows at least geometrically: each step doubles the top coordinate (two_mul_top_le_succ), so 2ⁿ ≤ (seq n).top (seq_top_ge_two_pow), and the top coordinates are unbounded (seq_top_unbounded). It reuses the parent's seq and seq_spec directly and adds only one sorted-triple inequality.",
+    "implications": "This quantifies the parent's qualitative infinitude result: not only are there infinitely many Markov triples, their maximal coordinates grow at least exponentially in the tree depth. The geometric bound is the elementary input behind counting results for Markov numbers (only finitely many below any bound; Zagier's asymptotic). The template — turn a strict-monotonicity move into a multiplicative one by proving a single sorted-triple inequality, then induct — transfers to other Vieta-jumping families such as the Hurwitz equation x² + y² + z² = kxyz.",
+    "openQuestions": [
+      "Sharpen the base of the exponential: prove the top coordinate more than doubles for n ≥ 1 (e.g. top(seq (n+1)) ≥ 3·top(seq n) − 1 using b ≥ 1 and a ≤ b), giving a stronger lower bound than 2ⁿ.",
+      "Turn the lower bound into a two-sided estimate: bound top(seq n) above (each step at most triples the maximum since a ≥ 1 gives 3bc − a ≤ 3bc − 1 < 3bc ≤ 3c²), pinning the growth rate between 2ⁿ and a super-exponential ceiling.",
+      "Extend the geometric bound to the generalized Hurwitz equation x² + y² + z² = kxyz for k ≥ 1: does the ascent 3kbc − a still at least double the maximum, and how does the base depend on k?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Aigner, Martin",
+      "title": "Markov's Theorem and 100 Years of the Uniqueness Conjecture",
+      "year": "2013",
+      "venue": "Springer",
+      "note": "Monograph on Markov triples and the Markov tree; discusses the rapid growth of Markov numbers along the tree, quantified here as the geometric lower bound 2ⁿ on the ascent sequence's maximal coordinate."
+    },
+    {
+      "authors": "Zagier, Don",
+      "title": "On the number of Markoff numbers below a given bound",
+      "year": "1982",
+      "venue": "Mathematics of Computation 39(160), 709–723",
+      "note": "Asymptotic count M(N) ∼ C(log N)² of Markov numbers below N; rests on the tree growth whose elementary lower bound (geometric growth of the ascent maxima) is the content of this entry."
+    },
+    {
+      "authors": "Markov, Andrey A.",
+      "title": "Sur les formes quadratiques binaires indéfinies",
+      "year": "1880",
+      "venue": "Mathematische Annalen 17, 379–399",
+      "note": "The founding work introducing the equation x²+y²+z²=3xyz and its infinite tree of solutions."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 93,
+    "axiomCount": 0,
+    "path": "Proofs/MarkovEquationOQ06OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New **verified (0-axiom, 0-sorry)** gallery child of `markov-equation-oq-06`, answering an open question listed on the parent entry: **quantify the growth of the Vieta ascent sequence of Markov triples.**

The parent builds the ascent sequence rooted at `(1,1,1)` — `(1,1,1) → (1,1,2) → (1,2,5) → (2,5,29) → ⋯` — and proves its top coordinate is *strictly* increasing (a `+1`-per-step bound, `seq_top_strictMono`). This entry sharpens that to a **geometric** bound.

## Theorems (`proofs/Proofs/MarkovEquationOQ06OQ01.lean`)

- `two_mul_top_le_succ` — each ascent step **at least doubles** the top coordinate: `2·(seq n).2.2 ≤ (seq (n+1)).2.2`. On a sorted Markov triple `1 ≤ a ≤ b ≤ c` the successor's top is `3bc − a`, and `3bc − a − 2c ≥ 3c(b − 1) ≥ 0` (one `nlinarith` fed the nonnegative product `c·(b−1)`).
- `seq_top_ge_two_pow` — the geometric lower bound `(2 : ℤ)^n ≤ (seq n).2.2`, by induction from `(seq 0).2.2 = 1` using the doubling step.
- `seq_top_unbounded` — the top coordinates exceed every bound (archimedeanity of ℤ via `pow_unbounded_of_one_lt`).

## Method

Reuses the parent's `seq` (iterated ascent map) and `seq_spec` (every term is a sorted Markov triple) as black boxes; the successor's top coordinate is read off definitionally by `rfl`. The whole geometric bound is one sorted-triple inequality plus a two-line induction. This is the elementary growth input behind counting results for Markov numbers (Zagier's asymptotic `M(N) ∼ C(log N)²`).

## Verification

- Offline-verified with `lake env lean` against the pinned Mathlib (parents `MarkovEquation` + `MarkovEquationOQ06` built first): **exit 0, no warnings** (so 0 sorries).
- `#print axioms` on all three theorems reports only `propext / Classical.choice / Quot.sound` — **0 axioms, no `native_decide`, no `sorryAx`**.
- 93 lines, 3 theorems, 0 definitions. `status: verified`, `badge: original`.

New gallery entry: `src/data/proofs/markov-equation-oq-06-oq-01/` (meta.json + annotations.json). No changes to shared files (lakefile globs `Proofs.*`; deployer regenerates listings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)