### PR TITLE
Enrich Sophie Germain identity OQ-04: split compositeness/sharpness, add annotation

### DIFF
--- a/src/data/proofs/sophie-germain-oq-04/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-04/annotations.json
@@ -2,49 +2,111 @@
   {
     "id": "ann-intro",
     "proofId": "sophie-germain-oq-04",
-    "range": { "startLine": 3, "endLine": 29 },
+    "range": {
+      "startLine": 3,
+      "endLine": 29
+    },
     "type": "concept",
     "title": "The Sophie Germain Identity (Not the Primes)",
     "content": "Marie-Sophie Germain's name attaches to two distinct objects: Sophie Germain *primes* (studied in the base entry) and the Sophie Germain *identity*, a polynomial factorization. The identity $a^4 + 4b^4 = (a^2 - 2ab + 2b^2)(a^2 + 2ab + 2b^2)$ factors a sum that resists the usual irreducibility heuristics — there is no rational root and no obvious difference of squares — yet it always factors. This entry proves the identity and its primality corollary, supplying a Lean proof the family's metadata advertised but never contained.",
     "mathContext": "$a^4 + 4b^4 = (a^2 + 2b^2)^2 - (2ab)^2.$",
     "significance": "key",
-    "relatedConcepts": ["polynomial factorization", "difference of squares", "competition number theory"],
-    "prerequisites": ["polynomial identities", "elementary number theory"]
+    "relatedConcepts": [
+      "polynomial factorization",
+      "difference of squares",
+      "competition number theory"
+    ],
+    "prerequisites": [
+      "polynomial identities",
+      "elementary number theory"
+    ]
   },
   {
     "id": "ann-identity",
     "proofId": "sophie-germain-oq-04",
-    "range": { "startLine": 31, "endLine": 46 },
+    "range": {
+      "startLine": 31,
+      "endLine": 46
+    },
     "type": "insight",
     "title": "One-Line Ring Proof and the n⁴+4 Specialization",
     "content": "`sophie_germain_identity` is proved by `ring` over ℤ once the right-hand side is recognized as $(a^2 + 2b^2)^2 - (2ab)^2$, a difference of squares hidden inside the sum. Setting $b = 1$ gives `n_pow_four_add_four_factor`: $n^4 + 4 = (n^2 - 2n + 2)(n^2 + 2n + 2)$, the classic Olympiad factorization. Working over ℤ keeps the subtraction in $a^2 - 2ab + 2b^2$ genuine.",
     "mathContext": "$a^4+4b^4=(a^2-2ab+2b^2)(a^2+2ab+2b^2);\\ \\ n^4+4=(n^2-2n+2)(n^2+2n+2).$",
     "significance": "key",
-    "relatedConcepts": ["ring tactic", "completing the square", "difference of squares"],
-    "prerequisites": ["polynomial ring arithmetic"]
+    "relatedConcepts": [
+      "ring tactic",
+      "completing the square",
+      "difference of squares"
+    ],
+    "prerequisites": [
+      "polynomial ring arithmetic"
+    ]
   },
   {
     "id": "ann-factor-sign",
     "proofId": "sophie-germain-oq-04",
-    "range": { "startLine": 48, "endLine": 53 },
+    "range": {
+      "startLine": 48,
+      "endLine": 53
+    },
     "type": "tactic",
     "title": "Each Factor is a Sum of Two Squares",
     "content": "`factor_nonneg` proves $a^2 - 2ab + 2b^2 = (a-b)^2 + b^2 \\ge 0$ (by `nlinarith` with the square hints). Each quadratic factor is a sum of two squares, hence nonnegative — and strictly positive away from $a = b = 0$ — which is why the factorization is into genuine positive integers.",
     "mathContext": "$a^2 - 2ab + 2b^2 = (a-b)^2 + b^2.$",
     "significance": "supporting",
-    "relatedConcepts": ["sum of two squares", "nlinarith", "nonnegativity"],
-    "prerequisites": ["quadratic forms"]
+    "relatedConcepts": [
+      "sum of two squares",
+      "nlinarith",
+      "nonnegativity"
+    ],
+    "prerequisites": [
+      "quadratic forms"
+    ]
   },
   {
     "id": "ann-composite",
     "proofId": "sophie-germain-oq-04",
-    "range": { "startLine": 55, "endLine": 71 },
+    "range": {
+      "startLine": 55,
+      "endLine": 71
+    },
     "type": "insight",
     "title": "n⁴ + 4 is Composite for n ≥ 2 — and the Threshold is Sharp",
     "content": "`not_prime_n_pow_four_add_four`: for $n \\ge 2$, $n^4 + 4$ is composite. The obstacle is ℕ's truncated subtraction in $n^2 - 2n + 2$; substituting $n = m + 2$ rewrites the smaller factor as the addition-only $(m+1)^2 + 1$, so $(m+2)^4 + 4 = ((m+1)^2+1)\\,((m+2)^2 + 2(m+2) + 2)$ is a pure `ring` identity. Both factors are $\\ne 1$, so `Nat.not_prime_mul` finishes. `one_pow_four_add_four_prime` ($1^4 + 4 = 5$ is prime) shows $n \\ge 2$ cannot be relaxed, and `five_pow_four_add_four_eq` gives $5^4 + 4 = 629 = 17 \\cdot 37$.",
     "mathContext": "$n\\ge 2 \\Rightarrow n^4+4 = ((n-1)^2+1)(n^2+2n+2),\\ \\text{both } > 1.$",
     "significance": "key",
-    "relatedConcepts": ["Nat.not_prime_mul", "truncated subtraction", "primality", "sharp bounds"],
-    "prerequisites": ["natural number primality", "ℕ vs ℤ casting"]
+    "relatedConcepts": [
+      "Nat.not_prime_mul",
+      "truncated subtraction",
+      "primality",
+      "sharp bounds"
+    ],
+    "prerequisites": [
+      "natural number primality",
+      "ℕ vs ℤ casting"
+    ]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "sophie-germain-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 71
+    },
+    "type": "example",
+    "title": "Sharpness of the n ≥ 2 bound",
+    "content": "Two theorems show the compositeness corollary is sharp. one_pow_four_add_four_prime proves 1⁴ + 4 = 5 is prime (norm_num), so n = 1 is a genuine exception and the hypothesis n ≥ 2 cannot be relaxed. five_pow_four_add_four_eq gives the concrete composite witness 5⁴ + 4 = 629 = 17·37 — exactly the values of the two quadratic factors (5²−2·5+2 = 17 and 5²+2·5+2 = 37) of the Sophie Germain identity at n = 5, b = 1.",
+    "mathContext": "The Sophie Germain identity forces n⁴ + 4 to factor for every n, but over ℕ the smaller factor n²−2n+2 = (n−1)²+1 equals 1 exactly when n = 1, which is why 5 is the unique prime in the family. These checks pin down that boundary and tie the abstract factorization to explicit integers.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sophie Germain identity",
+      "primality",
+      "sharpness of hypotheses",
+      "factorization witness"
+    ],
+    "prerequisites": [
+      "Nat.Prime",
+      "norm_num"
+    ]
   }
 ]

