### PR TITLE
research(schroeder-bernstein-oq03): add augment_range_step (odd-stage dual)

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1602,6 +1602,61 @@ theorem augment_domain_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
       exact (mem_mRan keptL y).mpr ⟨(u, w), (hmemKept (u, w)).mpr ⟨habL, hu⟩, hwy⟩
 
 /-!
+## Section 4l: The dual range step — odd-stage coverage by `Prod.swap` duality
+
+`augment_domain_step` (Section 4k) is the even-stage move: it makes a fresh *domain* anchor
+`a` covered while preserving all three invariants (`IsMatching`, `MatchingCorr`, `BuiltFrom`)
+and both monotonicities. The scheduler also needs the odd-stage move: make a fresh *range*
+anchor `c` covered. Rather than re-run the entire collision-chase argument on the range side,
+we obtain it *for free* from the coordinate-swap duality of Section 4e.
+
+The range step on the problem `(p, q, f, g)` is exactly the domain step on the swapped
+problem `(q, p, g, f)` with the swapped matching `L.map Prod.swap`: swapping exchanges
+`mDom ↔ mRan` (`mDom_map_swap`/`mRan_map_swap`), turns a matching into a matching
+(`isMatching_map_swap`), a `p ↔ q` correspondence into a `q ↔ p` one
+(`matchingCorr_map_swap`), and — crucially — carries the construction invariant across with
+`f`, `g` exchanged (`builtFrom_map_swap`). So we push the fresh range anchor `c` through
+`augment_domain_step` in the swapped world and swap the resulting matching back. This
+discharges the odd stage with no new list surgery, leaving only the outer stage recursion +
+computable read-off of `myhill_isomorphism`.
+-/
+
+/-- **The augmenting-path range step** (dual of `augment_domain_step`). For a fresh *range*
+    anchor `c ∉ mRan L` in a matching `L` satisfying `BuiltFrom` and the correspondence, there
+    is an extended matching `L'` still satisfying all three invariants, *covering* `c`
+    (`c ∈ mRan L'`), and monotone on both domain and range (`mDom L ⊆ mDom L'`,
+    `mRan L ⊆ mRan L'`). It is obtained by applying `augment_domain_step` to the
+    coordinate-swapped problem `(q, p, g, f)` with matching `L.map Prod.swap` (Section 4e
+    duality) and swapping the result back. This is the odd-stage move the priority scheduler
+    iterates, complementing the even-stage `augment_domain_step`. -/
+theorem augment_range_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hgpq : ∀ n, q n ↔ p (g n))
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hL : IsMatching L) (hC : MatchingCorr p q L) (hB : BuiltFrom f g L)
+    {c : ℕ} (hc : c ∉ mRan L) :
+    ∃ L', IsMatching L' ∧ MatchingCorr p q L' ∧ BuiltFrom f g L' ∧
+      c ∈ mRan L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') := by
+  -- Move to the swapped problem `(q, p, g, f)` with matching `L.map Prod.swap`; the fresh
+  -- range anchor `c` becomes a fresh *domain* anchor there.
+  have hc' : c ∉ mDom (L.map Prod.swap) := by rw [mDom_map_swap]; exact hc
+  obtain ⟨M, hMmatch, hMcorr, hMbuilt, hcM, hdomMono, hranMono⟩ :=
+    augment_domain_step (p := q) (q := p) (f := g) (g := f) hgpq hg hf
+      (isMatching_map_swap hL) (matchingCorr_map_swap hC) (builtFrom_map_swap hB) hc'
+  -- Swap the witness back: `L' := M.map Prod.swap`.
+  refine ⟨M.map Prod.swap, isMatching_map_swap hMmatch, matchingCorr_map_swap hMcorr,
+    builtFrom_map_swap hMbuilt, ?_, ?_, ?_⟩
+  · -- `c ∈ mRan (M.map swap) = mDom M`
+    rw [mRan_map_swap]; exact hcM
+  · -- domain monotone: `mDom L ⊆ mDom (M.map swap) = mRan M`
+    intro x hx
+    rw [mDom_map_swap]
+    exact hranMono x (by rw [mRan_map_swap]; exact hx)
+  · -- range monotone: `mRan L ⊆ mRan (M.map swap) = mDom M`
+    intro y hy
+    rw [mRan_map_swap]
+    exact hdomMono y (by rw [mDom_map_swap]; exact hy)
+
+/-!
 ## Section 5: The Myhill Isomorphism Theorem
 -/
 


### PR DESCRIPTION
## Summary

Adds `augment_range_step` to `Proofs/SchroederBernsteinOQ03.lean` (Myhill's Isomorphism Theorem, OQ-03) — the **odd-stage** back-and-forth move, the `Prod.swap` dual of the existing even-stage `augment_domain_step`.

This was the top item on the problem's `nextSteps` list ("Derive the range-stage dual `augment_range_step` from `augment_domain_step` via the Section 4e swap duality").

## What it proves

For a fresh **range** anchor `c ∉ mRan L` in a matching `L` satisfying `BuiltFrom` + correspondence, there is an extended matching `L'` that:
- preserves all three invariants (`IsMatching`, `MatchingCorr`, `BuiltFrom`),
- **covers** `c` (`c ∈ mRan L'`), and
- is monotone on both sides (`mDom L ⊆ mDom L'`, `mRan L ⊆ mRan L'`).

## How

Purely by the Section 4e coordinate-swap duality — no new list surgery. The range step on `(p, q, f, g)` is the domain step on the swapped problem `(q, p, g, f)` with matching `L.map Prod.swap`. We push `c` through `augment_domain_step` in the swapped world (via `isMatching_map_swap`, `matchingCorr_map_swap`, `builtFrom_map_swap`, `mDom_map_swap`/`mRan_map_swap`) and swap the witness back.

## Verification

- Typechecks against Mathlib v4.26.0 (`lake env lean`) with **zero errors**.
- Axiom-clean: derived only from already-verified 0-axiom lemmas; axioms are `propext`/`Classical.choice`/`Quot.sound`.
- The only remaining `sorry` is the outer `myhill_isomorphism` scheduler (stage recursion + computable read-off), unchanged by this PR.

Both atomic stage moves of the Myhill priority construction are now `BuiltFrom`-preserving and iterable; what remains is assembling the alternating stage recursion and reading off the computable permutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)