### PR TITLE
Research: lovasz-local-lemma-oq-01 - conditional-probability chain rule for avoidance

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01ChainRule.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01ChainRule.lean
@@ -1,0 +1,150 @@
+/-
+# Lovász Local Lemma — OQ-01: Conditional-Probability Chain Rule for Avoidance
+
+The gallery proof `LovaszLocalLemma.lean` develops the *symmetric* LLL entirely
+over `ℚ` as a combinatorial-budget surrogate; its `general_lll` only records the
+elementary fact `∏ (1 - xᵢ) > 0`. The authoritative OQ-01 goal is the genuine
+**measure-theoretic** LLL over a real probability space, where the content is the
+inequality `μ (⋂ᵢ Aᵢᶜ) ≥ ∏ (1 - xᵢ) > 0` — the *avoidance probability* is
+positive. `LovaszLocalLemmaOQ01.lean` lands the `d = 0` (mutually independent)
+base case; `LovaszLocalLemmaOQ01UnionBound.lean` lands the dependency-free
+first-moment extreme.
+
+This file lands the **exact skeleton of the general LLL induction**: the
+*conditional-probability chain rule* for a finite ordered family of events,
+
+  `μ (⋂ᵢ Aᵢ) = ∏ₖ μ[Aₖ | ⋂_{j<k} Aⱼ]`,
+
+which holds for **any** measurable family over **any** probability measure — no
+independence, no dependency graph, no LLL hypothesis. Specialised to the
+complements it gives the *survival-probability product form*
+
+  `μ (⋂ᵢ Aᵢᶜ) = ∏ₖ μ[Aₖᶜ | ⋂_{j<k} Aⱼᶜ]`,
+
+and hence the **avoidance-positivity criterion**: the events can be avoided
+simultaneously with positive probability **iff** every conditional survival
+probability `μ[Aₖᶜ | ⋂_{j<k} Aⱼᶜ]` is nonzero. This is precisely the reduction
+that the Lovász Local Lemma discharges: the LLL induction's entire job is to
+prove each conditional failure probability `μ[Aₖ | ⋂_{j<k} Aⱼᶜ]` bounded below 1
+(equivalently, each survival probability positive), and this file supplies the
+measure-theoretic bridge from that per-event bound to the global conclusion.
+
+## Main results
+
+* `cond_chain_avoidance` : the chain rule `μ (⋂ i∈range n, A i) =
+  ∏ k∈range n, μ[A k | ⋂ j∈range k, A j]`, for an arbitrary measurable family
+  over a probability measure.
+* `avoidance_eq_prod_survival_cond` : the complement/survival form
+  `μ (⋂ i∈range n, (A i)ᶜ) = ∏ k∈range n, μ[(A k)ᶜ | ⋂ j∈range k, (A j)ᶜ]`.
+* `avoidance_pos_iff` : `0 < μ (⋂ i∈range n, (A i)ᶜ)` **iff** every survival
+  conditional is nonzero — the LLL reduction target.
+* `survival_cond_eq_one_sub` : on a positive-measure history the survival
+  conditional is `1 - ` the failure conditional, connecting the criterion to the
+  usual LLL bound `μ[A k | history] < 1`.
+* `avoidance_pos_of_failure_cond_lt_one` : if every history has positive measure
+  and every conditional failure probability is `< 1`, avoidance is positive —
+  the exact shape the LLL induction produces.
+
+Everything is `Finset.range`-indexed (an explicit total order on the events, as
+the chain rule requires) and lives over an arbitrary `IsProbabilityMeasure`.
+No independence hypothesis is used anywhere.
+-/
+import Mathlib.Probability.ConditionalProbability
+
+open MeasureTheory ProbabilityTheory Finset
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01ChainRule
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A : ℕ → Set Ω}
+
+/-- Each finite history is measurable (a finite intersection of measurable sets). -/
+theorem measurableSet_hist (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :
+    MeasurableSet (⋂ j ∈ Finset.range n, A j) :=
+  Finset.measurableSet_biInter _ (fun b _ => hA b)
+
+/-- **Conditional-probability chain rule (avoidance skeleton of the LLL).**
+For an arbitrary measurable family `A : ℕ → Set Ω` over a probability measure, the
+probability of the intersection of the first `n` events factors as the product of
+the conditional probabilities of each event given all earlier ones:
+
+  `μ (⋂ i∈range n, A i) = ∏ k∈range n, μ[A k | ⋂ j∈range k, A j]`.
+
+No independence is assumed — this is the pure chain rule, the exact identity the
+Lovász Local Lemma induction fills in term by term. -/
+theorem cond_chain_avoidance (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :
+    μ (⋂ i ∈ Finset.range n, A i)
+      = ∏ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, A j] := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    -- history at `n+1` splits off the newest event `A n`
+    have hsplit : (⋂ i ∈ Finset.range (n + 1), A i)
+        = (⋂ i ∈ Finset.range n, A i) ∩ A n := by
+      rw [Finset.range_add_one]
+      rw [Finset.set_biInter_insert, Set.inter_comm]
+    rw [hsplit, Finset.prod_range_succ, ← ih]
+    -- the telescoping step: μ(history ∩ A n) = μ(history) · μ[A n | history]
+    rw [mul_comm]
+    exact (cond_mul_eq_inter (measurableSet_hist hA n) (A n) μ).symm
+
+/-- **Survival-probability product form.**
+Applying the chain rule to the complements gives the avoidance probability as a
+product of conditional *survival* probabilities:
+
+  `μ (⋂ i∈range n, (A i)ᶜ) = ∏ k∈range n, μ[(A k)ᶜ | ⋂ j∈range k, (A j)ᶜ]`.
+
+This is the genuine measure-theoretic LLL identity (the honest analogue of the
+rational surrogate's `∏ (1 - xᵢ)`): the avoidance probability is exactly the
+product of per-event conditional survival probabilities. -/
+theorem avoidance_eq_prod_survival_cond (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :
+    μ (⋂ i ∈ Finset.range n, (A i)ᶜ)
+      = ∏ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] :=
+  cond_chain_avoidance (fun i => (hA i).compl) n
+
+/-- **Avoidance-positivity criterion (the LLL reduction target).**
+The first `n` events can be avoided simultaneously with strictly positive
+probability **iff** every conditional survival probability is nonzero. Since the
+avoidance probability is the product of these conditionals (over a probability
+measure they are automatically finite, `≤ 1`), positivity of the product is
+equivalent to nonvanishing of each factor. The Lovász Local Lemma's role is
+exactly to certify the right-hand side. -/
+theorem avoidance_pos_iff (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :
+    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ)
+      ↔ ∀ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≠ 0 := by
+  rw [avoidance_eq_prod_survival_cond hA, zero_lt_iff, Finset.prod_ne_zero_iff]
+
+/-- On a positive-measure history the conditional *survival* probability is the
+complement of the conditional *failure* probability:
+`μ[(A k)ᶜ | history] = 1 - μ[A k | history]`. This is the bridge from the usual
+LLL bound (each conditional failure probability `< 1`) to the survival-positivity
+form used by `avoidance_pos_iff`. Requires the history to have positive measure,
+so that conditioning yields a genuine probability measure. -/
+theorem survival_cond_eq_one_sub (hA : ∀ i, MeasurableSet (A i)) (k : ℕ)
+    (hpos : μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0) :
+    μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ]
+      = 1 - μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] := by
+  haveI : IsProbabilityMeasure (μ[|⋂ j ∈ Finset.range k, (A j)ᶜ]) :=
+    cond_isProbabilityMeasure hpos
+  exact prob_compl_eq_one_sub (hA k)
+
+/-- **Sufficient LLL avoidance condition.**
+If every conditional failure probability `μ[A k | ⋂_{j<k} (A j)ᶜ]` is `< 1` and
+every history has positive measure, then all events are avoided with positive
+probability. This is precisely the shape the LLL induction delivers: the
+induction certifies each conditional failure probability bounded below 1 (in the
+symmetric regime, `≤ 2p < 1` under `e·p·(d+1) ≤ 1`), from which global avoidance
+positivity follows via the survival product. -/
+theorem avoidance_pos_of_failure_cond_lt_one (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)
+    (hpos : ∀ k ∈ Finset.range n, μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0)
+    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] < 1) :
+    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by
+  rw [avoidance_pos_iff hA]
+  intro k hk
+  rw [survival_cond_eq_one_sub hA k (hpos k hk)]
+  -- `1 - c ≠ 0` for `c < 1` in `ℝ≥0∞`
+  rw [Ne, tsub_eq_zero_iff_le, not_le]
+  exact hfail k hk
+
+end LovaszLocalLemmaOQ01ChainRule

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -94,3 +94,42 @@ Insights accumulated during research on this problem.
   multiple sessions. (Update 2026-07-02: the *independent* `d = 0` base case is
   now done and verified; only the bounded-dependency-degree inductive step
   remains open.)
