### PR TITLE
Enrich polynomial-derivative-leibniz-oq-01: link Vandermonde interpolation (crossRef 1→2)

### DIFF
--- a/src/data/proofs/polynomial-derivative-leibniz-oq-01/meta.json
+++ b/src/data/proofs/polynomial-derivative-leibniz-oq-01/meta.json
@@ -158,6 +158,11 @@
       "targetId": "leibniz-pi",
       "relationship": "related",
       "description": "Shares Leibniz's name only: leibniz-pi is his infinite SERIES for π, this entry is his PRODUCT RULE for polynomial derivatives."
+    },
+    {
+      "targetId": "vandermonde-interpolation-oq-01",
+      "relationship": "related",
+      "description": "Lagrange-interpolation companion. This entry evaluates the split-polynomial derivative at a node to obtain p'(rᵢ₀) = ∏_{j≠i₀}(rᵢ₀ − rⱼ) — precisely the Lagrange denominator whose reciprocal weights the interpolation basis. That entry proves Vandermonde nonvanishing and the resulting existence/uniqueness of polynomial interpolation through the same distinct nodes rᵢ; the nonvanishing of the denominator here (eval_derivative_prod_X_sub_C_ne_zero over a domain with distinct roots) is the local, derivative-side counterpart of the global Vandermonde nonvanishing there."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass (meta.json only) for **polynomial-derivative-leibniz-oq-01** (Leibniz Product Rule for Formal Polynomial Derivatives over a Finset).

- Added one substantive `crossReference` (1→2): to `vandermonde-interpolation-oq-01` (Vandermonde Nonvanishing, the Finite Identity Theorem, and Interpolation Uniqueness). The single prior crossReference was only a namesake disambiguation (leibniz-pi). This entry's `p'(rᵢ₀) = ∏_{j≠i₀}(rᵢ₀ − rⱼ)` is exactly the Lagrange-interpolation denominator, and its openQuestion "Derive the Lagrange interpolation formula" connects directly to that entry — the derivative-side nonvanishing is the local counterpart of the global Vandermonde nonvanishing.

Verified the link target exists. Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33877 on the same slug. Within size caps (2 crossReferences ≤ 20). JSON validated.
