### PR TITLE
Enrich Blichfeldt general-multiplicity (minkowski-fundamental-theorem-oq-03): +boundedness-free keyInsight (4→5)

### DIFF
--- a/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-03/meta.json
@@ -66,7 +66,8 @@
       "Averaging over the fundamental domain converts a global volume inequality into a pointwise multiplicity statement: the mean number of translates covering a point of F is exactly μs / μF, so exceeding k forces some point to be covered more than k times.",
       "Working with the abstract IsAddFundamentalDomain API (rather than a concrete ℝⁿ lattice) makes the theorem apply to any countable subgroup with an invariant measure, and collapses to Mathlib's k = 1 lemma with no extra hypotheses.",
       "The finite-extraction step is purely order-theoretic: an ℝ≥0∞ tsum of {0,1}-terms exceeding k, written as a supremum of finite partial sums, must already exceed k on some finite set, whose nonzero part has cardinality > k.",
-      "The parent's blichfeldt_statement carries convexity, symmetry, and a 2ⁿ factor and concludes with k+1 LATTICE POINTS — that is van der Corput's theorem. True Blichfeldt needs none of these and concludes with congruent points of s; conflating the two is a common textbook error that this entry avoids."
+      "The parent's blichfeldt_statement carries convexity, symmetry, and a 2ⁿ factor and concludes with k+1 LATTICE POINTS — that is van der Corput's theorem. True Blichfeldt needs none of these and concludes with congruent points of s; conflating the two is a common textbook error that this entry avoids.",
+      "The classical boundedness hypothesis on s is unnecessary: s is only assumed null-measurable, and the single inequality k • μF < μs drives everything. Even μs = ∞ is admissible — a uniform bound g ≤ k would force μs ≤ k·μF < ∞, so the pigeonhole still fires — and the finite-extraction lemma pulls a finite over-covering family of size > k out of a possibly-infinite covering tsum. The measure-theoretic averaging thus strictly generalizes the bounded-set statement without any compactness input."
     ]
   },
   "sections": [


### PR DESCRIPTION
Targeted enrichment of `minkowski-fundamental-theorem-oq-03` (pass 0, quality 92 — already strong, so one sharp verified addition rather than inflation).

**Added:** a 5th keyInsight documenting that this measure-theoretic form drops the classical **boundedness** hypothesis on `s`. The Lean statement assumes only `NullMeasurableSet s μ` and the single inequality `k • μF < μs`; even `μs = ∞` is admissible (a uniform bound `g ≤ k` would force `μs ≤ k·μF < ∞`), and the finite-extraction lemma pulls a finite over-covering family of size `> k` out of a possibly-infinite covering tsum. This strictly generalizes the bounded-set statement with no compactness input.

**Verified** against `Proofs/MinkowskiFundamentalTheoremOQ03.lean`: no boundedness in the hypotheses; theorem/axiom counts unchanged and accurate (2 thm, 0 axiom, verified/mathlib). meta.json 10.7→11.2 KB, under all size caps.

Data-generation step of `pnpm build` processed the entry cleanly; JSON validated.