### PR TITLE
Enrich lovasz-local-lemma-oq-01-union-bound: annotations 3→5

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-union-bound/annotations.json
@@ -25,6 +25,30 @@
     ]
   },
   {
+    "id": "ann-lll-oq01-ub-setup",
+    "proofId": "lovasz-local-lemma-oq-01-union-bound",
+    "range": {
+      "startLine": 36,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "The probability-space frame and ℝ≥0∞ truncated subtraction",
+    "content": "```lean\nimport Mathlib.Probability.Independence.Basic\nopen MeasureTheory Finset\nopen scoped ENNReal\nnamespace LovaszLocalLemmaOQ01UnionBound\nvariable {Ω : Type*} [MeasurableSpace Ω] {ι : Type*} [Fintype ι]\nvariable {μ : Measure Ω} [IsProbabilityMeasure μ] {A : ι → Set Ω}\n```\n\nThree typeclass choices carry the whole argument. `[Fintype ι]` makes the family *finite*, so the union bound is finite subadditivity (`measure_iUnion_fintype_le`) rather than the countable version — and lets $\\sum_i \\mu(A_i)$ and $n = |\\iota|$ be honest finite quantities. `[IsProbabilityMeasure μ]` is what turns a bound on $\\mu(\\bigcup_i A_i)$ into a bound on its complement via $\\mu(s^c) = 1 - \\mu(s)$; without total mass $1$ there is no complementation identity to exploit. Crucially all measures live in $\\mathbb{R}_{\\ge 0}^\\infty$ (`open scoped ENNReal`), where subtraction is **truncated** ($a - b = 0$ when $b \\ge a$). This is not a defect but the reason the lower bound $1 - \\sum_i \\mu(A_i)$ is stated unconditionally: when the total mass is supercritical the expression is simply $0$, and only the hypothesis $\\sum_i \\mu(A_i) < 1$ (via `tsub_pos_iff_lt`) makes it strictly positive.",
+    "mathContext": "Measures valued in $\\mathbb{R}_{\\ge 0}^\\infty$ with truncated subtraction: $1 - x = 0$ for $x \\ge 1$. `IsProbabilityMeasure` supplies $\\mu(\\Omega) = 1$ and hence $\\mu(s^c) = 1 - \\mu(s)$; `Fintype ι` supplies finite subadditivity and a finite $n = |\\iota|$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "extended non-negative reals ℝ≥0∞",
+      "truncated subtraction",
+      "probability measure",
+      "finite index (Fintype)",
+      "measurable space"
+    ],
+    "prerequisites": [
+      "measure theory: probability measures",
+      "extended non-negative reals and truncated subtraction"
+    ]
+  },
+  {
     "id": "ann-lll-oq01-ub-lowerbound",
     "proofId": "lovasz-local-lemma-oq-01-union-bound",
     "range": {
@@ -51,21 +75,45 @@
     "proofId": "lovasz-local-lemma-oq-01-union-bound",
     "range": {
       "startLine": 60,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "Positive avoidance from a subcritical total mass",
+    "content": "```lean\ntheorem lll_union_bound_avoidance\n    (hA : ∀ i, MeasurableSet (A i)) (hsum : ∑ i, μ (A i) < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) :=\n  lt_of_lt_of_le (tsub_pos_iff_lt.2 hsum) (lll_union_bound_iInter_compl_ge hA)\n```\n\nThe qualitative payoff of the lower bound: as soon as the total mass is subcritical ($\\sum_i \\mu(A_i) < 1$), *all* bad events are simultaneously avoided with strictly positive probability — with no independence and no bounded-dependency hypothesis whatsoever. The proof is a one-liner: `tsub_pos_iff_lt` turns $\\sum_i \\mu(A_i) < 1$ into $0 < 1 - \\sum_i \\mu(A_i)$ in $\\mathbb{R}_{\\ge 0}^\\infty$, and chaining that strict inequality through the lower bound `lll_union_bound_iInter_compl_ge` with `lt_of_lt_of_le` gives $0 < \\mu(\\bigcap_i A_i^c)$. This is the honest dependency-free baseline the Lovász Local Lemma is built to beat: it needs the *global* mass small, whereas the LLL needs only *local* dependency controlled.",
+    "mathContext": "tsub_pos_iff_lt : 0 < a − b ↔ b < a (here a = 1, b = ∑ μ(A i)); the strict inequality is transported through the lower bound by lt_of_lt_of_le.",
+    "significance": "core",
+    "relatedConcepts": [
+      "first-moment method",
+      "positive probability",
+      "probabilistic method",
+      "truncated subtraction in ℝ≥0∞"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01",
+      "the first-moment lower bound above"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ub-symmetric",
+    "proofId": "lovasz-local-lemma-oq-01-union-bound",
+    "range": {
+      "startLine": 69,
       "endLine": 82
     },
     "type": "insight",
-    "title": "Positive avoidance and the crude symmetric threshold n·p < 1",
-    "content": "```lean\ntheorem lll_union_bound_avoidance\n    (hA : ∀ i, MeasurableSet (A i)) (hsum : ∑ i, μ (A i) < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) :=\n  lt_of_lt_of_le (tsub_pos_iff_lt.2 hsum) (lll_union_bound_iInter_compl_ge hA)\n\ntheorem lll_union_bound_avoidance_symmetric\n    (hA : ∀ i, MeasurableSet (A i)) {p : ℝ≥0∞} (hbound : ∀ i, μ (A i) ≤ p)\n    (hcard : (Fintype.card ι : ℝ≥0∞) * p < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) := by\n  refine lll_union_bound_avoidance hA (lt_of_le_of_lt ?_ hcard)\n  calc ∑ i, μ (A i)\n      ≤ ∑ _i : ι, p := Finset.sum_le_sum (fun i _ => hbound i)\n    _ = (Fintype.card ι : ℝ≥0∞) * p := by\n        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]\n```\n\nStrict positivity is immediate from the lower bound: in $\\mathbb{R}_{\\ge 0}^\\infty$, `tsub_pos_iff_lt` says $0 < 1 - \\sum_i \\mu(A_i)$ exactly when $\\sum_i \\mu(A_i) < 1$. The symmetric corollary specializes to a uniform bound $\\mu(A_i) \\le p$: `Finset.sum_le_sum` and `Finset.sum_const` give $\\sum_i \\mu(A_i) \\le n\\,p$ with $n = |\\iota|$, so $n\\,p < 1$ suffices. This threshold $n\\,p < 1$ is precisely what the *symmetric* LLL improves: its budget $e\\,p\\,(d+1) \\le 1$ depends only on the local dependency degree $d$, not on the total number of events $n$ — the entire content of the open OQ-01 target.",
-    "mathContext": "tsub_pos_iff_lt : 0 < a − b ↔ b < a (here a = 1, b = ∑ μ(A i)); Finset.sum_const and Finset.card_univ turn ∑_{i : ι} p into (Fintype.card ι)·p.",
-    "significance": "core",
+    "title": "The crude symmetric threshold n·p < 1 — what the LLL relaxes",
+    "content": "```lean\ntheorem lll_union_bound_avoidance_symmetric\n    (hA : ∀ i, MeasurableSet (A i)) {p : ℝ≥0∞} (hbound : ∀ i, μ (A i) ≤ p)\n    (hcard : (Fintype.card ι : ℝ≥0∞) * p < 1) :\n    0 < μ (⋂ i, (A i)ᶜ) := by\n  refine lll_union_bound_avoidance hA (lt_of_le_of_lt ?_ hcard)\n  calc ∑ i, μ (A i)\n      ≤ ∑ _i : ι, p := Finset.sum_le_sum (fun i _ => hbound i)\n    _ = (Fintype.card ι : ℝ≥0∞) * p := by\n        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]\n```\n\nSpecializing to a uniform bound $\\mu(A_i) \\le p$ gives the *symmetric* form. `Finset.sum_le_sum` bounds $\\sum_i \\mu(A_i) \\le \\sum_i p$, and `Finset.sum_const` / `Finset.card_univ` collapse the constant sum to $n\\,p$ with $n = |\\iota|$, so $n\\,p < 1$ feeds straight into the plain avoidance theorem. This threshold $n\\,p < 1$ is exactly the benchmark the **symmetric Lovász Local Lemma** improves: its budget $e\\,p\\,(d+1) \\le 1$ depends only on the local dependency degree $d$, not on the total number of events $n$. Comparing the two — $n\\,p < 1$ here versus $e\\,p\\,(d+1) \\le 1$ for the LLL — makes the entire value of a *local* dependency structure quantitative, and pins down what the still-open OQ-01 target must deliver.",
+    "mathContext": "Finset.sum_le_sum with the uniform bound, then Finset.sum_const and Finset.card_univ turn ∑_{i : ι} p into (Fintype.card ι)·p; the symmetric sufficient condition is n·p < 1, to be compared with the LLL budget e·p·(d+1) ≤ 1.",
+    "significance": "key",
     "relatedConcepts": [
-      "union bound threshold",
       "symmetric Lovász Local Lemma",
       "dependency degree",
-      "e·p·(d+1) ≤ 1"
+      "e·p·(d+1) ≤ 1",
+      "union bound threshold"
     ],
     "prerequisites": [
-      "lovasz-local-lemma-oq-01"
+      "lovasz-local-lemma-oq-01",
+      "the positive-avoidance theorem above"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-01-union-bound` (union-bound / first-moment extreme of the Lovász Local Lemma).

## Change: annotations 3 → 5 (honest coverage, no padding)

The Lean file has three theorems but the third annotation bundled two of them and the measure-theoretic setup was unannotated. This pass splits by theorem and adds the frame:

1. **Split** the bundled `ann-lll-oq01-ub-avoidance` (was lines 60–82) into:
   - **Positive avoidance from a subcritical total mass** — `lll_union_bound_avoidance` (60–67).
   - **The crude symmetric threshold n·p < 1 — what the LLL relaxes** — `lll_union_bound_avoidance_symmetric` (69–82), the LLL comparison point (n·p<1 vs e·p·(d+1)≤1).
2. **New setup annotation** (36–44): the probability-space frame and the ℝ≥0∞ **truncated-subtraction** subtlety — why the lower bound `1 − ∑ μ(Aᵢ)` is stated unconditionally and needs `∑ < 1` (via `tsub_pos_iff_lt`) for strict positivity.

## Guardrails
- 5 annotations, each with `mathContext`, `relatedConcepts`, `significance`; ranges non-overlapping and covering all three theorems. No existing content deleted — the two split annotations preserve the original prose, re-scoped per theorem.
- meta.json unchanged (15.7 KB, within caps). JSON validated.
