### PR TITLE
Enrich Erdős #1054 OQ-01 (σ always representable): definitions annotation + 5th keyInsight

### DIFF
--- a/src/data/proofs/erdos-1054-construction-d-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-cd-oq01-overview",
     "proofId": "erdos-1054-construction-d-oq-01",
-    "range": { "startLine": 1, "endLine": 47 },
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
     "type": "concept",
     "title": "From case-by-case checks to one structural theorem",
     "content": "The parent file `Erdos1054ConstructionD` verifies *specific* numbers as representable — $1+p+p^2$ for $p=2,3,5,7,11,13$, and the Mersenne numbers $3,7,15,31,\\ldots$ — each by a separate `native_decide` computation. This file replaces all of them with a single observation.\n\nRecall $n$ is **representable** if it occurs as a partial sum of the *sorted* divisor list of some $m \\geq 1$. The partial sums of $[d_1 < d_2 < \\cdots < d_t]$ are $[d_1,\\; d_1{+}d_2,\\; \\ldots,\\; d_1{+}\\cdots{+}d_t]$. The **last** one is the sum of *all* divisors, i.e. the sum-of-divisors function $\\sigma(m) = \\sum_{d \\mid m} d$.\n\nHence: **for every $m \\geq 1$, $\\sigma(m)$ is representable**, witnessed by $m$ itself. Every concrete check in the parent is a special case — $\\sigma(p^2) = 1+p+p^2$, $\\sigma(2^k) = 2^{k+1}-1$ — and the general theorem needs no `native_decide`, so it is free of the `Lean.ofReduceBool` axiom.",
