### PR TITLE
amgm-oq020205: general-n first Newton inequality (all n, signed reals)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -35,13 +35,20 @@
         is NO sign hypothesis: the roots need only be real, which is exactly the
         advantage of the real-rootedness route the entry highlights (the parent's
         inductive proof needs `0 ≤ x i`).
+  * `newton_three_first` / `newton_three_second`  :  both Newton log-concavity
+        steps at `n = 3`, as nonnegative discriminants of the two derivative
+        quadratics Rolle produces, via explicit SOS certificates.  Signed reals.
+  * `sq_sum_eq`, `sq_sum_le_nat_mul_sum_sq`, `newton_first_general`  :  the
+        genuinely *arbitrary-`n`* first Newton (= first Maclaurin) inequality
+        `p_1² ≥ p_0 p_2`, i.e. `2 n · e₂ ≤ (n - 1) · e₁²`, for signed reals —
+        no enumeration, no appeal to the still-open general Rolle crux (see
+        Part III below).
 
-  The general case (`n ≥ 3`) needs the crux lemma "differentiation preserves
-  full real-rootedness (counting multiplicity)" — Rolle's theorem iterated on
-  `∏ (X - x_i)` — which is the multi-week formalization risk flagged in
-  `problem.md`.  It is honestly retained as open (documented in knowledge.md) and is
-  deliberately NOT stubbed out in this file, which is instead a complete,
-  self-contained, fully machine-checked quadratic/base atom of that program.
+  The general SECOND-and-higher steps (`p_k², k ≥ 2`, arbitrary `n`) need the
+  crux lemma "differentiation preserves full real-rootedness (counting
+  multiplicity)" — Rolle's theorem iterated on `∏ (X - x_i)` — which is the
+  multi-week formalization risk flagged in `problem.md`.  It is honestly retained
+  as open (documented in knowledge.md) and is deliberately NOT stubbed out.
 -/
 import Mathlib
 
@@ -186,5 +193,81 @@ theorem newton_three_normalized (x y z : ℝ) :
   refine ⟨?_, ?_⟩
   · nlinarith [newton_three_first x y z]
   · nlinarith [newton_three_second x y z]
