### PR TITLE
Enrich: Inverse Galois OQ-04-01-01 — add references

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-01-oq-01/meta.json
@@ -127,6 +127,32 @@
       "description": "Great-grandparent entry stating the Inverse Galois Problem; OQ-04 is its fourth open question"
     }
   ],
+  "references": [
+    {
+      "authors": "Serre, Jean-Pierre",
+      "title": "Topics in Galois Theory",
+      "year": "1992",
+      "note": "Jones & Bartlett (2nd ed. A K Peters, 2008). The standard reference on the Inverse Galois Problem, including the realizability of the alternating and symmetric groups over ℚ and the use of specialization and Frobenius/inertia data to control the Galois group — the strategy this entry mechanizes for A₅."
+    },
+    {
+      "authors": "Neukirch, Jürgen",
+      "title": "Algebraic Number Theory",
+      "year": "1999",
+      "note": "Springer Grundlehren 322. Chapter I develops the Kummer–Dedekind theorem (factorization of a rational prime read off from a defining polynomial mod p, valid away from the conductor), residue/inertia degrees, and the behavior of primes in towers — exactly the classical inputs packaged as the two bricks composed here."
+    },
+    {
+      "authors": "Malle, Gunter; Matzat, B. Heinrich",
+      "title": "Inverse Galois Theory",
+      "year": "1999",
+      "note": "Springer Monographs in Mathematics (2nd ed. 2018). Comprehensive monograph on realizing finite groups as Galois groups over ℚ and other fields; situates the A₅ realization and the reduction of a divisibility of |Gal| to inertia-degree data at an unramified prime within the broader program."
+    },
+    {
+      "authors": "Atiyah, Michael F.; Macdonald, Ian G.",
+      "title": "Introduction to Commutative Algebra",
+      "year": "1969",
+      "note": "Addison–Wesley. Chapter 5 proves the going-up theorem for integral extensions (a prime of the base lies below a prime of an integral extension) — the sole new ingredient this composition adds, supplied in Lean by Ideal.exists_maximal_ideal_liesOver_of_isIntegral."
+    }
+  ],
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/DedekindKummerToTower.lean",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04-oq-01-oq-01` (pass 0, quality 91).

The entry was already comprehensive (5 keyInsights, 4 fully-fielded annotations covering the whole 2-theorem/108-line file, rich overview and conclusion). The one genuine, non-inflationary gap was an **empty `references` array**.

## Change
Added 4 canonical references aligned to the entry's mathematical content:
- **Serre, _Topics in Galois Theory_ (1992)** — the standard IGP reference; A_n realizability and Frobenius/inertia control.
- **Neukirch, _Algebraic Number Theory_ (1999)** — Kummer–Dedekind factorization, inertia degrees, primes in towers (the classical inputs behind the two bricks).
- **Malle & Matzat, _Inverse Galois Theory_ (1999)** — the broader realization program.
- **Atiyah–Macdonald, _Introduction to Commutative Algebra_ (1969)** — going-up for integral extensions, the one new ingredient this composition adds.

## Validation
- JSON valid; meta.json 18 KB (≪ 60 KB cap); 4 references (≤ 25).
- No change to `status`/`badge`/`axiomCount` — data-only.
- Annotations deliberately left at 4: they already fully cover the file; a forced 5th would be redundant per the curation-not-accretion guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)