### PR TITLE
Enrich Newton's Identities in Low Degree: technique annotation + cross-ref + reference

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01/annotations.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["MvPolynomial.psum and esymm", "the Newton recurrence", "commutative rings"]
   },
   {
+    "id": "newton-ps-oq01-setup",
+    "proofId": "newton-power-sum-identities-oq-01",
+    "range": { "startLine": 32, "endLine": 37 },
+    "type": "technique",
+    "title": "The ambient setting and the reusable unrolling recipe",
+    "content": "`variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` fixes the generality once for all three lemmas: an *arbitrary* commutative ring `R` and any *finite* index type `σ`. Nothing stronger (no integral domain, no characteristic-zero, no ordering) is assumed, so the identities are universal in `MvPolynomial σ R`. The two non-trivial proofs (degrees 2 and 3) then share one four-step recipe worth naming: (1) apply `psum_eq_mul_esymm_sub_sum` at the target `k`; (2) rewrite the recurrence's inner index set {a ∈ antidiagonal k | 0 < a.1 < k} to an explicit finite set with an `omega`-proved `ext` lemma; (3) collapse the now-finite sum with `Finset.sum_singleton`/`Finset.sum_pair`; (4) substitute the already-proved lower-degree identities and close with `push_cast; ring`. Only steps (2)–(3) change with `k`; extending to degree 4, 5, … is purely mechanical.",
+    "mathContext": "The recurrence's inner sum $\\sum_{0<i<k}(-1)^i e_i\\,p_{k-i}$ is finite for each fixed $k$; the only per-degree work is enumerating $\\{(i,k-i) : 0<i<k\\}$, a linear-arithmetic fact `omega` settles. Working in $\\mathrm{MvPolynomial}\\,\\sigma\\,R$ over a bare `CommRing` means `ring` — not `field_simp` or numeric evaluation — discharges the final algebra.",
+    "significance": "key",
+    "relatedConcepts": ["MvPolynomial over a commutative ring", "Fintype index type", "proof-by-recurrence-unrolling", "omega + ring"],
+    "prerequisites": ["Lean variable / instance binders", "the Newton recurrence psum_eq_mul_esymm_sub_sum", "Finset.antidiagonal enumeration"]
+  },
+  {
     "id": "newton-ps-oq01-deg1",
     "proofId": "newton-power-sum-identities-oq-01",
     "range": { "startLine": 38, "endLine": 41 },

--- a/src/data/proofs/newton-power-sum-identities-oq-01/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01/meta.json
@@ -117,6 +117,11 @@
       "targetId": "newton-power-sum-identities-oq-01-oq-01",
       "relationship": "extends",
       "description": "Follow-up entry that develops this one: “Newton's Identities in Degrees 4 and 5: Explicit Power-Sum Closed Forms”. Newton's identities express the power sums pₖ = ∑ᵢ Xᵢᵏ of finitely many variables in terms of the elementary symmetric polynomials eⱼ."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "related",
+      "description": "“Maclaurin's Inequalities via Elementary Symmetric Polynomials.” The companion inequality-theoretic side of the elementary symmetric polynomials eₖ: where this entry gives Newton's exact identities relating the eₖ to the power sums, that entry proves the Newton–Maclaurin chain of inequalities among the normalized means Mₖ = eₖ/C(n,k). Together they cover the two classical bodies of results — equalities and inequalities — built on the eₖ."
     }
   ],
   "conclusion": {
@@ -156,6 +161,13 @@
       "year": "1992",
       "venue": "The American Mathematical Monthly 99(8), 749–751",
       "note": "Modern exposition and proofs of the Newton–Girard formulae"
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford Mathematical Monographs, 2nd ed., Oxford University Press",
+      "note": "Standard reference for the ring of symmetric functions; Chapter I develops Newton's identities and the change of basis between the power sums pₖ and the elementary symmetric functions eₖ"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `newton-power-sum-identities-oq-01` (Newton's identities in low degree).

**Annotation coverage 4 → 5.** Added `newton-ps-oq01-setup` (type `technique`) covering the previously-unannotated setup block (lines 32–37): the ambient `variable` generality (arbitrary `CommRing R`, any `Fintype σ`) and the *reusable four-step unrolling recipe* shared by the degree-2 and degree-3 proofs — apply the recurrence, `omega`-enumerate the finite inner index set, collapse with `sum_singleton`/`sum_pair`, substitute lower identities and `push_cast; ring`.

**Cross-references 1 → 2.** Linked `amgm-inequality-oq-02` ("Maclaurin's Inequalities via Elementary Symmetric Polynomials", `related`) — the inequality-theoretic companion to these exact-identity results on the elementary symmetric polynomials eₖ.

**References 2 → 3.** Added Macdonald, *Symmetric Functions and Hall Polynomials* (1995) — the canonical reference for the power-sum ↔ elementary-symmetric change of basis.

- No existing content removed; annotation ranges remain ascending and non-overlapping.
- meta.json ~12.9 KB, well under caps.
- JSON validated with a parser.
