### PR TITLE
Enrich Cayley-Hamilton minpoly characterization (cayley-hamilton-minpoly-oq-04-oq-01): 93→100

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-chminpolyoq04oq01-minpoly",
     "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
-    "range": { "startLine": 175, "endLine": 238 },
-    "type": "insight",
-    "title": "Minimal polynomial = Xⁿ, and the iff characterization",
-    "content": "minpoly_eq_X_pow_of_maximal_nilpotent: Nⁿ = 0 gives aeval N (Xⁿ) = 0, so minpoly K N ∣ Xⁿ; since X is prime (prime_X), dvd_prime_pow gives minpoly associated to Xⁱ, and eq_of_monic_of_associated (both monic) makes minpoly = Xⁱ; then Nⁱ = 0, so i ≥ n (else Nⁿ⁻¹ = Nⁿ⁻¹⁻ⁱ·Nⁱ = 0), forcing i = n. The converse maximal_nilpotent_of_minpoly_eq_X_pow reads Nⁿ = 0 off aeval, and rules out Nⁿ⁻¹ = 0 by a degree comparison (minpoly would divide Xⁿ⁻¹). Together they give the iff and natDegree(minpoly) = n, linking the construction to the parent's degree-based nonderogatory characterization.",
+    "range": { "startLine": 175, "endLine": 204 },
+    "type": "theorem",
+    "title": "Minimal polynomial = Xⁿ (forward direction)",
+    "content": "minpoly_eq_X_pow_of_maximal_nilpotent: Nⁿ = 0 gives aeval N (Xⁿ) = 0, so minpoly K N ∣ Xⁿ; since X is prime (prime_X), dvd_prime_pow gives minpoly associated to Xⁱ, and eq_of_monic_of_associated (both monic) makes minpoly = Xⁱ; then Nⁱ = 0, so i ≥ n (else Nⁿ⁻¹ = Nⁿ⁻¹⁻ⁱ·Nⁱ = 0), forcing i = n. natDegree_minpoly_eq_of_maximal_nilpotent then reads off natDegree(minpoly) = n, the nonderogatory condition at the level of the minimal polynomial, linking the construction to the parent's degree-based characterization.",
     "mathContext": "$\\mu\\mid X^n$, $X$ prime $\\Rightarrow \\mu = X^i$; $N^{n-1}\\ne 0\\Rightarrow i=n$, so $\\mu = X^n$ and $\\deg\\mu = n$.",
     "significance": "key",
     "relatedConcepts": ["minimal polynomial", "prime element X", "dvd_prime_pow", "associated polynomials", "natDegree"],
     "prerequisites": ["divisibility in polynomial rings", "prime elements", "monic polynomials"]
