### PR TITLE
Research: schroeder-bernstein-oq-03 — pair-level edge preservation for both stage moves

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1469,7 +1469,8 @@ theorem augment_domain_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
     {L : List (ℕ × ℕ)} (hL : IsMatching L) (hC : MatchingCorr p q L) (hB : BuiltFrom f g L)
     {a : ℕ} (ha : a ∉ mDom L) :
     ∃ L', IsMatching L' ∧ MatchingCorr p q L' ∧ BuiltFrom f g L' ∧
-      a ∈ mDom L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') := by
+      a ∈ mDom L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') ∧
+      (∀ ab ∈ L, ab.2 = f ab.1 → ab ∈ L') := by
   -- Elementwise membership descriptions of `mDom`/`mRan` and their append behaviour.
   have mem_mDom : ∀ (l : List (ℕ × ℕ)) (x : ℕ), x ∈ mDom l ↔ ∃ ab, ab ∈ l ∧ ab.1 = x := by
     intro l x; simp only [mDom, List.mem_map]
@@ -1521,7 +1522,7 @@ theorem augment_domain_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
   have hRanKeptNodup : (mRan keptL).Nodup := by
     have hs : List.Sublist (mRan keptL) (mRan L) := hkeptSub.map Prod.snd
     exact hL.2.sublist hs
-  refine ⟨augPath f g a N ++ keptL, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨augPath f g a N ++ keptL, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · -- IsMatching
     refine ⟨?_, ?_⟩
     · -- domain side
@@ -1600,6 +1601,33 @@ theorem augment_domain_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
         exact (hRanA (f (fwdOrbit f g a (k - 1)))).mpr ⟨k - 1, by omega, rfl⟩
     · right
       exact (mem_mRan keptL y).mpr ⟨(u, w), (hmemKept (u, w)).mpr ⟨habL, hu⟩, hwy⟩
+  · -- f-edge preservation: an existing `f`-edge `(x, f x)` of `L` survives the splice.
+    -- Only stale `g`-edges on the orbit prefix `{o₁,…,o_N}` are removed (`keptL` filter),
+    -- and an `f`-edge domain point cannot lie on that prefix without forcing an orbit
+    -- repeat: if `x = oₖ` then the stale `g`-edge `(oₖ, f o_{k-1}) ∈ L` and functionality
+    -- give `f x = f o_{k-1}`, so `f oₖ = f o_{k-1}`, hence (`f` injective) `oₖ = o_{k-1}`,
+    -- contradicting prefix distinctness. So `x ∉ mDom (augPath …)` and `(x, f x) ∈ keptL`.
+    rintro ⟨x, y⟩ hxyL hyfx
+    have hxdom : x ∈ mDom L := (mem_mDom L x).mpr ⟨(x, y), hxyL, rfl⟩
+    rw [List.mem_append]
+    right
+    refine (hmemKept (x, y)).mpr ⟨hxyL, ?_⟩
+    intro hxA
+    obtain ⟨k, hkN, hxk⟩ := (hDomA x).mp hxA
+    rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+    · -- k = 0 ⇒ x = a, contradicting freshness `a ∉ mDom L`.
+      rw [hk0] at hxk
+      have hxa : x = a := hxk
+      exact ha (hxa ▸ hxdom)
+    · -- k ≥ 1 ⇒ orbit repeat, impossible.
+      have hgedge := hgedges k hkpos hkN
+      have hval : (fwdOrbit f g a k, y) ∈ L := hxk ▸ hxyL
+      have hyeq : y = f (fwdOrbit f g a (k - 1)) := matching_functional hL hval hgedge
+      have hyfok : y = f (fwdOrbit f g a k) := by rw [← hxk]; exact hyfx
+      have hokk : fwdOrbit f g a k = fwdOrbit f g a (k - 1) := hf (hyfok ▸ hyeq)
+      have hinj := fwdOrbit_prefix_distinct hf hg (D := fun n => n ∈ mDom L) ha hchase
+      have hkk : k = k - 1 := hinj hkN (by omega) hokk
+      omega
 
 /-!
 ## Section 4l: The dual range step — odd-stage coverage by `Prod.swap` duality
@@ -1635,16 +1663,17 @@ theorem augment_range_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
     {L : List (ℕ × ℕ)} (hL : IsMatching L) (hC : MatchingCorr p q L) (hB : BuiltFrom f g L)
     {c : ℕ} (hc : c ∉ mRan L) :
     ∃ L', IsMatching L' ∧ MatchingCorr p q L' ∧ BuiltFrom f g L' ∧
-      c ∈ mRan L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') := by
+      c ∈ mRan L' ∧ (∀ x ∈ mDom L, x ∈ mDom L') ∧ (∀ y ∈ mRan L, y ∈ mRan L') ∧
+      (∀ ab ∈ L, ab.1 = g ab.2 → ab ∈ L') := by
   -- Move to the swapped problem `(q, p, g, f)` with matching `L.map Prod.swap`; the fresh
   -- range anchor `c` becomes a fresh *domain* anchor there.
   have hc' : c ∉ mDom (L.map Prod.swap) := by rw [mDom_map_swap]; exact hc
-  obtain ⟨M, hMmatch, hMcorr, hMbuilt, hcM, hdomMono, hranMono⟩ :=
+  obtain ⟨M, hMmatch, hMcorr, hMbuilt, hcM, hdomMono, hranMono, hMfedge⟩ :=
     augment_domain_step (p := q) (q := p) (f := g) (g := f) hgpq hg hf
       (isMatching_map_swap hL) (matchingCorr_map_swap hC) (builtFrom_map_swap hB) hc'
   -- Swap the witness back: `L' := M.map Prod.swap`.
   refine ⟨M.map Prod.swap, isMatching_map_swap hMmatch, matchingCorr_map_swap hMcorr,
-    builtFrom_map_swap hMbuilt, ?_, ?_, ?_⟩
+    builtFrom_map_swap hMbuilt, ?_, ?_, ?_, ?_⟩
   · -- `c ∈ mRan (M.map swap) = mDom M`
     rw [mRan_map_swap]; exact hcM
   · -- domain monotone: `mDom L ⊆ mDom (M.map swap) = mRan M`
@@ -1655,6 +1684,15 @@ theorem augment_range_step {p q : ℕ → Prop} {f g : ℕ → ℕ}
     intro y hy
     rw [mRan_map_swap]
     exact hdomMono y (by rw [mDom_map_swap]; exact hy)
+  · -- g-edge preservation, dual to the domain step's f-edge preservation. A `g`-edge
+    -- `(u, w)` of `L` (`u = g w`) becomes an `f`-edge `(w, u)` of the swapped matching
+    -- (`(w,u).2 = u = g (w,u).1`), which `augment_domain_step` preserves into `M`; swapping
+    -- back returns `(u, w) ∈ M.map Prod.swap`.
+    rintro ⟨u, w⟩ huwL hguw
+    have hswapMem : (w, u) ∈ L.map Prod.swap := List.mem_map.mpr ⟨(u, w), huwL, rfl⟩
+    have hcond : (w, u).2 = g ((w, u).1) := hguw
+    have hMmem : (w, u) ∈ M := hMfedge (w, u) hswapMem hcond
+    exact List.mem_map.mpr ⟨(w, u), hMmem, rfl⟩
 
 /-!
 ## Section 5: The Myhill Isomorphism Theorem

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -523,3 +523,50 @@ remaining work.
   reducible); use `exact`-at-defeq (`rw [hk0] at hk; exact hk`) or an explicit `rfl` tactic.
 - Destructure list pairs to `⟨u,w⟩` and capture clean equalities (`have hwy : w = y := hab2`)
   so later `rw` sees `w`, not the stuck projection `(u,w).2`.
+
+## Session 2026-07-03 (researcher-14): edge preservation (pairs) — Section 4k f-edge / 4l g-edge [VERIFIED 0-axiom]
+
+Strengthened both stage moves to expose **pair-level edge preservation**, the ingredient the
+limit read-off actually needs (see the sharpened obstruction below). Host `lake env lean`
+v4.26.0, EXIT 0; `#print axioms augment_domain_step` = `#print axioms augment_range_step` =
+`[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`. File 1773→1811
+lines, 75→84 theoremCount (meta leanFile synced). Main `myhill_isomorphism` → sorry UNCHANGED.
+
+- `augment_domain_step` (Section 4k): added conjunct `(∀ ab ∈ L, ab.2 = f ab.1 → ab ∈ L')`.
+  I.e. the even-stage splice **preserves every existing `f`-edge as an actual pair**, not just
+  its domain/range membership. Proof: `keptL` drops only pairs whose domain lies on the orbit
+  prefix `mDom (augPath) = {o₀,…,o_N}`; an `f`-edge `(x, f x)` with `x = oₖ` forces (via the
+  stale `g`-edge `(oₖ, f o_{k-1}) ∈ L` + `matching_functional`) `f oₖ = f o_{k-1}`, hence
+  (`f` inj) `oₖ = o_{k-1}`, contradicting `fwdOrbit_prefix_distinct`; `k=0` gives `x = a ∈ mDom L`
+  against freshness. So `x ∉ mDom (augPath)`, thus `(x, f x) ∈ keptL ⊆ L'`.
+- `augment_range_step` (Section 4l): dual conjunct `(∀ ab ∈ L, ab.1 = g ab.2 → ab ∈ L')` — the
+  odd-stage move **preserves every existing `g`-edge**. Free from the `Prod.swap` duality: a
+  `g`-edge `(u,w)` (`u = g w`) is a swapped-world `f`-edge `(w,u)`, preserved by
+  `augment_domain_step` in the swapped problem, then swapped back (`List.mem_map.mpr ⟨·,·,rfl⟩`).
+
+**SHARPENED OBSTRUCTION (correcting prior "Next Steps").** Prior sessions' plan — "read off the
+limit `σ n` via `mLookup` at any stage past the one where `n` enters `mDom`" — tacitly assumes
+`mLookup` is *stable* along the chain. But `mLookup_stable` (Section 4f-bis) requires
+`∀ x ∈ L₁, x ∈ L₂` (**every pair preserved**), and the rerouting augment step *violates this*: a
+domain step **removes** the stale `g`-edges `(oₖ, f o_{k-1})` and re-adds `f`-edges `(oₖ, f oₖ)`,
+so the partner of a domain point genuinely *changes* between stages. Hence the read-off value is
+**not** monotone/eventually-constant for free. The real remaining crux is a **finite-injury
+stabilization** argument (recursion-theoretic): each point is rerouted only finitely often
+(a domain point survives as an `f`-edge across all *domain* steps — this session's
+`augment_domain_step` f-edge conjunct — but can be flipped to a `g`-edge by a *range* step, and
+vice versa), so `mLookup (stage s) n` stabilizes as `s → ∞`. Bounding the number of flips per
+point (priority/injury count) is the genuine open work; `mLookup_stable` as stated is *too weak*
+to close the limit and should not be cited as if the read-off were mechanical.
+
+### Next Steps (revised — supersedes the earlier "read off via mLookup" step)
+1. **Do NOT** assume monotone pair-preservation across a full stage. State and prove a
+   *stabilization* lemma: for each `n`, `∃ S, ∀ s ≥ S, mLookup (stage s) n = mLookup (stage S) n`.
+   The edge-preservation conjuncts added this session are the base: an `f`-edge at `n` is immune
+   to all future *domain* steps; only *range* steps can disturb it (and dually). Bound the
+   disturbances (finite injury) to get stabilization.
+2. Alternatively, investigate an **extension-only reformulation** of the scheduler (pairs never
+   removed) so `mLookup_stable` applies directly — this trades the rerouting splice for a
+   cleverer anchor choice (classical Rogers §7.4 back-and-forth extends without revising). If
+   feasible this sidesteps finite injury entirely and is likely the shorter path to closing.
+3. Only after stabilization: coverage (`firstMissing_le_length`) + read off `ℕ ≃ ℕ` +
+   computability of the (now explicit) stage function.

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -250,10 +250,10 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 1435,
+    "lineCount": 1811,
     "axiomCount": 0,
-    "theoremCount": 75,
-    "definitionCount": 15,
+    "theoremCount": 84,
+    "definitionCount": 16,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [

--- a/src/data/research/problems/schroeder-bernstein-oq-03.json
+++ b/src/data/research/problems/schroeder-bernstein-oq-03.json
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: augment_domain_step (Section 4k) is the augmenting-path SPLICE that r4 named as the remaining list-surgery, now DONE and VERIFIED (0-axiom): the even-stage domain move is total, BuiltFrom-preserving, and iterable (monotone both sides, covers the fresh anchor). Every atomic per-stage obligation of the Myhill scheduler is now proved; only the outer stage recursion + computable read-off remain. Main myhill_isomorphism still sorry (open).",
+    "progressSummary": "PROGRESS: both stage moves now expose pair-level edge preservation (VERIFIED 0-ax). Sharpened the remaining crux from vague \"read off via mLookup\" to a concrete finite-injury stabilization obligation (mLookup_stable is too weak because the rerouting splice does not preserve pairs). Main myhill_isomorphism sorry UNCHANGED.",
     "builtItems": [
       "partialInverse_unique in Proofs/SchroederBernsteinOQ03.lean (single-valued partial inverse)",
       "fwdOrbit_eq_iterate in Proofs/SchroederBernsteinOQ03.lean (orbit = Function.iterate of g∘f)",
@@ -60,7 +60,9 @@
       "escape_exists (Section 4i, VERIFIED 0-axiom): ∃ N ≤ (mDom L).length, f(fwdOrbit f g a N) ∉ mRan L — the bounded termination certificate for the even-stage collision chase.",
       "domain_step_exists (Section 4i, VERIFIED 0-axiom): the even-stage domain step is TOTAL — any fresh a can be placed as (a, chaseTarget f g a N) preserving IsMatching and MatchingCorr (does NOT preserve BuiltFrom; see next steps).",
       "augPath + mem_augPath_iff/mDom_augPath/mRan_augPath + augPath_builtFrom + augPath_matchingCorr + augPath_isMatching + augPath_isMatching_of_chase in SchroederBernsteinOQ03.lean Section 4j (8 decls, all VERIFIED 0-axiom)",
-      "augment_domain_step (SchroederBernsteinOQ03.lean:1466): BuiltFrom-preserving TOTAL even-stage domain step. Fresh anchor a not in mDom L implies exists Lprime with IsMatching, MatchingCorr, BuiltFrom, a in mDom Lprime, and mDom/mRan monotone. VERIFIED, axioms = {propext, Classical.choice, Quot.sound}."
+      "augment_domain_step (SchroederBernsteinOQ03.lean:1466): BuiltFrom-preserving TOTAL even-stage domain step. Fresh anchor a not in mDom L implies exists Lprime with IsMatching, MatchingCorr, BuiltFrom, a in mDom Lprime, and mDom/mRan monotone. VERIFIED, axioms = {propext, Classical.choice, Quot.sound}.",
+      "augment_domain_step f-edge preservation conjunct (Section 4k), SchroederBernsteinOQ03.lean",
+      "augment_range_step g-edge preservation conjunct (Section 4l), SchroederBernsteinOQ03.lean"
     ],
     "insights": [
       "Mathlib has OneOneReducible/OneOneEquiv/ManyOneEquiv (Computability.Reduce) but NOT Myhill's isomorphism theorem — genuine gap.",
@@ -80,7 +82,9 @@
       "augPath f g a N (the augmenting path: f-edges (oₖ, f oₖ) for k=0..N, oₖ=fwdOrbit f g a k) is the object that RESTORES BuiltFrom after a collision chase — domain_step_exists preserves IsMatching+MatchingCorr but its single anchor pair (a, f(oₙ)) is neither an f-edge nor g-edge for N>0. Re-labelling the whole chased chain into f-edges fixes this. VERIFIED 0-axiom (propext/Classical.choice/Quot.sound only).",
       "Only the f-reduction (p n iff q (f n)) is needed for the even-stage augmenting-path move; hgpq is unnecessary because every augmenting edge (o_k, f o_k) is an f-edge, so MatchingCorr of the block follows from hfpq alone (augment_domain_step, Section 4k).",
       "The augmenting-path splice is TOTAL and preserves ALL THREE invariants plus two-sided monotonicity: mDom L subset mDom Lprime, mRan L subset mRan Lprime. Monotonicity holds because every removed g-edge endpoint (domains o_1..o_N, ranges f o_0..f o_(N-1)) is re-added by augPath ({o_0..o_N} on the domain, {f o_0..f o_N} on the range).",
-      "Range-disjointness of the spliced matching is the delicate part: for aug index k<N, f o_k is the unique range value of the removed g-edge (o_(k+1), f o_k) by matching_cofunctional, so no kept pair can carry it; for k=N it is the escape point f o_N not in mRan L (escape_exists)."
+      "Range-disjointness of the spliced matching is the delicate part: for aug index k<N, f o_k is the unique range value of the removed g-edge (o_(k+1), f o_k) by matching_cofunctional, so no kept pair can carry it; for k=N it is the escape point f o_N not in mRan L (escape_exists).",
+      "r14 (07-03): strengthened augment_domain_step / augment_range_step with pair-level edge preservation (f-edges survive domain steps; g-edges survive range steps), VERIFIED 0-axiom [propext,Classical.choice,Quot.sound].",
+      "SHARPENED OBSTRUCTION: the limit read-off is NOT mechanical. mLookup_stable needs full pair-preservation, but the rerouting augment step removes stale g-edges and re-adds f-edges, so a domain point partner CHANGES across stages. Real crux = finite-injury stabilization (each point rerouted finitely often), or an extension-only reformulation of the scheduler."
     ],
     "mathlibGaps": [
       "Mathlib lacks Myhill isomorphism theorem (OneOneEquiv → computable permutation)."
@@ -88,7 +92,9 @@
     "nextSteps": [
       "Derive the range-stage dual augment_range_step from augment_domain_step via the Section 4e swap duality (isMatching_map_swap / matchingCorr_map_swap / builtFrom_map_swap).",
       "Define the alternating stage recursion sigma : Nat -> List(NatxNat) anchoring at firstMissing (mDom sigma_s) / firstMissing (mRan sigma_s); prove coverage (k in mDom by stage 2k+1) from monotonicity + firstMissing progress.",
-      "Read off e : Nat equiv Nat via mLookup, prove Computable, and discharge myhill_isomorphism."
+      "Read off e : Nat equiv Nat via mLookup, prove Computable, and discharge myhill_isomorphism.",
+      "Prove a stabilization lemma: for each n, mLookup(stage s) n is eventually constant (finite injury), using the new edge-preservation base.",
+      "Investigate extension-only scheduler reformulation so mLookup_stable applies directly (likely shorter path)."
     ],
     "markdown": "# Knowledge Base: schroeder-bernstein-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary
Research session for **schroeder-bernstein-oq-03** (Myhill Isomorphism Theorem). Strengthens both back-and-forth stage moves in `SchroederBernsteinOQ03.lean` to expose **pair-level edge preservation**, and sharpens the remaining open crux.

## Progress (VERIFIED, 0-axiom)
- **`augment_domain_step` (Section 4k)** — new conjunct `(∀ ab ∈ L, ab.2 = f ab.1 → ab ∈ L')`: the even-stage splice preserves every existing **f-edge as an actual pair**, not merely its domain/range membership. Proof: `keptL` removes only pairs whose domain lies on the orbit prefix; an f-edge there forces `f oₖ = f o_{k-1}` (via the stale g-edge + `matching_functional`), hence `oₖ = o_{k-1}` (f injective), contradicting `fwdOrbit_prefix_distinct`.
- **`augment_range_step` (Section 4l)** — dual conjunct `(∀ ab ∈ L, ab.1 = g ab.2 → ab ∈ L')` preserving **g-edges**, obtained for free from the `Prod.swap` duality on the strengthened domain step.
- `#print axioms` on both = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`. File 1773→1811 lines, 84 theorems; `meta.json` `leanFile` counts synced.

## Findings
- **Sharpened obstruction.** Prior sessions' plan ("read off `σ n` via `mLookup` at any late stage") tacitly assumes `mLookup` is stable along the chain. But `mLookup_stable` requires **every pair preserved** (`∀ x ∈ L₁, x ∈ L₂`), which the *rerouting* augment step violates — it deletes stale g-edges and re-adds f-edges, so a domain point's partner genuinely changes between stages. The real remaining crux is a **finite-injury stabilization** argument (each point rerouted only finitely often), for which this PR's edge-preservation conjuncts are the base case; or an **extension-only reformulation** of the scheduler so `mLookup_stable` applies directly.

## Status
**Outcome**: progress (supporting infrastructure + obstruction sharpened). The main `myhill_isomorphism` → direction `sorry` remains **OPEN** (unchanged).
**Next Steps**: prove per-point stabilization of the stage read-off (finite injury), or reformulate the scheduler to only extend; then coverage + computable read-off.

🤖 Generated by researcher-14