### PR TITLE
Enrich Beta Function at Half-Integers: add reciprocal cross-reference

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
@@ -134,6 +134,11 @@
       "targetId": "gamma-reflection-formula-oq-01",
       "relationship": "related",
       "description": "Both entries evaluate Gamma/Beta at rational arguments using Mathlib's Analysis.SpecialFunctions.Gamma theory. The reflection formula gives Γ(s)Γ(1−s) = π/sin(πs) (whose s = 1/2 case is Γ(1/2)² = π); here the Beta–Gamma relation turns that same squared Gauss value into B(1/2,1/2) = π."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-03-oq-02",
+      "relationship": "related",
+      "description": "The reverse-direction companion on the same identity. That entry proves Γ(1/2)² = π independently of the Gaussian integral, by computing B(1/2,1/2) = ∫₀¹ x^(−1/2)(1−x)^(−1/2) dx = π from scratch via the fundamental theorem of calculus (antiderivative arcsin(2x−1)) and then reading off Γ(1/2)² = Γ(1)·B(1/2,1/2). This entry runs the implication the other way — it takes Mathlib's Gauss value Γ(1/2) = √π as given and derives B(1/2,1/2) = π from it — so together the two close the loop B(1/2,1/2) = π ⇔ Γ(1/2)² = π from both sides (integration and the Beta–Gamma relation)."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02` (quality 93, passes 0).

The entry was already comprehensively enriched (4 annotated sections, 5 keyInsights, full conclusion, mathlibDependencies), so this is a single targeted, curation-minded addition — not accretion. meta.json 13.4 KB → 14.1 KB, far under the 60 KB cap.

**Cross-reference (2 → 3, cap 20):** added `area-of-circle-oq-07-oq-03-oq-02` ("Γ(1/2)² = π via the Beta value B(1/2,1/2) = π and the arcsine density"). It is the reverse-direction companion on the same identity:
- *This* entry takes Mathlib's Gauss value Γ(1/2) = √π as given and derives B(1/2,1/2) = π (Gamma → Beta).
- *That* entry computes B(1/2,1/2) = π from scratch by direct integration (FTC, antiderivative arcsin(2x−1)) and reads off Γ(1/2)² = π (Beta → Gamma).

Together they close the loop B(1/2,1/2) = π ⇔ Γ(1/2)² = π from both sides. The connection was already named in an annotation (`betahalf2-ann-headline`) but was missing from `crossReferences`.

No claims changed; status/badge/axiomCount (verified / mathlib / 0) untouched. `pnpm build` passes.