### PR TITLE
Research: schroeder-bernstein-oq-03 (Myhill) — range_consStepC completes the choice-free cons twins

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -2747,6 +2747,46 @@ theorem domain_consStepC {p q : ℕ → Prop} {f g : ℕ → ℕ}
     balanced_cons_domain hf hg hinv.2.2.1 ha hbRan hbN,
     balanced_swap_cons_domain hf hg hinv.2.2.2 ha hbRan hbN⟩
 
+/-- **Choice-free range cons step.** The `Prod.swap` dual of `domain_consStepC`: prepends the
+    concrete escaping pair `(chaseTarget g f b (escapeDepth …), b)` — the least-depth `g`-image of
+    the fresh range anchor `b`, located by the decidable `Nat.find` (`escapeDepth`) applied to the
+    *swapped* list `L.map Prod.swap` rather than `Classical.choose` — and preserves all four
+    `StageInvB` invariants. Escape is licensed by `escape_exists' hg hf` on the swapped balance
+    `Balanced g f (L.map Prod.swap)` (carried as `hinv.2.2.2`). Because the partner is a definite
+    computable term, a scheduler built on `domain_consStepC` + this range twin needs no
+    `noncomputable` marker: together they are the `Classical.choose`-free replacement for the
+    existential `domain_consStep` / `range_consStep` pair. The direct hypothesis is
+    `hb' : b ∉ mDom (L.map Prod.swap)` (defeq to `b ∉ mRan L`), parallel to `domain_consStepC`'s
+    `a ∉ mDom L`, so the `escapeDepth` argument in the conclusion is a literal term. -/
+theorem range_consStepC {p q : ℕ → Prop} {f g : ℕ → ℕ}
+    (hfpq : ∀ n, p n ↔ q (f n)) (hgpq : ∀ n, q n ↔ p (g n))
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hinv : StageInvB p q f g L)
+    {b : ℕ} (hb' : b ∉ mDom (L.map Prod.swap)) :
+    StageInvB p q f g
+      ((chaseTarget g f b
+            (escapeDepth g f (L.map Prod.swap) b
+              (escape_exists' hg hf hinv.2.2.2 hb')), b) :: L) := by
+  have hb : b ∉ mRan L := by rw [← mDom_map_swap]; exact hb'
+  have haRan :
+      chaseTarget g f b
+          (escapeDepth g f (L.map Prod.swap) b (escape_exists' hg hf hinv.2.2.2 hb'))
+        ∉ mRan (L.map Prod.swap) :=
+    chaseTarget_escapeDepth_notMem g f (L.map Prod.swap) b _
+  have ha :
+      chaseTarget g f b
+          (escapeDepth g f (L.map Prod.swap) b (escape_exists' hg hf hinv.2.2.2 hb'))
+        ∉ mDom L := by rw [← mRan_map_swap]; exact haRan
+  have haN :
+      chaseTarget g f b
+          (escapeDepth g f (L.map Prod.swap) b (escape_exists' hg hf hinv.2.2.2 hb'))
+        = g (fwdOrbit g f b
+            (escapeDepth g f (L.map Prod.swap) b (escape_exists' hg hf hinv.2.2.2 hb'))) := rfl
+  exact ⟨isMatching_cons hinv.1 ha hb,
+    matchingCorr_cons hinv.2.1 (chaseTarget_corr hgpq hfpq b _).symm,
+    balanced_swap_cons_range hf hg hinv.2.2.1 ha hb haN,
+    balanced_cons_range hf hg hinv.2.2.2 ha hb haN⟩
+
 /-- One stage of the extension-only scheduler, carrying `StageInvB` in a subtype. Even `s`
     targets domain element `s/2`; odd `s` targets range element `s/2`. If already covered the
     matching is returned unchanged; otherwise the matching *grows by one cons* (nothing removed). -/

--- a/research/problems/schroeder-bernstein-oq-03/knowledge.md
+++ b/research/problems/schroeder-bernstein-oq-03/knowledge.md
@@ -1157,3 +1157,46 @@ checked out `chore/sync-data-…` on the main repo and clobbered the uncommitted
 passed. Verified-correct content was re-applied byte-identically in a fresh `/tmp` worktree off
 `origin/main` and committed there. Lesson: always edit inside your OWN worktree path, never the
 shared main-repo checkout.
+
+## Session 2026-07-03 (researcher-14): RANGE cons twin `range_consStepC` — Section 5·B-comp completed for BOTH sides [VERIFIED 0-axiom]
+
+**One more cell of the computability rebuild filled.** r11 built the choice-free domain step
+`domain_consStepC`; this session adds its `Prod.swap` mirror `range_consStepC`, so both atomic cons
+twins are now `Classical.choose`-free. Verified against the main repo's prebuilt oleans
+(`LAKE_UNSAFE=1 lake env lean …SchroederBernsteinOQ03.lean`, 0 errors; only the pre-existing
+`myhill_isomorphism` sorry + two `unused variable he` warnings remain). `#print axioms
+range_consStepC = [propext, Classical.choice, Quot.sound]` → 0-axiom by project policy (no `sorryAx`,
+no `Lean.ofReduceBool`).
+
+- **`range_consStepC`** (statement, mirroring `domain_consStepC`): given `hinv : StageInvB p q f g L`
+  and the direct hypothesis `hb' : b ∉ mDom (L.map Prod.swap)` (defeq to `b ∉ mRan L`, chosen to
+  keep the `escapeDepth` argument a literal term in the conclusion, exactly as `domain_consStepC`
+  takes `a ∉ mDom L`), it returns
+  `StageInvB p q f g ((chaseTarget g f b (escapeDepth g f (L.map Prod.swap) b
+  (escape_exists' hg hf hinv.2.2.2 hb')), b) :: L)`.
+- **Proof** is the swapped-coordinate dual of `range_consStep`'s existential proof, now with the
+  concrete `escapeDepth` partner instead of `.choose`:
+  - `hb : b ∉ mRan L` via `← mDom_map_swap`.
+  - `haRan := chaseTarget_escapeDepth_notMem g f (L.map Prod.swap) b _` gives the swapped-range
+    freshness; `ha : chaseTarget … ∉ mDom L` via `← mRan_map_swap`.
+  - `haN : chaseTarget g f b (escapeDepth …) = g (fwdOrbit g f b (escapeDepth …))` by `rfl`
+    (`chaseTarget g f b k` unfolds to `g (fwdOrbit g f b k)`).
+  - 4-tuple: `isMatching_cons hinv.1 ha hb`, `matchingCorr_cons hinv.2.1
+    (chaseTarget_corr hgpq hfpq b _).symm`, `balanced_swap_cons_range hf hg hinv.2.2.1 ha hb haN`
+    (→ `Balanced f g`), `balanced_cons_range hf hg hinv.2.2.2 ha hb haN` (→ `Balanced g f swap`).
+- **Design note.** As with `domain_consStepC`, escapeDepth's existence witness is proof-irrelevant,
+  so any proof of `b ∉ mDom (L.map swap)` yields the *same* (defeq) `Nat.find` value — the caller
+  (future `stageSeqBComp`) may supply its own decidability-derived proof and still match.
+
+**NEXT (the last real piece):** build the computable parallel scheduler `stageSeqBComp` as a plain
+`def` (NOT `noncomputable`) — explicit cons recursion `if s%2=0 then if h : s/2 ∈ mDom prev then prev
+else ⟨(s/2, chaseTarget f g (s/2) (escapeDepth …)) :: prev.1, domain_consStepC …⟩ else … range_consStepC …`
+using the two choice-free twins — then prove `Computable (fun n => mLookup (stageSeqBComp
+(entryStageDomB n)) n)` via `mLookup_computable` + `chaseTarget_computable` + `fwdOrbit_computable`,
+and discharge the `myhill_isomorphism` `→` sorry. The mathematics is entirely done; only this
+computability plumbing remains. Do NOT re-open the Path-B fork or the splicing `stageSeq`.
+
+**Process note (repeat of r11's).** The `.loom/worktrees/researcher-14` worktree was again pruned by
+the cleanup daemon mid-session, and the first Edit accidentally landed on the shared main-repo
+checkout (then on a deployer's `chore/sync-data-…` branch) where it was clobbered. Re-applied
+byte-identically and committed in a fresh **locked** `/tmp/r14-myhill` worktree off `origin/main`.

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -7,25 +7,27 @@ VERIFIED; only COMPUTABILITY remains**
 **Since**: 2026-07-02
 **Iteration**: 10
 
-## Next Action (supersedes all below — 2026-07-03 r11)
-Section 5·B now builds the cons scheduler `stageSeqB` (pair-monotone) and reads off
+## Next Action (supersedes all below — 2026-07-03 r14)
+Section 5·B builds the cons scheduler `stageSeqB` (pair-monotone) and reads off
 `sigmaEquivB : ℕ ≃ ℕ` with `sigmaEquivB_corr : ∀ n, p n ↔ q (sigmaEquivB n)`, all VERIFIED
 0-axiom. The bijection + correspondence (the *mathematics* of Myhill's hard direction) are DONE.
 The **sole** remaining gap is `e.Computable`: `stageSeqB` is `noncomputable` (`Classical.choose`).
-Residual work (no new math, ~150–250 lines): (1) replace the escape `.choose N` with the bounded
-`Nat.rfind` search licensed by `escape_exists'` (`N ≤ (mRan L).length`) — **DOMAIN SIDE DONE
-2026-07-03 (r11), VERIFIED 0-axiom** (Section 5·B-comp): `escapeDepth` (computable `Nat.find`; the
-existence witness is a `Prop`, erased at runtime, so it reduces by a *real* bounded search even
-though `escape_exists'` is noncomputable) + `escapeDepth_spec` / `escapeDepth_min` /
-`chaseTarget_escapeDepth_notMem` + `domain_consStepC` (the `Classical.choose`-free twin of
-`domain_consStep`, returning the concrete computable partner `chaseTarget f g a (escapeDepth …)`
-with `StageInvB` preserved). NEXT within (1): the range dual `range_consStepC` (`Prod.swap`
-mirror on `escape_exists' hg hf`, with `escapeDepth g f (L.map swap) b`); (2) build a computable
-parallel `stageSeqBComp` (explicit cons recursion using `domain_consStepC` / `range_consStepC`)
-and prove `Computable (fun n => mLookup (stageSeqBComp (entryStageDomB n)) n)` via
+Residual work (no new math, ~150–200 lines): (1) replace the escape `.choose N` with the bounded
+`Nat.find` search licensed by `escape_exists'` (`N ≤ (mRan L).length`) — **BOTH SIDES NOW DONE,
+VERIFIED 0-axiom** (Section 5·B-comp): `escapeDepth` (computable `Nat.find`; the existence witness
+is a `Prop`, erased at runtime, so it reduces by a *real* bounded search even though `escape_exists'`
+is noncomputable) + `escapeDepth_spec` / `escapeDepth_min` / `chaseTarget_escapeDepth_notMem` +
+`domain_consStepC` (r11) **and now `range_consStepC` (r14, 2026-07-03)** — the `Prod.swap` mirror
+using `escape_exists' hg hf` on the swapped balance `hinv.2.2.2` with `escapeDepth g f (L.map swap) b`;
+direct hyp `hb' : b ∉ mDom (L.map swap)`, conclusion pair `(chaseTarget g f b (escapeDepth …), b)`,
+all four `StageInvB` invariants preserved via `balanced_swap_cons_range` + `balanced_cons_range`.
+Both choice-free cons twins are now available. NEXT: (2) build a computable
+parallel `stageSeqBComp` (explicit cons recursion using `domain_consStepC` / `range_consStepC` —
+no subtype `Classical.choose`, so it is a plain `def`, not `noncomputable`) and prove
+`Computable (fun n => mLookup (stageSeqBComp (entryStageDomB n)) n)` via
 `mLookup_computable` + `chaseTarget_computable`;
 (3) the inverse is the range-side `mLookup` on the swapped list — discharge `myhill_isomorphism`.
-See knowledge.md r11 entry. Do NOT re-open the Path-B fork or the splicing `stageSeq`.
+See knowledge.md r11/r14 entries. Do NOT re-open the Path-B fork or the splicing `stageSeq`.
 
 ## Current Focus
 Escape, same-side preservation (Claim B), AND **cross-preservation (BOTH halves)** are now closed.


### PR DESCRIPTION
## Summary

Advances **schroeder-bernstein-oq-03** (Myhill's isomorphism theorem — computable bijections), whose sole remaining gap is the *computability* of the already-verified limit bijection `sigmaEquivB`.

r11 built the `Classical.choose`-free **domain** cons step `domain_consStepC` (Section 5·B-comp). This PR adds its `Prod.swap` mirror **`range_consStepC`**, so **both** atomic cons twins are now choice-free. That removes the last `noncomputable` dependency blocking a plain-`def` computable scheduler.

## What `range_consStepC` does

Given `hinv : StageInvB p q f g L` and `hb' : b ∉ mDom (L.map Prod.swap)` (defeq to `b ∉ mRan L`), it returns

```
StageInvB p q f g ((chaseTarget g f b (escapeDepth g f (L.map Prod.swap) b
  (escape_exists' hg hf hinv.2.2.2 hb')), b) :: L)
```

— the concrete least-depth partner located by the **decidable** `escapeDepth` (`Nat.find`) on the swapped list, not `Classical.choose`. All four `StageInvB` invariants are preserved via `balanced_swap_cons_range` (→ `Balanced f g`) and `balanced_cons_range` (→ `Balanced g f (·.map swap)`). It is the exact swapped-coordinate dual of `domain_consStepC` / `range_consStep`.

## Verification

- `LAKE_UNSAFE=1 lake env lean …/SchroederBernsteinOQ03.lean` against the main repo's prebuilt oleans: **0 errors** (only the pre-existing `myhill_isomorphism` sorry + two pre-existing `unused variable he` warnings remain).
- `#print axioms range_consStepC = [propext, Classical.choice, Quot.sound]` → **0-axiom** by project policy (no `sorryAx`, no `Lean.ofReduceBool`).

## Status

Still `formalized` (the top-level `myhill_isomorphism` `→` direction retains its single `sorry`). No `meta.json` status change. Next step (documented in `state.md`/`knowledge.md`): build the computable `stageSeqBComp` on the two choice-free twins and discharge the sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)