### PR TITLE
Enrich Wilson quotient / Wilson primes: dedicated ZMod(p²) congruence annotation (4→5)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-06/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-06/annotations.json
@@ -26,14 +26,26 @@
   {
     "id": "wq-ann-equiv",
     "proofId": "wilsons-theorem-oq-06",
-    "range": { "startLine": 77, "endLine": 109 },
+    "range": { "startLine": 77, "endLine": 97 },
     "type": "insight",
     "title": "The Wilson-Prime Equivalence is One Cancellation",
-    "content": "dvd_wilsonQuotient_iff proves p ∣ W_p ⟺ p² ∣ (p−1)!+1: rewrite (p−1)!+1 as p·W_p and p² as p·p, then Nat.mul_dvd_mul_iff_left cancels the common factor p. So the entire equivalence reduces to left-cancellation of divisibility — the number-theoretic depth lives only in Wilson's theorem upstream. WilsonPrime packages p.Prime ∧ p² ∣ (p−1)!+1; wilsonPrime_iff_dvd_wilsonQuotient restates it via the quotient. sq_dvd_iff_factorial_cast_eq_neg_one gives the ZMod (p²) congruence form (p−1)! ≡ −1 (mod p²), which holds for ALL p — primality is not needed for the equivalence, only for the divisibility to occur.",
-    "mathContext": "$p\\mid W_p \\iff p\\cdot p\\mid p\\cdot W_p=(p-1)!+1 \\iff p^2\\mid(p-1)!+1 \\iff (p-1)!\\equiv -1\\ (\\mathrm{mod}\\ p^2).$",
+    "content": "dvd_wilsonQuotient_iff proves p ∣ W_p ⟺ p² ∣ (p−1)!+1: rewrite (p−1)!+1 as p·W_p and p² as p·p, then Nat.mul_dvd_mul_iff_left cancels the common factor p. So the entire equivalence reduces to left-cancellation of divisibility — the number-theoretic depth lives only in Wilson's theorem upstream. WilsonPrime then packages the definition p.Prime ∧ p² ∣ (p−1)!+1, and wilsonPrime_iff_dvd_wilsonQuotient restates that condition purely via the quotient: p is a Wilson prime iff p ∣ W_p. The p²-divisibility 'second-order' Wilson condition is thus detected by a single first-order divisibility of the quotient.",
+    "mathContext": "$p\\mid W_p \\iff p\\cdot p\\mid p\\cdot W_p=(p-1)!+1 \\iff p^2\\mid(p-1)!+1$; and $\\mathrm{WilsonPrime}(p)\\iff p\\text{ prime}\\wedge p\\mid W_p.$",
     "significance": "key",
-    "relatedConcepts": ["Nat.mul_dvd_mul_iff_left", "left-cancellation", "ZMod (p²) congruence", "Wilson prime definition"],
+    "relatedConcepts": ["Nat.mul_dvd_mul_iff_left", "left-cancellation", "Wilson prime definition", "first-order test for a second-order condition"],
     "prerequisites": ["divisibility cancellation", "the quotient identity p·W_p = (p−1)!+1"]
+  },
+  {
+    "id": "wq-ann-zmod",
+    "proofId": "wilsons-theorem-oq-06",
+    "range": { "startLine": 98, "endLine": 109 },
+    "type": "insight",
+    "title": "The ZMod(p²) Congruence Form — No Primality Required",
+    "content": "sq_dvd_iff_factorial_cast_eq_neg_one recasts the divisibility p² ∣ (p−1)!+1 as the ring congruence ((p−1)! : ZMod (p²)) = −1. The bridge is ZMod.natCast_eq_zero_iff, turning p² ∣ ((p−1)!+1) into ((p−1)!+1 : ZMod (p²)) = 0; push_cast and a linear_combination / ring step move the +1 to the other side as −1. Notably this equivalence holds for EVERY p — primality is never used — so it is a purely formal restatement; primality enters only in whether the congruence actually holds. This is the p²-modulus refinement of Wilson's own (p−1)! ≡ −1 (mod p), and the exact condition defining a Wilson prime in congruence language.",
+    "mathContext": "For all $p$: $p^2\\mid(p-1)!+1 \\iff (p-1)!\\equiv -1\\ (\\mathrm{mod}\\ p^2)$ — the second-order lift of Wilson's $(p-1)!\\equiv -1\\ (\\mathrm{mod}\\ p)$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.natCast_eq_zero_iff", "ZMod (p²) congruence", "second-order Wilson condition", "push_cast / linear_combination"],
+    "prerequisites": ["ℕ → ZMod cast and vanishing", "Wilson's congruence mod p"]
   },
   {
     "id": "wq-ann-certs",


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-06` (annotations.json only).

The `wq-ann-equiv` annotation covered lines 77–109, bundling the quotient equivalence with the ZMod(p²) congruence form `sq_dvd_iff_factorial_cast_eq_neg_one` — a distinct result that even has its own keyInsight ("The ZMod congruence form needs no primality"). Split for prominence, lifting coverage 4→5 (continuous 1–126, all with mathContext/relatedConcepts/significance):

- **`wq-ann-equiv` (77–97)** — p ∣ W_p ⟺ p² ∣ (p−1)!+1 by one `Nat.mul_dvd_mul_iff_left` cancellation, plus the `WilsonPrime` definition and its quotient restatement.
- **`wq-ann-zmod` (98–109)** — the primality-free ZMod(p²) congruence (p−1)! ≡ −1 (mod p²) via `ZMod.natCast_eq_zero_iff`; the second-order lift of Wilson's mod-p congruence.

Verified axiom integrity while here: the Wilson-prime certificates (5, 13) use ordinary kernel `decide` (not `native_decide`), so `axiomCount: 0` / `verified` / `original` are correct — no `Lean.ofReduceBool`. No meta.json changes. JSON validated.