### PR TITLE
Research: laws-of-large-numbers-oq-01-oq-02-oq-01 — inclusive p-series tail leaf (MZ SLLN)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1065,13 +1065,55 @@ theorem tsum_shift_rpow_neg_le {s : ℝ} (hs : 1 < s) {N : ℕ} (hN : 1 ≤ N) :
   intro K
   exact sum_range_shift_rpow_neg_le hs hN K
 
+/-- **Inclusive tail bound for the real `p`-series.**  For `1 < s` and `N ≥ 1`,
+`∑_{j ≥ N} j^{-s} = ∑ₖ (k+N)^{-s} ≤ N^{1-s}·s/(s-1)`.  The inclusive-from-`N` companion of
+`tsum_shift_rpow_neg_le` (which starts the tail at `N+1`): splitting off the `j = N` term
+`N^{-s} ≤ N^{1-s}` and adding the shifted tail `N^{1-s}/(s-1)` combines to the constant
+`s/(s-1)`.  This is the shape the Tonelli interchange behind the MZ variance sum consumes after
+replacing the real threshold `|X|ᵖ` by `⌈|X|ᵖ⌉` (the inner tail starts at the ceiling, inclusive,
+not one past it). -/
+theorem tsum_ge_rpow_neg_le {s : ℝ} (hs : 1 < s) {N : ℕ} (hN : 1 ≤ N) :
+    ∑' k : ℕ, ((k + N : ℕ) : ℝ) ^ (-s) ≤ (N : ℝ) ^ (1 - s) * s / (s - 1) := by
+  have hNR : (1 : ℝ) ≤ (N : ℝ) := by exact_mod_cast hN
+  have hs1 : (0 : ℝ) < s - 1 := by linarith
+  refine Real.tsum_le_of_sum_range_le (fun k => Real.rpow_nonneg (by positivity) _) ?_
+  intro K
+  -- Partial sum ≤ the `j = N` term plus the shifted tail (adding the missing `(K+N)`-th term).
+  have hstep : ∑ k ∈ Finset.range K, ((k + N : ℕ) : ℝ) ^ (-s)
+      ≤ (N : ℝ) ^ (-s) + ∑ k ∈ Finset.range K, ((k + N + 1 : ℕ) : ℝ) ^ (-s) := by
+    have hsub : ∑ k ∈ Finset.range K, ((k + N : ℕ) : ℝ) ^ (-s)
+        ≤ ∑ k ∈ Finset.range (K + 1), ((k + N : ℕ) : ℝ) ^ (-s) := by
+      rw [Finset.sum_range_succ]
+      have : (0 : ℝ) ≤ ((K + N : ℕ) : ℝ) ^ (-s) := Real.rpow_nonneg (by positivity) _
+      linarith
+    refine hsub.trans (le_of_eq ?_)
+    rw [Finset.sum_range_succ', add_comm]
+    congr 1
+    · norm_num
+    · refine Finset.sum_congr rfl (fun k _ => ?_)
+      congr 1
+      push_cast; ring
+  refine hstep.trans ?_
+  have htail := sum_range_shift_rpow_neg_le hs hN K
+  have hNs : (N : ℝ) ^ (-s) ≤ (N : ℝ) ^ (1 - s) :=
+    Real.rpow_le_rpow_of_exponent_le hNR (by linarith)
+  have hcomb : (N : ℝ) ^ (1 - s) + (N : ℝ) ^ (1 - s) / (s - 1)
+      = (N : ℝ) ^ (1 - s) * s / (s - 1) := by
+    field_simp
+    ring
+  calc (N : ℝ) ^ (-s) + ∑ k ∈ Finset.range K, ((k + N + 1 : ℕ) : ℝ) ^ (-s)
+      ≤ (N : ℝ) ^ (1 - s) + (N : ℝ) ^ (1 - s) / (s - 1) := add_le_add hNs htail
+    _ = (N : ℝ) ^ (1 - s) * s / (s - 1) := hcomb
+
 #check @sum_range_shift_rpow_neg_le
 #check @tsum_shift_rpow_neg_le
+#check @tsum_ge_rpow_neg_le
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
 #print axioms sum_range_shift_rpow_neg_le
 #print axioms tsum_shift_rpow_neg_le
+#print axioms tsum_ge_rpow_neg_le
 
 end TailPSeries
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -6,6 +6,43 @@
 
 ---
 
+## Session 2026-07-04 (researcher-8) — S4b tail leaf: inclusive-from-N p-series bound (DEEP DIVE, PROGRESS)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress — new leaf `tsum_ge_rpow_neg_le` appended to
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (0 sorries, 0 `axiom`; docker build
+**succeeded, 7743 jobs**; `#print axioms` = `propext / Classical.choice / Quot.sound` only).
+
+### What it adds
+The Tonelli interchange behind the MZ variance sum `∑ᵢ Var(Yᵢ)/i^{2/p}` (`s := 2/p > 1`) keeps
+the truncated moment `𝔼[X²·𝟙{|X|ᵖ ≤ i}]` intact and sums the weight `i^{-s}` against it. After
+replacing the real threshold `|X|ᵖ` by `⌈|X|ᵖ⌉ =: N`, the inner deterministic factor is the tail
+`∑_{j ≥ N} j^{-s}` — starting **at** `N` (inclusive), not one past it. The existing backbone
+`tsum_shift_rpow_neg_le` bounds only the *exclusive* tail `∑_{j > N} j^{-s} ≤ N^{1-s}/(s-1)`.
+
+`tsum_ge_rpow_neg_le` supplies the inclusive companion:
+`∑ₖ (k+N)^{-s} = ∑_{j ≥ N} j^{-s} ≤ N^{1-s}·s/(s-1)` for `1 < s`, `N ≥ 1`. Proof: split off the
+`j = N` term (`N^{-s} ≤ N^{1-s}` by `rpow_le_rpow_of_exponent_le`, since `N ≥ 1` and `-s ≤ 1-s`)
+and add the exclusive tail `N^{1-s}/(s-1)`; the two combine to the constant `s/(s-1)`. The partial
+sums are bounded uniformly (via `Real.tsum_le_of_sum_range_le`, reusing `sum_range_shift_rpow_neg_le`).
+
+### Honest status
+A small, correct, reusable **arithmetic leaf**, NOT the variance-sum assembly itself. It is exactly
+the shape the Tonelli step consumes (inclusive tail at the ceiling threshold), removing an off-by-one
+gap between the existing exclusive backbone and the interchange. The substantive open work — the
+`∑'ᵢ`–`∫` Tonelli interchange assembling `∑ᵢ Var(Yᵢ)/i^{2/p} ≤ C·𝔼|X|ᵖ`, then step-3 centering and
+the final MZ combination via `ae_tendsto_average_zero_of_variance_weighted_bdd` — remains.
+
+### Next steps (unchanged frontier)
+- Tonelli interchange: `∑ᵢ i^{-s}·𝔼[X²·𝟙{|X|ᵖ ≤ i}] = 𝔼[X²·∑_{i ≥ |X|ᵖ} i^{-s}]`; bound the inner
+  tail with `tsum_ge_rpow_neg_le` at `N = ⌈|X|ᵖ⌉`, giving `≤ C·𝔼[X²·|X|^{p-2}] = C·𝔼|X|ᵖ`.
+- Step-3 centering (`integral_tail_abs_le` at `t = i^{1/p}`) → null sequence via dominated convergence.
+- Final MZ combination.
+
+---
+
+
+---
+
 ## S1 (researcher-14, 2026-07-02) — OBSERVE/ORIENT survey (text-only)
 
 Goal of this session: pin down the *exact* formal target, map what Mathlib

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 9): shipped the tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (tsum_shift_rpow_neg_le, 0-axiom VERIFIED) — the correct arithmetic backbone of the MZ variance sum. Corrected the prior per-term plan (which diverges as ∑ i^{-1}) to a Tonelli interchange. Remaining: the Tonelli assembly of the variance sum, step-3 centering, and final MZ combination.",
+    "progressSummary": "PROGRESS (iter 10, researcher-8): added the inclusive-from-N tail leaf tsum_ge_rpow_neg_le (∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1), 0-axiom, build 7743 jobs), the exact deterministic shape the MZ variance-sum Tonelli interchange consumes at N=⌈|X|ᵖ⌉ — closing the off-by-one gap vs the exclusive backbone tsum_shift_rpow_neg_le. Remaining: the ∑ᵢ–𝔼 Tonelli assembly of ∑ᵢVar(Yᵢ)/i^{2/p}≤C·𝔼|X|ᵖ (bounding the inner tail with this leaf), step-3 centering, and the final MZ combination.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -42,7 +42,8 @@
       "abs_le_rpow_mul_rpow_of_tail (§ TruncationMomentKernels) — step-3 centering kernel: 1<=p, 0<t, t<|x| => |x| <= t^(1-p)*|x|^p. Proof: rpow_add split |x|=|x|^p*|x|^(1-p) then Real.rpow_le_rpow_of_nonpos (1-p<=0). Verified 0-axiom.",
       "sq_le_rpow_mul_rpow_of_trunc (§ TruncationMomentKernels) — step-4 variance kernel: p<2, 0<t, |x|<=t => x^2 <= t^(2-p)*|x|^p. Proof: x=0 nonneg; else rpow_add split x^2=|x|^p*|x|^(2-p) (via rpow_natCast+sq_abs) then Real.rpow_le_rpow (0<=2-p). Verified 0-axiom.",
       "sum_range_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): integral-comparison block bound ∑_{k<K}(k+N+1)^{-s} ≤ N^{1-s}/(s-1) for s>1, N≥1, uniform in K (via AntitoneOn.sum_le_integral_Ico + integral_rpow), 0-axiom VERIFIED",
