### PR TITLE
Enrich Groups of Order p² Classification: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-05/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-05/annotations.json
@@ -2,96 +2,61 @@
   {
     "id": "ann-preamble",
     "proofId": "sylow-theorem-oq-05",
-    "range": {
-      "startLine": 1,
-      "endLine": 54
-    },
+    "range": { "startLine": 1, "endLine": 45 },
     "type": "concept",
     "title": "From 'abelian' to the isomorphism type",
     "content": "The module docstring frames the problem honestly: Mathlib already proves that a group of order p² is abelian (`IsPGroup.commutative_of_card_eq_prime_sq`), obtained from the nontrivial centre of a p-group plus the principle that a group with cyclic central quotient is abelian. Restating that alone would add nothing. The genuine remaining content — supplied by this file — is the element-order dichotomy that distinguishes the two abelian groups of order p², namely ℤ/p² (cyclic) and ℤ/p × ℤ/p (elementary abelian). The docstring previews the mechanism (Lagrange forces every element order into {1, p, p²}) and lists the four results.",
     "mathContext": "For a finite $p$-group the class equation gives $p \\mid |Z(G)|$, so $Z(G) \\ne 1$. When $|G| = p^2$ either $Z(G) = G$ or $|G/Z(G)| = p$ making $G/Z(G)$ cyclic; both yield $G$ abelian. The finite-abelian structure theorem then splits order-$p^2$ groups into $\\mathbb{Z}/p^2$ and $(\\mathbb{Z}/p)^2$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "class equation",
-      "centre of a p-group",
-      "structure theorem for finite abelian groups",
-      "Sylow theory"
-    ],
-    "prerequisites": [
-      "Lagrange's theorem",
-      "order of an element",
-      "cyclic groups",
-      "group exponent"
-    ]
+    "relatedConcepts": ["class equation", "centre of a p-group", "structure theorem for finite abelian groups", "Sylow theory"],
+    "prerequisites": ["Lagrange's theorem", "order of an element", "cyclic groups", "group exponent"]
   },
   {
     "id": "ann-abelian",
     "proofId": "sylow-theorem-oq-05",
-    "range": {
-      "startLine": 55,
-      "endLine": 65
-    },
+    "range": { "startLine": 46, "endLine": 54 },
     "type": "theorem",
     "title": "Groups of order p² are abelian",
     "content": "`mul_comm_of_card_eq_prime_sq` exposes Mathlib's `IsPGroup.commutative_of_card_eq_prime_sq` as the base of the classification. This is the one place where the entry leans directly on an existing Mathlib theorem, and the docstring says so explicitly — the added value of the file is everything that refines this to an isomorphism type.",
     "mathContext": "$|G| = p^2 \\Rightarrow \\forall a\\,b \\in G,\\ ab = ba$. The proof chain (nontrivial centre $\\Rightarrow$ $G/Z$ cyclic $\\Rightarrow$ $G$ abelian) is packaged by Mathlib.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "abelian group",
-      "commutator",
-      "central quotient"
-    ],
-    "prerequisites": [
-      "IsPGroup",
-      "Nat.card"
-    ]
+    "relatedConcepts": ["abelian group", "commutator", "central quotient"],
+    "prerequisites": ["IsPGroup", "Nat.card"]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "sylow-theorem-oq-05",
-    "range": {
-      "startLine": 66,
-      "endLine": 87
-    },
+    "range": { "startLine": 55, "endLine": 78 },
     "type": "theorem",
     "title": "The structural dichotomy: cyclic or exponent p",
     "content": "`isCyclic_or_pow_prime_eq_one` is the heart of the entry. By Lagrange the order of any element g divides p², so orderOf g = p^m with m ≤ 2. The case split is clean: if m = 2 then orderOf g = |G|, so g generates G (`isCyclic_of_orderOf_eq_card`) and G is cyclic; otherwise m ≤ 1 gives orderOf g ∣ p, hence g^p = 1 via `orderOf_dvd_iff_pow_eq_one`. This element-order invariant is exactly what Mathlib's abelian lemma leaves implicit, and it is what separates ℤ/p² from (ℤ/p)².",
     "mathContext": "$\\operatorname{ord}(g) \\mid p^2 \\Rightarrow \\operatorname{ord}(g) \\in \\{1, p, p^2\\}$. Some $\\operatorname{ord}(g) = p^2 \\Rightarrow G$ cyclic; else $\\forall g,\\ \\operatorname{ord}(g) \\mid p \\Rightarrow g^p = 1$.",
     "significance": "critical",
