### PR TITLE
Enrich Cubically Weighted Sum of Squares of Binomial Coefficients (CF OQ-07-OQ-06): add mainTheorems (0→3), 5th annotation

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-06/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-06/annotations.json
@@ -94,5 +94,28 @@
       "two_mul_sum_cube_weighted_sq (m-form)",
       "Nat.choose evaluation by decide"
     ]
+  },
+  {
+    "id": "numeric-verification",
+    "proofId": "combinations-formula-oq-07-oq-06",
+    "range": {
+      "startLine": 139,
+      "endLine": 143
+    },
+    "type": "insight",
+    "title": "Kernel-Checked Numeric Instance",
+    "content": "Two decide checks pin the closed form at n = 3: ∑_{k=0}^{3} k³·C(3,k)² = 0·1 + 1·9 + 8·9 + 27·1 = 0 + 9 + 72 + 27 = 108, and doubling gives 2·108 = 216 = 3²·4·C(4,2) = 9·4·6, matching n²·(n+1)·C(2n−2,n−1) with n = 3. Both use kernel decide (not native_decide), so the 0-axiom footprint is preserved.",
+    "mathContext": "$\\sum_{k=0}^{3} k^3\\binom{3}{k}^2 = 0+9+72+27 = 108,\\quad 2\\cdot 108 = 216 = 3^2\\cdot 4\\cdot\\binom{4}{2}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "third moment",
+      "central binomial coefficient",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "finite sums",
+      "Lean decide tactic"
+    ]
   }
 ]

--- a/src/data/proofs/combinations-formula-oq-07-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-06/meta.json
@@ -159,5 +159,22 @@
       "venue": "CPP",
       "note": "Provides Nat.choose, Nat.fib, and the antidiagonal/binomial API underlying this formalization."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sum_cube_weighted_sq_reduce",
+      "statement": "∑_{k=0}^{m+1} k³·C(m+1,k)² = (m+1)²·∑_{j=0}^{m} (j+1)·C(m,j)²",
+      "description": "Absorption + index-shift reduction: squaring the absorption identity k·C(m+1,k) = (m+1)·C(m,k−1) demotes the cubically-weighted square of C(m+1,·) to a linearly-weighted square of C(m,·) one order down. The vanishing k=0 term is peeled and the shift k↦k+1 turns weight k into k+1."
+    },
+    {
+      "name": "two_mul_sum_cube_weighted_sq",
+      "statement": "2·∑_{k=0}^{m+1} k³·C(m+1,k)² = (m+1)²·(m+2)·C(2m,m)",
+      "description": "The cubically-weighted central-binomial sum of squares in subtraction-free form. The reduction splits the linear sum into first + zeroth moments at level m, then closes with the first moment (OQ-07-OQ-03) and the zeroth moment (parent OQ-07 diagonal identity). The factor 2 absorbs the first-moment doubling."
+    },
+    {
+      "name": "two_mul_sum_cube_weighted_sq'",
+      "statement": "1 ≤ n → 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1)",
+      "description": "The third moment in classical form, recovered from the subtraction-free version by peeling n = m+1 and simplifying the natural-number subtractions. The headline result of the entry."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-06`.

**Gaps closed:**
- **mainTheorems (0→3)**: structured all three named results — `sum_cube_weighted_sq_reduce` (absorption + index-shift reduction), `two_mul_sum_cube_weighted_sq` (subtraction-free (m+1)²·(m+2)·C(2m,m)), and `two_mul_sum_cube_weighted_sq'` (classical third moment 2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1)) — each with statement and description from the Lean source.
- **Annotations (4→5)**: added `numeric-verification` for the two kernel `decide` checks at n=3 (∑ = 108, 2·108 = 216 = 3²·4·C(4,2)), preserving the 0-axiom footprint.

No content deleted; meta.json under caps.