### PR TITLE
Enrich Egorov's theorem (egorov-theorem-oq-01)

### DIFF
--- a/src/data/proofs/egorov-theorem-oq-01/annotations.json
+++ b/src/data/proofs/egorov-theorem-oq-01/annotations.json
@@ -2,49 +2,122 @@
   {
     "id": "ann-egorov-oq01-docstring",
     "proofId": "egorov-theorem-oq-01",
-    "range": { "startLine": 7, "endLine": 56 },
+    "range": {
+      "startLine": 7,
+      "endLine": 56
+    },
     "type": "concept",
     "title": "Egorov: a.e. Convergence Is Almost Uniform",
     "content": "The docstring states Egorov's theorem (Egorov 1911, Severini 1910): on a set s of FINITE measure, a.e. convergence fₙ → g of strongly measurable functions upgrades to UNIFORM convergence once a set of arbitrarily small measure is thrown away. Mathlib has the abstract theorem (tendstoUniformlyOn_of_ae_tendsto); restated for sequences as egorov_uniform_off_small_set. The mathematical substance added here is the canonical worked example xⁿ on [0,1], its a.e.-convergence verification, and the matching sharpness result showing the exceptional set is genuinely necessary. Fully verified, 0 sorries, 0 axioms, no native_decide.",
     "mathContext": "Egorov is Littlewood's second principle: 'every a.e.-convergent sequence of measurable functions is nearly uniformly convergent.' The finiteness of $\\mu(s)$ is essential.",
     "significance": "supporting",
-    "relatedConcepts": ["Egorov's theorem", "modes of convergence", "Littlewood's three principles", "uniform vs a.e. convergence", "Lusin's theorem"],
-    "prerequisites": ["measure theory", "almost-everywhere convergence", "uniform convergence"]
+    "relatedConcepts": [
+      "Egorov's theorem",
+      "modes of convergence",
+      "Littlewood's three principles",
+      "uniform vs a.e. convergence",
+      "Lusin's theorem"
+    ],
+    "prerequisites": [
+      "measure theory",
+      "almost-everywhere convergence",
+      "uniform convergence"
+    ]
   },
   {
     "id": "ann-egorov-oq01-general",
     "proofId": "egorov-theorem-oq-01",
-    "range": { "startLine": 63, "endLine": 79 },
+    "range": {
+      "startLine": 63,
+      "endLine": 79
+    },
     "type": "theorem",
     "title": "The Sequential Restatement",
     "content": "egorov_uniform_off_small_set specializes Mathlib's tendstoUniformlyOn_of_ae_tendsto to the index type ℕ. Hypotheses: each fₙ and g strongly measurable, s measurable with μ s ≠ ∞ (finite measure), and fₙ → g almost everywhere on s. Conclusion: for every ε > 0 there is a measurable t ⊆ s with μ t ≤ ENNReal.ofReal ε such that TendstoUniformlyOn f g atTop (s \\ t). The proof is a one-line re-export; its value is exposing the theorem in the ℕ-indexed shape the gallery's examples need, with the finite-measure hypothesis made explicit as μ s ≠ ∞.",
     "mathContext": "$f_n \\to g$ a.e. on measurable $s$ with $\\mu(s) < \\infty \\Rightarrow \\forall \\varepsilon>0\\ \\exists t \\subseteq s$ measurable, $\\mu(t) \\le \\varepsilon$, $f_n \\to g$ uniformly on $s \\setminus t$.",
     "significance": "supporting",
-    "relatedConcepts": ["tendstoUniformlyOn_of_ae_tendsto", "strong measurability", "finite measure", "TendstoUniformlyOn"],
-    "prerequisites": ["the abstract Egorov theorem", "ENNReal", "strongly measurable functions"]
+    "relatedConcepts": [
+      "tendstoUniformlyOn_of_ae_tendsto",
+      "strong measurability",
+      "finite measure",
+      "TendstoUniformlyOn"
+    ],
+    "prerequisites": [
+      "the abstract Egorov theorem",
+      "ENNReal",
+      "strongly measurable functions"
+    ]
   },
   {
     "id": "ann-egorov-oq01-ae",
     "proofId": "egorov-theorem-oq-01",
-    "range": { "startLine": 81, "endLine": 111 },
+    "range": {
+      "startLine": 81,
+      "endLine": 111
+    },
     "type": "insight",
     "title": "xⁿ → 0 a.e. and Egorov Applied",
     "content": "pow_ae_tendsto_zero_on_Icc establishes the a.e. hypothesis: via ae_iff, the failure set {x | x ∈ [0,1] ∧ xⁿ ↛ 0} is shown ⊆ {1} (for 0 ≤ x < 1, tendsto_pow_atTop_nhds_zero_of_lt_one gives xⁿ → 0, so any failure forces x = 1), and {1} has Lebesgue measure 0 (Real.volume_singleton), so by measure_mono_null the failure set is null. pow_egorov_on_Icc then discharges Egorov's four hypotheses: strong measurability (continuity of x ↦ xⁿ), finiteness (Real.volume_Icc gives vol[0,1] = 1 ≠ ∞), the a.e. limit just proved, and ε > 0 — producing the small exceptional set off which xⁿ → 0 uniformly. The exceptional point x=1 is exactly where uniformity is lost.",
     "mathContext": "Failure set $\\subseteq \\{1\\}$, $\\mathrm{vol}\\{1\\} = 0 \\Rightarrow x^n \\to 0$ a.e. on $[0,1]$; $\\mathrm{vol}[0,1]=1 < \\infty$ lets Egorov apply.",
     "significance": "key",
-    "relatedConcepts": ["ae_iff", "measure_mono_null", "Real.volume_singleton", "tendsto_pow_atTop_nhds_zero_of_lt_one", "null set"],
-    "prerequisites": ["almost-everywhere statements", "Lebesgue measure of intervals/points", "limits of powers"]
+    "relatedConcepts": [
+      "ae_iff",
+      "measure_mono_null",
+      "Real.volume_singleton",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one",
+      "null set"
+    ],
+    "prerequisites": [
+      "almost-everywhere statements",
+      "Lebesgue measure of intervals/points",
+      "limits of powers"
+    ]
   },
   {
-    "id": "ann-egorov-oq01-sharpness",
+    "id": "ann-egorov-oq01-obstruction",
     "proofId": "egorov-theorem-oq-01",
-    "range": { "startLine": 113, "endLine": 152 },
+    "range": {
+      "startLine": 113,
+      "endLine": 133
+    },
     "type": "theorem",
-    "title": "Sharpness: Non-Uniformity on [0,1) via the IVT",
-    "content": "The necessity half. exists_pow_ge_half shows that for every exponent N there is x ∈ [0,1) with xᴺ ≥ 1/2: x ↦ xᴺ is continuous on [0,1] with values 0ᴺ=0 and 1ᴺ=1, so by intermediate_value_Icc it attains 1/2 at some x, and a short case analysis pushes that x into the half-open [0,1). pow_not_tendstoUniformlyOn_Ico then refutes uniform convergence on [0,1): assume it holds, unfold via Metric.tendstoUniformlyOn_iff at ε = 1/2 to get an index N past which dist(0, xᴺ) < 1/2 for all x ∈ [0,1); instantiate at the bad point from exists_pow_ge_half to obtain 1/2 ≤ xᴺ < 1/2, contradiction. So despite xⁿ → 0 at EVERY point of [0,1), the convergence is not uniform — Egorov's removed set is unavoidable.",
-    "mathContext": "$\\forall N\\ \\exists x \\in [0,1),\\ x^N \\ge 1/2$ (IVT), so $\\sup_{[0,1)} x^N \\not\\to 0$: pointwise-everywhere convergence does not imply uniform convergence.",
+    "title": "The IVT Obstruction: xᴺ Reaches 1/2 in [0,1)",
+    "content": "exists_pow_ge_half isolates the pointwise obstruction to uniform convergence: for every exponent N there is a point x ∈ [0,1) with xᴺ ≥ 1/2. The function x ↦ xᴺ is continuous on [0,1] (continuous_pow) with endpoint values 0ᴺ = 0 and 1ᴺ = 1, so 1/2 lies in its image by the intermediate value theorem intermediate_value_Icc; a short case analysis excludes the endpoint x = 1 (where the value is 1, not 1/2), placing the witness in the half-open [0,1). The N = 0 case is handled separately with x = 0. This lemma quantifies exactly why supremum control fails: however far out in the sequence, xⁿ still climbs to 1/2 somewhere below 1.",
+    "mathContext": "$\\forall N\\ \\exists x\\in[0,1),\\ x^N \\ge 1/2$, by IVT on the continuous $x\\mapsto x^N$ with values $0$ and $1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "intermediate_value_Icc",
+      "continuous_pow",
+      "supremum obstruction",
+      "half-open interval"
+    ],
+    "prerequisites": [
+      "intermediate value theorem",
+      "continuity of powers",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "ann-egorov-oq01-nonuniform",
+    "proofId": "egorov-theorem-oq-01",
+    "range": {
+      "startLine": 135,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "Non-Uniformity: Everywhere ≠ Uniformly on [0,1)",
+    "content": "pow_not_tendstoUniformlyOn_Ico is the sharpness conclusion. Assume xⁿ → 0 uniformly on [0,1). Unfolding Metric.tendstoUniformlyOn_iff at ε = 1/2 produces an index N beyond which dist(0, xᴺ) < 1/2 for ALL x ∈ [0,1). Instantiate at the bad point supplied by exists_pow_ge_half: since dist(0, xᴺ) = |xᴺ| = xᴺ (non-negativity) and xᴺ ≥ 1/2, we get 1/2 ≤ xᴺ < 1/2 — a contradiction. Hence, although xⁿ converges to 0 at every single point of [0,1), it does not converge uniformly there. This is precisely the phenomenon Egorov tames: only after deleting a small set does uniformity appear.",
+    "mathContext": "Uniform on $[0,1)$ at $\\varepsilon=1/2$ would force $x^N < 1/2$ for all $x$, contradicting $\\exists x,\\ x^N \\ge 1/2$.",
     "significance": "key",
-    "relatedConcepts": ["intermediate_value_Icc", "Metric.tendstoUniformlyOn_iff", "non-uniform convergence", "sharpness", "necessity of hypotheses"],
-    "prerequisites": ["intermediate value theorem", "ε-definition of uniform convergence", "proof by contradiction"]
+    "relatedConcepts": [
+      "Metric.tendstoUniformlyOn_iff",
+      "non-uniform convergence",
+      "necessity of Egorov's exceptional set",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "ε-definition of uniform convergence",
+      "the IVT obstruction lemma"
+    ]
   }
 ]

