### PR TITLE
Formalize symmetric Lovász Local Lemma analytic core (ramsey-r4k-extensions-oq-03)

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensions.lean
+++ b/proofs/Proofs/RamseyR4kExtensions.lean
@@ -1163,6 +1163,113 @@ theorem ramsey_symmetric' (s t : ℕ) :
   exact ramseyUpperBound_symm s t hs ht
 
 -- ═════════════════════════════════════════════════════════════════════════
+-- Part XII: The Symmetric Lovász Local Lemma — Analytic Core
+-- ═════════════════════════════════════════════════════════════════════════
+
+/-
+### The symmetric-to-asymmetric bridge of the Lovász Local Lemma
+
+The **symmetric Lovász Local Lemma** states: if every bad event `Aᵢ` has
+`Pr[Aᵢ] ≤ p`, each `Aᵢ` is mutually independent of all but at most `d` of the
+others, and
+
+  `e · p · (d + 1) ≤ 1`,
+
+then `Pr[⋂ᵢ ¬Aᵢ] > 0`, so a configuration avoiding every bad event exists.
+
+The textbook derivation obtains the symmetric form from the *asymmetric*
+(general) LLL by choosing the uniform weights `xᵢ = 1/(d+1)`.  The asymmetric
+hypothesis then reads
+
+  `p ≤ xᵢ · (1 - xᵢ)^d = (1/(d+1)) · (1 - 1/(d+1))^d`,
+
+and the whole reduction turns on the elementary analytic inequality
+
+  `(1 - 1/(d+1))^d ≥ 1/e`.
+
+Mathlib currently packages neither the LLL nor this bridge.  We formalize the
+inequality (`lll_exp_weight_bound`) and the resulting symmetric→asymmetric
+reduction (`lll_symmetric_condition`) here, axiom-free.  These are exactly the
+pieces a future measure-theoretic LLL proof would consume; the probability-space
+(conditional-probability) induction itself remains a separate, larger
+formalization tracked as the open part of this problem.
+-/
+
+/-- **Analytic core of the symmetric LLL.**  For every `d`,
+    `e⁻¹ ≤ (1 - 1/(d+1))^d`.  Equivalently `(1 - 1/(d+1))^d ≥ 1/e`.  This is the
+    inequality that lets the symmetric LLL hypothesis `e·p·(d+1) ≤ 1` be met by
+    the uniform asymmetric weights `xᵢ = 1/(d+1)`. -/
+theorem lll_exp_weight_bound (d : ℕ) :
+    Real.exp (-1) ≤ (1 - 1 / (d + 1 : ℝ)) ^ d := by
+  rcases Nat.eq_zero_or_pos d with hd | hd
+  · -- d = 0: RHS = (1 - 1)^0 = 1 and e⁻¹ ≤ 1.
+    subst hd
+    simp only [pow_zero]
+    have : Real.exp (-1) ≤ Real.exp 0 := Real.exp_le_exp.mpr (by norm_num)
+    simpa using this
+  · -- d ≥ 1.
+    have hdpos : (0 : ℝ) < d := by exact_mod_cast hd
+    have hdne : (d : ℝ) ≠ 0 := ne_of_gt hdpos
+    set b : ℝ := 1 - 1 / (d + 1 : ℝ) with hb
+    have hbeq : b = d / (d + 1) := by rw [hb]; field_simp; ring
+    have hbpos : 0 < b := by rw [hbeq]; positivity
+    -- log((d+1)/d) ≤ 1/d  (from  log x ≤ x - 1)
+    have hlog : Real.log ((d + 1) / d) ≤ 1 / d := by
+      have h := Real.log_le_sub_one_of_pos (show (0 : ℝ) < ((d : ℝ) + 1) / d by positivity)
+      have he : ((d : ℝ) + 1) / d - 1 = 1 / d := by field_simp; ring
+      linarith [h, he]
+    -- log b = -log((d+1)/d) ≥ -1/d
+    have hlb : Real.log b = -Real.log ((d + 1) / d) := by
+      rw [hbeq, ← Real.log_inv, inv_div]
+    have hlogb : -(1 / d) ≤ Real.log b := by rw [hlb]; linarith [hlog]
+    -- d · log b ≥ -1
+    have hdlogb : (-1 : ℝ) ≤ (d : ℝ) * Real.log b := by
+      have hmul := mul_le_mul_of_nonneg_left hlogb (le_of_lt hdpos)
+      have hcancel : (d : ℝ) * -(1 / d) = -1 := by
+        rw [mul_neg, mul_one_div, div_self hdne]
+      linarith [hmul, hcancel]
+    -- exponentiate: e⁻¹ ≤ b^d
+    have hbd : (0 : ℝ) < b ^ d := pow_pos hbpos d
+    calc Real.exp (-1)
+        ≤ Real.exp ((d : ℝ) * Real.log b) := Real.exp_le_exp.mpr hdlogb
+      _ = Real.exp (Real.log (b ^ d)) := by rw [Real.log_pow]
+      _ = b ^ d := Real.exp_log hbd
+
+/-- **Symmetric → asymmetric bridge for the LLL.**  If `p ≥ 0` and the symmetric
+    LLL hypothesis `e·p·(d+1) ≤ 1` holds, then the asymmetric LLL weight
+    inequality is satisfied by the uniform choice `xᵢ = 1/(d+1)`:
+
+      `p ≤ (1/(d+1)) · (1 - 1/(d+1))^d`.
+
+    Consequently the symmetric hypothesis really does supply the input the general
+    LLL requires; only the probability-space induction of the general LLL is left
+    to close the full symmetric statement. -/
+theorem lll_symmetric_condition (p : ℝ) (hp : 0 ≤ p) (d : ℕ)
+    (hsym : Real.exp 1 * p * (d + 1) ≤ 1) :
+    p ≤ (1 / (d + 1 : ℝ)) * (1 - 1 / (d + 1 : ℝ)) ^ d := by
+  have hene : Real.exp 1 ≠ 0 := ne_of_gt (Real.exp_pos 1)
+  have hd1pos : (0 : ℝ) < (d + 1 : ℝ) := by positivity
+  have hexp := lll_exp_weight_bound d
+  have hinv : Real.exp (-1) = (Real.exp 1)⁻¹ := by rw [Real.exp_neg]
+  -- p·(d+1) ≤ e⁻¹  (rearrange the symmetric hypothesis)
+  have h1 : p * ((d : ℝ) + 1) ≤ (Real.exp 1)⁻¹ := by
+    have hh : Real.exp 1 * (p * ((d : ℝ) + 1)) ≤ 1 := by nlinarith [hsym]
+    calc p * ((d : ℝ) + 1)
+        = (Real.exp 1)⁻¹ * (Real.exp 1 * (p * ((d : ℝ) + 1))) := by
+          rw [← mul_assoc, inv_mul_cancel₀ hene, one_mul]
+      _ ≤ (Real.exp 1)⁻¹ * 1 := by
+          apply mul_le_mul_of_nonneg_left hh; positivity
+      _ = (Real.exp 1)⁻¹ := by ring
+  -- combine with e⁻¹ ≤ (1-1/(d+1))^d
+  have h2 : (Real.exp 1)⁻¹ ≤ (1 - 1 / ((d : ℝ) + 1)) ^ d := by rw [← hinv]; exact hexp
+  have key : p * ((d : ℝ) + 1) ≤ (1 - 1 / ((d : ℝ) + 1)) ^ d := h1.trans h2
+  -- divide through by (d+1) > 0
+  have hstep : p ≤ (1 - 1 / ((d : ℝ) + 1)) ^ d / ((d : ℝ) + 1) :=
+    (le_div_iff₀ hd1pos).mpr key
+  calc p ≤ (1 - 1 / ((d : ℝ) + 1)) ^ d / ((d : ℝ) + 1) := hstep
+    _ = (1 / ((d : ℝ) + 1)) * (1 - 1 / ((d : ℝ) + 1)) ^ d := by ring
+
+-- ═════════════════════════════════════════════════════════════════════════
 -- VERIFICATION CHECKS (Parts X-XI)
 -- ═════════════════════════════════════════════════════════════════════════
 
