### PR TITLE
Enrich Schur's Lemma for Abelian Groups: 5 sections + 5 keyInsights

### DIFF
--- a/src/data/proofs/schur-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/schur-lemma-oq-01-oq-02/meta.json
@@ -74,7 +74,7 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "That an irreducible complex representation of an abelian group is one-dimensional is the first structural theorem of character theory: it is why the irreducible characters of a finite abelian group are exactly its homomorphisms to ℂˣ, and why the dual group and Fourier analysis on abelian groups work as they do. The statement is the canonical first corollary of Schur's Lemma, appearing in Serre §3.1 and Fulton–Harris §1.3 immediately after the lemma itself.",
+    "historicalContext": "That an irreducible complex representation of an abelian group is one-dimensional is the first structural theorem of character theory: it is why the irreducible characters of a finite abelian group are exactly its homomorphisms to ℂˣ, and why the dual group and Fourier analysis on abelian groups work as they do. The statement is the canonical first corollary of Schur's Lemma, appearing in Serre §3.1 and Fulton–Harris §1.3 immediately after the lemma itself. Schur proved his lemma in 1905, and the one-dimensionality of abelian irreducibles was already implicit in Frobenius and Dedekind's founding work on group characters in the 1890s. The same principle scales far beyond finite groups: it is the discrete case of Pontryagin duality for locally compact abelian groups and, via Peter–Weyl, explains why harmonic analysis on a commutative group is analysis of its one-dimensional characters.",
     "problemStatement": "The parent entry asked (open question 2): does the scalar form of Schur's Lemma specialize cleanly to recover the classical statement that an irreducible complex representation of an abelian group is one-dimensional? This entry answers yes, and isolates the precise algebraic content: the only ingredient beyond the scalar form is that an abelian group's algebra is commutative, so the algebra elements themselves are the commuting endomorphisms Schur turns into scalars.",
     "text": "For a commutative k-algebra A acting on a simple module M that is finite-dimensional over an algebraically closed field k, one has finrank k M = 1. Specializing A to the group algebra k[G] of an abelian group G gives the classical result that finite-dimensional irreducible representations of abelian groups are one-dimensional, with the complex case k = ℂ as the headline. Verified in Lean with no axioms.",
     "proofStrategy": "1. exists_scalar_smul: for each a ∈ A, the map m ↦ a • m is LinearMap.lsmul A M a, an A-linear endomorphism of M precisely because A is commutative (a • (b • m) = (ab) • m = (ba) • m = b • (a • m)). The parent's schur_endomorphism_scalar then yields c : k with a • m = c • m for all m.\n2. simple_module_over_commutative_finrank_eq_one: pick a nonzero v (M is nontrivial by simplicity). The k-line span k {v} is closed under the A-action, since a • (t • v) = t • (a • v) = t • (c • v) ∈ span k {v}; package it as a Submodule A M with carrier span k {v}. Because v ≠ 0 the submodule is not ⊥, so by simplicity it is ⊤, i.e. span k {v} = ⊤. Hence finrank k M = finrank k (span k {v}) = 1.\n3. irreducible_rep_abelian_group_finrank_eq_one / irreducible_complex_rep_abelian_one_dim: instantiate A = k[G] (commutative because G is abelian), then k = ℂ.",
@@ -82,7 +82,8 @@
       "**Commutativity is the whole point.** Schur's scalar form needs an endomorphism that commutes with the action to conclude it is a scalar. For a general algebra those commuting endomorphisms form the (small) centralizer; for a commutative algebra *every* algebra element is one. This is the single hypothesis that separates the one-dimensional classification from the general theory.",
       "**Scalars make every line invariant.** Once each a ∈ A acts as a scalar on M, any k-line is automatically an A-submodule. Irreducibility then has no room to maneuver: a proper nonzero submodule exists unless the module is already a line.",
       "**Algebraic closure is inherited from the parent, not re-used.** The eigenvalue argument lives entirely in schur_endomorphism_scalar; this entry only consumes its conclusion. The result is therefore as sharp as the parent — it fails over ℝ, where an abelian group like ℤ/4 has an irreducible 2-dimensional real representation (rotation by 90°).",
