### PR TITLE
Research: ramsey-r4k-extensions-oq-03 (XV) — globalize deletion-window monotonicity

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -359,6 +359,49 @@ theorem deletionBound_mono_of_unionFeasible (hk : 2 ≤ k) (hkn : k ≤ n)
     deletionBound n k ≤ deletionBound (n + 1) k :=
   deletionBound_mono_of_pred_subthreshold hk hkn (by omega)
 
+/-- **The deletion bound is monotone across the entire `(k−1)` sub-threshold window.**
+    `deletionBound_mono_of_pred_subthreshold` shows a *single* step `n → n+1` never
+    decreases the deletion bound while `2·C(n,k−1) < 2^C(k,2)`.  Chaining that step by
+    induction gives the *global* statement its docstring only asserts: if the `(k−1)`
+    first moment stays subthreshold throughout the interval `[n, N)`, i.e.
+
+        `∀ m ∈ [n, N),  2·C(m,k−1) < 2^C(k,2)`,
+
+    then `deletionBound n k ≤ deletionBound N k` for the whole run.  In particular the
+    deletion optimum is attained no earlier than the *top* of the `(k−1)`-window
+    `2·C(·,k−1) < 2^C(k,2)`, which strictly contains the union window
+    `2·C(·,k) < 2^C(k,2)` (since `C(m,k−1) ≤ C(m,k)` on the increasing arm).  This is the
+    general, `decide`-free source of the alteration method's advantage over the sharp
+    union bound: the union bound stalls at the top of the `k`-window, the deletion bound
+    keeps climbing to the top of the wider `(k−1)`-window.  Axiom-free. -/
+theorem deletionBound_mono_window (hk : 2 ≤ k) {n : ℕ} (hkn : k ≤ n) :
+    ∀ N, n ≤ N → (∀ m, n ≤ m → m < N → 2 * m.choose (k - 1) < 2 ^ (k.choose 2)) →
+      deletionBound n k ≤ deletionBound N k := by
+  intro N hnN
+  induction N, hnN using Nat.le_induction with
+  | base => intro _; exact le_refl _
+  | succ N hnN ih =>
+      intro hsub
+      exact le_trans (ih (fun m hm hmN => hsub m hm (Nat.lt_succ_of_lt hmN)))
+        (deletionBound_mono_of_pred_subthreshold hk (le_trans hkn hnN)
+          (hsub N hnN (Nat.lt_succ_self N)))
+
+/-- **Ramsey form: the guaranteed mono-free set never shrinks across the `(k−1)`-window.**
+    For any host size `N` reachable from `n` without the `(k−1)` first moment crossing
+    threshold, the deletion method on `K_N` certifies a monochromatic-`Kₖ`-free set at
+    least as large as the one it certifies at `n`.  Combined with the strict window-width
+    gap this is exactly the mechanism behind the concrete `+1/+2/+3/+4` witnesses at
+    `k = 6,7,8,9`: each sits at the top of its `(k−1)`-window, strictly past the union
+    cap.  Immediate from `deletionBound_mono_window` and `ramsey_deletion_bound`. -/
+theorem deletion_noloss_across_window (hk : 2 ≤ k) {n N : ℕ} (hkn : k ≤ n) (hnN : n ≤ N)
+    (hsub : ∀ m, n ≤ m → m < N → 2 * m.choose (k - 1) < 2 ^ (k.choose 2)) :
+    ∃ (c : Coloring N) (R : Finset (Fin N)),
+      deletionBound n k ≤ R.card ∧
+      ∀ K : Finset (Fin N), K ⊆ R → K.card = k → ¬ Mono c K := by
+  obtain ⟨c, R, hRcard, hR⟩ :=
+    ramsey_deletion_bound (n := N) (k := k) hk (le_trans hkn hnN)
+  exact ⟨c, R, le_trans (deletionBound_mono_window hk hkn N hnN hsub) hRcard, hR⟩
+
 set_option maxHeartbeats 800000 in
 /-- **The sharp union bound caps at `n = 17` for `k = 6`.**  The first-moment test
     `2·C(n,6) < 2^{C(6,2)} = 2^{15}` holds at `n = 17` (`2·12376 = 24752 < 32768`) but