+  },
+  {
+    "id": "ann-chminpolyoq04oq01-converse",
+    "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
+    "range": { "startLine": 208, "endLine": 238 },
+    "type": "theorem",
+    "title": "The converse, the iff, and cyclic-vector existence",
+    "content": "maximal_nilpotent_of_minpoly_eq_X_pow is the converse: minpoly K N = Xⁿ reads Nⁿ = 0 directly off aeval, and rules out Nⁿ⁻¹ = 0 by a degree comparison — if Nⁿ⁻¹ = 0 the minimal polynomial would divide Xⁿ⁻¹ and have degree ≤ n−1, contradicting minpoly = Xⁿ. minpoly_eq_X_pow_iff_maximal_nilpotent packages the two directions as an iff, and has_cyclic_vector_of_minpoly_eq_X_pow feeds minpoly = Xⁿ back into Part I to produce an explicit cyclic vector — closing the equivalence between the algebraic (minimal polynomial) and geometric (cyclic vector) descriptions of maximal nilpotency.",
+    "mathContext": "$\\mu = X^n \\Rightarrow N^n = 0$; and $N^{n-1} = 0$ would force $\\deg\\mu \\le n-1$, contradiction — hence the iff, and a cyclic vector exists.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "degree comparison", "iff characterization", "cyclic vector", "maximal nilpotency"],
+    "prerequisites": ["minimal polynomial degree bounds", "the forward direction", "Part I cyclic-vector construction"]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
@@ -197,12 +197,20 @@
       "mathContext": "For a single Jordan block at 0, any vector not killed by Nⁿ⁻¹ generates the whole space under N; this works over any field with no genericity argument."
     },
     {
-      "id": "characterization",
-      "title": "Part II: Arithmetic characterisation via the minimal polynomial",
+      "id": "characterization-forward",
+      "title": "Part II: Minimal polynomial = Xⁿ (forward direction)",
       "startLine": 175,
+      "endLine": 204,
+      "summary": "minpoly_eq_X_pow_of_maximal_nilpotent: for a maximal-nilpotent matrix minpoly = Xⁿ (Nⁿ = 0 gives minpoly ∣ Xⁿ; X prime ⟹ minpoly = Xⁱ; Nⁿ⁻¹ ≠ 0 ⟹ i = n). natDegree_minpoly_eq_of_maximal_nilpotent reads off natDegree(minpoly) = n, the nonderogatory condition at the minimal-polynomial level.",
+      "mathContext": "$\\mu \\mid X^n$ and $X$ prime give $\\mu = X^i$; $N^{n-1} \\neq 0$ forces $i = n$, so $\\mu = X^n$ and $\\deg\\mu = n$."
+    },
+    {
+      "id": "characterization-converse",
+      "title": "Part II: The converse and the iff characterisation",
+      "startLine": 205,
       "endLine": 238,
-      "summary": "minpoly = Xⁿ for maximal nilpotent (divides Xⁿ; X prime ⟹ minpoly = Xⁱ; Nⁿ⁻¹≠0 ⟹ i=n); natDegree = n; converse minpoly=Xⁿ ⟹ maximal nilpotent; the iff; and cyclic-vector existence from minpoly=Xⁿ.",
-      "mathContext": "The minimal polynomial of a single nilpotent Jordan block of size n is Xⁿ; conversely minpoly = Xⁿ forces Nⁿ = 0 with Nⁿ⁻¹ ≠ 0 (else minpoly would divide Xⁿ⁻¹ and have degree < n)."
+      "summary": "maximal_nilpotent_of_minpoly_eq_X_pow: minpoly = Xⁿ recovers Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0 (the latter by a degree comparison — Nⁿ⁻¹ = 0 would make minpoly divide Xⁿ⁻¹). minpoly_eq_X_pow_iff_maximal_nilpotent packages both directions as an iff; has_cyclic_vector_of_minpoly_eq_X_pow derives cyclic-vector existence from minpoly = Xⁿ.",
+      "mathContext": "minpoly = Xⁿ ⟹ Nⁿ = 0; and Nⁿ⁻¹ = 0 would force deg(minpoly) ≤ n−1, contradicting minpoly = Xⁿ — giving the equivalence and cyclic-vector existence."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-oq-01` (93 → 100).

## Changes
- **Sections 4 → 5:** the 64-line `Part II: Arithmetic characterisation via the minimal polynomial` section (lines 175–238) bundled five theorems. Split at the converse boundary (line 205) into *Minimal polynomial = Xⁿ (forward direction)* (175–204: `minpoly_eq_X_pow_of_maximal_nilpotent`, `natDegree_minpoly_eq_of_maximal_nilpotent`) and *The converse and the iff characterisation* (205–238: `maximal_nilpotent_of_minpoly_eq_X_pow`, `minpoly_eq_X_pow_iff_maximal_nilpotent`, `has_cyclic_vector_of_minpoly_eq_X_pow`).
- **Annotations 4 → 5:** correspondingly split into two `theorem`-typed annotations, anchored to real construct lines (175 docstring, 208 converse theorem).

Score buckets filled: annotations 20 → 25, sections 8 → 10. Boundaries align with `Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean`; annotation build resolves with no warnings.