### PR TITLE
Enrich Wilson trichotomy (n-1)! mod n (wilsons-theorem-oq-05-oq-01)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
@@ -144,8 +144,15 @@
       "id": "trichotomy",
       "title": "The Prime Branch and the Complete Trichotomy",
       "startLine": 124,
+      "endLine": 151,
+      "summary": "factorial_pred_mod_of_prime transports Mathlib's ZMod Wilson statement to (n-1)! % n = n-1 via the cast ((n-1 : ℕ) : ZMod n) = -1. factorial_pred_mod bundles all three cases as (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0 by nested by_cases (n = 4 by kernel decide)."
+    },
+    {
+      "id": "characterization",
+      "title": "Sharp Characterization and the Sporadic Value",
+      "startLine": 152,
       "endLine": 169,
-      "summary": "factorial_pred_mod_of_prime transports Mathlib's ZMod Wilson statement to (n-1)! % n = n-1 via the cast ((n-1 : ℕ) : ZMod n) = -1. factorial_pred_mod bundles all three cases as (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0 (n = 4 by kernel decide). factorial_pred_mod_eq_zero_iff characterizes the vanishing residue, and four_factorial_pred_mod records (4-1)! % 4 = 2 explicitly."
+      "summary": "factorial_pred_mod_eq_zero_iff: for n ≥ 2, (n-1)! % n = 0 ⟺ ¬n.Prime ∧ n ≠ 4, so the vanishing residue flags every composite except 4. four_factorial_pred_mod records the lone exception (4-1)! % 4 = 2 explicitly by decide."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01`.

This entry has a very rich meta.json (full section coverage, 4 keyInsights, genuine open questions, references, crossReferences) but the annotation coverage was thin relative to the file: **7 theorems, only 4 annotations**, with the `trichotomy` annotation bundling 4 distinct theorems across 45 lines.

- **Annotations (4 → 5)**: split `factorial_pred_mod_eq_zero_iff` and `four_factorial_pred_mod` (lines 152–169) into a dedicated *Sharp Characterization and the Sporadic Value* annotation — the residue-0 ⟺ composite-and-≠4 test and the explicit 3! % 4 = 2. The `trichotomy` annotation is narrowed to lines 124–151 (prime branch + assembled equation) with expanded proof detail (the ZMod cast chain, the nested `by_cases` assembly).
- **Sections**: split the matching `trichotomy` section (124–169) into two aligned sections.

No content removed; meta.json 17.6 KB (well under the 60 KB cap). All annotation types valid. Badge/status unchanged (verified, 0-axiom, kernel `decide` for n=4 — accurate).