### PR TITLE
Research: sperner-mathlib4-oq-02 — hemisphere↔lower-dimension graph isomorphism of the cross-polytope door graph

### DIFF
--- a/proofs/Proofs/SpernerTuckerCrossPolytopeHemisphereIso.lean
+++ b/proofs/Proofs/SpernerTuckerCrossPolytopeHemisphereIso.lean
@@ -1,0 +1,109 @@
+/-
+  Sperner → Tucker program, `sperner-mathlib4-oq-02`.
+
+  # The hemisphere ↔ lower-dimension GRAPH ISOMORPHISM of the cross-polytope door graph
+
+  `SpernerTuckerCrossPolytopeHemisphere` established the coordinate-`0` drop/lift bijection
+  `hemisphereEquiv : {s : Facet (n+1) // s 0 = true} ≃ Facet n` and proved, *pointwise*, that
+  it preserves cube-adjacency (`hemisphere_adj_iff`: for facets in the positive hemisphere,
+  `(crossGraph (n+1)).Adj s t ↔ (crossGraph n).Adj (drop s) (drop t)`).  That is the raw
+  ingredient of the dimension recursion the open `TuckerTower.bridge` runs on — but a *pointwise*
+  adjacency-iff is not yet a first-class object one can transport global graph properties along.
+
+  This file packages it as a genuine **graph isomorphism**
+
+    `hemisphereIso : (crossGraph (n+1)).induce {s | s 0 = true} ≃g crossGraph n`,
+
+  the induced subgraph on the positive hemisphere mapped isomorphically onto the *entire* lower
+  cross-polytope graph `crossGraph n`.  With the isomorphism in hand, the level-`n` structure is
+  transported into a single hemisphere of the level-`(n+1)` sphere as first-class facts, exactly
+  the shape `bridge` consumes:
+
+    * `hemisphere_induce_connected` — the induced hemisphere door graph is **connected**, in
+      every dimension (transport of `crossGraph_connected` along `hemisphereIso`).  This is the
+      pseudomanifold-connectivity the path-following engine needs *localised to one hemisphere
+      fundamental domain* — the global counterpart, inside the symmetry-broken half, of the
+      ambient `SpernerTuckerCrossPolytopeConnected.crossGraph_connected`.
+    * `hemisphere_induce_degree` / `hemisphere_induce_regular` — the induced hemisphere door
+      graph is **`(n+1)`-regular** (transport of `facet_degree`): every hemisphere facet has, as
+      *interior* doors, exactly the `n+1` neighbours of its drop in `crossGraph n`.  This is the
+      graph-level upgrade of the pointwise `hemisphere_degree_split` (`#interior doors = n+1`).
+
+  So one hemisphere of `∂◊^{n+1}` carries an `(n+1)`-regular connected graph isomorphic to the
+  full lower cross-polytope `∂◊^{n}` — the precise "the level-`n` interior door graph lives inside
+  a level-`(n+1)` hemisphere" statement, now as a `≃g` rather than a bare adjacency-iff.
+
+  Honest status: geometric/graph-theoretic infrastructure for `bridge`, not a proof of `bridge`.
+  It does not install the Tucker labelling that turns the cube edges into *complementary* doors
+  (that labelling-broken almost-complementary structure carrying the odd interior seed remains the
+  open frontier).  Everything here is dimension-free (no `decide` / `native_decide`) and 0-axiom
+  (`propext` / `Classical.choice` / `Quot.sound` only), as the `#print axioms` guards confirm.
+-/
+import Mathlib
+import Proofs.SpernerTuckerCrossPolytopeHemisphere
+import Proofs.SpernerTuckerCrossPolytopeConnected
+
+namespace SpernerTuckerCrossPolytopeHemisphereIso
+
+open Finset SimpleGraph SpernerTuckerCrossPolytopeBoundary
+  SpernerTuckerCrossPolytopeHemisphere SpernerTuckerCrossPolytopeConnected
+
+variable (n : ℕ)
+
+/-! ## The hemisphere as an induced subgraph, isomorphic to the lower cross-polytope -/
+
+/-- **The hemisphere graph isomorphism.**  The subgraph of the `(n+2)`-cube `crossGraph (n+1)`
+induced on the positive hemisphere `{s | s 0 = true}` is isomorphic, via the coordinate-`0` drop
+`hemisphereEquiv`, to the *entire* lower cross-polytope graph `crossGraph n`.  This upgrades the
+pointwise adjacency-iff `hemisphere_adj_iff` to a first-class `≃g`, so that global graph properties
+(connectivity, regularity) transport between the two dimensions. -/
+def hemisphereIso :
+    (crossGraph (n + 1)).induce {s : Facet (n + 1) | s 0 = true} ≃g crossGraph n where
+  toEquiv := hemisphereEquiv n
+  map_rel_iff' {a b} := by
+    -- `(induce _).Adj a b` is defeq to `(crossGraph (n+1)).Adj a.1 b.1`; the map sends
+    -- `a ↦ drop a.1`, so this is exactly `hemisphere_adj_iff`.
+    change (crossGraph n).Adj (drop n a.1) (drop n b.1) ↔ (crossGraph (n + 1)).Adj a.1 b.1
+    exact (hemisphere_adj_iff n a.2 b.2).symm
+
+@[simp] theorem hemisphereIso_apply (a : {s : Facet (n + 1) | s 0 = true}) :
+    hemisphereIso n a = drop n a.1 := rfl
+
+/-! ## Transported global structure: connectivity and regularity of one hemisphere -/
+
+/-- **The induced hemisphere door graph is connected, in every dimension.**  Transport of the
+ambient `crossGraph_connected` along `hemisphereIso`.  Path-following needs the ambient
+triangulated sphere connected so a walk from a boundary door can reach an interior complementary
+simplex; this supplies that connectivity *within a single hemisphere fundamental domain* — the
+symmetry-broken half on which the odd seed lives. -/
+theorem hemisphere_induce_connected :
+    ((crossGraph (n + 1)).induce {s : Facet (n + 1) | s 0 = true}).Connected :=
+  (hemisphereIso n).connected_iff.mpr (crossGraph_connected n)
+
+/-- **Every hemisphere facet has exactly `n+1` interior doors.**  The degree of a facet in the
+induced hemisphere graph equals the degree of its coordinate-`0` drop in `crossGraph n`, namely
+`n+1` (`facet_degree`).  The graph-level form of `hemisphere_degree_split`'s `#interior = n+1`,
+transported along the neighbour-set equivalence of `hemisphereIso`. -/
+theorem hemisphere_induce_degree (a : {s : Facet (n + 1) | s 0 = true}) :
+    ((crossGraph (n + 1)).induce {s : Facet (n + 1) | s 0 = true}).degree a = n + 1 := by
+  rw [← card_neighborSet_eq_degree,
+      Fintype.card_congr ((hemisphereIso n).mapNeighborSet a),
+      card_neighborSet_eq_degree]
+  exact facet_degree n _
+
+/-- **The induced hemisphere door graph is `(n+1)`-regular, in every dimension.**  So one
+hemisphere of `∂◊^{n+1}` carries a full `(n+1)`-regular connected copy of the lower cross-polytope
+`∂◊^{n}` — the interior door graph the dimension recursion identifies. -/
+theorem hemisphere_induce_regular :
+    ((crossGraph (n + 1)).induce {s : Facet (n + 1) | s 0 = true}).IsRegularOfDegree (n + 1) :=
+  fun a => hemisphere_induce_degree n a
+
+/-! ## Axiom audit -- all results are 0-axiom (no `sorryAx`, no `Lean.ofReduceBool`),
+dimension-free (no `decide` / `native_decide`). -/
+
+#print axioms hemisphereIso
+#print axioms hemisphere_induce_connected
+#print axioms hemisphere_induce_degree
+#print axioms hemisphere_induce_regular
+
+end SpernerTuckerCrossPolytopeHemisphereIso

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -4,6 +4,66 @@ Tucker's lemma (and Borsuk–Ulam) from the parent's abstract door-counting engi
 
 ---
 
