### PR TITLE
Research: ramsey-r4k-extensions-oq-03 — deletion-window monotonicity via Pascal's rule (PART XIV)

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -304,6 +304,61 @@ theorem ramsey_deletion_one_past (hk : 2 ≤ k) (hkn : k ≤ n)
       ∀ K : Finset (Fin n), K ⊆ R → K.card = k → ¬ Mono c K :=
   ramsey_deletion_window hk hkn 1 (by simpa using hlo) (by simpa using hhi)
 
+/-- **The deletion window advances by exactly one vertex per step while the
+    `(k−1)`-clique first moment stays subthreshold.**  Recall the deletion bound is
+    `deletionBound n k = n − ⌊2·C(n,k) / 2^C(k,2)⌋`.  Its increment in `n` is governed by
+    Pascal's rule `C(n+1,k) = C(n,k) + C(n,k−1)`: the deleted-vertex count `⌊2·C(n,k)/q⌋`
+    (where `q = 2^C(k,2)`) can jump by at most one per step precisely when the *added*
+    mass `2·C(n,k−1)` is still below one full quantum `q`.  Hence, as long as
+
+        `2·C(n,k−1) < 2^C(k,2)`,
+
+    we have `deletionBound n k ≤ deletionBound (n+1) k`: adding a vertex never hurts the
+    guaranteed monochromatic-`Kₖ`-free set.
+
+    This is the *quantitative* content of the deletion window.  The sharp union bound
+    stalls at the largest `n` with `2·C(n,k) < q`; this lemma shows the deletion optimum
+    instead runs out to the largest `n` with `2·C(n,k−1) < q`.  Since in the Ramsey regime
+    `C(n,k−1) < C(n,k)` (the binomials are still on their increasing arm,
+    `Nat.choose_le_succ_of_lt_half_left`), that window is strictly wider — this is exactly
+    where the alteration method's extra factor of `≈ k` over the union bound comes from.
+    Pure `ℕ`-division, valid for every `k`; no `decide`. -/
+theorem deletionBound_mono_of_pred_subthreshold (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hpred : 2 * n.choose (k - 1) < 2 ^ (k.choose 2)) :
+    deletionBound n k ≤ deletionBound (n + 1) k := by
+  have hq : 0 < 2 ^ (k.choose 2) := pow_pos (by norm_num) _
+  -- Pascal's rule in the form we need (the exact binomial-ratio step).
+  have hpascal : 2 * (n + 1).choose k = 2 * n.choose k + 2 * n.choose (k - 1) := by
+    have h : (n + 1).choose k = n.choose k + n.choose (k - 1) := by
+      obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+      simp only [Nat.choose_succ_succ, Nat.add_sub_cancel]
+      ring
+    omega
+  simp only [deletionBound]
+  set q := 2 ^ (k.choose 2) with hq_def
+  set a := 2 * n.choose k with ha_def
+  set c := 2 * (n + 1).choose k with hc_def
+  set b := 2 * n.choose (k - 1) with hb_def
+  -- The floor `⌊c/q⌋` sits between `⌊a/q⌋` and `⌊a/q⌋ + 1` (added mass `b < q`).
+  have hxy : a / q ≤ c / q := Nat.div_le_div_right (by omega)
+  have hyx1 : c / q ≤ a / q + 1 :=
+    calc c / q ≤ (a + q) / q := Nat.div_le_div_right (by omega)
+      _ = a / q + 1 := Nat.add_div_right a hq
+  omega
+
+/-- **Wherever the sharp union bound is still feasible, the deletion bound is still
+    improving.**  If the first-moment test `2·C(n,k) < 2^C(k,2)` holds at `n` and the
+    binomials are on their increasing arm (`C(n,k−1) ≤ C(n,k)`, automatic in the Ramsey
+    regime `k−1 < n/2`), then `deletionBound n k ≤ deletionBound (n+1) k`.  Consequently
+    the deletion optimum lies at least as far out as the union optimum — and, because the
+    `(k−1)`-window `2·C(n,k−1) < 2^C(k,2)` is strictly wider than the `k`-window, strictly
+    beyond it.  A direct corollary of `deletionBound_mono_of_pred_subthreshold`. -/
+theorem deletionBound_mono_of_unionFeasible (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hunion : 2 * n.choose k < 2 ^ (k.choose 2))
+    (hmid : n.choose (k - 1) ≤ n.choose k) :
+    deletionBound n k ≤ deletionBound (n + 1) k :=
+  deletionBound_mono_of_pred_subthreshold hk hkn (by omega)
+
 set_option maxHeartbeats 800000 in
 /-- **The sharp union bound caps at `n = 17` for `k = 6`.**  The first-moment test
     `2·C(n,6) < 2^{C(6,2)} = 2^{15}` holds at `n = 17` (`2·12376 = 24752 < 32768`) but
