### PR TITLE
Enrich Sum of Primitive n-th Roots of Unity = μ(n)

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/annotations.json
@@ -68,22 +68,45 @@
     ]
   },
   {
-    "id": "ann-dm0502-inversion",
+    "id": "ann-dm0502-partition",
     "proofId": "de-moivre-oq-05-oq-02",
     "range": {
       "startLine": 79,
-      "endLine": 123
+      "endLine": 96
+    },
+    "type": "insight",
+    "title": "The Divisor Partition ∑_{d∣n} f(d) = g(n)",
+    "content": "Phase 1 of the main theorem establishes the key partition. Every $n$-th root of unity is a primitive root of unity of a unique order $d\\mid n$, so the finset of $n$-th roots decomposes as the disjoint union $\\bigcup_{d\\mid n}\\operatorname{primitiveRoots}(d)$ (`IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots`). Pairwise disjointness across distinct orders comes from `IsPrimitiveRoot.disjoint`, and `Finset.sum_biUnion` then splits the total sum along the partition, giving $\\sum_{d\\mid n}f(d)=g(n)$ for every $n>0$. This is the divisor-sum relation that Möbius inversion will later untangle.",
+    "mathContext": "$\\sum_{d\\mid n} f(d) = g(n)$, from a disjoint biUnion of primitive-root sets over the divisors of $n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "divisor partition",
+      "primitive roots of unity",
+      "Finset.sum_biUnion",
+      "pairwise disjointness"
+    ],
+    "prerequisites": [
+      "divisors of a natural number",
+      "disjoint unions of finsets"
+    ]
+  },
+  {
+    "id": "ann-dm0502-inversion",
+    "proofId": "de-moivre-oq-05-oq-02",
+    "range": {
+      "startLine": 97,
+      "endLine": 125
     },
     "type": "insight",
     "title": "Möbius Inversion Collapses to μ(n)",
-    "content": "The main theorem assembles the pieces. First, the divisor partition `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` together with disjointness (`IsPrimitiveRoot.disjoint`) and `Finset.sum_biUnion` yields $\\sum_{d\\mid n}f(d)=g(n)$ for every $n>0$. Feeding this to `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` inverts the relation to $f(n)=\\sum_{(a,b):ab=n}\\mu(a)\\,g(b)$. Because $g(b)=[b=1]$, every antidiagonal term with $b\\neq 1$ dies, leaving only $(a,b)=(n,1)$: $f(n)=\\mu(n)\\cdot g(1)=\\mu(n)$. The $n=0$ case is separate ($\\varnothing$ sum $=0=\\mu(0)$).",
+    "content": "Phase 2 inverts the partition. Feeding $\\sum_{d\\mid n}f(d)=g(n)$ to `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` gives $f(n)=\\sum_{(a,b):ab=n}\\mu(a)\\,g(b)$, a sum over `n.divisorsAntidiagonal`. The payoff is the sparsity of $g$: since $g(b)=[b=1]$, `Finset.sum_eq_single (n,1)` discards every antidiagonal term with $b\\neq 1$ (each contributes $\\mu(a)\\cdot 0$ via `sum_nthRootsFinset` and `if_neg`), leaving the single surviving term $(a,b)=(n,1)$: $f(n)=\\mu(n)\\cdot g(1)=\\mu(n)$. The $n=0$ case is handled separately, where the empty sum equals $0=\\mu(0)$.",
     "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$; the single surviving divisor term is the heart of the inversion.",
     "significance": "critical",
     "relatedConcepts": [
       "Möbius inversion",
-      "divisor partition",
-      "Finset.sum_biUnion",
-      "divisorsAntidiagonal"
+      "divisorsAntidiagonal",
+      "Finset.sum_eq_single",
+      "arithmetic functions"
     ],
     "prerequisites": [
       "Möbius inversion over a ring",

--- a/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
@@ -130,12 +130,20 @@
       "mathContext": "$g(n)=\\sum_{i<n}\\zeta^i$. For $n=1$ this is $\\zeta^0=1$; for $n>1$ the geometric series telescopes to $0$ since $\\zeta\\neq 1$ but $\\zeta^n=1$."
     },
     {
-      "id": "main-inversion",
-      "title": "Part III: Möbius Inversion Yields μ(n)",
-      "summary": "sum_primitiveRoots_eq_moebius: the partition ∑_{d∣n} f(d) = g(n) (sum_biUnion + disjointness) feeds Möbius inversion; only the divisor d = 1 survives, giving μ(n)·g(1) = μ(n)",
+      "id": "divisor-partition",
+      "title": "Part III: The Divisor Partition ∑_{d∣n} f(d) = g(n)",
+      "summary": "sum_primitiveRoots_eq_moebius, phase 1 (the hpart block): since every n-th root of unity is primitive of a unique order d ∣ n, the root set is the disjoint biUnion of primitiveRoots d over d ∣ n; IsPrimitiveRoot.disjoint gives pairwise disjointness and Finset.sum_biUnion turns it into ∑_{d∣n} f(d) = g(n) for every n > 0.",
       "startLine": 79,
-      "endLine": 123,
-      "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$ — the sparse support of $g$ collapses the inverted divisor sum to one term."
+      "endLine": 96,
+      "mathContext": "$\\sum_{d\\mid n} f(d) = g(n)$ via `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` and `Finset.sum_biUnion` over the pairwise-disjoint primitive-root sets."
+    },
+    {
+      "id": "moebius-inversion",
+      "title": "Part IV: Möbius Inversion Collapses to μ(n)",
+      "summary": "sum_primitiveRoots_eq_moebius, phase 2: ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq inverts the partition to f(n) = ∑_{(a,b):ab=n} μ(a)·g(b); Finset.sum_eq_single picks out (a,b) = (n,1), since g(b) = 0 for every b ≠ 1, leaving μ(n)·g(1) = μ(n). The n = 0 case is dispatched separately (empty sum = 0 = μ(0)).",
+      "startLine": 97,
+      "endLine": 125,
+      "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$ — the sparse support of $g$ ($g(b)=[b=1]$) collapses the inverted divisor sum to one term."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-02` (quality 93 → 100).

## Changes
- **annotations 4 → 5** and **sections 4 → 5**: split the coverage of the 45-line main theorem into its two natural phases — (III) the divisor partition ∑_{d∣n} f(d) = g(n) via disjoint biUnion + Finset.sum_biUnion (lines 79–96), and (IV) the Möbius inversion that collapses to μ(n) via sum_eq_single on the (n,1) antidiagonal term (lines 97–125).

historicalContext (732 chars), keyInsights, conclusion, mathContext, significance, and crossReferences were already complete. meta.json is 14.6 KB, well under the 60 KB cap. No Lean changes; `verified` (0 axioms, 0 sorries).