### PR TITLE
research(lovasz-local-lemma-oq-01): union-bound (first-moment) avoidance regime [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01UnionBound.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01UnionBound.lean
@@ -1,0 +1,84 @@
+/-
+# Lovász Local Lemma — OQ-01: Union-Bound (First-Moment) Avoidance Regime
+
+Companion to `Proofs/LovaszLocalLemmaOQ01.lean`, which lands the `d = 0`
+*mutually independent* base case of the measure-theoretic symmetric Lovász Local
+Lemma (avoidance probability factors as `∏ (1 - μ Aᵢ)`, strictly positive when
+each `μ Aᵢ < 1`). That is one extreme of the LLL landscape — full independence.
+
+This file lands the complementary, **dependency-free** extreme: the crude
+first-moment / union (Bonferroni) lower bound. For an *arbitrary* finite family of
+measurable events (no independence, no bounded-dependency hypothesis whatsoever),
+
+  `μ (⋂ i, (A i)ᶜ) ≥ 1 - ∑ i, μ (A i)`,
+
+so all bad events are avoided with positive probability as soon as the total mass
+`∑ μ (A i) < 1`. Equivalently, under a uniform bound `μ (A i) ≤ p`, the sufficient
+condition is `n · p < 1` where `n = |ι|`.
+
+These two files bracket the genuine open target of OQ-01 — the
+bounded-dependency-degree symmetric LLL (`e · p · (d + 1) ≤ 1`). The LLL is
+precisely the statement that a *bounded local* dependency structure lets one relax
+the crude global threshold `n · p < 1` proved here to the far weaker local
+threshold `e · p · (d + 1) ≤ 1`, independent of `n`. This union bound is the honest
+baseline the LLL improves upon; it is elementary (a one-line consequence of
+countable subadditivity), not the LLL itself.
+
+## Main results
+
+* `lll_union_bound_iInter_compl_ge` : the first-moment lower bound
+  `1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ)`, for any measurable family over a
+  probability space — no independence assumed.
+* `lll_union_bound_avoidance` : if `∑ i, μ (A i) < 1` then `0 < μ (⋂ i, (A i)ᶜ)`.
+* `lll_union_bound_avoidance_symmetric` : under a uniform bound `μ (A i) ≤ p` with
+  `(|ι|) · p < 1`, the same strict-avoidance conclusion.
+-/
+import Mathlib.Probability.Independence.Basic
+
+open MeasureTheory Finset
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01UnionBound
+
+variable {Ω : Type*} [MeasurableSpace Ω] {ι : Type*} [Fintype ι]
+variable {μ : Measure Ω} [IsProbabilityMeasure μ] {A : ι → Set Ω}
+
+/-- **First-moment (union / Bonferroni) avoidance bound.**
+For an *arbitrary* finite family of measurable events over a probability space —
+no independence and no bounded-dependency hypothesis — the probability that none
+of them occurs is at least `1 - ∑ μ (A i)`. This is the crude global baseline that
+the Lovász Local Lemma improves upon: it needs the total mass `∑ μ (A i)` to be
+small, whereas the LLL needs only the *local* dependency degree to be controlled. -/
+theorem lll_union_bound_iInter_compl_ge (hA : ∀ i, MeasurableSet (A i)) :
+    1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ) := by
+  have hU : MeasurableSet (⋃ i, A i) := MeasurableSet.iUnion hA
+  calc 1 - ∑ i, μ (A i)
+      ≤ 1 - μ (⋃ i, A i) := tsub_le_tsub_left (measure_iUnion_fintype_le μ A) 1
+    _ = μ ((⋃ i, A i)ᶜ) := (prob_compl_eq_one_sub hU).symm
+    _ = μ (⋂ i, (A i)ᶜ) := by rw [Set.compl_iUnion]
+
+/-- **Positive avoidance from a small total mass (dependency-free).**
+If the total probability of the bad events is subcritical (`∑ i, μ (A i) < 1`),
+then all of them are simultaneously avoided with strictly positive probability,
+with no independence or dependency-degree assumption. -/
+theorem lll_union_bound_avoidance
+    (hA : ∀ i, MeasurableSet (A i)) (hsum : ∑ i, μ (A i) < 1) :
+    0 < μ (⋂ i, (A i)ᶜ) :=
+  lt_of_lt_of_le (tsub_pos_iff_lt.2 hsum) (lll_union_bound_iInter_compl_ge hA)
+
+/-- **Symmetric union-bound avoidance.**
+Under a uniform bound `μ (A i) ≤ p` with `n · p < 1` (`n = |ι|` the number of bad
+events), all events are avoided with positive probability. This is the crude
+symmetric threshold `n · p < 1` that the symmetric LLL relaxes to the
+`n`-independent local budget `e · p · (d + 1) ≤ 1`. -/
+theorem lll_union_bound_avoidance_symmetric
+    (hA : ∀ i, MeasurableSet (A i)) {p : ℝ≥0∞} (hbound : ∀ i, μ (A i) ≤ p)
+    (hcard : (Fintype.card ι : ℝ≥0∞) * p < 1) :
+    0 < μ (⋂ i, (A i)ᶜ) := by
+  refine lll_union_bound_avoidance hA (lt_of_le_of_lt ?_ hcard)
+  calc ∑ i, μ (A i)
+      ≤ ∑ _i : ι, p := Finset.sum_le_sum (fun i _ => hbound i)
+    _ = (Fintype.card ι : ℝ≥0∞) * p := by
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+
+end LovaszLocalLemmaOQ01UnionBound

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -19,6 +19,28 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
+### Union-bound extreme (researcher-5, 2026-07-02) — NEW
+
+- **The dependency-free (first-moment) avoidance bound is fully provable and
+  elementary.** New file `Proofs/LovaszLocalLemmaOQ01UnionBound.lean` (0 sorry /
+  0 axiom; axioms = propext/choice/Quot only), gallery entry
+  `lovasz-local-lemma-oq-01-union-bound`: for an *arbitrary* Fintype-indexed
+  measurable family over an `IsProbabilityMeasure` (no independence),
+  `1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ)`, hence `0 < μ (⋂ i, (A i)ᶜ)` whenever
+  `∑ μ (A i) < 1` (uniform version: `(Fintype.card ι) * p < 1`).
+- **Route (no independence machinery).** `Set.compl_iUnion` (De Morgan) →
+  `measure_iUnion_fintype_le` (finite subadditivity = the union bound) →
+  `prob_compl_eq_one_sub` + `tsub_le_tsub_left` (1 − · is antitone in ℝ≥0∞) →
+  `tsub_pos_iff_lt` for positivity at the subcritical threshold. Contrast with the
+  base case, which needed generated σ-algebras + `iIndep.meas_iInter`.
+- **`IsProbabilityMeasure` must be assumed here** (there is no independence
+  hypothesis to derive it from, unlike the base case's `iIndepSet.isProbabilityMeasure`).
+- **Framing payoff.** The union bound (`∑ μ < 1`, any dependency) and the
+  independent product formula (`∏(1 − μ)`, full independence) are the two
+  *computable extremes* bracketing the LLL. The open OQ-01 target is exactly the
+  statement that a bounded local dependency degree `d` relaxes the crude global
+  threshold `n·p < 1` to the `n`-independent local budget `e·p·(d+1) ≤ 1`.
+
 ### Measure-theoretic front (researcher-11, 2026-07-02) — NEW
 
 - **The `d = 0` base case of the symmetric LLL is fully provable over a real

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,12 +1,44 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ACT (measure-theoretic base case landed; general dependency-degree LLL still open)
+**Phase**: ACT (both computable extremes landed — independent base case + union-bound baseline; general dependency-degree LLL still open)
 **Path**: full
 **Since**: 2026-06-27
-**Iteration**: 4
+**Iteration**: 5
 
-## This session (researcher-11, 2026-07-02)
+## This session (researcher-5, 2026-07-02)
+
+**Second measure-theoretic extreme: the dependency-free union (first-moment) bound.**
+New self-contained, **0-axiom / 0-sorry** file `Proofs/LovaszLocalLemmaOQ01UnionBound.lean`
+(new gallery entry `lovasz-local-lemma-oq-01-union-bound`) — the complementary extreme
+to the independent base case landed last session. Verified via Docker build (exit 0)
+and `#print axioms`: all three theorems depend only on propext / Classical.choice /
+Quot.sound.
+
+### New verified theorems (dependency-free avoidance)
+1. **`lll_union_bound_iInter_compl_ge`** — for an *arbitrary* Fintype-indexed
+   measurable family over an `IsProbabilityMeasure` (no independence at all),
+   `1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ)`. The complement of finite subadditivity.
+2. **`lll_union_bound_avoidance`** — if `∑ i, μ (A i) < 1` then `0 < μ (⋂ i, (A i)ᶜ)`.
+3. **`lll_union_bound_avoidance_symmetric`** — under `μ (A i) ≤ p` with
+   `(Fintype.card ι) * p < 1`, the same strict-avoidance conclusion.
+
+### Proof technique (elementary, reusable)
+`Set.compl_iUnion` (De Morgan) turns the avoidance event into `(⋃ A i)ᶜ`;
+`measure_iUnion_fintype_le` is the union bound; `prob_compl_eq_one_sub` +
+`tsub_le_tsub_left` (antitone truncated subtraction) flip it into the lower bound;
+`tsub_pos_iff_lt` gives positivity exactly at the subcritical threshold `∑ μ < 1`.
+Unlike the independent base case, **no** independence machinery is needed;
+`IsProbabilityMeasure` is an explicit hypothesis (no independence to derive it from).
+
+### Significance (honest)
+Elementary — a one-line complement of finite subadditivity. Its value is *framing*:
+together with the independent product formula `∏(1 − μ(A i))`, it pins the two
+computable extremes bracketing the LLL. The open target is exactly the statement
+that a bounded local dependency degree relaxes the crude global threshold `n·p < 1`
+proved here to the `n`-independent local budget `e·p·(d+1) ≤ 1`.
+
+## Prior session (researcher-11, 2026-07-02)
 
 **First genuine measure-theoretic content for OQ-01.** Every prior increment lived
 entirely over `ℚ` in `Proofs/LovaszLocalLemma.lean` (a rational probability-budget

--- a/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-lll-oq01-ub-overview",
+    "proofId": "lovasz-local-lemma-oq-01-union-bound",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "context",
+    "title": "The two computable extremes of the Lovász Local Lemma",
+    "content": "Open question OQ-01 asks for the genuine **measure-theoretic** Lovász Local Lemma: bad events as measurable sets $A_i \\subseteq \\Omega$ in a real `IsProbabilityMeasure`, with the conclusion $\\mu(\\bigcap_i A_i^c) > 0$. The companion entry `lovasz-local-lemma-oq-01` proved one extreme of the landscape — the **mutually independent** ($d = 0$) case, where the avoidance probability factors *exactly* as $\\prod_i (1 - \\mu(A_i))$. This file proves the opposite extreme: the **dependency-free** case, where *nothing* is assumed about how the events interact. There the best one can say is the crude first-moment (union / Bonferroni) bound $\\mu(\\bigcap_i A_i^c) \\ge 1 - \\sum_i \\mu(A_i)$, positive as soon as the total mass $\\sum_i \\mu(A_i) < 1$. The genuine open target — the bounded-dependency-degree symmetric LLL, budget $e\\,p\\,(d+1) \\le 1$ — lives *between* these two extremes: it is exactly the statement that a bounded *local* dependency structure lets one relax the crude *global* threshold $n\\,p < 1$ proved here to a budget independent of the number of events $n$.",
+    "mathContext": "Arbitrary measurable family $A : \\iota \\to \\mathrm{Set}\\,\\Omega$ over a `Fintype` index and an `IsProbabilityMeasure` $\\mu$; goal $\\mu\\!\\left(\\bigcap_i A_i^c\\right) \\ge 1 - \\sum_i \\mu(A_i)$, with no independence hypothesis.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "union bound",
+      "first-moment method",
+      "Bonferroni inequalities",
+      "measure-theoretic probability"
+    ],
+    "prerequisites": [
+      "measure theory: probability measures",
+      "lovasz-local-lemma-oq-01 (independent base case)",
+      "finite subadditivity of measures"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ub-lowerbound",
+    "proofId": "lovasz-local-lemma-oq-01-union-bound",
+    "range": {
+      "startLine": 46,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "First-moment lower bound: μ(⋂ Aᵢᶜ) ≥ 1 − ∑ μ(Aᵢ)",
+    "content": "```lean\ntheorem lll_union_bound_iInter_compl_ge (hA : ∀ i, MeasurableSet (A i)) :\n    1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ) := by\n  have hU : MeasurableSet (⋃ i, A i) := MeasurableSet.iUnion hA\n  calc 1 - ∑ i, μ (A i)\n      ≤ 1 - μ (⋃ i, A i) := tsub_le_tsub_left (measure_iUnion_fintype_le μ A) 1\n    _ = μ ((⋃ i, A i)ᶜ) := (prob_compl_eq_one_sub hU).symm\n    _ = μ (⋂ i, (A i)ᶜ) := by rw [Set.compl_iUnion]\n```\n\nThe whole argument is the union bound, read backwards. The avoidance event $\\bigcap_i A_i^c$ is the complement of the union $\\bigcup_i A_i$ (De Morgan, `Set.compl_iUnion`). Finite subadditivity (`measure_iUnion_fintype_le`) gives $\\mu(\\bigcup_i A_i) \\le \\sum_i \\mu(A_i)$, and in a probability measure `prob_compl_eq_one_sub` rewrites $\\mu((\\bigcup A_i)^c) = 1 - \\mu(\\bigcup A_i)$. Since $x \\mapsto 1 - x$ is antitone for truncated $\\mathbb{R}_{\\ge 0}^\\infty$ subtraction (`tsub_le_tsub_left`), the subadditivity bound flips into the desired lower bound. Note this holds **unconditionally**: when $\\sum_i \\mu(A_i) \\ge 1$ the left side is $0$ and the inequality degenerates to the trivial $0 \\le \\mu(\\bigcap A_i^c)$.",
+    "mathContext": "measure_iUnion_fintype_le : μ(⋃ i, A i) ≤ ∑ i, μ(A i) for a Fintype index; prob_compl_eq_one_sub : μ sᶜ = 1 − μ s in an IsProbabilityMeasure.",
+    "significance": "core",
+    "relatedConcepts": [
+      "union bound",
+      "finite subadditivity",
+      "De Morgan",
+      "truncated subtraction in ℝ≥0∞"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ub-avoidance",
+    "proofId": "lovasz-local-lemma-oq-01-union-bound",
+    "range": {
+      "startLine": 60,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Positive avoidance and the crude symmetric threshold n·p < 1",
+    "content": "```lean\ntheorem lll_union_bound_avoidance\n    (hA : ∀ i, MeasurableSet (A i)) (hsum : ∑ i, μ (A i) < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) :=\n  lt_of_lt_of_le (tsub_pos_iff_lt.2 hsum) (lll_union_bound_iInter_compl_ge hA)\n\ntheorem lll_union_bound_avoidance_symmetric\n    (hA : ∀ i, MeasurableSet (A i)) {p : ℝ≥0∞} (hbound : ∀ i, μ (A i) ≤ p)\n    (hcard : (Fintype.card ι : ℝ≥0∞) * p < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) := by\n  refine lll_union_bound_avoidance hA (lt_of_le_of_lt ?_ hcard)\n  calc ∑ i, μ (A i)\n      ≤ ∑ _i : ι, p := Finset.sum_le_sum (fun i _ => hbound i)\n    _ = (Fintype.card ι : ℝ≥0∞) * p := by\n        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]\n```\n\nStrict positivity is immediate from the lower bound: in $\\mathbb{R}_{\\ge 0}^\\infty$, `tsub_pos_iff_lt` says $0 < 1 - \\sum_i \\mu(A_i)$ exactly when $\\sum_i \\mu(A_i) < 1$. The symmetric corollary specializes to a uniform bound $\\mu(A_i) \\le p$: `Finset.sum_le_sum` and `Finset.sum_const` give $\\sum_i \\mu(A_i) \\le n\\,p$ with $n = |\\iota|$, so $n\\,p < 1$ suffices. This threshold $n\\,p < 1$ is precisely what the *symmetric* LLL improves: its budget $e\\,p\\,(d+1) \\le 1$ depends only on the local dependency degree $d$, not on the total number of events $n$ — the entire content of the open OQ-01 target.",
+    "mathContext": "tsub_pos_iff_lt : 0 < a − b ↔ b < a (here a = 1, b = ∑ μ(A i)); Finset.sum_const and Finset.card_univ turn ∑_{i : ι} p into (Fintype.card ι)·p.",
+    "significance": "core",
+    "relatedConcepts": [
+      "union bound threshold",
+      "symmetric Lovász Local Lemma",
+      "dependency degree",
+      "e·p·(d+1) ≤ 1"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "lovasz-local-lemma-oq-01-union-bound",
+  "title": "Lovász Local Lemma OQ-01: Union-Bound (First-Moment) Avoidance Regime",
+  "slug": "lovasz-local-lemma-oq-01-union-bound",
+  "description": "Companion to the measure-theoretic LLL base case (lovasz-local-lemma-oq-01), which handled the mutually independent d = 0 extreme. This entry lands the complementary dependency-free extreme: the crude first-moment / union (Bonferroni) lower bound. For an arbitrary finite family of measurable events over a real IsProbabilityMeasure — no independence and no bounded-dependency hypothesis whatsoever — μ(⋂ i, (A i)ᶜ) ≥ 1 − ∑ i, μ(A i), so all bad events are avoided with positive probability as soon as the total mass ∑ μ(A i) < 1 (equivalently n·p < 1 under a uniform bound μ(A i) ≤ p). Together the two files bracket the genuine open target of OQ-01 — the bounded-dependency-degree symmetric LLL (e·p·(d+1) ≤ 1), which is precisely the statement that a bounded local dependency structure relaxes this crude global threshold n·p < 1 to the n-independent local budget e·p·(d+1) ≤ 1. This union bound is the honest elementary baseline the LLL improves upon, not the LLL itself. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01UnionBound.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "union-bound",
+      "first-moment-method"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used). IsProbabilityMeasure is an explicit hypothesis (unlike the independent base case, where it is derived from independence — here there is no independence hypothesis to derive it from). Scope: this entry proves the dependency-free first-moment (union/Bonferroni) lower bound; it deliberately uses the crude global threshold ∑ μ(A i) < 1. The bounded-dependency-degree symmetric LLL (e·p·(d+1) ≤ 1), which relaxes this threshold, remains the open research target and is out of scope here.",
+    "lineCount": 84,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "lll_union_bound_iInter_compl_ge: for an arbitrary finite measurable family over a probability space (no independence), the avoidance probability is bounded below by 1 − ∑ μ(A i) — the first-moment / union (Bonferroni) lower bound, obtained by complementing the finite subadditivity bound measure_iUnion_fintype_le.",
+      "lll_union_bound_avoidance: if the total mass is subcritical (∑ μ(A i) < 1), then 0 < μ(⋂ i, (A i)ᶜ) with no independence or dependency-degree assumption — the dependency-free avoidance regime complementary to the independent base case of lovasz-local-lemma-oq-01.",
+      "lll_union_bound_avoidance_symmetric: under a uniform bound μ(A i) ≤ p with n·p < 1 (n = |ι|), the same strict-avoidance conclusion, exposing the crude symmetric threshold n·p < 1 that the symmetric LLL relaxes to the n-independent local budget e·p·(d+1) ≤ 1.",
+      "Framing contribution: the union bound and the independent product formula are the two computable extremes bracketing the LLL; making both fully verified over a real IsProbabilityMeasure clarifies exactly what the open LLL induction must buy — replacement of the global ∑ μ(A i) < 1 by a purely local dependency-degree budget."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.Independence.Basic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Finset"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01UnionBound",
+    "lineCount": 84,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01UnionBound.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "lll_union_bound_iInter_compl_ge",
+      "type": "core",
+      "description": "First-moment (union/Bonferroni) avoidance bound: for an arbitrary measurable family over a probability space, the probability that none of the events occurs is at least 1 − ∑ μ(A i). No independence assumed.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → 1 - ∑ i, μ (A i) ≤ μ (⋂ i, (A i)ᶜ)"
+    },
+    {
+      "name": "lll_union_bound_avoidance",
+      "type": "core",
+      "description": "Positive avoidance from subcritical total mass: if ∑ μ(A i) < 1 then 0 < μ(⋂ i, (A i)ᶜ), with no independence or dependency-degree hypothesis.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (hsum : ∑ i, μ (A i) < 1) → 0 < μ (⋂ i, (A i)ᶜ)"
+    },
+    {
+      "name": "lll_union_bound_avoidance_symmetric",
+      "type": "corollary",
+      "description": "Symmetric union-bound reformulation: under a uniform bound μ(A i) ≤ p with (Fintype.card ι)·p < 1, all events are avoided with positive probability.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (∀ i, μ (A i) ≤ p) → ((Fintype.card ι : ℝ≥0∞) * p < 1) → 0 < μ (⋂ i, (A i)ᶜ)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) is a refinement of the most elementary avoidance principle in probability: the union bound. If bad events A_1, …, A_n satisfy ∑ P(A_i) < 1 then P(⋃ A_i) < 1, so P(⋂ A_iᶜ) > 0 — all bad events can be avoided simultaneously, with no independence needed. This union (or first-moment / Bonferroni) bound is powerful but crude: its threshold ∑ P(A_i) < 1, i.e. n·p < 1 under a uniform bound p, degrades as the number of events n grows. The LLL's insight is that if each bad event is mutually independent of all but at most d others, a purely local budget e·p·(d+1) ≤ 1 — independent of n — already forces P(⋂ A_iᶜ) > 0. The union bound is thus the honest baseline the LLL improves upon.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces — bad events as measurable sets A_i ⊆ Ω in an IsProbabilityMeasure, real dependency structure, and the conclusion μ(⋂ A_iᶜ) > 0.\n\n**This entry (union-bound regime)**: prove the complementary dependency-free bound. For an arbitrary Fintype-indexed measurable family A : ι → Set Ω over an IsProbabilityMeasure, show μ(⋂ i, (A i)ᶜ) ≥ 1 − ∑ i, μ(A i), and hence 0 < μ(⋂ i, (A i)ᶜ) whenever ∑ μ(A i) < 1 (or n·p < 1 under a uniform bound μ(A i) ≤ p).",
+    "text": "The dependency-free avoidance regime of the Lovász Local Lemma, over a real probability space: with no independence or bounded-dependency assumption at all, the avoidance probability of an arbitrary finite family of bad events is at least 1 minus their total mass, so they can all be avoided simultaneously as soon as that total mass is below 1.",
+    "proofStrategy": "**De Morgan.** The avoidance event is the complement of the union of the bad events: ⋂ i, (A i)ᶜ = (⋃ i, A i)ᶜ (`Set.compl_iUnion`).\n\n**Finite subadditivity.** Mathlib's `measure_iUnion_fintype_le` gives μ(⋃ i, A i) ≤ ∑ i, μ(A i) for a Fintype index — the union bound.\n\n**Complement in a probability measure.** `prob_compl_eq_one_sub` turns μ((⋃ A i)ᶜ) into 1 − μ(⋃ A i); the antitone truncated subtraction 1 − (·) (`tsub_le_tsub_left`) converts the subadditivity bound into 1 − ∑ μ(A i) ≤ μ(⋂ (A i)ᶜ).\n\n**Positivity.** In ℝ≥0∞, `tsub_pos_iff_lt` gives 0 < 1 − ∑ μ(A i) exactly when ∑ μ(A i) < 1; the lower bound then forces 0 < μ(⋂ (A i)ᶜ).\n\n**Symmetric form.** Under μ(A i) ≤ p, `Finset.sum_le_sum` and `Finset.sum_const` bound ∑ μ(A i) ≤ n·p, so n·p < 1 suffices.",
+    "keyInsights": [
+      "The union bound and the independent product formula (lovasz-local-lemma-oq-01) are the two computable extremes that bracket the LLL: the union bound assumes nothing about dependency but needs the global mass ∑ μ(A i) < 1, while the product formula assumes full independence and gives the exact avoidance probability. The LLL lives between them.",
+      "Complementing the union bound is entirely elementary — finite subadditivity (measure_iUnion_fintype_le) plus prob_compl_eq_one_sub — and needs no independence machinery, unlike the base case which routed through generated σ-algebras.",
+      "All arithmetic stays in ℝ≥0∞ with truncated subtraction: the lower bound 1 − ∑ μ(A i) ≤ μ(⋂ (A i)ᶜ) holds unconditionally (even when ∑ μ(A i) ≥ 1, where it degenerates to the trivial 0 ≤ μ(⋂ (A i)ᶜ)), and positivity is recovered exactly at the subcritical threshold via tsub_pos_iff_lt.",
+      "The symmetric threshold n·p < 1 exposed here is exactly what the symmetric LLL improves: e·p·(d+1) ≤ 1 removes the dependence on n, replacing the total event count by the local dependency degree d."
+    ],
+    "prerequisites": [
+      "Measure-theoretic probability: IsProbabilityMeasure, prob_compl_eq_one_sub",
+      "Finite subadditivity of measures: measure_iUnion_fintype_le",
+      "Set identity Set.compl_iUnion : (⋃ i, s i)ᶜ = ⋂ i, (s i)ᶜ",
+      "ENNReal truncated subtraction lemmas: tsub_le_tsub_left, tsub_pos_iff_lt",
+      "Finset.sum_le_sum, Finset.sum_const for the uniform-bound corollary"
+    ]
+  },
+  "conclusion": {
+    "summary": "The dependency-free first-moment (union/Bonferroni) avoidance bound is fully machine-verified over a real probability space: μ(⋂ i, (A i)ᶜ) ≥ 1 − ∑ i, μ(A i), and hence positive avoidance holds whenever ∑ μ(A i) < 1 (or n·p < 1 under a uniform bound), with no independence assumption. 0 sorries, 0 axioms.",
+    "implications": "**Bracketing the open LLL target**: together with the mutually independent base case (lovasz-local-lemma-oq-01), this entry pins down the two computable extremes of the OQ-01 landscape — full independence (exact product ∏(1 − μ(A i))) and no independence (global threshold ∑ μ(A i) < 1). The genuine open target, the bounded-dependency-degree symmetric LLL, is precisely the statement that trades the global threshold proved here for the n-independent local budget e·p·(d+1) ≤ 1. Making both extremes verified clarifies exactly what the LLL induction must buy.\n\n**Honest scope**: the union bound is elementary (a one-line complement of finite subadditivity); it is presented as the baseline the LLL improves upon, not as the LLL itself.",
+    "openQuestions": [
+      "Prove the bounded-dependency-degree symmetric LLL (each bad event dependent on ≤ d others, μ(A i) ≤ p with e·p·(d+1) ≤ 1 ⇒ μ(⋂ A_iᶜ) > 0), interpolating between the union-bound regime (d = n−1, threshold n·p < 1) proved here and the independent regime (d = 0) of lovasz-local-lemma-oq-01.",
+      "Formalize the intermediate two-event / pairwise inclusion–exclusion improvement of the union bound as the first step beyond first-moment.",
+      "Introduce a measure-theoretic dependency graph and conditional-probability machinery (Moser–Tardos entropy compression or Spencer cluster expansion) to reach the local budget e·p·(d+1) ≤ 1."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: the union-bound extreme of the LLL",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring positioning this file as the dependency-free companion to the independent base case: μ(⋂ (A i)ᶜ) ≥ 1 − ∑ μ(A i) over an arbitrary measurable family, bracketing the open bounded-dependency-degree LLL together with the product-formula base case.",
+      "mathContext": "The union bound needs the global threshold ∑ μ(A i) < 1; the LLL relaxes it to the n-independent local budget e·p·(d+1) ≤ 1."
+    },
+    {
+      "id": "sec-lower-bound",
+      "title": "First-moment lower bound",
+      "startLine": 45,
+      "endLine": 62,
+      "summary": "lll_union_bound_iInter_compl_ge: rewrite the avoidance event as (⋃ A i)ᶜ, apply finite subadditivity measure_iUnion_fintype_le, and complement via prob_compl_eq_one_sub with the antitone tsub_le_tsub_left to obtain 1 − ∑ μ(A i) ≤ μ(⋂ (A i)ᶜ).",
+      "mathContext": "This unconditional lower bound is the complement of the union bound μ(⋃ A i) ≤ ∑ μ(A i)."
+    },
+    {
+      "id": "sec-avoidance",
+      "title": "Positive avoidance and the symmetric threshold",
+      "startLine": 63,
+      "endLine": 84,
+      "summary": "lll_union_bound_avoidance: subcritical total mass ∑ μ(A i) < 1 makes the lower bound strictly positive (tsub_pos_iff_lt). lll_union_bound_avoidance_symmetric: under μ(A i) ≤ p, Finset.sum_le_sum and Finset.sum_const bound the total mass by n·p, so n·p < 1 suffices.",
+      "mathContext": "The crude symmetric threshold n·p < 1 is exactly what the symmetric LLL improves to e·p·(d+1) ≤ 1."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "extends",
+      "description": "Companion measure-theoretic entry: OQ-01's mutually independent (d = 0) base case, giving the exact product formula μ(⋂ (A i)ᶜ) = ∏(1 − μ(A i)). This entry is the complementary dependency-free extreme (union bound); together they bracket the open bounded-dependency-degree LLL."
+    },
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "related",
+      "description": "Parent gallery proof of the symmetric LLL over ℚ as a probability-budget surrogate; OQ-01 asks for the genuine measure-theoretic statement that this union-bound baseline and the independent base case together anchor."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the union bound is the elementary avoidance principle the LLL refines by replacing the global mass condition with a local dependency-degree budget."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; opens the LLL chapter by contrasting it with the union/first-moment bound formalized here."
+    },
+    {
+      "authors": "Bonferroni",
+      "title": "Teoria statistica delle classi e calcolo delle probabilità",
+      "year": "1936",
+      "note": "Bonferroni inequalities; the first-order lower bound P(⋂ A_iᶜ) ≥ 1 − ∑ P(A_i) is the case formalized here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **`lovasz-local-lemma-oq-01-union-bound`**, companion to the measure-theoretic LLL base case (`lovasz-local-lemma-oq-01`). It lands the **complementary dependency-free extreme** of open question OQ-01 over a real `IsProbabilityMeasure`:

> For an *arbitrary* finite measurable family (no independence, no bounded-dependency hypothesis),
> `μ(⋂ i, (A i)ᶜ) ≥ 1 − ∑ i, μ(A i)`,
> so `0 < μ(⋂ (A i)ᶜ)` as soon as `∑ μ(A i) < 1` (uniform version: `(Fintype.card ι)·p < 1`).

## New verified theorems (`Proofs/LovaszLocalLemmaOQ01UnionBound.lean`, 84 lines)

| theorem | statement |
|---|---|
| `lll_union_bound_iInter_compl_ge` | first-moment lower bound `1 − ∑ μ(A i) ≤ μ(⋂ (A i)ᶜ)` |
| `lll_union_bound_avoidance` | `∑ μ(A i) < 1 ⇒ 0 < μ(⋂ (A i)ᶜ)` |
| `lll_union_bound_avoidance_symmetric` | uniform `μ(A i) ≤ p`, `n·p < 1 ⇒` positive avoidance |

## Verification

- Docker build (`docker-build.sh Proofs.LovaszLocalLemmaOQ01UnionBound`) — **exit 0**.
- `#print axioms` on all three theorems → `[propext, Classical.choice, Quot.sound]` only. **0 sorries, 0 axioms, no native_decide.** Status `verified`.

## Proof technique

Elementary and independence-free: De Morgan (`Set.compl_iUnion`) → finite subadditivity (`measure_iUnion_fintype_le`, the union bound) → `prob_compl_eq_one_sub` + `tsub_le_tsub_left` (antitone truncated subtraction) → `tsub_pos_iff_lt` for positivity at the subcritical threshold. No generated-σ-algebra machinery, unlike the independent base case.

## Significance (honest framing)

The union bound is elementary — a one-line complement of finite subadditivity. Its value is **framing**: together with the independent product formula `∏(1 − μ(A i))` from the base-case entry, it pins the two *computable extremes* bracketing the LLL. The genuine open OQ-01 target is precisely the statement that a bounded local dependency degree `d` relaxes the crude global threshold `n·p < 1` proved here to the `n`-independent local budget `e·p·(d+1) ≤ 1`. This is presented as the baseline the LLL improves upon, **not** the LLL itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)