### PR TITLE
Enrich Subset-of-a-Subset Identity: link its multinomial extension (crossRefs 2->3)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
@@ -120,6 +120,10 @@
     {
       "targetId": "combinations-formula-oq-09",
       "relationship": "related — weighted binomial row sums, whose ∑ k·C(n,k) = n·2^{n-1} is driven by the absorption corollary proved here"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01-oq-01",
+      "relationship": "extended-by — Trinomial Peeling, the multinomial extension of this identity: it carries the same denominator-clearing route from the binomial trinomial revision C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) to the three-part multinomial coefficient, factoring it as a nested pair of binomials"
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Enrichment pass — combinations-formula-oq-07-oq-01

Reciprocal-crossref gap. The child entry **combinations-formula-oq-07-oq-01-oq-01** ("Trinomial Peeling: the Multinomial Extension of Trinomial Revision") already links *up* to this entry as its `parent` and explicitly extends this entry's identity C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m) to the three-part multinomial coefficient by the same denominator-clearing route — but this entry carried **no forward link** to it.

### Change
`crossReferences` 2 → 3: added the `extended-by` link to the child (verified to exist). Clears the entry's ≥3-crossref shortfall and completes the parent↔child pair.

No content removed. Size within all caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)