### PR TITLE
Enrich Erdős #128 induced-subgraph monotonicity (erdos-128-wip-01): +tension keyInsight, +2 crossRefs

### DIFF
--- a/src/data/proofs/erdos-128-wip-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01/meta.json
@@ -54,7 +54,8 @@
       "The induced adjacency entails the ambient adjacency, so every induced substructure (triangle, edge) lifts to the ambient graph.",
       "Triangle-freeness is hereditary: it is the property 'no induced subgraph has a triangle', which is exactly why the C5-blow-up extremal examples remain triangle-free at every scale.",
       "Edge count is monotone under induction, the structural basis for the density hypothesis denseSubgraphs comparing subgraph edge counts to n^2/50.",
-      "These monotonicities are scaffold-level facts every partial-result proof uses implicitly; making them explicit and machine-checked is the foundation for any formal attack."
+      "These monotonicities are scaffold-level facts every partial-result proof uses implicitly; making them explicit and machine-checked is the foundation for any formal attack.",
+      "The two monotonicities pull in opposite directions, and that tension is the heart of the problem: edgeCount_induce_le says passing to an induced subgraph can only LOSE edges, yet the hypothesis demands EVERY induced subgraph on ≥ ⌊n/2⌋ vertices keep more than n²/50 of them. The question is whether a uniform density floor that survives this monotone erosion is strong enough to force a triangle — the C₅-blow-up shows density alone (≈1/5) does not, so the ⌊n/2⌋ size threshold and the exact 1/50 constant are what carry the weight."
     ]
   },
   "sections": [
@@ -89,6 +90,16 @@
       "targetId": "erdos-128",
       "relationship": "parent",
       "description": "The base Erdős #128 scaffold (Graph, edgeCount, induce, hasTriangle, triangleFree, denseSubgraphs and the prose partial results). This entry re-declares its objects (the scaffold fails to build) and proves their first structural theorems: hereditary triangle-freeness and monotone edge count."
+    },
+    {
+      "targetId": "erdos-128-wip-01-oq-01",
+      "relationship": "child",
+      "description": "Direct continuation: it proves the sharper fact underlying the heredity established here — triangle-freeness pulls back along ARBITRARY graph homomorphisms (not just induced-subgraph inclusions), and derives that every C₅-blow-up is triangle-free, formalizing exactly why the conjectured-optimal extremal witnesses for #128 evade the triangle while staying dense."
+    },
+    {
+      "targetId": "mantel-theorem",
+      "relationship": "related",
+      "description": "The classical precursor. Mantel's theorem (1907, the r=2 Turán case) says a triangle-free graph on n vertices has at most ⌊n²/4⌋ edges — a GLOBAL density ceiling forced by triangle-freeness. Erdős #128 turns this around: instead of asking how dense a triangle-free graph can be, it asks whether a LOCAL density floor on every large induced subgraph forces a triangle. The edge-count monotonicity and hereditary triangle-freeness proved here are the induced-subgraph bookkeeping that separates the two regimes."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-128-wip-01` (quality 92, pass 0). Verified accurate against `Proofs/Erdos128WIP01.lean`; additions are targeted (meta.json 8.2 KB → 9.9 KB, well under the 60 KB cap).

**Changes**
- **+1 keyInsight (4→5):** the two proved monotonicities pull in opposite directions, which is the heart of the problem — `edgeCount_induce_le` can only LOSE edges under induction, yet the hypothesis demands EVERY induced subgraph on ≥⌊n/2⌋ vertices stay above n²/50. The C₅-blow-up shows density alone (≈1/5) doesn't force a triangle, so the size threshold and the exact 1/50 constant carry the weight.
- **+2 crossReferences (1→3):**
  - `erdos-128-wip-01-oq-01` (child) — extends heredity to arbitrary graph homomorphisms; derives C₅-blow-ups are triangle-free.
  - `mantel-theorem` (related) — the classical r=2 Turán precursor; contrasts its global density ceiling for triangle-free graphs with #128's local density floor.

**Verification:** `pnpm build` passes. JSON valid. Caps respected (5 keyInsights ≤ 12, 3 crossRefs ≤ 20). Axiom integrity unchanged and accurate (status `verified`, axiomCount 0; the Lean file has 0 sorries, 0 axioms, no native_decide — `open Classical` for the edge-filter decidability is not a substantive assumption).