### PR TITLE
research(lovasz-local-lemma-oq-01): exact two-event inclusion–exclusion avoidance (0-axiom)

### DIFF
--- a/proofs/Proofs/LovaszLocalLemmaOQ01InclusionExclusion.lean
+++ b/proofs/Proofs/LovaszLocalLemmaOQ01InclusionExclusion.lean
@@ -1,0 +1,93 @@
+/-
+# Lovász Local Lemma — OQ-01: Exact Two-Event Inclusion–Exclusion Avoidance
+
+Companion to `Proofs/LovaszLocalLemmaOQ01.lean` (the `d = 0` mutually independent
+base case, avoidance `∏ (1 - μ Aᵢ)`) and
+`Proofs/LovaszLocalLemmaOQ01UnionBound.lean` (the dependency-free first-moment
+bound `μ (⋂ Aᵢᶜ) ≥ 1 - ∑ μ Aᵢ`). Those two files bracket the LLL landscape but
+both *bound* the avoidance probability. This file lands the **exact** value in the
+smallest genuinely-dependent regime — two events — via inclusion–exclusion.
+
+For two measurable events `A, B` over a probability space,
+
+  `μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B)`,
+
+i.e. `μ (Aᶜ ∩ Bᶜ) = 1 - μ A - μ B + μ (A ∩ B)` (stated additively to sidestep
+truncated `ℝ≥0∞` subtraction). This is *exact*, with no independence hypothesis:
+the pairwise overlap `μ (A ∩ B)` is precisely the correction the two-event union
+bound `μ (Aᶜ ∩ Bᶜ) ≥ 1 - μ A - μ B` discards.
+
+The corollary sharpens the union-bound avoidance threshold. The union bound proves
+positive avoidance from `μ A + μ B < 1`; here positivity holds under the strictly
+weaker `μ A + μ B < 1 + μ (A ∩ B)` — weaker by exactly the overlap `μ (A ∩ B)`,
+which is nonzero precisely when the events are positively correlated / dependent.
+This is the first quantitative place where *dependency helps*, foreshadowing why
+the LLL can beat the global `∑ μ Aᵢ < 1` threshold.
+
+## Main results
+
+* `two_event_avoidance_add` : the exact inclusion–exclusion identity
+  `μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B)`.
+* `two_event_avoidance` : positive avoidance `0 < μ (Aᶜ ∩ Bᶜ)` under the sharp
+  threshold `μ A + μ B < 1 + μ (A ∩ B)`.
+* `two_event_avoidance_of_union_lt` : the coarser union-bound sufficient condition
+  `μ A + μ B < 1` follows as a special case, exhibiting the strict improvement.
+-/
+import Mathlib.Probability.Independence.Basic
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace LovaszLocalLemmaOQ01InclusionExclusion
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+variable {A B : Set Ω}
+
+/-- **Exact two-event inclusion–exclusion avoidance identity.**
+For two measurable events over a probability space, the probability that *neither*
+occurs satisfies `μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B)`. Equivalently
+`μ (Aᶜ ∩ Bᶜ) = 1 - μ A - μ B + μ (A ∩ B)`, the exact avoidance value in the
+smallest dependent regime — the additive form avoids `ℝ≥0∞` truncated subtraction.
+No independence is assumed; the pairwise overlap `μ (A ∩ B)` is the exact
+correction dropped by the two-event union bound. -/
+theorem two_event_avoidance_add (hA : MeasurableSet A) (hB : MeasurableSet B) :
+    μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B) := by
+  have hAB : MeasurableSet (A ∪ B) := hA.union hB
+  -- avoidance is the complement of the union
+  have hcompl : Aᶜ ∩ Bᶜ = (A ∪ B)ᶜ := (Set.compl_union A B).symm
+  -- complement partitions the whole space
+  have h1 : μ (Aᶜ ∩ Bᶜ) + μ (A ∪ B) = 1 := by
+    rw [hcompl, add_comm, measure_add_measure_compl hAB, measure_univ]
+  -- inclusion–exclusion for the union
+  have h2 : μ (A ∪ B) + μ (A ∩ B) = μ A + μ B := measure_union_add_inter A hB
+  calc μ (Aᶜ ∩ Bᶜ) + μ A + μ B
+      = μ (Aᶜ ∩ Bᶜ) + (μ A + μ B) := by rw [add_assoc]
+    _ = μ (Aᶜ ∩ Bᶜ) + (μ (A ∪ B) + μ (A ∩ B)) := by rw [h2]
+    _ = (μ (Aᶜ ∩ Bᶜ) + μ (A ∪ B)) + μ (A ∩ B) := by rw [add_assoc]
+    _ = 1 + μ (A ∩ B) := by rw [h1]
+
+/-- **Sharp two-event positive avoidance.**
+Both events are simultaneously avoided with strictly positive probability as soon
+as `μ A + μ B < 1 + μ (A ∩ B)`. This threshold is strictly weaker than the
+union-bound condition `μ A + μ B < 1` whenever the overlap `μ (A ∩ B)` is positive:
+the first quantitative sign that dependency (here, positive correlation) *helps*
+avoid all bad events, which is the mechanism the full LLL exploits. -/
+theorem two_event_avoidance (hA : MeasurableSet A) (hB : MeasurableSet B)
+    (hlt : μ A + μ B < 1 + μ (A ∩ B)) :
+    0 < μ (Aᶜ ∩ Bᶜ) := by
+  rw [pos_iff_ne_zero]
+  intro h0
+  have hid := two_event_avoidance_add (μ := μ) hA hB
+  rw [h0, zero_add] at hid
+  exact hlt.ne hid
+
+/-- The coarse two-event union (first-moment) sufficient condition `μ A + μ B < 1`
+is the special case of `two_event_avoidance` obtained by discarding the overlap
+term `μ (A ∩ B) ≥ 0`. Recorded to make the improvement explicit: the exact identity
+strictly widens the avoidance-guaranteeing region by the pairwise overlap. -/
+theorem two_event_avoidance_of_union_lt (hA : MeasurableSet A) (hB : MeasurableSet B)
+    (hlt : μ A + μ B < 1) :
+    0 < μ (Aᶜ ∩ Bᶜ) :=
+  two_event_avoidance hA hB (lt_of_lt_of_le hlt (le_add_right le_rfl))
+
+end LovaszLocalLemmaOQ01InclusionExclusion

