### PR TITLE
Enrich: Infinitely Many Odd Abundant Numbers (93→100)

### DIFF
--- a/src/data/proofs/abundant-number-oq-03/annotations.json
+++ b/src/data/proofs/abundant-number-oq-03/annotations.json
@@ -80,5 +80,25 @@
       "rarity vs finiteness",
       "kernel decide vs native_decide"
     ]
+  },
+  {
+    "id": "abundant03-ann-reuse",
+    "proofId": "abundant-number-oq-03",
+    "range": { "startLine": 29, "endLine": 35 },
+    "type": "context",
+    "title": "Reuse: Composition Without New Computation",
+    "content": "The entire result is a *composition* of two facts imported from sibling entries, with no new divisor-sum computation performed here. `import Proofs.AbundantNumberOQ02` brings `abundant_945` — the fact that $945$ is abundant, itself proved axiom-free by kernel `decide` over a kernel-reducible $\\sigma$ (the reducibility is what makes that `decide` feasible without `native_decide`). `import Proofs.AbundantMultiplesOQ01` brings `abundant_mul_right` — a purely arithmetic closure lemma. The `open AbundantNumberOQ02 AbundantMultiplesOQ01` then exposes both by short name. Because $945$'s abundance is inherited rather than recomputed, this file introduces *zero* computational content and its axiom footprint is exactly that of its two dependencies (the foundational three), never touching `Lean.ofReduceBool`.",
+    "mathContext": "abundant_945 : Nat.Abundant 945 (kernel-decide, oq-02); abundant_mul_right : a.Abundant → 0 < t → (a*t).Abundant (oq-01). This entry adds only the odd-multiplier restriction and the injectivity/assembly.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Lean imports and `open` namespaces",
+      "kernel `decide` vs `native_decide` and their axiom footprints",
+      "abundant_945 (oq-02) and abundant_mul_right (oq-01)"
+    ],
+    "relatedConcepts": [
+      "proof reuse / composition",
+      "axiom footprint of dependencies",
+      "kernel-reducible σ"
+    ]
   }
 ]

--- a/src/data/proofs/abundant-number-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03/meta.json
@@ -81,9 +81,17 @@
       "id": "infinitude",
       "title": "Infinitely Many Odd Abundant Numbers",
       "startLine": 52,
+      "endLine": 68,
+      "summary": "`infinitely_many_odd_abundant : {n | Odd n ∧ n.Abundant}.Infinite` via `Set.infinite_of_injective_forall_mem` applied to the injective family odd_mul_succ_injective and the membership proof odd_abundant_945_mul. Complements `infinitely_many_abundant` (even family 12·(k+1)); no diagonal argument or cardinality bookkeeping.",
+      "mathContext": "An injective ℕ-indexed family of in-set witnesses forces the set to be infinite: Set.infinite_of_injective_forall_mem : Injective f → (∀ a, f a ∈ s) → s.Infinite."
+    },
+    {
+      "id": "axiom-audit",
+      "title": "Axiom Audit",
+      "startLine": 70,
       "endLine": 75,
-      "summary": "`infinitely_many_odd_abundant : {n | Odd n ∧ n.Abundant}.Infinite` via `Set.infinite_of_injective_forall_mem` applied to the injective family and the membership proof, followed by `#print axioms` confirming the result is axiom-free. Complements `infinitely_many_abundant` (even family 12·(k+1)); the proof is elementary and axiom-free.",
-      "mathContext": "An injective ℕ-indexed family of in-set witnesses forces the set to be infinite."
+      "summary": "`#print axioms infinitely_many_odd_abundant` confirms the result depends only on the foundational propext / Classical.choice / Quot.sound — no Lean.ofReduceBool (which native_decide would introduce) and no sorryAx. The proof is genuinely axiom-free, inheriting the kernel-decide abundant_945 without recomputation.",
+      "mathContext": "Axiom footprint = that of the two imported dependencies; kernel decide (not native_decide) keeps Lean.ofReduceBool absent, so the entry qualifies as verified / 0-axiom."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `abundant-number-oq-03`.

**Quality: 93 → 100.** Two gaps closed:
- **annotations 20 → 25**: added a 5th annotation (lines 29–35) on the reuse/composition structure — the file imports `abundant_945` (kernel-`decide`, oq-02) and `abundant_mul_right` (oq-01) and adds *zero* new divisor-sum computation, so its axiom footprint is exactly its dependencies' (never touching `Lean.ofReduceBool`).
- **sections 8 → 10**: split the final section into the main-theorem assembly (52–68) and an axiom-audit section (70–75, the `#print axioms` confirming 0-axiom).

All grounded in the Lean source. `meta.json` 17.6 KB, under caps. JSON validated.