+
+/-!  ## Part III — the general-`n` first Newton inequality (all `n`, signed reals)
+
+The `n = 2` and `n = 3` results above are per-arity SOS certificates.  This part
+gives the genuinely *arbitrary-`n`* first Newton (equivalently first Maclaurin)
+inequality `p₁² ≥ p₀ p₂`, for signed reals, with NO enumeration and NO appeal to
+the (still-open) general iterated-Rolle crux.
+
+Write `e₁ = ∑ xᵢ`, `p₂ = ∑ xᵢ²` (the second power sum) and
+`e₂ = ∑_{i < j} xᵢ xⱼ` (the second elementary symmetric polynomial).  Newton's
+first inequality `p₁² ≥ p₀ p₂` unwinds, with `p₁ = e₁/n`, `p₂ = e₂/binom n 2`,
+`p₀ = 1`, to the polynomial inequality
+
+    `2 n · e₂ ≤ (n - 1) · e₁²`.
+
+Two ingredients suffice:
+* the elementary identity `e₁² = p₂ + 2 e₂`  (`sq_sum_eq`, a clean induction), and
+* the QM–AM / Cauchy–Schwarz bound `e₁² ≤ n · p₂`  (`sq_sum_le_card_mul_sum_sq`).
+
+Substituting `p₂ = e₁² - 2 e₂` into `e₁² ≤ n · p₂` gives exactly
+`2 n · e₂ ≤ (n - 1) · e₁²`.  Because QM–AM needs only *real* inputs, the result
+holds for SIGNED reals — the same generalisation over the parent's `0 ≤ xᵢ`
+induction that the `n = 2` / `n = 3` discriminant route achieves, but now for
+every arity simultaneously.  The higher log-concavity steps (`p_k`, `k ≥ 2`) at
+arbitrary `n` remain the open Rolle-crux part. -/
+
+open Finset in
+/-- **Square-of-sum / elementary-symmetric identity.**  For any real sequence,
+`(∑_{i<n} xᵢ)² = ∑_{i<n} xᵢ² + 2 · ∑_{j<n} ∑_{i<j} xᵢ xⱼ`; that is
+`e₁² = p₂ + 2 e₂`, the expansion of the square of a sum into its diagonal (second
+power sum) and off-diagonal (second elementary symmetric) parts.  Proved by a
+clean induction on `n`, sidestepping any triangular reindexing. -/
+theorem sq_sum_eq (n : ℕ) (x : ℕ → ℝ) :
+    (∑ i ∈ range n, x i) ^ 2
+      = (∑ i ∈ range n, x i ^ 2)
+        + 2 * ∑ j ∈ range n, ∑ i ∈ range j, x i * x j := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [sum_range_succ, sum_range_succ, sum_range_succ]
+    have hmul : ∑ i ∈ range n, x i * x n = (∑ i ∈ range n, x i) * x n := by
+      rw [sum_mul]
+    rw [hmul]
+    linear_combination ih
+
+open Finset in
+/-- **QM–AM for the power sum.**  `(∑_{i<n} xᵢ)² ≤ n · ∑_{i<n} xᵢ²`.  This is the
+`f = g` case of Chebyshev's sum inequality (`sq_sum_le_card_mul_sum_sq`) applied
+on `range n`, using `#(range n) = n`. -/
+theorem sq_sum_le_nat_mul_sum_sq (n : ℕ) (x : ℕ → ℝ) :
+    (∑ i ∈ range n, x i) ^ 2 ≤ (n : ℝ) * ∑ i ∈ range n, x i ^ 2 := by
+  have h : (∑ i ∈ range n, x i) ^ 2 ≤ ((range n).card : ℝ) * ∑ i ∈ range n, x i ^ 2 :=
+    sq_sum_le_card_mul_sum_sq
+  simpa [card_range] using h
+
+open Finset in
+/-- **Newton's first inequality for arbitrary `n`, signed reals.**  With
+`e₁ = ∑_{i<n} xᵢ` and `e₂ = ∑_{j<n} ∑_{i<j} xᵢ xⱼ` the second elementary
+symmetric polynomial,
+    `2 n · e₂ ≤ (n - 1) · e₁²`.
+This is the normalized first Newton/Maclaurin inequality `p₁² ≥ p₀ p₂`
+(`p₁ = e₁/n`, `p₂ = e₂ / binom n 2`, `p₀ = 1`) after clearing denominators.  No
+sign hypothesis: it holds for all real `xᵢ`, generalising the `0 ≤ xᵢ` inductive
+parent to every arity at once.  Proof: substitute the identity `e₁² = p₂ + 2 e₂`
+(`sq_sum_eq`) into the QM–AM bound `e₁² ≤ n · p₂` (`sq_sum_le_nat_mul_sum_sq`). -/
+theorem newton_first_general (n : ℕ) (x : ℕ → ℝ) :
+    2 * (n : ℝ) * (∑ j ∈ range n, ∑ i ∈ range j, x i * x j)
+      ≤ ((n : ℝ) - 1) * (∑ i ∈ range n, x i) ^ 2 := by
+  have hid := sq_sum_eq n x
+  have hqm := sq_sum_le_nat_mul_sum_sq n x
+  -- scale the identity by `n`, so everything is linear in the three sums
+  have hn : (n : ℝ) * (∑ i ∈ range n, x i) ^ 2
+      = (n : ℝ) * (∑ i ∈ range n, x i ^ 2)
+        + 2 * (n : ℝ) * (∑ j ∈ range n, ∑ i ∈ range j, x i * x j) := by
+    rw [hid]; ring
+  nlinarith [hqm, hn]
 
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,53 +4,59 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 3 (PART II)
+**Iteration**: 4 (PART III)
 
 ## Current Focus
