### PR TITLE
Erdős #3: verify the (log N)^{1+δ}-threshold reduction (0-axiom) + repair bitrot

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -164,6 +164,221 @@ theorem required_bound_implies_conjecture :
   -- gap documented at `StrongRequiredBound`.
   sorry
 
+/- ## Constructive reduction at the `(log N)^{1+δ}` threshold
+
+   `RequiredBound` (the `o(N/log N)` threshold) is not known to imply the
+   conjecture (see the `StrongRequiredBound` docstring for the counterexample
+   profile). The strictly stronger `StrongRequiredBound` threshold
+   `r_k(N) = O(N/(log N)^{1+δ})`, however, *does* imply it, via an honest
+   dyadic-blocking + p-series argument. We prove that reduction below as a
+   fully machine-checked, 0-axiom conditional theorem. It isolates exactly the
+   analytic strength Erdős #3 is missing: the gap between `o(N/log N)` and
+   `O(N/(log N)^{1+δ})`. -/
+
+/-- Monotonicity of `ContainsAP` in the length: containing an `m`-term progression
+    implies containing every shorter `k`-term progression (`k ≤ m`), since the
+    first `k` terms of that progression already lie in `A`. -/
+theorem containsAP_of_le {A : Set ℕ} {k m : ℕ} (hkm : k ≤ m)
+    (h : ContainsAP A m) : ContainsAP A k := by
+  obtain ⟨a, d, hd, hsub⟩ := h
+  refine ⟨a, d, hd, subset_trans ?_ hsub⟩
+  rw [Finset.coe_subset]
+  apply Finset.image_subset_image
+  intro x hx
+  rw [Finset.mem_range] at hx ⊢
+  omega
+
+/-- **Analytic core of the reduction.**
+    If the counting function of `A` obeys `f_A(N) ≤ C · N / (log N)^{1+δ}` for all
+    large `N` (`δ > 0`), then `∑_{a ∈ A} 1/a` converges. Proof by dyadic blocking:
+    the reciprocal mass of the block `A ∩ [2^j, 2^{j+1})` is at most
+    `f_A(2^{j+1}) / 2^j ≤ 2C / ((j+1)·log 2)^{1+δ}`, the general term of a convergent
+    `p`-series (`p = 1 + δ > 1`). -/
+theorem summable_of_strongBound {A : Set ℕ} {C δ : ℝ} (hδ : 0 < δ) (hC : 0 < C)
+    (hbound : ∀ᶠ N in atTop,
+      (countingFunction A N : ℝ) ≤ C * (N : ℝ) / (Real.log N) ^ (1 + δ)) :
+    Summable (fun n : A => (1 : ℝ) / (n : ℝ)) := by
+  classical
+  set F : ℕ → ℝ := fun n => (1 : ℝ) / (n : ℝ) with hF
+  have hlog2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  set K : ℝ := 2 * C / (Real.log 2) ^ (1 + δ) with hKdef
+  have hKpos : 0 < K := by rw [hKdef]; positivity
+  set g : ℕ → ℝ := fun j => K / ((j : ℝ) + 1) ^ (1 + δ) with hgdef
+  have hg_nonneg : ∀ j, 0 ≤ g j := by intro j; rw [hgdef]; positivity
+  -- g is summable: it is a constant multiple of a p-series with p = 1 + δ > 1.
+  have hg_summable : Summable g := by
+    have hp : (1 : ℝ) < 1 + δ := by linarith
+    have h1 : Summable (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ (1 + δ)) :=
+      Real.summable_one_div_nat_rpow.mpr hp
+    have h2 : Summable (fun n : ℕ => (1 : ℝ) / ((n : ℝ) + 1) ^ (1 + δ)) := by
+      have h1' := (summable_nat_add_iff 1).mpr h1
+      simpa using h1'
+    rw [hgdef]
+    simpa [mul_one_div] using h2.mul_left K
+  -- Threshold beyond which the counting bound holds.
+  obtain ⟨N0, hN0⟩ := eventually_atTop.1 hbound
+  -- Dyadic block masses.
+  set block : ℕ → ℝ := fun j => ∑ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), A.indicator F i
+    with hblockdef
+  -- Every term of block j is ≤ 1/2^j (since 2^j ≤ i).
+  have hterm_le : ∀ j, ∀ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)),
+      A.indicator F i ≤ 1 / (2 : ℝ) ^ j := by
+    intro j i hi
+    rw [Finset.mem_Ico] at hi
+    have h2j : (2 : ℝ) ^ j ≤ (i : ℝ) := by exact_mod_cast hi.1
+    by_cases hmem : i ∈ A
+    · rw [Set.indicator_of_mem hmem, hF]
+      exact one_div_le_one_div_of_le (by positivity) h2j
+    · rw [Set.indicator_of_not_mem hmem]; positivity
+  -- Crude bound: every block has mass ≤ 1.
+  have hcrude : ∀ j, block j ≤ 1 := by
+    intro j
+    simp only [hblockdef]
+    calc ∑ i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), A.indicator F i
+        ≤ ∑ _i ∈ Finset.Ico (2 ^ j) (2 ^ (j + 1)), (1 / (2 : ℝ) ^ j) :=
+          Finset.sum_le_sum (hterm_le j)
+      _ = (Finset.Ico (2 ^ j) (2 ^ (j + 1))).card • (1 / (2 : ℝ) ^ j) := by
+          rw [Finset.sum_const]
+      _ = 1 := by
+          rw [Nat.card_Ico, nsmul_eq_mul]
+          have hsub : 2 ^ (j + 1) - 2 ^ j = 2 ^ j := by rw [pow_succ]; omega
+          rw [hsub, Nat.cast_pow, Nat.cast_ofNat, mul_one_div,
+            div_self (by positivity)]
+  -- Strong bound: for j ≥ N0, block mass ≤ g j.
+  have hstrong : ∀ j, N0 ≤ j → block j ≤ g j := by
+    intro j hj
+    have hbe : block j
+        = ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i := by
+      simp only [hblockdef, Set.indicator_apply]
+      rw [← Finset.sum_filter]
+    have hN0le : N0 ≤ 2 ^ (j + 1) :=
+      le_trans hj (le_trans (Nat.le_succ j) (Nat.le_of_lt Nat.lt_two_pow_self))
+    have hcb := hN0 (2 ^ (j + 1)) hN0le
+    have hcard : ((Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A)).card
+        ≤ countingFunction A (2 ^ (j + 1)) := by
+      rw [countingFunction]
+      apply Finset.card_le_card
+      intro x hx
+      rw [Finset.mem_filter, Finset.mem_Ico] at hx
+      rw [Finset.mem_filter, Finset.mem_range]
+      exact ⟨by omega, hx.2⟩
+    have hlogval : Real.log ((2 ^ (j + 1) : ℕ) : ℝ) = ((j : ℝ) + 1) * Real.log 2 := by
+      rw [Nat.cast_pow, Nat.cast_ofNat, Real.log_pow]; push_cast; ring
+    have hden : (Real.log ((2 ^ (j + 1) : ℕ) : ℝ)) ^ (1 + δ)
+        = ((j : ℝ) + 1) ^ (1 + δ) * (Real.log 2) ^ (1 + δ) := by
+      rw [hlogval, Real.mul_rpow (by positivity) (le_of_lt hlog2)]
+    have hnum : ((2 ^ (j + 1) : ℕ) : ℝ) = (2 : ℝ) ^ j * 2 := by
+      rw [Nat.cast_pow, Nat.cast_ofNat, pow_succ]
+    rw [hbe]
+    calc ∑ i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), F i
+        ≤ ∑ _i ∈ (Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A), (1 / (2 : ℝ) ^ j) := by
+          apply Finset.sum_le_sum
+          intro i hi
+          rw [Finset.mem_filter, Finset.mem_Ico] at hi
+          rw [hF]
+          exact one_div_le_one_div_of_le (by positivity) (by exact_mod_cast hi.1.1)
+      _ = (((Finset.Ico (2 ^ j) (2 ^ (j + 1))).filter (· ∈ A)).card : ℝ) * (1 / (2 : ℝ) ^ j) := by
+          rw [Finset.sum_const, nsmul_eq_mul]
+      _ ≤ (countingFunction A (2 ^ (j + 1)) : ℝ) * (1 / (2 : ℝ) ^ j) := by
+          apply mul_le_mul_of_nonneg_right _ (by positivity)
+          exact_mod_cast hcard
+      _ ≤ (C * ((2 ^ (j + 1) : ℕ) : ℝ) / (Real.log ((2 ^ (j + 1) : ℕ) : ℝ)) ^ (1 + δ))
+            * (1 / (2 : ℝ) ^ j) := by
+          apply mul_le_mul_of_nonneg_right _ (by positivity)
+          exact hcb
+      _ = g j := by
+          simp only [hgdef, hKdef]
+          rw [hden, hnum]
+          have ha : (2 : ℝ) ^ j ≠ 0 := by positivity
+          have hb : ((j : ℝ) + 1) ^ (1 + δ) ≠ 0 := by positivity
+          have hc : (Real.log 2) ^ (1 + δ) ≠ 0 := by positivity
+          field_simp
+  -- Combine into a uniform partial-sum bound and conclude summability.
+  have hcombine : ∀ j, block j ≤ (if j < N0 then (1 : ℝ) else 0) + g j := by
+    intro j
+    by_cases hjN0 : j < N0
+    · simp only [hjN0, if_true]
+      linarith [hcrude j, hg_nonneg j]
+    · simp only [hjN0, if_false, zero_add]
+      exact hstrong j (Nat.le_of_not_lt hjN0)
+  have hind0 : A.indicator F 0 = 0 := by simp [Set.indicator_apply, hF]
+  have hdyadic : ∀ J : ℕ, ∑ i ∈ Finset.Ico 1 (2 ^ J), A.indicator F i
+      = ∑ j ∈ Finset.range J, block j := by
+    intro J
+    induction J with
+    | zero => simp
+    | succ J ih =>
+      rw [Finset.sum_range_succ, ← ih]
+      simp only [hblockdef]
+      exact (Finset.sum_Ico_consecutive (A.indicator F)
+        (Nat.one_le_pow J 2 (by norm_num))
+        (Nat.pow_le_pow_right (by norm_num) (Nat.le_succ J))).symm
+  suffices hind : Summable (A.indicator F) by
+    exact summable_subtype_iff_indicator.mpr hind
+  apply summable_of_sum_range_le (c := (N0 : ℝ) + ∑' j, g j)
+  · intro n
+    exact Set.indicator_nonneg (fun i _ => by rw [hF]; positivity) n
+  · intro M
+    have hsubM : Finset.range M ⊆ Finset.range (2 ^ M) := by
+      intro x hx
+      rw [Finset.mem_range] at hx ⊢
+      exact lt_of_lt_of_le hx (Nat.le_of_lt Nat.lt_two_pow_self)
+    have hle1 : ∑ i ∈ Finset.range M, A.indicator F i
+        ≤ ∑ i ∈ Finset.range (2 ^ M), A.indicator F i := by
+      apply Finset.sum_le_sum_of_subset_of_nonneg hsubM
+      intro i _ _
+      exact Set.indicator_nonneg (fun a _ => by rw [hF]; positivity) i
+    have hsplit : ∑ i ∈ Finset.range (2 ^ M), A.indicator F i
+        = ∑ i ∈ Finset.Ico 1 (2 ^ M), A.indicator F i := by
+      rw [Finset.range_eq_Ico,
+        ← Finset.sum_Ico_consecutive (A.indicator F) (Nat.zero_le 1)
+          (Nat.one_le_pow M 2 (by norm_num)),
+        ← Finset.range_eq_Ico, Finset.sum_range_one, hind0, zero_add]
+    calc ∑ i ∈ Finset.range M, A.indicator F i
+        ≤ ∑ j ∈ Finset.range M, block j := by rw [← hdyadic M, ← hsplit]; exact hle1
+      _ ≤ ∑ j ∈ Finset.range M, ((if j < N0 then (1 : ℝ) else 0) + g j) :=
+          Finset.sum_le_sum (fun j _ => hcombine j)
+      _ = (∑ j ∈ Finset.range M, (if j < N0 then (1 : ℝ) else 0))
+            + ∑ j ∈ Finset.range M, g j := by rw [Finset.sum_add_distrib]
+      _ ≤ (N0 : ℝ) + ∑' j, g j := by
+          apply _root_.add_le_add
+          · rw [Finset.sum_boole]
+            have hsub2 : (Finset.range M).filter (· < N0) ⊆ Finset.range N0 := by
+              intro x hx
+              rw [Finset.mem_filter] at hx
+              exact Finset.mem_range.2 hx.2
+            calc (((Finset.range M).filter (· < N0)).card : ℝ)
+                ≤ ((Finset.range N0).card : ℝ) := by exact_mod_cast Finset.card_le_card hsub2
+              _ = (N0 : ℝ) := by rw [Finset.card_range]
+          · exact Summable.sum_le_tsum _ (fun j _ => hg_nonneg j) hg_summable
+
+/-- **The reduction actually goes through at the `(log N)^{1+δ}` threshold.**
+    If `r_k(N) = O(N / (log N)^{1+δ})` for some `δ > 0` and every `k ≥ 3`
+    (`StrongRequiredBound`), then Erdős #3 holds: every set with divergent
+    reciprocal sum contains arbitrarily long arithmetic progressions.
+
+    This is a fully machine-checked, `sorry`-free, axiom-free conditional theorem.
+    The proof: a length-`m` AP-free set has counting function bounded by `r_m(N)`
+    (`countingFunction_le_rothNumber`), hence `= O(N/(log N)^{1+δ})`, hence has a
+    *convergent* reciprocal sum (`summable_of_strongBound`) — contradicting
+    divergence. Contrast `required_bound_implies_conjecture`, whose `o(N/log N)`
+    hypothesis is *not* known to suffice: the gap between the two thresholds is
+    exactly the open content of Erdős #3. -/
+theorem strong_required_bound_implies_conjecture :
+    (∀ k : ℕ, k ≥ 3 → StrongRequiredBound k) → Erdos3Conjecture := by
+  intro hbound A hdiv k
+  apply containsAP_of_le (le_max_left k 3)
+  by_contra hAPfree
+  have hApf : IsAPFree A (max k 3) := hAPfree
+  obtain ⟨δ, hδ, C, hC, hev⟩ := hbound (max k 3) (le_max_right k 3)
+  have hcount : ∀ᶠ N in atTop,
+      (countingFunction A N : ℝ) ≤ C * (N : ℝ) / (Real.log N) ^ (1 + δ) := by
+    filter_upwards [hev] with N hN
+    calc (countingFunction A N : ℝ) ≤ (rothNumber (max k 3) N : ℝ) := by
+          exact_mod_cast countingFunction_le_rothNumber A (max k 3) N hApf
+      _ ≤ C * (N : ℝ) / (Real.log N) ^ (1 + δ) := hN
+  exact hdiv (summable_of_strongBound hδ hC hcount)
+
 /- ## Equivalent Formulations -/
 
 /- **Equivalent to Behrend-type bounds**: The conjecture asks whether

--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -28,13 +28,18 @@ import Mathlib
 
 open Set Filter Nat Finset
 
+open scoped Classical
+
 namespace Erdos3
 
 /- ## Core Definitions -/
 
-/-- A k-term arithmetic progression starting at a with common difference d -/
+/-- A k-term arithmetic progression starting at a with common difference d.
+    Defined via `Finset.image`, which needs no injectivity hypothesis on the
+    generating map (the map `i ↦ a + i·d` collapses when `d = 0`; callers that
+    care about genuine progressions require `d > 0`). -/
 def ArithProg (a d k : ℕ) : Finset ℕ :=
-  (Finset.range k).map ⟨fun i => a + i * d, fun _ _ h => by omega⟩
+  (Finset.range k).image (fun i => a + i * d)
 
 /-- A set contains a k-term AP if some (a, d) with d > 0 gives a subset -/
 def ContainsAP (A : Set ℕ) (k : ℕ) : Prop :=
@@ -61,11 +66,12 @@ def HasDivergentSum (A : Set ℕ) : Prop :=
 /-- r_k(N) = maximum size of subset of {1,...,N} avoiding k-term APs -/
 noncomputable def rothNumber (k N : ℕ) : ℕ :=
   Finset.sup
-    ((Finset.range (N + 1)).powerset.filter (fun S => IsAPFree (↑S : Set ℕ) k))
+    ((Finset.range (N + 1)).powerset.filter
+      (fun S : Finset ℕ => IsAPFree (↑S : Set ℕ) k))
     Finset.card
 
 /-- The counting function for A up to N -/
-def countingFunction (A : Set ℕ) (N : ℕ) : ℕ :=
+noncomputable def countingFunction (A : Set ℕ) (N : ℕ) : ℕ :=
   ((Finset.range (N + 1)).filter (· ∈ A)).card
 
 /- ## Key Threshold -/
@@ -83,7 +89,7 @@ def Erdos3Conjecture : Prop :=
 
 /- ## The Gap -/
 
-/-- **The Critical Gap**: Why the conjecture remains open.
+/- **The Critical Gap**: Why the conjecture remains open.
     For Erdős' conjecture, we need r_k(N) = o(N / log N).
     But current bounds only give r_k(N) = o(N / exp((log log N)^c)).
     Since exp((log log N)^c) grows slower than log N, there's a gap. -/
@@ -114,7 +120,7 @@ theorem countingFunction_le_rothNumber (A : Set ℕ) (k N : ℕ)
   -- The slice is a member of the family `rothNumber` sups over.
   have hmem : ((Finset.range (N + 1)).filter (· ∈ A)) ∈
       ((Finset.range (N + 1)).powerset.filter
-        (fun S => IsAPFree (↑S : Set ℕ) k)) := by
+        (fun S : Finset ℕ => IsAPFree (↑S : Set ℕ) k)) := by
     rw [Finset.mem_filter, Finset.mem_powerset]
     refine ⟨Finset.filter_subset _ _, ?_⟩
     intro hAP
