### PR TITLE
Enrich: Separability via Factor/Remainder Theorem (k=3 OQ) (→100/100)

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -55,6 +55,21 @@
     "prerequisites": ["one_lt_rootMultiplicity_iff_isRoot", "count_roots / Multiset.nodup_iff_count_le_one", "nodup_roots_iff_of_splits"]
   },
   {
+    "id": "ann-field-multiplicity",
+    "proofId": "factor-remainder-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 117
+    },
+    "type": "technique",
+    "title": "From Square-Divisibility to Root Multiplicity over a Field",
+    "content": "Moving to a field lets the divisibility criterion of Section I be read in the language of roots. sq_dvd_iff_one_lt_rootMultiplicity proves that for a nonzero p over a field, (X − a)² ∣ p exactly when a is a root of multiplicity greater than one — a genuine repeated root. roots_nodup_iff_forall_not_sq_dvd then globalizes this: the multiset p.roots has no duplicates iff there is no a with (X − a)² ∣ p. This is the technical hinge of the entry, converting the characteristic-free 'no repeated linear factor' statement into 'all roots distinct' — the form Mathlib's separability machinery for split polynomials consumes — without ever invoking the ordinary derivative in positive characteristic. Both lemmas hold over any field, so the bridge is itself characteristic-free.",
+    "mathContext": "$(X-a)^2 \\mid p \\iff \\operatorname{rootMultiplicity}_a(p) > 1$;\\quad $p.\\mathrm{roots}.\\mathrm{Nodup} \\iff \\forall a,\\ \\neg\\,(X-a)^2 \\mid p$.",
+    "significance": "technical",
+    "relatedConcepts": ["root multiplicity", "squarefree polynomial", "multiset of roots", "distinct roots", "splitting field"],
+    "prerequisites": ["Polynomial.rootMultiplicity", "Polynomial.roots over a field", "Multiset.Nodup"]
+  },
+  {
     "id": "ann-char-two",
     "proofId": "factor-remainder-theorem-oq-01-oq-02-oq-01",
     "range": {

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-02-oq-01/meta.json
@@ -122,16 +122,24 @@
       "mathContext": "Turns separability (coprimality with p′) into the absence of a square linear factor, in every characteristic."
     },
     {
-      "id": "field-iff",
-      "title": "Section II: Over a Field — Separable Iff No Repeated Linear Factor",
+      "id": "field-multiplicity",
+      "title": "Section II: Over a Field — Multiplicity and the Repeated-Square Criterion",
       "startLine": 92,
+      "endLine": 117,
+      "summary": "sq_dvd_iff_one_lt_rootMultiplicity turns square-divisibility into a multiplicity statement — over a field, (X − a)² ∣ p iff a is a root of multiplicity > 1 — and roots_nodup_iff_forall_not_sq_dvd upgrades it to the global 'all roots distinct iff no (X − a)² divides p'. Together they translate the ring-level divisibility form of Section I into the field-level language of root multiplicity that Mathlib's Separable ultimately measures.",
+      "mathContext": "$(X-a)^2 \\mid p \\iff \\operatorname{rootMult}_a(p) > 1$; and $p.\\text{roots}.\\text{Nodup} \\iff \\forall a,\\ \\neg\\,(X-a)^2 \\mid p$."
+    },
+    {
+      "id": "field-iff",
+      "title": "Section III: Over a Field — Separable Iff No Repeated Linear Factor",
+      "startLine": 118,
       "endLine": 122,
-      "summary": "sq_dvd_iff_one_lt_rootMultiplicity and roots_nodup_iff_forall_not_sq_dvd bridge the divisibility form to root multiplicity and to distinct roots, and separable_iff_forall_not_sq_dvd assembles the headline: a nonzero split polynomial is separable iff no (X − a)² divides it.",
-      "mathContext": "The explicit elementary criterion, combining the original divisibility bridge with Mathlib's split-polynomial separability test."
+      "summary": "separable_iff_forall_not_sq_dvd assembles the headline for a nonzero split polynomial over a field: p is Separable iff no (X − a)² divides it, combining the divisibility bridge of Sections I–II with Mathlib's split-polynomial separability test.",
+      "mathContext": "For nonzero split $p$ over a field: $p\\text{ Separable} \\iff \\forall a,\\ \\neg\\,(X-a)^2 \\mid p$."
     },
     {
       "id": "char-two",
-      "title": "Section III: Characteristic-2 Witnesses",
+      "title": "Section IV: Characteristic-2 Witnesses",
       "startLine": 124,
       "endLine": 152,
       "summary": "separable_X_sq_add_X_zmod_two (derivative = 1, separable) and not_separable_X_sq_zmod_two (derivative = 0, inseparable) compute the ordinary derivative over ZMod 2, confirming the separability criterion is correct even in the characteristic where the parent's hasseDeriv_detects_char_p warns the ordinary derivative is blind at higher multiplicity.",


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-02-oq-01` (quality 93 → 100).

**Gaps closed** (per find-targets scorer):
- **annotations** (20→25): added a 5th annotation, *From Square-Divisibility to Root Multiplicity over a Field*, covering the `sq_dvd_iff_one_lt_rootMultiplicity` / `roots_nodup_iff_forall_not_sq_dvd` bridge lemmas (lines 92–117), with mathContext, significance, relatedConcepts and prerequisites.
- **sections** (8→10): split the former Section II (92–122, which spanned three theorems) into *Section II: Multiplicity and the Repeated-Square Criterion* (92–117) and *Section III: Separable Iff No Repeated Linear Factor* (118–122) at the theorem boundary; the characteristic-2 witnesses become Section IV. All line ranges match the Lean source.

Two-file change; existing content preserved, additions are mathematically accurate.