@@ -21,39 +24,94 @@
     ]
   },
   {
+    "id": "ann-cd-oq01-defs",
+    "proofId": "erdos-1054-construction-d-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "Representability via partial sums of sorted divisors",
+    "content": "sortedDivisors m lists m.divisors in increasing order; partialDivisorSums m takes the running (cumulative) sums via scanl (·+·) 0 with the leading 0 dropped by .tail, so its last entry is σ(m) and its entries are the intermediate divisor-sum prefixes. IsRepresentable n := ∃ m ≥ 1, n ∈ partialDivisorSums m makes 'n is a partial divisor sum of some m' a first-class predicate — the target the whole file proves σ(m) always satisfies.",
+    "mathContext": "Casting representability as membership in a computable list (rather than an existential over subsets) is what lets the proof avoid native_decide: the witness is structural (σ(m) is literally the final scanl entry) instead of decided by kernel reduction, keeping the results Lean.ofReduceBool-free.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisor function",
+      "List.scanl",
+      "cumulative sums",
+      "representability predicate",
+      "σ (sum of divisors)"
+    ],
+    "prerequisites": [
+      "Nat.divisors",
+      "Finset.sort",
+      "List.scanl / List.tail"
+    ]
+  },
+  {
     "id": "ann-cd-oq01-foldl",
     "proofId": "erdos-1054-construction-d-oq-01",
-    "range": { "startLine": 67, "endLine": 79 },
+    "range": {
+      "startLine": 67,
+      "endLine": 79
+    },
     "type": "tactic",
     "title": "The accumulator identity for scanl",
     "content": "`partialDivisorSums m` is the tail of `scanl (·+·) 0 (sortedDivisors m)`. Batteries' `List.getLast_scanl` says the last entry of a `scanl` is `foldl (·+·) 0 L` — the running total. To identify that total with the list *sum*, we prove the small generalized lemma `foldl_add_acc : L.foldl (·+·) a = a + L.sum` by induction on `L` with the accumulator `a` generalized.\n\nGeneralizing the accumulator is essential: the naive statement `L.foldl (·+·) 0 = L.sum` does not strengthen the induction hypothesis enough, because the recursive call threads a *non-zero* accumulator `0 + d_1`.",
     "mathContext": "foldl with a moving accumulator: foldl (+) a [x₁,…,xₙ] = a + (x₁ + ⋯ + xₙ). Proven by induction generalizing a.",
     "significance": "supporting",
-    "relatedConcepts": ["list folds", "scanl/foldl", "induction generalization"],
-    "prerequisites": ["structural induction on lists"]
+    "relatedConcepts": [
+      "list folds",
+      "scanl/foldl",
+      "induction generalization"
+    ],
+    "prerequisites": [
+      "structural induction on lists"
+    ]
   },
   {
     "id": "ann-cd-oq01-key",
     "proofId": "erdos-1054-construction-d-oq-01",
-    "range": { "startLine": 85, "endLine": 120 },
+    "range": {
+      "startLine": 85,
+      "endLine": 120
+    },
     "type": "tactic",
     "title": "σ(m) is the final partial sum",
     "content": "The membership proof `sum_divisors_mem_partialSums` proceeds in three moves. (1) Rewrite the finset sum $\\sum_{d\\mid m} d$ to the list sum of `sortedDivisors m` using that the sort is a permutation of the divisor finset (`Finset.sort_perm_toList` + `Finset.sum_toList`). (2) Since $1 \\mid m$ (so the divisor finset is nonempty), the sorted list is `a :: l`, and `partialDivisorSums m` unfolds to `scanl (·+·) (0+a) l`. (3) The `getLast` of that `scanl` is in the list (`List.getLast_mem`) and equals `foldl (·+·) (0+a) l = (a::l).sum` by the accumulator identity. Therefore the divisor sum is a member.\n\nThe headline `sum_divisors_representable` then packages this with the witness `m`.",
     "mathContext": "Nonemptiness from 1 ∈ m.divisors (Nat.one_mem_divisors, m ≥ 1); the last scanl entry carries the total of all divisors.",
     "significance": "key",
-    "relatedConcepts": ["sorted divisors", "permutation invariance of sums", "scanl last element"],
-    "prerequisites": ["Finset.sort", "List.getLast"]
+    "relatedConcepts": [
+      "sorted divisors",
+      "permutation invariance of sums",
+      "scanl last element"
+    ],
+    "prerequisites": [
+      "Finset.sort",
+      "List.getLast"
+    ]
   },
   {
     "id": "ann-cd-oq01-geom",
     "proofId": "erdos-1054-construction-d-oq-01",
-    "range": { "startLine": 130, "endLine": 168 },
+    "range": {
+      "startLine": 130,
+      "endLine": 168
+    },
     "type": "concept",
     "title": "Prime-power corollary and recovered families",
     "content": "Specializing $m = p^k$ and using `Nat.sum_divisors_prime_pow` ($\\sum_{d \\mid p^k} d = \\sum_{i=0}^{k} p^i$) yields `geom_sum_representable`: **every geometric sum $1 + p + \\cdots + p^k$ for a prime $p$ is representable**, with witness $p^k$.\n\nTwo families fall out immediately. With $k=2$ we recover the parent's Construction D headline $1+p+p^2$ (`prime_sq_sum_representable'`). With $p=2$ we recover the Mersenne numbers $\\sum_{i=0}^{k} 2^i = 2^{k+1}-1$ (`mersenne_representable`). Both are now fully verified, without the `native_decide` the parent used for its concrete instances.",
     "mathContext": "∑_{i=0}^k p^i = (p^{k+1}-1)/(p-1) is the geometric sum; for p=2 it is the Mersenne number 2^{k+1}-1. All such values are σ of a prime power, hence representable.",
     "significance": "key",
-    "relatedConcepts": ["geometric series", "Mersenne numbers", "prime powers", "Erdős #1054 Construction D"],
-    "prerequisites": ["sum of divisors of a prime power", "geometric sums"]
+    "relatedConcepts": [
+      "geometric series",
+      "Mersenne numbers",
+      "prime powers",
+      "Erdős #1054 Construction D"
+    ],
+    "prerequisites": [
+      "sum of divisors of a prime power",
+      "geometric sums"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
@@ -71,7 +71,8 @@
       "**Representability of σ(m) is automatic, not a coincidence.** Every concrete check in the parent file is an instance of one structural fact — σ(m) is the final cumulative sum of the increasing divisor sequence — so the whole image of the σ function lands inside the representable set.",
       "**Eliminating native_decide is a genuine axiom strengthening.** The parent's native_decide witnesses depend on Lean.ofReduceBool; this file proves strictly more (an infinite family, uniformly) with only propext / Classical.choice / Quot.sound, so the results are honestly axiom-free.",
       "**Generalizing the fold accumulator is the technical crux.** The naive foldl (+) 0 L = L.sum does not strengthen the induction hypothesis, because the recursive call threads a non-zero accumulator; foldl_add_acc with a free accumulator a closes the induction.",
-      "**One theorem, two classical families.** The prime-power corollary ∑_{i=0}^k p^i unifies the parent's prime-square witnesses (k = 2) and the entire Mersenne family (p = 2), each previously checked individually, into a single statement valid for all primes and all exponents."
+      "**One theorem, two classical families.** The prime-power corollary ∑_{i=0}^k p^i unifies the parent's prime-square witnesses (k = 2) and the entire Mersenne family (p = 2), each previously checked individually, into a single statement valid for all primes and all exponents.",
+      "**The witness is the running total of sorted divisors, not a decided fact.** σ(m) appears as the last entry of the scanl-cumulative-sum list partialDivisorSums m, so representability is exhibited by an explicit structural witness; foldl_add_acc identifies that final entry with the divisor sum, and the corollaries for σ(p^k) and Mersenne numbers 2^{k+1}−1 are just instances at m = p^k."
     ],
     "prerequisites": [
       "Divisors of a natural number and the sum-of-divisors function σ (Mathlib.NumberTheory.Divisors)",


### PR DESCRIPTION
Enrichment pass on `erdos-1054-construction-d-oq-01` (quality 93 → 100).

- Add an annotation covering the previously-uncovered definitions (`sortedDivisors`, `partialDivisorSums`, `IsRepresentable`, lines 51–64).
- Add a 5th `keyInsight` on the structural, `native_decide`-free witness (σ(m) as the last scanl entry).

No Lean source changes.