### PR TITLE
Enrich 2-adic unit group structure (euler-totient-oq-01-oq-02-oq-03)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/annotations.json
@@ -38,13 +38,25 @@
   {
     "id": "ann-eulertot010203-structure",
     "proofId": "euler-totient-oq-01-oq-02-oq-03",
-    "range": { "startLine": 137, "endLine": 165 },
+    "range": { "startLine": 137, "endLine": 155 },
     "type": "insight",
-    "title": "The Internal Direct Product and Carmichael Recovery",
-    "content": "Section III assembles the theorem. card_units computes |(ℤ/2ⁿ⁺³ℤ)ˣ| = φ(2ⁿ⁺³) = 2ⁿ⁺². isComplement'_neg_one_five then feeds the disjointness (the crux) and the order count |⟨−1⟩|·|⟨5⟩| = 2·2ⁿ⁺¹ = 2ⁿ⁺² = |G| to isComplement'_of_card_mul_and_disjoint, yielding the internal direct product (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩ — so every unit is uniquely (−1)ᵃ·5ᵇ. Finally carmichael_two_pow recovers the parent's λ(2ᵏ) = 2ᵏ⁻² as the exponent of the product (lcm of the factor orders), delegating the arithmetic to Mathlib's carmichael_two_pow_of_ne_two.",
-    "mathContext": "Disjoint $+$ $|H|\\cdot|K| = |G|$ $\\Rightarrow$ $\\mathrm{IsComplement}'$; the product's exponent is $\\mathrm{lcm}(2, 2^{n+1}) = 2^{n+1} = 2^{k-2} = \\lambda(2^k)$.",
+    "title": "The Internal Direct Product (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩",
+    "content": "This is the structure theorem itself. card_units first pins the group order: |(ℤ/2ⁿ⁺³ℤ)ˣ| = φ(2ⁿ⁺³) = 2ⁿ⁺², via ZMod.card_units_eq_totient and Nat.totient_prime_pow_succ. isComplement'_neg_one_five then combines two facts — the disjointness ⟨−1⟩ ∩ ⟨5⟩ = {1} from the crux, and the order count |⟨−1⟩|·|⟨5⟩| = 2·2ⁿ⁺¹ = 2ⁿ⁺² = |G| — through isComplement'_of_card_mul_and_disjoint. The conclusion IsComplement' means multiplication ⟨−1⟩ × ⟨5⟩ → (ℤ/2ᵏℤ)ˣ is a bijection, i.e. every unit is UNIQUELY (−1)ᵃ·5ᵇ with a ∈ {0,1}, 0 ≤ b < 2ᵏ⁻². That uniqueness is exactly the classical two-generator decomposition (ℤ/2ᵏℤ)ˣ ≅ ℤ/2 × ℤ/2ᵏ⁻².",
+    "mathContext": "$\\mathrm{Disjoint} \\wedge |H|\\cdot|K| = |G| \\Rightarrow \\mathrm{IsComplement}'$; hence $(\\mathbb{Z}/2^k\\mathbb{Z})^\\times = \\langle -1\\rangle \\times \\langle 5\\rangle \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2^{k-2}$.",
     "significance": "key",
-    "relatedConcepts": ["IsComplement'", "isComplement'_of_card_mul_and_disjoint", "exponent of a direct product", "ZMod.card_units_eq_totient"],
+    "relatedConcepts": ["IsComplement'", "isComplement'_of_card_mul_and_disjoint", "internal direct product", "ZMod.card_units_eq_totient"],
     "prerequisites": ["the disjointness lemma", "the order count", "complementary subgroups"]
+  },
+  {
+    "id": "ann-eulertot010203-carmichael",
+    "proofId": "euler-totient-oq-01-oq-02-oq-03",
+    "range": { "startLine": 157, "endLine": 165 },
+    "type": "insight",
+    "title": "Recovering λ(2ᵏ) = 2ᵏ⁻² as the Product's Exponent",
+    "content": "carmichael_two_pow closes the loop back to the parent entry. The Carmichael function λ(m) is the exponent of (ℤ/mℤ)ˣ, and the exponent of a direct product is the lcm of the factor exponents. From the decomposition ⟨−1⟩ × ⟨5⟩ with factor orders 2 and 2ⁿ⁺¹, the exponent is lcm(2, 2ⁿ⁺¹) = 2ⁿ⁺¹ = 2ᵏ⁻² — strictly below the group order φ(2ᵏ) = 2ᵏ⁻¹, the quantitative signature of non-cyclicity. The Lean proof rewrites k = n+3 (so 2ᵏ⁻² becomes the honest power 2ⁿ⁺¹) and delegates the value to Mathlib's carmichael_two_pow_of_ne_two, exhibiting the structure theorem as the true explanation of the parent's recorded value.",
+    "mathContext": "$\\lambda(2^k) = \\exp(\\langle-1\\rangle \\times \\langle5\\rangle) = \\mathrm{lcm}(2, 2^{k-2}) = 2^{k-2} < 2^{k-1} = \\varphi(2^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["Carmichael function", "exponent of a direct product", "lcm of orders", "non-cyclic unit group"],
+    "prerequisites": ["the structure theorem", "carmichael_two_pow_of_ne_two", "group exponent"]
   }
 ]

