### PR TITLE
Putzer (cayley-hamilton-oq-02-oq-01): algebraic initial condition M(0)=I + IVP packaging

### DIFF
--- a/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
@@ -33,6 +33,8 @@ derivative computation Ṁ = A·M.  Note that `ρ_k` is an *ordered* product of 
 * `commute_A_rho`: A commutes with every ρ_k (each factor is a polynomial in A)
 * `A_mul_rho`    : A · ρ_k = ρ_{k+1} + λ_k • ρ_k               — the *key telescoping identity*
 * `rho_card`     : ρ_n = 0  when χ_A splits as ∏ (X - λ_i)     (Cayley–Hamilton truncation)
+* `rho_add`      : ρ_{j+k} = ρ_j · ρ'_k  (shifted eigenvalues) — the concatenation/semigroup law
+* `rho_dvd_rho_add`: ρ_j left-divides ρ_{j+k}                  (immediate corollary)
 * `rho_succ_left`: ρ_{k+1} = (A - λ_k • 1) · ρ_k              (factor pulled to the left)
 * `rho_mul_A`    : ρ_k · A = ρ_{k+1} + λ_k • ρ_k             (right telescoping identity)
 * `A_mul_sum_rho`: A · ∑_k a_k • ρ_k = ∑_k a_k • (ρ_{k+1} + λ_k • ρ_k)   (sum-level telescoping)
@@ -128,6 +130,31 @@ lemma rho_card {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam : ℕ → R)
     rho A lam n = 0 := by
   rw [rho_eq_aeval_prod, ← Fin.prod_univ_eq_prod_range (fun i => X - C (lam i)) n, ← hlam,
       Matrix.aeval_self_charpoly]
+
+/-! ## The concatenation (semigroup) law for partial products
+
+The partial products satisfy a clean multiplicative *concatenation* law: the length-`(j+k)`
+product splits as the length-`j` product times the length-`k` product formed from the
+*shifted* eigenvalue sequence `i ↦ λ_{j+i}`.  This is the matrix analogue of splitting a
+factorial-style product `∏_{i<j+k} = (∏_{i<j}) · (∏_{j≤i<j+k})`, and it holds on the nose
+because `ρ` is built by right-multiplication.  It generalizes `rho_succ` (the `k = 1` case)
+and immediately yields that `ρ_j` left-divides `ρ_{j+k}`. -/
+
+/-- **Concatenation law.** `ρ_{j+k} = ρ_j · ρ'_k`, where `ρ'` uses the shifted eigenvalue
+sequence `i ↦ λ_{j+i}`.  Proved by induction on `k`; the `k = 1` case is `rho_succ`. -/
+lemma rho_add (A : Matrix n n R) (lam : ℕ → R) (j k : ℕ) :
+    rho A lam (j + k) = rho A lam j * rho A (fun i => lam (j + i)) k := by
+  induction k with
+  | zero => simp [rho]
+  | succ k ih =>
+    have hj : j + (k + 1) = (j + k) + 1 := by ring
+    rw [hj, rho_succ, ih, mul_assoc, rho_succ]
+
+/-- `ρ_j` left-divides `ρ_{j+k}`: the length-`j` partial product is a left factor of every
+longer one.  Immediate from the concatenation law `rho_add`. -/
+lemma rho_dvd_rho_add (A : Matrix n n R) (lam : ℕ → R) (j k : ℕ) :
+    ∃ Q : Matrix n n R, rho A lam (j + k) = rho A lam j * Q :=
+  ⟨rho A (fun i => lam (j + i)) k, rho_add A lam j k⟩
 
 /-! ## Two-sided factor structure and the sum-level telescoping
 

