### PR TITLE
research(weak-goldbach-oq-01): offset-side ceiling on the Goldbach comet [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -305,4 +305,47 @@ example :
     ((Finset.Ico 5 10).filter (fun j => Nat.Prime j ∧ Nat.Prime (10 - j))).card = 2 := by
   decide
 
+/-! ## Offset-Side Ceiling: the Comet is Bounded by Half the Offsets
+
+The bounds above are all *prime-side*: they count admissible larger primes in the
+upper arm `[m, 2 * m)`.  There is a complementary *offset-side* constraint that
+needs no prime-counting input.  Once `m > 2` both summands `m - k` and `m + k` are
+odd (proved in `symmetric_pair_both_odd`), and `m - k` odd forces `k` to have the
+**opposite parity to `m`**.  So only offsets `k` with `k % 2 ≠ m % 2` can ever
+contribute a Goldbach partition — exactly half of `{0, …, m - 1}`.  This halves the
+offset search space and gives an elementary `≈ m/2` ceiling on the comet height,
+orthogonal to the prime-arm identity `symmetricPairCount_eq_upperArm_partitions`. -/
+
+/-- **Offset parity constraint.**  For `m > 2`, every offset `k` of a symmetric
+prime pair has the opposite parity to `m` (equivalently `m - k` and `m + k` are both
+odd).  Follows from `symmetric_pair_odd`: `m - k` odd means `m` and `k` differ in
+parity. -/
+theorem symmetric_pair_offset_parity {m k : ℕ} (hm : 2 < m) (hk : k < m)
+    (hp1 : Nat.Prime (m - k)) (hp2 : Nat.Prime (m + k)) :
+    m % 2 ≠ k % 2 := by
+  obtain ⟨j, hj⟩ := symmetric_pair_odd hm hk hp1 hp2
+  omega
+
+-- `m = 5` (odd): the contributing offsets `0, 2` are both even — opposite parity.
+example : (5 : ℕ) % 2 ≠ (2 : ℕ) % 2 :=
+  symmetric_pair_offset_parity (by norm_num) (by norm_num) (by decide) (by decide)
+-- `m = 6` (even): the contributing offset `1` is odd — opposite parity.
+example : (6 : ℕ) % 2 ≠ (1 : ℕ) % 2 :=
+  symmetric_pair_offset_parity (by norm_num) (by norm_num) (by decide) (by decide)
+
+/-- **Offset-side upper bound on the comet count.**  For `m > 2` the comet count is
+at most the number of offsets `k < m` of opposite parity to `m`.  Since exactly half
+of `{0, …, m - 1}` have opposite parity to `m`, this is an elementary `≈ m/2` ceiling
+on the Goldbach comet height that uses no density input, complementing the prime-arm
+bound `symmetricPairCount_le_primesInUpperArm`. -/
+theorem symmetricPairCount_le_oppositeParityOffsets {m : ℕ} (hm : 2 < m) :
+    symmetricPairCount m ≤
+      ((Finset.range m).filter (fun k => m % 2 ≠ k % 2)).card := by
+  rw [symmetricPairCount]
+  apply Finset.card_le_card
+  intro k hk
+  simp only [Finset.mem_filter, Finset.mem_range] at hk ⊢
+  obtain ⟨hkm, hp1, hp2⟩ := hk
+  exact ⟨hkm, symmetric_pair_offset_parity hm hkm hp1 hp2⟩
+
 end StrongGoldbach

--- a/src/data/proofs/strong-goldbach-symmetric/meta.json
+++ b/src/data/proofs/strong-goldbach-symmetric/meta.json
@@ -2,7 +2,7 @@
   "id": "strong-goldbach-symmetric",
   "title": "Strong Goldbach: Symmetric (Midpoint) Reformulation",
   "slug": "strong-goldbach-symmetric",
-  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. Also defines the Goldbach comet counting function (the number of symmetric prime pairs), proves existence ⟺ positive count and recasts the conjecture as a comet-positivity statement, and proves the structural fact that for 2m > 4 both Goldbach summands are odd. The conjecture itself is NOT proved; only the equivalences and structural facts are. 6 theorems, 5 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
+  "description": "A fully verified, axiom-free structural reformulation of the (open) Strong/Binary Goldbach Conjecture. Proves that an even number 2m is a sum of two primes if and only if there is an offset k < m with both m−k and m+k prime — i.e. every Goldbach partition is a pair of primes symmetric about the midpoint n/2. Lifts this to a conjecture-level equivalence StrongGoldbachConjecture ↔ SymmetricGoldbachConjecture, and supplies a decidable instance so any concrete case is machine-checkable by `decide`. Also defines the Goldbach comet counting function (the number of symmetric prime pairs), proves existence ⟺ positive count and recasts the conjecture as a comet-positivity statement, and proves the structural fact that for 2m > 4 both Goldbach summands are odd. Bounds the comet height two complementary ways: a prime-side identity equating it to the number of primes j ∈ [m, 2m) whose complement 2m−j is also prime, and an offset-side ceiling — for m > 2 only offsets k of opposite parity to m contribute, capping the count at ≈ m/2 with no density input. The conjecture itself is NOT proved; only the equivalences, structural facts, and bounds are. 12 theorems, 5 definitions, 1 decidable instance, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
@@ -20,8 +20,8 @@
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "assumptions": "None. The file is axiom-free (only the ordinary foundational axioms of Lean/Mathlib are used; `#print axioms` shows no `sorryAx`, no `Lean.ofReduceBool`). All examples use kernel `decide`, not `native_decide`. Note: this file does NOT prove the Strong Goldbach Conjecture, which remains open; it proves only that the conjecture is equivalent to its symmetric-prime-pair form.",
-    "lineCount": 212,
-    "theoremCount": 6,
+    "lineCount": 351,
+    "theoremCount": 12,
     "definitionCount": 5,
     "originalContributions": [
       "sumTwoPrimes_iff_symmetric: for every m, IsSumOfTwoPrimes (2m) ↔ ∃ k < m, Prime (m−k) ∧ Prime (m+k) — the midpoint-symmetry equivalence, valid without any lower bound on m",
@@ -30,6 +30,10 @@
       "hasSymmetricPrimePair_iff_count_pos: HasSymmetricPrimePair m ↔ 0 < symmetricPairCount m — existence of a Goldbach partition equals positivity of the comet count",
       "symmetricGoldbach_iff_count: SymmetricGoldbachConjecture ↔ (∀ m ≥ 2, 0 < symmetricPairCount m) — Strong Goldbach recast as comet positivity",
       "symmetric_pair_odd / symmetric_pair_both_odd: for m > 2 the smaller summand m−k (hence both m−k and m+k) is an odd prime — the value 2 never participates in a Goldbach partition of 2m > 4, since m−k = 2 forces m+k = 2(m−1), an even number > 2",
+      "symmetricPairCount_le_primesInUpperArm: the comet height is at most the number of primes in the upper arm [m, 2m), via the injection k ↦ m+k — a prime-counting ceiling π(2m) − π(m)",
+      "symmetricPairCount_eq_upperArm_partitions: the comet height EQUALS the number of primes j ∈ [m, 2m) whose complement 2m−j is also prime (bijection k ↦ m+k with inverse j ↦ j−m) — refines the upper bound to an exact Goldbach-partition count indexed by the larger summand",
+      "symmetric_pair_offset_parity: for m > 2, every contributing offset k has the opposite parity to m (m%2 ≠ k%2), since m−k is odd — the value 2 never participates, so k and m differ in parity",
+      "symmetricPairCount_le_oppositeParityOffsets: an offset-side ceiling — for m > 2 the comet height is at most the number of offsets k < m of opposite parity to m (≈ m/2), using no prime-counting input, complementary to the prime-arm bound",
       "HasSymmetricPrimePair: predicate for a prime pair symmetric about the midpoint m",
       "SymmetricGoldbachConjecture: the symmetric-form statement of Strong Goldbach",
       "decidableHasSymmetricPrimePair: decidable instance for the symmetric predicate, via a bounded existential over Finset.range"
@@ -115,9 +119,9 @@
   },
   "leanFile": {
     "namespace": "StrongGoldbach",
-    "lineCount": 262,
+    "lineCount": 351,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 5,
     "path": "Proofs/StrongGoldbachSymmetric.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends `Proofs/StrongGoldbachSymmetric.lean` (the verified, axiom-free symmetric reformulation of the open Strong/Binary Goldbach Conjecture) with an **offset-side ceiling** on the Goldbach comet height, complementary to the existing prime-arm bounds.

All prior bounds in the file are *prime-side* (they count admissible larger primes in the upper arm `[m, 2m)`). This adds the orthogonal *offset-side* constraint: once `m > 2` both summands `m − k` and `m + k` are odd, so `m − k` odd forces the offset `k` to have **opposite parity to `m`**. Only half the offsets can contribute, giving an elementary `≈ m/2` cap that needs no prime-counting input.

## New theorems (0 axioms, 0 sorries, kernel `decide` only)

- **`symmetric_pair_offset_parity`** — for `m > 2`, every offset `k` of a symmetric prime pair satisfies `m % 2 ≠ k % 2`.
- **`symmetricPairCount_le_oppositeParityOffsets`** — for `m > 2`, the comet count is `≤` the number of offsets `k < m` of opposite parity to `m`.

Each is illustrated with `decide`-checked examples (`m = 5` even offsets, `m = 6` odd offset).

## Meta sync

The gallery meta counts were stale from earlier sessions (before the upper-bound and exact-identity theorems were added). Synced: `lineCount 262→351`, `theoremCount 9→12`, and added `originalContributions` entries for the upper-bound, exact-identity, and new offset-parity results.

## Verification

Builds clean:
```
./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetric
✔ Built Proofs.StrongGoldbachSymmetric
```
0 `axiom` declarations, 0 real `sorry` (only a docstring mention), no `native_decide`.

**The Strong Goldbach Conjecture itself remains open** — only structural bounds are proved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)