### PR TITLE
Enrich Erdős #1023 growth brackets (erdos-1023-oq-04): +pigeonhole keyInsight, +2 sibling crossRefs

### DIFF
--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -60,7 +60,8 @@
       "The qualitative growth of the union-free maximum needs NO Stirling estimate: a single averaging of the binomial identity ∑ C(n,m) = 2^n against the maximality of the central column gives 2^n ≤ (n+1)·F(n) in one line.",
       "Combined with the trivial upper bound F(n) ≤ 2^n, this pins F(n) between 2^n/(n+1) and 2^n — capturing the 'order 2^n up to a polynomial factor' content of the parent's asymptotic axiom, but fully machine-checked.",
       "Divergence is purely combinatorial: the even subsequence F(2n) equals the central binomial coefficient centralBinom n, which dominates C(2n,1) = 2n, so F is unbounded without any analysis.",
-      "The central binomial coefficient is the largest entry of Pascal's row n; Nat.choose_le_middle is exactly the maximality statement that powers the lower bracket."
+      "The central binomial coefficient is the largest entry of Pascal's row n; Nat.choose_le_middle is exactly the maximality statement that powers the lower bracket.",
+      "The lower bracket is the 'maximum ≥ average' pigeonhole in disguise: row n of Pascal's triangle has exactly n+1 columns summing to 2^n, so the largest column — which is C(n, ⌊n/2⌋) = F(n) — is at least the mean 2^n/(n+1). No property of binomials beyond this counting is used, which is why the bound is one line and the (n+1) denominator is exactly the number of columns."
     ]
   },
   "sections": [
@@ -87,7 +88,7 @@
     "openQuestions": [
       "Sharpen the lower bracket to the true order: prove 2^n/√(c·n) ≤ C(n, floor(n/2)) (the √n rather than n denominator), which requires a Stirling-type estimate.",
       "Discharge the parent file's axioms (problem_447_solution Erdős-Kleitman optimality, stirling_central) to make the exact asymptotic fully proved.",
-      "Establish strict monotonicity F(n) < F(n+2) of the central binomial column directly from a Pascal recurrence, strengthening the unboundedness proved here."
+      "Establish strict monotonicity of the central binomial column in steps of two, F(n) < F(n+2), directly from a Pascal recurrence — the natural strict statement here, since F(0) = F(1) = 1 makes F(n) < F(n+1) fail at n = 0. The sibling entry erdos-1023-oq-03 already proves a strict monotonicity F(n) < F(n+1) for the union-free maximum by a family-injection argument; deriving the step-two central-binomial version purely arithmetically would strengthen the unboundedness proved here."
     ]
   },
   "crossReferences": [
@@ -95,6 +96,16 @@
       "targetId": "erdos-1023",
       "relationship": "parent",
       "description": "The main Erdős #1023 union-free families file (isUnionFree, middleLayer, the lower bound unionFreeMax_ge_middle, and the axiomatized Erdős-Kleitman optimality and Stirling asymptotic). It establishes F(n) = C(n, floor(n/2)); this sibling supplies the elementary, 0-axiom growth brackets 2^n/(n+1) ≤ F(n) ≤ 2^n and divergence that the parent only obtains through its Stirling axiom."
+    },
+    {
+      "targetId": "erdos-1023-oq-03",
+      "relationship": "sibling",
+      "description": "Closest sibling: it independently derives the SAME exponential lower bound F(n) ≥ 2^n/(n+1) from the axiom-free lower-bound construction (every k-layer is an antichain, hence union-free, so F(n) ≥ C(n,k) for all k), and additionally proves strict monotonicity F(n) < F(n+1). Where oq-03 approaches the bound through the family combinatorics, this entry (oq-04) obtains it as a pure averaging of the binomial row sum against Nat.choose_le_middle and pairs it with the matching upper bracket F(n) ≤ 2^n and divergence."
+    },
+    {
+      "targetId": "erdos-1023-oq-02",
+      "relationship": "sibling",
+      "description": "Develops the intersection and difference analogues of the union-free problem: the complementation bijection A ↦ Aᶜ carries union-free families onto intersection-free families, giving F∩(n) = F(n), so the same central-binomial value and hence the same 2^n/(n+1) ≤ F ≤ 2^n brackets proved here transfer verbatim to the intersection-free maximum."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `erdos-1023-oq-04` (quality 92, pass 0). The entry was already rich and accurate against the Lean source; additions are targeted, not inflationary (meta.json 11.4 KB → 13.2 KB, well under the 60 KB cap).

**Changes**
- **+1 keyInsight (4→5):** the lower bracket $2^n/(n+1) \le F(n)$ is the 'maximum ≥ average' pigeonhole over the $n+1$ Pascal columns summing to $2^n$ — explaining why it is a one-liner and why the denominator is exactly the column count.
- **+2 sibling crossReferences (1→3):**
  - `erdos-1023-oq-03` — independently derives the *same* $F(n) \ge 2^n/(n+1)$ (via every k-layer being an antichain) and adds strict monotonicity $F(n)<F(n+1)$.
  - `erdos-1023-oq-02` — intersection/difference analogues; complementation gives $F_\cap(n)=F(n)$, so the same brackets transfer.
- **Refined openQuestion #3:** noted that $F(0)=F(1)=1$ forces the step-two strict form $F(n)<F(n+2)$, and cross-linked oq-03's family-injection monotonicity.

**Verification:** `pnpm build` passes. JSON valid. Caps respected (5 keyInsights ≤ 12, 3 crossRefs ≤ 20). Axiom integrity unchanged (status `verified`, axiomCount 0 — accurate against the Lean file: 0 sorries, 0 axioms, kernel `decide` only, no native_decide).