@@ -1179,5 +1286,9 @@ theorem ramsey_symmetric' (s t : ℕ) :
 #check burr_erdos_conjecture
 #check ramsey_multiplicity
 #check ramsey_symmetric'
+
+-- Part XII: Symmetric Lovász Local Lemma — analytic core
+#check lll_exp_weight_bound
+#check lll_symmetric_condition
 
 end RamseyR4k

--- a/src/data/proofs/ramsey-r4k-extensions/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "ramsey-r4k-extensions",
   "title": "Ramsey R(4,k) Bounds: Probabilistic Method Extensions",
   "slug": "ramsey-r4k-extensions",
-  "description": "Formalizes Ramsey theory bounds for R(4,k) via the probabilistic method. Proves the Erdős 1947 lower bound R(k,k) ≥ 2^(k/2) (now fully axiom-free), explicit small-Ramsey constructions, and the binomial upper bounds. 80 theorems, 9 axioms for the deep analytic bounds (AKS/Kim R(3,k), Mattheus-Verstraete R(4,k), Spencer diagonal LLL, CGMS, Bohman-Keevash).",
+  "description": "Formalizes Ramsey theory bounds for R(4,k) via the probabilistic method. Proves the Erdős 1947 lower bound R(k,k) ≥ 2^(k/2) (now fully axiom-free), explicit small-Ramsey constructions, and the binomial upper bounds. Also formalizes the axiom-free analytic core of the symmetric Lovász Local Lemma — the inequality (1−1/(d+1))^d ≥ 1/e and the symmetric→asymmetric bridge e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))(1−1/(d+1))^d — the piece Mathlib lacks toward an LLL Ramsey lower bound. 82 theorems, 9 axioms for the deep analytic bounds (AKS/Kim R(3,k), Mattheus-Verstraete R(4,k), Spencer diagonal LLL, CGMS, Bohman-Keevash).",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
@@ -20,8 +20,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 9,
     "assumptions": "9 axioms, each a genuine deep result from the Ramsey-theory literature whose proof needs machinery not in Mathlib: aks_r3k_upper_bound and kim_r3k_lower_bound (R(3,k)=Θ(k²/log k)), r4k_upper_bound and r4k_lower_bound (two-colour R(4,k) bounds), spencer_diagonal_lower_bound (Spencer's LLL improvement), cgms_diagonal_upper_bound and cgms_epsilon_estimate (CGMS (4-ε)^k breakthrough), bohman_keevash_r3t and mattheus_verstraete_r4t. The Erdős first-moment lower bound erdos_probabilistic_lower_bound (R(k,k)≥2^(k/2)) is a proved theorem discharged by ErdosRamsey.erdos_probabilistic_lower_bound (Proofs/ErdosRamseyLowerBound.lean). Five former placeholder axioms were de-axiomatized this session: r4k_quadratic_lower, off_diagonal_ramsey_bounds, book_algorithm_structure, burr_erdos_conjecture and ramsey_multiplicity were all trivially-true propositions (three were literally `True`; r4k_quadratic_lower only forbade a red K₄, so the all-false coloring satisfies it; off_diagonal_ramsey_bounds only asserted two positive constants exist) — they are now proved theorems with honest docstrings noting the stated proposition does NOT encode the deep result its name references.",
