### PR TITLE
Enrich Niven's Theorem for Tangent: annotate double-angle bridge vs case dispatch (4→5)

### DIFF
--- a/src/data/proofs/niven-theorem-oq-03/annotations.json
+++ b/src/data/proofs/niven-theorem-oq-03/annotations.json
@@ -2,49 +2,118 @@
   {
     "id": "niven-oq03-header",
     "proofId": "niven-theorem-oq-03",
-    "range": { "startLine": 6, "endLine": 49 },
+    "range": {
+      "startLine": 6,
+      "endLine": 49
+    },
     "type": "concept",
     "title": "Niven for tangent: only {0, ±1}, via the double-angle bridge",
     "content": "The header states the tangent companion to Niven's theorem: if θ is a rational multiple of π and tan θ is rational, then tan θ ∈ {0, 1, −1} — a strictly smaller set than the five values {0, ±1/2, ±1} of the sine/cosine case. The strategy reduces to cosine Niven via the rational double-angle map cos(2θ) = (1 − tan²θ)/(1 + tan²θ), valid when cos θ ≠ 0: a rational tangent t makes cos(2θ) rational at the rational-multiple-of-π angle 2θ, so cosine Niven gives cos(2θ) ∈ {0, ±1/2, ±1}; solving for t leaves only {0, ±1}, since the two ±1/2 branches force t² = 1/3 or 3, impossible over ℚ (√3 irrational). At cos θ = 0, Lean's tan = sin/cos convention makes tan θ = 0, already in the target set — no side condition needed. Tangent is unbounded, so routing through the bounded image cos(2θ) restores a finite Niven enumeration.",
     "mathContext": "$\\theta \\in \\mathbb{Q}\\pi,\\ \\tan\\theta \\in \\mathbb{Q} \\implies \\tan\\theta \\in \\{0, 1, -1\\}$",
     "significance": "supporting",
-    "relatedConcepts": ["Niven's theorem", "double-angle identity", "rational multiples of π", "irrationality of √3"],
-    "prerequisites": ["Niven's cosine theorem", "tan = sin/cos", "the double-angle identity"]
+    "relatedConcepts": [
+      "Niven's theorem",
+      "double-angle identity",
+      "rational multiples of π",
+      "irrationality of √3"
+    ],
+    "prerequisites": [
+      "Niven's cosine theorem",
+      "tan = sin/cos",
+      "the double-angle identity"
+    ]
   },
   {
     "id": "niven-oq03-cos",
     "proofId": "niven-theorem-oq-03",
-    "range": { "startLine": 55, "endLine": 83 },
+    "range": {
+      "startLine": 55,
+      "endLine": 83
+    },
     "type": "theorem",
     "title": "cos_niven: the cosine classification (restated helper)",
     "content": "`cos_niven` restates Niven's cosine theorem (parent oq-01) so the tangent corollary is self-contained: if θ = (m/n)π and cos θ is rational, then cos θ ∈ {0, ±1/2, ±1}. The deep step — 2·cos θ is an algebraic integer — is delegated to Mathlib's `Real.isIntegral_two_mul_cos_rat_mul_pi`; `IsIntegral.exists_int_iff_exists_rat` pins 2·cos θ = k ∈ ℤ, the cosine bounds force k ∈ [−2, 2], and `interval_cases k` enumerates the five values, each closed by `linarith`. It is applied below to the *doubled* angle 2θ.",
     "mathContext": "$\\theta = \\tfrac{m}{n}\\pi,\\ \\cos\\theta \\in \\mathbb{Q} \\implies \\cos\\theta \\in \\{0, \\pm\\tfrac12, \\pm1\\}$",
     "significance": "key",
-    "relatedConcepts": ["algebraic integers", "Real.isIntegral_two_mul_cos_rat_mul_pi", "interval_cases", "cosine bounds"],
-    "prerequisites": ["integrality of 2cos(qπ)", "bounded integer enumeration"]
+    "relatedConcepts": [
+      "algebraic integers",
+      "Real.isIntegral_two_mul_cos_rat_mul_pi",
+      "interval_cases",
+      "cosine bounds"
+    ],
+    "prerequisites": [
+      "integrality of 2cos(qπ)",
+      "bounded integer enumeration"
+    ]
   },
   {
     "id": "niven-oq03-obstruction",
     "proofId": "niven-theorem-oq-03",
-    "range": { "startLine": 84, "endLine": 91 },
+    "range": {
+      "startLine": 84,
+      "endLine": 91
+    },
     "type": "theorem",
     "title": "no_rat_sq_eq_three: the irrationality obstruction",
     "content": "`no_rat_sq_eq_three`: (s : ℝ)² ≠ 3 for every rational s. If it did, then √3 = √(s²) = |s| (`Real.sqrt_sq_eq_abs`) would be a rational value, contradicting `Nat.prime_three.irrational_sqrt` (√3 ∉ ℚ). This single Diophantine fact is exactly what collapses cosine Niven's five values down to the tangent set {0, ±1}: the two ±1/2 branches demand tan²θ = 1/3 or 3, both excluded here.",
     "mathContext": "$\\sqrt3 \\notin \\mathbb{Q} \\implies \\forall s \\in \\mathbb{Q},\\ s^2 \\ne 3$",
     "significance": "key",
-    "relatedConcepts": ["irrationality of √3", "Nat.Prime.irrational_sqrt", "Real.sqrt_sq_eq_abs", "Diophantine obstruction"],
-    "prerequisites": ["irrationality of square roots of primes"]
+    "relatedConcepts": [
+      "irrationality of √3",
+      "Nat.Prime.irrational_sqrt",
+      "Real.sqrt_sq_eq_abs",
+      "Diophantine obstruction"
+    ],
+    "prerequisites": [
+      "irrationality of square roots of primes"
+    ]
   },
   {
     "id": "niven-oq03-tan",
     "proofId": "niven-theorem-oq-03",
-    "range": { "startLine": 93, "endLine": 142 },
+    "range": {
+      "startLine": 93,
+      "endLine": 116
+    },
     "type": "theorem",
-    "title": "tan_niven: the tangent companion via the double-angle identity",
-    "content": "`tan_niven` is the headline. If cos θ = 0 then tan θ = 0 (Lean's `tan = sin/cos` with div_zero) — done. Otherwise set t = tan θ (rational) and prove the double-angle identity cos(2θ) = (1 − t²)/(1 + t²) from `Real.cos_two_mul` and the Pythagorean identity (`eq_div_iff` + `field_simp` + `nlinarith`). Since cos(2θ) is then rational and 2θ = (2m/n)·π, `cos_niven` gives cos(2θ) ∈ {0, ±1/2, ±1}; a five-way `rcases` resolves t: value 0 ⟹ t² = 1 ⟹ t = ±1 (factoring (t−1)(t+1)); value 1 ⟹ t² = 0 ⟹ t = 0; value −1 is impossible (1 = −1); values ±1/2 ⟹ (3t)² = 3 or t² = 3, both killed by `no_rat_sq_eq_three`. The result completes the sin/cos/tan Niven triad.",
-    "mathContext": "$\\cos 2\\theta = \\frac{1 - \\tan^2\\theta}{1 + \\tan^2\\theta} \\in \\{0, \\pm\\tfrac12, \\pm1\\} \\implies \\tan\\theta \\in \\{0, \\pm1\\}$",
+    "title": "tan_niven: the Double-Angle Bridge to cos_niven",
+    "content": "tan_niven is the headline. Its base case is free: if cos θ = 0 then Lean's tan = sin/cos convention makes tan θ = sin θ / 0 = 0 (div_zero), already in the target set, with no separate argument needed. Otherwise set t = tan θ (rational by hypothesis). The bridge is the rational double-angle identity cos(2θ) = (1 − t²)/(1 + t²), proved from Real.cos_two_mul and the Pythagorean identity via eq_div_iff (1 + t² > 0 by positivity), field_simp, and nlinarith. This makes cos(2θ) rational, and 2θ = (2m/n)·π is still a rational multiple of π, so cos_niven applies to the doubled angle and returns cos(2θ) ∈ {0, ±1/2, ±1}. The unbounded tangent problem is thereby routed through the bounded cosine image — the key idea of the whole proof.",
+    "mathContext": "$\\cos 2\\theta = \\dfrac{1 - t^2}{1 + t^2}$ with $t = \\tan\\theta$; rational and at the rational-multiple angle $2\\theta = \\tfrac{2m}{n}\\pi$, so $\\cos 2\\theta \\in \\{0, \\pm\\tfrac12, \\pm1\\}$.",
     "significance": "key",
-    "relatedConcepts": ["double-angle identity", "Real.cos_two_mul", "Pythagorean identity", "case analysis"],
-    "prerequisites": ["cos_niven", "no_rat_sq_eq_three", "tan = sin/cos convention"]
+    "relatedConcepts": [
+      "double-angle identity",
+      "Real.cos_two_mul",
+      "Pythagorean identity",
+      "tan = sin/cos convention"
+    ],
+    "prerequisites": [
+      "cos_niven",
+      "the double-angle identity",
+      "positivity of 1 + t²"
+    ]
+  },
+  {
+    "id": "niven-oq03-tan-cases",
+    "proofId": "niven-theorem-oq-03",
+    "range": {
+      "startLine": 117,
+      "endLine": 142
+    },
+    "type": "theorem",
+    "title": "Resolving t from the Five Cosine Values",
+    "content": "A five-way rcases on cos_niven's output for cos(2θ) = (1 − t²)/(1 + t²) pins the tangent. cos 2θ = 0 forces the numerator 1 − t² = 0, so (t − 1)(t + 1) = 0 and t = ±1. cos 2θ = 1 forces t² = 0, so t = 0. cos 2θ = −1 is impossible — it demands 1 = −1 (nlinarith). The two decisive branches are ±1/2: cos 2θ = 1/2 gives t² = 1/3, i.e. (3t)² = 3, and cos 2θ = −1/2 gives t² = 3 — both excluded by no_rat_sq_eq_three since √3 ∉ ℚ. Exactly the ±1/2 values that survive for sine and cosine are the ones killed here, collapsing the five-element cosine set to the tangent set {0, ±1} and completing the sin/cos/tan Niven triad.",
+    "mathContext": "$\\cos 2\\theta \\in \\{0,1\\}\\Rightarrow t\\in\\{0,\\pm1\\}$; $\\cos 2\\theta = \\pm\\tfrac12 \\Rightarrow t^2 = \\tfrac13,3$, both impossible over $\\mathbb{Q}$; $\\cos 2\\theta = -1$ contradictory.",
+    "significance": "key",
+    "relatedConcepts": [
+      "case analysis",
+      "no_rat_sq_eq_three",
+      "factoring t²−1",
+      "irrationality of √3"
+    ],
+    "prerequisites": [
+      "no_rat_sq_eq_three",
+      "cos_niven enumeration",
+      "nlinarith"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `niven-theorem-oq-03` ("Niven's Theorem for Tangent").

## Change
- **annotations.json: 4 → 5 annotations**, reaching the coverage minimum.
- Split the 50-line `tan_niven` annotation (was L93–142) at its natural seam:
  - `niven-oq03-tan` (L93–116) — the **double-angle bridge**: `cos θ = 0` base case, deriving `cos(2θ) = (1−t²)/(1+t²)` rational, and applying `cos_niven` to the doubled angle.
  - new `niven-oq03-tan-cases` (L117–142) — **resolving t** from the five cosine values, with the ±1/2 branches killed by `no_rat_sq_eq_three` (√3 irrational).

## Why
`tan_niven` bundled two distinct ideas — the *reduction* (route unbounded tangent through the bounded `cos(2θ)` image) and the *case dispatch* (why only {0,±1} survive) — into one annotation. Separating them foregrounds the √3-irrationality obstruction that is the crux of why tangent's Niven set is strictly smaller than sine/cosine's. Both annotations carry full `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; ranges are disjoint and contiguous.

## Scope
- Touches **only** `annotations.json`; `meta.json` is byte-identical to `origin/main`. No open PRs on this slug.
