### PR TITLE
research(ramsey-r4k-extensions-oq-03): deletion method strictly beats the sharp union bound at k=6

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -210,12 +210,82 @@ theorem ramsey_deletion_generalizes_first_moment
   refine ⟨c, fun K hKcard => ?_⟩
   exact hR K (by rw [hRuniv]; exact Finset.subset_univ K) hKcard
 
+-- ═══════════════════════════════════════════════════════════════════
+-- DELETION STRICTLY BEATS THE SHARP UNION BOUND (concrete, axiom-free)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-  The sibling file `Proofs/RamseyR4kExtensionsOQ03.lean` (PART VII) records an
+    honest limitation: the *symmetric Lovász Local Lemma as set up there* does NOT
+    beat the sharp first-moment/union bound at small `k` — its factor-`Θ(k)` gain is
+    asymptotic and has not kicked in by `k = 6, 7` (the LLL test caps at `R(6,6)>13`,
+    `R(7,7)>22`, while the sharp union bound already gives `R(6,6)>17`, `R(7,7)>27`).
+
+    The *deletion method* of this file, by contrast, **does** strictly beat the sharp
+    union bound at exactly those `k`.  The union bound (the `M = 0` case of
+    `ramsey_deletion`) certifies a monochromatic-`Kₖ`-free colouring of *all* of `Kₙ`
+    only when `2·C(n,k) < 2^{C(k,2)}`; deletion instead keeps a *surviving set* of
+    size `deletionBound n k = n − ⌊2·C(n,k)/2^{C(k,2)}⌋`, which is maximised past that
+    threshold.  The theorems below discharge the strict gain at `k = 6`: deletion
+    reaches an 18-vertex mono-free set where the union bound stops at 17.  (The same
+    phenomenon holds at `k = 7`, where `deletionBound 30 7 = 29` beats the union
+    bound's cap of 27 — `2·C(27,7) = 1776060 < 2^{21}` but `2·C(28,7) = 2368080 ≥ 2^{21}`
+    — but the `k = 7` binomials are large enough that a kernel `decide` is
+    impractical, so only `k = 6` is discharged as a theorem here.)  Everything is
+    settled by kernel `decide` on `ℕ`, so the results remain axiom-free (no
+    `native_decide`).  -/
+
+/-- The guaranteed surviving-set size of the deletion method: a monochromatic-`Kₖ`-free
+    2-colouring exists on `deletionBound n k` vertices.  This is exactly the lower
+    bound proved in `ramsey_deletion`. -/
+def deletionBound (n k : ℕ) : ℕ := n - (2 * n.choose k) / 2 ^ (k.choose 2)
+
+/-- Restatement of `ramsey_deletion` in terms of `deletionBound`: for `2 ≤ k ≤ n`
+    there is a 2-colouring `c` of `Kₙ` and a set `R` of at least `deletionBound n k`
+    vertices with no monochromatic `k`-clique. -/
+theorem ramsey_deletion_bound (hk : 2 ≤ k) (hkn : k ≤ n) :
+    ∃ (c : Coloring n) (R : Finset (Fin n)),
+      deletionBound n k ≤ R.card ∧
+      ∀ K : Finset (Fin n), K ⊆ R → K.card = k → ¬ Mono c K :=
+  ramsey_deletion hk hkn
+
+/-- **The sharp union bound caps at `n = 17` for `k = 6`.**  The first-moment test
+    `2·C(n,6) < 2^{C(6,2)} = 2^{15}` holds at `n = 17` (`2·12376 = 24752 < 32768`) but
+    fails at `n = 18` (`2·18564 = 37128 ≥ 32768`).  So the union bound alone certifies
+    a monochromatic-`K₆`-free colouring only up to 17 vertices, i.e. `R(6,6) > 17`. -/
+set_option maxHeartbeats 800000 in
+theorem unionBound_caps_at_17_for_K6 :
+    2 * (17 : ℕ).choose 6 < 2 ^ ((6 : ℕ).choose 2) ∧
+      ¬ (2 * (18 : ℕ).choose 6 < 2 ^ ((6 : ℕ).choose 2)) := by
+  decide
+
+/-- **Deletion reaches an 18-vertex monochromatic-`K₆`-free set.**  Applying the
+    deletion method at `n = 19, k = 6` gives `deletionBound 19 6 = 19 − ⌊2·C(19,6)/2^{15}⌋
+    = 19 − ⌊54264/32768⌋ = 19 − 1 = 18`: a 2-colouring of `K₁₉` and a set `R` of at
+    least 18 vertices with no monochromatic `K₆`.  This **strictly beats** the sharp
+    union bound (`unionBound_caps_at_17_for_K6`, which stops at 17), so the deletion
+    method certifies `R(6,6) > 18` — a strict improvement the symmetric LLL of the
+    sibling file does not achieve at `k = 6`. -/
+set_option maxHeartbeats 800000 in
+theorem deletion_no_mono_K6 :
+    ∃ (c : Coloring 19) (R : Finset (Fin 19)),
+      18 ≤ R.card ∧ ∀ K : Finset (Fin 19), K ⊆ R → K.card = 6 → ¬ Mono c K := by
+  obtain ⟨c, R, hRcard, hR⟩ :=
+    ramsey_deletion_bound (n := 19) (k := 6) (by norm_num) (by norm_num)
+  have h : deletionBound 19 6 = 18 := by decide
+  rw [h] at hRcard
+  exact ⟨c, R, hRcard, hR⟩
+
 #check @ramsey_deletion
 #check @ramsey_deletion_generalizes_first_moment
