### PR TITLE
Enrich: Tietze Bounded Property ⇒ Normal (OQ-01-OQ-01-OQ-01) (→100/100)

### DIFF
--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -73,6 +73,31 @@
     ]
   },
   {
+    "id": "ann-level-set-separation",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 172
+    },
+    "type": "theorem",
+    "title": "Level Sets of the Extension Separate A and B",
+    "content": "Once the bounded hypothesis supplies an extension F of the {0,1} indicator, normality follows from an Urysohn-style level-set argument. The pointwise identity F = f on s (obtained by ContinuousMap.congr_fun on the extension equation) forces F = 0 on A and F = 1 on B. Then the preimages F⁻¹(Iio ½) and F⁻¹(Ioi ½) are open (F continuous), disjoint (½ separates the two intervals), and contain A and B respectively — exactly the data of normality. Notably the argument uses only the *existence* of a real extension, not any bound on its range, so the [0,1] output constraint in the hypothesis is never invoked; the value ½ is an arbitrary separating threshold.",
+    "mathContext": "$F=0$ on $A$, $F=1$ on $B$; $A\\subseteq F^{-1}(-\\infty,\\tfrac12)$, $B\\subseteq F^{-1}(\\tfrac12,\\infty)$, disjoint opens $\\Rightarrow$ $X$ normal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Urysohn's lemma",
+      "normal space",
+      "level set / preimage",
+      "separation by continuous functions",
+      "clopen set"
+    ],
+    "prerequisites": [
+      "ContinuousMap.congr_fun",
+      "preimage of an open set under a continuous map",
+      "definition of NormalSpace"
+    ]
+  },
+  {
     "id": "ann-equivalence-tfae",
     "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/meta.json
@@ -51,11 +51,18 @@
     },
     {
       "id": "converse",
-      "title": "The Main Result: Bounded Property Implies Normal",
+      "title": "The Main Result (I): Building the {0,1} Extension",
       "startLine": 113,
+      "endLine": 136,
+      "summary": "normalSpace_of_hasBoundedTietzeExtensionProperty, first half. For disjoint closed A, B, the part over B in s = A ∪ B is clopen (parent lemma), so the {0,1} indicator f is continuous on s (its frontier is empty, so Continuous.if applies) and has range in [0,1]. Applying the bounded hypothesis with a = 0, b = 1 extends f to F : X → ℝ.",
+      "mathContext": "$s=A\\cup B$; $B$ clopen in $s$ $\\Rightarrow$ the $\\{0,1\\}$ indicator $f$ is continuous and $[0,1]$-valued; bounded hypothesis gives $F:X\\to\\mathbb R$ extending $f$."
+    },
+    {
+      "id": "converse-separate",
+      "title": "The Main Result (II): Separating A and B by Level Sets",
+      "startLine": 137,
       "endLine": 172,
-      "summary": "normalSpace_of_hasBoundedTietzeExtensionProperty: the new content. For disjoint closed A, B the part over B in s = A ∪ B is clopen (parent lemma), so the {0,1} indicator is continuous on s and has range in [0,1]. The bounded hypothesis with a=0, b=1 extends it to F : X → ℝ with F = 0 on A, F = 1 on B; the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A and B. No separation axiom on X is assumed, and the output range constraint is not even used.",
-      "mathContext": "Disjoint closed $A,B$: the $\\{0,1\\}$ boundary function on $A\\cup B$ is $[0,1]$-valued; the bounded hypothesis extends it to $F$, and $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$, $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens."
+      "summary": "Second half of the theorem: the pointwise description of F (via congr_fun on the extension identity) gives F = 0 on A and F = 1 on B, and the disjoint open level sets F⁻¹(Iio ½) ⊇ A and F⁻¹(Ioi ½) ⊇ B witness normality. No separation axiom on X is assumed, and the output range constraint is never used."
     },
     {
       "id": "equivalence-tfae",


### PR DESCRIPTION
Enrichment pass for `tietze-extension-theorem-oq-01-oq-01-oq-01` (quality 93 → 100).

**Gaps closed** (find-targets scorer):
- **sections** (8→10): split the 58-line main-result section (113–172) into *Building the {0,1} Extension* (113–136, constructing the indicator and applying the bounded hypothesis to get F) and *Separating A and B by Level Sets* (137–172, the Urysohn-style separation) at the point where F is obtained. Line ranges match the Lean source.
- **annotations** (20→25): added a 5th annotation, *Level Sets of the Extension Separate A and B*, noting the argument uses only the existence of the extension (not the range bound), with mathContext, significance (key), relatedConcepts and prerequisites.

Two-file additive change; existing content preserved.