### PR TITLE
Enrich Constructive vs Classical IVT (intermediate-value-theorem-oq-02-oq-03): add mainTheorems (0->18)

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-03/meta.json
@@ -127,6 +127,134 @@
       "mathContext": "Given any Bool oracle $g : \\mathbb{R} \\to$ Bool with $g(x) = \\text{true} \\iff f(x) \\leq 0$, the algorithmic bisection $\\text{algoBisect}$ is fully computable. The structural theorems (width formula, sign invariant) require no classical axioms at any finite precision; Classical.choice enters only at the convergence step (completeness of $\\mathbb{R}$). For concrete decidable f-classes (e.g., rational-coefficient polynomials evaluated at rationals), the entire iteration becomes executable."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "paramBisectStep_width",
+      "type": "theorem",
+      "statement": "For any interval p and Bool choice c, (paramBisectStep p c).2 − (paramBisectStep p c).1 = (p.2 − p.1)/2.",
+      "significance": "One bisection step halves the interval width regardless of which half is chosen. Constructive: proved by case-splitting the Bool with no classical logic — the base fact that makes the whole width analysis oracle-independent.",
+      "description": "`cases c` on the Bool followed by simp on the paramBisectStep definition and ring."
+    },
+    {
+      "name": "paramBisect_width",
+      "type": "theorem",
+      "statement": "For any choice sequence and n steps, (paramBisect choices n p).2 − (paramBisect choices n p).1 = (p.2 − p.1)/2^n.",
+      "significance": "The exact geometric width formula (b−a)/2^n, holding for every choice sequence. This is fully constructive and is the quantitative engine behind convergence — width is pinned down before any classical completeness is invoked.",
+      "description": "Induction on n; the successor case rewrites with paramBisectStep_width and the inductive hypothesis, then ring."
+    },
+    {
+      "name": "paramBisectStep_ordered",
+      "type": "theorem",
+      "statement": "If p.1 ≤ p.2 then (paramBisectStep p c).1 ≤ (paramBisectStep p c).2 for any choice c.",
+      "significance": "A single step keeps the interval well-ordered (left endpoint ≤ right). Constructive invariant needed so 'width' and 'midpoint' stay meaningful.",
+      "description": "`cases c` then simp on paramBisectStep and linarith."
+    },
+    {
+      "name": "paramBisect_ordered",
+      "type": "theorem",
+      "statement": "If p.1 ≤ p.2 then (paramBisect choices n p).1 ≤ (paramBisect choices n p).2 for all n.",
+      "significance": "Well-ordering is preserved across all n steps and every choice sequence — the structural invariant underpinning monotonicity and containment.",
+      "description": "Induction on n using paramBisectStep_ordered at the successor step."
+    },
+    {
+      "name": "paramBisect_left_mono",
+      "type": "theorem",
+      "statement": "If p.1 ≤ p.2 then p.1 ≤ (paramBisect choices n p).1: the left endpoint never decreases.",
+      "significance": "The left endpoints form a non-decreasing sequence, one of the two monotonicity facts that (via completeness) force convergence. Proved constructively.",
+      "description": "Induction on n; at the successor step, case-split the choice and close each branch with the ordering hypothesis and linarith."
+    },
+    {
+      "name": "paramBisect_right_mono",
+      "type": "theorem",
+      "statement": "If p.1 ≤ p.2 then (paramBisect choices n p).2 ≤ p.2: the right endpoint never increases.",
+      "significance": "Right endpoints form a non-increasing sequence — the antitone counterpart of paramBisect_left_mono, jointly trapping the root.",
+      "description": "Induction on n; successor step case-splits the choice and uses the ordering hypothesis with linarith."
+    },
+    {
+      "name": "paramBisect_contained",
+      "type": "theorem",
+      "statement": "For a ≤ b, a ≤ (paramBisect choices n (a,b)).1 ∧ (paramBisect choices n (a,b)).2 ≤ b.",
+      "significance": "Every bisection interval stays inside the original [a, b] at each step, guaranteeing the endpoints are bounded — the boundedness half of 'bounded monotone ⇒ convergent'.",
+      "description": "Bundles paramBisect_left_mono and paramBisect_right_mono."
+    },
+    {
+      "name": "paramBisect_nested",
+      "type": "theorem",
+      "statement": "For m ≤ n, the step-n interval is nested inside the step-m interval: (paramBisect …m…).1 ≤ (paramBisect …n…).1 ∧ (paramBisect …n…).2 ≤ (paramBisect …m…).2.",
+      "significance": "The intervals form a nested decreasing family, the classical 'nested intervals' picture. This is exactly the monotonicity/antitonicity packaged for the convergence proof.",
+      "description": "Induction on n, splitting m < n vs m = n; the strict case combines the inductive hypothesis with a choice case-split and linarith."
+    },
+    {
+      "name": "paramBisect_sign",
+      "type": "theorem",
+      "statement": "Given f p.1 ≤ 0, 0 ≤ f p.2, and a sign-consistent choice sequence, f(left) ≤ 0 ∧ 0 ≤ f(right) after n steps.",
+      "significance": "The sign invariant f(left) ≤ 0 ≤ f(right) is preserved — the heart of why bisection converges to a root. Crucially it is proved WITHOUT classical logic: sign-consistency is taken as a hypothesis (an oracle), isolating the one classical ingredient.",
+      "description": "Induction on n; the successor step reads the sign-consistency equivalence at step n, case-splits choices n, and in the false branch uses push_neg to extract f(mid) > 0."
+    },
+    {
+      "name": "paramBisect_width_tendsto_zero",
+      "type": "theorem",
+      "statement": "For any choice sequence, the widths (paramBisect choices n (a,b)).2 − .1 tend to 0 as n → ∞.",
+      "significance": "Interval widths shrink to zero regardless of the oracle. Combined with monotonicity this pins the endpoints to a single common limit. Still constructive in content (a geometric-series limit).",
+      "description": "Rewrites the width as (b−a)·(1/2)^n and applies tendsto_const_nhds.mul with tendsto_pow_atTop_nhds_zero_of_lt_one."
+    },
+    {
+      "name": "paramBisect_endpoints_converge",
+      "type": "theorem",
+      "statement": "For a ≤ b, there exists x with both endpoint sequences (left and right) tending to x.",
+      "significance": "Left and right endpoints converge to a COMMON limit x — the first genuinely classical result, using completeness of ℝ (bounded monotone sequences converge). This marks the constructive/classical boundary the file is about.",
+      "description": "Monotone+BddAbove gives tendsto_atTop_ciSup for the left endpoints, Antitone+BddBelow gives tendsto_atTop_ciInf for the right; the limits agree because their difference is the width, which tends to 0 (tendsto_nhds_unique)."
+    },
+    {
+      "name": "bisection_limit_is_root",
+      "type": "theorem",
+      "statement": "If choices are sign-consistent, f is continuous, and the left endpoints tend to x, then f x = 0.",
+      "significance": "Identifies the common limit as an actual root of f. This closes the IVT: continuity plus the preserved sign invariant squeeze f(x) between ≤ 0 and ≥ 0.",
+      "description": "From the sign invariant, f(left_n) ≤ 0 and f(right_n) ≥ 0; both endpoint sequences tend to x (right via the width→0 identity), so le_of_tendsto and ge_of_tendsto give f x ≤ 0 and f x ≥ 0, closed by linarith."
+    },
+    {
+      "name": "constructive_vs_classical_ivt",
+      "type": "theorem",
+      "statement": "For a ≤ b, a four-part conjunction: (1) exact width (b−a)/2^n for all choices; (2) the sign invariant given sign-consistent choices; (3) width → 0; (4) endpoint convergence to a common limit.",
+      "significance": "The headline summary theorem: it bundles the three constructive results (width formula, sign invariant, width→0) with the one classical result (endpoint convergence), making the constructive/classical split of the IVT explicit and machine-checked.",
+      "description": "A four-tuple assembled from paramBisect_width, paramBisect_sign, paramBisect_width_tendsto_zero, and paramBisect_endpoints_converge."
+    },
+    {
+      "name": "algoBisect_eq_paramBisect",
+      "type": "theorem",
+      "statement": "algoBisect g n p = paramBisect (oracleChoices g p) n p.",
+      "significance": "Shows the self-contained algorithmic bisection (which computes its own branch from an oracle g) coincides with the parameterized version driven by the induced choice sequence. This transfer lets every paramBisect theorem apply to the concrete algorithm — the key to answering open question oq-01.",
+      "description": "Induction on n; the successor step unfolds both definitions and case-splits on g(mid) to match the paramBisectStep branches."
+    },
+    {
+      "name": "oracleChoices_signConsistent",
+      "type": "theorem",
+      "statement": "If g correctly decides f x ≤ 0 (g x = true ↔ f x ≤ 0), then the induced oracleChoices are SignConsistent with f at every length n.",
+      "significance": "A correct Bool sign oracle automatically yields sign-consistent choices — so the sign invariant becomes free rather than assumed. This is what upgrades the hypothesis-driven results into a genuine algorithm.",
+      "description": "Unfolds paramBisectMid, rewrites via algoBisect_eq_paramBisect so the midpoint is the algorithmic one, then applies the oracle correctness hypothesis hg pointwise."
+    },
+    {
+      "name": "algoBisect_sign",
+      "type": "theorem",
+      "statement": "Given a correct sign oracle g and f a ≤ 0 ≤ f b, the computable algoBisect preserves f(left) ≤ 0 ∧ 0 ≤ f(right) at every step n.",
+      "significance": "The sign invariant for the fully algorithmic bisection — holding without Classical.em. For any finite precision the algorithm needs no classical axioms, directly answering oq-01.",
+      "description": "Rewrites with algoBisect_eq_paramBisect and applies paramBisect_sign together with oracleChoices_signConsistent."
+    },
+    {
+      "name": "algoBisect_width",
+      "type": "theorem",
+      "statement": "(algoBisect g n p).2 − (algoBisect g n p).1 = (p.2 − p.1)/2^n.",
+      "significance": "The exact width formula transfers verbatim to the algorithmic bisection, confirming the concrete algorithm shrinks intervals geometrically.",
+      "description": "Rewrites with algoBisect_eq_paramBisect and applies paramBisect_width."
+    },
+    {
+      "name": "algoBisect_converges_to_root",
+      "type": "theorem",
+      "statement": "With a correct sign oracle g and continuous f satisfying f a ≤ 0 ≤ f b, there exists x with f x = 0 and both algoBisect endpoint sequences tending to x.",
+      "significance": "The capstone algorithmic IVT: the computable bisection converges to a genuine root. The only classical step is completeness of ℝ in the limit; the iteration, its width bound, and its sign invariant are all computed without Classical.em.",
+      "description": "Obtains the common limit from paramBisect_endpoints_converge on the induced choices, identifies it as a root via bisection_limit_is_root, and transfers both convergences through algoBisect_eq_paramBisect."
+    }
+  ],
   "overview": {
     "historicalContext": "The Intermediate Value Theorem (IVT) is one of the foundational results of real analysis, tracing back to Bolzano (1817) and Cauchy (1821). The classical proof relies on the least upper bound property of ℝ — a non-constructive axiom. In constructive mathematics (Brouwer, Bishop), the IVT is NOT provable in general: a continuous function can satisfy f(a) < 0 < f(b) without having a computable root.\n\nBishop (1967) showed that the IVT becomes provable constructively if f is **locally non-constant** (a stronger hypothesis). Without this, the bisection argument gets stuck at choosing which half-interval to recurse into — this requires knowing whether f(mid) ≤ 0 or f(mid) > 0, which requires decidability of real-number comparisons.\n\nThis entry formalizes the precise classical boundary: the bisection **structure** (width formula, sign invariant, width-to-zero) is constructive; the **convergence to a root** requires Classical.choice via the completeness of ℝ.",
     "problemStatement": "**OQ-02-OQ-03**: Can the constructive IVT be proved in Lean 4 without classical logic?\n\n**Answer**: Partial YES/NO — the bisection structure is constructive, but convergence requires Classical.choice:\n- **Constructive** (no Classical.em): width formula (b-a)/2^n, sign invariant, width→0\n- **Classical** (needs Classical.choice): endpoint convergence, root theorem\n\nThe key technique: parameterize the bisection by an explicit `choices: ℕ → Bool` oracle, separating the computable structure from the classical choice.",


### PR DESCRIPTION
Adds a complete `mainTheorems` array (18 entries) to the gallery entry, which previously rendered an empty Main Theorems section despite `theoremCount: 18`.

Each entry has `name`, `type`, `statement`, `significance`, and `description`, transcribed faithfully from `proofs/Proofs/IntermediateValueTheoremOQ02OQ03.lean`. Names and order match the Lean source exactly (verified by diff). Covers the parameterized bisection width bounds, ordering/monotonicity/nesting invariants, the sign invariant, width→0, the classical endpoint-convergence and root-extraction results, the summary `constructive_vs_classical_ivt`, and the algorithmic-oracle chain closing oq-01.

Status `verified` (0 sorries, 0 axioms) — unchanged. JSON-only; meta.json 15.7 KB -> 26.3 KB (well under the ~60 KB cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)