### PR TITLE
Enrich cayley-hamilton-oq-04: cross-link to Cramer's rule

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04/meta.json
@@ -89,6 +89,11 @@
       "targetId": "cayley-hamilton-oq-02",
       "relationship": "related",
       "description": "OQ-02 develops the general charpoly polynomial reduction; OQ-04 gives the fully explicit 2×2 closed forms and the adjugate inverse."
+    },
+    {
+      "targetId": "cramers-rule",
+      "relationship": "related",
+      "description": "The closed-form inverse A⁻¹ = (det A)⁻¹·[[d,-b],[-c,a]] proved here is exactly the 2×2 case of Cramer's rule, and the two-sided adjugate products A·adj A = adj A·A = (det A)·1 are the identity that makes Cramer's rule work in every dimension."
     }
   ],
   "sections": [


### PR DESCRIPTION
Targeted enrichment pass for `cayley-hamilton-oq-04` (Explicit 2×2 Cayley–Hamilton and the Adjugate Inverse Formula).

## Change
Added one `related` crossReference to the `cramers-rule` gallery entry. The proof derives the closed-form 2×2 inverse `A⁻¹ = (det A)⁻¹·[[d,-b],[-c,a]]` and the two-sided adjugate products `A·adj A = adj A·A = (det A)·1` — the 2×2 case of, and the identity underlying, Cramer's rule — yet had no navigation link to that entry. crossReferences 2→3 (cap 20).

## Why nothing else changed
The entry already meets every quality minimum, so per the enricher size/diminishing-returns guardrails I did **not** deepen prose or annotations:
- 5 annotations, all with mathContext, significance, relatedConcepts, prerequisites
- historicalContext ~1KB with real history (Cayley 1858, Cramer 1750)
- 4 keyInsights; conclusion with summary, implications, 2 openQuestions
- 5 sections covering the full 127-line Lean file
- meta.json 9.86KB (well under ~60KB cap)

Verified: both JSON files parse; `relationship: related` matches 7010 existing gallery uses; target `cramers-rule` exists on main.