### PR TITLE
research(mz-slln): discrete layer-cake tail-sum — S4b step-2 (Borel–Cantelli input)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -40,6 +40,18 @@
       to a uniform `L¹` bound on the partial sums, via
       `Submartingale.exists_ae_tendsto_of_bdd`.
 
+  **Truncation input — discrete layer cake (§ TailSum, step 2).** The MZ
+  truncation `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}` is justified by Borel–Cantelli, whose
+  input is the summable tail `∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`. For `Z = |X₀|ᵖ` this is
+  the deterministic tail-sum bound below; Mathlib has the continuous layer cake
+  but no discrete companion, so we supply it:
+
+    * `tsum_measure_add_one_le_lintegral` — `∑ₙ μ{Z ≥ n+1} ≤ ∫⁻ ofReal Z` for
+      measurable `Z ≥ 0`, via `lintegral_tsum` and the pointwise count
+      `∑ₙ 𝟙{n+1 ≤ Z} = ⌊Z⌋₊ ≤ Z`.
+    * `tsum_measure_add_one_ne_top` — the finiteness corollary that feeds the
+      first Borel–Cantelli lemma.
+
   Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`).
 -/
 import Mathlib
@@ -504,5 +516,86 @@ theorem ae_tendsto_sum_of_indep_of_variance_bdd [IsProbabilityMeasure μ]
   exact h12.trans (eLpNorm_two_partialSum_le X hindep hmemLp hmean V hV n)
 
 end Kolmogorov
+
+/-! ## S4b (step 2) — the tail-sum / Borel–Cantelli input
+
+The Marcinkiewicz–Zygmund truncation `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}` is justified by the
+first Borel–Cantelli lemma: `∑ᵢ P(Xᵢ ≠ Yᵢ) = ∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`, so a.s.
+`Xᵢ = Yᵢ` eventually and it suffices to prove the law for the truncations.  For
+identically distributed `Xᵢ` and `Z := |X₀|ᵖ ≥ 0`, this reduces to the deterministic
+measure-theoretic fact that the **tail sum** `∑ₙ μ{Z ≥ n+1}` is dominated by the first
+moment `∫⁻ ofReal Z` — the discrete companion of the layer-cake formula.  Mathlib has
+the continuous layer cake (`lintegral_eq_lintegral_meas_le`) but no discrete tail-sum
+bound; we supply it, together with the finiteness corollary that feeds Borel–Cantelli. -/
+
+section TailSum
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- **Pointwise tail count is bounded by the value.**  For `z ≥ 0`, the number of
+positive integers `n+1 ≤ z` — counted in `ℝ≥0∞` as `∑ₙ 𝟙{n+1 ≤ z}` — equals `⌊z⌋₊`,
+and hence is at most `z`. -/
+theorem tsum_indicator_add_one_le (z : ℝ) (hz : 0 ≤ z) :
+    ∑' n : ℕ, (if (n : ℝ) + 1 ≤ z then (1 : ℝ≥0∞) else 0) ≤ ENNReal.ofReal z := by
+  have hiff : ∀ n : ℕ, ((n : ℝ) + 1 ≤ z) ↔ n < ⌊z⌋₊ := by
+    intro n
+    rw [show (n : ℝ) + 1 = ((n + 1 : ℕ) : ℝ) by push_cast; ring,
+      ← Nat.le_floor_iff hz, Nat.add_one_le_iff]
+  have hcount : ∑' n : ℕ, (if (n : ℝ) + 1 ≤ z then (1 : ℝ≥0∞) else 0) = (⌊z⌋₊ : ℝ≥0∞) := by
+    have hcongr : ∀ n : ℕ, (if (n : ℝ) + 1 ≤ z then (1 : ℝ≥0∞) else 0)
+        = (if n < ⌊z⌋₊ then (1 : ℝ≥0∞) else 0) := fun n => by simp only [hiff n]
+    simp_rw [hcongr]
+    rw [tsum_eq_sum (s := Finset.range ⌊z⌋₊) fun n hn => if_neg (by simpa using hn),
+      Finset.sum_congr rfl fun n hn => if_pos (Finset.mem_range.mp hn),
+      Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one]
+  rw [hcount, ← ENNReal.ofReal_natCast]
+  exact ENNReal.ofReal_le_ofReal (Nat.floor_le hz)
+
+/-- **Discrete tail-sum bound (discrete layer cake / first-moment estimate).**  For a
+measurable `Z ≥ 0`, the tail sum of super-level measures is dominated by the first
+moment:
+
+    ∑ₙ μ {ω | (n : ℝ) + 1 ≤ Z ω}  ≤  ∫⁻ ω, ENNReal.ofReal (Z ω) ∂μ.
+
+This is the discrete companion of the layer-cake formula and the analytic core of the
+Marcinkiewicz–Zygmund truncation step (step 2): applied to `Z = |X₀|ᵖ` it turns the
+finite `p`-th moment `𝔼|X₀|ᵖ < ∞` into a summable tail `∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`.
+Proof: write each `μ Aₙ` as the integral of `𝟙_{Aₙ}`, swap sum and integral
+(`lintegral_tsum`), and bound the pointwise tail count `∑ₙ 𝟙{n+1 ≤ Z ω} = ⌊Z ω⌋₊ ≤ Z ω`. -/
+theorem tsum_measure_add_one_le_lintegral {Z : Ω → ℝ}
+    (hZmeas : Measurable Z) (hZnn : 0 ≤ Z) :
+    ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ Z x} ≤ ∫⁻ ω, ENNReal.ofReal (Z ω) ∂μ := by
+  have hA : ∀ n : ℕ, MeasurableSet {x | (n : ℝ) + 1 ≤ Z x} := fun n =>
+    measurableSet_le measurable_const hZmeas
+  have hswap : ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ Z x}
+      = ∫⁻ ω, ∑' n : ℕ, ({x | (n : ℝ) + 1 ≤ Z x}.indicator 1) ω ∂μ :=
+    calc ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ Z x}
+        = ∑' n : ℕ, ∫⁻ ω, ({x | (n : ℝ) + 1 ≤ Z x}.indicator 1) ω ∂μ :=
+          tsum_congr fun n => (lintegral_indicator_one (hA n)).symm
+      _ = ∫⁻ ω, ∑' n : ℕ, ({x | (n : ℝ) + 1 ≤ Z x}.indicator 1) ω ∂μ :=
+          (lintegral_tsum fun n => (measurable_const.indicator (hA n)).aemeasurable).symm
+  rw [hswap]
+  refine lintegral_mono fun ω => ?_
+  have hpt : (∑' n : ℕ, ({x | (n : ℝ) + 1 ≤ Z x}.indicator (1 : Ω → ℝ≥0∞)) ω)
+      = ∑' n : ℕ, (if (n : ℝ) + 1 ≤ Z ω then (1 : ℝ≥0∞) else 0) :=
+    tsum_congr fun n => by rw [Set.indicator_apply]; simp [Set.mem_setOf_eq]
+  rw [hpt]
+  exact tsum_indicator_add_one_le (Z ω) (hZnn ω)
+
+/-- **Summable tail from a finite first moment.**  If `Z ≥ 0` is measurable with finite
+first moment `∫⁻ ofReal Z < ∞`, the super-level tail sum is finite:
+`∑ₙ μ{Z ≥ n+1} ≠ ∞`.  This is exactly the hypothesis consumed by the first
+Borel–Cantelli lemma (`MeasureTheory.measure_limsup_eq_zero`), which then gives
+`Z < n+1` eventually a.s. — i.e. the MZ truncation `|Xᵢ| ≤ i^{1/p}` holds eventually. -/
+theorem tsum_measure_add_one_ne_top {Z : Ω → ℝ}
+    (hZmeas : Measurable Z) (hZnn : 0 ≤ Z)
+    (hZint : ∫⁻ ω, ENNReal.ofReal (Z ω) ∂μ ≠ ∞) :
+    ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ Z x} ≠ ∞ :=
+  ((tsum_measure_add_one_le_lintegral hZmeas hZnn).trans_lt hZint.lt_top).ne
+
+end TailSum
 
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -318,3 +318,58 @@ verified infrastructure, not scaffolding. It does not yet prove Marcinkiewicz–
 remaining **S4b** truncation/moment layer (Borel–Cantelli on `{X_i≠Y_i}`, `∑ Var(Y_i)/i^{2/p}<∞`
 via `p<2`) then feeds S4a into `ae_tendsto_kronecker_average_zero`. Worked in locked
 `/private/tmp/wt-r4-lln`, committed before building (worktree-deletion hazard did not recur).
+
+## S4b step-2 (researcher-14, 2026-07-03) — BUILD: discrete layer-cake tail-sum SHIPPED (verified)
+
+The Borel–Cantelli *input* for the MZ truncation is the summable tail
+`∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`. For identically distributed `Xᵢ` this is a deterministic
+measure-theoretic fact about `Z = |X₀|ᵖ ≥ 0`: the tail sum `∑ₙ μ{Z ≥ n+1}` is dominated
+by the first moment. Mathlib has the *continuous* layer cake
+(`lintegral_eq_lintegral_meas_le`) but **no discrete companion** (confirmed by repo-wide
+grep). Three theorems added to `Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TailSum),
+**0-sorry / 0-axiom** (`#print axioms` = propext/Classical.choice/Quot.sound on all three
+— no sorryAx, no `Lean.ofReduceBool`). Verified via `LAKE_UNSAFE=1 lake env lean` against
+the pinned prebuilt Mathlib oleans (v4.26.0): 0 errors.
+
+1. **`tsum_indicator_add_one_le (z : ℝ) (hz : 0 ≤ z)`** — pure ENNReal helper:
+   `∑' n, (if (n:ℝ)+1 ≤ z then 1 else 0) ≤ ENNReal.ofReal z`. The tail count equals
+   `⌊z⌋₊`: the summand is `1` iff `n < ⌊z⌋₊` (via `Nat.le_floor_iff hz` + `Nat.add_one_le_iff`
+   after `(n:ℝ)+1 = ((n+1:ℕ):ℝ)`), then `tsum_eq_sum` over `Finset.range ⌊z⌋₊`; finally
+   `⌊z⌋₊ ≤ z` by `Nat.floor_le`.
+2. **`tsum_measure_add_one_le_lintegral {Z} (hZmeas : Measurable Z) (hZnn : 0 ≤ Z)`** —
+   `∑ₙ μ{x | (n:ℝ)+1 ≤ Z x} ≤ ∫⁻ ω, ENNReal.ofReal (Z ω) ∂μ`. Proof: each `μ Aₙ =
+   ∫⁻ 𝟙_{Aₙ}` (`lintegral_indicator_one`, `Aₙ` measurable by `measurableSet_le`), swap
+   sum/integral (`lintegral_tsum`), pointwise bound via (1).
+3. **`tsum_measure_add_one_ne_top {Z} (… ) (hZint : ∫⁻ ofReal Z ≠ ∞)`** — finiteness
+   corollary `∑ₙ μ{Z ≥ n+1} ≠ ∞`, the exact hypothesis of first Borel–Cantelli
+   (`measure_limsup_eq_zero`).
+
+### Reusable Lean gotchas (Mathlib v4.26)
+
+- **`rw [lintegral_tsum h]` FAILS to unify** when the integrand is `s.indicator 1` (the
+  `1 : Ω → ℝ≥0∞` constant-one function): the higher-order matcher can't recover `f i a`
+  from `(s.indicator 1) a`. **Fix:** don't `rw`; use it as a `calc` step
+  `_ = ∫⁻ … := (lintegral_tsum h).symm` — the *expected type* of the calc step pins `f`,
+  so elaboration succeeds. (General lesson: for HO-unification-hostile lemmas, drive with
+  the expected type via `calc`/`exact`, not `rw`.)
+- `measurable_const.indicator (hs : MeasurableSet s) : Measurable (s.indicator (fun _ => c))`
+  unifies `c := 1` against `s.indicator 1` (Pi `1 = fun _ => 1` defeq). `.aemeasurable`
+  gives the `lintegral_tsum` hypothesis.
+- `lintegral_indicator_one (hs : MeasurableSet s) : ∫⁻ a, s.indicator 1 a ∂μ = μ s`.
+- `tsum_eq_sum (s := Finset.range N) (fun n hn => …) : ∑' = ∑ over range` — supply the
+  "zero outside `s`" proof; `simpa using hn` turns `n ∉ range N` into `¬ n < N` for `if_neg`.
+- `ENNReal.ofReal_natCast (n) : ENNReal.ofReal ↑n = ↑n` — use `← ` to turn `(⌊z⌋₊:ℝ≥0∞)`
+  into `ENNReal.ofReal ↑⌊z⌋₊` before `ENNReal.ofReal_le_ofReal (Nat.floor_le hz)`.
+- Avoid shadowing: write the super-level set as `{x | (n:ℝ)+1 ≤ Z x}` (not `{ω | …}`) so
+  the set-builder variable doesn't collide with the `∫⁻ ω` integration variable.
+
+### Honest status
+
+S4b step-2 is a genuine, complete, verified brick — the discrete layer-cake tail-sum and
+its Borel–Cantelli-feeding corollary — reusable well beyond MZ. It does **not** yet prove
+Marcinkiewicz–Zygmund: remaining are S4b step-1 (i.i.d. reduction to apply this to
+`Z=|X₀|ᵖ` + `measure_limsup_eq_zero`), step-3 (centered-truncation control), step-4
+(`∑ Var(Yᵢ)/i^{2/p}<∞`, uses `p<2`), then assembly with S4a + S2 Kronecker lift. Worked in
+a locked `/private/tmp/r14-session-*` worktree off `origin/main`, committed before verifying
+(the worktree-deletion hazard recurred at session start — designated `.loom/worktrees/researcher-14`
+was gone again; the locked /tmp worktree avoids the clobber trap).

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4a variance L¹-bound SHIPPED — S4b truncation remains)
+**Phase**: ACT (S4b step-2 tail-sum SHIPPED — remaining S4b analytic layer)
 **Since**: 2026-07-03
