### PR TITLE
Enrich sophie-germain-oq-01-oq-03: split divisibility annotation (4→5)

### DIFF
--- a/src/data/proofs/sophie-germain-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-01-oq-03/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-dvd",
     "proofId": "sophie-germain-oq-01-oq-03",
-    "range": { "startLine": 134, "endLine": 177 },
+    "range": { "startLine": 134, "endLine": 148 },
     "type": "theorem",
-    "title": "Divisibility and Compositeness",
-    "content": "Casting $2^p = -1$ back to $\\mathbb{N}$ via `ZMod.natCast_eq_zero_iff` gives the main theorem $q \\mid 2^p+1$ (two_pow_add_one_dvd). Because $2p < 2^p$ for $p \\ge 5$, the divisor $q = 2p+1$ is strictly between $1$ and $2^p+1$, so it is proper and $2^p+1$ is composite (two_pow_add_one_not_prime). The witness $p=5$ gives $11 \\mid 33 = 3 \\cdot 11$.",
-    "mathContext": "$q \\mid 2^p + 1,\\quad 1 < q < 2^p+1\\ (p \\ge 5).$",
+    "title": "The Main Divisibility Theorem",
+    "content": "two_pow_add_one_dvd casts the field congruence $2^p = -1$ back to $\\mathbb{N}$: via `ZMod.natCast_eq_zero_iff` the goal $q \\mid 2^p+1$ becomes $((2^p+1 : \\mathbb{N}) : \\mathrm{ZMod}\\,q) = 0$, and after `push_cast` the earlier two_pow_eq_neg_one rewrites $2^p$ to $-1$, leaving $-1 + 1 = 0$ closed by `ring`. So for a Sophie Germain prime $p \\equiv 1 \\pmod 4$ the safe prime $q = 2p+1$ divides the Fermat-type number $2^p+1$. sophieGermain_dvd_two_pow_add_one repackages this against the `IsSophieGermainPrime` predicate, unbundling $\\langle hp, hq\\rangle$ from the structure.",
+    "mathContext": "$p\\equiv 1\\ (4),\\ q=2p+1\\text{ prime} \\Rightarrow q \\mid 2^p + 1.$",
     "significance": "key",
-    "relatedConcepts": ["divisibility", "compositeness"],
-    "prerequisites": ["ZMod / ℕ cast", "proper divisor"]
+    "relatedConcepts": ["divisibility", "ZMod ↔ ℕ cast", "IsSophieGermainPrime", "Fermat-type numbers"],
+    "prerequisites": ["ZMod.natCast_eq_zero_iff", "two_pow_eq_neg_one"]
+  },
+  {
+    "id": "ann-composite",
+    "proofId": "sophie-germain-oq-01-oq-03",
+    "range": { "startLine": 150, "endLine": 177 },
+    "type": "theorem",
+    "title": "The Compositeness Consequence",
+    "content": "two_pow_add_one_not_prime turns the divisibility into a compositeness statement — the punchline of the entry. It shows $q = 2p+1$ is a PROPER divisor of $2^p+1$: the bound $2p < 2^p$ for $p \\ge 5$ (two_mul_lt_two_pow, with $p \\ge 5$ from five_le_of_prime_mod_four) places $q$ strictly between $1$ and $2^p+1$. A prime's only divisors are $1$ and itself (`eq_one_or_self_of_dvd`), both excluded by `omega`, so $2^p+1$ cannot be prime. The closing sanity checks confirm the smallest case $p = 5$: $5$ is a Sophie Germain prime and $11 = 2\\cdot5+1$ divides $2^5+1 = 33 = 3\\cdot 11$ (by `decide`).",
+    "mathContext": "$1 < q < 2^p + 1\\ (p \\ge 5) \\Rightarrow 2^p+1$ composite; witness $p=5$: $11 \\mid 33$.",
+    "significance": "supporting",
+    "relatedConcepts": ["compositeness", "proper divisor", "Fermat-type factorization", "Sophie Germain / safe prime"],
+    "prerequisites": ["two_pow_add_one_dvd", "Nat.Prime.eq_one_or_self_of_dvd"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sophie-germain-oq-01-oq-03` (quality 91, pass 0).

## Assessment
meta.json (11.3 KB) under caps and complete. Gap: **annotations 4, need 5**. The final annotation (134–177) bundled the divisibility theorem, the compositeness consequence, and the sanity checks.

## Change
Split into two focused annotations (no accretion elsewhere):
- **ann-dvd** (134–148): `two_pow_add_one_dvd` (q ∣ 2^p+1 via casting 2^p = −1 back to ℕ) and its `IsSophieGermainPrime`-packaged form.
- **ann-composite** (150–177): `two_pow_add_one_not_prime` — the punchline that q = 2p+1 is a *proper* divisor (1 < q < 2^p+1 for p ≥ 5), so 2^p+1 is composite — plus the p=5 sanity check (11 ∣ 33).

Result: 5 annotations, coverage 3–177.

## Verification
- JSON validated (`json.load`), 5 annotations.
- Content checked against `Proofs/SophieGermainOQ0103.lean` (theorem names, `push_cast`/`eq_one_or_self_of_dvd`/`two_mul_lt_two_pow` steps, the line-150 section boundary all match).