### PR TITLE
Enrich Orbit-Stabilizer over Nat.card: annotate finiteness-free setup (4→5 annotations)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-lag0201-context",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
-    "range": { "startLine": 5, "endLine": 55 },
+    "range": {
+      "startLine": 5,
+      "endLine": 55
+    },
     "type": "concept",
     "title": "Extending the Finite Orbit-Counting Family",
     "content": "The parent entry generalised Burnside's lemma off `Fintype` to `Finite` by observing that its core is a finiteness-free bijection. This entry applies the very same recipe to the orbit-stabilizer theorem — the other identity that bijection's machinery bundles — and reaches an even stronger conclusion: stated over `Nat.card`, orbit-stabilizer needs *no* finiteness hypothesis at all. We obtain `Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G` for an arbitrary group action, plus the index form `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`.",
@@ -21,39 +24,93 @@
     ]
   },
   {
+    "id": "ann-lag0201-setup",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 62
+    },
+    "type": "insight",
+    "title": "The Generality Lives in What the variable Block Omits",
+    "content": "The entire strength of this entry is encoded in a single line: `variable (G : Type*) (X : Type*) [Group G] [MulAction G X]`. The instance brackets carry only `Group G` and `MulAction G X` — there is deliberately **no** `[Finite G]`, `[Fintype G]`, or `[Finite X]`. Every theorem below inherits exactly these hypotheses, so each is stated for a wholly arbitrary group action. This is strictly more general than the parent's Burnside form, which still required a `Fintype G` to collapse its `finsum`; here even that vanishes. Reading the `variable` block is the fastest way to see the claim: what is *absent* from it is the entire contribution.",
+    "mathContext": "Contrast the ambient context with Mathlib's `MulAction.card_orbit_mul_card_stabilizer_eq_card_group`, whose signature carries `[Fintype α]` (and derived `Fintype` instances on the orbit and stabilizer). Dropping every finiteness bracket is sound because the proofs route through `Nat.card`, which is *total* — defined as $0$ on infinite types — so the identities hold vacuously-yet-correctly (both sides $0$) when $G$ is infinite, and coincide with the finite count otherwise.",
+    "significance": "key",
+    "relatedConcepts": [
+      "instance-implicit hypotheses",
+      "Nat.card totality",
+      "finiteness-free generalisation",
+      "MulAction typeclass"
+    ],
+    "prerequisites": [
+      "Lean variable / instance-implicit binders",
+      "Group and MulAction typeclasses",
+      "Nat.card is 0 on infinite types"
+    ]
+  },
+  {
     "id": "ann-lag0201-product",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
-    "range": { "startLine": 63, "endLine": 75 },
+    "range": {
+      "startLine": 63,
+      "endLine": 75
+    },
     "type": "tactic",
     "title": "Transporting orbitProdStabilizerEquivGroup through Nat.card",
     "content": "`card_orbit_mul_card_stabilizer_eq_card_group_nat` is a two-rewrite proof: `← Nat.card_prod` folds the product `Nat.card (orbit) * Nat.card (stabilizer)` into `Nat.card (orbit × stabilizer)`, and `Nat.card_congr (orbitProdStabilizerEquivGroup G x)` rewrites that to `Nat.card G` along Mathlib's bijection. There is no `cases nonempty_fintype` step (which the parent needed to collapse its `finsum`): `Nat.card_prod` and `Nat.card_congr` are unconditional, so the theorem carries no finiteness instance.",
     "mathContext": "This mirrors Mathlib's own `Fintype` proof line for line — `rw [← Fintype.card_prod, Fintype.card_congr (orbitProdStabilizerEquivGroup α b)]` — with `Fintype.card` replaced by `Nat.card`. The substitution is sound precisely because `Nat.card` agrees with `Fintype.card` on finite types and the transport lemmas have the same shape.",
     "significance": "key",
-    "relatedConcepts": ["Nat.card_prod", "Nat.card_congr", "orbitProdStabilizerEquivGroup"],
-    "prerequisites": ["orbitProdStabilizerEquivGroup", "Nat.card transport lemmas"]
+    "relatedConcepts": [
+      "Nat.card_prod",
+      "Nat.card_congr",
+      "orbitProdStabilizerEquivGroup"
+    ],
+    "prerequisites": [
+      "orbitProdStabilizerEquivGroup",
+      "Nat.card transport lemmas"
+    ]
   },
   {
     "id": "ann-lag0201-index",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
-    "range": { "startLine": 77, "endLine": 86 },
+    "range": {
+      "startLine": 77,
+      "endLine": 86
+    },
     "type": "tactic",
     "title": "Orbit Size = Stabilizer Index",
     "content": "`card_orbit_eq_card_quotient_stabilizer_nat` is a single term, `Nat.card_congr (orbitEquivQuotientStabilizer G x)`: the orbit of `x` is in bijection with the cosets `G ⧸ stabilizer G x`, so they have equal `Nat.card`. This is the orbit-counting form of Lagrange's theorem — the orbit size *is* the index of the stabilizer — and combined with the product identity it expresses both halves of the count.",
     "mathContext": "The bijection $\\mathrm{orbit}(x) \\cong G/\\mathrm{Stab}(x)$ is the heart of the orbit-stabilizer correspondence; reading it as $|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$ recovers the statement that orbit sizes divide the group order, the orbit-theoretic shadow of Lagrange's theorem.",
     "significance": "key",
-    "relatedConcepts": ["orbitEquivQuotientStabilizer", "stabilizer index", "Lagrange's theorem"],
-    "prerequisites": ["orbitEquivQuotientStabilizer", "Nat.card_congr"]
+    "relatedConcepts": [
+      "orbitEquivQuotientStabilizer",
+      "stabilizer index",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "orbitEquivQuotientStabilizer",
+      "Nat.card_congr"
+    ]
   },
   {
     "id": "ann-lag0201-recovered",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
-    "range": { "startLine": 88, "endLine": 96 },
+    "range": {
+      "startLine": 88,
+      "endLine": 96
+    },
     "type": "tactic",
     "title": "Recovering the Fintype Statement",
     "content": "`card_orbit_mul_card_stabilizer_eq_card_group_recovered` supplies the constructive `Fintype G`, `Fintype (orbit G x)`, `Fintype (stabilizer G x)` instances and derives Mathlib's exact `Fintype.card` identity from the `Nat.card` one by `simpa only [Nat.card_eq_fintype_card]`. This certifies the generalisation genuinely subsumes the original — the classical orbit-stabilizer theorem is the finite shadow of the unconditional `Nat.card` version.",
     "mathContext": "`Nat.card_eq_fintype_card : Nat.card α = Fintype.card α` whenever a `Fintype α` instance is present. Rewriting all three occurrences turns the `Nat.card` identity into the `Fintype.card` one, with no further mathematical input.",
     "significance": "key",
-    "relatedConcepts": ["Nat.card_eq_fintype_card", "Fintype recovery", "subsumption"],
-    "prerequisites": ["card_orbit_mul_card_stabilizer_eq_card_group_nat", "Nat.card_eq_fintype_card"]
+    "relatedConcepts": [
+      "Nat.card_eq_fintype_card",
+      "Fintype recovery",
+      "subsumption"
+    ],
+    "prerequisites": [
+      "card_orbit_mul_card_stabilizer_eq_card_group_nat",
+      "Nat.card_eq_fintype_card"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01` (Orbit-Stabilizer over `Nat.card`).

**Annotation coverage 4 → 5.** Added `ann-lag0201-setup` (type `insight`) covering the previously-unannotated setup block (lines 57–62). It explains that the file's entire generality is encoded in what the `variable (G X) [Group G] [MulAction G X]` block *omits* — no `[Finite]`/`[Fintype]` — and why dropping every finiteness bracket is sound (proofs route through the total `Nat.card`). Contrasts with Mathlib's `Fintype`-bound `card_orbit_mul_card_stabilizer_eq_card_group`.

- No existing content removed; ranges remain non-overlapping.
- meta.json unchanged (already ~21 KB, well under caps).
- JSON validated with a parser (this worktree lacks `node_modules`, so `tsc` cannot run; the build's enrichment step also rewrites annotations.json, so it is not used to validate).