@@ -430,6 +485,8 @@ theorem deletion_no_mono_K8 :
 #check @ramsey_deletion_generalizes_first_moment
 #check @ramsey_deletion_bound
 #check @ramsey_deletion_one_past
+#check @deletionBound_mono_of_pred_subthreshold
+#check @deletionBound_mono_of_unionFeasible
 #check @deletion_no_mono_K6
 #check @unionBound_caps_at_27_for_K7
 #check @deletion_no_mono_K7
@@ -446,6 +503,8 @@ theorem deletion_no_mono_K8 :
 #print axioms ramsey_deletion_window
 #print axioms ramsey_deletion_generalizes_first_moment
 #print axioms ramsey_deletion_one_past
+#print axioms deletionBound_mono_of_pred_subthreshold
+#print axioms deletionBound_mono_of_unionFeasible
 #print axioms deletion_no_mono_K6
 #print axioms unionBound_caps_at_27_for_K7
 #print axioms deletion_no_mono_K7

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -396,3 +396,55 @@ finding that the parent entry `RamseyR4kExtensions.lean` also silently failed to
 The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (Spencer's conditional-
 probability induction) remains the one non-Mathlib ingredient — a >1000-line measure-theoretic
 undertaking (BLOCKED). See sibling `lovasz-local-lemma-oq-01`.
+
+## PART XIV — quantifying the deletion window: monotonicity via Pascal's rule (researcher-14, 2026-07-04)
+
+**Mode**: ACT (RICH, score 36). **Outcome**: progress (+2 verified theorems, axiom-free).
+Machine-verified: docker-build clean, 7744 jobs, foundational axioms only
+(`propext / Classical.choice / Quot.sound`); no `decide`, no `native_decide`.
+
+### What this closes
+The prior state left one genuinely-mathematical (non-enumeration) increment open: *quantify
+how the deletion window width grows*, which "needs binomial-ratio estimates rather than
+`decide`." This session supplies the exact binomial-ratio step — **Pascal's rule** — and
+turns it into a monotonicity theorem for the deletion bound
+`deletionBound n k = n − ⌊2·C(n,k)/2^C(k,2)⌋`.
+
+- **`deletionBound_mono_of_pred_subthreshold`** (`2 ≤ k`, `k ≤ n`,
+  `2·C(n,k−1) < 2^C(k,2)`): `deletionBound n k ≤ deletionBound (n+1) k`. The deletion
+  bound is *nondecreasing* in `n` exactly while the `(k−1)`-clique first moment stays below
+  one quantum `q = 2^C(k,2)`.
+- **`deletionBound_mono_of_unionFeasible`** (`2 ≤ k`, `k ≤ n`, `2·C(n,k) < 2^C(k,2)`,
+  `C(n,k−1) ≤ C(n,k)`): same conclusion. Corollary: everywhere the sharp union bound is
+  still feasible, the deletion bound is still improving — so the deletion optimum lies **at
+  least as far out** as the union optimum. Since the `(k−1)`-window `2·C(n,k−1) < q` is
+  strictly wider than the `k`-window `2·C(n,k) < q` (the binomials are on their increasing
+  arm, `C(n,k−1) < C(n,k)` for `k−1 < n/2`, `Nat.choose_le_succ_of_lt_half_left`), the
+  deletion optimum sits **strictly beyond** it — the structural source of the alteration
+  method's `≈ k` gain over the union bound.
+
+### Technique (reusable ℕ-floor monotonicity idiom)
+The whole proof is an elementary `Nat`-division argument, no probability and no large
+`decide`:
+- **Pascal in the needed form**: `2·C(n+1,k) = 2·C(n,k) + 2·C(n,k−1)`. Get
+  `C(n+1,k) = C(n,k) + C(n,k−1)` by `obtain ⟨m, rfl⟩ : ∃ m, k = m+1` (from `2 ≤ k`), then
+  `simp only [Nat.choose_succ_succ, Nat.add_sub_cancel]; ring`; lift by `2·` with `omega`.
+- **Floor jumps by ≤ 1 per step**: with `a = 2·C(n,k)`, `b = 2·C(n,k−1) < q`,
+  `c = 2·C(n+1,k) = a+b`, the added mass `b` is below one quantum, so
+  `⌊c/q⌋ ≤ ⌊a/q⌋ + 1`. Proved by `c/q ≤ (a+q)/q` (`Nat.div_le_div_right` on `c ≤ a+q`,
+  which is `omega` from `b < q`) `= a/q + 1` (`Nat.add_div_right a hq`, `hq : 0 < q`).
+- **Close with `omega`** after `simp only [deletionBound]` and `set q/a/b/c`: given
+  `⌊a/q⌋ ≤ ⌊c/q⌋ ≤ ⌊a/q⌋+1`, `omega` proves `n − ⌊a/q⌋ ≤ (n+1) − ⌊c/q⌋` (it handles the
+  ℕ truncated subtraction and treats `a/q`, `c/q` as opaque atoms bounded by the two
+  hypotheses). Key: `set` before `omega` so the divisor `q` is a variable atom, not a
+  literal — `omega` then uses only the supplied inequalities, not built-in div lemmas.
+
+**Gotcha**: `pow_pos (by norm_num) _ : 0 < 2 ^ (k.choose 2)` is the robust positivity lemma
+(avoid the deprecated `Nat.pos_pow_of_pos`). `Nat.add_div_right a hq : (a + q)/q = a/q + 1`
+needs `hq : 0 < q` and the summand `q` on the *right*.
+
+### Still open (unchanged)
+The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (>1000-line measure-theoretic
+construction: probability space + mutual-independence `hindep`) remains the one non-Mathlib
+ingredient (BLOCKED). See sibling `lovasz-local-lemma-oq-01`. All finite/combinatorial and
+now the window-monotonicity content is discharged axiom-free.

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -4,28 +4,36 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 13 (PART XIII)
+**Iteration**: 14 (PART XIV)
 
 ## Current Focus
