### PR TITLE
research(amgm-inequality-oq-02-oq-02-oq-05): Newton at n=3 via SOS discriminant certificates (II)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -125,4 +125,66 @@ theorem newton_two_vars_normalized (x y : ℝ) :
     (1 : ℝ) * (x * y) ≤ ((x + y) / 2) ^ 2 := by
   simpa using newton_two_vars x y
 
+/-!  ## Newton at `n = 3`, via the real-rooted derivative quadratics
+
+For three real roots `x, y, z` the splitting cubic is
+`(X - x)(X - y)(X - z) = X³ - e₁ X² + e₂ X - e₃`, with
+`e₁ = x+y+z`, `e₂ = xy+yz+zx`, `e₃ = xyz`.  The two Newton inequalities are the
+nonnegative discriminants of the two degree-two polynomials Rolle produces:
+
+* differentiate once:  `P' = 3X² - 2e₁X + e₂`  (real-rooted ⇒ `4e₁² - 12e₂ ≥ 0`),
+  giving the first step `e₁² ≥ 3e₂`;
+* pass to the reciprocal cubic and differentiate:
+  `-3e₃X² + 2e₂X - e₁`  (real-rooted ⇒ `4e₂² - 12e₁e₃ ≥ 0`), giving the second
+  step `e₂² ≥ 3e₁e₃`.
+
+Each derivative quadratic's discriminant is established here *directly* as a sum
+of squares — which **is** the real-rootedness of that quadratic — so the `n = 3`
+case needs neither the general Rolle-iteration lemma (the multi-week crux flagged
+in `problem.md`) nor any sign hypothesis.  The Rolle picture is the motivation;
+the SOS certificate is the proof. -/
+
+/-- **Newton's first inequality at `n = 3`** (`p₁² ≥ p₀ p₂`), for arbitrary real
+`x, y, z`: in elementary-symmetric form `e₁² ≥ 3 e₂`, i.e.
+`3(xy+yz+zx) ≤ (x+y+z)²`.  This is the nonnegativity of the discriminant of the
+once-differentiated splitting cubic `P' = 3X² - 2e₁X + e₂`; the SOS certificate
+is `½[(x−y)² + (y−z)² + (z−x)²] ≥ 0`.  No sign hypothesis. -/
+theorem newton_three_first (x y z : ℝ) :
+    3 * (x * y + y * z + z * x) ≤ (x + y + z) ^ 2 := by
+  nlinarith [sq_nonneg (x - y), sq_nonneg (y - z), sq_nonneg (z - x)]
+
+/-- The once-differentiated splitting cubic `P' = 3X² - 2e₁X + e₂` has
+nonnegative discriminant — the discriminant phrasing of `newton_three_first`, and
+the `n = 3` instance of "a derivative of a real-rooted polynomial is real-rooted
+(discriminant `≥ 0`)". -/
+theorem discrim_deriv_cubic_first (x y z : ℝ) :
+    0 ≤ discrim 3 (-2 * (x + y + z)) (x * y + y * z + z * x) := by
+  rw [discrim]; nlinarith [newton_three_first x y z]
+
+/-- **Newton's second inequality at `n = 3`** (`p₂² ≥ p₁ p₃`), for arbitrary real
+`x, y, z`: in elementary-symmetric form `e₂² ≥ 3 e₁ e₃`, i.e.
+`3(x+y+z)·xyz ≤ (xy+yz+zx)²`.  This is the nonnegativity of the discriminant of
+the differentiated *reciprocal* cubic `-3e₃X² + 2e₂X - e₁`; the SOS certificate is
+`½[(xy−yz)² + (yz−zx)² + (zx−xy)²] ≥ 0`.  Holds for all signed reals. -/
+theorem newton_three_second (x y z : ℝ) :
+    3 * (x + y + z) * (x * y * z) ≤ (x * y + y * z + z * x) ^ 2 := by
+  nlinarith [sq_nonneg (x * y - y * z), sq_nonneg (y * z - z * x),
+    sq_nonneg (z * x - x * y)]
+
+/-- The differentiated reciprocal cubic `-3e₃X² + 2e₂X - e₁` has nonnegative
+discriminant — the discriminant phrasing of `newton_three_second`. -/
+theorem discrim_recip_deriv_cubic_second (x y z : ℝ) :
+    0 ≤ discrim (-3 * (x * y * z)) (2 * (x * y + y * z + z * x)) (-(x + y + z)) := by
+  rw [discrim]; nlinarith [newton_three_second x y z]
+
+/-- **Newton at `n = 3` in normalized (`p`) form.**  With `p₀ = 1`,
+`p₁ = e₁/3 = (x+y+z)/3`, `p₂ = e₂/3 = (xy+yz+zx)/3`, `p₃ = e₃ = xyz`, both
+log-concavity steps `p₁² ≥ p₀·p₂` and `p₂² ≥ p₁·p₃` hold for all signed reals. -/
+theorem newton_three_normalized (x y z : ℝ) :
+    (1 : ℝ) * ((x * y + y * z + z * x) / 3) ≤ ((x + y + z) / 3) ^ 2 ∧
+      ((x + y + z) / 3) * (x * y * z) ≤ ((x * y + y * z + z * x) / 3) ^ 2 := by
+  refine ⟨?_, ?_⟩
+  · nlinarith [newton_three_first x y z]
+  · nlinarith [newton_three_second x y z]
+
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
@@ -91,3 +91,33 @@ See PART I above.
 ## Dead Ends
 
 None yet.
