### PR TITLE
research: general Gaussian moments E[X^{2k}]=(2k-1)‼ via MGF derivative recursion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ05Incomplete01OQ01OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ05Incomplete01OQ01OQ01.lean
@@ -1,0 +1,225 @@
+/-
+# Gaussian even moments:  `E[X^{2k}] = (2k-1)‼`
+
+The grandparent file `AreaOfCircleOQ05Incomplete01OQ01` formalized the standard
+normal `X ~ N(0,1)`, settled the moments `E[X⁰], E[X¹], E[X²]`, and recorded the
+moment-generating function
+
+    `M_X(t) = E[e^{tX}] = exp(t²/2)`.
+
+It explicitly left open the **general moment formula**
+
+    `E[X^{2k}]   = (2k-1)‼`   (odd double factorial),
+    `E[X^{2k+1}] = 0`.
+
+This file closes that strand.
+
+## Method — MGF derivative recursion
+
+Mathlib's `iteratedDeriv_mgf_zero` identifies the moments with the derivatives of
+the MGF at `0`:  writing `g(t) = M_X(t) = exp(t²/2)`,
+
+    `E[Xⁿ] = g⁽ⁿ⁾(0)`.
+
+`g` solves the first-order ODE `g'(t) = t·g(t)`.  Differentiating this identity
+`n` times (Leibniz against the linear factor `t`, whose second derivative is `0`)
+and evaluating at `0` — where the `t·g⁽ⁿ⁾(t)` term vanishes — gives the
+parity-preserving recursion
+
+    `g⁽ⁿ⁺¹⁾(0) = n · g⁽ⁿ⁻¹⁾(0)`,   i.e.   `E[X^{n+1}] = n · E[X^{n-1}]`.
+
+Unwinding:  the even index accumulates `∏_{i<k}(2i+1) = (2k-1)‼`, while the odd
+index is annihilated by the base case `E[X] = 0`.
+
+## Main results
+
+* `moment_eq_iteratedDeriv` — `E[Xⁿ] = g⁽ⁿ⁾(0)` for the standard normal.
+* `moment_recursion`        — `E[X^{n+1}] = n · E[X^{n-1}]`.
+* `stdNormal_even_moment`   — `E[X^{2k}] = ∏_{i<k}(2i+1)`.
+* `stdNormal_even_moment_doubleFactorial` — `E[X^{2k}] = (2k-1)‼`.
+* `stdNormal_odd_moment`    — `E[X^{2k+1}] = 0`.
+
+Everything is `sorry`-free and axiom-free (only `propext / Classical.choice /
+Quot.sound`).
+-/
+
+import Mathlib.Probability.Moments.MGFAnalytic
+import Mathlib.Probability.Distributions.Gaussian.Real
+import Mathlib.Data.Nat.Factorial.DoubleFactorial
+import Proofs.AreaOfCircleOQ05Incomplete01OQ01
+import Mathlib.Tactic
+
+open MeasureTheory Real ProbabilityTheory
+open scoped ProbabilityTheory Nat
+
+namespace AreaOfCircleOQ05Incomplete01OQ01OQ01
+
+open AreaOfCircleOQ05Incomplete01OQ01 (stdNormal stdNormal_mgf)
+
+/-- The moment-generating function of the standard normal, as the smooth map
+    `g(t) = exp(t²/2)`.  (Equals `mgf id stdNormal`; see `g_eq_mgf`.) -/
+noncomputable def g : ℝ → ℝ := fun t => Real.exp (t ^ 2 / 2)
+
+@[simp] lemma g_zero : g 0 = 1 := by simp [g]
+
+/-- `g` is the moment-generating function of the standard normal. -/
+lemma g_eq_mgf : g = mgf id stdNormal := stdNormal_mgf.symm
+
+/-- `g` is smooth. -/
+lemma g_contDiff : ContDiff ℝ ⊤ g := by
+  unfold g
+  fun_prop
+
+/-- Each iterated derivative of `g` is differentiable (as `g` is `C^∞`). -/
+lemma differentiable_iteratedDeriv_g (n : ℕ) :
+    Differentiable ℝ (iteratedDeriv n g) :=
+  (g_contDiff.of_le le_top).differentiable_iteratedDeriv' n
+
+/-- The defining first-order ODE:  `g'(t) = t · g(t)`. -/
+lemma deriv_g : deriv g = fun t => t * g t := by
+  funext t
+  have hu : HasDerivAt (fun s : ℝ => s ^ 2 / 2) t t := by
+    have h := (hasDerivAt_pow 2 t).div_const 2
+    simpa using h
+  have h : HasDerivAt g (Real.exp (t ^ 2 / 2) * t) t := hu.exp
+  rw [h.deriv]
+  simp only [g]
+  ring
+
+/-- Pointwise form of the ODE. -/
+lemma deriv_g_apply (t : ℝ) : deriv g t = t * g t := congrFun deriv_g t
+
+/-- helper: `deriv (g⁽ᵏ⁾) = g⁽ᵏ⁺¹⁾`. -/
+lemma deriv_iteratedDeriv_g (k : ℕ) :
+    deriv (iteratedDeriv k g) = iteratedDeriv (k + 1) g := by
+  rw [iteratedDeriv_succ]
+
+/-- **Product-rule recursion for the iterated derivatives of `g`.**
+For every `n`,
+`g⁽ⁿ⁺²⁾(t) = t · g⁽ⁿ⁺¹⁾(t) + (n+1) · g⁽ⁿ⁾(t)`
+(the Leibniz expansion of `(t·g⁽ⁿ⁺¹⁾)'`, with no Nat subtraction). -/
+lemma iteratedDeriv_add_two_g (n : ℕ) :
+    iteratedDeriv (n + 2) g
+      = fun t => t * iteratedDeriv (n + 1) g t + ((n : ℝ) + 1) * iteratedDeriv n g t := by
+  -- `HasDerivAt` for each iterated derivative: `(g⁽ᵏ⁾)'(t) = g⁽ᵏ⁺¹⁾(t)`.
+  have hD : ∀ (k : ℕ) (t : ℝ),
+      HasDerivAt (iteratedDeriv k g) (iteratedDeriv (k + 1) g t) t := by
+    intro k t
+    have h := (differentiable_iteratedDeriv_g k t).hasDerivAt
+    rwa [deriv_iteratedDeriv_g] at h
+  induction n with
+  | zero =>
+    funext t
+    have e2 : iteratedDeriv 2 g = deriv (iteratedDeriv 1 g) := iteratedDeriv_succ
+    have e1 : iteratedDeriv 1 g = fun t => t * g t := by
+      rw [iteratedDeriv_succ, iteratedDeriv_zero, deriv_g]
+    have hg : HasDerivAt g (t * g t) t := by
+      have h := (differentiable_iteratedDeriv_g 0 t).hasDerivAt
+      rw [iteratedDeriv_zero, deriv_g_apply] at h
+      exact h
+    have hcomp : HasDerivAt (fun t => t * g t) (1 * g t + t * (t * g t)) t :=
+      (hasDerivAt_id t).mul hg
+    rw [e2, e1, hcomp.deriv]
+    simp only [iteratedDeriv_zero]
+    push_cast; ring
+  | succ n ih =>
+    funext t
+    -- `g⁽ⁿ⁺³⁾ = (g⁽ⁿ⁺²⁾)'`; substitute the `ih`-shape and differentiate the sum-product.
+    have key : iteratedDeriv (n + 1 + 2) g
+        = deriv (fun t => t * iteratedDeriv (n + 1) g t
+            + ((n : ℝ) + 1) * iteratedDeriv n g t) := by
+      have e : iteratedDeriv (n + 1 + 2) g = deriv (iteratedDeriv (n + 2) g) :=
+        iteratedDeriv_succ
+      rw [e, ih]
+    have hcomp : HasDerivAt
+        (fun t => t * iteratedDeriv (n + 1) g t + ((n : ℝ) + 1) * iteratedDeriv n g t)
+        (1 * iteratedDeriv (n + 1) g t + t * iteratedDeriv (n + 1 + 1) g t
+          + ((n : ℝ) + 1) * iteratedDeriv (n + 1) g t) t :=
+      ((hasDerivAt_id t).mul (hD (n + 1) t)).add (((hD n t).const_mul ((n : ℝ) + 1)))
+    rw [key, hcomp.deriv]
+    push_cast; ring
+
+/-- **Recursion at `0`.**  `g⁽ⁿ⁺²⁾(0) = (n+1) · g⁽ⁿ⁾(0)`.  The `t·g⁽ⁿ⁺¹⁾(t)`
+term of `iteratedDeriv_add_two_g` vanishes at `t = 0`. -/
+lemma iteratedDeriv_add_two_g_zero (n : ℕ) :
+    iteratedDeriv (n + 2) g 0 = (↑n + 1 : ℝ) * iteratedDeriv n g 0 := by
+  have h := congrFun (iteratedDeriv_add_two_g n) 0
+  simpa using h
+
+/-- Even iterated derivatives at `0` accumulate the product of odd numbers. -/
+lemma iteratedDeriv_even_g (k : ℕ) :
+    iteratedDeriv (2 * k) g 0 = ∏ i ∈ Finset.range k, (2 * (i : ℝ) + 1) := by
+  induction k with
+  | zero => simp
+  | succ n ih =>
+    have e : 2 * (n + 1) = 2 * n + 2 := by ring
+    rw [e, iteratedDeriv_add_two_g_zero, ih, Finset.prod_range_succ]
+    push_cast; ring
+
+/-- Odd iterated derivatives at `0` vanish (annihilated by `g'(0) = 0`). -/
+lemma iteratedDeriv_odd_g (k : ℕ) :
+    iteratedDeriv (2 * k + 1) g 0 = 0 := by
+  induction k with
+  | zero =>
+    have e : 2 * 0 + 1 = 1 := by norm_num
+    rw [e, iteratedDeriv_succ, iteratedDeriv_zero]
+    simp [deriv_g_apply]
+  | succ n ih =>
+    have e : 2 * (n + 1) + 1 = (2 * n + 1) + 2 := by ring
+    rw [e, iteratedDeriv_add_two_g_zero, ih, mul_zero]
+
+/-- **Moments as MGF derivatives.**  `E[Xⁿ] = g⁽ⁿ⁾(0)` for the standard normal. -/
+lemma moment_eq_iteratedDeriv (n : ℕ) :
+    ∫ x, x ^ n ∂stdNormal = iteratedDeriv n g 0 := by
+  have hmem : (0 : ℝ) ∈ interior (integrableExpSet id stdNormal) := by
+    have h : integrableExpSet id stdNormal = Set.univ := by
+      unfold stdNormal; exact integrableExpSet_id_gaussianReal
+    rw [h, interior_univ]; exact Set.mem_univ 0
+  rw [g_eq_mgf, iteratedDeriv_mgf_zero hmem n]
+  simp
+
+/-! ### Main theorems -/
+
+/-- **Moment recursion.**  `E[X^{n+2}] = (n+1) · E[Xⁿ]`. -/
+theorem moment_recursion (n : ℕ) :
+    ∫ x, x ^ (n + 2) ∂stdNormal = (↑n + 1 : ℝ) * ∫ x, x ^ n ∂stdNormal := by
+  rw [moment_eq_iteratedDeriv, moment_eq_iteratedDeriv, iteratedDeriv_add_two_g_zero]
+
+/-- **Even moment (product form).**  `E[X^{2k}] = ∏_{i<k}(2i+1)`. -/
+theorem stdNormal_even_moment (k : ℕ) :
+    ∫ x, x ^ (2 * k) ∂stdNormal = ∏ i ∈ Finset.range k, (2 * (i : ℝ) + 1) := by
+  rw [moment_eq_iteratedDeriv, iteratedDeriv_even_g]
+
+/-- **Odd moment.**  `E[X^{2k+1}] = 0` for the standard normal. -/
+theorem stdNormal_odd_moment (k : ℕ) :
+    ∫ x, x ^ (2 * k + 1) ∂stdNormal = 0 := by
+  rw [moment_eq_iteratedDeriv, iteratedDeriv_odd_g]
+
+/-- Double-factorial successor identity for odd arguments:
+`(2n+1)‼ = (2n+1) · (2n-1)‼`. -/
+lemma odd_df_succ (n : ℕ) : (2 * n + 1)‼ = (2 * n + 1) * (2 * n - 1)‼ := by
+  cases n with
+  | zero => decide
+  | succ m =>
+    have e1 : 2 * (m + 1) + 1 = (2 * m + 1) + 2 := by ring
+    have e2 : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
+    rw [e1, e2, Nat.doubleFactorial_add_two]
+
+/-- The product of the first `k` odd numbers is the odd double factorial. -/
+lemma prod_odd_eq_doubleFactorial (k : ℕ) :
+    (∏ i ∈ Finset.range k, (2 * i + 1)) = (2 * k - 1)‼ := by
+  induction k with
+  | zero => decide
+  | succ n ih =>
+    have e : 2 * (n + 1) - 1 = 2 * n + 1 := by omega
+    rw [Finset.prod_range_succ, ih, e, odd_df_succ n, Nat.mul_comm]
+
+/-- **Even moment (double-factorial form).**  `E[X^{2k}] = (2k-1)‼`.
+This closes the general even-moment strand left open by the grandparent. -/
+theorem stdNormal_even_moment_doubleFactorial (k : ℕ) :
+    ∫ x, x ^ (2 * k) ∂stdNormal = ((2 * k - 1)‼ : ℝ) := by
+  rw [stdNormal_even_moment, ← prod_odd_eq_doubleFactorial]
+  push_cast
+  rfl
+
+end AreaOfCircleOQ05Incomplete01OQ01OQ01

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+ {
+  "id": "aoc05inc010101-ann-overview",
+  "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "range": {
+   "startLine": 1,
+   "endLine": 55
+  },
+  "type": "concept",
+  "title": "Closing the General Moment Formula for N(0,1)",
+  "content": "The grandparent entry (area-of-circle-oq-05-incomplete-01-oq-01) formalizes the standard normal $X \\sim N(0,1)$ using Mathlib's `gaussianReal 0 1`, evaluates the first three moments $E[X^0]=1$, $E[X^1]=0$, $E[X^2]=1$, and records the moment-generating function $M_X(t)=E[e^{tX}]=\\exp(t^2/2)$, explicitly leaving the general moment formula open. This entry closes it: $E[X^{2k}]=(2k-1)!!$ (odd double factorial) and $E[X^{2k+1}]=0$. The method is a self-contained derivative recursion on the MGF, distinct from the integration-by-parts route used for the unnormalized physicist weight in the sibling area-of-circle-oq-07-oq-05-oq-01.",
+  "mathContext": "$E[X^{2k}] = (2k-1)!! = 1\\cdot 3\\cdot 5\\cdots(2k-1) = \\prod_{i<k}(2i+1)$, and $E[X^{2k+1}] = 0$, for the standard normal.",
+  "significance": "critical",
+  "prerequisites": [
+   "The standard normal N(0,1) and its MGF exp(t²/2) (area-of-circle-oq-05-incomplete-01-oq-01)",
+   "Moment-generating functions as derivative generators: ProbabilityTheory.iteratedDeriv_mgf_zero"
+  ],
+  "relatedConcepts": [
+   "Gaussian moments",
+   "moment-generating function",
+   "double factorial",
+   "Wick/Isserlis theorem",
+   "Hermite polynomials"
+  ]
+ },
+ {
+  "id": "aoc05inc010101-ann-ode",
+  "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "range": {
+   "startLine": 79,
+   "endLine": 95
+  },
+  "type": "technique",
+  "title": "The MGF ODE g'(t) = t·g(t)",
+  "content": "Writing $g(t)=M_X(t)=\\exp(t^2/2)$, the chain rule gives the defining first-order ODE $g'(t)=t\\,g(t)$ (`deriv_g`), since $\\frac{d}{dt}\\exp(t^2/2)=\\exp(t^2/2)\\cdot t$. This single differential relation is the engine of the whole computation: no integrability estimates are needed because everything is done on the smooth generating function. Smoothness ($g \\in C^\\infty$, `g_contDiff`) supplies the differentiability of every iterated derivative used below.",
+  "mathContext": "$g(t)=e^{t^2/2}$, $g'(t)=t\\,e^{t^2/2}=t\\,g(t)$.",
+  "significance": "important",
+  "prerequisites": [
+   "HasDerivAt.exp and the chain rule",
+   "Smoothness of exp∘(polynomial): ContDiff"
+  ],
+  "relatedConcepts": [
+   "ordinary differential equation",
+   "chain rule",
+   "smooth functions"
+  ]
+ },
+ {
+  "id": "aoc05inc010101-ann-recursion",
+  "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "range": {
+   "startLine": 96,
+   "endLine": 143
+  },
+  "type": "technique",
+  "title": "The Parity-Preserving Moment Recursion",
+  "content": "Differentiating the ODE $n$ times by Leibniz against the linear factor $t$ (whose second derivative vanishes) yields the closed derivative recursion $g^{(n+2)}(t) = t\\,g^{(n+1)}(t) + (n+1)\\,g^{(n)}(t)$ (`iteratedDeriv_add_two_g`), proved by induction with no Nat subtraction using `HasDerivAt` product and sum rules. Evaluating at $t=0$, where the $t\\,g^{(n+1)}(t)$ term vanishes, collapses it to $g^{(n+2)}(0)=(n+1)\\,g^{(n)}(0)$ (`iteratedDeriv_add_two_g_zero`). Via Mathlib's `iteratedDeriv_mgf_zero` this is exactly the moment recursion $E[X^{n+2}]=(n+1)\\,E[X^n]$ (`moment_recursion`).",
+  "mathContext": "$g^{(n+2)}(0) = (n+1)\\,g^{(n)}(0) \\iff E[X^{n+2}] = (n+1)\\,E[X^n]$.",
+  "significance": "critical",
+  "prerequisites": [
+   "Iterated derivatives: iteratedDeriv_succ, ContDiff.differentiable_iteratedDeriv'",
+   "HasDerivAt.mul, HasDerivAt.const_mul, HasDerivAt.add"
+  ],
+  "relatedConcepts": [
+   "Leibniz rule",
+   "recurrence relation",
+   "induction",
+   "iterated derivatives"
+  ]
+ },
+ {
+  "id": "aoc05inc010101-ann-moment-bridge",
+  "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "range": {
+   "startLine": 166,
+   "endLine": 174
+  },
+  "type": "technique",
+  "title": "From Probability Integral to Analytic Derivative",
+  "content": "`moment_eq_iteratedDeriv` bridges the probability integral to the analytic derivative: $\\int x^n\\,d\\mathrm{stdNormal} = g^{(n)}(0)$. It discharges the interior side-condition of `iteratedDeriv_mgf_zero` by showing `integrableExpSet id stdNormal = Set.univ` (so $0$ lies in its interior — the standard normal MGF is defined on all of $\\mathbb{R}$), then reconciles `mgf id stdNormal` with the explicit $g(t)=\\exp(t^2/2)$ recorded by the grandparent.",
+  "mathContext": "$\\int_{\\mathbb R} x^n\\, dN(0,1) = \\frac{d^n}{dt^n}M_X(t)\\big|_{t=0} = g^{(n)}(0)$.",
+  "significance": "important",
+  "prerequisites": [
+   "integrableExpSet_id_gaussianReal = Set.univ",
+   "iteratedDeriv_mgf_zero"
+  ],
+  "relatedConcepts": [
+   "moment generating function",
+   "analyticity of the MGF",
+   "interior of a set"
+  ]
+ },
+ {
+  "id": "aoc05inc010101-ann-doublefactorial",
+  "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "range": {
+   "startLine": 176,
+   "endLine": 220
+  },
+  "type": "key-step",
+  "title": "Unwinding to the Double Factorial and the Vanishing Odd Moments",
+  "content": "Unwinding the recursion from the base $E[X^0]=1$ accumulates $E[X^{2k}] = \\prod_{i<k}(2i+1)$ (`stdNormal_even_moment`), while the base $E[X^1]=g'(0)=0\\cdot g(0)=0$ annihilates the odd chain, giving $E[X^{2k+1}]=0$ (`stdNormal_odd_moment`). The product of the first $k$ odd numbers is matched to Mathlib's `Nat.doubleFactorial` via the odd successor identity $(2n+1)!! = (2n+1)\\cdot(2n-1)!!$ (`odd_df_succ`, `prod_odd_eq_doubleFactorial`), yielding the headline closed form $E[X^{2k}] = (2k-1)!!$ (`stdNormal_even_moment_doubleFactorial`).",
+  "mathContext": "$\\prod_{i<k}(2i+1) = (2k-1)!!$; both open strands (even and odd) follow from one recursion.",
+  "significance": "critical",
+  "prerequisites": [
+   "Nat.doubleFactorial and Nat.doubleFactorial_add_two",
+   "Finset.prod_range_succ"
+  ],
+  "relatedConcepts": [
+   "double factorial",
+   "odd numbers product",
+   "OEIS A001147",
+   "even and odd moments"
+  ]
+ }
+]

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
@@ -1,0 +1,75 @@
+{
+  "id": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "slug": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
+  "description": "Closes the general moment strand left open by the grandparent AreaOfCircleOQ05Incomplete01OQ01, which settled only E[X⁰], E[X¹], E[X²] for the standard normal X ~ N(0,1) and recorded the moment-generating function M_X(t) = exp(t²/2). This entry proves the full moment formula: E[X^{2k}] = (2k-1)‼ (odd double factorial) and E[X^{2k+1}] = 0. Method: Mathlib's iteratedDeriv_mgf_zero identifies E[Xⁿ] with the n-th derivative g⁽ⁿ⁾(0) of g(t) = M_X(t) = exp(t²/2); g solves the ODE g'(t) = t·g(t); differentiating this n times (Leibniz against the linear factor t) and evaluating at 0 — where the t·g⁽ⁿ⁺¹⁾(t) term vanishes — gives the parity-preserving recursion E[X^{n+2}] = (n+1)·E[Xⁿ]. Unwinding accumulates ∏_{i<k}(2i+1) = (2k-1)‼ on even indices and annihilates odd indices via E[X] = 0. 220 lines, 18 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.Moments.MGFAnalytic",
+      "Mathlib.Probability.Distributions.Gaussian.Real",
+      "Mathlib.Data.Nat.Factorial.DoubleFactorial",
+      "Proofs.AreaOfCircleOQ05Incomplete01OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Real",
+      "ProbabilityTheory"
+    ],
+    "namespace": "AreaOfCircleOQ05Incomplete01OQ01OQ01",
+    "lineCount": 220,
+    "axiomCount": 0,
+    "theoremCount": 18,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ05Incomplete01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "General Gaussian Moments: E[X^{2k}] = (2k-1)‼ via the MGF derivative recursion",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ05Incomplete01OQ01OQ01.lean",
+    "tags": [
+      "probability",
+      "gaussian",
+      "moments",
+      "moment-generating-function",
+      "iterated-derivative",
+      "double-factorial",
+      "analysis",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 220,
+    "theoremCount": 18,
+    "definitionCount": 1,
+    "badge": "verified",
+    "originalContributions": [
+      "stdNormal_even_moment_doubleFactorial: ∫ x^{2k} ∂stdNormal = (2k-1)‼ — the general even-moment formula for the standard normal N(0,1), for every k. The grandparent AreaOfCircleOQ05Incomplete01OQ01 evaluated only E[X⁰], E[X¹], E[X²] and explicitly left the general formula open; this entry closes it. The probabilist normalization (E[X^{2k}] = (2k-1)‼, no √π factor) is distinct from the physicist Gaussian-weight sibling area-of-circle-oq-07-oq-05-oq-01 (∫ x^{2n} e^{-x²} = (2n-1)‼√π/2ⁿ), and the method differs entirely: MGF-derivative recursion rather than integration by parts.",
+      "stdNormal_odd_moment: ∫ x^{2k+1} ∂stdNormal = 0 — the vanishing of every odd moment, obtained from the same recursion seeded by E[X] = 0 (the ODE gives g'(0) = 0·g(0) = 0). Both open strands — even and odd — fall out of one parity-preserving recursion.",
+      "iteratedDeriv_add_two_g: g⁽ⁿ⁺²⁾ = fun t ↦ t·g⁽ⁿ⁺¹⁾(t) + (n+1)·g⁽ⁿ⁾(t) for g(t) = exp(t²/2) — the Leibniz expansion of (t·g⁽ⁿ⁺¹⁾)' proved by induction with no Nat subtraction. This is the analytic engine: it packages the smoothness of g (ContDiff ℝ ⊤), the differentiability of every iterated derivative, and the product rule into a single closed recursion for the derivative functions.",
+      "iteratedDeriv_add_two_g_zero: g⁽ⁿ⁺²⁾(0) = (n+1)·g⁽ⁿ⁾(0) — the moment recursion, obtained by evaluating the previous identity at t = 0 where the t·g⁽ⁿ⁺¹⁾(t) term vanishes. Together with moment_eq_iteratedDeriv this yields moment_recursion: E[X^{n+2}] = (n+1)·E[Xⁿ].",
+      "moment_eq_iteratedDeriv: ∫ x^n ∂stdNormal = g⁽ⁿ⁾(0) — the bridge from the probability integral to the analytic derivative, discharging the interior-of-integrableExpSet side condition for the standard normal (integrableExpSet id stdNormal = Set.univ) so Mathlib's iteratedDeriv_mgf_zero applies, and reconciling mgf id stdNormal with the explicit g(t) = exp(t²/2) recorded by the grandparent.",
+      "deriv_g: deriv g = fun t ↦ t·g(t) — the defining first-order ODE of the Gaussian MGF, plus deriv_iteratedDeriv_g and prod_odd_eq_doubleFactorial (∏_{i<k}(2i+1) = (2k-1)‼, matching the accumulated product to Mathlib's Nat.doubleFactorial via the odd successor identity (2n+1)‼ = (2n+1)·(2n-1)‼)."
+    ],
+    "prerequisites": [
+      "Moment-generating functions and their analyticity: ProbabilityTheory.iteratedDeriv_mgf_zero",
+      "The standard normal MGF: ProbabilityTheory.mgf_id_gaussianReal and integrableExpSet_id_gaussianReal",
+      "Iterated derivatives and smoothness: ContDiff, iteratedDeriv_succ, ContDiff.differentiable_iteratedDeriv'",
+      "The product and chain rules for deriv: deriv_mul, deriv_const_mul, deriv_add, HasDerivAt.exp",
+      "The odd double factorial: Nat.doubleFactorial and Nat.doubleFactorial_add_two"
+    ],
+    "significance": "The moments of the standard normal are among the most-used constants in probability, statistics, and mathematical physics (Wick/Isserlis theorem, Hermite polynomials, method of moments). This entry gives the complete closed form E[X^{2k}] = (2k-1)‼ and E[X^{2k+1}] = 0 from a self-contained analytic recursion on the moment-generating function, reusing the grandparent's MGF computation and answering its own stated open question."
+  },
+  "crossReferences": [
+    {
+      "id": "area-of-circle-oq-05-incomplete-01-oq-01",
+      "relationship": "Parent entry: settles E[X⁰], E[X¹], E[X²] and records the MGF exp(t²/2); explicitly leaves the general moment formula open, which this entry closes."
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01",
+      "relationship": "Sibling even-moment result for the unnormalized physicist weight ∫ x^{2n} e^{-x²} = (2n-1)‼√π/2ⁿ, proved by integration by parts; this entry is the probabilist N(0,1) normalization proved by the MGF-derivative method."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the general moment strand left open by the grandparent **area-of-circle-oq-05-incomplete-01-oq-01**, which settled only $E[X^0], E[X^1], E[X^2]$ for the standard normal $X \sim N(0,1)$ and recorded the moment-generating function $M_X(t)=\exp(t^2/2)$, explicitly leaving the general formula open.

This entry proves the full moment formula:
$$E[X^{2k}] = (2k-1)!! \qquad E[X^{2k+1}] = 0.$$

## Method — MGF derivative recursion

- Mathlib's `iteratedDeriv_mgf_zero` identifies $E[X^n]$ with $g^{(n)}(0)$ for $g(t)=M_X(t)=\exp(t^2/2)$.
- $g$ solves the ODE $g'(t)=t\,g(t)$ (`deriv_g`).
- Differentiating $n$ times (Leibniz against the linear factor $t$, via `HasDerivAt` product/sum rules — no `Nat` subtraction) gives the closed derivative recursion `iteratedDeriv_add_two_g`: $g^{(n+2)} = t\,g^{(n+1)} + (n+1)\,g^{(n)}$.
- Evaluating at $0$ (where the $t\,g^{(n+1)}$ term vanishes) yields the moment recursion $E[X^{n+2}]=(n+1)\,E[X^n]$.
- The even index accumulates $\prod_{i<k}(2i+1)=(2k-1)!!$ (matched to `Nat.doubleFactorial` via $(2n+1)!!=(2n+1)(2n-1)!!$); the odd index is annihilated by $E[X]=0$.

## Main theorems

| Theorem | Statement |
|---|---|
| `stdNormal_even_moment_doubleFactorial` | $\int x^{2k}\,d\mathrm{stdNormal} = (2k-1)!!$ |
| `stdNormal_odd_moment` | $\int x^{2k+1}\,d\mathrm{stdNormal} = 0$ |
| `moment_recursion` | $E[X^{n+2}] = (n+1)\,E[X^n]$ |
| `stdNormal_even_moment` | $E[X^{2k}] = \prod_{i<k}(2i+1)$ |

## Relationship to existing work

Distinct from sibling **area-of-circle-oq-07-oq-05-oq-01** ($\int x^{2n} e^{-x^2} = (2n-1)!!\sqrt{\pi}/2^n$ via integration by parts): this is the probabilist $N(0,1)$ normalization proved by the MGF-derivative method.

## Verification

- New file `Proofs/AreaOfCircleOQ05Incomplete01OQ01OQ01.lean`: 220 lines, 18 theorems, 1 definition, **0 sorries, 0 axiom declarations**.
- Docker build (`docker-build.sh`): **3208 jobs, 0 errors**.
- `#print axioms` on both main theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Gallery entry (`meta.json` + `annotations.json`) added; `status: verified`, `badge: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)