-    "relatedConcepts": [
-      "Lagrange's theorem",
-      "orderOf divides card",
-      "cyclic generation by a maximal-order element",
-      "group exponent"
-    ],
-    "prerequisites": [
-      "orderOf_dvd_natCard",
-      "Nat.dvd_prime_pow",
-      "orderOf_dvd_iff_pow_eq_one"
-    ]
+    "relatedConcepts": ["Lagrange's theorem", "orderOf divides card", "cyclic generation by a maximal-order element", "group exponent"],
+    "prerequisites": ["orderOf_dvd_natCard", "Nat.dvd_prime_pow", "orderOf_dvd_iff_pow_eq_one"]
   },
   {
-    "id": "ann-characterization",
+    "id": "ann-cyclic-iff",
     "proofId": "sylow-theorem-oq-05",
-    "range": {
-      "startLine": 88,
-      "endLine": 109
-    },
+    "range": { "startLine": 79, "endLine": 91 },
     "type": "theorem",
-    "title": "Cyclic ⇔ maximal-order element; exponent p in the other branch",
-    "content": "Two capstone results. `isCyclic_iff_exists_orderOf_eq` says a group of order p² is cyclic exactly when some element attains the full order p² — the concrete witness for the ℤ/p² branch. `exponent_eq_prime_of_not_isCyclic` computes the exponent of the non-cyclic case to be exactly p: every element satisfies g^p = 1 (from the dichotomy), so the exponent divides p; and it cannot be 1, since that would make G a subsingleton contradicting |G| = p² > 1. Together with the abelian result this identifies the non-cyclic case as (ℤ/p)².",
-    "mathContext": "Cyclic $\\iff \\exists g,\\ \\operatorname{ord}(g) = p^2$. Non-cyclic $\\Rightarrow \\operatorname{exponent}(G) \\mid p$ and $\\operatorname{exponent}(G) \\ne 1$, so $\\operatorname{exponent}(G) = p$ (elementary abelian).",
+    "title": "Cyclic ⇔ an element of maximal order",
+    "content": "`isCyclic_iff_exists_orderOf_eq` pins down the ℤ/p² branch with a concrete witness: a group of order p² is cyclic exactly when some element attains the full order p². The forward direction extracts a generator via Mathlib's `isCyclic_iff_exists_orderOf_eq_natCard` and rewrites its order to p² using hG; the reverse direction feeds a maximal-order element straight into `isCyclic_of_orderOf_eq_card`. This turns the abstract property 'IsCyclic' into a checkable existence statement about element orders — the criterion one actually uses to recognise ℤ/p² in practice.",
+    "mathContext": "$\\text{IsCyclic}(G) \\iff \\exists g \\in G,\\ \\operatorname{ord}(g) = p^2$, i.e. $G \\cong \\mathbb{Z}/p^2$.",
     "significance": "critical",
-    "relatedConcepts": [
-      "elementary abelian group",
-      "group exponent",
-      "Monoid.exp_eq_one_iff",
-      "isomorphism classification"
-    ],
-    "prerequisites": [
-      "isCyclic_iff_exists_orderOf_eq_natCard",
-      "Monoid.exponent_dvd_of_forall_pow_eq_one",
-      "Nat.dvd_prime"
-    ]
+    "relatedConcepts": ["cyclic group", "generator", "maximal-order element", "isomorphism classification"],
+    "prerequisites": ["isCyclic_iff_exists_orderOf_eq_natCard", "isCyclic_of_orderOf_eq_card"]
+  },
+  {
+    "id": "ann-elementary-abelian",
+    "proofId": "sylow-theorem-oq-05",
+    "range": { "startLine": 92, "endLine": 109 },
+    "type": "theorem",
+    "title": "The elementary-abelian branch: exponent exactly p",
+    "content": "`exponent_eq_prime_of_not_isCyclic` computes the exponent of the non-cyclic case to be exactly p. From the dichotomy, not-cyclic gives g^p = 1 for every g, so `Monoid.exponent_dvd_of_forall_pow_eq_one` makes the exponent divide p; being prime, the exponent is 1 or p. It cannot be 1: `Monoid.exp_eq_one_iff` would force G subsingleton, hence |G| = 1, contradicting |G| = p² > 1 (closed by nlinarith with p ≥ 2). So the exponent is p. Together with `mul_comm_of_card_eq_prime_sq` this identifies the non-cyclic case as the elementary abelian group (ℤ/p)².",
+    "mathContext": "Non-cyclic $|G| = p^2 \\Rightarrow \\operatorname{exponent}(G) \\mid p$ and $\\operatorname{exponent}(G) \\ne 1$, so $\\operatorname{exponent}(G) = p$: $G \\cong (\\mathbb{Z}/p)^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["elementary abelian group", "group exponent", "Monoid.exp_eq_one_iff", "isomorphism classification"],
+    "prerequisites": ["Monoid.exponent_dvd_of_forall_pow_eq_one", "Nat.dvd_prime", "Nat.card_eq_one_iff_unique"]
   }
 ]

