### PR TITLE
Enrich Abel–Ruffini obstruction: link 3 sibling entries (crossRefs 2→5)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04-oq-01/meta.json
@@ -93,6 +93,21 @@
       "targetId": "abel-ruffini-oq-04-oq-01",
       "relationship": "related",
       "description": "Grandparent entry computes Gal(x⁵ − 4x + 2) ≅ S₅; this non-solvability obstruction is the abstract reason that computation implies unsolvability by radicals."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02",
+      "relationship": "related",
+      "description": "The complementary boundary case below the p ≥ 5 threshold: S₂, S₃, S₄ ARE solvable (that entry's complete classification), which is exactly why degrees ≤ 4 admit radical formulas. Together they pin the sharp cutoff — solvable for n ≤ 4, unsolvable from n = 5 — that this entry's cardinality hypothesis 5 ≤ #α encodes."
+    },
+    {
+      "targetId": "abel-ruffini-obstruction-oq-06",
+      "relationship": "related",
+      "description": "A parallel formalization of the same Abel–Ruffini obstruction: Sₙ is unsolvable for n ≥ 5. That entry states the non-solvability of the full symmetric group directly; this one derives it for a transitive subgroup with a transposition (which the Key Lemma forces to be all of S_p), the form needed for concrete Galois-group arguments."
+    },
+    {
+      "targetId": "abel-ruffini-oq-07-discriminant",
+      "relationship": "related",
+      "description": "An alternate route to a concrete unsolvable quintic: that entry proves Gal(X⁵ − X − 1) ≅ S₅ via the discriminant and a Jordan-type argument, whereas this obstruction (transitive + transposition ⟹ S_p ⟹ unsolvable) is the group-theoretic template both routes feed into."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-04-oq-01` (meta.json only, additive).

This well-curated entry (5 annotations, 4 deep keyInsights, clean 0-axiom disclosure) sat cross-referencing only its direct parent and grandparent, isolated within a dense Abel–Ruffini cluster. Added three genuinely, specifically related sibling links (all targets verified to exist):

- **`abel-ruffini-oq-04-oq-02`** — "S₂, S₃, S₄ Are Solvable": the complementary boundary *below* the p ≥ 5 threshold, the exact reason degrees ≤ 4 have radical formulas. Directly complements keyInsight #3.
- **`abel-ruffini-obstruction-oq-06`** — a parallel formalization of the same obstruction (Sₙ unsolvable for n ≥ 5), stated for the full symmetric group rather than a transitive subgroup.
- **`abel-ruffini-oq-07-discriminant`** — the alternate discriminant/Jordan route to Gal(X⁵ − X − 1) ≅ S₅; both routes feed this group-theoretic template.

No changes to status/badge/axiomCount (verified/original/0). Size 10.2 KB, crossRefs 5 (≤ 20 cap). JSON validated.