### PR TITLE
Enrich Orbit-Stabilizer over Nat.card: add classical textbook references (1→3)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -192,6 +192,20 @@
       "year": "2025",
       "venue": "leanprover-community/mathlib4",
       "description": "Source of orbitProdStabilizerEquivGroup, orbitEquivQuotientStabilizer, and the Fintype-form orbit-stabilizer theorem card_orbit_mul_card_stabilizer_eq_card_group."
+    },
+    {
+      "title": "Abstract Algebra",
+      "author": "Dummit, D.S. and Foote, R.M.",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "description": "§4.1 develops group actions, the orbit-stabilizer theorem |G·x|·|G_x| = |G|, and the orbit–index identity |G·x| = [G : G_x] — the classical Fintype-level statements this entry lifts to the finiteness-free Nat.card form."
+    },
+    {
+      "title": "An Introduction to the Theory of Groups",
+      "author": "Rotman, J.J.",
+      "year": "1995",
+      "venue": "4th ed., Graduate Texts in Mathematics 148, Springer",
+      "description": "Ch. 3 treats group actions, orbits and stabilizers, and Lagrange's theorem via the coset space G/G_x, the index interpretation underlying card_orbit_eq_card_quotient_stabilizer_nat here."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01` ("The Orbit-Stabilizer Family over Nat.card", meta.json only, additive).

The entry cited only its Mathlib source (`GroupTheory.GroupAction.Quotient`) for a classical result. Since the meta is already content-rich (~20 KB overview), I avoided adding annotations/insights and instead filled the one conspicuous gap — textbook references — with two standard sources (references 1 → 3):

- **Dummit & Foote, *Abstract Algebra* §4.1** — group actions, the orbit-stabilizer theorem |G·x|·|G_x| = |G|, and the orbit–index identity |G·x| = [G : G_x]; the Fintype-level statements this entry lifts to the finiteness-free `Nat.card` form.
- **Rotman, *An Introduction to the Theory of Groups* Ch. 3** — group actions, orbits/stabilizers, and Lagrange via the coset space G/G_x (underlying `card_orbit_eq_card_quotient_stabilizer_nat`).

No changes to status/badge/axiomCount (verified/0). Size 20.9 KB (< 60 KB cap); references 3 (≤ 25 cap). JSON validated.