### PR TITLE
Enrich 2×2 Cayley–Hamilton: annotate the cofactor definition

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-04/annotations.json
@@ -23,6 +23,29 @@
     ]
   },
   {
+    "id": "ann-ch04-cofactor",
+    "proofId": "cayley-hamilton-oq-04",
+    "range": {
+      "startLine": 49,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Named 2×2 Cofactor Matrix and Its Bridge to Mathlib's Adjugate",
+    "content": "Working over any commutative ring R, `cofactor A = !![A 1 1, -A 0 1; -A 1 0, A 0 0]` names the classical 2×2 adjugate [[d,-b],[-c,a]] so that the results below read like the textbook formulas rather than as `Matrix.adjugate` unfoldings. The single-line lemma `cofactor_eq_adjugate` proves this hand-written matrix equals Mathlib's general `adjugate A` in the 2×2 case, via `adjugate_fin_two`. This identification is the load-bearing bridge of the whole file: because the explicit products `mul_cofactor`/`cofactor_mul` are stated for `cofactor`, `cofactor_eq_adjugate` is what lets them count as genuine adjugate identities and lets the inverse formula connect to Mathlib's `Matrix.inv_def` (which is phrased in terms of `adjugate`). Keeping the definition entrywise-concrete is also what keeps every downstream proof reducible by `fin_cases`/`ring`.",
+    "mathContext": "$\\operatorname{cofactor} A = \\begin{pmatrix} d & -b \\\\ -c & a \\end{pmatrix} = \\operatorname{adjugate} A$ for $A = \\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}$ over a commutative ring.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "adjugate matrix",
+      "cofactor matrix",
+      "Matrix.adjugate",
+      "adjugate_fin_two"
+    ],
+    "prerequisites": [
+      "the adjugate (cofactor) matrix",
+      "2×2 matrix notation !![...]"
+    ]
+  },
+  {
     "id": "ann-ch04-cayley-hamilton",
     "proofId": "cayley-hamilton-oq-04",
     "range": {


### PR DESCRIPTION
## Enrichment pass — cayley-hamilton-oq-04 (0 passes → 1)

Already strong (quality 93): rich meta, 4 keyInsights, sections covering the whole file, cross-references, references, conclusion. The one genuine gap against the quality target was annotation coverage — the file had **4** annotations (target ≥5), and the **cofactor definition section (lines 49–61) was uncovered** despite being referenced by three of the existing annotations.

**Change:** added a 5th annotation (`ann-ch04-cofactor`, lines 49–61) for the named 2×2 cofactor matrix and `cofactor_eq_adjugate`. This is the load-bearing bridge of the file: because the explicit products `mul_cofactor`/`cofactor_mul` are stated for the hand-written `cofactor`, its identification with Mathlib's `adjugate` (via `adjugate_fin_two`) is what lets them count as genuine adjugate identities and connect the inverse formula to `Matrix.inv_def`. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

Annotations now cover the file in line-order with no gap in the definitional section.

**Guardrails:** annotations.json 7.2 KB; 5 annotations. No content deleted or modified. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)