### PR TITLE
Enrich Erdős Problem #728: Factorial Divisibility (erdos-728-factorial-divisibility): add mainTheorems (0→14)

### DIFF
--- a/src/data/proofs/erdos-728-factorial-divisibility/meta.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility/meta.json
@@ -241,5 +241,105 @@
       "description": "The probabilistic method is used in the formalization; both employ second-moment arguments"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "erdos_728",
+      "type": "theorem",
+      "statement": "0 < C, 0 < ε < 1/2 ⟹ (good_triples C ε).Infinite",
+      "significance": "The positive resolution of Erdős problem #728: for every C>0 and every 0<ε<1/2 there are infinitely many triples (a,b,n) with a!·b! ∣ n!·(a+b−n)! obeying the range constraints and a+b > n + C·log n — factorial divisibility persists beyond the logarithmic barrier.",
+      "description": "Reduces to producing triples with arbitrarily large n (infinite_of_unbounded_n), then for each N constructs a good triple via the probabilistic-method machinery (lemma_good_triple_construction_final)."
+    },
+    {
+      "name": "erdos_728_fc",
+      "type": "theorem",
+      "statement": "∀ᶠ ε in 𝓝[>]0, ∀ C>0, ∀ C'>C, ∃ a b n, 0 < n ∧ … (explicit good triple with a+b > n + C'·log n)",
+      "significance": "A finitary, fully-quantified companion to erdos_728: for all sufficiently small ε and any threshold C', an explicit good triple exists. This is the constructive existence statement underlying the infinitude result.",
+      "description": "Unpacks the eventual-in-ε construction, threading the threshold reduction (lemma_threshold_reduction) and the explicit small-prime/large-prime carry analysis."
+    },
+    {
+      "name": "lemma_forced_carries_largep",
+      "type": "theorem",
+      "statement": "p prime, 1 ≤ i < p, i ≤ (p−1)/2, p^j ∣ m+i ⟹ κ_p(m) ≥ j",
+      "significance": "The large-prime carry engine: if a prime power p^j divides some m+i in a short window, Kummer's theorem forces at least j carries when adding m to m in base p, so v_p(binom(2m,m)) ≥ j. Divisibility of a shifted value is converted into guaranteed p-adic valuation.",
+      "description": "Applies Kummer's theorem (padicValNat_choose) to write κ_p(m) as a carry sum, then shows p^j ∣ m+i forces ⌊2m/p^k⌋ − 2⌊m/p^k⌋ ≥ 1 for each k ≤ j via the congruence m ≡ −i (mod p^k)."
+    },
+    {
+      "name": "lemma_p_gt_2k",
+      "type": "theorem",
+      "statement": "p prime, 2k < p ⟹ κ_p(m) ≥ W_p(m,k)",
+      "significance": "For primes larger than the window (2k < p) the binomial valuation dominates the window-valuation W_p(m,k) = v_p((m+1)···(m+k)). Isolates the contribution of large primes to the divisibility.",
+      "description": "Case split on whether some m+i (1 ≤ i ≤ k) is divisible by p; if so, lemma_forced_carries_largep supplies the needed carries, otherwise W_p(m,k)=0."
+    },
+    {
+      "name": "lemma_forced_carries_smallp",
+      "type": "theorem",
+      "statement": "p prime ⟹ κ_p(m) ≥ X_p(p,m,L)",
+      "significance": "The small-prime counterpart: the binomial valuation dominates the random variable X_p counting favorable residues up to level L. Together with lemma_p_gt_2k this covers all primes and is the deterministic backbone of the probabilistic bound.",
+      "description": "Induction reducing κ_p and X_p to their carry/indicator definitions, bounding the valuation below by the count of forced carries at each level."
+    },
+    {
+      "name": "lemma_chernoff_binomial",
+      "type": "theorem",
+      "statement": "p prime ⟹ (fraction of m ∈ [0,p^L) with X_p(p,m,L) ≤ μ/2) ≤ exp(−μ/8)",
+      "significance": "The Chernoff tail bound at the heart of the probabilistic method: the density of 'bad' m for which the carry count falls below half its mean μ decays exponentially. This is what makes the union of bad sets summable.",
+      "description": "Combines a Markov exponential-moment bound (lemma_markov_exp) with the numeric inequality lemma_chernoff_inequality to convert the moment bound into the exp(−μ/8) tail."
+    },
+    {
+      "name": "lemma_chernoff_inequality",
+      "type": "theorem",
+      "statement": "0 ≤ θ ≤ 1 ⟹ log2·(θ/2) + log(1 − θ + θ·e^{−log2}) ≤ −θ/8",
+      "significance": "The scalar convexity estimate that powers the Chernoff bound — a clean explicit inequality controlling the exponential moment generating function of the Bernoulli carry indicators.",
+      "description": "Proved by nlinarith after unfolding the exponentials, using log 2 < 0.6931… and the elementary bound log x ≤ x − 1."
+    },
+    {
+      "name": "lemma_mod_uniform",
+      "type": "theorem",
+      "statement": "Q ≤ M^{1−η}, all a ∈ A below Q ⟹ Prob_{[M,2M]}(m mod Q ∈ A) ≤ |A|/Q + 2/M^η",
+      "significance": "Equidistribution of residues: on the dyadic block [M,2M] the reduction m mod Q is nearly uniform provided Q is not too large, so the probability of landing in a residue set A is essentially |A|/Q. Supplies the 'randomness' that the probabilistic method exploits.",
+      "description": "Counts integers in [M,2M] with m mod Q ∈ A by writing the interval as full periods plus a remainder, bounding the error by 2|A|."
+    },
+    {
+      "name": "lemma_bad_carries_bound",
+      "type": "theorem",
+      "statement": "p prime, M>0 ⟹ #{m ∈ [M,2M] : X_p ≤ μ/2} ≤ (M+1)(exp(−μ/8) + 2/M^η)",
+      "significance": "Transports the exponential Chernoff density on a full residue period to the working dyadic interval [M,2M], the count that must be summed over all primes and shown negligible.",
+      "description": "Feeds the per-period Chernoff bound (lemma_chernoff_binomial) through the near-uniformity estimate (lemma_mod_uniform) to bound the interval count."
+    },
+    {
+      "name": "lemma_mu_ge",
+      "type": "theorem",
+      "statement": "p prime ⟹ μ_p/2 ≥ (1−η)/2·θ_p·(log M / log p) − θ_p/2",
+      "significance": "Lower-bounds the mean carry count μ_p, showing it grows like log M / log p. A large mean is exactly what makes the Chernoff tail exp(−μ/8) small, closing the probabilistic argument.",
+      "description": "Rearranges lemma_mu_lower_bound: the expected number of favorable residues over L levels is at least a constant times log M / log p."
+    },
+    {
+      "name": "lemma_main_ineq_asymptotic",
+      "type": "theorem",
+      "statement": "c>0 ⟹ ((1−η)/6·log M − (log k + …·log(2k+1) + ½·log(2k+1))) → +∞",
+      "significance": "The decisive asymptotic: the gain (1−η)/6·log M eventually dominates all logarithmic error terms in the window size k, guaranteeing the constructed triples clear the a+b > n + C·log n threshold for large M.",
+      "description": "A Tendsto-atTop statement; the linear-in-log-M main term outpaces the O(log k · log log M) corrections as M → ∞."
+    },
+    {
+      "name": "lemma_good_m_exists_any_c",
+      "type": "theorem",
+      "statement": "c>0 ⟹ ∃ M₀, ∀ M ≥ M₀, ([M,2M] \\ bad_m_set M c) is nonempty",
+      "significance": "The pigeonhole payoff of the probabilistic method: once the total measure of bad m is < 1, a good m survives in every large dyadic block, yielding the required triple. Converts summable tail bounds into existence.",
+      "description": "Uses lemma_sum_bad_carries_small (the summed bad-carry mass tends to 0) so the bad set cannot cover the whole interval [M,2M]."
+    },
+    {
+      "name": "lemma_good_triple_construction_final",
+      "type": "theorem",
+      "statement": "From a good m (all small primes favorable) construct an explicit good triple (a,b,n) satisfying a!b! ∣ n!(a+b−n)! and the range/threshold constraints",
+      "significance": "The constructive core: turns a single well-behaved m into an actual factorial-divisibility triple meeting every constraint of problem #728, the object whose infinitude is the theorem.",
+      "description": "Assembles the divisibility from the per-prime valuation guarantees (small primes via lemma_small_primes_good, large primes via lemma_p_gt_2k) and Kummer's theorem, then checks the a+b > n + C log n threshold."
+    },
+    {
+      "name": "infinite_of_unbounded_n",
+      "type": "theorem",
+      "statement": "(∀ N, ∃ t ∈ S, t.2.2 ≥ N) ⟹ S.Infinite",
+      "significance": "The clean reduction principle closing the proof: a set of triples containing elements with arbitrarily large third coordinate n must be infinite. Lets the construction focus on producing large-n triples rather than counting them.",
+      "description": "Contrapositive: a finite set of naturals is bounded, so if the n-coordinates are unbounded the set cannot be finite."
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: Erdős Problem #728 (Factorial Divisibility) — add mainTheorems

Adds a curated `mainTheorems` array (0 → 14) to this 56-lemma **verified** (0 axioms, 0 sorries) research-grade formalization, previously exposing no structured theorem list. The curation traces the probabilistic-method proof (Kummer's theorem + Chernoff bounds) that factorial divisibility persists beyond the logarithmic barrier:

- **Main results**: `erdos_728` (infinitely many good triples) and `erdos_728_fc` (explicit finitary existence)
- **Kummer / carry analysis**: `lemma_forced_carries_largep`, `lemma_p_gt_2k`, `lemma_forced_carries_smallp`
- **Probabilistic method**: `lemma_chernoff_binomial`, `lemma_chernoff_inequality`, `lemma_mod_uniform`, `lemma_bad_carries_bound`
- **Mean growth & asymptotics**: `lemma_mu_ge`, `lemma_main_ineq_asymptotic`
- **Construction & closure**: `lemma_good_m_exists_any_c`, `lemma_good_triple_construction_final`, `infinite_of_unbounded_n`

Reliability gate passed: `meta.theoremCount` (56) == grep-count of top-level theorems/lemmas (56); 0 sorries; 0 axioms (verified). `meta.json` 13.0 KB → 21.4 KB, under the 60 KB cap.
