### PR TITLE
research(lovasz-local-lemma-oq-01): Euler condition ⇒ tight threshold (e·p·(d+1)≤1 → p≤T(d))

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean
@@ -1,0 +1,106 @@
+/-
+# Lovász Local Lemma — OQ-01: The Euler Symmetric Condition Implies the Tight Threshold
+
+The gallery proof `LovaszLocalLemma.lean` records the *tight* symmetric threshold
+
+  `T(d) = lllThreshold d = dᵈ / (d+1)^{d+1}`,
+
+the exact maximum of `x (1 - x)ᵈ`, and proves the symmetric LLL under the hypothesis
+`P[Aᵢ] ≤ T(d)`. The measure-theoretic OQ-01 front, meanwhile, is stated against the
+*memorable* symmetric condition that appears throughout the literature,
+
+  `e · p · (d + 1) ≤ 1`,
+
+where `e = exp 1`. These are two different sufficient conditions, and the standard
+textbook remark is that the Euler form is the (slightly weaker, hence safe)
+consequence of the tight one: **`e · p · (d+1) ≤ 1` implies `p ≤ T(d)`.**
+
+This file formalizes that bridge. It is elementary real analysis — *not* progress on
+the hard measure-theoretic induction — but it ties the two thresholds together with
+a machine-checked proof and pins down the exact inequality that makes the Euler form
+usable: `(1 + 1/d)ᵈ ≤ e` (the classic `e` bound), from `1 + x ≤ exp x`.
+
+## Main results
+
+* `one_add_inv_pow_le_exp_one` : `(1 + 1/d)ᵈ ≤ e` for `d ≥ 1` — the elementary
+  Euler bound, proved from `Real.add_one_le_exp` raised to the `d`-th power.
+* `succ_pow_le_exp_mul` : `(d+1)ᵈ ≤ e · dᵈ`, the multiplicative form.
+* `inv_exp_mul_le_lllThreshold` : `1 / (e · (d+1)) ≤ T(d)` — the Euler budget sits
+  below the tight threshold.
+* `euler_condition_implies_lllThreshold` : `e · p · (d+1) ≤ 1 → p ≤ T(d)`, the bridge:
+  any probability admitted by the memorable symmetric condition is admitted by the
+  tight threshold, so the tight-threshold symmetric LLL (`LovaszLocalLemma.symmetric_lll`)
+  applies verbatim under `e · p · (d+1) ≤ 1`.
+
+Everything is over `ℝ`; `lllThreshold` is cast from `ℚ` via `lllThreshold_cast`.
+-/
+import Proofs.LovaszLocalLemma
+
+open Real ProbMethod.LovaszLocal
+
+namespace LovaszLocalLemmaOQ01EulerThreshold
+
+/-- The classic Euler bound `(1 + 1/d)ᵈ ≤ e` for `d ≥ 1`.
+
+Proof: `Real.add_one_le_exp` gives `1/d + 1 ≤ exp (1/d)`; raising both nonnegative
+sides to the `d`-th power and using `exp (1/d) ^ d = exp (d · (1/d)) = exp 1`
+(with `d · (1/d) = 1` since `d ≠ 0`) finishes. -/
+theorem one_add_inv_pow_le_exp_one (d : ℕ) (hd : 1 ≤ d) :
+    (1 + 1 / (d : ℝ)) ^ d ≤ Real.exp 1 := by
+  have hd0 : (0 : ℝ) < d := by exact_mod_cast hd
+  have hstep : (1 + 1 / (d : ℝ)) ≤ Real.exp (1 / d) := by
+    have h := Real.add_one_le_exp (1 / (d : ℝ))
+    linarith
+  calc (1 + 1 / (d : ℝ)) ^ d
+      ≤ (Real.exp (1 / d)) ^ d := by
+        exact pow_le_pow_left₀ (by positivity) hstep d
+    _ = Real.exp ((d : ℝ) * (1 / d)) := by rw [← Real.exp_nat_mul]
+    _ = Real.exp 1 := by rw [mul_one_div, div_self (ne_of_gt hd0)]
+
+/-- Multiplicative form of the Euler bound: `(d+1)ᵈ ≤ e · dᵈ`. -/
+theorem succ_pow_le_exp_mul (d : ℕ) (hd : 1 ≤ d) :
+    ((d : ℝ) + 1) ^ d ≤ Real.exp 1 * (d : ℝ) ^ d := by
+  have hd0 : (0 : ℝ) < d := by exact_mod_cast hd
+  have hbase : (1 + 1 / (d : ℝ)) = ((d : ℝ) + 1) / d := by field_simp
+  have h := one_add_inv_pow_le_exp_one d hd
+  rw [hbase, div_pow, div_le_iff₀ (by positivity : (0 : ℝ) < (d : ℝ) ^ d)] at h
+  linarith
+
+/-- Real-cast of the tight symmetric threshold for `d ≥ 1`:
+`(T(d) : ℝ) = dᵈ / (d+1)^{d+1}`. -/
+theorem lllThreshold_cast (d : ℕ) (hd : 1 ≤ d) :
+    (lllThreshold d : ℝ) = (d : ℝ) ^ d / ((d : ℝ) + 1) ^ (d + 1) := by
+  simp only [lllThreshold, if_neg (by omega : d ≠ 0)]
+  push_cast
+  ring
+
+/-- The Euler budget lies below the tight threshold: `1 / (e · (d+1)) ≤ T(d)`.
+
+Equivalently `(d+1)^{d+1} ≤ e · (d+1) · dᵈ`, which after cancelling `(d+1)` is the
+multiplicative Euler bound `succ_pow_le_exp_mul`. -/
+theorem inv_exp_mul_le_lllThreshold (d : ℕ) (hd : 1 ≤ d) :
+    (1 : ℝ) / (Real.exp 1 * ((d : ℝ) + 1)) ≤ (lllThreshold d : ℝ) := by
+  have hd0 : (0 : ℝ) < d := by exact_mod_cast hd
+  have hd1 : (0 : ℝ) < (d : ℝ) + 1 := by positivity
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  rw [lllThreshold_cast d hd, div_le_div_iff₀ (by positivity) (by positivity), one_mul,
+    pow_succ]
+  have hkey := mul_le_mul_of_nonneg_right (succ_pow_le_exp_mul d hd) (le_of_lt hd1)
+  nlinarith [hkey]
+
+/-- **The Euler symmetric condition implies the tight threshold.**
+If `e · p · (d+1) ≤ 1` (the memorable symmetric LLL condition), then
+`p ≤ T(d)`, the tight threshold of the gallery proof. Hence the symmetric LLL under
+the tight threshold (`LovaszLocalLemma.symmetric_lll`) applies verbatim to any family
+whose event probabilities satisfy the Euler condition. -/
+theorem euler_condition_implies_lllThreshold (d : ℕ) (hd : 1 ≤ d)
+    (p : ℝ) (hcond : Real.exp 1 * p * ((d : ℝ) + 1) ≤ 1) :
+    p ≤ (lllThreshold d : ℝ) := by
+  have hd1 : (0 : ℝ) < (d : ℝ) + 1 := by positivity
+  have he : (0 : ℝ) < Real.exp 1 := Real.exp_pos 1
+  have hstep : p ≤ 1 / (Real.exp 1 * ((d : ℝ) + 1)) := by
+    rw [le_div_iff₀ (by positivity)]
+    nlinarith [hcond]
+  exact le_trans hstep (inv_exp_mul_le_lllThreshold d hd)
+
+end LovaszLocalLemmaOQ01EulerThreshold

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -195,3 +195,44 @@ Insights accumulated during research on this problem.
   deriving them from a measure-theoretic dependency structure (`bₖ = 2p` under
   `e·p·(d+1) ≤ 1`) is the open target. This entry guarantees the quantitative LLL
   conclusion then follows with no further probability theory.
