### PR TITLE
research(schroeder-bernstein-oq-03): cross-preservation of Balanced (Section 4i-quinquies) [VERIFIED 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -1740,6 +1740,121 @@ theorem balanced_cons_range {f g : ℕ → ℕ}
     (by rw [mRan_map_swap]; exact ha)
     haN
 
+/-!
+### Section 4i-quinquies: Cross-preservation of `Balanced` — the domain step preserves the
+    *swapped* balance too
+
+The extension-only scheduler alternates a domain (even) step and a range (odd) step, and each
+step's *escape* obligation is discharged on a different side: the domain step's escape
+(`escape_exists'`) needs `Balanced f g L`, while the range step's escape needs the swapped
+`Balanced g f (L.map Prod.swap)`. So the scheduler must carry **both** balances at once, and each
+atomic move must preserve **both**.
+
+`balanced_cons_domain` already shows a domain cons preserves `Balanced f g L`; the missing
+"cross" half is that a domain cons *also* preserves `Balanced g f (L.map Prod.swap)`. Note this is
+**not** an instance of `balanced_cons_range`: that lemma needs the placed pair `(a, b)` to satisfy
+`a = g (fwdOrbit g f b N')` (an `f∘g`-orbit relation), which holds only when `a`'s orbit is a
+*finite* cycle. When `a`'s `g∘f`-orbit is infinite no such `N'` exists, yet the swapped balance is
+still preserved (both intersections are inert on every `f∘g`-cycle). `balanced_swap_cons_domain`
+covers both cases uniformly, via a single `by_cases` on whether the escaped image `b` lies on the
+cycle `c` in question.
+
+The proof rests on two small orbit-algebra facts proved first:
+  * `fwdOrbit_swap_apply` — conjugation of the forward orbit by the head map: running the *swapped*
+    dynamics from `f x` equals `f ∘ (running the original dynamics from x)`. This is what lets the
+    escaped image `b = f (fwdOrbit f g a N)` be relocated onto the swapped `f∘g`-orbit.
+  * `onCycle_of_onCycle_apply` — if `f x` is `f∘g`-periodic then `x` is `g∘f`-periodic (cancel the
+    shared injective `f`). This transports periodicity of `b` back to periodicity of `a`.
+-/
+
+/-- **Conjugation of the forward orbit.** Running the swapped dynamics `g, f` from the point `f x`
+    is the `f`-image of running the original dynamics `f, g` from `x`:
+    `fwdOrbit g f (f x) j = f (fwdOrbit f g x j)`. (The `g∘f` and `f∘g` iterations are conjugate by
+    `f`.) The engine that moves the escaped green image between the two dynamics. -/
+theorem fwdOrbit_swap_apply (f g : ℕ → ℕ) (x j : ℕ) :
+    fwdOrbit g f (f x) j = f (fwdOrbit f g x j) := by
+  induction j with
+  | zero => rfl
+  | succ j ih => simp only [fwdOrbit, ih]
+
+/-- **Periodicity transports across `f`.** If `f x` is `f∘g`-periodic (`OnCycle g f (f x)`) then `x`
+    is `g∘f`-periodic (`OnCycle f g x`): the same positive period works after cancelling the shared
+    injective `f`. -/
+theorem onCycle_of_onCycle_apply {f g : ℕ → ℕ} (hf : Function.Injective f)
+    {x : ℕ} (h : OnCycle g f (f x)) : OnCycle f g x := by
+  obtain ⟨m, hm, hmeq⟩ := h
+  refine ⟨m, hm, ?_⟩
+  rw [fwdOrbit_swap_apply] at hmeq
+  exact hf hmeq
+
+/-- **Cross-preservation of `Balanced` (domain step preserves the swapped balance).** A domain cons
+    that prepends `(a, b)` with fresh domain anchor `a` and escaped green image
+    `b = f (fwdOrbit f g a N)` preserves the *swapped* cycle-balance `Balanced g f (L.map Prod.swap)`
+    — the invariant the odd-stage range escape (`escape_exists'` on the swapped problem) consumes.
+
+    Together with `balanced_cons_domain` (which preserves `Balanced f g L`) this discharges the
+    scheduler's obligation to carry both balances across a domain step; the range step is handled by
+    the coordinate-swap dual. On the `f∘g`-cycle `C` through any anchor `c`: if the escaped image
+    `b ∈ C` then `a` lands in `C.image g` (both sides gain one point); if `b ∉ C` then `a ∉ C.image g`
+    (both sides inert). The dichotomy is uniform — no separate periodic/infinite split at the top
+    level — because the "`a ∈ C.image g`" side is controlled entirely by whether `b ∈ C`. -/
+theorem balanced_swap_cons_domain {f g : ℕ → ℕ}
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hbal : Balanced g f (L.map Prod.swap)) {a b : ℕ}
+    (ha : a ∉ mDom L) (hb : b ∉ mRan L) {N : ℕ} (hbN : b = f (fwdOrbit f g a N)) :
+    Balanced g f (((a, b) :: L).map Prod.swap) := by
+  simp only [List.map_cons, Prod.swap_prod_mk]
+  intro c hc
+  have hdom : (mDom ((b, a) :: L.map Prod.swap)).toFinset = insert b (mRan L).toFinset := by
+    rw [mDom_cons, List.toFinset_cons, mDom_map_swap]
+  have hran : (mRan ((b, a) :: L.map Prod.swap)).toFinset = insert a (mDom L).toFinset := by
+    rw [mRan_cons, List.toFinset_cons, mRan_map_swap]
+  rw [hdom, hran]
+  have hbF : b ∉ (mRan L).toFinset := fun h => hb (List.mem_toFinset.mp h)
+  have haF : a ∉ (mDom L).toFinset := fun h => ha (List.mem_toFinset.mp h)
+  have hbalc := hbal hc
+  rw [mDom_map_swap, mRan_map_swap] at hbalc
+  by_cases hbC : b ∈ orbitCycle g f hc
+  · -- `b` on `c`'s `f∘g`-cycle ⟹ `a ∈ (cycle).image g`; both sides gain one fresh point.
+    have haImg : a ∈ (orbitCycle g f hc).image g := by
+      -- `b` periodic ⟹ `f (fwdOrbit f g a N)` periodic ⟹ `a` is `g∘f`-periodic.
+      have hocb : OnCycle g f b := onCycle_of_mem_orbitCycle hc hbC
+      rw [hbN] at hocb
+      have hoc_oN : OnCycle f g (fwdOrbit f g a N) := onCycle_of_onCycle_apply hf hocb
+      have hoa : OnCycle f g a := onCycle_of_fwdOrbit hf hg hoc_oN
+      have hmpos : 1 ≤ orbitPeriod f g hoa := orbitPeriod_pos hoa
+      refine Finset.mem_image.mpr
+        ⟨fwdOrbit g f b (orbitPeriod f g hoa * (N + 2) - (N + 1)), ?_, ?_⟩
+      · exact fwdOrbit_mem_orbitCycle hc hbC _
+      · -- `g (fwdOrbit g f b j) = fwdOrbit f g a (N + j + 1) = a` for the chosen `j`.
+        rw [hbN, fwdOrbit_swap_apply,
+          ← fwdOrbit_succ f g (fwdOrbit f g a N) (orbitPeriod f g hoa * (N + 2) - (N + 1)),
+          ← fwdOrbit_add f g a (orbitPeriod f g hoa * (N + 2) - (N + 1) + 1) N]
+        have hge : N + 1 ≤ orbitPeriod f g hoa * (N + 2) := by nlinarith [hmpos]
+        have harith :
+            orbitPeriod f g hoa * (N + 2) - (N + 1) + 1 + N = orbitPeriod f g hoa * (N + 2) := by
+          omega
+        rw [harith, fwdOrbit_mul_period hoa (N + 2)]
+    rw [Finset.inter_insert_of_mem hbC, Finset.inter_insert_of_mem haImg,
+      Finset.card_insert_of_notMem (fun h => hbF (Finset.mem_inter.mp h).2),
+      Finset.card_insert_of_notMem (fun h => haF (Finset.mem_inter.mp h).2),
+      hbalc]
+  · -- `b` off `c`'s cycle ⟹ `a ∉ (cycle).image g`; both intersections are inert.
+    have hanImg : a ∉ (orbitCycle g f hc).image g := by
+      intro hmem
+      rw [Finset.mem_image] at hmem
+      obtain ⟨y, hyC, hya⟩ := hmem
+      -- if `a = g y` with `y` on the cycle then `b = fwdOrbit g f y (N+1)` is on it too.
+      apply hbC
+      have hby : b = fwdOrbit g f y (N + 1) := by
+        have hconj : fwdOrbit f g (g y) N = g (fwdOrbit g f y N) := fwdOrbit_swap_apply g f y N
+        rw [hbN, ← hya, hconj]
+        simp only [fwdOrbit]
+      rw [hby]
+      exact fwdOrbit_mem_orbitCycle hc hyC (N + 1)
+    rw [Finset.inter_insert_of_notMem hbC, Finset.inter_insert_of_notMem hanImg]
+    exact hbalc
+
 /-- **Escape existence (bounded).** For a fresh domain anchor `a ∉ mDom L` in a matching `L`
     satisfying the construction invariant, some forward-orbit stage `N ≤ (mDom L).length` has a
     green image `f (fwdOrbit f g a N)` that is *fresh* in the range. Equivalently the collision

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -919,3 +919,65 @@ must ALSO preserve the swapped balance (and dually for the range step). Each is 
 foreign-cycle-exclusion argument applied on the OTHER dynamics: a domain cons `(a, f(fwdOrbit f g a
 N))` adds `a` to mDom and `b` to mRan; for the `g∘f`-*reverse* (`f∘g`) cycles counted by the
 swapped balance, `a` lands on some `f∘g`-cycle iff `b` does — provable but not yet formalized.
