### PR TITLE
Enrich Descartes total angular defect: overview framing annotation (4→5)

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-descartes-overview",
+    "proofId": "euler-polyhedral-formula-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "type": "context",
+    "title": "Descartes’ 4π theorem = discrete Gauss–Bonnet = Euler’s formula",
+    "content": "Around 1630 Descartes observed (in the manuscript 'De solidorum elementis', lost until an 1860 rediscovery via a Leibniz copy) that for any convex polyhedron the total angular defect — the sum over vertices of 2π minus the face angles meeting there — is always 4π (720°), independent of shape. The angular defect at a vertex is the discrete analogue of Gaussian curvature concentrated at a cone point, so Descartes' theorem is the polyhedral form of Gauss–Bonnet (∫K dA = 2π·χ) and is logically equivalent to Euler's polyhedral formula V−E+F=2. This file formalizes it self-containedly with 0 axioms: it models only the combinatorial/angle data of a polyhedral surface (vertex/edge/face counts and the multiset of face sizes), takes the planar polygon angle sum (n−2)π for an n-gon as the definition of how faces enter, and proves totalDefect = 2π·(V−E+F) (discrete Gauss–Bonnet) and its χ=2 corollary 4π. Because everything is linear in the symbol π, no analytic fact about π is needed — the proofs close by `ring` / `linear_combination` over ℝ.",
+    "mathContext": "Total angular defect $\\sum_v\\!\\big(2\\pi - \\sum_{f\\ni v}\\theta_{f,v}\\big) = 2\\pi\\,\\chi = 2\\pi(V-E+F)$; for a sphere $\\chi=2$ so the defect is $4\\pi$. Polyhedral Gauss–Bonnet with curvature concentrated at the vertices.",
+    "significance": "context",
+    "relatedConcepts": ["Descartes' theorem", "discrete Gauss–Bonnet", "angular defect as discrete curvature", "Euler characteristic", "Euler's polyhedral formula", "Platonic solids"],
+    "prerequisites": ["Euler's polyhedral formula V−E+F=2", "planar polygon angle sum (n−2)π", "Gaussian curvature (intuition)"]
+  },
+  {
     "id": "ann-total-face-angle",
     "proofId": "euler-polyhedral-formula-oq-01-oq-02-oq-01",
     "range": {


### PR DESCRIPTION
## Summary

Enrichment pass for `euler-polyhedral-formula-oq-01-oq-02-oq-01` (pass 0). Already high quality (quality 93): meta.json (~11 KB, far under caps) has 5 keyInsights, 4 sections, 2 crossReferences, 3 references, 3 openQuestions, and 4 deep annotations. All Lean claims (5 theorems, 8 defs, 0 sorries, 0 axioms) verified against `proofs/Proofs/EulerPolyhedralDescartes.lean`.

## Change

The 4 existing annotations cover the four proof-body sections (lines 33–161). The module **docstring** (lines 1–29) — the reader's entry point — had no annotation. This PR adds one `context` annotation `ann-descartes-overview`:

- Frames Descartes' 4π total-angular-defect theorem (c. 1630) as the polyhedral **discrete Gauss–Bonnet** identity `totalDefect = 2π·χ` and its equivalence to Euler's `V−E+F=2`.
- Explains the combinatorial model, the `(n−2)π` planar polygon angle-sum input, and why the whole proof is **0-axiom** (linear in the symbol π, closed by `ring`/`linear_combination`).

Brings the annotation count from 4 to the role's **5-minimum** and completes coverage of the docstring section.

## Scope discipline

Pure-addition, single annotation. No keyInsights/crossReferences/references touched — entry already meets/exceeds every quality minimum and sits far under all size caps. Targeted coverage completion, not accretion.