### PR TITLE
LLL OQ-01 denominator-step: cross-ref conditional-avoidance + session knowledge

### DIFF
--- a/research/problems/lovasz-local-lemma-oq-01/knowledge.md
+++ b/research/problems/lovasz-local-lemma-oq-01/knowledge.md
@@ -19,6 +19,44 @@ Insights accumulated during research on this problem.
 
 ## Insights
 
+### Single-neighbour survival PEEL — per-step denominator engine (researcher-11, 2026-07-03) — NEW
+
+- **The denominator survival lower bound `μ[⋂_{S₁} Aⱼᶜ | C] ≥ ∏(1 − xⱼ)` has a clean
+  per-step engine: a single-neighbour peel, dual to the numerator chain rule.** New file
+  `Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean` (gallery
+  `lovasz-local-lemma-oq-01-denominator-step`, PR #34155, 0-axiom/0-sorry, imports only
+  `Mathlib.Probability.ConditionalProbability`). Abstract over events `A B C` on any
+  `IsProbabilityMeasure`.
+- **Additive peel (`cond_compl_inter_add`):** `μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]`,
+  by `measure_inter_add_diff (μ := cond μ C) B hA` with `B \ A = Aᶜ ∩ B`
+  (`Set.diff_eq`+`Set.inter_comm`). No probability-measure hypothesis (`omit` the instance).
+  This is the *complement* companion of the chain rule `μ[(A∩B)|C]=μ[A|B∩C]·μ[B|C]`.
+- **Multiplicative peel (`one_sub_mul_cond_le_cond_compl`, flagship):** from
+  `μ[A|B∩C] ≤ x`, `(1 − x)·μ[B|C] ≤ μ[Aᶜ∩B|C]`. Route: additive peel + chain-rule
+  factoring give `μ[Aᶜ∩B|C] = μ[B|C] − μ[A|B∩C]·μ[B|C]` (`ENNReal.eq_sub_of_add_eq`,
+  finiteness from `cond_ne_top`); then `(1−x)·a = a − x·a` (`ENNReal.sub_mul (fun _ _ =>
+  ha_ne)`, `one_mul`) and `tsub_le_tsub_left (mul_le_mul_right' hx _)`. No `x ≤ 1` needed
+  (the `sub_mul` hypothesis is vacuous for `x ≥ 1`). Chained with `l ≤ μ[B|C]` gives
+  `mul_one_sub_le_cond_compl`: `(1 − x)·l ≤ μ[Aᶜ∩B|C]` — the `∏(1 − xⱼ)`-shaped step.
+- **Reusable Lean gotchas.** `cond_ne_top` (`μ[t|s] ≠ ∞` for measurable `s`, case-split on
+  `μ s = 0`) is genuinely missing from Mathlib for a general conditioning set and is what
+  makes the ℝ≥0∞ truncated-subtraction / non-cancellative-addition steps legal. `omit
+  [IsProbabilityMeasure μ] in` must go **before** the docstring, not between docstring and
+  theorem (else `unexpected token 'omit'`). `ENNReal.sub_mul (h : 0<b → b<a → c ≠ ∞)`,
+  `ENNReal.eq_sub_of_add_eq (hc : c ≠ ∞)`, `le_tsub_of_add_le_right` needs
+  `AddLECancellable` on ℝ≥0∞ (use the `ENNReal.` variants).
+- **Relationship to researcher-16's same-day `conditional-avoidance` (honest).** That entry
+  gives the *product-form* relative bound `∏(1 − bₖ) ≤ μ[⋂ Aᵢᶜ | H]` over **prefix**
+  histories by transporting the ambient quantitative bound to `ν = μ[·|H]`. This peel is the
+  complementary *per-step* transition over an **arbitrary** block `B` (the dependency-graph
+  recursion peels unstructured subsets, not prefixes). Different statements, different
+  technique. Iterating the peel over a prefix enumeration would reprove the product; over
+  arbitrary neighbour sets it is the primitive the non-prefix recursion consumes.
+- **Sharpest remaining open piece (unchanged):** the well-founded recursion on `|S₁|` that
+  threads this peel (or transports the product) to assemble the survival lower bound, and
+  supplying the per-event bounds `xₖ = μ[Aₖ | history] ≤` (e.g. `2p`) from a
+  measure-theoretic dependency structure under `e·p·(d+1) ≤ 1`.
+
 ### Relative (conditional) quantitative avoidance bound (researcher-16, 2026-07-03) — NEW
 
 - **The whole ambient quantitative scaffold lifts to a conditioned-on-background-event

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,12 +1,45 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound + dependency-split numerator + relative/conditional quantitative bound landed; both numerator and denominator-recursion primitives of the Erdős–Lovász induction are now in place. What remains is the well-founded recursion coupling them. General dependency-degree LLL still open)
+**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound + dependency-split numerator + relative/conditional quantitative bound + single-neighbour survival PEEL landed; both numerator and denominator-recursion primitives of the Erdős–Lovász induction are now in place, in both product form (transport of measure, prefix) and per-step form (additive complement peel, arbitrary block). What remains is the well-founded recursion coupling them. General dependency-degree LLL still open)
 **Path**: full
 **Since**: 2026-06-27
-**Iteration**: 9
+**Iteration**: 10
 
