### PR TITLE
Enrich Half-Integer Beta Diagonal: link child asymptotic entry

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
@@ -156,6 +156,11 @@
       "targetId": "gamma-reflection-formula-oq-01",
       "relationship": "related",
       "description": "Both entries evaluate Gamma at rational arguments. The reflection formula's s=1/2 case gives Γ(1/2)²=π; here that same squared Gauss value, propagated up the half-integer lattice by the functional equation, becomes the π-factor of the whole Beta diagonal."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The child entry that answers this entry's open question oq-01, deriving the n → ∞ asymptotic from the exact diagonal value proved here. Feeding B(n+1/2,n+1/2) = π·C(2n,n)/4^(2n) into the central-binomial Stirling estimate C(2n,n) ~ 4^n/√(πn) gives B(n+1/2,n+1/2) ~ √(π/n)·4^(-n) — exponential decay 4^(-n) modulated by a 1/√n factor, correcting the naive √(π/n) rate. This exact value is the essential input to that asymptotic."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-02-oq-01` (quality 93, passes 0).

The entry was already comprehensively enriched (4 annotated sections, 5 keyInsights, full conclusion, mathlibDependencies, openQuestions), so this is a single targeted, curation-minded addition — not accretion. meta.json 17.5 KB → 18.3 KB, well under the 60 KB cap.

**Cross-reference (3 → 4, cap 20):** added `beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01` ("Stirling Asymptotic of the Half-Integer Beta Diagonal: B(n+1/2,n+1/2) ~ √(π/n)·4^(-n)"). It is the **child that answers this entry's own open question oq-01** — feeding the exact diagonal value B(n+1/2,n+1/2) = π·C(2n,n)/4^(2n) proved here into the central-binomial Stirling estimate to get the corrected exponential decay rate. The child was already cited repeatedly in the keyInsights and openQuestions (and even bracketed as "[ANSWERED in child entry…]") but was missing from `crossReferences`, so the page named a follow-up it never linked.

No claims changed; status/badge/axiomCount (verified / original / 0) untouched. `pnpm build` passes.