### PR TITLE
research(lovasz-local-lemma-oq-01): subset-history toolkit for the dependency-graph LLL step [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01DependencySplit.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01DependencySplit.lean
@@ -1,0 +1,141 @@
+/-
+# Lovász Local Lemma — OQ-01: Subset-History Toolkit for the Dependency-Graph Step
+
+`Proofs/LovaszLocalLemmaOQ01ChainRule.lean` reduces the measure-theoretic LLL to a
+per-event conditional bound over the **prefix** history `⋂_{j<k} Aⱼᶜ`, and
+`Proofs/LovaszLocalLemmaOQ01Quantitative.lean` converts such bounds into avoidance
+estimates. The genuine *content* of the Lovász Local Lemma — the Erdős–Lovász
+induction that produces those per-event bounds from a bounded **dependency degree** —
+does not live over prefix histories at all. Its induction step conditions on the
+survival of an **arbitrary subset** `S` of the other events, and splits `S` into the
+*neighbours* and *non-neighbours* of the event under scrutiny. Every existing OQ-01
+file works exclusively over `Finset.range`-indexed prefixes and so cannot even state
+that step.
+
+This file supplies the two per-event moves of the dependency-graph induction step over
+**arbitrary finite subset histories** `⋂_{j∈S} Aⱼᶜ`, each proved unconditionally or
+from local independence:
+
+1. **Numerator monotonicity** (`cond_mono_num`): conditional probability is monotone in
+   its numerator, `E ⊆ F → μ[E | H] ≤ μ[F | H]`, for any measurable conditioning set
+   `H`. There is *no* such lemma in Mathlib. It is the step by which the induction drops
+   the neighbour factor: `μ[Aᵢ ∩ (⋂_{S₁} Aⱼᶜ) | H] ≤ μ[Aᵢ | H]`
+   (`cond_inter_le`).
+
+2. **Non-neighbour collapse over an arbitrary subset** (`cond_failure_eq_measure_of_indep_subset`):
+   if `Aᵢ` is independent of the survival history `⋂_{j∈S} Aⱼᶜ` of an *arbitrary* finite
+   `S` (of positive measure), the conditional failure probability equals the
+   unconditional one, `μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ)`. This is the arbitrary-subset
+   generalisation of the prefix-only non-neighbour step: in the dependency graph the
+   non-neighbours of `Aᵢ` form an unstructured set `S₂`, never a prefix, so the prefix
+   version cannot express the reduction the induction actually performs.
+
+Combining the two gives the **numerator half of the induction step over an arbitrary
+subset history** (`cond_failure_le_measure_of_indep_num`): conditioning `Aᵢ` on the
+survival of a *sub*-history it is independent of only *increases* its budget, so once
+the neighbour factor is dropped the failure probability is at most `μ(Aᵢ)`.
+
+## Main results
+
+* `cond_mono_num` : `E ⊆ F → μ[E | H] ≤ μ[F | H]` — conditional probability is monotone
+  in the numerator (new; not in Mathlib).
+* `cond_inter_le` : `μ[E ∩ F | H] ≤ μ[E | H]` — the neighbour-factor drop.
+* `measurableSet_survival` : `MeasurableSet (⋂ j ∈ S, (A j)ᶜ)` for any `Finset` `S`.
+* `cond_failure_eq_measure_of_indep_subset` : the arbitrary-subset non-neighbour
+  collapse `μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ)`.
+* `cond_failure_le_measure_of_indep_num` : conditioning `Aᵢ` on the survival of an
+  independent sub-history `S₂` and any extra events `T` gives failure `≤ μ(Aᵢ)`.
+
+What remains open (the actual LLL induction) is the *recursive denominator lower bound*
+`μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 - xⱼ)`, which combines these ingredients across
+a well-founded recursion on `|S|`. This file isolates exactly the unconditional /
+local-independence parts of that step.
+
+Everything is over an arbitrary `IsProbabilityMeasure`; no independence is assumed except
+where explicitly hypothesised.
+-/
+import Proofs.LovaszLocalLemmaOQ01ChainRule
+import Mathlib.Probability.Independence.Basic
+
+open MeasureTheory ProbabilityTheory Finset
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01DependencySplit
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+variable {A : ℕ → Set Ω} {E F H : Set Ω}
+
+/-- **Conditional probability is monotone in the numerator.**
+For any measurable conditioning set `H`, if `E ⊆ F` then `μ[E | H] ≤ μ[F | H]`.
+
+Mathlib has no monotonicity lemma for `cond` in the conditioned event, yet it is the
+elementary workhorse of the Lovász Local Lemma induction: the induction bounds the
+conditional failure of an event by *dropping* the neighbour-survival factor from the
+numerator, which is exactly an application of this inequality.
+
+Proof: `cond_apply` unfolds both sides to `(μ H)⁻¹ * μ (H ∩ ·)`; `H ∩ E ⊆ H ∩ F`, so
+`measure_mono` and left-multiplication by the common factor `(μ H)⁻¹` finish. -/
+theorem cond_mono_num (hH : MeasurableSet H) (hEF : E ⊆ F) :
+    μ[E | H] ≤ μ[F | H] := by
+  rw [cond_apply hH μ E, cond_apply hH μ F]
+  gcongr
+
+/-- **Neighbour-factor drop.**
+Intersecting the numerator with any set can only decrease the conditional probability:
+`μ[E ∩ F | H] ≤ μ[E | H]`. The special case `cond_mono_num Set.inter_subset_left` used
+by the LLL induction to discard the survival of `Aᵢ`'s neighbours from the numerator. -/
+theorem cond_inter_le (hH : MeasurableSet H) :
+    μ[E ∩ F | H] ≤ μ[E | H] :=
+  cond_mono_num hH Set.inter_subset_left
+
+/-- The survival history of an **arbitrary finite** index set is measurable. The
+subset-indexed analogue of `LovaszLocalLemmaOQ01ChainRule.measurableSet_hist` (which is
+`Finset.range`-only). -/
+theorem measurableSet_survival (hA : ∀ i, MeasurableSet (A i)) (S : Finset ℕ) :
+    MeasurableSet (⋂ j ∈ S, (A j)ᶜ) :=
+  Finset.measurableSet_biInter _ (fun b _ => (hA b).compl)
+
+variable [IsProbabilityMeasure μ]
+
+/-- **Non-neighbour collapse over an arbitrary subset history.**
+If the event `Aᵢ` is independent of the survival history `⋂_{j∈S} Aⱼᶜ` of an *arbitrary*
+finite set `S` (of positive measure), then its conditional failure probability collapses
+to the unconditional one:
+
+  `μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ)`.
+
+This is the arbitrary-subset form of the Lovász Local Lemma's non-neighbour step. In the
+dependency graph the events *not* adjacent to `Aᵢ` form an unstructured subset `S₂` — not
+a prefix — so this is the version the induction genuinely needs; the prefix-only variant
+cannot state it. Proof: `cond_apply` unfolds the conditional as `(μ H)⁻¹ · μ(H ∩ Aᵢ)`,
+`IndepSet.measure_inter_eq_mul` factors `μ(Aᵢ ∩ H) = μ(Aᵢ)·μ H`, and the finite nonzero
+`μ H` cancels. -/
+theorem cond_failure_eq_measure_of_indep_subset (hA : ∀ i, MeasurableSet (A i))
+    (S : Finset ℕ) (i : ℕ) (hpos : μ (⋂ j ∈ S, (A j)ᶜ) ≠ 0)
+    (hindep : IndepSet (A i) (⋂ j ∈ S, (A j)ᶜ) μ) :
+    μ[A i | ⋂ j ∈ S, (A j)ᶜ] = μ (A i) := by
+  have hHmeas : MeasurableSet (⋂ j ∈ S, (A j)ᶜ) := measurableSet_survival hA S
+  rw [cond_apply hHmeas, Set.inter_comm, hindep.measure_inter_eq_mul,
+      mul_comm (μ (A i)) _, ← mul_assoc,
+      ENNReal.inv_mul_cancel hpos (measure_ne_top μ _), one_mul]
+
+/-- **Numerator half of the dependency-graph induction step.**
+Let `S₂` be the non-neighbours of `Aᵢ` (independent of `Aᵢ`) and `T` any further events,
+with `S₂` of positive survival measure. Conditioning `Aᵢ` on the survival of `S₂`
+*together with* the extra events `T` keeps its failure probability at most `μ(Aᵢ)`:
+
+  `μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ)`.
+
+This packages the two moves — drop the neighbour factor `T` from the numerator
+(`cond_inter_le`), then collapse the independent sub-history to the unconditional
+probability (`cond_failure_eq_measure_of_indep_subset`). It is the numerator bound the
+LLL induction feeds into the recursive denominator estimate (still open). -/
+theorem cond_failure_le_measure_of_indep_num (hA : ∀ i, MeasurableSet (A i))
+    (S₂ T : Finset ℕ) (i : ℕ) (hpos : μ (⋂ j ∈ S₂, (A j)ᶜ) ≠ 0)
+    (hindep : IndepSet (A i) (⋂ j ∈ S₂, (A j)ᶜ) μ) :
+    μ[A i ∩ (⋂ j ∈ T, (A j)ᶜ) | ⋂ j ∈ S₂, (A j)ᶜ] ≤ μ (A i) := by
+  calc μ[A i ∩ (⋂ j ∈ T, (A j)ᶜ) | ⋂ j ∈ S₂, (A j)ᶜ]
+      ≤ μ[A i | ⋂ j ∈ S₂, (A j)ᶜ] := cond_inter_le (measurableSet_survival hA S₂)
+    _ = μ (A i) := cond_failure_eq_measure_of_indep_subset hA S₂ i hpos hindep
+
+end LovaszLocalLemmaOQ01DependencySplit

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -236,3 +236,48 @@ Insights accumulated during research on this problem.
   lean <file>` against MAIN's cached mathlib oleans. Under heavy concurrent load (70+
   lean procs) expect transient `invalid header` / `configuration is invalid` errors —
   retry with backoff; a clean pass confirms.
+
+### Dependency-graph induction step over ARBITRARY subset histories (researcher-4, 2026-07-03) — NEW
+
+- **The whole prefix-history scaffold cannot reach the real LLL — and here is why + the fix.**
+  Every prior OQ-01 measure-theoretic file (chain-rule, quantitative, union-bound,
+  base case, and the concurrent Independence file) conditions on the *prefix* history
+  `⋂_{j<k} Aⱼᶜ` because the chain rule needs a total order. But the Erdős–Lovász
+  induction bounds `Pr[Aᵢ | ⋂_{j∈S} Aⱼᶜ]` for an **arbitrary** subset `S`, split into
+  neighbours `S₁` and non-neighbours `S₂` of `Aᵢ` — unstructured sets, never prefixes.
+  New file `Proofs/LovaszLocalLemmaOQ01DependencySplit.lean` (0 sorry / 0 axiom;
+  axioms = propext/choice/Quot only), gallery entry
+  `lovasz-local-lemma-oq-01-dependency-split`, supplies the two per-event moves of that
+  step over arbitrary finite subset histories.
+- **`cond_mono_num` — conditional prob is monotone in the numerator, and Mathlib has NO
+  such lemma.** `E ⊆ F → μ[E | H] ≤ μ[F | H]` for any measurable `H`. Two `cond_apply`
+  rewrites to `(μ H)⁻¹ · μ(H ∩ ·)`, then a single `gcongr` (via `measure_mono` +
+  `Set.inter_subset_inter`). Natural upstream Mathlib contribution. Corollary
+  `cond_inter_le : μ[E ∩ F | H] ≤ μ[E | H]` is the neighbour-factor drop.
+- **`cond_failure_eq_measure_of_indep_subset` — the non-neighbour collapse over an
+  ARBITRARY subset.** `IndepSet Aᵢ (⋂_{j∈S} Aⱼᶜ) μ` + positive history ⇒
+  `μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ)`. Same proof as the concurrent Independence file's
+  prefix version (`cond_apply`, `IndepSet.measure_inter_eq_mul`, `ENNReal.inv_mul_cancel`)
+  but over a `Finset` `S` instead of `range n` — the version the dependency-graph
+  induction genuinely needs. The only missing ingredient the prefix version lacked was
+  general biInter measurability: `measurableSet_survival` (= `Finset.measurableSet_biInter`
+  on the complements). This proves the prefix restriction was incidental to the scaffold,
+  not intrinsic.
+- **`cond_failure_le_measure_of_indep_num`** combines the two: drop the neighbour factor
+  `T` from the numerator (`cond_inter_le`), then collapse the independent sub-history
+  (`cond_failure_eq_measure_of_indep_subset`) ⇒
+  `μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ)`. This is the LLL induction step's
+  **numerator** bound.
+- **Honest scope / still open.** The remaining hard piece is the recursive **denominator**
+  lower bound `μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 − xⱼ)`, obtained by well-founded
+  recursion on `|S₁|`, where the dependency-degree hypothesis enters. This file isolates
+  exactly the unconditional / local-independence parts of the induction step so the open
+  target is now sharply the denominator recursion.
+- **Lean gotchas.** `IndepSet` and `IndepSet.measure_inter_eq_mul` live in
+  `Mathlib.Probability.Independence.Basic` — ChainRule only imports
+  `Mathlib.Probability.ConditionalProbability`, so add the Independence.Basic import or
+  `IndepSet` gets auto-bound as an unknown implicit. `mul_le_mul_left'` is deprecated
+  (→ use `gcongr`). `cond_apply (hms) (μ) (t) : μ[t|s] = (μ s)⁻¹ * μ (s ∩ t)` (three
+  explicit args). Shared-repo build under 60+ concurrent lean procs: expect frequent
+  exit-139 crashes + `invalid header` — retry; two clean `EXIT=0` empty-output passes
+  confirm.

