### PR TITLE
Enrich Sum of Squares of First n Odd Numbers: references + header section

### DIFF
--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -42,6 +42,13 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Statement",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Docstring stating the open question ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 (the sum of the squares of the first n odd numbers), positioning it as the odd-indexed companion of the square-pyramidal identity ∑_{k≤n}k² = n(n+1)(2n+1)/6 and noting Mathlib lacks this variant. Imports (BigOperators.Intervals, Tactic), the namespace, and open Finset, followed by the docstring of the division-free integer form three_mul_sum_odd_squares — deliberately additive (3·∑ + n = 4n³) so the inductive step avoids ℕ truncated subtraction and closes by ring."
+    },
+    {
       "id": "integer-form",
       "title": "Division-free integer form (subtraction-free step)",
       "startLine": 46,
@@ -72,6 +79,22 @@
       "Polynomial identities over ℚ"
     ]
   },
+  "references": [
+    {
+      "authors": "Graham, R. L., Knuth, D. E., Patashnik, O.",
+      "title": "Concrete Mathematics: A Foundation for Computer Science",
+      "year": "1994",
+      "venue": "2nd ed., Addison-Wesley",
+      "note": "Standard reference for closed forms of finite sums; Chapter 2 develops summation of ∑ kᵐ and related power sums by perturbation and finite calculus"
+    },
+    {
+      "authors": "Conway, J. H., Guy, R. K.",
+      "title": "The Book of Numbers",
+      "year": "1996",
+      "venue": "Springer-Verlag",
+      "note": "Popular account of figurate and polygonal numbers, including sums of squares of consecutive and odd integers"
+    }
+  ],
   "conclusion": {
     "summary": "The sum of the squares of the first $n$ odd numbers, $\\sum_{k<n}(2k+1)^2$, equals $n(2n-1)(2n+1)/3$. This is proved twice: as the division-free exact ℕ identity $3\\sum(2k+1)^2 + n = 4n^3$, whose additive phrasing lets the inductive step close by `ring` with no truncated subtraction, and as the classical rational closed form over $\\mathbb{Q}$. Both depend on the single Mathlib lemma `sum_range_succ`. 0 axioms, 0 sorries.",
     "implications": [


### PR DESCRIPTION
Enrichment pass for `odd-squares-sum-oq-01` ("Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3"). Already annotation-rich (5 annotations, 4 keyInsights, 2 cross-references), so this targets its two weakest fields.

**References 0 → 2.** The entry had no references. Added the canonical sources for finite-sum closed forms: Graham–Knuth–Patashnik, *Concrete Mathematics* (1994), and Conway–Guy, *The Book of Numbers* (1996) for the figurate-number context.

**Sections: added the header (lines 1–45).** The `sections` array previously started at line 46, leaving the motivating docstring, imports, and namespace untiled. Added a `header` section (matching the file's section schema) so the section map covers the full file.

- No existing content removed; all collections well under caps (meta.json ~10 KB).
- JSON validated with a parser.