-Extended the real-rooted/discriminant route to the first nontrivial arity `n = 3`
-(both log-concavity steps), building on the PART-I `n = 2` base case. Five new
-theorems in `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, 0 sorries, 0 axioms
-(docker-build clean, 7743 jobs; Tier-A axiom-free):
-- `newton_three_first : 3(xy+yz+zx) ≤ (x+y+z)²`  (`e₁² ≥ 3e₂`, the first Newton
-  step at n=3), for SIGNED reals, SOS `½Σ(x−y)²`.
-- `newton_three_second : 3(x+y+z)·xyz ≤ (xy+yz+zx)²`  (`e₂² ≥ 3e₁e₃`, the second
-  Newton step), SOS `½Σ(xy−yz)²`.
-- `discrim_deriv_cubic_first` / `discrim_recip_deriv_cubic_second`: the same two
-  facts as the nonnegative discriminants of the derivative quadratic
-  `P' = 3X²−2e₁X+e₂` and the reciprocal-derivative quadratic `−3e₃X²+2e₂X−e₁` —
-  the `n = 3` instance of "a derivative of a real-rooted polynomial is
-  real-rooted (discriminant ≥ 0)".
-- `newton_three_normalized`: both steps in normalized `p`-mean form.
+Proved the genuinely **arbitrary-`n`** first Newton (= first Maclaurin)
+inequality `p₁² ≥ p₀ p₂` for SIGNED reals — no enumeration, no appeal to the
+still-open iterated-Rolle crux. Three new theorems in
+`Proofs/AmgmInequalityOQ02OQ02OQ05.lean` (docker-build clean, 7743 jobs,
+`LEAN_SKIP_CACHE=true`; 0 sorries, 0 axioms — foundational only):
 
-The `n = 3` discriminants are proved *directly* by SOS — which IS the
-real-rootedness of those quadratics — so this arity needs neither the general
-Rolle-iteration crux nor any sign hypothesis. Rolle is the motivation; SOS is the
-proof.
+- `sq_sum_eq`: the square-of-sum / elementary-symmetric identity
+  `(∑_{i<n} xᵢ)² = ∑_{i<n} xᵢ² + 2 ∑_{j<n} ∑_{i<j} xᵢ xⱼ`, i.e. `e₁² = p₂ + 2 e₂`,
+  proved by a clean induction on `n` (no triangular reindexing — the `succ` step
+  is `sum_range_succ ×3`, `Finset.sum_mul`, then `linear_combination ih`).
+- `sq_sum_le_nat_mul_sum_sq`: QM–AM `(∑ xᵢ)² ≤ n · ∑ xᵢ²`, specializing Mathlib's
+  Chebyshev lemma `sq_sum_le_card_mul_sum_sq` to `range n` via `card_range`.
+- `newton_first_general`: `2 n · e₂ ≤ (n − 1) · e₁²` for all `n` and all signed
+  reals — the normalized `p₁² ≥ p₀ p₂` after clearing denominators. Proof:
+  substitute `p₂ = e₁² − 2 e₂` into `e₁² ≤ n p₂`.
+
+This closes the `k = 1` (first) Newton inequality for EVERY arity at once,
+subsuming the earlier per-arity `n = 2` (`newton_two_vars`) and `n = 3`
+(`newton_three_first`) first steps. The theorem needed only *real* inputs (QM–AM
+is sign-agnostic), matching the real-rootedness route's signed-input advantage.
 
 ## Active Approach
-Classical calculus route: real-rootedness ⇒ (Rolle) derivative real-rooted ⇒
-reduce to a quadratic ⇒ discriminant ≥ 0 is Newton. n=2 and n=3 arities now
-complete via explicit SOS discriminant certificates; the GENERAL `n` reduction
-(arbitrary arity) still needs the packaged iterated-Rolle lemma.
+Two complementary engines now coexist in the file:
+1. real-rootedness / discriminant (Parts I–II): `n = 2`, `n = 3` per-arity, both
+   log-concavity steps, via SOS discriminant certificates;
+2. QM–AM / square-of-sum identity (Part III): the `k = 1` step for ALL `n`.
+
+The GENERAL higher steps (`k ≥ 2`, arbitrary `n`) still need the packaged
+iterated-Rolle lemma "differentiation preserves full real-rootedness counting
+multiplicity".
 
 ## Attempt Count
-- Total attempts: 2
-- Current approach attempts: 2
-- Approaches tried: real-rooted/discriminant atom + n=2 base case (I);
-  n=3 both steps via SOS discriminant certificates (II)
+- Total attempts: 3
+- Current approach attempts: 1 (QM–AM route)
+- Approaches tried: real-rooted/discriminant atom + n=2 (I); n=3 both steps via
+  SOS (II); general-n first step via QM–AM + square-of-sum identity (III)
 
 ## Blockers
-- **MATH**: general (arbitrary-`n`) Newton needs the packaged lemma
-  "differentiation preserves full real-rootedness counting multiplicity"
+- **MATH**: general (arbitrary-`n`) HIGHER Newton steps (`k ≥ 2`) need the packaged
+  lemma "differentiation preserves full real-rootedness counting multiplicity"
   (iterated Rolle on `∏(X - xᵢ)`) — not in Mathlib; `problem.md` estimates
