### PR TITLE
Enrich Sperner Infinite Tower: 5 sections + 5 annotations

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-03/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-03/annotations.json
@@ -2,49 +2,122 @@
   {
     "id": "ann-spc-oq03-header",
     "proofId": "sperner-simplicial-bridge-oq-03",
-    "range": { "startLine": 9, "endLine": 68 },
+    "range": {
+      "startLine": 9,
+      "endLine": 68
+    },
     "type": "concept",
     "title": "The open question: finite Sperner to an infinite limit via compactness",
     "content": "The module docstring poses the parent's infinite/limit open question and its resolution. The key idea is a clean factorisation: finite Sperner is a parity count over a finite door graph and cannot itself reach an infinite conclusion, so the passage to the limit must come from a separate compactness principle. Here that principle is Kőnig's infinity lemma. An infinite simplicial object is modelled as an ℕ-indexed tower of finite pseudomanifold complexes sharing one colouring, each with its own odd-boundary hypothesis, equipped with functorial restriction maps.",
     "mathContext": "A tower is $\\mathrm{topCells} : \\mathbb{N} \\to \\mathrm{Finset}(\\mathrm{Finset}\\ E)$ with per-level purity, the pseudomanifold condition, a single colouring $c : E \\to \\mathrm{Fin}(d+1)$, and per-level odd boundary parity. The finite bridge makes each level's panchromatic-cell set nonempty; it is finite as a subtype of the finite cell type. These are exactly the hypotheses of the inverse-system Kőnig lemma.",
     "significance": "key",
-    "relatedConcepts": ["Kőnig's infinity lemma", "inverse limit", "compactness", "pseudomanifold Sperner bridge", "finite-to-infinite passage"],
-    "prerequisites": ["finite Sperner's lemma", "inverse systems / towers", "Kőnig's infinity lemma"]
+    "relatedConcepts": [
+      "Kőnig's infinity lemma",
+      "inverse limit",
+      "compactness",
+      "pseudomanifold Sperner bridge",
+      "finite-to-infinite passage"
+    ],
+    "prerequisites": [
+      "finite Sperner's lemma",
+      "inverse systems / towers",
+      "Kőnig's infinity lemma"
+    ]
   },
   {
     "id": "ann-spc-oq03-pancell",
     "proofId": "sperner-simplicial-bridge-oq-03",
-    "range": { "startLine": 83, "endLine": 105 },
+    "range": {
+      "startLine": 83,
+      "endLine": 105
+    },
     "type": "concept",
     "title": "PanCell: panchromatic cells at a level, and their finiteness",
     "content": "levelVertex packages the parent bridge's vertexEnum labelling as a function of the tower level n, so the panchromaticity predicate matches the finite bridge verbatim. PanCell n is the subtype of the finite cell type {s // s ∈ topCells n} cut out by the decidable IsPanchromatic predicate. instFinitePanCell derives Finite (PanCell n) by `unfold PanCell; infer_instance` — a subtype of a Fintype is finite. This finiteness is one of the two inputs Kőnig requires.",
     "mathContext": "$\\mathrm{PanCell}\\ n = \\{\\sigma : \\{s // s \\in \\mathrm{topCells}\\ n\\} \\mid \\mathrm{IsPanchromatic}\\ (\\mathrm{levelVertex}\\ \\dots\\ n)\\ c\\ \\sigma\\}$. Since $\\{s // s \\in \\mathrm{topCells}\\ n\\}$ is a Fintype (finset-coe) and IsPanchromatic is decidable, PanCell $n$ is finite.",
     "significance": "supporting",
-    "relatedConcepts": ["subtype of a Fintype", "decidable IsPanchromatic", "vertexEnum labelling", "Finite instance"],
-    "prerequisites": ["Fintype / Finite typeclasses", "subtypes cut out by decidable predicates", "the parent bridge's vertexEnum"]
+    "relatedConcepts": [
+      "subtype of a Fintype",
+      "decidable IsPanchromatic",
+      "vertexEnum labelling",
+      "Finite instance"
+    ],
+    "prerequisites": [
+      "Fintype / Finite typeclasses",
+      "subtypes cut out by decidable predicates",
+      "the parent bridge's vertexEnum"
+    ]
   },
   {
     "id": "ann-spc-oq03-nonempty-level",
     "proofId": "sperner-simplicial-bridge-oq-03",
-    "range": { "startLine": 110, "endLine": 130 },
+    "range": {
+      "startLine": 110,
+      "endLine": 130
+    },
     "type": "tactic",
     "title": "nonempty_panCell: finite Sperner gives per-level nonemptiness",
     "content": "For each level n, `exists_panchromatic` (the imported finite bridge) applied to topCells n — with its purity hcard, pseudomanifold hpseudo, colouring c, and odd-boundary hbdry hypotheses — yields a panchromatic cell σ. Wrapping it as ⟨⟨σ, hσ⟩⟩ gives Nonempty (PanCell n). This is the second input Kőnig requires: every level nonempty.",
     "mathContext": "$\\mathrm{exists\\_panchromatic} : \\exists\\, \\sigma : \\{s // s \\in \\mathrm{topCells}\\ n\\},\\ \\mathrm{IsPanchromatic}\\ \\dots\\ c\\ \\sigma$, which is definitionally $\\mathrm{Nonempty}\\ (\\mathrm{PanCell}\\ n)$ after packaging the witness with its proof.",
     "significance": "key",
-    "relatedConcepts": ["exists_panchromatic (finite bridge)", "Nonempty", "door-counting parity", "per-level hypotheses"],
-    "prerequisites": ["the finite Sperner bridge", "Nonempty from an existential", "the odd boundary parity hypothesis"]
+    "relatedConcepts": [
+      "exists_panchromatic (finite bridge)",
+      "Nonempty",
+      "door-counting parity",
+      "per-level hypotheses"
+    ],
+    "prerequisites": [
+      "the finite Sperner bridge",
+      "Nonempty from an existential",
+      "the odd boundary parity hypothesis"
+    ]
   },
   {
     "id": "ann-spc-oq03-konig-thread",
     "proofId": "sperner-simplicial-bridge-oq-03",
-    "range": { "startLine": 138, "endLine": 164 },
+    "range": {
+      "startLine": 138,
+      "endLine": 160
+    },
     "type": "insight",
     "title": "Kőnig's infinity lemma: the coherent thread",
     "content": "exists_coherent_panchromatic_thread applies Mathlib's exists_seq_forall_proj_of_forall_finite. Its hypotheses are exactly level-0 finiteness (instFinitePanCell) and per-level nonemptiness (nonempty_panCell, supplied as a local instance), plus the tower's functorial restriction maps π with π_refl and π_trans. The finite-fiber requirement is discharged by `Set.toFinite _` since every level is a finite type. The output is a coherent thread f : (n : ℕ) → PanCell n with π hij (f j) = f i — a genuine inverse-limit object. Crucially Kőnig needs no surjectivity of π: the thread exists by the infinity argument, not downward choice.",
     "mathContext": "$\\mathrm{exists\\_seq\\_forall\\_proj\\_of\\_forall\\_finite}$: given $\\alpha : \\mathbb{N} \\to \\mathrm{Type}$ with $\\alpha_0$ finite, each $\\alpha_i$ nonempty, projections $\\pi$ (refl, trans), and finite fibers, there is $f$ with $\\pi_{ij}(f_j)=f_i$ for $i \\le j$. Here $\\alpha = \\mathrm{PanCell}$, and finite fibers hold because each $\\alpha_{i+1}$ is finite.",
     "significance": "key",
-    "relatedConcepts": ["exists_seq_forall_proj_of_forall_finite", "inverse-system Kőnig lemma", "coherent thread / infinite path", "Set.toFinite", "functorial restriction maps"],
-    "prerequisites": ["Kőnig's infinity lemma", "inverse limits", "typeclass resolution for Finite/Nonempty"]
+    "relatedConcepts": [
+      "exists_seq_forall_proj_of_forall_finite",
+      "inverse-system Kőnig lemma",
+      "coherent thread / infinite path",
+      "Set.toFinite",
+      "functorial restriction maps"
+    ],
+    "prerequisites": [
+      "Kőnig's infinity lemma",
+      "inverse limits",
+      "typeclass resolution for Finite/Nonempty"
+    ]
+  },
+  {
+    "id": "ann-spc-oq03-cells-exposed",
+    "proofId": "sperner-simplicial-bridge-oq-03",
+    "range": {
+      "startLine": 161,
+      "endLine": 186
+    },
+    "type": "theorem",
+    "title": "Panchromaticity exposed: the user-facing statement",
+    "content": "exists_coherent_panchromatic_cells is the same conclusion as the thread theorem, repackaged so that the panchromaticity of each selected cell is stated explicitly alongside the coherence. It destructures the thread f from exists_coherent_panchromatic_thread and returns ⟨f, fun n => (f n).2, hf⟩: the second projection (f n).2 is exactly the proof that the chosen cell f n is panchromatic (that datum was already carried inside the PanCell subtype), and hf is the coherence π hij (f j) = f i. This is the form a reader wants — a coherent selection of genuinely panchromatic cells across all levels — with no extra mathematical content beyond unbundling the subtype.",
+    "mathContext": "$\\exists f,\\ (\\forall n,\\ \\mathrm{IsPanchromatic}\\ (\\mathrm{levelVertex}\\ n)\\ c\\ (f\\,n).1)\\ \\wedge\\ \\forall i\\le j,\\ \\pi_{ij}(f_j)=f_i$, from the thread via $(f\\,n).2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subtype projection",
+      "IsPanchromatic",
+      "coherent selection",
+      "repackaging a conclusion"
+    ],
+    "prerequisites": [
+      "the coherent thread theorem",
+      "subtype .2 projections"
+    ]
   }
 ]

