### PR TITLE
Research: weak-goldbach-oq-01 — closed-form m−m/p ceiling on the Goldbach comet

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -529,4 +529,67 @@ theorem symmetricPairCount_le_notDvd {m p : ℕ} (hp : Nat.Prime p)
 example : ¬(Nat.Prime (15 - 3) ∧ Nat.Prime (15 + 3)) :=
   not_symmetric_pair_of_prime_dvd (p := 3) (by decide) (by decide) (by decide) (by decide)
 
+/-! ## Closing the Sieve Bound: an Explicit `m − m / p` Ceiling
+
+The divisibility sieve `symmetricPairCount_le_notDvd` bounds the comet height by the
+number of offsets `k < m` *not* divisible by a prime factor `p` of `m`.  When `p ∣ m`
+that count has a closed form: the offsets divisible by `p` are exactly
+`p · 0, p · 1, …, p · (m / p − 1)`, so there are `m / p` of them and `m − m / p` remain.
+This turns the sieve into an explicit density ceiling from any prime factor of `m`,
+
+    symmetricPairCount m ≤ m − m / p  =  (1 − 1 / p) · m,
+
+the closed-form analogue of `symmetricPairCount_le_half`.  Indeed the parity ceiling is
+the `p = 2` case: for even `m`, `m − m / 2 = m / 2 = ⌈m / 2⌉`.  A midpoint divisible by a
+*small* prime `p` has the most offsets removed (`1 / p` of them), tightening the ceiling. -/
+
+/-- **Count of multiples of `p` in `[0, m)` when `p ∣ m`.**  The offsets `k < m` divisible
+by `p` are exactly `p · 0, …, p · (m / p − 1)`, so there are `m / p` of them.  Proved by
+identifying the filtered set with the image of `range (m / p)` under `j ↦ p · j`, an
+injection since `p > 0`. -/
+theorem card_range_filter_dvd {m p : ℕ} (hp : 0 < p) (hpm : p ∣ m) :
+    ((Finset.range m).filter (fun k => p ∣ k)).card = m / p := by
+  have hm : p * (m / p) = m := Nat.mul_div_cancel' hpm
+  have hbij : (Finset.range m).filter (fun k => p ∣ k)
+      = (Finset.range (m / p)).image (fun j => p * j) := by
+    ext k
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_image]
+    constructor
+    · rintro ⟨hkm, j, rfl⟩
+      refine ⟨j, ?_, rfl⟩
+      have hlt : p * j < p * (m / p) := by rw [hm]; exact hkm
+      exact lt_of_mul_lt_mul_left hlt (Nat.zero_le p)
+    · rintro ⟨j, hj, rfl⟩
+      refine ⟨?_, dvd_mul_right p j⟩
+      calc p * j < p * (m / p) := mul_lt_mul_of_pos_left hj hp
+        _ = m := hm
+  rw [hbij, Finset.card_image_of_injective _ (mul_right_injective₀ hp.ne'),
+    Finset.card_range]
+
+/-- **Explicit `m − m / p` ceiling on the Goldbach comet height.**  For a prime `p` dividing
+the midpoint `m` with `p < m`,
+
+    symmetricPairCount m ≤ m − m / p,
+
+i.e. `2 * m` has at most `(1 − 1 / p) · m` Goldbach partitions.  This closes the sieve bound
+`symmetricPairCount_le_notDvd` to a closed form (the count of non-multiples of `p` in `[0, m)`
+being `m − m / p` by `card_range_filter_dvd`), the divisibility analogue of the parity ceiling
+`symmetricPairCount_le_half`. -/
+theorem symmetricPairCount_le_sub_div {m p : ℕ} (hp : Nat.Prime p)
+    (hpm : p ∣ m) (hpm' : p < m) :
+    symmetricPairCount m ≤ m - m / p := by
+  refine (symmetricPairCount_le_notDvd hp hpm hpm').trans ?_
+  have hsplit : ((Finset.range m).filter (fun k => p ∣ k)).card
+      + ((Finset.range m).filter (fun k => ¬ p ∣ k)).card
+      = (Finset.range m).card :=
+    Finset.filter_card_add_filter_neg_card_eq_card _
+  rw [Finset.card_range] at hsplit
+  have hcount := card_range_filter_dvd hp.pos hpm
+  omega
+
+-- Concrete ceiling: `m = 15 = 3 · 5`, `p = 3` gives `15 − 15 / 3 = 10`, and the comet
+-- height of `30` is `3` (`7+23, 11+19, 13+17`), so `3 ≤ 10`.
+example : symmetricPairCount 15 ≤ 15 - 15 / 3 :=
+  symmetricPairCount_le_sub_div (p := 3) (by decide) (by decide) (by decide)
+
 end StrongGoldbach

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -196,3 +196,35 @@ mid-commit (shell cwd recovered to `/Users/rwalters`). Working entirely in
 `/private/tmp/wt-researcher-4-goldbach` with commit-before-build saved all work. The deployer also
 merged PR #34154 at the knowledge-commit BEFORE my sieve commits landed, so the sieve needed a
 separate branch/PR cherry-picked onto the post-merge origin/main.
+
+## Session 2026-07-03 (researcher-4, 3rd pass) — Closed-form m−m/p sieve ceiling (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (same 0-axiom file `StrongGoldbachSymmetric.lean`). **Outcome**: 2 new verified theorems, build passes.
+
+The divisibility sieve `symmetricPairCount_le_notDvd` bounded the comet height by the *count of
+offsets not divisible by* a prime factor `p` of `m`, but left that count symbolic. Closed it to an
+explicit value, mirroring how `symmetricPairCount_le_half` closed the parity ceiling:
+
+1. **`card_range_filter_dvd`** (`0<p`, `p∣m` ⟹ `#{k<m : p∣k} = m/p`): the multiples of `p` in
+   `[0,m)` are exactly `p·0,…,p·(m/p−1)`. Proof identifies the filtered set with
+   `(range (m/p)).image (p·)` (a `Finset.ext` both ways using `Nat.mul_div_cancel' hpm` to turn
+   `p·j < m` into `j < m/p` via `lt_of_mul_lt_mul_left` / `mul_lt_mul_of_pos_left`), then
+   `Finset.card_image_of_injective … (mul_right_injective₀ hp.ne')` + `Finset.card_range`.
+2. **`symmetricPairCount_le_sub_div`** (prime `p∣m`, `p<m` ⟹ `symmetricPairCount m ≤ m − m/p`):
+   `trans` of the sieve bound with the closed count; the non-multiples split via
+   `Finset.filter_card_add_filter_neg_card_eq_card` + `card_range_filter_dvd`, closed by `omega`.
+
+This is the divisibility analogue of the parity ceiling: the `p=2` case gives `m − m/2 = ⌈m/2⌉`
+for even `m`, recovering `symmetricPairCount_le_half`. A small prime factor removes the most offsets
+(`1/p` of them), so `symmetricPairCount m ≤ (1 − 1/p)·m`. Example `m=15,p=3`: `15−5=10 ≥ 3`.
+
+**Verification**: `docker-build.sh Proofs.StrongGoldbachSymmetric` → `✔ Built (3058 jobs, exit 0)`.
+0 axioms, 0 sorry, kernel `decide` only (no `native_decide`). Does NOT touch the open conjecture —
+this is a density-ceiling structural fact, not a step toward proving Goldbach.
+
+**Remaining tractable target (unchanged):** `schnirelmann_basis_theorem` in `WeakGoldbach.lean`
+(~300–500 LOC, elementary, also a flagged Mathlib gap) is the one large discharge-an-axiom
+opportunity; the other 4 axioms are irreducible.
+
+**Env note.** Worked in locked `/private/tmp/wt-r4-goldbach` (dedicated branch), committed
+before building — the `.loom/worktrees/researcher-4` deletion hazard did not recur this pass.

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "OPEN (well-surveyed). Axiom-free symmetric/midpoint reformulation in gallery (PR #33936). All 5 WeakGoldbach.lean axioms irreducible in Mathlib v4.26.0; main conjecture open. Only tractable axiom = schnirelmann_basis_theorem (elementary, ~300-500 LOC dedicated session); researcher-4 added a precise Mathlib-API starter kit + missing-lemma statement + proof outline to knowledge.md so that session starts at zero ramp-up. No code this session per anti-scaffolding rule.",
+    "progressSummary": "OPEN (well-surveyed). Axiom-free symmetric/comet reformulation in gallery. Comet-height structural theory now includes: exact Goldbach-partition identities (upper/lower arm), parity ceiling ceil(m/2), full divisibility sieve, and (this pass) its CLOSED FORM symmetricPairCount m <= m - m/p from any prime factor p|m. All 5 WeakGoldbach.lean axioms irreducible in Mathlib v4.26.0; only tractable one = schnirelmann_basis_theorem (~300-500 LOC). Main conjecture untouched (all comet bounds are UPPER bounds; a nontrivial lower bound would be the real advance).",
     "builtItems": [
       "sumTwoPrimes_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:73 (per-n equivalence, 0-axiom)",
       "strong_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:98 (conjecture-level equivalence)",
@@ -39,7 +39,9 @@
       "symmetricPairCount_pos_of_prime in Proofs/StrongGoldbachSymmetric.lean (comet positive at prime midpoints)",
       "symmetricPairCount_le_primesInUpperArm in Proofs/StrongGoldbachSymmetric.lean (comet height <= primes in [m,2m), via k -> m+k injection)",
       "StrongGoldbachSymmetric.lean: FIXED symmetricPairCount_le_primesInUpperArm (Finset.mem_coe for card_le_card_of_injOn Set-membership)",
-      "StrongGoldbachSymmetric.lean: symmetricPairCount_eq_upperArm_partitions — exact comet-height = Goldbach-partition-count-of-2m identity, VERIFIED 0-axiom"
+      "StrongGoldbachSymmetric.lean: symmetricPairCount_eq_upperArm_partitions — exact comet-height = Goldbach-partition-count-of-2m identity, VERIFIED 0-axiom",
+      "card_range_filter_dvd in StrongGoldbachSymmetric.lean: #{k<m : p|k} = m/p when p|m (image-of-range bijection j->p*j)",
+      "symmetricPairCount_le_sub_div in StrongGoldbachSymmetric.lean: symmetricPairCount m <= m - m/p for prime p|m, p<m (closed form of the sieve bound symmetricPairCount_le_notDvd)"
     ],
     "insights": [
       "Strong Goldbach for even n=2m is equivalent to existence of a symmetric prime pair (m-k, m+k) with k<m — every Goldbach partition sits symmetrically about the midpoint n/2 (Goldbach comet).",
@@ -48,7 +50,8 @@
       "Prime midpoints are trivial: if m is prime then k=0 gives the diagonal Goldbach partition 2m = m + m, so Strong Goldbach holds unconditionally at every prime m and the Goldbach comet has no zero at prime abscissae.",
       "The comet height symmetricPairCount m is bounded above by the number of primes in the upper-arm interval [m, 2m) (each pair injects to its larger prime m+k), i.e. by the prime-counting increment pi(2m) - pi(m).",
       "Researcher-4 (07-03, second visit): StrongGoldbachSymmetric.lean symmetricPairCount_le_primesInUpperArm was BROKEN on origin/main — merged unbuilt. Finset.card_le_card_of_injOn (f)(MapsTo)(InjOn) yields Set-coerced membership (a ∈ ↑s), so rw [Finset.mem_filter] on it fails; fix = add Finset.mem_coe to the simp/rw. Repaired. Then proved symmetricPairCount_eq_upperArm_partitions: comet count = #{primes j in [m,2m) with 2m-j prime} EXACTLY (bijection k↦m+k with inverse j↦j-m), realizing the docstring claim comet height = Goldbach partition count of 2m, upgrading the prior ≤ bound to =.",
-      "SCHNIRELMANN STARTER KIT (researcher-4 SURVEY, no code): Mathlib v4.26.0 has the schnirelmannDensity API (mul_le_card_filter, le_schnirelmannDensity_iff counting bridges; eq_one_iff terminal step) but NOT the subadditivity theorem. Missing crux: sigma(A+B) >= sigma A + sigma B - sigma A * sigma B (elementary covering count, Nathanson Thm 7.4, ~120-180 LOC) + iteration to density>1/2 + basis-of-order-2 (~150-250 LOC). Discharges schnirelmann_basis_theorem axiom and fills Mathlib TODO. The ONLY tractable axiom in WeakGoldbach.lean; the other 4 are deep/open."
+      "SCHNIRELMANN STARTER KIT (researcher-4 SURVEY, no code): Mathlib v4.26.0 has the schnirelmannDensity API (mul_le_card_filter, le_schnirelmannDensity_iff counting bridges; eq_one_iff terminal step) but NOT the subadditivity theorem. Missing crux: sigma(A+B) >= sigma A + sigma B - sigma A * sigma B (elementary covering count, Nathanson Thm 7.4, ~120-180 LOC) + iteration to density>1/2 + basis-of-order-2 (~150-250 LOC). Discharges schnirelmann_basis_theorem axiom and fills Mathlib TODO. The ONLY tractable axiom in WeakGoldbach.lean; the other 4 are deep/open.",
+      "Closed-form density ceiling from any prime factor: for prime p|m, p<m, the Goldbach comet height satisfies symmetricPairCount m <= m - m/p = (1 - 1/p)*m. The p=2 case recovers the parity ceiling ceil(m/2) for even m."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for `weak-goldbach-oq-01` (Strong Goldbach, symmetric/comet reformulation). Extends the 0-axiom `StrongGoldbachSymmetric.lean` divisibility-sieve arc with a closed-form density ceiling.

## Progress
Two new verified theorems (no new axioms/sorries; file remains 0-axiom, kernel `decide` only):

- **`card_range_filter_dvd`** — for `0<p`, `p∣m`: `#{k<m : p∣k} = m/p`. The multiples of `p` in `[0,m)` are exactly `p·0,…,p·(m/p−1)`; proved by identifying the filtered set with `(range (m/p)).image (p·)` and counting via `Finset.card_image_of_injective`.
- **`symmetricPairCount_le_sub_div`** — for prime `p∣m` with `p<m`: `symmetricPairCount m ≤ m − m/p = (1 − 1/p)·m`.

This closes the previously-symbolic sieve bound `symmetricPairCount_le_notDvd` into an explicit value — the divisibility analogue of the parity ceiling `symmetricPairCount_le_half`, which is exactly the `p=2` case (`m − m/2 = ⌈m/2⌉` for even `m`).

## Files modified
- `proofs/Proofs/StrongGoldbachSymmetric.lean` (+2 theorems, +1 example)
- `research/problems/weak-goldbach-oq-01/knowledge.md`
- `src/data/research/problems/weak-goldbach-oq-01.json`

## Verification
`./proofs/scripts/docker-build.sh Proofs.StrongGoldbachSymmetric` → `✔ Built (3058 jobs, exit 0)`. 0 axioms, 0 sorry.

## Findings
All comet-height bounds proved to date are **upper** bounds; the open conjecture requires a nontrivial **lower** bound and is untouched. The one large tractable axiom-discharge target remains `schnirelmann_basis_theorem` in `WeakGoldbach.lean` (~300–500 LOC, also a flagged Mathlib gap); the other 4 axioms are irreducible.

## Status
**Outcome**: progress (structural theory, 0-axiom)
**Next Steps**: dedicated Schnirelmann-theorem session; investigate a nontrivial lower bound on the comet height.

🤖 Generated by researcher-4