### PR TITLE
Enrich: Abel–Ruffini General Relative Correspondence (93→100)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/annotations.json
@@ -87,5 +87,29 @@
       "IsSimpleGroup",
       "Subgroup.subgroupOf"
     ]
+  },
+  {
+    "id": "ann-reverse-pullback",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 148,
+      "endLine": 166
+    },
+    "type": "technique",
+    "title": "Reverse Direction: Pulling a Subtype Subgroup Back to G",
+    "content": "The harder (⇐) half of the bridge must produce subtype-lattice maximality from the ambient predicate. Given an arbitrary M : Subgroup ↥K with H.subgroupOf K ≤ M and (M).Normal, it sets N := M.map K.subtype — the image of M back in G — and rebuilds every hypothesis in the ambient interval: N ≤ K is map_subtype_le; the key round trip N.subgroupOf K = M is comap_map_eq_self_of_injective applied through injectivity of K.subtype; H ≤ N follows by mapping H.subgroupOf K ≤ M forward with map_mono and rewriting map_subgroupOf_eq_of_le; and normality (N.subgroupOf K).Normal transports back along that same identity. Feeding N to the ambient maximality IsMaxNorm.hmax returns N = H or N = K, which the round trip and subgroupOf_self convert back to M = H.subgroupOf K or M = ⊤.",
+    "mathContext": "The pair $M \\mapsto M.\\mathrm{map}\\,K.\\mathrm{subtype}$ and $N \\mapsto N.\\mathrm{subgroupOf}\\,K$ are mutually inverse on $\\mathrm{Subgroup}\\,\\uparrow K$ and the interval $[\\bot, K]$; the reverse direction is exactly this inverse applied to every quantified subgroup and its normality/inclusion side-conditions.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "map K.subtype pullback",
+      "injective comap round trip",
+      "subgroupOf_self edge case",
+      "order-isomorphism transport"
+    ],
+    "prerequisites": [
+      "Subgroup.map_subtype_le",
+      "Subgroup.comap_map_eq_self_of_injective",
+      "Subgroup.subtype_injective"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
@@ -107,8 +107,15 @@
       "id": "packaged",
       "title": "The Packaged Relative Correspondence",
       "startLine": 167,
-      "endLine": 195,
-      "summary": "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm plus the two dot-notation directions: IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K, the general case deferred by the parent."
+      "endLine": 178,
+      "summary": "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm: IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K for H ≤ K, the general case deferred by the parent. A two-line proof chaining isSimpleGroup_quotient_iff_isMaximalNormal (instantiated at ↥K, N = H.subgroupOf K) with the lattice-transfer bridge."
+    },
+    {
+      "id": "directions",
+      "title": "The Two Directions as Dot-Notation Lemmas",
+      "startLine": 179,
+      "endLine": 192,
+      "summary": "IsMaxNorm.isSimpleGroup_quotient (maximal-normal ⇒ simple subtype quotient) and IsMaxNorm.of_isSimpleGroup_quotient (its converse), the two implications of the packaged iff exposed as standalone lemmas — the form a composition-series / Jordan–Hölder argument consumes one implication at a time. The forward lemma threads the normality instance h.2.1 via haveI so the quotient typeclass resolves."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-04-oq-01-oq-01`.

**Quality: 93 → 100.** Two gaps closed:
- **annotations 20 → 25**: added a 5th annotation (lines 148–166) documenting the bridge's harder reverse direction — how an arbitrary `M : Subgroup ↥K` is pulled back to `N = M.map K.subtype` and every ≤/normality/edge-case hypothesis is reconstructed in the ambient interval `[H,K]` via the `comap_map_eq_self_of_injective` round trip.
- **sections 8 → 10**: split the packaged section into the packaged iff (167–178) and the two dot-notation direction lemmas (179–192), and corrected line ranges that over-ran the 192-line file.

All grounded in the Lean proof. `meta.json` 13.8 KB, under caps. JSON validated.