### PR TITLE
Enrich derangements low-codimension counts (derangements-oq-02-oq-04)

### DIFF
--- a/src/data/proofs/derangements-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/annotations.json
@@ -2,49 +2,123 @@
   {
     "id": "ann-der0204-setup",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 4, "endLine": 31 },
+    "range": {
+      "startLine": 4,
+      "endLine": 31
+    },
     "type": "concept",
     "title": "Setup: Continuing the Rencontres Table Toward the Identity",
     "content": "The file imports Mathlib and the parent module DerangementsOQ02. The docstring recalls the parent's main count S(n,k) = C(n,k)·D(n−k) — permutations of Fin n with exactly k fixed points — and its two extreme 'high-codimension' cases S(n,n) = 1 (the identity, permsWithAllFixed_card_eq_one) and S(n,n−1) = 0 (impossible: you cannot move exactly one point, permsWithNMinus1Fixed_eq_zero). The plan is to continue the table downward by specialising the formula at the small derangement values D(2) = 1 and D(3) = 2, producing S(n,n−2) = C(n,2) and S(n,n−3) = 2·C(n,3). The `open` line brings Finset, Nat, and the parent's PartialDerangements namespace into scope so card_perms_with_kfixed resolves unqualified. The two `decide`s below are kernel reductions (not native_decide), keeping the file axiom-free.",
     "mathContext": "$S(n,k) = \\binom{n}{k}D(n-k)$; the table of counts for $k = n, n{-}1, n{-}2, n{-}3,\\dots$ is $1,\\,0,\\,\\binom{n}{2},\\,2\\binom{n}{3},\\dots$",
     "significance": "supporting",
-    "relatedConcepts": ["rencontres numbers", "partial derangements", "fixed points of permutations", "derangement number D(n)"],
-    "prerequisites": ["the parent formula S(n,k) = C(n,k)·D(n−k)", "derangement numbers and fixed-point sets", "permutations of Fin n"]
+    "relatedConcepts": [
+      "rencontres numbers",
+      "partial derangements",
+      "fixed points of permutations",
+      "derangement number D(n)"
+    ],
+    "prerequisites": [
+      "the parent formula S(n,k) = C(n,k)·D(n−k)",
+      "derangement numbers and fixed-point sets",
+      "permutations of Fin n"
+    ]
   },
   {
-    "id": "ann-der0204-small-derangements",
+    "id": "ann-der0204-d2",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 33, "endLine": 37 },
+    "range": {
+      "startLine": 33,
+      "endLine": 34
+    },
     "type": "theorem",
-    "title": "Small Derangement Values D(2) = 1 and D(3) = 2",
-    "content": "Two one-line facts evaluated by kernel `decide`: numDerangements_two proves D(2) = 1 (the unique derangement of two points is the single transposition) and numDerangements_three proves D(3) = 2 (the two derangements of three points are the two 3-cycles). Because `numDerangements` on a fixed small numeral is a decidable computation over the finite Derangements type, the kernel reduces it directly — crucially this is `decide`, not `native_decide`, so it incurs no Lean.ofReduceBool axiom and the downstream counts remain genuinely verified. These constants are the only new arithmetic input; everything else is the parent's structural formula.",
-    "mathContext": "$D(2) = 1$ (one swap), $D(3) = 2$ (two 3-cycles); $D(m)$ counts fixed-point-free permutations of $m$ points.",
+    "title": "D(2) = 1: the Unique Derangement of Two Points",
+    "content": "numDerangements_two proves D(2) = 1 by kernel `decide`. There is exactly one fixed-point-free permutation of two points — the transposition (swap). Because numDerangements on the fixed numeral 2 is a decidable computation over the finite Derangements type, the kernel reduces it directly; crucially this is `decide`, not `native_decide`, so it introduces no Lean.ofReduceBool axiom. This constant is the sole arithmetic input to the codimension-2 count S(n,n−2) = C(n,2).",
+    "mathContext": "$D(2) = 1$ — the unique derangement of two points is the swap $(1\\,2)$.",
     "significance": "supporting",
