### PR TITLE
Enrich Bernoulli's Inequality: link AM-GM (named downstream consequence)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-05/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-05/meta.json
@@ -147,6 +147,11 @@
       "targetId": "geometric-series",
       "relationship": "related",
       "description": "The divergence (1+a)ⁿ → ∞ for a > 0 is the geometric-progression growth that Bernoulli quantifies with an explicit linear rate"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The arithmetic–geometric mean inequality, which this entry names as a downstream consequence of Bernoulli: applying 1 + n·a ≤ (1+a)ⁿ termwise (equivalently the tangent-line form 1 + n(a−1) ≤ aⁿ) yields the weighted AM–GM inequality. This entry's open question asks whether that first-order-truncation viewpoint gives a clean Lean proof of AM–GM; the amgm-inequality entry is the target such a derivation would land."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-05` (quality 93, passes 0).

Already well-enriched (4 keyInsights, historical context, 7 mainTheorems with statements, full conclusion with open questions). Single targeted cross-reference. meta.json 15.2 KB → 16.0 KB.

**Cross-reference (3 → 4, cap 20):** added `amgm-inequality` ("Arithmetic Mean - Geometric Mean Inequality"). The entry itself names AM–GM as a downstream consequence of Bernoulli — applying 1 + n·a ≤ (1+a)ⁿ termwise (equivalently the tangent-line form 1 + n(a−1) ≤ aⁿ) yields weighted AM–GM — and its open question explicitly asks whether that first-order-truncation viewpoint gives a clean Lean AM–GM proof. The target entry was previously unlinked despite being named in the prose.

No claims changed; status/badge/axiomCount (verified / mathlib / 0) untouched. `pnpm build` passes.