### PR TITLE
Enrich Fixed-point convolution identity (derangements-oq-07): de-bundle convolution proof 4→5

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-07/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-07/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-dcoq07-header",
     "proofId": "derangements-convergence-oq-07",
-    "range": { "startLine": 1, "endLine": 51 },
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
     "type": "concept",
     "title": "Module Overview: The Fixed-Point Convolution Identity",
     "content": "This module proves the classical binomial convolution n! = Σ_{k=0}^{n} C(n,k)·D(n−k), where D = numDerangements. Both sides count the permutations of an n-element set: the left directly, the right by sorting permutations by the size k of their fixed-point set. The docstring lays out the three-step bijective proof and notes that Mathlib records the analytic theory of numDerangements (the D(n)/n! → 1/e limit, numDerangements_sum) but not this convolution, so the file is a genuine addition rather than a wrapper. Imports are narrow — only Mathlib.Combinatorics.Derangements.Finite/Basic and Mathlib.Tactic — with opens Equiv, Function, Finset, Nat (the last brings the `!` factorial notation and numDerangements into scope).",
@@ -24,7 +27,10 @@
   {
     "id": "ann-dcoq07-fiber",
     "proofId": "derangements-convergence-oq-07",
-    "range": { "startLine": 53, "endLine": 77 },
+    "range": {
+      "startLine": 53,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "Fiber Count: Permutations With a Prescribed Fixed-Point Set",
     "content": "card_fixedPointFinset_fiber shows that the permutations σ of α whose fixed-point set is exactly S number numDerangements(|α| − |S|). The proof first rewrites the filter-cardinality as the cardinality of the subtype {σ // fixedFinset σ = S} (via Fintype.card_subtype). It then transports along Equiv.subtypeEquivRight to the predicate form '∀ a, ¬(a ∉ S) ↔ a ∈ fixedPoints σ', matching the shape of Mathlib's derangements.subtypeEquiv (· ∉ S). The double-negation bridge ¬(a ∉ S) ↔ a ∈ S is discharged by a pointwise Finset.ext_iff rewrite. Finally card_derangements_eq_numDerangements, Fintype.card_subtype_compl and Fintype.card_coe turn the derangement subtype count into numDerangements(|α| − |S|).",
@@ -44,31 +50,62 @@
     ]
   },
   {
-    "id": "ann-dcoq07-convolution",
+    "id": "ann-dcoq07-convolution-partition",
     "proofId": "derangements-convergence-oq-07",
-    "range": { "startLine": 79, "endLine": 107 },
+    "range": {
+      "startLine": 79,
+      "endLine": 98
+    },
     "type": "theorem",
-    "title": "The Convolution Identity Over a Finite Type",
-    "content": "card_perm_eq_sum_choose_mul_numDerangements assembles the fibers into |α|! = Σ_{k=0}^{|α|} C(|α|,k)·D(|α|−k). It rewrites |α|! = |Perm α| = |univ| (Fintype.card_perm), then partitions Perm α by the fixed-point-set map using Finset.card_eq_sum_card_fiberwise over the powerset of univ. Substituting the per-fiber count card_fixedPointFinset_fiber gives Σ_{S ⊆ univ} D(|α|−|S|). Regrouping the powerset by cardinality with powerset_card_disjiUnion + sum_disjiUnion turns this into a double sum over sizes k; on each k-block the derangement factor D(|α|−k) is constant (since |S| = k there), so Finset.sum_const + card_powersetCard collapse the block to C(|α|,k)·D(|α|−k).",
-    "mathContext": "This is double counting of $\\mathrm{Perm}\\,\\alpha$: the left side by $|\\mathrm{Perm}\\,\\alpha| = |\\alpha|!$, the right by summing the $D(|\\alpha|-k)$ permutations with a given $k$-element fixed set over the $\\binom{|\\alpha|}{k}$ choices of that set. The regrouping $\\sum_{S \\subseteq \\mathrm{univ}} = \\sum_k \\sum_{|S|=k}$ is exactly the disjoint-union decomposition of the powerset into its cardinality strata.",
+    "title": "Convolution, Step 1: Partition Perm α by Fixed-Point Set",
+    "content": "The first half of card_perm_eq_sum_choose_mul_numDerangements rewrites the target |α|! into a fiberwise sum over fixed-point sets. It replaces |α|! by |Perm α| = |univ| (Fintype.card_perm, card_univ), then applies Finset.card_eq_sum_card_fiberwise with the fibering map f = fun σ => univ.filter (fun x => σ x = x) into the powerset of univ: every permutation lands in the fiber indexed by its own fixed-point finset, and the side condition is discharged by Finset.mem_powerset.mpr (subset_univ _). This yields |α|! = Σ_{S ⊆ univ} (size of the S-fiber). Substituting the previous lemma card_fixedPointFinset_fiber via Finset.sum_congr turns each fiber size into numDerangements(|α| − |S|), leaving |α|! = Σ_{S ⊆ univ} D(|α| − |S|) — a sum ranging over all subsets, not yet grouped by size.",
+    "mathContext": "This is the double-counting core: $|\\mathrm{Perm}\\,\\alpha| = |\\alpha|!$ on the left, and on the right the partition of $\\mathrm{Perm}\\,\\alpha$ into fibers $\\{\\sigma : \\mathrm{fix}(\\sigma) = S\\}$ indexed by the possible fixed-point sets $S \\subseteq \\alpha$. Finset.card_eq_sum_card_fiberwise is exactly $|X| = \\sum_{y} |f^{-1}(y)|$, and each fiber has $D(|\\alpha| - |S|)$ elements by the fiber lemma.",
     "significance": "critical",
     "relatedConcepts": [
-      "Finset.card_eq_sum_card_fiberwise",
-      "Finset.powerset_card_disjiUnion",
-      "Finset.card_powersetCard",
       "Fintype.card_perm",
+      "Finset.card_eq_sum_card_fiberwise",
+      "fixed-point-set map",
+      "card_fixedPointFinset_fiber",
       "double counting"
     ],
     "prerequisites": [
-      "Fiberwise cardinality partition of a Finset",
-      "powersetCard and its cardinality C(n,k)",
-      "The fiber-count lemma card_fixedPointFinset_fiber"
+      "Fiberwise cardinality partition of a Finset (card_eq_sum_card_fiberwise)",
+      "The fiber-count lemma card_fixedPointFinset_fiber",
+      "Fintype.card_perm: |Perm α| = |α|!"
+    ]
+  },
+  {
+    "id": "ann-dcoq07-convolution-regroup",
+    "proofId": "derangements-convergence-oq-07",
+    "range": {
+      "startLine": 99,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Convolution, Step 2: Regroup by Cardinality and Collapse Blocks",
+    "content": "The second half regroups the unstratified sum Σ_{S ⊆ univ} D(|α| − |S|) by subset size. Finset.powerset_card_disjiUnion rewrites the powerset of univ as the disjoint union over k of the size-k blocks powersetCard k univ, and Finset.sum_disjiUnion turns the single sum into the double sum Σ_{k=0}^{|α|} Σ_{|S|=k} D(|α| − |S|). On each k-block the size is constant (|S| = i, extracted from Finset.mem_powersetCard), so the derangement factor D(|α| − |S|) rewrites to the constant D(|α| − i); Finset.sum_const then collapses the inner sum to (block size) • D(|α| − i), and Finset.card_powersetCard supplies the block size C(|α|, i). With smul_eq_mul this is exactly C(|α|, k)·D(|α| − k), completing |α|! = Σ_{k} C(|α|,k)·D(|α|−k).",
+    "mathContext": "The regrouping $\\sum_{S \\subseteq \\mathrm{univ}} = \\sum_{k} \\sum_{|S| = k}$ is the decomposition of the powerset into its cardinality strata (powerset_card_disjiUnion). Each stratum contains $\\binom{|\\alpha|}{k}$ subsets (card_powersetCard) and carries the constant factor $D(|\\alpha| - k)$, so summing the constant gives $\\binom{|\\alpha|}{k} \\cdot D(|\\alpha| - k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.powerset_card_disjiUnion",
+      "Finset.sum_disjiUnion",
+      "Finset.card_powersetCard",
+      "Finset.sum_const",
+      "cardinality stratification"
+    ],
+    "prerequisites": [
+      "powersetCard and its cardinality C(n,k) (card_powersetCard)",
+      "Disjoint-union regrouping of a sum (sum_disjiUnion)",
+      "Finset.sum_const for collapsing a constant summand"
     ]
   },
   {
     "id": "ann-dcoq07-nat",
     "proofId": "derangements-convergence-oq-07",
-    "range": { "startLine": 109, "endLine": 121 },
+    "range": {
+      "startLine": 109,
+      "endLine": 121
+    },
     "type": "theorem",
     "title": "ℕ Specialization and Concrete Instance",
     "content": "factorial_eq_sum_choose_mul_numDerangements specializes the finite-type identity to α = Fin n, giving n! = Σ_{k∈range(n+1)} C(n,k)·D(n−k) purely over ℕ; the reduction is a single simpa with Fintype.card_fin. A concrete example checks the identity at n = 4: 4! = 24 = C(4,0)·9 + C(4,1)·2 + C(4,2)·1 + C(4,3)·0 + C(4,4)·1 = 9 + 8 + 6 + 0 + 1, exercising the statement on a nontrivial instance (D(4)=9, D(3)=2, D(2)=1, D(1)=0, D(0)=1).",

--- a/src/data/proofs/derangements-convergence-oq-07/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-07/meta.json
@@ -96,12 +96,20 @@
       "mathContext": "Permutations fixing exactly S are, on the complement of S, fixed-point-free — i.e. derangements of a set of size |α| − |S|. Hence the fiber size is D(|α| − |S|)."
     },
     {
-      "id": "sec-convolution",
-      "title": "The convolution identity over a finite type",
+      "id": "sec-convolution-partition",
+      "title": "The convolution identity, Step 1: fiberwise partition of Perm α",
       "startLine": 79,
+      "endLine": 98,
+      "summary": "First half of card_perm_eq_sum_choose_mul_numDerangements: rewrite |α|! = |Perm α| = |univ| (Fintype.card_perm), then partition Perm α by the fixed-point-set map via Finset.card_eq_sum_card_fiberwise over the powerset of univ, and substitute the per-fiber count card_fixedPointFinset_fiber to reach |α|! = Σ_{S ⊆ univ} D(|α| − |S|).",
+      "mathContext": "Double counting Perm α: LHS by Fintype.card_perm, RHS by the fiberwise partition indexed by fixed-point sets S, each fiber of size D(|α| − |S|)."
+    },
+    {
+      "id": "sec-convolution-regroup",
+      "title": "The convolution identity, Step 2: regroup by cardinality",
+      "startLine": 99,
       "endLine": 107,
-      "summary": "Theorem card_perm_eq_sum_choose_mul_numDerangements: |α|! = Σ_{k=0}^{|α|} C(|α|,k)·D(|α|−k). Rewrites |α|! = |Perm α| = |univ|, partitions via Finset.card_eq_sum_card_fiberwise over the powerset by the fixed-point-set map, substitutes the fiber counts, regroups by cardinality with powerset_card_disjiUnion + sum_disjiUnion, and collapses each constant block with sum_const + card_powersetCard.",
-      "mathContext": "Double counting Perm α: LHS by Fintype.card_perm, RHS by summing the D(|α|−k) fibers over the C(|α|,k) subsets of each size k."
+      "summary": "Second half: regroup Σ_{S ⊆ univ} D(|α|−|S|) by |S| = k using powerset_card_disjiUnion + sum_disjiUnion, then collapse each constant block with Finset.sum_const + card_powersetCard (smul_eq_mul) to C(|α|,k)·D(|α|−k), giving |α|! = Σ_k C(|α|,k)·D(|α|−k).",
+      "mathContext": "The powerset splits into cardinality strata: C(|α|,k) subsets per size k, each carrying the constant derangement factor D(|α|−k)."
     },
     {
       "id": "sec-nat",


### PR DESCRIPTION
Enrichment pass for `derangements-convergence-oq-07` (Fixed-point convolution identity n! = Σ C(n,k)·D(n−k)).

This entry was already rich (quality 93). The one bundling gap: the convolution theorem `card_perm_eq_sum_choose_mul_numDerangements` (lines 79–107) is the meatiest in the file yet was covered by a single annotation/section despite containing two distinct proof phases. This PR de-bundles it 4→5 for finer navigability — no content inflation (meta.json 18.2 KB → 18.8 KB, well under caps).

**Annotations (4 → 5):** split `ann-dcoq07-convolution` into
- **Step 1 — Partition Perm α by fixed-point set** (79–98): |α|! = |Perm α| = |univ| via `Fintype.card_perm`, fiberwise partition with `Finset.card_eq_sum_card_fiberwise` over the powerset, then substitute the fiber count `card_fixedPointFinset_fiber` → Σ_{S ⊆ univ} D(|α|−|S|).
- **Step 2 — Regroup by cardinality and collapse blocks** (99–107): `powerset_card_disjiUnion` + `sum_disjiUnion` to stratify by |S|=k, then `sum_const` + `card_powersetCard` collapse each constant block to C(|α|,k)·D(|α|−k).

**Sections (4 → 5):** matching split of `sec-convolution` into `sec-convolution-partition` / `sec-convolution-regroup` with the same line ranges, keeping section/annotation coverage aligned.

No changes to the Lean proof, theorem counts, axioms, or status (verified, 0 sorries, 0 axioms).
