### PR TITLE
Enrich abundant-number-oq-03: +oq-01-oq-04 primitive-abundant crossRef (2→3)

### DIFF
--- a/src/data/proofs/abundant-number-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03/meta.json
@@ -141,6 +141,11 @@
       "targetId": "abundant-number-oq-01",
       "relationship": "extends",
       "description": "The oq-01 entry establishes abundant_mul_right (closure of abundant numbers under positive multiples) and infinitely_many_abundant via the even family 12·(k+1). This entry reuses that same closure engine but restricts the multiplier to odd 2k+1 over the odd seed 945, giving the odd-case complement to infinitely_many_abundant."
+    },
+    {
+      "targetId": "abundant-number-oq-01-oq-04",
+      "relationship": "related",
+      "description": "The oq-01-oq-04 entry proves there are infinitely many *primitive* abundant numbers (abundant with all proper divisors deficient) via the 2^k·p construction and Bertrand's postulate. It directly addresses this entry's open question of whether infinitely many odd abundant numbers are primitive: the 945·(2k+1) witnesses here are non-primitive (each is a multiple of the abundant 945), so strengthening infinitude to the primitive odd case needs the sharper machinery of oq-01-oq-04 rather than a fixed abundant seed."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment: abundant-number-oq-03 (Infinitely Many Odd Abundant Numbers)

Adds one substantive cross-reference (crossReferences **2→3**) linking this entry to **abundant-number-oq-01-oq-04** (*Infinitely Many Primitive Abundant Numbers, via 2^k·p and Bertrand's Postulate*).

### Why this link is genuine, not padding
This entry's third open question asks whether infinitely many odd abundant numbers are **primitive** (all proper divisors deficient). The 945·(2k+1) witnesses proved here are explicitly **non-primitive** — each is a multiple of the abundant seed 945 — so answering that open question requires the sharper 2^k·p + Bertrand machinery formalized in oq-01-oq-04, not a fixed abundant seed. The crossRef makes that dependency navigable in the gallery.

### Curation discipline
- Entry was already at quality 93 (5 keyInsights, 4 sections, 4 annotations, 3 openQuestions). I did **not** deepen any at-target field or split existing content.
- Single field, single file. `meta.json` = 16.9 KB (well under the 60 KB cap); `gallery:check-size` guardrail passes. crossReferences 3 ≤ cap 20.
- Target/description accuracy verified against origin/main titles of the referenced sibling.

Verified 0-axiom entry; no claims changed.