### PR TITLE
research(collatz-cycles-oq-02-oq-01): CF convergents of log₂3 + sharp two-sided rational cycle bounds

### DIFF
--- a/proofs/Proofs/CollatzCyclesOQ02OQ01.lean
+++ b/proofs/Proofs/CollatzCyclesOQ02OQ01.lean
@@ -1,0 +1,255 @@
+import Proofs.CollatzCyclesOQ02
+import Mathlib
+
+/-!
+# Collatz Cycles OQ-02-OQ-01: Continued-Fraction Convergents of `log₂ 3` and a Sharp Rational Cycle Bound
+
+The parent `CollatzCyclesOQ02` proves, for a hypothetical non-trivial Collatz cycle with
+`J` odd (tripling) steps and `M` even (halving) steps, the logarithmic lower bound
+`M > J · log₂ 3` (and `L = M + J > J · log₂ 6`), but it explicitly leaves the **sharp
+numerical refinement** — Eliahou's use of the *continued-fraction expansion* of `log₂ 3`
+to control the cycle length — unformalised.
+
+This file supplies the continued-fraction ingredient in a fully elementary, axiom-free way.
+
+## The continued fraction of `log₂ 3`
+
+`log₂ 3 = 1.5849625007…` has continued fraction expansion
+
+  `log₂ 3 = [1; 1, 1, 2, 2, 3, 1, 5, …]`,
+
+with convergents
+
+  `1/1,  2/1,  3/2,  8/5,  19/12,  65/41,  84/53,  485/306,  …`
+
+The even-indexed convergents lie **below** `log₂ 3` and the odd-indexed ones lie **above**.
+Every one of these bounds is equivalent to a *decidable integer comparison* between powers
+of `2` and `3`, because
+
+  `p/q < log₂ 3  ⟺  2^p < 3^q`      and      `p/q > log₂ 3  ⟺  2^p > 3^q`.
+
+We verify the whole ladder up to `485/306` this way (`norm_num` on the power comparisons),
+obtaining the rigorous sandwich
+
+  `84/53  <  log₂ 3  <  485/306`,
+
+i.e. `log₂ 3` is pinned to an interval of width `485/306 − 84/53 = 1/16218 ≈ 6.2·10⁻⁵`.
+
+## A sharp rational lower bound on cycle length (no logarithms)
+
+The lower convergent `84/53 < log₂ 3` yields, via the halving constraint `3^J < 2^M`, the
+clean **integer** inequality
+
+  `53 · M  ≥  84 · J + 1`,
+
+proved *without any real analysis*: chaining `2^{84} < 3^{53}` and `3^J < 2^M` gives
+`2^{84J} < 3^{53J} < 2^{53M}`, whence `84J < 53M` by strict monotonicity of `2^{(·)}`.
+Adding `53 · J` to both sides sharpens the cycle-length bound to
+
+  `53 · L = 53(M + J)  ≥  137 · J + 1`,   i.e.   `L ≥ (137 J + 1)/53 > 2.5849 · J`,
+
+matching the slope `log₂ 6 ≈ 2.585` of the parent's real-analytic bound but with an
+explicit rational constant coming directly from a convergent of `log₂ 3`.
+
+## Honest scope
+
+This formalises the continued-fraction *convergent bounds* of `log₂ 3` and the sharp
+rational bounds they give for the cycle length: the lower convergent `84/53` yields
+`53·M ≥ 84·J + 1` in the cycle regime `3^J < 2^M`, and the upper convergent `485/306`
+yields the mirror bound `306·M + 1 ≤ 485·J` in the anti-cycle regime `2^M < 3^J`, so the
+two sharpest convergents bracket the crossover ratio `M/J` from both sides with explicit
+integer certificates. Eliahou's celebrated numerical constant (a non-trivial cycle has
+length `≥ 17 087 915`) additionally needs the *two-sided* Diophantine gap on a *single*
+`(M,J)` — an upper constraint `2^M < 3^J·(1 + small)` from the cycle's minimal element —
+combined with the best-approximation denominators; that sharper second ingredient is beyond
+this entry. What is proved here is exactly the CF-approximation input, axiom-free.
+
+`#print axioms` on the headline results shows only `propext`, `Classical.choice`,
+`Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
+-/
+
+open Real
+
+-- The convergent certificates compare powers up to `2^485` / `3^306`; raise `norm_num`'s
+-- exponentiation-evaluation threshold (default 256) so these integer comparisons evaluate.
+set_option exponentiation.threshold 512
+
+namespace CollatzCyclesOQ02OQ01
+
+/-! ## Part I: from power comparisons to logarithm bounds -/
+
+/-- **Lower convergent bound.** If `2^p < 3^q` then `p < q · log₂ 3`, i.e. `p/q < log₂ 3`.
+The whole content is monotonicity of `log₂` applied to the integer inequality `2^p < 3^q`. -/
+theorem pow_lt_to_logb {p q : ℕ} (h : 2 ^ p < 3 ^ q) :
+    (p : ℝ) < (q : ℝ) * Real.logb 2 3 := by
+  have hcast : (2 : ℝ) ^ p < (3 : ℝ) ^ q := by exact_mod_cast h
+  have h2pos : (0 : ℝ) < (2 : ℝ) ^ p := by positivity
+  have hlt : Real.logb 2 ((2 : ℝ) ^ p) < Real.logb 2 ((3 : ℝ) ^ q) :=
+    Real.logb_lt_logb (by norm_num) h2pos hcast
+  rw [Real.logb_pow, Real.logb_pow, Real.logb_self_eq_one (by norm_num)] at hlt
+  rw [mul_one] at hlt
+  exact hlt
+
+/-- **Upper convergent bound.** If `3^q < 2^p` then `q · log₂ 3 < p`, i.e. `log₂ 3 < p/q`. -/
+theorem pow_gt_to_logb {p q : ℕ} (h : 3 ^ q < 2 ^ p) :
+    (q : ℝ) * Real.logb 2 3 < (p : ℝ) := by
+  have hcast : (3 : ℝ) ^ q < (2 : ℝ) ^ p := by exact_mod_cast h
+  have h3pos : (0 : ℝ) < (3 : ℝ) ^ q := by positivity
+  have hlt : Real.logb 2 ((3 : ℝ) ^ q) < Real.logb 2 ((2 : ℝ) ^ p) :=
+    Real.logb_lt_logb (by norm_num) h3pos hcast
+  rw [Real.logb_pow, Real.logb_pow, Real.logb_self_eq_one (by norm_num)] at hlt
+  rw [mul_one] at hlt
+  exact hlt
+
+/-! ## Part II: the continued-fraction ladder for `log₂ 3`
+
+Each bound is stated in cleared-denominator form `p < q · log₂ 3` (a convergent below)
+or `q · log₂ 3 < p` (a convergent above); the power comparison is discharged by `norm_num`.
+The convergents are `1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306`. -/
+
+/-- Convergent `1/1` (below): `1 < log₂ 3`. -/
+theorem conv_1_1 : (1 : ℝ) < 1 * Real.logb 2 3 := by
+  have h := pow_lt_to_logb (p := 1) (q := 1) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `2/1` (above): `log₂ 3 < 2`. -/
+theorem conv_2_1 : 1 * Real.logb 2 3 < (2 : ℝ) := by
+  have h := pow_gt_to_logb (p := 2) (q := 1) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `3/2` (below): `3 < 2 · log₂ 3`. -/
+theorem conv_3_2 : (3 : ℝ) < 2 * Real.logb 2 3 := by
+  have h := pow_lt_to_logb (p := 3) (q := 2) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `8/5` (above): `5 · log₂ 3 < 8`. -/
+theorem conv_8_5 : 5 * Real.logb 2 3 < (8 : ℝ) := by
+  have h := pow_gt_to_logb (p := 8) (q := 5) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `19/12` (below): `19 < 12 · log₂ 3`. -/
+theorem conv_19_12 : (19 : ℝ) < 12 * Real.logb 2 3 := by
+  have h := pow_lt_to_logb (p := 19) (q := 12) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `65/41` (above): `41 · log₂ 3 < 65`. -/
+theorem conv_65_41 : 41 * Real.logb 2 3 < (65 : ℝ) := by
+  have h := pow_gt_to_logb (p := 65) (q := 41) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `84/53` (below): `84 < 53 · log₂ 3`. This is the sharpest lower convergent
+of the ladder; `84/53 = 1.5849056… < log₂ 3`. -/
+theorem conv_84_53 : (84 : ℝ) < 53 * Real.logb 2 3 := by
+  have h := pow_lt_to_logb (p := 84) (q := 53) (by norm_num); push_cast at h; linarith
+
+/-- Convergent `485/306` (above): `306 · log₂ 3 < 485`. This is the sharpest upper convergent
+of the ladder; `485/306 = 1.5849673… > log₂ 3`. -/
+theorem conv_485_306 : 306 * Real.logb 2 3 < (485 : ℝ) := by
+  have h := pow_gt_to_logb (p := 485) (q := 306) (by norm_num); push_cast at h; linarith
+
+/-- **Headline sandwich.** The two sharpest convergents pin `log₂ 3` to the interval
+`(84/53, 485/306)` of width `1/16218`:
+
+  `84 < 53 · log₂ 3`   and   `306 · log₂ 3 < 485`. -/
+theorem logb_two_three_sandwich :
+    (84 : ℝ) < 53 * Real.logb 2 3 ∧ 306 * Real.logb 2 3 < (485 : ℝ) :=
+  ⟨conv_84_53, conv_485_306⟩
+
+/-! ## Part III: the sharp rational cycle bound (elementary, no logarithms) -/
+
+/-- **Sharp halving bound from the convergent `84/53`.**
+
+For a hypothetical non-trivial Collatz cycle with `J` odd steps and `M` even steps (halving
+constraint `3^J < 2^M`), the halvings satisfy the sharp *integer* inequality
+
+  `53 · M ≥ 84 · J + 1`.
+
+The proof is purely arithmetic — no real logarithms. From the convergent inequality
+`2^{84} < 3^{53}` we get `2^{84J} < 3^{53J}`, and raising the cycle constraint to the `53`rd
+power gives `3^{53J} < 2^{53M}`; chaining and cancelling the base `2` yields `84J < 53M`. -/
+theorem sharp_halving_bound {M J : ℕ} (h : 3 ^ J < 2 ^ M) :
+    84 * J + 1 ≤ 53 * M := by
+  rcases Nat.eq_zero_or_pos J with hJ | hJ
+  · -- `J = 0`: the constraint is `1 < 2^M`, forcing `M ≥ 1`, so `84·0 + 1 ≤ 53·M`.
+    subst hJ
+    simp only [pow_zero] at h
+    have hM : M ≠ 0 := by rintro rfl; simp at h
+    omega
+  · -- `J ≥ 1`: chain `2^{84J} < 3^{53J} < 2^{53M}`.
+    have hbase : (2 : ℕ) ^ 84 < 3 ^ 53 := by norm_num
+    have h1 : (2 : ℕ) ^ (84 * J) < 3 ^ (53 * J) := by
+      rw [pow_mul, pow_mul]
+      exact Nat.pow_lt_pow_left hbase hJ.ne'
+    have h2 : (3 : ℕ) ^ (53 * J) < 2 ^ (53 * M) := by
+      have e1 : (3 : ℕ) ^ (53 * J) = (3 ^ J) ^ 53 := by rw [← pow_mul, Nat.mul_comm]
+      have e2 : (2 : ℕ) ^ (53 * M) = (2 ^ M) ^ 53 := by rw [← pow_mul, Nat.mul_comm]
+      rw [e1, e2]
+      exact Nat.pow_lt_pow_left h (by norm_num)
+    have h3 : (2 : ℕ) ^ (84 * J) < 2 ^ (53 * M) := lt_trans h1 h2
+    have h4 : 84 * J < 53 * M := (Nat.pow_lt_pow_iff_right (by norm_num)).mp h3
+    omega
+
+/-- **Sharp cycle-length bound.** With total length `L = M + J`, the sharp halving bound
+gives `53 · L ≥ 137 · J + 1`, i.e. `L > (137/53) · J = 2.5849… · J`. This reproduces the
+parent's real-analytic slope `log₂ 6 ≈ 2.585` with an explicit rational constant drawn from
+the continued fraction of `log₂ 3`. -/
+theorem sharp_cycle_length_bound {M J : ℕ} (h : 3 ^ J < 2 ^ M) :
+    137 * J + 1 ≤ 53 * (M + J) := by
+  have := sharp_halving_bound h
+  omega
+
+/-! ## Part IV: the dual bound from the upper convergent `485/306`
+
+Parts II–III used the *lower* convergent `84/53 < log₂ 3` (integer certificate `2^84 < 3^53`).
+The *upper* convergent `log₂ 3 < 485/306` (integer certificate `3^306 < 2^485`) gives the
+mirror-image inequality, closing the elementary two-sided pinning of the ratio `M/J`. -/
+
+/-- **Dual sharp bound from the upper convergent `485/306`.**
+
+In the *anti-cycle* regime where tripling dominates (`2^M < 3^J`), the halvings obey the
+sharp *integer* upper bound
+
+  `306 · M + 1 ≤ 485 · J`,
+
+again with no real analysis. From the convergent certificate `3^306 < 2^485` we raise
+`2^M < 3^J` to the `306`th power: `2^{306M} < 3^{306J} = (3^306)^J < (2^485)^J = 2^{485M}`,
+and cancel the base `2`. Together with `sharp_halving_bound` this shows the two sharpest
+convergents `84/53` and `485/306` *bracket* the crossover ratio `M/J = log₂ 3` from both
+sides with explicit integer certificates. -/
+theorem sharp_tripling_bound {M J : ℕ} (h : 2 ^ M < 3 ^ J) :
+    306 * M + 1 ≤ 485 * J := by
+  rcases Nat.eq_zero_or_pos J with hJ | hJ
+  · -- `J = 0`: the hypothesis becomes `2^M < 1`, impossible since `2^M ≥ 1`.
+    subst hJ
+    simp only [pow_zero] at h
+    have : 1 ≤ 2 ^ M := Nat.one_le_pow _ _ (by norm_num)
+    omega
+  · -- `J ≥ 1`: chain `2^{306M} < 3^{306J} < 2^{485J}`.
+    have hbase : (3 : ℕ) ^ 306 < 2 ^ 485 := by norm_num
+    have h1 : (2 : ℕ) ^ (306 * M) < 3 ^ (306 * J) := by
+      have e1 : (2 : ℕ) ^ (306 * M) = (2 ^ M) ^ 306 := by rw [← pow_mul, Nat.mul_comm]
+      have e2 : (3 : ℕ) ^ (306 * J) = (3 ^ J) ^ 306 := by rw [← pow_mul, Nat.mul_comm]
+      rw [e1, e2]
+      exact Nat.pow_lt_pow_left h (by norm_num)
+    have h2 : (3 : ℕ) ^ (306 * J) < 2 ^ (485 * J) := by
+      rw [pow_mul, pow_mul]
+      exact Nat.pow_lt_pow_left hbase hJ.ne'
+    have h3 : (2 : ℕ) ^ (306 * M) < 2 ^ (485 * J) := lt_trans h1 h2
+    have h4 : 306 * M < 485 * J := (Nat.pow_lt_pow_iff_right (by norm_num)).mp h3
+    omega
+
+/-- **Two-sided ratio pinning.** Combining the two sharpest convergents, for any `J ≥ 1`:
+if the halving constraint `3^J < 2^M` holds (a genuine cycle) then `M/J > 84/53`, and if the
+reverse `2^M < 3^J` holds then `M/J < 485/306`. Stated in cleared-denominator integer form,
+the crossover `2^M` vs `3^J` is certified by these two convergents on either side. -/
+theorem ratio_pinned_by_convergents {M J : ℕ} :
+    (3 ^ J < 2 ^ M → 84 * J + 1 ≤ 53 * M) ∧
+    (2 ^ M < 3 ^ J → 306 * M + 1 ≤ 485 * J) :=
+  ⟨sharp_halving_bound, sharp_tripling_bound⟩
+
+/-- Sanity check: `M = 6` is excluded at `J = 4` (the parent's ladder requires `M ≥ 7`),
+since the halving constraint `3^4 < 2^6` is false (`81 > 64`). -/
+theorem sharp_bound_excludes_M6_at_J4 : ¬ (3 ^ 4 < 2 ^ 6) := by norm_num
+
+end CollatzCyclesOQ02OQ01
+
+-- Axiom audit: only the standard foundational axioms, in particular no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms CollatzCyclesOQ02OQ01.sharp_halving_bound
+#print axioms CollatzCyclesOQ02OQ01.sharp_tripling_bound
+#print axioms CollatzCyclesOQ02OQ01.ratio_pinned_by_convergents
+#print axioms CollatzCyclesOQ02OQ01.logb_two_three_sandwich

--- a/src/data/proofs/collatz-cycles-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/collatz-cycles-oq-02-oq-01/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "collatzoq0201-header",
+    "proofId": "collatz-cycles-oq-02-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 65
+    },
+    "type": "concept",
+    "title": "Module Header: The Continued Fraction of log₂3 and Honest Scope",
+    "content": "The parent `CollatzCyclesOQ02` proves the logarithmic lower bound $M > J\\log_2 3$ for a hypothetical non-trivial Collatz cycle but leaves Eliahou's *continued-fraction refinement* unformalized. This file supplies that ingredient. The continued fraction $\\log_2 3 = [1;1,1,2,2,3,1,5,\\dots]$ has convergents $1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306$, alternately below and above $\\log_2 3$. The crucial observation is that each convergent bound is a *decidable integer comparison*: $p/q < \\log_2 3 \\iff 2^p < 3^q$. The docstring is explicit about scope — this formalizes the continued-fraction *input*, not Eliahou's full numerical constant (length $\\geq 17{,}087{,}915$), which additionally needs a two-sided Diophantine gap on a single $(M,J)$ from the cycle's minimal element.",
+    "mathContext": "$\\log_2 3 = 1.5849625\\dots$; convergents alternate below/above; $p/q < \\log_2 3 \\iff 2^p < 3^q$ and $p/q > \\log_2 3 \\iff 2^p > 3^q$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz conjecture",
+      "3x+1 problem",
+      "continued fractions",
+      "Diophantine approximation",
+      "Eliahou's theorem"
+    ],
+    "prerequisites": [
+      "the Collatz map",
+      "continued-fraction convergents",
+      "base-2 logarithm"
+    ]
+  },
+  {
+    "id": "collatzoq0201-bridge",
+    "proofId": "collatz-cycles-oq-02-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "Bridge: Power Comparisons Become Logarithm Bounds",
+    "content": "`pow_lt_to_logb` and `pow_gt_to_logb` turn a decidable integer inequality into a real logarithm bound. If $2^p < 3^q$ then applying the strictly monotone $\\log_2$ (base $2 > 1$) and simplifying $\\log_2(2^p) = p$, $\\log_2(3^q) = q\\log_2 3$ gives $p < q\\log_2 3$; the reverse comparison gives the upper bound. These two lemmas are the only place real analysis enters, and even they are just monotonicity of `logb` composed with `logb_pow` and `logb_self_eq_one`.",
+    "mathContext": "$2^p < 3^q \\Rightarrow p < q\\log_2 3$ and $3^q < 2^p \\Rightarrow q\\log_2 3 < p$, via `Real.logb_lt_logb`, `Real.logb_pow`, `Real.logb_self_eq_one`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "logarithm monotonicity",
+      "base-2 logarithm"
+    ],
+    "prerequisites": [
+      "monotonicity of logb"
+    ]
+  },
+  {
+    "id": "collatzoq0201-ladder",
+    "proofId": "collatz-cycles-oq-02-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 150
+    },
+    "type": "key-step",
+    "title": "The Continued-Fraction Ladder and the Width-1/16218 Sandwich",
+    "content": "Each convergent theorem `conv_p_q` discharges its power comparison by `norm_num` (with `exponentiation.threshold` raised to 512 so powers up to $2^{485}$ and $3^{306}$ evaluate). The ladder $1/1 < \\log_2 3 < 2/1$, $3/2 < \\log_2 3 < 8/5$, $19/12 < \\log_2 3 < 65/41$, $84/53 < \\log_2 3 < 485/306$ tightens on both sides. `logb_two_three_sandwich` collects the two sharpest convergents into $84/53 < \\log_2 3 < 485/306$, an interval of width $485/306 - 84/53 = 1/16218 \\approx 6.2\\times10^{-5}$.",
+    "mathContext": "$84/53 = 1.5849056\\dots < \\log_2 3 < 1.5849673\\dots = 485/306$; width $1/16218$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "continued-fraction convergents",
+      "best rational approximation",
+      "decidable arithmetic"
+    ],
+    "prerequisites": [
+      "continued fractions",
+      "norm_num on integer powers"
+    ]
+  },
+  {
+    "id": "collatzoq0201-cycle-bound",
+    "proofId": "collatz-cycles-oq-02-oq-01",
+    "range": {
+      "startLine": 152,
+      "endLine": 193
+    },
+    "type": "key-step",
+    "title": "Sharp Rational Cycle Bound Without Real Analysis",
+    "content": "`sharp_halving_bound` proves the integer inequality $53M \\geq 84J + 1$ from the cycle constraint $3^J < 2^M$, using only the certificate $2^{84} < 3^{53}$: chaining $2^{84J} < 3^{53J} < 2^{53M}$ in $\\mathbb{N}$ and cancelling the base $2$ (strict monotonicity of $n\\mapsto 2^n$) gives $84J < 53M$. `sharp_cycle_length_bound` adds $53J$ to reach $53L \\geq 137J + 1$, i.e. $L > 2.5849J$ — reproducing the parent's real-analytic slope $\\log_2 6 \\approx 2.585$ with an explicit rational constant $137/53$ drawn directly from the convergent $84/53$. No logarithms appear in these proofs.",
+    "mathContext": "From $3^J < 2^M$: $53M \\geq 84J + 1$ and $53(M+J) \\geq 137J + 1$; constant $137/53 = 2.5849\\dots \\approx \\log_2 6$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Collatz cycle length",
+      "strict monotonicity of exponentials",
+      "rational approximation of log₂6"
+    ],
+    "prerequisites": [
+      "the halving constraint 3^J < 2^M",
+      "Nat.pow_lt_pow_left"
+    ]
+  },
+  {
+    "id": "collatzoq0201-dual",
+    "proofId": "collatz-cycles-oq-02-oq-01",
+    "range": {
+      "startLine": 195,
+      "endLine": 244
+    },
+    "type": "key-step",
+    "title": "Dual Bound and Two-Sided Ratio Pinning",
+    "content": "`sharp_tripling_bound` is the mirror image using the *upper* convergent $485/306$ (certificate $3^{306} < 2^{485}$): in the anti-cycle regime $2^M < 3^J$, raising to the $306$th power gives $2^{306M} < 3^{306J} < 2^{485J}$, so $306M + 1 \\leq 485J$. `ratio_pinned_by_convergents` packages both directions: the two sharpest convergents bracket the crossover ratio $M/J = \\log_2 3$ from both sides with explicit integer certificates. This closes the *elementary* two-sided pinning; Eliahou's sharper constant needs the two-sided Diophantine gap on a single $(M,J)$, which remains out of scope.",
+    "mathContext": "From $2^M < 3^J$: $306M + 1 \\leq 485J$ (mirror of $53M \\geq 84J + 1$); together they certify $M/J$ vs $\\log_2 3$ on both sides.",
+    "significance": "central",
+    "relatedConcepts": [
+      "dual convergent bound",
+      "two-sided rational approximation",
+      "anti-cycle regime"
+    ],
+    "prerequisites": [
+      "the upper convergent 485/306",
+      "Nat.pow_lt_pow_left"
+    ]
+  }
+]

--- a/src/data/proofs/collatz-cycles-oq-02-oq-01/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-02-oq-01/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "collatz-cycles-oq-02-oq-01",
+  "title": "Collatz Cycles OQ-02-OQ-01: Continued-Fraction Convergents of log₂3 and Sharp Rational Cycle Bounds",
+  "slug": "collatz-cycles-oq-02-oq-01",
+  "description": "Formalizes the continued-fraction convergents of log₂3 in a fully elementary, axiom-free way and uses them to sharpen the cycle-length bound of collatz-cycles-oq-02. Each convergent p/q of log₂3 is equivalent to a decidable integer comparison between powers of 2 and 3 (p/q < log₂3 ⟺ 2^p < 3^q), so the ladder 1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306 is verified by norm_num on power comparisons, pinning log₂3 to the interval (84/53, 485/306) of width 1/16218. The lower convergent yields the sharp integer bound 53·M ≥ 84·J + 1 (hence 53·L ≥ 137·J + 1) for a hypothetical cycle, and the upper convergent yields the mirror bound 306·M + 1 ≤ 485·J in the anti-cycle regime — bracketing the crossover ratio M/J = log₂3 from both sides with explicit integer certificates, with no real analysis. This is the continued-fraction input to Eliahou's theorem; his full numerical constant (length ≥ 17,087,915) needs an additional two-sided Diophantine gap on a single (M,J) beyond this entry.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CollatzCyclesOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "collatz",
+      "dynamical-systems",
+      "continued-fractions",
+      "diophantine-approximation",
+      "cycle-length",
+      "eliahou"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Mathlib.Analysis.SpecialFunctions.Log.Base (logb_lt_logb, logb_pow, logb_self_eq_one)",
+      "Mathlib.Algebra.Order.Monoid.Lemmas (Nat.pow_lt_pow_left, Nat.pow_lt_pow_iff_right)"
+    ],
+    "originalContributions": [
+      "pow_lt_to_logb / pow_gt_to_logb: bridge from decidable integer power comparisons 2^p ⋚ 3^q to logarithm bounds p ⋚ q·log₂3, via monotonicity of logb",
+      "conv_1_1 … conv_485_306: the continued-fraction ladder 1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306 of log₂3, each verified by norm_num on the equivalent power comparison",
+      "logb_two_three_sandwich: the two sharpest convergents pin log₂3 to (84/53, 485/306), an interval of width 1/16218 ≈ 6.2·10⁻⁵",
+      "sharp_halving_bound: from the cycle halving constraint 3^J < 2^M, the sharp integer bound 53·M ≥ 84·J + 1 (from the lower convergent 84/53), proved without real analysis",
+      "sharp_cycle_length_bound: total length L = M + J satisfies 53·L ≥ 137·J + 1, i.e. L > 2.5849·J, matching the parent's log₂6 slope with an explicit rational constant",
+      "sharp_tripling_bound: dual bound 306·M + 1 ≤ 485·J in the anti-cycle regime 2^M < 3^J (from the upper convergent 485/306), the elementary mirror of sharp_halving_bound",
+      "ratio_pinned_by_convergents: combines both directions, bracketing the crossover ratio M/J = log₂3 with the two sharpest convergents as integer certificates"
+    ],
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "lineCount": 255,
+    "mathlib_version": "v4.26.0",
+    "theoremCount": 16,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Eliahou (1993) proved that any non-trivial cycle of the Collatz map has length at least 17,087,915. The heart of his argument is the continued-fraction expansion of log₂3 = [1; 1, 1, 2, 2, 3, 1, 5, …], whose convergents give the best rational approximations and hence control how closely 2^M can approximate 3^J. The parent entry collatz-cycles-oq-02 formalized the elementary logarithmic core M > J·log₂3 but left the continued-fraction refinement — its explicit openQuestion — unformalized. This entry supplies exactly that continued-fraction ingredient, axiom-free.",
+    "problemStatement": "Formalize the continued-fraction convergents of log₂3 and use them to obtain sharp rational (integer-certified) bounds on the length of a hypothetical non-trivial Collatz cycle, refining the real-analytic bound of collatz-cycles-oq-02.",
+    "proofStrategy": "The key reduction is that every convergent bound p/q ⋚ log₂3 is equivalent to a decidable integer comparison 2^p ⋚ 3^q, discharged by norm_num (with exponentiation.threshold raised to 512 so powers up to 2^485 evaluate). Two bridge lemmas — pow_lt_to_logb and pow_gt_to_logb — turn each power comparison into a logarithm bound via monotonicity of logb. The convergent ladder up to 485/306 then pins log₂3 to a width-1/16218 interval. For the cycle bounds, the arithmetic is kept entirely in ℕ: from the certificate 2^84 < 3^53, raising the cycle constraint 3^J < 2^M through 2^{84J} < 3^{53J} < 2^{53M} and cancelling the base 2 gives 84·J < 53·M; the dual certificate 3^306 < 2^485 gives the mirror bound in the anti-cycle regime.",
+    "keyInsight": "A convergent inequality p/q < log₂3 is exactly the integer statement 2^p < 3^q, so the entire continued-fraction ladder — normally an analytic object — becomes a sequence of decidable norm_num checks, and the resulting cycle bounds can be proved purely in ℕ with no real logarithms at all.",
+    "keyInsights": [
+      "**Convergents are decidable integer comparisons.** p/q < log₂3 ⟺ 2^p < 3^q. This turns the continued-fraction expansion of log₂3 into a ladder of norm_num-checkable power comparisons, with no need for numerical analysis of the logarithm itself.",
+      "**Two convergents pin log₂3 to width 1/16218.** The sharpest lower (84/53) and upper (485/306) convergents give 84/53 < log₂3 < 485/306, an interval of width 485/306 − 84/53 = 1/16218 ≈ 6.2·10⁻⁵.",
+      "**The cycle bound needs no real analysis.** Chaining 2^{84J} < 3^{53J} < 2^{53M} in ℕ and cancelling the base 2 yields the sharp integer bound 53·M ≥ 84·J + 1 directly — the logarithm is a motivating heuristic, not a proof ingredient.",
+      "**The two sharpest convergents bracket the ratio from both sides.** sharp_halving_bound (lower convergent, cycle regime 3^J < 2^M) and sharp_tripling_bound (upper convergent, anti-cycle regime 2^M < 3^J) together certify the crossover ratio M/J = log₂3 with explicit integers on either side.",
+      "**Honest scope.** This is the continued-fraction *input* to Eliahou's theorem. His numerical constant additionally needs the two-sided Diophantine gap on a single (M,J) from the cycle's minimal element, which is deliberately out of scope here."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "From Power Comparisons to Logarithm Bounds",
+      "startLine": 79,
+      "endLine": 102,
+      "summary": "pow_lt_to_logb and pow_gt_to_logb: monotonicity of logb turns the decidable integer inequalities 2^p ⋚ 3^q into the logarithm bounds p ⋚ q·log₂3."
+    },
+    {
+      "id": "ladder",
+      "title": "The Continued-Fraction Ladder for log₂3",
+      "startLine": 104,
+      "endLine": 150,
+      "summary": "conv_1_1 … conv_485_306 verify the convergents 1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306 by norm_num on power comparisons; logb_two_three_sandwich pins log₂3 to (84/53, 485/306)."
+    },
+    {
+      "id": "cycle-bound",
+      "title": "Sharp Rational Cycle Bound (Elementary)",
+      "startLine": 152,
+      "endLine": 193,
+      "summary": "sharp_halving_bound (53·M ≥ 84·J + 1) and sharp_cycle_length_bound (53·L ≥ 137·J + 1) from the lower convergent 84/53, proved purely in ℕ."
+    },
+    {
+      "id": "dual-bound",
+      "title": "Dual Bound from the Upper Convergent 485/306",
+      "startLine": 195,
+      "endLine": 244,
+      "summary": "sharp_tripling_bound (306·M + 1 ≤ 485·J in the anti-cycle regime 2^M < 3^J) and ratio_pinned_by_convergents combine both convergents to bracket the crossover ratio M/J from both sides."
+    }
+  ],
+  "conclusion": {
+    "summary": "The continued-fraction convergents of log₂3 are formalized as decidable integer power comparisons, pinning log₂3 to the width-1/16218 interval (84/53, 485/306). The two sharpest convergents give sharp integer cycle bounds — 53·M ≥ 84·J + 1 in the cycle regime and 306·M + 1 ≤ 485·J in the anti-cycle regime — bracketing the crossover ratio M/J = log₂3 from both sides, all axiom-free and with no real analysis in the cycle bounds themselves.",
+    "implications": "**1. Continued fraction as decidable arithmetic.** The whole convergent ladder of log₂3 reduces to norm_num power comparisons, a reusable pattern for approximating any log_b a by rationals.\n\n**2. Sharp rational cycle constant.** The parent's slope log₂6 ≈ 2.585 is reproduced by the explicit rational 137/53 drawn directly from the convergent 84/53.\n\n**3. Honest scope.** This is NOT Eliahou's full numerical bound (length ≥ 17,087,915). That constant sharpens the estimate with a two-sided Diophantine gap on a single (M,J) from the cycle's minimal element, which is not formalized here.",
+    "openQuestions": [
+      "Formalize the two-sided Diophantine gap 3^J < 2^M < 3^J·(1 + ε) from a cycle's minimal element and combine with the best-approximation denominators to reach Eliahou's numerical constant.",
+      "Extend the convergent ladder further (485/306 → 1054/665 → …) to sharpen the width-1/16218 sandwich as needed for downstream bounds.",
+      "Abstract pow_lt_to_logb / pow_gt_to_logb into a general 'convergent = decidable integer comparison' lemma for arbitrary log_b a."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "collatz-cycles-oq-02",
+      "relationship": "extends",
+      "description": "Answers the parent's explicit openQuestion by formalizing the continued-fraction expansion of log₂3 and using its convergents to sharpen the cycle-length bound to an explicit rational constant."
+    },
+    {
+      "targetId": "collatz-cycles-oq-04",
+      "relationship": "depends-on",
+      "description": "The cycle bounds take the halving constraint 3^J < 2^M (established in collatz-cycles-oq-04) as hypothesis."
+    }
+  ],
+  "references": [
+    {
+      "title": "The 3x+1 problem: new lower bounds on nontrivial cycle lengths",
+      "author": "Eliahou, S.",
+      "year": "1993",
+      "description": "Proves any non-trivial Collatz cycle has length ≥ 17,087,915 via the continued-fraction expansion of log₂3 (Discrete Mathematics 118, 45–56)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.CollatzCyclesOQ02",
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CollatzCyclesOQ02OQ01",
+    "lineCount": 255,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 0,
+    "path": "Proofs/CollatzCyclesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}

--- a/src/data/research/problems/collatz-cycles-oq-02-oq-01.json
+++ b/src/data/research/problems/collatz-cycles-oq-02-oq-01.json
@@ -1,0 +1,120 @@
+{
+  "slug": "collatz-cycles-oq-02-oq-01",
+  "title": "Continued-Fraction Expansion of log₂3 for Eliahou's Sharp Cycle-Length Constant",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Compute the continued fraction } \\log_2 3 = [1; 1, 1, 2, 2, 3, 1, 5, \\ldots]\\\n\\text{and use its convergents } p_k/q_k \\text{ to bound } |q \\log_2 3 - p|\\\n\\text{from below, yielding Eliahou's sharp constant in } L \\ge c \\cdot \\log(\\text{min element}).",
+    "plain": "The parent proof gives a general logarithmic lower bound on the length L of a nontrivial Collatz cycle. Eliahou (1993) sharpened the constant in that bound; the sharpening rests on how well log₂3 can be approximated by rationals, which is governed by the continued-fraction expansion of log₂3. This problem asks to formalize that continued-fraction expansion (its early partial quotients / convergents) and extract the explicit irrationality-measure input that produces Eliahou's sharp numerical constant.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": "SOLVED (verified, axiom-free): continued-fraction convergents of log₂3 formalized as decidable integer power comparisons; sharp two-sided rational cycle bounds proved in ℕ. 16 theorems, 0 sorry, 0 axiom, 255 lines in Proofs/CollatzCyclesOQ02OQ01.lean. Gallery entry created. Eliahou's full numerical constant (needs two-sided Diophantine gap on a single (M,J)) remains beyond scope.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: CF convergent ladder of log₂3 + sharp integer cycle bounds, verified axiom-free. PR shipped.",
+    "builtItems": [
+      "pow_lt_to_logb / pow_gt_to_logb (bridge integer power comparison → logb bound) in Proofs/CollatzCyclesOQ02OQ01.lean",
+      "conv_1_1 … conv_485_306 convergent ladder + logb_two_three_sandwich (width-1/16218 sandwich)",
+      "sharp_halving_bound (53M ≥ 84J+1) + sharp_cycle_length_bound (53L ≥ 137J+1) from lower convergent 84/53",
+      "sharp_tripling_bound (306M+1 ≤ 485J) + ratio_pinned_by_convergents (two-sided) from upper convergent 485/306",
+      "Gallery entry src/data/proofs/collatz-cycles-oq-02-oq-01/ (meta.json + 5 annotations)"
+    ],
+    "insights": [
+      "Every convergent bound p/q ⋚ log₂3 is a decidable integer comparison 2^p ⋚ 3^q, so the whole continued-fraction ladder reduces to norm_num power checks (needs exponentiation.threshold ≥ 485).",
+      "The two sharpest convergents 84/53 and 485/306 pin log₂3 to an interval of width 1/16218 ≈ 6.2e-5.",
+      "The sharp integer cycle bound 53M ≥ 84J+1 (and its dual 306M+1 ≤ 485J) can be proved entirely in ℕ with no real analysis, by raising the cycle constraint to the convergent-denominator power and cancelling the base 2.",
+      "The original untracked draft never compiled: norm_num silently fails on 3^306 < 2^485 unless exponentiation.threshold is raised above the default 256."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Formalize the two-sided Diophantine gap 3^J < 2^M < 3^J(1+ε) from a cycle minimal element to reach Eliahou's numerical constant.",
+      "Abstract the convergent = decidable-integer-comparison pattern into a general log_b a lemma."
+    ],
+    "markdown": "# Knowledge Base: collatz-cycles-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nSeeker-selected OQ child of a gallery entry. See problem.md for the full statement, recommended approach, and Mathlib pointers.\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "collatz",
+    "continued-fractions",
+    "diophantine-approximation"
+  ],
+  "relatedProofs": [
+    "collatz-cycles",
+    "collatz-cycles-oq-02",
+    "collatz-cycles-oq-03",
+    "collatz-cycles-oq-04",
+    "collatz-structured-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T13:44:19.513Z",
+  "lastUpdate": "2026-07-03",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/CollatzCycles.lean",
+      "filename": "CollatzCycles.lean",
+      "lineCount": 257,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCycles.lean"
+    },
+    {
+      "path": "Proofs/CollatzCyclesOQ02.lean",
+      "filename": "CollatzCyclesOQ02.lean",
+      "lineCount": 94,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCyclesOQ02.lean"
+    },
+    {
+      "path": "Proofs/CollatzCyclesOQ02OQ01.lean",
+      "filename": "CollatzCyclesOQ02OQ01.lean",
+      "lineCount": 197,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCyclesOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CollatzCyclesOQ03.lean",
+      "filename": "CollatzCyclesOQ03.lean",
+      "lineCount": 81,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCyclesOQ03.lean"
+    },
+    {
+      "path": "Proofs/CollatzCyclesOQ04.lean",
+      "filename": "CollatzCyclesOQ04.lean",
+      "lineCount": 210,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CollatzCyclesOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **continued-fraction convergents of `log₂3`** and uses them to sharpen the Collatz cycle-length bound of the parent `collatz-cycles-oq-02` — answering that entry's explicit open question. Fully elementary and **axiom-free**.

### Mathematical content

- **Convergents = decidable integer comparisons.** The key reduction is `p/q < log₂3 ⟺ 2^p < 3^q`. So the convergent ladder `1/1, 2/1, 3/2, 8/5, 19/12, 65/41, 84/53, 485/306` is verified by `norm_num` on power comparisons — no numerical analysis of the logarithm needed. Two bridge lemmas (`pow_lt_to_logb`, `pow_gt_to_logb`) turn each power comparison into a `logb` bound via monotonicity.
- **Sandwich.** The two sharpest convergents give `84/53 < log₂3 < 485/306`, an interval of width `1/16218 ≈ 6.2·10⁻⁵`.
- **Sharp cycle bounds, no real analysis.** From the halving constraint `3^J < 2^M`, chaining `2^{84J} < 3^{53J} < 2^{53M}` in ℕ and cancelling the base gives `53·M ≥ 84·J + 1`, hence `53·L ≥ 137·J + 1` (`L > 2.5849·J`, reproducing the parent's `log₂6` slope with the explicit rational `137/53`).
- **Dual bound (new).** The upper convergent `485/306` (certificate `3^306 < 2^485`) gives the mirror inequality `306·M + 1 ≤ 485·J` in the anti-cycle regime `2^M < 3^J`. Together (`ratio_pinned_by_convergents`) the two convergents bracket the crossover ratio `M/J = log₂3` from both sides with explicit integer certificates.

### Honest scope

This is the continued-fraction **input** to Eliahou's theorem, not his full numerical constant (length ≥ 17,087,915). That constant additionally needs the two-sided Diophantine gap on a *single* `(M,J)` from the cycle's minimal element, which is deliberately out of scope.

### Verification

- 16 theorems, 0 definitions, **0 sorries, 0 axioms**, 255 lines.
- Verified via `lake env lean` against pinned Mathlib **v4.26.0** → 0 errors.
- `#print axioms` on `sharp_halving_bound`, `sharp_tripling_bound`, `ratio_pinned_by_convergents`, `logb_two_three_sandwich` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

Also fixes a latent bug in the prior untracked draft: `norm_num` cannot evaluate `3^306 < 2^485` unless `exponentiation.threshold` is raised above the default 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)