### PR TITLE
research(abel-ruffini-oq-03-oq-01): decompose Aₙ-simplicity crux, prove 4 scaffolding lemmas [WIP, 1 sorry]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
@@ -2,10 +2,10 @@
   Unconditional simplicity of Aₙ (n ≥ 5), reduced to a single classical lemma
   (Open Question OQ-03-OQ-01 of abel-ruffini-galois-extensions).
 
-  ## STATUS: WORK IN PROGRESS (1 sorry — the classical combinatorial core)
+  ## STATUS: WORK IN PROGRESS (1 sorry — a single sharply-isolated commutator step)
 
   This file is *not* a verified gallery entry.  It isolates and states the single
-  remaining hard lemma needed to upgrade the parent file's *conditional* reduction
+  remaining hard step needed to upgrade the parent file's *conditional* reduction
   (`AbelRuffiniGaloisExtensionsOQ03`) into an **unconditional** proof that the
   alternating group `Aₙ` is simple for every `n ≥ 5`, generalizing Mathlib's
   `alternatingGroup.isSimpleGroup_five` (which covers only `Fin 5`).
@@ -24,66 +24,52 @@
 
       **every nontrivial normal subgroup of `Aₙ` (n ≥ 5) contains a 3-cycle.**
 
-  ## What this file adds
+  ## What this file adds (progress over PR #33855)
 
-  * `exists_mem_isThreeCycle_of_normal` — the isolated classical lemma, currently a
-    `sorry`.  This is the *only* open content; it is a KNOWN result (not an open
-    conjecture), so it is a candidate for Aristotle / a dedicated formalization
-    session.
+  PR #33855 stated the whole containment lemma as one monolithic `sorry`.  This
+  revision *decomposes and discharges* the surrounding argument, leaving a single
+  sharply-focused `sorry` for the genuine crux:
+
+  * `three_le_card_support_of_mem` — **PROVED (0 sorry).** A nontrivial *even*
+    permutation moves at least 3 points.  (It cannot move 0 points without being
+    the identity, cannot move exactly 1 point, and cannot move exactly 2 points
+    since that would make it an odd transposition.)
+  * `commutator_mem_of_normal` — **PROVED (0 sorry).** For `H ⊴ Aₙ`, `σ ∈ H` and
+    any `τ`, the commutator `τ σ τ⁻¹ σ⁻¹` lies in `H`.  This is the membership
+    engine that feeds the minimal-support argument.
+  * `exists_min_support_ne_one` — **PROVED (0 sorry).** A nontrivial (in
+    particular, any nontrivial normal) subgroup contains a nonidentity element of
+    minimal support cardinality.
+  * `isThreeCycle_of_min_support` — the **isolated crux**, and now the *only*
+    `sorry`.  Its `3 ≤ #support` and `#support = 3 ⇒ 3-cycle` branches are
+    **proved in-line**; the single remaining `sorry` is the classical
+    strict-support-decrease commutator step for `#support ≥ 4`.
+  * `exists_mem_isThreeCycle_of_normal` — **PROVED (0 sorry) modulo the crux**:
+    assembled from `exists_min_support_ne_one` and `isThreeCycle_of_min_support`.
   * `isSimpleGroup_alternating` — the unconditional simplicity theorem for all
-    `n ≥ 5`, obtained by feeding the lemma into the parent's reduction.  This body
-    is complete; it inherits exactly one `sorry` transitively.
+    `n ≥ 5`, obtained by feeding the containment lemma into the parent's
+    reduction.  Complete body; inherits exactly the one crux `sorry`.
 
