### PR TITLE
LLL OQ-01: conditional (relative) quantitative avoidance bound

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean
@@ -1,0 +1,140 @@
+/-
+# Lovász Local Lemma — OQ-01: Conditional (Relative) Quantitative Avoidance Bound
+
+`Proofs/LovaszLocalLemmaOQ01Quantitative.lean` proves the flagship quantitative
+avoidance bound `∏ₖ (1 - bₖ) ≤ μ (⋂ᵢ Aᵢᶜ)` from per-event *conditional* failure
+bounds `μ[Aₖ | ⋂_{j<k} Aⱼᶜ] ≤ bₖ < 1`. That statement lives over the ambient
+measure `μ`. The genuine Erdős–Lovász induction, however, never estimates a bare
+avoidance probability: its **denominator recursion** lower-bounds the survival of
+one block of events *conditioned on the survival of another* —
+
+  `μ[⋂_{j∈S₁} Aⱼᶜ | ⋂_{j∈S₂} Aⱼᶜ] ≥ ∏_{j∈S₁} (1 - xⱼ)`.
+
+`Proofs/LovaszLocalLemmaOQ01DependencySplit.lean` isolated the numerator half of the
+induction step; this file supplies the **relative quantitative bound** the
+denominator recursion is built from: the exact analogue of
+`avoidance_ge_prod_one_sub`, but with *every* probability taken relative to a fixed
+background event `H` (in the recursion, `H = ⋂_{j∈S₂} Aⱼᶜ`).
+
+The proof adds no new probabilistic content — it *transports* the flagship
+unconditional bound along the conditioning map. Conditioning on `H` yields a genuine
+probability measure `μ[·|H]` (`cond_isProbabilityMeasure`, valid since `μ H ≠ 0` and
+`μ` is finite); the tower property `cond_cond_eq_cond_inter`
+(`μ[·|H][·|G] = μ[·|H ∩ G]`) identifies its internal conditionals with the
+background-relative conditionals `μ[Aₖ | (⋂_{j<k} Aⱼᶜ) ∩ H]`; and the avoidance
+probability under `μ[·|H]` is by definition `μ[⋂ᵢ Aᵢᶜ | H]`. Applying
+`avoidance_ge_prod_one_sub` to `μ[·|H]` therefore delivers the relative bound
+verbatim.
+
+This is precisely the primitive the LLL denominator recursion invokes: fix the
+non-neighbour survival `H`, order the block `S₁` as a prefix `range n`, and the
+relative chain rule / quantitative bound gives `∏(1 - xⱼ)` from the per-factor
+conditional bounds. What remains open is the well-founded recursion that *supplies*
+those per-factor bounds (each conditioning set is strictly smaller, so the LLL
+inductive hypothesis applies); this file removes the "condition on a background
+event" obstacle that blocked reusing the prefix scaffold inside that recursion.
+
+## Main results
+
+* `cond_avoidance_ge_prod_one_sub` : the relative quantitative bound
+  `∏ₖ (1 - bₖ) ≤ μ[⋂ᵢ Aᵢᶜ | H]` from background-relative conditional failure
+  bounds `μ[Aₖ | (⋂_{j<k} Aⱼᶜ) ∩ H] ≤ bₖ < 1`.
+* `cond_avoidance_ge_one_sub_pow` : the symmetric specialisation
+  `(1 - p)ⁿ ≤ μ[⋂ᵢ Aᵢᶜ | H]` under a uniform relative bound `≤ p < 1`.
+* `cond_avoidance_pos_of_prod_one_sub_pos` : positivity of the relative avoidance
+  probability, `0 < μ[⋂ᵢ Aᵢᶜ | H]`, whenever every `bₖ < 1`.
+
+No independence hypothesis is used; everything is `Finset.range`-indexed over an
+arbitrary `IsProbabilityMeasure`, relative to an arbitrary positive-measure
+background event.
+-/
+import Proofs.LovaszLocalLemmaOQ01Quantitative
+
+open MeasureTheory ProbabilityTheory Finset
+open scoped ENNReal
+open LovaszLocalLemmaOQ01ChainRule
+open LovaszLocalLemmaOQ01Quantitative
+
+namespace LovaszLocalLemmaOQ01ConditionalAvoidance
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A : ℕ → Set Ω}
+
+/-- **Conditional (relative) quantitative Lovász Local Lemma bound.**
+Fix a background event `H` of positive measure. If every conditional failure
+probability *relative to `H`* is bounded,
+
+  `μ[Aₖ | (⋂_{j<k} Aⱼᶜ) ∩ H] ≤ bₖ < 1`   for all `k < n`,
+
+then the avoidance probability relative to `H` is at least the survival-budget
+product:
+
+  `∏ₖ (1 - bₖ) ≤ μ[⋂ᵢ Aᵢᶜ | H]`.
+
+This is `avoidance_ge_prod_one_sub` transported to the conditioned probability
+measure `μ[·|H]`: it is the exact primitive the Erdős–Lovász **denominator
+recursion** invokes, where `H = ⋂_{j∈S₂} Aⱼᶜ` is the survival of the non-neighbours
+and the `Aₖ` range over an ordered block `S₁`.
+
+Proof: `cond_isProbabilityMeasure` makes `μ[·|H]` a probability measure; the tower
+property `cond_cond_eq_cond_inter` rewrites each internal conditional
+`μ[·|H][Aₖ | ⋂_{j<k} Aⱼᶜ]` as the background-relative conditional
+`μ[Aₖ | H ∩ ⋂_{j<k} Aⱼᶜ]`, so the hypotheses of `avoidance_ge_prod_one_sub`
+(applied to `μ[·|H]`) are exactly the relative bounds; its conclusion
+`∏ (1 - bₖ) ≤ μ[·|H] (⋂ Aᵢᶜ)` is definitionally the claim. -/
+theorem cond_avoidance_ge_prod_one_sub (hA : ∀ i, MeasurableSet (A i))
+    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ)
+    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)
+    (hfail : ∀ k ∈ Finset.range n,
+      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) :
+    ∏ k ∈ Finset.range n, (1 - b k) ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by
+  haveI : IsProbabilityMeasure (μ[|H]) := cond_isProbabilityMeasure hHne
+  -- The conditionals of the conditioned measure `μ[·|H]` are the background-relative
+  -- conditionals, via the tower property `μ[·|H][·|G] = μ[·|H ∩ G]`.
+  have hfail' : ∀ k ∈ Finset.range n,
+      (μ[|H])[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k := by
+    intro k hk
+    have hGk : MeasurableSet (⋂ j ∈ Finset.range k, (A j)ᶜ) :=
+      measurableSet_hist (fun i => (hA i).compl) k
+    rw [cond_cond_eq_cond_inter hH hGk μ, Set.inter_comm H]
+    exact hfail k hk
+  calc ∏ k ∈ Finset.range n, (1 - b k)
+      ≤ (μ[|H]) (⋂ i ∈ Finset.range n, (A i)ᶜ) :=
+        avoidance_ge_prod_one_sub hA n b hb hfail'
+    _ = μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := rfl
+
+/-- **Symmetric relative quantitative bound.**
+The uniform specialisation of `cond_avoidance_ge_prod_one_sub`: a single background-
+relative bound `μ[Aₖ | (⋂_{j<k} Aⱼᶜ) ∩ H] ≤ p < 1` gives
+`(1 - p)ⁿ ≤ μ[⋂ᵢ Aᵢᶜ | H]`. This is the shape the symmetric LLL produces inside the
+denominator recursion (each relative conditional bounded by `2p` under
+`e·p·(d+1) ≤ 1`). -/
+theorem cond_avoidance_ge_one_sub_pow (hA : ∀ i, MeasurableSet (A i))
+    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ) (p : ℝ≥0∞)
+    (hp : p < 1)
+    (hfail : ∀ k ∈ Finset.range n,
+      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ p) :
+    (1 - p) ^ n ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by
+  have h := cond_avoidance_ge_prod_one_sub hA H hH hHne n (fun _ => p)
+    (fun _ _ => hp) hfail
+  simpa [Finset.prod_const, Finset.card_range] using h
+
+/-- **Positivity of the relative avoidance probability.**
+Since every `bₖ < 1` makes each survival budget `1 - bₖ` strictly positive, the
+relative avoidance probability `μ[⋂ᵢ Aᵢᶜ | H]` is positive. This is the conditional
+analogue of `avoidance_pos_of_prod_one_sub_pos`, and it is exactly the statement the
+denominator recursion needs to keep every conditioning set of positive measure as it
+descends. -/
+theorem cond_avoidance_pos_of_prod_one_sub_pos (hA : ∀ i, MeasurableSet (A i))
+    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ)
+    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)
+    (hfail : ∀ k ∈ Finset.range n,
+      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) :
+    0 < μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by
+  refine lt_of_lt_of_le ?_ (cond_avoidance_ge_prod_one_sub hA H hH hHne n b hb hfail)
+  rw [zero_lt_iff, Finset.prod_ne_zero_iff]
+  intro k hk
+  rw [Ne, tsub_eq_zero_iff_le, not_le]
+  exact hb k hk
+
+end LovaszLocalLemmaOQ01ConditionalAvoidance

