### PR TITLE
research(erdos-1039): sync gallery meta with merged #33815 (0 sorries, 533 lines)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -17,14 +17,14 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 1039,
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 10,
-    "lineCount": 305,
-    "assumptions": "10 axioms total: 5 distinct (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected) declared identically in main file Proofs/Erdos1039Problem.lean and stub file Proofs/Stubs/Erdos1039Problem.lean (byte-identical, md5 bf950441c17b5b0f2ed93175e7181730). 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
+    "axiomCount": 5,
+    "lineCount": 533,
+    "assumptions": "5 axioms, all genuine published research results the proof correctly leaves unformalized (not overclaimed): benchmark_upper (Erdos-Herzog-Piranian benchmark rho(z^n-1) <= pi/(2n)), pommerenke_lower (Pommerenke 1961, rho >= 1/(2en^2)), klr_lower and klr_area_bound (Krishnapur-Lundberg-Ramachandran 2025, rho >> 1/(n*sqrt(log n))), and random_polynomial_expected. Formalizing any of these would require reproducing the source papers, so they are stated as axioms. The three elementary-geometry lemmas (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc) were completed in PR #33815 and the main file Proofs/Erdos1039Problem.lean now has 0 sorries (533 lines). The deprecated stub Proofs/Stubs/Erdos1039Problem.lean still holds the pre-#33815 state (3 sorries, the same 5 axioms) and is no longer byte-identical to the main file; it is not the presented proof (proofRepoPath is the main file) and adds no distinct assumptions. Note: random_polynomial_expected is currently degenerate as stated (the intended Expected[rho] middle term is a comment, so the Lean statement reduces to the trivial c1/sqrt(n) <= c2/sqrt(n)); a future session could either encode an Expected functional or convert it to a proved trivial lemma.",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
       {
@@ -244,12 +244,12 @@
     ],
     "opens": [],
     "namespace": "Erdos1039",
-    "lineCount": 305,
+    "lineCount": 533,
     "axiomCount": 5,
-    "theoremCount": 9,
+    "theoremCount": 14,
     "definitionCount": 17,
     "path": "Proofs/Erdos1039Problem.lean",
-    "sorries": 3,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
       "Proofs/Erdos1039ProblemAristotle.lean",
@@ -257,5 +257,5 @@
       "Proofs/Stubs/Erdos1039Problem.lean"
     ]
   },
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

The main proof file `Proofs/Erdos1039Problem.lean` was completed to **0 sorries** by PR #33815 (all three elementary-geometry lemmas proved), but the gallery `meta.json` still reported the **pre-#33815 state**: 3 sorries, 305 lines. This PR syncs the metadata to the actually-merged file.

## Changes (src/data/proofs/erdos-1039/meta.json)

| field | was | now | why |
|-------|-----|-----|-----|
| `sorries` (×3: top-level, meta, leanFile) | 3 | **0** | #33815 proved area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc |
| `lineCount` | 305 | **533** | file grew with the completed proofs + 5 helper lemmas |
| `theoremCount` | 9 | **14** | +5 helpers (inscribed_radius_le, bddAbove_inscribed_radii, …) |
| `axiomCount` (meta) | 10 | **5** | 5 *distinct* mathematical assumptions; the deprecated stub duplicates the same 5 and adds no new assumption |
| `assumptions` | stale | rewritten | see below |

## Axiom accounting

The 5 axioms are all **genuine published research results** the proof correctly leaves unformalized (not overclaimed):

- `benchmark_upper` — Erdős–Herzog–Piranian benchmark ρ(zⁿ−1) ≤ π/(2n)
- `pommerenke_lower` — Pommerenke 1961, ρ ≥ 1/(2en²)
- `klr_lower`, `klr_area_bound` — Krishnapur–Lundberg–Ramachandran 2025, ρ ≫ 1/(n√log n)
- `random_polynomial_expected`

The old `assumptions` text counted **10** axioms and justified it by claiming the main and stub files are "byte-identical (md5 bf9504…)". That claim is now **false**: after #33815 the main file (md5 ab7e41…) diverged from the deprecated stub `Proofs/Stubs/Erdos1039Problem.lean` (still bf9504…, still 3 sorries). Since the presented proof is the main file (`proofRepoPath`), the honest distinct-assumption count is **5**. `leanFile.axiomCount` already correctly read 5.

## Note recorded for a future session

`random_polynomial_expected` is **degenerate as stated**: the intended `Expected[ρ]` middle term is a *comment*, so the Lean statement reduces to the trivially-true `c₁/√n ≤ c₂/√n`. A future session could encode an `Expected` functional or convert it to a proved trivial lemma. Documented in the `assumptions` field; no Lean change made here.

`status`/`badge` remain `axiomatized`/`axiom` — correct (5 genuine axioms).

No Lean source changed; this is a pure metadata-integrity sync.