### PR TITLE
Enrich Explicit Reiman Bound for C₄-free graphs (erdos-1008-oq-02)

### DIFF
--- a/src/data/proofs/erdos-1008-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1008-oq-02/annotations.json
@@ -26,14 +26,26 @@
   {
     "id": "ann-1008oq02-graph-bound",
     "proofId": "erdos-1008-oq-02",
-    "range": { "startLine": 71, "endLine": 99 },
+    "range": { "startLine": 71, "endLine": 88 },
     "type": "proof",
     "title": "c4free_edge_bound_explicit — the explicit graph bound",
-    "content": "Instantiates the abstract lemma at $n = |V|$, $m = \\#E(G)$, $s = \\sqrt{4n-3}$, feeding in the parent's axiom-free theorem `Erdos1008.kovari_sos_turan`. With $|V| \\ge 1$ the radicand $4n-3 \\ge 0$, so `Real.sq_sqrt` gives $s^2 = 4n-3$, and `reiman_quadratic_solve` yields $4m \\le n(1+s)$, i.e. $m \\le \\tfrac14 n(1+\\sqrt{4n-3})$. `c4free_four_mul_edge_le` restates the same fact in cleared-denominator product form. Crucially the corollary uses only the parent's KST theorem, never its `axiom erdos_1008`, so it is fully verified.",
+    "content": "Instantiates the abstract lemma at $n = |V|$, $m = \\#E(G)$, $s = \\sqrt{4n-3}$, feeding in the parent's axiom-free theorem `Erdos1008.kovari_sos_turan`. With $|V| \\ge 1$ the radicand $4n-3 \\ge 0$, so `Real.sq_sqrt` gives $s^2 = 4n-3$, and `reiman_quadratic_solve` yields $4m \\le n(1+s)$, i.e. $m \\le \\tfrac14 n(1+\\sqrt{4n-3})$. Crucially the corollary uses only the parent's KST theorem, never its `axiom erdos_1008`, so it is fully verified.",
     "mathContext": "$\\#E(G) \\le \\tfrac14\\,|V|\\,(1+\\sqrt{4|V|-3})$ for $C_4$-free $G$, $|V|\\ge1$",
     "significance": "critical",
     "relatedConcepts": ["Real.sqrt", "Kővári–Sós–Turán", "edge density bound"],
     "prerequisites": ["real square roots", "the parent KST formalization"]
+  },
+  {
+    "id": "ann-1008oq02-product-form",
+    "proofId": "erdos-1008-oq-02",
+    "range": { "startLine": 89, "endLine": 99 },
+    "type": "proof",
+    "title": "c4free_four_mul_edge_le — the bound in product form",
+    "content": "Restates `c4free_edge_bound_explicit` with denominators cleared: $4\\,\\#E(G) \\le |V|\\,(1+\\sqrt{4|V|-3})$. This is the phrasing that avoids division in $\\mathbb{R}$ and is most convenient for feeding into later algebraic estimates (e.g. multiplying through or combining with other edge-count inequalities), where a $\\tfrac14$ factor would otherwise obstruct `nlinarith`/`ring` normalization. Same content as the explicit bound, one `linarith`/`ring` step away.",
+    "mathContext": "$4\\,\\#E(G) \\le |V|\\,(1+\\sqrt{4|V|-3})$ — the cleared-denominator form of the Reiman bound",
+    "significance": "supporting",
+    "relatedConcepts": ["cleared denominators", "edge density bound", "product-form inequalities"],
+    "prerequisites": ["ordered field arithmetic"]
   },
   {
     "id": "ann-1008oq02-root-exact",

--- a/src/data/proofs/erdos-1008-oq-02/meta.json
+++ b/src/data/proofs/erdos-1008-oq-02/meta.json
@@ -70,9 +70,17 @@
       "id": "graph-bound",
       "title": "The Explicit Graph Bound",
       "startLine": 71,
+      "endLine": 88,
+      "summary": "`c4free_edge_bound_explicit`: a $C_4$-free graph on $n=|V|\\ge1$ vertices has $\\le \\tfrac14 n(1+\\sqrt{4n-3})$ edges. Instantiates `reiman_quadratic_solve` at $n=|V|$, $m=\\#E(G)$, $s=\\sqrt{4n-3}$ (so $s^2=4n-3$ by `Real.sq_sqrt`), fed by the parent's axiom-free `Erdos1008.kovari_sos_turan`.",
+      "mathContext": "$\\#E(G) \\le \\tfrac14\\,|V|\\,(1+\\sqrt{4|V|-3})$ for $C_4$-free $G$, $|V|\\ge1$."
+    },
+    {
+      "id": "product-form",
+      "title": "Product Form of the Bound",
+      "startLine": 89,
       "endLine": 99,
-      "summary": "`c4free_edge_bound_explicit`: a $C_4$-free graph on $n=|V|\\ge1$ vertices has $\\le \\tfrac14 n(1+\\sqrt{4n-3})$ edges, via the parent `kovari_sos_turan` and `reiman_quadratic_solve`. `c4free_four_mul_edge_le` restates it in product form $4m \\le n(1+\\sqrt{4n-3})$.",
-      "mathContext": "$\\#E(G) \\le \\tfrac14\\,|V|\\,(1+\\sqrt{4|V|-3})$ for $C_4$-free $G$."
+      "summary": "`c4free_four_mul_edge_le`: the same bound with cleared denominators, $4\\,\\#E(G) \\le |V|\\,(1+\\sqrt{4|V|-3})$ — the form most convenient for downstream algebraic manipulation, avoiding division in ℝ.",
+      "mathContext": "$4\\,\\#E(G) \\le |V|\\,(1+\\sqrt{4|V|-3})$ for $C_4$-free $G$."
     },
     {
       "id": "root-exact",


### PR DESCRIPTION
Enrichment pass for `erdos-1008-oq-02` (quality 93 → 100).

## Changes
- **annotations 4 → 5** and **sections 4 → 5**: split the graph-bound coverage into two lemmas — `c4free_edge_bound_explicit` (the explicit ¼·n(1+√(4n-3)) edge bound, lines 71–88) and `c4free_four_mul_edge_le` (the cleared-denominator product form, lines 89–99).

historicalContext (1054 chars), keyInsights, conclusion, mathContext, significance, and crossReferences were already complete. meta.json is 9.9 KB, well under the 60 KB cap. No Lean changes; the entry stays fully verified (uses only the parent's KST theorem, not its axiom).