### PR TITLE
Enrich Euler totient Gauss-identity characterization (euler-totient-oq-02-oq-04)

### DIFF
--- a/src/data/proofs/euler-totient-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-04/annotations.json
@@ -36,15 +36,27 @@
     "prerequisites": ["Möbius inversion", "divisorsAntidiagonal"]
   },
   {
-    "id": "ann-characterization",
+    "id": "ann-mult-corollary",
     "proofId": "euler-totient-oq-02-oq-04",
-    "range": { "startLine": 94, "endLine": 116 },
+    "range": { "startLine": 94, "endLine": 98 },
     "type": "theorem",
-    "title": "Multiplicative Corollary and the {φ} Solution Set",
-    "content": "eq_totient_of_multiplicative_of_sum_eq answers the open question in its literal wording — φ is the unique multiplicative function satisfying Gauss's identity — obtained immediately from the stronger uniqueness (the multiplicativity hypothesis is displayed but never used). sum_eq_iff_eq_totient sharpens this to an iff: a function satisfies the divisor-sum identity iff it equals φ on the positive integers, so the solution set of Gauss's identity is exactly the singleton {φ}. The reverse direction folds f = φ back through sum congruence and Gauss's identity.",
-    "mathContext": "$\\{\\,f : \\sum_{d\\mid n} f(d) = n\\ \\forall n>0\\,\\} = \\{\\varphi\\}.$",
+    "title": "The Open Question's Literal Form",
+    "content": "eq_totient_of_multiplicative_of_sum_eq answers the open question in its exact wording: φ is the unique MULTIPLICATIVE function satisfying Gauss's divisor-sum identity. Faithful to the question, the multiplicativity premise f(1)=1 ∧ f(mn)=f(m)f(n) is written into the signature as _hmul — but the proof term is literally `eq_totient_of_sum_eq f hf`, so the hypothesis is never consumed. This is the file's honest disclosure that the 'multiplicative' qualifier in the question is redundant: the divisor-sum identity already forces the function to be φ, hence in particular multiplicative.",
+    "mathContext": "$\\big(f\\text{ multiplicative}\\ \\wedge\\ \\forall n>0,\\ \\sum_{d\\mid n} f(d)=n\\big) \\Rightarrow f=\\varphi$; the multiplicativity hypothesis is inert.",
+    "significance": "supporting",
+    "relatedConcepts": ["unique multiplicative function", "redundant hypothesis", "characterization", "Euler's totient"],
+    "prerequisites": ["the uniqueness theorem eq_totient_of_sum_eq"]
+  },
+  {
+    "id": "ann-solution-set",
+    "proofId": "euler-totient-oq-02-oq-04",
+    "range": { "startLine": 100, "endLine": 116 },
+    "type": "insight",
+    "title": "The Solution Set Is Exactly {φ}",
+    "content": "sum_eq_iff_eq_totient promotes the one-way uniqueness to a biconditional: f satisfies Gauss's divisor-sum identity on the positive integers iff f equals φ there. The forward implication is exactly eq_totient_of_sum_eq. The reverse assumes f = φ pointwise and computes the divisor sum by Finset.sum_congr — rewriting each term f(d) to φ(d) for d ∈ n.divisors (using Nat.pos_of_mem_divisors to invoke the pointwise equality) — then closes with totient_sum_eq. The upshot is the sharpest reading of 'characterizes': the solution set {f : Σ_{d|n} f(d) = n ∀ n>0} is the singleton {φ}.",
+    "mathContext": "$\\big(\\forall n>0,\\ \\sum_{d\\mid n} f(d)=n\\big) \\iff \\big(\\forall n>0,\\ f(n)=\\varphi(n)\\big)$, so $\\{f : f\\ast\\zeta=\\mathrm{id}\\} = \\{\\varphi\\}$.",
     "significance": "key",
-    "relatedConcepts": ["characterization", "unique multiplicative function", "Finset.sum_congr", "solution set"],
-    "prerequisites": ["the uniqueness theorem", "sum congruence"]
+    "relatedConcepts": ["biconditional characterization", "Finset.sum_congr", "Nat.pos_of_mem_divisors", "solution set", "singleton"],
+    "prerequisites": ["the uniqueness theorem", "sum congruence over divisors"]
   }
 ]

--- a/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-04/meta.json
@@ -126,12 +126,20 @@
       "mathContext": "$f \\ast \\zeta = \\mathrm{id} = \\varphi \\ast \\zeta \\ \\Rightarrow\\ f = \\mathrm{id}\\ast\\mu = \\varphi.$"
     },
     {
-      "id": "characterization",
-      "title": "Multiplicative Corollary and the {φ} Solution Set",
+      "id": "mult-corollary",
+      "title": "The Open Question's Literal Form: Unique Multiplicative Solution",
       "startLine": 94,
+      "endLine": 98,
+      "summary": "eq_totient_of_multiplicative_of_sum_eq answers the open question exactly as posed — φ is the unique multiplicative function satisfying Gauss's divisor-sum identity. The proof discards the multiplicativity hypothesis (displayed as _hmul for faithfulness) and delegates to the stronger eq_totient_of_sum_eq, making explicit that multiplicativity is redundant for uniqueness.",
+      "mathContext": "$\\big(f\\text{ mult.}\\wedge \\sum_{d\\mid n} f(d)=n\\big) \\Rightarrow f=\\varphi$; the multiplicativity premise is inert."
+    },
+    {
+      "id": "solution-set",
+      "title": "The Solution Set Is Exactly {φ}",
+      "startLine": 100,
       "endLine": 116,
-      "summary": "eq_totient_of_multiplicative_of_sum_eq answers the open question in its literal form (φ is the unique multiplicative solution), immediately from the stronger uniqueness. sum_eq_iff_eq_totient adds the converse via sum congruence and Gauss's identity, showing the Gauss identity's solution set is exactly {φ}.",
-      "mathContext": "$\\{\\,f : \\textstyle\\sum_{d\\mid n} f(d) = n\\,\\} = \\{\\varphi\\}.$"
+      "summary": "sum_eq_iff_eq_totient upgrades uniqueness to a biconditional: f satisfies Gauss's divisor-sum identity on the positives iff f = φ there. The forward direction reuses eq_totient_of_sum_eq; the reverse rewrites Σ_{d|n} f(d) via Finset.sum_congr into Σ_{d|n} φ(d) and closes with totient_sum_eq. This exhibits the identity's solution set as the singleton {φ}.",
+      "mathContext": "$\\big(\\forall n>0,\\ \\sum_{d\\mid n} f(d)=n\\big) \\iff \\big(\\forall n>0,\\ f(n)=\\varphi(n)\\big).$"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-02-oq-04`. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the combined characterization block at the theorem boundary into (a) `eq_totient_of_multiplicative_of_sum_eq` — the open question's literal 'unique multiplicative function' form, with an honest note that the multiplicativity premise is inert — and (b) `sum_eq_iff_eq_totient` — the biconditional showing the divisor-sum identity's solution set is exactly {φ}.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries (only propext/Classical.choice/Quot.sound), consistent with the Lean file's stated status.

Built via git-plumbing on origin/main; diff verified as exactly the 2 JSON files.