### PR TITLE
fix(gallery): downgrade amgm-oq-02-oq-03-oq-03-oq-02 from 'verified' — Lean source absent from main (#34436)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,14 @@
       "nnreal",
       "am-gm"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
     "lineCount": 132,
     "theoremCount": 5,
     "definitionCount": 2,
-    "assumptions": "0 axioms, 0 sorries. The NNReal chain is proved without routing through the parent AmgmInequalityOQ02OQ03OQ03.maclaurin_full_chain (which sits on the maclaurin_step axiom); instead the real chain is rebuilt in-file (maclaurin_full_chain_proved) by gap-induction on the de-axiomatized AmgmInequalityOQ02OQ03.maclaurin_step_proved — proved from first principles (Newton log-concavity via Cauchy-Schwarz) in AmgmInequalityOQ02OQ02.lean — and then transferred to ℝ≥0. #print axioms lists only the foundational propext / Classical.choice / Quot.sound.",
+    "assumptions": "NOT YET MACHINE-VERIFIED ON main. The Lean source Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean described here (the NNReal extension: elemSymmNN / maclaurinMeanNN and the coercion intertwiners) has not been merged to the canonical branch and has not been machine-checked — its docker build was blocked by a full-disk infrastructure outage. The only committed draft (research/amgm-oq0203030302-pending, commit 5e2ae613a38) contains an earlier real-valued chain rebuild (maclaurin_full_chain_proved), not the NNReal constructions this entry advertises, and it is itself flagged PENDING VERIFICATION. Design goal (unverified): prove the NNReal chain axiom-free by rebuilding the real chain in-file on the de-axiomatized AmgmInequalityOQ02OQ03.maclaurin_step_proved and transferring along the ℝ≥0 ↪ ℝ order-embedding, so #print axioms would list only propext / Classical.choice / Quot.sound. Downgraded from status=verified/badge=verified to formalized/wip pending recovery, merge and a clean docker build (#34436).",
     "originalContributions": [
       "Answers the open question affirmatively for NNReal: the Maclaurin chain M₁ ≥ M₂ ≥ ⋯ ≥ Mₙ extends verbatim to ℝ≥0, and the extension is axiom-free",
       "Defines the NNReal elementary symmetric polynomial elemSymmNN and Maclaurin mean maclaurinMeanNN = (elemSymmNN k x / C(n,k))^{1/k} using NNReal division and NNReal.rpow",


### PR DESCRIPTION
## Summary

Fixes the CRITICAL gallery-integrity issue #34436. The entry
`amgm-inequality-oq-02-oq-03-oq-03-oq-02` ("The Maclaurin Chain Extends to
NNReal") was published as **`status: verified` / `badge: verified`** with
`sorries: 0`, `axiomCount: 0` — but **no Lean source backs the claim on `main`**.

## Findings

- `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ02.lean` is **absent from `origin/main`** and from the entire working tree.
- No committed ref contains the NNReal constructions the meta advertises (`elemSymmNN`, `maclaurinMeanNN`, coercion intertwiners; 5 theorems / 2 defs / 132 lines).
- The only committed draft — branch `research/amgm-oq0203030302-pending`, commit `5e2ae613a38` — holds an **earlier real-valued chain rebuild** (3 theorems, 0 defs, no NNReal content), is itself flagged *"PENDING VERIFICATION - disk-full infra block"*, and is **not an ancestor of `origin/main`**.
- The enrichment (annotations, meta) reached main via #33846; the source it depends on never did.

So the "verified" claim has no proof behind it, and even a recovery from `5e2ae613a38` would not match this entry's NNReal meta.

## Fix (auditor's option 2 — avoid overclaiming)

Full machine verification is not possible right now: host disk is 91% full (~1.2 GB free vs the ~5 GB a docker build needs). Rather than publish an unverifiable "verified" badge, this downgrades the entry:

- `status`: `verified` → `formalized`
- `badge`: `verified` → `wip`
- `assumptions`: rewritten to disclose that the source is absent from `main` and unverified, with recovery/merge/clean-build gated on #34436.

`lineCount`/`theoremCount`/`definitionCount` are left as the design target and will be reconciled when the source is recovered, merged, and machine-checked.

## Follow-up (option 1, when infra allows)

Recover an NNReal source that matches the meta (or rewrite the meta to the recoverable real chain), run `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ03OQ03OQ02` + `#print axioms`, and only then restore `verified`.

Closes #34436

🤖 Generated with [Claude Code](https://claude.com/claude-code)