--- a/src/data/proofs/sylow-theorem-oq-05/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-05/meta.json
@@ -65,36 +65,39 @@
   },
   "sections": [
     {
-      "id": "header",
+      "id": "introduction",
       "title": "Introduction: From 'abelian' to the isomorphism type",
       "startLine": 1,
-      "endLine": 50,
-      "summary": "Module header explaining that Mathlib already proves groups of order p² are abelian, and that the genuine remaining content — packaged here — is the element-order dichotomy that separates ℤ/p² from (ℤ/p)².",
-      "mathContext": "Every finite $p$-group has nontrivial centre (class equation). For $|G| = p^2$ this yields abelian. The structure theorem splits abelian order-$p^2$ groups into $\\mathbb{Z}/p^2$ and $(\\mathbb{Z}/p)^2$; the separating invariant is whether an element of order $p^2$ exists."
+      "endLine": 45,
+      "summary": "Module docstring: Mathlib already gives that order-p² groups are abelian; the genuine content here is the element-order dichotomy distinguishing ℤ/p² from (ℤ/p)². Previews that Lagrange forces every element order into {1, p, p²}."
     },
     {
       "id": "abelian",
       "title": "Groups of order p² are abelian",
-      "startLine": 51,
-      "endLine": 61,
-      "summary": "Exposes Mathlib's `IsPGroup.commutative_of_card_eq_prime_sq` as the base of the classification.",
-      "mathContext": "$|G| = p^2 \\Rightarrow \\forall a\\,b,\\ ab = ba$, via nontrivial centre and the 'central quotient cyclic $\\Rightarrow$ abelian' principle."
+      "startLine": 46,
+      "endLine": 54,
+      "summary": "mul_comm_of_card_eq_prime_sq exposes Mathlib's IsPGroup.commutative_of_card_eq_prime_sq (nontrivial centre ⇒ cyclic central quotient ⇒ abelian) as the base of the classification."
     },
     {
       "id": "dichotomy",
       "title": "The structural dichotomy",
-      "startLine": 62,
-      "endLine": 83,
-      "summary": "Main result: a group of order p² is either cyclic or has every element satisfying g^p = 1, proved from Lagrange via the possible element orders 1, p, p².",
-      "mathContext": "$\\operatorname{ord}(g) \\mid p^2 \\Rightarrow \\operatorname{ord}(g) = p^m,\\ m \\le 2$. $m = 2 \\Rightarrow$ cyclic; $m \\le 1 \\Rightarrow \\operatorname{ord}(g) \\mid p \\Rightarrow g^p = 1$."
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "isCyclic_or_pow_prime_eq_one: by Lagrange orderOf g = p^m with m ≤ 2; m = 2 makes g a generator (cyclic), else orderOf g ∣ p so g^p = 1. This is the invariant separating ℤ/p² from (ℤ/p)²."
     },
     {
-      "id": "characterization",
-      "title": "Cyclic ⇔ maximal-order element; the elementary-abelian branch",
-      "startLine": 84,
-      "endLine": 105,
-      "summary": "Cyclicity is equivalent to the existence of an element of order p², and in the non-cyclic case the exponent is exactly p, identifying (with abelian) the group as (ℤ/p)².",
-      "mathContext": "Non-cyclic $\\Rightarrow$ exponent $\\mid p$; exponent $\\ne 1$ since $|G| = p^2 > 1$; hence exponent $= p$."
+      "id": "cyclic-iff",
+      "title": "Cyclic ⇔ a maximal-order element",
+      "startLine": 79,
+      "endLine": 91,
+      "summary": "isCyclic_iff_exists_orderOf_eq: a group of order p² is cyclic exactly when some element attains order p² — the concrete recognition criterion for the ℤ/p² branch."
+    },
+    {
+      "id": "elementary-abelian",
+      "title": "The elementary-abelian branch: exponent p",
+      "startLine": 92,
+      "endLine": 109,
+      "summary": "exponent_eq_prime_of_not_isCyclic: in the non-cyclic case every g satisfies g^p = 1 so the exponent divides p, and it is not 1 (else G subsingleton), giving exponent exactly p — the elementary abelian group (ℤ/p)²."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-05` (classifying groups of order p² as ℤ/p² or (ℤ/p)²).

Quality 93 → 100:
- Split the combined characterization into two at the theorem boundary — *Cyclic ⇔ a maximal-order element* (`isCyclic_iff_exists_orderOf_eq`) and *The elementary-abelian branch: exponent p* (`exponent_eq_prime_of_not_isCyclic`).
- 5 sections and 5 annotations now contiguously cover the full 109-line file; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 11 KB, well under the 60 KB guardrail. No axiom/status changes.