### PR TITLE
Enrich Binary GCD Cost Model: link independent O(log²) formalization

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
@@ -122,6 +122,11 @@
       "targetId": "binary-gcd-oq-01-oq-04-oq-02",
       "relationship": "related",
       "description": "Sibling analysis of the same binaryGcdSteps count (its symmetry and axis slices). That work refines the unit-cost step count; this work lifts it to a bit-operation cost."
+    },
+    {
+      "targetId": "bezout-identity-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "An independent formalization of the same classical result — the O(log² n) bit-operation complexity of Stein's Binary GCD — reached in a different gallery subtree by the same two-part strategy: bound the step count by 2·(log₂ a + log₂ b) + 2 (a Lamé-style bound), then multiply by a per-step bit cost. This entry supplies the explicit total-cost model binaryGcdCost (charging each step Nat.size a + Nat.size b) and the quadratic bound; that entry states the O(log²) conclusion and is itself the parent of the HGCD matrix-invariant work extending the analysis toward Schönhage's half-GCD."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-01-oq-01` (quality 93, passes 0).

The entry was already comprehensively enriched (4 annotated sections, 6 keyInsights, full conclusion, mathlibDependencies, mainTheorems, 3 references), so this is a single targeted, high-value addition — not accretion. meta.json 16.5 KB → 17.6 KB, well under the 60 KB cap.

**Cross-reference (3 → 4, cap 20):** added `bezout-identity-oq-01-oq-01-oq-01` ("Binary GCD O(log² n) Bit Complexity"). This is an **independent formalization of the same classical result** in a different gallery subtree, reached by the *same* two-part strategy — bound the step count by 2·(log₂ a + log₂ b) + 2 (a Lamé-style bound), then multiply by a per-step bit cost. This entry contributes the explicit total-cost model `binaryGcdCost` and the quadratic bound; that entry states the O(log²) conclusion and is the parent of the HGCD matrix-invariant work extending the analysis toward Schönhage's half-GCD.

Surfacing this parallel is genuinely useful — the two proofs of the same theorem were previously unlinked, and the cross-reference lets a reader move between the cost-model and the complexity-conclusion views (and onward to the half-GCD generalization). No claims changed; status/badge/axiomCount (verified / original / 0) untouched. `pnpm build` passes.