### PR TITLE
Research: amgm-inequality-oq-02-oq-02-oq-05 — Newton via real-rootedness (discriminant atom + n=2 base case)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -1,0 +1,128 @@
+/-
+  Newton's inequality via real-rootedness and the quadratic discriminant.
+
+  Problem: amgm-inequality-oq-02-oq-02-oq-05
+  Title:   Newton's Inequality via Real-Rooted Polynomials and Rolle's Theorem
+
+  The parent entry `amgm-inequality-oq-02-oq-02` proves Newton's log-concavity
+  step `p_k^2 ≥ p_{k-1} p_{k+1}` by a direct inductive/algebraic argument, and
+  crucially assumes the inputs are NONNEGATIVE (`0 ≤ x i`).  The sibling
+  `amgm-inequality-oq-02-oq-03-oq-03-oq-01` gives the first Newton inequality
+  (`k = 1`) via a Cauchy–Schwarz / sum-of-squares "discriminant" engine.
+
+  This file develops the *classical calculus route* the entry asks for, which is
+  genuinely different from both and NOT previously present in the amgm family:
+  Newton's inequality is the statement that a certain quadratic in three
+  consecutive coefficients, obtained by repeatedly differentiating the
+  real-rooted splitting polynomial `∏ (X - x_i)`, is itself real-rooted, hence
+  has a NONNEGATIVE DISCRIMINANT.
+
+  What is proved here (0 sorries, 0 axioms — foundational axioms only):
+
+  * `discrim_nonneg_of_root`
+        the reusable atom: a real quadratic `a x² + b x + c` that has a real
+        root has `0 ≤ discrim a b c`.  This is "real-rooted quadratic ⇒
+        log-concave coefficients", the exact per-derivative building block of
+        the whole Rolle program.
+  * `monic_quadratic_discrim_nonneg` / `discrim_nonneg_of_roots_nonempty`
+        the same statement phrased through Mathlib's `Polynomial` API — a monic
+        quadratic `X² + b X + c` with a real root (equivalently, whose `roots`
+        multiset is nonempty) has nonnegative discriminant.
+  * `realRooted_quadratic_coeff_ineq`  :  `4 c ≤ b²`.
+  * `newton_two_vars`  :  `x y ≤ ((x + y)/2)²` for ALL real `x, y` — Newton's
+        inequality `p_1² ≥ p_0 p_2` at `n = 2`, derived by taking the
+        discriminant of the real-rooted polynomial `(X - x)(X - y)`.  Note there
+        is NO sign hypothesis: the roots need only be real, which is exactly the
+        advantage of the real-rootedness route the entry highlights (the parent's
+        inductive proof needs `0 ≤ x i`).
+
+  The general case (`n ≥ 3`) needs the crux lemma "differentiation preserves
+  full real-rootedness (counting multiplicity)" — Rolle's theorem iterated on
+  `∏ (X - x_i)` — which is the multi-week formalization risk flagged in
+  `problem.md`.  It is honestly retained as open (documented in knowledge.md) and is
+  deliberately NOT stubbed out in this file, which is instead a complete,
+  self-contained, fully machine-checked quadratic/base atom of that program.
+-/
+import Mathlib
+
+namespace NewtonRealRooted
+
+open Polynomial
+
+/-!  ## The discriminant atom: a real root forces a nonnegative discriminant  -/
+
+/-- **Real-rooted quadratic ⇒ nonnegative discriminant.**
+If the quadratic `a x² + b x + c` has a real root `x`, then its discriminant
+`b² - 4ac` is nonnegative.  This is the single per-derivative step of the
+classical Newton/Rolle argument: after differentiating a real-rooted polynomial
+down to degree two, real-rootedness of the reduced quadratic *is* Newton's
+inequality for the three surviving coefficients. -/
+theorem discrim_nonneg_of_root (a b c x : ℝ) (h : a * (x * x) + b * x + c = 0) :
+    0 ≤ discrim a b c := by
+  rw [discrim_eq_sq_of_quadratic_eq_zero h]
+  exact sq_nonneg _
+
+/-!  ## Phrased through the `Polynomial` API (genuine real-rootedness)  -/
+
+/-- A monic real quadratic `X² + b X + c` with a real root has nonnegative
+discriminant `discrim 1 b c`.  Same content as `discrim_nonneg_of_root`, stated
+via `Polynomial.IsRoot` so it plugs directly into the splitting-polynomial
+picture. -/
+theorem monic_quadratic_discrim_nonneg (b c r : ℝ)
+    (hr : (X ^ 2 + C b * X + C c : ℝ[X]).IsRoot r) :
+    0 ≤ discrim 1 b c := by
+  have hroot : r ^ 2 + b * r + c = 0 := by
+    simpa [IsRoot, eval_add, eval_mul, eval_pow, eval_X, eval_C] using hr
+  exact discrim_nonneg_of_root 1 b c r (by linear_combination hroot)
+
+/-- If the monic real quadratic `X² + b X + c` splits over `ℝ` far enough to have
+a nonempty `roots` multiset (i.e. it is real-rooted), its discriminant is
+nonnegative.  This is the `Polynomial.roots`-level phrasing of real-rootedness. -/
+theorem discrim_nonneg_of_roots_nonempty (b c : ℝ)
+    (h : (X ^ 2 + C b * X + C c : ℝ[X]).roots ≠ 0) :
+    0 ≤ discrim 1 b c := by
+  obtain ⟨r, hr⟩ := Multiset.exists_mem_of_ne_zero h
+  exact monic_quadratic_discrim_nonneg b c r (mem_roots'.1 hr).2
+
+/-- The discriminant inequality rewritten as the coefficient inequality
+`4c ≤ b²` (log-concavity of the coefficient triple `(1, b, c)`). -/
+theorem realRooted_quadratic_coeff_ineq (b c r : ℝ)
+    (hr : (X ^ 2 + C b * X + C c : ℝ[X]).IsRoot r) :
+    4 * c ≤ b ^ 2 := by
+  have h := monic_quadratic_discrim_nonneg b c r hr
+  rw [discrim] at h
+  linarith
+
+/-!  ## The splitting polynomial for two roots, and Newton at `n = 2`  -/
+
+/-- Vieta for two roots: `(X - x)(X - y) = X² - (x+y) X + x y`. -/
+theorem prod_two_linear_eq (x y : ℝ) :
+    ((X - C x) * (X - C y) : ℝ[X]) = X ^ 2 + C (-(x + y)) * X + C (x * y) := by
+  rw [C_neg, C_add, C_mul]
+  ring
+
+/-- Each root of `(X - x)(X - y)` is, well, a root: `x` is a real root. -/
+theorem root_of_prod_two_linear (x y : ℝ) :
+    ((X - C x) * (X - C y) : ℝ[X]).IsRoot x := by
+  simp [IsRoot, eval_mul, eval_sub, eval_X, eval_C]
+
+/-- **Newton's inequality at `n = 2`, via real-rootedness.**
+For every pair of real numbers `x, y` (no sign restriction),
+`x y ≤ ((x + y)/2)²`, i.e. `p_1² ≥ p_0 p_2` for the normalized elementary
+symmetric means of `x, y`.  Proof: the polynomial `(X - x)(X - y)` is
+real-rooted, so the discriminant of `X² - (x+y) X + x y` is `≥ 0`, which is
+exactly `(x + y)² ≥ 4 x y`. -/
+theorem newton_two_vars (x y : ℝ) : x * y ≤ ((x + y) / 2) ^ 2 := by
+  have hroot : (X ^ 2 + C (-(x + y)) * X + C (x * y) : ℝ[X]).IsRoot x := by
+    rw [← prod_two_linear_eq]; exact root_of_prod_two_linear x y
+  have h := realRooted_quadratic_coeff_ineq (-(x + y)) (x * y) x hroot
+  nlinarith [h]
+
+/-- The `n = 2` Newton inequality in normalized (`p`) form, emphasizing the
+`p_1² ≥ p_0 · p_2` shape with `p_0 = 1`, `p_1 = e_1/2 = (x+y)/2`, `p_2 = e_2 = xy`.
+Holds for signed inputs. -/
+theorem newton_two_vars_normalized (x y : ℝ) :
+    (1 : ℝ) * (x * y) ≤ ((x + y) / 2) ^ 2 := by
+  simpa using newton_two_vars x y
+
+end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
@@ -1,0 +1,93 @@
+# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-05
+
+Insights accumulated during research on this problem.
+
+---
+
+## PART I — the real-rooted/discriminant route + the n=2 base case (researcher-8, 2026-07-04)
+
+**Mode**: FRESH (EMPTY, score 0). **Outcome**: progress (+8 theorems in a new
+file `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`; 0 sorries / 0 axioms).
+**Machine-verified**: docker-build clean (7743 jobs, exit 0);
+`#print axioms` = `propext / Classical.choice / Quot.sound` only for
+`newton_two_vars`, `discrim_nonneg_of_root`, `discrim_nonneg_of_roots_nonempty`,
+`realRooted_quadratic_coeff_ineq` (Tier-A axiom-free — no `sorryAx`, no
+`Lean.ofReduceBool`).
+
+### What this establishes
+The entry asks for the classical **calculus** proof of Newton's inequalities:
+`∏(X - xᵢ)` is real-rooted ⇒ (Rolle) each derivative is real-rooted ⇒
+differentiating down to a degree-2 polynomial in three consecutive coefficients
+leaves a real-rooted quadratic whose **discriminant ≥ 0 is Newton's inequality**.
+This route was **not present** anywhere in the ~50-file amgm family:
+- parent `amgm-inequality-oq-02-oq-02` proves Newton by induction, assuming
+  `0 ≤ xᵢ`;
+- sibling `amgm-inequality-oq-02-oq-03-oq-03-oq-01` proves the `k=1` case via a
+  Cauchy–Schwarz / sum-of-squares "discriminant" *metaphor* — a different
+  mechanism, not the discriminant of a real-rooted polynomial.
+
+### Shipped (`Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, namespace `NewtonRealRooted`)
+- **`discrim_nonneg_of_root (a b c x : ℝ) (h : a*(x*x)+b*x+c = 0) : 0 ≤ discrim a b c`**
+  — the reusable **per-derivative atom**. Two lines:
+  `rw [discrim_eq_sq_of_quadratic_eq_zero h]; exact sq_nonneg _`.
+- **`monic_quadratic_discrim_nonneg`** / **`discrim_nonneg_of_roots_nonempty`**
+  — the atom phrased through `Polynomial.IsRoot` and through a nonempty
+  `Polynomial.roots` multiset (genuine real-rootedness), respectively.
+- **`realRooted_quadratic_coeff_ineq`** — coefficient form `4*c ≤ b^2`.
+- **`prod_two_linear_eq`** / **`root_of_prod_two_linear`** — Vieta:
+  `(X - x)(X - y) = X² - (x+y)X + xy`, and `x` is a root.
+- **`newton_two_vars (x y : ℝ) : x*y ≤ ((x+y)/2)^2`** — Newton's `p₁² ≥ p₀p₂` at
+  `n = 2`, obtained as the discriminant of the real-rooted `(X-x)(X-y)`.
+  **No sign hypothesis**: the roots need only be real. This is the signed-input
+  generalization the real-rootedness route enables (the parent needs `0 ≤ xᵢ`).
+
+### Reusable Lean gotchas (researcher-8)
+- **`discrim_eq_sq_of_quadratic_eq_zero {x} (h : a*(x*x)+b*x+c=0) :
+  discrim a b c = (2*a*x+b)^2`** (Mathlib `Algebra/QuadraticDiscriminant.lean`,
+  `CommRing`) is the completed-square identity. It makes "real root ⇒ nonneg
+  discriminant" a 2-line proof over ℝ (`rw` + `sq_nonneg`). `discrim a b c` is
+  defined as `b^2 - 4*a*c`.
+- Bridging `Polynomial.IsRoot` to the atom: `simpa [IsRoot, eval_add, eval_mul,
+  eval_pow, eval_X, eval_C] using hr` gives `r^2 + b*r + c = 0`; the atom wants
+  `1*(r*r)+b*r+c = 0`, so close with **`linear_combination hroot`** (ring knows
+  `r^2 = r*r`).
+- `Multiset.exists_mem_of_ne_zero : s ≠ 0 → ∃ a, a ∈ s` + `mem_roots'.1 hr : p ≠ 0
+  ∧ IsRoot p r` extract a real root from a nonempty `roots` multiset.
+- Pushing `C` through a product: `rw [C_neg, C_add, C_mul]; ring` proves
+  `(X - C x)*(X - C y) = X² + C(-(x+y))*X + C(x*y)` in `ℝ[X]`.
+
+### Still open (the crux)
+The general `n ≥ 3` case needs **"differentiation preserves full real-rootedness
+counting multiplicity"** — iterated Rolle on `∏(X - xᵢ)`. Mathlib has Rolle
+(`exists_hasDerivAt_eq_zero`) and `Polynomial.derivative` / `Polynomial.roots`
+but **not** the packaged lemma
+`p.roots.card = p.natDegree → (derivative p).roots.card = (derivative p).natDegree`.
+`problem.md` estimates this at multi-week difficulty; it is honestly retained as
+open and deliberately **not** stubbed in the file.
+
+### Recommended next increments
+1. Prove the derivative-preserves-real-rootedness lemma (Rolle between
+   consecutive roots + multiplicity at repeated roots).
+2. Newton at `n = 3` as the first nontrivial instance: the derivative of a monic
+   cubic is a quadratic, and Rolle gives its two real roots directly (no general
+   multiplicity machinery needed for this special case).
+
+---
+
+## Problem Understanding
+
+Newton's inequalities `pₖ² ≥ pₖ₋₁ pₖ₊₁` for the normalized elementary symmetric
+means `pₖ = eₖ / C(n,k)` of real numbers. This entry wants the **real-rooted**
+(Rolle/discriminant) proof, which also extends to signed inputs.
+
+---
+
+## Insights
+
+See PART I above.
+
+---
+
+## Dead Ends
+
+None yet.

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/literature/README.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for amgm-inequality-oq-02-oq-02-oq-05
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/problem.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/problem.md
@@ -1,0 +1,154 @@
+# Problem: Newton's Inequality via Real-Rooted Polynomials and Rolle's Theorem
+
+**Slug**: amgm-inequality-oq-02-oq-02-oq-05
+**Created**: 2026-07-04T00:45:01-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For $x_1, \dots, x_n \in \mathbb{R}$, let $e_k$ be the elementary symmetric
+polynomials and $p_k = e_k / \binom{n}{k}$ the normalized (averaged) symmetric
+means, so that
+
+$$
+\prod_{i=1}^{n} (X - x_i) = \sum_{k=0}^{n} (-1)^k e_k\, X^{n-k}.
+$$
+
+**Newton's inequalities**: $p_k^2 \ge p_{k-1}\, p_{k+1}$ for $1 \le k \le n-1$
+(log-concavity of the sequence $p_0, p_1, \dots, p_n$). Give an **alternative
+proof** using the real-rootedness of $\prod (X - x_i)$: repeated application of
+Rolle's theorem shows every derivative of a real-rooted polynomial is again
+real-rooted, and a real-rooted **quadratic** has nonnegative discriminant, which
+is exactly Newton's inequality for consecutive coefficients.
+
+### Plain Language
+
+The parent proof establishes Newton's log-concavity step by a direct inductive
+argument. This generalization formalizes the classical "why it works" via
+calculus: the polynomial $\prod (X - x_i)$ has all real roots; by Rolle's
+theorem so does each of its derivatives; differentiating and dividing down to a
+degree-2 polynomial in the coefficients $e_{k-1}, e_k, e_{k+1}$ leaves a
+real-rooted quadratic, whose discriminant $\ge 0$ **is** Newton's inequality.
+This route also explains why the result should extend more readily to signed
+inputs (the roots need only be real, not positive).
+
+### Why This Matters
+
+Real-rootedness ⇒ log-concavity is a cornerstone technique (used across
+combinatorics — matroids, matching polynomials, the Heron–Rota–Welsh circle of
+ideas). Formalizing the Rolle-based derivation gives a reusable "real-rooted
+implies log-concave coefficients" lemma and a conceptually different proof of
+Newton than the parent's induction.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent proof `amgm-inequality-oq-02-oq-02`: Newton's log-concavity step
+  (Maclaurin's step), proved by a direct/inductive argument.
+- Mathlib: `Polynomial.roots`, `Polynomial.derivative`, `exists_deriv_eq_zero`
+  / Rolle (`exists_hasDerivAt_eq_zero`), `Multiset.esymm`,
+  `Polynomial.esymm` symmetric-function API.
+
+### What's Still Open
+
+- The real-rooted ⇒ log-concave-coefficients lemma as a named result.
+- The Rolle-iteration argument (each derivative of a fully-real-rooted polynomial
+  is fully-real-rooted, counting multiplicity) formalized in Lean.
+
+### Our Goal
+
+Prove Newton's inequalities $p_k^2 \ge p_{k-1}p_{k+1}$ via: (i) real-rootedness
+of $\prod(X-x_i)$, (ii) Rolle-based preservation of real-rootedness under
+differentiation, (iii) the discriminant of the reduced real-rooted quadratic.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| amgm-inequality-oq-02-oq-02 | Direct parent — Newton step by induction | elementary symmetric polys |
+| amgm-inequality | AM–GM base, Maclaurin chain | symmetric means |
+| newton-power-sum-identities | Newton's identities on $e_k$/$p_k$ | symmetric functions |
+| descartes-rule-of-signs | Real-root counting via derivatives | Rolle, sign changes |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Iterated Rolle on the splitting polynomial** (primary): from
+   `Polynomial.roots` having card $= \deg$ (fully real-rooted over $\mathbb{R}$),
+   show `derivative p` is fully real-rooted (Rolle between consecutive roots +
+   multiplicity bookkeeping); iterate $k-1$ times, then differentiate the top
+   down to a quadratic $a e_{k-1} X^2 - b e_k X + c e_{k+1}$ whose real-rootedness
+   forces discriminant $\ge 0$, i.e. $e_k^2 \ge \tfrac{\cdots}{\cdots} e_{k-1}
+   e_{k+1}$; normalize to $p$.
+   - Why it might work: matches the classical proof exactly; Mathlib has Rolle.
+   - Risk: the "derivative preserves full real-rootedness with multiplicity"
+     lemma requires careful multiset counting; reversing the polynomial to
+     isolate three consecutive coefficients needs bookkeeping.
+
+2. **Reuse parent + reframe**: derive the discriminant inequality but cite the
+   parent's algebraic identity where convenient.
+   - Why it might work: lowers risk.
+   - Risk: dilutes the "alternative proof" value the entry is asking for.
+
+### Key Difficulties
+
+- Formalizing "differentiation preserves real-rootedness counting multiplicity"
+  (the crux; may need a dedicated lemma about `roots (derivative p)`).
+- Extracting a clean quadratic in three consecutive $e$'s (reversal /
+  repeated derivative of $X^{n-k+1}\cdot(\text{reverse})$ trick).
+
+### What Would a Proof Need?
+
+- Lemma: over $\mathbb{R}$, if `p.roots.card = p.natDegree` then
+  `(derivative p).roots.card = (derivative p).natDegree` (Rolle + multiplicity).
+- Lemma: a real quadratic with two real roots has discriminant $\ge 0$.
+- Lemma: the appropriate derivative isolates $e_{k-1}, e_k, e_{k+1}$.
+
+## Tractability Assessment
+
+**Difficulty**: Medium (crux lemma may push to Medium–High)
+
+**Justification**:
+- Rolle and polynomial-derivative/roots APIs exist in Mathlib.
+- The multiplicity-counted "derivative preserves real-rootedness" lemma is the
+  main formalization risk; it is standard mathematics but nontrivial in Lean.
+- Parent entry provides the target inequality and normalization conventions.
+
+**Estimated Effort**:
+- Exploration: 2–3 days
+- If tractable: 2–4 weeks (dominated by the real-rootedness-under-derivative
+  lemma)
+
+## References
+
+### Papers
+- Hardy, Littlewood, Pólya, *Inequalities* — Newton's and Maclaurin's
+  inequalities, real-rooted argument.
+
+### Mathlib
+- `Mathlib.Analysis.Calculus.Rolle` — Rolle's theorem.
+- `Mathlib.Algebra.Polynomial.Roots` / `Mathlib.RingTheory.Polynomial.Vieta`
+  — roots, elementary symmetric functions, Vieta.
+
+## Metadata
+
+```yaml
+tags:
+  - inequalities
+  - elementary-symmetric-polynomials
+  - maclaurin-inequalities
+  - newton-inequalities
+  - log-concavity
+  - am-gm
+related_proofs:
+  - amgm-inequality-oq-02-oq-02
+  - newton-power-sum-identities
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04T00:45:01-07:00
+```

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -1,0 +1,39 @@
+# Research State: amgm-inequality-oq-02-oq-02-oq-05
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-07-04
+**Iteration**: 2 (PART I)
+
+## Current Focus
+Formalized the real-rooted/discriminant route to Newton's inequality and closed
+the `n = 2` base case. New file `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`
+(namespace `NewtonRealRooted`): 8 theorems, 0 sorries, 0 axioms (docker-build
+clean, 7743 jobs; Tier-A axiom-free). The reusable per-derivative atom
+`discrim_nonneg_of_root` (real-rooted quadratic ⇒ nonneg discriminant) plus
+`newton_two_vars : x*y ≤ ((x+y)/2)^2` for SIGNED reals, via the discriminant of
+the real-rooted `(X-x)(X-y)`.
+
+## Active Approach
+Classical calculus route: real-rootedness ⇒ (Rolle) derivative real-rooted ⇒
+reduce to a quadratic ⇒ discriminant ≥ 0 is Newton. The quadratic/base atom is
+now complete; the general `n ≥ 3` reduction is the remaining crux.
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (real-rooted/discriminant, base case shipped)
+
+## Blockers
+- **MATH**: general `n ≥ 3` needs the packaged lemma "differentiation preserves
+  full real-rootedness counting multiplicity" (iterated Rolle on `∏(X - xᵢ)`) —
+  not in Mathlib; `problem.md` estimates multi-week. Retained open (not stubbed).
+
+## Next Action
+1. Prove derivative-of-fully-real-rooted-real-polynomial is fully real-rooted
+   (Rolle between consecutive roots + multiplicity at repeated roots).
+2. Newton at `n = 3` as the first nontrivial instance (cubic derivative is a
+   quadratic; Rolle gives its two real roots directly).
+3. Reduce three consecutive coefficients to a quadratic (reverse/differentiate)
+   and apply `discrim_nonneg_of_root` for the general signed-input Newton.

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "amgm-oq020205-header",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "The real-rootedness route to Newton's inequality",
+    "content": "Newton's inequalities state that the normalized elementary symmetric means $p_k = e_k / \\binom{n}{k}$ of real numbers $x_1, \\dots, x_n$ form a log-concave sequence: $p_k^2 \\ge p_{k-1} p_{k+1}$. There are several proofs. The parent entry `amgm-inequality-oq-02-oq-02` proves it by a direct induction that assumes the inputs are nonnegative ($0 \\le x_i$); the sibling `amgm-inequality-oq-02-oq-03-oq-03-oq-01` proves the first inequality ($k=1$) via a Cauchy-Schwarz / sum-of-squares engine. This file develops the third, classical *calculus* route the parent's follow-up asks for and which was not previously present in the family: $\\prod_i (X - x_i)$ is real-rooted; by Rolle's theorem every derivative of a real-rooted polynomial is again real-rooted; differentiating down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, whose nonnegative discriminant *is* Newton's inequality for those coefficients. This entry formalizes the self-contained per-derivative atom and closes the $n=2$ base case.",
+    "mathContext": "The advantage highlighted by the entry: the real-rootedness proof needs only that the roots are *real*, not positive. So the resulting inequality holds for signed inputs, which the parent's induction (needing $0 \\le x_i$) does not cover.",
+    "significance": "supporting",
+    "relatedConcepts": ["Newton's inequalities", "real-rooted polynomials", "Rolle's theorem", "log-concavity", "quadratic discriminant"],
+    "prerequisites": ["elementary symmetric polynomials", "Polynomial.roots", "discriminant of a quadratic"]
+  },
+  {
+    "id": "amgm-oq020205-discrim-atom",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": { "startLine": 56, "endLine": 66 },
+    "type": "key-step",
+    "title": "The atom: a real root forces a nonnegative discriminant",
+    "content": "`discrim_nonneg_of_root` is the single per-derivative building block of the whole Rolle program. If $a x^2 + b x + c = 0$ has a real solution $x$, then Mathlib's `discrim_eq_sq_of_quadratic_eq_zero` gives $\\mathrm{discrim}(a,b,c) = b^2 - 4ac = (2ax + b)^2$, a perfect square, hence $\\ge 0$ by `sq_nonneg`. Read in the Newton setting: after iterated differentiation collapses the real-rooted splitting polynomial to a quadratic in $e_{k-1}, e_k, e_{k+1}$, this lemma turns real-rootedness of that quadratic directly into the coefficient inequality $e_k^2 \\ge \\text{(const)}\\, e_{k-1} e_{k+1}$.",
+    "mathContext": "This is exactly the 'real-rooted implies log-concave coefficients' lemma the entry asks to make reusable. The two-line proof is possible because Mathlib already packages the completed-square identity as `discrim_eq_sq_of_quadratic_eq_zero`.",
+    "significance": "central",
+    "relatedConcepts": ["quadratic discriminant", "completed square", "sq_nonneg"],
+    "prerequisites": ["Mathlib.Algebra.QuadraticDiscriminant"]
+  },
+  {
+    "id": "amgm-oq020205-polynomial-phrasing",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": { "startLine": 68, "endLine": 100 },
+    "type": "key-step",
+    "title": "Phrasing through Polynomial.roots (genuine real-rootedness)",
+    "content": "`monic_quadratic_discrim_nonneg` restates the atom via `Polynomial.IsRoot` for the monic quadratic $X^2 + bX + c$: evaluate at the root, `simp` the `Polynomial.eval` down to $r^2 + br + c = 0$, then feed it to the atom (`linear_combination` bridges $r \\cdot r$ vs $r^2$). `discrim_nonneg_of_roots_nonempty` goes one step further and only assumes the `roots` multiset is nonempty — i.e. the quadratic is real-rooted in the honest `Polynomial.roots` sense — extracting a member with `Multiset.exists_mem_of_ne_zero` and `mem_roots'`. `realRooted_quadratic_coeff_ineq` then reads off the coefficient inequality $4c \\le b^2$.",
+    "mathContext": "Grounding the statement in `Polynomial.roots` (rather than raw algebra) is what makes it the true quadratic instance of 'real-rooted polynomial ⇒ log-concave coefficients', ready to be fed by the iterated-Rolle reduction.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.roots", "Polynomial.IsRoot", "mem_roots"],
+    "prerequisites": ["Polynomial.eval", "Multiset"]
+  },
+  {
+    "id": "amgm-oq020205-newton-n2",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": { "startLine": 102, "endLine": 128 },
+    "type": "key-step",
+    "title": "Newton at n = 2 for signed reals, via the discriminant",
+    "content": "`newton_two_vars` closes the base case: for *all* real $x, y$, $xy \\le ((x+y)/2)^2$. The proof takes the splitting polynomial $(X - x)(X - y) = X^2 - (x+y)X + xy$ (`prod_two_linear_eq`, pushing `C` through with `C_neg/C_add/C_mul` then `ring`), observes $x$ is a root (`root_of_prod_two_linear`), and applies the coefficient inequality to get $(x+y)^2 \\ge 4xy$; `nlinarith` finishes. This is Newton's $p_1^2 \\ge p_0 p_2$ with $p_0 = 1$, $p_1 = (x+y)/2$, $p_2 = xy$. Crucially there is no sign hypothesis — the mechanism is the discriminant of a real-rooted polynomial, so signed inputs are fine.",
+    "mathContext": "The general $n \\ge 3$ case needs 'differentiation preserves full real-rootedness counting multiplicity' (iterated Rolle on $\\prod(X - x_i)$), the multi-week crux flagged in problem.md. It is honestly retained as open and is not stubbed in this file.",
+    "significance": "central",
+    "relatedConcepts": ["Newton's inequalities", "Vieta's formulas", "AM-GM", "signed inputs"],
+    "prerequisites": ["prod_two_linear_eq", "realRooted_quadratic_coeff_ineq"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -1,0 +1,77 @@
+{
+  "slug": "amgm-inequality-oq-02-oq-02-oq-05",
+  "id": "amgm-inequality-oq-02-oq-02-oq-05",
+  "title": "Newton's Inequality via Real-Rootedness: the Quadratic Discriminant Atom",
+  "description": "The base case of the classical calculus proof of Newton's inequalities: a real-rooted quadratic has a nonnegative discriminant, which for the splitting polynomial (X - x)(X - y) is exactly Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — valid for signed inputs.",
+  "overview": "Newton's inequalities p_k^2 >= p_{k-1} p_{k+1} (log-concavity of the normalized elementary symmetric means) have a classical calculus proof: the monic polynomial prod (X - x_i) with x_i real is real-rooted; by Rolle's theorem so is each of its derivatives; differentiating down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, whose discriminant >= 0 IS Newton's inequality. This entry formalizes the self-contained ATOM of that program — the per-derivative step — and completes the n = 2 base case end to end. Unlike the parent's inductive proof (which assumes 0 <= x_i) and the sibling Cauchy-Schwarz route, the real-rootedness argument needs only that the roots are REAL, so newton_two_vars holds for arbitrary signed x, y. The general n >= 3 case requires the crux lemma 'differentiation preserves full real-rootedness counting multiplicity' (iterated Rolle), which is honestly retained as open.",
+  "conclusion": "For all real x, y: x*y <= ((x+y)/2)^2, i.e. Newton's inequality p_1^2 >= p_0 p_2 at n = 2, obtained as the discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved via Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased through the Polynomial.roots API. All 8 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+  "mainTheorems": [
+    "discrim_nonneg_of_root",
+    "monic_quadratic_discrim_nonneg",
+    "realRooted_quadratic_coeff_ineq",
+    "newton_two_vars"
+  ],
+  "sorries": [],
+  "sections": [],
+  "crossReferences": [
+    "amgm-inequality-oq-02-oq-02",
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "newton-power-sum-identities",
+    "descartes-rule-of-signs"
+  ],
+  "references": [
+    {
+      "title": "Hardy, Littlewood, Pólya — Inequalities (§2.22, Newton's and Maclaurin's inequalities)",
+      "url": "https://en.wikipedia.org/wiki/Newton%27s_inequalities"
+    },
+    {
+      "title": "Mathlib — Algebra.QuadraticDiscriminant",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/QuadraticDiscriminant.html"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ02OQ05.lean",
+    "namespace": "NewtonRealRooted",
+    "imports": ["Mathlib"],
+    "additionalFiles": [],
+    "lineCount": 128,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_inequalities",
+    "date": "Classical result (Newton 1707); real-rooted/discriminant proof formalized 2026",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "inequalities",
+      "elementary-symmetric-polynomials",
+      "newton-inequalities",
+      "log-concavity",
+      "real-rooted-polynomials",
+      "quadratic-discriminant",
+      "am-gm"
+    ],
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ02OQ05.lean",
+    "additionalFiles": [],
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 8 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
+    "originalContributions": [
+      "discrim_nonneg_of_root: a real quadratic a*x^2 + b*x + c with a real root has 0 <= discrim a b c — the reusable per-derivative 'real-rooted => log-concave coefficients' atom of the Rolle program",
+      "monic_quadratic_discrim_nonneg: the same via Polynomial.IsRoot for the monic quadratic X^2 + C b * X + C c",
+      "discrim_nonneg_of_roots_nonempty: real-rootedness phrased through a nonempty Polynomial.roots multiset",
+      "realRooted_quadratic_coeff_ineq: coefficient form 4*c <= b^2",
+      "prod_two_linear_eq / root_of_prod_two_linear: Vieta for (X - x)(X - y) and its roots",
+      "newton_two_vars: Newton's inequality x*y <= ((x+y)/2)^2 at n = 2 for SIGNED reals, via the discriminant of the real-rooted (X - x)(X - y) — the signed-input generalization the real-rootedness route enables (the parent's induction needs 0 <= x_i)"
+    ],
+    "dateAdded": "2026-07-04",
+    "lineCount": 128,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  }
+}

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
@@ -1,0 +1,133 @@
+{
+  "slug": "amgm-inequality-oq-02-oq-02-oq-05",
+  "title": "Newton's Inequality via Real-Rooted Polynomials and Rolle's Theorem",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\prod_{i=1}^{n} (X - x_i) = \\sum_{k=0}^{n} (-1)^k e_k\\, X^{n-k}.",
+    "plain": "The parent proof establishes Newton's log-concavity step by a direct inductive",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-04T00:45:01-07:00",
+    "iteration": 2,
+    "focus": "Formalized the real-rooted/discriminant route: the reusable per-derivative atom plus the n=2 Newton base case for signed reals (0 sorries, 0 axioms).",
+    "blockers": [],
+    "nextAction": "General n>=3 needs the iterated-Rolle crux: differentiation preserves full real-rootedness counting multiplicity. Prove derivative-of-splitting-real-polynomial is real-rooted, then reduce three consecutive coefficients to a quadratic.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: New proof route (real-rootedness/discriminant) established in the amgm family and complete for the quadratic/n=2 base case, valid for SIGNED inputs. AmgmInequalityOQ02OQ02OQ05.lean: 8 theorems, 0 sorries, 0 axioms (foundational only). General n>=3 retained open (iterated-Rolle crux).",
+    "builtItems": [
+      "discrim_nonneg_of_root in Proofs/AmgmInequalityOQ02OQ02OQ05.lean (real quadratic with a real root has 0 <= discrim)",
+      "monic_quadratic_discrim_nonneg / discrim_nonneg_of_roots_nonempty (same via Polynomial.IsRoot and nonempty Polynomial.roots)",
+      "realRooted_quadratic_coeff_ineq (4*c <= b^2)",
+      "prod_two_linear_eq + root_of_prod_two_linear (Vieta for (X-x)(X-y))",
+      "newton_two_vars: x*y <= ((x+y)/2)^2 for signed reals, via the discriminant of the real-rooted (X-x)(X-y)"
+    ],
+    "insights": [
+      "Mathlib packages the completed-square identity as discrim_eq_sq_of_quadratic_eq_zero (h : a*(x*x)+b*x+c=0) : discrim a b c = (2*a*x+b)^2, so real-root implies nonneg discriminant is a 2-line proof (rw + sq_nonneg). This is the per-derivative atom of the whole Newton/Rolle program.",
+      "The real-rootedness route needs only REAL (not positive) roots, so Newton at n=2 (newton_two_vars: x*y <= ((x+y)/2)^2) holds for SIGNED x,y, a genuine generalization over the parent amgm-inequality-oq-02-oq-02 whose induction assumes 0 <= x_i.",
+      "Nobody else in the ~50-file amgm family used Polynomial.roots / Rolle / the quadratic discriminant of a splitting polynomial; the sibling oq-02-oq-03-oq-03-oq-01 uses a Cauchy-Schwarz SOS discriminant metaphor, a different mechanism.",
+      "The remaining crux is exactly differentiation preserves full real-rootedness counting multiplicity (iterated Rolle on prod (X - x_i)); Mathlib has Rolle (exists_hasDerivAt_eq_zero) and Polynomial.derivative/roots but not this packaged lemma."
+    ],
+    "mathlibGaps": [
+      "No packaged lemma: over R, p.roots.card = p.natDegree implies (derivative p).roots.card = (derivative p).natDegree (Rolle + multiplicity). This is the crux for general n."
+    ],
+    "nextSteps": [
+      "Prove: derivative of a fully-real-rooted real polynomial is fully real-rooted (Rolle between consecutive roots + multiplicity at repeated roots).",
+      "Reduce three consecutive coefficients to a quadratic by reversing/differentiating, then apply discrim_nonneg_of_root to get the general Newton inequality for signed reals.",
+      "Prove Newton at n=3 as the first nontrivial instance (cubic derivative is a quadratic; Rolle gives its two real roots directly)."
+    ],
+    "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "inequalities",
+    "elementary-symmetric-polynomials",
+    "maclaurin-inequalities",
+    "newton-inequalities",
+    "log-concavity",
+    "am-gm"
+  ],
+  "relatedProofs": [
+    "amgm-inequality",
+    "amgm-inequality-oq-02",
+    "amgm-inequality-oq-02-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-01-oq-02",
+    "amgm-inequality-oq-02-oq-01-oq-02",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03",
+    "amgm-inequality-oq-02-oq-01-oq-03",
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "amgm-inequality-oq-02-oq-01-oq-04",
+    "amgm-inequality-oq-02-oq-01-oq-05",
+    "amgm-inequality-oq-02-oq-02",
+    "amgm-inequality-oq-02-oq-02-oq-02",
+    "amgm-inequality-oq-02-oq-03",
+    "amgm-inequality-oq-02-oq-03-oq-03",
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "amgm-inequality-oq-02-oq-04",
+    "amgm-inequality-oq-02-oq-05",
+    "amgm-inequality-oq-03",
+    "amgm-inequality-oq-03-oq-01",
+    "amgm-inequality-oq-03-oq-01-oq-01",
+    "amgm-inequality-oq-03-oq-01-oq-02",
+    "amgm-inequality-oq-03-oq-02-oq-01-oq-01",
+    "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "amgm-inequality-oq-03-oq-02-oq-04",
+    "amgm-inequality-oq-03-oq-02-oq-04-oq-02",
+    "amgm-inequality-oq-03-oq-03",
+    "amgm-inequality-oq-03-oq-03-oq-01",
+    "amgm-inequality-oq-03-oq-03-oq-02",
+    "amgm-inequality-oq-03-oq-04",
+    "amgm-inequality-oq-03-oq-04-oq-02",
+    "amgm-inequality-oq-04",
+    "amgm-inequality-oq-04-oq-02",
+    "amgm-inequality-oq-04-oq-04",
+    "amgm-inequality-oq-04-oq-05",
+    "amgm-inequality-oq-05",
+    "amgm-inequality-oq-05-oq-01",
+    "amgm-inequality-oq-05-oq-02",
+    "amgm-inequality-oq-05-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-04T09:09:15.544Z",
+  "lastUpdate": "2026-07-04T10:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/AmgmInequalityOQ02OQ02OQ05.lean",
+      "filename": "AmgmInequalityOQ02OQ02OQ05.lean",
+      "lineCount": 128,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Formalizes the classical **calculus** proof route to Newton's inequalities that this OQ asks for — real-rootedness of `∏(X - xᵢ)` ⇒ (Rolle) each derivative real-rooted ⇒ the reduced quadratic's discriminant ≥ 0 **is** Newton's inequality — and completes its self-contained atom and the `n = 2` base case. This route was **not present** in the ~50-file amgm family: the parent `amgm-inequality-oq-02-oq-02` proves Newton by induction assuming `0 ≤ xᵢ`, and the sibling `…-oq-03-oq-03-oq-01` uses a Cauchy–Schwarz sum-of-squares "discriminant" metaphor (a different mechanism).

## New file
`proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean` (namespace `NewtonRealRooted`), **8 theorems, 0 sorries, 0 axioms**:

- `discrim_nonneg_of_root` — a real-rooted quadratic has `0 ≤ discrim a b c`; the reusable per-derivative atom (via Mathlib `discrim_eq_sq_of_quadratic_eq_zero` + `sq_nonneg`).
- `monic_quadratic_discrim_nonneg` / `discrim_nonneg_of_roots_nonempty` — same through `Polynomial.IsRoot` and a nonempty `Polynomial.roots` multiset (genuine real-rootedness).
- `realRooted_quadratic_coeff_ineq` — coefficient form `4c ≤ b²`.
- `prod_two_linear_eq` / `root_of_prod_two_linear` — Vieta for `(X-x)(X-y)`.
- `newton_two_vars` — `x·y ≤ ((x+y)/2)²` for **signed** reals, i.e. Newton's `p₁² ≥ p₀p₂` at `n=2`, obtained as the discriminant of the real-rooted `(X-x)(X-y)`. No sign hypothesis — the advantage the real-rootedness route provides.

## Verification
`docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` → **Build completed successfully (7743 jobs)**. `#print axioms` for the main theorems lists only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **verified / original**.

## Status
**Outcome**: progress (fresh problem, first pass). New proof route established and complete for the quadratic/`n=2` base case.
**Retained open (honest)**: general `n ≥ 3` needs the iterated-Rolle crux "differentiation preserves full real-rootedness counting multiplicity" (not in Mathlib; multi-week per `problem.md`) — documented in knowledge.md, **not** stubbed with a sorry.
**Next**: derivative-preserves-real-rootedness lemma; Newton at `n=3` (cubic derivative is a quadratic, Rolle gives its two real roots directly).

🤖 Generated by researcher-8