-      "tsum_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (s>1), via Real.tsum_le_of_sum_range_le, 0-axiom VERIFIED — the deterministic backbone of the MZ variance sum"
+      "tsum_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (s>1), via Real.tsum_le_of_sum_range_le, 0-axiom VERIFIED — the deterministic backbone of the MZ variance sum",
+      "tsum_ge_rpow_neg_le (inclusive-from-N p-series tail bound ∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1)) in LawsOfLargeNumbersOQ01OQ02OQ01.lean; docker build 7743 jobs, 0-axiom (propext/Classical.choice/Quot.sound only)."
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -65,7 +66,8 @@
       "INTEGRAL LIFTS SHIPPED (researcher-8 2026-07-03/04, VERIFIED): the two truncation-moment kernels are now lifted to the expectation level in § TruncationIntegralLifts of LawsOfLargeNumbersOQ01OQ02OQ01.lean. integral_trunc_sq_le (step 4, p<2): ∫(𝟙{|X|≤t}·X)² ≤ t^(2-p)·∫|X|^p; integral_tail_abs_le (step 3, 1≤p): ∫𝟙{t<|X|}·|X| ≤ t^(1-p)·∫|X|^p. Both via integral_mono_of_nonneg (needs integrability only of the dominating side t^(k)|X|^p = hint.const_mul; the truncated integrand may be non-integrable on infinite μ and is absorbed). Pure measure theory over arbitrary μ — no probability/independence/finiteness. docker-build Proofs.LawsOfLargeNumbersOQ01OQ02OQ01 → Built (7743 jobs, 42s, exit 0); #print axioms = [propext, Classical.choice, Quot.sound] only. These discharge the pointwise→integral gap in nextSteps; remaining is instantiating t=i^(1/p) and summing (step-4: Real.summable_one_div_nat_rpow with 2/p>1; step-3: tendsto_weighted_average_zero) then S5 assembly.",
       "CORRECTION: the MZ variance sum ∑ᵢ Var(Yᵢ)/i^{2/p} does NOT close by a per-term kernel bound. 𝔼[Yᵢ²] ≤ i^{(2-p)/p}·M divided by aᵢ²=i^{2/p} gives M·i^{-1}, and ∑ i^{-1} diverges. integral_trunc_sq_le is valid but not term-by-term summable.",
       "The correct variance-sum route is a Tonelli interchange: ∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}] = 𝔼[X²·∑_{i≥|X|ᵖ} i^{-2/p}] ≤ C·𝔼[X²·|X|^{p-2}] = C·𝔼|X|ᵖ. The inner tail is bounded by tsum_shift_rpow_neg_le with s=2/p.",
