### PR TITLE
Enrich Erdős #100 integer-distance bridge: why integrality caps distinct distances

### DIFF
--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/meta.json
@@ -53,7 +53,8 @@
       "Integer pairwise distances confine the distinct distances to {1, ..., floor(diam)}, a set of size at most the diameter.",
       "The bound is a pure counting injection: each distinct integer distance is a distinct point of a length-floor(D) range.",
       "This single inequality is what upgrades a distinct-distances lower bound (Guth-Katz, c n/log n) into a diameter lower bound for integer-distance sets.",
-      "The bridge is entirely independent of the hard explicit-construction sorry (Piepmeyer's 9-point witness) in the scaffold."
+      "The bridge is entirely independent of the hard explicit-construction sorry (Piepmeyer's 9-point witness) in the scaffold.",
+      "The cap #distinct ≤ diam is special to integer distances: for an arbitrary planar set the number of distinct distances is not constrained by the diameter (Guth-Katz shows it can grow like ~n/√(log n), far exceeding a fixed diameter). Integrality is exactly what forces the distances into {1, ..., floor(diam)}, which is why Erdős #100 admits a diameter lower bound while the general distinct-distances problem does not translate into one."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-01-incomplete-01`.

## Change
Adds one key insight (4→5): the cap #distinct ≤ diam is *special to integer distances*. For an arbitrary planar set the distinct-distance count is unconstrained by the diameter (Guth–Katz: ~n/√log n), and integrality is exactly what confines distances to {1,…,⌊diam⌋} — which is why Erdős #100 admits a diameter lower bound while the general distinct-distances problem does not. None of the existing four insights make this point.

## Integrity note
Confirmed the `verified`/0-sorry metadata is accurate: this file's three "sorry" occurrences are all **prose** in docstrings referring to the *separate* scaffold `Erdos100OQ01.lean`; this file itself cleanly proves 3 theorems with no `sorry`/`axiom`/`native_decide` and no assumption-carrying structures. The "incomplete" in the slug denotes a partial contribution to the open problem (the bridge lemma), not incomplete Lean.

## Validation
- JSON valid; 5 keyInsights (≤12 cap); meta.json well under 60 KB cap.
- Existing cross-refs (scaffold parent + foundational) verified to resolve; no Erdős #89/distinct-distances gallery entry exists to link.
- No annotation/schema/status changes.