--- a/src/data/proofs/sophie-germain-oq-04/meta.json
+++ b/src/data/proofs/sophie-germain-oq-04/meta.json
@@ -4,7 +4,9 @@
   "title": "The Sophie Germain Identity a⁴ + 4b⁴ and Its Compositeness Corollary",
   "description": "Sophie Germain's algebraic identity factors a sum that looks irreducible: a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²), obtained by completing a⁴ + 4b⁴ = (a²+2b²)² - (2ab)² as a difference of squares (sophie_germain_identity, one-line ring over ℤ). Its classic consequence is read off directly: n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2), so n⁴ + 4 is prime ONLY for n = 1 (where it is 5) and composite for every n ≥ 2 (not_prime_n_pow_four_add_four), with 1⁴+4 = 5 prime showing the bound is sharp and 5⁴+4 = 629 = 17·37 a concrete witness. Distinct from the base entry's Sophie Germain PRIME work (this is the algebraic identity, which the base meta lists but the source omits). Fully machine-checked, 0 sorries, 0 axioms.",
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "namespace": "SophieGermainOQ04",
     "lineCount": 71,
@@ -35,7 +37,9 @@
     "axiomCount": 0,
     "assumptions": "None. The identity is proved over ℤ by ring; the compositeness corollary is transported to ℕ without truncated subtraction. #print axioms reports only propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-19",
