### PR TITLE
Enrich: Carmichael Function λ / Euler Totient (OQ-01-OQ-02) (→100/100)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02/annotations.json
@@ -52,6 +52,18 @@
     "prerequisites": ["cyclicity of (ℤ/pᵏℤ)ˣ for odd p", "group exponent vs order", "Euler's theorem aᵠ⁽ⁿ⁾ = 1"]
   },
   {
+    "id": "ann-universal-exponent",
+    "proofId": "euler-totient-oq-01-oq-02",
+    "range": { "startLine": 59, "endLine": 66 },
+    "type": "insight",
+    "title": "λ Is the Smallest Universal Exponent, Sharper Than Euler's φ",
+    "content": "pow_carmichael expresses the property that gives the Carmichael function its name: a^{λ(n)} = 1 for every unit a modulo n. Euler's theorem already gives a^{φ(n)} = 1, but λ(n) ∣ φ(n) (carmichael_dvd_totient) and λ(n) can be strictly smaller — for powers of two λ(2ᵏ) = φ(2ᵏ)/2 — so λ is the optimal, smallest exponent that annihilates the whole unit group simultaneously. It is exactly the exponent of the abelian group (ℤ/nℤ)ˣ, i.e. the lcm of the orders of its elements, whereas φ(n) is merely its cardinality; the two coincide precisely when the group is cyclic (n = 1, 2, 4, pᵏ, or 2pᵏ for odd primes p).",
+    "mathContext": "$a^{\\lambda(n)}=1\\ \\forall a\\in(ℤ/nℤ)^\\times$; $\\ \\lambda(n)=\\exp\\big((ℤ/nℤ)^\\times\\big)\\mid\\varphi(n)=\\big|(ℤ/nℤ)^\\times\\big|$, with equality iff the group is cyclic.",
+    "significance": "key",
+    "relatedConcepts": ["exponent of a group", "Euler's theorem", "cyclic group", "primitive root", "least universal exponent"],
+    "prerequisites": ["group exponent vs order", "ArithmeticFunction.pow_carmichael", "(ZMod n)ˣ"]
+  },
+  {
     "id": "ann-concrete",
     "proofId": "euler-totient-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/euler-totient-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02/meta.json
@@ -107,15 +107,23 @@
     },
     {
       "id": "odd-primes",
-      "title": "Section II: Odd Prime Powers and General Bounds",
+      "title": "Section II: Odd Prime Powers and the λ ∣ φ Bound",
       "startLine": 52,
+      "endLine": 58,
+      "summary": "carmichael_odd_prime_pow records that for an odd prime p the unit group (ℤ/pᵏℤ)ˣ is cyclic, so λ(pᵏ) = φ(pᵏ); carmichael_dvd_totient gives the always-true divisibility λ(n) ∣ φ(n), the formal statement that λ refines Euler's totient exponent.",
+      "mathContext": "For odd prime $p$: $(ℤ/p^kℤ)^\\times$ cyclic $\\Rightarrow \\lambda(p^k)=\\varphi(p^k)$; in general $\\lambda(n)\\mid\\varphi(n)$."
+    },
+    {
+      "id": "universal-exponent",
+      "title": "Section III: The Universal Exponent Property",
+      "startLine": 59,
       "endLine": 66,
-      "summary": "carmichael_odd_prime_pow (λ(pᵏ) = φ(pᵏ) for odd primes, cyclic case), carmichael_dvd_totient (λ ∣ φ), pow_carmichael (a^{λ(n)} = 1).",
-      "mathContext": "Odd prime powers are cyclic, so λ = φ; in general λ ∣ φ and gives the optimal universal exponent."
+      "summary": "pow_carmichael states the defining property of the Carmichael function: every unit a modulo n satisfies a^{λ(n)} = 1. Combined with λ ∣ φ this makes λ(n) the *smallest* universal exponent, strictly sharper than Euler's a^{φ(n)} = 1 whenever λ(n) < φ(n) (e.g. all 2ᵏ, k ≥ 3).",
+      "mathContext": "$\\forall a\\in(ℤ/nℤ)^\\times,\\ a^{\\lambda(n)}=1$, and $\\lambda(n)$ is minimal with this property."
     },
     {
       "id": "concrete",
-      "title": "Section III: Concrete Values",
+      "title": "Section IV: Concrete Values",
       "startLine": 68,
       "endLine": 73,
       "summary": "carmichael_eight (λ(8) = 2) and carmichael_sixteen (λ(16) = 4), instantiating the 2ᵏ formula.",


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-02` (quality 93 → 100).

**Gaps closed** (find-targets scorer):
- **sections** (8→10): split the former Section II (52–66, which bundled the odd-prime result with two general-bounds theorems) into *Odd Prime Powers and the λ ∣ φ Bound* (52–58) and *The Universal Exponent Property* (59–66) at the `pow_carmichael` theorem boundary; the concrete values become Section IV. Line ranges match the Lean source.
- **annotations** (20→25): added a 5th annotation, *λ Is the Smallest Universal Exponent, Sharper Than Euler's φ*, explaining that λ(n) = exp((ℤ/nℤ)ˣ) ∣ φ(n) with equality iff the unit group is cyclic — with mathContext, significance (key), relatedConcepts and prerequisites.

Two-file additive change; existing content preserved.