### PR TITLE
Enrich L'Hôpital ∞/∞ growth-limits leaf: add import-block annotation

### DIFF
--- a/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "lhop02inc-ann-imports",
+    "proofId": "lhopital-oq-02-incomplete-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 4
+    },
+    "type": "context",
+    "title": "Imports: the parent rule is the load-bearing dependency",
+    "content": "Four imports set up the leaf. The three Mathlib modules supply only the elementary ingredients: `Log.Deriv` gives `Real.hasDerivAt_log` (derivative x⁻¹), and `Exp` / `Exponential` give `Real.hasDerivAt_exp` and `Real.tendsto_exp_atTop`. The decisive fourth import is `Proofs.LHopitalOQ02` — the sibling project file that proves `LHopitalInfty.lhopital_infty_atTop`, the ∞/∞ form of L'Hôpital's rule that Mathlib does not provide. Every theorem here ends with a single application of that imported rule, so the leaf is deliberately thin: it imports the hard theorem and feeds it routine hypotheses. This intra-project dependency (rather than a Mathlib one) is what makes the entry a genuine corollary demonstration of the parent's contribution.",
+    "mathContext": "The load-bearing lemma is $\\texttt{lhopital\\_infty\\_atTop}$: if $g\\to\\infty$, $g'\\ne 0$, and $f'/g'\\to c$, then $f/g\\to c$. The Mathlib imports only supply $(\\ln)'=x^{-1}$, $(\\exp)'=\\exp$, and $\\exp\\to\\infty$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "intra-project dependency vs Mathlib dependency",
+      "leaf/corollary file structure",
+      "LHopitalInfty.lhopital_infty_atTop",
+      "special-function derivative lemmas"
+    ],
+    "prerequisites": [
+      "Lean module imports and namespaces",
+      "the parent ∞/∞ L'Hôpital rule (Proofs.LHopitalOQ02)"
+    ]
+  },
+  {
     "id": "lhop02inc-ann-strategy",
     "proofId": "lhopital-oq-02-incomplete-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-02-incomplete-01` (quality 91, pass 0).

## Assessment
The entry was already high quality and well under all size caps (meta.json 9.3 KB). Against the enricher minimums the one clear gap was **annotation count: 4 present, 5 required**, plus the import block (lines 1–4) had no annotation coverage.

## Change
Added a single `context` annotation (`lhop02inc-ann-imports`, lines 1–4) with full `mathContext` / `significance` / `relatedConcepts` / `prerequisites`. It explains that the load-bearing dependency is the sibling project file `Proofs.LHopitalOQ02` (supplying `LHopitalInfty.lhopital_infty_atTop`, the ∞/∞ rule Mathlib lacks) — an intra-project rather than Mathlib dependency — while the three Mathlib imports supply only elementary derivative/limit lemmas.

Result: 5 annotations, full line coverage 1–122. No accretion elsewhere (keyInsights, conclusion, crossReferences already met targets, so left untouched).

## Verification
- JSON validated (python `json.load` on both files) and consumed cleanly by the annotation build phase (`pnpm build` enrichment step, our entry among 2337 processed). The build's later `tsc` step is unrelated — it fails only because this fresh worktree has no `node_modules`.
- Content verified against the Lean source `Proofs/LHopitalOQ02Incomplete01.lean` (imports and lemma names match).