### PR TITLE
research(polynomial-derivative-leibniz-oq-01-oq-01): discriminant identity ∏ p'(rᵢ) = (−1)^N·Vandermonde²

### DIFF
--- a/proofs/Proofs/PolynomialDerivativeLeibnizOQ01OQ01.lean
+++ b/proofs/Proofs/PolynomialDerivativeLeibnizOQ01OQ01.lean
@@ -1,0 +1,128 @@
+/-
+  The Discriminant Identity for a Split Polynomial
+  Open Question: polynomial-derivative-leibniz-oq-01-oq-01
+
+  The parent entry `polynomial-derivative-leibniz-oq-01` established, axiom-free over
+  any commutative ring, the value of the derivative of a split polynomial at one of its
+  roots:
+
+    `eval_derivative_prod_X_sub_C` :
+        p'(rᵢ₀) = ∏_{j ∈ s.erase i₀} (rᵢ₀ − rⱼ),   where p = ∏_{i∈s} (X − rᵢ),
+
+  the leave-one-out product of node differences (the Lagrange-interpolation denominator).
+
+  This entry answers the first open question left there: relate the **product of the
+  derivative values over all roots** to the **discriminant** ∏_{i<j}(rᵢ − rⱼ)². Working
+  over a linearly ordered index type we prove, over any commutative ring:
+
+    `prod_eval_derivative_eq` :
+        ∏_{i∈s} p'(rᵢ) = ∏_{i∈s} ∏_{j∈s.erase i} (rᵢ − rⱼ)                 (full off-diagonal product)
+
+    `prod_eval_derivative_eq_sign_mul_sq` :
+        ∏_{i∈s} p'(rᵢ) = (−1)^N · ( ∏_{i∈s} ∏_{j∈s, i<j} (rᵢ − rⱼ) )²
+      where N = ∑_{i∈s} #{ j ∈ s : i < j } is the number of unordered pairs of s
+      (equivalently N = C(#s, 2)).
+
+  The square being multiplied is exactly the Vandermonde product of node differences,
+  so the right-hand side is the discriminant of the split polynomial up to the sign
+  (−1)^N.  The proof is elementary: split the erased index set `s.erase i` into the
+  elements below and above `i`; the "below" half, after swapping the two summation
+  indices (`Finset.prod_comm'`), pairs term-by-term with the "above" half, and each
+  pair `(rᵢ − rⱼ)(rⱼ − rᵢ) = −(rᵢ − rⱼ)²` contributes a square and a factor of −1.
+
+  Zero axioms, zero sorries; only `[CommRing R]` and `[LinearOrder ι]` are used.
+
+  References:
+  - Lang, S., Algebra, 3rd ed., §IV.1 (formal derivative and the discriminant).
+  - The discriminant of a monic split polynomial ∏(X − rᵢ) is ∏_{i<j}(rᵢ − rⱼ)²; the
+    derivative-at-a-root value p'(rᵢ) = ∏_{j≠i}(rᵢ − rⱼ) is the standard route to it.
+-/
+
+import Mathlib
+import Proofs.PolynomialDerivativeLeibnizOQ01
+
+namespace PolyDerivLeibnizOQ01OQ01
+
+open Polynomial Finset
+
+variable {R : Type*} [CommRing R] {ι : Type*} [LinearOrder ι]
+
+/-- **Splitting an erased index set by order.** For a linear order, the product over
+    `s.erase i` factors as the product over the elements strictly below `i` times the
+    product over the elements strictly above `i`, since `j ≠ i ↔ j < i ∨ i < j`. -/
+theorem prod_erase_eq_prod_lt_mul_prod_gt (s : Finset ι) (i : ι) (g : ι → R) :
+    ∏ j ∈ s.erase i, g j
+      = (∏ j ∈ s.filter (fun j => j < i), g j) * ∏ j ∈ s.filter (fun j => i < j), g j := by
+  have hdisj : Disjoint (s.filter (fun j => j < i)) (s.filter (fun j => i < j)) := by
+    apply Finset.disjoint_left.mpr
+    intro a ha hb
+    simp only [Finset.mem_filter] at ha hb
+    exact absurd hb.2 (lt_asymm ha.2)
+  have hunion : s.erase i = s.filter (fun j => j < i) ∪ s.filter (fun j => i < j) := by
+    ext j
+    simp only [Finset.mem_erase, Finset.mem_union, Finset.mem_filter]
+    constructor
+    · rintro ⟨hji, hjs⟩
+      rcases lt_or_gt_of_ne hji with h | h
+      · exact Or.inl ⟨hjs, h⟩
+      · exact Or.inr ⟨hjs, h⟩
+    · rintro (⟨hjs, h⟩ | ⟨hjs, h⟩)
+      · exact ⟨ne_of_lt h, hjs⟩
+      · exact ⟨(ne_of_lt h).symm, hjs⟩
+  rw [hunion, Finset.prod_union hdisj]
+
+/-- **Product of the derivative values over all roots = full off-diagonal product.**
+    For `p = ∏_{i∈s}(X − rᵢ)`, by the parent entry's `eval_derivative_prod_X_sub_C`
+    each factor is a leave-one-out product, so
+    `∏_{i∈s} p'(rᵢ) = ∏_{i∈s} ∏_{j∈s.erase i} (rᵢ − rⱼ)`. -/
+theorem prod_eval_derivative_eq (s : Finset ι) (r : ι → R) :
+    ∏ i ∈ s, (derivative (∏ x ∈ s, (X - C (r x)))).eval (r i)
+      = ∏ i ∈ s, ∏ j ∈ s.erase i, (r i - r j) := by
+  apply Finset.prod_congr rfl
+  intro i hi
+  exact PolyDerivLeibnizOQ01.eval_derivative_prod_X_sub_C s r hi
+
+/-- **The discriminant identity.** Over any commutative ring with a linearly ordered
+    index type, the product of the derivative values of the split polynomial
+    `p = ∏_{i∈s}(X − rᵢ)` over all its roots equals, up to the sign `(−1)^N`, the square
+    of the Vandermonde product of node differences:
+      `∏_{i∈s} p'(rᵢ) = (−1)^N · (∏_{i∈s} ∏_{j∈s, i<j} (rᵢ − rⱼ))²`,
+    where `N = ∑_{i∈s} #{j ∈ s : i < j}` is the number of unordered pairs of `s`. -/
+theorem prod_eval_derivative_eq_sign_mul_sq (s : Finset ι) (r : ι → R) :
+    ∏ i ∈ s, (derivative (∏ x ∈ s, (X - C (r x)))).eval (r i)
+      = (-1) ^ (∑ i ∈ s, (s.filter (fun j => i < j)).card)
+        * (∏ i ∈ s, ∏ j ∈ s.filter (fun j => i < j), (r i - r j)) ^ 2 := by
+  rw [prod_eval_derivative_eq]
+  -- Split each `erase i` into the below-`i` and above-`i` halves.
+  have hsplit : ∏ i ∈ s, ∏ j ∈ s.erase i, (r i - r j)
+      = (∏ i ∈ s, ∏ j ∈ s.filter (fun j => j < i), (r i - r j))
+        * (∏ i ∈ s, ∏ j ∈ s.filter (fun j => i < j), (r i - r j)) := by
+    rw [← Finset.prod_mul_distrib]
+    apply Finset.prod_congr rfl
+    intro i _
+    exact prod_erase_eq_prod_lt_mul_prod_gt s i (fun j => r i - r j)
+  rw [hsplit]
+  -- Swap the summation indices in the below-`i` (lower-triangular) product.
+  have hlower : (∏ i ∈ s, ∏ j ∈ s.filter (fun j => j < i), (r i - r j))
+      = ∏ j ∈ s, ∏ i ∈ s.filter (fun i => j < i), (r i - r j) := by
+    apply Finset.prod_comm'
+    intro i j
+    simp only [Finset.mem_filter]
+    tauto
+  rw [hlower]
+  -- Pair the two triangular products term by term.
+  have key : (∏ j ∈ s, ∏ i ∈ s.filter (fun i => j < i), (r i - r j))
+           * (∏ i ∈ s, ∏ j ∈ s.filter (fun j => i < j), (r i - r j))
+      = ∏ i ∈ s, ∏ j ∈ s.filter (fun j => i < j), ((r j - r i) * (r i - r j)) := by
+    rw [← Finset.prod_mul_distrib]
+    apply Finset.prod_congr rfl
+    intro i _
+    rw [← Finset.prod_mul_distrib]
+  rw [key]
+  -- Each paired factor is `−(rᵢ − rⱼ)²`; collect the signs and the square.
+  have hpt : ∀ i j : ι, (r j - r i) * (r i - r j) = (-1) * (r i - r j) ^ 2 := by
+    intro i j; ring
+  simp_rw [hpt, Finset.prod_mul_distrib, Finset.prod_const, Finset.prod_pow]
+  rw [Finset.prod_pow_eq_pow_sum]
+
+end PolyDerivLeibnizOQ01OQ01

--- a/research/notes/polynomial-derivative-leibniz-oq-01-oq-01.md
+++ b/research/notes/polynomial-derivative-leibniz-oq-01-oq-01.md
@@ -1,0 +1,37 @@
+# Discriminant Identity for a Split Polynomial
+Open Question: polynomial-derivative-leibniz-oq-01-oq-01 (child of polynomial-derivative-leibniz-oq-01)
+
+## Result
+Over any `CommRing R` with a linearly ordered index type `ι`, for `p = ∏_{i∈s} (X − rᵢ)`:
+
+1. `prod_eval_derivative_eq` : ∏_{i∈s} p'(rᵢ) = ∏_{i∈s} ∏_{j∈s.erase i} (rᵢ − rⱼ)
+   (full off-diagonal product of node differences), from the parent entry's
+   `eval_derivative_prod_X_sub_C`.
+
+2. `prod_eval_derivative_eq_sign_mul_sq` :
+       ∏_{i∈s} p'(rᵢ) = (−1)^N · ( ∏_{i∈s} ∏_{j∈s, i<j} (rᵢ − rⱼ) )²
+   where N = ∑_{i∈s} #{ j ∈ s : i < j } is the number of unordered pairs of s (= C(#s,2)).
+   The squared factor is the Vandermonde product of node differences, so the RHS is the
+   discriminant of the split polynomial up to the sign (−1)^N.
+
+Answers open question #1 left by the parent entry.
+
+## Proof idea
+Split `s.erase i` into elements below/above `i` (linear order). The below-half, after
+swapping the two indices (`Finset.prod_comm'`), pairs term-by-term with the above-half;
+each pair `(rᵢ−rⱼ)(rⱼ−rᵢ) = −(rᵢ−rⱼ)²` yields a square and a factor of −1. Collect the
+signs with `prod_pow_eq_pow_sum` and the squares with `prod_pow`.
+
+Lemmas used (all confirmed present in Mathlib v4.26.0): Finset.prod_union, prod_comm',
+prod_mul_distrib, prod_const, prod_pow, prod_pow_eq_pow_sum, lt_or_gt_of_ne, lt_asymm.
+No axioms, no sorries, no native_decide/decide.
+
+## Verification status (2026-07-02)
+- Proof ELABORATED CLEANLY via `lake env lean` (EXIT=0, zero errors) on a self-contained
+  inlined copy (parent lemma inlined, `import Mathlib` only), during a consistent cache
+  window.
+- Authoritative `docker-build.sh` verification BLOCKED: host disk 100% full (131Mi free),
+  causing Docker containerd meta.db I/O errors AND intermittent host `.lake` olean
+  corruption (segfaults / invalid-header). Same infra outage documented previously.
+- ACTION NEEDED: re-run `./proofs/scripts/docker-build.sh Proofs.PolynomialDerivativeLeibnizOQ01OQ01`
+  once host disk is freed, then promote to a verified gallery entry (0-axiom).


### PR DESCRIPTION
## Summary
Answers **open question #1** of the verified parent entry `polynomial-derivative-leibniz-oq-01`: relate the product of the derivative values over all roots of a split polynomial $p = \prod_{i\in s}(X-r_i)$ to its **discriminant**.

Two new theorems (namespace `PolyDerivLeibnizOQ01OQ01`), over any `CommRing R` with a linearly ordered index type:

1. `prod_eval_derivative_eq` — $\prod_{i\in s} p'(r_i) = \prod_{i\in s}\prod_{j\in s\setminus\{i\}} (r_i - r_j)$ (full off-diagonal product of node differences), directly from the parent's `eval_derivative_prod_X_sub_C`.
2. `prod_eval_derivative_eq_sign_mul_sq` — $\prod_{i\in s} p'(r_i) = (-1)^N \cdot \bigl(\prod_{i\in s}\prod_{j\in s,\, i<j}(r_i-r_j)\bigr)^2$, where $N = \sum_{i\in s}\#\{j\in s : i<j\}$ is the number of unordered pairs of $s$ ($= \binom{|s|}{2}$). The squared factor is the Vandermonde product of node differences, so the RHS is the discriminant up to the sign $(-1)^N$.

## Proof idea
Split `s.erase i` into elements below/above `i` (linear order). The below-half, after swapping the two summation indices (`Finset.prod_comm'`), pairs term-by-term with the above-half; each pair $(r_i-r_j)(r_j-r_i) = -(r_i-r_j)^2$ contributes a square and a factor of $-1$. Signs collected with `prod_pow_eq_pow_sum`, squares with `prod_pow`.

No `axiom`/`sorry`/`native_decide`/`decide`. Reuses the parent (verified, 0-axiom); all Mathlib lemmas confirmed present in v4.26.0.

## ⚠️ Verification status
- ✅ **Proof elaborated cleanly** via `lake env lean` (EXIT=0, zero errors) on a self-contained inlined copy (parent lemma inlined, `import Mathlib` only) during a consistent cache window.
- ⛔ **Authoritative `docker-build.sh` verification BLOCKED**: host disk is **100% full (131 Mi free)**, causing Docker containerd `meta.db` I/O errors and intermittent host `.lake` olean corruption (segfaults / invalid-header). Same infra outage documented in prior sessions.
- **Action before merge/promotion:** re-run `./proofs/scripts/docker-build.sh Proofs.PolynomialDerivativeLeibnizOQ01OQ01` once disk is freed, then promote to a verified 0-axiom gallery entry.

Gallery `meta.json` intentionally **not** added yet — not claiming "verified" until an authoritative build passes (honesty policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)