### PR TITLE
research: cyclic vectors for prime-power minimal polynomial μ=qᵏ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean
@@ -1,0 +1,132 @@
+import Proofs.CayleyHamiltonMinpolyOQ04BackwardIncomplete01
+import Mathlib.Tactic
+
+/-
+# Cyclic Vectors for a Prime-Power Minimal Polynomial `μ = qᵏ`
+
+## Research Problem: cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02
+
+The parent file `CayleyHamiltonMinpolyOQ04BackwardIncomplete01` proves that when
+`minpoly K M` is **irreducible** of full degree `n`, *every nonzero* vector is a cyclic
+vector.  The sibling `…OQ01` then upgrades this to a full characterization (`cyclic ↔ v ≠ 0`)
+and counts the cyclic vectors over a finite field.
+
+This file handles the **next** case of the primary-decomposition ladder: the minimal
+polynomial is a **prime power**, `μ = qᵏ` with `q` irreducible.  Here the irreducible-case
+conclusion "every nonzero vector is cyclic" fails; instead the cyclic vectors are exactly
+those *not* killed by `qᵏ⁻¹`.
+
+## Main results
+
+* `cyclic_of_qkm1_ne_zero` — if `μ = qᵏ` (`q` irreducible, `deg μ = n`, `k ≥ 1`) and
+  `qᵏ⁻¹(M) v ≠ 0`, then `v` is a cyclic vector.
+* `qkm1_ne_zero_of_cyclic` — the converse: a cyclic vector is never annihilated by `qᵏ⁻¹`.
+* `cyclic_iff_qkm1_ne_zero` — the two directions combined: **`v` is cyclic iff
+  `qᵏ⁻¹(M) v ≠ 0`**.  This is the sharp characterization for the prime-power case.
+
+### Idea
+
+`IsCyclicVector M v` says the `M`-order of `v` (its monic annihilator) has degree `≥ n = deg μ`,
+i.e. equals `μ` since it always divides `μ`.  When `μ = qᵏ`, the order of `v` is `qʲ` for some
+`j ≤ k`, and it equals `qᵏ` iff `qᵏ⁻¹` does not annihilate `v`.
+
+For the substantive direction, suppose `qᵏ⁻¹(M) v ≠ 0` yet some nonzero `p` with `deg p < n`
+annihilates `v`.  Let `d = gcd(p, μ)`.  By Bézout (the parent's `gcd_aeval_mulVec_eq_zero`),
+`d(M) v = 0`.  Since `d ∣ qᵏ` and `q` is prime, `d` is associated to `qʲ` for some `j ≤ k`.
+If `j = k` then `μ = qᵏ ∣ p`, impossible for a nonzero `p` of degree `< deg μ`; hence
+`j ≤ k − 1`, so `d ∣ qᵏ⁻¹`.  Writing `qᵏ⁻¹ = e · d` and using that polynomials in `M` commute,
+`qᵏ⁻¹(M) v = e(M) (d(M) v) = 0`, contradicting the hypothesis.
+
+This generalizes the irreducible case (`k = 1`): there `qᵏ⁻¹ = q⁰ = 1`, so `qᵏ⁻¹(M) v = v`
+and the characterization collapses to `cyclic ↔ v ≠ 0`.
+
+## Status (0 axioms, 0 sorries)
+-/
+
+namespace CayleyHamiltonMinpolyOQ04BackwardInc01
+
+open Matrix Polynomial
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-- **Prime-power case, hard direction.** If `minpoly K M = qᵏ` with `q` irreducible of full
+degree `n` and `k ≥ 1`, then any vector not annihilated by `qᵏ⁻¹` is a cyclic vector. -/
+theorem cyclic_of_qkm1_ne_zero [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K) {q : K[X]} {k : ℕ} (_hk : 0 < k)
+    (hirr : Irreducible q) (hμ : minpoly K M = q ^ k)
+    (hdeg : (minpoly K M).natDegree = n)
+    {v : Fin n → K} (hv : (aeval M (q ^ (k - 1))).mulVec v ≠ 0) :
+    IsCyclicVector M v := by
+  intro p hp hann
+  by_contra hp0
+  -- Bézout: gcd(p, μ) annihilates v
+  set μ := minpoly K M with hμdef
+  set d := EuclideanDomain.gcd p μ with hddef
+  have hdv : (aeval M d).mulVec v = 0 := gcd_aeval_mulVec_eq_zero hann
+  have hd_dvd_p : d ∣ p := EuclideanDomain.gcd_dvd_left p μ
+  have hd_dvd_μ : d ∣ μ := EuclideanDomain.gcd_dvd_right p μ
+  -- q is prime, so divisors of qᵏ are associates of qʲ, j ≤ k
+  have hqp : Prime q := hirr.prime
+  have hd_dvd_qk : d ∣ q ^ k := by rw [← hμ]; exact hd_dvd_μ
+  obtain ⟨j, hjk, hassoc⟩ := (dvd_prime_pow hqp k).mp hd_dvd_qk
+  -- j ≠ k: otherwise μ = qᵏ ∣ p, impossible for nonzero p of degree < n
+  have hjlt : j < k := by
+    rcases lt_or_eq_of_le hjk with h | h
+    · exact h
+    · exfalso
+      -- j = k ⟹ q^k ~ d ∣ p ⟹ μ ∣ p ⟹ n ≤ deg p, contradicting deg p < n
+      have hμ_dvd_p : μ ∣ p := by
+        rw [hμ, ← h]
+        exact hassoc.symm.dvd.trans hd_dvd_p
+      have := Polynomial.natDegree_le_of_dvd hμ_dvd_p hp0
+      rw [hdeg] at this
+      omega
+  -- hence d ∣ qᵏ⁻¹
+  have hd_dvd_qkm1 : d ∣ q ^ (k - 1) :=
+    hassoc.dvd.trans (pow_dvd_pow q (Nat.le_sub_one_of_lt hjlt))
+  obtain ⟨e, he⟩ := hd_dvd_qkm1
+  -- qᵏ⁻¹(M) v = e(M) (d(M) v) = 0, contradicting hv
+  apply hv
+  have hcomm : q ^ (k - 1) = e * d := by rw [he]; ring
+  rw [hcomm, map_mul, ← Matrix.mulVec_mulVec, hdv, Matrix.mulVec_zero]
+
+/-- **Prime-power case, easy direction.** A cyclic vector is never annihilated by `qᵏ⁻¹`
+(when `q` is non-constant and `deg μ = n`): `qᵏ⁻¹` is a nonzero polynomial of degree
+`(k−1)·deg q < k·deg q = n`, so if it annihilated the cyclic `v` it would have to be `0`. -/
+theorem qkm1_ne_zero_of_cyclic [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K) {q : K[X]} {k : ℕ} (hk : 0 < k)
+    (hirr : Irreducible q) (hμ : minpoly K M = q ^ k)
+    (hdeg : (minpoly K M).natDegree = n)
+    {v : Fin n → K} (hcyc : IsCyclicVector M v) :
+    (aeval M (q ^ (k - 1))).mulVec v ≠ 0 := by
+  intro hzero
+  -- degree bookkeeping: n = k * deg q, and deg (qᵏ⁻¹) = (k−1) * deg q < n
+  have hdq : 0 < q.natDegree := hirr.natDegree_pos
+  have hn : n = k * q.natDegree := by
+    rw [← hdeg, hμ, Polynomial.natDegree_pow]
+  have hdeg_lt : (q ^ (k - 1)).natDegree < n := by
+    rw [Polynomial.natDegree_pow, hn]
+    have hk1 : k - 1 < k := Nat.sub_lt hk one_pos
+    exact (Nat.mul_lt_mul_right hdq).mpr hk1
+  -- qᵏ⁻¹ ≠ 0 since q ≠ 0
+  have hq0 : q ≠ 0 := hirr.ne_zero
+  have hpow0 : q ^ (k - 1) ≠ 0 := pow_ne_zero _ hq0
+  exact hpow0 (hcyc _ hdeg_lt hzero)
+
+/-- **Sharp characterization (prime-power minimal polynomial).** With `minpoly K M = qᵏ`
+(`q` irreducible, `deg μ = n`, `k ≥ 1`), a vector is cyclic **iff** it is not annihilated by
+`qᵏ⁻¹`.  For `k = 1` this is exactly the irreducible-case result `cyclic ↔ v ≠ 0`. -/
+theorem cyclic_iff_qkm1_ne_zero [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K) {q : K[X]} {k : ℕ} (hk : 0 < k)
+    (hirr : Irreducible q) (hμ : minpoly K M = q ^ k)
+    (hdeg : (minpoly K M).natDegree = n)
+    (v : Fin n → K) :
+    IsCyclicVector M v ↔ (aeval M (q ^ (k - 1))).mulVec v ≠ 0 :=
+  ⟨fun hcyc => qkm1_ne_zero_of_cyclic M hk hirr hμ hdeg hcyc,
+   fun hv => cyclic_of_qkm1_ne_zero M hk hirr hμ hdeg hv⟩
+
+end CayleyHamiltonMinpolyOQ04BackwardInc01
+
+#print axioms CayleyHamiltonMinpolyOQ04BackwardInc01.cyclic_of_qkm1_ne_zero
+#print axioms CayleyHamiltonMinpolyOQ04BackwardInc01.qkm1_ne_zero_of_cyclic
+#print axioms CayleyHamiltonMinpolyOQ04BackwardInc01.cyclic_iff_qkm1_ne_zero

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-cyc-oq0402-header",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "range": { "startLine": 4, "endLine": 44 },
+    "type": "concept",
+    "title": "Climbing the Primary-Decomposition Ladder: from Irreducible to Prime-Power μ",
+    "content": "The module docstring frames the research step. The parent proved that an irreducible minimal polynomial of full degree n makes every nonzero vector cyclic, and the sibling -oq-01 turned that into 'cyclic ⟺ v ≠ 0'. This file handles the next rung: μ = qᵏ, a prime power. Now 'every nonzero vector is cyclic' genuinely fails — vectors lying in ker qᵏ⁻¹(M) are non-cyclic even though nonzero. The correct criterion is that v is cyclic iff qᵏ⁻¹(M) v ≠ 0. Conceptually Kⁿ becomes the local K[X]-module K[X]/(qᵏ), whose generators are exactly the elements outside its unique maximal submodule q·K[X]/(qᵏ), i.e. the elements qᵏ⁻¹ does not kill. Setting k = 1 recovers the irreducible case verbatim.",
+    "mathContext": "Parent/-oq-01: $\\mu$ irreducible $\\Rightarrow$ cyclic $\\iff v \\ne 0$. Here $\\mu = q^k$: cyclic $\\iff q^{k-1}(M)\\,v \\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic vector", "prime-power minimal polynomial", "primary decomposition", "local module K[X]/(qᵏ)"],
+    "prerequisites": ["the irreducible-case characterization", "minimal polynomial of a matrix", "K[X]-module structure of Kⁿ"]
+  },
+  {
+    "id": "ann-cyc-oq0402-hard",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "range": { "startLine": 52, "endLine": 91 },
+    "type": "insight",
+    "title": "Hard direction: Bézout + the divisor structure of a prime power",
+    "content": "cyclic_of_qkm1_ne_zero is the substantive theorem. Suppose $q^{k-1}(M)\\,v \\ne 0$, yet some nonzero $p$ with $\\deg p < n$ annihilates $v$. Two mechanisms combine. First, the parent's Bézout lemma gcd_aeval_mulVec_eq_zero pushes the annihilation down to the gcd: $d = \\gcd(p,\\mu)$ satisfies $d(M)\\,v = 0$. Second, because $q$ is prime and $d \\mid q^k$, dvd_prime_pow forces $d$ to be associated to $q^j$ for some $j \\le k$. The exponent cannot be maximal: $j = k$ would give $\\mu = q^k \\mid p$, impossible for a nonzero $p$ of degree $< \\deg\\mu$ (natDegree_le_of_dvd). Hence $j \\le k-1$, so $d \\mid q^{k-1}$; writing $q^{k-1} = e\\cdot d$ and reordering the commuting evaluations $e(M), d(M)$ yields $q^{k-1}(M)\\,v = e(M)\\,(d(M)\\,v) = 0$ — contradicting the hypothesis. So no such $p$ exists and $v$ is cyclic.",
+    "mathContext": "$d=\\gcd(p,q^k)\\sim q^j$, $j\\le k-1 \\Rightarrow d \\mid q^{k-1} \\Rightarrow q^{k-1}(M)\\,v = e(M)(d(M)\\,v)=0$.",
+    "significance": "key",
+    "relatedConcepts": ["Bézout identity", "gcd of polynomials", "prime power divisors", "associated elements", "commuting matrix polynomials"],
+    "prerequisites": ["gcd_aeval_mulVec_eq_zero (parent)", "dvd_prime_pow", "Irreducible.prime", "natDegree_le_of_dvd", "Matrix.mulVec_mulVec"]
+  },
+  {
+    "id": "ann-cyc-oq0402-easy",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "range": { "startLine": 93, "endLine": 114 },
+    "type": "concept",
+    "title": "Easy direction: a degree count on qᵏ⁻¹",
+    "content": "qkm1_ne_zero_of_cyclic is the converse and is purely a degree argument. The polynomial $q^{k-1}$ is nonzero (a power of the nonzero irreducible $q$) and has natDegree $(k-1)\\cdot\\deg q$. Since $q$ is irreducible its degree is positive (Irreducible.natDegree_pos), so $(k-1)\\cdot\\deg q < k\\cdot\\deg q = \\deg\\mu = n$. A cyclic vector admits no nonzero annihilating polynomial of degree $< n$; therefore if $q^{k-1}(M)\\,v = 0$ the cyclic condition would force $q^{k-1} = 0$, which is false. Hence $q^{k-1}(M)\\,v \\ne 0$.",
+    "mathContext": "$\\deg(q^{k-1}) = (k-1)\\deg q < k\\deg q = n$, and $q^{k-1}\\ne 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["natDegree of a power", "irreducible polynomial has positive degree", "cyclic vector"],
+    "prerequisites": ["IsCyclicVector", "Polynomial.natDegree_pow", "Irreducible.natDegree_pos", "pow_ne_zero"]
+  },
+  {
+    "id": "ann-cyc-oq0402-iff",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "range": { "startLine": 116, "endLine": 128 },
+    "type": "insight",
+    "title": "The sharp iff and its collapse to the irreducible case",
+    "content": "cyclic_iff_qkm1_ne_zero assembles the two directions into IsCyclicVector M v ↔ (aeval M (qᵏ⁻¹)).mulVec v ≠ 0. This is the exact prime-power analogue of the sibling's cyclic ⟺ v ≠ 0, and specializes to it: when k = 1 the test polynomial is q⁰ = 1, so qᵏ⁻¹(M) v = v and the criterion reads v ≠ 0. Geometrically the cyclic locus is the punctured space {0}ᶜ with the proper subspace ker qᵏ⁻¹(M) removed — strictly smaller than in the irreducible case, matching the intuition that a prime-power block K[X]/(qᵏ) has 'fewer' generators than a field K[X]/(q).",
+    "mathContext": "$\\mathrm{IsCyclicVector}\\,M\\,v \\iff q^{k-1}(M)\\,v \\ne 0$; at $k=1$, $q^{k-1}=1$ gives $v \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["characterization theorem", "specialization to irreducible case", "cyclic locus", "kernel of qᵏ⁻¹(M)"],
+    "prerequisites": ["the two directional theorems above"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/index.ts
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq02Data: ProofData = {
+  proof: cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq02Proof,
+  annotations: cayleyHamiltonMinpolyOq04BackwardIncomplete01Oq02Annotations,
+}

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+  "title": "Cyclic Vectors for a Prime-Power Minimal Polynomial μ = qᵏ",
+  "slug": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+  "description": "Extends the irreducible-case characterization (sibling -oq-01) to the next rung of the primary-decomposition ladder: the minimal polynomial is a prime power μ = qᵏ with q irreducible. Here 'every nonzero vector is cyclic' fails; instead a vector is cyclic for M iff it is not annihilated by qᵏ⁻¹(M). The proof combines the parent's Bézout/gcd annihilation lemma with the divisor structure of a prime power (divisors of qᵏ are associates of qʲ, j ≤ k). For k = 1 this collapses exactly to the irreducible result cyclic ⟺ v ≠ 0. 3 theorems, 0 axioms, 0 sorries; verified, no native_decide.",
+  "leanFile": {
+    "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean",
+    "namespace": "CayleyHamiltonMinpolyOQ04BackwardInc01",
+    "imports": [
+      "Proofs.CayleyHamiltonMinpolyOQ04BackwardIncomplete01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "openQuestion": {
+    "id": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "parentId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "question": "The parent and sibling -oq-01 settle the case of an irreducible minimal polynomial (every nonzero vector is cyclic). What is the cyclic-vector locus when the minimal polynomial is a prime power μ = qᵏ with q irreducible — the first case where 'every nonzero vector is cyclic' fails?",
+    "answer": "A vector v is cyclic for M iff qᵏ⁻¹(M) v ≠ 0. The M-order of any v divides μ = qᵏ, hence equals qʲ for some j ≤ k, and it equals the full μ (the cyclic condition) exactly when qᵏ⁻¹ does not annihilate v. The hard direction runs: if some nonzero p of degree < n = deg μ annihilates v, then d = gcd(p, μ) annihilates v by Bézout and, being a divisor of the prime power qᵏ, is associated to qʲ with j ≤ k; j = k would force μ ∣ p (impossible by degrees), so j ≤ k−1, giving d ∣ qᵏ⁻¹ and hence qᵏ⁻¹(M) v = 0 — a contradiction. The cyclic locus is therefore {0}ᶜ minus the proper subspace ker qᵏ⁻¹(M). For k = 1 the criterion becomes q⁰(M) v = v ≠ 0, recovering the irreducible result exactly."
+  },
+  "highlights": [
+    "Sharp cyclic-vector criterion for a prime-power minimal polynomial: cyclic ⟺ qᵏ⁻¹(M) v ≠ 0",
+    "First case beyond irreducibility where the cyclic locus is a proper subset of the punctured space {0}ᶜ",
+    "Hard direction reduces the annihilator via Bézout to a gcd, then uses that divisors of qᵏ are associates of qʲ (j ≤ k)",
+    "Strictly generalizes the sibling -oq-01: k = 1 gives qᵏ⁻¹ = 1 and the criterion collapses to v ≠ 0",
+    "Reuses the verified parent's gcd_aeval_mulVec_eq_zero unchanged (imported, not re-proved)"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "If minpoly K M = qᵏ (q irreducible, deg = n, k ≥ 1) and qᵏ⁻¹(M) v ≠ 0, then v is a cyclic vector",
+      "type": "theorem"
+    },
+    {
+      "statement": "A cyclic vector is never annihilated by qᵏ⁻¹(M)",
+      "type": "theorem"
+    },
+    {
+      "statement": "IsCyclicVector M v ↔ qᵏ⁻¹(M) v ≠ 0 for a prime-power minimal polynomial of full degree",
+      "type": "theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "A cyclic (nonderogatory) vector for M ∈ Mₙ(K) generates Kⁿ under M. Viewing Kⁿ as a K[X]-module via X ↦ M, its structure is K[X]/(μ) when μ = charpoly = minpoly. The primary decomposition theorem factors this module along the prime powers dividing μ. The parent and sibling handled the base case μ = q (irreducible), where the module is a field and every nonzero vector generates. The prime-power case μ = qᵏ is the indecomposable local piece K[X]/(qᵏ): its generators are exactly the elements not lying in the unique maximal submodule q·K[X]/(qᵏ), i.e. the elements not killed by qᵏ⁻¹. This entry formalizes precisely that criterion at the matrix level.",
+    "problemStatement": "Characterize the cyclic vectors of a matrix M whose minimal polynomial is a prime power μ = qᵏ (q irreducible) of full degree n: prove that v is cyclic iff qᵏ⁻¹(M) v ≠ 0.",
+    "proofStrategy": "Easy direction (qkm1_ne_zero_of_cyclic): qᵏ⁻¹ is nonzero of natDegree (k−1)·deg q < k·deg q = n (using Irreducible.natDegree_pos and natDegree_pow), so if it annihilated the cyclic v the cyclic condition would force qᵏ⁻¹ = 0, a contradiction. Hard direction (cyclic_of_qkm1_ne_zero): assume qᵏ⁻¹(M) v ≠ 0 and some nonzero p with deg p < n annihilates v. By the parent's Bézout lemma gcd_aeval_mulVec_eq_zero, d = gcd(p, μ) satisfies d(M) v = 0. Since q is prime (Irreducible.prime) and d ∣ qᵏ, dvd_prime_pow gives d associated to qʲ with j ≤ k. If j = k then μ = qᵏ ∣ p, contradicting natDegree_le_of_dvd against deg p < n; hence j ≤ k−1 and d ∣ qᵏ⁻¹. Writing qᵏ⁻¹ = e·d and using that aeval-images commute (map_mul, Matrix.mulVec_mulVec), qᵏ⁻¹(M) v = e(M)(d(M) v) = 0, contradiction. The iff assembles the two directions.",
+    "keyInsights": [
+      "The cyclic condition 'no nonzero polynomial of degree < deg μ annihilates v' is equivalent to 'the M-order of v equals μ'; when μ = qᵏ the order is some qʲ, and equals qᵏ exactly when qᵏ⁻¹ fails to annihilate v.",
+      "Bézout collapses an arbitrary annihilating p to the gcd d = gcd(p, μ), and the prime-power structure of μ forces d to be a pure power qʲ — turning an unstructured hypothesis into a clean divisibility.",
+      "The degree obstruction j ≠ k is exactly 'μ does not divide a nonzero polynomial of smaller degree', the same mechanism that made the irreducible case work.",
+      "Commutativity of polynomial evaluations in M is what lets qᵏ⁻¹ = e·d be reordered so that the known relation d(M) v = 0 applies."
+    ],
+    "prerequisites": [
+      "Parent: cayley-hamilton-minpoly-oq-04-backward-incomplete-01 (IsCyclicVector, gcd_aeval_mulVec_eq_zero)",
+      "dvd_prime_pow: divisors of a prime power qᵏ are associates of qʲ with j ≤ k",
+      "Irreducible.prime (K[X] is a decomposition monoid) and Irreducible.natDegree_pos",
+      "Polynomial.natDegree_pow, Polynomial.natDegree_le_of_dvd; Matrix.mulVec_mulVec, map_mul for aeval"
+    ]
+  },
+  "sections": [
+    {
+      "id": "hard",
+      "title": "Hard Direction: qᵏ⁻¹(M) v ≠ 0 ⟹ cyclic",
+      "startLine": 52,
+      "endLine": 91,
+      "summary": "cyclic_of_qkm1_ne_zero: given an annihilating nonzero p of degree < n, Bézout sends d = gcd(p, μ) to an annihilator of v; the prime-power divisor structure makes d ~ qʲ with j ≤ k−1 (j = k would force μ ∣ p), so d ∣ qᵏ⁻¹ and qᵏ⁻¹(M) v = 0 — contradicting the hypothesis.",
+      "mathContext": "d = gcd(p, qᵏ) ~ qʲ, j ≤ k−1 ⟹ d ∣ qᵏ⁻¹ ⟹ qᵏ⁻¹(M) v = e(M)(d(M) v) = 0."
+    },
+    {
+      "id": "easy",
+      "title": "Easy Direction: cyclic ⟹ qᵏ⁻¹(M) v ≠ 0",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "qkm1_ne_zero_of_cyclic: qᵏ⁻¹ is a nonzero polynomial of natDegree (k−1)·deg q, which is < k·deg q = n because deg q > 0; the cyclic condition would then force qᵏ⁻¹ = 0, impossible.",
+      "mathContext": "deg(qᵏ⁻¹) = (k−1)·deg q < k·deg q = n and qᵏ⁻¹ ≠ 0 ⟹ qᵏ⁻¹(M) v ≠ 0."
+    },
+    {
+      "id": "iff",
+      "title": "Sharp Characterization",
+      "startLine": 116,
+      "endLine": 128,
+      "summary": "cyclic_iff_qkm1_ne_zero packages the two directions into IsCyclicVector M v ↔ qᵏ⁻¹(M) v ≠ 0, the prime-power analogue of the sibling's cyclic ⟺ v ≠ 0 (which is the k = 1 special case).",
+      "mathContext": "IsCyclicVector M v ⟺ (aeval M (qᵏ⁻¹)).mulVec v ≠ 0."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Hoffman, K.",
+        "Kunze, R."
+      ],
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "2nd ed., Prentice-Hall",
+      "note": "Cyclic decomposition theorem, primary decomposition of K[X]-modules, and rational canonical form."
+    },
+    {
+      "authors": [
+        "Dummit, D.",
+        "Foote, R."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Structure of finitely generated modules over a PID; the local module K[X]/(qᵏ) and its generators."
+    },
+    {
+      "authors": [
+        "Roman, S."
+      ],
+      "title": "Advanced Linear Algebra",
+      "year": "2008",
+      "venue": "3rd ed., Graduate Texts in Mathematics 135, Springer",
+      "note": "Cyclic/companion decomposition and nonderogatory matrices as those admitting a cyclic vector."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a matrix whose minimal polynomial is a prime power μ = qᵏ (q irreducible) of full degree n, a vector is cyclic iff it is not annihilated by qᵏ⁻¹(M). This extends the irreducible-case characterization (sibling -oq-01, the k = 1 instance) to the indecomposable local module K[X]/(qᵏ), where the cyclic locus is the punctured space minus the proper subspace ker qᵏ⁻¹(M). 3 theorems, 0 axioms, 0 sorries.",
+    "implications": "Together with the sibling this covers every primary (prime-power) block of a matrix's rational canonical form; the general (squarefree-coprime) case follows by primary decomposition and CRT, giving a route to the full cyclic-vector count over a finite field.",
+    "openQuestions": [
+      "Combine the primary blocks via CRT/primary decomposition to characterize cyclic vectors for an arbitrary minimal polynomial μ = ∏ qᵢ^{kᵢ}.",
+      "Count the cyclic vectors of the prime-power block over a finite field: |{0}ᶜ ∖ ker qᵏ⁻¹(M)| = qⁿ − q^{n − deg q}."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-07-03",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "cyclic-vector",
+      "nonderogatory",
+      "prime-power",
+      "primary-decomposition"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "cyclic_of_qkm1_ne_zero: for μ = qᵏ, any v with qᵏ⁻¹(M) v ≠ 0 is a cyclic vector (hard direction, via Bézout + prime-power divisor structure)",
+      "qkm1_ne_zero_of_cyclic: a cyclic vector is never annihilated by qᵏ⁻¹(M) (degree bound)",
+      "cyclic_iff_qkm1_ne_zero: sharp characterization IsCyclicVector M v ⟺ qᵏ⁻¹(M) v ≠ 0, generalizing the irreducible case (k = 1)"
+    ],
+    "proofStrategy": "Hard direction reduces an arbitrary annihilator to d = gcd(p, μ) via the parent's Bézout lemma, then uses dvd_prime_pow to force d ~ qʲ with j ≤ k−1 and concludes qᵏ⁻¹(M) v = 0; easy direction is a degree bound on qᵏ⁻¹; the iff combines them.",
+    "openQuestions": [
+      "Assemble primary blocks via CRT for arbitrary μ = ∏ qᵢ^{kᵢ}",
+      "Finite-field count of the prime-power block: qⁿ − q^{n − deg q}"
+    ],
+    "mathContext": {
+      "field": "Linear Algebra / Module Theory",
+      "keyTheorem": "For a matrix with prime-power minimal polynomial μ = qᵏ of full degree n, a vector is cyclic iff it is not annihilated by qᵏ⁻¹(M).",
+      "historicalBackground": "The local K[X]-module K[X]/(qᵏ) has a unique maximal submodule q·K[X]/(qᵏ); its generators are exactly the elements outside it, i.e. those not killed by qᵏ⁻¹. This is the primary block of the cyclic decomposition.",
+      "significance": "Advances the cyclic-vector characterization from the irreducible base case to the general prime-power block, the indecomposable piece of the primary decomposition, and sets up the CRT assembly for arbitrary minimal polynomials."
+    }
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02.json
@@ -1,0 +1,62 @@
+{
+  "slug": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+  "title": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+  "tier": "B",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "started": "2026-07-03",
+  "lastUpdate": "2026-07-03",
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-07-03",
+    "iteration": 1,
+    "focus": "Cyclic vectors for a prime-power minimal polynomial mu = q^k",
+    "blockers": [],
+    "nextAction": "",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "problemStatement": {
+    "formal": "Let M in M_n(K), minpoly K M = q^k with q irreducible and (minpoly K M).natDegree = n, k >= 1. Then IsCyclicVector M v <-> (aeval M (q^(k-1))).mulVec v != 0.",
+    "plain": "Characterize which vectors are cyclic for a matrix whose minimal polynomial is a prime power q^k. The irreducible case (k=1) has 'every nonzero vector cyclic'; the prime-power case does not. A vector is cyclic iff it is not annihilated by q^{k-1}(M).",
+    "whyMatters": [
+      "Next rung of the primary-decomposition ladder after the irreducible base case",
+      "First case where the cyclic locus is a proper subset of the punctured space {0}^c",
+      "Sets up CRT assembly toward cyclic-vector characterization for arbitrary minimal polynomials"
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "cayley-hamilton",
+    "minimal-polynomial",
+    "cyclic-vector",
+    "prime-power",
+    "primary-decomposition"
+  ],
+  "knowledge": {
+    "progressSummary": "COMPLETE: prime-power minpoly case mu = q^k. v cyclic <-> q^{k-1}(M)v != 0. 3 thms, 0 axioms (propext/Classical/Quot.sound only), 0 sorries, verified. Generalizes sibling -oq-01 (k=1 gives cyclic <-> v!=0). Imports parent's gcd_aeval_mulVec_eq_zero (Bezout) unchanged.",
+    "builtItems": [
+      "CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean (132 lines, 0 axioms, 0 sorries, verified)",
+      "cyclic_of_qkm1_ne_zero: hard direction — q^{k-1}(M)v != 0 => v cyclic (Bezout + dvd_prime_pow)",
+      "qkm1_ne_zero_of_cyclic: easy direction — cyclic => q^{k-1}(M)v != 0 (degree bound)",
+      "cyclic_iff_qkm1_ne_zero: sharp iff characterization"
+    ],
+    "insights": [
+      "IsCyclicVector v <=> M-order of v equals mu; for mu=q^k the order is q^j (j<=k) and equals mu iff q^{k-1} does not annihilate v",
+      "Bezout collapses an arbitrary annihilating p to d=gcd(p,mu); prime-power structure forces d ~ q^j (dvd_prime_pow), turning the unstructured hypothesis into clean divisibility",
+      "j=k is excluded because it forces mu=q^k | p, impossible for nonzero p of degree < deg mu (natDegree_le_of_dvd)",
+      "commutativity of aeval-images lets q^{k-1}=e*d be reordered so the known relation d(M)v=0 applies (map_mul + Matrix.mulVec_mulVec)",
+      "Irreducible.prime works in K[X] (DecompositionMonoid); Irreducible.natDegree_pos gives deg q > 0 for the degree bound"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Combine primary blocks via CRT/primary decomposition for arbitrary mu = prod q_i^{k_i}",
+      "Finite-field count of the prime-power block: |{0}^c \\ ker q^{k-1}(M)| = q^n - q^{n - deg q}",
+      "Relate ker q^{k-1}(M) to the socle / maximal submodule q*K[X]/(q^k) explicitly"
+    ],
+    "markdown": "# Knowledge: cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02\n\n## Session 2026-07-03 (Session 1) - Prime-power minimal polynomial case\n\n**Mode**: FRESH\n**Outcome**: completed (0 axioms, 0 sorries, verified)\n\n### What I Did\n- Formalized the cyclic-vector characterization for mu = q^k (q irreducible): v cyclic <-> q^{k-1}(M)v != 0.\n- Hard direction via the parent's Bezout lemma gcd_aeval_mulVec_eq_zero + dvd_prime_pow (divisors of q^k are associates of q^j, j<=k).\n- Easy direction via a natDegree bound on q^{k-1}.\n- Assembled the iff; built successfully under Docker; created gallery entry + annotations.\n\n### Key Findings\n- Generalizes sibling -oq-01: k=1 gives q^{k-1}=1, so the criterion collapses to v != 0.\n- Cyclic locus is {0}^c minus the proper subspace ker q^{k-1}(M).\n\n### Files Modified\n- proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean\n- src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/ (meta.json, annotations.json, index.ts)\n\n### Next Steps\n- CRT assembly for arbitrary minimal polynomials; finite-field count of the prime-power block.\n"
+  }
+}


### PR DESCRIPTION
## Summary

New gallery entry **cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02**: characterizes the cyclic vectors of a matrix whose minimal polynomial is a **prime power** μ = qᵏ (q irreducible) of full degree n.

**Result:** a vector `v` is cyclic for `M` **iff** `qᵏ⁻¹(M) v ≠ 0`.

This is the next rung of the primary-decomposition ladder after the irreducible base case handled by the parent and sibling `-oq-01`, and the **first case where "every nonzero vector is cyclic" fails**: the cyclic locus is the punctured space `{0}ᶜ` minus the proper subspace `ker qᵏ⁻¹(M)`. Setting `k = 1` gives `qᵏ⁻¹ = 1` and collapses the criterion to `cyclic ⟺ v ≠ 0`, exactly the sibling's result. It directly answers the open question stated in `-oq-01`.

## Theorems (3, verified — 0 axioms, 0 sorries)

`#print axioms` reports only `propext, Classical.choice, Quot.sound`.

- `cyclic_of_qkm1_ne_zero` (hard direction) — the parent's Bézout lemma `gcd_aeval_mulVec_eq_zero` sends `d = gcd(p, μ)` to an annihilator of `v`; `dvd_prime_pow` forces `d ~ qʲ` with `j ≤ k` (`j = k` would give `μ = qᵏ ∣ p`, impossible for nonzero `p` of degree `< deg μ`), hence `d ∣ qᵏ⁻¹` and `qᵏ⁻¹(M) v = 0`, contradiction.
- `qkm1_ne_zero_of_cyclic` (easy direction) — a degree count: `deg qᵏ⁻¹ = (k−1)·deg q < k·deg q = n`.
- `cyclic_iff_qkm1_ne_zero` — the sharp iff.

## Files

- `proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02.lean` (132 lines; imports the verified parent unchanged)
- `src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/` (meta.json, annotations.json, index.ts)
- `src/data/research/problems/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02.json`

## Verification

Built via `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ04BackwardIncomplete01OQ02` — completes successfully. Gallery registration confirmed (listings + manifest); `annotations:build` reports 0 errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)