### PR TITLE
Enrich Newton's Inequality (real-rootedness atom): structure overview/conclusion, add n=3 coverage

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/annotations.json
@@ -112,5 +112,30 @@
       "binomial coefficients",
       "newton_two_vars"
     ]
+  },
+  {
+    "id": "amgm-oq020205-newton-n3",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 128,
+      "endLine": 190
+    },
+    "type": "key-step",
+    "title": "Newton at n = 3 via the derivative quadratics' SOS discriminants",
+    "content": "The full n = 3 case is discharged for arbitrary signed reals x, y, z. The splitting cubic (X - x)(X - y)(X - z) = X^3 - e_1 X^2 + e_2 X - e_3 has, by Rolle, two degree-two derivatives whose nonnegative discriminants are the two Newton inequalities. newton_three_first proves 3(xy+yz+zx) <= (x+y+z)^2 (i.e. e_1^2 >= 3 e_2), the discriminant of P' = 3X^2 - 2 e_1 X + e_2; newton_three_second proves 3(x+y+z)xyz <= (xy+yz+zx)^2 (i.e. e_2^2 >= 3 e_1 e_3), the discriminant of the differentiated reciprocal cubic -3 e_3 X^2 + 2 e_2 X - e_1. discrim_deriv_cubic_first and discrim_recip_deriv_cubic_second restate these as literal discrim >= 0 statements, and newton_three_normalized packages both as the log-concavity steps p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3 in normalized form.",
+    "mathContext": "Each inequality is verified by nlinarith fed an explicit sum-of-squares certificate: the first from (1/2)[(x-y)^2 + (y-z)^2 + (z-x)^2] >= 0, the second from (1/2)[(xy-yz)^2 + (yz-zx)^2 + (zx-xy)^2] >= 0. The Rolle/derivative picture supplies the motivation and tells you which squares to write down; the SOS certificate is the actual proof, so the n = 3 case needs neither the general iterated-Rolle lemma nor any sign hypothesis.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Newton's inequalities",
+      "sum-of-squares certificate",
+      "discriminant",
+      "reciprocal polynomial",
+      "log-concavity"
+    ],
+    "prerequisites": [
+      "elementary symmetric polynomials",
+      "discriminant of a quadratic",
+      "nlinarith / positivstellensatz certificates"
+    ]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -2,14 +2,40 @@
   "slug": "amgm-inequality-oq-02-oq-02-oq-05",
   "id": "amgm-inequality-oq-02-oq-02-oq-05",
   "title": "Newton's Inequality via Real-Rootedness: the Quadratic Discriminant Atom",