+
+## PART II — Newton at n=3 via SOS discriminant certificates (researcher-5, 2026-07-04)
+
+**Mode**: ACT (MODERATE, score 13). **Outcome**: progress (+5 verified theorems, axiom-free).
+docker-build clean, 7743 jobs, foundational axioms only; no `decide`/`native_decide`, 0 sorries.
+
+### What this adds
+Extends the PART-I real-rooted/discriminant route from the `n = 2` base case to the first
+nontrivial arity `n = 3` — both Newton log-concavity steps, for SIGNED reals:
+- `newton_three_first`: `3(xy+yz+zx) ≤ (x+y+z)²` (`e₁² ≥ 3e₂`); SOS `½[(x−y)²+(y−z)²+(z−x)²]`.
+- `newton_three_second`: `3(x+y+z)·xyz ≤ (xy+yz+zx)²` (`e₂² ≥ 3e₁e₃`);
+  SOS `½[(xy−yz)²+(yz−zx)²+(zx−xy)²]`.
+- `discrim_deriv_cubic_first` / `discrim_recip_deriv_cubic_second`: same two facts as the
+  nonneg discriminants of `P' = 3X²−2e₁X+e₂` and `−3e₃X²+2e₂X−e₁`.
+- `newton_three_normalized`: both steps in normalized p-mean form.
+
+### Technique
+Each `nlinarith [sq_nonneg …]` closes the Newton inequality directly; the discriminant-form
+theorems are then `rw [discrim]; nlinarith [newton_three_*]`. The Rolle/derivative picture
+(cubic real-rooted ⇒ derivative quadratic real-rooted ⇒ discriminant ≥ 0) is the *motivation*;
+the SOS certificate is the *proof*, so no iterated-Rolle machinery is needed and no sign
+hypothesis is required (only real roots).
+
+SOS derivation of the second: `e₂² − 3e₁e₃ = x²y²+y²z²+z²x² − xyz(x+y+z) = ½Σ(xy−yz)²`.
+
+### Still open (unchanged)
+The GENERAL (arbitrary-`n`) Newton still needs "differentiation preserves full
+real-rootedness counting multiplicity" (iterated Rolle) — not in Mathlib, multi-week
+(`problem.md`). The per-arity SOS route works for each fixed small `n` but does not scale
+symbolically; n=4 would be a further concrete instance approaching enumeration.

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,36 +4,53 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 2 (PART I)
+**Iteration**: 3 (PART II)
 
 ## Current Focus
-Formalized the real-rooted/discriminant route to Newton's inequality and closed
-the `n = 2` base case. New file `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`
-(namespace `NewtonRealRooted`): 8 theorems, 0 sorries, 0 axioms (docker-build
-clean, 7743 jobs; Tier-A axiom-free). The reusable per-derivative atom
-`discrim_nonneg_of_root` (real-rooted quadratic ⇒ nonneg discriminant) plus
-`newton_two_vars : x*y ≤ ((x+y)/2)^2` for SIGNED reals, via the discriminant of
-the real-rooted `(X-x)(X-y)`.
+Extended the real-rooted/discriminant route to the first nontrivial arity `n = 3`
+(both log-concavity steps), building on the PART-I `n = 2` base case. Five new
+theorems in `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, 0 sorries, 0 axioms
+(docker-build clean, 7743 jobs; Tier-A axiom-free):
+- `newton_three_first : 3(xy+yz+zx) ≤ (x+y+z)²`  (`e₁² ≥ 3e₂`, the first Newton
+  step at n=3), for SIGNED reals, SOS `½Σ(x−y)²`.
+- `newton_three_second : 3(x+y+z)·xyz ≤ (xy+yz+zx)²`  (`e₂² ≥ 3e₁e₃`, the second
+  Newton step), SOS `½Σ(xy−yz)²`.
+- `discrim_deriv_cubic_first` / `discrim_recip_deriv_cubic_second`: the same two
+  facts as the nonnegative discriminants of the derivative quadratic
+  `P' = 3X²−2e₁X+e₂` and the reciprocal-derivative quadratic `−3e₃X²+2e₂X−e₁` —
+  the `n = 3` instance of "a derivative of a real-rooted polynomial is
+  real-rooted (discriminant ≥ 0)".
+- `newton_three_normalized`: both steps in normalized `p`-mean form.
+
+The `n = 3` discriminants are proved *directly* by SOS — which IS the
+real-rootedness of those quadratics — so this arity needs neither the general
+Rolle-iteration crux nor any sign hypothesis. Rolle is the motivation; SOS is the
+proof.
 
 ## Active Approach
 Classical calculus route: real-rootedness ⇒ (Rolle) derivative real-rooted ⇒
