### PR TITLE
Kolmogorov martingale assembly (S3) for the Marcinkiewicz–Zygmund SLLN

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -9,25 +9,38 @@
       → -oq-01-oq-02-oq-01  (this leaf: Marcinkiewicz–Zygmund SLLN, 1 ≤ p < 2)
 
   The full Marcinkiewicz–Zygmund strong law is a multi-session build; its
-  classical proof (truncation + Kolmogorov's convergence criterion) closes with
-  a purely analytic step:
+  classical proof factors into a purely analytic passage (Kronecker's lemma)
+  and a probabilistic engine (Kolmogorov's convergence criterion). This file
+  supplies the reusable infrastructure for both.
 
-    **Kronecker's lemma.** If `a n` is a positive, nondecreasing sequence with
-    `a n → ∞` and the series `∑ x n / a n` converges, then the Cesàro-type
-    average `(∑_{i<n} x i) / a n → 0`.
-
-  Mathlib has the *unweighted* Cesàro mean (`Filter.Tendsto.cesaro`) and Abel
-  summation (`Finset.sum_range_by_parts`), but **no Kronecker lemma** and no
-  weighted Toeplitz mean. This file supplies both:
+  **Analytic core — Kronecker's lemma.** If `a n` is a positive, nondecreasing
+  sequence with `a n → ∞` and the series `∑ x n / a n` converges, then the
+  Cesàro-type average `(∑_{i<n} x i) / a n → 0`. Mathlib has the *unweighted*
+  Cesàro mean (`Filter.Tendsto.cesaro`) and Abel summation
+  (`Finset.sum_range_by_parts`), but **no Kronecker lemma** and no weighted
+  Toeplitz mean; we supply both:
 
     * `tendsto_weighted_average_zero` — a Toeplitz/Silverman step: nonnegative
       weights whose partial sums are dominated by a normaliser `A n → ∞`,
-      applied to a null sequence, give a null weighted average. Independently
-      useful and the reusable core.
+      applied to a null sequence, give a null weighted average. Reusable core.
     * `kronecker_lemma` — Kronecker's lemma for real sequences, via Abel
       summation + the weighted average step.
+    * `ae_tendsto_kronecker_average_zero` — the a.e. lift of `kronecker_lemma`
+      across a sample space (S3 → S4 glue).
 
-  Verified: 0 sorry, 0 axiom.
+  **Probabilistic engine — Kolmogorov's convergence criterion (§ Kolmogorov).**
+  For independent mean-zero `L²` variables with `∑ Var < ∞`, the series `∑ Xᵢ`
+  converges a.s. We assemble this from Mathlib's a.e. martingale-convergence
+  theorem, contributing the two pieces the S3 survey flagged as missing:
+
+    * `martingale_sum_of_indep_mean_zero` — the shifted partial sums form a
+      martingale w.r.t. the natural filtration (increment independent of the
+      past ⟹ conditional expectation collapses to the vanishing mean).
+    * `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` — Kolmogorov's criterion reduced
+      to a uniform `L¹` bound on the partial sums, via
+      `Submartingale.exists_ae_tendsto_of_bdd`.
+
+  Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`).
 -/
 import Mathlib
 
@@ -282,5 +295,115 @@ theorem ae_tendsto_kronecker_average_zero
   filter_upwards [hconv] with ω hω
   obtain ⟨s, hs⟩ := hω
   exact kronecker_lemma a (fun i => x i ω) s ha_pos ha_mono ha_top hs
+
+/-! ## Kolmogorov's a.s.-convergence criterion — martingale assembly (S3)
+
+The probabilistic engine of the Marcinkiewicz–Zygmund proof (step 4 of the
+classical decomposition) is **Kolmogorov's convergence criterion**: for
+independent mean-zero `L²` random variables `Xᵢ` with `∑ Var(Xᵢ) < ∞`, the
+series `∑ Xᵢ` converges almost surely.
+
+The route is the a.e. martingale-convergence theorem. The shifted partial sums
+`f n = ∑_{i≤n} Xᵢ` form a **martingale** with respect to the natural filtration
+`ℱ = natural X` (`ℱ n = σ(X₀,…,Xₙ)`): the increment `f (n+1) − f n = X (n+1)` is
+independent of the past σ-algebra `ℱ n`, so `𝔼[X (n+1) | ℱ n] = 𝔼[X (n+1)] = 0`.
+An `L¹`-bounded submartingale converges a.s. by
+`MeasureTheory.Submartingale.exists_ae_tendsto_of_bdd`; on a probability space a
+uniform `L¹` bound on the partial sums follows from a uniform `L²` bound, i.e.
+from `∑ Var(Xᵢ) < ∞`.
+
+This section supplies the two *assembly* bricks flagged by the S3 survey — the
+martingale construction and the reduction to the convergence engine — leaving
+only the deterministic `∑ Var → L²`-bound bookkeeping (via
+`ProbabilityTheory.IndepFun.variance_sum`) for the final step. Neither brick
+introduces an axiom; the leaf stays on the 0-axiom track. -/
+
+section Kolmogorov
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal NNReal
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- **Independent mean-zero partial sums are a martingale.** For independent,
+integrable random variables `X i` with `𝔼[X i] = 0`, the shifted partial sums
+`f n = ∑_{i < n+1} X i` form a martingale with respect to the natural filtration
+of `X`.
+
+This is the probabilistic heart of Kolmogorov's convergence criterion: the
+martingale increment `f (n+1) − f n = X (n+1)` is independent of the past
+σ-algebra `ℱ n = σ(X₀,…,Xₙ)`, so its conditional expectation collapses to the
+(vanishing) mean. Built from Mathlib's `iIndepFun.condExp_natural_ae_eq_of_lt`
+and the increment criterion `martingale_of_condExp_sub_eq_zero_nat`. -/
+theorem martingale_sum_of_indep_mean_zero [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) (hmeas : ∀ i, StronglyMeasurable (X i))
+    (hindep : iIndepFun X μ) (hint : ∀ i, Integrable (X i) μ)
+    (hmean : ∀ i, μ[X i] = 0) :
+    Martingale (fun n => ∑ i ∈ range (n + 1), X i)
+      (Filtration.natural X hmeas) μ := by
+  -- adaptedness: each `Xᵢ` (i ≤ n) is `ℱ n`-measurable, so is the finite sum
+  have hadp : Adapted (Filtration.natural X hmeas)
+      (fun n => ∑ i ∈ range (n + 1), X i) := by
+    intro n
+    refine Finset.stronglyMeasurable_sum _ (fun i hi => ?_)
+    have hi' : i ≤ n := by simp only [Finset.mem_range] at hi; omega
+    exact (Filtration.adapted_natural hmeas i).mono
+      ((Filtration.natural X hmeas).mono hi')
+  refine martingale_of_condExp_sub_eq_zero_nat hadp ?_ ?_
+  · -- integrability of each partial sum
+    intro n
+    exact integrable_finset_sum' _ (fun i _ => hint i)
+  · -- the increment's conditional expectation given the past vanishes
+    intro n
+    have hincr : (fun n => ∑ i ∈ range (n + 1), X i) (n + 1)
+        - (fun n => ∑ i ∈ range (n + 1), X i) n = X (n + 1) := by
+      funext ω
+      simp only [Pi.sub_apply, Finset.sum_apply]
+      rw [Finset.sum_range_succ]
+      ring
+    rw [hincr]
+    have hcond := iIndepFun.condExp_natural_ae_eq_of_lt hmeas hindep (Nat.lt_succ_self n)
+    filter_upwards [hcond] with ω hω
+    simp only [hω, Pi.zero_apply]
+    exact hmean (n + 1)
+
+/-- **Kolmogorov's a.s.-convergence criterion, reduced to the `L¹` bound.** For
+independent mean-zero integrable random variables `X i` whose shifted partial
+sums `∑_{i≤n} Xᵢ` are uniformly bounded in `L¹`, the series `∑ i, X i` converges
+almost surely.
+
+This is Kolmogorov's convergence criterion modulo the deterministic `L¹` bound
+`hbdd` (which on a probability space follows from `∑ Var(X i) < ∞` via a uniform
+`L²` bound and `eLpNorm` monotonicity in the exponent). The proof feeds the
+partial-sum martingale into `Submartingale.exists_ae_tendsto_of_bdd` and shifts
+the index back from `∑_{i≤n}` to `∑_{i<n}`. Composing this with the a.e.
+Kronecker lift `ae_tendsto_kronecker_average_zero` yields the normalisation
+conclusion of the Marcinkiewicz–Zygmund strong law. -/
+theorem ae_tendsto_sum_of_indep_of_eLpNorm_bdd [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) (hmeas : ∀ i, StronglyMeasurable (X i))
+    (hindep : iIndepFun X μ) (hint : ∀ i, Integrable (X i) μ)
+    (hmean : ∀ i, μ[X i] = 0) (R : ℝ≥0)
+    (hbdd : ∀ n, eLpNorm (fun ω => ∑ i ∈ range (n + 1), X i ω) 1 μ ≤ (R : ℝ≥0∞)) :
+    ∀ᵐ ω ∂μ, ∃ c : ℝ, Tendsto (fun n => ∑ i ∈ range n, X i ω) atTop (𝓝 c) := by
+  have hmg := martingale_sum_of_indep_mean_zero X hmeas hindep hint hmean
+  have hsub := hmg.submartingale
+  -- put the `L¹` bound in the shape the engine expects (sum-of-functions form)
+  have hbdd' : ∀ n, eLpNorm ((fun n => ∑ i ∈ range (n + 1), X i) n) 1 μ ≤ (R : ℝ≥0∞) := by
+    intro n
+    have hfun : ((fun n => ∑ i ∈ range (n + 1), X i) n)
+        = (fun ω => ∑ i ∈ range (n + 1), X i ω) := by
+      funext ω; simp only [Finset.sum_apply]
+    rw [hfun]; exact hbdd n
+  have hconv := hsub.exists_ae_tendsto_of_bdd hbdd'
+  filter_upwards [hconv] with ω hω
+  obtain ⟨c, hc⟩ := hω
+  refine ⟨c, ?_⟩
+  -- rewrite the pointwise partial sums and shift the index down by one
+  have hc' : Tendsto (fun n => ∑ i ∈ range (n + 1), X i ω) atTop (𝓝 c) := by
+    refine hc.congr (fun n => ?_)
+    simp only [Finset.sum_apply]
+  exact (tendsto_add_atTop_iff_nat 1).mp hc'
+
+end Kolmogorov
 
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -225,3 +225,51 @@ remains is assembly, not new foundations.
   martingale from a sequence via `condExp_indep_eq` (imitate its structure).
 - Durrett, *PTE* (5e), Thm 2.5.6 (Kolmogorov's convergence theorem via the
   martingale route) — matches this reduction.
+
+---
+
+## S4 (researcher-14, 2026-07-03) — BUILD: Kolmogorov martingale assembly SHIPPED (verified)
+
+The S3 assembly is done. Two new theorems in
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`, **0-sorry / 0-axiom**
+(`#print axioms` = propext/Classical.choice/Quot.sound only — no sorryAx, no
+`Lean.ofReduceBool`). Verified via Docker build (7743 jobs, 0 errors).
+
+- `martingale_sum_of_indep_mean_zero` (L338) — for `X : ℕ → Ω → ℝ` independent
+  (`iIndepFun X μ`), integrable, mean-zero on a probability space, the shifted
+  partial sums `f n = ∑ i ∈ range (n+1), X i` are a `Martingale` wrt
+  `Filtration.natural X hmeas`. Proof: adaptedness by
+  `Finset.stronglyMeasurable_sum` over `Filtration.adapted_natural` + filtration
+  monotonicity; the increment condition `μ[f(n+1) − f n | ℱ n] =ᵐ 0` via
+  `martingale_of_condExp_sub_eq_zero_nat`, where the increment reduces to
+  `X (n+1)` (`Finset.sum_range_succ`) and
+  `iIndepFun.condExp_natural_ae_eq_of_lt hmeas hindep (Nat.lt_succ_self n)` gives
+  `μ[X(n+1) | ℱ n] =ᵐ fun _ => μ[X(n+1)] = 0`.
+- `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` (L382) — same hyps + a uniform L¹
+  bound `hbdd : ∀ n, eLpNorm (∑_{i≤n} X i) 1 μ ≤ (R : ℝ≥0∞)` ⟹
+  `∀ᵐ ω, ∃ c, Tendsto (∑_{i<n} X i ω) atTop (𝓝 c)`. Proof: `.submartingale` then
+  `Submartingale.exists_ae_tendsto_of_bdd`, then `Finset.sum_apply` +
+  `(tendsto_add_atTop_iff_nat 1).mp` to shift `∑_{i≤n} → ∑_{i<n}`.
+
+### Gotchas hit (for the next session)
+
+- **Use the SHIFTED sum** `f n = ∑ i ∈ range (n+1), X i` (i.e. `∑_{i≤n}`), NOT
+  `∑_{i<n}`. With `ℱ = natural X` (`ℱ n = σ(X_0..X_n)`), the increment must be
+  `X (n+1)`, which is *independent of* `ℱ n`. With `∑_{i<n}` the increment `X n`
+  is `ℱ n`-measurable and the martingale identity FAILS.
+  `iIndepFun.condExp_natural_ae_eq_of_lt` needs `i < j` (j strictly future).
+- Engine's bound variable is `R : ℝ≥0` (NNReal), coerced to `ℝ≥0∞` in the
+  hypothesis — state `hbdd` with `(R : ℝ≥0∞)`, not `R : ℝ≥0∞`.
+- Notation scopes: need `open scoped ENNReal NNReal` for `ℝ≥0∞` / `ℝ≥0`, and
+  `open MeasureTheory ProbabilityTheory` for `Martingale`/`condExp`/`iIndepFun`.
+
+### Remaining (S4a / S4b) — see state.md
+
+- **S4a:** discharge `hbdd` from `∑ Var(X_i) < ∞` (probability space:
+  `eLpNorm S_n 1 ≤ eLpNorm S_n 2 = sqrt(Var S_n) = sqrt(∑ Var)`). Named lemmas:
+  `IndepFun.variance_sum` (Variance.lean L275), `eLpNorm_le_eLpNorm_of_exponent_le`
+  (CompareExp.lean L98, needs `IsProbabilityMeasure`), and the
+  `evariance`↔`eLpNorm 2` bridge under mean-zero (`evariance_eq_lintegral_ofReal`).
+  Only fiddly part is ENNReal/rpow bookkeeping. Yields standalone Kolmogorov.
+- **S4b:** truncation + moment estimates (M–Z-specific), then final assembly with
+  `ae_tendsto_kronecker_average_zero`.

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,55 +1,61 @@
 # Current State
 
-**Phase**: ACT (S3 ready to build)
+**Phase**: ACT (S4 ready — variance L¹-bound + truncation remain)
 **Since**: 2026-07-03
-**Iteration**: 3 (S3 scoping; S2 shipped)
+**Iteration**: 4 (S3 martingale assembly SHIPPED; S2 Kronecker shipped; S1 survey)
 
 ## Current Focus
 
-**S2 is DONE — do not re-attempt Kronecker.** This leaf's `state.md` previously
-still listed S2 as the next action even though S2 had shipped; that staleness
-caused a duplicate re-derivation of Kronecker on 2026-07-03 (caught before merge
-and discarded). Corrected here.
+**S2 (Kronecker) and S3 (Kolmogorov martingale assembly) are BOTH DONE — do not
+re-derive either.** All in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`,
+verified 0-sorry / 0-axiom (only propext/Classical.choice/Quot.sound):
 
-Kronecker's lemma and the Toeplitz/Silverman weighted-average null step are
-already **verified 0-sorry / 0-axiom** on `main`:
+- `LawsOfLargeNumbers.MZ.kronecker_lemma` (L135) — S2
+- `LawsOfLargeNumbers.MZ.tendsto_weighted_average_zero` (L60) — S2 Toeplitz core
+- `LawsOfLargeNumbers.MZ.ae_tendsto_kronecker_average_zero` (L285) — a.e. lift
+- `LawsOfLargeNumbers.MZ.martingale_sum_of_indep_mean_zero` (L338) — **S3 NEW**:
+  shifted partial sums of independent mean-zero L¹ vars are a martingale wrt the
+  natural filtration (via `iIndepFun.condExp_natural_ae_eq_of_lt` +
+  `martingale_of_condExp_sub_eq_zero_nat`).
+- `LawsOfLargeNumbers.MZ.ae_tendsto_sum_of_indep_of_eLpNorm_bdd` (L382) — **S3
+  NEW**: Kolmogorov's criterion reduced to a uniform L¹ bound, via
+  `Submartingale.exists_ae_tendsto_of_bdd` + a one-step index shift.
 
-- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`
-  - `LawsOfLargeNumbers.MZ.kronecker_lemma` (L122)
-  - `LawsOfLargeNumbers.MZ.tendsto_weighted_average_zero` (L47)
-
-Current work = **S3 scoping**: the a.s.-convergence-of-independent-`L²`-series
-criterion (Kolmogorov). The 2026-07-02 survey called this a ">300 LOC bottleneck"
-but never checked Mathlib's martingale-convergence machinery. It turns out the
-a.s.-convergence *engine* and every glue lemma already exist in Mathlib (see
-`knowledge.md` §S3); the remaining work is **assembly**, not foundations.
+The S3 survey was right: the a.e.-convergence engine and all glue lemmas were
+already in Mathlib; S3 was assembly, and it is now assembled.
 
 ## Active Approach
 
-None in-flight (docs/scoping iteration). Next work item is the S3 assembly
-below — a real Lean build for a future session.
+None in-flight. Next work item is S4 below.
 
 ## Blockers
 
-- **S3 (assembly, multi-session):** wire the existing Mathlib pieces into
-  "partial sums of independent mean-zero `L²` variables converge a.s." No
-  foundational gap remains; it is glue + bookkeeping (natural filtration →
-  martingale property via `condExp_indep_eq` → uniform `L¹` bound via
-  `IndepFun.variance_sum` → `Submartingale.exists_ae_tendsto_of_bdd`).
+- **S4a (variance L¹ bound, ~1 short session, self-contained):** discharge the
+  `hbdd` hypothesis of `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` from
+  `∑ Var(X_i) < ∞`. On a probability space,
+  `eLpNorm S_n 1 ≤ eLpNorm S_n 2 = sqrt(Var[S_n]) = sqrt(∑_{i≤n} Var[X_i]) ≤
+  sqrt(∑ Var)`. Named Mathlib pieces: `ProbabilityTheory.IndepFun.variance_sum`
+  (variance of independent sum = sum of variances), `evariance` ↔ `eLpNorm 2`
+  bridge under mean-zero (`evariance_eq_lintegral_ofReal` / `variance` real
+  form), `eLpNorm_le_eLpNorm_of_exponent_le` (needs `IsProbabilityMeasure`).
+  Fiddly part: ENNReal/rpow bookkeeping connecting `eLpNorm _ 2` to the real
+  `variance`. This yields the standalone Kolmogorov convergence criterion.
+- **S4b (truncation + moment estimates, multi-session):** the M–Z-specific
+  analytic layer — truncation `Y_i = X_i·1{|X_i| ≤ i^{1/p}}`, `∑ P(X_i≠Y_i)<∞`
+  (Borel–Cantelli), centered-truncation control, and the variance-sum estimate
+  `∑ Var(Y_i)/i^{2/p} < ∞` (uses `p < 2`). Then combine S4a + Kronecker lift.
 
 ## Next Action
 
-- **S3 (next session, real Lean build):** formalise Kolmogorov's a.s.-convergence
-  criterion by assembling the named Mathlib lemmas in `knowledge.md` §S3.
-  Start a `*.lean` file, build the natural filtration of `X`, prove the partial
-  sums form a `Martingale`, bound `eLpNorm S_n 1 μ` uniformly, and apply
-  `Submartingale.exists_ae_tendsto_of_bdd`. Estimated 1–2 sessions now that the
-  engine is located (down from the survey's "multi-session, >300 LOC").
-- **S4:** assemble truncation (steps 1–3 of the MZ decomposition) + Kronecker
-  (S2, done) + Kolmogorov (S3) to conclude MZ.
+- **S4a (next session, self-contained Lean build):** prove
+  `kolmogorov_convergence` (no `hbdd` hypothesis) by discharging the L¹ bound
+  from `∑ Var < ∞` using the named lemmas above. This is the single cleanest
+  remaining increment and needs no new foundations.
+- **S4b:** the truncation moment-estimate layer, then final M–Z assembly.
 
 ## Attempt Counts
 
-- Total attempts: 3 (S1 survey; S2 shipped Kronecker; S3 scoping)
-- Current approach attempts: 0 (S3 assembly not yet started)
-- Approaches tried: 2 (S1 literature/decomposition; S2 Abel+Toeplitz Kronecker)
+- Total attempts: 4 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue)
+- Current approach attempts: 0 (S4a variance bound not yet started)
+- Approaches tried: 3 (S1 literature/decomposition; S2 Abel+Toeplitz;
+  S3 natural-filtration martingale + upcrossing engine)

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/annotations.json
@@ -113,5 +113,55 @@
       "squeeze_zero_norm",
       "limit arithmetic"
     ]
+  },
+  {
+    "id": "partial-sum-martingale",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 338,
+      "endLine": 380
+    },
+    "type": "insight",
+    "title": "Partial Sums of Independent Mean-Zero Variables Are a Martingale",
+    "content": "Kolmogorov's convergence criterion is realized through the a.e. martingale-convergence theorem, and this is the construction that unlocks it. Take the shifted partial sums f n = ∑_{i≤n} X_i and the natural filtration ℱ n = σ(X_0,…,X_n). The increment f(n+1) − f n = X(n+1) is independent of the past ℱ n, so its conditional expectation collapses to the mean: E[X(n+1) | ℱ n] = E[X(n+1)] = 0. That is exactly the hypothesis of Mathlib's increment criterion martingale_of_condExp_sub_eq_zero_nat, so f is a martingale. Adaptedness is a finite sum of natural-filtration-measurable coordinates; integrability is a finite sum of L¹ functions.",
+    "mathContext": "The key Mathlib input is `ProbabilityTheory.iIndepFun.condExp_natural_ae_eq_of_lt`: for $i < j$, $\\mu[X_j \\mid \\mathcal{F}_i] =^{ae} \\mathbb{E}[X_j]$. Applied at $j = n+1$, $i = n$ with $\\mathbb{E}[X_{n+1}] = 0$ it discharges the increment condition $\\mu[f(n+1) - f n \\mid \\mathcal{F} n] =^{ae} 0$. Using the shifted sum $f n = \\sum_{i \\le n} X_i$ (rather than $\\sum_{i<n}$) is what makes the increment $X_{n+1}$ land strictly in the future of $\\mathcal{F} n$, so independence — not measurability — governs its conditional expectation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "martingale",
+      "natural filtration",
+      "conditional expectation under independence",
+      "adapted process",
+      "Kolmogorov's convergence criterion"
+    ],
+    "prerequisites": [
+      "conditional expectation",
+      "filtrations",
+      "independence of random variables"
+    ]
+  },
+  {
+    "id": "kolmogorov-l1-reduction",
+    "proofId": "laws-of-large-numbers-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 382,
+      "endLine": 405
+    },
+    "type": "technique",
+    "title": "Reducing Kolmogorov's Criterion to an L¹ Bound",
+    "content": "With the partial-sum martingale in hand, a.s. convergence follows from Mathlib's a.e. martingale-convergence theorem Submartingale.exists_ae_tendsto_of_bdd, which needs only a uniform L¹ bound on the process. A martingale is a submartingale, so once the shifted sums are bounded in L¹ the engine yields a.e. convergence of f n = ∑_{i≤n} X_i; a one-step index shift (tendsto_add_atTop_iff_nat) transfers this to the target ∑_{i<n} X_i. This isolates the entire remaining probabilistic content of Kolmogorov's criterion into a single deterministic hypothesis — the uniform L¹ bound — which on a probability space follows from ∑ Var(X_i) < ∞.",
+    "mathContext": "On a probability measure $\\|S_n\\|_{L^1} \\le \\|S_n\\|_{L^2} = \\sqrt{\\mathrm{Var}[S_n]} = \\sqrt{\\sum_{i \\le n} \\mathrm{Var}[X_i]} \\le \\sqrt{\\sum_i \\mathrm{Var}[X_i]}$, using orthogonality of independent mean-zero increments (`IndepFun.variance_sum`) and `eLpNorm` monotonicity in the exponent. The theorem takes that bound $R : \\mathbb{R}_{\\ge 0}$ as a hypothesis, deferring the variance computation; supplying it completes the standalone criterion. Composed with `ae_tendsto_kronecker_average_zero`, this delivers the almost-sure normalisation at the heart of the Marcinkiewicz–Zygmund strong law.",
+    "significance": "key",
+    "relatedConcepts": [
+      "martingale convergence theorem",
+      "submartingale",
+      "L¹ boundedness",
+      "variance of independent sums",
+      "eLpNorm monotonicity"
+    ],
+    "prerequisites": [
+      "martingale convergence",
+      "Lᵖ spaces",
+      "variance"
+    ]
   }
 ]

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "laws-of-large-numbers-oq-01-oq-02-oq-01",
-  "title": "Kronecker's Lemma (Toeplitz Step) for the Marcinkiewicz–Zygmund SLLN",
+  "title": "Kronecker's Lemma and the Kolmogorov Martingale Assembly for the Marcinkiewicz–Zygmund SLLN",
   "slug": "laws-of-large-numbers-oq-01-oq-02-oq-01",
