### PR TITLE
Enrich Connected Space OQ-01: de-bundle dense corollaries (sections/annotations 4→5)

### DIFF
--- a/src/data/proofs/connected-space-oq-01/annotations.json
+++ b/src/data/proofs/connected-space-oq-01/annotations.json
@@ -75,11 +75,11 @@
     "proofId": "connected-space-oq-01",
     "range": {
       "startLine": 64,
-      "endLine": 73
+      "endLine": 67
     },
     "type": "insight",
     "title": "Dense Connected Subset ⟹ Connected Space",
-    "content": "connectedSpace_of_dense_connected is the practical corollary: if a space has a dense connected subset, the whole space is connected. The proof reduces ConnectedSpace α to IsConnected (univ) (connectedSpace_iff_univ); density gives closure s = univ (Dense.closure_eq), so univ is the closure of a connected set, which is connected (IsConnected.closure). This is a standard and reusable route to proving connectedness — establish it on a dense, easier-to-analyze part and let closure do the rest. preconnectedSpace_of_dense_preconnected is the preconnected analogue.",
+    "content": "connectedSpace_of_dense_connected is the practical corollary: if a space has a dense connected subset, the whole space is connected. The proof reduces ConnectedSpace α to IsConnected (univ) (connectedSpace_iff_univ); density gives closure s = univ (Dense.closure_eq), so univ is the closure of a connected set, which is connected (IsConnected.closure). This is a standard and reusable route to proving connectedness — establish it on a dense, easier-to-analyze part and let closure do the rest. Note that ConnectedSpace carries a nonemptiness obligation, which is discharged here by the connected subset s being nonempty (IsConnected bundles Nonempty).",
     "mathContext": "$s$ dense $\\Rightarrow \\overline{s} = \\mathrm{univ}$; $s$ connected $\\Rightarrow \\overline{s}$ connected; hence $\\mathrm{univ}$ is connected, i.e. $\\alpha$ is a ConnectedSpace.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -91,6 +91,29 @@
     "prerequisites": [
       "dense subsets",
       "connected spaces vs connected sets"
+    ]
+  },
+  {
+    "id": "ann-dense-preconnected",
+    "proofId": "connected-space-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "Dense Preconnected Subset ⟹ Preconnected Space",
+    "content": "preconnectedSpace_of_dense_preconnected is the preconnected analogue, and it is genuinely weaker — not just a cosmetic variant. PreconnectedSpace drops the nonemptiness requirement that ConnectedSpace carries (the empty space is preconnected but not connected), so this statement applies even when the dense subset s is empty and the ambient space is empty. The proof is the same shape: preconnectedSpace_iff_univ reduces to IsPreconnected univ, density gives closure s = univ (Dense.closure_eq), and IsPreconnected.closure finishes. Keeping the preconnected version separate is what lets downstream users pick exactly the hypothesis strength they have — IsPreconnected without a nonemptiness witness.",
+    "mathContext": "Same reduction as the connected case but via $\\text{PreconnectedSpace} \\iff \\text{IsPreconnected}(\\mathrm{univ})$; no nonemptiness is required, so it holds even for the empty space where ConnectedSpace fails.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "preconnectedSpace_iff_univ",
+      "PreconnectedSpace",
+      "IsPreconnected.closure",
+      "nonemptiness"
+    ],
+    "prerequisites": [
+      "dense subsets",
+      "preconnected vs connected (nonemptiness)"
     ]
   }
 ]

--- a/src/data/proofs/connected-space-oq-01/meta.json
+++ b/src/data/proofs/connected-space-oq-01/meta.json
@@ -71,7 +71,8 @@
       "The sharp form is 'bark and tree': any set t with s ⊆ t ⊆ closure s inherits preconnectedness — closing all the way is just the special case t = closure s.",
       "A dense connected subset upgrades to a connected whole space, because its closure is everything and the closure of a connected set is connected.",
       "Reducing global connectedness (ConnectedSpace) to connectedness of a dense part is a standard and reusable technique, e.g. for proving spaces built from connected dense skeletons are connected.",
-      "Working at the level of IsPreconnected / IsConnected on Set α (not just on the whole space) keeps the statements maximally reusable for subsets."
+      "Working at the level of IsPreconnected / IsConnected on Set α (not just on the whole space) keeps the statements maximally reusable for subsets.",
+      "The preconnected and connected forms of the density corollary are not interchangeable: ConnectedSpace requires nonemptiness while PreconnectedSpace does not, so the preconnected version holds even for the empty space and needs no nonemptiness witness — a distinction worth keeping explicit for downstream reuse."
     ],
     "prerequisites": [
       "Open sets, closure, and dense subsets",
@@ -109,9 +110,17 @@
       "id": "dense-corollary",
       "title": "Section III: Dense Connected ⟹ Connected Space",
       "startLine": 64,
-      "endLine": 73,
-      "summary": "connectedSpace_of_dense_connected and preconnectedSpace_of_dense_preconnected: a dense (pre)connected subset makes the whole space (pre)connected, via closure = univ and the closure result.",
+      "endLine": 67,
+      "summary": "connectedSpace_of_dense_connected: a dense connected subset makes the whole space connected, via connectedSpace_iff_univ, Dense.closure_eq (closure s = univ) and IsConnected.closure. The connected subset's nonemptiness supplies the nonemptiness ConnectedSpace requires.",
       "mathContext": "Reducing global connectedness to a dense part — a standard proof technique."
+    },
+    {
+      "id": "dense-corollary-preconnected",
+      "title": "Section IV: Dense Preconnected ⟹ Preconnected Space",
+      "startLine": 69,
+      "endLine": 73,
+      "summary": "preconnectedSpace_of_dense_preconnected: the preconnected analogue, which is strictly weaker because PreconnectedSpace drops the nonemptiness obligation carried by ConnectedSpace (the empty space is preconnected but not connected). Same reduction via preconnectedSpace_iff_univ, Dense.closure_eq and IsPreconnected.closure, applicable even without a nonemptiness witness.",
+      "mathContext": "$\\text{PreconnectedSpace} \\iff \\text{IsPreconnected}(\\mathrm{univ})$; no nonemptiness required, unlike the connected case."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01` (*The Closure of a (Pre)connected Set Is (Pre)connected*).

## Gap
The Lean file has **6 distinct theorems** but Section III (and its annotation) bundled *both* dense corollaries — `connectedSpace_of_dense_connected` (64-67) and `preconnectedSpace_of_dense_preconnected` (70-73) — while the section title named only the connected one. These are not interchangeable: `ConnectedSpace` requires nonemptiness, `PreconnectedSpace` does not (the empty space is preconnected but not connected).

## Changes
- **Split Section III** into Section III (Dense Connected, 64-67) and new Section IV (Dense Preconnected, 69-73).
- **Split `ann-dense`** into `ann-dense` (64-67) + new `ann-dense-preconnected` (69-73), the latter explaining the version drops nonemptiness and holds even for the empty space.
- **Added one keyInsight** (5→6) making the nonemptiness distinction explicit.

## Verification
- Quality **93→100** (sections 8→10, annotations 20→25 per `find-targets.ts`).
- meta.json **12.4 KB** — well under the 60 KB cap.
- JSON valid; all 5 annotations have valid `type`/`significance` enums.
- Validated via JSON parse + enum check + quality recompute (no node_modules in worktree).
- Every added claim reflects the actual Lean theorems; no invented content.