-    "mathlibDependencies": ["Nat.not_prime_mul"],
+    "mathlibDependencies": [
+      "Nat.not_prime_mul"
+    ],
     "originalContributions": [
       "Sophie Germain identity sophie_germain_identity: a⁴ + 4b⁴ = (a² - 2ab + 2b²)(a² + 2ab + 2b²) over ℤ — named in the base entry's meta but absent from the Lean source until now",
       "Specialization n_pow_four_add_four_factor: n⁴ + 4 = (n² - 2n + 2)(n² + 2n + 2)",
@@ -50,7 +54,10 @@
     ],
     "mathlib_version": "4.26.0",
     "lineCount": 71,
-    "relatedProblems": ["sophie-germain", "sophie-germain-oq-01"],
+    "relatedProblems": [
+      "sophie-germain",
+      "sophie-germain-oq-01"
+    ],
     "theoremCount": 6,
     "definitionCount": 0
   },
@@ -114,12 +121,16 @@
       "mathContext": "$a^2 - 2ab + 2b^2 = (a-b)^2 + b^2 \\ge 0$."
     },
     {
-      "id": "compositeness",
-      "title": "Compositeness of n⁴ + 4 and Sharpness",
-      "startLine": 55,
+      "title": "Compositeness of n⁴ + 4",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "not_prime_n_pow_four_add_four: for n ≥ 2, n⁴ + 4 is not prime. Substituting n = m + 2 makes the smaller factor the non-truncated (m+1)² + 1, giving n⁴ + 4 = ((m+1)²+1)·((m+2)²+2(m+2)+2) with both factors ≠ 1, so Nat.not_prime_mul applies."
+    },
+    {
+      "title": "Sharpness: the lone prime and a composite witness",
+      "startLine": 63,
       "endLine": 71,
-      "summary": "not_prime_n_pow_four_add_four: for n ≥ 2, n⁴ + 4 is composite. Substituting n = m + 2 turns the factorization into the addition-only ring identity (m+2)⁴ + 4 = ((m+1)² + 1)·((m+2)² + 2(m+2) + 2); both factors are ≠ 1, so Nat.not_prime_mul applies. one_pow_four_add_four_prime (5 is prime) shows the bound is sharp, and five_pow_four_add_four_eq exhibits 5⁴ + 4 = 17·37.",
-      "mathContext": "$n\\ge 2 \\Rightarrow n^4+4=((n-1)^2+1)(n^2+2n+2)$, both factors $>1$."
+      "summary": "The bound n ≥ 2 is sharp: one_pow_four_add_four_prime confirms 1⁴ + 4 = 5 is genuinely prime (the sole exception), and five_pow_four_add_four_eq exhibits the concrete factorization 5⁴ + 4 = 629 = 17·37, matching the identity's two quadratic factors at n = 5."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass on `sophie-germain-oq-04` (quality 93 → 100).

- Split the compositeness section at the sharpness boundary (line 63) → 5 sections.
- Add a 5th annotation covering the sharpness theorems (`1⁴+4=5` prime, concrete witness `5⁴+4=629=17·37`).

No Lean source changes.