--- a/src/data/proofs/sperner-simplicial-bridge-oq-03/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-03/meta.json
@@ -43,33 +43,39 @@
   },
   "sections": [
     {
-      "id": "sec-overview",
+      "id": "overview",
       "title": "Overview: from finite Sperner to an infinite tower via compactness",
       "startLine": 1,
       "endLine": 79,
-      "summary": "License header, imports of the parent SpernerSimplicialBridge and Mathlib's Order.KonigLemma, the module docstring, and namespace/open setup. Frames the open question: does finite panchromatic-cell existence extend to an infinite limit statement via a compactness (Kőnig / inverse-limit) argument?",
-      "mathContext": "The finite bridge is inherently finite — its door-counting parity is a counting argument over a finite door graph. To pass to the infinite, an infinite simplicial object is modelled as an ℕ-indexed tower of finite pseudomanifold complexes topCells n, all coloured by a single c, each with its own odd-boundary hypothesis. The finite theorem makes the set of panchromatic cells nonempty at each level; that set is finite because it is a subtype of the finite cell type. These are precisely the two hypotheses (level-0 finiteness, per-level nonemptiness) of Mathlib's inverse-system Kőnig lemma exists_seq_forall_proj_of_forall_finite, which then yields a coherent thread of panchromatic cells through the whole tower."
+      "summary": "The docstring poses the parent's infinite/limit open question: finite Sperner is a finite parity count, so the passage to the limit needs a separate compactness principle — here Kőnig's infinity lemma over an ℕ-indexed tower of finite pseudomanifold complexes sharing one colouring."
     },
     {
       "id": "pancell",
       "title": "Panchromatic-cell type and its finiteness",
       "startLine": 80,
       "endLine": 105,
-      "summary": "levelVertex packages the parent bridge's vertexEnum labelling as a function of the tower level n. PanCell n is the subtype of level-n cells that are panchromatic under the decidable IsPanchromatic predicate. instFinitePanCell derives Finite (PanCell n) from the finiteness of the cell type {s // s ∈ topCells n} — the finiteness input Kőnig consumes."
+      "summary": "levelVertex packages the bridge's vertex labelling per level; PanCell n is the subtype of cells cut out by the decidable IsPanchromatic; instFinitePanCell makes it Finite — one of Kőnig's two inputs."
     },
     {
       "id": "nonempty-level",
       "title": "Each tower level has a panchromatic cell",
       "startLine": 106,
       "endLine": 130,
-      "summary": "nonempty_panCell: for each level n, the finite bridge exists_panchromatic applied to topCells n (with its purity, pseudomanifold, and odd-boundary hypotheses) produces a panchromatic cell, establishing Nonempty (PanCell n). This is the per-level nonemptiness input to the compactness argument."
+      "summary": "nonempty_panCell: the imported finite bridge exists_panchromatic applied per level (with purity, pseudomanifold, colouring, odd-boundary hypotheses) gives Nonempty (PanCell n) — Kőnig's second input."
     },
     {
       "id": "konig-thread",
       "title": "Kőnig's infinity lemma: a coherent thread through the tower",
       "startLine": 131,
+      "endLine": 160,
+      "summary": "exists_coherent_panchromatic_thread applies exists_seq_forall_proj_of_forall_finite: finite levels + nonemptiness + functorial π (refl, trans) + finite fibers (Set.toFinite) yield a coherent thread f with π hij (f j) = f i. No surjectivity of π needed."
+    },
+    {
+      "id": "cells-exposed",
+      "title": "Panchromaticity exposed: the user-facing statement",
+      "startLine": 161,
       "endLine": 188,
-      "summary": "exists_coherent_panchromatic_thread applies Mathlib's exists_seq_forall_proj_of_forall_finite: with each PanCell n finite and nonempty and functorial restriction maps π, Kőnig produces a coherent thread f : (n : ℕ) → PanCell n satisfying π hij (f j) = f i. exists_coherent_panchromatic_cells repackages this to expose the panchromaticity of each (f n).1 alongside the coherence — the honest infinite analogue of the finite existence theorem."
+      "summary": "exists_coherent_panchromatic_cells repackages the thread so each selected cell's panchromaticity is explicit via (f n).2, returning ⟨f, fun n => (f n).2, hf⟩ — a coherent selection of genuinely panchromatic cells across all levels."
     }
   ],
   "overview": {


### PR DESCRIPTION
Enrichment pass for `sperner-simplicial-bridge-oq-03` (finite Sperner → infinite tower via Kőnig's infinity lemma).

Quality 93 → 100:
- Added the previously-unannotated final theorem `exists_coherent_panchromatic_cells` as a 5th section + annotation (*panchromaticity exposed: the user-facing statement*).
- 5 sections and 5 annotations; every annotation carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.
- meta.json 18 KB, under the 60 KB guardrail. No axiom/status changes.