### PR TITLE
Enrich Newton identities (deg 4-5): universality annotation + Vieta/Cayley-Hamilton crossRefs (recovers #33962)

### DIFF
--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/annotations.json
@@ -48,6 +48,18 @@
     ]
   },
   {
+    "id": "newton-ps-oq0101-setup",
+    "proofId": "newton-power-sum-identities-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 43 },
+    "type": "concept",
+    "title": "Universality: identities in MvPolynomial σ R for any finite σ, any commutative ring",
+    "content": "`variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` fixes the maximal generality. The results are proven inside the polynomial ring `MvPolynomial σ R`, so they are *universal symmetric-function identities* — one formula that holds no matter how the variables Xᵢ are later specialized, over any commutative ring (no field, no characteristic-zero hypothesis, and no invertibility of the integer coefficients 2, 4, 5 is required, since the recurrence produces them by repeated addition rather than division). Only `CommRing` and `Fintype σ` are assumed; the finiteness of σ makes the sums pₖ = ∑ᵢ Xᵢᵏ and eⱼ well-defined. When `card σ < k`, the elementary symmetric polynomial eₖ is the empty sum 0, so the higher terms silently vanish and the identities degenerate correctly (a single variable ⇒ p₄ = e₁⁴, p₅ = e₁⁵). This universality is exactly why the same statement specializes to the root-power relations of a quartic or quintic and to the trace-power/coefficient conversion of 4×4 and 5×5 matrices.",
+    "mathContext": "$p_k,\\,e_j \\in \\mathrm{MvPolynomial}\\,\\sigma\\,R,\\quad R\\ \\text{any CommRing},\\ \\sigma\\ \\text{finite};\\ \\ \\mathrm{card}\\,\\sigma < k \\Rightarrow e_k = 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["MvPolynomial", "symmetric function identity", "commutative ring generality", "esymm vanishing"],
+    "prerequisites": ["MvPolynomial", "Fintype", "elementary symmetric polynomial"]
+  },
+  {
     "id": "newton-ps-oq0101-deg123",
     "proofId": "newton-power-sum-identities-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
+++ b/src/data/proofs/newton-power-sum-identities-oq-01-oq-01/meta.json
@@ -123,6 +123,16 @@
       "proofId": "amgm-inequality-oq-02",
       "relation": "related",
       "description": "“Maclaurin's Inequalities via Elementary Symmetric Polynomials.” The inequality-theoretic companion to these exact power-sum identities: both bodies of results are built on the elementary symmetric polynomials eₖ, one giving Newton's equalities relating them to the power sums, the other the Newton–Maclaurin chain of inequalities among the means eₖ/C(n,k)."
+    },
+    {
+      "proofId": "vietas-formulas",
+      "relation": "related",
+      "description": "Vieta's formulas identify the elementary symmetric polynomials eⱼ of the roots of a monic polynomial with (± its coefficients). Composing Vieta with these Newton identities converts the coefficients of a quartic or quintic directly into the power sums p₄, p₅ of its roots — the elementary-symmetric side is the shared bridge."
+    },
+    {
+      "proofId": "cayley-hamilton-minpoly",
+      "relation": "related",
+      "description": "For an n×n matrix the elementary symmetric polynomials of the eigenvalues are (up to sign) the coefficients of the characteristic polynomial, while the power sums pₖ are the traces tr(Mᵏ). Newton's identities are exactly the change of basis between these two invariants of a matrix — the same eigenvalue-symmetric-function circle of ideas this Cayley–Hamilton/minimal-polynomial entry works within."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Recovers the enrichment from #33962, which was closed after its shared `feature/enricher-3` branch was overwritten during a deploy-cycle rebase (fork-remote branch-name ambiguity). Content is identical, rebased cleanly on main: +universality keyInsight and +Vieta & Cayley-Hamilton crossReferences on newton-power-sum-identities-oq-01-oq-01. Union-merged with main's concurrent amgm crossRef.

Labels: enrichment (no loom:review-requested — deployer merges directly).