### PR TITLE
Research: shannon-source-coding-wip-01-oq-02 — entropy additivity converse (additivity ⟺ independence) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/ShannonSourceCodingWIP01OQ02.lean
+++ b/proofs/Proofs/ShannonSourceCodingWIP01OQ02.lean
@@ -1,0 +1,305 @@
+import Mathlib
+
+/-
+  # Converse to entropy additivity: additivity holds *only* for product distributions
+
+  The parent file `ShannonSourceCodingWIP01` proves the **forward** direction of
+  the equality case of subadditivity of Shannon entropy: for a *product*
+  distribution `pXY(x, y) = pX(x)·pY(y)`,
+
+      H(pX ⊗ pY) = H(pX) + H(pY).
+
+  This file proves the **converse**. For an *arbitrary* joint distribution
+  `p : α × β → ℝ` (nonnegative, `∑ p = 1`) with marginals
+
+      pX(x) = ∑_y p(x, y),      pY(y) = ∑_x p(x, y),
+
+  additivity of entropy holds *exactly* when `p` is the product of its own
+  marginals:
+
+      H(p) = H(pX) + H(pY)   ⟺   ∀ x y, p(x, y) = pX(x)·pY(y).
+
+  In information-theoretic language, the entropy gap is the **mutual
+  information**
+
+      H(pX) + H(pY) − H(p) = ∑_{x,y} p(x,y) · log( p(x,y) / (pX(x)·pY(y)) )
+                            = D( p ‖ pX ⊗ pY )  ≥ 0,
+
+  a Kullback–Leibler divergence, and `D(p ‖ q) = 0` for probability
+  distributions `p, q` holds iff `p = q`. So the entropy is additive precisely
+  when `X` and `Y` are independent — the exact boundary of subadditivity.
+
+  ## Strategy
+  The engine is a self-contained **Gibbs equality lemma** (`gibbs_eq`): for
+  finite probability distributions `p, q` with `p ≪ q` (support of `p` inside
+  support of `q`), `∑ p·(log p − log q) ≤ 0` forces `p = q`. The proof uses the
+  tangent-line bound `log t ≤ t − 1` (Mathlib `Real.log_le_sub_one_of_pos`) with
+  its strict form `log t < t − 1` for `t ≠ 1` (from `Real.add_one_lt_exp`): the
+  per-term gap `e i = (q i − p i) − p i·(log q i − log p i) ≥ 0` sums to the
+  KL divergence, and `∑ eᵢ = 0` with each `eᵢ ≥ 0` forces every `eᵢ = 0`, hence
+  `pᵢ = qᵢ`.
+
+  Instantiating `q(x,y) = pX(x)·pY(y)` and identifying the KL divergence with the
+  entropy gap (`entropy_diff_eq`) yields the converse. Absolute continuity is
+  automatic here: `p(x,y) > 0 ⟹ pX(x), pY(y) > 0`.
+
+  ## Results
+  * `gibbs_eq`               : Gibbs / KL equality case for finite distributions.
+  * `entropy_diff_eq`        : `H(pX) + H(pY) − H(p)` equals the mutual-information sum.
+  * `entropy_prod`           : forward direction (product ⟹ additive; parent's result, reproved).
+  * `entropy_additive_converse` : **additivity ⟹ product distribution**.
+  * `entropy_additive_iff`   : the full characterization `H(p)=H(pX)+H(pY) ↔ product`.
+
+  `0` axioms.
+-/
+
+namespace ShannonSourceCodingWIP01OQ02
+
+open Real Finset
+
+variable {α β : Type*} [Fintype α] [Fintype β]
+
+/-- Shannon entropy in `negMulLog` form (matching the parent file):
+`H(p) = ∑ₓ negMulLog (p x)`. -/
+noncomputable def entropy {γ : Type*} [Fintype γ] (p : γ → ℝ) : ℝ :=
+  ∑ x, Real.negMulLog (p x)
+
+/-- Agreement with the standard definition `H(p) = -∑ₓ p x · log (p x)`. -/
+theorem entropy_eq_neg_sum {γ : Type*} [Fintype γ] (p : γ → ℝ) :
+    entropy p = -∑ x, p x * Real.log (p x) := by
+  unfold entropy
+  rw [← Finset.sum_neg_distrib]
+  exact Finset.sum_congr rfl fun x _ => by rw [Real.negMulLog]; ring
+
+/-- The `X`-marginal of a joint distribution `p : α × β → ℝ`. -/
+noncomputable def marginalX (p : α × β → ℝ) (x : α) : ℝ := ∑ y, p (x, y)
+
+/-- The `Y`-marginal of a joint distribution `p : α × β → ℝ`. -/
+noncomputable def marginalY (p : α × β → ℝ) (y : β) : ℝ := ∑ x, p (x, y)
+
+/-- A marginal of a normalised joint distribution is normalised. -/
+theorem sum_marginalX (p : α × β → ℝ) (hsum : ∑ xy, p xy = 1) :
+    ∑ x, marginalX p x = 1 := by
+  unfold marginalX
+  rw [← Fintype.sum_prod_type]
+  exact hsum
+
+theorem sum_marginalY (p : α × β → ℝ) (hsum : ∑ xy, p xy = 1) :
+    ∑ y, marginalY p y = 1 := by
+  unfold marginalY
+  rw [Finset.sum_comm, ← Fintype.sum_prod_type]
+  exact hsum
+
+/-- **Gibbs' inequality, equality case (finite form).** For finite probability
+distributions `p, q` (nonnegative, equal total mass) with `p` absolutely
+continuous with respect to `q` (`0 < p i → 0 < q i`), the Kullback–Leibler
+divergence `∑ᵢ p i·(log (p i) − log (q i))` is `≥ 0`, and if it is `≤ 0` then
+`p = q` pointwise. -/
+theorem gibbs_eq {γ : Type*} [Fintype γ] (p q : γ → ℝ)
+    (hp : ∀ i, 0 ≤ p i) (hq : ∀ i, 0 ≤ q i)
+    (hpq : ∑ i, p i = ∑ i, q i)
+    (hac : ∀ i, 0 < p i → 0 < q i)
+    (hKL : ∑ i, p i * (Real.log (p i) - Real.log (q i)) ≤ 0) :
+    ∀ i, p i = q i := by
+  -- Per-term nonnegative "gap": eᵢ = (qᵢ − pᵢ) − pᵢ(log qᵢ − log pᵢ) ≥ 0.
+  set e : γ → ℝ := fun i => (q i - p i) - p i * (Real.log (q i) - Real.log (p i))
+    with he_def
+  have he_nonneg : ∀ i, 0 ≤ e i := by
+    intro i
+    rw [he_def]; dsimp only
+    rcases eq_or_lt_of_le (hp i) with h0 | hpos
+    · rw [← h0]; simpa using hq i
+    · have hqi : 0 < q i := hac i hpos
+      have hpne : p i ≠ 0 := ne_of_gt hpos
+      have hbound : Real.log (q i / p i) ≤ q i / p i - 1 :=
+        Real.log_le_sub_one_of_pos (div_pos hqi hpos)
+      have hlog : Real.log (q i) - Real.log (p i) = Real.log (q i / p i) := by
+        rw [Real.log_div (ne_of_gt hqi) hpne]
+      have h2 : p i * Real.log (q i / p i) ≤ p i * (q i / p i - 1) :=
+        mul_le_mul_of_nonneg_left hbound (le_of_lt hpos)
+      have h3 : p i * (q i / p i - 1) = q i - p i := by field_simp
+      rw [hlog]; linarith
+  -- The sum of the gaps equals the KL divergence.
+  have hsum_e : ∑ i, e i = ∑ i, p i * (Real.log (p i) - Real.log (q i)) := by
+    have expand : ∀ i, e i = (q i - p i) + p i * (Real.log (p i) - Real.log (q i)) := by
+      intro i; rw [he_def]; dsimp only; ring
+    rw [Finset.sum_congr rfl (fun i _ => expand i), Finset.sum_add_distrib,
+        Finset.sum_sub_distrib, ← hpq]
+    ring
+  -- KL ≥ 0 and KL ≤ 0 (hypothesis) ⟹ KL = 0 ⟹ ∑ e = 0.
+  have hKL0 : ∑ i, p i * (Real.log (p i) - Real.log (q i)) = 0 :=
+    le_antisymm hKL (by rw [← hsum_e]; exact Finset.sum_nonneg (fun i _ => he_nonneg i))
+  have hsum_e0 : ∑ i, e i = 0 := by rw [hsum_e, hKL0]
+  have he_zero : ∀ i, e i = 0 :=
+    fun i => (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => he_nonneg j)).mp hsum_e0 i
+      (Finset.mem_univ i)
+  -- Each gap being zero forces pᵢ = qᵢ.
+  intro i
+  have hei : e i = 0 := he_zero i
+  rw [he_def] at hei; dsimp only at hei
+  rcases eq_or_lt_of_le (hp i) with h0 | hpos
+  · -- pᵢ = 0: the gap is qᵢ, so qᵢ = 0.
+    rw [← h0] at hei ⊢
+    simp only [sub_zero, zero_mul] at hei
+    exact hei.symm
+  · -- pᵢ > 0: strict tangent inequality unless qᵢ = pᵢ.
+    have hqi : 0 < q i := hac i hpos
+    have hpne : p i ≠ 0 := ne_of_gt hpos
+    by_contra hne
+    have hqp_ne : q i / p i ≠ 1 := by
+      intro h1
+      exact hne ((div_eq_one_iff_eq hpne).mp h1).symm
+    have ht : (0 : ℝ) < q i / p i := div_pos hqi hpos
+    have hlt : Real.log (q i / p i) < q i / p i - 1 := by
+      have hu : Real.log (q i / p i) ≠ 0 := by
+        intro h0
+        have hexp : Real.exp (Real.log (q i / p i)) = q i / p i := Real.exp_log ht
+        rw [h0, Real.exp_zero] at hexp
+        exact hqp_ne hexp.symm
+      have h := Real.add_one_lt_exp hu
+      rw [Real.exp_log ht] at h; linarith
+    have hlog : Real.log (q i) - Real.log (p i) = Real.log (q i / p i) := by
+      rw [Real.log_div (ne_of_gt hqi) hpne]
+    have h2 : p i * Real.log (q i / p i) < p i * (q i / p i - 1) :=
+      mul_lt_mul_of_pos_left hlt hpos
+    have h3 : p i * (q i / p i - 1) = q i - p i := by field_simp
+    rw [hlog] at hei
+    linarith
+
+/-- **The entropy gap is the mutual-information sum.** For any joint
+distribution `p : α × β → ℝ`,
+
+  `H(pX) + H(pY) − H(p) = ∑_{x,y} p(x,y)·(log p(x,y) − log pX(x) − log pY(y))`.
+
+This is a pure algebraic rearrangement (marginalisation), no positivity needed. -/
+theorem entropy_diff_eq (p : α × β → ℝ) :
+    entropy (marginalX p) + entropy (marginalY p) - entropy p
+      = ∑ xy : α × β, p xy *
+          (Real.log (p xy) - Real.log (marginalX p xy.1) - Real.log (marginalY p xy.2)) := by
+  have hX : ∑ x, marginalX p x * Real.log (marginalX p x)
+      = ∑ xy : α × β, p xy * Real.log (marginalX p xy.1) := by
+    simp only [marginalX]
+    rw [Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl fun x _ => ?_
+    dsimp only
+    rw [← Finset.sum_mul]
+  have hY : ∑ y, marginalY p y * Real.log (marginalY p y)
+      = ∑ xy : α × β, p xy * Real.log (marginalY p xy.2) := by
+    simp only [marginalY]
+    rw [Fintype.sum_prod_type, Finset.sum_comm]
+    refine Finset.sum_congr rfl fun y _ => ?_
+    dsimp only
+    rw [← Finset.sum_mul]
+  have hRHS : (∑ xy : α × β, p xy *
+        (Real.log (p xy) - Real.log (marginalX p xy.1) - Real.log (marginalY p xy.2)))
+      = (∑ xy : α × β, p xy * Real.log (p xy))
+        - (∑ xy : α × β, p xy * Real.log (marginalX p xy.1))
+        - (∑ xy : α × β, p xy * Real.log (marginalY p xy.2)) := by
+    simp only [mul_sub, Finset.sum_sub_distrib]
+  rw [entropy_eq_neg_sum p, entropy_eq_neg_sum (marginalX p), entropy_eq_neg_sum (marginalY p),
+      hX, hY, hRHS]
+  ring
+
+/-- **Forward direction (parent's result, reproved):** entropy is additive for a
+product distribution. -/
+theorem entropy_prod (pX : α → ℝ) (pY : β → ℝ)
+    (hX : ∑ x, pX x = 1) (hY : ∑ y, pY y = 1) :
+    entropy (fun xy : α × β => pX xy.1 * pY xy.2) = entropy pX + entropy pY := by
+  unfold entropy
+  rw [Fintype.sum_prod_type]
+  have key : ∀ x, (∑ y, Real.negMulLog (pX x * pY y))
+      = Real.negMulLog (pX x) + pX x * ∑ y, Real.negMulLog (pY y) := by
+    intro x
+    simp_rw [Real.negMulLog_mul]
+    rw [Finset.sum_add_distrib, ← Finset.sum_mul, hY, one_mul, ← Finset.mul_sum]
+  rw [Finset.sum_congr rfl fun x _ => key x, Finset.sum_add_distrib,
+    ← Finset.sum_mul, hX, one_mul]
+
+/-- **Entropy additivity converse.** If a nonnegative, normalised joint
+distribution `p` satisfies `H(p) = H(pX) + H(pY)`, then `p` is the product of its
+own marginals: `p(x, y) = pX(x)·pY(y)` for all `x, y`. Equivalently, additivity
+of entropy holds only when `X` and `Y` are independent. -/
+theorem entropy_additive_converse (p : α × β → ℝ)
+    (hp : ∀ xy, 0 ≤ p xy) (hsum : ∑ xy, p xy = 1)
+    (hadd : entropy p = entropy (marginalX p) + entropy (marginalY p)) :
+    ∀ x y, p (x, y) = marginalX p x * marginalY p y := by
+  -- Nonnegativity of the product distribution `q = pX ⊗ pY`.
+  have hq' : ∀ xy : α × β, 0 ≤ marginalX p xy.1 * marginalY p xy.2 := by
+    intro xy
+    exact mul_nonneg (Finset.sum_nonneg fun y _ => hp (xy.1, y))
+      (Finset.sum_nonneg fun x _ => hp (x, xy.2))
+  -- Absolute continuity: p(x,y) > 0 ⟹ pX(x), pY(y) > 0.
+  have hac' : ∀ xy : α × β, 0 < p xy → 0 < marginalX p xy.1 * marginalY p xy.2 := by
+    intro xy hpos
+    refine mul_pos ?_ ?_
+    · have hle : p (xy.1, xy.2) ≤ ∑ y, p (xy.1, y) :=
+        Finset.single_le_sum (f := fun y => p (xy.1, y)) (fun y _ => hp (xy.1, y))
+          (Finset.mem_univ xy.2)
+      rw [Prod.mk.eta] at hle
+      exact lt_of_lt_of_le hpos hle
+    · have hle : p (xy.1, xy.2) ≤ ∑ x, p (x, xy.2) :=
+        Finset.single_le_sum (f := fun x => p (x, xy.2)) (fun x _ => hp (x, xy.2))
+          (Finset.mem_univ xy.1)
+      rw [Prod.mk.eta] at hle
+      exact lt_of_lt_of_le hpos hle
+  -- Total mass of `q` is 1.
+  have hqsum : ∑ xy : α × β, marginalX p xy.1 * marginalY p xy.2 = 1 := by
+    have hsplit : ∑ xy : α × β, marginalX p xy.1 * marginalY p xy.2
+        = ∑ x, ∑ y, marginalX p x * marginalY p y := by
+      rw [Fintype.sum_prod_type]
+    rw [hsplit, ← Fintype.sum_mul_sum, sum_marginalX p hsum, sum_marginalY p hsum, mul_one]
+  have hpq : ∑ xy : α × β, p xy = ∑ xy : α × β, marginalX p xy.1 * marginalY p xy.2 := by
+    rw [hsum, hqsum]
+  -- The KL divergence w.r.t. `q` equals the (zero) entropy gap.
+  have hbridge : (∑ xy : α × β, p xy *
+        (Real.log (p xy) - Real.log (marginalX p xy.1 * marginalY p xy.2)))
+      = ∑ xy : α × β, p xy *
+          (Real.log (p xy) - Real.log (marginalX p xy.1) - Real.log (marginalY p xy.2)) := by
+    refine Finset.sum_congr rfl fun xy _ => ?_
+    rcases eq_or_lt_of_le (hp xy) with h0 | hpos
+    · rw [← h0]; ring
+    · have hmx : 0 < marginalX p xy.1 := by
+        have hle : p (xy.1, xy.2) ≤ ∑ y, p (xy.1, y) :=
+          Finset.single_le_sum (f := fun y => p (xy.1, y)) (fun y _ => hp (xy.1, y))
+            (Finset.mem_univ xy.2)
+        rw [Prod.mk.eta] at hle
+        exact lt_of_lt_of_le hpos hle
+      have hmy : 0 < marginalY p xy.2 := by
+        have hle : p (xy.1, xy.2) ≤ ∑ x, p (x, xy.2) :=
+          Finset.single_le_sum (f := fun x => p (x, xy.2)) (fun x _ => hp (x, xy.2))
+            (Finset.mem_univ xy.1)
+        rw [Prod.mk.eta] at hle
+        exact lt_of_lt_of_le hpos hle
+      rw [Real.log_mul (ne_of_gt hmx) (ne_of_gt hmy)]; ring
+  have hKL : ∑ xy : α × β, p xy *
+        (Real.log (p xy) - Real.log (marginalX p xy.1 * marginalY p xy.2)) ≤ 0 := by
+    rw [hbridge, ← entropy_diff_eq, ← hadd]
+    linarith
+  -- Apply the Gibbs equality lemma with `q = pX ⊗ pY`.
+  have key := gibbs_eq p (fun xy : α × β => marginalX p xy.1 * marginalY p xy.2)
+    hp hq' hpq hac' hKL
+  intro x y
+  simpa using key (x, y)
+
+/-- **Entropy additivity characterization.** For a nonnegative, normalised joint
+distribution `p`, entropy is additive iff `X` and `Y` are independent (the joint
+is the product of its marginals). The forward implication is the converse proved
+above; the backward implication is `entropy_prod`. -/
+theorem entropy_additive_iff (p : α × β → ℝ)
+    (hp : ∀ xy, 0 ≤ p xy) (hsum : ∑ xy, p xy = 1) :
+    entropy p = entropy (marginalX p) + entropy (marginalY p) ↔
+      ∀ x y, p (x, y) = marginalX p x * marginalY p y := by
+  constructor
+  · intro hadd
+    exact entropy_additive_converse p hp hsum hadd
+  · intro hprod
+    have hpeq : p = (fun xy : α × β => marginalX p xy.1 * marginalY p xy.2) := by
+      funext xy
+      exact hprod xy.1 xy.2
+    have step : entropy p
+        = entropy (fun xy : α × β => marginalX p xy.1 * marginalY p xy.2) :=
+      congrArg entropy hpeq
+    rw [step]
+    exact entropy_prod (marginalX p) (marginalY p) (sum_marginalX p hsum) (sum_marginalY p hsum)
+
+end ShannonSourceCodingWIP01OQ02

--- a/src/data/proofs/shannon-source-coding-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "shannon-conv-overview",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 3, "endLine": 61 },
+    "type": "concept",
+    "title": "Converse to entropy additivity: independence is forced",
+    "content": "The docstring frames the result. The parent file proves the forward direction of the equality case of subadditivity: a product distribution pXY(x,y) = pX(x)·pY(y) is additive, H(pX ⊗ pY) = H(pX) + H(pY). This file proves the converse: for an arbitrary joint distribution p, additivity H(p) = H(pX) + H(pY) forces p to equal the product of its own marginals — i.e. X and Y are independent. The engine is the observation that the entropy gap H(pX) + H(pY) − H(p) is the mutual information I(X;Y) = D(p ‖ pX ⊗ pY) ≥ 0, a Kullback–Leibler divergence that vanishes exactly when the two distributions coincide.",
+    "mathContext": "$H(p)=H(p_X)+H(p_Y)\\iff \\forall x\\,y,\\ p(x,y)=p_X(x)\\,p_Y(y)$",
+    "significance": "key",
+    "relatedConcepts": ["mutual information", "Kullback–Leibler divergence", "independence", "subadditivity of entropy", "Gibbs inequality"],
+    "prerequisites": ["Shannon entropy", "joint and marginal distributions", "relative entropy"]
+  },
+  {
+    "id": "shannon-conv-entropy-marginals",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 63, "endLine": 96 },
+    "type": "definition",
+    "title": "Entropy in negMulLog form and the marginals",
+    "content": "`entropy p = ∑ₓ negMulLog (p x)` matches the parent's definition and agrees with the standard −∑ p·log p (`entropy_eq_neg_sum`). The marginals `marginalX p x = ∑_y p(x,y)` and `marginalY p y = ∑_x p(x,y)` are the row/column sums of the joint. `sum_marginalX`/`sum_marginalY` show that a marginal of a normalised joint is itself normalised (∑ pX = ∑ pY = 1), obtained by flattening the double sum with `Fintype.sum_prod_type`.",
+    "mathContext": "$p_X(x)=\\sum_y p(x,y),\\qquad p_Y(y)=\\sum_x p(x,y),\\qquad \\sum_x p_X(x)=\\sum_y p_Y(y)=1$",
+    "significance": "supporting",
+    "relatedConcepts": ["Shannon entropy", "negMulLog", "marginal distribution"],
+    "prerequisites": ["Shannon entropy", "finite sums over product types", "probability normalisation"]
+  },
+  {
+    "id": "shannon-conv-gibbs",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 98, "endLine": 167 },
+    "type": "theorem",
+    "title": "Gibbs' inequality, equality case (the engine)",
+    "content": "`gibbs_eq` is the self-contained core: for finite probability distributions p, q of equal total mass with p absolutely continuous w.r.t. q (0 < p i ⟹ 0 < q i), if the KL divergence ∑ᵢ pᵢ(log pᵢ − log qᵢ) is ≤ 0 then p = q pointwise. The proof introduces the per-term gap eᵢ = (qᵢ − pᵢ) − pᵢ(log qᵢ − log pᵢ). Each eᵢ ≥ 0 from the tangent-line bound log t ≤ t − 1 (`Real.log_le_sub_one_of_pos`); the gaps sum to the KL divergence, so KL ≤ 0 (with KL ≥ 0 intrinsic) forces ∑ eᵢ = 0, hence every eᵢ = 0 (`Finset.sum_eq_zero_iff_of_nonneg`). Off the support eᵢ = qᵢ, giving qᵢ = 0 = pᵢ; on the support the strict bound log t < t − 1 for t ≠ 1 (from `Real.add_one_lt_exp`) makes eᵢ > 0 unless qᵢ = pᵢ.",
+    "mathContext": "$\\sum_i p_i\\log\\frac{p_i}{q_i}\\ge 0,\\qquad \\sum_i p_i\\log\\frac{p_i}{q_i}=0\\iff p=q$",
+    "significance": "critical",
+    "relatedConcepts": ["Gibbs inequality", "relative entropy", "tangent-line bound", "strict convexity of log"],
+    "prerequisites": ["Kullback–Leibler divergence", "convexity", "sum of nonnegative terms is zero iff all zero"]
+  },
+  {
+    "id": "shannon-conv-diff-eq",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 169, "endLine": 203 },
+    "type": "theorem",
+    "title": "The entropy gap is the mutual-information sum",
+    "content": "`entropy_diff_eq` is a pure algebraic rearrangement (no positivity): H(pX) + H(pY) − H(p) = ∑_{x,y} p(x,y)·(log p(x,y) − log pX(x) − log pY(y)). Each marginal entropy is re-expressed over the joint index via marginalisation (∑_x pX(x)·log pX(x) = ∑_{x,y} p(x,y)·log pX(x), pulling the log out with `Finset.sum_mul`), and the three sums are combined. The result identifies the entropy gap with the KL divergence D(p ‖ pX ⊗ pY) — the mutual information I(X;Y) — reducing the converse to a divergence-equality statement.",
+    "mathContext": "$H(p_X)+H(p_Y)-H(p)=\\sum_{x,y}p(x,y)\\log\\frac{p(x,y)}{p_X(x)\\,p_Y(y)}=D(p\\,\\|\\,p_X\\otimes p_Y)$",
+    "significance": "key",
+    "relatedConcepts": ["mutual information", "marginalisation", "relative entropy"],
+    "prerequisites": ["Shannon entropy", "double sums over products", "logarithm identities"]
+  },
+  {
+    "id": "shannon-conv-forward",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 205, "endLine": 220 },
+    "type": "theorem",
+    "title": "Forward direction: product ⟹ additive",
+    "content": "`entropy_prod` reproves the parent's pairwise additivity locally so the file is self-contained: for a product distribution with ∑ pX = ∑ pY = 1, H(pX ⊗ pY) = H(pX) + H(pY). The sum over α × β factors into a double sum (`Fintype.sum_prod_type`), `Real.negMulLog_mul` linearizes each product symbol, and normalisation collapses the cross terms. This supplies the backward implication of the final iff.",
+    "mathContext": "$H(p_X \\otimes p_Y) = H(p_X) + H(p_Y)$",
+    "significance": "supporting",
+    "relatedConcepts": ["additivity", "product distribution", "negMulLog_mul"],
+    "prerequisites": ["Shannon entropy", "double sums over products", "probability normalisation"]
+  },
+  {
+    "id": "shannon-conv-converse",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 222, "endLine": 286 },
+    "type": "theorem",
+    "title": "The converse: additive ⟹ product distribution",
+    "content": "`entropy_additive_converse` instantiates `gibbs_eq` with q(x,y) = pX(x)·pY(y). Three side-conditions are discharged: q is nonnegative (product of nonnegative marginals); q has total mass 1 (∑ q = (∑ pX)(∑ pY) = 1 via `Fintype.sum_mul_sum`); and — crucially — absolute continuity is derived, not assumed: p(x,y) > 0 implies pX(x) = ∑_{y'} p(x,y') ≥ p(x,y) > 0 and likewise pY(y) > 0 (`Finset.single_le_sum`), so q > 0 on the support of p. The KL divergence w.r.t. q equals the (vanishing) entropy gap via `entropy_diff_eq` and a bridge identifying log(pX·pY) = log pX + log pY on the support. `gibbs_eq` then yields p(x,y) = pX(x)·pY(y).",
+    "mathContext": "$H(p)=H(p_X)+H(p_Y)\\ \\Rightarrow\\ \\forall x\\,y,\\ p(x,y)=p_X(x)\\,p_Y(y)$",
+    "significance": "critical",
+    "relatedConcepts": ["independence", "absolute continuity", "product of marginals", "mutual information"],
+    "prerequisites": ["Gibbs equality case", "mutual-information identity", "single term bounded by sum"]
+  },
+  {
+    "id": "shannon-conv-iff",
+    "proofId": "shannon-source-coding-wip-01-oq-02",
+    "range": { "startLine": 288, "endLine": 304 },
+    "type": "theorem",
+    "title": "The full characterisation",
+    "content": "`entropy_additive_iff` assembles both directions: for a nonnegative, normalised joint distribution p, H(p) = H(pX) + H(pY) ⟺ ∀ x y, p(x,y) = pX(x)·pY(y). The forward implication is `entropy_additive_converse`; the backward implication rewrites p as the product of its marginals and applies `entropy_prod`. This is the exact equality condition for subadditivity of Shannon entropy: additivity holds precisely when X and Y are independent.",
+    "mathContext": "$H(p)=H(p_X)+H(p_Y)\\iff X\\perp Y$",
+    "significance": "key",
+    "relatedConcepts": ["subadditivity of entropy", "independence", "equality case"],
+    "prerequisites": ["forward and converse directions", "logical equivalence"]
+  }
+]

