### PR TITLE
research(ramsey-r4k-extensions-oq-03): exact +1/step deletion-window growth rate (XVI)

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean
@@ -359,6 +359,64 @@ theorem deletionBound_mono_of_unionFeasible (hk : 2 ≤ k) (hkn : k ≤ n)
     deletionBound n k ≤ deletionBound (n + 1) k :=
   deletionBound_mono_of_pred_subthreshold hk hkn (by omega)
 
+/-- **Exact one-step growth: the deletion bound gains *precisely one* vertex per step
+    when the added `(k−1)`-mass fits inside the current quantum remainder.**
+    `deletionBound_mono_of_pred_subthreshold` only shows the bound does not *decrease*
+    (`≤`).  The sharper question is *when it strictly grows*, and by how much.  Write
+    `q = 2^C(k,2)` and `a = 2·C(n,k)`; the deleted-vertex count is the floor `⌊a/q⌋`, so
+    `deletionBound n k = n − ⌊a/q⌋`.  By Pascal's rule the next numerator is
+    `2·C(n+1,k) = a + 2·C(n,k−1)`, i.e. the mass added in one step is `b = 2·C(n,k−1)`.
+    The floor `⌊(a+b)/q⌋` fails to advance — stays equal to `⌊a/q⌋` — exactly when the
+    added mass does not push the current remainder `a mod q` across the next multiple of
+    `q`, i.e. when
+
+        `(2·C(n,k) mod 2^C(k,2)) + 2·C(n,k−1) < 2^C(k,2)`.
+
+    Under that remainder condition the deleted count is unchanged while the host grows by
+    one, so the guaranteed monochromatic-`Kₖ`-free set gains **exactly one vertex**:
+    `deletionBound (n+1) k = deletionBound n k + 1`.  The extra hypothesis
+    `⌊a/q⌋ ≤ n` (the deleted count does not exceed the host — automatic wherever the
+    deletion bound is nonzero) makes the `ℕ` truncated subtraction exact.  This upgrades
+    the qualitative "`≤`" window monotonicity to the quantitative growth *rate* the earlier
+    parts left open — and it is still pure `ℕ`-division (`Nat.add_div`), valid for every
+    `k`, axiom-free. -/
+theorem deletionBound_stepGain (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hrem : (2 * n.choose k) % 2 ^ (k.choose 2) + 2 * n.choose (k - 1) < 2 ^ (k.choose 2))
+    (hlive : (2 * n.choose k) / 2 ^ (k.choose 2) ≤ n) :
+    deletionBound (n + 1) k = deletionBound n k + 1 := by
+  have hq : 0 < 2 ^ (k.choose 2) := pow_pos (by norm_num) _
+  -- Pascal's rule: the mass added in one step is `2·C(n,k−1)`.
+  have hpascal : 2 * (n + 1).choose k = 2 * n.choose k + 2 * n.choose (k - 1) := by
+    have h : (n + 1).choose k = n.choose k + n.choose (k - 1) := by
+      obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+      simp only [Nat.choose_succ_succ, Nat.add_sub_cancel]
+      ring
+    omega
+  simp only [deletionBound]
+  set q := 2 ^ (k.choose 2) with hq_def
+  set a := 2 * n.choose k with ha_def
+  set c := 2 * (n + 1).choose k with hc_def
+  set b := 2 * n.choose (k - 1) with hb_def
+  -- The added mass is below one quantum (a fortiori from the remainder condition).
+  have hbq : b < q := by omega
+  -- Hence the floor does not advance: `⌊(a+b)/q⌋ = ⌊a/q⌋`.
+  have hcq : c / q = a / q := by
+    rw [hpascal, Nat.add_div hq, Nat.mod_eq_of_lt hbq, Nat.div_eq_of_lt hbq]
+    have hnot : ¬ (q ≤ a % q + b) := by omega
+    simp [hnot]
+  omega
+
+/-- **Strict growth corollary.**  Under the same remainder condition, the deletion bound
+    is *strictly* increasing at `n`: `deletionBound n k < deletionBound (n+1) k`.  So the
+    window is not merely nonshrinking — wherever the current remainder has room for the
+    added `(k−1)`-mass, adding a vertex genuinely enlarges the certified
+    monochromatic-`Kₖ`-free set.  Immediate from `deletionBound_stepGain`. -/
+theorem deletionBound_strictMono_of_remainder (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hrem : (2 * n.choose k) % 2 ^ (k.choose 2) + 2 * n.choose (k - 1) < 2 ^ (k.choose 2))
+    (hlive : (2 * n.choose k) / 2 ^ (k.choose 2) ≤ n) :
+    deletionBound n k < deletionBound (n + 1) k := by
+  rw [deletionBound_stepGain hk hkn hrem hlive]; omega
+
 /-- **The deletion bound is monotone across the entire `(k−1)` sub-threshold window.**
     `deletionBound_mono_of_pred_subthreshold` shows a *single* step `n → n+1` never
     decreases the deletion bound while `2·C(n,k−1) < 2^C(k,2)`.  Chaining that step by
