### PR TITLE
Enrich 3 entries: add mainTheorems to de-moivre-oq-05-oq-02, cramers-rule-oq-04-oq-01, abel-ruffini-galois-extensions-oq-04-oq-01-oq-01

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01-oq-01/meta.json
@@ -55,6 +55,44 @@
     "theoremCount": 6,
     "definitionCount": 2
   },
+  "mainTheorems": [
+    {
+      "name": "isMaximalNormal_subgroupOf_iff_isMaxNorm",
+      "type": "core",
+      "description": "The lattice-transfer bridge and the file's central new result: for H ≤ K, being a maximal normal subgroup of the subtype group ↥K (IsMaximalNormal (H.subgroupOf K)) is exactly the ambient relative predicate IsMaxNorm H K. Relocates the maximality test from the awkward subtype lattice Subgroup ↥K into the concrete interval [H, K] ⊆ Subgroup G, using the order-isomorphic pair N ↦ N.subgroupOf K and M ↦ M.map K.subtype with round trips map_subgroupOf_eq_of_le and comap_map_eq_self_of_injective; properness collapses via subgroupOf_eq_top and subgroupOf_self.",
+      "leanType": "{H K : Subgroup G} → H ≤ K → (IsMaximalNormal (H.subgroupOf K) ↔ IsMaxNorm H K)"
+    },
+    {
+      "name": "isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm",
+      "type": "core",
+      "description": "The packaged general relative correspondence — precisely the case the parent entry deferred. For H ≤ K with H.subgroupOf K normal in ↥K, the subtype quotient ↥K ⧸ H.subgroupOf K is simple iff H is a maximal normal subgroup of K. Proved in two lines by instantiating the absolute correspondence at the group ↥K (N = H.subgroupOf K) and chaining with the lattice-transfer bridge.",
+      "leanType": "{H K : Subgroup G} → (hHK : H ≤ K) → [(H.subgroupOf K).Normal] → (IsSimpleGroup (↥K ⧸ H.subgroupOf K) ↔ IsMaxNorm H K)"
+    },
+    {
+      "name": "isSimpleGroup_quotient_iff_isMaximalNormal",
+      "type": "supporting",
+      "description": "The absolute (K = ⊤) correspondence in packaged form: for a normal N ◁ G, the genuine quotient G ⧸ N is simple iff N is a maximal normal subgroup of G (IsMaximalNormal N). Reproved inline so the file depends only on `import Mathlib`; instantiated at ↥K to drive the relative case.",
+      "leanType": "(N : Subgroup G) → [N.Normal] → (IsSimpleGroup (G ⧸ N) ↔ IsMaximalNormal N)"
+    },
+    {
+      "name": "isSimpleGroup_quotient_iff",
+      "type": "supporting",
+      "description": "The raw absolute correspondence underneath the packaged form: IsSimpleGroup (G ⧸ N) iff N ≠ ⊤ and every normal M with N ≤ M is either N or ⊤. Proved from isSimpleGroup_iff by transporting subgroups across the projection mk' via comap_map_mk' and the correspondence order-iso comapMk'OrderIso.",
+      "leanType": "(N : Subgroup G) → [N.Normal] → (IsSimpleGroup (G ⧸ N) ↔ N ≠ ⊤ ∧ ∀ M : Subgroup G, N ≤ M → M.Normal → M = N ∨ M = ⊤)"
+    },
+    {
+      "name": "IsMaxNorm.isSimpleGroup_quotient",
+      "type": "supporting",
+      "description": "Forward direction as a reusable dot-notation lemma: a maximal normal subgroup of K yields a simple subtype quotient. Threads the relative-normality instance h.2.1 via haveI so the quotient typeclass ↥K ⧸ H.subgroupOf K resolves — the form a composition-series argument consumes one implication at a time.",
+      "leanType": "{H K : Subgroup G} → (hHK : H ≤ K) → (h : IsMaxNorm H K) → IsSimpleGroup (↥K ⧸ H.subgroupOf K)"
+    },
+    {
+      "name": "IsMaxNorm.of_isSimpleGroup_quotient",
+      "type": "supporting",
+      "description": "Converse direction as a standalone lemma: simplicity of the subtype quotient ↥K ⧸ H.subgroupOf K forces H to be a maximal normal subgroup of K. The mpr/mp pair of the packaged iff, exposed for Jordan–Hölder consumption.",
+      "leanType": "{H K : Subgroup G} → (hHK : H ≤ K) → [(H.subgroupOf K).Normal] → IsSimpleGroup (↥K ⧸ H.subgroupOf K) → IsMaxNorm H K"
+    }
+  ],
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
     "lineCount": 192,

