### PR TITLE
research(cayley-hamilton-oq-02-oq-01): sum-level telescoping + two-sided factor structure for Putzer

### DIFF
--- a/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
@@ -33,6 +33,9 @@ derivative computation Ṁ = A·M.  Note that `ρ_k` is an *ordered* product of 
 * `commute_A_rho`: A commutes with every ρ_k (each factor is a polynomial in A)
 * `A_mul_rho`    : A · ρ_k = ρ_{k+1} + λ_k • ρ_k               — the *key telescoping identity*
 * `rho_card`     : ρ_n = 0  when χ_A splits as ∏ (X - λ_i)     (Cayley–Hamilton truncation)
+* `rho_succ_left`: ρ_{k+1} = (A - λ_k • 1) · ρ_k              (factor pulled to the left)
+* `rho_mul_A`    : ρ_k · A = ρ_{k+1} + λ_k • ρ_k             (right telescoping identity)
+* `A_mul_sum_rho`: A · ∑_k a_k • ρ_k = ∑_k a_k • (ρ_{k+1} + λ_k • ρ_k)   (sum-level telescoping)
 
 `A_mul_rho` is precisely what converts the term-by-term derivative
 d/dt (P_k ρ_{k-1}) = Ṗ_k ρ_{k-1} into a multiple of A, and `rho_card` is what makes
@@ -121,5 +124,44 @@ lemma rho_card {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam : ℕ → R)
     rho A lam n = 0 := by
   rw [rho_eq_aeval_prod, ← Fin.prod_univ_eq_prod_range (fun i => X - C (lam i)) n, ← hlam,
       Matrix.aeval_self_charpoly]
