### PR TITLE
Enrich Tietze Converse ⟺ Normality: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/annotations.json
@@ -2,99 +2,61 @@
   {
     "id": "ann-tietze-property",
     "proofId": "tietze-extension-theorem-oq-01-oq-01",
-    "range": {
-      "startLine": 46,
-      "endLine": 58
-    },
+    "range": { "startLine": 46, "endLine": 58 },
     "type": "definition",
-    "title": "The Tietze Extension Property",
+    "title": "The Tietze Extension Property and the Forward Direction",
     "content": "`HasTietzeExtensionProperty X` abstracts the conclusion of the Tietze extension theorem into a hypothesis on the space: for every closed s ⊆ X and every f ∈ C(s, ℝ) there is g ∈ C(X, ℝ) with g.restrict s = f. The forward direction `hasTietzeExtensionProperty_of_normalSpace` shows every NormalSpace has this property — it is exactly Mathlib's `ContinuousMap.exists_restrict_eq` repackaged. Stating it this way lets the converse below be assembled into a genuine equivalence rather than a one-sided restatement.",
-    "mathContext": "$\\mathrm{TietzeProp}(X):\\ \\forall s\\ \\text{closed},\\ \\forall f\\in C(s,\\mathbb{R}),\\ \\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$.",
+    "mathContext": "$\\mathrm{TietzeProp}(X):\\ \\forall s\\ \\text{closed},\\ \\forall f\\in C(s,\\mathbb{R}),\\ \\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$; every normal $X$ has it.",
     "significance": "key",
-    "relatedConcepts": [
-      "Tietze extension theorem",
-      "normal space",
-      "continuous extension",
-      "ContinuousMap.restrict"
-    ],
-    "prerequisites": [
-      "normal spaces",
-      "bundled continuous maps C(s, ℝ)",
-      "function restriction"
-    ]
+    "relatedConcepts": ["Tietze extension theorem", "normal space", "continuous extension", "ContinuousMap.restrict"],
+    "prerequisites": ["normal spaces", "bundled continuous maps C(s, ℝ)", "function restriction"]
   },
   {
     "id": "ann-clopen-lemma",
     "proofId": "tietze-extension-theorem-oq-01-oq-01",
-    "range": {
-      "startLine": 60,
-      "endLine": 82
-    },
+    "range": { "startLine": 60, "endLine": 82 },
     "type": "theorem",
     "title": "The Clopen Boundary Lemma",
     "content": "`isClopen_subtype_of_disjoint_closed` is the geometric heart of the argument. For disjoint closed A, B, look at the subspace s = A ∪ B. The part of s lying over B is closed, being the preimage of the closed set B under the continuous inclusion s ↪ X. It is also open: its complement in s is the part lying over A, because every point of s belongs to A or B (it is their union) and not to both (they are disjoint); that complement is again the preimage of a closed set, so it is closed, making the original set open. Hence it is clopen.",
     "mathContext": "Inside $s=A\\cup B$, the set $\\{x:x\\in B\\}$ is clopen — closed as the preimage of $B$, open since its complement is $\\{x:x\\in A\\}$ (using $A\\cap B=\\varnothing$).",
     "significance": "key",
-    "relatedConcepts": [
-      "clopen set",
-      "subspace topology",
-      "preimage of closed set",
-      "disjoint closed sets"
-    ],
-    "prerequisites": [
-      "IsClosed.preimage",
-      "isClosed_compl_iff",
-      "subtype topology"
-    ]
+    "relatedConcepts": ["clopen set", "subspace topology", "preimage of closed set", "disjoint closed sets"],
+    "prerequisites": ["IsClosed.preimage", "isClosed_compl_iff", "subtype topology"]
   },
   {
     "id": "ann-converse-main",
     "proofId": "tietze-extension-theorem-oq-01-oq-01",
-    "range": {
-      "startLine": 84,
-      "endLine": 141
-    },
+    "range": { "startLine": 84, "endLine": 141 },
     "type": "theorem",
     "title": "The Converse: Tietze Property Implies Normality",
     "content": "`normalSpace_of_hasTietzeExtensionProperty` is the new content. Since the part of s = A ∪ B over B is clopen, it has empty frontier, so the two-valued function x ↦ (if x ∈ B then 1 else 0) is continuous on s by `Continuous.if` (the frontier hypothesis is vacuous) — this is the {0,1} boundary function f, equal to 0 on A and 1 on B. The Tietze property extends f to F ∈ C(X, ℝ); unwinding F.restrict s = f at points of A and B gives F = 0 on A and F = 1 on B. Finally F⁻¹(Iio ½) and F⁻¹(Ioi ½) are open (preimages of open rays under the continuous F), contain A and B respectively, and are disjoint because ½ separates the two rays — exactly the disjoint open neighbourhoods required by NormalSpace. No separation axiom on X is used anywhere.",
     "mathContext": "Extend the $\\{0,1\\}$ boundary function on $A\\cup B$ to $F:X\\to\\mathbb{R}$; then $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$ and $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens, so $X$ is normal.",
     "significance": "critical",
-    "relatedConcepts": [
-      "Tietze extension converse",
-      "normal space",
-      "SeparatedNhds",
-      "level sets of continuous functions",
-      "Continuous.if"
-    ],
-    "prerequisites": [
-      "clopen boundary lemma",
-      "Continuous.if and empty frontier",
-      "isOpen_Iio / isOpen_Ioi",
-      "NormalSpace constructor"
-    ]
+    "relatedConcepts": ["Tietze extension converse", "normal space", "SeparatedNhds", "level sets of continuous functions", "Continuous.if"],
+    "prerequisites": ["clopen boundary lemma", "Continuous.if and empty frontier", "isOpen_Iio / isOpen_Ioi", "NormalSpace constructor"]
   },
   {
-    "id": "ann-corollaries",
+    "id": "ann-t1-statement",
     "proofId": "tietze-extension-theorem-oq-01-oq-01",
-    "range": {
-      "startLine": 143,
-      "endLine": 156
-    },
+    "range": { "startLine": 143, "endLine": 150 },
     "type": "theorem",
-    "title": "The T1 Statement and the Full Equivalence",
-    "content": "`t1Space_normalSpace_of_hasTietzeExtensionProperty` restates the result under the classical T1 hypothesis used in textbook phrasings of 'normal ⟺ Tietze'; the hypothesis is not used by the proof, so the entry is explicit that the bare extension property already forces normality. `normalSpace_iff_hasTietzeExtensionProperty` then pairs the converse with the forward direction into a true biconditional: a space is normal if and only if it has the Tietze extension property. This is the arrow absent from Mathlib, completing the loop 'normal ⟺ Tietze ⟺ Urysohn' opened by the parent entry.",
-    "mathContext": "$\\mathrm{T1}+\\mathrm{TietzeProp}\\Rightarrow\\mathrm{Normal}$; and $\\mathrm{Normal}\\iff\\mathrm{TietzeProp}$.",
+    "title": "The T1 (Textbook) Statement",
+    "content": "`t1Space_normalSpace_of_hasTietzeExtensionProperty` restates the result under the classical T1 hypothesis used in textbook phrasings of 'a T1 space is normal iff it has the Tietze extension property'. The point the entry makes explicit is that the T1 hypothesis is NOT used by the proof: the bare Tietze extension property already forces normality, so this T1 form is strictly weaker than the converse proved just above. It is included only to connect the result to the way the equivalence is usually stated in the literature.",
+    "mathContext": "$\\mathrm{T1}(X)+\\mathrm{TietzeProp}(X)\\Rightarrow\\mathrm{Normal}(X)$ — with the T1 hypothesis logically redundant.",
+    "significance": "supporting",
+    "relatedConcepts": ["T1 space", "textbook normality characterization", "redundant hypothesis"],
+    "prerequisites": ["the converse theorem", "T1Space"]
+  },
+  {
+    "id": "ann-equivalence",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01",
+    "range": { "startLine": 151, "endLine": 158 },
+    "type": "theorem",
+    "title": "The Full Equivalence: Normal ⟺ Tietze",
+    "content": "`normalSpace_iff_hasTietzeExtensionProperty` pairs the converse with the forward direction into a true biconditional: a topological space is normal if and only if it has the Tietze extension property. This is the arrow absent from Mathlib — Mathlib supplies only the forward direction (normal ⇒ extension) — and completing it turns the extension property into a characterisation of normality, closing the loop 'normal ⟺ Tietze ⟺ Urysohn' opened by the parent entry.",
+    "mathContext": "$\\mathrm{Normal}(X)\\iff\\mathrm{TietzeProp}(X)$ for any topological space $X$.",
     "significance": "key",
-    "relatedConcepts": [
-      "T1 space",
-      "normal space characterization",
-      "biconditional equivalence",
-      "Urysohn's lemma"
-    ],
-    "prerequisites": [
-      "the converse theorem",
-      "forward Tietze direction",
-      "T1Space"
-    ]
+    "relatedConcepts": ["biconditional equivalence", "normal space characterization", "Urysohn's lemma", "Tietze extension theorem"],
+    "prerequisites": ["the converse theorem", "forward Tietze direction"]
   }
 ]

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/meta.json
@@ -37,32 +37,35 @@
       "title": "The Tietze Extension Property and the Forward Direction",
       "startLine": 46,
       "endLine": 58,
