### PR TITLE
research(schroeder-bernstein-oq-03): splice the augmenting path — total, BuiltFrom-preserving domain step [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1423,6 +1423,185 @@ theorem augPath_isMatching_of_chase {f g : ℕ → ℕ} (hf : Function.Injective
   augPath_isMatching hf (fwdOrbit_prefix_distinct hf hg (D := fun n => n ∈ mDom L) ha hchase)
 
 /-!
+## Section 4k: Splicing the augmenting path — the `BuiltFrom`-preserving domain step
+
+Sections 4i/4j supplied the two halves of the even-stage domain step: `escape_exists`
+(the collision chase terminates at a range-fresh target) and `augPath`/`augPath_*` (the
+re-labelled `f`-edge block that restores `BuiltFrom`). What remained — named across several
+prior sessions as the genuine outstanding list-surgery — is to *splice* that block into the
+current matching, deleting the stale `g`-edges it re-labels, and verify the result is again a
+`BuiltFrom` matching respecting the correspondence.
+
+`augment_domain_step` does exactly that. Given a fresh anchor `a ∉ mDom L`, let `N` be the
+*minimal* escape depth (`Nat.find` on `f (fwdOrbit f g a N) ∉ mRan L`), so every earlier stage
+collides: `f (fwdOrbit f g a j) ∈ mRan L` for `j < N`. By `chase_gedge_chain` the matching then
+contains the `N` stale `g`-edges `(oₖ, f oₖ₋₁)` (`1 ≤ k ≤ N`, `oₖ = fwdOrbit f g a k`). Splicing
+`augPath f g a N` — the `f`-edges `(oₖ, f oₖ)` for `0 ≤ k ≤ N` — in place of those `g`-edges
+yields `L' := augPath f g a N ++ keptL`, where `keptL` drops exactly the pairs whose domain
+point lies on the re-labelled orbit prefix. The result:
+
+* **is a matching** — domains: `mDom (augPath …)` is the distinct orbit prefix, and `keptL`'s
+  domains are, by the filter, disjoint from it; ranges: `augPath`'s range values `f oₖ` for
+  `k < N` are the *removed* `g`-edges' range values (unique by co-functionality), while `f o_N`
+  is the escaped fresh point, so they avoid `mRan keptL`;
+* **respects the correspondence** — `augPath` does (each `f`-edge via `hfpq`), `keptL ⊆ L` does;
+* **preserves `BuiltFrom`** — `augPath` is all `f`-edges, `keptL ⊆ L`;
+* **covers the anchor** `a = o₀ ∈ mDom L'` and is **monotone** on both sides
+  (`mDom L ⊆ mDom L'`, `mRan L ⊆ mRan L'`): the removed `g`-edges' endpoints are all re-added by
+  the augmenting path.
+
+This is the total, invariant-preserving even-stage move the priority scheduler iterates; the
+odd (range) stage is its `Prod.swap` dual (Section 4e). Only the outer stage recursion +
+coverage read-off of `myhill_isomorphism` remains after this.
+-/
+
+/-- **The augmenting-path domain step.** For a fresh domain anchor `a ∉ mDom L` in a matching
+    `L` satisfying `BuiltFrom` and the correspondence, there is an extended matching `L'` that
+    still satisfies all three invariants, *covers* `a` (`a ∈ mDom L'`), and is monotone on both
+    domain and range (`mDom L ⊆ mDom L'`, `mRan L ⊆ mRan L'`). `L'` is obtained by splicing the
+    augmenting path `augPath f g a N` (for the minimal escape depth `N`) in place of the stale
+    `g`-edges it re-labels. Unlike `domain_step_exists`, this preserves `BuiltFrom`, so the next
+    stage's collision analysis (`collision_f_source`, `escape_exists`) still applies — making it
+    the move the scheduler can actually iterate. -/
+theorem augment_domain_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hfpq : ∀ n, p n ↔ q (f n))
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hL : IsMatching L) (hC : MatchingCorr p q L) (hB : BuiltFrom f g L)
+    {a : ℕ} (ha : a ∉ mDom L) :
+    ∃ L', IsMatching L' ∧ MatchingCorr p q L' ∧ BuiltFrom f g L' ∧
+      a ∈ mDom L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') := by
+  -- Elementwise membership descriptions of `mDom`/`mRan` and their append behaviour.
+  have mem_mDom : ∀ (l : List (ℕ × ℕ)) (x : ℕ), x ∈ mDom l ↔ ∃ ab, ab ∈ l ∧ ab.1 = x := by
+    intro l x; simp only [mDom, List.mem_map]
+  have mem_mRan : ∀ (l : List (ℕ × ℕ)) (y : ℕ), y ∈ mRan l ↔ ∃ ab, ab ∈ l ∧ ab.2 = y := by
+    intro l y; simp only [mRan, List.mem_map]
+  have mDom_append : ∀ (l₁ l₂ : List (ℕ × ℕ)), mDom (l₁ ++ l₂) = mDom l₁ ++ mDom l₂ := by
+    intro l₁ l₂; simp only [mDom, List.map_append]
+  have mRan_append : ∀ (l₁ l₂ : List (ℕ × ℕ)), mRan (l₁ ++ l₂) = mRan l₁ ++ mRan l₂ := by
+    intro l₁ l₂; simp only [mRan, List.map_append]
+  -- Minimal escape depth: first orbit stage whose green image is range-fresh; all earlier
+  -- stages collide.
+  obtain ⟨N, hN, hcoll⟩ :
+      ∃ N, f (fwdOrbit f g a N) ∉ mRan L ∧ ∀ j, j < N → f (fwdOrbit f g a j) ∈ mRan L := by
+    have hEsc : ∃ M, f (fwdOrbit f g a M) ∉ mRan L := by
+      obtain ⟨M, _, hM⟩ := escape_exists hf hg hL hB ha; exact ⟨M, hM⟩
+    refine ⟨Nat.find hEsc, Nat.find_spec hEsc, ?_⟩
+    intro j hj
+    exact not_not.mp (Nat.find_min hEsc hj)
+  -- The stale `g`-edges the chase runs over, and hence each chased orbit point is occupied.
+  have hgedges : ∀ m, 1 ≤ m → m ≤ N →
+      (fwdOrbit f g a m, f (fwdOrbit f g a (m - 1))) ∈ L :=
+    fun m hm1 hmN => chase_gedge_chain hf hg hL hB ha hcoll N (le_refl N) m hm1 hmN
+  have hchase : ∀ k, 1 ≤ k → k ≤ N → fwdOrbit f g a k ∈ mDom L := by
+    intro k hk1 hkN
+    exact (mem_mDom L _).mpr ⟨_, hgedges k hk1 hkN, rfl⟩
+  -- Membership descriptions of the augmenting path's domain and range.
+  have hDomA : ∀ x, x ∈ mDom (augPath f g a N) ↔ ∃ k, k ≤ N ∧ x = fwdOrbit f g a k := by
+    intro x
+    rw [mDom_augPath, List.mem_map]
+    constructor
+    · rintro ⟨k, hk, rfl⟩; exact ⟨k, Nat.lt_succ_iff.mp (List.mem_range.mp hk), rfl⟩
+    · rintro ⟨k, hk, rfl⟩; exact ⟨k, List.mem_range.mpr (Nat.lt_succ_iff.mpr hk), rfl⟩
+  have hRanA : ∀ y, y ∈ mRan (augPath f g a N) ↔ ∃ k, k ≤ N ∧ y = f (fwdOrbit f g a k) := by
+    intro y
+    rw [mRan_augPath, List.mem_map]
+    constructor
+    · rintro ⟨k, hk, rfl⟩; exact ⟨k, Nat.lt_succ_iff.mp (List.mem_range.mp hk), rfl⟩
+    · rintro ⟨k, hk, rfl⟩; exact ⟨k, List.mem_range.mpr (Nat.lt_succ_iff.mpr hk), rfl⟩
+  -- The kept part of `L`: pairs whose domain point is not re-labelled by the aug path.
+  set keptL := L.filter (fun ab => decide (ab.1 ∉ mDom (augPath f g a N))) with hkeptL
+  have hmemKept : ∀ ab, ab ∈ keptL ↔ ab ∈ L ∧ ab.1 ∉ mDom (augPath f g a N) := by
+    intro ab
+    simp only [hkeptL, List.mem_filter, decide_eq_true_eq]
+  have hApathM : IsMatching (augPath f g a N) := augPath_isMatching_of_chase hf hg ha hchase
+  have hkeptSub : List.Sublist keptL L := by rw [hkeptL]; exact List.filter_sublist
+  have hDomKeptNodup : (mDom keptL).Nodup := by
+    have hs : List.Sublist (mDom keptL) (mDom L) := hkeptSub.map Prod.fst
+    exact hL.1.sublist hs
+  have hRanKeptNodup : (mRan keptL).Nodup := by
+    have hs : List.Sublist (mRan keptL) (mRan L) := hkeptSub.map Prod.snd
+    exact hL.2.sublist hs
+  refine ⟨augPath f g a N ++ keptL, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · -- IsMatching
+    refine ⟨?_, ?_⟩
+    · -- domain side
+      rw [mDom_append, List.nodup_append]
+      refine ⟨hApathM.1, hDomKeptNodup, ?_⟩
+      intro x hxA x' hx'K hne
+      obtain ⟨ab, habK, hab1⟩ := (mem_mDom keptL x').mp hx'K
+      apply ((hmemKept ab).mp habK).2
+      rw [hab1, ← hne]
+      exact hxA
+    · -- range side
+      rw [mRan_append, List.nodup_append]
+      refine ⟨hApathM.2, hRanKeptNodup, ?_⟩
+      intro y hyA y' hy'K hne
+      obtain ⟨k, hkN, hyk⟩ := (hRanA y).mp hyA
+      obtain ⟨⟨u, w⟩, habK, hab2⟩ := (mem_mRan keptL y').mp hy'K
+      have hwy : w = y' := hab2
+      have habL : (u, w) ∈ L := ((hmemKept (u, w)).mp habK).1
+      have habD : u ∉ mDom (augPath f g a N) := ((hmemKept (u, w)).mp habK).2
+      have hwfok : w = f (fwdOrbit f g a k) := by rw [hwy, ← hne, hyk]
+      rcases Nat.lt_or_ge k N with hklt | hkge
+      · -- k < N: the removed `g`-edge (o_{k+1}, f o_k) shares the range value `f o_k` with
+        -- (u, w); co-functionality forces u = o_{k+1} ∈ mDom (augPath), contradiction.
+        have hgedge := hgedges (k + 1) (by omega) (by omega)
+        rw [show (k + 1) - 1 = k from by omega] at hgedge
+        have hval : (u, f (fwdOrbit f g a k)) ∈ L := by rw [← hwfok]; exact habL
+        have hueq : u = fwdOrbit f g a (k + 1) := matching_cofunctional hL hval hgedge
+        exact habD ((hDomA u).mpr ⟨k + 1, by omega, hueq⟩)
+      · -- k = N: `w = f o_N ∉ mRan L`, contradicting (u, w) ∈ L.
+        have hkeqN : k = N := by omega
+        refine hN ((mem_mRan L (f (fwdOrbit f g a N))).mpr ⟨(u, w), habL, ?_⟩)
+        rw [hkeqN] at hwfok
+        exact hwfok
+  · -- MatchingCorr
+    intro ab hab
+    rw [List.mem_append] at hab
+    rcases hab with hA | hK
+    · exact augPath_matchingCorr hfpq a N ab hA
+    · exact hC ab ((hmemKept ab).mp hK).1
+  · -- BuiltFrom
+    intro ab hab
+    rw [List.mem_append] at hab
+    rcases hab with hA | hK
+    · exact augPath_builtFrom f g a N ab hA
+    · exact hB ab ((hmemKept ab).mp hK).1
+  · -- a ∈ mDom L'
+    rw [mDom_append, List.mem_append]
+    exact Or.inl ((hDomA a).mpr ⟨0, Nat.zero_le N, rfl⟩)
+  · -- domain monotone
+    intro x hx
+    rw [mDom_append, List.mem_append]
+    by_cases hxA : x ∈ mDom (augPath f g a N)
+    · exact Or.inl hxA
+    · right
+      obtain ⟨ab, habL, hab1⟩ := (mem_mDom L x).mp hx
+      refine (mem_mDom keptL x).mpr ⟨ab, ?_, hab1⟩
+      exact (hmemKept ab).mpr ⟨habL, by rw [hab1]; exact hxA⟩
+  · -- range monotone
+    intro y hy
+    rw [mRan_append, List.mem_append]
+    obtain ⟨⟨u, w⟩, habL, hab2⟩ := (mem_mRan L y).mp hy
+    have hwy : w = y := hab2
+    by_cases hu : u ∈ mDom (augPath f g a N)
+    · -- u = o_k on the orbit prefix; k ≥ 1 (else u = a ∈ mDom L), and functionality gives
+      -- w = f o_{k-1} ∈ mRan (augPath).
+      obtain ⟨k, hkN, hk⟩ := (hDomA u).mp hu
+      rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+      · have hua : u = a := by rw [hk0] at hk; exact hk
+        exact absurd ((mem_mDom L a).mpr ⟨(u, w), habL, hua⟩) ha
+      · left
+        have hgedge : (fwdOrbit f g a k, f (fwdOrbit f g a (k - 1))) ∈ L :=
+          hgedges k hkpos hkN
+        have hgedge' : (u, f (fwdOrbit f g a (k - 1))) ∈ L := by rw [hk]; exact hgedge
+        have hval : w = f (fwdOrbit f g a (k - 1)) := matching_functional hL habL hgedge'
+        rw [← hwy, hval]
+        exact (hRanA (f (fwdOrbit f g a (k - 1)))).mpr ⟨k - 1, by omega, rfl⟩
+    · right
+      exact (mem_mRan keptL y).mpr ⟨(u, w), (hmemKept (u, w)).mpr ⟨habL, hu⟩, hwy⟩
+
+/-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/
 

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -467,3 +467,59 @@ so compile a worktree file with
 (~30s warm). GOTCHA: `lake env lean Proofs/...` from `REPO_ROOT/proofs` compiles the
 MAIN-repo file, NOT the worktree — pass the absolute worktree path. `List.nodup_range`
 takes `n` IMPLICIT (`List.nodup_range.map_on`, not `(List.nodup_range (N+1))`).
+
+## Session 2026-07-02 (researcher-9): augmenting-path splice — the BuiltFrom-preserving domain step is now TOTAL and iterable [VERIFIED, 0-axiom]
+
+Added **Section 4k** `augment_domain_step` (1 theorem, ~180 lines; host `lake env lean`
+v4.26.0, EXIT 0; `#print axioms` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`,
+no `ofReduceBool`). File 1539→1718 lines. This closes the exact "list-surgery splice" that r4
+named as the genuine remaining work: it turns the augmenting-path *object* (Section 4j) into an
+actual **invariant-preserving, iterable even-stage move**.
+
+**Statement.** For a fresh anchor `a ∉ mDom L` in a matching `L` with `IsMatching`,
+`MatchingCorr p q`, `BuiltFrom f g`, there is `L'` with all three invariants preserved, `a ∈
+mDom L'`, and *monotone* on both sides: `∀ x ∈ mDom L, x ∈ mDom L'` and `∀ y ∈ mRan L, y ∈ mRan
+L'`. (Only the `f`-reduction `hfpq` is needed — `hgpq` dropped; the augmenting edges are all
+`f`-edges.)
+
+**Construction.** `L' := augPath f g a N ++ keptL` where `N` is the *minimal* escape depth
+(`Nat.find` on `f (fwdOrbit f g a N) ∉ mRan L`, so `∀ j<N, f oⱼ ∈ mRan L`) and
+`keptL := L.filter (·.1 ∉ mDom (augPath f g a N))` drops exactly the pairs whose domain point
+lies on the re-labelled orbit prefix.
+
+**The four invariant proofs (all discharged):**
+- `BuiltFrom` / `MatchingCorr`: `augPath` supplies them (all `f`-edges; `augPath_builtFrom`,
+  `augPath_matchingCorr`), `keptL ⊆ L` inherits (`hmemKept.1` into `hB`/`hC`).
+- `IsMatching` **domain Nodup**: `mDom augPath` distinct (`augPath_isMatching_of_chase` via
+  `chase_gedge_chain`→`hchase`), `mDom keptL` a `Sublist`-inherited Nodup, and disjoint *by the
+  filter itself* — a kept pair has `.1 ∉ mDom augPath`.
+- `IsMatching` **range Nodup**: `mRan augPath = {f o_0..f o_N}` distinct; disjoint from `mRan
+  keptL` by cases on the aug index `k`: for `k<N`, `f oₖ` is the range value of the removed
+  `g`-edge `(o_{k+1}, f oₖ)` (from `hgedges`), so any kept pair sharing it would, by
+  `matching_cofunctional`, have domain `o_{k+1} ∈ mDom augPath` — contradicting the filter; for
+  `k=N`, `f o_N ∉ mRan L` (`escape_exists`).
+- **monotonicity**: every removed `g`-edge endpoint is re-added by `augPath` — domains
+  `o_1..o_N ⊆ {o_0..o_N}`, ranges `f o_0..f o_{N-1} ⊆ {f o_0..f o_N}`; and functionality pins a
+  kept pair with domain `oₖ (k≥1)` to range `f o_{k-1} ∈ mRan augPath` (`k=0` ⇒ `a ∈ mDom L`,
+  impossible).
+
+**Significance (honest).** This is the crux structural step, not the whole theorem. `main
+myhill_isomorphism → sorry UNCHANGED`. What remains is genuinely the *outer* recursion: iterate
+`augment_domain_step` and its `Prod.swap` dual (odd/range stage, Section 4e) over stages
+`0,1,2,…`, using `firstMissing` to pick the anchor at each stage, take the union/limit matching,
+and read off the computable `ℕ ≃ ℕ` via `mLookup` (proving totality on both sides from
+monotonicity + coverage, injectivity from `mLookup_injOn`/`mLookup_stable`, and computability of
+the stage function). Every atomic ingredient the recursion consumes now exists and is verified;
+the assembly (well-founded stage function + its computability + the bijection read-off) is the
+remaining work.
+
+**GOTCHAS (v4.26.0 / this file):**
+- The `<+` Sublist notation did NOT parse here (tokenised as `<` then `+`); use explicit
+  `List.Sublist a b`. Sublist→Nodup transfer is `hNodup.sublist hSub` (`List.Nodup.sublist`).
+- `List.nodup_append` yields the **pairwise** third component `∀ a∈l₁, ∀ b∈l₂, a ≠ b`, NOT
+  `List.Disjoint` — `rw [List.disjoint_left]` fails; `intro a ha b hb hne` directly.
+- `List.filter_sublist` takes p,l **implicit** (`exact List.filter_sublist`, not `… L`).
+- `fwdOrbit f g a 0 = a` is NOT closed by `rw`'s trailing rfl (fwdOrbit is a plain def, not
+  reducible); use `exact`-at-defeq (`rw [hk0] at hk; exact hk`) or an explicit `rfl` tactic.
+- Destructure list pairs to `⟨u,w⟩` and capture clean equalities (`have hwy : w = y := hab2`)
+  so later `rw` sees `w`, not the stuck projection `(u,w).2`.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -4,28 +4,34 @@
 **Phase**: DEVELOP
 **Path**: full
 **Since**: 2026-07-02
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Even-stage collision move of the Myhill priority scheduler: routing a blocked fresh
-domain point along the forward orbit to an escaping target.
+Assemble the outer stage recursion of the Myhill priority scheduler now that the atomic
+even-stage move is total and iterable (`augment_domain_step`, Section 4k).
 
 ## Active Approach
-Stage-wise finite back-and-forth (Rogers §7.4). Collision step obligations:
-(1) bounded termination — DONE (`fwdOrbit_chase_length_le`);
-(2) correspondence preservation — DONE this session (`fwdOrbit_corr`/`chase_target_corr`);
-(3) escape-existence (a fresh target actually exists) — OPEN, and found to be the real
-    crux (see knowledge.md 07-02: naive counting fails on f-edge orbit re-entry; likely
-    needs a stronger construction invariant than `BuiltFrom`).
+Stage-wise finite back-and-forth (Rogers §7.4). Even (domain) stage: `augment_domain_step`
+— DONE this session (BuiltFrom-preserving splice of the augmenting path, all invariants +
+monotonicity + anchor coverage, VERIFIED 0-axiom). Odd (range) stage: its `Prod.swap` dual
+via Section 4e (`isMatching_map_swap` / `matchingCorr_map_swap` / `builtFrom_map_swap`) —
+NOT YET INSTANTIATED but every ingredient present.
 
 ## Attempt Count
-- Approaches tried: 1 (stage-wise back-and-forth), in progress across sessions.
+- Approaches tried: 1 (stage-wise back-and-forth), advancing across sessions.
 
 ## Blockers
-Escape-existence / termination of the collision routing. Finer than the earlier
-`isGFree` Π₁ framing — blockers are named, but routing-termination is unproven.
+None at the atomic level — all per-stage obligations (termination, correspondence, BuiltFrom
+preservation, matching validity, monotonicity) are proved. Remaining work is the OUTER
+assembly: a well-founded stage function `σ : ℕ → List (ℕ×ℕ)`, its computability, and reading
+off a computable `ℕ ≃ ℕ` (totality on both sides from monotonicity + `firstMissing` coverage;
+injectivity from `mLookup_injOn` / `mLookup_stable`).
 
 ## Next Action
-Prove escape-existence for the collision step, or find the stronger stage invariant
-that makes the chase stay in `mDom L` until escape. Then assemble the stage recursion
-(matching chain + `firstMissing` coverage + read-off computable `ℕ ≃ ℕ`).
+1. Derive the range-stage dual `augment_range_step` from `augment_domain_step` via the swap
+   duality (Section 4e).
+2. Define the stage recursion alternating the two steps, anchoring each stage at
+   `firstMissing (mDom σₛ)` (even) / `firstMissing (mRan σₛ)` (odd).
+3. Prove coverage (`k ∈ mDom` by stage `2k+1`, dual for range) from monotonicity + the
+   `firstMissing` progress lemmas (Section 4e).
+4. Read off `e : ℕ ≃ ℕ` via `mLookup` and prove `.Computable`; discharge `myhill_isomorphism`.

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Constructed and VERIFIED the augmenting-path object augPath (Section 4j, 8 decls, 0-axiom) — the BuiltFrom-restoring block that prior sessions named as the missing piece. Termination side (escape_exists/domain_step_exists) was already done; this supplies the object the BuiltFrom-preserving domain step re-labels into. Remaining: splice augPath into the matching (list surgery removing the stale g-edges), then the stage recursion. Main myhill_isomorphism → sorry UNCHANGED (still open).",
+    "progressSummary": "PROGRESS: augment_domain_step (Section 4k) is the augmenting-path SPLICE that r4 named as the remaining list-surgery, now DONE and VERIFIED (0-axiom): the even-stage domain move is total, BuiltFrom-preserving, and iterable (monotone both sides, covers the fresh anchor). Every atomic per-stage obligation of the Myhill scheduler is now proved; only the outer stage recursion + computable read-off remain. Main myhill_isomorphism still sorry (open).",
     "builtItems": [
       "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
       "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
@@ -59,7 +59,8 @@
       "chase_gedge_chain (SchroederBernsteinOQ03.lean Section 4i, VERIFIED 0-axiom): ∀ t≤N, ∀ 1≤m≤t, (fwdOrbit f g a m, f(fwdOrbit f g a (m-1))) ∈ L, under injective f,g + IsMatching + BuiltFrom + a∉mDom L + all-collide-before-N.",
       "escape_exists (Section 4i, VERIFIED 0-axiom): ∃ N ≤ (mDom L).length, f(fwdOrbit f g a N) ∉ mRan L — the bounded termination certificate for the even-stage collision chase.",
       "domain_step_exists (Section 4i, VERIFIED 0-axiom): the even-stage domain step is TOTAL — any fresh a can be placed as (a, chaseTarget f g a N) preserving IsMatching and MatchingCorr (does NOT preserve BuiltFrom; see next steps).",
-      "augPath + mem_augPath_iff/mDom_augPath/mRan_augPath + augPath_builtFrom + augPath_matchingCorr + augPath_isMatching + augPath_isMatching_of_chase in SchroederBernsteinOQ03.lean Section 4j (8 decls, all VERIFIED 0-axiom)"
+      "augPath + mem_augPath_iff/mDom_augPath/mRan_augPath + augPath_builtFrom + augPath_matchingCorr + augPath_isMatching + augPath_isMatching_of_chase in SchroederBernsteinOQ03.lean Section 4j (8 decls, all VERIFIED 0-axiom)",
+      "augment_domain_step (SchroederBernsteinOQ03.lean:1466): BuiltFrom-preserving TOTAL even-stage domain step. Fresh anchor a not in mDom L implies exists Lprime with IsMatching, MatchingCorr, BuiltFrom, a in mDom Lprime, and mDom/mRan monotone. VERIFIED, axioms = {propext, Classical.choice, Quot.sound}."
     ],
     "insights": [
       "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
@@ -76,14 +77,18 @@
       "Escape existence IS provable (resolves the r9 obstruction): a persistent collision forces the g-edge (o_{k+1}, f o_k) at every chase stage. The f-edge alternative (o_k, f o_k) is excluded by matching functionality — it would share domain point o_k with the previous stage g-edge, forcing f(o_k)=f(o_{k-1}), hence (f inj) an orbit repeat o_k=o_{k-1}, hence (fwdOrbit_prefix_distinct) a ∈ mDom L, contradicting freshness.",
       "The naive pointwise induction (keep colliding ⟹ stay in mDom L) fails exactly as r9 found, but induction on the STAGE BOUND t (giving all earlier g-edges at once as IH) recovers it — the IH supplies both the prior g-edge for functionality and the [1..t] mDom-membership for prefix_distinct.",
       "REAL residual difficulty (finer than escape): the resolution edge (a, f(o_N)) placed by matching_step_chase is in general NEITHER an f-edge NOR a g-edge (N>0), so it BREAKS BuiltFrom. Iterating the scheduler (which needs BuiltFrom to re-run collision_f_source) requires the augmenting-path rewrite: re-label the chased g-edges (o_k, f o_{k-1}) as f-edges (o_k, f o_k), shifting the chain by one and freeing the fresh target. That list surgery + its IsMatching/MatchingCorr/BuiltFrom preservation is the remaining ~150-line piece.",
-      "augPath f g a N (the augmenting path: f-edges (oₖ, f oₖ) for k=0..N, oₖ=fwdOrbit f g a k) is the object that RESTORES BuiltFrom after a collision chase — domain_step_exists preserves IsMatching+MatchingCorr but its single anchor pair (a, f(oₙ)) is neither an f-edge nor g-edge for N>0. Re-labelling the whole chased chain into f-edges fixes this. VERIFIED 0-axiom (propext/Classical.choice/Quot.sound only)."
+      "augPath f g a N (the augmenting path: f-edges (oₖ, f oₖ) for k=0..N, oₖ=fwdOrbit f g a k) is the object that RESTORES BuiltFrom after a collision chase — domain_step_exists preserves IsMatching+MatchingCorr but its single anchor pair (a, f(oₙ)) is neither an f-edge nor g-edge for N>0. Re-labelling the whole chased chain into f-edges fixes this. VERIFIED 0-axiom (propext/Classical.choice/Quot.sound only).",
+      "Only the f-reduction (p n iff q (f n)) is needed for the even-stage augmenting-path move; hgpq is unnecessary because every augmenting edge (o_k, f o_k) is an f-edge, so MatchingCorr of the block follows from hfpq alone (augment_domain_step, Section 4k).",
+      "The augmenting-path splice is TOTAL and preserves ALL THREE invariants plus two-sided monotonicity: mDom L subset mDom Lprime, mRan L subset mRan Lprime. Monotonicity holds because every removed g-edge endpoint (domains o_1..o_N, ranges f o_0..f o_(N-1)) is re-added by augPath ({o_0..o_N} on the domain, {f o_0..f o_N} on the range).",
+      "Range-disjointness of the spliced matching is the delicate part: for aug index k<N, f o_k is the unique range value of the removed g-edge (o_(k+1), f o_k) by matching_cofunctional, so no kept pair can carry it; for k=N it is the escape point f o_N not in mRan L (escape_exists)."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
     ],
     "nextSteps": [
-      "Splice augPath into the matching: define keptL = L with the N re-labelled g-edges (oₖ, f o_{k-1}) removed (filter by domain ∉ {o_1..o_N}), then prove IsMatching (augPath ++ keptL) via List.Nodup.append — needs (a) minimal escape depth via Nat.find so all stages <N collide (giving the g-edges present by collision_f_source), (b) domain disjointness (a∉mDom L, o_k removed), (c) range disjointness (f o_k for k<N are the removed g-edge ranges by cofunctionality; f o_N is the escape ∉ mRan L). This closes the BuiltFrom-preserving domain step.",
-      "Then the stage recursion producing an increasing chain of BuiltFrom matchings + coverage (firstMissing) + read off computable ℕ≃ℕ."
+      "Derive the range-stage dual augment_range_step from augment_domain_step via the Section 4e swap duality (isMatching_map_swap / matchingCorr_map_swap / builtFrom_map_swap).",
+      "Define the alternating stage recursion sigma : Nat -> List(NatxNat) anchoring at firstMissing (mDom sigma_s) / firstMissing (mRan sigma_s); prove coverage (k in mDom by stage 2k+1) from monotonicity + firstMissing progress.",
+      "Read off e : Nat equiv Nat via mLookup, prove Computable, and discharge myhill_isomorphism."
     ],
     "markdown": "# Knowledge Base: schroeder-bernstein-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds **Section 4k** `augment_domain_step` to `proofs/Proofs/SchroederBernsteinOQ03.lean` — the **augmenting-path splice** that prior sessions (esp. researcher-4, PR #33864) named as the genuine remaining list-surgery for the Myhill / computable Schröder–Bernstein priority scheduler.

## What it proves

For a fresh domain anchor `a ∉ mDom L` in a matching `L` satisfying `IsMatching`, `MatchingCorr p q`, and `BuiltFrom f g`:

```
∃ L', IsMatching L' ∧ MatchingCorr p q L' ∧ BuiltFrom f g L' ∧
      a ∈ mDom L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L')
```

i.e. the even-stage domain move is now **total**, preserves **all three** invariants, **covers** the anchor, and is **monotone on both sides**. The witness is `L' := augPath f g a N ++ keptL`, where `N` is the minimal escape depth (`Nat.find` on `f (fwdOrbit f g a N) ∉ mRan L`) and `keptL` filters out exactly the stale `g`-edges the augmenting path re-labels.

Only the `f`-reduction `hfpq` is needed (the earlier `domain_step_exists` needed both; every augmenting edge is an `f`-edge).

## Why it matters

Sections 4i (`escape_exists`) and 4j (`augPath`) gave the *termination* certificate and the re-labelling *object*; this glues them into an actual **iterable** step that preserves `BuiltFrom`, so the *next* stage's collision analysis (`collision_f_source`, `escape_exists`) still applies. Every atomic per-stage obligation of the scheduler is now proved. What remains is the **outer** assembly: the range-stage dual (Section 4e `Prod.swap` duality), the alternating stage recursion, coverage via `firstMissing`, and reading off the computable `ℕ ≃ ℕ` via `mLookup`.

**`myhill_isomorphism` remains open** (its `sorry` is UNCHANGED — this is a structural sub-step, not the whole theorem).

## Verification

- Host `lake env lean` (`leanprover/lean4:v4.26.0`), **EXIT 0** across iterations.
- `#print axioms MyhillIsomorphism.augment_domain_step` = `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `ofReduceBool`** (0-axiom in the project sense).
- No new `axiom` declarations; the only `sorry` in the file is the pre-existing open `myhill_isomorphism`.

> Note: a later re-run of the host build hit a transient segfault / missing-Batteries-olean from concurrent disk pressure on the shared `.lake` (documented recurring hazard) — this is an environment artifact, not a proof issue; the theorem verified cleanly (EXIT 0 + axiom check) immediately before. Docker CI re-verifies.

File `SchroederBernsteinOQ03.lean` 1539 → 1718 lines. Also updates `knowledge.md`, `state.md`, and the problem JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)