### PR TITLE
research: Hyperbolic Ptolemy theorem in the Poincaré disk (synthesis-curvature-ptolemy-oq-02)

### DIFF
--- a/proofs/Proofs/SynthesisCurvaturePtolemyOQ02.lean
+++ b/proofs/Proofs/SynthesisCurvaturePtolemyOQ02.lean
@@ -1,0 +1,306 @@
+import Proofs.PtolemysComplexProof
+import Mathlib.Analysis.SpecialFunctions.Arsinh
+import Mathlib.Tactic
+
+/-!
+# Hyperbolic Ptolemy Theorem in the Poincaré Disk (K = -1)  —  OQ-02
+
+The synthesis file `SynthesisCurvaturePtolemy.lean` unifies the Euclidean
+(K = 0) and spherical (K > 0) Ptolemy theorems through its `curvatureSin K`
+function, and leaves the **hyperbolic case** (K = -1) as a *conjecture*, with the
+remark that a full treatment "requires the Poincaré disk metric as a metric
+space (~800-1200 lines), currently blocked in Mathlib".
+
+This file discharges that conjecture as a **fully verified theorem** (no
+`sorry`, no `axiom`, no structure-encoded assumption). The observation is that
+the heavy metric-space infrastructure is *not needed* for the Ptolemy relation
+itself. Everything reduces to the Euclidean `ptolemy_inequality` already proved
+in `PtolemysComplexProof.lean`.
+
+## The conformal chord
+
+Define the **conformal chord** of the Poincaré disk `D = {z : ℂ | ‖z‖ < 1}`:
+
+  `poincareChord z w = ‖z - w‖ / √((1 - ‖z‖²)(1 - ‖w‖²))`.
+
+The standard hyperbolic-geometry identity is `poincareChord z w = sinh(d_H/2)`,
+where `d_H` is the K = -1 geodesic distance. In the notation of the parent file,
+`sinh = curvatureSin (-1)`, so `poincareChord z w = curvatureSin (-1) (d_H/2)`.
+
+## Why the metric machinery is unnecessary
+
+For four points in `D`, every product `poincareChord zᵢ zⱼ · poincareChord zₖ zₗ`
+in the Ptolemy relation carries the **same** denominator
+
+  `√((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²))`,
+
+because the indices `{i,j,k,l}` are always a permutation of `{1,2,3,4}`. Clearing
+that common (strictly positive) denominator turns the hyperbolic Ptolemy
+inequality/equality **directly** into the Euclidean one. This "conformal-factor
+cancellation" is the entire content of the hyperbolic case — no Poincaré metric
+space, Möbius isometries, or hyperbolic-circle theory are required.
+
+## The distance and the sinh bridge
+
+We take the **standard closed form** of the Poincaré disk metric as the
+definition of the distance:
+
+  `poincareDist z w = 2 · arsinh( poincareChord z w )`
+
+(equivalently `arcosh(1 + 2 s²)` with `s = poincareChord z w`, using the identity
+`arcosh(1 + 2 s²) = 2 · arsinh s`). This is the textbook disk metric. With it,
+the bridge identity
+
+  `sinh(poincareDist z w / 2) = sinh(arsinh s) = s = poincareChord z w`
+
+is one line (`Real.sinh_arsinh`), letting us restate the theorems in the exact
+`sinh(d_H/2)` form of the parent's conjecture.
+
+## Honesty note
+
+- The reduction to the Euclidean Ptolemy theorem is **unconditional and fully
+  machine-checked** (`verified`, 0 sorries / 0 axioms).
+- `poincareDist` is *defined* by the standard closed form of the disk metric; we
+  do **not** re-derive that this closed form is a genuine metric (triangle
+  inequality, Möbius-invariance). No such fact is assumed anywhere below — the
+  proofs use only algebra and the Euclidean Ptolemy inequality.
+- We phrase the final statements with `Real.sinh` rather than importing the
+  parent's `curvatureSin` (which currently sits behind an unrelated
+  Mathlib-notation breakage in a sibling file). Since `curvatureSin (-1) = sinh`
+  by the parent's `curvatureSin_neg_one`, the statements are identical.
+
+## Results
+
+1. `poincareChord`               — the conformal chord `s(z,w) = sinh(d_H/2)`.
+2. `poincareChord_comm`          — symmetry `s(z,w) = s(w,z)`.
+3. `hyperbolic_ptolemy_inequality`
+                                 — Ptolemy inequality for `s` on four disk points.
+4. `hyperbolic_ptolemy_equality` — Ptolemy equality under the proportionality
+                                   (concyclicity) condition.
+5. `poincareDist` / `sinh_poincareDist_half`
+                                 — the disk metric and the `sinh(d_H/2) = s` bridge.
+6. `hyperbolic_ptolemy_inequality_sinh` / `hyperbolic_ptolemy_equality_sinh`
+                                 — the conjectured statements in `sinh(d_H/2)` form,
+                                   discharged.
+-/
+
+set_option linter.unusedVariables false
+
+-- ============================================================
+-- PART 1: The conformal chord function of the Poincaré disk
+-- ============================================================
+
+/-- The **conformal chord** of the Poincaré disk model:
+
+  `poincareChord z w = ‖z - w‖ / √((1 - ‖z‖²)(1 - ‖w‖²))`.
+
+For `z, w` in the open unit disk this equals `sinh(d_H(z,w) / 2)`, where `d_H` is
+the hyperbolic (K = -1) geodesic distance. It is the building block of the
+hyperbolic Ptolemy relation. -/
+noncomputable def poincareChord (z w : ℂ) : ℝ :=
+  ‖z - w‖ / Real.sqrt ((1 - ‖z‖ ^ 2) * (1 - ‖w‖ ^ 2))
+
+/-- Inside the open unit disk the conformal factor `1 - ‖z‖²` is strictly
+positive. -/
+lemma one_sub_normSq_pos {z : ℂ} (hz : ‖z‖ < 1) : 0 < 1 - ‖z‖ ^ 2 := by
+  nlinarith [norm_nonneg z, hz]
+
+/-- Split the single square root in `poincareChord` into a product of two square
+roots (valid because each conformal factor is nonnegative). -/
+lemma poincareChord_eq_div_mul {z w : ℂ} (hz : ‖z‖ < 1) (hw : ‖w‖ < 1) :
+    poincareChord z w =
+      ‖z - w‖ / (Real.sqrt (1 - ‖z‖ ^ 2) * Real.sqrt (1 - ‖w‖ ^ 2)) := by
+  rw [poincareChord, Real.sqrt_mul (one_sub_normSq_pos hz).le]
+
+/-- The conformal chord is symmetric: `poincareChord z w = poincareChord w z`. -/
+lemma poincareChord_comm (z w : ℂ) : poincareChord z w = poincareChord w z := by
+  unfold poincareChord
+  rw [norm_sub_rev, mul_comm (1 - ‖z‖ ^ 2) (1 - ‖w‖ ^ 2)]
+
+-- ============================================================
+-- PART 2: Hyperbolic Ptolemy inequality (all four disk points)
+-- ============================================================
+
+/-- **Hyperbolic Ptolemy Inequality** in the Poincaré disk.
+
+For any four points `z₁, z₂, z₃, z₄` in the open unit disk,
+
+  `s(z₁,z₃)·s(z₂,z₄) ≤ s(z₁,z₂)·s(z₃,z₄) + s(z₂,z₃)·s(z₁,z₄)`,
+
+where `s = poincareChord = sinh(d_H/2)`. No concyclicity hypothesis is needed.
+
+**Proof.** Each product `s(zᵢ,zⱼ)·s(zₖ,zₗ)` equals
+`‖zᵢ-zⱼ‖·‖zₖ-zₗ‖ / √∏ₘ(1-‖zₘ‖²)` — the denominator is the *same* for all three
+products because `{i,j,k,l} = {1,2,3,4}`. Dividing the Euclidean
+`ptolemy_inequality` by this common positive denominator gives the claim. -/
+theorem hyperbolic_ptolemy_inequality (z₁ z₂ z₃ z₄ : ℂ)
+    (h1 : ‖z₁‖ < 1) (h2 : ‖z₂‖ < 1) (h3 : ‖z₃‖ < 1) (h4 : ‖z₄‖ < 1) :
+    poincareChord z₁ z₃ * poincareChord z₂ z₄ ≤
+    poincareChord z₁ z₂ * poincareChord z₃ z₄ +
+    poincareChord z₂ z₃ * poincareChord z₁ z₄ := by
+  have n1 : Real.sqrt (1 - ‖z₁‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h1))
+  have n2 : Real.sqrt (1 - ‖z₂‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h2))
+  have n3 : Real.sqrt (1 - ‖z₃‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h3))
+  have n4 : Real.sqrt (1 - ‖z₄‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h4))
+  -- Express each opposite/diagonal product over the common denominator.
+  have e13_24 : poincareChord z₁ z₃ * poincareChord z₂ z₄ =
+      ‖z₁ - z₃‖ * ‖z₂ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h1 h3, poincareChord_eq_div_mul h2 h4]
+    field_simp
+    ring
+  have e12_34 : poincareChord z₁ z₂ * poincareChord z₃ z₄ =
+      ‖z₁ - z₂‖ * ‖z₃ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h1 h2, poincareChord_eq_div_mul h3 h4]
+    field_simp
+    ring
+  have e23_14 : poincareChord z₂ z₃ * poincareChord z₁ z₄ =
+      ‖z₂ - z₃‖ * ‖z₁ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h2 h3, poincareChord_eq_div_mul h1 h4]
+    field_simp
+    ring
+  rw [e13_24, e12_34, e23_14, div_add_div_same]
+  gcongr
+  exact ptolemy_inequality z₁ z₂ z₃ z₄
+
+-- ============================================================
+-- PART 3: Hyperbolic Ptolemy equality (concyclic condition)
+-- ============================================================
+
+/-- **Hyperbolic Ptolemy Equality** in the Poincaré disk.
+
+If the opposite-side products of the four disk points are positively
+proportional in `ℂ` — the algebraic form of concyclicity in cyclic order,
+`(z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)` with `t ≥ 0` — then the hyperbolic Ptolemy
+inequality is an **equality**:
+
+  `s(z₁,z₃)·s(z₂,z₄) = s(z₁,z₂)·s(z₃,z₄) + s(z₂,z₃)·s(z₁,z₄)`.
+
+Same common-denominator reduction, now to `ptolemy_equality_of_proportional`. -/
+theorem hyperbolic_ptolemy_equality (z₁ z₂ z₃ z₄ : ℂ)
+    (h1 : ‖z₁‖ < 1) (h2 : ‖z₂‖ < 1) (h3 : ‖z₃‖ < 1) (h4 : ‖z₄‖ < 1)
+    (t : ℝ) (ht : 0 ≤ t)
+    (hprop : (z₂ - z₃) * (z₁ - z₄) = (t : ℂ) * ((z₁ - z₂) * (z₃ - z₄))) :
+    poincareChord z₁ z₃ * poincareChord z₂ z₄ =
+    poincareChord z₁ z₂ * poincareChord z₃ z₄ +
+    poincareChord z₂ z₃ * poincareChord z₁ z₄ := by
+  have n1 : Real.sqrt (1 - ‖z₁‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h1))
+  have n2 : Real.sqrt (1 - ‖z₂‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h2))
+  have n3 : Real.sqrt (1 - ‖z₃‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h3))
+  have n4 : Real.sqrt (1 - ‖z₄‖ ^ 2) ≠ 0 :=
+    ne_of_gt (Real.sqrt_pos.mpr (one_sub_normSq_pos h4))
+  have e13_24 : poincareChord z₁ z₃ * poincareChord z₂ z₄ =
+      ‖z₁ - z₃‖ * ‖z₂ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h1 h3, poincareChord_eq_div_mul h2 h4]
+    field_simp
+    ring
+  have e12_34 : poincareChord z₁ z₂ * poincareChord z₃ z₄ =
+      ‖z₁ - z₂‖ * ‖z₃ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h1 h2, poincareChord_eq_div_mul h3 h4]
+    field_simp
+    ring
+  have e23_14 : poincareChord z₂ z₃ * poincareChord z₁ z₄ =
+      ‖z₂ - z₃‖ * ‖z₁ - z₄‖ /
+        (Real.sqrt (1 - ‖z₁‖ ^ 2) * Real.sqrt (1 - ‖z₂‖ ^ 2) *
+         Real.sqrt (1 - ‖z₃‖ ^ 2) * Real.sqrt (1 - ‖z₄‖ ^ 2)) := by
+    rw [poincareChord_eq_div_mul h2 h3, poincareChord_eq_div_mul h1 h4]
+    field_simp
+    ring
+  rw [e13_24, e12_34, e23_14, div_add_div_same,
+      ptolemy_equality_of_proportional z₁ z₂ z₃ z₄ t ht hprop]
+
+-- ============================================================
+-- PART 4: The Poincaré metric and the sinh(d_H/2) bridge
+-- ============================================================
+
+/-- The **Poincaré disk distance** in closed form:
+
+  `poincareDist z w = 2 · arsinh( poincareChord z w )`.
+
+This is the standard closed form of the K = -1 hyperbolic metric (equivalently
+`arcosh(1 + 2 s²)` with `s = poincareChord z w`). We take it as the definition;
+no metric-space axioms are used below. -/
+noncomputable def poincareDist (z w : ℂ) : ℝ :=
+  2 * Real.arsinh (poincareChord z w)
+
+/-- **Bridge identity**: the hyperbolic sine of the half-distance is exactly the
+conformal chord, i.e. `sinh(d_H(z,w)/2) = poincareChord z w`.
+
+In the parent's notation `curvatureSin (-1) = sinh`, so this reads
+`curvatureSin (-1) (d_H/2) = poincareChord z w`. It is immediate from
+`sinh (arsinh x) = x`. -/
+lemma sinh_poincareDist_half (z w : ℂ) :
+    Real.sinh (poincareDist z w / 2) = poincareChord z w := by
+  have h : poincareDist z w / 2 = Real.arsinh (poincareChord z w) := by
+    rw [poincareDist]; ring
+  rw [h, Real.sinh_arsinh]
+
+-- ============================================================
+-- PART 5: The conjectured statements, in sinh(d_H/2) form
+-- ============================================================
+
+/-- **Hyperbolic Ptolemy Inequality — `sinh(d_H/2)` form** (the parent's
+conjectured statement, now discharged).
+
+For four points in the open Poincaré disk, with hyperbolic distance `d_H`:
+
+  `sinh(d_H(z₁,z₃)/2) · sinh(d_H(z₂,z₄)/2)`
+  `≤ sinh(d_H(z₁,z₂)/2) · sinh(d_H(z₃,z₄)/2)`
+  `  + sinh(d_H(z₁,z₄)/2) · sinh(d_H(z₂,z₃)/2)`.
+
+Since `curvatureSin (-1) = sinh`, this is exactly the parent's conjectured
+hyperbolic Ptolemy inequality. Via the bridge identity it is
+`hyperbolic_ptolemy_inequality`. -/
+theorem hyperbolic_ptolemy_inequality_sinh (z₁ z₂ z₃ z₄ : ℂ)
+    (h1 : ‖z₁‖ < 1) (h2 : ‖z₂‖ < 1) (h3 : ‖z₃‖ < 1) (h4 : ‖z₄‖ < 1) :
+    Real.sinh (poincareDist z₁ z₃ / 2) * Real.sinh (poincareDist z₂ z₄ / 2) ≤
+    Real.sinh (poincareDist z₁ z₂ / 2) * Real.sinh (poincareDist z₃ z₄ / 2) +
+    Real.sinh (poincareDist z₁ z₄ / 2) * Real.sinh (poincareDist z₂ z₃ / 2) := by
+  simp only [sinh_poincareDist_half]
+  have key := hyperbolic_ptolemy_inequality z₁ z₂ z₃ z₄ h1 h2 h3 h4
+  rw [mul_comm (poincareChord z₁ z₄) (poincareChord z₂ z₃)]
+  exact key
+
+/-- **Hyperbolic Ptolemy Equality — `sinh(d_H/2)` form** (the parent's
+conjectured statement under the concyclicity/proportionality condition).
+
+Via the bridge identity this is `hyperbolic_ptolemy_equality`. -/
+theorem hyperbolic_ptolemy_equality_sinh (z₁ z₂ z₃ z₄ : ℂ)
+    (h1 : ‖z₁‖ < 1) (h2 : ‖z₂‖ < 1) (h3 : ‖z₃‖ < 1) (h4 : ‖z₄‖ < 1)
+    (t : ℝ) (ht : 0 ≤ t)
+    (hprop : (z₂ - z₃) * (z₁ - z₄) = (t : ℂ) * ((z₁ - z₂) * (z₃ - z₄))) :
+    Real.sinh (poincareDist z₁ z₃ / 2) * Real.sinh (poincareDist z₂ z₄ / 2) =
+    Real.sinh (poincareDist z₁ z₂ / 2) * Real.sinh (poincareDist z₃ z₄ / 2) +
+    Real.sinh (poincareDist z₁ z₄ / 2) * Real.sinh (poincareDist z₂ z₃ / 2) := by
+  simp only [sinh_poincareDist_half]
+  have key := hyperbolic_ptolemy_equality z₁ z₂ z₃ z₄ h1 h2 h3 h4 t ht hprop
+  rw [key]; ring
+
+-- ============================================================
+-- Summary
+-- ============================================================
+
+#check @poincareChord
+#check @poincareChord_comm
+#check @hyperbolic_ptolemy_inequality
+#check @hyperbolic_ptolemy_equality
+#check @poincareDist
+#check @sinh_poincareDist_half
+#check @hyperbolic_ptolemy_inequality_sinh
+#check @hyperbolic_ptolemy_equality_sinh

