### PR TITLE
Enrich Erdős #435 OQ-01/OQ-01 converse: add references (0->4)

### DIFF
--- a/src/data/proofs/erdos-435-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-435-oq-01-oq-01/meta.json
@@ -168,5 +168,23 @@
     "path": "Proofs/Erdos435NonPrimePower.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Erdős Problem #435 (erdosproblems.com) — largest integer not representable by C(n,1),…,C(n,n−1) for n not a prime power",
+      "url": "https://www.erdosproblems.com/435"
+    },
+    {
+      "title": "Lucas's theorem (binomial coefficients mod a prime) — the p-adic congruence C(n, p^{v_p(n)}) ≡ n/p^{v_p(n)} (mod p) driving the coprimality argument",
+      "url": "https://en.wikipedia.org/wiki/Lucas%27s_theorem"
+    },
+    {
+      "title": "OEIS A014963 — a(n) = p if n = p^k (prime power), else 1; equals gcd{C(n,1),…,C(n,n−1)}, i.e. exactly the dichotomy proved here",
+      "url": "https://oeis.org/A014963"
+    },
+    {
+      "title": "J. C. Rosales, P. A. García-Sánchez — Numerical Semigroups, Developments in Mathematics 20, Springer (2009) (Frobenius number and finite-complement criterion gcd of generators = 1)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4419-0160-6"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: Erdős #435 OQ-01/OQ-01 (converse) — add references (0 → 4)

The entry had no `references` array. Added 4 accurate sources for the
dichotomy gcd{C(n,1),…,C(n,n−1)} = 1 ⟺ n is not a prime power:

- **Erdős Problem #435** (erdosproblems.com) — the Frobenius-type problem for
  interior binomial coefficients.
- **Lucas's theorem** — the mod-p congruence the coprimality proof rests on.
- **OEIS A014963** — a(n) = p if n = p^k else 1, i.e. exactly gcd of the
  interior binomial coefficients; the precise dichotomy formalized here.
- **Rosales & García-Sánchez**, *Numerical Semigroups* (Springer, 2009) —
  Frobenius number and the finite-complement criterion (gcd of generators = 1).

Built via git plumbing off `origin/main` (shared working tree is reverted by a
background linter). `jq`-validated, `.references|length == 4`, no content deleted.
