### PR TITLE
Enrich General Gaussian Moments (E[X^{2k}]=(2k-1)‼): add overview, sections, conclusion, references

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/annotations.json
@@ -49,8 +49,8 @@
   "id": "aoc05inc010101-ann-recursion",
   "proofId": "area-of-circle-oq-05-incomplete-01-oq-01-oq-01",
   "range": {
-   "startLine": 96,
-   "endLine": 143
+   "startLine": 93,
+   "endLine": 147
   },
   "type": "technique",
   "title": "The Parity-Preserving Moment Recursion",

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01-oq-01/meta.json
@@ -62,6 +62,144 @@
     ],
     "significance": "The moments of the standard normal are among the most-used constants in probability, statistics, and mathematical physics (Wick/Isserlis theorem, Hermite polynomials, method of moments). This entry gives the complete closed form E[X^{2k}] = (2k-1)‼ and E[X^{2k+1}] = 0 from a self-contained analytic recursion on the moment-generating function, reusing the grandparent's MGF computation and answering its own stated open question."
   },
+  "overview": {
+    "historicalContext": "That the even moments of a standard Gaussian are the odd double factorials, E[X^{2k}] = (2k-1)‼ = 1·3·5···(2k-1), is one of the oldest computed integrals of probability, implicit already in Laplace's and Gauss's work on the normal law. The double factorial counts the perfect matchings of a 2k-element set — a combinatorial fact that reappears as the Wick/Isserlis theorem (Isserlis 1918; Wick 1950), which expresses any higher mixed moment of a jointly Gaussian family as a sum over pairings of second moments. In that language E[X^{2k}] = (number of pairings of 2k points) = (2k-1)‼, and the vanishing of the odd moments is the statement that an odd number of points cannot be perfectly paired. The same numbers are the leading coefficients of the (probabilist) Hermite polynomials Heₙ, the orthogonal polynomials for the Gaussian weight, and they underlie the method of moments for proving Gaussian limit theorems (a sequence with moments converging to (2k-1)‼ and 0 converges in distribution to N(0,1)). The classical derivation integrates x^{2k}e^{-x²/2} by parts; this entry instead runs the whole computation on the moment-generating function M_X(t) = exp(t²/2), turning the moment problem into an ODE-driven derivative recursion. The grandparent entry (area-of-circle-oq-05-incomplete-01-oq-01) had formalized N(0,1), its first three moments, and the MGF, but left the general-k formula explicitly open; this file closes it.",
+    "problemStatement": "For the standard normal X ~ N(0,1) (Mathlib's `gaussianReal 0 1`), prove the complete moment formula: every even moment is the odd double factorial, ∫ x^{2k} dN(0,1) = (2k-1)‼, and every odd moment vanishes, ∫ x^{2k+1} dN(0,1) = 0. The grandparent AreaOfCircleOQ05Incomplete01OQ01 settled only k ≤ 1 and recorded the moment-generating function M_X(t) = exp(t²/2); the general-k statement was its stated open question.",
+    "text": "The bell curve's moments have a beautiful closed form: the average of X² is 1, of X⁴ is 3, of X⁶ is 15, of X⁸ is 105 — each is the product of the odd numbers up to one less than the exponent, the 'double factorial' (2k-1)‼. Every odd moment is zero by symmetry. This entry proves the whole family at once, not by the usual integration-by-parts, but by exploiting that the Gaussian's moment-generating function g(t) = e^{t²/2} satisfies the tidy differential equation g'(t) = t·g(t). Differentiating that relation over and over produces a recursion linking each moment to the one two steps below it, and unwinding the recursion deposits exactly the product of odd numbers.",
+    "proofStrategy": "**MGF as derivative generator.** Mathlib's `iteratedDeriv_mgf_zero` gives E[Xⁿ] = g⁽ⁿ⁾(0) once 0 lies in the interior of the MGF's domain of definition; for N(0,1) that domain is all of ℝ (`integrableExpSet id stdNormal = Set.univ`), so the hypothesis is free (`moment_eq_iteratedDeriv`). Here g(t) = exp(t²/2) is the explicit MGF recorded by the grandparent.\n\n**The ODE.** The chain rule gives the first-order ODE g'(t) = t·g(t) (`deriv_g`). This single relation drives everything; no integrability estimates enter because the computation lives entirely on the smooth function g (`g_contDiff`: g ∈ C^∞).\n\n**The derivative recursion.** Differentiating the ODE n times by the Leibniz rule against the linear factor t (whose second derivative is 0) gives the closed recursion g⁽ⁿ⁺²⁾(t) = t·g⁽ⁿ⁺¹⁾(t) + (n+1)·g⁽ⁿ⁾(t) (`iteratedDeriv_add_two_g`), proved by induction with `HasDerivAt` product/sum rules and no Nat subtraction. At t = 0 the first term vanishes, collapsing it to g⁽ⁿ⁺²⁾(0) = (n+1)·g⁽ⁿ⁾(0) (`iteratedDeriv_add_two_g_zero`), i.e. the moment recursion E[X^{n+2}] = (n+1)·E[Xⁿ] (`moment_recursion`).\n\n**Unwinding.** Iterating on even indices from E[X⁰] = 1 accumulates ∏_{i<k}(2i+1) (`iteratedDeriv_even_g`, `stdNormal_even_moment`); on odd indices the base case g'(0) = 0·g(0) = 0 annihilates the whole chain (`iteratedDeriv_odd_g`, `stdNormal_odd_moment`). Finally the product of the first k odd numbers is identified with `Nat.doubleFactorial` via the odd successor identity (2n+1)‼ = (2n+1)·(2n-1)‼ (`odd_df_succ`, `prod_odd_eq_doubleFactorial`), yielding the headline E[X^{2k}] = (2k-1)‼ (`stdNormal_even_moment_doubleFactorial`).",
+    "keyInsights": [
+      "Both open strands — the even formula (2k-1)‼ and the vanishing of odd moments — fall out of a single parity-preserving recursion E[X^{n+2}] = (n+1)·E[Xⁿ]. The parity of the index is conserved because the recursion steps by two; the even chain is seeded by E[X⁰] = 1 and the odd chain by E[X¹] = 0, so one mechanism resolves both cases.",
+      "Working on the moment-generating function instead of the integral trades an analytic difficulty for an algebraic one. The classical integration-by-parts route must re-establish integrability of x^{2k}e^{-x²/2} at each step; the MGF route needs integrability only once (to place 0 in the interior of the MGF domain), after which everything is differentiation of the smooth function exp(t²/2).",
+      "The entire recursion is generated by the one differential equation g'(t) = t·g(t). Differentiating it n times is a Leibniz expansion against a linear factor, so the only surviving terms are t·g⁽ⁿ⁺¹⁾ and (n+1)·g⁽ⁿ⁾ — the second derivative of t is zero, which is exactly why the recursion is a clean two-term relation rather than an unbounded sum.",
+      "Evaluation at t = 0 is what turns a functional identity into an arithmetic one: the t·g⁽ⁿ⁺¹⁾(t) term is killed by its factor of t, leaving the pure multiplier (n+1). This is the analytic shadow of the combinatorial fact that (2k-1)‼ counts perfect matchings — adjoining a new point to 2k-2 existing ones can pair it in (2k-1) ways, the same (n+1) that appears in the recursion.",
+      "The odd double factorial (2k-1)‼ is matched to Mathlib's `Nat.doubleFactorial` entirely within ℕ (via the successor identity (2n+1)‼ = (2n+1)·(2n-1)‼) before a single cast to ℝ, keeping the arithmetic identity `decide`-checkable at the base case and avoiding Nat-subtraction pitfalls in `2*k - 1`."
+    ],
+    "prerequisites": [
+      "The standard normal N(0,1) and its MGF exp(t²/2) (grandparent area-of-circle-oq-05-incomplete-01-oq-01)",
+      "Moment-generating functions as derivative generators: ProbabilityTheory.iteratedDeriv_mgf_zero and integrableExpSet_id_gaussianReal",
+      "Iterated derivatives and smoothness: ContDiff, iteratedDeriv_succ, ContDiff.differentiable_iteratedDeriv'",
+      "The HasDerivAt product/sum/chain rules and the odd double factorial Nat.doubleFactorial / Nat.doubleFactorial_add_two"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "stdNormal_even_moment_doubleFactorial",
+      "type": "core",
+      "description": "The headline result closing the grandparent's open strand: every even moment of the standard normal is the odd double factorial, E[X^{2k}] = (2k-1)‼. Obtained from the product form by matching ∏_{i<k}(2i+1) to Nat.doubleFactorial.",
+      "leanType": "(k : ℕ) → ∫ x, x ^ (2 * k) ∂stdNormal = ((2 * k - 1)‼ : ℝ)"
+    },
+    {
+      "name": "stdNormal_odd_moment",
+      "type": "core",
+      "description": "Every odd moment of the standard normal vanishes: E[X^{2k+1}] = 0. Same recursion as the even case, seeded by E[X] = g'(0) = 0.",
+      "leanType": "(k : ℕ) → ∫ x, x ^ (2 * k + 1) ∂stdNormal = 0"
+    },
+    {
+      "name": "moment_recursion",
+      "type": "core",
+      "description": "The parity-preserving moment recursion E[X^{n+2}] = (n+1)·E[Xⁿ] for the standard normal, the engine from which both the even and odd formulas are unwound.",
+      "leanType": "(n : ℕ) → ∫ x, x ^ (n + 2) ∂stdNormal = ((n : ℝ) + 1) * ∫ x, x ^ n ∂stdNormal"
+    },
+    {
+      "name": "stdNormal_even_moment",
+      "type": "lemma",
+      "description": "Product form of the even moment: E[X^{2k}] = ∏_{i<k}(2i+1), the accumulated product of odd numbers before its identification with the double factorial.",
+      "leanType": "(k : ℕ) → ∫ x, x ^ (2 * k) ∂stdNormal = ∏ i ∈ Finset.range k, (2 * (i : ℝ) + 1)"
+    },
+    {
+      "name": "moment_eq_iteratedDeriv",
+      "type": "lemma",
+      "description": "Bridge from the probability integral to the analytic derivative: E[Xⁿ] = g⁽ⁿ⁾(0) for g(t) = exp(t²/2). Discharges the interior-of-domain side condition of iteratedDeriv_mgf_zero via integrableExpSet id stdNormal = Set.univ.",
+      "leanType": "(n : ℕ) → ∫ x, x ^ n ∂stdNormal = iteratedDeriv n g 0"
+    },
+    {
+      "name": "iteratedDeriv_add_two_g",
+      "type": "lemma",
+      "description": "The analytic engine: the Leibniz expansion of the iterated derivatives of g, g⁽ⁿ⁺²⁾(t) = t·g⁽ⁿ⁺¹⁾(t) + (n+1)·g⁽ⁿ⁾(t), proved by induction with HasDerivAt product/sum rules and no Nat subtraction.",
+      "leanType": "(n : ℕ) → iteratedDeriv (n + 2) g = fun t => t * iteratedDeriv (n + 1) g t + ((n : ℝ) + 1) * iteratedDeriv n g t"
+    },
+    {
+      "name": "deriv_g",
+      "type": "lemma",
+      "description": "The defining first-order ODE of the Gaussian MGF, deriv g = fun t => t · g t, from the chain rule on g(t) = exp(t²/2). Every subsequent recursion is a differentiated form of this identity.",
+      "leanType": "deriv g = fun t => t * g t"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Overview: closing the general moment strand",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring. Recalls that the grandparent AreaOfCircleOQ05Incomplete01OQ01 settled E[X⁰], E[X¹], E[X²] and recorded the MGF M_X(t) = exp(t²/2), leaving the general formula open. States the goal — E[X^{2k}] = (2k-1)‼ and E[X^{2k+1}] = 0 — and the method: identify moments with MGF derivatives, use the ODE g'(t) = t·g(t), differentiate n times, evaluate at 0, and unwind. Notes the file is sorry-free and axiom-free."
+    },
+    {
+      "id": "imports-setup",
+      "title": "Imports and namespace",
+      "startLine": 46,
+      "endLine": 57,
+      "summary": "Imports Mathlib's MGF-analyticity and Gaussian machinery, the double-factorial library, and the grandparent proof (source of stdNormal and stdNormal_mgf). Opens MeasureTheory, Real, ProbabilityTheory and the Nat scope, enters the namespace, and re-exposes stdNormal / stdNormal_mgf from the grandparent."
+    },
+    {
+      "id": "mgf-definition",
+      "title": "The MGF as a smooth function g(t) = exp(t²/2)",
+      "startLine": 59,
+      "endLine": 76,
+      "summary": "Defines g(t) = exp(t²/2) and records: g 0 = 1 (g_zero), g = mgf id stdNormal (g_eq_mgf, from the grandparent), g ∈ C^∞ (g_contDiff, by fun_prop), and hence every iterated derivative of g is differentiable (differentiable_iteratedDeriv_g). These supply all the smoothness the recursion consumes."
+    },
+    {
+      "id": "the-ode",
+      "title": "The defining ODE g'(t) = t·g(t)",
+      "startLine": 78,
+      "endLine": 90,
+      "summary": "deriv_g: the chain rule on exp(t²/2) yields the first-order ODE deriv g = fun t => t·g(t), with pointwise form deriv_g_apply. This single differential relation is the source of the entire moment recursion."
+    },
+    {
+      "id": "derivative-recursion",
+      "title": "The derivative recursion and its value at 0",
+      "startLine": 92,
+      "endLine": 147,
+      "summary": "deriv_iteratedDeriv_g (deriv of g⁽ᵏ⁾ is g⁽ᵏ⁺¹⁾), then the central iteratedDeriv_add_two_g: g⁽ⁿ⁺²⁾(t) = t·g⁽ⁿ⁺¹⁾(t) + (n+1)·g⁽ⁿ⁾(t), by induction on n with HasDerivAt product/sum rules (no Nat subtraction). Evaluating at t = 0 kills the t·g⁽ⁿ⁺¹⁾ term, giving iteratedDeriv_add_two_g_zero: g⁽ⁿ⁺²⁾(0) = (n+1)·g⁽ⁿ⁾(0)."
+    },
+    {
+      "id": "even-odd-derivatives",
+      "title": "Even derivatives accumulate; odd derivatives vanish",
+      "startLine": 149,
+      "endLine": 170,
+      "summary": "iteratedDeriv_even_g: unwinding the recursion on even indices from g⁽⁰⁾(0) = 1 gives g⁽²ᵏ⁾(0) = ∏_{i<k}(2i+1). iteratedDeriv_odd_g: the odd chain is annihilated by the base case g'(0) = 0·g(0) = 0, so g⁽²ᵏ⁺¹⁾(0) = 0. Both by induction on k."
+    },
+    {
+      "id": "moment-bridge",
+      "title": "From probability integral to MGF derivative",
+      "startLine": 171,
+      "endLine": 179,
+      "summary": "moment_eq_iteratedDeriv: E[Xⁿ] = g⁽ⁿ⁾(0). Places 0 in the interior of integrableExpSet id stdNormal (which equals Set.univ for the standard normal), applies Mathlib's iteratedDeriv_mgf_zero, and reconciles mgf id stdNormal with the explicit g via g_eq_mgf."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Main theorems: recursion and moment formulas",
+      "startLine": 181,
+      "endLine": 196,
+      "summary": "moment_recursion (E[X^{n+2}] = (n+1)·E[Xⁿ]), stdNormal_even_moment (E[X^{2k}] = ∏_{i<k}(2i+1)), and stdNormal_odd_moment (E[X^{2k+1}] = 0), each a one-line consequence of the moment bridge composed with the corresponding derivative lemma."
+    },
+    {
+      "id": "double-factorial",
+      "title": "Product of odds = double factorial; headline form",
+      "startLine": 198,
+      "endLine": 225,
+      "summary": "odd_df_succ ((2n+1)‼ = (2n+1)·(2n-1)‼) and prod_odd_eq_doubleFactorial (∏_{i<k}(2i+1) = (2k-1)‼) do the arithmetic inside ℕ, then stdNormal_even_moment_doubleFactorial casts to ℝ to deliver the headline E[X^{2k}] = (2k-1)‼, closing the grandparent's open strand."
+    }
+  ],
+  "conclusion": {
+    "summary": "The complete moment formula for the standard normal is machine-verified: E[X^{2k}] = (2k-1)‼ (odd double factorial) and E[X^{2k+1}] = 0, both derived from the single parity-preserving recursion E[X^{n+2}] = (n+1)·E[Xⁿ]. The recursion comes from differentiating the moment-generating-function ODE g'(t) = t·g(t) and evaluating at 0. Fully checked: 0 sorries, 0 axioms.",
+    "implications": "Closes the general-moment strand that the grandparent area-of-circle-oq-05-incomplete-01-oq-01 explicitly left open, upgrading its k ≤ 1 computation to all k. The MGF-derivative method is reusable: any distribution whose moment-generating function is known in closed form and analytic at 0 yields its moments by the same iteratedDeriv_mgf_zero bridge plus an ODE-driven recursion, without per-moment integrability work. The result is the analytic half of the Wick/Isserlis pairing count and supplies the exact constants needed for the method of moments and for Hermite-polynomial normalizations.",
+    "openQuestions": [
+      "Extend from the standard normal to the general Gaussian N(μ, σ²): derive the central moments E[(X−μ)^{2k}] = σ^{2k}(2k−1)‼ and the non-central moments via the binomial expansion, reusing the MGF exp(μt + σ²t²/2).",
+      "Formalize the full Wick/Isserlis theorem — E[∏ Xᵢ] as a sum over perfect matchings of pairwise covariances for a jointly Gaussian family — of which E[X^{2k}] = (2k−1)‼ is the single-variable diagonal case.",
+      "Connect the even moments to the (probabilist) Hermite polynomials Heₙ and their orthogonality relation ∫ Heₘ Heₙ dN(0,1) = n!·δₘₙ, whose diagonal m = n = k reproduces the double factorial through k!·(2k−1)‼/k! bookkeeping.",
+      "Apply the moment sequence ((2k−1)‼, 0) to a method-of-moments formalization: show that a sequence of random variables whose moments converge to these values converges in distribution to N(0,1)."
+    ]
+  },
   "crossReferences": [
     {
       "id": "area-of-circle-oq-05-incomplete-01-oq-01",
@@ -70,6 +208,32 @@
     {
       "id": "area-of-circle-oq-07-oq-05-oq-01",
       "relationship": "Sibling even-moment result for the unnormalized physicist weight ∫ x^{2n} e^{-x²} = (2n-1)‼√π/2ⁿ, proved by integration by parts; this entry is the probabilist N(0,1) normalization proved by the MGF-derivative method."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Isserlis, L.",
+      "title": "On a formula for the product-moment coefficient of any order of a normal frequency distribution in any number of variables",
+      "year": "1918",
+      "note": "Biometrika 12, 134–139. The original moment-pairing theorem for the multivariate normal; its single-variable diagonal case is E[X^{2k}] = (2k−1)‼."
+    },
+    {
+      "authors": "Wick, G. C.",
+      "title": "The evaluation of the collision matrix",
+      "year": "1950",
+      "note": "Physical Review 80, 268–272. The physics rediscovery of Isserlis' pairing formula (Wick's theorem), foundational for perturbative quantum field theory; the double factorial counts the contractions."
+    },
+    {
+      "authors": "Billingsley, P.",
+      "title": "Probability and Measure",
+      "year": "1995",
+      "note": "3rd ed., Wiley. Standard reference for the Gaussian moments and the method of moments (a distribution with moments (2k−1)‼ and 0 is N(0,1))."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib4: ProbabilityTheory.iteratedDeriv_mgf_zero and Nat.doubleFactorial",
+      "year": "2024",
+      "note": "The MGF-analyticity bridge E[Xⁿ] = M_X⁽ⁿ⁾(0) and the double-factorial library used to state and prove the closed form."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-incomplete-01-oq-01-oq-01` (quality 55, 0 prior passes).

## Gaps closed
The entry had strong `originalContributions` and 5 detailed annotations, but `meta.json` was missing the whole `overview`, `sections`, `conclusion`, `mainTheorems`, and `references` — the reason for the low score. All five are now added, every claim grounded in the 225-line Lean source:

- **overview**: `historicalContext` (the double factorial as perfect-matching count → Isserlis 1918 / Wick 1950, Hermite polynomials, method of moments), `problemStatement`, plain-language `text`, detailed `proofStrategy`, and 5 `keyInsights`
- **mainTheorems**: 7 entries with `leanType` — headline `stdNormal_even_moment_doubleFactorial`, `stdNormal_odd_moment`, `moment_recursion`, the product form, the MGF-derivative bridge, the derivative recursion, and the defining ODE
- **sections**: 9 sections covering all 225 lines (docstring → imports → MGF def → ODE → recursion → even/odd derivatives → moment bridge → main theorems → double factorial)
- **conclusion**: `summary`, `implications`, 4 `openQuestions` (general Gaussian N(μ,σ²), full Wick/Isserlis, Hermite orthogonality, method of moments)
- **references**: Isserlis 1918, Wick 1950, Billingsley, Mathlib

## Also fixed
The `ann-recursion` annotation was anchored at line 96 (mid-lemma body) — the annotation builder flagged 'No Lean construct found'. Retargeted to the `deriv_iteratedDeriv_g` declaration (line 93) and extended to 147 to cover the full recursion block.

## Verification
- JSON parses; `check-meta-size` passes (23.2 KB, well within the 60 KB cap)
- `scripts/annotations/build.ts` reports **no errors** for this entry (the anchor warning is resolved)
- No axiom/status changes: entry remains `verified`, 0 axioms, 0 sorries (matches the Lean file)