### PR TITLE
research(ramsey-r4k-extensions): de-axiomatize erdos_probabilistic_lower_bound + repair 3 Mathlib-bump breakages

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -18,6 +18,7 @@ import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
+import Proofs.ErdosRamseyLowerBound
 
 namespace RamseyR4k
 
@@ -48,8 +49,12 @@ For k ≥ 3, this gives R(k,k) > 2^(k/2).
     R(k,k) > 2^(k/2) for k ≥ 3.
     Proof: Color edges of K_n randomly. Expected number of monochromatic
     k-cliques is C(n,k) · 2^(1-C(k,2)). If n = ⌊2^(k/2)⌋, this is < 1,
-    so a good coloring exists. -/
-axiom erdos_probabilistic_lower_bound (k : ℕ) (hk : k ≥ 3) :
+    so a good coloring exists.
+
+    Previously an `axiom`; now discharged by the fully-proved, axiom-free
+    first-moment formalization `ErdosRamsey.erdos_probabilistic_lower_bound`
+    (`Proofs/ErdosRamseyLowerBound.lean`), whose statement is identical. -/
+theorem erdos_probabilistic_lower_bound (k : ℕ) (hk : k ≥ 3) :
     ∀ n : ℕ, n ≤ 2^(k/2) →
     ∃ (color : Fin n → Fin n → Bool),
       (∀ x y, color x y = color y x) ∧
@@ -57,7 +62,8 @@ axiom erdos_probabilistic_lower_bound (k : ℕ) (hk : k ≥ 3) :
       (∀ (s : Finset (Fin n)), s.card = k →
         ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
       (∀ (s : Finset (Fin n)), s.card = k →
-        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false))
+        ¬(∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false)) :=
+  ErdosRamsey.erdos_probabilistic_lower_bound k hk
 
 /-
 ## Part II: Off-Diagonal Bounds
@@ -968,9 +974,11 @@ This extension file contains:
 - **NEW** `ramseyUpperBound_diag_lt_four_pow`: R(k,k) < 4^k (cleaner statement)
 - **NEW** `ramseyUpperBound_le_two_pow`: R(r,s) ≤ 2^(r+s-2) (general bound)
 - **NEW** 4 verification theorems for exponential bounds
+- **NEW (de-axiomatized)** `erdos_probabilistic_lower_bound`: R(k,k) > 2^(k/2) —
+  previously an axiom, now a proved theorem discharged by the axiom-free
+  first-moment formalization `ErdosRamsey.erdos_probabilistic_lower_bound`
 
-**Axioms (7 total - deep probabilistic/asymptotic results):**
-- `erdos_probabilistic_lower_bound`: R(k,k) > 2^(k/2)
+**Axioms (6 total - deep probabilistic/asymptotic results):**
 - `aks_r3k_upper_bound`: R(3,k) = O(k²/log k)
 - `kim_r3k_lower_bound`: R(3,k) = Ω(k²/log k)
 - `r4k_upper_bound`: R(4,k) = O(k³/(log k)²)
@@ -1045,7 +1053,7 @@ theorem cgms_exponentially_better :
         C * (4 - ε) ^ k < 4 ^ k := by
   intro ε hε hε4 C hC
   -- Key: (4-ε)/4 < 1 and ≥ 0, so ((4-ε)/4)^k → 0
-  have hr_nn : (0 : ℝ) ≤ (4 - ε) / 4 := by positivity
+  have hr_nn : (0 : ℝ) ≤ (4 - ε) / 4 := div_nonneg (by linarith) (by norm_num)
   have hr_lt : (4 - ε) / 4 < 1 := by linarith
   -- Find k₀ such that ((4-ε)/4)^k₀ < 1/C
   obtain ⟨k₀, hk₀⟩ := exists_pow_lt_of_lt_one (by positivity : (0 : ℝ) < 1 / C) hr_lt
@@ -1058,7 +1066,7 @@ theorem cgms_exponentially_better :
     rw [div_pow] at hrk_bound
     -- (4-ε)^k / 4^k < 1/C, multiply through
     have h4k_pos : (0 : ℝ) < (4 : ℝ) ^ k := by positivity
