### PR TITLE
Enrich hilbert-14-oq-02 (fundamental theorem of symmetric polynomials): add mainTheorems (0→5)

### DIFF
--- a/src/data/proofs/hilbert-14-oq-02/meta.json
+++ b/src/data/proofs/hilbert-14-oq-02/meta.json
@@ -155,6 +155,38 @@
     "path": "Proofs/Hilbert14OQ02.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "symmetric_eq_aeval_esymm",
+      "type": "core",
+      "description": "Fundamental theorem of symmetric polynomials: when |σ| ≤ n, every symmetric polynomial is a polynomial in the elementary symmetric polynomials e₁,…,eₙ.",
+      "leanType": "(hn : Fintype.card σ ≤ n) → (p : MvPolynomial σ R) → p.IsSymmetric → ∃ q : MvPolynomial (Fin n) R, p = aeval (fun i : Fin n => esymm σ R (i + 1)) q"
+    },
+    {
+      "name": "symmetric_algEquiv_polynomial",
+      "type": "core",
+      "description": "The symmetric subalgebra is isomorphic (as an R-algebra) to a polynomial ring in n free variables, exhibiting the ring of symmetric polynomials as finitely generated and free.",
+      "leanType": "(hn : Fintype.card σ = n) → Nonempty (MvPolynomial (Fin n) R ≃ₐ[R] symmetricSubalgebra σ R)"
+    },
+    {
+      "name": "esymm_algebraicIndependent",
+      "type": "core",
+      "description": "The n elementary symmetric polynomials e₁,…,eₙ are algebraically independent over R when |σ| = n — the counterpart to their generating the symmetric subalgebra.",
+      "leanType": "(hn : Fintype.card σ = n) → AlgebraicIndependent R (fun i : Fin n => esymm σ R (i + 1))"
+    },
+    {
+      "name": "esymm_isHomogeneous",
+      "type": "supporting",
+      "description": "The k-th elementary symmetric polynomial is homogeneous of degree k.",
+      "leanType": "(k : ℕ) → (esymm σ R k).IsHomogeneous k"
+    },
+    {
+      "name": "esymm_totalDegree_le",
+      "type": "technical",
+      "description": "Each generator eᵢ₊₁ has total degree at most n, a degree bound used in the algebraic-independence argument.",
+      "leanType": "(i : Fin n) → (esymm σ R (i + 1)).totalDegree ≤ n"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "hilbert-14",


### PR DESCRIPTION
Enrichment pass for **hilbert-14-oq-02** (fundamental theorem of symmetric polynomials).

## What changed
- Added `mainTheorems` (0 → 5), populated from the actual Lean declarations in `Proofs/Hilbert14OQ02.lean` with exact `leanType` signatures.

## Theorems surfaced
**Core**
- `symmetric_eq_aeval_esymm` — every symmetric polynomial is a polynomial in e₁,…,eₙ
- `symmetric_algEquiv_polynomial` — symmetric subalgebra ≅ free polynomial ring in n variables
- `esymm_algebraicIndependent` — the n elementary symmetric polynomials are algebraically independent

**Supporting** — `esymm_isHomogeneous`  · **Technical** — `esymm_totalDegree_le`

No content removed. `meta.json` is 17 KB, under the 60 KB guardrail.
