### PR TITLE
Enrich Erdős #10 WIP OQ-02: annotate popcount recursions & subadditivity, add Kummer/Legendre references

### DIFF
--- a/src/data/proofs/erdos-10-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["binary expansion of a natural number", "Nat.bitIndices"]
   },
   {
+    "id": "ann-popcount-recursions",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 42, "endLine": 49 },
+    "type": "technique",
+    "title": "The Two Popcount Recursions: popcount(2n)=popcount n, popcount(2n+1)=popcount n+1",
+    "content": "These two one-line lemmas are the engine of every induction that follows. Appending a 0-bit (doubling, n ↦ 2n) shifts all set bits up by one position but adds none, so the Hamming weight is unchanged; appending a 1-bit (n ↦ 2n+1) adds exactly the new low bit, so the weight rises by one. Both fall straight out of the Mathlib recursion for the sorted bit-index list — bitIndices_two_mul maps the index list of n by (·+1) (same length), and bitIndices_two_mul_add_one prepends the index 0 (length +1). Reading a natural number bit-by-bit from the bottom, these are the only two moves, which is why a two-case parity split on the low bit drives the whole file. The base cases popcount 0 = 0 and popcount 1 = 1 anchor the recursion.",
+    "mathContext": "$\\mathrm{popcount}(2n)=\\mathrm{popcount}(n)$ and $\\mathrm{popcount}(2n+1)=\\mathrm{popcount}(n)+1$ — the low bit of $n$ contributes $n \\bmod 2$ to the weight, and the rest recurses on $\\lfloor n/2\\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["binary recursion", "Hamming weight", "Nat.bitIndices", "parity split"],
+    "prerequisites": ["Nat.bitIndices recursion", "binary expansion of a natural number"]
+  },
+  {
     "id": "ann-and-recursions",
     "proofId": "erdos-10-wip-01-oq-02",
     "range": { "startLine": 53, "endLine": 77 },
@@ -22,6 +34,18 @@
     "significance": "key",
     "relatedConcepts": ["Nat.testBit", "bit extensionality", "bitwise AND", "binary recursion"],
     "prerequisites": ["Nat.testBit and its recursion", "bitwise operations on ℕ"]
+  },
+  {
+    "id": "ann-subadditivity",
+    "proofId": "erdos-10-wip-01-oq-02",
+    "range": { "startLine": 79, "endLine": 126 },
+    "type": "theorem",
+    "title": "Subadditivity, Re-Derived In-File: popcount(a+b) ≤ popcount(a)+popcount(b)",
+    "content": "popcount_add_le is proved from scratch by strong induction on n = a + b (the auxiliary `key` fixes the sum so the induction hypothesis applies to every strictly smaller sum, not just a+b halved). After a zero base case, the proof splits on the parities of a and b. In the three cases with at most one odd operand the sum halves cleanly to 2·(qa+qb) or 2·(qa+qb)+1, each popcount rewrites via the recursions, and the goal is exactly the inductive hypothesis on qa+qb (with a possible +1 from a single low bit, closed by omega). The odd/odd case is the one where a carry happens: 2qa+1 + 2qb+1 = 2·(qa+qb+1), so the sum's popcount reduces to popcount(qa+qb+1) — strictly smaller in general than popcount(qa)+popcount(qb)+2 — and two IH applications plus omega finish it. Re-deriving this here (rather than importing the parent's RepWithAtMost proof) is what keeps the file self-contained and 0-axiom.",
+    "mathContext": "$\\mathrm{popcount}(a+b) \\le \\mathrm{popcount}(a)+\\mathrm{popcount}(b)$: carries only ever merge two 1-bits into one ($2^k+2^k = 2^{k+1}$), so addition can lose bits but never create them.",
+    "significance": "key",
+    "relatedConcepts": ["subadditivity", "strong induction", "carry propagation", "parity split"],
+    "prerequisites": ["strong induction on ℕ", "the popcount recursions", "binary addition and carries"]
   },
   {
     "id": "ann-eq-iff",

--- a/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-02/meta.json
@@ -96,6 +96,14 @@
     {
       "title": "Erdős Problem #10 (prime plus powers of two)",
       "url": "https://www.erdosproblems.com/10"
+    },
+    {
+      "title": "Kummer's theorem (carries and the largest prime power dividing a binomial coefficient)",
+      "url": "https://en.wikipedia.org/wiki/Kummer%27s_theorem"
+    },
+    {
+      "title": "Legendre's / de Polignac's formula and the digit-sum identity v_p(n!) = (n − s_p(n))/(p−1)",
+      "url": "https://en.wikipedia.org/wiki/Legendre%27s_formula"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `erdos-10-wip-01-oq-02` (Erdős #10 WIP OQ-02: the equality case of binary-popcount subadditivity).

This entry was fresh from the researcher (0 passes) with strong meta commentary but incomplete annotation coverage — two substantive Lean sections were unannotated. Changes:

**annotations.json (4 → 6 annotations):**
- **`ann-popcount-recursions`** (lines 42–49): the two popcount recursions `popcount(2n)=popcount n`, `popcount(2n+1)=popcount n+1` — the engine of every induction in the file, tied to the `Nat.bitIndices` list recursion and the base cases.
- **`ann-subadditivity`** (lines 79–126): the self-contained strong-induction proof of `popcount_add_le`, walking through the parity split and highlighting the odd/odd carry case; notes that re-deriving it in-file is what keeps the entry 0-axiom and independent of the parent's `RepWithAtMost` machinery.

Both new annotations carry full `mathContext` / `significance` / `relatedConcepts` / `prerequisites` fields.

**meta.json:**
- Added two `references` (Kummer's theorem; Legendre/de Polignac digit-sum formula) — both directly relevant to the `futureDirections` "Kummer-style carry-count refinement" already noted in the conclusion.

No existing content was altered or removed. `status`/`badge`/`axiomCount` (verified/original/0) reviewed against the Lean source and left unchanged — `#print axioms` reports only foundational axioms, no `native_decide`. meta.json is 8.8 KB, well under the 60 KB cap.