-      "summary": "HasTietzeExtensionProperty X packages the conclusion of the Tietze theorem as a property: every continuous real function on a closed set extends to all of X. hasTietzeExtensionProperty_of_normalSpace records the forward direction — every NormalSpace has this property — as a thin wrapper around Mathlib's ContinuousMap.exists_restrict_eq, so the converse below completes a genuine equivalence.",
-      "mathContext": "$\\mathrm{TietzeProp}(X):\\ \\forall\\,s\\ \\text{closed},\\ \\forall f\\in C(s,\\mathbb{R}),\\ \\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$; and $\\mathrm{Normal}\\Rightarrow\\mathrm{TietzeProp}$."
+      "summary": "HasTietzeExtensionProperty X abstracts 'every f ∈ C(s,ℝ) on a closed s extends to C(X,ℝ)'; hasTietzeExtensionProperty_of_normalSpace is the forward direction (Mathlib's ContinuousMap.exists_restrict_eq repackaged)."
     },
     {
       "id": "clopen-lemma",
       "title": "The Clopen Boundary Lemma",
       "startLine": 60,
       "endLine": 82,
-      "summary": "isClopen_subtype_of_disjoint_closed: for disjoint closed A, B, the part of the subspace s = A ∪ B lying over B is clopen. Closed as the preimage of B under the continuous inclusion; open because its complement in s is exactly the part over A (each point of s is in A or B and not both), again a preimage of a closed set. This is the geometric engine of the whole argument.",
-      "mathContext": "Inside $s=A\\cup B$, the set $\\{x : x\\in B\\}$ is clopen: closed (preimage of $B$) and open (complement is $\\{x:x\\in A\\}$, by $A\\cap B=\\varnothing$)."
+      "summary": "isClopen_subtype_of_disjoint_closed: inside s = A ∪ B (A,B disjoint closed), the part over B is clopen — closed as a preimage of B, open since its complement is the part over A. The geometric heart of the converse."
     },
     {
-      "id": "converse",
+      "id": "converse-main",
       "title": "The Converse: Tietze Property Implies Normal",
       "startLine": 84,
       "endLine": 141,
-      "summary": "normalSpace_of_hasTietzeExtensionProperty: the main result. The clopen set has empty frontier, so x ↦ (if x ∈ B then 1 else 0) is continuous on s by Continuous.if; the Tietze property extends it to F : X → ℝ with F = 0 on A, F = 1 on B; then F⁻¹(Iio ½) and F⁻¹(Ioi ½) are disjoint open neighbourhoods of A and B. No separation axiom on X is used.",
-      "mathContext": "Disjoint closed $A,B$: extend the $\\{0,1\\}$ boundary function on $A\\cup B$ to $F:X\\to\\mathbb{R}$; then $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$ and $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens."
+      "summary": "normalSpace_of_hasTietzeExtensionProperty: the clopen boundary makes the {0,1} boundary function continuous (Continuous.if, empty frontier); extend it to F, then F⁻¹(Iio ½) ⊇ A and F⁻¹(Ioi ½) ⊇ B are disjoint opens. No separation axiom on X is used."
     },
     {
-      "id": "corollaries",
-      "title": "The T1 Statement and the Equivalence",
+      "id": "t1-statement",
+      "title": "The T1 (Textbook) Statement",
       "startLine": 143,
-      "endLine": 156,
-      "summary": "t1Space_normalSpace_of_hasTietzeExtensionProperty restates the result under the classical T1 hypothesis (which is not actually used). normalSpace_iff_hasTietzeExtensionProperty pairs the converse with the forward direction into the full equivalence normal ⟺ Tietze extension property.",
-      "mathContext": "$\\mathrm{T1}+\\mathrm{TietzeProp}\\Rightarrow\\mathrm{Normal}$; and $\\mathrm{Normal}\\iff\\mathrm{TietzeProp}$."
+      "endLine": 150,
+      "summary": "t1Space_normalSpace_of_hasTietzeExtensionProperty: the classical T1 phrasing, with the entry making explicit that the T1 hypothesis is redundant — the bare Tietze property already forces normality."
+    },
+    {
+      "id": "equivalence",
+      "title": "The Full Equivalence: Normal ⟺ Tietze",
+      "startLine": 151,
+      "endLine": 158,
+      "summary": "normalSpace_iff_hasTietzeExtensionProperty pairs converse with forward into the biconditional normal ⟺ Tietze extension property — the arrow absent from Mathlib, closing the loop normal ⟺ Tietze ⟺ Urysohn."
     }
   ],
   "meta": {


### PR DESCRIPTION
Enrichment pass for `tietze-extension-theorem-oq-01-oq-01` (normal ⟺ has the Tietze extension property).

Quality 93 → 100:
- Split the final section/annotation into two at the theorem boundary — *The T1 (textbook) statement* (`t1Space_normalSpace_of_hasTietzeExtensionProperty`) and *The full equivalence: Normal ⟺ Tietze* (`normalSpace_iff_hasTietzeExtensionProperty`).
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 17 KB, under the 60 KB guardrail. No axiom/status changes.