### PR TITLE
Enrich HH-5 origami constructive core (angle-trisection-oq-05-oq-04-incomplete-01)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
@@ -74,6 +74,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Module docstring stating HH-5 (given distinct P₁, P₂ and a line ℓ, fold through P₂ landing P₁ on ℓ), the reflection-fixes-P₂ ⇒ circle argument, the isolation of the irrational circle-line witness from the rational fold, and the list of results (reflectAcross_distSq_fixed, perpBisector_contains_of_equidistSq, hh5_core/hh5_core_exact, hh5_solvable_iff). Imports Mathlib, opens Real, namespace AngleTrisectionOQ05OQ04Incomplete01.",
+      "mathContext": "HH-5 is solvable iff the circle centred at $P_2$ through $P_1$ meets $\\ell$; the landing point $P_1'$ satisfies $|P_1'-P_2| = |P_1-P_2|$, a $\\mathbb{R}\\sqrt{\\ }$ step, while the fold itself (the perpendicular bisector of $P_1P_1'$) is rational."
+    },
+    {
       "id": "planar-primitives",
       "title": "Planar Primitives (copied from parent)",
       "startLine": 66,


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-05-oq-04-incomplete-01`.

The 8 annotations and 2 sections both began at the code (lines 66/82), leaving the entire module docstring (1–59) — which frames HH-5, the reflection-fixes-P₂ ⇒ circle argument, and the rational/irrational split — with **no annotation and no section**.

- **Annotations (8 → 9)**: added a `HH-5 and the Rational/Irrational Split` module-overview annotation (1–59) covering the docstring.
- **Sections (2 → 3)**: added an `Overview and Setup` header section (1–65) with mathContext.

Verified the status is accurate: the sole irrational content (the circle-line intersection witness) is kept as a **theorem hypothesis**, not an axiom or structure-encoded assumption, so `verified` / 0-axiom is honest; the `incomplete` in the slug refers to the HH programme, not the Lean file (0 sorries, 0 axioms).

No content removed; meta.json 14.9 KB (well under the 60 KB cap). All annotation types valid.