### PR TITLE
Enrich Sperner Tucker Interior-Seed Witness-Gap (oq-02-oq-09): add annotation depth fields

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-09/annotations.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-09/annotations.json
@@ -8,7 +8,21 @@
     },
     "type": "concept",
     "title": "Sign door vs. genuine Tucker witness: quantifying the gap",
-    "content": "The directed pos→neg sign door rule of oq-02-oq-08 reads only signs (sgn : Fin 4 → ZMod 2, {+1,+2}↦0, {−1,−2}↦1) and fires on any oriented +→− side. A genuine Tucker witness is stronger: a side whose two labels are exactly antipodal, Compl x y := x = negL y (+1/−1 or +2/−2, not the merely opposite-sign +1/−2). The sibling entry forced exactly three interior degree-1 disc rooms under the sign rule; this entry asks how many of those three carry a GENUINE complementary door, and finds the answer can be zero. The seed count 3 therefore over-states the interior Tucker witnesses: no Tucker conclusion follows from the directed interior seed alone. All statements are decided by kernel decide over the 4⁴ = 256 antipodal labellings (a,b,c,d), so the axiom profile is propext / Classical.choice / Quot.sound only — no sorryAx, no Lean.ofReduceBool."
+    "content": "The directed pos→neg sign door rule of oq-02-oq-08 reads only signs (sgn : Fin 4 → ZMod 2, {+1,+2}↦0, {−1,−2}↦1) and fires on any oriented +→− side. A genuine Tucker witness is stronger: a side whose two labels are exactly antipodal, Compl x y := x = negL y (+1/−1 or +2/−2, not the merely opposite-sign +1/−2). The sibling entry forced exactly three interior degree-1 disc rooms under the sign rule; this entry asks how many of those three carry a GENUINE complementary door, and finds the answer can be zero. The seed count 3 therefore over-states the interior Tucker witnesses: no Tucker conclusion follows from the directed interior seed alone. All statements are decided by kernel decide over the 4⁴ = 256 antipodal labellings (a,b,c,d), so the axiom profile is propext / Classical.choice / Quot.sound only — no sorryAx, no Lean.ofReduceBool.",
+    "mathContext": "Two nested relations on the labels: the sign shadow $\\mathrm{sgn} : \\mathrm{Fin}\\,4 \\to \\mathbb{Z}/2$ that the directed door reads, versus exact antipodality $\\mathrm{Compl}\\,x\\,y := x = \\mathrm{negL}\\,y$ that a Tucker witness requires. Every claim is a decidable proposition over the $4^4 = 256$ antipodal labellings $(a,b,c,d)$, discharged by kernel `decide`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tucker's lemma",
+      "Borsuk–Ulam theorem",
+      "directed pos→neg sign door rule",
+      "sign map to ZMod 2",
+      "kernel decide (0-axiom exhaustive check)"
+    ],
+    "prerequisites": [
+      "sperner-mathlib4-oq-02-oq-08 (the directed interior seed and its count of three)",
+      "the Fin 4 / ZMod 2 label encoding {+1,+2,−1,−2}",
+      "Decidable propositions and Finset cardinality"
+    ]
   },
   {
     "id": "ann-compl-sign-sperner-oq02-oq09",
@@ -19,7 +33,20 @@
     },
     "type": "insight",
     "title": "Complementarity forces opposite signs (necessary, not sufficient)",
-    "content": "Compl x y := x = negL y is exact antipodality on the four labels; compl_imp_opposite_sign proves Compl x y ⇒ sgn x = sgn y + 1 over all Fin 4 × Fin 4 by decide. So every genuine witness is in particular a sign edge — the sign door graph never fails to see a witness ON SIGN. The gap is entirely elsewhere: an opposite-sign side need not be antipodal (+1→−2), and, because Compl is symmetric while dir counts only the +→− orientation, a complementary spoke oriented −→+ is not a door at all. The sign bit is a necessary but insufficient shadow of the Tucker-witness relation."
+    "content": "Compl x y := x = negL y is exact antipodality on the four labels; compl_imp_opposite_sign proves Compl x y ⇒ sgn x = sgn y + 1 over all Fin 4 × Fin 4 by decide. So every genuine witness is in particular a sign edge — the sign door graph never fails to see a witness ON SIGN. The gap is entirely elsewhere: an opposite-sign side need not be antipodal (+1→−2), and, because Compl is symmetric while dir counts only the +→− orientation, a complementary spoke oriented −→+ is not a door at all. The sign bit is a necessary but insufficient shadow of the Tucker-witness relation.",
+    "mathContext": "$\\mathrm{Compl}\\,x\\,y \\Rightarrow \\mathrm{sgn}\\,x = \\mathrm{sgn}\\,y + 1$ in $\\mathbb{Z}/2$, i.e. antipodal labels always carry opposite sign bits. The converse is false, so $\\mathrm{sgn}$ is a strict over-relaxation of $\\mathrm{Compl}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "exact antipodality (negL involution)",
+      "parity / ZMod 2 sign bit",
+      "necessary vs. sufficient conditions",
+      "relaxation of a relation to its shadow"
+    ],
+    "prerequisites": [
+      "negL = ![2,3,0,1] and sgn = ![0,0,1,1] on Fin 4",
+      "DecidableRel Compl (decEq x (negL y))",
+      "arithmetic in ZMod 2"
+    ]
   },
   {
     "id": "ann-subcount-sperner-oq02-oq09",
@@ -30,7 +57,20 @@
     },
     "type": "insight",
     "title": "The genuine interior witnesses are a sub-count of the three seed rooms",