+
+/-! ## Two-sided factor structure and the sum-level telescoping
+
+The identities above suffice to run the derivative computation `Ṁ = A · M` purely
+algebraically.  The factors `A - λ_i • 1` are polynomials in `A`, hence commute with
+every `ρ_k`, so each factor may be pulled to *either* side; and multiplication of the whole
+Putzer sum `∑_k a_k • ρ_k` by `A` telescopes term-by-term via `A_mul_rho`. -/
+
+/-- The defining factor may be pulled to the **left**: `ρ_{k+1} = (A - λ_k • 1) · ρ_k`.
+The complement of `rho_succ` (which multiplies on the right); the two agree because each
+factor commutes with `ρ_k`. -/
+lemma rho_succ_left (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    rho A lam (k + 1) = (A - lam k • (1 : Matrix n n R)) * rho A lam k := by
+  have hcomm : Commute (rho A lam k) (A - lam k • (1 : Matrix n n R)) :=
+    ((commute_A_rho A lam k).symm).sub_right
+      ((Commute.one_right (rho A lam k)).smul_right (lam k))
+  rw [rho_succ]; exact hcomm.eq
+
+/-- **Right telescoping identity.** `ρ_k · A = ρ_{k+1} + λ_k • ρ_k`.
+The mirror of `A_mul_rho`; identical because `A` commutes with `ρ_k`. -/
+lemma rho_mul_A (A : Matrix n n R) (lam : ℕ → R) (k : ℕ) :
+    rho A lam k * A = rho A lam (k + 1) + lam k • rho A lam k := by
+  rw [← A_comm_rho, A_mul_rho]
+
+/-- **Sum-level telescoping.** Multiplying the finite Putzer sum `∑_{k<m} a_k • ρ_k` by `A`
+distributes into the term-by-term telescoped form
+
+  `A · ∑_{k<m} a_k • ρ_k = ∑_{k<m} a_k • (ρ_{k+1} + λ_k • ρ_k)`.
+
+This is exactly the algebraic content of the derivative computation `Ṁ = A · M` for
+`M = ∑_k P_k • ρ_{k-1}`: it converts left-multiplication by `A` into a shift `ρ_k ↦ ρ_{k+1}`
+plus a diagonal `λ_k` term, with no analysis involved.  Holds for arbitrary coefficients
+`a : ℕ → R` over any `CommRing`. -/
+lemma A_mul_sum_rho (A : Matrix n n R) (lam : ℕ → R) (a : ℕ → R) (m : ℕ) :
+    A * ∑ k ∈ Finset.range m, a k • rho A lam k
+      = ∑ k ∈ Finset.range m, a k • (rho A lam (k + 1) + lam k • rho A lam k) := by
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [mul_smul_comm, A_mul_rho]
 
 end PutzerMatrixExp

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -35,10 +35,10 @@
   "leanFile": {
     "namespace": "PutzerMatrixExp",
     "path": "Proofs/CayleyHamiltonOQ02OQ01.lean",
-    "lineCount": 125,
+    "lineCount": 167,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "overview": {
@@ -97,7 +97,7 @@
     }
   ],
   "conclusion": {
-    "summary": "9 lemmas, 1 definition, 125 lines, 0 axioms, 0 sorries. A verified formalization of the algebraic core of Putzer's algorithm: the ordered partial product ρₖ, its commutation with A, the telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0. Holds over any commutative ring R. This is the exact algebraic scaffolding that the derivative computation Ṁ = A·M rests on in the full proof of e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}.",
+    "summary": "9 lemmas, 1 definition, 167 lines, 0 axioms, 0 sorries. A verified formalization of the algebraic core of Putzer's algorithm: the ordered partial product ρₖ, its commutation with A, the telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0. Holds over any commutative ring R. This is the exact algebraic scaffolding that the derivative computation Ṁ = A·M rests on in the full proof of e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}.",
     "implications": "The telescoping identity and the truncation ρₙ = 0 are the two facts that make Putzer's construction work: the first re-expresses each term's derivative as a multiple of A so the sum closes on itself, and the second both truncates the sum to n terms and kills the boundary term produced by the index shift. With these in hand, the remaining work is analytic: constructing the scalar coefficients Pₖ as the solutions of the triangular ODE system, differentiating the finite matrix sum term-by-term, and invoking uniqueness of the matrix-valued linear ODE Ṁ = A·M, M(0) = I against Mathlib's NormedSpace.exp.",
     "openQuestions": [
       "Construct the ODE coefficients Pₖ : ℝ → ℂ with HasDerivAt (P₁) (λ₁·P₁ t) t, P₁(0)=1 and HasDerivAt (Pₖ) (λₖ·Pₖ t + P_{k-1} t) t, Pₖ(0)=0, e.g. as iterated convolutions of exponentials, and prove their derivative relations.",


### PR DESCRIPTION
## Summary

Extends the verified algebraic core of **Putzer's algorithm** (`CayleyHamiltonOQ02OQ01.lean`, namespace `PutzerMatrixExp`) with three purely-algebraic lemmas that carry the deferred derivative computation `Ṁ = A·M` — with **no analysis**.

Putzer computes `e^{tA} = Σ_k P_k(t)·ρ_{k-1}` where `ρ_k = (A-λ_k I)⋯(A-λ_1 I)`. The existing file proves the per-factor telescoping `A·ρ_k = ρ_{k+1} + λ_k·ρ_k` (`A_mul_rho`) and the Cayley–Hamilton truncation `ρ_n = 0` (`rho_card`). This PR lifts that structure to the level of the whole Putzer sum and to both sides of the product.

## New results (0 axioms, 0 sorries)

- **`A_mul_sum_rho`** — `A · (Σ_{k<m} a_k • ρ_k) = Σ_{k<m} a_k • (ρ_{k+1} + λ_k • ρ_k)`. The sum-level form of the telescoping identity: left-multiplying the finite Putzer sum by `A` becomes a shift `ρ_k ↦ ρ_{k+1}` plus a diagonal `λ_k` term. This is exactly the algebraic content of `Ṁ = A·M` for `M = Σ_k P_k • ρ_{k-1}`. Arbitrary coefficients `a : ℕ → R` over any `CommRing`.
- **`rho_mul_A`** — `ρ_k · A = ρ_{k+1} + λ_k • ρ_k` (right telescoping; the mirror of `A_mul_rho`, since `A` commutes with `ρ_k`).
- **`rho_succ_left`** — `ρ_{k+1} = (A - λ_k • 1) · ρ_k` (the defining factor pulled to the **left**, complementing the definitional right-multiplication `rho_succ`; the two agree because each factor commutes with `ρ_k`).

Proofs are elementary (`Finset.mul_sum`, `mul_smul_comm`, `Commute` lemmas).

## Verification

`./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ01` → `✔ Built ... Build completed successfully (3058 jobs)`. Still **0 sorries, 0 axioms**. Bumps `meta.json` `theoremCount` 9→12 and `lineCount`.

Scope unchanged: this is the algebraic core; the analytic ODE-uniqueness layer (constructing `P_k`, `HasDerivAt`, matrix-valued `ODE_solution_unique`) remains deferred future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)