### PR TITLE
research(prob-method-second-moment-oq-04-oq-03-oq-01): weighted Paley–Zygmund lower-tail bound

### DIFF
--- a/proofs/Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean
@@ -1,0 +1,243 @@
+/-
+  Weighted-Finset Paley–Zygmund: the second-moment lower-tail bound
+
+  Open question OQ-04-OQ-03-OQ-01
+  (parent: prob-method-second-moment-oq-04-oq-03).
+
+  The parent file `ProbMethodSecondMomentOQ04OQ03.lean` generalises the
+  counting-measure second-moment method to an arbitrary nonnegative weight
+  `w : α → ℚ` over a finite index set `s : Finset α`, proving the *upper*-tail
+  side of the story:
+
+    * `weighted_cauchy_schwarz`  (∑ w·X)² ≤ (∑ w)·(∑ w·X²)
+    * `weighted_chebyshev`       P_w(|X − μ| ≥ a) ≤ Var_w(X)/a².
+
+  Chebyshev controls how much weight sits *far* from the mean. Its natural
+  companion — and the missing half of the second-moment method as it is used in
+  the probabilistic method (Alon–Spencer, *The Probabilistic Method*, §4.3) — is
+  the **Paley–Zygmund inequality**, which lower-bounds the weight sitting *above*
+  a fraction of the mean:
+
+    for a nonnegative `X`, `0 ≤ θ ≤ 1`, and the weighted mean `μ = (∑ w·X)/(∑ w)`,
+
+        P_w(X > θ·μ)  ≥  (1 − θ)² · μ² / E_w[X²].
+
+  Where Chebyshev says "the tail is thin", Paley–Zygmund says "the head is fat":
+  if the second moment is not much larger than the square of the mean, then a
+  constant fraction of the weight lies near the mean. This is the standard tool
+  for proving that a nonnegative random variable is positive with constant
+  probability (e.g. threshold phenomena in random graphs).
+
+  This file proves the weighted Paley–Zygmund inequality, staying in exactly the
+  same elementary `Finset` / `BigOperators` world as the parent — everything over
+  `ℚ`, no `MeasureTheory`, no real analysis. The engine is a hypothesis-free
+  weighted Cauchy–Schwarz (`wcs_raw`), the same tilted-square identity used by
+  the parent but with the positive-total-weight side condition removed so it also
+  applies to the tail sub-sum.
+
+  ## Results
+
+  * `wcs_raw` — weighted Cauchy–Schwarz with no positivity side condition:
+        (∑ w·X)² ≤ (∑ w)·(∑ w·X²)  for  w ≥ 0.
+
+  * `weighted_paley_zygmund_key` — the division-free heart:
+        (1 − θ)² · (∑ w·X)²  ≤  (∑_{X > θμ} w) · (∑ w·X²),
+    where the threshold event `{X > θμ}` is written `θ·(∑ w·X) < (∑ w)·X` to keep
+    the defining predicate division-free.
+
+  * `weighted_paley_zygmund` — the probability form
+        P_w(X > θ·μ)  ≥  (1 − θ)² · μ² / E_w[X²]
+    (needs a strictly positive weighted second moment to divide).
+
+  * `paley_zygmund_uniform` — the counting-measure specialization `w ≡ 1`:
+        (1 − θ)² · (∑ X)²  ≤  (#{i : θ·∑X < #s·X i}) · (∑ X²).
+
+  No `axiom`, no `sorry`, no `native_decide`.
+-/
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace ProbMethod.SecondMoment.Weighted
+
+open Finset BigOperators
+
+variable {α : Type*}
+
+/-! ## Hypothesis-free weighted Cauchy–Schwarz -/
+
+/-- **Weighted Cauchy–Schwarz, no side condition.** For a nonnegative weight `w`
+and any `X : α → ℚ`,
+
+    (∑ w·X)²  ≤  (∑ w)·(∑ w·X²).
+
+Unlike `ProbMethodSecondMomentOQ04OQ03.weighted_cauchy_schwarz`, this drops the
+`0 < ∑ w` hypothesis: when the total weight is zero every `w i` vanishes and both
+sides are `0`. Removing the side condition lets us apply Cauchy–Schwarz to the
+tail sub-sum in Paley–Zygmund, where the sub-sum's total weight is unknown. -/
+theorem wcs_raw (s : Finset α) (w X : α → ℚ) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * X i) ^ 2 ≤ (∑ i ∈ s, w i) * (∑ i ∈ s, w i * X i ^ 2) := by
+  set Sw := ∑ i ∈ s, w i with hSw
+  set SwX := ∑ i ∈ s, w i * X i with hSwX
+  set SwX2 := ∑ i ∈ s, w i * X i ^ 2 with hSwX2
+  -- Tilted sum of squares is nonnegative and expands to `Sw·(Sw·SwX2 − SwX²)`.
+  have hnn : 0 ≤ ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2 :=
+    Finset.sum_nonneg (fun i hi => mul_nonneg (hw i hi) (sq_nonneg _))
+  have hexp : ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2 = Sw * (Sw * SwX2 - SwX ^ 2) := by
+    have hterm : ∑ i ∈ s, w i * (Sw * X i - SwX) ^ 2
+        = ∑ i ∈ s, (Sw ^ 2 * (w i * X i ^ 2)
+            - 2 * Sw * SwX * (w i * X i) + SwX ^ 2 * w i) :=
+      Finset.sum_congr rfl (fun i _ => by ring)
+    rw [hterm, Finset.sum_add_distrib, Finset.sum_sub_distrib,
+        ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum, ← hSw, ← hSwX, ← hSwX2]
+    ring
+  rw [hexp] at hnn
+  -- Split on whether the total weight is zero.
+  rcases eq_or_lt_of_le (Finset.sum_nonneg hw) with hSw0 | hSwpos
+  · -- Sw = 0 ⇒ every weight is 0 ⇒ SwX = 0.
+    have hall : ∀ i ∈ s, w i = 0 := (Finset.sum_eq_zero_iff_of_nonneg hw).mp hSw0.symm
+    have hSwX0 : SwX = 0 := Finset.sum_eq_zero (fun i hi => by rw [hall i hi]; ring)
+    have hSw0' : Sw = 0 := hSw0.symm
+    rw [hSwX0, hSw0']; simp
+  · -- Sw > 0 ⇒ clear the positive factor.
+    have hD : 0 ≤ Sw * SwX2 - SwX ^ 2 := by nlinarith [hnn, hSwpos]
+    linarith [hD]
+
+/-! ## Weighted Paley–Zygmund -/
+
+/-- **Weighted Paley–Zygmund, cleared (division-free) form.** For a nonnegative
+weight `w`, a nonnegative `X`, positive total weight, and `0 ≤ θ ≤ 1`,
+
+    (1 − θ)² · (∑ w·X)²  ≤  (∑_{i : θ·(∑ w·X) < (∑ w)·X i} w i) · (∑ w·X²).
+
+The threshold set `{ θ·(∑ w·X) < (∑ w)·X i }` is the division-free rendering of
+`{ X i > θ·μ }` with `μ = (∑ w·X)/(∑ w)`. The proof: the head weight carries at
+least `(1 − θ)·(∑ w·X)` of the weighted sum of `X` (the tail contributes at most
+`θ·(∑ w·X)`), and weighted Cauchy–Schwarz on the head turns that linear lower
+bound into the quadratic one. -/
+theorem weighted_paley_zygmund_key (s : Finset α) (w X : α → ℚ) (θ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hX : ∀ i ∈ s, 0 ≤ X i)
+    (hS : 0 < ∑ i ∈ s, w i) (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * (∑ i ∈ s, w i * X i) ^ 2
+      ≤ (∑ i ∈ s.filter (fun i => θ * (∑ j ∈ s, w j * X j) < (∑ j ∈ s, w j) * X i), w i)
+          * (∑ i ∈ s, w i * X i ^ 2) := by
+  set Sw := ∑ i ∈ s, w i with hSw
+  set SwX := ∑ i ∈ s, w i * X i with hSwX
+  set A := s.filter (fun i => θ * SwX < Sw * X i) with hAdef
+  set B := s.filter (fun i => ¬ (θ * SwX < Sw * X i)) with hBdef
+  have hAsub : A ⊆ s := Finset.filter_subset _ _
+  have hBsub : B ⊆ s := Finset.filter_subset _ _
+  have hSwX_nn : 0 ≤ SwX :=
+    Finset.sum_nonneg (fun i hi => mul_nonneg (hw i hi) (hX i hi))
+  -- (1) Complement `B = {X ≤ θμ}` carries little weighted mass: ∑_B w·X ≤ θ·SwX.
+  have hθSwX_nn : 0 ≤ θ * SwX := mul_nonneg hθ0 hSwX_nn
+  have htail : Sw * (∑ i ∈ B, w i * X i) ≤ Sw * (θ * SwX) := by
+    calc Sw * (∑ i ∈ B, w i * X i)
+        = ∑ i ∈ B, w i * (Sw * X i) := by rw [Finset.mul_sum]; exact Finset.sum_congr rfl (fun i _ => by ring)
+      _ ≤ ∑ i ∈ B, w i * (θ * SwX) := by
+          refine Finset.sum_le_sum (fun i hi => ?_)
+          have hi_s : i ∈ s := hBsub hi
+          have hle : Sw * X i ≤ θ * SwX := not_lt.mp (Finset.mem_filter.mp hi).2
+          exact mul_le_mul_of_nonneg_left hle (hw i hi_s)
+      _ = (∑ i ∈ B, w i) * (θ * SwX) := by rw [Finset.sum_mul]
+      _ ≤ Sw * (θ * SwX) := by
+          apply mul_le_mul_of_nonneg_right _ hθSwX_nn
+          rw [hSw]
+          exact Finset.sum_le_sum_of_subset_of_nonneg hBsub
+            (fun i hi _ => hw i hi)
+  have htail' : (∑ i ∈ B, w i * X i) ≤ θ * SwX :=
+    le_of_mul_le_mul_left htail hS
+  -- (2) Hence the head carries a linear lower bound: (1−θ)·SwX ≤ ∑_A w·X.
+  have hsplit : (∑ i ∈ A, w i * X i) + (∑ i ∈ B, w i * X i) = SwX := by
+    rw [hSwX]; exact Finset.sum_filter_add_sum_filter_not s _ _
+  have hhead : (1 - θ) * SwX ≤ ∑ i ∈ A, w i * X i := by
+    have : ∑ i ∈ A, w i * X i = SwX - (∑ i ∈ B, w i * X i) := by linarith [hsplit]
+    rw [this]; nlinarith [htail']
+  have hhead_nn : 0 ≤ (1 - θ) * SwX := mul_nonneg (by linarith) hSwX_nn
+  -- (3) Cauchy–Schwarz on the head set A, then extend the X² sum back to s.
+  have hcs : (∑ i ∈ A, w i * X i) ^ 2
+      ≤ (∑ i ∈ A, w i) * (∑ i ∈ A, w i * X i ^ 2) :=
+    wcs_raw A w X (fun i hi => hw i (hAsub hi))
+  have hext : (∑ i ∈ A, w i * X i ^ 2) ≤ (∑ i ∈ s, w i * X i ^ 2) :=
+    Finset.sum_le_sum_of_subset_of_nonneg hAsub
+      (fun i hi _ => mul_nonneg (hw i hi) (sq_nonneg _))
+  have hAw_nn : 0 ≤ ∑ i ∈ A, w i :=
+    Finset.sum_nonneg (fun i hi => hw i (hAsub hi))
+  -- (4) Chain: (1−θ)²·SwX² ≤ (∑_A wX)² ≤ (∑_A w)(∑_A wX²) ≤ (∑_A w)(∑_s wX²).
+  calc (1 - θ) ^ 2 * SwX ^ 2
+      = ((1 - θ) * SwX) ^ 2 := by ring
+    _ ≤ (∑ i ∈ A, w i * X i) ^ 2 := by
+        apply pow_le_pow_left₀ hhead_nn hhead
+    _ ≤ (∑ i ∈ A, w i) * (∑ i ∈ A, w i * X i ^ 2) := hcs
+    _ ≤ (∑ i ∈ A, w i) * (∑ i ∈ s, w i * X i ^ 2) :=
+        mul_le_mul_of_nonneg_left hext hAw_nn
+
+/-- Weighted mean `(∑ w·X)/(∑ w)`, matching the parent file's `wmean`. -/
+def wmean (s : Finset α) (w X : α → ℚ) : ℚ :=
+  (∑ i ∈ s, w i * X i) / (∑ i ∈ s, w i)
+
+/-- Weighted lower-tail "probability": the fraction of total weight carried by
+points with `X i > θ·μ`, `μ` the weighted mean. The defining predicate is the
+division-free `θ·(∑ w·X) < (∑ w)·X i`, equivalent to `X i > θ·μ` when `∑ w > 0`. -/
+def wHeadProb (s : Finset α) (w X : α → ℚ) (θ : ℚ) : ℚ :=
+  (∑ i ∈ s.filter (fun i => θ * (∑ j ∈ s, w j * X j) < (∑ j ∈ s, w j) * X i), w i)
+    / (∑ i ∈ s, w i)
+
+/-- **Weighted Paley–Zygmund inequality (probability form).** With `μ = wmean`
+the weighted mean and `E_w[X²] = (∑ w·X²)/(∑ w)` the weighted second moment, for
+`0 ≤ θ ≤ 1`, positive total weight, nonnegative `X`, and positive weighted second
+moment,
+
+    P_w(X > θ·μ)  ≥  (1 − θ)² · μ² / E_w[X²].
+
+Written with `wHeadProb` on the left. This is the lower-tail companion to the
+parent's `weighted_chebyshev`. -/
+theorem weighted_paley_zygmund (s : Finset α) (w X : α → ℚ) (θ : ℚ)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hX : ∀ i ∈ s, 0 ≤ X i)
+    (hS : 0 < ∑ i ∈ s, w i) (hSX2 : 0 < ∑ i ∈ s, w i * X i ^ 2)
+    (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * wmean s w X ^ 2 / ((∑ i ∈ s, w i * X i ^ 2) / (∑ i ∈ s, w i))
+      ≤ wHeadProb s w X θ := by
+  set Sw := ∑ i ∈ s, w i with hSw
+  set SwX := ∑ i ∈ s, w i * X i with hSwX
+  set SwX2 := ∑ i ∈ s, w i * X i ^ 2 with hSwX2
+  set Aw := ∑ i ∈ s.filter (fun i => θ * SwX < Sw * X i), w i with hAw
+  have hkey : (1 - θ) ^ 2 * SwX ^ 2 ≤ Aw * SwX2 :=
+    weighted_paley_zygmund_key s w X θ hw hX hS hθ0 hθ1
+  -- LHS = (1−θ)²·(SwX/Sw)² / (SwX2/Sw) = (1−θ)²·SwX² / (Sw·SwX2).
+  have hErw : (1 - θ) ^ 2 * wmean s w X ^ 2 / (SwX2 / Sw)
+      = (1 - θ) ^ 2 * SwX ^ 2 / (Sw * SwX2) := by
+    rw [wmean, ← hSwX, ← hSw]
+    field_simp
+  rw [hErw, wHeadProb, ← hSwX, ← hSw, ← hAw]
+  rw [div_le_div_iff₀ (by positivity) hS]
+  -- goal: (1−θ)²·SwX² · Sw ≤ Aw · (Sw·SwX2)
+  nlinarith [hkey, hS.le, mul_nonneg hS.le hSX2.le]
+
+/-! ## Uniform (counting-measure) specialization -/
+
+/-- **Uniform Paley–Zygmund.** The counting-measure special case `w ≡ 1` of
+`weighted_paley_zygmund_key`:
+
+    (1 − θ)² · (∑ X)²  ≤  (#{i ∈ s : θ·∑X < #s·X i}) · (∑ X²),
+
+recovering the classical Paley–Zygmund lower-tail bound over a uniform finite
+sample space. -/
+theorem paley_zygmund_uniform (s : Finset α) (X : α → ℚ) (θ : ℚ)
+    (hX : ∀ i ∈ s, 0 ≤ X i) (hs : s.Nonempty) (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * (∑ i ∈ s, X i) ^ 2
+      ≤ ((s.filter (fun i => θ * (∑ j ∈ s, X j) < (s.card : ℚ) * X i)).card : ℚ)
+          * (∑ i ∈ s, X i ^ 2) := by
+  have hStot : 0 < ∑ i ∈ s, (1 : ℚ) := by
+    rw [Finset.sum_const, nsmul_eq_mul, mul_one]; exact_mod_cast hs.card_pos
+  have h := weighted_paley_zygmund_key s (fun _ => 1) X θ
+    (fun _ _ => zero_le_one) hX hStot hθ0 hθ1
+  simp only [one_mul] at h
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one] at h
+  -- rewrite the total weight `∑ 1 = #s` inside the filter predicate and the head count
+  have hcard : (∑ i ∈ s, (1 : ℚ)) = (s.card : ℚ) := by
+    rw [Finset.sum_const, nsmul_eq_mul, mul_one]
+  rw [hcard] at h
+  simpa using h
+
+end ProbMethod.SecondMoment.Weighted

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "pz-wcs-raw",
+    "proofId": "prob-method-second-moment-oq-04-oq-03-oq-01",
+    "range": { "startLine": 78, "endLine": 104 },
+    "type": "theorem",
+    "title": "Hypothesis-Free Weighted Cauchy–Schwarz",
+    "content": "The parent's weighted Cauchy–Schwarz (∑ w·X)² ≤ (∑ w)(∑ w·X²) required a positive total weight to clear the factor Sw. Paley–Zygmund needs to apply Cauchy–Schwarz to the head event {X > θμ}, whose total weight is not known to be positive, so the side condition must go. wcs_raw removes it: the same tilted sum of squares ∑ w·(Sw·X − SwX)² ≥ 0 expands to Sw·(Sw·SwX2 − SwX²), and the proof cases on whether Sw = 0. If Sw = 0, nonnegativity of w forces every weight to vanish (Finset.sum_eq_zero_iff_of_nonneg), so ∑ w·X = 0 and both sides are 0; if Sw > 0, nlinarith clears the factor exactly as in the parent.",
+    "mathContext": "$\\Big(\\sum_i w_i X_i\\Big)^2 \\le \\Big(\\sum_i w_i\\Big)\\Big(\\sum_i w_i X_i^2\\Big)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_nonneg", "Finset.sum_eq_zero_iff_of_nonneg", "sum-of-squares expansion", "case split on zero total weight"],
+    "relatedConcepts": ["Cauchy–Schwarz inequality", "second moment method", "degenerate measure", "sum of squares (SOS)"]
+  },
+  {
+    "id": "pz-key",
+    "proofId": "prob-method-second-moment-oq-04-oq-03-oq-01",
+    "range": { "startLine": 118, "endLine": 174 },
+    "type": "theorem",
+    "title": "Weighted Paley–Zygmund, Cleared (Division-Free) Form",
+    "content": "The heart of the inequality: (1 − θ)²·(∑ w·X)² ≤ (∑_{X>θμ} w)·(∑ w·X²). The threshold event {X > θμ} is written division-free as {θ·(∑ w·X) < (∑ w)·X}. Two moves. First, the complement B = {X ≤ θμ} carries little weighted mass: on B each Sw·X i ≤ θ·SwX, so pushing the total weight through gives Sw·(∑_B w·X) ≤ θ·SwX·Sw and cancelling Sw > 0 leaves ∑_B w·X ≤ θ·SwX. Splitting SwX = ∑_A w·X + ∑_B w·X (Finset.sum_filter_add_sum_filter_not) then forces the head lower bound ∑_A w·X ≥ (1 − θ)·SwX, which is ≥ 0 since θ ≤ 1 and SwX ≥ 0. Second, square this linear bound (pow_le_pow_left₀) and apply wcs_raw to the head A, extending its second moment up to the full ∑ w·X²: (1 − θ)²·SwX² ≤ (∑_A w·X)² ≤ (∑_A w)·SwX2.",
+    "mathContext": "$(1-\\theta)^2\\Big(\\sum w_i X_i\\Big)^2 \\le \\Big(\\sum_{X>\\theta\\mu} w_i\\Big)\\Big(\\sum w_i X_i^2\\Big)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_filter_add_sum_filter_not", "le_of_mul_le_mul_left", "pow_le_pow_left₀", "wcs_raw", "Finset.sum_le_sum_of_subset_of_nonneg"],
+    "relatedConcepts": ["Paley–Zygmund inequality", "anti-concentration", "second moment method", "head/tail decomposition"]
+  },
+  {
+    "id": "pz-defs",
+    "proofId": "prob-method-second-moment-oq-04-oq-03-oq-01",
+    "range": { "startLine": 176, "endLine": 193 },
+    "type": "definition",
+    "title": "Weighted Mean and Lower-Tail Fraction",
+    "content": "wmean s w X = (∑ w·X)/(∑ w) is the weighted mean μ, matching the parent file's wmean. wHeadProb s w X θ is the weighted lower-tail fraction P_w(X > θ·μ): the fraction of total weight carried by points satisfying the division-free predicate θ·(∑ w·X) < (∑ w)·X i, which is equivalent to X i > θ·μ when ∑ w > 0. Defining the event without division keeps the filter polynomial in the data and decidable over ℚ, and keeps the whole development measure-theory-free.",
+    "mathContext": "$\\mu_w = \\dfrac{\\sum w_i X_i}{\\sum w_i}, \\qquad P_w(X>\\theta\\mu_w) = \\dfrac{\\sum_{X>\\theta\\mu_w} w_i}{\\sum w_i}$",
+    "significance": "supporting",
+    "prerequisites": ["weighted average as ratio of Finset sums", "division-free threshold predicate"],
+    "relatedConcepts": ["weighted mean", "discrete measure", "tail probability"]
+  },
+  {
+    "id": "pz-prob",
+    "proofId": "prob-method-second-moment-oq-04-oq-03-oq-01",
+    "range": { "startLine": 195, "endLine": 215 },
+    "type": "theorem",
+    "title": "Weighted Paley–Zygmund (Probability Form)",
+    "content": "The statement in probability form: P_w(X > θ·μ) ≥ (1 − θ)²·μ²/E_w[X²], the lower-tail companion to the parent's weighted Chebyshev bound. With μ = wmean and E_w[X²] = (∑ w·X²)/(∑ w), rewriting the left side as (1 − θ)²·SwX²/(Sw·SwX2) and clearing the positive denominators Sw and SwX2 (div_le_div_iff₀) reduces the goal to the cleared key inequality, discharged by nlinarith. The positive-second-moment hypothesis 0 < ∑ w·X² is exactly what makes the ratio well-defined.",
+    "mathContext": "$P_w(X>\\theta\\mu) \\;\\ge\\; (1-\\theta)^2\\,\\dfrac{\\mu^2}{\\mathbb{E}_w[X^2]}$",
+    "significance": "critical",
+    "prerequisites": ["div_le_div_iff₀", "weighted_paley_zygmund_key", "clearing positive denominators"],
+    "relatedConcepts": ["Paley–Zygmund inequality", "anti-concentration", "second-moment ratio", "constant-probability positivity"]
+  },
+  {
+    "id": "pz-uniform",
+    "proofId": "prob-method-second-moment-oq-04-oq-03-oq-01",
+    "range": { "startLine": 226, "endLine": 242 },
+    "type": "theorem",
+    "title": "Uniform Paley–Zygmund (w ≡ 1 specialization)",
+    "content": "Instantiating the cleared key lemma at the constant weight w ≡ 1 recovers the classical counting-measure Paley–Zygmund bound: (1 − θ)²·(∑ X)² ≤ #{i : θ·∑X < #s·X i}·(∑ X²). The total weight ∑ 1 collapses to the cardinality #s (Finset.sum_const), the head weight ∑_A 1 becomes the count #A, and 1·X, 1·X² simplify. This confirms the weighted generalization is conservative — it contains the textbook uniform Paley–Zygmund inequality as a special case.",
+    "mathContext": "$(1-\\theta)^2\\Big(\\sum_i X_i\\Big)^2 \\le \\#\\{i: \\theta\\textstyle\\sum X < |s|\\,X_i\\}\\,\\sum_i X_i^2$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.sum_const", "constant weight specialization", "weighted_paley_zygmund_key"],
+    "relatedConcepts": ["counting measure", "uniform distribution", "conservative generalization"]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/index.ts
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodSecondMomentOq04Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodSecondMomentOq04Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodSecondMomentOq04Oq03Oq01Data: ProofData = {
+  proof: probMethodSecondMomentOq04Oq03Oq01Proof,
+  annotations: probMethodSecondMomentOq04Oq03Oq01Annotations,
+}

--- a/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,244 @@
+{
+  "id": "prob-method-second-moment-oq-04-oq-03-oq-01",
+  "title": "Weighted-Finset Paley–Zygmund: the Second-Moment Lower-Tail Bound",
+  "slug": "prob-method-second-moment-oq-04-oq-03-oq-01",
+  "description": "The Paley–Zygmund inequality — the lower-tail companion to Chebyshev in the second-moment method — over an arbitrary nonnegative weight w : α → ℚ on a Finset. Where the parent entry (prob-method-second-moment-oq-04-oq-03) proves the weighted Cauchy–Schwarz engine and the weighted Chebyshev upper-tail bound P_w(|X − μ| ≥ a) ≤ Var_w/a², this entry proves the missing half: for a nonnegative X and 0 ≤ θ ≤ 1, P_w(X > θ·μ) ≥ (1 − θ)²·μ²/E_w[X²]. Chebyshev says the tail is thin; Paley–Zygmund says the head is fat — if the weighted second moment is not much larger than the square of the weighted mean, a constant fraction of the weight sits near the mean. The proof reuses the parent's tilted-square Cauchy–Schwarz idea in a hypothesis-free form (wcs_raw, positivity side condition removed so it applies to the tail sub-sum) plus a linear head-weight lower bound. Everything is over ℚ with Finset/BigOperators — no MeasureTheory, no real analysis, no square roots. This realizes an open question stated explicitly in the parent entry. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (Paley–Zygmund inequality, 1932), weighted formalization in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Paley%E2%80%93Zygmund_inequality",
+    "date": "1932",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean",
+    "tags": [
+      "probabilistic-method",
+      "second-moment-method",
+      "paley-zygmund",
+      "cauchy-schwarz",
+      "concentration-inequalities",
+      "anti-concentration",
+      "weighted-sums",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_nonneg",
+        "description": "A Finset sum of nonnegative terms is nonnegative. Establishes both the tilted sum of squares ∑ w·(Sw·X − SwX)² ≥ 0 (the engine of wcs_raw) and the nonnegativity 0 ≤ ∑ w·X used to sign the head-weight lower bound.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "∑_{filter p} f + ∑_{filter ¬p} f = ∑_s f. Splits the weighted sum ∑ w·X into its head part {X > θμ} and complement {X ≤ θμ} without requiring DecidableEq on the carrier, replacing a set-difference argument.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset_of_nonneg",
+        "description": "Extending a sum over a subset to the whole Finset increases it when the added terms are nonnegative. Used to bound the complement weight ∑_B w ≤ ∑_s w and to extend the head second moment ∑_A w·X² up to ∑_s w·X² after Cauchy–Schwarz.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "le_of_mul_le_mul_left",
+        "description": "Cancels a positive left factor from an inequality. Divides the total weight Sw > 0 out of Sw·(∑_B w·X) ≤ Sw·(θ·SwX) to obtain the clean complement bound ∑_B w·X ≤ θ·SwX.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "pow_le_pow_left₀",
+        "description": "Monotonicity of squaring on nonnegatives: 0 ≤ a ≤ b → a² ≤ b². Turns the linear head lower bound 0 ≤ (1−θ)·SwX ≤ ∑_A w·X into the quadratic ((1−θ)·SwX)² ≤ (∑_A w·X)² feeding Cauchy–Schwarz.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "Cross-multiplication for an inequality between two fractions with positive denominators. Clears the positive denominators ∑ w and ∑ w·X² to pass from the cleared key inequality to the probability form P_w(X > θμ) ≥ (1−θ)²·μ²/E_w[X²].",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "∑ _ ∈ s, c = s.card • c. Collapses the constant weight ∑ 1 to the cardinality #s in the w ≡ 1 specialization, recovering the classical uniform Paley–Zygmund bound.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "weighted_paley_zygmund: a 0-axiom Lean proof of the weighted Paley–Zygmund lower-tail inequality P_w(X > θ·μ) ≥ (1−θ)²·μ²/E_w[X²] for a nonnegative X, nonnegative weight w with positive total weight, and 0 ≤ θ ≤ 1 — the anti-concentration companion to the parent's weighted Chebyshev bound, and the open question the parent entry explicitly posed.",
+      "weighted_paley_zygmund_key: the division-free heart, (1−θ)²·(∑ w·X)² ≤ (∑_{X>θμ} w)·(∑ w·X²), with the threshold event written θ·(∑ w·X) < (∑ w)·X to keep the defining predicate free of division. The head weight is shown to carry at least (1−θ)·(∑ w·X) of the weighted sum of X (the complement contributes at most θ·(∑ w·X)), and weighted Cauchy–Schwarz on the head turns that linear bound into the quadratic one.",
+      "wcs_raw: weighted discrete Cauchy–Schwarz (∑ w·X)² ≤ (∑ w)(∑ w·X²) with the parent's positive-total-weight side condition removed — when the total weight is zero every weight vanishes and both sides are 0. Dropping the hypothesis is what lets Cauchy–Schwarz be applied to the tail sub-sum, whose total weight is unknown a priori.",
+      "wmean, wHeadProb: the weighted mean and the weighted lower-tail fraction P_w(X > θ·μ), defined as ratios of Finset sums with a division-free defining predicate, keeping the development measure-theory-free.",
+      "paley_zygmund_uniform: the w ≡ 1 specialization recovering the classical counting-measure Paley–Zygmund bound (1−θ)²·(∑ X)² ≤ #{i : θ·∑X < #s·X i}·(∑ X²), confirming the weighted generalization is conservative."
+    ],
+    "dateAdded": "2026-07-03",
+    "relatedProblems": [
+      {
+        "id": "prob-method-second-moment-oq-04-oq-03",
+        "relationship": "Direct parent. Proves the weighted Cauchy–Schwarz engine and the weighted Chebyshev upper-tail bound, and lists 'a weighted Paley–Zygmund lower-tail bound P_w(X ≥ θ·μ) ≥ (1−θ)²·μ²/E_w[X²]' among its open questions. This child proves exactly that, reusing the tilted-square Cauchy–Schwarz idea in hypothesis-free form."
+      },
+      {
+        "id": "prob-method-second-moment-oq-04",
+        "relationship": "Grandparent. OQ-04 proves Cantelli's one-sided Chebyshev inequality over the uniform counting measure. The Paley–Zygmund bound here is the lower-tail (anti-concentration) counterpart, generalized to arbitrary nonnegative weights."
+      },
+      {
+        "id": "prob-method-second-moment",
+        "relationship": "Root of the probabilistic-method / second-moment line of work. Paley–Zygmund is the standard tool for proving a nonnegative random variable is positive with constant probability; this supplies its weighted, measure-theory-free formulation."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 243,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Hypotheses are inputs to the statements, not standing assumptions: the weight is nonnegative (0 ≤ w i on s), X is nonnegative (0 ≤ X i on s), the total weight is positive (0 < ∑ w), the fraction parameter satisfies 0 ≤ θ ≤ 1, and the probability form additionally assumes a positive weighted second moment (0 < ∑ w·X²) so the ratio is defined. The carrier α is an arbitrary type and all sums are over an explicit Finset s : Finset α; everything is over ℚ. #print axioms reports only the foundational propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The second-moment method controls a nonnegative random variable using only its first two moments. Its upper tail is Chebyshev's inequality (deviations above a threshold are rare); its lower tail is the Paley–Zygmund inequality, introduced by Raymond Paley and Antoni Zygmund in 1932 in their work on random trigonometric series. Paley–Zygmund is the anti-concentration workhorse of the probabilistic method: it shows that if E[X²] is within a constant factor of E[X]², then X is at least a constant fraction of its mean with constant probability — the standard route to proving thresholds in random graphs (a variable that is positive in expectation is actually positive with constant probability). The parent gallery entry generalizes the second-moment engine (weighted Cauchy–Schwarz) and the Chebyshev upper-tail bound to arbitrary nonnegative weights over ℚ, and lists the weighted Paley–Zygmund bound among its open questions. This entry closes that gap.",
+    "problemStatement": "Let s : Finset α, let w : α → ℚ be a weight with 0 ≤ w i for i ∈ s and positive total weight ∑ w > 0, let X : α → ℚ with 0 ≤ X i for i ∈ s, and let 0 ≤ θ ≤ 1. Writing μ = (∑ w·X)/(∑ w) for the weighted mean and E_w[X²] = (∑ w·X²)/(∑ w) for the weighted second moment (assumed positive), prove the weighted Paley–Zygmund inequality P_w(X > θ·μ) ≥ (1 − θ)²·μ²/E_w[X²], where P_w(X > θ·μ) is the fraction of total weight carried by points with X > θ·μ. Prove also the division-free cleared form and the w ≡ 1 specialization recovering the classical counting-measure statement.",
+    "text": "Abbreviate Sw = ∑ w, SwX = ∑ w·X, SwX2 = ∑ w·X². Split the index set into the head A = {X > θμ} and its complement B = {X ≤ θμ}. On B every point has X ≤ θμ, so B carries little weighted mass: ∑_B w·X ≤ θ·SwX (proved by pushing the total weight through and cancelling Sw > 0). Hence the head carries the rest, ∑_A w·X = SwX − ∑_B w·X ≥ (1 − θ)·SwX ≥ 0. Now apply weighted Cauchy–Schwarz to the head: (∑_A w·X)² ≤ (∑_A w)(∑_A w·X²) ≤ (∑_A w)·SwX2. Squaring the linear head bound and chaining gives (1 − θ)²·SwX² ≤ (∑_A w)·SwX2 — the cleared inequality — and dividing by the positive Sw·SwX2 yields the probability form.",
+    "proofStrategy": "All over ℚ with Finset sums; no measure theory, no real analysis, no square roots.\n\n1. **Hypothesis-free weighted Cauchy–Schwarz (wcs_raw).** Reuse the parent's tilted sum of squares ∑ w·(Sw·X − SwX)² ≥ 0 = Sw·(Sw·SwX2 − SwX²), but split on whether the total weight is zero: if Sw = 0 then (nonnegativity of w) every weight vanishes so both sides are 0; if Sw > 0, nlinarith clears the factor. Removing the positivity side condition is essential — it lets Cauchy–Schwarz apply to the head sub-sum, whose total weight is unknown.\n\n2. **Complement bound.** For the tail set B = {i : ¬(θ·SwX < Sw·X i)} = {X ≤ θμ}, each point gives Sw·X i ≤ θ·SwX; multiplying by w i ≥ 0, summing, bounding ∑_B w ≤ Sw, and cancelling Sw > 0 gives ∑_B w·X ≤ θ·SwX.\n\n3. **Head lower bound.** Finset.sum_filter_add_sum_filter_not splits SwX = ∑_A w·X + ∑_B w·X, so ∑_A w·X ≥ SwX − θ·SwX = (1 − θ)·SwX, which is ≥ 0 since θ ≤ 1 and SwX ≥ 0.\n\n4. **Cauchy–Schwarz on the head (weighted_paley_zygmund_key).** Square the head bound (pow_le_pow_left₀, both sides nonnegative), apply wcs_raw to A, and extend the head second moment up to the full ∑_s w·X² (nonnegative terms). Chaining: (1 − θ)²·SwX² ≤ (∑_A w·X)² ≤ (∑_A w)·SwX2.\n\n5. **Probability form (weighted_paley_zygmund).** Rewrite the μ²/E_w[X²] ratio as (1 − θ)²·SwX²/(Sw·SwX2), clear the positive denominators (div_le_div_iff₀), and finish with nlinarith on the cleared key inequality.\n\n6. **Uniform specialization (paley_zygmund_uniform).** Instantiate the key lemma at w ≡ 1; ∑ 1 = #s (Finset.sum_const), giving (1 − θ)²·(∑ X)² ≤ #{i : θ·∑X < #s·X i}·(∑ X²)."
+    ,
+    "keyInsights": [
+      "**Anti-concentration is Cauchy–Schwarz in reverse.** Chebyshev uses the second moment to bound the upper tail; Paley–Zygmund uses the same second moment — via Cauchy–Schwarz on the head event — to force a fat lower tail. Both tails of the second-moment method come from one inequality, applied to different sets.",
+      "**Dropping the positivity hypothesis is the enabling move.** The parent's weighted Cauchy–Schwarz required 0 < ∑ w. Paley–Zygmund applies Cauchy–Schwarz to the head set A, whose total weight can be anything, so the side condition must be removed. wcs_raw does this by casing on the zero-total-weight degenerate case (where every weight is 0).",
+      "**A linear head bound squared becomes the quadratic bound.** The crux is that the head carries at least (1 − θ)·(∑ w·X) of the weighted first moment; squaring this (legitimate because both sides are nonnegative for θ ≤ 1) is exactly what pairs with Cauchy–Schwarz's (∑_A w·X)² to produce the μ²/E_w[X²] ratio.",
+      "**Division-free thresholds.** Writing the event {X > θ·μ} as θ·(∑ w·X) < (∑ w)·X keeps the defining predicate polynomial in the data, so the filter is decidable over ℚ and the whole cleared argument avoids division until the final probability form.",
+      "**Conservative over the uniform case.** At w ≡ 1 the statement is the textbook Paley–Zygmund bound with the head fraction counted by cardinality, so the weighted development strictly contains the classical one."
+    ],
+    "prerequisites": [
+      "The weighted second-moment method: weighted Cauchy–Schwarz and Chebyshev (parent entry prob-method-second-moment-oq-04-oq-03)",
+      "The Paley–Zygmund inequality and second-moment anti-concentration",
+      "Finset sums and BigOperators algebra (sum_nonneg, sum_filter_add_sum_filter_not, sum_le_sum_of_subset_of_nonneg)",
+      "Weighted averages and the idea of a nonnegative weight as a discrete measure"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring",
+      "startLine": 1,
+      "endLine": 55,
+      "mathContext": "$P_w(X > \\theta\\mu) \\ge (1-\\theta)^2 \\dfrac{\\mu^2}{\\mathbb{E}_w[X^2]}$",
+      "summary": "Module docstring framing the file as the lower-tail (Paley–Zygmund) companion to the parent's weighted Chebyshev bound: Chebyshev says the tail is thin, Paley–Zygmund says the head is fat, both from the same weighted Cauchy–Schwarz engine, all over ℚ with no measure theory."
+    },
+    {
+      "id": "wcs-raw",
+      "title": "Hypothesis-Free Weighted Cauchy–Schwarz",
+      "startLine": 67,
+      "endLine": 104,
+      "mathContext": "$\\Big(\\sum w_i X_i\\Big)^2 \\le \\Big(\\sum w_i\\Big)\\Big(\\sum w_i X_i^2\\Big)$",
+      "summary": "wcs_raw proves weighted Cauchy–Schwarz with the parent's positive-total-weight side condition removed, casing on the degenerate zero-total-weight case so it applies to the head sub-sum in Paley–Zygmund."
+    },
+    {
+      "id": "pz-key",
+      "title": "Weighted Paley–Zygmund, Cleared Form",
+      "startLine": 106,
+      "endLine": 174,
+      "mathContext": "$(1-\\theta)^2\\Big(\\sum w_i X_i\\Big)^2 \\le \\Big(\\sum_{X>\\theta\\mu} w_i\\Big)\\Big(\\sum w_i X_i^2\\Big)$",
+      "summary": "weighted_paley_zygmund_key: the complement {X ≤ θμ} carries at most θ·(∑ w·X), so the head carries at least (1−θ)·(∑ w·X); squaring and applying wcs_raw to the head gives the cleared quadratic bound."
+    },
+    {
+      "id": "pz-defs",
+      "title": "Weighted Mean and Lower-Tail Fraction",
+      "startLine": 176,
+      "endLine": 193,
+      "mathContext": "$\\mu_w = \\dfrac{\\sum w_i X_i}{\\sum w_i}, \\quad P_w(X>\\theta\\mu_w)$",
+      "summary": "wmean and wHeadProb: the weighted mean and the weighted lower-tail fraction P_w(X > θ·μ), defined as ratios of Finset sums with a division-free defining predicate."
+    },
+    {
+      "id": "pz-prob-and-uniform",
+      "title": "Probability Form and Uniform Specialization",
+      "startLine": 195,
+      "endLine": 242,
+      "mathContext": "$(1-\\theta)^2(\\textstyle\\sum X)^2 \\le \\#\\{i: \\theta\\sum X < \\#s\\,X_i\\}\\,(\\textstyle\\sum X^2)$",
+      "summary": "weighted_paley_zygmund clears the positive denominators to give P_w(X > θμ) ≥ (1−θ)²·μ²/E_w[X²]; paley_zygmund_uniform is the w ≡ 1 specialization recovering the classical counting-measure Paley–Zygmund bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Paley–Zygmund lower-tail inequality of the second-moment method, generalized from the uniform counting measure to arbitrary nonnegative weights over ℚ: for nonnegative X and 0 ≤ θ ≤ 1, P_w(X > θ·μ) ≥ (1 − θ)²·μ²/E_w[X²]. Proved division-free by reusing the parent's tilted-square Cauchy–Schwarz in hypothesis-free form (wcs_raw) plus a linear head-weight lower bound. Zero sorries, zero axioms. The w ≡ 1 specialization recovers the classical statement, so the generalization is conservative.",
+    "implications": "Together with the parent's weighted Chebyshev bound this completes both tails of the weighted second-moment method: Chebyshev controls how much weight lies far from the mean, Paley–Zygmund guarantees a constant fraction of weight near the mean. This is the standard toolkit for anti-concentration arguments in the probabilistic method (positivity-with-constant-probability, thresholds in random structures), now available for non-uniform finite distributions in a measure-theory-free, computation-friendly Finset form. The hypothesis-free weighted Cauchy–Schwarz (wcs_raw) is itself a reusable primitive.",
+    "openQuestions": [
+      "State the sharp form of Paley–Zygmund via the second-moment/first-moment ratio, and compare it with the Cantelli refinement from the OQ-04 line to see which is tighter in the weighted setting.",
+      "Instantiate the weighted Paley–Zygmund bound on a concrete non-uniform application (e.g. a weighted subgraph or independent-set count) to prove a positivity-with-constant-probability statement end to end.",
+      "Combine weighted Chebyshev (upper tail) and weighted Paley–Zygmund (lower tail) into a two-sided concentration-plus-anti-concentration statement for a weighted count."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment-oq-04-oq-03",
+      "relationship": "extends",
+      "description": "Proves the weighted Paley–Zygmund lower-tail bound listed among the parent's open questions, reusing its tilted-square Cauchy–Schwarz engine in a hypothesis-free form and complementing its weighted Chebyshev upper-tail bound."
+    },
+    {
+      "targetId": "prob-method-second-moment-oq-04",
+      "relationship": "extends",
+      "description": "Supplies the lower-tail (anti-concentration) counterpart to OQ-04's Cantelli one-sided Chebyshev bound, generalized to arbitrary nonnegative weights."
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "extends",
+      "description": "Adds the Paley–Zygmund anti-concentration tool to the probabilistic-method / second-moment line of work in weighted, measure-theory-free form."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "ProbMethod.SecondMoment.Weighted",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 4
+  },
+  "references": [
+    {
+      "authors": "Paley, Raymond E. A. C.; Zygmund, Antoni",
+      "title": "On some series of functions",
+      "year": "1932",
+      "venue": "Proc. Cambridge Philos. Soc. 28",
+      "note": "Origin of the Paley–Zygmund inequality, in the study of random trigonometric series."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 4 develops the second-moment method; the Paley–Zygmund inequality is the standard anti-concentration tool generalized here to weighted sums."
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Weighted and sum-of-squares proofs of Cauchy–Schwarz of the type reused here in hypothesis-free form (wcs_raw)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "weighted_paley_zygmund",
+      "type": "core",
+      "description": "Weighted Paley–Zygmund inequality (probability form): for nonnegative X, nonnegative weight w with positive total weight, positive weighted second moment, and 0 ≤ θ ≤ 1, P_w(X > θ·μ) ≥ (1 − θ)²·μ²/E_w[X²] with μ the weighted mean. The lower-tail companion to the parent's weighted Chebyshev bound.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → (∀ i ∈ s, 0 ≤ X i) → 0 < ∑ i ∈ s, w i → 0 < ∑ i ∈ s, w i * X i ^ 2 → 0 ≤ θ → θ ≤ 1 → (1 - θ) ^ 2 * wmean s w X ^ 2 / ((∑ i ∈ s, w i * X i ^ 2) / (∑ i ∈ s, w i)) ≤ wHeadProb s w X θ"
+    },
+    {
+      "name": "weighted_paley_zygmund_key",
+      "type": "core",
+      "description": "The division-free heart: (1 − θ)²·(∑ w·X)² ≤ (∑_{X>θμ} w)·(∑ w·X²), with the threshold event written division-free as θ·(∑ w·X) < (∑ w)·X. The head weight carries at least (1 − θ)·(∑ w·X) and weighted Cauchy–Schwarz converts that to the quadratic bound.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → (∀ i ∈ s, 0 ≤ X i) → 0 < ∑ i ∈ s, w i → 0 ≤ θ → θ ≤ 1 → (1 - θ) ^ 2 * (∑ i ∈ s, w i * X i) ^ 2 ≤ (∑ i ∈ s.filter (fun i => θ * (∑ j ∈ s, w j * X j) < (∑ j ∈ s, w j) * X i), w i) * (∑ i ∈ s, w i * X i ^ 2)"
+    },
+    {
+      "name": "wcs_raw",
+      "type": "supporting",
+      "description": "Weighted discrete Cauchy–Schwarz with no positivity side condition: (∑ w·X)² ≤ (∑ w)(∑ w·X²) for nonnegative w. Dropping the parent's 0 < ∑ w hypothesis (both sides vanish when the total weight is 0) lets Cauchy–Schwarz apply to the tail sub-sum in Paley–Zygmund.",
+      "leanType": "(∀ i ∈ s, 0 ≤ w i) → (∑ i ∈ s, w i * X i) ^ 2 ≤ (∑ i ∈ s, w i) * (∑ i ∈ s, w i * X i ^ 2)"
+    },
+    {
+      "name": "paley_zygmund_uniform",
+      "type": "supporting",
+      "description": "The w ≡ 1 specialization: (1 − θ)²·(∑ X)² ≤ #{i ∈ s : θ·∑X < #s·X i}·(∑ X²), recovering the classical counting-measure Paley–Zygmund lower-tail bound.",
+      "leanType": "(∀ i ∈ s, 0 ≤ X i) → s.Nonempty → 0 ≤ θ → θ ≤ 1 → (1 - θ) ^ 2 * (∑ i ∈ s, X i) ^ 2 ≤ ((s.filter (fun i => θ * (∑ j ∈ s, X j) < (s.card : ℚ) * X i)).card : ℚ) * (∑ i ∈ s, X i ^ 2)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry: the **weighted Paley–Zygmund inequality**, the lower-tail (anti-concentration) companion to the parent's weighted Chebyshev bound in the second-moment method.

For a nonnegative weight `w`, nonnegative `X`, and `0 ≤ θ ≤ 1`, over a `Finset` and entirely over ℚ:

> **P_w(X > θ·μ) ≥ (1 − θ)² · μ² / E_w[X²]**   (μ = weighted mean)

This directly realizes an open question **stated in the parent entry** (`prob-method-second-moment-oq-04-oq-03`, #33694), which listed "a weighted Paley–Zygmund lower-tail bound" among its follow-ups. Together with the parent's weighted Chebyshev bound it completes **both tails** of the weighted second-moment method.

## Contents

`proofs/Proofs/ProbMethodSecondMomentOQ04OQ03OQ01.lean` — 4 theorems, 2 defs, 243 lines, no MeasureTheory / real analysis / square roots:

- **`wcs_raw`** — weighted Cauchy–Schwarz with the parent's `0 < ∑ w` side condition *removed* (both sides vanish at zero total weight). This is the enabling move: it lets Cauchy–Schwarz apply to the head event, whose total weight is unknown a priori.
- **`weighted_paley_zygmund_key`** — division-free cleared form `(1−θ)²·(∑ w·X)² ≤ (∑_{X>θμ} w)·(∑ w·X²)`. The head weight carries ≥ `(1−θ)·∑ w·X`; squaring and feeding through `wcs_raw` gives the quadratic bound. The threshold event is written `θ·(∑ w·X) < (∑ w)·X` to keep the predicate division-free.
- **`weighted_paley_zygmund`** — the probability form.
- **`paley_zygmund_uniform`** — `w ≡ 1` specialization recovering the classical counting-measure Paley–Zygmund bound (conservative generalization).

Plus gallery data (`meta.json`, `annotations.json`, `index.ts`) modeled on the parent entry.

## Verification

- `lake env lean` against Mathlib 4.26.0: **compiles clean, 0 sorries**.
- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status `verified`, badge `original`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)