### PR TITLE
Research(unit-distance-independence-oq-04): axiom-free χ_f(G) ≥ |V|/α(G) + Moser spindle χ_f ≥ 3.5

### DIFF
--- a/proofs/Proofs/UnitDistanceIndependenceOQ04.lean
+++ b/proofs/Proofs/UnitDistanceIndependenceOQ04.lean
@@ -1,0 +1,270 @@
+/-
+# Fractional chromatic lower bound for the unit-distance graph on ℝ²
+
+Open question `unit-distance-independence-oq-04` (Frankl–Wilson 1981):
+
+    The fractional chromatic number of the unit-distance graph on the plane
+    satisfies  χ_f(ℝ²) ≥ 3.5,
+
+strengthening the integer bound χ(ℝ²) ≥ 4 (De Grey 2018 even gives ≥ 5).
+
+## What this file proves (axiom-free)
+
+The mathematical engine behind every fractional-chromatic lower bound is the
+LP-duality inequality
+
+        χ_f(G) ≥ |V(G)| / α(G)                                      (★)
+
+for every finite graph `G`, where `α(G)` is the independence number.  We
+formalise a self-contained fractional chromatic number for finite graphs (the
+fractional set-cover LP over independent sets) and prove (★) by the standard
+double-counting / averaging argument:
+
+  * every vertex must be covered with total weight ≥ 1, so summing over the
+    `|V|` vertices gives `|V| ≤ ∑_I |I| · w(I)`;
+  * each weighted set is independent, hence `|I| ≤ α(G)`, giving
+    `∑_I |I| · w(I) ≤ α(G) · ∑_I w(I)`.
+
+Dividing yields `∑_I w(I) ≥ |V|/α(G)` for every fractional colouring `w`, so the
+infimum `χ_f(G)` is `≥ |V|/α(G)`.
+
+Specialising (★) to any 7-vertex graph with independence number `2` — the
+combinatorial signature of the **Moser spindle**, a unit-distance graph in the
+plane — gives `χ_f ≥ 7/2 = 3.5`.  The last step, an explicit ℝ²-embedding of
+the Moser spindle with all eleven unit distances verified, is recorded as the
+remaining open piece in the knowledge base.
+
+## Status
+
+0 axioms, 0 sorries.  `fractionalChromaticNumber` and the bound `(★)` are fully
+machine-checked (modulo the ordinary `propext / Classical.choice / Quot.sound`).
+This is genuine reusable infrastructure: `(★)` converts *any* independence-ratio
+certificate into a fractional chromatic lower bound.
+-/
+import Mathlib
+import Proofs.UnitDistanceIndependence
+
+open Finset
+
+namespace UnitDistanceIndependence.FractionalChromatic
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-! ## A fractional chromatic number for finite graphs
+
+A *fractional colouring* is a nonnegative weight `w I` on each finite vertex set
+`I`, supported on independent sets, such that every vertex is covered with total
+weight at least `1`.  Its cost is `∑_I w I`; the fractional chromatic number is
+the infimum of the cost over all fractional colourings. -/
+
+/-- The collection of all vertex subsets, as a `Finset (Finset V)`. -/
+noncomputable def allSets : Finset (Finset V) := (Finset.univ : Finset V).powerset
+
+/-- A fractional colouring of `G`: a nonnegative weighting of vertex subsets,
+supported on independent sets, that covers every vertex with weight `≥ 1`. -/
+def IsFracColoring (G : SimpleGraph V) [DecidableRel G.Adj] (w : Finset V → ℝ) : Prop :=
+  (∀ I : Finset V, 0 ≤ w I) ∧
+  (∀ I : Finset V, w I ≠ 0 → IsIndepFinset G I) ∧
+  (∀ v : V, 1 ≤ ∑ I ∈ allSets.filter (fun I => v ∈ I), w I)
+
+/-- The cost `∑_I w I` of a fractional colouring. -/
+noncomputable def fracCost (w : Finset V → ℝ) : ℝ := ∑ I ∈ allSets, w I
+
+/-- The set of achievable fractional-colouring costs of `G`. -/
+noncomputable def costSet (G : SimpleGraph V) [DecidableRel G.Adj] : Set ℝ :=
+  { x | ∃ w, IsFracColoring G w ∧ fracCost w = x }
+
+/-- **Fractional chromatic number** of a finite graph: the infimum of the cost
+over all fractional colourings. -/
+noncomputable def fractionalChromaticNumber (G : SimpleGraph V) [DecidableRel G.Adj] : ℝ :=
+  sInf (costSet G)
+
+/-! ## The singleton colouring: `costSet` is nonempty and bounded below -/
+
+/-- Any fractional colouring has nonnegative cost. -/
+theorem fracCost_nonneg {G : SimpleGraph V} [DecidableRel G.Adj]
+    {w : Finset V → ℝ} (hw : IsFracColoring G w) : 0 ≤ fracCost w :=
+  Finset.sum_nonneg (fun I _ => hw.1 I)
+
+/-- `costSet G` is bounded below by `0`. -/
+theorem costSet_bddBelow (G : SimpleGraph V) [DecidableRel G.Adj] :
+    BddBelow (costSet G) := by
+  refine ⟨0, ?_⟩
+  rintro x ⟨w, hw, rfl⟩
+  exact fracCost_nonneg hw
+
+/-- The indicator weighting of singletons: `w I = 1` if `I` is a singleton, else `0`. -/
+noncomputable def singletonWeight : Finset V → ℝ := fun I => if I.card = 1 then 1 else 0
+
+omit [Fintype V] [DecidableEq V] in
+theorem singletonWeight_nonneg (I : Finset V) : 0 ≤ singletonWeight I := by
+  unfold singletonWeight; split <;> norm_num
+
+/-- The singleton weighting is a valid fractional colouring of any graph. -/
+theorem isFracColoring_singletonWeight (G : SimpleGraph V) [DecidableRel G.Adj] :
+    IsFracColoring G (singletonWeight (V := V)) := by
+  refine ⟨fun I => singletonWeight_nonneg I, ?_, ?_⟩
+  · -- support on independent sets: a singleton is independent
+    intro I hI
+    have hcard : I.card = 1 := by
+      unfold singletonWeight at hI; by_contra h; simp [h] at hI
+    obtain ⟨a, rfl⟩ := Finset.card_eq_one.mp hcard
+    intro u hu v hv huv
+    rw [Finset.mem_singleton] at hu hv
+    exact absurd (hu.trans hv.symm) huv
+  · -- every vertex is covered with weight ≥ 1 (its own singleton contributes 1)
+    intro v
+    have hmem : ({v} : Finset V) ∈ allSets.filter (fun I => v ∈ I) := by
+      rw [Finset.mem_filter]
+      refine ⟨?_, Finset.mem_singleton_self v⟩
+      rw [allSets, Finset.mem_powerset]; exact Finset.subset_univ _
+    have hval : singletonWeight ({v} : Finset V) = 1 := by
+      unfold singletonWeight; simp
+    calc (1 : ℝ) = singletonWeight ({v} : Finset V) := hval.symm
+      _ ≤ ∑ I ∈ allSets.filter (fun I => v ∈ I), singletonWeight I :=
+          Finset.single_le_sum (fun I _ => singletonWeight_nonneg I) hmem
+
+theorem costSet_nonempty (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (costSet G).Nonempty :=
+  ⟨fracCost (singletonWeight (V := V)), singletonWeight (V := V),
+    isFracColoring_singletonWeight G, rfl⟩
+
+/-! ## The key double-counting identity and the `|V|/α` bound -/
+
+/-- **Double counting.** Summing each vertex's covering weight over all vertices
+equals the size-weighted total `∑_I |I| · w I`. -/
+theorem sum_coverage_eq (G : SimpleGraph V) [DecidableRel G.Adj] (w : Finset V → ℝ) :
+    (∑ v : V, ∑ I ∈ allSets.filter (fun I => v ∈ I), w I)
+      = ∑ I ∈ allSets, (I.card : ℝ) * w I := by
+  -- Replace the inner filtered sum by an `if`-guarded sum over all of `allSets`.
+  have step1 : ∀ v : V, (∑ I ∈ allSets.filter (fun I => v ∈ I), w I)
+      = ∑ I ∈ allSets, (if v ∈ I then w I else 0) := by
+    intro v; rw [Finset.sum_filter]
+  simp_rw [step1]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro I _
+  -- `∑_v (if v ∈ I then w I else 0) = |I| • w I`
+  rw [Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_const, nsmul_eq_mul]
+
+/-- **Cost lower bound.** Every fractional colouring of a nonempty-vertex graph
+costs at least `|V| / α(G)`. -/
+theorem card_div_indep_le_fracCost
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    {w : Finset V → ℝ} (hw : IsFracColoring G w) :
+    (Fintype.card V : ℝ) / (independenceNumber G : ℝ) ≤ fracCost w := by
+  by_cases hα : independenceNumber G = 0
+  · -- `α = 0` forces `V` empty, so `|V| = 0` and the bound is `0 ≤ cost`.
+    rw [hα]; simp only [Nat.cast_zero, div_zero]
+    exact fracCost_nonneg hw
+  have hαpos : 0 < independenceNumber G := Nat.pos_of_ne_zero hα
+  have hαR : (0 : ℝ) < (independenceNumber G : ℝ) := by exact_mod_cast hαpos
+  rw [div_le_iff₀ hαR, mul_comm]
+  -- `|V| = ∑_v 1 ≤ ∑_v coverage(v) = ∑_I |I| w I ≤ α · ∑_I w I = α · cost`.
+  have hcover : (Fintype.card V : ℝ)
+      ≤ ∑ v : V, ∑ I ∈ allSets.filter (fun I => v ∈ I), w I := by
+    calc (Fintype.card V : ℝ) = ∑ _v : V, (1 : ℝ) := by
+              rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
+      _ ≤ ∑ v : V, ∑ I ∈ allSets.filter (fun I => v ∈ I), w I :=
+              Finset.sum_le_sum (fun v _ => hw.2.2 v)
+  have hdc := sum_coverage_eq G w
+  have hbound : ∑ I ∈ allSets, (I.card : ℝ) * w I
+      ≤ (independenceNumber G : ℝ) * fracCost w := by
+    rw [fracCost, Finset.mul_sum]
+    apply Finset.sum_le_sum
+    intro I _
+    by_cases hwI : w I = 0
+    · rw [hwI]; simp
+    · have hindep : IsIndepFinset G I := hw.2.1 I hwI
+      have hcardα : (I.card : ℝ) ≤ (independenceNumber G : ℝ) := by
+        exact_mod_cast indep_card_le_alpha G I hindep
+      have hwpos : 0 ≤ w I := hw.1 I
+      calc (I.card : ℝ) * w I ≤ (independenceNumber G : ℝ) * w I :=
+              mul_le_mul_of_nonneg_right hcardα hwpos
+        _ = (independenceNumber G : ℝ) * w I := rfl
+  calc (Fintype.card V : ℝ)
+      ≤ ∑ v : V, ∑ I ∈ allSets.filter (fun I => v ∈ I), w I := hcover
+    _ = ∑ I ∈ allSets, (I.card : ℝ) * w I := hdc
+    _ ≤ (independenceNumber G : ℝ) * fracCost w := hbound
+
+/-- **Fractional clique / LP lower bound (★).** For every finite graph `G`,
+`χ_f(G) ≥ |V| / α(G)`. -/
+theorem card_div_indep_le_fractionalChromaticNumber
+    (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (Fintype.card V : ℝ) / (independenceNumber G : ℝ) ≤ fractionalChromaticNumber G := by
+  rw [fractionalChromaticNumber]
+  apply le_csInf (costSet_nonempty G)
+  rintro x ⟨w, hw, rfl⟩
+  exact card_div_indep_le_fracCost G hw
+
+/-! ## The Moser-spindle specialisation
+
+The **Moser spindle** is a unit-distance graph in ℝ² on `7` vertices whose
+independence number is `2`.  Applying `(★)` to it yields `χ_f ≥ 7/2 = 3.5`.
+Here we record the abstract combinatorial consequence; realising the spindle by
+explicit unit-distance coordinates in `Plane` is the remaining open step. -/
+
+/-- **Abstract Moser-spindle bound.** Any finite graph on exactly `7` vertices
+with independence number `2` has fractional chromatic number `≥ 7/2 = 3.5`. -/
+theorem fractionalChromaticNumber_ge_of_seven_indep_two
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hcard : Fintype.card V = 7) (hindep : independenceNumber G = 2) :
+    (7 : ℝ) / 2 ≤ fractionalChromaticNumber G := by
+  have h := card_div_indep_le_fractionalChromaticNumber G
+  rw [hcard, hindep] at h
+  norm_num at h
+  linarith [h]
+
+/-- Restatement in decimal form: such a graph has `χ_f ≥ 3.5`. -/
+theorem fractionalChromaticNumber_ge_of_seven_indep_two' {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hcard : Fintype.card V = 7) (hindep : independenceNumber G = 2) :
+    (3.5 : ℝ) ≤ fractionalChromaticNumber G := by
+  have h := fractionalChromaticNumber_ge_of_seven_indep_two G hcard hindep
+  norm_num at h ⊢
+  linarith [h]
+
+/-! ## A concrete Moser-spindle graph with `χ_f ≥ 3.5`
+
+We realise the Moser spindle as an abstract graph on `Fin 7` with its standard
+11-edge incidence and check, by decidable computation, that its independence
+number is `2`.  Combined with the bound `(★)`, this exhibits a concrete finite
+graph — combinatorially identical to the planar Moser spindle — with fractional
+chromatic number `≥ 3.5`.
+
+Vertex labels (two 60°/120° rhombi sharing the acute vertex `0`):
+`0` = shared acute apex; `1,2` = obtuse vertices of rhombus 1, `3` = its far
+apex; `4,5` = obtuse vertices of rhombus 2, `6` = its far apex; the spindle edge
+joins the far apexes `3–6`. -/
+
+/-- The edge relation of the Moser spindle on `Fin 7` (each undirected edge is
+listed once; symmetry/irreflexivity are added by `SimpleGraph.fromRel`). -/
+def moserRel : Fin 7 → Fin 7 → Prop := fun a b =>
+  (a = 0 ∧ b = 1) ∨ (a = 0 ∧ b = 2) ∨ (a = 1 ∧ b = 2) ∨
+  (a = 1 ∧ b = 3) ∨ (a = 2 ∧ b = 3) ∨
+  (a = 0 ∧ b = 4) ∨ (a = 0 ∧ b = 5) ∨ (a = 4 ∧ b = 5) ∨
+  (a = 4 ∧ b = 6) ∨ (a = 5 ∧ b = 6) ∨ (a = 3 ∧ b = 6)
+
+instance : DecidableRel moserRel := fun a b => by unfold moserRel; infer_instance
+
+/-- The **Moser spindle** as a simple graph on `Fin 7`. -/
+def moserSpindle : SimpleGraph (Fin 7) := SimpleGraph.fromRel moserRel
+
+instance : DecidableRel moserSpindle.Adj := fun a b => by
+  unfold moserSpindle SimpleGraph.fromRel; infer_instance
+
+/-- The Moser spindle has `7` vertices. -/
+theorem moserSpindle_card : Fintype.card (Fin 7) = 7 := by simp
+
+/-- The Moser spindle has independence number `2` (decidable check). -/
+theorem moserSpindle_independenceNumber : independenceNumber moserSpindle = 2 := by decide
+
+/-- **Concrete fractional chromatic bound.** The Moser spindle graph on `Fin 7`
+has `χ_f ≥ 7/2 = 3.5`, a fully machine-checked witness of the Frankl–Wilson
+lower bound at the graph level. -/
+theorem moserSpindle_fractionalChromaticNumber_ge :
+    (7 : ℝ) / 2 ≤ fractionalChromaticNumber moserSpindle :=
+  fractionalChromaticNumber_ge_of_seven_indep_two moserSpindle
+    moserSpindle_card moserSpindle_independenceNumber
+
+end UnitDistanceIndependence.FractionalChromatic

--- a/research/problems/unit-distance-independence-oq-04/knowledge.md
+++ b/research/problems/unit-distance-independence-oq-04/knowledge.md
@@ -1,27 +1,74 @@
 # Knowledge Base: unit-distance-independence-oq-04
 
-Insights accumulated during research on this problem.
+Frankl–Wilson (1981): the fractional chromatic number of the unit-distance
+graph on the plane satisfies **χ_f(ℝ²) ≥ 3.5**, strengthening χ(ℝ²) ≥ 4.
 
 ---
 
 ## Problem Understanding
 
-(Initial observations from OBSERVE phase will be recorded here.)
-
----
+The standard route is the LP-duality lower bound χ_f(G) ≥ |V(G)|/α(G) applied to
+a finite unit-distance subgraph. The **Moser spindle** (7 vertices, 11 edges,
+independence number 2) already attains |V|/α = 7/2 = 3.5, so it is the natural
+certificate.
 
 ## Insights
 
-(Insights from research attempts will be accumulated here.)
-
----
+- **χ_f(G) ≥ |V|/α(G) for all finite graphs** (not just vertex-transitive): a
+  one-line averaging argument over the fractional set-cover LP. This is the
+  reusable engine that turns any independence-ratio certificate into a χ_f bound.
+- **Moser spindle attains 3.5 exactly** — no larger Frankl–Wilson construction is
+  needed for the 3.5 bound.
+- **`decide` proves α of a small explicit `Fin n` graph** axiom-free (avoid
+  `native_decide`, which would add `Lean.ofReduceBool`).
+- Spindle adjacency (two 60°/120° rhombi sharing acute apex `0`):
+  edges `{0-1,0-2,1-2,1-3,2-3, 0-4,0-5,4-5,4-6,5-6, 3-6}`. Rhombus-1 obtuse
+  vertices `1,2` + far apex `3`; rhombus-2 obtuse `4,5` + far apex `6`; spindle
+  edge `3-6`.
 
 ## Mathlib Coverage Audit
 
-(After ORIENT phase: list of relevant Mathlib lemmas / APIs and their applicability.)
+- Mathlib has **no** fractional chromatic number (`Mathlib/Combinatorics/
+  SimpleGraph/{Coloring,Clique,ConcreteColorings}.lean` — none define χ_f). Built
+  a minimal `fractionalChromaticNumber` locally (~80 lines, fractional set-cover
+  LP infimum).
+- `UnitDistanceIndependence.lean` provides `IsIndepFinset`, `independenceNumber`,
+  `indep_card_le_alpha`, `unitDistGraph`, `Plane = EuclideanSpace ℝ (Fin 2)`.
 
----
+## Remaining Gap (open engineering step)
+
+Realise `moserSpindle : SimpleGraph (Fin 7)` by explicit coordinates in `Plane`:
+verify `dist = 1` on the 11 edges and `dist ≠ 1` on the 10 non-edges. Coordinates
+are irrational (√3 and the spindle-rotation angle), so the ~21 distance checks
+are the tedious-but-bounded remaining work; then transport χ_f ≥ 3.5 to the plane
+via a graph isomorphism `moserSpindle ≃g unitDistGraph S`.
 
 ## Anti-Goals
 
-(Things explicitly NOT to attempt — discovered duplicates, scope creep risks, etc.)
+- Do NOT use `native_decide` for α (would forfeit axiom-free status).
+- Do NOT search for a rational-coordinate spindle — the Moser spindle requires
+  irrational coordinates.
+
+---
+
+## Session 2026-07-03 (Session 2, researcher-8) — χ_f infrastructure + graph-level 3.5
+
+**Mode**: FRESH · **Outcome**: progress (axiom-free)
+
+### What I did
+- Confirmed Mathlib has no χ_f; built a self-contained `fractionalChromaticNumber`
+  for finite graphs (fractional set-cover LP infimum) in
+  `proofs/Proofs/UnitDistanceIndependenceOQ04.lean`.
+- Proved the LP averaging bound `card_div_indep_le_fractionalChromaticNumber`:
+  χ_f(G) ≥ |V|/α(G), via the double-counting identity `sum_coverage_eq`.
+- Built the concrete `moserSpindle : SimpleGraph (Fin 7)`, proved
+  `independenceNumber = 2` by `decide`, hence
+  `moserSpindle_fractionalChromaticNumber_ge : (7:ℝ)/2 ≤ χ_f(moserSpindle)`.
+- Verified axiom-free: `#print axioms` → `[propext, Classical.choice, Quot.sound]`.
+
+### Files
+- `proofs/Proofs/UnitDistanceIndependenceOQ04.lean` (new, 232 lines, 0 sorries, 0 axioms)
+
+### Next steps
+- Explicit ℝ² embedding of the spindle (11 unit distances + 10 non-unit) and a
+  graph iso to `unitDistGraph`, transporting χ_f ≥ 3.5 to χ_f(ℝ²) ≥ 3.5.

--- a/src/data/research/problems/unit-distance-independence-oq-04.json
+++ b/src/data/research/problems/unit-distance-independence-oq-04.json
@@ -1,0 +1,104 @@
+{
+  "slug": "unit-distance-independence-oq-04",
+  "title": "Prove the fractional chromatic number χ_f(ℝ²) ≥ 3",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-05-12T23:37:36Z",
+    "iteration": 2,
+    "focus": "Built axiom-free fractional chromatic number for finite graphs + LP lower bound χ_f(G) ≥ |V|/α(G); instantiated a concrete Moser spindle (Fin 7, α=2 by decide) giving χ_f ≥ 7/2 = 3.5 at the graph level.",
+    "blockers": [],
+    "nextAction": "Realise moserSpindle by explicit unit-distance coordinates in Plane = EuclideanSpace R (Fin 2): verify the 11 edges have distance 1 and the 10 non-edges have distance != 1, then transport χ_f >= 3.5 to the unit-distance graph on R^2.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: axiom-free χ_f infrastructure + graph-level χ_f(MoserSpindle) ≥ 3.5 proved. Remaining: explicit ℝ² unit-distance embedding of the spindle.",
+    "builtItems": [
+      "fractionalChromaticNumber (finite-graph fractional set-cover LP inf) in UnitDistanceIndependenceOQ04.lean",
+      "card_div_indep_le_fractionalChromaticNumber: χ_f(G) ≥ |V|/α(G) (axiom-free LP averaging bound), OQ04.lean",
+      "sum_coverage_eq: double-counting identity ∑_v cover(v) = ∑_I |I|·w(I), OQ04.lean",
+      "moserSpindle : SimpleGraph (Fin 7) with independenceNumber = 2 (by decide), OQ04.lean",
+      "moserSpindle_fractionalChromaticNumber_ge: χ_f(moserSpindle) ≥ 7/2 = 3.5 (0 axioms), OQ04.lean"
+    ],
+    "insights": [
+      "χ_f(G) ≥ |V|/α(G) holds for ALL finite graphs (not only vertex-transitive): one-line averaging over the fractional-cover LP. This converts any independence-ratio certificate into a χ_f lower bound.",
+      "Moser spindle (7 vertices, α=2) already attains the Frankl–Wilson value 7/2 = 3.5; no larger construction is needed for the 3.5 bound.",
+      "independenceNumber of a small explicit Fin n graph is provable by kernel `decide` (axiom-free), avoiding native_decide and its Lean.ofReduceBool axiom.",
+      "Derived spindle adjacency from the two-rhombi construction: shared acute apex 0; rhombus-1 {1,2 obtuse, 3 far apex}; rhombus-2 {4,5 obtuse, 6 far apex}; spindle edge 3–6. 11 edges total."
+    ],
+    "mathlibGaps": [
+      "Mathlib has NO fractional chromatic number (no SimpleGraph.fractionalChromaticNumber); built a minimal one locally (~80 lines).",
+      "Remaining gap for full ℝ² claim: explicit Moser-spindle coordinates need irrational entries (√3, spindle-rotation angle); verifying 11 unit distances + 10 non-unit distances in EuclideanSpace ℝ (Fin 2) is the open engineering step."
+    ],
+    "nextSteps": [
+      "Give 7 explicit points in EuclideanSpace ℝ (Fin 2) realising moserSpindle; prove dist = 1 on the 11 edges and dist ≠ 1 on the 10 non-edges (submit distance lemmas to Aristotle if tedious).",
+      "Build a graph iso moserSpindle ≃g unitDistGraph S transporting independenceNumber and hence χ_f ≥ 3.5 to the plane.",
+      "Optionally generalise fractionalChromaticNumber_ge_of_seven_indep_two to χ_f ≥ n/α for arbitrary certified (n, α)."
+    ],
+    "markdown": "# Knowledge Base: unit-distance-independence-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n(Initial observations from OBSERVE phase will be recorded here.)\n\n---\n\n## Insights\n\n(Insights from research attempts will be accumulated here.)\n\n---\n\n## Mathlib Coverage Audit\n\n(After ORIENT phase: list of relevant Mathlib lemmas / APIs and their applicability.)\n\n---\n\n## Anti-Goals\n\n(Things explicitly NOT to attempt — discovered duplicates, scope creep risks, etc.)\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "unit-distance-independence",
+    "unit-distance-independence-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-03T06:52:01.409Z",
+  "lastUpdate": "2026-07-03T12:30:00Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/UnitDistanceIndependence.lean",
+      "filename": "UnitDistanceIndependence.lean",
+      "lineCount": 960,
+      "theoremCount": 66,
+      "axiomCount": 1,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceIndependence.lean"
+    },
+    {
+      "path": "Proofs/UnitDistanceIndependenceOQ01.lean",
+      "filename": "UnitDistanceIndependenceOQ01.lean",
+      "lineCount": 301,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceIndependenceOQ01.lean"
+    },
+    {
+      "path": "Proofs/UnitDistanceIndependenceOQ04.lean",
+      "filename": "UnitDistanceIndependenceOQ04.lean",
+      "lineCount": 232,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/UnitDistanceIndependenceOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Progress on **unit-distance-independence-oq-04** (Frankl–Wilson 1981: χ_f(ℝ²) ≥ 3.5).

Mathlib has **no** fractional chromatic number, so this file builds a self-contained one for finite graphs and proves the LP-duality lower bound that is the engine behind *every* fractional-chromatic bound:

> **χ_f(G) ≥ |V(G)| / α(G)** for every finite graph `G`.

It then instantiates this at a concrete **Moser spindle** graph on `Fin 7` (independence number `2`, checked by kernel `decide`) to obtain a fully machine-checked, graph-level witness:

> **χ_f(moserSpindle) ≥ 7/2 = 3.5.**

### Key declarations (`proofs/Proofs/UnitDistanceIndependenceOQ04.lean`)
- `fractionalChromaticNumber` — fractional set-cover LP infimum for finite graphs.
- `card_div_indep_le_fractionalChromaticNumber` — the bound χ_f(G) ≥ |V|/α(G), via the double-counting identity `sum_coverage_eq` (∑_v cover(v) = ∑_I |I|·w(I)) and `α`-domination.
- `moserSpindle : SimpleGraph (Fin 7)` with `moserSpindle_independenceNumber : independenceNumber = 2` (by `decide`).
- `moserSpindle_fractionalChromaticNumber_ge : (7:ℝ)/2 ≤ χ_f(moserSpindle)`.

### Status
- **0 sorries, 0 axioms.** `#print axioms` → `[propext, Classical.choice, Quot.sound]`.
- Uses `decide` (kernel), **not** `native_decide`, so no `Lean.ofReduceBool` dependency.
- Builds via `./proofs/scripts/docker-build.sh Proofs.UnitDistanceIndependenceOQ04`.

### Remaining open step
Realising `moserSpindle` by explicit unit-distance coordinates in `Plane = EuclideanSpace ℝ (Fin 2)` (verify the 11 edges have distance 1 and the 10 non-edges do not), then transporting χ_f ≥ 3.5 to the unit-distance graph on ℝ² via a graph isomorphism. Documented in the knowledge base; coordinates are irrational (√3 + spindle-rotation angle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)