-    rw [div_lt_div_iff h4k_pos hC, one_mul, mul_comm] at hrk_bound
+    rw [div_lt_div_iff₀ h4k_pos hC, one_mul, mul_comm] at hrk_bound
     exact hrk_bound⟩
 
 /- ═══════════════════════════════════════════════════════════════════════════════
@@ -1119,7 +1127,11 @@ axiom ramsey_multiplicity :
 /-- **PROVED: R(s,t) is symmetric.** -/
 theorem ramsey_symmetric' (s t : ℕ) :
     ramseyUpperBound s t = ramseyUpperBound t s := by
-  exact ramsey_symmetry s t
+  rcases Nat.eq_zero_or_pos s with hs | hs
+  · subst hs; simp [ramseyUpperBound]
+  rcases Nat.eq_zero_or_pos t with ht | ht
+  · subst ht; simp [ramseyUpperBound]
+  exact ramseyUpperBound_symm s t hs ht
 
 -- ═════════════════════════════════════════════════════════════════════════
 -- VERIFICATION CHECKS (Parts X-XI)

--- a/src/data/proofs/ramsey-r4k-extensions/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "ramsey-r4k-extensions",
   "title": "Ramsey R(4,k) Bounds: Probabilistic Method Extensions",
   "slug": "ramsey-r4k-extensions",
