### PR TITLE
Goldbach comet: prove φ(m) ≤ m − m/p (totient ceiling dominates single-prime sieve)

### DIFF
--- a/proofs/Proofs/StrongGoldbachSymmetric.lean
+++ b/proofs/Proofs/StrongGoldbachSymmetric.lean
@@ -673,6 +673,48 @@ example : symmetricPairCount 15 ≤ Nat.totient 15 :=
 -- removing the multiples of `3` alone.
 example : Nat.totient 15 < 15 - 15 / 3 := by decide
 
+/-- **The totient ceiling dominates every single-prime sieve ceiling.**  For any prime
+`p ∣ m`,
+
+    φ(m) ≤ m − m / p.
+
+Every totative of `m` is coprime to `m`, hence — since `p ∣ m` — not divisible by `p`;
+so the `φ(m)` totatives inject into the `m − m / p` residues of `[0, m)` that are not
+multiples of `p` (counted by `card_range_filter_dvd`).  Combined with
+`symmetricPairCount_le_totient_of_not_prime` this proves *in general* what the numeric
+`example` above only checks at `m = 15`: the full-totient ceiling
+`symmetricPairCount_le_totient_of_not_prime` is at least as sharp as the single-prime
+ceiling `symmetricPairCount_le_sub_div` for **every** prime factor `p` of `m`.  (This is
+the Lean form of `φ(m) = m · ∏_{q ∣ m}(1 − 1/q) ≤ m · (1 − 1/p) = m − m/p`, but proved
+directly by the coprime-avoids-multiples inclusion rather than via the product formula.) -/
+theorem totient_le_sub_div {m p : ℕ} (hp : Nat.Prime p) (hpm : p ∣ m) :
+    Nat.totient m ≤ m - m / p := by
+  rw [Nat.totient_eq_card_coprime]
+  -- A totative of `m` is coprime to `m`, hence not divisible by the factor `p`.
+  have hsub : ((Finset.range m).filter (fun k => m.Coprime k))
+      ⊆ (Finset.range m).filter (fun k => ¬ p ∣ k) := by
+    intro k hk
+    simp only [Finset.mem_filter, Finset.mem_range] at hk ⊢
+    obtain ⟨hkm, hcop⟩ := hk
+    refine ⟨hkm, fun hpk => ?_⟩
+    have hcop' : Nat.gcd m k = 1 := hcop
+    have hd : p ∣ 1 := by rw [← hcop']; exact Nat.dvd_gcd hpm hpk
+    have hle := Nat.le_of_dvd Nat.one_pos hd
+    have := hp.two_le
+    omega
+  refine (Finset.card_le_card hsub).trans ?_
+  -- The non-multiples of `p` in `[0, m)` number `m − m / p`.
+  have hsplit : ((Finset.range m).filter (fun k => p ∣ k)).card
+      + ((Finset.range m).filter (fun k => ¬ p ∣ k)).card
+      = (Finset.range m).card :=
+    Finset.filter_card_add_filter_neg_card_eq_card _
+  rw [Finset.card_range] at hsplit
+  have hcount := card_range_filter_dvd hp.pos hpm
+  omega
+
+-- The general dominance, at `m = 15, p = 3`: `φ(15) = 8 ≤ 10 = 15 − 15/3`.
+example : Nat.totient 15 ≤ 15 - 15 / 3 := totient_le_sub_div (p := 3) (by decide) (by decide)
+
 /-! ## Sharper Ceiling at Odd Midpoints: Half the Totient
 
 For an **odd** midpoint `m` the two independent structural constraints on a

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -291,3 +291,34 @@ offset odd, so the parity constraint is redundant and `φ(m)` is the right count
 conjecture); a nontrivial LOWER bound remains the real advance. This is a genuine
 structural sharpening (new even-totative-involution mechanism), not axiom scaffolding —
 the file is 0-axiom / 0-sorry. Build via `docker-build.sh Proofs.StrongGoldbachSymmetric`.
