### PR TITLE
Enrich Three-Argument Tangent Law: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/tangent-addition-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01-oq-01/annotations.json
@@ -2,86 +2,61 @@
   {
     "id": "ann-module-header",
     "proofId": "tangent-addition-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 5,
-      "endLine": 44
-    },
+    "range": { "startLine": 5, "endLine": 45 },
     "type": "concept",
     "title": "From Two Angles to Three",
-    "content": "The parent entry proves the two-argument tangent law and the triangle identity for A+B+C=π. This file takes the genuinely more general step: tan(x+y+z) expressed in the elementary symmetric polynomials of tan x, tan y, tan z. The triple-angle formula and the triangle identity both fall out as corollaries — all 0 axioms / 0 sorries.",
-    "mathContext": "e₁ = Σ tan, e₂ = Σ tan·tan, e₃ = ∏ tan; the law is tan(x+y+z) = (e₁ - e₃)/(1 - e₂).",
+    "content": "The parent entry proves the two-argument tangent law and the triangle identity for A+B+C=π. This file takes the genuinely more general step: tan(x+y+z) expressed in the elementary symmetric polynomials of tan x, tan y, tan z. The triple-angle formula and the triangle identity both fall out as corollaries — all 0 axioms / 0 sorries. The docstring's Method section flags the key design choice: avoid the fragile nested-fraction route and instead reduce over the common denominator cos x·cos y·cos z.",
+    "mathContext": "$e_1 = \\sum\\tan,\\ e_2 = \\sum\\tan\\cdot\\tan,\\ e_3 = \\prod\\tan$; the law is $\\tan(x+y+z) = (e_1 - e_3)/(1 - e_2)$.",
     "significance": "key",
-    "relatedConcepts": [
-      "tangent addition law",
-      "elementary symmetric polynomials",
-      "multiple-angle formulas"
-    ],
-    "prerequisites": [
-      "tangent addition law",
-      "sine and cosine angle-sum identities"
-    ]
+    "relatedConcepts": ["tangent addition law", "elementary symmetric polynomials", "multiple-angle formulas"],
+    "prerequisites": ["tangent addition law", "sine and cosine angle-sum identities"]
   },
   {
-    "id": "ann-three-arg",
+    "id": "ann-three-arg-statement",
     "proofId": "tangent-addition-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 50,
-      "endLine": 72
-    },
+    "range": { "startLine": 46, "endLine": 63 },
     "type": "theorem",
-    "title": "Three-Argument Tangent Addition Law",
-    "content": "tan(x+y+z) = (tan x + tan y + tan z - tan x tan y tan z)/(1 - (tan x tan y + tan y tan z + tan z tan x)). The proof writes both sides over cos x·cos y·cos z: the numerator is then exactly the sin_add/cos_add expansion of sin(x+y+z), the denominator that of cos(x+y+z), and the law collapses to (N/c)/(D/c) = N/D via div_div_div_cancel_right₀. This avoids the brittle nested-fraction route of substituting tan(x+y) into a second tan_add.",
-    "mathContext": "Side-conditions cos x, cos y, cos z ≠ 0 and cos(x+y+z) ≠ 0.",
+    "title": "Three-Argument Law: Statement and sin/cos Triple-Sum Expansions",
+    "content": "tan_add_three states tan(x+y+z) = (tan x + tan y + tan z - tan x tan y tan z)/(1 - (tan x tan y + tan y tan z + tan z tan x)), the elementary-symmetric form, under cos x, cos y, cos z ≠ 0 and cos(x+y+z) ≠ 0. The proof opens by expanding the triple-sum sine and cosine via nested sin_add/cos_add (rewriting x+y+z = (x+y)+z, then ring): hs gives sin(x+y+z) as the alternating symmetric combination of sines and cosines, and hc gives cos(x+y+z) similarly. These two expansions are the raw material the collapse below turns into the tangent quotient.",
+    "mathContext": "$\\sin(x+y+z)$ and $\\cos(x+y+z)$ expanded as symmetric sums of $\\sin/\\cos x,y,z$ via nested $\\sin\\_add/\\cos\\_add$.",
     "significance": "key",