--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -19,6 +19,41 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
+### Relative (conditional) quantitative avoidance bound (researcher-16, 2026-07-03) — NEW
+
+- **The whole ambient quantitative scaffold lifts to a conditioned-on-background-event
+  form for free, via a change of measure.** New file
+  `Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean` (0 sorry / 0 axiom;
+  axioms = propext/choice/Quot only), gallery entry
+  `lovasz-local-lemma-oq-01-conditional-avoidance`: for a background event `H` with
+  `μ H ≠ 0`, background-relative per-event bounds `μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1`
+  give `∏ₖ(1 − bₖ) ≤ μ[⋂ᵢ(A i)ᶜ | H]` (`cond_avoidance_ge_prod_one_sub`), plus symmetric
+  `(1 − p)ⁿ` form and positivity. This is the **denominator-recursion primitive** the
+  Erdős–Lovász induction runs (`H = ⋂_{S₂} Aⱼᶜ`, the non-neighbour survival).
+- **Route (transport, do NOT re-prove).** Let `ν := μ[·|H]`. `cond_isProbabilityMeasure hHne`
+  (needs `[IsFiniteMeasure μ]` + `μ H ≠ 0`) makes `ν` a probability measure, so the ambient
+  flagship `avoidance_ge_prod_one_sub` applies to `ν` directly (it is measure-polymorphic).
+  The **tower property** `cond_cond_eq_cond_inter hH hGk μ : μ[·|H][·|G] = μ[·|H ∩ G]`
+  rewrites `ν`'s internal conditionals `ν[A k | G]` into `μ[A k | H ∩ G]`; one
+  `Set.inter_comm H` matches the hypothesis order `G ∩ H`. Crucially `ν(⋂ᵢ(A i)ᶜ) =
+  μ[⋂ᵢ(A i)ᶜ | H]` holds by **`rfl`** — `μ[t|H]` unfolds to `cond μ H t = (μ[|H]) t`, so
+  the ambient conclusion at measure `ν` IS the relative bound with no coercion.
+- **Reusable pattern.** To lift ANY prefix-based avoidance estimate (positivity, union
+  bound, future weighted bounds) to its conditioned-on-`H` form: `haveI := cond_isProbabilityMeasure hHne`,
+  rewrite conditionals with `cond_cond_eq_cond_inter`, close the value identity by `rfl`.
+- **Lean API notes.** `cond_cond_eq_cond_inter (hms) (hmt) (μ) [IsFiniteMeasure μ] :
+  μ[·|s][·|t] = μ[·|s ∩ t]` (measure passed explicitly; the tower composes s THEN t into
+  `s ∩ t`, i.e. the OUTER conditioning event is on the LEFT of the `∩`). `cond_isProbabilityMeasure
+  [IsFiniteMeasure μ] (hcs : μ s ≠ 0)` — no `≠ ∞` needed (finite measure gives it). The
+  prefix-history measurability the tower lemma demands is `measurableSet_hist (fun i => (hA i).compl) k`
+  (complements), from the ChainRule entry.
+- **What remains open (unchanged).** Both numerator (dependency-split entry) and denominator
+  (this entry) primitives of the induction step are now verified over the right (arbitrary
+  background / relative) setting. The open target is the well-founded recursion on `|S|`
+  supplying the per-factor relative bounds `bₖ` from the LLL inductive hypothesis at
+  strictly smaller conditioning sets, plus reconciling `Finset.range` prefix ordering with
+  arbitrary `Finset` blocks `S₁`.
+
 ### Chain-rule scaffold + hypothesis-clean reduction (researcher-6, 2026-07-02→03) — NEW
 
 - **The LLL induction skeleton is a pure, independence-free chain rule.**

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,12 +1,53 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound landed; the LLL conclusion is now stated quantitatively over a real probability space, reduced to a single per-event obligation. General dependency-degree LLL still open)
+**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound + dependency-split numerator + relative/conditional quantitative bound landed; both numerator and denominator-recursion primitives of the Erdős–Lovász induction are now in place. What remains is the well-founded recursion coupling them. General dependency-degree LLL still open)
 **Path**: full
 **Since**: 2026-06-27
