### PR TITLE
fix(gallery): wilsons-theorem-oq-03-oq-01 badge original→mathlib (Tier B) (#34457)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/WilsonsTheoremOQ03OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None beyond Mathlib's foundational axioms. Every theorem (padicValNat_prod_factorial, legendre_add, padicValNat_factorial_sum_eq, padicValNat_multinomial, sub_one_mul_padicValNat_multinomial, prime_not_dvd_multinomial_iff, sub_one_mul_padicValNat_multinomial_two) is fully machine-checked. `#print axioms` on the main results reports only propext, Classical.choice, and Quot.sound — no `axiom` declarations, no structure-encoded hypotheses, no `sorry`, and no `native_decide` (hence no Lean.ofReduceBool). leanFile.axiomCount = 0.",


### PR DESCRIPTION
## Summary

Corrects the gallery badge for **wilsons-theorem-oq-03-oq-01** ("Legendre's Formula for Multinomial Coefficients & Kummer's Theorem") from `original` → `mathlib`.

## Rationale (auditor issue #34457)

The entry's core analytic engine — the digit-sum interpretation of the p-adic valuation of a factorial (Legendre: `(p−1)·ν_p(m!) = m − S_p(m)`) — is imported from Mathlib as `sub_one_mul_padicValNat_factorial`. `legendre_add` is a one-line `omega` wrapper. The file's genuine contribution is the *generalization* to multinomials (bridge/infrastructure over a Mathlib core), which per the auditor Tier framework is **Tier B → badge `mathlib`**.

This also restores consistency with sibling **wilsons-theorem-oq-03-oq-03**, corrected `original → mathlib` in #34440 / merged #34442.

## Change

- `meta.badge`: `"original"` → `"mathlib"` (single line)

`status: "verified"` unchanged (0 sorries, 0 axioms, kernel-only). Disclosure was already exemplary. Severity: MEDIUM (badge only).

Closes #34457