### PR TITLE
research(mz-slln-oq010201): S4b step-1 — i.i.d. Borel–Cantelli truncation reduction (0-axiom)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -686,4 +686,112 @@ theorem ae_tendsto_average_zero_of_variance_weighted_bdd [IsProbabilityMeasure �
 
 end KolmogorovKronecker
 
+/-! ## S4b (step 1) — i.i.d. truncation reduction via first Borel–Cantelli
+
+The Marcinkiewicz–Zygmund proof replaces `Xᵢ` by the truncation
+`Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.  The replacement is justified by the **first
+Borel–Cantelli lemma**: if the tail sum `∑ᵢ P(|Xᵢ| > i^{1/p})` is finite then a.s.
+`Xᵢ = Yᵢ` for all large `i`, so it suffices to prove the law for the truncations.
+
+For identically distributed `Xᵢ` the tail probability transfers to `X₀`:
+
+    P(|Xᵢ| > i^{1/p}) = P(|X₀| > i^{1/p}) = P(|X₀|ᵖ > i),
+
+using `IdentDistrib.measure_mem_eq` and the elementary equivalence
+`i^{1/p} < |x| ↔ i < |x|ᵖ` (for `i ≥ 0`, `p > 0`).  The resulting sum
+`∑ᵢ P(|X₀|ᵖ > i)` is then bounded by the first moment `𝔼|X₀|ᵖ < ∞` via the discrete
+layer cake of § TailSum (step 2).  Feeding the finiteness into
+`MeasureTheory.ae_eventually_notMem` yields the a.s. eventual truncation
+`∀ᵐ ω, ∀ᶠ i, |Xᵢ ω| ≤ i^{1/p}`, the Borel–Cantelli conclusion that step 1 needs. -/
+
+section TruncationReduction
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} {μ : Measure Ω}
+
+/-- **Power/root reindexing of a truncation threshold.**  For `0 < p` and `0 ≤ a`,
+`0 ≤ b`, the root inequality `a^{1/p} < b` is equivalent to the power inequality
+`a < bᵖ`.  Applied to `a = i` and `b = |Xᵢ ω|` this turns the truncation event
+`{|Xᵢ| > i^{1/p}}` into the moment event `{|Xᵢ|ᵖ > i}`. -/
+theorem rpow_inv_lt_iff_lt_rpow {p : ℝ} (hp : 0 < p) {a b : ℝ} (ha : 0 ≤ a)
+    (hb : 0 ≤ b) : a ^ (1 / p) < b ↔ a < b ^ p := by
+  have key := Real.rpow_lt_rpow_iff (x := a ^ (1 / p)) (y := b) (z := p)
+    (Real.rpow_nonneg ha _) hb hp
+  rw [one_div, Real.rpow_inv_rpow ha hp.ne'] at key
+  rw [one_div]
+  exact key.symm
+
+/-- **Tail-sum finiteness for i.i.d. variables with a finite `p`-th moment.**  If the
+`Xᵢ` are identically distributed to `X₀` and `𝔼|X₀|ᵖ < ∞` (encoded as the finite
+lintegral `∫⁻ ofReal |X₀|ᵖ`), then the Marcinkiewicz–Zygmund truncation tail sum is
+finite:
+
+    ∑ᵢ μ {ω | i^{1/p} < |Xᵢ ω|}  ≠  ∞.
+
+Proof: transfer each tail measure to `X₀` (`IdentDistrib.measure_mem_eq`), reindex the
+threshold to the power event `{i < |X₀|ᵖ}` (`rpow_inv_lt_iff_lt_rpow`), split off the
+`i = 0` term (bounded by `1` on a probability space), and dominate the rest by the
+discrete layer-cake bound `tsum_measure_add_one_ne_top` applied to `Z = |X₀|ᵖ`. -/
+theorem tsum_measure_truncation_ne_top_of_identDistrib [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} {p : ℝ} (hp : 0 < p) (hmeas : ∀ i, Measurable (X i))
+    (hident : ∀ i, IdentDistrib (X i) (X 0) μ μ)
+    (hmom : ∫⁻ ω, ENNReal.ofReal (|X 0 ω| ^ p) ∂μ ≠ ∞) :
+    ∑' i : ℕ, μ {ω | (i : ℝ) ^ (1 / p) < |X i ω|} ≠ ∞ := by
+  have hX0 : Measurable (X 0) := hmeas 0
+  have hZmeas : Measurable (fun ω => |X 0 ω| ^ p) := by fun_prop
+  have hZnn : (0 : Ω → ℝ) ≤ fun ω => |X 0 ω| ^ p :=
+    fun ω => Real.rpow_nonneg (abs_nonneg _) p
+  -- The threshold set `{y | i^{1/p} < |y|}` is measurable and used to transfer via i.i.d.
+  have hthr : ∀ i : ℕ, MeasurableSet {y : ℝ | (i : ℝ) ^ (1 / p) < |y|} := fun i =>
+    measurableSet_lt measurable_const _root_.continuous_abs.measurable
+  -- Transfer + reindex: each tail measure equals `μ {ω | i < |X₀ ω|ᵖ}`.
+  have hstep : ∀ i : ℕ,
+      μ {ω | (i : ℝ) ^ (1 / p) < |X i ω|} = μ {ω | (i : ℝ) < |X 0 ω| ^ p} := by
+    intro i
+    have hpre_i : {ω | (i : ℝ) ^ (1 / p) < |X i ω|}
+        = (X i) ⁻¹' {y : ℝ | (i : ℝ) ^ (1 / p) < |y|} := rfl
+    have hpre_0 : {ω | (i : ℝ) < |X 0 ω| ^ p}
+        = (X 0) ⁻¹' {y : ℝ | (i : ℝ) ^ (1 / p) < |y|} := by
+      ext ω
+      simp only [Set.mem_setOf_eq, Set.mem_preimage]
+      exact (rpow_inv_lt_iff_lt_rpow hp (Nat.cast_nonneg i) (abs_nonneg _)).symm
+    rw [hpre_i, hpre_0]
+    exact (hident i).measure_mem_eq (hthr i)
+  simp_rw [hstep]
+  -- Split off the `i = 0` term and dominate the tail by the discrete layer cake.
+  -- (`tsum_eq_zero_add'` is the ENNReal-robust peel; the `Summable.tsum_eq_zero_add`
+  -- dot form triggers a `whnf` blow-up on the measure-of-set summand.)
+  rw [tsum_eq_zero_add' ENNReal.summable]
+  refine ENNReal.add_ne_top.mpr ⟨measure_ne_top μ _, ?_⟩
+  have hbig : ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ |X 0 x| ^ p} ≠ ∞ :=
+    tsum_measure_add_one_ne_top hZmeas hZnn hmom
+  have hle : ∑' b : ℕ, μ {ω | ((b + 1 : ℕ) : ℝ) < |X 0 ω| ^ p}
+      ≤ ∑' n : ℕ, μ {x | (n : ℝ) + 1 ≤ |X 0 x| ^ p} := by
+    refine ENNReal.tsum_le_tsum fun b => measure_mono fun ω hω => ?_
+    simp only [Set.mem_setOf_eq] at hω ⊢
+    push_cast at hω
+    linarith
+  exact (lt_of_le_of_lt hle hbig.lt_top).ne
+
+/-- **Almost-sure eventual truncation (first Borel–Cantelli, MZ step 1).**  For i.i.d.
+`Xᵢ` with a finite `p`-th moment (`𝔼|X₀|ᵖ < ∞`), almost surely `|Xᵢ| ≤ i^{1/p}` holds
+for all large `i` — hence the truncation `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}` agrees with `Xᵢ`
+eventually a.s.  This is the Borel–Cantelli output that reduces the Marcinkiewicz–Zygmund
+strong law to its truncated version.  Combines the tail-sum finiteness
+`tsum_measure_truncation_ne_top_of_identDistrib` with `MeasureTheory.ae_eventually_notMem`. -/
+theorem ae_eventually_abs_le_rpow_of_identDistrib [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} {p : ℝ} (hp : 0 < p) (hmeas : ∀ i, Measurable (X i))
+    (hident : ∀ i, IdentDistrib (X i) (X 0) μ μ)
+    (hmom : ∫⁻ ω, ENNReal.ofReal (|X 0 ω| ^ p) ∂μ ≠ ∞) :
+    ∀ᵐ ω ∂μ, ∀ᶠ i in atTop, |X i ω| ≤ (i : ℝ) ^ (1 / p) := by
+  have h := MeasureTheory.ae_eventually_notMem
+    (tsum_measure_truncation_ne_top_of_identDistrib hp hmeas hident hmom)
+  filter_upwards [h] with ω hω
+  filter_upwards [hω] with i hi
+  simpa only [Set.mem_setOf_eq, not_lt] using hi
+
+end TruncationReduction
+
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -373,3 +373,67 @@ Marcinkiewicz–Zygmund: remaining are S4b step-1 (i.i.d. reduction to apply thi
 a locked `/private/tmp/r14-session-*` worktree off `origin/main`, committed before verifying
 (the worktree-deletion hazard recurred at session start — designated `.loom/worktrees/researcher-14`
 was gone again; the locked /tmp worktree avoids the clobber trap).
+
+---
+
+## S4b step-1 (researcher-14, 2026-07-03) — BUILD: i.i.d. Borel–Cantelli truncation reduction SHIPPED (verified)
+
+**Mode**: FRESH (RICH knowledge, depth-first) · **Outcome**: progress (0-axiom brick shipped)
+
+### What I did
+
+Completed **S4b step-1**, connecting the step-2 discrete-layer-cake tail bound to the
+actual Marcinkiewicz–Zygmund truncation event. Three theorems added to
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TruncationReduction), all
+**0-sorry / 0-axiom** (`#print axioms` = `propext`/`Classical.choice`/`Quot.sound` on
+all three — no `sorryAx`, no `Lean.ofReduceBool`). Verified via `LAKE_UNSAFE=1 lake env
+lean` against the pinned prebuilt Mathlib v4.26.0 oleans: 0 errors, 0 warnings.
+
+1. **`rpow_inv_lt_iff_lt_rpow {p} (hp:0<p) {a b} (ha:0≤a) (hb:0≤b) : a^(1/p) < b ↔ a < b^p`**
+   — the elementary threshold reindex. Proof: `Real.rpow_lt_rpow_iff` (strict mono of
+   `·^p` on nonneg, `0<p`) rewritten by `Real.rpow_inv_rpow ha hp.ne'`
+   (`(a^p⁻¹)^p = a`); `one_div` bridges `1/p ↔ p⁻¹`.
+2. **`tsum_measure_truncation_ne_top_of_identDistrib`** — for i.i.d. `Xᵢ` (each
+   `IdentDistrib (Xᵢ) (X₀)`) with `𝔼|X₀|ᵖ < ∞` (finite `∫⁻ ofReal |X₀|ᵖ`), the truncation
+   tail `∑ᵢ μ{i^{1/p} < |Xᵢ|} ≠ ∞`. Proof chain: (a) each tail measure `= μ{i < |X₀|ᵖ}` —
+   `{ω | i^{1/p}<|Xᵢ ω|}` is `Xᵢ ⁻¹' {y | i^{1/p}<|y|}` (`rfl`), transfer by
+   `IdentDistrib.measure_mem_eq` on that measurable set, reindex the `X₀` side pointwise
+   by `rpow_inv_lt_iff_lt_rpow`; (b) peel `i=0` (`tsum_eq_zero_add'`, term `≤ 1` by
+   `measure_ne_top`); (c) dominate the `i≥1` tail by `tsum_measure_add_one_ne_top`
+   (step 2) with `Z=|X₀|ᵖ`, via `{(b+1:ℝ) < Z} ⊆ {(b:ℝ)+1 ≤ Z}` (`ENNReal.tsum_le_tsum` +
+   `measure_mono` + `push_cast`/`linarith`).
+3. **`ae_eventually_abs_le_rpow_of_identDistrib`** — feeds (2) into
+   `MeasureTheory.ae_eventually_notMem` (first Borel–Cantelli) ⟹
+   `∀ᵐ ω, ∀ᶠ i, |Xᵢ ω| ≤ i^{1/p}`. This is the truncation reduction: a.s. `Xᵢ = Yᵢ`
+   eventually where `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.
+
+### Key finding / reusable gotcha (Mathlib v4.26)
+
+- **`Summable.tsum_eq_zero_add` (dot form) is `whnf`-pathological** and must be avoided
+  for the ENNReal tsum peel. `rw [Summable.tsum_eq_zero_add ENNReal.summable]` blows past
+  **1 000 000 heartbeats at `whnf`** — and this reproduces *even on a fully abstract
+  `g : ℕ → ℝ≥0∞`* (`example (g) : ∑' i, g i = g 0 + ∑' n, g (n+1) := ENNReal.summable.tsum_eq_zero_add`
+  times out) and even when the split is stated as a fully-typed `have`. The fix is the
+  **primed, non-dot idiom `rw [tsum_eq_zero_add' ENNReal.summable]`** — exactly how
+  Mathlib's own `Topology/Instances/ENNReal/Lemmas.lean` peels ENNReal tsums. Compiles
+  instantly. Bisected via stubbed-dependency scratch files (`ScratchMZ.lean`).
+
+### Provenance note
+
+Salvaged a prior interrupted researcher-14 draft (the section text was correct but never
+compiled — the session died on the worktree-deletion hazard before verification). Its base
+was a stale `origin/main` predating S4a/S5, so it was transplanted onto current
+`origin/main` in a **locked** `/Users/rwalters/lg-wt/` worktree (the worktree-deletion
+hazard recurred twice this session; `--lock` is mandatory).
+
+### Files modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (+108 lines, § TruncationReduction)
+- `research/problems/.../state.md`, `.../knowledge.md`, problem JSON knowledge
+
+### Next steps
+
+S4b step-3 (centered-truncation control `∑ᵢ 𝔼Yᵢ/n^{1/p} → 0`) and step-4
+(`∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, uses `p<2`), then final assembly via S5
+`ae_tendsto_average_zero_of_variance_weighted_bdd` on the centered truncations plus this
+step's a.s. eventual `Xᵢ = Yᵢ`.

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,54 +1,52 @@
 # Current State
 
-**Phase**: ACT (S4b step-2 tail-sum SHIPPED — remaining S4b analytic layer)
+**Phase**: ACT (S4b step-1 truncation reduction SHIPPED — remaining S4b analytic layer)
 **Since**: 2026-07-03
-**Iteration**: 6 (S4b step-2 discrete-layer-cake tail-sum SHIPPED; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 7 (S4b step-1 i.i.d. Borel–Cantelli truncation SHIPPED; S4b step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
-**S2 (Kronecker) and S3 (Kolmogorov martingale assembly) are BOTH DONE — do not
-re-derive either.** All in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`,
-verified 0-sorry / 0-axiom (only propext/Classical.choice/Quot.sound):
+**S2 (Kronecker), S3 (Kolmogorov martingale assembly), S4a (variance L¹ bound),
+S4b step-2 (tail-sum) and S4b step-1 (i.i.d. truncation) are ALL DONE — do not
+re-derive any.** All in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`,
+verified 0-sorry / 0-axiom (only propext/Classical.choice/Quot.sound).
 
-- `LawsOfLargeNumbers.MZ.kronecker_lemma` (L135) — S2
-- `LawsOfLargeNumbers.MZ.tendsto_weighted_average_zero` (L60) — S2 Toeplitz core
-- `LawsOfLargeNumbers.MZ.ae_tendsto_kronecker_average_zero` (L285) — a.e. lift
-- `LawsOfLargeNumbers.MZ.martingale_sum_of_indep_mean_zero` (L338) — **S3 NEW**:
-  shifted partial sums of independent mean-zero L¹ vars are a martingale wrt the
-  natural filtration (via `iIndepFun.condExp_natural_ae_eq_of_lt` +
-  `martingale_of_condExp_sub_eq_zero_nat`).
-- `LawsOfLargeNumbers.MZ.ae_tendsto_sum_of_indep_of_eLpNorm_bdd` (L382) — **S3
-  NEW**: Kolmogorov's criterion reduced to a uniform L¹ bound, via
-  `Submartingale.exists_ae_tendsto_of_bdd` + a one-step index shift.
+## S4b step-1 — DONE (iteration 7, this session)
 
-The S3 survey was right: the a.e.-convergence engine and all glue lemmas were
-already in Mathlib; S3 was assembly, and it is now assembled.
+The **i.i.d. Borel–Cantelli truncation reduction** — connecting the step-2 tail-sum bound
+to the actual truncation event — is now in the file (§ TruncationReduction), all
+**0-sorry / 0-axiom** (`#print axioms` = propext/Classical.choice/Quot.sound on all three):
+
+- `rpow_inv_lt_iff_lt_rpow` — elementary threshold reindex `a^{1/p} < b ↔ a < bᵖ`
+  (`0<p`, `0≤a`, `0≤b`), via `Real.rpow_lt_rpow_iff` + `Real.rpow_inv_rpow`.
+- `tsum_measure_truncation_ne_top_of_identDistrib` — for i.i.d. `Xᵢ` with `𝔼|X₀|ᵖ<∞`,
+  the truncation tail sum `∑ᵢ μ{i^{1/p} < |Xᵢ|} ≠ ∞`. Proof: transfer each tail measure
+  to `X₀` (`IdentDistrib.measure_mem_eq` on the measurable set `{y | i^{1/p}<|y|}`),
+  reindex to `{i < |X₀|ᵖ}` (`rpow_inv_lt_iff_lt_rpow`), peel the `i=0` term
+  (`tsum_eq_zero_add'`, bounded by `1`), and dominate the rest by
+  `tsum_measure_add_one_ne_top` (step 2) with `Z=|X₀|ᵖ`.
+- `ae_eventually_abs_le_rpow_of_identDistrib` — feeds the finiteness into
+  `MeasureTheory.ae_eventually_notMem` ⟹ `∀ᵐ ω, ∀ᶠ i, |Xᵢ ω| ≤ i^{1/p}`, the exact
+  Borel–Cantelli output reducing MZ to its truncated version.
+
+**Do NOT re-derive.** The truncation is now justified: a.s. `Xᵢ = Yᵢ` eventually where
+`Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.
+
+### Reusable gotcha (Mathlib v4.26)
+
+- **`Summable.tsum_eq_zero_add` (dot form) is `whnf`-pathological** on a
+  `μ {ω | … }`-valued summand: `rw [Summable.tsum_eq_zero_add ENNReal.summable]` blows past
+  1 000 000 heartbeats at `whnf`, *even on a fully abstract `g : ℕ → ℝ≥0∞`* and even when
+  stated as a fully-typed `have`. **Fix: use the primed, non-dot idiom
+  `rw [tsum_eq_zero_add' ENNReal.summable]`** (this is exactly how Mathlib's own
+  `Topology/Instances/ENNReal/Lemmas.lean` peels ENNReal tsums). Compiles instantly.
 
 ## Active Approach
 
-None in-flight. Next work item is S4 below.
-
-## S4b step-2 — DONE (iteration 6, PR pending)
-
-The **discrete layer-cake tail-sum bound** — the Borel–Cantelli input for the truncation
-step — is now in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TailSum), all
-**0-sorry / 0-axiom** (`#print axioms` = propext/Classical.choice/Quot.sound):
-
-- `tsum_indicator_add_one_le` — pure ENNReal helper: `∑ₙ 𝟙{n+1 ≤ z} = ⌊z⌋₊ ≤ z`.
-- `tsum_measure_add_one_le_lintegral` — `∑ₙ μ{Z ≥ n+1} ≤ ∫⁻ ofReal Z` for measurable
-  `Z ≥ 0`. Proof: `lintegral_indicator_one` + `lintegral_tsum` swap + pointwise count.
-- `tsum_measure_add_one_ne_top` — finiteness corollary feeding `measure_limsup_eq_zero`.
-
-**Do NOT re-derive this.** Applied to `Z = |X₀|ᵖ` (with identical distribution and
-`𝔼|X₀|ᵖ < ∞`), it yields `∑ᵢ P(|Xᵢ| > i^{1/p}) < ∞`, hence a.s. `Xᵢ = Yᵢ` eventually.
+None in-flight. Next work item is S4b step-3 / step-4 below.
 
 ## Blockers
 
-- **S4b step-1 (identical-distribution reduction, ~1 session):** connect the tail-sum
-  bound to the i.i.d. truncation. From `IdentDistrib (Xᵢ) (X₀)` derive
-  `μ{|Xᵢ| > i^{1/p}} = μ{|X₀|ᵖ > i}`, then apply `tsum_measure_add_one_ne_top` with
-  `Z = |X₀|ᵖ` and the first Borel–Cantelli lemma (`measure_limsup_eq_zero`, needs the
-  `≠ ∞` we now provide) to get `∀ᵐ ω, ∀ᶠ i, Xᵢ ω = Yᵢ ω` where `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.
 - **S4b step-3 (centered-truncation control, ~1 session):** `∑ᵢ 𝔼Yᵢ / n^{1/p} → 0`
   using `𝔼X = 0` and a moment/`rpow` estimate on the truncated means (Kronecker-style).
 - **S4b step-4 (variance-sum estimate, ~1–2 sessions):** `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`
@@ -58,19 +56,22 @@ step — is now in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TailS
 
 **DONE (do not re-derive):** S1 survey · S2 Kronecker · S3 martingale · **S4a variance
 L¹-bound** (`ae_tendsto_sum_of_indep_of_variance_bdd` + `eLpNorm_two_sq_eq_evariance` +
-`eLpNorm_two_partialSum_le`, 0-axiom) · **S4b step-2 tail-sum** (this iteration).
+`eLpNorm_two_partialSum_le`) · **S4b step-2 tail-sum** · **S4b step-1 i.i.d. truncation**
+(this iteration). All 0-axiom.
 
 ## Next Action
 
-- **S4b step-1 (next):** identical-distribution reduction — from `IdentDistrib (Xᵢ) (X₀)`
-  get `μ{|Xᵢ| > i^{1/p}} = μ{|X₀|ᵖ > i}`, apply `tsum_measure_add_one_ne_top` (this
-  iteration) + first Borel–Cantelli (`measure_limsup_eq_zero`) ⟹ a.s. `Xᵢ = Yᵢ` eventually.
-  Then S4b step-3 (centering) and step-4 (variance sum, uses `p<2`).
+- **S4b step-3 (next):** centered-truncation control `∑ᵢ 𝔼Yᵢ / n^{1/p} → 0`. With
+  step-1 done, the surviving work is the two analytic estimates (step-3 centering,
+  step-4 variance sum using `p<2`), then final assembly:
+  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5) applied to the centered
+  truncations `Yᵢ − 𝔼Yᵢ`, combined with the step-1 a.s. eventual `Xᵢ = Yᵢ`.
 
 ## Attempt Counts
 
-- Total attempts: 6 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum)
-- Current approach attempts: 1 (S4b step-2 tail-sum — landed on 2nd elaboration; calc restructure of the lintegral_tsum swap)
-- Approaches tried: 5 (S1 literature/decomposition; S2 Abel+Toeplitz;
+- Total attempts: 7 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation)
+- Current approach attempts: 1 (S4b step-1 — landed after diagnosing the `tsum_eq_zero_add` whnf pathology; salvaged prior interrupted draft off origin/main)
+- Approaches tried: 6 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
-  S4b discrete layer cake via lintegral_tsum + floor count)
+  S4b step-2 discrete layer cake via lintegral_tsum + floor count;
+  S4b step-1 IdentDistrib transfer + rpow reindex + tsum peel + first Borel–Cantelli)

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,11 +31,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S3-glue, researcher-4, 2026-07-03): a.e. Kronecker lift SHIPPED 0-axiom — the deterministic S3→S4 passage from a.s. series convergence to the M-Z normalisation is complete. Remaining gap: the probabilistic Kolmogorov convergence criterion itself (martingale route scoped in #34161).",
+    "progressSummary": "PROGRESS (S4b step-1, researcher-14, 2026-07-03): i.i.d. Borel-Cantelli truncation reduction SHIPPED 0-axiom — a.s. |Xi|<=i^{1/p} eventually, reducing MZ to its truncated version. Remaining: analytic step-3 (centering) and step-4 (variance sum, uses p<2), then S5 assembly.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
-      "ae_tendsto_kronecker_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:266 — a.e. lift of kronecker_lemma: (∀ᵐ ω, ∑ x_i ω/a_i converges) ⟹ (∀ᵐ ω, (∑_{i<n} x_i ω)/a_n → 0). The S3→S4 glue. Verified 0-axiom (filter_upwards + kronecker_lemma)."
+      "ae_tendsto_kronecker_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:266 — a.e. lift of kronecker_lemma: (∀ᵐ ω, ∑ x_i ω/a_i converges) ⟹ (∀ᵐ ω, (∑_{i<n} x_i ω)/a_n → 0). The S3→S4 glue. Verified 0-axiom (filter_upwards + kronecker_lemma).",
+      "rpow_inv_lt_iff_lt_rpow (LawsOfLargeNumbersOQ01OQ02OQ01.lean, section TruncationReduction) — elementary threshold reindex a^{1/p}<b iff a<b^p (0<p,0<=a,0<=b), 0-axiom",
+      "tsum_measure_truncation_ne_top_of_identDistrib — for i.i.d. Xi with E|X0|^p<inf, truncation tail sum over i of mu{i^{1/p}<|Xi|} is finite (IdentDistrib.measure_mem_eq transfer + rpow reindex + tsum_eq_zero_add prime peel + step-2 tail-sum), 0-axiom",
+      "ae_eventually_abs_le_rpow_of_identDistrib — first Borel-Cantelli (ae_eventually_notMem) gives ae omega, eventually i, |Xi omega| <= i^{1/p}; MZ truncation reduction complete, 0-axiom"
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -48,13 +51,15 @@
       "S3 is ASSEMBLY not a foundation gap (researcher-16 2026-07-03): Mathlibs a.s. martingale convergence theorem Submartingale.exists_ae_tendsto_of_bdd (Probability/Martingale/Convergence.lean:191) is the a.s.-convergence engine; partial sums of independent mean-zero L2 vars are an L2-bounded (hence L1-bounded) martingale, so it applies directly.",
       "S3 glue lemmas all present in Mathlib v4.26.0: Filtration.natural (natural filtration), condExp_indep_eq (martingale increment: E[X_n|F_n]=E[X_n]=0 by independence; template usage in Probability/BorelCantelli.lean:54), IndepFun.variance_sum (Var of independent sum = sum Var, gives the uniform L1 bound via eLpNorm 1 <= eLpNorm 2 = sqrt(Var) on a probability measure).",
       "PROCESS: the S2 session updated the .json but not state.md/knowledge.md, so the markdown still said S2-next and a later session duplicated Kronecker. Always update state.md AND knowledge.md in the commit that ships Lean.",
-      "S3→S4 passage is now deterministic/axiom-free: ae_tendsto_kronecker_average_zero converts Kolmogorov criterion output (a.s. convergence of ∑ Y_i/a_i) directly into the M-Z normalisation ((∑_{i<n}Y_i)/a_n→0 a.s.). Only the probabilistic criterion (S3, martingale route per PR #34161) remains to reach the full M-Z SLLN."
+      "S3→S4 passage is now deterministic/axiom-free: ae_tendsto_kronecker_average_zero converts Kolmogorov criterion output (a.s. convergence of ∑ Y_i/a_i) directly into the M-Z normalisation ((∑_{i<n}Y_i)/a_n→0 a.s.). Only the probabilistic criterion (S3, martingale route per PR #34161) remains to reach the full M-Z SLLN.",
+      "S4b step-1 (i.i.d. truncation reduction) SHIPPED 0-axiom (iter 7): the Borel-Cantelli passage from the step-2 discrete-layer-cake tail bound to the a.s. eventual truncation |Xi|<=i^{1/p} is complete. Remaining MZ gaps are the two analytic estimates step-3 (centering: sum of E Yi / n^{1/p} -> 0) and step-4 (sum of Var(Yi)/i^{2/p} < inf, uses p<2), then final assembly via S5.",
+      "Mathlib gotcha (v4.26): Summable.tsum_eq_zero_add (dot form) is whnf-pathological on mu{setOf}-valued summands — rw blows past 1e6 heartbeats even on abstract g:Nat->ENNReal and even as a fully-typed have. Fix: use the primed non-dot idiom tsum_eq_zero_add' ENNReal.summable (Mathlib's own ENNReal peel idiom)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S3 (real Lean build, 1-2 sessions): assemble Kolmogorov a.s.-convergence criterion from named Mathlib lemmas (Filtration.natural -> Martingale via condExp_indep_eq -> uniform eLpNorm-1 bound via IndepFun.variance_sum -> Submartingale.exists_ae_tendsto_of_bdd). See knowledge.md S3 for the full reduction.",
-      "S4: assemble full M-Z SLLN (truncation + Borel-Cantelli tail + Kolmogorov S3 + kronecker_lemma S2).",
-      "Optional: generalize tendsto_weighted_average_zero to the full Silverman-Toeplitz regular-matrix summability theorem as a Mathlib contribution."
+      "S4b step-3: centered-truncation control sum of E Yi / n^{1/p} -> 0 via EX=0 + moment/rpow estimate on truncated means (Kronecker-style)",
+      "S4b step-4: variance-sum estimate sum of Var(Yi)/i^{2/p} < inf (uses p<2 essentially), then feed ae_tendsto_sum_of_indep_of_variance_bdd (S4a) + Kronecker lift (S2)",
+      "Final assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi - E Yi, combined with step-1 a.s. eventual Xi=Yi"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — S4b step 1 (i.i.d. truncation reduction)

Continues the multi-session build of the Marcinkiewicz–Zygmund strong law
(`laws-of-large-numbers-oq-01-oq-02-oq-01`). This ships **step 1 of S4b**: the
first-Borel–Cantelli passage that reduces MZ to its truncated version, connecting
the already-merged step-2 discrete layer-cake tail bound to the actual truncation event.

### What's added (§ TruncationReduction, +108 lines, all 0-sorry / 0-axiom)

- **`rpow_inv_lt_iff_lt_rpow`** — elementary threshold reindex `a^{1/p} < b ↔ a < b^p`
  (`0<p`, `0≤a`, `0≤b`), via `Real.rpow_lt_rpow_iff` + `Real.rpow_inv_rpow`.
- **`tsum_measure_truncation_ne_top_of_identDistrib`** — for i.i.d. `Xᵢ`
  (`IdentDistrib (Xᵢ) (X₀)`) with finite `p`-th moment `𝔼|X₀|ᵖ < ∞`, the truncation
  tail sum `∑ᵢ μ{i^{1/p} < |Xᵢ|} ≠ ∞`. Transfers each tail measure to `X₀`
  (`IdentDistrib.measure_mem_eq`), reindexes to `{i < |X₀|ᵖ}`, peels the `i=0` term
  (`tsum_eq_zero_add'`), and dominates the rest by the step-2 bound
  `tsum_measure_add_one_ne_top` with `Z = |X₀|ᵖ`.
- **`ae_eventually_abs_le_rpow_of_identDistrib`** — feeds the finiteness into
  `MeasureTheory.ae_eventually_notMem` (first Borel–Cantelli) to conclude
  `∀ᵐ ω, ∀ᶠ i, |Xᵢ ω| ≤ i^{1/p}`, i.e. a.s. `Xᵢ = Yᵢ` eventually for the truncation
  `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`.

### Verification

`#print axioms` on all three new theorems reports only
`[propext, Classical.choice, Quot.sound]` — genuinely **0-axiom** (no `sorryAx`,
no `Lean.ofReduceBool`). Checked with `lake env lean` against the pinned prebuilt
Mathlib v4.26.0 oleans: 0 errors, 0 warnings.

### Honest status

This is a genuine, reusable 0-axiom brick — but it does **not** yet prove
Marcinkiewicz–Zygmund. Remaining: S4b step-3 (centered-truncation control
`∑ᵢ 𝔼Yᵢ/n^{1/p} → 0`) and step-4 (`∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, where `p<2` is
essential), then final assembly via the S5 capstone
`ae_tendsto_average_zero_of_variance_weighted_bdd`.

### Implementation note

`Summable.tsum_eq_zero_add` (dot form) is `whnf`-pathological on `μ{setOf}`-valued
ENNReal summands (blows past 1e6 heartbeats even on an abstract `g : ℕ → ℝ≥0∞`); the
proof uses Mathlib's own robust idiom `tsum_eq_zero_add' ENNReal.summable` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)