### PR TITLE
Research: burnside-counting-oq-04-oq-01-oq-02 — closed form for binary bracelet numbers

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ04OQ01OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ01OQ02.lean
@@ -1,0 +1,189 @@
+import Mathlib
+import Proofs.BurnsideCountingOQ04OQ01OQ01
+import Proofs.BurnsideCountingOQ04OQ01OQ01OQ01
+
+/-!
+# Burnside Counting OQ-04-OQ-01-OQ-02: a closed form for the binary bracelet numbers
+
+## What this proves
+
+The grandparent chain reduced dihedral *bracelet* counting to a Burnside sum over
+`DihedralGroup n` acting on the binary colourings `Coloring n = ZMod n → Fin 2`
+(`BurnsideCountingOQ04OQ01OQ01.lean`, namespace `BurnsideBracelets`), and the sibling file
+`BurnsideCountingOQ04OQ01OQ01OQ01.lean` proved the *rotation* half of the per-element
+fixed-point count in closed form: a rotation by `i` fixes exactly `2 ^ gcd(n, i.val)`
+colourings.  Both files still computed the *bracelet numbers themselves* — `b(4) = 6`,
+`b(5) = 8`, `b(6) = 13` — by evaluating the Burnside sum with kernel `decide`, one length at a
+time, and neither wrote down the classical **closed form** for `b(n)`.
+
+This file writes that closed form down and validates it.  Burnside's lemma over
+`D_n = DihedralGroup n` (`|D_n| = 2n`) gives
+
+      `b(n) = (1 / 2n) · [ (rotation fixed-point total) + (reflection fixed-point total) ]`.
+
+Using the sibling's rotation closed form `2 ^ gcd(n, i.val)` and the classical reflection
+counts (odd `n`: every reflection fixes `2 ^ ((n+1)/2)`; even `n`: the `n/2` vertex-axis
+reflections fix `2 ^ (n/2 + 1)` each and the `n/2` edge-axis reflections fix `2 ^ (n/2)`
+each) this becomes the fully explicit
+
+      `rotTerm n  = ∑_{i : ZMod n} 2 ^ gcd(n, i.val)`
+      `reflTerm n = if n odd  then n · 2 ^ ((n+1)/2)`
+      `            else (n/2) · 2 ^ (n/2 + 1) + (n/2) · 2 ^ (n/2)`
+      `braceletClosed n = (rotTerm n + reflTerm n) / (2n)`.
+
+We prove:
+
+* `rotTerm_eq` — the rotation term **is** the sum of the true rotation fixed-point counts
+  `∑_i |Fix(r i)|`, uniformly in `n`, straight from the sibling's `card_rotFixed`
+  (no computation).
+* `braceletClosed_eq_orbitCount_{three,four,five,six}` — the closed form agrees with the
+  genuine dihedral orbit count `|Coloring n / D_n|` for `n = 3, 4, 5, 6`, the last three of
+  which are the grandparents' unconditionally-proved values and the first (`b(3) = 4`) a fresh
+  Burnside computation added here.  These pin the formula to ground truth, not to an OEIS
+  lookup.
+* `bracelet_seven … bracelet_ten` — the closed form then *predicts* the next bracelet numbers
+  `b(7)=18, b(8)=30, b(9)=46, b(10)=78` by pure arithmetic on the formula, **without** building
+  or enumerating the (rapidly growing) orbit quotients — the values are `A000029(7..10)` of the
+  OEIS "binary bracelets" sequence, beyond the length-`6` ceiling the parents reached by
+  `decide` on the quotient.
+
+## Honesty / Scope
+
+The *rotation* half of the formula is tied to the real fixed-point counts by a general,
+computation-free theorem (`rotTerm_eq`).  The *reflection* half is used here in its classical
+closed form and validated against the true orbit counts for every `n ≤ 6` (both reflection
+parities, vertex- and edge-axis, occur); a fully generic Lean proof of the per-reflection count
+`2 ^ (orbits of the reflection involution)` — the exact analogue of the sibling's rotation
+theorem — is the natural next open question and is *not* proved here.  So this is an explicit,
+ground-truth-anchored closed form plus its onward predictions, not a from-`n` derivation of the
+reflection term.  Everything below is axiom-free: no `native_decide`, only kernel `decide` on
+closed `ℕ`/finite data.  `#print axioms` on the headlines reports only `propext`,
+`Classical.choice`, `Quot.sound`.
+-/
+
+namespace BurnsideBraceletClosedForm
+
+open Finset MulAction
+
+/-! ## Part I: the closed-form formula -/
+
+/-- Rotation contribution to the Burnside sum: `∑_{i : ZMod n} 2 ^ gcd(n, i.val)`.  By the
+sibling's `card_rotFixed` this is exactly `∑_i |Fix(r i)|` (see `rotTerm_eq`), i.e. `n` times
+the classical binary *necklace* count `(1/n) ∑_{d ∣ n} φ(d) 2^{n/d}`. -/
+def rotTerm (n : ℕ) [NeZero n] : ℕ := ∑ i : ZMod n, 2 ^ Nat.gcd n i.val
+
+/-- Reflection contribution to the Burnside sum.  For odd `n` all `n` reflections pass through
+one vertex and the opposite edge-midpoint and each fixes `2 ^ ((n+1)/2)` colourings.  For even
+`n` the `n/2` vertex-axis reflections fix `2 ^ (n/2 + 1)` each and the `n/2` edge-axis
+reflections fix `2 ^ (n/2)` each. -/
+def reflTerm (n : ℕ) : ℕ :=
+  if n % 2 = 1 then n * 2 ^ ((n + 1) / 2)
+  else (n / 2) * 2 ^ (n / 2 + 1) + (n / 2) * 2 ^ (n / 2)
+
+/-- **The closed form for the number of binary bracelets of length `n`.**
+`b(n) = (rotTerm n + reflTerm n) / (2n)`, the Burnside average of the fixed-point counts over
+the `2n` symmetries of `DihedralGroup n`. -/
+def braceletClosed (n : ℕ) [NeZero n] : ℕ := (rotTerm n + reflTerm n) / (2 * n)
+
+/-! ## Part II: the rotation term is the true rotation fixed-point total -/
+
+/-- **The rotation term is genuine.**  `rotTerm n` equals the sum over all rotations of the
+true number of colourings each fixes — uniformly in `n`, with no computation — because the
+sibling file proved `|Fix(r i)| = 2 ^ gcd(n, i.val)`. -/
+theorem rotTerm_eq (n : ℕ) [NeZero n] :
+    rotTerm n = ∑ i : ZMod n, Fintype.card (BurnsideRotationFix.RotFixed n i) := by
+  simp only [rotTerm, BurnsideRotationFix.card_rotFixed]
+
+/-! ## Part III: ground-truth Burnside orbit counts for `n = 3` and `n = 4`
+
+`b(5)` and `b(6)` are imported from the grandparent (`BurnsideBracelets.bracelet_five`,
+`bracelet_six`); here we add `b(3)` and `b(4)` with the same generic action. -/
+
+open BurnsideBracelets in
+/-- Burnside fixed-point sum for the triangle (`D₃`, `6` symmetries × `8` colourings):
+identity fixes `8`, the two nontrivial rotations fix `2` each, the three reflections fix
+`2^2 = 4` each; `8 + 2·2 + 3·4 = 24`. -/
+theorem fixed_sum_three :
+    ∑ g : DihedralGroup 3, Fintype.card (fixedBy (Coloring 3) g) = 24 := by decide
+
+/-- **There are exactly `4` binary bracelets of length `3`** (`A000029(3) = 4`): Burnside turns
+the fixed-point sum `24` and `|D₃| = 6` into `24 / 6 = 4`. -/
+theorem bracelet_three :
+    Fintype.card (orbitRel.Quotient (DihedralGroup 3) (BurnsideBracelets.Coloring 3)) = 4 := by
+  have h := BurnsideBracelets.bracelet_count_mul 24 fixed_sum_three
+  omega
+
+open BurnsideBracelets in
+/-- Burnside fixed-point sum for the square (`D₄`, `8` symmetries × `16` colourings):
+rotations contribute `16 + 2 + 4 + 2 = 24`, the two vertex-axis reflections fix `2^3 = 8` each
+and the two edge-axis reflections fix `2^2 = 4` each; `24 + 2·8 + 2·4 = 48`. -/
+theorem fixed_sum_four :
+    ∑ g : DihedralGroup 4, Fintype.card (fixedBy (Coloring 4) g) = 48 := by decide
+
+/-- **There are exactly `6` binary bracelets of length `4`** (`A000029(4) = 6`): Burnside turns
+the fixed-point sum `48` and `|D₄| = 8` into `48 / 8 = 6`. -/
+theorem bracelet_four :
+    Fintype.card (orbitRel.Quotient (DihedralGroup 4) (BurnsideBracelets.Coloring 4)) = 6 := by
+  have h := BurnsideBracelets.bracelet_count_mul 48 fixed_sum_four
+  omega
+
+/-! ## Part IV: the closed form matches the ground-truth orbit counts, `n = 3,…,6` -/
+
+/-- The closed form evaluates to `4` at `n = 3`. -/
+theorem braceletClosed_three : braceletClosed 3 = 4 := by decide
+/-- The closed form evaluates to `6` at `n = 4`. -/
+theorem braceletClosed_four : braceletClosed 4 = 6 := by decide
+/-- The closed form evaluates to `8` at `n = 5`. -/
+theorem braceletClosed_five : braceletClosed 5 = 8 := by decide
+/-- The closed form evaluates to `13` at `n = 6`. -/
+theorem braceletClosed_six : braceletClosed 6 = 13 := by decide
+
+/-- The closed form reproduces the true number of dihedral orbits at `n = 3`. -/
+theorem braceletClosed_eq_orbitCount_three :
+    braceletClosed 3 =
+      Fintype.card (orbitRel.Quotient (DihedralGroup 3) (BurnsideBracelets.Coloring 3)) := by
+  rw [braceletClosed_three, bracelet_three]
+
+/-- The closed form reproduces the true number of dihedral orbits at `n = 4`. -/
+theorem braceletClosed_eq_orbitCount_four :
+    braceletClosed 4 =
+      Fintype.card (orbitRel.Quotient (DihedralGroup 4) (BurnsideBracelets.Coloring 4)) := by
+  rw [braceletClosed_four, bracelet_four]
+
+/-- The closed form reproduces the true number of dihedral orbits at `n = 5`
+(grandparent's `bracelet_five`). -/
+theorem braceletClosed_eq_orbitCount_five :
+    braceletClosed 5 =
+      Fintype.card (orbitRel.Quotient (DihedralGroup 5) (BurnsideBracelets.Coloring 5)) := by
+  rw [braceletClosed_five, BurnsideBracelets.bracelet_five]
+
+/-- The closed form reproduces the true number of dihedral orbits at `n = 6`
+(grandparent's `bracelet_six`). -/
+theorem braceletClosed_eq_orbitCount_six :
+    braceletClosed 6 =
+      Fintype.card (orbitRel.Quotient (DihedralGroup 6) (BurnsideBracelets.Coloring 6)) := by
+  rw [braceletClosed_six, BurnsideBracelets.bracelet_six]
+
+/-! ## Part V: onward predictions beyond the parents' computational ceiling
+
+The closed form now yields the next binary bracelet numbers by pure arithmetic — no orbit
+quotient is built or enumerated.  These are `A000029(7..10)`. -/
+
+/-- `b(7) = 18` from the closed form (odd length; `rotTerm = 128 + 6·2 = 140`,
+`reflTerm = 7·2^4 = 112`, `(140+112)/14 = 18`). -/
+theorem bracelet_seven : braceletClosed 7 = 18 := by decide
+/-- `b(8) = 30` from the closed form (even length; `rotTerm = 288`,
+`reflTerm = 4·2^5 + 4·2^4 = 192`, `(288+192)/16 = 30`). -/
+theorem bracelet_eight : braceletClosed 8 = 30 := by decide
+/-- `b(9) = 46` from the closed form. -/
+theorem bracelet_nine : braceletClosed 9 = 46 := by decide
+/-- `b(10) = 78` from the closed form. -/
+theorem bracelet_ten : braceletClosed 10 = 78 := by decide
+
+end BurnsideBraceletClosedForm
+
+-- Axiom audit: only the standard foundational axioms, in particular no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideBraceletClosedForm.braceletClosed_eq_orbitCount_six
+#print axioms BurnsideBraceletClosedForm.bracelet_ten
+#print axioms BurnsideBraceletClosedForm.rotTerm_eq

--- a/research/problems/burnside-counting-oq-04-oq-01-oq-02/knowledge.md
+++ b/research/problems/burnside-counting-oq-04-oq-01-oq-02/knowledge.md
@@ -1,0 +1,45 @@
+# burnside-counting-oq-04-oq-01-oq-02 — Closed form for binary bracelet numbers via dihedral Burnside sum
+
+## Result
+
+`BurnsideCountingOQ04OQ01OQ02.lean` (namespace `BurnsideBraceletClosedForm`) writes down and
+validates the classical closed form for the binary bracelet numbers `b(n) = A000029(n)`:
+
+```
+rotTerm n  = ∑_{i : ZMod n} 2 ^ gcd(n, i.val)            -- rotation fixed-point total
+reflTerm n = if n odd then n · 2^((n+1)/2)               -- reflection fixed-point total
+             else (n/2)·2^(n/2+1) + (n/2)·2^(n/2)
+braceletClosed n = (rotTerm n + reflTerm n) / (2 n)      -- Burnside average over |D_n| = 2n
+```
+
+- `rotTerm_eq` : for all `n`, `rotTerm n = ∑_i |Fix(r i)|` (via the sibling's
+  `card_rotFixed = 2^gcd(n, i.val)`) — computation-free.
+- `braceletClosed_eq_orbitCount_{three,four,five,six}` : the formula equals the genuine
+  `Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n))` for `n = 3,4,5,6`.
+  `b(3)=4`, `b(4)=6` are freshly Burnside-computed here (kernel `decide` on the fixed-point
+  sums `24`, `48`); `b(5)=8`, `b(6)=13` are imported from the grandparent.
+- `bracelet_seven … bracelet_ten` : the formula predicts `b(7)=18, b(8)=30, b(9)=46, b(10)=78`
+  by pure arithmetic, beyond the parents' length-6 `decide` ceiling.
+
+Axiom-free: no `native_decide`; `#print axioms` reports only `propext, Classical.choice,
+Quot.sound`.
+
+## Lineage
+
+- grandparent `burnside-counting-oq-04-oq-01-oq-01` — generic `DihedralGroup n` action on
+  `Coloring n = ZMod n → Fin 2`, `bracelet_count_mul` (Burnside), `b(5)`, `b(6)`.
+- sibling `burnside-counting-oq-04-oq-01-oq-01-oq-01` — rotation closed form
+  `|Fix(r i)| = 2^gcd(n, i.val)`; this file reuses it for `rotTerm_eq`.
+
+This entry answers the grandparent/sibling open question "replace per-`n` decide by a closed
+form for `b(n)`".
+
+## Next open question
+
+Prove the reflection fixed-point count generically: for the reflection `sr i` (acting as
+`x ↦ -i - x`), the number of fixed colourings is `2 ^ (orbits of that involution)`, i.e.
+`2^((n+1)/2)` for odd `n`, and `2^(n/2+1)` or `2^(n/2)` for even `n` according to the parity of
+`i` (whether `2x = -i` is solvable). That would prove `reflTerm n = ∑_i |Fix(sr i)|` and upgrade
+`braceletClosed n = A000029(n)` to a theorem for ALL `n`. Route: Burnside on the order-2
+subgroup `⟨sr i⟩ ≤ D_n` acting on `ZMod n`, giving `orbits = (n + |{x : 2x = -i}|)/2`, plus a
+quotient-bijection `RefFixed n i ≃ (ZMod n / ⟨sr i⟩ → Fin 2)` analogous to `rotFixedEquiv`.

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-burnoq040102-overview",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 66 },
+    "type": "concept",
+    "title": "A Closed Form for the Binary Bracelet Numbers",
+    "content": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the dihedral group D_n acting on the 2-colourings of an n-cycle, the orbits are the binary bracelets (necklaces up to rotation AND reflection), OEIS A000029. The grandparent computed b(4), b(5), b(6) one length at a time by kernel decide; the sibling gave the rotation fixed-point count 2^gcd(n, i.val) in closed form. This entry assembles the full closed form b(n) = (rotTerm n + reflTerm n) / (2n), ties the rotation term to the true fixed-point counts, validates the whole formula against the genuine dihedral orbit count for n = 3..6, and then predicts b(7)..b(10) by pure arithmetic — all axiom-free (no native_decide).",
+    "mathContext": "$b(n) = \\dfrac{1}{2n}\\Big(\\sum_{i \\in \\mathbb{Z}/n} 2^{\\gcd(n,\\,i)} + R(n)\\Big)$, $R(n) = n\\,2^{(n+1)/2}$ (odd $n$) or $\\tfrac{n}{2}\\,2^{n/2+1} + \\tfrac{n}{2}\\,2^{n/2}$ (even $n$).",
+    "significance": "central",
+    "relatedConcepts": ["Burnside's lemma", "dihedral group", "bracelet/necklace counting", "closed form", "OEIS A000029"],
+    "prerequisites": ["group actions and orbits", "the orbit-counting lemma", "dihedral groups"]
+  },
+  {
+    "id": "ann-burnoq040102-rotterm",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 86 },
+    "type": "definition",
+    "title": "The Rotation and Reflection Terms",
+    "content": "rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) is the total number of colourings fixed by all rotations — n times the classical binary necklace count. reflTerm n encodes the reflection dichotomy: for odd n all n reflections fix 2^((n+1)/2) colourings; for even n the n/2 vertex-axis reflections fix 2^(n/2+1) each and the n/2 edge-axis reflections fix 2^(n/2) each. braceletClosed n = (rotTerm n + reflTerm n) / (2n) is their Burnside average over the 2n dihedral symmetries.",
+    "mathContext": "$\\mathrm{rotTerm}(n) = \\sum_{i} 2^{\\gcd(n,i)},\\quad \\mathrm{braceletClosed}(n) = \\dfrac{\\mathrm{rotTerm}(n) + \\mathrm{reflTerm}(n)}{2n}.$",
+    "significance": "central",
+    "relatedConcepts": ["necklace count", "gcd", "reflection axes", "Burnside average"],
+    "prerequisites": ["ZMod arithmetic", "gcd and Euler's totient", "reflections in D_n"]
+  },
+  {
+    "id": "ann-burnoq040102-rotterm-eq",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "insight",
+    "title": "The Rotation Term Is the True Fixed-Point Total",
+    "content": "rotTerm_eq proves, uniformly in n and with no computation, that rotTerm n equals the genuine total Σ_{i : ZMod n} |Fix(r i)| of colourings fixed by each rotation. The proof is a single rewrite with the sibling's card_rotFixed (|Fix(r i)| = 2^gcd(n, i.val)). This is the one half of the formula that is anchored to the fixed-point counts for ALL n, not just the checked range.",
+    "mathContext": "$\\mathrm{rotTerm}(n) = \\sum_{i \\in \\mathbb{Z}/n} |\\mathrm{Fix}(r_i)| = \\sum_{i} 2^{\\gcd(n,i)}.$",
+    "significance": "central",
+    "relatedConcepts": ["fixed points of a rotation", "card_rotFixed", "generic proof"],
+    "prerequisites": ["orbit of a cyclic subgroup", "the sibling rotation formula"]
+  },
+  {
+    "id": "ann-burnoq040102-groundtruth",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 97, "endLine": 128 },
+    "type": "proof-step",
+    "title": "Ground-Truth Counts b(3) = 4 and b(4) = 6",
+    "content": "Using the grandparent's generic dihedral action, the Burnside fixed-point sums Σ_{g ∈ D₃} |Fix(g)| = 24 (6 symmetries × 8 colourings) and Σ_{g ∈ D₄} |Fix(g)| = 48 (8 × 16) are discharged by kernel decide, and bracelet_count_mul (bracelets · 2n = Σ |Fix(g)|) plus omega divides out to b(3) = 4 and b(4) = 6. b(5) = 8 and b(6) = 13 are imported from the grandparent. These four values are the ground truth the closed form is measured against.",
+    "mathContext": "$\\sum_{g \\in D_3}|\\mathrm{Fix}(g)| = 24 = 4\\cdot 6,\\qquad \\sum_{g \\in D_4}|\\mathrm{Fix}(g)| = 48 = 6\\cdot 8.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Burnside reduction", "kernel decide", "orbit count"],
+    "prerequisites": ["Burnside's lemma", "Fintype enumeration"]
+  },
+  {
+    "id": "ann-burnoq040102-match",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 130, "endLine": 166 },
+    "type": "insight",
+    "title": "The Closed Form Matches the Orbit Counts (n = 3..6)",
+    "content": "braceletClosed evaluates (kernel decide) to 4, 6, 8, 13 at n = 3, 4, 5, 6, and braceletClosed_eq_orbitCount_{three,four,five,six} rewrite each of these against the corresponding genuine orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)). Both reflection parities (odd n = 3, 5; even n = 4, 6) and both even-length axis types occur, so the formula is validated against Lean-checked ground truth across the full small-n range — not just against an OEIS table.",
+    "mathContext": "$\\mathrm{braceletClosed}(n) = |\\,\\mathrm{Coloring}(n)/D_n\\,|\\quad (n = 3,4,5,6).$",
+    "significance": "central",
+    "relatedConcepts": ["orbit quotient cardinality", "validation against ground truth", "reflection parity"],
+    "prerequisites": ["orbit quotients", "decidable equality of natural numbers"]
+  },
+  {
+    "id": "ann-burnoq040102-predictions",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 167, "endLine": 181 },
+    "type": "insight",
+    "title": "Predictions Beyond the Parents' Ceiling: b(7)..b(10)",
+    "content": "Once validated, the closed form yields b(7) = 18, b(8) = 30, b(9) = 46, b(10) = 78 (A000029(7..10)) by pure arithmetic on rotTerm and reflTerm — no orbit quotient is built or enumerated. These are exactly the lengths at which the parents' method (kernel decide on the orbit quotient) becomes infeasible, so the closed form's predictive reach is the concrete payoff of writing it down.",
+    "mathContext": "$b(7,8,9,10) = 18, 30, 46, 78.$",
+    "significance": "supporting",
+    "relatedConcepts": ["closed-form prediction", "computational ceiling", "OEIS A000029"],
+    "prerequisites": ["evaluating a closed-form ℕ expression"]
+  },
+  {
+    "id": "ann-burnoq040102-scope",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-02",
+    "range": { "startLine": 42, "endLine": 66 },
+    "type": "caveat",
+    "title": "Honest Scope: the Reflection Half Is Not Yet Generic",
+    "content": "The rotation half of the formula is proved equal to the true rotation total for all n (rotTerm_eq); the reflection half is used in its classical closed form and validated against the true orbit counts only for n ≤ 6. A fully generic Lean proof of the per-reflection count 2^(number of orbits of the reflection involution x ↦ -i - x) — the exact analogue of the sibling's rotation theorem — is the stated next open question and would upgrade braceletClosed n = A000029(n) from checked-for-small-n to a theorem for every n. Everything here is axiom-free: no native_decide, only kernel decide, so #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$|\\mathrm{Fix}(sr_i)| = 2^{\\#\\{\\text{orbits of } x \\mapsto -i-x\\}} = 2^{(n + |\\{x : 2x = -i\\}|)/2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["involution orbit count", "axiom audit", "open question"],
+    "prerequisites": ["reflections as involutions", "Burnside for the order-2 group"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "burnside-counting-oq-04-oq-01-oq-02",
+  "title": "A Closed Form for the Binary Bracelet Numbers via the Dihedral Burnside Sum",
+  "slug": "burnside-counting-oq-04-oq-01-oq-02",
+  "description": "Answers the standing open question of the burnside-counting-oq-04 line: replace the per-length kernel-decide computation of the binary bracelet numbers b(n) = A000029(n) by an explicit CLOSED FORM and pin it to ground truth. Burnside over DihedralGroup n (|D_n| = 2n) gives b(n) = (rotTerm n + reflTerm n) / 2n, where rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) is the rotation fixed-point total (n times the classical necklace count) and reflTerm n is the reflection total: for odd n every reflection fixes 2^((n+1)/2) colourings, for even n the n/2 vertex-axis reflections fix 2^(n/2+1) each and the n/2 edge-axis reflections fix 2^(n/2) each. The rotation half is tied to the true fixed-point counts by a general computation-free theorem rotTerm_eq (via the sibling's card_rotFixed = 2^gcd(n, i.val)); the whole formula is validated against the genuine dihedral orbit count |Coloring n / D_n| for n = 3, 4, 5, 6 (b(5), b(6) imported from the grandparent, b(3) = 4 and b(4) = 6 freshly Burnside-computed here, both reflection parities exercised). The closed form then PREDICTS b(7) = 18, b(8) = 30, b(9) = 46, b(10) = 78 by pure arithmetic — beyond the length-6 ceiling the parents reached by decide on the orbit quotient. Everything is axiom-free: no native_decide, only kernel decide on closed ℕ/finite data; #print axioms on the headlines reports only propext / Classical.choice / Quot.sound.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius (researcher-4)",
+    "date": "2026-07-02",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "necklaces",
+      "orbit-counting",
+      "closed-form",
+      "kernel-decide",
+      "native-decide-free",
+      "oeis-a000029"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-02",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide: the numeric closed-form evaluations and the two fresh Burnside fixed-point sums (24 for n=3, 48 for n=4) are all discharged by KERNEL decide on closed ℕ / finite data, so every headline depends only on propext, Classical.choice, Quot.sound (confirmed via #print axioms — no Lean.ofReduceBool, no sorryAx). Scope caveat: the rotation half of the formula is proved to equal the true rotation fixed-point total for all n (rotTerm_eq), but the reflection half is used in its classical closed form and validated against the true orbit counts only for n ≤ 6; a fully generic Lean proof of the per-reflection count 2^(orbits of the reflection involution) is the stated next open question and is NOT proved here.",
+    "lineCount": 189,
+    "theoremCount": 17,
+    "definitionCount": 3,
+    "verified": true,
+    "originalContributions": [
+      "braceletClosed n = (rotTerm n + reflTerm n) / (2n): the explicit closed form for the binary bracelet number b(n), written as the Burnside average of the rotation and reflection fixed-point totals over the 2n symmetries of DihedralGroup n",
+      "rotTerm_eq: a general, computation-free theorem that the rotation term rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) IS the true rotation fixed-point total Σ_i |Fix(r i)|, uniformly in n, straight from the sibling's card_rotFixed",
+      "fixed_sum_three / bracelet_three: Σ_{g ∈ D₃} |Fix(g)| = 24 by kernel decide (6 × 8) ⇒ b(3) = 24/6 = 4 = A000029(3), a fresh count the parent chain had not established",
+      "fixed_sum_four / bracelet_four: Σ_{g ∈ D₄} |Fix(g)| = 48 by kernel decide (8 × 16) ⇒ b(4) = 48/8 = 6 = A000029(4), recomputed with the generic action",
+      "braceletClosed_eq_orbitCount_{three,four,five,six}: the closed form equals the genuine dihedral orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for every n = 3,4,5,6 — both reflection parities and vertex/edge axes occur — pinning the formula to Lean-checked ground truth rather than an OEIS lookup",
+      "bracelet_seven … bracelet_ten: the closed form predicts b(7) = 18, b(8) = 30, b(9) = 46, b(10) = 78 (A000029(7..10)) by pure arithmetic, with no orbit quotient built or enumerated — beyond the length-6 kernel-decide ceiling of the parents"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BurnsideCountingOQ04OQ01OQ01",
+      "Proofs.BurnsideCountingOQ04OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction"
+    ],
+    "namespace": "BurnsideBraceletClosedForm",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "substantiveTheoremCount": 9,
+    "duplicateTheorems": 0,
+    "definitionCount": 3,
+    "path": "Proofs/BurnsideCountingOQ04OQ01OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "braceletClosed",
+      "type": "definition",
+      "description": "The closed form for the number of binary bracelets of length n: b(n) = (rotTerm n + reflTerm n) / (2n), the Burnside average of the rotation and reflection fixed-point totals over the 2n symmetries of DihedralGroup n.",
+      "leanType": "(n : ℕ) → [NeZero n] → ℕ := (rotTerm n + reflTerm n) / (2 * n)"
+    },
+    {
+      "name": "rotTerm_eq",
+      "type": "core",
+      "description": "The rotation term is genuine: rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) equals the true total of the numbers of colourings fixed by each rotation, uniformly in n and with no computation, because the sibling file proved |Fix(r i)| = 2^gcd(n, i.val).",
+      "leanType": "(n : ℕ) → [NeZero n] → rotTerm n = ∑ i : ZMod n, Fintype.card (BurnsideRotationFix.RotFixed n i)"
+    },
+    {
+      "name": "braceletClosed_eq_orbitCount_five",
+      "type": "core",
+      "description": "The closed form reproduces the genuine number of dihedral orbits at n = 5: braceletClosed 5 = Fintype.card (orbitRel.Quotient (DihedralGroup 5) (Coloring 5)) = 8, pinning the formula to the grandparent's ground-truth Burnside count.",
+      "leanType": "braceletClosed 5 = Fintype.card (orbitRel.Quotient (DihedralGroup 5) (BurnsideBracelets.Coloring 5))"
+    },
+    {
+      "name": "braceletClosed_eq_orbitCount_six",
+      "type": "core",
+      "description": "The closed form reproduces the genuine number of dihedral orbits at n = 6 (even length, both vertex- and edge-axis reflections): braceletClosed 6 = Fintype.card (orbitRel.Quotient (DihedralGroup 6) (Coloring 6)) = 13.",
+      "leanType": "braceletClosed 6 = Fintype.card (orbitRel.Quotient (DihedralGroup 6) (BurnsideBracelets.Coloring 6))"
+    },
+    {
+      "name": "bracelet_three",
+      "type": "supporting",
+      "description": "Fresh ground-truth Burnside count added here: Σ_{g ∈ D₃} |Fix(g)| = 24 by kernel decide gives Fintype.card (orbitRel.Quotient (DihedralGroup 3) (Coloring 3)) = 4 = A000029(3).",
+      "leanType": "Fintype.card (orbitRel.Quotient (DihedralGroup 3) (BurnsideBracelets.Coloring 3)) = 4"
+    },
+    {
+      "name": "bracelet_four",
+      "type": "supporting",
+      "description": "Ground-truth Burnside count via the generic action: Σ_{g ∈ D₄} |Fix(g)| = 48 by kernel decide gives Fintype.card (orbitRel.Quotient (DihedralGroup 4) (Coloring 4)) = 6 = A000029(4).",
+      "leanType": "Fintype.card (orbitRel.Quotient (DihedralGroup 4) (BurnsideBracelets.Coloring 4)) = 6"
+    },
+    {
+      "name": "bracelet_seven",
+      "type": "supporting",
+      "description": "Onward prediction of the closed form beyond the parents' computational ceiling: b(7) = 18 = A000029(7) by pure arithmetic (odd length; rotTerm = 128 + 6·2 = 140, reflTerm = 7·2^4 = 112, (140+112)/14 = 18), with no orbit quotient enumerated.",
+      "leanType": "braceletClosed 7 = 18"
+    },
+    {
+      "name": "bracelet_ten",
+      "type": "supporting",
+      "description": "Onward prediction: b(10) = 78 = A000029(10) from the closed form alone (even length; rotTerm = 1080, reflTerm = 5·2^6 + 5·2^5 = 480, (1080+480)/20 = 78).",
+      "leanType": "braceletClosed 10 = 78"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the cyclic rotation group ℤ/nℤ acting on the beads of an n-cycle it yields the binary necklace numbers N(n) = (1/n) Σ_{d ∣ n} φ(d) 2^{n/d}; for the dihedral group D_n, which adjoins the n reflections, it yields the bracelet numbers b(n) = A000029(n): 1, 2, 3, 4, 6, 8, 13, 18, 30, 46, 78, … for n = 0, 1, 2, …. The grandparent burnside-counting-oq-04-oq-01-oq-01 built the generic dihedral action and computed b(4) = 6, b(5) = 8, b(6) = 13 by kernel decide, one length at a time; its sibling burnside-counting-oq-04-oq-01-oq-01-oq-01 gave the ROTATION fixed-point count in closed form, |Fix(r i)| = 2^gcd(n, i.val), leaving the reflection half and the assembled closed form open. Writing down the classical closed form for b(n) and validating it against the machine-checked orbit counts is the natural completion.",
+    "problemStatement": "Replace the per-length kernel-decide computation of the binary bracelet numbers b(n) by an explicit closed form b(n) = (rotTerm n + reflTerm n) / (2n) assembled from the rotation and reflection fixed-point totals, tie the rotation term to the true fixed-point counts, validate the whole formula against the genuine dihedral orbit count |Coloring n / D_n| for small n, and use it to compute bracelet numbers beyond the length reachable by decide on the orbit quotient — all axiom-free (no native_decide).",
+    "text": "Burnside over D_n gives b(n)·2n = Σ_{g ∈ D_n} |Fix(g)| = (Σ_r 2^gcd(n,r)) + (reflection total). With rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) and reflTerm n = n·2^((n+1)/2) for odd n, (n/2)·2^(n/2+1) + (n/2)·2^(n/2) for even n, the bracelet number is braceletClosed n = (rotTerm n + reflTerm n) / (2n). The rotation term equals Σ_i |Fix(r i)| for every n (rotTerm_eq), and braceletClosed n matches Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for n = 3,4,5,6; it then yields b(7)=18, b(8)=30, b(9)=46, b(10)=78 by arithmetic alone.",
+    "proofStrategy": "Reuse the grandparent's generic dihedral action (DihedralGroup n on Coloring n = ZMod n → Fin 2) and its Burnside reduction bracelet_count_mul: bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)|. Define rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val), reflTerm n by the odd/even reflection dichotomy, and braceletClosed n = (rotTerm n + reflTerm n) / (2n). Prove rotTerm_eq by rewriting with the sibling's card_rotFixed (|Fix(r i)| = 2^gcd(n, i.val)) — no computation. Establish ground truth: fixed_sum_three = 24 and fixed_sum_four = 48 by kernel decide, then bracelet_three = 4 and bracelet_four = 6 by omega through bracelet_count_mul; import bracelet_five = 8 and bracelet_six = 13. Evaluate braceletClosed at 3,4,5,6 by kernel decide and rewrite each against the corresponding orbit count to get braceletClosed_eq_orbitCount_{three,four,five,six}. Finally evaluate braceletClosed at 7,8,9,10 by kernel decide for the onward predictions. Every decide is on closed ℕ / small finite data, so #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "keyInsights": [
+      "Burnside splits the bracelet count into a rotation total and a reflection total; the rotation total is exactly n times the classical necklace count and, by the sibling's card_rotFixed, equals Σ_{i} 2^gcd(n, i.val) with no computation — captured here as the general theorem rotTerm_eq",
+      "The reflection total has an odd/even dichotomy: for odd n all n reflections are conjugate and each fixes 2^((n+1)/2) colourings, while for even n the n/2 vertex-axis reflections fix 2^(n/2+1) and the n/2 edge-axis reflections fix 2^(n/2); reflTerm packages both regimes",
+      "Anchoring the formula: braceletClosed n is checked equal to the genuine orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for n = 3,4,5,6, so the closed form is validated against Lean-checked ground truth (both parities present), not merely against an OEIS table",
+      "Predictive reach: once validated, the closed form gives b(7)=18, b(8)=30, b(9)=46, b(10)=78 by pure arithmetic, never building the orbit quotient — precisely the lengths where decide on the quotient (the parents' method) becomes infeasible",
+      "Honesty of scope: only the rotation half is proved generically from the fixed-point counts; the reflection half is used in closed form and validated for n ≤ 6, with the fully generic per-reflection count left as the explicit next open question"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
+      "The dihedral group DihedralGroup n, |D_n| = 2n, and its rotation/reflection structure",
+      "Binary necklace and bracelet enumeration (OEIS A000029) and the reflection fixed-point dichotomy",
+      "Decidable equality and Fintype enumeration for kernel decide"
+    ]
+  },
+  "sections": [
+    {
+      "id": "formula",
+      "title": "The Closed-Form Formula",
+      "startLine": 68,
+      "endLine": 86,
+      "summary": "rotTerm n = Σ_{i : ZMod n} 2^gcd(n, i.val) (rotation total), reflTerm n by the odd/even reflection dichotomy, and braceletClosed n = (rotTerm n + reflTerm n) / (2n) — the Burnside average over the 2n dihedral symmetries.",
+      "mathContext": "$b(n) = \\dfrac{1}{2n}\\Big(\\sum_{i \\in \\mathbb{Z}/n} 2^{\\gcd(n,\\,i)} + R(n)\\Big),\\quad R(n) = \\begin{cases} n\\,2^{(n+1)/2} & n \\text{ odd} \\\\ \\tfrac{n}{2}\\,2^{n/2+1} + \\tfrac{n}{2}\\,2^{n/2} & n \\text{ even}\\end{cases}$"
+    },
+    {
+      "id": "rotterm",
+      "title": "The Rotation Term Is the True Fixed-Point Total",
+      "startLine": 88,
+      "endLine": 95,
+      "summary": "rotTerm_eq proves rotTerm n = Σ_{i : ZMod n} |Fix(r i)| uniformly in n by rewriting with the sibling's card_rotFixed (|Fix(r i)| = 2^gcd(n, i.val)) — no computation.",
+      "mathContext": "$\\mathrm{rotTerm}(n) = \\sum_{i \\in \\mathbb{Z}/n} |\\mathrm{Fix}(r_i)| = \\sum_{i} 2^{\\gcd(n,\\,i)}.$"
+    },
+    {
+      "id": "groundtruth",
+      "title": "Ground-Truth Burnside Counts b(3) = 4 and b(4) = 6",
+      "startLine": 97,
+      "endLine": 128,
+      "summary": "fixed_sum_three = 24 (6 × 8) and fixed_sum_four = 48 (8 × 16) by kernel decide feed the grandparent's bracelet_count_mul to give b(3) = 24/6 = 4 and b(4) = 48/8 = 6; b(5), b(6) are imported.",
+      "mathContext": "$\\sum_{g \\in D_3}|\\mathrm{Fix}(g)| = 24 = 4\\cdot 6,\\qquad \\sum_{g \\in D_4}|\\mathrm{Fix}(g)| = 48 = 6\\cdot 8.$"
+    },
+    {
+      "id": "match",
+      "title": "The Closed Form Matches the Orbit Counts, n = 3..6",
+      "startLine": 130,
+      "endLine": 183,
+      "summary": "braceletClosed evaluates to 4, 6, 8, 13 by kernel decide and equals the genuine orbit count Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) for each n = 3,4,5,6; the formula then predicts b(7)=18, b(8)=30, b(9)=46, b(10)=78 by arithmetic alone.",
+      "mathContext": "$\\mathrm{braceletClosed}(n) = |\\,\\mathrm{Coloring}(n)/D_n\\,|\\ (n \\le 6);\\quad b(7,8,9,10) = 18, 30, 46, 78.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Burnside over DihedralGroup n yields the explicit closed form b(n) = (rotTerm n + reflTerm n) / (2n) for the binary bracelet numbers. Its rotation half equals the true rotation fixed-point total for all n (rotTerm_eq), and the whole formula agrees with the machine-checked dihedral orbit count for n = 3,4,5,6 (b(3)=4 and b(4)=6 computed here, b(5)=8 and b(6)=13 imported). The formula then delivers b(7)=18, b(8)=30, b(9)=46, b(10)=78 by pure arithmetic, with 0 axioms beyond propext / Classical.choice / Quot.sound and no native_decide.",
+    "implications": "The bracelet numbers are now available by evaluating a closed-form ℕ expression rather than enumerating orbit quotients, which removes the length ceiling the parents hit with decide. The same rotTerm/reflTerm split, together with the generic rotation formula, is the scaffold for a fully symbolic derivation of A000029 and generalises to k-colour bracelets (Fin k) and to the corresponding necklace closed form.",
+    "openQuestions": [
+      "Prove the reflection fixed-point count in closed form generically, the exact analogue of the sibling's rotation theorem: for the reflection sr i, the number of fixed colourings is 2^(number of orbits of the involution x ↦ -i - x on ZMod n), i.e. 2^((n+1)/2) for odd n and 2^(n/2+1) or 2^(n/2) for even n according to the parity of i — thereby proving reflTerm n IS the true reflection total Σ_i |Fix(sr i)| and upgrading braceletClosed n = A000029(n) to a theorem for ALL n, not just n ≤ 6.",
+      "Assemble rotTerm_eq and the reflection analogue into a single closed-form identity b(n)·2n = Σ_{g ∈ D_n} |Fix(g)| valid for every n, and derive the standard N(n) = (1/n) Σ_{d ∣ n} φ(d) 2^{n/d} necklace form for the rotation part.",
+      "Generalise the closed form to k colours (Coloring n = ZMod n → Fin k), where rotTerm becomes Σ_i k^gcd(n, i.val) and the reflection term k^((n+1)/2) / k^(n/2+1) / k^(n/2), recovering the k-ary bracelet sequences."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Extends the grandparent's per-length kernel-decide bracelet counts b(5)=8, b(6)=13 (which it imports) into an explicit closed form b(n) = (rotTerm n + reflTerm n) / (2n), and adds the fresh ground-truth counts b(3)=4 and b(4)=6 with the same generic dihedral action."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+      "relationship": "builds-on",
+      "description": "Uses the sibling's rotation closed form card_rotFixed (|Fix(r i)| = 2^gcd(n, i.val)) to prove rotTerm_eq — that the rotation half of the bracelet formula is the true rotation fixed-point total — and completes its stated open question by supplying and validating the reflection half."
+    },
+    {
+      "targetId": "burnside-counting-oq-04",
+      "relationship": "extends",
+      "description": "Realises the index-2 folding programme of oq-04 as a concrete closed form: the reflection total it left abstract is written explicitly and the assembled b(n) is validated against the true dihedral orbit counts for n ≤ 6."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral bracelet counts (OEIS A000029)"
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A000029: Number of necklaces (bracelets) with n beads of 2 colors, allowing turning over",
+      "year": "2024",
+      "note": "b(3..10) = 4, 6, 8, 13, 18, 30, 46, 78 are the n = 3..10 terms reproduced and predicted here"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Assembles the classical **closed form for the binary bracelet numbers** `b(n) = A000029(n)` via the dihedral Burnside sum, ties its rotation half to the true fixed-point counts, validates the whole formula against Lean-checked orbit counts for `n = 3..6`, and uses it to predict `b(7)..b(10)` beyond the parents' computational reach.

```
braceletClosed n = (rotTerm n + reflTerm n) / (2n)              -- |D_n| = 2n
rotTerm n  = Σ_{i : ZMod n} 2^gcd(n, i.val)                     -- rotation total (n·necklaces)
reflTerm n = n·2^((n+1)/2)                       (odd n)        -- reflection total
             (n/2)·2^(n/2+1) + (n/2)·2^(n/2)     (even n)
```

## What is proved

- **`rotTerm_eq`** — for all `n`, `rotTerm n = Σ_i |Fix(r i)|`, computation-free, via the sibling's `card_rotFixed = 2^gcd(n, i.val)`.
- **`braceletClosed_eq_orbitCount_{three,four,five,six}`** — the closed form equals the genuine `Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n))` for `n = 3,4,5,6`. `b(3)=4` and `b(4)=6` are freshly Burnside-computed here (kernel `decide` on the fixed-point sums `24`, `48`); `b(5)=8`, `b(6)=13` imported from the grandparent. Both reflection parities and even-length axis types occur.
- **`bracelet_seven … bracelet_ten`** — the formula predicts `b(7)=18, b(8)=30, b(9)=46, b(10)=78` by pure arithmetic, no orbit quotient enumerated — beyond the length-6 kernel-`decide` ceiling of the parents.

Answers the standing open question of `burnside-counting-oq-04-oq-01-oq-01(-oq-01)`: *"replace the per-`n` `decide` by a closed form for `b(n) = A000029(n)`."*

## Verification / axioms

- Builds clean against Mathlib 4.26.0: `./proofs/scripts/docker-build.sh Proofs.BurnsideCountingOQ04OQ01OQ02` (Build succeeded, 7745 jobs).
- **Axiom-free**: no `native_decide`; `#print axioms` on the headlines reports only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`). `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0`.

## Honest scope

The **rotation** half is proved generically (`rotTerm_eq`). The **reflection** half is used in its classical closed form and validated against the true orbit counts only for `n ≤ 6`; a fully generic proof of the per-reflection count `2^(orbits of the reflection involution)` is the stated next open question (see `openQuestions`).

## Files

- `proofs/Proofs/BurnsideCountingOQ04OQ01OQ02.lean` (new, 189 lines, 17 theorems, 3 defs)
- `src/data/proofs/burnside-counting-oq-04-oq-01-oq-02/{meta.json,annotations.json}` (gallery entry, `mainTheorems` included)
- `research/problems/burnside-counting-oq-04-oq-01-oq-02/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)