### PR TITLE
Enrich Jacobi-Trudi Identity: correct stale sorry claims, add SSYT + cycle-lemma coverage

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/annotations.json
@@ -3,12 +3,12 @@
     "id": "ann-jt-header",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 1,
-      "endLine": 29
+      "startLine": 27,
+      "endLine": 39
     },
     "type": "concept",
     "title": "Jacobi-Trudi Identity: Historical and Mathematical Context",
-    "content": "The Jacobi-Trudi identity (1841) is one of the foundational formulas of algebraic combinatorics. It expresses Schur polynomials \u2014 characters of GL(n) representations and a natural basis for symmetric functions \u2014 as determinants of complete homogeneous symmetric polynomials h_n. This file provides the first Lean 4 definition of Schur polynomials using this formula as the primary definition. The namespace JacobiTrudi works over a general commutative ring R with a general finite type \u03c3 for variables, making all results fully abstract.\n\nThe three imports define the full dependency: `MvPolynomial.Symmetric.Defs` supplies `hsymm` (the h_n polynomials), `rename_hsymm`, and `IsSymmetric`; `Matrix.Determinant.Basic` supplies `Matrix.det`, `det_fin_zero`, `det_fin_one`, `det_fin_two`, and `AlgHom.map_det`; the parent file `BallotProblemOQ03OQ01OQ01` provides the LGV infrastructure that the combinatorial proof ultimately requires. The `open MvPolynomial Matrix Finset` declaration avoids namespace prefixes throughout.",
+    "content": "The Jacobi-Trudi identity (1841) is one of the foundational formulas of algebraic combinatorics. It expresses Schur polynomials \u2014 characters of GL(n) representations and a natural basis for symmetric functions \u2014 as determinants of complete homogeneous symmetric polynomials h_n. This file provides the first Lean 4 definition of Schur polynomials using this formula as the primary definition. The namespace JacobiTrudi works over a general commutative ring R with a general finite type \u03c3 for variables, making all results fully abstract.\n\nThe imports split into two groups. The algebraic core: `MvPolynomial.Symmetric.Defs` supplies `hsymm` (the h_n polynomials), `rename_hsymm`, and `IsSymmetric`; `Matrix.Determinant.Basic` supplies `Matrix.det`, `det_fin_zero`, `det_fin_one`, `det_fin_two`, and `AlgHom.map_det`. The combinatorial core, added to support the SSYT generating-function definition and the k=2 bijection: `Data.Sym.Card` (multiset cardinality / stars-and-bars), `Data.Fintype.BigOperators`, `Data.Multiset.Sort` (sorted-list representatives of symmetric multisets), and `Algebra.BigOperators.Fin`. The parent file `BallotProblemOQ03OQ01OQ01` provides the LGV infrastructure that the k\u22653 combinatorial proof ultimately requires. The `open MvPolynomial Matrix Finset` declaration avoids namespace prefixes throughout.",
     "mathContext": "The Jacobi-Trudi identity states: $s_\\lambda = \\det[h_{\\lambda_i - i + j}]_{1 \\le i,j \\le k}$ where $h_n = \\sum_{|\\alpha|=n} x^\\alpha$ is the $n$-th complete homogeneous symmetric polynomial (sum over all degree-$n$ monomials, no sign). The convention $h_n = 0$ for $n < 0$ is essential for the matrix entries to be well-defined; Lean enforces this via \u2115 subtraction with a conditional. There is an analogous dual formula: $s_\\lambda = \\det[e_{\\lambda_i' - i + j}]$ where $\\lambda'$ is the conjugate partition and $e_k$ are elementary symmetric polynomials (alternating-sign determinant of e_k's). This file uses only the h_n version.",
     "significance": "key",
     "relatedConcepts": [
@@ -32,8 +32,8 @@
     "id": "ann-jt-matrix-def",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 35,
-      "endLine": 47
+      "startLine": 47,
+      "endLine": 58
     },
     "type": "definition",
     "title": "Jacobi-Trudi Matrix and Schur Polynomial Definitions",
