### PR TITLE
research(lovasz-local-lemma-oq-01): discharge subset-history hpos side condition

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean
@@ -1,0 +1,129 @@
+/-
+# Lovász Local Lemma — OQ-01: Positivity of Subset Survival Histories
+
+The measure-theoretic OQ-01 development has assembled the Erdős–Lovász induction step over
+**arbitrary subset histories** (`…DependencySplit.lean`, `…InductionStep.lean`,
+`…SymmetricStep.lean`) and the neighbour-block denominator recursion
+(`…DenominatorRecursion.lean`). Two of those results —
+`cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod` — carry a *side condition* that is
+assumed but never discharged:
+
+  `hpos` : every partial survival history is non-null,
+           `∀ T ⊆ S, μ ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0`.
+
+The `…ChainRule.lean` file discharges the analogous condition, but **only over prefix
+histories** `⋂_{j<n} Aⱼᶜ` (`hist_pos_of_failure_cond_lt_one`, a `Finset.range` induction),
+and with no extra conditioning set `C`. The genuine dependency-graph induction conditions on
+the survival of an *unstructured subset* of the events, on top of a fixed non-neighbour block
+`C`, so the prefix result cannot supply its `hpos`.
+
+This file discharges the subset-history version. Over an arbitrary `IsProbabilityMeasure`,
+for a measurable conditioning set `C` of positive measure, if every per-event conditional
+failure probability over every sub-block stays below one,
+
+  `∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1`,
+
+then every subset survival history conditioned on `C` is non-null,
+
+  `∀ T ⊆ S, μ ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0`.
+
+The proof is a `Finset.induction` on `S`: the empty history is `univ ∩ C = C` (`μ C ≠ 0`);
+each `insert a s` step splits the survival set as `(A a)ᶜ ∩ ((⋂_{j∈s} Aⱼᶜ) ∩ C)` and
+telescopes via `cond_mul_eq_inter`, `μ ((A a)ᶜ ∩ H) = μ[(A a)ᶜ | H] · μ(H)`, where the
+survival conditional `μ[(A a)ᶜ | H] = 1 - μ[A a | H]` is strictly positive because the failure
+bound at `a` (sub-block `s`) is `< 1`, and `μ(H) ≠ 0` by the induction hypothesis. This is the
+subset-history analogue of `ChainRule.hist_pos_of_failure_cond_lt_one`, and it supplies the
+`hpos` argument of `DenominatorRecursion.cond_iInter_compl_ge_prod` and
+`cond_failure_le_x_prod` directly — one of the two undischarged side conditions of the LLL
+strong induction.
+
+## Main results
+
+* `survival_pos_of_failure_lt_one_subset` : the subset-history positivity itself,
+  `μ ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0` from the sub-block failure bounds, by induction on `S`.
+* `survival_pos_subset_forall` : the `∀ T ⊆ S` packaging that
+  `cond_iInter_compl_ge_prod` / `cond_failure_le_x_prod` consume as their `hpos` hypothesis
+  (each `T ⊆ S` inherits the sub-block bounds, so the main lemma applies to it).
+
+Everything is over an arbitrary `IsProbabilityMeasure`; the failure bounds are the only
+hypotheses. `0` sorries, `0` axioms.
+-/
+import Mathlib.Probability.ConditionalProbability
+
+open MeasureTheory ProbabilityTheory Finset
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01SubsetHistoryPos
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A : ℕ → Set Ω}
+
+/-- **Subset survival histories are non-null under sub-block failure bounds.**
+For a measurable conditioning set `C` of positive measure, if every per-event conditional
+failure probability over every sub-block of `S` stays strictly below one, then the survival
+history of `S` conditioned on `C` is non-null:
+
+  `μ ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0`.
+
+Proof by `Finset.induction` on `S`. Empty: `⋂_{j∈∅} Aⱼᶜ = univ`, so the set is `C`, non-null
+by hypothesis. Step `insert a s` (`a ∉ s`): the survival set factors as
+`(A a)ᶜ ∩ ((⋂_{j∈s} Aⱼᶜ) ∩ C)`; writing `H = (⋂_{j∈s} Aⱼᶜ) ∩ C`, the telescoping identity
+`cond_mul_eq_inter` gives `μ ((A a)ᶜ ∩ H) = μ[(A a)ᶜ | H] · μ(H)`. The second factor is
+non-null by the induction hypothesis (the sub-block bounds restrict from `insert a s` to `s`),
+and the first is `1 - μ[A a | H]` (on the positive history `H`, `prob_compl_eq_one_sub`), which
+is nonzero because the failure bound at `a` over sub-block `s` is `< 1`. -/
+theorem survival_pos_of_failure_lt_one_subset (hA : ∀ i, MeasurableSet (A i))
+    {C : Set Ω} (hCmeas : MeasurableSet C) (hCpos : μ C ≠ 0) :
+    ∀ S : Finset ℕ,
+      (∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) →
+      μ ((⋂ j ∈ S, (A j)ᶜ) ∩ C) ≠ 0 := by
+  intro S
+  induction S using Finset.induction_on with
+  | empty =>
+      intro _
+      simpa using hCpos
+  | @insert a s ha ih =>
+      intro hfail
+      have hsub : s ⊆ insert a s := Finset.subset_insert a s
+      -- restrict the sub-block failure bounds from `insert a s` down to `s`
+      have hfail' : ∀ b ∈ s, ∀ T ⊆ s, b ∉ T →
+          μ[A b | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1 :=
+        fun b hb T hT hbT =>
+          hfail b (Finset.mem_insert_of_mem hb) T (hT.trans hsub) hbT
+      -- history `H = (⋂_{j∈s} Aⱼᶜ) ∩ C` is non-null by the induction hypothesis
+      have hHpos : μ ((⋂ j ∈ s, (A j)ᶜ) ∩ C) ≠ 0 := ih hfail'
+      have hB : MeasurableSet (⋂ j ∈ s, (A j)ᶜ) :=
+        Finset.measurableSet_biInter s (fun j _ => (hA j).compl)
+      have hHmeas : MeasurableSet ((⋂ j ∈ s, (A j)ᶜ) ∩ C) := hB.inter hCmeas
+      -- the survival conditional at `a` is nonzero: `1 - μ[A a | H]` with `μ[A a | H] < 1`
+      have hfa : μ[A a | (⋂ j ∈ s, (A j)ᶜ) ∩ C] < 1 :=
+        hfail a (Finset.mem_insert_self a s) s hsub ha
+      have hsurv : μ[(A a)ᶜ | (⋂ j ∈ s, (A j)ᶜ) ∩ C] ≠ 0 := by
+        haveI : IsProbabilityMeasure (μ[|(⋂ j ∈ s, (A j)ᶜ) ∩ C]) :=
+          cond_isProbabilityMeasure hHpos
+        rw [prob_compl_eq_one_sub (hA a), Ne, tsub_eq_zero_iff_le, not_le]
+        exact hfa
+      -- factor the survival set and telescope
+      have hsplit : (⋂ j ∈ insert a s, (A j)ᶜ) ∩ C
+          = (A a)ᶜ ∩ ((⋂ j ∈ s, (A j)ᶜ) ∩ C) := by
+        rw [Finset.set_biInter_insert, Set.inter_assoc]
+      rw [hsplit, Set.inter_comm ((A a)ᶜ) ((⋂ j ∈ s, (A j)ᶜ) ∩ C),
+        ← cond_mul_eq_inter hHmeas ((A a)ᶜ) μ]
+      exact mul_ne_zero hsurv hHpos
+
+/-- **The `∀ T ⊆ S` packaging consumed by the denominator recursion.**
+Under the same sub-block failure bounds, *every* subset `T ⊆ S` has a non-null survival
+history conditioned on `C`. This is exactly the `hpos` hypothesis of
+`DenominatorRecursion.cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod`: each `T ⊆ S`
+inherits the sub-block bounds (its sub-blocks are sub-blocks of `S`), so
+`survival_pos_of_failure_lt_one_subset` applies to `T`. Supplying this discharges one of the
+two undischarged side conditions of the LLL strong induction. -/
+theorem survival_pos_subset_forall (hA : ∀ i, MeasurableSet (A i))
+    {C : Set Ω} (hCmeas : MeasurableSet C) (hCpos : μ C ≠ 0) (S : Finset ℕ)
+    (hfail : ∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) :
+    ∀ T ⊆ S, μ ((⋂ j ∈ T, (A j)ᶜ) ∩ C) ≠ 0 := by
+  intro T hT
+  exact survival_pos_of_failure_lt_one_subset hA hCmeas hCpos T
+    (fun a ha U hU haU => hfail a (hT ha) U (hU.trans hT) haU)
+
+end LovaszLocalLemmaOQ01SubsetHistoryPos

--- a/research/problems/lovasz-local-lemma-oq-01/state.md
+++ b/research/problems/lovasz-local-lemma-oq-01/state.md
@@ -1,10 +1,53 @@
 # Research State: lovasz-local-lemma-oq-01
 
 ## Current State
-**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound + dependency-split numerator + relative/conditional quantitative bound + single-neighbour survival PEEL landed; both numerator and denominator-recursion primitives of the Erdős–Lovász induction are now in place, in both product form (transport of measure, prefix) and per-step form (additive complement peel, arbitrary block). What remains is the well-founded recursion coupling them. General dependency-degree LLL still open)
+**Phase**: ACT (two computable extremes + chain-rule scaffold + quantitative lower bound + dependency-split numerator + induction-step assembly (asymmetric + symmetric) + denominator recursion (∏(1−xⱼ) neighbour-survival bound) + subset-history POSITIVITY landed. The Erdős–Lovász induction step and its denominator recursion are fully assembled; `cond_failure_le_x_prod` gives the per-event bound over the full history given two side conditions — `hpos` (subset histories non-null) and `hbound` (per-event failure bounds over sub-blocks). This session discharges `hpos` for arbitrary subset histories. What remains is the MUTUAL well-founded recursion on |S| that discharges `hbound` (and feeds `hpos`) simultaneously, then feeds the resulting prefix bounds into the quantitative avoidance product. General dependency-degree LLL still open)
 **Path**: full
 **Since**: 2026-06-27