-    "relatedConcepts": ["derangement number", "numDerangements", "kernel decide vs native_decide", "axiom integrity"],
-    "prerequisites": ["the definition of D(m) = numDerangements m", "decidable evaluation over a finite type", "the distinction between decide and native_decide"]
+    "relatedConcepts": [
+      "derangement number",
+      "numDerangements",
+      "transposition",
+      "kernel decide vs native_decide"
+    ],
+    "prerequisites": [
+      "D(m) = numDerangements m",
+      "decidable evaluation over a finite type"
+    ]
+  },
+  {
+    "id": "ann-der0204-d3",
+    "proofId": "derangements-oq-02-oq-04",
+    "range": {
+      "startLine": 36,
+      "endLine": 38
+    },
+    "type": "theorem",
+    "title": "D(3) = 2: the Two 3-Cycles",
+    "content": "numDerangements_three proves D(3) = 2 by kernel `decide`. The two fixed-point-free permutations of three points are exactly the two 3-cycles (1 2 3) and (1 3 2). As with D(2), this is a kernel reduction over the finite Derangements type — `decide`, not `native_decide` — so the axiom budget stays at only propext/Classical.choice/Quot.sound. This constant is the sole arithmetic input to the codimension-3 count S(n,n−3) = 2·C(n,3).",
+    "mathContext": "$D(3) = 2$ — the two 3-cycles $(1\\,2\\,3)$ and $(1\\,3\\,2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "derangement number",
+      "numDerangements",
+      "3-cycles",
+      "kernel decide vs native_decide"
+    ],
+    "prerequisites": [
+      "D(m) = numDerangements m",
+      "decidable evaluation over a finite type"
+    ]
   },
   {
     "id": "ann-codim-two",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 39, "endLine": 47 },
+    "range": {
+      "startLine": 39,
+      "endLine": 47
+    },
     "type": "theorem",
     "title": "Exactly n−2 Fixed Points: the Transpositions",
     "content": "For $n \\ge 2$, the number of permutations of $\\mathrm{Fin}\\,n$ with **exactly** $n-2$ fixed points is $\\binom{n}{2}$. These are precisely the transpositions: pick the two moved points ($\\binom{n}{2}$ ways), and the only derangement of two points is the swap ($D(2)=1$). The proof specialises the parent's $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-2$: rewrite by `card_perms_with_kfixed`, simplify the codimension $n-(n-2)=2$ with `omega`, drop the factor via `numDerangements_two` + `mul_one`, and convert $\\binom{n}{n-2}=\\binom{n}{2}$ by `Nat.choose_symm` (which consumes the hypothesis $n \\ge 2$).",
     "mathContext": "$S(n,n-2) = \\binom{n}{2}$ for $n \\ge 2$.",
     "significance": "key",
-    "relatedConcepts": ["partial derangements", "transpositions", "rencontres numbers", "binomial coefficient", "Nat.choose_symm"],
-    "prerequisites": ["the parent count card_perms_with_kfixed", "D(2) = 1", "binomial symmetry C(n,n−2) = C(n,2)", "omega for the codimension arithmetic"]
+    "relatedConcepts": [
+      "partial derangements",
+      "transpositions",
+      "rencontres numbers",
+      "binomial coefficient",
+      "Nat.choose_symm"
+    ],
+    "prerequisites": [
+      "the parent count card_perms_with_kfixed",
+      "D(2) = 1",
+      "binomial symmetry C(n,n−2) = C(n,2)",
+      "omega for the codimension arithmetic"
+    ]
   },
   {
     "id": "ann-codim-three",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 49, "endLine": 57 },