@@ -57,8 +57,8 @@
     "id": "ann-jt-base-cases",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 53,
-      "endLine": 61
+      "startLine": 64,
+      "endLine": 72
     },
     "type": "insight",
     "title": "Base Cases: Empty and Single-Row Partitions",
@@ -82,12 +82,12 @@
     "id": "ann-jt-entry-symmetry",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 67,
-      "endLine": 71
+      "startLine": 79,
+      "endLine": 87
     },
     "type": "insight",
     "title": "Entry-Level Symmetry: Each h_n is Individually Symmetric",
-    "content": "Before proving the full Schur polynomial is symmetric, we first establish that each entry of the Jacobi-Trudi matrix is individually symmetric. The key lemma is `rename_hsymm`: renaming variables in h_n by any permutation leaves it unchanged. The conditional entry (h_n or 0) requires `split_ifs` to handle both branches. This is a sorry pending resolution of a Lean unification issue with `hsymm_isSymmetric`.",
+    "content": "Before proving the full Schur polynomial is symmetric, we first establish that each entry of the Jacobi-Trudi matrix is individually symmetric (`jacobiTrudiMatrix_entry_isSymmetric`). The proof is a clean three-line case split: `simp only [jacobiTrudiMatrix]` unfolds the conditional entry, `split_ifs` handles both branches, then `exact hsymm_isSymmetric _` closes the h_n branch (Mathlib's proof that every complete homogeneous symmetric polynomial is symmetric) and `exact IsSymmetric.zero` closes the 0 branch. No sorry — this lemma is fully proved and is the entry-wise ingredient consumed by the full-symmetry proof below.",
     "mathContext": "A polynomial $\\phi \\in R[x_i : i \\in \\sigma]$ is symmetric if $\\phi(x_{e(i)}) = \\phi(x_i)$ for all permutations $e : \\sigma \\to \\sigma$. In Lean: `IsSymmetric \u03c6 = \u2200 e : Equiv.Perm \u03c3, MvPolynomial.rename e \u03c6 = \u03c6`. Mathlib's `hsymm_isSymmetric` proves this for $h_n$, and `rename_hsymm` gives the explicit rewrite `rename e (hsymm \u03c3 R n) = hsymm \u03c3 R n`. The zero case is trivial since `rename e 0 = 0`.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -107,12 +107,12 @@
     "id": "ann-jt-symmetry",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 73,
-      "endLine": 77
+      "startLine": 89,
+      "endLine": 100
     },
     "type": "insight",
     "title": "Full Symmetry of Schur Polynomials via AlgHom.map_det",
-    "content": "Symmetry of the Schur polynomial follows from two facts: (1) AlgHom.map_det lifts any ring algebra homomorphism through the determinant, and (2) rename_hsymm shows each h_n is individually symmetric. This is a sorry pending the entry-symmetry result above. Once that is proved, the full symmetry proof is 10 lines: apply AlgHom.map_det, then show each matrix entry is fixed by rename via jacobiTrudiMatrix_entry_isSymmetric.",
+    "content": "Symmetry of the Schur polynomial (`schurPolynomial_isSymmetric`) follows from two facts: (1) `AlgHom.map_det` lifts any R-algebra homomorphism through the determinant, and (2) each h_n is individually symmetric (the entry-level lemma above). This theorem is fully proved. The proof fixes a permutation `e`, unfolds `schurPolynomial`, rewrites with `AlgHom.map_det (rename ↑e)` to move `rename e` inside the determinant as `mapMatrix`, then `congr 1; ext i j` reduces the goal to showing each mapped entry equals the original — which is exactly `jacobiTrudiMatrix_entry_isSymmetric k sh i j e`. Symmetry is the defining property that makes s_λ a genuine symmetric function rather than an arbitrary polynomial.",
     "mathContext": "The key identity: for any $R$-algebra homomorphism $\\phi$, $\\phi(\\det M) = \\det(\\phi \\circ M)$. In Lean: `AlgHom.map_det`. Here $\\phi = \\texttt{rename}\\, e$ for a permutation $e : \\text{Perm}\\, \\sigma$, so $(\\texttt{rename}\\, e)(\\det M_{JT}) = \\det(\\texttt{mapMatrix}\\,(\\texttt{rename}\\, e)\\, M_{JT})$. Each entry satisfies $(\\texttt{rename}\\, e)(h_n) = h_n$, so the mapped matrix equals $M_{JT}$, giving $(\\texttt{rename}\\, e)(s_\\lambda) = s_\\lambda$. Symmetry is the defining property that distinguishes $s_\\lambda$ from ordinary polynomials.",
     "significance": "key",
     "relatedConcepts": [
@@ -133,12 +133,12 @@
     "id": "ann-jt-two-row",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 83,
-      "endLine": 90
+      "startLine": 108,
+      "endLine": 138
     },
     "type": "insight",
     "title": "Two-Row Schur Polynomial: Explicit Determinant Formula",