--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-02/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-02/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-scp-oq02-overview",
+    "proofId": "synthesis-curvature-ptolemy-oq-02",
+    "range": {
+      "startLine": 7,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "Overview: Hyperbolic Ptolemy via Conformal-Factor Cancellation",
+    "content": "The parent synthesis entry unifies the spherical (K>0) and Euclidean (K=0) Ptolemy theorems through curvatureSin K, and leaves the hyperbolic (K=-1) case as a CONJECTURE, estimating that a Poincaré-disk metric-space development of ~800–1200 lines (blocked in Mathlib) would be needed. This entry discharges the conjecture as a fully verified theorem. The mechanism is a change of variables: the hyperbolic half-distance sinh(d_H(z,w)/2) equals the conformal chord s(z,w) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)). In the Ptolemy relation each product s(zᵢ,zⱼ)·s(zₖ,zₗ) then carries the SAME denominator √((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²)), because the pair {i,j} and its complement {k,l} partition {1,2,3,4}. Cancelling that single positive factor turns the hyperbolic relation into the Euclidean ptolemy_inequality (for the inequality) and ptolemy_equality_of_proportional (for the equality). Taking the disk metric in its closed form d_H = 2·arsinh(s), the bridge sinh(d_H/2) = s is one line (Real.sinh_arsinh), so the results are stated in the exact sinh(d_H/2) = curvatureSin (-1) (d_H/2) form of the conjecture. 0 sorry, 0 axiom.",
+    "mathContext": "In the Poincaré disk the hyperbolic distance satisfies $\\sinh\\!\\big(\\tfrac12 d_H(z,w)\\big) = \\dfrac{|z-w|}{\\sqrt{(1-|z|^2)(1-|w|^2)}}$. Substituting this into the Ptolemy relation, the product over all four conformal factors $\\prod_i (1-|z_i|^2)$ divides out of every term, reducing the hyperbolic identity to the Euclidean chord identity $|z_1-z_3||z_2-z_4| \\le |z_1-z_2||z_3-z_4| + |z_2-z_3||z_1-z_4|$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "hyperbolic geometry",
+      "Poincaré disk model",
+      "Ptolemy's theorem",
+      "conformal factor",
+      "constant curvature geometry"
+    ],
+    "prerequisites": [
+      "Euclidean Ptolemy inequality",
+      "Poincaré disk model and hyperbolic distance",
+      "hyperbolic trigonometry (sinh, arsinh)"
+    ]
+  },
+  {
+    "id": "ann-scp-oq02-chord",
+    "proofId": "synthesis-curvature-ptolemy-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 119
+    },
+    "type": "concept",
+    "title": "The Conformal Chord of the Poincaré Disk",
+    "content": "`poincareChord z w = ‖z-w‖ / √((1-‖z‖²)(1-‖w‖²))` is the building block of the hyperbolic Ptolemy relation; for points in the open disk it equals `sinh(d_H(z,w)/2)`. Three supporting facts are established: `one_sub_normSq_pos` (the conformal factor `1-‖z‖²` is strictly positive on the open disk), `poincareChord_eq_div_mul` (the single root splits as `√(1-‖z‖²)·√(1-‖w‖²)` via `Real.sqrt_mul`, exposing the per-point factors that later cancel), and `poincareChord_comm` (symmetry, from `‖z-w‖ = ‖w-z‖` and commutativity of the conformal factors).",
+    "mathContext": "The factor $1-|z|^2$ is (up to the conformal density $2/(1-|z|^2)$) the local scale of the Poincaré metric at $z$. It is positive exactly on the open disk $|z|<1$, which is what makes the common denominator $\\sqrt{\\prod_i(1-|z_i|^2)}$ nonzero and hence cancellable in the Ptolemy reduction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "conformal factor",
+      "Poincaré metric",
+      "square-root identities",
+      "hyperbolic distance"
+    ],
+    "prerequisites": [
+      "complex modulus / norm",
+      "properties of Real.sqrt"
+    ]
+  },
+  {
+    "id": "ann-scp-oq02-inequality",
+    "proofId": "synthesis-curvature-ptolemy-oq-02",
+    "range": {
+      "startLine": 120,
+      "endLine": 171
+    },
+    "type": "proof-technique",
+    "title": "Hyperbolic Ptolemy Inequality by Common-Denominator Reduction",
+    "content": "`hyperbolic_ptolemy_inequality`: for ANY four points in the open disk (no concyclicity), `s(z₁,z₃)·s(z₂,z₄) ≤ s(z₁,z₂)·s(z₃,z₄) + s(z₂,z₃)·s(z₁,z₄)`. The proof rewrites each of the three products over the common denominator `√((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²))` using `field_simp`, combines the two right-hand fractions with `← add_div`, and then divides the Euclidean `ptolemy_inequality` by the common positive denominator using `gcongr`. No hyperbolic-metric machinery is invoked.",
+    "mathContext": "Writing $s(z_i,z_j) = |z_i-z_j|/(a_i a_j)$ with $a_k = \\sqrt{1-|z_k|^2}>0$, each product $s(z_i,z_j)s(z_k,z_l) = |z_i-z_j||z_k-z_l|/(a_1a_2a_3a_4)$ because $\\{i,j,k,l\\}=\\{1,2,3,4\\}$. So the inequality is the Euclidean one scaled by the single positive constant $1/(a_1a_2a_3a_4)$, valid unconditionally.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Ptolemy inequality",
+      "common denominator",
+      "monotonicity of division (gcongr)",
+      "hyperbolic geometry"
+    ],
+    "prerequisites": [
+      "Euclidean Ptolemy inequality (ptolemy_inequality)",
+      "field_simp and gcongr tactics"
+    ]
+  },
+  {
+    "id": "ann-scp-oq02-equality",
+    "proofId": "synthesis-curvature-ptolemy-oq-02",
+    "range": {
+      "startLine": 172,
+      "endLine": 221
+    },
+    "type": "proof-technique",
+    "title": "Hyperbolic Ptolemy Equality under the Concyclicity Condition",
+    "content": "`hyperbolic_ptolemy_equality`: when the opposite-side products are positively proportional in ℂ — `(z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄)` with `t ≥ 0`, the algebraic form of concyclicity in cyclic order — the hyperbolic inequality is an equality. Identical common-denominator reduction, closing with the Euclidean `ptolemy_equality_of_proportional` instead of the inequality.",
+    "mathContext": "Ptolemy equality holds exactly on the concyclicity locus, captured algebraically by the cross-ratio being real and nonnegative, i.e. the opposite-side products being positively proportional. Since the conformal denominators cancel identically, the Euclidean equality lifts verbatim to the hyperbolic chords.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Ptolemy equality",
+      "concyclicity",
+      "cross-ratio",
+      "hyperbolic circles"
+    ],
+    "prerequisites": [
+      "ptolemy_equality_of_proportional",
+      "cross-ratio and concyclicity"
+    ]
+  },
+  {
+    "id": "ann-scp-oq02-bridge",
+    "proofId": "synthesis-curvature-ptolemy-oq-02",
+    "range": {
+      "startLine": 222,
+      "endLine": 300
+    },
+    "type": "concept",
+    "title": "The Disk Metric, the sinh(d_H/2) Bridge, and the Discharged Conjecture",
+    "content": "`poincareDist z w = 2·arsinh(poincareChord z w)` is the standard closed form of the K=-1 disk metric (equivalently `arcosh(1+2s²)`, via `arcosh(1+2s²) = 2·arsinh s`). The bridge `sinh_poincareDist_half` gives `sinh(poincareDist z w / 2) = poincareChord z w` in one line from `Real.sinh_arsinh`. Rewriting through it, `hyperbolic_ptolemy_inequality_sinh` and `hyperbolic_ptolemy_equality_sinh` state the results in the exact `sinh(d_H/2)` form of the parent's conjecture; since `curvatureSin (-1) = sinh`, these ARE the parent's conjectured hyperbolic Ptolemy relation. The metric is taken by its closed form as a DEFINITION — the file does not (and need not) re-derive that it satisfies the metric axioms.",
+    "mathContext": "$d_H(z,w) = \\operatorname{arcosh}\\!\\big(1 + \\tfrac{2|z-w|^2}{(1-|z|^2)(1-|w|^2)}\\big) = 2\\operatorname{arsinh}(s)$ since $\\cosh(2\\operatorname{arsinh} s) = 1 + 2\\sinh^2(\\operatorname{arsinh} s) = 1 + 2s^2$. Then $\\sinh(d_H/2) = \\sinh(\\operatorname{arsinh} s) = s$, so the conjectured $\\sinh(d_H/2)$ statements collapse onto the proved chord relations.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Poincaré disk metric",
+      "hyperbolic distance closed form",
+      "arsinh / arcosh identities",
+      "curvatureSin (-1) = sinh"
+    ],
+    "prerequisites": [
+      "arsinh and its inverse identity Real.sinh_arsinh",
+      "closed form of the Poincaré metric"
+    ]
+  }
+]

