### PR TITLE
Enrich Ballot Problem OQ-04-OQ-01 (n=4 crossing discriminator)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
@@ -97,9 +97,17 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 25,
+      "mathContext": "Of the $B_4 = 15$ partitions of a 4-element set exactly one crosses, leaving $\\mathrm{catalan}\\,4 = 14$ non-crossing; the crossing one is the same-parity relation $\\{\\{0,2\\},\\{1,3\\}\\}$.",
+      "summary": "Docstring situating the file under the parent ballot-problem-oq-04 (IsNonCrossing on Setoid (Fin n); every partition with n ≤ 3 is non-crossing), and stating the goal: exhibit the unique crossing partition of Fin 4 — the same-parity relation {{0,2},{1,3}} whose interleaving 0 ~ 2, 1 ~ 3, ¬0 ~ 1 is the forbidden IsNonCrossing configuration — as a concrete verified witness for the n = 4 discriminator. Imports Proofs.BallotProblemOQ04, opens the parent namespace."
+    },
+    {
       "id": "definition",
       "title": "The Crossing Partition as Same-Parity",
-      "startLine": 27,
+      "startLine": 26,
       "endLine": 42,
       "mathContext": "$\\mathrm{crossing4} = \\ker(x \\mapsto x \\bmod 2)$, blocks $\\{0,2\\}$ and $\\{1,3\\}$.",
       "summary": "crossing4 is the same-parity equivalence on Fin 4 (kernel of the parity map); crossing4_iff records that membership is having equal parity, and crossing4_blocks exhibits the two interleaving blocks 0 ~ 2, 1 ~ 3 with ¬ 0 ~ 1."


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04-oq-01`.

The 6 annotations already cover the full file, but the meta `sections` array covered only lines 27–59, omitting the docstring/imports/setup (1–25).

- Added an `Overview and Setup` header section (1–25) with mathContext (the B₄ = 15 vs catalan 4 = 14 discriminator and the same-parity crossing witness).
- Extended the `definition` section to start at line 26 so it includes the `crossing4` docstring (sections 2 → 3, full-file coverage).

Verified against `Proofs/BallotProblemOQ04OQ01.lean`: 0 axioms, 0 sorries, no native_decide — status `verified` / badge `original` / `axiomCount: 0` all accurate. Only meta.json changed; 11.5 KB, well under the 60 KB cap.