### PR TITLE
Enrich Cunningham Chain Length Bound: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/sophie-germain-oq-03/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-03/annotations.json
@@ -26,14 +26,26 @@
   {
     "id": "ann-obstruction",
     "proofId": "sophie-germain-oq-03",
-    "range": { "startLine": 83, "endLine": 161 },
+    "range": { "startLine": 83, "endLine": 120 },
     "type": "insight",
-    "title": "The Fermat Obstruction and the Length Bound",
-    "content": "For an odd prime $a$, look at index $a - 1$. Modulo $a$: $a + 1 \\equiv 1$, and by Fermat's little theorem $2^{a-1} \\equiv 1$ (using that $\\gcd(2, a) = 1$ for an odd prime). Hence $\\mathrm{cunninghamTerm}(a, a-1) = 2^{a-1}(a+1) - 1 \\equiv 0 \\pmod a$ — this is `dvd_cunninghamTerm_pred`. That same term is at least $2a + 1 > a$ (`lt_cunninghamTerm_pred`), so it has the proper divisor $a$ and is composite. A chain of *primes* therefore cannot include index $a - 1$, giving `cunningham_length_le_pred`: the length is at most $a - 1$. `Nat.ModEq.pow_card_sub_one_eq_one` supplies Fermat directly in `Nat.ModEq` form, and `Nat.modEq_iff_dvd'` carries the congruence past the closed form's $-1$.",
+    "title": "The Fermat Obstruction: the (a−1)-th Term Is Composite",
+    "content": "For an odd prime $a$, look at index $a - 1$. Modulo $a$: $a + 1 \\equiv 1$, and by Fermat's little theorem $2^{a-1} \\equiv 1$ (using $\\gcd(2, a) = 1$ for an odd prime). Hence $\\mathrm{cunninghamTerm}(a, a-1) = 2^{a-1}(a+1) - 1 \\equiv 0 \\pmod a$ — this is `dvd_cunninghamTerm_pred` (via `Nat.ModEq.pow_card_sub_one_eq_one` for Fermat and `Nat.modEq_iff_dvd'` to carry the congruence past the closed form's $-1$). That same term is at least $2a + 1 > a$ — this is `lt_cunninghamTerm_pred`. Divisible by $a$ yet strictly larger than $a$, the term has $a$ as a proper divisor and is therefore composite.",
     "mathContext": "$2^{a-1}(a+1) - 1 \\equiv 0 \\pmod a,\\qquad 2^{a-1}(a+1) - 1 \\ge 2a + 1 > a.$",
     "significance": "key",
-    "relatedConcepts": ["Fermat's little theorem", "modular arithmetic", "compositeness"],
+    "relatedConcepts": ["Fermat's little theorem", "modular arithmetic", "compositeness", "proper divisor"],
     "prerequisites": ["Fermat's little theorem", "divisibility"]
+  },
+  {
+    "id": "ann-length-bound",
+    "proofId": "sophie-germain-oq-03",
+    "range": { "startLine": 121, "endLine": 161 },
+    "type": "theorem",
+    "title": "The Length Bound and Small-Case Corollaries",
+    "content": "Because the term at index $a - 1$ is composite, a chain of *primes* cannot reach that index: `cunningham_length_le_pred` concludes that a first-kind Cunningham chain starting at an odd prime $a$ has length at most $a - 1$. Specializing gives the concrete ceilings `length_le_two_from_three` (chains from $3$ have length ≤ 2) and `length_le_four_from_five` (chains from $5$ have length ≤ 4) — exactly the bounds the small primes exhibit. This is the mathematically meaningful replacement for the parent's empirical 'longest known chain' record: a proven, prime-dependent upper bound.",
+    "mathContext": "Odd prime $a$: chain length $\\le a - 1$; hence $\\le 2$ from $a=3$ and $\\le 4$ from $a=5$.",
+    "significance": "critical",
+    "relatedConcepts": ["length bound", "compositeness obstruction", "specialization"],
+    "prerequisites": ["the Fermat obstruction", "definition of a Cunningham chain"]
   },
   {
     "id": "ann-sharpness",

--- a/src/data/proofs/sophie-germain-oq-03/meta.json
+++ b/src/data/proofs/sophie-germain-oq-03/meta.json
@@ -4,7 +4,11 @@
   "title": "Cunningham Chains of Sophie Germain Primes Are Bounded by Their Starting Prime",
   "description": "The parent open question asks for the longest known Cunningham chain of Sophie Germain primes — an empirical record (the longest known first-kind chain has length 19), not a theorem. This entry formalizes the mathematical content behind it: a hard upper bound on chain length. A Cunningham chain of the first kind p₀, p₁, …, pₙ₋₁ (each pᵢ₊₁ = 2pᵢ + 1, so every link but the last is a Sophie Germain prime) solves to the closed form pᵢ = 2ⁱ·(a+1) − 1 with a = p₀. The main theorem cunningham_length_le_pred shows that if the starting prime a is odd (a > 2) then the chain has length ≤ a − 1: by Fermat's little theorem the term at index a−1 is ≡ 0 (mod a) yet exceeds a, hence composite, so the chain of primes cannot reach it. The bound is sharp — attained at a = 3 (chain 3, 7) and a = 5 (chain 5, 11, 23, 47, with 5·19 = 95 blocking the next link) — and the even prime a = 2 is genuinely excluded. Fully machine-checked, 0 sorries, 0 axioms.",
   "leanFile": {
-    "imports": ["Mathlib.FieldTheory.Finite.Basic", "Mathlib.Data.Nat.Prime.Basic", "Mathlib.Tactic"],
+    "imports": [
+      "Mathlib.FieldTheory.Finite.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
     "opens": [],
     "namespace": "SophieGermainOQ03",
     "lineCount": 189,
@@ -57,7 +61,10 @@
     ],
     "mathlib_version": "4.26.0",
     "lineCount": 189,
-    "relatedProblems": ["sophie-germain", "erdos-1065"],
+    "relatedProblems": [
+      "sophie-germain",
+      "erdos-1065"
+    ],
     "theoremCount": 11,
     "definitionCount": 2
   },
@@ -102,36 +109,39 @@
   ],
   "sections": [
     {
-      "id": "header",
+      "id": "imports-docstring",
       "title": "Imports and Module Docstring",
       "startLine": 1,
       "endLine": 48,
-      "summary": "Module docstring explaining that the literal open question (longest known chain, length 19) is a database record, and stating the substantive content: the closed form pᵢ = 2ⁱ·(a+1) − 1, the Fermat obstruction, the main bound length ≤ a − 1, its sharpness at a = 3 and a = 5, and the genuine exclusion of a = 2. Imports Mathlib.FieldTheory.Finite.Basic for Fermat's little theorem.",
-      "mathContext": "$p_i = 2^i(a+1) - 1,\\quad p_{i+1} = 2p_i + 1$."
+      "summary": "Frames the shift from the parent's empirical 'longest known Cunningham chain' record to a provable structural bound: a first-kind chain has p_{i+1}=2p_i+1, so all but the last term are Sophie Germain primes."
     },
     {
       "id": "closed-form",
       "title": "Closed-Form Description of a Cunningham Chain",
       "startLine": 49,
       "endLine": 82,
-      "summary": "Defines cunninghamTerm a i = 2^i·(a+1) − 1 and IsCunninghamChainFirstKind a n (the first n terms are all prime). cunninghamTerm_zero shows the chain starts at a; cunninghamTerm_succ proves it satisfies pᵢ₊₁ = 2pᵢ + 1, so the closed form genuinely describes a first-kind chain.",
-      "mathContext": "$\\mathrm{cunninghamTerm}(a,0)=a,\\quad \\mathrm{cunninghamTerm}(a,i{+}1)=2\\,\\mathrm{cunninghamTerm}(a,i)+1$."
+      "summary": "cunninghamTerm a i = 2^i(a+1)−1 solves the recurrence; cunninghamTerm_zero (starts at a) and cunninghamTerm_succ (satisfies p_{i+1}=2p_i+1, ℕ subtraction tamed by omega) plus the IsCunninghamChainFirstKind predicate."
     },
     {
       "id": "obstruction",
-      "title": "The Fermat Obstruction and the Length Bound",
+      "title": "The Fermat Obstruction",
       "startLine": 83,
+      "endLine": 120,
+      "summary": "dvd_cunninghamTerm_pred: for odd prime a, index a−1 gives 2^{a-1}(a+1)−1 ≡ 0 (mod a) by Fermat; lt_cunninghamTerm_pred: that term exceeds a. Divisible by a yet > a ⇒ composite."
+    },
+    {
+      "id": "length-bound",
+      "title": "The Length Bound and Small-Case Corollaries",
+      "startLine": 121,
       "endLine": 161,
-      "summary": "dvd_cunninghamTerm_pred: for an odd prime a, a divides the term at index a − 1, via 2^(a-1) ≡ 1 (Fermat, with 2 coprime to a) and a + 1 ≡ 1 modulo a. lt_cunninghamTerm_pred: that term is at least 2a + 1 > a. The main theorem cunningham_length_le_pred combines them — a prime term divisible by a and larger than a is impossible — to bound the length by a − 1, with starting_prime_ge its contrapositive.",
-      "mathContext": "$2^{a-1}(a+1)-1 \\equiv 0 \\pmod a,\\quad 2^{a-1}(a+1)-1 > a$."
+      "summary": "cunningham_length_le_pred: a chain from odd prime a has length ≤ a−1; length_le_two_from_three and length_le_four_from_five give the concrete ceilings 2 and 4."
     },
     {
       "id": "sharpness",
       "title": "Consequences and Sharpness",
       "startLine": 162,
       "endLine": 189,
-      "summary": "Specializations length_le_two_from_three and length_le_four_from_five, and the sharpness witnesses: chain_from_five_length_four (5, 11, 23, 47 all prime) with chain_from_five_not_length_five (95 = 5·19 blocks extension) pin the maximal chain from 5 at length 4 = 5 − 1, and chain_from_three_length_two does the same at 3.",
-      "mathContext": "$5,11,23,47$ prime; $2\\cdot 47+1 = 95 = 5\\cdot 19$ composite; length $= 4 = 5-1$."
+      "summary": "starting_prime_ge (length n needs a ≥ n+1); chain_from_five_length_four (5,11,23,47) and chain_from_five_not_length_five (95=5·19) show length exactly 4; chain_from_three_length_two; a=2 excluded since Fermat needs a∤2."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `sophie-germain-oq-03` (a first-kind Cunningham chain from an odd prime `a` has length ≤ a−1, via a Fermat obstruction).

Quality 93 → 100:
- Split the large obstruction block into *The Fermat Obstruction* (`dvd_cunninghamTerm_pred` / `lt_cunninghamTerm_pred`) and *The Length Bound and Small-Case Corollaries* (`cunningham_length_le_pred` plus the from-3/from-5 ceilings).
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 13 KB, under the 60 KB guardrail. No axiom/status changes.