-    "content": "intDoorCompl a b c d i tests whether room i's single interior directed door (on spoke d→vᵢ or v_{i+1}→d) sits on an actually-complementary pair; interiorComplDoor counts the interior degree-1 rooms with that test true. interiorComplDoor_le_interiorDeg1 decides interiorComplDoor ≤ interiorDeg1 (= 3) over all 256 labellings: whatever true interior witnesses exist are among the three seed rooms. The seed therefore contains the interior witnesses it finds — but, as the separation below shows, it may find none."
+    "content": "intDoorCompl a b c d i tests whether room i's single interior directed door (on spoke d→vᵢ or v_{i+1}→d) sits on an actually-complementary pair; interiorComplDoor counts the interior degree-1 rooms with that test true. interiorComplDoor_le_interiorDeg1 decides interiorComplDoor ≤ interiorDeg1 (= 3) over all 256 labellings: whatever true interior witnesses exist are among the three seed rooms. The seed therefore contains the interior witnesses it finds — but, as the separation below shows, it may find none.",
+    "mathContext": "$\\mathrm{interiorComplDoor}\\,a\\,b\\,c\\,d \\le \\mathrm{interiorDeg1}\\,a\\,b\\,c\\,d = 3$ pointwise over all $256$ labellings. The genuine-witness count is a Finset sub-cardinality of the degree-1 interior seed, obtained by conjoining the `intDoorCompl` Boolean test to the seed predicate.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset cardinality sub-count (#{...})",
+      "interior spoke door vs. boundary edge door",
+      "path-following degree-1 (terminal) rooms",
+      "predicate refinement by conjunction"
+    ],
+    "prerequisites": [
+      "interiorDeg1_eq_three (the seed is always three, from oq-02-oq-08)",
+      "intDoor / roomDoor door counts on disc rooms",
+      "Finset filtering and card monotonicity"
+    ]
   },
   {
     "id": "ann-witnessfree-sperner-oq02-oq09",
@@ -41,7 +81,20 @@
     },
     "type": "theorem",
     "title": "The interior seed can be entirely witness-free — yet Tucker holds on the boundary",
-    "content": "interior_seed_can_be_witness_free decides that at a = b = c = +1 (= 0), centre d = +2 (= 1) the directed rule still fires interiorDeg1 = 3 interior degree-1 rooms, yet interiorComplDoor = 0: none of the three doors is genuinely complementary. The mechanism is exact — every boundary vertex is ±1, so the centre label +2 has its antipode −2 absent from the whole boundary, and no interior spoke can be antipodal to the centre; all three seed doors are opposite-sign-but-not-antipodal. tucker_witness_is_on_boundary_there then decides that Tucker nonetheless holds at that labelling, its complementary edge being the BOUNDARY edge v₂–v₃ = (+1,−1) = Compl (V 0 0 0 2) (V 0 0 0 (rot 2)). The true witness lives exactly where the interior seed cannot see it — the sharp reason the pivot-terminal identification needs more than the sign-door count."
+    "content": "interior_seed_can_be_witness_free decides that at a = b = c = +1 (= 0), centre d = +2 (= 1) the directed rule still fires interiorDeg1 = 3 interior degree-1 rooms, yet interiorComplDoor = 0: none of the three doors is genuinely complementary. The mechanism is exact — every boundary vertex is ±1, so the centre label +2 has its antipode −2 absent from the whole boundary, and no interior spoke can be antipodal to the centre; all three seed doors are opposite-sign-but-not-antipodal. tucker_witness_is_on_boundary_there then decides that Tucker nonetheless holds at that labelling, its complementary edge being the BOUNDARY edge v₂–v₃ = (+1,−1) = Compl (V 0 0 0 2) (V 0 0 0 (rot 2)). The true witness lives exactly where the interior seed cannot see it — the sharp reason the pivot-terminal identification needs more than the sign-door count.",
+    "mathContext": "At $(a,b,c,d) = (+1,+1,+1,+2)$: $\\mathrm{interiorDeg1} = 3$ but $\\mathrm{interiorComplDoor} = 0$; simultaneously $\\mathrm{Compl}(v_2, v_3)$ holds with $(v_2,v_3) = (+1,-1)$ on the boundary. The centre $+2$ has antipode $-2 \\notin$ boundary $= \\{\\pm 1\\}$, so no interior spoke is antipodal to it.",
+    "significance": "key",
+    "relatedConcepts": [
+      "obstruction / scoping certificate",
+      "Freund–Todd signed-pivot terminal room",
+      "interior vs. boundary witness location",
+      "antipode absent from the boundary"
+    ],
+    "prerequisites": [
+      "Compl and the negL antipodal encoding",
+      "the interiorComplDoor sub-count definition",
+      "kernel decide on a fixed concrete labelling"
+    ]
   },
   {
     "id": "ann-notconstant-sperner-oq02-oq09",
@@ -52,6 +105,19 @@
     },
     "type": "insight",
     "title": "The complementary count is a genuine function of the labelling, and orientation blindness is explicit",
