### PR TITLE
Enrich Newton Real-Rooted (amgm-oq020205): add sections + normalized-form annotation

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
@@ -2,49 +2,115 @@
   {
     "id": "amgm-oq020205-header",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
-    "range": { "startLine": 1, "endLine": 47 },
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
     "type": "concept",
     "title": "The real-rootedness route to Newton's inequality",
     "content": "Newton's inequalities state that the normalized elementary symmetric means $p_k = e_k / \\binom{n}{k}$ of real numbers $x_1, \\dots, x_n$ form a log-concave sequence: $p_k^2 \\ge p_{k-1} p_{k+1}$. There are several proofs. The parent entry `amgm-inequality-oq-02-oq-02` proves it by a direct induction that assumes the inputs are nonnegative ($0 \\le x_i$); the sibling `amgm-inequality-oq-02-oq-03-oq-03-oq-01` proves the first inequality ($k=1$) via a Cauchy-Schwarz / sum-of-squares engine. This file develops the third, classical *calculus* route the parent's follow-up asks for and which was not previously present in the family: $\\prod_i (X - x_i)$ is real-rooted; by Rolle's theorem every derivative of a real-rooted polynomial is again real-rooted; differentiating down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, whose nonnegative discriminant *is* Newton's inequality for those coefficients. This entry formalizes the self-contained per-derivative atom and closes the $n=2$ base case.",
     "mathContext": "The advantage highlighted by the entry: the real-rootedness proof needs only that the roots are *real*, not positive. So the resulting inequality holds for signed inputs, which the parent's induction (needing $0 \\le x_i$) does not cover.",
     "significance": "supporting",
-    "relatedConcepts": ["Newton's inequalities", "real-rooted polynomials", "Rolle's theorem", "log-concavity", "quadratic discriminant"],
-    "prerequisites": ["elementary symmetric polynomials", "Polynomial.roots", "discriminant of a quadratic"]
+    "relatedConcepts": [
+      "Newton's inequalities",
+      "real-rooted polynomials",
+      "Rolle's theorem",
+      "log-concavity",
+      "quadratic discriminant"
+    ],
+    "prerequisites": [
+      "elementary symmetric polynomials",
+      "Polynomial.roots",
+      "discriminant of a quadratic"
+    ]
   },
   {
     "id": "amgm-oq020205-discrim-atom",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
-    "range": { "startLine": 56, "endLine": 66 },
+    "range": {
+      "startLine": 56,
+      "endLine": 66
+    },
     "type": "key-step",
     "title": "The atom: a real root forces a nonnegative discriminant",
     "content": "`discrim_nonneg_of_root` is the single per-derivative building block of the whole Rolle program. If $a x^2 + b x + c = 0$ has a real solution $x$, then Mathlib's `discrim_eq_sq_of_quadratic_eq_zero` gives $\\mathrm{discrim}(a,b,c) = b^2 - 4ac = (2ax + b)^2$, a perfect square, hence $\\ge 0$ by `sq_nonneg`. Read in the Newton setting: after iterated differentiation collapses the real-rooted splitting polynomial to a quadratic in $e_{k-1}, e_k, e_{k+1}$, this lemma turns real-rootedness of that quadratic directly into the coefficient inequality $e_k^2 \\ge \\text{(const)}\\, e_{k-1} e_{k+1}$.",
     "mathContext": "This is exactly the 'real-rooted implies log-concave coefficients' lemma the entry asks to make reusable. The two-line proof is possible because Mathlib already packages the completed-square identity as `discrim_eq_sq_of_quadratic_eq_zero`.",
     "significance": "central",
-    "relatedConcepts": ["quadratic discriminant", "completed square", "sq_nonneg"],
-    "prerequisites": ["Mathlib.Algebra.QuadraticDiscriminant"]
+    "relatedConcepts": [
+      "quadratic discriminant",
+      "completed square",
+      "sq_nonneg"
+    ],
+    "prerequisites": [
+      "Mathlib.Algebra.QuadraticDiscriminant"
+    ]
   },
   {
     "id": "amgm-oq020205-polynomial-phrasing",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
-    "range": { "startLine": 68, "endLine": 100 },
+    "range": {
+      "startLine": 68,
+      "endLine": 100
+    },
     "type": "key-step",
     "title": "Phrasing through Polynomial.roots (genuine real-rootedness)",
     "content": "`monic_quadratic_discrim_nonneg` restates the atom via `Polynomial.IsRoot` for the monic quadratic $X^2 + bX + c$: evaluate at the root, `simp` the `Polynomial.eval` down to $r^2 + br + c = 0$, then feed it to the atom (`linear_combination` bridges $r \\cdot r$ vs $r^2$). `discrim_nonneg_of_roots_nonempty` goes one step further and only assumes the `roots` multiset is nonempty — i.e. the quadratic is real-rooted in the honest `Polynomial.roots` sense — extracting a member with `Multiset.exists_mem_of_ne_zero` and `mem_roots'`. `realRooted_quadratic_coeff_ineq` then reads off the coefficient inequality $4c \\le b^2$.",
     "mathContext": "Grounding the statement in `Polynomial.roots` (rather than raw algebra) is what makes it the true quadratic instance of 'real-rooted polynomial ⇒ log-concave coefficients', ready to be fed by the iterated-Rolle reduction.",
     "significance": "supporting",
-    "relatedConcepts": ["Polynomial.roots", "Polynomial.IsRoot", "mem_roots"],
-    "prerequisites": ["Polynomial.eval", "Multiset"]
+    "relatedConcepts": [
+      "Polynomial.roots",
+      "Polynomial.IsRoot",
+      "mem_roots"
+    ],
+    "prerequisites": [
+      "Polynomial.eval",
+      "Multiset"
+    ]
   },
   {
     "id": "amgm-oq020205-newton-n2",
     "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
-    "range": { "startLine": 102, "endLine": 128 },
+    "range": {
+      "startLine": 102,
+      "endLine": 128
+    },
     "type": "key-step",
     "title": "Newton at n = 2 for signed reals, via the discriminant",
     "content": "`newton_two_vars` closes the base case: for *all* real $x, y$, $xy \\le ((x+y)/2)^2$. The proof takes the splitting polynomial $(X - x)(X - y) = X^2 - (x+y)X + xy$ (`prod_two_linear_eq`, pushing `C` through with `C_neg/C_add/C_mul` then `ring`), observes $x$ is a root (`root_of_prod_two_linear`), and applies the coefficient inequality to get $(x+y)^2 \\ge 4xy$; `nlinarith` finishes. This is Newton's $p_1^2 \\ge p_0 p_2$ with $p_0 = 1$, $p_1 = (x+y)/2$, $p_2 = xy$. Crucially there is no sign hypothesis — the mechanism is the discriminant of a real-rooted polynomial, so signed inputs are fine.",
     "mathContext": "The general $n \\ge 3$ case needs 'differentiation preserves full real-rootedness counting multiplicity' (iterated Rolle on $\\prod(X - x_i)$), the multi-week crux flagged in problem.md. It is honestly retained as open and is not stubbed in this file.",
     "significance": "central",
-    "relatedConcepts": ["Newton's inequalities", "Vieta's formulas", "AM-GM", "signed inputs"],
-    "prerequisites": ["prod_two_linear_eq", "realRooted_quadratic_coeff_ineq"]
+    "relatedConcepts": [
+      "Newton's inequalities",
+      "Vieta's formulas",
+      "AM-GM",
+      "signed inputs"
+    ],
+    "prerequisites": [
+      "prod_two_linear_eq",
+      "realRooted_quadratic_coeff_ineq"
+    ]
+  },
+  {
+    "id": "amgm-oq020205-normalized",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 121,
+      "endLine": 127
+    },
+    "type": "insight",
+    "title": "The normalized p-form: reading the atom as log-concavity",
+    "content": "`newton_two_vars_normalized` restates the base case as $1 \\cdot (xy) \\le ((x+y)/2)^2$ — trivially equivalent to `newton_two_vars` via `simpa`, but written to expose the canonical Newton shape $p_1^2 \\ge p_0\\, p_2$. Here $p_0 = e_0 = 1$, $p_1 = e_1/\\binom{2}{1} = (x+y)/2$, and $p_2 = e_2/\\binom{2}{2} = xy$ are the *normalized* elementary symmetric means, so the inequality is precisely the $k=1$ instance of log-concavity $p_k^2 \\ge p_{k-1}p_{k+1}$. For two variables this single inequality is the entire Newton chain, and dividing by $p_0=1$ recovers the AM–GM statement $\\sqrt{xy} \\le (x+y)/2$ whenever $x, y \\ge 0$.",
+    "mathContext": "The normalization by the binomial coefficients $\\binom{n}{k}$ is what makes Newton's inequalities strictly stronger than Maclaurin's ($p_1 \\ge p_2^{1/2} \\ge \\dots \\ge p_n^{1/n}$) and is essential for the log-concavity phrasing; at $n=2$ the two coincide and both reduce to AM–GM.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "normalized elementary symmetric means",
+      "log-concavity",
+      "Maclaurin's inequality",
+      "AM-GM"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "newton_two_vars"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -12,7 +12,36 @@
     "newton_two_vars"
   ],
   "sorries": [],