@@ -652,6 +710,8 @@ theorem deletion_no_mono_K10 :
 #print axioms ramsey_deletion_one_past
 #print axioms deletionBound_mono_of_pred_subthreshold
 #print axioms deletionBound_mono_of_unionFeasible
+#print axioms deletionBound_stepGain
+#print axioms deletionBound_strictMono_of_remainder
 #print axioms deletionBound_mono_window
 #print axioms deletion_noloss_across_window
 #print axioms deletion_no_mono_K6

--- a/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/knowledge.md
@@ -448,3 +448,42 @@ The symmetric-LLL avoidance principle `SymmetricLLLForRamsey` (>1000-line measur
 construction: probability space + mutual-independence `hindep`) remains the one non-Mathlib
 ingredient (BLOCKED). See sibling `lovasz-local-lemma-oq-01`. All finite/combinatorial and
 now the window-monotonicity content is discharged axiom-free.
+
+## PART XVI — exact growth rate: +1 vertex per step (researcher-5, 2026-07-04)
+
+**Mode**: ACT (RICH, score 36). **Outcome**: progress (+2 verified theorems, axiom-free).
+Machine-verified: docker-build clean, 7744 jobs, foundational axioms only
+(`propext / Classical.choice / Quot.sound`); no `decide`, no `native_decide`.
+
+### What this closes
+PARTs XIV–XV proved the deletion bound is *nondecreasing* (`≤`) across the `(k−1)`-window
+but left open *when it strictly grows and by how much* — the prior notes flagged this as
+"needs binomial-ratio estimates rather than `decide`." This session gives the exact integer
+answer via `Nat.add_div`.
+
+- **`deletionBound_stepGain`** (`2 ≤ k`, `k ≤ n`,
+  remainder `2·C(n,k) mod q + 2·C(n,k−1) < q`, live `⌊2·C(n,k)/q⌋ ≤ n`, `q = 2^C(k,2)`):
+  `deletionBound (n+1) k = deletionBound n k + 1`. The deleted-vertex floor `⌊a/q⌋`
+  cannot advance when the step's added mass `b = 2·C(n,k−1)` fits inside the current
+  remainder `a mod q`, so the host gains one vertex and the deleted count is unchanged —
+  net `+1`.
+- **`deletionBound_strictMono_of_remainder`**: strict corollary,
+  `deletionBound n k < deletionBound (n+1) k` under the same hypotheses.
+
+### Technique (floor-nonadvance idiom via `Nat.add_div`)
+The whole `⌊(a+b)/q⌋ = ⌊a/q⌋` step is `Nat.add_div hq` (`0 < q`), which expands
+`(a+b)/q = a/q + b/q + if q ≤ a%q + b%q then 1 else 0`. With `b < q` (a fortiori from the
+remainder condition): `b%q = b` (`Nat.mod_eq_of_lt`), `b/q = 0` (`Nat.div_eq_of_lt`), and the
+`if` collapses to `0` because `¬(q ≤ a%q + b)` is exactly the remainder hypothesis
+(`omega` + `simp [hnot]`). Then `omega` finishes `(n+1) − a/q = (n − a/q) + 1` given the
+live hypothesis `a/q ≤ n` (needed for exact ℕ truncated subtraction). Pascal's rule
+`2·C(n+1,k) = 2·C(n,k) + 2·C(n,k−1)` reused verbatim from PART XIV. Note: `b < q` alone
+(the PART-XIV hypothesis) gives only `≤`; the *strict/exact* result needs the sharper
+`a%q + b < q`, so these theorems are genuinely stronger, not restatements.
+
+### Elementary line now saturated
+The `+1`/step law is the sharpest possible integer statement of the deletion-window growth
+rate; no further elementary-`Nat` increment remains. Remaining directions both need
+machinery beyond `omega`: (a) the BLOCKED `SymmetricLLLForRamsey` measure theory (>1000
+lines, sibling `lovasz-local-lemma-oq-01`), or (b) `Nat.choose` / Stirling asymptotics
+(real analysis). Recommend releasing the claim.

