### PR TITLE
Enrich measure-theoretic LLL (lovasz-local-lemma-oq-01): add overview annotation + section

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-lll-oq01-overview",
+    "proofId": "lovasz-local-lemma-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Measure-theoretic LLL: the honest d = 0 base case",
+    "content": "The gallery's main Lovász Local Lemma entry (`LovaszLocalLemma.lean`) develops the *symmetric* LLL entirely over ℚ as a probabilistic-budget **surrogate** — it never touches a real probability space. Open question OQ-01 asks for the genuine **measure-theoretic** statement: bad events as measurable sets $A_i \\subseteq \\Omega$ in a real `IsProbabilityMeasure`, with the conclusion $\\mu(\\bigcap_i A_i^c) > 0$ (all bad events can be simultaneously avoided with positive probability). The full LLL (bounded dependency degree $d$, budget $e\\,p\\,(d+1) \\le 1$) is a multi-session target with no Mathlib counterpart; this file lands the **$d = 0$ base case** — the mutually independent regime — as a fully verified, axiom-free measure-theoretic theorem. Because every LLL induction bottoms out at the independent case, this is the honest measure-theoretic anchor for the OQ-01 program. The setup is deliberately minimal: an arbitrary `Fintype` index and `IsProbabilityMeasure` is *derived* from mutual independence, not assumed.",
+    "mathContext": "Events $A : \\iota \\to \\mathrm{Set}\\,\\Omega$ over a `Fintype` index, mutually independent (`iIndepSet A μ`) with $\\mu(A_i) < 1$; goal $\\mu\\!\\left(\\bigcap_i A_i^c\\right) = \\prod_i (1 - \\mu(A_i)) > 0$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "measure-theoretic probability",
+      "IsProbabilityMeasure",
+      "mutual independence",
+      "surrogate vs genuine formalization"
+    ],
+    "prerequisites": [
+      "measure theory: probability measures",
+      "lovasz-local-lemma (ℚ surrogate parent)",
+      "independence of events"
+    ]
+  },
+  {
     "id": "ann-lll-oq01-bridge",
     "proofId": "lovasz-local-lemma-oq-01",
     "range": {

--- a/src/data/proofs/lovasz-local-lemma-oq-01/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01/meta.json
@@ -100,6 +100,14 @@
   },
   "sections": [
     {
+      "id": "sec-overview",
+      "title": "Overview: measure-theoretic LLL and the d = 0 base case",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Module docstring contrasting the gallery's ℚ-surrogate LLL with the genuine measure-theoretic OQ-01 goal μ(⋂ Aᵢᶜ) > 0, and scoping this file to the fully verified, axiom-free d = 0 (mutually independent) base case. Imports Mathlib.Probability.Independence.Basic and fixes a Fintype-indexed measurable family A : ι → Set Ω.",
+      "mathContext": "Every LLL induction bottoms out at the independent case, so the d = 0 factorization proved here is the measure-theoretic anchor of the OQ-01 program."
+    },
+    {
       "id": "sec-bridge",
       "title": "Bridge: complements measurable in generated σ-algebras",
       "startLine": 42,


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-01` (the measure-theoretic $d=0$ base case of the Lovász Local Lemma).

**Gap:** the module docstring (lines 1–37) — the conceptual overview contrasting the gallery's ℚ-surrogate LLL with the genuine measure-theoretic OQ-01 goal $\mu(\bigcap_i A_i^c)>0$, and scoping this file to the axiom-free $d=0$ base case — was uncovered by both annotations (first began at line 42) and sections (first began at line 42).

**Fix:** added a matched pair:
- `ann-lll-oq01-overview` (1–37) — `context` annotation on the surrogate-vs-measure-theoretic distinction and why the independent case is the honest anchor for the induction.
- `sec-overview` (1–37) — matching section.

Reaches the ≥5 annotation coverage target and closes the header gap. Pure additions; new annotation carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. JSON validated.