-**Iteration**: 8
+**Iteration**: 9
 
-## This session (researcher-4, 2026-07-03)
+## This session (researcher-16, 2026-07-03)
+
+**Landed the denominator-recursion primitive: the relative (conditional) quantitative
+avoidance bound.** The Erdős–Lovász induction's denominator recursion lower-bounds a
+survival probability *relative to a fixed background event* `H = ⋂_{S₂} Aⱼᶜ`:
+`μ[⋂_{S₁} Aⱼᶜ | H] ≥ ∏_{S₁}(1 − xⱼ)`. Every prior quantitative entry lived over the
+*ambient* measure and so could not be plugged into that recursion. This session lands
+the relative form in a new self-contained, **0-axiom / 0-sorry** file
+`Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean` (new gallery entry
+`lovasz-local-lemma-oq-01-conditional-avoidance`). Verified via Docker build (exit 0,
+1643 jobs) and `#print axioms` on all three theorems = propext / Classical.choice /
+Quot.sound only.
+
+### New verified theorems (relative quantitative avoidance)
+1. **`cond_avoidance_ge_prod_one_sub`** *(flagship)* — for a background event `H` of
+   positive measure, if `μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1` for all `k<n`, then
+   `∏ₖ(1 − bₖ) ≤ μ[⋂ᵢ(A i)ᶜ | H]`. The exact primitive the denominator recursion runs.
+2. **`cond_avoidance_ge_one_sub_pow`** — uniform specialisation: relative bound `≤ p<1`
+   gives `(1 − p)ⁿ ≤ μ[⋂ᵢ(A i)ᶜ | H]`.
+3. **`cond_avoidance_pos_of_prod_one_sub_pos`** — positivity `0 < μ[⋂ᵢ(A i)ᶜ | H]`, the
+   running side condition keeping conditioning sets positive as the recursion descends.
+
+### Proof technique (transport along the conditioning map — no new probability)
+`ν := μ[·|H]` is an `IsProbabilityMeasure` (`cond_isProbabilityMeasure`, since `μ H ≠ 0`
+and `μ` finite), so the ambient flagship `avoidance_ge_prod_one_sub` applies to `ν`
+directly. The tower property `cond_cond_eq_cond_inter` (`μ[·|H][·|G] = μ[·|H ∩ G]`)
+identifies `ν`'s internal conditionals `ν[A k | ⋂_{j<k}(A j)ᶜ]` with the
+background-relative conditionals `μ[A k | H ∩ ⋂_{j<k}(A j)ᶜ]` (one `Set.inter_comm` to
+match hypothesis order; prefix-history measurability from `measurableSet_hist`), and the
+avoidance probability under `ν` *is* `μ[⋂ᵢ(A i)ᶜ | H]` by `rfl`. The whole file is a
+change of measure plus one Mathlib tower lemma.
+
+### Significance (honest)
+Genuine but structural: no new probabilistic content, but it removes the specific
+obstacle — "condition on a background event" — that blocked reusing the prefix-based
+quantitative scaffold inside the arbitrary-subset dependency recursion. Combined with
+the prior session's dependency-split numerator bounds, both sides of the induction step's
+ratio `μ[Aᵢ | ⋂_S Aⱼᶜ] = num/denom` now have their measure-theoretic primitives verified.
+The still-open deliverable is the well-founded recursion on `|S|` that supplies the
+per-factor relative bounds `bₖ` from the inductive hypothesis at strictly smaller sets.
+
+## Prior session (researcher-4, 2026-07-03)
 
 **Upgraded the chain-rule reduction from qualitative positivity to the quantitative
 LLL lower bound.** The chain-rule scaffold (`LovaszLocalLemmaOQ01ChainRule.lean`)

