### PR TITLE
Research: british-flag-theorem-oq-01-oq-01-oq-02 — Weighted Leibniz identity (affine-simplex generalization) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/BritishFlagSimplexOQ010102.lean
+++ b/proofs/Proofs/BritishFlagSimplexOQ010102.lean
@@ -1,0 +1,163 @@
+/-
+  The Weighted Leibniz Identity
+  (affine-simplex generalization of the British Flag squared-distance identity)
+  Open Question: british-flag-theorem-oq-01-oq-01-oq-02
+
+  The British Flag Theorem, and its parallelogram-defect sharpening
+  (`BritishFlagTheoremOQ01OQ01`), are the four-point instances of a single
+  weighted squared-distance identity attached to an arbitrary finite family of
+  points — the classical **Leibniz relation** (a.k.a. the generalized parallel
+  axis / Stewart relation).
+
+  Given a finite family of points `v i` in a real inner product space, real
+  weights `w i`, an observer `p`, and ANY reference point `g`, the weighted sum
+  of squared distances decomposes as
+
+    ∑ᵢ wᵢ ‖p − vᵢ‖²
+      = W ‖p − g‖²  −  2 ⟪p − g, (∑ᵢ wᵢ • vᵢ) − W • g⟫  +  ∑ᵢ wᵢ ‖vᵢ − g‖²,
+
+  where `W = ∑ᵢ wᵢ`.  This is `weighted_dist_sq_master`.
+
+  ## Corollaries
+
+  * `weighted_leibniz` — when `g` is the weighted barycenter
+    (`∑ᵢ wᵢ • vᵢ = W • g`), the cross term vanishes and we obtain the Leibniz
+    relation
+      ∑ᵢ wᵢ ‖p − vᵢ‖² = W ‖p − g‖² + ∑ᵢ wᵢ ‖vᵢ − g‖².
+    The `p`-dependence is isolated in the single term `W ‖p − g‖²`.
+
+  * `british_flag_independence` — when the weights are *balanced*
+    (`W = 0` and `∑ᵢ wᵢ • vᵢ = 0`), the weighted sum of squared distances is
+    **independent of the observer** `p`.  This is the abstract content of the
+    British Flag Theorem: the signed combination of squared distances is a
+    constant of the point configuration alone.
+
+  * `british_flag_rectangle` — recovers the classical four-point statement
+    ‖P−A‖² + ‖P−C‖² = ‖P−B‖² + ‖P−D‖² for a *rectangle* `A, B, C, D`
+    (parallelogram closure `C = B + D − A` together with the orthogonality
+    `⟪B − A, D − A⟫ = 0`).  This is the balanced-weight `(1, −1, 1, −1)` instance
+    of `british_flag_independence`: the signed sum of squared distances is
+    observer-independent, and orthogonality makes its constant value vanish.
+    Matches `BritishFlagTheoremOQ01OQ01.british_flag`.  (Note the orthogonality
+    hypothesis is genuinely needed: for a non-rectangular parallelogram the
+    observer-independent constant equals `2⟪B − A, D − A⟫ ≠ 0`.)
+
+  ## Proof Strategy
+
+  Translate each term through the reference point `g`:
+  `p − vᵢ = (p − g) − (vᵢ − g)`.  Expanding `‖p − vᵢ‖²` with `norm_sub_sq_real`
+  and summing over the (weighted) family, the cross terms collect into a single
+  inner product `⟪p − g, ∑ᵢ wᵢ • (vᵢ − g)⟫` via bilinearity (`inner_weighted_sum`).
+  Everything else is `Finset` sum bookkeeping.  No division is used, so the master
+  identity holds for arbitrary weights (including the balanced `W = 0` case).
+-/
+
+import Mathlib
+
+open scoped InnerProductSpace BigOperators
+
+namespace BritishFlagSimplexOQ010102
+
+variable {ι : Type*} {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- Bilinearity lemma: the weighted sum of the cross inner products
+    `⟪p − g, vᵢ − g⟫` collapses into a single inner product against the weighted
+    displacement `(∑ᵢ wᵢ • vᵢ) − (∑ᵢ wᵢ) • g`. -/
+theorem inner_weighted_sum (s : Finset ι) (w : ι → ℝ) (v : ι → V) (p g : V) :
+    ∑ i ∈ s, w i * ⟪p - g, v i - g⟫_ℝ
+      = ⟪p - g, (∑ i ∈ s, w i • v i) - (∑ i ∈ s, w i) • g⟫_ℝ := by
+  rw [inner_sub_right, inner_sum]
+  simp only [real_inner_smul_right, inner_sub_right, mul_sub]
+  rw [Finset.sum_sub_distrib, Finset.sum_mul]
+
+/-- **Weighted Leibniz master identity.** For a finite family of points `v i`
+    with real weights `w i`, an observer `p`, and any reference point `g`,
+
+      ∑ᵢ wᵢ ‖p − vᵢ‖²
+        = W ‖p − g‖² − 2⟪p − g, (∑ᵢ wᵢ • vᵢ) − W • g⟫ + ∑ᵢ wᵢ ‖vᵢ − g‖²
+
+    where `W = ∑ᵢ wᵢ`.  No hypothesis on the weights is required. -/
+theorem weighted_dist_sq_master (s : Finset ι) (w : ι → ℝ) (v : ι → V) (p g : V) :
+    ∑ i ∈ s, w i * ‖p - v i‖ ^ 2
+      = (∑ i ∈ s, w i) * ‖p - g‖ ^ 2
+        - 2 * ⟪p - g, (∑ i ∈ s, w i • v i) - (∑ i ∈ s, w i) • g⟫_ℝ
+        + ∑ i ∈ s, w i * ‖v i - g‖ ^ 2 := by
+  have key : ∀ i ∈ s, w i * ‖p - v i‖ ^ 2
+      = w i * ‖p - g‖ ^ 2 - 2 * (w i * ⟪p - g, v i - g⟫_ℝ) + w i * ‖v i - g‖ ^ 2 := by
+    intro i _
+    have h : p - v i = (p - g) - (v i - g) := by abel
+    rw [h, norm_sub_sq_real]
+    ring
+  rw [Finset.sum_congr rfl key, Finset.sum_add_distrib, Finset.sum_sub_distrib,
+    ← Finset.sum_mul, ← Finset.mul_sum, inner_weighted_sum]
+
+/-- **Leibniz relation.** If `g` is the weighted barycenter of the family
+    (`∑ᵢ wᵢ • vᵢ = (∑ᵢ wᵢ) • g`), the cross term vanishes:
+
+      ∑ᵢ wᵢ ‖p − vᵢ‖² = W ‖p − g‖² + ∑ᵢ wᵢ ‖vᵢ − g‖².
+
+    All dependence on the observer `p` is concentrated in `W ‖p − g‖²`. -/
+theorem weighted_leibniz (s : Finset ι) (w : ι → ℝ) (v : ι → V) (p g : V)
+    (hbary : ∑ i ∈ s, w i • v i = (∑ i ∈ s, w i) • g) :
+    ∑ i ∈ s, w i * ‖p - v i‖ ^ 2
+      = (∑ i ∈ s, w i) * ‖p - g‖ ^ 2 + ∑ i ∈ s, w i * ‖v i - g‖ ^ 2 := by
+  have h := weighted_dist_sq_master s w v p g
+  rw [hbary, sub_self, inner_zero_right, mul_zero, sub_zero] at h
+  exact h
+
+/-- **British Flag independence.** If the weights are *balanced* — the total
+    weight vanishes (`∑ᵢ wᵢ = 0`) and the weighted centroid vanishes
+    (`∑ᵢ wᵢ • vᵢ = 0`) — then the weighted sum of squared distances does not
+    depend on the observer: for any two points `p` and `q`,
+
+      ∑ᵢ wᵢ ‖p − vᵢ‖² = ∑ᵢ wᵢ ‖q − vᵢ‖².
+
+    This is the abstract British Flag Theorem: a balanced signed combination of
+    squared distances is a constant of the configuration. -/
+theorem british_flag_independence (s : Finset ι) (w : ι → ℝ) (v : ι → V) (p q : V)
+    (hW : ∑ i ∈ s, w i = 0) (hcent : ∑ i ∈ s, w i • v i = 0) :
+    ∑ i ∈ s, w i * ‖p - v i‖ ^ 2 = ∑ i ∈ s, w i * ‖q - v i‖ ^ 2 := by
+  have hval : ∀ r : V, ∑ i ∈ s, w i * ‖r - v i‖ ^ 2 = ∑ i ∈ s, w i * ‖v i‖ ^ 2 := by
+    intro r
+    have h := weighted_dist_sq_master s w v r 0
+    simp only [hW, zero_mul, smul_zero, sub_zero, hcent, inner_zero_right, mul_zero,
+      zero_add, sub_zero] at h
+    exact h
+  rw [hval p, hval q]
+
+/-- **British Flag Theorem (classical four-point / rectangle form).** For a
+    rectangle `A, B, C, D` — parallelogram closure `C = B + D − A` with the
+    orthogonality `⟪B − A, D − A⟫ = 0` — and any observer `P`, the sums of squared
+    distances to opposite vertices agree:
+
+      ‖P − A‖² + ‖P − C‖² = ‖P − B‖² + ‖P − D‖².
+
+    This is the balanced-weight `(1, −1, 1, −1)` instance of the general
+    `british_flag_independence`: the signed sum `‖P−A‖² − ‖P−B‖² + ‖P−C‖² − ‖P−D‖²`
+    is independent of `P`, and by the master identity its constant value is the
+    parallelogram defect `2⟪B − A, D − A⟫`, which vanishes exactly when the sides
+    are orthogonal.  Proved here directly through the same `norm_sub_sq_real`
+    expansion that underlies `weighted_dist_sq_master`. -/
+theorem british_flag_rectangle (P A B C D : V) (hpar : C = B + D - A)
+    (hperp : ⟪B - A, D - A⟫_ℝ = 0) :
+    ‖P - A‖ ^ 2 + ‖P - C‖ ^ 2 = ‖P - B‖ ^ 2 + ‖P - D‖ ^ 2 := by
+  -- Parallelogram defect: the signed sum equals `2⟪B−A, D−A⟫`, independent of `P`.
+  have pd : ‖P - A‖ ^ 2 + ‖P - (A + (B - A) + (D - A))‖ ^ 2
+        - ‖P - (A + (B - A))‖ ^ 2 - ‖P - (A + (D - A))‖ ^ 2
+      = 2 * ⟪B - A, D - A⟫_ℝ := by
+    have e1 : P - (A + (B - A) + (D - A)) = (P - A) - ((B - A) + (D - A)) := by abel
+    have e2 : P - (A + (B - A)) = (P - A) - (B - A) := by abel
+    have e3 : P - (A + (D - A)) = (P - A) - (D - A) := by abel
+    rw [e1, e2, e3, norm_sub_sq_real (P - A) ((B - A) + (D - A)),
+      norm_sub_sq_real (P - A) (B - A), norm_sub_sq_real (P - A) (D - A),
+      norm_add_sq_real (B - A) (D - A), inner_add_right]
+    ring
+  rw [hperp, mul_zero] at pd
+  have hB : A + (B - A) = B := by abel
+  have hD : A + (D - A) = D := by abel
+  rw [hB, hD] at pd
+  have hC : B + (D - A) = C := by rw [hpar]; abel
+  rw [hC] at pd
+  linarith
+
+end BritishFlagSimplexOQ010102

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,221 @@
+{
+  "id": "british-flag-theorem-oq-01-oq-01-oq-02",
+  "title": "The Weighted Leibniz Identity (Affine-Simplex Generalization of the British Flag Theorem)",
+  "slug": "british-flag-theorem-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's affine-simplex open question: replaces the four corners of the British Flag Theorem by an arbitrary finite family of weighted points and proves the master weighted squared-distance identity — the classical Leibniz relation. In a real inner product space, for weights wᵢ, points vᵢ, observer p, and any reference point g, ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖² where W = ∑ᵢ wᵢ. Two corollaries follow: the Leibniz relation (g = weighted barycenter kills the cross term) and observer-independence under balanced weights (W = 0, ∑ᵢ wᵢ•vᵢ = 0), which is the abstract content of the British Flag Theorem for arbitrary point configurations. The classical four-point rectangle form is recovered as the balanced (1,−1,1,−1) instance.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BritishFlagSimplexOQ010102.lean",
+    "tags": [
+      "geometry",
+      "inner-product-space",
+      "british-flag-theorem",
+      "leibniz-relation",
+      "stewart-relation",
+      "metric-identities",
+      "euclidean-geometry",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All five theorems are fully machine-checked in an arbitrary real inner product space (NormedAddCommGroup V with InnerProductSpace ℝ V), over an arbitrary index type with a Finset of summation. Proofs expand squared norms via Mathlib's norm_sub_sq_real / norm_add_sq_real, collapse weighted cross terms by bilinearity (inner_sum, real_inner_smul_right, inner_sub_right), and close by ring / linarith / Finset sum bookkeeping. Only the foundational axioms propext, Classical.choice, Quot.sound are used. No decide / native_decide.",
+    "dateAdded": "2026-07-02",
+    "lineCount": 163,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "weighted_dist_sq_master (PROVED, MAIN): the master weighted squared-distance identity ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖² for an arbitrary finite family, arbitrary real weights (no sign or normalization constraint), and arbitrary reference point g — the affine-simplex generalization the parent's open question asked for",
+      "inner_weighted_sum (PROVED): the bilinearity lemma collapsing ∑ᵢ wᵢ⟪p−g, vᵢ−g⟫ into the single inner product ⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ against the weighted displacement",
+      "weighted_leibniz (PROVED): the classical Leibniz relation — when g is the weighted barycenter (∑ᵢ wᵢ•vᵢ = W•g) the cross term vanishes and ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² + ∑ᵢ wᵢ‖vᵢ−g‖², isolating all p-dependence in W‖p−g‖²",
+      "british_flag_independence (PROVED): the abstract British Flag Theorem for n points — under balanced weights (W = 0 and ∑ᵢ wᵢ•vᵢ = 0) the weighted sum of squared distances is independent of the observer, so a balanced signed combination of squared distances is a constant of the configuration",
+      "british_flag_rectangle (PROVED): recovers the classical four-point statement ‖P−A‖²+‖P−C‖² = ‖P−B‖²+‖P−D‖² for a rectangle (C = B+D−A, ⟪B−A,D−A⟫ = 0) as the balanced (1,−1,1,−1) instance; the orthogonality hypothesis is genuinely required since the observer-independent constant equals the parallelogram defect 2⟪B−A,D−A⟫"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x − y‖² = ‖x‖² − 2⟪x,y⟫_ℝ + ‖y‖² — expands each ‖p − vᵢ‖² after translating through g",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_add_sq_real",
+        "description": "‖x + y‖² = ‖x‖² + 2⟪x,y⟫_ℝ + ‖y‖² — expands ‖(B−A)+(D−A)‖² in the rectangle recovery",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_sum",
+        "description": "⟪x, ∑ᵢ f i⟫ = ∑ᵢ ⟪x, f i⟫ — pushes the inner product through the weighted sum in inner_weighted_sum",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "real_inner_smul_right",
+        "description": "⟪x, r • y⟫_ℝ = r * ⟪x, y⟫_ℝ — pulls each scalar weight out of the inner product",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_sub_right",
+        "description": "⟪x, y − z⟫ = ⟪x,y⟫ − ⟪x,z⟫ — splits the displacement and the reference-point terms",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The British Flag Theorem (for a point P and rectangle ABCD, |PA|²+|PC|²=|PB|²+|PD|²) and its parallelogram-defect sharpening are the four-point shadows of a single classical identity attached to any weighted family of points: the Leibniz relation, also known as the generalized parallel-axis theorem or (in its collinear specialization) Stewart's relation. Leibniz's identity states that the weighted sum of squared distances from a variable point to a fixed system of point-masses splits into a term depending only on the distance to the barycenter plus a fixed 'moment of inertia about the barycenter'. This entry formalizes the full master identity — for an arbitrary finite family, arbitrary real weights, and an arbitrary reference point — and derives from it both the Leibniz barycenter relation and the observer-independence that is the true content of the British Flag Theorem, recovering the classical four-point rectangle statement as one balanced instance.",
+    "problemStatement": "**OQ-01-01-02 of british-flag-theorem**\n\nReplace the four corners of the British Flag Theorem by an affine simplex (an arbitrary finite family of weighted points) and prove the analogous weighted squared-distance identity, connecting to the Leibniz / Stewart relations.",
+    "text": "In a real inner product space, for weights wᵢ, points vᵢ, observer p, and any reference point g, ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖², where W = ∑ᵢ wᵢ.",
+    "proofStrategy": "Translate every term through the reference point g via p − vᵢ = (p − g) − (vᵢ − g), so norm_sub_sq_real expands ‖p − vᵢ‖² = ‖p−g‖² − 2⟪p−g, vᵢ−g⟫ + ‖vᵢ−g‖² with all inner products in canonical orientation. Multiply by wᵢ and sum: the constant term factors as W‖p−g‖² (Finset.sum_mul), the quadratic residues sum to ∑ᵢ wᵢ‖vᵢ−g‖², and the cross terms ∑ᵢ wᵢ⟪p−g, vᵢ−g⟫ collapse — by inner_sum, real_inner_smul_right, and inner_sub_right — into the single inner product ⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ (lemma inner_weighted_sum). No division is used anywhere, so the master identity holds for all weights including the balanced W = 0 case. The Leibniz corollary substitutes the barycenter condition ∑ᵢ wᵢ•vᵢ = W•g (cross term → ⟪·,0⟫ = 0); the independence corollary substitutes W = 0 and ∑ᵢ wᵢ•vᵢ = 0 and evaluates at g = 0 to expose that the total no longer depends on the observer; the rectangle corollary is the (1,−1,1,−1) instance closed by the same norm_sub_sq_real expansion and linarith.",
+    "keyInsights": [
+      "One master identity subsumes the whole British-Flag / parallelogram-defect family: the four-point results are the |ι| = 4 balanced instances of a statement about arbitrary weighted point systems. The generalization is genuine — it holds for any finite number of points, not just four.",
+      "Avoiding division is the decisive design choice. Stating the barycenter condition as ∑ᵢ wᵢ•vᵢ = W•g (rather than g = (1/W)∑ᵢ wᵢ•vᵢ) lets the SAME identity cover the balanced W = 0 case, which is exactly where the British Flag Theorem lives. A division-based statement would exclude precisely the interesting case.",
+      "The cross term is the crux, and bilinearity does all the work: ∑ᵢ wᵢ⟪p−g, vᵢ−g⟫ = ⟪p−g, ∑ᵢ wᵢ•(vᵢ−g)⟫ = ⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫. It vanishes either because the displacement (∑ᵢ wᵢ•vᵢ) − W•g is zero (barycenter → Leibniz) or because it is annihilated on both counts (balanced weights → British Flag).",
+      "Observer-independence is the abstract British Flag content: for balanced weights the map p ↦ ∑ᵢ wᵢ‖p−vᵢ‖² is constant. The classical equality ‖PA‖²+‖PC‖²=‖PB‖²+‖PD‖² is this constancy plus the vanishing of the constant, which for a parallelogram equals the defect 2⟪B−A, D−A⟫ and requires orthogonality.",
+      "Leibniz ⇒ physics: with wᵢ point-masses and g the center of mass, the relation is the parallel-axis theorem — the moment of inertia about any point p equals the moment about the center of mass plus (total mass)·|p−g|². The same one-line inner-product expansion proves the geometric and the mechanical statement simultaneously."
+    ],
+    "prerequisites": [
+      "Real inner product spaces and the squared-norm expansion lemmas norm_sub_sq_real / norm_add_sq_real",
+      "Bilinearity of the real inner product (inner_sum, real_inner_smul_right, inner_sub_right) and scalar–vector algebra (smul_sub, smul_zero)",
+      "Finite-sum manipulation over a Finset (Finset.sum_add_distrib, sum_sub_distrib, sum_mul, mul_sum)",
+      "The notion of a weighted barycenter / center of mass and the Leibniz (parallel-axis) relation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring stating the master identity, its three corollaries (Leibniz, British-Flag independence, classical rectangle), and the translate-through-g proof strategy. Imports Mathlib, opens the InnerProductSpace and BigOperators scopes, and fixes an arbitrary index type ι and real inner product space V.",
+      "mathContext": "Ambient structure `[NormedAddCommGroup V] [InnerProductSpace ℝ V]`; sums range over a `Finset ι`; `⟪x, y⟫_ℝ` is the real inner product."
+    },
+    {
+      "id": "sec-inner-lemma",
+      "title": "Bilinearity Lemma: Collapsing the Weighted Cross Sum",
+      "startLine": 63,
+      "endLine": 72,
+      "summary": "inner_weighted_sum: ∑ᵢ wᵢ⟪p−g, vᵢ−g⟫ = ⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫. Proof pushes the inner product through the sum (inner_sub_right, inner_sum), pulls out each scalar weight (real_inner_smul_right), and reconciles the two sides by Finset.sum_sub_distrib and Finset.sum_mul.",
+      "mathContext": "This is bilinearity of ⟪·,·⟫ applied to a weighted finite sum; it is the single place the family structure interacts with the inner product."
+    },
+    {
+      "id": "sec-master",
+      "title": "Master Theorem: The Weighted Squared-Distance Identity",
+      "startLine": 73,
+      "endLine": 92,
+      "summary": "weighted_dist_sq_master: the full identity for arbitrary weights and reference point. A pointwise lemma expands wᵢ‖p−vᵢ‖² via norm_sub_sq_real (after abel-rewriting p−vᵢ = (p−g)−(vᵢ−g)); summing and splitting with Finset.sum_add_distrib / sum_sub_distrib / sum_mul / mul_sum, then applying inner_weighted_sum, yields the result.",
+      "mathContext": "∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖². No hypothesis on the weights; no division."
+    },
+    {
+      "id": "sec-leibniz",
+      "title": "Corollary: The Leibniz Relation (Barycenter Form)",
+      "startLine": 94,
+      "endLine": 106,
+      "summary": "weighted_leibniz: with the barycenter condition ∑ᵢ wᵢ•vᵢ = W•g, the displacement vanishes (sub_self) and the cross term becomes ⟪p−g, 0⟫ = 0 (inner_zero_right), giving ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² + ∑ᵢ wᵢ‖vᵢ−g‖².",
+      "mathContext": "The classical Leibniz / parallel-axis relation: all observer dependence is concentrated in the single term W‖p−g‖²."
+    },
+    {
+      "id": "sec-independence",
+      "title": "Corollary: British-Flag Observer-Independence (n points)",
+      "startLine": 108,
+      "endLine": 126,
+      "summary": "british_flag_independence: for balanced weights (W = 0, ∑ᵢ wᵢ•vᵢ = 0), evaluating the master identity at g = 0 shows ∑ᵢ wᵢ‖r−vᵢ‖² = ∑ᵢ wᵢ‖vᵢ‖² for every r, hence the value is the same for any two observers p, q.",
+      "mathContext": "The abstract British Flag Theorem: a balanced signed combination of squared distances is a constant of the point configuration alone, independent of the observer."
+    },
+    {
+      "id": "sec-rectangle",
+      "title": "Corollary: Classical Four-Point Rectangle Form",
+      "startLine": 128,
+      "endLine": 162,
+      "summary": "british_flag_rectangle: the balanced (1,−1,1,−1) instance. A parallelogram-defect computation (norm_sub_sq_real / norm_add_sq_real / inner_add_right, ring) shows the signed sum equals 2⟪B−A,D−A⟫; the orthogonality hypothesis makes it zero, giving ‖P−A‖²+‖P−C‖² = ‖P−B‖²+‖P−D‖² (linarith).",
+      "mathContext": "Recovers the named British Flag Theorem; the orthogonality hypothesis is essential because the observer-independent constant is the defect 2⟪B−A,D−A⟫."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the Parallelogram Defect Identity (four-point form). This entry generalizes the four corners to an arbitrary weighted finite family, proving the master Leibniz identity of which the parallelogram defect is the (1,−1,1,−1) instance — directly answering the parent's affine-simplex / Leibniz–Stewart open question."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the British Flag Theorem in the coordinate plane. The observer-independence corollary here is its abstract content for arbitrary point systems."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified in an arbitrary real inner product space: the weighted squared-distance master identity ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ) − W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖² holds for any finite family, any real weights, and any reference point. Its corollaries are the Leibniz barycenter relation, the n-point British-Flag observer-independence, and the classical four-point rectangle theorem. Zero sorries, zero extra axioms.",
+    "implications": "**Unification**: the British Flag Theorem, its parallelogram-defect sharpening, the Leibniz relation, and the parallel-axis theorem are all instances or corollaries of one division-free identity, now formalized in full generality.\\n\\n**Beyond four points**: observer-independence of a balanced signed squared-distance sum holds for arbitrary finite configurations, not just rectangles — the genuine affine-simplex generalization requested by the parent.\\n\\n**Dimension- and index-free**: phrased over an abstract inner product space and an arbitrary index type, the identity holds verbatim in ℝ², ℝ³, and any (pre-)Hilbert space, for any number of weighted points.",
+    "openQuestions": [
+      "Stewart's theorem as a named instance: specialize weighted_leibniz to three collinear points (a cevian configuration) and derive Stewart's relation man + dad = bmb + cnc in closed form, making the collinear specialization explicit.",
+      "Sharp converse: if ∑ᵢ wᵢ‖p−vᵢ‖² is independent of the observer p for a fixed weighted family, must the weights be balanced (W = 0 and ∑ᵢ wᵢ•vᵢ = 0)? Characterize exactly the families whose signed squared-distance sum is a configuration constant."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "weighted_dist_sq_master",
+      "type": "core",
+      "description": "The master weighted squared-distance (Leibniz) identity for an arbitrary finite family, arbitrary real weights, and arbitrary reference point g.",
+      "leanType": "(s : Finset ι) → (w : ι → ℝ) → (v : ι → V) → (p g : V) → ∑ i ∈ s, w i * ‖p - v i‖^2 = (∑ i ∈ s, w i) * ‖p - g‖^2 - 2 * ⟪p - g, (∑ i ∈ s, w i • v i) - (∑ i ∈ s, w i) • g⟫_ℝ + ∑ i ∈ s, w i * ‖v i - g‖^2"
+    },
+    {
+      "name": "weighted_leibniz",
+      "type": "core",
+      "description": "The Leibniz relation: when g is the weighted barycenter, ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² + ∑ᵢ wᵢ‖vᵢ−g‖².",
+      "leanType": "(s : Finset ι) → (w : ι → ℝ) → (v : ι → V) → (p g : V) → (∑ i ∈ s, w i • v i = (∑ i ∈ s, w i) • g) → ∑ i ∈ s, w i * ‖p - v i‖^2 = (∑ i ∈ s, w i) * ‖p - g‖^2 + ∑ i ∈ s, w i * ‖v i - g‖^2"
+    },
+    {
+      "name": "british_flag_independence",
+      "type": "core",
+      "description": "Under balanced weights (W = 0 and ∑ᵢ wᵢ•vᵢ = 0) the weighted sum of squared distances is independent of the observer — the abstract British Flag Theorem for n points.",
+      "leanType": "(s : Finset ι) → (w : ι → ℝ) → (v : ι → V) → (p q : V) → (∑ i ∈ s, w i = 0) → (∑ i ∈ s, w i • v i = 0) → ∑ i ∈ s, w i * ‖p - v i‖^2 = ∑ i ∈ s, w i * ‖q - v i‖^2"
+    },
+    {
+      "name": "british_flag_rectangle",
+      "type": "corollary",
+      "description": "Classical four-point British Flag Theorem, recovered as the balanced (1,−1,1,−1) instance; needs orthogonality ⟪B−A,D−A⟫ = 0.",
+      "leanType": "(P A B C D : V) → C = B + D - A → ⟪B - A, D - A⟫_ℝ = 0 → ‖P - A‖^2 + ‖P - C‖^2 = ‖P - B‖^2 + ‖P - D‖^2"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace (scoped)",
+      "BigOperators (scoped)"
+    ],
+    "namespace": "BritishFlagSimplexOQ010102",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/BritishFlagSimplexOQ010102.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Gottfried Wilhelm Leibniz",
+      "title": "Leibniz's identity for the barycenter (moment-of-inertia decomposition)",
+      "year": "1600s",
+      "venue": "classical",
+      "note": "The weighted squared-distance identity ∑ᵢ wᵢ|p−vᵢ|² = W|p−g|² + ∑ᵢ wᵢ|vᵢ−g|² about the barycenter g; formalized here as weighted_leibniz and generalized to arbitrary reference points and balanced weights."
+    },
+    {
+      "authors": "Matthew Stewart",
+      "title": "Some General Theorems of Considerable Use in the Higher Parts of Mathematics",
+      "year": "1746",
+      "venue": "Edinburgh",
+      "note": "Stewart's relation for a cevian is the three-collinear-point specialization of the Leibniz identity formalized here."
+    },
+    {
+      "authors": "Martin Gardner",
+      "title": "Mathematical Games",
+      "year": "1970",
+      "venue": "Scientific American",
+      "note": "Popularized the British Flag Theorem; the classical rectangle identity is the balanced (1,−1,1,−1) instance (british_flag_rectangle) of the master identity."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent's affine-simplex open question: **replaces the four corners of the British Flag Theorem by an arbitrary finite family of weighted points** and proves the master weighted squared-distance identity — the classical **Leibniz relation** — in any real inner product space.

Problem: `british-flag-theorem-oq-01-oq-01-oq-02` (the parent `british-flag-theorem-oq-01-oq-01` lists this verbatim as its open question #2: *"replace the four corners by an affine simplex … connecting to the Leibniz / Stewart relations"*).

## Main result

For weights `wᵢ`, points `vᵢ`, observer `p`, and **any** reference point `g` (with `W = ∑ᵢ wᵢ`):

```
∑ᵢ wᵢ‖p − vᵢ‖²  =  W‖p − g‖²  −  2⟪p − g, (∑ᵢ wᵢ•vᵢ) − W•g⟫  +  ∑ᵢ wᵢ‖vᵢ − g‖²
```

No constraint on the weights, **no division** — so the identity covers the balanced `W = 0` case where the British Flag Theorem lives.

## Theorems (all proved, 0 sorries)

| Theorem | Statement |
|---|---|
| `weighted_dist_sq_master` | the master identity above |
| `inner_weighted_sum` | bilinearity lemma collapsing `∑ᵢ wᵢ⟪p−g, vᵢ−g⟫` into one inner product |
| `weighted_leibniz` | barycenter form (`∑ᵢ wᵢ•vᵢ = W•g` ⟹ cross term vanishes) — the Leibniz / parallel-axis relation |
| `british_flag_independence` | balanced weights ⟹ `∑ᵢ wᵢ‖p−vᵢ‖²` is **independent of the observer** — abstract British Flag for `n` points |
| `british_flag_rectangle` | classical 4-point `‖PA‖²+‖PC‖² = ‖PB‖²+‖PD‖²` as the balanced `(1,−1,1,−1)` instance |

The orthogonality hypothesis in `british_flag_rectangle` is genuinely needed: for a non-rectangular parallelogram the observer-independent constant equals the defect `2⟪B−A, D−A⟫ ≠ 0`.

## Verification

- **Docker-built** against Mathlib v4.26.0 (`./proofs/scripts/docker-build.sh Proofs.BritishFlagSimplexOQ010102`) — build succeeded.
- 5 theorems, 163 lines, **0 sorries, 0 `axiom` declarations, no structure-encoded assumptions**, no `decide`/`native_decide`. Only foundational `propext`/`Classical.choice`/`Quot.sound`.
- `status: verified`, `badge: original`, `axiomCount: 0`.

## Files

- `proofs/Proofs/BritishFlagSimplexOQ010102.lean`
- `src/data/proofs/british-flag-theorem-oq-01-oq-01-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)