### PR TITLE
Enrich Cubic Sine Limit: annotate squeeze obligations & filter-membership technique (4→5)

### DIFF
--- a/src/data/proofs/lhopital-oq-05/annotations.json
+++ b/src/data/proofs/lhopital-oq-05/annotations.json
@@ -2,49 +2,118 @@
   {
     "id": "ann-lhoq05-header",
     "proofId": "lhopital-oq-05",
-    "range": { "startLine": 1, "endLine": 32 },
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
     "type": "concept",
     "title": "A Taylor-bound squeeze instead of three L'Hôpital passes",
     "content": "The limit lim_{x→0} (x − sin x)/x³ = 1/6 is the textbook example where L'Hôpital must be applied **three times** (numerator and denominator vanish to third order at 0). This entry sidesteps that entirely: the leading nonzero Taylor term of x − sin x is x³/6, and Mathlib already ships the explicit cubic Taylor bound `Real.sin_bound : |x| ≤ 1 → |sin x − (x − x³/6)| ≤ |x|⁴·(5/96)`. The decisive observation is a degree count — the **error term has degree 4** while the **denominator is x³** — so the deviation of the quotient from 1/6 is controlled *linearly*: |(x−sin x)/x³ − 1/6| ≤ (5/96)·|x|. Since that bound → 0 and holds on a punctured neighbourhood of 0 (where |x| ≤ 1 is automatic), a squeeze delivers the limit with no iterated differentiation. The file imports only Mathlib and opens `Filter`/`Topology` for the neighbourhood filters.",
     "mathContext": "$\\left|\\frac{x-\\sin x}{x^3}-\\frac16\\right| = \\frac{|\\sin x-(x-x^3/6)|}{|x|^3} \\le \\frac{|x|^4\\cdot 5/96}{|x|^3} = \\frac{5}{96}|x| \\xrightarrow[x\\to0]{} 0.$ The degree-4 numerator error beats the degree-3 denominator by one power of $x$.",
     "significance": "supporting",
-    "relatedConcepts": ["Taylor's theorem with explicit remainder", "Real.sin_bound", "squeeze theorem", "iterated L'Hôpital", "order of vanishing"],
-    "prerequisites": ["Taylor expansion of sine", "the squeeze theorem", "order of a zero"]
+    "relatedConcepts": [
+      "Taylor's theorem with explicit remainder",
+      "Real.sin_bound",
+      "squeeze theorem",
+      "iterated L'Hôpital",
+      "order of vanishing"
+    ],
+    "prerequisites": [
+      "Taylor expansion of sine",
+      "the squeeze theorem",
+      "order of a zero"
+    ]
   },
   {
     "id": "ann-deviation-bound",
     "proofId": "lhopital-oq-05",
-    "range": { "startLine": 33, "endLine": 47 },
+    "range": {
+      "startLine": 33,
+      "endLine": 47
+    },
     "type": "insight",
     "title": "Divide the Taylor Remainder by x³",
     "content": "abs_sub_le is the quantitative heart of the limit. Mathlib's Real.sin_bound says |sin x − (x − x³/6)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the cubic Maclaurin remainder. Rewriting the deviation as −(sin x − (x − x³/6))/x³ (field_simp; ring), then using |a/b| = |a|/|b| and |x³| = |x|³, the deviation equals |sin x − (x − x³/6)|/|x|³. Dividing the degree-4 numerator bound by the degree-3 denominator leaves (5/96)·|x|: a bound linear in x that visibly vanishes. No differentiation, no L'Hôpital — the indeterminate 0/0 is resolved by a single off-the-shelf Taylor estimate.",
     "mathContext": "$\\left|\\dfrac{x-\\sin x}{x^3} - \\dfrac16\\right| = \\dfrac{|\\sin x - (x - x^3/6)|}{|x|^3} \\le \\dfrac{(5/96)|x|^4}{|x|^3} = \\tfrac{5}{96}|x|.$",
     "significance": "key",
-    "relatedConcepts": ["Taylor remainder", "Maclaurin series of sine", "error bounds", "Real.sin_bound"],
-    "prerequisites": ["Taylor's theorem with remainder", "absolute value algebra"]
+    "relatedConcepts": [
+      "Taylor remainder",
+      "Maclaurin series of sine",
+      "error bounds",
+      "Real.sin_bound"
+    ],
+    "prerequisites": [
+      "Taylor's theorem with remainder",
+      "absolute value algebra"
+    ]
   },
   {
     "id": "ann-the-limit",
     "proofId": "lhopital-oq-05",
-    "range": { "startLine": 49, "endLine": 69 },
+    "range": {
+      "startLine": 49,
+      "endLine": 55
+    },
     "type": "insight",
-    "title": "One Squeeze Finishes It",
-    "content": "tendsto_cubic_sine reduces the limit-to-1/6 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|. The bound |deviation| ≤ a x from abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x| → 0 (continuity of absolute value) scaled by 5/96. The two-sided control sits inside a single absolute value, so one squeeze — not separate upper and lower envelopes — suffices.",
-    "mathContext": "$0 \\le \\left|\\tfrac{x-\\sin x}{x^3} - \\tfrac16\\right| \\le \\tfrac{5}{96}|x| \\to 0$ on $\\mathcal{N}_{\\neq}(0)$ (squeeze).",
+    "title": "Reducing the Limit to a One-Sided Normed Squeeze",
+    "content": "tendsto_cubic_sine first turns the goal `(x−sin x)/x³ → 1/6` into a limit-to-0 for the deviation via tendsto_sub_nhds_zero_iff, then applies squeeze_zero_norm' with the explicit envelope a x = (5/96)·|x|. squeeze_zero_norm' concludes f → 0 from just an *upper* control ‖f x‖ ≤ a x (eventually) together with a → 0 — no matching lower envelope is needed, because the two-sided control already sits inside the single absolute value |deviation|. So the whole limit is reduced to two obligations: an eventual bound and a vanishing majorant.",
+    "mathContext": "$0 \\le \\left|\\tfrac{x-\\sin x}{x^3} - \\tfrac16\\right| \\le \\tfrac{5}{96}|x|$, and $\\tfrac{5}{96}|x| \\to 0$; the normed squeeze needs only this upper envelope.",
     "significance": "key",
-    "relatedConcepts": ["squeeze theorem", "punctured neighbourhood filter", "eventual bounds", "continuity of absolute value"],
-    "prerequisites": ["squeeze/sandwich theorem", "filters and neighbourhoods"]
+    "relatedConcepts": [
+      "squeeze_zero_norm'",
+      "tendsto_sub_nhds_zero_iff",
+      "normed squeeze",
+      "envelope/majorant"
+    ],
+    "prerequisites": [
+      "squeeze/sandwich theorem",
+      "limits of the difference"
+    ]
+  },
+  {
+    "id": "ann-squeeze-obligations",
+    "proofId": "lhopital-oq-05",
+    "range": {
+      "startLine": 56,
+      "endLine": 69
+    },
+    "type": "technique",
+    "title": "Discharging the Two Squeeze Obligations via Filter Membership",
+    "content": "The normed squeeze leaves two goals. (1) **Eventual bound.** abs_sub_le needs both x ≠ 0 and |x| ≤ 1; both are produced as *filter membership* facts on 𝓝[≠] 0: self_mem_nhdsWithin gives x ≠ 0, and the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds), pulled into the punctured filter by nhdsWithin_le_nhds — so |x| ≤ 1 holds eventually; filter_upwards conjoins them and hands both hypotheses to abs_sub_le, after unfolding closed-ball membership to |x| ≤ 1 (Real.dist_eq). This is how an analytic 'for x near 0' is discharged in Mathlib's filter idiom without ever choosing an explicit δ. (2) **Vanishing majorant.** (5/96)·|x| → 0 because |x| → 0 (continuity of absolute value, continuous_abs.tendsto) restricted to the punctured filter and scaled by the constant 5/96.",
+    "mathContext": "Eventual bound holds on $\\overline{B}(0,1)\\cap\\{x\\neq 0\\}\\in\\mathcal{N}_{\\neq}(0)$; majorant $\\tfrac{5}{96}|x|\\xrightarrow[x\\to0]{}\\tfrac{5}{96}\\cdot 0=0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "punctured neighbourhood filter 𝓝[≠]",
+      "filter_upwards",
+      "closedBall_mem_nhds",
+      "continuity of absolute value"
+    ],
+    "prerequisites": [
+      "filters and eventual (frequently/eventually) statements",
+      "neighbourhood bases in a metric space"
+    ]
   },
   {
     "id": "ann-taylor-coefficient",
     "proofId": "lhopital-oq-05",
-    "range": { "startLine": 71, "endLine": 81 },
+    "range": {
+      "startLine": 71,
+      "endLine": 81
+    },
     "type": "concept",
     "title": "1/6 Is the Third Taylor Coefficient (1/3!)",
     "content": "tendsto_cubic_sine_factorial restates the value 1/6 as 1/3!. This is not cosmetic: x − sin x = x³/6 − x⁵/120 + ⋯, so its leading nonvanishing Maclaurin term is x³/3!, and the limit of (x − sin x)/x³ is exactly that coefficient 1/3!. It mirrors the order-1 sibling entry (lhopital-oq-04), where the limit is the ratio of first Taylor coefficients f′(a)/1! — here the single third coefficient is read off directly, exhibiting L'Hôpital-at-order-k as Taylor-coefficient extraction.",
     "mathContext": "$\\dfrac{x-\\sin x}{x^3} \\to \\dfrac{1}{3!} = \\dfrac16$, the order-3 Maclaurin coefficient of $x-\\sin x$.",
     "significance": "supporting",
-    "relatedConcepts": ["Taylor coefficients", "factorial denominators", "higher-order L'Hôpital", "Maclaurin series"],
-    "prerequisites": ["Maclaurin expansion", "factorials"]
+    "relatedConcepts": [
+      "Taylor coefficients",
+      "factorial denominators",
+      "higher-order L'Hôpital",
+      "Maclaurin series"
+    ],
+    "prerequisites": [
+      "Maclaurin expansion",
+      "factorials"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-05` ("The Cubic Sine Limit: (x − sin x)/x³ → 1/6").

## Change
- **annotations.json: 4 → 5 annotations**, reaching the coverage minimum.
- Split the `tendsto_cubic_sine` annotation (was L49–69) at its natural seam:
  - `ann-the-limit` (L49–55) — the **reduction** to a one-sided normed squeeze (`tendsto_sub_nhds_zero_iff` + `squeeze_zero_norm'`).
  - new `ann-squeeze-obligations` (L56–69, `type: technique`) — **discharging the two obligations**, with a focused explanation of the filter-membership idiom (`self_mem_nhdsWithin`, `Metric.closedBall_mem_nhds`, `nhdsWithin_le_nhds`, `filter_upwards`) that auto-supplies the `|x| ≤ 1` hypothesis, plus the vanishing majorant via `continuous_abs.tendsto`.

## Why
The squeeze proof has two genuinely distinct conceptual layers, and the filter-membership technique — how Mathlib discharges an analytic "for x near 0" without choosing an explicit δ — is real pedagogy that the single bundled annotation only mentioned in passing. Both new annotations carry full `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`; ranges stay disjoint and coverage is contiguous.

## Scope
- Touches **only** `annotations.json`; `meta.json` is byte-identical to `origin/main`. No open PRs on this slug.
