### PR TITLE
Enrich Quantitative Cantor (#A < #(A → Prop)): add conclusion, +2 keyInsights

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01-oq-03/meta.json
@@ -52,7 +52,9 @@
     "keyInsights": [
       "The open question is a one-line consequence of the standard cardinal Cantor theorem once A → Prop is identified with its power set Set A — the identification the parent's map-level development never phrased at the cardinal level.",
       "The strict cardinal gap #A < #(A → Prop) is strictly stronger than non-surjectivity: it fixes both the direction and the strictness of the size difference, and re-implies non-surjectivity because any surjection A ↠ B forces #B ≤ #A.",
-      "#A < #(A → Prop) and #A < #(Set A) are the same proposition up to definitional equality (Set A ≡ A → Prop), so no transport lemma is needed between them — only Cardinal.mk_set to reach 2^#A."
+      "#A < #(A → Prop) and #A < #(Set A) are the same proposition up to definitional equality (Set A ≡ A → Prop), so no transport lemma is needed between them — only Cardinal.mk_set to reach 2^#A.",
+      "The reduction is carried by definitional, not merely propositional, equality: because A → Prop unfolds to Set A, the term cardinality_gap_set A already has type #A < #(A → Prop), so cardinality_gap needs no rewriting — a fact the closing rfl example makes explicit. The genuine mathematical content lives entirely in the single step #(Set A) = 2^#A; everything else is Lean's kernel unfolding the same object under two names.",
+      "The strict gap a < 2^a is only the first rung of a ladder of cardinal Cantor theorems: König's theorem sharpens it to a < cf(2^a), controlling the cofinality of the power cardinal, and iterating the power-set operation yields the strict chain #A < #(𝒫A) < #(𝒫²A) < ⋯ that generates the beth hierarchy ℶ_α. The gap proved here is the minimal such statement — enough to re-derive non-surjectivity, but strictly weaker than these refinements."
     ]
   },
   "crossReferences": [
@@ -96,5 +98,14 @@
       "title": "The gap is strictly stronger",
       "content": "not_surjective_of_cardinality_gap re-derives the parent's non-surjectivity from the gap: a surjection A ↠ (A → Prop) would force #(A → Prop) ≤ #A (Cardinal.mk_le_of_surjective), contradicting #A < #(A → Prop). Thus the quantitative statement subsumes the qualitative one."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Open question #3 of the parent 'Reflexive Objects and the Fixed-Point Property' is settled: for every type A the cardinals #A and #(A → Prop) are strictly ordered, #A < #(A → Prop), not merely distinct. The three theorems reduce this to Mathlib's cardinal Cantor theorem Cardinal.cantor (a < 2^a) via the definitional identification A → Prop ≡ Set A and #(Set A) = 2^#A (Cardinal.mk_set), and not_surjective_of_cardinality_gap closes the loop by recovering the parent's qualitative non-surjectivity from the strict gap. The formalization is 84 lines, 3 theorems, 0 sorries, 0 axiom declarations.",
+    "implications": "The result pins down the parent's Cantor obstruction quantitatively: a strict inequality of cardinals fixes both the direction and the strictness of the size difference, whereas non-surjectivity alone leaves open which cardinal is larger. Because any surjection A ↠ B forces #B ≤ #A, the gap re-implies non-surjectivity, so it is provably the stronger statement — the qualitative theorem is a corollary of the quantitative one, not vice versa. Methodologically the entry illustrates a recurring pattern: a bespoke map-level argument (here the Lawvere fixed-point recovery of Cantor) often has a one-line cardinal-arithmetic shadow once the objects are named correctly (A → Prop as a power set), and the shadow is frequently the sharper result.",
+    "openQuestions": [
+      "König's theorem sharpens Cantor to #A < cf(2^#A), bounding the cofinality of the power cardinal rather than just its size. Can the parent's Lawvere fixed-point framework be pushed to recover this strictly stronger cardinal bound, or does cofinality genuinely lie outside the diagonal/fixed-point paradigm?",
+      "The cardinal statement leans on classical cardinal arithmetic (well-ordering of cardinals, Cardinal.mk_set) and thus on Classical.choice. Does an analogous strict gap survive in constructive or predicative foundations, where power-set cardinals need not be well-behaved and 'strictly larger' must be formulated without a linear order on cardinals?",
+      "Iterating the power-set operation gives the strict chain #A < #(𝒫A) < #(𝒫²A) < ⋯ underlying the beth hierarchy ℶ_α. Is there a uniform gallery formalization of ℶ_α that captures all of these gaps — and their limit stages — at once, rather than one instance per entry?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-03-oq-01-incomplete-01-oq-01-oq-03` (0 prior enrichment passes; quality 79).

## Gaps addressed
- **Missing `conclusion`** — the entry had no conclusion object at all. Added `summary`, `implications`, and 3 substantive `openQuestions` (König's cofinality sharpening a < cf(2^a); constructive/predicative status; the beth-hierarchy chain #A < #(𝒫A) < #(𝒫²A) < ⋯).
- **keyInsights 3 → 5** — added (1) the reduction is carried by *definitional* not propositional equality (A → Prop unfolds to Set A, witnessed by the closing `rfl`), and (2) the gap a < 2^a as the minimal rung of the ladder König/beth refine.

All additions are grounded in the Lean source (`cardinality_gap_set`, `cardinality_gap`, `not_surjective_of_cardinality_gap`). No claims altered: `status: verified`, `axiomCount: 0` (only foundational propext/Choice/Quot.sound via the Mathlib cardinal API — correctly not counted). meta.json 7.5KB → 10.8KB, within all size caps.