### PR TITLE
Enrich Erdős #579 (K₂,₂,₂-free dense graphs): add 4 references (0→4)

### DIFF
--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "Erdős, Hajnal, Sós, and Szemerédi studied the relationship between forbidden subgraphs and independence numbers in dense graphs. The octahedron K₂,₂,₂ (complete tripartite graph with parts of size 2) has Turán density 1/8: the maximum number of edges in a K₂,₂,₂-free graph on n vertices is (1/8 + o(1))n². EHSS (1983) proved that for edge density exceeding this threshold (δ > 1/8), K₂,₂,₂-free graphs must have linear independence numbers α(G) ≥ c·n. The conjecture extends this to all δ > 0, asking whether even sub-Turán density K₂,₂,₂-free graphs are forced to have large independent sets. This parallels Problem #533 (triangle-free subsets in K₅-free graphs), forming part of a broader program in Ramsey-Turán theory that investigates how forbidden subgraph conditions interact with density to force structural properties.",
     "problemStatement": "For every δ > 0 and n sufficiently large, must every K₂,₂,₂-free graph on n vertices with at least δn² edges contain an independent set of size ≫_δ n?",
     "text": "For δ > 0 and n large, must every K₂,₂,₂-free graph on n vertices with ≥ δn² edges contain an independent set of size ≫_δ n? Proved for δ > 1/8 by EHSS. Open for general δ.",
-    "proofStrategy": "The formalization uses Mathlib's SimpleGraph type with K₂,₂,₂ containment defined by enumerating all 12 cross-edges between three vertex pairs. Edge density, independent sets, and the independence number are defined as standard predicates. The EHSS result (δ > 1/8), the full conjecture (all δ > 0), and the Turán bound ex(n; K₂,₂,₂) = (1/8+o(1))n² are axiomatized. The Filter.atTop mechanism elegantly handles 'sufficiently large n' quantification.",
+    "proofStrategy": "The formalization uses Mathlib's SimpleGraph type with K₂,₂,₂ containment defined by enumerating all 12 cross-edges between three vertex pairs. Edge density, independent sets, and the independence number are defined as standard predicates. The EHSS result (δ > 1/8), the full conjecture (all δ > 0), and the Turán bound ex(n; K₂,₂,₂) = (1/8+o(1))n² are recorded as documented statements alongside the definitions (the file provides definitional scaffolding; these results are written as prose, not yet declared as Lean axioms or theorems, so the file carries 0 axioms and 0 sorries). The Filter.atTop mechanism elegantly handles 'sufficiently large n' quantification.",
     "keyInsights": [
       "**Turán threshold 1/8**: K₂,₂,₂-free graphs have at most (1/8+o(1))n² edges; above this density, the EHSS proof exploits structural constraints from exceeding the extremal bound",
       "**Sub-Turán mystery**: For δ ≤ 1/8, the graph is within the Turán limit, and the EHSS argument breaks down—new techniques are needed to establish linear independence numbers",
@@ -125,6 +125,61 @@
       "targetId": "erdos-128",
       "relationship": "related",
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, open"
+    }
+  ],
+  "references": [
+    {
+      "key": "EHSS83",
+      "authors": [
+        "P. Erdős",
+        "A. Hajnal",
+        "V. T. Sós",
+        "E. Szemerédi"
+      ],
+      "title": "More results on Ramsey—Turán type problems",
+      "venue": "Combinatorica",
+      "year": "1983",
+      "volume": "3",
+      "pages": "69–81",
+      "doi": "10.1007/BF02579342",
+      "note": "Source of the problem; proves the δ > 1/8 case—K₂,₂,₂-free graphs above the Turán threshold have linear independence number."
+    },
+    {
+      "key": "ES71",
+      "authors": [
+        "P. Erdős",
+        "M. Simonovits"
+      ],
+      "title": "An extremal graph problem",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae",
+      "year": "1971",
+      "volume": "22",
+      "pages": "275–282",
+      "note": "Determines the Turán number of the octahedron: ex(n; K₂,₂,₂) = (1/8 + o(1))n², explaining the threshold δ = 1/8."
+    },
+    {
+      "key": "SS01",
+      "authors": [
+        "M. Simonovits",
+        "V. T. Sós"
+      ],
+      "title": "Ramsey–Turán theory",
+      "venue": "Discrete Mathematics",
+      "year": "2001",
+      "volume": "229",
+      "pages": "293–340",
+      "doi": "10.1016/S0012-365X(00)00214-4",
+      "note": "Survey of the Ramsey–Turán program that frames how forbidden subgraphs and density interact to force independence structure."
+    },
+    {
+      "key": "erdosproblems579",
+      "authors": [
+        "Thomas Bloom (ed.)"
+      ],
+      "title": "Erdős Problem 579",
+      "venue": "erdosproblems.com",
+      "year": "2024",
+      "note": "Curated statement and status of the problem: https://erdosproblems.com/579"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for **erdos-579** (Erdős Problem #579: Independent Sets in K₂,₂,₂-Free Dense Graphs).

## Changes (meta.json only)
- **Added a `references` array (0 → 4)**, all verified against the literature:
  - **EHSS 1983** — Erdős, Hajnal, Sós, Szemerédi, "More results on Ramsey—Turán type problems," *Combinatorica* 3, 69–81 (DOI 10.1007/BF02579342). Source of the problem; proves the δ > 1/8 case.
  - **Erdős–Simonovits 1971** — "An extremal graph problem," *Acta Math. Acad. Sci. Hungar.* 22, 275–282. Determines the octahedron Turán number ex(n; K₂,₂,₂) = (1/8+o(1))n², the source of the δ = 1/8 threshold.
  - **Simonovits–Sós 2001** — "Ramsey–Turán theory," *Discrete Math.* 229, 293–340. Survey framing the broader program.
  - **erdosproblems.com/579** — curated statement/status.
- **Corrected `proofStrategy` wording.** The prior text said the EHSS result, the full conjecture, and the Turán bound "are axiomatized." The actual Lean file (`Proofs/Erdos579Problem.lean`) contains **only 5 definitions**; these results appear as prose doc-comments, not as `axiom` or `theorem` declarations. Reworded to say they are recorded as documented statements (file carries 0 axioms, 0 theorems, 0 sorries).

## Integrity note for reviewers
`meta.status` is `"axiomatized"` and `meta.badge` is `"wip"`, but the Lean file has **no `axiom` declarations and no assumption-carrying structures** — it is a definitional scaffold with the mathematical results stated only in comments. Per the Axiom Integrity Policy, `axiomCount: 0` is correct here. I left `status` unchanged (flagging rather than silently altering it); a maintainer may prefer `"formalized"` or a scaffold-specific status, but that is a larger judgment call outside this enrichment.

Size after edit: ~9.2 KB (well under the 60 KB cap). No annotations changed (already 7 annotations, all with `mathContext`).
