### PR TITLE
Research: MZ variance-sum Tonelli integrand bound (tsum_indicator_ge_rpow_neg_le)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1105,15 +1105,92 @@ theorem tsum_ge_rpow_neg_le {s : ℝ} (hs : 1 < s) {N : ℕ} (hN : 1 ≤ N) :
       ≤ (N : ℝ) ^ (1 - s) + (N : ℝ) ^ (1 - s) / (s - 1) := add_le_add hNs htail
     _ = (N : ℝ) ^ (1 - s) * s / (s - 1) := hcomb
 
+/-- **Pointwise inner-tail bound for the MZ variance sum (Tonelli integrand).**  For `1 < s` and
+any real `y`, the weighted tail of `i^{-s}` over the truncation region `{i : ℕ | y ≤ i}` is
+controlled by a single power of `max 1 y`:
+
+    ∑'_{i : y ≤ i} i^{-s} ≤ (max 1 y)^{1-s} · s/(s-1).
+
+This is the deterministic integrand bound the Tonelli interchange behind the MZ variance sum
+consumes.  After swapping `∑ᵢ` and `𝔼`, the inner `∑ᵢ` runs over the truncation region
+`{i | |X| ≤ i^{1/p}} = {i | |X|ᵖ ≤ i}`; with `y = |X|ᵖ`, `s = 2/p (> 1)` this bounds it by
+`(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)`, whose `|X| ≥ 1` branch is `|X|^{p-2}` — exactly the factor that,
+multiplied by `X²`, integrates to `𝔼|X|ᵖ` (the `|X| < 1` branch collapses to the constant
+`s/(s-1)`, integrable on a probability space).
+
+Proof: the region is `{i | ⌈y⌉₊ ≤ i}` (`Nat.ceil_le`); reindex the indicator tsum to the
+inclusive tail `∑' k, (k+⌈y⌉₊)^{-s}` (`Summable.sum_add_tsum_nat_add`, the head over
+`range ⌈y⌉₊` vanishing since the indicator is `0` below the threshold) and apply
+`tsum_ge_rpow_neg_le`, then dominate `⌈y⌉₊^{1-s} ≤ (max 1 y)^{1-s}` by antitonicity of `·^{1-s}`
+(`1 - s ≤ 0`, `max 1 y ≤ ⌈y⌉₊`).  The `⌈y⌉₊ = 0` (i.e. `y ≤ 0`) branch peels the vanishing
+`i = 0` term and reuses the `N = 1` tail. -/
+theorem tsum_indicator_ge_rpow_neg_le {s : ℝ} (hs : 1 < s) (y : ℝ) :
+    ∑' i : ℕ, {i : ℕ | y ≤ (i : ℝ)}.indicator (fun i => (i : ℝ) ^ (-s)) i
+      ≤ (max 1 y) ^ (1 - s) * s / (s - 1) := by
+  have hs1 : (0 : ℝ) < s - 1 := by linarith
+  have hexp : (1 : ℝ) - s ≤ 0 := by linarith
+  have hf_summ : Summable (fun i : ℕ => (i : ℝ) ^ (-s)) :=
+    Real.summable_nat_rpow.mpr (by linarith)
+  set N : ℕ := ⌈y⌉₊ with hN
+  -- rewrite the truncation region `{i | y ≤ i}` as `{i | N ≤ i}`
+  have hset : {i : ℕ | y ≤ (i : ℝ)} = {i : ℕ | N ≤ i} := by
+    ext i; simp only [Set.mem_setOf_eq]; rw [hN]; exact Nat.ceil_le.symm
+  rw [hset]
+  -- reindex the indicator tsum to the inclusive tail `∑' k, (k + N)^{-s}`
+  have hind_summ : Summable ({i : ℕ | N ≤ i}.indicator (fun i : ℕ => (i : ℝ) ^ (-s))) :=
+    hf_summ.indicator _
+  have hhead : ∑ i ∈ Finset.range N,
+      {i : ℕ | N ≤ i}.indicator (fun i : ℕ => (i : ℝ) ^ (-s)) i = 0 := by
+    apply Finset.sum_eq_zero
+    intro i hi
+    rw [Finset.mem_range] at hi
+    exact Set.indicator_of_notMem (by simp only [Set.mem_setOf_eq]; omega) _
+  have hshift := hind_summ.sum_add_tsum_nat_add N
+  rw [hhead, zero_add] at hshift
+  have hreidx : (∑' i, {i : ℕ | N ≤ i}.indicator (fun i : ℕ => (i : ℝ) ^ (-s)) (i + N))
+      = ∑' i : ℕ, ((i + N : ℕ) : ℝ) ^ (-s) := by
+    refine tsum_congr (fun i => ?_)
+    rw [Set.indicator_of_mem (by simp only [Set.mem_setOf_eq]; omega)]
+  rw [hreidx] at hshift
+  rw [← hshift]
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · -- `N = 0` : `y ≤ 0`, so `max 1 y = 1` and the bound is `s/(s-1)`
+    have hy0 : y ≤ 0 := Nat.ceil_eq_zero.mp (hN.symm.trans hN0)
+    have hmax : max 1 y = 1 := max_eq_left (by linarith)
+    rw [hmax, Real.one_rpow, one_mul, hN0]
+    have hz0 : ((0 : ℕ) : ℝ) ^ (-s) = 0 := by
+      rw [Nat.cast_zero, Real.zero_rpow (by linarith : -s ≠ 0)]
+    calc ∑' i : ℕ, ((i + 0 : ℕ) : ℝ) ^ (-s)
+        = ∑' i : ℕ, (i : ℝ) ^ (-s) := by norm_num
+      _ = ((0 : ℕ) : ℝ) ^ (-s) + ∑' k : ℕ, ((k + 1 : ℕ) : ℝ) ^ (-s) := hf_summ.tsum_eq_zero_add
+      _ = ∑' k : ℕ, ((k + 1 : ℕ) : ℝ) ^ (-s) := by rw [hz0, zero_add]
+      _ ≤ s / (s - 1) := by
+          have h := tsum_ge_rpow_neg_le hs (le_refl 1)
+          rwa [Nat.cast_one, Real.one_rpow, one_mul] at h
+  · -- `N ≥ 1`
+    refine (tsum_ge_rpow_neg_le hs hNpos).trans ?_
+    have hx : (0 : ℝ) < max 1 y := lt_of_lt_of_le zero_lt_one (le_max_left 1 y)
+    have hxy : max 1 y ≤ (N : ℝ) :=
+      max_le (by exact_mod_cast hNpos) (by rw [hN]; exact Nat.le_ceil y)
+    have hpow : (N : ℝ) ^ (1 - s) ≤ (max 1 y) ^ (1 - s) :=
+      Real.rpow_le_rpow_of_nonpos hx hxy hexp
+    have hfac : (0 : ℝ) ≤ s / (s - 1) := div_nonneg (by linarith) (by linarith)
+    calc (N : ℝ) ^ (1 - s) * s / (s - 1)
+        = (N : ℝ) ^ (1 - s) * (s / (s - 1)) := by ring
+      _ ≤ (max 1 y) ^ (1 - s) * (s / (s - 1)) := mul_le_mul_of_nonneg_right hpow hfac
+      _ = (max 1 y) ^ (1 - s) * s / (s - 1) := by ring
+
 #check @sum_range_shift_rpow_neg_le
 #check @tsum_shift_rpow_neg_le
 #check @tsum_ge_rpow_neg_le
+#check @tsum_indicator_ge_rpow_neg_le
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
 #print axioms sum_range_shift_rpow_neg_le
 #print axioms tsum_shift_rpow_neg_le
 #print axioms tsum_ge_rpow_neg_le
+#print axioms tsum_indicator_ge_rpow_neg_le
 
 end TailPSeries
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -590,3 +590,53 @@ then S5 assembly through `ae_tendsto_average_zero_of_variance_weighted_bdd`.
 - proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (new § TruncationIntegralLifts)
 - src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json (leanFiles + knowledge)
 - research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md (this entry)
+
+---
+
+## Iter 11 (researcher-8, 2026-07-04) — BUILD: Tonelli integrand bound (pointwise inner-tail) SHIPPED & VERIFIED
+
+The **pointwise inner-tail bound** the MZ variance-sum Tonelli interchange consumes is now in
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TailPSeries), 0-sorry / 0-`axiom`
+(`#print axioms` = propext/Classical.choice/Quot.sound — no `sorryAx`, no `Lean.ofReduceBool`).
+Verified via `docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built (7743 jobs, exit 0)**.
+
+- `tsum_indicator_ge_rpow_neg_le {s} (hs : 1 < s) (y : ℝ)` —
+  `∑' i, {i | y ≤ (i:ℝ)}.indicator (fun i => (i:ℝ)^(-s)) i ≤ (max 1 y)^(1-s)·s/(s-1)`.
+  This is the shape produced by the `∑ᵢ`–`𝔼` interchange: after swapping, the inner `∑ᵢ` runs
+  over the truncation region `{i | |X| ≤ i^{1/p}} = {i | |X|ᵖ ≤ i}`, and with `y = |X|ᵖ`,
+  `s = 2/p` it is bounded by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)`, whose `|X| ≥ 1` branch is
+  `|X|^{p-2}` — the factor that multiplied by `X²` integrates to `𝔼|X|ᵖ`.
+
+### Proof structure (reusable)
+
+1. The truncation region `{i | y ≤ (i:ℝ)}` equals `{i | ⌈y⌉₊ ≤ i}` by `Nat.ceil_le`.
+2. Reindex the indicator tsum to the **inclusive tail** `∑' k, (k+⌈y⌉₊)^{-s}` via
+   `Summable.sum_add_tsum_nat_add ⌈y⌉₊` — the head `∑_{i<⌈y⌉₊}` of the indicator vanishes
+   (`Set.indicator_of_notMem` below threshold), and the shifted body `indicator (i+N) = (i+N)^{-s}`
+   (`Set.indicator_of_mem`, `N ≤ i+N`). Then apply the iter-10 leaf `tsum_ge_rpow_neg_le`.
+3. Dominate `⌈y⌉₊^{1-s} ≤ (max 1 y)^{1-s}` by `Real.rpow_le_rpow_of_nonpos` (antitone, `1-s ≤ 0`,
+   `max 1 y ≤ ⌈y⌉₊` from `Nat.le_ceil` + `⌈y⌉₊ ≥ 1`).
+4. `⌈y⌉₊ = 0` (⇔ `y ≤ 0`, `Nat.ceil_eq_zero`) branch: `max 1 y = 1`, bound `= s/(s-1)`; peel the
+   vanishing `i=0` term with `Summable.tsum_eq_zero_add` (`0^{-s}=0`, `Real.zero_rpow`) and reuse
+   `tsum_ge_rpow_neg_le` at `N=1`.
+
+### Reusable Lean gotchas (Mathlib v4.26)
+
+- **`Set.indicator_of_not_mem` is deprecated** (2025-05-23) → use `Set.indicator_of_notMem` (camelCase).
+- The additive of `Multipliable.prod_mul_tprod_nat_add` is **`Summable.sum_add_tsum_nat_add k h`**
+  (`(∑ i∈range k, f i) + ∑' i, f(i+k) = ∑' i, f i`) — the clean way to reindex an indicator tsum
+  to a shifted tail without fighting `Function.Injective.tsum_eq` (which does not exist by that name).
+- `Real.summable_nat_rpow.mpr (h : p < -1) : Summable (fun n => (n:ℝ)^p)`; `Summable.indicator _`
+  lifts it to the indicator. `Summable.tsum_eq_zero_add : ∑' b, f b = f 0 + ∑' b, f(b+1)`.
+- `Nat.ceil_le : ⌈a⌉₊ ≤ n ↔ a ≤ n`; `Nat.le_ceil : a ≤ ⌈a⌉₊`; `Nat.ceil_eq_zero : ⌈a⌉₊ = 0 ↔ a ≤ 0`.
+
+### Honest status
+
+A genuine, complete, verified brick — the exact deterministic integrand bound flagged as the
+Tonelli input. It does **not** yet prove Marcinkiewicz–Zygmund: the surviving work is the
+measure-theoretic `∑'`–`∫` interchange itself (`lintegral_tsum`, nonneg + measurability), which
+plugs this bound into `𝔼[X²·(inner tail)]` and integrates to `C·𝔼|X|ᵖ`, yielding
+`∑ᵢ Var(Yᵢ)/i^{2/p} < ∞` for `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5); then step-3
+centering and the final combination. Worked in external home-dir worktree `/Users/rwalters/lg-r8-mz-tonelli`
+(build FROM the worktree with `LEAN_SKIP_CACHE=true`, hardlinked `proofs/.lake/packages`), committed
+before building.

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 *arithmetic backbone* — tail p-series bound SHIPPED & VERIFIED — remaining: Tonelli interchange + assembly)
+**Phase**: ACT (S4b step-4 *Tonelli integrand bound* — pointwise inner-tail bound SHIPPED & VERIFIED — remaining: the ∑ᵢ–𝔼 interchange itself + assembly)
 **Since**: 2026-07-04
-**Iteration**: 9 (S4b step-4 tail p-series bound `∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1)` SHIPPED & build-VERIFIED; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 11 (S4b step-4 pointwise inner-tail bound `tsum_indicator_ge_rpow_neg_le` `∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1)` SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -109,22 +109,26 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 
 ## Next Action
 
-- **S4b step-4, the arithmetic backbone is now DONE (iteration 9):** `tsum_shift_rpow_neg_le`
-  supplies `∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1)` (`s>1`) — exactly the tail estimate the interchange
-  needs with `s = 2/p`, `N ≈ |X|ᵖ`. **Do not re-derive it.**
-- **Next: assemble the variance sum via Tonelli.** Use `MeasureTheory.lintegral_tsum` /
-  `∑'`-`∫` interchange (nonneg) to turn `∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}]` into
-  `𝔼[X²·∑_{i≥|X|ᵖ} i^{-2/p}]`, bound the inner tail with `tsum_shift_rpow_neg_le`
-  (note `∑_{i≥|X|ᵖ} i^{-2/p} ≤ C·(|X|ᵖ)^{1-2/p} = C·|X|^{p-2}` for `|X|≥1`; handle `|X|<1` by
-  the full `ζ(2/p)` constant), then integrate to `C·𝔼|X|ᵖ`. This yields
-  `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5).
+- **S4b step-4 Tonelli integrand bound is now DONE (iteration 11):** `tsum_indicator_ge_rpow_neg_le`
+  supplies `∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1)` (`s>1`) — the inner-tail bound the
+  interchange consumes with `y = |X|ᵖ`, `s = 2/p`. Built on iter-10 `tsum_ge_rpow_neg_le`
+  (inclusive tail) via a ceiling reindex (`Nat.ceil_le` + `Summable.sum_add_tsum_nat_add`) and
+  rpow antitonicity, `y≤0` edge case peeled. **Do not re-derive it.**
+- **Next: the ∑ᵢ–𝔼 Tonelli interchange itself.** Use `MeasureTheory.lintegral_tsum` /
+  `∑'`-`∫` interchange (nonneg, measurability side-goals) to turn `∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}]`
+  into `𝔼[X²·∑ᵢ i^{-2/p}𝟙{|X|≤i^{1/p}}]`; the inner sum is **exactly**
+  `tsum_indicator_ge_rpow_neg_le` at `y=|X|ᵖ`, `s=2/p` (via `|X|≤i^{1/p} ↔ |X|ᵖ≤i`, the rpow
+  reindex `rpow_inv_lt_iff_lt_rpow` / a `≤` companion). Then `(max 1 |X|ᵖ)^{1-2/p}`: `|X|≥1`
+  branch `=|X|^{p-2}` so `X²·bound=|X|^p`; `|X|<1` branch `=` const. Integrate to `C·(𝔼|X|ᵖ+1)`.
+  This yields `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, feeding `ae_tendsto_average_zero_of_variance_weighted_bdd`
+  (S5). Watch the `ha_pos` weight positivity (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.
 
 ## Attempt Counts
 
-- Total attempts: 9 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series bound)
-- Current approach attempts: 1 (S4b step-4 tail p-series bound — `AntitoneOn.sum_le_integral_Ico` + `integral_rpow` + `Real.tsum_le_of_sum_range_le`, landed clean on first build; corrected the flawed per-term variance-sum plan → Tonelli interchange)
+- Total attempts: 11 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound)
+- Current approach attempts: 1 (S4b step-4 pointwise inner-tail bound `tsum_indicator_ge_rpow_neg_le` — `Nat.ceil_le` region rewrite + `Summable.sum_add_tsum_nat_add` reindex to inclusive tail + `Real.rpow_le_rpow_of_nonpos` antitone dressing + `Summable.tsum_eq_zero_add` for the `y≤0` peel; landed clean on first build)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
   S4b step-2 discrete layer cake via lintegral_tsum + floor count;

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 10, researcher-8): added the inclusive-from-N tail leaf tsum_ge_rpow_neg_le (∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1), 0-axiom, build 7743 jobs), the exact deterministic shape the MZ variance-sum Tonelli interchange consumes at N=⌈|X|ᵖ⌉ — closing the off-by-one gap vs the exclusive backbone tsum_shift_rpow_neg_le. Remaining: the ∑ᵢ–𝔼 Tonelli assembly of ∑ᵢVar(Yᵢ)/i^{2/p}≤C·𝔼|X|ᵖ (bounding the inner tail with this leaf), step-3 centering, and the final MZ combination.",
+    "progressSummary": "PROGRESS (iter 11, researcher-8): added tsum_indicator_ge_rpow_neg_le — the pointwise inner-tail bound ∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1) that the MZ variance-sum Tonelli interchange consumes at y=|X|ᵖ, s=2/p. Built on the inclusive tail leaf tsum_ge_rpow_neg_le via a ceiling reindex (Nat.ceil_le + Summable.sum_add_tsum_nat_add) and rpow antitonicity, with the y≤0 edge case peeled. 0-axiom, build 7743 jobs. Remaining: the ∑ᵢ–𝔼 Tonelli interchange itself (lintegral_tsum, nonneg) turning ∑ᵢi^{-2/p}𝔼[X²𝟙{|X|≤i^{1/p}}] into 𝔼[X²·(inner tail)] and integrating this pointwise bound to C·𝔼|X|ᵖ; then step-3 centering and the final MZ combination.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -43,7 +43,8 @@
       "sq_le_rpow_mul_rpow_of_trunc (§ TruncationMomentKernels) — step-4 variance kernel: p<2, 0<t, |x|<=t => x^2 <= t^(2-p)*|x|^p. Proof: x=0 nonneg; else rpow_add split x^2=|x|^p*|x|^(2-p) (via rpow_natCast+sq_abs) then Real.rpow_le_rpow (0<=2-p). Verified 0-axiom.",
       "sum_range_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): integral-comparison block bound ∑_{k<K}(k+N+1)^{-s} ≤ N^{1-s}/(s-1) for s>1, N≥1, uniform in K (via AntitoneOn.sum_le_integral_Ico + integral_rpow), 0-axiom VERIFIED",
       "tsum_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (s>1), via Real.tsum_le_of_sum_range_le, 0-axiom VERIFIED — the deterministic backbone of the MZ variance sum",
-      "tsum_ge_rpow_neg_le (inclusive-from-N p-series tail bound ∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1)) in LawsOfLargeNumbersOQ01OQ02OQ01.lean; docker build 7743 jobs, 0-axiom (propext/Classical.choice/Quot.sound only)."
+      "tsum_ge_rpow_neg_le (inclusive-from-N p-series tail bound ∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1)) in LawsOfLargeNumbersOQ01OQ02OQ01.lean; docker build 7743 jobs, 0-axiom (propext/Classical.choice/Quot.sound only).",
+      "LawsOfLargeNumbers.MZ.tsum_indicator_ge_rpow_neg_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean — pointwise inner-tail bound ∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) (Tonelli integrand for the MZ variance sum), 0-axiom"
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -67,17 +68,18 @@
       "CORRECTION: the MZ variance sum ∑ᵢ Var(Yᵢ)/i^{2/p} does NOT close by a per-term kernel bound. 𝔼[Yᵢ²] ≤ i^{(2-p)/p}·M divided by aᵢ²=i^{2/p} gives M·i^{-1}, and ∑ i^{-1} diverges. integral_trunc_sq_le is valid but not term-by-term summable.",
       "The correct variance-sum route is a Tonelli interchange: ∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}] = 𝔼[X²·∑_{i≥|X|ᵖ} i^{-2/p}] ≤ C·𝔼[X²·|X|^{p-2}] = C·𝔼|X|ᵖ. The inner tail is bounded by tsum_shift_rpow_neg_le with s=2/p.",
       "Mathlib's Analysis/PSeries supplies only summability (summable_nat_rpow_inv), not the quantitative tail ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1); the latter is built here by integral comparison (AntitoneOn.sum_le_integral_Ico against ∫ x^{-s}=x^{1-s}/(1-s)).",
-      "The Tonelli interchange for ∑ᵢVar(Yᵢ)/i^{2/p} needs the INCLUSIVE tail ∑_{j≥N}j^{-s} at N=⌈|X|ᵖ⌉ (inner sum starts AT the ceiling), but the existing backbone tsum_shift_rpow_neg_le bounds only the EXCLUSIVE tail ∑_{j>N}j^{-s}. tsum_ge_rpow_neg_le closes this off-by-one: ∑ₖ(k+N)^{-s} ≤ N^{1-s}·s/(s-1) for s>1, N≥1, by splitting off the j=N term (N^{-s}≤N^{1-s}) and adding the exclusive tail N^{1-s}/(s-1)."
+      "The Tonelli interchange for ∑ᵢVar(Yᵢ)/i^{2/p} needs the INCLUSIVE tail ∑_{j≥N}j^{-s} at N=⌈|X|ᵖ⌉ (inner sum starts AT the ceiling), but the existing backbone tsum_shift_rpow_neg_le bounds only the EXCLUSIVE tail ∑_{j>N}j^{-s}. tsum_ge_rpow_neg_le closes this off-by-one: ∑ₖ(k+N)^{-s} ≤ N^{1-s}·s/(s-1) for s>1, N≥1, by splitting off the j=N term (N^{-s}≤N^{1-s}) and adding the exclusive tail N^{1-s}/(s-1).",
+      "tsum_indicator_ge_rpow_neg_le (r8, iter 11, 0-axiom, build 7743 jobs): the pointwise inner-tail bound the Tonelli interchange consumes. ∑_{i: y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) for s>1. Region {i|y≤i}={i|⌈y⌉₊≤i} (Nat.ceil_le); reindex indicator tsum to inclusive tail ∑ (k+⌈y⌉₊)^{-s} via Summable.sum_add_tsum_nat_add (head over range ⌈y⌉₊ vanishes), apply tsum_ge_rpow_neg_le, dominate ⌈y⌉₊^{1-s}≤(max 1 y)^{1-s} by rpow antitonicity. y≤0 branch peels vanishing i=0 term via Summable.tsum_eq_zero_add, reuses N=1 tail."
     ],
     "mathlibGaps": [
       "No quantitative p-series tail bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) in Mathlib (only summability). Supplied locally as tsum_shift_rpow_neg_le."
     ],
     "nextSteps": [
-      "Assemble ∑ᵢ Var(Yᵢ)/i^{2/p} < ∞ via a nonneg ∑'-∫ Tonelli interchange, bounding the inner tail ∑_{i≥|X|ᵖ} i^{-2/p} with tsum_shift_rpow_neg_le (s=2/p), then integrate to C·𝔼|X|ᵖ; feed ae_tendsto_average_zero_of_variance_weighted_bdd.",
-      "DONE (r8 2026-07-03/04): pointwise kernels AND their integral lifts (integral_trunc_sq_le, integral_tail_abs_le) are build-verified, 0-axiom.",
-      "S4b step-4 series: instantiate integral_trunc_sq_le at t=i^(1/p) to get E[Yi²]≤i^((2-p)/p)·E|X|^p, then Var(Yi)≤E[Yi²] and ∑ Var(Yi)/i^(2/p) ≤ E|X|^p·∑ i^(-2/p) < ∞ via Real.summable_one_div_nat_rpow (2/p>1). Needs i^(1/p)>0 and the rpow-exponent arithmetic (i^(1/p))^(2-p)=i^((2-p)/p).",
-      "S4b step-3 series: instantiate integral_tail_abs_le at t=i^(1/p); with E[X]=0, |E Yi|=|E[X·𝟙{|X|>i^(1/p)}]|≤∫𝟙{i^(1/p)<|X|}|X|≤i^((1-p)/p)·E|X|^p, a null sequence (ci=E[|X|^p·𝟙{|X|>i^(1/p)}]→0 by dominated convergence); feed tendsto_weighted_average_zero with weight i^(1/p-1).",
-      "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd (S5) on centered truncations Yi-E Yi + step-1 a.s. eventual Xi=Yi + step-3 centering ⟹ full MZ SLLN."
+      "DONE (r8 iter 11): tsum_indicator_ge_rpow_neg_le — pointwise inner-tail bound ∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1), the Tonelli integrand bound. 0-axiom, build-verified. Do NOT re-derive.",
+      "NEXT: the ∑ᵢ–𝔼 Tonelli interchange. Use MeasureTheory.lintegral_tsum (nonneg, measurability side-goals) to turn ∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}] into 𝔼[X²·∑ᵢ i^{-2/p}𝟙{|X|≤i^{1/p}}]; the inner sum is exactly tsum_indicator_ge_rpow_neg_le with y=|X|ᵖ, s=2/p (via |X|≤i^{1/p} ↔ |X|ᵖ≤i, rpow reindex). Then bound (max 1 |X|ᵖ)^{1-2/p}: |X|≥1 branch = |X|^{p-2} so X²·(bound)=|X|^p; |X|<1 branch = const. Integrate to C·(𝔼|X|ᵖ+1).",
+      "Then: Var(Yi)≤𝔼[Yi²]=𝔼[X²𝟙{|X|≤i^{1/p}}] and ∑ᵢVar(Yi)/i^{2/p}≤C·𝔼|X|ᵖ<∞ feeds ae_tendsto_average_zero_of_variance_weighted_bdd (S5). Note the weight aᵢ must be positive (ha_pos) — use aᵢ=(i+1)^{1/p} or max 1 i^{1/p}, reconcile with the i^{-2/p} weight.",
+      "S4b step-3 centering: instantiate integral_tail_abs_le at t=i^{1/p}; with 𝔼X=0, |𝔼Yi|≤i^{(1-p)/p}·𝔼|X|ᵖ (null sequence), feed tendsto_weighted_average_zero.",
+      "Assembly: ae_tendsto_average_zero_of_variance_weighted_bdd on centered truncations Yi−𝔼Yi + step-1 a.s. eventual Xi=Yi + step-3 centering ⟹ full MZ SLLN."
     ]
   },
   "tags": [
@@ -101,7 +103,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.191Z",
-  "lastUpdate": "2026-07-04T06:37:27Z",
+  "lastUpdate": "2026-07-04T07:00:53Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -262,8 +264,8 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ02OQ01.lean",
-      "lineCount": 984,
-      "theoremCount": 19,
+      "lineCount": 1197,
+      "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — `laws-of-large-numbers-oq-01-oq-02-oq-01`, iteration 11

Adds one verified, **0-axiom** theorem to `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`
(§ TailPSeries): the **pointwise inner-tail bound** that the MZ variance-sum Tonelli interchange
consumes.

### `tsum_indicator_ge_rpow_neg_le`

For `1 < s` and any real `y`:

```
∑'_{i : ℕ}  {i | y ≤ i}.indicator (fun i => i^(-s)) i  ≤  (max 1 y)^(1-s) · s/(s-1).
```

After the `∑ᵢ`–`𝔼` interchange, the inner `∑ᵢ` runs over the truncation region
`{i | |X| ≤ i^{1/p}} = {i | |X|ᵖ ≤ i}`; with `y = |X|ᵖ`, `s = 2/p (> 1)` this bounds it by
`(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)`, whose `|X| ≥ 1` branch is `|X|^{p-2}` — exactly the factor that,
multiplied by `X²`, integrates to `𝔼|X|ᵖ`. This is the deterministic integrand bound flagged in
the prior state as the Tonelli input.

### Proof

1. Region `{i | y ≤ i} = {i | ⌈y⌉₊ ≤ i}` (`Nat.ceil_le`).
2. Reindex the indicator tsum to the inclusive tail `∑' k, (k+⌈y⌉₊)^{-s}` via
   `Summable.sum_add_tsum_nat_add` (head over `range ⌈y⌉₊` vanishes), then apply the existing
   inclusive-tail leaf `tsum_ge_rpow_neg_le`.
3. Dominate `⌈y⌉₊^{1-s} ≤ (max 1 y)^{1-s}` by rpow antitonicity (`Real.rpow_le_rpow_of_nonpos`).
4. `⌈y⌉₊ = 0` (i.e. `y ≤ 0`) edge case peels the vanishing `i = 0` term
   (`Summable.tsum_eq_zero_add`) and reuses the `N = 1` tail.

### Verification

- `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built (7743 jobs, exit 0)**.
- `#print axioms tsum_indicator_ge_rpow_neg_le` → `[propext, Classical.choice, Quot.sound]` only —
  no `sorryAx`, no `Lean.ofReduceBool`. 0-sorry / 0-axiom by construction.

### Scope / honesty

This is reusable infrastructure, **not** the full Marcinkiewicz–Zygmund law. Remaining: the
measure-theoretic `∑'`–`∫` interchange itself (`lintegral_tsum`, nonneg + measurability) that
plugs this bound into `𝔼[X²·(inner tail)]` → `C·𝔼|X|ᵖ`, yielding `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`
(feeds `ae_tendsto_average_zero_of_variance_weighted_bdd`), then step-3 centering and the final
combination. Knowledge/state/JSON updated accordingly.