+
+## Session 2026-07-03 (researcher-14): cross-preservation closed — Section 4i-quinquies (VERIFIED 0-axiom)
+
+Closed the single remaining step-4 blocker before scheduler assembly: **cross-preservation** of
+`Balanced`. The extension-only scheduler alternates a domain (even) and range (odd) step, and each
+step's escape obligation is discharged on a *different* side — the domain step's `escape_exists'`
+needs `Balanced f g L`, the range step's needs the swapped `Balanced g f (L.map swap)`. So the
+scheduler must carry BOTH balances and each atomic move must preserve BOTH. `balanced_cons_domain`
+(r16, #34114) already preserves `Balanced f g L` under a domain cons; the missing "cross" half was
+that a domain cons ALSO preserves `Balanced g f (L.map swap)`.
+
+Added **Section 4i-quinquies** to `SchroederBernsteinOQ03.lean` (3 decls, all VERIFIED 0-axiom —
+`#print axioms` = {propext, Classical.choice, Quot.sound} for the main lemma; {propext} for the two
+helpers; no sorryAx, no ofReduceBool). File 2460→2559 lines. Main `myhill_isomorphism` → sorry
+UNCHANGED (still open).
+
+- `fwdOrbit_swap_apply : fwdOrbit g f (f x) j = f (fwdOrbit f g x j)` — the `g∘f` and `f∘g`
+  iterations are conjugate by `f`; the engine that relocates the escaped green image
+  `b = f (fwdOrbit f g a N)` onto the swapped `f∘g`-orbit. 2-line induction.
+- `onCycle_of_onCycle_apply : Injective f → OnCycle g f (f x) → OnCycle f g x` — periodicity
+  transports across `f` (cancel the shared injective `f`).
+- `balanced_swap_cons_domain` (main): a domain cons `(a,b)` with `b = f (fwdOrbit f g a N)` fresh
+  preserves `Balanced g f (L.map swap)`.
+
+**Key point — why this is NOT `balanced_cons_range`.** `balanced_cons_range` needs the placed pair
+to satisfy `a = g (fwdOrbit g f b N')` (an `f∘g`-orbit relation between `a` and `b`). Computing
+`g (fwdOrbit g f b j) = fwdOrbit f g a (N+j+1)`, so `a = g(fwdOrbit g f b j)` requires
+`fwdOrbit f g a (N+j+1) = a`, i.e. `a` returns to itself — possible ONLY when `a`'s `g∘f`-orbit is
+a finite cycle. When the orbit is infinite there is NO such `N'`, yet the swapped balance is still
+preserved (both intersections inert on every `f∘g`-cycle). `balanced_swap_cons_domain` handles both
+uniformly via a single `by_cases` on `b ∈ orbitCycle g f hc` — the dichotomy that actually controls
+the invariant, rather than the periodic/infinite split at the top level:
+  * `b ∈ C`: `b` periodic ⟹ (via `onCycle_of_onCycle_apply` + `onCycle_of_fwdOrbit`) `a` is
+    `g∘f`-periodic with period `m`; the witness `y := fwdOrbit g f b (m*(N+2) − (N+1))` lands in `C`
+    (closure, `fwdOrbit_mem_orbitCycle`) and `g y = fwdOrbit f g a (m*(N+2)) = a`
+    (`fwdOrbit_mul_period`). So `a ∈ C.image g`; both sides gain one fresh point.
+  * `b ∉ C`: if `a = g y` with `y ∈ C` then `b = fwdOrbit g f y (N+1) ∈ C` (closure) — contradiction.
+    So `a ∉ C.image g`; both sides inert.
+
+The clean direction (`b ∉ C`) needs no modular arithmetic; only the `b ∈ C` witness does, and it is
+purely mechanical given the existing orbit-algebra tower (`fwdOrbit_add`, `fwdOrbit_mul_period`,
+`fwdOrbit_swap_apply`, `fwdOrbit_succ`).
+
+### Next Steps (updated)
+1. **Range-step dual:** `balanced_cons_range` (swapped) + the analogous `balanced_swap_cons_range`
+   (a range cons preserves `Balanced f g L`) — obtainable for free from `balanced_swap_cons_domain`
+   by the `Prod.swap` duality (apply to `(g, f, L.map swap)`), mirroring how `balanced_cons_range`
+   reuses `balanced_cons_domain`. This completes "carry BOTH balances across BOTH steps".
+2. Build the extension-only stage function on `domain_step_exists` (cons; escape via
+   `escape_exists'`) carrying the pair `(Balanced f g L, Balanced g f (L.map swap))`, preserved by
+   `balanced_cons_domain` + `balanced_swap_cons_domain` (even) and the two range duals (odd).
+3. Read off `e` via `mLookup` + `mLookup_stable` (pair-monotone since cons-only), prove `.Computable`,
+   discharge the `myhill_isomorphism` sorry. NOTE: the current Section 4m `stageSeq` is built on the
+   *splicing* `augment_*_step` (removes/relabels g-edges ⟹ NOT pair-monotone ⟹ `mLookup_stable` does
+   not apply). The decided Path B rebuilds `stageSeq` on the cons steps above; do NOT read off the
+   existing splicing `stageSeq`.
+
+**Build/verify:** r16's non-Docker path confirmed working this session — the file is self-contained
+on Mathlib, so `LEAN_PATH` → main repo's prebuilt package oleans
+(`$MAIN/proofs/.lake/packages/*/.lake/build/lib/lean` + `$MAIN/proofs/.lake/build/lib/lean`) with
+`elan run leanprover/lean4:v4.26.0 lean Proofs/SchroederBernsteinOQ03.lean`. Full file compiles in
+~30s (oleans cached); only warning is the expected `myhill_isomorphism` sorry. No Docker, no lake build.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -4,16 +4,18 @@
 **Phase**: DEVELOP
 **Path**: full — **extension-only (Path B) chosen; fork RESOLVED 2026-07-03 (r4)**
 **Since**: 2026-07-02
-**Iteration**: 7
+**Iteration**: 8
 
 ## Current Focus
-The `BuiltFrom`-free **escape** side AND the invariant *preservation* (Claim B) are now both
-closed (2026-07-03, r16): `Balanced` over `orbitCycle`, `balanced_nil`, `escape_of_balanced`,
-`escape_exists'` (Section 4i-ter) plus `balanced_cons_domain` / `balanced_cons_range` (Section
-4i-quater) all VERIFIED 0-axiom. Remaining critical path is **scheduler assembly** (step 4) and
-its one genuinely-new obligation, *cross-preservation* (see Blockers). The termination↔stability
-fork is decided: cons steps suffice, so `mLookup_stable` applies directly and no finite-injury
-stabilization is needed.
+Escape, same-side preservation (Claim B), AND now **cross-preservation** (the domain step's
+half) are all closed. `balanced_swap_cons_domain` (Section 4i-quinquies, 2026-07-03 r14, VERIFIED
+0-axiom) shows a domain cons preserves the *swapped* balance `Balanced g f (L.map swap)` too —
+uniformly over both the periodic and infinite-orbit cases (single `by_cases` on `b ∈ cycle`, NOT
+reducible to `balanced_cons_range` which needs the periodic-only `a = g(fwdOrbit g f b N')`).
+Remaining critical path is **scheduler assembly** (step 4): the range-step dual of cross-preservation
+(free by `Prod.swap` duality) + the cons-based `stageSeq` carrying both balances + the computable
+read-off. The termination↔stability fork is decided: cons steps suffice, so `mLookup_stable` applies
+directly and no finite-injury stabilization is needed.
 
 ## Active Approach
 Stage-wise finite back-and-forth (Rogers §7.4), **extend-only**. Even/odd atomic moves DONE and
@@ -35,16 +37,19 @@ cons supplies an f-edge-like pair) but the *count* is preserved. Path B is viabl
   (`OrbitGEdged`) refuted, replaced by `Balanced`.
 
 ## Blockers