-      "**Abelian group ⇒ commutative group algebra.** The bridge from representations to commutative algebras is the single instance MonoidAlgebra.commRing: a representation of G is a k[G]-module, and k[G] is commutative exactly when G is. No representation-specific machinery is needed beyond this."
+      "**Abelian group ⇒ commutative group algebra.** The bridge from representations to commutative algebras is the single instance MonoidAlgebra.commRing: a representation of G is a k[G]-module, and k[G] is commutative exactly when G is. No representation-specific machinery is needed beyond this.",
+      "**One-dimensionality characterizes abelianness.** The converse also holds: a finite group all of whose complex irreducibles are one-dimensional must be abelian, since the dimensions dᵢ satisfy Σ dᵢ² = |G| with the number of irreducibles equal to the number of conjugacy classes. So this theorem is one direction of a clean equivalence between commutativity and having only linear characters — the nonabelian world genuinely needs higher-dimensional irreps (e.g. S₃ has a 2-dimensional one)."
     ],
     "prerequisites": [
       "Modules over a commutative algebra; simple (irreducible) modules and the submodule lattice",
@@ -93,36 +94,39 @@
   },
   "sections": [
     {
-      "id": "imports-docstring",
+      "id": "imports-statement",
       "title": "Imports and Statement",
       "startLine": 1,
       "endLine": 71,
-      "summary": "File docstring explaining how the commutative case turns the parent's scalar form into a one-dimensionality classification, and listing the three headline statements. Imports the simple-module API, eigenspace/finrank lemmas, the group-algebra API, and the parent file Proofs.SchursLemma.",
-      "mathContext": "From the scalar form of Schur's lemma to the dimension of irreducibles of abelian groups."
+      "summary": "Framing docstring: over an algebraically closed field every finite-dimensional irreducible representation of an abelian group is one-dimensional. Built on the parent's scalar form of Schur's lemma, specialized to the case where the algebra itself is commutative."
     },
     {
-      "id": "commutative-core",
-      "title": "The Commutative Core",
+      "id": "commutative-setting",
+      "title": "The Commutative Setting and Scalar Action",
       "startLine": 73,
-      "endLine": 133,
-      "summary": "smul_k_comm (the k- and A-actions commute via algebraMap), exists_scalar_smul (each algebra element acts as a scalar, by feeding LinearMap.lsmul A M a into the parent's schur_endomorphism_scalar), and simple_module_over_commutative_finrank_eq_one (a simple module over a commutative algebra, finite-dimensional over an algebraically closed field, is one-dimensional).",
-      "mathContext": "A commutative algebra acting simply and finite-dimensionally over an algebraically closed field forces dimension one."
+      "endLine": 90,
+      "summary": "The section Commutative context (algebraically closed k, commutative k-algebra A, simple finite-dimensional M with IsScalarTower). smul_k_comm commutes the k- and A-actions; exists_scalar_smul feeds LinearMap.lsmul a into the parent's Schur to make every a ∈ A act as a scalar."
     },
     {
-      "id": "group-rep",
+      "id": "algebraic-core",
+      "title": "The Algebraic Core: Simple ⟹ One-Dimensional",
+      "startLine": 93,
+      "endLine": 133,
+      "summary": "simple_module_over_commutative_finrank_eq_one: since A acts by scalars, any k-line span k {v} is an A-submodule; simplicity forces it to be ⊤, so finrank k M = 1 via finrank_span_singleton."
+    },
+    {
+      "id": "group-representations",
       "title": "Group Representations",
       "startLine": 135,
       "endLine": 160,
-      "summary": "irreducible_rep_abelian_group_finrank_eq_one: instantiates the commutative core at A = k[G] for an abelian group G, using MonoidAlgebra.commRing, to conclude that a finite-dimensional simple k[G]-module is one-dimensional.",
-      "mathContext": "Irreducible representations of abelian groups over an algebraically closed field."
+      "summary": "irreducible_rep_abelian_group_finrank_eq_one: a representation of abelian G is a k[G]-module, and MonoidAlgebra.commRing makes k[G] commutative, so the algebraic core applies directly."
     },
     {
       "id": "complex-case",
       "title": "The Complex Case",
       "startLine": 162,
       "endLine": 173,
-      "summary": "irreducible_complex_rep_abelian_one_dim: the headline k = ℂ specialization — every finite-dimensional irreducible complex representation of an abelian group is one-dimensional.",
-      "mathContext": "The classification underlying the character theory of abelian groups."
+      "summary": "irreducible_complex_rep_abelian_one_dim: the headline k = ℂ specialization, immediate because ℂ is algebraically closed."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `schur-lemma-oq-01-oq-02` (irreducible reps of abelian groups over an algebraically closed field are 1-dimensional).

Quality 93 → 100 (this entry already had 7 annotations, so the gap was elsewhere):
- Split *The Commutative Core* into *The Commutative Setting and Scalar Action* and *The Algebraic Core: Simple ⟹ One-Dimensional* → 5 sections.
- Added a 5th keyInsight: one-dimensionality characterizes abelianness (via Σ dᵢ² = |G| and the conjugacy-class count).
- Extended historicalContext (>500 chars) with the Schur 1905 / Frobenius–Dedekind origins and the Pontryagin-duality / Peter–Weyl generalization.
- meta.json 16 KB, under the 60 KB guardrail. No axiom/status changes.