### PR TITLE
Enrich negative Pell OQ-08: link the D=2 existence-chain sibling (crossRef 1→2)

### DIFF
--- a/src/data/proofs/pell-equation-oq-08/meta.json
+++ b/src/data/proofs/pell-equation-oq-08/meta.json
@@ -49,6 +49,11 @@
       "targetId": "pell-equation",
       "relationship": "extends",
       "description": "The root entry proves x² − Dy² = 1 always has infinitely many solutions for non-square D > 0. This entry treats the negative form x² − Dy² = −1, which is far more restrictive, and proves congruence obstructions (D ≢ 3 mod 4; no prime factor ≡ 3 mod 4) that must hold for any solution to exist."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-01",
+      "relationship": "related",
+      "description": "The existence-side complement: for the smallest solvable negative instance D = 2, that entry classifies all positive solutions of x² − 2y² = −1 as the odd-power chain of the fundamental unit of ℤ[√2]. Together the two entries frame negative-Pell solvability from both sides — this file certifies non-existence by local congruence obstructions (D ≡ 3 mod 4, or a prime factor ≡ 3 mod 4), while the sibling constructs the full infinite solution family precisely when the obstruction is absent and the fundamental unit has norm −1."
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass (meta.json only) for **pell-equation-oq-08** (Congruence Obstructions to the Negative Pell Equation).

- Added one `crossReference` (1→2): to `pell-equation-oq-06-oq-01` (classification of all positive solutions of x² − 2y² = −1 for D = 2). The entry's description and conclusion repeatedly cite this D = 2 existence chain as its complement, but it was never linked. The two entries now frame negative-Pell solvability from both sides — this file certifies non-existence via local congruence obstructions, the sibling constructs the full solution family when the obstruction is absent.

Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33874 on the same slug. Verified link target exists. Within size caps (13.5 KB ≤ 60 KB, 2 crossReferences ≤ 20). Build passes.
