### PR TITLE
Enrich Birthday k=3 n=4 Closed Form: link 4 named siblings (crossRefs 1->5)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
@@ -88,6 +88,26 @@
       "targetId": "birthday-problem-oq-03-oq-01-oq-01",
       "relationship": "extends",
       "description": "Parent: the O(n²) slot recurrence with closed forms for n = 1, 2, 3. This entry adds the n = 4 closed form, proved 0-axiom (no native_decide)."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling generalizing the parent's k=3 slot recurrence to a full multiplicity-histogram recurrence Rk for k-way coincidences. This entry's exact n = 4 value d⁴ − 4d² + 3d is a concrete k = 3 evaluation of the count that framework tracks — it is the open question 'extend to the k-way count R_k' listed here, made explicit for one term."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "relationship": "complementary",
+      "description": "Complementary view of the same k=3 count: that entry derives the large-n coincidence threshold n ≈ (6d²ln2)^(1/3), whereas this entry pins down the exact small-n closed form. Together they bracket birthdayCount3 from both the asymptotic and the exact-enumeration sides."
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: the k=3 extension-counting framework from which the parent slot recurrence R is built. This entry is a leaf computation within that framework, evaluating its count at n = 4."
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "The classical birthday problem at the root of this open-question chain. The k=3 'at most two per day' count refined here is the triple-coincidence analogue of the original all-distinct birthday count."
     }
   ],
   "sections": [


### PR DESCRIPTION
## Enrichment pass — birthday-problem-oq-03-oq-01-oq-01-oq-05

This entry ("Closed Form for the k=3 Birthday Count at n = 4") was otherwise well-curated (5 annotations w/ mathContext, 5 keyInsights, 4 sections, 4 references, complete conclusion) but had only **one** crossReference — to its parent — despite naming several siblings in its prose and open questions.

### Change
`crossReferences` 1 → 5. Added four substantive links to **named, verified-to-exist** relatives:

- **birthday-problem-oq-03-oq-01-oq-01-oq-02** (`related`) — the k-way histogram recurrence Rk generalizing the parent slot recurrence. This is exactly the entry's own open question 'extend to the k-way count R_k', made concrete for one term.
- **birthday-problem-oq-03-oq-01-oq-01-oq-03** (`complementary`) — the large-n k=3 coincidence threshold n ≈ (6d²ln2)^(1/3); exact small-n closed form vs asymptotic threshold, the two sides of birthdayCount3.
- **birthday-problem-oq-03-oq-01** (`related`) — grandparent extension-counting framework underlying R.
- **birthday-problem** (`related`) — the classical root problem.

No content removed. File 9.2 KB, all size caps satisfied (`check-meta-size` passes). Non-inflationary: closes a genuine reciprocal-crossref gap in a family of 20 sibling entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)