### PR TITLE
Enrich Lovász Local Lemma OQ-01 inclusion-exclusion

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/annotations.json
@@ -74,22 +74,47 @@
     "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
     "range": {
       "startLine": 69,
-      "endLine": 93
+      "endLine": 83
     },
     "type": "insight",
-    "title": "Sharp avoidance threshold and union-bound recovery",
-    "content": "```lean\ntheorem two_event_avoidance (hA : MeasurableSet A) (hB : MeasurableSet B)\n    (hlt : μ A + μ B < 1 + μ (A ∩ B)) :\n    0 < μ (Aᶜ ∩ Bᶜ) := by\n  rw [pos_iff_ne_zero]\n  intro h0\n  have hid := two_event_avoidance_add (μ := μ) hA hB\n  rw [h0, zero_add] at hid\n  exact hlt.ne hid\n\ntheorem two_event_avoidance_of_union_lt (hA : MeasurableSet A) (hB : MeasurableSet B)\n    (hlt : μ A + μ B < 1) :\n    0 < μ (Aᶜ ∩ Bᶜ) :=\n  two_event_avoidance hA hB (lt_of_lt_of_le hlt (le_add_right le_rfl))\n```\n\nPositivity is read straight off the exact identity: if $\\mu(A^c \\cap B^c) = 0$ then the identity collapses to $\\mu(A) + \\mu(B) = 1 + \\mu(A \\cap B)$, contradicting the strict hypothesis $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$; hence $\\mu(A^c \\cap B^c) \\ne 0$ (`pos_iff_ne_zero`). The threshold $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ is **strictly weaker** than the union-bound condition $\\mu(A) + \\mu(B) < 1$ exactly when $\\mu(A \\cap B) > 0$, i.e. when the events overlap (are positively correlated). The corollary `two_event_avoidance_of_union_lt` recovers the crude union-bound condition by discarding $\\mu(A \\cap B) \\ge 0$ (`le_add_right`), making the improvement explicit.",
-    "mathContext": "$\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ is the sharp two-event avoidance threshold; it beats the first-moment threshold $\\mu(A) + \\mu(B) < 1$ by the overlap $\\mu(A \\cap B)$ — the elementary germ of the LLL's dependency gain.",
+    "title": "The sharp positive-avoidance threshold",
+    "content": "`two_event_avoidance` reads positivity straight off the exact identity: assume $\\mu(A^c \\cap B^c) = 0$; then `two_event_avoidance_add` collapses to $\\mu(A) + \\mu(B) = 1 + \\mu(A \\cap B)$, contradicting the strict hypothesis $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$. So $\\mu(A^c \\cap B^c) \\ne 0$, and `pos_iff_ne_zero` upgrades $\\ne 0$ to $> 0$. The whole proof is four lines because the identity has already done the work — no measure estimates, just a strict inequality refuting an equality. The threshold $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ is the *sharp* condition guaranteeing at least one outcome avoids both bad events, and it is exactly the germ of the LLL's dependency gain: the admissible region grows by the overlap $\\mu(A \\cap B)$.",
+    "mathContext": "two_event_avoidance: μ A + μ B < 1 + μ(A ∩ B) ⇒ 0 < μ(Aᶜ ∩ Bᶜ). Proof: if μ(Aᶜ∩Bᶜ)=0 the exact identity forces μ A + μ B = 1 + μ(A∩B), contradicting the strict hypothesis; pos_iff_ne_zero finishes.",
     "significance": "central",
     "relatedConcepts": [
       "positive correlation",
-      "first-moment method",
+      "sharp avoidance threshold",
       "avoidance probability",
+      "ENNReal pos_iff_ne_zero",
       "Lovász Local Lemma"
     ],
     "prerequisites": [
-      "ENNReal order: pos_iff_ne_zero, le_add_right",
-      "the exact identity two_event_avoidance_add"
+      "the exact identity two_event_avoidance_add",
+      "ENNReal.pos_iff_ne_zero"
+    ]
+  },
+  {
+    "id": "ann-lll-oq01-ie-union-recovery",
+    "proofId": "lovasz-local-lemma-oq-01-inclusion-exclusion",
+    "range": {
+      "startLine": 84,
+      "endLine": 93
+    },
+    "type": "key-step",
+    "title": "Union-bound recovery: the overlap is exactly what is thrown away",
+    "content": "`two_event_avoidance_of_union_lt` recovers the crude first-moment condition $\\mu(A) + \\mu(B) < 1$ as a *corollary* of the sharp threshold, by discarding the overlap: since $\\mu(A \\cap B) \\ge 0$, one has $1 \\le 1 + \\mu(A \\cap B)$, so $\\mu(A) + \\mu(B) < 1$ implies $\\mu(A) + \\mu(B) < 1 + \\mu(A \\cap B)$ (`lt_of_lt_of_le` with `le_add_right`). Feeding that into `two_event_avoidance` gives positivity. The one-line derivation makes the improvement precise and directional: the sharp threshold is *strictly* weaker than the union-bound threshold exactly when $\\mu(A \\cap B) > 0$ — when the events are positively correlated. This is the two-event shadow of why the LLL beats the union bound in general: dependency (overlap) enlarges the region where global avoidance is still forced.",
+    "mathContext": "two_event_avoidance_of_union_lt: μ A + μ B < 1 ⇒ 0 < μ(Aᶜ ∩ Bᶜ), via lt_of_lt_of_le hlt (le_add_right le_rfl) feeding two_event_avoidance. Strictly weaker gain = μ(A ∩ B).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "union bound / first-moment method",
+      "Bonferroni inequality",
+      "corollary by weakening",
+      "le_add_right, lt_of_lt_of_le",
+      "dependency gain over the union bound"
+    ],
+    "prerequisites": [
+      "two_event_avoidance (the sharp threshold)",
+      "ENNReal order lemmas le_add_right, lt_of_lt_of_le"
     ]
   }
 ]

