### PR TITLE
Enrich Erdős #1029: fix stale/inaccurate section + annotation metadata

### DIFF
--- a/src/data/proofs/erdos-1029/annotations.json
+++ b/src/data/proofs/erdos-1029/annotations.json
@@ -8,7 +8,7 @@
     },
     "type": "concept",
     "title": "Problem Overview: Ramsey Number Growth Rate",
-    "content": "Erdős Problem #1029 (1993) asks whether R(k)/(k·2^{k/2}) → ∞, where R(k) is the diagonal Ramsey number. This is one of the most important open problems in combinatorics, with a $100 prize for proof and $1000 for disproof. The formalization defines Ramsey numbers via Nat.find using an axiomatized existence result, states the known upper and lower bounds, and formulates the conjecture as a Filter.Tendsto statement.",
+    "content": "Erdős Problem #1029 (1993) asks whether R(k)/(k·2^{k/2}) → ∞, where R(k) is the diagonal Ramsey number. This is one of the most important open problems in combinatorics, with a $100 prize for proof and $1000 for disproof. The formalization defines Ramsey numbers via Nat.find using the proved existence theorem ramsey_exists (from the imported Proofs.RamseysTheorem), states the known upper and lower bounds as axioms, and formulates the conjecture as a Filter.Tendsto statement. The entry carries 4 axioms in total: the two literature bounds (erdos_szekeres_upper, spencer_lower_bound) and the two known values (R_3, R_4).",
     "mathContext": "The gap between the lower bound ~2^{k/2} and upper bound ~4^k is enormous. Despite 90 years of work since Erdős-Szekeres, neither the base 4 in the upper bound nor the base √2 in the lower bound has been improved. This problem asks whether the lower bound can be improved by even a factor tending to infinity.",
     "significance": "key",
     "relatedConcepts": [
@@ -27,13 +27,13 @@
     "id": "ann-1029-ramsey-def",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 39,
-      "endLine": 69
+      "startLine": 40,
+      "endLine": 113
     },
     "type": "definition",
     "title": "Ramsey Number Definition",
-    "content": "R(k) is defined as the minimal n such that every 2-coloring of K_n contains a monochromatic K_k. Edge colorings assign a Boolean to each unordered pair (Sym2 V). The existence of such n is axiomatized via ramsey_exists, allowing R to be defined as Nat.find (ramsey_exists k). The specification theorem R_spec follows directly from Nat.find_spec.",
-    "mathContext": "The use of Nat.find ensures R(k) is truly minimal. The axiomatization of ramsey_exists replaces the Erdős-Szekeres inductive proof, which would require substantial formalization of the recurrence R(s,t) ≤ R(s-1,t) + R(s,t-1) and the base cases.",
+    "content": "R(k) is defined as the minimal n such that every 2-coloring of K_n contains a monochromatic K_k. Edge colorings assign a Boolean to each unordered pair (EdgeColoring V := Sym2 V → Bool). The existence of such n is the proved theorem ramsey_exists (imported from Proofs.RamseysTheorem — NOT an axiom), which lets R be defined as Nat.find (ramsey_exists k). The specification theorem R_spec follows directly from Nat.find_spec.",
+    "mathContext": "The use of Nat.find ensures R(k) is truly minimal. ramsey_exists is a genuine theorem here (the finite case of Ramsey's theorem, supplied by the imported RamseysTheorem development), so no axiom is spent on existence — the entry's 4 axioms are the two bounds and the two known values R_3, R_4.",
     "significance": "key",
     "relatedConcepts": [
       "Nat.find",
@@ -51,12 +51,12 @@
     "id": "ann-1029-bounds",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 70,
-      "endLine": 92
+      "startLine": 114,
+      "endLine": 123
     },
     "type": "concept",
     "title": "Classical Bounds on R(k)",
