### PR TITLE
Enrich abel-ruffini-oq-11: split bundled base-case annotation (4→5, +roots-of-unity abelian)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-11/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-11/annotations.json
@@ -2,49 +2,126 @@
   {
     "id": "ann-setup",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 3, "endLine": 38 },
+    "range": {
+      "startLine": 3,
+      "endLine": 38
+    },
     "type": "concept",
     "title": "Setup: The Two Faces of Abel–Ruffini",
     "content": "The docstring frames the entry against the negative face of Abel–Ruffini — Sₙ unsolvable for n ≥ 5, hence the general quintic is not solvable by radicals — which is formalized elsewhere in this project (AbelRuffini.lean, and AbelRuffiniOQ07 for the concrete X⁵ − X − 1 ≅ S₅). The positive face addressed here is Galois' answer to 'why do radicals work for the cases they do': by Galois' criterion an equation is solvable by radicals iff its Galois group is solvable, and the polynomials one can write with radicals (pure powers Xⁿ = a and their finite combinations) always have solvable groups. Mathlib provides the single-equation facts and an abstract multiset product but neither a usable finite-product form nor the side-by-side dichotomy; both are supplied below. The file imports only Mathlib and opens Polynomial over a field F.",
     "mathContext": "Galois' criterion: solvable by radicals $\\iff$ solvable Galois group. Positive face: pure powers and their products have solvable groups.",
     "significance": "supporting",
-    "relatedConcepts": ["Abel–Ruffini theorem", "Galois' criterion", "solvable group", "solvability by radicals", "symmetric group obstruction"],
-    "prerequisites": ["Galois theory and the Galois group of a polynomial", "solvable groups", "the unsolvability of Sₙ for n ≥ 5"]
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "Galois' criterion",
+      "solvable group",
+      "solvability by radicals",
+      "symmetric group obstruction"
+    ],
+    "prerequisites": [
+      "Galois theory and the Galois group of a polynomial",
+      "solvable groups",
+      "the unsolvability of Sₙ for n ≥ 5"
+    ]
   },
   {
     "id": "ann-single",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 43, "endLine": 51 },
+    "range": {
+      "startLine": 43,
+      "endLine": 45
+    },
     "type": "theorem",
-    "title": "Pure Equations Are Solvable",
-    "content": "Every pure equation $X^n = a$ has a solvable Galois group (`gal_pow_sub_C_isSolvable`), as do the $n$-th roots of unity $X^n = 1$ (`gal_pow_sub_one_isSolvable`). These are the atoms of the radical-solvable side: a single root extraction never destroys solvability. By Galois' criterion this is exactly why $\\sqrt[n]{a}$ is, tautologically, expressible by radicals. Both re-expose Mathlib's gal_X_pow_sub_C_isSolvable / gal_X_pow_sub_one_isSolvable as named building blocks; the roots-of-unity group is in fact abelian (a subgroup of the cyclotomic units), hence solvable a fortiori.",
-    "mathContext": "$\\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})$ and $\\mathrm{IsSolvable}((X^n - 1).\\mathrm{Gal})$.",
+    "title": "The Base Case: Xⁿ = a Is Solvable",
+    "content": "The general pure equation $X^n = a$ has a solvable Galois group (`gal_pow_sub_C_isSolvable`, re-exposing Mathlib's `gal_X_pow_sub_C_isSolvable`). This is the atom of the radical-solvable side: extracting a single $n$-th root never destroys solvability. By Galois' criterion it is exactly why $\\sqrt[n]{a}$ is, tautologically, expressible by radicals. Over a field already containing the $n$-th roots of unity the splitting field $F(\\sqrt[n]{a})$ is a Kummer extension with cyclic Galois group; in general it sits one abelian layer above the cyclotomic base, so the group is solvable but need not be abelian — contrast the roots-of-unity case just below.",
+    "mathContext": "$\\mathrm{IsSolvable}\\bigl((X^n - a).\\mathrm{Gal}\\bigr)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Galois group", "solvable group", "roots of unity", "radical extension", "cyclotomic field"],
-    "prerequisites": ["the Galois group of Xⁿ − a", "abelian ⟹ solvable", "Mathlib's single-equation AbelRuffini lemmas"]
+    "relatedConcepts": [
+      "Galois group",
+      "solvable group",
+      "radical extension",
+      "Kummer extension",
+      "cyclic group"
+    ],
+    "prerequisites": [
+      "the Galois group of Xⁿ − a",
+      "Galois' solvability criterion",
+      "Mathlib's gal_X_pow_sub_C_isSolvable"
+    ]
+  },
+  {
+    "id": "ann-roots-of-unity",
+    "proofId": "abel-ruffini-oq-11",
+    "range": {
+      "startLine": 47,
+      "endLine": 51
+    },
+    "type": "theorem",
+    "title": "Sharper Base Case: Roots of Unity Are Abelian",
+    "content": "The cyclotomic equation $X^n = 1$ has a Galois group that is not merely solvable but **abelian** (`gal_pow_sub_one_isSolvable`, from Mathlib's `gal_X_pow_sub_one_isSolvable`). This is strictly stronger than the general $X^n = a$ case: the Galois group of the $n$-th cyclotomic extension embeds into the unit group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ via the action $\\zeta \\mapsto \\zeta^k$ on a primitive root, and $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is abelian. Abelian $\\Rightarrow$ solvable a fortiori. Structurally this is the *first* layer of every radical tower: one adjoins the roots of unity to make the ground field 'Kummer-ready' before extracting radicals, which is why the two lemmas are stated as separate atoms rather than one — the cyclotomic step supplies the abelian bottom of the solvable series, the pure-radical step supplies the cyclic layers on top.",
+    "mathContext": "$\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\hookrightarrow (\\mathbb{Z}/n\\mathbb{Z})^\\times$, abelian, so $\\mathrm{IsSolvable}\\bigl((X^n - 1).\\mathrm{Gal}\\bigr)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "roots of unity",
+      "cyclotomic field",
+      "abelian group",
+      "unit group (ℤ/nℤ)ˣ",
+      "Kummer theory"
+    ],
+    "prerequisites": [
+      "cyclotomic extensions",
+      "abelian ⟹ solvable",
+      "Mathlib's gal_X_pow_sub_one_isSolvable"
+    ]
   },
   {
     "id": "ann-closure",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 53, "endLine": 65 },
