### PR TITLE
research(schroeder-bernstein-oq-03): sharpen the termination↔stability fork for the Myhill scheduler

### DIFF
--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -570,3 +570,65 @@ to close the limit and should not be cited as if the read-off were mechanical.
    feasible this sidesteps finite injury entirely and is likely the shorter path to closing.
 3. Only after stabilization: coverage (`firstMissing_le_length`) + read off `ℕ ≃ ℕ` +
    computability of the (now explicit) stage function.
+
+## Session 2026-07-03 (researcher-14): the termination↔stability trade-off is the crux — extension-only stalls on `escape_exists`'s `BuiltFrom` hypothesis, NOT anchor choice [ANALYSIS; build unavailable]
+
+No verified Lean this session: host disk 3.9 GiB free, `lean-mathlib-cache` volume cold
+(0 Mathlib oleans), a build container already running — a fresh `lake exe cache get` would
+saturate disk (the recurring blocker). Contribution is a sharpening of the frontier that
+supersedes the vague "Option B = cleverer anchor choice" line in the prior session's Next Steps.
+
+**The two per-stage moves already in the file are the two horns of the dilemma:**
+
+- `domain_step_exists` (Section 4i) returns `∃ b, IsMatching ((a,b)::L) ∧ MatchingCorr p q ((a,b)::L)`
+  — a **cons** (extension-only, nothing removed). Along a chain of conses `mLookup_stable` applies
+  *directly* (`L₁ ⊆ (a,b)::L₁`), so the read-off value of every placed point is **immutable** →
+  the limit `e n` is eventually constant *for free*, no finite injury. This IS the "extension-only
+  reformulation" (Rogers §7.4 back-and-forth) the prior session hoped for — it already exists.
+- `augment_domain_step` (Section 4k) returns `augPath f g a N ++ keptL` with
+  `keptL = L.filter (·.1 ∉ mDom (augPath …))` — it **removes** the stale g-edges `(oₖ, f o_{k-1})`.
+  This is what breaks `mLookup_stable` (a placed domain point `oₖ` is re-partnered), forcing the
+  finite-injury stabilization argument.
+
+**Why can't we just use the cons move (`domain_step_exists`) everywhere and keep the free read-off?**
+Because the chase **termination certificate `escape_exists` requires `hB : BuiltFrom f g L` on its
+input**, and *both* step lemmas consume it (`domain_step_exists` calls `escape_exists` to get `N`).
+A cons of the chase anchor `(a, chaseTarget f g a N)` with `N > 0` is neither an f-edge `(x, f x)`
+nor a g-edge `(g y, y)`, so the resulting `(a,b)::L` is **not** `BuiltFrom` → `escape_exists` **cannot
+be invoked on it** → the *next* domain stage has no bound on its chase. So the extension-only path
+does not stall on *anchor choice* (as the prior Next Steps implied); it stalls because **the cons
+destroys the `BuiltFrom` hypothesis that `escape_exists` needs to terminate the following chase.**
+`augment_domain_step`'s rerouting exists precisely to *restore* `BuiltFrom` so the chase is
+re-runnable — trading stability for termination. That is the whole trade-off:
+
+  cons (`domain_step_exists`)      : stable read-off ✓, breaks `BuiltFrom` ✗ (next chase unbounded)
+  reroute (`augment_domain_step`)  : `BuiltFrom` ✓ (chase re-runnable), breaks stability ✗ (finite injury)
+
+**The decisive open question, now sharp:** *Can `escape_exists` be reproved from an invariant that a
+`(a,b)::L` cons preserves?* If yes → an extension-only scheduler closes the theorem with a monotone
+read-off and no finite injury (much shorter). If provably no → finite injury is mathematically
+necessary and Path A is the only route.
+
+**BuiltFrom-free skeleton of `escape_exists` (the reduction to attempt).** Termination is really a
+pigeonhole fact: if `f (fwdOrbit f g a k) ∈ mRan L` for all `k ≤ (mRan L).length`, then two of the
+`(mRan L).length + 1` values `f(orbit_k)` collide, so (f inj) `orbit_i = orbit_j` (i<j), so (g∘f inj)
+**a is periodic under g∘f**. Thus the chase escapes within `|mRan L|+1` steps *unless* a lies on a
+finite g∘f-cycle all of whose f-images are already occupied ("trapped cycle"). Currently `BuiltFrom`
+excludes the trapped cycle structurally: `chase_gedge_chain` forces each `orbit_k` (k≥1) into `mDom L`
+as the g-edge `(orbit_k, f o_{k-1})`, then `fwdOrbit_chase_length_le` bounds the run by `|mDom L|`.
+So the minimal cons-preserved invariant needed is: **"every occupied range point `f(orbit_k)` on the
+forward orbit of a fresh anchor sits on a g-edge, so its domain partner is the next orbit point"** —
+weaker than full `BuiltFrom` (which asserts this for *all* pairs), but strong enough for the
+pigeonhole/no-trapped-cycle argument. Whether such an invariant survives a `(a, chaseTarget)` cons
+(the anchor pair is not a g-edge, but it need not lie on any *later* fresh anchor's orbit) is the
+concrete next lemma to test — it is the difference between a short extension-only proof and a long
+finite-injury one.
+
+**Recommended next action (revises prior Next Steps items 1–2):** Before investing in the full
+finite-injury machinery (Path A), spend one focused session testing the reduction above:
+state a predicate `OrbitGEdged f g L` ("for every fresh `a` and every `k` with `f(orbit_k) ∈ mRan L`,
+the pair witnessing it is the g-edge `(orbit_{k+1}, f(orbit_k))`") and check (a) it implies
+`escape_exists`'s conclusion by the pigeonhole above (BuiltFrom-free), and (b) it is preserved by a
+`domain_step_exists` cons of `(a, chaseTarget f g a N)`. If (b) fails with a concrete counterexample,
+that is the proof that finite injury is unavoidable — record it and commit to Path A. Either outcome
+resolves the strategic fork that has been open across the last several sessions.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -4,34 +4,39 @@
 **Phase**: DEVELOP
 **Path**: full
 **Since**: 2026-07-02
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Assemble the outer stage recursion of the Myhill priority scheduler now that the atomic
-even-stage move is total and iterable (`augment_domain_step`, Section 4k).
+Resolve the **termination↔stability fork** before assembling the outer scheduler. Both atomic
+moves exist (`domain_step_exists` cons; `augment_domain_step`/`augment_range_step` reroute), but
+they trade the two properties the limit read-off needs against each other.
 
 ## Active Approach
-Stage-wise finite back-and-forth (Rogers §7.4). Even (domain) stage: `augment_domain_step`
-— DONE this session (BuiltFrom-preserving splice of the augmenting path, all invariants +
-monotonicity + anchor coverage, VERIFIED 0-axiom). Odd (range) stage: its `Prod.swap` dual
-via Section 4e (`isMatching_map_swap` / `matchingCorr_map_swap` / `builtFrom_map_swap`) —
-NOT YET INSTANTIATED but every ingredient present.
+Stage-wise finite back-and-forth (Rogers §7.4). Even/odd moves DONE and VERIFIED 0-axiom
+(`augment_domain_step` Section 4k, `augment_range_step` Section 4l, both with pair-level edge
+preservation). The blocker is no longer atomic — it is which move to iterate:
+
+- **cons** (`domain_step_exists`): stable read-off (`mLookup_stable` applies directly to a cons)
+  but the anchor pair is not `BuiltFrom`, so `escape_exists` cannot bound the *next* chase.
+- **reroute** (`augment_domain_step`): restores `BuiltFrom` (chase re-runnable) but removes pairs,
+  breaking `mLookup_stable` → forces a finite-injury stabilization argument for the read-off.
 
 ## Attempt Count
 - Approaches tried: 1 (stage-wise back-and-forth), advancing across sessions.
 
 ## Blockers
-None at the atomic level — all per-stage obligations (termination, correspondence, BuiltFrom
-preservation, matching validity, monotonicity) are proved. Remaining work is the OUTER
-assembly: a well-founded stage function `σ : ℕ → List (ℕ×ℕ)`, its computability, and reading
-off a computable `ℕ ≃ ℕ` (totality on both sides from monotonicity + `firstMissing` coverage;
-injectivity from `mLookup_injOn` / `mLookup_stable`).
+Strategic fork, not a missing atomic lemma. The read-off cannot cite `mLookup_stable` mechanically
+under the rerouting move. Deciding between the two moves = deciding whether `escape_exists`
+(chase termination) can be reproved from a **cons-preserved** invariant weaker than `BuiltFrom`.
 
-## Next Action
-1. Derive the range-stage dual `augment_range_step` from `augment_domain_step` via the swap
-   duality (Section 4e).
-2. Define the stage recursion alternating the two steps, anchoring each stage at
-   `firstMissing (mDom σₛ)` (even) / `firstMissing (mRan σₛ)` (odd).
-3. Prove coverage (`k ∈ mDom` by stage `2k+1`, dual for range) from monotonicity + the
-   `firstMissing` progress lemmas (Section 4e).
-4. Read off `e : ℕ ≃ ℕ` via `mLookup` and prove `.Computable`; discharge `myhill_isomorphism`.
+## Next Action (revises prior 1–4; see knowledge.md 2026-07-03 r14 for the full reduction)
+1. **Test the fork first.** State `OrbitGEdged f g L` ("every occupied range point on a fresh
+   anchor's forward orbit sits on a g-edge") and check (a) it implies `escape_exists`'s conclusion
+   by pigeonhole on `(mRan L).length` (BuiltFrom-free: else two `f(orbit_k)` collide ⟹ a periodic
+   under g∘f), and (b) it survives a `domain_step_exists` cons of `(a, chaseTarget f g a N)`.
+2. If (b) holds → build the **extension-only** scheduler on `domain_step_exists`; read off `e` with
+   `mLookup` + `mLookup_stable` (values immutable); prove `.Computable`; discharge the sorry. Short path.
+3. If (b) fails (concrete counterexample) → finite injury is unavoidable; commit to the rerouting
+   scheduler and build the stabilization lemma (bound f↔g flips per point via the edge-preservation
+   conjuncts). Long path. Record the counterexample either way.
+4. Then coverage (`firstMissing_le_length`, `k ∈ mDom` by stage `2k+1`) + computable read-off.


### PR DESCRIPTION
## Summary

Analysis session on **schroeder-bernstein-oq-03** (Myhill Isomorphism Theorem — computable Schröder–Bernstein). **No verified Lean this session:** host disk at 3.9 GiB free, the `lean-mathlib-cache` Docker volume is cold (0 Mathlib oleans), and a build container is already running — a fresh `lake exe cache get` would saturate disk (the recurring blocker noted in prior sessions). This PR updates only the research knowledge base.

The `myhill_isomorphism` `sorry` is unchanged. The contribution is a **sharpening of the strategic fork** that has been open across several sessions.

## What was pinned down

The two per-stage moves already in `SchroederBernsteinOQ03.lean` are the two horns of one dilemma:

| move | read-off | `BuiltFrom` | consequence |
|------|----------|-------------|-------------|
| `domain_step_exists` (cons `(a,b)::L`) | **stable** (`mLookup_stable` applies to a cons) | **destroyed** (anchor pair is neither f- nor g-edge) | next chase has no `escape_exists` bound |
| `augment_domain_step` (`augPath ++ keptL`, removes g-edges) | **broken** (placed points re-partnered) | **preserved** | forces finite-injury stabilization |

The key correction to the prior session's Next Steps: the extension-only path does **not** stall on *anchor choice* — `domain_step_exists` already *is* the Rogers §7.4 extension-only move. It stalls because **`escape_exists` (chase termination) requires `BuiltFrom` on its input**, and a cons of the chase anchor destroys it.

## The decisive open question, now sharp

*Can `escape_exists` be reproved from an invariant a cons preserves?* If yes → extension-only scheduler with a free monotone read-off (short). If provably no → finite injury is necessary (long). The knowledge base records the BuiltFrom-free pigeonhole skeleton (termination reduces to excluding a trapped g∘f-cycle) and a concrete predicate `OrbitGEdged` to test next session — testing it resolves the fork either way.

## Files
- `research/problems/schroeder-bernstein-oq-03/knowledge.md` — new dated session section with the full analysis + reduction.
- `research/problems/schroeder-bernstein-oq-03/state.md` — Current Focus / Blockers / Next Action revised to the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)