### PR TITLE
research(lovasz-local-lemma-oq-01): quantitative avoidance lower bound ∏(1−bₖ) ≤ μ(⋂ Aᵢᶜ)

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01Quantitative.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01Quantitative.lean
@@ -1,0 +1,114 @@
+/-
+# Lovász Local Lemma — OQ-01: Quantitative Avoidance Lower Bound
+
+`Proofs/LovaszLocalLemmaOQ01ChainRule.lean` reduces the measure-theoretic LLL to a
+per-event conditional bound and proves the *qualitative* conclusion
+`avoidance_pos_of_failure_cond_lt_one'`: if every conditional failure probability
+`μ[Aₖ | ⋂_{j<k} Aⱼᶜ]` is `< 1`, then the events are avoided with **positive**
+probability. That is only the positivity half of the Lovász Local Lemma.
+
+The LLL actually delivers a **quantitative** lower bound. This file lands it: if
+every conditional failure probability is bounded by `bₖ < 1`, then
+
+  `∏ₖ (1 - bₖ) ≤ μ (⋂ᵢ Aᵢᶜ)`.
+
+This is the honest measure-theoretic analogue of the rational-surrogate
+`general_lll` in the gallery proof `LovaszLocalLemma.lean` (which merely records
+`∏ (1 - xᵢ) > 0` over `ℚ`): here `∏ (1 - bₖ)` is a genuine *lower bound on the real
+avoidance probability over an arbitrary probability space*, not a stand-alone
+budget. Positivity (`avoidance_pos_of_failure_cond_lt_one'`) is recovered as the
+special case where the product is itself positive, but the quantitative bound is
+strictly stronger — it pins how large the avoidance probability must be.
+
+The proof reuses the chain-rule scaffold with no new probabilistic input: the
+survival product `μ (⋂ Aᵢᶜ) = ∏ μ[Aₖᶜ | history]` factors the avoidance
+probability, history positivity is automatic from the failure bounds
+(`hist_pos_of_failure_cond_lt_one`), and on each positive history the survival
+conditional is `1 - μ[Aₖ | history] ≥ 1 - bₖ` (antitone truncated subtraction).
+Monotonicity of the finite `ℝ≥0∞` product finishes.
+
+## Main results
+
+* `avoidance_ge_prod_one_sub` : the quantitative LLL lower bound
+  `∏ₖ (1 - bₖ) ≤ μ (⋂ᵢ Aᵢᶜ)` from per-event conditional failure bounds `bₖ < 1`.
+* `avoidance_ge_one_sub_pow` : the symmetric specialisation — a uniform bound
+  `μ[Aₖ | history] ≤ p < 1` gives `(1 - p)ⁿ ≤ μ (⋂ᵢ Aᵢᶜ)`.
+* `avoidance_pos_of_prod_one_sub_pos` : the quantitative bound recovers
+  positivity, since `0 < ∏ₖ (1 - bₖ)` whenever every `bₖ < 1`.
+
+No independence hypothesis is used anywhere; everything is `Finset.range`-indexed
+over an arbitrary `IsProbabilityMeasure`.
+-/
+import Proofs.LovaszLocalLemmaOQ01ChainRule
+
+open MeasureTheory ProbabilityTheory Finset
+open scoped ENNReal
+open LovaszLocalLemmaOQ01ChainRule
+
+namespace LovaszLocalLemmaOQ01Quantitative
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A : ℕ → Set Ω}
+
+/-- **Quantitative Lovász Local Lemma lower bound.**
+If every conditional failure probability `μ[Aₖ | ⋂_{j<k} Aⱼᶜ]` is bounded by some
+`bₖ < 1`, then the avoidance probability is at least the product of the survival
+budgets:
+
+  `∏ₖ (1 - bₖ) ≤ μ (⋂ᵢ Aᵢᶜ)`.
+
+This is the honest measure-theoretic form of the LLL conclusion `μ (⋂ Aᵢᶜ) ≥
+∏ (1 - xᵢ)` — a real lower bound on the avoidance probability, not a rational
+budget surrogate. It strengthens `avoidance_pos_of_failure_cond_lt_one'` (which
+gives only positivity) to a quantitative estimate.
+
+Proof: the survival-product identity `avoidance_eq_prod_survival_cond` rewrites the
+avoidance probability as `∏ₖ μ[Aₖᶜ | history]`; history positivity is automatic
+(`hist_pos_of_failure_cond_lt_one`), so on each history the survival conditional is
+`1 - μ[Aₖ | history] ≥ 1 - bₖ` by antitonicity of truncated subtraction; monotonicity
+of the finite `ℝ≥0∞` product closes it. -/
+theorem avoidance_ge_prod_one_sub (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)
+    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)
+    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) :
+    ∏ k ∈ Finset.range n, (1 - b k) ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by
+  rw [avoidance_eq_prod_survival_cond hA]
+  refine Finset.prod_le_prod' fun k hk => ?_
+  -- membership propagation: for `m < k` (`< n`) the hypotheses at `m` still apply
+  have hkn : k < n := Finset.mem_range.mp hk
+  have hposk : μ (⋂ j ∈ Finset.range k, (A j)ᶜ) ≠ 0 :=
+    hist_pos_of_failure_cond_lt_one hA k fun m hm =>
+      lt_of_le_of_lt (hfail m (Finset.mem_range.mpr (lt_trans (Finset.mem_range.mp hm) hkn)))
+        (hb m (Finset.mem_range.mpr (lt_trans (Finset.mem_range.mp hm) hkn)))
+  -- on the positive history, survival = 1 - failure ≥ 1 - bₖ
+  rw [survival_cond_eq_one_sub hA k hposk]
+  exact tsub_le_tsub_left (hfail k hk) 1
+
+/-- **Symmetric quantitative LLL bound.**
+If every conditional failure probability is bounded by a single uniform `p < 1`,
+then `(1 - p)ⁿ ≤ μ (⋂ᵢ Aᵢᶜ)`. This is the symmetric-regime specialisation of
+`avoidance_ge_prod_one_sub` and the quantitative shape the symmetric LLL produces
+(under `e·p·(d+1) ≤ 1` the induction certifies each conditional failure `≤ p`). -/
+theorem avoidance_ge_one_sub_pow (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) (p : ℝ≥0∞)
+    (hp : p < 1)
+    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ p) :
+    (1 - p) ^ n ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by
+  have h := avoidance_ge_prod_one_sub hA n (fun _ => p) (fun _ _ => hp) hfail
+  simpa [Finset.prod_const, Finset.card_range] using h
+
+/-- **Positivity recovered from the quantitative bound.**
+Since every `bₖ < 1` makes each survival budget `1 - bₖ` strictly positive, the
+product lower bound `∏ (1 - bₖ)` is itself positive, so
+`avoidance_ge_prod_one_sub` re-derives `avoidance_pos_of_failure_cond_lt_one'` as a
+corollary — the qualitative LLL is the quantitative one read at the coarsest
+resolution. -/
+theorem avoidance_pos_of_prod_one_sub_pos (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)
+    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)
+    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) :
+    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by
+  refine lt_of_lt_of_le ?_ (avoidance_ge_prod_one_sub hA n b hb hfail)
+  rw [zero_lt_iff, Finset.prod_ne_zero_iff]
+  intro k hk
+  rw [Ne, tsub_eq_zero_iff_le, not_le]
+  exact hb k hk
+
+end LovaszLocalLemmaOQ01Quantitative

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -161,3 +161,37 @@ Insights accumulated during research on this problem.
   `cond_mul_eq_inter (hms) (t) (μ)` needs `[IsFiniteMeasure μ]` only (not
   probability), and holds unconditionally including the measure-zero case, which
   is why the chain rule needs NO positive-measure hypotheses.
