### PR TITLE
Enrich ptolemys-theorem-oq-05: split final annotation (4→5)

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-ptolemy-dist",
     "proofId": "ptolemys-theorem-oq-05",
-    "range": { "startLine": 138, "endLine": 152 },
-    "type": "insight",
-    "title": "Dimension-free four-point form and a 3D witness",
-    "content": "ptolemy_dist transports the origin form to an arbitrary NormedAddTorsor over a real inner product space by translating the fourth point d to the origin (x = a−ᵥd, y = b−ᵥd, z = c−ᵥd): dist_eq_norm_vsub rewrites distances as norms of vsub differences and vsub_sub_vsub_cancel_right cancels the common d, after which ptolemy_origin closes it. The concrete instantiation in EuclideanSpace ℝ (Fin 3) exhibits Ptolemy's inequality in three dimensions — a configuration the gallery's complex-number proof, tied to the plane, cannot reach.",
+    "range": { "startLine": 134, "endLine": 145 },
+    "type": "theorem",
+    "title": "The Dimension-Free Four-Point Form",
+    "content": "ptolemy_dist transports the origin form to four arbitrary points a, b, c, d of an arbitrary NormedAddTorsor over a real inner product space — i.e. any inner-product affine space, in any dimension. The translation trick sends the fourth point d to the origin: apply ptolemy_origin to x = a−ᵥd, y = b−ᵥd, z = c−ᵥd. Then dist_eq_norm_vsub rewrites every distance as the norm of a vsub difference, and vsub_sub_vsub_cancel_right cancels the common d so that, e.g., dist a c = ‖(a−ᵥd) − (c−ᵥd)‖ = ‖x − z‖; the origin inequality closes the goal verbatim. This is the coordinate-free statement of Ptolemy's inequality that the complex-number proof cannot express.",
     "mathContext": "$\\operatorname{dist}(a,c)\\operatorname{dist}(b,d) \\le \\operatorname{dist}(a,b)\\operatorname{dist}(c,d) + \\operatorname{dist}(b,c)\\operatorname{dist}(a,d)$ for $a,b,c,d$ in any inner-product affine space.",
     "significance": "key",
-    "relatedConcepts": ["NormedAddTorsor", "inner-product affine space", "EuclideanSpace"],
+    "relatedConcepts": ["NormedAddTorsor", "inner-product affine space", "translation to the origin", "vsub_sub_vsub_cancel_right"],
     "prerequisites": ["affine spaces and torsors", "vsub and dist"]
+  },
+  {
+    "id": "ann-ptolemy-3d",
+    "proofId": "ptolemys-theorem-oq-05",
+    "range": { "startLine": 147, "endLine": 151 },
+    "type": "context",
+    "title": "A Three-Dimensional Witness",
+    "content": "The closing example instantiates ptolemy_dist in EuclideanSpace ℝ (Fin 3), exhibiting Ptolemy's inequality for four points of ordinary 3-space by a one-line application. This is the concrete payoff of the entire OQ-05 entry: the gallery's original proof relies on the complex algebraic identity (z₁−z₃)(z₂−z₄) = (z₁−z₂)(z₃−z₄) + (z₁−z₄)(z₂−z₃), which lives in the field ℂ and is therefore locked to the plane. The inversion-based proof formalized here has no such ceiling, and this 3D instance makes the gain visible — a configuration the planar proof simply cannot address.",
+    "mathContext": "The same inequality holds in $\\mathbb{R}^3$ (and every $\\mathbb{R}^n$), witnessed here in $\\texttt{EuclideanSpace}\\ \\mathbb{R}\\ (\\texttt{Fin}\\ 3)$, beyond the reach of the $\\mathbb{C}$-based planar proof.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace ℝ (Fin 3)", "dimension independence", "complex-number proof (planar limitation)"],
+    "prerequisites": ["EuclideanSpace as an inner-product space", "instantiating a general theorem"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-05` (quality 91, pass 0).

## Assessment
meta.json (10.5 KB) under caps and complete. Gap: **annotations 4, need 5**. The final annotation (138–152) bundled the general four-point theorem with the 3D example.

## Change
Split into two focused annotations (no accretion elsewhere):
- **ann-ptolemy-dist** (134–145): `ptolemy_dist` — the dimension-free four-point form over any `NormedAddTorsor`, via the translate-`d`-to-origin trick.
- **ann-ptolemy-3d** (147–151): the `EuclideanSpace ℝ (Fin 3)` witness — the concrete payoff of the whole OQ-05 entry, since the gallery's ℂ-based planar proof cannot reach 3D.

Result: 5 annotations; coverage matches the Lean theorem/example boundaries.

## Verification
- JSON validated (`json.load`), 5 annotations.
- Content checked against `Proofs/PtolemyInequalityInnerProduct.lean` (`ptolemy_dist` at 138, example at 149, `vsub_sub_vsub_cancel_right`/`dist_eq_norm_vsub` steps all match).