### PR TITLE
Enrich Single-Letter Fano Converse for the BEC: MAP/collision intuition annotation (4→5)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-bec-oq-03/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "ann-bec-oq03-overview",
+        "proofId": "shannon-channel-coding-bec-oq-03",
+        "range": { "startLine": 1, "endLine": 63 },
+        "type": "concept",
+        "title": "An Axiom-Free Step Toward the BEC Converse",
+        "content": "The base entry proves the binary erasure channel's INFORMATION capacity C(bec p) = (1−p)·log 2 axiom-free, and the sibling oq-02 obtains the OPERATIONAL coding theorem only by invoking the framework's abstract axioms channel_coding_achievability / channel_coding_converse. This file threads a genuinely axiom-free needle between them: it instantiates the gallery's already-PROVED abstract single-letter Fano converse fano_converse_shannon_form — (1 − P_e)·log|α| ≤ channelCapacity ch + h(P_e) — at the concrete channel bec with the uniform Bernoulli(1/2) input. The single channel-specific ingredient is a closed-form computation of the Fano collision-error term P_e, which for the uniform-input BEC collapses to exactly p/2. Because fano_converse_shannon_form and the underlying fano_inequality are THEOREMS (not axioms), the specialisation introduces no assumptions: status 'verified', badge 'original', axiomCount 0. SCOPE (stated honestly in the header): this is the single-letter (one channel use) converse; it does NOT discharge the block-coding axiom channel_coding_converse, which additionally needs the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C — the open remaining piece.",
+        "mathContext": "$(1 - P_e)\\log|\\alpha| \\le \\mathrm{channelCapacity}\\,\\mathrm{ch} + h(P_e)$ specialised at $\\mathrm{ch} = \\mathrm{bec}\\,p$, uniform input, with $P_e = p/2$ and $C = (1-p)\\log 2$.",
+        "significance": "supporting",
+        "relatedConcepts": ["binary erasure channel", "Fano's inequality", "channel-coding converse", "single-letter vs block converse", "information-theoretic vs operational"],
+        "prerequisites": ["the base BEC capacity entry", "the proved abstract Fano converse fano_converse_shannon_form", "binary entropy function"]
+    },
+    {
+        "id": "ann-bec-oq03-fano-error",
+        "proofId": "shannon-channel-coding-bec-oq-03",
+        "range": { "startLine": 64, "endLine": 138 },
+        "type": "theorem",
+        "title": "The Fano Error Term Equals p/2 (Closed Form)",
+        "content": "bec_uniform_fano_error proves that the Fano collision-error term P_e = 1 − Σ_y Σ_x P(x,y)²/P(y) of the uniform-input binary erasure channel evaluates in closed form to exactly p/2. The proof works directly over the joint distribution P(x,y) = ½·W(x|y). The outer sum over the erasure alphabet Option Bool is split with Fintype.sum_option into an erasure term (y = none) and a sum over un-erased outputs (y = some b). For y = none the output marginal is p and each of the two inputs contributes (½p)²/p = p/4, summing to p/2. For y = some b the marginal is ½(1−p) and only the matching input x = b is nonzero, contributing (½(1−p))²/(½(1−p)) = ½(1−p); the two symbols give 1−p. Hence Σ_y Σ_x P(x,y)²/P(y) = p/2 + (1−p) = 1 − p/2, so P_e = p/2. The per-output kernel values (hjn, hjs) and output marginals (hden_none, hden_some) come from the parent's bec_W_none / bec_W_some / bec_ymarg_none / bec_ymarg_some; the concrete Bool conditions in the un-erased slice are discharged with explicit if_pos / if_neg rewrites before field_simp; ring.",
+        "mathContext": "$P_e = 1 - \\big(\\tfrac{p}{2} + (1-p)\\big) = \\tfrac{p}{2}$; joint $P(x,y) = \\tfrac12 W(x\\mid y)$, marginals $P(\\mathrm{none}) = p$, $P(\\mathrm{some}\\,b) = \\tfrac12(1-p)$.",
+        "significance": "critical",
+        "relatedConcepts": ["Fano error term", "joint distribution", "output marginal", "erasure channel kernel", "closed-form computation"],
+        "prerequisites": ["bec_W_none / bec_W_some", "bec_ymarg_none / bec_ymarg_some", "Fintype.sum_option / Fintype.sum_bool"]
+    },
+    {
+        "id": "ann-bec-oq03-collision-intuition",
+        "proofId": "shannon-channel-coding-bec-oq-03",
+        "range": { "startLine": 64, "endLine": 138 },
+        "type": "insight",
+        "title": "Why the Error Term Halves: Erasure Collides Two Equiprobable Inputs",
+        "content": "The clean value P_e = p/2 is not a coincidence of the algebra — it has a direct operational reading. The Fano collision term Σ_y Σ_x P(x,y)²/P(y) is the probability that two independent draws from the same posterior P(x | y) agree, averaged over the output y; equivalently 1 − P_e is the probability an ideal maximum-a-posteriori decoder guesses the input correctly on a single use. On an un-erased output (probability 1−p) the decoder learns the bit exactly: the posterior is a point mass, its collision probability is 1, and these outputs contribute the full 1−p to the sum with zero error. On an erasure (probability p) the two equiprobable inputs are perfectly confused: the posterior is uniform on {false, true}, its collision probability is only ½, so an erasure contributes p·½ = p/2 of error. Summing, P_e = p·½ = p/2 — the erasure probability halved precisely because a symmetric two-way tie leaves exactly one bit of residual doubt worth ½ in collision terms. This is why the same fano_converse_shannon_form specialisation, applied to the BSC, will instead pick up that channel's own posterior-collision profile rather than a simple halving.",
+        "mathContext": "$1 - P_e = \\sum_y P(y)\\sum_x P(x\\mid y)^2$ (expected posterior collision); erasure posterior uniform $\\Rightarrow \\sum_x P(x\\mid y)^2 = \\tfrac12$, so erasures give $p\\cdot\\tfrac12 = \\tfrac{p}{2}$ error; un-erased posterior a point mass $\\Rightarrow$ collision $1$, zero error.",
+        "significance": "supporting",
+        "relatedConcepts": ["maximum a posteriori decoding", "posterior collision probability", "binary symmetric channel", "residual uncertainty", "erasure symmetry"],
+        "prerequisites": ["Bayes' rule / posterior distribution", "bec_uniform_fano_error", "binary symmetric channel"]
+    },
+    {
+        "id": "ann-bec-oq03-converse",
+        "proofId": "shannon-channel-coding-bec-oq-03",
+        "range": { "startLine": 140, "endLine": 173 },
+        "type": "theorem",
+        "title": "Single-Letter Fano Converse for the BEC (Axiom-Free)",
+        "content": "bec_single_letter_fano_converse instantiates the proved abstract converse fano_converse_shannon_form at ch := bec p with the uniform input, yielding (1 − p/2)·log 2 ≤ (1 − p)·log 2 + h(p/2). Three inputs feed the specialisation: the uniformity hypothesis (each uniformBool.p x = |Bool|⁻¹, checked directly), the cardinality bound |Bool| = 2 ≥ 2, and the non-negativity of the Fano error term (immediate from P_e = p/2 > 0). The abstract converse's error term is then rewritten by bec_uniform_fano_error and its capacity term by the parent's bec_capacity, and Fintype.card_bool collapses log|Bool| to log 2. Every ingredient is a proved theorem, so #print axioms shows only propext / Classical.choice / Quot.sound — none of the channel-coding framework axioms appear. This is the single-letter engine of the channel-coding converse, made operational and axiom-free for the BEC.",
+        "mathContext": "$(1 - p/2)\\log 2 \\le (1-p)\\log 2 + h(p/2)$, from $\\mathrm{fano\\_converse\\_shannon\\_form}$ with $|\\mathrm{Bool}| = 2$, $C = (1-p)\\log 2$, $P_e = p/2$.",
+        "significance": "critical",
+        "relatedConcepts": ["Fano's inequality", "channel-coding converse", "binary entropy", "channel capacity", "axiom-free specialisation"],
+        "prerequisites": ["fano_converse_shannon_form", "bec_capacity", "bec_uniform_fano_error"]
+    },
+    {
+        "id": "ann-bec-oq03-lower-bound",
+        "proofId": "shannon-channel-coding-bec-oq-03",
+        "range": { "startLine": 175, "endLine": 192 },
+        "type": "theorem",
+        "title": "Rearranged Fano Error Lower Bound",
+        "content": "bec_fano_error_lower_bound isolates the residual error term by the algebraic identity (1 − p/2)·log 2 = (1 − p)·log 2 + (p/2)·log 2, turning the converse into (p/2)·log 2 ≤ h(p/2). Intuitively: the binary entropy of the single-use erasure error p/2 cannot be smaller than (p/2)·log 2 — the residual uncertainty a single BEC use leaves about the input is quantitatively bounded below. The proof rewrites the identity into the converse and finishes with linarith.",
+        "mathContext": "$(p/2)\\log 2 \\le h(p/2)$, via $(1 - p/2)\\log 2 = (1-p)\\log 2 + (p/2)\\log 2$.",
+        "significance": "supporting",
+        "relatedConcepts": ["binary entropy lower bound", "Fano error term", "algebraic rearrangement"],
+        "prerequisites": ["bec_single_letter_fano_converse"]
+    }
+]

