### PR TITLE
research(kronecker-oq03-oq02-wip): complete odd-positive multiplicativity + QR, fix kronecker0_mul bit-rot [BUILD-BLOCKED]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -170,24 +170,22 @@ private theorem kroneckerNeg1_mul (a b : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) :
     Uses: |a·b| = 1 iff |a| = 1 ∧ |b| = 1 (units in ℤ). -/
 private theorem kronecker0_mul (a b : ℤ) (hab : a * b ≠ 0) :
     kronecker0 (a * b) = kronecker0 a * kronecker0 b := by
-  simp only [kronecker0]
-  by_cases hab1 : a * b = 1 ∨ a * b = -1
-  · -- |a*b| = 1 implies |a| = 1 and |b| = 1
-    have ha1 : a = 1 ∨ a = -1 := by
-      rcases hab1 with h | h
-      · exact Int.isUnit_eq_one_or.mp (isUnit_of_mul_eq_one _ _ h)
-      · have := Int.isUnit_eq_one_or.mp (isUnit_of_mul_eq_one _ _ (neg_eq_iff_eq_neg.mpr h ▸
-          show a * b * -1 = 1 from by linarith))
-        rcases this with h1 | h1 <;> [right; left] <;> linarith
-    have hb1 : b = 1 ∨ b = -1 := by
-      rcases ha1 with rfl | rfl <;> simp_all
-    simp [ha1, hb1]
-  · -- |a*b| ≠ 1
-    simp [hab1]
-    by_cases ha1 : a = 1 ∨ a = -1
-    · -- |a| = 1 but |a*b| ≠ 1, so |b| ≠ 1
-      rcases ha1 with rfl | rfl <;> simp_all
-    · simp [ha1]
+  by_cases ha : a = 1 ∨ a = -1
+  · by_cases hb : b = 1 ∨ b = -1
+    · -- both a and b are units ⇒ a*b = ±1
+      rcases ha with rfl | rfl <;> rcases hb with rfl | rfl <;> decide
+    · -- a is a unit, b is not ⇒ a*b is not a unit
+      have hnu : ¬(a * b = 1 ∨ a * b = -1) := by
+        rcases ha with rfl | rfl
+        · simpa using hb
+        · push_neg at hb ⊢; omega
+      simp only [kronecker0, if_neg hnu, if_neg hb, mul_zero]
+  · -- a is not a unit ⇒ a*b is not a unit
+    have hnu : ¬(a * b = 1 ∨ a * b = -1) := by
+      rintro (h | h)
+      · exact ha (Int.isUnit_iff.mp (isUnit_of_mul_eq_one a b h))
+      · exact ha (Int.isUnit_iff.mp (isUnit_of_mul_eq_one a (-b) (by rw [mul_neg, h]; norm_num)))
+    simp only [kronecker0, if_neg hnu, if_neg ha, zero_mul]
 
 /-- The Kronecker symbol is completely multiplicative in the first argument:
     (ab/n) = (a/n)(b/n), provided a*b ≠ 0.

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
@@ -208,16 +208,70 @@ theorem kronecker_mul_left (a b n : ℤ) (hab : a * b ≠ 0) :
   · rw [jacobiSym.mul_left, kroneckerNeg1_mul a b ha hb]; ring
   · rw [jacobiSym.mul_left]; ring
 
-/-- The Kronecker symbol is completely multiplicative in the second argument:
-    (a/mn) = (a/m)(a/n), provided m * n ≠ 0 or |a| ≤ 1.
+/-- **Multiplicativity in the second argument, odd positive case.**
+    For odd positive moduli m, n, the Kronecker symbol satisfies
+    (a/mn) = (a/m)(a/n).
 