-  "description": "The Marcinkiewicz–Zygmund strong law (rate n^{1/p} for E|X|^p < ∞, 1 ≤ p < 2) is a multi-session build whose classical truncation proof closes with a purely analytic step: Kronecker's lemma. If a_n > 0 is nondecreasing with a_n → ∞ and the series ∑ x_n / a_n converges, then the weighted average (∑_{i<n} x_i) / a_n → 0. Mathlib has the unweighted Cesàro mean and Abel summation but no Kronecker lemma and no weighted Toeplitz mean. This entry supplies both, verified with 0 sorries and 0 axioms, as the reusable analytic engine for the M–Z assembly.",
+  "description": "The Marcinkiewicz–Zygmund strong law (rate n^{1/p} for E|X|^p < ∞, 1 ≤ p < 2) is a multi-session build whose classical proof factors into an analytic passage (Kronecker's lemma) and a probabilistic engine (Kolmogorov's convergence criterion). This entry supplies the reusable infrastructure for both, verified with 0 sorries and 0 axioms. (1) Kronecker's lemma: if a_n > 0 is nondecreasing with a_n → ∞ and ∑ x_n / a_n converges, then (∑_{i<n} x_i) / a_n → 0 — absent from Mathlib, built on a Toeplitz/Silverman weighted-average null step. (2) Kolmogorov's criterion, assembled via Mathlib's a.e. martingale-convergence theorem: the shifted partial sums of independent mean-zero variables form a martingale w.r.t. the natural filtration (martingale_sum_of_indep_mean_zero), and an L¹-bounded such sum converges a.s. (ae_tendsto_sum_of_indep_of_eLpNorm_bdd), reducing the criterion to a uniform L¹ bound.",
   "meta": {
-    "author": "Leopold Kronecker (lemma); formalization researcher-16",
+    "author": "Leopold Kronecker & A. Kolmogorov (results); formalization researcher-16, researcher-14",
     "sourceUrl": "https://en.wikipedia.org/wiki/Kronecker%27s_lemma",
     "date": "1885",
     "status": "verified",
@@ -23,9 +23,9 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 0,
-    "lineCount": 248,
+    "lineCount": 409,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_range_by_parts",
@@ -46,14 +46,37 @@
         "theorem": "squeeze_zero_norm",
         "description": "If ‖f n‖ ≤ g n and g n → 0 then f n → 0",
         "module": "Mathlib.Analysis.Normed.Order.Lattice"
+      },
+      {
+        "theorem": "ProbabilityTheory.iIndepFun.condExp_natural_ae_eq_of_lt",
+        "description": "For independent variables, the conditional expectation of X_j given the natural filtration up to i < j equals the mean E[X_j]",
+        "module": "Mathlib.Probability.BorelCantelli"
+      },
+      {
+        "theorem": "MeasureTheory.martingale_of_condExp_sub_eq_zero_nat",
+        "description": "A process is a martingale if it is adapted, integrable, and each increment has vanishing conditional expectation given the past",
+        "module": "Mathlib.Probability.Martingale.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.Submartingale.exists_ae_tendsto_of_bdd",
+        "description": "The a.e. martingale-convergence theorem: an L¹-bounded submartingale converges almost everywhere",
+        "module": "Mathlib.Probability.Martingale.Convergence"
+      },
+      {
+        "theorem": "MeasureTheory.Filtration.adapted_natural",
+        "description": "A process is adapted to its own natural filtration",
+        "module": "Mathlib.Probability.Process.Adapted"
       }
     ],
     "originalContributions": [
       "Theorem tendsto_weighted_average_zero: a Toeplitz/Silverman null step — nonnegative weights c_i whose partial sums are dominated by a normaliser A n → ∞, applied to a null sequence e n → 0, give (∑_{i<n} c_i e_i) / A n → 0. The reusable analytic core, absent from Mathlib.",
-      "Theorem kronecker_lemma: Kronecker's lemma for real sequences — a_n > 0 nondecreasing, a_n → ∞, ∑ x_n / a_n convergent ⟹ (∑_{i<n} x_i) / a_n → 0, via Abel summation reduced to the weighted-average step. Not present in Mathlib 4.26 (only the unrelated matrix Kronecker product exists)."
+      "Theorem kronecker_lemma: Kronecker's lemma for real sequences — a_n > 0 nondecreasing, a_n → ∞, ∑ x_n / a_n convergent ⟹ (∑_{i<n} x_i) / a_n → 0, via Abel summation reduced to the weighted-average step. Not present in Mathlib 4.26 (only the unrelated matrix Kronecker product exists).",
+      "Theorem ae_tendsto_kronecker_average_zero: the almost-everywhere lift of kronecker_lemma across a sample space — if for a.e. ω the series ∑ x_i(ω)/a_i converges, then a.e. the Kronecker average (∑_{i<n} x_i(ω))/a_n → 0. The deterministic glue joining Kolmogorov's a.s.-convergence output to the M–Z normalisation.",
+      "Theorem martingale_sum_of_indep_mean_zero: the shifted partial sums f n = ∑_{i≤n} X_i of independent, integrable, mean-zero random variables form a martingale with respect to the natural filtration. The probabilistic heart of Kolmogorov's convergence criterion; the martingale increment X_{n+1} is independent of the past σ-algebra, so its conditional expectation collapses to the vanishing mean (via iIndepFun.condExp_natural_ae_eq_of_lt and the increment criterion martingale_of_condExp_sub_eq_zero_nat).",
+      "Theorem ae_tendsto_sum_of_indep_of_eLpNorm_bdd: Kolmogorov's a.s.-convergence criterion reduced to a uniform L¹ bound — for independent mean-zero integrable X_i whose shifted partial sums are uniformly bounded in L¹, the series ∑_i X_i converges almost surely. Feeds the partial-sum martingale into Mathlib's a.e. martingale-convergence engine (Submartingale.exists_ae_tendsto_of_bdd) and shifts the index from ∑_{i≤n} back to ∑_{i<n}. Leaves only the deterministic ∑ Var < ∞ ⟹ L¹-bound bookkeeping for the final assembly step."
     ],
     "dateAdded": "2026-07-03",
