### PR TITLE
LLN/M–Z S4a: Kolmogorov convergence criterion from a variance-sum bound

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -404,6 +404,100 @@ theorem ae_tendsto_sum_of_indep_of_eLpNorm_bdd [IsProbabilityMeasure μ]
     simp only [Finset.sum_apply]
   exact (tendsto_add_atTop_iff_nat 1).mp hc'
 
+/-! ## S4a — discharging the `L¹` bound from a variance-sum bound
+
+The convergence engine `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` requires a uniform
+`L¹` bound `hbdd` on the partial sums.  On a probability space this is exactly what a
+bound on the variance sums `∑ Var(Xᵢ)` provides, via `‖·‖₁ ≤ ‖·‖₂` and the
+orthogonality identity `Var(∑ Xᵢ) = ∑ Var(Xᵢ)` for independent variables.  The one
+missing link is the mean-zero bridge `‖X‖₂² = eVar[X]` (Mathlib has `evariance` and
+`eLpNorm` but no lemma connecting them), supplied here. -/
+
+/-- **`L²` seminorm squared equals the extended variance, for a mean-zero variable.**
+For `X` with `𝔼[X] = 0`,
+
+    eLpNorm X 2 μ ^ 2 = evariance X μ.
+
+Mathlib defines `evariance X μ = ∫⁻ ‖X - 𝔼[X]‖ₑ²` and `eLpNorm X 2 μ` separately with no
+bridge between them; when `𝔼[X] = 0` the centering is trivial and the two coincide after
+the standard `(∫⁻ ‖X‖ₑ²)^{1/2}` unfolding of the `L²` seminorm.  This is the crux that
+turns a variance bound into the `L¹` hypothesis of the Kolmogorov engine. -/
+theorem eLpNorm_two_sq_eq_evariance {X : Ω → ℝ} (h0 : μ[X] = 0) :
+    eLpNorm X 2 μ ^ 2 = evariance X μ := by
+  rw [eLpNorm_eq_lintegral_rpow_enorm (by norm_num) (by norm_num), evariance]
+  simp only [h0, sub_zero, ENNReal.toReal_ofNat]
+  rw [← ENNReal.rpow_natCast ((∫⁻ x, ‖X x‖ₑ ^ (2 : ℝ) ∂μ) ^ (1 / (2 : ℝ))) 2,
+    ← ENNReal.rpow_mul, show (1 / (2 : ℝ)) * ((2 : ℕ) : ℝ) = 1 by norm_num, ENNReal.rpow_one]
+  simp_rw [ENNReal.rpow_two]
+
+/-- **Uniform `L²` bound on the partial sums from a variance-sum bound.**  For
+independent mean-zero `L²` variables `X i` with `∑_{i≤n} Var(Xᵢ) ≤ V` for all `n`,
+every shifted partial sum satisfies
+
+    eLpNorm (∑_{i≤n} Xᵢ) 2 μ ≤ ENNReal.ofReal (√V).
+
+Proof: `‖Sₙ‖₂² = eVar[Sₙ] = ofReal(Var Sₙ) = ofReal(∑_{i≤n} Var Xᵢ) ≤ ofReal V` using the
+mean-zero bridge `eLpNorm_two_sq_eq_evariance`, `ofReal_variance`, and the independence
+orthogonality identity `IndepFun.variance_sum`; then take square roots by the monotone
+`ℝ≥0∞`-power `·^{1/2}`. -/
+theorem eLpNorm_two_partialSum_le [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) (hindep : iIndepFun X μ) (hmemLp : ∀ i, MemLp (X i) 2 μ)
+    (hmean : ∀ i, μ[X i] = 0) (V : ℝ)
+    (hV : ∀ n, ∑ i ∈ range (n + 1), variance (X i) μ ≤ V) (n : ℕ) :
+    eLpNorm (fun ω => ∑ i ∈ range (n + 1), X i ω) 2 μ ≤ ENNReal.ofReal (Real.sqrt V) := by
+  have hint : ∀ i, Integrable (X i) μ := fun i => (hmemLp i).integrable one_le_two
+  have hSpt : (fun ω => ∑ i ∈ range (n + 1), X i ω) = ∑ i ∈ range (n + 1), X i := by
+    funext ω; simp only [Finset.sum_apply]
+  rw [hSpt]
+  set S : Ω → ℝ := ∑ i ∈ range (n + 1), X i with hSdef
+  have hSmemLp : MemLp S 2 μ := memLp_finset_sum' _ (fun i _ => hmemLp i)
+  have hSmean : μ[S] = 0 := by
+    rw [hSdef, integral_finset_sum _ (fun i _ => hint i)]
+    simp only [hmean, Finset.sum_const_zero]
+  have hpair : Set.Pairwise (↑(range (n + 1)) : Set ℕ)
+      (fun i j => IndepFun (X i) (X j) μ) := fun i _ j _ hij => hindep.indepFun hij
+  have hvar : variance S μ = ∑ i ∈ range (n + 1), variance (X i) μ := by
+    rw [hSdef]; exact IndepFun.variance_sum (fun i _ => hmemLp i) hpair
+  have hV0 : 0 ≤ V := le_trans (variance_nonneg (X 0) μ) (by simpa using hV 0)
+  have hsq : eLpNorm S 2 μ ^ 2 ≤ ENNReal.ofReal V := by
+    rw [eLpNorm_two_sq_eq_evariance hSmean, ← ofReal_variance hSmemLp, hvar]
+    exact ENNReal.ofReal_le_ofReal (hV n)
+  have hmono := ENNReal.rpow_le_rpow hsq (by norm_num : (0 : ℝ) ≤ 1 / 2)
+  rw [← ENNReal.rpow_natCast (eLpNorm S 2 μ) 2, ← ENNReal.rpow_mul,
+    show ((2 : ℕ) : ℝ) * (1 / (2 : ℝ)) = 1 by norm_num, ENNReal.rpow_one] at hmono
+  rwa [← ENNReal.ofReal_rpow_of_nonneg hV0 (by norm_num), ← Real.sqrt_eq_rpow] at hmono
+
+/-- **Kolmogorov's a.s.-convergence criterion (variance-sum form).**  For independent
+mean-zero `L²` random variables `X i` whose variance partial sums are uniformly bounded,
+`∑_{i≤n} Var(Xᵢ) ≤ V`, the series `∑ i, X i` converges almost surely.
+
+This discharges the deterministic `L¹` hypothesis `hbdd` of
+`ae_tendsto_sum_of_indep_of_eLpNorm_bdd` from the variance-sum bound, via
+`eLpNorm_two_partialSum_le` and `‖·‖₁ ≤ ‖·‖₂` on a probability space
+(`eLpNorm_le_eLpNorm_of_exponent_le`).  It is the clean statement of Kolmogorov's
+convergence theorem; composing it with the a.e. Kronecker lift
+`ae_tendsto_kronecker_average_zero` gives the normalisation step of the
+Marcinkiewicz–Zygmund strong law. -/
+theorem ae_tendsto_sum_of_indep_of_variance_bdd [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) (hmeas : ∀ i, StronglyMeasurable (X i))
+    (hindep : iIndepFun X μ) (hmemLp : ∀ i, MemLp (X i) 2 μ)
+    (hmean : ∀ i, μ[X i] = 0) (V : ℝ)
+    (hV : ∀ n, ∑ i ∈ range (n + 1), variance (X i) μ ≤ V) :
+    ∀ᵐ ω ∂μ, ∃ c : ℝ, Tendsto (fun n => ∑ i ∈ range n, X i ω) atTop (𝓝 c) := by
+  have hint : ∀ i, Integrable (X i) μ := fun i => (hmemLp i).integrable one_le_two
+  refine ae_tendsto_sum_of_indep_of_eLpNorm_bdd X hmeas hindep hint hmean
+    (Real.sqrt V).toNNReal (fun n => ?_)
+  have hasm : AEStronglyMeasurable (fun ω => ∑ i ∈ range (n + 1), X i ω) μ := by
+    have hEq : (fun ω => ∑ i ∈ range (n + 1), X i ω) = ∑ i ∈ range (n + 1), X i := by
+      funext ω; simp only [Finset.sum_apply]
+    rw [hEq]; exact (memLp_finset_sum' _ (fun i _ => hmemLp i)).aestronglyMeasurable
+  have h12 : eLpNorm (fun ω => ∑ i ∈ range (n + 1), X i ω) 1 μ
+      ≤ eLpNorm (fun ω => ∑ i ∈ range (n + 1), X i ω) 2 μ :=
+    eLpNorm_le_eLpNorm_of_exponent_le (by norm_num) hasm
+  have hcoe : ((Real.sqrt V).toNNReal : ℝ≥0∞) = ENNReal.ofReal (Real.sqrt V) := rfl
+  rw [hcoe]
+  exact h12.trans (eLpNorm_two_partialSum_le X hindep hmemLp hmean V hV n)
+
 end Kolmogorov
 
 end LawsOfLargeNumbers.MZ

--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -452,8 +452,10 @@ theorem eLpNorm_two_partialSum_le [IsProbabilityMeasure μ]
   set S : Ω → ℝ := ∑ i ∈ range (n + 1), X i with hSdef
   have hSmemLp : MemLp S 2 μ := memLp_finset_sum' _ (fun i _ => hmemLp i)
   have hSmean : μ[S] = 0 := by
-    rw [hSdef, integral_finset_sum _ (fun i _ => hint i)]
-    simp only [hmean, Finset.sum_const_zero]
+    have h1 : μ[S] = ∑ i ∈ range (n + 1), μ[X i] := by
+      simp_rw [hSdef, Finset.sum_apply]
+      exact integral_finset_sum _ (fun i _ => hint i)
+    rw [h1]; simp only [hmean, Finset.sum_const_zero]
   have hpair : Set.Pairwise (↑(range (n + 1)) : Set ℕ)
       (fun i j => IndepFun (X i) (X j) μ) := fun i _ j _ hij => hindep.indepFun hij
   have hvar : variance S μ = ∑ i ∈ range (n + 1), variance (X i) μ := by
@@ -465,7 +467,10 @@ theorem eLpNorm_two_partialSum_le [IsProbabilityMeasure μ]
   have hmono := ENNReal.rpow_le_rpow hsq (by norm_num : (0 : ℝ) ≤ 1 / 2)
   rw [← ENNReal.rpow_natCast (eLpNorm S 2 μ) 2, ← ENNReal.rpow_mul,
     show ((2 : ℕ) : ℝ) * (1 / (2 : ℝ)) = 1 by norm_num, ENNReal.rpow_one] at hmono
-  rwa [← ENNReal.ofReal_rpow_of_nonneg hV0 (by norm_num), ← Real.sqrt_eq_rpow] at hmono
+  -- rewrite the `L²` bound `(ofReal V)^{1/2}` as `ofReal √V`
+  have hrw : ENNReal.ofReal V ^ (1 / 2 : ℝ) = ENNReal.ofReal (Real.sqrt V) := by
+    rw [Real.sqrt_eq_rpow, ENNReal.ofReal_rpow_of_nonneg hV0 (by norm_num)]
+  exact hmono.trans_eq hrw
 
 /-- **Kolmogorov's a.s.-convergence criterion (variance-sum form).**  For independent
 mean-zero `L²` random variables `X i` whose variance partial sums are uniformly bounded,

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -273,3 +273,48 @@ The S3 assembly is done. Two new theorems in
   Only fiddly part is ENNReal/rpow bookkeeping. Yields standalone Kolmogorov.
 - **S4b:** truncation + moment estimates (M–Z-specific), then final assembly with
   `ae_tendsto_kronecker_average_zero`.
+
+## Session 2026-07-03 (researcher-4) — S4a: Kolmogorov convergence from a variance-sum bound (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (S4a, the flagged "single cleanest remaining increment"). **Outcome**:
+3 new verified theorems, build ✔ (7743 jobs), 0-axiom (`#print axioms` =
+propext/Classical.choice/Quot.sound on both the main theorem and the bridge lemma).
+
+Discharged the deterministic `hbdd` L¹ hypothesis of
+`ae_tendsto_sum_of_indep_of_eLpNorm_bdd` from a variance-sum bound. Three theorems added
+to `Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ Kolmogorov):
+
+1. **`eLpNorm_two_sq_eq_evariance`** `(h0 : μ[X] = 0) : eLpNorm X 2 μ ^ 2 = evariance X μ`.
+   The mean-zero bridge — **Mathlib has NO `eLpNorm`↔`evariance` lemma** (confirmed by
+   repo-wide grep), this supplies the centered case. Proof: unfold `eLpNorm` via
+   `eLpNorm_eq_lintegral_rpow_enorm` to `(∫⁻‖X‖ₑ²)^{1/2}`; unfold `evariance`, kill the
+   centering with `simp [h0, sub_zero]`; reconcile the outer `(·)^{1/2}` squared back to
+   the lintegral via `← ENNReal.rpow_natCast _ 2`, `← ENNReal.rpow_mul`, `(1/2)*2=1`,
+   `rpow_one`; then `simp_rw [ENNReal.rpow_two]` to align the integrand's `^(2:ℝ)` (rpow)
+   with `evariance`'s `^2` (nat pow).
+2. **`eLpNorm_two_partialSum_le`** — uniform L² bound `‖Sₙ‖₂ ≤ ofReal(√V)` from
+   `∑_{i≤n} Var ≤ V`. `‖Sₙ‖₂² = eVar[Sₙ] = ofReal(Var Sₙ) = ofReal(∑Var) ≤ ofReal V`
+   (bridge + `ofReal_variance` + `IndepFun.variance_sum` orthogonality), then √ by the
+   monotone ℝ≥0∞-power `ENNReal.rpow_le_rpow · (0≤1/2)`.
+3. **`ae_tendsto_sum_of_indep_of_variance_bdd`** — Kolmogorov's a.s.-convergence criterion
+   in variance-sum form: `‖·‖₁ ≤ ‖·‖₂` (`eLpNorm_le_eLpNorm_of_exponent_le`, needs
+   `IsProbabilityMeasure` + `AEStronglyMeasurable`) chained with (2).
+
+**Reusable Lean gotchas (Mathlib v4.26):**
+- `eLpNorm_le_eLpNorm_of_exponent_le (hpq)(hf : AEStronglyMeasurable f μ)` — DOES need the
+  measurability arg (not just `IsProbabilityMeasure`).
+- Mean of a Finset-sum-of-functions: `μ[∑ i, X i] = ∑ μ[X i]` needs
+  `simp_rw [Finset.sum_apply]` BEFORE `integral_finset_sum` (the latter's LHS is
+  `∫ ∑ i, f i a`, not `∫ (∑ i, f i) a` — the plain `rw` fails on the unapplied sum).
+- `(ENNReal.ofReal V)^{1/2} = ofReal(√V)`: `rw [Real.sqrt_eq_rpow,
+  ENNReal.ofReal_rpow_of_nonneg hV0 (by norm_num)]` (forward), NOT a single `← rw` on the
+  goal — the `←` direction fails to find the `ofReal(V^_)` pattern.
+- `ENNReal.ofReal x = ↑x.toNNReal` by `rfl`, so `R := (√V).toNNReal` coerces to
+  `ofReal(√V)` definitionally.
+- `V ≥ 0` comes free from `hV 0`: `variance_nonneg (X 0) μ ≤ ∑_{i<1} Var = Var(X 0) ≤ V`.
+
+**Honest status.** S4a is the standalone Kolmogorov convergence theorem — genuine, complete,
+verified infrastructure, not scaffolding. It does not yet prove Marcinkiewicz–Zygmund: the
+remaining **S4b** truncation/moment layer (Borel–Cantelli on `{X_i≠Y_i}`, `∑ Var(Y_i)/i^{2/p}<∞`
+via `p<2`) then feeds S4a into `ae_tendsto_kronecker_average_zero`. Worked in locked
+`/private/tmp/wt-r4-lln`, committed before building (worktree-deletion hazard did not recur).

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4 ready — variance L¹-bound + truncation remain)
+**Phase**: ACT (S4a variance L¹-bound SHIPPED — S4b truncation remains)
 **Since**: 2026-07-03
-**Iteration**: 4 (S3 martingale assembly SHIPPED; S2 Kronecker shipped; S1 survey)
+**Iteration**: 5 (S4a Kolmogorov-from-variance-sum SHIPPED; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -47,15 +47,18 @@ None in-flight. Next work item is S4 below.
 
 ## Next Action
 
-- **S4a (next session, self-contained Lean build):** prove
-  `kolmogorov_convergence` (no `hbdd` hypothesis) by discharging the L¹ bound
-  from `∑ Var < ∞` using the named lemmas above. This is the single cleanest
-  remaining increment and needs no new foundations.
-- **S4b:** the truncation moment-estimate layer, then final M–Z assembly.
+- **S4a — DONE (iteration 5, PR pending).** `ae_tendsto_sum_of_indep_of_variance_bdd`
+  discharges the `hbdd` L¹ bound from `∑_{i≤n} Var(Xᵢ) ≤ V`, plus the two supporting
+  lemmas `eLpNorm_two_sq_eq_evariance` (the mean-zero `‖X‖₂² = eVar[X]` bridge — Mathlib
+  gap) and `eLpNorm_two_partialSum_le` (uniform L² bound). All 0-axiom, build ✔ 7743 jobs.
+- **S4b (next):** the truncation moment-estimate layer — `Y_i = X_i·1{|X_i| ≤ i^{1/p}}`,
+  `∑ P(X_i≠Y_i)<∞` (Borel–Cantelli), centered-truncation control, variance-sum estimate
+  `∑ Var(Y_i)/i^{2/p} < ∞` (uses `p < 2`). Then feed S4a into the Kronecker lift
+  `ae_tendsto_kronecker_average_zero` for the final M–Z normalisation.
 
 ## Attempt Counts
 
-- Total attempts: 4 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue)
-- Current approach attempts: 0 (S4a variance bound not yet started)
-- Approaches tried: 3 (S1 literature/decomposition; S2 Abel+Toeplitz;
-  S3 natural-filtration martingale + upcrossing engine)
+- Total attempts: 5 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound)
+- Current approach attempts: 1 (S4a variance bound — landed on 2nd build)
+- Approaches tried: 4 (S1 literature/decomposition; S2 Abel+Toeplitz;
+  S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge)


### PR DESCRIPTION
## Summary

Advances the Marcinkiewicz–Zygmund SLLN formalization (`laws-of-large-numbers-oq-01-oq-02-oq-01`)
by completing **step S4a**: discharging the deterministic `L¹` hypothesis `hbdd` of the
existing convergence engine `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` from a bound on the
variance partial sums. This yields the standalone **Kolmogorov a.s.-convergence criterion**.

Three theorems added to `Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ Kolmogorov):

