### PR TITLE
Research: erdos-1-wip-01-oq-03 — Conway–Guy construction beats powers of two (decidable DSS criterion + cg4…cg8 witnesses)

### DIFF
--- a/proofs/Proofs/Erdos1Wip01OQ03.lean
+++ b/proofs/Proofs/Erdos1Wip01OQ03.lean
@@ -1,0 +1,166 @@
+/-
+  Erdős Problem #1 — WIP Extension, OQ03: The Conway–Guy Construction
+
+  Erdős #1 asks for the minimum possible largest element `f(n)` of a set of `n`
+  positive integers all of whose subset sums are distinct (a "Sidon-for-sums"
+  or *distinct-subset-sums* (DSS) set).
+
+  The trivial construction `{1, 2, 4, …, 2^(n-1)}` (formalized in
+  `Erdos1Wip01.lean` as `powers_of_two_has_dss`) shows `f(n) ≤ 2^(n-1)`.
+  Conway and Guy (1968) discovered a family that does **strictly better**: for
+  every `n ≥ 4` there is a DSS set of size `n` whose largest element is
+  *strictly below* `2^(n-1)`. Their sets are the difference sets of the
+  Conway–Guy sequence `a = 0, 1, 2, 4, 7, 13, 24, 44, 84, 161, …`
+  (OEIS A005318): the `n`-element set is `{a(n) − a(n−i) : 1 ≤ i ≤ n}`.
+
+  **What this file contributes.**
+
+  1. `hasDistinctSubsetSums_iff_image_card` — a *decidable* reformulation of the
+     DSS property: `A` has distinct subset sums iff the number of *distinct*
+     subset sums equals the number of subsets `2^|A|`. The bare definition
+     quantifies over all of `Finset ℕ`, so it is not decidable as written; this
+     lemma reduces it to an injectivity check on `A.powerset`, which `decide`
+     can settle for concrete `A`. This is reusable infrastructure for the whole
+     Erdős #1 family.
+
+  2. Explicit Conway–Guy witnesses `cg4 … cg8`, each verified by kernel
+     `decide` (no `native_decide`, hence no `Lean.ofReduceBool`): every one has
+     distinct subset sums, has the right cardinality, and has largest element
+     strictly below the powers-of-two bound `2^(n-1)`.
+
+  3. `conwayGuy_beats_powers_of_two` — the packaged statement that for each
+     `n ∈ {4,5,6,7,8}` there is an `n`-element DSS set with largest element
+     `< 2^(n-1)`, so the powers-of-two construction is *not* optimal.
+
+  **What remains open (the OQ).** Whether the Conway–Guy sets are *optimal*
+  (achieve `f(n)`) is known only for `n ≤ 10` (verified computationally) and is
+  open for `n ≥ 11`. Proving optimality — or even the `< 2^(n-1)` gap — for
+  *all* `n` requires the general recurrence `a(n+1) = 2a(n) − a(n−r)`,
+  `r = round(√(2n))`, whose subset-sum-distinctness has no known elementary
+  induction. This file certifies the phenomenon on explicit cases; the general
+  bound stays open.
+
+  References:
+  - Conway, Guy (1968): Solution of a problem of Erdős (the construction here)
+  - Erdős (1955): Problems in additive number theory
+  - Guy, Unsolved Problems in Number Theory, C8
+  - OEIS A005318
+-/
+
+import Proofs.Erdos1Problem
+import Mathlib
+
+open Finset
+
+-- The `decide` calls certifying distinct subset sums for the larger Conway–Guy
+-- witnesses (n = 7, 8) evaluate a powerset-image cardinality over 2ⁿ subsets,
+-- which exceeds the default elaboration recursion depth.
+set_option maxRecDepth 10000
+
+namespace Erdos1WIPOQ03
+
+/-! ═══════════════════════════════════════════════════════════════════════════
+PART I: A DECIDABLE CRITERION FOR DISTINCT SUBSET SUMS
+
+`hasDistinctSubsetSums A` is defined by a universal quantifier over *all*
+`Finset ℕ`, which is not decidable. We reduce it to injectivity of the
+subset-sum map on the (finite) powerset, which `decide` can evaluate.
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Decidable criterion for distinct subset sums.** `A` has distinct subset
+    sums iff the map `S ↦ ∑ S` is injective on `A.powerset`, equivalently iff
+    the number of *distinct* subset sums equals the number `2^|A|` of subsets.
+
+    The right-hand side is a `Finset` cardinality identity, hence decidable, so
+    concrete instances follow by `decide`. -/
+theorem hasDistinctSubsetSums_iff_image_card (A : Finset ℕ) :
+    hasDistinctSubsetSums A ↔
+      (A.powerset.image (fun S => S.sum id)).card = A.powerset.card := by
+  rw [Finset.card_image_iff]
+  constructor
+  · -- DSS ⇒ injective-on-powerset
+    intro h a ha b hb hab
+    exact h a b (Finset.mem_powerset.mp (Finset.mem_coe.mp ha))
+      (Finset.mem_powerset.mp (Finset.mem_coe.mp hb)) hab
+  · -- injective-on-powerset ⇒ DSS
+    intro h S T hS hT hST
+    exact h (Finset.mem_coe.mpr (Finset.mem_powerset.mpr hS))
+      (Finset.mem_coe.mpr (Finset.mem_powerset.mpr hT)) hST
+
+/-- Convenience form with the explicit `2^|A|` count of subsets. -/
+theorem hasDistinctSubsetSums_iff_card_pow (A : Finset ℕ) :
+    hasDistinctSubsetSums A ↔
+      (A.powerset.image (fun S => S.sum id)).card = 2 ^ A.card := by
+  rw [hasDistinctSubsetSums_iff_image_card, Finset.card_powerset]
+
+/-! ═══════════════════════════════════════════════════════════════════════════
+PART II: EXPLICIT CONWAY–GUY WITNESSES
+
+Each `cgN` is the `N`-element difference set of the Conway–Guy sequence
+`0,1,2,4,7,13,24,44,84,…`. We certify by kernel `decide` that each has distinct
+subset sums, the correct cardinality, and largest element strictly below the
+powers-of-two bound `2^(N-1)`.
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- Conway–Guy set of size 4: `{3,5,6,7}`, largest element `7 < 8 = 2^3`. -/
+def cg4 : Finset ℕ := {3, 5, 6, 7}
+/-- Conway–Guy set of size 5: `{6,9,11,12,13}`, largest element `13 < 16 = 2^4`. -/
+def cg5 : Finset ℕ := {6, 9, 11, 12, 13}
+/-- Conway–Guy set of size 6: `{11,17,20,22,23,24}`, largest element `24 < 32 = 2^5`. -/
+def cg6 : Finset ℕ := {11, 17, 20, 22, 23, 24}
+/-- Conway–Guy set of size 7: `{20,31,37,40,42,43,44}`, largest element `44 < 64 = 2^6`. -/
+def cg7 : Finset ℕ := {20, 31, 37, 40, 42, 43, 44}
+/-- Conway–Guy set of size 8: `{40,60,71,77,80,82,83,84}`, largest element `84 < 128 = 2^7`. -/
+def cg8 : Finset ℕ := {40, 60, 71, 77, 80, 82, 83, 84}
+
+-- Cardinalities.
+theorem cg4_card : cg4.card = 4 := by decide
+theorem cg5_card : cg5.card = 5 := by decide
+theorem cg6_card : cg6.card = 6 := by decide
+theorem cg7_card : cg7.card = 7 := by decide
+theorem cg8_card : cg8.card = 8 := by decide
+
+-- Distinct subset sums (via the decidable criterion).
+theorem cg4_dss : hasDistinctSubsetSums cg4 := by
+  rw [hasDistinctSubsetSums_iff_image_card]; decide
+theorem cg5_dss : hasDistinctSubsetSums cg5 := by
+  rw [hasDistinctSubsetSums_iff_image_card]; decide
+theorem cg6_dss : hasDistinctSubsetSums cg6 := by
+  rw [hasDistinctSubsetSums_iff_image_card]; decide
+theorem cg7_dss : hasDistinctSubsetSums cg7 := by
+  rw [hasDistinctSubsetSums_iff_image_card]; decide
+theorem cg8_dss : hasDistinctSubsetSums cg8 := by
+  rw [hasDistinctSubsetSums_iff_image_card]; decide
+
+-- Every element is below the powers-of-two bound `2^(n-1)`.
+theorem cg4_lt : ∀ x ∈ cg4, x < 2 ^ 3 := by decide
+theorem cg5_lt : ∀ x ∈ cg5, x < 2 ^ 4 := by decide
+theorem cg6_lt : ∀ x ∈ cg6, x < 2 ^ 5 := by decide
+theorem cg7_lt : ∀ x ∈ cg7, x < 2 ^ 6 := by decide
+theorem cg8_lt : ∀ x ∈ cg8, x < 2 ^ 7 := by decide
+
+/-! ═══════════════════════════════════════════════════════════════════════════
+PART III: THE POWERS-OF-TWO CONSTRUCTION IS NOT OPTIMAL
+
+For each `n ∈ {4,…,8}` there is an `n`-element DSS set all of whose elements are
+`< 2^(n-1)`. Since the powers-of-two set `{1,…,2^(n-1)}` attains the value
+`2^(n-1)`, the Conway–Guy set strictly improves on it.
+═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Conway–Guy beats powers of two.** For every `n ∈ {4,5,6,7,8}` there exists
+    a set `A` of `n` positive integers with distinct subset sums whose every
+    element is strictly below `2^(n-1)` — the value attained by the
+    powers-of-two construction. Hence powers-of-two is not optimal for these `n`. -/
+theorem conwayGuy_beats_powers_of_two :
+    ∀ n ∈ ({4, 5, 6, 7, 8} : Finset ℕ),
+      ∃ A : Finset ℕ, A.card = n ∧ hasDistinctSubsetSums A ∧
+        (∀ x ∈ A, 0 < x) ∧ (∀ x ∈ A, x < 2 ^ (n - 1)) := by
+  intro n hn
+  fin_cases hn
+  · exact ⟨cg4, cg4_card, cg4_dss, by decide, cg4_lt⟩
+  · exact ⟨cg5, cg5_card, cg5_dss, by decide, cg5_lt⟩
+  · exact ⟨cg6, cg6_card, cg6_dss, by decide, cg6_lt⟩
+  · exact ⟨cg7, cg7_card, cg7_dss, by decide, cg7_lt⟩
+  · exact ⟨cg8, cg8_card, cg8_dss, by decide, cg8_lt⟩
+
+end Erdos1WIPOQ03