@@ -535,6 +578,8 @@ theorem deletion_no_mono_K9 :
 #check @ramsey_deletion_one_past
 #check @deletionBound_mono_of_pred_subthreshold
 #check @deletionBound_mono_of_unionFeasible
+#check @deletionBound_mono_window
+#check @deletion_noloss_across_window
 #check @deletion_no_mono_K6
 #check @unionBound_caps_at_27_for_K7
 #check @deletion_no_mono_K7
@@ -555,6 +600,8 @@ theorem deletion_no_mono_K9 :
 #print axioms ramsey_deletion_one_past
 #print axioms deletionBound_mono_of_pred_subthreshold
 #print axioms deletionBound_mono_of_unionFeasible
+#print axioms deletionBound_mono_window
+#print axioms deletion_noloss_across_window
 #print axioms deletion_no_mono_K6
 #print axioms unionBound_caps_at_27_for_K7
 #print axioms deletion_no_mono_K7

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -4,36 +4,40 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 14 (PART XIV)
+**Iteration**: 15 (PART XV)
 
 ## Current Focus
-Quantified the deletion window's growth (the direction flagged as the one genuine, non-
-enumeration increment). Two axiom-free theorems in
+Globalized the PART-XIV single-step monotonicity into the window-wide statement its own
+docstring only asserted. Two new axiom-free theorems in
 `Proofs/RamseyR4kExtensionsOQ03Deletion.lean`:
-- `deletionBound_mono_of_pred_subthreshold`: `deletionBound n k ≤ deletionBound (n+1) k`
-  whenever `2·C(n,k−1) < 2^C(k,2)` — the deletion bound is nondecreasing in `n` exactly
-  while the `(k−1)`-clique first moment stays below one quantum.
-- `deletionBound_mono_of_unionFeasible`: same conclusion under `2·C(n,k) < 2^C(k,2)` and
-  `C(n,k−1) ≤ C(n,k)`. Corollary: the deletion optimum lies at least as far out as (and,
-  in the Ramsey regime, strictly beyond) the union optimum — the structural source of the
-  alteration method's `≈ k` gain.
+- `deletionBound_mono_window`: chaining the single step by `Nat.le_induction`,
+  `deletionBound n k ≤ deletionBound N k` whenever `2·C(m,k−1) < 2^C(k,2)` for every
+  `m ∈ [n, N)`. So the deletion optimum is attained no earlier than the *top* of the
+  `(k−1)`-window — the general, `decide`-free statement that the alteration bound keeps
+  climbing past the union cap (top of the strictly narrower `k`-window).
+- `deletion_noloss_across_window`: Ramsey form — for any `N` reachable across the
+  `(k−1)`-window there is a 2-colouring of `K_N` with a monochromatic-`Kₖ`-free set of at
+  least `deletionBound n k` vertices. This is the general mechanism instantiated by the
+  concrete `+1/+2/+3/+4` witnesses at `k = 6,7,8,9`.
 
-The engine is Pascal's rule `C(n+1,k) = C(n,k) + C(n,k−1)` (the exact binomial-ratio step)
-plus a ℕ-floor "jump ≤ 1 per step" lemma; closed by `omega`. No `decide`, no probability.
+PART XIV proved only the single step `n → n+1`; PART XV turns that into the whole run,
+completing the "runs out to the top of the `(k−1)`-window" claim. Pure `Nat` induction on
+top of the existing Pascal-rule step; closed by `le_trans`/`omega`. No `decide`, no
+probability. docker-build clean (7744 jobs), Tier-A axiom-free.
 
 ## Active Approach
 Elementary `Nat`-division monotonicity. docker-build clean (7744 jobs), Tier-A axiom-free
 (`propext / Classical.choice / Quot.sound`).
 
 ## Attempt Count
-- Total attempts: 14
+- Total attempts: 15
 - Current approach attempts: 1
 - Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
   identity, honest union-bound comparison (VII), deletion method (VIII), k=7
   machine-checked witness + compile repair (IX), general M=1 gain theorem (X),
   avoidance_pos numeric premises (XI), k=8 witness via descFactorial (XII),
   general M-window unification theorem (XIII), deletion-window monotonicity via
-  Pascal's rule (XIV)
+  Pascal's rule (XIV), window-wide monotonicity + Ramsey form via Nat.le_induction (XV)
 
 ## Blockers
 - **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
