### PR TITLE
Enrich Catalan Turán inequality (catalan-numbers-oq-01-oq-04): 93→100

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
@@ -66,10 +66,33 @@
     ]
   },
   {
-    "id": "ann-catalan-turan-surplus",
+    "id": "ann-catalan-turan-statement",
     "proofId": "catalan-numbers-oq-01-oq-04",
     "range": {
       "startLine": 73,
+      "endLine": 80
+    },
+    "type": "theorem",
+    "title": "Strict log-convexity: the Turán inequality and its exact gap",
+    "content": "catalan_turan states Cₙ₊₁² < Cₙ · Cₙ₊₂ for every n — strict log-convexity of the Catalan sequence, a Turán-type inequality. The docstring records that strictness is uniform, not asymptotic: the multiplicative gap is exactly (2n²+7n+6)/(2n²+7n+3), which exceeds 1 for all n and tends to 1 only as n → ∞. Mathlib has an extensive Catalan API (the quotient/recurrence forms) but no log-convexity or Turán-type statement, so this is new infrastructure.",
+    "mathContext": "$C_{n+1}^2 < C_n C_{n+2}$, with $\\frac{C_n C_{n+2}}{C_{n+1}^2} = \\frac{2n^2+7n+6}{2n^2+7n+3} > 1$; the numerator exceeds the denominator by a constant $3$ independent of $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Turán inequality",
+      "log-convexity",
+      "Catalan numbers",
+      "strict unimodality"
+    ],
+    "prerequisites": [
+      "Catalan numbers",
+      "log-convex sequences"
+    ]
+  },
+  {
+    "id": "ann-catalan-turan-surplus",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": {
+      "startLine": 81,
       "endLine": 112
     },
     "type": "insight",

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
@@ -96,11 +96,20 @@
       "summary": "catalan_pos: 0 < catalan n, recovered from (n+1)·catalan n = centralBinom n > 0 (Nat.centralBinom_pos). The strict positivity of catalan (n+1) and catalan (n+2) is what upgrades the nonnegative surplus 3·(b·c) to a strictly positive one."
     },
     {
-      "id": "turan-inequality",
-      "title": "The Turán inequality via a positive surplus",
+      "id": "turan-statement",
+      "title": "The Turán inequality: statement and exact strictness gap",
       "startLine": 73,
+      "endLine": 80,
+      "summary": "The docstring states strict log-convexity catalan (n+1)² < catalan n · catalan (n+2) for every n, and records that the strictness is uniform: the multiplicative gap is exactly (2n²+7n+6)/(2n²+7n+3) > 1. Mathlib has the Catalan API but no Turán-type inequality.",
+      "mathContext": "$C_{n+1}^2 < C_n C_{n+2}$ with ratio $\\frac{C_n C_{n+2}}{C_{n+1}^2} = \\frac{2n^2+7n+6}{2n^2+7n+3} > 1$ for all $n$."
+    },
+    {
+      "id": "turan-proof",
+      "title": "Proof via consecutive recurrences and a positive surplus",
+      "startLine": 81,
       "endLine": 112,
-      "summary": "catalan_turan: builds the two recurrence instances (R1 at n, R2 at n+1, the latter reindexed n+1+1 = n+2), proves the surplus identity D·(a·c) = D·b² + 3·(b·c) with D = 2(2n+1)(2n+3) by one linear_combination, then uses 3·(b·c) > 0 and left-cancellation of D (lt_of_mul_lt_mul_left) to conclude b² < a·c, transferred back to ℕ by exact_mod_cast."
+      "summary": "catalan_turan: builds the two recurrence instances (R1 at n, R2 at n+1, the latter reindexed n+1+1 = n+2), proves the surplus identity D·(a·c) = D·b² + 3·(b·c) with D = 2(2n+1)(2n+3) by one linear_combination, then uses 3·(b·c) > 0 and left-cancellation of D (lt_of_mul_lt_mul_left) to conclude b² < a·c, transferred back to ℕ by exact_mod_cast.",
+      "mathContext": "$D\\,(a c) = D\\,b^2 + 3\\,(b c)$ with $D = 2(2n+1)(2n+3) > 0$; since $3(bc) > 0$, cancelling $D$ gives $b^2 < a c$."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-04` (93 → 100).

## Changes
- **Sections 4 → 5:** the 40-line `Turán inequality via a positive surplus` section (lines 73–112) bundled the theorem's statement docstring with its proof. Split at the theorem boundary (line 81) into *statement and exact strictness gap* (73–80) and *proof via consecutive recurrences and a positive surplus* (81–112), each with its own `mathContext`.
- **Annotations 4 → 5:** correspondingly split into a `theorem`-typed statement annotation (73–80, the Turán inequality and its uniform gap (2n²+7n+6)/(2n²+7n+3)) and the existing constant-3 surplus-identity `insight` (81–112). Both anchor to real construct lines (docstring / theorem).

Score buckets filled: annotations 20 → 25, sections 8 → 10. Boundaries align with `Proofs/CatalanNumbersOQ01OQ04.lean`; annotation build resolves with no warnings.