### PR TITLE
Enrich Telescoping Product ∏(1−1/k²)=(n+1)/(2n): +eventual-equality annotation, +2 keyInsights

### DIFF
--- a/src/data/proofs/telescoping-product-oq-01/annotations.json
+++ b/src/data/proofs/telescoping-product-oq-01/annotations.json
@@ -91,5 +91,29 @@
       "real analysis",
       "filters (Mathlib)"
     ]
+  },
+  {
+    "id": "eventual-equality-congr",
+    "proofId": "telescoping-product-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "Eventual Equality via Tendsto.congr'",
+    "content": "The limit is not proved by manipulating the quotient (n+1)/(2n) directly, but by showing it is *eventually* equal to the manifestly convergent sequence 1/2 + (1/2)(1/n). Filter.Tendsto.congr' only requires the two sequences to agree on a set that lies in the filter — here the tail {n ≥ 1} supplied by Filter.eventually_ge_atTop 1 — because a limit at atTop ignores any finite prefix. filter_upwards introduces that tail hypothesis n ≥ 1, giving n ≠ 0 so field_simp can clear denominators and reduce both sides to a common numerator. This sidesteps the need for a quotient-limit lemma entirely.",
+    "mathContext": "$\\texttt{Tendsto.congr'}$ upgrades $f =^{\\mathcal F} g$ (equality on a set in the filter $\\mathcal F$) plus $g \\to L$ to $f \\to L$. The at-infinity filter $\\texttt{atTop}$ makes any cofinite condition — such as $n \\ge 1$, which is needed only so that $\\frac{n+1}{2n} = \\frac12 + \\frac{1}{2n}$ is well defined — free, because the limit depends only on the tail of the sequence.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Filter.Tendsto.congr'",
+      "eventually equal (=ᶠ)",
+      "filter_upwards",
+      "atTop filter",
+      "field_simp"
+    ],
+    "prerequisites": [
+      "filters and limits",
+      "Mathlib filter API"
+    ]
   }
 ]

--- a/src/data/proofs/telescoping-product-oq-01/meta.json
+++ b/src/data/proofs/telescoping-product-oq-01/meta.json
@@ -95,7 +95,9 @@
       "The single algebraic move is the difference-of-squares factorisation 1 − 1/k² = (k−1)(k+1)/k²; everything else is bookkeeping of endpoint terms.",
       "Finset.prod_Icc_succ_top is the multiplicative analogue of peeling the last term of a sum, and makes the induction over Finset.Icc 2 n completely mechanical.",
       "Choosing the base point n = 1 (the empty product) rather than n = 2 keeps the closed form (n+1)/(2n) valid at the boundary, where it reads 2/2 = 1.",
-      "The limit is cleanest after the eventual rewrite (n+1)/(2n) = 1/2 + (1/2)(1/n), reducing convergence to the standard fact 1/n → 0 rather than a quotient limit."
+      "The limit is cleanest after the eventual rewrite (n+1)/(2n) = 1/2 + (1/2)(1/n), reducing convergence to the standard fact 1/n → 0 rather than a quotient limit.",
+      "The single factor (1 − 1/k²) hides two one-sided telescopes running in opposite directions: ∏(k−1)/k = 1/n collapses from the bottom and ∏(k+1)/k = (n+1)/2 collapses from the top, and (n+1)/(2n) is simply their product — the induction just tracks both endpoint contributions at once.",
+      "Convergence is proved by Tendsto.congr' rather than by simplifying the quotient: since a limit at atTop depends only on the tail, the sequence need only be eventually equal (for n ≥ 1) to 1/2 + (1/2)(1/n), which sidesteps any quotient-limit lemma."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `telescoping-product-oq-01` (quality 91, passes 0 → first pass).

The entry was already strong and well under all size caps (10.7→11.3 KB). Targeted additions to reach the stated minimums and surface two genuinely distinct ideas:

- **+5th annotation** (technique, lines 84–96): the `Filter.Tendsto.congr'` *eventual-equality* idiom used in the limit proof — the sequence need only agree with `1/2 + (1/2)(1/n)` on the `n ≥ 1` tail (from `filter_upwards`/`eventually_ge_atTop`) because a limit at `atTop` ignores any finite prefix; `field_simp` then clears denominators. This sidesteps any quotient-limit lemma. (Annotations now 4 → 5.)
- **+2 keyInsights**: (1) the single factor `1−1/k²` hides two one-sided telescopes running in opposite directions, `∏(k−1)/k = 1/n` (bottom) and `∏(k+1)/k = (n+1)/2` (top), whose product is the closed form; (2) convergence is proved by `Tendsto.congr'` rather than by simplifying the quotient. (keyInsights 4 → 6, within the 12 cap.)

No content removed; all additions are mathematically verified against the Lean source. JSON validated via the build's enrichment phase (all 2339 entries parsed cleanly).