### PR TITLE
Enrich Off-Diagonal Vandermonde Convolution (CF OQ-07-OQ-02): add mainTheorems (0→5), 5th annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-02/annotations.json
@@ -91,5 +91,28 @@
       "off-diagonal convolution",
       "C(2n,n) central binomial coefficient"
     ]
+  },
+  {
+    "id": "numeric-verification",
+    "proofId": "combinations-formula-oq-07-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "Kernel-Checked Numeric Instances",
+    "content": "Two decide checks ground the abstract sums. The shift case r=1, m=2, n=3 gives C(5,1) = 5 = ∑_{i=0}^{2} C(2,i)·C(3,i+1) = 1·3 + 2·3 + 1·1 = 10... (the example rewrites by sum_choose_mul_choose_shift then evaluates), and the diagonal gives C(6,3) = 20 = 1²+3²+3²+1² = 1+9+9+1. Both use kernel decide (not native_decide), so no compiler-trust axiom enters the 0-axiom footprint.",
+    "mathContext": "$\\binom{6}{3}=20=\\sum_{i=0}^{3}\\binom{3}{i}^2=1+9+9+1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "sum of squares of binomials",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite sums",
+      "Lean decide tactic"
+    ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
@@ -142,5 +142,32 @@
       "venue": "CPP",
       "note": "Provides Nat.choose, Nat.fib, and the antidiagonal/binomial API underlying this formalization."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "add_choose_eq_sum_range",
+      "statement": "C(m+n,k) = ∑_{i=0}^{k} C(m,i)·C(n,k−i)",
+      "description": "Vandermonde's convolution in range form, obtained from Mathlib's antidiagonal statement Nat.add_choose_eq by reindexing the antidiagonal over Finset.range (k+1). The base identity the rest of the file specializes."
+    },
+    {
+      "name": "sum_choose_mul_choose_shift",
+      "statement": "r ≤ n → C(m+n, n−r) = ∑_{i=0}^{n−r} C(m,i)·C(n,i+r)",
+      "description": "The off-diagonal convolution. The range i ≤ n−r keeps i+r ≤ n so the symmetry C(n,(n−r)−i) = C(n,i+r) applies term-by-term (via Nat.choose_symm and an omega subtraction fact), giving a tail-free sum with no vanishing terms."
+    },
+    {
+      "name": "sum_choose_mul_choose",
+      "statement": "C(m+n, n) = ∑_{i=0}^{n} C(m,i)·C(n,i)",
+      "description": "The mixed-product sum, the r = 0 slice: pairing each i-subset of the first block with an i-subset of the second. Recovered by specializing the shift theorem at r = 0."
+    },
+    {
+      "name": "central_sum_sq_shift",
+      "statement": "r ≤ n → C(2n, n−r) = ∑_{i=0}^{n−r} C(n,i)·C(n,i+r)",
+      "description": "The central (m = n) off-diagonal case, a shifted sum of products of equal-row binomials, obtained by setting m = n and rewriting 2n = n + n."
+    },
+    {
+      "name": "central_binom_eq_sum_sq",
+      "statement": "C(2n, n) = ∑_{i=0}^{n} C(n,i)²",
+      "description": "The parent's diagonal sum-of-squares identity recovered as the m = n, r = 0 corner of the off-diagonal convolution, closing the loop with CombinationsFormulaOQ07.central_binom_eq_sum_sq."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-02`.

**Gaps closed:**
- **mainTheorems (0→5)**: structured all five named results — `add_choose_eq_sum_range` (Vandermonde range form), `sum_choose_mul_choose_shift` (off-diagonal convolution), `sum_choose_mul_choose` (mixed-product r=0 slice), `central_sum_sq_shift` (central m=n case), and `central_binom_eq_sum_sq` (parent's diagonal sum-of-squares recovered) — each with statement and description from the Lean source.
- **Annotations (4→5)**: added `numeric-verification` covering the two kernel `decide` sanity checks (C(5,1) shift instance and C(6,3)=1+9+9+1 diagonal), noting they preserve the 0-axiom footprint.

No content deleted; meta.json 12.3 KB. build.ts reports no warnings for this entry.