### PR TITLE
Enrich stirling-formula-oq-03: add Whittaker–Watson reference (1→2)

### DIFF
--- a/src/data/proofs/stirling-formula-oq-03/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03/meta.json
@@ -105,6 +105,13 @@
       "title": "Arithmetica Infinitorum",
       "year": "1656",
       "note": "Original derivation of the infinite product (π/2) = ∏ (2k)²/((2k−1)(2k+1))"
+    },
+    {
+      "authors": "Whittaker, E. T.; Watson, G. N.",
+      "title": "A Course of Modern Analysis",
+      "year": "1927",
+      "venue": "4th ed., Cambridge University Press (§12.13)",
+      "note": "Rigorous modern treatment of the Wallis product within the theory of the Gamma function, and its use in deriving Stirling's asymptotic constant √(2π)."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass (meta.json only) for **stirling-formula-oq-03** (Wallis product as a standalone limit).

- Added one standard secondary `reference` (1→2): Whittaker & Watson, *A Course of Modern Analysis* §12.13 — the rigorous modern treatment of the Wallis product within the Gamma-function theory and its role in fixing Stirling's constant √(2π). The entry previously cited only Wallis' 1656 primary source, despite its narrative connecting the product to the modern Stirling derivation.

Verified both existing crossReferences resolve. Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33892 on the same slug. Within size caps (2 references ≤ 25). JSON validated.
