### PR TITLE
Enrich Dini modulus on compact subinterval (dini-theorem-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -2,49 +2,115 @@
   {
     "id": "dini-oq010201-ann-overview",
     "proofId": "dini-theorem-oq-01-oq-02-oq-01",
-    "range": { "startLine": 1, "endLine": 56 },
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
     "type": "concept",
     "title": "Recovering Uniform Convergence on a Compact Subinterval",
     "content": "The header frames OQ-01 of the parent (dini-theorem-oq-01-oq-02). The parent showed that on the non-compact [0,1) the witness xⁿ fails to converge uniformly to 0, with the sharp unattained supremum sup_{x∈[0,1)} |xⁿ| = 1. This file restores compactness by retreating to [0,1−δ] (δ ∈ (0,1]) and asks how fast uniform convergence is repaired. The answer is governed by a single quantity, (1−δ)ⁿ: the supremum becomes ATTAINED at the right endpoint, decays geometrically, and yields uniform convergence with an explicit modulus.",
     "mathContext": "$\\sup_{x\\in[0,1-\\delta]} x^n = (1-\\delta)^n \\to 0$, with explicit modulus $N(\\varepsilon,\\delta)=\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil$.",
     "significance": "supporting",
-    "relatedConcepts": ["Dini's theorem", "uniform convergence", "compactness", "geometric decay"],
-    "prerequisites": ["pointwise vs uniform convergence", "supremum / maximum"]
+    "relatedConcepts": [
+      "Dini's theorem",
+      "uniform convergence",
+      "compactness",
+      "geometric decay"
+    ],
+    "prerequisites": [
+      "pointwise vs uniform convergence",
+      "supremum / maximum"
+    ]
   },
   {
     "id": "dini-oq010201-ann-attained",
     "proofId": "dini-theorem-oq-01-oq-02-oq-01",
-    "range": { "startLine": 57, "endLine": 97 },
+    "range": {
+      "startLine": 57,
+      "endLine": 97
+    },
     "type": "insight",
     "title": "The Supremum is Attained at the Right Endpoint",
     "content": "pow_le_endpoint records the one inequality everything rests on: for x ∈ [0,1−δ], xⁿ ≤ (1−δ)ⁿ (pow_le_pow_left₀, since 0 ≤ x ≤ 1−δ). Because the right endpoint 1−δ lies IN the interval (δ ≤ 1 ⟹ 0 ≤ 1−δ), the value (1−δ)ⁿ is both a member of { xⁿ : x ∈ [0,1−δ] } and an upper bound of it — i.e. its greatest element (isGreatest_pow_image_Icc). IsGreatest.csSup_eq then gives pow_sSup_Icc: sSup = (1−δ)ⁿ, an ATTAINED maximum. This is the structural contrast with the parent's [0,1), where the supremum 1 is a least upper bound approached but never attained — exactly the compactness that Dini's theorem requires. pow_uniform_error_Icc rewrites |xⁿ − 0| = xⁿ to read the uniform error off as (1−δ)ⁿ.",
     "mathContext": "$\\operatorname{IsGreatest}\\{x^n:x\\in[0,1-\\delta]\\}\\,(1-\\delta)^n$; attained at $x=1-\\delta$.",
     "significance": "critical",
-    "relatedConcepts": ["greatest element", "attained maximum", "monotone power functions"],
-    "prerequisites": ["supremum vs maximum", "upper bounds"]
+    "relatedConcepts": [
+      "greatest element",
+      "attained maximum",
+      "monotone power functions"
+    ],
+    "prerequisites": [
+      "supremum vs maximum",
+      "upper bounds"
+    ]
   },
   {
     "id": "dini-oq010201-ann-uniform",
     "proofId": "dini-theorem-oq-01-oq-02-oq-01",
-    "range": { "startLine": 98, "endLine": 133 },
+    "range": {
+      "startLine": 98,
+      "endLine": 133
+    },
     "type": "insight",
     "title": "Geometric Decay and Uniform Convergence Recovered",
     "content": "pow_tendsto_zero: since 0 ≤ 1−δ < 1 (from δ ∈ (0,1]), the endpoint value (1−δ)ⁿ → 0 (tendsto_pow_atTop_nhds_zero_of_lt_one). pow_tendstoUniformlyOn_Icc is the headline: feeding the uniform bound xⁿ ≤ (1−δ)ⁿ and the geometric decay into the ε-criterion (Metric.tendstoUniformlyOn_iff) gives xⁿ ⇉ 0 uniformly on [0,1−δ]. This is the exact positive counterpart of the parent's pow_not_tendstoUniformlyOn_Ico_sharp: the SAME witness sequence, opposite verdict, separated only by whether the boundary point 1 is included in the closure of the domain.",
     "mathContext": "$x^n \\rightrightarrows 0$ on $[0,1-\\delta]$, because $\\sup_x x^n = (1-\\delta)^n \\to 0$.",
     "significance": "critical",
-    "relatedConcepts": ["uniform convergence criterion", "geometric sequences", "Dini's theorem"],
-    "prerequisites": ["ε-N definition of uniform convergence", "limits of geometric sequences"]
+    "relatedConcepts": [
+      "uniform convergence criterion",
+      "geometric sequences",
+      "Dini's theorem"
+    ],
+    "prerequisites": [
+      "ε-N definition of uniform convergence",
+      "limits of geometric sequences"
+    ]
   },
   {
-    "id": "dini-oq010201-ann-modulus",
+    "id": "dini-oq010201-ann-log-modulus",
     "proofId": "dini-theorem-oq-01-oq-02-oq-01",
-    "range": { "startLine": 134, "endLine": 194 },
+    "range": {
+      "startLine": 132,
+      "endLine": 154
+    },
     "type": "insight",
-    "title": "The Explicit Modulus via Logarithms",
-    "content": "pow_lt_of_log_modulus makes the rate explicit. Set r = 1−δ ∈ (0,1) (needs δ < 1), so log r < 0 (Real.log_neg). Taking logs, (1−δ)ⁿ ≤ ε ⟺ n·log r ≤ log ε (Real.log_pow plus monotonicity of exp/log); since log r < 0, dividing reverses the inequality (div_le_iff_of_neg), giving the threshold n ≥ log ε / log(1−δ). pow_lt_of_ceil_modulus packages this as the natural-number modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉ via Nat.le_ceil. As δ → 0 the threshold blows up (log(1−δ) → 0⁻), interpolating to the parent's non-uniformity on [0,1).",
-    "mathContext": "$n \\ge \\dfrac{\\log\\varepsilon}{\\log(1-\\delta)} \\implies (1-\\delta)^n \\le \\varepsilon$; modulus $\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil$.",
-    "significance": "critical",
-    "relatedConcepts": ["modulus of convergence", "logarithms", "geometric decay rate"],
-    "prerequisites": ["properties of log", "ceiling function", "sign-flip when dividing by a negative"]
+    "title": "The Explicit Modulus via Logarithms (Real Threshold)",
+    "content": "pow_lt_of_log_modulus makes the convergence rate explicit. Set r = 1−δ ∈ (0,1) (this is where δ < 1 is needed), so log r < 0 by Real.log_neg. Taking logarithms turns the goal (1−δ)ⁿ ≤ ε into n·log r ≤ log ε; because log r is NEGATIVE, dividing by it reverses the inequality (div_le_iff_of_neg), producing the threshold n ≥ log ε / log(1−δ). The Lean proof re-exponentiates: rewriting rⁿ = exp(log rⁿ) and ε = exp(log ε) via Real.exp_log (both positive), it reduces to log(rⁿ) ≤ log ε, and Real.log_pow gives log(rⁿ) = n·log r — exactly the multiplied inequality.",
+    "mathContext": "$(1-\\delta)^n \\le \\varepsilon \\iff n\\log(1-\\delta) \\le \\log\\varepsilon$; $\\log(1-\\delta)<0$ flips the division, giving $n \\ge \\log\\varepsilon/\\log(1-\\delta)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_neg",
+      "div_le_iff_of_neg",
+      "Real.log_pow",
+      "sign-flip when dividing by a negative"
+    ],
+    "prerequisites": [
+      "properties of log",
+      "monotonicity of exp",
+      "inequalities with negative denominators"
+    ]
+  },
+  {
+    "id": "dini-oq010201-ann-ceil-modulus",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 155,
+      "endLine": 194
+    },
+    "type": "insight",
+    "title": "Packaging the Modulus as ⌈log ε / log(1−δ)⌉",
+    "content": "pow_lt_of_ceil_modulus converts the real threshold into an honest natural-number modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉₊. The proof chains Nat.le_ceil (log ε/log(1−δ) ≤ ⌈…⌉₊) with the hypothesis ⌈…⌉₊ ≤ n to recover the real bound of pow_lt_of_log_modulus. This is the fully explicit answer to the parent's open question — an effective rate, not merely an existence statement. The interpolation is instructive: as δ → 0⁺ the base 1−δ → 1⁻, log(1−δ) → 0⁻, and the modulus N(ε,δ) → ∞, recovering in the limit the parent's failure of uniform convergence on the non-compact [0,1).",
+    "mathContext": "$N(\\varepsilon,\\delta)=\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil_+$; $\\delta\\to0^+ \\Rightarrow N\\to\\infty$, matching the parent's non-uniformity on $[0,1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.le_ceil",
+      "modulus of convergence",
+      "effective bounds",
+      "limiting behavior as δ→0"
+    ],
+    "prerequisites": [
+      "ceiling function",
+      "the real-threshold lemma"
+    ]
   }
 ]

