### PR TITLE
Enrich Second Subdiagonal of Stirling Numbers: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/stirling-second-kind-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-03/annotations.json
@@ -8,33 +8,20 @@
     "content": "Mathlib records the diagonal S(n,n)=1 and the first subdiagonal S(n+1,n)=C(n+1,2) of the Stirling numbers of the second kind, but stops there. This file proves the next entry, the second subdiagonal S(n,n−2) = C(n,3) + 3·C(n,4). Combinatorially, a partition of an n-set into n−2 blocks must be one triple plus singletons (C(n,3) ways) or two doubletons plus singletons (C(n,4) ways to pick the four paired elements, times the 3 perfect matchings of four elements). The proof is a single induction on m for the form S(m+2,m) = C(m+2,3) + 3·C(m+2,4).",
     "mathContext": "$S(n,n-2) = \\binom{n}{3} + 3\\binom{n}{4}$, splitting partitions into one-triple and two-doubleton shapes.",
     "significance": "critical",
-    "relatedConcepts": [
-      "Stirling numbers of the second kind",
-      "set partitions",
-      "subdiagonal closed forms",
-      "perfect matchings of four elements"
-    ],
-    "prerequisites": [
-      "set partitions",
-      "binomial coefficients"
-    ]
+    "relatedConcepts": ["Stirling numbers of the second kind", "set partitions", "subdiagonal closed forms", "perfect matchings of four elements"],
+    "prerequisites": ["set partitions", "binomial coefficients"]
   },
   {
     "id": "ann-absorption",
     "proofId": "stirling-second-kind-oq-01-oq-03",
-    "range": { "startLine": 53, "endLine": 65 },
+    "range": { "startLine": 51, "endLine": 65 },
     "type": "tactic",
     "title": "The Absorption Identity m·C(m+2,2) = 3·C(m+2,3)",
     "content": "This is the only arithmetic fact the induction step needs beyond linear bookkeeping. It is the n=m+2, k=2 instance of Nat.choose_succ_right_eq, which states C(n,k+1)·(k+1) = C(n,k)·(n−k); here it reads C(m+2,3)·3 = C(m+2,2)·((m+2)−2), and Nat.add_sub_cancel collapses (m+2)−2 to m. Reorienting by commutativity gives m·C(m+2,2) = 3·C(m+2,3). Isolating it as a named lemma lets the main step finish with omega once it is substituted.",
     "mathContext": "$m\\binom{m+2}{2} = 3\\binom{m+2}{3}$, from $\\binom{n}{k+1}(k+1) = \\binom{n}{k}(n-k)$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "binomial absorption",
-      "Pascal-triangle arithmetic"
-    ],
-    "prerequisites": [
-      "binomial coefficient identities"
-    ]
+    "relatedConcepts": ["binomial absorption", "Pascal-triangle arithmetic"],
+    "prerequisites": ["binomial coefficient identities"]
   },
   {
     "id": "ann-main-theorem",
@@ -45,33 +32,31 @@
     "content": "stirlingSecond_sub_two proves S(m+2,m) = C(m+2,3) + 3·C(m+2,4) by induction on m. The base m=0 is decide (both sides are 0). The successor step applies the Pascal recurrence Nat.stirlingSecond_succ_succ exactly once to get S(m+3,m+1) = (m+1)·S(m+2,m+1) + S(m+2,m); it rewrites the first subdiagonal term S(m+2,m+1)=C(m+2,2) via Nat.stirlingSecond_succ_self_left and the second via the induction hypothesis. Two instances of Pascal's rule Nat.choose_succ_succ' expand the target's C(m+3,3) and C(m+3,4) over the column m+2; add_one_mul splits (m+1)·C(m+2,2); the absorption identity is substituted; and omega closes the now-linear goal in the three binomials.",
     "mathContext": "$S(m+2,m) = \\binom{m+2}{3} + 3\\binom{m+2}{4}$ for all $m \\in \\mathbb{N}$.",
     "significance": "critical",
-    "relatedConcepts": [
-      "Pascal recurrence for Stirling numbers",
-      "first subdiagonal S(n+1,n)=C(n+1,2)",
-      "induction on n",
-      "omega for linear closure"
-    ],
-    "prerequisites": [
-      "Stirling Pascal recurrence",
-      "Pascal's rule for binomials"
-    ]
+    "relatedConcepts": ["Pascal recurrence for Stirling numbers", "first subdiagonal S(n+1,n)=C(n+1,2)", "induction on n", "omega for linear closure"],
+    "prerequisites": ["Stirling Pascal recurrence", "Pascal's rule for binomials"]
   },
   {
     "id": "ann-shifted-form",
     "proofId": "stirling-second-kind-oq-01-oq-03",
-    "range": { "startLine": 88, "endLine": 98 },
+    "range": { "startLine": 87, "endLine": 92 },
     "type": "theorem",
-    "title": "Index-Shifted Form and Numeric Checks",
-    "content": "stirlingSecond_sub_two' re-indexes the result to the symmetric statement S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2, writing n = m+2 via Nat.exists_eq_add_of_le and simplifying n−2 = m. Five decide-checked examples verify the formula against directly computed Stirling values: S(2,0)=0, S(3,1)=1, S(4,2)=7, S(5,3)=25, S(6,4)=65. These use kernel-reduction decide (not native_decide), so they introduce no Lean.ofReduceBool dependency.",
-    "mathContext": "$S(n,n-2) = \\binom{n}{3} + 3\\binom{n}{4}$ for $n \\ge 2$; verified numerically through $n=6$.",
+    "title": "Index-Shifted Form S(n,n−2) = C(n,3) + 3·C(n,4)",
+    "content": "stirlingSecond_sub_two' re-indexes the result to the symmetric statement S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2. Writing n = m+2 via Nat.exists_eq_add_of_le turns the natural-number subtraction n−2 into the honest m (avoiding truncated-subtraction pitfalls), after which the m-indexed theorem applies verbatim. This is the form a reader recognises as 'the second subdiagonal', stated directly in n rather than in the induction variable.",
+    "mathContext": "$S(n,n-2) = \\binom{n}{3} + 3\\binom{n}{4}$ for $n \\ge 2$, via $n = m+2$.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "index shifting",
-      "kernel-reduction decide",
-      "numeric verification"
-    ],
-    "prerequisites": [
-      "natural-number subtraction"
-    ]
+    "relatedConcepts": ["index shifting", "natural-number subtraction", "Nat.exists_eq_add_of_le"],
+    "prerequisites": ["natural-number subtraction"]
+  },
+  {
+    "id": "ann-sanity-checks",
+    "proofId": "stirling-second-kind-oq-01-oq-03",
+    "range": { "startLine": 93, "endLine": 100 },
+    "type": "insight",
+    "title": "Sanity Checks Against Computed Values",
+    "content": "Five decide-checked examples verify the closed form against directly computed Stirling values: S(2,0)=0, S(3,1)=1, S(4,2)=7, S(5,3)=25, S(6,4)=65. These use kernel-reduction decide (not native_decide), so they introduce NO Lean.ofReduceBool dependency — the file remains genuinely axiom-free, consistent with the entry's verified status. The checks double as a guard against an off-by-one or coefficient error in the two-shape combinatorial count.",
+    "mathContext": "$S(4,2)=7 = \\binom{4}{3}+3\\binom{4}{4} = 4+3$; $S(6,4)=65 = \\binom{6}{3}+3\\binom{6}{4} = 20+45$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel-reduction decide", "numeric verification", "axiom-free proofs"],
+    "prerequisites": ["decide tactic"]
   }
 ]

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-03/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-03/meta.json
@@ -79,36 +79,39 @@
   },
   "sections": [
     {
-      "id": "imports-docstring",
+      "id": "overview",
       "title": "Overview and Strategy",
       "startLine": 1,
       "endLine": 45,
-      "summary": "File docstring stating the second-subdiagonal identity S(m+2,m) = C(m+2,3)+3·C(m+2,4), its set-partition interpretation (one triple, or two doubletons), and the induction plan resting on the Pascal recurrence, the first subdiagonal, and a single absorption identity.",
-      "mathContext": "S(n,n−2) = C(n,3) + 3·C(n,4): partitions of an n-set into n−2 blocks split into one-triple and two-doubleton shapes."
+      "summary": "Mathlib stops at the first subdiagonal S(n+1,n)=C(n+1,2); this file proves the second, S(n,n−2)=C(n,3)+3·C(n,4), reflecting the one-triple vs two-doubleton partition shapes. Proof is one induction on m for S(m+2,m)."
     },
     {
       "id": "absorption",
       "title": "The Absorption Identity",
-      "startLine": 53,
+      "startLine": 51,
       "endLine": 65,
-      "summary": "absorption: m·C(m+2,2) = 3·C(m+2,3), the single non-omega arithmetic fact behind the induction step. It is the n=m+2, k=2 instance of Nat.choose_succ_right_eq (with Nat.add_sub_cancel collapsing (m+2)−2 to m), reoriented by commutativity.",
-      "mathContext": "$m\\binom{m+2}{2} = 3\\binom{m+2}{3}$, an instance of $\\binom{n}{k+1}(k+1) = \\binom{n}{k}(n-k)$."
+      "summary": "absorption: m·C(m+2,2) = 3·C(m+2,3), the only non-omega arithmetic fact, from Nat.choose_succ_right_eq with (m+2)−2 = m. Named separately so the main step closes by omega after substitution."
     },
     {
       "id": "main-theorem",
       "title": "The Second Subdiagonal S(m+2,m) = C(m+2,3) + 3·C(m+2,4)",
       "startLine": 67,
       "endLine": 86,
-      "summary": "stirlingSecond_sub_two: induction on m. Base m=0 by decide. Step applies Nat.stirlingSecond_succ_succ once, rewrites the first subdiagonal term via Nat.stirlingSecond_succ_self_left and the rest via the induction hypothesis, expands the target binomials with two instances of Nat.choose_succ_succ', splits the leading coefficient with add_one_mul, substitutes absorption, and closes by omega.",
-      "mathContext": "$S(m+2,m) = \\binom{m+2}{3} + 3\\binom{m+2}{4}$ for all $m$."
+      "summary": "stirlingSecond_sub_two by induction on m: one Pascal recurrence Nat.stirlingSecond_succ_succ, rewrite the first subdiagonal and the IH, expand C(m+3,3)/C(m+3,4) by Pascal's rule, substitute absorption, close by omega."
     },
     {
       "id": "shifted-form",
-      "title": "Index-Shifted Form and Sanity Checks",
-      "startLine": 88,
-      "endLine": 98,
-      "summary": "stirlingSecond_sub_two': re-indexes to S(n,n−2) = C(n,3)+3·C(n,4) for n ≥ 2 via Nat.exists_eq_add_of_le and n−2 = m. Five decide-checked examples confirm the formula against directly computed values S(2,0)=0, S(3,1)=1, S(4,2)=7, S(5,3)=25, S(6,4)=65.",
-      "mathContext": "$S(n,n-2) = \\binom{n}{3} + 3\\binom{n}{4}$ for $n \\ge 2$; numeric checks through $n=6$."
+      "title": "Index-Shifted Form",
+      "startLine": 87,
+      "endLine": 92,
+      "summary": "stirlingSecond_sub_two': the symmetric statement S(n,n−2)=C(n,3)+3·C(n,4) for n ≥ 2, via n = m+2 (Nat.exists_eq_add_of_le) to tame the natural-number subtraction."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks",
+      "startLine": 93,
+      "endLine": 100,
+      "summary": "Five decide-checked values (S(2,0)=0 … S(6,4)=65) confirm the formula; kernel-reduction decide keeps the file free of Lean.ofReduceBool, preserving verified/axiom-free status."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `stirling-second-kind-oq-01-oq-03` (S(n,n−2) = C(n,3) + 3·C(n,4)).

Quality 93 → 100:
- Split the final section/annotation into the index-shifted theorem (`stirlingSecond_sub_two'`) and the decide-checked sanity checks (with a note that kernel-reduction `decide` keeps the file free of `Lean.ofReduceBool`).
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 12 KB, under the 60 KB guardrail. No axiom/status changes.