### PR TITLE
Enrich Lovász Local Lemma OQ-01 Euler Threshold: add sections array (0→7)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
@@ -106,6 +106,57 @@
       "Monotonicity of powers pow_le_pow_left₀ and the ordered-field division lemmas div_le_iff₀, div_le_div_iff₀, le_div_iff₀"
     ]
   },
+  "sections": [
+    {
+      "id": "docstring-motivation",
+      "title": "Motivation: two forms of the symmetric LLL hypothesis",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring. Contrasts the tight symmetric threshold T(d) = lllThreshold d = dᵈ/(d+1)^{d+1} (the exact maximum of x(1−x)ᵈ, formalized over ℚ by the parent proof) with the memorable Euler condition e·p·(d+1) ≤ 1 used by the OQ-01 measure-theoretic front. States the goal — the standard textbook bridge e·p·(d+1) ≤ 1 ⟹ p ≤ T(d) — and previews the four main lemmas, flagging that this is elementary real analysis rather than progress on the hard measure-theoretic induction."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 37,
+      "endLine": 42,
+      "summary": "Imports the parent gallery proof Proofs.LovaszLocalLemma (source of lllThreshold and symmetric_lll), opens the Real and ProbMethod.LovaszLocal namespaces, and enters the LovaszLocalLemmaOQ01EulerThreshold namespace."
+    },
+    {
+      "id": "euler-bound",
+      "title": "The classic Euler bound (1 + 1/d)ᵈ ≤ e",
+      "startLine": 43,
+      "endLine": 58,
+      "summary": "one_add_inv_pow_le_exp_one. Instantiates Real.add_one_le_exp (1 + x ≤ exp x) at x = 1/d to get 1 + 1/d ≤ exp(1/d), raises both nonnegative sides to the d-th power via pow_le_pow_left₀, and simplifies exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 with Real.exp_nat_mul and d·(1/d) = 1 (d ≠ 0). This single inequality is what puts the constant e into the LLL."
+    },
+    {
+      "id": "multiplicative-form",
+      "title": "Multiplicative form (d+1)ᵈ ≤ e·dᵈ",
+      "startLine": 60,
+      "endLine": 67,
+      "summary": "succ_pow_le_exp_mul. Rewrites 1 + 1/d = (d+1)/d, then div_pow and div_le_iff₀ clear the denominator, turning the Euler bound (1+1/d)ᵈ ≤ e into (d+1)ᵈ ≤ e·dᵈ — the form used in the threshold comparison."
+    },
+    {
+      "id": "threshold-cast",
+      "title": "Real-cast of the tight threshold",
+      "startLine": 69,
+      "endLine": 75,
+      "summary": "lllThreshold_cast. Bridges the parent proof's ℚ-valued threshold to ℝ: for d ≥ 1, (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}. Unfolds the d ≠ 0 branch of lllThreshold, then push_cast; ring."
+    },
+    {
+      "id": "budget-below-threshold",
+      "title": "The Euler budget sits below the tight threshold",
+      "startLine": 77,
+      "endLine": 89,
+      "summary": "inv_exp_mul_le_lllThreshold: 1/(e·(d+1)) ≤ T(d). After casting the threshold and applying div_le_div_iff₀ and pow_succ, the goal reduces to (d+1)^{d+1} ≤ e·(d+1)·dᵈ, i.e. the multiplicative Euler bound scaled by the positive factor (d+1); closed by nlinarith from succ_pow_le_exp_mul."
+    },
+    {
+      "id": "the-bridge",
+      "title": "The bridge: Euler condition ⟹ tight threshold",
+      "startLine": 91,
+      "endLine": 106,
+      "summary": "euler_condition_implies_lllThreshold. From e·p·(d+1) ≤ 1, le_div_iff₀ gives p ≤ 1/(e·(d+1)), and le_trans with inv_exp_mul_le_lllThreshold yields p ≤ T(d). No nonnegativity hypothesis on p is needed (p < 0 satisfies both sides trivially since T(d) > 0), so the statement holds in full generality; the namespace closes at line 106."
+    }
+  ],
   "conclusion": {
     "summary": "The memorable Euler symmetric LLL condition e·p·(d+1) ≤ 1 is machine-verified to imply the tight threshold p ≤ T(d) = dᵈ/(d+1)^{d+1} used by the parent gallery proof, via the classic Euler inequality (1 + 1/d)ᵈ ≤ e. Elementary real analysis, fully checked: 0 sorries, 0 axioms.",
     "implications": "**Connects the two threshold fronts of the OQ-01 landscape.** The parent proof lovasz-local-lemma develops the tight symmetric threshold T(d) over ℚ; the OQ-01 measure-theoretic entries (lovasz-local-lemma-oq-01, its union-bound, chain-rule, and quantitative refinements) are stated against the Euler condition e·p·(d+1) ≤ 1. This entry is the verified bridge: it shows the Euler hypothesis is a legitimate, slightly conservative consequence of the tight threshold, so results proved under either hypothesis transfer to the other. It also isolates the exact inequality — (1 + 1/d)ᵈ ≤ e — that puts the constant e into the LLL.\n\n**Honest scope**: this is real-analysis bookkeeping about which hypothesis is stronger, not a proof that either hypothesis suffices for avoidance. The measure-theoretic symmetric LLL — that e·p·(d+1) ≤ 1 forces μ(⋂ Aᵢᶜ) > 0 over a real probability space with a bounded-dependency-degree structure — remains the open research target; see the chain-rule and quantitative entries for the reduction that awaits the per-event conditional bounds.",


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-01-euler-threshold` (quality 88, passes 0).

## Gap addressed
The entry had rich `overview`, `mainTheorems`, 5 detailed annotations, `conclusion`, `crossReferences`, and `references` — but **no `sections` array**. The enricher role requires `sections` covering the full Lean file; this was the one clear structural gap.

## Change
Added a 7-item `sections` array mapping the full 106-line Lean file to meaningful summaries:

1. **docstring-motivation** (1–36) — the two forms of the symmetric LLL hypothesis
2. **imports-namespace** (37–42)
3. **euler-bound** (43–58) — `one_add_inv_pow_le_exp_one`: (1 + 1/d)ᵈ ≤ e
4. **multiplicative-form** (60–67) — `succ_pow_le_exp_mul`: (d+1)ᵈ ≤ e·dᵈ
5. **threshold-cast** (69–75) — `lllThreshold_cast`
6. **budget-below-threshold** (77–89) — `inv_exp_mul_le_lllThreshold`
7. **the-bridge** (91–106) — `euler_condition_implies_lllThreshold`

Line ranges verified against the source; each summary names the lemma and the tactics used.

## Guardrails
- Only `meta.json` changed (+51 lines). No existing content deleted or altered.
- File is **20.6 KB**, well under the ~60 KB cap.
- `status`/`badge`/`axiomCount` unchanged and accurate (verified, 0 sorries, 0 axioms — confirmed against the Lean source).
- Validated via `scripts/annotations/build.ts`: no warnings/errors for this entry, entry present in generated `listings.json`.