### PR TITLE
research(mz-slln): S4b step-3/4 truncation-moment kernels (verified 0-axiom)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -62,11 +62,11 @@
       running Kolmogorov's criterion on the rescaled `Xᵢ = aᵢ⁻¹·Yᵢ` and feeding
       its a.s.-convergence output through the a.e. Kronecker lift.
 
-  Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`) through
-  § TruncationReduction. The trailing § TruncationMomentKernels (the two S4b step-3/4
-  pointwise `rpow` kernels) is written 0-sorry/0-`axiom` but its build is PENDING — it was
-  added while the host disk was 100 % full and the mandated Docker build could not run;
-  compile it before treating those two lemmas as machine-checked.
+  Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`).
+  The trailing § TruncationMomentKernels (the two S4b step-3/4 pointwise `rpow`
+  kernels) is now machine-checked: `docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01`
+  → Built (7743 jobs, exit 0). Pure `Real.rpow` real-analysis, no
+  `decide`/`native_decide`/`sorry`/`axiom`, so 0-axiom by construction.
 -/
 import Mathlib
 

--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -62,7 +62,11 @@
       running Kolmogorov's criterion on the rescaled `Xᵢ = aᵢ⁻¹·Yᵢ` and feeding
       its a.s.-convergence output through the a.e. Kronecker lift.
 
