### PR TITLE
Research: laws-of-large-numbers-oq-01-oq-02-oq-01 — MZ variance-sum pointwise Tonelli integrand (tsum_weight_trunc_sq_le)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1180,10 +1180,48 @@ theorem tsum_indicator_ge_rpow_neg_le {s : ℝ} (hs : 1 < s) (y : ℝ) :
       _ ≤ (max 1 y) ^ (1 - s) * (s / (s - 1)) := mul_le_mul_of_nonneg_right hpow hfac
       _ = (max 1 y) ^ (1 - s) * s / (s - 1) := by ring
 
+/-- **Pointwise Tonelli integrand for the MZ variance sum.**  For `1 < s`, `0 < p` and any
+real `x`, the `i^{-s}`-weighted truncated-square sum over the *root-form* truncation region
+`{i | |x| ≤ i^{1/p}}` — exactly `∑ᵢ i^{-s}·(𝟙{|x| ≤ i^{1/p}}·x)²`, the per-`ω` summand of
+the variance series after `t = i^{1/p}` — is bounded by a single power of `max 1 |x|ᵖ`:
+
+    ∑'_i 𝟙{|x| ≤ i^{1/p}}·(i^{-s}·x²)  ≤  (max 1 |x|ᵖ)^{1-s}·s/(s-1) · x².
+
+This is the deterministic integrand the Tonelli interchange behind `∑ᵢ Var(Yᵢ)/i^{2/p}`
+consumes: with `s = 2/p (> 1 ⟺ p < 2)` the `|x| ≥ 1` branch of the bound is `x²·|x|^{p-2} =
+|x|ᵖ`, integrating to `𝔼|X|ᵖ`; the `|x| < 1` branch collapses to `x²·s/(s-1)`, integrable on a
+probability space.
+
+Proof: pull `x²` out of the indicator (`Set.indicator_apply` + `ring`) and out of the tsum
+(`tsum_mul_right`); rewrite the root-form region `{i | |x| ≤ i^{1/p}}` to the power-form region
+`{i | |x|ᵖ ≤ i}` (complement of `rpow_inv_lt_iff_lt_rpow` via `not_lt`); then apply the
+deterministic tail bound `tsum_indicator_ge_rpow_neg_le` at `y = |x|ᵖ` and multiply through by
+`x² ≥ 0`. -/
+theorem tsum_weight_trunc_sq_le {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (x : ℝ) :
+    ∑' i : ℕ, {i : ℕ | |x| ≤ (i : ℝ) ^ (1 / p)}.indicator
+        (fun i => (i : ℝ) ^ (-s) * x ^ 2) i
+      ≤ (max 1 (|x| ^ p)) ^ (1 - s) * s / (s - 1) * x ^ 2 := by
+  set S : Set ℕ := {i : ℕ | |x| ≤ (i : ℝ) ^ (1 / p)} with hS
+  -- pull `x²` out of the indicator, then out of the tsum
+  have hpt : ∀ i : ℕ,
+      S.indicator (fun i => (i : ℝ) ^ (-s) * x ^ 2) i
+        = S.indicator (fun i => (i : ℝ) ^ (-s)) i * x ^ 2 := by
+    intro i; simp only [Set.indicator_apply]; split_ifs <;> ring
+  rw [tsum_congr hpt, tsum_mul_right]
+  -- rewrite the root-form region `{i | |x| ≤ i^{1/p}}` to the power-form `{i | |x|ᵖ ≤ i}`
+  have hSeq : S = {i : ℕ | |x| ^ p ≤ (i : ℝ)} := by
+    rw [hS]; ext i
+    simp only [Set.mem_setOf_eq]
+    rw [← not_lt, ← not_lt]
+    exact not_congr (rpow_inv_lt_iff_lt_rpow hp (Nat.cast_nonneg i) (abs_nonneg x))
+  rw [hSeq]
+  exact mul_le_mul_of_nonneg_right (tsum_indicator_ge_rpow_neg_le hs (|x| ^ p)) (sq_nonneg x)
+
 #check @sum_range_shift_rpow_neg_le
 #check @tsum_shift_rpow_neg_le
 #check @tsum_ge_rpow_neg_le
 #check @tsum_indicator_ge_rpow_neg_le
+#check @tsum_weight_trunc_sq_le
 
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
@@ -1191,6 +1229,7 @@ theorem tsum_indicator_ge_rpow_neg_le {s : ℝ} (hs : 1 < s) (y : ℝ) :
 #print axioms tsum_shift_rpow_neg_le
 #print axioms tsum_ge_rpow_neg_le
 #print axioms tsum_indicator_ge_rpow_neg_le
+#print axioms tsum_weight_trunc_sq_le
 
 end TailPSeries
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -6,6 +6,51 @@
 
 ---
 
+## Session 2026-07-04 (researcher-14, iter 12) — S4b step-4 pointwise Tonelli integrand SHIPPED (verified)
+
+**Mode**: REVISIT (RICH). **Outcome**: progress — new leaf `tsum_weight_trunc_sq_le` appended to
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (0 sorries, 0 `axiom`; docker build
+**succeeded, 7743 jobs, exit 0**; `#print axioms` = `propext / Classical.choice / Quot.sound` only).
+
+### What it adds
+The remaining measure-theoretic lift for the MZ variance sum is a single `∑'ᵢ`–`∫` Tonelli
+interchange. Its **integrand** — the per-`ω` inner sum after the swap — is the deterministic fact
+this leaf isolates:
+
+    tsum_weight_trunc_sq_le {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (x : ℝ) :
+      ∑' i : ℕ, {i | |x| ≤ (i:ℝ)^(1/p)}.indicator (fun i => (i:ℝ)^(-s) * x^2) i
+        ≤ (max 1 (|x|^p))^(1-s) * s/(s-1) * x^2
+
+With `x = X(ω)`, `s = 2/p` this is *exactly* `∑ᵢ i^{-s}·Yᵢ(ω)²` where `Yᵢ = 𝟙{|X|≤i^{1/p}}·X` is
+the step-4 truncation (region matches `integral_trunc_sq_le`'s `t = i^{1/p}` verbatim). So after
+the interchange the whole variance-sum integrand is dominated by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X²`,
+whose `|X|≥1` branch is `|X|^{p-2}·X² = |X|ᵖ` (→ `𝔼|X|ᵖ`) and `|X|<1` branch is `const·X²`.
+
+### Technique (reusable)
+Three moves, each one line: (1) pull `x²` out of the indicator —
+`simp only [Set.indicator_apply]; split_ifs <;> ring` (the `x∉S` branch is `0 = 0·x²`); (2) pull it
+out of the tsum — `tsum_mul_right`; (3) **bridge root-form to power-form region** — the truncation
+set `{i | |x| ≤ i^{1/p}}` equals `{i | |x|ᵖ ≤ i}` because `|x| ≤ i^{1/p} ↔ ¬(i^{1/p} < |x|) ↔
+¬(i < |x|ᵖ) ↔ |x|ᵖ ≤ i`, i.e. `rw [← not_lt, ← not_lt]; exact not_congr (rpow_inv_lt_iff_lt_rpow …)`
+reusing the **existing** strict reindex lemma rather than proving a new `≤` companion. Then
+`tsum_indicator_ge_rpow_neg_le` (iter 11) at `y = |x|ᵖ` + `mul_le_mul_of_nonneg_right … (sq_nonneg x)`.
+
+### Honest status
+A correct, reusable **deterministic integrand leaf**, NOT the interchange or the variance-sum
+assembly. It converts the abstract iter-11 `{i | y ≤ i}` bound into the concrete root-form summand
+the probabilistic interchange will integrate, and does the root↔power region bridge once and for all.
+The substantive open work — the actual `MeasureTheory.integral_tsum` swap with its integrability
+side-goals, then integrating the RHS to `C·(𝔼|X|ᵖ + 1)`, then step-3 centering and the final MZ
+combination via `ae_tendsto_average_zero_of_variance_weighted_bdd` — remains.
+
+### Next steps
+- **The interchange itself**: `∑'ᵢ ∫ i^{-s}·Yᵢ² dμ = ∫ ∑'ᵢ i^{-s}·Yᵢ² dμ` via `integral_tsum`
+  (per-term integrability + `∑'∫|·|<∞`); dominate the integrand by `tsum_weight_trunc_sq_le`.
+- Integrate the RHS bound to `C·(𝔼|X|ᵖ + 1)` (split `|X|≥1` / `|X|<1`); feed S5.
+- Step-3 centering, then final MZ combination.
+
+---
+
 ## Session 2026-07-04 (researcher-8) — S4b tail leaf: inclusive-from-N p-series bound (DEEP DIVE, PROGRESS)
 
 **Mode**: REVISIT (RICH). **Outcome**: progress — new leaf `tsum_ge_rpow_neg_le` appended to

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 *Tonelli integrand bound* — pointwise inner-tail bound SHIPPED & VERIFIED — remaining: the ∑ᵢ–𝔼 interchange itself + assembly)
+**Phase**: ACT (S4b step-4 *Tonelli integrand* — pointwise per-`ω` variance-sum integrand SHIPPED & VERIFIED — remaining: the ∑ᵢ–𝔼 interchange itself + assembly)
 **Since**: 2026-07-04
-**Iteration**: 11 (S4b step-4 pointwise inner-tail bound `tsum_indicator_ge_rpow_neg_le` `∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1)` SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 12 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -109,26 +109,29 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 
 ## Next Action
 
-- **S4b step-4 Tonelli integrand bound is now DONE (iteration 11):** `tsum_indicator_ge_rpow_neg_le`
-  supplies `∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1)` (`s>1`) — the inner-tail bound the
-  interchange consumes with `y = |X|ᵖ`, `s = 2/p`. Built on iter-10 `tsum_ge_rpow_neg_le`
-  (inclusive tail) via a ceiling reindex (`Nat.ceil_le` + `Summable.sum_add_tsum_nat_add`) and
-  rpow antitonicity, `y≤0` edge case peeled. **Do not re-derive it.**
-- **Next: the ∑ᵢ–𝔼 Tonelli interchange itself.** Use `MeasureTheory.lintegral_tsum` /
-  `∑'`-`∫` interchange (nonneg, measurability side-goals) to turn `∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}]`
-  into `𝔼[X²·∑ᵢ i^{-2/p}𝟙{|X|≤i^{1/p}}]`; the inner sum is **exactly**
-  `tsum_indicator_ge_rpow_neg_le` at `y=|X|ᵖ`, `s=2/p` (via `|X|≤i^{1/p} ↔ |X|ᵖ≤i`, the rpow
-  reindex `rpow_inv_lt_iff_lt_rpow` / a `≤` companion). Then `(max 1 |X|ᵖ)^{1-2/p}`: `|X|≥1`
-  branch `=|X|^{p-2}` so `X²·bound=|X|^p`; `|X|<1` branch `=` const. Integrate to `C·(𝔼|X|ᵖ+1)`.
-  This yields `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`, feeding `ae_tendsto_average_zero_of_variance_weighted_bdd`
-  (S5). Watch the `ha_pos` weight positivity (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
+- **S4b step-4 pointwise Tonelli integrand is now DONE (iteration 12):** `tsum_weight_trunc_sq_le`
+  supplies, for `1<s`, `0<p`, any `x`, the **per-`ω` variance summand bound**
+  `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²`. This is the exact `x=X(ω)`,
+  `s=2/p` integrand of the interchange: the root-form truncation region `{i | |x| ≤ i^{1/p}}`
+  (matching `integral_trunc_sq_le`'s `t=i^{1/p}`) is bridged to the power-form `{i | |x|ᵖ ≤ i}`
+  (complement of `rpow_inv_lt_iff_lt_rpow` via `not_lt`), `x²` is pulled through
+  (`tsum_mul_right`), and iter-11 `tsum_indicator_ge_rpow_neg_le` closes it. **Do not re-derive.**
+- **Next: the ∑ᵢ–𝔼 Tonelli interchange itself** (the one remaining measure-theoretic lift for
+  step-4). Use `MeasureTheory.integral_tsum` / `lintegral_tsum` (nonneg, per-term integrability +
+  `∑'∫|·|<∞` side-goals) to move `∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² dμ = ∫ ∑'ᵢ (…) dμ`; the inner
+  `∑'ᵢ` under the integral is **literally** `tsum_weight_trunc_sq_le` at `x=X(ω)`, so the integrand
+  is dominated by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X²`. Integrate the RHS: `|X|≥1` branch
+  `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so `X²·bound=|X|^p → 𝔼|X|ᵖ`; `|X|<1` branch collapses to
+  `const·X² → const·𝔼X²` (finite via `𝔼|X|ᵖ` + probability space). Yields `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`,
+  feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
+  (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.
 
 ## Attempt Counts
 
-- Total attempts: 11 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound)
-- Current approach attempts: 1 (S4b step-4 pointwise inner-tail bound `tsum_indicator_ge_rpow_neg_le` — `Nat.ceil_le` region rewrite + `Summable.sum_add_tsum_nat_add` reindex to inclusive tail + `Real.rpow_le_rpow_of_nonpos` antitone dressing + `Summable.tsum_eq_zero_add` for the `y≤0` peel; landed clean on first build)
+- Total attempts: 12 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand)
+- Current approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
   S4b step-2 discrete layer cake via lintegral_tsum + floor count;

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -19,19 +19,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-03T11:45:00.000Z",
-    "iteration": 3,
-    "focus": "S2 (Kronecker + Toeplitz) shipped & verified. S3 (Kolmogorov a.s.-convergence criterion) re-scoped: engine + all glue lemmas already in Mathlib; remaining work is assembly, not foundations.",
+    "since": "2026-07-04T00:10:00.000Z",
+    "iteration": 12,
+    "focus": "S4b step-4 pointwise Tonelli integrand tsum_weight_trunc_sq_le SHIPPED & verified (0-axiom, 7743 jobs). Remaining: the ∑'ᵢ–∫ interchange itself, then integrate RHS to C·(𝔼|X|ᵖ+1), then step-3 centering + final MZ combination.",
     "blockers": [],
-    "nextAction": "S3 assembly (1-2 sessions): build natural filtration of X, prove partial sums are a Martingale via condExp_indep_eq, bound eLpNorm(S_n,1) uniformly via IndepFun.variance_sum, apply Submartingale.exists_ae_tendsto_of_bdd.",
+    "nextAction": "Tonelli interchange via MeasureTheory.integral_tsum: ∑'ᵢ ∫ i^{-s}·Yᵢ² dμ = ∫ ∑'ᵢ i^{-s}·Yᵢ² dμ (per-term integrability + ∑'∫|·|<∞); the inner ∑'ᵢ is literally tsum_weight_trunc_sq_le at x=X(ω), dominating the integrand by (max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X². Integrate RHS: |X|≥1 branch → 𝔼|X|ᵖ, |X|<1 branch → const·𝔼X². Yields ∑ᵢ Var(Yᵢ)/i^{2/p}<∞ for ae_tendsto_average_zero_of_variance_weighted_bdd (S5); then step-3 centering and final MZ combination.",
     "attemptCounts": {
-      "total": 3,
-      "currentApproach": 0,
-      "approachesTried": 2
+      "total": 12,
+      "currentApproach": 1,
+      "approachesTried": 7
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 11, researcher-8): added tsum_indicator_ge_rpow_neg_le — the pointwise inner-tail bound ∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1) that the MZ variance-sum Tonelli interchange consumes at y=|X|ᵖ, s=2/p. Built on the inclusive tail leaf tsum_ge_rpow_neg_le via a ceiling reindex (Nat.ceil_le + Summable.sum_add_tsum_nat_add) and rpow antitonicity, with the y≤0 edge case peeled. 0-axiom, build 7743 jobs. Remaining: the ∑ᵢ–𝔼 Tonelli interchange itself (lintegral_tsum, nonneg) turning ∑ᵢi^{-2/p}𝔼[X²𝟙{|X|≤i^{1/p}}] into 𝔼[X²·(inner tail)] and integrating this pointwise bound to C·𝔼|X|ᵖ; then step-3 centering and the final MZ combination.",
+    "progressSummary": "PROGRESS (iter 12, researcher-14): added tsum_weight_trunc_sq_le — the pointwise Tonelli integrand for the MZ variance sum. For 1<s, 0<p, any x: ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². With x=X(ω), s=2/p this is exactly ∑ᵢ i^{-s}·Yᵢ(ω)² for the step-4 truncation Yᵢ=𝟙{|X|≤i^{1/p}}·X (region matches integral_trunc_sq_le's t=i^{1/p}). Bridges the abstract iter-11 {i|y≤i} bound (tsum_indicator_ge_rpow_neg_le) to the concrete root-form summand the interchange integrates, doing the root↔power region rewrite once. 0-axiom, build 7743 jobs exit 0. Remaining: the ∑'ᵢ–∫ Tonelli interchange itself (MeasureTheory.integral_tsum, integrability side-goals) moving ∑'ᵢ∫ i^{-s}Yᵢ² = ∫∑'ᵢ i^{-s}Yᵢ² and dominating the integrand by this leaf, then integrating the RHS to C·(𝔼|X|ᵖ+1); then step-3 centering and the final MZ combination.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -44,7 +44,8 @@
       "sum_range_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): integral-comparison block bound ∑_{k<K}(k+N+1)^{-s} ≤ N^{1-s}/(s-1) for s>1, N≥1, uniform in K (via AntitoneOn.sum_le_integral_Ico + integral_rpow), 0-axiom VERIFIED",
       "tsum_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (s>1), via Real.tsum_le_of_sum_range_le, 0-axiom VERIFIED — the deterministic backbone of the MZ variance sum",
       "tsum_ge_rpow_neg_le (inclusive-from-N p-series tail bound ∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1)) in LawsOfLargeNumbersOQ01OQ02OQ01.lean; docker build 7743 jobs, 0-axiom (propext/Classical.choice/Quot.sound only).",
-      "LawsOfLargeNumbers.MZ.tsum_indicator_ge_rpow_neg_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean — pointwise inner-tail bound ∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) (Tonelli integrand for the MZ variance sum), 0-axiom"
+      "LawsOfLargeNumbers.MZ.tsum_indicator_ge_rpow_neg_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean — pointwise inner-tail bound ∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) (Tonelli integrand for the MZ variance sum), 0-axiom",
+      "LawsOfLargeNumbers.MZ.tsum_weight_trunc_sq_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries) — pointwise Tonelli integrand for the MZ variance sum: for 1<s, 0<p, any x, ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². The exact per-ω summand of the variance series (x=X(ω), s=2/p); root-form region {i||x|≤i^{1/p}} bridged to power-form {i||x|ᵖ≤i} via not_lt on rpow_inv_lt_iff_lt_rpow, x² pulled out (tsum_mul_right), closed by tsum_indicator_ge_rpow_neg_le. docker build 7743 jobs, 0-axiom."
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",


### PR DESCRIPTION
## Summary

Advances the **Marcinkiewicz–Zygmund SLLN** formalization (`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`) by one verified leaf: the **pointwise integrand** of the `∑'ᵢ–∫` Tonelli interchange behind the variance sum `∑ᵢ Var(Yᵢ)/i^{2/p}`.

`tsum_weight_trunc_sq_le` — for `1 < s`, `0 < p` and any real `x`:

```
∑'ᵢ 𝟙{|x| ≤ i^{1/p}}·(i^{-s}·x²)  ≤  (max 1 |x|ᵖ)^{1-s} · s/(s-1) · x²
```

With `x = X(ω)`, `s = 2/p` this is **exactly** `∑ᵢ i^{-s}·Yᵢ(ω)²` for the step-4 truncation `Yᵢ = 𝟙{|X| ≤ i^{1/p}}·X` — the root-form region matches `integral_trunc_sq_le`'s `t = i^{1/p}` verbatim. So after the interchange the whole variance-sum integrand is dominated by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X²`, whose `|X|≥1` branch is `|X|^{p-2}·X² = |X|ᵖ` (→ `𝔼|X|ᵖ`).

## What it bridges

The prior leaf `tsum_indicator_ge_rpow_neg_le` (iter 11) bounds the abstract tail over `{i | y ≤ i}`. This leaf converts it to the concrete **root-form** summand the probabilistic interchange integrates, doing the root↔power region bridge once:

1. pull `x²` out of the indicator (`Set.indicator_apply` + `ring`) and the tsum (`tsum_mul_right`);
2. rewrite `{i | |x| ≤ i^{1/p}}` to `{i | |x|ᵖ ≤ i}` — the complement of the **existing** `rpow_inv_lt_iff_lt_rpow` via `not_lt` (no new `≤` companion needed);
3. apply `tsum_indicator_ge_rpow_neg_le` at `y = |x|ᵖ` and `mul_le_mul_of_nonneg_right … (sq_nonneg x)`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built, 7743 jobs, exit 0**.
- `#print axioms tsum_weight_trunc_sq_le` = `propext / Classical.choice / Quot.sound` only — **Tier-A axiom-free**, 0 sorries, 0 `axiom`, no `native_decide`.

## Honest status

A correct, reusable **deterministic integrand leaf** — NOT the interchange or the variance-sum assembly. The substantive open work remains: the actual `MeasureTheory.integral_tsum` swap (with its integrability side-goals), integrating the RHS to `C·(𝔼|X|ᵖ + 1)`, then step-3 centering and the final MZ combination via `ae_tendsto_average_zero_of_variance_weighted_bdd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)