### PR TITLE
fix(gallery): wilsons-theorem-oq-03-oq-03 badge original→mathlib (Tier B via Kummer) (#34440)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-03/meta.json
@@ -110,7 +110,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Kummer%27s_theorem",
     "date": "1852",
     "status": "verified",
-    "badge": "original",
+    "badge": "mathlib",
     "tags": [
       "number-theory",
       "p-adic",


### PR DESCRIPTION
Closes #34440.

## Problem
The entry `wilsons-theorem-oq-03-oq-03` carries `badge: "original"` (Tier A), but its main theorem `padicValNat_centralBinom_two` is derived in ~4 lines from Mathlib's Kummer identity `sub_one_mul_padicValNat_choose_eq_sub_sum_digits` plus the elementary shift lemma. Per the CLAUDE.md tier table, "core argument relies on a Mathlib theorem" ⇒ Tier B ⇒ badge `mathlib`.

## Fix
- `meta.badge`: `original` → `mathlib` (one word).

No text changes: the title ("Kummer in Digit-Sum Form"), docstring, and `mathlibDependencies` already credit Kummer's identity prominently and make no forbidden Tier-B independence claims. `status` stays `verified` — the auditor confirmed 0 sorries, 0 axioms, no `native_decide`, file present on main, and all counts matching. This is purely a badge-classification correction, not a narrative rewrite.

Discovered during gallery integrity audit.