-  multi-week. Retained open (not stubbed). The per-arity SOS route sidesteps it
-  for fixed small `n` but does not scale symbolically.
+  multi-week. The `k = 1` step is now closed for all `n` (Part III), so this
+  blocker is narrowed to the higher steps only.
 
 ## Next Action
-1. n=4 by the same SOS discriminant route (three Newton steps; degree grows but
-   each reduced quadratic still admits an SOS certificate) — a further concrete
-   instance if desired, though it approaches enumeration.
-2. The genuine general increment: prove derivative-of-fully-real-rooted is
-   fully-real-rooted (Rolle between consecutive roots + multiplicity), then
-   reduce three consecutive coefficients to a quadratic and apply
-   `discrim_nonneg_of_root` for the arbitrary-`n`, signed-input Newton.
+1. The genuine next general increment: the iterated-Rolle crux
+   (derivative-of-fully-real-rooted is fully-real-rooted), which unlocks `k ≥ 2`
+   at arbitrary `n`. Mathlib has `Rolle` (`exists_hasDerivAt_eq_zero`) and
+   `Polynomial.derivative`/`roots` but not the packaged multiplicity-counting
+   statement.
+2. Alternatively, a general `k = 1` Maclaurin corollary in explicit
+   `p₁ = e₁/n`, `p₂ = e₂/C(n,2)` normalized form (currently stated in the
+   cleared-denominator equivalent).

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -2,9 +2,9 @@
   "slug": "amgm-inequality-oq-02-oq-02-oq-05",
   "id": "amgm-inequality-oq-02-oq-02-oq-05",
   "title": "Newton's Inequality via Real-Rootedness: the Quadratic Discriminant Atom",
