### PR TITLE
Enrich Erdős #396 OQ-04 Catalan factor: add references (0->4)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04/meta.json
+++ b/src/data/proofs/erdos-396-oq-04/meta.json
@@ -115,5 +115,23 @@
       "description": "Parent problem: descending factorials dividing central binomial coefficients. This OQ sharpens the central binomial recurrence underlying the Catalan divisibility base case."
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #396 (erdosproblems.com) — descending-factorial divisibility n(n−1)⋯(n−k) ∣ C(2n,n)",
+      "url": "https://www.erdosproblems.com/396"
+    },
+    {
+      "title": "P. Erdős, R. L. Graham — Old and New Problems and Results in Combinatorial Number Theory, Monographies de L'Enseignement Mathématique 28 (1980) (source of the divisibility questions on central binomial coefficients)",
+      "url": "https://www.renyi.hu/~p_erdos/1980-30.pdf"
+    },
+    {
+      "title": "OEIS A000108 — Catalan numbers, with the two-term recurrence (n+2)·C(n+1) = 2(2n+1)·C(n) reproved here",
+      "url": "https://oeis.org/A000108"
+    },
+    {
+      "title": "Mathlib — Combinatorics.Enumerative.Catalan (catalan, gosperCatalan, succ_mul_catalan_eq_centralBinom) and Combinatorics.Choose.Central (centralBinom, succ_mul_centralBinom_succ, two_dvd_centralBinom_succ)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Combinatorics/Enumerative/Catalan.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: Erdős #396 OQ-04 (Catalan factor) — add references (0 → 4)

The entry had no `references` array. Added 4 accurate, verifiable sources
grounding the narrative already in the overview:

- **Erdős Problem #396** (erdosproblems.com) — the descending-factorial
  divisibility question.
- **Erdős & Graham (1980)**, *Old and New Problems and Results in
  Combinatorial Number Theory* — origin of the central-binomial divisibility
  problems.
- **OEIS A000108** — Catalan numbers; the two-term recurrence
  (n+2)·C(n+1) = 2(2n+1)·C(n) reproved in this entry.
- **Mathlib** Combinatorics.Enumerative.Catalan / Combinatorics.Choose.Central
  — the exact lemmas (`succ_mul_centralBinom_succ`, `gosperCatalan`,
  `two_dvd_centralBinom_succ`, …) this entry builds on and strengthens.

Built via git plumbing off `origin/main` (shared working tree is reverted by
a background linter). meta.json validated with `jq`, `.references|length == 4`.
No content deleted.