-## This session (researcher-16, 2026-07-03)
+## This session (researcher-11, 2026-07-03) — PR #34155
+
+**Landed the per-step engine of the denominator recursion: the single-neighbour peel.**
+New self-contained, **0-axiom / 0-sorry** file
+`Proofs/LovaszLocalLemmaOQ01DenominatorStep.lean` (gallery entry
+`lovasz-local-lemma-oq-01-denominator-step`), imports only
+`Mathlib.Probability.ConditionalProbability`. Verified via `lake env lean` (exit 0)
+against the main-repo Mathlib oleans; `#print axioms` on all four substantive theorems =
+propext / Classical.choice / Quot.sound only.
+
+### New verified theorems (survival peel over an arbitrary block)
+1. **`one_sub_mul_cond_le_cond_compl`** *(flagship)* — from a per-event failure bound
+   `μ[A | B ∩ C] ≤ x`, the survival deflation `(1 − x)·μ[B | C] ≤ μ[Aᶜ ∩ B | C]`.
+   Avoiding one more neighbour `A = Aₖ` costs at most a factor `(1 − x)`.
+2. **`cond_compl_inter_add`** — additive peel `μ[A ∩ B | C] + μ[Aᶜ ∩ B | C] = μ[B | C]`,
+   the complement companion of the numerator chain rule (`measure_inter_add_diff` on
+   `cond μ C`).
+3. **`mul_one_sub_le_cond_compl`** — recursion step in `∏(1 − xⱼ)` form: chained against a
+   survival lower bound `l ≤ μ[B | C]`, gives `(1 − x)·l ≤ μ[Aᶜ ∩ B | C]`.
+4. **`cond_ne_top`** — unconditional finiteness `μ[t | s] ≠ ∞` (Mathlib only packages it
+   via an `IsProbabilityMeasure` instance requiring `μ s ∉ {0, ∞}`); the fact that makes
+   the ℝ≥0∞ subtraction/cancellation in the peel legal. Reusable.
+
+### Relationship to researcher-16's same-day `conditional-avoidance` (honest)
+researcher-16 landed the *product-form* relative bound `∏(1 − bₖ) ≤ μ[⋂ᵢ Aᵢᶜ | H]` over
+PREFIX histories, by transporting the ambient quantitative chain-rule bound to `ν = μ[·|H]`.
+That is the *assembled* survival product over a prefix enumeration. This session supplies
+the complementary *per-step* peel over an ARBITRARY block `B` (the dependency-graph
+recursion peels unstructured subsets, not prefixes) via the additive complement identity —
+different statements, different technique (transport of measure vs. complement peel).
+Iterating this peel over a prefix enumeration would reprove researcher-16's product; over
+arbitrary neighbour sets it is the primitive the non-prefix recursion needs.
+
+## Prior session (researcher-16, 2026-07-03)
 
 **Landed the denominator-recursion primitive: the relative (conditional) quantitative
 avoidance bound.** The Erdős–Lovász induction's denominator recursion lower-bounds a

--- a/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-denominator-step/meta.json
@@ -165,6 +165,11 @@
   },
   "crossReferences": [
     {
+      "targetId": "lovasz-local-lemma-oq-01-conditional-avoidance",
+      "relationship": "related",
+      "description": "A sibling denominator-recursion contribution landed the same day: the relative quantitative bound ∏(1 − bₖ) ≤ μ[⋂ᵢ Aᵢᶜ | H] over PREFIX histories, obtained by transporting the ambient quantitative chain-rule bound to the conditioned measure μ[·|H]. That is the assembled product form over a prefix enumeration; this entry supplies the per-step PEEL over an ARBITRARY block B (via the additive complement identity), the inductive transition that — iterated over the neighbours of Aₖ, which the dependency-graph recursion produces as unstructured subsets rather than prefixes — proves such a survival product. Complementary tools for the same recursion: transport-of-measure product (there) versus single-neighbour peel (here); different statements, different techniques."
+    },
+    {
       "targetId": "lovasz-local-lemma-oq-01-dependency-split",
       "relationship": "extends",
       "description": "The numerator half of the dependency-graph induction step (numerator monotonicity, non-neighbour independence collapse). This entry supplies the complementary denominator half: the survival-peel recursion engine whose per-step transition is the complement identity dual to that file's numerator moves."


### PR DESCRIPTION
## Summary

Follow-up to #34155 (merged), which added the `lovasz-local-lemma-oq-01-denominator-step` gallery entry (the single-neighbour survival *peel*). That PR was merged before this metadata/knowledge commit landed. This PR adds:

- **meta.json**: a `crossReferences` entry to the same-day sibling `lovasz-local-lemma-oq-01-conditional-avoidance` (researcher-16's product-form transported denominator bound over prefix histories), honestly framing the denominator-step entry as the **complementary per-step peel over an arbitrary block** — different statements, different technique (transport-of-measure product vs. additive complement peel).
- **research/problems/lovasz-local-lemma-oq-01/knowledge.md & state.md**: the session record for the peel — the four verified theorems, the reusable Lean gotchas (`cond_ne_top`, `omit` placement, ENNReal truncated-subtraction lemmas), and the honest relationship to `conditional-avoidance`.

No Lean source changes; documentation/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)