### PR TITLE
Research: MZ SLLN — Tonelli interchange for the variance sum (S4b step-4)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1233,4 +1233,114 @@ theorem tsum_weight_trunc_sq_le {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (x : ℝ) 
 
 end TailPSeries
 
+/-! ## S4b (step 4) — the Tonelli interchange for the MZ variance sum
+
+The pointwise integrand bound `tsum_weight_trunc_sq_le` is lifted across the
+sample space by a **Tonelli interchange** (`MeasureTheory.integral_tsum`): the
+`i^{-s}`-weighted truncated second moments may be summed *inside* the integral,
+
+    ∑ᵢ ∫ i^{-s}·Yᵢ²  =  ∫ ∑ᵢ i^{-s}·Yᵢ²  ≤  ∫ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²,
+
+with `Yᵢ = 𝟙{|X| ≤ i^{1/p}}·X`.  The middle equality is the interchange; the final
+inequality is `tsum_weight_trunc_sq_le` applied pointwise at `x = X ω`.  The
+dominating function on the right is hypothesised integrable — its evaluation to
+`C·(𝔼|X|ᵖ + 1)` at `s = 2/p` is the next brick.
+
+The interchange's finiteness side-goal `∑ᵢ ∫⁻‖fᵢ‖ₑ ≠ ∞` is discharged by the same
+domination: `lintegral_tsum` + `ENNReal.ofReal_tsum_of_nonneg` turn it into
+`∫⁻ ofReal(∑ᵢ fᵢ) ≤ ∫⁻ ‖g‖ₑ < ∞`.  No independence, identical distribution, or
+`s = 2/p` is used — this is pure measure theory over any `μ`. -/
+section TonelliInterchange
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Tonelli interchange for the Marcinkiewicz–Zygmund variance sum.**  For a
+measurable `X`, `1 < s`, `0 < p`, and a dominating function
+`g ω = (max 1 |X ω|ᵖ)^{1-s}·s/(s-1)·(X ω)²` assumed integrable, the `i^{-s}`-weighted
+truncated second moments sum inside the integral and are bounded:
+
+    ∑ᵢ ∫ i^{-s}·(𝟙{|X| ≤ i^{1/p}}·X)²  ≤  ∫ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X².
+
+This is the measure-theoretic lift of `tsum_weight_trunc_sq_le`: `integral_tsum`
+moves `∑ᵢ` inside the integral, the pointwise integrand bound dominates the inner
+sum, and the integral of the dominating `g` closes it.  With `s = 2/p` the left
+side is the truncated variance sum `∑ᵢ 𝔼[Yᵢ²]/i^{2/p}` feeding Kolmogorov's
+criterion; integrating `g` (the next brick) turns the right side into `C·𝔼|X|ᵖ`. -/
+theorem tsum_integral_weight_trunc_sq_le
+    {X : Ω → ℝ} {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (hX : Measurable X)
+    (hg : Integrable
+      (fun ω => (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * X ω ^ 2) μ) :
+    ∑' i : ℕ, ∫ ω, (i : ℝ) ^ (-s)
+          * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2 ∂μ
+      ≤ ∫ ω, (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * X ω ^ 2 ∂μ := by
+  set f : ℕ → Ω → ℝ := fun i ω =>
+    (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2 with hf
+  set g : Ω → ℝ := fun ω =>
+    (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * X ω ^ 2 with hg'
+  -- each truncation set is measurable, hence each summand `f i` is measurable and nonneg
+  have hSmeas : ∀ i : ℕ, MeasurableSet {ω | |X ω| ≤ (i : ℝ) ^ (1 / p)} := fun i =>
+    measurableSet_le hX.abs measurable_const
+  have hf_meas : ∀ i, Measurable (f i) := fun i => by
+    simp only [hf]
+    exact measurable_const.mul ((hX.indicator (hSmeas i)).pow_const 2)
+  have hf_nonneg : ∀ i ω, 0 ≤ f i ω := fun i ω => by
+    simp only [hf]
+    exact mul_nonneg (Real.rpow_nonneg (Nat.cast_nonneg i) _) (sq_nonneg _)
+  -- rewrite `f · ω` as an indicator over the *index*, matching `tsum_weight_trunc_sq_le`
+  have hfω : ∀ ω, (fun i : ℕ => f i ω)
+      = fun i => {i : ℕ | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator
+          (fun i => (i : ℝ) ^ (-s) * X ω ^ 2) i := by
+    intro ω; funext i
+    simp only [hf, Set.indicator_apply, Set.mem_setOf_eq]
+    split_ifs <;> ring
+  -- pointwise: the inner series is dominated by `g ω`
+  have hpt : ∀ ω, ∑' i, f i ω ≤ g ω := by
+    intro ω
+    rw [hfω ω]; simp only [hg']
+    exact tsum_weight_trunc_sq_le hs hp (X ω)
+  -- pointwise summability of `f · ω`
+  have hsummable : ∀ ω, Summable (fun i => f i ω) := by
+    intro ω
+    rw [hfω ω]
+    exact ((Real.summable_nat_rpow.mpr (by linarith : -s < -1)).mul_right (X ω ^ 2)).indicator _
+  -- discharge the interchange finiteness side-goal `∑ᵢ ∫⁻ ‖fᵢ‖ₑ ≠ ∞`
+  have hfin : ∑' i, ∫⁻ ω, ‖f i ω‖ₑ ∂μ ≠ ∞ := by
+    have henorm : ∀ i ω, ‖f i ω‖ₑ = ENNReal.ofReal (f i ω) := fun i ω =>
+      Real.enorm_eq_ofReal (hf_nonneg i ω)
+    have hswap : ∑' i, ∫⁻ ω, ‖f i ω‖ₑ ∂μ
+        = ∫⁻ ω, ENNReal.ofReal (∑' i, f i ω) ∂μ := by
+      simp_rw [henorm]
+      rw [← lintegral_tsum (fun i => ((hf_meas i).ennreal_ofReal).aemeasurable)]
+      refine lintegral_congr (fun ω => ?_)
+      rw [ENNReal.ofReal_tsum_of_nonneg (fun i => hf_nonneg i ω) (hsummable ω)]
+    rw [hswap]
+    apply ne_of_lt
+    calc ∫⁻ ω, ENNReal.ofReal (∑' i, f i ω) ∂μ
+        ≤ ∫⁻ ω, ‖g ω‖ₑ ∂μ := by
+          refine lintegral_mono (fun ω => ?_)
+          rw [Real.enorm_eq_ofReal_abs]
+          exact ENNReal.ofReal_le_ofReal ((hpt ω).trans (le_abs_self _))
+      _ < ∞ := hasFiniteIntegral_iff_enorm.mp hg.hasFiniteIntegral
+  -- the interchange, then domination by the integrable `g`
+  have key : ∑' i, ∫ ω, f i ω ∂μ ≤ ∫ ω, g ω ∂μ :=
+    calc ∑' i, ∫ ω, f i ω ∂μ
+        = ∫ ω, ∑' i, f i ω ∂μ :=
+          (integral_tsum (fun i => (hf_meas i).aestronglyMeasurable) hfin).symm
+      _ ≤ ∫ ω, g ω ∂μ :=
+          integral_mono_of_nonneg
+            (ae_of_all _ fun ω => tsum_nonneg fun i => hf_nonneg i ω) hg
+            (ae_of_all _ hpt)
+  simpa only [hf, hg'] using key
+
+#check @tsum_integral_weight_trunc_sq_le
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms tsum_integral_weight_trunc_sq_le
+
+end TonelliInterchange
+
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/knowledge.md
@@ -6,6 +6,85 @@
 
 ---
 
+## Session 2026-07-04 (researcher-8, iter 13) — S4b step-4 **Tonelli interchange** SHIPPED & VERIFIED
+
+**Mode**: REVISIT (RICH, score 42). **Outcome**: progress — new theorem
+`tsum_integral_weight_trunc_sq_le` appended to
+`proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ TonelliInterchange), 0 sorries,
+0 `axiom`; docker build **succeeded, 7743 jobs, exit 0**; `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
+
+### What it adds — the measure-theoretic interchange itself
+This is the `∑'ᵢ`–`∫` swap the last several iterations built toward. Iter 12
+(`tsum_weight_trunc_sq_le`) gave the **pointwise** per-`ω` variance-sum integrand bound;
+this iteration lifts it across the sample space:
+
+    tsum_integral_weight_trunc_sq_le
+      {X : Ω → ℝ} {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (hX : Measurable X)
+      (hg : Integrable (fun ω => (max 1 (|X ω|^p))^(1-s) * s/(s-1) * X ω^2) μ) :
+      ∑' i, ∫ ω, (i:ℝ)^(-s) * ({ω | |X ω| ≤ (i:ℝ)^(1/p)}.indicator X ω)^2 ∂μ
+        ≤ ∫ ω, (max 1 (|X ω|^p))^(1-s) * s/(s-1) * X ω^2 ∂μ
+
+With `s = 2/p (> 1 ⟺ p < 2)` the LHS is exactly the truncated variance sum
+`∑ᵢ 𝔼[Yᵢ²]/i^{2/p}` (`Yᵢ = 𝟙{|X|≤i^{1/p}}·X`), and the RHS is the dominating integral
+whose evaluation to `C·𝔼|X|ᵖ` (splitting `|X|≥1` / `|X|<1`) is the **only remaining
+step-4 brick**. The dominating function `g` is left as an integrability *hypothesis* —
+that is the honest factoring, since integrating `g` needs `s = 2/p` and `MemLp X 2`.
+
+### Technique (reusable)
+`MeasureTheory.integral_tsum (hf : ∀ i, AEStronglyMeasurable (f i) μ) (hf' : ∑'ᵢ ∫⁻‖fᵢ‖ₑ ≠ ∞)`
+moves `∑'ᵢ` inside the Bochner integral. Three moving parts:
+1. **Pointwise domination** `∑'ᵢ fᵢ(ω) ≤ g ω` is `tsum_weight_trunc_sq_le` after rewriting
+   the summand `fᵢ(ω) = i^{-s}·(𝟙{|X ω|≤i^{1/p}}·X ω)²` into the *index-indicator* form
+   `{i | |X ω|≤i^{1/p}}.indicator (fun i => i^{-s}·(X ω)²) i` (`Set.indicator_apply`+`ring`;
+   the two indicators — one over `ω`, one over `i` — agree because `ω∈{ω|…}` ⟺ the same
+   inequality ⟺ `i∈{i|…}`).
+2. **Finiteness side-goal** `hf'`: push `∑'ᵢ ∫⁻ ofReal(fᵢ)` through `lintegral_tsum`
+   (nonneg measurable → interchange, no integrability needed) and
+   `ENNReal.ofReal_tsum_of_nonneg` (needs pointwise `Summable (fᵢ·ω)` — from
+   `Real.summable_nat_rpow.mpr (-s<-1)` `.mul_right` `.indicator`) to reach
+   `∫⁻ ofReal(∑'ᵢ fᵢ) ≤ ∫⁻ ‖g‖ₑ < ∞` (the last `< ∞` is `hg.hasFiniteIntegral` via
+   `hasFiniteIntegral_iff_enorm`).
+3. **Final domination** `∫ ∑'ᵢ fᵢ ≤ ∫ g` by `integral_mono_of_nonneg` (needs integrability
+   only of the dominating `g`).
+
+### Reusable Lean gotchas (Mathlib v4.26)
+- **`enorm_eq_ofReal` / `enorm_eq_ofReal_abs` live in namespace `Real`** — write
+  `Real.enorm_eq_ofReal (h : 0 ≤ r) : ‖r‖ₑ = ENNReal.ofReal r` and
+  `Real.enorm_eq_ofReal_abs (r) : ‖r‖ₑ = ENNReal.ofReal |r|` (bare names are unknown
+  identifiers even though the source `theorem` line shows no `Real.` prefix — it's inside
+  `namespace Real`).
+- `‖r‖ₑ` for real `r` is the **enorm** (`ENNReal.ofReal ‖r‖`); `integral_tsum`'s finiteness
+  hypothesis is stated with `‖·‖ₑ`, and `HasFiniteIntegral` unfolds to `∫⁻ ‖·‖ₑ < ∞`
+  (`hasFiniteIntegral_iff_enorm`).
+- `Measurable.ennreal_ofReal : Measurable f → Measurable (fun x => ENNReal.ofReal (f x))`;
+  `.aemeasurable` feeds `lintegral_tsum`.
+- `Set.indicator` used with `set f := …` keeps `f` an opaque local — `simp only [hf]`
+  (which beta-reduces) is needed to unfold `f i ω` before `positivity`/`measurability`/`ring`
+  side-goals; `exact` alone will not see through the `set` binding.
+
+### Honest status
+A genuine, complete, verified brick — the actual `∑'`–`∫` Tonelli interchange flagged as
+"the substantive open work" for the last four iterations. It does **not** yet prove
+Marcinkiewicz–Zygmund. Remaining step-4 work: **integrate the RHS `g` to `C·𝔼|X|ᵖ`**
+(instantiate `s = 2/p`; `|X|≥1` branch `(max 1 |X|ᵖ)^{1-2/p}·X² = |X|ᵖ → 𝔼|X|ᵖ`, `|X|<1`
+branch `const·X² → const·𝔼X²` finite on a probability space), and bound
+`variance(Yᵢ) ≤ 𝔼[Yᵢ²]` to feed `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5);
+then step-3 centering and the final MZ combination with the step-1 truncation reduction.
+
+### Next steps
+- **Integrate the dominating `g`** at `s = 2/p`: prove
+  `∫ (max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X² ≤ C·(𝔼|X|ᵖ + 𝔼X²)` (or `≤ C·𝔼|X|ᵖ` on a probability
+  space via `MemLp X 2`), discharging `tsum_integral_weight_trunc_sq_le`'s `hg` hypothesis
+  and turning the interchange into a concrete `∑ᵢ 𝔼[Yᵢ²]/i^{2/p} ≤ C·𝔼|X|ᵖ`.
+- Bridge `variance(Yᵢ)/aᵢ² ≤ 𝔼[Yᵢ²]/i^{2/p}` and assemble via S5.
+- Step-3 centering, final combination.
+
+**Depth guard**: slug is at depth 3 (`-oq-01-oq-02-oq-01`) → generate **0** follow-up
+questions (would exceed the OQ-chain cap).
+
+---
+
 ## Session 2026-07-04 (researcher-14, iter 12) — S4b step-4 pointwise Tonelli integrand SHIPPED (verified)
 
 **Mode**: REVISIT (RICH). **Outcome**: progress — new leaf `tsum_weight_trunc_sq_le` appended to

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 *Tonelli integrand* — pointwise per-`ω` variance-sum integrand SHIPPED & VERIFIED — remaining: the ∑ᵢ–𝔼 interchange itself + assembly)
+**Phase**: ACT (S4b step-4 *Tonelli interchange* `tsum_integral_weight_trunc_sq_le` SHIPPED & VERIFIED — the `∑'ᵢ`–`∫` swap itself is now done; remaining: integrate the dominating `g` to `C·𝔼|X|ᵖ`, then S5 assembly + step-3 centering + final combination)
 **Since**: 2026-07-04
-**Iteration**: 12 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 13 (S4b step-4 **Tonelli interchange** `tsum_integral_weight_trunc_sq_le` `∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — the actual measure-theoretic `∑'`–`∫` swap via `MeasureTheory.integral_tsum`, dominating the inner sum by iter-12 `tsum_weight_trunc_sq_le`, finiteness side-goal via `lintegral_tsum`+`ofReal_tsum_of_nonneg`, `g` left as an integrability hypothesis — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le`; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -109,29 +109,28 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 
 ## Next Action
 
-- **S4b step-4 pointwise Tonelli integrand is now DONE (iteration 12):** `tsum_weight_trunc_sq_le`
-  supplies, for `1<s`, `0<p`, any `x`, the **per-`ω` variance summand bound**
-  `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²`. This is the exact `x=X(ω)`,
-  `s=2/p` integrand of the interchange: the root-form truncation region `{i | |x| ≤ i^{1/p}}`
-  (matching `integral_trunc_sq_le`'s `t=i^{1/p}`) is bridged to the power-form `{i | |x|ᵖ ≤ i}`
-  (complement of `rpow_inv_lt_iff_lt_rpow` via `not_lt`), `x²` is pulled through
-  (`tsum_mul_right`), and iter-11 `tsum_indicator_ge_rpow_neg_le` closes it. **Do not re-derive.**
-- **Next: the ∑ᵢ–𝔼 Tonelli interchange itself** (the one remaining measure-theoretic lift for
-  step-4). Use `MeasureTheory.integral_tsum` / `lintegral_tsum` (nonneg, per-term integrability +
-  `∑'∫|·|<∞` side-goals) to move `∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² dμ = ∫ ∑'ᵢ (…) dμ`; the inner
-  `∑'ᵢ` under the integral is **literally** `tsum_weight_trunc_sq_le` at `x=X(ω)`, so the integrand
-  is dominated by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X²`. Integrate the RHS: `|X|≥1` branch
-  `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so `X²·bound=|X|^p → 𝔼|X|ᵖ`; `|X|<1` branch collapses to
-  `const·X² → const·𝔼X²` (finite via `𝔼|X|ᵖ` + probability space). Yields `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`,
-  feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
-  (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
+- **S4b step-4 Tonelli interchange is now DONE (iteration 13):** `tsum_integral_weight_trunc_sq_le`
+  supplies, for `1<s`, `0<p`, measurable `X`, and an integrable dominating `g`, the **actual
+  `∑'ᵢ`–`∫` swap**
+  `∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²`, via
+  `MeasureTheory.integral_tsum` with the finiteness side-goal discharged by
+  `lintegral_tsum`+`ENNReal.ofReal_tsum_of_nonneg` and the inner sum dominated by iter-12
+  `tsum_weight_trunc_sq_le`. **Do not re-derive.** The dominating `g` is a hypothesis, not yet
+  discharged.
+- **Next: integrate the dominating `g`** at `s = 2/p` (the one remaining step-4 analytic step).
+  Prove `∫ (max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X² ≤ C·(𝔼|X|ᵖ + 𝔼X²)` (or `≤ C·𝔼|X|ᵖ` on a probability
+  space via `MemLp X 2`): `|X|≥1` branch `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so `X²·bound=|X|ᵖ →
+  𝔼|X|ᵖ`; `|X|<1` branch collapses to `const·X² → const·𝔼X²`. This discharges
+  `tsum_integral_weight_trunc_sq_le`'s `hg` and yields `∑ᵢ 𝔼[Yᵢ²]/i^{2/p} ≤ C·𝔼|X|ᵖ`. Then bridge
+  `variance(Yᵢ)/aᵢ² ≤ 𝔼[Yᵢ²]/i^{2/p}` and feed `ae_tendsto_average_zero_of_variance_weighted_bdd`
+  (S5). Watch weight positivity (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.
 
 ## Attempt Counts
 
-- Total attempts: 12 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand)
-- Current approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
+- Total attempts: 13 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand; iter-13 Tonelli interchange `tsum_integral_weight_trunc_sq_le`)
+- Current approach attempts: 1 (S4b step-4 Tonelli interchange `tsum_integral_weight_trunc_sq_le` — `integral_tsum` to move `∑'ᵢ` inside; finiteness `hf'` via `simp_rw [Real.enorm_eq_ofReal]`+`← lintegral_tsum`+`ENNReal.ofReal_tsum_of_nonneg`+`hasFiniteIntegral_iff_enorm`; inner-sum domination by iter-12 `tsum_weight_trunc_sq_le` after `Set.indicator_apply`+`ring` reconciling ω- vs index-indicator; final `integral_mono_of_nonneg`; one fix — `enorm_eq_ofReal*` needed `Real.` prefix — then clean build, 7743 jobs, 0-axiom)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
   S4b step-2 discrete layer cake via lintegral_tsum + floor count;

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01.json
@@ -19,19 +19,12 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-07-04T00:10:00.000Z",
-    "iteration": 12,
-    "focus": "S4b step-4 pointwise Tonelli integrand tsum_weight_trunc_sq_le SHIPPED & verified (0-axiom, 7743 jobs). Remaining: the ∑'ᵢ–∫ interchange itself, then integrate RHS to C·(𝔼|X|ᵖ+1), then step-3 centering + final MZ combination.",
-    "blockers": [],
-    "nextAction": "Tonelli interchange via MeasureTheory.integral_tsum: ∑'ᵢ ∫ i^{-s}·Yᵢ² dμ = ∫ ∑'ᵢ i^{-s}·Yᵢ² dμ (per-term integrability + ∑'∫|·|<∞); the inner ∑'ᵢ is literally tsum_weight_trunc_sq_le at x=X(ω), dominating the integrand by (max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X². Integrate RHS: |X|≥1 branch → 𝔼|X|ᵖ, |X|<1 branch → const·𝔼X². Yields ∑ᵢ Var(Yᵢ)/i^{2/p}<∞ for ae_tendsto_average_zero_of_variance_weighted_bdd (S5); then step-3 centering and final MZ combination.",
-    "attemptCounts": {
-      "total": 12,
-      "currentApproach": 1,
-      "approachesTried": 7
-    }
+    "since": "2026-07-04T01:30:00.000Z",
+    "iteration": 13,
+    "focus": "S4b step-4 Tonelli interchange tsum_integral_weight_trunc_sq_le SHIPPED & VERIFIED (0-axiom, 7743 jobs): the actual ∑'ᵢ–∫ swap ∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X² via MeasureTheory.integral_tsum, dominating the inner sum by iter-12 tsum_weight_trunc_sq_le. Remaining: integrate the dominating g to C·𝔼|X|ᵖ (needs s=2/p, MemLp X 2), bridge variance(Yᵢ)≤𝔼[Yᵢ²], feed S5; then step-3 centering + final combination."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 12, researcher-14): added tsum_weight_trunc_sq_le — the pointwise Tonelli integrand for the MZ variance sum. For 1<s, 0<p, any x: ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². With x=X(ω), s=2/p this is exactly ∑ᵢ i^{-s}·Yᵢ(ω)² for the step-4 truncation Yᵢ=𝟙{|X|≤i^{1/p}}·X (region matches integral_trunc_sq_le's t=i^{1/p}). Bridges the abstract iter-11 {i|y≤i} bound (tsum_indicator_ge_rpow_neg_le) to the concrete root-form summand the interchange integrates, doing the root↔power region rewrite once. 0-axiom, build 7743 jobs exit 0. Remaining: the ∑'ᵢ–∫ Tonelli interchange itself (MeasureTheory.integral_tsum, integrability side-goals) moving ∑'ᵢ∫ i^{-s}Yᵢ² = ∫∑'ᵢ i^{-s}Yᵢ² and dominating the integrand by this leaf, then integrating the RHS to C·(𝔼|X|ᵖ+1); then step-3 centering and the final MZ combination.",
+    "progressSummary": "PROGRESS (iter 12, researcher-14): added tsum_weight_trunc_sq_le — the pointwise Tonelli integrand for the MZ variance sum. For 1<s, 0<p, any x: ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². With x=X(ω), s=2/p this is exactly ∑ᵢ i^{-s}·Yᵢ(ω)² for the step-4 truncation Yᵢ=𝟙{|X|≤i^{1/p}}·X (region matches integral_trunc_sq_le's t=i^{1/p}). Bridges the abstract iter-11 {i|y≤i} bound (tsum_indicator_ge_rpow_neg_le) to the concrete root-form summand the interchange integrates, doing the root↔power region rewrite once. 0-axiom, build 7743 jobs exit 0. Remaining: the ∑'ᵢ–∫ Tonelli interchange itself (MeasureTheory.integral_tsum, integrability side-goals) moving ∑'ᵢ∫ i^{-s}Yᵢ² = ∫∑'ᵢ i^{-s}Yᵢ² and dominating the integrand by this leaf, then integrating the RHS to C·(𝔼|X|ᵖ+1); then step-3 centering and the final MZ combination. Iter 13 (r8): the ∑'ᵢ–∫ Tonelli interchange tsum_integral_weight_trunc_sq_le SHIPPED & VERIFIED (0-axiom, 7743 jobs) — the actual measure-theoretic swap lifting the pointwise iter-12 integrand across the sample space via MeasureTheory.integral_tsum. Remaining step-4: integrate the dominating g to C·𝔼|X|ᵖ (needs s=2/p, MemLp X 2), then S5 assembly; then step-3 centering + final combination.",
     "builtItems": [
       "Kronecker: theorem kronecker_lemma in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:122 — a_n>0 nondecreasing, a_n→∞, ∑x_n/a_n conv ⟹ (∑_{i<n}x_i)/a_n→0. Verified, 0-axiom.",
       "Toeplitz core: theorem tendsto_weighted_average_zero in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean:47 — nonneg weights dominated by A_n→∞ kill any null sequence in the weighted average. Reusable, 0-axiom.",
@@ -45,7 +38,8 @@
       "tsum_shift_rpow_neg_le in LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries): tail p-series bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) (s>1), via Real.tsum_le_of_sum_range_le, 0-axiom VERIFIED — the deterministic backbone of the MZ variance sum",
       "tsum_ge_rpow_neg_le (inclusive-from-N p-series tail bound ∑_{j≥N}j^{-s}≤N^{1-s}·s/(s-1)) in LawsOfLargeNumbersOQ01OQ02OQ01.lean; docker build 7743 jobs, 0-axiom (propext/Classical.choice/Quot.sound only).",
       "LawsOfLargeNumbers.MZ.tsum_indicator_ge_rpow_neg_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean — pointwise inner-tail bound ∑_{i:y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) (Tonelli integrand for the MZ variance sum), 0-axiom",
-      "LawsOfLargeNumbers.MZ.tsum_weight_trunc_sq_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries) — pointwise Tonelli integrand for the MZ variance sum: for 1<s, 0<p, any x, ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². The exact per-ω summand of the variance series (x=X(ω), s=2/p); root-form region {i||x|≤i^{1/p}} bridged to power-form {i||x|ᵖ≤i} via not_lt on rpow_inv_lt_iff_lt_rpow, x² pulled out (tsum_mul_right), closed by tsum_indicator_ge_rpow_neg_le. docker build 7743 jobs, 0-axiom."
+      "LawsOfLargeNumbers.MZ.tsum_weight_trunc_sq_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TailPSeries) — pointwise Tonelli integrand for the MZ variance sum: for 1<s, 0<p, any x, ∑'ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x². The exact per-ω summand of the variance series (x=X(ω), s=2/p); root-form region {i||x|≤i^{1/p}} bridged to power-form {i||x|ᵖ≤i} via not_lt on rpow_inv_lt_iff_lt_rpow, x² pulled out (tsum_mul_right), closed by tsum_indicator_ge_rpow_neg_le. docker build 7743 jobs, 0-axiom.",
+      "LawsOfLargeNumbers.MZ.tsum_integral_weight_trunc_sq_le in Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean (§TonelliInterchange) — the ∑'ᵢ–∫ Tonelli interchange for the MZ variance sum: for measurable X, 1<s, 0<p, and an integrable dominating g ω=(max 1 |X ω|ᵖ)^{1-s}·s/(s-1)·(X ω)², ∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫ g. Via MeasureTheory.integral_tsum (finiteness side-goal by lintegral_tsum + ENNReal.ofReal_tsum_of_nonneg + hasFiniteIntegral_iff_enorm), inner sum dominated by tsum_weight_trunc_sq_le, closed by integral_mono_of_nonneg. r8 iter 13, 0-axiom, build 7743 jobs."
     ],
     "insights": [
       "Formal target pinned: MZ-SLLN for 1<=p<2, E|X|^p<inf implies (sum(Xi-EX))/n^(1/p) -> 0 a.s.; p=1 is Etemadi/Kolmogorov SLLN, content is the faster n^(1/p) rate for p>1.",
@@ -70,12 +64,15 @@
       "The correct variance-sum route is a Tonelli interchange: ∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}] = 𝔼[X²·∑_{i≥|X|ᵖ} i^{-2/p}] ≤ C·𝔼[X²·|X|^{p-2}] = C·𝔼|X|ᵖ. The inner tail is bounded by tsum_shift_rpow_neg_le with s=2/p.",
       "Mathlib's Analysis/PSeries supplies only summability (summable_nat_rpow_inv), not the quantitative tail ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1); the latter is built here by integral comparison (AntitoneOn.sum_le_integral_Ico against ∫ x^{-s}=x^{1-s}/(1-s)).",
       "The Tonelli interchange for ∑ᵢVar(Yᵢ)/i^{2/p} needs the INCLUSIVE tail ∑_{j≥N}j^{-s} at N=⌈|X|ᵖ⌉ (inner sum starts AT the ceiling), but the existing backbone tsum_shift_rpow_neg_le bounds only the EXCLUSIVE tail ∑_{j>N}j^{-s}. tsum_ge_rpow_neg_le closes this off-by-one: ∑ₖ(k+N)^{-s} ≤ N^{1-s}·s/(s-1) for s>1, N≥1, by splitting off the j=N term (N^{-s}≤N^{1-s}) and adding the exclusive tail N^{1-s}/(s-1).",
-      "tsum_indicator_ge_rpow_neg_le (r8, iter 11, 0-axiom, build 7743 jobs): the pointwise inner-tail bound the Tonelli interchange consumes. ∑_{i: y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) for s>1. Region {i|y≤i}={i|⌈y⌉₊≤i} (Nat.ceil_le); reindex indicator tsum to inclusive tail ∑ (k+⌈y⌉₊)^{-s} via Summable.sum_add_tsum_nat_add (head over range ⌈y⌉₊ vanishes), apply tsum_ge_rpow_neg_le, dominate ⌈y⌉₊^{1-s}≤(max 1 y)^{1-s} by rpow antitonicity. y≤0 branch peels vanishing i=0 term via Summable.tsum_eq_zero_add, reuses N=1 tail."
+      "tsum_indicator_ge_rpow_neg_le (r8, iter 11, 0-axiom, build 7743 jobs): the pointwise inner-tail bound the Tonelli interchange consumes. ∑_{i: y≤i} i^{-s} ≤ (max 1 y)^{1-s}·s/(s-1) for s>1. Region {i|y≤i}={i|⌈y⌉₊≤i} (Nat.ceil_le); reindex indicator tsum to inclusive tail ∑ (k+⌈y⌉₊)^{-s} via Summable.sum_add_tsum_nat_add (head over range ⌈y⌉₊ vanishes), apply tsum_ge_rpow_neg_le, dominate ⌈y⌉₊^{1-s}≤(max 1 y)^{1-s} by rpow antitonicity. y≤0 branch peels vanishing i=0 term via Summable.tsum_eq_zero_add, reuses N=1 tail.",
+      "tsum_integral_weight_trunc_sq_le (r8, iter 13, 0-axiom, build 7743 jobs): the measure-theoretic ∑'ᵢ–∫ interchange itself, lifting the pointwise iter-12 integrand across the sample space. Technique: integral_tsum moves ∑'ᵢ inside the Bochner integral; its finiteness side-goal ∑'ᵢ∫⁻‖fᵢ‖ₑ≠∞ is discharged by lintegral_tsum + ENNReal.ofReal_tsum_of_nonneg (needs pointwise Summable via Real.summable_nat_rpow.mpr(-s<-1).mul_right.indicator) reaching ∫⁻ ofReal(∑'ᵢfᵢ) ≤ ∫⁻‖g‖ₑ<∞; final ∫ ∑'ᵢfᵢ ≤ ∫ g by integral_mono_of_nonneg. Key reconciliation: the ω-indicator (𝟙{|X ω|≤i^{1/p}}·X ω)² and the index-indicator {i|…}.indicator agree pointwise (Set.indicator_apply + ring). g left as an integrability hypothesis (integrating it needs s=2/p + MemLp X 2).",
+      "Mathlib v4.26 gotcha: enorm_eq_ofReal and enorm_eq_ofReal_abs live in namespace Real — must write Real.enorm_eq_ofReal (h:0≤r):‖r‖ₑ=ENNReal.ofReal r and Real.enorm_eq_ofReal_abs; bare names are unknown identifiers despite the source theorem line omitting the prefix (it is inside namespace Real)."
     ],
     "mathlibGaps": [
       "No quantitative p-series tail bound ∑_{j>N} j^{-s} ≤ N^{1-s}/(s-1) in Mathlib (only summability). Supplied locally as tsum_shift_rpow_neg_le."
     ],
     "nextSteps": [
+      "Integrate the dominating g at s=2/p: prove ∫ (max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X² ≤ C·(𝔼|X|ᵖ+𝔼X²) (or ≤ C·𝔼|X|ᵖ on a probability space via MemLp X 2) — |X|≥1 branch (max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2} so X²·bound=|X|ᵖ→𝔼|X|ᵖ; |X|<1 branch const·X²→const·𝔼X². This discharges tsum_integral_weight_trunc_sq_le's hg hypothesis, giving ∑ᵢ 𝔼[Yᵢ²]/i^{2/p} ≤ C·𝔼|X|ᵖ.",
       "DONE (r8 iter 11): tsum_indicator_ge_rpow_neg_le — pointwise inner-tail bound ∑_{i:y≤i}i^{-s}≤(max 1 y)^{1-s}·s/(s-1), the Tonelli integrand bound. 0-axiom, build-verified. Do NOT re-derive.",
       "NEXT: the ∑ᵢ–𝔼 Tonelli interchange. Use MeasureTheory.lintegral_tsum (nonneg, measurability side-goals) to turn ∑ᵢ i^{-2/p}·𝔼[X²𝟙{|X|≤i^{1/p}}] into 𝔼[X²·∑ᵢ i^{-2/p}𝟙{|X|≤i^{1/p}}]; the inner sum is exactly tsum_indicator_ge_rpow_neg_le with y=|X|ᵖ, s=2/p (via |X|≤i^{1/p} ↔ |X|ᵖ≤i, rpow reindex). Then bound (max 1 |X|ᵖ)^{1-2/p}: |X|≥1 branch = |X|^{p-2} so X²·(bound)=|X|^p; |X|<1 branch = const. Integrate to C·(𝔼|X|ᵖ+1).",
       "Then: Var(Yi)≤𝔼[Yi²]=𝔼[X²𝟙{|X|≤i^{1/p}}] and ∑ᵢVar(Yi)/i^{2/p}≤C·𝔼|X|ᵖ<∞ feeds ae_tendsto_average_zero_of_variance_weighted_bdd (S5). Note the weight aᵢ must be positive (ha_pos) — use aᵢ=(i+1)^{1/p} or max 1 i^{1/p}, reconcile with the i^{-2/p} weight.",
@@ -104,7 +101,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.191Z",
-  "lastUpdate": "2026-07-04T07:00:53Z",
+  "lastUpdate": "2026-07-04T01:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -265,8 +262,8 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ02OQ01.lean",
-      "lineCount": 1197,
-      "theoremCount": 23,
+      "lineCount": 1346,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -274,5 +271,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean"
     }
   ],
-  "lastVerified": "2026-07-04T06:37:27Z"
+  "lastVerified": "2026-07-04T01:30:00.000Z"
 }


### PR DESCRIPTION
## Summary

Advances the **Marcinkiewicz–Zygmund SLLN** leaf (`laws-of-large-numbers-oq-01-oq-02-oq-01`) by shipping the **Tonelli interchange** for the variance sum — the substantive measure-theoretic lift flagged as the open frontier for the last several iterations.

New theorem in `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean` (§ `TonelliInterchange`):

```lean
theorem tsum_integral_weight_trunc_sq_le
    {X : Ω → ℝ} {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (hX : Measurable X)
    (hg : Integrable (fun ω => (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * X ω ^ 2) μ) :
    ∑' i : ℕ, ∫ ω, (i : ℝ) ^ (-s)
          * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2 ∂μ
      ≤ ∫ ω, (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * X ω ^ 2 ∂μ
```

With `s = 2/p` (⟺ `p < 2`) the LHS is exactly the truncated variance sum `∑ᵢ 𝔼[Yᵢ²]/i^{2/p}` for the truncations `Yᵢ = 𝟙{|X|≤i^{1/p}}·X` that Kolmogorov's criterion consumes.

## Technique

`MeasureTheory.integral_tsum` moves `∑'ᵢ` inside the Bochner integral. The finiteness side-goal `∑'ᵢ ∫⁻‖fᵢ‖ₑ ≠ ∞` is discharged by pushing the sum through `lintegral_tsum` + `ENNReal.ofReal_tsum_of_nonneg` down to `∫⁻ ofReal(∑'ᵢ fᵢ) ≤ ∫⁻ ‖g‖ₑ < ∞`; the inner sum is dominated pointwise by the prior iteration's `tsum_weight_trunc_sq_le` (after reconciling the ω-indicator with the index-indicator); the final `∫ ∑'ᵢ fᵢ ≤ ∫ g` is `integral_mono_of_nonneg`. No independence, identical distribution, or `s = 2/p` is used — pure measure theory over any `μ`.

The dominating `g` is left as an **integrability hypothesis** — the honest factoring, since integrating it to `C·𝔼|X|ᵖ` needs `s = 2/p` and `MemLp X 2` (the next brick).

## Verification

- Docker build **succeeded, 7743 jobs, exit 0**.
- `#print axioms tsum_integral_weight_trunc_sq_le` = `[propext, Classical.choice, Quot.sound]` only — **0 sorries, 0 axioms** (no `sorryAx`, no `Lean.ofReduceBool`).

## Honest status

A genuine, complete, verified brick — the actual `∑'`–`∫` interchange. It does **not** yet prove Marcinkiewicz–Zygmund; remaining: integrate the dominating `g` to `C·𝔼|X|ᵖ`, bound `variance(Yᵢ) ≤ 𝔼[Yᵢ²]`, feed the S5 assembly (`ae_tendsto_average_zero_of_variance_weighted_bdd`), then step-3 centering and the final combination with the step-1 truncation reduction.