### PR TITLE
Enrich inverse-Galois A₅ OQ-04-01-01 (Kummer–Dedekind × inertia-tower composition): annotation coverage 4→5

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/annotations.json
@@ -47,6 +47,29 @@
     ]
   },
   {
+    "id": "ann-namespace-oq040101",
+    "proofId": "inverse-galois-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 59
+    },
+    "type": "context",
+    "title": "The four opened namespaces map the API this file composes",
+    "content": "Before the two theorems, `open Polynomial NumberField Ideal RingOfIntegers` and `namespace DedekindKummerToTower` fix the ambient API surface — and the choice of exactly these four namespaces is itself a summary of what the proof touches. `Polynomial` exposes `minpoly`, `natDegree`, and the mod-p factor `Q : (ZMod p)[X]` fed to Kummer–Dedekind. `NumberField` / `RingOfIntegers` provide `𝓞 K`, `RingOfIntegers.exponent`, and `RingOfIntegers.monicFactorsMod` — the arithmetic of the number field K and its integers θ. `Ideal` supplies the central objects `span {(p:ℤ)}`, `inertiaDeg`, `inertiaDegIn`, `IsMaximal`, and the going-up lemma `Ideal.exists_maximal_ideal_liesOver_of_isIntegral`. Opening them lets the two-theorem body read as pure mathematics rather than fully-qualified paths, and the `namespace` keeps the local names (`span_p_isMaximal`, `dvd_inertiaDegIn_of_dvd_natDegree_factor`) from colliding with the imported bricks.",
+    "mathContext": "The proof lives at the intersection of four theories: polynomial factorization mod $p$ ($\\texttt{Polynomial}$), the arithmetic of $\\mathcal{O}_K$ ($\\texttt{NumberField}$, $\\texttt{RingOfIntegers}$), and prime/inertia structure of ideals ($\\texttt{Ideal}$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "namespace and open in Lean 4",
+      "Mathlib Ideal / inertiaDegIn API",
+      "RingOfIntegers.monicFactorsMod",
+      "minpoly and mod-p factorization"
+    ],
+    "prerequisites": [
+      "Lean 4 open/namespace scoping",
+      "organization of Mathlib number-theory namespaces"
+    ]
+  },
+  {
     "id": "ann-span-maximal-oq040101",
     "proofId": "inverse-galois-oq-04-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04-oq-01-oq-01` (Composing Kummer–Dedekind Step 1 with the inertia-tower brick, inverse-Galois A₅ OQ-04).

## Annotation coverage: 4 → 5

The entry already annotated both theorem declarations, the imports, and the module docstring. The one uncovered region was the `open … / namespace` setup block (L57–59), whose choice of exactly four namespaces is itself a map of the APIs the proof composes. Added:

- **`ann-namespace-oq040101` (L59)** — "The four opened namespaces map the API this file composes": explains that `open Polynomial NumberField Ideal RingOfIntegers` fixes the ambient API surface — `Polynomial` (`minpoly`, the mod-p factor `Q`), `NumberField`/`RingOfIntegers` (`𝓞 K`, `RingOfIntegers.exponent`, `monicFactorsMod`), and `Ideal` (`span {(p:ℤ)}`, `inertiaDeg`/`inertiaDegIn`, and the going-up lemma) — giving the reader a landscape of the four theories this composition sits at the intersection of.

The new annotation carries `mathContext` (LaTeX), `significance: context`, `relatedConcepts`, and `prerequisites`, matching the existing style. All 5 annotations validated against the canonical `origin/main` Lean file (`resolver.ts validate`: 5 valid, 0 misaligned). This brings the entry to the ≥5-annotation quality target.

No changes to `meta.json` — its `keyInsights` (5), `sections` (3), `historicalContext` (~1 KB), `crossReferences` (4), and full `conclusion` already meet quality targets; `meta.json` stays well under the size cap (~16 KB).
