### PR TITLE
MZ SLLN OQ-01-02-01: variance-sum finiteness (ℝ≥0∞) from Integrable |X|ᵖ

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1501,9 +1501,40 @@ theorem lintegral_tsum_trunc_sq_weight_le_moment
 
 #check @lintegral_tsum_trunc_sq_weight_le_moment
 
+/-- **Finiteness of the MZ variance sum (ℝ≥0∞).**  For a measurable `X` with finite `p`-th
+absolute moment (`Integrable |X|ᵖ`) and `0 < p < 2`, the `i^{-2/p}`-weighted sum of the truncated
+second moments is finite:
+
+    ∑'ᵢ ∫⁻ ω, i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)²  < ∞.
+
+Proof: bound by the master estimate `lintegral_tsum_trunc_sq_weight_le_moment`
+`= ofReal(C)·∫⁻ ω, |X ω|ᵖ`; the constant factor is `< ∞` (`ENNReal.ofReal_lt_top`) and the moment
+factor is `< ∞` because `Integrable (fun ω => |X ω|ᵖ)` transfers, via
+`hasFiniteIntegral_iff_ofReal` on the nonnegative integrand `|X|ᵖ`, to
+`∫⁻ ω, ofReal(|X ω|ᵖ) < ∞`; then `ENNReal.mul_lt_top`.
+
+This is exactly the summability hypothesis of the Kolmogorov weighted criterion
+`ae_tendsto_average_zero_of_variance_weighted_bdd` (S5) applied to the centered truncations
+`Yᵢ − 𝔼Yᵢ` (`aᵢ = i^{1/p}`), the final analytic input to the Marcinkiewicz–Zygmund SLLN. -/
+theorem tsum_lintegral_trunc_sq_weight_lt_top
+    (X : Ω → ℝ) (hX : Measurable X) {p : ℝ} (hp : 0 < p) (hp2 : p < 2)
+    (hint : Integrable (fun ω => |X ω| ^ p) μ) :
+    ∑' i : ℕ, ∫⁻ ω, ENNReal.ofReal
+        ((i : ℝ) ^ (-(2 / p)) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) ∂μ
+      < ∞ := by
+  refine (lintegral_tsum_trunc_sq_weight_le_moment X hX hp hp2).trans_lt ?_
+  apply ENNReal.mul_lt_top ENNReal.ofReal_lt_top
+  -- `∫⁻ ω, ofReal(|X ω|ᵖ) < ∞` from `Integrable (fun ω => |X ω|ᵖ)` via the nonneg iff.
+  have hnn : (0 : Ω → ℝ) ≤ᵐ[μ] fun ω => |X ω| ^ p :=
+    ae_of_all _ (fun ω => Real.rpow_nonneg (abs_nonneg _) _)
+  exact (hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral
+
+#check @tsum_lintegral_trunc_sq_weight_lt_top
+
 -- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
 -- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
 #print axioms lintegral_tsum_trunc_sq_weight_le_moment
+#print axioms tsum_lintegral_trunc_sq_weight_lt_top
 
 end MasterVarianceBound
 

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 *Tonelli interchange* — the ∑ᵢ–𝔼 lower-integral interchange itself SHIPPED & VERIFIED — remaining: RHS-integrand finiteness extraction + assembly)
+**Phase**: ACT (S4b step-4 variance sum — master bound + ℝ≥0∞ finiteness SHIPPED & VERIFIED — remaining: real-summable conversion + S5 feed + step-3 centering + assembly)
 **Since**: 2026-07-04
-**Iteration**: 13 (S4b step-4 **Tonelli interchange** `lintegral_tsum_trunc_sq_weight_le`: `∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral (unconditional for nonneg, sidestepping Bochner `integral_tsum`'s `∑∫‖·‖<∞` which is the very finiteness sought), then `lintegral_mono` dominates the pointwise `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω` via `ENNReal.ofReal_tsum_of_nonneg` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 16 (S4b step-4 **ℝ≥0∞ finiteness** `tsum_lintegral_trunc_sq_weight_lt_top`: for `Integrable |X|ᵖ`, `0<p<2`, the weighted variance sum `∑'ᵢ ∫⁻ i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)² < ∞` — `.trans_lt` the iter-15 master bound then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` with moment factor finite via `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral` (`hnn` by `Real.rpow_nonneg`) — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs, PR #34406; iter 15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`; iter 14 RHS-integrand domination `trunc_rpow_weight_sq_le_rpow`; iter 13 S4b step-4 **Tonelli interchange** `lintegral_tsum_trunc_sq_weight_le`: `∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral (unconditional for nonneg, sidestepping Bochner `integral_tsum`'s `∑∫‖·‖<∞` which is the very finiteness sought), then `lintegral_mono` dominates the pointwise `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω` via `ENNReal.ofReal_tsum_of_nonneg` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -131,12 +131,22 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
   (const pull, needs only `ofReal_ne_top` — no measurability), `lintegral_mono` + `ENNReal.ofReal_mul`
   + `trunc_rpow_weight_sq_le_rpow`. **This is the quantitative `∑ᵢ Var(Yᵢ)/aᵢ² ≤ C·𝔼|X|ᵖ`.**
   **Do not re-derive.**
