### PR TITLE
Enrich Pick/Hibi OQ-03-ext-OQ-02: add Ehrhart & Macdonald primary sources (refs 2→4)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
@@ -92,6 +92,24 @@
       "year": "2015",
       "venue": "2nd ed., Undergraduate Texts in Mathematics, Springer",
       "note": "Standard modern reference for Pick's theorem, Ehrhart polynomials, Ehrhart–Macdonald reciprocity and h*-vectors."
+    },
+    {
+      "authors": [
+        "Ehrhart, E."
+      ],
+      "title": "Sur les polyèdres rationnels homothétiques à n dimensions",
+      "year": "1962",
+      "venue": "C. R. Acad. Sci. Paris 254, pp. 616–618",
+      "note": "Ehrhart's original theorem that the lattice-point count of dilates nP of a lattice polytope is a polynomial in n — the L(n) whose generating series carries the h*-vector."
+    },
+    {
+      "authors": [
+        "Macdonald, I. G."
+      ],
+      "title": "Polynomials associated with finite cell-complexes",
+      "year": "1971",
+      "venue": "J. London Math. Soc. (2) 4, pp. 181–192",
+      "note": "The Ehrhart–Macdonald reciprocity theorem L*(n) = (−1)^d L(−n), whose consequence H(t) = t^d H(1/t) is exactly the self-reciprocity hypothesis that supplies palindromy in reflexive_hStar_palindromic."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass (meta.json only) for **picks-theorem-oq-03-ext-oq-02** (Reflexive Polytopes and Palindromic h*-Vectors: Hibi's Algebraic Criterion).

- Added two primary-source `references` (2→4): Ehrhart (1962, original lattice-point polynomial theorem) and Macdonald (1971, the Ehrhart–Macdonald reciprocity theorem). Both are the mathematical linchpins the `historicalContext`, `proofStrategy`, and `keyInsights` repeatedly invoke — the reciprocity L*(n) = (−1)^d L(−n) whose H(t) = t^d H(1/t) consequence is exactly the self-reciprocity hypothesis of `reflexive_hStar_palindromic` — yet neither primary source was cited in the reference list (only Hibi + Beck–Robins).

Verified all 3 existing crossReferences resolve to real gallery entries. Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33875 on the same slug. Within size caps (4 references ≤ 25). JSON validated.
