### PR TITLE
Enrich Area of Circle OQ-02-03-02: shell/FTC surface–volume derivation

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-03-oq-02/annotations.json
@@ -4,21 +4,23 @@
     "proofId": "area-of-circle-oq-02-oq-03-oq-02",
     "range": {
       "startLine": 1,
-      "endLine": 57
+      "endLine": 61
     },
-    "type": "context",
+    "type": "concept",
     "title": "Two Derivations of Sₙ = n·Vₙ: Gamma Recurrence vs. Shell Integration",
     "content": "The parent entry proved Sₙ = n·Vₙ algebraically, by unfolding the Gamma closed forms Vₙ = π^(n/2)/Γ(n/2+1) and Sₙ = 2π^(n/2)/Γ(n/2) and invoking the functional equation Γ(n/2+1)=(n/2)·Γ(n/2). This file gives the geometric derivation the parent flagged as open: the unit n-ball is the union of spherical shells of radius r∈[0,1], each shell carrying (n−1)-measure Sₙ·rⁿ⁻¹ (the unit sphere scaled by r), so integrating shells gives Vₙ = ∫₀¹ Sₙ rⁿ⁻¹ dr. The definition shellVolume reuses the parent's unitSphereSurface and unitBallVolume unchanged; the novelty is that Vₙ is now realized as an interval integral rather than a Gamma quotient.",
