### PR TITLE
Enrich Huzita–Hatori HH-5 core: add module-overview annotation (8→9)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/annotations.json
@@ -1,5 +1,33 @@
 [
   {
+    "id": "ann-module-overview",
+    "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 65
+    },
+    "type": "context",
+    "title": "What This File Completes — and Why It Is 'Incomplete'",
+    "content": "The header states the scope precisely. This file discharges the RATIONAL (square-root-free) core of Huzita–Hatori axiom HH-5 for the open problem angle-trisection-oq-05-oq-04 (strengthening the HH origami axioms). HH-5 asks: given distinct points P₁, P₂ and a line ℓ, produce a fold through P₂ that lands P₁ onto ℓ. Since the fold is a reflection fixing P₂, the landing point P₁' must satisfy |P₁'−P₂| = |P₁−P₂| — it lies on the circle centred at P₂ through P₁ — so HH-5 is solvable iff that circle meets ℓ, and locating P₁' is a genuine Real.sqrt circle–line intersection. The 'incomplete' in the slug is exactly this: the file deliberately ISOLATES that one irrational existence step, keeping the landing point P₁' as a hypothesis (a witness), and proves everything else purely rationally. What remains fully verified here is the fold construction and its characterisation; what is factored out (not sorried, but hypothesised) is the existence of the witness. This honest separation pins ALL of HH-5's algebraic degree to the single circle–line intersection.",
+    "mathContext": "HH-5 solvable for $(P_1,P_2,\\ell)$ $\\iff$ $\\ell$ meets the circle $\\{X : |X-P_2| = |P_1-P_2|\\}$; the fold is then the perpendicular bisector of $P_1P_1'$, rational in the witness $P_1'$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Huzita–Hatori axioms",
+      "origami constructibility",
+      "circle–line intersection (the irrational step)",
+      "rational core vs irrational witness"
+    ],
+    "prerequisites": [
+      "reflections and folds in the plane",
+      "constructibility / Real.sqrt"
+    ],
+    "tags": [
+      "context",
+      "overview",
+      "huzita-hatori"
+    ]
+  },
+  {
     "id": "ann-reflect-across",
     "proofId": "angle-trisection-oq-05-oq-04-incomplete-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-05-oq-04-incomplete-01` (annotations.json only).

The file's 8 annotations all began at line 82, leaving the entire header docstring (1–65) — which explains HH-5, the reflection-forces-circle argument, and the deliberate rational-core / irrational-witness split — with no annotation coverage. Added `ann-module-overview` (1–65) that orients the reader and, importantly, explains why the slug says **"incomplete"**: the single `Real.sqrt` circle–line intersection is isolated as a *hypothesised* witness landing point (not a `sorry`), so the fold construction and its solvability characterisation are fully verified while the one irrational existence step is honestly factored out.

Consistent with meta (`status: verified`, `sorries: 0`, `axiomCount: 0`) — the irrationality lives in a theorem hypothesis, not an axiom. No meta.json changes. JSON validated (9 annotations).