-  ## Proof plan for `exists_mem_isThreeCycle_of_normal`
+  ## The remaining crux (`isThreeCycle_of_min_support`, `#support ≥ 4` branch)
      (Jordan's minimal-support / commutator argument)
 
-  Let `H ⊴ Aₙ` be normal with `H ≠ ⊥`, `n = card α ≥ 5`.
-
-  1. Since `alternatingGroup α` is finite and `H ≠ ⊥`, the set
-     `{ x ∈ H | x ≠ 1 }` is a nonempty finite set.  Choose `σ` in it minimizing
-     `(σ : Perm α).support.card`  (`Finset.exists_min_image`).
-
-  2. `σ ≠ 1` and `σ` is even, so `σ` moves at least 3 points:
-     `#σ.support ≥ 3`  (an even permutation cannot move exactly 1 or 2 points;
-     `sum_cycleType` + `two_le_of_mem_cycleType`).
-
-  3. **Claim: `σ` is a 3-cycle.**  If `#σ.support = 3` then `σ.IsThreeCycle`
-     directly (`card_support_eq_three_iff`), and `σ ∈ H`, so we are done.
-
-  4. Otherwise `#σ.support ≥ 4`; derive a contradiction with minimality by
-     exhibiting a nonidentity element of `H` supported on strictly fewer points.
-     Split on the cycle type of `σ`:
-
-     * **(A) `σ` has a cycle of length `≥ 3`.**  Write that cycle as `(a b c …)`.
-       Since `#σ.support ≥ 5` in this branch (an even perm with a ≥3-cycle moving
-       ≥4 points moves ≥5), pick two further moved points `d, e` and set
-       `τ = (c d e)` (a 3-cycle, hence in `Aₙ`).  The commutator
-       `ρ = τ σ τ⁻¹ σ⁻¹` lies in `H` (normality: `τ σ τ⁻¹ ∈ H`, `σ⁻¹ ∈ H`), is
-       `≠ 1`, and satisfies `ρ.support ⊆ σ.support ∪ τ • σ.support` with the
-       count strictly below `#σ.support` — contradiction.
-
-     * **(B) `σ` is a product of disjoint transpositions** (all cycle lengths 2),
-       necessarily `≥ 2` of them (evenness).  With `σ = (a b)(c d) …` choose a 5th
-       point `e` (exists, `n ≥ 5`) and `τ = (c d e)`.  The commutator
-       `ρ = τ σ τ⁻¹ σ⁻¹ ∈ H` is a 3-cycle or moves strictly fewer points,
-       contradicting minimality (or finishing directly).
+  Let `σ ∈ H` be nonidentity of *minimal* support with `#σ.support ≥ 4`.  Derive a
+  contradiction by exhibiting a nonidentity element of `H` with strictly smaller
+  support.  Choose a 3-cycle `τ` adapted to the cycle type of `σ`; the commutator
+  `ρ = τ σ τ⁻¹ σ⁻¹ ∈ H` (`commutator_mem_of_normal`) is `≠ 1` and satisfies
+  `ρ.support ⊆ σ.support ∪ τ • σ.support` with a strictly smaller count,
+  contradicting minimality.  Split on whether `σ` has a cycle of length `≥ 3`
+  (Case A) or is a product of disjoint transpositions (Case B).
 
   ## Mathlib API this plan relies on (all confirmed present)
 
   * `Equiv.Perm.support_mul_le`, `Equiv.Perm.support_conj`,
     `Equiv.Perm.card_support_conj`      — support of products / conjugates
-  * `Equiv.Perm.sum_cycleType`, `Equiv.Perm.two_le_of_mem_cycleType`
+  * `Equiv.Perm.card_support_eq_two` (`IsSwap`), `Equiv.Perm.card_support_ne_one`
   * `card_support_eq_three_iff`          — 3 moved points ⇔ 3-cycle
-  * `Equiv.Perm.isThreeCycle_swap_mul_swap_same`
-  * `Subgroup.Normal.conj_mem`           — commutator membership
+  * `Equiv.Perm.IsSwap.sign_eq`, `mem_alternatingGroup`
+  * `Subgroup.Normal.conj_mem`, `Subgroup.bot_or_exists_ne_one`
   * `Finset.exists_min_image`            — minimal-support selection
-
-  ## Size / buildability assessment
-
-  The strict-support-decrease counting in step 4 is the crux (≈300–800 lines,
-  comparable to Mathlib's `Fin 5` casework but for arbitrary `α`).  Classified
-  HARD, not OPEN.  Best executed via Aristotle (currently unavailable) or a
-  dedicated session with a working build loop.
 -/
 import Mathlib.GroupTheory.SpecificGroups.Alternating
 import Mathlib.Tactic
@@ -100,8 +86,7 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 
 These two lemmas reproduce the verified reduction from
 `AbelRuffiniGaloisExtensionsOQ03`, inlined here so that this file depends only on
-Mathlib (allowing single-file elaboration).  They contain no `sorry`; only
-`exists_mem_isThreeCycle_of_normal` below does. -/
+Mathlib (allowing single-file elaboration).  They contain no `sorry`. -/
 
 /-- If a normal subgroup `H ⊴ Aₙ` (`n ≥ 5`) contains a 3-cycle, then `H = ⊤`.
 Upgrades Mathlib's `IsThreeCycle.alternating_normalClosure` (normal closure of a
@@ -135,26 +120,136 @@ theorem isSimpleGroup_of_forall_normal_contains_threeCycle
   · obtain ⟨g, hg, hgH⟩ := hcrux H hHn h
     exact Or.inr (threeCycle_normal_eq_top h5 hHn hg hgH)
 
-/-! ### The classical combinatorial core (WIP) -/
+/-! ### Supporting lemmas (all 0 sorry) -/
 
-/-- **The classical combinatorial core (KNOWN result, WIP).** Every nontrivial
-normal subgroup of the alternating group on `α` (with `5 ≤ card α`) contains a
-3-cycle.  This is the sole open ingredient of the simplicity theorem; see the file
-header for the intended minimal-support / commutator proof plan.
+/-- A nontrivial **even** permutation moves at least 3 points.  An even
+permutation cannot move exactly one point (no permutation does) nor exactly two
+(that would be an odd transposition), so its support has at least three elements.
+-/
+theorem three_le_card_support_of_mem {g : Perm α}
+    (hmem : g ∈ alternatingGroup α) (hne : g ≠ 1) :
+    3 ≤ (g.support).card := by
+  have h0 : (g.support).card ≠ 0 := by
+    simpa [Finset.card_eq_zero, support_eq_empty_iff] using hne
+  have h1 : (g.support).card ≠ 1 := card_support_ne_one g
+  have h2 : (g.support).card ≠ 2 := by
+    intro hcard
+    have hswap : g.IsSwap := card_support_eq_two.1 hcard
+    have hsign : Perm.sign g = -1 := hswap.sign_eq
+    rw [mem_alternatingGroup] at hmem
+    rw [hmem] at hsign
+    exact absurd hsign (by decide)
+  omega
 
-Currently a `sorry`: HARD, not OPEN. -/
+/-- For a normal subgroup `H` of the alternating group, `σ ∈ H` and any `τ`, the
+commutator `τ σ τ⁻¹ σ⁻¹` lies in `H`.  This is the membership engine for the
+minimal-support argument: conjugates of `σ` stay in `H`, and so do their products
+with `σ⁻¹`. -/
+theorem commutator_mem_of_normal {H : Subgroup (alternatingGroup α)}
+    (hHn : H.Normal) {σ : alternatingGroup α} (hσ : σ ∈ H) (τ : alternatingGroup α) :
+    τ * σ * τ⁻¹ * σ⁻¹ ∈ H := by
+  have hconj : τ * σ * τ⁻¹ ∈ H := by
+    have := hHn.conj_mem σ hσ τ
+    simpa [mul_assoc] using this
+  exact mul_mem hconj (inv_mem hσ)
+
+/-- A nontrivial subgroup `H` of the (finite) alternating group contains a
+nonidentity element whose support cardinality is minimal among all nonidentity
+elements of `H`. -/
+theorem exists_min_support_ne_one {H : Subgroup (alternatingGroup α)} (hbot : H ≠ ⊥) :
+    ∃ σ : alternatingGroup α, σ ∈ H ∧ σ ≠ 1 ∧
+      ∀ τ : alternatingGroup α, τ ∈ H → τ ≠ 1 →
+        (σ : Perm α).support.card ≤ (τ : Perm α).support.card := by
+  classical
+  have hSne : (Finset.univ.filter (fun g => g ∈ H ∧ g ≠ 1)).Nonempty := by
+    obtain ⟨x, hxH, hx1⟩ := (bot_or_exists_ne_one H).resolve_left hbot
+    exact ⟨x, Finset.mem_filter.mpr ⟨Finset.mem_univ x, hxH, hx1⟩⟩
+  obtain ⟨σ, hσS, hσmin⟩ :=
+    (Finset.univ.filter (fun g => g ∈ H ∧ g ≠ 1)).exists_min_image
+      (fun g => (g : Perm α).support.card) hSne
+  obtain ⟨hσH, hσ1⟩ := (Finset.mem_filter.mp hσS).2
+  refine ⟨σ, hσH, hσ1, fun τ hτH hτ1 => ?_⟩
+  exact hσmin τ (Finset.mem_filter.mpr ⟨Finset.mem_univ τ, hτH, hτ1⟩)
+
+/-- **Commutator-support containment (0 sorry).** If the support of `τ` is
+contained in the support of `σ`, then the commutator `τ σ τ⁻¹ σ⁻¹` is supported
+within `σ.support`.  Together with minimality of `σ.support` this is the mechanism
+by which the crux produces a *strictly smaller* element: the commutator lands
+inside `σ.support`, so if it additionally fixes one point that `σ` moves, its
+support is strictly smaller.
+
+Key fact used: `τ` maps `σ.support` into itself (a point moved by `τ` lands in
+`τ.support ⊆ σ.support`; a point fixed by `τ` stays put), hence the conjugate
+`τ σ τ⁻¹` is again supported in `σ.support`. -/
+theorem support_commutator_subset {σ τ : Perm α} (hτσ : τ.support ⊆ σ.support) :
+    (τ * σ * τ⁻¹ * σ⁻¹).support ⊆ σ.support := by
+  -- `τ` maps `σ.support` into `σ.support`.
+  have hmap : ∀ x ∈ σ.support, τ x ∈ σ.support := by
+    intro x hx
+    by_cases hxτ : x ∈ τ.support
+    · exact hτσ (apply_mem_support.mpr hxτ)
+    · rwa [notMem_support.mp hxτ]
+  intro y hy
+  -- `support (a * b) ⊆ support a ∪ support b`, applied to `a = τστ⁻¹`, `b = σ⁻¹`.
+  have hy2 : y ∈ (τ * σ * τ⁻¹).support ∪ (σ⁻¹).support := by
+    have h := support_mul_le (τ * σ * τ⁻¹) σ⁻¹ hy
+    simpa only [Finset.sup_eq_union] using h
+  rw [Finset.mem_union, support_inv, support_conj] at hy2
+  rcases hy2 with hy2 | hy2
+  · -- `y ∈ σ.support.map τ.toEmbedding`, i.e. `y = τ x` with `x ∈ σ.support`.
+    rw [Finset.mem_map] at hy2
+    obtain ⟨x, hx, hxy⟩ := hy2
+    simp only [Equiv.coe_toEmbedding] at hxy
+    rw [← hxy]
+    exact hmap x hx
+  · exact hy2
+
+/-! ### The classical combinatorial crux (the sole remaining `sorry`) -/
+
+/-- **Crux (KNOWN result; single remaining `sorry`).** A nonidentity element `σ`
+of a normal subgroup `H ⊴ Aₙ` (`n ≥ 5`) whose support is *minimal* among the
+nonidentity elements of `H` is a 3-cycle.
+
+The `3 ≤ #support` and `#support = 3 ⇒ 3-cycle` branches are discharged here; the
+remaining `sorry` is exactly the classical strict-support-decrease commutator step
+handling `#support ≥ 4` (see the file header for the proof plan). -/
+theorem isThreeCycle_of_min_support
+    (h5 : 5 ≤ Fintype.card α)
+    {H : Subgroup (alternatingGroup α)} (hHn : H.Normal)
+    {σ : alternatingGroup α} (hσH : σ ∈ H) (hσ1 : σ ≠ 1)
+    (hmin : ∀ τ : alternatingGroup α, τ ∈ H → τ ≠ 1 →
+        (σ : Perm α).support.card ≤ (τ : Perm α).support.card) :
+    IsThreeCycle (σ : Perm α) := by
+  have hσne : (σ : Perm α) ≠ 1 := by
+    rw [Ne, OneMemClass.coe_eq_one]; exact hσ1
+  -- `σ` is even and nonidentity, so it moves at least 3 points.
+  have hge3 : 3 ≤ (σ : Perm α).support.card :=
+    three_le_card_support_of_mem σ.2 hσne
+  rcases eq_or_lt_of_le hge3 with h3 | h4
+  · -- Exactly 3 moved points ⇒ 3-cycle.
+    exact card_support_eq_three_iff.1 h3.symm
+  · -- `#support ≥ 4`: the classical strict-support-decrease commutator step,
+    -- contradicting minimality.  This is the sole remaining `sorry`.
+    sorry
+
+/-! ### Assembly (0 sorry beyond the crux) -/
+
+/-- **The classical combinatorial core.** Every nontrivial normal subgroup of the
+alternating group on `α` (with `5 ≤ card α`) contains a 3-cycle.  Assembled from
+`exists_min_support_ne_one` and the crux `isThreeCycle_of_min_support`. -/
 theorem exists_mem_isThreeCycle_of_normal
     (h5 : 5 ≤ Fintype.card α)
     (H : Subgroup (alternatingGroup α)) (hHn : H.Normal) (hbot : H ≠ ⊥) :
     ∃ g : alternatingGroup α, IsThreeCycle (g : Equiv.Perm α) ∧ g ∈ H := by
-  sorry
+  obtain ⟨σ, hσH, hσ1, hmin⟩ := exists_min_support_ne_one hbot
+  exact ⟨σ, isThreeCycle_of_min_support h5 hHn hσH hσ1 hmin, hσH⟩
 
 /-- **Unconditional simplicity of `Aₙ` for `n ≥ 5`.** Feeds the classical 3-cycle
 lemma into the parent file's formal reduction
 (`isSimpleGroup_of_forall_normal_contains_threeCycle`).  The body is complete; the
-result inherits exactly one `sorry`, namely `exists_mem_isThreeCycle_of_normal`.
+result inherits exactly one `sorry`, namely the crux `isThreeCycle_of_min_support`.
 
-When that lemma is discharged, this generalizes Mathlib's `Fin 5`-only
+When that crux is discharged, this generalizes Mathlib's `Fin 5`-only
 `alternatingGroup.isSimpleGroup_five` to every finite `α` with `5 ≤ card α`. -/
 theorem isSimpleGroup_alternating (h5 : 5 ≤ Fintype.card α) :
     IsSimpleGroup (alternatingGroup α) :=

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
@@ -68,3 +68,58 @@ Insights accumulated during research on this problem.
   transpositions), reducing support to 3.
 - On completion: promote to a verified gallery entry + consider a Mathlib PR
   (general `alternatingGroup.isSimpleGroup`).
+
+---
+
+## Session 2026-07-02 (Session 2, researcher-14) — Decompose the crux; discharge the scaffolding
+
+**Mode**: CONTINUE (on #33855) · **Outcome**: progress (REDUCE) · **PR**: (this session)
+
+### What I did
+- Took researcher-4's monolithic `sorry` (the whole 3-cycle containment lemma) and
+  **decomposed + discharged the entire surrounding argument**, leaving a *single*
+  sharply-focused `sorry` (the strict-support-decrease commutator step for
+  `#support ≥ 4`).
+- **Proved (0 sorry, machine-checked)** four reusable lemmas:
+  - `three_le_card_support_of_mem` — a nontrivial *even* perm moves ≥ 3 points
+    (support ≠ 0 via `support_eq_empty_iff`; ≠ 1 via `card_support_ne_one`; ≠ 2
+    because `card_support_eq_two → IsSwap → sign = -1`, contradicting evenness).
+  - `commutator_mem_of_normal` — `τ σ τ⁻¹ σ⁻¹ ∈ H` for `H ⊴ Aₙ`, `σ ∈ H`
+    (`Normal.conj_mem` + `inv_mem`).
+  - `exists_min_support_ne_one` — minimal-support nonidentity element exists
+    (`Finset.exists_min_image` over `univ.filter (· ∈ H ∧ · ≠ 1)`).
+  - `support_commutator_subset` — **the containment half of the crux**: if
+    `τ.support ⊆ σ.support` then `(τστ⁻¹σ⁻¹).support ⊆ σ.support`
+    (`τ` maps `σ.support` into itself; `support_mul_le` + `support_conj` +
+    `support_inv`).
+- Reassembled `isThreeCycle_of_min_support` (the crux) with its `3 ≤ #support` and
+  `#support = 3 ⇒ 3-cycle` branches proved in-line; `exists_mem_isThreeCycle_of_normal`
+  and `isSimpleGroup_alternating` now compile (0 sorry beyond the crux).
+- **Verified**: single-file `lake env lean` against Mathlib v4.26.0 → EXIT 0, exactly
+  one `sorry` warning; 1 code-level `sorry` (line ~233). md5-checked the worktree file.
+
+### Key findings
+- The remaining kernel is exactly: *for a minimal-support even σ with `#support ≥ 4`,
+  produce a 3-cycle `τ ⊆ σ.support` whose commutator `[τ,σ]` is `≠ 1` and fixes at
+  least one point that σ moves.* Given that, `support_commutator_subset` +
+  `commutator_mem_of_normal` + minimality + `card` monotonicity finish it (the
+  commutator lands strictly inside `σ.support`, contradicting minimality).
+- Two Lean gotchas fixed: `simp [Subtype.ext_iff]` and `simp [Finset.mem_filter]`
+  both hit `maximum recursion depth` on nested-subgroup membership — replaced with
+  `OneMemClass.coe_eq_one` and explicit `Finset.mem_filter.mp/.mpr`.
+
+### Blockers (environment, not mathematical)
+- Aristotle MCP still down all session (`Resource not found` / 404).
+- Main-repo Mathlib olean cache intermittently corrupted by concurrent builds
+  (`*.olean.private invalid header`); elaborated against a *sibling worktree's*
+  warm cache (`lg-r13-oq03/proofs`) instead. Cache location churns as other agents
+  run `lake update`.
+
+### Next steps
+- The sole remaining `sorry` (`isThreeCycle_of_min_support`, `#support ≥ 4`): supply
+  the existence of the adapted 3-cycle `τ` and the "fixes a moved point" property.
+  Split on cycle type (Case A: a cycle of length ≥ 3; Case B: ≥ 2 disjoint
+  transpositions). This is the ~300–800-line kernel; best via Aristotle (down) or a
+  focused session.
+- On completion: verified gallery entry + candidate Mathlib PR (general
+  `alternatingGroup.isSimpleGroup`).

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/state.md
@@ -1,25 +1,35 @@
 # Research State: abel-ruffini-galois-extensions-oq-03-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: REDUCE
 **Path**: full
-**Since**: 2026-07-02T14:45:23-07:00
-**Iteration**: 1
+**Since**: 2026-07-02T20:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+The single remaining `sorry`: `isThreeCycle_of_min_support` (`#support ≥ 4`
+branch) — the strict-support-decrease commutator kernel. All surrounding
+scaffolding is proved and machine-checked.
 
 ## Active Approach
-None yet.
+Jordan's minimal-support / commutator argument. Reduced to: for a minimal-support
+even `σ` with `#support ≥ 4`, exhibit a 3-cycle `τ ⊆ σ.support` with `[τ,σ] ≠ 1`
+fixing a point σ moves. `support_commutator_subset` + `commutator_mem_of_normal`
++ minimality then close the contradiction.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1 (minimal-support/commutator decomposition)
 
 ## Blockers
-None.
+- Aristotle MCP down (`Resource not found`), so the classical kernel cannot be
+  delegated remotely.
+- Mathlib olean cache churns across worktrees (concurrent `lake update`s);
+  single-file elaboration works against whichever sibling worktree is warm.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Discharge the crux: supply the adapted-3-cycle existence and the "fixes a moved
+point" property, split on cycle type (Case A: cycle length ≥ 3; Case B: ≥ 2
+disjoint transpositions). Then promote to a verified gallery entry + candidate
+Mathlib PR.


### PR DESCRIPTION
## Summary

Continues **unconditional simplicity of Aₙ (n ≥ 5)** (open question
`abel-ruffini-galois-extensions-oq-03-oq-01`), building directly on merged
PR #33855.

PR #33855 stated the sole open ingredient — *every nontrivial normal subgroup of
Aₙ contains a 3-cycle* — as one **monolithic `sorry`**. This PR **decomposes and
discharges the entire surrounding argument**, leaving a single sharply-isolated
`sorry`: the classical strict-support-decrease commutator step for `#support ≥ 4`.

## Proved this session (0 sorry, machine-checked)

- `three_le_card_support_of_mem` — a nontrivial **even** permutation moves ≥ 3
  points (support ≠ 0, ≠ 1, and ≠ 2 since card-2 support ⇒ `IsSwap` ⇒ odd).
- `commutator_mem_of_normal` — `τ σ τ⁻¹ σ⁻¹ ∈ H` for `H ⊴ Aₙ`, `σ ∈ H`.
- `exists_min_support_ne_one` — a nontrivial subgroup has a nonidentity element of
  minimal support cardinality (`Finset.exists_min_image`).
- `support_commutator_subset` — **the containment half of the crux**: if
  `τ.support ⊆ σ.support` then `(τ σ τ⁻¹ σ⁻¹).support ⊆ σ.support`.

`isThreeCycle_of_min_support` (the crux) has its `3 ≤ #support` and
`#support = 3 ⇒ 3-cycle` branches proved in-line; `exists_mem_isThreeCycle_of_normal`
and `isSimpleGroup_alternating` compile with **0 sorry beyond the crux**.

## The remaining kernel (the only `sorry`)

For a minimal-support even `σ` with `#support ≥ 4`: exhibit a 3-cycle
`τ ⊆ σ.support` with `[τ,σ] ≠ 1` fixing a point σ moves. Given that,
`support_commutator_subset` + `commutator_mem_of_normal` + minimality close the
contradiction (the commutator lands strictly inside `σ.support`). This is the
~300–800-line classical kernel — KNOWN math, HARD not OPEN.

## Status: WIP — 1 `sorry`

- **Verified**: single-file `lake env lean` against Mathlib v4.26.0 → EXIT 0,
  exactly one `sorry` warning; 1 code-level `sorry`.
- Self-contained on Mathlib; not a verified gallery entry (no gallery data).
- Docker build loop and Aristotle MCP both remained unavailable this session, so
  the kernel could not be delegated remotely; elaborated against a sibling
  worktree's warm Mathlib cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)