### PR TITLE
Enrich Subset-of-a-Subset Identity (CF OQ-07-OQ-01): add mainTheorems (0→3), 5th annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "trinomial-revision-context",
     "proofId": "combinations-formula-oq-07-oq-01",
-    "range": { "startLine": 1, "endLine": 56 },
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
     "type": "concept",
     "title": "Trinomial Revision: Vandermonde's Multiplicative Companion",
     "content": "The subset-of-a-subset identity C(n,k)·C(k,m) = C(n,m)·C(n-m,k-m) (for m ≤ k ≤ n) is the multiplicative partner of Vandermonde's additive convolution. Both count one structure two ways. Here the structure is a nested selection — an m-subcommittee inside a k-committee inside an n-person group: counting committee-first gives C(n,k)·C(k,m); counting subcommittee-first (pick the m members from all n, then the remaining k-m committee seats from the n-m leftovers) gives C(n,m)·C(n-m,k-m). Mathlib provides Vandermonde but not this identity.",
@@ -24,7 +27,10 @@
   {
     "id": "main-identity-thm",
     "proofId": "combinations-formula-oq-07-oq-01",
-    "range": { "startLine": 65, "endLine": 95 },
+    "range": {
+      "startLine": 65,
+      "endLine": 95
+    },
     "type": "theorem",
     "title": "Subset-of-a-Subset Identity by Clearing Denominators",
     "content": "choose_mul_choose proves C(n,k)·C(k,m) = C(n,m)·C(n-m,k-m) without any summation or induction. The trick: multiply both sides by D = m!·(k-m)!·(n-k)!. Four applications of Nat.choose_mul_factorial_mul_factorial collapse each side to n!. On the left, C(k,m)·m!·(k-m)! = k! and then C(n,k)·k!·(n-k)! = n!. On the right, using (n-m)-(k-m) = n-k, the block C(n-m,k-m)·(k-m)!·(n-k)! = (n-m)! and then C(n,m)·m!·(n-m)! = n!. Since D > 0, Nat.eq_of_mul_eq_mul_right cancels it.",
@@ -45,7 +51,10 @@
   {
     "id": "central-blocks-thm",
     "proofId": "combinations-formula-oq-07-oq-01",
-    "range": { "startLine": 100, "endLine": 109 },
+    "range": {
+      "startLine": 100,
+      "endLine": 109
+    },
     "type": "theorem",
     "title": "Central-Blocks Form",
     "content": "choose_mul_choose_of_le' rewrites the leftover block from the bottom to the top: C(n,k)·C(k,m) = C(n,m)·C(n-m,n-k). It follows from the main identity by Nat.choose_symm, which gives C(n-m,k-m) = C(n-m,n-k) since (n-m)-(k-m) = n-k.",
@@ -63,7 +72,10 @@
   {
     "id": "absorption-corollary",
     "proofId": "combinations-formula-oq-07-oq-01",
-    "range": { "startLine": 111, "endLine": 129 },
+    "range": {
+      "startLine": 111,
+      "endLine": 119
+    },
     "type": "theorem",
     "title": "Absorption / Committee-Chair Corollary",
     "content": "mul_choose_eq specializes the general identity at m=1 to recover the classical absorption identity k·C(n,k) = n·C(n-1,k-1). With C(n,1)=n and C(k,1)=k (Nat.choose_one_right), trinomial revision reads C(n,k)·k = n·C(n-1,k-1) — choosing a k-committee and designating one chair, two ways. Numeric checks confirm C(5,3)·C(3,2) = C(5,2)·C(3,1) = 30 and 3·C(5,3) = 5·C(4,2) = 30 by decide.",
@@ -78,6 +90,28 @@
     "prerequisites": [
       "C(n,1) = n",
       "the subset-of-a-subset identity at m=1"
+    ]
+  },
+  {
+    "id": "numeric-verification",
+    "proofId": "combinations-formula-oq-07-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "Kernel-Checked Numeric Instances",
+    "content": "Two `decide` examples pin the abstract identities to concrete arithmetic: C(5,3)·C(3,2) = 10·3 = 30 = 10·3 = C(5,2)·C(3,1) confirms the headline subset-of-a-subset identity, and 3·C(5,3) = 30 = 5·C(4,2) = 5·6 confirms absorption. Because `decide` runs Lean's kernel-trusted decision procedure on closed ℕ terms (not `native_decide`), these checks add no compiler-trust axiom — they remain part of the 0-axiom, propext/Choice/Quot-only footprint.",
+    "mathContext": "$\\binom{5}{3}\\binom{3}{2}=10\\cdot 3=30=\\binom{5}{2}\\binom{3}{1};\\qquad 3\\binom{5}{3}=30=5\\binom{4}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decidable equality",
+      "kernel reduction",
+      "committee-subcommittee counting"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Lean decide tactic"
     ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-01/meta.json
@@ -149,5 +149,22 @@
       "venue": "CPP",
       "note": "Provides Nat.choose, Nat.fib, and the antidiagonal/binomial API underlying this formalization."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "choose_mul_choose",
+      "statement": "m ≤ k → k ≤ n → C(n,k)·C(k,m) = C(n,m)·C(n−m,k−m)",
+      "description": "The subset-of-a-subset identity (trinomial revision): choosing a k-committee from n people and then an m-subcommittee equals choosing the m-subcommittee first and then the remaining k−m committee seats from the n−m leftovers. Mathlib's missing multiplicative companion to Vandermonde; proved by multiplying both sides by the shared denominator m!·(k−m)!·(n−k)! and collapsing each to n! via Nat.choose_mul_factorial_mul_factorial, then cancelling the positive denominator."
+    },
+    {
+      "name": "choose_mul_choose_of_le'",
+      "statement": "m ≤ k → k ≤ n → C(n,k)·C(k,m) = C(n,m)·C(n−m,n−k)",
+      "description": "The central-blocks (symmetric) form, obtained from choose_mul_choose by rewriting the leftover block with Nat.choose_symm: C(n−m,k−m) = C(n−m,n−k). Counts the unused seats from the top of the block rather than the bottom."
+    },
+    {
+      "name": "mul_choose_eq",
+      "statement": "1 ≤ k → k ≤ n → k·C(n,k) = n·C(n−1,k−1)",
+      "description": "The absorption / committee-chair corollary, recovered as the m = 1 slice of trinomial revision via Nat.choose_one_right (C(n,1) = n). Not independent mathematics but a one-line specialization; it is the engine behind weighted row sums such as ∑ k·C(n,k) = n·2^{n−1}."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-01`.

**Gaps closed:**
- **mainTheorems (0→3)**: structured the three named results — `choose_mul_choose` (the trinomial-revision identity), `choose_mul_choose_of_le'` (central-blocks form), and `mul_choose_eq` (absorption/committee-chair corollary) — each with statement and description drawn from the Lean source.
- **Annotations (4→5)**: added `numeric-verification` covering the two `decide` sanity checks (C(5,3)·C(3,2)=C(5,2)·C(3,1)=30 and 3·C(5,3)=5·C(4,2)=30), noting kernel `decide` (not `native_decide`) preserves the 0-axiom footprint. Tightened the absorption annotation range.

No content deleted; meta.json 12.2 KB (well under caps). build.ts reports no warnings for this entry.