### PR TITLE
research(ramsey-r4k-extensions-oq-03): general M=1 deletion gain theorem (unifies k=6/k=7 witnesses)

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -248,6 +248,40 @@ theorem ramsey_deletion_bound (hk : 2 ≤ k) (hkn : k ≤ n) :
       ∀ K : Finset (Fin n), K ⊆ R → K.card = k → ¬ Mono c K :=
   ramsey_deletion hk hkn
 
+/-- **The general "one step past the union threshold" gain.**  Suppose `n` sits in the
+    first deletion window past the sharp union bound, i.e.
+
+        `2 ^ C(k,2) ≤ 2·C(n,k) < 2·2 ^ C(k,2)`.
+
+    The left inequality says the union-bound test `2·C(n,k) < 2 ^ C(k,2)` *fails* at `n`
+    (so the first moment certifies nothing on all of `Kₙ`); the two together pin the
+    deletion count `M = ⌊2·C(n,k)/2 ^ C(k,2)⌋ = 1`.  Deleting that single bad-clique
+    representative leaves a monochromatic-`Kₖ`-free set of `n − 1` vertices — a strict
+    improvement over the union bound precisely where the union bound gives out.
+
+    This is the *general* mechanism behind the concrete `k = 6` (`n = 19`) and `k = 7`
+    (`n = 30`) witnesses below: both land in exactly this `M = 1` window, so
+    `deletion_no_mono_K6` and `deletion_no_mono_K7` are instances of this theorem.  No
+    large `decide` is needed here — the `M = 1` collapse is pure `ℕ`-division reasoning,
+    valid for every `k`. -/
+theorem ramsey_deletion_one_past (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hlo : 2 ^ (k.choose 2) ≤ 2 * n.choose k)
+    (hhi : 2 * n.choose k < 2 * 2 ^ (k.choose 2)) :
+    ∃ (c : Coloring n) (R : Finset (Fin n)),
+      n - 1 ≤ R.card ∧
+      ∀ K : Finset (Fin n), K ⊆ R → K.card = k → ¬ Mono c K := by
+  have hbpos : 0 < 2 ^ (k.choose 2) := pow_pos (by norm_num) _
+  -- the two window inequalities force the deletion count `M` to be exactly `1`
+  have hM1 : (2 * n.choose k) / 2 ^ (k.choose 2) = 1 := by
+    have hq1 : 1 ≤ (2 * n.choose k) / 2 ^ (k.choose 2) := by
+      rw [Nat.le_div_iff_mul_le hbpos]; simpa using hlo
+    have hq2 : (2 * n.choose k) / 2 ^ (k.choose 2) < 2 := by
+      rw [Nat.div_lt_iff_lt_mul hbpos]; exact hhi
+    omega
+  obtain ⟨c, R, hRcard, hR⟩ := ramsey_deletion (n := n) (k := k) hk hkn
+  rw [hM1] at hRcard
+  exact ⟨c, R, hRcard, hR⟩
+
 set_option maxHeartbeats 800000 in
 /-- **The sharp union bound caps at `n = 17` for `k = 6`.**  The first-moment test
     `2·C(n,6) < 2^{C(6,2)} = 2^{15}` holds at `n = 17` (`2·12376 = 24752 < 32768`) but
@@ -324,6 +358,7 @@ theorem deletion_no_mono_K7 :
 #check @ramsey_deletion
 #check @ramsey_deletion_generalizes_first_moment
 #check @ramsey_deletion_bound
+#check @ramsey_deletion_one_past
 #check @deletion_no_mono_K6
 #check @unionBound_caps_at_27_for_K7
 #check @deletion_no_mono_K7
@@ -336,6 +371,7 @@ theorem deletion_no_mono_K7 :
 -- reduction cheap (single-recursion `descFactorial`), also axiom-free.
 #print axioms ramsey_deletion
 #print axioms ramsey_deletion_generalizes_first_moment
+#print axioms ramsey_deletion_one_past
 #print axioms deletion_no_mono_K6
 #print axioms unionBound_caps_at_27_for_K7
 #print axioms deletion_no_mono_K7

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -4,6 +4,50 @@ Insights accumulated during research on this problem.
 
 ---
 
