### PR TITLE
Enrich Chebyshev θ ≤ n·log 4: cross-reference Bertrand's postulate and the Chebyshev–PNT bridge

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
@@ -124,6 +124,16 @@
       "targetId": "chebyshev-bounds",
       "relationship": "related",
       "description": "Chebyshev's Prime Counting Bounds — the classical two-sided θ(x) ≍ x estimates of which θ(n) ≤ n·log 4 is the clean upper half."
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's Postulate (Erdős's 1932 elementary proof). The constant log 4 = 2·log 2 here descends from exactly the same central-binomial counting C(2n,n) ≤ 4ⁿ that drives Erdős's proof of Bertrand's postulate; the primorial bound n# ≤ 4ⁿ this entry logarithmizes is one of the estimates in that argument."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "related",
+      "description": "Chebyshev–PNT Bridge: Explicit Bounds on π(x). Where this entry bounds the log-weighted prime sum θ(n) via the primorial, the bridge converts Chebyshev-type primorial/central-binomial bounds into explicit estimates on π(x); together they trace the route θ(x) ≍ x ⇒ π(x) ≍ x/log x toward the Prime Number Theorem invoked in the open questions."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment pass — chebyshev-bounds-oq-06-oq-02 (0 passes → 1)

Already a rich entry (quality 93): 4 full annotations covering the whole 76-line/4-section file, 5 keyInsights, detailed sections, mathlibDependencies, conclusion with 3 open questions. The file's four natural sections are each already annotated, so forcing a 5th annotation would be padding.

The genuine gap was **cross-referencing**: the entry's prose repeatedly invokes Bertrand's postulate (the `log 4 = 2·log 2` constant descends from the same Erdős `C(2n,n) ≤ 4ⁿ` counting) and the Prime Number Theorem / θ ≍ x ⇒ π(x) ≍ x/log x route (implications + all three open questions), yet linked to neither gallery entry.

**Change:** added two cross-references (2 → 4, cap 20), both to entries confirmed present with accurate titles:
- `bertrands-postulate` — same central-binomial counting behind the primorial bound this entry logarithmizes.
- `chebyshev-pnt-bridge` (*Explicit Bounds on π(x)*) — the θ → π(x) continuation toward the PNT named in the open questions.

**Guardrails:** meta.json 12.9 KB (≪ 60 KB); crossReferences = 4 (≪ 20). No content deleted. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)