### PR TITLE
research(ramsey-r4k-extensions-oq-03): quantify why LLL beats the union bound (PART VI) + gallery entry

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03.lean
@@ -270,4 +270,43 @@ theorem ramseyLLLCondition_13_6 : RamseyLLLCondition 13 6 :=
 theorem ramseyLLLCondition_7_5 : RamseyLLLCondition 7 5 :=
   (ramseyLLLCondition_iff 7 5).mpr (by decide)
 
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: WHY LLL BEATS THE UNION BOUND (dependency-vs-total identity)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Exact dependency-to-total identity.**  Counting incidences
+    `(k-clique, edge inside it)` two ways gives
+    `C(n,2)·d = C(k,2)²·C(n,k)`, where `d = cliqueDependencyBound n k` is the LLL
+    dependency degree and `C(n,k)` is the total number of bad events (the k-cliques
+    of `K_n`).  Equivalently `d / C(n,k) = C(k,2)² / C(n,2)`: the dependency degree
+    is only a `Θ(k⁴/n²)` fraction of all events, which is exactly why the *local*
+    LLL test controls the process where the *global* union bound cannot.  Pure
+    finite counting via the subset-of-a-subset identity `Nat.choose_mul`. -/
+theorem cliqueDependency_total_identity {n k : ℕ} (hk : 2 ≤ k) :
+    n.choose 2 * cliqueDependencyBound n k = (k.choose 2) ^ 2 * n.choose k := by
+  unfold cliqueDependencyBound
+  have h : n.choose k * k.choose 2 = n.choose 2 * (n - 2).choose (k - 2) :=
+    Nat.choose_mul (n := n) (k := k) (s := 2) hk
+  calc n.choose 2 * (k.choose 2 * (n - 2).choose (k - 2))
+      = k.choose 2 * (n.choose 2 * (n - 2).choose (k - 2)) := by ring
+    _ = k.choose 2 * (n.choose k * k.choose 2) := by rw [← h]
+    _ = (k.choose 2) ^ 2 * n.choose k := by ring
+
+/-- **In the Ramsey regime the dependency degree is dominated by the total event
+    count.**  Whenever `C(k,2)² ≤ C(n,2)` (i.e. `n` is at least quadratic in `k`,
+    which holds with enormous room to spare once `n ≈ 2^{k/2}`), the LLL dependency
+    degree `d` is at most the number `C(n,k)` of monochromatic-clique events.  This
+    is the precise sense in which the symmetric LLL's *local* condition
+    `e·p·(d+1) ≤ 1` is weaker — hence satisfiable for larger `n` — than the
+    first-moment/union-bound condition, which must control all `C(n,k)` events at
+    once. -/
+theorem cliqueDependencyBound_le_total {n k : ℕ} (hk : 2 ≤ k) (hn : 2 ≤ n)
+    (hreg : (k.choose 2) ^ 2 ≤ n.choose 2) :
+    cliqueDependencyBound n k ≤ n.choose k := by
+  have hpos : 0 < n.choose 2 := Nat.choose_pos hn
+  have key : n.choose 2 * cliqueDependencyBound n k ≤ n.choose 2 * n.choose k := by
+    rw [cliqueDependency_total_identity hk]
+    gcongr
+  exact le_of_mul_le_mul_left key hpos
+
 end RamseyLLL

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -4,6 +4,37 @@ Insights accumulated during research on this problem.
 
 ---
 
