### PR TITLE
Enrich summation-by-parts-oq-01-oq-01: split header (4→5)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01/annotations.json
@@ -2,14 +2,26 @@
   {
     "id": "sbp0101-ann-header",
     "proofId": "summation-by-parts-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 53 },
+    "range": { "startLine": 1, "endLine": 19 },
     "type": "concept",
     "title": "The Second Rung of the Arithmetico-Geometric Ladder",
-    "content": "The header states the target identity for $\\sum_{k<n} k^2 r^k$ over any field with $r \\neq 1$, and situates it: Mathlib has the geometric closed form (`geom_sum_eq`) and the gallery has the first-order $\\sum k r^k$ (the parent entry), but neither has the *quadratically weighted* sum. It is the finite, hypothesis-free analogue of twice-differentiating the geometric series, whose $|r|<1$ limit is the classical $r(1+r)/(1-r)^3$. The two imports are `Mathlib.Algebra.BigOperators.Module` (for `Finset.sum_range_by_parts`) and `Mathlib.Tactic` (for `field_simp`, `ring`, `push_cast`); the file fixes an arbitrary field `K` and opens `Finset`.",
+    "content": "The header states the target identity for $\\sum_{k<n} k^2 r^k$ over any field with $r \\neq 1$: the quadratically weighted geometric sum, each term the arithmetic weight $k^2$ times the geometric factor $r^k$. It is the next step beyond the parent entry SummationByPartsOQ01 (the first-order $\\sum k r^k$), and the finite, hypothesis-free analogue of twice-differentiating the geometric series, whose $n\\to\\infty$ limit for $|r|<1$ is the classical $\\sum k^2 r^k = r(1+r)/(1-r)^3$. The two imports are Mathlib.Algebra.BigOperators.Module (for Finset.sum_range_by_parts) and Mathlib.Tactic (field_simp, ring, push_cast); the file fixes an arbitrary field K and opens Finset.",
     "mathContext": "$\\sum_{k=0}^{n-1} k^2 r^k = \\dfrac{n^2 r^n - (2n^2-2n-1)r^{n+1} + (n-1)^2 r^{n+2} - r^2 - r}{(r-1)^3}.$ The integer coefficients are interpreted in $K$.",
     "significance": "supporting",
-    "relatedConcepts": ["arithmetico-geometric series", "Abel summation", "generating functions", "finite differences"],
+    "relatedConcepts": ["arithmetico-geometric series", "quadratic arithmetic weight", "twice-differentiated geometric series", "finite differences"],
     "prerequisites": ["finite sums", "fields", "geometric series"]
+  },
+  {
+    "id": "sbp0101-ann-novelty-method",
+    "proofId": "summation-by-parts-oq-01-oq-01",
+    "range": { "startLine": 21, "endLine": 53 },
+    "type": "concept",
+    "title": "Why It's New, and Two Independent Proof Routes",
+    "content": "The docstring scopes the contribution and previews the method. Mathlib has geom_sum_eq (the geometric closed form) and, via the parent entry, the gallery has the first-order $\\sum k r^k$; NEITHER records the quadratically weighted $\\sum k^2 r^k$ over a general field. Crucially the gallery's infinite entries (GeometricSeriesOQ06) are analytic limits requiring $\\lVert r\\rVert < 1$, whereas this is the exact FINITE sum over any field under the single algebraic hypothesis $r \\neq 1$ — an algebraic identity, not an analytic limit. The file proves it TWO independent ways: by induction (clearing $(r-1)^3$ to a polynomial identity), and by Abel's summation by parts. The by-parts route is the conceptual payoff: because the quadratic weight $f(k)=k^2$ has non-constant forward differences $f(k+1)-f(k)=2k+1$, summation by parts reduces the second-order sum to a genuinely first-order weighted sum of geometric partial sums — the recursive ladder $\\sum k^2 r^k \\rightsquigarrow \\sum (2k+1)\\cdot(\\text{geom}) \\rightsquigarrow \\cdots$.",
+    "mathContext": "Finite field identity under $r \\neq 1$ (not an $\\lVert r\\rVert<1$ analytic limit); summation by parts uses $\\Delta(k^2) = 2k+1$ to drop the order by one.",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation by parts", "finite vs analytic (|r|<1) sums", "forward differences", "order-reduction ladder"],
+    "prerequisites": ["summation by parts", "geometric partial sums"]
   },
   {
     "id": "sbp0101-ann-closed-form",


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01` (quality 91, pass 0).

## Assessment
meta.json (12.6 KB) under caps and complete. Gap: **annotations 4, need 5** (3 theorems + a 53-line header covering three docstring sections).

## Change
Split the header into the result and its scholarly placement (no accretion elsewhere):
- **sbp0101-ann-header** (1–19): the target closed form Σₖ<ₙ k²rᵏ, the quadratically weighted sum one rung beyond the parent's first-order Σ k rᵏ.
- **sbp0101-ann-novelty-method** (21–53): why it's new — a finite, hypothesis-free field identity (r ≠ 1) versus the gallery's analytic \|r\|<1 limits — plus the two independent proof routes, highlighting the Abel summation-by-parts order-reduction ladder (Δ(k²) = 2k+1 drops the second-order sum to first order).

Result: 5 annotations, coverage aligned to docstring sections and theorems.

## Verification
- JSON validated (`json.load`), 5 annotations.
- Content checked against `Proofs/SummationByPartsOQ01OQ01.lean` (the three theorems at 58/77/93, the 'What This Proves'/'Why…'/'Method' docstring sections, and `sum_range_by_parts` all match).