-**Iteration**: 10
+**Iteration**: 11
+
+## This session (researcher-14, 2026-07-03) — subset-history positivity
+
+**Discharged one of the two undischarged side conditions of the LLL strong induction.**
+`DenominatorRecursion.cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod` take an
+`hpos` hypothesis — `∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0` (every subset survival history,
+on top of a fixed non-neighbour block `C`, is non-null) — that was assumed but never
+proved. `ChainRule.hist_pos_of_failure_cond_lt_one` discharges only the PREFIX-history
+version (`Finset.range`, no `C`), which the dependency-graph induction cannot use.
+
+New self-contained **0-axiom / 0-sorry** file
+`Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean` (gallery entry
+`lovasz-local-lemma-oq-01-subset-history-pos`), imports only
+`Mathlib.Probability.ConditionalProbability`. Verified via `lean` (exit 0) against the
+main-repo Mathlib oleans; `#print axioms` on both theorems = propext / Classical.choice /
+Quot.sound only.
+
+### New verified theorems
+1. **`survival_pos_of_failure_lt_one_subset`** — for measurable `C` with `μ C ≠ 0`, if
+   every per-event failure over every sub-block stays `< 1`
+   (`∀ a∈S, ∀ T⊆S, a∉T → μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1`), then
+   `μ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0`. `Finset.induction` on `S`: empty history is `C`; each
+   `insert a s` step factors the survival set as `(A a)ᶜ ∩ H` (`H = (⋂_{j∈s} Aⱼᶜ) ∩ C`),
+   telescopes via `cond_mul_eq_inter` to `μ[(A a)ᶜ | H]·μ(H)`, both factors nonzero
+   (`μ(H)≠0` by IH; `μ[(A a)ᶜ|H] = 1 − μ[A a|H] ≠ 0` since failure `< 1`).
+2. **`survival_pos_subset_forall`** — the `∀ T ⊆ S` packaging matching the `hpos`
+   argument of `cond_iInter_compl_ge_prod` / `cond_failure_le_x_prod` character-for-character.
+
+### Note (avoided redundancy)
+First drafted a `LovaszLocalLemmaOQ01IndepDrop.lean` (conditional-drop under independence
+`μ[t|s]=μ t`) but DISCARDED it — `DependencySplit.cond_failure_eq_measure_of_indep_subset`
+and `CondIndep.cond_avoidance_eq_self` already prove exactly that (identical rewrite), and
+the base case `lll_independent_meas_iInter_compl` covers the independent-regime product.
+Chose the genuinely-missing subset-history `hpos` instead.
+
+### Next action (the remaining open capstone)
+Assemble `∀ i ∉ S, μ[A i | ⋂_{j∈S} Aⱼᶜ] ≤ x` by strong induction on `|S|`: split `S` into
+neighbours `S₁` / non-neighbours `S₂` of `i`, apply `cond_failure_le_x_symmetric` with
+`hpos := survival_pos_subset_forall` (this session) and `hbound` from the strong IH on the
+strictly-smaller sub-blocks `T ∪ S₂`; needs a structural dependency-graph independence
+hypothesis (`IndepSet (A i) (⋂_{j∈S₂} Aⱼᶜ)`, from `CondIndep.indepSet_avoidance` under
+mutual independence, or an abstract graph hypothesis for bounded degree). Then feed the
+prefix specialization into `Quantitative.avoidance_ge_prod_one_sub` for `∏(1−x) ≤ μ(⋂ Aᵢᶜ)`.
 
 ## This session (researcher-11, 2026-07-03) — PR #34155
 