-    "content": "interiorComplDoor_not_constant decides interiorComplDoor = 0 at (+1,+1,+1,+2) and = 3 at (+1,+1,+1,+1): the genuine interior witness count ranges over the labellings even though interiorDeg1 is the constant 3, so no fixed fraction of the seed is witness. orientation_blind_witness exhibits the concrete under-count cause: at a = b = c = d = +1 the interior spoke v₃ → d = (−1) → (+1) is genuinely complementary (Compl (V 0 0 0 3) 0, since negL 0 = 2 = V 0 0 0 3) but its directed door is 0 — the +→− rule does not count the −→+ orientation. Over- and under-counting together sever the sign-door count from the true complementary count."
+    "content": "interiorComplDoor_not_constant decides interiorComplDoor = 0 at (+1,+1,+1,+2) and = 3 at (+1,+1,+1,+1): the genuine interior witness count ranges over the labellings even though interiorDeg1 is the constant 3, so no fixed fraction of the seed is witness. orientation_blind_witness exhibits the concrete under-count cause: at a = b = c = d = +1 the interior spoke v₃ → d = (−1) → (+1) is genuinely complementary (Compl (V 0 0 0 3) 0, since negL 0 = 2 = V 0 0 0 3) but its directed door is 0 — the +→− rule does not count the −→+ orientation. Over- and under-counting together sever the sign-door count from the true complementary count.",
+    "mathContext": "$\\mathrm{interiorComplDoor} = 0$ at $(+1,+1,+1,+2)$ and $= 3$ at $(+1,+1,+1,+1)$ while $\\mathrm{interiorDeg1} \\equiv 3$; and $\\mathrm{Compl}(v_3, d) \\wedge \\mathrm{dir}(\\mathrm{sgn}\\,v_3, \\mathrm{sgn}\\,d) = 0$ at $a=b=c=d=+1$, the spoke $(-1)\\to(+1)$ complementary but not a directed door.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orientation blindness of a directed rule",
+      "symmetric relation vs. oriented door indicator",
+      "under-counting vs. over-counting",
+      "labelling-dependent (non-constant) invariant"
+    ],
+    "prerequisites": [
+      "dir : ZMod 2 → ZMod 2 → ℕ directed door indicator",
+      "symmetry of Compl (x = negL y ⇔ y = negL x)",
+      "kernel decide on the two witness labellings"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sperner-mathlib4-oq-02-oq-09` (The Interior Seed Can Be Witness-Free).

## Gap addressed
All 5 annotations carried only `content`/`title`/`type`/`range` — missing the depth fields the quality target requires. This adds to **every** annotation:

- **`mathContext`** — LaTeX statement of each result: the sign shadow $\mathrm{sgn}:\mathrm{Fin}\,4\to\mathbb{Z}/2$ vs exact antipodality $\mathrm{Compl}\,x\,y:=x=\mathrm{negL}\,y$; the headline $\mathrm{interiorDeg1}=3,\ \mathrm{interiorComplDoor}=0$ separation at $(+1,+1,+1,+2)$ with the boundary witness $(+1,-1)$; the sub-count bound; and the orientation-blind spoke.
- **`significance`** — context / supporting / key per annotation.
- **`relatedConcepts`** + **`prerequisites`** — Tucker's lemma / Borsuk–Ulam, the negL involution, ZMod 2 parity, Finset sub-cardinality, kernel `decide`, and the sibling seed entry oq-02-oq-08.

## Notes
- Annotation **content unchanged**; only added fields. `meta.json` untouched (already richly enriched: 5 sections, 4 keyInsights, full conclusion, 3 crossRefs).
- All claims verified against the Lean source `SpernerTuckerHexagonInteriorSeedWitnessGap.lean`.
- Verified valid JSON (5 annotations, schema-conformant). Single-file diff (+71/−5).

_Note: committed via git plumbing because the host disk is at 100% capacity and full worktree checkouts are being wiped by emergency cleanup; pnpm build was substituted with JSON.parse validation + schema conformance check._