### PR TITLE
Enrich Erdős #899 (Growth of Difference Sets): add 3 references (0→3)

### DIFF
--- a/src/data/proofs/erdos-899/meta.json
+++ b/src/data/proofs/erdos-899/meta.json
@@ -150,5 +150,39 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, combinatorics, density"
     }
   ],
+  "references": [
+    {
+      "key": "Ruzsa78",
+      "authors": [
+        "I. Z. Ruzsa"
+      ],
+      "title": "On the cardinality of A+A and A−A",
+      "venue": "Combinatorics (Keszthely, 1976), Colloquia Mathematica Societatis János Bolyai, vol. 18, North-Holland",
+      "year": "1978",
+      "pages": "933–938",
+      "note": "Proves the affirmative answer: for a zero-density set A, |A−A| grows unboundedly faster than |A|."
+    },
+    {
+      "key": "TV06",
+      "authors": [
+        "T. Tao",
+        "V. H. Vu"
+      ],
+      "title": "Additive Combinatorics",
+      "venue": "Cambridge Studies in Advanced Mathematics 105, Cambridge University Press",
+      "year": "2006",
+      "note": "Standard reference for sumset/difference-set estimates, the Plünnecke–Ruzsa inequalities, and Freiman's theorem."
+    },
+    {
+      "key": "erdosproblems899",
+      "authors": [
+        "Thomas Bloom (ed.)"
+      ],
+      "title": "Erdős Problem 899",
+      "venue": "erdosproblems.com",
+      "year": "2024",
+      "note": "Curated statement and status of the problem: https://erdosproblems.com/899"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for **erdos-899** (Erdős Problem #899: Growth of Difference Sets).

## Changes (meta.json only)
Added a `references` array (**0 → 3**), all verified against the literature:
- **Ruzsa 1978** — I. Z. Ruzsa, "On the cardinality of A+A and A−A," *Combinatorics (Keszthely, 1976)*, Coll. Math. Soc. J. Bolyai **18**, 933–938 (North-Holland). This is the paper that proves the problem's affirmative answer (a zero-density set has |A−A| growing unboundedly faster than |A|).
- **Tao–Vu 2006** — *Additive Combinatorics*, Cambridge Studies in Advanced Mathematics 105. Standard reference for sumset/difference-set estimates and the Plünnecke–Ruzsa inequalities.
- **erdosproblems.com/899** — curated statement/status.

Size after edit: ~8.4 KB (well under the 60 KB cap). No annotations changed.
