### PR TITLE
Enrich Dihedral recognition / DihedralGroup.lift: add annotation depth fields

### DIFF
--- a/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/inverse-galois-d4-oq-03-incomplete-01/annotations.json
@@ -8,7 +8,22 @@
     },
     "type": "concept",
     "title": "Why the parent's Sylow route needs replacing",
-    "content": "The **parent** open question `inverse-galois-d4-oq-03` proves one concrete instance, $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$, by a **Sylow argument**: an order-$8$ subgroup of $S_4$ is a Sylow $2$-subgroup (since $8 = 2^3$ is the full $2$-part of $|S_4| = 24$), all Sylow $2$-subgroups are conjugate, and the explicit copy $\\langle (0\\,1\\,2\\,3), (1\\,3)\\rangle$ is dihedral. That route is **intrinsically special to $n = 4$** — it exploits a numerical coincidence about $|S_4|$.\n\nThe uniform Schinzel–Velez criterion for arbitrary $(n, a)$ is blocked in Lean only by the absence of **Capelli's irreducibility theorem** from Mathlib `v4.26.0`. This file isolates the part that is provable *now*: the pure group-theoretic **recognition engine**, independent of field theory and of Capelli. A prior audit of the parent flagged the concrete gap it fills — Mathlib provides `DihedralGroup n`, its multiplication table, cardinality, and order witnesses, but **no `DihedralGroup.lift`**: no constructor building a homomorphism *out of* $D_n$ from a generator pair satisfying the relations."
+    "content": "The **parent** open question `inverse-galois-d4-oq-03` proves one concrete instance, $\\mathrm{Gal}(X^4 - 2 / \\mathbb{Q}) \\cong D_4$, by a **Sylow argument**: an order-$8$ subgroup of $S_4$ is a Sylow $2$-subgroup (since $8 = 2^3$ is the full $2$-part of $|S_4| = 24$), all Sylow $2$-subgroups are conjugate, and the explicit copy $\\langle (0\\,1\\,2\\,3), (1\\,3)\\rangle$ is dihedral. That route is **intrinsically special to $n = 4$** — it exploits a numerical coincidence about $|S_4|$.\n\nThe uniform Schinzel–Velez criterion for arbitrary $(n, a)$ is blocked in Lean only by the absence of **Capelli's irreducibility theorem** from Mathlib `v4.26.0`. This file isolates the part that is provable *now*: the pure group-theoretic **recognition engine**, independent of field theory and of Capelli. A prior audit of the parent flagged the concrete gap it fills — Mathlib provides `DihedralGroup n`, its multiplication table, cardinality, and order witnesses, but **no `DihedralGroup.lift`**: no constructor building a homomorphism *out of* $D_n$ from a generator pair satisfying the relations.",
+    "significance": "context",
+    "mathContext": "$|S_4| = 24 = 2^3 \\cdot 3$, so an order-$8$ subgroup is a full Sylow $2$-subgroup — the coincidence the parent's $n=4$ proof exploits. The uniform statement is the Schinzel–Velez criterion for $\\mathrm{Gal}(X^n - a/\\mathbb{Q})$, whose Lean formalization is blocked only by the absence of Capelli's irreducibility theorem $X^n - a$ from Mathlib. The missing purely group-theoretic ingredient is a lift $D_n \\to^* G$: Mathlib has $D_n = \\langle s, t \\mid s^n = t^2 = (st)^2 = 1\\rangle$ but no constructor mapping *out* of it.",
+    "relatedConcepts": [
+      "Sylow theorems",
+      "inverse Galois problem",
+      "Capelli's irreducibility theorem",
+      "Schinzel–Velez criterion",
+      "DihedralGroup",
+      "universal property of a presentation"
+    ],
+    "prerequisites": [
+      "Sylow theory",
+      "group presentations",
+      "Galois theory of X^n − a"
+    ]
   },
   {
     "id": "ann-d4oq03inc01-rotation",
@@ -19,7 +34,21 @@
     },
     "type": "insight",
     "title": "The rotation half: σ-powers are well-defined modulo n",