-    "relatedConcepts": [
-      "angle-sum identities",
-      "common denominator method"
-    ],
-    "prerequisites": [
-      "Real.sin_add",
-      "Real.cos_add",
-      "Real.tan_eq_sin_div_cos"
-    ]
+    "relatedConcepts": ["angle-sum identities", "triple-sum expansion", "elementary symmetric polynomials"],
+    "prerequisites": ["Real.sin_add", "Real.cos_add"]
+  },
+  {
+    "id": "ann-three-arg-collapse",
+    "proofId": "tangent-addition-formula-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "technique",
+    "title": "The Common-Denominator Collapse",
+    "content": "The finish writes both the claimed numerator e₁ − e₃ and denominator 1 − e₂ over the single common denominator cos x·cos y·cos z (hnum, hden — each proved by tan_eq_sin_div_cos then field_simp <;> ring). The numerator-over-c is exactly hs and the denominator-over-c exactly hc, so tan(x+y+z) = sin/cos = (N/c)/(D/c), which collapses by div_div_div_cancel_right₀ (using cos x·cos y·cos z ≠ 0) to N/D — the claimed formula. This common-denominator strategy sidesteps the brittle nested-fraction route of substituting tan(x+y) into a second tan_add.",
+    "mathContext": "$(N/c)/(D/c) = N/D$ via $\\texttt{div\\_div\\_div\\_cancel\\_right}_0$, with $c = \\cos x\\cos y\\cos z \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["common denominator method", "field_simp", "div_div_div_cancel_right₀"],
+    "prerequisites": ["Real.tan_eq_sin_div_cos", "field_simp / ring"]
   },
   {
     "id": "ann-triple-angle",
     "proofId": "tangent-addition-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 74,
-      "endLine": 81
-    },
+    "range": { "startLine": 74, "endLine": 81 },
     "type": "theorem",
     "title": "Triple-Angle Formula",
-    "content": "tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x), obtained by specializing the three-argument law to x=y=z and finishing with ring. The classical multiple-angle formula for the tangent.",
-    "mathContext": "Diagonal x=y=z of the symmetric law; needs cos x ≠ 0 and cos(3x) ≠ 0.",
+    "content": "tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x), obtained by specializing the three-argument law to x=y=z and finishing with ring. The classical multiple-angle formula for the tangent, now a one-line corollary of the symmetric law.",
+    "mathContext": "Diagonal $x=y=z$ of the symmetric law; needs $\\cos x \\ne 0$ and $\\cos(3x) \\ne 0$.",
     "significance": "key",
-    "relatedConcepts": [
-      "multiple-angle formulas",
-      "Chebyshev-like recurrences"
-    ],
-    "prerequisites": [
-      "three-argument tangent law"
-    ]
+    "relatedConcepts": ["multiple-angle formulas", "Chebyshev-like recurrences"],
+    "prerequisites": ["three-argument tangent law"]
   },
   {
     "id": "ann-triangle",
     "proofId": "tangent-addition-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 83,
-      "endLine": 108
-    },
+    "range": { "startLine": 83, "endLine": 108 },
     "type": "theorem",
     "title": "Triangle Identity from the General Law",
-    "content": "For A+B+C = π, tan(A+B+C) = tan π = 0, so the numerator e₁ - e₃ of the three-argument law must vanish: tan A + tan B + tan C = tan A·tan B·tan C. The denominator 1 - e₂ is shown nonzero from cos(A+B+C) = cos A cos B cos C·(1 - e₂), and div_eq_zero_iff finishes. This recovers the parent's triangle identity as a special case of the general law.",
-    "mathContext": "A+B+C = π and cos A, cos B, cos C ≠ 0.",
+    "content": "For A+B+C = π, tan(A+B+C) = tan π = 0, so the numerator e₁ - e₃ of the three-argument law must vanish: tan A + tan B + tan C = tan A·tan B·tan C. The denominator 1 - e₂ is shown nonzero from cos(A+B+C) = cos A cos B cos C·(1 - e₂), and div_eq_zero_iff finishes. This recovers the parent's triangle identity as a special case of the general law — the unification advertised in the header.",
+    "mathContext": "$A+B+C = \\pi$ and $\\cos A, \\cos B, \\cos C \\ne 0 \\Rightarrow \\tan A + \\tan B + \\tan C = \\tan A\\tan B\\tan C$.",
     "significance": "key",
-    "relatedConcepts": [
-      "triangle tangent identity",
-      "unification"
-    ],
-    "prerequisites": [
-      "three-argument tangent law",
-      "div_eq_zero_iff"
-    ]
+    "relatedConcepts": ["triangle tangent identity", "unification", "div_eq_zero_iff"],
+    "prerequisites": ["three-argument tangent law", "div_eq_zero_iff"]
   }
 ]

