### PR TITLE
Enrich Ballot Problem OQ-04 (non-crossing partitions)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04/annotations.json
@@ -51,22 +51,45 @@
     "proofId": "ballot-problem-oq-04",
     "range": {
       "startLine": 113,
-      "endLine": 153
+      "endLine": 137
     },
     "type": "insight",
-    "title": "The Structural Meaning of Non-Crossing",
-    "content": "The core lemmas. all_related: in a non-crossing partition, an interleaving configuration (a~c and b~d with a<b<c<d) forces ALL four indices into one block — so two distinct blocks can only 'meet' by coinciding. outer_related is the corollary that the two endpoints a~d are related, collapsing the whole interval. isNonCrossing_iff gives the standard 'no genuine crossing' reformulation: there is no pair of distinct blocks with interleaving representatives. The first genuine crossing is {{0,2},{1,3}} on Fin 4 — which is exactly why C₄ = 14 = Bell B₄ (15) minus that single crossing partition.",
-    "mathContext": "Non-crossing $\\Rightarrow$ an interleaving $a\\sim c,\\ b\\sim d$ ($a<b<c<d$) forces $a\\sim b\\sim c\\sim d$; first crossing $\\{\\{0,2\\},\\{1,3\\}\\}$ on $[4]$, $C_4=14=B_4-1$.",
+    "title": "The Structural Meaning: Interleaving Forces a Single Block",
+    "content": "The core structural lemmas. all_related: in a non-crossing partition, an interleaving configuration (a~c and b~d with a<b<c<d) forces ALL four indices into one block (a~b, b~c, c~d) — so two distinct blocks can only 'meet' by coinciding. The proof is a short transitivity chain: the definition gives a~b directly, then b~a~c gives b~c, and c~b~d gives c~d. outer_related is the corollary that the two endpoints a~d are related, collapsing the whole interval [a,d] into one block. This is the precise algebraic content of non-crossing-ness that any bijection proof must exploit.",
+    "mathContext": "Non-crossing $\\Rightarrow$ an interleaving $a\\sim c,\\ b\\sim d$ ($a<b<c<d$) forces $a\\sim b\\sim c\\sim d$, hence $a\\sim d$ (outer_related).",
     "significance": "key",
     "relatedConcepts": [
       "all_related lemma",
       "blocks meet only by coinciding",
-      "no-genuine-crossing reformulation",
-      "Catalan vs Bell numbers"
+      "transitivity chain",
+      "outer_related corollary"
     ],
     "prerequisites": [
       "the IsNonCrossing definition",
-      "transitivity of the block relation"
+      "transitivity/symmetry of the block relation (Setoid)"
+    ]
+  },
+  {
+    "id": "ballot-nc-ann-iff",
+    "proofId": "ballot-problem-oq-04",
+    "range": {
+      "startLine": 139,
+      "endLine": 151
+    },
+    "type": "insight",
+    "title": "The 'No Genuine Crossing' Reformulation",
+    "content": "isNonCrossing_iff recasts the forcing definition into the form the combinatorics literature actually uses: IsNonCrossing s holds iff there is NO quadruple a<b<c<d with a~c, b~d but ¬a~b — i.e. no two genuinely distinct blocks with interleaving representatives. The forward direction applies the definition to the witness and contradicts ¬a~b; the reverse uses by_contra to manufacture exactly such a forbidden witness. This negative/existential form is what makes the count tractable: the first genuine crossing is {{0,2},{1,3}} on Fin 4, which is exactly why C₄ = 14 = Bell B₄ (15) minus that single crossing partition — the first place the Catalan and Bell numbers diverge.",
+    "mathContext": "$\\mathrm{IsNonCrossing}(s) \\iff \\neg\\exists\\, a<b<c<d,\\ a\\sim c \\wedge b\\sim d \\wedge \\neg(a\\sim b)$; first crossing $\\{\\{0,2\\},\\{1,3\\}\\}$ on $[4]$, $C_4=14=B_4-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "no-genuine-crossing reformulation",
+      "Catalan vs Bell numbers",
+      "existential negation",
+      "by_contra"
+    ],
+    "prerequisites": [
+      "the IsNonCrossing definition",
+      "classical negation of an existential"
     ]
   },
   {

--- a/src/data/proofs/ballot-problem-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04/meta.json
@@ -109,11 +109,19 @@
     },
     {
       "id": "structural-meaning",
-      "title": "The Structural Meaning of Non-Crossing",
-      "summary": "all_related: a crossing configuration forces all four indices into one block; outer_related: the whole interval [a,d] collapses; isNonCrossing_iff: the 'no genuine crossing' reformulation.",
+      "title": "The Structural Meaning: Interleaving Forces One Block",
+      "summary": "all_related: a crossing configuration a<b<c<d with a~c, b~d forces all four indices into one block; outer_related: the endpoints a~d are related, so the whole interval [a,d] collapses into a single block.",
       "startLine": 110,
-      "endLine": 153,
+      "endLine": 137,
       "mathContext": "Using symmetry and transitivity of the equivalence relation, s a c and s b d with a<b<c<d and the non-crossing forcing s a b yield s a b, s b c, s c d — two blocks interleave only by coinciding."
+    },
+    {
+      "id": "no-genuine-crossing",
+      "title": "The 'No Genuine Crossing' Reformulation",
+      "summary": "isNonCrossing_iff: a partition is non-crossing iff there is no a<b<c<d with a~c, b~d and ¬a~b. This is the standard existential-negation form; the first violating partition {{0,2},{1,3}} on Fin 4 is exactly the C₄ = 14 = B₄ − 1 discrepancy between Catalan and Bell numbers.",
+      "startLine": 139,
+      "endLine": 153,
+      "mathContext": "IsNonCrossing s ↔ ¬∃ a b c d, a<b ∧ b<c ∧ c<d ∧ s a c ∧ s b d ∧ ¬ s a b."
     },
     {
       "id": "dyck-side",


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04` (quality 93 → 100).

Scorer gaps were **annotations 20→25** (4 annotations) and **sections 8→10** (4 sections).

- Split the broad "structural meaning" annotation and section (which bundled three theorems spanning lines 110–153) at the natural boundary into: the single-block core (`all_related` / `outer_related`, 113–137) and the "no genuine crossing" reformulation (`isNonCrossing_iff`, 139–151).
- Now 5 annotations and 5 sections, each anchored to real declarations (annotation build reports no warnings for this entry).

meta.json within size caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)