### PR TITLE
Enrich Binary GCD total cost model (binary-gcd-oq-01-oq-01): 93→100

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/annotations.json
@@ -31,12 +31,12 @@
     "id": "ann-bgcost-2",
     "proofId": "binary-gcd-oq-01-oq-01",
     "range": {
-      "startLine": 59,
-      "endLine": 89
+      "startLine": 60,
+      "endLine": 81
     },
     "type": "definition",
     "title": "The Cost Recursion: Bit-Length per Step",
-    "content": "**The cost model.** $\\mathtt{binaryGcdCost}$ mirrors the five-branch recursion of $\\mathtt{binaryGcdSteps}$ *exactly* — even/even halves both, even/odd halves one, odd/odd subtracts the smaller from the larger and halves the difference — but instead of adding $1$ per step it adds $\\mathtt{Nat.size}(a) + \\mathtt{Nat.size}(b)$, the combined bit-length of the operands *at that step*. It is well-founded on $a+b$ (each branch strictly shrinks the sum, discharged by `decreasing_by omega`), with a finished computation ($a=0$ or $b=0$) costing $0$ (the two `@[simp]` boundary lemmas).",
+    "content": "**The cost model.** $\\mathtt{binaryGcdCost}$ mirrors the five-branch recursion of $\\mathtt{binaryGcdSteps}$ *exactly* — even/even halves both, even/odd halves one, odd/odd subtracts the smaller from the larger and halves the difference — but instead of adding $1$ per step it adds $\\mathtt{Nat.size}(a) + \\mathtt{Nat.size}(b)$, the combined bit-length of the operands *at that step*. It is well-founded on $a+b$: each branch strictly shrinks the sum (division by $2$ and truncated subtraction both decrease $a+b$ on positive operands), and the obligations are discharged uniformly by `termination_by a + b` / `decreasing_by all_goals omega`.",
     "mathContext": "Charging bit-length per step is faithful because every Stein primitive — a right shift, a subtraction, or a parity/comparison test — is $\\Theta(\\text{bit-length})$ bit operations.",
     "significance": "critical",
     "relatedConcepts": [
@@ -52,6 +52,33 @@
       "definition",
       "cost-model",
       "recursion"
+    ]
+  },
+  {
+    "id": "ann-bgcost-2b",
+    "proofId": "binary-gcd-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 89
+    },
+    "type": "theorem",
+    "title": "Boundary Lemmas: Zero Cost at a Finished Computation",
+    "content": "**The base cases, made definitional.** Two `@[simp]` lemmas pin the recursion's boundary: $\\mathtt{binaryGcdCost}\\,0\\,b = 0$ and $\\mathtt{binaryGcdCost}\\,a\\,0 = 0$. They say the honest statement that *once an operand is zero the GCD is already known, so no further bit operations are charged*. The left case is the first defining equation ($\\mathtt{binaryGcdCost.eq\\_1}$) directly; the right case needs a `cases a` because the `match` lists `0, _` before `_, 0`, so `a = 0` falls through the first equation and `a = a'+1` through the second ($\\mathtt{binaryGcdCost.eq\\_2}$). Marking both `@[simp]` lets the later induction close its $a=0$ and $b=0$ leaves by `simp` alone.",
+    "mathContext": "These are the recursion's fixed points: $\\mathtt{binaryGcdCost}$ accumulates $\\mathtt{Nat.size}\\,a + \\mathtt{Nat.size}\\,b$ strictly *before* recursing, so a terminal pair contributes nothing — matching $\\mathtt{binaryGcdSteps}\\,0\\,b = 0$ step-for-step and keeping the two recursions aligned at the base.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Base cases of a well-founded recursion",
+      "Match-arm ordering and generated equation lemmas (eq_1, eq_2)",
+      "@[simp] normal forms feeding a later induction"
+    ],
+    "prerequisites": [
+      "How Lean compiles a multi-argument match into equation lemmas",
+      "Case analysis on a Nat successor"
+    ],
+    "tags": [
+      "proof-step",
+      "base-case",
+      "simp-lemma"
     ]
   },
   {

--- a/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-01/meta.json
@@ -86,9 +86,17 @@
       "id": "cost-definition",
       "title": "The total bit-operation cost model",
       "startLine": 59,
-      "endLine": 89,
-      "summary": "binaryGcdCost a b: mirrors the five-branch recursion of binaryGcdSteps but charges each step Nat.size a + Nat.size b (the combined bit-length of the current operands) instead of 1. Well-founded on a + b. The two boundary simp lemmas binaryGcdCost_zero_left/right record the zero cost of a finished computation.",
+      "endLine": 81,
+      "summary": "binaryGcdCost a b: mirrors the five-branch recursion of binaryGcdSteps but charges each step Nat.size a + Nat.size b (the combined bit-length of the current operands) instead of 1. Well-founded on a + b, with termination_by a + b and decreasing_by all_goals omega discharging every branch (division and truncated subtraction both shrink the sum).",
       "mathContext": "Each Stein reduction — a shift (halving an even operand), a subtraction of the smaller odd operand from the larger, or the parity/comparison test — is linear in the bit-length of the operands, so Nat.size a + Nat.size b is the faithful per-step bit cost. binaryGcdCost is the sum of these costs over the whole reduction sequence."
+    },
+    {
+      "id": "boundary-lemmas",
+      "title": "Boundary lemmas: zero cost at a finished computation",
+      "startLine": 82,
+      "endLine": 89,
+      "summary": "Two @[simp] lemmas fix the recursion's boundary: binaryGcdCost_zero_left (binaryGcdCost 0 b = 0) and binaryGcdCost_zero_right (binaryGcdCost a 0 = 0). The left case is the first generated equation (eq_1); the right needs cases a because the match lists 0,_ before _,0, so a = a'+1 goes through eq_2. Both are marked @[simp] so the later induction closes its a = 0 and b = 0 leaves automatically.",
+      "mathContext": "Once an operand is zero the GCD is already known, so no further bit operations are charged: these are the fixed points of the cost recursion, matching binaryGcdSteps 0 b = 0 step-for-step and keeping the two recursions aligned at the base."
     },
     {
       "id": "per-step-bound",


### PR DESCRIPTION
Enrichment pass for `binary-gcd-oq-01-oq-01` (quality 93 → 100).

## Changes
- **Sections 4 → 5:** the cost-model section bundled the `binaryGcdCost` definition (lines 59–81) with the two base-case simp lemmas (83–89). Split them at the theorem boundary into a *recursion definition* section and a *boundary lemmas* section.
- **Annotations 4 → 5:** added `ann-bgcost-2b` covering `binaryGcdCost_zero_left`/`binaryGcdCost_zero_right` — match-arm ordering (`0,_` before `_,0`), the generated `eq_1`/`eq_2` equation lemmas, and how `@[simp]` feeds the later strong induction's base leaves.
- Anchored both split annotations to real construct lines (60 = def docstring, 83 = the `@[simp] theorem`) and typed the boundary-lemma annotation as `theorem` — annotation build resolves with no warnings.

Score buckets filled: annotations 20 → 25, sections 8 → 10. All content is theorem-boundary-aligned and mathematically accurate against `Proofs/BinaryGcdOQ01OQ01.lean`.