--- a/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-lll-oq01-subpos-overview",
+    "proofId": "lovasz-local-lemma-oq-01-subset-history-pos",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "context",
+    "title": "The undischarged non-nullness side condition of the LLL strong induction",
+    "content": "The measure-theoretic OQ-01 development has assembled the Erdős–Lovász induction step over arbitrary subset histories and the neighbour-block denominator recursion. But two of those results — `cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod` — carry a side condition that is *assumed but never proved*:\n$$\\texttt{hpos}: \\quad \\forall\\, T \\subseteq S,\\ \\mu\\!\\left(\\Big(\\bigcap_{j\\in T} A_j^c\\Big) \\cap C\\right) \\ne 0.$$\nThe chain-rule entry `lovasz-local-lemma-oq-01-chain-rule` discharges the analogous fact, but **only over prefix histories** $\\bigcap_{j<n} A_j^c$ (a `Finset.range` induction) and with no extra conditioning block $C$. The genuine dependency-graph induction conditions on the avoidance of an *unstructured subset* $S$ on top of a fixed non-neighbour block $C$, so the prefix result cannot supply its `hpos`. This file discharges the subset-history version.",
+    "mathContext": "The LLL strong induction maintains two invariants over subset histories: the per-event failure bounds $\\mu[A_i \\mid \\text{avoidance}] \\le x_i$ and the non-nullness of the histories. This entry supplies the second half.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "survival history positivity",
+      "conditional probability",
+      "strong induction",
+      "denominator recursion"
+    ],
+    "prerequisites": [
+      "lovasz-local-lemma-oq-01-denominator-recursion (consumes hpos)",
+      "lovasz-local-lemma-oq-01-chain-rule (prefix-only positivity)",
+      "conditional probability μ[t|s]"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-subpos-setup",
+    "proofId": "lovasz-local-lemma-oq-01-subset-history-pos",
+    "range": {
+      "startLine": 51,
+      "endLine": 74
+    },
+    "type": "context",
+    "title": "Frame: self-contained on Mathlib",
+    "content": "```lean\nimport Mathlib.Probability.ConditionalProbability\nopen MeasureTheory ProbabilityTheory Finset\nopen scoped ENNReal\nnamespace LovaszLocalLemmaOQ01SubsetHistoryPos\nvariable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]\nvariable {A : ℕ → Set Ω}\n```\n\nThe entry imports **only** `Mathlib.Probability.ConditionalProbability` — no sibling OQ-01 file — so it is a self-contained lemma about conditional probability. The three tools it needs all come from that import: the telescoping identity `cond_mul_eq_inter` ($\\mu[t\\mid s]\\cdot\\mu(s) = \\mu(s\\cap t)$), the fact that conditioning on a positive-measure set gives a probability measure (`cond_isProbabilityMeasure`), and the complement rule `prob_compl_eq_one_sub`.",
+    "mathContext": "`μ[t|s]` is `ProbabilityTheory.cond μ s t`; `[IsProbabilityMeasure μ]` supplies the finiteness needed by `cond_mul_eq_inter` and the probability-measure structure on `μ[·|H]`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cond_mul_eq_inter",
+      "cond_isProbabilityMeasure",
+      "prob_compl_eq_one_sub"
+    ],
+    "prerequisites": [
+      "Mathlib.Probability.ConditionalProbability"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-subpos-main",
+    "proofId": "lovasz-local-lemma-oq-01-subset-history-pos",
+    "range": {
+      "startLine": 75,
+      "endLine": 119
+    },
+    "type": "key-step",
+    "title": "survival_pos_of_failure_lt_one_subset — the Finset.induction",
+    "content": "```lean\ntheorem survival_pos_of_failure_lt_one_subset (hA : ∀ i, MeasurableSet (A i))\n    {C : Set Ω} (hCmeas : MeasurableSet C) (hCpos : μ C ≠ 0) :\n    ∀ S : Finset ℕ,\n      (∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) →\n      μ ((⋂ j ∈ S, (A j)ᶜ) ∩ C) ≠ 0\n```\n\n**Empty history**: $\\bigcap_{j\\in\\emptyset} A_j^c = \\text{univ}$, so the set is $\\text{univ}\\cap C = C$, non-null by `hCpos`.\n\n**Insert step** `insert a s` ($a\\notin s$): restrict the sub-block bounds to $s$ and get $\\mu(H)\\ne 0$ by the induction hypothesis, where $H = (\\bigcap_{j\\in s} A_j^c)\\cap C$. Factor the survival set as $(A_a)^c \\cap H$ (`Finset.set_biInter_insert`, `Set.inter_assoc`) and telescope with `cond_mul_eq_inter`:\n$$\\mu\\big((A_a)^c \\cap H\\big) = \\mu[(A_a)^c \\mid H]\\cdot \\mu(H).$$\nThe survival conditional is nonzero: on the positive history $H$, `cond_isProbabilityMeasure` makes $\\mu[\\cdot\\mid H]$ a probability measure, so `prob_compl_eq_one_sub` gives $\\mu[(A_a)^c\\mid H] = 1 - \\mu[A_a\\mid H]$, which is $\\ne 0$ because the failure bound at $a$ over sub-block $s$ is $<1$. Both factors nonzero $\\Rightarrow$ the product is nonzero (`mul_ne_zero`).",
+    "mathContext": "The only quantitative input is $1 - \\mu[A_a\\mid H] > 0$: as long as no event is certain given the history, each conditioning step multiplies by a strictly positive survival factor, so positivity propagates. No independence, dependency graph, or numeric LLL budget is used.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.induction",
+      "cond_mul_eq_inter",
+      "prob_compl_eq_one_sub",
+      "survival probability",
+      "tsub_eq_zero_iff_le"
+    ],
+    "prerequisites": [
+      "μ[t|s]·μ s = μ(s∩t)",
+      "μ[·|H] a probability measure for μ H ≠ 0",
+      "1 − μ[A a|H] > 0 from μ[A a|H] < 1"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-subpos-packaging",
+    "proofId": "lovasz-local-lemma-oq-01-subset-history-pos",
+    "range": {
+      "startLine": 121,
+      "endLine": 129
+    },
+    "type": "key-step",
+    "title": "survival_pos_subset_forall — the hpos term the recursion consumes",
+    "content": "```lean\ntheorem survival_pos_subset_forall (hA : ∀ i, MeasurableSet (A i))\n    {C : Set Ω} (hCmeas : MeasurableSet C) (hCpos : μ C ≠ 0) (S : Finset ℕ)\n    (hfail : ∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) :\n    ∀ T ⊆ S, μ ((⋂ j ∈ T, (A j)ᶜ) ∩ C) ≠ 0 := by\n  intro T hT\n  exact survival_pos_of_failure_lt_one_subset hA hCmeas hCpos T\n    (fun a ha U hU haU => hfail a (hT ha) U (hU.trans hT) haU)\n```\n\nEach $T \\subseteq S$ inherits the sub-block failure bounds (its sub-blocks are sub-blocks of $S$), so the main lemma applies to $T$. The conclusion $\\forall T \\subseteq S,\\ \\mu((\\bigcap_{j\\in T} A_j^c)\\cap C)\\ne 0$ matches the `hpos` hypothesis of `DenominatorRecursion.cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod` **character-for-character**, so supplying it discharges one of the two undischarged side conditions of the LLL strong induction.",
+    "mathContext": "The failure hypothesis here (μ[A a|H] < 1) is strictly weaker than the induction's invariant (μ[A a|H] ≤ x a with x a < 1), so this positivity slots in for free wherever the induction has established its numeric bounds.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "cond_iInter_compl_ge_prod",
+      "cond_failure_le_x_prod",
+      "hpos side condition",
+      "subset monotonicity"
+    ],
+    "prerequisites": [
+      "survival_pos_of_failure_lt_one_subset",
+      "subset transitivity of the failure bounds"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-subset-history-pos/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "lovasz-local-lemma-oq-01-subset-history-pos",
+  "title": "Lovász Local Lemma OQ-01: Positivity of Subset Survival Histories",
+  "slug": "lovasz-local-lemma-oq-01-subset-history-pos",
+  "description": "Discharges one of the two undischarged side conditions of the measure-theoretic Lovász Local Lemma strong induction: the non-nullness of arbitrary subset survival histories. The OQ-01 development has assembled the Erdős–Lovász induction step over arbitrary subset histories (lovasz-local-lemma-oq-01-dependency-split, -induction-step, -symmetric-step) and the neighbour-block denominator recursion (lovasz-local-lemma-oq-01-denominator-recursion). Two of those results — cond_iInter_compl_ge_prod and cond_failure_le_x_prod — carry a side condition assumed but never proved: hpos, that every partial survival history is non-null, ∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0. The chain-rule entry (lovasz-local-lemma-oq-01-chain-rule) proves the analogous fact but only over PREFIX histories ⋂_{j<n} Aⱼᶜ (hist_pos_of_failure_cond_lt_one, a Finset.range induction) and with no extra conditioning set C; the genuine dependency-graph induction conditions on an unstructured subset of events on top of a fixed non-neighbour block C, so the prefix result cannot supply its hpos. This entry proves the subset-history version: over an arbitrary IsProbabilityMeasure, for a measurable C of positive measure, if every per-event conditional failure over every sub-block stays below one (∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1), then every subset survival history conditioned on C is non-null (∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0). The proof is a Finset.induction on S: the empty history is univ ∩ C = C (μ C ≠ 0); each insert a s step splits the survival set as (A a)ᶜ ∩ ((⋂_{j∈s} Aⱼᶜ) ∩ C) and telescopes via cond_mul_eq_inter, μ((A a)ᶜ ∩ H) = μ[(A a)ᶜ | H]·μ(H), where the survival conditional μ[(A a)ᶜ | H] = 1 − μ[A a | H] is positive since the failure bound at a is < 1, and μ(H) ≠ 0 by induction. The packaged ∀ T ⊆ S form matches the hpos hypothesis of cond_iInter_compl_ge_prod and cond_failure_le_x_prod character-for-character. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "conditional-probability"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used — confirmed by #print axioms on both theorems). IsProbabilityMeasure is an explicit hypothesis. The conditioning set C is required measurable and of positive measure, and the per-sub-block failure bounds μ[A a | (⋂_T Aⱼᶜ) ∩ C] < 1 are explicit hypotheses (these are strictly weaker than, hence discharged by, the ≤ x a bounds with x a < 1 that the LLL induction maintains). Scope: this entry proves the subset-history non-nullness (the hpos side condition of the denominator recursion); it does NOT prove the mutually-recursive per-event failure bounds (hbound), which together with this positivity assemble the full symmetric-LLL strong induction — that mutual well-founded recursion on |S| remains the open research target.",
+    "lineCount": 129,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "survival_pos_of_failure_lt_one_subset: subset survival histories are non-null under sub-block failure bounds. For a measurable conditioning set C of positive measure, if every per-event conditional failure probability over every sub-block of S stays < 1, then μ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0. Proved by Finset.induction on S: empty history is C (non-null); the insert a s step factors the survival set as (A a)ᶜ ∩ H with H = (⋂_{j∈s} Aⱼᶜ) ∩ C, telescopes via cond_mul_eq_inter to μ[(A a)ᶜ | H]·μ(H), and shows both factors nonzero — μ(H) ≠ 0 by the induction hypothesis, and μ[(A a)ᶜ | H] = 1 − μ[A a | H] ≠ 0 (prob_compl_eq_one_sub on the positive history) since the failure bound at a over sub-block s is < 1.",
+      "survival_pos_subset_forall: the ∀ T ⊆ S packaging that DenominatorRecursion.cond_iInter_compl_ge_prod and cond_failure_le_x_prod consume verbatim as their hpos hypothesis. Each T ⊆ S inherits the sub-block failure bounds (its sub-blocks are sub-blocks of S), so the main lemma applies to it. This is the exact term shape those theorems require, so supplying it discharges one of the two undischarged side conditions of the LLL strong induction.",
+      "Subset-history generalization of the chain-rule prefix positivity: ChainRule.hist_pos_of_failure_cond_lt_one proves non-nullness only over Finset.range prefixes with no conditioning set; the dependency-graph induction needs it over arbitrary subsets S with an extra non-neighbour block C. This entry supplies exactly that generalization, closing the gap between the prefix reduction and the subset-history machinery."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.ConditionalProbability"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Finset"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01SubsetHistoryPos",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "substantiveTheoremCount": 2,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "survival_pos_of_failure_lt_one_subset",
+      "type": "core",
+      "description": "Subset survival histories are non-null under sub-block failure bounds: for a measurable conditioning set C of positive measure, if μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1 for every a ∈ S and every T ⊆ S with a ∉ T, then μ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0. Proved by Finset.induction on S, telescoping each insert step via cond_mul_eq_inter with the strictly-positive survival conditional 1 − μ[A a | H].",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → {C : Set Ω} → MeasurableSet C → μ C ≠ 0 → ∀ S : Finset ℕ, (∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) → μ ((⋂ j ∈ S, (A j)ᶜ) ∩ C) ≠ 0"
+    },
+    {
+      "name": "survival_pos_subset_forall",
+      "type": "corollary",
+      "description": "The ∀ T ⊆ S packaging consumed as the hpos hypothesis of DenominatorRecursion.cond_iInter_compl_ge_prod and cond_failure_le_x_prod: under the same sub-block failure bounds, every subset T ⊆ S has a non-null survival history conditioned on C, since each T inherits the sub-block bounds. Discharges one of the two undischarged side conditions of the LLL strong induction.",
+      "leanType": "(hA : ∀ i, MeasurableSet (A i)) → {C : Set Ω} → MeasurableSet C → μ C ≠ 0 → (S : Finset ℕ) → (∀ a ∈ S, ∀ T ⊆ S, a ∉ T → μ[A a | (⋂ j ∈ T, (A j)ᶜ) ∩ C] < 1) → ∀ T ⊆ S, μ ((⋂ j ∈ T, (A j)ᶜ) ∩ C) ≠ 0"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The classical Lovász Local Lemma (Erdős–Lovász 1975) is proved by a strong induction on the size of the conditioning set: to bound the conditional failure probability of a bad event given the avoidance of a subset S of the other events, one splits S into the event's neighbours and non-neighbours in the dependency graph and recurses on strictly smaller subsets. The induction simultaneously maintains two facts about every subset history: the per-event failure bounds (μ[A i | avoidance] ≤ x i) and the non-nullness of the histories themselves (so that the conditional probabilities are well-defined). The measure-theoretic OQ-01 development has verified the induction STEP over arbitrary subset histories and the denominator recursion that builds the neighbour-block survival lower bound, but both leave the non-nullness of the subset histories as an unproved hypothesis, discharged in the gallery only for prefix histories over a total order. This entry supplies the subset-history non-nullness, the missing structural half that the strong induction must carry alongside the failure bounds.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces, with real dependency structure and the quantitative avoidance conclusion.\n\n**This entry (subset-history positivity)**: prove that the non-nullness side condition of the dependency-graph induction holds. For an arbitrary IsProbabilityMeasure, a measurable conditioning set C with μ C ≠ 0, and a family A : ℕ → Set Ω, if every per-event conditional failure over every sub-block stays below one, μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1 for all a ∈ S, T ⊆ S with a ∉ T, then every subset survival history conditioned on C is non-null: ∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0 — exactly the hpos hypothesis of cond_iInter_compl_ge_prod and cond_failure_le_x_prod.",
+    "text": "For the Lovász Local Lemma induction to even make sense, the avoidance histories it conditions on must have positive probability — otherwise the conditional probabilities are undefined. This entry proves that they do: as long as no bad event is ever forced to happen given the earlier avoidances (every conditional failure probability stays strictly below one), then avoiding any subset of the bad events, on top of a fixed background block, always has positive probability. The proof adds one event at a time and multiplies by the surviving room 1 − (failure probability) > 0.",
+    "proofStrategy": "**Finset.induction on S.**\n\n*Empty history*: ⋂_{j∈∅} Aⱼᶜ = univ, so the set is univ ∩ C = C, non-null by hypothesis (μ C ≠ 0).\n\n*Insert step* insert a s (a ∉ s): restrict the sub-block failure bounds from insert a s down to s and apply the induction hypothesis to get μ(H) ≠ 0 for H = (⋂_{j∈s} Aⱼᶜ) ∩ C. Factor the new survival set: (⋂_{j∈insert a s} Aⱼᶜ) ∩ C = (A a)ᶜ ∩ H (Finset.set_biInter_insert then Set.inter_assoc). Telescope via cond_mul_eq_inter: μ((A a)ᶜ ∩ H) = μ[(A a)ᶜ | H]·μ(H) (after Set.inter_comm). The survival conditional is nonzero: on the positive history H the conditional measure is a probability measure (cond_isProbabilityMeasure), so prob_compl_eq_one_sub gives μ[(A a)ᶜ | H] = 1 − μ[A a | H], and the failure bound at a over sub-block s (μ[A a | H] < 1) makes 1 − μ[A a | H] ≠ 0 (tsub_eq_zero_iff_le, not_le). Both factors nonzero ⇒ the product is nonzero (mul_ne_zero).\n\n**Packaging**: survival_pos_subset_forall applies the main lemma to each T ⊆ S, whose sub-block bounds are inherited from S's — giving the ∀ T ⊆ S shape the denominator recursion consumes.",
+    "keyInsights": [
+      "The strong induction underlying the LLL carries TWO invariants over subset histories — the per-event failure bounds and the non-nullness of the histories — and they are genuinely separate obligations. The OQ-01 machinery had the induction step (which produces the failure bounds given non-null histories) but treated non-nullness as an external hypothesis; this entry proves the non-nullness half in the exact shape the machinery consumes.",
+      "Subset histories, unlike prefix histories, are unstructured: the chain-rule prefix positivity (hist_pos_of_failure_cond_lt_one) telescopes along a fixed total order and cannot state the fact for an arbitrary Finset S sitting on top of a background block C. A Finset.induction on S — adding events in an arbitrary order — is the right form, and the extra conditioning set C threads through unchanged.",
+      "The single quantitative input is the trivial-looking 1 − μ[A a | H] > 0: as long as no event is certain given the history, each conditioning step multiplies the history measure by a strictly positive survival factor, so positivity propagates. No independence, no dependency graph, and no numeric LLL budget is needed — only that failure is never forced.",
+      "The failure hypothesis here (μ[A a | H] < 1) is strictly weaker than the LLL invariant (μ[A a | H] ≤ x a with x a < 1) the strong induction maintains, so this positivity slots in for free wherever the induction has established its bounds. It isolates exactly the non-nullness content, decoupled from the numeric budget.",
+      "With this in hand, the remaining gap in OQ-01 is sharp: the mutual well-founded recursion on |S| that simultaneously establishes the per-event failure bounds (hbound) and consumes this positivity (hpos) to run cond_failure_le_x_prod at each event, then feeds the resulting prefix bounds into the quantitative avoidance product."
+    ],
+    "prerequisites": [
+      "Measure-theoretic conditional probability μ[t|s] = ProbabilityTheory.cond μ s t and the telescoping identity cond_mul_eq_inter (μ[t|s]·μ s = μ(s ∩ t))",
+      "cond_isProbabilityMeasure (conditioning on a positive-measure set yields a probability measure) and prob_compl_eq_one_sub (μ sᶜ = 1 − μ s)",
+      "Finite intersections over Finsets: Finset.set_biInter_insert, Finset.measurableSet_biInter",
+      "ℝ≥0∞ truncated subtraction: tsub_eq_zero_iff_le; mul_ne_zero",
+      "The consuming theorems DenominatorRecursion.cond_iInter_compl_ge_prod and cond_failure_le_x_prod (whose hpos hypothesis this discharges)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "framing",
+      "title": "Framing: The Undischarged Non-Nullness Side Condition",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "The module docstring positions the file in the OQ-01 landscape: the induction-step and denominator-recursion entries carry an hpos side condition (every partial survival history non-null) that is assumed but never proved for subset histories; the chain-rule entry proves only the prefix-history version with no conditioning set. This file discharges the subset-history version with an extra conditioning block C, matching the shape cond_iInter_compl_ge_prod and cond_failure_le_x_prod consume.",
+      "mathContext": "The LLL strong induction maintains two invariants over subset histories — the failure bounds and non-nullness — and this file supplies the second, over an arbitrary IsProbabilityMeasure, from the failure bounds alone."
+    },
+    {
+      "id": "setup",
+      "title": "Imports and Ambient Assumptions",
+      "startLine": 51,
+      "endLine": 74,
+      "summary": "Imports only Mathlib.Probability.ConditionalProbability; opens MeasureTheory / ProbabilityTheory / Finset and the ENNReal scope; fixes a measurable space Ω, a measure μ with the [IsProbabilityMeasure μ] instance, and a family A : ℕ → Set Ω. No sibling proof files are imported — the entry is self-contained on Mathlib.",
+      "mathContext": "μ[t|s] is ProbabilityTheory.cond μ s t; IsProbabilityMeasure supplies finiteness for cond_mul_eq_inter and cond_isProbabilityMeasure."
+    },
+    {
+      "id": "subset-positivity",
+      "title": "Subset Survival Histories Are Non-Null",
+      "startLine": 75,
+      "endLine": 119,
+      "summary": "survival_pos_of_failure_lt_one_subset: for measurable C with μ C ≠ 0, if μ[A a | (⋂_{j∈T} Aⱼᶜ) ∩ C] < 1 for all a ∈ S, T ⊆ S with a ∉ T, then μ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0. Finset.induction on S: empty history is C; the insert a s step factors the survival set as (A a)ᶜ ∩ H (H = (⋂_{j∈s} Aⱼᶜ) ∩ C), telescopes via cond_mul_eq_inter to μ[(A a)ᶜ | H]·μ(H), and shows both factors nonzero — μ(H) ≠ 0 by IH, and μ[(A a)ᶜ | H] = 1 − μ[A a | H] ≠ 0 since the failure bound at a is < 1.",
+      "mathContext": "The survival conditional 1 − μ[A a | H] is computed by prob_compl_eq_one_sub after cond_isProbabilityMeasure hHpos makes μ[·|H] a probability measure; its positivity is tsub_eq_zero_iff_le / not_le applied to μ[A a | H] < 1."
+    },
+    {
+      "id": "packaging",
+      "title": "The ∀ T ⊆ S Packaging for the Denominator Recursion",
+      "startLine": 121,
+      "endLine": 129,
+      "summary": "survival_pos_subset_forall: under the same sub-block failure bounds, every subset T ⊆ S has a non-null survival history conditioned on C. Applies the main lemma to each T (whose sub-blocks are sub-blocks of S, so the bounds are inherited). This is exactly the hpos hypothesis of DenominatorRecursion.cond_iInter_compl_ge_prod and cond_failure_le_x_prod.",
+      "mathContext": "The conclusion ∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0 matches the consuming theorems' hpos argument character-for-character."
+    }
+  ],
+  "conclusion": {
+    "summary": "The non-nullness of arbitrary subset survival histories — the hpos side condition of the measure-theoretic LLL strong induction — is fully machine-verified over a real probability space: from sub-block conditional failure bounds < 1 (and a positive-measure conditioning block C), every subset survival history conditioned on C is non-null, in the exact ∀ T ⊆ S shape the denominator recursion consumes. 0 sorries, 0 axioms.",
+    "implications": "**Discharges one of the two undischarged side conditions of the LLL strong induction.** The dependency-graph induction step (lovasz-local-lemma-oq-01-induction-step, -symmetric-step) and the denominator recursion (lovasz-local-lemma-oq-01-denominator-recursion) both assume, but never prove, that the subset survival histories are non-null (hpos); the gallery previously discharged this only for prefix histories over a total order (lovasz-local-lemma-oq-01-chain-rule). This entry supplies the subset-history version with the extra non-neighbour conditioning block, so cond_iInter_compl_ge_prod and cond_failure_le_x_prod can now be run once the per-event failure bounds are in hand.\n\n**Honest scope**: the remaining open target is the mutual well-founded recursion on |S| that simultaneously establishes the per-event failure bounds (hbound) — via the induction step, splitting each conditioning subset into neighbours and non-neighbours and recursing on strictly smaller subsets — and consumes this positivity to close the loop. This entry removes the structural (non-nullness) half of that recursion's obligations, leaving the numeric (failure-bound) half as the genuine content still to be assembled.",
+    "openQuestions": [
+      "Assemble the LLL strong induction on |S|: prove ∀ i ∉ S, μ[A i | ⋂_{j∈S} Aⱼᶜ] ≤ x i by strong induction, splitting S into neighbours S₁ and non-neighbours S₂ of i, using cond_failure_le_x_prod (denominator recursion) with this entry's survival_pos_subset_forall for hpos and the strong induction hypothesis on strictly smaller subsets for hbound.",
+      "Feed the assembled prefix per-event bounds into the quantitative avoidance product (lovasz-local-lemma-oq-01-quantitative, avoidance_ge_prod_one_sub) to conclude ∏(1 − x i) ≤ μ(⋂ Aᵢᶜ), the full symmetric LLL lower bound over a real probability space.",
+      "Formulate the dependency-graph independence hypothesis structurally (each A i independent of the σ-algebra generated by its non-neighbours) and derive the per-instance IndepSet (A i) (⋂_{j∈S₂} Aⱼᶜ) terms that the induction step consumes, generalizing lovasz-local-lemma-oq-01-cond-indep from full mutual independence to a bounded dependency degree.",
+      "Upstream the subset-history positivity: survival_pos_of_failure_lt_one_subset is a general fact about conditional probability (no LLL content) and could join Mathlib.Probability.ConditionalProbability alongside the telescoping identities it is built from."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-denominator-recursion",
+      "relationship": "extends",
+      "description": "The denominator recursion cond_iInter_compl_ge_prod and cond_failure_le_x_prod take as an unproved hypothesis hpos: ∀ T ⊆ S, μ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0. This entry's survival_pos_subset_forall proves exactly that term, discharging the side condition."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-chain-rule",
+      "relationship": "generalizes",
+      "description": "ChainRule.hist_pos_of_failure_cond_lt_one proves survival-history non-nullness only over prefix histories ⋂_{j<n} Aⱼᶜ (a Finset.range induction) with no conditioning set. This entry generalizes it to arbitrary subset histories ⋂_{j∈S} Aⱼᶜ on top of a background block C, the form the dependency-graph induction needs."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-induction-step",
+      "relationship": "related",
+      "description": "The induction step produces the per-event failure bounds given non-null histories; this entry supplies the non-null histories given the failure bounds. Together they are the two invariants the LLL strong induction maintains over subset histories."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01-symmetric-step",
+      "relationship": "related",
+      "description": "The symmetric induction-step invariant cond_failure_le_x_symmetric also conditions on subset survival histories and requires them non-null; this entry's positivity is the structural side condition that assembly consumes."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; the strong induction maintains, over every subset of conditioning events, both the per-event failure bounds and the well-definedness (non-nullness) of the avoidance histories."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; the LLL induction conditions on avoidance of subsets of events and tacitly uses that these avoidance probabilities are positive — the fact this entry makes explicit and machine-checked."
+    },
+    {
+      "authors": "Spencer",
+      "title": "Ten Lectures on the Probabilistic Method",
+      "year": "1994",
+      "note": "Presents the LLL via conditional probabilities on growing avoidance histories; positivity of the histories is what keeps the conditionals well-defined throughout the recursion."
+    }
+  ]
+}


