### PR TITLE
Enrich Erdős #435 non-prime-power converse: docstring framing annotation (4→5)

### DIFF
--- a/src/data/proofs/erdos-435-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-435-oq-01-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "erdos435npp-ann-docstring",
+    "proofId": "erdos-435-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Why Erdős #435 is posed only for non-prime-powers",
+    "content": "Erdős Problem #435 asks for the largest integer not representable as a non-negative combination of the interior binomial coefficients C(n,1), …, C(n,n−1) — the Frobenius number of the numerical semigroup they generate. That quantity exists only when the semigroup has finite complement, which for a numerical semigroup happens exactly when its generators are globally coprime (gcd = 1). This file is one of three: `Erdos435Problem.lean` states the problem and the Hwang–Song formula, `Erdos435PrimePowerObstruction.lean` proves the easy half (for n = pᵏ every interior C(n,j) shares the factor p, so gcd > 1 and no Frobenius number exists), and this file proves the converse — the reason the problem is well-posed for the n it is stated over. Together they establish the sharp dichotomy gcd{C(n,1),…,C(n,n−1)} = 1 ⟺ n is not a prime power. The proof engine is Lucas' theorem: for each prime p ∣ n with a = v_p(n), the witness coefficient satisfies C(n, pᵃ) ≡ n/pᵃ (mod p), and n/pᵃ = ordCompl[p] n is coprime to p, so no prime divides all generators.",
+    "mathContext": "For a numerical semigroup, finite complement ⟺ gcd of generators = 1. Here that reduces to the dichotomy $\\gcd\\{\\binom{n}{j}: 1\\le j\\le n-1\\} = 1 \\iff n \\text{ is not a prime power}$, matching OEIS A014963.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős Problem #435", "numerical semigroup", "Frobenius number", "global coprimality", "Hwang–Song formula", "prime-power dichotomy"],
+    "prerequisites": ["numerical semigroups and the Frobenius number", "binomial coefficients", "prime powers"]
+  },
+  {
     "id": "erdos435npp-ann-lucas-setup",
     "proofId": "erdos-435-oq-01-oq-01",
     "range": { "startLine": 42, "endLine": 49 },


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-435-oq-01-oq-01` (pass 0). Already a high-quality entry (quality 93): meta.json (~15.7 KB, well under caps) has 5 keyInsights, 4 sections, 2 crossReferences, 4 references, and 4 deep annotations. All Lean claims (2 theorems, 0 sorries, 0 axioms, Mathlib-only) verified against `proofs/Proofs/Erdos435NonPrimePower.lean`.

## Change

The 4 existing annotations all cover the **proof body** (lines 42–116). The module **docstring** (lines 1–26) — the framing a reader sees first — had no annotation. This PR adds one `context` annotation `erdos435npp-ann-docstring`:

- Explains *why* Erdős #435 is restricted to non-prime-powers: the Frobenius number exists iff the generating numerical semigroup has finite complement iff the interior binomial coefficients are globally coprime.
- States the sharp dichotomy `gcd{C(n,1),…,C(n,n−1)} = 1 ⟺ n not a prime power` (= OEIS A014963).
- Situates this file (the converse) against the problem file and the prime-power obstruction file, and names the Lucas-theorem proof engine.

This brings the annotation count from 4 to the role's **5-minimum** and completes annotation coverage of the docstring section.

## Scope discipline

Pure-addition, single annotation. No keyInsights/crossReferences/references touched — the entry already meets/exceeds every quality minimum and sits far under all size caps. Targeted coverage completion, not accretion.