### PR TITLE
Enrich Wilson Quotient and Wilson Primes (wilsons-theorem-oq-06)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-06/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-06/meta.json
@@ -98,28 +98,40 @@
       "title": "Module Overview and the Wilson Quotient",
       "startLine": 1,
       "endLine": 53,
-      "summary": "Module docstring stating the goal (Wilson quotient W_p = ((p−1)!+1)/p as an integer, the three equivalent Wilson-prime conditions, certification of 5 and 13 axiom-free), the result list, imports of Mathlib.NumberTheory.Wilson and Mathlib.Tactic, and the definition `wilsonQuotient p = ((p−1)!+1)/p`."
+      "summary": "Module docstring stating the goal (Wilson quotient W_p = ((p−1)!+1)/p as an integer, the three equivalent Wilson-prime conditions, certification of 5 and 13 axiom-free), the result list, imports of Mathlib.NumberTheory.Wilson and Mathlib.Tactic, and the definition `wilsonQuotient p = ((p−1)!+1)/p`.",
+      "mathContext": "$W_p = \\dfrac{(p-1)!+1}{p}$; $p$ is a Wilson prime when $p \\mid W_p$, i.e. $p^2 \\mid (p-1)!+1$. Only 5, 13, 563 are known."
     },
     {
       "id": "wilson-divisibility-and-quotient",
       "title": "Wilson's Theorem in ℕ and the Quotient Identity",
       "startLine": 54,
       "endLine": 75,
-      "summary": "`prime_dvd_factorial_pred_add_one` re-derives p ∣ (p−1)!+1 from ZMod.wilsons_lemma via the cast bridge; `mul_wilsonQuotient` turns it into p·W_p = (p−1)!+1 with Nat.mul_div_cancel'; `wilsonQuotient_pos` shows W_p > 0 since p·W_p is a successor."
+      "summary": "`prime_dvd_factorial_pred_add_one` re-derives p ∣ (p−1)!+1 from ZMod.wilsons_lemma via the cast bridge; `mul_wilsonQuotient` turns it into p·W_p = (p−1)!+1 with Nat.mul_div_cancel'; `wilsonQuotient_pos` shows W_p > 0 since p·W_p is a successor.",
+      "mathContext": "$((p-1)!+1 : \\mathrm{ZMod}\\,p) = 0 \\Rightarrow p \\mid (p-1)!+1 \\Rightarrow p\\cdot W_p = (p-1)!+1$, so $W_p \\in \\mathbb{Z}_{>0}$."
     },
     {
       "id": "wilson-prime-conditions",
-      "title": "The Three Equivalent Wilson-Prime Conditions",
+      "title": "The Wilson-Prime Equivalence by Cancellation",
       "startLine": 77,
+      "endLine": 82,
+      "summary": "`dvd_wilsonQuotient_iff` proves p ∣ W_p ⟺ p² ∣ (p−1)!+1 by rewriting (p−1)!+1 = p·W_p, p² = p·p and cancelling the common factor p via Nat.mul_dvd_mul_iff_left.",
+      "mathContext": "$p \\mid W_p \\iff p\\cdot p \\mid p\\cdot W_p = (p-1)!+1 \\iff p^2 \\mid (p-1)!+1$ — pure left-cancellation of divisibility."
+    },
+    {
+      "id": "wilson-prime-definition",
+      "title": "The Wilson-Prime Definition and Its Equivalent Forms",
+      "startLine": 83,
       "endLine": 109,
-      "summary": "`dvd_wilsonQuotient_iff` proves p ∣ W_p ⟺ p² ∣ (p−1)!+1 by rewriting (p−1)!+1 = p·W_p, p² = p·p and cancelling via Nat.mul_dvd_mul_iff_left; `WilsonPrime` packages the definition; `wilsonPrime_iff_dvd_wilsonQuotient` restates it through the quotient; `sq_dvd_iff_factorial_cast_eq_neg_one` gives the ZMod (p²) congruence form (for any p)."
+      "summary": "`WilsonPrime p := p.Prime ∧ p² ∣ (p−1)!+1`; `wilsonPrime_iff_dvd_wilsonQuotient` restates it through the quotient (p ∣ W_p); `sq_dvd_iff_factorial_cast_eq_neg_one` gives the ZMod (p²) congruence form (p−1)! ≡ −1 (mod p²), which holds for any p.",
+      "mathContext": "Three interchangeable forms: $p^2 \\mid (p-1)!+1 \\iff p \\mid W_p \\iff (p-1)! \\equiv -1 \\pmod{p^2}$."
     },
     {
       "id": "wilson-prime-certificates",
       "title": "Certifying the Wilson Primes 5 and 13",
       "startLine": 111,
       "endLine": 126,
-      "summary": "`wilsonPrime_five` (25 ∣ 25) and `wilsonPrime_thirteen` (169 ∣ 479001601) certified by kernel `decide` — not `native_decide` — keeping the entry axiom-free; `wilsonQuotient_five` records W₅ = 5."
+      "summary": "`wilsonPrime_five` (25 ∣ 25) and `wilsonPrime_thirteen` (169 ∣ 479001601) certified by kernel `decide` — not `native_decide` — keeping the entry axiom-free; `wilsonQuotient_five` records W₅ = 5.",
+      "mathContext": "$4!+1 = 25 = 5^2$ and $12!+1 = 479001601 = 13^2\\cdot 2834329$, so $5$ and $13$ are Wilson primes."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-06`.

Rich meta.json already (full section coverage, 4 keyInsights, genuine open questions, references, crossReferences), but annotation coverage was thin: **9 theorems + 2 definitions, only 4 annotations**, with one annotation bundling a definition and 3 theorems across 33 lines.

- **Annotations (4 → 5)**: split off the `WilsonPrime` definition and its two equivalent forms (`wilsonPrime_iff_dvd_wilsonQuotient`, `sq_dvd_iff_factorial_cast_eq_neg_one` — the ZMod(p²) congruence that holds for any p; lines 83–109) into a dedicated *definition and equivalent forms* annotation. The cancellation annotation is narrowed to `dvd_wilsonQuotient_iff` (77–82).
- **Sections**: split the matching `wilson-prime-conditions` section (77–109) into two aligned sections, and added `mathContext` to **all 5 sections** (none had it before).

No content removed; meta.json 16.3 KB (well under the 60 KB cap). All annotation types valid. Badge/status unchanged (verified, 0-axiom, kernel `decide` for 5/13 — accurate).