+    "range": {
+      "startLine": 49,
+      "endLine": 57
+    },
     "type": "theorem",
     "title": "Exactly n−3 Fixed Points: Pairs of 3-Cycles",
     "content": "For $n \\ge 3$, the number of permutations with exactly $n-3$ fixed points is $2\\binom{n}{3}$: choose the three moved points ($\\binom{n}{3}$ ways), each set of three admitting the two 3-cycles ($D(3)=2$). Again a specialisation of $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-3$ — rewrite by `card_perms_with_kfixed`, reduce $n-(n-3)=3$ by `omega`, substitute `numDerangements_three` (D(3)=2), apply `Nat.choose_symm` for $\\binom{n}{n-3}=\\binom{n}{3}$, and reorient with `Nat.mul_comm` to the form $2\\binom{n}{3}$. Together with the parent's $S(n,n)=1$, $S(n,n-1)=0$ and the codimension-2 case, this completes the top of the fixed-point distribution: $1, 0, \\binom{n}{2}, 2\\binom{n}{3}, \\dots$",
     "mathContext": "$S(n,n-3) = 2\\binom{n}{3}$ for $n \\ge 3$.",
     "significance": "supporting",
-    "relatedConcepts": ["partial derangements", "3-cycles", "rencontres numbers", "Nat.choose_symm", "binomial coefficient"],
-    "prerequisites": ["the parent count card_perms_with_kfixed", "D(3) = 2", "binomial symmetry C(n,n−3) = C(n,3)", "omega for the codimension arithmetic"]
+    "relatedConcepts": [
+      "partial derangements",
+      "3-cycles",
+      "rencontres numbers",
+      "Nat.choose_symm",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "the parent count card_perms_with_kfixed",
+      "D(3) = 2",
+      "binomial symmetry C(n,n−3) = C(n,3)",
+      "omega for the codimension arithmetic"
+    ]
   }
 ]

--- a/src/data/proofs/derangements-oq-02-oq-04/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/meta.json
@@ -61,11 +61,20 @@
       "mathContext": "$S(n,k) = \\binom{n}{k}\\,D(n-k)$ specialised at codimensions $0,1,2,3$ gives $1,\\,0,\\,\\binom{n}{2},\\,2\\binom{n}{3}$."
     },
     {
-      "id": "small-derangements",
-      "title": "Small Derangement Values",
+      "id": "small-d2",
+      "title": "D(2) = 1: the Unique Transposition",
       "startLine": 33,
+      "endLine": 34,
+      "summary": "numDerangements_two proves D(2) = 1 by kernel `decide`: the only fixed-point-free permutation of two points is the single swap. This constant feeds the codimension-2 count.",
+      "mathContext": "$D(2) = 1$ — one derangement of two points (the transposition)."
+    },
+    {
+      "id": "small-d3",
+      "title": "D(3) = 2: the Two 3-Cycles",
+      "startLine": 36,
       "endLine": 38,
-      "summary": "numDerangements_two: D(2) = 1 (the unique swap); numDerangements_three: D(3) = 2 (the two 3-cycles), both by kernel decide. These feed the codimension counts below."
+      "summary": "numDerangements_three proves D(3) = 2 by kernel `decide`: the two derangements of three points are the two 3-cycles. This constant feeds the codimension-3 count. Both decides are kernel reductions (not native_decide), keeping the file axiom-free.",
+      "mathContext": "$D(3) = 2$ — the two 3-cycles on three points."
     },
     {
       "id": "codim-two",


### PR DESCRIPTION
Enrichment pass for `derangements-oq-02-oq-04`. Quality score **93 → 100**.

## Changes
- **Sections 4 → 5** and **annotations 4 → 5:** split the combined small-derangements block into separate `D(2) = 1` (unique transposition) and `D(3) = 2` (two 3-cycles) entries, each aligned to its own theorem and feeding the codimension-2 / codimension-3 counts respectively. Each carries mathContext/significance/relatedConcepts/prerequisites.

## Axiom integrity
No status/badge change; entry remains verified, 0 axioms, 0 sorries — the split annotations reinforce that both `decide`s are kernel reductions (no ofReduceBool).

Built via git-plumbing from the origin/main blob; diff verified non-empty via the 3-dot compare API.