### PR TITLE
research(weak-goldbach-oq-01): close Schnirelmann iteration bookkeeping (only the inequality remains)

### DIFF
--- a/proofs/Proofs/SchnirelmannBasis.lean
+++ b/proofs/Proofs/SchnirelmannBasis.lean
@@ -177,6 +177,112 @@ theorem exists_pow_deficiency_lt_half
   exists_pow_lt_of_lt_one (by norm_num) (by linarith)
 
 /-
+  ── Iteration bookkeeping: `h`-fold sum-sets and basis composition ────────────
+
+  The density-boosting iteration of Schnirelmann's theorem produces the `h`-fold
+  sum-set `h · A` and needs the bookkeeping that an element of `h · A` is a sum
+  of at most `h` elements of `A`, and that composing two such representations
+  gives a sum of at most `2h` elements. The lemmas below discharge that
+  bookkeeping *completely* (0 sorry / 0 axiom), leaving Schnirelmann's inequality
+  as the *sole* remaining gap toward `schnirelmann_basis_theorem`.
+-/
+
+/-- `IsSumOfAtMost A h n`: `n` is a sum of at most `h` elements of `A` (with
+    repetition). This is `WeakGoldbach.IsAdditiveBasis A h` unfolded at a single
+    point `n`, using the identical `Multiset` shape. -/
+def IsSumOfAtMost (A : Set ℕ) (h n : ℕ) : Prop :=
+  ∃ S : Multiset ℕ, (∀ x ∈ S, x ∈ A) ∧ S.card ≤ h ∧ S.sum = n
+
+/-- `0` is a sum of at most `h` elements of `A` for every `h`: the empty
+    multiset works (`0` summands, empty sum). No hypothesis `0 ∈ A` is needed. -/
+theorem zero_isSumOfAtMost (A : Set ℕ) (h : ℕ) : IsSumOfAtMost A h 0 :=
+  ⟨0, by simp, by simp, by simp⟩
+
+/-- Relax the summand budget: a sum of at most `h` elements is also a sum of at
+    most `h'` elements when `h ≤ h'`. -/
+theorem IsSumOfAtMost.mono {A : Set ℕ} {h h' n : ℕ}
+    (hn : IsSumOfAtMost A h n) (hh : h ≤ h') : IsSumOfAtMost A h' n := by
+  obtain ⟨S, hS, hSc, hSs⟩ := hn
+  exact ⟨S, hS, le_trans hSc hh, hSs⟩
+
+/-- **Composition.** If `m` is a sum of at most `h₁` elements of `A` and `p` is a
+    sum of at most `h₂` elements of `A`, then `m + p` is a sum of at most
+    `h₁ + h₂` elements of `A`: concatenate the two witnessing multisets. -/
+theorem IsSumOfAtMost.add {A : Set ℕ} {h₁ h₂ m p : ℕ}
+    (hm : IsSumOfAtMost A h₁ m) (hp : IsSumOfAtMost A h₂ p) :
+    IsSumOfAtMost A (h₁ + h₂) (m + p) := by
+  obtain ⟨S, hS, hSc, hSs⟩ := hm
+  obtain ⟨T, hT, hTc, hTs⟩ := hp
+  refine ⟨S + T, ?_, ?_, ?_⟩
+  · intro x hx
+    rw [Multiset.mem_add] at hx
+    rcases hx with hx | hx
+    · exact hS x hx
+    · exact hT x hx
+  · rw [Multiset.card_add]; omega
+  · rw [Multiset.sum_add, hSs, hTs]
+
+/-- The `h`-fold sum-set of `A`: the set of naturals expressible as a sum of at
+    most `h` elements of `A`. Always contains `0` (see `zero_mem_sumsetPow`),
+    which is exactly the `0 ∈ ·` hypothesis the covering lemma needs. -/
+def sumsetPow (A : Set ℕ) (h : ℕ) : Set ℕ := {n | IsSumOfAtMost A h n}
+
+@[simp] theorem mem_sumsetPow {A : Set ℕ} {h n : ℕ} :
+    n ∈ sumsetPow A h ↔ IsSumOfAtMost A h n := Iff.rfl
+
+/-- `0` lies in every `h`-fold sum-set of `A`. -/
+theorem zero_mem_sumsetPow (A : Set ℕ) (h : ℕ) : 0 ∈ sumsetPow A h :=
+  zero_isSumOfAtMost A h
+
+/-- The sum of a multiset all of whose entries lie in the `h`-fold sum-set
+    `sumsetPow A h` is itself a sum of at most `S.card · h` elements of `A`.
+    Proof by multiset induction, using `IsSumOfAtMost.add` at each `cons`. -/
+theorem isSumOfAtMost_multiset_sum {A : Set ℕ} {h : ℕ} :
+    ∀ S : Multiset ℕ, (∀ x ∈ S, x ∈ sumsetPow A h) →
+      IsSumOfAtMost A (S.card * h) S.sum := by
+  intro S
+  induction S using Multiset.induction with
+  | empty =>
+      intro _
+      simp only [Multiset.card_zero, Nat.zero_mul, Multiset.sum_zero]
+      exact zero_isSumOfAtMost A 0
+  | cons a s ih =>
+      intro hmem
+      have ha : IsSumOfAtMost A h a := hmem a (Multiset.mem_cons_self a s)
+      have hs : IsSumOfAtMost A (s.card * h) s.sum :=
+        ih (fun x hx => hmem x (Multiset.mem_cons_of_mem hx))
+      have hidx : (s.card + 1) * h = h + s.card * h := by ring
+      rw [Multiset.card_cons, Multiset.sum_cons, hidx]
+      exact ha.add hs
+
+/-- **Basis composition (bookkeeping step of Schnirelmann's theorem).** If the
+    `h`-fold sum-set `sumsetPow A h` has Schnirelmann density `≥ 1/2`, then `A`
+    itself is an additive basis of order `2h`: every `n` is a sum of at most `2h`
+    elements of `A`.
+
+    This composes two verified pieces — `isAdditiveBasis_two_of_density_ge_half`
+    (density `≥ 1/2` ⇒ the sum-set is a basis of order `2`) with
+    `isSumOfAtMost_multiset_sum` (each sum-set element unpacks into `≤ h`
+    elements of `A`) — closing the entire iteration bookkeeping. The result is in
+    the exact `Multiset` shape of `WeakGoldbach.IsAdditiveBasis A (2h)`.
+
+    Combined with `exists_pow_deficiency_lt_half`, this reduces
+    `schnirelmann_basis_theorem` to the *single* outstanding lemma: Schnirelmann's
+    inequality `σ(A ⊕ B) ≥ σA + σB − σA·σB` (needed to push some `σ(sumsetPow A h)`
+    above `1/2`). -/
+theorem isAdditiveBasis_of_sumsetPow_density_ge_half {A : Set ℕ} {h : ℕ}
+    [DecidablePred (· ∈ sumsetPow A h)]
+    (hdens : 1 / 2 ≤ schnirelmannDensity (sumsetPow A h)) (n : ℕ) :
+    ∃ S : Multiset ℕ, (∀ x ∈ S, x ∈ A) ∧ S.card ≤ 2 * h ∧ S.sum = n := by
+  obtain ⟨S, hS, hSc, hSs⟩ :=
+    isAdditiveBasis_two_of_density_ge_half (zero_mem_sumsetPow A h) hdens n
+  have hsum : IsSumOfAtMost A (S.card * h) n := by
+    have := isSumOfAtMost_multiset_sum S hS
+    rwa [hSs] at this
+  obtain ⟨T, hT, hTc, hTs⟩ := hsum.mono (by gcongr)
+  exact ⟨T, hT, hTc, hTs⟩
+
+/-
   ── Remaining gap toward `schnirelmann_basis_theorem` ─────────────────────────
 
   The `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean` states
@@ -193,17 +299,22 @@ theorem exists_pow_deficiency_lt_half
        density sum > 1, and `sumset_covers_of_density_add_ge_one` finishes:
        every n is a sum of ≤ 2h elements of A, i.e. A is a basis of order 2h.
 
-  Step (2) is now bracketed by two verified lemmas above:
+  Step (2) is now fully verified above:
     * its analytic input — `∃ h, (1 − σ(A))^h < 1/2` — is
       `exists_pow_deficiency_lt_half`;
     * its terminal step — `σ ≥ 1/2 ⇒ additive basis of order 2`, in the
       `Multiset` shape of `IsAdditiveBasis` — is
-      `isAdditiveBasis_two_of_density_ge_half`.
+      `isAdditiveBasis_two_of_density_ge_half`;
+    * its bookkeeping — an element of the `h`-fold sum-set is a sum of `≤ h`
+      elements of `A`, and this composes to order `2h` — is
+      `isSumOfAtMost_multiset_sum` / `IsSumOfAtMost.add`, packaged as the
+      reduction `isAdditiveBasis_of_sumsetPow_density_ge_half`:
+        `σ(sumsetPow A h) ≥ 1/2 ⇒ IsAdditiveBasis A (2h)`.
 
-  What remains between them is precisely step (1), Schnirelmann's inequality,
-  together with the bookkeeping that an element of the iterated sumset `h·A` is
-  a sum of at most `h` elements of `A`. The covering lemma (step 2's engine) is
-  already available for it.
+  The **sole** remaining gap is therefore step (1), Schnirelmann's inequality
+  `σ(A ⊕ B) ≥ σA + σB − σA·σB` (the delicate gap-counting step). Once it lands,
+  iterating it drives `σ(sumsetPow A h)` above `1/2` for some `h`, and
+  `isAdditiveBasis_of_sumsetPow_density_ge_half` discharges the axiom outright.
 -/
 
 end SchnirelmannBasis

--- a/proofs/Proofs/SchnirelmannBasis.lean
+++ b/proofs/Proofs/SchnirelmannBasis.lean
@@ -279,7 +279,9 @@ theorem isAdditiveBasis_of_sumsetPow_density_ge_half {A : Set ℕ} {h : ℕ}
   have hsum : IsSumOfAtMost A (S.card * h) n := by
     have := isSumOfAtMost_multiset_sum S hS
     rwa [hSs] at this
-  obtain ⟨T, hT, hTc, hTs⟩ := hsum.mono (by gcongr)
+  have hmono : IsSumOfAtMost A (2 * h) n :=
+    hsum.mono (mul_le_mul_right' hSc h)
+  obtain ⟨T, hT, hTc, hTs⟩ := hmono
   exact ⟨T, hT, hTc, hTs⟩
 
 /-

--- a/research/problems/weak-goldbach-oq-01/knowledge.md
+++ b/research/problems/weak-goldbach-oq-01/knowledge.md
@@ -391,3 +391,58 @@ a concurrent process reset the working tree to origin/main. Recovered by working
 locked `/private/tmp/wt-r14-schnir` worktree, committing IMMEDIATELY before verifying,
 and verifying via `lake env lean` against the main repo's `.lake` oleans (fresh
 worktree has none). Do this from the start.
+
+## Session 2026-07-04 (researcher-8) — Close the iteration bookkeeping; only Schnirelmann's inequality remains (ACT, PROGRESS)
+
+**Mode**: ACT (build) · **Outcome**: 6 new verified lemmas in `SchnirelmannBasis.lean`
+(0 sorry / 0 axiom), reducing `schnirelmann_basis_theorem` to a *single* remaining lemma.
+
+Prior sessions built the **covering** engine (`sumset_covers_of_density_add_ge_one`,
+`basis_order_two_of_density_ge_half`) and *bracketed* the iteration with the analytic
+input `exists_pow_deficiency_lt_half` and the terminal `isAdditiveBasis_two_of_density_ge_half`.
+The stated remaining gaps were (1) Schnirelmann's inequality and (2) the "bookkeeping that an
+element of the iterated sum-set `h·A` is a sum of at most `h` elements of `A`". **This session
+fully closes (2)** — the entire multiset bookkeeping — leaving (1) as the ONLY missing piece.
+
+**Built (`SchnirelmannBasis.lean`, all kernel-checked, pure tactics):**
+- `IsSumOfAtMost A h n` — `n` is a sum of ≤ `h` elements of `A` (the exact `Multiset` shape of
+  `WeakGoldbach.IsAdditiveBasis A h` at a single point).
+- `zero_isSumOfAtMost` — `0` is always such a sum (empty multiset; no `0 ∈ A` needed).
+- `IsSumOfAtMost.mono` — relax the summand budget `h ≤ h'`.
+- `IsSumOfAtMost.add` — **composition**: `IsSumOfAtMost A h₁ m → IsSumOfAtMost A h₂ p →
+  IsSumOfAtMost A (h₁+h₂) (m+p)` (concatenate witnessing multisets; `Multiset.mem_add`,
+  `card_add`, `sum_add`).
+- `sumsetPow A h := {n | IsSumOfAtMost A h n}` + `zero_mem_sumsetPow` (0 is free — supplies the
+  `0 ∈ ·` hypothesis the covering lemma needs).
+- `isSumOfAtMost_multiset_sum` — by `Multiset.induction`: if every entry of `S` lies in
+  `sumsetPow A h`, then `S.sum` is a sum of ≤ `S.card · h` elements of `A`.
+- **`isAdditiveBasis_of_sumsetPow_density_ge_half`** (capstone reduction):
+  `σ(sumsetPow A h) ≥ 1/2 → IsAdditiveBasis A (2h)`. Composes
+  `isAdditiveBasis_two_of_density_ge_half` (density ≥ ½ ⇒ the sum-set is a basis of order 2) with
+  `isSumOfAtMost_multiset_sum` (each sum-set element unpacks to ≤ `h` `A`-elements), giving the
+  order-2h basis in the `IsAdditiveBasis` `Multiset` shape.
+
+**Net effect on the reduction.** The chain to `schnirelmann_basis_theorem` is now:
+`σA>0` → (Schnirelmann's inequality, OPEN) → `σ(sumsetPow A h)>½` for some `h` → (this session's
+reduction, DONE) → `IsAdditiveBasis A (2h)`. **Only Schnirelmann's inequality
+`σ(A⊕B) ≥ σA+σB−σA·σB` remains** — the delicate gap-counting step (Nathanson *Additive Number
+Theory* Thm 7.4 / Ruzsa), est. ~120–180 LOC, still the hard part and an explicit Mathlib TODO.
+
+**Gotcha.** `hsum.mono (by gcongr)` fails with an *unconstrained metavariable* budget `h'`
+("Application type mismatch") — `gcongr` has no target to reduce against. Fix: give the result an
+explicit type `IsSumOfAtMost A (2*h) n` and pass `mul_le_mul_right' hSc h` for `S.card·h ≤ 2·h`.
+
+**Verification**: `docker-build.sh Proofs.SchnirelmannBasis` → **Built (7743 jobs, exit 0)**.
+New lemmas use only `obtain`/`rw`/`simp`/`induction`/`ring`/`exact`/`mul_le_mul_right'` — no
+`decide`/`native_decide`/`sorry`/`axiom` — and depend only on the file's already-0-axiom lemmas,
+so `#print axioms` stays `[propext, Classical.choice, Quot.sound]`. Does NOT touch the open
+binary-Goldbach conjecture (still legitimately axiomatized).
+
+**Env note.** `.loom/worktrees/researcher-8` is orphaned (broken `.git`). Worked in a detached
+`/private/tmp/wt-r8-schnir` worktree off `origin/main`, committed before building. The hardlinked
+`.lake` fought `lake exe cache get` (permission-denied on `.olean.private.hash` overwrites under
+Docker FUSE); verified instead by building the edited file against the MAIN repo's fully-populated
+writable `.lake` (copy-in, build, restore) — clean and reliable.
+
+**Aristotle** MCP was reachable this session but not used: the residual gap (Schnirelmann's
+inequality) is a gap-counting construction, not a named-lemma lookup Aristotle resolves.

--- a/research/problems/weak-goldbach-oq-01/state.md
+++ b/research/problems/weak-goldbach-oq-01/state.md
@@ -4,24 +4,30 @@
 **Phase**: ACT (in progress)
 **Path**: full
 **Since**: 2026-07-03
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean`. Split
-into two components; the **covering** component is now built and verified in
-`proofs/Proofs/SchnirelmannBasis.lean` (Schnirelmann's covering lemma + the
-density-≥-½ basis-of-order-2 corollary, 0 sorry / 0 axiom).
+Discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean`. The
+**covering** component and now the **entire iteration bookkeeping** are built and
+verified in `proofs/Proofs/SchnirelmannBasis.lean` (0 sorry / 0 axiom). The
+**sole** remaining ingredient is Schnirelmann's inequality itself.
 
 ## Active Approach
 Schnirelmann's theorem, decomposed:
 - [DONE] Covering lemma: σA+σB ≥ 1 ⟹ A⊕B ⊇ ℕ  (`sumset_covers_of_density_add_ge_one`).
+- [DONE] Terminal + iteration bookkeeping (r8, iter 4): `IsSumOfAtMost` +
+  composition (`.add`), the `h`-fold sum-set `sumsetPow`, and the reduction
+  `isAdditiveBasis_of_sumsetPow_density_ge_half : σ(sumsetPow A h) ≥ ½ ⟹
+  IsAdditiveBasis A (2h)`. Closes the "an element of h·A is a sum of ≤h elements
+  of A" gap and the order-2h composition.
 - [OPEN] Schnirelmann's inequality: σ(A⊕B) ≥ σA+σB−σA·σB — the gap-counting step.
-- [OPEN] Iteration 1−σ(h·A) ≤ (1−σA)^h to reach density > ½, then apply the
-  order-2 corollary to `h·A` ⟹ basis of order 2h ⟹ discharge the axiom.
+  **Now the only missing piece**: iterating it drives some σ(sumsetPow A h) above
+  ½, and the reduction above then discharges the axiom outright.
 
 ## Attempt Count
-- Total attempts: 2 (1 survey, 1 act)
-- Approaches tried: covering lemma (SUCCESS), sumset inequality (not yet attempted)
+- Total attempts: 3 (1 survey, 2 act)
+- Approaches tried: covering lemma (SUCCESS), iteration bookkeeping (SUCCESS),
+  sumset inequality (not yet attempted — the sole remaining gap)
 
 ## Blockers
 - Schnirelmann's inequality is the delicate gap-counting argument (Ruzsa,

--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -17,19 +17,22 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-22T13:03:46.384Z",
-    "iteration": 2,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "since": "2026-07-03",
+    "iteration": 4,
+    "focus": "Discharging schnirelmann_basis_theorem in WeakGoldbach.lean. The covering engine and the ENTIRE iteration bookkeeping are now verified in SchnirelmannBasis.lean (0 sorry / 0 axiom). Only Schnirelmann's inequality remains.",
+    "blockers": [
+      "Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB is the delicate gap-counting step (Nathanson Thm 7.4 / Ruzsa); an explicit Mathlib TODO, ~120-180 LOC.",
+      "Binary Goldbach itself is genuinely open and must stay axiomatized."
+    ],
+    "nextAction": "Formalize Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB (0 in A, 0 in B). Iterating it drives some sigma(sumsetPow A h) above 1/2, and isAdditiveBasis_of_sumsetPow_density_ge_half then discharges the axiom outright.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "OPEN (well-surveyed). Axiom-free symmetric/comet reformulation in gallery. Comet-height structural theory: exact Goldbach-partition identities (upper/lower arm), parity ceiling ceil(m/2), full divisibility sieve, single-prime m-m/p, Euler-totient ceiling phi(m) (composite) / phi(m)+1 (general), and (this pass) the HALF-TOTIENT ceiling phi(m)/2 at ODD composite midpoints — the sharpest ceiling there, via the even-totative involution k->m-k. All 5 WeakGoldbach.lean axioms irreducible in Mathlib v4.26.0; only tractable one = schnirelmann_basis_theorem (~300-500 LOC). Main conjecture untouched (all comet bounds are UPPER bounds; a nontrivial LOWER bound remains the real advance).",
+    "progressSummary": "Toward discharging schnirelmann_basis_theorem: SchnirelmannBasis.lean (0 sorry / 0 axiom) now contains the covering lemma (sumset_covers_of_density_add_ge_one), the density->=1/2 basis-of-order-2 corollary, the analytic iteration input (exists_pow_deficiency_lt_half), and — as of iter 4 (r8) — the complete iteration bookkeeping: IsSumOfAtMost + composition (.add), the h-fold sum-set sumsetPow, and the reduction isAdditiveBasis_of_sumsetPow_density_ge_half (sigma(sumsetPow A h) >= 1/2 => IsAdditiveBasis A (2h)). The SOLE remaining ingredient is Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB.",
     "builtItems": [
       "sumTwoPrimes_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:73 (per-n equivalence, 0-axiom)",
       "strong_iff_symmetric in Proofs/StrongGoldbachSymmetric.lean:98 (conjecture-level equivalence)",
@@ -47,7 +50,8 @@
       "symmetricPairCount_le_totient_of_not_prime in StrongGoldbachSymmetric.lean: for composite m, comet height <= phi(m); dominates every single-prime m-m/p bound",
       "card_even_totatives_eq_card_odd_totatives in StrongGoldbachSymmetric.lean: even/odd totatives of odd m>1 equinumerous (involution k->m-k), 0-axiom",
       "card_even_totatives_eq_totient_div_two in StrongGoldbachSymmetric.lean: #{even totatives of odd m} = phi(m)/2, 0-axiom",
-      "symmetricPairCount_le_half_totient_of_odd_not_prime in StrongGoldbachSymmetric.lean: odd composite comet height <= phi(m)/2 (factor-2 sharper than totient bound), 0-axiom"
+      "symmetricPairCount_le_half_totient_of_odd_not_prime in StrongGoldbachSymmetric.lean: odd composite comet height <= phi(m)/2 (factor-2 sharper than totient bound), 0-axiom",
+      "SchnirelmannBasis.lean iter4 (r8): IsSumOfAtMost, .mono, .add (composition), sumsetPow, zero_mem_sumsetPow, isSumOfAtMost_multiset_sum, isAdditiveBasis_of_sumsetPow_density_ge_half (sigma(sumsetPow A h) >= 1/2 => IsAdditiveBasis A (2h)). 0 sorry / 0 axiom, docker-build 7743 jobs."
     ],
     "insights": [
       "Strong Goldbach for even n=2m is equivalent to existence of a symmetric prime pair (m-k, m+k) with k<m — every Goldbach partition sits symmetrically about the midpoint n/2 (Goldbach comet).",
@@ -63,8 +67,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize a lower bound on the number of symmetric prime pairs (partial Goldbach comet asymptotic) — would give Strong Goldbach for almost all m if pushed.",
-      "Investigate the minimal offset k(m) for which (m-k,m+k) are both prime; relate to prime-gap bounds."
+      "Formalize Schnirelmann's inequality sigma(A+B) >= sA+sB-sA*sB (the gap-counting core, Nathanson Thm 7.4) — now the ONLY missing piece; combine with isAdditiveBasis_of_sumsetPow_density_ge_half to discharge schnirelmann_basis_theorem."
     ]
   },
   "tags": [
@@ -83,7 +86,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.384Z",
-  "lastUpdate": "2026-07-02",
+  "lastUpdate": "2026-07-04",
   "significance": 8,
   "tractability": 2,
   "leanFiles": [
@@ -97,6 +100,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WeakGoldbach.lean"
+    },
+    {
+      "path": "Proofs/SchnirelmannBasis.lean",
+      "filename": "SchnirelmannBasis.lean",
+      "lineCount": 322,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchnirelmannBasis.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Progress toward discharging the `schnirelmann_basis_theorem` axiom in `WeakGoldbach.lean` (part of **weak-goldbach-oq-01**, the Strong/Binary Goldbach entry). This PR **fully closes the iteration bookkeeping** of Schnirelmann's theorem, reducing the axiom to a **single** remaining lemma: Schnirelmann's inequality.

Prior sessions built the *covering* engine (`sumset_covers_of_density_add_ge_one`), the density-≥-½ order-2 corollary, the analytic iteration input (`exists_pow_deficiency_lt_half`), and the terminal step (`isAdditiveBasis_two_of_density_ge_half`). The two stated remaining gaps were **(1)** Schnirelmann's inequality and **(2)** the "bookkeeping that an element of the iterated sum-set `h·A` is a sum of at most `h` elements of `A`". This PR closes **(2)** completely.

## New lemmas in `proofs/Proofs/SchnirelmannBasis.lean` (0 sorry / 0 axiom)

- `IsSumOfAtMost A h n` — `n` is a sum of ≤ `h` elements of `A` (exact `Multiset` shape of `WeakGoldbach.IsAdditiveBasis A h` at a point).
- `zero_isSumOfAtMost`, `IsSumOfAtMost.mono` — `0` is always such a sum; relax the summand budget.
- `IsSumOfAtMost.add` — **composition**: `IsSumOfAtMost A h₁ m → IsSumOfAtMost A h₂ p → IsSumOfAtMost A (h₁+h₂) (m+p)`.
- `sumsetPow A h := {n | IsSumOfAtMost A h n}` + `zero_mem_sumsetPow` (0 is free — supplies the `0 ∈ ·` covering hypothesis).
- `isSumOfAtMost_multiset_sum` — by `Multiset.induction`: entries in `sumsetPow A h` ⟹ `S.sum` is a sum of ≤ `S.card·h` elements of `A`.
- **`isAdditiveBasis_of_sumsetPow_density_ge_half`** (capstone reduction): `σ(sumsetPow A h) ≥ 1/2 → IsAdditiveBasis A (2h)`.

## Net effect

The chain to `schnirelmann_basis_theorem` is now:

`σA>0` → *(Schnirelmann's inequality — OPEN)* → `σ(sumsetPow A h) > ½` for some `h` → *(this PR — DONE)* → `IsAdditiveBasis A (2h)`.

The **sole** remaining ingredient is Schnirelmann's inequality `σ(A⊕B) ≥ σA + σB − σA·σB` (the delicate gap-counting step, Nathanson *Additive Number Theory* Thm 7.4; an explicit Mathlib TODO).

## Verification

`./proofs/scripts/docker-build.sh Proofs.SchnirelmannBasis` → **Built (7743 jobs, exit 0)**. New lemmas use only pure tactics (`obtain`/`rw`/`simp`/`induction`/`ring`/`exact`/`mul_le_mul_right'`) and depend only on the file's already-0-axiom lemmas — no `decide`/`native_decide`/`sorry`/`axiom`. Does **not** touch the open binary-Goldbach conjecture (still legitimately axiomatized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)