### PR TITLE
Enrich Ballot Problem OQ-04: link Dyck-Catalan-count side (crossRefs 2→3)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04/meta.json
@@ -143,6 +143,11 @@
       "targetId": "ballot-problem-oq-03",
       "relationship": "related",
       "description": "A sibling ballot strand that, like this entry, bridges the ballot/lattice-path combinatorics to Mathlib's enumerative infrastructure. Both sit under the ballot/Catalan umbrella; this entry adds the non-crossing-partition side."
+    },
+    {
+      "targetId": "dyck-catalan-count-oq-01",
+      "relationship": "related",
+      "description": "The dedicated formalization of the ballot/Dyck side this entry re-exposes: Dyck words of semilength n are counted by catalan n. OQ-04 hinges on that count — its dyck_side_card theorem re-exports the very card_dyckWord_semilength_eq_catalan result proved there — so this entry supplies the non-crossing-partition codomain that the Dyck-counted domain of that entry bijects onto."
     }
   ]
 }


### PR DESCRIPTION
## Enrichment: ballot-problem-oq-04 (add Dyck-Catalan cross-reference)

Adds one genuine cross-reference from **Ballot Problem OQ-04** (non-crossing partitions) to **`dyck-catalan-count-oq-01`** ("Dyck Words Are Counted by the Catalan Numbers").

**Why this is a real gap, not inflation:** the OQ-04 entry's whole fourth section ("The Ballot/Dyck Side of the Bijection") and its `dyck_side_card` theorem re-export Mathlib's `card_dyckWord_semilength_eq_catalan` — the exact result formalized in `dyck-catalan-count-oq-01`. The entry previously cross-referenced only `ballot-problem` (parent) and `ballot-problem-oq-03` (sibling), leaving the dedicated Dyck-Catalan-count entry — the source of the count OQ-04 depends on — unlinked.

- meta.json: crossReferences 2 → 3
- No other fields touched; entry was already fully enriched (5 keyInsights, 8 originalContributions, mathContext on all sections).
- Target verified present on origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
