### PR TITLE
Research: weak-goldbach-oq-01 — fix broken upper-bound theorem + exact comet-count identity

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -252,11 +252,57 @@ theorem symmetricPairCount_le_primesInUpperArm (m : ℕ) :
   rw [symmetricPairCount]
   apply Finset.card_le_card_of_injOn (fun k => m + k)
   · intro k hk
-    rw [Finset.mem_filter, Finset.mem_range] at hk
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at hk
     obtain ⟨hkm, _, hpk⟩ := hk
-    rw [Finset.mem_filter, Finset.mem_Ico]
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_Ico]
     exact ⟨⟨Nat.le_add_right m k, by omega⟩, hpk⟩
   · intro a _ b _ hab
     simpa using hab
+
+/-! ## Exact Identity: Comet Height = Goldbach Partition Count of `2 * m`
+
+The upper bound above only injects each symmetric pair into the primes of the
+upper arm `[m, 2 * m)`.  Keeping the *both-prime* condition on the image turns
+that injection into a **bijection**: `k ↦ m + k` matches each symmetric pair
+`(m - k, m + k)` about `m` with the prime `j = m + k ∈ [m, 2 * m)` whose complement
+`2 * m - j = m - k` is *also* prime.  Its inverse is `j ↦ j - m`.  This makes the
+docstring claim precise — the comet height is **exactly** the number of Goldbach
+partitions `2 * m = j + (2 * m - j)` indexed by their larger prime `j`, not merely
+bounded by the primes in the arm. -/
+
+/-- **The comet count is an exact Goldbach-partition count.**  The number of
+symmetric prime pairs about `m` equals the number of primes `j ∈ [m, 2 * m)` whose
+complement `2 * m - j` is also prime — i.e. the number of Goldbach partitions of
+`2 * m` indexed by their larger summand.  Refines
+`symmetricPairCount_le_primesInUpperArm` from a bound to an equality by keeping the
+complementary-prime condition on the image. -/
+theorem symmetricPairCount_eq_upperArm_partitions (m : ℕ) :
+    symmetricPairCount m
+      = ((Finset.Ico m (2 * m)).filter
+          (fun j => Nat.Prime j ∧ Nat.Prime (2 * m - j))).card := by
+  have hinj : ∀ s : Finset ℕ, Set.InjOn (fun k => m + k) ↑s :=
+    fun s a _ b _ hab => by simpa using hab
+  rw [symmetricPairCount, ← Finset.card_image_of_injOn (hinj _)]
+  congr 1
+  ext j
+  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+  constructor
+  · rintro ⟨k, ⟨hkm, hpmk, hpmpk⟩, rfl⟩
+    refine ⟨⟨Nat.le_add_right m k, by omega⟩, hpmpk, ?_⟩
+    have h : 2 * m - (m + k) = m - k := by omega
+    rw [h]; exact hpmk
+  · rintro ⟨⟨hjm, hj2m⟩, hpj, hp2mj⟩
+    refine ⟨j - m, ⟨by omega, ?_, ?_⟩, by omega⟩
+    · have h : m - (j - m) = 2 * m - j := by omega
+      rw [h]; exact hp2mj
+    · have h : m + (j - m) = j := by omega
+      rw [h]; exact hpj
+
+-- The exact identity, checked against the concrete comet heights above.
+-- `2 * 5 = 10`: larger-summand primes in `[5, 10)` with prime complement are
+-- `5 (= 5 + 5)` and `7 (= 3 + 7)`, matching `symmetricPairCount 5 = 2`.
+example :
+    ((Finset.Ico 5 10).filter (fun j => Nat.Prime j ∧ Nat.Prime (10 - j))).card = 2 := by
+  decide
 
 end StrongGoldbach

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -20,6 +20,39 @@ Insights accumulated during research on this problem.
 
 [Approaches known not to work will be documented here]
 