+    "range": {
+      "startLine": 53,
+      "endLine": 65
+    },
     "type": "theorem",
     "title": "The Radical-Solvable Closure (new)",
     "content": "**Any finite product $\\prod_{i\\in s}(X^{n_i} - a_i)$ of pure radical equations has a solvable Galois group.** This is the constructive counterpart to the symmetric-group obstruction — everything one can assemble from root extractions stays solvable. Proved by `Finset.cons_induction`: the empty product is $1$, solvable by gal_one_isSolvable, and each new factor $X^{n_i} - a_i$ is glued onto the solvable running product with `gal_mul_isSolvable` (p.Gal, q.Gal solvable ⟹ (p·q).Gal solvable). Mathlib gives only the single-equation fact and an abstract multiset product gal_prod_isSolvable; this directly usable indexed finite-product form, polymorphic in the index type ι, is the entry's new content.",
     "mathContext": "$\\mathrm{IsSolvable}\\bigl((\\textstyle\\prod_{i\\in s}(X^{n_i} - a_i)).\\mathrm{Gal}\\bigr)$ for any finite $s$.",
     "significance": "key",
-    "relatedConcepts": ["Galois group", "solvable group", "closure under products", "Finset.cons_induction", "gal_mul_isSolvable"],
-    "prerequisites": ["solvability closed under polynomial multiplication", "induction over a Finset", "the single-equation base case"]
+    "relatedConcepts": [
+      "Galois group",
+      "solvable group",
+      "closure under products",
+      "Finset.cons_induction",
+      "gal_mul_isSolvable"
+    ],
+    "prerequisites": [
+      "solvability closed under polynomial multiplication",
+      "induction over a Finset",
+      "the single-equation base case"
+    ]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 67, "endLine": 76 },
+    "range": {
+      "startLine": 67,
+      "endLine": 76
+    },
     "type": "theorem",
     "title": "The Two Faces of Abel–Ruffini",
     "content": "The dichotomy in one statement: pure radical equations $X^n = a$ always have solvable Galois groups (radicals succeed), yet $S_m$ is not solvable for $m \\ge 5$ (the obstruction making the general quintic unsolvable). The proof pairs gal_X_pow_sub_C_isSolvable with `Equiv.Perm.not_solvable (Fin m)`, the cardinality hypothesis 5 ≤ #(Fin m) coming from `Cardinal.mk_fin`. The entire theory of solvability by radicals lives in the gap between these two facts: the general quintic's group is Sₙ, which escapes the radical-solvable closure exactly at n = 5.",
     "mathContext": "$(\\forall n\\,a,\\ \\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})) \\wedge (\\forall m \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_m))$.",
     "significance": "key",
-    "relatedConcepts": ["Abel–Ruffini theorem", "solvability by radicals", "symmetric group Sₘ", "Equiv.Perm.not_solvable", "dichotomy"],
-    "prerequisites": ["the radical-solvable side above", "non-solvability of Sₘ for m ≥ 5", "Cardinal.mk_fin"]
+    "relatedConcepts": [
+      "Abel–Ruffini theorem",
+      "solvability by radicals",
+      "symmetric group Sₘ",
+      "Equiv.Perm.not_solvable",
+      "dichotomy"
+    ],
+    "prerequisites": [
+      "the radical-solvable side above",
+      "non-solvability of Sₘ for m ≥ 5",
+      "Cardinal.mk_fin"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment: `abel-ruffini-oq-11` — split bundled base-case annotation (annotations 4→5)

The annotation `ann-single` on lines **43–51** bundled **two mathematically distinct theorems**:

- `gal_pow_sub_C_isSolvable` (43–45) — the general pure equation $X^n = a$ is solvable
- `gal_pow_sub_one_isSolvable` (47–51) — the roots of unity $X^n = 1$

These are not the same fact. The roots-of-unity case is **strictly sharper**: its Galois group embeds into $(\mathbb{Z}/n\mathbb{Z})^\times$ and is **abelian**, not merely solvable. That distinction is load-bearing — the cyclotomic step supplies the *abelian bottom* of every radical tower (adjoining roots of unity to make the ground field Kummer-ready), while the pure-radical step supplies the cyclic layers on top. The bundled annotation buried this in a trailing clause.

### Change
Split `ann-single` into two focused, single-theorem annotations:

| id | range | focus |
|----|-------|-------|
| `ann-single` (narrowed) | 43–45 | general $X^n=a$ / Kummer layer, cyclic |
| `ann-roots-of-unity` (new) | 47–51 | cyclotomic $X^n=1$, embeds in $(\mathbb{Z}/n\mathbb{Z})^\times$, abelian |

- **annotations 4 → 5** (reaches the ≥5 coverage minimum)
- Every annotation now covers exactly one theorem; each has `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- `meta.json` unchanged. Single-file diff (`annotations.json`), well under all size caps.

Coverage/curation improvement, not accretion.
