### PR TITLE
Enrich Wilson trichotomy (n−1)! mod n: give the headline result its own annotation (4→5)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01/annotations.json
@@ -36,15 +36,27 @@
     "prerequisites": ["the mul_dvd_factorial engine", "minFac and its divisibility"]
   },
   {
+    "id": "wilson-tri-ann-prime",
+    "proofId": "wilsons-theorem-oq-05-oq-01",
+    "range": { "startLine": 124, "endLine": 133 },
+    "type": "proof-step",
+    "title": "The Prime Branch, Transported from Mathlib's ZMod Wilson",
+    "content": "factorial_pred_mod_of_prime re-derives the classical prime side self-contained: for prime n, (n−1)! % n = n−1. The bridge is the cast identity ((n−1 : ℕ) : ZMod n) = −1 (assembled from Nat.cast_sub, ZMod.natCast_self, zero_sub), which turns Mathlib's ZMod-valued Wilson biconditional Nat.prime_iff_fac_equiv_neg_one into a natural-number congruence (n−1)! ≡ n−1 [MOD n]. Because n−1 < n, Nat.mod_eq_of_lt collapses that congruence to the exact remainder n−1. This keeps the entry independent of the parent wilsons-theorem-oq-05 while still reusing Mathlib's hard direction of Wilson.",
+    "mathContext": "For prime $n$: $((n-1:\\mathbb{N}):\\mathbb{Z}/n)=-1$, so $(n-1)!\\equiv -1\\equiv n-1 \\pmod n$; and $n-1<n$ gives $(n-1)!\\bmod n = n-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Wilson's theorem (ZMod form)", "Nat.prime_iff_fac_equiv_neg_one", "cast (n−1) ≡ −1", "Nat.ModEq / Nat.mod_eq_of_lt"],
+    "prerequisites": ["Mathlib's ZMod Wilson statement", "casting ℕ → ZMod n"]
+  },
+  {
     "id": "wilson-tri-ann-trichotomy",
     "proofId": "wilsons-theorem-oq-05-oq-01",
-    "range": { "startLine": 124, "endLine": 169 },
+    "range": { "startLine": 134, "endLine": 169 },
     "type": "insight",
-    "title": "The Prime Branch and the Assembled Trichotomy",
-    "content": "factorial_pred_mod_of_prime transports Mathlib's ZMod Wilson statement to (n−1)! % n = n−1, via the cast ((n−1 : ℕ) : ZMod n) = −1. factorial_pred_mod then bundles all three cases into the single equation (n−1)! % n = if n.Prime then n−1 else if n = 4 then 2 else 0 (the n=4 value by kernel decide — keeping the file axiom-free). factorial_pred_mod_eq_zero_iff records the sharp characterization that residue 0 detects 'composite and not 4' exactly, and four_factorial_pred_mod notes (4−1)! % 4 = 2 explicitly.",
-    "mathContext": "Prime: $(n-1)!\\equiv -1 \\equiv n-1$. Bundled: $(n-1)!\\bmod n = \\text{if prime } n-1\\text{ else if }n=4\\ 2\\text{ else }0$; residue $0 \\iff$ composite and $\\neq 4$.",
+    "title": "The Assembled Trichotomy and Its Sharp Corollaries",
+    "content": "factorial_pred_mod is the headline result: it bundles all three cases into the single closed-form equation (n−1)! % n = if n.Prime then n−1 else if n = 4 then 2 else 0, dispatching by by_cases on primality and then on n = 4. The n=4 value closes by ordinary kernel `decide` — not native_decide — so the file stays axiom-free (no Lean.ofReduceBool). Two corollaries sharpen it: factorial_pred_mod_eq_zero_iff proves residue 0 detects 'composite and not 4' exactly (a prime gives n−1 ≥ 1 and n=4 gives 2, both nonzero), and four_factorial_pred_mod records the lone exception (4−1)! % 4 = 2 — 4 = 2² is too small for 2 and 2·2 to be distinct factors below 4, which is precisely why the composite argument skips it.",
+    "mathContext": "Bundled: $(n-1)!\\bmod n = \\begin{cases} n-1 & n\\text{ prime}\\\\ 2 & n=4\\\\ 0 & \\text{else}\\end{cases}$; and $(n-1)!\\bmod n = 0 \\iff (n\\text{ composite} \\wedge n\\neq 4)$.",
     "significance": "key",
-    "relatedConcepts": ["Wilson's theorem (ZMod form)", "cast (n−1)≡−1", "kernel decide", "iff characterization"],
-    "prerequisites": ["the composite case", "Mathlib's ZMod Wilson statement"]
+    "relatedConcepts": ["closed-form trichotomy", "kernel decide (axiom-free)", "residue-0 iff characterization", "the n=4 exception"],
+    "prerequisites": ["the prime branch", "the composite case"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01` (annotations.json only).

The final annotation covered lines 124–169, bundling **four** distinct theorems — including the headline result `factorial_pred_mod` (the complete closed-form trichotomy) — into one block. This split gives the main result appropriate prominence and lifts coverage from 4 to 5 annotations, all with mathContext / relatedConcepts / significance and continuous 1–169 coverage:

- **`wilson-tri-ann-prime` (124–133)** — the prime branch `factorial_pred_mod_of_prime`, transported from Mathlib's ZMod Wilson biconditional via the cast ((n−1:ℕ):ZMod n) = −1 and `Nat.mod_eq_of_lt`.
- **`wilson-tri-ann-trichotomy` (134–169)** — the assembled trichotomy (n−1)! % n = if n.Prime then n−1 else if n=4 then 2 else 0, plus the residue-0-iff-composite-and-≠4 corollary and the explicit n=4 exception.

Axiom integrity noted inline: the n=4 value uses ordinary kernel `decide` (not `native_decide`), so the entry remains genuinely axiom-free (no `Lean.ofReduceBool`) — consistent with meta `axiomCount: 0`. No meta.json changes. JSON validated.