--- a/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-lll-oq01-ie-overview",
+    "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "context",
+    "title": "The first correction to the union bound",
+    "content": "Open question OQ-01 asks for the genuine **measure-theoretic** Lovász Local Lemma over a real `IsProbabilityMeasure`. Two companion entries pin down the computable extremes: `lovasz-local-lemma-oq-01` handles **mutual independence** (avoidance factors exactly as $\\prod_i (1 - \\mu(A_i))$), and `lovasz-local-lemma-oq-01-union-bound` handles the **dependency-free** case (only the first-moment bound $\\mu(\\bigcap_i A_i^c) \\ge 1 - \\sum_i \\mu(A_i)$). Both merely *bound* the avoidance probability once dependence is allowed. This file computes the **exact** value in the smallest genuinely dependent regime — two events — by inclusion–exclusion: $\\mu(A^c \\cap B^c) + \\mu(A) + \\mu(B) = 1 + \\mu(A \\cap B)$, i.e. $\\mu(A^c \\cap B^c) = 1 - \\mu(A) - \\mu(B) + \\mu(A \\cap B)$. The overlap $\\mu(A \\cap B)$ is *exactly* the term the two-event union bound throws away, and it is nonzero precisely when the events are positively correlated — the first quantitative sign that dependency helps avoid all bad events.",
+    "mathContext": "Two measurable events $A, B$ over an `IsProbabilityMeasure` $\\mu$; exact identity $\\mu(A^c \\cap B^c) = 1 - \\mu(A) - \\mu(B) + \\mu(A \\cap B)$, no independence hypothesis.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lovász Local Lemma",
+      "inclusion–exclusion",
+      "Bonferroni inequalities",
+      "union bound",
+      "measure-theoretic probability"
+    ],
+    "prerequisites": [
+      "measure theory: probability measures",
+      "lovasz-local-lemma-oq-01-union-bound (first-moment bound)",
+      "two-set inclusion–exclusion"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ie-setup",
+    "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+    "range": {
+      "startLine": 36,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "The probability-space frame",
+    "content": "```lean\nimport Mathlib.Probability.Independence.Basic\nopen MeasureTheory\nopen scoped ENNReal\nnamespace LovaszLocalLemmaOQ01InclusionExclusion\nvariable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]\nvariable {A B : Set Ω}\n```\n\nUnlike the independent base case, which derives `IsProbabilityMeasure` from mutual independence, here there is no independence hypothesis, so `[IsProbabilityMeasure μ]` is assumed outright — it is what supplies $\\mu(\\Omega) = 1$ and hence the complementation identity $\\mu(s^c) + \\mu(s) = 1$. Only two events are needed, so the index is not a `Fintype` family but a bare pair $A, B : \\mathrm{Set}\\,\\Omega$. All measures live in $\\mathbb{R}_{\\ge 0}^\\infty$; the identity is stated **additively** ($\\mu(A^c \\cap B^c) + \\mu(A) + \\mu(B) = 1 + \\mu(A \\cap B)$) precisely so the proof never invokes truncated subtraction.",
+    "mathContext": "`IsProbabilityMeasure μ` gives $\\mu(\\Omega) = 1$ and $\\mu(s^c) + \\mu(s) = 1$; the additive statement keeps all arithmetic inside $\\mathbb{R}_{\\ge 0}^\\infty$ addition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "probability measure",
+      "extended non-negative reals ℝ≥0∞",
+      "measurable space"
+    ],
+    "prerequisites": [
+      "measure theory: probability measures"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ie-identity",
+    "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+    "range": {
+      "startLine": 46,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "Exact identity: μ(Aᶜ ∩ Bᶜ) + μA + μB = 1 + μ(A ∩ B)",
+    "content": "```lean\ntheorem two_event_avoidance_add (hA : MeasurableSet A) (hB : MeasurableSet B) :\n    μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B) := by\n  have hAB : MeasurableSet (A ∪ B) := hA.union hB\n  have hcompl : Aᶜ ∩ Bᶜ = (A ∪ B)ᶜ := (Set.compl_union A B).symm\n  have h1 : μ (Aᶜ ∩ Bᶜ) + μ (A ∪ B) = 1 := by\n    rw [hcompl, add_comm, measure_add_measure_compl hAB, measure_univ]\n  have h2 : μ (A ∪ B) + μ (A ∩ B) = μ A + μ B := measure_union_add_inter A hB\n  calc μ (Aᶜ ∩ Bᶜ) + μ A + μ B\n      = μ (Aᶜ ∩ Bᶜ) + (μ A + μ B) := by rw [add_assoc]\n    _ = μ (Aᶜ ∩ Bᶜ) + (μ (A ∪ B) + μ (A ∩ B)) := by rw [h2]\n    _ = (μ (Aᶜ ∩ Bᶜ) + μ (A ∪ B)) + μ (A ∩ B) := by rw [add_assoc]\n    _ = 1 + μ (A ∩ B) := by rw [h1]\n```\n\nTwo Mathlib facts do all the work. **Complementation**: $A^c \\cap B^c = (A \\cup B)^c$ (De Morgan, `Set.compl_union`), and in a probability measure `measure_add_measure_compl` gives $\\mu(A^c \\cap B^c) + \\mu(A \\cup B) = \\mu(\\Omega) = 1$. **Two-set inclusion–exclusion**: `measure_union_add_inter` gives the subtraction-free identity $\\mu(A \\cup B) + \\mu(A \\cap B) = \\mu(A) + \\mu(B)$. Substituting the second into the goal and regrouping, the union term $\\mu(A \\cup B)$ cancels against the complementation identity, leaving $1 + \\mu(A \\cap B)$. Every line is an $\\mathbb{R}_{\\ge 0}^\\infty$ addition — no finiteness or truncation side-conditions ever appear, even though the probability measure makes all quantities finite.",
+    "mathContext": "Equivalent to $\\mu(A^c \\cap B^c) = 1 - \\mu(A) - \\mu(B) + \\mu(A \\cap B)$, the order-two (exact) case of inclusion–exclusion $\\mu(\\bigcap A_i^c) = \\sum_S (-1)^{|S|} \\mu(\\bigcap_{i\\in S} A_i)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "inclusion–exclusion principle",
+      "De Morgan's law",
+      "measure_union_add_inter",
+      "complement of an event"
+    ],
+    "prerequisites": [
+      "Set.compl_union",
+      "measure_add_measure_compl",
+      "measure_union_add_inter"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ie-avoidance",
+    "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+    "range": {
+      "startLine": 69,
+      "endLine": 93
+    },
+    "type": "insight",
+    "title": "Sharp avoidance threshold and union-bound recovery",
+    "content": "```lean\ntheorem two_event_avoidance (hA : MeasurableSet A) (hB : MeasurableSet B)\n    (hlt : μ A + μ B < 1 + μ (A ∩ B)) :\n    0 < μ (Aᶜ ∩ Bᶜ) := by\n  rw [pos_iff_ne_zero]\n  intro h0\n  have hid := two_event_avoidance_add (μ := μ) hA hB\n  rw [h0, zero_add] at hid\n  exact hlt.ne hid\n\ntheorem two_event_avoidance_of_union_lt (hA : MeasurableSet A) (hB : MeasurableSet B)\n    (hlt : μ A + μ B < 1) :\n    0 < μ (Aᶜ ∩ Bᶜ) :=\n  two_event_avoidance hA hB (lt_of_lt_of_le hlt (le_add_right le_rfl))\n```\n\nPositivity is read straight off the exact identity: if $\\mu(A^c \\cap B^c) = 0$ then the identity collapses to $\\mu(A) + \\mu(B) = 1 + \\mu(A \\cap B)$, contradicting the strict hypothesis $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$; hence $\\mu(A^c \\cap B^c) \\ne 0$ (`pos_iff_ne_zero`). The threshold $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ is **strictly weaker** than the union-bound condition $\\mu(A) + \\mu(B) < 1$ exactly when $\\mu(A \\cap B) > 0$, i.e. when the events overlap (are positively correlated). The corollary `two_event_avoidance_of_union_lt` recovers the crude union-bound condition by discarding $\\mu(A \\cap B) \\ge 0$ (`le_add_right`), making the improvement explicit.",
+    "mathContext": "$\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ is the sharp two-event avoidance threshold; it beats the first-moment threshold $\\mu(A) + \\mu(B) < 1$ by the overlap $\\mu(A \\cap B)$ — the elementary germ of the LLL's dependency gain.",
+    "significance": "central",
+    "relatedConcepts": [
+      "positive correlation",
+      "first-moment method",
+      "avoidance probability",
+      "Lovász Local Lemma"
+    ],
+    "prerequisites": [
+      "ENNReal order: pos_iff_ne_zero, le_add_right",
+      "the exact identity two_event_avoidance_add"
+    ]
+  }
+]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+  "title": "Lovász Local Lemma OQ-01: Exact Two-Event Inclusion–Exclusion Avoidance",
+  "slug": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+  "description": "The first step beyond the first-moment / union bound in the measure-theoretic Lovász Local Lemma program (OQ-01). Companion to the mutually independent base case (lovasz-local-lemma-oq-01, exact product ∏(1 − μ(A i))) and the dependency-free union bound (lovasz-local-lemma-oq-01-union-bound, μ(⋂ (A i)ᶜ) ≥ 1 − ∑ μ(A i)) — both of which only bound the avoidance probability in the general dependent case. This entry lands the EXACT avoidance value in the smallest genuinely dependent regime, two events, via inclusion–exclusion: over a real IsProbabilityMeasure, μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B), i.e. μ(Aᶜ ∩ Bᶜ) = 1 − μ A − μ B + μ(A ∩ B), with no independence hypothesis. The pairwise overlap μ(A ∩ B) is precisely the correction the two-event union bound discards, so positive avoidance holds under the sharp threshold μ A + μ B < 1 + μ(A ∩ B) — strictly weaker than the union-bound condition μ A + μ B < 1 whenever the events are positively correlated. This is the first quantitative place where dependency helps avoid all bad events, the mechanism the full LLL exploits. Fully machine-verified, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LovaszLocalLemmaOQ01InclusionExclusion.lean",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "lovász-local-lemma",
+      "measure-theory",
+      "probability",
+      "inclusion-exclusion",
+      "bonferroni"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "assumptions": "Fully verified: 0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide/decide (only foundational propext/Classical.choice/Quot.sound from the Mathlib lemmas used). IsProbabilityMeasure is an explicit hypothesis (as in the union-bound entry; there is no independence hypothesis from which to derive it). Scope: this entry proves the EXACT two-event inclusion–exclusion avoidance identity and its sharp positivity corollary — the first-moment-plus-one-term regime. The full n-event inclusion–exclusion and the bounded-dependency-degree symmetric LLL (e·p·(d+1) ≤ 1) remain the open research target and are out of scope here.",
+    "lineCount": 93,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "verified": true,
+    "originalContributions": [
+      "two_event_avoidance_add: the exact two-event inclusion–exclusion identity μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) over a real probability space, with no independence hypothesis — stated additively to sidestep ℝ≥0∞ truncated subtraction, obtained by combining measure_add_measure_compl (complement partitions the space) with measure_union_add_inter (two-set inclusion–exclusion).",
+      "two_event_avoidance: positive avoidance 0 < μ(Aᶜ ∩ Bᶜ) under the SHARP threshold μ A + μ B < 1 + μ(A ∩ B), obtained from the exact identity — strictly weaker than the union-bound condition μ A + μ B < 1 exactly by the pairwise overlap μ(A ∩ B).",
+      "two_event_avoidance_of_union_lt: the coarse union-bound sufficient condition μ A + μ B < 1 recovered as the special case obtained by discarding the overlap term μ(A ∩ B) ≥ 0, making the strict improvement explicit.",
+      "Framing contribution: this is the exact first step beyond the first-moment bound explicitly flagged as open by the union-bound entry (lovasz-local-lemma-oq-01-union-bound). Because the two-event identity is exact, it isolates the pairwise-overlap correction μ(A ∩ B) as the precise quantity by which dependency loosens the avoidance threshold — the elementary seed of why the LLL beats the global ∑ μ(A i) < 1 bound."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.Independence.Basic"
+    ],
+    "opens": [
+      "MeasureTheory"
+    ],
+    "namespace": "LovaszLocalLemmaOQ01InclusionExclusion",
+    "lineCount": 93,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 3,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/LovaszLocalLemmaOQ01InclusionExclusion.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "two_event_avoidance_add",
+      "type": "core",
+      "description": "Exact two-event inclusion–exclusion avoidance identity: for two measurable events over a probability space, μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B), i.e. μ(Aᶜ ∩ Bᶜ) = 1 − μ A − μ B + μ(A ∩ B). No independence assumed; the additive form avoids ℝ≥0∞ truncated subtraction.",
+      "leanType": "(hA : MeasurableSet A) → (hB : MeasurableSet B) → μ (Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ (A ∩ B)"
+    },
+    {
+      "name": "two_event_avoidance",
+      "type": "core",
+      "description": "Sharp two-event positive avoidance: both events are avoided with positive probability as soon as μ A + μ B < 1 + μ(A ∩ B), the threshold strictly weaker than the union bound's μ A + μ B < 1 by the pairwise overlap μ(A ∩ B).",
+      "leanType": "(hA : MeasurableSet A) → (hB : MeasurableSet B) → (μ A + μ B < 1 + μ (A ∩ B)) → 0 < μ (Aᶜ ∩ Bᶜ)"
+    },
+    {
+      "name": "two_event_avoidance_of_union_lt",
+      "type": "corollary",
+      "description": "The coarse union-bound sufficient condition μ A + μ B < 1 recovered as a special case by discarding the overlap term, exhibiting the strict improvement the exact identity provides.",
+      "leanType": "(hA : MeasurableSet A) → (hB : MeasurableSet B) → (μ A + μ B < 1) → 0 < μ (Aᶜ ∩ Bᶜ)"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Lovász Local Lemma (Erdős–Lovász, 1975) refines the union bound: if bad events A_1, …, A_n satisfy ∑ P(A_i) < 1 then P(⋂ A_iᶜ) > 0. The union bound is the zeroth-order Bonferroni inequality; the exact avoidance probability is given by inclusion–exclusion, P(⋂ A_iᶜ) = ∑_{S} (−1)^{|S|} P(⋂_{i∈S} A_i). For two events this truncates to the exact identity P(Aᶜ ∩ Bᶜ) = 1 − P(A) − P(B) + P(A ∩ B), the first place the crude union bound acquires a correction. That correction — the pairwise overlap P(A ∩ B) — is exactly the quantity that dependency between the events controls, and it is the elementary germ of the LLL's central idea: structural information about how bad events interact can only help avoid them.",
+    "problemStatement": "**Open question OQ-01 (from LovaszLocalLemma.lean)**: formalize the full probabilistic Lovász Local Lemma over measure-theoretic probability spaces — bad events as measurable sets A_i ⊆ Ω in an IsProbabilityMeasure, with conclusion μ(⋂ A_iᶜ) > 0.\n\n**This entry (two-event inclusion–exclusion)**: prove the exact avoidance value in the smallest dependent regime. For two measurable events A, B over an IsProbabilityMeasure, show μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) (equivalently μ(Aᶜ ∩ Bᶜ) = 1 − μ A − μ B + μ(A ∩ B)), and derive positive avoidance under the sharp threshold μ A + μ B < 1 + μ(A ∩ B). This is the first step beyond the first-moment / union bound explicitly flagged as open by the union-bound companion entry.",
+    "text": "The exact two-event avoidance probability of the Lovász Local Lemma, over a real probability space: for any two measurable bad events, the probability that neither occurs equals one minus their masses plus their overlap. The overlap term is exactly what the crude union bound throws away, and it is the first quantitative sign that dependency between bad events makes them easier to avoid.",
+    "proofStrategy": "**Avoidance is a complement.** De Morgan gives Aᶜ ∩ Bᶜ = (A ∪ B)ᶜ (`Set.compl_union`), so in a probability measure `measure_add_measure_compl` yields μ(Aᶜ ∩ Bᶜ) + μ(A ∪ B) = μ(univ) = 1.\n\n**Two-set inclusion–exclusion.** Mathlib's `measure_union_add_inter` gives the ℝ≥0∞-safe additive identity μ(A ∪ B) + μ(A ∩ B) = μ A + μ B (no truncated subtraction).\n\n**Combine additively.** Substituting μ A + μ B = μ(A ∪ B) + μ(A ∩ B) into the goal and regrouping, the union term cancels against the complement identity, leaving μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B). Every step is an ℝ≥0∞ addition, so no finiteness or truncation side-conditions arise.\n\n**Positivity.** If μ(Aᶜ ∩ Bᶜ) = 0 the identity forces μ A + μ B = 1 + μ(A ∩ B), contradicting the strict hypothesis μ A + μ B < 1 + μ(A ∩ B); hence 0 < μ(Aᶜ ∩ Bᶜ) (`pos_iff_ne_zero`). The union-bound corollary follows since μ(A ∩ B) ≥ 0.",
+    "keyInsights": [
+      "The two-event case is where the union bound first becomes non-tight. The union bound μ(Aᶜ ∩ Bᶜ) ≥ 1 − μ A − μ B is exactly the inclusion–exclusion identity with the +μ(A ∩ B) term dropped; keeping it makes the two-event statement an exact equality, not a bound.",
+      "Stating the identity additively — μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) rather than with a subtraction — sidesteps ℝ≥0∞ truncated subtraction entirely: the proof is a chain of additions using measure_add_measure_compl and measure_union_add_inter, with no finiteness hypotheses needed even though the probability measure makes everything finite anyway.",
+      "The sharp avoidance threshold μ A + μ B < 1 + μ(A ∩ B) is strictly weaker than the union-bound threshold μ A + μ B < 1 exactly when μ(A ∩ B) > 0, i.e. when the two events are positively correlated. This is the first quantitative instance of the LLL's guiding principle: dependency structure among bad events can only help avoid them all.",
+      "The identity is a two-set special case of the general inclusion–exclusion formula μ(⋂ A_iᶜ) = ∑_{S ⊆ ι} (−1)^{|S|} μ(⋂_{i ∈ S} A_i). The n-event version — and the Bonferroni truncations that bound it — is the natural next increment toward controlling avoidance by low-order joint masses, en route to the bounded-dependency-degree LLL."
+    ],
+    "prerequisites": [
+      "Measure-theoretic probability: IsProbabilityMeasure, measure_add_measure_compl, measure_univ",
+      "Two-set inclusion–exclusion: measure_union_add_inter (μ(s ∪ t) + μ(s ∩ t) = μ s + μ t)",
+      "Set identity Set.compl_union : (s ∪ t)ᶜ = sᶜ ∩ tᶜ",
+      "ℝ≥0∞ order: pos_iff_ne_zero, le_add_right"
+    ]
+  },
+  "conclusion": {
+    "summary": "The exact two-event inclusion–exclusion avoidance identity is fully machine-verified over a real probability space: μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B), with no independence assumption. Positive avoidance follows under the sharp threshold μ A + μ B < 1 + μ(A ∩ B), strictly weaker than the union-bound condition by the pairwise overlap. 0 sorries, 0 axioms.",
+    "implications": "**First step beyond first-moment**: the union-bound entry (lovasz-local-lemma-oq-01-union-bound) explicitly listed 'the two-event / pairwise inclusion–exclusion improvement of the union bound' as the first open step past the first-moment method. This entry discharges exactly that step, and does so with an EXACT identity rather than a bound, isolating the pairwise overlap μ(A ∩ B) as the precise correction dependency supplies.\n\n**Honest scope**: the two-event identity is elementary (two Mathlib lemmas combined additively); it is presented as the first rung of the inclusion–exclusion / dependency ladder toward the open bounded-dependency-degree LLL, not as the LLL itself.",
+    "openQuestions": [
+      "Prove the general n-event inclusion–exclusion identity μ(⋂ A_iᶜ) = ∑_{S ⊆ ι} (−1)^{|S|} μ(⋂_{i ∈ S} A_i) and the associated Bonferroni truncation bounds over a probability measure.",
+      "Bound avoidance below using only low-order joint masses (pairwise ∑_{i<j} μ(A_i ∩ A_j)) as an intermediate between the first-moment bound and full inclusion–exclusion.",
+      "Prove the bounded-dependency-degree symmetric LLL (each bad event dependent on ≤ d others, μ(A i) ≤ p with e·p·(d+1) ≤ 1 ⇒ μ(⋂ A_iᶜ) > 0), the genuine open target between the independent regime (d = 0) and the union-bound regime (d = n−1)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: the first correction to the union bound",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring positioning this file as the exact two-event inclusion–exclusion refinement of the union bound, the first step past first-moment in the OQ-01 program. States μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) and the sharpened avoidance threshold μ A + μ B < 1 + μ(A ∩ B).",
+      "mathContext": "The pairwise overlap μ(A ∩ B) is the exact correction the two-event union bound discards; it is nonzero precisely when the events are dependent (positively correlated)."
+    },
+    {
+      "id": "sec-identity",
+      "title": "Exact inclusion–exclusion identity",
+      "startLine": 46,
+      "endLine": 67,
+      "summary": "two_event_avoidance_add: rewrite Aᶜ ∩ Bᶜ as (A ∪ B)ᶜ, use measure_add_measure_compl for μ(Aᶜ ∩ Bᶜ) + μ(A ∪ B) = 1 and measure_union_add_inter for μ(A ∪ B) + μ(A ∩ B) = μ A + μ B, then combine additively to μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B).",
+      "mathContext": "Stated additively to avoid ℝ≥0∞ truncated subtraction; equivalent to μ(Aᶜ ∩ Bᶜ) = 1 − μ A − μ B + μ(A ∩ B)."
+    },
+    {
+      "id": "sec-avoidance",
+      "title": "Sharp positive avoidance and union-bound recovery",
+      "startLine": 69,
+      "endLine": 93,
+      "summary": "two_event_avoidance: from the exact identity, μ(Aᶜ ∩ Bᶜ) = 0 would force μ A + μ B = 1 + μ(A ∩ B), contradicting the strict threshold; hence positive avoidance under μ A + μ B < 1 + μ(A ∩ B). two_event_avoidance_of_union_lt: the coarse condition μ A + μ B < 1 follows by discarding μ(A ∩ B) ≥ 0.",
+      "mathContext": "The sharp threshold beats the union bound exactly by the overlap μ(A ∩ B): the first quantitative sign that dependency helps avoidance."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lovasz-local-lemma-oq-01-union-bound",
+      "relationship": "extends",
+      "description": "This entry discharges the open step the union-bound entry flagged — 'the intermediate two-event / pairwise inclusion–exclusion improvement of the union bound as the first step beyond first-moment' — replacing the union bound's inequality with an exact two-event identity that isolates the pairwise-overlap correction."
+    },
+    {
+      "targetId": "lovasz-local-lemma-oq-01",
+      "relationship": "related",
+      "description": "Companion measure-theoretic entry: OQ-01's mutually independent (d = 0) base case with exact product μ(⋂ (A i)ᶜ) = ∏(1 − μ(A i)). For two independent events μ(A ∩ B) = μ A · μ B, and this entry's identity specializes to the product (1 − μ A)(1 − μ B)."
+    },
+    {
+      "targetId": "lovasz-local-lemma",
+      "relationship": "related",
+      "description": "Parent gallery proof of the symmetric LLL over ℚ as a probability-budget surrogate; OQ-01 asks for the genuine measure-theoretic statement that this inclusion–exclusion increment advances toward."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Lovász",
+      "title": "Problems and Results on 3-Chromatic Hypergraphs and Some Related Questions",
+      "year": "1975",
+      "note": "Original LLL paper; refines the union bound whose first correction term is the pairwise overlap formalized here."
+    },
+    {
+      "authors": "Bonferroni",
+      "title": "Teoria statistica delle classi e calcolo delle probabilità",
+      "year": "1936",
+      "note": "Bonferroni inequalities; the exact two-event case P(Aᶜ ∩ Bᶜ) = 1 − P(A) − P(B) + P(A ∩ B) formalized here is inclusion–exclusion truncated (and exact) at order two."
+    },
+    {
+      "authors": "Alon, Spencer",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "note": "Standard reference; develops the LLL as the refinement of the union/first-moment bound that this pairwise-inclusion–exclusion step begins to sharpen."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Advances the measure-theoretic Lovász Local Lemma program (OQ-01) by one honest step: the **exact avoidance probability in the smallest genuinely dependent regime — two events — via inclusion–exclusion**.

Two existing companion entries bracket the LLL landscape but both only *bound* avoidance once dependence is allowed:
- `lovasz-local-lemma-oq-01` — mutually independent (`d = 0`) base case, exact product `∏(1 − μ Aᵢ)`.
- `lovasz-local-lemma-oq-01-union-bound` — dependency-free first-moment bound `μ(⋂ Aᵢᶜ) ≥ 1 − ∑ μ Aᵢ`.

The union-bound entry explicitly flagged "the intermediate two-event / pairwise inclusion–exclusion improvement of the union bound" as its first open follow-up. **This PR discharges exactly that**, with an *exact* identity rather than a bound.

## Results (`Proofs/LovaszLocalLemmaOQ01InclusionExclusion.lean`)

Over a real `IsProbabilityMeasure`, no independence hypothesis:

- `two_event_avoidance_add` : `μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B)`
  (i.e. `μ(Aᶜ ∩ Bᶜ) = 1 − μ A − μ B + μ(A ∩ B)`; stated additively to avoid `ℝ≥0∞` truncated subtraction — combines `measure_add_measure_compl` with `measure_union_add_inter`).
- `two_event_avoidance` : `0 < μ(Aᶜ ∩ Bᶜ)` under the sharp threshold `μ A + μ B < 1 + μ(A ∩ B)`, strictly weaker than the union-bound condition `μ A + μ B < 1` exactly by the pairwise overlap `μ(A ∩ B)`.
- `two_event_avoidance_of_union_lt` : recovers the coarse union-bound condition `μ A + μ B < 1` as a special case.

The pairwise overlap `μ(A ∩ B)` is precisely the correction the two-event union bound discards; it is positive exactly when the events are positively correlated. This is the first quantitative place where **dependency helps avoidance** — the elementary germ of why the LLL beats the global `∑ μ(A i) < 1` threshold.

## Verification

- Docker-built clean (`Proofs.LovaszLocalLemmaOQ01InclusionExclusion`): **0 sorries, 0 axioms**, no `native_decide`/`decide`.
- Gallery entry `lovasz-local-lemma-oq-01-inclusion-exclusion` added (meta.json + annotations.json); `annotations:validate --strict` reports no errors/warnings for the new entry; meta-size check passes.

Honest scope: the two-event identity is elementary (two Mathlib lemmas combined additively); it is presented as the first rung of the inclusion–exclusion / dependency ladder toward the open bounded-dependency-degree LLL, not as the LLL itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)