-      "Mathlib's Analysis/PSeries supplies only summability (summable_nat_rpow_inv), not the quantitative tail ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1); the latter is built here by integral comparison (AntitoneOn.sum_le_integral_Ico against ∫ x^{-s}=x^{1-s}/(1-s))."
+      "Mathlib's Analysis/PSeries supplies only summability (summable_nat_rpow_inv), not the quantitative tail ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1); the latter is built here by integral comparison (AntitoneOn.sum_le_integral_Ico against ∫ x^{-s}=x^{1-s}/(1-s)).",
+      "The Tonelli interchange for ∑ᵢVar(Yᵢ)/i^{2/p} needs the INCLUSIVE tail ∑_{j≥N}j^{-s} at N=⌈|X|ᵖ⌉ (inner sum starts AT the ceiling), but the existing backbone tsum_shift_rpow_neg_le bounds only the EXCLUSIVE tail ∑_{j>N}j^{-s}. tsum_ge_rpow_neg_le closes this off-by-one: ∑ₖ(k+N)^{-s} ≤ N^{1-s}·s/(s-1) for s>1, N≥1, by splitting off the j=N term (N^{-s}≤N^{1-s}) and adding the exclusive tail N^{1-s}/(s-1)."
     ],
     "mathlibGaps": [
       "No quantitative p-series tail bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) in Mathlib (only summability). Supplied locally as tsum_shift_rpow_neg_le."
@@ -99,7 +101,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.191Z",
-  "lastUpdate": "2026-07-03",
+  "lastUpdate": "2026-07-04T06:37:27Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -268,5 +270,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean"
     }
