### PR TITLE
Enrich prime-gap-bounds-oq-02: split long main-theorem annotation (4→5)

### DIFF
--- a/src/data/proofs/prime-gap-bounds-oq-02/annotations.json
+++ b/src/data/proofs/prime-gap-bounds-oq-02/annotations.json
@@ -71,23 +71,45 @@
     "proofId": "prime-gap-bounds-oq-02",
     "range": {
       "startLine": 106,
-      "endLine": 194
+      "endLine": 159
     },
     "type": "theorem",
-    "title": "The Explicit Chebyshev Upper Bound on π(x)",
-    "content": "primeCounting_floor_le proves π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x for x > 1. Key step: every prime p with √x < p ≤ x satisfies log p ≥ log √x = ½ log x (Real.log_sqrt), so keeping only the tail of θ(x) = Σ_{p ≤ x} log p gives θ(x) ≥ (½ log x)·#{√x < p ≤ x : prime} = (½ log x)(π(⌊x⌋) − π(⌊√x⌋)) via sum_le_sum and sum_le_sum_of_subset_of_nonneg. Combined with θ(x) ≤ log4·x and divided by ½ log x > 0, then adding π(⌊√x⌋) ≤ √x + 1, this yields the bound. The constant 2log4 = log16 ≈ 2.77 is non-sharp but the result is unconditional and axiom-free.",
-    "mathContext": "π(⌊x⌋) − π(⌊√x⌋) ≤ (2log4)x/log x, and π(⌊√x⌋) ≤ √x + 1 ⟹ π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x.",
+    "title": "Lower-Bounding θ by the Prime Tail Above √x",
+    "content": "primeCounting_floor_le proves π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x for x > 1. The crux — this first phase — is a one-sided tail estimate on Chebyshev's θ. Set b = ⌊x⌋, s = ⌊√x⌋, and let T = {p ∈ (s, b] : prime} be the primes strictly above √x. Every such prime satisfies (p : ℝ) > √x (from p ≥ s+1 > √x via Nat.lt_floor_add_one), hence log p ≥ log √x = ½ log x by Real.log_sqrt and log monotonicity (hlog_lb). Since T is a subset of all primes in (0, b] and every log term is nonnegative (hlog_nonneg), discarding the small primes gives θ(x) = Σ_{p ≤ x} log p ≥ Σ_{p ∈ T} log p ≥ |T|·(½ log x), assembled from Finset.sum_const, Finset.sum_le_sum, and Finset.sum_le_sum_of_subset_of_nonneg. Only the single scale √x is used — no dyadic decomposition.",
+    "mathContext": "For $\\sqrt x < p \\le x$, $\\log p \\ge \\log\\sqrt x = \\tfrac12\\log x$, so $\\theta(x) \\ge |T|\\cdot\\tfrac12\\log x$ where $T = \\{p : \\sqrt x < p \\le x,\\ p\\text{ prime}\\}$.",
     "significance": "central",
     "relatedConcepts": [
       "Chebyshev tail argument",
-      "theta_le_log4_mul_x",
       "Real.log_sqrt",
-      "single-scale √x"
+      "single-scale √x",
+      "Finset.sum_le_sum_of_subset_of_nonneg"
+    ],
+    "prerequisites": [
+      "Chebyshev θ as a sum of log p",
+      "Nat.lt_floor_add_one, Real.log_le_log"
+    ]
+  },
+  {
+    "id": "ann-pgb-oq02-assembly",
+    "proofId": "prime-gap-bounds-oq-02",
+    "range": {
+      "startLine": 160,
+      "endLine": 194
+    },
+    "type": "proof-step",
+    "title": "Assembling the Explicit Bound",
+    "content": "The second phase turns the tail lower bound |T|·(½ log x) ≤ θ(x) into the headline inequality. Chebyshev's upper bound θ(x) ≤ log4·x (theta_le_log4_mul_x) gives |T|·(½ log x) ≤ log4·x. The θ↔π bridge count_primes_Ioc rewrites |T| = π(b) − π(s) (valid since s ≤ b, itself from √x ≤ x and floor monotonicity), so dividing by ½ log x > 0 (le_div_iff₀ + nlinarith) yields π(b) − π(s) ≤ (2 log4)·x/log x. Finally the small primes are controlled by π(s) ≤ √x + 1 (primeCounting_le_succ composed with Nat.floor_le), and one `linarith` combines the two to reach π(⌊x⌋) ≤ √x + 1 + (log16)·x/log x. The constant 2 log4 = log16 ≈ 2.77 is non-sharp but the result is unconditional and axiom-free.",
+    "mathContext": "$|T| = \\pi(b) - \\pi(s) \\le \\frac{2\\log 4\\,x}{\\log x}$, and $\\pi(s) \\le \\sqrt x + 1 \\Rightarrow \\pi(\\lfloor x\\rfloor) \\le \\sqrt x + 1 + \\frac{\\log 16\\,x}{\\log x}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "theta_le_log4_mul_x",
+      "count_primes_Ioc (θ↔π bridge)",
+      "le_div_iff₀",
+      "non-sharp explicit constant"
     ],
     "prerequisites": [
       "Chebyshev.theta_le_log4_mul_x",
-      "count_primes_Ioc",
-      "Finset.sum_le_sum_of_subset_of_nonneg"
+      "count_primes_Ioc, primeCounting_le_succ"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `prime-gap-bounds-oq-02` (quality 91, pass 0).

## Assessment
meta.json (11.3 KB) is under caps and complete. The gap was **annotations: 4 present, 5 required**. Unlike other entries the deficit wasn't a bundled multi-theorem annotation — the main annotation (106–194) is one long theorem `primeCounting_floor_le`, but its proof has two mathematically distinct phases.

## Change
Split the main annotation at the natural boundary (line 160, `-- Chebyshev upper bound on θ`):
- **ann-pgb-oq02-main** (106–159): the crux — lower-bounding Chebyshev's θ(x) by the prime tail T above √x, using `log p ≥ ½ log x` for `p > √x`.
- **ann-pgb-oq02-assembly** (160–194): applying `theta_le_log4_mul_x`, the `count_primes_Ioc` θ↔π bridge to rewrite |T| = π(b) − π(s), dividing out, and adding `π(s) ≤ √x + 1` to reach the headline bound.

Result: 5 annotations, contiguous coverage 1–194.

## Verification
- JSON validated (`json.load`), 5 annotations.
- Content checked against `Proofs/BoundedPrimeGapsOQ02Chebyshev.lean` (`hlog_lb`/`hθ_ge`/`le_div_iff₀`/`hs_le` steps, lemma names, and the line-160 phase boundary all match).