### PR TITLE
research(laws-of-large-numbers): Silverman–Toeplitz summability theorem, verified 0-axiom

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01OQ02.lean
@@ -1,0 +1,190 @@
+/-
+  Laws of Large Numbers — OQ-01-OQ-02-OQ-01-OQ-02
+  Marcinkiewicz–Zygmund SLLN: the Silverman–Toeplitz summability engine
+
+  Chain:
+    laws-of-large-numbers
+      → -oq-01              (heavy-tailed LLN)
+      → -oq-01-oq-02        (SLLN rate of convergence)
+      → -oq-01-oq-02-oq-01  (Marcinkiewicz–Zygmund SLLN: Kronecker's lemma)
+      → -oq-01-oq-02-oq-01-oq-02  (this leaf: package the Toeplitz null step into
+                                    the general Silverman–Toeplitz theorem)
+
+  The Kronecker-lemma entry (`LawsOfLargeNumbersOQ01OQ02OQ01.lean`) proved a single
+  *nonnegative-weight* Toeplitz null step, `tendsto_weighted_average_zero`, and used
+  it to close Kronecker's lemma.  Its second open question asked to package that step
+  into the general **Silverman–Toeplitz regular-matrix summability theorem**, of which
+  both that lemma and Mathlib's unweighted Cesàro mean are special cases.  This file
+  supplies it.
+
+  A (triangular) **summability matrix** `A : ℕ → ℕ → ℝ` transforms a sequence `x` into
+  `y n = ∑_{k<n} A n k * x k`.  Toeplitz's classical characterisation says the method
+  is **regular** — it preserves every limit — as soon as
+
+    * (col) every column tends to `0`      : `∀ k, A · k → 0`,
+    * (bnd) row absolute sums are bounded   : `∀ n, ∑_{k<n} |A n k| ≤ C`,
+    * (row) row sums tend to `1`            : `∑_{k<n} A n k → 1`.
+
+  This file proves both the null form and the full regular (limit-preserving) form,
+  and derives the Cesàro mean as the special case `A n k = 1/n`, exhibiting the
+  general engine that subsumes the earlier signed/normaliser Toeplitz step
+  (its `A n k = c k / A_norm n`, with `C = 1`).
+
+  Verified: 0 sorry, 0 axiom.
+-/
+import Mathlib
+
+open Filter Finset
+open scoped Topology
+
+namespace LawsOfLargeNumbers.Toeplitz
+
+/-- **Toeplitz null step (general, signed weights).** Let `A : ℕ → ℕ → ℝ` be a
+triangular summability matrix whose row absolute sums are bounded by `C`
+(`∑_{k<n} |A n k| ≤ C`) and each of whose columns tends to `0`
+(`A · k → 0`). If `e k → 0`, then the transformed sequence
+`∑_{k<n} A n k * e k → 0`.
+
+This generalises the earlier nonnegative-weight step
+(`tendsto_weighted_average_zero`): there `A n k = c k / A_norm n` with `c ≥ 0` and
+`∑_{k<n} c k ≤ A_norm n`, giving row absolute sums `≤ 1` and columns
+`c k / A_norm n → 0`.  Here the weights may have arbitrary sign; only the two
+Toeplitz conditions are used.
+
+Proof: given `ε`, past some `N` the factor `e k` is uniformly below
+`ε / (2(C+1))`, so the tail contributes at most `(ε/2(C+1)) · C < ε/2`; the fixed
+head `∑_{k<N} A n k * e k` is a finite sum of columns, each `→ 0`, hence `< ε/2`
+eventually. -/
+theorem tendsto_toeplitz_zero
+    (A : ℕ → ℕ → ℝ) (e : ℕ → ℝ) (C : ℝ)
+    (hbnd : ∀ n, ∑ k ∈ range n, |A n k| ≤ C)
+    (hcol : ∀ k, Tendsto (fun n => A n k) atTop (𝓝 0))
+    (he : Tendsto e atTop (𝓝 0)) :
+    Tendsto (fun n => ∑ k ∈ range n, A n k * e k) atTop (𝓝 0) := by
+  have hC : (0 : ℝ) ≤ C := by have := hbnd 0; simpa using this
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  set δ : ℝ := ε / (2 * (C + 1)) with hδdef
+  have hδpos : 0 < δ := by rw [hδdef]; positivity
+  -- `e` is eventually below `δ`
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp he δ hδpos
+  -- the head, a finite sum of columns, tends to `0`
+  have hhead : Tendsto (fun n => ∑ k ∈ range N, A n k * e k) atTop (𝓝 0) := by
+    have : Tendsto (fun n => ∑ k ∈ range N, A n k * e k) atTop
+        (𝓝 (∑ k ∈ range N, (0 : ℝ) * e k)) := by
+      apply tendsto_finset_sum
+      intro k _
+      exact (hcol k).mul_const (e k)
+    simpa using this
+  obtain ⟨M, hM⟩ := Metric.tendsto_atTop.mp hhead (ε / 2) (by positivity)
+  refine ⟨max M N, fun n hn => ?_⟩
+  have hnM : M ≤ n := le_trans (le_max_left _ _) hn
+  have hnN : N ≤ n := le_trans (le_max_right _ _) hn
+  rw [Real.dist_eq, sub_zero]
+  -- split the sum at `N`
+  have hsplit : (∑ k ∈ range n, A n k * e k)
+      = (∑ k ∈ range N, A n k * e k) + ∑ k ∈ Ico N n, A n k * e k := by
+    rw [Finset.sum_range_add_sum_Ico _ hnN]
+  rw [hsplit]
+  -- head bound
+  have hheadb : |∑ k ∈ range N, A n k * e k| < ε / 2 := by
+    have := hM n hnM; rw [Real.dist_eq, sub_zero] at this; exact this
+  -- tail bound: `≤ δ * C`
+  have htailb : |∑ k ∈ Ico N n, A n k * e k| ≤ δ * C := by
+    calc |∑ k ∈ Ico N n, A n k * e k|
+        ≤ ∑ k ∈ Ico N n, |A n k * e k| := Finset.abs_sum_le_sum_abs _ _
+      _ ≤ ∑ k ∈ Ico N n, |A n k| * δ := by
+            apply Finset.sum_le_sum
+            intro k hk
+            rw [abs_mul]
+            have hek : |e k| ≤ δ := by
+              have := hN k (mem_Ico.1 hk).1
+              rw [Real.dist_eq, sub_zero] at this
+              exact this.le
+            exact mul_le_mul_of_nonneg_left hek (abs_nonneg _)
+      _ = (∑ k ∈ Ico N n, |A n k|) * δ := by rw [Finset.sum_mul]
+      _ ≤ (∑ k ∈ range n, |A n k|) * δ := by
+            apply mul_le_mul_of_nonneg_right _ hδpos.le
+            apply Finset.sum_le_sum_of_subset_of_nonneg
+            · rw [range_eq_Ico]; exact Ico_subset_Ico (Nat.zero_le _) le_rfl
+            · exact fun k _ _ => abs_nonneg _
+      _ ≤ C * δ := mul_le_mul_of_nonneg_right (hbnd n) hδpos.le
+      _ = δ * C := by ring
+  -- `δ * C ≤ ε / 2`
+  have hδC : δ * C ≤ ε / 2 := by
+    rw [hδdef, div_mul_eq_mul_div,
+        div_le_iff₀ (by positivity : (0 : ℝ) < 2 * (C + 1))]
+    nlinarith [hε, hC]
+  calc |(∑ k ∈ range N, A n k * e k) + ∑ k ∈ Ico N n, A n k * e k|
+      ≤ |∑ k ∈ range N, A n k * e k| + |∑ k ∈ Ico N n, A n k * e k| := abs_add_le _ _
+    _ < ε / 2 + δ * C := by linarith [hheadb, htailb]
+    _ ≤ ε / 2 + ε / 2 := by linarith [hδC]
+    _ = ε := by ring
+
+/-- **Silverman–Toeplitz regularity theorem.** A triangular summability matrix `A`
+that is (col) column-null, (bnd) row-absolutely bounded and (row) row-sum-normalised
+to `1` is **regular**: it preserves every limit. If `x n → L`, then the transformed
+sequence `∑_{k<n} A n k * x k → L`.
+
+This is the sufficiency ("Toeplitz") direction of the Silverman–Toeplitz theorem;
+Mathlib's Cesàro mean and the Marcinkiewicz–Zygmund Kronecker step are both instances.
+
+Proof: write `∑ A n k x k = ∑ A n k (x k − L) + (∑ A n k) · L`.  The first term is
+`tendsto_toeplitz_zero` applied to the null sequence `x k − L`; the second tends to
+`1 · L = L` by (row). -/
+theorem tendsto_toeplitz
+    (A : ℕ → ℕ → ℝ) (x : ℕ → ℝ) (L C : ℝ)
+    (hbnd : ∀ n, ∑ k ∈ range n, |A n k| ≤ C)
+    (hcol : ∀ k, Tendsto (fun n => A n k) atTop (𝓝 0))
+    (hrow : Tendsto (fun n => ∑ k ∈ range n, A n k) atTop (𝓝 1))
+    (hx : Tendsto x atTop (𝓝 L)) :
+    Tendsto (fun n => ∑ k ∈ range n, A n k * x k) atTop (𝓝 L) := by
+  -- null part: `∑ A n k (x k − L) → 0`
+  have hnull := tendsto_toeplitz_zero A (fun k => x k - L) C hbnd hcol
+    (by have := hx.sub_const L; simpa using this)
+  -- row part: `(∑ A n k) · L → 1 · L = L`
+  have hrowL : Tendsto (fun n => (∑ k ∈ range n, A n k) * L) atTop (𝓝 (1 * L)) :=
+    hrow.mul_const L
+  rw [one_mul] at hrowL
+  have hsum := hnull.add hrowL
+  rw [zero_add] at hsum
+  -- reassemble pointwise: `∑ A n k (x k − L) + (∑ A n k) · L = ∑ A n k · x k`
+  refine Tendsto.congr (fun n => ?_) hsum
+  rw [Finset.sum_mul, ← Finset.sum_add_distrib]
+  exact Finset.sum_congr rfl (fun k _ => by ring)
+
+/-- **Cesàro mean as a Silverman–Toeplitz instance.** The unweighted average of a
+convergent sequence converges to the same limit — obtained here from
+`tendsto_toeplitz` with the matrix `A n k = 1/n` (columns `1/n → 0`, row absolute
+sums `= 1 ≤ 1`, row sums `= 1`).  This is the classical special case; it matches
+Mathlib's `Filter.Tendsto.cesaro` and witnesses that the general engine subsumes it. -/
+theorem tendsto_cesaro_of_toeplitz (x : ℕ → ℝ) (L : ℝ)
+    (hx : Tendsto x atTop (𝓝 L)) :
+    Tendsto (fun n => (∑ k ∈ range n, x k) / n) atTop (𝓝 L) := by
+  have h := tendsto_toeplitz (fun n _ => (n : ℝ)⁻¹) x L 1 ?_ ?_ ?_ hx
+  · refine h.congr (fun n => ?_)
+    rw [Finset.sum_div]
+    exact Finset.sum_congr rfl (fun k _ => by ring)
+  · -- (bnd) `∑_{k<n} |1/n| ≤ 1`
+    intro n
+    rcases Nat.eq_zero_or_pos n with h0 | h0
+    · subst h0; simp
+    · have : ∑ k ∈ range n, |(↑n : ℝ)⁻¹| = 1 := by
+        rw [Finset.sum_const, card_range, nsmul_eq_mul, abs_of_nonneg (by positivity),
+            mul_inv_cancel₀ (by exact_mod_cast h0.ne')]
+      exact le_of_eq this
+  · -- (col) each column `1/n → 0`
+    intro k
+    exact tendsto_natCast_atTop_atTop.inv_tendsto_atTop
+  · -- (row) `∑_{k<n} 1/n → 1`
+    have hev : (fun n => ∑ k ∈ range n, (↑n : ℝ)⁻¹) =ᶠ[atTop] (fun _ => (1 : ℝ)) := by
+      filter_upwards [eventually_gt_atTop 0] with n hn
+      rw [Finset.sum_const, card_range, nsmul_eq_mul,
+          mul_inv_cancel₀ (by exact_mod_cast hn.ne')]
+    exact tendsto_const_nhds.congr' hev.symm
+
+end LawsOfLargeNumbers.Toeplitz
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms LawsOfLargeNumbers.Toeplitz.tendsto_toeplitz

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "intro-silverman-toeplitz",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "insight",
+    "title": "One Theorem Behind Every Averaging Method",
+    "content": "The strong laws of large numbers are powered by averaging: Kolmogorov's SLLN by the Cesàro mean, the Marcinkiewicz–Zygmund refinement by the a_n-weighted Toeplitz mean of Kronecker's lemma. The Silverman–Toeplitz theorem is the single abstract statement of which all of these are instances: a triangular summability matrix preserves every limit exactly when its columns vanish, its row absolute sums are bounded, and its row sums tend to 1. The companion Kronecker entry proved just one nonnegative-weight null step; this file packages it into the general theorem, verified with 0 sorries and 0 axioms.",
+    "mathContext": "A matrix $A : \\mathbb{N} \\to \\mathbb{N} \\to \\mathbb{R}$ acts by $(Ax)_n = \\sum_{k<n} A_{n,k} x_k$. It is *regular* if $x_n \\to L$ implies $(Ax)_n \\to L$ for all convergent $x$. Sufficiency (Toeplitz's direction): (col) $\\forall k,\\ A_{\\cdot,k} \\to 0$; (bnd) $\\sum_{k<n} |A_{n,k}| \\le C$; (row) $\\sum_{k<n} A_{n,k} \\to 1$. Mathlib 4.26 has only the $A_{n,k} = 1/n$ instance (`Filter.Tendsto.cesaro`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Silverman–Toeplitz theorem",
+      "regular summability",
+      "Cesàro mean",
+      "Toeplitz mean",
+      "strong law of large numbers"
+    ],
+    "prerequisites": [
+      "convergence of sequences",
+      "matrix summability methods",
+      "Cesàro averages"
+    ]
+  },
+  {
+    "id": "toeplitz-null-general",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 133
+    },
+    "type": "technique",
+    "title": "The Null Step, Now for Signed Weights",
+    "content": "`tendsto_toeplitz_zero` is the reusable core: a matrix with bounded row absolute sums (∑_{k<n} |A n k| ≤ C) and null columns (A · k → 0) sends every null sequence to a null transform. The proof is the archetypal ε/2 split. Choose N past which |e_k| < δ = ε/(2(C+1)); the tail ∑_{N≤k<n} A n k e k is bounded in absolute value by δ·∑|A n k| ≤ δ·C ≤ ε/2 via the triangle inequality; the fixed head ∑_{k<N} A n k e k is a finite sum of columns, each → 0, hence eventually < ε/2. Unlike the earlier version the weights carry arbitrary sign — only their absolute-sum bound is used.",
+    "mathContext": "The tail estimate is $\\bigl|\\sum_{N\\le k<n} A_{n,k} e_k\\bigr| \\le \\sum_{N\\le k<n} |A_{n,k}|\\,|e_k| \\le \\delta \\sum_{k<n} |A_{n,k}| \\le \\delta C$ with $\\delta = \\varepsilon/(2(C+1))$, so $\\delta C \\le \\varepsilon/2$ with no case split on $C = 0$. The head $\\sum_{k<N} A_{n,k} e_k \\to \\sum_{k<N} 0 \\cdot e_k = 0$ by `tendsto_finset_sum` since each column $A_{\\cdot,k} \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Toeplitz null step",
+      "ε/2 argument",
+      "triangle inequality for sums",
+      "signed weights"
+    ],
+    "prerequisites": [
+      "limit of a sequence",
+      "finite sums of convergent sequences"
+    ]
+  },
+  {
+    "id": "regularity-centering",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 135,
+      "endLine": 159
+    },
+    "type": "insight",
+    "title": "From Null Step to Regularity by Centering",
+    "content": "The full theorem `tendsto_toeplitz` needs only one extra idea: centering. Write ∑_{k<n} A n k x k = ∑_{k<n} A n k (x k − L) + (∑_{k<n} A n k)·L. The first term is the null step applied to the null sequence x k − L; the second tends to 1·L = L by the row-sum condition. This is why the null step is the genuine content: the row-sum-to-1 hypothesis enters solely to pin the limit's value.",
+    "mathContext": "The decomposition $\\sum_{k<n} A_{n,k} x_k = \\sum_{k<n} A_{n,k}(x_k - L) + \\bigl(\\sum_{k<n} A_{n,k}\\bigr) L$ is an exact pointwise identity (`Finset.sum_add_distrib` and `Finset.sum_mul`). The first summand $\\to 0$ by `tendsto_toeplitz_zero`; the second $\\to 1 \\cdot L = L$ by (row). Necessity of all three conditions (the converse) is left open.",
+    "significance": "important",
+    "relatedConcepts": [
+      "regular summability",
+      "centering a sequence",
+      "limit-preserving transforms"
+    ],
+    "prerequisites": [
+      "algebra of limits",
+      "distributing a finite sum"
+    ]
+  },
+  {
+    "id": "cesaro-instance",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 161,
+      "endLine": 184
+    },
+    "type": "insight",
+    "title": "Cesàro Mean as a Corollary",
+    "content": "Instantiating A n k = 1/n recovers the unweighted Cesàro mean: (∑_{k<n} x k)/n → L whenever x n → L. The three Toeplitz conditions become elementary: columns 1/n → 0, row absolute sums ∑_{k<n} |1/n| = n·(1/n) = 1 ≤ 1, and row sums = 1 → 1. This matches Mathlib's `Filter.Tendsto.cesaro` and witnesses that the general engine subsumes it — exactly the packaging the parent entry's open question asked for.",
+    "mathContext": "With $A_{n,k} = 1/n$, the transform $\\sum_{k<n} \\tfrac1n x_k = \\tfrac1n \\sum_{k<n} x_k$ is the Cesàro average. The row sums $\\sum_{k<n} 1/n$ equal $1$ for every $n \\ge 1$ (via `Finset.sum_const` and `mul_inv_cancel₀`), so they tend to $1$; the columns $1/n \\to 0$ come from `tendsto_natCast_atTop_atTop.inv_tendsto_atTop`.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Cesàro mean",
+      "special case",
+      "Filter.Tendsto.cesaro"
+    ],
+    "prerequisites": [
+      "Cesàro averages",
+      "1/n → 0"
+    ]
+  }
+]

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+  "title": "The Silverman–Toeplitz Summability Theorem (Regular Matrix Methods)",
+  "slug": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+  "description": "The Marcinkiewicz–Zygmund Kronecker-lemma entry proved a single nonnegative-weight Toeplitz null step. Its open question asked to package that step into the general Silverman–Toeplitz theorem, of which both that lemma and Mathlib's unweighted Cesàro mean are special cases. This entry supplies it: a triangular summability matrix A n k is regular — it preserves every limit — as soon as its columns tend to 0, its row absolute sums are bounded, and its row sums tend to 1. Both the null form and the full limit-preserving form are proved, and the Cesàro mean is derived as the instance A n k = 1/n. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Otto Toeplitz / L. L. Silverman (theorem); formalization researcher-11",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Silverman%E2%80%93Toeplitz_theorem",
+    "date": "1911",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01OQ02.lean",
+    "tags": [
+      "probability",
+      "law-of-large-numbers",
+      "silverman-toeplitz",
+      "summability",
+      "regular-matrix",
+      "cesaro-mean",
+      "toeplitz-mean",
+      "real-analysis",
+      "series",
+      "infrastructure",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "lineCount": 190,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_add_sum_Ico",
+        "description": "Split a range sum ∑_{k<n} at a threshold N into head ∑_{k<N} plus tail ∑_{N≤k<n}",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "tendsto_finset_sum",
+        "description": "A finite sum of sequences each tending to a limit tends to the sum of the limits",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv_tendsto_atTop",
+        "description": "If f n → ∞ then (f n)⁻¹ → 0; used for the Cesàro columns 1/n → 0",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "Finset.abs_sum_le_sum_abs",
+        "description": "Triangle inequality for finite sums, |∑ f| ≤ ∑ |f|, bounding the Toeplitz tail",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "Theorem tendsto_toeplitz_zero: the general (signed-weight) Toeplitz null step — a triangular matrix A n k whose row absolute sums are bounded (∑_{k<n} |A n k| ≤ C) and whose columns are null (A · k → 0) sends any null sequence e k → 0 to ∑_{k<n} A n k · e k → 0. Strictly generalizes the earlier nonnegative-weight step tendsto_weighted_average_zero, whose A n k = c k / A_norm n is a special case with C = 1.",
+      "Theorem tendsto_toeplitz: the Silverman–Toeplitz regularity theorem (sufficiency direction) — a column-null, row-absolutely-bounded, row-sum-normalized triangular matrix preserves every limit: x n → L ⟹ ∑_{k<n} A n k · x k → L. The general regular-summability engine, absent from Mathlib 4.26.",
+      "Theorem tendsto_cesaro_of_toeplitz: the unweighted Cesàro mean recovered as the instance A n k = 1/n, exhibiting Mathlib's Filter.Tendsto.cesaro as one special case of the general theorem and confirming the packaging requested by the parent's open question."
+    ],
+    "dateAdded": "2026-07-03",
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms tendsto_toeplitz reports only propext, Classical.choice, Quot.sound (standard foundations).",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Finset"
+    ],
+    "namespace": "LawsOfLargeNumbers.Toeplitz",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Silverman–Toeplitz theorem (Silverman 1913, Toeplitz 1911) characterizes exactly which infinite-matrix summability methods are regular, i.e. assign to every convergent sequence its ordinary limit. It is the abstract umbrella over the classical averaging methods: the Cesàro mean, Hölder and Nörlund means, and the weighted Toeplitz mean that closes Kronecker's lemma at the heart of the strong law of large numbers. The three conditions — columns tending to zero, uniformly bounded row absolute sums, and row sums tending to one — are jointly necessary and sufficient for regularity. Mathlib 4.26 carries the unweighted Cesàro mean (Filter.Tendsto.cesaro) as an isolated fact but not the general theorem of which it is an instance; the companion Kronecker-lemma entry proved only a single nonnegative-weight null step and flagged the general packaging as open.",
+    "problemStatement": "Prove, in Lean 4 with 0 axioms, the sufficiency direction of the Silverman–Toeplitz theorem for triangular matrices. A matrix A : ℕ → ℕ → ℝ acts on a sequence x by (A x)_n = ∑_{k<n} A_{n,k} x_k. Show: if (col) each column A_{·,k} → 0, (bnd) the row absolute sums satisfy ∑_{k<n} |A_{n,k}| ≤ C, and (row) the row sums ∑_{k<n} A_{n,k} → 1, then x_n → L implies (A x)_n → L. First prove the null form (L = 0 with the row condition dropped), then derive the unweighted Cesàro mean as the instance A_{n,k} = 1/n.",
+    "proofStrategy": "Three theorems. (1) tendsto_toeplitz_zero (null form): given ε, choose N past which |e_k| < δ := ε/(2(C+1)); split ∑_{k<n} A_{n,k} e_k at N. The tail is bounded in absolute value by δ·∑_{k<n}|A_{n,k}| ≤ δ·C ≤ ε/2 (via the triangle inequality and the row-absolute bound); the fixed head ∑_{k<N} A_{n,k} e_k is a finite sum of columns, each → 0 by (col), hence eventually < ε/2. The (C+1) denominator sidesteps the degenerate C = 0 case with no case split. (2) tendsto_toeplitz (regularity): write ∑_{k<n} A_{n,k} x_k = ∑_{k<n} A_{n,k} (x_k − L) + (∑_{k<n} A_{n,k})·L. The first term → 0 by the null form applied to the null sequence x_k − L; the second → 1·L = L by (row). A pointwise Finset.sum_add_distrib identity reassembles the two. (3) tendsto_cesaro_of_toeplitz: instantiate A_{n,k} = 1/n. Columns 1/n → 0 (inverse of the natural cast to ∞); row absolute sums ∑_{k<n} |1/n| = n·(1/n) = 1 ≤ 1; row sums = 1 → 1. The transform ∑_{k<n} (1/n) x_k equals (∑_{k<n} x_k)/n, giving the Cesàro conclusion.",
+    "keyInsights": [
+      "The entire theorem factors through the null step: once a column-null, row-absolutely-bounded matrix is shown to annihilate every null sequence, regularity is one line of centering (x_k = (x_k − L) + L) plus the row-sum condition.",
+      "Only two of the three Toeplitz conditions are needed for the null form; the row-sum-to-1 condition enters solely to fix the limit's value, which is exactly why the null step is the reusable core and the earlier Kronecker entry could stop there.",
+      "Signs are irrelevant to the null step: replacing the earlier nonnegative-weight hypothesis by a bound on the row absolute sums ∑|A_{n,k}| ≤ C covers signed and complex-style averaging matrices with the same ε/2 tail estimate, at no extra cost.",
+      "The nonnegative-weight normaliser form (A_{n,k} = c_k / A_n with ∑ c_k ≤ A_n) has row absolute sums ≤ 1 and columns c_k / A_n → 0, so it is literally the C = 1 instance of tendsto_toeplitz_zero — the general theorem subsumes the entry that motivated it.",
+      "Mathlib's Filter.Tendsto.cesaro is the A_{n,k} = 1/n instance; deriving it here from the general engine both validates the formalization against a known result and demonstrates the packaging the parent's open question requested."
+    ]
+  },
+  "sections": [
+    {
+      "id": "toeplitz-null",
+      "title": "The General Toeplitz Null Step",
+      "startLine": 58,
+      "endLine": 133,
+      "summary": "Proves tendsto_toeplitz_zero: a triangular matrix with bounded row absolute sums (∑_{k<n} |A n k| ≤ C) and null columns (A · k → 0) sends every null sequence to a null transform. An ε/2 split at a threshold N: the tail is bounded by δ·C with δ = ε/(2(C+1)); the finite head is a sum of null columns via tendsto_finset_sum."
+    },
+    {
+      "id": "regularity",
+      "title": "Silverman–Toeplitz Regularity",
+      "startLine": 135,
+      "endLine": 159,
+      "summary": "Proves tendsto_toeplitz: adding the row-sum condition ∑_{k<n} A n k → 1 upgrades the null step to a limit-preserving (regular) method, x n → L ⟹ ∑_{k<n} A n k · x k → L. Centering x k = (x k − L) + L reduces to the null step plus the row limit 1·L = L."
+    },
+    {
+      "id": "cesaro-instance",
+      "title": "Cesàro Mean as a Special Case",
+      "startLine": 161,
+      "endLine": 184,
+      "summary": "Proves tendsto_cesaro_of_toeplitz: instantiating A n k = 1/n recovers the unweighted Cesàro mean (∑_{k<n} x k)/n → L, matching Mathlib's Filter.Tendsto.cesaro and confirming the general engine subsumes it. The three Toeplitz conditions reduce to 1/n → 0, ∑ 1/n = 1, and row sums = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry contributes the general Silverman–Toeplitz summability theorem — the null step and the full regular (limit-preserving) form for triangular matrices — fully verified in Lean 4 with 0 sorries and 0 axioms, together with the Cesàro mean as an explicit instance. It packages the isolated nonnegative-weight step of the companion Kronecker-lemma entry into the theorem of which that step, the Kronecker weights, and Mathlib's Cesàro mean are all special cases.",
+    "implications": "Regular summability is the abstract engine behind every averaging method used in the strong laws of large numbers: the Cesàro mean of Kolmogorov's SLLN, the a_n-weighted Toeplitz mean of Kronecker's lemma, and their higher-order refinements are single instances of this one theorem. Supplying it axiom-free turns each future averaging step in the Marcinkiewicz–Zygmund assembly into a matter of checking three elementary matrix conditions rather than re-running an ε/2 argument. The result is a natural candidate for upstreaming to Mathlib, where only the Cesàro special case currently exists.",
+    "openQuestions": [
+      "Prove the necessity direction of Silverman–Toeplitz (a matrix method that preserves all limits must satisfy the three conditions), completing the iff characterization of regular triangular summability.",
+      "Extend from triangular matrices (finite row supports ∑_{k<n}) to genuine infinite-row matrices with tsum-summable rows, matching the classical statement over ℓ¹ rows.",
+      "Assemble the full Marcinkiewicz–Zygmund SLLN for 1 ≤ p < 2 by combining truncation, the Borel–Cantelli tail bound, Kolmogorov's convergence criterion, and the Kronecker lemma this summability engine now underlies."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Kronecker's lemma and its single nonnegative-weight Toeplitz null step. This entry packages that step into the general Silverman–Toeplitz theorem, answering its second open question; the parent's step is the C = 1 instance here."
+    },
+    {
+      "targetId": "laws-of-large-numbers-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "States the Marcinkiewicz–Zygmund SLLN and its n^{1/p} rate. Regular summability is the deterministic engine of the averaging steps in its truncation proof."
+    },
+    {
+      "targetId": "laws-of-large-numbers",
+      "relationship": "ancestor",
+      "description": "Foundational WLLN/SLLN entry. The Cesàro and weighted means underlying every strong law are instances of the Silverman–Toeplitz theorem formalized here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question #2** of `laws-of-large-numbers-oq-01-oq-02-oq-01` (Kronecker's Lemma / Toeplitz step): *"Package the Toeplitz null step into the general regular-matrix (Silverman–Toeplitz) summability theorem, of which both this lemma and Mathlib's Cesàro mean are special cases."*

New file `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01OQ02.lean` (190 lines, 3 theorems, 0 definitions):

- **`tendsto_toeplitz_zero`** — the general **signed-weight** Toeplitz null step. A triangular matrix `A n k` with bounded row absolute sums (`∑_{k<n} |A n k| ≤ C`) and null columns (`A · k → 0`) sends every null sequence `e k → 0` to `∑_{k<n} A n k · e k → 0`. Strictly generalizes the parent's `tendsto_weighted_average_zero`, whose `A n k = c k / A_norm n` is the `C = 1` instance.
- **`tendsto_toeplitz`** — the **Silverman–Toeplitz regularity theorem** (sufficiency direction). Column-null + row-absolutely-bounded + row-sums→1 ⟹ the method preserves every limit: `x n → L ⟹ ∑_{k<n} A n k · x k → L`. Proved by centering `x k = (x k − L) + L` and applying the null step.
- **`tendsto_cesaro_of_toeplitz`** — Mathlib's unweighted **Cesàro mean** `(∑_{k<n} x k)/n → L` recovered as the `A n k = 1/n` instance, confirming the general engine subsumes `Filter.Tendsto.cesaro`.

## Verification

- **0 sorries, 0 axioms.** `#print axioms tendsto_toeplitz` reports only `propext`, `Classical.choice`, `Quot.sound` (standard foundations).
- Docker build passes under Mathlib 4.26 (`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01OQ02`).
- Gallery entry added (`meta.json` + `annotations.json`), status `verified`, badge `original`.

## Mathematical context

The Silverman–Toeplitz theorem is the abstract umbrella over the classical averaging methods — Cesàro, Nörlund, and the weighted Toeplitz mean that closes Kronecker's lemma at the heart of the strong law of large numbers. Mathlib 4.26 carries only the Cesàro special case; this supplies the general regular-summability engine, a natural candidate for upstreaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)