### PR TITLE
Enrich Normal Automorphism Degree Formula (angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01): add foundational mainTheorem (6→7)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/meta.json
@@ -139,6 +139,13 @@
   ],
   "mainTheorems": [
     {
+      "name": "card_algEquiv_eq_finSepDegree",
+      "type": "theorem",
+      "statement": "For a normal extension K/F: Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K",
+      "significance": "The foundational input to the entire development: for a normal extension the number of F-algebra automorphisms equals the separable degree [K:F]ₛ. Every downstream result — the degree factorisation, divisibility, the inseparable quotient, and the separability boundary — rewrites through this single equality. Normality is essential: without it |Aut_F(K)| can be strictly smaller than the separable degree, since not every embedding into an algebraic closure need land back inside K.",
+      "description": "Reproved in one line as (Nat.card_congr (Normal.algHomEquivAut F (AlgebraicClosure K) K)).symm: the normal extension's equivalence Normal.algHomEquivAut between automorphisms and embeddings, counted on both sides, yields the separable-degree equality. Recalls the parent NormalAutEquality.card_algEquiv_eq_finSepDegree."
+    },
+    {
       "name": "finrank_eq_card_algEquiv_mul_finInsepDegree",
       "type": "theorem",
       "statement": "For a normal extension K/F: Module.finrank F K = Nat.card (K ≃ₐ[F] K) * Field.finInsepDegree F K",


### PR DESCRIPTION
## Enrichment: add the foundational main theorem (mainTheorems 6→7)

`NormalAutDegreeFormula.lean` proves 8 theorems; the gallery's `mainTheorems`
listed 6 of them but omitted **`card_algEquiv_eq_finSepDegree`** — the earliest
theorem in the file (line 67) and the load-bearing base of the whole
development:

> For a normal extension `K/F`: `Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K`

Every downstream result — the degree factorisation
`[K:F] = |Aut_F(K)| · [K:F]ᵢ`, divisibility, the inseparable quotient, and the
separability boundary — is proved by rewriting through this single equality. It
was the only genuine main result missing from the list, so the gallery
under-represented the proof's actual structure.

The other unlisted theorem, `card_algEquiv_pos`, is a technical positivity
helper (used to license cancellation) and is correctly left out.

- mainTheorems: 6 → 7, inserted in file order (first)
- No other fields touched; meta.json 22 KB (under the ~60 KB cap)
- JSON validated
