### PR TITLE
Enrich Poisson(1) Limit of Fixed-Point Count (derangements-oq-04-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/derangements-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-04-oq-01-oq-01/annotations.json
@@ -47,24 +47,42 @@
   {
     "id": "derangements-oq040101-poisson-main",
     "proofId": "derangements-oq-04-oq-01-oq-01",
-    "range": { "startLine": 58, "endLine": 99 },
+    "range": { "startLine": 58, "endLine": 84 },
     "type": "insight",
-    "title": "Assembling the Poisson Limit from the Closed Form",
-    "content": "fixedPoints_tendsto_poisson is the main theorem: for fixed k, S(n,k)/n! → e^{-1}/k!. Because k is constant, n−k → ∞ (hsubk via omega), so composing with the partial-sum limit gives altFactPartialSum(n−k) → e^{-1}. Scaling by the constant 1/k! (const_mul) yields the target limit after a ring rewrite of (1/k!)·e^{-1} = e^{-1}/k!. The crux is a congr'/eventuallyEq step: the scaled partial sums equal S(n,k)/n! only eventually, precisely for n ≥ k. On that set the pointwise identity is discharged by substituting the parent's real closed form (card_perms_with_kfixed_closed_form_real) and clearing denominators with field_simp, using that n! and k! are nonzero.",
-    "mathContext": "For $n\\ge k$, cancelling $n!$ in $S(n,k)=(n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$ gives $S(n,k)/n!=(1/k!)\\,\\texttt{altFactPartialSum}(n-k)$. Since $k$ fixed $\\Rightarrow n-k\\to\\infty$, $\\texttt{altFactPartialSum}(n-k)\\to e^{-1}$, and multiplying by the constant $1/k!$ gives $S(n,k)/n!\\to e^{-1}/k!$. The eventual (not identical) equality is handled with $\\texttt{Tendsto.congr'}$ on $\\{n\\mid k\\le n\\}$.",
+    "title": "Assembling the Poisson Limit: Composition and Scaling",
+    "content": "fixedPoints_tendsto_poisson is the main theorem: for fixed k, S(n,k)/n! → e^{-1}/k!. Phase one builds the limit from the analytic input. Because k is constant, n−k → ∞ (hsubk, proved by omega), so composing the partial-sum limit with n ↦ n−k gives altFactPartialSum(n−k) → e^{-1} (Tendsto.comp). Scaling by the constant 1/k! (Tendsto.const_mul) produces a sequence tending to (1/k!)·e^{-1}, and a ring rewrite identifies that limit with the target e^{-1}/k!.",
+    "mathContext": "Since $k$ fixed $\\Rightarrow n-k\\to\\infty$, $\\texttt{altFactPartialSum}(n-k)\\to e^{-1}$, and multiplying by the constant $1/k!$ gives limit $(1/k!)e^{-1}=e^{-1}/k!$.",
     "significance": "key",
+    "relatedConcepts": [
+      "composition of tendsto (Tendsto.comp)",
+      "const_mul of a limit",
+      "tendsto_atTop_atTop",
+      "Poisson limit theorem"
+    ],
+    "prerequisites": [
+      "Tendsto.comp and Tendsto.const_mul",
+      "limits of scaled sequences"
+    ]
+  },
+  {
+    "id": "derangements-oq040101-eventual-eq",
+    "proofId": "derangements-oq-04-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 100 },
+    "type": "technique",
+    "title": "Eventual Equality with S(n,k)/n! via the Parent Closed Form",
+    "content": "Phase two connects the scaled partial sums to the actual probability sequence. The two agree only EVENTUALLY — precisely on {n | k ≤ n} — so the limit transfers via Tendsto.congr' with eventuallyEq_iff_exists_mem and eventually_ge_atTop k. On that set the pointwise identity S(n,k)/n! = (1/k!)·altFactPartialSum(n−k) is discharged by substituting the parent's real closed form card_perms_with_kfixed_closed_form_real, unfolding altFactPartialSum, and clearing the nonzero n! and k! denominators with field_simp (factorial_cast_ne_zero'). This eventual-equality pattern is the standard way to prove a limit of a sequence that only matches a tractable formula past some index.",
+    "mathContext": "For $n\\ge k$, cancelling $n!$ in $S(n,k)=(n!/k!)\\sum_{j=0}^{n-k}(-1)^j/j!$ gives $S(n,k)/n!=(1/k!)\\,\\texttt{altFactPartialSum}(n-k)$; the eventual (not identical) equality is handled by $\\texttt{Tendsto.congr'}$ on $\\{n\\mid k\\le n\\}$.",
+    "significance": "supporting",
     "relatedConcepts": [
       "eventual equality of sequences (Tendsto.congr')",
       "Filter.Eventually and atTop",
-      "const_mul of a limit",
       "cancelling n! (field_simp)",
-      "composition of tendsto"
+      "eventuallyEq_iff_exists_mem"
     ],
     "prerequisites": [
       "the parent closed form (real version)",
-      "Tendsto.comp and Tendsto.const_mul",
-      "eventuallyEq_iff_exists_mem",
-      "field_simp / factorial_cast_ne_zero'"
+      "field_simp / factorial_cast_ne_zero'",
+      "eventual equality of filters"
     ]
   },
   {

--- a/src/data/proofs/derangements-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-04-oq-01-oq-01/meta.json
@@ -119,12 +119,20 @@
       "mathContext": "∑_{j=0}^{m}(-1)^j/j! → ∑_{j=0}^{∞}(-1)^j/j! = e^{-1}."
     },
     {
-      "id": "poisson-limit",
-      "title": "The Poisson(1) Limit of the Fixed-Point Distribution",
-      "startLine": 62,
-      "endLine": 102,
-      "summary": "fixedPoints_tendsto_poisson: for fixed k, S(n,k)/n! → e^{-1}/k!. Since n - k → ∞ (tendsto_atTop_atTop via omega), the partial sums along n - k still tend to e^{-1}; scaling by the constant 1/k! (Tendsto.const_mul) gives limit e^{-1}/k!; Tendsto.congr' swaps the scaled partial sums for S(n,k)/n! using the eventual (n ≥ k) identity S(n,k)/n! = (1/k!)·altFactPartialSum(n-k) from the parent closed form, closed by field_simp; ring.",
+      "id": "poisson-limit-assembly",
+      "title": "The Poisson(1) Limit: Composition and Scaling",
+      "startLine": 58,
+      "endLine": 84,
+      "summary": "fixedPoints_tendsto_poisson (statement + phase 1): for fixed k the target is S(n,k)/n! → e^{-1}/k!. Since n - k → ∞ (tendsto_atTop_atTop via omega), composing with the partial-sum limit gives altFactPartialSum(n-k) → e^{-1}; scaling by the constant 1/k! (Tendsto.const_mul) and a ring rewrite of (1/k!)·e^{-1} yield the limit e^{-1}/k!.",
       "mathContext": "Pr[X_n = k] = S(n,k)/n! → e^{-1}/k!, the Poisson(1) probability mass function."
+    },
+    {
+      "id": "poisson-limit-eventual-eq",
+      "title": "Eventual Equality with S(n,k)/n! via the Parent Closed Form",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "fixedPoints_tendsto_poisson (phase 2): Tendsto.congr' swaps the scaled partial sums for the actual sequence S(n,k)/n!, which agree only eventually — on {n | k ≤ n} (eventually_ge_atTop). On that set the pointwise identity S(n,k)/n! = (1/k!)·altFactPartialSum(n-k) is discharged by substituting the parent's real closed form card_perms_with_kfixed_closed_form_real and clearing the nonzero n!, k! denominators with field_simp.",
+      "mathContext": "For n ≥ k: cancelling n! in S(n,k) = (n!/k!)·∑_{j≤n-k}(-1)^j/j! gives S(n,k)/n! = (1/k!)·altFactPartialSum(n-k)."
     },
     {
       "id": "consistency",


### PR DESCRIPTION
Enrichment pass for `derangements-oq-04-oq-01-oq-01` (quality 93 → 100).

## Changes
- **annotations 4 → 5** and **sections 4 → 5**: split the coverage of the 42-line main theorem `fixedPoints_tendsto_poisson` into its two proof phases — (1) building the limit by composing the partial-sum limit with n↦n−k and scaling by 1/k! (lines 58–84), and (2) the `Tendsto.congr'` eventual-equality step that swaps in S(n,k)/n! via the parent closed form and `field_simp` (lines 85–100).

historicalContext (913 chars), keyInsights (5), conclusion, and crossReferences were already complete. meta.json is 16.2 KB, under the 60 KB cap. No Lean changes; verified (0 axioms, 0 sorries).