--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "synthesis-curvature-ptolemy-oq-02",
+  "title": "Hyperbolic Ptolemy Theorem in the Poincaré Disk via Conformal-Factor Cancellation",
+  "slug": "synthesis-curvature-ptolemy-oq-02",
+  "description": "Discharges the hyperbolic (K=-1) Ptolemy conjecture left open by the parent synthesis entry, as a fully verified theorem (0 sorries, 0 axioms). Written through the conformal chord s(z,w) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) = sinh(d_H(z,w)/2), every product s(zᵢ,zⱼ)·s(zₖ,zₗ) in the Ptolemy relation carries the SAME denominator √∏(1-‖zᵢ‖²) — because {i,j,k,l} is always a permutation of {1,2,3,4}. Clearing that common positive denominator reduces both the hyperbolic Ptolemy inequality (all four disk points) and the equality (concyclic case) DIRECTLY to the Euclidean ptolemy_inequality / ptolemy_equality_of_proportional. The ~800–1200 lines of Poincaré metric-space infrastructure the parent flagged as blocking are shown to be unnecessary for the Ptolemy relation itself. Taking the standard closed-form disk metric d_H = 2·arsinh(s) as the definition, the sinh(d_H/2) = s bridge is one line (Real.sinh_arsinh), so the theorems are stated in the exact sinh(d_H/2) form of the conjecture (equivalently curvatureSin (-1) (d_H/2), since curvatureSin (-1) = sinh).",
+  "meta": {
+    "author": "Lean Genius Researcher (2026)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Ptolemy%27s_theorem",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SynthesisCurvaturePtolemyOQ02.lean",
+    "tags": [
+      "geometry",
+      "hyperbolic-geometry",
+      "ptolemy",
+      "poincare-disk",
+      "curvature",
+      "trigonometry",
+      "conformal-geometry",
+      "synthesis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ptolemy_inequality",
+        "description": "Complex Ptolemy inequality ‖z₁-z₃‖·‖z₂-z₄‖ ≤ ‖z₁-z₂‖·‖z₃-z₄‖ + ‖z₂-z₃‖·‖z₁-z₄‖ for any z_i ∈ ℂ",
+        "module": "Proofs.PtolemysComplexProof"
+      },
+      {
+        "theorem": "ptolemy_equality_of_proportional",
+        "description": "Euclidean Ptolemy equality under the positive-proportionality (concyclicity) condition (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄), t ≥ 0",
+        "module": "Proofs.PtolemysComplexProof"
+      },
+      {
+        "theorem": "Real.sinh_arsinh",
+        "description": "sinh (arsinh x) = x — the sinh↔arsinh inverse identity used for the sinh(d_H/2) = poincareChord bridge",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arsinh"
+      },
+      {
+        "theorem": "Real.sqrt_mul",
+        "description": "√(x·y) = √x·√y for x ≥ 0 — splits the conformal factor into a product of two roots",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      }
+    ],
+    "originalContributions": [
+      "poincareChord z w = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)): the conformal chord of the Poincaré disk, equal to sinh(d_H(z,w)/2)",
+      "hyperbolic_ptolemy_inequality: the hyperbolic Ptolemy inequality for ANY four points in the open unit disk (no concyclicity assumption), proved by common-denominator reduction to the Euclidean ptolemy_inequality",
+      "hyperbolic_ptolemy_equality: the hyperbolic Ptolemy equality under the algebraic concyclicity (positive-proportionality) condition, reduced to ptolemy_equality_of_proportional",
+      "Common-denominator cancellation: every product s(zᵢ,zⱼ)·s(zₖ,zₗ) shares the denominator √∏(1-‖zᵢ‖²) since {i,j,k,l}={1,2,3,4}, so the hyperbolic relation is the Euclidean one divided by that positive factor — the ~800–1200 lines of Poincaré metric-space infrastructure the parent flagged are unnecessary",
+      "poincareDist z w = 2·arsinh(poincareChord z w): the standard closed form of the K=-1 disk metric (= arcosh(1+2s²)), and sinh_poincareDist_half: sinh(d_H/2) = poincareChord z w via Real.sinh_arsinh",
+      "hyperbolic_ptolemy_inequality_sinh / hyperbolic_ptolemy_equality_sinh: the parent's conjectured statements, stated in the exact sinh(d_H/2) form (= curvatureSin (-1) (d_H/2)) and discharged"
+    ],
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "lineCount": 300,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Fully machine-verified. The reduction to the Euclidean Ptolemy theorem is unconditional. The hyperbolic distance poincareDist is DEFINED by the standard closed form d_H = 2·arsinh(s) of the Poincaré disk metric; the file does not re-derive that this closed form satisfies the metric axioms (triangle inequality, Möbius-invariance), and no such fact is used in any proof. Statements are phrased with Real.sinh (= curvatureSin (-1) by the parent's curvatureSin_neg_one) and depend only on the clean Proofs.PtolemysComplexProof module plus Mathlib.",
+    "mathlib_version": "4.26.0",
+    "parentProof": "synthesis-curvature-ptolemy",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "id": "conformal-chord",
+      "title": "The Conformal Chord of the Poincaré Disk",
+      "startLine": 89,
+      "endLine": 119,
+      "description": "Defines poincareChord z w = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)); proves the conformal factor 1-‖z‖² is positive inside the disk, the square-root split poincareChord z w = ‖z-w‖/(√(1-‖z‖²)·√(1-‖w‖²)), and the symmetry poincareChord z w = poincareChord w z.",
+      "summary": "poincareChord = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) = sinh(d_H/2); factor positivity, root split, symmetry",
+      "mathContext": "In the Poincaré disk model D = {z ∈ ℂ : ‖z‖ < 1}, the hyperbolic (K=-1) distance satisfies the standard identity sinh(d_H(z,w)/2) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)). The factor 1-‖z‖² is the conformal factor of the model at z; it is strictly positive precisely on the open disk, which is what makes the common denominator √∏(1-‖zᵢ‖²) invertible."
+    },
+    {
+      "title": "Hyperbolic Ptolemy Inequality",
+      "startLine": 120,
+      "endLine": 171,
+      "description": "Proves hyperbolic_ptolemy_inequality: for any four points in the open unit disk, poincareChord z₁ z₃·poincareChord z₂ z₄ ≤ poincareChord z₁ z₂·poincareChord z₃ z₄ + poincareChord z₂ z₃·poincareChord z₁ z₄. Each product is rewritten over the common denominator √∏(1-‖zᵢ‖²); dividing the Euclidean ptolemy_inequality by that positive factor (via gcongr) gives the result.",
+      "summary": "Hyperbolic Ptolemy inequality for all four disk points, by common-denominator reduction to the Euclidean case",
+      "id": "hyperbolic-inequality",
+      "mathContext": "The three products s(z₁,z₃)s(z₂,z₄), s(z₁,z₂)s(z₃,z₄), s(z₂,z₃)s(z₁,z₄) all equal ‖·‖·‖·‖ / √((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²)): the four disk points contribute their conformal factors exactly once to each product because the index pair {i,j} and its complement {k,l} partition {1,2,3,4}. So the hyperbolic inequality is the Euclidean chord inequality scaled by a single positive constant 1/√∏(1-‖zᵢ‖²), and no concyclicity is needed for the inequality direction."
+    },
+    {
+      "title": "Hyperbolic Ptolemy Equality",
+      "startLine": 172,
+      "endLine": 221,
+      "description": "Proves hyperbolic_ptolemy_equality: under the positive-proportionality condition (z₂-z₃)(z₁-z₄) = t·(z₁-z₂)(z₃-z₄) with t ≥ 0 — the algebraic form of concyclicity in cyclic order — the hyperbolic Ptolemy inequality becomes an equality. Same common-denominator reduction, now to ptolemy_equality_of_proportional.",
+      "summary": "Hyperbolic Ptolemy equality under the algebraic concyclicity condition, reduced to ptolemy_equality_of_proportional",
+      "id": "hyperbolic-equality",
+      "mathContext": "Equality in Ptolemy's theorem is the concyclicity locus. Algebraically it is captured by the opposite-side products being positively proportional in ℂ (the cross-ratio being real and ≥ 0), which is exactly the hypothesis of the Euclidean ptolemy_equality_of_proportional. Because the conformal denominators cancel identically, that Euclidean equality lifts verbatim to the hyperbolic chords."
+    },
+    {
+      "title": "The Poincaré Metric and the sinh(d_H/2) Bridge",
+      "startLine": 222,
+      "endLine": 247,
+      "description": "Defines poincareDist z w = 2·arsinh(poincareChord z w) — the standard closed form of the K=-1 disk metric (equivalently arcosh(1+2s²), using arcosh(1+2s²) = 2·arsinh s) — and proves sinh_poincareDist_half: sinh(poincareDist z w / 2) = poincareChord z w, immediate from Real.sinh_arsinh.",
+      "summary": "poincareDist = 2·arsinh(chord); sinh(d_H/2) = poincareChord via Real.sinh_arsinh",
+      "id": "metric-bridge",
+      "mathContext": "The Poincaré disk metric has the closed form d_H(z,w) = arcosh(1 + 2‖z-w‖²/((1-‖z‖²)(1-‖w‖²))) = 2·arsinh(s) with s = poincareChord z w, since cosh(2·arsinh s) = 1 + 2 sinh²(arsinh s) = 1 + 2s². Taking this closed form as the definition of the distance turns the bridge sinh(d_H/2) = sinh(arsinh s) = s into a one-line consequence of the sinh∘arsinh inverse identity, with no need to prove the metric axioms separately."
+    },
+    {
+      "title": "The Conjectured Statements in sinh(d_H/2) Form",
+      "startLine": 248,
+      "endLine": 300,
+      "description": "Restates the results in the exact sinh(d_H/2) form of the parent's conjecture: hyperbolic_ptolemy_inequality_sinh and hyperbolic_ptolemy_equality_sinh, obtained by rewriting each curvatureSin (-1) (d_H/2) = sinh(d_H/2) as poincareChord via the bridge. Since curvatureSin (-1) = sinh, these are precisely the parent's hyperbolic Ptolemy conjecture, now discharged.",
+      "summary": "hyperbolic_ptolemy_{inequality,equality}_sinh: the parent's conjecture in sinh(d_H/2) (= curvatureSin (-1) (d_H/2)) form, discharged",
+      "id": "conjecture-discharged",
+      "mathContext": "The parent SynthesisCurvaturePtolemy.lean conjectures the hyperbolic Ptolemy relation with each length ℓ replaced by curvatureSin (-1) (ℓ/2) = sinh(ℓ/2), and remarks that it 'requires the Poincaré disk metric (~800–1200 lines), currently blocked in Mathlib.' The bridge sinh(poincareDist/2) = poincareChord collapses those statements onto the already-proved chord inequality/equality, discharging the conjecture with zero sorries and zero axioms."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Ptolemy's theorem — that for a cyclic quadrilateral the product of the diagonals equals the sum of the products of opposite sides — has constant-curvature analogues in which each Euclidean length ℓ is replaced by sn_K(ℓ/2), the K-curvature sine: sin(ℓ/2) on the sphere (K>0) and sinh(ℓ/2) in the hyperbolic plane (K<0). The parent synthesis entry unifies these through curvatureSin K and proves the spherical case, but leaves the hyperbolic (K=-1) case as a conjecture, estimating that a Poincaré-disk metric-space development of 800–1200 lines would be required. This entry shows that estimate is unnecessary for the Ptolemy relation itself: the hyperbolic identity is the Euclidean one in disguise, obtained by cancelling a common conformal factor.",
+    "problemStatement": "Prove the hyperbolic (K=-1) analogue of Ptolemy's theorem in the Poincaré disk: for four points z₁,z₂,z₃,z₄ in the open unit disk with hyperbolic distance d_H, sinh(d_H(z₁,z₃)/2)·sinh(d_H(z₂,z₄)/2) ≤ sinh(d_H(z₁,z₂)/2)·sinh(d_H(z₃,z₄)/2) + sinh(d_H(z₁,z₄)/2)·sinh(d_H(z₂,z₃)/2), with equality iff the points are concyclic — the sinh(ℓ/2) = curvatureSin (-1) (ℓ/2) specialization of the parent's unified relation.",
+    "text": "Expressing sinh(d_H(z,w)/2) as the conformal chord s(z,w) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) reveals that every product in the Ptolemy relation carries the identical denominator √∏(1-‖zᵢ‖²). Cancelling it reduces the hyperbolic statement to the Euclidean Ptolemy inequality/equality already in the gallery.",
+    "proofStrategy": "(1) Define the conformal chord poincareChord z w and split its single root into √(1-‖z‖²)·√(1-‖w‖²). (2) Rewrite each of the three products in the Ptolemy relation over the common denominator √∏(1-‖zᵢ‖²) (field_simp). (3) For the inequality, divide the Euclidean ptolemy_inequality by that positive factor with gcongr; for the equality, substitute ptolemy_equality_of_proportional. (4) Define the disk metric by its closed form d_H = 2·arsinh(s), prove sinh(d_H/2) = s via Real.sinh_arsinh, and rewrite the chord statements into the conjectured sinh(d_H/2) form.",
+    "keyInsights": [
+      "The whole hyperbolic case is a change of variables: sinh(d_H/2) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) turns hyperbolic Ptolemy into Euclidean Ptolemy times a common conformal constant.",
+      "The common denominator √((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²)) appears in every product because the two index pairs of each term always partition {1,2,3,4} — this is the structural reason the Poincaré metric machinery cancels out.",
+      "Because the cancelled factor is a single positive constant, the inequality direction needs no concyclicity, while equality is inherited verbatim from the Euclidean proportionality (concyclicity) condition.",
+      "Taking the disk metric in its closed form d_H = 2·arsinh(s) makes sinh(d_H/2) = s a one-line inverse-function identity, so the conjecture can be stated and proved in its intended sinh(d_H/2) form without building the metric space.",
+      "A conjecture flagged as needing ~800–1200 lines of blocked infrastructure is discharged in ~300 lines depending only on the clean complex-number Ptolemy proof and Mathlib — an instance where the right coordinates collapse a claimed obstruction."
+    ],
+    "prerequisites": [
+      "Euclidean Ptolemy inequality and its proportional-equality case (Proofs.PtolemysComplexProof)",
+      "The Poincaré disk model and the identity sinh(d_H(z,w)/2) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²))",
+      "Real.sqrt_mul (splitting √ of a product) and Real.sinh_arsinh (the sinh↔arsinh inverse)",
+      "gcongr / field_simp for the common-denominator manipulation"
+    ],
+    "openQuestions": [
+      "Formalize the actual Poincaré-disk metric space and prove d_H = 2·arsinh(s) is a genuine metric (triangle inequality, Möbius-invariance), connecting poincareDist here to a MetricSpace instance.",
+      "Prove the concyclicity characterization directly in disk terms: identify exactly which four-point configurations satisfy the positive-proportionality hypothesis as lying on a common hyperbolic circle or geodesic.",
+      "Establish the full curvature-parametrized Ptolemy equality curvatureSin K (d_K/2) across all K in one statement, unifying the spherical (parent) and hyperbolic (this entry) cases through the continuous curvatureSin family."
+    ]
+  },
+  "conclusion": {
+    "summary": "The hyperbolic (K=-1) Ptolemy theorem in the Poincaré disk is proved as a fully verified theorem (0 sorries, 0 axioms), both as an inequality for all four disk points and as an equality under the concyclicity (positive-proportionality) condition, in the sinh(d_H/2) = curvatureSin (-1) (d_H/2) form conjectured by the parent entry.",
+    "implications": "This discharges the hyperbolic Ptolemy conjecture recorded in SynthesisCurvaturePtolemy.lean without the ~800–1200 lines of Poincaré metric-space infrastructure the parent estimated as necessary. The key is the conformal-factor cancellation: sinh(d_H/2) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²)) makes every product in the Ptolemy relation share the denominator √∏(1-‖zᵢ‖²), so the hyperbolic relation is the Euclidean one scaled by a positive constant. Together with the parent's spherical result, all three constant-curvature Ptolemy relations (K>0, K=0, K<0) are now machine-verified.",
+    "openQuestions": [
+      "Build the genuine Poincaré-disk MetricSpace instance and prove poincareDist is its distance.",
+      "Characterize the positive-proportionality hypothesis geometrically as concyclicity on a hyperbolic circle.",
+      "State and prove a single curvature-parametrized Ptolemy equality curvatureSin K (d_K/2) valid for all K."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "parent",
+      "description": "Defines curvatureSin K and the unified Ptolemy relation, proves the spherical (K=1) inequality, and states the hyperbolic (K=-1) case as a conjecture with the remark that it needs ~800–1200 lines of Poincaré metric-space infrastructure. This entry discharges that conjecture in the sinh(d_H/2) = curvatureSin (-1) (d_H/2) form via conformal-factor cancellation."
+    },
+    {
+      "targetId": "ptolemys-complex-proof",
+      "relationship": "uses",
+      "description": "Supplies ptolemy_inequality and ptolemy_equality_of_proportional, the Euclidean complex-number Ptolemy results that the hyperbolic case reduces to after cancelling the common conformal denominator."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Alan F. Beardon"
+      ],
+      "title": "The Geometry of Discrete Groups",
+      "year": "1983",
+      "venue": "Graduate Texts in Mathematics, vol. 91, Springer",
+      "note": "Standard reference for the Poincaré disk model and the distance formula sinh(d_H(z,w)/2) = ‖z-w‖/√((1-‖z‖²)(1-‖w‖²))."
+    },
+    {
+      "authors": [
+        "J. E. Valentine"
+      ],
+      "title": "An analogue of Ptolemy's theorem and its converse in hyperbolic geometry",
+      "year": "1970",
+      "venue": "Pacific Journal of Mathematics 34(3), 817–825",
+      "note": "Classical statement of the hyperbolic Ptolemy theorem and its concyclicity converse."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.PtolemysComplexProof",
+      "Mathlib.Analysis.SpecialFunctions.Arsinh",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "",
+    "lineCount": 300,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "sorries": 0,
+    "path": "Proofs/SynthesisCurvaturePtolemyOQ02.lean",
+    "definitionCount": 2
+  }
+}