-    "content": "Because $\\sigma^n = 1$, the power $\\sigma^k$ depends only on $k \\bmod n$: writing $k = (k/n)\\cdot n + (k \\bmod n)$ and collapsing the $\\sigma^n = 1$ factor gives $\\sigma^{k \\bmod n} = \\sigma^k$ (`pow_mod`). This is exactly what makes the rotation map $i \\mapsto \\sigma^{i.\\mathrm{val}}$, indexed by $i : \\mathrm{ZMod}\\ n$, well-defined.\n\nTwo consequences package it as an additive map $\\mathrm{ZMod}\\ n \\to G$: additivity $\\sigma^{(i+j).\\mathrm{val}} = \\sigma^{i.\\mathrm{val}}\\cdot\\sigma^{j.\\mathrm{val}}$ (`spow_add`, from `ZMod.val_add` + `pow_mod`) and inversion-of-negation $(\\sigma^{i.\\mathrm{val}})^{-1} = \\sigma^{(-i).\\mathrm{val}}$ (`spow_neg`). These three lemmas are the entire rotation half of the dihedral lift."
+    "content": "Because $\\sigma^n = 1$, the power $\\sigma^k$ depends only on $k \\bmod n$: writing $k = (k/n)\\cdot n + (k \\bmod n)$ and collapsing the $\\sigma^n = 1$ factor gives $\\sigma^{k \\bmod n} = \\sigma^k$ (`pow_mod`). This is exactly what makes the rotation map $i \\mapsto \\sigma^{i.\\mathrm{val}}$, indexed by $i : \\mathrm{ZMod}\\ n$, well-defined.\n\nTwo consequences package it as an additive map $\\mathrm{ZMod}\\ n \\to G$: additivity $\\sigma^{(i+j).\\mathrm{val}} = \\sigma^{i.\\mathrm{val}}\\cdot\\sigma^{j.\\mathrm{val}}$ (`spow_add`, from `ZMod.val_add` + `pow_mod`) and inversion-of-negation $(\\sigma^{i.\\mathrm{val}})^{-1} = \\sigma^{(-i).\\mathrm{val}}$ (`spow_neg`). These three lemmas are the entire rotation half of the dihedral lift.",
+    "significance": "supporting",
+    "mathContext": "$\\sigma^n = 1 \\Rightarrow \\sigma^k = \\sigma^{k \\bmod n}$, so $k \\mapsto \\sigma^k$ factors through $\\mathrm{ZMod}\\,n$. The three lemmas make $i \\mapsto \\sigma^{i.\\mathrm{val}}$ an additive-to-multiplicative map: $\\sigma^{(i+j).\\mathrm{val}} = \\sigma^{i.\\mathrm{val}}\\sigma^{j.\\mathrm{val}}$ and $(\\sigma^{i.\\mathrm{val}})^{-1} = \\sigma^{(-i).\\mathrm{val}}$, i.e. a group hom $\\mathrm{ZMod}\\,n \\to G$ onto the rotation subgroup $\\langle\\sigma\\rangle \\cong C_n$.",
+    "relatedConcepts": [
+      "cyclic group C_n",
+      "ZMod n",
+      "order of an element",
+      "modular exponentiation",
+      "ZMod.val_add"
+    ],
+    "prerequisites": [
+      "ZMod.val",
+      "modular arithmetic",
+      "pow_eq_pow_iff_of_order"
+    ]
   },
   {
     "id": "ann-d4oq03inc01-commutation",
@@ -30,7 +59,20 @@
     },
     "type": "insight",
     "title": "One commutation identity drives every mixed product",
