### PR TITLE
docker-build: share Mathlib source across worktrees (fix recurring disk-full → Docker corruption)

### DIFF
--- a/proofs/scripts/docker-build.sh
+++ b/proofs/scripts/docker-build.sh
@@ -24,6 +24,15 @@ SKIP_CACHE="${LEAN_SKIP_CACHE:-false}"
 TARGET="${1:-}"
 IMAGE="lean4-arm64:v4.26.0"
 CACHE_VOLUME="lean-mathlib-cache"
+# Shared Mathlib SOURCE checkout (.lake/packages, ~6.8GB). Without this, every
+# worktree's bind-mounted /workspace accumulates its own 6.8GB copy of the
+# identical pinned Mathlib source on the host — dozens of worktrees × 6.8GB was
+# repeatedly filling the disk to 100% and corrupting Docker's containerd store,
+# taking down all builds. All worktrees branch from main and pin the same
+# mathlib rev, so one shared volume is correct; on a rare mathlib bump `lake`
+# detects the manifest mismatch and re-resolves into the volume (self-healing),
+# exactly as the already-shared CACHE_VOLUME (.lake/build) handles rev changes.
+PACKAGES_VOLUME="lean-mathlib-packages"
 
 detect_host_cpus() {
     local host_cpus
@@ -79,6 +88,12 @@ if ! docker volume inspect "$CACHE_VOLUME" &>/dev/null 2>&1; then
     docker volume create "$CACHE_VOLUME"
 fi
 
+# Create persistent volume for the shared Mathlib source checkout (.lake/packages)
+if ! docker volume inspect "$PACKAGES_VOLUME" &>/dev/null 2>&1; then
+    echo "Creating persistent Mathlib packages volume..."
+    docker volume create "$PACKAGES_VOLUME"
+fi
+
 # Build command - download cache first if not skipped
 if [ "$SKIP_CACHE" = "true" ]; then
     BUILD_CMD="lake build ${TARGET}"
@@ -125,6 +140,7 @@ docker run --rm \
     --cpus="$CPU_LIMIT" \
     -v "${REPO_ROOT}:/workspace:delegated" \
     -v "${CACHE_VOLUME}:/workspace/proofs/.lake/build:delegated" \
+    -v "${PACKAGES_VOLUME}:/workspace/proofs/.lake/packages:delegated" \
     -w /workspace/proofs \
     --name "$CONTAINER_NAME" \
     "$IMAGE" \


### PR DESCRIPTION
## Problem

Each worktree's bind-mounted `/workspace` accumulated its own **~6.8GB copy** of the identical pinned Mathlib source in `proofs/.lake/packages` on the host. With dozens of concurrent researcher/mechanic worktrees, this repeatedly filled the Data volume to **100%**, which **corrupted Docker Desktop's containerd content store** and took down **all** Lean builds pipeline-wide:

```
docker: Error response from daemon: apply layer error ... input/output error
docker system df → blob sha256:... input/output error
```

Recovery required a full Docker Desktop restart plus reaping ~60GB of duplicated `.lake` dirs — an emergency that has recurred multiple times.

## Root cause

The *compiled* Mathlib (`.lake/build`) is **already shared** via the `lean-mathlib-cache` Docker volume. Only the **source tree** (`.lake/packages`) was being duplicated per worktree on the host.

## Fix

Mount a second persistent volume, `lean-mathlib-packages`, at `.lake/packages` — one line mirroring the existing `.lake/build` pattern. The source now lives in **one shared copy** instead of N host-side copies.

**Disk cost: `(N worktrees × 6.8GB)` → flat `~6.9GB` total.**

## Why it's safe

- All worktrees branch from `main` and pin the same mathlib rev (`2df2f0150c27`), so one shared source is correct.
- On a rare mathlib bump, `lake` detects the manifest mismatch and re-resolves into the volume (self-healing) — **exactly** how the already-shared `.lake/build` volume handles rev transitions. Sharing source is strictly *safer* than sharing compiled oleans, which already works.
- `.lake` is gitignored (purely local/regenerable).

## Verification

Ran a full build with the shared volume:
- `Build completed successfully (7744 jobs)`, 0 errors.
- Host worktree `.lake/packages` = **0B** after the build (source went to the volume).
- `lean-mathlib-packages` volume = 6.937GB (the single shared copy).

## Rollout note

The first build after this lands does a one-time source populate into the new volume; every subsequent build across the whole fleet reuses it with zero host-side growth. Existing worktrees' stale host-side `.lake/packages` can be reclaimed with `rm -rf <wt>/proofs/.lake` (regenerable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)