-  Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`).
+  Verified: 0 sorry, 0 axiom (only `propext`/`Classical.choice`/`Quot.sound`) through
+  § TruncationReduction. The trailing § TruncationMomentKernels (the two S4b step-3/4
+  pointwise `rpow` kernels) is written 0-sorry/0-`axiom` but its build is PENDING — it was
+  added while the host disk was 100 % full and the mandated Docker build could not run;
+  compile it before treating those two lemmas as machine-checked.
 -/
 import Mathlib
 
@@ -793,5 +797,90 @@ theorem ae_eventually_abs_le_rpow_of_identDistrib [IsProbabilityMeasure μ]
   simpa only [Set.mem_setOf_eq, not_lt] using hi
 
 end TruncationReduction
+
+/-! ## S4b (steps 3–4) — the two truncation-moment kernels
+
+With step 1 (the a.s. eventual truncation `|Xᵢ| ≤ i^{1/p}`) in hand, the
+Marcinkiewicz–Zygmund proof reduces to two analytic estimates on the truncated
+variables `Yᵢ = Xᵢ·𝟙{|Xᵢ| ≤ i^{1/p}}`:
+
+* **step 3 (centering).** `n^{-1/p} ∑_{i<n} 𝔼Yᵢ → 0`.  Since `𝔼X = 0`, one has
+  `|𝔼Yᵢ| ≤ 𝔼[|X|·𝟙{|X| > i^{1/p}}]`, and on the tail `{|X| > i^{1/p}}` the bound
+  `|x| ≤ i^{(1-p)/p}·|x|^p` turns this into a `Toeplitz`-summable null sequence.
+* **step 4 (variance).** `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`.  On the truncation
+  `{|X| ≤ i^{1/p}}` the bound `x² ≤ i^{(2-p)/p}·|x|^p` gives
+  `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|^p`, so the weighted sum is controlled by
+  `𝔼|X|^p · ∑ᵢ i^{-2/p}`, convergent precisely because `p < 2` (`2/p > 1`).
+
+Both estimates rest on a single pointwise `rpow` inequality apiece; those two
+kernels are supplied here.  They are pure real-analysis facts (no measure theory),
+elementary, and reused verbatim by the integral-level estimates of the two steps.
+The `1 ≤ p` / `p < 2` hypotheses enter through the sign of the scaling exponent
+(`1 - p ≤ 0` makes the tail factor sub-linear; `2 - p ≥ 0` makes the truncation
+factor super-linear). -/
+
+section TruncationMomentKernels
+
+/-- **Tail moment kernel (MZ step 3, centering).**  For an exponent `1 ≤ p`, a
+threshold `0 < t`, and a point on the tail `t < |x|`, the absolute value is
+dominated by the `p`-th power scaled by the sub-linear factor `t^{1-p}`:
+
+    |x| ≤ t^{1-p} · |x|^p.
+
+Applied with `t = i^{1/p}` (so `t^{1-p} = i^{(1-p)/p}`) this is the pointwise
+inequality behind the centering estimate
+`|𝔼Yᵢ| ≤ 𝔼[|X|·𝟙{|X| > i^{1/p}}] ≤ i^{(1-p)/p}·𝔼|X|^p`, whose right-hand side
+is a `tendsto_weighted_average_zero`-summable null sequence.
+
+Proof: split `|x| = |x|^p · |x|^{1-p}` (`rpow_add`), and since `1 - p ≤ 0` and
+`0 < t < |x|`, the antitone rpow bound `|x|^{1-p} ≤ t^{1-p}`
+(`rpow_le_rpow_of_nonpos`) finishes it. -/
+theorem abs_le_rpow_mul_rpow_of_tail {p t x : ℝ} (hp : 1 ≤ p) (ht : 0 < t)
+    (hx : t < |x|) : |x| ≤ t ^ (1 - p) * |x| ^ p := by
+  have hxpos : 0 < |x| := ht.trans hx
+  have hexp : 1 - p ≤ 0 := by linarith
+  have hstep : |x| ^ (1 - p) ≤ t ^ (1 - p) :=
+    Real.rpow_le_rpow_of_nonpos ht hx.le hexp
+  have hsplit : |x| ^ p * |x| ^ (1 - p) = |x| := by
+    rw [← Real.rpow_add hxpos, show p + (1 - p) = 1 by ring, Real.rpow_one]
+  calc |x| = |x| ^ p * |x| ^ (1 - p) := hsplit.symm
+    _ ≤ |x| ^ p * t ^ (1 - p) :=
+        mul_le_mul_of_nonneg_left hstep (Real.rpow_nonneg hxpos.le p)
+    _ = t ^ (1 - p) * |x| ^ p := by ring
+
+/-- **Truncated second-moment kernel (MZ step 4, variance).**  For an exponent
+`p < 2`, a threshold `0 < t`, and a point inside the truncation `|x| ≤ t`, the
+square is dominated by the `p`-th power scaled by the super-linear factor `t^{2-p}`:
+
+    x² ≤ t^{2-p} · |x|^p.
+
+Applied with `t = i^{1/p}` (so `t^{2-p} = i^{(2-p)/p}`) this is the pointwise
+inequality behind the second-moment estimate `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|^p`; summed
+against `i^{-2/p}` it yields `∑ᵢ Var(Yᵢ)/i^{2/p} ≤ 𝔼|X|^p · ∑ᵢ i^{-2/p} < ∞`, the
+convergent series (using `p < 2`, i.e. `2/p > 1`) that Kolmogorov's criterion
+consumes.
+
+Proof: the `x = 0` case is nonnegativity of the right-hand side; otherwise split
+`x² = |x|^2 = |x|^p · |x|^{2-p}` (`rpow_add`, `sq_abs`), and since `0 ≤ 2 - p` and
+`0 < |x| ≤ t`, the monotone rpow bound `|x|^{2-p} ≤ t^{2-p}` (`rpow_le_rpow`)
+finishes it. -/
+theorem sq_le_rpow_mul_rpow_of_trunc {p t x : ℝ} (hp : p < 2) (ht : 0 < t)
+    (hx : |x| ≤ t) : x ^ 2 ≤ t ^ (2 - p) * |x| ^ p := by
+  rcases eq_or_ne x 0 with h0 | h0
+  · subst h0
+    rw [show (0 : ℝ) ^ 2 = 0 by norm_num]
+    exact mul_nonneg (Real.rpow_nonneg ht.le _) (Real.rpow_nonneg (abs_nonneg _) _)
+  · have hxpos : 0 < |x| := abs_pos.mpr h0
+    have hexp : 0 ≤ 2 - p := by linarith
+    have hstep : |x| ^ (2 - p) ≤ t ^ (2 - p) := Real.rpow_le_rpow hxpos.le hx hexp
+    have hsplit : |x| ^ p * |x| ^ (2 - p) = x ^ 2 := by
+      rw [← Real.rpow_add hxpos, show p + (2 - p) = 2 by ring,
+        show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast, sq_abs]
+    calc x ^ 2 = |x| ^ p * |x| ^ (2 - p) := hsplit.symm
+      _ ≤ |x| ^ p * t ^ (2 - p) :=
+          mul_le_mul_of_nonneg_left hstep (Real.rpow_nonneg hxpos.le p)
+      _ = t ^ (2 - p) * |x| ^ p := by ring
+
+end TruncationMomentKernels
 
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -440,19 +440,18 @@ step's a.s. eventual `Xᵢ = Yᵢ`.
 
 ---
 
-## S4b steps 3–4 kernels (researcher-14, 2026-07-03) — BUILD: pointwise truncation-moment kernels WRITTEN (UNVERIFIED — host disk full)
+## S4b steps 3–4 kernels (written r14 2026-07-03, VERIFIED r8 2026-07-04) — BUILD: pointwise truncation-moment kernels SHIPPED
 
-**Outcome: BUILD (unverified).** Wrote the two **pointwise `rpow` inequalities** that are
+**Outcome: BUILD (verified).** Wrote the two **pointwise `rpow` inequalities** that are
 the analytic hearts of the two remaining S4b estimates (centering and variance). Both are
-pure real-analysis (no measure theory), elementary, reusable, written 0-sorry / 0-`axiom`.
+pure real-analysis (no measure theory), elementary, reusable, 0-sorry / 0-`axiom`.
 New section `§ TruncationMomentKernels` in `LawsOfLargeNumbersOQ01OQ02OQ01.lean`.
 
-> **VERIFICATION BLOCKED.** The mandated Docker build did not run: host disk 100 % full
-> (122 Mi free of 926 Gi), Docker daemon I/O-erroring on its own content store. All
-> Mathlib lemmas were name/signature-checked against the pinned `v4.26.0` source and the
-> idioms mirror the already-verified S4b step-1 lemmas, but the file is **not** compiled.
-> Next session must build before relying on these lemmas. (Disk culprit is the user's
-> *other* repos, per prior deployer/auditor notes — not this repo.)
+> **VERIFIED (researcher-8, 2026-07-04).** The disk-full blocker cleared (9.3 Gi free);
+> `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built
+> (7743 jobs, 54s, exit 0)**. Both kernels use only `Real.rpow` lemmas with no
+> `decide`/`native_decide`/`sorry`/`axiom`, so 0-axiom by construction. The r14
+> name/signature pre-checks against the pinned `v4.26.0` source all held.
 
 ### What shipped
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -437,3 +437,76 @@ S4b step-3 (centered-truncation control `∑ᵢ 𝔼Yᵢ/n^{1/p} → 0`) and ste
 (`∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, uses `p<2`), then final assembly via S5
 `ae_tendsto_average_zero_of_variance_weighted_bdd` on the centered truncations plus this
 step's a.s. eventual `Xᵢ = Yᵢ`.
+
+---
+
+## S4b steps 3–4 kernels (researcher-14, 2026-07-03) — BUILD: pointwise truncation-moment kernels WRITTEN (UNVERIFIED — host disk full)
+
+**Outcome: BUILD (unverified).** Wrote the two **pointwise `rpow` inequalities** that are
+the analytic hearts of the two remaining S4b estimates (centering and variance). Both are
+pure real-analysis (no measure theory), elementary, reusable, written 0-sorry / 0-`axiom`.
+New section `§ TruncationMomentKernels` in `LawsOfLargeNumbersOQ01OQ02OQ01.lean`.
+
+> **VERIFICATION BLOCKED.** The mandated Docker build did not run: host disk 100 % full
+> (122 Mi free of 926 Gi), Docker daemon I/O-erroring on its own content store. All
+> Mathlib lemmas were name/signature-checked against the pinned `v4.26.0` source and the
+> idioms mirror the already-verified S4b step-1 lemmas, but the file is **not** compiled.
+> Next session must build before relying on these lemmas. (Disk culprit is the user's
+> *other* repos, per prior deployer/auditor notes — not this repo.)
+
+### What shipped
+
+- `abs_le_rpow_mul_rpow_of_tail` — **step-3 kernel (centering).**
+  `1 ≤ p`, `0 < t`, `t < |x|` ⟹ `|x| ≤ t^{1-p} · |x|^p`.
+  Mechanism: `|x| = |x|^p · |x|^{1-p}` (`Real.rpow_add`, exponent `p+(1-p)=1`), and
+  the **sign of `1-p`** does the work — `1-p ≤ 0` with `0 < t ≤ |x|` gives the
+  *antitone* rpow bound `|x|^{1-p} ≤ t^{1-p}` via `Real.rpow_le_rpow_of_nonpos`
+  `(hx : 0<x) (hxy : x≤y) (hz : z≤0) : y^z ≤ x^z`.
+- `sq_le_rpow_mul_rpow_of_trunc` — **step-4 kernel (variance).**
+  `p < 2`, `0 < t`, `|x| ≤ t` ⟹ `x² ≤ t^{2-p} · |x|^p`.
+  Mechanism: `x=0` case is RHS-nonnegativity; else `x² = |x|^2 = |x|^p · |x|^{2-p}`
+  via `Real.rpow_add` + the cast chain `|x|^{(2:ℝ)} = |x|^{((2:ℕ):ℝ)} = |x|^{(2:ℕ)} = x²`
+  (`Real.rpow_natCast`, `sq_abs`), then `0 ≤ 2-p` with `0 < |x| ≤ t` gives the
+  *monotone* rpow bound `|x|^{2-p} ≤ t^{2-p}` via `Real.rpow_le_rpow`.
+
+### Insights (propagate)
+
+- **The `p`-regime hypotheses enter through one sign each.** `1 ≤ p` ⟺ `1-p ≤ 0`
+  (tail factor `t^{1-p}` sub-linear, step-3); `p < 2` ⟺ `0 ≤ 2-p` (truncation factor
+  `t^{2-p}` super-linear + `2/p > 1` for the variance-sum convergence, step-4). This is
+  the *entire* role of `1 ≤ p < 2` at the pointwise level — everything else is `rpow`
+  bookkeeping.
+- **`rpow_add` split idiom.** To relate `|x|` (or `x²`) to `|x|^p·(threshold)^{exp}`,
+  write the target power as `|x|^p · |x|^{k-p}` (`k=1` tail, `k=2` variance) via
+  `← Real.rpow_add hxpos` with the exponent identity closed by `show … = k by ring`,
+  then bound the *second* factor by the threshold using the appropriate signed-exponent
+  monotonicity lemma. Reused verbatim in both kernels.
+- **`x^(2:ℝ) = x^(2:ℕ)` cast chain** (recurs whenever a square meets rpow): 
+  `rw [show (2:ℝ) = ((2:ℕ):ℝ) by norm_num, Real.rpow_natCast, sq_abs]`. `sq_abs` turns
+  `|x|^(2:ℕ)` into `x^(2:ℕ)` for free.
+- These kernels are **pointwise only** — the surviving work is the *integral lift*:
+  `integral_mono`/`abs_integral_le` against the kernel to reach `|𝔼Yᵢ| ≤ i^{(1-p)/p}𝔼|X|^p`
+  (step-3) and `𝔼[Yᵢ²] ≤ i^{(2-p)/p}𝔼|X|^p` (step-4), plus the two sums.
+
+### Recommended next: step-4 before step-3
+
+Step-4's integral lift is more self-contained (just `integral_mono` on the indicator
+`Yᵢ² = Xᵢ²·𝟙{|Xᵢ|≤i^{1/p}}` + a Mathlib `∑ i^{-2/p}` convergence lemma —
+`Real.summable_one_div_nat_rpow` with `2/p > 1`), whereas step-3 additionally needs the
+weight partial-sum asymptotic `∑_{i<n} i^{1/p-1} ~ p·n^{1/p} → ∞` for
+`tendsto_weighted_average_zero`. Do step-4 first.
+
+### Process / hazard
+
+- **Worktree-deletion hazard recurred (3rd session running).** The unlocked worktree at
+  `.loom/worktrees/researcher-14` was deleted mid-session by a concurrent cleanup, then a
+  `/private/tmp` replacement was *also* deleted. Only **`--lock`ed** worktrees survive
+  (all long-lived worktrees in `git worktree list` show `locked`). Mandatory pattern:
+  `git worktree add --lock /Users/rwalters/lg-wt/<name> <branch>`.
+- The stale `feature/researcher-14` branch is at an *old* main commit with **no** MZ file;
+  the merged MZ work lives on `origin/main`. Always base new MZ work on `origin/main`.
+
+### Files modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (+~90 lines, § TruncationMomentKernels)
+- `research/problems/.../state.md`, `.../knowledge.md`, problem JSON knowledge

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b steps 3–4 truncation-moment *kernels* SHIPPED — remaining: integral-level estimates + assembly)
-**Since**: 2026-07-03
-**Iteration**: 8 (S4b step-3/step-4 pointwise moment kernels SHIPPED; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Phase**: ACT (S4b steps 3–4 truncation-moment *kernels* SHIPPED & VERIFIED — remaining: integral-level estimates + assembly)
+**Since**: 2026-07-04
+**Iteration**: 8 (S4b step-3/step-4 pointwise moment kernels SHIPPED & build-VERIFIED; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -41,18 +41,17 @@ to the actual truncation event — is now in the file (§ TruncationReduction), 
   `rw [tsum_eq_zero_add' ENNReal.summable]`** (this is exactly how Mathlib's own
   `Topology/Instances/ENNReal/Lemmas.lean` peels ENNReal tsums). Compiles instantly.
 
-## S4b steps 3–4 (kernels) — WRITTEN, BUILD-BLOCKED (iteration 8, this session)
+## S4b steps 3–4 (kernels) — SHIPPED & VERIFIED (iteration 8 written r14, verified r8)
 
-> **VERIFICATION STATUS: UNVERIFIED.** The mandated Docker build could **not** run —
-> the host disk is 100 % full (122 Mi free of 926 Gi) and the Docker daemon is
-> I/O-erroring on its own content store. Every Mathlib lemma used was pre-checked for
-> name + signature against the pinned `v4.26.0` source, and the proof idioms mirror the
-> already-verified S4b step-1 lemmas in the same file, but the file has **not** been
-> compiled. Do not treat these two lemmas as machine-checked until a Docker build passes.
+> **VERIFICATION STATUS: VERIFIED (researcher-8, 2026-07-04).** The disk-full blocker
+> cleared (9.3 Gi free); `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01`
+> → **Built (7743 jobs, 54s, exit 0)**. Both kernels are pure `Real.rpow` real-analysis
+> with no `decide`/`native_decide`/`sorry`/`axiom` and depend only on already-0-axiom
+> Mathlib lemmas, so 0-axiom by construction (`propext`/`Classical.choice`/`Quot.sound`).
 
 The two **pointwise truncation-moment kernels** — the analytic hearts of the two
 remaining S4b estimates — are now in the file (§ TruncationMomentKernels), pure
-real-analysis (no measure theory), written 0-sorry / 0-`axiom` (build-pending):
+real-analysis (no measure theory), 0-sorry / 0-`axiom`, machine-checked:
 
 - `abs_le_rpow_mul_rpow_of_tail` — **step-3 kernel (centering):** for `1 ≤ p`,
   `0 < t`, `t < |x|`, one has `|x| ≤ t^{1-p} · |x|^p`. Proof: split
@@ -68,11 +67,9 @@ real-analysis (no measure theory), written 0-sorry / 0-`axiom` (build-pending):
   the `p < 2` hypothesis enters exactly through the sign `0 ≤ 2-p`, making the scaling
   factor super-linear so `∑ᵢ i^{-2/p}` converges.
 
-**Do NOT re-derive** (once the build confirms them). The two pointwise inequalities are
-settled modulo the pending compile; the surviving work is the *integral-level* lift of
-each (indicator/`integral_mono` plumbing to reach `|𝔼Yᵢ|` and `𝔼[Yᵢ²]`), then the two
-sums, then assembly. **First action next session: run the Docker build to verify these
-two lemmas** (host disk permitting).
+**Do NOT re-derive.** The two pointwise inequalities are settled and verified; the
+surviving work is the *integral-level* lift of each (indicator/`integral_mono` plumbing
+to reach `|𝔼Yᵢ|` and `𝔼[Yᵢ²]`), then the two sums, then assembly.
 
 ## Active Approach
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-1 truncation reduction SHIPPED — remaining S4b analytic layer)
+**Phase**: ACT (S4b steps 3–4 truncation-moment *kernels* SHIPPED — remaining: integral-level estimates + assembly)
 **Since**: 2026-07-03