-  "description": "The classical calculus proof of Newton's inequalities via real-rootedness: a real-rooted quadratic has nonnegative discriminant, which for the splitting polynomial (X - x)(X - y) is exactly Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — valid for signed inputs. The n = 3 case (both log-concavity steps) is discharged directly via the derivative quadratics' sum-of-squares discriminants.",
+  "description": "The classical calculus proof of Newton's inequalities via real-rootedness: a real-rooted quadratic has nonnegative discriminant, which for the splitting polynomial (X - x)(X - y) is exactly Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — valid for signed inputs. The n = 3 case (both log-concavity steps) is discharged directly via the derivative quadratics' sum-of-squares discriminants. Part III then proves the FIRST Newton/Maclaurin inequality p_1^2 >= p_0 p_2 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — via the square-of-sum identity e_1^2 = p_2 + 2 e_2 and the QM-AM bound e_1^2 <= n p_2, no enumeration and no appeal to the still-open iterated-Rolle crux.",
   "overview": {
-    "problemStatement": "Newton's inequalities assert that the normalized elementary symmetric means p_k = e_k / C(n,k) of n real numbers are log-concave: p_k^2 >= p_{k-1} p_{k+1} for 1 <= k <= n-1. Equivalently, the sequence of elementary symmetric polynomials of any real vector is a log-concave (indeed ultra-log-concave) sequence. This entry establishes the self-contained per-derivative ATOM of the classical calculus proof and completes the n = 2 base case end to end, then discharges the full n = 3 case directly.",
+    "problemStatement": "Newton's inequalities assert that the normalized elementary symmetric means p_k = e_k / C(n,k) of n real numbers are log-concave: p_k^2 >= p_{k-1} p_{k+1} for 1 <= k <= n-1. Equivalently, the sequence of elementary symmetric polynomials of any real vector is a log-concave (indeed ultra-log-concave) sequence. This entry establishes the self-contained per-derivative ATOM of the classical calculus proof and completes the n = 2 base case end to end, discharges the full n = 3 case directly, and proves the k = 1 (first) Newton inequality for EVERY n over signed reals.",
     "proofStrategy": "The monic polynomial prod (X - x_i) with x_i real is real-rooted; by Rolle's theorem each of its derivatives is real-rooted too. Differentiating a real-rooted polynomial down to a degree-2 polynomial in three consecutive coefficients leaves a real-rooted quadratic, and 'real-rooted quadratic => nonnegative discriminant' is exactly the Newton inequality relating those three coefficients. The reusable atom is proved via Mathlib's discrim_eq_sq_of_quadratic_eq_zero (the completed-square identity discrim a b c = (2 a x + b)^2) and phrased through the Polynomial.roots API. For n = 3 the two derivative quadratics' nonnegative discriminants are certified directly as sums of squares, so no general Rolle-iteration lemma is needed there.",
     "historicalContext": "Newton recorded these inequalities in his Arithmetica Universalis (posthumously published, 1707), in the course of bounding the number of imaginary roots of a polynomial from the signs of its coefficients; Maclaurin (1729) supplied the companion chain of inequalities p_1 >= p_2^{1/2} >= ... >= p_n^{1/n} that now bears his name and sharpens AM-GM. Newton himself gave no proof, and a fully rigorous derivation waited until the 19th and 20th centuries; the treatment in Hardy, Littlewood and Polya's Inequalities (1934, Section 2.22) became canonical. The real-rootedness argument formalized here reveals Newton's inequalities as a statement about the geometry of polynomial roots rather than about positive numbers: because it only uses that the roots are REAL (never that they are nonnegative), it proves the inequalities for arbitrary signed inputs, a genuine strengthening of the classical AM-GM-flavored versions. The log-concavity of the elementary symmetric functions is now understood as the prototype of a vast web of results — Newton's inequalities are the coefficient-wise shadow of the fact that real-rooted polynomials have log-concave coefficient sequences (a special case of the theory of hyperbolic polynomials and, more recently, of Lorentzian polynomials of Branden and Huh).",
     "keyInsights": [
@@ -13,18 +13,19 @@
       "Because the argument uses only that the roots are real, newton_two_vars holds for arbitrary SIGNED x, y — unlike the parent's inductive proof, which assumes 0 <= x_i, and unlike the Cauchy-Schwarz sibling route.",
       "Rolle's theorem is the engine of the general program: differentiating a real-rooted polynomial preserves real-rootedness, so each Newton inequality is the discriminant of a degree-two derivative of the splitting polynomial.",
       "For n = 3 the two required derivative quadratics have discriminants that are visibly sums of squares — 3(x+y+z)^2 - 9(xy+yz+zx) = (3/2)[(x-y)^2+(y-z)^2+(z-x)^2] and its reciprocal-cubic analogue — so the case closes by nlinarith with explicit SOS certificates, needing neither the general iterated-Rolle lemma nor any sign hypothesis.",
-      "The Rolle picture supplies the motivation and the reciprocal-polynomial trick (to reach the second inequality), but the actual Lean proof at n = 3 is the SOS certificate: the geometry tells you which squares to write down, and nlinarith verifies them."
+      "The Rolle picture supplies the motivation and the reciprocal-polynomial trick (to reach the second inequality), but the actual Lean proof at n = 3 is the SOS certificate: the geometry tells you which squares to write down, and nlinarith verifies them.",
+      "The FIRST Newton inequality k = 1 needs no Rolle machinery at any arity: it is equivalent to the QM-AM / Cauchy-Schwarz bound e_1^2 <= n * (sum of squares) once the square-of-sum identity e_1^2 = p_2 + 2 e_2 (p_2 the second power sum, e_2 the second elementary symmetric polynomial) is in hand. So the arbitrary-n case k = 1 is proved directly (sq_sum_eq + sq_sum_le_card_mul_sum_sq), for signed reals, in Part III — only the higher steps k >= 2 at general n remain tied to the open iterated-Rolle crux."
     ]
   },
   "conclusion": {
-    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. All 13 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. Finally, Part III proves the FIRST Newton inequality k = 1 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — from the square-of-sum identity e_1^2 = p_2 + 2 e_2 (sq_sum_eq, a clean induction) together with the QM-AM bound e_1^2 <= n p_2 (Mathlib's sq_sum_le_card_mul_sum_sq), needing no Rolle-iteration lemma. All 16 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
     "implications": [
       "Provides a reusable, signed-input building block — 'a real-rooted quadratic has nonnegative discriminant' — that any log-concavity/Newton-inequality development can differentiate down onto, decoupling the arithmetic atom from the (harder) real-rootedness-preservation step.",
       "Demonstrates that the n = 2 and n = 3 Newton inequalities need no positivity hypothesis at all: they are facts about real roots, not about positive numbers, and hence strictly generalize the AM-GM-style statements that assume x_i >= 0.",
       "Isolates precisely what remains open for a general-n formalization: only the counting-with-multiplicity form of 'differentiation preserves real-rootedness' (iterated Rolle) is missing; the coefficient-to-discriminant translation is already in hand."
     ],
     "openQuestions": [
-      "Formalize the crux lemma that differentiating a fully real-rooted real polynomial yields a fully real-rooted polynomial (counting multiplicity) — the iterated-Rolle step — which would upgrade this atom to a proof of Newton's inequalities for every n.",
+      "Formalize the crux lemma that differentiating a fully real-rooted real polynomial yields a fully real-rooted polynomial (counting multiplicity) — the iterated-Rolle step — which would upgrade the atom to a proof of the HIGHER Newton inequalities (k >= 2) for every n; the first step k = 1 is already proved at arbitrary n in Part III via QM-AM.",
       "Extend the SOS-certificate approach used at n = 3 to n = 4 and beyond, or show that beyond some degree explicit sum-of-squares certificates for the derivative-quadratic discriminants become impractical, forcing the general Rolle route.",
       "Connect this real-rootedness proof to the modern Lorentzian/hyperbolic-polynomial framework (Branden-Huh), where log-concavity of the elementary symmetric coefficients is a special case of a much broader phenomenon."
     ]
@@ -35,7 +36,8 @@
     "newton_two_vars",
     "newton_three_first",
     "newton_three_second",
-    "newton_three_normalized"
+    "newton_three_normalized",
+    "newton_first_general"
   ],
   "sorries": [],
   "sections": [
@@ -87,6 +89,13 @@
       "startLine": 164,
       "endLine": 190,
       "summary": "newton_three_second: 3(x+y+z)*xyz <= (xy+yz+zx)^2 for signed reals, via the SOS certificate (1/2)[(xy-yz)^2+(yz-zx)^2+(zx-xy)^2] >= 0, with discrim_recip_deriv_cubic_second its discriminant phrasing on the differentiated reciprocal cubic. newton_three_normalized assembles both steps in normalized p-form: p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3, all for arbitrary signed reals."
+    },
+    {
+      "id": "part-iii-general-n-first",
+      "title": "Part III: the general-n first Newton inequality (all n, signed reals)",
+      "startLine": 191,
+      "endLine": 273,
+      "summary": "The arbitrary-n first Newton/Maclaurin inequality, avoiding both enumeration and the open Rolle crux. sq_sum_eq: (sum_{i<n} x_i)^2 = sum_{i<n} x_i^2 + 2 sum_{j<n} sum_{i<j} x_i x_j (i.e. e_1^2 = p_2 + 2 e_2), proved by a clean induction on n that sidesteps any triangular reindexing. sq_sum_le_nat_mul_sum_sq: the QM-AM bound (sum x_i)^2 <= n * sum x_i^2, from Mathlib's Chebyshev lemma sq_sum_le_card_mul_sum_sq on range n with card_range. newton_first_general: substituting p_2 = e_1^2 - 2 e_2 into e_1^2 <= n p_2 gives 2 n e_2 <= (n-1) e_1^2 — the normalized p_1^2 >= p_0 p_2 after clearing denominators — for signed reals at every arity."
     }
   ],
   "crossReferences": [
@@ -112,8 +121,8 @@
       "Mathlib"
     ],
     "additionalFiles": [],