--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
@@ -115,11 +115,19 @@
     },
     {
       "id": "structure",
-      "title": "Section III: The Structure Theorem and Carmichael Recovery",
+      "title": "Section III: The Internal Direct Product ⟨−1⟩ × ⟨5⟩",
       "startLine": 137,
+      "endLine": 155,
+      "summary": "card_units computes |(ℤ/2ⁿ⁺³ℤ)ˣ| = φ(2ⁿ⁺³) = 2ⁿ⁺² via ZMod.card_units_eq_totient and Nat.totient_prime_pow_succ. isComplement'_neg_one_five then feeds the disjointness (the crux) and the order count |⟨−1⟩|·|⟨5⟩| = 2·2ⁿ⁺¹ = 2ⁿ⁺² = |G| into isComplement'_of_card_mul_and_disjoint, yielding the internal direct product (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩ — every unit uniquely (−1)ᵃ·5ᵇ.",
+      "mathContext": "Disjoint $\\wedge\\ |H|\\cdot|K| = |G|\\ \\Rightarrow\\ \\mathrm{IsComplement}'$; $(\\mathbb{Z}/2^k\\mathbb{Z})^\\times = \\langle -1\\rangle \\times \\langle 5\\rangle$."
+    },
+    {
+      "id": "carmichael",
+      "title": "Section IV: Recovering λ(2ᵏ) = 2ᵏ⁻² from the Structure",
+      "startLine": 157,
       "endLine": 166,
-      "summary": "card_units (|(ℤ/2ⁿ⁺³ℤ)ˣ| = 2ⁿ⁺²), isComplement'_neg_one_five (the internal direct product (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩), and carmichael_two_pow (recovering λ(2ᵏ) = 2ᵏ⁻²).",
-      "mathContext": "Disjointness plus the order count give the IsComplement' decomposition, whose exponent is λ(2ᵏ)."
+      "summary": "carmichael_two_pow recovers the parent's value λ(2ᵏ) = 2ᵏ⁻² as the exponent of the direct product — the lcm of the factor orders lcm(2, 2ⁿ⁺¹) = 2ⁿ⁺¹ — delegating the arithmetic to Mathlib's carmichael_two_pow_of_ne_two after rewriting k = n+3 so the exponent 2ᵏ⁻² is the genuine power 2ⁿ⁺¹.",
+      "mathContext": "$\\lambda(2^k) = \\mathrm{lcm}(2, 2^{k-2}) = 2^{k-2} = 2^{n+1}$, the order of the larger factor $\\langle 5\\rangle$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-02-oq-03` — (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩ structure theorem. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the combined Section III at the theorem boundary into (a) the internal-direct-product structure theorem `isComplement'_neg_one_five` (with `card_units`) and (b) the Carmichael-recovery corollary `carmichael_two_pow` (λ(2ᵏ) = 2ᵏ⁻² as the product's exponent). Each new annotation carries mathContext/significance/relatedConcepts/prerequisites.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries, no native_decide.

Built via git-plumbing on origin/main; diff verified non-empty and exactly the 2 JSON files via the 3-dot compare API (index.ts left untouched).