### PR TITLE
Research: Pell chains — uniform trace recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ in ℤ√d (pell-equation-oq-06-oq-03-oq-03)

### DIFF
--- a/proofs/Proofs/PellEquationOQ06OQ03OQ03.lean
+++ b/proofs/Proofs/PellEquationOQ06OQ03OQ03.lean
@@ -1,0 +1,196 @@
+/-
+Pell's Equation OQ-06-OQ-03-OQ-03: The Uniform Trace Recurrence for Pell Chains
+
+The parent entry (`pell-equation-oq-06-oq-03`) records that each coordinate of the
+negative-Pell chain of `x² − 2y² = −1` satisfies the *specific* second-order
+recurrence
+
+    uₙ₊₂ = 6 uₙ₊₁ − uₙ,
+
+the coefficient `6` being the trace of the transfer matrix `[[3,4],[2,3]]`
+(multiplication by the fundamental unit `3 + 2√2` of `ℤ[√2]`). This entry proves the
+*uniform* statement behind that computation, for an arbitrary real-quadratic ring
+`ℤ√d` and an arbitrary generating element `z`:
+
+    for the chain  sₙ = zⁿ · w,   both coordinates satisfy
+        uₙ₊₂ = 2·(z.re)·uₙ₊₁ − N(z)·uₙ,
+
+where `N(z) = z.re² − d·z.im²` is the norm. This is exactly the Cayley–Hamilton
+relation for the `ℤ`-linear transfer map `s ↦ z·s`, whose matrix `[[z.re, d·z.im],
+[z.im, z.re]]` has trace `2·z.re` and determinant `N(z)`; the characteristic
+polynomial is `t² − 2(z.re)t + N(z)`.
+
+Specializing to a *unit* `z` (norm `1`) gives the recurrence with the `−uₙ` tail seen
+in the parent, with coefficient `2·(z.re)`. For `d = 2`, `z = 3 + 2√2` one has
+`z.re = 3`, recovering `uₙ₊₂ = 6uₙ₊₁ − uₙ`. The base point `w` is free: taking `w` a
+solution of `x² − d y² = −1` (norm `−1`) makes every chain element a negative-Pell
+solution — this is recorded in `chain_norm`.
+
+Main results:
+  • `re_rec` / `im_rec`         — the general trace recurrence, coefficient `2·z.re`,
+                                  tail `N(z)`, for each coordinate of `zⁿ·w`.
+  • `unit_re_rec` / `unit_im_rec` — the unit case `N(z) = 1`: `uₙ₊₂ = 2(z.re)uₙ₊₁ − uₙ`.
+  • `chain_norm`                — every element of the chain has norm `N(w)`; so a
+                                  negative-Pell base propagates to the whole chain.
+  • `rec_unique`                — the recurrence plus two initial values determines a
+                                  sequence uniquely (structural payoff, general form).
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent entry: `pell-equation-oq-06-oq-03` (the concrete `d = 2` recurrence `6`).
+- Grandparent: `pell-equation-oq-06` (the vector recurrence / unit multiplication).
+- Cayley–Hamilton for `2×2`: `M² = (tr M)·M − (det M)·I`.
+-/
+
+import Mathlib
+
+namespace PellEquationOQ06OQ03OQ03
+
+open Zsqrtd
+
+variable {d : ℤ}
+
+/-
+## One-step (vector) recurrence
+
+Multiplying the chain state by the generator `z` acts as the transfer matrix
+`[[z.re, d·z.im], [z.im, z.re]]`. These two lemmas are just the real/imaginary parts
+of `zⁿ⁺¹·w = z·(zⁿ·w)`.
+-/
+
+/-- Real part of one chain step: `(zⁿ⁺¹·w).re = z.re·(zⁿ·w).re + d·z.im·(zⁿ·w).im`. -/
+theorem re_step (z w : ℤ√d) (n : ℕ) :
+    (z ^ (n + 1) * w).re = z.re * (z ^ n * w).re + d * z.im * (z ^ n * w).im := by
+  have h : z ^ (n + 1) * w = z * (z ^ n * w) := by rw [pow_succ]; ring
+  rw [h, re_mul]
+
+/-- Imaginary part of one chain step: `(zⁿ⁺¹·w).im = z.re·(zⁿ·w).im + z.im·(zⁿ·w).re`. -/
+theorem im_step (z w : ℤ√d) (n : ℕ) :
+    (z ^ (n + 1) * w).im = z.re * (z ^ n * w).im + z.im * (z ^ n * w).re := by
+  have h : z ^ (n + 1) * w = z * (z ^ n * w) := by rw [pow_succ]; ring
+  rw [h, im_mul]
+
+/-
+## The uniform trace recurrence (Cayley–Hamilton)
+
+Iterating the one-step recurrence twice and eliminating the imaginary part yields the
+order-2 scalar recurrence with coefficient `2·z.re` (the trace) and tail `N(z)` (the
+determinant). This is `M² = (tr M)·M − (det M)·I` applied to the chain state.
+-/
+
+/-- **General trace recurrence, first coordinate.**
+    `(zⁿ⁺²·w).re = 2·(z.re)·(zⁿ⁺¹·w).re − N(z)·(zⁿ·w).re`, for any `z, w : ℤ√d`. -/
+theorem re_rec (z w : ℤ√d) (n : ℕ) :
+    (z ^ (n + 2) * w).re
+      = 2 * z.re * (z ^ (n + 1) * w).re - z.norm * (z ^ n * w).re := by
+  rw [show n + 2 = n + 1 + 1 from rfl, re_step z w (n + 1), re_step z w n,
+    im_step z w n, norm_def]
+  ring
+
+/-- **General trace recurrence, second coordinate.** Same coefficients; both
+    coordinates of `zⁿ·w` obey the recurrence dictated by the characteristic
+    polynomial `t² − 2(z.re)t + N(z)`. -/
+theorem im_rec (z w : ℤ√d) (n : ℕ) :
+    (z ^ (n + 2) * w).im
+      = 2 * z.re * (z ^ (n + 1) * w).im - z.norm * (z ^ n * w).im := by
+  rw [show n + 2 = n + 1 + 1 from rfl, im_step z w (n + 1), im_step z w n,
+    re_step z w n, norm_def]
+  ring
+
+/-
+## The unit case: the negative-Pell recurrence
+
+When the generator `z` is a unit (`N(z) = 1`), the tail coefficient collapses to `1`
+and we recover the parent's shape `uₙ₊₂ = 2(z.re)·uₙ₊₁ − uₙ`.
+-/
+
+/-- **Unit trace recurrence, first coordinate.** If `N(z) = 1` then
+    `(zⁿ⁺²·w).re = 2·(z.re)·(zⁿ⁺¹·w).re − (zⁿ·w).re`. For `d = 2`, `z = 3 + 2√2`
+    (so `z.re = 3`) this is the parent's `uₙ₊₂ = 6uₙ₊₁ − uₙ`. -/
+theorem unit_re_rec (z w : ℤ√d) (hz : z.norm = 1) (n : ℕ) :
+    (z ^ (n + 2) * w).re = 2 * z.re * (z ^ (n + 1) * w).re - (z ^ n * w).re := by
+  rw [re_rec, hz, one_mul]
+
+/-- **Unit trace recurrence, second coordinate.** The companion statement for the
+    `y`-values. -/
+theorem unit_im_rec (z w : ℤ√d) (hz : z.norm = 1) (n : ℕ) :
+    (z ^ (n + 2) * w).im = 2 * z.re * (z ^ (n + 1) * w).im - (z ^ n * w).im := by
+  rw [im_rec, hz, one_mul]
+
+/-
+## Norm propagation along the chain
+
+The multiplicativity of the norm shows every chain element shares the norm of the
+base point (up to the unit generator). In particular a negative-Pell base (`N(w) = −1`)
+generates a chain of negative-Pell solutions.
+-/
+
+/-- `N(zⁿ) = N(z)ⁿ`: the norm is multiplicative under powers. -/
+theorem norm_pow (z : ℤ√d) (n : ℕ) : (z ^ n).norm = z.norm ^ n := by
+  induction n with
+  | zero => simp
+  | succ k ih => rw [pow_succ, norm_mul, ih, pow_succ]
+
+/-- **Norm is constant along a unit-generated chain.** If `N(z) = 1` then every
+    `zⁿ·w` has norm `N(w)`. Hence a base solving `x² − d y² = −1` yields a whole
+    chain of solutions of the same equation. -/
+theorem chain_norm (z w : ℤ√d) (hz : z.norm = 1) (n : ℕ) :
+    (z ^ n * w).norm = w.norm := by
+  rw [norm_mul, norm_pow, hz, one_pow, one_mul]
+
+/-
+## Structural payoff: the recurrence characterizes the sequence
+
+The order-2 recurrence together with two initial values pins the sequence down. This
+is the abstract form of the parent's `negPellSeq_fst_unique` / `..._snd_unique`,
+valid for any coefficient `c`.
+-/
+
+/-- **Uniqueness.** Two integer sequences obeying `uₙ₊₂ = c·uₙ₊₁ − uₙ` with matching
+    first two values coincide everywhere (standard two-step induction). -/
+theorem rec_unique (c : ℤ) (u v : ℕ → ℤ)
+    (hu : ∀ n, u (n + 2) = c * u (n + 1) - u n)
+    (hv : ∀ n, v (n + 2) = c * v (n + 1) - v n)
+    (h0 : u 0 = v 0) (h1 : u 1 = v 1) : ∀ n, u n = v n := by
+  have key : ∀ n, u n = v n ∧ u (n + 1) = v (n + 1) := by
+    intro n
+    induction n with
+    | zero => exact ⟨h0, h1⟩
+    | succ k ih =>
+      obtain ⟨a, b⟩ := ih
+      exact ⟨b, by rw [hu, hv, a, b]⟩
+  exact fun n => (key n).1
+
+/-
+## Sanity checks: recovering the parent `d = 2` chain
+
+The fundamental unit `3 + 2√2` of `ℤ[√2]` has norm `1` and real part `3`, so the unit
+recurrence coefficient `2·z.re = 6` matches the parent's `uₙ₊₂ = 6uₙ₊₁ − uₙ`. The base
+`1 + √2` has norm `−1`, so the generated chain solves `x² − 2y² = −1`.
+-/
+
+example : ((3 + 2 * sqrtd : ℤ√2)).norm = 1 := by decide
+example : ((3 + 2 * sqrtd : ℤ√2)).re = 3 := by decide
+example : 2 * ((3 + 2 * sqrtd : ℤ√2)).re = 6 := by decide
+example : ((1 + sqrtd : ℤ√2)).norm = -1 := by decide
+
+-- The concrete unit recurrence for the parent chain, obtained by specialization.
+example (n : ℕ) :
+    (((3 + 2 * sqrtd : ℤ√2)) ^ (n + 2) * (1 + sqrtd)).re
+      = 6 * (((3 + 2 * sqrtd : ℤ√2)) ^ (n + 1) * (1 + sqrtd)).re
+        - (((3 + 2 * sqrtd : ℤ√2)) ^ n * (1 + sqrtd)).re := by
+  have h := unit_re_rec (3 + 2 * sqrtd : ℤ√2) (1 + sqrtd) (by decide) n
+  simpa using h
+
+-- Every element of that chain is a negative-Pell solution: norm = −1.
+example (n : ℕ) : (((3 + 2 * sqrtd : ℤ√2)) ^ n * (1 + sqrtd)).norm = -1 := by
+  rw [chain_norm _ _ (by decide)]; decide
+
+#check @re_rec
+#check @im_rec
+#check @unit_re_rec
+#check @chain_norm
+#check @rec_unique
+
+end PellEquationOQ06OQ03OQ03