-    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only propext, Classical.choice, Quot.sound (standard foundations).",
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms on both Kolmogorov theorems reports only propext, Classical.choice, Quot.sound (standard foundations); no sorryAx, no Lean.ofReduceBool.",
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
@@ -62,12 +85,14 @@
     ],
     "opens": [
       "Filter",
-      "Finset"
+      "Finset",
+      "MeasureTheory",
+      "ProbabilityTheory"
     ],
     "namespace": "LawsOfLargeNumbers.MZ",
-    "lineCount": 248,
+    "lineCount": 409,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
     "sorries": 0
@@ -95,18 +120,32 @@
     {
       "id": "kronecker",
       "title": "Kronecker's Lemma via Abel Summation",
-      "startLine": 111,
-      "endLine": 248,
+      "startLine": 135,
+      "endLine": 259,
       "summary": "Proves kronecker_lemma. Uses Finset.sum_range_by_parts for Abel summation, a telescoping identity for the weight partial sums, and a centering split S_{m+1}−S_{i+1} = (S_{m+1}−s) − (S_{i+1}−s). The three resulting pieces converge to 0 by, respectively, null×bounded, squeeze, and the Toeplitz step above."
+    },
+    {
+      "id": "kronecker-lift",
+      "title": "Almost-Everywhere Kronecker Lift (S3 → S4 glue)",
+      "startLine": 261,
+      "endLine": 297,
+      "summary": "Proves ae_tendsto_kronecker_average_zero: the pointwise lift of kronecker_lemma across a measure space via filter_upwards. Turns a.e. convergence of the random series ∑ x_i(ω)/a_i directly into the a.e. Kronecker normalisation (∑_{i<n} x_i(ω))/a_n → 0 — the deterministic bridge from Kolmogorov's criterion to the M–Z conclusion."
+    },
+    {
+      "id": "kolmogorov-martingale",
+      "title": "Kolmogorov's Convergence Criterion — Martingale Assembly",
+      "startLine": 299,
+      "endLine": 407,
+      "summary": "Proves martingale_sum_of_indep_mean_zero (the shifted partial sums f n = ∑_{i≤n} X_i of independent mean-zero integrable variables are a martingale w.r.t. the natural filtration ℱ, since the increment X_{n+1} is independent of ℱ n so E[X_{n+1}|ℱ n] = E[X_{n+1}] = 0) and ae_tendsto_sum_of_indep_of_eLpNorm_bdd (feeding that martingale, once L¹-bounded, into Mathlib's Submartingale.exists_ae_tendsto_of_bdd and shifting the index down by one to conclude a.s. convergence of ∑_{i<n} X_i). Adaptedness is Finset.stronglyMeasurable_sum over Filtration.adapted_natural; the martingale identity is martingale_of_condExp_sub_eq_zero_nat fed by iIndepFun.condExp_natural_ae_eq_of_lt."
     }
   ],
   "conclusion": {
-    "summary": "This entry contributes the analytic engine of the strong laws of large numbers — Kronecker's lemma for real sequences and the Toeplitz weighted-average null step it rests on — fully verified in Lean 4 with 0 sorries and 0 axioms. Both results are absent from Mathlib 4.26 (which has only the unweighted Cesàro mean and matrix Kronecker products) and are independently reusable.",
-    "implications": "Kronecker's lemma is the deterministic bridge from convergence of a random series ∑ (Y_i − E Y_i)/a_i to almost-sure convergence of a normalized partial sum. Supplying it as a standalone, axiom-free lemma removes one of the two blocking gaps (the other being Kolmogorov's convergence/three-series criterion) on the path to a full Marcinkiewicz–Zygmund SLLN formalization, and is equally usable for Kolmogorov's classical SLLN. The Toeplitz step is a general summability tool with uses well beyond probability.",
+    "summary": "This entry contributes both engines of the strong laws of large numbers — the analytic Kronecker's lemma (with its Toeplitz weighted-average null step) and the probabilistic Kolmogorov convergence criterion (assembled through Mathlib's a.e. martingale-convergence theorem) — fully verified in Lean 4 with 0 sorries and 0 axioms. Kronecker's lemma and the Toeplitz step are absent from Mathlib 4.26; the Kolmogorov assembly wires existing Mathlib machinery (conditional expectation under independence, the increment martingale criterion, the upcrossing convergence engine) into the partial-sum martingale that the criterion needs. All five theorems are independently reusable.",
+    "implications": "The two blocking gaps on the path to a full Marcinkiewicz–Zygmund SLLN identified by the S1 survey were Kronecker's lemma and Kolmogorov's convergence criterion. Kronecker's lemma is supplied outright. For Kolmogorov's criterion, the S3 survey re-scoped it from a >300-line foundational build to an assembly of existing Mathlib martingale machinery; this entry realizes that assembly's two hard bricks — the martingale construction (martingale_sum_of_indep_mean_zero) and the reduction to the a.e. convergence engine (ae_tendsto_sum_of_indep_of_eLpNorm_bdd) — leaving only the deterministic ∑ Var < ∞ ⟹ uniform-L¹-bound computation (a variance-orthogonality + eLpNorm-monotonicity step, via IndepFun.variance_sum). Composed with ae_tendsto_kronecker_average_zero, these close every structural step of the M–Z normalisation; the remaining work is the truncation moment-estimates and the final variance bookkeeping.",
     "openQuestions": [
-      "Prove Kolmogorov's convergence criterion (a.s. convergence of a series of independent, mean-zero, summable-variance random variables) — the remaining >300-line bottleneck before Kronecker's lemma can be composed into the M–Z SLLN.",
+      "Discharge the uniform L¹ bound hypothesis of ae_tendsto_sum_of_indep_of_eLpNorm_bdd from ∑ Var(X_i) < ∞: on a probability space, eLpNorm(∑_{i≤n} X_i) 1 μ ≤ eLpNorm(...) 2 μ = sqrt(Var[∑_{i≤n} X_i]) = sqrt(∑_{i≤n} Var[X_i]) ≤ sqrt(∑ Var), via ProbabilityTheory.IndepFun.variance_sum and eLpNorm exponent monotonicity. This yields the standalone Kolmogorov convergence criterion.",
       "Package the Toeplitz null step into the general regular-matrix (Silverman–Toeplitz) summability theorem, of which both this lemma and Mathlib's Cesàro mean are special cases, as a candidate Mathlib contribution.",
-      "Assemble the full Marcinkiewicz–Zygmund SLLN for 1 ≤ p < 2 by combining truncation, the Borel–Cantelli tail bound, Kolmogorov's criterion, and this Kronecker lemma."
+      "Assemble the full Marcinkiewicz–Zygmund SLLN for 1 ≤ p < 2 by combining truncation (Y_i = X_i·1{|X_i| ≤ i^{1/p}}, ∑ P(X_i ≠ Y_i) < ∞ by Borel–Cantelli), the centered-truncation control, the variance-sum bound (with a_i = i^{1/p}, using p < 2), the Kolmogorov criterion above, and the Kronecker lift."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Marcinkiewicz–Zygmund SLLN leaf (`laws-of-large-numbers-oq-01-oq-02-oq-01`), iteration S3. The classical M–Z proof factors into an analytic passage (Kronecker's lemma, already shipped) and a probabilistic engine (**Kolmogorov's convergence criterion**). This PR builds the two "assembly" bricks the S3 survey identified as the remaining gap, **verified 0-sorry / 0-axiom**.

## New theorems (both axiom-free)

- **`martingale_sum_of_indep_mean_zero`** — the shifted partial sums `f n = ∑_{i≤n} X_i` of independent, integrable, mean-zero random variables form a `Martingale` w.r.t. the natural filtration `ℱ n = σ(X₀,…,Xₙ)`. The increment `f(n+1) − f n = X(n+1)` is independent of the past, so `𝔼[X(n+1) | ℱ n] = 𝔼[X(n+1)] = 0`. Built on Mathlib's `iIndepFun.condExp_natural_ae_eq_of_lt` and `martingale_of_condExp_sub_eq_zero_nat`.
- **`ae_tendsto_sum_of_indep_of_eLpNorm_bdd`** — Kolmogorov's a.s.-convergence criterion reduced to a uniform `L¹` bound on the partial sums: feeds the martingale into Mathlib's a.e. martingale-convergence engine `Submartingale.exists_ae_tendsto_of_bdd` and shifts the index `∑_{i≤n} → ∑_{i<n}`.

## Why this shape

The martingale identity requires the **shifted** sum `∑_{i≤n}` (not `∑_{i<n}`): with the natural filtration, only then is the increment `X(n+1)` strictly in the future of `ℱ n`, so independence — not measurability — governs its conditional expectation. This isolates all remaining probabilistic content of the criterion into a single deterministic hypothesis (the `L¹` bound), which on a probability space follows from `∑ Var(Xᵢ) < ∞` via `IndepFun.variance_sum` + `eLpNorm` monotonicity — the clean next-session increment (S4a).

## Verification

- Docker build `Proofs.LawsOfLargeNumbersOQ01OQ02OQ01`: **7743 jobs, 0 errors**.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`, badge `original`.

## Changes

- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` — +2 theorems (new `Kolmogorov` section) + updated header.
- Gallery `meta.json` (theoremCount 2→5, new sections, contributions, dependencies, open questions) and `annotations.json` (+2).
- Problem `state.md` / `knowledge.md` — record S3 shipped, scope S4a/S4b, and flag the shifted-sum gotcha to prevent duplicate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)