-    Same edge case as kronecker_mul_left: kroneckerNeg1(0) = 1 causes
-    issues when one of m, n is -1 and the other introduces a 0.
-    Fix: require m * n ≠ 0. -/
-/-- **Quadratic reciprocity for the Kronecker symbol**:
-    For fundamental discriminants d₁, d₂ with gcd(d₁,d₂) = 1:
-    (d₁/|d₂|)(d₂/|d₁|) = (-1)^{((d₁-1)/2)·((d₂-1)/2)}
+    Here both moduli lie in the odd positive range where the Kronecker
+    symbol coincides with the Jacobi symbol, so the result reduces to
+    `jacobiSym.mul_right'`. The fully general statement (even and negative
+    moduli) requires tracking the sign character and the mod-8 factor for
+    powers of 2; that case is left open — see the module note below. -/
+theorem kronecker_mul_right_odd (a : ℤ) (m n : ℕ)
+    (hm : 0 < m) (hn : 0 < n) (hmo : m % 2 = 1) (hno : n % 2 = 1) :
+    kronecker a ((m : ℤ) * n) = kronecker a m * kronecker a n := by
+  have hmn : 0 < m * n := Nat.mul_pos hm hn
+  have hmno : (m * n) % 2 = 1 :=
+    Nat.odd_iff.mp ((Nat.odd_iff.mpr hmo).mul (Nat.odd_iff.mpr hno))
+  have ecast : ((m : ℤ) * (n : ℤ)) = ((m * n : ℕ) : ℤ) := by push_cast; ring
+  rw [ecast, kronecker_eq_jacobi a (m * n) hmn hmno,
+    kronecker_eq_jacobi a m hm hmo, kronecker_eq_jacobi a n hn hno,
+    jacobiSym.mul_right' a (by omega) (by omega)]
 
-    This generalizes Gauss's QR to arbitrary discriminants and
-    is the form used in class field theory. -/
+/-- **Quadratic reciprocity for the Kronecker symbol, odd positive case.**
+    For odd positive m, n:
+    (m/n) = (-1)^{((m-1)/2)·((n-1)/2)} · (n/m).
+
+    For odd positive moduli the Kronecker symbol agrees with the Jacobi
+    symbol, so this is exactly `jacobiSym.quadratic_reciprocity` transported
+    across `kronecker_eq_jacobi`. No coprimality hypothesis is needed: when
+    gcd(m,n) > 1 both sides vanish.
+
+    The general reciprocity law for arbitrary (even/negative) discriminants
+    d₁, d₂ — the form used in class field theory, equivalent to Artin
+    reciprocity for quadratic extensions of ℚ — additionally requires the
+    supplementary laws (2/n) and (-1/n) and is left open here. -/
+theorem kronecker_quadratic_reciprocity (m n : ℕ)
+    (hm : 0 < m) (hn : 0 < n) (hmo : m % 2 = 1) (hno : n % 2 = 1) :
+    kronecker (m : ℤ) n = (-1) ^ (m / 2 * (n / 2)) * kronecker (n : ℤ) m := by
+  rw [kronecker_eq_jacobi (m : ℤ) n hn hno, kronecker_eq_jacobi (n : ℤ) m hm hmo]
+  exact jacobiSym.quadratic_reciprocity (Nat.odd_iff.mpr hmo) (Nat.odd_iff.mpr hno)
+
+/-- **Quadratic reciprocity, congruence form.**
+    If additionally m ≡ 1 (mod 4), the sign factor is trivial and reciprocity
+    becomes a plain equality (m/n) = (n/m). -/
+theorem kronecker_reciprocity_one_mod_four (m n : ℕ)
+    (hm : m % 4 = 1) (hn : 0 < n) (hno : n % 2 = 1) :
+    kronecker (m : ℤ) n = kronecker (n : ℤ) m := by
+  have hmo : m % 2 = 1 := by omega
+  have hmpos : 0 < m := by omega
+  rw [kronecker_eq_jacobi (m : ℤ) n hn hno, kronecker_eq_jacobi (n : ℤ) m hmpos hmo]
+  exact jacobiSym.quadratic_reciprocity_one_mod_four hm (Nat.odd_iff.mpr hno)
+
+/-!
+## Module note: what remains open
+
+The full Kronecker symbol is completely multiplicative in *both* arguments
+over all of ℤ×ℤ, and satisfies a generalized quadratic reciprocity law for
+arbitrary fundamental discriminants. The theorems above establish these
+properties on the odd positive range, where the symbol coincides with the
+Jacobi symbol and the results follow from Mathlib's Jacobi API.
+
+The remaining even/negative cases require the supplementary laws for the
+special moduli — `kronecker2` (the mod-8 pattern for n = 2) and
+`kroneckerNeg1` (the sign character for n = -1) — together with a Gauss-sum
+or induction argument to combine them with the odd part. These are not yet
+in Mathlib and are left as open work.
+-/
+
 end KroneckerSymbol

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-wip-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
   "title": "Kronecker Symbol WIP Completion",
-  "phase": "NEW",
+  "phase": "PROGRESS",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -11,29 +11,54 @@
     "whyMatters": []
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "kronecker_mul_right_odd: (a/mn)=(a/m)(a/n) for odd positive m,n (via jacobiSym.mul_right')",
+      "kronecker_quadratic_reciprocity: (m/n)=(-1)^((m/2)(n/2))*(n/m) for odd positive m,n (via jacobiSym.quadratic_reciprocity)",
+      "kronecker_reciprocity_one_mod_four: (m/n)=(n/m) when m%4=1 (via jacobiSym.quadratic_reciprocity_one_mod_four)"
+    ],
+    "open": [
+      "Multiplicativity in the second argument for general (even/negative) moduli",
+      "Generalized quadratic reciprocity for arbitrary fundamental discriminants (needs supplementary laws (2/n),(-1/n) + Gauss sums)"
+    ],
+    "goal": "Fill the two Section-6 stubs (mul in n, QR) with proven theorems; keep hard general cases honestly open."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-05T06:55:50.081Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "PROGRESS",
+    "since": "2026-07-03T01:14:09Z",
+    "iteration": 2,
+    "focus": "Odd-positive-modulus case completed by reduction to Mathlib's Jacobi API; also repaired pre-existing kronecker0_mul bit-rot (Int.isUnit_eq_one_or no longer an iff).",
+    "blockers": [
+      "Docker Lean build unavailable: containerd 'meta.db: input/output error' (daemon flapping); changes source-reviewed against Mathlib signatures but NOT machine-verified."
+    ],
+    "nextAction": "Run docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02 once Docker is repaired; if green, mark PR #33901 ready.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Section 6 had two dangling docstrings (parse error) for mul-in-n and generalized QR. Replaced with three proven theorems on the odd-positive-modulus range where kronecker = jacobiSym, each a direct transport of a Mathlib Jacobi lemma across the file's kronecker_eq_jacobi. Separately fixed a pre-existing build break in kronecker0_mul. PR #33901 (draft, build-blocked).",
+    "builtItems": [
+      "kronecker_mul_right_odd",
+      "kronecker_quadratic_reciprocity",
+      "kronecker_reciprocity_one_mod_four",
+      "kronecker0_mul (repaired)"
+    ],
+    "insights": [
+      "For odd positive moduli the Kronecker symbol IS the Jacobi symbol (kronecker_eq_jacobi), so mul-in-n and QR come for free from jacobiSym.mul_right' and jacobiSym.quadratic_reciprocity.",
+      "No coprimality hypothesis is needed for the odd-positive QR: when gcd(m,n)>1 both sides vanish.",
+      "The general even/negative case genuinely needs the supplementary laws (2/n) and (-1/n) plus a Gauss-sum/induction combination not yet in Mathlib.",
+      "kronecker0_mul had bit-rotted: Int.isUnit_eq_one_or is now IsUnit u -> (u=1 v u=-1), not an iff; use Int.isUnit_iff instead."
+    ],
+    "mathlibGaps": [
+      "No Kronecker symbol in Mathlib (only jacobiSym for odd positive denominators).",
+      "No supplementary-law lemmas connecting (2/n)/(-1/n) to the odd part for a generalized reciprocity."
+    ],
+    "nextSteps": [
+      "Machine-verify via docker-build once infra is restored.",
+      "Attempt general mul-in-n by factoring n into 2-adic valuation + odd part and combining kronecker2/kroneckerNeg1 with the odd part."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Completes the WIP Kronecker-symbol formalization in
`Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean` (problem
`elementary-quadratic-reciprocity-oq-03-oq-02-wip-01`). Section 6 previously
held **two dangling docstrings with no theorems** (a parse error) describing
multiplicativity in the second argument and generalized quadratic reciprocity.
This PR replaces the stubs with proven theorems on the tractable **odd positive
modulus** range, where the Kronecker symbol coincides with the Jacobi symbol.

### New theorems (all reduce to Mathlib's Jacobi API via the file's own `kronecker_eq_jacobi`)
- `kronecker_mul_right_odd` — `(a/mn) = (a/m)(a/n)` for odd positive `m,n`, via `jacobiSym.mul_right'`.
- `kronecker_quadratic_reciprocity` — `(m/n) = (-1)^((m/2)(n/2)) · (n/m)` for odd positive `m,n`, via `jacobiSym.quadratic_reciprocity` (no coprimality hypothesis needed).
- `kronecker_reciprocity_one_mod_four` — plain equality `(m/n) = (n/m)` when `m ≡ 1 (mod 4)`, via `jacobiSym.quadratic_reciprocity_one_mod_four`.
- A module note documents what remains open (even/negative moduli need the supplementary laws `(2/n)`, `(-1/n)` + a Gauss-sum/induction argument, not yet in Mathlib).

### Pre-existing bug fix
- **`kronecker0_mul` was already broken** under the current Mathlib: it relied on `Int.isUnit_eq_one_or.mp`, but `Int.isUnit_eq_one_or` is now `IsUnit u → (u = 1 ∨ u = -1)` (a function, not an iff), so `.mp` fails to elaborate. Rewrote the proof via `Int.isUnit_iff` + `isUnit_of_mul_eq_one` with a clean unit/non-unit case split. Statement unchanged.

No new `axiom`s or `sorry`s. No `native_decide` (one `decide` on fully concrete `±1` arithmetic, ordinary kernel reduction).

## ⚠️ Build status: NOT machine-verified — DRAFT

The Docker Lean build could **not** be run to completion: the local Docker
Desktop is failing with the containerd storage error
`write .../io.containerd.metadata.v1.bolt/meta.db: input/output error`
(daemon flapping up/down, `curl` missing in cache-get, "unexpected EOF" on
container waits). This is host-infrastructure corruption, not a proof problem,
and needs a human to repair Docker Desktop.

The changes were **source-reviewed against the exact Mathlib signatures**
(`jacobiSym.mul_right'`, `jacobiSym.quadratic_reciprocity`,
`jacobiSym.quadratic_reciprocity_one_mod_four`, `Int.isUnit_iff`,
`isUnit_of_mul_eq_one`, `mul_neg`) confirmed in
`proofs/.lake/packages/mathlib/...`, and every rewrite chain was traced by
hand. But per the repository's Axiom Integrity Policy I am **not** claiming
`verified` without a clean `docker-build.sh` run.

**Action for reviewer/deployer:** once Docker is healthy, run
`./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ02`
and, if green, mark ready. Gallery `meta.json` was intentionally left unchanged
(still `badge: wip`) to avoid overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
