### PR TITLE
Enrich negative Pell OQ-08: split bundled annotation (4→5)

### DIFF
--- a/src/data/proofs/pell-equation-oq-08/annotations.json
+++ b/src/data/proofs/pell-equation-oq-08/annotations.json
@@ -84,28 +84,54 @@
     ]
   },
   {
-    "id": "ann-pelloq08-necessary-and-concrete",
+    "id": "ann-pelloq08-necessary",
     "proofId": "pell-equation-oq-08",
     "range": {
       "startLine": 94,
-      "endLine": 119
+      "endLine": 101
     },
-    "type": "proof-step",
-    "title": "Necessary Condition, Classical Cases, and Sharpness",
-    "content": "**Packaging.** `neg_pell_solvable_imp_no_prime_factor_three_mod_four` is the contrapositive: if $x^2 - Dy^2 = -1$ is solvable, every prime factor of $D$ satisfies $p \\% 4 \\neq 3$ — the classical necessary condition. `neg_pell_three_no_sol` and `neg_pell_seven_no_sol` instantiate the mod-4 obstruction at the textbook unsolvable cases $D = 3, 7$. Finally `neg_pell_two_example` exhibits $(1,1)$ solving $x^2 - 2y^2 = -1$: $D = 2 \\not\\equiv 3 \\pmod 4$ is solvable, so the obstructions genuinely depend on $D$'s residue class and are not vacuous.",
-    "mathContext": "Necessary but not sufficient: e.g. $D = 34 = 2\\cdot 17$ passes both tests yet $x^2 - 34y^2 = -1$ is unsolvable.",
-    "significance": "supporting",
+    "type": "theorem",
+    "title": "The Classical Necessary Condition (Contrapositive)",
+    "content": "**`neg_pell_solvable_imp_no_prime_factor_three_mod_four`.** This packages the prime-factor obstruction as the classical *necessary condition* for solvability: if $x^2 - Dy^2 = -1$ has any solution, then no prime factor $p$ of $D$ can satisfy $p \\equiv 3 \\pmod 4$. The proof is a direct contrapositive — assume such a $p$ exists, destructure the hypothesised solution $\\langle x, y, h\\rangle$, and feed it to `neg_pell_no_sol_of_prime_factor_three_mod_four`, which already rules it out. This is the statement one actually cites when screening a $D$ for negative-Pell solvability.",
+    "mathContext": "Solvable $\\Rightarrow$ every prime $p \\mid D$ has $p \\equiv 1 \\pmod 4$ (or $p = 2$). This is necessary but *not* sufficient.",
+    "significance": "key",
     "relatedConcepts": [
       "Contrapositive necessary conditions",
-      "Sharpness witnesses",
-      "Necessary vs. sufficient congruence criteria"
+      "Screening criterion for negative Pell",
+      "Prime factorisation of D"
     ],
     "prerequisites": [
-      "The two obstruction theorems above",
-      "Concrete instantiation with norm_num"
+      "The prime-factor obstruction above",
+      "Contrapositive reasoning"
     ],
     "tags": [
       "necessary-condition",
+      "contrapositive",
+      "negative-pell"
+    ]
+  },
+  {
+    "id": "ann-pelloq08-concrete",
+    "proofId": "pell-equation-oq-08",
+    "range": {
+      "startLine": 103,
+      "endLine": 119
+    },
+    "type": "example",
+    "title": "Concrete Cases and Sharpness",
+    "content": "**Worked instances.** `neg_pell_three_no_sol` and `neg_pell_seven_no_sol` instantiate the mod-4 obstruction at the textbook unsolvable cases $D = 3, 7$ (each discharged by `neg_pell_no_sol_of_D_three_mod_four (by norm_num)`). `neg_pell_two_example` is the sharpness witness: $(x, y) = (1, 1)$ solves $x^2 - 2y^2 = -1$ since $1 - 2 = -1$. Because $D = 2 \\not\\equiv 3 \\pmod 4$ and has no prime factor $\\equiv 3 \\pmod 4$, both obstructions correctly permit it — confirming they genuinely depend on $D$'s residue class rather than forbidding every $D$.",
+    "mathContext": "Necessary but not sufficient: e.g. $D = 34 = 2\\cdot 17$ passes both tests yet $x^2 - 34y^2 = -1$ is unsolvable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sharpness witnesses",
+      "Necessary vs. sufficient congruence criteria",
+      "Concrete instantiation with norm_num"
+    ],
+    "prerequisites": [
+      "The two obstruction theorems above",
+      "Evaluating small Diophantine cases"
+    ],
+    "tags": [
       "concrete-instances",
       "sharpness",
       "negative-pell"


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-08` (quality 91, pass 0).

## Assessment
meta.json (12.8 KB) is well under caps and already complete. The one gap was **annotations: 4 present, 5 required**; the final annotation (lines 94–119) bundled a distinct theorem (the classical necessary condition) with the concrete-instance/sharpness block.

## Change
Split into two focused annotations (no accretion elsewhere):
- **ann-pelloq08-necessary** (94–101): `neg_pell_solvable_imp_no_prime_factor_three_mod_four` — the contrapositive necessary condition used to screen a `D` for negative-Pell solvability.
- **ann-pelloq08-concrete** (103–119): the unsolvable cases `D = 3, 7` and the `D = 2` sharpness witness `(1,1)`, showing the obstructions depend on `D`'s residue class.

Result: 5 annotations, each covering one coherent block; coverage 1–119.

## Verification
- JSON validated (`json.load`), 5 annotations, ranges match the Lean theorem boundaries.
- Content checked against `Proofs/PellEquationOQ08.lean` (theorem names, line ranges, `norm_num` discharges all match).