+
+### Euler condition ⇒ tight threshold bridge (researcher-4, 2026-07-03) — NEW
+
+- **The memorable symmetric condition `e·p·(d+1) ≤ 1` is implied by the tight
+  threshold `p ≤ T(d) = dᵈ/(d+1)^{d+1}`, and now this is machine-checked.** New file
+  `Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean` (0 sorry / 0 axiom), gallery entry
+  `lovasz-local-lemma-oq-01-euler-threshold`: `euler_condition_implies_lllThreshold`
+  proves `e·p·(d+1) ≤ 1 → p ≤ (lllThreshold d : ℝ)` for `d ≥ 1` and any real `p`
+  (no `0 ≤ p` needed — negative `p` is trivial since `T(d) > 0`). This links the
+  parent proof's ℚ-valued tight threshold front to the Euler condition used
+  throughout the OQ-01 measure-theoretic entries.
+- **Core inequality: `(1 + 1/d)ᵈ ≤ e`** (`one_add_inv_pow_le_exp_one`). This is the
+  single fact that puts the constant `e` into the LLL. Route:
+  `Real.add_one_le_exp (1/d) : 1/d + 1 ≤ exp(1/d)` → `pow_le_pow_left₀ (by positivity)
+  hstep d` raises to the dᵗʰ power → `← Real.exp_nat_mul` rewrites `exp(1/d)^d =
+  exp(d·(1/d))`, and `mul_one_div; div_self (d ≠ 0)` gives `d·(1/d) = 1`, so RHS `= e`.
+- **Chain to the threshold.** `succ_pow_le_exp_mul`: clear the denominator
+  (`1+1/d = (d+1)/d`, `div_pow`, `div_le_iff₀`) to get `(d+1)ᵈ ≤ e·dᵈ`.
+  `lllThreshold_cast`: `(lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}` via
+  `simp only [lllThreshold, if_neg (d≠0)]; push_cast; ring`.
+  `inv_exp_mul_le_lllThreshold`: `1/(e(d+1)) ≤ T(d)` — after
+  `div_le_div_iff₀ .. ..; one_mul; pow_succ` the goal is `(d+1)ᵈ·(d+1) ≤ dᵈ·(e·(d+1))`,
+  closed by `nlinarith [mul_le_mul_of_nonneg_right succ_pow_le_exp_mul (le_of_lt hd1)]`.
+  Final bridge: `le_div_iff₀` turns `e·p·(d+1) ≤ 1` into `p ≤ 1/(e(d+1))`, then
+  `le_trans` with the threshold bound.
+- **Reusable Lean gotchas.** `lllThreshold` lives in namespace `ProbMethod.LovaszLocal`
+  (NOT `LovaszLocalLemma`) — `open ProbMethod.LovaszLocal`. `pow_le_pow_left` is gone /
+  unknown here; use `pow_le_pow_left₀ (ha : 0 ≤ a) (hab : a ≤ b) : ∀ n, aⁿ ≤ bⁿ`.
+  `Real.exp_nat_mul : exp(↑n * x) = exp x ^ n` (so `← Real.exp_nat_mul` collapses
+  `exp x ^ n`). `Real.add_one_le_exp x : x + 1 ≤ exp x`.
+- **Honest scope.** This is elementary real analysis about *which hypothesis is
+  stronger* (Euler form is a slightly conservative consequence of the tight
+  threshold: `1/(e(d+1)) < T(d)` strictly), NOT a proof that either hypothesis forces
+  positive avoidance. The measure-theoretic symmetric LLL induction (deriving the
+  per-event conditional bounds `bₖ = 2p` under `e·p·(d+1) ≤ 1`, to feed
+  `avoidance_ge_prod_one_sub` from the quantitative entry) remains the open target.
+- **Shared-repo build note.** Fresh researcher worktrees have no `.lake`/`node_modules`;
+  typecheck a single file via `cp` into MAIN `proofs/Proofs/` + `LAKE_UNSAFE=1 lake env
+  lean <file>` against MAIN's cached mathlib oleans. Under heavy concurrent load (70+
+  lean procs) expect transient `invalid header` / `configuration is invalid` errors —
+  retry with backoff; a clean pass confirms.

