### PR TITLE
Enrich Distance-to-Nearest-Integer Cosecant Bound: header section

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/meta.json
@@ -61,6 +61,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: the cosecant→distance bridge",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Docstring situating this file between the sibling geometric sum bound |∑ e^{2πiθn}| ≤ 1/|sin(πθ)| and its sharper distance-to-nearest-integer form ≤ 1/(2‖θ‖). The bridge is the elementary inequality |sin(πθ)| ≥ 2‖θ‖ proved here in four steps (chord bound 2θ ≤ sin(πθ); its absolute-value form; the ‖·‖ version by π·ℤ-periodicity; the cosecant reciprocal), driven by Mathlib's Jordan inequality and abs_sub_round. Ends with the single import Mathlib.",
+      "mathContext": "$|\\sin(\\pi\\theta)| \\ge 2\\lVert\\theta\\rVert,\\qquad \\lVert\\theta\\rVert = |\\theta - \\mathrm{round}\\,\\theta| \\in [0,\\tfrac12].$"
+    },
+    {
       "id": "chord",
       "title": "Concavity chord bound and the [−1/2,1/2] cosecant bound",
       "startLine": 40,


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-01-incomplete-01` ("The Distance-to-Nearest-Integer Cosecant Bound: |sin(πθ)| ≥ 2‖θ‖"). The entry is already annotation-rich (5 annotations, 4 keyInsights, 2 cross-references, 2 canonical references), so this is a single targeted coverage fix.

**Sections: added the header (lines 1–39).** The `sections` array previously started at line 40, leaving the motivating docstring and import untiled. Added a `header` section summarizing the cosecant→distance bridge and its four proof steps, so the section map covers the full file.

- No existing content removed; all collections remain well under caps (meta.json ~10 KB).
- JSON validated with a parser.