+## PART VI — why LLL beats the union bound, quantified (researcher-4, 2026-07-03)
+
+Appended to `RamseyR4kExtensionsOQ03.lean` on top of the decidable-criterion
+PART V (integer test `6·(d+1) ≤ 2^{C(k,2)}` + concrete `R(6,6)>13`, `R(5,5)>7`
+witnesses). Two axiom-free unconditional theorems (`#print axioms` = only
+`propext, Classical.choice, Quot.sound`):
+
+- **`cliqueDependency_total_identity`** (`2 ≤ k`):
+  `C(n,2) · cliqueDependencyBound n k = C(k,2)² · C(n,k)`. Double-count
+  `(k-clique, edge-inside-it)` incidences via Mathlib's subset-of-a-subset
+  identity `Nat.choose_mul (s := 2)`
+  (`n.choose k * k.choose 2 = n.choose 2 * (n-2).choose (k-2)`), then two `ring`
+  steps around one `rw [← h]`. Gives `d/C(n,k) = C(k,2)²/C(n,2)`: the LLL
+  dependency degree is a `Θ(k⁴/n²)` fraction of the total bad-event count — the
+  exact reason the *local* LLL test succeeds where the *global* union bound fails.
+- **`cliqueDependencyBound_le_total`** (`2 ≤ k`, `2 ≤ n`, `C(k,2)² ≤ C(n,2)`):
+  `d ≤ C(n,k)`. Cancel `C(n,2) > 0` via
+  `le_of_mul_le_mul_left … (Nat.choose_pos hn)`; `≤` side by `gcongr`.
+
+**Gotcha**: `Nat.choose_mul` is in `Mathlib/Data/Nat/Choose/Basic.lean:160`,
+`{n k s} (hsk : s ≤ k) : n.choose k * k.choose s = n.choose s * (n-s).choose (k-s)`;
+instantiate `(s := 2)`, feed `hk : 2 ≤ k`. `ring` works over ℕ since `n-2`, `k-2`
+stay opaque atoms.
+
+**Remaining gap unchanged**: the only non-Mathlib ingredient is the
+measure-theoretic step inside `SymmetricLLLForRamsey` (positive avoidance
+probability ⇒ existence). All numeric/combinatorial content is now discharged.
+See sibling `lovasz-local-lemma-oq-01`.
+
+---
+
 ## Problem Understanding
 
 [Initial observations about the problem will be recorded here]

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03/annotations.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03/annotations.json
@@ -1,0 +1,188 @@
+[
+  {
+    "id": "r4k-oq03-ann-docstring",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "The dependency degree as exact counting",
+    "content": "The symmetric Lovász Local Lemma feasibility test for Spencer's improved Ramsey lower bound is e·p·(d+1) ≤ 1, with p the probability that a fixed k-clique is monochromatic and d its dependency degree. This module computes d with no probability theory. The bad event 'clique S is monochromatic' is statistically dependent on 'clique T is monochromatic' exactly when S and T share an edge, i.e. |S∩T| ≥ 2. The number of such dependent cliques is at most C(k,2)·C(n−2,k−2). The companion entry ramsey-r4k-extensions-oq-03-oq-01 supplies the other input p.",
+    "mathContext": "Symmetric LLL: if Pr[Aᵢ] ≤ p and each Aᵢ is mutually independent of all but ≤ d others, then e·p·(d+1) ≤ 1 implies Pr[⋂ Āᵢ] > 0. Here the Aᵢ are the monochromatic-k-clique events and two are dependent iff their cliques share an edge.",
+    "significance": "Reduces the dependency-degree input d of the LLL to a finite cardinality bound about overlapping cliques, machine-checkable without any measure theory.",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "dependency graph",
+      "probabilistic method",
+      "Ramsey numbers"
+    ],
+    "prerequisites": [
+      "random 2-colourings of complete graphs",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-parameters",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 42,
+      "endLine": 81
+    },
+    "type": "definition",
+    "title": "cliqueMonoProb, cliqueDependencyBound, RamseyLLLCondition: the LLL inputs",
+    "content": "cliqueMonoProb k = 2/2^C(k,2) is the bad-event probability p; cliqueDependencyBound n k = C(k,2)·C(n−2,k−2) is the dependency degree d; RamseyLLLCondition n k asserts the symmetric-LLL test 3·p·(d+1) ≤ 1, using the rational surrogate e ≤ 3 shared with the gallery's other LLL files. cliqueMonoProb_pos and cliqueMonoProb_le_one bound p in (0,1] for k ≥ 2 (a clique has at least one edge, so 2^C(k,2) ≥ 2).",
+    "mathContext": "These are the three quantities the symmetric LLL feasibility condition e·p·(d+1) ≤ 1 needs, assembled into a single decidable-shaped rational inequality on (n,k).",
+    "significance": "Packages the Ramsey-specific LLL inputs into one applicability predicate whose validity at (n,k) certifies R(k,k) > n.",
+    "relatedConcepts": [
+      "Lovász Local Lemma feasibility",
+      "binomial coefficient",
+      "monochromatic clique"
+    ],
+    "prerequisites": [
+      "Euler's number surrogate e ≤ 3",
+      "rational arithmetic in Lean"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-containing",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 87,
+      "endLine": 128
+    },
+    "type": "theorem",
+    "title": "containing_card_le: at most C(n−2,k−2) k-cliques through a fixed edge",
+    "content": "For a fixed 2-element edge e, the k-cliques of Kₙ containing e number at most C(n−2,k−2). The proof exhibits the map T ↦ T∖e as an injection from these cliques into the (k−2)-subsets of univ∖e (the n−2 vertices outside e): the image has the right cardinality (card_sdiff_of_subset, |T∖e| = k−2), and the map is injective because T = (T∖e) ∪ e is recoverable via Finset.sdiff_union_of_subset. Concludes with Finset.card_le_card_of_injOn and card_powersetCard.",
+    "mathContext": "This is the 'cliques through a fixed edge' count, the per-edge factor C(n−2,k−2) in the dependency bound d = C(k,2)·C(n−2,k−2).",
+    "significance": "A reusable finite-combinatorics lemma: choosing the remaining k−2 vertices of a clique once its edge e is fixed is a (k−2)-subset choice from the n−2 other vertices.",
+    "relatedConcepts": [
+      "injective image cardinality",
+      "powersetCard",
+      "set difference"
+    ],
+    "prerequisites": [
+      "Finset.card_le_card_of_injOn",
+      "Finset.sdiff_union_of_subset",
+      "Finset.card_powersetCard"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-dependency",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 129,
+      "endLine": 163
+    },
+    "type": "theorem",
+    "title": "cliqueNeighbors_card_le: the dependency-degree bound d ≤ C(k,2)·C(n−2,k−2)",
+    "content": "For any fixed k-clique S, the number of other k-cliques meeting S in ≥ 2 vertices (its LLL dependency neighbourhood) is at most C(k,2)·C(n−2,k−2). Each dependent clique T shares a 2-element edge e ⊆ S∩T (Finset.exists_subset_card_eq from |S∩T| ≥ 2), so cliqueNeighbors S k is covered by the biUnion over the C(k,2) edges e of S of the cliques containing e. Applying Finset.card_biUnion_le_card_mul with the per-edge bound containing_card_le and card_powersetCard for |S.powersetCard 2| = C(k,2) gives the product bound.",
+    "mathContext": "This is Key Lemma 3 of the LLL-for-Ramsey plan — the dependency degree d that, together with p, feeds the feasibility test e·p·(d+1) ≤ 1. It is the fact stated but not proved in the RamseyR4kExtensions narrative.",
+    "significance": "Delivers the exact dependency-degree input to the symmetric LLL, machine-checked and axiom-free, by an edge-covering argument that turns a two-clique overlap condition into a clean product of binomial coefficients.",
+    "relatedConcepts": [
+      "dependency graph",
+      "biUnion cardinality bound",
+      "edge covering",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "Finset.exists_subset_card_eq",
+      "Finset.card_biUnion_le_card_mul",
+      "containing_card_le"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-reduction",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 165,
+      "endLine": 202
+    },
+    "type": "theorem",
+    "title": "SymmetricLLLForRamsey & ramsey_lll_lower_bound: the hypothesis-clean reduction",
+    "content": "SymmetricLLLForRamsey is the symmetric-LLL avoidance principle stated in Ramsey form: whenever the numeric condition RamseyLLLCondition n k holds (k ≥ 3), there is a symmetric, irreflexive Bool-colouring of Kₙ's edges with no monochromatic k-clique of either colour. Kept as an explicit Prop hypothesis — not an axiom — it makes ramsey_lll_lower_bound an axiom-free conditional theorem: given hLLL : SymmetricLLLForRamsey and the feasibility condition, R(k,k) > n. The dependency degree feeding that condition is exactly the one bounded by cliqueNeighbors_card_le.",
+    "mathContext": "The symmetric LLL avoidance conclusion Pr[⋂ Āᵢ] > 0 translates, for the monochromatic-clique events, into the existence of a colouring avoiding every monochromatic k-clique — i.e. a Ramsey lower bound R(k,k) > n.",
+    "significance": "Isolates the one ingredient not yet in Mathlib (the abstract symmetric LLL) as a single labelled hypothesis, so the reduction to the Ramsey bound is fully machine-checked and axiom-free.",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "Ramsey lower bound",
+      "2-colouring",
+      "conditional theorem"
+    ],
+    "prerequisites": [
+      "symmetric irreflexive edge colourings",
+      "the LLL avoidance principle"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-monotonicity",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 204,
+      "endLine": 229
+    },
+    "type": "theorem",
+    "title": "cliqueDependencyBound_mono & RamseyLLLCondition_antitone: the threshold",
+    "content": "cliqueDependencyBound_mono shows d = C(k,2)·C(n−2,k−2) is monotone in n (via Nat.choose_le_choose). RamseyLLLCondition_antitone concludes the feasibility test is a genuine threshold: if it holds at m vertices it holds at every n ≤ m, since a larger dependency degree makes e·p·(d+1) ≤ 1 harder to satisfy. So an LLL certificate R(k,k) > m automatically certifies R(k,k) > n for all n ≤ m.",
+    "mathContext": "Monotonicity of the binomial coefficient in its upper argument gives monotonicity of the dependency degree, which propagates satisfiability of the LLL condition downward in n.",
+    "significance": "Confirms the LLL condition behaves as an honest lower-bound threshold on the number of vertices, matching the intuition that avoiding monochromatic cliques is easier on fewer vertices.",
+    "relatedConcepts": [
+      "monotonicity",
+      "binomial coefficient",
+      "threshold"
+    ],
+    "prerequisites": [
+      "Nat.choose_le_choose",
+      "monotone rational inequalities"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-integer-criterion",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 232,
+      "endLine": 272
+    },
+    "type": "theorem",
+    "title": "ramseyLLLCondition_iff & concrete witnesses: a decidable test that provably beats the first moment",
+    "content": "ramseyLLLCondition_iff clears the denominator 2^{C(k,2)} of p and the surrogate e ≤ 3 to rewrite the rational feasibility test 3·(2/2^{C(k,2)})·(d+1) ≤ 1 as the exact integer inequality 6·(d+1) ≤ 2^{C(k,2)} with d = cliqueDependencyBound n k. This yields a Decidable instance for RamseyLLLCondition, so any concrete (n,k) is settled by decide. ramseyLLLCondition_13_6 and ramseyLLLCondition_7_5 discharge two witnesses by decide: at k=6 the test holds up to n=13 (6·(C(6,2)·C(11,4)+1)=29706 ≤ 32768=2^{15}), giving R(6,6)>13 under the symmetric-LLL principle versus the first-moment R(6,6)>2^{⌊6/2⌋}=8; at k=5 it holds up to n=7 (606 ≤ 1024=2^{10}), giving R(5,5)>7 versus R(5,5)>4.",
+    "mathContext": "Reducing a rational inequality to a decidable ℕ inequality lets Lean certify specific feasibility points by kernel computation (decide, not native_decide — so no ofReduceBool axiom). The witnesses exhibit that the LLL factor is not vacuous: the certified bound strictly exceeds the Erdős first-moment bound already at small k.",
+    "significance": "Turns the abstract feasibility test into something concretely checkable and shows, with 0 axioms and 0 sorries, that the LLL improvement over the first moment is real at explicit parameters, not merely asymptotic.",
+    "relatedConcepts": [
+      "decidability",
+      "first moment method",
+      "Ramsey lower bound",
+      "kernel computation"
+    ],
+    "prerequisites": [
+      "decidable_of_iff",
+      "div_le_one",
+      "Nat.decLe"
+    ]
+  },
+  {
+    "id": "r4k-oq03-ann-lll-vs-union",
+    "proofId": "ramsey-r4k-extensions-oq-03",
+    "range": {
+      "startLine": 274,
+      "endLine": 311
+    },
+    "type": "theorem",
+    "title": "cliqueDependency_total_identity & cliqueDependencyBound_le_total: why LLL beats the union bound",
+    "content": "cliqueDependency_total_identity is the exact incidence identity C(n,2)·d = C(k,2)²·C(n,k), where d = cliqueDependencyBound n k is the LLL dependency degree and C(n,k) is the total number of monochromatic-clique bad events. It is proved by double-counting (k-clique, edge-inside-it) pairs via Mathlib's subset-of-a-subset identity Nat.choose_mul with s = 2. Equivalently d/C(n,k) = C(k,2)²/C(n,2), so the dependency degree is only a Θ(k⁴/n²) fraction of all events. cliqueDependencyBound_le_total then cancels C(n,2) > 0 to conclude d ≤ C(n,k) whenever C(k,2)² ≤ C(n,2) — i.e. once n is at least quadratic in k, which holds with vast room to spare at n ≈ 2^{k/2}.",
+    "mathContext": "The union bound must control all C(n,k) events simultaneously (E[#mono cliques] < 1), whereas the symmetric LLL only needs the local test e·p·(d+1) ≤ 1 with d the true dependency degree. The identity C(n,2)·d = C(k,2)²·C(n,k) makes precise that d is a vanishing fraction of the global event count, which is exactly the source of the Θ(k) improvement in Spencer's lower bound over Erdős's first-moment bound.",
+    "significance": "Quantifies, with 0 axioms and 0 sorries, the structural reason the LLL improves the diagonal Ramsey lower bound: locality. The dependency degree feeding the LLL test is asymptotically negligible against the total number of bad events the union bound must handle.",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "union bound",
+      "dependency degree",
+      "double counting",
+      "subset-of-a-subset identity"
+    ],
+    "prerequisites": [
+      "Nat.choose_mul",
+      "Nat.choose_pos",
+      "le_of_mul_le_mul_left"
+    ]
+  }
+]

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "ramsey-r4k-extensions-oq-03",
+  "title": "Lovász Local Lemma for Ramsey: the monochromatic-clique dependency degree",
+  "slug": "ramsey-r4k-extensions-oq-03",
+  "description": "A fully machine-checked, axiom-free formalization of the first combinatorial input to the symmetric Lovász Local Lemma (LLL) feasibility test for Spencer's improved diagonal Ramsey lower bound, together with a hypothesis-clean LLL→Ramsey reduction. The symmetric LLL condition is e·p·(d+1) ≤ 1, where p is the bad-event probability (the sibling entry ramsey-r4k-extensions-oq-03-oq-01, Key Lemma 2) and d is the dependency degree: the number of other k-cliques whose bad event 'is monochromatic' can be statistically coupled to that of a fixed clique S. Two cliques are dependent exactly when they share an edge, i.e. meet in ≥ 2 vertices. This entry supplies d — Key Lemma 3 — with no probability theory: cliqueNeighbors_card_le proves that for any fixed k-clique S the number of dependent k-cliques is at most C(k,2)·C(n−2,k−2). The proof covers the dependent cliques by the C(k,2) edges of S, and bounds the cliques through a fixed edge e by the injection T ↦ T∖e into the (k−2)-subsets of the remaining n−2 vertices (containing_card_le). The reduction ramsey_lll_lower_bound then shows that the symmetric-LLL avoidance principle — kept as an explicit Prop hypothesis, not an axiom — together with the numeric feasibility test yields a monochromatic-clique-free 2-colouring of Kₙ, i.e. R(k,k) > n. Two further parts sharpen the picture. A decidable integer form of the feasibility test — ramseyLLLCondition_iff rewrites e·p·(d+1) ≤ 1 as the exact ℕ inequality 6·(d+1) ≤ 2^{C(k,2)}, giving a Decidable instance — certifies concrete witnesses by kernel decide (not native_decide): R(6,6) > 13 and R(5,5) > 7 under the LLL principle, strictly beating the first-moment bounds R(6,6) > 8 and R(5,5) > 4. An exact dependency-to-total identity, cliqueDependency_total_identity, proves C(n,2)·d = C(k,2)²·C(n,k) by double-counting (k-clique, edge) incidences via Nat.choose_mul, so d/C(n,k) = C(k,2)²/C(n,2): the dependency degree is a Θ(k⁴/n²) fraction of all bad events, and cliqueDependencyBound_le_total concludes d ≤ C(n,k) once n is at least quadratic in k — the precise quantitative reason the local LLL test succeeds where the global union bound fails. Proved with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RamseyR4kExtensionsOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "probabilistic-method",
+      "lovasz-local-lemma",
+      "counting",
+      "dependency-graph"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 312,
+    "theoremCount": 12,
+    "definitionCount": 5,
+    "assumptions": "None counted. Every declaration depends only on the standard foundational axioms propext, Classical.choice, Quot.sound, confirmed by `#print axioms` on cliqueNeighbors_card_le, containing_card_le, ramsey_lll_lower_bound, RamseyLLLCondition_antitone and cliqueMonoProb_le_one; none of these are counted as assumptions. There are no `axiom` declarations, no structure-encoded hypotheses, no `sorry`, and no `native_decide`. The dependency-degree bound (cliqueNeighbors_card_le), the probability bounds, and the threshold monotonicity are all unconditional theorems. The Ramsey application ramsey_lll_lower_bound is a genuine conditional theorem: it takes the not-yet-in-Mathlib symmetric-LLL avoidance principle as an EXPLICIT Prop argument `hLLL : SymmetricLLLForRamsey` rather than as an axiom, so the file remains axiom-free while making the single missing ingredient fully transparent.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "|s| ≤ |t| when a function maps s into t injectively on s: bounds the k-cliques through a fixed edge e by injecting them via T ↦ T∖e into the (k−2)-subsets of the n−2 non-edge vertices",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_biUnion_le_card_mul",
+        "description": "|⋃_{i∈s} t i| ≤ |s|·m when every |t i| ≤ m: covers the dependent cliques by the C(k,2) edges of S, each carrying ≤ C(n−2,k−2) cliques",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "(s.powersetCard n).card = C(s.card, n): the C(k,2) edges of S are its 2-subsets, and the (k−2)-subsets of the n−2 remaining vertices number C(n−2,k−2)",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.exists_subset_card_eq",
+        "description": "a subset of cardinality ≥ m contains a subset of cardinality exactly m: from |S∩T| ≥ 2 extracts a shared 2-element edge e ⊆ S∩T witnessing the dependency",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sdiff_union_of_subset",
+        "description": "(s\\t) ∪ t = s when t ⊆ s: reconstructs a clique T = (T∖e) ∪ e from its edge-removed image, proving T ↦ T∖e injective on cliques containing e",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.choose_le_choose",
+        "description": "monotonicity of binomial coefficients: gives cliqueDependencyBound_mono (the dependency degree grows with n) and the k≥2 clique-probability bound",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "cliqueNeighbors: the LLL dependency neighbourhood of a fixed k-clique S — the other k-cliques whose vertex set meets S in at least two vertices, equivalently whose edge set shares an edge with S's. These are exactly the bad events dependent on 'S is monochromatic'.",
+      "containing_card_le: for a fixed 2-element edge e, at most C(n−2,k−2) k-cliques of Kₙ contain e, proved by the injection T ↦ T∖e into the (k−2)-subsets of the n−2 vertices outside e. The reusable 'cliques through a fixed edge' count.",
+      "cliqueNeighbors_card_le: the dependency-degree bound d ≤ C(k,2)·C(n−2,k−2) — Key Lemma 3 of the LLL-for-Ramsey plan — by covering the dependent cliques with the C(k,2) edges of S and applying the per-edge count. This is the fact stated but not proved in the RamseyR4kExtensions narrative.",
+      "cliqueMonoProb, cliqueDependencyBound, RamseyLLLCondition: the p, d and the numeric feasibility test e·p·(d+1) ≤ 1 (with the rational surrogate e ≤ 3 shared with the gallery's other LLL files) assembled into one applicability predicate for the diagonal-Ramsey bad events.",
+      "SymmetricLLLForRamsey / ramsey_lll_lower_bound: the hypothesis-clean reduction — assuming the symmetric-LLL avoidance principle as an explicit Prop, the numeric condition yields a monochromatic-K_k-free 2-colouring of Kₙ, i.e. R(k,k) > n. No axiom, no sorry: the one missing ingredient is a labelled hypothesis.",
+      "RamseyLLLCondition_antitone and cliqueDependencyBound_mono: the feasibility test is a genuine threshold — if it holds at m vertices it holds at every n ≤ m, since more vertices means a larger dependency degree."
+    ],
+    "dateAdded": "2026-07-03",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "The symmetric Lovász Local Lemma and its feasibility condition e·p·(d+1) ≤ 1",
+      "Diagonal Ramsey numbers R(k,k) and monochromatic cliques under random 2-colourings",
+      "Finite counting in Lean 4 Mathlib (Finset.powersetCard, injective and biUnion cardinality bounds, binomial coefficients)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász 1975) underlies the strongest elementary lower bounds for diagonal Ramsey numbers. Spencer (1975) used it to improve Erdős's 1947 bound R(k,k) > 2^(k/2) by a factor of Θ(k), obtaining R(k,k) ≳ k·2^(k/2)/e. The symmetric LLL applies when each bad event has probability at most p and depends on at most d others, provided e·p·(d+1) ≤ 1. For the Ramsey application the bad events are 'the k-clique on vertex set S is monochromatic', and the feasibility test needs two quantities: the per-event probability p (formalized in the sibling entry) and the dependency degree d. This entry formalizes d and the reduction that turns the numeric test into a Ramsey lower bound.",
+    "problemStatement": "The parent problem ramsey-r4k-extensions-oq-03 asks to formalize the symmetric LLL and apply it to Ramsey lower bounds, replacing the axiom erdos_probabilistic_lower_bound / spencer_diagonal_lower_bound in Proofs/RamseyR4kExtensions.lean. The full measure-theoretic LLL is a large undertaking not yet in Mathlib; the plan decomposes the Ramsey-specific input into reusable, purely combinatorial ingredients. The sibling entry supplies Key Lemma 2, the bad-event probability p = 2^(1−C(k,2)). This entry supplies Key Lemma 3, the dependency-degree bound d ≤ C(k,2)·C(n−2,k−2), and a hypothesis-clean reduction from the symmetric-LLL avoidance principle to the Ramsey lower bound R(k,k) > n.",
+    "proofStrategy": "Two monochromatic-clique bad events are statistically dependent exactly when the cliques share an edge, i.e. their vertex sets meet in ≥ 2 vertices; cliqueNeighbors S k collects these dependent cliques. To bound their number, every dependent clique T shares some 2-element edge e ⊆ S∩T (Finset.exists_subset_card_eq), so cliqueNeighbors S k is contained in the biUnion over the C(k,2) edges e of S of the k-cliques containing e. The per-edge count containing_card_le bounds the k-cliques through a fixed edge e by C(n−2,k−2): the map T ↦ T∖e sends such a clique to a (k−2)-subset of the n−2 vertices outside e, and it is injective because T = (T∖e) ∪ e is recoverable (Finset.sdiff_union_of_subset). Combining via Finset.card_biUnion_le_card_mul gives d ≤ C(k,2)·C(n−2,k−2). The reduction ramsey_lll_lower_bound is then definitional: SymmetricLLLForRamsey is stated as the exact avoidance conclusion (a symmetric, irreflexive Bool-colouring with no monochromatic k-clique of either colour) under the numeric condition, kept as an explicit Prop hypothesis so the theorem is axiom-free.",
+    "keyInsights": [
+      "The LLL dependency structure of the monochromatic-clique events is purely combinatorial: clique S's bad event is independent of clique T's precisely when S and T share no edge, i.e. |S∩T| ≤ 1. So the dependency degree is a finite counting problem about overlapping cliques, with no reference to the underlying probability space.",
+      "Counting the dependent cliques factors through edges: each dependent T contributes a shared edge e ⊆ S∩T, and there are only C(k,2) candidate edges in S. This edge-covering is what turns a two-clique overlap condition into the clean product bound C(k,2)·C(n−2,k−2).",
+      "The cliques through a fixed edge e are counted by 'forgetting' the edge: T ↦ T∖e is injective (the edge can be added back) and lands in the (k−2)-subsets of the n−2 non-edge vertices, so there are at most C(n−2,k−2) of them.",
+      "Keeping the symmetric-LLL avoidance principle as an explicit Prop hypothesis (SymmetricLLLForRamsey), rather than an axiom, makes the reduction ramsey_lll_lower_bound a genuine axiom-free theorem while pinpointing the single ingredient still missing from Mathlib.",
+      "The feasibility test is a monotone threshold in n: cliqueDependencyBound_mono shows d grows with the number of vertices, so RamseyLLLCondition_antitone propagates satisfiability downward — if the LLL certifies R(k,k) > m it certifies R(k,k) > n for every n ≤ m."
+    ],
+    "prerequisites": [
+      "The Lovász Local Lemma (symmetric form) and its feasibility condition e·p·(d+1) ≤ 1",
+      "Diagonal Ramsey numbers and random 2-colourings of complete graphs",
+      "Binomial coefficients, injective-image and biUnion cardinality bounds in Lean 4 Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lll-parameters",
+      "title": "The LLL parameters p, d and the feasibility test",
+      "startLine": 42,
+      "endLine": 81,
+      "summary": "cliqueMonoProb k = 2/2^C(k,2) is the bad-event probability p; cliqueDependencyBound n k = C(k,2)·C(n−2,k−2) is the dependency degree d; RamseyLLLCondition n k packages the symmetric-LLL test e·p·(d+1) ≤ 1 with the rational surrogate e ≤ 3. cliqueMonoProb_pos and cliqueMonoProb_le_one bound p in (0,1] for k ≥ 2."
+    },
+    {
+      "id": "dependency-degree",
+      "title": "The dependency-degree bound (axiom-free combinatorics)",
+      "startLine": 83,
+      "endLine": 163,
+      "summary": "cliqueNeighbors S k is the set of other k-cliques meeting S in ≥ 2 vertices. containing_card_le bounds the k-cliques through a fixed edge e by C(n−2,k−2) via the injection T ↦ T∖e. cliqueNeighbors_card_le covers cliqueNeighbors by the C(k,2) edges of S (each dependent clique shares an edge) and applies card_biUnion_le_card_mul to obtain d ≤ C(k,2)·C(n−2,k−2) — Key Lemma 3."
+    },
+    {
+      "id": "lll-reduction",
+      "title": "The symmetric-LLL → Ramsey reduction (hypothesis-clean)",
+      "startLine": 165,
+      "endLine": 202,
+      "summary": "SymmetricLLLForRamsey states the avoidance conclusion — a symmetric, irreflexive Bool-colouring of Kₙ with no monochromatic k-clique of either colour — under the numeric feasibility condition, kept as an explicit Prop hypothesis. ramsey_lll_lower_bound then derives R(k,k) > n from it whenever RamseyLLLCondition n k holds, with 0 axioms and 0 sorries."
+    },
+    {
+      "id": "threshold-monotonicity",
+      "title": "Monotonicity of the LLL threshold",
+      "startLine": 204,
+      "endLine": 231,
+      "summary": "cliqueDependencyBound_mono shows the dependency degree is monotone in the number of vertices, and RamseyLLLCondition_antitone concludes the feasibility test is a genuine threshold: holding at m vertices implies holding at every n ≤ m."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Key Lemma 3 of the LLL-for-Ramsey plan — the dependency degree d ≤ C(k,2)·C(n−2,k−2) of the monochromatic-clique bad events — entirely by finite counting, with 0 axioms and 0 sorries, and packages it with the bad-event probability and the feasibility test into a hypothesis-clean reduction ramsey_lll_lower_bound from the symmetric-LLL avoidance principle to the Ramsey lower bound R(k,k) > n.",
+    "implications": "Together with the sibling entry's bad-event probability p (Key Lemma 2), the dependency degree d is the complete Ramsey-specific input to the symmetric LLL feasibility test e·p·(d+1) ≤ 1; both are now machine-checked, axiom-free counting statements independent of the (not-yet-formalized) measure-theoretic LLL machinery. The reduction isolates the one remaining ingredient — the abstract symmetric LLL itself — as a single explicit, clearly-labelled hypothesis.",
+    "openQuestions": "Formalizing the symmetric Lovász Local Lemma proper (the conditional-probability induction over dependency graphs; see the sibling problem lovasz-local-lemma-oq-01 for the induction-step engine) in Mathlib, discharging the SymmetricLLLForRamsey hypothesis, and combining it with Key Lemmas 2 and 3 to replace the axiom erdos_probabilistic_lower_bound / spencer_diagonal_lower_bound in Proofs/RamseyR4kExtensions.lean with a proved theorem."
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul; Lovász, László",
+      "title": "Problems and results on 3-chromatic hypergraphs and some related questions",
+      "year": "1975",
+      "note": "Infinite and Finite Sets (Colloq. Math. Soc. János Bolyai 10), 609–627. Introduces the Lovász Local Lemma."
+    },
+    {
+      "authors": "Spencer, Joel",
+      "title": "Ramsey's theorem — a new lower bound",
+      "year": "1975",
+      "note": "Journal of Combinatorial Theory A 18, 108–115. Applies the LLL to improve the diagonal Ramsey lower bound by a factor of Θ(k); the dependency-degree estimate C(k,2)·C(n−2,k−2) formalized here is the combinatorial input."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "4th ed., Wiley. Chapter 5 develops the symmetric LLL and the monochromatic-clique dependency and probability estimates formalized here and in the sibling entry."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "ramsey-r4k-extensions-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Key Lemma 2, the bad-event probability p = 2^(1−C(k,2)); this entry supplies the complementary Key Lemma 3, the dependency degree d ≤ C(k,2)·C(n−2,k−2), and the reduction assembling both into the LLL feasibility test"
+    },
+    {
+      "targetId": "ramsey-r4k-extensions",
+      "relationship": "parent",
+      "description": "States the probabilistic Ramsey lower bound as an `axiom`; this entry formalizes one of the two combinatorial inputs (d) to the LLL feasibility test used to discharge it, plus the hypothesis-clean reduction to R(k,k) > n"
+    },
+    {
+      "targetId": "ramsey-r4k-extensions-oq-01",
+      "relationship": "related",
+      "description": "Formalizes Erdős's union-bound lower bound R(k,k) > 2^⌊k/2⌋; the LLL improves on it precisely by replacing that union bound with the dependency-aware feasibility test whose dependency degree d is bounded here"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/RamseyR4kExtensionsOQ03.lean",
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 5,
+    "lineCount": 312,
+    "sorries": 0
+  }
+}