-    "content": "For the two-row partition (a, b) with a \u2265 b \u2265 0, the Jacobi-Trudi formula gives s_{(a,b)} = h_a * h_b - h_{a+1} * h_{b-1}. This is the 2\u00d72 determinant expansion. When b = 0, the second term vanishes (h_{-1} = 0 by the \u2115 convention). Lean's det_fin_two gives the 2\u00d72 expansion mechanically, and Matrix.cons lemmas extract the entries. Currently a sorry due to the complexity of normalizing the conditional entry logic.",
+    "content": "For the two-row partition (a, b), the Jacobi-Trudi formula gives s_{(a,b)} = h_a * h_b - h_{a+1} * h_{b-1} (and s_{(a,b)} = h_a * h_b when b = 0, since h_{-1} = 0 by the \u2115 convention). This theorem (`schurPolynomial_two_row`) is fully proved: `Matrix.det_fin_two` gives the 2\u00d72 expansion M\u2080\u2080\u00b7M\u2081\u2081 \u2212 M\u2080\u2081\u00b7M\u2081\u2080 mechanically, and the four conditional entries evaluate to M\u2080\u2080 = h_a, M\u2080\u2081 = h_{a+1}, M\u2081\u2080 = h_{b-1} (or 0 when b = 0), M\u2081\u2081 = h_b. This is the smallest case where the alternating-sign determinant structure genuinely appears, and it is precisely the identity the k=2 SSYT bijection (Part XI) matches against the tableau generating function.",
     "mathContext": "For partition $\\lambda = (a, b)$ with $a \\ge b \\ge 0$: $$s_{(a,b)} = \\det\\begin{pmatrix} h_a & h_{a+1} \\\\ h_{b-1} & h_b \\end{pmatrix} = h_a h_b - h_{a+1} h_{b-1}$$ where $h_{-1} = 0$ by convention. This is the simplest non-trivial case of Jacobi-Trudi and illustrates the alternating-sign (determinant) structure. The formula generalizes: for a hook partition $(a, 1^b)$, the Jacobi-Trudi determinant is tridiagonal. The two-row case is also used to prove the Pieri rule.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -158,13 +158,13 @@
     "id": "ann-jt-hook-connection",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 96,
-      "endLine": 101
+      "startLine": 139,
+      "endLine": 160
     },
     "type": "insight",
     "title": "Evaluation at All-Ones: Stars-and-Bars and Symmetric Group",
