### PR TITLE
Enrich Tsallis Entropy (AM-GM OQ-03-04-02)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04-oq-02/annotations.json
@@ -7,7 +7,19 @@
     "title": "Overview: Tsallis Entropy as the q-Deformed Rényi Identity",
     "content": "The parent entry proved H_α(p) = −log(M_{α−1}(p,p)), that Rényi entropy is the logarithm of a power mean. This file builds the Tsallis analogue by replacing the ordinary logarithm with the q-deformed logarithm ln_q(x) = (x^{1−q}−1)/(1−q), which tends to log(x) as q → 1. Tsallis entropy S_q(p) = (1 − Σ pᵢ^q)/(q−1) then satisfies a pseudo-additive product law whose cross term (1−q)·S_q(p)·S_q(r) is the signature of non-extensivity and vanishes as q → 1.",
     "mathContext": "$\\ln_q(x) = \\frac{x^{1-q}-1}{1-q}$; $S_q(p) = \\frac{1 - \\sum_i p_i^q}{q-1}$; $S_q = \\ln_q(\\exp(H_q))$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "Tsallis entropy",
+      "Rényi entropy",
+      "q-deformed logarithm",
+      "non-extensive statistical mechanics",
+      "power mean"
+    ],
+    "prerequisites": [
+      "amgm-inequality-oq-03-oq-04 (Rényi entropy = log of a power mean)",
+      "Shannon entropy",
+      "real powers rpow"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-02-defs",
@@ -17,17 +29,39 @@
     "title": "The q-Logarithm and Tsallis Entropy",
     "content": "renyiEntropy is reproduced locally so the file is self-contained. qLog is the q-deformed logarithm ln_q(x) = (x^{1−q}−1)/(1−q). tsallisEntropy is S_q(p) = (1 − Σ pᵢ^q)/(q−1). As q → 1 the q-logarithm degenerates to log and S_q degenerates to Shannon entropy.",
     "mathContext": "$\\ln_q(x) = \\frac{x^{1-q}-1}{1-q}$, $S_q(p) = \\frac{1-\\sum_i p_i^q}{q-1}$",
-    "significance": "standard"
+    "significance": "supporting",
+    "relatedConcepts": [
+      "q-deformed logarithm",
+      "Tsallis entropy",
+      "Rényi entropy",
+      "Shannon entropy limit"
+    ],
+    "prerequisites": [
+      "Real.rpow on positive reals",
+      "finite sums over a Finset",
+      "probability distributions (Σ pᵢ = 1)"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-03-qlogmul",
     "proofId": "amgm-inequality-oq-03-oq-04-oq-02",
-    "range": { "startLine": 86, "endLine": 98 },
+    "range": { "startLine": 92, "endLine": 98 },
     "type": "technique",
     "title": "The Pseudo-Additive Law of the q-Logarithm",
     "content": "qLog_mul proves ln_q(xy) = ln_q(x) + ln_q(y) + (1−q)·ln_q(x)·ln_q(y). Expanding (xy)^{1−q} = x^{1−q}·y^{1−q} via Real.mul_rpow and clearing the denominator (1−q) reduces the whole statement to a ring identity. The cross term (1−q)·ln_q(x)·ln_q(y) is the entire q-deformation; setting q = 1 recovers log(xy) = log x + log y.",
     "mathContext": "$\\ln_q(xy) = \\ln_q x + \\ln_q y + (1-q)\\,\\ln_q x\\,\\ln_q y$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "pseudo-additivity",
+      "functional equation of the logarithm",
+      "Real.mul_rpow",
+      "q-deformation cross term"
+    ],
+    "prerequisites": [
+      "Real.mul_rpow",
+      "field algebra / ring normalization",
+      "the definition of qLog"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-04-escort",
@@ -37,7 +71,18 @@
     "title": "Escort Form: the Exact q-Analogue of Shannon Entropy",
     "content": "tsallis_eq_neg_sum_qLog proves S_q(p) = −Σ pᵢ^q·ln_q(pᵢ). The pointwise lemma pow_mul_qLog gives pᵢ^q·ln_q(pᵢ) = (pᵢ − pᵢ^q)/(1−q) using pᵢ^q·pᵢ^{1−q} = pᵢ (Real.rpow_add). Summing and applying Σ pᵢ = 1 collapses the numerator to 1 − Σ pᵢ^q. This is Shannon's H = −Σ pᵢ log pᵢ with log replaced by ln_q and probabilities re-weighted by the escort powers pᵢ^q.",
     "mathContext": "$S_q(p) = -\\sum_i p_i^q \\ln_q(p_i)$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "escort distribution",
+      "Shannon entropy form −Σ p log p",
+      "Real.rpow_add",
+      "escort weights pᵢ^q"
+    ],
+    "prerequisites": [
+      "Real.rpow_add (pᵢ^q · pᵢ^{1−q} = pᵢ)",
+      "Finset.sum manipulation",
+      "normalization Σ pᵢ = 1"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-05-bridge",
@@ -47,7 +92,18 @@
     "title": "Bridge to Rényi: S_q = ln_q(exp(H_q))",
     "content": "tsallis_eq_qLog_exp_renyi is the direct Tsallis analogue of the parent's H_α = −log(M_{α−1}). Rewriting exp(H_q)^{1−q} = exp((1−q)·H_q) via Real.rpow_def_of_pos, the exponent (1−q)·H_q simplifies to log(Σ pᵢ^q), and exp∘log = id (using Σ pᵢ^q > 0) closes it. Where Rényi uses the exp/log pair, Tsallis uses the q-exponential/q-logarithm pair applied to the same information content.",
     "mathContext": "$S_q(p) = \\ln_q\\!\\big(\\exp H_q(p)\\big)$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "q-exponential",
+      "Rényi–Tsallis correspondence",
+      "Real.rpow_def_of_pos",
+      "exp∘log = id"
+    ],
+    "prerequisites": [
+      "the parent identity H_α = −log(M_{α−1})",
+      "Real.rpow_def_of_pos, Real.exp_log",
+      "positivity of Σ pᵢ^q"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-06-nonextensive",
@@ -57,7 +113,18 @@
     "title": "Non-Extensivity on Product Distributions",
     "content": "tsallis_pseudo_additive proves S_q(p⊗r) = S_q(p) + S_q(r) + (1−q)·S_q(p)·S_q(r) for the product distribution (i,j) ↦ pᵢ·rⱼ on s ×ˢ t. The key step is that the escort sum factorizes: Σ_{(i,j)} (pᵢ rⱼ)^q = (Σ pᵢ^q)(Σ rⱼ^q), via Finset.sum_product and Finset.sum_mul_sum. The product law is then exact field algebra in (q−1). The cross term (1−q)·S_q(p)·S_q(r) is exactly the departure from Shannon's additivity, and vanishes as q → 1.",
     "mathContext": "$S_q(p\\otimes r) = S_q(p) + S_q(r) + (1-q)\\,S_q(p)\\,S_q(r)$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "non-extensivity",
+      "product distribution",
+      "Finset.sum_mul_sum",
+      "additivity of Shannon entropy"
+    ],
+    "prerequisites": [
+      "Finset.sum_product, Finset.sum_mul_sum",
+      "product measure on s ×ˢ t",
+      "the escort-sum factorization"
+    ]
   },
   {
     "id": "ann-tsallis-oq0302-07-limit",
@@ -67,6 +134,17 @@
     "title": "The q → 1 Limit as a Derivative",
     "content": "qLog_tendsto_log proves ln_q(x) → log(x) as q → 1 (for x > 0). After the substitution u = 1−q, ln_q(x) equals the slope at 0 of the map u ↦ exp(log x · u), namely (exp(log x · u) − 1)/u. That map has derivative log x at 0 (chain rule on exp and const-mul), so hasDerivAt_iff_tendsto_slope yields the limit on the punctured neighborhood 𝓝[≠] 1. The reparametrization q ↦ 1−q sends 𝓝[≠] 1 to 𝓝[≠] 0, and Real.rpow_def_of_pos identifies the slope function with ln_q. This is the analytic statement that the entire q-deformed framework recovers the Shannon case.",
     "mathContext": "$\\lim_{q\\to 1} \\ln_q(x) = \\log x$ for $x>0$, read off as the derivative of $u\\mapsto x^u$ at $u=0$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": [
+      "derivative as a limit of slopes",
+      "hasDerivAt_iff_tendsto_slope",
+      "punctured neighborhood filter 𝓝[≠]",
+      "Shannon limit q → 1"
+    ],
+    "prerequisites": [
+      "hasDerivAt and tendsto_slope",
+      "chain rule for exp and const-mul",
+      "filter reparametrization 𝓝[≠] 1 → 𝓝[≠] 0"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-03-oq-04-oq-02` (quality 90 → 100).

Single scorer gap was **crossRefs 0→10**: all 7 annotations were missing `relatedConcepts` (the scorer reads annotation `relatedConcepts`, not meta.crossReferences).

- Added `relatedConcepts` and `prerequisites` to all 7 annotations (q-logarithm, Tsallis/Rényi/Shannon entropy, escort distribution, non-extensivity, the q→1 derivative limit, and the specific Mathlib lemmas each step uses).
- Fixed a pre-existing annotation whose range started in a docstring (86) so it now anchors on the `qLog_mul` theorem (92); annotation build reports no warnings for this entry.

meta.json within size caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)