### PR TITLE
Enrich Erdős #101 OQ-01 base cases: split witness section, add 5th annotation

### DIFF
--- a/src/data/proofs/erdos-101-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-101-oq-01-oq-02/annotations.json
@@ -2,49 +2,122 @@
   {
     "id": "ann-erdos101oq0102-overview",
     "proofId": "erdos-101-oq-01-oq-02",
-    "range": { "startLine": 1, "endLine": 32 },
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
     "type": "concept",
     "title": "Anchoring the Extremal Function of a $100 Open Problem",
     "content": "The docstring frames the contribution: the parent OQ-01 scaffold introduces the genuine size-indexed extremal quantity maxCountAtSize n = sSup { fourPointLineCount Q | |Q| = n, NoFiveCollinear Q } — the precise function the $100 open Erdős #101 OQ-01 asks to bound by o(n²) — and certifies its O(n²) upper bound, but the asymptotic statement says nothing about the small values. Those base values are the boundary conditions every candidate growth rate must interpolate. This file pins them exactly: maxCountAtSize n = 0 for all n < 4, and maxCountAtSize 4 = 1, the latter realised by an EXPLICIT no-five-collinear configuration. It does not attack the open o(n²) regime; it anchors the extremal function at its base.",
     "mathContext": "$\\mathrm{maxCountAtSize}(n) = \\sup\\{\\mathrm{fourPointLineCount}(Q) : |Q| = n,\\ \\text{no five collinear}\\}$; here $\\mathrm{maxCountAtSize}(n) = 0$ for $n<4$ and $\\mathrm{maxCountAtSize}(4)=1$.",
     "significance": "supporting",
-    "relatedConcepts": ["Erdős problems", "incidence geometry", "four-point lines", "extremal function", "Solymosi–Stojaković bound"],
-    "prerequisites": ["extremal combinatorics", "suprema in ℕ"]
+    "relatedConcepts": [
+      "Erdős problems",
+      "incidence geometry",
+      "four-point lines",
+      "extremal function",
+      "Solymosi–Stojaković bound"
+    ],
+    "prerequisites": [
+      "extremal combinatorics",
+      "suprema in ℕ"
+    ]
   },
   {
     "id": "ann-erdos101oq0102-basevalues",
     "proofId": "erdos-101-oq-01-oq-02",
-    "range": { "startLine": 40, "endLine": 57 },
+    "range": {
+      "startLine": 40,
+      "endLine": 57
+    },
     "type": "theorem",
     "title": "The Extremal Function Vanishes Below Size 4",
     "content": "maxCountAtSize_eq_zero_of_lt_four proves that for every n < 4 the size-indexed extremal four-point-line function is 0. A set with fewer than four points cannot host a four-point line, so fourPointLineCount Q = 0 for every candidate Q of size n (fourPointLineCount_lt_four). Feeding this uniform bound through the parent's maxCountAtSize_lt_of_forall with the real threshold X = 1 yields (maxCountAtSize n : ℝ) < 1, and a natural number below 1 is 0 (omega). The lemma covers the empty-candidate case n = 0 (where sSup ∅ = 0) uniformly with the nonempty cases n = 1,2,3.",
     "mathContext": "$n < 4 \\Rightarrow \\forall Q\\,(|Q|=n),\\ \\mathrm{fourPointLineCount}(Q)=0 \\Rightarrow \\mathrm{maxCountAtSize}(n) < 1 \\Rightarrow \\mathrm{maxCountAtSize}(n)=0$.",
     "significance": "key",
-    "relatedConcepts": ["maxCountAtSize_lt_of_forall", "fourPointLineCount_lt_four", "supremum of zero set", "omega"],
-    "prerequisites": ["ℕ→ℝ casting", "suprema"]
+    "relatedConcepts": [
+      "maxCountAtSize_lt_of_forall",
+      "fourPointLineCount_lt_four",
+      "supremum of zero set",
+      "omega"
+    ],
+    "prerequisites": [
+      "ℕ→ℝ casting",
+      "suprema"
+    ]
   },
   {
     "id": "ann-erdos101oq0102-witness",
     "proofId": "erdos-101-oq-01-oq-02",
-    "range": { "startLine": 58, "endLine": 122 },
+    "range": {
+      "startLine": 58,
+      "endLine": 122
+    },
     "type": "theorem",
     "title": "An Explicit Configuration Realising One Four-Point Line",
     "content": "The witness is the concrete PlanarPointSet of four x-axis points (0,0),(1,0),(2,0),(3,0). witness_card shows it has cardinality 4 (three card_insert_of_notMem steps, distinctness by Prod.ext_iff); witness_noFive is vacuous no-five-collinear via noFiveCollinear_small (only four points); witness_all_collinear shows every point lies on the line y = 0, hence is collinear with the anchors (0,0),(1,0) (each of the four cases closes by ring). The centrepiece witness_fourPointLineCount computes fourPointLineCount witness = 1 directly from the definition: the only cardinality-4 subset of a four-element set is the set itself (Finset.eq_of_subset_of_card_le), and that subset satisfies the collinearity predicate, so the counted family is exactly the singleton {witness.points}.",
     "mathContext": "Four collinear points on $y=0$: the unique size-4 subset is the whole set, collinear via anchors $(0,0),(1,0)$, so $\\mathrm{fourPointLineCount} = |\\{P.\\mathrm{points}\\}| = 1$.",
     "significance": "critical",
-    "relatedConcepts": ["explicit construction", "Finset.eq_of_subset_of_card_le", "noFiveCollinear_small", "Finset.eq_singleton_iff_unique_mem", "collinearity"],
-    "prerequisites": ["Finset cardinality", "powerset filtering", "collinearity predicate"]
+    "relatedConcepts": [
+      "explicit construction",
+      "Finset.eq_of_subset_of_card_le",
+      "noFiveCollinear_small",
+      "Finset.eq_singleton_iff_unique_mem",
+      "collinearity"
+    ],
+    "prerequisites": [
+      "Finset cardinality",
+      "powerset filtering",
+      "collinearity predicate"
+    ]
   },
   {
     "id": "ann-erdos101oq0102-sizefour",
     "proofId": "erdos-101-oq-01-oq-02",
-    "range": { "startLine": 123, "endLine": 151 },
+    "range": {
+      "startLine": 123,
+      "endLine": 151
+    },
     "type": "insight",
     "title": "The First Non-Trivial Value: maxCountAtSize 4 = 1",
     "content": "maxCountAtSize_four_eq_one pins the extremal function at its first non-trivial argument, from both sides. Lower bound 1 ≤ maxCountAtSize 4: the explicit witness attains fourPointLineCount = 1 at cardinality 4, so le_maxCountAtSize (with witness_fourPointLineCount and witness_card) delivers it. Upper bound maxCountAtSize 4 ≤ 1: every no-five-collinear set of four points has at most 4·3/12 = 1 four-point line by the framework's elementary packing bound improved_upper_bound; pushing this through maxCountAtSize_lt_of_forall with threshold X = 2 gives (maxCountAtSize 4 : ℝ) < 2, hence ≤ 1 (omega). The two bounds meet at exactly 1 — the smallest positive value of the OQ-01 extremal function, certified against both a concrete realising configuration and the elementary density ceiling.",
     "mathContext": "$1 \\le \\mathrm{maxCountAtSize}(4)$ (explicit witness) and $\\mathrm{maxCountAtSize}(4) \\le \\lfloor 4\\cdot 3/12\\rfloor = 1$ (packing bound), so $\\mathrm{maxCountAtSize}(4)=1$.",
     "significance": "critical",
-    "relatedConcepts": ["le_maxCountAtSize", "improved_upper_bound", "le_antisymm", "packing bound", "extremal value"],
-    "prerequisites": ["the explicit witness", "the elementary packing bound"]
+    "relatedConcepts": [
+      "le_maxCountAtSize",
+      "improved_upper_bound",
+      "le_antisymm",
+      "packing bound",
+      "extremal value"
+    ],
+    "prerequisites": [
+      "the explicit witness",
+      "the elementary packing bound"
+    ]
+  },
+  {
+    "id": "ann-erdos101oq0102-onelinecount",
+    "proofId": "erdos-101-oq-01-oq-02",
+    "range": {
+      "startLine": 99,
+      "endLine": 122
+    },
+    "type": "key-step",
+    "title": "The witness realises exactly one four-point line",
+    "content": "witness_fourPointLineCount proves fourPointLineCount witness = 1 by showing the filtered family of collinear 4-subsets is the singleton {witness.points}. Existence uses the anchors (0,0),(1,0) with witness_all_collinear; uniqueness uses that any 4-element subset of a 4-element set must be the whole set (Finset.eq_of_subset_of_card_le), so Finset.card_singleton finishes.",
+    "mathContext": "This is the constructive lower bound maxCountAtSize 4 ≥ 1: an explicit no-five-collinear configuration attaining one four-point line. Paired with the improved_upper_bound (≤ 4·3/12 = 1) it pins maxCountAtSize 4 = 1, the first non-trivial value of the extremal function in Erdős #101's four-point-line thread.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "four-point line count",
+      "collinearity",
+      "Finset.powerset filter",
+      "extremal configuration",
+      "no-five-collinear sets"
+    ],
+    "prerequisites": [
+      "Finset.eq_of_subset_of_card_le",
+      "Finset.eq_singleton_iff_unique_mem",
+      "collinearity predicate"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-101-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-101-oq-01-oq-02/meta.json
@@ -77,12 +77,16 @@
       "mathContext": "n < 4 implies fourPointLineCount Q = 0 for all candidates (fourPointLineCount_lt_four), so maxCountAtSize n < 1 (via maxCountAtSize_lt_of_forall, threshold 1), hence = 0."
     },
     {
-      "id": "explicit-witness",
-      "title": "The Explicit Witness at Size 4",
-      "summary": "witness (four x-axis points), witness_card (= 4), witness_noFive (vacuous no-five-collinear), witness_all_collinear (all on y = 0), and witness_fourPointLineCount: the configuration realises exactly one four-point line, computed directly from the definition.",
+      "title": "The explicit witness at size 4",
       "startLine": 58,
+      "endLine": 98,
+      "summary": "The witness PlanarPointSet: the four x-axis points (0,0),(1,0),(2,0),(3,0). witness_card shows they are pairwise distinct (cardinality 4), witness_noFive is vacuous (only four points, via noFiveCollinear_small), and witness_all_collinear checks every point lies on y=0, hence is collinear with the anchors (0,0),(1,0) by a one-line ring computation of the collinearity predicate."
+    },
+    {
+      "title": "The witness realises exactly one four-point line",
+      "startLine": 99,
       "endLine": 122,
-      "mathContext": "The only cardinality-4 subset of a four-element set is the set itself (Finset.eq_of_subset_of_card_le); it satisfies the collinearity predicate with anchors (0,0),(1,0) since every point has y = 0, so the counted family is the singleton {witness.points}."
+      "summary": "witness_fourPointLineCount: fourPointLineCount witness = 1. The only cardinality-4 subset of a four-element set is the set itself (Finset.eq_of_subset_of_card_le), and it satisfies the collinearity predicate, so the filtered family collapses to the singleton {witness.points} and its card is 1 — the lower-bound half of the size-4 value."
     },
     {
       "id": "size-four-value",


### PR DESCRIPTION
Enrichment pass on `erdos-101-oq-01-oq-02` (quality 93 → 100).

- Split the size-4 witness section at `witness_fourPointLineCount` (line 99) → 5 sections (witness construction vs the one-four-point-line computation).
- Add a 5th annotation covering `witness_fourPointLineCount` — the constructive lower bound `maxCountAtSize 4 ≥ 1`.

No Lean source changes.