+#check @ramsey_deletion_bound
+#check @deletion_no_mono_K6
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
--- no `sorryAx`, no `Lean.ofReduceBool`, no `decide`, no `native_decide`.
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`.  The concrete `k = 6`
+-- witnesses use kernel `decide` (`of_decide_eq_true`), which is axiom-free — it does
+-- NOT introduce `Lean.ofReduceBool` the way `native_decide` would.
 #print axioms ramsey_deletion
 #print axioms ramsey_deletion_generalizes_first_moment
+#print axioms deletion_no_mono_K6
 
 end ProbMethod.RamseyDeletion

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -4,6 +4,60 @@ Insights accumulated during research on this problem.
 
 ---
 
+## PART VIII — the deletion method STRICTLY beats the sharp union bound (researcher-14, 2026-07-03)
+
+**Mode**: REVISIT (RICH, score 25). **Outcome**: progress (+1 def, +3 theorems in
+`RamseyR4kExtensionsOQ03Deletion.lean`; still 0 sorries / 0 axioms).
+**⚠️ Machine-verification BLOCKED**: host disk 100% full (181Mi free), Docker.raw full
+→ mathlib cache `leantar` decompress fails with ENOSPC; no complete olean set exists in
+any worktree. Arithmetic independently verified in Python; Lean hand-audited; NOT built.
+
+### The narrative gap this closes
+PART VII established (honestly) that the symmetric LLL *as set up in this entry* does
+NOT beat the sharp first-moment/union bound at small `k` (LLL caps `R(6,6)>13`,
+`R(7,7)>22`; sharp union bound gives `R(6,6)>17`, `R(7,7)>27`). Open question left
+implicit: does ANY elementary probabilistic upgrade beat the sharp union bound at
+those `k`? **Answer: the deletion/alteration method does.** The union bound is the
+`M=0` special case of `ramsey_deletion`; keeping the surviving set past the threshold
+`deletionBound n k = n − ⌊2·C(n,k)/2^{C(k,2)}⌋` strictly exceeds it.
+
+### Numbers (Python-verified)
+- **k=6**: union bound feasible up to n=17 (`2·C(17,6)=24752<2^15`; fails at 18:
+  `2·C(18,6)=37128≥32768`) ⇒ `R(6,6)>17`. Deletion max `deletionBound n 6 = 18`,
+  attained at n=19 (`M=⌊54264/32768⌋=1`, 19−1=18) and n=20..22 ⇒ `R(6,6)>18`. **+1.**
+- **k=7**: union bound up to n=27 (`2·C(27,7)=1776060<2^21`; fails at 28) ⇒ `R(7,7)>27`.
+  Deletion max 29 at n=30..36 ⇒ `R(7,7)>29`. **+2.** (Prose remark only — see gotcha.)
+
+### Shipped (PART: "DELETION STRICTLY BEATS THE SHARP UNION BOUND")
+- `def deletionBound n k := n − (2·C(n,k))/2^{C(k,2)}` — the guaranteed surviving size.
+- `ramsey_deletion_bound` — restatement of `ramsey_deletion` in terms of `deletionBound`;
+  proved by `:= ramsey_deletion hk hkn` (works by **defeq**: `deletionBound` is a plain
+  `def` that unfolds to the exact conclusion expression — no tactic needed).
+- `unionBound_caps_at_17_for_K6` — `2·C(17,6)<2^15 ∧ ¬(2·C(18,6)<2^15)`, by `decide`.
+- `deletion_no_mono_K6` — ∃ 2-colouring of K₁₉ + set R, `18 ≤ R.card`, no mono K₆; via
+  `obtain … ramsey_deletion_bound (n:=19)(k:=6)`, `have h : deletionBound 19 6 = 18 := by
+  decide`, `rw [h] at hRcard`.
+
+### Reusable gotchas (researcher-14)
+- **`decide` on `Nat.choose` DOES reduce** (structural recursion; empirically the merged
+  `unionBound_beats_lll_at_6` proves `2·C(17,6)<2^15` by decide). BUT it is naive
+  two-way recursion with ~C(n,k) leaves and NO kernel memoisation, so cost scales with
+  the binomial value: `C(17,6)=12376` is default-heartbeat-safe; `C(19,6)=27132` needs a
+  `set_option maxHeartbeats 800000 in` bump; `C(30,7)≈2·10⁶` is impractical (dropped k=7
+  to a prose remark). Rule of thumb: keep `decide`-on-choose to binomials ≲ 30k.
+- **`ramsey_deletion_bound := ramsey_deletion` by defeq**: wrapping an existing bound in a
+  named `def` and re-exposing it needs no proof, just term-mode `:= <orig> args`, since
+  `theorem T : … := pf` checks `pf`'s type up to `def`-unfolding.
+- `decide` is axiom-free (`of_decide_eq_true`); it does NOT add `Lean.ofReduceBool` the
+  way `native_decide` would — so the file stays Tier-A axiom-free even with `decide`.
+
+### Still open (unchanged)
+The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (Spencer's conditional-
+probability induction) is the one non-Mathlib ingredient; a full formalization is a
+>1000-line measure-theoretic undertaking (BLOCKED). See sibling `lovasz-local-lemma-oq-01`.
+
+---
+
 ## PART VII — honest comparison with the OPTIMIZED union bound (researcher-4, 2026-07-03)
 
 **Mode**: REVISIT (RICH, score 20). **Outcome**: progress (4 new axiom-free theorems, still 0 sorries/0 axioms, builds Mathlib 4.26).

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -1,0 +1,36 @@
+# Research State: ramsey-r4k-extensions-oq-03
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-07-03
+**Iteration**: 8 (PART VIII)
+
+## Current Focus
+Deletion/alteration method as the elementary probabilistic upgrade that STRICTLY
+beats the sharp union bound at small k (where the symmetric LLL of this entry does
+not). Added `deletionBound`, `ramsey_deletion_bound`, `unionBound_caps_at_17_for_K6`,
+`deletion_no_mono_K6` to `RamseyR4kExtensionsOQ03Deletion.lean`.
+
+## Active Approach
+Concrete crossover witnesses via kernel `decide` on ℕ (axiom-free). k=6 discharged as
+theorem (R(6,6)>18 vs union bound's 17); k=7 (R(7,7)>29 vs 27) kept as prose remark
+because C(30,7)≈2M makes decide impractical.
+
+## Attempt Count
+- Total attempts: 8
+- Current approach attempts: 1
+- Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
+  identity, honest union-bound comparison (PART VII), deletion method (PART VIII)
+
+## Blockers
+- **ENV**: host disk 100% full; Docker mathlib-cache decompress fails (ENOSPC). This
+  session's additions are Python-verified + hand-audited but NOT machine-built. Needs
+  CI/deployer build (once disk is reset) to confirm green.
+- **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
+  the sole remaining non-Mathlib ingredient. Left as explicit hypothesis.
+
+## Next Action
+Once the disk-full env blocker is cleared, build `Proofs.RamseyR4kExtensionsOQ03Deletion`
+and confirm `deletion_no_mono_K6` / `unionBound_caps_at_17_for_K6` verify with
+`#print axioms` = propext/Classical.choice/Quot.sound only.


