### PR TITLE
Enrich explicit Carmichael function (euler-totient-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/annotations.json
@@ -69,23 +69,45 @@
     ]
   },
   {
+    "id": "ann-euler-sharpened",
+    "proofId": "euler-totient-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 105
+    },
+    "type": "insight",
+    "title": "Euler's Theorem, Sharpened",
+    "content": "pow_carmichael_eq_one records the universal-exponent property a^{λ(n)} = 1 for every unit a ∈ (ℤ/nℤ)ˣ — the sharp form of Euler's theorem, which only asserts a^{φ(n)} = 1. carmichael_dvd_totient' records the complementary fact λ(n) ∣ φ(n), so the Carmichael exponent never exceeds and always divides Euler's totient; the two together say λ(n) is the TRUE (least) universal exponent, refining φ(n). Both are thin re-exports of Mathlib's pow_carmichael and carmichael_dvd_totient, presented here as the headline corollaries that motivate studying λ at all.",
+    "mathContext": "$a^{\\lambda(n)} = 1$ for all $a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times$, and $\\lambda(n) \\mid \\varphi(n)$; $\\lambda(n)$ is the exponent (least universal power), $\\varphi(n)$ merely a universal power.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pow_carmichael",
+      "carmichael_dvd_totient",
+      "Euler's theorem",
+      "group exponent"
+    ],
+    "prerequisites": [
+      "Euler's theorem a^φ(n) ≡ 1",
+      "exponent divides order"
+    ]
+  },
+  {
     "id": "ann-concrete",
     "proofId": "euler-totient-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 104,
+      "startLine": 107,
       "endLine": 136
     },
     "type": "insight",
-    "title": "Euler Sharpened and the First Carmichael Number",
-    "content": "pow_carmichael_eq_one and carmichael_dvd_totient' re-export the universal exponent a^{λ(n)}=1 and λ(n) ∣ φ(n). The concrete block computes λ(15)=lcm(2,4)=4 and λ(561)=lcm(2,10,16)=80 (561=3·11·17, the first Carmichael number) by iterating carmichael_mul over the coprime prime factors, with carmichael_odd_prime giving each λ(p)=p−1 and the kernel (decide) reducing the nested lcm. carmichael_561_dvd_560 records the Korselt witness 80 ∣ 560=561−1 that makes 561 a Carmichael number.",
-    "mathContext": "Korselt's criterion: a squarefree composite $n$ is a Carmichael number iff $\\lambda(n) \\mid n-1$. For $n=561$, $\\lambda(561)=80 \\mid 560$, so $a^{560}\\equiv 1 \\pmod{561}$ for every $a$ coprime to 561 — 561 is a Fermat pseudoprime to every such base.",
-    "significance": "supporting",
+    "title": "Concrete Evaluations and the First Carmichael Number",
+    "content": "The concrete block computes λ(15) = lcm(2,4) = 4 and λ(561) = lcm(2,10,16) = 80 (561 = 3·11·17, the first Carmichael number) by iterating carmichael_mul over the coprime prime factors, with carmichael_odd_prime giving each λ(p) = p−1 and kernel `decide` reducing the nested lcm. carmichael_561_dvd_560 records the Korselt witness 80 ∣ 560 = 561−1: since λ(561) ∣ 561−1, every a coprime to 561 satisfies a^{560} ≡ 1 (mod 561), which is exactly why 561 is a Carmichael (Fermat-pseudoprime-to-every-base) number. These specific values are genuinely absent from Mathlib.",
+    "mathContext": "Korselt's criterion: a squarefree composite $n$ is a Carmichael number iff $\\lambda(n) \\mid n-1$. For $n=561$: $\\lambda(561)=80 \\mid 560$, so $a^{560}\\equiv 1 \\pmod{561}$ for every $a$ coprime to 561.",
+    "significance": "key",
     "relatedConcepts": [
       "carmichael_mul",
-      "pow_carmichael",
-      "carmichael_dvd_totient",
       "Korselt's criterion",
-      "Carmichael number"
+      "Carmichael number",
+      "Fermat pseudoprime"
     ],
     "prerequisites": [
       "lcm computation",

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
@@ -119,6 +119,14 @@
   },
   "sections": [
     {
+      "id": "overview-framing",
+      "title": "Overview: What Mathlib Already Has vs. What This Adds",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "The docblock is explicit that the parent's requested identity λ(n) = lcm_i λ(pᵢ^{kᵢ}) is already Mathlib's ArithmeticFunction.carmichael_factorization, alongside the per-prime-power closed forms carmichael_pow_of_prime_ne_two (odd p) and carmichael_two_pow_of_ne_two (p=2). Rather than reprove these as thin wrappers, the file cites them and contributes the genuinely unassembled pieces: the explicit closed form λ(n) = lcm_{p|n} p^{k_p−1}(p−1) for odd n, and concrete Carmichael-number evaluations (notably 561) absent from Mathlib.",
+      "mathContext": "$\\lambda(n)$ is the exponent of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$; via CRT $\\lambda(\\prod p_i^{k_i}) = \\operatorname{lcm}_i \\lambda(p_i^{k_i})$ and $\\lambda(n)\\mid\\varphi(n)$."
+    },
+    {
       "id": "odd-prime-power-values",
       "title": "Explicit Values on Odd Prime Powers",
       "startLine": 49,


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-01-oq-01` — the explicit Carmichael closed form and λ(561)=80. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5:** added an overview/framing section covering the honesty docblock (what Mathlib already provides via `carmichael_factorization` vs. what this file assembles).
- **Annotations 4 → 5:** split the combined corollary+evaluations annotation at the theorem boundary into 'Euler's Theorem, Sharpened' (`pow_carmichael_eq_one`, `carmichael_dvd_totient'`) and 'Concrete Evaluations and the First Carmichael Number' (λ(15), λ(561), Korselt witness). Each carries mathContext/significance/relatedConcepts/prerequisites.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries.

Built via git-plumbing from the origin/main blob (robust against working-tree contention); diff verified non-empty and exactly the 2 JSON files via the 3-dot compare API.