### PR TITLE
Enrich Catalan difference identity (catalan-numbers-oq-05): 93→100

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-05/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-05/annotations.json
@@ -72,19 +72,42 @@
     "proofId": "catalan-numbers-oq-05",
     "range": {
       "startLine": 76,
-      "endLine": 91
+      "endLine": 81
     },
-    "type": "concept",
-    "title": "centralBinom restatement and numerical checks",
-    "content": "catalan_eq_centralBinom_sub' restates the identity through Nat.centralBinom (Mathlib's preferred spelling), via Nat.centralBinom_eq_two_mul_choose. The five examples evaluate both sides at n = 0..4, confirming the first Catalan numbers 1, 1, 2, 5, 14 as C(2n,n) − C(2n,n+1): e.g. at n = 2, C(4,2) − C(4,3) = 6 − 4 = 2, and at n = 4, C(8,4) − C(8,5) = 70 − 56 = 14.",
-    "mathContext": "$C_0,\\dots,C_4 = 1,1,2,5,14$; e.g. $\\binom{8}{4}-\\binom{8}{5} = 70-56 = 14 = C_4$.",
+    "type": "theorem",
+    "title": "centralBinom restatement of the difference identity",
+    "content": "catalan_eq_centralBinom_sub' restates catalan n = C(2n,n) − C(2n,n+1) through Nat.centralBinom, Mathlib's preferred spelling of the central coefficient. The proof rewrites the leading C(2n,n) as Nat.centralBinom n via Nat.centralBinom_eq_two_mul_choose and delegates to the choose-form theorem catalan_eq_centralBinom_sub — no new mathematical content, only alignment with Mathlib's API so downstream results can consume the identity directly.",
+    "mathContext": "$\\mathrm{catalan}\\,n = \\mathrm{centralBinom}\\,n - \\binom{2n}{n+1}$, where $\\mathrm{centralBinom}\\,n = \\binom{2n}{n}$ definitionally.",
     "significance": "supporting",
     "relatedConcepts": [
       "Nat.centralBinom",
+      "Nat.centralBinom_eq_two_mul_choose",
       "Catalan numbers"
     ],
     "prerequisites": [
-      "binomial coefficient evaluation"
+      "the choose-form difference identity",
+      "Mathlib's centralBinom spelling"
+    ]
+  },
+  {
+    "id": "ann-catalan-sub-checks",
+    "proofId": "catalan-numbers-oq-05",
+    "range": {
+      "startLine": 83,
+      "endLine": 91
+    },
+    "type": "concept",
+    "title": "Numerical sanity checks against the first Catalan numbers",
+    "content": "Five example lemmas instantiate catalan_eq_centralBinom_sub at n = 0..4, confirming the first Catalan numbers 1, 1, 2, 5, 14 as C(2n,n) − C(2n,n+1): e.g. at n = 2, C(4,2) − C(4,3) = 6 − 4 = 2, and at n = 4, C(8,4) − C(8,5) = 70 − 56 = 14. Because each example is proved by the general theorem itself (not by decide), they double as a lightweight regression check that the identity's indices are correct.",
+    "mathContext": "$C_0,\\dots,C_4 = 1,1,2,5,14$; e.g. $\\binom{8}{4}-\\binom{8}{5} = 70-56 = 14 = C_4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "binomial coefficient evaluation",
+      "regression sanity check"
+    ],
+    "prerequisites": [
+      "the difference identity catalan_eq_centralBinom_sub"
     ]
   }
 ]

--- a/src/data/proofs/catalan-numbers-oq-05/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-05/meta.json
@@ -95,11 +95,20 @@
       "summary": "catalan_eq_centralBinom_sub: rewrites C(2n,n) = (n+1)·catalan n (bridge) and C(2n,n+1) = n·catalan n (workhorse lemma), turning the goal into (n+1)·c − n·c = c; Nat.add_one_mul and Nat.add_sub_cancel_left finish it. No appeal to b ≤ a is needed — the truncated subtraction resolves algebraically."
     },
     {
-      "id": "centralbinom-restatement-and-checks",
-      "title": "centralBinom restatement and numerical sanity checks",
+      "id": "centralbinom-restatement",
+      "title": "centralBinom restatement of the difference identity",
       "startLine": 76,
+      "endLine": 81,
+      "summary": "catalan_eq_centralBinom_sub' restates catalan n = C(2n,n) − C(2n,n+1) through Nat.centralBinom (Mathlib's preferred spelling of the central coefficient), obtained by rewriting with Nat.centralBinom_eq_two_mul_choose and delegating to the choose-form theorem.",
+      "mathContext": "$\\mathrm{catalan}\\,n = \\mathrm{centralBinom}\\,n - \\binom{2n}{n+1}$, with $\\mathrm{centralBinom}\\,n = \\binom{2n}{n}$ by definition — a pure renaming that aligns the result with Mathlib's API."
+    },
+    {
+      "id": "numerical-checks",
+      "title": "Numerical sanity checks against the first Catalan numbers",
+      "startLine": 83,
       "endLine": 91,
-      "summary": "catalan_eq_centralBinom_sub' restates the identity through Nat.centralBinom (Mathlib's preferred spelling), and five examples confirm it against the first Catalan numbers 1, 1, 2, 5, 14 at n = 0..4."
+      "summary": "Five example lemmas evaluate both sides of catalan_eq_centralBinom_sub at n = 0..4, confirming the first Catalan numbers 1, 1, 2, 5, 14 as C(2n,n) − C(2n,n+1).",
+      "mathContext": "$C_0,\\dots,C_4 = 1,1,2,5,14$; e.g. at $n=4$, $\\binom{8}{4}-\\binom{8}{5} = 70-56 = 14 = C_4$."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-05` (93 → 100).

## Changes
- **Sections 4 → 5:** the `centralBinom restatement and numerical sanity checks` section (lines 76–91) bundled the `catalan_eq_centralBinom_sub'` restatement theorem with five `example` sanity checks. Split at the theorem boundary (line 82) into the *centralBinom restatement* (76–81) and *numerical sanity checks* (83–91), and added `mathContext` to both to match the file's other sections.
- **Annotations 4 → 5:** correspondingly split into a `theorem`-typed restatement annotation and a `concept`-typed numerical-checks annotation.

Score buckets filled: annotations 20 → 25, sections 8 → 10. Boundaries align with the theorem structure of `Proofs/CatalanNumbersOQ05.lean`; annotation build resolves with no warnings.