--- a/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
@@ -79,36 +79,39 @@
   },
   "sections": [
     {
-      "id": "sec-header",
+      "id": "header",
       "title": "Imports, Overview, and Setup",
       "startLine": 1,
       "endLine": 45,
-      "summary": "Imports (Mathlib trigonometric/arctan and complex-trig modules plus Mathlib.Tactic) and the file-level docstring motivating the three-argument extension of the parent's two-angle tangent law, introducing the elementary symmetric polynomials e₁, e₂, e₃ of tan x, tan y, tan z and previewing the triple-angle and triangle-identity corollaries; opens the Real namespace.",
-      "mathContext": "e₁ = Σ tan, e₂ = Σ tan·tan, e₃ = ∏ tan; the law tan(x+y+z) = (e₁ − e₃)/(1 − e₂) is developed below over the common denominator cos x·cos y·cos z."
+      "summary": "Docstring: the parent gives the two-argument law and triangle identity; this file proves the more general three-argument law tan(x+y+z) = (e₁−e₃)/(1−e₂) with triple-angle and triangle identity as corollaries. Method: reduce over the common denominator cos x·cos y·cos z rather than nested fractions."
     },
     {
-      "id": "three-arg-law",
-      "title": "The Three-Argument Tangent Addition Law",
+      "id": "three-arg-statement",
+      "title": "Three-Argument Law: Statement and sin/cos Triple-Sum Expansions",
       "startLine": 46,
+      "endLine": 63,
+      "summary": "tan_add_three stated in elementary-symmetric form; the proof first expands sin(x+y+z) and cos(x+y+z) as symmetric sums via nested sin_add/cos_add (hs, hc)."
+    },
+    {
+      "id": "three-arg-collapse",
+      "title": "The Common-Denominator Collapse",
+      "startLine": 64,
       "endLine": 72,
-      "summary": "Proves tan(x+y+z) = (e₁ - e₃)/(1 - e₂) by recognizing the symmetric numerator/denominator as the sin/cos expansions of sin(x+y+z) and cos(x+y+z) over cos x cos y cos z, then cancelling via div_div_div_cancel_right₀.",
-      "mathContext": "e₁ = tan x+tan y+tan z, e₂ = Σ tan·tan, e₃ = tan x tan y tan z."
+      "summary": "Numerator e₁−e₃ and denominator 1−e₂ are rewritten over cos x·cos y·cos z (hnum, hden); matching hs/hc, tan(x+y+z) = (N/c)/(D/c) collapses via div_div_div_cancel_right₀ to N/D."
     },
     {
       "id": "triple-angle",
       "title": "Triple-Angle Formula",
       "startLine": 74,
       "endLine": 81,
-      "summary": "The x=y=z diagonal: tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x), one ring specialization of the three-argument law.",
-      "mathContext": "Classical multiple-angle formula for the tangent."
+      "summary": "tan_three_mul: the x=y=z diagonal gives tan(3x) = (3 tan x − tan³x)/(1 − 3 tan²x), finished with ring."
     },
     {
-      "id": "triangle-identity",
+      "id": "triangle",
       "title": "Triangle Identity Recovered",
       "startLine": 83,
       "endLine": 108,
-      "summary": "For A+B+C = π, tan(A+B+C) = tan π = 0, so the numerator e₁ - e₃ vanishes: tan A + tan B + tan C = tan A·tan B·tan C, recovering the parent's identity from the general law.",
-      "mathContext": "Denominator 1-e₂ shown nonzero via cos(A+B+C) = cos A cos B cos C·(1-e₂)."
+      "summary": "tan_sum_eq_tan_prod_of_three: for A+B+C=π, tan(A+B+C)=0 forces e₁−e₃=0, i.e. tan A+tan B+tan C = tan A tan B tan C, recovering the parent's identity via div_eq_zero_iff."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `tangent-addition-formula-oq-01-oq-01` (tan(x+y+z) in elementary symmetric polynomials of the tangents).

Quality 93 → 100:
- Split the core theorem `tan_add_three` into its two proof stages — the sin/cos triple-sum expansions, and the common-denominator collapse (`div_div_div_cancel_right₀`).
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 11 KB, under the 60 KB guardrail. No axiom/status changes.