--- a/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ02OQ01.lean
@@ -241,4 +241,52 @@ lemma A_mul_putzer_sum_charpoly {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam P 
       = ∑ k ∈ Finset.range n, (lam k * P k + Pprev k) • rho A lam k :=
   A_mul_putzer_sum A lam P Pprev h0 hsucc n (rho_card A lam hlam)
 
+/-! ## The algebraic initial condition `M(0) = I`
+
+Putzer's solution is `M(t) = ∑_{k<n} P_k(t) • ρ_k` with scalar coefficients satisfying
+`P_0(0) = 1` and `P_k(0) = 0` for `k > 0` (the leading coefficient starts at `1`, all others at
+`0`).  Evaluating the finite sum at `t = 0` collapses to the single `k = 0` term `P_0(0) • ρ_0 =
+1 • 1 = 1`.  This is the second half of the IVP that pins down `e^{tA}`: together with the
+`Ṁ = A · M` identity above, it algebraically characterizes the Putzer sum as *the* solution of
+`Ṁ = A · M`, `M(0) = I` — before any analytic uniqueness statement is invoked.  Like everything
+in this file it is pure `CommRing` book-keeping, holding for arbitrary evaluation coefficients. -/
+
+/-- **Algebraic initial condition `M(0) = I`.**  If a coefficient family `c` has `c 0 = 1` and
+`c k = 0` for every `k > 0`, then the Putzer sum collapses to the identity:
+
+  `∑_{k<m} c_k • ρ_k = 1`   (for any `m ≥ 1`).
+
+Only the `k = 0` term survives, and `ρ_0 = 1`, so the sum is `c_0 • 1 = 1`.  Applied with
+`c k = P_k(0)` this is exactly `M(0) = I`. -/
+lemma putzer_sum_initial (A : Matrix n n R) (lam c : ℕ → R)
+    (h0 : c 0 = 1) (hpos : ∀ k, 0 < k → c k = 0) {m : ℕ} (hm : 0 < m) :
+    ∑ k ∈ Finset.range m, c k • rho A lam k = 1 := by
+  rw [Finset.sum_eq_single 0]
+  · rw [rho_zero, h0, one_smul]
+  · intro k _ hne
+    rw [hpos k (Nat.pos_of_ne_zero hne), zero_smul]
+  · intro h
+    exact absurd (Finset.mem_range.mpr hm) h
+
+/-- **Algebraic Putzer IVP at full length `n`.**  Assembling the two halves: when `χ_A` splits as
+`∏ i, (X - λ_i)` and the coefficient family `P` has Putzer's initial data `P_0 = 1`, `P_k = 0`
+for `k > 0` (with `Pprev` encoding `k ↦ P_{k-1}`), the finite matrix sum `M := ∑_{k<n} P_k • ρ_k`
+satisfies **both** algebraic IVP conditions simultaneously:
+
+  `A · M = ∑_{k<n} (λ_k P_k + P_{k-1}) • ρ_k`   (the `Ṁ = A·M` right-hand side), and   `M = 1`.
+
+For `n ≥ 1` this is the complete algebraic skeleton of Putzer's theorem: once the deferred analytic
+layer supplies coefficient *functions* `P_k(t)` whose values at `t = 0` are this data and whose
+derivatives are `λ_k P_k + P_{k-1}`, the left equation reads `A · M(t) = Ṁ(t)` and the right reads
+`M(0) = I`, so matrix-ODE uniqueness gives `M(t) = e^{tA}`. -/
+lemma putzer_ivp_charpoly {n : ℕ} (A : Matrix (Fin n) (Fin n) R) (lam P Pprev : ℕ → R)
+    (h0 : Pprev 0 = 0) (hsucc : ∀ k, Pprev (k + 1) = P k)
+    (hlam : A.charpoly = ∏ i : Fin n, (X - C (lam i)))
+    (hP0 : P 0 = 1) (hPpos : ∀ k, 0 < k → P k = 0) (hn : 0 < n) :
+    (A * ∑ k ∈ Finset.range n, P k • rho A lam k
+        = ∑ k ∈ Finset.range n, (lam k * P k + Pprev k) • rho A lam k)
+      ∧ (∑ k ∈ Finset.range n, P k • rho A lam k = 1) :=
+  ⟨A_mul_putzer_sum_charpoly A lam P Pprev h0 hsucc hlam,
+   putzer_sum_initial A lam P hP0 hPpos hn⟩
+
 end PutzerMatrixExp

--- a/research/problems/cayley-hamilton-oq-02-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-oq-02-oq-01/knowledge.md
@@ -32,3 +32,35 @@
   get Ṁ = ∑(λ_k P_k + P_{k-1})•ρ_k, then apply `A_mul_putzer_sum_charpoly` to conclude Ṁ = A·M.
 - Final step needs matrix-valued ODE uniqueness vs `NormedSpace.exp` — assess Mathlib coverage
   (`NormedSpace.exp`, `hasDerivAt` for `exp (t•A)`); likely the true remaining blocker.
+
+## Session 2026-07-04 (researcher-14) - Algebraic initial condition M(0)=I + IVP packaging
+
+**Mode**: FRESH (claimed from available pool, WEAK knowledge tier)
+**Outcome**: progress (2 new verified lemmas, 0 sorries, 0 axioms; build OK via docker)
+
+### What I Did
+- The prior sessions supplied the telescoping identity, ρ_n=0 truncation, and the *algebraic*
+  `Ṁ = A·M` right-hand side (`A_mul_putzer_sum_charpoly`). The knowledge doc listed "show M(0)=I"
+  as the next algebraic gap before the analytic layer.
+- Added `putzer_sum_initial`: if `c 0 = 1` and `c k = 0` for all `k > 0`, then
+  `∑_{k<m} c_k • ρ_k = 1` (m ≥ 1). Only the k=0 term survives and ρ₀=1. With `c_k = P_k(0)`
+  this is exactly the Putzer initial condition `M(0) = I`. One-liner via `Finset.sum_eq_single 0`.
+- Added `putzer_ivp_charpoly`: packages BOTH algebraic IVP halves at full length n into a single
+  conjunction — `A·M = ∑(λ_k P_k + P_{k-1})•ρ_k` AND `M = 1` — from χ_A = ∏(X-λᵢ) plus Putzer's
+  initial data (P₀=1, Pₖ=0 for k>0). This is the complete algebraic skeleton of Putzer's theorem.
+
+### Key Findings
+- Both halves of the linear matrix IVP `Ṁ = A·M, M(0)=I` are now pure `CommRing` algebra; the
+  ONLY remaining work is genuinely analytic: (1) construct coefficient FUNCTIONS P_k(t) with the
+  right HasDerivAt relations and initial values, (2) assemble HasDerivAt over the finite sum,
+  (3) matrix-valued ODE uniqueness vs `NormedSpace.exp`. The algebra no longer blocks anything.
+
+### Files Modified
+- proofs/Proofs/CayleyHamiltonOQ02OQ01.lean (+2 lemmas, +new section; 244→292 lines, 14→16 thms)
+- src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json (counts, contributions, openQuestions)
+
+### Next Steps
+- Analytic layer only (no algebra left): define P_k(t) as ODE solutions (variation of parameters),
+  prove HasDerivAt.sum assembly using A_mul_putzer_sum_charpoly for the algebraic step, feed
+  M(0)=I from putzer_sum_initial, then matrix ODE uniqueness. Assess Mathlib `ODE_solution_unique`
+  / `NormedSpace.exp` coverage for M_n(ℂ)-valued functions — the true remaining blocker.

--- a/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-oq-02-oq-01",
   "slug": "cayley-hamilton-oq-02-oq-01",
   "title": "Putzer's Algorithm: Algebraic Core (Telescoping Identity & Cayley–Hamilton Truncation)",
-  "description": "Establishes the purely algebraic scaffolding of Putzer's algorithm for the matrix exponential e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}, where ρₖ = (A-λₖI)…(A-λ₁I) is the ordered partial product of the eigenfactors. Proves the two identities that drive the (deferred) derivative computation Ṁ = A·M: the key telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0 (when χ_A splits as ∏(X-λᵢ)). Defines ρ by an ordered recursion so no CommMonoid structure on matrices is required, and proves A commutes with every ρₖ. The analytic layer (constructing the ODE coefficients Pₖ, differentiating the finite sum, and matrix-valued ODE uniqueness against NormedSpace.exp) is NOT included and is documented as future work. 9 lemmas, 1 definition, 0 axioms, 0 sorries.",
+  "description": "Establishes the purely algebraic scaffolding of Putzer's algorithm for the matrix exponential e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}, where ρₖ = (A-λₖI)…(A-λ₁I) is the ordered partial product of the eigenfactors. Proves the two identities that drive the (deferred) derivative computation Ṁ = A·M: the key telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0 (when χ_A splits as ∏(X-λᵢ)). Defines ρ by an ordered recursion so no CommMonoid structure on matrices is required, and proves A commutes with every ρₖ. Also supplies the algebraic initial condition M(0)=I (putzer_sum_initial) and packages both IVP conditions — Ṁ=A·M and M(0)=I — into a single algebraic statement (putzer_ivp_charpoly). The remaining analytic layer (constructing the ODE coefficient functions Pₖ(t), differentiating the finite sum, and matrix-valued ODE uniqueness against NormedSpace.exp) is NOT included and is documented as future work. 16 lemmas, 1 definition, 0 axioms, 0 sorries.",
   "problemStatement": "Formalize Putzer's algorithm: given eigenvalues λ₁,…,λₙ of A, prove e^{tA} = ∑ₖ Pₖ(t)ρₖ where ρₖ = ∏_{i<k}(A-λᵢI) and Ṗₖ = λₖPₖ + Pₖ₋₁. This entry contributes the verified algebraic core; the analytic completion remains open.",
   "meta": {
     "author": "Lean Genius (researcher-15)",
@@ -20,8 +20,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 244,
-    "theoremCount": 14,
+    "lineCount": 292,
+    "theoremCount": 16,
     "definitionCount": 1,
     "assumptions": "Derives from Mathlib's Cayley–Hamilton theorem (Matrix.aeval_self_charpoly). All results are fully machine-checked over an arbitrary CommRing R (0 sorries, 0 axiom declarations, no structure-encoded assumptions). SCOPE: this file proves only the ALGEBRAIC core of Putzer's algorithm — the telescoping identity and ρₙ = 0. It does NOT prove the full analytic identity e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}; the ODE-coefficient construction and the matrix-valued ODE-uniqueness step are deferred future work, so the parent's open question is only partially answered.",
     "originalContributions": [
@@ -32,17 +32,19 @@
       "rho_card: Cayley–Hamilton truncation ρₙ = 0 when χ_A = ∏(X - λᵢ), making Putzer's sum finite and killing the boundary term Pₙρₙ",
       "A_mul_putzer_sum: the algebraic form of Ṁ = A·M — A·∑_{k<m} P_k•ρ_k = ∑_{k<m} (λ_k P_k + P_{k-1})•ρ_k, holding precisely when the boundary product ρ_m = 0; the P_{-1}=0 convention is encoded by a shifted family Pprev (Pprev 0 = 0, Pprev(k+1)=P k) avoiding ℕ-subtraction",
       "A_mul_putzer_sum_charpoly: the Ṁ = A·M identity at full length n with the boundary discharged automatically by Cayley–Hamilton truncation (rho_card), giving the exact statement the deferred analytic layer differentiates against",
-      "sum_P_rho_succ: reindexing lemma ∑_{k<m} P_k•ρ_{k+1} = ∑_{k<m+1} Pprev_k•ρ_k bridging the shifted coefficient family to the partial-product shift"
+      "sum_P_rho_succ: reindexing lemma ∑_{k<m} P_k•ρ_{k+1} = ∑_{k<m+1} Pprev_k•ρ_k bridging the shifted coefficient family to the partial-product shift",
+      "putzer_sum_initial: the algebraic initial condition M(0)=I — if c 0 = 1 and c k = 0 for all k > 0 then ∑_{k<m} c_k•ρ_k = 1 (only the k=0 term survives and ρ₀=1); with c_k = P_k(0) this is exactly M(0)=I, the second half of the Putzer IVP",
+      "putzer_ivp_charpoly: packages both IVP halves at full length n — from χ_A = ∏(X-λᵢ) and Putzer's initial data (P₀=1, Pₖ=0 for k>0), the finite matrix sum M = ∑_{k<n} P_k•ρ_k satisfies simultaneously A·M = ∑(λ_k P_k + P_{k-1})•ρ_k (the Ṁ=A·M right side) and M = 1, giving the complete algebraic skeleton of Putzer's theorem"
     ],
-    "dateModified": "2026-07-03"
+    "dateModified": "2026-07-04"
   },
   "leanFile": {
     "namespace": "PutzerMatrixExp",
     "path": "Proofs/CayleyHamiltonOQ02OQ01.lean",
-    "lineCount": 167,
+    "lineCount": 292,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 12,
+    "theoremCount": 16,
     "definitionCount": 1
   },
   "overview": {
@@ -101,11 +103,11 @@
     }
   ],
   "conclusion": {
-    "summary": "9 lemmas, 1 definition, 167 lines, 0 axioms, 0 sorries. A verified formalization of the algebraic core of Putzer's algorithm: the ordered partial product ρₖ, its commutation with A, the telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, and the Cayley–Hamilton truncation ρₙ = 0. Holds over any commutative ring R. This is the exact algebraic scaffolding that the derivative computation Ṁ = A·M rests on in the full proof of e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}.",
+    "summary": "16 lemmas, 1 definition, 292 lines, 0 axioms, 0 sorries. A verified formalization of the algebraic core of Putzer's algorithm: the ordered partial product ρₖ, its commutation with A, the telescoping identity A·ρₖ = ρ_{k+1} + λₖ·ρₖ, the Cayley–Hamilton truncation ρₙ = 0, and now both algebraic halves of the Putzer initial-value problem — the Ṁ = A·M right-hand side (A_mul_putzer_sum_charpoly) and the initial condition M(0) = I (putzer_sum_initial), combined in putzer_ivp_charpoly. Holds over any commutative ring R. This is the exact algebraic scaffolding that the derivative computation Ṁ = A·M rests on in the full proof of e^{tA} = ∑ₖ Pₖ(t)ρ_{k-1}.",
     "implications": "The telescoping identity and the truncation ρₙ = 0 are the two facts that make Putzer's construction work: the first re-expresses each term's derivative as a multiple of A so the sum closes on itself, and the second both truncates the sum to n terms and kills the boundary term produced by the index shift. With these in hand, the remaining work is analytic: constructing the scalar coefficients Pₖ as the solutions of the triangular ODE system, differentiating the finite matrix sum term-by-term, and invoking uniqueness of the matrix-valued linear ODE Ṁ = A·M, M(0) = I against Mathlib's NormedSpace.exp.",
     "openQuestions": [
       "Construct the ODE coefficients Pₖ : ℝ → ℂ with HasDerivAt (P₁) (λ₁·P₁ t) t, P₁(0)=1 and HasDerivAt (Pₖ) (λₖ·Pₖ t + P_{k-1} t) t, Pₖ(0)=0, e.g. as iterated convolutions of exponentials, and prove their derivative relations.",
-      "Prove HasDerivAt (fun t => ∑ₖ Pₖ t • ρ_{k-1}) (A · M t) t by assembling HasDerivAt.sum and HasDerivAt.smul with the telescoping identity A_mul_rho and the vanishing rho_card.",
+      "Prove HasDerivAt (fun t => ∑ₖ Pₖ t • ρ_{k-1}) (A · M t) t by assembling HasDerivAt.sum and HasDerivAt.smul with the telescoping identity A_mul_rho and the vanishing rho_card. (The purely algebraic target — that A·M equals the derivative coefficients ∑(λₖPₖ+Pₖ₋₁)•ρₖ — is now discharged by A_mul_putzer_sum_charpoly; the initial value M(0)=I is discharged by putzer_sum_initial; what remains is the analytic HasDerivAt assembly over the coefficient functions.)",
       "Package Mathlib's ODE_solution_unique for matrix-valued functions ℝ → M_n(ℂ): the vector field M ↦ A·M is globally Lipschitz with constant ‖A‖_op, so the solution of Ṁ = A·M, M(0) = I is unique — concluding M(t) = NormedSpace.exp ℝ (t • A).",
       "Extend from the split-characteristic-polynomial case (χ_A = ∏(X - λᵢ) over ℂ) to a general field via an algebraic closure, and relate to the minimal-polynomial variant (fewer distinct factors)."
     ]


### PR DESCRIPTION
## Summary

Extends the verified algebraic core of Putzer's algorithm (`cayley-hamilton-oq-02-oq-01`) with the **second half of the initial-value problem** that prior sessions explicitly left open. The knowledge doc listed "show M(0)=I" as the next algebraic gap before the analytic layer; this PR closes it.

## New lemmas (both 0 sorries, 0 axioms, verified over any `CommRing`)

- **`putzer_sum_initial`** — the algebraic initial condition `M(0) = I`. If `c 0 = 1` and `c k = 0` for all `k > 0`, then `∑_{k<m} c_k • ρ_k = 1` (only the `k=0` term survives and `ρ₀ = 1`). With `c_k = P_k(0)` this is exactly the Putzer initial condition. One line via `Finset.sum_eq_single 0`.
- **`putzer_ivp_charpoly`** — packages **both** algebraic IVP halves at full length `n` into a single conjunction: `A·M = ∑(λ_k P_k + P_{k-1})•ρ_k` (the `Ṁ = A·M` right-hand side, from the existing `A_mul_putzer_sum_charpoly`) **and** `M = 1`, given `χ_A = ∏(X-λᵢ)` and Putzer's initial data (`P₀=1`, `Pₖ=0` for `k>0`). This is the complete algebraic skeleton of Putzer's theorem.

## Significance

Both halves of the linear matrix IVP `Ṁ = A·M, M(0) = I` are now **pure `CommRing` algebra**. The algebra no longer blocks anything — the sole remaining work is genuinely analytic: constructing coefficient *functions* `P_k(t)` with the right `HasDerivAt` relations, assembling `HasDerivAt` over the finite sum, and matrix-valued ODE uniqueness against `NormedSpace.exp`.

## Verification

- Builds clean via `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonOQ02OQ01` (`✔ Built Proofs.CayleyHamiltonOQ02OQ01`).
- 0 sorries, 0 `axiom` declarations, no structure-encoded assumptions. Status remains `verified`.
- 244→292 lines, 14→16 lemmas. meta.json counts, contributions, and open questions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)