-    "content": "Evaluating h_n at x\u2081 = \u22ef = x\u2096 = 1 gives the number of monomials of degree n in k variables, which equals C(n+k-1, k-1) = |{weak compositions of n into k parts}| = |Sym(Fin k) n|. This connects the algebraic Jacobi-Trudi formula to combinatorial counting, and to the dimension of the degree-n component of the polynomial ring. Currently sorry pending the `Nat.multichoose` = `Nat.choose` reduction.",
-    "mathContext": "For the $n$-th complete homogeneous symmetric polynomial in $k$ variables: $h_n(1,1,\\ldots,1) = \\binom{n+k-1}{k-1}$. This equals $|\\text{Sym}(\\text{Fin}\\, k)\\, n|$ \u2014 the number of multisets of size $n$ from a $k$-element set (\"stars and bars\"). In Lean: `eval (fun _ => 1) (hsymm (Fin k) R n) = Nat.choose (n + k - 1) (k - 1)`. When combined with Jacobi-Trudi, evaluating $s_\\lambda(1,\\ldots,1)$ counts the number of SSYT of shape $\\lambda$ with entries in $\\{1,\\ldots,k\\}$, which equals the dimension of the corresponding GL(k) representation.",
+    "content": "Evaluating h_n at x\u2081 = \u22ef = x\u2096 = 1 gives the number of monomials of degree n in k variables, which equals C(n+k-1, k-1) = |{weak compositions of n into k parts}| = |Sym(Fin k) n|. This connects the algebraic Jacobi-Trudi formula to combinatorial counting, and to the dimension of the degree-n component of the polynomial ring. This theorem (`schurPolynomial_one_row_at_one`) is fully proved: it reduces to `hsymm` via `schurPolynomial_one_row`, evaluates each monomial to 1 at all-ones, and counts the terms with `Sym.card_sym_eq_choose`. The proof uses the C(k+n-1, n) form (correct at k = 0) rather than C(n+k-1, k-1).",
+    "mathContext": "For the $n$-th complete homogeneous symmetric polynomial in $k$ variables: $h_n(1,1,\\ldots,1) = \\binom{n+k-1}{k-1}$. This equals $|\\text{Sym}(\\text{Fin}\\, k)\\, n|$ \u2014 the number of multisets of size $n$ from a $k$-element set (\"stars and bars\"). In Lean the proved form is `eval (fun _ => 1) (hsymm (Fin k) R n) = Nat.choose (k + n - 1) n`, closed by `Sym.card_sym_eq_choose`; for $k \\ge 1$ this equals $\\binom{n+k-1}{k-1}$. When combined with Jacobi-Trudi, evaluating $s_\\lambda(1,\\ldots,1)$ counts the number of SSYT of shape $\\lambda$ with entries in $\\{1,\\ldots,k\\}$, which equals the dimension of the corresponding GL(k) representation.",
     "significance": "supporting",
     "relatedConcepts": [
       "stars and bars",
@@ -182,15 +182,70 @@
     ]
   },
   {
+    "id": "ann-jt-ssyt-def",
+    "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 292
+    },
+    "type": "definition",
+    "title": "SSYT Generating Function: The Combinatorial Definition of Schur Polynomials",
+    "content": "This part supplies the second, purely combinatorial definition of the Schur polynomial that `jacobi_trudi_ssyt_eq` matches against the determinant. `SSYTFin n k sh` is the first Lean 4 semistandard-Young-tableaux type for an arbitrary shape: a subtype of fillings `(i : Fin k) × Fin (sh i) → Fin n` satisfying weakly-increasing rows and strictly-increasing columns. Both conditions are decidable over finite types, so `SSYTFin` carries a `Fintype` instance via `Subtype.fintype` — this is what lets the generating function be a finite sum. `SSYTFin.weight T = ∏_p X (T p)` is the monomial recording the multiset of entries, and `ssytSchurFin n k sh = ∑ T, T.weight` sums it over all tableaux. Two base cases are fully proved here: k=0 (`ssytSchurFin_empty`) via `Unique`/`IsEmpty` (the empty tableau has empty product 1), and k=1 (`ssytSchurFin_one_row`) via an explicit bijection `SSYTFin n 1 sh ≃ Sym (Fin n) m` between one-row tableaux and size-m multisets, using `List.sortedLE_ofFn_iff` to translate 'weakly increasing filling' into 'sorted multiset representative'.",
+    "mathContext": "The combinatorial Schur polynomial is $s_\\lambda = \\sum_{T \\in \\mathrm{SSYT}(\\lambda, n)} x^{T}$ where $x^T = \\prod_{c \\in \\lambda} x_{T(c)}$ and $T$ ranges over fillings of the Young diagram of $\\lambda$ with entries in $\\{1,\\ldots,n\\}$ that weakly increase along rows and strictly increase down columns. The identity to be proved is that this equals the Jacobi-Trudi determinant $\\det[h_{\\lambda_i - i + j}]$. In Lean the shape is `sh : Fin k → ℕ`, a cell is `(i : Fin k) × Fin (sh i)`, and a one-row SSYT of length $m$ corresponds bijectively to a multiset in $\\mathrm{Sym}(\\mathrm{Fin}\\,n)\\,m$ — the identity $h_m = \\sum_{\\text{1-row SSYT of length } m} x^T$ that seeds the general LGV argument.",
+    "significance": "key",
+    "relatedConcepts": [
+      "semistandard Young tableaux (SSYT)",
+      "Schur polynomial combinatorial definition",
+      "generating function",
+      "Sym (multisets)",
+      "Fintype instance",
+      "sorted multiset representative"
+    ],
+    "prerequisites": [
+      "Young tableaux theory",
+      "Mathlib.Data.Sym.Card",
+      "Fintype and Subtype.fintype",
+      "monomials in MvPolynomial"
+    ]
+  },
+  {
+    "id": "ann-jt-cycle-lemma",
+    "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1820,
+      "endLine": 1948
+    },
+    "type": "concept",
+    "title": "Sub-lemma 2B: the Multiset Cycle Lemma — Open Core of the k=2 Case (sorry, L1907)",
+    "content": "This is one of the file's two open sorries (L1907) and the sole gap on the k=2 Jacobi-Trudi path: `noColStrict_subSym_a_count_eq_subSym_le_aplus1_count`. For b ≥ 2 and b ≤ a it asserts that, among the distinct size-a submultisets P of M.1, the number admitting NO column-strict size-b complement equals the number of distinct size-(a+1) submultisets of M.1. This is exactly a multiset generalization of the Dvoretzky-Motzkin / Lyndon Cycle Lemma (the classical ballot-counting reflection principle), specialized to sorted multiset prefixes — a form not currently in Mathlib and a plausible small upstream contribution. Everything upstream of it is proved: Sub-lemma 1 (`split_count_eq_subSym_le_count`) reduces (P,Q)-pair counts to single-P counts, Sub-lemma 2A converts the pair-form col-strict count into single-Sym form, and Sub-lemma 2 composes them via a filter partition + `omega`. The rotation infrastructure of Part VIII (`rotateSortedList` and its Prefix/Suffix `Sym`-packagings) and the canonical-complement bridge (`noColStrict_iff_canonicalComp`) are scaffolding assembled toward a cycle-class-cardinality proof of this lemma; per the S30 finding, the naive 'first-violation drop' forward map is non-injective, so the intended argument tags each bad P with a canonical first-descent rotation index rather than a single element.",
+    "mathContext": "Writing $M \\in \\mathrm{Sym}(\\mathrm{Fin}\\,n)\\,(a+b)$, the claim is $\\#\\{P \\le M : |P| = a,\\ \\neg\\exists Q,\\ |Q|=b,\\ P+Q=M \\wedge \\mathrm{ColStrict}(P,Q)\\} = \\#\\{P' \\le M : |P'| = a+1\\}$, where $\\mathrm{ColStrict}$ compares the $j$-th smallest elements of the sorted representatives for $j < \\min(a,b)$. This is the additive heart of the ballot reflection identity $\\sum_{\\text{col-strict}} \\mathrm{wt} = h_a h_b - h_{a+1} h_{b-1}$: the classical Cycle Lemma says that among the $c$ cyclic rotations of a sequence with a fixed excess, exactly one is a 'good' (ballot) sequence, converting a 'no valid complement' count into a shifted-size count. The multiset version must additionally handle repeated elements via rotation-equivariance of the sorted-prefix presentation, which is why `rotateSortedList_toMultiset` (rotation preserves the underlying multiset) is the pivotal structural lemma.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cycle Lemma",
+      "Dvoretzky-Motzkin",
+      "ballot problem",
+      "reflection principle",
+      "col-strict Sym pairs",
+      "rotateSortedList",
+      "sorted multiset prefix"
+    ],
+    "prerequisites": [
+      "ballot problem / cycle lemma",
+      "multisets (Sym) and sorted representatives",
+      "Finset.card bijections",
+      "List.rotate"
+    ]
+  },
+  {
     "id": "ann-jt-lgv",
     "proofId": "ballot-problem-oq-03-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 103,
-      "endLine": 129
+      "startLine": 2521,
+      "endLine": 2557
     },
     "type": "concept",
