### PR TITLE
Enrich polynomial-derivative-leibniz-oq-01: add missing header section

### DIFF
--- a/src/data/proofs/polynomial-derivative-leibniz-oq-01/meta.json
+++ b/src/data/proofs/polynomial-derivative-leibniz-oq-01/meta.json
@@ -102,6 +102,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview, Imports and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating the open question and the four results supplied (the Finset Leibniz rule, the split-polynomial derivative, its value at a root, and the simple-roots nonvanishing), contrasting them with Mathlib's existing two-factor (derivative_mul), iterated (iterate_derivative_mul) and Multiset (derivative_prod) forms. Then imports Mathlib, opens Polynomial and Finset, and fixes a commutative ring R with a DecidableEq index type ι over which all the finite products range.",
+      "mathContext": "Setup: the formal derivative Polynomial.derivative over an arbitrary CommRing R and finite products ∏_{i∈s} over a Finset s ⊆ ι."
+    },
+    {
       "id": "finset-rule",
       "title": "The Finset Leibniz Product Rule",
       "startLine": 54,


### PR DESCRIPTION
Enrichment pass for `polynomial-derivative-leibniz-oq-01` (quality 91, passes 0).

## What changed
The entry's prose (5 keyInsights, conclusion with 3 open questions, 2 references, 4 full-field annotations covering the whole file) already met the enrichment targets. The one defect: `sections` began at line 54, so **lines 1–53 had no section** — the module docstring, imports, `namespace`/`open`, and the `CommRing R`/`DecidableEq ι` variable setup were all uncovered.

Added `sec-header` (1–52) describing the docstring and setup. Sections now tile the full 124-line file (1–52, 54–80, 82–110, 112–124), matching the existing annotation coverage exactly.

## Verification
- meta.json / annotations.json parse as valid JSON.
- `check-meta-size.ts`: within caps.
- Section ranges verified against `Proofs/PolynomialDerivativeLeibnizOQ01.lean` (124 lines, 5 theorems, 0 axioms/sorries): docstring 1–38, setup 40–46, `derivative_finset_prod` 54–67, `derivative_prod_pair` 71–77, `derivative_prod_X_sub_C` 82–88, `eval_derivative_prod_X_sub_C` 95–105, `eval_derivative_prod_X_sub_C_ne_zero` 112–122.