### PR TITLE
Enrich Weighted Sum of Squares of Binomial Coefficients (CF OQ-07-OQ-03): add mainTheorems (0→4), 5th annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03/annotations.json
@@ -95,5 +95,28 @@
       "binomial symmetry",
       "cancellation in ℕ"
     ]
+  },
+  {
+    "id": "numeric-verification",
+    "proofId": "combinations-formula-oq-07-oq-03",
+    "range": {
+      "startLine": 131,
+      "endLine": 135
+    },
+    "type": "insight",
+    "title": "Kernel-Checked Numeric Instance",
+    "content": "Two decide checks pin the closed form at n = 3: ∑_{k=0}^{3} k·C(3,k)² = 0·1 + 1·9 + 2·9 + 3·1 = 0 + 9 + 18 + 3 = 30, and the same sum equals 3·C(5,2) = 3·10 = 30, matching n·C(2n−1,n−1) with n = 3. Both use kernel decide (not native_decide), so the 0-axiom footprint is preserved.",
+    "mathContext": "$\\sum_{k=0}^{3} k\\binom{3}{k}^2 = 0+9+18+3 = 30 = 3\\binom{5}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "weighted binomial sums",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite sums",
+      "Lean decide tactic"
+    ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
@@ -156,5 +156,27 @@
       "venue": "CPP",
       "note": "Provides Nat.choose, Nat.fib, and the antidiagonal/binomial API underlying this formalization."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sum_weighted_sq_reflect",
+      "statement": "∑_{k=0}^{n} k·C(n,k)² = ∑_{k=0}^{n} (n−k)·C(n,k)²",
+      "description": "Reflection symmetry: the substitution k ↦ n−k combined with C(n,n−k) = C(n,k) shows the k-weighted and (n−k)-weighted sums of squares coincide. The pivot on which the closed form rests, proved via Finset.sum_range_reflect and Nat.choose_symm."
+    },
+    {
+      "name": "two_mul_sum_weighted_sq",
+      "statement": "2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n)",
+      "description": "The weighted central-binomial sum of squares, stated with a factor of 2 to package the reflection symmetry and avoid natural-number subtraction. Adding the sum to its reflection gives n·∑ C(n,k)², which equals n·C(2n,n) by the parent's diagonal identity."
+    },
+    {
+      "name": "central_binom_two_mul_pred",
+      "statement": "1 ≤ n → C(2n,n) = 2·C(2n−1,n−1)",
+      "description": "Halving the central binomial coefficient: Pascal's rule splits C(2n,n) into the two symmetric halves C(2n−1,n−1) = C(2n−1,n). Proved by peeling n = m+1 and applying Nat.choose_succ_succ with the symmetry C(2m+1,m+1) = C(2m+1,m)."
+    },
+    {
+      "name": "sum_weighted_sq",
+      "statement": "1 ≤ n → ∑_{k=0}^{n} k·C(n,k)² = n·C(2n−1,n−1)",
+      "description": "The classical closed form, obtained by combining the factor-of-2 identity with the halving lemma and cancelling the 2 via Nat.eq_of_mul_eq_mul_left. The headline result of the entry."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-03`.

**Gaps closed:**
- **mainTheorems (0→4)**: structured all four named results — `sum_weighted_sq_reflect` (reflection symmetry), `two_mul_sum_weighted_sq` (2·∑ = n·C(2n,n)), `central_binom_two_mul_pred` (halving C(2n,n)), and `sum_weighted_sq` (classical closed form ∑ k·C(n,k)² = n·C(2n−1,n−1)) — each with statement and description from the Lean source.
- **Annotations (4→5)**: added `numeric-verification` for the two kernel `decide` checks at n=3 (∑ = 30 = 3·C(5,2)), preserving the 0-axiom footprint.

No content deleted; meta.json under caps. build.ts reports no warnings for this entry.