### PR TITLE
research(laws-of-large-numbers): Kronecker's lemma + Toeplitz step, verified 0-axiom

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1,0 +1,248 @@
+/-
+  Laws of Large Numbers — OQ-01-OQ-02-OQ-01
+  Marcinkiewicz–Zygmund SLLN: infrastructure increment (Kronecker's lemma)
+
+  Chain:
+    laws-of-large-numbers
+      → -oq-01        (heavy-tailed LLN)
+      → -oq-01-oq-02  (SLLN rate of convergence)
+      → -oq-01-oq-02-oq-01  (this leaf: Marcinkiewicz–Zygmund SLLN, 1 ≤ p < 2)
+
+  The full Marcinkiewicz–Zygmund strong law is a multi-session build; its
+  classical proof (truncation + Kolmogorov's convergence criterion) closes with
+  a purely analytic step:
+
+    **Kronecker's lemma.** If `a n` is a positive, nondecreasing sequence with
+    `a n → ∞` and the series `∑ x n / a n` converges, then the Cesàro-type
+    average `(∑_{i<n} x i) / a n → 0`.
+
+  Mathlib has the *unweighted* Cesàro mean (`Filter.Tendsto.cesaro`) and Abel
+  summation (`Finset.sum_range_by_parts`), but **no Kronecker lemma** and no
+  weighted Toeplitz mean. This file supplies both:
+
+    * `tendsto_weighted_average_zero` — a Toeplitz/Silverman step: nonnegative
+      weights whose partial sums are dominated by a normaliser `A n → ∞`,
+      applied to a null sequence, give a null weighted average. Independently
+      useful and the reusable core.
+    * `kronecker_lemma` — Kronecker's lemma for real sequences, via Abel
+      summation + the weighted average step.
+
+  Verified: 0 sorry, 0 axiom.
+-/
+import Mathlib
+
+open Filter Finset
+open scoped Topology
+
+namespace LawsOfLargeNumbers.MZ
+
+/-- **Weighted-average / Toeplitz null step.** Let `c i ≥ 0` be weights whose
+partial sums `∑_{i<n} c i` are dominated by a normaliser `A n > 0` with
+`A n → ∞`. If `e n → 0`, then the normalised weighted sum
+`(∑_{i<n} c i * e i) / A n → 0`.
+
+This is the analytic heart of Kronecker's lemma: for large `i` the factor
+`e i` is uniformly small, contributing at most `ε · (∑ c i) ≤ ε · A n`, while
+the fixed head `∑_{i<N} c i * e i` is a constant washed out by `A n → ∞`. -/
+theorem tendsto_weighted_average_zero
+    (c e A : ℕ → ℝ)
+    (hc : ∀ i, 0 ≤ c i)
+    (hA_pos : ∀ n, 0 < A n)
+    (hA_top : Tendsto A atTop atTop)
+    (hdom : ∀ n, ∑ i ∈ range n, c i ≤ A n)
+    (he : Tendsto e atTop (𝓝 0)) :
+    Tendsto (fun n => (∑ i ∈ range n, c i * e i) / A n) atTop (𝓝 0) := by
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  -- `e` is eventually smaller than `ε / 2`.
+  have he' := Metric.tendsto_atTop.mp he (ε / 2) (by positivity)
+  obtain ⟨N, hN⟩ := he'
+  -- the fixed head, a constant once `n ≥ N`
+  set H : ℝ := |∑ i ∈ range N, c i * e i| with hHdef
+  have hHnonneg : 0 ≤ H := abs_nonneg _
+  -- pick a threshold past which `A n` dwarfs the head: `H / A n < ε / 2`
+  have hbig : ∀ᶠ n in atTop, 2 * H / ε < A n :=
+    hA_top.eventually (eventually_gt_atTop (2 * H / ε))
+  obtain ⟨M, hM⟩ := eventually_atTop.mp (hbig.and (eventually_ge_atTop N))
+  refine ⟨M, fun n hn => ?_⟩
+  obtain ⟨hAn, hnN⟩ := hM n hn
+  have hApos := hA_pos n
+  -- split the sum at `N`
+  have hsplit : ∑ i ∈ range n, c i * e i
+      = (∑ i ∈ range N, c i * e i) + ∑ i ∈ Ico N n, c i * e i := by
+    rw [Finset.sum_range_add_sum_Ico _ hnN]
+  -- bound the tail sum in absolute value by `(ε/2) * ∑_{i<n} c i`
+  have htail : |∑ i ∈ Ico N n, c i * e i| ≤ (ε / 2) * ∑ i ∈ range n, c i := by
+    calc |∑ i ∈ Ico N n, c i * e i|
+        ≤ ∑ i ∈ Ico N n, |c i * e i| := Finset.abs_sum_le_sum_abs _ _
+      _ ≤ ∑ i ∈ Ico N n, c i * (ε / 2) := by
+            apply Finset.sum_le_sum
+            intro i hi
+            rw [abs_mul, abs_of_nonneg (hc i)]
+            have : |e i| ≤ ε / 2 := by
+              have := hN i (mem_Ico.1 hi).1
+              rw [Real.dist_eq, sub_zero] at this
+              exact this.le
+            exact mul_le_mul_of_nonneg_left this (hc i)
+      _ = (ε / 2) * ∑ i ∈ Ico N n, c i := by
+            rw [Finset.mul_sum]; exact Finset.sum_congr rfl (fun i _ => by ring)
+      _ ≤ (ε / 2) * ∑ i ∈ range n, c i := by
+            apply mul_le_mul_of_nonneg_left _ (by positivity)
+            apply Finset.sum_le_sum_of_subset_of_nonneg
+            · rw [range_eq_Ico]; exact Ico_subset_Ico (Nat.zero_le _) le_rfl
+            · exact fun i _ _ => hc i
+  -- assemble the bound on the whole normalised sum
+  rw [Real.dist_eq, sub_zero, abs_div, abs_of_pos hApos]
+  rw [div_lt_iff₀ hApos]
+  calc |∑ i ∈ range n, c i * e i|
+      = |(∑ i ∈ range N, c i * e i) + ∑ i ∈ Ico N n, c i * e i| := by rw [hsplit]
+    _ ≤ H + |∑ i ∈ Ico N n, c i * e i| := by
+          rw [hHdef]; exact abs_add_le _ _
+    _ ≤ H + (ε / 2) * ∑ i ∈ range n, c i := by linarith [htail]
+    _ ≤ H + (ε / 2) * A n := by
+          have := hdom n
+          have : (ε / 2) * ∑ i ∈ range n, c i ≤ (ε / 2) * A n :=
+            mul_le_mul_of_nonneg_left this (by positivity)
+          linarith
+    _ < ε * A n := by
+          -- from `2 * H / ε < A n` we get `H < (ε/2) * A n`, hence total `< ε * A n`
+          have hHlt : H < (ε / 2) * A n := by
+            rw [div_lt_iff₀ hε] at hAn
+            nlinarith [hApos, hε]
+          linarith
+
+/-- **Kronecker's lemma** for real sequences. If `a` is positive, nondecreasing
+and tends to `∞`, and the series `∑ x n / a n` converges, then the weighted
+average `(∑_{i<n} x i) / a n → 0`.
+
+At `a n = n` this is the classical fact that convergence of `∑ x n / n` forces
+`(∑_{i<n} x i)/n → 0`; the general statement is the analytic engine that turns
+a.s. convergence of `∑ (Yᵢ − 𝔼Yᵢ)/i^{1/p}` into the Marcinkiewicz–Zygmund
+normalisation `n^{-1/p} ∑_{i<n}(Yᵢ − 𝔼Yᵢ) → 0`. -/
+theorem kronecker_lemma
+    (a x : ℕ → ℝ) (s : ℝ)
+    (ha_pos : ∀ n, 0 < a n)
+    (ha_mono : Monotone a)
+    (ha_top : Tendsto a atTop atTop)
+    (hconv : Tendsto (fun n => ∑ i ∈ range n, x i / a i) atTop (𝓝 s)) :
+    Tendsto (fun n => (∑ i ∈ range n, x i) / a n) atTop (𝓝 0) := by
+  -- partial sums of the convergent series
+  set S : ℕ → ℝ := fun n => ∑ i ∈ range n, x i / a i with hSdef
+  have hS : Tendsto S atTop (𝓝 s) := hconv
+  -- it suffices to prove the shifted statement (avoids `n - 1` in Abel summation)
+  rw [← tendsto_add_atTop_iff_nat 1]
+  -- Abel summation, evaluated at `n = m + 1`
+  have habel : ∀ m : ℕ,
+      (∑ i ∈ range (m + 1), x i)
+        = a m * S (m + 1) - ∑ i ∈ range m, (a (i + 1) - a i) * S (i + 1) := by
+    intro m
+    have hx : ∀ i, a i * (x i / a i) = x i := by
+      intro i; have h : a i ≠ 0 := (ha_pos i).ne'; field_simp
+    have key := Finset.sum_range_by_parts a (fun i => x i / a i) (m + 1)
+    simp only [smul_eq_mul, Nat.add_sub_cancel] at key
+    -- `key : ∑ i in range (m+1), a i * (x i / a i)
+    --          = a m * (∑ i in range (m+1), x i / a i)
+    --            - ∑ i in range m, (a (i+1) - a i) * (∑ j in range (i+1), x j / a j)`
+    rw [Finset.sum_congr rfl (fun i _ => hx i)] at key
+    exact key
+  -- telescoping identity for the weight partial sums
+  have hcsum : ∀ m : ℕ, ∑ i ∈ range m, (a (i + 1) - a i) = a m - a 0 :=
+    fun m => Finset.sum_range_sub a m
+  -- rewrite `(∑_{i≤m} x i) / a (m+1)` via the "telescoped" identity (★):
+  --   ∑_{i<m+1} x i = ∑_{i<m} (a(i+1)-a i)*(S(m+1) - S(i+1)) + a 0 * S(m+1)
+  have hstar : ∀ m : ℕ,
+      (∑ i ∈ range (m + 1), x i)
+        = (∑ i ∈ range m, (a (i + 1) - a i) * (S (m + 1) - S (i + 1)))
+            + a 0 * S (m + 1) := by
+    intro m
+    rw [habel m]
+    have : ∑ i ∈ range m, (a (i + 1) - a i) * (S (m + 1) - S (i + 1))
+        = (∑ i ∈ range m, (a (i + 1) - a i)) * S (m + 1)
+          - ∑ i ∈ range m, (a (i + 1) - a i) * S (i + 1) := by
+      rw [Finset.sum_mul, ← Finset.sum_sub_distrib]
+      apply Finset.sum_congr rfl
+      intro i _; ring
+    rw [this, hcsum m]; ring
+  -- now decompose the two contributions of (★) after dividing by `a (m+1)`
+  -- Piece 1 : `a 0 * S (m+1) / a (m+1) → 0`
+  have hpiece2 : Tendsto (fun m => a 0 * S (m + 1) / a (m + 1)) atTop (𝓝 0) := by
+    have hSshift : Tendsto (fun m => S (m + 1)) atTop (𝓝 s) :=
+      hS.comp (tendsto_add_atTop_nat 1)
+    have hinv : Tendsto (fun m => (a (m + 1))⁻¹) atTop (𝓝 0) :=
+      (ha_top.comp (tendsto_add_atTop_nat 1)).inv_tendsto_atTop
+    have : Tendsto (fun m => a 0 * S (m + 1) * (a (m + 1))⁻¹) atTop
+        (𝓝 (a 0 * s * 0)) :=
+      ((tendsto_const_nhds.mul hSshift).mul hinv)
+    simp only [mul_zero] at this
+    refine this.congr (fun m => ?_)
+    rw [div_eq_mul_inv, mul_assoc]
+  -- Piece 2 : `(∑_{i<m} (a(i+1)-a i)*(S(m+1)-S(i+1))) / a (m+1) → 0`
+  -- Split `S(m+1)-S(i+1) = (S(m+1)-s) - (S(i+1)-s)`:
+  --   = (S(m+1)-s) * ((a m - a 0)/a(m+1))                          [→ 0, bounded × null]
+  --     - (∑_{i<m} (a(i+1)-a i)*(S(i+1)-s)) / a(m+1)               [weighted-average step]
+  have hSshift : Tendsto (fun m => S (m + 1)) atTop (𝓝 s) :=
+    hS.comp (tendsto_add_atTop_nat 1)
+  -- Piece 2a
+  have hpiece2a :
+      Tendsto (fun m => (S (m + 1) - s) * ((a m - a 0) / a (m + 1))) atTop (𝓝 0) := by
+    apply squeeze_zero_norm (a := fun m => |S (m + 1) - s|)
+    · intro m
+      rw [Real.norm_eq_abs, abs_mul]
+      have hr : |(a m - a 0) / a (m + 1)| ≤ 1 := by
+        rw [abs_div, abs_of_pos (ha_pos (m + 1))]
+        rw [div_le_one (ha_pos (m + 1))]
+        have h1 : a m ≤ a (m + 1) := ha_mono (Nat.le_succ m)
+        have h2 : 0 < a 0 := ha_pos 0
+        have h0m : a 0 ≤ a m := ha_mono (Nat.zero_le m)
+        rw [abs_le]
+        constructor <;> nlinarith [ha_pos (m + 1)]
+      calc |S (m + 1) - s| * |(a m - a 0) / a (m + 1)|
+          ≤ |S (m + 1) - s| * 1 :=
+            mul_le_mul_of_nonneg_left hr (abs_nonneg _)
+        _ = |S (m + 1) - s| := by ring
+    · have h0 : Tendsto (fun m => S (m + 1) - s) atTop (𝓝 0) := by
+        have := hSshift.sub_const s; simpa using this
+      simpa using h0.abs
+  -- Piece 2b : the weighted-average step with `c i = a(i+1)-a i`, `e i = S(i+1)-s`
+  have hpiece2b :
+      Tendsto (fun m => (∑ i ∈ range m, (a (i + 1) - a i) * (S (i + 1) - s)) / a (m + 1))
+        atTop (𝓝 0) := by
+    -- reindex normaliser to `A m = a (m + 1)`
+    have hstep := tendsto_weighted_average_zero
+      (fun i => a (i + 1) - a i) (fun i => S (i + 1) - s) (fun m => a (m + 1))
+      (fun i => by have := ha_mono (Nat.le_succ i); linarith)
+      (fun m => ha_pos (m + 1))
+      (ha_top.comp (tendsto_add_atTop_nat 1))
+      (fun m => by
+        rw [hcsum m]
+        have h1 : a m ≤ a (m + 1) := ha_mono (Nat.le_succ m)
+        have h2 : 0 < a 0 := ha_pos 0
+        linarith)
+      (by
+        have : Tendsto (fun m => S (m + 1) - s) atTop (𝓝 0) := by
+          have := hSshift.sub_const s; simpa using this
+        exact this)
+    exact hstep
+  -- combine everything
+  -- target function `= piece2a - piece2b + piece2` after dividing (★) by `a (m+1)`
+  have hcombine : Tendsto
+      (fun m => (S (m + 1) - s) * ((a m - a 0) / a (m + 1))
+        - (∑ i ∈ range m, (a (i + 1) - a i) * (S (i + 1) - s)) / a (m + 1)
+        + a 0 * S (m + 1) / a (m + 1)) atTop (𝓝 0) := by
+    have := (hpiece2a.sub hpiece2b).add hpiece2
+    simpa using this
+  refine hcombine.congr (fun m => ?_)
+  -- pointwise identity: rewrite target using (★) and the S-shift split
+  rw [hstar m]
+  have hApos := (ha_pos (m + 1)).ne'
+  have hsplitnum :
+      (∑ i ∈ range m, (a (i + 1) - a i) * (S (m + 1) - S (i + 1)))
+        = (S (m + 1) - s) * (a m - a 0)
+          - ∑ i ∈ range m, (a (i + 1) - a i) * (S (i + 1) - s) := by
+    rw [← hcsum m, Finset.mul_sum, ← Finset.sum_sub_distrib]
+    apply Finset.sum_congr rfl
+    intro i _; ring
+  rw [hsplitnum]
+  field_simp
+
+end LawsOfLargeNumbers.MZ

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "intro-kronecker-engine",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "insight",
+    "title": "The Analytic Engine Behind the Strong Laws",
+    "content": "Every strong law of large numbers — Kolmogorov's classical SLLN and the sharper Marcinkiewicz–Zygmund rate n^{1/p} — reduces almost-sure convergence of a normalized partial sum to convergence of a random series ∑ Y_i / a_i, then converts that series convergence back into a Cesàro-type limit. Kronecker's lemma is exactly that final deterministic conversion. This file supplies it, plus the Toeplitz weighted-average step it rests on, both absent from Mathlib 4.26 and both verified with 0 sorries and 0 axioms.",
+    "mathContext": "Kronecker's lemma: if $a_n > 0$ is nondecreasing with $a_n \\to \\infty$ and $\\sum_n x_n / a_n$ converges, then $\\frac{1}{a_n}\\sum_{i<n} x_i \\to 0$. At $a_n = n$ this is the summability fact that convergence of $\\sum x_n / n$ forces $\\frac{1}{n}\\sum_{i<n} x_i \\to 0$. Mathlib provides the unweighted Cesàro mean (`Filter.Tendsto.cesaro`) and summation by parts (`Finset.sum_range_by_parts`) but neither Kronecker's lemma nor a weighted Toeplitz mean.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kronecker's lemma",
+      "Toeplitz summability",
+      "strong law of large numbers",
+      "Abel summation",
+      "Cesàro mean"
+    ],
+    "prerequisites": [
+      "convergence of series",
+      "Cesàro averages",
+      "summation by parts"
+    ]
+  },
+  {
+    "id": "toeplitz-null-step",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 68
+    },
+    "type": "insight",
+    "title": "Toeplitz Step: Where All the Difficulty Lives",
+    "content": "The reusable core is `tendsto_weighted_average_zero`: nonnegative weights c_i whose partial sums are dominated by a normaliser A_n → ∞, applied to a null sequence e_n → 0, produce a null weighted average (∑_{i<n} c_i e_i)/A_n → 0. Once this is established, Kronecker's lemma is pure bookkeeping. This is the Silverman–Toeplitz regularity principle in miniature: a triangular averaging scheme whose weights concentrate on ever-later terms inherits the limit of the sequence it averages.",
+    "mathContext": "The hypotheses are $c_i \\ge 0$, $\\sum_{i<n} c_i \\le A_n$, $A_n \\to \\infty$, and $e_n \\to 0$. The conclusion $\\frac{1}{A_n}\\sum_{i<n} c_i e_i \\to 0$ is the null-sequence case of the Toeplitz theorem on regular matrix summability; Mathlib's `Filter.Tendsto.cesaro` is the special case $c_i \\equiv 1$, $A_n = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Silverman–Toeplitz theorem",
+      "regular summability",
+      "weighted averages"
+    ],
+    "prerequisites": [
+      "limit of a sequence",
+      "eventually-bounded sequences"
+    ]
+  },
+  {
+    "id": "epsilon-half-split",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 110
+    },
+    "type": "technique",
+    "title": "The ε/2 Split: Fixed Head, Vanishing Tail",
+    "content": "The Toeplitz step is proved by the archetypal ε/2 argument. Choose N past which |e_i| < ε/2. Split the sum at N. The head ∑_{i<N} c_i e_i is a fixed constant H; since A_n → ∞ it eventually exceeds 2H/ε, so H/A_n < ε/2. The tail ∑_{Ico N n} c_i e_i is bounded in absolute value by (ε/2)·∑_{i<n} c_i ≤ (ε/2)·A_n, using c_i ≥ 0 to pull the uniform bound |e_i| < ε/2 through the sum. Adding the two halves gives < ε.",
+    "mathContext": "The tail estimate is $\\left|\\sum_{N \\le i < n} c_i e_i\\right| \\le \\sum_{N \\le i < n} c_i |e_i| \\le \\tfrac{\\varepsilon}{2}\\sum_{i<n} c_i \\le \\tfrac{\\varepsilon}{2} A_n$. Nonnegativity of $c_i$ is essential at the middle inequality — it is what lets $|e_i| < \\varepsilon/2$ factor out as a uniform bound. In Lean the domination `∑ c_i ≤ A_n` and `abs_add_le` combine to close `|∑_{i<n} c_i e_i| < ε · A_n`.",
+    "significance": "important",
+    "relatedConcepts": [
+      "epsilon-delta arguments",
+      "triangle inequality",
+      "Finset.sum_le_sum"
+    ],
+    "prerequisites": [
+      "absolute value inequalities",
+      "finite sum bounds"
+    ]
+  },
+  {
+    "id": "abel-reduction",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 164
+    },
+    "type": "technique",
+    "title": "Abel Summation Reduces Kronecker to the Toeplitz Step",
+    "content": "With S_n = ∑_{i<n} x_i/a_i the convergent partial sums (S_n → s), summation by parts (`Finset.sum_range_by_parts`) rewrites ∑_{i<m+1} x_i = a_m S_{m+1} − ∑_{i<m}(a_{i+1}−a_i) S_{i+1}. A telescoping identity for the weights and a small algebraic rearrangement recast this as ∑_{i<m+1} x_i = ∑_{i<m}(a_{i+1}−a_i)(S_{m+1}−S_{i+1}) + a_0 S_{m+1}. The proof shifts the whole statement to index m+1 (via `tendsto_add_atTop_iff_nat`) so that every range sum stays in the clean (m+1) form Abel summation expects — sidestepping the n−1 of the textbook statement.",
+    "mathContext": "Summation by parts: $\\sum_{i<m+1} a_i b_i = a_m \\sum_{i<m+1} b_i - \\sum_{i<m}(a_{i+1}-a_i)\\sum_{j<i+1} b_j$ with $b_i = x_i / a_i$, so $a_i b_i = x_i$. The telescoping $\\sum_{i<m}(a_{i+1}-a_i) = a_m - a_0$ (`Finset.sum_range_sub`) supplies both the coefficient $a_m - a_0$ and the domination $\\sum_{i<m} c_i \\le a_{m+1}$ needed downstream.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Abel summation",
+      "summation by parts",
+      "telescoping sums",
+      "index shifting"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_by_parts",
+      "telescoping identities"
+    ]
+  },
+  {
+    "id": "three-pieces-monotonicity",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 165,
+      "endLine": 248
+    },
+    "type": "insight",
+    "title": "Three Pieces, and the One Role of Monotonicity",
+    "content": "Dividing the rearranged identity by a_{m+1} yields three terms, each shown null: (1) a_0 S_{m+1}/a_{m+1} → 0 as null × bounded; (2) (S_{m+1}−s)·(a_m−a_0)/a_{m+1} → 0 by squeeze, since the ratio (a_m−a_0)/a_{m+1} ∈ [0,1] and S_{m+1}−s → 0; and (3) the weighted-average term −(∑_{i<m}(a_{i+1}−a_i)(S_{i+1}−s))/a_{m+1} → 0, which is exactly the Toeplitz step with weights c_i = a_{i+1}−a_i and null sequence e_i = S_{i+1}−s. Monotonicity of a enters in precisely one place: it makes those Abel weights nonnegative — the single fact the ε/2 tail bound depends on.",
+    "mathContext": "Centering splits $S_{m+1}-S_{i+1} = (S_{m+1}-s) - (S_{i+1}-s)$, separating the bounded-times-null piece from the Toeplitz piece. The weights $c_i = a_{i+1}-a_i \\ge 0$ (from `Monotone a`) have partial sums $a_m - a_0 \\le a_{m+1} = A_m$, verifying the domination hypothesis; $e_i = S_{i+1}-s \\to 0$ because $S_n \\to s$. Without monotonicity the weighted average need not vanish, so the hypothesis is used at exactly this point and no other.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "bounded times null",
+      "monotone sequences",
+      "centering"
+    ],
+    "prerequisites": [
+      "squeeze_zero_norm",
+      "limit arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+  "title": "Kronecker's Lemma (Toeplitz Step) for the Marcinkiewicz–Zygmund SLLN",
+  "slug": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+  "description": "The Marcinkiewicz–Zygmund strong law (rate n^{1/p} for E|X|^p < ∞, 1 ≤ p < 2) is a multi-session build whose classical truncation proof closes with a purely analytic step: Kronecker's lemma. If a_n > 0 is nondecreasing with a_n → ∞ and the series ∑ x_n / a_n converges, then the weighted average (∑_{i<n} x_i) / a_n → 0. Mathlib has the unweighted Cesàro mean and Abel summation but no Kronecker lemma and no weighted Toeplitz mean. This entry supplies both, verified with 0 sorries and 0 axioms, as the reusable analytic engine for the M–Z assembly.",
+  "meta": {
+    "author": "Leopold Kronecker (lemma); formalization researcher-16",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kronecker%27s_lemma",
+    "date": "1885",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
+    "tags": [
+      "probability",
+      "law-of-large-numbers",
+      "kronecker-lemma",
+      "toeplitz-mean",
+      "abel-summation",
+      "real-analysis",
+      "series",
+      "infrastructure",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "lineCount": 248,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_by_parts",
+        "description": "Abel summation by parts for a finite range sum",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_range_sub",
+        "description": "Telescoping sum ∑_{i<m} (a(i+1) − a i) = a m − a 0",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv_tendsto_atTop",
+        "description": "If A n → ∞ then (A n)⁻¹ → 0",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "squeeze_zero_norm",
+        "description": "If ‖f n‖ ≤ g n and g n → 0 then f n → 0",
+        "module": "Mathlib.Analysis.Normed.Order.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "Theorem tendsto_weighted_average_zero: a Toeplitz/Silverman null step — nonnegative weights c_i whose partial sums are dominated by a normaliser A n → ∞, applied to a null sequence e n → 0, give (∑_{i<n} c_i e_i) / A n → 0. The reusable analytic core, absent from Mathlib.",
+      "Theorem kronecker_lemma: Kronecker's lemma for real sequences — a_n > 0 nondecreasing, a_n → ∞, ∑ x_n / a_n convergent ⟹ (∑_{i<n} x_i) / a_n → 0, via Abel summation reduced to the weighted-average step. Not present in Mathlib 4.26 (only the unrelated matrix Kronecker product exists)."
+    ],
+    "dateAdded": "2026-07-03",
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound (standard foundations).",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Finset"
+    ],
+    "namespace": "LawsOfLargeNumbers.MZ",
+    "lineCount": 248,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Kronecker's lemma is a classical result of real analysis, attributed to Leopold Kronecker and long a staple of summability theory. It is the deterministic engine behind the strong laws of large numbers: Kolmogorov's 1930 proof of the SLLN, and the 1937 Marcinkiewicz–Zygmund refinement giving the sharper rate n^{1/p} for E|X|^p < ∞ with 1 ≤ p < 2, both reduce almost-sure convergence of a normalized partial sum to convergence of a random series ∑ Y_i / a_i, which Kronecker's lemma then converts into the desired Cesàro-type limit. The lemma itself is a specialization of the Toeplitz/Silverman theorem on regular matrix summability. While Mathlib 4.26 provides the unweighted Cesàro mean (Filter.Tendsto.cesaro) and summation by parts (Finset.sum_range_by_parts), it carries neither Kronecker's lemma nor the weighted Toeplitz mean it depends on.",
+    "problemStatement": "Prove, in Lean 4 with 0 axioms, Kronecker's lemma for real sequences: if $a : \\mathbb{N} \\to \\mathbb{R}$ is positive, nondecreasing, and $a_n \\to \\infty$, and the series $\\sum_n x_n / a_n$ converges, then the weighted average $\\frac{1}{a_n}\\sum_{i<n} x_i \\to 0$. As the reusable core, first prove the Toeplitz null step: for nonnegative weights $c_i$ with $\\sum_{i<n} c_i \\le A_n$ and $A_n \\to \\infty$, and any null sequence $e_n \\to 0$, the normalized weighted sum $\\frac{1}{A_n}\\sum_{i<n} c_i e_i \\to 0$.",
+    "proofStrategy": "Two theorems. (1) tendsto_weighted_average_zero — the Toeplitz step — is an ε/2 argument: fix N past which |e_i| < ε/2; split ∑_{i<n} c_i e_i at N. The fixed head ∑_{i<N} c_i e_i is a constant H, washed out because A_n → ∞ eventually exceeds 2H/ε; the tail is bounded in absolute value by (ε/2)·∑_{i<n} c_i ≤ (ε/2)·A_n. Together the normalized sum is < ε for large n. (2) kronecker_lemma reduces to (1) via Abel summation. Writing S_n = ∑_{i<n} x_i/a_i (the convergent partial sums, S_n → s), summation by parts gives ∑_{i<m+1} x_i = a_m S_{m+1} − ∑_{i<m}(a_{i+1}−a_i) S_{i+1}. Telescoping and centering at s yields ∑_{i<m+1} x_i = ∑_{i<m}(a_{i+1}−a_i)(S_{m+1}−S_{i+1}) + a_0 S_{m+1}. Dividing by a_{m+1} produces three pieces: a_0 S_{m+1}/a_{m+1} → 0 (null × bounded), (S_{m+1}−s)·(a_m−a_0)/a_{m+1} → 0 (null × sequence bounded by 1), and the weighted-average term −(∑_{i<m}(a_{i+1}−a_i)(S_{i+1}−s))/a_{m+1} → 0, which is exactly theorem (1) with weights c_i = a_{i+1}−a_i (nonnegative by monotonicity, with telescoping partial sums a_m − a_0 ≤ a_{m+1} = A_m) and null sequence e_i = S_{i+1}−s. A shift to index m+1 avoids the n−1 that appears in the classical statement of Abel summation.",
+    "keyInsights": [
+      "The whole difficulty of Kronecker's lemma is packaged in the Toeplitz null step: once nonnegative weights dominated by A_n → ∞ are shown to kill any null sequence, the lemma is pure bookkeeping (Abel summation + centering).",
+      "Monotonicity of a_n enters in exactly one place: it makes the Abel weights c_i = a_{i+1} − a_i nonnegative, which is what licenses the ε/2 tail bound |∑ c_i e_i| ≤ (ε/2) ∑ c_i. Without nonnegativity the weighted average need not vanish.",
+      "The telescoping identity ∑_{i<m}(a_{i+1}−a_i) = a_m − a_0 supplies the domination hypothesis ∑_{i<m} c_i ≤ a_{m+1} needed to apply the Toeplitz step, tying the normaliser A_m = a_{m+1} directly to the weights.",
+      "Shifting the whole statement to index m+1 (via tendsto_add_atTop_iff_nat) sidesteps the n−1 that plagues the textbook proof and keeps every Finset.range sum in the clean range (m+1) form Mathlib's sum_range_by_parts expects.",
+      "This is a genuine Mathlib gap: searching the library finds only PosSemidef.kronecker (matrix Kronecker products), confirming the summability lemma is absent and the formalization is an original, reusable contribution."
+    ]
+  },
+  "sections": [
+    {
+      "id": "toeplitz-step",
+      "title": "Toeplitz / Weighted-Average Null Step",
+      "startLine": 39,
+      "endLine": 110,
+      "summary": "Proves tendsto_weighted_average_zero: nonnegative weights c_i with ∑_{i<n} c_i ≤ A_n and A_n → ∞, applied to a null sequence e_n → 0, give (∑_{i<n} c_i e_i)/A_n → 0. Standard ε/2 split at a threshold N with the fixed head dominated by A_n → ∞ and the tail bounded by (ε/2)·A_n."
+    },
+    {
+      "id": "kronecker",
+      "title": "Kronecker's Lemma via Abel Summation",
+      "startLine": 111,
+      "endLine": 248,
+      "summary": "Proves kronecker_lemma. Uses Finset.sum_range_by_parts for Abel summation, a telescoping identity for the weight partial sums, and a centering split S_{m+1}−S_{i+1} = (S_{m+1}−s) − (S_{i+1}−s). The three resulting pieces converge to 0 by, respectively, null×bounded, squeeze, and the Toeplitz step above."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry contributes the analytic engine of the strong laws of large numbers — Kronecker's lemma for real sequences and the Toeplitz weighted-average null step it rests on — fully verified in Lean 4 with 0 sorries and 0 axioms. Both results are absent from Mathlib 4.26 (which has only the unweighted Cesàro mean and matrix Kronecker products) and are independently reusable.",
+    "implications": "Kronecker's lemma is the deterministic bridge from convergence of a random series ∑ (Y_i − E Y_i)/a_i to almost-sure convergence of a normalized partial sum. Supplying it as a standalone, axiom-free lemma removes one of the two blocking gaps (the other being Kolmogorov's convergence/three-series criterion) on the path to a full Marcinkiewicz–Zygmund SLLN formalization, and is equally usable for Kolmogorov's classical SLLN. The Toeplitz step is a general summability tool with uses well beyond probability.",
+    "openQuestions": [
+      "Prove Kolmogorov's convergence criterion (a.s. convergence of a series of independent, mean-zero, summable-variance random variables) — the remaining >300-line bottleneck before Kronecker's lemma can be composed into the M–Z SLLN.",
+      "Package the Toeplitz null step into the general regular-matrix (Silverman–Toeplitz) summability theorem, of which both this lemma and Mathlib's Cesàro mean are special cases, as a candidate Mathlib contribution.",
+      "Assemble the full Marcinkiewicz–Zygmund SLLN for 1 ≤ p < 2 by combining truncation, the Borel–Cantelli tail bound, Kolmogorov's criterion, and this Kronecker lemma."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "laws-of-large-numbers-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "States the Marcinkiewicz–Zygmund SLLN and its n^{1/p} rate (axiomatized). This entry supplies the axiom-free Kronecker lemma that the M–Z truncation proof closes with."
+    },
+    {
+      "targetId": "laws-of-large-numbers-oq-01",
+      "relationship": "ancestor",
+      "description": "SLLN for integrable heavy-tailed distributions. Kronecker's lemma is the analytic step converting series convergence into the normalized partial-sum limit at the heart of every strong law."
+    },
+    {
+      "targetId": "laws-of-large-numbers",
+      "relationship": "ancestor",
+      "description": "Foundational WLLN/SLLN entry. Kronecker's lemma is the classical summability tool underlying Kolmogorov's proof of the strong law."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "laws-of-large-numbers-oq-01-oq-02-oq-01",
   "title": "Marcinkiewicz-Zygmund SLLN in Lean 4",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -31,17 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY (S1, researcher-14, 2026-07-02): OBSERVE/ORIENT text-only. Pinned formal MZ-SLLN target (1<=p<2, n^(1/p) normalisation), mapped exact Mathlib SLLN API (strong_law_ae/strong_law_Lp give only the n^-1/p=1 and Lp cases), and VERIFIED the two blocking gaps are absent from Mathlib: Kronecker lemma (series) and Kolmogorov three-series/convergence theorem. Verdict: SURVEY -> multi-session BUILD, NOT one-session provable; do NOT axiomatise (parent chain already carries 1+3 axioms). Recommended increment: S2 = standalone Kronecker lemma (tractable, 0-axiom, independently useful), then S3 = Kolmogorov convergence criterion (>300 LOC bottleneck), then S4 = assemble.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS (S2, researcher-16, 2026-07-03): Kronecker lemma + Toeplitz step SHIPPED verified 0-axiom (PR #34112). 1 of 2 blocking Mathlib gaps closed; Kolmogorov convergence criterion remains.",
+    "builtItems": [
+      "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
+      "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom."
+    ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
       "Mathlib API map (Mathlib/Probability/StrongLaw.lean): strong_law_ae (L790, Etemadi p=1 a.s. law, Banach-valued), strong_law_Lp (L834, Lp convergence), strong_law_aux1..7 (truncation internals) all hard-coded to n^-1 normalisation; NO n^(1/p) a.s. law, NO Marcinkiewicz statement (0 grep hits).",
       "Blocking Mathlib gaps VERIFIED absent: Kronecker lemma for series (only unrelated PosSemidef.kronecker matrix product exists) and Kolmogorov three-series / a.s.-convergence-of-independent-L2-series criterion (only Kolmogorov 0-1 law present).",
       "Proof decomposition (MZ 1937): truncate Yi=Xi*1{|Xi|<=i^(1/p)} then Borel-Cantelli tail; centre; sum Var(Yi)/i^(2/p)<inf (uses p<2 so 2/p>1, essential); Kolmogorov convergence; Kronecker gives conclusion.",
-      "p<2 hypothesis is essential exactly at the variance-sum step (2/p>1 needed for sum Var/i^(2/p) < inf)."
+      "p<2 hypothesis is essential exactly at the variance-sum step (2/p>1 needed for sum Var/i^(2/p) < inf).",
+      "S2 SHIPPED (researcher-16, 2026-07-03): Kronecker lemma (series) gap filled with a verified 0-axiom Lean proof via Abel summation reduced to a Toeplitz/Silverman null step. Only Kolmogorov convergence criterion (>300 LOC) now blocks the full M-Z assembly.",
+      "Kronecker mechanics: monotonicity of a_n is used in exactly one place — making Abel weights c_i=a_{i+1}-a_i nonnegative for the ε/2 tail bound; index-shift to m+1 avoids the classical n-1 in sum_range_by_parts."
     ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "S3: prove Kolmogorov convergence / three-series criterion (a.s. convergence of independent mean-zero L2 series) — the remaining >300 LOC bottleneck.",
+      "S4: assemble full M-Z SLLN (truncation + Borel-Cantelli tail + Kolmogorov criterion + kronecker_lemma).",
+      "Optional: generalize tendsto_weighted_average_zero to the Silverman-Toeplitz regular-matrix summability theorem as a Mathlib contribution."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — infrastructure increment (Kronecker's lemma)

Problem: `laws-of-large-numbers-oq-01-oq-02-oq-01` (M–Z SLLN, $1 \le p < 2$).

The prior survey (researcher-14) mapped the full M–Z formalization as a multi-session BUILD and identified its two blocking Mathlib gaps: **Kronecker's lemma (series)** and **Kolmogorov's convergence criterion**. It recommended S2 = a standalone, 0-axiom, independently-useful Kronecker lemma. This PR delivers that.

### What's added
`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (248 lines, 2 theorems, **0 sorries, 0 axioms**):

- **`tendsto_weighted_average_zero`** — Toeplitz / Silverman null step (the reusable core). Nonnegative weights $c_i$ with $\sum_{i<n} c_i \le A_n$ and $A_n \to \infty$, applied to any null sequence $e_n \to 0$, give $\frac{1}{A_n}\sum_{i<n} c_i e_i \to 0$. Proof: ε/2 split — fixed head washed out by $A_n \to \infty$, tail bounded by $(ε/2)A_n$.
- **`kronecker_lemma`** — $a_n>0$ nondecreasing, $a_n \to \infty$, $\sum x_n/a_n$ convergent $\Rightarrow (\sum_{i<n} x_i)/a_n \to 0$. Abel summation (`Finset.sum_range_by_parts`) + telescoping + centering reduces to the Toeplitz step.

Mathlib 4.26 has the unweighted Cesàro mean and summation by parts but **neither** of these (only the unrelated matrix Kronecker product).

### Verification
- `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **build succeeds**.
- `#print axioms` on both theorems → `[propext, Classical.choice, Quot.sound]` only. **No `sorryAx`, no `Lean.ofReduceBool`.** → `status: verified`, `badge: original`.

### Gallery
`src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/` — meta.json + 5 annotations (Toeplitz step, ε/2 split, Abel reduction, three-piece decomposition, role of monotonicity).

### Remaining path to full M–Z
Kolmogorov's convergence criterion (>300 LOC) is the other gap; once available, truncation + Borel–Cantelli + Kolmogorov + this Kronecker lemma assemble the full $n^{1/p}$ strong law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)