-  ]
+  ],
+  "lastVerified": "2026-07-04T06:37:27Z"
 }


### PR DESCRIPTION
## Summary
Research session for `laws-of-large-numbers-oq-01-oq-02-oq-01` (**Marcinkiewicz–Zygmund SLLN in Lean 4**). Adds the inclusive-from-`N` tail bound for the real `p`-series — the deterministic input the MZ variance-sum Tonelli interchange consumes.

## What it adds — `tsum_ge_rpow_neg_le` in `LawsOfLargeNumbersOQ01OQ02OQ01.lean`
For `1 < s` and `N ≥ 1`:
```
∑_{j ≥ N} j^{-s} = ∑ₖ (k+N)^{-s} ≤ N^{1-s}·s/(s-1)
```

The MZ variance sum `∑ᵢ Var(Yᵢ)/i^{2/p}` (`s := 2/p > 1`) is finite via a Tonelli interchange of `∑ᵢ` and `𝔼` that keeps the truncated moment `𝔼[X²·𝟙{|X|ᵖ ≤ i}]` intact and sums the weight `i^{-s}` against it. After replacing the real threshold `|X|ᵖ` by `N = ⌈|X|ᵖ⌉`, the inner factor is the tail `∑_{j ≥ N} j^{-s}` — starting **at** `N` (inclusive).

The existing backbone `tsum_shift_rpow_neg_le` bounds only the **exclusive** tail `∑_{j > N} j^{-s} ≤ N^{1-s}/(s-1)`. This leaf closes the off-by-one: split off the `j = N` term (`N^{-s} ≤ N^{1-s}` by `rpow_le_rpow_of_exponent_le`) and add the exclusive tail; the constants combine to `s/(s-1)`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` — **Build succeeded (7743 jobs)**.
- 0 sorries, 0 `axiom` declarations; `#print axioms tsum_ge_rpow_neg_le` = `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`, no `decide`).

## Honest status
A small, correct, reusable **arithmetic leaf**, NOT the variance-sum assembly. It removes the off-by-one gap between the existing exclusive backbone and the interchange. The substantive open work remains: the `∑ᵢ`–`𝔼` Tonelli interchange assembling `∑ᵢ Var(Yᵢ)/i^{2/p} ≤ C·𝔼|X|ᵖ`, step-3 centering, and the final MZ combination.

## Outcome
**progress** (DEEP DIVE) — one build-verified 0-axiom leaf on the critical path; knowledge base and problem JSON updated.

🤖 Generated by researcher-8