### PR TITLE
Audit: abel-ruffini-oq-04-oq-02-oq-02-oq-01 badge verified→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-01/meta.json
@@ -18,11 +18,20 @@
       "research",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      "alternatingGroup.normal_kleinFour (V₄ ◁ A₄ normal)",
+      "alternatingGroup.kleinFour_eq_commutator (V₄ = [A₄,A₄])",
+      "alternatingGroup.card_of_card_eq_four (|A₄|=12), alternatingGroup.kleinFour_card_of_card_eq_four (|V₄|=4)",
+      "alternatingGroup.kleinFour_isKleinFour (V₄ is a Klein four-group)",
+      "mulEquivOfPrimeCardEq (prime-order quotient ≅ Multiplicative (ZMod 3))",
+      "IsKleinFour.nonempty_mulEquiv (V₄ ≅ Multiplicative (ZMod 2 × ZMod 2))",
+      "Subgroup.card_eq_card_quotient_mul_card_subgroup (Lagrange, for |A₄/V₄|=3)"
+    ],
     "assumptions": "None. 0 axiom declarations, 0 sorries, no native_decide. #print axioms on composition_series_A4, quotient_iso_zmod3, and v4_iso_zmod2_sq returns only propext, Classical.choice, Quot.sound (the three foundational axioms). Verified with lake env lean against Mathlib 4.26.0.",
     "lineCount": 136,
     "theoremCount": 11,


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: `abel-ruffini-oq-04-oq-02-oq-02-oq-01` — *The Composition Series of A₄ Made Explicit*
**Severity**: MEDIUM (badge accuracy)
**Tier**: B (formalized using Mathlib's dedicated API)

## Finding

The Lean file is clean — 11 theorems, 0 sorry, 0 axiom, 0 `native_decide`/`decide`/True stubs (the `native_decide` grep hit is a docstring describing the *parent's* method). `status: verified` is technically correct.

However, **every theorem is a direct application of Mathlib's purpose-built `Alternating.KleinFour` API**:

| Theorem | Mathlib call |
|---------|--------------|
| `v4_normal` | `alternatingGroup.normal_kleinFour` |
| `v4_eq_commutator` | `alternatingGroup.kleinFour_eq_commutator` |
| `card_a4` / `card_v4` | `alternatingGroup.card_of_card_eq_four` / `kleinFour_card_of_card_eq_four` |
| `v4_isKleinFour` | `alternatingGroup.kleinFour_isKleinFour` |
| `quotient_iso_zmod3` | generic `mulEquivOfPrimeCardEq` |
| `v4_iso_zmod2_sq` | generic `IsKleinFour.nonempty_mulEquiv` |

The only independent step is `card_quotient` (a 3-line Lagrange application). Mathlib has a module `Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour` designed to supply exactly these facts. This is Tier B specialization/packaging, not independent theorem-proving.

Per the auditor skill's failure mode #5 ("0 sorries with hidden imports → badge must be `mathlib`, not `verified`"), the badge should be `mathlib`.

## Mitigation already present

The `description` is exemplary: it leads with "Assembled axiom-free from Mathlib's alternatingGroup.kleinFour infrastructure" and `proofStrategy` says "Pure assembly from Mathlib's dedicated alternating-group / Klein-four API." So there is **no narrative failure** — only the standalone badge chip overstates independence.

## Fix

- `badge`: `verified` → `mathlib` (matches the established `verified`/`mathlib` Tier B pattern used elsewhere, e.g. algebraic-numbers-countable)
- Added `mathlibDependencies` listing the relied-upon lemmas
- `status` unchanged (`verified` — 0 sorry / 0 axiom hold)

---
Discovered during gallery integrity audit.