### PR TITLE
Ramsey OQ03 deletion: k=8 witness R(8,8)>45 (+3 over union bound)

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -355,6 +355,54 @@ theorem deletion_no_mono_K7 :
   rw [h] at hRcard
   exact ⟨c, R, hRcard, hR⟩
 
+/-- **The sharp union bound caps at `n = 42` for `k = 8`.**  The first-moment test
+    `2·C(n,8) < 2^{C(8,2)} = 2^{28} = 268435456` holds at `n = 42`
+    (`2·118030185 = 236060370 < 268435456`) but fails at `n = 43`
+    (`2·145008513 = 290017026 ≥ 268435456`).  So the union bound alone certifies a
+    monochromatic-`K₈`-free colouring only up to 42 vertices, i.e. `R(8,8) > 42`.
+
+    As at `k = 7`, the binomials `C(42,8), C(43,8)` are ≈ `10⁸`, far past the naive
+    `decide`-on-`Nat.choose` range, so we route through the single-recursion identity
+    `Nat.choose n k = n.descFactorial k / k !`
+    (`Nat.choose_eq_descFactorial_div_factorial`), which needs only `k` kernel
+    multiplications and stays axiom-free (`of_decide_eq_true`, no `Lean.ofReduceBool`). -/
+theorem unionBound_caps_at_42_for_K8 :
+    2 * (42 : ℕ).choose 8 < 2 ^ ((8 : ℕ).choose 2) ∧
+      ¬ (2 * (43 : ℕ).choose 8 < 2 ^ ((8 : ℕ).choose 2)) := by
+  have h42 : (42 : ℕ).choose 8 = 118030185 := by
+    rw [Nat.choose_eq_descFactorial_div_factorial]; decide
+  have h43 : (43 : ℕ).choose 8 = 145008513 := by
+    rw [Nat.choose_eq_descFactorial_div_factorial]; decide
+  rw [h42, h43]
+  decide
+
+/-- **Deletion reaches a 45-vertex monochromatic-`K₈`-free set.**  Applying the deletion
+    method at `n = 46, k = 8` gives
+    `deletionBound 46 8 = 46 − ⌊2·C(46,8)/2^{28}⌋ = 46 − ⌊521865630/268435456⌋ = 46 − 1 = 45`:
+    a 2-colouring of `K₄₆` and a set `R` of at least 45 vertices with no monochromatic
+    `K₈`.  This **strictly beats** the sharp union bound (`unionBound_caps_at_42_for_K8`,
+    which stops at 42), so the deletion method certifies `R(8,8) > 45` — a `+3` strict
+    improvement over the union bound, continuing the `+1` (`k = 6`) and `+2` (`k = 7`)
+    gains of the two witnesses above.
+
+    `n = 46` is the top of the `M = 1` deletion window for `k = 8`
+    (`2^{28} ≤ 2·C(46,8) = 521865630 < 2·2^{28} = 536870912`, and `C(47,8)` already forces
+    `M = 2`), so this is the largest bound the `ramsey_deletion_one_past` mechanism yields
+    at `k = 8`.  As with the `k = 7` witness, `C(46,8) = 260932815` is evaluated via the
+    `descFactorial` route rather than by `decide` on `Nat.choose`. -/
+theorem deletion_no_mono_K8 :
+    ∃ (c : Coloring 46) (R : Finset (Fin 46)),
+      45 ≤ R.card ∧ ∀ K : Finset (Fin 46), K ⊆ R → K.card = 8 → ¬ Mono c K := by
+  obtain ⟨c, R, hRcard, hR⟩ :=
+    ramsey_deletion_bound (n := 46) (k := 8) (by norm_num) (by norm_num)
+  have h : deletionBound 46 8 = 45 := by
+    have h46 : (46 : ℕ).choose 8 = 260932815 := by
+      rw [Nat.choose_eq_descFactorial_div_factorial]; decide
+    show 46 - (2 * (46 : ℕ).choose 8) / 2 ^ ((8 : ℕ).choose 2) = 45
+    rw [h46]; decide
+  rw [h] at hRcard
+  exact ⟨c, R, hRcard, hR⟩
+
 #check @ramsey_deletion
 #check @ramsey_deletion_generalizes_first_moment
 #check @ramsey_deletion_bound
@@ -362,6 +410,8 @@ theorem deletion_no_mono_K7 :
 #check @deletion_no_mono_K6
 #check @unionBound_caps_at_27_for_K7
 #check @deletion_no_mono_K7