-- **Next: extract real finiteness + feed S5.** From `Integrable (fun ω => |X ω|ᵖ)` (⟹
-  `∫⁻ ofReal(|X|ᵖ) < ∞` via `Integrable.lintegral_lt_top`/`hasFiniteIntegral` + `ofReal`/`nnnorm`
-  bridge on the nonneg `|X|ᵖ`), the master bound RHS `ofReal(C)·(finite)` is `< ∞`
-  (`ENNReal.mul_lt_top`), so the ℝ≥0∞ variance sum is finite. Convert to a real
-  `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` (each summand = `(∫⁻ …).toReal` via `lintegral_ofReal`/`ofReal_toReal`),
-  feeding `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
+- **ℝ≥0∞ finiteness extraction is now DONE (iteration 16, PR #34406):**
+  `tsum_lintegral_trunc_sq_weight_lt_top` — for measurable `X`, `0<p<2`, and
+  `Integrable (fun ω => |X ω|ᵖ)`, the whole weighted variance sum is finite:
+  `∑'ᵢ ∫⁻ i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)² < ∞`. Proof: `.trans_lt` the iter-15 master bound
+  `lintegral_tsum_trunc_sq_weight_le_moment` (`= ofReal(C)·∫⁻|X|ᵖ`), then
+  `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` with the moment factor finite via
+  `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral` (nonneg iff on integrand
+  `|X|ᵖ`; `hnn : (0:Ω→ℝ) ≤ᵐ[μ] fun ω => |X ω|ᵖ` from `Real.rpow_nonneg`). **Do not re-derive.**
+  **Gotcha:** the naive route `Integrable.lintegral_lt_top` does NOT exist; the working
+  bridge is `hasFiniteIntegral_iff_ofReal` (in `L1Space/HasFiniteIntegral.lean`), which needs
+  the pointwise-nonneg `0 ≤ᵐ[μ] f` hypothesis.
+- **Next: convert to a real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` + feed S5.** From the ℝ≥0∞ finiteness
+  (`tsum_lintegral_trunc_sq_weight_lt_top`): the ℝ≥0∞ tsum is finite ⟹ each term `< ∞`, so
+  each summand `= (∫⁻ …).toReal` via `lintegral_ofReal`/`ofReal_toReal`, then an
+  `ENNReal.tsum_toReal`/`Summable` bridge, feeding
+  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
   (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.
@@ -144,7 +154,8 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
 ## Attempt Counts
 
 - Total attempts: 13 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand; iter-13 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le`)
-- Latest approach attempts: 1 (S4b step-4 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` — `lintegral_tsum` [per-term `Measurable.indicator`∘`measurableSet_le`∘`pow_const`∘`const_mul`∘`ENNReal.measurable_ofReal`] to push `∑'ᵢ` inside `∫⁻`, then `lintegral_mono` + `ENNReal.ofReal_tsum_of_nonneg` [summand summable via `Real.summable_nat_rpow`.`mul_right`.`indicator`] + `tsum_weight_trunc_sq_le`; one binder-type fix [`fun i : ℕ`], then clean build 7743 jobs, 0-axiom)
+- Latest approach attempts: 1 (S4b step-4 ℝ≥0∞ finiteness `tsum_lintegral_trunc_sq_weight_lt_top` — `.trans_lt` iter-15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`, then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` + `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral`; landed clean on first build, 7743 jobs, 0-axiom, PR #34406)
+- Prior approach attempts: 1 (S4b step-4 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` — `lintegral_tsum` [per-term `Measurable.indicator`∘`measurableSet_le`∘`pow_const`∘`const_mul`∘`ENNReal.measurable_ofReal`] to push `∑'ᵢ` inside `∫⁻`, then `lintegral_mono` + `ENNReal.ofReal_tsum_of_nonneg` [summand summable via `Real.summable_nat_rpow`.`mul_right`.`indicator`] + `tsum_weight_trunc_sq_le`; one binder-type fix [`fun i : ℕ`], then clean build 7743 jobs, 0-axiom)
 - Prior approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;
   S3 natural-filtration martingale + upcrossing engine; S4a orthogonality + eLpNorm bridge;


### PR DESCRIPTION
## Summary

Advances the Marcinkiewicz–Zygmund SLLN formalization (`laws-of-large-numbers-oq-01-oq-02-oq-01`) by one leaf: **finiteness extraction** from the master variance-sum bound.

Adds one theorem to `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`:

```lean
theorem tsum_lintegral_trunc_sq_weight_lt_top
    (X : Ω → ℝ) (hX : Measurable X) {p : ℝ} (hp : 0 < p) (hp2 : p < 2)
    (hint : Integrable (fun ω => |X ω| ^ p) μ) :
    ∑' i : ℕ, ∫⁻ ω, ENNReal.ofReal
        ((i : ℝ) ^ (-(2 / p)) * ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2) ∂μ
      < ∞
```

## Mathematical content

The prior iteration shipped the **master variance-sum bound** (in ℝ≥0∞)

    ∑'ᵢ ∫⁻ ω, i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)²  ≤  ofReal((2/p)/(2/p−1)) · ∫⁻ ω, |X ω|ᵖ.

This PR extracts finiteness: given `Integrable (fun ω => |X ω|ᵖ)`, the RHS is `ofReal(C) · (finite)`, hence `< ∞`. The moment factor's finiteness transfers from integrability via `hasFiniteIntegral_iff_ofReal` on the nonnegative integrand `|X|ᵖ`; the product is bounded by `ENNReal.mul_lt_top` with `ENNReal.ofReal_lt_top`.

This is exactly the **summability hypothesis** consumed by the S5 Kolmogorov weighted criterion `ae_tendsto_average_zero_of_variance_weighted_bdd`, applied to the centered truncations `Yᵢ − 𝔼Yᵢ` with weights `aᵢ = i^{1/p}` — the final analytic input to the SLLN before step-3 centering and assembly.

## Verification

- **Build**: `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built (7743 jobs, exit 0)**.
- **Axioms**: `tsum_lintegral_trunc_sq_weight_lt_top` depends on `[propext, Classical.choice, Quot.sound]` only — **0 sorry, 0 axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)