-    "content": "From the single relation $\\tau\\sigma = \\sigma^{-1}\\tau$, an induction on $m$ yields $\\sigma^m\\tau = \\tau(\\sigma^m)^{-1}$ (`sigma_pow_mul_tau`): the reflection conjugates each rotation power to its inverse. This one identity, together with the periodicity of §1, computes both mixed products in the dihedral normal form $\\tau^\\varepsilon\\sigma^k$:\n\n- **rotation · reflection** (`rot_mul_refl`): $\\sigma^{i}\\,(\\tau\\sigma^{j}) = \\tau\\,\\sigma^{j-i}$;\n- **reflection · reflection** (`refl_mul_refl`): $(\\tau\\sigma^{i})(\\tau\\sigma^{j}) = \\sigma^{j-i}$.\n\nThe reflection relation $\\tau^2 = 1$ is used in **exactly one place** — cancelling the two $\\tau$'s in `refl_mul_refl`. This cleanly separates the three dihedral relations by role: $\\sigma^n = 1$ governs rotations, $\\tau\\sigma = \\sigma^{-1}\\tau$ governs commutation, $\\tau^2 = 1$ governs reflection composition."
+    "content": "From the single relation $\\tau\\sigma = \\sigma^{-1}\\tau$, an induction on $m$ yields $\\sigma^m\\tau = \\tau(\\sigma^m)^{-1}$ (`sigma_pow_mul_tau`): the reflection conjugates each rotation power to its inverse. This one identity, together with the periodicity of §1, computes both mixed products in the dihedral normal form $\\tau^\\varepsilon\\sigma^k$:\n\n- **rotation · reflection** (`rot_mul_refl`): $\\sigma^{i}\\,(\\tau\\sigma^{j}) = \\tau\\,\\sigma^{j-i}$;\n- **reflection · reflection** (`refl_mul_refl`): $(\\tau\\sigma^{i})(\\tau\\sigma^{j}) = \\sigma^{j-i}$.\n\nThe reflection relation $\\tau^2 = 1$ is used in **exactly one place** — cancelling the two $\\tau$'s in `refl_mul_refl`. This cleanly separates the three dihedral relations by role: $\\sigma^n = 1$ governs rotations, $\\tau\\sigma = \\sigma^{-1}\\tau$ governs commutation, $\\tau^2 = 1$ governs reflection composition.",
+    "significance": "key",
+    "mathContext": "The braid relation $\\tau\\sigma = \\sigma^{-1}\\tau$ induces $\\sigma^m\\tau = \\tau\\sigma^{-m}$ by induction on $m$ — reflection conjugates each rotation to its inverse. Every element of $D_n$ has the normal form $\\tau^{\\varepsilon}\\sigma^k$ ($\\varepsilon \\in \\{0,1\\}$); this identity reduces the two mixed products to normal form: $\\sigma^i(\\tau\\sigma^j) = \\tau\\sigma^{j-i}$ and $(\\tau\\sigma^i)(\\tau\\sigma^j) = \\sigma^{j-i}$, with $\\tau^2 = 1$ used exactly once.",
+    "relatedConcepts": [
+      "dihedral relations",
+      "conjugation",
+      "normal form of dihedral elements",
+      "semidirect product C_n ⋊ C_2",
+      "braid/commutation relation"
+    ],
+    "prerequisites": [
+      "induction on exponents",
+      "group relation manipulation"
+    ]
   },
   {
     "id": "ann-d4oq03inc01-lift",
@@ -41,7 +83,21 @@
     },
     "type": "proof-step",
     "title": "liftHom — the missing DihedralGroup.lift, proved without `decide`",