@@ -160,7 +166,7 @@ theorem required_bound_implies_conjecture :
 
 /- ## Equivalent Formulations -/
 
-/-- **Equivalent to Behrend-type bounds**: The conjecture asks whether
+/- **Equivalent to Behrend-type bounds**: The conjecture asks whether
     Behrend's construction cannot be improved to achieve N / log N density. -/
 
 /- ## Green-Tao Connection -/
@@ -183,8 +189,8 @@ example : ArithProg 1 2 3 = {1, 3, 5} := by decide
 /-- 4-term AP: {a, a+d, a+2d, a+3d} -/
 example : ArithProg 2 3 4 = {2, 5, 8, 11} := by decide
 
-/-- The set {1, 2, 4, 5, 10, 11, 13, 14} is 3-AP-free (Roth's example) -/
--- This is a classic construction avoiding 3-term APs
+/- The set {1, 2, 4, 5, 10, 11, 13, 14} is 3-AP-free (Roth's example);
+   this is a classic construction avoiding 3-term APs. -/
 
 /- ## Problem Status -/
 

--- a/research/problems/erdos-3-incomplete-01/knowledge.md
+++ b/research/problems/erdos-3-incomplete-01/knowledge.md
@@ -3,131 +3,114 @@
 Erdős Problem #3 ($5000, OPEN): if `∑_{a∈A} 1/a = ∞` then `A` contains
 arbitrarily long arithmetic progressions.
 
-The claimed sorry is in `Proofs/Erdos3Problem.lean`:
-
-```lean
-theorem required_bound_implies_conjecture :
-    (∀ k : ℕ, k ≥ 3 → RequiredBound k) → Erdos3Conjecture := sorry
-```
-
-where `RequiredBound k := ∀ c>0, ∀ᶠ N, rothNumber k N ≤ c·N/log N` (i.e.
-`r_k(N) = o(N/log N)`) and `Erdos3Conjecture := ∀ A, HasDivergentSum A →
-∀ k, ContainsAP A k`.
+File: `proofs/Proofs/Erdos3Problem.lean`. Two thresholds appear:
+`RequiredBound k = r_k(N) = o(N/log N)` and the stronger
+`StrongRequiredBound k = r_k(N) = O(N/(log N)^{1+δ})` for some `δ>0`.
 
 ---
 
-## FINDING: the sorry's threshold `o(N/log N)` is INSUFFICIENT for the reduction
+## RESULT (2026-07-04): the strong-threshold reduction is now PROVEN (0-axiom)
 
-The file frames this sorry as a mechanical "logical implication" and claims
-(header, line 12) the conjecture is *equivalent* to `r_k(N) = o(N/log N)`. The
-reverse direction actually written as the sorry is **not** provable by the
-standard reciprocal-sum argument, because `o(N/log N)` is the wrong threshold.
+A prior session designed a provable reduction at the `(log N)^{1+δ}` threshold
+but could not compile it (no Mathlib build was available). This session
+**compiled and verified it**, plus repaired the file, which did not build at all.
 
-**The intended proof.** Fix `k ≥ 3`, take `A` with `HasDivergentSum A`, and
-suppose for contradiction `A` is AP-free of length `k` (`¬ContainsAP A k`). Then
-every subset of `A ∩ [1,N]` is AP-free, so the counting function satisfies
+### The file did not compile on `main` (bitrot)
 
-```
-f_A(N) := |A ∩ [1,N]|  ≤  rothNumber k N.
-```
+The enrichment adding `countingFunction_le_rothNumber` / `StrongRequiredBound`
+was merged **without a build** (math PRs skip rebuild), leaving multiple hard
+errors. All fixed in commit "Repair Erdos3Problem.lean bitrot":
+- `ArithProg` used `Finset.map` with a bogus `by omega` injectivity proof —
+  `i ↦ a + i·d` is not injective (collapses when `d = 0`), and `omega` cannot
+  prove nonlinear injectivity anyway. Switched to `Finset.image` (no injectivity
+  hypothesis). This is mathematically harmless: `ContainsAP` still requires
+  `d > 0`, and only membership/subset facts about `ArithProg` are used.
+- `rothNumber` / `countingFunction` / the bridge lemma filtered over `Set`
+  membership without `Decidable` instances → added `open scoped Classical`,
+  marked `countingFunction` `noncomputable`, annotated the powerset-filter
+  binder as `Finset ℕ`.
+- three orphaned `/-- -/` docstrings (attached to no declaration) → `/- -/`.
 
-Under `RequiredBound k`, `rothNumber k N = o(N/log N)`, hence `f_A(N) = o(N/log N)`.
-The proof wants to conclude `∑_{a∈A} 1/a < ∞`, contradicting `HasDivergentSum A`.
-
-**Why it fails.** `f_A(N) = o(N/log N)` does **not** imply `∑ 1/a` converges.
-By partial summation `∑_{a∈A} 1/a ≍ ∑_n f_A(n)/n²`. Take the borderline profile
-
-```
-f(N) ≍ N / (log N · log log N)      ( = o(N/log N),  since  ·/(N/log N) = 1/loglog N → 0 ),
-```
-
-for which
-
-```
-∑ f(n)/n²  ≍  ∫ dt / (t · log t · log log t)  =  log log log t → ∞.
-```
-
-So a set can have counting function `o(N/log N)` **and** divergent reciprocal
-sum. Whether such a set can also be AP-free is *exactly* the negation of Erdős #3
-(Behrend's AP-free sets have size `N/exp(c√log N)`, far below this, with
-convergent reciprocal sum). Hence the sorry at the `o(N/log N)` threshold is **as
-hard as Erdős #3 itself** — not a tractable logical step. Tractability rated 4/10
-by the seeker is over-optimistic for the statement as written.
-
-## CONSTRUCTIVE FIX: a genuinely provable reduction at the `(log N)^{1+ε}` threshold
-
-Strengthen the hypothesis to the bound that actually powers the reciprocal-sum
-argument. Add a new definition and theorem (leaving the original sorry as the
-open, correctly-labelled hard reduction):
+### The 0-axiom conditional theorem (commit "Prove strong_required_bound…")
 
 ```lean
-/-- The bound that suffices for the reciprocal-sum reduction:
-    r_k(N) = O(N / (log N)^{1+ε}) for some ε > 0. -/
-def StrongBound (k : ℕ) : Prop :=
-  ∃ ε : ℝ, 0 < ε ∧ ∃ C : ℝ, ∀ᶠ N in atTop,
-    (rothNumber k N : ℝ) ≤ C * N / (Real.log N) ^ (1 + ε)
-
-theorem strong_bound_implies_conjecture :
-    (∀ k : ℕ, k ≥ 3 → StrongBound k) → Erdos3Conjecture
+theorem strong_required_bound_implies_conjecture :
+    (∀ k : ℕ, k ≥ 3 → StrongRequiredBound k) → Erdos3Conjecture
 ```
 
-**Proof (dyadic blocking — avoids Abel summation and Bertrand series).** With `A`
-AP-free of length `k`, `f_A(N) ≤ rothNumber k N ≤ C·N/(log N)^{1+ε}` for large `N`.
-Decompose `A` into dyadic blocks `A ∩ (2^j, 2^{j+1}]`:
+Fully machine-checked, `sorry`-free, axiom-free (uses only `classical` + standard
+Mathlib summability/p-series lemmas; does not touch `euler_prime_sum_diverges`).
 
-```
-∑_{a∈A} 1/a  =  Σ_j  Σ_{a ∈ A∩(2^j,2^{j+1}]} 1/a
-             ≤  Σ_j  |A ∩ (2^j,2^{j+1}]| / 2^j
-             ≤  Σ_j  f_A(2^{j+1}) / 2^j
-             ≤  Σ_j  C·2^{j+1} / ( ((j+1)·log 2)^{1+ε} · 2^j )
-             =  (2C / (log 2)^{1+ε}) · Σ_j 1/(j+1)^{1+ε}   <  ∞,
-```
+Supporting lemmas added:
+- `containsAP_of_le : k ≤ m → ContainsAP A m → ContainsAP A k` — monotonicity in
+  the length (first `k` terms of an `m`-AP form a `k`-AP), via
+  `Finset.image_subset_image`. Lets the main proof reduce every `k` to
+  `max k 3 ≥ 3`.
+- `summable_of_strongBound` — the analytic core. If
+  `f_A(N) ≤ C·N/(log N)^{1+δ}` eventually (`δ>0`), then `∑_{a∈A} 1/a` converges.
 
-the last sum being a convergent p-series (`p = 1+ε > 1`). So `∑ 1/a` converges,
-contradicting `HasDivergentSum A`. ∎
+**Proof of the core (dyadic blocking).** Reduce to summability of the
+`ℕ`-indicator `A.indicator (1/·)` via `summable_subtype_iff_indicator`, then to
+bounded partial sums via `summable_of_sum_range_le`. For each `M`,
+`∑_{i<M} ≤ ∑_{i<2^M}`, which regroups (induction, `sum_Ico_consecutive`) into
+dyadic blocks `∑_{j<M} block_j`, `block_j = ∑_{i∈[2^j,2^{j+1})} A.indicator(1/·) i`.
+Two bounds on each block:
+- crude: `block_j ≤ 1` (`|[2^j,2^{j+1})| = 2^j` terms, each `≤ 1/2^j`);
+- strong (`j ≥ N0`): `block_j ≤ |A∩[2^j,2^{j+1})|/2^j ≤ f_A(2^{j+1})/2^j
+  ≤ 2C/((j+1)·log 2)^{1+δ} =: g j`, using `Real.log (2^{j+1}) = (j+1)·log 2`
+  and `Real.mul_rpow`.
+Hence `block_j ≤ 𝟙[j<N0] + g j`, so `∑_{j<M} block_j ≤ N0 + ∑' g`, and `g`
+is a constant multiple of the convergent p-series `∑ 1/(j+1)^{1+δ}`
+(`Real.summable_one_div_nat_rpow`, `p = 1+δ > 1`, reindexed by
+`summable_nat_add_iff`). Bounded partial sums ⟹ summable ⟹ contradiction with
+`HasDivergentSum`.
 
-This is a real 0-axiom conditional theorem: it isolates the *exact* analytic
-strength the reduction needs, and makes explicit that the gap between it and
-`o(N/log N)` is where Erdős #3's difficulty lives.
+The main theorem combines this with the bridge lemma
+`countingFunction_le_rothNumber` (AP-free ⟹ `f_A(N) ≤ r_k(N)`).
 
-**Mathlib API (4.26.0):**
-- p-series: `Real.summable_one_div_nat_rpow : Summable (fun n => 1/n^p) ↔ 1 < p`
-  (or `Real.summable_nat_rpow_inv`); comparison `Summable.of_nonneg_of_le`.
-- reindex reciprocal sum over `A` by dyadic blocks: `tsum` over the subtype `A`
-  regrouped via `Set.Ioc (2^j) (2^(j+1))`; `ENNReal.tsum_biUnion` / `tsum_iUnion`
-  or a `Finset`-exhaustion `HasSum` argument — the fiddly step.
-- `Real.log_pow` / `Real.log_rpow`, `Real.rpow_natCast`, `Real.rpow_le_rpow`.
-- small `k` (`k ≤ 2`): `ContainsAP A k` is trivial for a divergent-sum (hence
-  infinite) `A`; only `k ≥ 3` needs `StrongBound`, matching the hypothesis's `k≥3`.
+---
 
-Estimated ~200–280 lines; the dyadic reindexing of the `tsum` is the main cost.
+## Why the WEAKER `o(N/log N)` threshold is still an honest sorry
 
-## What is BLOCKED
+`required_bound_implies_conjecture` (hypothesis `RequiredBound = o(N/log N)`)
+remains `sorry`. This is **not** laziness: at that threshold the implication is
+as hard as Erdős #3 itself. `f_A(N) = o(N/log N)` does not force `∑1/a < ∞`:
+the borderline profile `f(N) ≍ N/(log N·log log N)` is `o(N/log N)` yet has
+divergent reciprocal sum (`∑ f(n)/n² ≍ ∫ dt/(t·log t·log log t) = log log log t
+→ ∞`). Whether such a set can also be AP-free is exactly the open content of
+Erdős #3. The gap between `o(N/log N)` and `O(N/(log N)^{1+δ})` is precisely
+where the difficulty lives — which is what the new theorem makes explicit.
 
-- The **original** sorry (`o(N/log N)` threshold): as hard as Erdős #3; do not
-  attempt a direct proof. Best action is to (a) add the `StrongBound` reduction
-  above, and (b) re-document the original as "open, threshold-critical," fixing
-  the header's over-strong "equivalent to `o(N/log N)`" claim.
-- Erdős #3 itself: open. Best known Roth-type bounds
-  (Kelley–Meka 2023 `r_3(N) ≪ N/exp((log N)^{1/11})`, Leng–Sah–Sawhney 2024) are
-  far from even `o(N/log N)`, let alone `O(N/(log N)^{1+ε})` — the file header's
-  results list is accurate on this point.
+Best known Roth-type bounds (Kelley–Meka 2023 `r_3(N) ≪ N/exp((log N)^{1/11})`,
+Leng–Sah–Sawhney 2024) are far from even `o(N/log N)`, let alone the
+`(log N)^{1+δ}` threshold.
 
-## Existing file inventory (`Proofs/Erdos3Problem.lean`, 163 lines)
+---
 
-- Defs: `ArithProg`, `ContainsAP`, `IsAPFree`, `reciprocalSum`, `HasDivergentSum`,
-  `rothNumber`, `countingFunction`, `SublogarithmicGrowth`, `Erdos3Conjecture`,
-  `RequiredBound`.
-- `euler_prime_sum_diverges` (axiom), `erdos3_implies_green_tao` (proved),
-  `erdos_3_open` (trivial `em`).
-- Sorry count: 1 (`required_bound_implies_conjecture`).
+## File inventory (`Proofs/Erdos3Problem.lean`, 440 lines, builds: 7743 jobs)
+
+- Defs: `ArithProg` (now `image`), `ContainsAP`, `ContainsArbitrarilyLongAP`,
+  `IsAPFree`, `reciprocalSum`, `HasDivergentSum`, `rothNumber`,
+  `countingFunction`, `SublogarithmicGrowth`, `Erdos3Conjecture`,
+  `RequiredBound`, `StrongRequiredBound`.
+- Proved (0 new axioms): `countingFunction_le_rothNumber`, `containsAP_of_le`,
+  `summable_of_strongBound`, `strong_required_bound_implies_conjecture`,
+  `erdos3_implies_green_tao`, `erdos_3_open`.
+- 1 axiom: `euler_prime_sum_diverges` (Euler 1737; deep, kept).
+- 1 sorry: `required_bound_implies_conjecture` (threshold-critical; open).
 
 ## Status
 
-PARTIAL / IN-PROGRESS. Delivered: (1) a correctness FINDING — the current sorry's
-`o(N/log N)` threshold is insufficient (Abel-summation counterexample) and the
-statement as written is as hard as Erdős #3; (2) a fully designed, 0-axiom
-provable replacement `strong_bound_implies_conjecture` at the `(log N)^{1+ε}`
-threshold via dyadic blocking + p-series, with exact Mathlib API. Verification
-deferred this iteration: no Mathlib olean cache in the environment and disk at
-99%, so no `import Mathlib` build could be run (see state.md).
+PROGRESS. Delivered this session: (1) repaired a non-compiling file (bitrot);
+(2) proved, 0-axiom and sorry-free, `strong_required_bound_implies_conjecture`,
+the reduction at the correct `(log N)^{1+δ}` threshold, machine-verified in
+Lean 4 / Mathlib 4.26. The original `o(N/log N)` sorry is correctly retained as
+threshold-critical (as hard as Erdős #3).
+
+## Next steps
+
+- The remaining `sorry` should NOT be attacked directly — it is as hard as
+  Erdős #3. Leave it documented.
+- Possible follow-ups (shallow, optional): a `k ≤ 2` corollary that any infinite
+  set trivially contains 2-APs; or expose `summable_of_strongBound` as a reusable
+  density→convergence lemma for other reciprocal-sum problems.

--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -1,47 +1,43 @@
 # State: erdos-3-incomplete-01
 
-**Phase**: PARTIAL (finding + verified design)
-**Since**: 2026-07-02
-**Attempts**: 1
-**Status**: available
+**Phase**: ACT (verified reduction landed)
+**Since**: 2026-07-04
+**Attempts**: 2
+**Status**: progress
 
 ## Current Focus
 
-The sorry `required_bound_implies_conjecture` in `Proofs/Erdos3Problem.lean`.
+The `(log N)^{1+δ}` threshold reduction for Erdős #3, now machine-verified.
 
-## Finding
+## Result this iteration
 
-The sorry's hypothesis `RequiredBound k = r_k(N) = o(N/log N)` is the WRONG
-threshold: the reciprocal-sum reduction fails at `o(N/log N)` (counting function
-`~ N/(log N·loglog N)` is `o(N/log N)` yet has divergent reciprocal sum). As
-written the sorry is as hard as Erdős #3 — not a mechanical implication. The file
-header's "equivalent to `o(N/log N)`" claim is over-strong. Details + counterexample
-in knowledge.md.
-
-## Constructive design (0-axiom, provable)
-
-Add `StrongBound k := ∃ε>0, ∃C, ∀ᶠ N, r_k(N) ≤ C·N/(log N)^{1+ε}` and
-`strong_bound_implies_conjecture`, proved by dyadic blocking of `∑ 1/a` into a
-convergent p-series `∑ 1/(j+1)^{1+ε}`. Full proof sketch + Mathlib API in
-knowledge.md.
+1. **Bitrot repair.** `Proofs/Erdos3Problem.lean` did not compile on `main`
+   (enrichment merged without a build): `ArithProg` used `Finset.map` with a
+   false `omega` injectivity proof; filters over `Set` membership lacked
+   `Decidable` instances; three orphaned `/--` docstrings. Fixed → builds
+   cleanly (7743 jobs).
+2. **0-axiom reduction proved.** `strong_required_bound_implies_conjecture`:
+   `(∀ k≥3, StrongRequiredBound k) → Erdos3Conjecture`, `sorry`-free and
+   axiom-free, via dyadic blocking + convergent p-series
+   (`summable_of_strongBound`) and the bridge lemma. Plus `containsAP_of_le`
+   (length monotonicity). See knowledge.md for the full argument.
 
 ## Blockers
 
-1. **Environment (this iteration):** no Mathlib olean cache in the repo; disk at
-   99%; worktrees reaped under disk pressure. No `import Mathlib` build could run,
-   so the `StrongBound` reduction was designed but not compiled/verified.
-2. **Mathematics:** the original `o(N/log N)` sorry is as hard as Erdős #3
-   (blocked); Erdős #3 open; best Roth bounds far from the needed threshold.
+- **Mathematics only:** the original `o(N/log N)` sorry
+  (`required_bound_implies_conjecture`) is threshold-critical — as hard as
+  Erdős #3 (counterexample profile in knowledge.md). Do NOT attempt directly.
+- Erdős #3 itself: open; best Roth bounds far from the needed threshold.
 
 ## Next Action
 
-When a Mathlib build is available: add `StrongBound` + `strong_bound_implies_conjecture`
-to `Erdos3Problem.lean` (or a companion `Erdos3StrongBound.lean`), verify 0-axiom
-via `lake env lean`, and correct the header's "equivalent to o(N/log N)" wording.
-Consider filing a mechanic/curator note to re-label the original sorry as
-threshold-critical rather than a tractable logical step.
+Leave the threshold-critical sorry documented. Optional shallow follow-ups:
+a `k ≤ 2` triviality corollary, or reusing `summable_of_strongBound` as a
+density→convergence lemma elsewhere. The environment recipe (external worktree,
+`LEAN_SKIP_CACHE=true`, 16 GB) is proven to work for this file.
 
 ## Attempts
 
-- 1: threshold analysis + StrongBound design (this iteration; verification deferred
-  on environment).
+- 1: threshold analysis + StrongBound design (verification deferred — no build).
+- 2: repaired non-compiling file; compiled & verified the StrongBound reduction
+  (0-axiom, 7743 jobs); memory bump to 16 GB needed (transient SIGBUS at 8 GB).

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -233,10 +233,10 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 163,
+    "lineCount": 440,
     "axiomCount": 1,
-    "theoremCount": 3,
-    "definitionCount": 11,
+    "theoremCount": 7,
+    "definitionCount": 12,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1
   },

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-3-incomplete-01",
   "title": "Erdős Problem #3: Arithmetic Progressions in Large Sets",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,35 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-03T08:28:28Z",
-    "iteration": 1,
-    "focus": "",
+    "iteration": 2,
+    "focus": "Verified StrongRequiredBound reduction; original o(N/log N) sorry is threshold-critical (open)",
     "blockers": [],
-    "nextAction": "",
+    "nextAction": "Leave threshold-critical sorry documented; optional shallow follow-ups",
     "attemptCounts": {
-      "total": 0,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "Repaired non-compiling file (bitrot); proved strong_required_bound_implies_conjecture 0-axiom via dyadic blocking + p-series (machine-verified, 7743 jobs). Original o(N/log N) sorry retained as threshold-critical.",
+    "builtItems": [
+      "containsAP_of_le",
+      "summable_of_strongBound",
+      "strong_required_bound_implies_conjecture (0-axiom)"
+    ],
+    "insights": [
+      "File did not compile on main (enrichment merged without build): ArithProg map/omega injectivity false for d=0, missing Decidable for Set-membership filters, orphaned /-- docstrings.",
+      "The (log N)^{1+δ} threshold DOES imply Erdos #3 (dyadic blocking + convergent p-series); this is now a verified 0-axiom conditional theorem.",
+      "The o(N/log N) threshold does NOT obviously imply it: borderline profile N/(log N loglog N) is o(N/log N) with divergent reciprocal sum. That sorry is as hard as Erdos #3."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Do not attack the threshold-critical sorry directly",
+      "Optional: k<=2 triviality corollary; reuse summable_of_strongBound elsewhere"
+    ],
     "markdown": "# Knowledge: erdos-3-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Problem `erdos-3-incomplete-01` (Erdős #3, \$5000, open). Two deliverables:

### 1. Bitrot repair — the file did not compile on `main`

`proofs/Proofs/Erdos3Problem.lean` was merged in a non-compiling state
(enrichment merged without a build; math PRs skip rebuild). Fixed:
- `ArithProg` used `Finset.map` with a **false** `by omega` injectivity proof —
  `i ↦ a + i·d` is not injective (`d = 0` collapses it), and `omega` cannot do
  nonlinear injectivity. Switched to `Finset.image` (no injectivity needed;
  `ContainsAP` still requires `d > 0`).
- filters over `Set` membership (`rothNumber`, `countingFunction`, bridge lemma)
  lacked `Decidable` instances → `open scoped Classical`, `noncomputable`,
  binder annotation.
- three orphaned `/-- -/` docstrings (no following declaration) → `/- -/`.

### 2. Verified 0-axiom conditional theorem

```lean
theorem strong_required_bound_implies_conjecture :
    (∀ k : ℕ, k ≥ 3 → StrongRequiredBound k) → Erdos3Conjecture
```

Fully machine-checked, **`sorry`-free and axiom-free**. If
`r_k(N) = O(N/(log N)^{1+δ})` for some `δ>0` and every `k≥3`, then every set with
divergent reciprocal sum contains arbitrarily long APs.

Supporting lemmas (also 0-axiom):
- `containsAP_of_le` — `ContainsAP` is monotone in the length.
- `summable_of_strongBound` — the analytic core: a strong counting bound forces a
  convergent reciprocal sum, by **dyadic blocking**. The mass of
  `A ∩ [2^j, 2^{j+1})` is `≤ f_A(2^{j+1})/2^j ≤ 2C/((j+1)·log 2)^{1+δ}`, the
  general term of a convergent p-series (`p = 1+δ > 1`). Reduces to bounded
  partial sums of the ℕ-indicator (`summable_of_sum_range_le`,
  `summable_subtype_iff_indicator`).

This isolates exactly the analytic strength Erdős #3 lacks: the gap between the
`o(N/log N)` threshold (`required_bound_implies_conjecture`, still an honest
`sorry` — as hard as Erdős #3) and the `O(N/(log N)^{1+δ})` threshold proved here.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos3Problem` → **Build completed
successfully (7743 jobs)**. Only warning: the intentionally-retained
threshold-critical `sorry`.

File status unchanged at the file level: still 1 axiom
(`euler_prime_sum_diverges`) + 1 `sorry` (threshold-critical). The new theorem
depends on neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)