### PR TITLE
Research: Neumann series for a perturbed unit x − t (geometric-series-oq-02-oq-03-oq-01-oq-03)

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
@@ -51,11 +51,11 @@ variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
 -- Part I: The factorization `x − t = x · (1 − x⁻¹ t)`
 -- ============================================================================
 
+omit [HasSummableGeomSeries R] in
 /-- **Factoring out the unit.** For a unit `x` and any `t`,
 `x − t = x · (1 − x⁻¹ t)`.  This is the algebraic engine of the whole file: it
 turns a perturbation of `x` into a perturbation of `1`, ready for the Neumann
 series. -/
-omit [HasSummableGeomSeries R] in
 theorem factor_sub (x : Rˣ) (t : R) :
     (x : R) - t = ↑x * (1 - (↑x⁻¹ : R) * t) := by
   rw [mul_sub, mul_one, ← mul_assoc, Units.mul_inv, one_mul]

--- a/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
@@ -1,0 +1,184 @@
+import Mathlib.Analysis.Normed.Ring.Units
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# The Neumann Series for a Perturbed Unit `x − t` (geometric-series-oq-02-oq-03-oq-01-oq-03)
+
+The Neumann series `(1 − t)⁻¹ = ∑' n, tⁿ` (see `GeometricSeriesOQ02OQ03OQ01`)
+inverts a small perturbation of the *identity*.  This file answers the open
+question of generalizing it to a perturbation of an *arbitrary unit* `x`:
+
+    if `x` is a unit and `‖x⁻¹ t‖ < 1`, then `x − t` is a unit and
+
+        (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹.
+
+The whole result rests on the factorization
+
+        x − t = x · (1 − x⁻¹ t),
+
+which reduces the perturbed inverse to the ordinary Neumann series applied to
+`s := x⁻¹ t`.  The hypothesis `‖x⁻¹ t‖ < 1` is the sharp Neumann condition: it is
+exactly what makes `1 − x⁻¹ t` a unit, and it is implied by (but weaker, in a
+noncommutative ring, than) Mathlib's `‖t‖ < ‖x⁻¹‖⁻¹` used in `Units.add` /
+`NormedRing.inverse_add`.
+
+Contents:
+
+  * `factor_sub` — the algebraic identity `x − t = x · (1 − x⁻¹ t)`;
+  * `isUnit_sub` — `x − t` is a unit;
+  * `neumann_series_sub` — `(x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹`;
+  * `hasSum_neumann_series_sub` — the `HasSum` form;
+  * `neumann_sub_mul_left` / `neumann_sub_mul_right` — genuine two-sided inverse;
+  * `neumann_sub_partial_remainder` — finite truncation with explicit remainder;
+  * `inverse_sub_continuousAt` — local continuity of `t ↦ (x − t)⁻¹`, the first
+    step toward the local analyticity of inversion.
+
+Each result is derived from the identity above and Mathlib's normed-ring API; the
+contribution is the packaged, named Neumann-series API for a perturbed unit.
+
+Status: 0 axioms, 0 sorries
+-/
+
+namespace GeometricSeriesOQ02OQ03OQ01OQ03
+
+open scoped Topology
+open Finset
+
+variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
+
+-- ============================================================================
+-- Part I: The factorization `x − t = x · (1 − x⁻¹ t)`
+-- ============================================================================
+
+/-- **Factoring out the unit.** For a unit `x` and any `t`,
+`x − t = x · (1 − x⁻¹ t)`.  This is the algebraic engine of the whole file: it
+turns a perturbation of `x` into a perturbation of `1`, ready for the Neumann
+series. -/
+theorem factor_sub (x : Rˣ) (t : R) :
+    (x : R) - t = ↑x * (1 - (↑x⁻¹ : R) * t) := by
+  rw [mul_sub, mul_one, ← mul_assoc, Units.mul_inv, one_mul]
+
+-- ============================================================================
+-- Part II: Invertibility of `x − t`
+-- ============================================================================
+
+/-- **A perturbation of a unit stays a unit.** If `‖x⁻¹ t‖ < 1` then `x − t` is a
+unit — the qualitative core of the perturbed Neumann series. -/
+theorem isUnit_sub (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    IsUnit ((x : R) - t) := by
+  rw [factor_sub x t]
+  exact x.isUnit.mul (isUnit_one_sub_of_norm_lt_one h)
+
+-- ============================================================================
+-- Part III: The perturbed Neumann series
+-- ============================================================================
+
+/-- **Neumann series for a perturbed unit.** If `x` is a unit and `‖x⁻¹ t‖ < 1`
+then
+
+    (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹.
+
+Setting `x = 1` recovers the ordinary Neumann series `(1 − t)⁻¹ = ∑' n, tⁿ`. -/
+theorem neumann_series_sub (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    Ring.inverse ((x : R) - t) = (∑' n : ℕ, ((↑x⁻¹ : R) * t) ^ n) * ↑x⁻¹ := by
+  set s : R := (↑x⁻¹ : R) * t with hs
+  set u : Rˣ := Units.oneSub s h with hu
+  have hfac : (↑x : R) - t = ↑(x * u) := by
+    rw [Units.val_mul, hu, Units.val_oneSub, factor_sub x t, hs]
+  rw [hfac, Ring.inverse_unit, mul_inv_rev, Units.val_mul]
+  congr 1
+  rw [← Ring.inverse_unit u, hu, Units.val_oneSub, ← geom_series_eq_inverse s h]
+
+/-- The `HasSum` form of the perturbed Neumann series: the partial sums
+`∑_{i<N} (x⁻¹ t)ⁱ · x⁻¹` converge to `(x − t)⁻¹`. -/
+theorem hasSum_neumann_series_sub (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    HasSum (fun n : ℕ => ((↑x⁻¹ : R) * t) ^ n * ↑x⁻¹) (Ring.inverse ((x : R) - t)) := by
+  rw [neumann_series_sub x t h]
+  exact ((summable_geometric_of_norm_lt_one h).hasSum).mul_right _
+
+-- ============================================================================
+-- Part IV: Two-sided inverse
+-- ============================================================================
+
+/-- The perturbed Neumann series is a genuine **left** inverse of `x − t`. -/
+theorem neumann_sub_mul_left (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    ((∑' n : ℕ, ((↑x⁻¹ : R) * t) ^ n) * ↑x⁻¹) * ((x : R) - t) = 1 := by
+  rw [← neumann_series_sub x t h]
+  exact Ring.inverse_mul_cancel _ (isUnit_sub x t h)
+
+/-- The perturbed Neumann series is a genuine **right** inverse of `x − t`. -/
+theorem neumann_sub_mul_right (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    ((x : R) - t) * ((∑' n : ℕ, ((↑x⁻¹ : R) * t) ^ n) * ↑x⁻¹) = 1 := by
+  rw [← neumann_series_sub x t h]
+  exact Ring.mul_inverse_cancel _ (isUnit_sub x t h)
+
+-- ============================================================================
+-- Part V: Finite truncation with remainder
+-- ============================================================================
+
+/-- **Partial-sum remainder.** Truncating the perturbed Neumann series after `N`
+terms leaves the explicit remainder `(x⁻¹ t)ᴺ · (x − t)⁻¹`:
+
+    (x − t)⁻¹ = (∑_{i<N} (x⁻¹ t)ⁱ) · x⁻¹ + (x⁻¹ t)ᴺ · (x − t)⁻¹.
+
+Since `‖(x⁻¹ t)ᴺ‖ → 0`, the truncation approximates the inverse to any accuracy —
+the basis of preconditioned iterative inversion. -/
+theorem neumann_sub_partial_remainder (x : Rˣ) (N : ℕ) (t : R)
+    (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
+    Ring.inverse ((x : R) - t)
+      = (∑ i ∈ range N, ((↑x⁻¹ : R) * t) ^ i) * ↑x⁻¹
+        + ((↑x⁻¹ : R) * t) ^ N * Ring.inverse ((x : R) - t) := by
+  have key : Ring.inverse ((x : R) - t)
+      = Ring.inverse (1 - (↑x⁻¹ : R) * t) * ↑x⁻¹ := by
+    rw [neumann_series_sub x t h, geom_series_eq_inverse _ h]
+  conv_lhs =>
+    rw [key, NormedRing.inverse_one_sub_nth_order' N h, add_mul, mul_assoc, ← key]
+
+-- ============================================================================
+-- Part VI: Local continuity of inversion
+-- ============================================================================
+
+/-- **Local continuity of the perturbed inverse.** For a unit `x` and any base
+point `t₀` with `‖x⁻¹ t₀‖ < 1`, the map `t ↦ (x − t)⁻¹` is continuous at `t₀`.
+This is the first quantitative step toward the local analyticity of inversion on
+the (open) unit group. -/
+theorem inverse_sub_continuousAt (x : Rˣ) (t₀ : R) (h : ‖(↑x⁻¹ : R) * t₀‖ < 1) :
+    ContinuousAt (fun t : R => Ring.inverse ((x : R) - t)) t₀ := by
+  obtain ⟨v, hv⟩ := isUnit_sub x t₀ h
+  have hcont : ContinuousAt Ring.inverse ((x : R) - t₀) :=
+    hv ▸ NormedRing.inverse_continuousAt v
+  exact hcont.comp (continuousAt_const.sub continuousAt_id)
+
+-- ============================================================================
+-- Part VII: Summary
+-- ============================================================================
+
+/-
+## Summary
+
+| Result | Statement | Backing |
+|--------|-----------|---------|
+| `factor_sub` | x − t = x · (1 − x⁻¹ t) | ring + `Units.mul_inv` |
+| `isUnit_sub` | x − t is a unit | `isUnit_one_sub_of_norm_lt_one` |
+| `neumann_series_sub` | (x − t)⁻¹ = (∑' (x⁻¹ t)ⁿ) x⁻¹ | `geom_series_eq_inverse` |
+| `hasSum_neumann_series_sub` | partial sums → (x − t)⁻¹ | `HasSum.mul_right` |
+| `neumann_sub_mul_left/right` | two-sided inverse | `Ring.(inverse_)mul_cancel` |
+| `neumann_sub_partial_remainder` | truncation + (x⁻¹ t)ᴺ·(x − t)⁻¹ | `inverse_one_sub_nth_order'` |
+| `inverse_sub_continuousAt` | t ↦ (x − t)⁻¹ continuous | `inverse_continuousAt` |
+
+Taking `x = 1` collapses every statement to the corresponding result of the
+parent file `GeometricSeriesOQ02OQ03OQ01`.  The sharp hypothesis `‖x⁻¹ t‖ < 1`
+(rather than Mathlib's `‖t‖ < ‖x⁻¹‖⁻¹`) means the series converges precisely on
+the largest ball guaranteeing `1 − x⁻¹ t` invertible, and `inverse_sub_continuousAt`
+is the local step behind the openness of the unit group and the holomorphy of the
+resolvent `(λ − T)⁻¹` in spectral theory.
+-/
+
+end GeometricSeriesOQ02OQ03OQ01OQ03
+
+#check @GeometricSeriesOQ02OQ03OQ01OQ03.neumann_series_sub
+#check @GeometricSeriesOQ02OQ03OQ01OQ03.isUnit_sub
+#check @GeometricSeriesOQ02OQ03OQ01OQ03.hasSum_neumann_series_sub
+#check @GeometricSeriesOQ02OQ03OQ01OQ03.neumann_sub_partial_remainder
+#check @GeometricSeriesOQ02OQ03OQ01OQ03.inverse_sub_continuousAt

--- a/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
+++ b/proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean
@@ -55,6 +55,7 @@ variable {R : Type*} [NormedRing R] [HasSummableGeomSeries R]
 `x − t = x · (1 − x⁻¹ t)`.  This is the algebraic engine of the whole file: it
 turns a perturbation of `x` into a perturbation of `1`, ready for the Neumann
 series. -/
+omit [HasSummableGeomSeries R] in
 theorem factor_sub (x : Rˣ) (t : R) :
     (x : R) - t = ↑x * (1 - (↑x⁻¹ : R) * t) := by
   rw [mul_sub, mul_one, ← mul_assoc, Units.mul_inv, one_mul]
@@ -82,13 +83,10 @@ then
 Setting `x = 1` recovers the ordinary Neumann series `(1 − t)⁻¹ = ∑' n, tⁿ`. -/
 theorem neumann_series_sub (x : Rˣ) (t : R) (h : ‖(↑x⁻¹ : R) * t‖ < 1) :
     Ring.inverse ((x : R) - t) = (∑' n : ℕ, ((↑x⁻¹ : R) * t) ^ n) * ↑x⁻¹ := by
-  set s : R := (↑x⁻¹ : R) * t with hs
-  set u : Rˣ := Units.oneSub s h with hu
-  have hfac : (↑x : R) - t = ↑(x * u) := by
-    rw [Units.val_mul, hu, Units.val_oneSub, factor_sub x t, hs]
-  rw [hfac, Ring.inverse_unit, mul_inv_rev, Units.val_mul]
-  congr 1
-  rw [← Ring.inverse_unit u, hu, Units.val_oneSub, ← geom_series_eq_inverse s h]
+  have hfac : (↑x : R) - t = ↑(x * Units.oneSub ((↑x⁻¹ : R) * t) h) := by
+    rw [Units.val_mul, Units.val_oneSub, factor_sub x t]
+  rw [hfac, Ring.inverse_unit, mul_inv_rev, Units.val_mul, ← Ring.inverse_unit,
+    Units.val_oneSub, geom_series_eq_inverse ((↑x⁻¹ : R) * t) h]
 
 /-- The `HasSum` form of the perturbed Neumann series: the partial sums
 `∑_{i<N} (x⁻¹ t)ⁱ · x⁻¹` converge to `(x − t)⁻¹`. -/

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/annotations.json
@@ -1,0 +1,185 @@
+[
+  {
+    "id": "ann-overview-header",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
+    "type": "concept",
+    "title": "Overview: the Neumann series for a perturbed unit x − t",
+    "content": "The Neumann series $(1-t)^{-1}=\\sum_n t^n$ inverts a perturbation of the *identity*. This file generalises it to a perturbation of an arbitrary *unit* $x$: if $x$ is invertible and $\\lVert x^{-1}t\\rVert < 1$, then $x-t$ is invertible with $(x-t)^{-1} = \\left(\\sum_n (x^{-1}t)^n\\right) x^{-1}$. Everything rests on the factorization $x-t = x\\,(1 - x^{-1}t)$, which turns a perturbation of $x$ into a perturbation of $1$ and lets the ordinary Neumann series (parent entry) do the analytic work on $s := x^{-1}t$. The file fixes an ambient normed ring $R$ with `HasSummableGeomSeries R` (every Banach algebra), opens the `Topology` scope and `Finset`, and exposes a named API: `factor_sub`, `isUnit_sub`, `neumann_series_sub`, its `HasSum` form, the two-sided-inverse lemmas, `neumann_sub_partial_remainder`, and `inverse_sub_continuousAt`.",
+    "mathContext": "For a unit $x$ with $\\lVert x^{-1}t\\rVert<1$: $(x-t)^{-1}=\\left(\\sum_{n\\ge0}(x^{-1}t)^n\\right)x^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Neumann series",
+      "units in a Banach algebra",
+      "perturbation of a unit",
+      "resolvent",
+      "openness of the unit group",
+      "analyticity of inversion"
+    ],
+    "prerequisites": [
+      "the Neumann series for 1 − t",
+      "units and order-reversing inverse of a product",
+      "Ring.inverse on units"
+    ]
+  },
+  {
+    "id": "ann-factorization",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 55,
+      "endLine": 62
+    },
+    "type": "tactic",
+    "title": "The factorization x − t = x · (1 − x⁻¹ t)",
+    "content": "factor_sub is the algebraic engine of the file: for a unit $x$ and any $t$, $x - t = x\\,(1 - x^{-1}t)$. The proof is pure ring algebra — distribute, then cancel $x\\cdot x^{-1}=1$ via `Units.mul_inv` — so it needs no analysis at all; the theorem is marked `omit [HasSummableGeomSeries R]` to drop the unused geometric-series typeclass. This identity is what reduces the whole perturbed theory to the identity-perturbation Neumann series applied to $s = x^{-1}t$.",
+    "mathContext": "$x - t = x(1 - x^{-1}t)$, valid for any unit $x$ and any $t$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "factoring out a unit",
+      "distributive law",
+      "Units.mul_inv"
+    ],
+    "prerequisites": [
+      "ring arithmetic",
+      "units of a ring"
+    ]
+  },
+  {
+    "id": "ann-invertibility",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "Invertibility of x − t",
+    "content": "isUnit_sub shows that if $\\lVert x^{-1}t\\rVert<1$ then $x-t$ is a unit. Rewriting through `factor_sub`, $x-t$ becomes the product $x\\,(1-x^{-1}t)$ of two units: $x$ is a unit by hypothesis, and $1-x^{-1}t$ is a unit because the sharp Neumann bound $\\lVert x^{-1}t\\rVert<1$ makes `isUnit_one_sub_of_norm_lt_one` fire. This is the qualitative heart of the perturbed Neumann series and the local form of the openness of the unit group.",
+    "mathContext": "$\\lVert x^{-1}t\\rVert < 1 \\Rightarrow x - t \\in R^\\times$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "units are open",
+      "product of units",
+      "isUnit_one_sub_of_norm_lt_one"
+    ],
+    "prerequisites": [
+      "units of a normed ring",
+      "the factorization x − t = x(1 − x⁻¹ t)"
+    ]
+  },
+  {
+    "id": "ann-series",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 78,
+      "endLine": 97
+    },
+    "type": "concept",
+    "title": "The perturbed Neumann series",
+    "content": "neumann_series_sub is the main identity: $(x-t)^{-1} = \\left(\\sum_n (x^{-1}t)^n\\right)x^{-1}$. The proof realises $x-t$ as the value of the unit $x\\cdot\\mathrm{Units.oneSub}(x^{-1}t)$, applies `Ring.inverse_unit` and the order-reversing product inverse `mul_inv_rev` — so the series lands on the *left* of $x^{-1}$, as noncommutativity demands — and rewrites the inner inverse of $1-x^{-1}t$ back to the geometric series via `geom_series_eq_inverse`. hasSum_neumann_series_sub records the same fact as a `HasSum` by multiplying the geometric `HasSum` on the right by $x^{-1}$ (`HasSum.mul_right`). Setting $x=1$ recovers the parent's $(1-t)^{-1}=\\sum_n t^n$.",
+    "mathContext": "$(x-t)^{-1} = \\left(\\sum_{n\\ge0}(x^{-1}t)^n\\right)x^{-1}$, with the series on the left of $x^{-1}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Neumann series",
+      "order-reversing inverse of a product",
+      "geom_series_eq_inverse",
+      "HasSum.mul_right"
+    ],
+    "prerequisites": [
+      "Ring.inverse on units",
+      "Units.oneSub and val_oneSub",
+      "the geometric series in a Banach algebra"
+    ]
+  },
+  {
+    "id": "ann-two-sided",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 102,
+      "endLine": 113
+    },
+    "type": "tactic",
+    "title": "Two-sided inverse",
+    "content": "neumann_sub_mul_left and neumann_sub_mul_right verify that $\\left(\\sum_n (x^{-1}t)^n\\right)x^{-1}$ is a genuine two-sided inverse of $x-t$: multiplying on either side gives $1$. Each proof rewrites the series back to $\\mathrm{Ring.inverse}(x-t)$ via neumann_series_sub and then applies `Ring.inverse_mul_cancel` / `Ring.mul_inverse_cancel` with the unit witness `isUnit_sub`.",
+    "mathContext": "$\\left(\\sum_n (x^{-1}t)^n\\right)x^{-1}(x-t) = (x-t)\\left(\\sum_n (x^{-1}t)^n\\right)x^{-1} = 1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "two-sided inverse",
+      "Ring.inverse_mul_cancel",
+      "unit witness"
+    ],
+    "prerequisites": [
+      "the perturbed Neumann series",
+      "cancellation for Ring.inverse on units"
+    ]
+  },
+  {
+    "id": "ann-truncation",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 118,
+      "endLine": 135
+    },
+    "type": "concept",
+    "title": "Finite truncation with remainder",
+    "content": "neumann_sub_partial_remainder gives the exact truncation $(x-t)^{-1} = \\left(\\sum_{i<N}(x^{-1}t)^i\\right)x^{-1} + (x^{-1}t)^N (x-t)^{-1}$. The proof passes through the helper identity $(x-t)^{-1} = (1-x^{-1}t)^{-1}x^{-1}$ and Mathlib's `NormedRing.inverse_one_sub_nth_order'` for the inner factor, distributing $x^{-1}$ on the right. Since $\\lVert (x^{-1}t)^N\\rVert \\to 0$, the truncation approximates the inverse to any accuracy — the basis of preconditioned iterative inversion, where $x$ plays the role of the preconditioner / splitting matrix.",
+    "mathContext": "$(x-t)^{-1} = \\left(\\sum_{i<N}(x^{-1}t)^i\\right)x^{-1} + (x^{-1}t)^N (x-t)^{-1}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "truncation with remainder",
+      "iterative inversion",
+      "preconditioning / matrix splitting",
+      "inverse_one_sub_nth_order'"
+    ],
+    "prerequisites": [
+      "the perturbed Neumann series",
+      "the nth-order remainder for 1 − s"
+    ]
+  },
+  {
+    "id": "ann-continuity",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 140,
+      "endLine": 150
+    },
+    "type": "concept",
+    "title": "Local continuity of inversion",
+    "content": "inverse_sub_continuousAt shows that $t \\mapsto (x-t)^{-1}$ is continuous at every base point $t_0$ with $\\lVert x^{-1}t_0\\rVert<1$. The proof takes the unit witness from `isUnit_sub`, invokes `NormedRing.inverse_continuousAt` at the unit $x-t_0$, and composes with the continuous map $t\\mapsto x-t$. This is the local statement whose global form is the openness of the unit group and whose refinement — expanding the Neumann series as a convergent power series — is the analyticity of inversion and the holomorphy of the resolvent $(\\lambda-T)^{-1}$.",
+    "mathContext": "$t \\mapsto (x-t)^{-1}$ is continuous at each $t_0$ with $\\lVert x^{-1}t_0\\rVert<1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "continuity of inversion",
+      "openness of the unit group",
+      "resolvent",
+      "local analyticity"
+    ],
+    "prerequisites": [
+      "continuity of Ring.inverse at a unit",
+      "composition of continuous maps"
+    ]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+    "range": {
+      "startLine": 151,
+      "endLine": 182
+    },
+    "type": "concept",
+    "title": "Summary",
+    "content": "The table collects the eight results and their Mathlib backing. Setting $x=1$ collapses every statement to the parent entry `GeometricSeriesOQ02OQ03OQ01`. The sharp hypothesis $\\lVert x^{-1}t\\rVert<1$ — weaker, in a noncommutative ring, than Mathlib's $\\lVert t\\rVert<\\lVert x^{-1}\\rVert^{-1}$ — means the series converges on the largest ball guaranteeing $1-x^{-1}t$ invertible, and `inverse_sub_continuousAt` is the local step behind the openness of the unit group and the holomorphy of the resolvent in spectral theory.",
+    "mathContext": "$x=1$ recovers the parent Neumann series; the file is the local model for the analyticity of inversion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Banach-algebra spectral theory",
+      "resolvent holomorphy",
+      "perturbation theory"
+    ],
+    "prerequisites": [
+      "the results of Parts I–VI"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/index.ts
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOq02Oq03Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOq02Oq03Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOq02Oq03Oq01Oq03Data: ProofData = {
+  proof: geometricSeriesOq02Oq03Oq01Oq03Proof,
+  annotations: geometricSeriesOq02Oq03Oq01Oq03Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+  "title": "Geometric Series OQ-02-03-01-03: The Neumann Series for a Perturbed Unit x − t",
+  "slug": "geometric-series-oq-02-oq-03-oq-01-oq-03",
+  "description": "Generalizes the Neumann series (1 − t)⁻¹ = ∑' n, tⁿ from a perturbation of the identity to a perturbation of an arbitrary unit x: if x is a unit in a normed ring with summable geometric series and ‖x⁻¹ t‖ < 1, then x − t is invertible with (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹. The whole result rests on the factorization x − t = x · (1 − x⁻¹ t), reducing the perturbed inverse to the ordinary Neumann series applied to s = x⁻¹ t. Packages the factorization, the unit property, the series identity and its HasSum form, the two-sided-inverse relations, the finite truncation with explicit remainder (x⁻¹ t)ᴺ·(x − t)⁻¹, and the local continuity of t ↦ (x − t)⁻¹ — the first step toward local analyticity of inversion. 8 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "neumann-series",
+      "normed-ring",
+      "banach-algebra",
+      "operator-inverse",
+      "perturbation-theory",
+      "resolvent"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified; #print axioms reports only propext, Classical.choice, and Quot.sound. Built on Mathlib's geom_series_eq_inverse, isUnit_one_sub_of_norm_lt_one, Units.oneSub / Units.val_oneSub, Ring.inverse_unit, Ring.(inverse_)mul_cancel, NormedRing.inverse_one_sub_nth_order', and NormedRing.inverse_continuousAt.",
+    "lineCount": 182,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "factor_sub: the algebraic identity x − t = x · (1 − x⁻¹ t), the engine reducing a perturbation of a unit to a perturbation of the identity",
+      "neumann_series_sub: (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹ for a unit x with ‖x⁻¹ t‖ < 1 — the perturbed Neumann series, sharp hypothesis, handling noncommutativity via the Units API",
+      "isUnit_sub: a perturbation of a unit by t with ‖x⁻¹ t‖ < 1 stays a unit",
+      "neumann_sub_mul_left / neumann_sub_mul_right: the series is a genuine two-sided inverse of x − t",
+      "neumann_sub_partial_remainder: the finite truncation (∑_{i<N} (x⁻¹ t)ⁱ)·x⁻¹ + (x⁻¹ t)ᴺ·(x − t)⁻¹",
+      "inverse_sub_continuousAt: t ↦ (x − t)⁻¹ is continuous at every point with ‖x⁻¹ t‖ < 1, the local step toward analyticity of inversion"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Neumann series (I − T)⁻¹ = ∑ Tⁿ, introduced by Carl Neumann in the 1870s for integral equations, inverts a perturbation of the identity. The passage to a perturbation of an arbitrary invertible element x — writing x − t = x(1 − x⁻¹t) and expanding — is the standard device by which functional analysis proves that the group of units of a Banach algebra is open and that inversion is analytic: every unit has a whole ball of units around it, on which the inverse is given by a convergent power series in the perturbation. Specialized to x = λ·1 and t = T this is exactly the resolvent expansion (λ − T)⁻¹ = ∑ λ^{-(n+1)} Tⁿ that makes the resolvent a holomorphic function of λ, the analytic backbone of spectral theory.",
+    "problemStatement": "Generalize the Neumann series from 1 − t to x − t for an arbitrary unit x: show that ‖x⁻¹ t‖ < 1 implies x − t is invertible with inverse (∑' n, (x⁻¹ t)ⁿ)·x⁻¹, and package the invertibility, the series and its HasSum form, the two-sided-inverse relations, the truncation-with-remainder, and the local continuity of t ↦ (x − t)⁻¹.",
+    "text": "Factor x − t = x·(1 − x⁻¹t). With s := x⁻¹t and ‖s‖ < 1, the inner factor 1 − s is invertible by the ordinary Neumann series, so x − t is a product of two units and hence a unit. Taking inverses (in the correct, order-reversing way for a possibly noncommutative ring), (x − t)⁻¹ = (1 − s)⁻¹·x⁻¹ = (∑' n, sⁿ)·x⁻¹. The truncation identity for 1 − s multiplies through by x⁻¹ to give (x − t)⁻¹ = (∑_{i<N} sⁱ)·x⁻¹ + sᴺ·(x − t)⁻¹, and continuity of Ring.inverse at the unit x − t yields continuity of t ↦ (x − t)⁻¹.",
+    "proofStrategy": "Work over a NormedRing R with [HasSummableGeomSeries R]. factor_sub is pure ring algebra plus Units.mul_inv (it omits the geometric-series typeclass). isUnit_sub factors and multiplies the unit witnesses x.isUnit and isUnit_one_sub_of_norm_lt_one. neumann_series_sub realizes x − t as ↑(x · Units.oneSub s h), applies Ring.inverse_unit and the order-reversing mul_inv_rev on units, and rewrites the inner inverse via geom_series_eq_inverse. The HasSum form multiplies the geometric HasSum on the right by x⁻¹. The two-sided-inverse relations rewrite the series back to Ring.inverse (x − t) and apply Ring.inverse_mul_cancel / mul_inverse_cancel. neumann_sub_partial_remainder rewrites through the helper (x − t)⁻¹ = (1 − s)⁻¹·x⁻¹ and Mathlib's inverse_one_sub_nth_order'. inverse_sub_continuousAt composes NormedRing.inverse_continuousAt with the continuous map t ↦ x − t.",
+    "keyInsights": [
+      "The single factorization x − t = x·(1 − x⁻¹ t) reduces the entire perturbed theory to the identity-perturbation Neumann series — no new analysis is needed, only the geometric series for s = x⁻¹ t",
+      "The sharp hypothesis is ‖x⁻¹ t‖ < 1, exactly what makes 1 − x⁻¹ t a unit; in a noncommutative ring this is strictly weaker than Mathlib's ‖t‖ < ‖x⁻¹‖⁻¹ used by Units.add / NormedRing.inverse_add, since ‖x⁻¹ t‖ ≤ ‖x⁻¹‖‖t‖ can be small even when ‖t‖ is not",
+      "Noncommutativity forces the order-reversed inverse (x·u)⁻¹ = u⁻¹·x⁻¹, so the series sits on the LEFT of x⁻¹: (x − t)⁻¹ = (∑' (x⁻¹ t)ⁿ)·x⁻¹, not x⁻¹·(∑' ...)",
+      "Continuity of t ↦ (x − t)⁻¹ at every ‖x⁻¹ t‖ < 1 is the local statement whose global form is the openness of the unit group and whose refinement is the holomorphy of the resolvent"
+    ],
+    "prerequisites": [
+      "The Neumann series (1 − t)⁻¹ = ∑' n, tⁿ for ‖t‖ < 1 (parent entry)",
+      "Units of a ring and the order-reversing inverse of a product",
+      "Ring.inverse and its behaviour on units",
+      "Continuity of inversion in a normed ring"
+    ]
+  },
+  "conclusion": {
+    "summary": "Fully machine-verified generalization of the Neumann series to a perturbed unit: for a unit x with ‖x⁻¹ t‖ < 1, x − t is invertible and (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ)·x⁻¹, packaged with the factorization x − t = x·(1 − x⁻¹ t), the HasSum form, the two-sided-inverse relations, the finite truncation with explicit remainder (x⁻¹ t)ᴺ·(x − t)⁻¹, and the local continuity of t ↦ (x − t)⁻¹. Zero axioms, zero sorries.",
+    "implications": "This is the local model for the analyticity of inversion: around any unit x, every nearby element x − t (with ‖x⁻¹ t‖ < 1) is a unit whose inverse is a convergent power series in the perturbation. It is the mechanism behind the openness of the unit group of a Banach algebra and, specialized to x = λ·1, behind the holomorphy of the resolvent (λ − T)⁻¹ — the entry point to spectral theory and the holomorphic functional calculus. Taking x = 1 collapses every statement to the parent Neumann-series entry.",
+    "openQuestions": [
+      "Upgrade inverse_sub_continuousAt to full analyticity: express t ↦ (x − t)⁻¹ as a convergent power series (AnalyticAt) via the packaged Neumann expansion",
+      "Bound the truncation error ‖(x − t)⁻¹ − (∑_{i<N} (x⁻¹ t)ⁱ)·x⁻¹‖ ≤ ‖x⁻¹ t‖ᴺ·‖x⁻¹‖/(1 − ‖x⁻¹ t‖)",
+      "Specialize x = λ·1, t = T to obtain the resolvent expansion (λ − T)⁻¹ = ∑ λ^{-(n+1)} Tⁿ and its holomorphy in λ"
+    ]
+  },
+  "leanFile": {
+    "namespace": "GeometricSeriesOQ02OQ03OQ01OQ03",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-02-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry establishes the Neumann series (1 − t)⁻¹ = ∑' n, tⁿ for a perturbation of the identity. This entry generalizes it to a perturbation x − t of an arbitrary unit x, via the factorization x − t = x·(1 − x⁻¹ t); setting x = 1 recovers the parent's statements verbatim."
+    }
+  ],
+  "sections": [
+    {
+      "id": "factorization",
+      "title": "Part I: The factorization x − t = x · (1 − x⁻¹ t)",
+      "startLine": 50,
+      "endLine": 62,
+      "summary": "factor_sub is the pure-algebra identity x − t = x·(1 − x⁻¹ t) (using only Units.mul_inv; it omits the geometric-series typeclass). This turns a perturbation of the unit x into a perturbation of the identity, ready for the ordinary Neumann series."
+    },
+    {
+      "id": "invertibility",
+      "title": "Part II: Invertibility of x − t",
+      "startLine": 63,
+      "endLine": 73,
+      "summary": "isUnit_sub: if ‖x⁻¹ t‖ < 1 then x − t is a unit, as a product of the unit x and the unit 1 − x⁻¹ t (isUnit_one_sub_of_norm_lt_one)."
+    },
+    {
+      "id": "series",
+      "title": "Part III: The perturbed Neumann series",
+      "startLine": 74,
+      "endLine": 97,
+      "summary": "neumann_series_sub: (x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ)·x⁻¹, realizing x − t as ↑(x · Units.oneSub (x⁻¹ t) h), applying the order-reversing unit inverse and geom_series_eq_inverse. hasSum_neumann_series_sub records the HasSum form by multiplying the geometric HasSum on the right by x⁻¹."
+    },
+    {
+      "id": "two-sided",
+      "title": "Part IV: Two-sided inverse",
+      "startLine": 98,
+      "endLine": 113,
+      "summary": "neumann_sub_mul_left and neumann_sub_mul_right confirm (∑' (x⁻¹ t)ⁿ)·x⁻¹ is a genuine two-sided inverse of x − t, via Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness isUnit_sub."
+    },
+    {
+      "id": "truncation",
+      "title": "Part V: Finite truncation with remainder",
+      "startLine": 114,
+      "endLine": 135,
+      "summary": "neumann_sub_partial_remainder: (x − t)⁻¹ = (∑_{i<N} (x⁻¹ t)ⁱ)·x⁻¹ + (x⁻¹ t)ᴺ·(x − t)⁻¹, obtained from the helper (x − t)⁻¹ = (1 − x⁻¹ t)⁻¹·x⁻¹ and Mathlib's inverse_one_sub_nth_order'."
+    },
+    {
+      "id": "continuity",
+      "title": "Part VI: Local continuity of inversion",
+      "startLine": 136,
+      "endLine": 150,
+      "summary": "inverse_sub_continuousAt: t ↦ (x − t)⁻¹ is continuous at every t₀ with ‖x⁻¹ t₀‖ < 1, by composing NormedRing.inverse_continuousAt (at the unit x − t₀) with the continuous map t ↦ x − t. The first quantitative step toward local analyticity of inversion."
+    },
+    {
+      "id": "summary",
+      "title": "Part VII: Summary",
+      "startLine": 151,
+      "endLine": 182,
+      "summary": "Tabulates the results, notes that x = 1 collapses each to the parent Neumann-series entry, and situates local continuity as the source of the openness of the unit group and the holomorphy of the resolvent (λ − T)⁻¹."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question **geometric-series-oq-02-oq-03-oq-01-oq-03** (OQ #3 of the Neumann-series parent entry): *generalize the Neumann series to `(x − t)⁻¹` for an arbitrary unit `x` with `‖x⁻¹ t‖ < 1`, giving local analyticity of inversion.*

New file `proofs/Proofs/GeometricSeriesOQ02OQ03OQ01OQ03.lean` (**8 theorems, 0 definitions, 0 axioms, 0 sorries**; `#print axioms` → `propext, Classical.choice, Quot.sound` only). Docker build clean on Mathlib v4.26.0.

## Mathematical content

Everything rests on the factorization `x − t = x · (1 − x⁻¹ t)`, reducing a perturbation of an arbitrary unit to a perturbation of the identity, where the ordinary Neumann series applies to `s := x⁻¹ t`:

- `factor_sub` — the algebraic identity `x − t = x · (1 − x⁻¹ t)` (pure ring algebra; omits the unused `HasSummableGeomSeries` typeclass).
- `isUnit_sub` — `x − t` is a unit (product of the unit `x` and the unit `1 − x⁻¹ t`).
- `neumann_series_sub` — **`(x − t)⁻¹ = (∑' n, (x⁻¹ t)ⁿ) · x⁻¹`**, with the series on the *left* of `x⁻¹` as noncommutativity demands (order-reversing `(x·u)⁻¹ = u⁻¹·x⁻¹`).
- `hasSum_neumann_series_sub` — the `HasSum` form.
- `neumann_sub_mul_left` / `neumann_sub_mul_right` — genuine two-sided inverse.
- `neumann_sub_partial_remainder` — finite truncation `(∑_{i<N}(x⁻¹ t)ⁱ)·x⁻¹ + (x⁻¹ t)ᴺ·(x − t)⁻¹`.
- `inverse_sub_continuousAt` — `t ↦ (x − t)⁻¹` is continuous at every `‖x⁻¹ t₀‖ < 1`, the local step toward analyticity of inversion.

**Sharp hypothesis.** The condition is `‖x⁻¹ t‖ < 1` — exactly what makes `1 − x⁻¹ t` invertible. In a noncommutative ring this is strictly weaker than Mathlib's `‖t‖ < ‖x⁻¹‖⁻¹` (used by `Units.add` / `NormedRing.inverse_add`), since `‖x⁻¹ t‖ ≤ ‖x⁻¹‖‖t‖` can be small even when `‖t‖` is not. Setting `x = 1` collapses every statement to the parent entry.

## Gallery integration

`src/data/proofs/geometric-series-oq-02-oq-03-oq-01-oq-03/` — `meta.json`, `annotations.json`, `index.ts`. `pnpm annotations:build` regenerates `listings.json` / `data-manifest.json` cleanly (entry included). Status `verified`, badge `mathlib`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)