-Unified the deletion hierarchy into a single general theorem `ramsey_deletion_window`:
-for any window index M with `M·2^C(k,2) ≤ 2·C(n,k) < (M+1)·2^C(k,2)`, deletion certifies
-`R(k,k) > n − M`. The two prior special-case theorems are now one-line corollaries with
-unchanged signatures: `ramsey_deletion_generalizes_first_moment` = M=0,
-`ramsey_deletion_one_past` = M=1. Concrete k=6/7/8 witnesses unchanged. Tier-A axiom-free.
+Quantified the deletion window's growth (the direction flagged as the one genuine, non-
+enumeration increment). Two axiom-free theorems in
+`Proofs/RamseyR4kExtensionsOQ03Deletion.lean`:
+- `deletionBound_mono_of_pred_subthreshold`: `deletionBound n k ≤ deletionBound (n+1) k`
+  whenever `2·C(n,k−1) < 2^C(k,2)` — the deletion bound is nondecreasing in `n` exactly
+  while the `(k−1)`-clique first moment stays below one quantum.
+- `deletionBound_mono_of_unionFeasible`: same conclusion under `2·C(n,k) < 2^C(k,2)` and
+  `C(n,k−1) ≤ C(n,k)`. Corollary: the deletion optimum lies at least as far out as (and,
+  in the Ramsey regime, strictly beyond) the union optimum — the structural source of the
+  alteration method's `≈ k` gain.
+
+The engine is Pascal's rule `C(n+1,k) = C(n,k) + C(n,k−1)` (the exact binomial-ratio step)
+plus a ℕ-floor "jump ≤ 1 per step" lemma; closed by `omega`. No `decide`, no probability.
 
 ## Active Approach
-Machine-verified concrete witnesses (docker-build clean, 7744 jobs), Tier-A axiom-free
-(`propext / Classical.choice / Quot.sound`). k=8 binomials (≈10⁸) evaluated via
-`Nat.choose_eq_descFactorial_div_factorial` to keep kernel `decide` cheap and axiom-free.
+Elementary `Nat`-division monotonicity. docker-build clean (7744 jobs), Tier-A axiom-free
+(`propext / Classical.choice / Quot.sound`).
 
 ## Attempt Count
-- Total attempts: 13
+- Total attempts: 14
 - Current approach attempts: 1
 - Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
   identity, honest union-bound comparison (VII), deletion method (VIII), k=7
   machine-checked witness + compile repair (IX), general M=1 gain theorem (X),
   avoidance_pos numeric premises (XI), k=8 witness via descFactorial (XII),
-  general M-window unification theorem (XIII)
+  general M-window unification theorem (XIII), deletion-window monotonicity via
+  Pascal's rule (XIV)
 
 ## Blockers
 - **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
