### PR TITLE
Enrich Cramer/Cayley–Hamilton adjugate (cramers-rule-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-header",
     "proofId": "cramers-rule-oq-04-oq-01",
-    "range": { "startLine": 1, "endLine": 36 },
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
     "type": "concept",
     "title": "Cramer's Rule and Cayley–Hamilton Share One Identity",
     "content": "The unifying theme of the file: the single universal adjugate identity adjugate B · B = (det B)·I specializes to both classical theorems. Feed it the scalar matrix B = A and it becomes A·(adj A · b) = (det A)·b — the determinant form of Cramer's rule, solving Ax = b up to a factor of det A. Feed it instead the characteristic matrix B = xI − A over the polynomial ring R[X], where det(xI − A) = χ_A(x), and it becomes adj(xI − A)·(xI − A) = χ_A(x)·I; evaluating this polynomial-matrix identity at A makes the right side χ_A(A) and the left side vanish, yielding the Cayley–Hamilton theorem χ_A(A) = 0. (This is why Cayley–Hamilton is NOT the naive 'substitute A for x in det(xI − A)' — that substitution is ill-typed; the rigorous route goes through the adjugate identity and an algebra evaluation.) A corollary is that the minimal polynomial divides the characteristic polynomial. Mathlib proves Cayley–Hamilton this way (aeval_self_charpoly); this entry packages the underlying adjugate identities and ties both theorems to their common source.",
@@ -33,8 +36,17 @@
     "content": "adjugate_charmatrix_mul is the OQ's explicit target: adj(xI − A)·(xI − A) = χ_A(x)·I over the polynomial ring R[X]. It is nothing but the universal adjugate identity adj(B)·B = (det B)·I (Mathlib's adjugate_mul) applied to the characteristic matrix B = charmatrix M = xI − A, using that χ_A(x) = det(xI − A) by definition. The same identity, applied instead to a scalar matrix A, gives Cramer's rule — so determinants, matrix inverses, and the characteristic polynomial all flow from one cofactor identity.",
     "mathContext": "$\\mathrm{adj}(xI - A)\\,(xI - A) = \\chi_A(x)\\,I$ in $\\mathrm{Mat}_n(R[X])$, since $\\chi_A(x) = \\det(xI - A)$.",
     "significance": "key",
-    "relatedConcepts": ["adjugate matrix", "characteristic polynomial", "cofactor expansion", "characteristic matrix xI − A"],
-    "prerequisites": ["adjugate / classical adjoint", "the universal identity adj(B)·B = (det B)·I", "polynomial matrices R[X]"]
+    "relatedConcepts": [
+      "adjugate matrix",
+      "characteristic polynomial",
+      "cofactor expansion",
+      "characteristic matrix xI − A"
+    ],
+    "prerequisites": [
+      "adjugate / classical adjoint",
+      "the universal identity adj(B)·B = (det B)·I",
+      "polynomial matrices R[X]"
+    ]
   },
   {
     "id": "ann-noncommutative",
@@ -48,22 +60,62 @@
     "content": "cayley_hamilton (χ_A(A) = 0) does NOT follow by substituting x = A into the identity χ_A(x)·I = adj(xI−A)·(xI−A): the coefficient ring Matrix n n R is non-commutative, so naive substitution is invalid (this is the classic fallacy — 'plug in A and the right side vanishes'). Mathlib's aeval_self_charpoly handles it correctly by lifting the adjugate identity to Polynomial (Matrix n n R) and evaluating at A, where the right factor (xI − A) telescopes to zero through the algebra evaluation map. Over a field this immediately gives minpoly_dvd_charpoly: the minimal polynomial divides the characteristic polynomial, so its degree is at most n.",
     "mathContext": "$\\chi_A(A) = 0$; over a field, $\\mathrm{minpoly}_K(A) \\mid \\chi_A$, hence $\\deg \\mathrm{minpoly}_K(A) \\le n$.",
     "significance": "key",
-    "relatedConcepts": ["Cayley–Hamilton theorem", "non-commutative coefficient ring", "aeval / algebra evaluation", "minimal polynomial"],
-    "prerequisites": ["the substitution fallacy for matrix coefficients", "Polynomial (Matrix n n R)", "minimal vs characteristic polynomial"]
+    "relatedConcepts": [
+      "Cayley–Hamilton theorem",
+      "non-commutative coefficient ring",
+      "aeval / algebra evaluation",
+      "minimal polynomial"
+    ],
+    "prerequisites": [
+      "the substitution fallacy for matrix coefficients",
+      "Polynomial (Matrix n n R)",
+      "minimal vs characteristic polynomial"
+    ]
+  },
+  {
+    "id": "ann-mul-adjugate",
+    "proofId": "cramers-rule-oq-04-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 61
+    },
+    "type": "insight",
+    "title": "The Second Adjugate Identity A·adj(A) = (det A)·I",
+    "content": "mul_adjugate_eq records the companion of the reflexive identity used for Cayley–Hamilton: A·adjugate A = (det A)·I (Mathlib's mul_adjugate). This is literally the same universal cofactor identity adj(B)·B = (det B)·I — here in the form B·adj(B), evaluated on the scalar matrix B = A rather than the characteristic matrix xI − A. It is the algebraic source of Cramer's rule: because A·adj(A) is the scalar matrix (det A)·I, the adjugate acts as a determinant-scaled inverse whenever det A is a unit.",
+    "mathContext": "$A\\,\\mathrm{adj}(A) = (\\det A)\\,I$; when $\\det A \\in R^\\times$, $A^{-1} = (\\det A)^{-1}\\,\\mathrm{adj}(A)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "adjugate matrix",
+      "determinant",
+      "matrix inverse via adjugate",
+      "cofactor identity"
+    ],
+    "prerequisites": [
+      "the universal identity adj(B)·B = (det B)·I",
+      "units of the base ring"
+    ]
   },
   {
     "id": "ann-cramer",
     "proofId": "cramers-rule-oq-04-oq-01",
     "range": {
-      "startLine": 58,
+      "startLine": 63,
       "endLine": 69
     },
     "type": "insight",
     "title": "Cramer's Rule as the Adjugate Applied to a Vector",
-    "content": "The other face of the same identity. mul_adjugate_eq records A·adj(A) = (det A)·I, and adjugate_mulVec_solve applies it to a vector: A·(adj A · b) = (det A)·b, so the adjugate solves the linear system Ax = b up to the determinant. The proof is the adjugate identity again — A·(adj A · b) = (A·adj A)·b (mulVec_mulVec associativity) = (det A · I)·b = det A · b (mul_adjugate, smul_mulVec_assoc, one_mulVec). Dividing by det A when it is invertible gives the classical Cramer solution x = (det A)⁻¹·adj A · b. This exhibits Cramer's rule and Cayley–Hamilton as two specialisations of the single identity adj(B)·B = (det B)·I — to a scalar matrix and to the characteristic matrix respectively.",
+    "content": "adjugate_mulVec_solve applies the second adjugate identity to a right-hand-side vector b: A·(adj A · b) = (det A)·b, so the adjugate solves the linear system Ax = b up to the scalar det A. The proof reassociates the matrix–vector products — A·(adj A · b) = (A·adj A)·b (mulVec_mulVec) = ((det A)·I)·b (mul_adjugate) = (det A)·b (smul_mulVec_assoc, one_mulVec). Dividing by det A when it is invertible yields the classical Cramer solution x = (det A)⁻¹·adj A · b. Together with adjugate_charmatrix_mul this exhibits Cramer's rule and Cayley–Hamilton as the two specializations — scalar matrix and characteristic matrix — of the single identity adj(B)·B = (det B)·I.",
     "mathContext": "$A\\,(\\mathrm{adj}(A)\\,b) = (\\det A)\\,b$; if $\\det A$ is a unit, $x = (\\det A)^{-1}\\,\\mathrm{adj}(A)\\,b$.",
     "significance": "key",
-    "relatedConcepts": ["Cramer's rule", "adjugate matrix", "matrix-vector product associativity", "linear systems Ax = b"],
-    "prerequisites": ["the adjugate identity A·adj A = (det A)·I", "matrix–vector multiplication (mulVec)", "units of the base ring"]
+    "relatedConcepts": [
+      "Cramer's rule",
+      "matrix-vector product associativity",
+      "linear systems Ax = b",
+      "mulVec_mulVec"
+    ],
+    "prerequisites": [
+      "the second adjugate identity",
+      "matrix–vector multiplication (mulVec)"
+    ]
   }
 ]

