### PR TITLE
Enrich British-Flag weighted Leibniz identity: add annotations.json (0→6)

### DIFF
--- a/src/data/proofs/british-flag-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "ann-bfs-header",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "context",
+    "title": "One Identity Behind Leibniz, British-Flag, and the Rectangle Theorem",
+    "content": "The docstring frames the whole file: the British Flag Theorem and its parallelogram-defect sharpening are the four-point instances of a single weighted squared-distance identity for an arbitrary finite family of points — the classical Leibniz relation (generalized parallel-axis / Stewart relation). Given points vᵢ in a real inner product space, real weights wᵢ, an observer p, and ANY reference point g, the weighted sum of squared distances splits into a p-term, a cross term, and a g-term. The strategy is stated too: translate every point through g (p − vᵢ = (p − g) − (vᵢ − g)), expand each ‖p − vᵢ‖² by norm_sub_sq_real, and collect the cross terms into one inner product via bilinearity. No division is used, so the identity holds for ARBITRARY weights, including the balanced W = 0 case that powers the British Flag corollary.",
+    "mathContext": "$\\sum_i w_i\\lVert p-v_i\\rVert^2 = W\\lVert p-g\\rVert^2 - 2\\langle p-g,\\ (\\sum_i w_i\\,v_i)-W\\,g\\rangle + \\sum_i w_i\\lVert v_i-g\\rVert^2,\\quad W=\\sum_i w_i.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Leibniz relation",
+      "parallel axis / Stewart theorem",
+      "British Flag Theorem",
+      "inner product space",
+      "reference-point translation"
+    ],
+    "prerequisites": [
+      "real inner product spaces and norms",
+      "finite (Finset) sums"
+    ],
+    "tags": ["context", "overview", "leibniz-identity"]
+  },
+  {
+    "id": "ann-bfs-bilinearity",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 63, "endLine": 72 },
+    "type": "proof-step",
+    "title": "Bilinearity: Collapsing the Weighted Cross Sum",
+    "content": "inner_weighted_sum is the linear-algebra engine: the weighted sum ∑ᵢ wᵢ⟪p−g, vᵢ−g⟫ of cross inner products collapses into a SINGLE inner product ⟪p−g, (∑ᵢ wᵢ•vᵢ) − (∑ᵢ wᵢ)•g⟫. The proof is pure bilinearity of the real inner product: inner_sub_right and inner_sum pull the sum and subtraction out of the second argument, real_inner_smul_right moves the weights, and Finset.sum_sub_distrib / Finset.sum_mul reassemble the two Finset sums. This is what lets the master identity's many cross terms become one inner product against the weighted displacement.",
+    "mathContext": "$\\sum_i w_i\\langle p-g,\\ v_i-g\\rangle = \\langle p-g,\\ \\big(\\sum_i w_i\\,v_i\\big)-\\big(\\sum_i w_i\\big)g\\rangle$ by bilinearity of $\\langle\\cdot,\\cdot\\rangle$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bilinearity of the inner product",
+      "inner_sum / inner_sub_right",
+      "weighted displacement",
+      "Finset sum distributivity"
+    ],
+    "prerequisites": [
+      "inner product linearity lemmas",
+      "Finset.sum manipulation"
+    ],
+    "tags": ["proof-step", "bilinearity"]
+  },
+  {
+    "id": "ann-bfs-master",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 92 },
+    "type": "insight",
+    "title": "The Master Weighted Squared-Distance Identity",
+    "content": "weighted_dist_sq_master is the headline result: for any weights wᵢ, observer p, and reference point g, ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² − 2⟪p−g, (∑ᵢ wᵢ•vᵢ)−W•g⟫ + ∑ᵢ wᵢ‖vᵢ−g‖². The proof establishes a per-term identity `key` by rewriting p − vᵢ = (p − g) − (vᵢ − g) and expanding with norm_sub_sq_real (‖a−b‖² = ‖a‖² − 2⟪a,b⟫ + ‖b‖²), closed by ring; then Finset.sum_add_distrib / sum_sub_distrib split the summed identity and inner_weighted_sum folds the middle terms into the single cross inner product. Crucially NO hypothesis on the weights is needed — the identity is unconditional, which is exactly what makes the balanced-weight corollaries possible.",
+    "mathContext": "Per term: $w_i\\lVert p-v_i\\rVert^2 = w_i\\lVert p-g\\rVert^2 - 2w_i\\langle p-g,v_i-g\\rangle + w_i\\lVert v_i-g\\rVert^2$; summing and applying inner_weighted_sum gives the master identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "norm_sub_sq_real (polarization)",
+      "reference-point decomposition",
+      "unconditional in the weights",
+      "generalized parallel axis"
+    ],
+    "prerequisites": [
+      "the bilinearity lemma inner_weighted_sum",
+      "norm_sub_sq_real"
+    ],
+    "tags": ["insight", "master-identity", "key"]
+  },
+  {
+    "id": "ann-bfs-leibniz",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 94, "endLine": 106 },
+    "type": "insight",
+    "title": "Corollary: The Leibniz Relation at the Barycenter",
+    "content": "weighted_leibniz specializes the master identity to g = the weighted barycenter, i.e. ∑ᵢ wᵢ•vᵢ = W•g. Then the displacement (∑ᵢ wᵢ•vᵢ) − W•g is 0, so the cross inner product vanishes (sub_self, inner_zero_right), leaving the clean Leibniz relation ∑ᵢ wᵢ‖p−vᵢ‖² = W‖p−g‖² + ∑ᵢ wᵢ‖vᵢ−g‖². All dependence on the observer p is concentrated in the single term W‖p−g‖² — the generalized parallel-axis theorem, with ∑ᵢ wᵢ‖vᵢ−g‖² the moment of inertia about the barycenter.",
+    "mathContext": "At the barycenter $g$: $\\sum_i w_i\\lVert p-v_i\\rVert^2 = W\\lVert p-g\\rVert^2 + \\sum_i w_i\\lVert v_i-g\\rVert^2$ — the $p$-dependence is isolated in $W\\lVert p-g\\rVert^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "barycenter / center of mass",
+      "parallel axis theorem",
+      "moment of inertia",
+      "vanishing cross term"
+    ],
+    "prerequisites": [
+      "the master identity",
+      "the barycenter condition ∑ wᵢvᵢ = Wg"
+    ],
+    "tags": ["insight", "leibniz", "barycenter"]
+  },
+  {
+    "id": "ann-bfs-independence",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 108, "endLine": 126 },
+    "type": "insight",
+    "title": "Corollary: British-Flag Observer-Independence (n points)",
+    "content": "british_flag_independence is the abstract British Flag Theorem for n points. With BALANCED weights — total weight W = ∑ᵢ wᵢ = 0 and vanishing weighted centroid ∑ᵢ wᵢ•vᵢ = 0 — the weighted sum ∑ᵢ wᵢ‖p−vᵢ‖² does not depend on the observer p. The proof evaluates the master identity at reference point g = 0 for an arbitrary r: both the W‖r‖² term (W = 0) and the cross term (centroid 0) drop out, leaving ∑ᵢ wᵢ‖r−vᵢ‖² = ∑ᵢ wᵢ‖vᵢ‖², a constant free of r. Applying this to p and q gives equality. So a balanced signed combination of squared distances is an invariant of the point configuration alone — the essential content of the British Flag Theorem.",
+    "mathContext": "If $\\sum_i w_i=0$ and $\\sum_i w_i v_i=0$ then $\\sum_i w_i\\lVert p-v_i\\rVert^2 = \\sum_i w_i\\lVert v_i\\rVert^2$ for every $p$ — observer-independent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "British Flag Theorem",
+      "balanced weights (W = 0)",
+      "observer independence",
+      "configuration invariant"
+    ],
+    "prerequisites": [
+      "the master identity at g = 0",
+      "balanced-weight hypotheses"
+    ],
+    "tags": ["insight", "british-flag", "invariance"]
+  },
+  {
+    "id": "ann-bfs-rectangle",
+    "proofId": "british-flag-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 128, "endLine": 162 },
+    "type": "insight",
+    "title": "Corollary: The Classical Four-Point Rectangle Form",
+    "content": "british_flag_rectangle recovers the textbook statement ‖P−A‖²+‖P−C‖² = ‖P−B‖²+‖P−D‖² for a rectangle A,B,C,D, i.e. the balanced (1,−1,1,−1) instance. The rectangle is encoded as a parallelogram closure C = B + D − A plus orthogonality ⟪B−A, D−A⟫ = 0. The proof computes the parallelogram defect directly: rewriting the four vertices through A and expanding with norm_sub_sq_real and norm_add_sq_real, the signed sum equals 2⟪B−A, D−A⟫ — independent of P — which orthogonality kills. The docstring flags that this hypothesis is genuinely needed: for a non-rectangular parallelogram the observer-independent constant is 2⟪B−A, D−A⟫ ≠ 0. Matches BritishFlagTheoremOQ01OQ01.british_flag.",
+    "mathContext": "For a rectangle ($C=B+D-A$, $\\langle B-A,D-A\\rangle=0$): $\\lVert P-A\\rVert^2+\\lVert P-C\\rVert^2 = \\lVert P-B\\rVert^2+\\lVert P-D\\rVert^2$; the parallelogram defect $2\\langle B-A,D-A\\rangle$ vanishes iff the sides are orthogonal.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "classical British Flag Theorem",
+      "parallelogram defect",
+      "orthogonality of sides",
+      "norm_add_sq_real"
+    ],
+    "prerequisites": [
+      "british_flag_independence (conceptually)",
+      "parallelogram closure and orthogonality"
+    ],
+    "tags": ["insight", "rectangle", "classical"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `british-flag-theorem-oq-01-oq-01-oq-02` ("The Weighted Leibniz Identity — Affine-Simplex Generalization of the British Flag Theorem").

This freshly-added research entry (#33921) had a rich ~20 KB meta.json but **no annotations.json at all** — zero inline coverage of the 163-line proof. Created the file from scratch with 6 annotations giving continuous coverage (1–162), each with mathContext, significance, relatedConcepts, and prerequisites:

1. **Header/context (1–61)** — the one identity behind Leibniz, British-Flag, and the rectangle theorem; the reference-point translation strategy.
2. **`inner_weighted_sum` (63–72)** — the bilinearity engine collapsing the weighted cross sum into one inner product.
3. **`weighted_dist_sq_master` (73–92)** — the headline unconditional weighted squared-distance identity (via `norm_sub_sq_real` + the bilinearity lemma).
4. **`weighted_leibniz` (94–106)** — the Leibniz relation at the barycenter (parallel-axis theorem; p-dependence isolated in W‖p−g‖²).
5. **`british_flag_independence` (108–126)** — observer-independence for balanced weights (W=0, centroid 0): the abstract n-point British Flag Theorem.
6. **`british_flag_rectangle` (128–162)** — the classical four-point rectangle form as the (1,−1,1,−1) instance; parallelogram defect 2⟪B−A,D−A⟫ killed by orthogonality.

No meta.json changes (status/badge/axiomCount already verified/0). JSON validated.