### PR TITLE
Enrich Automorphism Bound |Aut_F(K)| ≤ [K:F]_s (angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "angtri-oq05-ann-inseparable",
     "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
-    "range": { "startLine": 87, "endLine": 105 },
+    "range": { "startLine": 83, "endLine": 96 },
     "type": "insight",
     "title": "Purely inseparable boundary case",
-    "content": "subsingleton_algEquiv_of_isPurelyInseparable specializes the bound at the boundary: a finite purely inseparable extension has [K:F]_s = 1 (IsPurelyInseparable.finSepDegree_eq_one), so Nat.card (K ≃ₐ[F] K) ≤ 1, which Finite.card_le_one_iff_subsingleton turns into Subsingleton (K ≃ₐ[F] K). card_algEquiv_eq_one_of_isPurelyInseparable states it as the equality Nat.card = 1 (subsingleton + the identity witness). This answers the parent's second open question (Mathlib has no direct Subsingleton theorem here) and replaces the parent's char-p Frobenius identity (σ(x)−x)^{pⁿ}=0 with a one-line consequence of a general, reusable degree bound.",
-    "mathContext": "$K/F$ purely inseparable $\\Rightarrow [K:F]_s = 1 \\Rightarrow \\mathrm{Nat.card}(K\\simeq_F K) \\le 1 \\Rightarrow$ Subsingleton, in fact $=1$.",
+    "content": "subsingleton_algEquiv_of_isPurelyInseparable specializes the bound at the boundary: a finite purely inseparable extension has [K:F]_s = 1 (IsPurelyInseparable.finSepDegree_eq_one), so Nat.card (K ≃ₐ[F] K) ≤ 1, which Finite.card_le_one_iff_subsingleton turns into Subsingleton (K ≃ₐ[F] K). Finiteness of the automorphism group is itself obtained from the injection toEmb into the finite Field.Emb F K. This answers the parent's second open question (Mathlib has no direct Subsingleton theorem here) and replaces the parent's char-p Frobenius identity (σ(x)−x)^{pⁿ}=0 with a one-line consequence of a general, reusable degree bound.",
+    "mathContext": "$K/F$ purely inseparable $\\Rightarrow [K:F]_s = 1 \\Rightarrow \\mathrm{Nat.card}(K\\simeq_F K) \\le 1 \\Rightarrow$ Subsingleton.",
     "significance": "key",
     "relatedConcepts": ["IsPurelyInseparable.finSepDegree_eq_one", "Finite.card_le_one_iff_subsingleton", "purely inseparable extensions", "Frobenius-free argument"],
     "prerequisites": ["the automorphism bound", "purely inseparable extensions have separable degree 1"]
+  },
+  {
+    "id": "angtri-oq05-ann-eq-one",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 97, "endLine": 105 },
+    "type": "technique",
+    "title": "Sharpening the boundary case to an equality",
+    "content": "card_algEquiv_eq_one_of_isPurelyInseparable upgrades the subsingleton statement to the exact count Nat.card (K ≃ₐ[F] K) = 1. Where Subsingleton only says 'at most one', the equality also records that the group is nonempty — its single element being the identity automorphism. The proof feeds the subsingleton instance together with the inhabitant 1 : K ≃ₐ[F] K to Nat.card_eq_one_iff_unique, which characterises cardinality-one types as exactly the inhabited subsingletons (the types with a unique element). This is the crisp 'exactly the identity' form the parent's gal_card_one_of_purelyInseparable_splitting ultimately wants.",
+    "mathContext": "Nat.card_eq_one_iff_unique : Nat.card α = 1 ↔ Nonempty (Unique α); here uniqueness comes from the subsingleton instance and the identity 1 : K ≃ₐ[F] K as the inhabitant.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.card_eq_one_iff_unique", "unique element / inhabited subsingleton", "identity automorphism", "trivial Galois group"],
+    "prerequisites": ["the subsingleton boundary case", "Nat.card and card-one characterisations"]
   }
 ]

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/meta.json
@@ -118,10 +118,19 @@
     },
     {
       "id": "purely-inseparable",
-      "title": "Purely Inseparable Boundary Case",
-      "startLine": 87,
+      "title": "Purely Inseparable Boundary Case (Subsingleton)",
+      "startLine": 83,
+      "endLine": 96,
+      "summary": "subsingleton_algEquiv_of_isPurelyInseparable: for a finite purely inseparable K/F the automorphism group is a subsingleton. The injection toEmb gives Finite (K ≃ₐ[F] K), then Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K = 1 (via IsPurelyInseparable.finSepDegree_eq_one) forces card ≤ 1, i.e. a subsingleton — recovering the parent's purely-inseparable conclusion without the Frobenius computation.",
+      "mathContext": "Purely inseparable ⟹ [K:F]_s = 1; combined with |Aut_F(K)| ≤ [K:F]_s this pins |Aut_F(K)| ≤ 1, and Finite.card_le_one_iff_subsingleton converts the count to Subsingleton (K ≃ₐ[F] K)."
+    },
+    {
+      "id": "boundary-case-equality",
+      "title": "Boundary Case as an Equality",
+      "startLine": 97,
       "endLine": 105,
-      "summary": "subsingleton_algEquiv_of_isPurelyInseparable and card_algEquiv_eq_one_of_isPurelyInseparable: the bound at [K:F]_s = 1 forces a trivial automorphism group, recovering the parent's purely-inseparable conclusion without the Frobenius computation."
+      "summary": "card_algEquiv_eq_one_of_isPurelyInseparable restates the boundary case sharply: a finite purely inseparable extension has exactly one F-algebra automorphism (the identity), Nat.card (K ≃ₐ[F] K) = 1. It upgrades the subsingleton (≤ 1) to an equality by exhibiting the identity automorphism as the unique element.",
+      "mathContext": "Nat.card_eq_one_iff_unique: a type has card 1 iff it is a subsingleton and inhabited; here inhabitedness is the identity automorphism 1 : K ≃ₐ[F] K."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment 93 → 100/100 (verified against origin/main). Split the combined purely-inseparable section/annotation into a `subsingleton` part and a `boundary-case-equality` part covering `card_algEquiv_eq_one_of_isPurelyInseparable`: sections 4→5 (+2), annotations 4→5 (+5). Ranges verified against `proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05.lean`. All annotations carry mathContext/significance/relatedConcepts. JSON validated. Branched off current origin/main.