@@ -33,11 +41,12 @@ Machine-verified concrete witnesses (docker-build clean, 7744 jobs), Tier-A axio
   `lovasz-local-lemma-oq-01`.
 
 ## Next Action
-The axiom-free deletion line is now at a natural stopping point: the mechanism is stated
-at full generality (`ramsey_deletion_window` for every window index M), with M=0/M=1
-corollaries and concrete k=6,7,8 witnesses. Further k=9+ witnesses would be enumeration
-theater (no new mathematics). The one genuinely valuable — but hard — remaining direction
-is the BLOCKED `SymmetricLLLForRamsey` measure-theory construction (>1000 lines): the
-probability space + mutual-independence `hindep`. A possible but analytically nontrivial
-increment would quantify how the window width (hence the deletion gain over the sharp
-union optimum) grows with k, which needs binomial-ratio estimates rather than `decide`.
+The axiom-free line is now saturated: the deletion mechanism is stated at full generality
+(`ramsey_deletion_window`, every M), with the window's *monotonic growth* now characterized
+by the `(k−1)`-clique threshold (PART XIV), plus concrete k=6,7,8 witnesses. The only
+remaining genuinely-mathematical increments both require the BLOCKED measure-theoretic LLL:
+either (a) the `SymmetricLLLForRamsey` construction itself, or (b) a Stirling-based
+*asymptotic* statement that the additive window width grows like a constant fraction of the
+union value (needs real analysis / `Nat.choose` asymptotics beyond Pascal). Further concrete
+k≥9 witnesses would be enumeration theater. Recommend releasing the claim; the natural next
+worker should target the sibling `lovasz-local-lemma-oq-01` measure-theory core.


### PR DESCRIPTION
## Summary

Quantifies how the Erdős **deletion (alteration) window** grows with `n` — the one genuinely-mathematical (non-enumeration) increment left open by PART XIII. Two new theorems in `Proofs/RamseyR4kExtensionsOQ03Deletion.lean`, both axiom-free.

The deletion method gives `R(k,k) > deletionBound n k = n − ⌊2·C(n,k) / 2^C(k,2)⌋`. This PR characterizes when that bound *improves* as `n` grows, via **Pascal's rule** `C(n+1,k) = C(n,k) + C(n,k−1)` — the exact binomial-ratio step the prior state flagged as needed.

### New theorems
- **`deletionBound_mono_of_pred_subthreshold`** (`2 ≤ k`, `k ≤ n`, `2·C(n,k−1) < 2^C(k,2)`): `deletionBound n k ≤ deletionBound (n+1) k`. The deletion bound is *nondecreasing* in `n` exactly while the `(k−1)`-clique first moment stays below one quantum `q = 2^C(k,2)`.
- **`deletionBound_mono_of_unionFeasible`** (`2 ≤ k`, `k ≤ n`, `2·C(n,k) < 2^C(k,2)`, `C(n,k−1) ≤ C(n,k)`): same conclusion. **Corollary:** everywhere the sharp union bound is still feasible, the deletion bound is still improving — so the deletion optimum lies *at least as far out* as the union optimum, and (since the `(k−1)`-window is strictly wider than the `k`-window in the Ramsey regime) *strictly beyond* it. This is the structural source of the alteration method's `≈ k` gain over the union bound.

### Technique
Pure `ℕ`-division, valid for every `k`, no `decide`/`native_decide`:
- Pascal in the form `2·C(n+1,k) = 2·C(n,k) + 2·C(n,k−1)` (`obtain ⟨m,rfl⟩` + `Nat.choose_succ_succ`).
- Added mass `2·C(n,k−1) < q` ⇒ the floor jumps by ≤ 1 per step (`Nat.div_le_div_right` + `Nat.add_div_right`).
- `omega` closes the `ℕ`-truncated-subtraction inequality with the divisor `set` as an atom.

## Verification
- `docker-build.sh Proofs.RamseyR4kExtensionsOQ03Deletion` — **clean, 7744 jobs**.
- `#print axioms` for both new theorems: `[propext, Classical.choice, Quot.sound]` only. **0 sorries, 0 `axiom` declarations, no `Lean.ofReduceBool`.** Tier-A axiom-free.

## Remaining (unchanged)
The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (>1000-line measure-theoretic construction) remains the one non-Mathlib ingredient (BLOCKED); see sibling `lovasz-local-lemma-oq-01`. All finite/combinatorial content — and now the window-growth monotonicity — is discharged axiom-free.