-    "mathContext": "$V_n = \\int_0^1 S_n\\, r^{n-1}\\,dr$; shells of radius $r$ have measure $S_n r^{n-1}$.",
-    "significance": "context",
+    "mathContext": "$V_n = \\int_0^1 S_n\\, r^{n-1}\\,dr$; a shell of radius $r$ has $(n-1)$-measure $S_n r^{n-1}$, since the sphere $S^{n-1}(r)$ scales as $r^{n-1}S^{n-1}(1)$.",
+    "significance": "supporting",
     "relatedConcepts": [
       "spherical shell integration",
       "Cavalieri's principle",
-      "fundamental theorem of calculus"
+      "fundamental theorem of calculus",
+      "onion / coarea decomposition"
     ],
     "prerequisites": [
       "interval integration",
-      "spherical coordinates"
+      "spherical coordinates",
+      "the parent unitSphereSurface / unitBallVolume definitions"
     ]
   },
   {
@@ -49,44 +51,94 @@
     "id": "ann-aoc-oq02-oq03-oq02-ftc",
     "proofId": "area-of-circle-oq-02-oq-03-oq-02",
     "range": {
-      "startLine": 67,
-      "endLine": 82
+      "startLine": 63,
+      "endLine": 73
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The FTC Core: ∫₀¹ rⁿ⁻¹ dr = 1/n",
     "content": "integral_r_pow is the single application of the Fundamental Theorem of Calculus on which the whole file rests. Mathlib's integral_pow gives ∫₀¹ rᵏ dr = (1ᵏ⁺¹−0ᵏ⁺¹)/(k+1); with k = n−1 the exponent becomes n−1+1, reconciled to n by Nat.succ_pred_eq_of_pos (n≥1). The numerator 1ⁿ−0ⁿ = 1 (using zero_pow for n≥1), and the real-valued denominator ↑(n−1)+1 is reconciled to ↑n by exact_mod_cast on the Nat identity n−1+1=n. The result 1/n is the antiderivative rⁿ/n evaluated across [0,1].",
     "mathContext": "$\\int_0^1 r^{n-1}\\,dr = \\left[\\tfrac{r^n}{n}\\right]_0^1 = \\tfrac{1}{n}$.",
-    "significance": "core",
+    "significance": "critical",
     "relatedConcepts": [
       "fundamental theorem of calculus",
       "monomial integration",
-      "Nat subtraction casts"
+      "Nat subtraction casts",
+      "zero_pow"
     ],
     "prerequisites": [
       "integral_pow",
-      "natural-number casts to ℝ"
+      "natural-number casts to ℝ",
+      "Nat.succ_pred_eq_of_pos"
     ]
   },
   {
     "id": "ann-aoc-oq02-oq03-oq02-main",
     "proofId": "area-of-circle-oq-02-oq-03-oq-02",
     "range": {
-      "startLine": 83,
-      "endLine": 116
+      "startLine": 75,
+      "endLine": 96
     },
-    "type": "key-step",
+    "type": "theorem",
     "title": "Sₙ = n·shellVolume n Without the Gamma Recurrence",
-    "content": "shellVolume_eq factors the constant Sₙ out of the integral (intervalIntegral.integral_const_mul) and applies the FTC core to get Sₙ/n. surface_eq_n_mul_shellVolume then reads off Sₙ = n·shellVolume n: the n=0 branch uses Γ(0)=0 (both sides 0), and the n≥1 branch is field_simp. Crucially this proof never touches the Gamma functional equation — the proportionality constant n comes from the antiderivative of rⁿ⁻¹, not from the half-dimension shift Γ(n/2+1)↔Γ(n/2). shellVolume_eq_unitBallVolume then substitutes the parent's own surface_eq_n_mul_volume to prove shellVolume n = Vₙ, reconciling the geometric and analytic routes so that the two independent derivations of Sₙ=n·Vₙ provably agree.",
-    "mathContext": "$S_n = n\\cdot\\mathrm{shellVolume}(n)$ (FTC) and $\\mathrm{shellVolume}(n) = V_n$ (reconciliation with the Gamma form).",
-    "significance": "core",
+    "content": "shellVolume_eq factors the constant Sₙ out of the integral (intervalIntegral.integral_const_mul) and applies the FTC core to get Sₙ/n. surface_eq_n_mul_shellVolume then reads off Sₙ = n·shellVolume n: the n=0 branch uses Γ(0)=0 (both sides 0), and the n≥1 branch is field_simp. Crucially this proof never touches the Gamma functional equation — the proportionality constant n comes from the antiderivative of rⁿ⁻¹, not from the half-dimension shift Γ(n/2+1)↔Γ(n/2). This is the whole point of the open question: the same surface–volume scaling arises from pure integral geometry rather than from special-function algebra.",
+    "mathContext": "$\\mathrm{shellVolume}(n) = S_n/n$ (const-factor rule + FTC), hence $S_n = n\\cdot\\mathrm{shellVolume}(n)$.",
+    "significance": "critical",
     "relatedConcepts": [
       "constant factor rule",
       "surface-volume scaling",
-      "divergence theorem"
+      "junk-value convention Γ(0)=0",
+      "field_simp"
     ],
     "prerequisites": [
       "intervalIntegral.integral_const_mul",
-      "the parent's surface_eq_n_mul_volume"
+      "the FTC core integral_r_pow",
+      "Real.Gamma_zero"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-oq02-reconcile",
+    "proofId": "area-of-circle-oq-02-oq-03-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "Reconciliation: the Shell Integral Reproduces the Gamma Volume Vₙ",
+    "content": "shellVolume_eq_unitBallVolume closes the loop between the two independent derivations. It rewrites shellVolume n = Sₙ/n via shellVolume_eq, then substitutes the parent's Gamma-based surface_eq_n_mul_volume (Sₙ = n·Vₙ) and cancels the factor n (div_self, mul_comm/mul_div_assoc) to conclude shellVolume n = Vₙ. So the geometrically-defined shell integral and the analytically-defined Gamma quotient are provably the same real number — the FTC route and the Gamma route do not merely give the same scaling law, they compute the same volume.",
+    "mathContext": "$\\mathrm{shellVolume}(n) = \\dfrac{S_n}{n} = \\dfrac{n\\,V_n}{n} = V_n$, using the parent identity $S_n = n\\,V_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "consistency of independent derivations",
+      "cancellation of the scaling factor",
+      "Gamma closed form for the ball volume"
+    ],
+    "prerequisites": [
+      "shellVolume_eq",
+      "the parent surface_eq_n_mul_volume",
+      "div_self on ℝ"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-oq02-special",
+    "proofId": "area-of-circle-oq-02-oq-03-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 121
+    },
+    "type": "theorem",
+    "title": "Special Values and the Final Agreement Sₙ = n·Vₙ",
+    "content": "shellVolume_two = π (unit disk from circular shells) and shellVolume_three = 4π/3 (unit ball from spherical shells) are concrete sanity checks: the shell integral reproduces the classical low-dimensional volumes via shellVolume_eq_unitBallVolume and the parent's computed values. Finally shell_surface_agrees states the headline identity Sₙ = n·Vₙ with Vₙ now realized concretely as the shell integral, chaining surface_eq_n_mul_shellVolume with the reconciliation lemma — the geometric derivation delivering exactly the parent's Gamma-derived result.",
+    "mathContext": "$\\mathrm{shellVolume}(2)=\\pi,\\ \\mathrm{shellVolume}(3)=\\tfrac{4\\pi}{3};\\quad S_n = n\\,V_n\\ (n\\ge 1)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "area of the disk",
+      "volume of the ball",
+      "dimensional sanity checks",
+      "surface-volume identity"
+    ],
+    "prerequisites": [
+      "shellVolume_eq_unitBallVolume",
+      "the parent unitBallVolume_two / unitBallVolume_three"
     ]
   },
   {


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-02-oq-03-oq-02` (quality 87 → 100).

Scorer breakdown gap was **annotations 15→25** (only 3 annotations; the shallowest bucket), with mathContext/significance/crossRefs each at 9/10.

- Split the broad third annotation (which spanned four theorems) into three granular annotations at declaration boundaries: `surface_eq_n_mul_shellVolume` (FTC surface–volume identity), `shellVolume_eq_unitBallVolume` (reconciliation with the Gamma volume), and the special values `shellVolume_two/three` + `shell_surface_agrees`.
- Now 5 annotations, all with mathContext, significance (valid enum), relatedConcepts, prerequisites.
- All resolve to real Lean constructs (annotation build: no warnings for this entry); meta.json within size caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)