--- a/research/problems/erdos-1-wip-01-oq-03/knowledge.md
+++ b/research/problems/erdos-1-wip-01-oq-03/knowledge.md
@@ -1,0 +1,64 @@
+# Knowledge Base: erdos-1-wip-01-oq-03
+
+**Problem**: Erdős #1 — Conway–Guy construction / optimality (WIP Extension OQ03)
+**Open question**: Is the Conway–Guy sequence optimal for large n? Known for n ≤ 10
+(OEIS A005318), open for n ≥ 11. Is there algebraic structure enabling a Lean
+formalization of its construction?
+
+---
+
+## Session 2026-07-03 (Session 1) — Decidable DSS criterion + Conway–Guy witnesses
+
+**Mode**: FRESH
+**Outcome**: progress (new verified entry)
+
+### What I Did
+
+1. Surveyed the Erdős #1 family. Existing infra (`Erdos1Wip01.lean`) proves the
+   powers-of-two upper bound `f(n) ≤ 2^(n-1)` via a superincreasing extension
+   lemma, but nothing certified the **Conway–Guy** improvement that beats it.
+2. Identified the tractable, honestly-scoped deliverable: the *optimality*
+   question is open (n ≥ 11), and even the general `< 2^(n-1)` gap needs the
+   Conway–Guy recurrence `a(n+1)=2a(n)−a(n−r)`, `r=round(√(2n))`, whose
+   subset-sum-distinctness has no known elementary induction (prior session on
+   `erdos-1-wip-01` flagged the recurrence as "unclear"). So I certified the
+   phenomenon on explicit cases and built reusable decidability infrastructure.
+3. Created `proofs/Proofs/Erdos1Wip01OQ03.lean` (0 sorries, 0 axioms):
+   - `hasDistinctSubsetSums_iff_image_card`: the bare DSS definition quantifies
+     over all `Finset ℕ` (not decidable); reduced it to injectivity of the
+     subset-sum map on `A.powerset`, i.e. `(A.powerset.image (·.sum id)).card =
+     A.powerset.card`. Decidable ⇒ concrete instances by `decide`.
+   - `hasDistinctSubsetSums_iff_card_pow`: same with explicit `2^|A|`.
+   - Explicit Conway–Guy witnesses `cg4…cg8` = difference sets of
+     `0,1,2,4,7,13,24,44,84`: `{3,5,6,7}`, `{6,9,11,12,13}`,
+     `{11,17,20,22,23,24}`, `{20,31,37,40,42,43,44}`,
+     `{40,60,71,77,80,82,83,84}`. Each certified DSS + card + all elements
+     `< 2^(n-1)` by kernel `decide` (NO native_decide, so axiom-free).
+   - `conwayGuy_beats_powers_of_two`: for n ∈ {4,…,8} there is an n-element DSS
+     set with every element `< 2^(n-1)` — powers-of-two is not optimal.
+
+### Key Findings
+
+- **DSS is decidable via powerset-image cardinality.** `Finset.card_image_iff`
+  turns "distinct subset sums" into an `InjOn` check on the powerset, which
+  `decide` evaluates in O(2^n) rather than the naive O(4^n) pair scan.
+- **Conway–Guy difference sets verified numerically** (Python) for n=4..9: all
+  DSS, all with max element < 2^(n-1) (7<8, 13<16, 24<32, 44<64, 84<128,
+  161<256). Chose n≤8 for kernel-`decide` feasibility (axiom-free). n=7,8 need
+  `set_option maxRecDepth 10000`.
+- **Optimality stays open.** A005318 optimality is only computationally known
+  for n ≤ 10; no algebraic proof for large n. Not attempted (genuinely open).
+
+### Files Modified
+
+- `proofs/Proofs/Erdos1Wip01OQ03.lean` (new)
+- `src/data/proofs/erdos-1-wip-01-oq-03/meta.json` (new gallery entry)
+
+### Next Steps
+
+- Formalize the Conway–Guy recurrence `a(n+1)=2a(n)−a(n−round(√(2n)))` as a Lean
+  `def` and attempt an inductive DSS proof for the general family (HARD/OPEN —
+  candidate for Aristotle on the concrete recurrence lemmas).
+- Push the decidable criterion into `Erdos1Wip01.lean` for reuse across OQ01–04.
+- Larger explicit witnesses (n=9,10) would need `native_decide` (adds
+  `Lean.ofReduceBool`) — only if an axiomatized variant is wanted.