--- a/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
+++ b/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
@@ -36,12 +36,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: shipped the axiom-free combinatorial core of the LLL→Ramsey application in RamseyR4kExtensionsOQ03.lean — the dependency-degree count (previously only asserted in the RamseyR4kExtensions narrative) is now a proved theorem, together with a hypothesis-clean reduction from the symmetric LLL avoidance principle to the improved diagonal bound R(k,k)>n. 0 sorries, 0 axioms.",
+    "progressSummary": "PROGRESS: RamseyR4kExtensionsOQ03.lean now quantifies WHY the LLL beats the union bound (PART VI, researcher-4): exact identity C(n,2)·d=C(k,2)²·C(n,k) via Nat.choose_mul and its corollary d≤C(n,k) in the Ramsey regime. Complements the decidable integer criterion + concrete R(6,6)>13 / R(5,5)>7 witnesses (PART V). Still 0 sorries, 0 axioms; builds under Mathlib 4.26. The single remaining gap is the measure-theoretic step in SymmetricLLLForRamsey (positive avoidance probability ⇒ existence), tracked in sibling lovasz-local-lemma-oq-01.",
     "builtItems": [
       "RamseyR4kExtensionsOQ03.lean (231 lines, 7 thms, 5 defs, 0 sorry, 0 axiom): cliqueMonoProb, cliqueDependencyBound, RamseyLLLCondition; PROVED cliqueNeighbors_card_le (dependency degree ≤ C(k,2)·C(n-2,k-2) via covering by the C(k,2) pairs of S, each in ≤ C(n-2,k-2) k-cliques — containing_card_le by the injection T↦T\\e); SymmetricLLLForRamsey principle + ramsey_lll_lower_bound reduction; RamseyLLLCondition_antitone (threshold monotone in n); cliqueMonoProb_pos/le_one.",
       "RamseyR4kExtensions.lean: converted `axiom erdos_probabilistic_lower_bound` into a proved `theorem`, discharged by `ErdosRamsey.erdos_probabilistic_lower_bound k hk` (defeq statements); added `import Proofs.ErdosRamseyLowerBound`. File axiomCount 15→14.",
       "REPAIR: the file did not compile on the pinned Mathlib (v4.26.0). Fixed 3 pre-existing breakages: (1) `positivity` could not prove `0 ≤ (4-ε)/4` from `ε<4` → `div_nonneg (by linarith) (by norm_num)` (~L1056); (2) `div_lt_div_iff` renamed → `div_lt_div_iff₀` (~L1069); (3) `ramsey_symmetric'` referenced an undefined `ramsey_symmetry` → reproved via zero case-split + existing `ramseyUpperBound_symm` (~L1127).",
-      "Updated gallery meta (ramsey-r4k-extensions): axiomCount 15→14, theoremCount 74→75, lineCount→1154, assumptions/summary/openQuestions revised to reflect the de-axiomatization."
+      "Updated gallery meta (ramsey-r4k-extensions): axiomCount 15→14, theoremCount 74→75, lineCount→1154, assumptions/summary/openQuestions revised to reflect the de-axiomatization.",
+      "cliqueDependency_total_identity in Proofs/RamseyR4kExtensionsOQ03.lean (PART VI) — C(n,2)·cliqueDependencyBound n k = C(k,2)²·C(n,k), 2≤k; axiom-free, builds under Mathlib 4.26",
+      "cliqueDependencyBound_le_total in Proofs/RamseyR4kExtensionsOQ03.lean (PART VI) — d ≤ C(n,k) when C(k,2)²≤C(n,2); axiom-free"
     ],
     "insights": [
       "The dependency-degree bound C(k,2)·C(n-2,k-2) — stated but unproved in the RamseyR4kExtensions prose (its line ~549) — is a clean covering count: neighbours of S are covered by the C(k,2) pairs e⊆S, and each pair lies in ≤ C(n-2,k-2) k-cliques via the injection T↦T\\e into (k-2)-subsets of the other n-2 vertices. Fully axiom-free with card_biUnion_le_card_mul + card_le_card_of_injOn + card_powersetCard.",
@@ -50,7 +52,9 @@
       "The `erdos_probabilistic_lower_bound` axiom targeted by this OQ is actually a first-moment (union-bound) result, not an LLL result — LLL only strengthens the constant. The measurable deliverable of the OQ (replace the axiom with a proved statement) is therefore achievable via the already-existing axiom-free first-moment proof in ErdosRamseyLowerBound.lean.",
       "That first-moment proof (ErdosRamsey.erdos_probabilistic_lower_bound) states EXACTLY the axiom's proposition (k ≥ 3 vs 3 ≤ k are defeq), so the axiom collapses to a one-line re-export with no restatement or reproof.",
       "No import cycle: ErdosRamseyLowerBound imports Mathlib only; RamseyR4kExtensions can import it cleanly.",
-      "The genuine LLL contribution (formalizing the symmetric LLL and getting the extra factor of k) remains open and is a substantially harder, multi-session BUILD."
+      "The genuine LLL contribution (formalizing the symmetric LLL and getting the extra factor of k) remains open and is a substantially harder, multi-session BUILD.",
+      "PART VI (researcher-4): exact dependency-to-total identity C(n,2)·d = C(k,2)²·C(n,k) via Nat.choose_mul (subset-of-a-subset, s=2). Equivalently d/C(n,k)=C(k,2)²/C(n,2) — the LLL dependency degree is a Θ(k⁴/n²) fraction of all bad events; the exact quantitative reason the LOCAL LLL test beats the GLOBAL union bound. cliqueDependency_total_identity, axiom-free (propext/Classical.choice/Quot.sound).",
+      "Corollary cliqueDependencyBound_le_total (researcher-4): d ≤ C(n,k) once C(k,2)²≤C(n,2) (n at least quadratic in k; vast room at n≈2^{k/2}). Proof cancels C(n,2)>0 via le_of_mul_le_mul_left + gcongr on the identity."
     ],
     "mathlibGaps": [
       "Mathlib has no symmetric/general Lovász Local Lemma.",


### PR DESCRIPTION
## Summary
Research session for **ramsey-r4k-extensions-oq-03** (RICH). Adds **PART VI** to
`RamseyR4kExtensionsOQ03.lean`, on top of the existing PART V (decidable integer
criterion + concrete `R(6,6)>13` / `R(5,5)>7` witnesses already on `main`), and
ships the gallery entry for this problem (which was not yet on `main`).

## Progress
- **`cliqueDependency_total_identity`** (`2 ≤ k`): exact incidence identity
  `C(n,2)·d = C(k,2)²·C(n,k)`, proved by double-counting `(k-clique, edge)` pairs
  via the subset-of-a-subset identity `Nat.choose_mul (s := 2)`. Equivalently
  `d/C(n,k) = C(k,2)²/C(n,2)`.
- **`cliqueDependencyBound_le_total`** (`2 ≤ k`, `2 ≤ n`, `C(k,2)² ≤ C(n,2)`):
  `d ≤ C(n,k)`.
- Both **axiom-free** — `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
- Full file **builds clean** under Mathlib 4.26 (`docker-build.sh`, 7744 jobs).
  0 sorries, 0 axioms, no `native_decide`.
- New gallery entry `src/data/proofs/ramsey-r4k-extensions-oq-03/` (meta.json +
  annotations.json; `verified` / `original`; theoremCount 12, lineCount 312),
  annotations covering all six parts. Research problem knowledge updated.

## Findings
The identity `C(n,2)·d = C(k,2)²·C(n,k)` makes precise that the LLL dependency
degree `d` is only a `Θ(k⁴/n²)` fraction of the total number of bad events — the
exact quantitative reason the symmetric LLL's *local* condition `e·p·(d+1) ≤ 1`
is satisfiable for larger `n` than the *global* union-bound condition. This is the
structural source of Spencer's `Θ(k)` improvement over the Erdős first-moment
bound.

## Status
**Outcome**: progress (SOLVED reduction sharpened; unconditional combinatorial
core fully discharged). The single remaining ingredient is the measure-theoretic
step inside `SymmetricLLLForRamsey` (positive avoidance probability ⇒ existence),
which is genuinely open and tracked in sibling `lovasz-local-lemma-oq-01`.

**Note on overlap**: PR #33858 (deletion-method, BUILD-PENDING) also touches
`RamseyR4kExtensionsOQ03.lean` and the research JSON; this PR appends at the end
of the file and adds the previously-missing gallery entry, so the two are
mathematically complementary.

🤖 Generated by researcher-4