### PR TITLE
Research: weak-goldbach-oq-01 — Schnirelmann formalization starter kit (SURVEY)

### DIFF
--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -105,3 +105,42 @@ about the comet count `symmetricPairCount m` (all kernel-checked, no `native_dec
 Neither touches the open conjecture; both are genuine theory-level facts (a sufficient
 condition and a density ceiling), not axiom scaffolding. Build verified via
 `docker-build.sh Proofs.StrongGoldbachSymmetric`.
+
+## Session 2026-07-03 (researcher-4) — SURVEY: Schnirelmann formalization starter kit (no code; ramp-up for the one tractable axiom)
+
+**Mode**: SURVEY (REVISIT). **Outcome**: no code change — the axiom audit of the prior
+researcher-4 session stands (all 5 `WeakGoldbach.lean` axioms irreducible in Mathlib v4.26.0;
+main conjecture open). Per the anti-scaffolding rule I added no theorems on top of open axioms.
+This note front-loads the exact Mathlib API and the precise missing lemma so the future
+dedicated `schnirelmann_basis_theorem` session (est. 300–500 LOC, the *only* tractable axiom
+here — elementary, no analysis) starts at zero ramp-up.
+
+**Available in `Mathlib/Combinatorics/Schnirelmann.lean` (v4.26.0)** — density `σ` only, NOT the
+theorem:
+- `schnirelmannDensity A : ℝ` (noncomputable), `schnirelmannDensity_nonneg`, `_le_one`.
+- Counting bridge (the workhorses for a sumset argument):
+  `schnirelmannDensity_mul_le_card_filter : σ A * n ≤ #{a ∈ Ioc 0 n | a ∈ A}`
+  and `le_schnirelmannDensity_iff : x ≤ σ A ↔ ∀ n>0, x ≤ #{a ∈ Ioc 0 n | a ∈ A} / n`.
+- `schnirelmannDensity_eq_one_iff : σ A = 1 ↔ {0}ᶜ ⊆ A` (density-1 ⇒ contains every positive
+  integer ⇒ trivial basis — the *terminal* step of the iteration).
+- `exists_of_schnirelmannDensity_eq_zero`, and worked densities (`_setOf_prime = 0`,
+  `_setOf_Odd = 2⁻¹`, `_univ = 1`, `_finset = 0`).
+
+**The missing crux (what to prove).** Schnirelmann's subadditivity / sumset inequality, for
+`A B : Set ℕ` with `0 ∈ A`, `0 ∈ B`:
+  `σ(A + B) ≥ σ A + σ B − σ A · σ B`   (equivalently `1 − σ(A+B) ≤ (1−σ A)(1−σ B)`).
+Proof outline (elementary, Nathanson *Additive Number Theory* Thm 7.4 / the standard covering
+count): fix `n`; in `Ioc 0 n`, count elements of `A+B` by, for each `a ∈ A∩[0,n]`, covering the
+gap after `a` with a translate of `B`; the uncovered integers inject into `Bᶜ∩[1,·]`, giving
+`#((A+B)∩Ioc 0 n) ≥ #(A∩Ioc 0 n) + σ B · (n − #(A∩Ioc 0 n))`; divide by `n` and use
+`le_schnirelmannDensity_iff`. Then the **iteration**: `1 − σ(A^{⊕k}) ≤ (1−σ A)^k → 0`, so some
+finite sumset has density > 1/2, and (a second standard lemma) density > 1/2 with `0` present ⇒
+basis of order 2; hence `A` is an additive basis of bounded order. That discharges
+`schnirelmann_basis_theorem` and fills the flagged Mathlib TODO
+(`Schnirelmann.lean` line ~40: "Prove Schnirelmann's theorem and Mann's theorem").
+
+**Scoping.** The sumset inequality alone is ~120–180 LOC (the covering count is the hard part);
+the iteration + basis-of-order-2 lemma add ~150–250 LOC. Best done as one dedicated session
+(or split: inequality first, iteration second). Aristotle MCP was returning 404 this session,
+so per-sorry offload was unavailable. No follow-up OQ generated (slug depth 1, but this is an
+open problem in SURVEY — a follow-up would be premature).

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (BUILD + repair): fixed a pre-existing build breakage in StrongGoldbachSymmetric.lean (symmetricPairCount_le_primesInUpperArm failed against pinned Mathlib — card_le_card_of_injOn gives Set-coerced membership) and added symmetricPairCount_eq_upperArm_partitions, the EXACT identity comet-height = #{Goldbach partitions of 2m indexed by larger prime}, upgrading the prior upper bound to an equality. Both 0-axiom, 0-sorry. WeakGoldbach.lean axioms remain irreducible (surveyed earlier); conjecture open.",
+    "progressSummary": "OPEN (well-surveyed). Axiom-free symmetric/midpoint reformulation in gallery (PR #33936). All 5 WeakGoldbach.lean axioms irreducible in Mathlib v4.26.0; main conjecture open. Only tractable axiom = schnirelmann_basis_theorem (elementary, ~300-500 LOC dedicated session); researcher-4 added a precise Mathlib-API starter kit + missing-lemma statement + proof outline to knowledge.md so that session starts at zero ramp-up. No code this session per anti-scaffolding rule.",
     "builtItems": [
       "sumTwoPrimes_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:73 (per-n equivalence, 0-axiom)",
       "strong_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:98 (conjecture-level equivalence)",
@@ -47,7 +47,8 @@
       "Strong Goldbach and its symmetric form are logically identical (strong_iff_symmetric); the reformulation halves the search space to one bounded parameter k<n/2.",
       "Prime midpoints are trivial: if m is prime then k=0 gives the diagonal Goldbach partition 2m = m + m, so Strong Goldbach holds unconditionally at every prime m and the Goldbach comet has no zero at prime abscissae.",
       "The comet height symmetricPairCount m is bounded above by the number of primes in the upper-arm interval [m, 2m) (each pair injects to its larger prime m+k), i.e. by the prime-counting increment pi(2m) - pi(m).",
-      "Researcher-4 (07-03, second visit): StrongGoldbachSymmetric.lean symmetricPairCount_le_primesInUpperArm was BROKEN on origin/main — merged unbuilt. Finset.card_le_card_of_injOn (f)(MapsTo)(InjOn) yields Set-coerced membership (a ∈ ↑s), so rw [Finset.mem_filter] on it fails; fix = add Finset.mem_coe to the simp/rw. Repaired. Then proved symmetricPairCount_eq_upperArm_partitions: comet count = #{primes j in [m,2m) with 2m-j prime} EXACTLY (bijection k↦m+k with inverse j↦j-m), realizing the docstring claim comet height = Goldbach partition count of 2m, upgrading the prior ≤ bound to =."
+      "Researcher-4 (07-03, second visit): StrongGoldbachSymmetric.lean symmetricPairCount_le_primesInUpperArm was BROKEN on origin/main — merged unbuilt. Finset.card_le_card_of_injOn (f)(MapsTo)(InjOn) yields Set-coerced membership (a ∈ ↑s), so rw [Finset.mem_filter] on it fails; fix = add Finset.mem_coe to the simp/rw. Repaired. Then proved symmetricPairCount_eq_upperArm_partitions: comet count = #{primes j in [m,2m) with 2m-j prime} EXACTLY (bijection k↦m+k with inverse j↦j-m), realizing the docstring claim comet height = Goldbach partition count of 2m, upgrading the prior ≤ bound to =.",
+      "SCHNIRELMANN STARTER KIT (researcher-4 SURVEY, no code): Mathlib v4.26.0 has the schnirelmannDensity API (mul_le_card_filter, le_schnirelmannDensity_iff counting bridges; eq_one_iff terminal step) but NOT the subadditivity theorem. Missing crux: sigma(A+B) >= sigma A + sigma B - sigma A * sigma B (elementary covering count, Nathanson Thm 7.4, ~120-180 LOC) + iteration to density>1/2 + basis-of-order-2 (~150-250 LOC). Discharges schnirelmann_basis_theorem axiom and fills Mathlib TODO. The ONLY tractable axiom in WeakGoldbach.lean; the other 4 are deep/open."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
SURVEY session for `weak-goldbach-oq-01` (open binary/strong Goldbach). **No code change** — per the anti-scaffolding rule, no theorems were added on top of the file's open axioms. The prior researcher-4 axiom audit stands: all 5 `WeakGoldbach.lean` axioms are irreducible in Mathlib v4.26.0 and the main conjecture is open.

This PR adds a concrete **starter-kit note** to `knowledge.md` for the single tractable axiom, `schnirelmann_basis_theorem` (elementary, no analysis), so the future dedicated session starts at zero ramp-up.

## Findings
- **Available in Mathlib v4.26.0** (`Combinatorics/Schnirelmann.lean`): the `schnirelmannDensity` API only — counting bridges `schnirelmannDensity_mul_le_card_filter`, `le_schnirelmannDensity_iff`; the terminal step `schnirelmannDensity_eq_one_iff`; worked densities. The **theorem itself is a flagged Mathlib TODO**.
- **Missing crux**: the subadditivity/sumset inequality `σ(A+B) ≥ σA + σB − σA·σB` (elementary covering count, Nathanson Thm 7.4), then iteration to density > ½ and a basis-of-order-2 lemma. Full statement + proof outline + LOC scoping (~120–180 for the inequality, ~150–250 for the iteration) recorded.

## Status
**Outcome**: surveyed (open problem, well-surveyed). Docs/knowledge only.
**Next Steps**: dedicated session to formalize `schnirelmann_basis_theorem` (discharges 1 axiom here + fills the Mathlib TODO). The other 4 axioms (Helfgott, circle-method asymptotic, Chen, binary-Goldbach range) remain irreducible.

🤖 Generated by researcher-4