--- a/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
@@ -1,0 +1,97 @@
+{
+  "id": "erdos-1-wip-01-oq-03",
+  "title": "Erdős #1: The Conway–Guy Construction Beats Powers of Two",
+  "slug": "erdos-1-wip-01-oq-03",
+  "description": "Erdős Problem #1 (distinct subset sums) asks for the minimum largest element f(n) of an n-element set of positive integers all of whose 2ⁿ subset sums are distinct. The trivial powers-of-two set {1,2,…,2^(n-1)} gives f(n) ≤ 2^(n-1); Conway and Guy (1968) discovered a family that does strictly better. This entry (1) proves a decidable reformulation of the distinct-subset-sums (DSS) property — the bare definition quantifies over all of Finset ℕ, but DSS holds iff the number of distinct subset sums equals 2ⁿ, an injectivity check on the powerset that `decide` can evaluate — and (2) uses it to machine-certify, by kernel `decide` (no native_decide, hence axiom-free), the explicit Conway–Guy difference-set witnesses cg4…cg8 = {3,5,6,7}, {6,9,11,12,13}, {11,17,20,22,23,24}, {20,31,37,40,42,43,44}, {40,60,71,77,80,82,83,84}. Each is DSS with largest element strictly below 2^(n-1) (7<8, 13<16, 24<32, 44<64, 84<128), so the powers-of-two construction is not optimal for n∈{4,…,8}.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-03",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1Wip01OQ03.lean",
+    "tags": [
+      "erdos",
+      "additive-combinatorics",
+      "subset-sums",
+      "distinct-subset-sums",
+      "conway-guy",
+      "extremal-combinatorics",
+      "decidability",
+      "combinatorics",
+      "number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results are fully machine-checked in Lean 4 with 0 sorries and 0 axiom declarations (only Mathlib's foundational propext/Classical.choice/Quot.sound). The distinct-subset-sums certifications use kernel `decide` — NOT `native_decide` — so the proofs do not depend on Lean.ofReduceBool. Imports Proofs.Erdos1Problem for the shared hasDistinctSubsetSums predicate.",
+    "lineCount": 166,
+    "theoremCount": 18,
+    "definitionCount": 5,
+    "dateAdded": "2026-07-03",
+    "originalContributions": [
+      "hasDistinctSubsetSums_iff_image_card: A has distinct subset sums iff (A.powerset.image (·.sum id)).card = A.powerset.card, i.e. the subset-sum map is injective on the powerset. Converts an undecidable ∀-over-Finset-ℕ definition into a decidable powerset cardinality identity — reusable infrastructure for the whole Erdős #1 family, letting concrete DSS claims be settled by `decide` in O(2ⁿ) rather than the naive O(4ⁿ) pair scan.",
+      "hasDistinctSubsetSums_iff_card_pow: the same criterion with the explicit count (A.powerset.image (·.sum id)).card = 2^|A| via Finset.card_powerset.",
+      "cg4…cg8: the explicit Conway–Guy difference sets of the sequence 0,1,2,4,7,13,24,44,84 (OEIS A005318), each certified DSS by kernel `decide`.",
+      "cg4_dss…cg8_dss: distinct-subset-sums certificates for sets of size 4–8, axiom-free (kernel `decide`, no ofReduceBool).",
+      "cg4_lt…cg8_lt: each Conway–Guy set has every element strictly below the powers-of-two bound 2^(n-1) (7<8, 13<16, 24<32, 44<64, 84<128).",
+      "conwayGuy_beats_powers_of_two: for every n∈{4,5,6,7,8} there is an n-element set of positive integers with distinct subset sums and every element < 2^(n-1) — the value attained by {1,…,2^(n-1)} — so the powers-of-two construction is not optimal for these n."
+    ],
+    "prerequisites": [
+      "Finset basics (Lean 4 / Mathlib): powerset, image, card",
+      "Finset.card_image_iff (image cardinality = injectivity on the source)",
+      "Decidability of bounded quantifiers over finsets",
+      "The distinct-subset-sums predicate from Erdos1Problem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1 (the \\$500 distinct-subset-sums problem, posed c. 1931) asks whether every n-element set A of positive integers with all 2ⁿ subset sums distinct must satisfy max(A) ≥ c·2ⁿ for an absolute constant c, and more precisely what the minimum possible largest element f(n) is. The powers-of-two set {1,2,4,…,2^(n-1)} is the obvious distinct-subset-sums (DSS) set and gives the upper bound f(n) ≤ 2^(n-1). In 1968 Conway and Guy found a construction that beats it: starting from the sequence a = 0,1,2,4,7,13,24,44,84,161,… (OEIS A005318, defined by a(n+1) = 2a(n) − a(n−r) with r = round(√(2n))), the n-element difference set {a(n) − a(n−i) : 1 ≤ i ≤ n} has distinct subset sums and largest element a(n) < 2^(n-1) for n ≥ 4. These sets are conjectured optimal; optimality is verified computationally for n ≤ 10 and open for n ≥ 11.",
+    "problemStatement": "Formalize and machine-verify the Conway–Guy phenomenon for explicit cases: exhibit, for small n, n-element sets of positive integers with distinct subset sums whose largest element is strictly below the powers-of-two bound 2^(n-1). Along the way, make the distinct-subset-sums property decidable so such witnesses can be certified by `decide` rather than by hand.",
+    "proofStrategy": "The predicate hasDistinctSubsetSums A := ∀ S T : Finset ℕ, S ⊆ A → T ⊆ A → ∑S = ∑T → S = T quantifies over all of Finset ℕ and is not decidable as written. The key lemma hasDistinctSubsetSums_iff_image_card rewrites it, via Finset.card_image_iff, as the statement that S ↦ ∑S is injective on A.powerset — equivalently that (A.powerset.image (·.sum id)).card = A.powerset.card. Membership in A.powerset is definitionally S ⊆ A, so the two forms are interchangeable; the right-hand side is a finite cardinality identity and hence decidable. Each Conway–Guy witness cgN is then given as an explicit Finset ℕ, and cgN_dss follows by rewriting with the criterion and calling kernel `decide` over its 2^N-element powerset image (maxRecDepth is raised for N = 7, 8). Cardinalities and the element bounds x < 2^(N-1) are likewise decided. The packaged theorem conwayGuy_beats_powers_of_two collects the five cases by fin_cases over the finset {4,5,6,7,8}.",
+    "keyInsights": [
+      "**Distinct subset sums is a decidable property — once you look at the powerset.** The definition ranges over all finsets of ℕ, so `decide` cannot touch it directly. But S ⊆ A is exactly S ∈ A.powerset, and injectivity of the sum map on the finite powerset is a cardinality identity (image.card = powerset.card). This single rewrite turns every concrete DSS question into a finite computation.",
+      "**Counting distinct sums beats checking all pairs.** The criterion phrases DSS as image.card = 2ⁿ, an O(2ⁿ) computation (build the finset of subset sums, compare its size to 2ⁿ), rather than the naive O(4ⁿ) scan over all pairs (S,T). This is what makes n = 8 (256 subsets) feasible for the kernel.",
+      "**Axiom-free by choosing kernel `decide` over `native_decide`.** native_decide would compile the check to native code but drags in the Lean.ofReduceBool axiom, disqualifying a 'verified' badge. Kernel `decide` reduces inside the trusted kernel, so cg4…cg8 are certified with no extra axioms; the price is bounding n by feasibility (n ≤ 8) and raising maxRecDepth.",
+      "**Conway–Guy beats the obvious construction, concretely.** {1,2,4,…,2^(n-1)} reaches 2^(n-1); the Conway–Guy difference sets reach only 24 at n=6 (vs 32), 44 at n=7 (vs 64), 84 at n=8 (vs 128). The gap widens with n, which is the whole point of the construction — superincreasing sets are not optimal.",
+      "**What stays open.** These are witnesses, not a general theorem. Proving the < 2^(n-1) gap for all n — let alone Conway–Guy optimality, open for n ≥ 11 — needs the general recurrence a(n+1) = 2a(n) − a(n−round(√(2n))) and an inductive proof of distinctness that no elementary argument is known to give. This entry certifies the phenomenon; it does not close the problem."
+    ],
+    "prerequisites": [
+      "Finset basics (Lean 4 / Mathlib): powerset, image, sum, card",
+      "The image-cardinality/injectivity correspondence Finset.card_image_iff",
+      "Decidability of bounded quantifiers and equalities over finsets",
+      "The distinct-subset-sums predicate hasDistinctSubsetSums from Erdos1Problem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring stating Erdős #1, the powers-of-two bound f(n) ≤ 2^(n-1), and the Conway–Guy difference-set construction that beats it. Imports Proofs.Erdos1Problem (for the shared hasDistinctSubsetSums predicate) and Mathlib, and raises maxRecDepth to 10000 for the n=7,8 decision procedures.",
+      "mathContext": "The Conway–Guy sequence 0,1,2,4,7,13,24,44,84,… (OEIS A005318) gives, as its n-element difference set, a DSS set of largest element < 2^(n-1) for n ≥ 4. Optimality is known only for n ≤ 10."
+    },
+    {
+      "id": "criterion",
+      "title": "Part I: A Decidable Criterion for Distinct Subset Sums",
+      "startLine": 63,
+      "endLine": 100,
+      "summary": "hasDistinctSubsetSums_iff_image_card reduces the ∀-over-all-finsets definition to injectivity of S ↦ ∑S on A.powerset, i.e. (A.powerset.image (·.sum id)).card = A.powerset.card, via Finset.card_image_iff plus Finset.mem_powerset/mem_coe bridging. hasDistinctSubsetSums_iff_card_pow restates the count as 2^|A|.",
+      "mathContext": "S ⊆ A ⇔ S ∈ A.powerset, and image.card = source.card ⇔ InjOn; combining gives a decidable equivalent of DSS that `decide` can evaluate in O(2ⁿ)."
+    },
+    {
+      "id": "witnesses",
+      "title": "Part II: Explicit Conway–Guy Witnesses",
+      "startLine": 102,
+      "endLine": 148,
+      "summary": "Definitions cg4…cg8 (the difference sets {3,5,6,7}, {6,9,11,12,13}, {11,17,20,22,23,24}, {20,31,37,40,42,43,44}, {40,60,71,77,80,82,83,84}) with their cardinalities (cgN_card), distinct-subset-sums certificates (cgN_dss, via the criterion + kernel `decide`), and element bounds cgN_lt : ∀ x ∈ cgN, x < 2^(n-1).",
+      "mathContext": "Each set is verified DSS by kernel reduction over its powerset image; the largest element is 7,13,24,44,84 against powers-of-two bounds 8,16,32,64,128."
+    },
+    {
+      "id": "not-optimal",
+      "title": "Part III: The Powers-of-Two Construction Is Not Optimal",
+      "startLine": 150,
+      "endLine": 166,
+      "summary": "conwayGuy_beats_powers_of_two: for every n ∈ {4,5,6,7,8} there is an n-element set of positive integers with distinct subset sums and every element < 2^(n-1). Proved by fin_cases over the finset, discharging each case with the corresponding cgN lemmas and a `decide` for positivity.",
+      "mathContext": "Since {1,2,…,2^(n-1)} attains 2^(n-1), the existence of a DSS set strictly under that bound shows the powers-of-two/superincreasing construction is suboptimal for these n."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes a self-contained, honestly-scoped component of **Erdős Problem #1** (distinct subset sums): the **Conway–Guy construction** beats the trivial powers-of-two bound for small `n`.

Erdős #1 asks for the minimum largest element `f(n)` of an `n`-element set of positive integers whose `2ⁿ` subset sums are all distinct (DSS). Powers-of-two `{1,2,…,2^(n-1)}` gives `f(n) ≤ 2^(n-1)`; Conway–Guy (1968) do strictly better.

This entry (`proofs/Proofs/Erdos1Wip01OQ03.lean`, 166 lines, **0 sorries, 0 axioms**):

1. **`hasDistinctSubsetSums_iff_image_card`** — a *decidable* reformulation of the DSS property. The bare definition quantifies over all of `Finset ℕ` (not decidable); this reduces it to injectivity of the subset-sum map on `A.powerset`, i.e. `(A.powerset.image (·.sum id)).card = A.powerset.card`, which `decide` settles for concrete `A`. Reusable infrastructure for the whole Erdős #1 family.
2. **Explicit Conway–Guy witnesses `cg4…cg8`** — difference sets of the sequence `0,1,2,4,7,13,24,44,84` (OEIS A005318): `{3,5,6,7}`, `{6,9,11,12,13}`, `{11,17,20,22,23,24}`, `{20,31,37,40,42,43,44}`, `{40,60,71,77,80,82,83,84}`. Each certified DSS with largest element strictly below `2^(n-1)` (7<8, 13<16, 24<32, 44<64, 84<128) by **kernel `decide`** — *not* `native_decide`, hence no `Lean.ofReduceBool`, fully axiom-free.
3. **`conwayGuy_beats_powers_of_two`** — packaged: for every `n∈{4,…,8}` there is an `n`-element positive-integer DSS set with every element `< 2^(n-1)`, so powers-of-two is not optimal for these `n`.

## What stays open (the OQ)

Whether Conway–Guy is *optimal* (`f(n)` exactly) is known only for `n ≤ 10` and open for `n ≥ 11`. Even the general `< 2^(n-1)` gap needs the recurrence `a(n+1)=2a(n)−a(n−r)`, `r=round(√(2n))`, whose subset-sum-distinctness has no known elementary induction. This file certifies the phenomenon on explicit cases; the general bound remains open.

## Verification

- Built successfully via `./proofs/scripts/docker-build.sh Proofs.Erdos1Wip01OQ03` → `✔ Built Proofs.Erdos1Wip01OQ03`.
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- Gallery entry: `src/data/proofs/erdos-1-wip-01-oq-03/meta.json` (status `verified`, badge `original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)