+## Session 2026-07-02 (researcher-5) — BUILD: the hemisphere ↔ lower-dimension GRAPH ISOMORPHISM (Insight 9)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress (BUILD) — new
+`proofs/Proofs/SpernerTuckerCrossPolytopeHemisphereIso.lean` (~110 LOC, 3 thm + 1 def + 1 `@[simp]`,
+0 sorries, 0 `axiom` decls, dimension-free — no `decide`/`native_decide`).
+
+**Verification**: host `lake env lean` over the main-repo Mathlib `.olean` cache, **exit 0, 0
+errors**. First rebuilt the missing dependency olean
+`SpernerTuckerCrossPolytopeConnected.olean` (single-file elaboration, re-confirmed 0-axiom =
+`[propext, Classical.choice, Quot.sound]`), then elaborated the new file: all four
+`#print axioms` guards report **`[propext, Classical.choice, Quot.sound]` only** — no `sorryAx`,
+no `Lean.ofReduceBool`, no `decide`. (Single-file `lake env lean` used, not `lake build`, for
+memory safety per the repo policy.)
+
+### What it proves (Insight 9)
+The two prior cross-polytope sessions proved the hemisphere ↔ lower-dimension recursion only
+**pointwise**: `SpernerTuckerCrossPolytopeHemisphere.hemisphere_adj_iff` is a bare adjacency-iff
+`(crossGraph (n+1)).Adj s t ↔ (crossGraph n).Adj (drop s) (drop t)` on the positive hemisphere,
+and `hemisphere_degree_split` gave `#interior doors = n+1` as a numeric fact. Neither packaged the
+recursion as a first-class object one can transport *global* graph properties along.
+
+This session installs the **graph isomorphism**
+`hemisphereIso : (crossGraph (n+1)).induce {s | s 0 = true} ≃g crossGraph n` — the induced subgraph
+on the positive hemisphere mapped isomorphically onto the *entire* lower cross-polytope graph
+`crossGraph n`, via the coordinate-`0` drop `hemisphereEquiv`. The `≃g` is built directly from
+`hemisphere_adj_iff` (the `map_rel_iff'` field is `(hemisphere_adj_iff n a.2 b.2).symm` after a
+`change` exposing the `induce`/`comap` defeq). With the iso in hand, two level-`n` facts transport
+into a single hemisphere of the level-`(n+1)` sphere:
+- `hemisphere_induce_connected` — the induced hemisphere door graph is **connected** in every
+  dimension (`(hemisphereIso n).connected_iff.mpr (crossGraph_connected n)`). This is the
+  path-following pseudomanifold-connectivity *localised to one hemisphere fundamental domain* — the
+  symmetry-broken half on which the odd seed lives — the counterpart inside the half of the ambient
+  `SpernerTuckerCrossPolytopeConnected.crossGraph_connected`.
+- `hemisphere_induce_degree` / `hemisphere_induce_regular` — the induced hemisphere door graph is
+  **`(n+1)`-regular** (`facet_degree` transported along `(hemisphereIso n).mapNeighborSet` +
+  `card_neighborSet_eq_degree`). The graph-level upgrade of `hemisphere_degree_split`'s numeric
+  `#interior = n+1`.
+
+Net: one hemisphere of `∂◊^{n+1}` carries an `(n+1)`-regular **connected** graph isomorphic to the
+full lower cross-polytope `∂◊^{n}` — the precise "the level-`n` interior door graph lives inside a
+level-`(n+1)` hemisphere" statement `bridge` runs its induction on, now a `≃g` rather than a
+pointwise adjacency-iff, so future work can transport endpoint counts and connectivity for free.
+
+### Honest status
+Graph-theoretic infrastructure for `bridge`, **not** a proof of `bridge`. Still no Tucker
+*labelling* turning the cube edges into *complementary* doors; the labelling-broken
+almost-complementary structure carrying the odd interior seed remains the open frontier. Value is
+that the recursion is now a transportable graph iso, and hemisphere connectivity (needed by
+path-following) is established as a corollary.
+
+### Next steps (frontier unchanged)
+- Build the **asymmetric** Tucker labelling on ∂◊^{n+1} whose hemisphere half (now known to be a
+  connected `(n+1)`-regular copy of ∂◊^{n}) carries the ODD interior seed. Connect to
+  `AntipodalParity.bridge_of_card_eq` / `InductiveTower.TuckerTower.bridge`.
+- Transport `interiorEndpoints`/boundary-door **counts** along `hemisphereIso` to state the
+  `bridge` count-equality `#boundary(n+1) = #interior(n)` on the hemisphere directly.
+- Continuous n≥2 Tucker ⟹ Borsuk–Ulam (mesh→0 + compactness): separate analytic phase.
+
+---
+
 ## Session 2026-07-02 (researcher-5) — BUILD: the canonical signed labelling + naive-labelling no-go (Insight 8)
 
 **Mode**: REVISIT (RICH). **Outcome**: progress (BUILD) — new


