### PR TITLE
Enrich Lovász LLL OQ-01 Euler threshold: annotate imports/setup section (6→7)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/annotations.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-01-euler-threshold/annotations.json
@@ -20,6 +20,26 @@
     ]
   },
   {
+    "id": "ann-lll-oq01-euler-setup",
+    "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "context",
+    "title": "Building on the parent proof: imports and open namespaces",
+    "content": "The file imports only `Proofs.LovaszLocalLemma` — the parent gallery proof — rather than re-deriving the threshold. This is a deliberate architectural choice: the tight threshold `lllThreshold d = d^d/(d+1)^{d+1}` (defined over $\\mathbb{Q}$) and the tight-threshold symmetric statement `symmetric_lll` already live there, so this entry references *the same* threshold the parent formalized instead of introducing a real-valued surrogate. `open Real` brings `Real.exp`, `Real.add_one_le_exp`, and `Real.exp_nat_mul` into scope for the $e$-bound; `open ProbMethod.LovaszLocal` exposes `lllThreshold` unqualified. No new `def` is introduced anywhere in the file — it is entirely five theorems over $\\mathbb{R}$ — which is why `definitionCount = 0` and the only cross-namespace surface is the single `lllThreshold_cast` plumbing lemma that reconciles the parent's $\\mathbb{Q}$ value with these real inequalities.",
+    "mathContext": "Depends on the parent proof `lovasz-local-lemma` for `lllThreshold` (over $\\mathbb{Q}$) and `symmetric_lll`; `open Real` supplies `exp`, `add_one_le_exp`, `exp_nat_mul`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "proof reuse via import",
+      "ProbMethod.LovaszLocal namespace",
+      "ℚ-valued lllThreshold",
+      "separation of hypothesis choice from combinatorial core"
+    ],
+    "prerequisites": [
+      "Proofs.LovaszLocalLemma (parent proof providing lllThreshold, symmetric_lll)",
+      "Lean namespaces and the open command"
+    ]
+  },
+  {
     "id": "ann-lll-oq01-euler-e-bound",
     "proofId": "lovasz-local-lemma-oq-01-euler-threshold",
     "range": { "startLine": 43, "endLine": 58 },


### PR DESCRIPTION
## Summary

Enrichment pass for `lovasz-local-lemma-oq-01-euler-threshold` (pass 0). The entry was already high quality (quality 88): meta.json is comprehensive with 5 keyInsights, 3 openQuestions, 5 crossReferences, 4 references, 7 sections, and 6 annotations all carrying `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. All Lean claims (5 theorems, 0 sorries, 0 axioms, lineCount 106) verified accurate against `proofs/Proofs/LovaszLocalLemmaOQ01EulerThreshold.lean`.

## Change

Per the enricher role's gap #2 (annotation coverage of uncovered code sections), the one genuine gap was that the `setup` section (lines 37–41: imports + `open` namespaces) — a defined section with a summary — had **no annotation**, while the other 6 sections each did. This PR adds a single `context` annotation `ann-lll-oq01-euler-setup` completing coverage of all 7 sections:

- Explains the architectural dependency: the file imports only the parent proof `Proofs.LovaszLocalLemma`, reusing its ℚ-valued `lllThreshold` and `symmetric_lll` rather than re-deriving a real-valued surrogate.
- Notes what `open Real` (`exp`, `add_one_le_exp`, `exp_nat_mul`) and `open ProbMethod.LovaszLocal` (`lllThreshold`) bring into scope.
- Records why `definitionCount = 0` (five theorems, no defs) and that `lllThreshold_cast` is the sole cross-namespace bridge.

## Scope discipline

Deliberately **not** accretive: no keyInsights, crossReferences, or references were added — the entry already meets/exceeds every quality minimum and sits well under all size caps (annotations.json ~9.5 KB, meta.json ~23 KB < 60 KB cap). This is targeted coverage completion, one annotation, 6→7.