### PR TITLE
Enrich Gaussian Second Moment (area-of-circle-oq-07-oq-05-oq-02): add mainTheorems (0→4)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/meta.json
@@ -1,7 +1,7 @@
 {
   "id": "area-of-circle-oq-07-oq-05-oq-02",
   "slug": "area-of-circle-oq-07-oq-05-oq-02",
-  "description": "Recovers the parent's Gaussian second moment ∫_ℝ x² e^{-x²} = √π/2 as a value of Euler's Gamma function, through the substitution u = x². The substitution turns the half-line moment ∫_{x>0} x² e^{-x²} into ½·Γ(3/2) = √π/4 via Mathlib's change-of-variables integral_comp_rpow_Ioi_of_pos, and the special value Γ(3/2) = √π/2 follows from Γ(s+1) = s·Γ(s) and Γ(1/2) = √π. Identifies the full-line moment with Γ(3/2).",
+  "description": "Connects the parent's Gaussian second moment to the Gamma function. The substitution u = x² turns Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} du into twice the half-line Gaussian moment, giving ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 = √π/4 (the substitution bridge, via Mathlib's integral_comp_rpow_Ioi_of_pos). The special value Γ(3/2) = √π/2 follows from the functional equation Γ(s+1) = s·Γ(s) and Γ(1/2) = √π, and the full-line moment is identified with Γ(3/2), reproducing the parent's √π/2 as a Gamma value. 131 lines, 4 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
@@ -25,7 +25,6 @@
     "sorries": 0
   },
   "title": "The Gaussian Second Moment as a Gamma Value: ∫ x² e^{-x²} = Γ(3/2) = √π/2 via u = x²",
-  "description": "Connects the parent's Gaussian second moment to the Gamma function. The substitution u = x² turns Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} du into twice the half-line Gaussian moment, giving ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 = √π/4 (the substitution bridge, via Mathlib's integral_comp_rpow_Ioi_of_pos). The special value Γ(3/2) = √π/2 follows from the functional equation Γ(s+1) = s·Γ(s) and Γ(1/2) = √π, and the full-line moment is identified with Γ(3/2), reproducing the parent's √π/2 as a Gamma value. 131 lines, 4 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -127,6 +126,36 @@
       "endLine": 130,
       "summary": "theorem gaussian_second_moment_eq_gamma: ∫_ℝ x² e^{-x²} = Γ(3/2), rewriting the parent's value √π/2 (AreaOfCircleOQ07OQ05.gaussian_second_moment) against gamma_three_half. theorem gaussian_second_moment_Ioi_eq: the explicit half-line value ∫_{x>0} x² e^{-x²} = √π/4, i.e. ½·Γ(3/2).",
       "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2} = \\Gamma\\!\\left(\\tfrac32\\right),\\quad \\int_0^\\infty x^2 e^{-x^2} = \\tfrac{\\sqrt\\pi}{4}$"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gamma_three_half",
+      "type": "theorem",
+      "statement": "Real.Gamma (3 / 2) = Real.sqrt π / 2",
+      "significance": "The special value at the heart of the connection: it turns the abstract Gamma value Γ(3/2) into the concrete Gaussian constant √π/2, so every downstream integral identity lands on an explicit closed form.",
+      "description": "Proved from the Gamma functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) at s = 1/2 together with the Gaussian special value Γ(1/2) = √π (Real.Gamma_one_half_eq), then a single ring step. This is the half-integer instance Γ(3/2) of the general Γ(n + 1/2) ladder."
+    },
+    {
+      "name": "gaussian_second_moment_Ioi",
+      "type": "theorem",
+      "statement": "∫ x in Ioi 0, x ^ 2 * Real.exp (-x ^ 2) = Real.Gamma (3 / 2) / 2",
+      "significance": "The substitution bridge — the mathematical core of the entry. It identifies the half-line Gaussian second moment with ½·Γ(3/2), exposing u = x² as the change of variables that turns a Gaussian moment into Euler's integral.",
+      "description": "Starts from Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} (Real.Gamma_eq_integral) and applies Mathlib's change-of-variables integral_comp_rpow_Ioi_of_pos with p = 2 — the same lemma Mathlib uses for Γ(1/2) = √π. The bulk of the proof is the pointwise rpow bookkeeping (x^(2:ℝ) ↦ x², (x²)^(1/2) ↦ x) reconciling the substituted integrand with the monomial x²·e^{-x²}."
+    },
+    {
+      "name": "gaussian_second_moment_eq_gamma",
+      "type": "theorem",
+      "statement": "∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = Real.Gamma (3 / 2)",
+      "significance": "The requested connection stated cleanly: the parent entry's full-line second moment IS the Gamma value Γ(3/2). Composed with gamma_three_half it reproduces the parent's √π/2 as a special value of the Gamma function.",
+      "description": "A two-rewrite proof: it rewrites with the parent's AreaOfCircleOQ07OQ05.gaussian_second_moment (which supplies the full-line value) and gamma_three_half, reusing prior work rather than re-integrating. This makes explicit that the full-line moment is the double of the half-line moment ½·Γ(3/2)."
+    },
+    {
+      "name": "gaussian_second_moment_Ioi_eq",
+      "type": "theorem",
+      "statement": "∫ x in Ioi 0, x ^ 2 * Real.exp (-x ^ 2) = Real.sqrt π / 4",
+      "significance": "A consistency check pinning the half-line moment to the explicit constant √π/4 = ½·Γ(3/2), the value the open question's phrasing '√π/2 = ½·Γ(3/2)' actually refers to. It resolves the factor-of-two ambiguity between the half-line and full-line moments.",
+      "description": "Combines gaussian_second_moment_Ioi (= Γ(3/2)/2) with gamma_three_half (Γ(3/2) = √π/2) and a ring step, yielding √π/4."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment: add missing `mainTheorems` (0 → 4)

`meta.theoremCount` was `4`, but the entry had **no `mainTheorems` array**, so the gallery's *Main Theorems* section rendered empty. This adds all four theorems from the Lean file with accurate statements, significance, and proof descriptions:

- **`gamma_three_half`** — `Γ(3/2) = √π/2`, the special value at the heart of the connection.
- **`gaussian_second_moment_Ioi`** — the `u = x²` substitution bridge: `∫_{x>0} x² e^{-x²} = Γ(3/2)/2`.
- **`gaussian_second_moment_eq_gamma`** — the full-line moment is `Γ(3/2)` (the requested connection).
- **`gaussian_second_moment_Ioi_eq`** — consistency check pinning the half-line moment to `√π/4`.

Statements copied verbatim from `Proofs/AreaOfCircleOQ07OQ05OQ02.lean` (lines 75, 87, 121, 127).

Also collapses a pre-existing **duplicate `description` key** (the file had two `description` fields — invalid JSON). `JSON.parse` already returned the last one, so the rendered description is unchanged; the dead duplicate is removed.

Single-file change to `meta.json`; JSON validated. File is 18.3 KB, well under the 60 KB cap.
