### PR TITLE
Enrich Pythagorean Triples (Gaussian classification): link Fermat two-squares

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
@@ -112,6 +112,11 @@
       "relationship": "related",
       "description": "The base Pythagorean-triples entry and its parametric formula.",
       "targetId": "pythagorean-triples"
+    },
+    {
+      "relationship": "related",
+      "description": "The hypotenuse corollary here — every positive primitive triple has z = m²+n² = N(m+ni), a sum of two squares — is the Pythagorean shadow of Fermat's two-squares theorem. Both rest on the same arithmetic of ℤ[i]: this entry exhibits sums of two squares as Gaussian norms of squares z², while that entry characterizes exactly which primes (and integers) are sums of two squares. Named in open question 1.",
+      "targetId": "fermat-two-squares"
     }
   ],
   "references": [


### PR DESCRIPTION
Focused, non-inflationary enrichment for `pythagorean-triples-oq-02-oq-01` (meta.json only).

This entry already meets all quality targets (7 annotations with near-full coverage, 4 keyInsights, 3 sections, 3 references, conclusion with 3 open questions), so per the size/curation guardrail I made a single high-value addition rather than deepening.

**crossReferences 2 → 3**: add `fermat-two-squares` ("Fermat's Sum of Two Squares"). The entry's own hypotenuse corollary — every positive primitive triple has z = m²+n² = N(m+ni), a sum of two squares — is the Pythagorean shadow of Fermat's two-squares theorem, and both rest on the arithmetic of ℤ[i]. The link was already named in open question 1 and the conclusion prose but was never wired as a cross-reference. Target verified to exist.

No changes to status/badge/axiomCount (remains verified/mathlib/0). Size 10.9 KB, well under caps. JSON validated.