### PR TITLE
Enrich summation-by-parts-oq-01-oq-01-oq-01: split ladder annotation (4→5)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "sbp010101-ann-ladder",
     "proofId": "summation-by-parts-oq-01-oq-01-oq-01",
-    "range": { "startLine": 112, "endLine": 152 },
+    "range": { "startLine": 112, "endLine": 132 },
     "type": "insight",
-    "title": "Reading the Ladder off the Engine: f≡1, f=k, f=k²",
-    "content": "Three corollaries instantiate (★) and recover each rung of the ladder. `geom_sum_via_recursion` ($f \\equiv 1$): the forward differences vanish, so (★) collapses to $(r-1)\\sum r^k = r^n - 1$ — the geometric series, the bottom of the ladder. `sum_range_id_mul_geom_recursion` ($f(k) = k$): $\\Delta f \\equiv 1$ is constant, so the first-order sum reduces to a pure geometric sum. `sum_range_sq_mul_geom_recursion` ($f(k) = k^2$): $\\Delta f(k) = 2k+1$ is linear, so the second-order sum reduces to a first-order weighted sum — exactly the degree-lowering step the parent entry performed by hand. Each is a one-line specialization (`geom_weighted_recursion`, then `simp`/`push_cast`/`ring` to normalize the difference term).",
-    "mathContext": "$f \\equiv 1: \\Delta f = 0$; $f(k)=k: \\Delta f = 1$; $f(k)=k^2: \\Delta f(k) = (k+1)^2 - k^2 = 2k+1$. The degree of $\\Delta f$ is always one less than that of $f$ — the engine of the recursion.",
+    "title": "Bottom Two Rungs: f≡1 (geometric) and f=k (first-order)",
+    "content": "Two corollaries instantiate the master recursion (★) at the low rungs. `geom_sum_via_recursion` ($f \\equiv 1$): the forward differences vanish, so (★) collapses to $(r-1)\\sum r^k = r^n - 1$ — the geometric series, the bottom of the ladder, obtained by `simpa` from the engine. `sum_range_id_mul_geom_recursion` ($f(k) = k$): $\\Delta f \\equiv 1$ is constant, so the first-order arithmetico-geometric sum reduces to a pure geometric sum $(r-1)\\sum k r^k = n r^n - \\sum r^{k+1}$; the proof rewrites by the engine, kills the $f(0)=0$ boundary term, and normalizes the difference termwise with `push_cast`/`ring`. Each rung is a one-line specialization of the single master lemma.",
+    "mathContext": "$f \\equiv 1: \\Delta f = 0 \\Rightarrow (r-1)\\sum r^k = r^n-1$; $f(k)=k: \\Delta f = 1 \\Rightarrow (r-1)\\sum k r^k = n r^n - \\sum r^{k+1}$.",
     "significance": "key",
-    "relatedConcepts": ["geometric series", "first-order arithmetico-geometric sum", "second-order sum", "degree lowering"],
-    "prerequisites": ["forward differences of polynomials", "specialization of identities"]
+    "relatedConcepts": ["geometric series", "first-order arithmetico-geometric sum", "specialization of an identity", "constant forward differences"],
+    "prerequisites": ["forward differences", "geometric partial sums"]
+  },
+  {
+    "id": "sbp010101-ann-second-rung",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 152 },
+    "type": "insight",
+    "title": "Top Rung: f=k² Recovers the Parent's Degree-Lowering",
+    "content": "`sum_range_sq_mul_geom_recursion` is the payoff: instantiating (★) at $f(k) = k^2$, the forward differences $\\Delta f(k) = (k+1)^2 - k^2 = 2k+1$ are LINEAR in $k$, so the master recursion reduces the second-order sum to a first-order weighted sum $(r-1)\\sum k^2 r^k = n^2 r^n - \\sum (2k+1) r^{k+1}$. This is exactly the degree-lowering step that the parent entry SummationByPartsOQ01OQ01 carried out BY HAND via Abel summation — here it falls out as a one-line specialization of the general engine (`geom_weighted_recursion`, then `simp`/`ring_nf`/`push_cast`/`ring` to normalize). The whole point of this OQ-01³ entry is that the manual ladder-climbing is subsumed by a single reusable recursion, and this top rung demonstrates it at the quadratic weight.",
+    "mathContext": "$f(k)=k^2:\\ \\Delta f(k) = 2k+1 \\Rightarrow (r-1)\\sum k^2 r^k = n^2 r^n - \\sum (2k+1) r^{k+1}$ — the parent's manual step, now a corollary.",
+    "significance": "critical",
+    "relatedConcepts": ["second-order sum", "degree lowering", "linear forward differences", "generalizing a by-hand proof"],
+    "prerequisites": ["forward differences of k²", "the master recursion (★)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01-oq-01` (quality 91, pass 0).

## Assessment
meta.json (15 KB) under caps and complete. Gap: **annotations 4, need 5** (6 theorems). The `ladder` annotation (112–152) bundled three 'rung' theorems (orders 0, 1, 2).

## Change
Split the ladder by rung (no accretion elsewhere):
- **sbp010101-ann-ladder** (112–132): the bottom two rungs — geometric (f≡1, Δf=0) and first-order (f=k, Δf=1).
- **sbp010101-ann-second-rung** (134–152): the top rung f=k² (Δf=2k+1), which recovers the parent entry's by-hand Abel degree-lowering as a one-line corollary of the general recursion engine — the whole point of this OQ-01³ entry.

Result: 5 annotations, coverage aligned to theorem groups.

## Verification
- JSON validated (`json.load`), 5 annotations.
- Content checked against `Proofs/SummationByPartsOQ01OQ01OQ01.lean` (`geom_sum_via_recursion` 114, `sum_range_id_mul_geom_recursion` 123, `sum_range_sq_mul_geom_recursion` 139, and the Δf=2k+1 reduction all match).