-    "content": "`liftHom : DihedralGroup n →* G` sends $r\\,i \\mapsto \\sigma^{i.\\mathrm{val}}$ and $sr\\,i \\mapsto \\tau\\,\\sigma^{i.\\mathrm{val}}$. `map_one'` is immediate; `map_mul'` is a **four-case match** on the constructors of $D_n$ — $r\\cdot r$, $r\\cdot sr$, $sr\\cdot r$, $sr\\cdot sr$ — each discharged by the corresponding Mathlib multiplication simp lemma (`r_mul_r`, `r_mul_sr`, `sr_mul_r`, `sr_mul_sr`) followed by a §1–§3 law.\n\nThe decisive design point: **none of this is a finite `decide`.** The homomorphism law is proved from the abstract relations, so `liftHom` works for an *arbitrary* carrier group $G$ — not merely a finite permutation group $S_k$ where a `decide` would be available. That is precisely what makes it the reusable constructor Mathlib lacks. The two `@[simp]` lemmas `liftHom_r_one : \\mathrm{liftHom}(r\\,1) = \\sigma$ and `liftHom_sr_zero : \\mathrm{liftHom}(sr\\,0) = \\tau$ pin the generator images for the recognition step."
+    "content": "`liftHom : DihedralGroup n →* G` sends $r\\,i \\mapsto \\sigma^{i.\\mathrm{val}}$ and $sr\\,i \\mapsto \\tau\\,\\sigma^{i.\\mathrm{val}}$. `map_one'` is immediate; `map_mul'` is a **four-case match** on the constructors of $D_n$ — $r\\cdot r$, $r\\cdot sr$, $sr\\cdot r$, $sr\\cdot sr$ — each discharged by the corresponding Mathlib multiplication simp lemma (`r_mul_r`, `r_mul_sr`, `sr_mul_r`, `sr_mul_sr`) followed by a §1–§3 law.\n\nThe decisive design point: **none of this is a finite `decide`.** The homomorphism law is proved from the abstract relations, so `liftHom` works for an *arbitrary* carrier group $G$ — not merely a finite permutation group $S_k$ where a `decide` would be available. That is precisely what makes it the reusable constructor Mathlib lacks. The two `@[simp]` lemmas `liftHom_r_one : \\mathrm{liftHom}(r\\,1) = \\sigma$ and `liftHom_sr_zero : \\mathrm{liftHom}(sr\\,0) = \\tau$ pin the generator images for the recognition step.",
+    "significance": "key",
+    "mathContext": "$\\mathrm{liftHom} : D_n \\to^* G$, $\\; r\\,i \\mapsto \\sigma^{i.\\mathrm{val}}, \\; sr\\,i \\mapsto \\tau\\sigma^{i.\\mathrm{val}}$. This realizes the universal property of the dihedral presentation: any $(\\sigma,\\tau)$ satisfying $\\sigma^n = \\tau^2 = 1,\\ \\tau\\sigma = \\sigma^{-1}\\tau$ extends uniquely to a homomorphism out of $D_n$. The multiplicativity $\\mathrm{map\\_mul}'$ is a $2\\times 2$ case split on the constructors $r/sr$, each closed by §1–§3 laws — crucially *not* a finite `decide`, so it holds for an arbitrary carrier $G$.",
+    "relatedConcepts": [
+      "MonoidHom",
+      "universal property of a group presentation",
+      "DihedralGroup constructors r/sr",
+      "free group / relations",
+      "von Dyck's theorem"
+    ],
+    "prerequisites": [
+      "MonoidHom.mk",
+      "DihedralGroup multiplication (r_mul_r, r_mul_sr, sr_mul_r, sr_mul_sr)",
+      "map_mul'"
+    ]
   },
   {
     "id": "ann-d4oq03inc01-recognition",
@@ -52,6 +108,20 @@
     },
     "type": "key-result",
     "title": "The recognition theorem: generation + order match ⟹ D_n",
