### PR TITLE
Enrich Central Binomial as Sum of Squares: link Catalan difference form

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02-oq-03/meta.json
@@ -128,6 +128,11 @@
       "targetId": "binomial-theorem-oq-04",
       "relationship": "extends",
       "description": "Grandparent entry on Vandermonde's identity"
+    },
+    {
+      "targetId": "catalan-numbers-oq-05",
+      "relationship": "related",
+      "description": "Another identity for the same central binomial coefficient C(2n,n): that entry expresses the Catalan numbers as the difference Cₙ = C(2n,n) − C(2n,n+1) over ℕ, where this entry expresses C(2n,n) itself as the sum of squares Σ C(n,k)². Together they give two complementary structural views of the central binomial coefficient — its ℓ² decomposition (this entry) and its relation to the Catalan sequence (that entry)."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-04-oq-02-oq-03` (quality 93, passes 0).

Already well-enriched (5 keyInsights, historical context, mainTheorems with statements, 3 references, full conclusion with open questions), so this is a single targeted cross-reference. meta.json 14.0 KB → 14.9 KB.

**Cross-reference (3 → 4, cap 20):** added `catalan-numbers-oq-05` ("Catalan numbers as a difference of central binomial coefficients: Cₙ = C(2n,n) − C(2n,n+1)"). Both entries are identities for the *same* object, the central binomial coefficient C(2n,n): this entry gives its ℓ² decomposition C(2n,n) = Σ C(n,k)², while that entry relates it to the Catalan sequence via a difference over ℕ. Complementary structural views that were previously unlinked, improving navigation across the gallery's central-binomial material (all three existing cross-refs stayed inside the binomial-theorem family).

No claims changed; status/badge/axiomCount (verified / original / 0) untouched. `pnpm build` passes.