-  "sections": [],
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Program overview: the real-rootedness route",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring situating this file against the two sibling proofs. It states the classical calculus strategy — differentiate the real-rooted splitting polynomial prod (X - x_i) down to degree two (Rolle), whose nonnegative discriminant IS Newton's inequality — and scopes this entry to the self-contained per-derivative atom plus the n = 2 base case, honestly retaining the general iterated-Rolle step as open."
+    },
+    {
+      "id": "discriminant-atom",
+      "title": "The discriminant atom",
+      "startLine": 52,
+      "endLine": 63,
+      "summary": "discrim_nonneg_of_root: a real quadratic a x^2 + b x + c with a real root has 0 <= discrim a b c. Proved in two lines by rewriting with Mathlib's discrim_eq_sq_of_quadratic_eq_zero (which packages the completed-square identity discrim a b c = (2 a x + b)^2) and closing with sq_nonneg. This is the reusable 'real-rooted => log-concave coefficients' building block."
+    },
+    {
+      "id": "polynomial-api",
+      "title": "Phrasing through the Polynomial API",
+      "startLine": 65,
+      "endLine": 94,
+      "summary": "Restates the atom in genuine real-rootedness terms: monic_quadratic_discrim_nonneg (via Polynomial.IsRoot on X^2 + C b X + C c), discrim_nonneg_of_roots_nonempty (assuming only that the roots multiset is nonempty, extracting a member with mem_roots'), and realRooted_quadratic_coeff_ineq reading off the coefficient inequality 4 c <= b^2."
+    },
+    {
+      "id": "splitting-newton-n2",
+      "title": "The splitting polynomial and Newton at n = 2",
+      "startLine": 96,
+      "endLine": 128,
+      "summary": "Vieta for two roots (prod_two_linear_eq: (X - x)(X - y) = X^2 - (x+y) X + x y), the fact that x is a root (root_of_prod_two_linear), then newton_two_vars: x y <= ((x+y)/2)^2 for ALL real x, y via the discriminant, and its normalized restatement newton_two_vars_normalized emphasizing the p_1^2 >= p_0 p_2 shape."
+    }
+  ],
   "crossReferences": [
     "amgm-inequality-oq-02-oq-02",
     "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
@@ -32,7 +61,9 @@
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ02OQ05.lean",
     "namespace": "NewtonRealRooted",
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "additionalFiles": [],
     "lineCount": 128,
     "theoremCount": 8,


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-02-oq-05` (passes 0, quality 50).

**Sections** (`meta.json` `sections` was `[]`): added 4 sections covering all 128 lines of the Lean file — program-overview docstring, the discriminant atom, the Polynomial-API phrasing, and the splitting-polynomial / Newton-at-n=2 block.

**Annotations** (4 → 5): added an annotation for `newton_two_vars_normalized` (lines 121–127), previously uncovered by a dedicated annotation. It explains the normalized p-form $p_1^2 \ge p_0 p_2$, the log-concavity reading, and the relation to Maclaurin's inequality and AM–GM.

Content-only JSON enrichment; no Lean source changes. `status`/`badge`/`axiomCount` unchanged and consistent with the verified 0-axiom file.