-    "lineCount": 1183,
-    "theoremCount": 80,
+    "lineCount": 1294,
+    "theoremCount": 82,
     "definitionCount": 13,
     "originalContributions": [
       "IsRamseyColoring: 2-coloring of K_n edges avoiding monochromatic K_r or K_s",
@@ -30,7 +30,9 @@
       "r_diagonal_first_moment_bound: E[mono K_k] < 1/2 for n = 2^(k/2) (proved)",
       "r4k_interval: R(4,k) ∈ [Ω(k²/log k), O(k³/log k)] (stated)",
       "diagonal_gap: proven gap between Spencer lower and CFS upper bound",
-      "Framework for the probabilistic method: deletion argument, Lovász Local Lemma setup"
+      "Framework for the probabilistic method: deletion argument, Lovász Local Lemma setup",
+      "lll_exp_weight_bound: the elementary analytic inequality e⁻¹ ≤ (1−1/(d+1))^d, proved axiom-free from Real.log_le_sub_one_of_pos — the core estimate underlying the symmetric Lovász Local Lemma (Mathlib has no LLL)",
+      "lll_symmetric_condition: the symmetric→asymmetric LLL bridge — e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))·(1−1/(d+1))^d, showing the uniform weights xᵢ = 1/(d+1) satisfy the general LLL hypothesis; only the probability-space induction of the general LLL remains open"
     ]
   },
   "overview": {
@@ -46,7 +48,8 @@
       "The probabilistic method revolutionized combinatorics: existence proofs without constructions",
       "**ramseyUpperBound algebra is self-contained**: the symmetry, base case R(2,s)=s, and Pascal recursion are all proved from Mathlib's binomial coefficient lemmas without any Ramsey theory beyond the C(r+s-2,r-1) definition — the formalization is purely combinatorial.",
       "**The 3-regular triangle-free K_8 construction for R(3,4)≥9**: the 12 red edges (degree-3 regular, girth≥4, independence number 3) are hardcoded in `r34Color` and both the no-red-K3 and no-blue-K4 properties are verified by native_decide in under a second — a remarkable feat of computational combinatorics.",
-      "**native_decide closes the gap between lower and upper bounds**: the combination of explicit colorings (C_5, K_8, Paley-17, Paley-13) proved by native_decide with the binomial upper bounds narrows R(3,3)=6, R(3,4)=9, R(4,4)∈{18,19,20} exactly."
+      "**native_decide closes the gap between lower and upper bounds**: the combination of explicit colorings (C_5, K_8, Paley-17, Paley-13) proved by native_decide with the binomial upper bounds narrows R(3,3)=6, R(3,4)=9, R(4,4)∈{18,19,20} exactly.",
+      "**The symmetric LLL reduces to one analytic inequality**: the entire symmetric-to-asymmetric derivation of the Lovász Local Lemma hinges on (1−1/(d+1))^d ≥ 1/e. Taking logs, this is d·log(1−1/(d+1)) ≥ −1, which follows from log x ≤ x−1 applied to x = (d+1)/d. Formalized here as `lll_exp_weight_bound`, it lets the symmetric hypothesis e·p·(d+1) ≤ 1 be met by the uniform weights xᵢ = 1/(d+1) (`lll_symmetric_condition`) — the exact input a future measure-theoretic LLL proof would consume."
     ],
     "prerequisites": [
       "Ramsey theory: monochromatic cliques, Ramsey numbers",
@@ -56,19 +59,19 @@
     ]
   },
   "conclusion": {
-    "summary": "Ramsey number bounds are formalized with 9 axioms, each a genuine deep result (AKS/Kim R(3,k), two-colour R(4,k), Spencer's LLL diagonal bound, CGMS, Bohman-Keevash, Mattheus-Verstraete). The Erdős 1947 first-moment lower bound R(k,k)≥2^(k/2), previously axiomatized, is now fully proved (axiom-free). Five former placeholder axioms — all trivially-true propositions that did not actually encode the deep results their names referenced — were de-axiomatized into proved theorems with honest docstrings. The elementary bounds (Pascal triangle, first-moment setup, explicit small colorings) are fully proved. 80 theorems, ~1180 lines documenting the state of the art in Ramsey theory.",
+    "summary": "Ramsey number bounds are formalized with 9 axioms, each a genuine deep result (AKS/Kim R(3,k), two-colour R(4,k), Spencer's LLL diagonal bound, CGMS, Bohman-Keevash, Mattheus-Verstraete). The Erdős 1947 first-moment lower bound R(k,k)≥2^(k/2), previously axiomatized, is now fully proved (axiom-free). Five former placeholder axioms — all trivially-true propositions that did not actually encode the deep results their names referenced — were de-axiomatized into proved theorems with honest docstrings. The elementary bounds (Pascal triangle, first-moment setup, explicit small colorings) are fully proved. A new Part XII formalizes the axiom-free analytic core of the symmetric Lovász Local Lemma: the inequality (1−1/(d+1))^d ≥ 1/e (`lll_exp_weight_bound`) and the symmetric→asymmetric bridge e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))(1−1/(d+1))^d (`lll_symmetric_condition`), which Mathlib lacks; only the general LLL's probability-space induction remains open. 82 theorems, ~1290 lines documenting the state of the art in Ramsey theory.",
     "implications": "The probabilistic method established by Erdős is one of the most powerful tools in combinatorics. Formalizing even its setup (IsRamseyColoring, first moment framework) creates infrastructure for future Lean 4 probabilistic combinatorics. The R(4,k) problem remains one of the most actively studied in extremal combinatorics.",
     "openQuestions": [
-      "Strengthen the proved bound via the symmetric Lovász Local Lemma: R(k,k) ≥ (1+o(1))·(k/e)·2^(k/2), a factor-k improvement over the first-moment bound",
-      "Reduce the R(4,k) gap: closing from [k²/log k, k³/log k] to [k², k²] would be a major breakthrough",
-      "Formalize the Lovász Local Lemma and its applications to Ramsey theory"
+      "Complete the symmetric Lovász Local Lemma: its analytic core (`lll_exp_weight_bound`, `lll_symmetric_condition`) is now formalized axiom-free; what remains is the probability-space conditional-probability induction (Spencer's argument) that turns the weight inequality into Pr[⋂ᵢ ¬Aᵢ] > 0",
+      "Apply the completed LLL to the monochromatic-clique bad events to strengthen the proved bound to R(k,k) ≥ (1+o(1))·(k/e)·2^(k/2), a factor-k improvement over the first-moment bound",
+      "Reduce the R(4,k) gap: closing from [k²/log k, k³/log k] to [k², k²] would be a major breakthrough"
     ]
   },
   "leanFile": {
     "namespace": "RamseyR4kExtensions",
-    "lineCount": 1183,
+    "lineCount": 1294,
     "axiomCount": 9,
-    "theoremCount": 80,
+    "theoremCount": 82,
     "definitionCount": 13,
     "path": "Proofs/RamseyR4kExtensions.lean",
     "sorries": 0
@@ -267,6 +270,14 @@
       "endLine": 1142,
       "mathContext": "Frontier results: genuine axioms CGMS $R(k,k)\\le(4-\\varepsilon)^k$, Bohman-Keevash, Mattheus-Verstraete $R(4,t)$; plus documentation-only placeholders (Burr-Erdős, multiplicity, book algorithm) now proved as trivial `True`.",
       "summary": "Part IX. Summary of extensions and recent frontier results. Genuine axioms: the Campos-Griffiths-Morris-Sahasrabudhe (CGMS) exponential improvement $R(k,k)\\le(4-\\varepsilon)^k$ with its $\\varepsilon$ estimate, Bohman-Keevash $R(3,t)$, and Mattheus-Verstraete $R(4,t)$. The book-algorithm structure, off-diagonal bounds, the Burr-Erdős conjecture, and Ramsey multiplicity are now proved theorems rather than axioms — their Lean propositions are trivially true (`True` or bare existence of positive constants) and their docstrings state explicitly that the underlying deep theorems are NOT formalized here."
+    },
+    {
+      "id": "lll-analytic-core",
+      "title": "Part XII: The Symmetric Lovász Local Lemma — Analytic Core",
+      "startLine": 1165,
+      "endLine": 1272,
+      "mathContext": "The symmetric LLL ($e\\,p\\,(d+1)\\le1\\Rightarrow\\Pr[\\bigcap\\overline{A_i}]>0$) reduces to the asymmetric LLL via the inequality $(1-1/(d+1))^d\\ge1/e$.",
+      "summary": "Part XII. The axiom-free analytic core of the symmetric Lovász Local Lemma, which Mathlib lacks. `lll_exp_weight_bound` proves $e^{-1}\\le(1-1/(d+1))^d$ (by taking logs: $d\\log(1-1/(d+1))\\ge-1$ from $\\log x\\le x-1$). `lll_symmetric_condition` uses it for the symmetric→asymmetric bridge: $e\\,p\\,(d+1)\\le1\\Rightarrow p\\le\\tfrac{1}{d+1}(1-\\tfrac{1}{d+1})^d$, i.e. the uniform weights $x_i=1/(d+1)$ satisfy the general LLL hypothesis. Only the general LLL's probability-space induction is left to close the full symmetric statement."
     }
   ],
   "sorries": 0,

