### PR TITLE
Audit fix: list 8 additional Lean files for abundant-number-oq-02-oq-01

### DIFF
--- a/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-02-oq-01/meta.json
@@ -200,6 +200,16 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 14,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "additionalFiles": [
+      "Proofs/AbundantNumberOQ02OQ01ExponentBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01GeneralBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01LowerBound.lean",
+      "Proofs/AbundantNumberOQ02OQ01Minimality.lean",
+      "Proofs/AbundantNumberOQ02OQ01OmegaSevenPrimes.lean",
+      "Proofs/AbundantNumberOQ02OQ01SevenPrimeExponents.lean",
+      "Proofs/AbundantNumberOQ02OQ01Squarefree.lean",
+      "Proofs/AbundantNumberOQ02OQ01Unconditional.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: abundant-number-oq-02-oq-01 (smallest odd abundant number coprime to 3 = 5391411025)
**Severity**: LOW (undersell / traceability, not an overclaim)

### Problem
`meta.leanFile.additionalFiles` was empty, but the entry aggregates **94 theorems across 2436 lines in 9 Lean files**. Only the 127-line/14-theorem main file (`AbundantNumberOQ02OQ01.lean`) was linked. A visitor sees `theoremCount: 94` backed by a single 14-theorem file — which reads as inflation.

### Fix
Add the 8 sibling files that supply the remaining 80 theorems to `leanFile.additionalFiles`:

| File | thms | lines |
|------|-----:|------:|
| ExponentBound | 5 | 198 |
| GeneralBound | 7 | 295 |
| LowerBound | 6 | 194 |
| Minimality | 5 | 151 |
| OmegaSevenPrimes | 2 | 305 |
| SevenPrimeExponents | 12 | 472 |
| Squarefree | 29 | 428 |
| Unconditional | 14 | 266 |

Main + 8 additional = 94 theorems / 2436 lines, matching the aggregate meta.

### Verification status unchanged
All 9 files independently re-verified: **0 real sorries, 0 axiom declarations, 0 `native_decide` usage** (every `sorry`/`native_decide` string hit is in prose asserting their absence), 0 `True` stubs. The `verified`/`verified` badge is justified. This PR touches meta.json only.

---
Discovered during gallery integrity audit.