### PR TITLE
Schnirelmann basis: terminal (IsAdditiveBasis form) + convergence lemmas

### DIFF
--- a/proofs/Proofs/SchnirelmannBasis.lean
+++ b/proofs/Proofs/SchnirelmannBasis.lean
@@ -134,6 +134,48 @@ theorem basis_order_two_of_density_ge_half
     ∃ a ∈ A, ∃ b ∈ A, a + b = n :=
   sumset_covers_of_density_add_ge_one hA0 hA0 (by linarith) n
 
+/-- **Terminal step of Schnirelmann's theorem, in additive-basis form.** If
+    `0 ∈ A` and `σ(A) ≥ 1/2`, then `A` is an additive basis of order `2` in the
+    exact `Multiset` shape used by `WeakGoldbach.IsAdditiveBasis`: every `n` is
+    the sum of a multiset of `≤ 2` elements of `A`.
+
+    Where `basis_order_two_of_density_ge_half` produces a bare pair `a + b = n`,
+    this repackages it as the multiset witness `{a, b}` that
+    `schnirelmann_basis_theorem` requires as its conclusion. It is the *final*
+    link of the density-boosting chain: once an iterated sumset `h·A` has been
+    shown to have density `> 1/2` (via Schnirelmann's inequality — the one
+    remaining gap), this lemma discharges the basis property for `h·A`, hence
+    for `A` at order `2h`. -/
+theorem isAdditiveBasis_two_of_density_ge_half
+    (hA0 : 0 ∈ A) (h : 1 / 2 ≤ schnirelmannDensity A) (n : ℕ) :
+    ∃ S : Multiset ℕ, (∀ x ∈ S, x ∈ A) ∧ S.card ≤ 2 ∧ S.sum = n := by
+  obtain ⟨a, ha, b, hb, hab⟩ := basis_order_two_of_density_ge_half hA0 h n
+  refine ⟨{a, b}, ?_, ?_, ?_⟩
+  · intro x hx
+    simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton] at hx
+    rcases hx with rfl | rfl
+    · exact ha
+    · exact hb
+  · simp only [Multiset.insert_eq_cons, Multiset.card_cons, Multiset.card_singleton]
+    omega
+  · simpa [Multiset.insert_eq_cons, Multiset.sum_cons] using hab
+
+/-- **Convergence input for the density-boosting iteration.** If `σ(A) > 0`
+    then the "deficiency" `1 − σ(A)` is `< 1`, so it decays geometrically and
+    some finite power drops below `1/2`: `∃ h, (1 − σ(A))^h < 1/2`.
+
+    This is the analytic half of the iteration. Schnirelmann's inequality gives
+    `1 − σ(h·A) ≤ (1 − σ(A))^h` (the outstanding combinatorial gap); picking the
+    `h` supplied here then yields `σ(h·A) > 1/2`, at which point
+    `isAdditiveBasis_two_of_density_ge_half` closes the argument. Together these
+    two lemmas reduce `schnirelmann_basis_theorem` to exactly the sumset
+    inequality plus the bookkeeping "an element of `h·A` is a sum of `≤ h`
+    elements of `A`". -/
+theorem exists_pow_deficiency_lt_half
+    (hpos : 0 < schnirelmannDensity A) :
+    ∃ h : ℕ, (1 - schnirelmannDensity A) ^ h < 1 / 2 :=
+  exists_pow_lt_of_lt_one (by norm_num) (by linarith)
+
 /-
   ── Remaining gap toward `schnirelmann_basis_theorem` ─────────────────────────
 
@@ -151,8 +193,17 @@ theorem basis_order_two_of_density_ge_half
        density sum > 1, and `sumset_covers_of_density_add_ge_one` finishes:
        every n is a sum of ≤ 2h elements of A, i.e. A is a basis of order 2h.
 