### PR DESCRIPTION
## Summary

Advances `sperner-mathlib4-oq-02` (Tucker's Lemma / Borsuk–Ulam from abstract door-counting). The two prior cross-polytope sessions proved the hemisphere ↔ lower-dimension recursion only **pointwise** (`SpernerTuckerCrossPolytopeHemisphere.hemisphere_adj_iff`, a bare adjacency-iff; `hemisphere_degree_split`, a numeric `#interior = n+1`). This PR packages that recursion as a **first-class graph isomorphism** and transports global graph structure along it.

New file `proofs/Proofs/SpernerTuckerCrossPolytopeHemisphereIso.lean` (~110 LOC, 3 thm + 1 def, 0 sorries, 0 axioms):

- **`hemisphereIso : (crossGraph (n+1)).induce {s | s 0 = true} ≃g crossGraph n`** — the induced subgraph on the positive hemisphere, mapped isomorphically onto the *entire* lower cross-polytope graph via the coordinate-`0` drop `hemisphereEquiv`. The `≃g`'s `map_rel_iff'` is `hemisphere_adj_iff` after a `change` exposing the `induce`/`comap` defeq.
- **`hemisphere_induce_connected`** — the induced hemisphere door graph is **connected**, every dimension (transport of `crossGraph_connected` via `Iso.connected_iff`). Path-following pseudomanifold-connectivity, localised to the symmetry-broken hemisphere fundamental domain.
- **`hemisphere_induce_degree` / `hemisphere_induce_regular`** — the induced hemisphere door graph is **`(n+1)`-regular** (`facet_degree` transported via `Iso.mapNeighborSet` + `card_neighborSet_eq_degree`). Graph-level upgrade of `hemisphere_degree_split`.

Net: one hemisphere of `∂◊^{n+1}` is a verified connected `(n+1)`-regular copy of `∂◊^{n}` — the precise "the level-`n` interior door graph lives inside a level-`(n+1)` hemisphere" statement `bridge` runs its dimension induction on, now a `≃g` rather than a pointwise adjacency-iff, so future work can transport endpoint counts and connectivity for free.

## Verification

Host `lake env lean` over the main-repo Mathlib `.olean` cache — **exit 0, 0 errors** (single-file elaboration, not `lake build`, per repo memory-safety policy). All four `#print axioms` guards report **`[propext, Classical.choice, Quot.sound]` only** — 0-axiom, no `sorryAx`, no `Lean.ofReduceBool`, dimension-free (no `decide`/`native_decide`). Auto-discovered by the `Proofs.*` lakefile glob (no shared-import edit).

## Honest status

Infrastructure for `bridge`, **not** a proof of `bridge`. No Tucker *labelling* turning cube edges into *complementary* doors is installed; the labelling-broken almost-complementary structure carrying the odd interior seed remains the open frontier. Value: the recursion is now a transportable graph iso, and hemisphere connectivity (needed by path-following) is established as a corollary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)