--- a/src/data/proofs/shannon-channel-coding-bec-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-03/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "shannon-channel-coding-bec-oq-03",
+  "title": "Single-Letter Fano Converse for the Binary Erasure Channel",
+  "slug": "shannon-channel-coding-bec-oq-03",
+  "description": "Contributes a genuinely axiom-free step toward the operational converse of the binary erasure channel. The sibling entry shannon-channel-coding-bec-oq-02 derives the BEC operational coding theorem only by applying the framework's abstract axioms channel_coding_achievability / channel_coding_converse. This entry instead instantiates the gallery's PROVED abstract single-letter Fano converse fano_converse_shannon_form at the concrete channel bec : DMChannel Bool (Option Bool) with the uniform Bernoulli(1/2) input. The one new ingredient is a closed-form computation: for the uniform-input BEC the Fano collision-error term P_e = 1 - Σ_y Σ_x P(x,y)²/P(y) collapses to exactly p/2 (erasures contribute p/2, un-erased symbols contribute nothing). Substituting the proved capacity bec_capacity = (1-p)·log 2, the cardinality |Bool| = 2, and P_e = p/2 yields the concrete converse (1 - p/2)·log 2 ≤ (1 - p)·log 2 + h(p/2), equivalently (p/2)·log 2 ≤ h(p/2). This is the single-letter engine behind the channel-coding converse, made operational and axiom-free for the BEC. It does NOT discharge the block-coding axiom channel_coding_converse itself (that needs the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C), which remains the open piece. 0 axioms, 0 sorries.",
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 192,
+    "path": "Proofs/ShannonChannelCodingBECOQ03.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Claude Shannon (1948) / Robert Fano (1961), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
+    "date": "1961",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ03.lean",
+    "tags": [
+      "information-theory",
+      "probability",
+      "coding-theory",
+      "channel-capacity",
+      "erasure-channel",
+      "fano-inequality",
+      "converse",
+      "advanced"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.sum_option",
+        "description": "Splits the outer sum over the erasure alphabet Option Bool into the y = none (erasure) term plus the sum over y = some b, the backbone of the closed-form Fano error computation",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Fintype.sum_bool",
+        "description": "Expands the inner sums over the two-element input/output alphabet Bool into the false and true summands",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "log 2 > 0, used implicitly when the converse is read as a lower bound on the binary entropy h(p/2)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "bec_uniform_fano_error: the Fano collision-error term for the uniform-input BEC evaluates in closed form to exactly p/2. Proved by a direct computation over the joint distribution P(x,y) = ½·W(x|y): the erasure output y = none (marginal p) contributes 2·((½p)²/p) = p/2, and each un-erased output y = some b (marginal ½(1-p)) contributes (½(1-p))²/(½(1-p)) = ½(1-p), summing to 1-p; hence Σ_y Σ_x P(x,y)²/P(y) = 1 - p/2 and P_e = p/2.",
+      "bec_single_letter_fano_converse: the proved abstract Fano converse fano_converse_shannon_form specialised to the BEC with uniform input gives (1 - p/2)·log 2 ≤ (1 - p)·log 2 + h(p/2), combining the proved Fano inequality, the proved capacity value bec_capacity, and the closed-form error term. Axiom-free.",
+      "bec_fano_error_lower_bound: the algebraically rearranged form (p/2)·log 2 ≤ h(p/2), isolating the residual error term — the binary entropy of the single-use erasure error p/2 must dominate (p/2)·log 2."
+    ],
+    "assumptions": "0 axioms, 0 sorries. #print axioms confirms every result depends only on the ordinary foundational axioms propext / Classical.choice / Quot.sound — none of the channel-coding framework axioms (channel_coding_achievability, channel_coding_converse) are on the critical path. The proofs use only the gallery's PROVED theorems fano_converse_shannon_form and fano_inequality (both proved in ShannonChannelCoding.lean, not axioms) and the parent's axiom-free capacity value bec_capacity, plus the closed-form joint-distribution computation. No native_decide. SCOPE: this is the SINGLE-LETTER (one channel use) converse. It does NOT discharge the operational block-coding axiom channel_coding_converse, whose proof additionally requires the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C and Fano applied to the block message — that remains the open piece for a fully axiom-free operational converse.",
+    "dateAdded": "2026-07-03",
+    "axiomCount": 0,
+    "lineCount": 192,
+    "prerequisites": [
+      "The binary erasure channel bec : DMChannel Bool (Option Bool), its transition kernel bec_W_none / bec_W_some, and output marginals bec_ymarg_none / bec_ymarg_some (ShannonChannelCodingBEC.lean)",
+      "The proved capacity value bec_capacity : channelCapacity (bec p) = (1 - p) · log 2 (ShannonChannelCodingBEC.lean)",
+      "The proved abstract single-letter Fano converse fano_converse_shannon_form and the Fano inequality (ShannonChannelCoding.lean)",
+      "The binary entropy function h and the uniform input BSCCapacity.uniformBool"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Fano's inequality (1961) is the analytic heart of the converse to Shannon's channel coding theorem: it lower-bounds the conditional entropy H(X|Y) — and hence the decoding error probability — by the residual uncertainty that the channel leaves about the input. For a discrete memoryless channel the single-use converse says (1 - P_e)·log|X| ≤ C + h(P_e), where C is the channel capacity, P_e the Fano error term, and h the binary entropy. The binary erasure channel is the transparent test case: an input bit is either received intact (probability 1-p) or replaced by a known erasure symbol (probability p), giving capacity 1 - p bits.\n\nThe base gallery entry proves the BEC's information capacity (1 - p)·log 2 axiom-free, and the sibling oq-02 obtains the operational coding theorem by invoking the framework's abstract achievability/converse AXIOMS. This entry closes a genuinely axiom-free gap between them: it instantiates the gallery's already-PROVED abstract Fano converse at the BEC, the one channel-specific input being that the uniform-input Fano error term equals exactly p/2.",
+    "problemStatement": "**Single-letter Fano converse for the BEC.** For a binary erasure channel with erasure probability $0 < p < 1$ and the uniform Bernoulli$(1/2)$ input, the Fano collision-error term is exactly $P_e = p/2$, and the proved abstract single-letter Fano converse specialises to\n$$\\left(1 - \\tfrac{p}{2}\\right)\\log 2 \\;\\le\\; (1-p)\\log 2 + h\\!\\left(\\tfrac{p}{2}\\right),$$\nequivalently $\\tfrac{p}{2}\\log 2 \\le h(p/2)$, with $h$ the binary entropy function. Every step is axiom-free.",
+    "text": "Instantiates the gallery's proved abstract Fano converse at the binary erasure channel, using the closed-form uniform-input error term P_e = p/2 and the proved capacity (1-p)·log 2, to obtain the axiom-free single-letter converse.",
+    "proofStrategy": "Three steps, all axiom-free:\n\n1. **Closed-form error term** (`bec_uniform_fano_error`): compute $\\sum_y \\sum_x P(x,y)^2 / P(y)$ over the joint distribution $P(x,y) = \\tfrac12 W(x\\mid y)$. Split the outer sum with `Fintype.sum_option`. For $y = \\text{none}$ (erasure, marginal $p$): both inputs give $(\\tfrac12 p)^2/p = p/4$, summing to $p/2$. For $y = \\text{some }b$ (un-erased, marginal $\\tfrac12(1-p)$): only $x=b$ is nonzero, giving $\\tfrac12(1-p)$, and the two symbols give $1-p$. Total $1 - p/2$, so $P_e = p/2$.\n\n2. **Specialise the Fano converse** (`bec_single_letter_fano_converse`): apply the proved `fano_converse_shannon_form` to `bec p` with uniform input (verifying the uniformity hypothesis and $|\\text{Bool}| = 2 \\ge 2$), then rewrite the error term with step 1 and the capacity with `bec_capacity`.\n\n3. **Rearrange** (`bec_fano_error_lower_bound`): the algebraic identity $(1 - p/2)\\log 2 = (1-p)\\log 2 + (p/2)\\log 2$ turns the converse into the isolated lower bound $(p/2)\\log 2 \\le h(p/2)$ by `linarith`.",
+    "keyInsights": [
+      "The converse's only channel-specific ingredient is the Fano error term, and for the uniform-input BEC it has the strikingly clean closed form P_e = p/2 — the erasure probability halved, because on an erasure the two equiprobable inputs collide symmetrically.",
+      "Because the gallery already PROVES the abstract single-letter Fano converse (fano_converse_shannon_form is a theorem, not an axiom), specialising it introduces no new assumptions: this entry is axiom-free where the sibling oq-02 operational converse is axiomatized.",
+      "The result is the single-letter (one channel use) engine of the converse. Upgrading it to the operational block-coding converse — discharging the channel_coding_converse axiom — additionally requires the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C, which is the genuinely open remaining piece.",
+      "Honesty: #print axioms shows only propext / Classical.choice / Quot.sound. The channel-coding framework axioms never enter, so status is 'verified', not 'axiomatized' — in deliberate contrast to the sibling operational entry.",
+      "The p/2 has a decoder-theoretic reading: 1 − P_e is the expected posterior collision probability, i.e. the single-use success probability of an ideal MAP decoder. Un-erased outputs (prob 1−p) give a point-mass posterior with collision 1 and zero error; erasures (prob p) give a uniform posterior over two inputs with collision ½, contributing p·½. The halving is exactly the ½ collision of a symmetric two-way tie, which is why the same specialisation applied to the BSC picks up that channel's own posterior profile instead."
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Single-Letter Fano Converse — Setup",
+      "summary": "Module header, imports of the parent BEC development, and the honest scope statement: this file supplies the axiom-free single-letter Fano converse for the BEC, instantiating the proved abstract converse rather than assuming the operational axioms",
+      "startLine": 1,
+      "endLine": 63,
+      "mathContext": "Base: $C(\\mathrm{bec}\\,p) = (1-p)\\log 2$ (proved) and the proved abstract converse $(1-P_e)\\log|\\alpha| \\le C + h(P_e)$. Only new input: the uniform-input error term $P_e = p/2$."
+    },
+    {
+      "id": "fano-error",
+      "title": "The Fano Error Term Equals p/2",
+      "summary": "bec_uniform_fano_error: closed-form evaluation of the Fano collision-error term for the uniform-input BEC. Splitting over the erasure alphabet, the erasure output contributes p/2 and the un-erased outputs contribute 1-p, giving Σ P(x,y)²/P(y) = 1 - p/2 and P_e = p/2",
+      "startLine": 64,
+      "endLine": 138,
+      "mathContext": "$P_e = 1 - \\sum_y \\sum_x P(x,y)^2/P(y) = 1 - (p/2 + (1-p)) = p/2$; joint $P(x,y) = \\tfrac12 W(x\\mid y)$, marginals $P(\\text{none}) = p$, $P(\\text{some }b) = \\tfrac12(1-p)$."
+    },
+    {
+      "id": "single-letter-converse",
+      "title": "Single-Letter Fano Converse for the BEC (Axiom-Free)",
+      "summary": "bec_single_letter_fano_converse: the proved fano_converse_shannon_form specialised to the BEC with uniform input yields (1 - p/2)·log 2 ≤ (1 - p)·log 2 + h(p/2), combining the proved Fano inequality, the proved capacity bec_capacity, and the closed-form error term",
+      "startLine": 140,
+      "endLine": 173,
+      "mathContext": "$(1 - p/2)\\log 2 \\le (1-p)\\log 2 + h(p/2)$; from $\\mathrm{fano\\_converse\\_shannon\\_form}$ with $|\\mathrm{Bool}| = 2$, $C = (1-p)\\log 2$, $P_e = p/2$."
+    },
+    {
+      "id": "error-lower-bound",
+      "title": "Rearranged Fano Error Lower Bound",
+      "summary": "bec_fano_error_lower_bound: the algebraic rearrangement (p/2)·log 2 ≤ h(p/2), isolating the residual error term — the binary entropy of the single-use erasure error must dominate (p/2)·log 2",
+      "startLine": 175,
+      "endLine": 192,
+      "mathContext": "$(p/2)\\log 2 \\le h(p/2)$, via $(1 - p/2)\\log 2 = (1-p)\\log 2 + (p/2)\\log 2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the single-letter Fano converse for the binary erasure channel with no axioms: for uniform input the Fano error term is exactly p/2, and the gallery's proved abstract Fano converse then specialises to (1 - p/2)·log 2 ≤ (1 - p)·log 2 + h(p/2), equivalently (p/2)·log 2 ≤ h(p/2). This is the axiom-free single-letter engine of the channel-coding converse, in deliberate contrast to the sibling operational entry oq-02 which invokes the framework's converse axiom.",
+    "implications": "Provides the concrete one-use converse for the BEC entirely from proved results, isolating exactly what remains axiomatic in the operational converse: the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C that lifts the single-letter inequality to block codes. The closed-form error computation P_e = p/2 is a reusable template — the same specialisation of fano_converse_shannon_form applies to the BSC and other concrete channels once their uniform-input Fano error term is computed.",
+    "openQuestions": [
+      "Discharge the operational block-coding axiom channel_coding_converse for the BEC by proving the multi-use data-processing bound I(W; Ŷⁿ) ≤ n·C and applying Fano to the block message, upgrading the sibling oq-02 operational converse from axiomatized to verified.",
+      "Compute the Fano error term and the analogous single-letter converse for the BSC (binary symmetric channel), reusing the fano_converse_shannon_form specialisation pattern established here.",
+      "Strengthen to the strong converse (error → 1 above capacity) and quantify the finite-blocklength dispersion for the BEC."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-bec",
+      "relationship": "extends",
+      "description": "The parent: the BEC information capacity C(bec p) = (1 - p) log 2, proved axiom-free, together with the channel bec, its kernel, and output marginals used in the closed-form error computation."
+    },
+    {
+      "targetId": "shannon-channel-coding-bec-oq-02",
+      "relationship": "sibling",
+      "description": "The operational coding theorem for the BEC, which obtains its converse by INVOKING the abstract axiom channel_coding_converse. This entry instead proves the single-letter Fano converse axiom-free, isolating what remains axiomatic in the operational form."
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "uses",
+      "description": "Supplies the PROVED abstract single-letter Fano converse fano_converse_shannon_form and the Fano inequality (both theorems, not axioms), specialised here to the BEC."
+    },
+    {
+      "targetId": "shannon-channel-coding-bec-oq-01",
+      "relationship": "sibling",
+      "description": "The q-ary erasure channel capacity generalization; a companion open-question offshoot of the same BEC development."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "bec_uniform_fano_error",
+      "type": "core",
+      "description": "The Fano collision-error term of the uniform-input binary erasure channel evaluates in closed form to exactly p/2. Proved by direct computation over the joint distribution: the erasure output contributes p/2 and the un-erased outputs contribute 1-p, so 1 - Σ_y Σ_x P(x,y)²/P(y) = p/2.",
+      "leanType": "0 < p → p < 1 → (1 - ∑ y : Option Bool, ∑ x : Bool, jointDist (bec p ..) uniformBool (x, y) ^ 2 / (∑ x', jointDist (bec p ..) uniformBool (x', y))) = p / 2"
+    },
+    {
+      "name": "bec_single_letter_fano_converse",
+      "type": "core",
+      "description": "The single-letter Fano converse for the BEC, axiom-free: the proved abstract converse fano_converse_shannon_form specialised to the BEC with uniform input, using the closed-form error term p/2 and the proved capacity (1-p)·log 2.",
+      "leanType": "0 < p → p < 1 → (1 - p / 2) * Real.log 2 ≤ (1 - p) * Real.log 2 + h (p / 2)"
+    },
+    {
+      "name": "bec_fano_error_lower_bound",
+      "type": "corollary",
+      "description": "The rearranged form isolating the residual error term: the binary entropy of the single-use erasure error p/2 must dominate (p/2)·log 2.",
+      "leanType": "0 < p → p < 1 → (p / 2) * Real.log 2 ≤ h (p / 2)"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Robert M. Fano"
+      ],
+      "title": "Transmission of Information: A Statistical Theory of Communications",
+      "year": 1961,
+      "venue": "MIT Press",
+      "note": "Origin of Fano's inequality, the analytic core of the channel-coding converse."
+    },
+    {
+      "authors": [
+        "Thomas M. Cover",
+        "Joy A. Thomas"
+      ],
+      "title": "Elements of Information Theory",
+      "year": 2006,
+      "venue": "Wiley (2nd ed.)",
+      "note": "Fano's inequality and the converse to the channel coding theorem; the binary erasure channel as a worked example."
+    },
+    {
+      "authors": [
+        "David J. C. MacKay"
+      ],
+      "title": "Information Theory, Inference, and Learning Algorithms",
+      "year": 2003,
+      "venue": "Cambridge University Press",
+      "note": "Accessible treatment of the erasure channel, capacity, and the binary entropy function."
+    }
+  ]
+}


### PR DESCRIPTION
Enrichment pass for `shannon-channel-coding-bec-oq-03` (Single-Letter Fano Converse for the BEC).

The entry was already strong (17 KB, well under the 60 KB cap) but sat at the 4-annotation floor. This pass reaches the ≥5-annotation quality minimum with genuinely new mathematical content, then stops (no accretion):

- **New annotation `ann-bec-oq03-collision-intuition`** (insight): explains *why* the Fano error term collapses to exactly `p/2` via the maximum-a-posteriori / posterior-collision reading — un-erased outputs give a point-mass posterior (collision 1, zero error), erasures give a uniform posterior over two inputs (collision ½), so error = `p·½ = p/2`. Ties the halving to symmetric two-way confusion and notes why the same `fano_converse_shannon_form` specialisation yields a different profile for the BSC.
- **New keyInsight** (5th): the decoder-theoretic reading of `1 − P_e` as the ideal single-use MAP success probability.

No content deleted; size 17.4 → 17.9 KB, still far under cap. `npx tsx scripts/gallery/check-meta-size.ts` passes; `pnpm build` passes.
