### PR TITLE
Enrich Gaussians form a convolution semigroup (area-of-circle-oq-05-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/annotations.json
@@ -71,26 +71,49 @@
     ]
   },
   {
-    "id": "ann-aoc-oq05oq03oq02-fourier-shadow",
+    "id": "ann-aoc-oq05oq03oq02-mass",
     "proofId": "area-of-circle-oq-05-oq-03-oq-02",
     "range": {
       "startLine": 183,
+      "endLine": 196
+    },
+    "type": "technique",
+    "title": "Mass Preservation: Convolution Stays Among Probability Densities",
+    "content": "gaussian_density_integral_eq_one proves ∫_ℝ φ_σ(x) dx = 1 — each centred Gaussian density has total mass 1. This is the invariant that makes the convolution semigroup law (★) a statement about probability densities: since φ_{σ₁} and φ_{σ₂} are probability densities, their convolution φ_{√(σ₁²+σ₂²)} is too. The proof factors out the leading reciprocal (σ√(2π))⁻¹, evaluates the remaining bare Gaussian integral with Mathlib's integral_gaussian, and observes that the resulting √(π/(1/2σ²)) = σ√(2π) exactly cancels the reciprocal.",
+    "mathContext": "$\\int_{\\mathbb R} \\varphi_\\sigma(x)\\,dx = (\\sigma\\sqrt{2\\pi})^{-1}\\int e^{-x^2/(2\\sigma^2)}dx = (\\sigma\\sqrt{2\\pi})^{-1}\\cdot \\sigma\\sqrt{2\\pi} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "probability density",
+      "total mass / normalisation",
+      "integral_gaussian",
+      "convolution of densities"
+    ],
+    "prerequisites": [
+      "the Gaussian integral ∫ e^{-x²/(2σ²)} = σ√(2π)",
+      "probability densities integrate to 1"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq05oq03oq02-fourier-shadow",
+    "proofId": "area-of-circle-oq-05-oq-03-oq-02",
+    "range": {
+      "startLine": 198,
       "endLine": 216
     },
     "type": "insight",
     "title": "The Fourier Shadow: Convolution Becomes Multiplication",
-    "content": "Two corollaries close the entry. gaussian_density_integral_eq_one shows each φ_σ integrates to 1, so convolution preserves total mass — the result is again a probability density. charFun_mul records the dual of the convolution law on the Fourier side: with χ_σ(t)=e^{−σ²t²/2} (the characteristic function proved in the parent and its dilation sibling), χ_{σ₁}(t)·χ_{σ₂}(t)=χ_{√(σ₁²+σ₂²)}(t). This is exactly 'the Fourier transform turns convolution into multiplication', specialised to Gaussians — the same variance-addition viewed from the two sides of the transform.",
-    "mathContext": "Convolution of densities ↔ multiplication of characteristic functions; the density and Fourier sides of the same semigroup.",
+    "content": "charFun_mul records the dual of the convolution law on the Fourier side: with χ_σ(t)=e^{−σ²t²/2} (the characteristic function proved on the Fourier side in the parent and its dilation sibling), χ_{σ₁}(t)·χ_{σ₂}(t)=χ_{√(σ₁²+σ₂²)}(t). This is exactly 'the Fourier transform turns convolution into multiplication', specialised to Gaussians — the same variance-addition viewed from the two sides of the transform. charFun_zero (χ_σ(0)=1) records the normalisation that the characteristic function of a probability measure equals 1 at the origin, matching the mass-preservation corollary.",
+    "mathContext": "Convolution of densities ↔ multiplication of characteristic functions; $e^{-\\sigma_1^2 t^2/2}e^{-\\sigma_2^2 t^2/2}=e^{-(\\sigma_1^2+\\sigma_2^2)t^2/2}$ are the density and Fourier sides of the same semigroup.",
     "significance": "supporting",
     "relatedConcepts": [
       "characteristic function",
       "convolution theorem",
-      "probability density"
+      "variance addition",
+      "Fourier duality"
     ],
     "prerequisites": [
       "characteristic functions / Fourier transform",
-      "the convolution theorem (transform of a convolution is a product)",
-      "probability densities integrate to 1"
+      "the convolution theorem (transform of a convolution is a product)"
     ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-02/meta.json
@@ -72,12 +72,20 @@
       "mathContext": "The main result: the centred normal family is a convolution semigroup with additive variances — the Gaussian / heat-kernel semigroup in explicit density form."
     },
     {
-      "id": "corollaries",
-      "title": "Part III: Mass Preservation and the Fourier Shadow",
+      "id": "mass-preservation",
+      "title": "Part III.a: Mass Preservation",
       "startLine": 183,
+      "endLine": 196,
+      "summary": "gaussian_density_integral_eq_one proves ∫_ℝ φ_σ(x) dx = 1: each centred Gaussian density is a probability density, so the convolution semigroup law (★) sends probability densities to probability densities. The proof pulls out the leading reciprocal, evaluates the bare Gaussian integral with integral_gaussian, and cancels via √(π/(1/2σ²)) = σ√(2π).",
+      "mathContext": "$\\int_{\\mathbb R}\\varphi_\\sigma = 1$ is the total-mass invariant of (★): convolution of probability densities is a probability density. It follows from $\\int e^{-x^2/(2\\sigma^2)}dx = \\sigma\\sqrt{2\\pi}$."
+    },
+    {
+      "id": "fourier-shadow",
+      "title": "Part III.b: The Fourier Shadow",
+      "startLine": 198,
       "endLine": 216,
-      "summary": "gaussian_density_integral_eq_one (∫ φ_σ = 1, so convolution preserves total mass), the characteristic function χ_σ(t)=e^{−σ²t²/2}, charFun_mul (χ_{σ₁}·χ_{σ₂}=χ_{√(σ₁²+σ₂²)}), and charFun_zero.",
-      "mathContext": "The convolution lands among probability densities, and on the Fourier side becomes multiplication of characteristic functions — the dual of the density-side law."
+      "summary": "The characteristic function χ_σ(t) = e^{−σ²t²/2} (the Fourier-side value from the parent entries), charFun_mul proving χ_{σ₁}(t)·χ_{σ₂}(t) = χ_{√(σ₁²+σ₂²)}(t) — 'Fourier turns convolution into multiplication' specialised to Gaussians, dual to gaussian_convolution — and the normalisation charFun_zero (χ_σ(0) = 1).",
+      "mathContext": "$e^{-\\sigma_1^2 t^2/2}\\,e^{-\\sigma_2^2 t^2/2} = e^{-(\\sigma_1^2+\\sigma_2^2)t^2/2}$: multiplying characteristic functions adds variances, the dual of the density-side convolution law."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment 93 → 100/100 (verified against origin/main). Split the combined Part III section/annotation into a `mass-preservation` part (`gaussian_density_integral_eq_one`) and a `fourier-shadow` part (`charFun_mul`/`charFun_zero`): sections 4→5 (+2), annotations 4→5 (+5). Ranges verified against `proofs/Proofs/AreaOfCircleOQ05OQ03OQ02.lean`. Every annotation carries mathContext/significance/relatedConcepts. JSON validated. Branched off current origin/main.