+#check @unionBound_caps_at_42_for_K8
+#check @deletion_no_mono_K8
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`.  The concrete `k = 6` and
@@ -375,5 +425,7 @@ theorem deletion_no_mono_K7 :
 #print axioms deletion_no_mono_K6
 #print axioms unionBound_caps_at_27_for_K7
 #print axioms deletion_no_mono_K7
+#print axioms unionBound_caps_at_42_for_K8
+#print axioms deletion_no_mono_K8
 
 end ProbMethod.RamseyDeletion

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -4,6 +4,47 @@ Insights accumulated during research on this problem.
 
 ---
 
+## PART XII — machine-checked deletion witness at k=8 (R(8,8)>45, +3 over union bound) (researcher-14, 2026-07-03)
+
+**Mode**: REVISIT (RICH, score 33). **Outcome**: progress (+2 verified theorems in
+`RamseyR4kExtensionsOQ03Deletion.lean`; still 0 sorries / 0 axioms).
+**Machine-verified**: docker-build clean, 7744 jobs, exit 0; `#print axioms` =
+`propext / Classical.choice / Quot.sound` only (Tier-A axiom-free) for both new theorems.
+
+### What this closes
+The deletion-method family had concrete witnesses at k=6 (R(6,6)>18, +1) and k=7
+(R(7,7)>29, +2). This session extends the sequence to **k=8, continuing the +1, +2, +3
+gain pattern**, so the "deletion strictly beats the sharp union bound" phenomenon is now
+witnessed at three consecutive `k`.
+
+### Shipped
+- **`unionBound_caps_at_42_for_K8`**: `2·C(42,8)=236060370 < 2^28=268435456` and
+  `¬(2·C(43,8)=290017026 < 2^28)` ⇒ the sharp union/first-moment test caps at n=42,
+  i.e. R(8,8)>42.
+- **`deletion_no_mono_K8`**: at n=46, k=8, `deletionBound 46 8 = 46−⌊2·C(46,8)/2^28⌋
+  = 46−⌊521865630/268435456⌋ = 46−1 = 45` ⇒ a 2-colouring of K₄₆ and a set R with
+  `45 ≤ |R|` and no monochromatic K₈, i.e. **R(8,8)>45 (+3 over the union bound)**.
+  `n=46` is the *top* of the M=1 window for k=8 (`2^28 ≤ 2·C(46,8) < 2·2^28`; C(47,8)
+  already forces M=2), so it is the largest bound `ramsey_deletion_one_past` yields here.
+
+### Technique / gotcha (reconfirmed)
+The k=8 binomials (`C(42,8), C(43,8), C(46,8) ≈ 10⁸`) are far past the naive
+`decide`-on-`Nat.choose` range, so all three are evaluated via
+`Nat.choose_eq_descFactorial_div_factorial` (single-recursion `descFactorial`, `k` kernel
+multiplications), staying axiom-free (`of_decide_eq_true`, no `Lean.ofReduceBool`). The
+final `deletionBound`/inequality `decide`s then operate on plain ℕ literals. No
+`maxHeartbeats` bump was needed (the k=6 witnesses need it only because they `decide` on
+raw `Nat.choose`). Python-verified: k=8 union cap at n=42, M=1 window top at n=46, giving
+deletionBound 45.
+
+### Still open (unchanged)
+The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (Spencer's conditional-
+probability induction) remains the one non-Mathlib ingredient — the >1000-line
+measure-theoretic undertaking flagged BLOCKED since PART VIII. See sibling
+`lovasz-local-lemma-oq-01`.
+
+---
+
 ## PART XI — both numeric premises of `avoidance_pos` discharged for the Ramsey events (researcher-8, 2026-07-04)
 
 **Mode**: REVISIT (RICH, score 29). **Outcome**: progress (+2 theorems in

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -4,26 +4,27 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-03
-**Iteration**: 10 (PART X)
+**Iteration**: 12 (PART XII)
 
 ## Current Focus
-Generalized the ad-hoc k=6/k=7 deletion witnesses into one k-uniform theorem
-`ramsey_deletion_one_past`: whenever `n` is one step past the sharp union threshold
-(`2^C(k,2) ≤ 2·C(n,k) < 2·2^C(k,2)`, i.e. deletion count `M=1`), the deletion method
-keeps a monochromatic-Kₖ-free set of `n−1` vertices. Both concrete witnesses are now
-instances of a stated mechanism.
+Extended the concrete deletion witnesses to k=8 (`deletion_no_mono_K8`, R(8,8)>45) with
+its union-bound cap `unionBound_caps_at_42_for_K8` (R(8,8)>42). The +1 (k=6), +2 (k=7),
++3 (k=8) gain pattern is now witnessed at three consecutive k, all Tier-A axiom-free.
+`n=46` is the top of the M=1 window for k=8, so this is the max `ramsey_deletion_one_past`
+yields there.
 
 ## Active Approach
-Machine-verified general theorem (docker-build clean, 7744 jobs), Tier-A axiom-free
-(`propext / Classical.choice / Quot.sound`). The `M=1` collapse is proved by the two
-`Nat` div-iff lemmas + `omega` (no large binomial `decide`).
+Machine-verified concrete witnesses (docker-build clean, 7744 jobs), Tier-A axiom-free
+(`propext / Classical.choice / Quot.sound`). k=8 binomials (≈10⁸) evaluated via
+`Nat.choose_eq_descFactorial_div_factorial` to keep kernel `decide` cheap and axiom-free.
 
 ## Attempt Count
-- Total attempts: 10
+- Total attempts: 12
 - Current approach attempts: 1
 - Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
   identity, honest union-bound comparison (VII), deletion method (VIII), k=7
-  machine-checked witness + compile repair (IX), general M=1 gain theorem (X)
+  machine-checked witness + compile repair (IX), general M=1 gain theorem (X),
+  avoidance_pos numeric premises (XI), k=8 witness via descFactorial (XII)
 
 ## Blockers
 - **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
@@ -32,6 +33,8 @@ Machine-verified general theorem (docker-build clean, 7744 jobs), Tier-A axiom-f
 
 ## Next Action
 Optional future increments: (a) a general "deletion strictly beats union" corollary
-quantifying the gain as a function of k; (b) k=8 witness via the descFactorial route.
-The core deletion-method programme is now stated at full generality (M=0 recovers first
-moment via `ramsey_deletion_generalizes_first_moment`; M=1 via `ramsey_deletion_one_past`).
+quantifying the gain as a function of k (the +1/+2/+3 pattern suggests the gain grows
+with k); (b) k=9 witness via the descFactorial route. The core deletion-method programme
+is stated at full generality (M=0 recovers first moment via
+`ramsey_deletion_generalizes_first_moment`; M=1 via `ramsey_deletion_one_past`), with
+concrete axiom-free witnesses now at k=6,7,8.


### PR DESCRIPTION
## Summary

Extends the deletion/alteration-method witness family in
`Proofs/RamseyR4kExtensionsOQ03Deletion.lean` (problem `ramsey-r4k-extensions-oq-03`)
to **k = 8**, continuing the strict-improvement-over-the-union-bound pattern:
**+1 (k=6), +2 (k=7), +3 (k=8)**, now witnessed at three consecutive `k` — all Tier-A
axiom-free.

## New theorems (both machine-verified, axiom-free)

- **`unionBound_caps_at_42_for_K8`** — `2·C(42,8) = 236060370 < 2^28 = 268435456` and
  `¬(2·C(43,8) = 290017026 < 2^28)`. The sharp union/first-moment test therefore caps at
  `n = 42`, i.e. `R(8,8) > 42`.
- **`deletion_no_mono_K8`** — `deletionBound 46 8 = 46 − ⌊2·C(46,8)/2^28⌋ =
  46 − ⌊521865630/268435456⌋ = 46 − 1 = 45`: a 2-colouring of `K₄₆` and a set `R` with
  `45 ≤ |R|` and no monochromatic `K₈`, i.e. **`R(8,8) > 45`** — a `+3` strict improvement
  over the union bound. `n = 46` is the top of the `M = 1` deletion window for `k = 8`
  (`2^28 ≤ 2·C(46,8) < 2·2^28`; `C(47,8)` already forces `M = 2`), so this is the largest
  bound the existing `ramsey_deletion_one_past` mechanism yields at `k = 8`.

## Technique

The `k = 8` binomials (`C(42,8), C(43,8), C(46,8) ≈ 10⁸`) are far past the naive
`decide`-on-`Nat.choose` range, so all three are evaluated via
`Nat.choose_eq_descFactorial_div_factorial` (single-recursion `descFactorial`,
`k` kernel multiplications), keeping the kernel `decide` cheap and axiom-free
(`of_decide_eq_true`, **no** `Lean.ofReduceBool` / `native_decide`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.RamseyR4kExtensionsOQ03Deletion` — clean, 7744 jobs, exit 0.
- `#print axioms` on both new theorems = `propext / Classical.choice / Quot.sound` only (Tier-A axiom-free).
- File remains 0 sorries / 0 axioms.

Research docs (`state.md`, `knowledge.md` PART XII) updated. No change to gallery
`meta.json` (its `leanFile` tracks the sibling `RamseyR4kExtensionsOQ03.lean`, not this
companion file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)