### PR TITLE
Enrich Hockey-Stick Identity: link arithmetic-series (Gauss's sum)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
@@ -123,6 +123,11 @@
       "targetId": "binomial-theorem-oq-02-oq-02-oq-01",
       "relationship": "sibling",
       "description": "Sibling addressing the first open question (q-Vandermonde base cases via Gaussian binomials)"
+    },
+    {
+      "targetId": "arithmetic-series",
+      "relationship": "related",
+      "description": "Gauss's formula 1+2+…+n = n(n+1)/2 proved directly (the classic pairing argument). This entry re-derives the very same closed form (gauss_sum) as the r = 1 specialization of the hockey-stick identity — the triangular numbers are the r = 1 diagonal of Pascal's triangle — so the two entries give complementary routes to Gauss's sum: elementary pairing versus a binomial-coefficient telescope of Pascal's rule."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-02-oq-02` (quality 93, passes 0).

Already well-enriched (5 keyInsights, historical context, mainTheorems with statements, 3 references, full conclusion with open questions), so this is a single targeted cross-reference — not accretion. meta.json 11.4 KB → 12.2 KB.

**Cross-reference (2 → 3, cap 20):** added `arithmetic-series` ("Sum of an Arithmetic Series"), which proves Gauss's formula 1+2+…+n = n(n+1)/2 by the classic pairing argument. This entry re-derives the *same* closed form (`gauss_sum`) as the r = 1 specialization of the hockey-stick identity — the triangular numbers are the r = 1 diagonal of Pascal's triangle. The two entries are complementary routes to Gauss's sum (elementary pairing vs. a binomial-coefficient telescope of Pascal's rule) and were previously unlinked.

No claims changed; status/badge/axiomCount (verified / mathlib / 0) untouched. `pnpm build` passes.