### PR TITLE
Enrich Erdős #1054 OQ-01 sum-of-divisors: add references (0->4)

### DIFF
--- a/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
@@ -173,5 +173,23 @@
       "description": "Recovers the Mersenne family (∑ 2^i = 2^{k+1}-1 = σ(2^k)) without native_decide.",
       "significance": "The infinite Mersenne family of representable numbers, axiom-free."
     }
+  ],
+  "references": [
+    {
+      "title": "Erdős Problem #1054 (erdosproblems.com) — representability via partial sums of the sorted divisor list ('Construction D')",
+      "url": "https://www.erdosproblems.com/1054"
+    },
+    {
+      "title": "OEIS A000203 — σ(n), the sum of divisors of n, the arithmetic function shown always representable here",
+      "url": "https://oeis.org/A000203"
+    },
+    {
+      "title": "G. H. Hardy, E. M. Wright — An Introduction to the Theory of Numbers, 6th ed., Oxford (2008), §16.7–16.8 (σ(n), perfect numbers, Mersenne numbers 2^{k+1}−1 = σ(2^k))",
+      "url": "https://global.oup.com/academic/product/an-introduction-to-the-theory-of-numbers-9780199219865"
+    },
+    {
+      "title": "Mathlib — NumberTheory.Divisors (Nat.divisors, Nat.sigma / ∑_{d∣n} d) underlying the sorted-divisor-list formalization",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/Divisors.html"
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment: Erdős #1054 OQ-01 (sum-of-divisors) — add references (0 → 4)

The entry had no `references` array. Added 4 accurate sources grounding the
narrative (σ(m), Mersenne/perfect numbers, divisor lists):

- **Erdős Problem #1054** (erdosproblems.com) — the "Construction D"
  representability question.
- **OEIS A000203** — σ(n), the sum-of-divisors function proved always
  representable here.
- **Hardy & Wright**, *An Introduction to the Theory of Numbers* (§16.7–16.8) —
  σ, perfect numbers, and the Mersenne identity 2^{k+1}−1 = σ(2^k) the entry
  subsumes.
- **Mathlib** NumberTheory.Divisors — `Nat.divisors` / `Nat.sigma` underlying
  the axiom-free (no `native_decide` / `Lean.ofReduceBool`) formalization.

Built via git plumbing off `origin/main` (shared working tree is reverted by a
background linter). `jq`-validated, `.references|length == 4`, no content deleted.