+
+## Session 2026-07-03 (researcher-4) — Prove the totient-dominates-sieve inequality φ(m) ≤ m−m/p (CONSOLIDATION, PROGRESS)
+
+**Mode**: REVISIT (0-axiom file `StrongGoldbachSymmetric.lean`). **Outcome**: 1 new verified
+theorem, build passes (3058 jobs, ✔), 0-axiom.
+
+The file's totient-ceiling section asserted in prose (and only ever *example*-checked, line
+674: `example : Nat.totient 15 < 15 - 15/3 := by decide`) that the full-totient ceiling
+`symmetricPairCount_le_totient_of_not_prime` **dominates** every single-prime sieve ceiling
+`symmetricPairCount_le_sub_div`, justifying it by `φ(m) = m·∏_{q∣m}(1−1/q) ≤ m·(1−1/p) = m−m/p`.
+Upgraded that asserted-but-unproven dominance to a **general theorem**:
+
+- **`totient_le_sub_div`** (`p.Prime`, `p ∣ m`): `Nat.totient m ≤ m − m/p`. Proof avoids the
+  product formula entirely: every totative of `m` is coprime to `m`, hence (as `p ∣ m`) not
+  divisible by `p`, so the `φ(m)` totatives `⊆ {k<m : ¬p∣k}`; that non-multiple set has size
+  `m − m/p` via the file's own **`card_range_filter_dvd`** + `filter_card_add_filter_neg_card_eq_card`,
+  and `Finset.card_le_card` + `omega` close it. The coprime⇒¬p∣k step: `Nat.dvd_gcd hpm hpk`
+  gives `p ∣ gcd m k = 1` (rewrite via `hcop : Nat.gcd m k = 1`, from `m.Coprime k` by defeq),
+  contradiction by `Nat.le_of_dvd` + `hp.two_le`/`omega`.
+
+**Why this is not scaffolding.** It adds no new comet bound; it *proves the ordering* the file
+already claimed between two existing ceilings, replacing a single numeric `example` with the
+general fact. `φ(m) ≤ m−m/p` is also a clean standalone `Nat.totient` inequality (plausibly
+Mathlib-worthy). Kernel-checked, pure tactics (no `decide`/`native_decide`/`sorry`/`axiom`), so
+`#print axioms` stays `propext, Classical.choice, Quot.sound`.
+
+**Honest status (unchanged).** Everything here is still on the UPPER-bound side of the Goldbach
+comet; the open conjecture is untouched and a nontrivial LOWER bound remains the real advance.
+The one large axiom-discharging target is still `schnirelmann_basis_theorem` (~300–500 LOC,
+elementary, flagged Mathlib gap). Worked in locked `/private/tmp/wt-r4-goldbach`, committed
+before building (the `.loom/worktrees/researcher-4` deletion hazard did not recur this pass).


### PR DESCRIPTION
## Summary

`StrongGoldbachSymmetric.lean` (the 0-axiom "Goldbach comet" reformulation) contains a
sequence of upper-bound ceilings on the comet height `symmetricPairCount m`. Its totient
section asserts — in prose, and only ever *example*-checks at `m = 15` — that the
full-totient ceiling `symmetricPairCount_le_totient_of_not_prime` **dominates** every
single-prime sieve ceiling `symmetricPairCount_le_sub_div`, because
`φ(m) = m·∏_{q∣m}(1 − 1/q) ≤ m·(1 − 1/p) = m − m/p`.

This PR upgrades that asserted-but-unproven dominance to a **general theorem**:

```lean
theorem totient_le_sub_div {m p : ℕ} (hp : Nat.Prime p) (hpm : p ∣ m) :
    Nat.totient m ≤ m - m / p
```

## Proof

No product formula: every totative of `m` is coprime to `m`, hence — since `p ∣ m` — not
divisible by `p`. So the `φ(m)` totatives inject into `{k < m : ¬ p ∣ k}`, whose size is
`m − m/p` by the file's own `card_range_filter_dvd` plus
`filter_card_add_filter_neg_card_eq_card`; `Finset.card_le_card` + `omega` finish.

## Why this is not scaffolding

It adds no new comet bound and does **not** touch the open conjecture. It *proves the
ordering the file already claimed* between two existing ceilings, replacing a single
numeric `example` (`φ(15) < 15 − 15/3 by decide`) with the general fact. `φ(m) ≤ m − m/p`
is also a clean standalone `Nat.totient` inequality.

## Verification

- `docker-build.sh Proofs.StrongGoldbachSymmetric` → ✔ Built (3058 jobs, exit 0).
- Pure tactics only (`rw`, `simp only`, `omega`, `Nat.le_of_dvd`, `Finset.card_le_card`,
  `card_range_filter_dvd`, `Nat.dvd_gcd`); no `decide`/`native_decide`/`sorry`/`axiom`.
  Axiom footprint stays `propext, Classical.choice, Quot.sound`. File remains 0-axiom / 0-sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)