-    "content": "`nonempty_mulEquiv_dihedralGroup` is the payoff. For a **finite** $G$ carrying generators $\\sigma, \\tau$ with the dihedral relations, if additionally $\\langle \\sigma, \\tau\\rangle = G$ (`Subgroup.closure {σ, τ} = ⊤`) and $|G| = 2n$ with $n \\ge 2$, then $G \\cong D_n$.\n\nThe proof is short because it buys injectivity for free:\n\n1. **Surjectivity** of `liftHom` from generation: its range is a subgroup containing both $\\sigma = \\mathrm{liftHom}(r\\,1)$ and $\\tau = \\mathrm{liftHom}(sr\\,0)$, hence contains $\\langle\\sigma,\\tau\\rangle = G$, so it is $\\top$.\n2. **Bijectivity** from the order match: $\\mathrm{Fintype.card}(D_n) = 2n = \\mathrm{Nat.card}\\ G$, so `Fintype.bijective_iff_surjective_and_card` promotes the surjection to a bijection — **no kernel computation, no hand-checked injectivity**.\n3. `MulEquiv.ofBijective … |>.symm` delivers $G \\simeq^* D_n$.\n\nThis is the $n$-uniform tool: any Galois group $\\mathrm{Gal}(X^n - a / \\mathbb{Q})$ exhibited with a rotation/reflection generating pair of the right order is identified as $D_n$ with no further group theory — replacing the parent's $n=4$-specific Sylow argument."
+    "content": "`nonempty_mulEquiv_dihedralGroup` is the payoff. For a **finite** $G$ carrying generators $\\sigma, \\tau$ with the dihedral relations, if additionally $\\langle \\sigma, \\tau\\rangle = G$ (`Subgroup.closure {σ, τ} = ⊤`) and $|G| = 2n$ with $n \\ge 2$, then $G \\cong D_n$.\n\nThe proof is short because it buys injectivity for free:\n\n1. **Surjectivity** of `liftHom` from generation: its range is a subgroup containing both $\\sigma = \\mathrm{liftHom}(r\\,1)$ and $\\tau = \\mathrm{liftHom}(sr\\,0)$, hence contains $\\langle\\sigma,\\tau\\rangle = G$, so it is $\\top$.\n2. **Bijectivity** from the order match: $\\mathrm{Fintype.card}(D_n) = 2n = \\mathrm{Nat.card}\\ G$, so `Fintype.bijective_iff_surjective_and_card` promotes the surjection to a bijection — **no kernel computation, no hand-checked injectivity**.\n3. `MulEquiv.ofBijective … |>.symm` delivers $G \\simeq^* D_n$.\n\nThis is the $n$-uniform tool: any Galois group $\\mathrm{Gal}(X^n - a / \\mathbb{Q})$ exhibited with a rotation/reflection generating pair of the right order is identified as $D_n$ with no further group theory — replacing the parent's $n=4$-specific Sylow argument.",
+    "significance": "key",
+    "mathContext": "Recognition theorem: for finite $G$ with $\\sigma,\\tau$ satisfying the dihedral relations, if $\\langle\\sigma,\\tau\\rangle = G$ and $|G| = 2n$ with $n \\ge 2$, then $G \\cong D_n$. Surjectivity of $\\mathrm{liftHom}$ follows from generation; the cardinality match $\\mathrm{card}(D_n) = 2n = \\mathrm{card}\\,G$ upgrades surjectivity to bijectivity via $\\texttt{Fintype.bijective\\_iff\\_surjective\\_and\\_card}$ — no kernel computation. This is the $n$-uniform replacement for the parent's $n=4$ Sylow argument.",
+    "relatedConcepts": [
+      "MulEquiv",
+      "Subgroup.closure",
+      "pigeonhole for finite maps",
+      "inverse Galois problem",
+      "Fintype.card"
+    ],
+    "prerequisites": [
+      "Subgroup.closure = ⊤",
+      "Fintype.bijective_iff_surjective_and_card",
+      "MulEquiv.ofBijective"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `inverse-galois-d4-oq-03-incomplete-01` (quality 70, passes 1; freshly created by researcher-14 in #34016).

**Gap addressed:** all 5 annotations carried rich `content`/`title`/`range` but were **missing every enrichment field the gallery renders** — `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` were absent on all of them. This is the depth gap behind the quality-70 score.

**Change:** added all four fields to each of the 5 annotations, with LaTeX `mathContext` drawn directly from the Lean source:
| annotation | significance | mathContext focus |
|---|---|---|
| overview | `context` | $|S_4|=24=2^3\cdot3$ Sylow coincidence; Capelli / Schinzel–Velez blocker |
| rotation | `supporting` | $\sigma^k=\sigma^{k\bmod n}$; the $\mathrm{ZMod}\,n\to G$ rotation map |
| commutation | `key` | braid relation $\Rightarrow \sigma^m\tau=\tau\sigma^{-m}$; dihedral normal form |
| lift | `key` | universal property of the $D_n$ presentation; carrier-agnostic (no `decide`) |
| recognition | `key` | generation + $|G|=2n \Rightarrow G\cong D_n$ via card-match bijectivity |

Annotation `content`, `title`, `range`, and `type` are **unchanged**; `meta.json` untouched. Verified status intact (0 axioms, 0 sorries).