--- a/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
@@ -74,6 +74,38 @@
       }
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "adjugate_charmatrix_mul",
+      "type": "core",
+      "description": "The adjugate-reflexive identity and the algebraic heart of Cayley–Hamilton: over R[X], the adjugate of the characteristic matrix xI − A times the characteristic matrix equals the characteristic polynomial times the identity, adj(xI − A)·(xI − A) = χ_A(x)·I. Instantiates Mathlib's general adjugate_mul at B = charmatrix M.",
+      "leanType": "(M : Matrix n n R) → adjugate (charmatrix M) * charmatrix M = M.charpoly • 1"
+    },
+    {
+      "name": "cayley_hamilton",
+      "type": "core",
+      "description": "The Cayley–Hamilton theorem: every matrix satisfies its own characteristic polynomial, χ_A(A) = 0. Obtained from the adjugate-reflexive identity by passing to Polynomial (Matrix n n R) and evaluating at A (Mathlib: aeval_self_charpoly).",
+      "leanType": "(M : Matrix n n R) → aeval M M.charpoly = 0"
+    },
+    {
+      "name": "adjugate_mulVec_solve",
+      "type": "core",
+      "description": "The determinant form of Cramer's rule: the adjugate solves A x = b up to the determinant, A·(adj A · b) = (det A)·b. When det A is a unit this yields the explicit solution x = (det A)⁻¹ · adj A · b. Rests on the same adjugate identity A·adj A = (det A)·I that drives Cayley–Hamilton.",
+      "leanType": "(A : Matrix n n R) → (b : n → R) → A *ᵥ (adjugate A *ᵥ b) = A.det • b"
+    },
+    {
+      "name": "mul_adjugate_eq",
+      "type": "supporting",
+      "description": "The scalar adjugate identity A·adj(A) = (det A)·I — the common source of both Cramer's rule (B = A) and Cayley–Hamilton (B = xI − A). Instantiates Mathlib's mul_adjugate.",
+      "leanType": "(A : Matrix n n R) → A * adjugate A = A.det • 1"
+    },
+    {
+      "name": "minpoly_dvd_charpoly",
+      "type": "supporting",
+      "description": "Over a field, the minimal polynomial of A divides its characteristic polynomial — a direct consequence of Cayley–Hamilton (χ_A annihilates A, so minpoly ∣ χ_A).",
+      "leanType": "{K : Type*} → [Field K] → (M : Matrix n n K) → minpoly K M ∣ M.charpoly"
+    }
+  ],
   "overview": {
     "historicalContext": "The adjugate (classical adjoint) of a square matrix A is the transpose of its cofactor matrix, and it satisfies the fundamental identity adj(A)·A = A·adj(A) = (det A)·I. This single identity underlies two cornerstones of linear algebra. **Cramer's rule** applies it to A itself: when det A is invertible, A⁻¹ = (det A)⁻¹·adj(A), so the system Ax = b has the explicit solution x = (det A)⁻¹·adj(A)·b. The **Cayley–Hamilton theorem** applies it to the characteristic matrix B = xI − A over the polynomial ring R[X]: since det(xI − A) = χ_A(x), the identity reads adj(xI − A)·(xI − A) = χ_A(x)·I, and passing to Polynomial (Matrix n n R) and evaluating at A telescopes the right factor to zero, yielding χ_A(A) = 0.\n\nMathlib formalizes the adjugate identity (adjugate_mul, mul_adjugate) and proves Cayley–Hamilton exactly via this route (aeval_self_charpoly, whose proof opens with adjugate (charmatrix M) * charmatrix M = M.charpoly • 1). This entry answers the parent's OQ-04-OQ-01 by exposing the adjugate-reflexive identity as a named lemma, restating Cayley–Hamilton and its minpoly consequence, and recording the determinant form of Cramer's rule — making explicit that both theorems flow from the same adjugate identity.",
     "problemStatement": "Formalize the algebraic Cayley–Hamilton theorem via the adjugate-reflexive identity adj(xI − A)·(xI − A) = χ_A(x)·I, and tie it to Cramer's rule through their shared adjugate identity adj(B)·B = (det B)·I. Record Cayley–Hamilton, minpoly ∣ charpoly, and the determinant form of Cramer's rule.",

--- a/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
@@ -66,6 +66,26 @@
     "theoremCount": 3,
     "definitionCount": 0
   },