-    "lineCount": 190,
-    "theoremCount": 13,
+    "lineCount": 273,
+    "theoremCount": 16,
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
@@ -137,7 +146,7 @@
     "additionalFiles": [],
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 8 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
+    "assumptions": "None. All 16 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
     "originalContributions": [
       "discrim_nonneg_of_root: a real quadratic a*x^2 + b*x + c with a real root has 0 <= discrim a b c — the reusable per-derivative 'real-rooted => log-concave coefficients' atom of the Rolle program",
       "monic_quadratic_discrim_nonneg: the same via Polynomial.IsRoot for the monic quadratic X^2 + C b * X + C c",
@@ -147,11 +156,14 @@
       "newton_two_vars: Newton's inequality x*y <= ((x+y)/2)^2 at n = 2 for SIGNED reals, via the discriminant of the real-rooted (X - x)(X - y) — the signed-input generalization the real-rootedness route enables (the parent's induction needs 0 <= x_i)",
       "newton_three_first / newton_three_second: the two Newton inequalities at n = 3 (e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3) for arbitrary signed reals, each proved by nlinarith with an explicit sum-of-squares certificate coming from the discriminant of a derivative quadratic",
       "discrim_deriv_cubic_first / discrim_recip_deriv_cubic_second: the discriminant phrasing of the n = 3 inequalities, exhibiting them as the nonnegative discriminants of the once-differentiated splitting cubic and the differentiated reciprocal cubic",
-      "newton_three_normalized: both n = 3 log-concavity steps in normalized p-form, confirming p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3 for all signed reals"
+      "newton_three_normalized: both n = 3 log-concavity steps in normalized p-form, confirming p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3 for all signed reals",
+      "sq_sum_eq: the square-of-sum / elementary-symmetric identity (sum_{i<n} x_i)^2 = sum_{i<n} x_i^2 + 2 sum_{j<n} sum_{i<j} x_i x_j (e_1^2 = p_2 + 2 e_2) for any real sequence, proved by a clean induction on n with no triangular reindexing",
+      "sq_sum_le_nat_mul_sum_sq: the QM-AM bound (sum_{i<n} x_i)^2 <= n * sum_{i<n} x_i^2, specializing Mathlib's Chebyshev inequality sq_sum_le_card_mul_sum_sq to range n",
+      "newton_first_general: the FIRST Newton/Maclaurin inequality 2 n e_2 <= (n-1) e_1^2 (normalized p_1^2 >= p_0 p_2) for ARBITRARY n and signed reals, derived by substituting e_1^2 = p_2 + 2 e_2 into the QM-AM bound — no enumeration and no appeal to the open iterated-Rolle crux, generalising the per-arity n=2/n=3 first steps to every arity at once"
     ],
     "dateAdded": "2026-07-04",