-    "content": "Four axiomatized bounds capture the state of knowledge: (1) Erdős-Szekeres upper bound R(k) ≤ C(2k-2, k-1), proved by induction in 1935; (2) asymptotic upper bound R(k) ≤ C·4^k/√k from Stirling's approximation; (3) probabilistic lower bound R(k) ≥ c·k·2^{k/2}; (4) Spencer's improvement giving the constant √2/e ≈ 0.52.",
+    "content": "Two axioms capture the known bounds (they are not re-proved here): erdos_szekeres_upper, the upper bound R(k) ≤ C(2k-2, k-1) (Erdős–Szekeres 1935, ≈ C·4^k/√k by Stirling), and spencer_lower_bound, the probabilistic lower bound R(k) ≥ (√2/e)·k·2^{k/2} (Erdős 1947, constant sharpened by Spencer 1975 via the Lovász Local Lemma). These are 2 of the entry's 4 axioms.",
     "mathContext": "The upper bound uses a simple double counting argument. The lower bound is a landmark application of the probabilistic method: count expected monochromatic k-cliques in a random 2-coloring. Spencer's refinement uses the Lovász Local Lemma to handle dependencies between clique events.",
     "significance": "key",
     "relatedConcepts": [
@@ -75,8 +75,8 @@
     "id": "ann-1029-conjecture",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 93,
-      "endLine": 123
+      "startLine": 125,
+      "endLine": 154
     },
     "type": "concept",
     "title": "The Main Conjecture and Equivalence",
@@ -99,13 +99,13 @@
     "id": "ann-1029-negation",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 124,
-      "endLine": 140
+      "startLine": 156,
+      "endLine": 166
     },
     "type": "concept",
-    "title": "Lower Bound and Negation Analysis",
-    "content": "Spencer's result gives ratio_bounded_below: for any ε > 0, the ratio eventually exceeds √2/e - ε. The negation of the conjecture is formalized as conjectureNegation: the ratio is bounded above by some M. The equivalence between ¬conjecture and conjectureNegation is axiomatized, as it requires careful analysis of filter negation and boundedness.",
-    "mathContext": "The negation equivalence relates the filter-theoretic statement ¬(Tendsto f atTop atTop) to the existence of a uniform upper bound. This is not entirely trivial since the conjecture concerns divergence to +∞, and its negation involves limsup being finite.",
+    "title": "The Negation of the Conjecture",
+    "content": "conjectureNegation is defined as ∃ M : ℝ, ∀ k : ℕ, ramseyRatio k ≤ M — i.e. the ratio is uniformly bounded above, the statement that the probabilistic lower bound is essentially tight (the $1000 disproof direction). It is a plain definition capturing 'the conjecture fails', not an axiom, and the file does not (currently) prove a formal ¬erdos1029Conjecture ↔ conjectureNegation equivalence — that filter-boundedness bridge is left implicit. Spencer's constant √2/e ≈ 0.52 is a lower bound for the ratio (from the spencer_lower_bound axiom), which is why the ratio cannot tend to 0.",
+    "mathContext": "conjectureNegation : ∃ M, ∀ k, ramseyRatio k ≤ M. Relating this to ¬(Tendsto ramseyRatio atTop atTop) is a filter-negation/boundedness argument (the negation involves a finite limsup); the file states the bounded form directly.",
     "significance": "key",
     "relatedConcepts": [
       "Spencer-bound",
@@ -123,12 +123,12 @@
     "id": "ann-1029-small-values",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 141,
-      "endLine": 161
+      "startLine": 168,
+      "endLine": 182
     },
     "type": "concept",
     "title": "Known Ramsey Numbers",