-No strategic blocker remains — the path is decided and Claim B is closed. The one genuinely-new
-step-4 obligation surfaced while proving the cons lemmas: **cross-preservation**. The scheduler
+No strategic blocker remains — the path is decided, Claim B is closed, and the domain-step half of
+**cross-preservation** is now closed too (`balanced_swap_cons_domain`, r14 2026-07-03). The scheduler
 must carry BOTH `Balanced f g L` (domain-side escape via `escape_exists'`) and
-`Balanced g f (L.map Prod.swap)` (range-side escape, swap-dual). `balanced_cons_domain` preserves
-the former under a domain cons; `balanced_cons_range` preserves the latter under a range cons.
-Still to prove: the domain step *also* preserves the swapped balance, and the range step *also*
-preserves `Balanced f g L` (each step touches at most one cycle on each side; the untouched side's
-balance is inert because the added pair's foreign coordinate lands off every foreign cycle —
-same foreign-cycle-exclusion argument as `mem_orbitCycle_of_fwdOrbit_mem`, applied on the other
-dynamics). Not hard, but not yet formalized. **Build environment is NOT hostile** —
+`Balanced g f (L.map Prod.swap)` (range-side escape, swap-dual) across BOTH atomic moves. Status of
+the four preservation obligations:
+- domain cons preserves `Balanced f g L` — DONE (`balanced_cons_domain`, r16).
+- domain cons preserves `Balanced g f (L.map swap)` — **DONE (`balanced_swap_cons_domain`, r14).**
+- range cons preserves `Balanced g f (L.map swap)` — DONE (`balanced_cons_range`, r16).
+- range cons preserves `Balanced f g L` — the swap-dual of `balanced_swap_cons_domain`, still to
+  formalize (should be ~free: apply `balanced_swap_cons_domain` to the swapped problem
+  `(g, f, L.map swap)`, mirroring how `balanced_cons_range` reuses `balanced_cons_domain`).
+Then the remaining step-4 work is pure assembly (cons-based `stageSeq` + read-off + computability).
+**Build environment is NOT hostile** —
 researcher-16 established a reliable verify path (2026-07-03): the file is self-contained on
 Mathlib, so compile the worktree copy with `LEAN_PATH` → the main repo's prebuilt oleans and
 `elan run leanprover/lean4:v4.26.0 lean` (no Docker, no `lake build`). Recorded in knowledge.md.