+
+### Quantitative lower bound (researcher-4, 2026-07-03) — NEW
+
+- **The chain-rule reduction upgrades from positivity to the quantitative LLL
+  bound with one order-theoretic step.** New file
+  `Proofs/LovaszLocalLemmaOQ01Quantitative.lean` (0 sorry / 0 axiom), gallery entry
+  `lovasz-local-lemma-oq-01-quantitative`: if `μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1`
+  for all `k < n`, then `∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ)` (`avoidance_ge_prod_one_sub`).
+  This is the honest measure-theoretic form of `μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ)`: the parent
+  proof's rational surrogate `∏(1 − xᵢ)` is a *verified lower bound on the real
+  avoidance probability*, not just an analogue.
+- **Route (reuses the chain-rule scaffold, no new probability).** `rw
+  [avoidance_eq_prod_survival_cond hA]` turns the RHS into `∏ₖ μ[(A k)ᶜ | history]`;
+  `Finset.prod_le_prod'` (finite-product monotonicity in a canonically ordered
+  comm monoid — works directly for ℝ≥0∞) reduces to the factorwise bound; on each
+  history (positive via `hist_pos_of_failure_cond_lt_one`, since `bₖ < 1` ⇒
+  `μ[A k|history] < 1`) `survival_cond_eq_one_sub` gives `survival = 1 − failure`,
+  and `tsub_le_tsub_left (hfail k hk) 1` gives `1 − bₖ ≤ 1 − μ[A k|history]`.
+- **Symmetric form.** `avoidance_ge_one_sub_pow`: constant `bₖ = p` collapses via
+  `Finset.prod_const` + `Finset.card_range` to `(1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ)` — the
+  multiplicative counterpart of the union-bound extreme's additive `1 − np`.
+- **Positivity subsumed.** `avoidance_pos_of_prod_one_sub_pos` re-derives the
+  chain-rule entry's `avoidance_pos_of_failure_cond_lt_one'` from the strictly
+  stronger quantitative bound (`∏(1 − bₖ) > 0` via `zero_lt_iff` +
+  `Finset.prod_ne_zero_iff` + `tsub_eq_zero_iff_le`).
+- **Key API note.** `Finset.prod_le_prod'` (the multiplicative/`OrderedCommMonoid`
+  lemma) applies to ℝ≥0∞ products of the form `∏ f ≤ ∏ g` given `∀ i ∈ s, f i ≤ g i`
+  — no nonnegativity side goals, unlike the ordered-semiring `Finset.prod_le_prod`.
+  Membership propagation `m < k < n ⟹ m ∈ range n` needs `lt_trans` on the two
+  `Finset.mem_range` facts.
+- **What remains open (unchanged).** The per-event bounds `bₖ` are hypotheses;
+  deriving them from a measure-theoretic dependency structure (`bₖ = 2p` under
+  `e·p·(d+1) ≤ 1`) is the open target. This entry guarantees the quantitative LLL
+  conclusion then follows with no further probability theory.

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,12 +1,56 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ACT (two computable extremes + chain-rule scaffold landed; scaffold now reduces the LLL to a single per-event obligation. General dependency-degree LLL still open)
+**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound landed; the LLL conclusion is now stated quantitatively over a real probability space, reduced to a single per-event obligation. General dependency-degree LLL still open)
 **Path**: full
 **Since**: 2026-06-27
-**Iteration**: 7
+**Iteration**: 8
 
