### PR TITLE
Enrich Erdős #286 small-k Egyptian representations (erdos-286-oq-01): +rigidity keyInsight, sharpen crossRef

### DIFF
--- a/src/data/proofs/erdos-286-oq-01/meta.json
+++ b/src/data/proofs/erdos-286-oq-01/meta.json
@@ -87,7 +87,8 @@
       "**The threshold is exactly 3.** The parent shows k = 2 fails and the interval problem needs k ≥ 3; this entry certifies that k = 3 already succeeds and, moreover, does so uniquely — the smallest interval-representable case is a single explicit triple.",
       "**Uniqueness is a two-step squeeze, not a search.** Ordering a < b < c turns the equation into successive reciprocal bounds: the smallest denominator is pinned to 2, then the middle to 3, leaving the largest determined algebraically. No unbounded search or decidability over ℚ is required.",
       "**inv_inj cleanly closes the last step.** Rather than clearing denominators, rewriting 1/c = 1/6 to c⁻¹ = 6⁻¹ and applying injectivity of inversion extracts c = 6 without field_simp fragility.",
-      "**Interval-free but interval-relevant.** The {2,3,6} solution has denominators spanning width 6 − 2 = 4 < (e − 1)·3 ≈ 5.15, so it already lies in a short interval in the parent's sense — a concrete witness at the k = 3 threshold."
+      "**Interval-free but interval-relevant.** The {2,3,6} solution has denominators spanning width 6 − 2 = 4 < (e − 1)·3 ≈ 5.15, so it already lies in a short interval in the parent's sense — a concrete witness at the k = 3 threshold.",
+      "**Rigid at k = 3, branching at k = 4.** Uniqueness is a threshold phenomenon: k = 3 admits the single triple {2,3,6}, but k = 4 already admits at least six distinct representations. Four of them — {2,3,7,42}, {2,3,8,24}, {2,3,9,18}, {2,3,10,15} — are obtained from {2,3,6} by splitting its largest term 1/6 into two distinct unit fractions (1/6 = 1/7+1/42 = 1/8+1/24 = 1/9+1/18 = 1/10+1/15), so the unique k = 3 seed literally generates most of the next level; the remaining two ({2,4,5,20}, {2,4,6,12}) come from the a = 2, b = 4 branch that k = 3 forbids."
     ],
     "prerequisites": [
       "Egyptian fractions and unit-fraction representations of 1",
@@ -136,7 +137,7 @@
     {
       "targetId": "erdos-286-oq-02",
       "relationship": "related",
-      "description": "A sibling child of Erdős #286; both refine the small-k / monotonicity structure of the parent problem."
+      "description": "Sibling child of Erdős #286 that discharges the parent's monotonicity axiom via the splitting identity 1/m = 1/(m+1) + 1/(m(m+1)). That identity is the exact mechanism connecting this entry's threshold to the next level: applying it (and its variants) to the largest term 1/6 of the unique k = 3 solution {2,3,6} produces the k = 4 representations {2,3,7,42}, {2,3,8,24}, {2,3,9,18}, {2,3,10,15} — so oq-02's splitting is the inductive step that grows the base case classified here."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-286-oq-01` (quality 92, pass 0). Verified accurate against `Proofs/Erdos286OQ01.lean` (4 theorems, 0 sorries, 0 axioms, badge `original`). Additions are targeted (meta.json 11.3 KB → 12.2 KB).

**Changes**
- **+1 keyInsight (4→5):** uniqueness at k=3 is a *threshold/rigidity* phenomenon — the single triple {2,3,6} at k=3 vs ≥6 representations at k=4. Four of the six k=4 solutions ({2,3,7,42}, {2,3,8,24}, {2,3,9,18}, {2,3,10,15}) arise by splitting the largest term 1/6 of {2,3,6} into two distinct unit fractions (1/6 = 1/7+1/42 = 1/8+1/24 = 1/9+1/18 = 1/10+1/15); the other two come from the a=2,b=4 branch k=3 forbids. **All arithmetic verified** with an exact-rational check.
- **Sharpened the `erdos-286-oq-02` crossReference** from vague ('both refine the small-k structure') to specific: oq-02's splitting identity 1/m = 1/(m+1)+1/(m(m+1)) is exactly the inductive step that grows this entry's classified k=3 base case into the k=4 enumeration (openQuestion #2).

**Verification:** `pnpm build` passes. JSON valid. Caps respected (5 keyInsights ≤ 12, 2 crossRefs ≤ 20). Axiom integrity unchanged and accurate.