--- a/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
+++ b/src/data/research/problems/ramsey-r4k-extensions-oq-03.json
@@ -12,32 +12,35 @@
   },
   "knownResults": {
     "proven": [
-      "erdos_probabilistic_lower_bound (R(k,k) > 2^(k/2)) is now a proved, axiom-free theorem — de-axiomatized in RamseyR4kExtensions.lean by wiring in the first-moment formalization ErdosRamsey.erdos_probabilistic_lower_bound."
+      "erdos_probabilistic_lower_bound (R(k,k) > 2^(k/2)) is now a proved, axiom-free theorem — de-axiomatized in RamseyR4kExtensions.lean by wiring in the first-moment formalization ErdosRamsey.erdos_probabilistic_lower_bound.",
+      "lll_exp_weight_bound (RamseyR4kExtensions.lean, Part XII): e⁻¹ ≤ (1 − 1/(d+1))^d for all d, axiom-free (propext/Classical.choice/Quot.sound only). Proof: for d ≥ 1 take logs — d·log(1−1/(d+1)) ≥ d·(−1/d) = −1 using log((d+1)/d) ≤ 1/d from Real.log_le_sub_one_of_pos; exponentiate. This is the analytic core Mathlib lacks for the symmetric LLL.",
+      "lll_symmetric_condition (RamseyR4kExtensions.lean, Part XII): the symmetric→asymmetric LLL bridge — for p ≥ 0, e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))·(1−1/(d+1))^d, axiom-free. Shows the symmetric hypothesis supplies exactly the asymmetric-LLL weight inequality with uniform xᵢ = 1/(d+1), the input the companion SymmetricLLLForRamsey principle consumes."
     ],
     "open": [
-      "The symmetric Lovász Local Lemma itself is not yet formalized in Lean/Mathlib.",
-      "The factor-k LLL improvement R(k,k) > (1+o(1))(k/e)2^(k/2) over the first-moment bound."
+      "The measure-theoretic heart of the general LLL — Spencer's conditional-probability induction turning the (now-proved) weight inequality lll_symmetric_condition into Pr[⋂ᵢ ¬Aᵢ] > 0 — is not yet formalized in Lean/Mathlib.",
+      "The factor-k LLL improvement R(k,k) > (1+o(1))(k/e)2^(k/2) over the first-moment bound (needs the completed LLL applied to the monochromatic-clique bad events)."
     ],
     "goal": "Formalize the symmetric LLL and use it to strengthen the (now proved) first-moment Ramsey lower bound."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-03T13:20:00-07:00",
-    "iteration": 3,
-    "focus": "Axiom hygiene: de-axiomatized 5 trivially-true placeholder axioms in RamseyR4kExtensions (14->9). r4k_quadratic_lower, off_diagonal_ramsey_bounds, book_algorithm_structure, burr_erdos_conjecture, ramsey_multiplicity were all trivially satisfiable (three literally `True`; r4k_quadratic_lower only forbids a red K4 so all-false coloring works; off_diagonal only asserts two positive constants). Now proved theorems with honest docstrings flagging the gap to the named deep result. The symmetric LLL proper remains an open multi-session BUILD.",
+    "since": "2026-07-03T18:40:00-07:00",
+    "iteration": 4,
+    "focus": "Formalized the axiom-free analytic core of the symmetric LLL directly in RamseyR4kExtensions.lean (new Part XII, +2 theorems, theoremCount 80->82, lineCount 1183->1294, axiomCount unchanged at 9): lll_exp_weight_bound (e⁻¹ ≤ (1−1/(d+1))^d) and lll_symmetric_condition (the symmetric→asymmetric bridge e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))(1−1/(d+1))^d). Docker build clean, #print axioms confirms only propext/Classical.choice/Quot.sound. This supplies the exact weight inequality the companion SymmetricLLLForRamsey principle takes as input; only the probability-space induction remains.",
     "blockers": [
-      "General symmetric LLL needs a conditional-probability induction (Spencer's argument) over a probability space — Mathlib has no LLL and the induction is delicate; estimated a multi-session BUILD."
+      "The general LLL's conditional-probability induction (Spencer's argument) over a probability space is still needed to turn the proved weight inequality into Pr[⋂ᵢ ¬Aᵢ] > 0 — Mathlib has no LLL and the induction is delicate; estimated a multi-session BUILD."
     ],
-    "nextAction": "Discharge the SymmetricLLLForRamsey hypothesis by formalizing the symmetric LLL avoidance principle (Spencer's conditional-probability induction) over the Sym2 edge space used by ErdosRamsey.exists_avoiding_coloring, then instantiate it with cliqueMonoProb/cliqueDependencyBound.",
+    "nextAction": "Formalize the symmetric-LLL avoidance principle (Spencer's conditional-probability induction) over the Sym2 edge space used by ErdosRamsey.exists_avoiding_coloring, feeding lll_symmetric_condition as the verified weight inequality, then instantiate with cliqueMonoProb/cliqueDependencyBound to discharge SymmetricLLLForRamsey.",
     "attemptCounts": {
-      "total": 2,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 2
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: axiom hygiene on RamseyR4kExtensions.lean, axiomCount 14->9. Converted 5 vacuous placeholder axioms to proved theorems (verified: docker build clean, 0 sorry). Remaining 9 axioms are all genuine deep literature results. Symmetric LLL itself still an open BUILD.",
+    "progressSummary": "PROGRESS: formalized the axiom-free analytic core of the symmetric LLL in RamseyR4kExtensions.lean (Part XII): lll_exp_weight_bound (e⁻¹ ≤ (1−1/(d+1))^d) and lll_symmetric_condition (symmetric→asymmetric bridge). theoremCount 80->82, lineCount 1183->1294, axiomCount unchanged 9; docker build clean, #print axioms clean (propext/Classical.choice/Quot.sound). Mathlib has no LLL, so this bridge inequality is a genuine gap-filler. Remaining open: the probability-space induction of the general LLL.",
     "builtItems": [
+      "RamseyR4kExtensions.lean Part XII (session 2026-07-03, this iteration): lll_exp_weight_bound — proves e⁻¹ ≤ (1−1/(d+1))^d axiom-free; d=0 handled by 0^0=1 ≥ e⁻¹, d≥1 by logs (set b=d/(d+1); log b = −log((d+1)/d) ≥ −1/d via Real.log_le_sub_one_of_pos; d·log b ≥ −1; exponentiate with Real.exp_le_exp + Real.log_pow + Real.exp_log). lll_symmetric_condition — from e·p·(d+1)≤1 derive p·(d+1) ≤ e⁻¹ (via inv_mul_cancel₀ rearrangement) then chain e⁻¹ ≤ (1−1/(d+1))^d and divide by (d+1) with le_div_iff₀. Both verified: docker build clean, #print axioms = {propext, Classical.choice, Quot.sound}. Gotchas recorded: field_simp leaves a residual ring goal here (append `; ring`); le_div_iff is deprecated → le_div_iff₀.",
       "RamseyR4kExtensionsOQ03.lean (231 lines, 7 thms, 5 defs, 0 sorry, 0 axiom): cliqueMonoProb, cliqueDependencyBound, RamseyLLLCondition; PROVED cliqueNeighbors_card_le (dependency degree ≤ C(k,2)·C(n-2,k-2) via covering by the C(k,2) pairs of S, each in ≤ C(n-2,k-2) k-cliques — containing_card_le by the injection T↦T\\e); SymmetricLLLForRamsey principle + ramsey_lll_lower_bound reduction; RamseyLLLCondition_antitone (threshold monotone in n); cliqueMonoProb_pos/le_one.",
       "RamseyR4kExtensions.lean: converted `axiom erdos_probabilistic_lower_bound` into a proved `theorem`, discharged by `ErdosRamsey.erdos_probabilistic_lower_bound k hk` (defeq statements); added `import Proofs.ErdosRamseyLowerBound`. File axiomCount 15→14.",
       "REPAIR: the file did not compile on the pinned Mathlib (v4.26.0). Fixed 3 pre-existing breakages: (1) `positivity` could not prove `0 ≤ (4-ε)/4` from `ε<4` → `div_nonneg (by linarith) (by norm_num)` (~L1056); (2) `div_lt_div_iff` renamed → `div_lt_div_iff₀` (~L1069); (3) `ramsey_symmetric'` referenced an undefined `ramsey_symmetry` → reproved via zero case-split + existing `ramseyUpperBound_symm` (~L1127).",
@@ -90,13 +93,13 @@
     "mathlib": []
   },
   "started": "2026-07-02T18:04:16.809Z",
-  "lastUpdate": "2026-07-03T13:20:00-07:00",
+  "lastUpdate": "2026-07-03T18:40:00-07:00",
   "leanFiles": [
     {
       "path": "Proofs/RamseyR4kExtensions.lean",
       "filename": "RamseyR4kExtensions.lean",
-      "lineCount": 1183,
-      "theoremCount": 80,
+      "lineCount": 1294,
+      "theoremCount": 82,
       "axiomCount": 9,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Progress on **ramsey-r4k-extensions-oq-03** (Lovász Local Lemma and Ramsey lower bounds). Adds a new **Part XII** to `Proofs/RamseyR4kExtensions.lean` formalizing the **axiom-free analytic core of the symmetric Lovász Local Lemma** — the piece Mathlib does not currently package.

The textbook derivation of the *symmetric* LLL (`e·p·(d+1) ≤ 1 ⇒ Pr[⋂ᵢ ¬Aᵢ] > 0`) from the *asymmetric* (general) LLL chooses uniform weights `xᵢ = 1/(d+1)` and turns entirely on the elementary inequality `(1 − 1/(d+1))^d ≥ 1/e`. This PR proves that inequality and the resulting reduction:

- **`lll_exp_weight_bound`** — `e⁻¹ ≤ (1 − 1/(d+1))^d` for all `d`. Proof (for `d ≥ 1`) takes logs: `d·log(1 − 1/(d+1)) ≥ d·(−1/d) = −1`, using `log((d+1)/d) ≤ 1/d` from `Real.log_le_sub_one_of_pos`; then exponentiate.
- **`lll_symmetric_condition`** — the symmetric→asymmetric bridge: for `p ≥ 0`, `e·p·(d+1) ≤ 1 ⇒ p ≤ (1/(d+1))·(1 − 1/(d+1))^d`. This is exactly the asymmetric-LLL weight inequality with uniform `xᵢ = 1/(d+1)`, the input the companion `SymmetricLLLForRamsey` reduction consumes.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.RamseyR4kExtensions` — **build clean**.
- `#print axioms` on both new theorems → `{propext, Classical.choice, Quot.sound}` only — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).
- `theoremCount` 80 → 82, `lineCount` 1183 → 1294, `axiomCount` unchanged at 9, 0 sorries.

## Still open

Only the general LLL's probability-space induction (Spencer's conditional-probability argument) remains — turning the now-proved weight inequality into `Pr[⋂ᵢ ¬Aᵢ] > 0`, then instantiating with the monochromatic-clique bad events for the factor-`k` Ramsey improvement.

Gallery `meta.json` and the research problem JSON are updated to match (new section entry, revised open questions, insights, and counts).