-    "content": "The known exact values are axiomatized: R(1)=1 (trivial), R(2)=2, R(3)=6 (the party problem), R(4)=18 (Greenwood-Gleason 1955). For R(5), only bounds are known: 43 ≤ R(5) ≤ 48. The difficulty of computing even R(5) exactly illustrates the explosive growth of Ramsey numbers.",
+    "content": "Two exact values are stated as axioms: R_3 : R 3 = 6 (the party problem) and R_4 : R 4 = 18 (Greenwood-Gleason 1955). These are asserted from the literature, NOT computed by decide/native_decide (the file uses no kernel decision procedure). R(1)=1 and R(2)=2 appear only as docstring comments; for R(5) only bounds are known (43 ≤ R(5) ≤ 48). The difficulty of computing even R(5) exactly illustrates the explosive growth of Ramsey numbers, and is why the exact values are taken as axioms rather than verified.",
     "mathContext": "R(3)=6 is the classic 'party problem': among 6 people, there must be 3 mutual friends or 3 mutual strangers. R(4)=18 was proved using the Paley graph on F_17 for the lower bound. The gap for R(5) has resisted computational attacks for decades.",
     "significance": "key",
     "relatedConcepts": [
@@ -147,12 +147,12 @@
     "id": "ann-1029-ratios",
     "proofId": "erdos-1029",
     "range": {
-      "startLine": 162,
-      "endLine": 190
+      "startLine": 183,
+      "endLine": 211
     },
     "type": "concept",
     "title": "Ratio Values and Prize",
-    "content": "The ratio R(k)/(k·2^{k/2}) is computed for k=3 (≈0.707) and k=4 (=1.125), showing the ratio crosses 1 between k=3 and k=4. These small values suggest the ratio may be increasing, consistent with the conjecture. Erdős offered $100 for proof and $1000 for disproof, one of his many famous problem prizes.",
+    "content": "The theorems ratio_3 and ratio_4 evaluate ramseyRatio at k=3 (≈0.707) and k=4 (=1.125) — proved by simp+ring after substituting the R_3/R_4 axioms — showing the ratio crosses 1 between k=3 and k=4. erdos1029OpenProblem records the conjecture as the prize target. These small values suggest the ratio may be increasing, consistent with the conjecture. Erdős offered $100 for proof and $1000 for disproof, one of his many famous problem prizes.",
     "mathContext": "The computed ratios use the exact values R(3)=6 and R(4)=18. The proofs are by ring normalization after substituting the known values. The increasing trend from 0.707 to 1.125 is suggestive but far from conclusive evidence for divergence.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-1029/meta.json
+++ b/src/data/proofs/erdos-1029/meta.json
@@ -50,52 +50,60 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Setup",
+      "summary": "Module docstring stating problem #1029 (prove R(k)/(k·2^{k/2}) → ∞), the Erdős–Szekeres bounds, the probabilistic-method lower bound and Spencer's constant, and the $100/$1000 prize. Imports Mathlib and Proofs.RamseysTheorem, opens Nat and Filter.",
+      "startLine": 1,
+      "endLine": 38,
+      "mathContext": "$(1+o(1))\\cdot\\frac{k}{e}\\cdot 2^{k/2} \\le R(k) \\le \\binom{2k-2}{k-1} \\approx 4^k/\\sqrt{k}$; the open question is whether $R(k)/(k\\cdot 2^{k/2}) \\to \\infty$."
+    },
+    {
       "id": "ramsey-numbers",
       "title": "Ramsey Numbers",
-      "summary": "EdgeColoring, IsMonochromatic, HasMonochromaticClique, ramsey_exists axiom, R definition, R_spec",
-      "startLine": 39,
-      "endLine": 69,
-      "mathContext": "The diagonal Ramsey number $R(k)$ is the minimum $n$ such that every 2-coloring of $K_n$ contains a monochromatic $K_k$. Defined via `R := Nat.find (ramsey_exists k)` where `ramsey_exists` asserts the finite case of Ramsey's theorem. `EdgeColoring G c` assigns each edge of `SimpleGraph G` a color in `Fin 2`."
+      "summary": "EdgeColoring, IsMonochromatic, HasMonochromaticClique (definitions); ramsey_exists (theorem, the finite Ramsey existence, from the imported Proofs.RamseysTheorem); the noncomputable R definition via Nat.find; and R_spec.",
+      "startLine": 40,
+      "endLine": 113,
+      "mathContext": "The diagonal Ramsey number $R(k)$ is the minimum $n$ such that every 2-coloring of $K_n$ contains a monochromatic $K_k$. Defined via `R k := Nat.find (ramsey_exists k)`, where `ramsey_exists` is a proved theorem (not an axiom) giving the finite case of Ramsey's theorem. `EdgeColoring V := Sym2 V → Bool`."
     },
     {
       "id": "bounds",
-      "title": "Known Bounds",
-      "summary": "Erdős-Szekeres upper/lower bounds, Spencer's improvement",
-      "startLine": 70,
-      "endLine": 92,
-      "mathContext": "Erdős-Szekeres (1935): $R(k) \\leq \\binom{2k-2}{k-1} \\leq 4^k/\\sqrt{k}$. Erdős (1947, probabilistic method): $R(k) \\geq (\\sqrt{2}/e) \\cdot k \\cdot 2^{k/2}$. Spencer (1975) improved the constant. The gap between $2^{k/2}$ and $4^k = 2^{2k}$ is exponential; closing it is one of the central problems in combinatorics."
+      "title": "Known Bounds (axioms)",
+      "summary": "erdos_szekeres_upper and spencer_lower_bound — the two literature bounds, stated as axioms (not re-proved here): 2 of the entry's 4 axioms.",
+      "startLine": 114,
+      "endLine": 123,
+      "mathContext": "Erdős–Szekeres (1935): $R(k) \\leq \\binom{2k-2}{k-1} \\leq 4^k/\\sqrt{k}$. Erdős (1947, probabilistic method) / Spencer (1975): $R(k) \\geq (\\sqrt{2}/e)\\cdot k\\cdot 2^{k/2}$. Both are taken as axioms; the gap between $2^{k/2}$ and $4^k = 2^{2k}$ is exponential."
     },
     {
       "id": "conjecture",
       "title": "The Conjecture",
-      "summary": "ramseyRatio, erdos1029Conjecture, equivalence proof",
-      "startLine": 93,
-      "endLine": 123,
-      "mathContext": "The `ramseyRatio k := R(k) / (k · 2^{k/2})`. Erdős's conjecture: `ramseyRatio k → ∞` as $k \\to \\infty$. Equivalently, $R(k) = \\omega(k \\cdot 2^{k/2})$. This would show the probabilistic lower bound is not tight. Proved equivalent to: for every $C$, $R(k) > C \\cdot k \\cdot 2^{k/2}$ for large $k$."
+      "summary": "ramseyRatio (the normalized ratio R(k)/(k·2^{k/2})), erdos1029Conjecture (Tendsto ramseyRatio atTop atTop), the alternative ε-form erdos1029ConjectureAlt, and conjecture_equiv proving the two formulations equivalent.",
+      "startLine": 125,
+      "endLine": 154,
+      "mathContext": "`ramseyRatio k := R(k) / (k · 2^{k/2})`. Erdős's conjecture: `ramseyRatio k → ∞`, i.e. $R(k) = \\omega(k\\cdot 2^{k/2})$. `conjecture_equiv` proves this equivalent to: for every $M$, eventually $\\mathrm{ramseyRatio}\\,k > M$."
     },
     {
       "id": "lower-bound",
-      "title": "Lower Bound Analysis",
-      "summary": "ratio_bounded_below, conjectureNegation, negation_equiv axiom",
-      "startLine": 124,
-      "endLine": 140,
-      "mathContext": "The ratio is bounded below by $\\sqrt{2}/e \\approx 0.520$ (from the Erdős lower bound). The conjecture asks whether this ratio grows without bound. The negation ($\\exists C,\\, R(k) \\leq C \\cdot k \\cdot 2^{k/2}$ infinitely often) would mean the probabilistic bound is essentially tight — Erdős offered $\\$1000$ for this."
+      "title": "Lower Bound Is Not Tight",
+      "summary": "conjectureNegation — the negation as a definition (∃ M, ∀ k, ramseyRatio k ≤ M): if the conjecture fails the ratio is bounded.",
+      "startLine": 156,
+      "endLine": 166,
+      "mathContext": "The ratio is bounded below by $\\sqrt{2}/e \\approx 0.520$. `conjectureNegation` states $\\exists M,\\ \\forall k,\\ \\mathrm{ramseyRatio}\\,k \\le M$ — the probabilistic bound being essentially tight, for which Erdős offered $\\$1000$."
     },
     {
       "id": "small-values",
-      "title": "Known Values",
-      "summary": "R(1)=1, R(2)=2, R(3)=6, R(4)=18, R(5) bounds",
-      "startLine": 141,
-      "endLine": 161,
-      "mathContext": "Known exact values: $R(1) = 1$, $R(2) = 2$, $R(3) = 6$, $R(4) = 18$. $R(5)$ is unknown: $43 \\leq R(5) \\leq 48$. The small-value computations are verified by `native_decide` or `decide`. $R(3) = 6$ is the party problem: among 6 people, there must be 3 mutual friends or 3 mutual strangers."
+      "title": "Known Values (R_3, R_4 as axioms)",
+      "summary": "R_3 : R 3 = 6 and R_4 : R 4 = 18 — the two known nontrivial exact diagonal Ramsey values, asserted as axioms (from the literature: R(4)=18 is Greenwood–Gleason 1955), NOT computed by decide. These are the other 2 of the entry's 4 axioms.",
+      "startLine": 168,
+      "endLine": 182,
+      "mathContext": "Known exact values $R(1)=1$, $R(2)=2$, $R(3)=6$, $R(4)=18$; $R(5)$ is unknown ($43 \\le R(5) \\le 48$). $R(3)=6$ is the party problem. $R_3$ and $R_4$ are stated as axioms citing classical results, not verified by kernel computation."
     },
     {
       "id": "ratio-values",
-      "title": "Ratio Computations",
-      "summary": "Ratio at k=3 and k=4, prize problem",
-      "startLine": 162,
-      "endLine": 190,
-      "mathContext": "Ratio at $k=3$: $R(3)/(3 \\cdot 2^{3/2}) = 6/(3 \\cdot 2\\sqrt{2}) \\approx 0.707$. At $k=4$: $R(4)/(4 \\cdot 2^2) = 18/16 = 1.125$. The growth from $0.707$ to $1.125$ is suggestive but not proof of divergence. Erdős offered $\\$100$ for proof and $\\$1000$ for disproof."
+      "title": "Ratio Computations and the Prize Problem",
+      "summary": "ratio_3 and ratio_4 evaluate ramseyRatio at k=3,4 (proved by simp+ring from the R_3/R_4 axioms); erdos1029OpenProblem records the main conjecture as the prize target.",
+      "startLine": 183,
+      "endLine": 211,
+      "mathContext": "$\\mathrm{ramseyRatio}(3) = 6/(3\\cdot 2^{3/2}) \\approx 0.707$; $\\mathrm{ramseyRatio}(4) = 18/16 = 1.125$. The increase is suggestive but not a proof of divergence. Erdős: $\\$100$ proof / $\\$1000$ disproof."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-1029` (Ramsey number growth rate).

The metadata was written against an **older version** of the Lean file, so the sections and annotations had stale line ranges and referenced declarations that no longer exist. Verified every claim against `Proofs/Erdos1029Problem.lean`:

**Accuracy fixes:**
- `ramsey_exists` is a **theorem** (imported from `Proofs.RamseysTheorem`), not an axiom as the metadata claimed — existence costs no axiom.
- Removed references to the **non-existent** `ratio_bounded_below` and `negation_equiv axiom`. The real declaration is `conjectureNegation` (a `def`), and no formal ¬conjecture ↔ bounded equivalence is proved.
- Corrected "Four axiomatized bounds" → the **two** bound axioms (`erdos_szekeres_upper`, `spencer_lower_bound`); the other two of the four axioms are the values `R_3`, `R_4`.
- Fixed the false claim that small values are "verified by native_decide or decide" — the file uses **no** decision procedure; `R_3`/`R_4` are axioms asserted from the literature (Greenwood–Gleason 1955).
- Remapped **all** section/annotation line ranges to the current 211-line file, and added a header section (sections 6 → 7).

`axiomCount: 4` is confirmed accurate (`grep -c '^axiom '` = 4). No content of value removed; meta.json 12.9 KB (well under the 60 KB cap).