### PR TITLE
Enrich stirling-first-kind-oq-02: link follow-up children (crossRefs 2→4)

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02/meta.json
@@ -146,6 +146,16 @@
       "targetId": "stirling-second-kind-oq-01",
       "relationship": "related",
       "description": "Companion second-kind entry (the column closed form S(n,2) = 2^(n-1)−1); the second-kind numbers are connection coefficients in the opposite direction (powers in terms of falling factorials)"
+    },
+    {
+      "targetId": "stirling-first-kind-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Follow-up entry that develops this one: 'Stirling Orthogonality — the first- and second-kind triangles are inverse matrices.' It uses the generating identity proved here (c(n,k) = [Xᵏ] ascPochhammer ℤ n), together with its second-kind counterpart, to establish the orthogonality relation ∑ⱼ (−1)^{n−j} c(n,j) S(j,k) = [n=k]."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Direct follow-up that answers this entry's second open question: the alternating row sum ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2, obtained by evaluating the same rising-factorial generating polynomial at X = −1 (where the factor (X+1) forces a zero)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass (meta.json only) for **stirling-first-kind-oq-02** (rising-factorial generating identity).

- Added two forward `crossReferences` (2→4) to this entry's own follow-up children, which were previously unlinked:
  - `stirling-first-kind-oq-02-oq-01` — Stirling Orthogonality (first/second-kind triangles are inverse matrices), built on the generating identity proved here.
  - `stirling-first-kind-oq-02-oq-02` — the alternating row sum ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2, which is exactly this entry's **openQuestion #2**, resolved by evaluating the same generating polynomial at X = −1.

Verified both targets exist. Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33890 on the same slug. Within size caps (4 crossReferences ≤ 20). JSON validated.
