### PR TITLE
Lovász LLL OQ-01: denominator recursion step (neighbour-survival peel)

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean
@@ -1,0 +1,168 @@
+/-
+# Lovász Local Lemma — OQ-01: The Denominator Recursion Step (Neighbour-Survival Peel)
+
+`Proofs/LovaszLocalLemmaOQ01DependencySplit.lean` supplies the *numerator* moves of the
+Erdős–Lovász dependency-graph induction step over an arbitrary subset history — numerator
+monotonicity of conditional probability and the non-neighbour independence collapse —
+reaching `μ[Aᵢ ∩ (⋂_{S₁} Aⱼᶜ) | ⋂_{S₂} Aⱼᶜ] ≤ μ(Aᵢ)`. That is only the numerator; the
+Erdős–Lovász argument bounds `μ[Aᵢ | history]` over the **full** survival
+`(⋂_{S₁} Aⱼᶜ) ∩ (⋂_{S₂} Aⱼᶜ)`, for which the missing ingredient is the **neighbour-block
+survival lower bound**
+
+  `μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏_{j∈S₁} (1 - xⱼ)`,
+
+"which the LLL strong induction supplies". That strong induction is a recursion on the
+neighbour block `S₁`, peeling one neighbour `Aₖ` at a time. The engine of that
+recursion — the single-peel transition that turns a survival lower bound over `S₁ \ {k}`
+into one over `S₁` — is missing from every OQ-01 file. This file supplies it.
+
+The transition is the *complement* companion of the conditional chain rule. Where the
+chain rule factors a numerator `μ[(A ∩ B) | C] = μ[A | B ∩ C]·μ[B | C]`, the survival
+recursion needs the **complement** `μ[Aᶜ ∩ B | C]` — the probability that, on top of
+surviving the already-peeled block `B`, the new neighbour `Aₖ` is *also* avoided. Writing
+`A = Aₖ`, `B = ⋂_{j∈S₁∖{k}} Aⱼᶜ` (the partially-peeled neighbour survival), `C` the
+non-neighbour block, the identity is
+
+  `μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]`      (`cond_compl_inter_add`, additive),
+
+and, combined with the numerator factoring `μ[A ∩ B | C] = μ[A | B ∩ C]·μ[B|C]` and a
+per-event failure bound `μ[A | B ∩ C] ≤ x`, it yields the multiplicative peel
+
+  `(1 - x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]`           (`one_sub_mul_cond_le_cond_compl`),
+
+i.e. adding one more avoided neighbour deflates the survival probability by at most a
+factor `(1 - x)`. Chaining it against an inductive lower bound `l ≤ μ[B | C]` gives the
+recursion step in the exact `∏(1 - xⱼ)` shape:
+
+  `(1 - x) · l ≤ μ[Aᶜ ∩ B | C]`                  (`mul_one_sub_le_cond_compl`).
+
+Iterating this over the neighbours of `Aₖ` (a well-founded recursion on `|S₁|`, still to
+be assembled) produces the survival lower bound the dependency split consumes.
+
+Everything is over an arbitrary `IsProbabilityMeasure`, stated abstractly for events
+`A B C : Set Ω` (instantiate `A = Aₖ`, `B = ⋂_{S₁∖{k}} Aⱼᶜ`, `C = ⋂_{S₂} Aⱼᶜ`). No
+independence is assumed: this is the pure conditional-measure bookkeeping of the peel.
+The one numerator identity it uses (`cond_inter_eq_cond_cond_mul`) is reproved inline so
+the file depends only on Mathlib.
+
+## Main results
+
+* `cond_ne_top` : `μ[t | s] ≠ ∞` for measurable `s` — conditionals are finite (needed to
+  cancel/subtract them; not packaged in Mathlib for a general conditioning set).
+* `cond_compl_inter_add` : `μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]` — the additive peel
+  identity (the survival mass over `B` splits according to whether `A` also holds).
+* `one_sub_mul_cond_le_cond_compl` *(flagship)* : `(1 - x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]`
+  from `μ[A | B ∩ C] ≤ x` — the multiplicative single-neighbour peel.
+* `mul_one_sub_le_cond_compl` : `(1 - x) · l ≤ μ[Aᶜ ∩ B | C]` from a survival lower bound
+  `l ≤ μ[B | C]` — the recursion step in `∏(1 - xⱼ)` form.
+-/
+import Mathlib.Probability.ConditionalProbability
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01DenominatorStep
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A B C : Set Ω}
+
+/-- **Two-block conditioning chain rule (numerator identity).**
+`μ[(A ∩ B) | C] = μ[A | B ∩ C] · μ[B | C]`, for arbitrary events over a probability
+measure with `μ(B ∩ C) ≠ 0`. Reproved inline (it also appears in the sibling BayesSplit
+development) so this file depends only on Mathlib. Proof: `cond_apply` unfolds all three
+conditionals to `(measure)⁻¹ · (intersection measure)`; the `μ(B ∩ C)` factor cancels
+against its inverse (finite, nonzero over a probability measure) and the surviving
+intersections agree after reassociation. -/
+theorem cond_inter_eq_cond_cond_mul (hB : MeasurableSet B) (hC : MeasurableSet C)
+    (hBC : μ (B ∩ C) ≠ 0) :
+    μ[(A ∩ B) | C] = μ[A | B ∩ C] * μ[B | C] := by
+  rw [cond_apply hC, cond_apply (hB.inter hC), cond_apply hC]
+  have e2 : μ (B ∩ C ∩ A) = μ (C ∩ (A ∩ B)) := by
+    congr 1
+    ext x; simp only [Set.mem_inter_iff]; tauto
+  have e1 : μ (C ∩ B) = μ (B ∩ C) := by rw [Set.inter_comm]
+  rw [e1, e2,
+    show (μ (B ∩ C))⁻¹ * μ (C ∩ (A ∩ B)) * ((μ C)⁻¹ * μ (B ∩ C))
+        = ((μ (B ∩ C))⁻¹ * μ (B ∩ C)) * ((μ C)⁻¹ * μ (C ∩ (A ∩ B))) from by ring,
+    ENNReal.inv_mul_cancel hBC (measure_ne_top μ _), one_mul]
+
+/-- **Conditionals are finite.**
+For any measurable conditioning set `s`, the conditional probability `μ[t | s]` is never
+`∞`. If `μ s = 0` the conditional is `0` (the numerator `μ(s ∩ t) ≤ μ s` vanishes); else
+`(μ s)⁻¹` and `μ(s ∩ t)` are both finite. Mathlib packages finiteness of `cond` only via
+an `IsProbabilityMeasure` instance that requires `μ s ∉ {0, ∞}`; this unconditional
+`≠ ∞` fact is what lets the survival peel subtract and cancel conditional masses. -/
+theorem cond_ne_top {s : Set Ω} (hs : MeasurableSet s) (t : Set Ω) :
+    μ[t | s] ≠ ∞ := by
+  rw [cond_apply hs]
+  rcases eq_or_ne (μ s) 0 with h | h
+  · have h0 : μ (s ∩ t) = 0 := measure_mono_null Set.inter_subset_left h
+    rw [h0, mul_zero]; exact ENNReal.zero_ne_top
+  · exact ENNReal.mul_ne_top (ENNReal.inv_ne_top.2 h) (measure_ne_top μ _)
+
+omit [IsProbabilityMeasure μ] in
+/-- **Additive peel identity.**
+The survival mass over `B`, conditioned on `C`, splits according to whether the new event
+`A` also holds:
+
+  `μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]`.
+
+This is `measure_inter_add_diff` applied to the conditional measure `cond μ C`, with
+`B \ A = Aᶜ ∩ B`. It is the complement companion of the numerator chain rule: where the
+chain rule factors `μ[A ∩ B | C]`, the survival recursion needs the residual
+`μ[Aᶜ ∩ B | C]` — the mass surviving `B` *and* avoiding `A`. -/
+theorem cond_compl_inter_add (hA : MeasurableSet A) :
+    μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] := by
+  have h := measure_inter_add_diff (μ := cond μ C) B hA
+  rw [Set.inter_comm B A, Set.diff_eq, Set.inter_comm B Aᶜ] at h
+  exact h
+
+/-- **Multiplicative single-neighbour peel (flagship).**
+If the per-event failure probability over the refined history `B ∩ C` is bounded,
+`μ[A | B ∩ C] ≤ x`, then avoiding `A` on top of surviving `B` deflates the survival
+probability by at most the factor `(1 - x)`:
+
+  `(1 - x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]`.
+
+This is the exact transition the Erdős–Lovász survival recursion performs when it peels
+one neighbour `A = Aₖ` off the neighbour block. Proof: the additive peel gives
+`μ[Aᶜ ∩ B | C] = μ[B|C] - μ[A ∩ B | C]`; the numerator identity rewrites
+`μ[A ∩ B | C] = μ[A | B ∩ C]·μ[B | C]`, at most `x·μ[B|C]`; and `(1 - x)·μ[B|C] =
+μ[B|C] - x·μ[B|C]` (`ENNReal.sub_mul`, valid since `μ[B|C] ≠ ∞`). Only the conditioning
+set `B ∩ C` needs positive measure (for the numerator identity); no independence. -/
+theorem one_sub_mul_cond_le_cond_compl (hA : MeasurableSet A) (hB : MeasurableSet B)
+    (hC : MeasurableSet C) (hBC : μ (B ∩ C) ≠ 0) {x : ℝ≥0∞} (hx : μ[A | B ∩ C] ≤ x) :
+    (1 - x) * μ[B | C] ≤ μ[Aᶜ ∩ B | C] := by
+  have ha_ne : μ[B | C] ≠ ∞ := cond_ne_top hC B
+  have hp_ne : μ[A | B ∩ C] ≠ ∞ := cond_ne_top (hB.inter hC) A
+  -- additive peel, with the numerator factored by the chain rule
+  have hadd : μ[A | B ∩ C] * μ[B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] := by
+    rw [← cond_inter_eq_cond_cond_mul hB hC hBC]; exact cond_compl_inter_add hA
+  -- so the residual equals the truncated subtraction
+  have hres : μ[Aᶜ ∩ B | C] = μ[B | C] - μ[A | B ∩ C] * μ[B | C] :=
+    ENNReal.eq_sub_of_add_eq (ENNReal.mul_ne_top hp_ne ha_ne)
+      (by rw [add_comm]; exact hadd)
+  calc (1 - x) * μ[B | C]
+      = μ[B | C] - x * μ[B | C] := by rw [ENNReal.sub_mul (fun _ _ => ha_ne), one_mul]
+    _ ≤ μ[B | C] - μ[A | B ∩ C] * μ[B | C] :=
+        tsub_le_tsub_left (mul_le_mul_right' hx _) _
+    _ = μ[Aᶜ ∩ B | C] := hres.symm
+
+/-- **Survival recursion step (∏(1 - xⱼ) form).**
+Chaining the multiplicative peel against an inductive survival lower bound `l ≤ μ[B | C]`
+gives the recursion step in the shape the Lovász Local Lemma strong induction iterates:
+
+  `(1 - x) · l ≤ μ[Aᶜ ∩ B | C]`.
+
+With `l = ∏_{j∈S₁∖{k}} (1 - xⱼ)` the survival bound over the partially-peeled neighbour
+block and `x = xₖ`, one application extends it to `∏_{j∈S₁} (1 - xⱼ)` over the block with
+`Aₖ` peeled. Iterating over all neighbours yields the survival lower bound the
+dependency-graph induction step consumes. -/
+theorem mul_one_sub_le_cond_compl (hA : MeasurableSet A) (hB : MeasurableSet B)
+    (hC : MeasurableSet C) (hBC : μ (B ∩ C) ≠ 0) {x l : ℝ≥0∞}
+    (hx : μ[A | B ∩ C] ≤ x) (hl : l ≤ μ[B | C]) :
+    (1 - x) * l ≤ μ[Aᶜ ∩ B | C] :=
+  le_trans (mul_le_mul_left' hl _)
+    (one_sub_mul_cond_le_cond_compl hA hB hC hBC hx)
+
+end LovaszLocalLemmaOQ01DenominatorStep

--- a/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "ann-lll-oq01-denom-overview",
+    "proofId": "lovasz-local-lemma-oq-01-denominator-step",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "context",
+    "title": "The hard half of the LLL is a denominator, and it peels neighbours one at a time",
+    "content": "The conditional chain rule factors the numerator of the Erdős–Lovász induction step, $\\mu[(A\\cap B)\\mid C] = \\mu[A\\mid B\\cap C]\\cdot\\mu[B\\mid C]$ (reproved inline here), and the sibling dependency-split entry uses such moves to reduce the bounded dependency-degree Lovász Local Lemma to a single named estimate: the neighbour-block survival lower bound $\\mu[\\bigcap_{j\\in S_1} A_j^c \\mid C] \\ge \\prod_{j\\in S_1}(1-x_j)$. That lower bound is itself a recursion — it peels the neighbours of $A_k$ off one at a time, each peel costing a factor $(1-x_k)$ — and its per-step engine is a **complement** identity, dual to the product identity. This file supplies that engine over an arbitrary probability measure and abstract events $A,B,C$: the additive peel $\\mu[A\\cap B\\mid C] + \\mu[A^c\\cap B\\mid C] = \\mu[B\\mid C]$, the multiplicative peel $(1-x)\\mu[B\\mid C] \\le \\mu[A^c\\cap B\\mid C]$ under a per-event bound $\\mu[A\\mid B\\cap C]\\le x$, and the $\\prod(1-x_j)$-shaped recursion step. No independence is assumed — this is pure conditional-measure bookkeeping.",
+    "mathContext": "Denominator half of the LLL induction step: bound the neighbour survival $\\mu[\\bigcap_{j\\in S_1} A_j^c \\mid C]$ from below by peeling one neighbour $A_k$ at a time, each peel scaling by $(1-x_k)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "Erdős–Lovász induction",
+      "neighbour-block survival",
+      "conditional probability",
+      "denominator recursion"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01-dependency-split (numerator half)",
+      "conditional chain rule μ[(A ∩ B) | C] = μ[A | B ∩ C] · μ[B | C] (reproved inline)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-denom-finite",
+    "proofId": "lovasz-local-lemma-oq-01-denominator-step",
+    "range": {
+      "startLine": 89,
+      "endLine": 102
+    },
+    "type": "technical",
+    "title": "Conditionals are finite — the quiet obstruction to peeling",
+    "content": "`cond_ne_top`: $\\mu[t\\mid s] \\ne \\infty$ for any measurable conditioning set $s$. This looks trivial but is exactly what the peel needs. Because $\\mathbb{R}_{\\ge 0}^\\infty$ subtraction is truncated and its addition is **not** cancellative, rewriting $\\mu[A^c\\cap B\\mid C] = \\mu[B\\mid C] - \\mu[A\\cap B\\mid C]$ requires $\\mu[A\\cap B\\mid C] \\ne \\infty$. Mathlib only certifies finiteness of `cond` via an `IsProbabilityMeasure` instance that presupposes $\\mu s \\notin \\{0,\\infty\\}$. Here the null case is handled explicitly: `cond_apply` unfolds $\\mu[t\\mid s] = (\\mu s)^{-1}\\mu(s\\cap t)$, and when $\\mu s = 0$ the numerator $\\mu(s\\cap t)\\le\\mu s$ vanishes, giving $0\\ne\\infty$; otherwise $(\\mu s)^{-1}$ and $\\mu(s\\cap t)$ are both finite (`ENNReal.mul_ne_top`). So the peel holds for ANY measurable conditioning set.",
+    "mathContext": "μ[t|s] = (μ s)⁻¹ · μ(s ∩ t) ≠ ∞: case split on μ s = 0 (numerator null) vs μ s ≠ 0 (both factors finite).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ENNReal truncated subtraction",
+      "non-cancellative addition",
+      "cond_apply",
+      "finiteness of conditional probability"
+    ],
+    "prerequisites": [
+      "cond_apply: μ[t|s] = (μ s)⁻¹ · μ(s ∩ t)",
+      "ENNReal.mul_ne_top, ENNReal.inv_ne_top, measure_ne_top"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-denom-additive",
+    "proofId": "lovasz-local-lemma-oq-01-denominator-step",
+    "range": {
+      "startLine": 103,
+      "endLine": 119
+    },
+    "type": "insight",
+    "title": "The additive peel: survival mass splits on whether the new event also holds",
+    "content": "`cond_compl_inter_add`: $\\mu[A\\cap B\\mid C] + \\mu[A^c\\cap B\\mid C] = \\mu[B\\mid C]$. Conditioned on $C$, the survival mass over the block $B$ divides into the part where the new neighbour $A$ *also* occurs and the part where it is avoided too. This is the **complement companion** of the numerator chain rule: where the chain rule factors $\\mu[A\\cap B\\mid C]$, the survival recursion cares about the residual $\\mu[A^c\\cap B\\mid C]$ — the mass that survives $B$ and avoids $A$. The proof is one application of `measure_inter_add_diff` to the conditional measure `cond μ C` at the frame $B$ and split $A$, rewriting $B\\setminus A = A^c\\cap B$ (`Set.diff_eq` + `Set.inter_comm`). No probability-measure hypothesis is needed, so the `IsProbabilityMeasure` instance is `omit`-ted here.",
+    "mathContext": "measure_inter_add_diff on cond μ C: (cond μ C)(B ∩ A) + (cond μ C)(B \\ A) = (cond μ C) B, with B \\ A = Aᶜ ∩ B.",
+    "significance": "core",
+    "relatedConcepts": [
+      "measure_inter_add_diff",
+      "conditional measure",
+      "complement split",
+      "additivity of measure"
+    ],
+    "prerequisites": [
+      "measure_inter_add_diff: μ(s ∩ t) + μ(s \\ t) = μ s",
+      "Set.diff_eq: B \\ A = B ∩ Aᶜ"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-denom-mult",
+    "proofId": "lovasz-local-lemma-oq-01-denominator-step",
+    "range": {
+      "startLine": 120,
+      "endLine": 150
+    },
+    "type": "insight",
+    "title": "The multiplicative peel: one more avoided neighbour costs a factor (1 − x)",
+    "content": "`one_sub_mul_cond_le_cond_compl` (flagship): if the per-event failure probability over the refined history $B\\cap C$ is bounded, $\\mu[A\\mid B\\cap C]\\le x$, then $(1-x)\\cdot\\mu[B\\mid C] \\le \\mu[A^c\\cap B\\mid C]$. Avoiding one more neighbour $A=A_k$ on top of surviving $B$ deflates the survival probability by at most $(1-x)$. Proof: the additive peel plus the chain-rule factoring give $\\mu[A^c\\cap B\\mid C] = \\mu[B\\mid C] - \\mu[A\\mid B\\cap C]\\cdot\\mu[B\\mid C]$ (`ENNReal.eq_sub_of_add_eq`, finiteness from `cond_ne_top`). Then a three-step `calc`: $(1-x)\\mu[B\\mid C] = \\mu[B\\mid C] - x\\,\\mu[B\\mid C]$ (`ENNReal.sub_mul`, valid since $\\mu[B\\mid C]\\ne\\infty$); this is $\\le \\mu[B\\mid C] - \\mu[A\\mid B\\cap C]\\mu[B\\mid C]$ because $\\mu[A\\mid B\\cap C]\\le x$ (`tsub_le_tsub_left` on `mul_le_mul_right' hx`); and that equals the residual. Only $B\\cap C$ needs positive measure — no independence enters.",
+    "mathContext": "(1 − x)·μ[B|C] = μ[B|C] − x·μ[B|C] ≤ μ[B|C] − μ[A|B∩C]·μ[B|C] = μ[Aᶜ ∩ B | C], using μ[A|B∩C] ≤ x.",
+    "significance": "core",
+    "relatedConcepts": [
+      "ENNReal.sub_mul",
+      "ENNReal.eq_sub_of_add_eq",
+      "tsub_le_tsub_left",
+      "numerator chain rule",
+      "survival probability deflation"
+    ],
+    "prerequisites": [
+      "cond_compl_inter_add (additive peel)",
+      "cond_inter_eq_cond_cond_mul (numerator chain rule, reproved inline)",
+      "cond_ne_top (finiteness)"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-denom-recstep",
+    "proofId": "lovasz-local-lemma-oq-01-denominator-step",
+    "range": {
+      "startLine": 151,
+      "endLine": 168
+    },
+    "type": "insight",
+    "title": "The recursion step, already in ∏(1 − xⱼ) form",
+    "content": "`mul_one_sub_le_cond_compl`: from a survival lower bound $l \\le \\mu[B\\mid C]$ and the per-event bound $\\mu[A\\mid B\\cap C]\\le x$, conclude $(1-x)\\cdot l \\le \\mu[A^c\\cap B\\mid C]$ — via `le_trans` of the monotonicity $(1-x)\\,l \\le (1-x)\\,\\mu[B\\mid C]$ (`mul_le_mul_left' hl`) with the flagship peel. This is the transition the LLL strong induction iterates: instantiate $l = \\prod_{j\\in S_1\\setminus\\{k\\}}(1-x_j)$ (the survival bound over the partially-peeled neighbour block) and $x = x_k$; one application extends it to $\\prod_{j\\in S_1}(1-x_j)$ over the block with $A_k$ peeled. What remains genuinely open is only the recursion scaffolding — a well-founded induction on $|S_1|$ threading this step — plus supplying the per-event bounds $x_k$ from a measure-theoretic dependency structure. The analytic work of each step is discharged here.",
+    "mathContext": "(1 − x)·l ≤ (1 − x)·μ[B|C] ≤ μ[Aᶜ ∩ B | C]; with l = ∏_{S₁∖{k}}(1 − xⱼ), x = xₖ, extends the survival bound to ∏_{S₁}(1 − xⱼ).",
+    "significance": "core",
+    "relatedConcepts": [
+      "well-founded recursion",
+      "product lower bound",
+      "strong induction",
+      "monotonicity of multiplication"
+    ],
+    "prerequisites": [
+      "one_sub_mul_cond_le_cond_compl (multiplicative peel)",
+      "mul_le_mul_left' (monotonicity in ℝ≥0∞)"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "lovasz-local-lemma-oq-01-denominator-step",
+  "title": "Lovász Local Lemma OQ-01: The Denominator Recursion Step (Neighbour-Survival Peel)",
+  "slug": "lovasz-local-lemma-oq-01-denominator-step",
+  "description": "The dependency-split entry supplies the NUMERATOR moves of the Erdős–Lovász dependency-graph induction step (numerator monotonicity, non-neighbour independence collapse), reaching μ[Aᵢ ∩ (⋂_{S₁} Aⱼᶜ) | ⋂_{S₂} Aⱼᶜ] ≤ μ(Aᵢ). That is only the numerator; the induction bounds μ[Aᵢ | full history], for which the missing ingredient is the neighbour-block survival lower bound μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏(1 − xⱼ), 'which the LLL strong induction supplies'. That strong induction is a recursion on the neighbour block S₁, peeling one neighbour Aₖ at a time. This entry supplies the ENGINE of that recursion — the single-neighbour peel transition — which is missing from every OQ-01 file. The transition is the COMPLEMENT companion of the conditional chain rule μ[(A ∩ B) | C] = μ[A | B ∩ C] · μ[B | C] (reproved inline here so the file depends only on Mathlib): where the chain rule factors the numerator μ[A ∩ B | C], the survival recursion needs the residual μ[Aᶜ ∩ B | C] (the mass that survives the already-peeled block B AND also avoids the new neighbour Aₖ). The additive peel identity μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] (cond_compl_inter_add), combined with the numerator factoring and a per-event failure bound μ[A | B ∩ C] ≤ x, yields the multiplicative peel (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C] (one_sub_mul_cond_le_cond_compl): adding one more avoided neighbour deflates the survival probability by at most a factor (1 − x). Chained against an inductive lower bound l ≤ μ[B | C] it gives the recursion step in the exact ∏(1 − xⱼ) shape: (1 − x) · l ≤ μ[Aᶜ ∩ B | C] (mul_one_sub_le_cond_compl). Iterating this over the neighbours of Aₖ (a well-founded recursion on |S₁|, still to be assembled) produces the survival lower bound the dependency-graph induction step consumes. Everything is over an arbitrary IsProbabilityMeasure, stated abstractly for events A B C; no independence is assumed — this is the pure conditional-measure bookkeeping of the peel. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "conditional-probability"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on cond_ne_top, cond_compl_inter_add, one_sub_mul_cond_le_cond_compl, and mul_one_sub_le_cond_compl). Scope: this entry supplies the single-neighbour peel transition that drives the survival (denominator) recursion of the Lovász Local Lemma's dependency-graph induction — the additive complement identity μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] and its multiplicative consequence (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C] under a per-event failure bound μ[A | B ∩ C] ≤ x. It does NOT prove the LLL induction itself: assembling the per-step peel into the full survival lower bound μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏(1 − xⱼ) by well-founded recursion on |S₁|, and supplying the per-event bounds x = xₖ from a dependency structure, remain the open OQ-01 research targets. The per-event failure bound (μ[A | B ∩ C] ≤ x), the survival lower bound (l ≤ μ[B | C]), and the positive-measure hypothesis (μ(B ∩ C) ≠ 0) are stated explicitly as arguments; they are not axioms.",
+    "lineCount": 168,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "one_sub_mul_cond_le_cond_compl (flagship): the multiplicative single-neighbour peel — if the per-event failure probability over the refined history B ∩ C is bounded, μ[A | B ∩ C] ≤ x, then avoiding A on top of surviving B deflates the survival probability by at most the factor (1 − x): (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]. This is the exact transition the Erdős–Lovász survival recursion performs when it peels one neighbour A = Aₖ off the neighbour block. Proof: the additive peel gives μ[Aᶜ ∩ B | C] = μ[B|C] − μ[A ∩ B | C] (ENNReal.eq_sub_of_add_eq, needing finiteness of the conditional); the numerator chain rule rewrites μ[A ∩ B | C] = μ[A | B ∩ C]·μ[B | C] ≤ x·μ[B|C]; and (1 − x)·μ[B|C] = μ[B|C] − x·μ[B|C] via ENNReal.sub_mul. Only the conditioning set B ∩ C needs positive measure; no independence.",
+      "cond_compl_inter_add: the additive peel identity μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] — the survival mass over B, conditioned on C, splits according to whether the new event A also holds. It is the complement companion of the numerator chain rule: where the chain rule factors μ[A ∩ B | C], the survival recursion needs the residual μ[Aᶜ ∩ B | C]. Proof: measure_inter_add_diff applied to the conditional measure cond μ C, with B \\ A = Aᶜ ∩ B.",
+      "mul_one_sub_le_cond_compl: the survival recursion step in ∏(1 − xⱼ) form — chaining the multiplicative peel against an inductive survival lower bound l ≤ μ[B | C] gives (1 − x) · l ≤ μ[Aᶜ ∩ B | C], the shape the LLL strong induction iterates. With l = ∏_{j∈S₁∖{k}}(1 − xⱼ) and x = xₖ one application extends the survival bound to ∏_{j∈S₁}(1 − xⱼ) over the block with Aₖ peeled.",
+      "cond_ne_top: conditionals are finite, μ[t | s] ≠ ∞ for any measurable conditioning set s (if μ s = 0 the numerator μ(s ∩ t) ≤ μ s vanishes; else (μ s)⁻¹ and μ(s ∩ t) are both finite). Mathlib packages finiteness of cond only via an IsProbabilityMeasure instance requiring μ s ∉ {0, ∞}; this unconditional ≠ ∞ fact is what lets the survival peel subtract and cancel conditional masses.",
+      "Framing contribution: identifies the survival (denominator) recursion of the LLL as a per-neighbour peel driven by a single complement identity, dual to the numerator chain-rule split, and delivers that peel as a general, independence-free lemma — reducing the remaining open OQ-01 piece to a well-founded recursion assembling per-step peels plus the supply of the per-event bounds xₖ."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.ConditionalProbability"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "ENNReal"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01DenominatorStep",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 5,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "one_sub_mul_cond_le_cond_compl",
+      "type": "core",
+      "description": "The multiplicative single-neighbour peel (flagship): if μ[A | B ∩ C] ≤ x, then (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]. Avoiding A on top of surviving B deflates the survival probability by at most the factor (1 − x) — the exact transition the Erdős–Lovász survival recursion performs when it peels one neighbour off the neighbour block. Proof: additive peel μ[Aᶜ ∩ B | C] = μ[B|C] − μ[A ∩ B | C], the numerator chain-rule factoring μ[A ∩ B | C] = μ[A | B ∩ C]·μ[B | C] ≤ x·μ[B|C], and (1 − x)·μ[B|C] = μ[B|C] − x·μ[B|C] via ENNReal.sub_mul.",
+      "leanType": "(hA : MeasurableSet A) → (hB : MeasurableSet B) → (hC : MeasurableSet C) → (hBC : μ (B ∩ C) ≠ 0) → (hx : μ[A | B ∩ C] ≤ x) → (1 - x) * μ[B | C] ≤ μ[Aᶜ ∩ B | C]"
+    },
+    {
+      "name": "cond_compl_inter_add",
+      "type": "core",
+      "description": "The additive peel identity: μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]. The survival mass over B, conditioned on C, splits according to whether the new event A also holds. The complement companion of the numerator chain rule; measure_inter_add_diff applied to the conditional measure cond μ C, with B \\ A = Aᶜ ∩ B.",
+      "leanType": "(hA : MeasurableSet A) → μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]"
+    },
+    {
+      "name": "mul_one_sub_le_cond_compl",
+      "type": "core",
+      "description": "The survival recursion step in ∏(1 − xⱼ) form: chaining the multiplicative peel against an inductive survival lower bound l ≤ μ[B | C] gives (1 − x) · l ≤ μ[Aᶜ ∩ B | C]. With l = ∏_{j∈S₁∖{k}}(1 − xⱼ) and x = xₖ, one application extends the survival bound to ∏_{j∈S₁}(1 − xⱼ) over the block with Aₖ peeled.",
+      "leanType": "(hA : MeasurableSet A) → (hB : MeasurableSet B) → (hC : MeasurableSet C) → (hBC : μ (B ∩ C) ≠ 0) → (hx : μ[A | B ∩ C] ≤ x) → (hl : l ≤ μ[B | C]) → (1 - x) * l ≤ μ[Aᶜ ∩ B | C]"
+    },
+    {
+      "name": "cond_ne_top",
+      "type": "lemma",
+      "description": "Conditionals are finite: μ[t | s] ≠ ∞ for any measurable conditioning set s. If μ s = 0 the conditional is 0 (numerator μ(s ∩ t) ≤ μ s vanishes); else (μ s)⁻¹ and μ(s ∩ t) are both finite. The unconditional finiteness the survival peel needs to subtract and cancel conditional masses, absent from Mathlib for a general conditioning set.",
+      "leanType": "(hs : MeasurableSet s) → (t : Set Ω) → μ[t | s] ≠ ∞"
+    },
+    {
+      "name": "cond_inter_eq_cond_cond_mul",
+      "type": "lemma",
+      "description": "The two-block conditioning chain rule (numerator identity): μ[(A ∩ B) | C] = μ[A | B ∩ C] · μ[B | C], for arbitrary events over a probability measure with μ(B ∩ C) ≠ 0. A standard conditional-probability identity (it also appears in sibling OQ-01 developments), reproved inline here so the file depends only on Mathlib. Proof: cond_apply unfolds all three conditionals to (measure)⁻¹ · (intersection measure); the μ(B ∩ C) factor cancels against its inverse and the surviving intersections agree after reassociation. Used to factor the numerator μ[A ∩ B | C] in the multiplicative peel.",
+      "leanType": "(hB : MeasurableSet B) → (hC : MeasurableSet C) → (hBC : μ (B ∩ C) ≠ 0) → μ[(A ∩ B) | C] = μ[A | B ∩ C] * μ[B | C]"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) states that if each of a family of 'bad' events is mutually independent of all but at most d others and each has probability at most p with e·p·(d+1) ≤ 1, then with positive probability none occurs. Its proof — due to Erdős and Lovász, streamlined by Spencer and by Alon–Spencer's The Probabilistic Method — is an induction bounding Pr[Aᵢ | ⋂_{j∈S} Āⱼ] ≤ xᵢ for every subset S of events not containing i. The induction step splits S into S₁ = neighbours of i and S₂ = non-neighbours: the non-neighbour part factors out by independence, the neighbour part is dropped from the numerator, and the neighbour survival in the DENOMINATOR is bounded below recursively by ∏_{j∈S₁}(1 − xⱼ). That denominator lower bound is itself a recursion: it peels the neighbours of Aᵢ one at a time, each peel multiplying the survival probability by a factor (1 − xₖ). The OQ-01 gallery front formalized the measure-theoretic surroundings (chain-rule reduction, quantitative avoidance bound, union-bound and independent extremes) and then, in the dependency-split entries, the per-event moves of the induction step — culminating in the numerator Bayes identity μ[(A ∩ B) | C] = μ[A | B ∩ C]·μ[B | C], which reduces the LLL to exactly the neighbour-survival lower bound. This entry supplies the engine of that lower bound's recursion: the single-neighbour peel.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces, including the dependency-graph induction that produces per-event conditional bounds from a bounded dependency degree.\n\n**This entry (denominator recursion engine)**: supply the single-neighbour peel transition driving the survival (denominator) recursion μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏_{j∈S₁}(1 − xⱼ). Over an arbitrary probability measure and abstract events A B C: (1) the additive peel identity μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]; (2) from a per-event failure bound μ[A | B ∩ C] ≤ x, the multiplicative peel (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]; (3) chained against a survival lower bound l ≤ μ[B | C], the recursion step (1 − x) · l ≤ μ[Aᶜ ∩ B | C] in ∏(1 − xⱼ) form.",
+    "text": "The hard half of the Lovász Local Lemma is a denominator: to bound the chance that one more bad event happens, given a bunch already avoided, you divide by the probability that the entangled 'neighbour' events were all avoided — and that survival probability must be bounded below. The classic argument does it by peeling neighbours off one at a time, each peel costing a factor (1 − xₖ), until you reach the clean product ∏(1 − xⱼ). This entry is exactly one peel: the identity that the survival mass over a block splits into 'the new event also happens' plus 'it is avoided too', and the resulting bound showing that avoiding one more neighbour shrinks the survival probability by at most (1 − x). It is the complement mirror of the earlier the numerator chain rule, and it is what the recursion iterates.",
+    "proofStrategy": "**Finiteness (cond_ne_top).** cond_apply rewrites μ[t | s] = (μ s)⁻¹ · μ(s ∩ t). If μ s = 0 then μ(s ∩ t) ≤ μ s = 0 so the product is 0 ≠ ∞; else (μ s)⁻¹ ≠ ∞ (ENNReal.inv_ne_top) and μ(s ∩ t) ≠ ∞ (measure_ne_top), so ENNReal.mul_ne_top closes it. This unconditional finiteness is what lets the subsequent subtraction and cancellation go through.\n\n**Additive peel (cond_compl_inter_add).** Apply measure_inter_add_diff to the conditional measure cond μ C at the sets B (frame) and A (split): (cond μ C)(B ∩ A) + (cond μ C)(B \\ A) = (cond μ C) B. Rewriting B ∩ A = A ∩ B and B \\ A = Aᶜ ∩ B (Set.diff_eq + Set.inter_comm) gives μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]. No probability-measure hypothesis is needed (the IsProbabilityMeasure instance is omitted for this lemma).\n\n**Multiplicative peel (one_sub_mul_cond_le_cond_compl).** From the additive peel and the numerator chain rule μ[A ∩ B | C] = μ[A | B ∩ C]·μ[B | C], ENNReal.eq_sub_of_add_eq (using cond_ne_top for finiteness) gives μ[Aᶜ ∩ B | C] = μ[B|C] − μ[A | B ∩ C]·μ[B|C]. A three-step calc: (1 − x)·μ[B|C] = μ[B|C] − x·μ[B|C] (ENNReal.sub_mul, valid since μ[B|C] ≠ ∞), then tsub_le_tsub_left with μ[A | B ∩ C]·μ[B|C] ≤ x·μ[B|C] (mul_le_mul_right' hx), then the equality for the residual.\n\n**Recursion step (mul_one_sub_le_cond_compl).** le_trans of mul_le_mul_left' hl (monotonicity (1 − x)·l ≤ (1 − x)·μ[B|C]) with the multiplicative peel.",
+    "keyInsights": [
+      "The Lovász Local Lemma has two halves and the earlier OQ-01 entries had only clean tools for one. The numerator half (dependency-split, and the numerator chain rule) factors μ[(A ∩ B) | C] = μ[A | B ∩ C]·μ[B | C] and drops the neighbour factor. The denominator half — bounding the neighbour-block survival μ[B | C] from below — is a separate recursion, and its per-step engine is a COMPLEMENT identity, μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C], not the product identity. Recognising that duality is what turns the survival bound into a one-neighbour-at-a-time peel.",
+      "The multiplicative peel needs no independence and no dependency-degree hypothesis: it is pure conditional-measure algebra. All the LLL-specific content — which events are neighbours, the value of the per-event budget x = xₖ — enters only through the two supplied inequalities (μ[A | B ∩ C] ≤ x and l ≤ μ[B | C]). Isolating the peel as a general lemma over abstract events A B C means the eventual recursion assembly is a purely combinatorial induction over Finset subsets, with the analytic work already done here.",
+      "Finiteness of conditional probabilities is the quiet obstruction. Because ℝ≥0∞ subtraction is truncated and its addition is not cancellative, the peel's 'μ[Aᶜ ∩ B | C] = μ[B|C] − μ[A ∩ B | C]' step requires μ[A ∩ B | C] ≠ ∞ — which Mathlib only certifies via an IsProbabilityMeasure instance that presupposes the conditioning set is neither null nor infinite. cond_ne_top removes that presupposition, handling the null case explicitly, so the peel holds for ANY measurable conditioning set.",
+      "The peel is stated in the exact ∏(1 − xⱼ) shape the target consumes: mul_one_sub_le_cond_compl takes a survival lower bound l over the partially-peeled block and returns one over the block with one more neighbour removed, scaled by (1 − x). What remains is genuinely just the recursion scaffolding — a well-founded induction on |S₁| threading this step — plus supplying the per-event bounds xₖ from a measure-theoretic dependency structure."
+    ],
+    "prerequisites": [
+      "The numerator chain rule identity μ[(A ∩ B) | C] = μ[A | B ∩ C]·μ[B | C] (cond_inter_eq_cond_cond_mul)",
+      "ProbabilityTheory.cond and cond_apply: μ[t|s] = (μ s)⁻¹ · μ(s ∩ t)",
+      "measure_inter_add_diff: μ(s ∩ t) + μ(s \\ t) = μ s, applied to the conditional measure cond μ C",
+      "ENNReal truncated-subtraction algebra: ENNReal.sub_mul, ENNReal.eq_sub_of_add_eq, tsub_le_tsub_left"
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-motivation",
+      "title": "Motivation: the denominator recursion peels neighbours one at a time",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Module docstring. Explains that the dependency-split entry supplies only the numerator moves of the LLL induction step, and that reaching a bound on μ[Aᵢ | full history] requires the neighbour-block survival lower bound μ[⋂_{S₁} Aⱼᶜ | C] ≥ ∏(1 − xⱼ) — a recursion peeling neighbours one at a time. States the engine this file supplies — the complement companion of the conditional chain rule — via the additive peel, the multiplicative peel, and the ∏(1 − xⱼ)-shaped recursion step, all over an arbitrary probability measure with no independence assumed. Notes that the one numerator identity used is reproved inline so the file depends only on Mathlib."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 59,
+      "endLine": 67,
+      "summary": "Imports Mathlib.Probability.ConditionalProbability. Opens MeasureTheory, ProbabilityTheory, and the ENNReal scope; enters the LovaszLocalLemmaOQ01DenominatorStep namespace with the ambient measurable space, probability measure μ, and abstract events A B C."
+    },
+    {
+      "id": "numerator-identity",
+      "title": "The two-block conditioning chain rule (reproved inline)",
+      "startLine": 69,
+      "endLine": 88,
+      "summary": "cond_inter_eq_cond_cond_mul: μ[(A ∩ B) | C] = μ[A | B ∩ C] · μ[B | C] for μ(B ∩ C) ≠ 0. cond_apply unfolds all three conditionals to (measure)⁻¹ · (intersection measure); the μ(B ∩ C) factor cancels against its inverse and the surviving intersections agree after reassociation (a ring-normalised rewrite). Standard conditional-probability identity reproved inline so the file depends only on Mathlib; supplies the numerator factoring for the multiplicative peel."
+    },
+    {
+      "id": "cond-ne-top",
+      "title": "Conditionals are finite",
+      "startLine": 89,
+      "endLine": 102,
+      "summary": "cond_ne_top: μ[t | s] ≠ ∞ for measurable s. cond_apply unfolds to (μ s)⁻¹ · μ(s ∩ t); a case split on μ s = 0 (numerator vanishes) versus μ s ≠ 0 (both factors finite, ENNReal.mul_ne_top) gives finiteness for ANY measurable conditioning set — the fact the peel needs to subtract and cancel conditional masses, absent from Mathlib for a general conditioning set."
+    },
+    {
+      "id": "additive-peel",
+      "title": "The additive peel identity",
+      "startLine": 103,
+      "endLine": 119,
+      "summary": "cond_compl_inter_add: μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C], proved by measure_inter_add_diff on the conditional measure cond μ C with B \\ A = Aᶜ ∩ B (Set.diff_eq + Set.inter_comm). No IsProbabilityMeasure needed (the instance is omitted). The complement companion of the numerator chain rule."
+    },
+    {
+      "id": "multiplicative-peel",
+      "title": "The multiplicative single-neighbour peel (flagship)",
+      "startLine": 120,
+      "endLine": 150,
+      "summary": "one_sub_mul_cond_le_cond_compl: from μ[A | B ∩ C] ≤ x, (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C]. Combines the additive peel with the numerator identity to write μ[Aᶜ ∩ B | C] = μ[B|C] − μ[A | B ∩ C]·μ[B|C] (ENNReal.eq_sub_of_add_eq, finiteness from cond_ne_top), then a three-step calc using ENNReal.sub_mul and tsub_le_tsub_left. Only B ∩ C needs positive measure; no independence."
+    },
+    {
+      "id": "recursion-step",
+      "title": "The survival recursion step in ∏(1 − xⱼ) form",
+      "startLine": 151,
+      "endLine": 168,
+      "summary": "mul_one_sub_le_cond_compl: from a survival lower bound l ≤ μ[B | C] and μ[A | B ∩ C] ≤ x, (1 − x) · l ≤ μ[Aᶜ ∩ B | C], via le_trans of mul_le_mul_left' hl and the flagship peel. The exact per-step transition the LLL strong induction iterates over the neighbours of Aₖ. The namespace closes at line 168."
+    }
+  ],
+  "conclusion": {
+    "summary": "The single-neighbour peel that drives the survival (denominator) recursion of the Lovász Local Lemma's dependency-graph induction is machine-verified over an arbitrary probability space: the additive complement identity μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C] (cond_compl_inter_add), its multiplicative consequence (1 − x) · μ[B | C] ≤ μ[Aᶜ ∩ B | C] under a per-event failure bound (one_sub_mul_cond_le_cond_compl), and the ∏(1 − xⱼ)-shaped recursion step (mul_one_sub_le_cond_compl), supported by the unconditional finiteness of conditionals (cond_ne_top). 0 sorries, 0 axioms.",
+    "implications": "**Completes the analytic content of the LLL induction step's denominator half.** The dependency-split entries supplied the numerator half (drop the neighbour factor, factor the Bayes product) and named the neighbour-block survival lower bound as the single remaining estimate. This entry delivers the per-step engine of that lower bound: one peel of one neighbour, costing a factor (1 − x). Dual to the product chain-rule identity, it uses the COMPLEMENT split rather than the factoring, and it needs no independence — the LLL-specific inputs enter only through two supplied inequalities.\n\n**Honest scope**: this is one step of a recursion, not the recursion. Assembling the peel into the full survival lower bound μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏_{j∈S₁}(1 − xⱼ) requires a well-founded induction over the neighbour Finset S₁ (threading this step and the per-event bounds it consumes), and the per-event bounds x = xₖ must still be produced from a measure-theoretic dependency structure. Those remain the open OQ-01 targets; this entry reduces them to purely combinatorial recursion assembly with the analytic work discharged.",
+    "openQuestions": [
+      "Assemble the single-neighbour peel (mul_one_sub_le_cond_compl) into the full neighbour-block survival lower bound μ[⋂_{j∈S₁} Aⱼᶜ | ⋂_{j∈S₂} Aⱼᶜ] ≥ ∏_{j∈S₁}(1 − xⱼ) by well-founded recursion on |S₁|, threading the per-event bounds μ[Aₖ | history] ≤ xₖ that the induction hypothesis supplies.",
+      "Combine the completed survival lower bound with the dependency-split numerator bound to close the Erdős–Lovász induction step Pr[Aᵢ | ⋂_{j∈S} Aⱼᶜ] ≤ xᵢ over an arbitrary subset history, the full mutual-induction that is the heart of the measure-theoretic LLL.",
+      "Feed the resulting per-event bounds into lovasz-local-lemma-oq-01-quantitative's avoidance_ge_prod_one_sub to obtain the asymmetric general LLL conclusion μ(⋂ Aᵢᶜ) ≥ ∏(1 − xᵢ) over a genuine probability space."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-dependency-split",
+      "relationship": "extends",
+      "description": "The numerator half of the dependency-graph induction step (numerator monotonicity, non-neighbour independence collapse). This entry supplies the complementary denominator half: the survival-peel recursion engine whose per-step transition is the complement identity dual to that file's numerator moves."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "extends",
+      "description": "The prefix-history scaffold reducing avoidance to per-event conditional bounds. The survival peel proved here is the tool that, once assembled into the neighbour-block survival lower bound, produces those per-event bounds from a bounded dependency degree."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-quantitative",
+      "relationship": "related",
+      "description": "The quantitative avoidance bound ∏(1 − bₖ) ≤ μ(⋂ Aᵢᶜ), which consumes per-event conditional bounds bₖ. The survival peel is the missing engine that (via the still-open recursion) turns a dependency-degree hypothesis into those bₖ."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "related",
+      "description": "The d = 0 base case μ(⋂ Aᵢᶜ) = ∏(1 − μ(Aᵢ)) from full mutual independence. The general (d > 0) survival recursion this entry drives reduces, at its base, to that independent product."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the induction bounds Pr[Aᵢ | ⋂_{j∈S} Āⱼ] over arbitrary subsets S, with the neighbour-block survival in the denominator bounded below by ∏(1 − xⱼ)."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Chapter 5 gives the standard induction proof of the LLL; the denominator survival probability is bounded below by peeling the neighbours one at a time, each peel contributing a factor (1 − xₖ) — the transition this entry formalizes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Supplies the **engine of the Erdős–Lovász survival (denominator) recursion** for the measure-theoretic Lovász Local Lemma (OQ-01) — the single-neighbour *peel* transition, which was missing from every existing OQ-01 file.

The sibling `lovasz-local-lemma-oq-01-dependency-split` entry supplied the *numerator* moves of the induction step and named the remaining estimate explicitly: the neighbour-block survival lower bound `μ[⋂_{j∈S₁} Aⱼᶜ | C] ≥ ∏(1 − xⱼ)`, "which the LLL strong induction supplies". That induction is a recursion on the neighbour block `S₁`, peeling one neighbour `Aₖ` at a time. This PR lands its per-step transition.

## New file (0-axiom / 0-sorry, self-contained)

`proofs/Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean` — imports only `Mathlib.Probability.ConditionalProbability`; abstract over events `A B C : Set Ω` on an arbitrary `IsProbabilityMeasure`. No independence assumed — pure conditional-measure bookkeeping.

| theorem | statement |
|---|---|
| `cond_compl_inter_add` | `μ[A ∩ B \| C] + μ[Aᶜ ∩ B \| C] = μ[B \| C]` — additive peel; complement companion of the conditional chain rule |
| `one_sub_mul_cond_le_cond_compl` *(flagship)* | from `μ[A \| B ∩ C] ≤ x`, `(1 − x)·μ[B \| C] ≤ μ[Aᶜ ∩ B \| C]` — avoiding one more neighbour deflates survival by at most `(1 − x)` |
| `mul_one_sub_le_cond_compl` | chained against `l ≤ μ[B \| C]`: `(1 − x)·l ≤ μ[Aᶜ ∩ B \| C]` — the recursion step in `∏(1 − xⱼ)` form |
| `cond_ne_top` | `μ[t \| s] ≠ ∞` for any measurable conditioning set — unconditional finiteness Mathlib lacks, needed for the ℝ≥0∞ subtraction/cancellation |
| `cond_inter_eq_cond_cond_mul` | the numerator chain rule `μ[(A ∩ B) \| C] = μ[A \| B ∩ C]·μ[B \| C]`, reproved inline so the file depends only on Mathlib |

## Verification

- `lake env lean Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean` → exit 0 (only deprecation warnings, matching sibling merged files).
- `#print axioms` on all four substantive theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `ofReduceBool`, no `native_decide`.

## Gallery

New entry `src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/` (meta.json + annotations.json), structurally mirroring the dependency-split entry.

## Honest scope

This is **one step of a recursion, not the recursion**. The per-event failure bound (`μ[A | B ∩ C] ≤ x`), the survival lower bound (`l ≤ μ[B | C]`), and positive-measure hypothesis are explicit arguments — not axioms. Still open: assembling the peel into the full survival lower bound by well-founded recursion on `|S₁|`, and supplying the per-event bounds `xₖ` from a measure-theoretic dependency structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)