### PR TITLE
Enrich Erdős #1 Conway–Guy (erdos-1-wip-01-oq-03)

### DIFF
--- a/src/data/proofs/erdos-1-wip-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-erdos1-oq03-overview",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Erdős #1 and the Conway–Guy Construction",
+    "content": "The module docstring frames the whole file. Erdős Problem #1 asks for the minimum largest element f(n) of an n-element set of positive integers whose 2ⁿ subset sums are all distinct. The powers-of-two set {1,2,4,…,2^(n-1)} is the obvious distinct-subset-sums (DSS) witness and gives f(n) ≤ 2^(n-1). Conway and Guy (1968) beat it: the n-element difference set of the sequence 0,1,2,4,7,13,24,44,84,… (OEIS A005318) is DSS with largest element strictly below 2^(n-1) for n ≥ 4. This file contributes a decidable reformulation of DSS, kernel-`decide` certificates for the explicit witnesses cg4…cg8, and the packaged non-optimality theorem.",
+    "mathContext": "$f(n) = \\min\\{\\max(A) : |A| = n,\\ \\text{all } 2^n \\text{ subset sums of } A \\text{ distinct}\\}$; powers of two give $f(n) \\le 2^{n-1}$, Conway–Guy give $f(n) < 2^{n-1}$ for $n \\ge 4$.",
+    "significance": "context",
+    "relatedConcepts": ["distinct subset sums", "Sidon sets", "Conway–Guy sequence", "OEIS A005318", "extremal set theory"],
+    "prerequisites": ["additive combinatorics", "subset sums"]
+  },
+  {
+    "id": "ann-erdos1-oq03-maxrecdepth",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 55, "endLine": 58 },
+    "type": "technique",
+    "title": "Raising maxRecDepth for Kernel Decision",
+    "content": "The distinct-subset-sums checks for the larger witnesses (n = 7, 8) force the Lean kernel to reduce a cardinality computation over a powerset of 2⁷ = 128 and 2⁸ = 256 subsets. That reduction nests deeper than the default elaboration recursion limit, so `set_option maxRecDepth 10000` is required. Crucially this raises only the recursion budget of ordinary kernel `decide`; it does not switch to `native_decide`, so no compiler-trust axiom (`Lean.ofReduceBool`) is introduced.",
+    "mathContext": "The powerset of an $n$-set has $2^n$ elements; building $\\{\\sum S : S \\subseteq A\\}$ and comparing its cardinality to $2^n$ costs $O(2^n)$ kernel reductions, deepest at $n = 8$ ($256$ subsets).",
+    "significance": "technical",
+    "relatedConcepts": ["kernel reduction", "decide tactic", "recursion depth", "trusted kernel"],
+    "prerequisites": ["Lean elaboration", "decidability"]
+  },
+  {
+    "id": "ann-erdos1-oq03-criterion",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 70, "endLine": 88 },
+    "type": "insight",
+    "title": "Making Distinct Subset Sums Decidable",
+    "content": "`hasDistinctSubsetSums A` is defined by a universal quantifier over ALL of `Finset ℕ`, which is not decidable as written. The key lemma rewrites it, through `Finset.card_image_iff`, as the statement that the subset-sum map S ↦ ∑S is injective on the finite `A.powerset` — equivalently that the image `(A.powerset.image (·.sum id)).card` equals `A.powerset.card`. Since membership `S ∈ A.powerset` is definitionally `S ⊆ A`, the two forms are interchangeable, and the right-hand side is a finite cardinality identity that `decide` can evaluate. This single rewrite is the reusable engine for the entire Erdős #1 family.",
+    "mathContext": "$A \\text{ is DSS} \\iff S \\mapsto \\sum S \\text{ is injective on } \\mathcal{P}(A) \\iff |\\{\\textstyle\\sum S : S \\subseteq A\\}| = |\\mathcal{P}(A)|.$",
+    "significance": "key",
+    "relatedConcepts": ["injectivity", "Finset.card_image_iff", "powerset", "decidability", "pigeonhole principle"],
+    "prerequisites": ["Finset image and card", "decidable equality"]
+  },
+  {
+    "id": "ann-erdos1-oq03-cardpow",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 90, "endLine": 94 },
+    "type": "definition",
+    "title": "The Explicit 2^|A| Count",
+    "content": "A convenience restatement of the criterion that replaces `A.powerset.card` with the explicit value `2 ^ A.card`, using `Finset.card_powerset`. This is the form one actually reasons about: 'A has distinct subset sums iff the number of distinct subset sums equals 2^|A|.' It makes the O(2ⁿ) nature of the check visible and is the shape most naturally quoted in write-ups.",
+    "mathContext": "$|\\mathcal{P}(A)| = 2^{|A|}$ (Finset.card_powerset), so $A \\text{ is DSS} \\iff |\\{\\textstyle\\sum S : S \\subseteq A\\}| = 2^{|A|}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_powerset", "cardinality of powerset", "counting"],
+    "prerequisites": ["powerset cardinality"]
+  },
+  {
+    "id": "ann-erdos1-oq03-witnesses",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 105, "endLine": 121 },
+    "type": "definition",
+    "title": "The Conway–Guy Difference Sets cg4…cg8",
+    "content": "The five explicit witnesses are the n-element difference sets of the Conway–Guy sequence: cg4 = {3,5,6,7}, cg5 = {6,9,11,12,13}, cg6 = {11,17,20,22,23,24}, cg7 = {20,31,37,40,42,43,44}, cg8 = {40,60,71,77,80,82,83,84}. Each is obtained as {a(n) − a(n−i) : 1 ≤ i ≤ n} from a = 0,1,2,4,7,13,24,44,84,…, and the `cgN_card` lemmas confirm each has exactly n distinct elements. Their largest elements 7,13,24,44,84 sit strictly below the powers-of-two bounds 8,16,32,64,128.",
+    "mathContext": "$\\mathrm{cg}_n = \\{a(n) - a(n-i) : 1 \\le i \\le n\\}$ with $a = 0,1,2,4,7,13,24,44,84,\\dots$; e.g. $\\mathrm{cg}_6 = \\{11,17,20,22,23,24\\}$, $\\max = 24 < 32 = 2^5$.",
+    "significance": "key",
+    "relatedConcepts": ["difference set", "Conway–Guy sequence", "OEIS A005318", "greedy construction"],
+    "prerequisites": ["Finset literals", "sequences"]
+  },
+  {
+    "id": "ann-erdos1-oq03-dss-certs",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 123, "endLine": 133 },
+    "type": "technique",
+    "title": "Certifying Distinct Subset Sums by Kernel decide",
+    "content": "Each `cgN_dss` proves `hasDistinctSubsetSums cgN` by rewriting with `hasDistinctSubsetSums_iff_image_card` and then calling kernel `decide`. The kernel builds the finset of the 2ⁿ subset sums and checks its cardinality equals `cgN.powerset.card`. Because this is ordinary `decide` (reduction inside the trusted kernel), not `native_decide`, the certificates add no axioms beyond Mathlib's foundational propext/Classical.choice/Quot.sound — the entry legitimately earns a 'verified', axiom-free status. Counting distinct sums is O(2ⁿ), far cheaper than the naive O(4ⁿ) scan over all pairs (S,T).",
+    "mathContext": "Rewrite to $|\\{\\textstyle\\sum S : S \\subseteq \\mathrm{cg}_n\\}| = |\\mathcal{P}(\\mathrm{cg}_n)|$, then reduce: an $O(2^n)$ check versus the naive $O(4^n)$ scan over pairs.",
+    "significance": "key",
+    "relatedConcepts": ["decide tactic", "kernel reduction", "axiom-free verification", "Lean.ofReduceBool", "computational complexity"],
+    "prerequisites": ["decidability", "trusted kernel"]
+  },
+  {
+    "id": "ann-erdos1-oq03-bounds",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 135, "endLine": 140 },
+    "type": "technique",
+    "title": "Elements Below the Powers-of-Two Bound",
+    "content": "The `cgN_lt` lemmas certify, again by `decide`, that every element of cgN is strictly below 2^(n-1): the value 2^(n-1) is exactly the largest element of the powers-of-two set {1,2,4,…,2^(n-1)}. These bounds (7<8, 13<16, 24<32, 44<64, 84<128) are what turn the DSS certificates into a statement about optimality — they witness that Conway–Guy sets are more compact than the superincreasing benchmark.",
+    "mathContext": "$\\forall x \\in \\mathrm{cg}_n,\\ x < 2^{n-1}$; the gap $2^{n-1} - \\max(\\mathrm{cg}_n)$ is $1,3,8,20,44$ for $n = 4,\\dots,8$ and widens with $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["superincreasing sequence", "powers of two", "extremal bound"],
+    "prerequisites": ["order on ℕ", "decidability"]
+  },
+  {
+    "id": "ann-erdos1-oq03-main",
+    "proofId": "erdos-1-wip-01-oq-03",
+    "range": { "startLine": 150, "endLine": 164 },
+    "type": "insight",
+    "title": "Powers of Two Are Not Optimal",
+    "content": "The packaged theorem `conwayGuy_beats_powers_of_two` collects the five cases: for every n ∈ {4,5,6,7,8} there is an n-element set of positive integers with distinct subset sums whose every element is strictly below 2^(n-1). The proof does `fin_cases` over the finset {4,5,6,7,8} and discharges each branch with the corresponding cgN_card, cgN_dss, cgN_lt lemmas plus a `decide` for positivity. Since the powers-of-two construction attains exactly 2^(n-1), the existence of a strictly smaller DSS set proves that construction is not optimal for these n — a concrete, machine-checked instance of the Conway–Guy phenomenon.",
+    "mathContext": "$\\forall n \\in \\{4,5,6,7,8\\}\\ \\exists A,\\ |A| = n \\wedge \\mathrm{DSS}(A) \\wedge (\\forall x\\in A,\\ 0 < x < 2^{n-1})$; contrast $\\max\\{1,2,\\dots,2^{n-1}\\} = 2^{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["fin_cases", "existential witness", "non-optimality", "Conway–Guy construction", "Erdős problems"],
+    "prerequisites": ["case analysis over finsets", "existential proofs"]
+  }
+]