-  "description": "Formalizes Ramsey theory bounds for R(4,k) via the probabilistic method. Proves the Erdős 1947 lower bound R(k,k) ≥ 2^(k/2), the Spencer improvement, the Conlon-Fox-Sudakov upper bound, and the R(4,k) quadratic lower bound R(4,k) ≥ Ω(k²/log k). 74 theorems, 15 axioms for the deep analytic bounds.",
+  "description": "Formalizes Ramsey theory bounds for R(4,k) via the probabilistic method. Proves the Erdős 1947 lower bound R(k,k) ≥ 2^(k/2) (now fully axiom-free), the Spencer improvement, the Conlon-Fox-Sudakov upper bound, and the R(4,k) quadratic lower bound R(4,k) ≥ Ω(k²/log k). 75 theorems, 14 axioms for the deep analytic bounds.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
@@ -18,10 +18,10 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 15,
-    "assumptions": "15 axioms covering: erdos_probabilistic_lower_bound (R(k,k)≥2^(k/2) via first moment method), aks_r3k_upper_bound and kim_r3k_lower_bound (R(3,k) bounds), r4k_upper_bound and r4k_lower_bound (R(4,k) bounds), spencer_diagonal_lower_bound (Spencer's improvement), r4k_quadratic_lower (Ω(k²/log k) lower bound), cgms_diagonal_upper_bound and cgms_epsilon_estimate (Conlon-Fox-Sudakov 2009), book_algorithm_structure, and several supporting analytic bounds. These represent the state of the art in Ramsey theory, proofs of which require probabilistic method machinery not yet in Mathlib.",
-    "lineCount": 1142,
-    "theoremCount": 74,
+    "axiomCount": 14,
+    "assumptions": "14 axioms covering: aks_r3k_upper_bound and kim_r3k_lower_bound (R(3,k) bounds), r4k_upper_bound and r4k_lower_bound (R(4,k) bounds), spencer_diagonal_lower_bound (Spencer's improvement), r4k_quadratic_lower (Ω(k²/log k) lower bound), cgms_diagonal_upper_bound and cgms_epsilon_estimate (Conlon-Fox-Sudakov 2009), book_algorithm_structure, and several supporting analytic bounds. The Erdős first-moment lower bound erdos_probabilistic_lower_bound (R(k,k)≥2^(k/2)) is no longer an axiom — it is now a proved theorem discharged by the axiom-free formalization ErdosRamsey.erdos_probabilistic_lower_bound (Proofs/ErdosRamseyLowerBound.lean). The remaining axioms represent the state of the art in Ramsey theory, proofs of which require probabilistic method machinery not yet in Mathlib.",
+    "lineCount": 1154,
+    "theoremCount": 75,
     "definitionCount": 13,
     "originalContributions": [
       "IsRamseyColoring: 2-coloring of K_n edges avoiding monochromatic K_r or K_s",
@@ -56,19 +56,19 @@
     ]
   },
   "conclusion": {
-    "summary": "Ramsey number bounds are formalized with 15 axioms covering the deep probabilistic and analytic results. The elementary bounds (Pascal triangle, first moment setup) are fully proved. 74 theorems, 1142 lines documenting the state of the art in Ramsey theory.",
+    "summary": "Ramsey number bounds are formalized with 14 axioms covering the deep probabilistic and analytic results. The Erdős 1947 first-moment lower bound R(k,k)≥2^(k/2), previously axiomatized, is now fully proved (axiom-free). The elementary bounds (Pascal triangle, first moment setup) are fully proved. 75 theorems, 1150 lines documenting the state of the art in Ramsey theory.",
     "implications": "The probabilistic method established by Erdős is one of the most powerful tools in combinatorics. Formalizing even its setup (IsRamseyColoring, first moment framework) creates infrastructure for future Lean 4 probabilistic combinatorics. The R(4,k) problem remains one of the most actively studied in extremal combinatorics.",
     "openQuestions": [
-      "Prove erdos_probabilistic_lower_bound: requires formalization of uniform random colorings and expectation in Lean 4",
+      "Strengthen the proved bound via the symmetric Lovász Local Lemma: R(k,k) ≥ (1+o(1))·(k/e)·2^(k/2), a factor-k improvement over the first-moment bound",
       "Reduce the R(4,k) gap: closing from [k²/log k, k³/log k] to [k², k²] would be a major breakthrough",
       "Formalize the Lovász Local Lemma and its applications to Ramsey theory"
     ]
   },
   "leanFile": {
     "namespace": "RamseyR4kExtensions",
-    "lineCount": 1142,
-    "axiomCount": 15,
-    "theoremCount": 74,
+    "lineCount": 1154,
+    "axiomCount": 14,
+    "theoremCount": 75,
     "definitionCount": 13,
     "path": "Proofs/RamseyR4kExtensions.lean",
     "sorries": 0

--- a/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
+++ b/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
@@ -1,0 +1,95 @@
+{
+  "slug": "ramsey-r4k-extensions-oq-03",
+  "title": "Lovász Local Lemma and Ramsey Lower Bounds",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(Symmetric LLL) Events } A_1,\\dots,A_m,\\ \\Pr[A_i]\\le p,\\ \\text{each } A_i \\text{ mutually independent of all but } \\le d \\text{ others},\\ e\\,p\\,(d+1)\\le 1 \\Rightarrow \\Pr\\!\\Big[\\bigcap_i \\overline{A_i}\\Big] > 0.",
+    "plain": "The Lovász Local Lemma (LLL) says that if you have many \"bad\" events, each unlikely and each depending on only a few of the others, then with positive probability none of the bad events happens — so a configuration avoiding all of them exists. We want to formalize the symmetric LLL in Lean 4 and use it in Ramsey theory: model a random 2-coloring of the edges of $K_n$, let the bad events be \"this particular $k$-clique is monochromatic,\" and apply LLL to prove that for suitable $n$ a coloring with no monochromatic $K_k$ exists, i.e. a lower bound $R(k,k) > n$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "erdos_probabilistic_lower_bound (R(k,k) > 2^(k/2)) is now a proved, axiom-free theorem — de-axiomatized in RamseyR4kExtensions.lean by wiring in the first-moment formalization ErdosRamsey.erdos_probabilistic_lower_bound."
+    ],
+    "open": [
+      "The symmetric Lovász Local Lemma itself is not yet formalized in Lean/Mathlib.",
+      "The factor-k LLL improvement R(k,k) > (1+o(1))(k/e)2^(k/2) over the first-moment bound."
+    ],
+    "goal": "Formalize the symmetric LLL and use it to strengthen the (now proved) first-moment Ramsey lower bound."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-02T22:00:00-07:00",
+    "iteration": 2,
+    "focus": "De-axiomatized erdos_probabilistic_lower_bound in RamseyR4kExtensions using the existing axiom-free first-moment proof. The symmetric LLL proper remains open.",
+    "blockers": [
+      "General symmetric LLL needs a conditional-probability induction (Spencer's argument) over a probability space — Mathlib has no LLL and the induction is delicate; estimated a multi-session BUILD."
+    ],
+    "nextAction": "Formalize the symmetric LLL statement and its induction proof, then apply it to obtain the factor-k stronger R(k,k) lower bound.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: de-axiomatized erdos_probabilistic_lower_bound (axiomCount 15→14) AND repaired 3 pre-existing Mathlib-bump breakages that had left the file non-compiling. Symmetric LLL itself remains an open BUILD.",
+    "builtItems": [
+      "RamseyR4kExtensions.lean: converted `axiom erdos_probabilistic_lower_bound` into a proved `theorem`, discharged by `ErdosRamsey.erdos_probabilistic_lower_bound k hk` (defeq statements); added `import Proofs.ErdosRamseyLowerBound`. File axiomCount 15→14.",
+      "REPAIR: the file did not compile on the pinned Mathlib (v4.26.0). Fixed 3 pre-existing breakages: (1) `positivity` could not prove `0 ≤ (4-ε)/4` from `ε<4` → `div_nonneg (by linarith) (by norm_num)` (~L1056); (2) `div_lt_div_iff` renamed → `div_lt_div_iff₀` (~L1069); (3) `ramsey_symmetric'` referenced an undefined `ramsey_symmetry` → reproved via zero case-split + existing `ramseyUpperBound_symm` (~L1127).",
+      "Updated gallery meta (ramsey-r4k-extensions): axiomCount 15→14, theoremCount 74→75, lineCount→1154, assumptions/summary/openQuestions revised to reflect the de-axiomatization."
+    ],
+    "insights": [
+      "The gallery entry ramsey-r4k-extensions claimed verified/0-sorry but its Lean file did NOT compile on the current Mathlib pin — three lemmas had been broken by a Mathlib rename/deprecation and an undefined-identifier typo. The de-axiomatization forced a full rebuild that surfaced this; repairing it restores the entry to a genuinely compiling state.",
+      "The `erdos_probabilistic_lower_bound` axiom targeted by this OQ is actually a first-moment (union-bound) result, not an LLL result — LLL only strengthens the constant. The measurable deliverable of the OQ (replace the axiom with a proved statement) is therefore achievable via the already-existing axiom-free first-moment proof in ErdosRamseyLowerBound.lean.",
+      "That first-moment proof (ErdosRamsey.erdos_probabilistic_lower_bound) states EXACTLY the axiom's proposition (k ≥ 3 vs 3 ≤ k are defeq), so the axiom collapses to a one-line re-export with no restatement or reproof.",
+      "No import cycle: ErdosRamseyLowerBound imports Mathlib only; RamseyR4kExtensions can import it cleanly.",
+      "The genuine LLL contribution (formalizing the symmetric LLL and getting the extra factor of k) remains open and is a substantially harder, multi-session BUILD."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no symmetric/general Lovász Local Lemma.",
+      "The LLL proof needs a conditional-probability induction over a finite product probability space; the supporting `ProbabilityTheory.cond` manipulation for the mutual-independence dependency graph is not packaged."
+    ],
+    "nextSteps": [
+      "Formalize the symmetric LLL statement (events, dependency degree d, e·p·(d+1) ≤ 1 ⇒ Pr[∩ ¬A_i] > 0).",
+      "Prove it via Spencer's conditional-probability induction over a finite probability space (measure-theory-free, rational-counting style consistent with the gallery's first-moment files if feasible).",
+      "Apply the LLL to the monochromatic-clique bad events to obtain R(k,k) > (1+o(1))(k/e)·2^(k/2)."
+    ],
+    "markdown": "# Knowledge Base: ramsey-r4k-extensions-oq-03\n\n## Problem Understanding\n\nThe OQ asks to formalize the symmetric Lovász Local Lemma (LLL) and apply it to Ramsey theory, **replacing the axiomatized `erdos_probabilistic_lower_bound` in the `ramsey-r4k-extensions` entry with a proved statement**.\n\n## Key realization\n\n`erdos_probabilistic_lower_bound` (R(k,k) > 2^(k/2)) is a **first-moment** result. Its exact proposition was already proved, axiom-free, in `Proofs/ErdosRamseyLowerBound.lean` as `ErdosRamsey.erdos_probabilistic_lower_bound`. So the OQ's concrete measurable deliverable is closed by wiring that proof in, without needing LLL.\n\n## What was done (Session 2026-07-02)\n\n- `RamseyR4kExtensions.lean`: `axiom erdos_probabilistic_lower_bound` → `theorem ... := ErdosRamsey.erdos_probabilistic_lower_bound k hk`; added `import Proofs.ErdosRamseyLowerBound`. Axiom count 15 → 14.\n- Updated gallery meta counts and prose.\n\n## Still open\n\n- The symmetric LLL itself (statement + conditional-probability induction proof).\n- The factor-k strengthening R(k,k) > (1+o(1))(k/e)·2^(k/2) that LLL yields over the first moment.\n\n## Dead Ends\n\n- None yet; LLL not attempted (scoped as a separate multi-session BUILD).\n"
+  },
+  "tags": [
+    "combinatorics",
+    "probabilistic-method",
+    "lovasz-local-lemma",
+    "ramsey",
+    "probability"
+  ],
+  "relatedProofs": [
+    "ramsey-r4k",
+    "ramsey-r4k-extensions",
+    "erdos-ramsey-lower-bound"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T18:04:16.809Z",
+  "lastUpdate": "2026-07-02T22:00:00-07:00",
+  "leanFiles": [
+    {
+      "path": "Proofs/RamseyR4kExtensions.lean",
+      "filename": "RamseyR4kExtensions.lean",
+      "lineCount": 1154,
+      "theoremCount": 75,
+      "axiomCount": 14,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RamseyR4kExtensions.lean"
+    }
+  ]
+}


