### PR TITLE
Enrich Hockey-Stick Identity and Figurate Numbers

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/annotations.json
@@ -36,7 +36,14 @@
     "relatedConcepts": [
       "induction",
       "Pascal's rule",
-      "sum_range_succ"
+      "sum_range_succ",
+      "Nat.choose_succ_succ",
+      "telescoping sums"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "Finset.sum_range_succ (peeling the top term)",
+      "Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1)"
     ]
   },
   {
@@ -52,7 +59,14 @@
     "mathContext": "The interval [r, n] version of the hockey-stick sum.",
     "significance": "supporting",
     "relatedConcepts": [
-      "interval sum"
+      "interval sum",
+      "Nat.sum_Icc_choose",
+      "Finset.Icc",
+      "reindexing range vs Icc"
+    ],
+    "prerequisites": [
+      "the diagonal form hockeyStick",
+      "Finset.Icc and interval-indexed sums"
     ]
   },
   {
@@ -69,7 +83,14 @@
     "significance": "key",
     "relatedConcepts": [
       "Gauss sum",
-      "triangular numbers"
+      "triangular numbers",
+      "Nat.choose_one_right",
+      "Nat.choose_two_right",
+      "arithmetic series"
+    ],
+    "prerequisites": [
+      "the interval form hockeyStick_Icc",
+      "C(m,1) = m and C(n+1,2) = n(n+1)/2"
     ]
   },
   {
@@ -86,7 +107,13 @@
     "significance": "supporting",
     "relatedConcepts": [
       "tetrahedral numbers",
-      "figurate numbers"
+      "figurate numbers",
+      "simplicial numbers",
+      "r-simplex numbers C(n+1,r+1)"
+    ],
+    "prerequisites": [
+      "the interval form hockeyStick_Icc at r=2",
+      "triangular numbers C(m,2)"
     ]
   }
 ]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
@@ -70,7 +70,8 @@
       "Finset.sum_range_succ is the right engine — peeling the top term reduces the sum to the previous case plus one binomial coefficient that Pascal absorbs",
       "Gauss's sum 1+2+…+n is the r=1 diagonal of Pascal's triangle: ∑ C(m,1) = C(n+1,2)",
       "Tetrahedral numbers are the r=2 diagonal: ∑ C(m,2) = C(n+1,3), so partial sums of triangular numbers are tetrahedral",
-      "Index normalization r+(m+1) = r+m+1 (definitional but not syntactic) must be made explicit before Pascal's rule fires"
+      "Index normalization r+(m+1) = r+m+1 (definitional but not syntactic) must be made explicit before Pascal's rule fires",
+      "There is a purely combinatorial proof complementing this inductive one: C(n+1,r+1) counts the (r+1)-element subsets of {0,1,…,n}, and classifying each subset by its largest element m (which ranges over r,…,n) leaves C(m,r) choices for the remaining r elements below it — summing gives ∑_{m} C(m,r) = C(n+1,r+1), the interval form directly. The induction here is the algebraic shadow of that bijection, with Pascal's rule playing the role of the largest-element case split."
     ],
     "prerequisites": [
       "Binomial coefficients and Pascal's rule",


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-02-oq-02` (The Hockey-Stick Identity and Figurate Numbers).

## Changes
- **+1 keyInsight (5→6):** the classify-by-maximum *combinatorial* proof of the hockey-stick identity — C(n+1,r+1) counts (r+1)-subsets of {0,…,n}, and classifying each by its largest element m gives C(m,r), summing to the interval form. This complements the inductive proof in the file and frames Pascal's rule as the algebraic shadow of the largest-element case split.
- **Annotation prerequisites 2/5 → 5/5:** added `prerequisites` to the induction, Icc, Gauss, and tetrahedral annotations.
- **Deepened thin `relatedConcepts`:** the Icc/Gauss/tetrahedral annotations gained specific Mathlib lemma links and concept cross-refs (was as sparse as one entry).

## Verification
- JSON valid; `meta.json` 12.4 KB (well under the 60 KB cap).
- `scripts/annotations/build.ts`: no errors for this entry.
- `pnpm build` passes.

Status/badge/axiom fields unchanged and accurate (verified, mathlib badge, 0 axioms — kernel `decide` only).