### PR TITLE
Strong Goldbach comet: odd-prime divisibility sieve on the offsets

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -473,4 +473,60 @@ theorem symmetricPairCount_le_half {m : ℕ} (hm : 2 < m) :
 -- two Goldbach partitions (`3 + 7`, `5 + 5`) and `⌈5/2⌉ = 3`, so `2 ≤ 3`.
 example : symmetricPairCount 5 ≤ (5 + 1) / 2 := symmetricPairCount_le_half (by norm_num)
 
+/-! ## Divisibility Sieve: Every Prime Factor of `m` Thins the Offsets
+
+The parity ceiling above is the special case `p = 2` of a general phenomenon. If a
+prime `p` divides the midpoint `m`, then any offset `k` that is *also* divisible by `p`
+kills the pair: `p ∣ (m − k)` and `p ∣ (m + k)`, so for both to be prime we'd need
+`m − k = p = m + k`, impossible once `k > 0`. Hence contributing offsets avoid the
+multiples of every prime factor of `m`. This is the arithmetic behind the **rays of the
+Goldbach comet**: a midpoint `m` divisible by many small primes has *more* admissible
+offsets removed on the composite side, yet paradoxically tends to have a *higher* comet
+count because the surviving summands `m ± k` are freed of those small factors — the
+classic reason highly composite `m` sit on the comet's dense upper rays. -/
+
+/-- **Prime-divisibility exclusion.** If a prime `p` divides `m` and also divides a
+nonzero offset `k`, then `(m − k, m + k)` is *not* a symmetric prime pair: `p` divides
+both `m − k` and `m + k`, so each — if prime — would have to equal `p`, forcing
+`m − k = m + k`, impossible for `k > 0`. Generalizes `symmetric_pair_offset_parity` (the
+`p = 2` case) to every prime factor of `m`. -/
+theorem not_symmetric_pair_of_prime_dvd {m k p : ℕ} (hp : Nat.Prime p)
+    (hpm : p ∣ m) (hk0 : 0 < k) (hpk : p ∣ k) :
+    ¬(Nat.Prime (m - k) ∧ Nat.Prime (m + k)) := by
+  rintro ⟨h1, h2⟩
+  have hd1 : p ∣ (m - k) := Nat.dvd_sub' hpm hpk
+  have hd2 : p ∣ (m + k) := Nat.dvd_add hpm hpk
+  have e1 : p = m - k := (h1.eq_one_or_self_of_dvd p hd1).resolve_left hp.ne_one
+  have e2 : p = m + k := (h2.eq_one_or_self_of_dvd p hd2).resolve_left hp.ne_one
+  omega
+
+/-- **Sieve bound on the comet count from a proper prime factor of `m`.** If a prime `p`
+divides `m` with `p < m` (so `m` is composite), then every contributing offset avoids the
+multiples of `p`, hence the comet count is at most the number of offsets `k < m` that are
+*not* divisible by `p`. For odd `p` this is an arithmetic constraint independent of the
+parity ceiling `symmetricPairCount_le_half`. -/
+theorem symmetricPairCount_le_notDvd {m p : ℕ} (hp : Nat.Prime p)
+    (hpm : p ∣ m) (hpm' : p < m) :
+    symmetricPairCount m ≤ ((Finset.range m).filter (fun k => ¬ p ∣ k)).card := by
+  rw [symmetricPairCount]
+  apply Finset.card_le_card
+  intro k hk
+  simp only [Finset.mem_filter, Finset.mem_range] at hk ⊢
+  obtain ⟨hkm, hp1, hp2⟩ := hk
+  refine ⟨hkm, ?_⟩
+  intro hpk
+  rcases Nat.eq_zero_or_pos k with hk0 | hk0
+  · -- `k = 0`: `m - 0 = m` is prime yet `p ∣ m` with `1 < p < m`, impossible.
+    subst hk0
+    simp only [Nat.sub_zero] at hp1
+    rcases hp1.eq_one_or_self_of_dvd p hpm with h | h
+    · exact hp.ne_one h
+    · omega
+  · exact not_symmetric_pair_of_prime_dvd hp hpm hk0 hpk ⟨hp1, hp2⟩
+
+-- Concrete exclusion: `m = 15 = 3·5`, offset `k = 3` (a multiple of `3 ∣ 15`) gives
+-- `(12, 18)` — neither prime — so it contributes no Goldbach partition of `30`.
+example : ¬(Nat.Prime (15 - 3) ∧ Nat.Prime (15 + 3)) :=
+  not_symmetric_pair_of_prime_dvd (p := 3) (by decide) (by decide) (by decide) (by decide)
+
 end StrongGoldbach

--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -494,8 +494,8 @@ theorem not_symmetric_pair_of_prime_dvd {m k p : ℕ} (hp : Nat.Prime p)
     (hpm : p ∣ m) (hk0 : 0 < k) (hpk : p ∣ k) :
     ¬(Nat.Prime (m - k) ∧ Nat.Prime (m + k)) := by
   rintro ⟨h1, h2⟩
-  have hd1 : p ∣ (m - k) := Nat.dvd_sub' hpm hpk
-  have hd2 : p ∣ (m + k) := Nat.dvd_add hpm hpk
+  have hd1 : p ∣ (m - k) := Nat.dvd_sub hpm hpk
+  have hd2 : p ∣ (m + k) := dvd_add hpm hpk
   have e1 : p = m - k := (h1.eq_one_or_self_of_dvd p hd1).resolve_left hp.ne_one
   have e2 : p = m + k := (h2.eq_one_or_self_of_dvd p hd2).resolve_left hp.ne_one
   omega

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -174,3 +174,25 @@ re-applying, and committing IMMEDIATELY before building. Do this from the start 
 **Remaining tractable target (unchanged):** `schnirelmann_basis_theorem` in `WeakGoldbach.lean`
 (~300–500 LOC, elementary, also a flagged Mathlib gap) is the one large discharge-an-axiom
 opportunity; the other 4 axioms are irreducible (Helfgott / circle method / Chen / binary-verified).
+
+## Session 2026-07-03 (researcher-4, 2nd pass) — Odd-prime divisibility sieve (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (same file). **Outcome**: 2 new verified theorems (PR #34159; lower-arm PR #34154 already merged).
+
+Generalized the parity ceiling (p=2 case) to every prime factor of `m`:
+
+1. **`not_symmetric_pair_of_prime_dvd`**: prime `p | m`, `p | k`, `k>0` ⟹ `(m-k, m+k)` not
+   both-prime. `p | (m±k)`, so each prime summand would equal `p`, forcing `m-k=m+k` (omega).
+   This is the arithmetic behind the Goldbach comet's *rays*.
+2. **`symmetricPairCount_le_notDvd`**: proper prime factor `p<m` ⟹ comet ≤ `#{k<m : ¬p|k}`
+   (k=0 handled: `m` composite so `m-0=m` not prime).
+
+**Mathlib gotcha (v4.26.0)**: `Nat.dvd_sub'` was RENAMED to `Nat.dvd_sub` (dropped the prime;
+same signature, no `≤` hyp). `Nat.dvd_add` also gone — use generic `dvd_add`. First build failed
+on `Unknown constant Nat.dvd_sub'`; fixed → `✔ Built (17s)`.
+
+**Env hazard (RECURRED, 2nd time this pass)**: `.loom/worktrees/researcher-4` was fully DELETED
+mid-commit (shell cwd recovered to `/Users/rwalters`). Working entirely in
+`/private/tmp/wt-researcher-4-goldbach` with commit-before-build saved all work. The deployer also
+merged PR #34154 at the knowledge-commit BEFORE my sieve commits landed, so the sieve needed a
+separate branch/PR cherry-picked onto the post-merge origin/main.


### PR DESCRIPTION
## Summary

Follow-up to #34154 (dual partition identity + reflection symmetry, now merged). Adds the **divisibility sieve** to `proofs/Proofs/StrongGoldbachSymmetric.lean` — the arithmetic explaining the Goldbach comet's *ray* structure. The existing parity ceiling `symmetricPairCount_le_half` is only the `p = 2` special case; this generalizes it to every prime factor of the midpoint `m`.

- **`not_symmetric_pair_of_prime_dvd`** — if a prime `p ∣ m` also divides a nonzero offset `k`, then `(m − k, m + k)` is **not** a symmetric prime pair: `p` divides both `m − k` and `m + k`, so each — if prime — must equal `p`, forcing `m − k = m + k` (impossible for `k > 0`). Generalizes `symmetric_pair_offset_parity`.
- **`symmetricPairCount_le_notDvd`** — for a proper prime factor `p < m` (so `m` composite), the comet count is at most `#{k < m : ¬ p ∣ k}`. For odd `p` this is an arithmetic constraint independent of the parity ceiling. This is why highly composite midpoints sit on the comet's dense upper rays: their small prime factors sieve out the composite-side offsets, leaving the surviving summands `m ± k` free of those factors.

## Verification
- Docker build: `✔ Built Proofs.StrongGoldbachSymmetric (17s)`, exit 0 (verified on this exact file content)
- 0 axioms, 0 `sorry`; example case (`m = 15`, `k = 3`) kernel-`decide`
- Does **not** touch the open conjecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)