--- a/src/data/proofs/egorov-theorem-oq-01/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01/meta.json
@@ -153,12 +153,20 @@
       "mathContext": "For $0 \\le x < 1$, $x^n \\to 0$; the only exceptional point is $x=1$ with $\\mathrm{vol}\\{1\\}=0$. Hence the a.e. hypothesis holds and Egorov applies on the unit-measure interval."
     },
     {
-      "id": "sharpness",
-      "title": "Sharpness: the Convergence Is Genuinely Non-Uniform",
+      "id": "sharpness-obstruction",
+      "title": "Sharpness I: The IVT Obstruction xᴺ ≥ 1/2",
       "startLine": 113,
+      "endLine": 133,
+      "summary": "exists_pow_ge_half: for every exponent N there is x ∈ [0,1) with xᴺ ≥ 1/2. Since x ↦ xᴺ is continuous on [0,1] with endpoint values 0 and 1, the intermediate value theorem (intermediate_value_Icc) attains 1/2 at some x, and a case split pushes that point into the half-open [0,1). This is the pointwise obstruction that blocks uniform convergence.",
+      "mathContext": "$\\forall N\\ \\exists x\\in[0,1),\\ x^N \\ge 1/2$ — the sup of $x^N$ over $[0,1)$ stays $\\ge 1/2$ for all $N$."
+    },
+    {
+      "id": "sharpness-nonuniform",
+      "title": "Sharpness II: Non-Uniformity on [0,1)",
+      "startLine": 135,
       "endLine": 152,
-      "summary": "exists_pow_ge_half: for every N there is x ∈ [0,1) with xᴺ ≥ 1/2, via the intermediate value theorem on x ↦ xᴺ (from 0 to 1). pow_not_tendstoUniformlyOn_Ico: xⁿ does NOT converge uniformly to 0 on [0,1) — assuming it does, the ε = 1/2 definition at a bad point gives 1/2 ≤ xᴺ < 1/2, a contradiction. So Egorov's exceptional set cannot be omitted.",
-      "mathContext": "$\\sup_{x \\in [0,1)} x^N \\ge 1/2$ for every $N$, so uniform convergence (which would force $\\sup \\to 0$) fails — pointwise-everywhere convergence does not upgrade to uniform."
+      "summary": "pow_not_tendstoUniformlyOn_Ico refutes uniform convergence of xⁿ → 0 on [0,1): unfolding Metric.tendstoUniformlyOn_iff at ε = 1/2 yields an index N past which dist(0, xᴺ) < 1/2 for all x ∈ [0,1); instantiating at the bad point from exists_pow_ge_half gives 1/2 ≤ xᴺ < 1/2, a contradiction. So convergence at every point of [0,1) does NOT upgrade to uniform convergence — Egorov's removed set is unavoidable.",
+      "mathContext": "$x^n \\to 0$ everywhere on $[0,1)$ yet not uniformly; the exceptional set Egorov removes cannot be omitted."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `egorov-theorem-oq-01`. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the sharpness block at the theorem boundary into (a) the IVT obstruction lemma `exists_pow_ge_half` (for every N there is x ∈ [0,1) with xᴺ ≥ 1/2) and (b) the non-uniformity theorem `pow_not_tendstoUniformlyOn_Ico`. Each new annotation carries mathContext/significance/relatedConcepts/prerequisites.

(The annotations.json diff is larger than the content change because re-serialization normalized the `range` objects to multiline; the data is unchanged apart from the split.)

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries, no native_decide.

Built via git-plumbing from the origin/main blob; diff verified non-empty via the 3-dot compare API.