### PR TITLE
Research: MZ SLLN — integral lifts of the truncation-moment kernels

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -883,4 +883,102 @@ theorem sq_le_rpow_mul_rpow_of_trunc {p t x : ℝ} (hp : p < 2) (ht : 0 < t)
 
 end TruncationMomentKernels
 
+/-! ## S4b (steps 3–4) — the integral lifts of the two truncation-moment kernels
+
+The two pointwise `rpow` kernels of the previous section are lifted here to the
+integral (expectation) level by monotonicity of the Bochner integral
+(`integral_mono_of_nonneg`, which needs integrability only of the dominating
+side).  For a measurable `X` whose `p`-th absolute moment `∫ |X|ᵖ` is finite, and a
+threshold `t > 0`:
+
+* **step 4 (variance).**  `∫ (𝟙{|X| ≤ t}·X)² ≤ t^{2-p}·∫|X|ᵖ`
+  (`integral_trunc_sq_le`, `p < 2`).  With `t = i^{1/p}` this is the truncated
+  second-moment estimate `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|ᵖ`; summed against `i^{-2/p}` it
+  gives the finite variance sum Kolmogorov's criterion consumes.
+* **step 3 (centering).**  `∫ 𝟙{t < |X|}·|X| ≤ t^{1-p}·∫|X|ᵖ`
+  (`integral_tail_abs_le`, `1 ≤ p`).  With `t = i^{1/p}` this bounds the centering
+  tail `𝔼[|X|·𝟙{|X| > i^{1/p}}] ≤ i^{(1-p)/p}·𝔼|X|ᵖ`, the null sequence feeding
+  `tendsto_weighted_average_zero`.
+
+Both are pure measure theory over an arbitrary measure `μ` — no probability,
+independence, or finiteness of `μ` is used (the truncated integrand may itself be
+non-integrable when `μ` is infinite, which `integral_mono_of_nonneg` absorbs by
+returning `0` for the undefined integral, still `≤` the finite bound). -/
+
+section TruncationIntegralLifts
+
+open MeasureTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Truncated second-moment integral lift (MZ step 4, variance).**  Integrating the
+pointwise kernel `sq_le_rpow_mul_rpow_of_trunc` over any measure `μ`: for `p < 2`, a
+threshold `0 < t`, and `X` with finite `p`-th absolute moment, the truncation
+`Y = 𝟙{|X| ≤ t}·X` satisfies
+
+    ∫ Y² ≤ t^{2-p} · ∫ |X|ᵖ.
+
+With `t = i^{1/p}` (so `t^{2-p} = i^{(2-p)/p}`) this is the second-moment estimate
+`𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|ᵖ` behind the variance sum `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`. -/
+theorem integral_trunc_sq_le
+    (X : Ω → ℝ) {p t : ℝ} (hp : p < 2) (ht : 0 < t)
+    (hint : Integrable (fun ω => |X ω| ^ p) μ) :
+    ∫ ω, ({ω | |X ω| ≤ t}.indicator X ω) ^ 2 ∂μ
+      ≤ t ^ (2 - p) * ∫ ω, |X ω| ^ p ∂μ := by
+  have hpt : ∀ ω, ({ω | |X ω| ≤ t}.indicator X ω) ^ 2 ≤ t ^ (2 - p) * |X ω| ^ p := by
+    intro ω
+    rw [Set.indicator_apply]
+    split_ifs with h
+    · rw [Set.mem_setOf_eq] at h
+      exact sq_le_rpow_mul_rpow_of_trunc hp ht h
+    · rw [show ((0 : ℝ)) ^ 2 = 0 by norm_num]
+      exact mul_nonneg (Real.rpow_nonneg ht.le _) (Real.rpow_nonneg (abs_nonneg _) _)
+  calc ∫ ω, ({ω | |X ω| ≤ t}.indicator X ω) ^ 2 ∂μ
+      ≤ ∫ ω, t ^ (2 - p) * |X ω| ^ p ∂μ :=
+        integral_mono_of_nonneg
+          (ae_of_all _ (fun ω => sq_nonneg _))
+          (hint.const_mul _)
+          (ae_of_all _ hpt)
+    _ = t ^ (2 - p) * ∫ ω, |X ω| ^ p ∂μ := integral_const_mul _ _
+
+/-- **Tail absolute-moment integral lift (MZ step 3, centering).**  Integrating the
+pointwise kernel `abs_le_rpow_mul_rpow_of_tail` over any measure `μ`: for `1 ≤ p`, a
+threshold `0 < t`, and `X` with finite `p`-th absolute moment,
+
+    ∫ 𝟙{t < |X|}·|X| ≤ t^{1-p} · ∫ |X|ᵖ.
+
+With `t = i^{1/p}` (so `t^{1-p} = i^{(1-p)/p}`) this bounds the centering tail
+`𝔼[|X|·𝟙{|X| > i^{1/p}}] ≤ i^{(1-p)/p}·𝔼|X|ᵖ`, the `tendsto_weighted_average_zero`
+null sequence. -/
+theorem integral_tail_abs_le
+    (X : Ω → ℝ) {p t : ℝ} (hp : 1 ≤ p) (ht : 0 < t)
+    (hint : Integrable (fun ω => |X ω| ^ p) μ) :
+    ∫ ω, {ω | t < |X ω|}.indicator (fun ω => |X ω|) ω ∂μ
+      ≤ t ^ (1 - p) * ∫ ω, |X ω| ^ p ∂μ := by
+  have hpt : ∀ ω, {ω | t < |X ω|}.indicator (fun ω => |X ω|) ω
+      ≤ t ^ (1 - p) * |X ω| ^ p := by
+    intro ω
+    rw [Set.indicator_apply]
+    split_ifs with h
+    · rw [Set.mem_setOf_eq] at h
+      exact abs_le_rpow_mul_rpow_of_tail hp ht h
+    · exact mul_nonneg (Real.rpow_nonneg ht.le _) (Real.rpow_nonneg (abs_nonneg _) _)
+  calc ∫ ω, {ω | t < |X ω|}.indicator (fun ω => |X ω|) ω ∂μ
+      ≤ ∫ ω, t ^ (1 - p) * |X ω| ^ p ∂μ :=
+        integral_mono_of_nonneg
+          (ae_of_all _ (fun ω => Set.indicator_nonneg (fun _ _ => abs_nonneg _) ω))
+          (hint.const_mul _)
+          (ae_of_all _ hpt)
+    _ = t ^ (1 - p) * ∫ ω, |X ω| ^ p ∂μ := integral_const_mul _ _
+
+#check @integral_trunc_sq_le
+#check @integral_tail_abs_le
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms integral_trunc_sq_le
+#print axioms integral_tail_abs_le
+
+end TruncationIntegralLifts
+
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -509,3 +509,47 @@ weight partial-sum asymptotic `∑_{i<n} i^{1/p-1} ~ p·n^{1/p} → ∞` for
 
 - `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (+~90 lines, § TruncationMomentKernels)
 - `research/problems/.../state.md`, `.../knowledge.md`, problem JSON knowledge
+
+## Session 2026-07-03 (researcher-8) — S4b integral lifts: kernels → expectations (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (RICH, score 29). **Outcome**: progress (DEEP DIVE) — new
+`§ TruncationIntegralLifts` in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`
+(2 theorems, 0 sorry, 0 axiom). **VERIFIED**: `docker-build.sh
+Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → Built (7743 jobs, 42s, exit 0);
+`#print axioms` on both = `[propext, Classical.choice, Quot.sound]` only — no
+`sorryAx`, no `Lean.ofReduceBool`, no `decide`.
+
+### What this session did
+Lifted the two verified pointwise `rpow` kernels (`sq_le_rpow_mul_rpow_of_trunc`,
+`abs_le_rpow_mul_rpow_of_tail`) from the previous session to the expectation level —
+exactly the top-priority `nextSteps` items ("integral lift ... do first,
+self-contained"):
+
+- **`integral_trunc_sq_le`** (step 4, variance, `p < 2`):
+  `∫ (𝟙{|X| ≤ t}·X)² ∂μ ≤ t^{2-p} · ∫ |X|^p ∂μ`.
+- **`integral_tail_abs_le`** (step 3, centering, `1 ≤ p`):
+  `∫ 𝟙{t < |X|}·|X| ∂μ ≤ t^{1-p} · ∫ |X|^p ∂μ`.
+
+### Technique (reusable)
+Both go through `MeasureTheory.integral_mono_of_nonneg`, whose key virtue is it
+needs integrability **only of the dominating side** (`hint.const_mul _`, i.e.
+`t^k · |X|^p` integrable from the `E|X|^p < ∞` hypothesis). The truncated integrand
+on the LHS may itself be non-integrable when `μ` is infinite; `integral_mono_of_nonneg`
+absorbs that by returning `0` for the undefined integral, still `≤` the finite bound.
+Pointwise bound: `Set.indicator_apply` + `split_ifs`; the on-set branch is the kernel
+verbatim, the off-set branch is `0 ≤ t^k·|X|^p` (`mul_nonneg (Real.rpow_nonneg …) …`).
+Then `integral_const_mul` pulls the `t^k` constant out. **No probability,
+independence, or finiteness of `μ` is used** — pure measure theory over arbitrary `μ`.
+
+### Honest status
+Genuine progress on the critical path, but NOT the full SLLN. What remains (updated
+`nextSteps`): instantiate `t = i^{1/p}` in each lift, do the `rpow` exponent
+arithmetic `(i^{1/p})^{2-p} = i^{(2-p)/p}`, and (step 4) sum against `i^{-2/p}` via
+`Real.summable_one_div_nat_rpow` (converges iff `2/p > 1`, i.e. `p < 2`) to get the
+finite variance sum; (step 3) feed the null sequence to `tendsto_weighted_average_zero`;
+then S5 assembly through `ae_tendsto_average_zero_of_variance_weighted_bdd`.
+
+### Files Modified
+- proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (new § TruncationIntegralLifts)
+- src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json (leanFiles + knowledge)
+- research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md (this entry)

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S4b step-3/4 kernels; written r14 2026-07-03, VERIFIED r8 2026-07-04): the two pointwise rpow truncation-moment kernels SHIPPED in § TruncationMomentKernels — abs_le_rpow_mul_rpow_of_tail (step-3 centering: 1<=p,0<t,t<|x| => |x|<=t^(1-p)|x|^p) and sq_le_rpow_mul_rpow_of_trunc (step-4 variance: p<2,0<t,|x|<=t => x^2<=t^(2-p)|x|^p). VERIFIED: docker-build Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 -> Built (7743 jobs, 54s, exit 0); pure Real.rpow, 0-axiom by construction. Remaining: integral lift of each kernel (integral_mono) + the two sums (step-4 uses 2/p>1) + S5 assembly.",
+    "progressSummary": "PROGRESS (integral lifts, researcher-8 2026-07-03, VERIFIED): the two pointwise rpow kernels are now lifted to expectations in § TruncationIntegralLifts of LawsOfLargeNumbersOQ01OQ02OQ01.lean. integral_trunc_sq_le: ∫(𝟙{|X|≤t}·X)²≤t^(2-p)·∫|X|^p (p<2, step-4 variance); integral_tail_abs_le: ∫𝟙{t<|X|}·|X|≤t^(1-p)·∫|X|^p (1≤p, step-3 centering). Both by integral_mono_of_nonneg over an arbitrary measure (no probability/finiteness), 0-axiom, docker-build exit 0 (7743 jobs). Remaining: instantiate t=i^(1/p), sum against i^(-2/p) (Real.summable_one_div_nat_rpow, 2/p>1) for the finite variance sum; the step-3 weighted-average null via tendsto_weighted_average_zero; then S5 assembly through ae_tendsto_average_zero_of_variance_weighted_bdd.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -59,14 +59,15 @@
       "MZ pointwise level: the whole role of 1<=p<2 is two exponent signs — 1-p<=0 (tail factor t^(1-p) sub-linear, step-3, needs antitone Real.rpow_le_rpow_of_nonpos) and 0<=2-p (truncation factor t^(2-p) super-linear + 2/p>1 for variance-sum convergence, step-4, needs monotone Real.rpow_le_rpow).",
       "Reusable rpow_add split idiom: to bound |x| (or x^2) by |x|^p*(threshold)^exp, write target = |x|^p*|x|^(k-p) via (← Real.rpow_add hxpos) with exponent identity closed by (show ...=k by ring), then bound the second factor by the threshold with the signed-exponent monotonicity lemma. Used verbatim in both kernels.",
       "x^(2:R)=x^(2:N) cast chain when a square meets rpow: rw [show (2:R)=((2:N):R) by norm_num, Real.rpow_natCast, sq_abs] (sq_abs turns |x|^(2:N) into x^(2:N)).",
