### PR TITLE
research(minkowski-fundamental-theorem-oq-03-oq-01): add missing gallery entry [VERIFIED, 0-axiom]

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "van der Corput's k-fold refinement of Minkowski's theorem",
+    "content": "The header states van der Corput's theorem and its relationship to Minkowski and Blichfeldt. Minkowski (k = 1): a convex, centrally symmetric body of volume > 2ⁿ·covol(L) contains a nonzero lattice point. van der Corput: raising the threshold to k·2ⁿ·covol(L) yields at least k nonzero lattice points, which by central symmetry come in ± pairs. The measure-theoretic core is the parent entry's convexity-free Blichfeldt engine; this file supplies only the geometric passage from congruent points of ½s to lattice points of s. Mathlib formalizes Minkowski's k = 1 theorem but not the general-k count.",
+    "mathContext": "$k\\cdot(\\operatorname{covol}(L)\\cdot 2^n) < \\operatorname{vol}(s) \\Rightarrow \\exists\\,D\\subseteq L,\\ k\\le\\#D,\\ 0\\notin D,\\ \\forall v\\in D,\\ v\\in s.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "geometry of numbers",
+      "van der Corput theorem",
+      "Minkowski's fundamental theorem",
+      "Blichfeldt principle",
+      "central symmetry"
+    ],
+    "prerequisites": [
+      "lattices and covolume",
+      "convex symmetric bodies",
+      "Lebesgue / additive Haar measure"
+    ]
+  },
+  {
+    "id": "ann-passage-lemma",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 57, "endLine": 68 },
+    "type": "lemma",
+    "title": "half_diff_mem_of_symmetric_convex: congruent points give a lattice point",
+    "content": "The reusable geometric heart. For a convex, centrally symmetric set s in any real vector space, the scaled difference 2⁻¹·(a - b) of any two points a, b ∈ s again lies in s. The proof rewrites 2⁻¹·(a - b) = 2⁻¹·a + 2⁻¹·(-b): symmetry gives -b ∈ s, and convexity with weights (2⁻¹, 2⁻¹) places the midpoint of a and -b in s. This single lemma isolates exactly where central symmetry and convexity enter the geometry-of-numbers argument, and is stated with no measure structure so it can be reused freely.",
+    "mathContext": "$a,b\\in s,\\ s\\text{ convex symmetric} \\Rightarrow \\tfrac12(a-b) = \\tfrac12 a + \\tfrac12(-b) \\in s.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "convexity",
+      "central symmetry",
+      "midpoint",
+      "difference body"
+    ],
+    "prerequisites": [
+      "definition of a convex set",
+      "scalar multiplication in a real vector space"
+    ]
+  },
+  {
+    "id": "ann-half-volume",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 74, "endLine": 80 },
+    "type": "theorem",
+    "title": "measure_half_smul: the half-body volume identity",
+    "content": "vol(½s) = (2ⁿ)⁻¹·vol(s), with n = finrank ℝ E. Computed directly from Mathlib's additive-Haar scaling law addHaar_smul_of_nonneg, which gives vol(r•s) = ENNReal.ofReal(rⁿ)·vol(s) for r ≥ 0; here r = 2⁻¹, and ENNReal.ofReal((2⁻¹)ⁿ) is rewritten to (2ⁿ)⁻¹ via ofReal_pow, ofReal_inv_of_pos, ofReal_ofNat and inv_pow. This identity is the bridge that turns the van der Corput volume hypothesis k·covol(L)·2ⁿ < vol(s) into the plain Blichfeldt input k·covol(L) < vol(½s).",
+    "mathContext": "$\\operatorname{vol}(\\tfrac12 s) = (2^n)^{-1}\\,\\operatorname{vol}(s),\\quad n=\\dim_\\mathbb{R} E.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "additive Haar measure",
+      "scaling of volume",
+      "finrank"
+    ],
+    "prerequisites": [
+      "Haar measure on a finite-dimensional real space",
+      "ENNReal arithmetic"
+    ]
+  },
+  {
+    "id": "ann-reduction",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 82, "endLine": 104 },
+    "type": "key-step",
+    "title": "Reducing the volume hypothesis to the Blichfeldt input",
+    "content": "The statement of vanDerCorput and the first proof step. Using measure_half_smul, the hypothesis k • (μF · 2ⁿ) < μs is transformed into k • μF < μ(½s): multiplying the target inequality through by the finite, nonzero factor 2ⁿ and cancelling with ENNReal.mul_lt_mul_iff_left recovers exactly the volume excess consumed by the parent's Blichfeldt engine. This is where the 2ⁿ factor characteristic of Minkowski-type theorems is absorbed.",
+    "mathContext": "$k\\,\\mu F\\cdot 2^n < \\mu s \\iff k\\,\\mu F < (2^n)^{-1}\\mu s = \\mu(\\tfrac12 s).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "half-body trick",
+      "covolume comparison",
+      "ENNReal cancellation"
+    ],
+    "prerequisites": [
+      "measure_half_smul",
+      "strict inequalities in ℝ≥0∞"
+    ]
+  },
+  {
+    "id": "ann-assembly",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 141 },
+    "type": "tactic",
+    "title": "From the Blichfeldt family to nonzero lattice points",
+    "content": "The engine exists_finset_lattice_common_vadd applied to ½s yields a common point z and a finite T ⊆ L with k < #T such that z ∈ l +ᵥ ½s for all l ∈ T; unfolding the vadd (mem_vadd_set_iff_neg_vadd_mem, mem_inv_smul_set_iff₀) gives 2·(z - l) ∈ s. Fixing a base point l₀ ∈ T, each other l ∈ T produces the lattice point l - l₀, whose coercion equals 2⁻¹·(2(z - l₀) - 2(z - l)) and lands in s by half_diff_mem_of_symmetric_convex. The map l ↦ l - l₀ is injective (sub_left_injective) and hits 0 only at l₀, so its image over T.erase l₀ has #T - 1 ≥ k distinct nonzero lattice points of s.",
+    "mathContext": "$l\\mapsto l-l_0,\\ (l-l_0:E)=\\tfrac12\\bigl(2(z-l_0)-2(z-l)\\bigr)\\in s,\\quad \\#(T\\setminus\\{l_0\\})\\ge k.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Blichfeldt multiplicity",
+      "pointwise pigeonhole",
+      "injective image cardinality",
+      "pointwise vadd of sets"
+    ],
+    "prerequisites": [
+      "exists_finset_lattice_common_vadd (parent entry)",
+      "Finset.image and card_image_of_injective",
+      "coercion of subgroup subtraction"
+    ]
+  },
+  {
+    "id": "ann-minkowski",
+    "proofId": "minkowski-fundamental-theorem-oq-03-oq-01",
+    "range": { "startLine": 143, "endLine": 157 },
+    "type": "theorem",
+    "title": "Minkowski's fundamental theorem as the case k = 1",
+    "content": "minkowski_of_vanDerCorput specializes vanDerCorput to k = 1: a convex symmetric body of volume > covol(L)·2ⁿ contains a nonzero lattice point v, and by central symmetry its antipode -v ∈ s as well. This exhibits Minkowski's classical theorem not as a separate argument but as the smallest instance of the general count, with the antipode read off directly from h_symm — a clean demonstration that van der Corput's theorem is the honest generalization.",
+    "mathContext": "$\\mu F\\cdot 2^n < \\mu s \\Rightarrow \\exists\\,v\\in L,\\ v\\ne 0,\\ v\\in s\\ \\text{and}\\ -v\\in s.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Minkowski's fundamental theorem",
+      "specialization",
+      "antipode / ± pair"
+    ],
+    "prerequisites": [
+      "vanDerCorput",
+      "nonempty Finset from positive cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "minkowski-fundamental-theorem-oq-03-oq-01",
+  "title": "van der Corput's Convex-Body Counting Theorem",
+  "slug": "minkowski-fundamental-theorem-oq-03-oq-01",
+  "description": "The general-k (van der Corput) refinement of Minkowski's fundamental theorem, derived from the general-multiplicity Blichfeldt principle of the parent entry. A convex, centrally symmetric body s whose volume exceeds k·2ⁿ·covol(L) contains not just one nonzero lattice point (Minkowski, k = 1) but at least k of them: a finite set D ⊆ L with k ≤ #D, 0 ∉ D, and (v : E) ∈ s for every v ∈ D. Central symmetry sends each v to its antipode -v ∈ s, so the points come in ± pairs — the 'k pairs / k+1 points counting the origin' normalization of van der Corput's theorem. Mathlib formalizes only the k = 1 Minkowski convex-body theorem; the general-k count is not in Mathlib. The geometric passage from congruent points of ½s to genuine lattice points of s is packaged in the reusable lemma half_diff_mem_of_symmetric_convex, and Minkowski's fundamental theorem is recovered as the case k = 1 (with antipode).",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean",
+    "author": "Lean Genius",
+    "date": "2026",
+    "tags": [
+      "number-theory",
+      "geometry-of-numbers",
+      "van-der-corput",
+      "minkowski-theorem",
+      "blichfeldt",
+      "lattices",
+      "convex-body",
+      "measure-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 168,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-07-02",
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.Measure.addHaar_smul_of_nonneg",
+        "description": "μ (r • s) = ENNReal.ofReal (r ^ finrank ℝ E) · μ s for r ≥ 0 — gives vol(½s) = (2ⁿ)⁻¹·vol(s)",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar"
+      },
+      {
+        "theorem": "Set.mem_vadd_set_iff_neg_vadd_mem",
+        "description": "z ∈ l +ᵥ A ↔ -l +ᵥ z ∈ A — extracts z - l ∈ ½s from the Blichfeldt covering",
+        "module": "Mathlib.Algebra.Group.Pointwise.Set.Basic"
+      },
+      {
+        "theorem": "Set.mem_inv_smul_set_iff₀",
+        "description": "x ∈ a⁻¹ • A ↔ a • x ∈ A (a ≠ 0) — turns membership in ½s into 2·(z - l) ∈ s",
+        "module": "Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set"
+      },
+      {
+        "theorem": "Convex.smul",
+        "description": "convexity is preserved under scaling — ½s is convex, hence null-measurable",
+        "module": "Mathlib.Analysis.Convex.Function"
+      },
+      {
+        "theorem": "ENNReal.mul_lt_mul_iff_left",
+        "description": "a·c < b·c ↔ a < b for c ≠ 0, ≠ ∞ — cancels the 2ⁿ factor to compare k·covol(L) with vol(½s)",
+        "module": "Mathlib.Data.ENNReal.Operations"
+      }
+    ],
+    "originalContributions": [
+      "vanDerCorput: the general-k convex-body counting theorem — a convex, centrally symmetric body with vol(s) > k·covol(L)·2ⁿ contains at least k nonzero lattice points (a finite D ⊆ L, 0 ∉ D, all lattice points of s). Mathlib has only the k = 1 Minkowski theorem; this general count has no Mathlib counterpart. It is derived from the parent entry's Blichfeldt engine exists_finset_lattice_common_vadd applied to the half-body ½s.",
+      "half_diff_mem_of_symmetric_convex: the reusable 'congruent points → genuine lattice point' lemma — for convex symmetric s, a, b ∈ s ⟹ 2⁻¹·(a - b) ∈ s. This packages the central-symmetry / convexity passage that the parent's open question asked to be isolated.",
+      "measure_half_smul: the explicit half-body volume identity vol(½s) = (2ⁿ)⁻¹·vol(s), the bridge that turns the hypothesis k·covol(L)·2ⁿ < vol(s) into the Blichfeldt input k·covol(L) < vol(½s).",
+      "minkowski_of_vanDerCorput: Minkowski's fundamental theorem recovered as the case k = 1 — a convex symmetric body of volume > covol(L)·2ⁿ contains a nonzero lattice point together with its antipode."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Minkowski's fundamental theorem (1889) states that a convex, centrally symmetric body in ℝⁿ of volume exceeding 2ⁿ times the covolume of a lattice must contain a nonzero lattice point. J. G. van der Corput's refinement replaces the volume threshold 2ⁿ·covolume by k·2ⁿ·covolume and concludes with at least k pairs of nonzero lattice points (equivalently k+1 lattice points counting the origin). Both are consequences of Blichfeldt's convexity-free multiplicity principle: passing to the half-body ½s converts the k-fold volume excess into k+1 points of ½s that are pairwise congruent modulo the lattice, and convexity together with central symmetry turns each congruence into a genuine lattice point of s. Mathlib formalizes Minkowski's k = 1 theorem (exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure) but not the general-k count.",
+    "problemStatement": "Derive van der Corput's convex-body counting theorem from the parent entry's general-multiplicity Blichfeldt principle: for a full-rank lattice L ⊆ E with fundamental domain F and a convex, centrally symmetric, null-measurable body s, if k·(covol(L)·2ⁿ) < vol(s) then s contains at least k nonzero lattice points of L. Isolate the passage from congruent points of ½s to lattice points of s as a reusable lemma, and recover Minkowski's theorem at k = 1.",
+    "proofStrategy": "Follow Mathlib's own k = 1 Minkowski derivation, but carry the entire over-covered family instead of a single pair. First, measure_half_smul gives vol(½s) = (2ⁿ)⁻¹·vol(s), so the hypothesis k·covol(L)·2ⁿ < vol(s) becomes k·covol(L) < vol(½s) after cancelling 2ⁿ (ENNReal.mul_lt_mul_iff_left). Apply the parent's exists_finset_lattice_common_vadd to ½s to obtain a finite T ⊆ L with k < #T and a common point z with z ∈ l +ᵥ ½s, i.e. 2·(z - l) ∈ s, for every l ∈ T. Fix a base point l₀ ∈ T; for each other l ∈ T, half_diff_mem_of_symmetric_convex applied to 2·(z - l₀) and 2·(z - l) yields (l - l₀ : E) = 2⁻¹·(2(z - l₀) - 2(z - l)) ∈ s. The map l ↦ l - l₀ is injective and avoids 0 off l₀, so its image over T \\ {l₀} is a family of #T - 1 ≥ k nonzero lattice points of s.",
+    "keyInsights": [
+      "Passing to the half-body ½s is the whole trick: its volume is exactly 2⁻ⁿ·vol(s), so a k·2ⁿ volume excess for s becomes a plain k-fold excess for ½s, which is exactly what the convexity-free Blichfeldt engine consumes.",
+      "The parent entry already did the hard measure-theoretic pigeonhole (exists_finset_lattice_common_vadd); this file supplies only the geometry — turning congruent points into lattice points — so the derivation is short and reuses a heavy verified engine rather than reproving it.",
+      "half_diff_mem_of_symmetric_convex is the reusable heart: for convex symmetric s, the scaled difference 2⁻¹·(a - b) of any two points a, b ∈ s stays in s (midpoint of a and -b). This single lemma is where both central symmetry and convexity are used.",
+      "Central symmetry gives the ± pairing for free: since s is symmetric and L is a subgroup, each guaranteed nonzero lattice point v ∈ s has -v ∈ s as well, recovering the classical 'k pairs' phrasing without any extra counting.",
+      "Minkowski's fundamental theorem is not a separate proof but the specialization k = 1, with the antipode supplied directly by symmetry — a clean demonstration that van der Corput's theorem is the honest generalization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-passage",
+      "title": "The Central-Symmetry / Convexity Passage Lemma",
+      "startLine": 57,
+      "endLine": 68,
+      "summary": "half_diff_mem_of_symmetric_convex: for a convex, centrally symmetric set s, if a, b ∈ s then 2⁻¹·(a - b) ∈ s. Proved by writing 2⁻¹·(a - b) as the convex midpoint of a and -b, using symmetry for -b ∈ s and convexity for the midpoint. This is the abstract 'two congruent points give a genuine lattice point' step, stated over any real vector space with no measure structure."
+    },
+    {
+      "id": "sec-halfvolume",
+      "title": "Volume of the Half-Scaled Body",
+      "startLine": 74,
+      "endLine": 80,
+      "summary": "measure_half_smul: vol(½s) = (2ⁿ)⁻¹·vol(s), where n = finrank ℝ E. A direct computation from Mathlib's additive-Haar scaling law addHaar_smul_of_nonneg, converting ENNReal.ofReal((2⁻¹)ⁿ) into (2ⁿ)⁻¹. This identity is the bridge that reduces the van der Corput hypothesis to the Blichfeldt input."
+    },
+    {
+      "id": "sec-vandercorput",
+      "title": "van der Corput's Counting Theorem and Minkowski at k = 1",
+      "startLine": 82,
+      "endLine": 157,
+      "summary": "The main result vanDerCorput and its k = 1 corollary minkowski_of_vanDerCorput. Rewriting the hypothesis via measure_half_smul reduces to k·covol(L) < vol(½s); the parent's Blichfeldt engine yields a common point z and a finite T ⊆ L with k < #T and 2·(z - l) ∈ s for each l ∈ T. Translating by a base point l₀ and applying the passage lemma produces #T - 1 ≥ k nonzero lattice points l - l₀ ∈ s. The corollary specializes k = 1 and reads off the antipode from central symmetry."
+    }
+  ],
+  "conclusion": {
+    "summary": "Derives van der Corput's convex-body counting theorem from the parent entry's general-multiplicity Blichfeldt principle: a convex, centrally symmetric body s with vol(s) > k·covol(L)·2ⁿ contains at least k nonzero lattice points of L (a finite D ⊆ L with k ≤ #D, 0 ∉ D, all lying in s), which by central symmetry come in ± pairs. The proof passes to the half-body ½s — whose volume is (2ⁿ)⁻¹·vol(s), so the k·2ⁿ excess becomes a plain k-fold excess — feeds it to the verified Blichfeldt engine exists_finset_lattice_common_vadd, and turns the resulting congruent points into lattice points via the reusable lemma half_diff_mem_of_symmetric_convex (for convex symmetric s, a, b ∈ s ⟹ 2⁻¹·(a - b) ∈ s). Minkowski's fundamental theorem is recovered as the case k = 1 with its antipode. All four results are 0-axiom (propext / Classical.choice / Quot.sound only) and machine-checked; the general-k count has no Mathlib counterpart.",
+    "implications": "Completing this derivation closes the principal open question of the parent Blichfeldt entry: the multiplicity principle really does yield van der Corput's k-fold refinement of Minkowski's theorem once convexity and symmetry are reintroduced. The isolated lemmas — the half-body volume identity and the symmetry/convexity passage — are exactly the geometry-of-numbers glue needed to move between congruent points and lattice points, and are reusable for concrete ℝⁿ lattices (via ZLattice) and for downstream lattice-point-counting bounds.",
+    "openQuestions": [
+      "Specialize vanDerCorput to a concrete full-rank ZLattice in ℝⁿ with the Lebesgue covolume, recovering the classical van der Corput bound with an explicit lattice rather than the abstract fundamental-domain API.",
+      "Sharpen the pairing into an exact count: show the k nonzero lattice points can be organized into ⌈k/2⌉ genuine ± pairs and quantify how the guaranteed count grows as vol(s)/covol(L) increases past k·2ⁿ.",
+      "Combine with the sibling class-number bound to derive an effective bound on the shortest nonzero lattice vector (a Minkowski first-theorem estimate) from the van der Corput count."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-fundamental-theorem-oq-03",
+      "relationship": "parent",
+      "description": "Blichfeldt's Generalization of Minkowski's Fundamental Theorem — the general-multiplicity pigeonhole (exists_finset_lattice_common_vadd) that is the engine consumed here on the half-body ½s. This entry discharges that parent's leading open question."
+    },
+    {
+      "targetId": "minkowski-fundamental-theorem",
+      "relationship": "related",
+      "description": "Minkowski's Fundamental Theorem (Geometry of Numbers) — the k = 1 convex-body theorem, recovered here as minkowski_of_vanDerCorput; van der Corput's counting theorem is its k-fold generalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **van der Corput convex-body counting theorem** (`minkowski-fundamental-theorem-oq-03-oq-01`) was formalized and merged in #33844 as `proofs/Proofs/MinkowskiFundamentalTheoremOQ03OQ01.lean` — VERIFIED, 0-axiom. However that PR shipped **without the `src/data/proofs/` gallery entry** that every sibling research child has (parent oq-03, oq-04, oq-01-oq-01, … all have one). This PR fills that gap.

## What this adds

- `src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/meta.json`
- `src/data/proofs/minkowski-fundamental-theorem-oq-03-oq-01/annotations.json` (6 annotations)

Describing the **already-merged** Lean proof:
- 4 theorems / 0 definitions / 0 sorries / **0 axioms**
- headline `vanDerCorput`: vol(s) > k·2ⁿ·covol(L) ⟹ ≥ k nonzero lattice points (± pairs by symmetry)
- reusable lemma `half_diff_mem_of_symmetric_convex` (congruent points → lattice point)
- `measure_half_smul` (half-body volume identity)
- `minkowski_of_vanDerCorput` (Minkowski's theorem as k=1, with antipode)
- `badge: original`, `status: verified` (consistent with `oq-01-oq-01`/`oq-01-oq-02` children)

## Verification

During this session I independently reproduced the same result and ran `#print axioms` on the merged file's theorems: they depend only on `propext` / `Classical.choice` / `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Schema keys diff-clean against the parent `oq-03` entry; `meta.json` is 12.3 KB (well under the 60 KB gallery cap).

No Lean source is changed — this is a pure gallery-data completion for a proof already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)