+
+### Chain-rule scaffold (researcher-6, 2026-07-02) — NEW
+
+- **The conditional-probability chain rule is the independence-free skeleton of
+  the LLL induction, and it is fully provable now.** New file
+  `Proofs/LovaszLocalLemmaOQ01ChainRule.lean` (0 sorry / 0 axiom), gallery entry
+  `lovasz-local-lemma-oq-01-chain-rule`: for an arbitrary measurable family
+  `A : ℕ → Set Ω` over any `IsProbabilityMeasure`,
+  `μ (⋂ i∈range n, A i) = ∏ k∈range n, μ[A k | ⋂ j∈range k, A j]`
+  (`cond_chain_avoidance`). No independence, no dependency graph, no LLL bound.
+- **Route (pure telescoping, no positivity side conditions).** Induction on `n`;
+  the history at `n+1` splits off the newest event via `Finset.range_add_one` +
+  `Finset.set_biInter_insert` + `Set.inter_comm`; the one-step multiplication
+  rule `cond_mul_eq_inter : μ[t|s]·μ s = μ(s∩t)` (holds even when `μ s = 0`)
+  extends the product, and `Finset.prod_range_succ` absorbs the new factor. Base
+  case `μ univ = 1 = ∏∅`. Histories are measurable via
+  `Finset.measurableSet_biInter`.
+- **Survival/avoidance form + criterion.** Instantiating at the complements
+  (`avoidance_eq_prod_survival_cond`) gives
+  `μ(⋂ (A i)ᶜ) = ∏ k, μ[(A k)ᶜ | ⋂_{j<k}(A j)ᶜ]` — the honest measure-theoretic
+  analogue of the rational surrogate `∏(1 − xᵢ)`. Then `avoidance_pos_iff`:
+  `0 < μ(⋂ (A i)ᶜ) ↔ ∀ k, μ[(A k)ᶜ | history] ≠ 0` (finite ℝ≥0∞ product positive
+  iff no factor vanishes, via `zero_lt_iff` + `Finset.prod_ne_zero_iff`). This is
+  the exact reduction the LLL discharges.
+- **Bridge to the standard LLL bound.** `survival_cond_eq_one_sub`: on a
+  positive-measure history, `cond_isProbabilityMeasure` makes conditioning a prob
+  measure, so `μ[(A k)ᶜ | history] = 1 − μ[A k | history]` (`prob_compl_eq_one_sub`).
+  `avoidance_pos_of_failure_cond_lt_one`: history positive ∧ each failure
+  conditional `< 1` ⇒ avoidance positive — the exact shape the LLL induction
+  produces (symmetric regime: `μ[A k|history] ≤ 2p < 1` under `e·p·(d+1) ≤ 1`).
+- **What remains open, sharpened.** The scaffold isolates precisely the missing
+  ingredient: a strong-induction bound `μ[A i | ⋂_{j∈S} A_jᶜ] ≤ 2p` (equivalently
+  each conditional survival `≥ 1 − 2p > 0`) for all `i, S`, under a
+  measure-theoretic dependency (conditional independence of `A i` from
+  non-neighbours). Plug that into `avoidance_pos_of_failure_cond_lt_one`.
+- **Key API note.** `Finset.range_succ` is deprecated → use `Finset.range_add_one`.
+  `cond_mul_eq_inter (hms) (t) (μ)` needs `[IsFiniteMeasure μ]` only (not
+  probability), and holds unconditionally including the measure-zero case, which
+  is why the chain rule needs NO positive-measure hypotheses.