-  "description": "The base case of the classical calculus proof of Newton's inequalities: a real-rooted quadratic has a nonnegative discriminant, which for the splitting polynomial (X - x)(X - y) is exactly Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — valid for signed inputs.",
-  "overview": "Newton's inequalities p_k^2 >= p_{k-1} p_{k+1} (log-concavity of the normalized elementary symmetric means) have a classical calculus proof: the monic polynomial prod (X - x_i) with x_i real is real-rooted; by Rolle's theorem so is each of its derivatives; differentiating down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, whose discriminant >= 0 IS Newton's inequality. This entry formalizes the self-contained ATOM of that program — the per-derivative step — and completes the n = 2 base case end to end. Unlike the parent's inductive proof (which assumes 0 <= x_i) and the sibling Cauchy-Schwarz route, the real-rootedness argument needs only that the roots are REAL, so newton_two_vars holds for arbitrary signed x, y. The general n >= 3 case requires the crux lemma 'differentiation preserves full real-rootedness counting multiplicity' (iterated Rolle), which is honestly retained as open.",
-  "conclusion": "For all real x, y: x*y <= ((x+y)/2)^2, i.e. Newton's inequality p_1^2 >= p_0 p_2 at n = 2, obtained as the discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved via Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased through the Polynomial.roots API. All 8 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+  "description": "The classical calculus proof of Newton's inequalities via real-rootedness: a real-rooted quadratic has nonnegative discriminant, which for the splitting polynomial (X - x)(X - y) is exactly Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — valid for signed inputs. The n = 3 case (both log-concavity steps) is discharged directly via the derivative quadratics' sum-of-squares discriminants.",
+  "overview": {
+    "problemStatement": "Newton's inequalities assert that the normalized elementary symmetric means p_k = e_k / C(n,k) of n real numbers are log-concave: p_k^2 >= p_{k-1} p_{k+1} for 1 <= k <= n-1. Equivalently, the sequence of elementary symmetric polynomials of any real vector is a log-concave (indeed ultra-log-concave) sequence. This entry establishes the self-contained per-derivative ATOM of the classical calculus proof and completes the n = 2 base case end to end, then discharges the full n = 3 case directly.",
+    "proofStrategy": "The monic polynomial prod (X - x_i) with x_i real is real-rooted; by Rolle's theorem each of its derivatives is real-rooted too. Differentiating a real-rooted polynomial down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, and 'real-rooted quadratic => nonnegative discriminant' is exactly the Newton inequality relating those three coefficients. The reusable atom is proved via Mathlib's discrim_eq_sq_of_quadratic_eq_zero (the completed-square identity discrim a b c = (2 a x + b)^2) and phrased through the Polynomial.roots API. For n = 3 the two derivative quadratics' nonnegative discriminants are certified directly as sums of squares, so no general Rolle-iteration lemma is needed there.",
+    "historicalContext": "Newton recorded these inequalities in his Arithmetica Universalis (posthumously published, 1707), in the course of bounding the number of imaginary roots of a polynomial from the signs of its coefficients; Maclaurin (1729) supplied the companion chain of inequalities p_1 >= p_2^{1/2} >= ... >= p_n^{1/n} that now bears his name and sharpens AM-GM. Newton himself gave no proof, and a fully rigorous derivation waited until the 19th and 20th centuries; the treatment in Hardy, Littlewood and Polya's Inequalities (1934, Section 2.22) became canonical. The real-rootedness argument formalized here reveals Newton's inequalities as a statement about the geometry of polynomial roots rather than about positive numbers: because it only uses that the roots are REAL (never that they are nonnegative), it proves the inequalities for arbitrary signed inputs, a genuine strengthening of the classical AM-GM-flavored versions. The log-concavity of the elementary symmetric functions is now understood as the prototype of a vast web of results — Newton's inequalities are the coefficient-wise shadow of the fact that real-rooted polynomials have log-concave coefficient sequences (a special case of the theory of hyperbolic polynomials and, more recently, of Lorentzian polynomials of Branden and Huh).",
+    "keyInsights": [
+      "A real quadratic a x^2 + b x + c that possesses a real root must have nonnegative discriminant b^2 - 4ac; via the completed-square identity discrim a b c = (2 a x + b)^2 at any root x, this is a one-line consequence of sq_nonneg and is the entire arithmetic content of the n = 2 case.",
+      "Newton's inequality p_1^2 >= p_0 p_2 at n = 2 is literally the discriminant of the splitting polynomial (X - x)(X - y) = X^2 - (x+y) X + x y, so log-concavity of the coefficients is real-rootedness of the polynomial itself.",
+      "Because the argument uses only that the roots are real, newton_two_vars holds for arbitrary SIGNED x, y — unlike the parent's inductive proof, which assumes 0 <= x_i, and unlike the Cauchy-Schwarz sibling route.",
+      "Rolle's theorem is the engine of the general program: differentiating a real-rooted polynomial preserves real-rootedness, so each Newton inequality is the discriminant of a degree-two derivative of the splitting polynomial.",
+      "For n = 3 the two required derivative quadratics have discriminants that are visibly sums of squares — 3(x+y+z)^2 - 9(xy+yz+zx) = (3/2)[(x-y)^2+(y-z)^2+(z-x)^2] and its reciprocal-cubic analogue — so the case closes by nlinarith with explicit SOS certificates, needing neither the general iterated-Rolle lemma nor any sign hypothesis.",
+      "The Rolle picture supplies the motivation and the reciprocal-polynomial trick (to reach the second inequality), but the actual Lean proof at n = 3 is the SOS certificate: the geometry tells you which squares to write down, and nlinarith verifies them."
+    ]
+  },
+  "conclusion": {
+    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. All 13 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+    "implications": [
+      "Provides a reusable, signed-input building block — 'a real-rooted quadratic has nonnegative discriminant' — that any log-concavity/Newton-inequality development can differentiate down onto, decoupling the arithmetic atom from the (harder) real-rootedness-preservation step.",
+      "Demonstrates that the n = 2 and n = 3 Newton inequalities need no positivity hypothesis at all: they are facts about real roots, not about positive numbers, and hence strictly generalize the AM-GM-style statements that assume x_i >= 0.",
+      "Isolates precisely what remains open for a general-n formalization: only the counting-with-multiplicity form of 'differentiation preserves real-rootedness' (iterated Rolle) is missing; the coefficient-to-discriminant translation is already in hand."
+    ],
+    "openQuestions": [
+      "Formalize the crux lemma that differentiating a fully real-rooted real polynomial yields a fully real-rooted polynomial (counting multiplicity) — the iterated-Rolle step — which would upgrade this atom to a proof of Newton's inequalities for every n.",
+      "Extend the SOS-certificate approach used at n = 3 to n = 4 and beyond, or show that beyond some degree explicit sum-of-squares certificates for the derivative-quadratic discriminants become impractical, forcing the general Rolle route.",
+      "Connect this real-rootedness proof to the modern Lorentzian/hyperbolic-polynomial framework (Branden-Huh), where log-concavity of the elementary symmetric coefficients is a special case of a much broader phenomenon."
+    ]
+  },
   "mainTheorems": [
     "discrim_nonneg_of_root",
-    "monic_quadratic_discrim_nonneg",
     "realRooted_quadratic_coeff_ineq",
-    "newton_two_vars"
+    "newton_two_vars",
+    "newton_three_first",
+    "newton_three_second",
+    "newton_three_normalized"
   ],
   "sorries": [],
   "sections": [
@@ -40,6 +66,27 @@
       "startLine": 96,
       "endLine": 128,
       "summary": "Vieta for two roots (prod_two_linear_eq: (X - x)(X - y) = X^2 - (x+y) X + x y), the fact that x is a root (root_of_prod_two_linear), then newton_two_vars: x y <= ((x+y)/2)^2 for ALL real x, y via the discriminant, and its normalized restatement newton_two_vars_normalized emphasizing the p_1^2 >= p_0 p_2 shape."
+    },
+    {
+      "id": "newton-n3-strategy",
+      "title": "Newton at n = 3: the derivative-quadratic strategy",
+      "startLine": 128,
+      "endLine": 146,
+      "summary": "Docstring for the n = 3 case: the splitting cubic (X - x)(X - y)(X - z) = X^3 - e_1 X^2 + e_2 X - e_3 gives, via Rolle, two degree-two derivatives whose nonnegative discriminants are the two Newton inequalities. Differentiating once yields P' = 3X^2 - 2 e_1 X + e_2 (so 4 e_1^2 - 12 e_2 >= 0, i.e. e_1^2 >= 3 e_2); passing to the reciprocal cubic and differentiating yields -3 e_3 X^2 + 2 e_2 X - e_1 (so e_2^2 >= 3 e_1 e_3). Each derivative quadratic's discriminant is established directly as a sum of squares, so the case needs no general Rolle-iteration lemma and no sign hypothesis."
+    },
+    {
+      "id": "newton-n3-first",
+      "title": "Newton's first inequality at n = 3",
+      "startLine": 147,
+      "endLine": 163,
+      "summary": "newton_three_first: 3(xy+yz+zx) <= (x+y+z)^2 for arbitrary real x, y, z, proved by nlinarith with the SOS certificate (1/2)[(x-y)^2+(y-z)^2+(z-x)^2] >= 0. discrim_deriv_cubic_first restates it as 0 <= discrim 3 (-2 e_1) e_2, the discriminant of the once-differentiated splitting cubic."
+    },
+    {
+      "id": "newton-n3-second",
+      "title": "Newton's second inequality at n = 3 and normalized form",
+      "startLine": 164,
+      "endLine": 190,
+      "summary": "newton_three_second: 3(x+y+z)*xyz <= (xy+yz+zx)^2 for signed reals, via the SOS certificate (1/2)[(xy-yz)^2+(yz-zx)^2+(zx-xy)^2] >= 0, with discrim_recip_deriv_cubic_second its discriminant phrasing on the differentiated reciprocal cubic. newton_three_normalized assembles both steps in normalized p-form: p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3, all for arbitrary signed reals."
     }
   ],
   "crossReferences": [
@@ -65,8 +112,8 @@
       "Mathlib"
     ],
     "additionalFiles": [],