--- a/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pell060303-re-step",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 63, "endLine": 66 },
+    "type": "technique",
+    "title": "The transfer map as one chain step",
+    "content": "`re_step` reads off the real part of the identity $z^{n+1}\\cdot w = z\\cdot(z^n\\cdot w)$ using Mathlib's `Zsqrtd.re_mul`. This is the first row of the transfer matrix $\\begin{pmatrix}z_{\\mathrm{re}}&d\\,z_{\\mathrm{im}}\\\\ z_{\\mathrm{im}}&z_{\\mathrm{re}}\\end{pmatrix}$ acting on the coordinate vector $(z^nw)$. The whole proof is `rw [pow_succ]; ring` to reassociate, then `rw [re_mul]`.",
+    "mathContext": "$(z^{n+1}w)_{\\mathrm{re}} = z_{\\mathrm{re}}(z^nw)_{\\mathrm{re}} + d\\,z_{\\mathrm{im}}(z^nw)_{\\mathrm{im}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic integer ring", "transfer matrix", "Zsqrtd multiplication"],
+    "prerequisites": ["ℤ√d arithmetic"]
+  },
+  {
+    "id": "ann-pell060303-re-rec",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 82, "endLine": 89 },
+    "type": "insight",
+    "title": "The uniform trace recurrence: coefficient 2·z.re, tail N(z)",
+    "content": "`re_rec` is the heart of the entry. Applying `re_step` twice (to unfold $z^{n+2}w$) and `im_step` once, then substituting the norm definition $N(z) = z_{\\mathrm{re}}^2 - d\\,z_{\\mathrm{im}}^2$, the imaginary part cancels and `ring` closes the goal $u_{n+2} = 2z_{\\mathrm{re}}u_{n+1} - N(z)u_n$. The coefficients are exactly the trace $2z_{\\mathrm{re}}$ and determinant $N(z)$ of the transfer map — the parent's $(6,1)$ is the single case $z = 3+2\\sqrt2$, $d = 2$. This is Cayley–Hamilton $M^2 = (\\operatorname{tr}M)M - (\\det M)I$ applied to the chain state, proved without ever building a matrix.",
+    "mathContext": "$u_{n+2} = 2z_{\\mathrm{re}}u_{n+1} - N(z)u_n$ with $N(z) = z_{\\mathrm{re}}^2 - d\\,z_{\\mathrm{im}}^2$; the $y_n$-term of the double expansion cancels against $-N(z)u_n$.",
+    "significance": "key",
+    "relatedConcepts": ["Cayley–Hamilton theorem", "characteristic polynomial", "trace and determinant", "linear recurrence"],
+    "prerequisites": ["Pell's equation", "quadratic integer ring", "matrix trace and determinant"]
+  },
+  {
+    "id": "ann-pell060303-unit-rec",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 108, "endLine": 113 },
+    "type": "concept",
+    "title": "The unit case recovers the parent recurrence",
+    "content": "`unit_re_rec` rewrites the hypothesis $N(z) = 1$ into `re_rec`, collapsing the tail to $-u_n$ and giving $u_{n+2} = 2z_{\\mathrm{re}}u_{n+1} - u_n$ — the shape the parent entry proved. Because $z$ ranges over all norm-one units of all rings $\\mathbb{Z}\\sqrt d$, this single lemma subsumes the parent's $d = 2$ computation: for $z = 3 + 2\\sqrt2$ one has $2z_{\\mathrm{re}} = 6$, verified in-file by direct specialization.",
+    "mathContext": "$N(z) = 1 \\Rightarrow u_{n+2} = 2z_{\\mathrm{re}}u_{n+1} - u_n$; $z = 3+2\\sqrt2 \\Rightarrow 2\\cdot 3 = 6$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental unit", "negative Pell equation", "specialization"],
+    "prerequisites": ["units of ℤ[√d]", "Pell's equation"]
+  },
+  {
+    "id": "ann-pell060303-chain-norm",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 138, "endLine": 140 },
+    "type": "insight",
+    "title": "A unit generator keeps the chain on one conic",
+    "content": "`chain_norm` uses norm multiplicativity — `norm_pow` ($N(z^n) = N(z)^n$, an induction on `Zsqrtd.norm_mul`) — to show that if $z$ is a unit then $N(z^n\\cdot w) = N(w)$ for all $n$. Arithmetically: the entire chain lives on the level set $\\{x^2 - dy^2 = N(w)\\}$. So a single negative-Pell base $w$ (with $N(w) = -1$) generates an infinite family of solutions of $x^2 - dy^2 = -1$ — this is the reason the trace recurrence stays inside the solution set.",
+    "mathContext": "$N(z^n w) = N(z)^n N(w)$; $N(z) = 1 \\Rightarrow N(z^n w) = N(w)$.",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "level sets of the norm form", "orbit of a unit"],
+    "prerequisites": ["norm of ℤ[√d]", "multiplicative maps"]
+  },
+  {
+    "id": "ann-pell060303-unique",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 152, "endLine": 163 },
+    "type": "technique",
+    "title": "Recurrence + two seeds = unique sequence",
+    "content": "`rec_unique` proves that any two integer sequences satisfying $u_{n+2} = c\\,u_{n+1} - u_n$ with the same first two values are equal, for an arbitrary coefficient $c$. The proof is the standard two-step induction: strengthen the goal to the pair $(u_n = v_n,\\ u_{n+1} = v_{n+1})$, so the recurrence step has both hypotheses available. This is the coefficient-agnostic abstraction of the parent's coordinate-specific uniqueness lemmas.",
+    "mathContext": "A degree-2 linear recurrence with two initial conditions has a unique solution over $\\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strong induction", "linear recurrence uniqueness", "initial value problem"],
+    "prerequisites": ["mathematical induction"]
+  },
+  {
+    "id": "ann-pell060303-sanity",
+    "proofId": "pell-equation-oq-06-oq-03-oq-03",
+    "range": { "startLine": 173, "endLine": 188 },
+    "type": "concept",
+    "title": "Recovering the concrete d = 2 chain",
+    "content": "Kernel-`decide` checks confirm $N(3+2\\sqrt2) = 1$, $(3+2\\sqrt2)_{\\mathrm{re}} = 3$, $2\\cdot 3 = 6$, and $N(1+\\sqrt2) = -1$. Specializing `unit_re_rec` to $z = 3+2\\sqrt2$, $w = 1+\\sqrt2$ then reproduces the parent's $u_{n+2} = 6u_{n+1} - u_n$, and `chain_norm` shows every member of that chain has norm $-1$, i.e. solves $x^2 - 2y^2 = -1$. All `decide` here is kernel reduction, not `native_decide`, so the file stays axiom-free.",
+    "mathContext": "$N(3+2\\sqrt2)=9-8=1$; the chain $(3+2\\sqrt2)^n(1+\\sqrt2)$ solves $x^2-2y^2=-1$ and obeys $u_{n+2}=6u_{n+1}-u_n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "specialization", "negative Pell equation"],
+    "prerequisites": ["ℤ√2 arithmetic"]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-03-oq-03/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "pell-equation-oq-06-oq-03-oq-03",
+  "title": "Pell Chains: The Uniform Trace Recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ in ℤ√d",
+  "slug": "pell-equation-oq-06-oq-03-oq-03",
+  "description": "The parent (oq-06-oq-03) records that each coordinate of the negative-Pell chain of x² − 2y² = −1 satisfies the specific recurrence uₙ₊₂ = 6uₙ₊₁ − uₙ, the coefficient 6 being the trace of the transfer matrix [[3,4],[2,3]]. This entry proves the uniform statement behind that computation, valid in any real-quadratic ring ℤ√d and for any generator z: the chain sₙ = zⁿ·w has both coordinates obeying uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ, where N(z) = z.re² − d·z.im² is the norm. This is exactly the Cayley–Hamilton relation for the ℤ-linear transfer map s ↦ z·s, whose 2×2 matrix has trace 2·z.re and determinant N(z). Specializing to a unit (N(z) = 1) collapses the tail to −uₙ, recovering the parent's shape; for d = 2, z = 3 + 2√2 (z.re = 3) it gives the concrete 6uₙ₊₁ − uₙ. The entry also proves norm propagation along the chain (a negative-Pell base yields a chain of negative-Pell solutions) and the general uniqueness of a sequence pinned by the recurrence plus two initial values. This directly resolves open question #3 of the parent entry.",
+  "meta": {
+    "author": "Lean Genius (uniform trace recurrence via Zsqrtd / Cayley–Hamilton); classical theory",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ06OQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "negative-pell",
+      "linear-recurrence",
+      "cayley-hamilton",
+      "quadratic-integer-ring",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-04",
+    "lineCount": 196,
+    "originalContributions": [
+      "re_rec / im_rec: the uniform trace recurrence (zⁿ⁺²·w).re/im = 2·(z.re)·(zⁿ⁺¹·w).re/im − N(z)·(zⁿ·w).re/im for arbitrary z, w in any ℤ√d — the parent's coefficient 6 replaced by the general trace 2·z.re and the tail 1 by the general determinant N(z), proved from two applications of the one-step recurrence and a single ring identity",
+      "unit_re_rec / unit_im_rec: the unit specialization N(z) = 1 giving uₙ₊₂ = 2(z.re)·uₙ₊₁ − uₙ; instantiating d = 2, z = 3 + 2√2 recovers the parent's 6uₙ₊₁ − uₙ (verified in-file by specialization)",
+      "chain_norm: every element of a unit-generated chain zⁿ·w has norm N(w) (via multiplicativity norm_pow), so a base solving x² − d y² = −1 propagates to a whole chain of negative-Pell solutions",
+      "rec_unique: the recurrence uₙ₊₂ = c·uₙ₊₁ − uₙ with two initial values determines an integer sequence uniquely, for any coefficient c — the abstract form of the parent's coordinate-specific uniqueness lemmas"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the concrete d = 2 sanity checks use kernel `decide` on ℤ√2 arithmetic, not `native_decide`). Imports only Mathlib, using its Zsqrtd (ℤ√d) API: re_mul, im_mul, norm_def, norm_mul.",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-06-oq-03",
+      "relationship": "generalizes",
+      "description": "The parent proves the concrete d = 2 recurrence uₙ₊₂ = 6uₙ₊₁ − uₙ with coefficient 6 = tr[[3,4],[2,3]]. This entry proves the recurrence uniformly in d and in the generator z, with coefficient 2·z.re and tail N(z); the parent is the case d = 2, z = 3 + 2√2, verified in-file by specialization. It resolves the parent's open question #3 (uniform trace coefficient for x² − D y² = −1)."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-02",
+      "relationship": "related",
+      "description": "The sibling realizes the negative-Pell chain as powers of the fundamental unit ζ = 1 + √2 of ℤ[√2]. This entry works directly in ℤ√d with the abstract generator z, and its unit case (N(z) = 1) is the ring-theoretic content of that powers-of-a-unit picture: the trace 2·z.re and norm N(z) are the coefficients of the minimal polynomial t² − 2(z.re)t + N(z) of z over ℚ."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Generating Pell-type solutions by linear recurrences goes back to Brahmagupta and Bhāskara II: from a fundamental unit and its transfer relation, all chain members follow by integer arithmetic with no square roots. In modern terms the generator is an element z of the quadratic integer ring ℤ√d = ℤ[√d], multiplication by which acts on the coordinate vector (re, im) as the matrix [[z.re, d·z.im],[z.im, z.re]] of trace 2·z.re and determinant N(z) = z.re² − d·z.im². Cayley–Hamilton (M² = (tr M)M − (det M)I) forces every coordinate of the orbit zⁿ·w to satisfy the order-2 recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ. The parent entry saw this for the single case d = 2, z = 3 + 2√2 (coefficient 6); this entry proves it once and for all.",
+    "problemStatement": "The parent entry proves the coordinate recurrence uₙ₊₂ = 6uₙ₊₁ − uₙ only for the specific chain of x² − 2y² = −1. Is this a coincidence of d = 2, or the shadow of a uniform law? Concretely: for an arbitrary quadratic integer ring ℤ√d and an arbitrary generator z, do both coordinates of the chain zⁿ·w satisfy a single second-order recurrence, and what are its coefficients in terms of z?",
+    "proofStrategy": "Work in ℤ√d. The one-step relation zⁿ⁺¹·w = z·(zⁿ·w) gives, via the Zsqrtd multiplication formulas re_mul/im_mul, the coupled vector recurrence re_step and im_step. Applying these twice to (zⁿ⁺²·w) and eliminating the cross-coordinate term with the norm definition N(z) = z.re² − d·z.im² leaves the scalar recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ, discharged by `ring`. The unit case rewrites N(z) = 1. Norm propagation follows from the multiplicativity norm_pow (an induction on norm_mul). Uniqueness is the standard two-step induction tracking the pair (uₙ, uₙ₊₁).",
+    "keyInsights": [
+      "The recurrence coefficient is the *trace* 2·z.re and the tail is the *determinant* N(z) of the transfer map s ↦ z·s. The parent's `6` is 2·3 = 2·(z.re) for z = 3 + 2√2, and the parent's `1` is N(z) = 9 − 2·4 = 1 — both are instances of a single law, not features of d = 2.",
+      "Both coordinates satisfy the SAME recurrence because each is a ℤ-linear functional of the orbit zⁿ·w, and Cayley–Hamilton annihilates the transfer matrix by t² − 2(z.re)t + N(z). The coordinates differ only in initial data.",
+      "The proof never constructs a matrix: the vector recurrences re_step/im_step come straight from the Zsqrtd multiplication formulas, and one `ring` call eliminates the imaginary part. The matrix/Cayley–Hamilton story is the *explanation*; the formal proof is an elementary algebraic identity in the ring ℤ√d.",
+      "Norm multiplicativity (N(zⁿ·w) = N(z)ⁿ·N(w)) makes the chain norm-preserving when z is a unit. Hence a single negative-Pell base w (N(w) = −1) generates an entire chain of solutions of x² − d y² = −1 — the arithmetic reason the recurrence stays inside the solution set.",
+      "The generator z and the base point w are decoupled: the recurrence holds for ANY base w, while the norm of w decides which conic (norm level set) the chain sweeps out. Fixing z a unit and varying w tiles the solutions of x² − d y² = N(w)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Research Context",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States the uniform trace recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ for the chain zⁿ·w in an arbitrary ℤ√d, identifies the coefficients as (trace, determinant) of the transfer map, and explains how the parent's d = 2, coefficient-6 case and the powers-of-a-unit sibling both specialize from it.",
+      "mathContext": "Transfer matrix $\\begin{pmatrix}z_{\\mathrm{re}}&d\\,z_{\\mathrm{im}}\\\\ z_{\\mathrm{im}}&z_{\\mathrm{re}}\\end{pmatrix}$, $\\operatorname{tr}=2z_{\\mathrm{re}}$, $\\det=N(z)=z_{\\mathrm{re}}^2-d\\,z_{\\mathrm{im}}^2$, characteristic polynomial $t^2-2z_{\\mathrm{re}}t+N(z)$."
+    },
+    {
+      "id": "one-step",
+      "title": "One-step (vector) recurrence",
+      "startLine": 54,
+      "endLine": 72,
+      "summary": "re_step and im_step compute the real and imaginary parts of zⁿ⁺¹·w = z·(zⁿ·w) via the Zsqrtd multiplication formulas, giving the coupled first-order recurrence — the action of the transfer matrix.",
+      "mathContext": "$(z^{n+1}w)_{\\mathrm{re}}=z_{\\mathrm{re}}(z^nw)_{\\mathrm{re}}+d\\,z_{\\mathrm{im}}(z^nw)_{\\mathrm{im}}$, $(z^{n+1}w)_{\\mathrm{im}}=z_{\\mathrm{re}}(z^nw)_{\\mathrm{im}}+z_{\\mathrm{im}}(z^nw)_{\\mathrm{re}}$."
+    },
+    {
+      "id": "trace-recurrence",
+      "title": "The uniform trace recurrence (Cayley–Hamilton)",
+      "startLine": 74,
+      "endLine": 99,
+      "summary": "re_rec and im_rec iterate the one-step recurrence twice and eliminate the imaginary part using N(z) = z.re² − d·z.im², yielding uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ for each coordinate — Cayley–Hamilton for the transfer map, discharged by `ring`.",
+      "mathContext": "$M^2=(\\operatorname{tr}M)M-(\\det M)I$ applied to the state $(z^nw)$ gives $u_{n+2}=2z_{\\mathrm{re}}u_{n+1}-N(z)u_n$."
+    },
+    {
+      "id": "unit-case",
+      "title": "The unit case: the negative-Pell recurrence",
+      "startLine": 101,
+      "endLine": 119,
+      "summary": "unit_re_rec and unit_im_rec specialize to N(z) = 1, collapsing the tail to −uₙ and recovering the parent's shape uₙ₊₂ = 2(z.re)·uₙ₊₁ − uₙ; for d = 2, z = 3 + 2√2 this is the parent's 6uₙ₊₁ − uₙ.",
+      "mathContext": "$N(z)=1\\Rightarrow u_{n+2}=2z_{\\mathrm{re}}u_{n+1}-u_n$; $z=3+2\\sqrt2\\Rightarrow 2z_{\\mathrm{re}}=6$."
+    },
+    {
+      "id": "norm-propagation",
+      "title": "Norm propagation along the chain",
+      "startLine": 121,
+      "endLine": 140,
+      "summary": "norm_pow proves N(zⁿ) = N(z)ⁿ by induction on norm_mul; chain_norm concludes that a unit generator keeps the chain norm constant at N(w), so a negative-Pell base yields a chain of negative-Pell solutions.",
+      "mathContext": "$N(z^n w)=N(z)^n N(w)$; if $N(z)=1$ then $N(z^n w)=N(w)$, so $N(w)=-1\\Rightarrow$ every chain member solves $x^2-dy^2=-1$."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Structural payoff: the recurrence characterizes the sequence",
+      "startLine": 142,
+      "endLine": 163,
+      "summary": "rec_unique shows two integer sequences obeying uₙ₊₂ = c·uₙ₊₁ − uₙ with matching first two values coincide everywhere — the abstract, coefficient-agnostic form of the parent's coordinate-specific uniqueness lemmas.",
+      "mathContext": "A second-order linear recurrence with two seeds has a unique solution; a two-step induction on the pair $(u_n,u_{n+1})$ closes the argument."
+    },
+    {
+      "id": "sanity",
+      "title": "Sanity checks: recovering the parent d = 2 chain",
+      "startLine": 165,
+      "endLine": 196,
+      "summary": "Kernel-`decide` checks confirm N(3 + 2√2) = 1, (3 + 2√2).re = 3, 2·(3 + 2√2).re = 6, and N(1 + √2) = −1; specializing unit_re_rec recovers the parent's 6uₙ₊₁ − uₙ, and chain_norm gives norm −1 for every member of that chain.",
+      "mathContext": "$N(3+2\\sqrt2)=9-8=1$, $2\\cdot3=6$; $N(1+\\sqrt2)=1-2=-1$; the chain $(3+2\\sqrt2)^n(1+\\sqrt2)$ solves $x^2-2y^2=-1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 196-line file (0 sorries, 0 axioms, no native_decide) lifts the parent's single computation to a uniform theorem: in any quadratic integer ring ℤ√d, both coordinates of the chain zⁿ·w satisfy the order-2 recurrence uₙ₊₂ = 2(z.re)·uₙ₊₁ − N(z)·uₙ, whose coefficients are the trace and determinant of the transfer map s ↦ z·s. The unit case (N(z) = 1) recovers the parent's shape and, at d = 2, z = 3 + 2√2, its concrete 6uₙ₊₁ − uₙ; norm multiplicativity shows a unit-generated chain stays on a fixed conic, and a general uniqueness lemma pins any such sequence down from two initial values.",
+    "implications": "Reducing multiplication by a quadratic unit to a scalar recurrence is Cayley–Hamilton for a 2×2 matrix, made computable by pure integer arithmetic and now proved uniformly rather than case-by-case. The result directly answers open question #3 of the parent entry (uniform trace coefficient for x² − D y² = −1) and provides reusable ℤ√d infrastructure — the vector step, the trace recurrence, norm multiplicativity, and recurrence uniqueness — for other Pell-chain and quadratic-unit formalizations.",
+    "openQuestions": [
+      "Promote re_rec/im_rec to the genuine matrix statement: show M² = (2·z.re)M − N(z)·I for M = [[z.re, d·z.im],[z.im, z.re]] using Mathlib's Matrix.charpoly / Cayley–Hamilton, and derive the coordinate recurrences as the action of that relation, making the trace/determinant provenance explicit in Lean.",
+      "Give the closed form uₙ = A·λⁿ + B·μⁿ where λ, μ = z.re ± √(z.re² − N(z)) are the characteristic roots (the conjugate images of z), tying the recurrence solution back to the powers-of-a-unit description of the sibling entry."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 196,
+    "axiomCount": 0,
+    "path": "Proofs/PellEquationOQ06OQ03OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 8,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "E. J. Barbeau",
+      "title": "Pell's Equation",
+      "year": 2003,
+      "venue": "Springer",
+      "note": "Book-length treatment of Pell solutions, recurrences, and the group structure of the solution chains."
+    },
+    {
+      "authors": "T. Koshy",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": 2001,
+      "venue": "Wiley",
+      "note": "Second-order linear recurrences of Pell/Lucas type and their trace/determinant coefficients."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib: a unified library of mathematics formalized in Lean 4",
+      "year": 2020,
+      "venue": "CPP",
+      "note": "Provides the Zsqrtd (ℤ[√d]) API — re_mul, im_mul, norm_def, norm_mul — underlying this formalization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the parent entry **pell-equation-oq-06-oq-03** — which proves the concrete `d = 2` recurrence `uₙ₊₂ = 6uₙ₊₁ − uₙ` for the chain of `x² − 2y² = −1` — to a **uniform theorem** valid in any quadratic integer ring `ℤ√d` and for any generator `z`:

> For the chain `sₙ = zⁿ · w`, both coordinates satisfy
> `uₙ₊₂ = 2·(z.re)·uₙ₊₁ − N(z)·uₙ`,
> where `N(z) = z.re² − d·z.im²` is the norm.

The coefficients are exactly the **trace** `2·z.re` and **determinant** `N(z)` of the ℤ-linear transfer map `s ↦ z·s` (matrix `[[z.re, d·z.im],[z.im, z.re]]`) — the Cayley–Hamilton relation, proved directly in `ℤ√d` by one `ring` identity without ever constructing a matrix.

This **directly resolves open question #3** of the parent entry ("formalize the trace coefficient uniformly in D").

## Main results

8 theorems, **0 sorries, 0 axioms, no `native_decide`**:

| Theorem | Statement |
|---|---|
| `re_rec` / `im_rec` | general trace recurrence, coefficient `2·z.re`, tail `N(z)` |
| `unit_re_rec` / `unit_im_rec` | unit case `N(z)=1`: `uₙ₊₂ = 2(z.re)uₙ₊₁ − uₙ` |
| `chain_norm` | norm multiplicativity keeps a unit-generated chain on one conic — a negative-Pell base (`N(w)=−1`) generates a chain of negative-Pell solutions |
| `rec_unique` | recurrence + two initial values determine the sequence |

The parent's `(6, 1)` is recovered as the case `d = 2`, `z = 3 + 2√2` (`2·z.re = 6`, `N(z) = 1`), verified in-file by specialization.

## Verification

- Built with `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ06OQ03OQ03` — builds successfully (7743 jobs).
- Imports only `Mathlib`; uses the `Zsqrtd` API (`re_mul`, `im_mul`, `norm_def`, `norm_mul`).
- Concrete `d = 2` sanity checks use kernel `decide` (not `native_decide`), so the file is axiom-free.
- Full gallery data included (`meta.json`, `annotations.json`); `listings.json` regenerated by the deployer on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)