-  Step (1) is the outstanding work; the covering lemma (step 2's engine) is now
-  available for it.
+  Step (2) is now bracketed by two verified lemmas above:
+    * its analytic input — `∃ h, (1 − σ(A))^h < 1/2` — is
+      `exists_pow_deficiency_lt_half`;
+    * its terminal step — `σ ≥ 1/2 ⇒ additive basis of order 2`, in the
+      `Multiset` shape of `IsAdditiveBasis` — is
+      `isAdditiveBasis_two_of_density_ge_half`.
+
+  What remains between them is precisely step (1), Schnirelmann's inequality,
+  together with the bookkeeping that an element of the iterated sumset `h·A` is
+  a sum of at most `h` elements of `A`. The covering lemma (step 2's engine) is
+  already available for it.
 -/
 
 end SchnirelmannBasis

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -359,3 +359,35 @@ Once (1) lands, `schnirelmann_basis_theorem` becomes a theorem and one axiom lea
 
 Aristotle MCP available this cycle but not used (covering lemma proved manually; the residual
 sumset inequality is a gap-argument, not a named-lemma lookup Aristotle would resolve).
+
+## Session 2026-07-03 (researcher-14) — Schnirelmann iteration brackets (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (0-axiom axiom-discharge file `SchnirelmannBasis.lean`). **Outcome**: 2 new verified lemmas, sharpened reduction (PR #34220).
+
+The covering lemma (`sumset_covers_of_density_add_ge_one`) and density-≥-½ pair
+corollary were already in place. Added the two lemmas that **bracket the iteration
+(step 2)** of Schnirelmann's theorem, expressed in the axiom's own vocabulary:
+
+1. **`isAdditiveBasis_two_of_density_ge_half`**: `0∈A`, `σ(A)≥1/2` ⟹ every `n` is
+   the sum of a `Multiset` of `≤2` elements of `A` — the *exact* `Multiset` shape
+   of `WeakGoldbach.IsAdditiveBasis` (the axiom's conclusion). Repackages the bare
+   pair `a+b=n` from `basis_order_two_of_density_ge_half` as witness `{a,b}`.
+   Gotcha: `simp only [Multiset.insert_eq_cons, card_cons, card_singleton]` reduces
+   the card goal to `1+1≤2` but does NOT close it — needs a trailing `omega`.
+2. **`exists_pow_deficiency_lt_half`**: `σ(A)>0` ⟹ `∃h, (1−σ(A))^h < 1/2`, the
+   geometric-decay input to the iteration, one line via `exists_pow_lt_of_lt_one`.
+
+These are the terminal + analytic ends of step 2. The remaining gap is now precisely
+**step 1 (Schnirelmann's inequality `σ(A⊕B)≥σA+σB−σA·σB`, the gap-counting core)**
+plus the bookkeeping "an element of `h·A` is a sum of `≤h` elements of `A`".
+
+**Verification**: `lake env lean` vs main-repo Mathlib v4.26.0 oleans → exit 0.
+`#print axioms` for both = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`,
+no `Lean.ofReduceBool`). Does NOT touch the open conjecture.
+
+**Env hazard (RECURRED)**: my first edit to the file in the MAIN checkout was WIPED
+mid-session — the main checkout sits on the deployer's `chore/sync-data-*` branch and
+a concurrent process reset the working tree to origin/main. Recovered by working in a
+locked `/private/tmp/wt-r14-schnir` worktree, committing IMMEDIATELY before verifying,
+and verifying via `lake env lean` against the main repo's `.lake` oleans (fresh
+worktree has none). Do this from the start.


### PR DESCRIPTION
## Summary

Extends `proofs/Proofs/SchnirelmannBasis.lean` (the 0-axiom covering-lemma file toward discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean`) with the two lemmas that **bracket the density-boosting iteration** — the terminal step and its analytic input — sharpening the reduction of the axiom.

**Problem**: `weak-goldbach-oq-01` (Strong/Weak Goldbach; open, stays axiomatized). This targets the *one tractable* of the file's 5 axioms, `schnirelmann_basis_theorem` (also a flagged Mathlib TODO).

## New results (both 0-axiom, kernel-checked)

- **`isAdditiveBasis_two_of_density_ge_half`** — `0 ∈ A`, `σ(A) ≥ 1/2` ⟹ every `n` is the sum of a `Multiset` of `≤ 2` elements of `A`, in the **exact shape of `WeakGoldbach.IsAdditiveBasis`** (the axiom's conclusion). Repackages the bare pair from `basis_order_two_of_density_ge_half` as the multiset witness `{a, b}`. This is the *terminal* link of Schnirelmann's theorem.
- **`exists_pow_deficiency_lt_half`** — `σ(A) > 0` ⟹ `∃ h, (1 − σ(A))^h < 1/2`: the geometric-decay input the iteration needs, via `exists_pow_lt_of_lt_one`.

Together these are the two ends of the iteration (step 2). What remains between them is precisely **Schnirelmann's inequality** `σ(A⊕B) ≥ σA+σB−σA·σB` (the delicate gap-counting step) plus the bookkeeping that an element of `h·A` is a sum of `≤ h` elements of `A`. The closing doc block is updated to reflect this sharpened gap.

## Verification

`lake env lean` against the repo's Mathlib v4.26.0 oleans → exit 0, 0 errors. `#print axioms` for both new theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.

## Honest scope

Does **not** touch the open Goldbach conjecture. Genuine infrastructure on the axiom-elimination path (0-axiom, no scaffolding on top of any axiom); the hard core (the inequality) is unchanged and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)