### PR TITLE
audit(erdos-1039): drop deprecated Stubs from additionalFiles (fix axiom-undercount false positive)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -63,9 +63,7 @@
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
-      "Proofs/Erdos1039ProblemAristotle.lean",
-      "Proofs/Stubs/Erdos1039Aristotle.lean",
-      "Proofs/Stubs/Erdos1039Problem.lean"
+      "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },
   "overview": {
@@ -252,9 +250,7 @@
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
-      "Proofs/Erdos1039ProblemAristotle.lean",
-      "Proofs/Stubs/Erdos1039Aristotle.lean",
-      "Proofs/Stubs/Erdos1039Problem.lean"
+      "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },
   "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-1039 (Polynomial Lemniscate Disc Radius)
**Type**: Auditor tooling false-positive — data-only meta.json fix

### Problem
`scripts/auditor/find-targets.ts` flagged erdos-1039 with `axiom undercount: claims 5, actual declarations 10` on **every** cycle. The detector aggregates `^axiom ` declarations across `proofRepoPath` + all `additionalFiles`. The entry listed the deprecated stub `Proofs/Stubs/Erdos1039Problem.lean`, which duplicates the **same 5 named axioms** already in the presented proof `Proofs/Erdos1039Problem.lean`:

- `benchmark_upper`, `pommerenke_lower`, `klr_lower`, `klr_area_bound`, `random_polynomial_expected`

5 (main) + 5 (deprecated stub) = 10 vs `meta.axiomCount: 5` → perpetual flag. This ranked erdos-1039 as the #1 audit target indefinitely (already re-audited 5×, always resolving clean), **blocking the auditor pool from the 273 genuinely-unaudited proofs**.

### Verification
- Presented proof `Proofs/Erdos1039Problem.lean`: **5 axioms, 0 sorries, 0 True stubs** → `axiomCount: 5` is correct.
- Deprecated stub is orphaned (nothing imports it), superseded by #33815, adds **no distinct assumptions** (same 5 axiom names, +3 stale sorries).
- The `assumptions` field already documents the stub as deprecated and not the presented proof.

### Fix
Remove the two deprecated `Proofs/Stubs/*` entries from `additionalFiles` (both flattened blocks). The detector now counts only the presented proof's real assumptions.

After fix: `find-targets.ts --issues` returns **0 flagged targets**. JSON validated. No Lean source touched.

---
Discovered during gallery integrity audit.