### PR TITLE
Enrich Markov Triples Coprime: annotate the parity corollary (4→5 annotations)

### DIFF
--- a/src/data/proofs/markov-equation-oq-04/annotations.json
+++ b/src/data/proofs/markov-equation-oq-04/annotations.json
@@ -2,49 +2,119 @@
   {
     "id": "markov-oq04-ann-header",
     "proofId": "markov-equation-oq-04",
-    "range": { "startLine": 1, "endLine": 50 },
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
     "type": "concept",
     "title": "Coprimality as a Markov-Tree Invariant",
     "content": "The Markov equation x² + y² + z² = 3xyz has every positive solution reachable from the root (1,1,1) by Vieta jumps z ↦ 3xy − z and coordinate transpositions (proved in the parent Proofs.MarkovEquation). This file shows the three coordinates of any positive Markov triple are pairwise coprime — not by a fresh descent, but as a property that holds at the root and is preserved by every generating move. The `Coprime3` predicate bundles the three `IsCoprime` statements on the product type ℤ × ℤ × ℤ so the induction lines up with the Step/Reachable infrastructure without higher-order unification trouble.",
     "mathContext": "$x^2 + y^2 + z^2 = 3xyz; \\qquad \\mathrm{Coprime3}(x,y,z) := \\gcd(x,y) = \\gcd(y,z) = \\gcd(x,z) = 1.$",
     "significance": "key",
-    "relatedConcepts": ["Markov equation", "Vieta jumping", "Markov tree", "pairwise coprimality"],
-    "prerequisites": ["Diophantine equations", "gcd / IsCoprime over ℤ", "reachability relations"]
+    "relatedConcepts": [
+      "Markov equation",
+      "Vieta jumping",
+      "Markov tree",
+      "pairwise coprimality"
+    ],
+    "prerequisites": [
+      "Diophantine equations",
+      "gcd / IsCoprime over ℤ",
+      "reachability relations"
+    ]
   },
   {
     "id": "markov-oq04-ann-vieta",
     "proofId": "markov-equation-oq-04",
-    "range": { "startLine": 52, "endLine": 67 },
+    "range": {
+      "startLine": 52,
+      "endLine": 67
+    },
     "type": "theorem",
     "title": "The Vieta Jump Preserves Coprimality",
     "content": "`coprime_fst_vieta` and `coprime_snd_vieta` are the entire arithmetic content: a Vieta jump z ↦ 3xy − z leaves coprimality with x and with y unchanged, because 3xy − z = −z + x·(3y) = −z + y·(3x) differs from −z by a multiple of x (resp. y). Each is proved by rewriting the expression and applying `IsCoprime.add_mul_left_right_iff` (adding a multiple of x to the right argument preserves IsCoprime x) and `IsCoprime.neg_right_iff` (negation preserves coprimality). Thus IsCoprime x (3xy−z) ↔ IsCoprime x z.",
     "mathContext": "$\\gcd(x,\\,3xy - z) = \\gcd(x, z), \\qquad \\gcd(y,\\,3xy - z) = \\gcd(y, z).$",
     "significance": "critical",
-    "relatedConcepts": ["Vieta involution", "IsCoprime.add_mul_left_right_iff", "congruence mod x", "invariance"],
-    "prerequisites": ["IsCoprime API", "ring normalization"]
+    "relatedConcepts": [
+      "Vieta involution",
+      "IsCoprime.add_mul_left_right_iff",
+      "congruence mod x",
+      "invariance"
+    ],
+    "prerequisites": [
+      "IsCoprime API",
+      "ring normalization"
+    ]
   },
   {
     "id": "markov-oq04-ann-invariant",
     "proofId": "markov-equation-oq-04",
-    "range": { "startLine": 69, "endLine": 106 },
+    "range": {
+      "startLine": 69,
+      "endLine": 106
+    },
     "type": "theorem",
     "title": "Transporting Coprimality from the Root",
     "content": "Three steps assemble the invariant. `coprime3_one`: the root (1,1,1) is pairwise coprime (gcd 1 1 = 1). `coprime3_of_step`: any single move preserves Coprime3 — transpositions merely permute the three coprimality statements, and the Vieta jump uses the two preservation lemmas; because every move is its own inverse, the backward direction needed for head-induction is available. `coprime3_of_isMarkov`: `markov_classification` (parent) gives a reachability path from any positive triple to the root, and `Relation.ReflTransGen.head_induction_on` pushes coprimality back one move at a time from (1,1,1) to the given triple.",
     "mathContext": "$\\mathrm{Reachable}\\,(x,y,z)\\,(1,1,1) \\implies \\mathrm{Coprime3}(x,y,z).$",
     "significance": "critical",
-    "relatedConcepts": ["head induction", "ReflTransGen", "involutive moves", "invariant propagation"],
-    "prerequisites": ["the Vieta preservation lemmas", "markov_classification", "Relation.ReflTransGen"]
+    "relatedConcepts": [
+      "head induction",
+      "ReflTransGen",
+      "involutive moves",
+      "invariant propagation"
+    ],
+    "prerequisites": [
+      "the Vieta preservation lemmas",
+      "markov_classification",
+      "Relation.ReflTransGen"
+    ]
   },
   {
     "id": "markov-oq04-ann-headline",
     "proofId": "markov-equation-oq-04",
-    "range": { "startLine": 108, "endLine": 165 },
+    "range": {
+      "startLine": 108,
+      "endLine": 135
+    },
     "type": "theorem",
-    "title": "Headline Coprimality and the Parity Corollary",
-    "content": "`markov_coprime` states the headline (all three pairs coprime) with single-pair projections, and `markov_gcd_eq_one` restates it via `Int.gcd · · = 1`. The parity consequence follows from `not_two_dvd_both`: a coprime pair cannot share the factor 2, since `IsCoprime.isUnit_of_dvd'` would make 2 a unit in ℤ (ruled out by `Int.isUnit_iff`). Hence `markov_at_most_one_even` / `markov_not_both_even`: no two coordinates of a Markov triple are simultaneously even — matching (1,1,1), (1,1,2), (1,2,5), (2,5,29), … where even entries are isolated. Sanity checks confirm the small triples.",
-    "mathContext": "$\\mathrm{IsCoprime}\\,a\\,b \\implies \\lnot(2 \\mid a \\land 2 \\mid b); \\qquad \\text{at most one of } x,y,z \\text{ is even}.$",
+    "title": "Headline: All Three Pairs Are Coprime",
+    "content": "markov_coprime is the headline result — in any positive Markov triple the three pairs (x,y), (y,z), (x,z) are each coprime over ℤ — read straight off coprime3_of_isMarkov. The three single-pair projections markov_coprime_12 / _23 / _13 expose each coprimality individually for downstream use. markov_gcd_eq_one then restates the whole thing in gcd form via Int.isCoprime_iff_gcd_eq_one, delivering Int.gcd x y = Int.gcd y z = Int.gcd x z = 1 — the phrasing most convenient for number-theoretic consequences.",
+    "mathContext": "$\\gcd(x,y)=\\gcd(y,z)=\\gcd(x,z)=1$ for every positive solution of $x^2+y^2+z^2=3xyz$.",
     "significance": "key",
-    "relatedConcepts": ["gcd = 1", "parity", "units of ℤ", "Lagrange spectrum normalization"],
-    "prerequisites": ["the coprimality theorem", "IsCoprime.isUnit_of_dvd'", "Int.isUnit_iff"]
+    "relatedConcepts": [
+      "pairwise coprimality",
+      "Int.isCoprime_iff_gcd_eq_one",
+      "gcd = 1 form",
+      "Markov numbers"
+    ],
+    "prerequisites": [
+      "the coprimality invariant coprime3_of_isMarkov",
+      "IsCoprime ↔ gcd = 1 over ℤ"
+    ]
+  },
+  {
+    "id": "markov-oq04-ann-parity",
+    "proofId": "markov-equation-oq-04",
+    "range": {
+      "startLine": 137,
+      "endLine": 165
+    },
+    "type": "theorem",
+    "title": "The Parity Corollary: At Most One Even Coordinate",
+    "content": "The classical parity consequence of coprimality. not_two_dvd_both shows a coprime pair cannot share the factor 2: if 2 ∣ a and 2 ∣ b then IsCoprime.isUnit_of_dvd' would force 2 to be a unit in ℤ, contradicted by Int.isUnit_iff (the only ℤ-units are ±1). Applying this to each of the three coprime pairs gives markov_at_most_one_even — no two coordinates of a Markov triple are simultaneously even — and its Even-phrased form markov_not_both_even, the textbook statement 'two Markov numbers cannot both be even'. This matches the small triples (1,1,1), (1,1,2), (1,2,5), (2,5,29), … where any even entry is isolated. The closing examples sanity-check the coprimality, gcd, and parity APIs on those explicit triples.",
+    "mathContext": "$\\mathrm{IsCoprime}\\,a\\,b \\Rightarrow \\lnot(2\\mid a \\wedge 2\\mid b)$; hence at most one of $x,y,z$ is even (2 is not a unit in $\\mathbb{Z}$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parity",
+      "IsCoprime.isUnit_of_dvd'",
+      "units of ℤ (±1)",
+      "even Markov numbers"
+    ],
+    "prerequisites": [
+      "the pairwise coprimality theorem",
+      "units of a commutative ring",
+      "Int.isUnit_iff"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-04` ("Markov Triples Are Pairwise Coprime").

## Change
- **annotations.json: 4 → 5 annotations**, reaching the coverage minimum.
- Split the oversized "Headline Coprimality and the Parity Corollary" annotation (was L108–165, spanning 8 theorems + sanity examples) at its natural seam:
  - `markov-oq04-ann-headline` (L108–135) — the headline coprimality result, its three single-pair projections, and the `gcd = 1` form.
  - new `markov-oq04-ann-parity` (L137–165) — the **parity corollary**: `not_two_dvd_both` → `markov_at_most_one_even` → `markov_not_both_even` ("two Markov numbers cannot both be even"), plus the sanity checks.

## Why
The parity consequence — a famous classical fact about Markov numbers — was bundled into a single 58-line annotation covering everything from the headline to the sanity examples. Giving it its own annotation surfaces the `IsCoprime.isUnit_of_dvd'` / `Int.isUnit_iff` argument (2 is not a unit in ℤ) that the reader most wants explained. Both annotations carry full `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; ranges are disjoint and contiguous.

## Scope
- Touches **only** `annotations.json`; `meta.json` is byte-identical to `origin/main`. No open PRs on this slug.