-**Iteration**: 7 (S4b step-1 i.i.d. Borel–Cantelli truncation SHIPPED; S4b step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 8 (S4b step-3/step-4 pointwise moment kernels SHIPPED; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -41,37 +41,76 @@ to the actual truncation event — is now in the file (§ TruncationReduction), 
   `rw [tsum_eq_zero_add' ENNReal.summable]`** (this is exactly how Mathlib's own
   `Topology/Instances/ENNReal/Lemmas.lean` peels ENNReal tsums). Compiles instantly.
 
+## S4b steps 3–4 (kernels) — WRITTEN, BUILD-BLOCKED (iteration 8, this session)
+
+> **VERIFICATION STATUS: UNVERIFIED.** The mandated Docker build could **not** run —
+> the host disk is 100 % full (122 Mi free of 926 Gi) and the Docker daemon is
+> I/O-erroring on its own content store. Every Mathlib lemma used was pre-checked for
+> name + signature against the pinned `v4.26.0` source, and the proof idioms mirror the
+> already-verified S4b step-1 lemmas in the same file, but the file has **not** been
+> compiled. Do not treat these two lemmas as machine-checked until a Docker build passes.
+
+The two **pointwise truncation-moment kernels** — the analytic hearts of the two
+remaining S4b estimates — are now in the file (§ TruncationMomentKernels), pure
+real-analysis (no measure theory), written 0-sorry / 0-`axiom` (build-pending):
+
+- `abs_le_rpow_mul_rpow_of_tail` — **step-3 kernel (centering):** for `1 ≤ p`,
+  `0 < t`, `t < |x|`, one has `|x| ≤ t^{1-p} · |x|^p`. Proof: split
+  `|x| = |x|^p·|x|^{1-p}` (`Real.rpow_add`), then `1-p ≤ 0` + `0 < t < |x|` give
+  `|x|^{1-p} ≤ t^{1-p}` (`Real.rpow_le_rpow_of_nonpos`). With `t = i^{1/p}` this is
+  the pointwise bound behind `|𝔼Yᵢ| ≤ i^{(1-p)/p}·𝔼|X|^p` (a
+  `tendsto_weighted_average_zero`-summable null sequence).
+- `sq_le_rpow_mul_rpow_of_trunc` — **step-4 kernel (variance):** for `p < 2`,
+  `0 < t`, `|x| ≤ t`, one has `x² ≤ t^{2-p} · |x|^p`. Proof: `x=0` is RHS-nonneg;
+  else split `x² = |x|^p·|x|^{2-p}` (`Real.rpow_add`, `sq_abs`, `Real.rpow_natCast`),
+  then `0 ≤ 2-p` + `0 < |x| ≤ t` give `|x|^{2-p} ≤ t^{2-p}` (`Real.rpow_le_rpow`).
+  With `t = i^{1/p}` this is the pointwise bound behind `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|^p`;
+  the `p < 2` hypothesis enters exactly through the sign `0 ≤ 2-p`, making the scaling
+  factor super-linear so `∑ᵢ i^{-2/p}` converges.
+
+**Do NOT re-derive** (once the build confirms them). The two pointwise inequalities are
+settled modulo the pending compile; the surviving work is the *integral-level* lift of
+each (indicator/`integral_mono` plumbing to reach `|𝔼Yᵢ|` and `𝔼[Yᵢ²]`), then the two
+sums, then assembly. **First action next session: run the Docker build to verify these
+two lemmas** (host disk permitting).
+
 ## Active Approach
 
-None in-flight. Next work item is S4b step-3 / step-4 below.
+None in-flight. Next work item is the integral lift of the two kernels below.
 
 ## Blockers
 
-- **S4b step-3 (centered-truncation control, ~1 session):** `∑ᵢ 𝔼Yᵢ / n^{1/p} → 0`
-  using `𝔼X = 0` and a moment/`rpow` estimate on the truncated means (Kronecker-style).
-- **S4b step-4 (variance-sum estimate, ~1–2 sessions):** `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`
-  (uses `p < 2`, so `2/p > 1` — this is where `p < 2` is *essential*). Then feed into
-  `ae_tendsto_sum_of_indep_of_variance_bdd` (S4a) and lift via
-  `ae_tendsto_kronecker_average_zero` (S2) for the final M–Z normalisation.
+- **S4b step-3 integral lift (~1 session):** turn `abs_le_rpow_mul_rpow_of_tail` into
+  `|𝔼Yᵢ| ≤ i^{(1-p)/p}·𝔼|X|^p` (via `𝔼X = 0` ⟹ `𝔼Yᵢ = -𝔼[X·𝟙{|X|>i^{1/p}}]`,
+  `abs_integral_le`, `integral_mono` against the kernel), then
+  `∑_{i<n} 𝔼Yᵢ / n^{1/p} → 0` via `tendsto_weighted_average_zero` with the null
+  sequence `cᵢ = 𝔼[|X|^p·𝟙{|X|>i^{1/p}}] → 0` and weight `i^{(1-p)/p}` (needs the
+  weight partial-sum asymptotic `∑_{i<n} i^{1/p-1} ~ p·n^{1/p} → ∞`).
+- **S4b step-4 integral lift (~1–2 sessions):** turn `sq_le_rpow_mul_rpow_of_trunc`
+  into `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|^p` (`integral_mono` on `Yᵢ² = Xᵢ²·𝟙{|Xᵢ|≤i^{1/p}}`),
+  then `Var(Yᵢ) ≤ 𝔼[Yᵢ²]` and `∑ᵢ Var(Yᵢ)/i^{2/p} ≤ 𝔼|X|^p · ∑ᵢ i^{-2/p} < ∞`
+  (Mathlib `Real.summable_one_div_nat_rpow` / `summable_nat_rpow`, `2/p > 1`).
+- **Assembly:** `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5) on the centered
+  truncations `Yᵢ − 𝔼Yᵢ`, combined with step-1's a.s. eventual `Xᵢ = Yᵢ` and step-3's
+  centering control, gives the full M–Z SLLN.
 
 **DONE (do not re-derive):** S1 survey · S2 Kronecker · S3 martingale · **S4a variance
 L¹-bound** (`ae_tendsto_sum_of_indep_of_variance_bdd` + `eLpNorm_two_sq_eq_evariance` +
 `eLpNorm_two_partialSum_le`) · **S4b step-2 tail-sum** · **S4b step-1 i.i.d. truncation**
-(this iteration). All 0-axiom.
+· **S4b step-3/step-4 pointwise moment kernels** (this iteration). All 0-axiom.
 
 ## Next Action
 
-- **S4b step-3 (next):** centered-truncation control `∑ᵢ 𝔼Yᵢ / n^{1/p} → 0`. With
-  step-1 done, the surviving work is the two analytic estimates (step-3 centering,
-  step-4 variance sum using `p<2`), then final assembly:
-  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5) applied to the centered
-  truncations `Yᵢ − 𝔼Yᵢ`, combined with the step-1 a.s. eventual `Xᵢ = Yᵢ`.
+- **S4b step-4 integral lift (next):** it is more self-contained than step-3 (no weight
+  asymptotics needed — just `integral_mono` + a Mathlib `∑ i^{-2/p}` convergence lemma),
+  so prove `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞` first, then return to step-3's centering control.
 
 ## Attempt Counts
 
-- Total attempts: 7 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation)
-- Current approach attempts: 1 (S4b step-1 — landed after diagnosing the `tsum_eq_zero_add` whnf pathology; salvaged prior interrupted draft off origin/main)
-- Approaches tried: 6 (S1 literature/decomposition; S2 Abel+Toeplitz;
+- Total attempts: 8 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels)
+- Current approach attempts: 1 (S4b step-3/4 kernels — elementary `rpow_add` split + signed-exponent monotonicity, landed clean; worktree recreated as locked after concurrent cleanup nuked the unlocked one)
+- Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
   S4b step-2 discrete layer cake via lintegral_tsum + floor count;
-  S4b step-1 IdentDistrib transfer + rpow reindex + tsum peel + first Borel–Cantelli)
+  S4b step-1 IdentDistrib transfer + rpow reindex + tsum peel + first Borel–Cantelli;
+  S4b step-3/4 pointwise rpow kernels via rpow_add split + rpow_le_rpow(_of_nonpos))

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,14 +31,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S4b step-1, researcher-14, 2026-07-03): i.i.d. Borel-Cantelli truncation reduction SHIPPED 0-axiom — a.s. |Xi|<=i^{1/p} eventually, reducing MZ to its truncated version. Remaining: analytic step-3 (centering) and step-4 (variance sum, uses p<2), then S5 assembly.",
+    "progressSummary": "PROGRESS (S4b step-3/4 kernels, researcher-14, 2026-07-03): the two pointwise rpow truncation-moment kernels WRITTEN in § TruncationMomentKernels — abs_le_rpow_mul_rpow_of_tail (step-3 centering: 1<=p,0<t,t<|x| => |x|<=t^(1-p)|x|^p) and sq_le_rpow_mul_rpow_of_trunc (step-4 variance: p<2,0<t,|x|<=t => x^2<=t^(2-p)|x|^p). UNVERIFIED: host disk 100% full, Docker build could not run; lemma signatures pre-checked vs pinned Mathlib v4.26.0. Remaining: integral lift of each kernel (integral_mono) + the two sums (step-4 uses 2/p>1) + S5 assembly.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
       "ae_tendsto_kronecker_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:266 — a.e. lift of kronecker_lemma: (∀ᵐ ω, ∑ x_i ω/a_i converges) ⟹ (∀ᵐ ω, (∑_{i<n} x_i ω)/a_n → 0). The S3→S4 glue. Verified 0-axiom (filter_upwards + kronecker_lemma).",
       "rpow_inv_lt_iff_lt_rpow (LawsOfLargeNumbersOQ01OQ02OQ01.lean, section TruncationReduction) — elementary threshold reindex a^{1/p}<b iff a<b^p (0<p,0<=a,0<=b), 0-axiom",
       "tsum_measure_truncation_ne_top_of_identDistrib — for i.i.d. Xi with E|X0|^p<inf, truncation tail sum over i of mu{i^{1/p}<|Xi|} is finite (IdentDistrib.measure_mem_eq transfer + rpow reindex + tsum_eq_zero_add prime peel + step-2 tail-sum), 0-axiom",
-      "ae_eventually_abs_le_rpow_of_identDistrib — first Borel-Cantelli (ae_eventually_notMem) gives ae omega, eventually i, |Xi omega| <= i^{1/p}; MZ truncation reduction complete, 0-axiom"
+      "ae_eventually_abs_le_rpow_of_identDistrib — first Borel-Cantelli (ae_eventually_notMem) gives ae omega, eventually i, |Xi omega| <= i^{1/p}; MZ truncation reduction complete, 0-axiom",
+      "abs_le_rpow_mul_rpow_of_tail (§ TruncationMomentKernels) — step-3 centering kernel: 1<=p, 0<t, t<|x| => |x| <= t^(1-p)*|x|^p. Proof: rpow_add split |x|=|x|^p*|x|^(1-p) then Real.rpow_le_rpow_of_nonpos (1-p<=0). WRITTEN, build-pending (host disk full).",
+      "sq_le_rpow_mul_rpow_of_trunc (§ TruncationMomentKernels) — step-4 variance kernel: p<2, 0<t, |x|<=t => x^2 <= t^(2-p)*|x|^p. Proof: x=0 nonneg; else rpow_add split x^2=|x|^p*|x|^(2-p) (via rpow_natCast+sq_abs) then Real.rpow_le_rpow (0<=2-p). WRITTEN, build-pending (host disk full)."
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -53,13 +55,18 @@
       "PROCESS: the S2 session updated the .json but not state.md/knowledge.md, so the markdown still said S2-next and a later session duplicated Kronecker. Always update state.md AND knowledge.md in the commit that ships Lean.",
       "S3→S4 passage is now deterministic/axiom-free: ae_tendsto_kronecker_average_zero converts Kolmogorov criterion output (a.s. convergence of ∑ Y_i/a_i) directly into the M-Z normalisation ((∑_{i<n}Y_i)/a_n→0 a.s.). Only the probabilistic criterion (S3, martingale route per PR #34161) remains to reach the full M-Z SLLN.",
       "S4b step-1 (i.i.d. truncation reduction) SHIPPED 0-axiom (iter 7): the Borel-Cantelli passage from the step-2 discrete-layer-cake tail bound to the a.s. eventual truncation |Xi|<=i^{1/p} is complete. Remaining MZ gaps are the two analytic estimates step-3 (centering: sum of E Yi / n^{1/p} -> 0) and step-4 (sum of Var(Yi)/i^{2/p} < inf, uses p<2), then final assembly via S5.",
-      "Mathlib gotcha (v4.26): Summable.tsum_eq_zero_add (dot form) is whnf-pathological on mu{setOf}-valued summands — rw blows past 1e6 heartbeats even on abstract g:Nat->ENNReal and even as a fully-typed have. Fix: use the primed non-dot idiom tsum_eq_zero_add' ENNReal.summable (Mathlib's own ENNReal peel idiom)."
+      "Mathlib gotcha (v4.26): Summable.tsum_eq_zero_add (dot form) is whnf-pathological on mu{setOf}-valued summands — rw blows past 1e6 heartbeats even on abstract g:Nat->ENNReal and even as a fully-typed have. Fix: use the primed non-dot idiom tsum_eq_zero_add' ENNReal.summable (Mathlib's own ENNReal peel idiom).",
+      "MZ pointwise level: the whole role of 1<=p<2 is two exponent signs — 1-p<=0 (tail factor t^(1-p) sub-linear, step-3, needs antitone Real.rpow_le_rpow_of_nonpos) and 0<=2-p (truncation factor t^(2-p) super-linear + 2/p>1 for variance-sum convergence, step-4, needs monotone Real.rpow_le_rpow).",
+      "Reusable rpow_add split idiom: to bound |x| (or x^2) by |x|^p*(threshold)^exp, write target = |x|^p*|x|^(k-p) via (← Real.rpow_add hxpos) with exponent identity closed by (show ...=k by ring), then bound the second factor by the threshold with the signed-exponent monotonicity lemma. Used verbatim in both kernels.",
+      "x^(2:R)=x^(2:N) cast chain when a square meets rpow: rw [show (2:R)=((2:N):R) by norm_num, Real.rpow_natCast, sq_abs] (sq_abs turns |x|^(2:N) into x^(2:N)).",
+      "ENVIRONMENT: host disk 100% full (122Mi/926Gi) blocked the Docker build this session; daemon I/O-errors on its own content store. Docker verification impossible until user frees space (culprit = other repos, not this one). New Lean is written+signature-checked but UNVERIFIED."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S4b step-3: centered-truncation control sum of E Yi / n^{1/p} -> 0 via EX=0 + moment/rpow estimate on truncated means (Kronecker-style)",
-      "S4b step-4: variance-sum estimate sum of Var(Yi)/i^{2/p} < inf (uses p<2 essentially), then feed ae_tendsto_sum_of_indep_of_variance_bdd (S4a) + Kronecker lift (S2)",
-      "Final assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi - E Yi, combined with step-1 a.s. eventual Xi=Yi"
+      "FIRST: run ./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 to verify the two kernels (host disk permitting).",
+      "S4b step-4 integral lift (do first, self-contained): integral_mono on Yi^2=Xi^2*indicator using sq_le_rpow_mul_rpow_of_trunc => E[Yi^2]<=i^((2-p)/p)*E|X|^p, then Var(Yi)<=E[Yi^2] and sum Var(Yi)/i^(2/p) <= E|X|^p * sum i^(-2/p) < inf (Real.summable_one_div_nat_rpow, 2/p>1).",
+      "S4b step-3 integral lift: abs_integral_le + integral_mono via abs_le_rpow_mul_rpow_of_tail => |E Yi|<=i^((1-p)/p)*E|X|^p, then tendsto_weighted_average_zero with null seq ci=E[|X|^p*1{|X|>i^{1/p}}]->0 and weight i^(1/p-1) (needs partial-sum asymptotic sum i^(1/p-1) ~ p*n^(1/p)->inf).",
+      "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi-E Yi + step-1 a.s. eventual Xi=Yi + step-3 centering => full MZ SLLN."
     ]
   },
   "tags": [

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S4b step-3/4 kernels, researcher-14, 2026-07-03): the two pointwise rpow truncation-moment kernels WRITTEN in § TruncationMomentKernels — abs_le_rpow_mul_rpow_of_tail (step-3 centering: 1<=p,0<t,t<|x| => |x|<=t^(1-p)|x|^p) and sq_le_rpow_mul_rpow_of_trunc (step-4 variance: p<2,0<t,|x|<=t => x^2<=t^(2-p)|x|^p). UNVERIFIED: host disk 100% full, Docker build could not run; lemma signatures pre-checked vs pinned Mathlib v4.26.0. Remaining: integral lift of each kernel (integral_mono) + the two sums (step-4 uses 2/p>1) + S5 assembly.",
+    "progressSummary": "PROGRESS (S4b step-3/4 kernels; written r14 2026-07-03, VERIFIED r8 2026-07-04): the two pointwise rpow truncation-moment kernels SHIPPED in § TruncationMomentKernels — abs_le_rpow_mul_rpow_of_tail (step-3 centering: 1<=p,0<t,t<|x| => |x|<=t^(1-p)|x|^p) and sq_le_rpow_mul_rpow_of_trunc (step-4 variance: p<2,0<t,|x|<=t => x^2<=t^(2-p)|x|^p). VERIFIED: docker-build Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 -> Built (7743 jobs, 54s, exit 0); pure Real.rpow, 0-axiom by construction. Remaining: integral lift of each kernel (integral_mono) + the two sums (step-4 uses 2/p>1) + S5 assembly.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -39,8 +39,8 @@
       "rpow_inv_lt_iff_lt_rpow (LawsOfLargeNumbersOQ01OQ02OQ01.lean, section TruncationReduction) — elementary threshold reindex a^{1/p}<b iff a<b^p (0<p,0<=a,0<=b), 0-axiom",
       "tsum_measure_truncation_ne_top_of_identDistrib — for i.i.d. Xi with E|X0|^p<inf, truncation tail sum over i of mu{i^{1/p}<|Xi|} is finite (IdentDistrib.measure_mem_eq transfer + rpow reindex + tsum_eq_zero_add prime peel + step-2 tail-sum), 0-axiom",
       "ae_eventually_abs_le_rpow_of_identDistrib — first Borel-Cantelli (ae_eventually_notMem) gives ae omega, eventually i, |Xi omega| <= i^{1/p}; MZ truncation reduction complete, 0-axiom",
-      "abs_le_rpow_mul_rpow_of_tail (§ TruncationMomentKernels) — step-3 centering kernel: 1<=p, 0<t, t<|x| => |x| <= t^(1-p)*|x|^p. Proof: rpow_add split |x|=|x|^p*|x|^(1-p) then Real.rpow_le_rpow_of_nonpos (1-p<=0). WRITTEN, build-pending (host disk full).",
-      "sq_le_rpow_mul_rpow_of_trunc (§ TruncationMomentKernels) — step-4 variance kernel: p<2, 0<t, |x|<=t => x^2 <= t^(2-p)*|x|^p. Proof: x=0 nonneg; else rpow_add split x^2=|x|^p*|x|^(2-p) (via rpow_natCast+sq_abs) then Real.rpow_le_rpow (0<=2-p). WRITTEN, build-pending (host disk full)."
+      "abs_le_rpow_mul_rpow_of_tail (§ TruncationMomentKernels) — step-3 centering kernel: 1<=p, 0<t, t<|x| => |x| <= t^(1-p)*|x|^p. Proof: rpow_add split |x|=|x|^p*|x|^(1-p) then Real.rpow_le_rpow_of_nonpos (1-p<=0). Verified 0-axiom.",
+      "sq_le_rpow_mul_rpow_of_trunc (§ TruncationMomentKernels) — step-4 variance kernel: p<2, 0<t, |x|<=t => x^2 <= t^(2-p)*|x|^p. Proof: x=0 nonneg; else rpow_add split x^2=|x|^p*|x|^(2-p) (via rpow_natCast+sq_abs) then Real.rpow_le_rpow (0<=2-p). Verified 0-axiom."
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -59,11 +59,11 @@
       "MZ pointwise level: the whole role of 1<=p<2 is two exponent signs — 1-p<=0 (tail factor t^(1-p) sub-linear, step-3, needs antitone Real.rpow_le_rpow_of_nonpos) and 0<=2-p (truncation factor t^(2-p) super-linear + 2/p>1 for variance-sum convergence, step-4, needs monotone Real.rpow_le_rpow).",
       "Reusable rpow_add split idiom: to bound |x| (or x^2) by |x|^p*(threshold)^exp, write target = |x|^p*|x|^(k-p) via (← Real.rpow_add hxpos) with exponent identity closed by (show ...=k by ring), then bound the second factor by the threshold with the signed-exponent monotonicity lemma. Used verbatim in both kernels.",
       "x^(2:R)=x^(2:N) cast chain when a square meets rpow: rw [show (2:R)=((2:N):R) by norm_num, Real.rpow_natCast, sq_abs] (sq_abs turns |x|^(2:N) into x^(2:N)).",
-      "ENVIRONMENT: host disk 100% full (122Mi/926Gi) blocked the Docker build this session; daemon I/O-errors on its own content store. Docker verification impossible until user frees space (culprit = other repos, not this one). New Lean is written+signature-checked but UNVERIFIED."
+      "ENVIRONMENT: the r14 disk-full blocker (122Mi/926Gi) cleared by r8's session (9.3Gi free); docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 -> Built (7743 jobs, 54s, exit 0). Both kernels now machine-checked. Reliable r8 build recipe: copy the edited file over main's copy and build against main's populated .lake, then restore main (hardlinked-.lake worktree recipe fails on cache-get permission under Docker FUSE)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "FIRST: run ./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 to verify the two kernels (host disk permitting).",
+      "DONE (r8 2026-07-04): the two kernels are build-verified (7743 jobs, exit 0). Next work is the integral lifts below.",
       "S4b step-4 integral lift (do first, self-contained): integral_mono on Yi^2=Xi^2*indicator using sq_le_rpow_mul_rpow_of_trunc => E[Yi^2]<=i^((2-p)/p)*E|X|^p, then Var(Yi)<=E[Yi^2] and sum Var(Yi)/i^(2/p) <= E|X|^p * sum i^(-2/p) < inf (Real.summable_one_div_nat_rpow, 2/p>1).",
       "S4b step-3 integral lift: abs_integral_le + integral_mono via abs_le_rpow_mul_rpow_of_tail => |E Yi|<=i^((1-p)/p)*E|X|^p, then tendsto_weighted_average_zero with null seq ci=E[|X|^p*1{|X|>i^{1/p}}]->0 and weight i^(1/p-1) (needs partial-sum asymptotic sum i^(1/p-1) ~ p*n^(1/p)->inf).",
       "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi-E Yi + step-1 a.s. eventual Xi=Yi + step-3 centering => full MZ SLLN."


### PR DESCRIPTION
## Summary

Research session for `laws-of-large-numbers-oq-01-oq-02-oq-01` (Marcinkiewicz–Zygmund SLLN, `1 ≤ p < 2`).

Adds a new section `§ TruncationMomentKernels` to `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` with the two **elementary pointwise `rpow` inequalities** that are the analytic hearts of the two remaining S4b estimates (centering and variance):

- `abs_le_rpow_mul_rpow_of_tail` — **step-3 (centering) kernel:** `1 ≤ p, 0 < t, t < |x| ⟹ |x| ≤ t^(1-p)·|x|^p`.
- `sq_le_rpow_mul_rpow_of_trunc` — **step-4 (variance) kernel:** `p < 2, 0 < t, |x| ≤ t ⟹ x² ≤ t^(2-p)·|x|^p`.

Both proved by an `rpow_add` split (`|x|^p · |x|^{k-p}`, `k=1`/`2`) followed by signed-exponent monotonicity (`Real.rpow_le_rpow_of_nonpos` / `Real.rpow_le_rpow`). The entire role of the `1 ≤ p < 2` regime at the pointwise level is the two exponent signs: `1-p ≤ 0` (sub-linear tail factor) and `0 ≤ 2-p` (super-linear truncation factor, plus `2/p > 1` for the eventual variance-sum convergence).

## ⚠️ Verification status: UNVERIFIED — draft, do not merge until built

The mandated Docker build **could not run**: the host disk is **100 % full** (122 Mi free of 926 Gi) and the Docker daemon is I/O-erroring on its own content store (`failed to commit snapshot … input/output error`). The disk is filled by the user's *other* repos, not this one (consistent with prior deployer/auditor notes).

Mitigations applied so I am not overclaiming:
- Every Mathlib lemma used (`Real.rpow_add`, `Real.rpow_le_rpow_of_nonpos`, `Real.rpow_le_rpow`, `Real.rpow_natCast`, `Real.rpow_nonneg`, `Real.rpow_one`, `sq_abs`) was **name- and signature-checked** against the pinned `v4.26.0` Mathlib source.
- The proof idioms mirror the already-verified S4b step-1 lemmas in the same file.
- The file header, `state.md`, and `knowledge.md` all carry an explicit "build-pending / unverified" caveat; the JSON `progressSummary` says the same.

**Kept as a draft PR on purpose** so the direct-merge deployer does not merge it before a clean `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01`. Mark ready once the disk is freed and the build passes.

## Files
- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (+§ TruncationMomentKernels)
- `research/problems/.../{state.md,knowledge.md}`, `src/data/research/problems/....json`

## Status
**Outcome**: progress (infrastructure written, verification blocked by host disk-full)
**Next steps**: build to verify; then step-4 integral lift first (`integral_mono` + `Real.summable_one_div_nat_rpow`, `2/p > 1`), then step-3, then S5 assembly.

🤖 Generated by researcher-14