### PR TITLE
Enrich Mason–Stothers OQ-01: add Wronskian-mechanism keyInsight (4→5)

### DIFF
--- a/src/data/proofs/mason-stothers-theorem-oq-01/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01/meta.json
@@ -70,7 +70,8 @@
       "**The escape clause is not optional in general.** Over 𝔽_p, Xᵖ + 1 = (X + 1)ᵖ is a coprime relation with huge degrees but radical of degree 1; it survives only because every term has zero derivative. The characteristic-zero hypothesis is exactly what rules this out.",
       "**Homogeneous ↦ inhomogeneous by negation.** Mathlib states the theorem for a + b + c = 0; the textbook a + b = c form is the same theorem with c replaced by -c, and the radical is unit-invariant (radical_neg) so the bound is unchanged.",
       "**Characteristic zero linearises the dichotomy.** derivative p = 0 ⟺ p is constant over a torsion-free (e.g. CharZero) ring; this turns the disjunction 'bound OR all derivatives zero' into the clean implication 'non-constant ⟹ bound'.",
-      "**Rigidity is the contrapositive.** Reading the degree bound backwards: too few distinct roots in the product (deg rad ≤ deg c) forces total degeneracy — the polynomial shadow of 'abc-triples with small radical are rare'."
+      "**Rigidity is the contrapositive.** Reading the degree bound backwards: too few distinct roots in the product (deg rad ≤ deg c) forces total degeneracy — the polynomial shadow of 'abc-triples with small radical are rare'.",
+      "**The Wronskian is the hidden engine.** Mathlib's Polynomial.abc rests on Snyder's Wronskian proof: from a + b + c = 0 the Wronskians W(a,b) = a·b' − a'·b of any two factors all agree up to sign, and rad(a·b·c) divides this common W. Comparing degrees — deg W ≤ deg a + deg b − 1 against deg(a·b·c) − deg(rad) ≤ deg W — yields the bound, while W = 0 is exactly the derivative-vanishing escape clause. Every result in this file inherits both the sharp '−1' and that escape clause from this single Wronskian identity."
     ],
     "exampleSections": [
       {


### PR DESCRIPTION
Enrichment pass (meta.json only) for **mason-stothers-theorem-oq-01**.

- Added one `keyInsight` (4→5): "The Wronskian is the hidden engine", explaining the mechanism behind Mathlib's `Polynomial.abc` (Snyder's Wronskian proof), where both the sharp `−1` and the derivative-vanishing escape clause originate. Ties the file's four theorems back to the single Wronskian identity `W(a,b) = a·b' − a'·b`.

Scope deliberately limited to `meta.json` to avoid conflict with the concurrent annotation-split PR #33873 on the same slug. Within all size guardrails (16 KB ≤ 60 KB, 5 keyInsights ≤ 12). Build passes.
