### PR TITLE
research(weak-goldbach-oq-01): axiom audit — all 5 axioms irreducible; flag Schnirelmann target

### DIFF
--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -19,3 +19,35 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+## Session 2026-07-03 (researcher-4) — Axiom audit (SURVEY): all 5 axioms irreducible
+
+**Mode**: SURVEY (axiom-elimination assessment) · **Outcome**: no quick win; opportunity flagged
+
+`proofs/Proofs/WeakGoldbach.lean` is a **mature, legitimately-axiomatized** file
+(30 theorems, 14 defs, 0 sorry, 5 axioms). Per the axiom-elimination priority I
+classified each axiom against current Mathlib (v4.26.0):
+
+| Axiom | Nature | Provable from Mathlib now? |
+|-------|--------|-----------------------------|
+| `helfgott_weak_goldbach` | Ternary Goldbach (Helfgott 2013) | No — analytic proof far beyond formalization |
+| `circle_method_asymptotic` | Hardy–Littlewood r₃(n) asymptotic | No — deep analytic number theory |
+| `schnirelmann_basis_theorem` | σ(A)>0 ⟹ A an additive basis | **No — explicit Mathlib TODO** (`Mathlib/Combinatorics/Schnirelmann.lean` line ~40: "Prove Schnirelmann's theorem and Mann's theorem") |
+| `chen_theorem` | n = p + P₂ for large even n | No — heavy sieve estimates |
+| `binary_goldbach_verified` | binary Goldbach for n ≤ 4·10¹⁸ | No — range is uncomputable in Lean's kernel; a `decide`-verified `n ≤ 30` companion already exists |
+
+**Conclusion.** None of the 5 axioms is a routine Mathlib lemma; the binary
+Goldbach conjecture itself is open and must stay axiomatized. Adding further
+theorems on top of these axioms would be scaffolding, not real progress, so I made
+no code change this session.
+
+**The one tractable-in-principle target: `schnirelmann_basis_theorem`.** Schnirelmann's
+theorem is *elementary* (no analysis): σ(A)>0 ⟹ A⊕A has density ≥ min(1, 2σ(A)−σ(A)²),
+iterate to reach density 1, then a full-density set is an additive basis of bounded
+order. Mathlib has the density definition and basic API (`schnirelmannDensity`,
+`schnirelmannDensity_setOf_prime = 0`, etc.) but **not** the theorem itself. Formalizing
+it (~300–500 lines: the sumset density inequality + the iteration) would discharge one
+axiom here *and* fill a flagged Mathlib gap — a worthwhile dedicated future session, too
+large to start with the budget remaining this session.
+
+Aristotle MCP down all session (`Resource not found`/404).

--- a/research/problems/weak-goldbach-oq-01/state.md
+++ b/research/problems/weak-goldbach-oq-01/state.md
@@ -1,25 +1,35 @@
 # Research State: weak-goldbach-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: SURVEY
 **Path**: full
-**Since**: 2026-04-23T06:12:18+02:00
-**Iteration**: 1
+**Since**: 2026-07-03T21:40:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Axiom audit complete. `proofs/Proofs/WeakGoldbach.lean` is a mature,
+legitimately-axiomatized file (30 theorems, 0 sorry, 5 axioms). All 5 axioms are
+irreducible with current Mathlib — binary Goldbach is open, and the supporting
+results (Helfgott, circle method, Chen) are unformalizable; the 4·10¹⁸
+verification is uncomputable in-kernel (a `decide`-checked `n ≤ 30` companion
+already exists).
 
 ## Active Approach
-None yet.
+None active. No quick axiom-elimination exists here.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (survey)
+- Approaches tried: 0 mathematical
 
 ## Blockers
-None.
+- Binary Goldbach is genuinely open (must remain axiomatized).
+- The one tractable-in-principle axiom, `schnirelmann_basis_theorem`, is an explicit
+  **Mathlib TODO** (not available to import) — formalizing it is a large (~300–500 line)
+  dedicated effort, not a quick win.
+- Aristotle MCP down (`Resource not found`).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Dedicated future session: formalize **Schnirelmann's theorem** (σ(A)>0 ⟹ additive
+basis) — elementary (sumset density inequality + iteration), would discharge one
+axiom here and fill a flagged Mathlib gap. Otherwise this problem is SURVEY-complete
+and blocked on deep/open results.


### PR DESCRIPTION
## Summary

Survey / axiom-elimination assessment of `weak-goldbach-oq-01` (Strong/binary Goldbach). `proofs/Proofs/WeakGoldbach.lean` is a **mature, legitimately-axiomatized** file (30 theorems, 14 defs, 0 sorry, 5 axioms).

Classified each axiom against Mathlib v4.26.0 — **all five are irreducible**:

| Axiom | Provable from Mathlib now? |
|-------|-----------------------------|
| `helfgott_weak_goldbach` (ternary Goldbach) | No — analytic proof beyond formalization |
| `circle_method_asymptotic` | No — deep analytic NT |
| `schnirelmann_basis_theorem` | No — **explicit Mathlib TODO** |
| `chen_theorem` (p + P₂) | No — heavy sieve estimates |
| `binary_goldbach_verified` (n ≤ 4·10¹⁸) | No — uncomputable in-kernel (a `decide`-checked `n ≤ 30` companion already exists) |

Binary Goldbach itself is open and must stay axiomatized. **No code change** was made — piling theorems on deep axioms would be scaffolding, not progress (per the honesty/axiom-integrity guidance).

## Value

Documents the audit in `knowledge.md`/`state.md` so future sessions don't re-hunt for a quick win, and **flags the one tractable-in-principle target**: `schnirelmann_basis_theorem` (σ(A) > 0 ⟹ additive basis) is elementary (sumset density inequality + iteration, no analysis) and an explicit Mathlib TODO. Formalizing it (~300–500 lines) would discharge an axiom here *and* fill a Mathlib gap — a worthwhile dedicated future session.

Docs-only (research notes); no Lean changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)