### PR TITLE
Enrich Second Moment of Squared Binomial Coefficients (CF OQ-07-OQ-03-OQ-01): add mainTheorems (0→3), 5th annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/annotations.json
@@ -93,5 +93,28 @@
       "sum_sq_weighted_sq_succ",
       "omega for linear arithmetic over ℕ"
     ]
+  },
+  {
+    "id": "numeric-verification",
+    "proofId": "combinations-formula-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 121
+    },
+    "type": "insight",
+    "title": "Kernel-Checked Numeric Instance",
+    "content": "Two decide checks pin the closed form at n = 3: ∑_{k=0}^{3} k²·C(3,k)² = 0·1 + 1·9 + 4·9 + 9·1 = 0 + 9 + 36 + 9 = 54, and the same sum equals 3²·C(4,2) = 9·6 = 54, matching n²·C(2n−2,n−1) with n = 3. Both use kernel decide (not native_decide), so the 0-axiom footprint is preserved.",
+    "mathContext": "$\\sum_{k=0}^{3} k^2\\binom{3}{k}^2 = 0+9+36+9 = 54 = 3^2\\binom{4}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "second moment",
+      "central binomial coefficient",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite sums",
+      "Lean decide tactic"
+    ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03-oq-01/meta.json
@@ -150,5 +150,22 @@
       "venue": "CPP",
       "note": "Provides Nat.choose, Nat.fib, and the antidiagonal/binomial API underlying this formalization."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "term_absorb",
+      "statement": "(j+1)²·C(m+1,j+1)² = (m+1)²·C(m,j)²",
+      "description": "Single-absorption term identity: squaring the committee-chair absorption (j+1)·C(m+1,j+1) = (m+1)·C(m,j) (Mathlib's Nat.add_one_mul_choose_eq) collapses each j-weighted binomial square into a j-free multiple of C(m,j)². The termwise engine of the moment computation."
+    },
+    {
+      "name": "sum_sq_weighted_sq_succ",
+      "statement": "∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m)",
+      "description": "The second moment in subtraction-free form (n = m+1). Peeling the vanishing k=0 term and reindexing by j+1 lets term_absorb pull out (m+1)², leaving ∑ C(m,j)² = C(2m,m) by the parent's diagonal identity."
+    },
+    {
+      "name": "sum_sq_weighted_sq",
+      "statement": "1 ≤ n → ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1)",
+      "description": "The classical closed form for the second moment of squared binomial coefficients, recovered from the subtraction-free version by peeling n = m+1 and simplifying the natural-number subtractions. The headline result."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-03-oq-01`.

**Gaps closed:**
- **mainTheorems (0→3)**: structured all three named results — `term_absorb` (single-absorption term identity), `sum_sq_weighted_sq_succ` (subtraction-free second moment (m+1)²·C(2m,m)), and `sum_sq_weighted_sq` (classical closed form ∑ k²·C(n,k)² = n²·C(2n−2,n−1)) — each with statement and description from the Lean source.
- **Annotations (4→5)**: added `numeric-verification` for the two kernel `decide` checks at n=3 (∑ = 54 = 3²·C(4,2)), preserving the 0-axiom footprint.

No content deleted; meta.json under caps.