### PR TITLE
Enrich Pythagorean triples classification: existence-vs-bijection key insight

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
@@ -59,7 +59,8 @@
       "**Legs = Re/Im of a Gaussian square**: (m²-n², 2mn) are exactly the components of (m+ni)², so the parametrization is 'square a Gaussian integer'.",
       "**Hypotenuse = Gaussian norm**: m²+n² = N(m+ni), and N(z²)=N(z)² is precisely the Pythagorean relation.",
       "**Why opposite parity and coprimality give primitivity**: these are exactly the conditions under which m+ni is (up to units) not divisible by 1+i, keeping the square primitive.",
-      "**The hard direction needs ℤ[i] UFD**: that every primitive triple comes from a single Gaussian square is unique factorization in disguise — supplied by Mathlib."
+      "**The hard direction needs ℤ[i] UFD**: that every primitive triple comes from a single Gaussian square is unique factorization in disguise — supplied by Mathlib.",
+      "**Existence, not yet a bijection**: the formalized classification asserts every primitive triple *arises from some* coprime opposite-parity (m,n), but only up to swapping the legs and the sign of z. It is an existence statement, not an explicit parametrizing bijection; pinning down a unique generator requires normalizing to m > n > 0 (with x the odd leg, z > 0) and proving injectivity there — the content of open question 3. The `±` and leg-swap in the biconditional are exactly the residual ambiguity that normalization removes."
     ],
     "prerequisites": [
       "Gaussian integers and their norm",


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-02-oq-01`.

## Change
Adds one key insight (4→5) filling a genuine conceptual gap the existing four don't cover: the formalized classification is an **existence** statement — every primitive triple arises from *some* coprime opposite-parity (m,n), up to leg-swap and sign of z — not yet an explicit parametrizing **bijection**. The insight ties the `±`/leg-swap ambiguity in the biconditional to the `m > n > 0` normalization and the injectivity that open question 3 asks for.

## Validation
- JSON valid; 5 keyInsights (≤12 cap), meta.json 11.5 KB (≪60 KB cap).
- No schema/status/badge/axiom changes; cross-refs untouched (all 3 verified valid).
- Curation-respecting: a single sharp insight, no bloat.