### PR TITLE
research(laws-of-large-numbers): compose Kolmogorov + Kronecker into MZ SLLN normalisation step, verified 0-axiom

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -52,6 +52,16 @@
     * `tsum_measure_add_one_ne_top` — the finiteness corollary that feeds the
       first Borel–Cantelli lemma.
 
+  **Capstone — Kolmogorov + Kronecker (§ KolmogorovKronecker).** The analytic and
+  probabilistic halves are finally composed into the normalisation step of the
+  Marcinkiewicz–Zygmund law itself:
+
+    * `ae_tendsto_average_zero_of_variance_weighted_bdd` — for independent
+      mean-zero `L²` variables `Yᵢ` and a positive nondecreasing weight `aₙ → ∞`
+      with `∑ᵢ Var(Yᵢ)/aᵢ² < ∞`, almost surely `aₙ⁻¹ ∑_{i<n} Yᵢ → 0`. Obtained by
+      running Kolmogorov's criterion on the rescaled `Xᵢ = aᵢ⁻¹·Yᵢ` and feeding
+      its a.s.-convergence output through the a.e. Kronecker lift.
+
   Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`).
 -/
 import Mathlib
@@ -597,5 +607,83 @@ theorem tsum_measure_add_one_ne_top {Z : Ω → ℝ}
   ((tsum_measure_add_one_le_lintegral hZmeas hZnn).trans_lt hZint.lt_top).ne
 
 end TailSum
+
+/-! ## S5 — Kolmogorov + Kronecker: the SLLN normalisation step
+
+The two engines built above are finally composed. Kolmogorov's criterion
+(`ae_tendsto_sum_of_indep_of_variance_bdd`) turns a variance-sum bound into a.s.
+convergence of a series `∑ Xᵢ`; the a.e. Kronecker lift
+(`ae_tendsto_kronecker_average_zero`) turns a.s. convergence of `∑ Yᵢ/aᵢ` into
+the normalised average `(∑_{i<n} Yᵢ)/aₙ → 0`. Feeding the rescaled variables
+`Xᵢ = aᵢ⁻¹·Yᵢ` into the former and its output into the latter yields, in one
+clean statement, the **normalisation step of the Marcinkiewicz–Zygmund strong
+law**: for independent mean-zero `L²` variables `Yᵢ` and a positive nondecreasing
+weight `aₙ → ∞` with `∑ᵢ Var(Yᵢ)/aᵢ² < ∞`, almost surely `aₙ⁻¹ ∑_{i<n} Yᵢ → 0`.
+
+At `aₙ = n` and `Yᵢ = Xᵢ − 𝔼Xᵢ` this is Kolmogorov's classical SLLN under the
+`∑ Var(Xᵢ)/i² < ∞` hypothesis; the general weight is precisely the normaliser
+the MZ truncation feeds in. This is the capstone tying the file's analytic and
+probabilistic halves together — still on the 0-axiom track. -/
+
+section KolmogorovKronecker
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal NNReal
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- **Kolmogorov–Kronecker normalisation step of the Marcinkiewicz–Zygmund SLLN.**
+For independent mean-zero `L²` random variables `Y i`, and a positive,
+nondecreasing weight sequence `a` with `a n → ∞` whose weighted variance partial
+sums are uniformly bounded, `∑_{i≤n} Var(Yᵢ)/aᵢ² ≤ V`, the normalised averages
+converge to zero almost surely:
+
+    (∑_{i<n} Yᵢ) / aₙ → 0     a.s.
+
+Proof: apply Kolmogorov's criterion `ae_tendsto_sum_of_indep_of_variance_bdd` to
+the rescaled variables `Xᵢ = aᵢ⁻¹·Yᵢ` — independence is preserved by
+`iIndepFun.comp`, the `L²` and mean-zero properties by `MemLp.const_mul` and
+`integral_const_mul`, and `Var(Xᵢ) = aᵢ⁻²·Var(Yᵢ)` by `variance_const_mul`, so
+the weighted-variance hypothesis becomes the plain variance-sum bound the engine
+needs — obtaining a.s. convergence of `∑ᵢ Yᵢ/aᵢ`; then feed that into the a.e.
+Kronecker lift `ae_tendsto_kronecker_average_zero`. -/
+theorem ae_tendsto_average_zero_of_variance_weighted_bdd [IsProbabilityMeasure μ]
+    (Y : ℕ → Ω → ℝ) (a : ℕ → ℝ)
+    (hmeas : ∀ i, StronglyMeasurable (Y i))
+    (hindep : iIndepFun Y μ) (hmemLp : ∀ i, MemLp (Y i) 2 μ)
+    (hmean : ∀ i, μ[Y i] = 0)
+    (ha_pos : ∀ n, 0 < a n) (ha_mono : Monotone a) (ha_top : Tendsto a atTop atTop)
+    (V : ℝ)
+    (hV : ∀ n, ∑ i ∈ range (n + 1), variance (Y i) μ / (a i) ^ 2 ≤ V) :
+    ∀ᵐ ω ∂μ, Tendsto (fun n => (∑ i ∈ range n, Y i ω) / a n) atTop (𝓝 0) := by
+  -- rescaled variables `Xᵢ = aᵢ⁻¹ · Yᵢ`
+  set X : ℕ → Ω → ℝ := fun i ω => (a i)⁻¹ * Y i ω with hXdef
+  have hXmeas : ∀ i, StronglyMeasurable (X i) := fun i => (hmeas i).const_mul _
+  have hXindep : iIndepFun X μ := by
+    have h := hindep.comp (fun i (y : ℝ) => (a i)⁻¹ * y)
+      (fun i => measurable_const.mul measurable_id)
+    simpa [hXdef, Function.comp] using h
+  have hXmemLp : ∀ i, MemLp (X i) 2 μ := fun i => (hmemLp i).const_mul _
+  have hXmean : ∀ i, μ[X i] = 0 := by
+    intro i
+    simp only [hXdef, integral_const_mul, hmean i, mul_zero]
+  -- `Var(Xᵢ) = aᵢ⁻² · Var(Yᵢ) = Var(Yᵢ)/aᵢ²`
+  have hXvar : ∀ i, variance (X i) μ = variance (Y i) μ / (a i) ^ 2 := by
+    intro i
+    rw [hXdef, variance_const_mul, inv_pow, div_eq_inv_mul]
+  -- Kolmogorov's criterion for the rescaled variables gives a.s. convergence of `∑ Xᵢ`
+  have hconv := ae_tendsto_sum_of_indep_of_variance_bdd X hXmeas hXindep hXmemLp hXmean V
+    (fun n => by simp_rw [hXvar]; exact hV n)
+  -- rewrite `∑ Xᵢ ω = ∑ Yᵢ ω / aᵢ` to feed the Kronecker lift
+  have hconv' : ∀ᵐ ω ∂μ, ∃ s : ℝ,
+      Tendsto (fun n => ∑ i ∈ range n, Y i ω / a i) atTop (𝓝 s) := by
+    filter_upwards [hconv] with ω hω
+    obtain ⟨c, hc⟩ := hω
+    refine ⟨c, hc.congr (fun n => ?_)⟩
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    simp only [hXdef, div_eq_inv_mul]
+  exact ae_tendsto_kronecker_average_zero a Y ha_pos ha_mono ha_top hconv'
+
+end KolmogorovKronecker
 
 end LawsOfLargeNumbers.MZ

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "laws-of-large-numbers-oq-01-oq-02-oq-01",
   "title": "Kronecker's Lemma and the Kolmogorov Martingale Assembly for the Marcinkiewicz–Zygmund SLLN",
   "slug": "laws-of-large-numbers-oq-01-oq-02-oq-01",
-  "description": "The Marcinkiewicz–Zygmund strong law (rate n^{1/p} for E|X|^p < ∞, 1 ≤ p < 2) is a multi-session build whose classical proof factors into an analytic passage (Kronecker's lemma) and a probabilistic engine (Kolmogorov's convergence criterion). This entry supplies the reusable infrastructure for both, verified with 0 sorries and 0 axioms. (1) Kronecker's lemma: if a_n > 0 is nondecreasing with a_n → ∞ and ∑ x_n / a_n converges, then (∑_{i<n} x_i) / a_n → 0 — absent from Mathlib, built on a Toeplitz/Silverman weighted-average null step. (2) Kolmogorov's criterion, assembled via Mathlib's a.e. martingale-convergence theorem: the shifted partial sums of independent mean-zero variables form a martingale w.r.t. the natural filtration (martingale_sum_of_indep_mean_zero), and an L¹-bounded such sum converges a.s. (ae_tendsto_sum_of_indep_of_eLpNorm_bdd), reducing the criterion to a uniform L¹ bound.",
+  "description": "The Marcinkiewicz–Zygmund strong law (rate n^{1/p} for E|X|^p < ∞, 1 ≤ p < 2) is a multi-session build whose classical proof factors into an analytic passage (Kronecker's lemma) and a probabilistic engine (Kolmogorov's convergence criterion). This entry supplies the reusable infrastructure for both, verified with 0 sorries and 0 axioms. (1) Kronecker's lemma: if a_n > 0 is nondecreasing with a_n → ∞ and ∑ x_n / a_n converges, then (∑_{i<n} x_i) / a_n → 0 — absent from Mathlib, built on a Toeplitz/Silverman weighted-average null step. (2) Kolmogorov's criterion, assembled via Mathlib's a.e. martingale-convergence theorem: the shifted partial sums of independent mean-zero variables form a martingale w.r.t. the natural filtration (martingale_sum_of_indep_mean_zero), and an L¹-bounded such sum converges a.s. (ae_tendsto_sum_of_indep_of_eLpNorm_bdd), reducing the criterion to a uniform L¹ bound. (3) Capstone — the Kolmogorov–Kronecker normalisation step of the Marcinkiewicz–Zygmund law itself (ae_tendsto_average_zero_of_variance_weighted_bdd): for independent mean-zero L² variables Y_i and a positive nondecreasing weight a_n → ∞ with ∑_i Var(Y_i)/a_i² < ∞, almost surely a_n⁻¹ ∑_{i<n} Y_i → 0, by running Kolmogorov's criterion on the rescaled X_i = a_i⁻¹·Y_i and feeding its a.s.-convergence output through the a.e. Kronecker lift.",
   "meta": {
     "author": "Leopold Kronecker & A. Kolmogorov (results); formalization researcher-16, researcher-14",
     "sourceUrl": "https://en.wikipedia.org/wiki/Kronecker%27s_lemma",
@@ -23,9 +23,9 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 12,
     "definitionCount": 0,
-    "lineCount": 409,
+    "lineCount": 689,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_range_by_parts",
@@ -90,9 +90,9 @@
       "ProbabilityTheory"
     ],
     "namespace": "LawsOfLargeNumbers.MZ",
-    "lineCount": 409,
+    "lineCount": 689,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 12,
     "definitionCount": 0,
     "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Composes the two engines already present in `LawsOfLargeNumbersOQ01OQ02OQ01.lean` — **Kolmogorov's convergence criterion** (`ae_tendsto_sum_of_indep_of_variance_bdd`) and the **a.e. Kronecker lift** (`ae_tendsto_kronecker_average_zero`) — which were built in prior sessions but never joined. The file's own docstrings repeatedly pointed at this composition as the outstanding "normalisation step."

## New theorem

```
ae_tendsto_average_zero_of_variance_weighted_bdd
```

For independent mean-zero $L^2$ random variables $Y_i$ and a positive nondecreasing weight $a_n \to \infty$ with $\sum_i \operatorname{Var}(Y_i)/a_i^2 < \infty$ (uniform partial-sum bound), almost surely
$$ a_n^{-1} \sum_{i<n} Y_i \to 0. $$

This is exactly the normalisation step of the **Marcinkiewicz–Zygmund strong law**; at $a_n = n$, $Y_i = X_i - \mathbb{E}X_i$ it is Kolmogorov's classical SLLN under $\sum \operatorname{Var}(X_i)/i^2 < \infty$.

### Proof

Apply Kolmogorov's criterion to the rescaled variables $X_i = a_i^{-1} Y_i$:
- independence preserved by `iIndepFun.comp`;
- $L^2$ and mean-zero by `MemLp.const_mul` / `integral_const_mul`;
- $\operatorname{Var}(X_i) = a_i^{-2}\operatorname{Var}(Y_i)$ by `variance_const_mul`, turning the weighted-variance hypothesis into the plain variance-sum bound the engine consumes.

This yields a.s. convergence of $\sum_i Y_i/a_i$, which is fed into the a.e. Kronecker lift.

## Verification

- `docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` — **passes** (7743 jobs).
- **0 sorries, 0 axiom declarations**; no `native_decide`. Stays on the 0-axiom track (only `propext`/`Classical.choice`/`Quot.sound`).
- Updated stale `meta.json` `leanFile` counts (5→12 theorems, 409→689 lines) and appended the capstone to the description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)