### PR TITLE
research(weak-goldbach-oq-01): Goldbach comet counting function + parity constraint [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -136,4 +136,77 @@ example : ¬HasSymmetricPrimePair 1 := by decide
 example : IsSumOfTwoPrimes 10 :=
   (sumTwoPrimes_iff_symmetric 5).mpr (by decide)
 
+/-! ## The Goldbach Comet Counting Function
+
+Turning the existential predicate into a *quantitative* object: the number of
+symmetric prime pairs about the midpoint `m`. This counts the offsets `k < m`
+for which both `m - k` and `m + k` are prime — equivalently the number of
+(ordered-by-size) Goldbach partitions of `2 * m`. Plotting this count against
+`2 * m` produces the well-known **Goldbach comet**. The Strong Goldbach
+Conjecture is exactly the statement that this count is *positive* for every
+`m ≥ 2`. -/
+
+/-- The **Goldbach comet count** at midpoint `m`: the number of offsets `k < m`
+with both `m - k` and `m + k` prime. This equals the number of Goldbach
+partitions `2 * m = p + q` with `p ≤ q` (via `p = m - k`, `q = m + k`). -/
+def symmetricPairCount (m : ℕ) : ℕ :=
+  ((Finset.range m).filter (fun k => Nat.Prime (m - k) ∧ Nat.Prime (m + k))).card
+
+/-- The symmetric predicate holds iff the comet count is positive: existence of a
+Goldbach partition is the same as the count being nonzero. -/
+theorem hasSymmetricPrimePair_iff_count_pos (m : ℕ) :
+    HasSymmetricPrimePair m ↔ 0 < symmetricPairCount m := by
+  rw [symmetricPairCount, Finset.card_pos]
+  constructor
+  · rintro ⟨k, hk, hp1, hp2⟩
+    exact ⟨k, Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hk, hp1, hp2⟩⟩
+  · rintro ⟨k, hk⟩
+    rw [Finset.mem_filter, Finset.mem_range] at hk
+    exact ⟨k, hk.1, hk.2.1, hk.2.2⟩
+
+/-- **Strong Goldbach as a positivity statement about the comet.** The conjecture
+is equivalent to: the Goldbach comet count is positive for every `m ≥ 2`. -/
+theorem symmetricGoldbach_iff_count :
+    SymmetricGoldbachConjecture ↔ ∀ m : ℕ, 2 ≤ m → 0 < symmetricPairCount m := by
+  unfold SymmetricGoldbachConjecture
+  exact forall_congr' fun m => imp_congr_right fun _ => hasSymmetricPrimePair_iff_count_pos m
+
+/-! ## Structural Constraint: Both Summands Are Odd for `2 * m > 4`
+
+Every Goldbach partition of an even number `> 4` consists of two **odd** primes.
+In the symmetric picture, once `m > 2` the smaller prime `m - k` cannot be `2`:
+if it were, the larger prime would be `m + k = 2 * (m - 1)`, which is even and
+`> 2`, hence not prime. So `2` never participates, and both summands are odd. -/
+
+/-- For `m > 2`, the smaller summand `m - k` of a symmetric prime pair is odd. -/
+theorem symmetric_pair_odd {m k : ℕ} (hm : 2 < m) (hk : k < m)
+    (hp1 : Nat.Prime (m - k)) (hp2 : Nat.Prime (m + k)) :
+    Odd (m - k) := by
+  rcases hp1.eq_two_or_odd' with h2 | hodd
+  · -- If `m - k = 2`, then `m + k = 2 * (m - 1)` is an even prime `> 2`: impossible.
+    exfalso
+    have heven : Even (m + k) := ⟨m - 1, by omega⟩
+    have : m + k = 2 := (Nat.Prime.even_iff hp2).mp heven
+    omega
+  · exact hodd
+
+/-- For `m > 2`, **both** summands `m - k` and `m + k` of a symmetric prime pair
+are odd primes. -/
+theorem symmetric_pair_both_odd {m k : ℕ} (hm : 2 < m) (hk : k < m)
+    (hp1 : Nat.Prime (m - k)) (hp2 : Nat.Prime (m + k)) :
+    Odd (m - k) ∧ Odd (m + k) := by
+  refine ⟨symmetric_pair_odd hm hk hp1 hp2, ?_⟩
+  obtain ⟨j, hj⟩ := symmetric_pair_odd hm hk hp1 hp2
+  exact ⟨j + k, by omega⟩
+
+-- Concrete comet heights, verified by kernel `decide` (axiom-free).
+-- `2 * 5 = 10 = 3 + 7 = 5 + 5`, so two symmetric pairs (`k = 0, 2`).
+example : symmetricPairCount 5 = 2 := by decide
+-- `2 * 6 = 12 = 5 + 7`, a single symmetric pair (`k = 1`).
+example : symmetricPairCount 6 = 1 := by decide
+
+-- Positivity of the comet at a few midpoints, routed through the equivalence.
+example : 0 < symmetricPairCount 9 :=
+  (hasSymmetricPrimePair_iff_count_pos 9).mp (by decide)
+
 end StrongGoldbach

--- a/src/data/proofs/strong-goldbach-symmetric/annotations.json
+++ b/src/data/proofs/strong-goldbach-symmetric/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-definitions",
     "proofId": "strong-goldbach-symmetric",
-    "range": { "startLine": 40, "endLine": 58 },
+    "range": {
+      "startLine": 40,
+      "endLine": 58
+    },
     "type": "definition",
     "title": "Predicates: Sum of Two Primes and Symmetric Prime Pair",
     "content": "`IsSumOfTwoPrimes n` asserts $\\exists p, q$ prime with $n = p + q$ — the raw Strong Goldbach target. `HasSymmetricPrimePair m` asserts $\\exists k < m$ with both $m - k$ and $m + k$ prime, encoding a Goldbach partition of $2m$ as a prime pair symmetric about the midpoint $m$. The two conjecture-level predicates `StrongGoldbachConjecture` (∀ even $n > 2$) and `SymmetricGoldbachConjecture` (∀ $m \\geq 2$) package these into the statements shown equivalent below.",
@@ -23,7 +26,10 @@
   {
     "id": "ann-per-n-equivalence",
     "proofId": "strong-goldbach-symmetric",
-    "range": { "startLine": 60, "endLine": 92 },
+    "range": {
+      "startLine": 60,
+      "endLine": 92
+    },
     "type": "theorem",
     "title": "Midpoint-Symmetry Equivalence",
     "content": "`sumTwoPrimes_iff_symmetric`: for every $m$, $2m$ is a sum of two primes iff there is $k < m$ with $m - k$ and $m + k$ both prime. Forward: given $2m = p + q$, order the primes with `le_total`; the smaller one is $\\leq m$ (since $2\\min(p,q) \\leq p+q = 2m$), so setting $k = m - \\min(p,q)$ gives $m - k = \\min$ and $m + k = \\max$, with the ℕ-subtraction identities discharged by `omega` using that every prime is $\\geq 2$. Reverse: $p = m-k$, $q = m+k$ sum to $2m$ by `omega`. No lower bound on $m$ is needed — for $m = 0$ both sides are false.",
@@ -44,7 +50,10 @@
   {
     "id": "ann-conjecture-equivalence",
     "proofId": "strong-goldbach-symmetric",
-    "range": { "startLine": 94, "endLine": 110 },
+    "range": {
+      "startLine": 94,
+      "endLine": 110
+    },
     "type": "theorem",
     "title": "Conjecture-Level Equivalence",
     "content": "`strong_iff_symmetric`: `StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture`. Each direction transports through the per-$n$ equivalence. Forward: given $m \\geq 2$, apply Strong Goldbach to $n = 2m$ (which is even and $> 2$) and convert via the forward per-$n$ equivalence. Reverse: given even $n > 2$, write $n = 2r$ from `Even n`, note $r \\geq 2$, and apply the symmetric form at $r$. This shows the two conjectures are logically identical — proving either proves both. Neither is proved here.",
@@ -63,7 +72,10 @@
   {
     "id": "ann-decidability-examples",
     "proofId": "strong-goldbach-symmetric",
-    "range": { "startLine": 112, "endLine": 139 },
+    "range": {
+      "startLine": 112,
+      "endLine": 138
+    },
     "type": "technique",
     "title": "Decidability and Axiom-Free Verified Examples",
     "content": "`decidableHasSymmetricPrimePair` derives a `Decidable` instance by rewriting the bounded existential $\\exists k < m$ as $\\exists k \\in \\text{Finset.range } m$ (via `decidable_of_iff`), which Lean can decide because `Nat.Prime` is decidable. This lets `decide` certify concrete symmetric partitions — $10 = 3+7$ ($m=5,k=2$), $12 = 5+7$, $18 = 7+11$ — by kernel reduction. Crucially these use `decide`, not `native_decide`, so the file introduces no `Lean.ofReduceBool` axiom and stays fully axiom-free. `¬HasSymmetricPrimePair 1` confirms $n = 2$ is correctly excluded, matching the $n > 2$ hypothesis.",
@@ -79,6 +91,53 @@
       "Decidable typeclass",
       "Finset.mem_range",
       "decidability of Nat.Prime"
+    ]
+  },
+  {
+    "id": "ann-comet-count",
+    "proofId": "strong-goldbach-symmetric",
+    "range": {
+      "startLine": 139,
+      "endLine": 173
+    },
+    "type": "definition",
+    "title": "The Goldbach Comet Counting Function",
+    "content": "`symmetricPairCount m` is the number of offsets $k < m$ (over `Finset.range m`) with both $m - k$ and $m + k$ prime — the height of the Goldbach comet at $2m$, equivalently the number of size-ordered Goldbach partitions of $2m$. `hasSymmetricPrimePair_iff_count_pos` upgrades the existential predicate to positivity of this count, via `Finset.card_pos` and a routine round-trip through `Finset.mem_filter`/`Finset.mem_range`. `symmetricGoldbach_iff_count` then recasts the whole conjecture: Strong Goldbach holds iff the comet count is positive for every $m \\geq 2$. Concrete heights `symmetricPairCount 5 = 2` (from $10 = 3+7 = 5+5$) and `symmetricPairCount 6 = 1` (from $12 = 5+7$) are certified by kernel `decide`, keeping the section axiom-free.",
+    "mathContext": "$r(2m) := \\#\\{\\, k < m : \\mathbb{P}(m-k) \\wedge \\mathbb{P}(m+k) \\,\\}, \\qquad \\text{HasSymmetricPrimePair}(m) \\iff r(2m) > 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Goldbach comet",
+      "partition counting function",
+      "Finset.card_pos",
+      "Hardy–Littlewood asymptotic"
+    ],
+    "prerequisites": [
+      "Finset.filter and Finset.card",
+      "Finset.card_pos",
+      "decidability of Nat.Prime"
+    ]
+  },
+  {
+    "id": "ann-parity-constraint",
+    "proofId": "strong-goldbach-symmetric",
+    "range": {
+      "startLine": 174,
+      "endLine": 212
+    },
+    "type": "theorem",
+    "title": "Both Summands Are Odd for 2m > 4",
+    "content": "`symmetric_pair_odd`: for $m > 2$, the smaller prime $m - k$ of a symmetric pair must be odd. If instead $m - k = 2$, then $k = m - 2$ and the larger prime would be $m + k = 2(m-1)$, an even number greater than $2$ — but `Nat.Prime.even_iff` forces an even prime to equal $2$, and `omega` closes the contradiction. `symmetric_pair_both_odd` extends oddness to $m + k = (m-k) + 2k$. Together they formalize the elementary but often-cited fact that the prime $2$ never appears in a Goldbach partition of an even number greater than $4$ — every such partition is a sum of two odd primes.",
+    "mathContext": "$m > 2 \\wedge \\mathbb{P}(m-k) \\wedge \\mathbb{P}(m+k) \\implies \\mathrm{Odd}(m-k) \\wedge \\mathrm{Odd}(m+k)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "even prime",
+      "parity of Goldbach summands",
+      "Nat.Prime.even_iff"
+    ],
+    "prerequisites": [
+      "Nat.Prime.eq_two_or_odd'",
+      "Nat.Prime.even_iff",
+      "the omega decision procedure"
     ]
   }
 ]

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -2,7 +2,7 @@
   "id": "strong-goldbach-symmetric",
   "title": "Strong Goldbach: Symmetric (Midpoint) Reformulation",
   "slug": "strong-goldbach-symmetric",
