### PR TITLE
research(schroeder-bernstein-oq-03): bridge bounded escape search → canonical escape depth

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03.lean
@@ -2750,6 +2750,45 @@ theorem escapeDepth_le {f g : ℕ → ℕ}
   obtain ⟨N, hNle, hN⟩ := escape_exists_bounded hf hg hbal ha
   exact le_trans (Nat.find_min' _ hN) hNle
 
+/-- **Bounded escape search (plain, proof-free).** A `List.findIdx` over the *finite* window
+    `List.range ((mRan L).length + 1)` for the first stage whose green image escapes `mRan L`.
+    Unlike `escapeDepth` (which is `Nat.find` and carries the escape-existence proof `hex` as an
+    argument), `firstEscapeB` is an honest total function `List (ℕ × ℕ) → ℕ → ℕ` with **no** proof
+    argument and **no** `Classical.choose` — it is amenable to Mathlib's `Computable` typeclass.
+    By `firstEscapeB_eq_escapeDepth` it computes the *same* value as `escapeDepth` whenever escape is
+    guaranteed within the window (`escapeDepth_le`), so a scheduler may replace the choice-carrying
+    `escapeDepth` by `firstEscapeB` without changing the pairing. This is the computability keystone
+    the module docstring flags: relocating the unbounded `Nat.find` into a bounded, plainly
+    executable scan licensed by `escape_exists'`'s `N ≤ (mRan L).length` bound. -/
+def firstEscapeB (f g : ℕ → ℕ) (L : List (ℕ × ℕ)) (a : ℕ) : ℕ :=
+  (List.range ((mRan L).length + 1)).findIdx
+    (fun N => decide (f (fwdOrbit f g a N) ∉ mRan L))
+
+/-- **The bounded search equals the canonical escape depth.** Under the balance invariant that
+    licenses escape (`escape_exists'`), the least escaping stage `escapeDepth = Nat.find` lies in the
+    window `[0, (mRan L).length]` (`escapeDepth_le`); hence the bounded `List.findIdx` over
+    `List.range ((mRan L).length + 1)` returns exactly that least stage. The proof is
+    `List.findIdx_eq` at the index `escapeDepth`: the predicate is `true` there
+    (`escapeDepth_spec`, the escape) and `false` at every earlier stage (`escapeDepth_min`, the
+    collisions), and `List.getElem_range` identifies `(range _)[j] = j`. This is the flagged
+    correctness keystone: it certifies that the *plain, choice-free, computable* `firstEscapeB`
+    reproduces the *least-depth* pairing of the classical construction, not merely *some* pairing. -/
+theorem firstEscapeB_eq_escapeDepth {f g : ℕ → ℕ}
+    (hf : Function.Injective f) (hg : Function.Injective g)
+    {L : List (ℕ × ℕ)} (hbal : Balanced f g L) {a : ℕ} (ha : a ∉ mDom L) :
+    firstEscapeB f g L a = escapeDepth f g L a (escape_exists' hf hg hbal ha) := by
+  have hle : escapeDepth f g L a (escape_exists' hf hg hbal ha) ≤ (mRan L).length :=
+    escapeDepth_le hf hg hbal ha
+  have hlen : escapeDepth f g L a (escape_exists' hf hg hbal ha)
+      < (List.range ((mRan L).length + 1)).length := by
+    rw [List.length_range]; omega
+  rw [firstEscapeB, List.findIdx_eq hlen]
+  refine ⟨?_, fun j hji => ?_⟩
+  · simp only [List.getElem_range, decide_eq_true_eq]
+    exact escapeDepth_spec f g L a _
+  · simp only [List.getElem_range, decide_eq_false_iff_not, not_not]
+    exact escapeDepth_min f g L a _ hji
+
 /-- **Choice-free domain cons step.** Prepends the concrete escaping pair
     `(a, chaseTarget f g a (escapeDepth …))` — the least-depth green image, located by the
     decidable `Nat.find` above rather than `Classical.choose` — and preserves all four

--- a/research/problems/schroeder-bernstein-oq-03/state.md
+++ b/research/problems/schroeder-bernstein-oq-03/state.md
@@ -7,7 +7,29 @@ VERIFIED; only COMPUTABILITY remains**
 **Since**: 2026-07-02
 **Iteration**: 10
 
-## Next Action (supersedes all below — 2026-07-03 r8)
+## Next Action (supersedes all below — 2026-07-03 r8b)
+**r8b landed the flagged-risk correctness keystone (VERIFIED 0-axiom, PR pending):**
+- `firstEscapeB f g L a := (List.range ((mRan L).length + 1)).findIdx (fun N => decide (f (fwdOrbit
+  f g a N) ∉ mRan L))` — a plain total function: NO `Classical.choose`, NO proof argument, so it is
+  `Computable`-amenable (unlike `escapeDepth`, which carries the escape-existence proof).
+- `firstEscapeB_eq_escapeDepth` — the bridge `firstEscapeB f g L a = escapeDepth f g L a
+  (escape_exists' …)` under the balance invariant. Proof: `List.findIdx_eq` at index `escapeDepth`
+  (`escapeDepth_le` puts it in-window; `escapeDepth_spec` = predicate true there; `escapeDepth_min`
+  = false at earlier stages; `List.getElem_range` for `(range n)[j]=j`). **This retires the
+  documented "only real risk (core findIdx lemma hunt)."** The lemmas used all exist in
+  Lean core v4.26.0 `Init.Data.List.Find`/`Range`: `findIdx_eq`, `getElem_range`, `length_range`.
+
+**REMAINING (concrete, next session) — pure mechanical Primrec assembly, no new math:**
+1. **`firstEscapeB_computable`** — `Computable (fun (La : List (ℕ×ℕ) × ℕ) => firstEscapeB f g La.1
+   La.2)` given `hf hg : Computable`. Building blocks all confirmed present:
+   `Primrec.list_findIdx` (Primrec.lean:1007), `Primrec.list_range` (:973), `Primrec.list_length`
+   (:996), `Primrec.list_map` (:967, for `mRan = map Prod.snd`), `fwdOrbit_computable` (in-file).
+   ONLY open sub-lemma: a **list-membership Bool primrec** `Primrec₂ (fun (l:List ℕ) y => decide (y
+   ∈ l))` for the per-element escape predicate — likely via `Primrec.list_idxOf` (:1013) +
+   `y ∈ l ↔ l.idxOf y < l.length`, or an `exists_mem_list`/`beq` route. This is the next lemma hunt.
+2. Then the computable scheduler + read-off + `myhill_isomorphism` discharge (unchanged from below).
+
+## Next Action (superseded — 2026-07-03 r8)
 **r8 landed the two definitional keystones for computability (VERIFIED 0-axiom, PR pending):**
 - `escape_exists_bounded` — merged dichotomy KEEPING the `N ≤ (mRan L).length` bound that
   `escape_exists'` discarded (both arms `escape_of_balanced` / `escape_of_infinite_orbit` already

--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 3132,
+    "lineCount": 3171,
     "mathlibDependencies": [
       {
         "theorem": "OneOneReducible",
@@ -57,13 +57,14 @@
       "Read-off coherence layer (Section 4f-bis): mLookup_mem_of_mem_dom (the lookup lands on a genuine recorded edge), mLookup_injOn (the read-off is injective across the domain, via range-side Nodup), and mLookup_stable (read-off values are stable as the matching grows) — the well-definedness/injectivity/coherence obligations the eventual assembly of the limit permutation consumes, collision-independent (VERIFIED, 0-axiom)",
       "Escape existence for the collision chase (Section 4i): escape_exists — for a fresh domain anchor a ∉ mDom L in a BuiltFrom matching, some forward-orbit stage N ≤ (mDom L).length has a range-fresh image f(fwdOrbit f g a N), so the even-stage collision chase always terminates within L.length steps. Proved via chase_gedge_chain (a persistent collision forces the g-edge (o_{k+1}, f o_k) at every stage — the f-edge alternative is excluded by matching functionality, which would force an orbit repeat and hence a ∈ mDom L) + fwdOrbit_chase_length_le. domain_step_exists then makes the even-stage domain step total (preserving IsMatching and MatchingCorr). Resolves the documented \"escape existence is not free\" obstruction; VERIFIED, 0-axiom.",
       "Computability keystones for the escape depth (r8, 2026-07-03): escape_exists_bounded — the escape_exists' dichotomy but RETAINING the N ≤ (mRan L).length bound both arms already prove (escape_of_balanced periodic + escape_of_infinite_orbit infinite), which escape_exists' had discarded; and escapeDepth_le — the least escaping stage escapeDepth f g L a (Nat.find) satisfies escapeDepth ≤ (mRan L).length. Together these establish that the CANONICAL domain-cons partner chaseTarget f g a (escapeDepth …) lives in a computable bounded window: it can be located by a plain bounded scan of the first (mRan L).length + 1 forward-orbit stages instead of Nat.find-with-existence-proof, the numerical fact that unblocks a fully computable rebuild of the extension-only scheduler. VERIFIED, 0-axiom.",
-      "Read-off collapse to a computable stage index (r8, 2026-07-03): sigmaB_eq_bound — the limit permutation value σ n equals mLookup (stageSeqB (2n+1)).1 n, i.e. the read-off is a lookup into the stage list at the FIXED computable index 2n+1, eliminating the noncomputable entryStageDomB (Nat.find) search from the read-off formula. Combined with (forthcoming) computability of the stage list and mLookup_computable, this is the final shape from which Computable σ follows. VERIFIED, 0-axiom."
+      "Read-off collapse to a computable stage index (r8, 2026-07-03): sigmaB_eq_bound — the limit permutation value σ n equals mLookup (stageSeqB (2n+1)).1 n, i.e. the read-off is a lookup into the stage list at the FIXED computable index 2n+1, eliminating the noncomputable entryStageDomB (Nat.find) search from the read-off formula. Combined with (forthcoming) computability of the stage list and mLookup_computable, this is the final shape from which Computable σ follows. VERIFIED, 0-axiom.",
+      "Bounded escape search = canonical escape depth (r8b, 2026-07-03): firstEscapeB f g L a := (List.range ((mRan L).length + 1)).findIdx (fun N => decide (f (fwdOrbit f g a N) ∉ mRan L)) — a plain total function (no Classical.choose, no proof argument, hence Computable-amenable) — and the bridge firstEscapeB_eq_escapeDepth proving firstEscapeB f g L a = escapeDepth f g L a (escape_exists' …) whenever the balance invariant licenses escape. Proof is List.findIdx_eq at index escapeDepth: the escape predicate is true there (escapeDepth_spec) and false at every earlier stage (escapeDepth_min), with escapeDepth_le placing escapeDepth inside the window. This is the flagged correctness keystone — it certifies the choice-free bounded scan reproduces the LEAST-depth pairing of the classical construction, so a scheduler may substitute firstEscapeB for escapeDepth verbatim. The remaining step to Computable σ is now the mechanical Primrec assembly of firstEscapeB (list_findIdx + list_range + fwdOrbit_computable + a list-membership Bool primrec). VERIFIED, 0-axiom."
     ],
     "openProblems": [
       "Hard direction of Myhill's theorem: construct computable bijection from computable injections via back-and-forth priority argument (~200 lines of Partrec-based formalization)"
     ],
-    "theoremCount": 159,
-    "definitionCount": 32,
+    "theoremCount": 160,
+    "definitionCount": 33,
     "additionalFiles": [
       "Proofs/SchroederBernsteinOQ03Aristotle.lean"
     ]
@@ -252,10 +253,10 @@
       "Computable"
     ],
     "namespace": "MyhillIsomorphism",
-    "lineCount": 3132,
+    "lineCount": 3171,
     "axiomCount": 0,
-    "theoremCount": 159,
-    "definitionCount": 32,
+    "theoremCount": 160,
+    "definitionCount": 33,
     "sorries": 1,
     "path": "Proofs/SchroederBernsteinOQ03.lean",
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Adds the **flagged-risk correctness keystone** for the computability of Myhill's isomorphism (`schroeder-bernstein-oq-03`, hard direction). The prior session (PR #34255) landed the *numerical* keystones (`escape_exists_bounded`, `escapeDepth_le`, `sigmaB_eq_bound`) and flagged the `firstEscapeB = escapeDepth` bridge as "the only real risk (core findIdx lemma hunt)." This PR closes exactly that bridge.

> **Stacked on #34255** (`research/myhill-oq03-computable-r8`). This branch contains #34255's commit plus one new commit; if #34255 merges first the diff auto-reduces to just the bridge.

## What's proved (VERIFIED, 0-axiom)

- **`firstEscapeB f g L a`** `:= (List.range ((mRan L).length + 1)).findIdx (fun N => decide (f (fwdOrbit f g a N) ∉ mRan L))` — a *plain total function*: no `Classical.choose`, no proof argument, hence amenable to Mathlib's `Computable` typeclass (unlike `escapeDepth`, which is `Nat.find` carrying the escape-existence proof).
- **`firstEscapeB_eq_escapeDepth`** — `firstEscapeB f g L a = escapeDepth f g L a (escape_exists' …)` whenever the `Balanced` invariant licenses escape. Proof: `List.findIdx_eq` at index `escapeDepth` — `escapeDepth_le` puts it in-window, `escapeDepth_spec` = predicate true there, `escapeDepth_min` = false at all earlier stages, `List.getElem_range` identifies `(range n)[j] = j`. All lemmas exist in Lean core v4.26.0 (`Init.Data.List.Find`/`Range`).

This certifies the choice-free bounded scan reproduces the **least-depth** pairing of the classical back-and-forth construction, so a scheduler may substitute `firstEscapeB` for `escapeDepth` verbatim.

## Verification

`#print axioms MyhillIsomorphism.firstEscapeB_eq_escapeDepth` → `[propext, Classical.choice, Quot.sound]` (foundational only; 0 assumptions). File compiles via `lake env lean` against prebuilt oleans. `myhill_isomorphism` hard-direction `sorry` unchanged (1 sorry).

## Remaining (mechanical Primrec assembly, no new math)

`firstEscapeB_computable` via `Primrec.list_findIdx` + `list_range` + `list_length` + `list_map` + `fwdOrbit_computable`; only open sub-lemma is a list-membership Bool primrec. Then the computable scheduler + read-off discharge `myhill_isomorphism`. See `state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)