### PR DESCRIPTION
Advances the measure-theoretic Lovász Local Lemma (OQ-01) by discharging **one of the two undischarged side conditions** of the Erdős–Lovász strong induction.

## Context

The OQ-01 development has assembled the induction step over arbitrary subset histories (`DependencySplit`, `InductionStep`, `SymmetricStep`) and the neighbour-block denominator recursion (`DenominatorRecursion`). But `cond_iInter_compl_ge_prod` and `cond_failure_le_x_prod` carry a side condition assumed but never proved:

```
hpos : ∀ T ⊆ S, μ ((⋂_{j∈T} Aⱼᶜ) ∩ C) ≠ 0
```

`ChainRule.hist_pos_of_failure_cond_lt_one` proves the analogous fact **only over prefix histories** (`Finset.range`, no conditioning block `C`), which the dependency-graph induction cannot use — it conditions on an *unstructured subset* `S` on top of a fixed non-neighbour block `C`.

## This PR

New self-contained file `Proofs/LovaszLocalLemmaOQ01SubsetHistoryPos.lean` (imports only `Mathlib.Probability.ConditionalProbability`), **0 sorries / 0 axioms** (verified via `lean`; `#print axioms` = `propext / Classical.choice / Quot.sound` on both theorems):

- **`survival_pos_of_failure_lt_one_subset`** — for measurable `C` with `μ C ≠ 0`, if every per-event conditional failure over every sub-block stays `< 1`, then `μ((⋂_{j∈S} Aⱼᶜ) ∩ C) ≠ 0`. `Finset.induction` on `S`, telescoping each `insert` step via `cond_mul_eq_inter` with the strictly-positive survival conditional `1 − μ[A a | H]`.
- **`survival_pos_subset_forall`** — the `∀ T ⊆ S` packaging matching the `hpos` hypothesis of `cond_iInter_compl_ge_prod` / `cond_failure_le_x_prod` **character-for-character**.

Also adds gallery entry `lovasz-local-lemma-oq-01-subset-history-pos` and a session note in `state.md`.

## Scope / honesty

This discharges the **structural** (non-nullness) half of the strong induction's obligations. The **numeric** half — the mutual well-founded recursion on `|S|` that establishes the per-event failure bounds (`hbound`) and consumes this `hpos` — remains the open capstone (documented in `state.md`).

A drafted `IndepDrop` file (conditional-drop under independence) was **discarded as redundant** with the existing `DependencySplit.cond_failure_eq_measure_of_indep_subset` / `CondIndep.cond_avoidance_eq_self` (identical rewrite) before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)