### PR TITLE
Enrich Euler-Mascheroni Constant: Bounds, Structure, and Connections (harmonic-divergence-oq-01): add mainTheorems (0→14)

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-01/meta.json
@@ -184,5 +184,105 @@
     "definitionCount": 3,
     "theoremCount": 52
   },
-  "sorries": 0
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "harmonic_not_summable",
+      "type": "theorem",
+      "statement": "¬ Summable (fun n : ℕ => 1/n)",
+      "significance": "The harmonic series diverges — the foundational fact the whole entry orbits. Despite its terms tending to 0, ∑ 1/n has no finite sum, the classical result of Oresme/Bernoulli.",
+      "description": "Delegates to Mathlib's Real.not_summable_one_div_natCast."
+    },
+    {
+      "name": "harmonic_tendsto_atTop",
+      "type": "theorem",
+      "statement": "Tendsto (fun n => ∑_{k<n} 1/(k+1)) atTop atTop",
+      "significance": "The quantitative divergence: the partial sums H_n increase without bound. Complements non-summability with the actual → +∞ behavior, the growth γ measures against log n.",
+      "description": "Mathlib's tendsto_sum_range_one_div_nat_succ_atTop."
+    },
+    {
+      "name": "log_le_harmonic",
+      "type": "theorem",
+      "statement": "log(n+1) ≤ H_n",
+      "significance": "The lower half of the logarithmic sandwich H_n ≈ log n: the harmonic number always exceeds log(n+1). Pins the divergence rate to that of the logarithm from below.",
+      "description": "Mathlib's log_add_one_le_harmonic, from comparing the harmonic sum with the integral of 1/x."
+    },
+    {
+      "name": "harmonic_le_log",
+      "type": "theorem",
+      "statement": "H_n ≤ 1 + log n",
+      "significance": "The upper half of the sandwich: H_n is at most 1 + log n. Together with log(n+1) ≤ H_n it traps H_n − log n in a bounded interval — the very quantity converging to γ.",
+      "description": "Mathlib's harmonic_le_one_add_log."
+    },
+    {
+      "name": "γ_seq_tendsto",
+      "type": "theorem",
+      "statement": "Tendsto γ_seq atTop (nhds γ)",
+      "significance": "Defines the Euler–Mascheroni constant as the limit of H_n − log n: the bounded gap between harmonic growth and logarithmic growth actually converges. γ ≈ 0.5772… exists.",
+      "description": "Delegates to Real.tendsto_eulerMascheroniSeq for the defining sequence γ_seq."
+    },
+    {
+      "name": "γ_seq_lt_γ",
+      "type": "theorem",
+      "statement": "∀ n, γ_seq n < γ  (and dually γ < γ_seq' n)",
+      "significance": "The two-sided sandwich that localizes γ: the increasing sequence γ_seq approaches from below and the decreasing γ_seq' from above, so every pair of terms brackets γ. The basis of all numerical bounds.",
+      "description": "Real.eulerMascheroniSeq_lt_eulerMascheroniConstant; the companion γ_lt_γ_seq' gives the upper bracket."
+    },
+    {
+      "name": "γ_mem_Ioo",
+      "type": "theorem",
+      "statement": "γ ∈ Set.Ioo 0 1  (in fact 1/2 < γ < 2/3)",
+      "significance": "Concrete containment: γ lies strictly between 1/2 and 2/3, hence in (0,1). Enough to prove γ is not an integer and to seed the rational-exclusion results.",
+      "description": "Combines γ_pos with γ_lt_two_thirds; the sharper one_half_lt_γ and γ_lt_two_thirds come from evaluating the sandwich sequences."
+    },
+    {
+      "name": "exp_γ_bounds",
+      "type": "theorem",
+      "statement": "exp(1/2) < exp(γ) < exp(2/3)",
+      "significance": "Transfers the γ bounds through the exponential (relevant to Mertens' third theorem, where e^γ appears), showing e^γ ∈ (e^{1/2}, e^{2/3}) ≈ (1.649, 1.948).",
+      "description": "Applies strict monotonicity of exp (Real.exp_strictMono) to 1/2 < γ < 2/3."
+    },
+    {
+      "name": "sandwich_gap",
+      "type": "theorem",
+      "statement": "n ≥ 1 ⟹ γ_seq' n − γ_seq n = log(n+1) − log n",
+      "significance": "Computes the exact width of the bracketing interval at stage n as log(1 + 1/n). This closed form makes the convergence rate explicit and quantifies the approximation error.",
+      "description": "Unfolds both Euler–Mascheroni sequences; their difference telescopes to the single logarithm log(n+1) − log n."
+    },
+    {
+      "name": "sandwich_gap_tendsto",
+      "type": "theorem",
+      "statement": "Tendsto (fun n => γ_seq' n − γ_seq n) atTop (nhds 0)",
+      "significance": "The bracket collapses: the gap log(1 + 1/n) → 0, so the two sandwich sequences squeeze to a common limit — a self-contained proof that γ is well-defined and computable to any precision.",
+      "description": "From sandwich_gap the gap equals log((n+1)/n) → log 1 = 0; combined with γ_seq_tendsto by the squeeze."
+    },
+    {
+      "name": "harmonic_padic_val",
+      "type": "theorem",
+      "statement": "padicValRat 2 (H_n) = −⌊log₂ n⌋",
+      "significance": "The 2-adic valuation of the harmonic number is exactly −⌊log₂ n⌋ < 0 for n ≥ 2 — a negative 2-adic valuation, so H_n has a 2 in its denominator and cannot be an integer. The p-adic engine behind Theisinger's theorem.",
+      "description": "Mathlib's padicValRat_two_harmonic; the highest power of 2 up to n appears once in the denominator and never cancels."
+    },
+    {
+      "name": "harmonic_never_integer",
+      "type": "theorem",
+      "statement": "n ≥ 2 ⟹ ¬ (H_n).isInt",
+      "significance": "Theisinger's theorem: no harmonic number H_n (n ≥ 2) is an integer. A clean consequence of the negative 2-adic valuation, one of the entry's headline structural results.",
+      "description": "harmonic_not_int: since padicValRat 2 (H_n) < 0, the denominator is even, so H_n ∉ ℤ."
+    },
+    {
+      "name": "γ_avoids_denom_le_4",
+      "type": "theorem",
+      "statement": "γ ≠ 1/4 ∧ γ ≠ 1/3 ∧ γ ≠ 1/2 ∧ γ ≠ 2/3 ∧ γ ≠ 3/4",
+      "significance": "Systematic rational exclusion: γ equals none of the rationals with denominator ≤ 4 lying in its known interval. A rigorous (if partial) Diophantine chip at the famously open irrationality of γ.",
+      "description": "Bundles the individual γ_ne_* results, each ruling out a candidate rational by the numeric bounds 1/2 < γ < 2/3."
+    },
+    {
+      "name": "irrational_γ_ne_rat",
+      "type": "theorem",
+      "statement": "Irrational γ ⟹ ∀ r : ℚ, γ ≠ r",
+      "significance": "The conditional payoff: were γ proven irrational (still open), it would differ from every rational. Frames what the outstanding conjecture would deliver, keeping the entry honest about what is and isn't known.",
+      "description": "Direct from the definition of Irrational (h.ne_rat); stated conditionally since Irrational γ is unproved."
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: Euler-Mascheroni Constant (Bounds, Structure, Connections) — add mainTheorems

Adds a curated `mainTheorems` array (0 → 14) to this 52-theorem **verified** (0 axioms, 0 sorries) entry, previously exposing no structured theorem list. The curation spans harmonic divergence, the logarithmic sandwich defining γ, and its structural/Diophantine properties:

- **Divergence**: `harmonic_not_summable`, `harmonic_tendsto_atTop`
- **Log sandwich**: `log_le_harmonic` (log(n+1) ≤ H_n), `harmonic_le_log` (H_n ≤ 1 + log n)
- **γ existence & bounds**: `γ_seq_tendsto`, `γ_seq_lt_γ`, `γ_mem_Ioo` (1/2 < γ < 2/3), `exp_γ_bounds`, `sandwich_gap`, `sandwich_gap_tendsto`
- **Theisinger / p-adic**: `harmonic_padic_val` (v₂(H_n) = −⌊log₂ n⌋), `harmonic_never_integer`
- **Diophantine**: `γ_avoids_denom_le_4`, `irrational_γ_ne_rat` (conditional on the open irrationality of γ)

Reliability gate passed: `meta.theoremCount` (52) == grep-count of top-level theorems/lemmas (52); 0 sorries; 0 axioms (verified). `meta.json` 14.6 KB → 21.1 KB, under the 60 KB cap.
