### PR TITLE
Enrich Cyclic Vectors for Prime-Power Minimal Polynomial μ = qᵏ: de-bundle hard-direction annotation (4→5)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02/annotations.json
@@ -12,16 +12,28 @@
     "prerequisites": ["the irreducible-case characterization", "minimal polynomial of a matrix", "K[X]-module structure of Kⁿ"]
   },
   {
-    "id": "ann-cyc-oq0402-hard",
+    "id": "ann-cyc-oq0402-hard-bezout",
     "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
-    "range": { "startLine": 52, "endLine": 91 },
+    "range": { "startLine": 52, "endLine": 71 },
     "type": "insight",
-    "title": "Hard direction: Bézout + the divisor structure of a prime power",
-    "content": "cyclic_of_qkm1_ne_zero is the substantive theorem. Suppose $q^{k-1}(M)\\,v \\ne 0$, yet some nonzero $p$ with $\\deg p < n$ annihilates $v$. Two mechanisms combine. First, the parent's Bézout lemma gcd_aeval_mulVec_eq_zero pushes the annihilation down to the gcd: $d = \\gcd(p,\\mu)$ satisfies $d(M)\\,v = 0$. Second, because $q$ is prime and $d \\mid q^k$, dvd_prime_pow forces $d$ to be associated to $q^j$ for some $j \\le k$. The exponent cannot be maximal: $j = k$ would give $\\mu = q^k \\mid p$, impossible for a nonzero $p$ of degree $< \\deg\\mu$ (natDegree_le_of_dvd). Hence $j \\le k-1$, so $d \\mid q^{k-1}$; writing $q^{k-1} = e\\cdot d$ and reordering the commuting evaluations $e(M), d(M)$ yields $q^{k-1}(M)\\,v = e(M)\\,(d(M)\\,v) = 0$ — contradicting the hypothesis. So no such $p$ exists and $v$ is cyclic.",
-    "mathContext": "$d=\\gcd(p,q^k)\\sim q^j$, $j\\le k-1 \\Rightarrow d \\mid q^{k-1} \\Rightarrow q^{k-1}(M)\\,v = e(M)(d(M)\\,v)=0$.",
+    "title": "Hard direction, step 1: Bézout reduces the annihilator to a prime power",
+    "content": "cyclic_of_qkm1_ne_zero is the substantive theorem, proved by contradiction: assume $q^{k-1}(M)\\,v \\ne 0$ yet some nonzero $p$ with $\\deg p < n$ annihilates $v$ (unfolding IsCyclicVector via `intro p hp hann; by_contra`). The proof then structures the arbitrary annihilator $p$ into something rigid. First, the parent's Bézout lemma gcd_aeval_mulVec_eq_zero pushes the annihilation down to the gcd: setting $d = \\gcd(p,\\mu)$, one gets $d(M)\\,v = 0$, with $d \\mid p$ and $d \\mid \\mu$. Second, because $q$ is prime (Irreducible.prime) and $d \\mid q^k$, dvd_prime_pow forces $d$ to be *associated to a pure power* $q^j$ for some $j \\le k$. An unstructured annihilator has become a single exponent $j$ to pin down.",
+    "mathContext": "$d = \\gcd(p,\\mu)$ with $d(M)v = 0$ (Bézout); $d \\mid q^k$ and $q$ prime $\\Rightarrow d \\sim q^j$, $j \\le k$ (dvd_prime_pow).",
     "significance": "key",
-    "relatedConcepts": ["Bézout identity", "gcd of polynomials", "prime power divisors", "associated elements", "commuting matrix polynomials"],
-    "prerequisites": ["gcd_aeval_mulVec_eq_zero (parent)", "dvd_prime_pow", "Irreducible.prime", "natDegree_le_of_dvd", "Matrix.mulVec_mulVec"]
+    "relatedConcepts": ["Bézout identity", "gcd of polynomials", "prime power divisors", "associated elements", "dvd_prime_pow"],
+    "prerequisites": ["gcd_aeval_mulVec_eq_zero (parent)", "dvd_prime_pow", "Irreducible.prime", "EuclideanDomain.gcd"]
+  },
+  {
+    "id": "ann-cyc-oq0402-hard-conclude",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02",
+    "range": { "startLine": 73, "endLine": 91 },
+    "type": "insight",
+    "title": "Hard direction, step 2: the degree obstruction and commuting evaluations",
+    "content": "With $d \\sim q^j$ ($j \\le k$) in hand, two steps finish. The exponent cannot be maximal: $j = k$ would give $\\mu = q^k \\sim d \\mid p$, so $\\mu \\mid p$ and natDegree_le_of_dvd would force $n = \\deg\\mu \\le \\deg p$, contradicting $\\deg p < n$. Hence $j \\le k-1$ (Nat.le_sub_one_of_lt) and $d \\mid q^{k-1}$ (pow_dvd_pow). Writing $q^{k-1} = e\\cdot d$ and using that polynomial evaluations in the *fixed* matrix $M$ commute — map_mul turns the product into a matrix product and Matrix.mulVec_mulVec reassociates the action — gives $q^{k-1}(M)\\,v = e(M)\\,(d(M)\\,v) = e(M)\\,0 = 0$, contradicting the hypothesis $q^{k-1}(M)\\,v \\ne 0$. So no such $p$ exists and $v$ is cyclic.",
+    "mathContext": "$j = k \\Rightarrow \\mu \\mid p \\Rightarrow n \\le \\deg p$ (contradiction); so $d \\mid q^{k-1}$, and $q^{k-1}(M)v = e(M)(d(M)v) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["degree obstruction μ ∤ p", "natDegree_le_of_dvd", "commuting matrix polynomials", "map_mul / aeval", "Matrix.mulVec_mulVec"],
+    "prerequisites": ["natDegree_le_of_dvd", "pow_dvd_pow", "Matrix.mulVec_mulVec", "map_mul for aeval"]
   },
   {
     "id": "ann-cyc-oq0402-easy",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-02` (pass 0, quality 91).

The entry was already rich (meta ~15 KB, well under caps) but had only **4 annotations** — below the role's 5-annotation minimum. The single 'hard direction' annotation covered a 40-line range (52–91) spanning two genuinely distinct proof mechanisms, so I de-bundled it:

- **Step 1 (52–71):** Bézout reduces an arbitrary annihilator `p` to `d = gcd(p, μ)` (via the parent's `gcd_aeval_mulVec_eq_zero`), and `dvd_prime_pow` forces `d ~ qʲ` with `j ≤ k` — turning unstructured data into a single exponent to pin down.
- **Step 2 (73–91):** the degree obstruction rules out `j = k` (else `μ ∣ p`, contradicting `deg p < n` via `natDegree_le_of_dvd`), so `d ∣ qᵏ⁻¹`; commuting evaluations `qᵏ⁻¹ = e·d` then give `qᵏ⁻¹(M)v = e(M)(d(M)v) = 0`, the contradiction.

Verification: JSON valid; `check-meta-size.ts` within caps; annotation ranges (4-44, 52-71, 73-91, 93-114, 116-128) non-overlapping and within the 132-line Lean file; all claims cross-checked against the source. No meta.json / status / axiom changes (remains verified, 0 axioms).