### PR TITLE
Enrich Hockey-Stick Identity: fix stale reference note

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
@@ -204,7 +204,7 @@
       "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
       "year": 2020,
       "venue": "CPP",
-      "note": "Provides Nat.multinomial, Finset.piAntidiag, PMF, and the probability/binomial API underlying this formalization."
+      "note": "Provides the binomial-coefficient API underlying this formalization: Finset.sum_range_succ, Nat.choose_succ_succ (Pascal's rule), Nat.sum_Icc_choose (the interval hockey-stick), and Nat.choose_one_right / Nat.choose_two_right for the figurate specializations."
     }
   ]
 }


### PR DESCRIPTION
## Correction (accuracy fix)

The `binomial-theorem-oq-02-oq-02-oq-02` (Hockey-Stick Identity) entry had a stale, incorrect Mathlib-community reference note — a copy-paste artifact from an unrelated probability formalization:

> Provides Nat.multinomial, Finset.piAntidiag, PMF, and the probability/binomial API underlying this formalization.

This entry uses **none** of `Nat.multinomial`, `Finset.piAntidiag`, or `PMF`. Corrected the note to name the API the proof actually relies on:

> Provides the binomial-coefficient API underlying this formalization: Finset.sum_range_succ, Nat.choose_succ_succ (Pascal's rule), Nat.sum_Icc_choose (the interval hockey-stick), and Nat.choose_one_right / Nat.choose_two_right for the figurate specializations.

## Notes
- Single-field accuracy fix; no inflation. The entry is already well-worked (6 full annotations, 5 mainTheorems, complete sections/conclusion), so no deepening was warranted under the size-guardrail SKIP rule.
- JSON validated; `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)