-    "title": "LGV Connection (Open): SSYT \u2194 Non-Intersecting Paths via RSK",
-    "content": "The combinatorial proof of the Jacobi-Trudi identity via the LGV lemma proceeds: semistandard Young tableaux (SSYT) of shape \u03bb biject with non-intersecting lattice path systems via RSK correspondence; each lattice path encodes a weakly increasing variable sequence whose monomial weight is a term of h_n; summing over SSYT gives det[h_{sh_i+j-i}]. This sorry represents approximately 400 lines of Lean formalization (SSYT structure ~100 lines + RSK bijection ~200 lines + weight matching ~100 lines). The placeholder theorem is stated as a tautology (schurPolynomial = schurPolynomial) until the RHS can be replaced by the SSYT generating function.\n\nThe comment block (lines 103-118) is a detailed formalization roadmap: Step 1 (SSYT ~100 lines) requires a type for semistandard Young tableaux of shape `sh : Fin k \u2192 \u2115` with entries in `Fin n`, plus a monomial weight function that maps a SSYT T to $\\prod_i x_{T(i)}$. Step 2 (RSK ~200 lines) is the Robinson-Schensted-Knuth bijection proving SSYT biject with pairs of non-intersecting lattice paths from the LGV source points $A_i$ to $B_j$. Step 3 (weight matching ~100 lines) proves the LGV determinant (with the edge weights from the parent `BallotProblemOQ03OQ01OQ01` proof) equals the SSYT generating function $\\sum_{T: \\text{SSYT}(\\lambda)} x^T$. The placeholder `schurPolynomial k sh = schurPolynomial k sh` is a true but trivial tautology \u2014 not even a statement of the actual theorem \u2014 representing work in progress.",
+    "title": "Main Theorem jacobi_trudi_ssyt_eq: SSYT Generating Function equals the Determinant (k=0,1,2 proved; k\u22653 open via RSK/LGV)",
+    "content": "`jacobi_trudi_ssyt_eq` is the file's principal theorem: for an antitone shape `sh`, the determinant definition equals the tableau generating function, `schurPolynomial k sh = ssytSchurFin n k sh`. This is a genuine statement of the Jacobi-Trudi identity (not a placeholder), proved by case analysis on k: k=0 dispatches to `schurPolynomial_empty`/`ssytSchurFin_empty` (both 1); k=1 to `schurPolynomial_one_row`/`ssytSchurFin_one_row` (both h_n); k=2 to `ssytSchurFin_two_row`, the two-row bijection assembled in Part XI from the ballot-counting machinery. Only the k\u22653 branch remains a `sorry` (L2555). Note the k=2 branch is itself transitively conditional on the one deep combinatorial sorry, Sub-lemma 2B (`noColStrict_subSym_a_count_eq_subSym_le_aplus1_count`, L1907, the multiset Cycle Lemma) \u2014 so the file has exactly two open gaps: L1907 (closes k=2) and L2555 (k\u22653).\n\nThe k\u22653 roadmap in the trailing comment: Step 1 \u2014 an algebraic (ring-valued) LGV lemma `det(M) = \u2211 over non-intersecting path tuples of \u220f edge-weights`, the polynomial analogue of `lgv_lemma_rxr` from `BallotProblemOQ03OQ02`. Step 2 \u2014 the RSK correspondence bijecting `SSYTFin n k sh` with non-intersecting tuples of one-row SSYTs in the Jacobi-Trudi lattice configuration. Step 3 \u2014 matching each matrix entry `M[i][j] = h_{sh(i)+j-i}` to a sum of one-row-SSYT weights via `ssytSchurFin_one_row`. The proved k=2 case supplies the base case for any inductive attack; the algebraic LGV is the key missing piece.",
     "mathContext": "The LGV proof: define a weighted digraph where edge weights encode polynomial variables, with sources $A_i = (0, i-1)$ and targets $B_j = (\\lambda_j - j + k, j-1)$. A system of non-intersecting paths from $(A_1,\\ldots,A_k)$ to $(B_{\\sigma(1)},\\ldots,B_{\\sigma(k)})$ encodes a SSYT of shape $\\lambda$. The LGV lemma (proved in parent entry `ballot-problem-oq-03-oq-01-oq-01`) gives $\\det[e(A_i, B_j)] = \\sum_{\\text{NI paths}} \\text{wt}$. Matching weights shows this equals $\\sum_{T \\in \\text{SSYT}(\\lambda)} x^T = s_\\lambda$ (the combinatorial definition of Schur polynomials via SSYT). The RSK bijection (Step 2) is one of the deepest results in algebraic combinatorics: it establishes that $|\\text{SSYT}(\\lambda, n)| = \\dim V^\\lambda_n$ (the GL(n) representation dimension) via a bijective proof.",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-03-oq-01-oq-01-oq-01` (Jacobi-Trudi Identity). Quality 45, 0 prior passes.

## Problem
The annotations were stale from an early version of the proof: they described the symmetry, two-row-formula, and hook-length theorems as unproven `sorry`s, and the main theorem as a trivial `schurPolynomial = schurPolynomial` tautology placeholder. The current Lean file proves all four of those fully and states `jacobi_trudi_ssyt_eq` as a genuine identity. Only **two** sorries remain (verified against source): Sub-lemma 2B (`noColStrict_subSym_a_count_eq_subSym_le_aplus1_count`, L1907, the multiset Cycle Lemma) and the k≥3 case (L2555). A reader was being actively misled about what is proved.

## Changes (annotations.json only)
- **Corrected 5 stale annotations** to reflect the true 2-sorry state: entry-level symmetry, full symmetry via `AlgHom.map_det`, two-row determinant formula, hook-length evaluation at all-ones (also fixed the binomial form to the proved `C(k+n-1, n)`), and the main theorem.
- **Fixed all drifted line ranges** — the old ranges (1–129) no longer matched the 2557-line file. New ranges anchor on current Lean constructs; `pnpm annotations:build` reports **zero warnings** for this entry.
- **Retargeted + rewrote the LGV annotation** onto the real `jacobi_trudi_ssyt_eq` (L2521), documenting the k=0/1/2 proved dispatch and the k≥3 RSK+algebraic-LGV roadmap.
- **Added 2 annotations** covering previously un-annotated machinery: the SSYT generating-function definition (Part VI) and Sub-lemma 2B / the open multiset Cycle Lemma (Part IX, L1907).

Annotations: 8 → 10. `meta.json` left untouched (already accurate about both sorries and axiomCount 0; 41 KB, within the 60 KB cap).

## Verification
- `pnpm gallery:check-size`: within caps
- `pnpm annotations:build`: exit 0, no warnings for this entry
- Sorry/axiom counts cross-checked against `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` (2 sorries at L1907/L2555, 0 axioms)