+## PART X — the general `M=1` gain theorem unifying the k=6/k=7 witnesses (researcher-14, 2026-07-03)
+
+**Mode**: REVISIT (RICH, score 29). **Outcome**: progress (+1 general theorem
+`ramsey_deletion_one_past` in `RamseyR4kExtensionsOQ03Deletion.lean`; still 0 sorries/0
+axioms). **Machine-verified**: docker-build clean, 7744 jobs, `#print axioms` =
+`propext / Classical.choice / Quot.sound` only (Tier-A axiom-free).
+
+### What this closes
+PARTS VIII/IX shipped the concrete deletion witnesses `deletion_no_mono_K6` (R(6,6)>18,
+n=19) and `deletion_no_mono_K7` (R(7,7)>29, n=30) as *ad-hoc* `decide`-on-`deletionBound`
+calculations. Both land in the same structural regime — one step past the sharp union
+threshold, where the deletion count `M = ⌊2·C(n,k)/2^C(k,2)⌋ = 1`. This session extracts
+that regime as a **general, k-uniform theorem** so the concrete witnesses become instances
+of a stated mechanism rather than isolated numeric facts.
+
+### Shipped
+- **`ramsey_deletion_one_past (hk : 2 ≤ k) (hkn : k ≤ n)
+  (hlo : 2^C(k,2) ≤ 2·C(n,k)) (hhi : 2·C(n,k) < 2·2^C(k,2))`** ⇒ a 2-colouring `c` of
+  `Kₙ` and a set `R` with `n − 1 ≤ |R|` and no monochromatic `Kₖ`.
+  Reading: `hlo` says the union-bound test `2·C(n,k) < 2^C(k,2)` *fails* at `n` (first
+  moment certifies nothing on all of Kₙ); the pair pins `M = 1`, so deletion still keeps
+  `n − 1` vertices. This is exactly the +1-over-the-threshold gain, uniform in `k`.
+- Verified both concrete witnesses sit in this window (Python + kernel): k=6,n=19:
+  `2^15=32768 ≤ 54264 < 65536`; k=7,n=30: `2^21=2097152 ≤ 4071600 < 4194304`. Both give
+  `deletionBound = n−1` (=18, =29), matching PARTS VIII/IX.
+
+### Reusable gotcha (researcher-14)
+- **`M = 1` collapse without nonlinear `omega`.** To prove `x/b = 1` from `b ≤ x < 2b`
+  with `b` a *variable* (`b = 2^C(k,2)`), `omega` alone fails (it can't reason about the
+  variable division). Route through the two `Nat` div-iff lemmas to turn the quotient into
+  linear facts, then `omega`:
+  `rw [Nat.le_div_iff_mul_le hbpos]` reduces `1 ≤ x/b` to `1·b ≤ x` (`simpa using hlo`);
+  `rw [Nat.div_lt_iff_lt_mul hbpos]` reduces `x/b < 2` to `x < 2·b` (`exact hhi`, matches
+  the RHS `n*k` shape exactly with n=2). Then `1 ≤ x/b` and `x/b < 2` give `x/b = 1` by
+  `omega`. This is the k-uniform replacement for PART VIII/IX's per-witness
+  `decide`-on-`deletionBound`, and needs NO large binomial evaluation.
+
+### Still open (unchanged)
+The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (Spencer's conditional-
+probability induction) remains the one non-Mathlib ingredient — a >1000-line measure-
+theoretic undertaking. See sibling `lovasz-local-lemma-oq-01`.
+
+---
+
 ## PART VIII — the deletion method STRICTLY beats the sharp union bound (researcher-14, 2026-07-03)
 
 **Mode**: REVISIT (RICH, score 25). **Outcome**: progress (+1 def, +3 theorems in

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -4,33 +4,34 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-03
-**Iteration**: 8 (PART VIII)
+**Iteration**: 10 (PART X)
 
 ## Current Focus
-Deletion/alteration method as the elementary probabilistic upgrade that STRICTLY
-beats the sharp union bound at small k (where the symmetric LLL of this entry does
-not). Added `deletionBound`, `ramsey_deletion_bound`, `unionBound_caps_at_17_for_K6`,
-`deletion_no_mono_K6` to `RamseyR4kExtensionsOQ03Deletion.lean`.
+Generalized the ad-hoc k=6/k=7 deletion witnesses into one k-uniform theorem
+`ramsey_deletion_one_past`: whenever `n` is one step past the sharp union threshold
+(`2^C(k,2) ≤ 2·C(n,k) < 2·2^C(k,2)`, i.e. deletion count `M=1`), the deletion method
+keeps a monochromatic-Kₖ-free set of `n−1` vertices. Both concrete witnesses are now
+instances of a stated mechanism.
 
 ## Active Approach
-Concrete crossover witnesses via kernel `decide` on ℕ (axiom-free). k=6 discharged as
-theorem (R(6,6)>18 vs union bound's 17); k=7 (R(7,7)>29 vs 27) kept as prose remark
-because C(30,7)≈2M makes decide impractical.
+Machine-verified general theorem (docker-build clean, 7744 jobs), Tier-A axiom-free
+(`propext / Classical.choice / Quot.sound`). The `M=1` collapse is proved by the two
+`Nat` div-iff lemmas + `omega` (no large binomial `decide`).
 
 ## Attempt Count
-- Total attempts: 8
+- Total attempts: 10
 - Current approach attempts: 1
 - Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
-  identity, honest union-bound comparison (PART VII), deletion method (PART VIII)
+  identity, honest union-bound comparison (VII), deletion method (VIII), k=7
+  machine-checked witness + compile repair (IX), general M=1 gain theorem (X)
 
 ## Blockers
-- **ENV**: host disk 100% full; Docker mathlib-cache decompress fails (ENOSPC). This
-  session's additions are Python-verified + hand-audited but NOT machine-built. Needs
-  CI/deployer build (once disk is reset) to confirm green.
 - **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
-  the sole remaining non-Mathlib ingredient. Left as explicit hypothesis.
+  the sole remaining non-Mathlib ingredient. Left as explicit hypothesis. See sibling
+  `lovasz-local-lemma-oq-01`.
 
 ## Next Action
-Once the disk-full env blocker is cleared, build `Proofs.RamseyR4kExtensionsOQ03Deletion`
-and confirm `deletion_no_mono_K6` / `unionBound_caps_at_17_for_K6` verify with
-`#print axioms` = propext/Classical.choice/Quot.sound only.
+Optional future increments: (a) a general "deletion strictly beats union" corollary
+quantifying the gain as a function of k; (b) k=8 witness via the descFactorial route.
+The core deletion-method programme is now stated at full generality (M=0 recovers first
+moment via `ramsey_deletion_generalizes_first_moment`; M=1 via `ramsey_deletion_one_past`).


### PR DESCRIPTION
## Summary

Extracts the ad-hoc concrete deletion witnesses `deletion_no_mono_K6` (R(6,6)>18) and `deletion_no_mono_K7` (R(7,7)>29) into a single **k-uniform** theorem stating the underlying mechanism.

**New theorem** in `Proofs/RamseyR4kExtensionsOQ03Deletion.lean`:

```lean
theorem ramsey_deletion_one_past (hk : 2 ≤ k) (hkn : k ≤ n)
    (hlo : 2 ^ (k.choose 2) ≤ 2 * n.choose k)
    (hhi : 2 * n.choose k < 2 * 2 ^ (k.choose 2)) :
    ∃ (c : Coloring n) (R : Finset (Fin n)),
      n - 1 ≤ R.card ∧
      ∀ K : Finset (Fin n), K ⊆ R → K.card = k → ¬ Mono c K
```

The hypothesis `hlo` says the sharp union-bound test `2·C(n,k) < 2^C(k,2)` **fails** at `n` (so the first moment certifies nothing on all of Kₙ); together with `hhi` it pins the deletion count `M = ⌊2·C(n,k)/2^C(k,2)⌋ = 1`, and deletion keeps `n − 1` vertices. This is the +1-over-the-threshold gain, uniform in `k`.

Both prior witnesses land in exactly this window:
- k=6, n=19: `2^15 = 32768 ≤ 54264 < 65536`
- k=7, n=30: `2^21 = 2097152 ≤ 4071600 < 4194304`

so they are instances of a stated mechanism rather than isolated numeric `decide`s.

## Verification

- **Machine-verified**: `docker-build.sh Proofs.RamseyR4kExtensionsOQ03Deletion` clean, 7744 jobs.
- **Axiom-free (Tier A)**: `#print axioms ramsey_deletion_one_past` = `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- 0 sorries, 0 axiom declarations. No change to gallery `meta.json` (companion file; the tracked `leanFile` is the main OQ03 file).

## Proof note

The `M = 1` collapse is proved without nonlinear `omega`: since the divisor `b = 2^C(k,2)` is a variable, `x/b = 1` is obtained by rewriting through `Nat.le_div_iff_mul_le` and `Nat.div_lt_iff_lt_mul` (turning the quotient bounds into the linear facts `b ≤ x` and `x < 2b`), then `omega`. No large binomial `decide` is required — the result holds for every `k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)