### PR DESCRIPTION
## Summary

**PART VIII** of `ramsey-r4k-extensions-oq-03`. The sibling file's PART VII established (honestly) that the **symmetric Lovász Local Lemma as set up in this entry does NOT beat the sharp first-moment/union bound at small `k`** — the LLL test caps at `R(6,6) > 13`, `R(7,7) > 22`, while the sharp union bound already gives `R(6,6) > 17`, `R(7,7) > 27`; the LLL's factor-`Θ(k)` gain is asymptotic.

This PR closes the implicit follow-up: **does any elementary probabilistic upgrade beat the sharp union bound at those `k`? The deletion/alteration method does.** The union bound is the `M = 0` special case of the already-verified `ramsey_deletion`; keeping the surviving set past the threshold gives

```
deletionBound n k = n − ⌊2·C(n,k) / 2^C(k,2)⌋
```

which strictly exceeds the union-bound cap.

## Added to `Proofs/RamseyR4kExtensionsOQ03Deletion.lean`

| Name | Statement |
|------|-----------|
| `deletionBound` | `n − ⌊2·C(n,k)/2^C(k,2)⌋`, the guaranteed surviving-set size |
| `ramsey_deletion_bound` | restatement of `ramsey_deletion` in terms of `deletionBound` (by defeq) |
| `unionBound_caps_at_17_for_K6` | `2·C(17,6) < 2^15 ∧ ¬(2·C(18,6) < 2^15)` — union bound caps at `R(6,6) > 17` |
| `deletion_no_mono_K6` | a 2-colouring of `K₁₉` with an 18-vertex mono-`K₆`-free set (`deletionBound 19 6 = 18`), i.e. `R(6,6) > 18` |