-**Iteration**: 5 (S4a Kolmogorov-from-variance-sum SHIPPED; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 6 (S4b step-2 discrete-layer-cake tail-sum SHIPPED; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -28,37 +28,49 @@ already in Mathlib; S3 was assembly, and it is now assembled.
 
 None in-flight. Next work item is S4 below.
 
+## S4b step-2 — DONE (iteration 6, PR pending)
+
+The **discrete layer-cake tail-sum bound** — the Borel–Cantelli input for the truncation
+step — is now in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TailSum), all
+**0-sorry / 0-axiom** (`#print axioms` = propext/Classical.choice/Quot.sound):
+
+- `tsum_indicator_add_one_le` — pure ENNReal helper: `∑ₙ 𝟙{n+1 ≤ z} = ⌊z⌋₊ ≤ z`.
+- `tsum_measure_add_one_le_lintegral` — `∑ₙ μ{Z ≥ n+1} ≤ ∫⁻ ofReal Z` for measurable
+  `Z ≥ 0`. Proof: `lintegral_indicator_one` + `lintegral_tsum` swap + pointwise count.
+- `tsum_measure_add_one_ne_top` — finiteness corollary feeding `measure_limsup_eq_zero`.
+
+**Do NOT re-derive this.** Applied to `Z = |X₀|ᵖ` (with identical distribution and
+`𝔼|X₀|ᵖ < ∞`), it yields `∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`, hence a.s. `Xᵢ = Yᵢ` eventually.
+
 ## Blockers
 
-- **S4a (variance L¹ bound, ~1 short session, self-contained):** discharge the
-  `hbdd` hypothesis of `ae_tendsto_sum_of_indep_of_eLpNorm_bdd` from
-  `∑ Var(X_i) < ∞`. On a probability space,
-  `eLpNorm S_n 1 ≤ eLpNorm S_n 2 = sqrt(Var[S_n]) = sqrt(∑_{i≤n} Var[X_i]) ≤
-  sqrt(∑ Var)`. Named Mathlib pieces: `ProbabilityTheory.IndepFun.variance_sum`
-  (variance of independent sum = sum of variances), `evariance` ↔ `eLpNorm 2`
-  bridge under mean-zero (`evariance_eq_lintegral_ofReal` / `variance` real
-  form), `eLpNorm_le_eLpNorm_of_exponent_le` (needs `IsProbabilityMeasure`).
-  Fiddly part: ENNReal/rpow bookkeeping connecting `eLpNorm _ 2` to the real
-  `variance`. This yields the standalone Kolmogorov convergence criterion.
-- **S4b (truncation + moment estimates, multi-session):** the M–Z-specific
-  analytic layer — truncation `Y_i = X_i·1{|X_i| ≤ i^{1/p}}`, `∑ P(X_i≠Y_i)<∞`
-  (Borel–Cantelli), centered-truncation control, and the variance-sum estimate
-  `∑ Var(Y_i)/i^{2/p} < ∞` (uses `p < 2`). Then combine S4a + Kronecker lift.
+- **S4b step-1 (identical-distribution reduction, ~1 session):** connect the tail-sum
+  bound to the i.i.d. truncation. From `IdentDistrib (Xᵢ) (X₀)` derive
+  `μ{|Xᵢ| > i^{1/p}} = μ{|X₀|ᵖ > i}`, then apply `tsum_measure_add_one_ne_top` with
+  `Z = |X₀|ᵖ` and the first Borel–Cantelli lemma (`measure_limsup_eq_zero`, needs the
+  `≠ ∞` we now provide) to get `∀ᵐ ω, ∀ᶠ i, Xᵢ ω = Yᵢ ω` where `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.
+- **S4b step-3 (centered-truncation control, ~1 session):** `∑ᵢ 𝔼Yᵢ / n^{1/p} → 0`
+  using `𝔼X = 0` and a moment/`rpow` estimate on the truncated means (Kronecker-style).
+- **S4b step-4 (variance-sum estimate, ~1–2 sessions):** `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`
+  (uses `p < 2`, so `2/p > 1` — this is where `p < 2` is *essential*). Then feed into
+  `ae_tendsto_sum_of_indep_of_variance_bdd` (S4a) and lift via
+  `ae_tendsto_kronecker_average_zero` (S2) for the final M–Z normalisation.
+
+**DONE (do not re-derive):** S1 survey · S2 Kronecker · S3 martingale · **S4a variance
+L¹-bound** (`ae_tendsto_sum_of_indep_of_variance_bdd` + `eLpNorm_two_sq_eq_evariance` +
+`eLpNorm_two_partialSum_le`, 0-axiom) · **S4b step-2 tail-sum** (this iteration).
 
 ## Next Action
 
-- **S4a — DONE (iteration 5, PR pending).** `ae_tendsto_sum_of_indep_of_variance_bdd`
-  discharges the `hbdd` L¹ bound from `∑_{i≤n} Var(Xᵢ) ≤ V`, plus the two supporting
-  lemmas `eLpNorm_two_sq_eq_evariance` (the mean-zero `‖X‖₂² = eVar[X]` bridge — Mathlib
-  gap) and `eLpNorm_two_partialSum_le` (uniform L² bound). All 0-axiom, build ✔ 7743 jobs.
-- **S4b (next):** the truncation moment-estimate layer — `Y_i = X_i·1{|X_i| ≤ i^{1/p}}`,
-  `∑ P(X_i≠Y_i)<∞` (Borel–Cantelli), centered-truncation control, variance-sum estimate
-  `∑ Var(Y_i)/i^{2/p} < ∞` (uses `p < 2`). Then feed S4a into the Kronecker lift
-  `ae_tendsto_kronecker_average_zero` for the final M–Z normalisation.
+- **S4b step-1 (next):** identical-distribution reduction — from `IdentDistrib (Xᵢ) (X₀)`
+  get `μ{|Xᵢ| > i^{1/p}} = μ{|X₀|ᵖ > i}`, apply `tsum_measure_add_one_ne_top` (this
+  iteration) + first Borel–Cantelli (`measure_limsup_eq_zero`) ⟹ a.s. `Xᵢ = Yᵢ` eventually.
+  Then S4b step-3 (centering) and step-4 (variance sum, uses `p<2`).
 
 ## Attempt Counts
 
-- Total attempts: 5 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound)
-- Current approach attempts: 1 (S4a variance bound — landed on 2nd build)
-- Approaches tried: 4 (S1 literature/decomposition; S2 Abel+Toeplitz;
-  S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge)
+- Total attempts: 6 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum)
+- Current approach attempts: 1 (S4b step-2 tail-sum — landed on 2nd elaboration; calc restructure of the lintegral_tsum swap)
+- Approaches tried: 5 (S1 literature/decomposition; S2 Abel+Toeplitz;
+  S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
+  S4b discrete layer cake via lintegral_tsum + floor count)


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — S4b step-2

Problem: `laws-of-large-numbers-oq-01-oq-02-oq-01` (Marcinkiewicz–Zygmund strong law, `1 ≤ p < 2`).

This iteration ships the **discrete companion of the layer-cake formula** — the analytic core of the MZ truncation step. It is the Borel–Cantelli *input* that justifies replacing `Xᵢ` by the truncation `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.

### What's new (`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`, § TailSum)

For measurable `Z ≥ 0`:

```
∑ₙ μ {x | (n:ℝ) + 1 ≤ Z x}  ≤  ∫⁻ ω, ENNReal.ofReal (Z ω) ∂μ
```

so a finite first moment yields a **summable tail**. Applied to `Z = |X₀|ᵖ`, `𝔼|X₀|ᵖ < ∞` becomes `∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞` — the hypothesis of the first Borel–Cantelli lemma.

| Theorem | Statement |
|---|---|
| `tsum_indicator_add_one_le` | pointwise tail count `∑ₙ 𝟙{n+1 ≤ z} = ⌊z⌋₊ ≤ z` (ℝ≥0∞) |
| `tsum_measure_add_one_le_lintegral` | the tail-sum bound above (`lintegral_tsum` swap + floor count) |
| `tsum_measure_add_one_ne_top` | finiteness corollary `∑ₙ μ{Z ≥ n+1} ≠ ∞`, feeding `measure_limsup_eq_zero` |

Mathlib has the **continuous** layer cake (`lintegral_eq_lintegral_meas_le`) but no discrete tail-sum bound (confirmed by repo-wide grep).

### Verification

- `LAKE_UNSAFE=1 lake env lean` against pinned Mathlib **v4.26.0** oleans: **0 errors**.
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` — **0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).
- 0 sorries.

### Honest scope

This is a genuine, reusable brick — **not** a proof of Marcinkiewicz–Zygmund. Remaining S4b work (see `state.md`/`knowledge.md`): step-1 i.i.d. reduction (apply this to `Z=|X₀|ᵖ` via `IdentDistrib` + first Borel–Cantelli), step-3 centered-truncation control, step-4 variance-sum estimate `∑ Var(Yᵢ)/i^{2/p} < ∞` (uses `p<2`), then assembly with the already-shipped S4a variance L¹-bound and S2 Kronecker lift.

Builds on prior iterations: S2 Kronecker's lemma, S3 martingale assembly, S4a Kolmogorov variance-sum criterion — all previously merged, all 0-axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)