-  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. The conjecture itself is NOT proved; only the equivalence is. 2 theorems, 4 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
+  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. Also defines the Goldbach comet counting function (the number of symmetric prime pairs), proves existence ⟺ positive count and recasts the conjecture as a comet-positivity statement, and proves the structural fact that for 2m > 4 both Goldbach summands are odd. The conjecture itself is NOT proved; only the equivalences and structural facts are. 6 theorems, 5 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
@@ -20,12 +20,16 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 139,
-    "theoremCount": 2,
-    "definitionCount": 4,
+    "lineCount": 212,
+    "theoremCount": 6,
+    "definitionCount": 5,
     "originalContributions": [
       "sumTwoPrimes_iff_symmetric: for every m, IsSumOfTwoPrimes (2m) ↔ ∃ k < m, Prime (m−k) ∧ Prime (m+k) — the midpoint-symmetry equivalence, valid without any lower bound on m",
       "strong_iff_symmetric: StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture — the conjecture-level equivalence",
+      "symmetricPairCount: the Goldbach comet counting function — the number of offsets k < m with both m−k and m+k prime (equivalently the number of size-ordered Goldbach partitions of 2m)",
+      "hasSymmetricPrimePair_iff_count_pos: HasSymmetricPrimePair m ↔ 0 < symmetricPairCount m — existence of a Goldbach partition equals positivity of the comet count",
+      "symmetricGoldbach_iff_count: SymmetricGoldbachConjecture ↔ (∀ m ≥ 2, 0 < symmetricPairCount m) — Strong Goldbach recast as comet positivity",
+      "symmetric_pair_odd / symmetric_pair_both_odd: for m > 2 the smaller summand m−k (hence both m−k and m+k) is an odd prime — the value 2 never participates in a Goldbach partition of 2m > 4, since m−k = 2 forces m+k = 2(m−1), an even number > 2",
       "HasSymmetricPrimePair: predicate for a prime pair symmetric about the midpoint m",
       "SymmetricGoldbachConjecture: the symmetric-form statement of Strong Goldbach",
       "decidableHasSymmetricPrimePair: decidable instance for the symmetric predicate, via a bounded existential over Finset.range"
@@ -82,25 +86,39 @@
       "id": "sec-decidability-examples",
       "title": "Decidability and Verified Examples",
       "startLine": 112,
-      "endLine": 139,
+      "endLine": 138,
       "summary": "decidableHasSymmetricPrimePair via a bounded existential over Finset.range, then `decide`-verified symmetric partitions (m = 5, 6, 9), the negative case ¬HasSymmetricPrimePair 1 (matching the exclusion n > 2), and a sanity check transporting the partition 10 = 3 + 7 through the equivalence."
+    },
+    {
+      "id": "sec-comet-count",
+      "title": "The Goldbach Comet Counting Function",
+      "startLine": 139,
+      "endLine": 173,
+      "summary": "symmetricPairCount m := card of the offsets k < m in Finset.range with both m−k and m+k prime — the height of the Goldbach comet at 2m. hasSymmetricPrimePair_iff_count_pos turns the existential predicate into positivity of this count (via Finset.card_pos), and symmetricGoldbach_iff_count recasts the whole conjecture as: the comet count is positive for every m ≥ 2. Exact comet heights symmetricPairCount 5 = 2 and 6 = 1 are certified by kernel `decide`."
+    },
+    {
+      "id": "sec-parity-constraint",
+      "title": "Structural Constraint: Both Summands Are Odd for 2m > 4",
+      "startLine": 174,
+      "endLine": 212,
+      "summary": "symmetric_pair_odd: for m > 2, the smaller prime m−k of a symmetric pair is odd — if it were 2 then m+k = 2(m−1) would be an even prime > 2, impossible (proved via Nat.Prime.even_iff and omega). symmetric_pair_both_odd extends this to both summands. This is the formal statement that the prime 2 never participates in a Goldbach partition of an even number greater than 4."
     }
   ],
   "conclusion": {
-    "summary": "This file gives a fully verified, axiom-free reformulation of the open Strong Goldbach Conjecture in terms of prime pairs symmetric about the midpoint n/2. The per-n equivalence sumTwoPrimes_iff_symmetric and the conjecture-level strong_iff_symmetric show that Strong Goldbach is logically identical to its symmetric form, while a decidable instance makes concrete partitions machine-checkable. The conjecture itself is not proved — only the equivalence and the decidability infrastructure.",
+    "summary": "This file gives a fully verified, axiom-free reformulation of the open Strong Goldbach Conjecture in terms of prime pairs symmetric about the midpoint n/2. The per-n equivalence sumTwoPrimes_iff_symmetric and the conjecture-level strong_iff_symmetric show that Strong Goldbach is logically identical to its symmetric form; the Goldbach comet counting function symmetricPairCount makes the number of partitions a first-class object, with hasSymmetricPrimePair_iff_count_pos and symmetricGoldbach_iff_count recasting the conjecture as comet positivity; and symmetric_pair_both_odd records that the prime 2 never participates once 2m > 4. A decidable instance makes concrete partitions and comet heights machine-checkable. The conjecture itself is not proved — only the equivalences, the comet-count infrastructure, and the parity constraint.",
     "implications": "The symmetric viewpoint is the basis of the 'Goldbach comet' and of most computational and heuristic work on Goldbach partitions: it halves the search space and exposes the symmetry that Hardy–Littlewood-type asymptotics count. Having this equivalence verified axiom-free provides a clean, reusable interface: any future proof (or large-scale verification) can target whichever of the two equivalent forms is more convenient.",
     "openQuestions": [
       "Strong (Binary) Goldbach Conjecture itself: every even n > 2 is a sum of two primes — still open; this file only reduces it to the symmetric form.",
-      "Goldbach comet asymptotic: the Hardy–Littlewood conjectured count of symmetric prime pairs G(2m) ~ 2C₂ ∏_{p|m, p>2} (p−1)/(p−2) · 2m/(log 2m)² would, if proved, give Strong Goldbach for almost all m; can any nontrivial lower bound on the number of symmetric pairs be formalized?",
+      "Goldbach comet asymptotic: the Hardy–Littlewood conjectured count of symmetric prime pairs G(2m) ~ 2C₂ ∏_{p|m, p>2} (p−1)/(p−2) · 2m/(log 2m)² would, if proved, give Strong Goldbach for almost all m. The comet count symmetricPairCount is now a defined object here (with existence ⟺ positivity), giving a concrete target; can any nontrivial lower bound on it be formalized?",
       "Monotone / structural strengthenings: is there an even n whose only symmetric prime pair has large offset k close to m? Bounds on the minimal offset relate to prime gaps."
     ]
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 139,
+    "lineCount": 212,
     "axiomCount": 0,
-    "theoremCount": 2,
-    "definitionCount": 4,
+    "theoremCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the verified symmetric/midpoint reformulation of the **Strong (Binary) Goldbach Conjecture** (`Proofs/StrongGoldbachSymmetric.lean`, gallery entry `strong-goldbach-symmetric`) with a **quantitative** and a **structural** layer. Both are fully machine-checked with only the ordinary foundational axioms (`propext`, `Classical.choice`, `Quot.sound`) — verified by `#print axioms`, with **no `sorryAx` and no `Lean.ofReduceBool`** (all `decide` calls are kernel reduction, not `native_decide`).

The Strong Goldbach Conjecture itself **remains open** — this PR proves only equivalences and structural facts about Goldbach partitions.

## New results

- **`symmetricPairCount`** — the *Goldbach comet counting function*: the number of offsets `k < m` (over `Finset.range m`) with both `m − k` and `m + k` prime, i.e. the number of size-ordered Goldbach partitions of `2m`.
- **`hasSymmetricPrimePair_iff_count_pos`** — existence of a Goldbach partition ⟺ positivity of the comet count (`Finset.card_pos`).
- **`symmetricGoldbach_iff_count`** — Strong Goldbach recast as: the comet count is positive for every `m ≥ 2`.
- **`symmetric_pair_odd` / `symmetric_pair_both_odd`** — for `2m > 4`, both summands of every symmetric prime pair are **odd** primes. (If `m − k = 2` then `m + k = 2(m−1)` is even and `> 2`, so not prime — proved via `Nat.Prime.even_iff` + `omega`.) This is the formal statement that the prime `2` never participates in a Goldbach partition of an even number `> 4`.

Concrete comet heights `symmetricPairCount 5 = 2` (`10 = 3+7 = 5+5`) and `symmetricPairCount 6 = 1` (`12 = 5+7`) are certified by kernel `decide`.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetric` — **build succeeds**.
- `#print axioms` on the new theorems: `[propext, Classical.choice, Quot.sound]` only.
- File now: **6 theorems, 5 definitions, 1 decidable instance, 212 lines, 0 sorries, 0 axioms.**
- Gallery `meta.json` and `annotations.json` updated (counts, sections, contributions, open questions); annotation validator clean for this entry.

## Context

Addresses the `weak-goldbach-oq-01` research problem's stated next step: "Formalize a lower bound on the number of symmetric prime pairs (partial Goldbach comet)." This PR makes that count a first-class formal object (with existence ⟺ positivity), providing a concrete target for future asymptotic/lower-bound work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)