### PR TITLE
Enrich Vandermonde convolution for rising factorials (arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/annotations.json
@@ -94,5 +94,28 @@
       "Nat.ascFactorial",
       "Nat.choose"
     ]
+  },
+  {
+    "id": "ann-asoq010102-binomial-type",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 204,
+      "endLine": 220
+    },
+    "type": "concept",
+    "title": "Rising Factorials Form a Sequence of Binomial Type",
+    "content": "The closing summary names what the file has established: the rising-factorial polynomials p_k(x) = x^{(k)} = (ascPochhammer S k).eval x are a SEQUENCE OF BINOMIAL TYPE. A polynomial sequence {p_k} is of binomial type when it satisfies the umbral binomial theorem p_k(x+y) = ∑_m C(k,m) p_m(x) p_{k-m}(y) — exactly Part I's ascPochhammer_eval_add. The ordinary monomials p_k(x)=x^k are the prototypical example (Commute.add_pow); rising and falling factorials are the two other classical instances, central to umbral calculus and the theory of Sheffer/Appell sequences. The headline is therefore the ADDITIVE (Chu–Vandermonde) companion to Mathlib's MULTIPLICATIVE composition law ascPochhammer_mul, and it discharges open questions #2 and #3 of the parent multiset-coefficient entry.",
+    "mathContext": "Binomial type: $p_k(x+y)=\\sum_{m=0}^{k}\\binom{k}{m}p_m(x)\\,p_{k-m}(y)$, with $p_k(x)=x^{\\overline k}$ here; the multiplicative sibling is $x^{\\overline{m+n}} = x^{\\overline m}\\,(x+m)^{\\overline n}$ (ascPochhammer_mul).",
+    "significance": "key",
+    "relatedConcepts": [
+      "sequence of binomial type",
+      "umbral / Appell calculus",
+      "Chu–Vandermonde identity",
+      "ascPochhammer_mul (multiplicative companion)"
+    ],
+    "prerequisites": [
+      "the binomial theorem for monomials",
+      "ascPochhammer / rising factorials"
+    ]
   }
 ]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -80,9 +80,18 @@
     {
       "id": "concrete-checks",
       "title": "Part IV: Concrete Verification",
-      "summary": "Three decide checks (no native_decide): a=b=1,k=2 (=6); a=2,b=1,k=2 (=12); a=1,b=2,k=3 (=60).",
+      "summary": "Three decide checks (no native_decide): a=b=1,k=2 (=6); a=2,b=1,k=2 (=12); a=1,b=2,k=3 (=60). Kernel decide keeps the entry axiom-free (no Lean.ofReduceBool from native_decide).",
       "startLine": 182,
-      "endLine": 220
+      "endLine": 203,
+      "mathContext": "(2)^{(2)} = 2·3 = 6; (3)^{(2)} = 3·4 = 12; (3)^{(3)} = 3·4·5 = 60 — each matched against the Vandermonde convolution's RHS by ordinary kernel reduction."
+    },
+    {
+      "id": "binomial-type-summary",
+      "title": "Summary: Rising Factorials Are of Binomial Type",
+      "summary": "The closing doc block recaps the four parts and states the headline: the rising-factorial polynomials x^{(k)} form a sequence of binomial type, so the additive Chu–Vandermonde law is the additive companion to Mathlib's multiplicative ascPochhammer_mul, answering open questions #2 and #3 of the parent multiset-coefficient entry. 0 axioms / 0 sorries / no native_decide.",
+      "startLine": 204,
+      "endLine": 220,
+      "mathContext": "A polynomial sequence {p_k} is of binomial type when p_k(x+y) = ∑_m C(k,m) p_m(x) p_{k-m}(y); here p_k = ascPochhammer(k), the umbral/Appell analogue of the ordinary binomial theorem (p_k(x)=x^k)."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment 93 → 100/100 (verified against origin/main; full worktree). Split the closing Summary doc block into its own `binomial-type-summary` section and added a matching `concept` annotation explaining that rising factorials form a sequence of binomial type (the additive Chu–Vandermonde companion to Mathlib's `ascPochhammer_mul`): sections 4→5, annotations 4→5. Ranges verified against `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean`. JSON validated. No existing content removed.