-      "ENVIRONMENT: the r14 disk-full blocker (122Mi/926Gi) cleared by r8's session (9.3Gi free); docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 -> Built (7743 jobs, 54s, exit 0). Both kernels now machine-checked. Reliable r8 build recipe: copy the edited file over main's copy and build against main's populated .lake, then restore main (hardlinked-.lake worktree recipe fails on cache-get permission under Docker FUSE)."
+      "ENVIRONMENT: the r14 disk-full blocker (122Mi/926Gi) cleared by r8's session (9.3Gi free); docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 -> Built (7743 jobs, 54s, exit 0). Both kernels now machine-checked. Reliable r8 build recipe: copy the edited file over main's copy and build against main's populated .lake, then restore main (hardlinked-.lake worktree recipe fails on cache-get permission under Docker FUSE).",
+      "INTEGRAL LIFTS SHIPPED (researcher-8 2026-07-03/04, VERIFIED): the two truncation-moment kernels are now lifted to the expectation level in § TruncationIntegralLifts of LawsOfLargeNumbersOQ01OQ02OQ01.lean. integral_trunc_sq_le (step 4, p<2): ∫(𝟙{|X|≤t}·X)² ≤ t^(2-p)·∫|X|^p; integral_tail_abs_le (step 3, 1≤p): ∫𝟙{t<|X|}·|X| ≤ t^(1-p)·∫|X|^p. Both via integral_mono_of_nonneg (needs integrability only of the dominating side t^(k)|X|^p = hint.const_mul; the truncated integrand may be non-integrable on infinite μ and is absorbed). Pure measure theory over arbitrary μ — no probability/independence/finiteness. docker-build Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 → Built (7743 jobs, 42s, exit 0); #print axioms = [propext, Classical.choice, Quot.sound] only. These discharge the pointwise→integral gap in nextSteps; remaining is instantiating t=i^(1/p) and summing (step-4: Real.summable_one_div_nat_rpow with 2/p>1; step-3: tendsto_weighted_average_zero) then S5 assembly."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "DONE (r8 2026-07-04): the two kernels are build-verified (7743 jobs, exit 0). Next work is the integral lifts below.",
-      "S4b step-4 integral lift (do first, self-contained): integral_mono on Yi^2=Xi^2*indicator using sq_le_rpow_mul_rpow_of_trunc => E[Yi^2]<=i^((2-p)/p)*E|X|^p, then Var(Yi)<=E[Yi^2] and sum Var(Yi)/i^(2/p) <= E|X|^p * sum i^(-2/p) < inf (Real.summable_one_div_nat_rpow, 2/p>1).",
-      "S4b step-3 integral lift: abs_integral_le + integral_mono via abs_le_rpow_mul_rpow_of_tail => |E Yi|<=i^((1-p)/p)*E|X|^p, then tendsto_weighted_average_zero with null seq ci=E[|X|^p*1{|X|>i^{1/p}}]->0 and weight i^(1/p-1) (needs partial-sum asymptotic sum i^(1/p-1) ~ p*n^(1/p)->inf).",
-      "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi-E Yi + step-1 a.s. eventual Xi=Yi + step-3 centering => full MZ SLLN."
+      "DONE (r8 2026-07-03/04): pointwise kernels AND their integral lifts (integral_trunc_sq_le, integral_tail_abs_le) are build-verified, 0-axiom.",
+      "S4b step-4 series: instantiate integral_trunc_sq_le at t=i^(1/p) to get E[Yi²]≤i^((2-p)/p)·E|X|^p, then Var(Yi)≤E[Yi²] and ∑ Var(Yi)/i^(2/p) ≤ E|X|^p·∑ i^(-2/p) < ∞ via Real.summable_one_div_nat_rpow (2/p>1). Needs i^(1/p)>0 and the rpow-exponent arithmetic (i^(1/p))^(2-p)=i^((2-p)/p).",
+      "S4b step-3 series: instantiate integral_tail_abs_le at t=i^(1/p); with E[X]=0, |E Yi|=|E[X·𝟙{|X|>i^(1/p)}]|≤∫𝟙{i^(1/p)<|X|}|X|≤i^((1-p)/p)·E|X|^p, a null sequence (ci=E[|X|^p·𝟙{|X|>i^(1/p)}]→0 by dominated convergence); feed tendsto_weighted_average_zero with weight i^(1/p-1).",
+      "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi-E Yi + step-1 a.s. eventual Xi=Yi + step-3 centering ⟹ full MZ SLLN."
     ]
   },
   "tags": [
@@ -247,6 +248,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
+      "filename": "LawsOfLargeNumbersOQ01OQ02OQ01.lean",
+      "lineCount": 984,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Research session on `laws-of-large-numbers-oq-01-oq-02-oq-01` (Marcinkiewicz–Zygmund SLLN, `1 ≤ p < 2`).

Adds `§ TruncationIntegralLifts` to `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`, lifting the two previously-verified pointwise `rpow` truncation-moment kernels to the **expectation (Bochner integral) level** — the top-priority `nextSteps` items.

## Progress
- **`integral_trunc_sq_le`** (S4b step 4, variance; `p < 2`):
  `∫ (𝟙{|X| ≤ t}·X)² ∂μ ≤ t^{2-p} · ∫ |X|^p ∂μ`
- **`integral_tail_abs_le`** (S4b step 3, centering; `1 ≤ p`):
  `∫ 𝟙{t < |X|}·|X| ∂μ ≤ t^{1-p} · ∫ |X|^p ∂μ`

Both proved via `integral_mono_of_nonneg`, which needs integrability only of the dominating side (`t^k·|X|^p`, from `E|X|^p < ∞`); the truncated LHS integrand may be non-integrable on an infinite measure and is absorbed. Pure measure theory over an arbitrary `μ` — no probability, independence, or finiteness assumptions.

## Verification
`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built (7743 jobs, 42s, exit 0)**. `#print axioms` on both theorems = `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, `Lean.ofReduceBool`, or `decide`. **0 sorry, 0 axiom.**

## Status
**Outcome**: progress (DEEP DIVE, on critical path)
**Next Steps**: instantiate `t = i^{1/p}` in each lift, sum the step-4 bound against `i^{-2/p}` (`Real.summable_one_div_nat_rpow`, converges iff `p < 2`) for the finite variance sum; feed the step-3 null sequence to `tendsto_weighted_average_zero`; then S5 assembly via `ae_tendsto_average_zero_of_variance_weighted_bdd`.

🤖 Generated by researcher-8