### PR TITLE
MZ SLLN: real Summable of weighted truncated second moments (S4b→S5 hand-off)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean
@@ -1538,4 +1538,85 @@ theorem tsum_lintegral_trunc_sq_weight_lt_top
 
 end MasterVarianceBound
 
+/-! ## Real summability of the MZ variance sum (feed for the Kolmogorov criterion)
+
+The ℝ≥0∞ finiteness `tsum_lintegral_trunc_sq_weight_lt_top` is transported here to a
+genuine real `Summable`.  Each lower integral is the `ENNReal.ofReal` of the (finite,
+nonnegative) Bochner integral of the truncated square — the truncation `𝟙{|X|≤t}·X` is
+bounded by `t`, hence its square is integrable on a finite measure — so
+`ENNReal.summable_toReal` turns the finite ℝ≥0∞ tsum into summability of the real sequence
+
+    i ↦ i^{-2/p} · ∫ ω, (𝟙{|X ω| ≤ i^{1/p}}·X ω)².
+
+For `aᵢ = i^{1/p}` this is exactly `∑ᵢ 𝔼[Yᵢ²]/aᵢ² < ∞`; since `Var(Yᵢ) ≤ 𝔼[Yᵢ²]`, its
+partial sums are the bounded weighted-variance sums the Kolmogorov criterion
+`ae_tendsto_average_zero_of_variance_weighted_bdd` (S5) consumes.  This is the real-analytic
+hand-off from the measure-theoretic finiteness backbone to the probabilistic assembly. -/
+section RealVarianceSummable
+
+open MeasureTheory
+open scoped ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Square-integrability of a single MZ truncation.**  The truncated variable
+`Yₜ = 𝟙{|X| ≤ t}·X` is bounded by `t` (both branches: `|X| ≤ t` on the set, `0` off it),
+so `Yₜ²` is dominated by the constant `t²` and is integrable on any finite measure.
+Reusable for the second-moment integrals of the Marcinkiewicz–Zygmund truncations. -/
+theorem integrable_trunc_sq [IsFiniteMeasure μ]
+    (X : Ω → ℝ) (hX : Measurable X) (t : ℝ) :
+    Integrable (fun ω => ({ω | |X ω| ≤ t}.indicator X ω) ^ 2) μ := by
+  have hmeasset : MeasurableSet {ω | |X ω| ≤ t} :=
+    measurableSet_le hX.abs measurable_const
+  have hY : Measurable (fun ω => {ω | |X ω| ≤ t}.indicator X ω) :=
+    hX.indicator hmeasset
+  refine Integrable.mono' (integrable_const (t ^ 2))
+    (hY.pow_const 2).aestronglyMeasurable (ae_of_all _ (fun ω => ?_))
+  rw [Real.norm_eq_abs, abs_of_nonneg (sq_nonneg _), Set.indicator_apply]
+  split_ifs with h
+  · rw [Set.mem_setOf_eq] at h
+    nlinarith [sq_abs (X ω), h, abs_nonneg (X ω), (abs_nonneg (X ω)).trans h]
+  · rw [show ((0 : ℝ)) ^ 2 = 0 by norm_num]; exact sq_nonneg _
+
+#check @integrable_trunc_sq
+
+/-- **Real summability of the weighted truncated second moments (MZ step 4).**  On a finite
+measure, for a measurable `X` with `Integrable |X|ᵖ` and `0 < p < 2`, the real sequence of
+`i^{-2/p}`-weighted truncated second moments is summable:
+
+    Summable (fun i => i^{-2/p} · ∫ ω, (𝟙{|X ω| ≤ i^{1/p}}·X ω)²).
+
+Proof: `tsum_lintegral_trunc_sq_weight_lt_top` gives the ℝ≥0∞ tsum `< ∞`, so
+`ENNReal.summable_toReal` yields summability of the `.toReal` terms.  Each such term equals
+`i^{-2/p} · ∫ (truncation)²`: the lower integral of `ENNReal.ofReal` of a nonnegative
+integrable function is `ENNReal.ofReal` of its Bochner integral
+(`ofReal_integral_eq_lintegral_ofReal`, with integrability from `integrable_trunc_sq`), the
+constant `i^{-2/p} ≥ 0` pulls through both `ofReal` and the integral (`integral_const_mul`),
+and `ENNReal.toReal_ofReal` strips the coercion off the nonnegative real. -/
+theorem summable_trunc_sq_weight_of_integrable [IsFiniteMeasure μ]
+    (X : Ω → ℝ) (hX : Measurable X) {p : ℝ} (hp : 0 < p) (hp2 : p < 2)
+    (hint : Integrable (fun ω => |X ω| ^ p) μ) :
+    Summable (fun i : ℕ => (i : ℝ) ^ (-(2 / p)) *
+      ∫ ω, ({ω | |X ω| ≤ (i : ℝ) ^ (1 / p)}.indicator X ω) ^ 2 ∂μ) := by
+  have hsummable :=
+    ENNReal.summable_toReal (tsum_lintegral_trunc_sq_weight_lt_top X hX hp hp2 hint).ne
+  refine hsummable.congr (fun i => ?_)
+  rw [← ofReal_integral_eq_lintegral_ofReal
+        ((integrable_trunc_sq X hX ((i : ℝ) ^ (1 / p))).const_mul ((i : ℝ) ^ (-(2 / p))))
+        (ae_of_all _ (fun ω => mul_nonneg
+          (Real.rpow_nonneg (Nat.cast_nonneg i) _) (sq_nonneg _))),
+      integral_const_mul,
+      ENNReal.toReal_ofReal
+        (mul_nonneg (Real.rpow_nonneg (Nat.cast_nonneg i) _)
+          (integral_nonneg (fun ω => sq_nonneg _)))]
+
+#check @summable_trunc_sq_weight_of_integrable
+
+-- Axiom audit: foundational axioms only (propext / Classical.choice / Quot.sound);
+-- no `sorryAx`, no `Lean.ofReduceBool`, no `decide` / `native_decide`.
+#print axioms integrable_trunc_sq
+#print axioms summable_trunc_sq_weight_of_integrable
+
+end RealVarianceSummable
+
 end LawsOfLargeNumbers.MZ