+  "mainTheorems": [
+    {
+      "name": "sum_primitiveRoots_eq_moebius",
+      "type": "core",
+      "description": "The headline identity: for every n, the sum of the primitive n-th roots of unity in ℂ equals μ(n), the Möbius function value cast into ℂ. Proved by partitioning the n-th roots by their exact order (∑_{d∣n} f(d) = g(n)), evaluating g(k) = [k=1] via a geometric series, and applying Möbius inversion so only the d=1 term survives, leaving μ(n)·1.",
+      "leanType": "(n : ℕ) → ∑ ζ ∈ primitiveRoots n ℂ, ζ = (μ n : ℂ)"
+    },
+    {
+      "name": "sum_nthRootsFinset",
+      "type": "supporting",
+      "description": "Evaluation of g: the sum of ALL n-th roots of unity in ℂ is 1 when n = 1 and 0 otherwise (the parent de-moivre-oq-05 result, restated). For n > 1 the geometric series over ζ^0,…,ζ^{n-1} vanishes (IsPrimitiveRoot.geom_sum_eq_zero); n = 1 gives the single root 1.",
+      "leanType": "{n : ℕ} → (hn : 0 < n) → ∑ x ∈ nthRootsFinset n (1 : ℂ), x = if n = 1 then 1 else 0"
+    },
+    {
+      "name": "nthRootsFinset_eq_image",
+      "type": "supporting",
+      "description": "Enumeration lemma: given a primitive n-th root ζ (n > 0), the finset of n-th roots of unity is exactly the image of range n under i ↦ ζ^i. Turns the abstract root set into an indexed geometric progression so its sum becomes a finite geometric series; uses IsPrimitiveRoot.eq_pow_of_pow_eq_one.",
+      "leanType": "{n : ℕ} → (hn : 0 < n) → {ζ : ℂ} → IsPrimitiveRoot ζ n → nthRootsFinset n (1 : ℂ) = (range n).image (ζ ^ ·)"
+    }
+  ],
   "overview": {
     "historicalContext": "That the sum of the primitive $n$-th roots of unity equals the Möbius function $\\mu(n)$ is a classical bridge between the analytic geometry of the unit circle and multiplicative number theory. The $n$-th roots of unity are the vertices of a regular $n$-gon; grouping them by exact order partitions the circle's roots over the divisors of $n$. The sum of *all* $n$-th roots vanishes for $n>1$ (the second-from-top coefficient of $z^n-1$), and Möbius inversion of this divisor relation isolates the *primitive* contribution as $\\mu(n)$. The identity appears as Theorem 2.7 in Apostol's *Introduction to Analytic Number Theory* and underlies the constant term of the cyclotomic polynomial and Ramanujan-sum evaluations $c_n(1)=\\mu(n)$.",
     "problemStatement": "**Open Question**: Compute the sum of the primitive $n$-th roots of unity in $\\mathbb{C}$.\n\n**Answer**: It equals the Möbius function: $\\displaystyle\\sum_{\\substack{\\zeta^n=1\\\\ \\operatorname{ord}\\zeta=n}}\\zeta=\\mu(n)$. In particular the sum is $0$ exactly when $n$ has a squared prime factor, $+1$ when $n$ is a product of an even number of distinct primes, and $-1$ for an odd number.",


### PR DESCRIPTION
Enrichment pass adding the structured `mainTheorems` index to three entries that had full overviews/sections/annotations but no `mainTheorems` array. Three independent single-file (`meta.json`) additions, all well under the 60 KB cap; JSON validates and the gallery annotations build reports no errors for any of them.

### 1. `abel-ruffini-galois-extensions-oq-04-oq-01-oq-01` (0→6)
- **core** — `isMaximalNormal_subgroupOf_iff_isMaxNorm` (lattice-transfer bridge), `isSimpleGroup_quotient_subgroupOf_iff_isMaxNorm` (packaged general relative correspondence, the deferred case).
- **supporting** — absolute K=⊤ correspondence (packaged + raw) and the two direction lemmas. 13.3→17.5 KB.

### 2. `cramers-rule-oq-04-oq-01` (0→5)
- **core** — `adjugate_charmatrix_mul`, `cayley_hamilton`, `adjugate_mulVec_solve`.
- **supporting** — `mul_adjugate_eq`, `minpoly_dvd_charpoly`. 12.3→14.4 KB.

### 3. `de-moivre-oq-05-oq-02` (0→3)
- **core** — `sum_primitiveRoots_eq_moebius` (∑ primitive n-th roots of unity = μ(n)).
- **supporting** — `sum_nthRootsFinset` (evaluation of g via geometric series), `nthRootsFinset_eq_image`. 11.6→13.2 KB.

Each theorem entry carries an accurate `leanType` signature and description.