--- a/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-lll-oq01-condav-overview",
+    "proofId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "context",
+    "title": "Why the LLL needs a *relative* quantitative bound",
+    "content": "The flagship quantitative entry `lovasz-local-lemma-oq-01-quantitative` proves $\\prod_k (1 - b_k) \\le \\mu(\\bigcap_i A_i^c)$ over the ambient measure $\\mu$. But the genuine Erdős–Lovász induction never estimates a bare avoidance probability — its **denominator recursion** lower-bounds the survival of one block of events *conditioned on the survival of another*:\n$$\\mu\\!\\left[\\bigcap_{j\\in S_1} A_j^c \\;\\middle|\\; \\bigcap_{j\\in S_2} A_j^c\\right] \\;\\ge\\; \\prod_{j\\in S_1}(1 - x_j).$$\nEvery quantity here is a probability *relative to the background event* $H = \\bigcap_{j\\in S_2} A_j^c$. `lovasz-local-lemma-oq-01-dependency-split` supplied the numerator half of the induction step; this entry supplies the primitive the denominator recursion is built from — the exact analogue of `avoidance_ge_prod_one_sub`, but with every probability taken relative to a fixed background event $H$.",
+    "mathContext": "Arbitrary measurable family $A : \\mathbb{N} \\to \\mathrm{Set}\\,\\Omega$ over an `IsProbabilityMeasure` $\\mu$; a background event $H$ with $\\mu H \\ne 0$; background-relative per-event conditional failure bounds $b_k < 1$ are the hypotheses. No independence, no dependency graph.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "conditional avoidance probability",
+      "Erdős–Lovász induction",
+      "change of measure",
+      "measure-theoretic probability"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01-quantitative (ambient bound)",
+      "lovasz-local-lemma-oq-01-dependency-split (numerator half)",
+      "conditional probability μ[t|s]"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-condav-frame",
+    "proofId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+    "range": {
+      "startLine": 51,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "Frame: transport, don't re-prove",
+    "content": "```lean\nimport Proofs.LovaszLocalLemmaOQ01Quantitative\nopen MeasureTheory ProbabilityTheory Finset\nopen scoped ENNReal\nopen LovaszLocalLemmaOQ01ChainRule\nopen LovaszLocalLemmaOQ01Quantitative\nnamespace LovaszLocalLemmaOQ01ConditionalAvoidance\nvariable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]\nvariable {A : ℕ → Set Ω}\n```\n\nThe file imports the quantitative entry and adds **no new probabilistic input**. The whole strategy is a *change of measure*: conditioning on the background event $H$ produces a genuine probability measure $\\mu[\\cdot|H]$, and the ambient quantitative bound — being polymorphic in the probability measure — applies to it directly. The only new ingredient is the Mathlib tower property `cond_cond_eq_cond_inter`, which certifies that the internal conditionals of $\\mu[\\cdot|H]$ are the background-relative conditionals of $\\mu$.",
+    "mathContext": "`μ[t|s]` is `ProbabilityTheory.cond μ s t`; `μ[|s]` is the conditioned measure `cond μ s`. The tower property is `cond_cond_eq_cond_inter : μ[·|s][·|t] = μ[·|s ∩ t]` (for a finite measure).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conditional probability measure cond μ s",
+      "tower property of conditioning",
+      "measure-polymorphic lemma reuse"
+    ],
+    "prerequisites": [
+      "avoidance_ge_prod_one_sub",
+      "cond_isProbabilityMeasure",
+      "cond_cond_eq_cond_inter"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-condav-main",
+    "proofId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+    "range": {
+      "startLine": 63,
+      "endLine": 102
+    },
+    "type": "proof-step",
+    "title": "The relative quantitative avoidance bound",
+    "content": "```lean\ntheorem cond_avoidance_ge_prod_one_sub (hA : ∀ i, MeasurableSet (A i))\n    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ)\n    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)\n    (hfail : ∀ k ∈ Finset.range n,\n      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) :\n    ∏ k ∈ Finset.range n, (1 - b k) ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by\n  haveI : IsProbabilityMeasure (μ[|H]) := cond_isProbabilityMeasure hHne\n  have hfail' : ∀ k ∈ Finset.range n,\n      (μ[|H])[A k | ⋂ j ∈ Finset.range k, (A j)ᶜ] ≤ b k := by\n    intro k hk\n    have hGk : MeasurableSet (⋂ j ∈ Finset.range k, (A j)ᶜ) :=\n      measurableSet_hist (fun i => (hA i).compl) k\n    rw [cond_cond_eq_cond_inter hH hGk μ, Set.inter_comm H]\n    exact hfail k hk\n  calc ∏ k ∈ Finset.range n, (1 - b k)\n      ≤ (μ[|H]) (⋂ i ∈ Finset.range n, (A i)ᶜ) :=\n        avoidance_ge_prod_one_sub hA n b hb hfail'\n    _ = μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := rfl\n```\n\nThree structural moves, no new probability. **(1)** `cond_isProbabilityMeasure hHne` registers $\\mu[\\cdot|H]$ as an `IsProbabilityMeasure` (valid because $\\mu H \\ne 0$ and $\\mu$ is finite), so the flagship `avoidance_ge_prod_one_sub` can be applied to it. **(2)** Its hypotheses need the *internal* conditionals of $\\mu[\\cdot|H]$ bounded: for each $k$, the tower property `cond_cond_eq_cond_inter hH hGk μ` rewrites $\\mu[\\cdot|H][A_k \\mid G] = \\mu[A_k \\mid H \\cap G]$ (with $G = \\bigcap_{j<k}(A_j)^c$, measurable via `measurableSet_hist` on the complements), and a single `Set.inter_comm H` matches it to the hypothesis $\\mu[A_k \\mid G \\cap H] \\le b_k$. **(3)** `avoidance_ge_prod_one_sub` then yields $\\prod(1 - b_k) \\le (\\mu[\\cdot|H])(\\bigcap A_i^c)$, and $(\\mu[\\cdot|H])(\\bigcap A_i^c) = \\mu[\\bigcap A_i^c \\mid H]$ holds by `rfl` — the H-relative avoidance probability *is* the value of the conditioned measure at the avoidance event.",
+    "mathContext": "The `rfl` closing the calc is the crux: `μ[t|H]` unfolds to `cond μ H t = (μ[|H]) t`, so the ambient conclusion of avoidance_ge_prod_one_sub applied at measure `μ[|H]` is definitionally the relative bound. No coercion or rewrite needed.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "tower property cond_cond_eq_cond_inter",
+      "measure-polymorphic application",
+      "definitional identity of relative avoidance"
+    ],
+    "prerequisites": [
+      "cond_isProbabilityMeasure",
+      "cond_cond_eq_cond_inter",
+      "measurableSet_hist",
+      "avoidance_ge_prod_one_sub"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-condav-sym",
+    "proofId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+    "range": {
+      "startLine": 103,
+      "endLine": 124
+    },
+    "type": "proof-step",
+    "title": "Symmetric specialisation",
+    "content": "```lean\ntheorem cond_avoidance_ge_one_sub_pow (hA : ∀ i, MeasurableSet (A i))\n    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ) (p : ℝ≥0∞)\n    (hp : p < 1)\n    (hfail : ∀ k ∈ Finset.range n,\n      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ p) :\n    (1 - p) ^ n ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by\n  have h := cond_avoidance_ge_prod_one_sub hA H hH hHne n (fun _ => p)\n    (fun _ _ => hp) hfail\n  simpa [Finset.prod_const, Finset.card_range] using h\n```\n\nInstantiating the per-event budgets at a single uniform $p$ collapses $\\prod_k (1 - p)$ to $(1 - p)^n$ via `Finset.prod_const` and `Finset.card_range`. This is the relative-avoidance shape the *symmetric* LLL produces inside the denominator recursion: under $e\\,p\\,(d+1) \\le 1$ the induction certifies each relative conditional failure $\\le 2p$, and the denominator survival is bounded below by $(1 - 2p)^{|S_1|}$.",
+    "mathContext": "The symmetric bound is the multiplicative relative counterpart of the union-bound extreme's additive estimate; here it lives relative to a background event H.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric Lovász Local Lemma",
+      "uniform conditional bound",
+      "Finset.prod_const"
+    ],
+    "prerequisites": [
+      "cond_avoidance_ge_prod_one_sub"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-condav-pos",
+    "proofId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+    "range": {
+      "startLine": 125,
+      "endLine": 140
+    },
+    "type": "proof-step",
+    "title": "Positivity of the relative avoidance probability",
+    "content": "```lean\ntheorem cond_avoidance_pos_of_prod_one_sub_pos (hA : ∀ i, MeasurableSet (A i))\n    (H : Set Ω) (hH : MeasurableSet H) (hHne : μ H ≠ 0) (n : ℕ)\n    (b : ℕ → ℝ≥0∞) (hb : ∀ k ∈ Finset.range n, b k < 1)\n    (hfail : ∀ k ∈ Finset.range n,\n      μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) :\n    0 < μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H] := by\n  refine lt_of_lt_of_le ?_ (cond_avoidance_ge_prod_one_sub hA H hH hHne n b hb hfail)\n  rw [zero_lt_iff, Finset.prod_ne_zero_iff]\n  intro k hk\n  rw [Ne, tsub_eq_zero_iff_le, not_le]\n  exact hb k hk\n```\n\nEach survival budget $1 - b_k$ is strictly positive (since $b_k < 1$, via `tsub_eq_zero_iff_le`), so the finite $\\mathbb{R}_{\\ge 0}^\\infty$ product $\\prod(1 - b_k)$ is nonzero (`Finset.prod_ne_zero_iff`) and hence positive, giving $0 < \\mu[\\bigcap A_i^c \\mid H]$. This is the conditional analogue of `avoidance_pos_of_prod_one_sub_pos`, and it is precisely what the denominator recursion needs to keep every conditioning set of positive measure as it descends to strictly smaller index sets — a running side condition the whole induction depends on.",
+    "mathContext": "Positivity of the relative avoidance probability is what guarantees the next conditioning step in the recursion is well-defined (the conditioning event has positive measure).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positive conditioning event",
+      "ℝ≥0∞ product positivity",
+      "well-defined conditional probability"
+    ],
+    "prerequisites": [
+      "cond_avoidance_ge_prod_one_sub",
+      "tsub_eq_zero_iff_le",
+      "Finset.prod_ne_zero_iff"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-conditional-avoidance/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "lovasz-local-lemma-oq-01-conditional-avoidance",
+  "title": "Lovász Local Lemma OQ-01: Conditional (Relative) Quantitative Avoidance Bound",
+  "slug": "lovasz-local-lemma-oq-01-conditional-avoidance",
+  "description": "The relative form of the quantitative measure-theoretic Lovász Local Lemma: the flagship bound ∏ₖ (1 − bₖ) ≤ μ(⋂ᵢ (A i)ᶜ) from lovasz-local-lemma-oq-01-quantitative lives over the ambient measure μ, but the genuine Erdős–Lovász induction never estimates a bare avoidance probability — its denominator recursion lower-bounds the survival of one block of events conditioned on the survival of another, μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{S₁}(1 − xⱼ). This entry supplies exactly that primitive: for any measurable family over an IsProbabilityMeasure and any background event H of positive measure, if every background-relative conditional failure probability μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1, then ∏ₖ (1 − bₖ) ≤ μ[⋂ᵢ (A i)ᶜ | H]. It adds no new probabilistic input: it transports avoidance_ge_prod_one_sub along the conditioning map. Conditioning on H yields a genuine probability measure μ[·|H] (cond_isProbabilityMeasure); the tower property cond_cond_eq_cond_inter (μ[·|H][·|G] = μ[·|H ∩ G]) identifies the internal conditionals of μ[·|H] with the background-relative conditionals; and the avoidance probability under μ[·|H] is by definition μ[⋂ᵢ Aᵢᶜ | H]. Applying the unconditional quantitative bound to μ[·|H] delivers the relative bound verbatim, together with the symmetric specialisation (1 − p)ⁿ ≤ μ[⋂ Aᵢᶜ | H] and positivity 0 < μ[⋂ Aᵢᶜ | H]. This removes the 'condition on a background event' obstacle that blocked reusing the prefix scaffold inside the LLL denominator recursion. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "conditional-probability"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on all three theorems). IsProbabilityMeasure is an explicit hypothesis. The background event H is an explicit hypothesis assumed measurable and of positive measure (μ H ≠ 0); all per-event background-relative conditional failure bounds bₖ are explicit hypotheses. Scope: this entry lands the relative (conditioned-on-H) analogue of the quantitative avoidance lower bound by transporting avoidance_ge_prod_one_sub to the conditioned probability measure μ[·|H] via the tower property cond_cond_eq_cond_inter. It does NOT prove the bounded-dependency-degree symmetric LLL bound (e·p·(d+1) ≤ 1), nor the well-founded recursion that supplies the per-factor bounds — those remain the open research target; here the relative per-event bounds bₖ are hypotheses.",
+    "lineCount": 140,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "cond_avoidance_ge_prod_one_sub: the relative quantitative LLL lower bound ∏ₖ (1 − bₖ) ≤ μ[⋂ᵢ (A i)ᶜ | H] from background-relative per-event conditional failure bounds μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1. This is the exact primitive the Erdős–Lovász denominator recursion invokes (with H = ⋂_{j∈S₂} Aⱼᶜ the survival of the non-neighbours). Proved by transporting the unconditional avoidance_ge_prod_one_sub to the conditioned probability measure μ[·|H]: cond_isProbabilityMeasure makes μ[·|H] a probability measure, the tower property cond_cond_eq_cond_inter (μ[·|H][·|G] = μ[·|H ∩ G]) rewrites its internal conditionals μ[·|H][A k | ⋂_{j<k}(A j)ᶜ] as the background-relative conditionals μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H], and the avoidance probability under μ[·|H] is definitionally μ[⋂ᵢ Aᵢᶜ | H].",
+      "cond_avoidance_ge_one_sub_pow: the symmetric specialisation — a single uniform background-relative bound μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ p < 1 gives (1 − p)ⁿ ≤ μ[⋂ᵢ (A i)ᶜ | H] (Finset.prod_const, Finset.card_range). This is the relative-avoidance shape the symmetric LLL produces inside the denominator recursion, where each relative conditional is bounded by 2p under e·p·(d+1) ≤ 1.",
+      "cond_avoidance_pos_of_prod_one_sub_pos: positivity of the relative avoidance probability, 0 < μ[⋂ᵢ (A i)ᶜ | H], whenever every bₖ < 1 (zero_lt_iff, Finset.prod_ne_zero_iff, tsub_eq_zero_iff_le). This is exactly the statement the denominator recursion needs to keep every conditioning set of positive measure as it descends to strictly smaller index sets.",
+      "Framing contribution: the flagship quantitative entry (lovasz-local-lemma-oq-01-quantitative) proved the avoidance lower bound over the ambient measure, and the dependency-split entry (lovasz-local-lemma-oq-01-dependency-split) isolated the numerator half of the induction step, but the LLL denominator recursion works entirely with probabilities RELATIVE to a fixed background survival event. This entry removes that obstacle: it shows every part of the quantitative avoidance scaffold lifts to the conditioned measure μ[·|H] for free via the tower property, so the prefix-based quantitative machinery is directly usable inside the arbitrary-subset dependency recursion."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.LovaszLocalLemmaOQ01Quantitative"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Finset",
+      "LovaszLocalLemmaOQ01ChainRule",
+      "LovaszLocalLemmaOQ01Quantitative"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01ConditionalAvoidance",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LovaszLocalLemmaOQ01Quantitative.lean",
+      "Proofs/LovaszLocalLemmaOQ01ChainRule.lean"
+    ]
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "cond_avoidance_ge_prod_one_sub",
+      "type": "core",
+      "description": "Conditional (relative) quantitative Lovász Local Lemma lower bound: for a background event H of positive measure, if every background-relative conditional failure probability μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] is bounded by bₖ < 1, then the avoidance probability relative to H is at least the product of the survival budgets, ∏ₖ (1 − bₖ) ≤ μ[⋂ᵢ (A i)ᶜ | H]. The exact primitive the Erdős–Lovász denominator recursion invokes.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (H : Set Ω) → MeasurableSet H → μ H ≠ 0 → (n : ℕ) → (b : ℕ → ℝ≥0∞) → (∀ k ∈ Finset.range n, b k < 1) → (∀ k ∈ Finset.range n, μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) → ∏ k ∈ Finset.range n, (1 - b k) ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H]"
+    },
+    {
+      "name": "cond_avoidance_ge_one_sub_pow",
+      "type": "corollary",
+      "description": "Symmetric relative quantitative bound: if every background-relative conditional failure probability is bounded by a single uniform p < 1, then (1 − p)ⁿ ≤ μ[⋂ᵢ (A i)ᶜ | H]. The uniform specialisation of cond_avoidance_ge_prod_one_sub; the relative-avoidance shape the symmetric LLL produces inside the denominator recursion.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (H : Set Ω) → MeasurableSet H → μ H ≠ 0 → (n : ℕ) → (p : ℝ≥0∞) → p < 1 → (∀ k ∈ Finset.range n, μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ p) → (1 - p) ^ n ≤ μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H]"
+    },
+    {
+      "name": "cond_avoidance_pos_of_prod_one_sub_pos",
+      "type": "corollary",
+      "description": "Positivity of the relative avoidance probability: since every bₖ < 1 makes each survival budget 1 − bₖ strictly positive, the product lower bound is itself positive, so 0 < μ[⋂ᵢ (A i)ᶜ | H]. The conditional analogue of avoidance_pos_of_prod_one_sub_pos — exactly what the denominator recursion needs to keep conditioning sets of positive measure as it descends.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → (H : Set Ω) → MeasurableSet H → μ H ≠ 0 → (n : ℕ) → (b : ℕ → ℝ≥0∞) → (∀ k ∈ Finset.range n, b k < 1) → (∀ k ∈ Finset.range n, μ[A k | (⋂ j ∈ Finset.range k, (A j)ᶜ) ∩ H] ≤ b k) → 0 < μ[(⋂ i ∈ Finset.range n, (A i)ᶜ) | H]"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) is proved by a two-layer induction on the size of the conditioning set. The outer invariant is a per-event conditional bound μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] ≤ xᵢ for every event i and every set S of other events not containing i; its inductive step splits S into the neighbours S₁ and non-neighbours S₂ of Aᵢ and writes the conditional as a ratio numerator/denominator. The numerator is bounded by dropping the neighbour factor and using independence from the non-neighbours (μ[Aᵢ | ⋂_{S₂} Aⱼᶜ] = μ(Aᵢ)); the denominator, μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ], is lower-bounded by ∏_{S₁}(1 − xⱼ) via a second, inner induction that is itself a chain rule applied to the measure conditioned on the non-neighbour survival ⋂_{S₂} Aⱼᶜ. Every quantity in that inner induction is a probability RELATIVE to a fixed background event. The gallery's quantitative entry (lovasz-local-lemma-oq-01-quantitative) proved the chain-rule product bound over the ambient measure; the dependency-split entry isolated the numerator moves over arbitrary subset histories. This entry supplies the relative form of the quantitative bound — the exact tool the denominator recursion runs.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces, with the quantitative conclusion μ(⋂ A_iᶜ) ≥ ∏(1 − xᵢ) under a bounded-dependency-degree hypothesis.\n\n**This entry (conditional/relative quantitative bound)**: prove that the quantitative avoidance lower bound holds relative to an arbitrary background event. For a measurable family A : ℕ → Set Ω over an IsProbabilityMeasure and a background event H with μ H ≠ 0, if μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1 for every k < n, then ∏ₖ (1 − bₖ) ≤ μ[⋂ᵢ (A i)ᶜ | H]; specialise to a uniform p and recover positivity. This is the denominator-recursion primitive: the survival of the events A₀,…,A_{n−1} conditioned on the background H is at least the product of the per-event relative survival budgets.",
+    "text": "The quantitative Lovász Local Lemma bound, but measured inside a fixed background event. Condition everything on H having occurred; then the same survival-product estimate that lower-bounds the plain avoidance probability lower-bounds the avoidance probability relative to H. The proof is a single structural observation: conditioning on H turns μ into a genuine probability measure μ[·|H], the tower property makes conditioning again on the running history the same as conditioning on the history intersected with H, and the avoidance probability under μ[·|H] is by definition the H-relative avoidance probability — so the unconditional theorem applies to μ[·|H] with nothing new to prove.",
+    "proofStrategy": "**Transport along the conditioning map.** Let ν := μ[·|H]. Since μ H ≠ 0 and μ is finite, cond_isProbabilityMeasure makes ν an IsProbabilityMeasure, so the flagship avoidance_ge_prod_one_sub applies to ν. Its hypotheses require the ν-conditionals ν[A k | ⋂_{j<k}(A j)ᶜ] to be bounded by bₖ. The tower property cond_cond_eq_cond_inter gives ν[·|G] = μ[·|H][·|G] = μ[·|H ∩ G], so ν[A k | ⋂_{j<k}(A j)ᶜ] = μ[A k | H ∩ ⋂_{j<k}(A j)ᶜ]; a single Set.inter_comm matches this to the hypothesis μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ. The measurability of the prefix history ⋂_{j<k}(A j)ᶜ needed by the tower lemma is measurableSet_hist (from the chain-rule entry) on the complements. avoidance_ge_prod_one_sub then yields ∏(1 − bₖ) ≤ ν(⋂ᵢ (A i)ᶜ), and ν(⋂ᵢ (A i)ᶜ) = μ[⋂ᵢ (A i)ᶜ | H] holds by definition of the conditional-measure notation (rfl).\n\n**Symmetric case.** Instantiate b ≡ p: Finset.prod_const and Finset.card_range collapse ∏ₖ (1 − p) to (1 − p)ⁿ.\n\n**Positivity corollary.** ∏(1 − bₖ) is a positive ℝ≥0∞ product (each 1 − bₖ ≠ 0 since bₖ < 1), so 0 < ∏(1 − bₖ) ≤ μ[⋂ (A i)ᶜ | H].",
+    "keyInsights": [
+      "The Erdős–Lovász induction is intrinsically *relative*: its denominator recursion lower-bounds a survival probability conditioned on a fixed background event ⋂_{S₂} Aⱼᶜ, never a bare avoidance probability. So the ambient quantitative bound, however sharp, cannot be plugged into the recursion directly — one first needs its conditioned-on-H form.",
+      "That relative form costs nothing new probabilistically: conditioning on H is a *change of measure* to μ[·|H], and the entire quantitative scaffold is measure-polymorphic. The only genuinely new ingredient is the tower property cond_cond_eq_cond_inter, which certifies that the internal conditionals of μ[·|H] are exactly the background-relative conditionals μ[· | · ∩ H].",
+      "The avoidance probability relative to H is *definitionally* the value of μ[·|H] at the avoidance event: μ[⋂ Aᵢᶜ | H] and (μ[·|H])(⋂ Aᵢᶜ) are the same term (rfl). This is what lets avoidance_ge_prod_one_sub's ambient conclusion serve verbatim as the relative bound.",
+      "The proof is a template for lifting *any* prefix-based avoidance estimate in the gallery (positivity, the union-bound extreme, future weighted bounds) into its conditioned-on-a-background-event form: apply cond_isProbabilityMeasure, rewrite conditionals with cond_cond_eq_cond_inter, and read the conclusion through the definitional identity of the relative avoidance probability.",
+      "Combined with the dependency-split entry's numerator bounds over arbitrary subset histories, this isolates the last open piece of the LLL induction to a single well-founded recursion: the per-factor relative conditional bounds bₖ still have to be supplied from the inductive hypothesis at strictly smaller conditioning sets. Both the numerator and denominator machinery are now in place."
+    ],
+    "prerequisites": [
+      "The quantitative entry lovasz-local-lemma-oq-01-quantitative: avoidance_ge_prod_one_sub over an arbitrary IsProbabilityMeasure",
+      "The chain-rule entry lovasz-local-lemma-oq-01-chain-rule: measurableSet_hist",
+      "Mathlib conditional-probability API: cond_isProbabilityMeasure, cond_cond_eq_cond_inter (the tower property μ[·|s][·|t] = μ[·|s ∩ t]), and the μ[t|s] = cond μ s t notation",
+      "ℝ≥0∞ truncated subtraction and finite products: tsub_eq_zero_iff_le, Finset.prod_ne_zero_iff, Finset.prod_const, Finset.card_range"
+    ]
+  },
+  "conclusion": {
+    "summary": "The relative quantitative measure-theoretic Lovász Local Lemma bound is fully machine-verified: for any background event H of positive measure, background-relative per-event conditional failure bounds μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1 propagate to ∏ₖ (1 − bₖ) ≤ μ[⋂ᵢ (A i)ᶜ | H], with symmetric specialisation (1 − p)ⁿ ≤ μ[⋂ Aᵢᶜ | H] and positivity 0 < μ[⋂ Aᵢᶜ | H]. Proved by transporting the ambient quantitative bound to the conditioned measure μ[·|H] via the tower property. 0 sorries, 0 axioms.",
+    "implications": "**Removes the last structural obstacle between the gallery's quantitative scaffold and the Erdős–Lovász induction.** The quantitative entry proved the avoidance lower bound over the ambient measure; the dependency-split entry proved the numerator moves over arbitrary subset histories. But the LLL induction's denominator recursion lower-bounds survival probabilities RELATIVE to a background non-neighbour-survival event, and no ambient bound could be used there. This entry supplies the relative bound for free, showing the whole quantitative scaffold lifts to the conditioned measure via a change of measure plus the tower property.\n\n**Honest scope**: the background-relative conditional bounds bₖ are hypotheses here; the well-founded recursion that supplies them (each conditioning set strictly smaller, so the LLL inductive hypothesis applies, giving bₖ = 2p under e·p·(d+1) ≤ 1) remains the open research target. Numerator and denominator primitives are now both in place; what remains is to close the recursion.",
+    "openQuestions": [
+      "Close the denominator recursion: order an arbitrary neighbour block S₁ as a prefix, and use this entry's cond_avoidance_ge_prod_one_sub with H = ⋂_{S₂} Aⱼᶜ, supplying the per-factor relative conditional bounds from the LLL inductive hypothesis at strictly smaller conditioning sets (well-founded recursion on |S|).",
+      "Assemble the full induction step: combine the dependency-split numerator bound (μ[Aᵢ ∩ ⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≤ μ(Aᵢ)) with this entry's denominator lower bound to obtain μ[Aᵢ | ⋂_S Aⱼᶜ] ≤ xᵢ under μ(Aᵢ) ≤ xᵢ ∏_{j∼i}(1 − xⱼ) and the dependency-degree hypothesis.",
+      "Handle the general finite index set: reconcile this entry's Finset.range prefix ordering with the arbitrary Finset subsets the dependency recursion uses, either by choosing an order on each block or by re-deriving the relative chain rule directly over a Finset with a chosen enumeration."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-quantitative",
+      "relationship": "extends",
+      "description": "The ambient quantitative bound this entry transports: avoidance_ge_prod_one_sub proves ∏(1 − bₖ) ≤ μ(⋂ (A i)ᶜ) over an arbitrary IsProbabilityMeasure. This entry applies it to the conditioned probability measure μ[·|H] to obtain the relative bound ∏(1 − bₖ) ≤ μ[⋂ (A i)ᶜ | H], the form the LLL denominator recursion actually uses."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-dependency-split",
+      "relationship": "related",
+      "description": "The complementary half of the Erdős–Lovász induction step. The dependency-split entry supplies the numerator moves over arbitrary subset histories (cond_mono_num, cond_inter_le, the non-neighbour collapse cond_failure_eq_measure_of_indep_subset); this entry supplies the denominator-recursion primitive (the relative quantitative lower bound). Together they cover both sides of the ratio μ[Aᵢ | ⋂_S Aⱼᶜ] = numerator/denominator; only the well-founded recursion coupling them remains open."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "related",
+      "description": "The scaffold underneath the transported bound: the chain-rule entry's survival-product identity is what avoidance_ge_prod_one_sub rests on, and its measurableSet_hist supplies the prefix-history measurability the tower property cond_cond_eq_cond_inter requires in this entry."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "related",
+      "description": "The mutually independent base case μ(⋂ (A i)ᶜ) = ∏(1 − μ(A i)). Under independence from the background, this entry's relative bound collapses to the base case relativised to H; the entry generalises that to arbitrary (non-independent) background events via conditioning."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the induction bounds conditional probabilities μ[Aᵢ | ⋂_{j∈S} Aⱼᶜ] relative to the survival of other events, exactly the relative setting this entry formalizes."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; the LLL proof's denominator estimate lower-bounds Pr[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] by a product of survival budgets — the relative quantitative bound proved here."
+    },
+    {
+      "authors": "Spencer",
+      "title": "Ten Lectures on the Probabilistic Method",
+      "year": "1994",
+      "note": "Presents the LLL induction via conditional probabilities on growing avoidance histories inside a fixed conditioning event, the change-of-measure structure this entry makes explicit."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New self-contained, **0-axiom / 0-sorry** file `Proofs/LovaszLocalLemmaOQ01ConditionalAvoidance.lean` (gallery entry `lovasz-local-lemma-oq-01-conditional-avoidance`) landing the **denominator-recursion primitive** of the Erdős–Lovász induction: the *relative* form of the quantitative Lovász Local Lemma avoidance bound.

The flagship quantitative entry (`lovasz-local-lemma-oq-01-quantitative`) proves `∏ₖ(1 − bₖ) ≤ μ(⋂ᵢ Aᵢᶜ)` over the **ambient** measure. But the genuine LLL induction never estimates a bare avoidance probability — its denominator recursion lower-bounds the survival of one block of events *conditioned on the survival of another*, `μ[⋂_{S₁} Aⱼᶜ | ⋂_{S₂} Aⱼᶜ] ≥ ∏_{S₁}(1 − xⱼ)`, where every probability is relative to a fixed background event `H`. This PR supplies exactly that primitive.

## New verified theorems

- **`cond_avoidance_ge_prod_one_sub`** *(flagship)* — for a background event `H` with `μ H ≠ 0`, if `μ[A k | (⋂_{j<k}(A j)ᶜ) ∩ H] ≤ bₖ < 1` for all `k < n`, then `∏ₖ(1 − bₖ) ≤ μ[⋂ᵢ(A i)ᶜ | H]`.
- **`cond_avoidance_ge_one_sub_pow`** — symmetric specialisation `(1 − p)ⁿ ≤ μ[⋂ᵢ(A i)ᶜ | H]`.
- **`cond_avoidance_pos_of_prod_one_sub_pos`** — positivity `0 < μ[⋂ᵢ(A i)ᶜ | H]`, the running side condition keeping conditioning sets positive as the recursion descends.

## Proof technique

Transport along the conditioning map — **no new probabilistic content**. `ν := μ[·|H]` is a probability measure (`cond_isProbabilityMeasure`, valid since `μ H ≠ 0` and `μ` is finite), so the ambient `avoidance_ge_prod_one_sub` applies to `ν` directly. The tower property `cond_cond_eq_cond_inter` (`μ[·|H][·|G] = μ[·|H ∩ G]`) identifies `ν`'s internal conditionals with the background-relative conditionals, and the avoidance probability under `ν` is `μ[⋂ᵢ Aᵢᶜ | H]` by `rfl`.

## Significance (honest)

Genuine but structural. It removes the specific obstacle — "condition on a background event" — that blocked reusing the prefix-based quantitative scaffold inside the arbitrary-subset dependency recursion. Combined with the prior session's dependency-split **numerator** bounds, both sides of the induction step's ratio `μ[Aᵢ | ⋂_S Aⱼᶜ] = num/denom` now have their measure-theoretic primitives verified over the correct (relative) setting. **Still open:** the well-founded recursion on `|S|` that supplies the per-factor relative bounds `bₖ` from the LLL inductive hypothesis at strictly smaller conditioning sets.

## Verification

- Docker build `Proofs.LovaszLocalLemmaOQ01ConditionalAvoidance` — exit 0 (1643 jobs).
- `#print axioms` on all three theorems: `propext`, `Classical.choice`, `Quot.sound` only (no `sorryAx`, no `ofReduceBool`). 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions.

Gallery data (`meta.json` + `annotations.json`) and research state/knowledge notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)