### PR TITLE
Enrich Hockey-Stick Identity and Figurate Numbers

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
@@ -61,7 +61,7 @@
     "definitionCount": 0
   },
   "overview": {
-    "historicalContext": "The hockey-stick identity — that summing a diagonal of Pascal's triangle gives the entry just below the end of the diagonal — appears in Zhu Shijie's 1303 *Jade Mirror of the Four Unknowns* and is named for the shape the summed cells trace. Its specializations are the oldest sums in mathematics: r = 1 gives Gauss's 1+2+…+n = n(n+1)/2, and r = 2 gives the tetrahedral numbers (partial sums of triangular numbers). The identity is equivalent to repeated application of Pascal's rule.",
+    "historicalContext": "The hockey-stick identity — that summing a diagonal of Pascal's triangle gives the single entry just below and beyond the diagonal's end — appears in Zhu Shijie's 1303 *Jade Mirror of the Four Unknowns* (Siyuan yujian), one of the high points of Chinese algebra, centuries before Pascal's 1654 *Traité du triangle arithmétique* gave the triangle its European name. The modern nickname comes from the shape the summed cells trace on the triangle: a straight blade of consecutive diagonal entries ending in a bent 'toe' at the result; it is also called the Christmas-stocking identity. Its specializations are among the oldest sums in mathematics: the r = 1 diagonal is Gauss's 1+2+…+n = n(n+1)/2, the triangular numbers studied by the Pythagoreans and catalogued in Nicomachus's *Introduction to Arithmetic* (c. 100 CE); the r = 2 diagonal gives the tetrahedral numbers, the partial sums of triangular numbers. Structurally the whole identity is nothing more than Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1) telescoped down a diagonal, which is exactly the inductive proof formalized here.",
     "problemStatement": "Derive the hockey-stick identity C(r,r)+C(r+1,r)+…+C(n,r) = C(n+1,r+1) from the binomial framework using Finset.sum_range_succ and a telescoping (Pascal) argument.",
     "text": "An independent induction proof of the hockey-stick identity plus its figurate-number consequences.",
     "proofStrategy": "Induction on n in the diagonal form ∑_{i=0}^{n} C(r+i, r) = C(r+n+1, r+1). The base case is C(r,r) = C(r+1,r+1) = 1. The step peels the top term with Finset.sum_range_succ, applies the induction hypothesis, and closes with Pascal's rule Nat.choose_succ_succ: C(r+m+1, r+1) + C(r+m+1, r) = C(r+m+2, r+1). The interval form is Mathlib's Nat.sum_Icc_choose; specializing it at r = 1 (with C(m,1) = m) yields Gauss's sum, and at r = 2 the tetrahedral numbers.",
@@ -81,11 +81,19 @@
   },
   "sections": [
     {
+      "id": "prelude",
+      "title": "Imports and Framing of OQ#2",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring framing the parent's second open question, the Mathlib import, the BinomialHockeyStick namespace, and the Part I header introducing the inductive route to the hockey-stick identity.",
+      "mathContext": "Goal: ∑_{i=0}^{n} C(r+i,r) = C(r+n+1,r+1)."
+    },
+    {
       "id": "hockey-induction",
       "title": "The Hockey-Stick Identity by Induction",
-      "startLine": 1,
+      "startLine": 42,
       "endLine": 51,
-      "summary": "Module docstring framing OQ#2. Proves ∑_{i≤n} C(r+i,r) = C(r+n+1,r+1) by induction with Finset.sum_range_succ and Pascal's rule — the telescoping derivation requested.",
+      "summary": "Proves the diagonal form ∑_{i≤n} C(r+i,r) = C(r+n+1,r+1) by induction on n: Finset.sum_range_succ peels the top term, the IH rewrites the remaining sum, and Pascal's rule Nat.choose_succ_succ closes each step (after normalizing r+(m+1) = r+m+1).",
       "mathContext": "Step: C(r+m+1,r+1) + C(r+m+1,r) = C(r+m+2,r+1) by Pascal."
     },
     {
@@ -93,16 +101,24 @@
       "title": "Interval Form (Mathlib)",
       "startLine": 52,
       "endLine": 60,
-      "summary": "Relates the diagonal form to Mathlib's Nat.sum_Icc_choose: ∑_{m∈Icc r n} C(m,r) = C(n+1,r+1).",
+      "summary": "Part II relates the diagonal form to Mathlib's Nat.sum_Icc_choose, giving the interval phrasing ∑_{m∈Icc r n} C(m,r) = C(n+1,r+1) alongside the range form.",
       "mathContext": "Both standard phrasings of the hockey-stick identity."
     },
     {
-      "id": "figurate",
-      "title": "Figurate-Number Consequences",
+      "id": "gauss-sum",
+      "title": "Gauss's Sum (r = 1 diagonal)",
       "startLine": 61,
+      "endLine": 76,
+      "summary": "Part III begins with the r = 1 specialization: sum_Icc_id rewrites the interval form with C(m,1)=m to get 1+…+n = C(n+1,2), and gauss_sum expands C(n+1,2) via Nat.choose_two_right to the closed form n(n+1)/2.",
+      "mathContext": "C(m,1) = m; C(n+1,2) = n(n+1)/2 — the triangular numbers."
+    },
+    {
+      "id": "tetrahedral",
+      "title": "Tetrahedral Numbers (r = 2 diagonal) and Sanity Check",
+      "startLine": 77,
       "endLine": 84,
-      "summary": "Gauss's sum 1+…+n = C(n+1,2) = n(n+1)/2 (r=1), and tetrahedral numbers ∑ C(m,2) = C(n+1,3) (r=2); plus a numeric sanity check.",
-      "mathContext": "C(m,1) = m gives the triangular sum; C(m,2) summed gives the tetrahedral sequence."
+      "summary": "The r = 2 specialization sum_Icc_triangular: partial sums of triangular numbers ∑_{m∈Icc 2 n} C(m,2) = C(n+1,3) are the tetrahedral numbers, followed by a decide-checked numeric sanity test 1+2+3+4+5 = 15 = C(6,2).",
+      "mathContext": "∑ C(m,2) = C(n+1,3); numeric check ∑_{m=1}^{5} m = 15 = C(6,2)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-02-oq-02` (quality 93 → 100).

## Changes
- **historicalContext**: expanded past the depth threshold with Zhu Shijie's 1303 *Jade Mirror* vs. Pascal's 1654 *Traité*, the origin of the 'hockey-stick'/Christmas-stocking name, and the Pythagorean/Nicomachus lineage of triangular and tetrahedral numbers.
- **sections**: split 3 → 5 at theorem boundaries, covering all 84 lines (prelude/framing, inductive proof, Mathlib Icc form, Gauss's sum r=1, tetrahedral r=2 + numeric sanity check).

Annotations, keyInsights, conclusion, and crossReferences were already complete. meta.json is 14.3 KB, well under the 60 KB cap. No Lean changes; `verified` (0 axioms, 0 sorries).