### PR TITLE
Enrich tangent-addition-formula-oq-01-oq-01: add references array + header section

### DIFF
--- a/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
@@ -79,6 +79,14 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Imports, Overview, and Setup",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Imports (Mathlib trigonometric/arctan and complex-trig modules plus Mathlib.Tactic) and the file-level docstring motivating the three-argument extension of the parent's two-angle tangent law, introducing the elementary symmetric polynomials e₁, e₂, e₃ of tan x, tan y, tan z and previewing the triple-angle and triangle-identity corollaries; opens the Real namespace.",
+      "mathContext": "e₁ = Σ tan, e₂ = Σ tan·tan, e₃ = ∏ tan; the law tan(x+y+z) = (e₁ − e₃)/(1 − e₂) is developed below over the common denominator cos x·cos y·cos z."
+    },
+    {
       "id": "three-arg-law",
       "title": "The Three-Argument Tangent Addition Law",
       "startLine": 46,
@@ -136,5 +144,27 @@
     "path": "Proofs/TangentAdditionFormulaOQ01.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "authors": [
+        "Abramowitz, M.",
+        "Stegun, I. A."
+      ],
+      "title": "Handbook of Mathematical Functions",
+      "year": "1964",
+      "venue": "National Bureau of Standards, §4.3 (Trigonometric Functions)",
+      "note": "§4.3.16–4.3.42 tabulate the tangent addition and multiple-angle formulas, including tan(A+B) and the triple-angle form tan(3x) = (3tan x − tan³x)/(1 − 3tan²x) specialized here."
+    },
+    {
+      "authors": [
+        "Gradshteyn, I. S.",
+        "Ryzhik, I. M."
+      ],
+      "title": "Table of Integrals, Series, and Products",
+      "year": "2014",
+      "venue": "8th ed., Academic Press, §1.31–1.33",
+      "note": "Standard reference for the sum-of-angles trigonometric identities in elementary-symmetric-polynomial form, the general shape (odd eₖ)/(even eₖ) generalized in this entry's open question."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass (meta.json only) for **tangent-addition-formula-oq-01-oq-01** (Three-Argument Tangent Addition Law).

Two genuine structural gaps filled:
- **Added a `references` array** (was entirely absent — the entry cited only a Wikipedia `sourceUrl`): Abramowitz & Stegun §4.3 (which tabulates the tangent addition and triple-angle formulas proved here) and Gradshteyn & Ryzhik §1.31–1.33 (the sum-of-angles identities in elementary-symmetric-polynomial form, matching this entry's (eₖ)/(eₖ) generalization).
- **Added a `sec-header` section** (lines 1–45) so `sections` now cover the full 108-line Lean file; previously the three sections began at line 46, leaving imports, the docstring, and `open Real` undocumented.

No `references`/`sections` inflation elsewhere. No Machin cross-reference added: the "MachinFromAddition" entry named in an open question is not present in the gallery. No concurrent PR on this slug. JSON validated.
