### PR TITLE
Enrich Non-Crossing Partitions as Finpartitions: add mainTheorems (0→5)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02/meta.json
@@ -187,5 +187,42 @@
     "definitionCount": 4,
     "theoremCount": 6
   },
-  "sorries": 0
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "isNonCrossingFp_ofSetoid_iff",
+      "type": "theorem",
+      "statement": "IsNonCrossingFp (Finpartition.ofSetoid s) ↔ IsNonCrossing s",
+      "significance": "The agreement theorem, and the technical heart of the entry: it certifies that the new Fintype-bearing Finpartition model of non-crossing partitions describes exactly the same objects as the parent's setoid predicate. Without it the port would be a fresh definition of unknown fidelity; with it, every structural result about the parent's IsNonCrossing transfers, and the count nonCrossingCount is provably a count of the intended objects. The proof is a one-line unfold plus Mathlib's Finpartition.mem_part_ofSetoid_iff_rel, which identifies b ∈ (ofSetoid s).part a with s a b.",
+      "description": "unfold IsNonCrossingFp IsNonCrossing; simp only [Finpartition.mem_part_ofSetoid_iff_rel] — rewrite the same-part membership as the setoid relation, collapsing the two predicates to the same quantified statement."
+    },
+    {
+      "name": "isNonCrossingFp_of_n_le_three",
+      "type": "theorem",
+      "statement": "n ≤ 3 → (P : Finpartition (univ : Finset (Fin n))) → IsNonCrossingFp P",
+      "significance": "A crossing requires four strictly increasing indices a < b < c < d, which cannot exist in Fin n for n ≤ 3. Hence every partition of at most three points is trivially non-crossing. This is the structural reason the non-crossing count agrees with the Bell number below n = 4, and it isolates n = 4 as the first place the two families can differ.",
+      "description": "intro a b c d hab hbc hcd _ _; exfalso; rw [Fin.lt_def] at hab hbc hcd; have hd := d.isLt; omega — the four increasing indices and the bound d < n ≤ 3 are contradictory by linear arithmetic."
+    },
+    {
+      "name": "nonCrossingCount_eq_card_of_n_le_three",
+      "type": "theorem",
+      "statement": "n ≤ 3 → nonCrossingCount n = Fintype.card (Finpartition (univ : Finset (Fin n)))",
+      "significance": "For n ≤ 3 the non-crossing subtype is the whole partition Fintype, so the non-crossing count equals the total partition count — the Bell number Bₙ. This anchors the small-n regime (Bell 0..3 = 1, 1, 2, 5) where non-crossing and unrestricted partitions coincide, against which the n = 4 divergence is measured.",
+      "description": "unfold nonCrossingCount; exact Fintype.card_congr (Equiv.subtypeUnivEquiv (isNonCrossingFp_of_n_le_three hn)) — since the predicate holds universally, the subtype is equivalent to the base Fintype and their cardinalities agree."
+    },
+    {
+      "name": "crossing4_not_isNonCrossing",
+      "type": "theorem",
+      "statement": "¬ IsNonCrossing crossing4",
+      "significance": "The concrete crossing witness at n = 4: the parity partition {{0,2},{1,3}} (kernel of ·%2 on Fin 4) has 0 ~ 2 and 1 ~ 3 but 0 ≁ 1, so the indices 0 < 1 < 2 < 3 interleave. This single explicit partition is what forces the strict drop of the count at n = 4 and realises the catalan 4 = 14 < 15 = Bell 4 gap.",
+      "description": "Apply the non-crossing hypothesis at 0 1 2 3 to force crossing4.r 0 1, i.e. 0 % 2 = 1 % 2, then derive a contradiction by decide on the parity relation."
+    },
+    {
+      "name": "nonCrossingCount_four_lt",
+      "type": "theorem",
+      "statement": "nonCrossingCount 4 < Fintype.card (Finpartition (univ : Finset (Fin 4)))",
+      "significance": "The headline result: n = 4 is the first point at which non-crossing partitions are a STRICT subfamily of all partitions, so the non-crossing count falls below the Bell number. This is the catalan 4 = 14 < 15 = Bell 4 phenomenon rendered as a theorem about the Finpartition model rather than a hand computation, and it is exactly the divergence that makes the sibling counting statement nonCrossingCount n = catalan n non-trivial.",
+      "description": "Fintype.card_subtype_lt (x := crossing4Fp) crossing4Fp_not_isNonCrossingFp — the existence of one partition failing the predicate makes the subtype strictly smaller than the ambient Fintype."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04-oq-02` (quality 93, passes 0).

**Gap addressed (systemic missing-mainTheorems):** `leanFile.theoremCount` is 6 but `mainTheorems` was an empty array, so the gallery's *Main Theorems* section rendered empty despite six proven theorems in the source.

**Change:** populated `mainTheorems` with the 5 load-bearing results (`name`/`type`/`statement`/`significance`/`description`), taken verbatim from `Proofs/BallotProblemOQ04OQ02.lean`:
1. `isNonCrossingFp_ofSetoid_iff` — the setoid ↔ Finpartition **agreement** theorem (technical heart; certifies the Fintype-bearing model describes the same objects as the parent's setoid predicate).
2. `isNonCrossingFp_of_n_le_three` — no crossings below four points (a crossing needs 4 increasing indices).
3. `nonCrossingCount_eq_card_of_n_le_three` — non-crossing count = total partition count (Bell number) for $n \le 3$.
4. `crossing4_not_isNonCrossing` — the parity partition ${{0,2},{1,3}}$ (kernel of $\cdot\%2$) crosses: the concrete witness.
5. `nonCrossingCount_four_lt` — **the discriminator**: $n=4$ is the first strict drop, the $\mathrm{catalan}\,4 = 14 < 15 = \mathrm{Bell}\,4$ phenomenon as a theorem about the model.

Omitted only the one-line bridge `crossing4Fp_not_isNonCrossingFp` (immediate corollary of #1 and #4). `meta.json` 17.7 KB → 21.8 KB (under the 60 KB cap); no other fields touched. Axiom status unchanged (0 axioms, 0 sorries; `n=4` witness uses kernel `decide`, not `native_decide`).