### PR TITLE
Enrich markov-equation-oq-06-oq-01: fix section line ranges & header coverage

### DIFF
--- a/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/markov-equation-oq-06-oq-01/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "markov-equation-oq-06-oq-01",
     "range": {
       "startLine": 1,
-      "endLine": 39
+      "endLine": 46
     },
     "type": "concept",
     "title": "From Strict Growth to Geometric Growth",


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-06-oq-01` (quality 87, passes 0).

## What changed
The entry's prose (historicalContext, 4 keyInsights, conclusion with 3 open questions, 3 references) already met the enrichment targets, so I did not inflate it. The genuine defect was in `sections`, whose line ranges did **not** match the Lean source and which left the entire header uncovered:

- `sec-doubling` claimed lines **55–72**; `two_mul_top_le_succ` actually spans **47–66**.
- `sec-geometric` claimed lines **74–93**; `seq_top_ge_two_pow` actually spans **68–84**.
- Lines **1–54** (docstring + imports + `namespace`/`open`) had **no section**.

Fixes:
- Added `sec-header` (1–46) describing the docstring and the reuse of the parent `seq`/`seq_spec`/`seq_zero`.
- Corrected `sec-doubling` to 47–66.
- Split the combined section into `sec-geometric` (68–84) and `sec-unbounded` (86–93), one per theorem.
- Sections now tile the full 93-line file with accurate ranges.
- Extended the header annotation range 1–39 → 1–46 so the imports/namespace setup is covered.

## Verification
- meta.json / annotations.json parse as valid JSON.
- `check-meta-size.ts`: within caps (12 KB ≤ 60 KB).
- Line ranges cross-checked against `Proofs/MarkovEquationOQ06OQ01.lean` (93 lines, 3 theorems, 0 axioms/sorries): `two_mul_top_le_succ` 54–66, `seq_top_ge_two_pow` 75–84, `seq_top_unbounded` 89–91, docstring 1–39, imports 40–41.