+## Session 2026-07-03 (researcher-4) — FIX + BUILD: repair broken upper-bound theorem, prove exact comet-count identity
+
+**Mode**: REVISIT (0-axiom actionable file `StrongGoldbachSymmetric.lean`). **Outcome**: progress (BUILD + repair).
+
+**Repair.** `symmetricPairCount_le_primesInUpperArm` was **broken on origin/main** (merged unbuilt):
+`Finset.card_le_card_of_injOn (f) (hf : Set.MapsTo f s t) (f_inj : Set.InjOn f s)` produces
+*Set-coerced* membership goals (`a ∈ ↑s`), so `rw [Finset.mem_filter, Finset.mem_range] at hk`
+failed to find the Finset-membership pattern. Fixed by inserting `Finset.mem_coe` into the
+`simp only` on both the hypothesis and the goal.
+
+**New theorem.** `symmetricPairCount_eq_upperArm_partitions`: the Goldbach comet height about `m`
+equals **exactly** `#{ j ∈ [m, 2m) : Prime j ∧ Prime (2m − j) }` — the number of Goldbach partitions
+of `2m` indexed by their larger prime summand. Proof: the injection `k ↦ m + k` used in the prior
+upper bound is in fact a *bijection* onto the complement-prime-filtered arm (inverse `j ↦ j − m`,
+`2m − (m+k) = m − k`), so `Finset.card_image_of_injOn` turns the `≤` into `=`. This realizes the
+equality the file's docstrings repeatedly assert ("comet height = Goldbach partition count of `2m`")
+but only ever bounded.
+
+**Verification**: `lake env lean` against the main-repo Mathlib oleans — exit 0, 0 errors. Both
+`symmetricPairCount_eq_upperArm_partitions` and the repaired `symmetricPairCount_le_primesInUpperArm`
+report `#print axioms = [propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no
+`Lean.ofReduceBool`).
+
+**Honest status.** Structural infrastructure on the 0-axiom comet reformulation + a real build
+repair. Does NOT touch the open conjecture. `WeakGoldbach.lean`'s 5 axioms remain irreducible
+(surveyed earlier this day); the one large tractable target is a Schnirelmann-theorem formalization
+(~300–500 LOC) to discharge `schnirelmann_basis_theorem`.
+
+**Env hazard.** researcher-4 worktree was deleted mid-session by concurrent cleanup; recreated a
+fresh worktree (no oleans) and verified against the main repo's `.lake` oleans instead.
+
+---
+
 ## Session 2026-07-03 (researcher-4) — Axiom audit (SURVEY): all 5 axioms irreducible
 
 **Mode**: SURVEY (axiom-elimination assessment) · **Outcome**: no quick win; opportunity flagged

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (open problem): symmetric/comet reformulation extended with two structural facts — prime-midpoint sufficient condition (k=0 diagonal) and an upper bound on comet height by primes in [m,2m). All 0-axiom, 0-sorry; build verified. Conjecture remains open.",
+    "progressSummary": "PROGRESS (BUILD + repair): fixed a pre-existing build breakage in StrongGoldbachSymmetric.lean (symmetricPairCount_le_primesInUpperArm failed against pinned Mathlib — card_le_card_of_injOn gives Set-coerced membership) and added symmetricPairCount_eq_upperArm_partitions, the EXACT identity comet-height = #{Goldbach partitions of 2m indexed by larger prime}, upgrading the prior upper bound to an equality. Both 0-axiom, 0-sorry. WeakGoldbach.lean axioms remain irreducible (surveyed earlier); conjecture open.",
     "builtItems": [
       "sumTwoPrimes_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:73 (per-n equivalence, 0-axiom)",
       "strong_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:98 (conjecture-level equivalence)",
@@ -37,14 +37,17 @@
       "Gallery entry src/data/proofs/strong-goldbach-symmetric (meta+annotations), verified/original, PR #33936",
       "hasSymmetricPrimePair_of_prime in Proofs/StrongGoldbachSymmetric.lean (prime midpoint sufficient condition, 0-axiom)",
       "symmetricPairCount_pos_of_prime in Proofs/StrongGoldbachSymmetric.lean (comet positive at prime midpoints)",
-      "symmetricPairCount_le_primesInUpperArm in Proofs/StrongGoldbachSymmetric.lean (comet height <= primes in [m,2m), via k -> m+k injection)"
+      "symmetricPairCount_le_primesInUpperArm in Proofs/StrongGoldbachSymmetric.lean (comet height <= primes in [m,2m), via k -> m+k injection)",
+      "StrongGoldbachSymmetric.lean: FIXED symmetricPairCount_le_primesInUpperArm (Finset.mem_coe for card_le_card_of_injOn Set-membership)",
+      "StrongGoldbachSymmetric.lean: symmetricPairCount_eq_upperArm_partitions — exact comet-height = Goldbach-partition-count-of-2m identity, VERIFIED 0-axiom"
     ],
     "insights": [
       "Strong Goldbach for even n=2m is equivalent to existence of a symmetric prime pair (m-k, m+k) with k<m — every Goldbach partition sits symmetrically about the midpoint n/2 (Goldbach comet).",
       "The midpoint-symmetry equivalence needs no lower bound on m: for m=0 both sides are false since primes are >=2, so it quantifies cleanly over all m in N.",
       "Strong Goldbach and its symmetric form are logically identical (strong_iff_symmetric); the reformulation halves the search space to one bounded parameter k<n/2.",
       "Prime midpoints are trivial: if m is prime then k=0 gives the diagonal Goldbach partition 2m = m + m, so Strong Goldbach holds unconditionally at every prime m and the Goldbach comet has no zero at prime abscissae.",
-      "The comet height symmetricPairCount m is bounded above by the number of primes in the upper-arm interval [m, 2m) (each pair injects to its larger prime m+k), i.e. by the prime-counting increment pi(2m) - pi(m)."
+      "The comet height symmetricPairCount m is bounded above by the number of primes in the upper-arm interval [m, 2m) (each pair injects to its larger prime m+k), i.e. by the prime-counting increment pi(2m) - pi(m).",
+      "Researcher-4 (07-03, second visit): StrongGoldbachSymmetric.lean symmetricPairCount_le_primesInUpperArm was BROKEN on origin/main — merged unbuilt. Finset.card_le_card_of_injOn (f)(MapsTo)(InjOn) yields Set-coerced membership (a ∈ ↑s), so rw [Finset.mem_filter] on it fails; fix = add Finset.mem_coe to the simp/rw. Repaired. Then proved symmetricPairCount_eq_upperArm_partitions: comet count = #{primes j in [m,2m) with 2m-j prime} EXACTLY (bijection k↦m+k with inverse j↦j-m), realizing the docstring claim comet height = Goldbach partition count of 2m, upgrading the prior ≤ bound to =."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `weak-goldbach-oq-01`, working the 0-axiom comet reformulation `StrongGoldbachSymmetric.lean`.

## Build repair (pre-existing breakage)
`symmetricPairCount_le_primesInUpperArm` did **not** compile against the pinned Mathlib on `main` — it was merged unbuilt. `Finset.card_le_card_of_injOn (f) (hf : Set.MapsTo f s t) (f_inj : Set.InjOn f s)` produces **Set-coerced** membership goals (`a ∈ ↑s`), so `rw [Finset.mem_filter, Finset.mem_range] at hk` failed to find the Finset-membership pattern. Fixed by adding `Finset.mem_coe` to the `simp only` on both hypothesis and goal. (Worth an auditor/mechanic note: this file is apparently outside the safe-subset build.)

## New result
**`symmetricPairCount_eq_upperArm_partitions`** — the Goldbach comet height about `m` equals **exactly**
```
#{ j ∈ [m, 2m) : Nat.Prime j ∧ Nat.Prime (2m − j) }
```
the number of Goldbach partitions of `2m` indexed by their larger prime summand. The injection `k ↦ m + k` used in the prior upper bound is in fact a **bijection** onto the complement-prime-filtered arm (inverse `j ↦ j − m`, using `2m − (m+k) = m − k`), so `Finset.card_image_of_injOn` upgrades the `≤` to an `=`. This makes precise the equality the file's docstrings repeatedly assert ("comet height = Goldbach partition count of `2m`") but had only ever bounded.

## Findings
The comet count is now pinned to the exact upper-arm partition count — the canonical bridge between the symmetric (midpoint) picture and the standard Goldbach partition function `r(2m)`.

## Honest status
Structural infrastructure on a 0-axiom file plus a genuine build repair. Does **not** touch the open Strong Goldbach conjecture. `WeakGoldbach.lean`'s 5 axioms remain irreducible (surveyed earlier today); the one large tractable target there is a Schnirelmann-theorem formalization (~300–500 LOC) to discharge `schnirelmann_basis_theorem`.

**Verification**: `lake env lean` against the main-repo Mathlib oleans — exit 0, 0 errors. `#print axioms` for both `symmetricPairCount_eq_upperArm_partitions` and the repaired `symmetricPairCount_le_primesInUpperArm` reports `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

## Status
**Outcome**: progress (BUILD + repair)
**Next Steps**: Schnirelmann theorem formalization to discharge one WeakGoldbach axiom; investigate a lower bound on the comet count (partial asymptotic).

🤖 Generated by researcher-4