### PR TITLE
Enrich Catalan reciprocal log-concavity: fix docstring line attribution

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/annotations.json
@@ -26,7 +26,7 @@
   {
     "id": "ann-catalan-instance",
     "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
-    "range": { "startLine": 66, "endLine": 87 },
+    "range": { "startLine": 66, "endLine": 80 },
     "type": "key-step",
     "title": "Applying the principle to the Catalan numbers",
     "content": "catalan_recip_logConcave instantiates the principle over ℚ. The three positivity hypotheses 0 < Cₙ, Cₙ₊₁, Cₙ₊₂ come from casting Nat.catalan_pos, and the Turán hypothesis y² < x·z is the parent's catalan_turan cast to ℚ (exact_mod_cast). Feeding these to recip_sq_gt_of_sq_lt yields (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² for every n — no new combinatorics, just the parent inequality read through reciprocation.",
@@ -38,7 +38,7 @@
   {
     "id": "ann-standard-indexing",
     "proofId": "catalan-numbers-oq-01-oq-04-oq-02",
-    "range": { "startLine": 89, "endLine": 96 },
+    "range": { "startLine": 82, "endLine": 96 },
     "type": "key-step",
     "title": "Restating in the standard log-concavity indexing (n ≥ 1)",
     "content": "catalan_recip_logConcave_shift converts catalan_recip_logConcave from the offset form (indexed at n, n+1, n+2) into the textbook shape aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1, with aₙ = 1/Cₙ. The reindexing is purely mechanical: Nat.exists_eq_add_of_lt writes n = m+1 (legal because n ≥ 1), after which n−1 = m and n+1 = m+2 collapse the shifted statement onto the base lemma via simp/simpa. This is the form a reader recognizes as 'strict log-concavity', so it is the theorem worth citing downstream even though it carries no new mathematical content beyond catalan_recip_logConcave.",

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04-oq-02/meta.json
@@ -80,13 +80,13 @@
       "id": "catalan-instance",
       "title": "Strict log-concavity of the reciprocal Catalan sequence",
       "startLine": 66,
-      "endLine": 87,
+      "endLine": 80,
       "summary": "catalan_recip_logConcave: (1/Cₙ)(1/Cₙ₊₂) < (1/Cₙ₊₁)² over ℚ for every n. Casts catalan_pos for positivity and the parent's catalan_turan for the Turán hypothesis, then applies the reciprocation principle."
     },
     {
       "id": "standard-indexing",
       "title": "Standard indexing and the refuted candidate",
-      "startLine": 89,
+      "startLine": 82,
       "endLine": 108,
       "summary": "catalan_recip_logConcave_shift restates the inequality as aₙ² > aₙ₋₁·aₙ₊₁ for n ≥ 1 (reindexing at n = m+1); catalanOverSucc_not_logConcave_at_one refutes the suggested candidate Cₙ/(n+1) by evaluating at n=1 (1/4 < 2/3 via norm_num)."
     }


### PR DESCRIPTION
Accuracy fix for `catalan-numbers-oq-01-oq-04-oq-02`.

The `catalan-instance` annotation (and its matching `meta.json` section) ran to line 87, swallowing lines 82–88 — the docstring of the *next* theorem `catalan_recip_logConcave_shift`. Meanwhile `standard-indexing` started at line 89, omitting its own docstring.

Fix: `catalan-instance` now ends at line 80; `standard-indexing` now starts at line 82. Each theorem's docstring is attributed to the correct annotation/section.

Pure line-range integer change — no prose or content edits. JSON validated. Entry was already at target quality (5 rich annotations, 12.5KB meta, full conclusion); this is the one genuine defect found.