### PR TITLE
Enrich Lovász Local Lemma OQ-01 (Euler threshold): add sections map (0→7)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/meta.json
@@ -106,6 +106,57 @@
       "Monotonicity of powers pow_le_pow_left₀ and the ordered-field division lemmas div_le_iff₀, div_le_div_iff₀, le_div_iff₀"
     ]
   },
+  "sections": [
+    {
+      "id": "overview-docstring",
+      "title": "Overview: two forms of the symmetric threshold",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring laying out the problem: the parent proof records the tight symmetric threshold T(d) = dᵈ/(d+1)^{d+1} (the exact maximum of x(1−x)ᵈ) with hypothesis P[Aᵢ] ≤ T(d), while the OQ-01 measure-theoretic front is stated against the memorable Euler condition e·p·(d+1) ≤ 1. States the goal — that the Euler form is the slightly weaker, hence safe, consequence e·p·(d+1) ≤ 1 ⇒ p ≤ T(d) — and identifies the pivotal inequality (1 + 1/d)ᵈ ≤ e coming from 1 + x ≤ exp x."
+    },
+    {
+      "id": "setup",
+      "title": "Imports and namespace",
+      "startLine": 37,
+      "endLine": 41,
+      "summary": "Imports the parent proof Proofs.LovaszLocalLemma (source of lllThreshold), opens Real and ProbMethod.LovaszLocal, and enters the LovaszLocalLemmaOQ01EulerThreshold namespace. No new definitions are introduced — the file is entirely theorems over ℝ."
+    },
+    {
+      "id": "euler-bound",
+      "title": "The classic Euler bound (1 + 1/d)ᵈ ≤ e",
+      "startLine": 43,
+      "endLine": 58,
+      "summary": "one_add_inv_pow_le_exp_one. From Real.add_one_le_exp instantiated at x = 1/d, 1 + 1/d ≤ exp(1/d); both sides nonnegative, so pow_le_pow_left₀ raises to the d-th power, and exp(1/d)ᵈ = exp(d·(1/d)) = exp 1 via Real.exp_nat_mul with d·(1/d) = 1 (d ≠ 0). This is the single inequality that puts the constant e into the LLL."
+    },
+    {
+      "id": "multiplicative-form",
+      "title": "Multiplicative form (d+1)ᵈ ≤ e·dᵈ",
+      "startLine": 60,
+      "endLine": 67,
+      "summary": "succ_pow_le_exp_mul. Rewrites 1 + 1/d = (d+1)/d and clears the denominator (div_pow, div_le_iff₀) to turn the Euler bound into the denominator-free multiplicative inequality (d+1)ᵈ ≤ e·dᵈ, the form used downstream."
+    },
+    {
+      "id": "threshold-cast",
+      "title": "Real-cast of the tight threshold",
+      "startLine": 69,
+      "endLine": 75,
+      "summary": "lllThreshold_cast. Bridges the parent proof's ℚ-valued lllThreshold to ℝ: for d ≥ 1, (lllThreshold d : ℝ) = dᵈ/(d+1)^{d+1}, by unfolding the definition (if_neg for d ≠ 0), push_cast, and ring. Lets the real-analysis inequalities speak directly about T(d)."
+    },
+    {
+      "id": "euler-below-threshold",
+      "title": "The Euler budget sits below the threshold",
+      "startLine": 77,
+      "endLine": 89,
+      "summary": "inv_exp_mul_le_lllThreshold: 1/(e·(d+1)) ≤ (lllThreshold d : ℝ). Via lllThreshold_cast, div_le_div_iff₀ and pow_succ, this reduces to (d+1)^{d+1} ≤ e·(d+1)·dᵈ — the multiplicative Euler bound scaled by (d+1) — closed by nlinarith from succ_pow_le_exp_mul."
+    },
+    {
+      "id": "bridge",
+      "title": "The bridge: Euler condition ⇒ tight threshold",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "euler_condition_implies_lllThreshold, the main result. From e·p·(d+1) ≤ 1 and le_div_iff₀, p ≤ 1/(e·(d+1)); chaining with inv_exp_mul_le_lllThreshold gives p ≤ T(d). Needs no nonnegativity hypothesis on p (a negative p satisfies both sides trivially), so the tight-threshold symmetric LLL of the parent proof applies verbatim under the memorable Euler condition."
+    }
+  ],
   "conclusion": {
     "summary": "The memorable Euler symmetric LLL condition e·p·(d+1) ≤ 1 is machine-verified to imply the tight threshold p ≤ T(d) = dᵈ/(d+1)^{d+1} used by the parent gallery proof, via the classic Euler inequality (1 + 1/d)ᵈ ≤ e. Elementary real analysis, fully checked: 0 sorries, 0 axioms.",
     "implications": "**Connects the two threshold fronts of the OQ-01 landscape.** The parent proof lovasz-local-lemma develops the tight symmetric threshold T(d) over ℚ; the OQ-01 measure-theoretic entries (lovasz-local-lemma-oq-01, its union-bound, chain-rule, and quantitative refinements) are stated against the Euler condition e·p·(d+1) ≤ 1. This entry is the verified bridge: it shows the Euler hypothesis is a legitimate, slightly conservative consequence of the tight threshold, so results proved under either hypothesis transfer to the other. It also isolates the exact inequality — (1 + 1/d)ᵈ ≤ e — that puts the constant e into the LLL.\n\n**Honest scope**: this is real-analysis bookkeeping about which hypothesis is stronger, not a proof that either hypothesis suffices for avoidance. The measure-theoretic symmetric LLL — that e·p·(d+1) ≤ 1 forces μ(⋂ Aᵢᶜ) > 0 over a real probability space with a bounded-dependency-degree structure — remains the open research target; see the chain-rule and quantitative entries for the reduction that awaits the per-event conditional bounds.",


### PR DESCRIPTION
Enrichment pass for `lovasz-local-lemma-oq-01-euler-threshold`.

**Real gap closed:** the entry was rich in every narrative field (1136-char historicalContext, 4 keyInsights, complete conclusion with 3 open questions, 3 crossReferences, 5 mainTheorems) but the `sections` array was empty (0). This PR fills it with a 7-part map of the 106-line Lean file, each section carrying startLine/endLine and a substantive summary:

1. Overview docstring (1–36) — the two threshold forms and the goal
2. Imports & namespace (37–41)
3. The Euler bound `(1+1/d)ᵈ ≤ e` (43–58)
4. Multiplicative form `(d+1)ᵈ ≤ e·dᵈ` (60–67)
5. Real-cast of `lllThreshold` (69–75)
6. Euler budget below the threshold (77–89)
7. The bridge `e·p·(d+1) ≤ 1 ⇒ p ≤ T(d)` (91–104)

**No inflation:** existing complete fields were left untouched; only the empty structural field was populated. meta.json 17.3 → 20.7 KB (cap 60 KB, size check passes). JSON validated.