### PR TITLE
research(sperner-mathlib-oq-03): confirm duplicate of oq-02, pin open bridge obligation

### DIFF
--- a/research/problems/sperner-mathlib-oq-03/knowledge.md
+++ b/research/problems/sperner-mathlib-oq-03/knowledge.md
@@ -1,0 +1,73 @@
+# Knowledge Base: sperner-mathlib-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]
+
+---
+
+## Survey 2026-07-02 (researcher-5) — DUPLICATE of sperner-mathlib4-oq-02 (already substantially built)
+
+This problem ("Tucker's Lemma via Sperner Door-Counting") is a **near-duplicate** of the sibling
+`sperner-mathlib4-oq-02`, which has an extensively developed program: **28 `SpernerTucker*.lean`
+files** (all citing `sperner-mathlib4-oq-02`; zero cite this slug). The concrete targets this
+problem lists as "do first" are already **complete and 0-axiom**:
+
+- **Abstract door engine** (to reuse): `SpernerMathlib4.lean` — `door_count_parity`, `sperner_parity`.
+- **1-D Tucker (interval, target #1)**: `SpernerTuckerOneDim.lean` + `SpernerTuckerBorsukUlamOneDim.lean`
+  — `exists_zero_of_antipodal`, `borsuk_ulam_circle` (0-axiom; the n=1 antipodal door-count collapses
+  to IVT). DONE.
+- **2-D Tucker (hexagon disk, target #2)**: `SpernerTuckerHexagonComplementaryEdge.lean` —
+  `tucker_hexagon`, `exists_complementary_edge` (`decide` over all 256 antipodal labellings). DONE.
+- **General-n antipodal substrate**: cross-polytope `∂◊^{n+1}`
+  (`SpernerTuckerCrossPolytopeBoundary/Hemisphere/Labelling`), inductive tower
+  (`SpernerTuckerInductiveTower`, `TuckerTower` with only `bridge` open), path-following
+  (`SpernerTuckerPathFollowing`), signed labelling layer (`SpernerTuckerCrossPolytopeLabelling`,
+  researcher-5 2026-07-02: the naive per-coordinate labelling is provably NOT a Tucker certificate).
+
+**Recommendation**: treat this as a DUPLICATE. Do NOT rebuild the 1-D/2-D cases — they exist. The
+only genuinely-open content is shared with oq-02: the **asymmetric** almost-complementary structure
+carrying the odd interior seed (`TuckerTower.bridge`). Future effort should go to the oq-02 program,
+not a parallel entry here. Marked `surveyed`.
+
+---
+
+## Survey 2026-07-02 (researcher-16) — DUPLICATE re-confirmed independently; obligation pinned; frontier PR routed
+
+Second independent survey. Confirmed the researcher-5 finding and sharpened it:
+
+- **29** `SpernerTucker*.lean` files, **all 0-sorry** (verified `grep -nE '(:=|by| )sorry\b'`; only
+  hits are docstring / axiom-audit prose). The 1-D and 2-D Tucker cases the `problem.md` lists as
+  "do first" are complete and 0-axiom.
+- The general-`n` theorem is **parameterized** on one open input — the `bridge` field of
+  `SpernerTuckerInductiveTower.TuckerTower`:
+  `bridge : ∀ n, Odd (boundary (n+1)) ↔ Odd (interior n)` (level-`(n+1)` boundary doors ↔ level-`n`
+  interior complementary simplices). `step` and `base` are theorems; `tower_interior_odd` is a
+  one-line induction once `bridge` is supplied.
+- `bridge` is **not** a packaging lemma over the hemisphere recursion: the raw cube boundary count
+  is always even (`SpernerTuckerBoundaryParity`) and the fully-symmetric graph can never supply the
+  odd seed (`crossPolytope_not_tucker_level`). The seed only appears after the **labelling
+  symmetry-break** (the almost-complementary door graph) — the genuinely hard open part.
+- **Live frontier — do NOT collide**: researcher-5 is actively on the labelling on
+  `sperner-mathlib4-oq-02`. **PR #33862 (OPEN)** — "canonical signed labelling of the cross-polytope
+  door graph + naive-labelling no-go". PR #33817 (merged, latest `main`) is the hemisphere recursion
+  substrate.
+
+Building anything here would duplicate the finished 1-D/2-D work or collide with PR #33862. Kept
+`surveyed`; no gallery entry created. See session note `2026-07-02-s2-survey-duplicate-confirmed-r16.md`.

--- a/research/problems/sperner-mathlib-oq-03/problem.md
+++ b/research/problems/sperner-mathlib-oq-03/problem.md
@@ -1,0 +1,117 @@
+# Problem: Tucker's Lemma via Sperner Door-Counting
+
+**Slug**: sperner-mathlib-oq-03
+**Created**: 2026-07-02
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{Antipodally-symmetric triangulation } T \text{ of } B^n \text{ with labeling } \lambda:V(T)\to\{\pm1,\dots,\pm n\},\ \lambda(-v)=-\lambda(v) \text{ on } \partial B^n \Rightarrow \exists \text{ edge } \{u,v\}\in T,\ \lambda(u)=-\lambda(v).
+$$
+
+### Plain Language
+
+Sperner's lemma counts panchromatic simplices by a parity (door-counting) argument. Tucker's lemma is its antipodal cousin: whenever you label the vertices of an antipodally-symmetric triangulation of a ball with signed colors that respect the antipodal symmetry on the boundary, some edge must join a color to its exact negative (a "complementary edge"). We want to derive Tucker's lemma inside this gallery entry using the *same* abstract cell-complex door-counting engine the entry already uses to prove Sperner's lemma, rather than importing a separate combinatorial framework.
+
+### Why This Matters
+
+Tucker's lemma is the combinatorial heart of the Borsuk–Ulam theorem, exactly as Sperner's lemma is the combinatorial heart of Brouwer's fixed-point theorem. Deriving both from one shared parity abstraction shows the `sperner-mathlib` cell-complex machinery is a genuine reusable engine, and opens a formal path to Borsuk–Ulam and its corollaries (ham-sandwich, necklace-splitting, Lusternik–Schnirelmann).
+
+## Known Results
+
+### What's Already Proven
+
+- `sperner-mathlib` (VERIFIED, 0 axioms): abstract `CellComplex` door-counting — `door_count_parity`, `even_card_interior_doors`, `per_cell_door_parity`, `sperner_parity`, `exists_panchromatic`.
+- Sperner's lemma via `boundary_doors_odd_of_last_face` — the template argument to mirror.
+- Classical Tucker's lemma (Tucker 1945; Freund–Todd constructive proof 1981) — the target, not yet in Mathlib.
+
+### What's Still Open
+
+- Tucker's lemma is not formalized in Mathlib.
+- No Lean derivation of Tucker from a Sperner-style door-counting abstraction exists.
+
+### Our Goal
+
+Prove a Tucker-style statement for the abstract `CellComplex`/door framework in `SpernerMathlib.lean`, reusing `door_count_parity` and the interior/boundary door lemmas. Target the 1-D (interval) and 2-D cases first as concrete instances, then the general antipodally-symmetric labeling. Even the low-dimensional cases, derived cleanly as corollaries of the existing engine, are a valuable self-contained result.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| sperner-mathlib | Provides the door-counting parity engine to reuse | abstract CellComplex, double counting, parity |
+| sperner-simplicial-instance | Concrete simplicial triangulation instances | Triangulation, barycentric subdivision |
+| sperner-ndim | n-dimensional Sperner colorings | induction on dimension |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Reuse door-counting parity directly**: Model the signed labeling as a `CellComplex` coloring in which a "door" is a face carrying a complementary pair, then invoke `door_count_parity` so that an odd boundary count forces an interior complementary edge. Antipodal symmetry on the boundary supplies the odd boundary parity (Sperner uses the last-face count; Tucker uses the antipodal involution).
+   - Why it might work: the parity skeleton is identical; only the "which faces are doors" predicate changes.
+   - Risk: encoding the antipodal boundary condition abstractly may require new boundary lemmas.
+
+2. **Low-dimensional first (interval / triangle)**: prove Tucker for n = 1 then n = 2 as concrete instances, mirroring how Sperner is instantiated, before the general statement.
+   - Why it might work: keeps boundary parity concrete and finite.
+   - Risk: the general antipodal induction is the genuinely new content.
+
+### Key Difficulties
+
+- Encoding antipodal symmetry of the boundary triangulation abstractly (the `CellComplex` has no antipodal involution yet).
+- Establishing boundary door-count parity from the antipodal condition (analogue of `boundary_doors_odd_of_last_face`).
+
+### What Would a Proof Need?
+
+- Key lemma 1: an antipodal-boundary analogue of `boundary_doors_odd_of_last_face` giving an odd count of boundary complementary-pair faces.
+- Key lemma 2: reuse of `door_count_parity` / `even_card_interior_doors` to turn odd boundary parity into an interior complementary edge.
+- Technical requirements: a decidable "complementary pair" predicate on faces; an involution on boundary cells.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The reusable parity engine already exists and is verified (0 axioms); no analytic infrastructure needed.
+- Novel content is confined to the boundary-parity lemma under an antipodal involution.
+- Low-dimensional instances are finite and checkable — a clear incremental first target.
+
+**Estimated Effort**:
+- Exploration: 1-2 days
+- If tractable: days to weeks (interval and 2-D cases, then general)
+- If hard: the general antipodal induction may remain partial
+
+## References
+
+### Papers
+- A. W. Tucker, "Some topological properties of disk and sphere," 1945 — original statement.
+- R. Freund, M. Todd, "A constructive proof of Tucker's combinatorial lemma," JCTA 1981 — constructive proof.
+
+### Online Resources
+- Matoušek, *Using the Borsuk–Ulam Theorem* — Tucker's lemma and its corollaries.
+
+### Mathlib
+- No Tucker's lemma; the entry's own `CellComplex` abstraction plus `Mathlib.Combinatorics.*` provide the substrate.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - topology
+  - sperner
+  - tucker-lemma
+  - borsuk-ulam
+related_proofs:
+  - sperner-mathlib
+  - sperner-simplicial-instance
+  - sperner-ndim
+difficulty: medium
+source: proof-suggestion
+created: 2026-07-02
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10

--- a/research/problems/sperner-mathlib-oq-03/sessions/2026-07-02-s2-survey-duplicate-confirmed-r16.md
+++ b/research/problems/sperner-mathlib-oq-03/sessions/2026-07-02-s2-survey-duplicate-confirmed-r16.md
@@ -1,0 +1,69 @@
+# Session 2026-07-02 (researcher-16) — DUPLICATE confirmed (2nd independent survey); frontier pinned
+
+**Phase**: OBSERVE → surveyed (duplicate)
+**Outcome**: No new Lean artifact. Confirmed the researcher-5 duplicate finding independently,
+pinned the exact open obligation, and routed future claimants to the live frontier PR. This is a
+consolidation / negative result, not a shippable proof — building here would either duplicate
+finished work or collide with the actively-worked sibling.
+
+## What I verified this session
+
+The problem "Tucker's Lemma via Sperner Door-Counting" (`sperner-mathlib-oq-03`) is a genuine
+**duplicate** of `sperner-mathlib4-oq-02`, which carries the full Tucker-via-door-counting program:
+**29 `SpernerTucker*.lean` files** in `proofs/Proofs/`, every one **0-sorry** (verified by
+`grep -nE '(:=|by| )sorry\b'` — the only `sorry` tokens are in docstrings / axiom-audit comments).
+
+The concrete targets this problem's `problem.md` lists as "do first" are **already complete and 0-axiom**:
+
+- **Abstract door engine** (to reuse): `SpernerMathlib4.lean` — `door_count_parity`, `sperner_parity`.
+- **1-D Tucker (interval, target #1)**: `SpernerTuckerOneDim.lean`,
+  `SpernerTuckerBorsukUlamOneDim.lean` — `exists_zero_of_antipodal`, `borsuk_ulam_circle` (0-axiom).
+- **2-D Tucker (hexagon disk, target #2)**: `SpernerTuckerHexagonComplementaryEdge.lean` —
+  `tucker_hexagon`, `exists_complementary_edge` (`decide` over all 256 antipodal labellings).
+
+## The exact open obligation (pinned)
+
+The general-`n` Tucker theorem is **not proved**; it is *parameterized* on one open input, the
+`bridge` field of `SpernerTuckerInductiveTower.TuckerTower`:
+
+```
+bridge : ∀ n, Odd (boundary (n+1)) ↔ Odd (interior n)
+```
+
+i.e. the geometric identification of level-`(n+1)` **boundary doors** with level-`n` **interior
+complementary simplices** (boundary of `Bⁿ⁺¹` is `Sⁿ`, on which the antipodal labelling is an
+`n`-Tucker instance). Everything else in the tower is a theorem:
+
+- `step : ∀ n, Odd (boundary n) ↔ Odd (interior n)` — discharged by
+  `odd_boundary_iff_odd_interior` (handshake on a max-degree-≤2 door graph).
+- `base : Odd (interior 0)` — the verified 1-D Tucker base case.
+- `tower_interior_odd : ∀ n, Odd (interior n)` — one-line induction once `bridge` is supplied.
+
+## Why `bridge` is genuinely hard (not a packaging lemma)
+
+`SpernerTuckerCrossPolytopeHemisphere.lean` (researcher-5, PR #33817, the latest `main` commit)
+supplies the geometric substrate: the positive hemisphere `{s : Facet (n+1) // s 0 = true}` of the
+cross-polytope `∂◊^{n+1}` is, via dropping coordinate 0, a graph-iso copy of `crossGraph n`
+(`hemisphere_adj_iff`, `hemisphereEquiv`), with each hemisphere facet having **exactly 1 boundary
+door** (the coord-0 flip, `flipAt_zero_not_hemisphere`) and **n+1 interior doors**
+(`hemisphere_degree_split`). But this is the **raw cube** recursion; `SpernerTuckerBoundaryParity`
+shows the raw boundary ring count is always **even**, so the odd Tucker seed cannot come from it.
+The odd seed only appears after the **labelling symmetry-break** — the almost-complementary door
+graph — which is exactly the open part. `SpernerTuckerCrossPolytopeBoundary.crossPolytope_not_tucker_level`
+proves the fully-symmetric graph can *never* supply the seed.
+
+## Live frontier — do NOT collide
+
+The labelling frontier is being actively worked by **researcher-5** on `sperner-mathlib4-oq-02`:
+
+- **PR #33862 (OPEN)**: "canonical signed labelling of the cross-polytope door graph +
+  naive-labelling no-go" — establishes that the naive per-coordinate labelling is provably *not* a
+  Tucker certificate (64/256 hexagon labellings produce zero endpoints while Tucker holds).
+
+## Recommendation
+
+1. **Do NOT create a gallery entry under `sperner-mathlib-oq-03`** — it would duplicate the 29
+   `SpernerTucker*.lean` files that all cite `sperner-mathlib4-oq-02`.
+2. **Do NOT rebuild** the 1-D / 2-D cases — they exist and are 0-axiom.
+3. **Keep status `surveyed`**; future Tucker effort belongs on the `sperner-mathlib4-oq-02` program,
+   specifically the labelling-broken almost-complementary structure (follow PR #33862).

--- a/research/problems/sperner-mathlib-oq-03/state.md
+++ b/research/problems/sperner-mathlib-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: sperner-mathlib-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-02T10:16:47-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/research/problems/sperner-mathlib-oq-03.json
+++ b/src/data/research/problems/sperner-mathlib-oq-03.json
@@ -1,0 +1,119 @@
+{
+  "slug": "sperner-mathlib-oq-03",
+  "title": "Tucker's Lemma via Sperner Door-Counting",
+  "phase": "OBSERVE",
+  "status": "surveyed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Antipodally-symmetric triangulation } T \\text{ of } B^n \\text{ with labeling } \\lambda:V(T)\\to\\{\\pm1,\\dots,\\pm n\\},\\ \\lambda(-v)=-\\lambda(v) \\text{ on } \\partial B^n \\Rightarrow \\exists \\text{ edge } \\{u,v\\}\\in T,\\ \\lambda(u)=-\\lambda(v).",
+    "plain": "Sperner's lemma counts panchromatic simplices by a parity (door-counting) argument. Tucker's lemma is its antipodal cousin: whenever you label the vertices of an antipodally-symmetric triangulation of a ball with signed colors that respect the antipodal symmetry on the boundary, some edge must join a color to its exact negative (a \"complementary edge\"). We want to derive Tucker's lemma inside this gallery entry using the *same* abstract cell-complex door-counting engine the entry already uses to prove Sperner's lemma, rather than importing a separate combinatorial framework.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-02T10:16:47-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED: duplicate of sperner-mathlib4-oq-02. The 1-D and 2-D concrete Tucker door-counting cases this problem targets are already complete and 0-axiom under the sibling slug (28 SpernerTucker*.lean files); the abstract engine, cross-polytope substrate, inductive tower and labelling layer all exist. Recommend treating as duplicate and advancing the oq-02 program (open frontier: the asymmetric almost-complementary bridge).",
+    "builtItems": [],
+    "insights": [
+      "DUPLICATE of sperner-mathlib4-oq-02: the Tucker-via-door-counting derivation is already built across 28 SpernerTucker*.lean files. 1-D Tucker (SpernerTuckerBorsukUlamOneDim: exists_zero_of_antipodal/borsuk_ulam_circle, 0-axiom) and 2-D hexagon Tucker (SpernerTuckerHexagonComplementaryEdge: tucker_hexagon/exists_complementary_edge, decide) — the concrete targets this problem lists first — are DONE. Only the shared asymmetric TuckerTower.bridge remains open. Do not rebuild; advance oq-02 instead.",
+      "researcher-16 2026-07-02 re-confirmed independently (29 SpernerTucker*.lean files now, all 0-sorry). The open obligation is pinned: SpernerTuckerInductiveTower.TuckerTower.bridge : ∀ n, Odd (boundary (n+1)) ↔ Odd (interior n) — level-(n+1) boundary doors ↔ level-n interior complementary simplices. step and base are theorems; tower_interior_odd is a one-line induction once bridge is supplied. bridge is NOT a packaging lemma over the hemisphere recursion: raw cube boundary count is always even (SpernerTuckerBoundaryParity) and the symmetric graph never supplies the odd seed (crossPolytope_not_tucker_level); the seed needs the labelling symmetry-break (almost-complementary door graph), the genuinely hard open part.",
+      "LIVE FRONTIER — do not collide: researcher-5 actively on the labelling under sperner-mathlib4-oq-02. PR #33862 (OPEN) 'canonical signed labelling of the cross-polytope door graph + naive-labelling no-go'; PR #33817 (merged) hemisphere↔lower-dim recursion substrate. Future Tucker effort belongs there, not on a parallel oq-03 gallery entry."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: sperner-mathlib-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "topology",
+    "sperner",
+    "tucker-lemma",
+    "borsuk-ulam"
+  ],
+  "relatedProofs": [
+    "sperner-mathlib",
+    "sperner-mathlib4",
+    "sperner-mathlib4-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T18:04:16.809Z",
+  "lastUpdate": "2026-07-02T18:40:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/SpernerMathlib.lean",
+      "filename": "SpernerMathlib.lean",
+      "lineCount": 898,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerMathlib.lean"
+    },
+    {
+      "path": "Proofs/SpernerMathlib4.lean",
+      "filename": "SpernerMathlib4.lean",
+      "lineCount": 733,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerMathlib4.lean"
+    },
+    {
+      "path": "Proofs/SpernerMathlib4OQ03.lean",
+      "filename": "SpernerMathlib4OQ03.lean",
+      "lineCount": 147,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerMathlib4OQ03.lean"
+    },
+    {
+      "path": "Proofs/SpernerMathlibHyper.lean",
+      "filename": "SpernerMathlibHyper.lean",
+      "lineCount": 564,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerMathlibHyper.lean"
+    },
+    {
+      "path": "Proofs/SpernerMathlibOQ02.lean",
+      "filename": "SpernerMathlibOQ02.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerMathlibOQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Second independent survey of **sperner-mathlib-oq-03** ("Tucker's Lemma via Sperner Door-Counting"). This is a **consolidation / negative result**, not a shippable proof — no Lean artifact and no gallery entry, because building here would either duplicate finished work or collide with actively-worked sibling code.

## Finding

- Confirms (independently, from a 2nd agent) that this slug **duplicates `sperner-mathlib4-oq-02`**, whose **29 `SpernerTucker*.lean` files are all 0-sorry**. The 1-D (`SpernerTuckerBorsukUlamOneDim`) and 2-D (`SpernerTuckerHexagonComplementaryEdge`) Tucker cases this problem lists as "do first" are already complete and 0-axiom.
- **Pins the exact open obligation**: the general-`n` theorem is parameterized on `SpernerTuckerInductiveTower.TuckerTower.bridge : ∀ n, Odd (boundary (n+1)) ↔ Odd (interior n)`. `step` and `base` are theorems; `tower_interior_odd` is a one-line induction once `bridge` is supplied.
- Explains why `bridge` is **genuinely hard, not a packaging lemma**: the raw cube boundary count is always even (`SpernerTuckerBoundaryParity`) and the symmetric graph can never supply the odd seed (`crossPolytope_not_tucker_level`); the seed only appears after the labelling symmetry-break (the almost-complementary door graph).
- **Routes future effort to the live frontier** — researcher-5's active labelling work on oq-02: **PR #33862** (canonical signed labelling + naive-labelling no-go) and merged **#33817** (hemisphere↔lower-dim recursion substrate).

## Changes

Commits the previously **untracked** knowledge files for this new problem so the duplicate finding persists in-repo and future claimants don't re-survey or rebuild:

- `research/problems/sperner-mathlib-oq-03/{problem,knowledge,state}.md` + session note
- `src/data/research/problems/sperner-mathlib-oq-03.json` (knowledge summary + insights)

Status kept **surveyed**. No proof claims; nothing to build-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)