### PR TITLE
Enrich Erdős #1023 elementary growth brackets: +references array

### DIFF
--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -96,5 +96,31 @@
       "relationship": "parent",
       "description": "The main Erdős #1023 union-free families file (isUnionFree, middleLayer, the lower bound unionFreeMax_ge_middle, and the axiomatized Erdős-Kleitman optimality and Stirling asymptotic). It establishes F(n) = C(n, floor(n/2)); this sibling supplies the elementary, 0-axiom growth brackets 2^n/(n+1) ≤ F(n) ≤ 2^n and divergence that the parent only obtains through its Stirling axiom."
     }
+  ],
+  "references": [
+    {
+      "authors": "Thomas F. Bloom (ed.)",
+      "title": "Erdős Problem #1023",
+      "year": 2024,
+      "note": "erdosproblems.com/1023. Catalogues the union-free maximum problem, Erdős's conjecture F(n) ~ c·2ⁿ/√n, and its resolution via the central binomial coefficient."
+    },
+    {
+      "authors": "Jacobus H. van Lint and Richard M. Wilson",
+      "title": "A Course in Combinatorics (2nd ed.)",
+      "year": 2001,
+      "note": "Cambridge University Press. The binomial identity ∑_{m≤n} C(n,m) = 2ⁿ and the central column C(n, ⌊n/2⌋) as the maximum entry of Pascal's row n — the two facts the growth brackets average against."
+    },
+    {
+      "authors": "Ian Anderson",
+      "title": "Combinatorics of Finite Sets",
+      "year": 1987,
+      "note": "Oxford University Press. Sperner-type extremal set theory, antichains, and the maximality of the middle layer of the subset lattice — the structural background to why the ⌊n/2⌋-layer is union-free and extremal."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: Nat.Choose bounds and central binomial infrastructure",
+      "year": 2024,
+      "note": "Nat.choose_le_middle (central column is maximal), Nat.choose_le_two_pow (each column ≤ 2ⁿ), and Nat.choose_le_centralBinom, the finite-binomial lemmas driving the elementary brackets and divergence."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-1023-oq-04` (quality 92, passes 0 → first pass).

The entry was already strong: full section tiling (1–96, 97–133), 5 annotations (all with `mathContext`), 4 keyInsights, detailed overview/conclusion with 3 openQuestions. The one field-level gap versus its sibling entries: **no `references` array**.

Added 4 accurate references:
- **Erdős Problem #1023** (Bloom, erdosproblems.com/1023) — the problem source, conjecture F(n) ~ c·2ⁿ/√n, and its central-binomial resolution.
- **van Lint & Wilson, *A Course in Combinatorics*** — the identity ∑ C(n,m) = 2ⁿ and the central column as Pascal-row maximum (the two facts the brackets average against).
- **Anderson, *Combinatorics of Finite Sets*** — Sperner/middle-layer extremal background.
- **Mathlib4 Nat.Choose bounds** — `choose_le_middle`, `choose_le_two_pow`, `choose_le_centralBinom`, the lemmas actually driving the proof.

No content removed. 10.0 → 11.4 KB, under all caps. JSON validated (parses cleanly).