--- a/research/problems/ramsey-r4k-extensions-oq-03/state.md
+++ b/research/problems/ramsey-r4k-extensions-oq-03/state.md
@@ -4,25 +4,26 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 15 (PART XV)
+**Iteration**: 16 (PART XVI)
 
 ## Current Focus
-Globalized the PART-XIV single-step monotonicity into the window-wide statement its own
-docstring only asserted. Two new axiom-free theorems in
+Upgraded the qualitative window monotonicity (`≤`) to a **quantitative growth rate**:
+the deletion bound grows by *exactly one vertex per step* under an explicit remainder
+condition. Two new axiom-free theorems in
 `Proofs/RamseyR4kExtensionsOQ03Deletion.lean`:
-- `deletionBound_mono_window`: chaining the single step by `Nat.le_induction`,
-  `deletionBound n k ≤ deletionBound N k` whenever `2·C(m,k−1) < 2^C(k,2)` for every
-  `m ∈ [n, N)`. So the deletion optimum is attained no earlier than the *top* of the
-  `(k−1)`-window — the general, `decide`-free statement that the alteration bound keeps
-  climbing past the union cap (top of the strictly narrower `k`-window).
-- `deletion_noloss_across_window`: Ramsey form — for any `N` reachable across the
-  `(k−1)`-window there is a 2-colouring of `K_N` with a monochromatic-`Kₖ`-free set of at
-  least `deletionBound n k` vertices. This is the general mechanism instantiated by the
-  concrete `+1/+2/+3/+4` witnesses at `k = 6,7,8,9`.
+- `deletionBound_stepGain`: with `q = 2^C(k,2)`, `a = 2·C(n,k)`, if the current
+  remainder has room for the added `(k−1)`-mass — `a mod q + 2·C(n,k−1) < q` — and the
+  deleted count is live (`⌊a/q⌋ ≤ n`), then `deletionBound (n+1) k = deletionBound n k + 1`.
+  Exact `+1` per step, proved via `Nat.add_div`: the floor `⌊(a+b)/q⌋` cannot advance
+  when the added mass `b` does not push `a mod q` across the next multiple of `q`.
+- `deletionBound_strictMono_of_remainder`: strict-inequality corollary,
+  `deletionBound n k < deletionBound (n+1) k` under the same remainder condition — the
+  window is not merely nonshrinking but genuinely *growing* wherever the remainder has room.
 
-PART XIV proved only the single step `n → n+1`; PART XV turns that into the whole run,
-completing the "runs out to the top of the `(k−1)`-window" claim. Pure `Nat` induction on
-top of the existing Pascal-rule step; closed by `le_trans`/`omega`. No `decide`, no
+PART XV proved only `≤` (the bound never shrinks across the `(k−1)`-window); PART XVI pins
+*when and by how much* it strictly increases, closing the "how fast does the window grow"
+question the prior notes flagged as needing binomial-ratio estimates — supplying the exact
+integer answer (+1/step) via the same Pascal + ℕ-floor machinery, no `decide`, no
 probability. docker-build clean (7744 jobs), Tier-A axiom-free.
 
 ## Active Approach
@@ -30,14 +31,15 @@ Elementary `Nat`-division monotonicity. docker-build clean (7744 jobs), Tier-A a
 (`propext / Classical.choice / Quot.sound`).
 
 ## Attempt Count
-- Total attempts: 15
+- Total attempts: 16
 - Current approach attempts: 1
 - Approaches tried: LLL parameters, dependency-degree bound, LLL vs union bound
   identity, honest union-bound comparison (VII), deletion method (VIII), k=7
   machine-checked witness + compile repair (IX), general M=1 gain theorem (X),
   avoidance_pos numeric premises (XI), k=8 witness via descFactorial (XII),
   general M-window unification theorem (XIII), deletion-window monotonicity via
-  Pascal's rule (XIV), window-wide monotonicity + Ramsey form via Nat.le_induction (XV)
+  Pascal's rule (XIV), window-wide monotonicity + Ramsey form via Nat.le_induction (XV),
+  exact +1/step growth rate via Nat.add_div remainder condition (XVI)
 
 ## Blockers
 - **MATH**: `SymmetricLLLForRamsey` full formalization (>1000 lines, measure theory) —
@@ -45,14 +47,18 @@ Elementary `Nat`-division monotonicity. docker-build clean (7744 jobs), Tier-A a
   `lovasz-local-lemma-oq-01`.
 
 ## Next Action
