### PR TITLE
research(weak-goldbach-oq-01): Schnirelmann covering lemma [VERIFIED, 0-axiom, 3 thm, new file]

### DIFF
--- a/proofs/Proofs/SchnirelmannBasis.lean
+++ b/proofs/Proofs/SchnirelmannBasis.lean
@@ -1,0 +1,158 @@
+/-
+  Schnirelmann's covering lemma (toward the additive-basis theorem).
+
+  This file develops the first missing piece flagged in Mathlib's
+  `Mathlib/Combinatorics/Schnirelmann.lean` TODO list:
+
+    * "Show that if the sum of two densities is at least one, the sumset
+       covers the positive naturals."
+
+  formalized here as `sumset_covers_of_density_add_ge_one`.
+
+  This is the *covering* step of Schnirelmann's theorem. Fully discharging the
+  `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean` additionally
+  requires Schnirelmann's *inequality* (`σ(A ⊕ B) ≥ σA + σB − σA·σB`) to boost
+  the density of iterated sumsets above `1/2`; that step is the remaining gap
+  (see the note at the bottom of this file).
+
+  The proof of the covering lemma is the classical pigeonhole argument: for a
+  target `n`, the `A`-elements of `[0,n]` and the reflected `B`-elements
+  `{x : n - x ∈ B}` of `[0,n]` each have cardinality `≥ σ·n + 1`; if they were
+  disjoint their union would exceed `[0,n]`, contradicting `σA + σB ≥ 1`. Hence
+  they meet, yielding `a ∈ A`, `b ∈ B` with `a + b = n`.
+-/
+import Mathlib
+
+open Finset
+
+namespace SchnirelmannBasis
+
+variable {A B : Set ℕ} [DecidablePred (· ∈ A)] [DecidablePred (· ∈ B)]
+
+/-- The number of `A`-elements in `{0, 1, …, n}` is at least `σ(A)·n + 1`
+    when `0 ∈ A`: the `+1` accounts for `0`, which the density infimum (taken
+    over `Ioc 0 n`) does not see. -/
+lemma card_Icc_filter_ge (hA0 : 0 ∈ A) (n : ℕ) :
+    schnirelmannDensity A * n + 1 ≤ (#{a ∈ Icc 0 n | a ∈ A} : ℝ) := by
+  have h0not : (0 : ℕ) ∉ {a ∈ Ioc 0 n | a ∈ A} := by simp
+  have hsub : insert 0 {a ∈ Ioc 0 n | a ∈ A} ⊆ {a ∈ Icc 0 n | a ∈ A} := by
+    intro x hx
+    simp only [mem_insert, mem_filter, mem_Ioc, mem_Icc] at hx ⊢
+    rcases hx with rfl | ⟨⟨_, h2⟩, h3⟩
+    · exact ⟨⟨Nat.zero_le _, Nat.zero_le _⟩, hA0⟩
+    · exact ⟨⟨Nat.zero_le _, h2⟩, h3⟩
+  have hcard : #{a ∈ Ioc 0 n | a ∈ A} + 1 ≤ #{a ∈ Icc 0 n | a ∈ A} := by
+    have := card_le_card hsub
+    rwa [card_insert_of_notMem h0not] at this
+  have hdens : schnirelmannDensity A * n ≤ (#{a ∈ Ioc 0 n | a ∈ A} : ℝ) :=
+    schnirelmannDensity_mul_le_card_filter
+  have hcast : (#{a ∈ Ioc 0 n | a ∈ A} : ℝ) + 1 ≤ (#{a ∈ Icc 0 n | a ∈ A} : ℝ) := by
+    exact_mod_cast hcard
+  linarith
+
+/-- The reflected count: the number of `x ∈ {0, …, n}` with `n - x ∈ B` is at
+    least `σ(B)·n + 1` when `0 ∈ B`. The reflection `x ↦ n - x` sends the
+    `B`-elements of `[1,n]` injectively into this set, and `x = n` (giving
+    `n - n = 0 ∈ B`) supplies the extra `+1`. -/
+lemma card_reflect_filter (hB0 : 0 ∈ B) (n : ℕ) :
+    schnirelmannDensity B * n + 1 ≤ (#{x ∈ Icc 0 n | (n - x) ∈ B} : ℝ) := by
+  set s : Finset ℕ := {b ∈ Ioc 0 n | b ∈ B} with hs
+  set t : Finset ℕ := {x ∈ Icc 0 n | (n - x) ∈ B} with ht
+  have hn_t : n ∈ t := by
+    simp only [ht, mem_filter, mem_Icc, Nat.sub_self]
+    exact ⟨⟨Nat.zero_le _, le_refl _⟩, hB0⟩
+  have himg : s.image (fun b => n - b) ⊆ t := by
+    intro y hy
+    simp only [mem_image, hs, mem_filter, mem_Ioc] at hy
+    obtain ⟨b, ⟨⟨_, hbn⟩, hbB⟩, rfl⟩ := hy
+    simp only [ht, mem_filter, mem_Icc]
+    exact ⟨⟨Nat.zero_le _, Nat.sub_le _ _⟩, by rwa [Nat.sub_sub_self hbn]⟩
+  have hninimg : n ∉ s.image (fun b => n - b) := by
+    simp only [mem_image, hs, mem_filter, mem_Ioc, not_exists]
+    rintro b ⟨⟨hb0, hbn⟩, _⟩
+    omega
+  have hinj : Set.InjOn (fun b => n - b) s := by
+    intro a ha b hb hab
+    simp only [hs, coe_filter, Set.mem_setOf_eq, mem_Ioc] at ha hb
+    simp only at hab
+    omega
+  have hcardimg : (s.image (fun b => n - b)).card = s.card := card_image_of_injOn hinj
+  have hins : insert n (s.image (fun b => n - b)) ⊆ t := by
+    rw [insert_subset_iff]; exact ⟨hn_t, himg⟩
+  have hcard : s.card + 1 ≤ t.card := by
+    have := card_le_card hins
+    rwa [card_insert_of_notMem hninimg, hcardimg] at this
+  have hdens : schnirelmannDensity B * n ≤ (s.card : ℝ) :=
+    schnirelmannDensity_mul_le_card_filter
+  have hcast : (s.card : ℝ) + 1 ≤ (t.card : ℝ) := by exact_mod_cast hcard
+  linarith
+
+/-- **Schnirelmann's covering lemma.** If `0 ∈ A`, `0 ∈ B`, and the Schnirelmann
+    densities satisfy `σ(A) + σ(B) ≥ 1`, then every natural number `n` is a sum
+    `a + b` with `a ∈ A` and `b ∈ B`.
+
+    This is the item "if the sum of two densities is at least one, the sumset
+    covers the positive naturals" from the Mathlib `Schnirelmann.lean` TODO. -/
+theorem sumset_covers_of_density_add_ge_one
+    (hA0 : 0 ∈ A) (hB0 : 0 ∈ B)
+    (h : 1 ≤ schnirelmannDensity A + schnirelmannDensity B) (n : ℕ) :
+    ∃ a ∈ A, ∃ b ∈ B, a + b = n := by
+  set SA : Finset ℕ := {a ∈ Icc 0 n | a ∈ A} with hSA_def
+  set TB : Finset ℕ := {x ∈ Icc 0 n | (n - x) ∈ B} with hTB_def
+  by_cases hdisj : Disjoint SA TB
+  · exfalso
+    have hunion : SA ∪ TB ⊆ Icc 0 n :=
+      union_subset (filter_subset _ _) (filter_subset _ _)
+    have hcardun : SA.card + TB.card ≤ (Icc 0 n).card := by
+      rw [← card_union_of_disjoint hdisj]
+      exact card_le_card hunion
+    have hIcc : (Icc 0 n).card = n + 1 := by rw [Nat.card_Icc]; omega
+    have hSA : schnirelmannDensity A * n + 1 ≤ (SA.card : ℝ) := card_Icc_filter_ge hA0 n
+    have hTB : schnirelmannDensity B * n + 1 ≤ (TB.card : ℝ) := card_reflect_filter hB0 n
+    have hcast : (SA.card : ℝ) + (TB.card : ℝ) ≤ (n : ℝ) + 1 := by
+      have hnat : SA.card + TB.card ≤ n + 1 := by rw [hIcc] at hcardun; exact hcardun
+      have : ((SA.card + TB.card : ℕ) : ℝ) ≤ ((n + 1 : ℕ) : ℝ) := by exact_mod_cast hnat
+      push_cast at this; linarith
+    have hge1 : (n : ℝ) ≤ schnirelmannDensity A * n + schnirelmannDensity B * n := by
+      have h2 := mul_le_mul_of_nonneg_right h (by positivity : (0 : ℝ) ≤ (n : ℝ))
+      rw [one_mul, add_mul] at h2
+      exact h2
+    linarith
+  · rw [Finset.not_disjoint_iff] at hdisj
+    obtain ⟨x, hxSA, hxTB⟩ := hdisj
+    simp only [hSA_def, mem_filter, mem_Icc] at hxSA
+    simp only [hTB_def, mem_filter, mem_Icc] at hxTB
+    obtain ⟨⟨_, hxn⟩, hxA⟩ := hxSA
+    obtain ⟨_, hnxB⟩ := hxTB
+    exact ⟨x, hxA, n - x, hnxB, by omega⟩
+
+/-- If `0 ∈ A` and the Schnirelmann density of `A` is at least `1/2`, then `A`
+    is an additive basis of order `2`: every natural number is a sum of two
+    elements of `A`. Immediate from the covering lemma with `B := A`. -/
+theorem basis_order_two_of_density_ge_half
+    (hA0 : 0 ∈ A) (h : 1 / 2 ≤ schnirelmannDensity A) (n : ℕ) :
+    ∃ a ∈ A, ∃ b ∈ A, a + b = n :=
+  sumset_covers_of_density_add_ge_one hA0 hA0 (by linarith) n
+
+/-
+  ── Remaining gap toward `schnirelmann_basis_theorem` ─────────────────────────
+
+  The `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean` states
+    σ(A) > 0 → ∃ h, IsAdditiveBasis A h.
+  Discharging it from the covering lemma above requires two further ingredients:
+
+    1. Schnirelmann's inequality (subadditivity of the "deficiency" 1 − σ):
+         σ(A ⊕ B) ≥ σ(A) + σ(B) − σ(A)·σ(B),   equivalently
+         1 − σ(A ⊕ B) ≤ (1 − σ(A))·(1 − σ(B)).
+       This is the delicate gap-counting step (Ruzsa, *Sumsets and structure*).
+
+    2. Iteration: from (1), 1 − σ(h·A) ≤ (1 − σ(A))^h, so for h large enough
+       that (1 − σ(A))^h < 1/2 we get σ(h·A) > 1/2; two copies of h·A then have
+       density sum > 1, and `sumset_covers_of_density_add_ge_one` finishes:
+       every n is a sum of ≤ 2h elements of A, i.e. A is a basis of order 2h.
+
+  Step (1) is the outstanding work; the covering lemma (step 2's engine) is now
+  available for it.
+-/
+
+end SchnirelmannBasis

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -322,3 +322,40 @@ comet; the open conjecture is untouched and a nontrivial LOWER bound remains the
 The one large axiom-discharging target is still `schnirelmann_basis_theorem` (~300–500 LOC,
 elementary, flagged Mathlib gap). Worked in locked `/private/tmp/wt-r4-goldbach`, committed
 before building (the `.loom/worktrees/researcher-4` deletion hazard did not recur this pass).
+
+## Session 2026-07-03 (researcher-4) — ACT: Schnirelmann covering lemma VERIFIED (component toward discharging `schnirelmann_basis_theorem`)
+
+**Mode**: ACT (build) · **Outcome**: new verified file `proofs/Proofs/SchnirelmannBasis.lean`
+(3 theorems, 0 sorry, 0 axiom, kernel-checked). **Does NOT yet discharge the axiom** — one
+further ingredient remains (see below). No change to `WeakGoldbach.lean`; its 5 axioms stand.
+
+Prior sessions flagged `schnirelmann_basis_theorem` (σ(A)>0 ⟹ additive basis) as the one
+tractable-in-principle axiom, ~300–500 LOC, elementary, an explicit **Mathlib TODO**. This
+session built the first of its two components.
+
+**Built (`SchnirelmannBasis.lean`):**
+- `sumset_covers_of_density_add_ge_one` — **Schnirelmann's covering lemma**: `0∈A`, `0∈B`,
+  `σ(A)+σ(B) ≥ 1` ⟹ every `n` is `a+b`, `a∈A`, `b∈B`. This is verbatim the Mathlib TODO item
+  *"if the sum of two densities is at least one, the sumset covers the positive naturals."*
+  Proof = classical pigeonhole: `|A∩[0,n]| ≥ σA·n+1` (`card_Icc_filter_ge`) and the reflected
+  count `|{x∈[0,n] : n−x∈B}| ≥ σB·n+1` (`card_reflect_filter`, via the involution `x↦n−x`
+  injecting `B∩[1,n]` plus the endpoint `x=n`); disjoint ⟹ their union `⊆ [0,n]` forces
+  `(σA+σB)·n ≤ n−1`, contradicting `σA+σB≥1`, so they meet.
+- `basis_order_two_of_density_ge_half` — corollary: `0∈A`, `σ(A) ≥ 1/2` ⟹ `A⊕A ⊇ ℕ` (basis
+  of order 2). Immediate from the covering lemma with `B:=A`.
+
+Key Mathlib API leaned on: `schnirelmannDensity_mul_le_card_filter` (σ·n ≤ |A∩Ioc 0 n|),
+`card_image_of_injOn`, `card_union_of_disjoint`, `Nat.sub_sub_self`.
+
+**Remaining gap to discharge the axiom (documented in-file):**
+1. **Schnirelmann's inequality** `σ(A⊕B) ≥ σA+σB−σA·σB` (subadditivity of the deficiency
+   `1−σ`). This is the delicate gap-counting step (Ruzsa, *Sumsets and structure*) — the truly
+   hard part, still open here.
+2. Iteration: `1−σ(h·A) ≤ (1−σA)^h` ⟹ pick `h` with `σ(h·A) > 1/2`, then
+   `basis_order_two_of_density_ge_half` on `h·A` gives a basis of order `2h`.
+
+Once (1) lands, `schnirelmann_basis_theorem` becomes a theorem and one axiom leaves
+`WeakGoldbach.lean`. The covering engine (2's finisher) is now in place.
+
+Aristotle MCP available this cycle but not used (covering lemma proved manually; the residual
+sumset inequality is a gap-argument, not a named-lemma lookup Aristotle would resolve).

--- a/research/problems/weak-goldbach-oq-01/state.md
+++ b/research/problems/weak-goldbach-oq-01/state.md
@@ -1,35 +1,34 @@
 # Research State: weak-goldbach-oq-01
 
 ## Current State
-**Phase**: SURVEY
+**Phase**: ACT (in progress)
 **Path**: full
-**Since**: 2026-07-03T21:40:00-07:00
-**Iteration**: 2
+**Since**: 2026-07-03
+**Iteration**: 3
 
 ## Current Focus
-Axiom audit complete. `proofs/Proofs/WeakGoldbach.lean` is a mature,
-legitimately-axiomatized file (30 theorems, 0 sorry, 5 axioms). All 5 axioms are
-irreducible with current Mathlib — binary Goldbach is open, and the supporting
-results (Helfgott, circle method, Chen) are unformalizable; the 4·10¹⁸
-verification is uncomputable in-kernel (a `decide`-checked `n ≤ 30` companion
-already exists).
+Discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean`. Split
+into two components; the **covering** component is now built and verified in
+`proofs/Proofs/SchnirelmannBasis.lean` (Schnirelmann's covering lemma + the
+density-≥-½ basis-of-order-2 corollary, 0 sorry / 0 axiom).
 
 ## Active Approach
-None active. No quick axiom-elimination exists here.
+Schnirelmann's theorem, decomposed:
+- [DONE] Covering lemma: σA+σB ≥ 1 ⟹ A⊕B ⊇ ℕ  (`sumset_covers_of_density_add_ge_one`).
+- [OPEN] Schnirelmann's inequality: σ(A⊕B) ≥ σA+σB−σA·σB — the gap-counting step.
+- [OPEN] Iteration 1−σ(h·A) ≤ (1−σA)^h to reach density > ½, then apply the
+  order-2 corollary to `h·A` ⟹ basis of order 2h ⟹ discharge the axiom.
 
 ## Attempt Count
-- Total attempts: 1 (survey)
-- Approaches tried: 0 mathematical
+- Total attempts: 2 (1 survey, 1 act)
+- Approaches tried: covering lemma (SUCCESS), sumset inequality (not yet attempted)
 
 ## Blockers
-- Binary Goldbach is genuinely open (must remain axiomatized).
-- The one tractable-in-principle axiom, `schnirelmann_basis_theorem`, is an explicit
-  **Mathlib TODO** (not available to import) — formalizing it is a large (~300–500 line)
-  dedicated effort, not a quick win.
-- Aristotle MCP down (`Resource not found`).
+- Schnirelmann's inequality is the delicate gap-counting argument (Ruzsa,
+  *Sumsets and structure*); an open Mathlib TODO. Non-trivial to formalize.
+- Binary Goldbach itself remains genuinely open (must stay axiomatized).
 
 ## Next Action
-Dedicated future session: formalize **Schnirelmann's theorem** (σ(A)>0 ⟹ additive
-basis) — elementary (sumset density inequality + iteration), would discharge one
-axiom here and fill a flagged Mathlib gap. Otherwise this problem is SURVEY-complete
-and blocked on deep/open results.
+Formalize Schnirelmann's inequality `σ(A⊕B) ≥ σA+σB−σA·σB` (with 0∈A, 0∈B), then
+the iteration; this closes the chain to `schnirelmann_basis_theorem`. The covering
+finisher is already in place in `SchnirelmannBasis.lean`.


### PR DESCRIPTION
## Summary

New verified file `proofs/Proofs/SchnirelmannBasis.lean` (3 theorems, **0 sorry, 0 axiom**, kernel-checked) formalizing **Schnirelmann's covering lemma** — a verbatim item from the Mathlib `Combinatorics/Schnirelmann.lean` TODO list and a necessary component toward discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean`.

## What's proved

- **`sumset_covers_of_density_add_ge_one`**: if `0 ∈ A`, `0 ∈ B`, and `σ(A) + σ(B) ≥ 1`, then every natural `n` is `a + b` with `a ∈ A`, `b ∈ B`.
  This is exactly the Mathlib TODO item *"if the sum of two densities is at least one, the sumset covers the positive naturals."* Proof is the classical pigeonhole: `|A∩[0,n]| ≥ σA·n+1` and the reflected count `|{x∈[0,n] : n−x∈B}| ≥ σB·n+1` (via the involution `x↦n−x`); if disjoint their union `⊆ [0,n]` forces `(σA+σB)·n ≤ n−1`, contradicting `σA+σB ≥ 1`, so they intersect.
- **`basis_order_two_of_density_ge_half`**: if `0 ∈ A` and `σ(A) ≥ 1/2` then `A⊕A ⊇ ℕ` (additive basis of order 2). Immediate corollary.

## Honest scope

This **does not discharge** `schnirelmann_basis_theorem` — `WeakGoldbach.lean` is unchanged and its 5 axioms stand. Full discharge additionally needs **Schnirelmann's inequality** `σ(A⊕B) ≥ σA+σB−σA·σB` (the delicate gap-counting step) plus the density-boosting iteration `1−σ(h·A) ≤ (1−σA)^h`; those remain open. This PR builds the *covering engine* that the iteration's finisher will call. The remaining gap is documented in-file and in `research/problems/weak-goldbach-oq-01/{knowledge,state}.md`.

## Verification

Built via `./proofs/scripts/docker-build.sh Proofs.SchnirelmannBasis` — succeeds. No `sorry`, no `axiom`, no `native_decide` (`#print axioms` reduces to `propext, Classical.choice, Quot.sound`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)