--- a/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
@@ -78,20 +78,38 @@
       "mathContext": "S ⊆ A ⇔ S ∈ A.powerset, and image.card = source.card ⇔ InjOn; combining gives a decidable equivalent of DSS that `decide` can evaluate in O(2ⁿ)."
     },
     {
-      "id": "witnesses",
-      "title": "Part II: Explicit Conway–Guy Witnesses",
+      "id": "witnesses-defs",
+      "title": "Part II(a): The Conway–Guy Witness Sets and Their Sizes",
       "startLine": 102,
-      "endLine": 148,
-      "summary": "Definitions cg4…cg8 (the difference sets {3,5,6,7}, {6,9,11,12,13}, {11,17,20,22,23,24}, {20,31,37,40,42,43,44}, {40,60,71,77,80,82,83,84}) with their cardinalities (cgN_card), distinct-subset-sums certificates (cgN_dss, via the criterion + kernel `decide`), and element bounds cgN_lt : ∀ x ∈ cgN, x < 2^(n-1).",
+      "endLine": 121,
+      "summary": "Definitions cg4…cg8 (the difference sets {3,5,6,7}, {6,9,11,12,13}, {11,17,20,22,23,24}, {20,31,37,40,42,43,44}, {40,60,71,77,80,82,83,84}) together with the cardinality lemmas cgN_card confirming each has exactly n distinct elements.",
+      "mathContext": "cgN is the n-element difference set of the Conway–Guy sequence 0,1,2,4,7,13,24,44,84,…; cgN_card verifies |cgN| = n by `decide`."
+    },
+    {
+      "id": "witnesses-certs",
+      "title": "Part II(b): DSS Certificates and Element Bounds",
+      "startLine": 123,
+      "endLine": 140,
+      "summary": "Distinct-subset-sums certificates cgN_dss (rewrite by hasDistinctSubsetSums_iff_image_card, then kernel `decide` over the 2ⁿ-element powerset image) and the element bounds cgN_lt : ∀ x ∈ cgN, x < 2^(n-1).",
       "mathContext": "Each set is verified DSS by kernel reduction over its powerset image; the largest element is 7,13,24,44,84 against powers-of-two bounds 8,16,32,64,128."
     },
     {
       "id": "not-optimal",
       "title": "Part III: The Powers-of-Two Construction Is Not Optimal",
-      "startLine": 150,
+      "startLine": 142,
       "endLine": 166,
       "summary": "conwayGuy_beats_powers_of_two: for every n ∈ {4,5,6,7,8} there is an n-element set of positive integers with distinct subset sums and every element < 2^(n-1). Proved by fin_cases over the finset, discharging each case with the corresponding cgN lemmas and a `decide` for positivity.",
       "mathContext": "Since {1,2,…,2^(n-1)} attains 2^(n-1), the existence of a DSS set strictly under that bound shows the powers-of-two/superincreasing construction is suboptimal for these n."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "This entry machine-certifies, axiom-free (kernel `decide`, no native_decide, no Lean.ofReduceBool), that the trivial powers-of-two construction for Erdős Problem #1 is not optimal. The engine is a single decidability lemma — hasDistinctSubsetSums_iff_image_card — that reduces the ∀-over-all-finsets definition of distinct subset sums to a finite powerset-image cardinality identity, letting `decide` settle concrete cases in O(2ⁿ) instead of the naive O(4ⁿ) pair scan. Applied to the explicit Conway–Guy difference sets cg4…cg8, it certifies each is DSS with largest element strictly below the powers-of-two bound 2^(n-1) (7<8, 13<16, 24<32, 44<64, 84<128), and packages the five cases into conwayGuy_beats_powers_of_two.",
+    "implications": "The decidable criterion is reusable infrastructure for the whole Erdős #1 family: any concrete DSS claim over a small set is now a one-line `decide`. Verifying the Conway–Guy phenomenon inside the trusted kernel — rather than via native compilation — keeps the entry genuinely axiom-free, illustrating the deliberate tradeoff between feasibility (n ≤ 8) and axiom cleanliness. More broadly, it gives a formal, checkable answer to a natural question about a $500 Erdős problem: superincreasing sets, the 'obvious' distinct-subset-sums construction, are provably beaten for every n from 4 to 8, and the gap 2^(n-1) − max(cgₙ) = 1,3,8,20,44 widens with n.",
+    "openQuestions": [
+      "Does the Conway–Guy difference set have largest element < 2^(n-1) for ALL n ≥ 4? This requires the general recurrence a(n+1) = 2a(n) − a(n−round(√(2n))) and an inductive proof of subset-sum distinctness for which no elementary argument is known.",
+      "Are the Conway–Guy sets optimal, i.e. do they attain f(n)? This is verified computationally only for n ≤ 10 and is open for n ≥ 11.",
+      "Erdős's original question: is f(n) ≥ c·2ⁿ for an absolute constant c? The best known lower bounds (Erdős–Moser type, via the second moment method) fall short of the conjectured constant.",
+      "Can kernel `decide` be pushed past n = 8 without native_decide, e.g. by a smarter reflected decision procedure that avoids materializing the full 2ⁿ-element subset-sum finset?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-1-wip-01-oq-03` (Erdős #1: the Conway–Guy construction beats powers of two). Quality score **28 → 100**.

## Changes
- **Added `annotations.json`** — 8 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering: the module overview, the maxRecDepth option, the decidable DSS criterion (`hasDistinctSubsetSums_iff_image_card`), the `2^|A|` count form, the Conway–Guy witnesses cg4…cg8, the kernel-`decide` DSS certificates, the element bounds, and the packaged `conwayGuy_beats_powers_of_two` theorem.
- **Added `conclusion`** to meta.json — summary, implications, and 4 open questions (all-n gap, optimality open for n ≥ 11, Erdős lower bound, pushing kernel decide past n = 8).
- **Split the witnesses section** into defs / certificates so `sections` covers the full Lean file (now 5 sections).

## Axiom integrity
No status/badge changes. The entry claims axiom-free via kernel `decide` (not `native_decide`), so no `Lean.ofReduceBool`; the added annotations state this explicitly and accurately.

Built via git-plumbing on top of `origin/main`; verified the diff is exactly these 2 files with no spurious deletions.