-reduce to a quadratic ⇒ discriminant ≥ 0 is Newton. The quadratic/base atom is
-now complete; the general `n ≥ 3` reduction is the remaining crux.
+reduce to a quadratic ⇒ discriminant ≥ 0 is Newton. n=2 and n=3 arities now
+complete via explicit SOS discriminant certificates; the GENERAL `n` reduction
+(arbitrary arity) still needs the packaged iterated-Rolle lemma.
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (real-rooted/discriminant, base case shipped)
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: real-rooted/discriminant atom + n=2 base case (I);
+  n=3 both steps via SOS discriminant certificates (II)
 
 ## Blockers
-- **MATH**: general `n ≥ 3` needs the packaged lemma "differentiation preserves
-  full real-rootedness counting multiplicity" (iterated Rolle on `∏(X - xᵢ)`) —
-  not in Mathlib; `problem.md` estimates multi-week. Retained open (not stubbed).
+- **MATH**: general (arbitrary-`n`) Newton needs the packaged lemma
+  "differentiation preserves full real-rootedness counting multiplicity"
+  (iterated Rolle on `∏(X - xᵢ)`) — not in Mathlib; `problem.md` estimates
+  multi-week. Retained open (not stubbed). The per-arity SOS route sidesteps it
+  for fixed small `n` but does not scale symbolically.
 
 ## Next Action
-1. Prove derivative-of-fully-real-rooted-real-polynomial is fully real-rooted
-   (Rolle between consecutive roots + multiplicity at repeated roots).
-2. Newton at `n = 3` as the first nontrivial instance (cubic derivative is a
-   quadratic; Rolle gives its two real roots directly).
-3. Reduce three consecutive coefficients to a quadratic (reverse/differentiate)
-   and apply `discrim_nonneg_of_root` for the general signed-input Newton.
+1. n=4 by the same SOS discriminant route (three Newton steps; degree grows but
+   each reduced quadratic still admits an SOS certificate) — a further concrete
+   instance if desired, though it approaches enumeration.
+2. The genuine general increment: prove derivative-of-fully-real-rooted is
+   fully-real-rooted (Rolle between consecutive roots + multiplicity), then
+   reduce three consecutive coefficients to a quadratic and apply
+   `discrim_nonneg_of_root` for the arbitrary-`n`, signed-input Newton.


### PR DESCRIPTION
## Summary

Iteration II on **amgm-inequality-oq-02-oq-02-oq-05** (Newton's inequality via real-rooted polynomials / the quadratic discriminant). Extends the PART-I `n = 2` base case to the first nontrivial arity `n = 3`, proving **both** Newton log-concavity steps for arbitrary (signed) reals.

## New theorems (in `proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean`)

With `e₁ = x+y+z`, `e₂ = xy+yz+zx`, `e₃ = xyz`:

- **`newton_three_first`** — `3(xy+yz+zx) ≤ (x+y+z)²`, i.e. `e₁² ≥ 3e₂` (first Newton step). SOS: `½[(x−y)²+(y−z)²+(z−x)²]`.
- **`newton_three_second`** — `3(x+y+z)·xyz ≤ (xy+yz+zx)²`, i.e. `e₂² ≥ 3e₁e₃` (second Newton step). SOS: `½[(xy−yz)²+(yz−zx)²+(zx−xy)²]`.
- **`discrim_deriv_cubic_first`** / **`discrim_recip_deriv_cubic_second`** — the same two facts phrased as the nonnegative discriminants of the derivative quadratic `P' = 3X²−2e₁X+e₂` and the reciprocal-derivative quadratic `−3e₃X²+2e₂X−e₁`. This is the `n = 3` instance of "a derivative of a real-rooted polynomial is real-rooted (discriminant ≥ 0)".
- **`newton_three_normalized`** — both steps in normalized `p`-mean form (`p₁²≥p₀p₂`, `p₂²≥p₁p₃`).

## Why this is faithful and not a stub

The discriminants of the two derivative quadratics are established *directly* by sum-of-squares — which **is** exactly the real-rootedness of those quadratics. So the `n = 3` arity needs neither the general iterated-Rolle lemma (the multi-week crux flagged in `problem.md`, still honestly open) nor any sign restriction (real roots suffice — the advantage of the real-rootedness route the entry highlights). The Rolle/derivative picture is the motivation; the SOS certificate is the proof.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` — **clean, 7743 jobs**.
- 0 sorries, 0 `axiom` declarations, no `decide`/`native_decide`; foundational axioms only (Tier-A).

The general arbitrary-`n` Newton (via iterated Rolle) remains open and is documented in `state.md` / `knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)