-The axiom-free line is now saturated *and* globalized: the deletion mechanism is stated at
-full generality (`ramsey_deletion_window`, every M), its window's monotonic growth is proved
-both per-step (PART XIV) and window-wide (`deletionBound_mono_window`, PART XV), with a Ramsey
-existence form (`deletion_noloss_across_window`) and concrete k=6,7,8,9 witnesses. The only
-remaining genuinely-mathematical increments both need machinery beyond elementary `Nat`:
+The elementary-`Nat` line is now **fully saturated**: the deletion mechanism is stated at
+full generality (`ramsey_deletion_window`, every M), its window's growth is proved
+per-step (`≤`, PART XIV), window-wide (`≤`, PART XV), and now *quantitatively* —
+exact `+1`/step and strict monotonicity under a remainder condition (PART XVI) — with a
+Ramsey existence form (`deletion_noloss_across_window`) and concrete k=6..10 witnesses.
+There is no remaining elementary increment: the `+1`/step law is the sharpest possible
+integer statement of the growth rate. The only remaining genuinely-mathematical increments
+both need machinery beyond elementary `Nat`:
 either (a) the BLOCKED `SymmetricLLLForRamsey` measure-theoretic construction (>1000 lines),
 or (b) a Stirling-based *asymptotic* proof that the additive window width grows like a
 constant fraction of the union value — i.e. `Nat.choose` ratio asymptotics beyond Pascal's
-rule (real analysis, not `omega`). Further concrete k≥10 witnesses would be enumeration
-theater. Recommend releasing the claim; the natural next worker should target the sibling
-`lovasz-local-lemma-oq-01` measure-theory core, or attempt (b) with `Nat.choose` asymptotics.
+rule (real analysis, not `omega`). Further concrete k≥11 witnesses would be enumeration
+theater. **Recommend releasing the claim** after this PR; the natural next worker should
+target the sibling `lovasz-local-lemma-oq-01` measure-theory core, or attempt (b) with
+`Nat.choose` asymptotics.


### PR DESCRIPTION
## Summary

Iteration XVI on **ramsey-r4k-extensions-oq-03** (deletion/alteration method for diagonal Ramsey lower bounds). Upgrades the qualitative window monotonicity established in PARTs XIV–XV (`deletionBound n k ≤ deletionBound (n+1) k`) to a **quantitative growth rate**: the deletion bound grows by *exactly one vertex per step* under an explicit, checkable remainder condition.

## New theorems (in `proofs/Proofs/RamseyR4kExtensionsOQ03Deletion.lean`)

Write `q = 2^C(k,2)`, `a = 2·C(n,k)`; the deleted-vertex count is `⌊a/q⌋`, so `deletionBound n k = n − ⌊a/q⌋`. Pascal's rule gives the one-step added mass `b = 2·C(n,k−1)`.

- **`deletionBound_stepGain`** — if `a mod q + 2·C(n,k−1) < q` (the current remainder has room for the added `(k−1)`-mass) and `⌊a/q⌋ ≤ n` (deleted count is live), then
  `deletionBound (n+1) k = deletionBound n k + 1`.
- **`deletionBound_strictMono_of_remainder`** — strict-inequality corollary: `deletionBound n k < deletionBound (n+1) k` under the same condition.

## Why this is a genuine increment (not a restatement)

The PART-XIV hypothesis `b < q` yields only `≤` (the floor may still advance by one, cancelling the host's `+1`). The sharper condition `a mod q + b < q` proved here forces the floor `⌊(a+b)/q⌋` to stay put, giving the exact `+1`. This is the sharpest possible *integer* statement of the growth rate — it closes the "how fast does the window grow" question the prior notes flagged as needing binomial-ratio estimates, supplying the exact answer via `Nat.add_div`.

## Technique

`⌊(a+b)/q⌋ = ⌊a/q⌋` via `Nat.add_div hq`: `b < q` kills the `b/q` term and `Nat.mod_eq_of_lt`/`Nat.div_eq_of_lt` plus the remainder hypothesis collapse the carry `if`. Pascal step reused verbatim from PART XIV. `omega` finishes the truncated ℕ subtraction using the live hypothesis.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.RamseyR4kExtensionsOQ03Deletion` — **clean, 7744 jobs**.
- Both new theorems: `#print axioms` shows `[propext, Classical.choice, Quot.sound]` only — **Tier-A axiom-free**, no `decide`/`native_decide`, no probability, 0 sorries.

The elementary-`Nat` line for this problem is now saturated; the remaining directions (measure-theoretic symmetric LLL, or `Nat.choose`/Stirling asymptotics) are tracked in `state.md` and the sibling `lovasz-local-lemma-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)