### PR TITLE
Enrich Lagrange OQ-02-01-02 (sum of stabilizer cardinalities): annotation coverage 4→5

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -2,49 +2,121 @@
   {
     "id": "lagrange-oq020102-header",
     "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
-    "range": { "startLine": 3, "endLine": 36 },
+    "range": {
+      "startLine": 3,
+      "endLine": 36
+    },
     "type": "concept",
     "title": "The point-side counting identity, without Burnside",
     "content": "The header frames the goal. For a finite group G acting on a finite set X, the incidence set {(g,x) : g·x = x} can be counted two ways: by group element, giving Σ_g |Fix(g)| (Burnside / Cauchy–Frobenius), or by point, giving Σ_x |Stab(x)|. Both equal |X/G|·|G|. The parent derives Burnside via the full double-counting chain; this child proves the point-side identity Σ_x |Stab(x)| = |X/G|·|G| *directly* from the orbit-stabilizer theorem, with no detour through Burnside. The mechanism: the disjoint union of stabilizers decomposes over orbits, and on each orbit it is orbit(rep) × Stab(rep) ≃ G, so summing the |X/G| orbits gives (X/G) × G.",
     "mathContext": "$\\sum_{x \\in X} |\\mathrm{Stab}(x)| = |X/G| \\cdot |G|$",
     "significance": "supporting",
-    "relatedConcepts": ["Burnside's lemma", "orbit-stabilizer theorem", "double counting", "group actions"],
-    "prerequisites": ["group actions", "orbits and stabilizers", "the orbit-stabilizer theorem"]
+    "relatedConcepts": [
+      "Burnside's lemma",
+      "orbit-stabilizer theorem",
+      "double counting",
+      "group actions"
+    ],
+    "prerequisites": [
+      "group actions",
+      "orbits and stabilizers",
+      "the orbit-stabilizer theorem"
+    ]
+  },
+  {
+    "id": "lagrange-oq020102-setup",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "The G-action setup and the orbit-space notation Ω = X/G",
+    "content": "Before either declaration, a compact setup block fixes the acting group and the orbit space. `open MulAction` brings Mathlib's group-action API (orbit, stabilizer, orbitRel, orbitProdStabilizerEquivGroup) into scope; the `variable {α : Type*} [Group α] {β : Type*} [MulAction α β]` line declares a group α acting on a set β once, so both the equivalence and the counting theorem inherit the same context. The load-bearing line is `local notation \"Ω\" => Quotient (orbitRel α β)`: it names the quotient of β by the orbit relation — the orbit space X/G — as Ω. Every subsequent occurrence of Ω (the codomain Ω × α of the bijection, `Fintype.card Ω` as the orbit count |X/G|, and each representative `ω.out` for `ω : Ω`) reads through this abbreviation, which is why the whole file can state Σ_x |Stab(x)| = |X/G|·|G| so tersely.",
+    "mathContext": "$\\Omega := \\mathrm{Quotient}(\\mathrm{orbitRel}\\ \\alpha\\ \\beta) = X/G$, the set of orbits; $|\\Omega| = \\mathrm{Fintype.card}\\ \\Omega$ is the orbit count.",
+    "significance": "context",
+    "relatedConcepts": [
+      "orbitRel and the orbit space X/G",
+      "MulAction API",
+      "Lean local notation",
+      "section variables"
+    ],
+    "prerequisites": [
+      "group actions and orbit relations",
+      "quotient types in Lean 4",
+      "local notation and variable binders"
+    ]
   },
   {
     "id": "lagrange-oq020102-bijection",
     "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
-    "range": { "startLine": 46, "endLine": 65 },
+    "range": {
+      "startLine": 46,
+      "endLine": 65
+    },
     "type": "definition",
     "title": "sigmaStabilizerEquivOrbitsProdGroup: the stabilizer half of the Burnside bijection",
     "content": "The noncomputable equivalence (Σ b : β, stabilizer α b) ≃ Ω × α (Ω = X/G), built as a `calc` chain of Mathlib equivalences: (1) `selfEquivSigmaOrbits` decomposes X into its orbits; (2) `Equiv.sigmaAssoc` reassociates the nested sigma; (3) `stabilizerEquivStabilizerOfOrbitRel` replaces each point's stabilizer by that of the orbit representative ω.out (stabilizers in an orbit are conjugate); (4) `sigmaEquivProd` recombines each orbit's contribution as orbit × stabilizer; (5) `orbitProdStabilizerEquivGroup` collapses orbit(rep) × Stab(rep) to G; (6) a final `sigmaEquivProd` gives Ω × α. Mathlib only exposes the *combined* fixed-point/orbit bijection `sigmaFixedByEquivOrbitsProdGroup`; isolating the stabilizer half as a standalone equivalence is the file's contribution.",
     "mathContext": "$\\left(\\textstyle\\Sigma_{b}\\ \\mathrm{Stab}(b)\\right) \\simeq \\Omega \\times \\alpha,\\quad \\mathrm{orbit}(\\omega) \\times \\mathrm{Stab}(\\omega) \\simeq G$",
     "significance": "key",
-    "relatedConcepts": ["selfEquivSigmaOrbits", "orbitProdStabilizerEquivGroup", "stabilizerEquivStabilizerOfOrbitRel", "sigma/product equivalences"],
-    "prerequisites": ["orbit decomposition of a G-set", "the orbit-stabilizer equivalence", "sigma and product types"]
+    "relatedConcepts": [
+      "selfEquivSigmaOrbits",
+      "orbitProdStabilizerEquivGroup",
+      "stabilizerEquivStabilizerOfOrbitRel",
+      "sigma/product equivalences"
+    ],
+    "prerequisites": [
+      "orbit decomposition of a G-set",
+      "the orbit-stabilizer equivalence",
+      "sigma and product types"
+    ]
   },
   {
     "id": "lagrange-oq020102-counting",
     "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
-    "range": { "startLine": 67, "endLine": 74 },
+    "range": {
+      "startLine": 67,
+      "endLine": 74
+    },
     "type": "theorem",
     "title": "sum_card_stabilizer_eq_card_orbits_mul_card_group: taking cardinalities",
     "content": "`sum_card_stabilizer_eq_card_orbits_mul_card_group` is the headline counting identity Σ_b |Stab(b)| = |Ω|·|α|. The proof is two rewrites: cardinality is multiplicative across the bijection, so `Fintype.card_prod`, `Fintype.card_sigma`, and `Fintype.card_congr sigmaStabilizerEquivOrbitsProdGroup` turn Σ_b |Stab(b)| into |(X/G) × G| = |X/G|·|G|. This is the stabilizer-side twin of Mathlib's `sum_card_fixedBy_eq_card_orbits_mul_card_group` (Burnside), obtained without circular dependence on Burnside.",
     "mathContext": "$\\left|\\textstyle\\Sigma_b\\ \\mathrm{Stab}(b)\\right| = |(X/G) \\times G| = |X/G| \\cdot |G|$",
     "significance": "key",
-    "relatedConcepts": ["Fintype.card_congr", "Fintype.card_sigma", "Fintype.card_prod", "Burnside twin identity"],
-    "prerequisites": ["cardinality of sigma and product types", "cardinality is a bijection invariant"]
+    "relatedConcepts": [
+      "Fintype.card_congr",
+      "Fintype.card_sigma",
+      "Fintype.card_prod",
+      "Burnside twin identity"
+    ],
+    "prerequisites": [
+      "cardinality of sigma and product types",
+      "cardinality is a bijection invariant"
+    ]
   },
   {
     "id": "lagrange-oq020102-representatives",
     "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
-    "range": { "startLine": 51, "endLine": 64 },
+    "range": {
+      "startLine": 51,
+      "endLine": 64
+    },
     "type": "technique",
     "title": "Why the equivalence is noncomputable: choosing orbit representatives",
     "content": "The equivalence is marked `noncomputable` for a structural reason worth highlighting: it indexes each orbit by a chosen representative `ω.out`, where `ω : Ω = Quotient (orbitRel α β)` and `Quotient.out` selects a preimage of the quotient class. That choice is justified by `Classical.choice`, so the construction is non-constructive even though both sides are finite. The orbit-level steps then all reduce to the representative: `stabilizerEquivStabilizerOfOrbitRel hb` transports a point's stabilizer to `Stab(ω.out)` along the orbit relation `hb`, and `orbitProdStabilizerEquivGroup α ω.out` is the orbit-stabilizer equivalence anchored at `ω.out`. The cardinality identity is unaffected — `Fintype.card_congr` only needs the bijection to exist, not to compute — which is exactly why a noncomputable equivalence still yields a clean, axiom-free counting theorem (only the foundational `Classical.choice`).",
     "mathContext": "$\\omega \\in \\Omega = X/G$, $\\ \\omega.\\mathrm{out} \\in X$ a representative; $\\mathrm{Stab}(x) \\cong \\mathrm{Stab}(\\omega.\\mathrm{out})$ for $x$ in the orbit of $\\omega.\\mathrm{out}$.",
     "significance": "supporting",
-    "relatedConcepts": ["Quotient.out", "orbit representatives", "Classical.choice", "noncomputable definitions", "card_congr needs only existence"],
-    "prerequisites": ["quotient types and Quotient.out", "the axiom of choice in Lean", "noncomputable vs computable definitions"]
+    "relatedConcepts": [
+      "Quotient.out",
+      "orbit representatives",
+      "Classical.choice",
+      "noncomputable definitions",
+      "card_congr needs only existence"
+    ],
+    "prerequisites": [
+      "quotient types and Quotient.out",
+      "the axiom of choice in Lean",
+      "noncomputable vs computable definitions"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-02` (Sum of stabilizer cardinalities directly from orbit-stabilizer).

## Annotation coverage: 4 → 5

The entry already annotated both declarations (the `sigmaStabilizerEquivOrbitsProdGroup` equivalence and the `sum_card_stabilizer_...` counting theorem) plus a nested technique note on noncomputability. The one uncovered region was the setup block (L40–44), which introduces the notation every later line reads through. Added:

- **`lagrange-oq020102-setup` (L40–44)** — "The G-action setup and the orbit-space notation Ω = X/G": explains `open MulAction`, the shared `variable {α} [Group α] {β} [MulAction α β]` context, and the load-bearing `local notation "Ω" => Quotient (orbitRel α β)` that names the orbit space X/G — used throughout as the codomain `Ω × α`, the orbit count `Fintype.card Ω`, and each representative `ω.out`.

The new annotation carries `mathContext` (LaTeX), `significance: context`, `relatedConcepts`, and `prerequisites`, matching the existing style. All 5 annotations validated against the canonical `origin/main` Lean file (`resolver.ts validate`: 5 valid, 0 misaligned).

No changes to `meta.json` — its `keyInsights` (5), `sections` (3), `historicalContext` (~640 chars), and full `conclusion` already meet quality targets; `meta.json` stays well under the size cap (~9.4 KB).
