### PR TITLE
Enrich Bézout step-matrix factorization: add missing annotations.json (0→8)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "bezout-oq010201-header",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "From a closed-form reduction matrix to its per-step factorization",
+    "content": "The grandparent entry (bezout-identity-oq-01-oq-02) packaged the extended Euclidean algorithm as a single closed-form unimodular matrix U(a,b) with U ·ᵥ (a,b) = (gcd, 0), and asked to realize U as an explicit product of the elementary step matrices E(q) = !![0,1; 1,-q] indexed by the successive Euclidean quotients qᵢ. This file answers that question. One division step a = q·b + r acts on the column (a,b) by E(q): E(q) ·ᵥ (a,b) = (b, a − q·b) = (b, a % b). Chaining the steps until the second coordinate hits 0 assembles euclidProd a b = E(q_k)·⋯·E(q_1), and the file proves it (1) reduces (a,b) to (gcd a b, 0), (2) is unimodular (det = ±1), and (3) equals the literal fold of the quotient list.",
+    "mathContext": "$U(a,b) = \\begin{pmatrix} \\gcd_A & \\gcd_B \\\\ -b/g & a/g \\end{pmatrix},\\quad E(q) = \\begin{pmatrix} 0 & 1 \\\\ 1 & -q \\end{pmatrix},\\quad \\mathrm{euclidProd}(a,b) = E(q_k)\\cdots E(q_1)$",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean algorithm", "unimodular matrix", "elementary matrices", "continued fractions", "change of basis"],
+    "prerequisites": ["the Euclidean algorithm", "2×2 integer matrices", "gcd"]
+  },
+  {
+    "id": "bezout-oq010201-step-matrix",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 64, "endLine": 77 },
+    "type": "definition",
+    "title": "The elementary step matrix E(q) and its two defining properties",
+    "content": "`E q = !![0,1; 1,-q]` is the atom of the whole construction. `E_mulVec` proves E q ·ᵥ ![a,b] = ![b, a − q·b]: multiplying by E swaps the two coordinates and subtracts q copies of the new second coordinate — exactly one Euclidean division step when q = ⌊a/b⌋, since then a − q·b = a % b. `E_det` proves det (E q) = −1 via Matrix.det_fin_two_of (ad − bc = 0·(−q) − 1·1 = −1), so every factor is unimodular. These are the two facts every downstream induction consumes: E_mulVec drives the reduction, E_det drives the determinant.",
+    "mathContext": "$E(q)\\begin{pmatrix} a \\\\ b \\end{pmatrix} = \\begin{pmatrix} b \\\\ a - qb \\end{pmatrix},\\qquad \\det E(q) = 0\\cdot(-q) - 1\\cdot 1 = -1$",
+    "significance": "key",
+    "relatedConcepts": ["elementary matrix", "matrix-vector product", "2×2 determinant", "Euclidean division step"],
+    "prerequisites": ["Matrix.mulVec", "Matrix.det_fin_two_of"]
+  },
+  {
+    "id": "bezout-oq010201-euclidprod-def",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 79, "endLine": 94 },
+    "type": "definition",
+    "title": "euclidProd: accumulating the product by well-founded recursion",
+    "content": "`euclidProd a b` is defined by well-founded recursion on the second coordinate b: the identity matrix when b = 0, otherwise euclidProd b (a % b) · E ⌊a/b⌋. Termination is `termination_by b` with `decreasing_by Nat.mod_lt` (a % b < b when b > 0). The new factor E ⌊a/b⌋ is multiplied on the right, so unfolding the recursion yields E(q_k)·⋯·E(q_1) with the quotients appearing right-to-left. The unfolding lemmas euclidProd_zero (base) and euclidProd_pos (step) expose the two cases for later inductions, and the recursion structure generates the custom induction principle euclidProd.induct used to prove every headline theorem.",
+    "mathContext": "$\\mathrm{euclidProd}(a,b) = \\begin{cases} I & b = 0 \\\\ \\mathrm{euclidProd}(b,\\, a \\bmod b)\\cdot E(\\lfloor a/b\\rfloor) & b \\neq 0 \\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["well-founded recursion", "termination_by / decreasing_by", "Nat.mod_lt", "generated induction principle"],
+    "prerequisites": ["well-founded recursion in Lean", "Nat.mod_lt", "the Euclidean recursion"]
+  },
+  {
+    "id": "bezout-oq010201-reduction",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 96, "endLine": 115 },
+    "type": "theorem",
+    "title": "Reduction: euclidProd a b ·ᵥ (a,b) = (gcd a b, 0)",
+    "content": "`euclidProd_mulVec` is the headline result: the whole matrix product carries the input column to (gcd a b, 0), matching the net effect of the grandparent's closed-form U. Proved by euclidProd.induct. Base case b = 0: euclidProd = I and Nat.gcd_zero_right gives gcd a 0 = a, so the column is (a, 0). Step case: euclidProd_pos peels one factor, mulVec_mulVec + E_mulVec apply the single step to give second coordinate a − ⌊a/b⌋·b, which Nat.mod_add_div rewrites (over ℤ) to a % b; the induction hypothesis then reduces (b, a%b), and Nat.gcd_rec identifies gcd b (a%b) with gcd a b so the two sides match.",
+    "mathContext": "$\\mathrm{euclidProd}(a,b)\\begin{pmatrix} a \\\\ b \\end{pmatrix} = \\begin{pmatrix} \\gcd(a,b) \\\\ 0 \\end{pmatrix}$; step uses $a - \\lfloor a/b\\rfloor b = a \\bmod b$ (Nat.mod_add_div) and $\\gcd(a,b) = \\gcd(b, a\\bmod b)$ (Nat.gcd_rec)",
+    "significance": "critical",
+    "relatedConcepts": ["euclidProd.induct", "Matrix.mulVec_mulVec", "Nat.mod_add_div", "Nat.gcd_rec"],
+    "prerequisites": ["the step matrix action E_mulVec", "well-founded induction", "Nat.gcd_rec"]
+  },
+  {
+    "id": "bezout-oq010201-unimodular",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 116, "endLine": 125 },
+    "type": "theorem",
+    "title": "Unimodularity: det(euclidProd a b) is a unit of ℤ",
+    "content": "`euclidProd_det` shows the reduction is an invertible integral change of basis. Because the determinant is multiplicative (Matrix.det_mul) and each factor E(q) has determinant −1 (E_det), the product's determinant is (−1)^k, a unit of ℤ. The induction is short: base case det I = 1 is a unit; step case det (euclidProd b (a%b) · E ⌊a/b⌋) = det(…)·(−1), and the product of a unit (induction hypothesis) with the unit −1 is a unit (ih.mul (isUnit_one.neg)). Unimodularity is thus structural — it never needs a per-pair computation.",
+    "mathContext": "$\\det\\bigl(\\mathrm{euclidProd}(a,b)\\bigr) = \\prod_i \\det E(q_i) = (-1)^k \\in \\mathbb{Z}^\\times$",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.det_mul", "IsUnit", "unimodular / GL₂(ℤ)", "determinant multiplicativity"],
+    "prerequisites": ["determinant of a product", "units of ℤ", "E_det"]
+  },
+  {
+    "id": "bezout-oq010201-coprime",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 131 },
+    "type": "theorem",
+    "title": "Coprime specialization: (a,b) ↦ (1,0)",
+    "content": "`euclidProd_mulVec_coprime` specializes the reduction to a coprime pair: since Nat.Coprime a b means gcd a b = 1, euclidProd_mulVec immediately gives euclidProd a b ·ᵥ (a,b) = (1,0). This is the per-step realization of the grandparent's closed-form coprime statement (there U ∈ SL₂(ℤ) sends (a,b) to (1,0)); here the same collapse is exhibited as an explicit product of elementary matrices.",
+    "mathContext": "$\\gcd(a,b) = 1 \\implies \\mathrm{euclidProd}(a,b)\\begin{pmatrix} a \\\\ b \\end{pmatrix} = \\begin{pmatrix} 1 \\\\ 0 \\end{pmatrix}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.Coprime", "SL₂(ℤ)", "specialization"],
+    "prerequisites": ["the reduction theorem euclidProd_mulVec", "coprimality"]
+  },
+  {
+    "id": "bezout-oq010201-quotients",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 132, "endLine": 171 },
+    "type": "theorem",
+    "title": "Making 'indexed by the quotients qᵢ' literal: euclidQuots, stepProduct, and their equality",
+    "content": "This block turns the informal phrase 'product of step matrices indexed by the quotients' into a proved identity. `euclidQuots a b = [q₁,…,q_k]` collects the successive Euclidean quotients (same well-founded recursion, emitting ⌊a/b⌋ instead of a matrix). `stepProduct` folds a list into E(q_k)·⋯·E(q_1) via List.foldr. `euclidProd_eq_stepProduct` then proves euclidProd a b = stepProduct (euclidQuots a b) by a one-line euclidProd.induct: the definitions of euclidProd and euclidQuots are kept definitionally parallel (both recurse on b, both peel ⌊a/b⌋), so the step case closes with euclidProd_pos, euclidQuots_pos, and stepProduct_cons. The quotients qᵢ are exactly the partial quotients of the continued-fraction expansion of a/b, so this identifies the accumulated Euclidean matrix with the standard continued-fraction matrix product.",
+    "mathContext": "$\\mathrm{euclidProd}(a,b) = \\mathrm{stepProduct}\\bigl(\\mathrm{euclidQuots}(a,b)\\bigr) = E(q_k)\\cdots E(q_1),\\quad q_i = \\text{partial quotients of the continued fraction of } a/b$",
+    "significance": "key",
+    "relatedConcepts": ["continued fractions", "partial quotients", "List.foldr", "definitional alignment of recursions"],
+    "prerequisites": ["euclidProd.induct", "list folds", "continued-fraction partial quotients"]
+  },
+  {
+    "id": "bezout-oq010201-examples",
+    "proofId": "bezout-identity-oq-01-oq-02-oq-01",
+    "range": { "startLine": 172, "endLine": 189 },
+    "type": "concept",
+    "title": "Concrete sanity checks, axiom-free",
+    "content": "Three examples close the entry: (12,8) ↦ (gcd = 4, 0), the coprime pair (7,5) ↦ (1,0), and the quotient list euclidQuots 12 8 = [1,2] (from 12 = 1·8 + 4 and 8 = 2·4 + 0), so euclidProd 12 8 = E 2 · E 1. Crucially these are discharged by `simpa`/`norm_num` unfolding the recursion — not by native_decide — so the entry stays genuinely 0-axiom (only propext / Classical.choice / Quot.sound, and no Lean.ofReduceBool).",
+    "mathContext": "$\\mathrm{euclidProd}(12,8)\\,\\begin{pmatrix}12\\\\8\\end{pmatrix} = \\begin{pmatrix}4\\\\0\\end{pmatrix},\\quad \\mathrm{euclidQuots}(12,8) = [1,2]$",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_num", "axiom-free verification", "worked example"],
+    "prerequisites": ["the reduction theorem", "the quotient list definition"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-01-oq-02-oq-01` (quality 45 — it had **no annotations.json at all**, the entire quality gap).

## Change
Adds a complete `annotations.json` with **8 inline annotations**, each carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, tiling the 188-line Lean file in step with the meta's 8 sections:
1. Problem framing (closed-form U → per-step factorization)
2. The step matrix E(q) and its two properties (E_mulVec = one division step, E_det = −1)
3. `euclidProd` well-founded recursion assembling the product
4. **Reduction** `euclidProd_mulVec` (the euclidProd.induct proof, Nat.mod_add_div + Nat.gcd_rec)
5. **Unimodularity** via determinant multiplicativity
6. Coprime specialization → (1,0)
7. The quotient-list / `stepProduct` equality making 'indexed by qᵢ' literal, with the continued-fraction partial-quotient link
8. The axiom-free sanity checks

## Validation
- JSON valid; canonical enum values (types concept/definition/theorem; significance critical/key/supporting).
- All 8 ranges verified within the 188-line file, non-overlapping.
- All 3 existing cross-refs resolve; meta unchanged (already rich — 5 insights, 8 sections).
- Content checked against the actual Lean source (E = !![0,1;1,-q], the induction structure, no native_decide).