### PR TITLE
Enrich Reverse Minkowski from Cauchy-Schwarz (cauchy-schwarz-integral-oq-02-oq-03): 93→100

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-forms",
     "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
-    "range": { "startLine": 118, "endLine": 136 },
+    "range": { "startLine": 118, "endLine": 129 },
     "type": "insight",
     "title": "One-Sided and Difference Forms",
-    "content": "norm_sub_norm_le_norm_add gives the one-sided ‖u‖−‖v‖ ≤ ‖u+v‖ (drop the absolute value via le_abs_self). reverse_minkowski_sub gives the classical difference form |‖u‖−‖v‖| ≤ ‖u−v‖ by substituting −v (norm_neg turns ‖−v‖ into ‖v‖, sub_eq_add_neg turns u+(−v) into u−v). norm_add_ge_norm_sub_norm restates the result as the lower bound ‖f+g‖ ≥ ‖f‖−‖g‖ exactly as the open question poses it.",
+    "content": "norm_sub_norm_le_norm_add gives the one-sided ‖u‖−‖v‖ ≤ ‖u+v‖ (drop the absolute value via le_abs_self). reverse_minkowski_sub gives the classical difference form |‖u‖−‖v‖| ≤ ‖u−v‖ by substituting −v: norm_neg turns ‖−v‖ into ‖v‖, and sub_eq_add_neg turns u+(−v) into u−v. Together they package the reverse triangle inequality in the two shapes most often cited downstream.",
     "mathContext": "$$\\big|\\|u\\|-\\|v\\|\\big| \\le \\|u-v\\| \\quad(\\text{reflection } v\\mapsto -v)$$",
     "significance": "supporting",
     "relatedConcepts": ["le_abs_self", "norm_neg", "sub_eq_add_neg", "reverse triangle inequality"],
     "prerequisites": ["absolute value bounds", "norm of negation"]
+  },
+  {
+    "id": "ann-lp-lower-bound",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "range": { "startLine": 130, "endLine": 136 },
+    "type": "theorem",
+    "title": "The Lᵖ Lower Bound Exactly as Posed",
+    "content": "norm_add_ge_norm_sub_norm restates the Lᵖ result in the ge-orientation the open question asks for: for 1 ≤ p and f, g ∈ Lᵖ(μ), ‖f+g‖_p ≥ ‖f‖_p − ‖g‖_p. It is definitionally the same content as reverse_minkowski_lp (a lower bound on the sum norm rather than an upper bound on the norm difference), provided as a separate lemma so callers can cite the sum-norm lower bound directly without re-deriving it from the absolute-value form.",
+    "mathContext": "$\\|f+g\\|_p \\ge \\|f\\|_p - \\|g\\|_p$ for $1 \\le p$; the ge-oriented reading of $\\big|\\|f\\|_p-\\|g\\|_p\\big| \\le \\|f+g\\|_p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["reverse Minkowski", "Lᵖ norm", "sum-norm lower bound"],
+    "prerequisites": ["Lᵖ spaces", "the reverse triangle inequality"]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
@@ -97,9 +97,17 @@
       "id": "forms",
       "title": "One-Sided and Difference Forms",
       "startLine": 118,
+      "endLine": 129,
+      "summary": "norm_sub_norm_le_norm_add drops the absolute value to the one-sided ‖u‖−‖v‖ ≤ ‖u+v‖ (le_abs_self); reverse_minkowski_sub recovers the classical difference form |‖u‖−‖v‖| ≤ ‖u−v‖ by the reflection v ↦ −v.",
+      "mathContext": "Difference form via v ↦ −v: $\\|u+(-v)\\| = \\|u-v\\|$ (norm_neg, sub_eq_add_neg)."
+    },
+    {
+      "id": "lp-lower-bound",
+      "title": "The Lᵖ Lower Bound as Posed",
+      "startLine": 130,
       "endLine": 136,
-      "summary": "norm_sub_norm_le_norm_add (one-sided ‖u‖−‖v‖ ≤ ‖u+v‖), reverse_minkowski_sub (difference form |‖u‖−‖v‖| ≤ ‖u−v‖), and norm_add_ge_norm_sub_norm (the Lᵖ inequality exactly as posed).",
-      "mathContext": "Difference form via v ↦ −v (norm_neg, sub_eq_add_neg)."
+      "summary": "norm_add_ge_norm_sub_norm restates the result for Lᵖ (1 ≤ p) as the lower bound ‖f+g‖_p ≥ ‖f‖_p − ‖g‖_p, matching the open question's phrasing exactly; it is the ge-oriented reading of reverse_minkowski_lp.",
+      "mathContext": "$\\|f+g\\|_p \\ge \\|f\\|_p - \\|g\\|_p$ for $1 \\le p$ — the sum-norm lower bound the open question asks for."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-02-oq-03` (93 → 100).

## Changes
- **Sections 4 → 5:** the `One-Sided and Difference Forms` section (lines 118–136) bundled three theorems. Split at the theorem boundary (line 130) into *One-Sided and Difference Forms* (118–129: `norm_sub_norm_le_norm_add`, `reverse_minkowski_sub`) and *The Lᵖ Lower Bound as Posed* (130–136: `norm_add_ge_norm_sub_norm`).
- **Annotations 4 → 5:** correspondingly split, with a `theorem`-typed annotation for the Lᵖ lower bound stated exactly as the open question poses it.

Score buckets filled: annotations 20 → 25, sections 8 → 10. Boundaries align with `Proofs/CauchySchwarzIntegralOQ02OQ03.lean`; annotation build resolves with no warnings.