### PR TITLE
Enrich stirling-second-kind-oq-01: link children + first-kind dual (crossRefs 1→4)

### DIFF
--- a/src/data/proofs/stirling-second-kind-oq-01/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01/meta.json
@@ -122,6 +122,21 @@
       "targetId": "stirling-formula",
       "relationship": "related",
       "description": "Shares the Stirling name but concerns a distinct object: Stirling numbers (combinatorial) versus Stirling's asymptotic factorial formula (analytic)"
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Direct follow-up answering this entry's first open question: the three-block column S(n,3) = (3ⁿ⁻¹ + 1)/2 − 2ⁿ⁻¹, obtained by the same recurrence-to-geometric-sum method one column further right."
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Direct follow-up answering this entry's second open question: the general finite-difference closed form k!·S(n,k) = ∑ⱼ (−1)ʲ C(k,j)(k−j)ⁿ, which specializes to S(n,2) = 2ⁿ⁻¹ − 1 at k = 2."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-01",
+      "relationship": "related",
+      "description": "The dual triangle: first-kind numbers c(n,k) count permutations by cycles and are the connection coefficients from falling factorials back to powers, inverse to the second-kind numbers here (powers to falling factorials). That entry proves the first-kind row sum ∑ₖ c(n,k) = n!."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass (meta.json only) for **stirling-second-kind-oq-01** (two-block column S(n,2) = 2ⁿ⁻¹ − 1).

- Added three substantive `crossReferences` (1→4); the sole prior entry was only a namesake disambiguation:
  - `stirling-second-kind-oq-01-oq-01` — the three-block column S(n,3), which **answers this entry's open question #1**.
  - `stirling-second-kind-oq-01-oq-02` — the general finite-difference formula k!·S(n,k) = ∑(−1)ʲC(k,j)(k−j)ⁿ, which **answers this entry's open question #2** and specializes to S(n,2) at k=2.
  - `stirling-first-kind-oq-01` — the dual (first-kind, cycle-counting) triangle, inverse connection coefficients.

Verified all targets exist. Scope limited to `meta.json` to avoid conflict with concurrent annotation-split PR #33896 on the same slug. Within size caps (4 crossReferences ≤ 20). JSON validated.
