### PR TITLE
Enrich Erdős #396 OQ-04 (Catalan cofactor): sanity-check annotation + 5th keyInsight

### DIFF
--- a/src/data/proofs/erdos-396-oq-04/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04/annotations.json
@@ -11,8 +11,17 @@
     "content": "Mathlib's `Nat.succ_mul_centralBinom_succ` states $(n+1)\\,C(2(n+1),n+1) = 2(2n+1)\\,C(2n,n)$. Rewriting $C(2n,n) = (n+1)\\,\\mathrm{catalan}\\,n$ via `succ_mul_catalan_eq_centralBinom` and cancelling the nonzero factor $n+1$ with `Nat.eq_of_mul_eq_mul_left` yields $C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$. This exposes the Catalan number as the exact cofactor of $2(2n+1)$ — a form Mathlib does not record, since it proves Catalan integrality through a Gosper telescoping instead.",
     "mathContext": "$C(2(n+1),n+1) = 2(2n+1)\\,C_n$ where $C_n = \\mathrm{catalan}\\,n$.",
     "significance": "critical",
-    "relatedConcepts": ["central binomial coefficient", "Catalan numbers", "Nat.eq_of_mul_eq_mul_left", "cancellation", "closed form"],
-    "prerequisites": ["combinatorics", "natural number arithmetic"]
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "Catalan numbers",
+      "Nat.eq_of_mul_eq_mul_left",
+      "cancellation",
+      "closed form"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "natural number arithmetic"
+    ]
   },
   {
     "id": "ann-e396oq04-divisibility",
@@ -26,8 +35,17 @@
     "content": "Reading the closed form as a product gives four divisibilities of the next central binomial coefficient: by $\\mathrm{catalan}\\,n$ (cofactor $2(2n+1)$), by $2(2n+1)$, by the odd factor $2n+1$, and by $2$. The odd-factor statement strengthens Mathlib's `two_dvd_centralBinom_succ`, which records only the even factor.",
     "mathContext": "$\\mathrm{catalan}\\,n \\mid C(2(n+1),n+1)$ and $(2n+1) \\mid C(2(n+1),n+1)$.",
     "significance": "key",
-    "relatedConcepts": ["divisibility", "central binomial coefficient", "Catalan numbers", "odd factor", "Erdős problem #396"],
-    "prerequisites": ["divisibility", "number theory"]
+    "relatedConcepts": [
+      "divisibility",
+      "central binomial coefficient",
+      "Catalan numbers",
+      "odd factor",
+      "Erdős problem #396"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "number theory"
+    ]
   },
   {
     "id": "ann-e396oq04-recurrence",
@@ -41,8 +59,17 @@
     "content": "Applying `succ_mul_catalan_eq_centralBinom` at index $n+1$ gives $(n+2)\\,\\mathrm{catalan}(n+1) = C(2(n+1),n+1)$; substituting the closed form yields the elementary recurrence $(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ — the standard computational recurrence for Catalan numbers, here obtained without binomial coefficients.",
     "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{2(2n+1)}{n+2} C_n$.",
     "significance": "key",
-    "relatedConcepts": ["Catalan recurrence", "Catalan numbers", "central binomial coefficient", "integer sequence", "Gosper telescoping"],
-    "prerequisites": ["combinatorics", "recurrence relations"]
+    "relatedConcepts": [
+      "Catalan recurrence",
+      "Catalan numbers",
+      "central binomial coefficient",
+      "integer sequence",
+      "Gosper telescoping"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "recurrence relations"
+    ]
   },
   {
     "id": "ann-e396oq04-coprime",
@@ -56,7 +83,40 @@
     "content": "The two natural divisors $n+1$ and $2n+1$ of consecutive central binomial coefficients are coprime: peeling $2n+1 = n + 1\\cdot(n+1)$ reduces $\\gcd(n+1, 2n+1)$ to $\\gcd(n+1, n) = \\gcd(n, 1) = 1$. This explains why the two divisibility constraints act independently.",
     "mathContext": "$\\gcd(n+1,\\,2n+1) = 1$ for all $n$.",
     "significance": "supporting",
-    "relatedConcepts": ["coprimality", "Euclidean algorithm", "greatest common divisor", "independent divisors"],
-    "prerequisites": ["number theory", "gcd"]
+    "relatedConcepts": [
+      "coprimality",
+      "Euclidean algorithm",
+      "greatest common divisor",
+      "independent divisors"
+    ],
+    "prerequisites": [
+      "number theory",
+      "gcd"
+    ]
+  },
+  {
+    "id": "ann-e396oq04-sanity",
+    "proofId": "erdos-396-oq-04",
+    "range": {
+      "startLine": 118,
+      "endLine": 131
+    },
+    "type": "example",
+    "title": "Sanity checks against explicit Catalan values",
+    "content": "Three worked examples confirm the results on concrete inputs: C(2·1,1) = 2 = 2·(2·0+1)·catalan 0 (the closed form at n=0), C(6,3) = 20 = 2·(2·2+1)·catalan 2 = 2·5·2 (closed form at n=2, checked by decide), and the recurrence at n=2, (2+2)·catalan 3 = 2·(2·2+1)·catalan 2 i.e. 4·5 = 20. Each reuses the corresponding general theorem (centralBinom_succ_eq, catalan_recurrence) rather than re-deriving, so they double as usage demonstrations.",
+    "mathContext": "These #eval-style checks anchor the abstract identities to small numbers, catching off-by-one or factor errors in the 2(2n+1)·catalan n cofactorization and confirming the two-term recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n on a nontrivial instance.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "central binomial coefficient",
+      "sanity check",
+      "decide",
+      "recurrence verification"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom",
+      "catalan",
+      "decide"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04/meta.json
+++ b/src/data/proofs/erdos-396-oq-04/meta.json
@@ -36,7 +36,8 @@
       "**The Catalan number is the exact cofactor of 2(2n+1).** Cancelling n+1 from the Mathlib recurrence collapses it to C(2(n+1),n+1) = 2(2n+1)·catalan n — a closed form Mathlib does not state, since it derives integrality via Gosper telescoping instead.",
       "**The odd factor 2n+1 divides the next central binomial coefficient.** This strengthens Mathlib's `two_dvd_centralBinom_succ` (the even factor 2); both factors, and their product 2(2n+1), divide C(2(n+1),n+1).",
       "**An elementary two-term Catalan recurrence falls out for free.** (n+2)·catalan(n+1) = 2(2n+1)·catalan n is the standard computational recurrence for Catalan numbers, obtained here without binomial coefficients once the closed form is in hand.",
-      "**The two natural divisors are coprime.** gcd(n+1, 2n+1) = 1 (peel 2n+1 = n + 1·(n+1) down to gcd(n,1)=1), explaining why the n+1 and 2n+1 divisibilities act independently on consecutive central binomial coefficients."
+      "**The two natural divisors are coprime.** gcd(n+1, 2n+1) = 1 (peel 2n+1 = n + 1·(n+1) down to gcd(n,1)=1), explaining why the n+1 and 2n+1 divisibilities act independently on consecutive central binomial coefficients.",
+      "**Everything is checked against concrete Catalan values.** Worked examples confirm C(2,1)=2, C(6,3)=20=2·5·catalan 2, and the recurrence (n+2)·catalan(n+1)=2(2n+1)·catalan n at n=2 (4·5=20) — each reusing the general theorem, so the closed form and recurrence are validated on nontrivial instances, not just stated."
     ],
     "prerequisites": [
       "Central binomial coefficients and Catalan numbers",


### PR DESCRIPTION
Enrichment pass on `erdos-396-oq-04` (quality 93 → 100).

- Add an annotation covering the previously-uncovered explicit Catalan-value sanity checks (lines 118–131).
- Add a 5th `keyInsight` noting the concrete-value validation of the closed form and two-term recurrence.

No Lean source changes.