### PR DESCRIPTION
## Summary

Closes the **domain-step half of cross-preservation** — the last genuinely-new obligation before the extension-only scheduler assembly of Myhill's isomorphism theorem (`schroeder-bernstein-oq-03`).

The extension-only back-and-forth alternates a domain (even) and range (odd) step, and each step's *escape* obligation is discharged on a different side: the domain step's `escape_exists'` needs `Balanced f g L`, while the range step's needs the swapped `Balanced g f (L.map Prod.swap)`. So the scheduler must carry **both** balances and every atomic move must preserve **both**. `balanced_cons_domain` (r16, #34114) already preserves `Balanced f g L` under a domain cons; this PR adds the missing "cross" half.

## New declarations (Section 4i-quinquies)

All VERIFIED 0-axiom — `#print axioms` = `{propext, Classical.choice, Quot.sound}` for the main lemma, `{propext}` for the helpers; **no `sorryAx`, no `ofReduceBool`**.

- `fwdOrbit_swap_apply : fwdOrbit g f (f x) j = f (fwdOrbit f g x j)` — the `g∘f` and `f∘g` iterations are conjugate by `f`.
- `onCycle_of_onCycle_apply : Injective f → OnCycle g f (f x) → OnCycle f g x` — periodicity transports across `f`.
- `balanced_swap_cons_domain` (main) — a domain cons `(a,b)` with `b = f(fwdOrbit f g a N)` fresh preserves `Balanced g f (L.map Prod.swap)`.

## Why this is not `balanced_cons_range`

`balanced_cons_range` requires the placed pair to satisfy `a = g(fwdOrbit g f b N')`, which holds **only** when `a`'s `g∘f`-orbit is a finite cycle (computing `g(fwdOrbit g f b j) = fwdOrbit f g a (N+j+1)`, so `a = g(…)` forces `a` to return to itself). For infinite orbits no such `N'` exists, yet the swapped balance is still preserved (both intersections inert on every `f∘g`-cycle). `balanced_swap_cons_domain` handles both cases uniformly via a single `by_cases` on `b ∈ orbitCycle`.

## Status

- `myhill_isomorphism` → hard-direction `sorry` **UNCHANGED** (still open). This is infrastructure toward it, not closure.
- File `SchroederBernsteinOQ03.lean`: 2460 → 2559 lines, +3 decls. No duplicate declaration names; full file compiles clean (only the expected `myhill_isomorphism` sorry warning).

## Verification

Non-Docker path (file is self-contained on Mathlib): `LEAN_PATH` → main repo prebuilt package oleans + `elan run leanprover/lean4:v4.26.0 lean Proofs/SchroederBernsteinOQ03.lean`. Compiles in ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)