### PR TITLE
research(hilbert-13-oq-03): fiber characterization sharpens the point-separation necessity

### DIFF
--- a/proofs/Proofs/Hilbert13OQ03.lean
+++ b/proofs/Proofs/Hilbert13OQ03.lean
@@ -75,6 +75,35 @@ theorem eq_of_feature_eq {X : Type*} {Q : ℕ} {Ψ : X → (Fin Q → ℝ)} {f :
     _ = ∑ q, Φ q (Ψ y q) := by rw [h]
     _ = f y := (hΦ y).symm
 
+/-- **Converse: the feature map is the *only* obstruction.**
+    If the feature map already distinguishes `x` and `y`, then some representable function does
+    too — namely the feature coordinate `q` on which they differ, realised by the outer family
+    `Φ_q = id`, `Φ_{q'} = 0` for `q' ≠ q`. So the outer layer *can* recover any separation the
+    inner layer provides; it is powerless only against merges. -/
+theorem exists_representable_of_feature_ne {X : Type*} {Q : ℕ} (Ψ : X → (Fin Q → ℝ))
+    {x y : X} (h : Ψ x ≠ Ψ y) :
+    ∃ f : X → ℝ, OuterRepresentable Ψ f ∧ f x ≠ f y := by
+  obtain ⟨q, hq⟩ := Function.ne_iff.mp h
+  refine ⟨fun z => Ψ z q, ⟨fun q' => if q' = q then id else 0, fun z => ?_⟩, hq⟩
+  rw [Finset.sum_eq_single_of_mem q (Finset.mem_univ q)]
+  · simp
+  · intro q' _ hq'; simp [hq']
+
+/-- **Fibers of the feature map = indistinguishability classes.**
+    The representable functions separate `x` and `y` *iff* the feature map does. Combining the
+    collapse lemma (`eq_of_feature_eq`) with its converse, the equivalence relation "every
+    representable function agrees on `x` and `y`" is *exactly* `Ψ x = Ψ y`: the feature map's
+    fibers are precisely the classes of points no Kolmogorov–Arnold superposition can tell apart.
+    This sharpens "point separation is necessary" into "point separation is exactly what the
+    outer layer cannot recover". -/
+theorem representable_separates_iff_feature_ne {X : Type*} {Q : ℕ} (Ψ : X → (Fin Q → ℝ))
+    (x y : X) :
+    (∃ f : X → ℝ, OuterRepresentable Ψ f ∧ f x ≠ f y) ↔ Ψ x ≠ Ψ y := by
+  constructor
+  · rintro ⟨f, hf, hfxy⟩ h
+    exact hfxy (eq_of_feature_eq hf h)
+  · exact fun h => exists_representable_of_feature_ne Ψ h
+
 /-- **Necessity of point separation.**
     Suppose every function that *some* continuous function distinguishes is representable through
     `Ψ` (the "universal inner family" situation), and that continuous functions separate the
@@ -174,6 +203,8 @@ which we do not formalise here.
 -/
 
 #check @eq_of_feature_eq
+#check @exists_representable_of_feature_ne
+#check @representable_separates_iff_feature_ne
 #check @feature_injective_of_universal
 #check @inner_injective_of_feature_injective
 #check @inner_functions_must_be_injective

--- a/src/data/proofs/hilbert-13-oq-03/meta.json
+++ b/src/data/proofs/hilbert-13-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-13-oq-03",
   "title": "Hilbert's 13th, OQ-03: Point Separation Is Necessary for the Inner Functions",
   "slug": "hilbert-13-oq-03",
-  "description": "Isolates and fully verifies the unconditional necessary core of 'what are the minimal requirements on the inner functions' in the Kolmogorov–Arnold superposition f(x) = Σ_q Φ_q(Σ_p coeff_{p,q} φ_p(x_p)). Bundling the inner data into a feature map Ψ, the outer functions see x only through Ψ(x); so if a fixed inner family represents every continuous function, Ψ must be injective (point-separating), and each inner φ_p must itself be injective. Explicitly does NOT resolve sufficiency (Sternfeld's stronger uniform-separation criterion). 6 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "description": "Isolates and fully verifies the unconditional necessary core of 'what are the minimal requirements on the inner functions' in the Kolmogorov–Arnold superposition f(x) = Σ_q Φ_q(Σ_p coeff_{p,q} φ_p(x_p)). Bundling the inner data into a feature map Ψ, the outer functions see x only through Ψ(x); so if a fixed inner family represents every continuous function, Ψ must be injective (point-separating), and each inner φ_p must itself be injective. Explicitly does NOT resolve sufficiency (Sternfeld's stronger uniform-separation criterion). 8 theorems, 2 definitions, 0 axioms, 0 sorries.",
   "meta": {
     "proofRepoPath": "Proofs/Hilbert13OQ03.lean",
     "author": "Lean Genius",
@@ -111,7 +111,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The necessary core of Hilbert 13 / OQ-03 is machine-verified with 0 axioms and 0 sorries: any inner family that yields a Kolmogorov–Arnold superposition for every continuous function must separate points, and each inner function φ_p must be injective. 6 theorems, 2 definitions, 182 lines.",
+    "summary": "The necessary core of Hilbert 13 / OQ-03 is machine-verified with 0 axioms and 0 sorries: any inner family that yields a Kolmogorov–Arnold superposition for every continuous function must separate points, and each inner function φ_p must be injective. 8 theorems, 2 definitions, 213 lines.",
     "implications": "The feature-map abstraction cleanly localizes the representational burden to the inner data and gives a reusable, dimension-agnostic necessary condition. It clarifies the floor of admissibility for the inner functions while leaving the exact threshold — Sternfeld's uniform (measure-)separation criterion — as the deeper open target.",
     "openQuestions": [
       "Formalize Sternfeld's uniform separation criterion and prove it is the exact admissibility threshold (sufficiency)",
@@ -125,9 +125,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert13OQ03",
-    "lineCount": 182,
+    "lineCount": 213,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/Hilbert13OQ03.lean",
     "sorries": 0
@@ -151,6 +151,12 @@
       "type": "core",
       "description": "Under the same universality hypothesis, the bundled inner feature map must be injective — the inner family must separate the points of the cube",
       "leanType": "(∀ f, Continuous f → OuterRepresentable (kaFeature φ coeff) f) → Function.Injective (kaFeature φ coeff)"
+    },
+    {
+      "name": "representable_separates_iff_feature_ne",
+      "type": "core",
+      "description": "Exact characterization sharpening the necessity result: the representable functions separate two domain points if and only if the feature map does. The fibers of Ψ are precisely the classes of points no Kolmogorov–Arnold superposition can distinguish — point separation is exactly what the outer layer cannot recover.",
+      "leanType": "∀ {X : Type*} {Q : ℕ} (Ψ : X → Fin Q → ℝ) (x y : X), (∃ f, OuterRepresentable Ψ f ∧ f x ≠ f y) ↔ Ψ x ≠ Ψ y"
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Extends the verified `Hilbert13OQ03.lean` (the necessary-core of the Kolmogorov–Arnold inner-function requirements — "point separation is mandatory") with the **exact converse** to its collapse lemma, upgrading a one-directional necessity result into a full characterization.

The file already proves `eq_of_feature_eq`: if the feature map `Ψ` merges two points (`Ψ x = Ψ y`), every representable function is forced to agree on them. This PR proves the other direction and closes the loop.

## New results (0 axioms, 0 sorries)

- **`exists_representable_of_feature_ne`** — if `Ψ` *distinguishes* `x` and `y`, then some representable function does too: take the feature coordinate `q` on which they differ, realised by the outer family `Φ_q = id`, `Φ_{q'} = 0` (`q' ≠ q`). So the outer layer **can** recover any separation the inner layer provides; it is powerless only against merges.
- **`representable_separates_iff_feature_ne`** — the representable functions separate `x` and `y` **iff** `Ψ x ≠ Ψ y`. The fibers of the feature map are *exactly* the indistinguishability classes of Kolmogorov–Arnold superpositions. This sharpens "point separation is necessary" into "point separation is **exactly** what the outer layer cannot recover."

Proofs are elementary Mathlib sum manipulation (`Finset.sum_eq_single_of_mem`, `Function.ne_iff`).

## Verification

`./proofs/scripts/docker-build.sh Proofs.Hilbert13OQ03` → `Build completed successfully (7743 jobs)`; both new theorems type-check with the expected signatures (`#check` output confirmed). Still **0 axioms, 0 sorries** — `verified`.

Also bumps `meta.json` `leanFile.theoremCount` 6→8 and `lineCount`, and adds the iff to `mainTheorems`, for gallery/audit consistency.

Scope unchanged: this is the *necessity* floor; sufficiency (Sternfeld's uniform-separation criterion) remains out of scope, as documented in the file's closing remark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)