### PR TITLE
Enrich Erdős #489 (Gaps Between B-Free Numbers): add 3 references (0→3)

### DIFF
--- a/src/data/proofs/erdos-489/meta.json
+++ b/src/data/proofs/erdos-489/meta.json
@@ -171,5 +171,40 @@
       "description": "Related Erdős problem sharing themes: gaps, number-theory, squarefree"
     }
   ],
+  "references": [
+    {
+      "key": "Erdos66",
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "On the difference of consecutive terms of sequences defined by divisibility properties",
+      "venue": "Acta Arithmetica",
+      "year": "1966",
+      "volume": "12",
+      "pages": "175–182",
+      "note": "Foundational paper on gaps in B-free (A-free) sequences; source of the problem and the squarefree-case moment estimates."
+    },
+    {
+      "key": "Chan23",
+      "authors": [
+        "T. H. Chan"
+      ],
+      "title": "On moments of gaps between consecutive squarefree numbers",
+      "venue": "Moscow Journal of Combinatorics and Number Theory",
+      "year": "2023",
+      "volume": "12",
+      "note": "Asymptotics Σ (s_{k+1}−s_k)^γ ∼ B(γ)x for 0 ≤ γ < 3.75, covering the second moment (γ=2) of the solved squarefree case."
+    },
+    {
+      "key": "erdosproblems489",
+      "authors": [
+        "Thomas Bloom (ed.)"
+      ],
+      "title": "Erdős Problem 489",
+      "venue": "erdosproblems.com",
+      "year": "2024",
+      "note": "Curated statement and status of the problem: https://erdosproblems.com/489"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for **erdos-489** (Erdős Problem #489: Gaps Between B-Free Numbers).

## Changes (meta.json only)
Added a `references` array (**0 → 3**), all verified against the literature:
- **Erdős 1966** — P. Erdős, "On the difference of consecutive terms of sequences defined by divisibility properties," *Acta Arithmetica* **12**, 175–182. The foundational paper on gaps in B-free (A-free) sequences and the source of the problem.
- **Chan 2023** — T. H. Chan, "On moments of gaps between consecutive squarefree numbers," *Moscow J. Comb. Number Theory* **12**. Proves Σ(s_{k+1}−s_k)^γ ∼ B(γ)x for 0 ≤ γ < 3.75, which covers the second moment (γ=2) of the solved squarefree case central to this problem.
- **erdosproblems.com/489** — curated statement/status.

Size after edit: ~8.8 KB (well under the 60 KB cap). No annotations changed.