### PR DESCRIPTION
Closes the measurable deliverable of open question **ramsey-r4k-extensions-oq-03** — "replace the axiomatized `erdos_probabilistic_lower_bound` in the RamseyR4kExtensions entry with a proved statement."

## De-axiomatization
- `erdos_probabilistic_lower_bound` (R(k,k) > 2^(k/2)) is a **first-moment** (union-bound) result. Its exact proposition was already proved, **axiom-free**, in `Proofs/ErdosRamseyLowerBound.lean` as `ErdosRamsey.erdos_probabilistic_lower_bound`.
- Converted the `axiom` into a `theorem` discharged by that lemma (statements are defeq: `k ≥ 3` vs `3 ≤ k`); added `import Proofs.ErdosRamseyLowerBound`. No import cycle. **File axiom count 15 → 14.**

## Repair — the file did NOT compile on the pinned Mathlib (v4.26.0)
The forced rebuild surfaced three pre-existing breakages, unrelated to the axiom, that had left this "verified" entry non-compiling:
1. `positivity` could not prove `0 ≤ (4-ε)/4` from `ε < 4` → `div_nonneg (by linarith) (by norm_num)`.
2. `div_lt_div_iff` was renamed → `div_lt_div_iff₀` (identical signature).
3. `ramsey_symmetric'` referenced an **undefined** `ramsey_symmetry` → reproved via a zero case-split + the existing `ramseyUpperBound_symm`.

## Verification
`./proofs/scripts/docker-build.sh Proofs.RamseyR4kExtensions` **succeeds** (7744 jobs, 0 errors, 0 sorries). 14 axioms remain (the deep asymptotic Ramsey results — AKS/Kim/Spencer/CGMS/Mattheus–Verstraete etc.). Gallery meta updated (axiomCount 15→14, theoremCount 74→75, lineCount→1154, assumptions/summary/openQuestions). Status stays `axiomatized`.

The symmetric **Lovász Local Lemma** itself (which would strengthen the bound by a factor of k) remains an open, multi-session BUILD — recorded as the entry's new lead open question and in the research problem file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
