### PR TITLE
Enrich: Solvability of Sₐ Downward Closed Under Injections (93→100)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/annotations.json
@@ -63,22 +63,42 @@
     ]
   },
   {
-    "id": "ann-routes-agree-downset",
+    "id": "ann-routes-agree",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
-    "range": { "startLine": 96, "endLine": 127 },
+    "range": { "startLine": 93, "endLine": 104 },
     "type": "insight",
-    "title": "Two proofs of the same down-closedness",
-    "content": "`mono_routes_agree` re-proves the monotone implication a second way: rewrite both `IsSolvable (Perm β)` and the goal through the parent threshold `perm_solvable_iff_card`, leaving the pure arithmetic goal $|\\beta| \\le 4 \\to |\\alpha| \\le 4$ under $|\\alpha| \\le |\\beta|$, closed by `omega`. That the abstract subgroup-descent of §1 and this arithmetic both establish the same implication is the precise sense in which 'subgroup descent' and 'the down-closedness of $n \\le 4$' are one statement. The remaining lemmas package the consequence: `solvable_perm_card_isDownSet` (the solvable cardinalities are closed downward) and `four_is_max_solvable_card` ($4$ is the maximum solvable cardinality — the order-theoretic shadow of $S_5$ being the minimal non-solvable symmetric group).",
-    "mathContext": "A bounded down-set of ℕ with maximum 4 is exactly {0,1,2,3,4}; 5 is its minimal exclusion, which is the seed of Abel–Ruffini.",
+    "title": "Two proofs of the same implication",
+    "content": "`mono_routes_agree` re-proves the monotone implication a second way: rewrite both `IsSolvable (Perm β)` and the goal through the parent threshold `perm_solvable_iff_card`, leaving the pure arithmetic goal $|\\beta| \\le 4 \\to |\\alpha| \\le 4$ under $|\\alpha| \\le |\\beta|$, closed by `omega`. That the abstract subgroup-descent of §1 and this arithmetic *both* establish the same implication is the precise sense in which 'solvability descends along injections' and 'the down-closedness of $n \\le 4$' are one statement viewed two ways — the structural route explains *why*, the arithmetic route pins the *boundary*.",
+    "mathContext": "The arithmetic route consumes the parent threshold as a black box; it neither reproves subgroup-closure nor recomputes the value 4 — under card α ≤ card β the whole content collapses to omega on ℕ.",
+    "significance": "key",
+    "relatedConcepts": [
+      "route agreement",
+      "arithmetic vs structural proof",
+      "omega",
+      "parent cardinality threshold"
+    ],
+    "prerequisites": [
+      "the parent cardinality threshold",
+      "linear arithmetic (omega)"
+    ]
+  },
+  {
+    "id": "ann-downset-packaging",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 127 },
+    "type": "insight",
+    "title": "Packaging the down-set {0,1,2,3,4}",
+    "content": "Three lemmas turn the threshold into an explicit order-theoretic object. `solvable_perm_card_eq_le_four` rewrites `IsSolvable (Perm (Fin n)) ↔ n ≤ 4` (via `perm_solvable_iff_card` and `Fintype.card_fin`); `solvable_perm_card_isDownSet` reads off downward closure `m ≤ n → solvable (Fin n) → solvable (Fin m)` — the monotonicity of §2 restated on ℕ, discharged by `omega`; and `four_is_max_solvable_card` conjoins the witness `IsSolvable (Perm (Fin 4))` with the bound `∀ n, solvable (Fin n) → n ≤ 4`, exhibiting 4 as the maximum. Together they present {n | IsSolvable (Perm (Fin n))} = {0,1,2,3,4} as a bounded down-set.",
+    "mathContext": "A bounded down-set of ℕ with maximum 4 is exactly {0,1,2,3,4}; 5 is its minimal exclusion — the order-theoretic shadow of $S_5$ being the minimal non-solvable symmetric group, and the seed of Abel–Ruffini.",
     "significance": "key",
     "relatedConcepts": [
       "down-set with maximum",
       "minimal non-solvable group",
       "S₅",
-      "omega"
+      "Fintype.card_fin"
     ],
     "prerequisites": [
-      "order theory",
+      "order theory (down-sets)",
       "the parent cardinality threshold"
     ]
   }

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
@@ -195,11 +195,19 @@
       "mathContext": "A finite type embeds into another exactly when its cardinality is no larger, so the structural descent of §1 is precisely cardinality monotonicity once an embedding is produced."
     },
     {
+      "id": "route-agreement",
+      "title": "§3 Route agreement",
+      "startLine": 93,
+      "endLine": 104,
+      "summary": "mono_routes_agree re-derives the monotone implication arithmetically: rewrite hypothesis and goal through the parent threshold perm_solvable_iff_card, leaving card β ≤ 4 → card α ≤ 4 under card α ≤ card β, closed by omega. The structural descent of §1–2 and this arithmetic prove the same implication.",
+      "mathContext": "The abstract subgroup-descent route explains why solvability is monotone; the arithmetic route, consuming the parent threshold as a black box, pins the boundary — the two agree by mono_routes_agree."
+    },
+    {
       "id": "downset",
-      "title": "§3 Route agreement and the down-set packaging",
-      "startLine": 96,
+      "title": "§4 The down-set packaging",
+      "startLine": 105,
       "endLine": 127,
-      "summary": "mono_routes_agree re-derives the monotone implication arithmetically from perm_solvable_iff_card + omega, matching §2; solvable_perm_card_eq_le_four, solvable_perm_card_isDownSet, and four_is_max_solvable_card present {n | solvable (Perm (Fin n))} = {0,1,2,3,4} as a bounded down-set.",
+      "summary": "solvable_perm_card_eq_le_four (IsSolvable (Perm (Fin n)) ↔ n ≤ 4), solvable_perm_card_isDownSet (downward closure on ℕ), and four_is_max_solvable_card (4 is the maximum, with witness Perm (Fin 4) solvable) present {n | solvable (Perm (Fin n))} = {0,1,2,3,4} as a bounded down-set.",
       "mathContext": "The threshold n ≤ 4 is downward closed and bounded by 4, so it is the down-set with maximum 4 — the order-theoretic shadow of S₅ being the minimal non-solvable symmetric group."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01`.

**Quality: 93 → 100.** Two gaps closed by splitting the combined route-agreement/down-set material at its natural boundary (`mono_routes_agree` vs the three down-set lemmas):
- **annotations 20 → 25**: the single annotation covering lines 96–127 became two — 'Two proofs of the same implication' (93–104, the arithmetic route via `perm_solvable_iff_card` + `omega`) and 'Packaging the down-set {0,1,2,3,4}' (105–127, `solvable_perm_card_eq_le_four` / `isDownSet` / `four_is_max_solvable_card`).
- **sections 8 → 10**: §3 split into §3 route agreement (93–104) and §4 the down-set packaging (105–127).

All grounded in the Lean source. `meta.json` 20.9 KB, under caps. JSON validated.