-## This session (researcher-6, 2026-07-03)
+## This session (researcher-4, 2026-07-03)
+
+**Upgraded the chain-rule reduction from qualitative positivity to the quantitative
+LLL lower bound.** The chain-rule scaffold (`LovaszLocalLemmaOQ01ChainRule.lean`)
+reduced the measure-theoretic LLL to per-event conditional failure bounds but proved
+only the *qualitative* half — `avoidance_pos_of_failure_cond_lt_one'`: failure
+conditionals `< 1` ⇒ avoidance positive. The Lovász Local Lemma is actually a
+*quantitative* statement (`μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ)`, of which positivity is a corollary).
+This session lands the quantitative bound in a new self-contained, **0-axiom /
+0-sorry** file `Proofs/LovaszLocalLemmaOQ01Quantitative.lean` (new gallery entry
+`lovasz-local-lemma-oq-01-quantitative`). Verified via `lake env lean` (exit 0)
+against the main-repo Mathlib + ChainRule `.olean` cache; `#print axioms` on all
+three theorems = propext / Classical.choice / Quot.sound only.
+
+### New verified theorems (quantitative avoidance lower bound)
+1. **`avoidance_ge_prod_one_sub`** *(flagship)* — if every conditional failure
+   probability `μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1`, then
+   `∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ)`. The honest measure-theoretic form of the LLL
+   conclusion `μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ)` — a genuine lower bound on the real avoidance
+   probability, not the parent proof's ℚ-valued surrogate `∏(1 − xᵢ)`.
+2. **`avoidance_ge_one_sub_pow`** — symmetric specialisation: a uniform bound
+   `μ[A k | history] ≤ p < 1` gives `(1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ)`. The quantitative shape
+   the symmetric LLL produces.
+3. **`avoidance_pos_of_prod_one_sub_pos`** — positivity recovered from the
+   quantitative bound (`∏(1 − bₖ) > 0` since each `bₖ < 1`), re-deriving
+   `avoidance_pos_of_failure_cond_lt_one'` as the coarse corollary.
+
+### Proof technique (no new probabilistic input)
+`avoidance_eq_prod_survival_cond` (from the chain-rule entry) rewrites the avoidance
+probability as the finite `ℝ≥0∞` product `∏ₖ μ[(A k)ᶜ | history]`; `Finset.prod_le_prod'`
+reduces the inequality to the *factorwise* bound `1 − bₖ ≤ survival`; on each history
+(positive automatically via `hist_pos_of_failure_cond_lt_one`) `survival_cond_eq_one_sub`
+gives `survival = 1 − μ[A k | history]`, and antitonicity of truncated subtraction
+`tsub_le_tsub_left` converts `μ[A k | history] ≤ bₖ` into `1 − bₖ ≤ 1 − μ[A k | history]`.
+The quantitative bound is the qualitative reduction plus one order-theoretic step.
+
+### Significance (honest)
+The chain rule already did the probabilistic work; this closes the qualitative→
+quantitative gap so the gallery states the LLL conclusion in the form the theorem is
+really about. The per-event bounds `bₖ` remain hypotheses — deriving them
+(`bₖ = 2p` under `e·p·(d+1) ≤ 1`) from a measure-theoretic dependency structure is the
+still-open target. This entry guarantees that once those bounds are in hand, the
+quantitative LLL conclusion follows with no further probability theory.
+
+## Prior session (researcher-6, 2026-07-03)
 
 **Sharpened the chain-rule scaffold: the LLL reduction is now hypothesis-clean.**
 The prior session (researcher-6, PR #34024) landed

--- a/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-lll-oq01-quant-overview",
+    "proofId": "lovasz-local-lemma-oq-01-quantitative",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "From avoidance positivity to the quantitative LLL lower bound",
+    "content": "The Lovász Local Lemma is a **quantitative** statement: under its hypotheses one gets not merely $\\mu(\\bigcap_i A_i^c) > 0$ but the lower bound $\\mu(\\bigcap_i A_i^c) \\ge \\prod_i (1 - x_i)$, of which positivity is only a corollary. The gallery's chain-rule scaffold `lovasz-local-lemma-oq-01-chain-rule` reduced the LLL to per-event conditional bounds and proved exactly the qualitative half — `avoidance_pos_of_failure_cond_lt_one'`: if every conditional failure probability $\\mu[A_k \\mid \\bigcap_{j<k} A_j^c] < 1$, avoidance is positive. This file lands the quantitative bound the theorem is really about:\n$$\\prod_k (1 - b_k) \\;\\le\\; \\mu\\!\\left(\\bigcap_i A_i^c\\right) \\qquad\\text{whenever } \\mu[A_k \\mid \\text{history}] \\le b_k < 1.$$\nRead against the parent proof `lovasz-local-lemma` (whose `general_lll` only records the rational surrogate $\\prod(1 - x_i) > 0$ over $\\mathbb{Q}$), the point is that $\\prod(1 - b_k)$ is a *genuine lower bound on the real avoidance probability* over an arbitrary probability space — the surrogate is not merely analogous to the true measure, it bounds it.",
+    "mathContext": "Arbitrary measurable family $A : \\mathbb{N} \\to \\mathrm{Set}\\,\\Omega$ over an `IsProbabilityMeasure` $\\mu$; per-event conditional failure bounds $b_k < 1$ are the only hypotheses (history positivity is derived). No independence, no dependency graph.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "avoidance probability lower bound",
+      "conditional probability",
+      "survival product",
+      "measure-theoretic probability"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01-chain-rule (survival-product scaffold)",
+      "conditional probability μ[t|s]",
+      "ℝ≥0∞ truncated subtraction"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-quant-setup",
+    "proofId": "lovasz-local-lemma-oq-01-quantitative",
+    "range": {
+      "startLine": 42,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "Frame: reuse the chain-rule scaffold",
+    "content": "```lean\nimport Proofs.LovaszLocalLemmaOQ01ChainRule\nopen MeasureTheory ProbabilityTheory Finset\nopen scoped ENNReal\nopen LovaszLocalLemmaOQ01ChainRule\nnamespace LovaszLocalLemmaOQ01Quantitative\nvariable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]\nvariable {A : ℕ → Set Ω}\n```\n\nThe file imports the chain-rule entry directly and adds **no new probabilistic input**. Everything downstream is assembled from three lemmas proved there: the survival-product identity `avoidance_eq_prod_survival_cond` ($\\mu(\\bigcap (A_i)^c) = \\prod_k \\mu[(A_k)^c \\mid \\text{history}]$), the factorwise bridge `survival_cond_eq_one_sub` ($\\mu[(A_k)^c \\mid \\text{history}] = 1 - \\mu[A_k \\mid \\text{history}]$ on a positive history), and the automatic history positivity `hist_pos_of_failure_cond_lt_one`. The same $\\mathbb{N}$-prefix ordering (`Finset.range`) is inherited, since the chain rule needs a total order on the events.",
+    "mathContext": "`μ[t|s]` is `ProbabilityTheory.cond μ s t`; all quantities live in `ℝ≥0∞`, where truncated subtraction `1 - c` and finite products are the working algebra.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conditional probability cond μ s t",
+      "survival-product identity",
+      "ℝ≥0∞ (ENNReal)"
+    ],
+    "prerequisites": [
+      "avoidance_eq_prod_survival_cond",
+      "survival_cond_eq_one_sub",
+      "hist_pos_of_failure_cond_lt_one"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-quant-main",
+    "proofId": "lovasz-local-lemma-oq-01-quantitative",
+    "range": {
+      "startLine": 52,
+      "endLine": 89
+    },
+    "type": "proof-step",
+    "title": "The quantitative avoidance lower bound",
+    "content": "```lean\ntheorem avoidance_ge_prod_one_sub (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)\n    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)\n    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) :\n    ∏ k ∈ Finset.range n, (1 - b k) ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by\n  rw [avoidance_eq_prod_survival_cond hA]\n  refine Finset.prod_le_prod' fun k hk => ?_\n  ...\n  rw [survival_cond_eq_one_sub hA k hposk]\n  exact tsub_le_tsub_left (hfail k hk) 1\n```\n\nThe entire quantitative content is one order-theoretic step on top of the chain-rule scaffold. First `avoidance_eq_prod_survival_cond` rewrites the goal's right-hand side as the finite $\\mathbb{R}_{\\ge 0}^\\infty$ product $\\prod_k \\mu[(A_k)^c \\mid \\text{history}]$. Then `Finset.prod_le_prod'` (monotonicity of a finite product in a canonically ordered commutative monoid) reduces the inequality to a **factorwise** bound $1 - b_k \\le \\mu[(A_k)^c \\mid \\text{history}]$ for each $k \\in \\mathrm{range}\\,n$. For that factor: the history $\\bigcap_{j<k}(A_j)^c$ has positive measure automatically — `hist_pos_of_failure_cond_lt_one` derives it from the failure bounds, since $b_k < 1$ forces each $\\mu[A_k \\mid \\text{history}] \\le b_k < 1$ — so `survival_cond_eq_one_sub` turns the survival factor into $1 - \\mu[A_k \\mid \\text{history}]$, and antitonicity of truncated subtraction `tsub_le_tsub_left` converts $\\mu[A_k \\mid \\text{history}] \\le b_k$ into $1 - b_k \\le 1 - \\mu[A_k \\mid \\text{history}]$.",
+    "mathContext": "The membership propagation `m < k < n ⟹ m ∈ range n` (via `lt_trans`) is what lets the per-index history positivity call reuse the global failure/upper bounds. No factor needs a uniform bound — each is handled locally in ℝ≥0∞.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Finset.prod_le_prod' (product monotonicity)",
+      "tsub_le_tsub_left (antitone truncated subtraction)",
+      "survival = 1 − failure",
+      "automatic history positivity"
+    ],
+    "prerequisites": [
+      "avoidance_eq_prod_survival_cond",
+      "survival_cond_eq_one_sub",
+      "hist_pos_of_failure_cond_lt_one",
+      "Finset.prod_le_prod'"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-quant-symmetric",
+    "proofId": "lovasz-local-lemma-oq-01-quantitative",
+    "range": {
+      "startLine": 90,
+      "endLine": 102
+    },
+    "type": "proof-step",
+    "title": "Symmetric specialisation: (1 − p)ⁿ",
+    "content": "```lean\ntheorem avoidance_ge_one_sub_pow (hA : ∀ i, MeasurableSet (A i)) (n : ℕ) (p : ℝ≥0∞)\n    (hp : p < 1)\n    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ p) :\n    (1 - p) ^ n ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by\n  have h := avoidance_ge_prod_one_sub hA n (fun _ => p) (fun _ _ => hp) hfail\n  simpa [Finset.prod_const, Finset.card_range] using h\n```\n\nInstantiating the general bound at the constant budget $b_k \\equiv p$ collapses the product $\\prod_{k \\in \\mathrm{range}\\,n}(1 - p)$ to $(1 - p)^n$ via `Finset.prod_const` and `Finset.card_range`. This is the **symmetric-regime** quantitative LLL bound: a single uniform conditional failure bound $p < 1$ yields an avoidance probability at least exponentially small in $n$ — precisely the shape the symmetric LLL delivers (under $e \\cdot p \\cdot (d+1) \\le 1$ the induction certifies each conditional failure $\\le p$).",
+    "mathContext": "The exponential lower bound $(1-p)^n$ is the quantitative counterpart of the union-bound extreme's additive $1 - np$; both bound the same avoidance probability from below under different hypotheses.",
+    "significance": "central",
+    "relatedConcepts": [
+      "symmetric Lovász Local Lemma",
+      "Finset.prod_const",
+      "exponential avoidance lower bound"
+    ],
+    "prerequisites": [
+      "avoidance_ge_prod_one_sub"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-quant-positivity",
+    "proofId": "lovasz-local-lemma-oq-01-quantitative",
+    "range": {
+      "startLine": 103,
+      "endLine": 114
+    },
+    "type": "proof-step",
+    "title": "Positivity is the quantitative bound at coarsest resolution",
+    "content": "```lean\ntheorem avoidance_pos_of_prod_one_sub_pos (hA : ∀ i, MeasurableSet (A i)) (n : ℕ)\n    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)\n    (hfail : ∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) :\n    0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ) := by\n  refine lt_of_lt_of_le ?_ (avoidance_ge_prod_one_sub hA n b hb hfail)\n  rw [zero_lt_iff, Finset.prod_ne_zero_iff]\n  intro k hk\n  rw [Ne, tsub_eq_zero_iff_le, not_le]\n  exact hb k hk\n```\n\nThe qualitative Lovász Local Lemma is recovered as a corollary: since every $b_k < 1$ makes the survival budget $1 - b_k$ strictly positive (`tsub_eq_zero_iff_le`), the finite product $\\prod_k(1 - b_k)$ is nonzero (`Finset.prod_ne_zero_iff`), hence strictly positive, and it lower-bounds the avoidance probability. So $0 < \\mu(\\bigcap(A_i)^c)$ — reproving `avoidance_pos_of_failure_cond_lt_one'` from the strictly stronger quantitative estimate. Positivity is the quantitative bound read at its coarsest resolution: it forgets *how large* $\\prod(1 - b_k)$ is and keeps only that it is nonzero.",
+    "mathContext": "This makes explicit that the chain-rule entry's positivity result is not lost but subsumed — the gallery's OQ-01 landscape now states the LLL conclusion quantitatively, with qualitative positivity as a derived special case.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "zero_lt_iff",
+      "Finset.prod_ne_zero_iff",
+      "qualitative vs quantitative LLL"
+    ],
+    "prerequisites": [
+      "avoidance_ge_prod_one_sub"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-quantitative/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "lovasz-local-lemma-oq-01-quantitative",
+  "title": "Lovász Local Lemma OQ-01: Quantitative Avoidance Lower Bound",
+  "slug": "lovasz-local-lemma-oq-01-quantitative",
+  "description": "The quantitative measure-theoretic Lovász Local Lemma conclusion, over an arbitrary real IsProbabilityMeasure with no independence hypothesis. The gallery's chain-rule scaffold (lovasz-local-lemma-oq-01-chain-rule) reduces the LLL to a per-event conditional bound and proves only the qualitative half — avoidance_pos_of_failure_cond_lt_one': if every conditional failure probability μ[A k | ⋂_{j<k}(A j)ᶜ] < 1, avoidance has positive probability. But the Lovász Local Lemma actually delivers a quantitative lower bound, and this entry lands it: if every conditional failure probability is bounded by some bₖ < 1, then ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ). This is the honest measure-theoretic analogue of the rational-surrogate general_lll in the parent proof lovasz-local-lemma (which only records ∏(1 − xᵢ) > 0 over ℚ): here ∏(1 − bₖ) is a genuine lower bound on the real avoidance probability over a probability space, not a stand-alone budget. Qualitative positivity is recovered as the special case where the product is itself positive (avoidance_pos_of_prod_one_sub_pos), and the symmetric specialisation avoidance_ge_one_sub_pow gives (1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ) from a uniform failure bound p < 1 — the quantitative shape the symmetric LLL produces. The proof adds no new probabilistic input: it multiplies the survival-product identity avoidance_eq_prod_survival_cond by the factorwise bound survival = 1 − failure ≥ 1 − bₖ (antitone truncated subtraction), with history positivity supplied automatically by hist_pos_of_failure_cond_lt_one. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01Quantitative.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "conditional-probability"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on all three theorems). IsProbabilityMeasure is an explicit hypothesis. All results take the per-event conditional failure bounds as explicit hypotheses; history positivity is NOT assumed (it is discharged internally via hist_pos_of_failure_cond_lt_one from the chain-rule entry). Scope: this entry lands the quantitative avoidance lower bound as a consequence of the chain-rule survival product plus factorwise truncated-subtraction monotonicity. It does NOT prove the bounded-dependency-degree symmetric LLL bound (e·p·(d+1) ≤ 1) — that remains the open research target; here the per-event conditional bounds bₖ are hypotheses, and the open work is to derive them from a dependency structure.",
+    "lineCount": 114,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "avoidance_ge_prod_one_sub: the quantitative measure-theoretic LLL lower bound ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ) from per-event conditional failure bounds μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1. This is the honest form of the LLL conclusion μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) — a real lower bound on the avoidance probability over an arbitrary probability space, strictly stronger than the qualitative positivity avoidance_pos_of_failure_cond_lt_one'. Proved by rewriting with the survival-product identity avoidance_eq_prod_survival_cond and bounding each ℝ≥0∞ factor: history positivity is automatic (hist_pos_of_failure_cond_lt_one), so survival_cond_eq_one_sub gives μ[(A k)ᶜ | history] = 1 − μ[A k | history] ≥ 1 − bₖ (tsub_le_tsub_left, antitone truncated subtraction), and Finset.prod_le_prod' lifts the factorwise bound to the product.",
+      "avoidance_ge_one_sub_pow: the symmetric specialisation — a single uniform bound μ[A k | history] ≤ p < 1 gives (1 − p)ⁿ ≤ μ(⋂ᵢ (A i)ᶜ). Obtained from avoidance_ge_prod_one_sub with the constant budget bₖ = p (Finset.prod_const, Finset.card_range). This is the quantitative shape the symmetric LLL delivers: under e·p·(d+1) ≤ 1 the induction certifies each conditional failure ≤ p, yielding an exponential-in-n avoidance lower bound.",
+      "avoidance_pos_of_prod_one_sub_pos: the quantitative bound recovers the qualitative one. Since every bₖ < 1 makes each survival budget 1 − bₖ strictly positive, the product lower bound ∏(1 − bₖ) is itself positive (zero_lt_iff, Finset.prod_ne_zero_iff, tsub_eq_zero_iff_le), so avoidance positivity follows from avoidance_ge_prod_one_sub — the qualitative LLL is the quantitative one read at the coarsest resolution.",
+      "Framing contribution: this closes the gap between the chain-rule reduction (which reduced the LLL to per-event conditional bounds and proved only positivity of the avoidance probability) and the actual LLL conclusion, which is a quantitative lower bound. Making the lower bound ∏(1 − bₖ) a verified theorem over a real probability space — rather than the parent proof's ℚ-valued surrogate ∏(1 − xᵢ) — pins exactly how large the avoidance probability must be, and shows the surrogate budget is a genuine lower bound on the true measure."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.LovaszLocalLemmaOQ01ChainRule"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Finset",
+      "LovaszLocalLemmaOQ01ChainRule"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01Quantitative",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01Quantitative.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LovaszLocalLemmaOQ01ChainRule.lean"
+    ]
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "avoidance_ge_prod_one_sub",
+      "type": "core",
+      "description": "Quantitative Lovász Local Lemma lower bound: if every conditional failure probability μ[A k | ⋂_{j<k}(A j)ᶜ] is bounded by bₖ < 1, then the avoidance probability is at least the product of the survival budgets, ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ). The honest measure-theoretic form of the LLL conclusion μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) — a real lower bound, not a rational budget surrogate.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → (b : ℕ → ℝ≥0∞) → (∀ k ∈ Finset.range n, b k < 1) → (∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) → ∏ k ∈ Finset.range n, (1 - b k) ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ)"
+    },
+    {
+      "name": "avoidance_ge_one_sub_pow",
+      "type": "corollary",
+      "description": "Symmetric quantitative LLL bound: if every conditional failure probability is bounded by a single uniform p < 1, then (1 − p)ⁿ ≤ μ(⋂ᵢ (A i)ᶜ). The symmetric-regime specialisation of avoidance_ge_prod_one_sub and the quantitative shape the symmetric LLL produces.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → (p : ℝ≥0∞) → p < 1 → (∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ p) → (1 - p) ^ n ≤ μ (⋂ i ∈ Finset.range n, (A i)ᶜ)"
+    },
+    {
+      "name": "avoidance_pos_of_prod_one_sub_pos",
+      "type": "corollary",
+      "description": "Positivity recovered from the quantitative bound: since every bₖ < 1 makes each survival budget 1 − bₖ strictly positive, the product lower bound is itself positive, so avoidance_ge_prod_one_sub re-derives the qualitative avoidance positivity avoidance_pos_of_failure_cond_lt_one' — the qualitative LLL is the quantitative one read at the coarsest resolution.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (n : ℕ) → (b : ℕ → ℝ≥0∞) → (∀ k ∈ Finset.range n, b k < 1) → (∀ k ∈ Finset.range n, μ[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k) → 0 < μ (⋂ i ∈ Finset.range n, (A i)ᶜ)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) is stated quantitatively: when each of n bad events has probability ≤ p and is mutually independent of all but ≤ d others, and e·p·(d+1) ≤ 1, then not merely μ(⋂ Aᵢᶜ) > 0 but μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) for suitable weights xᵢ ∈ (0,1) (in the symmetric case a bound of the form (1 − ·)ⁿ). The positivity statement is only a corollary of this lower bound. Every classical proof — Lovász's original induction, Spencer's exposition, Shearer's optimal analysis — first establishes the per-event conditional bound μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] ≤ some xᵢ, then multiplies these through the chain rule to reach the quantitative product bound. The gallery's parent proof develops the symmetric LLL over ℚ as a probability-budget surrogate whose general_lll records ∏(1 − xᵢ) > 0; OQ-01 asks for the genuine measure-theoretic statement. The independent base case, the union-bound extreme, and the chain-rule scaffold are already verified; the chain-rule entry reduced the LLL to per-event conditional bounds but proved only qualitative positivity. This entry supplies the quantitative product bound the LLL is really about.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces — bad events as measurable sets A_i ⊆ Ω in an IsProbabilityMeasure, real dependency structure, and the quantitative conclusion μ(⋂ A_iᶜ) ≥ ∏(1 − xᵢ).\n\n**This entry (quantitative lower bound)**: prove that per-event conditional failure bounds propagate to a quantitative avoidance lower bound. For an arbitrary measurable family A : ℕ → Set Ω over an IsProbabilityMeasure, if μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1 for every k < n, then ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ); specialise to a uniform bound p to get (1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ), and recover qualitative positivity as the coarse corollary.",
+    "text": "The quantitative heart of the Lovász Local Lemma over a real probability space: bound how likely each bad event is to happen given the earlier ones avoided, and the product of the surviving room, ∏(1 − bₖ), is a genuine lower bound on the probability that all the bad events are simultaneously avoided. Positivity of the avoidance probability — all the chain-rule scaffold proved — is just this bound read at its coarsest, ignoring how large the product actually is.",
+    "proofStrategy": "**From the survival product to the lower bound.** The chain-rule entry's avoidance_eq_prod_survival_cond rewrites the avoidance probability as a finite ℝ≥0∞ product of conditional survival probabilities, μ(⋂ (A i)ᶜ) = ∏ₖ μ[(A k)ᶜ | ⋂_{j<k}(A j)ᶜ]. It then suffices to bound each factor below by 1 − bₖ and lift factorwise via monotonicity of the finite product (Finset.prod_le_prod'). For the factor bound at index k: history positivity μ(⋂_{j<k}(A j)ᶜ) ≠ 0 is automatic from the failure bounds (hist_pos_of_failure_cond_lt_one, since bₖ < 1 makes each μ[A k | history] < 1), so on the positive history survival_cond_eq_one_sub gives μ[(A k)ᶜ | history] = 1 − μ[A k | history]; then μ[A k | history] ≤ bₖ and antitonicity of truncated subtraction (tsub_le_tsub_left) yield 1 − bₖ ≤ 1 − μ[A k | history] = survival factor.\n\n**Symmetric case.** Instantiate b ≡ p: Finset.prod_const and Finset.card_range collapse ∏ₖ (1 − p) to (1 − p)ⁿ.\n\n**Positivity corollary.** ∏(1 − bₖ) is a positive ℝ≥0∞ product (each 1 − bₖ ≠ 0 since bₖ < 1, via tsub_eq_zero_iff_le and Finset.prod_ne_zero_iff), so 0 < ∏(1 − bₖ) ≤ μ(⋂ (A i)ᶜ).",
+    "keyInsights": [
+      "The Lovász Local Lemma is a *quantitative* statement — μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) — and positivity is only its coarsest corollary. The chain-rule entry stopped at positivity (avoidance_pos_of_failure_cond_lt_one'); this entry lands the actual product lower bound, so the gallery now states the LLL conclusion in the form the theorem is really about.",
+      "No new probabilistic machinery is needed beyond the chain-rule scaffold: the survival-product identity already expresses the avoidance probability as ∏ₖ μ[(A k)ᶜ | history], and the entire additional content is a *factorwise* inequality survival ≥ 1 − bₖ plus monotonicity of the finite ℝ≥0∞ product. The quantitative bound is the qualitative reduction plus one order-theoretic step.",
+      "Truncated subtraction in ℝ≥0∞ does the bookkeeping cleanly: μ[A k | history] ≤ bₖ gives 1 − bₖ ≤ 1 − μ[A k | history] by antitonicity (tsub_le_tsub_left), with no need for the histories or conditionals to be strictly below 1 in any uniform way — each factor is handled locally.",
+      "The lower bound ∏(1 − bₖ) is exactly the honest measure-theoretic replacement for the parent proof's rational surrogate ∏(1 − xᵢ): the surrogate is not merely analogous to the true avoidance probability, it is a verified *lower bound* on it, provided the surrogate weights are read as conditional failure bounds.",
+      "The per-event bounds bₖ are the sole hypotheses; the histories' positivity, previously a separate assumption, is derived. This isolates the open research target precisely: supply the bounds bₖ (in the symmetric regime bₖ = 2p under e·p·(d+1) ≤ 1) from a measure-theoretic dependency structure, and the quantitative LLL conclusion follows from this entry with no further probability theory."
+    ],
+    "prerequisites": [
+      "The chain-rule scaffold lovasz-local-lemma-oq-01-chain-rule: avoidance_eq_prod_survival_cond, survival_cond_eq_one_sub, hist_pos_of_failure_cond_lt_one",
+      "Measure-theoretic conditional probability μ[t|s] and IsProbabilityMeasure",
+      "ℝ≥0∞ truncated subtraction: tsub_le_tsub_left (antitone), tsub_eq_zero_iff_le",
+      "Finite products in an ordered commutative monoid: Finset.prod_le_prod', Finset.prod_ne_zero_iff, Finset.prod_const, Finset.card_range"
+    ]
+  },
+  "conclusion": {
+    "summary": "The quantitative measure-theoretic Lovász Local Lemma lower bound is fully machine-verified over a real probability space: per-event conditional failure bounds μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1 propagate to ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ), with the symmetric specialisation (1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ) and qualitative positivity recovered as a corollary. No independence hypothesis; history positivity is derived, not assumed. 0 sorries, 0 axioms.",
+    "implications": "**Closes the qualitative-to-quantitative gap in the OQ-01 landscape.** The chain-rule entry reduced the LLL to per-event conditional bounds and proved avoidance *positivity*; this entry upgrades that to the quantitative *lower bound* ∏(1 − bₖ) the Lovász Local Lemma actually asserts, over a genuine probability measure. Together with the independent base case (lovasz-local-lemma-oq-01), the union-bound extreme (lovasz-local-lemma-oq-01-union-bound), and the chain-rule scaffold (lovasz-local-lemma-oq-01-chain-rule), the gallery now states every part of the LLL conclusion except the derivation of the conditional bounds from a dependency structure.\n\n**Honest scope**: the conditional failure bounds bₖ are hypotheses here; deriving them (bₖ = 2p under e·p·(d+1) ≤ 1) from a measure-theoretic dependency graph remains the open research target. This entry guarantees that once those bounds are in hand, the quantitative LLL conclusion follows with no further probability theory.",
+    "openQuestions": [
+      "Derive the per-event conditional failure bounds bₖ (symmetric regime: μ[A i | ⋂_{j∈S} Aⱼᶜ] ≤ 2p for all events i and histories S under e·p·(d+1) ≤ 1) from a measure-theoretic dependency structure — conditional independence of A i from the σ-algebra generated by its non-neighbours — and feed them into avoidance_ge_prod_one_sub to obtain the full symmetric LLL lower bound.",
+      "Match the standard weighted form μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) with xᵢ the Lovász weights satisfying μ(Aᵢ) ≤ xᵢ ∏_{j∼i}(1 − xⱼ): identify the conditional bounds bₖ that make avoidance_ge_prod_one_sub reproduce this exact product.",
+      "Extend from the linear prefix order Finset.range n to an arbitrary Fintype with a chosen order and study how the choice of ordering trades off against the individual conditional bounds bₖ, given that the product lower bound is order-invariant but the factors are not."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "extends",
+      "description": "The chain-rule scaffold this entry builds on directly: avoidance_eq_prod_survival_cond gives the survival-product form, survival_cond_eq_one_sub the factorwise survival = 1 − failure identity, and hist_pos_of_failure_cond_lt_one the automatic history positivity. The chain-rule entry proved qualitative avoidance positivity (avoidance_pos_of_failure_cond_lt_one'); this entry upgrades that reduction to the quantitative lower bound ∏(1 − bₖ) ≤ μ(⋂ (A i)ᶜ) the LLL actually asserts."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "related",
+      "description": "The mutually independent (d = 0) base case, giving the exact product μ(⋂ (A i)ᶜ) = ∏(1 − μ(A i)). That equality is the independence-special case of this entry's lower bound: under independence each conditional survival probability equals the unconditional 1 − μ(A k), so the inequality ∏(1 − bₖ) ≤ μ(⋂ (A i)ᶜ) is tight with bₖ = μ(A k)."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-union-bound",
+      "relationship": "related",
+      "description": "The dependency-free first-moment extreme μ(⋂ (A i)ᶜ) ≥ 1 − ∑ μ(A i). Both are quantitative avoidance lower bounds under different hypotheses: the union bound is additive (subcritical ∑ μ < 1), this entry multiplicative (per-event conditional bounds); together they bracket the LLL quantitatively."
+    },
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "related",
+      "description": "Parent gallery proof of the symmetric LLL over ℚ, whose general_lll records only ∏(1 − xᵢ) > 0 as a probability-budget surrogate. This entry shows that surrogate product is a genuine lower bound on the real avoidance probability over a probability space when the weights are read as conditional failure bounds."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the conclusion is the quantitative lower bound μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ), of which positivity is a corollary."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; the LLL chapter proves the quantitative product bound by bounding each conditional failure probability and multiplying through the chain rule — the exact structure this entry formalizes."
+    },
+    {
+      "authors": "Spencer",
+      "title": "Ten Lectures on the Probabilistic Method",
+      "year": "1994",
+      "note": "Presents the LLL induction via conditional probabilities on growing avoidance histories, yielding the product lower bound on the avoidance probability."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Upgrades the OQ-01 chain-rule reduction from **qualitative avoidance positivity** to the **quantitative Lovász Local Lemma lower bound** the theorem is really about. The LLL asserts `μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ)`; positivity (all the chain-rule entry proved) is only its coarsest corollary. This PR lands the product lower bound over a genuine real probability space.

New self-contained **0-axiom / 0-sorry** file `proofs/Proofs/LovaszLocalLemmaOQ01Quantitative.lean`, new gallery entry `lovasz-local-lemma-oq-01-quantitative`.

## New verified theorems

- **`avoidance_ge_prod_one_sub`** (flagship) — if every conditional failure probability `μ[A k | ⋂_{j<k}(A j)ᶜ] ≤ bₖ < 1`, then `∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ)`. The honest measure-theoretic form of `μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ)`: the parent proof's ℚ-valued surrogate `∏(1 − xᵢ)` is a *verified lower bound on the real avoidance probability*, not merely an analogue.
- **`avoidance_ge_one_sub_pow`** — symmetric specialisation: a uniform bound `μ[A k | history] ≤ p < 1` gives `(1 − p)ⁿ ≤ μ(⋂ (A i)ᶜ)` — the multiplicative counterpart of the union-bound extreme's additive `1 − np`.
- **`avoidance_pos_of_prod_one_sub_pos`** — recovers the chain-rule entry's `avoidance_pos_of_failure_cond_lt_one'` as the coarse corollary (`∏(1 − bₖ) > 0`).

## Proof technique (no new probabilistic input)

Reuses the chain-rule scaffold entirely: `avoidance_eq_prod_survival_cond` rewrites the avoidance probability as the finite ℝ≥0∞ product `∏ₖ μ[(A k)ᶜ | history]`; `Finset.prod_le_prod'` reduces to a factorwise bound; on each history (positive automatically via `hist_pos_of_failure_cond_lt_one`) `survival_cond_eq_one_sub` gives `survival = 1 − failure`, and `tsub_le_tsub_left` (antitone truncated subtraction) converts `μ[A k | history] ≤ bₖ` into `1 − bₖ ≤ 1 − μ[A k | history]`. The quantitative bound is the qualitative reduction plus one order-theoretic step.

## Verification

- `lake env lean Proofs/LovaszLocalLemmaOQ01Quantitative.lean` → exit 0 (against main-repo Mathlib + ChainRule `.olean` cache).
- `#print axioms` on all three theorems → `propext`, `Classical.choice`, `Quot.sound` only (0 axioms, `verified` badge).

## Scope (honest)

The per-event conditional bounds `bₖ` are **hypotheses**. Deriving them (`bₖ = 2p` under `e·p·(d+1) ≤ 1`) from a measure-theoretic dependency structure remains the open OQ-01 target; this entry guarantees the quantitative LLL conclusion then follows with no further probability theory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)