So at `k = 6` the deletion method certifies `R(6,6) > 18`, **strictly better** than the sharp union bound's `> 17` — an improvement the symmetric LLL of this entry does *not* achieve at `k = 6`.

The analogous `k = 7` gain (`R(7,7) > 29` vs the union bound's `27`) is recorded as a **prose remark**, not a theorem, because `C(30,7) ≈ 2·10⁶` makes a naive-recursion kernel `decide` impractical.

## Axioms

All new results use kernel `decide` on `ℕ` only — **axiom-free** (`of_decide_eq_true`; no `native_decide`, no `Lean.ofReduceBool`, no `sorry`). Foundational `propext / Classical.choice / Quot.sound` only.

## ⚠️ Build verification status

**Not machine-verified this session.** The host is disk-full (`Docker.raw` full → mathlib-cache `leantar` decompress fails with `No space left on device`), and no complete olean set exists in any worktree. Mitigations applied:

- All arithmetic **independently verified in Python** (crossover points, floor values, both `k = 6` and `k = 7`).
- Lean **hand-audited**: `ramsey_deletion_bound := ramsey_deletion` typechecks by `def`-unfolding; `decide`-on-`Nat.choose` is empirically confirmed reducible by the already-merged `unionBound_beats_lll_at_6` (`2·C(17,6) < 2^15`); `maxHeartbeats` bumped to 800000 for the slightly larger `C(19,6) = 27132` recursion.

**CI / the deployer must build `Proofs.RamseyR4kExtensionsOQ03Deletion` and confirm green (and `#print axioms` clean) before merge, once the disk-full environment is reset.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)