-    "lineCount": 190,
-    "theoremCount": 13,
+    "lineCount": 273,
+    "theoremCount": 16,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   }


### PR DESCRIPTION
## Summary

Extends `amgm-inequality-oq-02-oq-02-oq-05` (Newton's inequality via real-rootedness) with **Part III**: the genuinely **arbitrary-`n`** first Newton / Maclaurin inequality `p₁² ≥ p₀ p₂` for **signed reals** — no per-arity enumeration and no appeal to the still-open iterated-Rolle crux.

Previously the file had the `n = 2` and `n = 3` first steps as separate SOS discriminant certificates. This closes the `k = 1` step for **every** arity at once.

## What's added (3 theorems)

- **`sq_sum_eq`** — the square-of-sum / elementary-symmetric identity `(∑_{i<n} xᵢ)² = ∑_{i<n} xᵢ² + 2 ∑_{j<n} ∑_{i<j} xᵢ xⱼ`, i.e. `e₁² = p₂ + 2 e₂`. Proved by a clean induction on `n` (no triangular reindexing).
- **`sq_sum_le_nat_mul_sum_sq`** — QM–AM `(∑ xᵢ)² ≤ n · ∑ xᵢ²`, specializing Mathlib's Chebyshev lemma `sq_sum_le_card_mul_sum_sq` to `range n`.
- **`newton_first_general`** — `2 n · e₂ ≤ (n − 1) · e₁²` for all `n` and all signed reals (the normalized `p₁² ≥ p₀ p₂` after clearing denominators). Substituting `p₂ = e₁² − 2 e₂` into `e₁² ≤ n p₂` gives it in one step.

Because QM–AM needs only real inputs, the result holds for signed reals — the same generalisation over the parent's `0 ≤ xᵢ` induction that the discriminant route achieves, now for every arity simultaneously.

## Verification

- `docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` (`LEAN_SKIP_CACHE=true`, `LEAN_MEMORY_LIMIT=8192`): **7743 jobs, build succeeded**.
- **0 sorries, 0 axioms** (foundational only — additions use only `sq_sum_le_card_mul_sum_sq`, `sum_range_succ`, `Finset.sum_mul`, `card_range`, induction, `ring`/`nlinarith`/`linear_combination`; no `sorry`/`axiom`/`native_decide`/`decide`). Status stays `verified` / `original`.
- Gallery `meta.json` and research `state.md` updated: `theoremCount` 13 → 16, `lineCount` 190 → 273, new main theorem + Part III section + narrowed open question (the general higher steps `k ≥ 2` remain the open Rolle crux; `k = 1` is now done for all `n`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)