--- a/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01/meta.json
@@ -150,12 +150,20 @@
       "mathContext": "The matrix satisfies its characteristic polynomial; the minimal polynomial divides it."
     },
     {
-      "id": "cramer",
-      "title": "Section III: Cramer's Rule from the Same Adjugate",
-      "startLine": 60,
+      "id": "second-adjugate",
+      "title": "Section III: The Second Adjugate Identity A·adj(A) = (det A)·I",
+      "startLine": 58,
+      "endLine": 61,
+      "summary": "mul_adjugate_eq records the companion form of the universal identity, A·adjugate A = (det A)·I (Mathlib's mul_adjugate). Where Section I used adj(B)·B on the characteristic matrix, this is the same cofactor identity on the scalar matrix A — the source from which Cramer's rule flows.",
+      "mathContext": "$A\\,\\mathrm{adj}(A) = (\\det A)\\,I$, the scalar-matrix face of $\\mathrm{adj}(B)B=(\\det B)I$."
+    },
+    {
+      "id": "cramer-solve",
+      "title": "Section IV: Cramer's Rule as the Adjugate Applied to a Vector",
+      "startLine": 63,
       "endLine": 69,
-      "summary": "mul_adjugate_eq (A·adj A = (det A)·I) and adjugate_mulVec_solve (A·(adj A · b) = (det A)·b) — the determinant form of Cramer's rule, from the same adjugate identity.",
-      "mathContext": "The adjugate solves Ax = b up to det A; dividing by det A (when invertible) is Cramer's rule."
+      "summary": "adjugate_mulVec_solve applies the second identity to a vector: A·(adj A · b) = (det A)·b, via mulVec_mulVec associativity, mul_adjugate, smul_mulVec_assoc, and one_mulVec. When det A is a unit, dividing gives the classical Cramer solution x = (det A)⁻¹·adj A·b — exhibiting Cramer's rule and Cayley–Hamilton as two specializations of one identity.",
+      "mathContext": "$A\\,(\\mathrm{adj}(A)\\,b) = (\\det A)\\,b$; $\\det A$ a unit $\\Rightarrow x = (\\det A)^{-1}\\mathrm{adj}(A)\\,b$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-04-oq-01`. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the Cramer's-rule block at the theorem boundary into (a) the second adjugate identity `mul_adjugate_eq` (A·adj A = (det A)·I) and (b) the vector-solve form `adjugate_mulVec_solve` (A·(adj A·b) = (det A)·b), reinforcing the theme that Cramer and Cayley–Hamilton are two specializations of adj(B)·B = (det B)·I. Each new annotation carries mathContext/significance/relatedConcepts/prerequisites.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries.

Built via git-plumbing from the origin/main blob; diff verified non-empty via the 3-dot compare API.