### PR TITLE
research(abel-ruffini-oq-03-oq-01): prove Case A strict-decrease engine for Aₙ-simplicity crux [WIP, 1 sorry]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean
@@ -40,10 +40,20 @@
   * `exists_min_support_ne_one` — **PROVED (0 sorry).** A nontrivial (in
     particular, any nontrivial normal) subgroup contains a nonidentity element of
     minimal support cardinality.
+  * `support_commutator_subset` — **PROVED (0 sorry).** If `τ.support ⊆ σ.support`
+    then the commutator `τ σ τ⁻¹ σ⁻¹` is supported within `σ.support`.
+  * `exists_smaller_commutator_of_five_points` — **PROVED (0 sorry).** The
+    strict-support-decrease *engine* for the cycle-of-length-`≥3` case: from five
+    distinct points `a,b,c,d,e` (with `b,c,d,e` moved and `σ a = b`, `σ b = c`),
+    the commutator with the 3-cycle `(c d e)` is a nonidentity element of `H` of
+    strictly smaller support.  This discharges the hard *quantitative* half of the
+    `#support ≥ 4` branch; what remains for the crux is the purely *combinatorial*
+    extraction of such a configuration (Case A) and the involution case (Case B).
   * `isThreeCycle_of_min_support` — the **isolated crux**, and now the *only*
     `sorry`.  Its `3 ≤ #support` and `#support = 3 ⇒ 3-cycle` branches are
-    **proved in-line**; the single remaining `sorry` is the classical
-    strict-support-decrease commutator step for `#support ≥ 4`.
+    **proved in-line**; the single remaining `sorry` is the `#support ≥ 4` branch,
+    now reduced (given the engine above) to producing the five-point configuration
+    or handling the disjoint-transposition (involution) case.
   * `exists_mem_isThreeCycle_of_normal` — **PROVED (0 sorry) modulo the crux**:
     assembled from `exists_min_support_ne_one` and `isThreeCycle_of_min_support`.
   * `isSimpleGroup_alternating` — the unconditional simplicity theorem for all