--- a/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "ann-lll-oq01-depsplit-overview",
+    "proofId": "lovasz-local-lemma-oq-01-dependency-split",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "context",
+    "title": "Why the LLL induction step needs arbitrary subset histories",
+    "content": "The measure-theoretic OQ-01 scaffold (`lovasz-local-lemma-oq-01-chain-rule`, `-quantitative`) reduces the Lovász Local Lemma to a per-event bound on the conditional failure probability over the **prefix** history $\\bigcap_{j<k} A_j^c$. That reduction is genuine, but it is not the LLL: the actual Erdős–Lovász induction bounds $\\Pr[A_i \\mid \\bigcap_{j\\in S} A_j^c]$ for an **arbitrary** subset $S$ of the other events, splitting $S$ into the *neighbours* $S_1$ and *non-neighbours* $S_2$ of $A_i$ in the dependency graph. Those sets are unstructured — never prefixes of a fixed enumeration — so no prefix-history lemma can even state the induction step. This file supplies the two per-event moves of that step over arbitrary finite subset histories $\\bigcap_{j\\in S} A_j^c$: numerator monotonicity (to drop the neighbour factor) and the non-neighbour independence collapse. What it deliberately does not prove is the recursive denominator bound, which is where the well-founded recursion on $|S|$ and the dependency-degree hypothesis enter.",
+    "mathContext": "Induction step of the LLL: bound $\\Pr[A_i \\mid \\bigcap_{j\\in S} A_j^c] \\le x_i$ for arbitrary $S \\not\\ni i$, by splitting $S = S_1 \\sqcup S_2$ into neighbours and non-neighbours of $A_i$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "dependency graph",
+      "conditional probability",
+      "Erdős–Lovász induction",
+      "neighbour/non-neighbour split"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01-chain-rule (prefix-history reduction)",
+      "conditional probability μ[t|s] = (μ s)⁻¹ · μ(s ∩ t)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-depsplit-mono",
+    "proofId": "lovasz-local-lemma-oq-01-dependency-split",
+    "range": { "startLine": 68, "endLine": 82 },
+    "type": "insight",
+    "title": "Conditional probability is monotone in the numerator",
+    "content": "`cond_mono_num`: for any measurable conditioning set $H$, if $E \\subseteq F$ then $\\mu[E \\mid H] \\le \\mu[F \\mid H]$. Surprisingly, Mathlib has **no** monotonicity lemma for `cond` in the conditioned event. The proof is elementary: `cond_apply` rewrites both sides as $(\\mu H)^{-1} \\cdot \\mu(H \\cap \\cdot)$; from $E \\subseteq F$ we get $H \\cap E \\subseteq H \\cap F$, and `measure_mono` plus the common nonnegative factor $(\\mu H)^{-1}$ finish — a single `gcongr` after the rewrites. This is the workhorse of the LLL induction: the induction bounds a conditional failure probability by *dropping* the survival of $A_i$'s neighbours from the numerator, which is exactly one application of this inequality (its corollary `cond_inter_le`, $\\mu[E \\cap F \\mid H] \\le \\mu[E \\mid H]$).",
+    "mathContext": "$E \\subseteq F \\Rightarrow \\mu[E \\mid H] \\le \\mu[F \\mid H]$, via $\\mu[t\\mid s] = (\\mu s)^{-1}\\mu(s\\cap t)$ and monotonicity of $\\mu$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "monotonicity of measure",
+      "conditional probability",
+      "cond_apply",
+      "gcongr"
+    ],
+    "prerequisites": [
+      "cond_apply: μ[t|s] = (μ s)⁻¹ · μ(s ∩ t)",
+      "measure_mono: s ⊆ t → μ s ≤ μ t"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-depsplit-measurable",
+    "proofId": "lovasz-local-lemma-oq-01-dependency-split",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "technical",
+    "title": "Measurability of arbitrary-subset survival histories",
+    "content": "`measurableSet_survival`: $\\bigcap_{j\\in S} A_j^c$ is measurable for any `Finset` $S$, by `Finset.measurableSet_biInter` applied to the complements. This is the subset-indexed analogue of the chain-rule file's `measurableSet_hist`, which is restricted to `Finset.range n`. It is the *only* ingredient the prefix version was missing to run the non-neighbour reduction over arbitrary subsets — evidence that the prefix restriction in the earlier files was incidental to the chain-rule scaffold, not intrinsic to the mathematics. The `IsProbabilityMeasure` instance is switched on immediately after (line 98) for the results that need finite, cancellable measures.",
+    "mathContext": "MeasurableSet (⋂ j ∈ S, (A j)ᶜ) for a Finset S, from finite intersections of measurable sets.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.measurableSet_biInter",
+      "finite intersections",
+      "measurable sets"
+    ],
+    "prerequisites": [
+      "Finset.measurableSet_biInter",
+      "MeasurableSet.compl"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-depsplit-collapse",
+    "proofId": "lovasz-local-lemma-oq-01-dependency-split",
+    "range": { "startLine": 100, "endLine": 120 },
+    "type": "insight",
+    "title": "The non-neighbour collapse over an arbitrary subset",
+    "content": "`cond_failure_eq_measure_of_indep_subset`: if $A_i$ is independent of the survival history $H = \\bigcap_{j\\in S} A_j^c$ of an **arbitrary** finite $S$ (with $\\mu H \\ne 0$), then the conditional failure probability collapses to the unconditional one, $\\mu[A_i \\mid H] = \\mu(A_i)$. This is the arbitrary-subset generalisation of the prefix-only non-neighbour step: in the dependency graph the events *not* adjacent to $A_i$ form an unstructured set $S_2$, so this — not the prefix version — is what the induction actually applies. The proof is identical in spirit to the prefix case: `cond_apply` unfolds $\\mu[A_i\\mid H] = (\\mu H)^{-1}\\mu(H\\cap A_i)$, `Set.inter_comm` and `IndepSet.measure_inter_eq_mul` factor $\\mu(A_i \\cap H) = \\mu(A_i)\\,\\mu H$, and `ENNReal.inv_mul_cancel` cancels the finite nonzero $\\mu H$, leaving $\\mu(A_i)$.",
+    "mathContext": "IndepSet Aᵢ (⋂_{j∈S} Aⱼᶜ) μ and μ(⋂_{j∈S} Aⱼᶜ) ≠ 0 ⟹ μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ).",
+    "significance": "core",
+    "relatedConcepts": [
+      "IndepSet.measure_inter_eq_mul",
+      "conditional probability",
+      "ENNReal.inv_mul_cancel",
+      "non-neighbour reduction"
+    ],
+    "prerequisites": [
+      "IndepSet.measure_inter_eq_mul: independence factors the joint measure",
+      "cond_apply and ENNReal cancellation"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-depsplit-numstep",
+    "proofId": "lovasz-local-lemma-oq-01-dependency-split",
+    "range": { "startLine": 122, "endLine": 141 },
+    "type": "insight",
+    "title": "Assembling the numerator half of the induction step",
+    "content": "`cond_failure_le_measure_of_indep_num` packages the two moves into the numerator bound the LLL induction feeds into its recursive denominator estimate: if $A_i$ is independent of the positive-measure history $\\bigcap_{j\\in S_2} A_j^c$ (its non-neighbours), then for *any* further events $T$, $\\mu[A_i \\cap (\\bigcap_{j\\in T} A_j^c) \\mid \\bigcap_{j\\in S_2} A_j^c] \\le \\mu(A_i)$. The proof is a two-step `calc`: `cond_inter_le` drops the extra neighbour factor $T$ from the numerator, then `cond_failure_eq_measure_of_indep_subset` collapses the independent sub-history to $\\mu(A_i)$. This is exactly the LLL induction's numerator bound $\\Pr[A_i \\cap \\bigcap_{S_1} A_j^c \\mid \\bigcap_{S_2} A_j^c] \\le \\Pr[A_i] $; what remains open is the recursive **denominator** lower bound $\\Pr[\\bigcap_{S_1} A_j^c \\mid \\bigcap_{S_2} A_j^c] \\ge \\prod_{j\\in S_1}(1-x_j)$.",
+    "mathContext": "μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ) under independence of Aᵢ from the non-neighbour survival ⋂_{j∈S₂} Aⱼᶜ.",
+    "significance": "core",
+    "relatedConcepts": [
+      "LLL induction step",
+      "neighbour/non-neighbour split",
+      "numerator bound",
+      "recursive denominator bound (open)"
+    ],
+    "prerequisites": [
+      "cond_inter_le (numerator drop)",
+      "cond_failure_eq_measure_of_indep_subset (non-neighbour collapse)"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "lovasz-local-lemma-oq-01-dependency-split",
+  "title": "Lovász Local Lemma OQ-01: Subset-History Toolkit for the Dependency-Graph Step",
+  "slug": "lovasz-local-lemma-oq-01-dependency-split",
+  "description": "The measure-theoretic OQ-01 entries (chain-rule, quantitative, union-bound) all reduce the Lovász Local Lemma to a per-event conditional bound over the PREFIX history ⋂_{j<k} Aⱼᶜ. But the genuine content of the LLL — the Erdős–Lovász induction that produces those bounds from a bounded dependency degree — does not live over prefixes at all: its induction step conditions on the survival of an ARBITRARY subset S of the events and splits S into the neighbours and non-neighbours of the event under scrutiny. This entry supplies the two per-event moves of that step over arbitrary finite subset histories ⋂_{j∈S} Aⱼᶜ, each proved unconditionally or from local independence. (1) Numerator monotonicity cond_mono_num: μ[E | H] ≤ μ[F | H] whenever E ⊆ F, for any measurable conditioning set H — there is no such lemma in Mathlib, and it is the step by which the induction drops the neighbour-survival factor from the numerator (cond_inter_le). (2) Non-neighbour collapse cond_failure_eq_measure_of_indep_subset: if Aᵢ is independent of the survival history ⋂_{j∈S} Aⱼᶜ of an arbitrary finite S of positive measure, then μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ) — the arbitrary-subset generalisation of the prefix-only non-neighbour step, which is the version the dependency-graph induction genuinely needs (non-neighbours form an unstructured set, never a prefix). Combining them gives the numerator half of the induction step (cond_failure_le_measure_of_indep_num): once the neighbour factor is dropped, conditioning on an independent sub-history leaves the failure probability at most μ(Aᵢ). What remains open is the recursive DENOMINATOR lower bound μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏(1 − xⱼ), which combines these ingredients across a well-founded recursion on |S| — the actual LLL induction. This entry isolates exactly the unconditional / local-independence parts of that step. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01DependencySplit.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "conditional-probability",
+      "independence"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on cond_mono_num, cond_failure_eq_measure_of_indep_subset, and cond_failure_le_measure_of_indep_num). Scope: this entry supplies the arbitrary-subset-history ingredients of the Lovász Local Lemma's dependency-graph induction step — numerator monotonicity of conditional probability and the non-neighbour independence collapse over an arbitrary finite subset — each proved unconditionally or from an explicitly-hypothesised local independence. It does NOT prove the LLL induction itself: the recursive denominator lower bound μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏(1 − xⱼ), obtained by well-founded recursion on the subset size and combining these ingredients, remains the open OQ-01 research target. The independence hypotheses (IndepSet Aᵢ (⋂_{j∈S} Aⱼᶜ) μ) and the positive-measure-history hypotheses are stated explicitly as arguments; they are not axioms.",
+    "lineCount": 141,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "cond_mono_num: conditional probability is monotone in the numerator — E ⊆ F → μ[E | H] ≤ μ[F | H] for any measurable conditioning set H. Mathlib has no monotonicity lemma for cond in the conditioned event; this is a clean, reusable general lemma proved by unfolding both sides with cond_apply to (μ H)⁻¹ · μ(H ∩ ·) and applying measure_mono to H ∩ E ⊆ H ∩ F (via gcongr). It is the elementary workhorse of the LLL induction's neighbour-factor drop and a natural upstream Mathlib contribution.",
+      "cond_failure_eq_measure_of_indep_subset: the non-neighbour collapse over an ARBITRARY finite subset history — if Aᵢ is independent of ⋂_{j∈S} Aⱼᶜ (positive measure), then μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ). This generalises the prefix-only (⋂_{j<n}) reduction to the unstructured subsets the dependency-graph induction actually conditions on: in the dependency graph the non-neighbours of Aᵢ form an arbitrary set S₂, never a prefix, so the prefix version cannot state this step. Proof via cond_apply, IndepSet.measure_inter_eq_mul, and cancellation of the finite nonzero μ(⋂_{j∈S} Aⱼᶜ).",
+      "cond_inter_le: the neighbour-factor drop μ[E ∩ F | H] ≤ μ[E | H], the special case of cond_mono_num at Set.inter_subset_left used to discard the survival of Aᵢ's neighbours from the numerator.",
+      "measurableSet_survival: measurability of the arbitrary-finite-subset survival history ⋂_{j∈S} Aⱼᶜ (Finset.measurableSet_biInter on the complements), the subset-indexed analogue of the chain-rule file's Finset.range-only measurableSet_hist.",
+      "cond_failure_le_measure_of_indep_num: the numerator half of the dependency-graph induction step — conditioning Aᵢ on the survival of an independent sub-history S₂ together with any extra events T gives μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ). Packages the two moves (drop the neighbour factor T, then collapse the independent sub-history) into the exact numerator bound the LLL induction feeds into its recursive denominator estimate.",
+      "Framing contribution: identifies precisely why the existing prefix-history scaffold (chain-rule, quantitative) cannot reach the actual LLL — the induction operates over arbitrary subset histories — and isolates the parts of the induction step that are true unconditionally or from local independence, leaving the recursive denominator bound as the single remaining open piece."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.LovaszLocalLemmaOQ01ChainRule",
+      "Mathlib.Probability.Independence.Basic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Finset",
+      "ENNReal"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01DependencySplit",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01DependencySplit.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LovaszLocalLemmaOQ01ChainRule.lean"
+    ]
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "cond_mono_num",
+      "type": "core",
+      "description": "Conditional probability is monotone in the numerator: for any measurable conditioning set H, if E ⊆ F then μ[E | H] ≤ μ[F | H]. Mathlib has no such lemma. It is the elementary workhorse of the LLL induction's neighbour-factor drop, proved by unfolding cond_apply to (μ H)⁻¹ · μ(H ∩ ·) and applying measure_mono to H ∩ E ⊆ H ∩ F.",
+      "leanType": "(hH : MeasurableSet H) → (hEF : E ⊆ F) → μ[E | H] ≤ μ[F | H]"
+    },
+    {
+      "name": "cond_failure_eq_measure_of_indep_subset",
+      "type": "core",
+      "description": "The non-neighbour collapse over an arbitrary finite subset history: if Aᵢ is independent of the survival history ⋂_{j∈S} Aⱼᶜ of an arbitrary finite S of positive measure, then the conditional failure probability equals the unconditional one, μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ). The arbitrary-subset generalisation of the prefix-only non-neighbour step the dependency-graph induction requires.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (S : Finset ℕ) → (i : ℕ) → (hpos : μ (⋂ j ∈ S, (A j)ᶜ) ≠ 0) → (hindep : IndepSet (A i) (⋂ j ∈ S, (A j)ᶜ) μ) → μ[A i | ⋂ j ∈ S, (A j)ᶜ] = μ (A i)"
+    },
+    {
+      "name": "cond_failure_le_measure_of_indep_num",
+      "type": "core",
+      "description": "The numerator half of the dependency-graph induction step: conditioning Aᵢ on the survival of an independent sub-history S₂ together with any further events T keeps its failure probability at most μ(Aᵢ). Combines the neighbour-factor drop (cond_inter_le) with the non-neighbour collapse (cond_failure_eq_measure_of_indep_subset).",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (S₂ T : Finset ℕ) → (i : ℕ) → (hpos : μ (⋂ j ∈ S₂, (A j)ᶜ) ≠ 0) → (hindep : IndepSet (A i) (⋂ j ∈ S₂, (A j)ᶜ) μ) → μ[A i ∩ (⋂ j ∈ T, (A j)ᶜ) | ⋂ j ∈ S₂, (A j)ᶜ] ≤ μ (A i)"
+    },
+    {
+      "name": "cond_inter_le",
+      "type": "lemma",
+      "description": "The neighbour-factor drop: intersecting the numerator with any set can only decrease the conditional probability, μ[E ∩ F | H] ≤ μ[E | H]. The special case of cond_mono_num at Set.inter_subset_left.",
+      "leanType": "(hH : MeasurableSet H) → μ[E ∩ F | H] ≤ μ[E | H]"
+    },
+    {
+      "name": "measurableSet_survival",
+      "type": "lemma",
+      "description": "The survival history of an arbitrary finite index set is measurable: MeasurableSet (⋂ j ∈ S, (A j)ᶜ). The subset-indexed analogue of the chain-rule file's Finset.range-only measurableSet_hist, via Finset.measurableSet_biInter on the complements.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (S : Finset ℕ) → MeasurableSet (⋂ j ∈ S, (A j)ᶜ)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) states that if each of a family of 'bad' events is mutually independent of all but at most d others and each has probability at most p with e·p·(d+1) ≤ 1, then with positive probability none occurs. Its proof is an induction — due to Erdős and Lovász, streamlined by Spencer and by Alon–Spencer's The Probabilistic Method — that bounds each conditional probability Pr[Aᵢ | ⋂_{j∈S} Āⱼ] by a variable xᵢ, for every subset S of events not containing i. The induction step splits S into S₁ = neighbours of i and S₂ = non-neighbours: the non-neighbour part factors out by independence (Pr[Aᵢ | ⋂_{S₂} Āⱼ] = Pr[Aᵢ]), the neighbour part is dropped from the numerator, and the neighbour survival in the denominator is bounded below recursively by ∏_{j∈S₁}(1 − xⱼ). Crucially, this recursion is over ARBITRARY subsets S — the sets S₁, S₂ produced by the neighbour/non-neighbour split are unstructured, never prefixes of a fixed enumeration. The OQ-01 gallery front (chain-rule, quantitative, union-bound, base case) formalized the measure-theoretic surroundings of this argument entirely over PREFIX histories ⋂_{j<k} Āⱼ, which suffice for the chain-rule reduction but cannot express the induction step itself. This entry closes that gap on the ingredient side, providing the two per-event moves of the induction step over arbitrary subset histories.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces, including the dependency-graph induction that produces per-event conditional bounds from a bounded dependency degree.\n\n**This entry (dependency-graph step ingredients)**: supply the two moves of the Erdős–Lovász induction step over an ARBITRARY finite subset history ⋂_{j∈S} Aⱼᶜ, each proved unconditionally or from local independence. (1) Numerator monotonicity: E ⊆ F → μ[E | H] ≤ μ[F | H]. (2) Non-neighbour collapse: Aᵢ independent of ⋂_{j∈S} Aⱼᶜ (positive measure) → μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ). Combined: μ[Aᵢ ∩ ⋂_{j∈T} Aⱼᶜ | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ).",
+    "text": "The real proof of the Lovász Local Lemma is an induction that asks: given that a bunch of bad events have all been avoided so far, how likely is one more bad event? To answer it you split the 'so far' set into the events that are entangled with the new one (its neighbours) and the ones that aren't (non-neighbours). Independence lets you ignore the non-neighbours; the neighbours you handle recursively. The subtlety is that the sets you recurse on are arbitrary — they are not the first-k-events prefixes that the earlier gallery entries were built on. This entry provides exactly the two arbitrary-subset moves the induction needs: conditioning on more only shrinks a numerator, and conditioning on an independent block changes nothing.",
+    "proofStrategy": "**Numerator monotonicity (cond_mono_num).** cond_apply rewrites μ[E | H] = (μ H)⁻¹ · μ(H ∩ E) and likewise for F. Since E ⊆ F gives H ∩ E ⊆ H ∩ F, measure_mono and the shared factor (μ H)⁻¹ finish; the whole thing is one gcongr call after the two rewrites. Its corollary cond_inter_le is cond_mono_num at Set.inter_subset_left.\n\n**Non-neighbour collapse (cond_failure_eq_measure_of_indep_subset).** For an arbitrary Finset S, measurableSet_survival (= Finset.measurableSet_biInter on the complements) supplies measurability of H = ⋂_{j∈S} Aⱼᶜ. cond_apply unfolds μ[Aᵢ | H] = (μ H)⁻¹ · μ(H ∩ Aᵢ); Set.inter_comm and IndepSet.measure_inter_eq_mul factor μ(Aᵢ ∩ H) = μ(Aᵢ) · μ H; ENNReal.inv_mul_cancel cancels the finite nonzero μ H (positive by hypothesis, finite over a probability measure), leaving μ(Aᵢ).\n\n**Combination (cond_failure_le_measure_of_indep_num).** A two-step calc: cond_inter_le drops the extra events T from the numerator (μ[Aᵢ ∩ ⋂_{T} Aⱼᶜ | H] ≤ μ[Aᵢ | H]), then cond_failure_eq_measure_of_indep_subset rewrites μ[Aᵢ | H] = μ(Aᵢ).",
+    "keyInsights": [
+      "The earlier OQ-01 scaffold is prefix-bound by construction: the chain rule μ(⋂ᵢ Aᵢ) = ∏ₖ μ[Aₖ | ⋂_{j<k} Aⱼ] needs a total order, so every downstream file conditions on ⋂_{j<k}. But the LLL induction step conditions on ⋂_{j∈S} for arbitrary S produced by a neighbour/non-neighbour split — these are never prefixes, so reaching the induction requires leaving the prefix world entirely. This entry makes that move.",
+      "Numerator monotonicity of conditional probability (E ⊆ F → μ[E|H] ≤ μ[F|H]) is absent from Mathlib despite being elementary — cond is (μ H)⁻¹ · μ(H ∩ ·) and measure is monotone. Isolating it as cond_mono_num turns the LLL induction's neighbour-drop into a one-line application and is a clean upstream contribution in its own right.",
+      "The non-neighbour independence step is exactly the same proof whether the history is a prefix ⋂_{j<n} or an arbitrary subset ⋂_{j∈S} — cond_apply + IndepSet.measure_inter_eq_mul + cancellation. The only thing the prefix version was missing was general biInter measurability, supplied here by measurableSet_survival. This shows the prefix restriction in earlier files was incidental to the scaffold, not intrinsic to the mathematics.",
+      "What is NOT proved here is precisely the hard part: the recursive DENOMINATOR bound μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 − xⱼ), which is where the well-founded recursion on |S| and the dependency-degree hypothesis enter. This entry deliberately isolates the unconditional / local-independence ingredients so the remaining open piece is sharply delineated."
+    ],
+    "prerequisites": [
+      "The chain-rule scaffold lovasz-local-lemma-oq-01-chain-rule (prefix-history reduction of avoidance to per-event conditional bounds)",
+      "ProbabilityTheory.cond and cond_apply: μ[t|s] = (μ s)⁻¹ · μ(s ∩ t)",
+      "ProbabilityTheory.IndepSet and IndepSet.measure_inter_eq_mul: independence factors the joint measure",
+      "measure_mono and Finset.measurableSet_biInter (finite intersections of measurable sets are measurable)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-motivation",
+      "title": "Motivation: the induction step lives over arbitrary subset histories",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring. Explains that the existing OQ-01 scaffold (chain-rule, quantitative) reduces the LLL to a per-event bound over PREFIX histories ⋂_{j<k} Aⱼᶜ, but the actual Erdős–Lovász induction step conditions on the survival of an ARBITRARY subset S and splits it into neighbours and non-neighbours. States the two per-event moves this file supplies over arbitrary subset histories (numerator monotonicity + non-neighbour collapse) and their combination, and flags the open piece (the recursive denominator bound)."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 57,
+      "endLine": 66,
+      "summary": "Imports the chain-rule scaffold Proofs.LovaszLocalLemmaOQ01ChainRule and Mathlib.Probability.Independence.Basic (for IndepSet and IndepSet.measure_inter_eq_mul). Opens MeasureTheory, ProbabilityTheory, Finset, and the ENNReal scope; enters the LovaszLocalLemmaOQ01DependencySplit namespace with the ambient measurable space, probability measure μ, event family A, and sets E, F, H."
+    },
+    {
+      "id": "cond-mono-num",
+      "title": "Numerator monotonicity of conditional probability",
+      "startLine": 68,
+      "endLine": 82,
+      "summary": "cond_mono_num: for measurable H and E ⊆ F, μ[E | H] ≤ μ[F | H]. Both sides unfold via cond_apply to (μ H)⁻¹ · μ(H ∩ ·); H ∩ E ⊆ H ∩ F, so gcongr (via measure_mono and Set.inter_subset_inter) closes it. There is no monotonicity lemma for cond in Mathlib; this is the workhorse of the LLL induction's neighbour-factor drop."
+    },
+    {
+      "id": "cond-inter-le",
+      "title": "The neighbour-factor drop",
+      "startLine": 83,
+      "endLine": 89,
+      "summary": "cond_inter_le: μ[E ∩ F | H] ≤ μ[E | H], the special case cond_mono_num Set.inter_subset_left used by the induction to discard the survival of Aᵢ's neighbours from the numerator."
+    },
+    {
+      "id": "measurable-survival",
+      "title": "Measurability of arbitrary-subset survival histories",
+      "startLine": 91,
+      "endLine": 98,
+      "summary": "measurableSet_survival: MeasurableSet (⋂ j ∈ S, (A j)ᶜ) for any Finset S, via Finset.measurableSet_biInter on the complements. The subset-indexed analogue of the chain-rule file's Finset.range-only measurableSet_hist — the one ingredient the prefix version was missing for the arbitrary-subset reduction. The IsProbabilityMeasure instance is switched on at line 98 for the remaining results."
+    },
+    {
+      "id": "nonneighbour-collapse",
+      "title": "Non-neighbour collapse over an arbitrary subset",
+      "startLine": 100,
+      "endLine": 120,
+      "summary": "cond_failure_eq_measure_of_indep_subset: if Aᵢ is independent of ⋂_{j∈S} Aⱼᶜ (positive measure), then μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ). cond_apply unfolds the conditional, Set.inter_comm and IndepSet.measure_inter_eq_mul factor μ(Aᵢ ∩ H) = μ(Aᵢ)·μ H, and ENNReal.inv_mul_cancel cancels the finite nonzero μ H. The arbitrary-subset form of the LLL non-neighbour step."
+    },
+    {
+      "id": "numerator-step",
+      "title": "The numerator half of the dependency-graph induction step",
+      "startLine": 122,
+      "endLine": 141,
+      "summary": "cond_failure_le_measure_of_indep_num: μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ) when Aᵢ is independent of the positive-measure history ⋂_{j∈S₂} Aⱼᶜ. A two-step calc: cond_inter_le drops the extra events T from the numerator, then cond_failure_eq_measure_of_indep_subset collapses the independent sub-history to μ(Aᵢ). The namespace closes at line 141."
+    }
+  ],
+  "conclusion": {
+    "summary": "The two per-event moves of the Lovász Local Lemma's dependency-graph induction step — numerator monotonicity of conditional probability (cond_mono_num, new to Mathlib) and the non-neighbour independence collapse over an arbitrary finite subset (cond_failure_eq_measure_of_indep_subset) — are machine-verified over an arbitrary probability space, and combined into the numerator bound cond_failure_le_measure_of_indep_num. 0 sorries, 0 axioms.",
+    "implications": "**Breaks the prefix-history barrier of the OQ-01 scaffold.** The chain-rule, quantitative, union-bound, and base-case entries all condition on PREFIX histories ⋂_{j<k} Aⱼᶜ, which the chain rule forces but which cannot express the LLL induction step (whose neighbour/non-neighbour split produces arbitrary subsets). This entry supplies the arbitrary-subset ingredients: numerator monotonicity and the non-neighbour collapse over ⋂_{j∈S} Aⱼᶜ, showing the prefix restriction was incidental to the scaffold rather than intrinsic.\n\n**Honest scope**: this delivers only the unconditional / local-independence parts of the induction step. The remaining open piece — the recursive denominator lower bound μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 − xⱼ), obtained by well-founded recursion on the subset size and where the dependency-degree hypothesis actually enters — is exactly what a full formalization of the measure-theoretic LLL still requires. This entry sharpens the target by isolating what is already true from what the recursion must supply.",
+    "openQuestions": [
+      "Prove the recursive denominator lower bound μ[⋂_{j∈S₁} Aⱼᶜ | ⋂_{j∈S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 − xⱼ) by well-founded recursion on |S₁|, combining cond_failure_le_measure_of_indep_num with the neighbour split, to close the Erdős–Lovász induction step Pr[Aᵢ | ⋂_{j∈S} Aⱼᶜ] ≤ xᵢ.",
+      "Formalize the dependency-graph structure itself (a symmetric relation on the event index with μ(Aᵢ) mutually independent of the non-neighbours as a family) so that the neighbour/non-neighbour split S = S₁ ⊔ S₂ and the resulting IndepSet Aᵢ (⋂_{j∈S₂} Aⱼᶜ) hypothesis are derivable rather than assumed per-application.",
+      "Chain the completed induction step into the chain-rule scaffold's per-event bound μ[Aₖ | ⋂_{j<k} Aⱼᶜ] ≤ xₖ to obtain the asymmetric general LLL conclusion μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) via lovasz-local-lemma-oq-01-quantitative."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "extends",
+      "description": "The prefix-history scaffold that reduces the measure-theoretic LLL to a per-event conditional bound μ[Aₖ | ⋂_{j<k} Aⱼᶜ] over the ⋂_{j<k} prefix. This entry moves beyond prefixes to the arbitrary subset histories ⋂_{j∈S} Aⱼᶜ that the LLL induction step actually conditions on, generalising the chain-rule file's measurableSet_hist to measurableSet_survival."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-quantitative",
+      "relationship": "related",
+      "description": "The quantitative avoidance bound ∏(1 − bₖ) ≤ μ(⋂ Aᵢᶜ), which consumes per-event conditional bounds bₖ. The numerator step proved here (cond_failure_le_measure_of_indep_num) is the ingredient the still-open LLL induction combines with the recursive denominator bound to produce those bₖ."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "related",
+      "description": "The d = 0 base case proving μ(⋂ Aᵢᶜ) = ∏(1 − μ(Aᵢ)) from full mutual independence. This entry supplies the non-neighbour independence collapse that the general (d > 0) induction step uses to reduce to that independent regime over the non-neighbour block."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-euler-threshold",
+      "relationship": "related",
+      "description": "The real-analysis bridge e·p·(d+1) ≤ 1 ⟹ p ≤ T(d) fixing the symmetric hypothesis. This entry supplies the measure-theoretic ingredients of the induction that would consume such a per-event budget xᵢ = 1/(d+1)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the induction bounds Pr[Aᵢ | ⋂_{j∈S} Āⱼ] over arbitrary subsets S via the neighbour/non-neighbour split."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Chapter 5 gives the standard induction proof of the LLL; the induction step splits the conditioning set into neighbours and non-neighbours, uses independence to factor out the non-neighbours, and bounds the neighbour survival recursively — the argument whose ingredients this entry formalizes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **`lovasz-local-lemma-oq-01-dependency-split`** advancing the measure-theoretic Lovász Local Lemma (OQ-01). **Verified: 0 sorries, 0 axioms** (`#print axioms` = `propext`/`Classical.choice`/`Quot.sound` only).

The existing OQ-01 scaffold (`chain-rule`, `quantitative`, `union-bound`, base case) reduces the LLL to a per-event conditional bound over the **prefix** history `⋂_{j<k} Aⱼᶜ`. But the genuine Erdős–Lovász induction bounds `Pr[Aᵢ | ⋂_{j∈S} Aⱼᶜ]` over an **arbitrary** subset `S`, split into the *neighbours* and *non-neighbours* of `Aᵢ` in the dependency graph — unstructured sets, never prefixes. The prefix scaffold cannot even state the induction step. This entry supplies the two per-event moves of that step over arbitrary finite subset histories.

## New results (`Proofs/LovaszLocalLemmaOQ01DependencySplit.lean`)

- **`cond_mono_num`** — conditional probability is monotone in the numerator: `E ⊆ F → μ[E | H] ≤ μ[F | H]`. **Mathlib has no such lemma**; a clean, reusable upstream candidate. Corollary `cond_inter_le` is the neighbour-factor drop.
- **`cond_failure_eq_measure_of_indep_subset`** — the non-neighbour collapse over an arbitrary `Finset S`: `IndepSet Aᵢ (⋂_{j∈S} Aⱼᶜ) μ` + positive history ⇒ `μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] = μ(Aᵢ)`. Generalises the prefix-only reduction to the unstructured subsets the dependency-graph induction actually conditions on (measurability via `measurableSet_survival`).
- **`cond_failure_le_measure_of_indep_num`** — combines the two into the induction step's **numerator** bound `μ[Aᵢ ∩ (⋂_{j∈T} Aⱼᶜ) | ⋂_{j∈S₂} Aⱼᶜ] ≤ μ(Aᵢ)`.

## Honest scope

This delivers only the unconditional / local-independence ingredients of the induction step. The remaining hard piece — the recursive **denominator** lower bound `μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏(1 − xⱼ)` by well-founded recursion on `|S₁|`, where the dependency-degree hypothesis enters — remains the open OQ-01 target. The contribution sharpens that target by isolating what is already true.

## Verification

- `lake env lean Proofs/LovaszLocalLemmaOQ01DependencySplit.lean` → clean (0 errors, 0 warnings), confirmed on two independent passes.
- `#print axioms` on all three core theorems → foundational axioms only.
- `meta.json` within the 60 KB gallery cap (25 KB); both JSON files parse.

## Files
- `proofs/Proofs/LovaszLocalLemmaOQ01DependencySplit.lean` (new, 141 lines)
- `src/data/proofs/lovasz-local-lemma-oq-01-dependency-split/{meta,annotations}.json` (new gallery entry)
- `research/problems/lovasz-local-lemma-oq-01/knowledge.md` (session note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)