--- a/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-inclusion-exclusion/meta.json
@@ -81,7 +81,8 @@
       "The two-event case is where the union bound first becomes non-tight. The union bound μ(Aᶜ ∩ Bᶜ) ≥ 1 − μ A − μ B is exactly the inclusion–exclusion identity with the +μ(A ∩ B) term dropped; keeping it makes the two-event statement an exact equality, not a bound.",
       "Stating the identity additively — μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) rather than with a subtraction — sidesteps ℝ≥0∞ truncated subtraction entirely: the proof is a chain of additions using measure_add_measure_compl and measure_union_add_inter, with no finiteness hypotheses needed even though the probability measure makes everything finite anyway.",
       "The sharp avoidance threshold μ A + μ B < 1 + μ(A ∩ B) is strictly weaker than the union-bound threshold μ A + μ B < 1 exactly when μ(A ∩ B) > 0, i.e. when the two events are positively correlated. This is the first quantitative instance of the LLL's guiding principle: dependency structure among bad events can only help avoid them all.",
-      "The identity is a two-set special case of the general inclusion–exclusion formula μ(⋂ A_iᶜ) = ∑_{S ⊆ ι} (−1)^{|S|} μ(⋂_{i ∈ S} A_i). The n-event version — and the Bonferroni truncations that bound it — is the natural next increment toward controlling avoidance by low-order joint masses, en route to the bounded-dependency-degree LLL."
+      "The identity is a two-set special case of the general inclusion–exclusion formula μ(⋂ A_iᶜ) = ∑_{S ⊆ ι} (−1)^{|S|} μ(⋂_{i ∈ S} A_i). The n-event version — and the Bonferroni truncations that bound it — is the natural next increment toward controlling avoidance by low-order joint masses, en route to the bounded-dependency-degree LLL.",
+      "Positivity is obtained by refuting an equality, not by estimating a measure. Because the exact identity pins μ(Aᶜ ∩ Bᶜ) to a single value 1 + μ(A ∩ B) − μ A − μ B, the strict hypothesis μ A + μ B < 1 + μ(A ∩ B) makes μ(Aᶜ ∩ Bᶜ) = 0 self-contradictory, so pos_iff_ne_zero yields strict positivity in four lines with no lower-bound computation. This is the structural payoff of proving an exact identity first: every threshold result downstream is a one-step consequence, and the union-bound corollary follows merely by weakening the hypothesis with μ(A ∩ B) ≥ 0."
     ],
     "prerequisites": [
       "Measure-theoretic probability: IsProbabilityMeasure, measure_add_measure_compl, measure_univ",
@@ -104,9 +105,17 @@
       "id": "sec-overview",
       "title": "Overview: the first correction to the union bound",
       "startLine": 1,
-      "endLine": 44,
+      "endLine": 35,
       "summary": "Module docstring positioning this file as the exact two-event inclusion–exclusion refinement of the union bound, the first step past first-moment in the OQ-01 program. States μ(Aᶜ ∩ Bᶜ) + μ A + μ B = 1 + μ(A ∩ B) and the sharpened avoidance threshold μ A + μ B < 1 + μ(A ∩ B).",
       "mathContext": "The pairwise overlap μ(A ∩ B) is the exact correction the two-event union bound discards; it is nonzero precisely when the events are dependent (positively correlated)."
+    },
+    {
+      "id": "sec-setup",
+      "title": "Imports, namespace, and the ambient probability measure",
+      "startLine": 36,
+      "endLine": 44,
+      "summary": "Opens MeasureTheory, enters the LovaszLocalLemmaOQ01InclusionExclusion namespace, and fixes an ambient IsProbabilityMeasure μ over a measurable space with two measurable events A, B. No independence typeclass is assumed — the identity and threshold hold for arbitrary (possibly dependent) events.",
+      "mathContext": "Ambient: measurable space Ω, μ an IsProbabilityMeasure (μ Set.univ = 1), events A B : Set Ω with MeasurableSet hypotheses supplied per-theorem. No IndepSet / iIndepSet assumption."
     },
     {
       "id": "sec-identity",
@@ -118,11 +127,19 @@
     },
     {
       "id": "sec-avoidance",
-      "title": "Sharp positive avoidance and union-bound recovery",
+      "title": "Sharp positive avoidance",
       "startLine": 69,
+      "endLine": 83,
+      "summary": "two_event_avoidance: from the exact identity, μ(Aᶜ ∩ Bᶜ) = 0 would force μ A + μ B = 1 + μ(A ∩ B), contradicting the strict threshold; hence positive avoidance under μ A + μ B < 1 + μ(A ∩ B). Four-line proof: pos_iff_ne_zero, then refute the equality with the strict hypothesis.",
+      "mathContext": "μ A + μ B < 1 + μ(A ∩ B) ⇒ 0 < μ(Aᶜ ∩ Bᶜ). The sharp threshold: the exact condition guaranteeing at least one outcome avoids both events."
+    },
+    {
+      "id": "sec-union-recovery",
+      "title": "Union-bound recovery as a corollary",
+      "startLine": 84,
       "endLine": 93,
-      "summary": "two_event_avoidance: from the exact identity, μ(Aᶜ ∩ Bᶜ) = 0 would force μ A + μ B = 1 + μ(A ∩ B), contradicting the strict threshold; hence positive avoidance under μ A + μ B < 1 + μ(A ∩ B). two_event_avoidance_of_union_lt: the coarse condition μ A + μ B < 1 follows by discarding μ(A ∩ B) ≥ 0.",
-      "mathContext": "The sharp threshold beats the union bound exactly by the overlap μ(A ∩ B): the first quantitative sign that dependency helps avoidance."
+      "summary": "two_event_avoidance_of_union_lt: the coarse first-moment condition μ A + μ B < 1 follows from the sharp threshold by discarding μ(A ∩ B) ≥ 0 (le_add_right), then applying two_event_avoidance. Makes the improvement directional: the sharp threshold is strictly weaker exactly when the overlap μ(A ∩ B) > 0.",
+      "mathContext": "μ A + μ B < 1 ⇒ 0 < μ(Aᶜ ∩ Bᶜ), via lt_of_lt_of_le hlt (le_add_right le_rfl). The gain over the union bound is exactly μ(A ∩ B) — the first quantitative sign that dependency helps avoidance."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Enrichment pass — quality 89 → 100

Enriches `lovasz-local-lemma-oq-01-inclusion-exclusion` (passes: 0). Gaps were annotations 4→5, sections 3→5, keyInsights 4→5.

### Changes
- **annotations.json 4→5**: split the combined sharp-avoidance annotation (69–93) into the sharp-threshold theorem `two_event_avoidance` (69–83) and the union-bound-recovery corollary `two_event_avoidance_of_union_lt` (84–93), each with full mathContext / significance / relatedConcepts / prerequisites.
- **meta.json sections 3→5**: split `sec-overview` into docstring (1–35) + measure setup (36–44), and `sec-avoidance` into the two theorems (69–83, 84–93) — mirroring the annotations.
- **meta.json keyInsights 4→5**: added an insight on obtaining positivity by *refuting an equality* (the exact identity pins μ(Aᶜ∩Bᶜ) to a single value), the structural payoff that makes every downstream threshold a one-step consequence.

### Quality breakdown (after)
`annotations 25 · mathContext 10 · significance 10 · historicalContext 10 · keyInsights 10 · conclusion 15 · sections 10 · crossRefs 10 = 100`

No Lean source changed. meta.json 18 KB.