### PR TITLE
Research: MZ variance-sum Tonelli interchange (lintegral_tsum_trunc_sq_weight_le)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1327,4 +1327,59 @@ theorem lintegral_tsum_trunc_sq_weight_le
 
 end TonelliInterchange
 
+/-! ## Pointwise domination of the interchange RHS integrand (MZ step-4 finiteness core)
+
+The Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` bounds the variance sum by
+`∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` with `s = 2/p`.  At *exactly* that exponent the integrand
+core `(max 1 |X|ᵖ)^{1-2/p}·X²` is dominated **pointwise** by `|X|ᵖ`, which makes the RHS
+integral finite whenever `𝔼|X|ᵖ < ∞`.  The two regions both land under `|x|ᵖ`:
+
+* `|x| ≥ 1`: `max = |x|ᵖ`, and `(|x|ᵖ)^{1-2/p}·|x|² = |x|^{(p-2)+2} = |x|ᵖ` (equality);
+* `|x| < 1`: `max = 1`, so the core is `x² = |x|² = |x|ᵖ·|x|^{2-p} ≤ |x|ᵖ` (`|x|^{2-p} ≤ 1`
+  since `0 ≤ 2-p` and `|x| ≤ 1`).
+
+0-sorry / 0-`axiom`. -/
+section VarianceMajorant
+
+/-- **RHS-integrand domination (MZ step-4 finiteness core).**  For `0 < p < 2` and any real
+`x`, the interchange integrand core at `s = 2/p` is dominated by `|x|ᵖ`:
+
+    (max 1 |x|ᵖ)^{1 - 2/p} · x²  ≤  |x|ᵖ.
+
+Multiplying by the nonnegative constant `s/(s-1)` (`s = 2/p`) dominates the full interchange
+RHS integrand by `s/(s-1)·|X|ᵖ`, giving `∫⁻ (…) < ∞` from `𝔼|X|ᵖ < ∞` — the next leaf. -/
+theorem trunc_rpow_weight_sq_le_rpow {p x : ℝ} (hp : 0 < p) (hp2 : p < 2) :
+    (max 1 (|x| ^ p)) ^ (1 - 2 / p) * x ^ 2 ≤ |x| ^ p := by
+  have hx2 : x ^ 2 = |x| ^ (2 : ℝ) := by
+    rw [← sq_abs x, ← Real.rpow_natCast (|x|) 2]; norm_num
+  rcases le_or_gt (|x|) 1 with hle | hgt
+  · -- |x| ≤ 1 : max = 1, split |x|² = |x|ᵖ·|x|^{2-p} with |x|^{2-p} ≤ 1
+    have hap : |x| ^ p ≤ 1 := Real.rpow_le_one (abs_nonneg x) hle hp.le
+    rw [max_eq_left hap, Real.one_rpow, one_mul, hx2]
+    have hsplit : |x| ^ (2 : ℝ) = |x| ^ p * |x| ^ (2 - p) := by
+      rw [← Real.rpow_add_of_nonneg (abs_nonneg x) hp.le (by linarith),
+          show p + (2 - p) = (2 : ℝ) from by ring]
+    rw [hsplit]
+    have h1 : |x| ^ (2 - p) ≤ 1 := Real.rpow_le_one (abs_nonneg x) hle (by linarith)
+    calc |x| ^ p * |x| ^ (2 - p)
+        ≤ |x| ^ p * 1 := mul_le_mul_of_nonneg_left h1 (Real.rpow_nonneg (abs_nonneg x) p)
+      _ = |x| ^ p := mul_one _
+  · -- 1 < |x| : max = |x|ᵖ, exact equality
+    have hxpos : (0 : ℝ) < |x| := lt_trans one_pos hgt
+    have hap : 1 ≤ |x| ^ p := by
+      calc (1 : ℝ) = (1 : ℝ) ^ p := (Real.one_rpow p).symm
+        _ ≤ |x| ^ p := Real.rpow_le_rpow zero_le_one hgt.le hp.le
+    have hexp : p * (1 - 2 / p) + 2 = p := by field_simp; ring
+    have hval : (max 1 (|x| ^ p)) ^ (1 - 2 / p) * x ^ 2 = |x| ^ p := by
+      rw [max_eq_right hap, hx2, ← Real.rpow_mul (abs_nonneg x), ← Real.rpow_add hxpos, hexp]
+    exact le_of_eq hval
+
+#check @trunc_rpow_weight_sq_le_rpow
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms trunc_rpow_weight_sq_le_rpow
+
+end VarianceMajorant
+
 end LawsOfLargeNumbers.MZ

--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1233,4 +1233,98 @@ theorem tsum_weight_trunc_sq_le {s p : ℝ} (hs : 1 < s) (hp : 0 < p) (x : ℝ) 
 
 end TailPSeries
 
+/-! ## Tonelli interchange for the MZ variance sum (measure-theoretic lift of step 4)
+
+The variance series `∑ᵢ Var(Yᵢ)/aᵢ^{2}` with `aᵢ = i^{1/p}` and truncations
+`Yᵢ = 𝟙{|X| ≤ i^{1/p}}·X` is finite **not** term-by-term (that diverges — see the
+`TailPSeries` note) but by a **Tonelli interchange** of `∑ᵢ` and `∫`.  For nonnegative
+integrands the interchange is *unconditional*: `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ`
+through the lower integral needing only a per-term measurability side goal, sidestepping the
+Bochner `integral_tsum` whose `∑'ᵢ ∫‖·‖ < ∞` hypothesis is *exactly* the finiteness we are
+trying to establish.  The pointwise integrand is then dominated by the deterministic bound
+`tsum_weight_trunc_sq_le` at `x = X ω`.
+
+This yields the master estimate (in `ℝ≥0∞`, `s = 2/p`)
+
+    ∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²,
+
+the lower-integral form of `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} ≤ 𝔼[(max 1 |X|ᵖ)^{1-2/p}·(2/p)/(2/p-1)·X²]`.
+With `s = 2/p > 1` the RHS integrand is dominated by `s/(s-1)·max(X², |X|ᵖ)`, integrable on a
+probability space with `𝔼|X|ᵖ < ∞`; so the whole variance sum is finite (that finiteness
+extraction is the next leaf).  0-sorry / 0-`axiom`. -/
+section TonelliInterchange
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Tonelli interchange bound for the MZ variance series.**  For a measurable `X`, `1 < s`
+and `0 < p`, the `i^{-s}`-weighted truncated second moments, summed in `ℝ≥0∞`, are bounded by
+the integral of the deterministic pointwise majorant of `tsum_weight_trunc_sq_le`:
+
+    ∑'ᵢ ∫⁻ ω, i^{-s}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ∫⁻ ω, (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X².
+
+Proof: `lintegral_tsum` (nonneg summand, per-term measurable) pushes `∑'ᵢ` inside the lower
+integral; then `lintegral_mono` dominates the pointwise `∑'ᵢ` by `tsum_weight_trunc_sq_le` at
+`x = X ω`, pulling `ENNReal.ofReal` through the real tsum via `ENNReal.ofReal_tsum_of_nonneg`
+(the per-`ω` summand is summable: an indicator of the `p`-series `i^{-s}` scaled by `X ω ^ 2`). -/
+theorem lintegral_tsum_trunc_sq_weight_le
+    (X : Ω → ℝ) (hX : Measurable X) {s p : ℝ} (hs : 1 < s) (hp : 0 < p) :
+    ∑' i : ℕ, ∫⁻ ω, ENNReal.ofReal
+        ((i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) ∂μ
+      ≤ ∫⁻ ω, ENNReal.ofReal
+        ((max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * (X ω) ^ 2) ∂μ := by
+  -- per-term measurability of `ω ↦ ofReal (i^{-s}·(𝟙{|X|≤i^{1/p}}·X)²)`
+  have hmeas : ∀ i : ℕ, AEMeasurable
+      (fun ω => ENNReal.ofReal
+        ((i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2)) μ := by
+    intro i
+    refine (ENNReal.measurable_ofReal.comp ?_).aemeasurable
+    exact ((hX.indicator (measurableSet_le hX.abs measurable_const)).pow_const 2).const_mul _
+  -- push `∑'ᵢ` inside the lower integral (unconditional for nonneg summands)
+  rw [← lintegral_tsum hmeas]
+  -- dominate pointwise by `tsum_weight_trunc_sq_le` at `x = X ω`
+  apply lintegral_mono
+  intro ω
+  -- the real summand equals the root-form indicator summand of `tsum_weight_trunc_sq_le`
+  have hri : ∀ i : ℕ,
+      (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2
+        = {j : ℕ | |X ω| ≤ (j : ℝ) ^ (1 / p)}.indicator
+            (fun j => (j : ℝ) ^ (-s) * (X ω) ^ 2) i := by
+    intro i
+    simp only [Set.indicator_apply, Set.mem_setOf_eq]
+    split_ifs <;> ring
+  have hr_nonneg : ∀ i : ℕ,
+      0 ≤ (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2 :=
+    fun i => mul_nonneg (Real.rpow_nonneg (Nat.cast_nonneg i) _) (sq_nonneg _)
+  have hclean_summ : Summable
+      ({j : ℕ | |X ω| ≤ (j : ℝ) ^ (1 / p)}.indicator
+        (fun j => (j : ℝ) ^ (-s) * (X ω) ^ 2)) :=
+    ((Real.summable_nat_rpow.mpr (by linarith : -s < -1)).mul_right ((X ω) ^ 2)).indicator _
+  have hr_summ : Summable
+      (fun i : ℕ => (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) :=
+    hclean_summ.congr (fun i => (hri i).symm)
+  calc ∑' i : ℕ, ENNReal.ofReal
+          ((i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2)
+      = ENNReal.ofReal (∑' i : ℕ,
+          (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) :=
+        (ENNReal.ofReal_tsum_of_nonneg hr_nonneg hr_summ).symm
+    _ ≤ ENNReal.ofReal ((max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * (X ω) ^ 2) := by
+        apply ENNReal.ofReal_le_ofReal
+        calc ∑' i : ℕ,
+              (i : ℝ) ^ (-s) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2
+            = ∑' i : ℕ, {j : ℕ | |X ω| ≤ (j : ℝ) ^ (1 / p)}.indicator
+                (fun j => (j : ℝ) ^ (-s) * (X ω) ^ 2) i := tsum_congr hri
+          _ ≤ (max 1 (|X ω| ^ p)) ^ (1 - s) * s / (s - 1) * (X ω) ^ 2 :=
+              tsum_weight_trunc_sq_le hs hp (X ω)
+
+#check @lintegral_tsum_trunc_sq_weight_le
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms lintegral_tsum_trunc_sq_weight_le
+
+end TonelliInterchange
+
 end LawsOfLargeNumbers.MZ

--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1382,4 +1382,60 @@ theorem trunc_rpow_weight_sq_le_rpow {p x : ℝ} (hp : 0 < p) (hp2 : p < 2) :
 
 end VarianceMajorant
 
+/-! ## Master finiteness bound for the MZ variance sum (interchange ∘ domination)
+
+Chaining the Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` (at `s = 2/p`) with the
+pointwise domination `trunc_rpow_weight_sq_le_rpow` and a constant pull-out collapses the whole
+`i^{-2/p}`-weighted truncated-second-moment sum to a single multiple of the `p`-th moment:
+
+    ∑'ᵢ ∫⁻ ω, i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ofReal((2/p)/(2/p-1)) · ∫⁻ ω, |X|ᵖ.
+
+This is the quantitative `∑ᵢ Var(Yᵢ)/aᵢ² ≤ C·𝔼|X|ᵖ` (in `ℝ≥0∞`, `aᵢ = i^{1/p}`): with
+`𝔼|X|ᵖ < ∞` the RHS is finite, so the variance sum is finite — the summability hypothesis of the
+Kolmogorov criterion `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5).  0-sorry / 0-`axiom`. -/
+section MasterVarianceBound
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Master variance-sum bound (MZ step 4).**  For a measurable `X` and `0 < p < 2`, the
+`i^{-2/p}`-weighted truncated second moments sum to at most a constant multiple of the `p`-th
+absolute moment (all in `ℝ≥0∞`):
+
+    ∑'ᵢ ∫⁻ ω, i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ofReal((2/p)/(2/p-1)) · ∫⁻ ω, |X|ᵖ.
+
+Proof: `lintegral_tsum_trunc_sq_weight_le` at `s = 2/p` bounds the LHS by the integral of the
+interchange majorant; `lintegral_const_mul'` pulls the constant out of the target; then
+`lintegral_mono` + `trunc_rpow_weight_sq_le_rpow` dominate the integrand pointwise by
+`(2/p)/(2/p-1)·|X ω|ᵖ`. -/
+theorem lintegral_tsum_trunc_sq_weight_le_moment
+    (X : Ω → ℝ) (hX : Measurable X) {p : ℝ} (hp : 0 < p) (hp2 : p < 2) :
+    ∑' i : ℕ, ∫⁻ ω, ENNReal.ofReal
+        ((i : ℝ) ^ (-(2 / p)) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) ∂μ
+      ≤ ENNReal.ofReal ((2 / p) / (2 / p - 1)) * ∫⁻ ω, ENNReal.ofReal (|X ω| ^ p) ∂μ := by
+  have hs : (1 : ℝ) < 2 / p := by rw [lt_div_iff₀ hp]; linarith
+  have hc : (0 : ℝ) ≤ (2 / p) / (2 / p - 1) := div_nonneg (by positivity) (by linarith)
+  refine (lintegral_tsum_trunc_sq_weight_le X hX hs hp).trans ?_
+  rw [← lintegral_const_mul' (ENNReal.ofReal ((2 / p) / (2 / p - 1)))
+        (fun ω => ENNReal.ofReal (|X ω| ^ p)) ENNReal.ofReal_ne_top]
+  apply lintegral_mono
+  intro ω
+  dsimp only
+  rw [← ENNReal.ofReal_mul hc]
+  apply ENNReal.ofReal_le_ofReal
+  calc (max 1 (|X ω| ^ p)) ^ (1 - 2 / p) * (2 / p) / (2 / p - 1) * (X ω) ^ 2
+      = (2 / p) / (2 / p - 1) * ((max 1 (|X ω| ^ p)) ^ (1 - 2 / p) * (X ω) ^ 2) := by ring
+    _ ≤ (2 / p) / (2 / p - 1) * |X ω| ^ p :=
+        mul_le_mul_of_nonneg_left (trunc_rpow_weight_sq_le_rpow hp hp2) hc
+
+#check @lintegral_tsum_trunc_sq_weight_le_moment
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms lintegral_tsum_trunc_sq_weight_le_moment
+
+end MasterVarianceBound
+
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -118,14 +118,19 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
   `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω`, pulling `ENNReal.ofReal` through the real
   tsum via `ENNReal.ofReal_tsum_of_nonneg` (per-`ω` summand summable: an indicator of the `i^{-s}`
   `p`-series scaled by `X ω ^ 2`). **Do not re-derive.**
-- **Next: RHS-integrand finiteness extraction.** With `s = 2/p (>1 ⟺ p<2)`, bound the master RHS
-  integrand `(max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` and show it is *integrable* (⟹ the `∫⁻` RHS is `< ∞`,
-  ⟹ the ℝ≥0∞ variance sum is finite): `|X|≥1` branch `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so the
-  integrand `= s/(s-1)·|X|^p → s/(s-1)·𝔼|X|ᵖ`; `|X|<1` branch `max = 1`, integrand `= s/(s-1)·X²`
-  bounded by `s/(s-1)` on a probability space. Uniform majorant `s/(s-1)·max(X²,|X|ᵖ) ≤
-  s/(s-1)·(1+|X|ᵖ)`, integrable via `𝔼|X|ᵖ<∞` + `IsProbabilityMeasure`. Convert the finite `∫⁻`
-  RHS back to a real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` (via `lintegral_ofReal`/`ofReal_ne_top` bridges),
-  feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
+- **RHS-integrand pointwise domination core is now DONE (iteration 14):**
+  `trunc_rpow_weight_sq_le_rpow` — for `0<p<2`, any `x`, the interchange integrand core at
+  `s=2/p` is dominated by `|x|ᵖ`: `(max 1 |x|ᵖ)^{1-2/p}·x² ≤ |x|ᵖ`. Two branches, both under
+  `|x|ᵖ`: `|x|≥1` gives equality `(|x|ᵖ)^{1-2/p}·|x|²=|x|^{(p-2)+2}=|x|ᵖ` (`Real.rpow_mul`+
+  `rpow_add`, exponent `p·(1-2/p)+2=p` by `field_simp;ring`); `|x|<1` splits `|x|²=|x|ᵖ·|x|^{2-p}`
+  (`Real.rpow_add_of_nonneg`) with `|x|^{2-p}≤1` (`Real.rpow_le_one`). **Do not re-derive.**
+- **Next: RHS integrability + `∫⁻` finiteness.** Multiply `trunc_rpow_weight_sq_le_rpow` by the
+  nonneg constant `s/(s-1)` (`s=2/p`) ⟹ the full interchange RHS integrand `≤ s/(s-1)·|X|ᵖ`
+  pointwise; then `Integrable (fun ω => |X ω|ᵖ)` ⟹ `∫⁻ ω, ofReal(RHS integrand) < ∞` (via
+  `lintegral_ofReal_le_lintegral_ofReal`/`integrable.lintegral_lt_top` + `ofReal_ne_top`).
+  Chained with `lintegral_tsum_trunc_sq_weight_le` this gives the ℝ≥0∞ variance sum finite;
+  convert to real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞`, feeding
+  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
   (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -124,13 +124,19 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
   `|x|ᵖ`: `|x|≥1` gives equality `(|x|ᵖ)^{1-2/p}·|x|²=|x|^{(p-2)+2}=|x|ᵖ` (`Real.rpow_mul`+
   `rpow_add`, exponent `p·(1-2/p)+2=p` by `field_simp;ring`); `|x|<1` splits `|x|²=|x|ᵖ·|x|^{2-p}`
   (`Real.rpow_add_of_nonneg`) with `|x|^{2-p}≤1` (`Real.rpow_le_one`). **Do not re-derive.**
-- **Next: RHS integrability + `∫⁻` finiteness.** Multiply `trunc_rpow_weight_sq_le_rpow` by the
-  nonneg constant `s/(s-1)` (`s=2/p`) ⟹ the full interchange RHS integrand `≤ s/(s-1)·|X|ᵖ`
-  pointwise; then `Integrable (fun ω => |X ω|ᵖ)` ⟹ `∫⁻ ω, ofReal(RHS integrand) < ∞` (via
-  `lintegral_ofReal_le_lintegral_ofReal`/`integrable.lintegral_lt_top` + `ofReal_ne_top`).
-  Chained with `lintegral_tsum_trunc_sq_weight_le` this gives the ℝ≥0∞ variance sum finite;
-  convert to real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞`, feeding
-  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
+- **Master variance-sum bound is now DONE (iteration 15):** `lintegral_tsum_trunc_sq_weight_le_moment`
+  collapses the whole weighted sum to a constant times the `p`-th moment (in ℝ≥0∞):
+  `∑'ᵢ ∫⁻ i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ofReal((2/p)/(2/p-1)) · ∫⁻ |X|ᵖ`. Proof: chain
+  `lintegral_tsum_trunc_sq_weight_le` at `s=2/p` (`hs: 1<2/p` via `lt_div_iff₀`), `lintegral_const_mul'`
+  (const pull, needs only `ofReal_ne_top` — no measurability), `lintegral_mono` + `ENNReal.ofReal_mul`
+  + `trunc_rpow_weight_sq_le_rpow`. **This is the quantitative `∑ᵢ Var(Yᵢ)/aᵢ² ≤ C·𝔼|X|ᵖ`.**
+  **Do not re-derive.**
+- **Next: extract real finiteness + feed S5.** From `Integrable (fun ω => |X ω|ᵖ)` (⟹
+  `∫⁻ ofReal(|X|ᵖ) < ∞` via `Integrable.lintegral_lt_top`/`hasFiniteIntegral` + `ofReal`/`nnnorm`
+  bridge on the nonneg `|X|ᵖ`), the master bound RHS `ofReal(C)·(finite)` is `< ∞`
+  (`ENNReal.mul_lt_top`), so the ℝ≥0∞ variance sum is finite. Convert to a real
+  `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` (each summand = `(∫⁻ …).toReal` via `lintegral_ofReal`/`ofReal_toReal`),
+  feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
   (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 *Tonelli integrand* — pointwise per-`ω` variance-sum integrand SHIPPED & VERIFIED — remaining: the ∑ᵢ–𝔼 interchange itself + assembly)
+**Phase**: ACT (S4b step-4 *Tonelli interchange* — the ∑ᵢ–𝔼 lower-integral interchange itself SHIPPED & VERIFIED — remaining: RHS-integrand finiteness extraction + assembly)
 **Since**: 2026-07-04
-**Iteration**: 12 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 13 (S4b step-4 **Tonelli interchange** `lintegral_tsum_trunc_sq_weight_le`: `∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral (unconditional for nonneg, sidestepping Bochner `integral_tsum`'s `∑∫‖·‖<∞` which is the very finiteness sought), then `lintegral_mono` dominates the pointwise `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω` via `ENNReal.ofReal_tsum_of_nonneg` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -109,20 +109,22 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 
 ## Next Action
 
-- **S4b step-4 pointwise Tonelli integrand is now DONE (iteration 12):** `tsum_weight_trunc_sq_le`
-  supplies, for `1<s`, `0<p`, any `x`, the **per-`ω` variance summand bound**
-  `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²`. This is the exact `x=X(ω)`,
-  `s=2/p` integrand of the interchange: the root-form truncation region `{i | |x| ≤ i^{1/p}}`
-  (matching `integral_trunc_sq_le`'s `t=i^{1/p}`) is bridged to the power-form `{i | |x|ᵖ ≤ i}`
-  (complement of `rpow_inv_lt_iff_lt_rpow` via `not_lt`), `x²` is pulled through
-  (`tsum_mul_right`), and iter-11 `tsum_indicator_ge_rpow_neg_le` closes it. **Do not re-derive.**
-- **Next: the ∑ᵢ–𝔼 Tonelli interchange itself** (the one remaining measure-theoretic lift for
-  step-4). Use `MeasureTheory.integral_tsum` / `lintegral_tsum` (nonneg, per-term integrability +
-  `∑'∫|·|<∞` side-goals) to move `∑'ᵢ ∫ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² dμ = ∫ ∑'ᵢ (…) dμ`; the inner
-  `∑'ᵢ` under the integral is **literally** `tsum_weight_trunc_sq_le` at `x=X(ω)`, so the integrand
-  is dominated by `(max 1 |X|ᵖ)^{1-2/p}·s/(s-1)·X²`. Integrate the RHS: `|X|≥1` branch
-  `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so `X²·bound=|X|^p → 𝔼|X|ᵖ`; `|X|<1` branch collapses to
-  `const·X² → const·𝔼X²` (finite via `𝔼|X|ᵖ` + probability space). Yields `∑ᵢ Var(Yᵢ)/i^{2/p} < ∞`,
+- **S4b step-4 Tonelli interchange is now DONE (iteration 13):** `lintegral_tsum_trunc_sq_weight_le`
+  supplies, for measurable `X`, `1<s`, `0<p`, the **master lower-integral estimate**
+  `∑'ᵢ ∫⁻ ω, i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ ω, (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²`. Proof:
+  `MeasureTheory.lintegral_tsum` (per-term measurability only — **unconditional for nonneg
+  summands**, deliberately avoiding Bochner `integral_tsum` whose `∑'ᵢ∫‖·‖<∞` side goal is the
+  very finiteness we seek) pushes `∑'ᵢ` inside `∫⁻`; then `lintegral_mono` dominates the pointwise
+  `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω`, pulling `ENNReal.ofReal` through the real
+  tsum via `ENNReal.ofReal_tsum_of_nonneg` (per-`ω` summand summable: an indicator of the `i^{-s}`
+  `p`-series scaled by `X ω ^ 2`). **Do not re-derive.**
+- **Next: RHS-integrand finiteness extraction.** With `s = 2/p (>1 ⟺ p<2)`, bound the master RHS
+  integrand `(max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` and show it is *integrable* (⟹ the `∫⁻` RHS is `< ∞`,
+  ⟹ the ℝ≥0∞ variance sum is finite): `|X|≥1` branch `(max 1 |X|ᵖ)^{1-2/p}=|X|^{p-2}` so the
+  integrand `= s/(s-1)·|X|^p → s/(s-1)·𝔼|X|ᵖ`; `|X|<1` branch `max = 1`, integrand `= s/(s-1)·X²`
+  bounded by `s/(s-1)` on a probability space. Uniform majorant `s/(s-1)·max(X²,|X|ᵖ) ≤
+  s/(s-1)·(1+|X|ᵖ)`, integrable via `𝔼|X|ᵖ<∞` + `IsProbabilityMeasure`. Convert the finite `∫⁻`
+  RHS back to a real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` (via `lintegral_ofReal`/`ofReal_ne_top` bridges),
   feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
   (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
@@ -130,8 +132,9 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 
 ## Attempt Counts
 
-- Total attempts: 12 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand)
-- Current approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
+- Total attempts: 13 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand; iter-13 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le`)
+- Latest approach attempts: 1 (S4b step-4 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` — `lintegral_tsum` [per-term `Measurable.indicator`∘`measurableSet_le`∘`pow_const`∘`const_mul`∘`ENNReal.measurable_ofReal`] to push `∑'ᵢ` inside `∫⁻`, then `lintegral_mono` + `ENNReal.ofReal_tsum_of_nonneg` [summand summable via `Real.summable_nat_rpow`.`mul_right`.`indicator`] + `tsum_weight_trunc_sq_le`; one binder-type fix [`fun i : ℕ`], then clean build 7743 jobs, 0-axiom)
+- Prior approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;
   S4b step-2 discrete layer cake via lintegral_tsum + floor count;


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — step-4 Tonelli interchange (verified, 0-axiom)

Problem: `laws-of-large-numbers-oq-01-oq-02-oq-01` (MZ strong law, `1 ≤ p < 2`).

This closes the **central remaining measure-theoretic obstacle** of step 4 — the ∑ᵢ–𝔼 interchange behind the truncated variance series `∑ᵢ Var(Yᵢ)/i^{2/p}`. New lemma `lintegral_tsum_trunc_sq_weight_le`: for measurable `X`, `1 < s`, `0 < p`,

```
∑'ᵢ ∫⁻ ω, i^{-s}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ∫⁻ ω, (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²
```

### Why lintegral, not Bochner
The naive per-term bound `𝔼[Yᵢ²] ≤ i^{(2-p)/p}·𝔼|X|ᵖ` divided by `i^{2/p}` leaves `i^{-1}`, whose sum **diverges** — so the series is finite only via the interchange, keeping the truncated moment intact. Bochner `integral_tsum` is unusable here: its `∑'ᵢ∫‖·‖<∞` hypothesis is *exactly* the finiteness we are trying to prove. `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral **unconditionally** for nonnegative summands (only a per-term measurability side goal).

### Proof
1. Per-term measurability: `Measurable.indicator ∘ measurableSet_le ∘ pow_const ∘ const_mul ∘ ENNReal.measurable_ofReal`.
2. `lintegral_tsum` → `lintegral_mono`.
3. Pointwise at `x = X ω`: pull `ENNReal.ofReal` through the real tsum (`ENNReal.ofReal_tsum_of_nonneg`; summand summable = indicator of the `i^{-s}` p-series scaled by `X ω ^ 2`), then dominate by the iter-12 pointwise integrand `tsum_weight_trunc_sq_le`.

### Next (documented in state.md)
RHS-integrand finiteness extraction: `s = 2/p` makes the RHS integrand `≤ s/(s-1)·(1 + |X|ᵖ)`, integrable via `𝔼|X|ᵖ<∞` + `IsProbabilityMeasure` ⟹ the variance sum is finite, feeding S5.

### Verification
`docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built, 7743 jobs, exit 0**. `#print axioms lintegral_tsum_trunc_sq_weight_le` = `[propext, Classical.choice, Quot.sound]` — **0-axiom** (no `sorryAx`, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)