--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-lll-oq01-euler-overview",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Two forms of the symmetric Lovász Local Lemma hypothesis",
+    "content": "The symmetric Lovász Local Lemma is quoted in two ways. The **tight** form asks each bad event to have probability at most $T(d) = d^d/(d+1)^{d+1}$, the exact maximum of $x(1-x)^d$ attained at $x = 1/(d+1)$; this is `lllThreshold` in the parent gallery proof `lovasz-local-lemma`, formalized over $\\mathbb{Q}$. The **memorable** form, quoted almost everywhere and used in the OQ-01 measure-theoretic entries, asks $e\\cdot p\\cdot(d+1) \\le 1$ where $e = \\exp 1$. This file proves the standard textbook fact linking them: the memorable Euler condition is the safe (slightly weaker) consequence of the tight threshold, $e\\cdot p\\cdot(d+1) \\le 1 \\Rightarrow p \\le T(d)$. The single inequality that puts the constant $e$ into the LLL is the classic $(1 + 1/d)^d \\le e$.",
+    "mathContext": "Bridge between $p \\le T(d) = d^d/(d+1)^{d+1}$ (tight) and $e\\cdot p\\cdot(d+1) \\le 1$ (memorable), for integer degree $d \\ge 1$ and real $p$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "symmetric LLL threshold",
+      "Euler's number e",
+      "(1 + 1/n)^n bound"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma (tight threshold lllThreshold)",
+      "the inequality 1 + x ≤ exp x"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-euler-e-bound",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 43, "endLine": 58 },
+    "type": "insight",
+    "title": "The classic Euler bound (1 + 1/d)ᵈ ≤ e",
+    "content": "The heart of the file. `Real.add_one_le_exp` gives $1 + x \\le \\exp x$ for every real $x$; instantiated at $x = 1/d$ it reads $1 + 1/d \\le \\exp(1/d)$. Both sides are nonnegative, so raising to the $d$-th power (`pow_le_pow_left₀`) preserves the inequality: $(1 + 1/d)^d \\le \\exp(1/d)^d$. Finally $\\exp(1/d)^d = \\exp(d\\cdot(1/d)) = \\exp 1$ via `Real.exp_nat_mul` and $d\\cdot(1/d) = 1$ (valid since $d \\ne 0$). This is the sequence that climbs toward $e$ from below, and it is exactly why the constant $e$ appears in the memorable LLL condition.",
+    "mathContext": "$(1 + 1/d)^d \\le e$ for $d \\ge 1$, from $1 + x \\le \\exp x$ raised to the $d$-th power.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Real.add_one_le_exp",
+      "Real.exp_nat_mul",
+      "monotonicity of powers",
+      "limit definition of e"
+    ],
+    "prerequisites": [
+      "Real.add_one_le_exp: 1 + x ≤ exp x",
+      "pow_le_pow_left₀ (monotonicity of x ↦ xⁿ on nonnegatives)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-euler-mul-form",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 60, "endLine": 75 },
+    "type": "insight",
+    "title": "Multiplicative form and the real-cast of the threshold",
+    "content": "`succ_pow_le_exp_mul` clears the denominator in the Euler bound: writing $1 + 1/d = (d+1)/d$ and using `div_pow`, `div_le_iff₀` turns $(1+1/d)^d \\le e$ into $(d+1)^d \\le e\\cdot d^d$. Alongside it, `lllThreshold_cast` bridges the parent proof's $\\mathbb{Q}$-valued threshold to $\\mathbb{R}$: for $d \\ge 1$, $(\\texttt{lllThreshold}\\,d : \\mathbb{R}) = d^d/(d+1)^{d+1}$ (unfold the $d \\ne 0$ branch, then `push_cast; ring`). These two plumbing lemmas set up the threshold comparison.",
+    "mathContext": "$(d+1)^d \\le e\\cdot d^d$; and $(\\texttt{lllThreshold}\\,d : \\mathbb{R}) = d^d/(d+1)^{d+1}$ for $d \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "div_pow",
+      "div_le_iff₀",
+      "Rat.cast / push_cast"
+    ],
+    "prerequisites": [
+      "one_add_inv_pow_le_exp_one",
+      "lllThreshold d = dᵈ/(d+1)^{d+1} (parent proof)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-euler-below-threshold",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "insight",
+    "title": "The Euler budget sits below the tight threshold",
+    "content": "`inv_exp_mul_le_lllThreshold`: $1/(e(d+1)) \\le T(d)$. After casting the threshold and applying `div_le_div_iff₀` and `pow_succ`, the goal becomes $(d+1)^{d+1} \\le e\\cdot(d+1)\\cdot d^d$, i.e. the multiplicative Euler bound $(d+1)^d \\le e\\cdot d^d$ multiplied through by the positive factor $(d+1)$ — closed by `nlinarith` from `succ_pow_le_exp_mul`. Because $(1+1/d)^d < e$ strictly for every finite $d$, this inequality is strict: the Euler budget is genuinely (if only slightly) more conservative than the sharp threshold.",
+    "mathContext": "$1/(e(d+1)) \\le d^d/(d+1)^{d+1} = T(d)$, equivalent to $(d+1)^d \\le e\\cdot d^d$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "div_le_div_iff₀",
+      "pow_succ",
+      "conservative sufficient conditions"
+    ],
+    "prerequisites": [
+      "succ_pow_le_exp_mul",
+      "lllThreshold_cast"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-euler-bridge",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 91, "endLine": 104 },
+    "type": "insight",
+    "title": "The bridge: the Euler condition implies the tight threshold",
+    "content": "`euler_condition_implies_lllThreshold`: from $e\\cdot p\\cdot(d+1) \\le 1$, `le_div_iff₀` gives $p \\le 1/(e(d+1))$, and chaining with `inv_exp_mul_le_lllThreshold` yields $p \\le T(d)$. So any event probability admitted by the memorable symmetric condition is admitted by the tight threshold, and the tight-threshold symmetric LLL (`symmetric_lll` in the parent proof) applies verbatim under the Euler hypothesis. No nonnegativity assumption on $p$ is needed — for $p < 0$ both the hypothesis and the conclusion hold trivially since $T(d) > 0$ — so the statement is proved in its strongest form. This is real-analysis bookkeeping about *which hypothesis is stronger*, not a proof that either hypothesis forces positive avoidance probability; that measure-theoretic induction remains the open OQ-01 target.",
+    "mathContext": "$e\\cdot p\\cdot(d+1) \\le 1 \\Rightarrow p \\le (\\texttt{lllThreshold}\\,d : \\mathbb{R})$, for $d \\ge 1$ and any real $p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_div_iff₀",
+      "transitivity of ≤",
+      "sufficient conditions for the symmetric LLL"
+    ],
+    "prerequisites": [
+      "inv_exp_mul_le_lllThreshold",
+      "symmetric_lll (parent proof, tight-threshold LLL)"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "lovasz-local-lemma-oq-01-euler-threshold",
+  "title": "Lovász Local Lemma OQ-01: The Euler Condition Implies the Tight Threshold",
+  "slug": "lovasz-local-lemma-oq-01-euler-threshold",
+  "description": "The symmetric Lovász Local Lemma is quoted in two forms: the tight threshold P[Aᵢ] ≤ T(d) = dᵈ/(d+1)^{d+1} (the exact maximum of x(1−x)ᵈ, formalized in the parent gallery proof lovasz-local-lemma as lllThreshold), and the memorable Euler form e·p·(d+1) ≤ 1 that appears throughout the literature and in the OQ-01 measure-theoretic target. This entry proves the standard textbook fact that the Euler form is the safe (slightly weaker) consequence of the tight one: e·p·(d+1) ≤ 1 implies p ≤ T(d). The mathematical core is the classic Euler inequality (1 + 1/d)ᵈ ≤ e, obtained from the elementary 1 + x ≤ exp x (Real.add_one_le_exp) raised to the d-th power with exp(1/d)ᵈ = exp(d·(1/d)) = exp 1. From it, the multiplicative form (d+1)ᵈ ≤ e·dᵈ follows, hence 1/(e·(d+1)) ≤ T(d) (the Euler budget sits below the tight threshold), and finally the bridge e·p·(d+1) ≤ 1 → p ≤ T(d). This ties the gallery's rational-surrogate threshold front to the Euler symmetric condition used in the OQ-01 measure-theoretic statement: any event probability admitted by the memorable condition is admitted by the tight threshold, so the tight-threshold symmetric LLL (symmetric_lll in the parent proof) applies verbatim under e·p·(d+1) ≤ 1. This is elementary real analysis, not progress on the hard measure-theoretic induction, but it is fully machine-verified and pins the exact inequality that justifies the memorable form. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "real-analysis",
+      "inequalities",
+      "exponential-function"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on euler_condition_implies_lllThreshold). Scope: this is an elementary real-analysis bridge between two forms of the symmetric LLL hypothesis. It proves e·p·(d+1) ≤ 1 → p ≤ T(d) via the Euler inequality (1+1/d)ᵈ ≤ e. It does NOT prove the measure-theoretic symmetric LLL itself (that the tight threshold or the Euler condition suffices to avoid the bad events with positive probability over a real probability space) — that bounded-dependency-degree induction remains the open OQ-01 research target. What this entry adds is the machine-checked justification for why the memorable Euler condition is a valid sufficient hypothesis: it is implied by the tight threshold that the parent gallery proof already uses.",
+    "lineCount": 106,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "euler_condition_implies_lllThreshold: the bridge e·p·(d+1) ≤ 1 → p ≤ (lllThreshold d : ℝ). Any event probability admitted by the memorable symmetric LLL condition is admitted by the tight threshold T(d) = dᵈ/(d+1)^{d+1} of the parent gallery proof, so the tight-threshold symmetric LLL (symmetric_lll) applies verbatim under the Euler condition. No nonnegativity hypothesis on p is needed: if p < 0 both the hypothesis and the conclusion hold trivially, so the statement is proved in its strongest form.",
+      "one_add_inv_pow_le_exp_one: the classic Euler bound (1 + 1/d)ᵈ ≤ e for d ≥ 1, proved directly from Real.add_one_le_exp (1 + x ≤ exp x) instantiated at x = 1/d, raised to the d-th power via pow_le_pow_left₀, using exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 (Real.exp_nat_mul with d·(1/d) = 1). A clean self-contained proof of the standard sequence bound below e.",
+      "succ_pow_le_exp_mul: the multiplicative form (d+1)ᵈ ≤ e·dᵈ, obtained from the Euler bound by clearing the denominator (1 + 1/d = (d+1)/d, div_pow, div_le_iff₀).",
+      "inv_exp_mul_le_lllThreshold: 1/(e·(d+1)) ≤ (lllThreshold d : ℝ), the statement that the Euler budget sits below the tight threshold. Reduces (via div_le_div_iff₀ and pow_succ) to (d+1)^{d+1} ≤ e·(d+1)·dᵈ, i.e. (d+1)ᵈ ≤ e·dᵈ after cancelling the (d+1) factor.",
+      "lllThreshold_cast: the real-cast bridge (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1} for d ≥ 1, connecting the parent proof's ℚ-valued threshold to the real-analysis inequalities.",
+      "Framing contribution: the parent gallery proof formalizes the tight symmetric threshold T(d) over ℚ, while the OQ-01 measure-theoretic front is stated against the Euler condition e·p·(d+1) ≤ 1. This entry is the machine-checked link between the two — it explains, with a verified proof, why the memorable Euler form is a legitimate (and slightly conservative) sufficient condition."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.LovaszLocalLemma"
+    ],
+    "opens": [
+      "Real",
+      "ProbMethod.LovaszLocal"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01EulerThreshold",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LovaszLocalLemma.lean"
+    ]
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "euler_condition_implies_lllThreshold",
+      "type": "core",
+      "description": "The Euler symmetric condition implies the tight threshold: if e·p·(d+1) ≤ 1 (the memorable symmetric LLL condition), then p ≤ (lllThreshold d : ℝ), the tight threshold dᵈ/(d+1)^{d+1} of the parent gallery proof. Hence the tight-threshold symmetric LLL applies verbatim to any family whose event probabilities satisfy the Euler condition.",
+      "leanType": "(d : ℕ) → (hd : 1 ≤ d) → (p : ℝ) → (Real.exp 1 * p * ((d : ℝ) + 1) ≤ 1) → p ≤ (lllThreshold d : ℝ)"
+    },
+    {
+      "name": "one_add_inv_pow_le_exp_one",
+      "type": "core",
+      "description": "The classic Euler bound (1 + 1/d)ᵈ ≤ e for d ≥ 1. Proved from Real.add_one_le_exp (1 + x ≤ exp x) at x = 1/d, raised to the d-th power, using exp(1/d)ᵈ = exp(d·(1/d)) = exp 1.",
+      "leanType": "(d : ℕ) → (hd : 1 ≤ d) → (1 + 1 / (d : ℝ)) ^ d ≤ Real.exp 1"
+    },
+    {
+      "name": "succ_pow_le_exp_mul",
+      "type": "lemma",
+      "description": "Multiplicative form of the Euler bound: (d+1)ᵈ ≤ e·dᵈ. Obtained from one_add_inv_pow_le_exp_one by clearing denominators.",
+      "leanType": "(d : ℕ) → (hd : 1 ≤ d) → ((d : ℝ) + 1) ^ d ≤ Real.exp 1 * (d : ℝ) ^ d"
+    },
+    {
+      "name": "inv_exp_mul_le_lllThreshold",
+      "type": "lemma",
+      "description": "The Euler budget lies below the tight threshold: 1/(e·(d+1)) ≤ (lllThreshold d : ℝ). Reduces to (d+1)ᵈ ≤ e·dᵈ after cancelling the (d+1) factor.",
+      "leanType": "(d : ℕ) → (hd : 1 ≤ d) → (1 : ℝ) / (Real.exp 1 * ((d : ℝ) + 1)) ≤ (lllThreshold d : ℝ)"
+    },
+    {
+      "name": "lllThreshold_cast",
+      "type": "lemma",
+      "description": "Real-cast of the tight symmetric threshold for d ≥ 1: (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}, bridging the parent proof's ℚ-valued threshold to the real-analysis inequalities.",
+      "leanType": "(d : ℕ) → (hd : 1 ≤ d) → (lllThreshold d : ℝ) = (d : ℝ) ^ d / ((d : ℝ) + 1) ^ (d + 1)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The symmetric Lovász Local Lemma (Erdős–Lovász, 1975) is almost always quoted in the memorable Euler form: if each of n bad events has probability ≤ p, each is mutually independent of all but ≤ d others, and e·p·(d+1) ≤ 1, then the events are simultaneously avoidable with positive probability. The constant e is not accidental — the sharp threshold for the symmetric case is T(d) = dᵈ/(d+1)^{d+1} = max_x x(1−x)ᵈ, attained at x = 1/(d+1), and the Euler form is the clean sufficient condition obtained by bounding this threshold below with 1/(e(d+1)) using (1+1/d)ᵈ ≤ e. Alon and Spencer's The Probabilistic Method states both forms and notes the tight one is 'a bit stronger'; the e·p·(d+1) ≤ 1 version is preferred in applications for its memorability. The parent gallery proof lovasz-local-lemma formalizes the tight threshold T(d) over ℚ (lllThreshold, its value at d = 1,2,3, monotonicity T(d+1) ≤ T(d), and the ≤ 1/4 bound); the OQ-01 measure-theoretic front, meanwhile, targets the Euler-form statement over a real probability space. This entry supplies the elementary but previously-unformalized link between the two hypotheses.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces, including the symmetric conclusion under e·p·(d+1) ≤ 1.\n\n**This entry (threshold bridge)**: prove that the memorable Euler symmetric condition is implied by the tight threshold the parent proof already uses. For d ≥ 1 and p : ℝ, if e·p·(d+1) ≤ 1 then p ≤ T(d) = (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}. The mathematical core is the classic Euler inequality (1 + 1/d)ᵈ ≤ e.",
+    "text": "Two ways to state the symmetric Lovász Local Lemma: the tight one, 'each bad event has probability at most dᵈ/(d+1)^{d+1}', and the memorable one, 'e times the probability times the degree-plus-one is at most 1'. The memorable version is what everyone quotes — and this entry proves, with a fully checked argument, that it is the safe choice: whenever the memorable condition holds, so does the tight one. The whole thing rests on the classic inequality (1 + 1/d)ᵈ ≤ e, the sequence that climbs toward e from below.",
+    "proofStrategy": "**The Euler bound.** Real.add_one_le_exp gives 1 + x ≤ exp x for all real x; at x = 1/d this reads 1 + 1/d ≤ exp(1/d). Both sides are nonnegative, so raising to the d-th power (pow_le_pow_left₀) gives (1 + 1/d)ᵈ ≤ exp(1/d)ᵈ, and exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 by Real.exp_nat_mul together with d·(1/d) = 1 (d ≠ 0). This is one_add_inv_pow_le_exp_one.\n\n**Multiplicative form.** Writing 1 + 1/d = (d+1)/d and using div_pow, div_le_iff₀ turns the Euler bound into (d+1)ᵈ ≤ e·dᵈ (succ_pow_le_exp_mul).\n\n**Below the threshold.** Casting the ℚ-valued lllThreshold to ℝ (lllThreshold_cast: (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}), the claim 1/(e(d+1)) ≤ T(d) becomes, after div_le_div_iff₀ and pow_succ, the inequality (d+1)^{d+1} ≤ e·(d+1)·dᵈ, which is (d+1)ᵈ ≤ e·dᵈ multiplied through by (d+1) — closed by nlinarith from succ_pow_le_exp_mul.\n\n**The bridge.** From e·p·(d+1) ≤ 1 and le_div_iff₀ we get p ≤ 1/(e(d+1)); chaining with inv_exp_mul_le_lllThreshold gives p ≤ T(d).",
+    "keyInsights": [
+      "The constant e in the memorable LLL condition e·p·(d+1) ≤ 1 comes from exactly one place: the bound (1 + 1/d)ᵈ ≤ e on the sequence converging to e. Formalizing that single inequality is what turns the tight threshold dᵈ/(d+1)^{d+1} into the clean sufficient condition p ≤ 1/(e(d+1)).",
+      "The Euler condition is strictly conservative: 1/(e(d+1)) < T(d) for every finite d because (1+1/d)ᵈ < e strictly. The memorable form therefore admits a (slightly) smaller family of probabilities than the tight threshold — it trades a small amount of the sharp constant for a memorable statement, and this entry certifies that trade is always safe.",
+      "No probability theory is used: the entire content is a real-analysis inequality about exp and powers. This cleanly separates the *choice of hypothesis* (which threshold to assume) from the *hard combinatorial induction* (that the hypothesis actually forces positive avoidance probability), which remains the open OQ-01 target.",
+      "The proof needs no nonnegativity assumption on p. Because T(d) > 0, a negative p satisfies both the Euler condition and the conclusion trivially, so euler_condition_implies_lllThreshold holds in full generality — a small illustration of proving the strongest clean statement rather than the one matching the intended probability use-case."
+    ],
+    "prerequisites": [
+      "The parent gallery proof lovasz-local-lemma: lllThreshold d = dᵈ/(d+1)^{d+1} and the tight-threshold symmetric LLL symmetric_lll",
+      "Real.add_one_le_exp: the elementary bound 1 + x ≤ exp x",
+      "Real.exp_nat_mul: exp(n·x) = (exp x)ⁿ, and Real.exp_pos",
+      "Monotonicity of powers pow_le_pow_left₀ and the ordered-field division lemmas div_le_iff₀, div_le_div_iff₀, le_div_iff₀"
+    ]
+  },
+  "conclusion": {
+    "summary": "The memorable Euler symmetric LLL condition e·p·(d+1) ≤ 1 is machine-verified to imply the tight threshold p ≤ T(d) = dᵈ/(d+1)^{d+1} used by the parent gallery proof, via the classic Euler inequality (1 + 1/d)ᵈ ≤ e. Elementary real analysis, fully checked: 0 sorries, 0 axioms.",
+    "implications": "**Connects the two threshold fronts of the OQ-01 landscape.** The parent proof lovasz-local-lemma develops the tight symmetric threshold T(d) over ℚ; the OQ-01 measure-theoretic entries (lovasz-local-lemma-oq-01, its union-bound, chain-rule, and quantitative refinements) are stated against the Euler condition e·p·(d+1) ≤ 1. This entry is the verified bridge: it shows the Euler hypothesis is a legitimate, slightly conservative consequence of the tight threshold, so results proved under either hypothesis transfer to the other. It also isolates the exact inequality — (1 + 1/d)ᵈ ≤ e — that puts the constant e into the LLL.\n\n**Honest scope**: this is real-analysis bookkeeping about which hypothesis is stronger, not a proof that either hypothesis suffices for avoidance. The measure-theoretic symmetric LLL — that e·p·(d+1) ≤ 1 forces μ(⋂ Aᵢᶜ) > 0 over a real probability space with a bounded-dependency-degree structure — remains the open research target; see the chain-rule and quantitative entries for the reduction that awaits the per-event conditional bounds.",
+    "openQuestions": [
+      "Feed the tight threshold p ≤ T(d) (equivalently the Euler condition, via this bridge) into a measure-theoretic dependency structure to derive the per-event conditional failure bounds μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] ≤ 2p required by lovasz-local-lemma-oq-01-quantitative, completing the symmetric LLL over a real probability space.",
+      "Quantify the gap: prove T(d) − 1/(e(d+1)) > 0 explicitly and give its asymptotics, making precise how much sharpness the memorable Euler form sacrifices relative to the tight threshold.",
+      "Formalize the asymmetric general LLL threshold condition μ(Aᵢ) ≤ xᵢ ∏_{j∼i}(1 − xⱼ) and show the symmetric Euler condition is its uniform-weight (xᵢ = 1/(d+1)) specialisation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "extends",
+      "description": "The parent gallery proof, which formalizes the tight symmetric threshold lllThreshold d = dᵈ/(d+1)^{d+1} over ℚ (its values at d = 1,2,3, monotonicity, the ≤ 1/4 bound) and the tight-threshold symmetric LLL symmetric_lll. This entry casts that threshold to ℝ (lllThreshold_cast) and proves the memorable Euler condition e·p·(d+1) ≤ 1 implies p ≤ T(d), so symmetric_lll applies under the Euler hypothesis."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-quantitative",
+      "relationship": "related",
+      "description": "The measure-theoretic quantitative lower bound ∏(1 − bₖ) ≤ μ(⋂ Aᵢᶜ), whose open target is to derive the per-event conditional bounds bₖ = 2p under e·p·(d+1) ≤ 1. This entry supplies the arithmetic behind that Euler condition: e·p·(d+1) ≤ 1 is exactly the memorable form of p ≤ T(d), and here that implication is proved."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "related",
+      "description": "The chain-rule scaffold that reduces the measure-theoretic LLL to per-event conditional bounds under the symmetric regime e·p·(d+1) ≤ 1. This entry certifies that the Euler condition invoked there is implied by the tight threshold of the parent proof."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the symmetric condition is stated in the e·p·(d+1) ≤ 1 form."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "States both the tight threshold and the memorable e·p·(d+1) ≤ 1 condition for the symmetric LLL, noting the tight form is slightly stronger — the implication this entry formalizes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **lovasz-local-lemma-oq-01-euler-threshold** with the 0-sorry / 0-axiom file `Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean` (106 lines, 5 theorems).

Machine-checks the standard textbook link between the two forms of the symmetric Lovász Local Lemma hypothesis:

- **tight threshold** — `p ≤ T(d) = dᵈ/(d+1)^{d+1}` (the parent proof's `lllThreshold`, over ℚ);
- **memorable Euler form** — `e·p·(d+1) ≤ 1` (quoted throughout the literature and used in the OQ-01 measure-theoretic entries).

**Main result** `euler_condition_implies_lllThreshold`: `e·p·(d+1) ≤ 1 → p ≤ (lllThreshold d : ℝ)` for `d ≥ 1` and any real `p` — so the Euler form is a (slightly conservative) consequence of the tight threshold, and the tight-threshold `symmetric_lll` applies verbatim under the Euler condition.

## Proof chain

- `one_add_inv_pow_le_exp_one` — the classic `(1 + 1/d)ᵈ ≤ e`, from `Real.add_one_le_exp` raised to the dᵗʰ power (`exp(1/d)ᵈ = exp(d·(1/d)) = exp 1`). This is the single inequality that puts the constant `e` into the LLL.
- `succ_pow_le_exp_mul` — multiplicative form `(d+1)ᵈ ≤ e·dᵈ`.
- `lllThreshold_cast` — real-cast `(lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}`.
- `inv_exp_mul_le_lllThreshold` — `1/(e(d+1)) ≤ T(d)` (the Euler budget sits below the tight threshold).

## Scope (honest)

Elementary real analysis about *which hypothesis is stronger* — **not** a proof that either hypothesis forces positive avoidance. The measure-theoretic symmetric LLL induction (deriving the per-event conditional bounds under `e·p·(d+1) ≤ 1` to feed the quantitative entry's `avoidance_ge_prod_one_sub`) remains the open OQ-01 target.

## Verification

`#print axioms euler_condition_implies_lllThreshold` = `propext, Classical.choice, Quot.sound` only. 0 sorries, 0 `axiom` declarations, no `native_decide`. Typechecked with `lake env lean` against the cached Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)