### PR TITLE
Fix: downgrade amgm-inequality-oq-02-oq-03-oq-03-oq-02 from 'verified' (Lean source absent from main) (#34436)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,14 @@
       "nnreal",
       "am-gm"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "lineCount": 132,
     "theoremCount": 5,
     "definitionCount": 2,
-    "assumptions": "0 axioms, 0 sorries. The NNReal chain is proved without routing through the parent AmgmInequalityOQ02OQ03OQ03.maclaurin_full_chain (which sits on the maclaurin_step axiom); instead the real chain is rebuilt in-file (maclaurin_full_chain_proved) by gap-induction on the de-axiomatized AmgmInequalityOQ02OQ03.maclaurin_step_proved — proved from first principles (Newton log-concavity via Cauchy-Schwarz) in AmgmInequalityOQ02OQ02.lean — and then transferred to ℝ≥0. #print axioms lists only the foundational propext / Classical.choice / Quot.sound.",
+    "assumptions": "PENDING VERIFICATION — the Lean source Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean is NOT yet present on the canonical `main` branch (it exists only in an unmerged draft commit whose docker build was blocked by a full disk), so the machine-check below has not been confirmed on main. Downgraded from verified to formalized pending recovery of the source and a successful docker build + #print axioms. Draft claim to re-confirm: 0 axioms, 0 sorries. The NNReal chain is proved without routing through the parent AmgmInequalityOQ02OQ03OQ03.maclaurin_full_chain (which sits on the maclaurin_step axiom); instead the real chain is rebuilt in-file (maclaurin_full_chain_proved) by gap-induction on the de-axiomatized AmgmInequalityOQ02OQ03.maclaurin_step_proved — proved from first principles (Newton log-concavity via Cauchy-Schwarz) in AmgmInequalityOQ02OQ02.lean — and then transferred to ℝ≥0. #print axioms lists only the foundational propext / Classical.choice / Quot.sound.",
     "originalContributions": [
       "Answers the open question affirmatively for NNReal: the Maclaurin chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ extends verbatim to ℝ≥0, and the extension is axiom-free",
       "Defines the NNReal elementary symmetric polynomial elemSymmNN and Maclaurin mean maclaurinMeanNN = (elemSymmNN k x / C(n,k))^{1/k} using NNReal division and NNReal.rpow",


### PR DESCRIPTION
## Fix

Downgrade the gallery entry `amgm-inequality-oq-02-oq-03-oq-03-oq-02` from `verified` so it no longer overclaims a machine-check whose Lean source is not present on `main`.

## Evidence

**Before**: `meta.json` on `main` declared `status: "verified"`, `badge: "verified"`, `sorries: 0`, `axiomCount: 0`, with a detailed `#print axioms` verification claim.

**Reality**: `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean` is **absent from `origin/main`**. The source exists only in the unmerged draft commit `5e2ae613a38` ("axiom-free Maclaurin chain [PENDING VERIFICATION - disk-full infra block]"), which is not an ancestor of `main`. The gallery data was merged; the proof it depends on was not, and it was never machine-checked (docker build blocked by a full disk).

**After** (metadata-only, 3 fields):
- `meta.status`: `"verified"` → `"formalized"`
- `meta.badge`: `"verified"` → `"wip"`
- `meta.assumptions`: prefixed with a `PENDING VERIFICATION` note explaining the source is not yet on `main` and the machine-check is unconfirmed, pending recovery + a successful docker build + `#print axioms`.

I chose the auditor's **option 2** (downgrade) over option 1 (recover + verify) because the build cannot be run right now — host disk is at 91% (1.2 GiB free; docker build needs >5 GB) — and adding an unverified `.lean` file to `main` risks breaking the Lean build. Once disk pressure clears, a follow-up can cherry-pick the source, `docker-build.sh Proofs.AmgmInequalityOQ02OQ03OQ03OQ02`, confirm `#print axioms`, and restore `verified`. All four dependency files (`AmgmInequalityOQ02`, `…OQ02`, `…OQ03`, `…OQ03OQ03`) are already on `main`.

Closes #34436

---
Automated fix by lean-mechanic agent.