### PR DESCRIPTION
## Summary

Discharges the **hyperbolic (K = −1) Ptolemy conjecture** left open by the parent entry `synthesis-curvature-ptolemy` — as a **fully verified theorem** (0 sorries, 0 axioms; `#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`).

The parent file states the hyperbolic case as a conjecture and remarks it "requires the Poincaré disk metric as a metric space (~800–1200 lines), currently blocked in Mathlib." This PR shows that infrastructure is **unnecessary for the Ptolemy relation itself**.

## Key insight — conformal-factor cancellation

Write the hyperbolic half-distance as the conformal chord
```
s(z,w) = ‖z-w‖ / √((1-‖z‖²)(1-‖w‖²))  =  sinh(d_H(z,w)/2).
```
In the Ptolemy relation every product `s(zᵢ,zⱼ)·s(zₖ,zₗ)` carries the **same** denominator `√((1-‖z₁‖²)(1-‖z₂‖²)(1-‖z₃‖²)(1-‖z₄‖²))`, because the index pair `{i,j}` and its complement `{k,l}` always partition `{1,2,3,4}`. Cancelling that single positive factor reduces the hyperbolic Ptolemy inequality/equality **directly** to the Euclidean `ptolemy_inequality` / `ptolemy_equality_of_proportional` already in the gallery.

