### PR TITLE
Enrich: Silverman–Toeplitz Summability Theorem (91→100)

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -90,5 +90,28 @@
       "Cesàro averages",
       "1/n → 0"
     ]
+  },
+  {
+    "id": "subsumes-nonnegative-step",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 57
+    },
+    "type": "context",
+    "title": "Subsuming the Nonnegative-Weight Toeplitz Step",
+    "content": "The theorem's docstring pins the exact relationship to the companion Kronecker entry. That entry's step tendsto_weighted_average_zero used a nonnegative normaliser matrix A n k = c k / A_norm n with c ≥ 0 and ∑_{k<n} c k ≤ A_norm n; its row absolute sums are automatically ≤ 1 and its columns c k / A_norm n → 0. So it is precisely the C = 1, nonnegative instance of tendsto_toeplitz_zero here. The generalization is twofold: the row bound C is now an arbitrary constant rather than 1, and the weights may carry any sign — the null-step proof never uses positivity, only the absolute-sum bound ∑|A n k| ≤ C in the triangle-inequality tail estimate. This is what lets a single theorem cover the Kronecker weights, signed averaging matrices, and Mathlib's Cesàro mean at once.",
+    "mathContext": "Only two of the three Toeplitz conditions — (bnd) $\\sum_{k<n}|A_{n,k}| \\le C$ and (col) $A_{\\cdot,k}\\to 0$ — enter the null step; the row-sum condition (row) is reserved for fixing the limit in the regular form. Dropping the sign constraint costs nothing because the tail is controlled through $|A_{n,k}|$, not $A_{n,k}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "generalization by absolute-sum bound",
+      "nonnegative normaliser matrices",
+      "signed summability weights",
+      "special-case instantiation"
+    ],
+    "prerequisites": [
+      "the Kronecker-lemma weighted average step",
+      "absolute value and the triangle inequality"
+    ]
   }
 ]

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -89,9 +89,17 @@
   },
   "sections": [
     {
+      "id": "framing",
+      "title": "Framing: The Summability Chain and Toeplitz's Three Conditions",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "The module docstring places this leaf at the end of the Marcinkiewicz–Zygmund SLLN chain: the Kronecker-lemma entry proved one nonnegative-weight Toeplitz null step and asked for its packaging into the general Silverman–Toeplitz theorem. It defines the triangular summability matrix action (A x)_n = ∑_{k<n} A n k · x k and states the three regularity conditions — (col) columns → 0, (bnd) row absolute sums ≤ C, (row) row sums → 1 — then imports Mathlib and opens Filter / Finset / Topology.",
+      "mathContext": "Regularity means limit preservation: x n → L ⟹ (A x)_n → L for every convergent x. Toeplitz's classical characterization is that (col)+(bnd)+(row) are jointly sufficient (and, in the full theorem, necessary)."
+    },
+    {
       "id": "toeplitz-null",
       "title": "The General Toeplitz Null Step",
-      "startLine": 58,
+      "startLine": 42,
       "endLine": 133,
       "summary": "Proves tendsto_toeplitz_zero: a triangular matrix with bounded row absolute sums (∑_{k<n} |A n k| ≤ C) and null columns (A · k → 0) sends every null sequence to a null transform. An ε/2 split at a threshold N: the tail is bounded by δ·C with δ = ε/(2(C+1)); the finite head is a sum of null columns via tendsto_finset_sum."
     },
@@ -108,6 +116,14 @@
       "startLine": 161,
       "endLine": 184,
       "summary": "Proves tendsto_cesaro_of_toeplitz: instantiating A n k = 1/n recovers the unweighted Cesàro mean (∑_{k<n} x k)/n → L, matching Mathlib's Filter.Tendsto.cesaro and confirming the general engine subsumes it. The three Toeplitz conditions reduce to 1/n → 0, ∑ 1/n = 1, and row sums = 1."
+    },
+    {
+      "id": "axiom-audit",
+      "title": "Axiom Audit",
+      "startLine": 186,
+      "endLine": 191,
+      "summary": "Closes the namespace and runs #print axioms on the main regularity theorem tendsto_toeplitz, documenting that it depends only on the foundational axioms propext / Classical.choice / Quot.sound — no sorryAx and no Lean.ofReduceBool. This substantiates the entry's 0-sorry, 0-axiom 'verified' status.",
+      "mathContext": "The absence of Lean.ofReduceBool confirms no native_decide/decide was used to discharge a substantive step; per the project's axiom-integrity policy the ordinary foundational axioms do not count against a verified badge."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `laws-of-large-numbers-oq-01-oq-02-oq-01-oq-02`.

**Quality: 91 → 100.** Two gaps closed:
- **annotations 20 → 25**: added a 5th annotation (lines 42–57) explaining how `tendsto_toeplitz_zero` subsumes the companion Kronecker entry's nonnegative-weight step as its `C = 1` instance, and why the null step needs no sign hypothesis (the tail is bounded through `|A n k|`).
- **sections 6 → 10**: added a framing section (1–40, the summability chain + Toeplitz's three conditions) and an axiom-audit section (186–191, the `#print axioms` confirming foundational-only dependence); extended the null-step section to include its docstring.

All grounded in the Lean source; no content removed. `meta.json` 13.8 KB, under caps. JSON validated.