### PR TITLE
Enrich: Königsberg / Euler Trail Necessity (OQ-02-OQ-01-OQ-02) (→100/100)

### DIFF
--- a/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/annotations.json
@@ -90,5 +90,30 @@
       "Eulerian-trail",
       "degree-parity"
     ]
+  },
+  {
+    "id": "ann-ue-circuit-obstruction",
+    "proofId": "konigsberg-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 109
+    },
+    "type": "key-insight",
+    "title": "One Odd Vertex Already Kills Every Eulerian Circuit",
+    "content": "no_eulerian_circuit_of_odd_degree isolates the closed-trail case: if even a single vertex x has odd degree, no Eulerian circuit can exist. It is the exact contrapositive of eulerian_circuit_forall_even (a circuit forces every degree even), so the proof is a two-line rintro-and-apply. This is strictly stronger than the general trail obstruction no_eulerian_trail_of_card_odd_ne, which needs the odd-vertex count to avoid both 0 and 2: for a *circuit* the endpoints coincide, so the only admissible parity profile is all-even, and any lone odd vertex is fatal. For the Königsberg graph, where all four landmasses have odd degree, either obstruction already closes the problem.",
+    "mathContext": "$\\exists x,\\ \\mathrm{Odd}(\\deg x)\\ \\Rightarrow\\ \\nexists\\ \\text{closed Eulerian trail}$; contrapositive of $\\text{circuit}\\Rightarrow\\forall v,\\ \\mathrm{Even}(\\deg v)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Eulerian circuit",
+      "parity of degrees",
+      "contrapositive",
+      "closed walk",
+      "handshake lemma"
+    ],
+    "prerequisites": [
+      "eulerian_circuit_forall_even",
+      "Nat.not_even_iff_odd",
+      "SimpleGraph.Walk.IsEulerian"
+    ]
   }
 ]

--- a/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02-oq-01-oq-02/meta.json
@@ -114,10 +114,17 @@
     },
     {
       "id": "sec-obstruction",
-      "title": "Königsberg Obstruction",
+      "title": "General Königsberg Obstruction",
       "startLine": 87,
+      "endLine": 100,
+      "summary": "no_eulerian_trail_of_card_odd_ne: if the number of odd-degree vertices is neither 0 nor 2, the graph admits no Eulerian trail at all. Königsberg's bridge graph has four odd-degree landmasses, so this is exactly Euler's 1736 impossibility, proved by contradiction from the trail's parity dichotomy (card_odd_degree ∈ {0, 2})."
+    },
+    {
+      "id": "sec-circuit-obstruction",
+      "title": "Circuit Form of the Obstruction",
+      "startLine": 101,
       "endLine": 109,
-      "summary": "no_eulerian_trail_of_card_odd_ne and no_eulerian_circuit_of_odd_degree — parity obstructions ruling out Eulerian trails/circuits, generalizing the Seven Bridges impossibility"
+      "summary": "no_eulerian_circuit_of_odd_degree: a single odd-degree vertex already forbids an Eulerian circuit — the contrapositive of eulerian_circuit_forall_even. This is the closed-trail specialization, sharper than the general trail obstruction because one bad vertex suffices."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `konigsberg-oq-02-oq-01-oq-02` (quality 93 → 100).

**Gaps closed** (find-targets scorer):
- **sections** (8→10): split the obstruction section (87–109), which bundled two theorems, into *General Königsberg Obstruction* (87–100, `no_eulerian_trail_of_card_odd_ne`) and *Circuit Form of the Obstruction* (101–109, `no_eulerian_circuit_of_odd_degree`) at the theorem boundary. Line ranges match the Lean source.
- **annotations** (20→25): added a 5th annotation, *One Odd Vertex Already Kills Every Eulerian Circuit*, on the circuit-form corollary as the contrapositive of `eulerian_circuit_forall_even`, with mathContext, significance (key), relatedConcepts and prerequisites.

Two-file additive change; existing content preserved.