Taking the disk metric in its standard closed form `d_H = 2·arsinh(s)`, the bridge `sinh(d_H/2) = s` is one line (`Real.sinh_arsinh`), so the final theorems are stated in the exact `sinh(d_H/2) = curvatureSin (-1) (d_H/2)` form of the conjecture.

## What's proved

- `hyperbolic_ptolemy_inequality` — for **any** four points in the open disk (no concyclicity).
- `hyperbolic_ptolemy_equality` — under the positive-proportionality (concyclicity) condition.
- `sinh_poincareDist_half` — the `sinh(d_H/2) = poincareChord` bridge.
- `hyperbolic_ptolemy_inequality_sinh` / `hyperbolic_ptolemy_equality_sinh` — the parent's conjectured statements, discharged.

## Honesty notes

- The reduction to the Euclidean theorem is **unconditional and fully machine-checked** (`verified`, `badge: original`).
- `poincareDist` is **defined** by the standard closed form of the disk metric; the file does not re-derive the metric axioms (triangle inequality, Möbius-invariance) and uses no such fact.
- The file imports only the **clean** `Proofs.PtolemysComplexProof` + Mathlib, not the parent `SynthesisCurvaturePtolemy`. That parent chain (`PtolemysTheoremOQ01OQ02.lean`) is currently **broken by a Mathlib bump** — it uses `⟪a,b⟫_ℝ` without `open scoped RealInnerProductSpace`. That is a pre-existing, unrelated breakage flagged for the mechanic; this PR does not touch it. Since `curvatureSin (-1) = sinh`, phrasing with `Real.sinh` is equivalent to the parent notation.

## Build

`./proofs/scripts/docker-build.sh Proofs.SynthesisCurvaturePtolemyOQ02` → builds clean (Lean 4.26.0 / Mathlib), 0 sorries, 0 axioms.

## Files
- `proofs/Proofs/SynthesisCurvaturePtolemyOQ02.lean` (new, 300 lines, 8 theorems, 2 defs)
- `src/data/proofs/synthesis-curvature-ptolemy-oq-02/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)