-    "lineCount": 128,
-    "theoremCount": 8,
+    "lineCount": 190,
+    "theoremCount": 13,
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
@@ -97,11 +144,14 @@
       "discrim_nonneg_of_roots_nonempty: real-rootedness phrased through a nonempty Polynomial.roots multiset",
       "realRooted_quadratic_coeff_ineq: coefficient form 4*c <= b^2",
       "prod_two_linear_eq / root_of_prod_two_linear: Vieta for (X - x)(X - y) and its roots",
-      "newton_two_vars: Newton's inequality x*y <= ((x+y)/2)^2 at n = 2 for SIGNED reals, via the discriminant of the real-rooted (X - x)(X - y) — the signed-input generalization the real-rootedness route enables (the parent's induction needs 0 <= x_i)"
+      "newton_two_vars: Newton's inequality x*y <= ((x+y)/2)^2 at n = 2 for SIGNED reals, via the discriminant of the real-rooted (X - x)(X - y) — the signed-input generalization the real-rootedness route enables (the parent's induction needs 0 <= x_i)",
+      "newton_three_first / newton_three_second: the two Newton inequalities at n = 3 (e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3) for arbitrary signed reals, each proved by nlinarith with an explicit sum-of-squares certificate coming from the discriminant of a derivative quadratic",
+      "discrim_deriv_cubic_first / discrim_recip_deriv_cubic_second: the discriminant phrasing of the n = 3 inequalities, exhibiting them as the nonnegative discriminants of the once-differentiated splitting cubic and the differentiated reciprocal cubic",
+      "newton_three_normalized: both n = 3 log-concavity steps in normalized p-form, confirming p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3 for all signed reals"
     ],
     "dateAdded": "2026-07-04",
-    "lineCount": 128,
-    "theoremCount": 8,
+    "lineCount": 190,
+    "theoremCount": 13,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   }


### PR DESCRIPTION
Enrichment pass on `amgm-inequality-oq-02-oq-02-oq-05` (quality 63 → 100).

**Changes (meta.json + annotations.json only):**
- Convert string-encoded `overview` → object: `problemStatement`, `proofStrategy`, `historicalContext` (Newton 1707 / Maclaurin / real-rootedness history), 6 `keyInsights`.
- Convert string-encoded `conclusion` → object: `summary`, `implications`, `openQuestions`.
- Refresh stale metadata: `lineCount` 128→190, `theoremCount` 8→13 (the Lean file has grown an n=3 section).
- Add 3 sections + 1 annotation covering the n=3 derivative-quadratic proofs (`newton_three_first`, `newton_three_second`, `newton_three_normalized`, discriminant phrasings).
- Update `mainTheorems` and `originalContributions` for the n=3 results.

No Lean source changes.