### PR TITLE
Research: schroeder-bernstein-oq-03 (Myhill) — computable escape-depth core (Section 5·B-comp) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -2673,6 +2673,80 @@ theorem range_consStep {p q : ℕ → Prop} {f g : ℕ → ℕ}
   · exact balanced_swap_cons_range hf hg hBfg ha hb haN
   · exact balanced_cons_range hf hg hBgf ha hb haN
 
+/-!
+### Section 5·B-comp: The computable escape-depth core (`Classical.choose`-free)
+
+`stageStepB` is `noncomputable` for exactly one reason: it reads its fresh partner off the
+existential `domain_consStep`/`range_consStep` via `.choose`, and those rest on
+`escape_exists'`'s `Classical.choose`. This block removes that dependency for the domain
+(even) step.
+
+The pivot is that the escape predicate `fun N => f (fwdOrbit f g a N) ∉ mRan L` is **decidable**
+(list membership over `ℕ`), and escape is *guaranteed* (`escape_exists'`). Hence the least
+escaping depth is a genuine `Nat.find`, and — crucially — `Nat.find` is **computable even when
+its existence witness is a `noncomputable` proof**, because that witness is a `Prop` and is
+*erased* at runtime; only the decidable 0,1,2,… search actually runs. This is precisely the
+"re-parameterise to the bounded search that `escape_exists'` licenses" step the module docstring
+flags as the sole remaining gap: the concrete target `chaseTarget f g a (escapeDepth …)` is
+computable, and `domain_consStepC` supplies its `StageInvB`-preservation proof with **no**
+`Classical.choose` anywhere in the computational content. -/
+
+/-- **Computable least escape depth.** The smallest forward-orbit stage `N` at which the green
+    image `f (fwdOrbit f g a N)` escapes `mRan L`. Decidable predicate + guaranteed escape
+    (`escape_exists'`) ⇒ a genuine `Nat.find`; the existence witness `hex` is a `Prop` and is
+    erased at runtime, so this reduces by a real bounded search and is computable regardless of
+    how `hex` was proved. This is the `Classical.choose`-free core of the domain step. -/
+def escapeDepth (f g : ℕ → ℕ) (L : List (ℕ × ℕ)) (a : ℕ)
+    (hex : ∃ N, f (fwdOrbit f g a N) ∉ mRan L) : ℕ :=
+  Nat.find hex
+
+/-- The escape depth genuinely escapes: its green image lies outside `mRan L`. -/
+theorem escapeDepth_spec (f g : ℕ → ℕ) (L : List (ℕ × ℕ)) (a : ℕ)
+    (hex : ∃ N, f (fwdOrbit f g a N) ∉ mRan L) :
+    f (fwdOrbit f g a (escapeDepth f g L a hex)) ∉ mRan L :=
+  Nat.find_spec hex
+
+/-- **Minimality** of the escape depth: every earlier stage still collides (stays in `mRan L`).
+    This is the bound the scheduler uses to match the *least*-depth semantics of the classical
+    construction, so the computable rebuild yields the *same* pairing, not merely *a* pairing. -/
+theorem escapeDepth_min (f g : ℕ → ℕ) (L : List (ℕ × ℕ)) (a : ℕ)
+    (hex : ∃ N, f (fwdOrbit f g a N) ∉ mRan L) {j : ℕ}
+    (hj : j < escapeDepth f g L a hex) :
+    f (fwdOrbit f g a j) ∈ mRan L :=
+  not_not.mp (Nat.find_min hex hj)
+
+/-- The chase target at the escape depth is the concrete fresh green partner
+    (`chaseTarget` unfolds to `f ∘ fwdOrbit`), packaged for the cons step. -/
+theorem chaseTarget_escapeDepth_notMem (f g : ℕ → ℕ) (L : List (ℕ × ℕ)) (a : ℕ)
+    (hex : ∃ N, f (fwdOrbit f g a N) ∉ mRan L) :
+    chaseTarget f g a (escapeDepth f g L a hex) ∉ mRan L :=
+  escapeDepth_spec f g L a hex
+
+/-- **Choice-free domain cons step.** Prepends the concrete escaping pair
+    `(a, chaseTarget f g a (escapeDepth …))` — the least-depth green image, located by the
+    decidable `Nat.find` above rather than `Classical.choose` — and preserves all four
+    `StageInvB` invariants. This is the computable-ready twin of `domain_consStep`: same result
+    list, but the partner is a *definite computable term* instead of an `.choose` read-off, so a
+    scheduler built on it needs no `noncomputable` marker. -/
+theorem domain_consStepC {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hfpq : ∀ n, p n ↔ q (f n)) (hgpq : ∀ n, q n ↔ p (g n))
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hinv : StageInvB p q f g L)
+    {a : ℕ} (ha : a ∉ mDom L) :
+    StageInvB p q f g
+      ((a, chaseTarget f g a
+            (escapeDepth f g L a (escape_exists' hf hg hinv.2.2.1 ha))) :: L) := by
+  have hbRan :
+      chaseTarget f g a (escapeDepth f g L a (escape_exists' hf hg hinv.2.2.1 ha)) ∉ mRan L :=
+    chaseTarget_escapeDepth_notMem f g L a _
+  have hbN :
+      chaseTarget f g a (escapeDepth f g L a (escape_exists' hf hg hinv.2.2.1 ha))
+        = f (fwdOrbit f g a (escapeDepth f g L a (escape_exists' hf hg hinv.2.2.1 ha))) := rfl
+  have hstep := matching_step_chase hfpq hgpq hinv.1 hinv.2.1 ha hbRan
+  exact ⟨hstep.1, hstep.2,
+    balanced_cons_domain hf hg hinv.2.2.1 ha hbRan hbN,
+    balanced_swap_cons_domain hf hg hinv.2.2.2 ha hbRan hbN⟩
+
 /-- One stage of the extension-only scheduler, carrying `StageInvB` in a subtype. Even `s`
     targets domain element `s/2`; odd `s` targets range element `s/2`. If already covered the
     matching is returned unchanged; otherwise the matching *grows by one cons* (nothing removed). -/

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -1116,3 +1116,44 @@ lemmas in ~5–20s.
 worktree (`git worktree add --lock /tmp/lg-r11-sb -b … origin/main`); locked worktrees survive the
 cleanup daemon. All verified content was staged in `/tmp/sb_scratch.lean` (outside the reaped tree)
 so it survived the clobber. Commit+push immediately from the locked worktree.
+
+## Session 2026-07-03 (researcher-11): COMPUTABLE ESCAPE-DEPTH CORE — Section 5·B-comp [VERIFIED 0-axiom]
+
+**Advance on the sole remaining gap (computability of `sigmaEquivB`).** The Path-B scheduler's
+non-computability traces to a single choke point: `stageStepB` reads its fresh partner off the
+existential `domain_consStep`/`range_consStep` via `.choose`, and those rest on `escape_exists'`'s
+`Classical.choose`. Section 5·B-comp removes that dependency for the **domain (even) step**, all
+VERIFIED (docker build `Proofs.SchroederBernsteinOQ03`, 0 errors; only the pre-existing
+`myhill_isomorphism` sorry + two `unused variable he` warnings remain):
+
+- **`escapeDepth f g L a (hex : ∃ N, f (fwdOrbit f g a N) ∉ mRan L) : ℕ := Nat.find hex`.**
+  The KEY realisation: the escape predicate is **decidable** (list membership over `ℕ`), so this is
+  a genuine `Nat.find`. And `Nat.find` is **computable even though `hex` comes from the
+  noncomputable `escape_exists'`**, because `hex : Prop` is *erased at runtime* — only the decidable
+  0,1,2,… search runs. This is exactly the "re-parameterise to the bounded `Nat.rfind` search that
+  `escape_exists'` licenses" step the module docstring names as the last mile. No `Classical.choose`
+  survives in the *computational content*; the classical proof rides along erased.
+- **`escapeDepth_spec`** (`= Nat.find_spec`), **`escapeDepth_min`** (`not_not.mp (Nat.find_min …)`
+  — every earlier stage still collides, so the rebuild reproduces the *least*-depth pairing, not
+  merely *a* pairing), **`chaseTarget_escapeDepth_notMem`** (spec restated through `chaseTarget`,
+  which unfolds by `rfl` to `f ∘ fwdOrbit`).
+- **`domain_consStepC`** — the `Classical.choose`-free twin of `domain_consStep`. Instead of
+  `∃ b, StageInvB ((a,b)::L) ∧ …`, it returns `StageInvB ((a, chaseTarget f g a (escapeDepth …)) :: L)`
+  for the **concrete computable** partner, reusing `matching_step_chase` + `balanced_cons_domain` +
+  `balanced_swap_cons_domain` verbatim (all four `StageInvB` invariants preserved). Proof is a
+  4-tuple assembly; the `escapeDepth` existence arg is threaded via `hinv.2.2.1` (proof-irrelevant).
+
+**NEXT (unchanged plan, one cell filled):** (1-range) `range_consStepC` — the `Prod.swap` mirror
+using `escape_exists' hg hf hinv.2.2.2 hb'` and `escapeDepth g f (L.map Prod.swap) b` (the swapped
+problem); `a := chaseTarget g f b (escapeDepth …)`, `a ∉ mDom L` via `← mRan_map_swap`. Then (2)
+build the computable `stageStepBComp`/`stageSeqBComp` on `domain_consStepC`/`range_consStepC` (plain
+`if s%2=0 then if h: s/2 ∈ mDom … else ⟨(s/2, chaseTarget …) :: prev, domain_consStepC …⟩ …` — no
+`noncomputable` needed) and prove it `Computable` via `mLookup_computable` + `chaseTarget_computable`
++ `fwdOrbit_computable`; (3) discharge `myhill_isomorphism`. Do NOT re-open the Path-B fork.
+
+**Process note:** my Read/Edit/docker-build accidentally targeted the **main-repo absolute path**
+(`/Users/rwalters/GitHub/lean-genius/proofs/…`) not the worktree; a concurrent **deployer** agent
+checked out `chore/sync-data-…` on the main repo and clobbered the uncommitted edit AFTER the build
+passed. Verified-correct content was re-applied byte-identically in a fresh `/tmp` worktree off
+`origin/main` and committed there. Lesson: always edit inside your OWN worktree path, never the
+shared main-repo checkout.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -13,9 +13,17 @@ Section 5·B now builds the cons scheduler `stageSeqB` (pair-monotone) and reads
 0-axiom. The bijection + correspondence (the *mathematics* of Myhill's hard direction) are DONE.
 The **sole** remaining gap is `e.Computable`: `stageSeqB` is `noncomputable` (`Classical.choose`).
 Residual work (no new math, ~150–250 lines): (1) replace the escape `.choose N` with the bounded
-`Nat.rfind` search licensed by `escape_exists'` (`N ≤ (mRan L).length`); (2) build a computable
-parallel `stageSeqBComp` (explicit cons recursion) and prove `Computable (fun n => mLookup
-(stageSeqBComp (entryStageDomB n)) n)` via `mLookup_computable` + `chaseTarget_computable`;
+`Nat.rfind` search licensed by `escape_exists'` (`N ≤ (mRan L).length`) — **DOMAIN SIDE DONE
+2026-07-03 (r11), VERIFIED 0-axiom** (Section 5·B-comp): `escapeDepth` (computable `Nat.find`; the
+existence witness is a `Prop`, erased at runtime, so it reduces by a *real* bounded search even
+though `escape_exists'` is noncomputable) + `escapeDepth_spec` / `escapeDepth_min` /
+`chaseTarget_escapeDepth_notMem` + `domain_consStepC` (the `Classical.choose`-free twin of
+`domain_consStep`, returning the concrete computable partner `chaseTarget f g a (escapeDepth …)`
+with `StageInvB` preserved). NEXT within (1): the range dual `range_consStepC` (`Prod.swap`
+mirror on `escape_exists' hg hf`, with `escapeDepth g f (L.map swap) b`); (2) build a computable
+parallel `stageSeqBComp` (explicit cons recursion using `domain_consStepC` / `range_consStepC`)
+and prove `Computable (fun n => mLookup (stageSeqBComp (entryStageDomB n)) n)` via
+`mLookup_computable` + `chaseTarget_computable`;
 (3) the inverse is the range-side `mLookup` on the swapped list — discharge `myhill_isomorphism`.
 See knowledge.md r11 entry. Do NOT re-open the Path-B fork or the splicing `stageSeq`.
 

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 2980,
+    "lineCount": 3054,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -60,8 +60,8 @@
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 152,
-    "definitionCount": 31,
+    "theoremCount": 156,
+    "definitionCount": 32,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
     ]
@@ -250,10 +250,10 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 2980,
+    "lineCount": 3054,
     "axiomCount": 0,
-    "theoremCount": 152,
-    "definitionCount": 31,
+    "theoremCount": 156,
+    "definitionCount": 32,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Attacks the **sole remaining gap** in the hard direction of Myhill's isomorphism theorem: the *computability* of the Path-B limit bijection `sigmaEquivB`. The scheduler `stageStepB` is `noncomputable` for one reason only — it reads its fresh partner off an existential (`domain_consStep`/`range_consStep`) via `.choose`, which rests on `escape_exists'`'s `Classical.choose`. This PR removes that dependency for the **domain (even) step**.

## The key idea

The escape predicate `fun N => f (fwdOrbit f g a N) ∉ mRan L` is **decidable** (list membership over `ℕ`). So the least escaping depth is a genuine `Nat.find` — and `Nat.find` is **computable even though its existence witness comes from the noncomputable `escape_exists'`**, because that witness is a `Prop`, *erased at runtime*; only the decidable `0,1,2,…` search actually runs. This is exactly the "re-parameterise to the bounded search `escape_exists'` licenses" step the module docstring names as the last mile.

## New declarations (Section 5·B-comp, all VERIFIED 0-axiom)

- **`escapeDepth`** `:= Nat.find hex` — the computable least escaping forward-orbit stage.
- **`escapeDepth_spec`** / **`escapeDepth_min`** / **`chaseTarget_escapeDepth_notMem`** — escape guarantee, least-depth minimality (so the rebuild reproduces the *same* pairing), and the `chaseTarget` restatement.
- **`domain_consStepC`** — the `Classical.choose`-free twin of `domain_consStep`: returns `StageInvB p q f g ((a, chaseTarget f g a (escapeDepth …)) :: L)` for the **concrete computable** partner, reusing `matching_step_chase` + `balanced_cons_domain` + `balanced_swap_cons_domain` (all four `StageInvB` invariants preserved).

## Verification

`./proofs/scripts/docker-build.sh Proofs.SchroederBernsteinOQ03` — **build succeeded (3065 jobs, 0 errors)**. The only remaining `sorry` is the pre-existing `myhill_isomorphism` gap; the five new declarations are 0-axiom (`propext`/`Classical.choice`/`Quot.sound` only, no `sorryAx`/`ofReduceBool`).

## Next steps (recorded in state.md / knowledge.md)

1. Range dual `range_consStepC` (`Prod.swap` mirror on `escape_exists' hg hf`, `escapeDepth g f (L.map swap) b`).
2. Computable `stageSeqBComp` on `domain_consStepC`/`range_consStepC` (no `noncomputable` marker), proven `Computable` via `mLookup_computable` + `chaseTarget_computable` + `fwdOrbit_computable`.
3. Discharge `myhill_isomorphism`.

meta.json counts synced (2980→3054 lines, 152→156 thms, 31→32 defs); `axiomCount` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)