@@ -41,12 +45,14 @@ Elementary `Nat`-division monotonicity. docker-build clean (7744 jobs), Tier-A a
   `lovasz-local-lemma-oq-01`.
 
 ## Next Action
-The axiom-free line is now saturated: the deletion mechanism is stated at full generality
-(`ramsey_deletion_window`, every M), with the window's *monotonic growth* now characterized
-by the `(k−1)`-clique threshold (PART XIV), plus concrete k=6,7,8 witnesses. The only
-remaining genuinely-mathematical increments both require the BLOCKED measure-theoretic LLL:
-either (a) the `SymmetricLLLForRamsey` construction itself, or (b) a Stirling-based
-*asymptotic* statement that the additive window width grows like a constant fraction of the
-union value (needs real analysis / `Nat.choose` asymptotics beyond Pascal). Further concrete
-k≥9 witnesses would be enumeration theater. Recommend releasing the claim; the natural next
-worker should target the sibling `lovasz-local-lemma-oq-01` measure-theory core.
+The axiom-free line is now saturated *and* globalized: the deletion mechanism is stated at
+full generality (`ramsey_deletion_window`, every M), its window's monotonic growth is proved
+both per-step (PART XIV) and window-wide (`deletionBound_mono_window`, PART XV), with a Ramsey
+existence form (`deletion_noloss_across_window`) and concrete k=6,7,8,9 witnesses. The only
+remaining genuinely-mathematical increments both need machinery beyond elementary `Nat`:
+either (a) the BLOCKED `SymmetricLLLForRamsey` measure-theoretic construction (>1000 lines),
+or (b) a Stirling-based *asymptotic* proof that the additive window width grows like a
+constant fraction of the union value — i.e. `Nat.choose` ratio asymptotics beyond Pascal's
+rule (real analysis, not `omega`). Further concrete k≥10 witnesses would be enumeration
+theater. Recommend releasing the claim; the natural next worker should target the sibling
+`lovasz-local-lemma-oq-01` measure-theory core, or attempt (b) with `Nat.choose` asymptotics.


### PR DESCRIPTION
## Summary

Continues the axiom-free **deletion (alteration) method** line for diagonal Ramsey lower bounds (`ramsey-r4k-extensions-oq-03`). PART XIV proved that a *single* host-size step `n → n+1` never lowers the deletion bound while the `(k−1)`-clique first moment stays subthreshold (`2·C(n,k−1) < 2^C(k,2)`), but its docstring only **asserted** the window-wide consequence. This PR proves it.

### New theorems (both axiom-free)

- **`deletionBound_mono_window`** — by `Nat.le_induction` over the existing single-step lemma:
  `deletionBound n k ≤ deletionBound N k` whenever `2·C(m,k−1) < 2^C(k,2)` for every `m ∈ [n, N)`.
  So the deletion optimum is attained no earlier than the **top of the `(k−1)`-window** — the general, `decide`-free statement that the alteration bound keeps climbing past the union cap (top of the strictly narrower `k`-window). This is the structural source of the alteration method's `≈ k` gain over the union bound.
- **`deletion_noloss_across_window`** — Ramsey existence form: for any `N` reachable across the `(k−1)`-window there is a 2-colouring of `K_N` with a monochromatic-`Kₖ`-free set of at least `deletionBound n k` vertices. This is the general mechanism the concrete `+1/+2/+3/+4` witnesses at `k = 6,7,8,9` instantiate.

### Method

Pure `Nat` induction on top of the existing Pascal-rule single step (`deletionBound_mono_of_pred_subthreshold`); closed by `le_trans`/`omega`. No `decide`, no probability measure.

### Verification

- `docker-build.sh Proofs.RamseyR4kExtensionsOQ03Deletion` — **clean, 7744 jobs**.
- `#print axioms` confirms both new theorems depend only on `propext / Classical.choice / Quot.sound` (Tier-A axiom-free — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`).

### Scope / honest boundary

The remaining genuinely-mathematical increments need machinery beyond elementary `Nat`: either the BLOCKED `SymmetricLLLForRamsey` measure-theory construction (>1000 lines; see sibling `lovasz-local-lemma-oq-01`), or a Stirling-based asymptotic that the window width grows like a constant fraction of the union value (`Nat.choose` ratio asymptotics beyond Pascal). Further concrete `k ≥ 10` witnesses would be enumeration theater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)