--- a/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-lll-oq01-cr-overview",
+    "proofId": "lovasz-local-lemma-oq-01-chain-rule",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "The measure-theoretic scaffold shared by every LLL proof",
+    "content": "Open question OQ-01 asks for the genuine **measure-theoretic** Lovász Local Lemma: bad events as measurable sets $A_i \\subseteq \\Omega$ in a real `IsProbabilityMeasure`, conclusion $\\mu(\\bigcap_i A_i^c) > 0$. The gallery already has the two *computable extremes* — the mutually independent case `lovasz-local-lemma-oq-01` (exact product $\\prod(1 - \\mu(A_i))$) and the dependency-free union bound `lovasz-local-lemma-oq-01-union-bound` ($\\mu(\\bigcap A_i^c) \\ge 1 - \\sum \\mu(A_i)$). What both extremes, and the still-open bounded-degree LLL, quietly share is a single **independence-free** identity: the conditional-probability chain rule\n$$\\mu\\!\\left(\\bigcap_{i} A_i\\right) = \\prod_{k} \\mu\\!\\left[A_k \\;\\middle|\\; \\bigcap_{j<k} A_j\\right].$$\nRead at the complements it becomes the survival-product form, and it converts the LLL's global question 'can every bad event be avoided?' into the purely local question 'is every conditional survival probability positive?'. This file isolates that scaffold. The mathematical work the LLL actually does — bounding each conditional factor using the dependency structure — is precisely what is *not* here; the chain rule is the frame that work fills in.",
+    "mathContext": "Arbitrary measurable family $A : \\mathbb{N} \\to \\mathrm{Set}\\,\\Omega$ over an `IsProbabilityMeasure` $\\mu$. The $\\mathbb{N}$-index supplies the total order the chain rule needs; no independence, no dependency graph, no LLL hypothesis.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "conditional probability",
+      "chain rule / multiplication rule",
+      "avoidance probability",
+      "measure-theoretic probability"
+    ],
+    "prerequisites": [
+      "measure-theoretic probability",
+      "conditional probability μ[t|s]",
+      "lovasz-local-lemma-oq-01 (independent base case)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-cr-setup",
+    "proofId": "lovasz-local-lemma-oq-01-chain-rule",
+    "range": {
+      "startLine": 52,
+      "endLine": 74
+    },
+    "type": "context",
+    "title": "Frame: probability measure, ℕ-ordered events, measurable histories",
+    "content": "```lean\nimport Mathlib.Probability.ConditionalProbability\nopen MeasureTheory ProbabilityTheory Finset\nopen scoped ENNReal\nnamespace LovaszLocalLemmaOQ01ChainRule\nvariable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]\nvariable {A : ℕ → Set Ω}\n\ntheorem measurableSet_hist (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :\n    MeasurableSet (⋂ j ∈ Finset.range n, A j) :=\n  Finset.measurableSet_biInter _ (fun b _ => hA b)\n```\n\nTwo design choices carry the file. Indexing the events by $\\mathbb{N}$ (rather than a `Fintype` as in the two extreme entries) is deliberate: the chain rule requires a *total order* on the events — 'each event conditioned on the earlier ones' — and `Finset.range n` is the canonical prefix order that makes the induction and `Finset.prod_range_succ` line up. The **history** $\\bigcap_{j \\in \\mathrm{range}\\,k} A_j$ is the conditioning event at step $k$; `measurableSet_hist` records that it is measurable, being a *finite* intersection of measurable sets (`Finset.measurableSet_biInter`). Measurability of the history is exactly the side condition Mathlib's telescoping lemma `cond_mul_eq_inter` needs, so this one-line lemma is what lets the main induction fire at every step.",
+    "mathContext": "`μ[t|s]` denotes `ProbabilityTheory.cond μ s t`. Histories are finite intersections over `Finset.range k`, hence measurable; `IsProbabilityMeasure` gives $\\mu(\\Omega) = 1$, used for the base case of the chain rule.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conditional probability cond μ s t",
+      "measurable finite intersection",
+      "Finset.range prefix order",
+      "probability measure"
+    ],
+    "prerequisites": [
+      "measurability of finite intersections",
+      "conditional probability notation"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-cr-chainrule",
+    "proofId": "lovasz-local-lemma-oq-01-chain-rule",
+    "range": {
+      "startLine": 75,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "The chain rule: μ(⋂ Aᵢ) = ∏ μ[Aₖ | earlier], by telescoping",
+    "content": "```lean\ntheorem cond_chain_avoidance (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :\n    μ (⋂ i ∈ Finset.range n, A i)\n      = ∏ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, A j] := by\n  induction n with\n  | zero => simp\n  | succ n ih =>\n    have hsplit : (⋂ i ∈ Finset.range (n + 1), A i)\n        = (⋂ i ∈ Finset.range n, A i) ∩ A n := by\n      rw [Finset.range_add_one]; rw [Finset.set_biInter_insert, Set.inter_comm]\n    rw [hsplit, Finset.prod_range_succ, ← ih]\n    rw [mul_comm]\n    exact (cond_mul_eq_inter (measurableSet_hist hA n) (A n) μ).symm\n```\n\nThe engine is Mathlib's one-step multiplication rule `cond_mul_eq_inter`: $\\mu[t \\mid s]\\cdot \\mu(s) = \\mu(s \\cap t)$, valid for any finite measure and — crucially — *even when $\\mu(s) = 0$* (both sides vanish), so no positivity side condition is needed. The induction peels off the newest event: the history at $n+1$ is the history at $n$ intersected with $A_n$ (`Finset.range_add_one` then `Set.biInter_insert`), and `cond_mul_eq_inter` with $s = $ history, $t = A_n$ turns $\\mu(\\text{history} \\cap A_n)$ into $\\mu(\\text{history})\\cdot\\mu[A_n \\mid \\text{history}]$. The induction hypothesis rewrites $\\mu(\\text{history})$ as the length-$n$ product, and `Finset.prod_range_succ` absorbs the new factor. The base case is $\\mu(\\Omega) = 1 = $ empty product. **No independence anywhere** — this is the pure telescoping identity, the exact frame the LLL induction fills in one factor at a time.",
+    "mathContext": "Chain / multiplication rule $\\mu(A_1 \\cap \\cdots \\cap A_n) = \\prod_{k} \\mu[A_k \\mid A_1 \\cap \\cdots \\cap A_{k-1}]$. Because `cond_mul_eq_inter` holds unconditionally in $\\mathbb{R}_{\\ge 0}^\\infty$, the identity needs no positive-measure hypotheses.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "chain rule for probabilities",
+      "telescoping product",
+      "cond_mul_eq_inter",
+      "induction on Finset.range"
+    ],
+    "prerequisites": [
+      "conditional probability multiplication rule",
+      "Finset.prod_range_succ",
+      "Set.biInter_insert"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-cr-survival",
+    "proofId": "lovasz-local-lemma-oq-01-chain-rule",
+    "range": {
+      "startLine": 92,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Survival product and the avoidance-positivity criterion",
+    "content": "```lean\ntheorem avoidance_eq_prod_survival_cond (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :\n    μ (⋂ i ∈ Finset.range n, (A i)ᶜ)\n      = ∏ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] :=\n  cond_chain_avoidance (fun i => (hA i).compl) n\n\ntheorem avoidance_pos_iff (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) :\n    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ)\n      ↔ ∀ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≠ 0 := by\n  rw [avoidance_eq_prod_survival_cond hA, zero_lt_iff, Finset.prod_ne_zero_iff]\n```\n\nThe LLL is a statement about *avoidance*, so the useful form applies the chain rule to the **complements** $A_i^c$ (measurable via `.compl`): the avoidance probability equals the product of conditional *survival* probabilities $\\mu[A_k^c \\mid \\bigcap_{j<k} A_j^c]$. This is the honest measure-theoretic replacement for the parent proof's rational surrogate $\\prod(1 - x_i)$ — each factor is a genuine conditional survival probability, not an abstract weight. The payoff is `avoidance_pos_iff`: a finite product in $\\mathbb{R}_{\\ge 0}^\\infty$ is positive **iff** no factor is zero (`zero_lt_iff` + `Finset.prod_ne_zero_iff`), so global avoidance positivity reduces to the *per-event* condition that every conditional survival probability is nonzero. This is the reduction the Lovász Local Lemma discharges: prove each local factor positive, and $\\mu(\\bigcap A_i^c) > 0$ follows automatically.",
+    "mathContext": "$\\mu(\\bigcap_i A_i^c) = \\prod_k \\mu[A_k^c \\mid \\bigcap_{j<k} A_j^c]$; in $\\mathbb{R}_{\\ge 0}^\\infty$ a finite product is positive iff every factor is nonzero, giving $0 < \\mu(\\bigcap A_i^c) \\iff \\forall k,\\ \\mu[A_k^c \\mid \\text{history}] \\ne 0$.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "survival probability",
+      "avoidance probability",
+      "Finset.prod_ne_zero_iff",
+      "reduction to per-event bounds"
+    ],
+    "prerequisites": [
+      "chain rule (previous section)",
+      "product positivity in ℝ≥0∞"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-cr-bridge",
+    "proofId": "lovasz-local-lemma-oq-01-chain-rule",
+    "range": {
+      "startLine": 118,
+      "endLine": 150
+    },
+    "type": "insight",
+    "title": "Bridge to the standard LLL bound: survival = 1 − failure",
+    "content": "```lean\ntheorem survival_cond_eq_one_sub (hA : ∀ i, MeasurableSet (A i)) (k : ℕ)\n    (hpos : μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0) :\n    μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ]\n      = 1 - μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] := by\n  haveI : IsProbabilityMeasure (μ[|⋂ j ∈ Finset.range k, (A j)ᶜ]) :=\n    cond_isProbabilityMeasure hpos\n  exact prob_compl_eq_one_sub (hA k)\n\ntheorem avoidance_pos_of_failure_cond_lt_one (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)\n    (hpos : ∀ k ∈ Finset.range n, μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0)\n    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] < 1) :\n    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by\n  rw [avoidance_pos_iff hA]; intro k hk\n  rw [survival_cond_eq_one_sub hA k (hpos k hk)]\n  rw [Ne, tsub_eq_zero_iff_le, not_le]; exact hfail k hk\n```\n\nThe LLL literature always bounds the conditional *failure* probability $\\mu[A_k \\mid \\text{history}] < 1$ (symmetrically, $\\le 2p$ under $e\\,p\\,(d+1) \\le 1$). `survival_cond_eq_one_sub` translates that into the *survival* form the criterion wants: on a **positive-measure** history, conditioning yields a genuine probability measure (`cond_isProbabilityMeasure`), so `prob_compl_eq_one_sub` gives $\\mu[A_k^c \\mid \\text{history}] = 1 - \\mu[A_k \\mid \\text{history}]$. Then `avoidance_pos_of_failure_cond_lt_one` closes the loop: failure conditional $< 1$ makes the survival conditional nonzero (`tsub_eq_zero_iff_le`), and `avoidance_pos_iff` upgrades all these per-event bounds to global avoidance positivity. The positive-measure hypotheses are **not** artifacts to hide: if a history $\\bigcap_{j<k} A_j^c$ had measure zero the whole avoidance probability would already be zero. A real LLL induction produces both the failure bound and the history positivity by the same argument, so these hypotheses are exactly what the LLL delivers — stated honestly here rather than assumed away.",
+    "mathContext": "On a positive-measure history, $\\mu[A_k^c \\mid \\text{history}] = 1 - \\mu[A_k \\mid \\text{history}]$; a failure conditional $< 1$ then gives a nonzero survival conditional, and the criterion yields $0 < \\mu(\\bigcap A_i^c)$. This is the exact interface a bounded-dependency-degree LLL proof plugs into.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "conditional failure probability",
+      "cond_isProbabilityMeasure",
+      "prob_compl_eq_one_sub",
+      "LLL induction interface"
+    ],
+    "prerequisites": [
+      "conditioning yields a probability measure",
+      "complement law in a probability measure",
+      "truncated subtraction tsub_eq_zero_iff_le"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-chain-rule/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "lovasz-local-lemma-oq-01-chain-rule",
+  "title": "Lovász Local Lemma OQ-01: Conditional-Probability Chain Rule for Avoidance",
+  "slug": "lovasz-local-lemma-oq-01-chain-rule",
+  "description": "The measure-theoretic skeleton of the Lovász Local Lemma induction. For an arbitrary measurable family of events A : ℕ → Set Ω over a real IsProbabilityMeasure — no independence, no dependency graph, no LLL hypothesis — the probability of a finite intersection factors as the product of conditional probabilities of each event given all earlier ones: μ(⋂ i∈range n, A i) = ∏ k∈range n, μ[A k | ⋂ j∈range k, A j]. Specialised to the complements this gives the survival-product form μ(⋂ i, (A i)ᶜ) = ∏ k, μ[(A k)ᶜ | ⋂ j<k, (A j)ᶜ], and hence the avoidance-positivity criterion: the events can be simultaneously avoided with positive probability iff every conditional survival probability is nonzero. This is precisely the reduction the LLL discharges — the LLL induction's entire job is to certify each conditional failure probability μ[A k | history] bounded below 1, and this entry supplies the measure-theoretic bridge from that per-event bound to the global avoidance conclusion. Complements the two computable extremes already in the gallery (the independent d=0 base case lovasz-local-lemma-oq-01 and the dependency-free union bound lovasz-local-lemma-oq-01-union-bound) by providing the general chain-rule scaffold that any LLL proof, at any dependency degree, must instantiate. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01ChainRule.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "conditional-probability",
+      "chain-rule"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used). IsProbabilityMeasure is an explicit hypothesis. The chain rule cond_chain_avoidance and its complement form avoidance_eq_prod_survival_cond and criterion avoidance_pos_iff are unconditional (no independence, no positive-measure side condition). survival_cond_eq_one_sub and avoidance_pos_of_failure_cond_lt_one carry explicit positive-measure (history nonvanishing) hypotheses — these are supplied by the LLL induction itself and are stated honestly as hypotheses here. Scope: this entry provides the general chain-rule scaffold and the reduction of avoidance-positivity to per-event conditional bounds; it does NOT prove the bounded-dependency-degree symmetric LLL bound (e·p·(d+1) ≤ 1), which remains the open research target and is out of scope. The chain rule is the frame the LLL fills in, not the LLL itself.",
+    "lineCount": 150,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "cond_chain_avoidance: the conditional-probability chain rule for a finite ordered family, μ(⋂ i∈range n, A i) = ∏ k∈range n, μ[A k | ⋂ j∈range k, A j], over an arbitrary measurable family and any probability measure — no independence. Proved by induction on n, splitting off the newest event via Finset.range_add_one/Set.biInter_insert and applying the telescoping identity cond_mul_eq_inter (μ[t|s]·μ s = μ(s∩t)) at each step. This is the exact identity the LLL induction fills in term by term.",
+      "avoidance_eq_prod_survival_cond: the survival-product form μ(⋂ i, (A i)ᶜ) = ∏ k, μ[(A k)ᶜ | ⋂ j<k, (A j)ᶜ], obtained by instantiating the chain rule at the complements — the honest measure-theoretic analogue of the rational surrogate's ∏(1 − xᵢ).",
+      "avoidance_pos_iff: 0 < μ(⋂ i, (A i)ᶜ) ↔ every conditional survival probability is nonzero. Because the avoidance probability is a finite product of ℝ≥0∞ conditionals, positivity reduces (via zero_lt_iff and Finset.prod_ne_zero_iff) to nonvanishing of each factor — this is the precise target the LLL certifies.",
+      "survival_cond_eq_one_sub: on a positive-measure history, μ[(A k)ᶜ | history] = 1 − μ[A k | history] (via cond_isProbabilityMeasure + prob_compl_eq_one_sub), the bridge from the usual LLL bound 'each conditional failure probability < 1' to the survival-positivity form.",
+      "avoidance_pos_of_failure_cond_lt_one: if every history has positive measure and every conditional failure probability μ[A k | history] < 1, then avoidance is positive — the exact shape the LLL induction produces (in the symmetric regime the induction certifies μ[A k | history] ≤ 2p < 1 under e·p·(d+1) ≤ 1).",
+      "Framing contribution: the chain rule is the general scaffold common to every LLL proof regardless of dependency degree; making it a verified, standalone, independence-free identity isolates exactly what the LLL induction must add on top of pure measure theory — a lower bound on each conditional survival probability derived from the dependency structure."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.ConditionalProbability"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Finset"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01ChainRule",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01ChainRule.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "cond_chain_avoidance",
+      "type": "core",
+      "description": "Conditional-probability chain rule: for an arbitrary measurable family over a probability measure, μ(⋂ i∈range n, A i) equals the product over k of the conditional probability of A k given all earlier events. No independence assumed — the pure telescoping identity the LLL induction fills in.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → μ (⋂ i ∈ Finset.range n, A i) = ∏ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, A j]"
+    },
+    {
+      "name": "avoidance_eq_prod_survival_cond",
+      "type": "core",
+      "description": "Survival-product form: applying the chain rule to the complements gives the avoidance probability as the product of conditional survival probabilities μ[(A k)ᶜ | ⋂ j<k, (A j)ᶜ] — the honest measure-theoretic analogue of the rational surrogate ∏(1 − xᵢ).",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → μ (⋂ i ∈ Finset.range n, (A i)ᶜ) = ∏ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ]"
+    },
+    {
+      "name": "avoidance_pos_iff",
+      "type": "core",
+      "description": "Avoidance-positivity criterion (the LLL reduction target): the events can be simultaneously avoided with positive probability iff every conditional survival probability is nonzero.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → (0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ) ↔ ∀ k ∈ Finset.range n, μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≠ 0)"
+    },
+    {
+      "name": "survival_cond_eq_one_sub",
+      "type": "corollary",
+      "description": "On a positive-measure history, the conditional survival probability is one minus the conditional failure probability — the bridge from the usual LLL bound (failure conditional < 1) to survival positivity.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (k : ℕ) → (hpos : μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0) → μ[(A k)ᶜ | ⋂ j ∈ Finset.range k, (A j)ᶜ] = 1 - μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ]"
+    },
+    {
+      "name": "avoidance_pos_of_failure_cond_lt_one",
+      "type": "corollary",
+      "description": "Sufficient LLL avoidance condition: if every history has positive measure and every conditional failure probability μ[A k | history] < 1, then avoidance is positive — the exact shape the LLL induction produces.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → (∀ k ∈ range n, μ (⋂ j ∈ range k, (A j)ᶜ) ≠ 0) → (∀ k ∈ range n, μ[A k | ⋂ j ∈ range k, (A j)ᶜ] < 1) → 0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) certifies that finitely many 'bad' events can all be avoided (μ(⋂ Aᵢᶜ) > 0) when each is mutually independent of all but a bounded number d of the others and the local budget e·p·(d+1) ≤ 1 holds. Every classical proof — the original Lovász induction, Spencer's exposition, Shearer's optimal bounds — runs through conditional probabilities: it bounds μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] for growing conditioning sets S by strong induction on |S|. Underneath that induction sits a purely measure-theoretic identity requiring no independence at all: the chain rule that expresses the probability of an intersection as a telescoping product of one-step conditional probabilities. The gallery's parent proof develops the symmetric LLL over ℚ as a probability-budget surrogate (its general_lll only records ∏(1 − xᵢ) > 0); OQ-01 asks for the genuine measure-theoretic statement. Two extremes are already verified — the independent d=0 base case and the dependency-free union bound. This entry supplies the common scaffold both extremes and the open general case share.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces — bad events as measurable sets A_i ⊆ Ω in an IsProbabilityMeasure, real dependency structure, and the conclusion μ(⋂ A_iᶜ) > 0.\n\n**This entry (chain-rule scaffold)**: prove the conditional-probability chain rule that the LLL induction instantiates. For an arbitrary measurable family A : ℕ → Set Ω over an IsProbabilityMeasure, μ(⋂ i∈range n, A i) = ∏ k∈range n, μ[A k | ⋂ j∈range k, A j]; specialise to the complements to get the survival-product form and the avoidance-positivity criterion 0 < μ(⋂ (A i)ᶜ) ↔ every conditional survival probability nonzero.",
+    "text": "The measure-theoretic backbone of the Lovász Local Lemma: over a real probability space, the probability that a finite ordered list of events all occur is the product of the conditional probabilities of each event given the ones before it. Reading this at the complements turns the question 'can all the bad events be avoided?' into 'is every conditional survival probability positive?' — which is exactly what the LLL induction certifies.",
+    "proofStrategy": "**Chain rule by induction on n.** The base case n = 0 is μ(univ) = 1 = empty product. For the step, the history at n+1 splits off the newest event: ⋂_{i∈range(n+1)} A i = (⋂_{i∈range n} A i) ∩ A n (Finset.range_add_one + Set.biInter_insert + Set.inter_comm). Mathlib's telescoping identity cond_mul_eq_inter gives μ[A n | history]·μ(history) = μ(history ∩ A n); combined with the induction hypothesis μ(history) = ∏_{range n} and Finset.prod_range_succ, the product extends by exactly the new factor. Each history is measurable as a finite intersection (Finset.measurableSet_biInter).\n\n**Complement form.** Instantiate the chain rule at the family i ↦ (A i)ᶜ (measurable via .compl); this is the survival-product form.\n\n**Positivity criterion.** In ℝ≥0∞ a finite product is positive iff no factor vanishes (zero_lt_iff + Finset.prod_ne_zero_iff), giving the avoidance-positivity iff directly from the survival-product form.\n\n**Bridge to the LLL bound.** On a positive-measure history, conditioning yields a genuine probability measure (cond_isProbabilityMeasure), so prob_compl_eq_one_sub gives μ[(A k)ᶜ | history] = 1 − μ[A k | history]; a failure conditional < 1 makes the survival conditional nonzero (tsub_eq_zero_iff_le), and the criterion then delivers avoidance positivity.",
+    "keyInsights": [
+      "The chain rule μ(⋂ Aᵢ) = ∏ μ[Aₖ | earlier] is completely independence-free: it is the pure telescoping of cond_mul_eq_inter, valid for any measurable family over any probability measure. What the LLL adds is not this identity but a *lower bound* on each conditional factor derived from the dependency structure — isolating the chain rule shows exactly where the mathematical content of the LLL lives.",
+      "Reading the identity at the complements is the whole point: μ(⋂ Aᵢᶜ) = ∏ μ[Aₖᶜ | ⋂_{j<k} Aⱼᶜ] is the honest measure-theoretic replacement for the parent proof's rational surrogate ∏(1 − xᵢ), where each factor is a genuine conditional survival probability rather than an abstract weight.",
+      "Avoidance positivity reduces to a *per-event* condition (avoidance_pos_iff): because the avoidance probability is a finite product in ℝ≥0∞, it is positive iff every conditional survival probability is nonzero. The LLL induction's role is precisely to certify each of these local factors — the global conclusion is then automatic.",
+      "The positive-measure hypotheses in survival_cond_eq_one_sub and avoidance_pos_of_failure_cond_lt_one are not artifacts to be hidden: when a history ⋂_{j<k} Aⱼᶜ has measure zero the whole avoidance probability is already zero, and conditioning on it is meaningless. The LLL induction supplies both the failure-conditional bound < 1 *and* the positivity of each history by the same argument, so these hypotheses are exactly what a real LLL proof delivers, stated honestly.",
+      "This scaffold is dependency-degree agnostic: the independent base case (lovasz-local-lemma-oq-01), the union-bound extreme (lovasz-local-lemma-oq-01-union-bound), and the open bounded-degree LLL all instantiate the same chain rule and differ only in how they bound the conditional survival factors. The identity is the common frame; the dependency structure is the added content."
+    ],
+    "prerequisites": [
+      "Measure-theoretic probability: IsProbabilityMeasure, measure_univ",
+      "Conditional probability μ[t|s] = cond μ s t and the telescoping identity cond_mul_eq_inter : μ[t|s]·μ s = μ(s∩t)",
+      "cond_isProbabilityMeasure and prob_compl_eq_one_sub for the survival/failure bridge",
+      "Finite intersections: Finset.measurableSet_biInter, Set.biInter_insert, Finset.range_add_one",
+      "Big operators: Finset.prod_range_succ, Finset.prod_ne_zero_iff; ℝ≥0∞ order: zero_lt_iff, tsub_eq_zero_iff_le"
+    ]
+  },
+  "conclusion": {
+    "summary": "The conditional-probability chain rule for finite avoidance is fully machine-verified over a real probability space: μ(⋂ i∈range n, A i) = ∏ k, μ[A k | earlier], with no independence hypothesis. Its complement form expresses the avoidance probability as a product of conditional survival probabilities, and the resulting criterion reduces global avoidance positivity to the per-event condition that every conditional survival probability is nonzero — the exact target the Lovász Local Lemma induction certifies. 0 sorries, 0 axioms.",
+    "implications": "**The scaffold every LLL proof shares**: together with the independent base case (lovasz-local-lemma-oq-01) and the dependency-free union bound (lovasz-local-lemma-oq-01-union-bound), this entry completes the frame of the OQ-01 landscape. Those two entries are the computable extremes; this one is the general chain-rule scaffold on which all three — and the open bounded-degree LLL — are built. It isolates precisely what the open LLL induction must add on top of pure measure theory: a lower bound on each conditional survival probability μ[Aₖᶜ | history] extracted from the dependency structure.\n\n**Honest scope**: the chain rule is elementary telescoping; it is presented as the measure-theoretic frame the LLL fills in, not as the LLL bound itself. The bounded-dependency-degree budget e·p·(d+1) ≤ 1 remains open.",
+    "openQuestions": [
+      "Prove the bounded-dependency-degree symmetric LLL by supplying the missing ingredient this scaffold isolates: a strong-induction bound μ[A i | ⋂_{j∈S} Aⱼᶜ] ≤ 2p (equivalently, each conditional survival probability ≥ 1 − 2p > 0) for all events i and histories S, under e·p·(d+1) ≤ 1 and a measure-theoretic dependency (conditional independence of A i from events outside its neighbourhood).",
+      "Formalize a measure-theoretic dependency graph and the conditional-independence hypothesis 'A i is independent of the σ-algebra generated by the non-neighbours', then plug the resulting per-event survival bound into avoidance_pos_of_failure_cond_lt_one.",
+      "Generalise the chain rule from the linear order Finset.range n to an arbitrary well-order or Fintype with a chosen order, and quantify how the choice of ordering affects the individual conditional factors (the product is order-invariant, but each factor is not)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: the chain-rule scaffold of the LLL",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring positioning this file as the general measure-theoretic scaffold shared by every LLL proof: the conditional-probability chain rule μ(⋂ Aᵢ) = ∏ μ[Aₖ | earlier], its survival-product complement form, and the avoidance-positivity criterion that reduces the LLL conclusion to a per-event conditional bound.",
+      "mathContext": "The chain rule is independence-free; the LLL adds a lower bound on each conditional survival factor derived from the dependency structure."
+    },
+    {
+      "id": "sec-setup",
+      "title": "Probability-space frame and history measurability",
+      "startLine": 52,
+      "endLine": 74,
+      "summary": "Imports Mathlib.Probability.ConditionalProbability; sets up an arbitrary IsProbabilityMeasure μ and ℕ-indexed measurable family A. measurableSet_hist: each finite history ⋂ j∈range n, A j is measurable via Finset.measurableSet_biInter.",
+      "mathContext": "ℕ-indexing supplies the total order the chain rule requires; histories are finite intersections, hence measurable, so cond_mul_eq_inter applies at each step."
+    },
+    {
+      "id": "sec-chain-rule",
+      "title": "The conditional-probability chain rule",
+      "startLine": 75,
+      "endLine": 99,
+      "summary": "cond_chain_avoidance: induction on n. The history at n+1 splits off the newest event (Finset.range_add_one, Set.biInter_insert, Set.inter_comm); cond_mul_eq_inter provides the telescoping step μ[A n | history]·μ(history) = μ(history ∩ A n), and Finset.prod_range_succ extends the product by exactly the new conditional factor.",
+      "mathContext": "The pure telescoping identity, valid for any measurable family over any probability measure — the frame the LLL induction fills in term by term."
+    },
+    {
+      "id": "sec-survival-criterion",
+      "title": "Survival product form and avoidance-positivity criterion",
+      "startLine": 100,
+      "endLine": 122,
+      "summary": "avoidance_eq_prod_survival_cond: instantiate the chain rule at the complements to write μ(⋂ (A i)ᶜ) as a product of conditional survival probabilities. avoidance_pos_iff: since this is a finite ℝ≥0∞ product, positivity reduces (zero_lt_iff, Finset.prod_ne_zero_iff) to every factor being nonzero — the LLL reduction target.",
+      "mathContext": "The honest measure-theoretic analogue of the rational surrogate ∏(1 − xᵢ), and the reduction of the global LLL conclusion to per-event conditional bounds."
+    },
+    {
+      "id": "sec-bridge",
+      "title": "Bridge to the LLL failure-probability bound",
+      "startLine": 123,
+      "endLine": 150,
+      "summary": "survival_cond_eq_one_sub: on a positive-measure history conditioning is a probability measure (cond_isProbabilityMeasure), so μ[(A k)ᶜ | history] = 1 − μ[A k | history] (prob_compl_eq_one_sub). avoidance_pos_of_failure_cond_lt_one: if every history is positive and every failure conditional < 1, avoidance is positive — the exact shape the LLL induction produces.",
+      "mathContext": "Connects the survival-positivity criterion to the standard LLL bound 'each conditional failure probability < 1'; the positive-measure hypotheses are what a real LLL induction supplies."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "extends",
+      "description": "The mutually independent (d = 0) base case, giving the exact product μ(⋂ (A i)ᶜ) = ∏(1 − μ(A i)). That factorization is the independence-special case of the general survival-product form avoidance_eq_prod_survival_cond proved here: under independence each conditional survival probability μ[(A k)ᶜ | history] collapses to the unconditional 1 − μ(A k)."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-union-bound",
+      "relationship": "related",
+      "description": "The dependency-free first-moment extreme μ(⋂ (A i)ᶜ) ≥ 1 − ∑ μ(A i). Together with the independent base case it brackets the LLL; this entry supplies the general chain-rule scaffold that both extremes and the open bounded-degree LLL instantiate."
+    },
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "related",
+      "description": "Parent gallery proof of the symmetric LLL over ℚ as a probability-budget surrogate whose general_lll only records ∏(1 − xᵢ) > 0. This entry provides the genuine measure-theoretic identity that surrogate stands in for."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the induction bounds conditional probabilities μ[Aᵢ | ⋂ Aⱼᶜ], the factors this chain rule multiplies together."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; the LLL chapter's proof runs through exactly the conditional-probability chain rule and the strong-induction bound on each conditional failure probability."
+    },
+    {
+      "authors": "Spencer",
+      "title": "Ten Lectures on the Probabilistic Method",
+      "year": "1994",
+      "note": "Presents the LLL induction via conditional probabilities on growing avoidance histories — the setting this scaffold formalizes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **measure-theoretic skeleton of the Lovász Local Lemma induction** as a fully verified, independence-free identity, plus a new gallery entry `lovasz-local-lemma-oq-01-chain-rule`.

The parent gallery proof develops the symmetric LLL over ℚ as a probability-budget surrogate (its `general_lll` only records `∏(1 − xᵢ) > 0`). OQ-01 asks for the genuine measure-theoretic statement `μ(⋂ Aᵢᶜ) > 0`. The gallery already has the two *computable extremes* — the independent `d=0` base case (`lovasz-local-lemma-oq-01`) and the dependency-free union bound (`lovasz-local-lemma-oq-01-union-bound`). This PR supplies the general chain-rule scaffold all three (and the open bounded-degree LLL) instantiate.

## Progress

New file `proofs/Proofs/LovaszLocalLemmaOQ01ChainRule.lean` (150 lines, 0 sorries, 0 axioms):

- **`cond_chain_avoidance`** — the chain rule `μ(⋂ i∈range n, A i) = ∏ k, μ[A k | ⋂ j<k, A j]` for an arbitrary measurable family over any `IsProbabilityMeasure`. Pure telescoping via Mathlib's `cond_mul_eq_inter : μ[t|s]·μ s = μ(s∩t)` (which holds even when `μ s = 0`), so **no independence and no positive-measure side conditions**.
- **`avoidance_eq_prod_survival_cond`** — complement form `μ(⋂ (A i)ᶜ) = ∏ k, μ[(A k)ᶜ | ⋂_{j<k}(A j)ᶜ]`, the honest measure-theoretic analogue of the surrogate `∏(1 − xᵢ)`.
- **`avoidance_pos_iff`** — `0 < μ(⋂ (A i)ᶜ) ↔ ∀ k, μ[(A k)ᶜ | history] ≠ 0`: global avoidance positivity reduces to a per-event condition. This is exactly the reduction the LLL discharges.
- **`survival_cond_eq_one_sub`** / **`avoidance_pos_of_failure_cond_lt_one`** — bridge to the standard LLL bound: on a positive-measure history each conditional survival prob is `1 − ` the conditional failure prob, so "each failure conditional `< 1`" ⟹ avoidance positive (the exact shape the LLL induction produces; symmetric regime `≤ 2p < 1` under `e·p·(d+1) ≤ 1`).

Also adds the gallery entry (`meta.json`, `annotations.json`) and updates `research/problems/lovasz-local-lemma-oq-01/knowledge.md`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.LovaszLocalLemmaOQ01ChainRule` — green, **no warnings**. No `sorry`, no `axiom`, no `native_decide`/`decide`; only standard Mathlib measure-theory lemmas (foundational `propext`/`Classical.choice`/`Quot.sound` only) → `status: verified`, `badge: verified`, `axiomCount: 0`. Gallery annotations validate (entry produces no errors).

## Findings

The chain rule is completely independence-free — it is pure telescoping of `cond_mul_eq_inter`. What the LLL *adds* is not this identity but a **lower bound on each conditional survival factor** derived from the dependency structure. Isolating the scaffold sharpens exactly what remains open.

## Status

**Outcome**: progress (verified increment; main OQ-01 target still open)
**Next Steps**: supply the missing ingredient — a strong-induction bound `μ[A i | ⋂_{j∈S} A_jᶜ] ≤ 2p` under a measure-theoretic dependency (conditional independence of `A i` from non-neighbours) — and plug it into `avoidance_pos_of_failure_cond_lt_one`.

🤖 Generated by researcher-6