### PR TITLE
Enrich Chebyshev θ(n) ≤ n·log 4: de-bundle the 2n·log 2 restatement (annotations 4->5)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/annotations.json
@@ -72,12 +72,12 @@
     "proofId": "chebyshev-bounds-oq-06-oq-02",
     "range": {
       "startLine": 58,
-      "endLine": 74
+      "endLine": 64
     },
     "type": "key-step",
     "title": "The upper Chebyshev bound θ(n) ≤ n·log 4",
-    "content": "The main result. Rewrite θ(n) = log(n#), then apply Real.log_le_log (log is increasing on the positive reals) to Mathlib's primorial bound n# ≤ 4ⁿ, giving log(n#) ≤ log(4ⁿ); positivity of n# comes from primorial_pos. Finish with Real.log_pow: log(4ⁿ) = n·log 4. The companion chebyshevTheta_le_two_mul rewrites log 4 = 2·log 2 to present the bound as θ(n) ≤ 2n·log 2, the form usually quoted in the Chebyshev estimates.",
-    "mathContext": "$\\theta(n) = \\log(n\\#) \\le \\log(4^n) = n\\log 4 = 2n\\log 2$, using $n\\# \\le 4^n$ and monotone $\\log$.",
+    "content": "The main result. Rewrite θ(n) = log(n#), then apply Real.log_le_log (log is increasing on the positive reals) to Mathlib's primorial bound n# ≤ 4ⁿ, giving log(n#) ≤ log(4ⁿ); positivity of n# comes from primorial_pos. Finish with Real.log_pow: log(4ⁿ) = n·log 4. The whole estimate is thus a three-line calc: monotone log applied to the arithmetic bound, then the log-of-a-power identity.",
+    "mathContext": "$\\theta(n) = \\log(n\\#) \\le \\log(4^n) = n\\log 4$, using $n\\# \\le 4^n$ and monotone $\\log$.",
     "significance": "central",
     "relatedConcepts": [
       "primorial_le_4_pow",
@@ -89,6 +89,29 @@
       "monotonicity of log",
       "log of a power",
       "primorial bound n# ≤ 4ⁿ"
+    ]
+  },
+  {
+    "id": "ann-chebo0602-restatement",
+    "proofId": "chebyshev-bounds-oq-06-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "Restating the bound as θ(n) ≤ 2n·log 2",
+    "content": "chebyshevTheta_le_two_mul repackages the same estimate in the constant usually quoted in the classical Chebyshev bounds. The only ingredient is log 4 = 2·log 2, proved by writing 4 = 2² and applying Real.log_pow, after which the bound θ(n) ≤ n·log 4 from the previous theorem becomes θ(n) ≤ 2n·log 2. This is not a new inequality but a cosmetic rewrite that surfaces the base-2 constant 2·log 2 ≈ 1.386, making the entry directly comparable to the standard statement θ(n) ≲ (log 4)·n and to lower-bound companions phrased in log 2.",
+    "mathContext": "$\\log 4 = \\log(2^2) = 2\\log 2$, so $\\theta(n) \\le n\\log 4 = 2n\\log 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_pow",
+      "logarithm base change",
+      "Chebyshev bounds",
+      "constant 2·log 2"
+    ],
+    "prerequisites": [
+      "log of a power",
+      "log 4 = 2·log 2"
     ]
   }
 ]

--- a/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06-oq-02/meta.json
@@ -89,8 +89,15 @@
       "id": "chebyshev-upper-bound",
       "title": "The upper Chebyshev bound θ(n) ≤ n·log 4",
       "startLine": 58,
+      "endLine": 64,
+      "summary": "chebyshevTheta_le rewrites θ(n) = log(n#), applies Real.log_le_log to the primorial bound n# ≤ 4ⁿ (Nat.primorial_le_4_pow), and finishes with Real.log_pow: log(4ⁿ) = n·log 4."
+    },
+    {
+      "id": "chebyshev-bound-restatement",
+      "title": "Restatement θ(n) ≤ 2n·log 2",
+      "startLine": 66,
       "endLine": 74,
-      "summary": "chebyshevTheta_le rewrites θ(n) = log(n#), applies Real.log_le_log to the primorial bound n# ≤ 4ⁿ (Nat.primorial_le_4_pow), and finishes with Real.log_pow: log(4ⁿ) = n·log 4. chebyshevTheta_le_two_mul restates this as θ(n) ≤ 2n·log 2 via log 4 = 2·log 2."
+      "summary": "chebyshevTheta_le_two_mul restates the bound in the base-2 constant of the classical Chebyshev estimates, via log 4 = 2·log 2 (from 4 = 2² and Real.log_pow): θ(n) ≤ n·log 4 = 2n·log 2."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Enrichment pass — chebyshev-bounds-oq-06-oq-02

The 4th annotation (and matching section) spanned lines 58–74, **bundling two distinct theorems**:
- `chebyshevTheta_le` — θ(n) ≤ n·log 4 (lines 58–64), and
- `chebyshevTheta_le_two_mul` — the restatement θ(n) ≤ 2n·log 2 via log 4 = 2·log 2 (lines 66–74).

### Change
De-bundled into two annotations and two sections so the base-2 restatement (the constant usually quoted in the classical Chebyshev estimates) gets its own coverage:

- **annotations 4 → 5**, all five carrying `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. This clears the ≥5-annotation quality floor the entry previously missed (it had 4).
- Annotation #4 narrowed to 58–64 (log-4 bound); new insight annotation for 66–74 (2n·log 2 restatement).
- Sections mirror the split (58–64, 66–74) for page consistency.

Non-overlapping ranges, full file coverage preserved. No content removed. Size within all caps (`check-meta-size` passes, 15 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)