--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/meta.json
@@ -102,11 +102,20 @@
       "endLine": 133
     },
     {
-      "id": "explicit-modulus",
-      "title": "The Explicit Modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉",
-      "summary": "pow_lt_of_log_modulus (real-threshold modulus via logarithms and div_le_iff_of_neg) and pow_lt_of_ceil_modulus (packaged natural-number modulus via Nat.le_ceil)",
+      "id": "log-modulus",
+      "title": "The Explicit Modulus: Real Log Threshold",
       "startLine": 134,
-      "endLine": 194
+      "endLine": 154,
+      "summary": "pow_lt_of_log_modulus turns the geometric bound into a quantitative threshold: for δ ∈ (0,1) and ε > 0, once n ≥ log ε / log(1−δ) we have (1−δ)ⁿ ≤ ε. Taking logarithms sends (1−δ)ⁿ ≤ ε to n·log(1−δ) ≤ log ε; since log(1−δ) < 0 (Real.log_neg), dividing reverses the inequality (div_le_iff_of_neg), and re-exponentiating via Real.exp_log/Real.log_pow closes it.",
+      "mathContext": "$n \\ge \\log\\varepsilon/\\log(1-\\delta) \\Rightarrow (1-\\delta)^n \\le \\varepsilon$ (log is negative, so the division flips the inequality)."
+    },
+    {
+      "id": "ceil-modulus",
+      "title": "The Explicit Modulus: Natural-Number Form",
+      "startLine": 155,
+      "endLine": 194,
+      "summary": "pow_lt_of_ceil_modulus packages the real threshold as a concrete natural-number modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉₊, using Nat.le_ceil to bridge the ceiling to the real bound and delegating to pow_lt_of_log_modulus. As δ → 0 the threshold blows up (log(1−δ) → 0⁻), interpolating continuously to the parent's non-uniformity on the full [0,1).",
+      "mathContext": "$N(\\varepsilon,\\delta)=\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil_+$; $n \\ge N \\Rightarrow (1-\\delta)^n \\le \\varepsilon$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `dini-theorem-oq-01-oq-02-oq-01`. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the explicit-modulus block at the theorem boundary into (a) the real log-threshold `pow_lt_of_log_modulus` (sign-flip when dividing by log(1−δ) < 0) and (b) the packaged natural-number modulus `pow_lt_of_ceil_modulus` = ⌈log ε / log(1−δ)⌉₊, with the δ→0⁺ interpolation back to the parent's non-uniformity. Each new annotation carries mathContext/significance/relatedConcepts/prerequisites.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries.

Built via git-plumbing from the origin/main blob; diff verified non-empty via the 3-dot compare API.