### PR TITLE
Enrich The Markov Vieta Ascent Grows at Least Geometrically (markov-equation-oq-06-oq-01)

### DIFF
--- a/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
@@ -24,6 +24,29 @@
     ]
   },
   {
+    "id": "markov-oq0601-ann-setup",
+    "proofId": "markov-equation-oq-06-oq-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Reusing the Parent's Ascent Infrastructure",
+    "content": "The file imports the verified parent leaf Proofs.MarkovEquationOQ06 (and, transitively, Proofs.MarkovEquation) and opens both namespaces. Everything about the ascent itself is inherited: `seq n` is the parent's iterated Vieta-jump of (1,1,1), `seq_spec n` certifies that `seq n` is a sorted Markov triple 1 ≤ a ≤ b ≤ c, and `seq_zero` records (seq 0) = (1,1,1). This entry adds no new definitions (definitionCount = 0) — it consumes these three facts as black boxes and contributes only the quantitative growth estimate, so the whole geometric bound is a thin, axiom-free layer over already-checked infrastructure rather than a fresh construction of the Markov tree.",
+    "mathContext": "$\\text{seq},\\ \\text{seq\\_spec},\\ \\text{seq\\_zero}\\ \\text{imported};\\qquad (\\mathrm{seq}\\,0) = (1,1,1),\\ \\ 1 \\le a \\le b \\le c.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "proof reuse",
+      "sorted Markov triple invariant",
+      "Vieta ascent map",
+      "modular formalization"
+    ],
+    "prerequisites": [
+      "Lean namespaces and imports",
+      "the parent entry markov-equation-oq-06"
+    ]
+  },
+  {
     "id": "markov-oq0601-ann-doubling",
     "proofId": "markov-equation-oq-06-oq-01",
     "range": {

--- a/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/meta.json
@@ -56,9 +56,16 @@
   },
   "sections": [
     {
+      "id": "sec-header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Docstring recalling the parent's Vieta ascent sequence rooted at (1,1,1) and its ascent map ascent (a,b,c) = (b, c, 3bc − a), and stating the quantitative refinement proved here (each step at least doubles the top coordinate, giving 2ⁿ ≤ (seq n).top). Then imports Mathlib and the parent leaf Proofs.MarkovEquationOQ06, opens both namespaces, so seq, seq_spec and seq_zero are reused directly — this file adds only the growth estimate on top of the parent's infrastructure."
+    },
+    {
       "id": "sec-doubling",
       "title": "The Doubling Step",
-      "startLine": 55,
+      "startLine": 47,
       "endLine": 72,
       "summary": "two_mul_top_le_succ proves that one ascent step at least doubles the top coordinate: 2·(seq n).2.2 ≤ (seq (n+1)).2.2. Using the parent's seq_spec to get a sorted Markov triple 1 ≤ a ≤ b ≤ c, the successor's top coordinate 3bc − a (obtained by rfl) satisfies 3bc − a − 2c ≥ 3c(b − 1) ≥ 0, discharged by nlinarith with the nonnegative product c·(b − 1)."
     },


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-06-oq-01`.

**Coverage gaps closed:**
- **Sections**: added `sec-header` (lines 1–46) covering the docstring, imports, and setup. Previously the `sections` array started at line 55, leaving the entire header/setup block undocumented. Also extended `sec-doubling` to start at line 47 so it includes the theorem's docstring.
- **Annotations**: added a 5th annotation (`markov-oq0601-ann-setup`, lines 40–46) documenting the reuse of the parent's `seq` / `seq_spec` / `seq_zero` infrastructure — this filled the previously uncovered import/namespace block and reaches the 5-annotation quality target. All annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

No content removed; meta.json stays at 11.7 KB, well under the 60 KB cap. JSON validated; axiom/status fields unchanged (0-axiom, verified — accurate for this file).