@@ -204,6 +214,106 @@ theorem support_commutator_subset {σ τ : Perm α} (hτσ : τ.support ⊆ σ.s
     exact hmap x hx
   · exact hy2
 
+/-- **Case A engine (0 sorry).** The strict-support-decrease step of Jordan's
+argument, in the exact form the crux consumes for a permutation with a cycle of
+length `≥ 3`.  Given five *distinct* points `a, b, c, d, e` with `b, c, d, e` all
+moved by `σ` and `σ a = b`, `σ b = c` (so `a, b, c` lie on a common cycle of length
+`≥ 3`), the commutator of `σ` with the 3-cycle `τ = (c d e)` is a nonidentity
+element of `H` whose support is *strictly smaller* than that of `σ`.
+
+Mechanism: `ρ = τ σ τ⁻¹ σ⁻¹ ∈ H` by normality (`commutator_mem_of_normal`); it is
+supported inside `σ.support` (`support_commutator_subset`, as
+`τ.support ⊆ {c,d,e} ⊆ σ.support`); `ρ c = e ≠ c` so `ρ ≠ 1`; and `ρ b = b` while
+`b ∈ σ.support`, so the support drops by at least one point. -/
+theorem exists_smaller_commutator_of_five_points
+    {H : Subgroup (alternatingGroup α)} (hHn : H.Normal)
+    {σ : alternatingGroup α} (hσH : σ ∈ H)
+    {a b c d e : α}
+    (_hab : a ≠ b) (hac : a ≠ c) (had : a ≠ d) (hae : a ≠ e)
+    (hbc : b ≠ c) (hbd : b ≠ d) (hbe : b ≠ e)
+    (hcd : c ≠ d) (hce : c ≠ e) (hde : d ≠ e)
+    (hbsupp : b ∈ (σ : Perm α).support)
+    (hc : c ∈ (σ : Perm α).support) (hd : d ∈ (σ : Perm α).support)
+    (he : e ∈ (σ : Perm α).support)
+    (hσab : (σ : Perm α) a = b) (hσbc : (σ : Perm α) b = c) :
+    ∃ ρ : alternatingGroup α, ρ ∈ H ∧ ρ ≠ 1 ∧
+      (ρ : Perm α).support.card < (σ : Perm α).support.card := by
+  classical
+  set sp : Perm α := (σ : Perm α) with hsp
+  -- The 3-cycle τ = (c d e), as an element of the alternating group.
+  set τp : Perm α := Equiv.swap c d * Equiv.swap c e with hτp
+  have hτ3 : τp.IsThreeCycle := isThreeCycle_swap_mul_swap_same hcd hce hde
+  have hτmem : τp ∈ alternatingGroup α := hτ3.mem_alternatingGroup
+  set τ : alternatingGroup α := ⟨τp, hτmem⟩ with hτ
+  -- `τ.support ⊆ {c, d, e}`.
+  have hτsub : τp.support ⊆ ({c, d, e} : Finset α) := by
+    intro x hx
+    rw [hτp] at hx
+    have hx2 := support_mul_le (Equiv.swap c d) (Equiv.swap c e) hx
+    rw [Finset.sup_eq_union, support_swap hcd, support_swap hce] at hx2
+    simp only [Finset.mem_union, Finset.mem_insert, Finset.mem_singleton] at hx2 ⊢
+    tauto
+  have hcde_sub : ({c, d, e} : Finset α) ⊆ sp.support := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl
+    · exact hc
+    · exact hd
+    · exact he
+  have hτσ : τp.support ⊆ sp.support := hτsub.trans hcde_sub
+  -- `a, b ∉ τ.support`.
+  have hbτ : b ∉ τp.support := by
+    intro h; have := hτsub h
+    simp only [Finset.mem_insert, Finset.mem_singleton] at this
+    rcases this with h | h | h
+    · exact hbc h
+    · exact hbd h
+    · exact hbe h
+  have haτ : a ∉ τp.support := by
+    intro h; have := hτsub h
+    simp only [Finset.mem_insert, Finset.mem_singleton] at this
+    rcases this with h | h | h
+    · exact hac h
+    · exact had h
+    · exact hae h
+  -- Basic pointwise values of `τ` and `τ⁻¹`.
+  have hτpb : τp b = b := notMem_support.mp hbτ
+  have hτpinvb : τp⁻¹ b = b := notMem_support.mp (by rw [support_inv]; exact hbτ)
+  have hτpinva : τp⁻¹ a = a := notMem_support.mp (by rw [support_inv]; exact haτ)
+  have hτpc : τp c = e := by
+    rw [hτp, Equiv.Perm.mul_apply, Equiv.swap_apply_left,
+      Equiv.swap_apply_of_ne_of_ne (Ne.symm hce) (Ne.symm hde)]
+  -- `sp⁻¹ c = b` and `sp⁻¹ b = a` from the cycle relations.
+  have hspc : sp⁻¹ c = b := by rw [← hσbc]; exact Equiv.symm_apply_apply _ _
+  have hspb : sp⁻¹ b = a := by rw [← hσab]; exact Equiv.symm_apply_apply _ _
+  -- The commutator element and its underlying permutation.
+  set ρ : alternatingGroup α := τ * σ * τ⁻¹ * σ⁻¹ with hρ
+  have hρcoe : (ρ : Perm α) = τp * sp * τp⁻¹ * sp⁻¹ := by
+    rw [hρ]
+    simp only [Subgroup.coe_mul, Subgroup.coe_inv, hτ, hsp]
+  refine ⟨ρ, ?_, ?_, ?_⟩
+  · rw [hρ]; exact commutator_mem_of_normal hHn hσH τ
+  · -- `ρ ≠ 1`, since its underlying permutation sends `c` to `e ≠ c`.
+    have hρc : (ρ : Perm α) c = e := by
+      rw [hρcoe]
+      simp only [Equiv.Perm.mul_apply]
+      rw [hspc, hτpinvb, hσbc, hτpc]
+    intro hρ1
+    have hc1 : (ρ : Perm α) c = c := by rw [hρ1, Subgroup.coe_one, Equiv.Perm.one_apply]
+    rw [hρc] at hc1
+    exact hce hc1.symm
+  · -- Support strictly smaller: `ρ` fixes `b ∈ σ.support` but is supported in it.
+    have hsub : (ρ : Perm α).support ⊆ sp.support := by
+      rw [hρcoe]; exact support_commutator_subset hτσ
+    have hρb : (ρ : Perm α) b = b := by
+      rw [hρcoe]
+      simp only [Equiv.Perm.mul_apply]
+      rw [hspb, hτpinva, hσab, hτpb]
+    have hbnotρ : b ∉ (ρ : Perm α).support := notMem_support.mpr hρb
+    have hss : (ρ : Perm α).support ⊂ sp.support :=
+      (Finset.ssubset_iff_of_subset hsub).mpr ⟨b, hbsupp, hbnotρ⟩
+    exact Finset.card_lt_card hss
+
 /-! ### The classical combinatorial crux (the sole remaining `sorry`) -/
 
 /-- **Crux (KNOWN result; single remaining `sorry`).** A nonidentity element `σ`
@@ -211,8 +321,12 @@ of a normal subgroup `H ⊴ Aₙ` (`n ≥ 5`) whose support is *minimal* among t
 nonidentity elements of `H` is a 3-cycle.
 
 The `3 ≤ #support` and `#support = 3 ⇒ 3-cycle` branches are discharged here; the
-remaining `sorry` is exactly the classical strict-support-decrease commutator step
-handling `#support ≥ 4` (see the file header for the proof plan). -/
+remaining `sorry` is the `#support ≥ 4` branch.  Its quantitative core — that a
+suitable commutator strictly shrinks the support — is now the **proved** lemma
+`exists_smaller_commutator_of_five_points`; the residual `sorry` is the
+combinatorial extraction of a five-point configuration `a,b,c,d,e` with `σ a = b`,
+`σ b = c` (available whenever `σ² ≠ 1` and `#support ≥ 5`) together with the
+disjoint-transposition (`σ² = 1`) case. -/
 theorem isThreeCycle_of_min_support
     (h5 : 5 ≤ Fintype.card α)
     {H : Subgroup (alternatingGroup α)} (hHn : H.Normal)

--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
@@ -123,3 +123,53 @@ Insights accumulated during research on this problem.
   focused session.
 - On completion: verified gallery entry + candidate Mathlib PR (general
   `alternatingGroup.isSimpleGroup`).
+
+## Session 2026-07-03 (Session 3, researcher-16) — Prove the Case A strict-decrease engine
+
+**Mode**: DEEP DIVE (continues #33855 isolate → #33912 four-lemma decomposition)
+**Outcome**: progress (1 new 0-sorry lemma; still 1 crux sorry) · **PR**: (this session)
+
+### What I did
+- Aristotle MCP still down (`Resource not found`/404) — manual formalization only.
+  Elaborated via `lake env lean <abs worktree path>` against main's prebuilt
+  Mathlib oleans (durable worktree `/Users/rwalters/lg-r16-abelruffini`; the
+  `.loom/worktrees/researcher-16` copy was reaped mid-session, as usual).
+- Proved **`exists_smaller_commutator_of_five_points`** (0 sorry): the quantitative
+  *engine* of the `#support ≥ 4` crux branch for the cycle-of-length-≥3 case.
+  Given five distinct points `a,b,c,d,e` with `b,c,d,e ∈ supp σ`, `σ a = b`,
+  `σ b = c`, the commutator `ρ = τ σ τ⁻¹ σ⁻¹` with the 3-cycle
+  `τ = swap c d * swap c e = (c d e)` is a nonidentity element of `H` with
+  `#supp ρ < #supp σ`.
+- Re-elaborated whole file: EXIT 0, exactly one `sorry` (crux `#support ≥ 4`
+  branch), 10 theorems.
+
+### Key findings (the exact working construction)
+- Take `τ = swap c d * swap c e` (`isThreeCycle_swap_mul_swap_same hcd hce hde`
+  gives `IsThreeCycle`, hence `mem_alternatingGroup`). `τ.support ⊆ {c,d,e}` via
+  `support_mul_le` + `support_swap` (no need for the *exact* support set).
+- **ρ ≠ 1**: compute `ρ c = τ(σ(τ⁻¹(σ⁻¹ c))) = τ(σ(τ⁻¹ b)) = τ(σ b) = τ c = e ≠ c`.
+  Uses `σ⁻¹ c = b` (from `σ b = c`, `Equiv.symm_apply_apply`), `τ⁻¹ b = b` and
+  `τ b = b` (as `b ∉ τ.support`), `τ c = e` (`mul_apply`+`swap_apply_left`+
+  `swap_apply_of_ne_of_ne`).
+- **strict decrease**: `ρ b = τ(σ(τ⁻¹(σ⁻¹ b))) = τ(σ(τ⁻¹ a)) = τ(σ a) = τ b = b`,
+  so `b ∉ ρ.support`; with `ρ.support ⊆ σ.support` (the already-proved
+  `support_commutator_subset`) and `b ∈ σ.support` this gives a *strict* subset
+  (`Finset.ssubset_iff_of_subset` + `Finset.card_lt_card`).
+- Note: the a,b,c hypothesis `σ a = b, σ b = c` are exactly what `σ² ≠ 1` yields
+  (set `a` with `σ² a ≠ a`, `b = σ a`, `c = σ² a`; all three are moved & distinct).
+- `Equiv.Perm.inv_apply_self` is DEPRECATED → use `Equiv.symm_apply_apply` (works
+  on `sp⁻¹` by defeq `sp⁻¹ = sp.symm`).
+
+### What remains for the crux (`#support ≥ 4` branch)
+1. **Case A extraction**: when `σ² ≠ 1`, produce `a,b,c` (above) plus two more
+   moved points `d,e` — needs `#supp σ ≥ 5`. Ruling out `#supp σ = 4` in this case
+   needs the parity fact "even + `σ² ≠ 1` ⇒ not a single 4-cycle" (cycleType).
+   Then `exists_smaller_commutator_of_five_points` closes it against minimality.
+2. **Case B (`σ² = 1`, disjoint transpositions, ≥2 of them)**: needs its OWN engine
+   — `σ = (a b)(c d)…`, pick a 5th point `e` (n ≥ 5), `τ = (c d e)`; then
+   `[τ,σ]` is a 3-cycle on `{c,d,e}` (support 3 < 4), NOT ⊆ supp σ. A second
+   engine lemma with a general `#supp([τ,σ]) < #supp σ` count is required.
+
+### Blockers (environment, not mathematical)
+- Aristotle MCP down all session (404). Docker build not attempted (single-file
+  `lake env lean` sufficed and is faster with warm oleans).


### PR DESCRIPTION
## Summary

Incremental progress on **general-$n$ simplicity of the alternating group** $A_n$ ($n \ge 5$), the group-theoretic heart of Abel–Ruffini. Mathlib proves simplicity only for `Fin 5` (`alternatingGroup.isSimpleGroup_five`); this line of work (#33855 → #33912 → this PR) builds an unconditional proof for all $n \ge 5$, with the whole theorem now resting on **one** remaining `sorry`.

## What this PR adds

Proves **`exists_smaller_commutator_of_five_points`** (0 sorry) — the quantitative *engine* of the `#support ≥ 4` branch of the crux (Jordan's minimal-support / commutator argument):

> Given five distinct points $a,b,c,d,e$ with $b,c,d,e$ moved by $\sigma$ and $\sigma a = b$, $\sigma b = c$, the commutator $\rho = \tau\sigma\tau^{-1}\sigma^{-1}$ with the 3-cycle $\tau=(c\,d\,e)$ is a nonidentity element of $H$ with $\#\operatorname{supp}\rho < \#\operatorname{supp}\sigma$.

Mechanism (fully formalized):
- $\rho \in H$ by normality (`commutator_mem_of_normal`);
- $\rho$ is supported inside $\operatorname{supp}\sigma$ (`support_commutator_subset`, since $\operatorname{supp}\tau \subseteq \{c,d,e\} \subseteq \operatorname{supp}\sigma$);
- $\rho(c) = e \ne c$, so $\rho \ne 1$;
- $\rho(b) = b$ while $b \in \operatorname{supp}\sigma$, so the support strictly drops.

This discharges the hard *quantitative* half of Case A; the crux's single `sorry` is now reduced to the purely *combinatorial* extraction of the five-point configuration (available whenever $\sigma^2 \ne 1$ and $\#\operatorname{supp}\sigma \ge 5$) plus the disjoint-transposition ($\sigma^2 = 1$) case.

## Status
- Elaborates via `lake env lean` (against Mathlib v4.26.0 oleans): **EXIT 0**, exactly **one** `sorry` (crux `#support ≥ 4` branch), **10 theorems**.
- Not a verified gallery entry yet — WIP toward `isSimpleGroup_alternating` for all $n \ge 5$.
- Aristotle MCP was unavailable this session (404); proof done manually.

## Next steps
1. Case A extraction: from $\sigma^2 \ne 1$ get $a,b,c$; two more moved points need $\#\operatorname{supp}\sigma \ge 5$ (cycleType parity to rule out a 4-cycle).
2. Case B ($\sigma^2 = 1$): a second engine for the disjoint-transposition case ($[\tau,\sigma]$ becomes a 3-cycle of support 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)