### PR TITLE
Enrich HGCD Matrix Invariant: link Lehmer's GCD (same unimodular invariant)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -107,6 +107,11 @@
       "targetId": "bezout-identity-oq-01-oq-01",
       "relationship": "builds-on",
       "description": "Grandparent entry on the extended Euclidean / Bézout identity, whose Euclidean steps and Bézout cofactors (continuants) are exactly the quantities the accumulated matrix product Rₖ encodes."
+    },
+    {
+      "targetId": "gcd-algorithm-oq-03",
+      "relationship": "related",
+      "description": "Lehmer's GCD — the classical multi-precision accelerator that Schönhage's HGCD generalizes. That entry formalizes the same core idea from the correctness side: a determinant ±1 (unimodular) 2×2 integer matrix, obtained by folding a batch of partial quotients from the leading words, preserves the GCD when applied to the full inputs (its headline gcd_unimodular). This entry formalizes the structural counterpart — that the product of the per-step quotient matrices Q(q) is itself unimodular (det_Rprod: det Rₖ = (−1)^k) and reproduces the Euclidean steps (Rprod_mulVec). Together they are the gallery's two treatments of the invariant 'unimodular 2×2 integer matrices encode partial Euclidean steps' for fast GCD: Lehmer's single splice and HGCD's recursive splicing."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-01-oq-01-oq-01-oq-02` (quality 93, passes 0).

The entry was already comprehensively enriched (4 annotated sections, 5 keyInsights, full conclusion, mainTheorems, 3 references), so this is a single targeted, high-value addition — not accretion. meta.json 15.5 KB → 16.6 KB, well under the 60 KB cap.

**Cross-reference (2 → 3, cap 20):** added `gcd-algorithm-oq-03` ("Lehmer's GCD: unimodular invariance of the multi-precision step"). This is the gallery's other entry on the same mathematical idea:
- **Lehmer's GCD** (the classical multi-precision accelerator that Schönhage's HGCD generalizes) proves it from the *correctness* side — a determinant ±1 matrix folding a batch of partial quotients preserves the GCD (`gcd_unimodular`).
- **This HGCD entry** proves the *structural* counterpart — the product of per-step quotient matrices Q(q) is unimodular (`det_Rprod`: det Rₖ = (−1)^k) and reproduces the Euclidean steps (`Rprod_mulVec`).

Together they are the gallery's two treatments of "unimodular 2×2 integer matrices encode partial Euclidean steps" for fast GCD — Lehmer's single splice and HGCD's recursive splicing. The connection was previously unlinked despite being the closest neighbor in the gallery.

I deliberately did *not* add the same-parent sibling `-oq-04` (binary-GCD constant tightness), which addresses a different open question and would be filler. No claims changed; status/badge/axiomCount (verified / 0) untouched. `pnpm build` passes.