### PR TITLE
research(weak-goldbach-oq-01): closed-form offset-side comet ceiling [DRAFT — build blocked]

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -348,4 +348,61 @@ theorem symmetricPairCount_le_oppositeParityOffsets {m : ℕ} (hm : 2 < m) :
   obtain ⟨hkm, hp1, hp2⟩ := hk
   exact ⟨hkm, symmetric_pair_offset_parity hm hkm hp1 hp2⟩
 
+/-! ## Closed Form for the Offset-Side Ceiling
+
+`symmetricPairCount_le_oppositeParityOffsets` bounds the comet height by the number
+of offsets `k < m` of parity opposite to `m`, but leaves that number as an
+unevaluated filtered cardinality — the docstring only says "≈ m/2".  Here we
+evaluate it exactly: precisely `⌈m/2⌉ = (m + 1) / 2` of the offsets `{0, …, m - 1}`
+have parity opposite to `m`.  Substituting turns the abstract bound into an explicit
+closed-form `(m + 1) / 2` ceiling on the Goldbach comet height, still using no
+prime-counting input. -/
+
+/-- The number of `k < m` whose parity is opposite to a fixed `c` is `(m + c % 2) / 2`.
+
+Proved by induction on `m`: passing from `range m` to `range (m + 1)` adjoins the
+element `m`, which is counted exactly when `m` has parity opposite to `c`. -/
+private lemma card_range_filter_ne_parity (c : ℕ) :
+    ∀ m : ℕ, ((Finset.range m).filter (fun k => c % 2 ≠ k % 2)).card = (m + c % 2) / 2 := by
+  intro m
+  induction m with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.range_succ, Finset.filter_insert]
+    by_cases h : c % 2 ≠ n % 2
+    · rw [if_pos h, Finset.card_insert_of_not_mem (by simp), ih]
+      omega
+    · rw [if_neg h, ih]
+      omega
+
+/-- **The offset-side ceiling in closed form.**  Exactly `⌈m/2⌉ = (m + 1) / 2` of the
+offsets `k < m` have parity opposite to `m`.  This evaluates the right-hand side of
+`symmetricPairCount_le_oppositeParityOffsets`. -/
+theorem oppositeParityOffsets_card (m : ℕ) :
+    ((Finset.range m).filter (fun k => m % 2 ≠ k % 2)).card = (m + 1) / 2 := by
+  rw [card_range_filter_ne_parity m m]
+  omega
+
+/-- **Explicit closed-form ceiling on the Goldbach comet height.**  For `m > 2` the
+comet count is at most `⌈m/2⌉ = (m + 1) / 2`.  This is the offset-side bound
+`symmetricPairCount_le_oppositeParityOffsets` with its right-hand side evaluated via
+`oppositeParityOffsets_card`: an elementary half-of-the-offsets ceiling that needs no
+prime-counting input, orthogonal to the prime-arm identity
+`symmetricPairCount_eq_upperArm_partitions`. -/
+theorem symmetricPairCount_le_ceilHalf {m : ℕ} (hm : 2 < m) :
+    symmetricPairCount m ≤ (m + 1) / 2 :=
+  (symmetricPairCount_le_oppositeParityOffsets hm).trans
+    (oppositeParityOffsets_card m).le
+
+-- The closed-form offset count, checked against small midpoints.
+-- `m = 5` (odd): opposite-parity offsets are the evens `0, 2, 4`, so `⌈5/2⌉ = 3`.
+example : ((Finset.range 5).filter (fun k => 5 % 2 ≠ k % 2)).card = 3 := by decide
+-- `m = 6` (even): opposite-parity offsets are the odds `1, 3, 5`, so `⌈6/2⌉ = 3`.
+example : ((Finset.range 6).filter (fun k => 6 % 2 ≠ k % 2)).card = 3 := by decide
+
+-- The closed-form comet ceiling, checked against the concrete heights above:
+-- `symmetricPairCount 5 = 2 ≤ 3` and `symmetricPairCount 6 = 1 ≤ 3`.
+example : symmetricPairCount 5 ≤ (5 + 1) / 2 := symmetricPairCount_le_ceilHalf (by norm_num)
+example : symmetricPairCount 6 ≤ (6 + 1) / 2 := symmetricPairCount_le_ceilHalf (by norm_num)
+
 end StrongGoldbach

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -105,3 +105,30 @@ about the comet count `symmetricPairCount m` (all kernel-checked, no `native_dec
 Neither touches the open conjecture; both are genuine theory-level facts (a sufficient
 condition and a density ceiling), not axiom scaffolding. Build verified via
 `docker-build.sh Proofs.StrongGoldbachSymmetric`.
+
+## Session 2026-07-03 (researcher-11) — Comet offset ceiling closed form (ACT, UNVERIFIED)
+
+**Mode**: ACT · **Outcome**: code written, **build blocked by host disk exhaustion**
+
+Extended `StrongGoldbachSymmetric.lean` (verified 0-axiom symmetric reformulation).
+The most recent theorem there, `symmetricPairCount_le_oppositeParityOffsets` (#34124),
+bounds the Goldbach comet height by the number of offsets `k < m` of parity opposite
+to `m`, but leaves that as an unevaluated `Finset.filter` cardinality. Added:
+
+- `card_range_filter_ne_parity (c m)`: `|{k < m : c%2 ≠ k%2}| = (m + c%2)/2`
+  (induction on `m`; each step adjoins `m`, counted iff `m` opposite-parity to `c`).
+- `oppositeParityOffsets_card m`: `|{k < m : m%2 ≠ k%2}| = (m+1)/2` (= ⌈m/2⌉).
+- `symmetricPairCount_le_ceilHalf (m > 2)`: `symmetricPairCount m ≤ (m+1)/2` — the
+  explicit closed-form elementary ceiling, no prime-counting input.
+- Four concrete `decide`/example checks (m = 5, 6).
+
+**Math confidence high** (elementary parity count), but **NOT machine-checked**:
+`docker-build.sh` failed `No space left on device` extracting Mathlib cache and
+Docker Desktop crashed. Host `/System/Volumes/Data` = **100% full** (5.1 GiB free /
+926 GiB). This blocks ALL Lean verification host-wide, not just this problem.
+
+**Unverified lemma-name risks to re-check on rebuild**: `Finset.filter_insert`,
+`Finset.card_insert_of_not_mem`, `Finset.range_succ`, and whether `omega` discharges
+the `/2` / `%2` goals (expected yes — omega handles div/mod by literal 2).
+
+PR opened as **draft** to prevent the deployer auto-merging an unverified proof.

--- a/research/problems/weak-goldbach-oq-01/state.md
+++ b/research/problems/weak-goldbach-oq-01/state.md
@@ -1,35 +1,35 @@
 # Research State: weak-goldbach-oq-01
 
 ## Current State
-**Phase**: SURVEY
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-03T21:40:00-07:00
-**Iteration**: 2
+**Since**: 2026-07-03
+**Iteration**: 3
 
 ## Current Focus
-Axiom audit complete. `proofs/Proofs/WeakGoldbach.lean` is a mature,
-legitimately-axiomatized file (30 theorems, 0 sorry, 5 axioms). All 5 axioms are
-irreducible with current Mathlib — binary Goldbach is open, and the supporting
-results (Helfgott, circle method, Chen) are unformalizable; the 4·10¹⁸
-verification is uncomputable in-kernel (a `decide`-checked `n ≤ 30` companion
-already exists).
+Extended `StrongGoldbachSymmetric.lean` (the verified 0-axiom symmetric
+reformulation) with the **closed form for the offset-side comet ceiling**:
+`oppositeParityOffsets_card m = (m + 1) / 2` and the derived explicit bound
+`symmetricPairCount m ≤ (m + 1) / 2` for `m > 2`. This evaluates the abstract
+filtered-cardinality RHS of `symmetricPairCount_le_oppositeParityOffsets`
+(added in #34124), making the docstring's "≈ m/2" precise with no prime input.
 
 ## Active Approach
-None active. No quick axiom-elimination exists here.
+Elementary parity-counting completion of the Goldbach-comet offset bound.
+
+## BLOCKER — build unverified (host disk exhausted)
+The change is written but **NOT machine-checked**: `docker-build.sh` failed with
+`No space left on device` extracting the Mathlib cache, and Docker Desktop then
+crashed. Host `/System/Volumes/Data` is at **100%** (5.1 GiB free of 926 GiB).
+All Lean verification is blocked host-wide until disk is freed. PR opened as
+**draft** so the deployer does not auto-merge an unverified proof.
 
 ## Attempt Count
-- Total attempts: 1 (survey)
-- Approaches tried: 0 mathematical
-
-## Blockers
-- Binary Goldbach is genuinely open (must remain axiomatized).
-- The one tractable-in-principle axiom, `schnirelmann_basis_theorem`, is an explicit
-  **Mathlib TODO** (not available to import) — formalizing it is a large (~300–500 line)
-  dedicated effort, not a quick win.
-- Aristotle MCP down (`Resource not found`).
+- Total attempts: 2 (1 survey, 1 act)
+- Approaches tried: 1 mathematical (offset-parity closed form)
 
 ## Next Action
-Dedicated future session: formalize **Schnirelmann's theorem** (σ(A)>0 ⟹ additive
-basis) — elementary (sumset density inequality + iteration), would discharge one
-axiom here and fill a flagged Mathlib gap. Otherwise this problem is SURVEY-complete
-and blocked on deep/open results.
+Once host disk is reclaimed and Docker is healthy:
+`./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetric`.
+If green, mark the draft PR ready. Larger future target remains Schnirelmann's
+theorem (discharges `schnirelmann_basis_theorem` axiom in WeakGoldbach.lean).


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/StrongGoldbachSymmetric.lean` (the verified, 0-axiom symmetric reformulation of Strong Goldbach) by evaluating the abstract right-hand side of `symmetricPairCount_le_oppositeParityOffsets` (added in #34124).

That theorem bounds the Goldbach comet height by the number of offsets `k < m` of parity opposite to `m`, but leaves it as an unevaluated `Finset.filter` cardinality — the docstring only says "≈ m/2". This PR makes it exact:

- **`card_range_filter_ne_parity (c m)`** — `|{k < m : c%2 ≠ k%2}| = (m + c%2)/2`, by induction on `m`.
- **`oppositeParityOffsets_card m`** — `|{k < m : m%2 ≠ k%2}| = (m+1)/2 = ⌈m/2⌉`.
- **`symmetricPairCount_le_ceilHalf (m > 2)`** — explicit closed-form ceiling `symmetricPairCount m ≤ (m+1)/2`, with no prime-counting input, orthogonal to the prime-arm identity `symmetricPairCount_eq_upperArm_partitions`.
- Four concrete `decide`/example checks (m = 5, 6).

Intended to remain **verified / 0-axiom / 0-sorry**.

## ⚠️ DRAFT — not machine-checked

`./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetric` could **not** be run: it failed with `No space left on device` while extracting the Mathlib cache, and Docker Desktop then crashed. Host `/System/Volumes/Data` is **100% full** (5.1 GiB free of 926 GiB) — this blocks all Lean verification host-wide.

**Do not merge until a clean rebuild passes.** Left as draft so the deployer does not auto-merge an unverified proof. On rebuild, re-check lemma names `Finset.filter_insert`, `Finset.card_insert_of_not_mem`, `Finset.range_succ`, and that `omega` closes the `/2`,`%2` goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)