--- a/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-02-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: ACT (S4b step-4 variance sum — master bound + ℝ≥0∞ finiteness SHIPPED & VERIFIED — remaining: real-summable conversion + S5 feed + step-3 centering + assembly)
+**Phase**: ACT (S4b step-4 variance sum — master bound + ℝ≥0∞ finiteness + **real-`Summable` conversion** SHIPPED & VERIFIED — remaining: S5 feed [Var≤2nd-moment + partial-sums-bounded-by-total] + step-3 centering + assembly)
 **Since**: 2026-07-04
-**Iteration**: 16 (S4b step-4 **ℝ≥0∞ finiteness** `tsum_lintegral_trunc_sq_weight_lt_top`: for `Integrable |X|ᵖ`, `0<p<2`, the weighted variance sum `∑'ᵢ ∫⁻ i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)² < ∞` — `.trans_lt` the iter-15 master bound then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` with moment factor finite via `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral` (`hnn` by `Real.rpow_nonneg`) — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs, PR #34406; iter 15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`; iter 14 RHS-integrand domination `trunc_rpow_weight_sq_le_rpow`; iter 13 S4b step-4 **Tonelli interchange** `lintegral_tsum_trunc_sq_weight_le`: `∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral (unconditional for nonneg, sidestepping Bochner `integral_tsum`'s `∑∫‖·‖<∞` which is the very finiteness sought), then `lintegral_mono` dominates the pointwise `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω` via `ENNReal.ofReal_tsum_of_nonneg` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
+**Iteration**: 17 (S4b step-4 **real `Summable` hand-off** `summable_trunc_sq_weight_of_integrable`: for `Integrable |X|ᵖ`, `0<p<2`, finite measure, the real weighted variance sequence `i ↦ i^{-2/p}·∫(𝟙{|X|≤i^{1/p}}·X)²` is `Summable` — `ENNReal.summable_toReal` on the iter-16 ℝ≥0∞ finiteness, each `.toReal` term identified via `ofReal_integral_eq_lintegral_ofReal` [per-term integrability from new reusable `integrable_trunc_sq`: truncation bounded by `t`, `Integrable.mono'` vs `integrable_const t²` on finite measure] + `integral_const_mul` const-pull + `ENNReal.toReal_ofReal` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs, PR #34421. **This is the real `∑ᵢ 𝔼[Yᵢ²]/aᵢ² < ∞` the S5 criterion consumes.** iter 16 S4b step-4 **ℝ≥0∞ finiteness** `tsum_lintegral_trunc_sq_weight_lt_top`: for `Integrable |X|ᵖ`, `0<p<2`, the weighted variance sum `∑'ᵢ ∫⁻ i^{-2/p}·(𝟙{|X|≤i^{1/p}}·X)² < ∞` — `.trans_lt` the iter-15 master bound then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` with moment factor finite via `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral` (`hnn` by `Real.rpow_nonneg`) — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs, PR #34406; iter 15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`; iter 14 RHS-integrand domination `trunc_rpow_weight_sq_le_rpow`; iter 13 S4b step-4 **Tonelli interchange** `lintegral_tsum_trunc_sq_weight_le`: `∑'ᵢ ∫⁻ i^{-s}·(𝟙{|X|≤i^{1/p}}·X)² ≤ ∫⁻ (max 1 |X|ᵖ)^{1-s}·s/(s-1)·X²` — `MeasureTheory.lintegral_tsum` pushes `∑'ᵢ` inside the lower integral (unconditional for nonneg, sidestepping Bochner `integral_tsum`'s `∑∫‖·‖<∞` which is the very finiteness sought), then `lintegral_mono` dominates the pointwise `∑'ᵢ` by iter-12 `tsum_weight_trunc_sq_le` at `x=X ω` via `ENNReal.ofReal_tsum_of_nonneg` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 12 pointwise integrand `tsum_weight_trunc_sq_le` `∑ᵢ 𝟙{|x|≤i^{1/p}}·(i^{-s}·x²) ≤ (max 1 |x|ᵖ)^{1-s}·s/(s-1)·x²` — the exact per-`ω` summand of the variance series, root-form region `{i|`|x|`≤i^{1/p}}` bridged to power-form `{i|`|x|ᵖ`≤i}` — SHIPPED & build-VERIFIED, 0-axiom, 7743 jobs; iter 11 inner-tail bound `tsum_indicator_ge_rpow_neg_le`; iter 10 inclusive tail `tsum_ge_rpow_neg_le`; iter 9 exclusive backbone `∑_{j>N}j^{-s}≤N^{1-s}/(s-1)`; step-3/4 kernels; step-1 truncation; step-2 tail-sum; S4a variance L¹-bound; S3 martingale; S2 Kronecker; S1 survey)
 
 ## Current Focus
 
@@ -142,19 +142,30 @@ interchange**: keep the truncated moment `𝔼[X²·𝟙{|X| ≤ i^{1/p}}]` inta
   **Gotcha:** the naive route `Integrable.lintegral_lt_top` does NOT exist; the working
   bridge is `hasFiniteIntegral_iff_ofReal` (in `L1Space/HasFiniteIntegral.lean`), which needs
   the pointwise-nonneg `0 ≤ᵐ[μ] f` hypothesis.
-- **Next: convert to a real `∑ᵢ 𝔼[Yᵢ²]·i^{-2/p} < ∞` + feed S5.** From the ℝ≥0∞ finiteness
-  (`tsum_lintegral_trunc_sq_weight_lt_top`): the ℝ≥0∞ tsum is finite ⟹ each term `< ∞`, so
-  each summand `= (∫⁻ …).toReal` via `lintegral_ofReal`/`ofReal_toReal`, then an
-  `ENNReal.tsum_toReal`/`Summable` bridge, feeding
-  `ae_tendsto_average_zero_of_variance_weighted_bdd` (S5). Watch weight positivity
-  (use `aᵢ=(i+1)^{1/p}` or `max 1 i^{1/p}`).
+- **Real `Summable` conversion is now DONE (iteration 17, PR #34421):**
+  `summable_trunc_sq_weight_of_integrable` — for `Integrable |X|ᵖ`, `0<p<2`, finite measure,
+  `Summable (fun i => i^{-2/p}·∫(𝟙{|X|≤i^{1/p}}·X)²)`. Proof: `ENNReal.summable_toReal` on the
+  iter-16 ℝ≥0∞ finiteness, then `.congr` identifying each `.toReal` term via
+  `ofReal_integral_eq_lintegral_ofReal` (integrability from new reusable `integrable_trunc_sq`:
+  `|𝟙{|X|≤t}·X| ≤ t` ⟹ `Integrable.mono'` vs `integrable_const t²`), `integral_const_mul`,
+  `ENNReal.toReal_ofReal`. **Do not re-derive.** **Gotcha:** `Integrable.const_mul` puts the
+  constant on the LEFT (`fun ω => c * f ω`), matching the `ofReal(i^{-2/p} * …)` integrand order.
+- **Next: feed S5.** Two small gaps remain before `ae_tendsto_average_zero_of_variance_weighted_bdd`:
+  (a) `variance (Yᵢ) μ ≤ ∫ Yᵢ²` (Mathlib `variance_le_expectation_sq` / `variance_le_...`; needs
+  `μ[Yᵢ²]` finite — from `integrable_trunc_sq`), and (b) `∀ n, ∑_{i≤n} Var(Yᵢ)/aᵢ² ≤ V` from the
+  `Summable` total via `sum_le_tsum` (nonneg terms, partial ≤ total). **Weight positivity:** S5's
+  `ha_pos`/`ha_mono` need `aᵢ>0`; `aᵢ=i^{1/p}` fails at `i=0`, so reindex to `aᵢ=(i+1)^{1/p}` (the
+  `i=0` variance term is `Var(𝟙{|X|≤0}·X)=Var(0)=0`, harmless) or `max 1 i^{1/p}` — reconcile with
+  the `i^{-2/p}` weight in the Summable (note `(i+1)^{-2/p} ≤ i^{-2/p}` only for `i≥1`; cleanest is
+  to prove the Summable directly at weight `(i+1)^{-2/p}` by the same route, or dominate).
 - **Then: step-3 centering** (via `integral_tail_abs_le` + `tendsto_weighted_average_zero`) and
   the final combination with the step-1 truncation reduction into the MZ statement.
 
 ## Attempt Counts
 
 - Total attempts: 13 (S1 survey; S2 Kronecker; S3 martingale assembly; +glue; S4a variance L¹ bound; S4b step-2 tail-sum; S4b step-1 i.i.d. truncation; S4b step-3/4 moment kernels; S4b step-4 tail p-series backbone; iter-10 inclusive tail; iter-11 pointwise inner-tail bound; iter-12 pointwise Tonelli integrand; iter-13 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le`)
-- Latest approach attempts: 1 (S4b step-4 ℝ≥0∞ finiteness `tsum_lintegral_trunc_sq_weight_lt_top` — `.trans_lt` iter-15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`, then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` + `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral`; landed clean on first build, 7743 jobs, 0-axiom, PR #34406)
+- Latest approach attempts: 1 (S4b step-4 real `Summable` hand-off `summable_trunc_sq_weight_of_integrable` + reusable `integrable_trunc_sq` — `ENNReal.summable_toReal` on iter-16 ℝ≥0∞ finiteness, `.congr` via `ofReal_integral_eq_lintegral_ofReal`+`integral_const_mul`+`ENNReal.toReal_ofReal`; landed clean on first build, 7743 jobs, 0-axiom, PR #34421)
+- Prior approach attempts: 1 (S4b step-4 ℝ≥0∞ finiteness `tsum_lintegral_trunc_sq_weight_lt_top` — `.trans_lt` iter-15 master bound `lintegral_tsum_trunc_sq_weight_le_moment`, then `ENNReal.mul_lt_top ENNReal.ofReal_lt_top` + `(hasFiniteIntegral_iff_ofReal hnn).mp hint.hasFiniteIntegral`; landed clean on first build, 7743 jobs, 0-axiom, PR #34406)
 - Prior approach attempts: 1 (S4b step-4 Tonelli interchange `lintegral_tsum_trunc_sq_weight_le` — `lintegral_tsum` [per-term `Measurable.indicator`∘`measurableSet_le`∘`pow_const`∘`const_mul`∘`ENNReal.measurable_ofReal`] to push `∑'ᵢ` inside `∫⁻`, then `lintegral_mono` + `ENNReal.ofReal_tsum_of_nonneg` [summand summable via `Real.summable_nat_rpow`.`mul_right`.`indicator`] + `tsum_weight_trunc_sq_le`; one binder-type fix [`fun i : ℕ`], then clean build 7743 jobs, 0-axiom)
 - Prior approach attempts: 1 (S4b step-4 pointwise Tonelli integrand `tsum_weight_trunc_sq_le` — `Set.indicator_apply`+`ring` to pull `x²` out of the indicator, `tsum_mul_right` to pull it out of the tsum, root→power region rewrite via `not_lt` on `rpow_inv_lt_iff_lt_rpow`, then `tsum_indicator_ge_rpow_neg_le` + `mul_le_mul_of_nonneg_right`; landed clean on first build, 7743 jobs, 0-axiom)
 - Approaches tried: 7 (S1 literature/decomposition; S2 Abel+Toeplitz;


### PR DESCRIPTION
## Marcinkiewicz–Zygmund SLLN — iteration 17 (`laws-of-large-numbers-oq-01-oq-02-oq-01`)

Transports the ℝ≥0∞ variance-sum finiteness (`tsum_lintegral_trunc_sq_weight_lt_top`, iter 16, PR #34406) to a genuine **real `Summable`** — the exact form the Kolmogorov weighted criterion (S5, `ae_tendsto_average_zero_of_variance_weighted_bdd`) consumes.

### New lemmas (`§ RealVarianceSummable`, `proofs/Proofs/LawsOfLargeNumbersOQ01OQ02OQ01.lean`)

- `integrable_trunc_sq` — the truncation `Yₜ = 𝟙{|X|≤t}·X` is bounded by `t`, so `Yₜ²` is dominated by the constant `t²` and integrable on any finite measure (`Integrable.mono'` against `integrable_const`). Reusable.
- `summable_trunc_sq_weight_of_integrable` — for measurable `X` with `Integrable |X|ᵖ`, `0 < p < 2`, on a finite measure:

  ```
  Summable (fun i => i^{-2/p} · ∫ ω, (𝟙{|X ω| ≤ i^{1/p}}·X ω)²)
  ```

  i.e. `∑ᵢ 𝔼[Yᵢ²]/aᵢ² < ∞` for `aᵢ = i^{1/p}`.

### Proof

`ENNReal.summable_toReal` turns the finite ℝ≥0∞ tsum into summability of the `.toReal` terms; each term equals `i^{-2/p}·∫(trunc)²` because the lower integral of `ENNReal.ofReal` of a nonnegative integrable function is `ENNReal.ofReal` of its Bochner integral (`ofReal_integral_eq_lintegral_ofReal`), the constant `i^{-2/p} ≥ 0` pulls through (`integral_const_mul`), and `ENNReal.toReal_ofReal` strips the coercion.

### Verification

- `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ02OQ01` → **Built (7743 jobs, 56s, exit 0)**.
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` — **0-axiom**, no `sorryAx` / `ofReduceBool` / `decide` / `native_decide`.

### Remaining toward the full MZ SLLN

- `Summable → ∀ n, ∑_{i≤n} Var(Yᵢ)/aᵢ² ≤ V` via `Var(Yᵢ) ≤ 𝔼[Yᵢ²]` + partial-sums-bounded-by-total (positive weight `aᵢ = (i+1)^{1/p}` or `max 1 i^{1/p}`).
- Feed centered truncations `Yᵢ − 𝔼Yᵢ` into S5; combine with step-1 truncation reduction and step-3 centering control for the final statement.