--- a/src/data/proofs/shannon-source-coding-wip-01-oq-02/meta.json
+++ b/src/data/proofs/shannon-source-coding-wip-01-oq-02/meta.json
@@ -1,0 +1,223 @@
+{
+  "id": "shannon-source-coding-wip-01-oq-02",
+  "title": "Entropy Additivity Converse: Additivity Holds Only for Product Distributions",
+  "slug": "shannon-source-coding-wip-01-oq-02",
+  "description": "Proves the converse to the parent's entropy additivity (shannon-source-coding-wip-01, H(pX ⊗ pY) = H(pX) + H(pY) for product distributions). For an arbitrary nonnegative, normalised joint distribution p : α × β → ℝ with marginals pX(x) = ∑_y p(x,y) and pY(y) = ∑_x p(x,y), additivity of Shannon entropy holds exactly when p is the product of its own marginals: H(p) = H(pX) + H(pY) ⟺ ∀ x y, p(x,y) = pX(x)·pY(y). The entropy gap is the mutual information H(pX) + H(pY) − H(p) = D(p ‖ pX ⊗ pY) ≥ 0, a Kullback–Leibler divergence that vanishes iff the two distributions coincide. The engine is a self-contained finite Gibbs equality lemma proved from the tangent-line bound log t ≤ t − 1 and its strict form log t < t − 1 (t ≠ 1). This is the exact boundary of subadditivity: entropy is additive precisely when X and Y are independent. 8 theorems, 3 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonSourceCodingWIP01OQ02.lean",
+    "tags": [
+      "information-theory",
+      "shannon-entropy",
+      "source-coding",
+      "mutual-information",
+      "kullback-leibler",
+      "gibbs-inequality",
+      "independence",
+      "product-distribution",
+      "negMulLog"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 305,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "assumptions": "None. All 8 theorems proved, 0 axioms. Verified axiom-free: #print axioms entropy_additive_iff and entropy_additive_converse report only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool). The only hypotheses are that p is nonnegative and normalised (∑ p = 1) — the defining properties of a joint probability distribution. Absolute continuity of p with respect to pX ⊗ pY is not assumed; it is derived (p(x,y) > 0 ⟹ pX(x), pY(y) > 0).",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_le_sub_one_of_pos",
+        "description": "log x ≤ x − 1 for x > 0 — the tangent-line bound giving KL divergence ≥ 0 termwise",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.add_one_lt_exp",
+        "description": "x + 1 < exp x for x ≠ 0 — yields the strict tangent bound log t < t − 1 (t ≠ 1) that forces equality only at t = 1, the crux of the equality case",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Real.negMulLog_mul",
+        "description": "negMulLog(x·y) = y·negMulLog x + x·negMulLog y — linearizes the entropy of a product symbol (forward-direction engine, entropy_prod)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.NegMulLog"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "a sum of nonnegative terms is zero iff every term is zero — converts KL = 0 into the pointwise equality p = q",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "a single nonnegative term is at most the whole sum — derives pX(x), pY(y) > 0 from p(x,y) > 0 (absolute continuity)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Fintype.sum_prod_type",
+        "description": "∑ over α × β factors as a double sum — used for marginalisation in the mutual-information identity",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "Fintype.sum_mul_sum",
+        "description": "(∑ f)(∑ g) = ∑∑ f·g — shows the product distribution pX ⊗ pY has total mass 1",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      }
+    ],
+    "dateAdded": "2026-07-02"
+  },
+  "overview": {
+    "historicalContext": "Subadditivity of Shannon entropy, H(X,Y) ≤ H(X) + H(Y), is a cornerstone of information theory; the deficit H(X) + H(Y) − H(X,Y) is precisely the mutual information I(X;Y), which measures the statistical dependence between X and Y. Gibbs' inequality (equivalently, nonnegativity of the Kullback–Leibler divergence) states that I(X;Y) ≥ 0 with equality iff X and Y are independent. The parent entry proves the forward direction of the equality case — a product distribution is additive — and this entry closes the loop with the converse: additivity forces independence. Together they pin subadditivity's exact boundary. The equality analysis of KL divergence is the same mechanism behind maximum-entropy characterisations and the data-processing inequality.",
+    "problemStatement": "Let p : α × β → ℝ be a nonnegative joint distribution with ∑ p = 1 and marginals pX(x) = ∑_y p(x,y), pY(y) = ∑_x p(x,y). Prove that H(p) = H(pX) + H(pY) holds if and only if p(x,y) = pX(x)·pY(y) for all x, y (i.e. X and Y are independent), where H is Shannon entropy in negMulLog form.",
+    "proofStrategy": "The entropy gap H(pX) + H(pY) − H(p) is rearranged (marginalisation, entropy_diff_eq) into the mutual-information sum ∑_{x,y} p(x,y)·(log p(x,y) − log pX(x) − log pY(y)), which equals the Kullback–Leibler divergence D(p ‖ q) with q(x,y) = pX(x)·pY(y). A self-contained finite Gibbs equality lemma (gibbs_eq) shows: for probability distributions p, q with p absolutely continuous w.r.t. q, the per-term gap eᵢ = (qᵢ − pᵢ) − pᵢ(log qᵢ − log pᵢ) is ≥ 0 (from log t ≤ t − 1), sums to the KL divergence, and — when the divergence is ≤ 0 — every eᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg). The strict tangent bound log t < t − 1 for t ≠ 1 (from Real.add_one_lt_exp) then forces qᵢ = pᵢ at each point of the support, while off the support eᵢ = qᵢ = 0. Absolute continuity is automatic: p(x,y) > 0 ⟹ pX(x), pY(y) > 0 (Finset.single_le_sum). Instantiating gibbs_eq with q = pX ⊗ pY yields the converse; combining with the forward direction (entropy_prod) gives the iff.",
+    "keyInsights": [
+      "**The entropy gap is a KL divergence.** H(pX) + H(pY) − H(p) equals ∑_{x,y} p(x,y)·log(p(x,y)/(pX(x)·pY(y))) = D(p ‖ pX ⊗ pY), the mutual information; its nonnegativity is Gibbs' inequality and its vanishing is exactly independence. This reframing turns an entropy identity into a divergence-equality problem.",
+      "**Strict convexity is the crux of the converse.** Nonnegativity of KL uses only log t ≤ t − 1, but the converse needs the strict bound log t < t − 1 for t ≠ 1 (derived from Real.add_one_lt_exp). Summed over a support, a single strict term would make the divergence positive, so equality forces q = p pointwise.",
+      "**Absolute continuity is derived, not assumed.** If p(x,y) > 0 then its marginals pX(x) = ∑_{y'} p(x,y') and pY(y) are ≥ p(x,y) > 0 (Finset.single_le_sum), so the product q(x,y) = pX(x)·pY(y) never vanishes on the support of p — the divergence is always well-defined.",
+      "**Exact boundary of subadditivity.** Read with the gallery's subadditivity entry (H(X,Y) ≤ H(X)+H(Y)) and the parent's forward additivity, this converse completes the characterisation: equality in subadditivity ⟺ independence.",
+      "**Axiom-free and hypothesis-minimal.** The only assumptions are nonnegativity and normalisation of p; #print axioms confirms reliance only on propext, Classical.choice, Quot.sound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "entropy-and-marginals",
+      "title": "Entropy in negMulLog form and the marginals",
+      "startLine": 63,
+      "endLine": 96,
+      "summary": "entropy p := ∑ₓ negMulLog(p x) (matching the parent), with entropy_eq_neg_sum tying it to −∑ p·log p. marginalX/marginalY are the two marginals of a joint distribution, and sum_marginalX/sum_marginalY show a marginal of a normalised joint is normalised.",
+      "mathContext": "$H(p)=\\sum_x\\mathrm{negMulLog}(p_x),\\quad p_X(x)=\\sum_y p(x,y),\\quad p_Y(y)=\\sum_x p(x,y).$"
+    },
+    {
+      "id": "gibbs-equality",
+      "title": "Gibbs' inequality, equality case (finite form)",
+      "startLine": 98,
+      "endLine": 167,
+      "summary": "gibbs_eq: for finite probability distributions p, q with p ≪ q, if ∑ᵢ pᵢ(log pᵢ − log qᵢ) ≤ 0 then p = q. The per-term gap eᵢ ≥ 0 (from log t ≤ t − 1) sums to the KL divergence; ∑ eᵢ = 0 forces each eᵢ = 0, and the strict bound log t < t − 1 (t ≠ 1) forces qᵢ = pᵢ.",
+      "mathContext": "$\\sum_i p_i\\log\\frac{p_i}{q_i}\\ge 0,\\qquad =0 \\iff p=q.$"
+    },
+    {
+      "id": "entropy-diff",
+      "title": "The entropy gap is the mutual-information sum",
+      "startLine": 175,
+      "endLine": 203,
+      "summary": "entropy_diff_eq: H(pX) + H(pY) − H(p) = ∑_{x,y} p(x,y)·(log p(x,y) − log pX(x) − log pY(y)). A pure marginalisation rearrangement (no positivity), identifying the gap with the KL divergence D(p ‖ pX ⊗ pY).",
+      "mathContext": "$H(p_X)+H(p_Y)-H(p)=\\sum_{x,y}p(x,y)\\log\\frac{p(x,y)}{p_X(x)\\,p_Y(y)}.$"
+    },
+    {
+      "id": "converse-and-iff",
+      "title": "The converse and the full characterisation",
+      "startLine": 205,
+      "endLine": 304,
+      "summary": "entropy_prod reproves the forward direction (product ⟹ additive). entropy_additive_converse instantiates gibbs_eq with q = pX ⊗ pY (deriving nonnegativity, normalisation, and absolute continuity of q) to conclude additivity ⟹ product. entropy_additive_iff assembles both into H(p) = H(pX) + H(pY) ⟺ independence.",
+      "mathContext": "$H(p)=H(p_X)+H(p_Y)\\iff \\forall x\\,y,\\; p(x,y)=p_X(x)\\,p_Y(y).$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Shannon entropy is additive for a joint distribution exactly when that distribution is the product of its marginals: H(p) = H(pX) + H(pY) ⟺ ∀ x y, p(x,y) = pX(x)·pY(y). Proved by identifying the entropy gap with the Kullback–Leibler divergence D(p ‖ pX ⊗ pY) and establishing a self-contained finite Gibbs equality lemma. 8 theorems, 3 definitions, 0 sorries, 0 axioms.",
+    "implications": "Completes the equality analysis of subadditivity of entropy: additivity ⟺ independence. This converse, together with the parent's forward direction, characterises the exact boundary of the subadditivity inequality and supplies the divergence-equality machinery (KL = 0 ⟺ equal distributions) reused across maximum-entropy and data-processing arguments.",
+    "openQuestions": [
+      "Quantitative (stability) form: bound the total-variation distance ‖p − pX ⊗ pY‖ by the entropy gap H(pX) + H(pY) − H(p) via Pinsker's inequality, upgrading the equality characterisation to an approximate one.",
+      "Chain-rule route: derive the same converse from H(X,Y) = H(X) + H(Y|X) and the equality case of conditioning-reduces-entropy (H(Y|X) = H(Y) ⟺ independence), once conditional entropy is formalised."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "ShannonSourceCodingWIP01OQ02",
+    "lineCount": 305,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/ShannonSourceCodingWIP01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-source-coding-wip-01",
+      "relationship": "extends",
+      "description": "Parent entry proves the forward direction (product distribution ⟹ additive entropy); this file proves the converse (additive entropy ⟹ product distribution), completing the iff"
+    },
+    {
+      "targetId": "shannon-source-coding-wip-01-oq-01",
+      "relationship": "complements",
+      "description": "Sibling iterates the forward additivity to the n-fold i.i.d. product; this file characterises when additivity holds at all (independence)"
+    },
+    {
+      "targetId": "shannon-entropy",
+      "relationship": "extends",
+      "description": "ShannonEntropy proves subadditivity H(X,Y) ≤ H(X)+H(Y); this file identifies its exact equality condition — the joint is the product of its marginals"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "entropy_additive_iff",
+      "type": "core",
+      "statement": "(∀ xy, 0 ≤ p xy) → ∑ p = 1 → (entropy p = entropy (marginalX p) + entropy (marginalY p) ↔ ∀ x y, p (x, y) = marginalX p x * marginalY p y)",
+      "description": "Shannon entropy is additive iff the joint distribution is the product of its marginals (X and Y independent).",
+      "significance": "The full equality characterisation of subadditivity: additivity of entropy ⟺ independence"
+    },
+    {
+      "name": "entropy_additive_converse",
+      "type": "core",
+      "statement": "(∀ xy, 0 ≤ p xy) → ∑ p = 1 → entropy p = entropy (marginalX p) + entropy (marginalY p) → ∀ x y, p (x, y) = marginalX p x * marginalY p y",
+      "description": "If entropy is additive then the joint distribution is the product of its own marginals.",
+      "significance": "The converse direction, the new content; combines with entropy_prod to give the iff"
+    },
+    {
+      "name": "gibbs_eq",
+      "type": "lemma",
+      "statement": "(∀ i, 0 ≤ p i) → (∀ i, 0 ≤ q i) → ∑ p = ∑ q → (∀ i, 0 < p i → 0 < q i) → ∑ i, p i * (log (p i) − log (q i)) ≤ 0 → ∀ i, p i = q i",
+      "description": "Gibbs' inequality equality case: the KL divergence of finite distributions vanishes only when they coincide.",
+      "significance": "The self-contained divergence-equality engine driving the converse"
+    },
+    {
+      "name": "entropy_diff_eq",
+      "type": "lemma",
+      "statement": "entropy (marginalX p) + entropy (marginalY p) − entropy p = ∑ xy, p xy * (log (p xy) − log (marginalX p xy.1) − log (marginalY p xy.2))",
+      "description": "The entropy gap equals the mutual-information sum (KL divergence w.r.t. the product of marginals).",
+      "significance": "Reframes the entropy identity as a divergence-equality problem"
+    },
+    {
+      "name": "entropy_prod",
+      "type": "lemma",
+      "statement": "∑ pX = 1 → ∑ pY = 1 → entropy (fun (x,y) => pX x · pY y) = entropy pX + entropy pY",
+      "description": "Forward direction: entropy is additive for a product distribution (parent's result, reproved locally).",
+      "significance": "Supplies the backward implication of the iff"
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Claude E. Shannon",
+      "title": "A Mathematical Theory of Communication",
+      "year": 1948,
+      "venue": "Bell System Technical Journal 27, 379–423 & 623–656",
+      "note": "Introduces entropy and mutual information; additivity for independent sources underlies the source coding theorem."
+    },
+    {
+      "authors": "Thomas M. Cover and Joy A. Thomas",
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley, 2nd ed.",
+      "note": "Chapter 2: mutual information I(X;Y) = H(X)+H(Y)−H(X,Y) ≥ 0 with equality iff X, Y independent; nonnegativity of relative entropy (Gibbs' inequality)."
+    },
+    {
+      "authors": "Solomon Kullback and Richard A. Leibler",
+      "title": "On Information and Sufficiency",
+      "year": 1951,
+      "venue": "Annals of Mathematical Statistics 22 (1), 79–86",
+      "note": "Introduces the relative entropy D(p ‖ q), whose nonnegativity and equality case are the engine of this converse."
+    },
+    {
+      "authors": "Imre Csiszár and János Körner",
+      "title": "Information Theory: Coding Theorems for Discrete Memoryless Systems",
+      "year": 2011,
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Systematic treatment of the equality conditions in information inequalities."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **converse** to the parent entry's entropy additivity (`shannon-source-coding-wip-01`, which proves `H(pX ⊗ pY) = H(pX) + H(pY)` for product distributions). For an arbitrary nonnegative, normalised joint distribution `p : α × β → ℝ` with marginals `pX(x) = ∑_y p(x,y)`, `pY(y) = ∑_x p(x,y)`:

```
H(p) = H(pX) + H(pY)  ⟺  ∀ x y, p(x,y) = pX(x)·pY(y)     (X ⟂ Y)
```

This pins the exact equality boundary of subadditivity of Shannon entropy: additivity holds **precisely** when X and Y are independent.

## Mathematical content

The entropy gap is the mutual information / Kullback–Leibler divergence:

```
H(pX) + H(pY) − H(p) = ∑_{x,y} p(x,y)·log( p(x,y) / (pX(x)·pY(y)) ) = D(p ‖ pX ⊗ pY) ≥ 0,
```

which vanishes iff the two distributions coincide. The engine is a self-contained finite **Gibbs equality lemma** (`gibbs_eq`): nonnegativity uses the tangent bound `log t ≤ t − 1`, and the converse uses its strict form `log t < t − 1` (`t ≠ 1`, from `Real.add_one_lt_exp`). Absolute continuity of `p` w.r.t. `pX ⊗ pY` is **derived**, not assumed (`p(x,y) > 0 ⟹ pX(x), pY(y) > 0` via `Finset.single_le_sum`).

## Verification

- **8 theorems, 3 definitions, 305 lines, 0 sorries.**
- Builds under Docker (`Proofs.ShannonSourceCodingWIP01OQ02`, Lean/Mathlib 4.26.0).
- **Verified axiom-free**: `#print axioms` on `entropy_additive_iff` and `entropy_additive_converse` reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- No `sorry`/`admit`/`axiom`/`native_decide`/`decide`.

## Key theorems

| Name | Statement |
|------|-----------|
| `entropy_additive_iff` | `H(p) = H(pX)+H(pY) ↔ ∀ x y, p(x,y) = pX(x)·pY(y)` |
| `entropy_additive_converse` | additive ⟹ product distribution (the new content) |
| `gibbs_eq` | KL-divergence equality case for finite distributions |
| `entropy_diff_eq` | entropy gap = mutual-information sum |
| `entropy_prod` | forward direction (parent's result, reproved locally) |

Gallery entry added at `src/data/proofs/shannon-source-coding-wip-01-oq-02/` (meta.json + 7 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)