### PR TITLE
research(cayley-hamilton-oq-02-oq-01): algebraic Ṁ = A·M bridge for Putzer [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
@@ -46,7 +46,11 @@ matrix-valued ODE-uniqueness step) is deferred to a companion development.
 
 ## Status
 - [x] Algebraic core: complete, no sorries
-- [ ] Analytic layer (P_k construction, Ṁ = A·M, ODE uniqueness): future work
+- [x] Algebraic form of `Ṁ = A·M` (`A_mul_putzer_sum` / `A_mul_putzer_sum_charpoly`): the ODE
+      identity reduced to pure algebra, with the Cayley–Hamilton truncation discharging the
+      boundary term — no analysis
+- [ ] Analytic layer (P_k construction as ODE solutions, term-by-term differentiation of the
+      finite sum, matrix-valued ODE uniqueness against `NormedSpace.exp`): future work
 
 ## Mathlib dependencies
 - `Matrix.aeval_self_charpoly` : Cayley–Hamilton (χ_A(A) = 0)
@@ -163,5 +167,78 @@ lemma A_mul_sum_rho (A : Matrix n n R) (lam : ℕ → R) (a : ℕ → R) (m : �
   rw [Finset.mul_sum]
   refine Finset.sum_congr rfl (fun k _ => ?_)
   rw [mul_smul_comm, A_mul_rho]
+
+/-! ## The algebraic form of `Ṁ = A · M` (the analytic bridge)
+
+The Putzer solution is `M(t) = ∑_{k<n} P_k(t) • ρ_k`, where the scalar coefficients satisfy the
+triangular ODE system `Ṗ_k = λ_k P_k + P_{k-1}` (with the convention `P_{-1} ≡ 0`).  Differentiating
+term-by-term gives `Ṁ = ∑_{k<n} (λ_k P_k + P_{k-1}) • ρ_k`.  The claim that Putzer's formula solves
+`Ṁ = A · M` is therefore, *before any analysis is invoked*, the purely algebraic identity
+
+  `A · ∑_{k<n} P_k • ρ_k = ∑_{k<n} (λ_k P_k + P_{k-1}) • ρ_k`.
+
+The two lemmas below isolate exactly this identity and show that it holds **precisely because the
+Cayley–Hamilton truncation `ρ_n = 0` kills the boundary term** `P_{n-1} • ρ_n`.  The `P_{k-1}`
+convention (`P_{-1} = 0`) is encoded cleanly, without `ℕ`-subtraction, by a second coefficient
+family `Pprev` with `Pprev 0 = 0` and `Pprev (k+1) = P k`. -/
+
+/-- Re-indexing the shifted Putzer sum.  With `Pprev 0 = 0` and `Pprev (k+1) = P k` (so `Pprev`
+plays the role of `k ↦ P_{k-1}`), the sum of `P_k • ρ_{k+1}` over `k < m` equals the sum of
+`Pprev_k • ρ_k` over `k < m + 1`.  Pure book-keeping via `Finset.sum_range_succ'`. -/
+lemma sum_P_rho_succ (A : Matrix n n R) (lam P Pprev : ℕ → R)
+    (h0 : Pprev 0 = 0) (hsucc : ∀ k, Pprev (k + 1) = P k) (m : ℕ) :
+    ∑ k ∈ Finset.range m, P k • rho A lam (k + 1)
+      = ∑ k ∈ Finset.range (m + 1), Pprev k • rho A lam k := by
+  rw [Finset.sum_range_succ']
+  simp only [hsucc, h0, zero_smul, add_zero]
+
+/-- **Algebraic `Ṁ = A · M`.**  For the Putzer sum `M = ∑_{k<m} P_k • ρ_k`, multiplication by `A`
+reproduces the derivative coefficients `λ_k P_k + P_{k-1}` **as soon as the boundary product
+`ρ_m = 0` vanishes**:
+
+  `A · ∑_{k<m} P_k • ρ_k = ∑_{k<m} (λ_k P_k + Pprev_k) • ρ_k`.
+
+Here `Pprev` encodes `k ↦ P_{k-1}` (with `Pprev 0 = 0`).  The single hypothesis `hbdry : ρ_m = 0`
+is what makes the identity close: it deletes the otherwise-leftover term `P_{m-1} • ρ_m`.  This is
+the purely algebraic heart of Putzer's ODE argument — no analysis, over any `CommRing`. -/
+lemma A_mul_putzer_sum (A : Matrix n n R) (lam P Pprev : ℕ → R)
+    (h0 : Pprev 0 = 0) (hsucc : ∀ k, Pprev (k + 1) = P k) (m : ℕ)
+    (hbdry : rho A lam m = 0) :
+    A * ∑ k ∈ Finset.range m, P k • rho A lam k
+      = ∑ k ∈ Finset.range m, (lam k * P k + Pprev k) • rho A lam k := by
+  have hshift : ∑ k ∈ Finset.range m, P k • rho A lam (k + 1)
+      = ∑ k ∈ Finset.range m, Pprev k • rho A lam k := by
+    rw [sum_P_rho_succ A lam P Pprev h0 hsucc, Finset.sum_range_succ, hbdry, smul_zero,
+      add_zero]
+  calc A * ∑ k ∈ Finset.range m, P k • rho A lam k
+      = ∑ k ∈ Finset.range m, P k • (rho A lam (k + 1) + lam k • rho A lam k) :=
+        A_mul_sum_rho A lam P m
+    _ = ∑ k ∈ Finset.range m, (P k • rho A lam (k + 1) + (lam k * P k) • rho A lam k) := by
+        refine Finset.sum_congr rfl (fun k _ => ?_)
+        rw [smul_add, smul_smul, mul_comm (P k) (lam k)]
+    _ = (∑ k ∈ Finset.range m, P k • rho A lam (k + 1))
+          + ∑ k ∈ Finset.range m, (lam k * P k) • rho A lam k := Finset.sum_add_distrib
+    _ = (∑ k ∈ Finset.range m, (lam k * P k) • rho A lam k)
+          + ∑ k ∈ Finset.range m, Pprev k • rho A lam k := by rw [hshift, add_comm]
+    _ = ∑ k ∈ Finset.range m, ((lam k * P k) • rho A lam k + Pprev k • rho A lam k) :=
+        Finset.sum_add_distrib.symm
+    _ = ∑ k ∈ Finset.range m, (lam k * P k + Pprev k) • rho A lam k := by
+        refine Finset.sum_congr rfl (fun k _ => ?_); rw [add_smul]
+
+/-- **Putzer `Ṁ = A · M`, boundary supplied by Cayley–Hamilton.**  When `χ_A = ∏ i, (X - λ_i)`,
+the truncation `ρ_n = 0` (`rho_card`) automatically discharges the boundary term, so the algebraic
+`Ṁ = A · M` identity holds at the full length `n` with no side condition beyond the eigenvalue
+factorization:
+
+  `A · ∑_{k<n} P_k • ρ_k = ∑_{k<n} (λ_k P_k + P_{k-1}) • ρ_k`.
+
+This is the exact statement the deferred analytic layer will differentiate against: once `P_k` are
+the ODE coefficients, the left side is `A · M(t)` and the right side is `Ṁ(t)`. -/
+lemma A_mul_putzer_sum_charpoly {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam P Pprev : ℕ → R)
+    (h0 : Pprev 0 = 0) (hsucc : ∀ k, Pprev (k + 1) = P k)
+    (hlam : A.charpoly = ∏ i : Fin n, (X - C (lam i))) :
+    A * ∑ k ∈ Finset.range n, P k • rho A lam k
+      = ∑ k ∈ Finset.range n, (lam k * P k + Pprev k) • rho A lam k :=
+  A_mul_putzer_sum A lam P Pprev h0 hsucc n (rho_card A lam hlam)
 
 end PutzerMatrixExp

--- a/research/problems/cayley-hamilton-oq-02-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-oq-02-oq-01/knowledge.md
@@ -1,0 +1,34 @@
+
+## Session 2026-07-03 (researcher-16) - Algebraic Ṁ = A·M bridge
+
+**Mode**: FRESH (claimed from available pool, WEAK knowledge tier)
+**Outcome**: progress (3 new verified lemmas, 0 sorries, 0 axioms)
+
+### What I Did
+- The gallery entry proved only the algebraic *core* (telescoping identity `A·ρ_k = ρ_{k+1}+λ_k•ρ_k`
+  and the Cayley–Hamilton truncation `ρ_n = 0`). The analytic completion (`Ṁ = A·M`, ODE uniqueness)
+  was fully deferred.
+- Isolated the single most important missing bridge: the identity `Ṁ = A·M` is, *before any analysis*,
+  the pure-algebra statement
+    `A·∑_{k<m} P_k•ρ_k = ∑_{k<m} (λ_k P_k + P_{k-1})•ρ_k`,
+  which holds **iff the boundary product `ρ_m = 0` vanishes** — exactly what Cayley–Hamilton provides.
+- Formalized it as `A_mul_putzer_sum` (general boundary hypothesis) and `A_mul_putzer_sum_charpoly`
+  (boundary discharged by `rho_card` at length `n`), plus the reindexing helper `sum_P_rho_succ`.
+
+### Key Findings
+- The `P_{-1} = 0` convention is cleanly encoded without ℕ-subtraction by a second family `Pprev`
+  with `Pprev 0 = 0`, `Pprev (k+1) = P k`. Avoids `if k = 0` / `Nat.sub` pain in the sum reindexing.
+- The boundary term that the ODE argument must kill is exactly `Pprev m • ρ_m = P_{m-1} • ρ_n`;
+  `rho_card` (ρ_n = 0) deletes it. This pins down *where* Cayley–Hamilton enters the analytic proof.
+- Proof is pure `CommRing` algebra: `Finset.sum_range_succ'`, `add_smul`, `smul_smul`, `sum_add_distrib`.
+
+### Files Modified
+- proofs/Proofs/CayleyHamiltonOQ02OQ01.lean (+3 lemmas, 167→244 lines)
+- src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json (counts + originalContributions)
+
+### Next Steps
+- Analytic layer: define P_k(t) as ODE solutions (variation of parameters,
+  P_k(t)=∫_0^t e^{λ_k(t-s)}P_{k-1}(s)ds), show M(0)=I, differentiate the finite sum term-by-term to
+  get Ṁ = ∑(λ_k P_k + P_{k-1})•ρ_k, then apply `A_mul_putzer_sum_charpoly` to conclude Ṁ = A·M.
+- Final step needs matrix-valued ODE uniqueness vs `NormedSpace.exp` — assess Mathlib coverage
+  (`NormedSpace.exp`, `hasDerivAt` for `exp (t•A)`); likely the true remaining blocker.

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "problemStatement": "Formalize Putzer's algorithm: given eigenvalues λ₁,…,λₙ of A, prove e^{tA} = ∑ₖ Pₖ(t)ρₖ where ρₖ = ∏_{i<k}(A-λᵢI) and Ṗₖ = λₖPₖ + Pₖ₋₁. This entry contributes the verified algebraic core; the analytic completion remains open.",
   "meta": {
     "author": "Lean Genius (researcher-15)",
-    "date": "2026-07-02",
+    "date": "2026-07-03",
     "dateAdded": "2026-07-02",
     "status": "verified",
     "badge": "verified",
@@ -20,8 +20,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 125,
-    "theoremCount": 9,
+    "lineCount": 244,
+    "theoremCount": 14,
     "definitionCount": 1,
     "assumptions": "Derives from Mathlib's Cayley–Hamilton theorem (Matrix.aeval_self_charpoly). All results are fully machine-checked over an arbitrary CommRing R (0 sorries, 0 axiom declarations, no structure-encoded assumptions). SCOPE: this file proves only the ALGEBRAIC core of Putzer's algorithm — the telescoping identity and ρₙ = 0. It does NOT prove the full analytic identity e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}; the ODE-coefficient construction and the matrix-valued ODE-uniqueness step are deferred future work, so the parent's open question is only partially answered.",
     "originalContributions": [
@@ -29,8 +29,12 @@
       "commute_A_rho: A commutes with every partial product ρₖ (each factor is a polynomial in A)",
       "A_mul_rho: the key telescoping identity A·ρₖ = ρ_{k+1} + λₖ•ρₖ — the algebraic engine that lets the derivative Ṁ collapse to A·M",
       "rho_eq_aeval_prod: ρₖ = aeval A (∏_{i<k}(X - C λᵢ)), bridging the ordered matrix product to the commutative polynomial product",
-      "rho_card: Cayley–Hamilton truncation ρₙ = 0 when χ_A = ∏(X - λᵢ), making Putzer's sum finite and killing the boundary term Pₙρₙ"
-    ]
+      "rho_card: Cayley–Hamilton truncation ρₙ = 0 when χ_A = ∏(X - λᵢ), making Putzer's sum finite and killing the boundary term Pₙρₙ",
+      "A_mul_putzer_sum: the algebraic form of Ṁ = A·M — A·∑_{k<m} P_k•ρ_k = ∑_{k<m} (λ_k P_k + P_{k-1})•ρ_k, holding precisely when the boundary product ρ_m = 0; the P_{-1}=0 convention is encoded by a shifted family Pprev (Pprev 0 = 0, Pprev(k+1)=P k) avoiding ℕ-subtraction",
+      "A_mul_putzer_sum_charpoly: the Ṁ = A·M identity at full length n with the boundary discharged automatically by Cayley–Hamilton truncation (rho_card), giving the exact statement the deferred analytic layer differentiates against",
+      "sum_P_rho_succ: reindexing lemma ∑_{k<m} P_k•ρ_{k+1} = ∑_{k<m+1} Pprev_k•ρ_k bridging the shifted coefficient family to the partial-product shift"
+    ],
+    "dateModified": "2026-07-03"
   },
   "leanFile": {
     "namespace": "PutzerMatrixExp",


### PR DESCRIPTION
## Summary

Advances the **Putzer's Algorithm** gallery entry (`cayley-hamilton-oq-02-oq-01`), which previously proved only the *algebraic core* (telescoping identity + Cayley–Hamilton truncation `ρ_n = 0`) and deferred the entire analytic layer.

This PR adds the **algebraic form of the ODE identity `Ṁ = A·M`** — the single most important missing bridge between the verified algebra and the deferred analysis. Before any analysis is invoked, the claim that Putzer's formula `M = ∑_{k<n} P_k•ρ_k` solves `Ṁ = A·M` is exactly the pure-algebra identity

> `A·∑_{k<m} P_k•ρ_k = ∑_{k<m} (λ_k P_k + P_{k-1})•ρ_k`

which holds **precisely when the boundary product `ρ_m = 0` vanishes**. This isolates *where* Cayley–Hamilton (`rho_card`) enters the analytic proof: it deletes the otherwise-leftover boundary term `P_{m-1}•ρ_n`.

## New lemmas (all verified, 0 sorries, 0 axioms, arbitrary `CommRing`)

- `sum_P_rho_succ` — reindexing `∑_{k<m} P_k•ρ_{k+1} = ∑_{k<m+1} Pprev_k•ρ_k`
- `A_mul_putzer_sum` — `Ṁ = A·M` given the boundary hypothesis `ρ_m = 0`
- `A_mul_putzer_sum_charpoly` — boundary discharged automatically by Cayley–Hamilton at length `n`

The `P_{-1} = 0` convention is encoded cleanly by a shifted family `Pprev` (`Pprev 0 = 0`, `Pprev (k+1) = P k`), avoiding `ℕ`-subtraction in the sum manipulation.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ01` — **passes** (3058 jobs)
- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions; status remains `verified`.

## Scope / remaining open work

Still deferred (the true analytic blocker): constructing `P_k(t)` as ODE solutions, term-by-term differentiation of the finite sum, and matrix-valued ODE uniqueness against `NormedSpace.exp`. Once `P_k` are the ODE coefficients, `A_mul_putzer_sum_charpoly` is exactly the statement the analytic layer differentiates against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)