1. **`eLpNorm_two_sq_eq_evariance`** `(h0 : μ[X] = 0) : eLpNorm X 2 μ ^ 2 = evariance X μ`
   — the mean-zero bridge between the `L²` seminorm and the extended variance. **Mathlib
   has no `eLpNorm`↔`evariance` lemma** (confirmed by repo-wide search); this supplies the
   centered case, which is the crux of turning a variance bound into an `L¹` bound.
2. **`eLpNorm_two_partialSum_le`** — uniform `L²` bound `‖Sₙ‖₂ ≤ ENNReal.ofReal (√V)` from
   `∑_{i≤n} Var(Xᵢ) ≤ V`, via the bridge, `ofReal_variance`, and the independence
   orthogonality identity `IndepFun.variance_sum`, then a monotone `ℝ≥0∞`-power `·^{1/2}`.
3. **`ae_tendsto_sum_of_indep_of_variance_bdd`** — Kolmogorov's criterion in variance-sum
   form: for independent mean-zero `L²` variables with `∑_{i≤n} Var(Xᵢ) ≤ V`, the series
   `∑ i, X i` converges a.s. (via `‖·‖₁ ≤ ‖·‖₂` on a probability space).

## Verification

- `docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → ✔ Built (7743 jobs, exit 0).
- `#print axioms` on `ae_tendsto_sum_of_indep_of_variance_bdd` and `eLpNorm_two_sq_eq_evariance`
  → `[propext, Classical.choice, Quot.sound]` only. Pure tactics, no `sorry`/`decide`/
  `native_decide`/`axiom`. File remains 0-sorry / 0-axiom.

## Scope (honest)

This is genuine, complete infrastructure — the standalone Kolmogorov convergence theorem —
**not** a proof of Marcinkiewicz–Zygmund. The remaining **S4b** truncation/moment layer
(Borel–Cantelli on `{Xᵢ ≠ Yᵢ}`, `∑ Var(Yᵢ)/i^{2/p} < ∞` using `p < 2`) then composes S4a
with the a.e. Kronecker lift `ae_tendsto_kronecker_average_zero` for the final normalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)