### PR TITLE
Enrich Tietze from Urysohn: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01/annotations.json
@@ -1,99 +1,62 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "urysohns-lemma-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Tietze from Urysohn: the Strategy and What Is New",
+    "content": "The module docstring states the direction that matters. The parent entry (tietze-extension-theorem-oq-01) derived Urysohn's lemma FROM Tietze — the easy direction. This file does the harder, classical direction: Tietze FROM Urysohn, and it makes the engine of that classical argument explicit. The strategy is the standard one-step-plus-geometric-iteration: a single approximation lemma reduces the sup-error by a factor 2/3 using a globally defined function of norm ≤ M/3 supplied by Urysohn's lemma; iterating gives (2/3)ⁿ decay; the uniform limit is the extension. The value added over Mathlib is that urysohn_approx_step and urysohn_approx_iterate are stated in elementary set form (a closed subset s and ordinary continuous functions), not the bundled closed-embedding / →ᵇ form Mathlib folds into its internal proof. Everything is machine-checked with no sorry and no extra axioms.",
+    "mathContext": "Goal: closed $s\\subseteq X$ normal, $f\\in C(s,\\mathbb{R})\\Rightarrow\\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$, built as a uniform limit with $(2/3)^n$ error decay.",
+    "significance": "context",
+    "relatedConcepts": ["Tietze extension theorem", "Urysohn's lemma", "normal space", "uniform limit"],
+    "prerequisites": ["point-set topology", "continuous functions", "normal spaces"]
+  },
+  {
     "id": "ann-restrict-helper",
     "proofId": "urysohns-lemma-oq-01-oq-01",
-    "range": {
-      "startLine": 39,
-      "endLine": 46
-    },
+    "range": { "startLine": 39, "endLine": 46 },
     "type": "definition",
     "title": "Restricting a Global Function to the Closed Set",
     "content": "`restrictToClosed s g` packages the restriction of a global continuous function g : C(X, ℝ) to the subtype s, by composing g with the continuous inclusion ↑ : s → X. The simp lemma `restrictToClosed_apply` records that it evaluates as g at the underlying point: (g|_s)(x) = g(↑x). This bookkeeping is what lets the iteration treat the residual f − g|_s as a genuine continuous function on s, so that the one-step lemma can be applied to it again.",
     "mathContext": "$g\\in C(X,\\mathbb{R}),\\ s\\subseteq X\\Rightarrow g|_s\\in C(s,\\mathbb{R}),\\ (g|_s)(x)=g(x)$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "subspace topology",
-      "continuous restriction",
-      "subtype inclusion"
-    ],
-    "prerequisites": [
-      "continuous maps",
-      "subtypes",
-      "function composition"
-    ]
+    "relatedConcepts": ["subspace topology", "continuous restriction", "subtype inclusion"],
+    "prerequisites": ["continuous maps", "subtypes", "function composition"]
   },
   {
     "id": "ann-approx-step",
     "proofId": "urysohns-lemma-oq-01-oq-01",
-    "range": {
-      "startLine": 47,
-      "endLine": 116
-    },
+    "range": { "startLine": 47, "endLine": 116 },
     "type": "theorem",
     "title": "The One-Step Urysohn Approximation Lemma (Engine)",
     "content": "`urysohn_approx_step` is the heart of the classical Tietze proof, derived directly from Urysohn's lemma. For a closed set s in a normal space X and a continuous f : C(s, ℝ) with |f| ≤ M, form the two closed disjoint sublevel sets {x ∈ s : f x ≤ −M/3} and {x ∈ s : f x ≥ M/3}, pushed forward to X along the closed inclusion s ↪ X (`IsClosed.isClosedEmbedding_subtypeVal`, whose isClosedMap turns closed subsets of s into closed subsets of X). Urysohn's lemma in interval form (`exists_bounded_mem_Icc_of_closed_of_le`) yields a global continuous g : X → [−M/3, M/3] equal to −M/3 on the first set and M/3 on the second. A three-way case split on the value of f x — below −M/3, above M/3, or in the middle band — verifies |f x − g x| ≤ (2/3)·M on s: on the extreme sets g hits the matching endpoint, and on the middle band both |f x| and |g x| are bounded by M/3. The trivial case M = 0 forces f ≡ 0 and takes g = 0. Crucially this is NOT a wrapper of Mathlib's bundled `tietze_extension_step`; it is a fresh derivation in elementary set form.",
     "mathContext": "Normal $X$, closed $s$, $|f|\\le M$ on $s\\Rightarrow\\exists g\\in C(X,\\mathbb{R}),\\ |g|\\le M/3,\\ |f-g|\\le\\tfrac23 M$ on $s$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Urysohn's lemma",
-      "normal space",
-      "sublevel sets",
-      "closed embedding",
-      "approximation"
-    ],
-    "prerequisites": [
-      "Urysohn's lemma",
-      "closed maps",
-      "absolute value bounds",
-      "continuous functions on subspaces"
-    ]
+    "relatedConcepts": ["Urysohn's lemma", "normal space", "sublevel sets", "closed embedding", "approximation"],
+    "prerequisites": ["Urysohn's lemma", "closed maps", "absolute value bounds", "continuous functions on subspaces"]
   },
   {
     "id": "ann-geometric-iterate",
     "proofId": "urysohns-lemma-oq-01-oq-01",
-    "range": {
-      "startLine": 118,
-      "endLine": 147
-    },
+    "range": { "startLine": 118, "endLine": 147 },
     "type": "theorem",
     "title": "Quantitative Iteration: Geometric Error Decay",
     "content": "`urysohn_approx_iterate` iterates the approximation step to a quantitative bound: by induction on n, there is a global continuous g : C(X, ℝ) with sup-error |f − g| ≤ (2/3)ⁿ·M on s. The base case n = 0 takes g = 0 with error ≤ M = (2/3)⁰·M. The inductive step applies `urysohn_approx_step` to the residual r = f − gₙ|_s — which is continuous on s and bounded by (2/3)ⁿ·M — obtaining a correction h with |r − h| ≤ (2/3)·(2/3)ⁿ·M, and sets gₙ₊₁ = gₙ + h, so |f − gₙ₊₁| = |r − h| ≤ (2/3)ⁿ⁺¹·M. This explicit geometric decay is exactly why the classical construction converges, and it is a standalone statement Mathlib does not expose: Mathlib's iteration is folded directly into the limit construction.",
     "mathContext": "$\\forall n,\\ \\exists g\\in C(X,\\mathbb{R}),\\ |f-g|\\le(2/3)^n M$ on $s$.",
     "significance": "key",
-    "relatedConcepts": [
-      "geometric convergence",
-      "induction",
-      "residual",
-      "uniform approximation"
-    ],
-    "prerequisites": [
-      "mathematical induction",
-      "geometric sequences",
-      "the approximation step"
-    ]
+    "relatedConcepts": ["geometric convergence", "induction", "residual", "uniform approximation"],
+    "prerequisites": ["mathematical induction", "geometric sequences", "the approximation step"]
   },
   {
     "id": "ann-tietze-limit",
     "proofId": "urysohns-lemma-oq-01-oq-01",
-    "range": {
-      "startLine": 149,
-      "endLine": 169
-    },
+    "range": { "startLine": 149, "endLine": 169 },
     "type": "theorem",
     "title": "The Tietze Extension Theorem as the Uniform Limit",
-    "content": "`tietze_extension_of_urysohn`: every continuous real-valued function on a closed subset of a normal space extends to a global continuous function ( continuous extension with g|_s = f ). `tietze_extension_Icc_of_urysohn`: the range-constrained form — an [a,b]-valued continuous function on a closed set extends to an [a,b]-valued continuous function on all of X, via `exists_restrict_eq_forall_mem_of_closed` with the OrdConnected target Icc a b. These headline statements are the uniform limit of the approximants built above; the analytic assembly of the limit is delegated to Mathlib's TietzeExtension machinery, which performs precisely the Urysohn iteration formalized by `urysohn_approx_step` and `urysohn_approx_iterate`. Exposing the engine separately is what makes the derivation 'Tietze from Urysohn' concrete rather than a re-export.",
+    "content": "`tietze_extension_of_urysohn`: every continuous real-valued function on a closed subset of a normal space extends to a global continuous function (a continuous extension with g|_s = f). `tietze_extension_Icc_of_urysohn`: the range-constrained form — an [a,b]-valued continuous function on a closed set extends to an [a,b]-valued continuous function on all of X, via `exists_restrict_eq_forall_mem_of_closed` with the OrdConnected target Icc a b. These headline statements are the uniform limit of the approximants built above; the analytic assembly of the limit is delegated to Mathlib's TietzeExtension machinery, which performs precisely the Urysohn iteration formalized by `urysohn_approx_step` and `urysohn_approx_iterate`. Exposing the engine separately is what makes the derivation 'Tietze from Urysohn' concrete rather than a re-export.",
     "mathContext": "$f\\in C(s,\\mathbb{R}),\\ f(s)\\subseteq[a,b]\\Rightarrow\\exists g\\in C(X,\\mathbb{R}),\\ g(X)\\subseteq[a,b],\\ g|_s=f$.",
     "significance": "key",
-    "relatedConcepts": [
-      "Tietze extension theorem",
-      "uniform limit",
-      "OrdConnected",
-      "range-constrained extension"
-    ],
-    "prerequisites": [
-      "uniform convergence",
-      "TietzeExtension class",
-      "order-connected sets"
-    ]
+    "relatedConcepts": ["Tietze extension theorem", "uniform limit", "OrdConnected", "range-constrained extension"],
+    "prerequisites": ["uniform convergence", "TietzeExtension class", "order-connected sets"]
   }
 ]

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01/meta.json
@@ -33,36 +33,39 @@
   },
   "sections": [
     {
-      "id": "restriction-helper",
+      "id": "overview",
+      "title": "Tietze from Urysohn: Strategy and Imports",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring: the parent derived Urysohn from Tietze (easy); this file does the harder classical direction, Tietze from Urysohn, exposing the one-step approximation engine in elementary set form (not Mathlib's bundled →ᵇ form). No sorry, no extra axioms."
+    },
+    {
+      "id": "restrict",
       "title": "Restricting a Global Function to a Closed Set",
       "startLine": 39,
       "endLine": 46,
-      "summary": "restrictToClosed packages the restriction of a global continuous function g : C(X, ℝ) to the subtype s as a continuous function on s, by composing with the continuous inclusion. restrictToClosed_apply records that it evaluates as g at the underlying point. This is the bookkeeping that lets the iteration treat the residual f − g|_s as a genuine continuous function on s.",
-      "mathContext": "$g\\in C(X,\\mathbb{R}),\\ s\\subseteq X\\ \\Rightarrow\\ g|_s\\in C(s,\\mathbb{R}),\\ (g|_s)(x)=g(x)$."
+      "summary": "restrictToClosed s g composes a global continuous g : C(X,ℝ) with the inclusion s ↪ X; restrictToClosed_apply records (g|_s)(x) = g(↑x), letting the iteration treat the residual f − g|_s as a continuous function on s."
     },
     {
-      "id": "approximation-step",
+      "id": "approx-step",
       "title": "The One-Step Urysohn Approximation Lemma",
       "startLine": 47,
       "endLine": 116,
-      "summary": "urysohn_approx_step — the engine. For a closed s in a normal X and f : C(s, ℝ) with |f| ≤ M, Urysohn's lemma (exists_bounded_mem_Icc_of_closed_of_le) applied to the closed disjoint sublevel sets {f ≤ −M/3} and {f ≥ M/3} (pushed to X along the closed inclusion) yields a global continuous g with |g| ≤ M/3 and |f − g| ≤ (2/3)·M on s. The bound is verified by a three-way case split on the value of f x.",
-      "mathContext": "Normal $X$, closed $s$, $|f|\\le M$ on $s$ $\\Rightarrow\\ \\exists g\\in C(X,\\mathbb{R}),\\ |g|\\le M/3,\\ |f-g|\\le \\tfrac23 M$ on $s$."
+      "summary": "urysohn_approx_step: from |f| ≤ M on closed s, Urysohn's lemma (exists_bounded_mem_Icc_of_closed_of_le) gives global g with |g| ≤ M/3 and |f − g| ≤ (2/3)M on s, via two closed sublevel sets pushed to X and a three-way case split. A fresh derivation, not a wrapper of tietze_extension_step."
     },
     {
-      "id": "geometric-iteration",
+      "id": "iterate",
       "title": "Quantitative Iteration: Geometric Error Decay",
       "startLine": 118,
       "endLine": 147,
-      "summary": "urysohn_approx_iterate iterates the step. By induction on n, there is a global continuous g with sup-error |f − g| ≤ (2/3)ⁿ·M on s. The base case takes g = 0 (error ≤ M); the inductive step applies urysohn_approx_step to the residual f − gₙ|_s and adds the correction, contracting the error by a further factor 2/3. This is the explicit reason the construction converges to an extension.",
-      "mathContext": "$\\forall n,\\ \\exists g\\in C(X,\\mathbb{R}),\\ |f-g|\\le (2/3)^n M$ on $s$."
+      "summary": "urysohn_approx_iterate: induction on n gives a global continuous g with |f − g| ≤ (2/3)ⁿ·M on s; each step corrects the residual by the one-step lemma. The explicit geometric decay is the standalone convergence statement Mathlib folds into its limit."
     },
     {
-      "id": "tietze-extension",
+      "id": "tietze-limit",
       "title": "The Tietze Extension Theorem as the Limit",
       "startLine": 149,
       "endLine": 169,
-      "summary": "tietze_extension_Icc_of_urysohn: an [a,b]-valued continuous function on a closed set extends to an [a,b]-valued continuous function on X (exists_restrict_eq_forall_mem_of_closed, Icc OrdConnected). tietze_extension_of_urysohn: the plain real-valued extension (ContinuousMap.exists_restrict_eq). These are the uniform limit of the approximants above; Mathlib's TietzeExtension machinery performs exactly the Urysohn iteration to assemble the limit.",
-      "mathContext": "$f\\in C(s,\\mathbb{R}),\\ f(s)\\subseteq[a,b]\\ \\Rightarrow\\ \\exists g\\in C(X,\\mathbb{R}),\\ g(X)\\subseteq[a,b],\\ g|_s=f$."
+      "summary": "tietze_extension_of_urysohn (real-valued extension g|_s = f) and tietze_extension_Icc_of_urysohn (range-constrained [a,b]-valued form via OrdConnected Icc): the uniform limit of the approximants, with the analytic assembly delegated to Mathlib's TietzeExtension machinery — precisely the Urysohn iteration exposed above."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `urysohns-lemma-oq-01-oq-01` (deriving the Tietze extension theorem from Urysohn's lemma).

Quality 93 → 100:
- Added a 5th section + annotation covering the module header — the *Tietze from Urysohn* strategy docstring — so all 169 lines are covered contiguously from line 1.
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 18 KB, under the 60 KB guardrail. No axiom/status changes.