### PR TITLE
Add abel-ruffini-oq-06-oq-01-oq-03: extension-closure of solvable groups, packaged

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ06OQ01OQ03.lean
+++ b/proofs/Proofs/AbelRuffiniOQ06OQ01OQ03.lean
@@ -1,0 +1,104 @@
+import Mathlib
+
+/-
+# Extension-closure of solvable groups, packaged (abel-ruffini-oq-06-oq-01-oq-03)
+
+The parent entry `Proofs.AbelRuffiniOQ06OQ01` proves `A₄` solvable by an inline
+short-exact-sequence argument: it exhibits the Klein-four subgroup `V₄ ⊴ A₄`, checks
+`IsSolvable V₄` and `IsSolvable (A₄ ⧸ V₄)`, and then feeds the two into Mathlib's general
+`solvable_of_ker_le_range` on the maps `V₄.subtype` and `QuotientGroup.mk' V₄`, discharging
+the side condition `ker (mk' V₄) ≤ range (V₄.subtype)` by hand. Its third open question asks
+to abstract this recurring boilerplate into a single reusable lemma — the standard
+**extension-closure of solvable groups**:
+
+    given `N ⊴ G` with `N` solvable and `G ⧸ N` solvable, `G` itself is solvable.
+
+Mathlib supplies the *general* extension lemma `solvable_of_ker_le_range` (phrased for an
+arbitrary pair of homomorphisms with `ker g ≤ range f`) and the two one-sided corollaries
+`solvable_of_solvable_injective` (subgroups) and `solvable_of_surjective` (quotients), but it
+does **not** package the symmetric normal-subgroup/quotient form. This entry provides it.
+
+  * `isSolvable_of_normal_of_quotient` — the packaged lemma, instance-driven: from
+    `[N.Normal]`, `[IsSolvable N]`, `[IsSolvable (G ⧸ N)]` conclude `IsSolvable G`. It is the
+    `solvable_of_ker_le_range` specialization to `f = N.subtype`, `g = QuotientGroup.mk' N`,
+    where `ker (mk' N) = N = range N.subtype` makes the side condition an equality.
+  * `isSolvable_of_normal_of_isSolvable_quotient` — the same statement with the two
+    solvability facts as explicit hypotheses rather than instances (convenient when they are
+    produced as terms, e.g. by `isSolvable_of_comm`).
+  * `isSolvable_of_isSolvable_commutator` — a corollary capturing the *metabelian* pattern in
+    one step: a group is solvable as soon as its commutator subgroup is. Here the quotient
+    factor is automatic — `G ⧸ commutator G` is abelian by definition of the commutator
+    (`quotient_commutative_iff_commutator_le` with `commutator G ≤ commutator G`).
+  * `alternatingFinFour_isSolvable` — the prototypical instance, re-deriving the parent's
+    `A₄` result through the packaged lemma. The `solvable_of_ker_le_range` invocation and its
+    hand-rolled `ker ≤ range` side goal disappear into a single `exact`.
+
+Status: 0 sorries, 0 axioms, no `native_decide`. `#print axioms` on the four declarations
+reports only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace AbelRuffiniOQ06OQ01OQ03
+
+open Equiv
+
+/-- **Extension-closure of solvable groups (packaged).** If `N` is a normal subgroup of `G`
+with both `N` and the quotient `G ⧸ N` solvable, then `G` is solvable. This is the standard
+"solvable-by-solvable is solvable" closure property; it specializes Mathlib's general
+`solvable_of_ker_le_range` to the inclusion `N.subtype` and the projection `mk' N`, whose
+range and kernel both equal `N`, turning the `ker ≤ range` side condition into `N ≤ N`. -/
+theorem isSolvable_of_normal_of_quotient {G : Type*} [Group G] (N : Subgroup G) [N.Normal]
+    [IsSolvable N] [IsSolvable (G ⧸ N)] : IsSolvable G :=
+  solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+    (le_of_eq (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype]))
+
+/-- **Extension-closure, hypothesis form.** The same statement as
+`isSolvable_of_normal_of_quotient` but taking the solvability of `N` and of `G ⧸ N` as
+explicit term arguments. Useful when those facts are obtained constructively (for instance
+from `isSolvable_of_comm` on an abelian kernel and quotient) rather than resolved by instance
+search. -/
+theorem isSolvable_of_normal_of_isSolvable_quotient {G : Type*} [Group G] (N : Subgroup G)
+    [N.Normal] (hN : IsSolvable N) (hQ : IsSolvable (G ⧸ N)) : IsSolvable G :=
+  haveI := hN
+  haveI := hQ
+  isSolvable_of_normal_of_quotient N
+
+/-- **Metabelian criterion.** A group is solvable whenever its commutator subgroup is. This
+is the one-step form of extension-closure: the quotient factor `G ⧸ commutator G` is abelian
+for free — by the very definition of the commutator subgroup
+(`quotient_commutative_iff_commutator_le` applied to `commutator G ≤ commutator G`) — so only
+the solvability of the derived subgroup must be supplied. Iterating this reproves that a group
+with a terminating derived series is solvable. -/
+theorem isSolvable_of_isSolvable_commutator {G : Type*} [Group G]
+    (h : IsSolvable (commutator G)) : IsSolvable G := by
+  haveI := h
+  haveI : IsSolvable (G ⧸ commutator G) :=
+    isSolvable_of_comm fun a b =>
+      (Subgroup.Normal.quotient_commutative_iff_commutator_le.mpr le_rfl).comm a b
+  exact isSolvable_of_normal_of_quotient (commutator G)
+
+/-- **`A₄ = alternatingGroup (Fin 4)` is solvable, via the packaged lemma.** The prototypical
+instance of extension-closure and the source of this generalization. `V₄ = kleinFour (Fin 4)`
+is normal in `A₄`, is solvable because it has exponent two hence is abelian, and gives an
+abelian (hence solvable) quotient `A₄ ⧸ V₄ ≅ ℤ/3` because it is exactly the commutator
+subgroup. The parent entry closed this with a bare `solvable_of_ker_le_range` plus a
+hand-written `ker ≤ range` side goal; here those collapse into one application of
+`isSolvable_of_normal_of_quotient`. -/
+theorem alternatingFinFour_isSolvable : IsSolvable (alternatingGroup (Fin 4)) := by
+  have hα4 : Nat.card (Fin 4) = 4 := Nat.card_eq_fintype_card.trans (Fintype.card_fin 4)
+  set N := alternatingGroup.kleinFour (Fin 4) with hN
+  haveI hNnormal : N.Normal := alternatingGroup.normal_kleinFour hα4
+  -- V₄ has exponent two, hence is abelian, hence solvable.
+  have hexp : Monoid.exponent N = 2 := by
+    rw [hN]; exact alternatingGroup.exponent_kleinFour_of_card_eq_four hα4
+  haveI hNsolv : IsSolvable N :=
+    isSolvable_of_comm (fun a b => mul_comm_of_exponent_two hexp a b)
+  -- A₄ / V₄ is abelian because V₄ is the commutator subgroup of A₄.
+  have hcomm_le : commutator (alternatingGroup (Fin 4)) ≤ N :=
+    le_of_eq (alternatingGroup.kleinFour_eq_commutator hα4).symm
+  haveI hQsolv : IsSolvable (alternatingGroup (Fin 4) ⧸ N) :=
+    isSolvable_of_comm fun a b =>
+      (Subgroup.Normal.quotient_commutative_iff_commutator_le.mpr hcomm_le).comm a b
+  -- Extension-closure on 1 → V₄ → A₄ → A₄/V₄ → 1, packaged in one step.
+  exact isSolvable_of_normal_of_quotient N
+
+end AbelRuffiniOQ06OQ01OQ03

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "Packaging the extension-closure of solvable groups",
+    "content": "Solvability is closed under subgroups, quotients, and extensions. Mathlib records the first two (solvable_of_solvable_injective, solvable_of_surjective) and proves the general extension lemma solvable_of_ker_le_range — stated for an arbitrary pair of homomorphisms f : G' →* G, g : G →* G'' with g.ker ≤ f.range — but does not package the canonical normal-subgroup form 'N ⊴ G with N and G ⧸ N solvable ⟹ G solvable'. That is exactly the shape the parent A₄ proof needed and wrote out by hand. This entry provides the packaged lemma, a hypothesis variant, a metabelian corollary, and re-derives A₄ through the abstraction.",
+    "mathContext": "The extension case is the substantive closure property: given a short exact sequence $1 \\to N \\to G \\to G/N \\to 1$ with $N$ and $G/N$ solvable, the derived series of $G$ concatenates those of $N$ and $G/N$, so $G$ is solvable. This is what makes 'solvable' equivalent to 'admits a composition series with abelian factors' and underlies every metabelian argument.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "solvable group",
+      "extension of groups",
+      "short exact sequence",
+      "derived series",
+      "closure properties"
+    ],
+    "prerequisites": [
+      "solvable groups",
+      "normal subgroups and quotients",
+      "group homomorphisms"
+    ]
+  },
+  {
+    "id": "ann-packaged-lemma",
+    "proofId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "insight",
+    "title": "The ker ≤ range side condition degenerates to N ≤ N",
+    "content": "isSolvable_of_normal_of_quotient specializes solvable_of_ker_le_range to f = N.subtype : N →* G and g = QuotientGroup.mk' N : G →* G ⧸ N. For this specific pair the side condition ker g ≤ range f is an equality of one and the same subgroup: QuotientGroup.ker_mk' gives ker (mk' N) = N and Subgroup.range_subtype gives range (N.subtype) = N. So the containment collapses to N ≤ N, discharged by le_of_eq of two rewrites. This is precisely the boilerplate the parent inlined and the reason the packaging is worth stating once.",
+    "mathContext": "The projection $\\pi : G \\to G/N$ has $\\ker \\pi = N$ and the inclusion $\\iota : N \\hookrightarrow G$ has $\\operatorname{im} \\iota = N$, so $\\ker \\pi = \\operatorname{im} \\iota$ holds on the nose. The general lemma only needs $\\ker \\pi \\le \\operatorname{im} \\iota$; here equality makes the hypothesis automatic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "solvable_of_ker_le_range",
+      "quotient map kernel",
+      "subgroup inclusion range",
+      "short exact sequence"
+    ],
+    "prerequisites": [
+      "kernel and range of homomorphisms",
+      "quotient groups",
+      "subgroup.subtype"
+    ]
+  },
+  {
+    "id": "ann-hypothesis-variant",
+    "proofId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 69 },
+    "type": "technique",
+    "title": "Instance form vs. hypothesis form",
+    "content": "isSolvable_of_normal_of_quotient takes IsSolvable N and IsSolvable (G ⧸ N) as typeclass instances, which is convenient when instance search can find them. isSolvable_of_normal_of_isSolvable_quotient restates the identical conclusion with those two facts as explicit term arguments, then promotes them to instances with haveI before delegating. This is the ergonomic form when the solvability certificates are produced constructively — e.g. isSolvable_of_comm applied to an abelian kernel and quotient — rather than resolved automatically.",
+    "mathContext": "The two versions are logically identical; the distinction is purely about how the solvability data reaches the lemma (Lean instance resolution vs. an explicit proof term). Providing both mirrors the common Mathlib practice of pairing an instance-driven lemma with a hypothesis-driven one.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "typeclass instances",
+      "haveI",
+      "API ergonomics"
+    ],
+    "prerequisites": [
+      "Lean typeclass resolution"
+    ]
+  },
+  {
+    "id": "ann-metabelian-corollary",
+    "proofId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "range": { "startLine": 71, "endLine": 84 },
+    "type": "insight",
+    "title": "The commutator subgroup gives the abelian quotient for free",
+    "content": "isSolvable_of_isSolvable_commutator specializes the packaged lemma to N = commutator G. Here the quotient factor needs no separate certificate: G ⧸ commutator G is abelian by the very definition of the commutator subgroup — quotient_commutative_iff_commutator_le says G ⧸ N is commutative iff commutator G ≤ N, and with N = commutator G the hypothesis is reflexivity. So isSolvable_of_comm makes the quotient solvable and only the solvability of the derived subgroup must be supplied. Iterating this criterion walks up any terminating derived series.",
+    "mathContext": "$G/[G,G]$ is the abelianization of $G$, abelian by construction. Thus a group is solvable iff its derived subgroup $G' = [G,G]$ is solvable — the inductive characterization of solvability. This is the one-step engine of the metabelian pattern: kernel and abelian-quotient certificate are the same subgroup $G'$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "commutator subgroup",
+      "abelianization",
+      "metabelian group",
+      "derived series",
+      "inductive characterization of solvability"
+    ],
+    "prerequisites": [
+      "commutator subgroup",
+      "abelianization",
+      "quotient_commutative_iff_commutator_le"
+    ]
+  },
+  {
+    "id": "ann-a4-application",
+    "proofId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "range": { "startLine": 86, "endLine": 104 },
+    "type": "insight",
+    "title": "A₄ solvable, in one application of the packaged lemma",
+    "content": "alternatingFinFour_isSolvable re-derives the parent's headline result through the abstraction. V₄ = alternatingGroup.kleinFour (Fin 4) is normal (normal_kleinFour), solvable because it has exponent two hence is abelian (exponent_kleinFour_of_card_eq_four + mul_comm_of_exponent_two + isSolvable_of_comm), and yields an abelian quotient A₄ ⧸ V₄ because V₄ IS the commutator subgroup (kleinFour_eq_commutator + quotient_commutative_iff_commutator_le). Where the parent closed with solvable_of_ker_le_range N.subtype (mk' N) (le_of_eq …), this entry closes with a bare exact isSolvable_of_normal_of_quotient N — confirming the abstraction subsumes its prototypical instance.",
+    "mathContext": "$A_4$ of order 12 sits in the two-step derived series $A_4 \\rhd V_4 \\rhd 1$: the Klein-four commutator subgroup $V_4 \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is abelian, and $A_4/V_4 \\cong \\mathbb{Z}/3$ is abelian, so $A_4$ is metabelian, hence solvable. This is the one degree of the Abel–Ruffini threshold that the prime-order argument cannot reach.",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating group A₄",
+      "Klein four-group V₄",
+      "metabelian group",
+      "Abel–Ruffini threshold",
+      "commutator subgroup"
+    ],
+    "prerequisites": [
+      "alternating groups",
+      "group exponent",
+      "commutator subgroup"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "abel-ruffini-oq-06-oq-01-oq-03",
+  "title": "Extension-Closure of Solvable Groups, Packaged: IsSolvable G from N ⊴ G, IsSolvable N, IsSolvable (G ⧸ N)",
+  "slug": "abel-ruffini-oq-06-oq-01-oq-03",
+  "description": "Abstracts the recurring short-exact-sequence argument of the parent A₄ proof into a single reusable lemma — the standard extension-closure of solvable groups: if N is a normal subgroup of G with both N and the quotient G ⧸ N solvable, then G is solvable. Mathlib supplies the general extension lemma solvable_of_ker_le_range (for an arbitrary pair of homomorphisms with ker g ≤ range f) and its two one-sided corollaries solvable_of_solvable_injective (subgroups) and solvable_of_surjective (quotients), but it does NOT package the symmetric normal-subgroup/quotient form; this entry provides it. isSolvable_of_normal_of_quotient specializes solvable_of_ker_le_range to f = N.subtype and g = QuotientGroup.mk' N, where ker (mk' N) = N = range N.subtype collapses the ker ≤ range side condition to N ≤ N. isSolvable_of_normal_of_isSolvable_quotient is the same statement with the two solvability facts as explicit term hypotheses rather than instances (convenient when produced by isSolvable_of_comm). isSolvable_of_isSolvable_commutator captures the metabelian pattern in one step: a group is solvable as soon as its commutator subgroup is, because the quotient factor G ⧸ commutator G is abelian for free by the definition of the commutator (quotient_commutative_iff_commutator_le applied to commutator G ≤ commutator G). Finally alternatingFinFour_isSolvable re-derives the parent's A₄ result through the packaged lemma: the bare solvable_of_ker_le_range invocation and its hand-written ker ≤ range side goal collapse into one exact isSolvable_of_normal_of_quotient. 4 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (researcher-6)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ06OQ01OQ03.lean",
+    "parentProof": "abel-ruffini-oq-06-oq-01",
+    "openQuestionId": "abel-ruffini-oq-06-oq-01-oq-03",
+    "tags": [
+      "abel-ruffini",
+      "group-theory",
+      "solvable-group",
+      "extension-closure",
+      "short-exact-sequence",
+      "commutator-subgroup",
+      "metabelian",
+      "derived-series",
+      "normal-subgroup",
+      "quotient-group"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 104,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond the foundational propext / Classical.choice / Quot.sound. #print axioms on all four theorems (isSolvable_of_normal_of_quotient, isSolvable_of_normal_of_isSolvable_quotient, isSolvable_of_isSolvable_commutator, alternatingFinFour_isSolvable) reports exactly [propext, Classical.choice, Quot.sound]. No native_decide, no Lean.ofReduceBool.",
+    "buildStatus": "Verified via ./proofs/scripts/docker-build.sh Proofs.AbelRuffiniOQ06OQ01OQ03 against pinned Mathlib v4.26.0. Build completed successfully (7743 jobs), 0 errors, olean produced. #print axioms on all four theorems confirms 0 non-foundational axioms.",
+    "mathlibDependencies": [
+      {
+        "theorem": "solvable_of_ker_le_range",
+        "description": "The general extension lemma: for f : G' →* G and g : G →* G'' with g.ker ≤ f.range and both G', G'' solvable, G is solvable. The packaged normal-subgroup form specializes this to f = N.subtype, g = QuotientGroup.mk' N.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "QuotientGroup.ker_mk'",
+        "description": "The kernel of the canonical projection QuotientGroup.mk' N : G →* G ⧸ N equals N. Together with range_subtype this turns the ker ≤ range side condition into N ≤ N.",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Defs"
+      },
+      {
+        "theorem": "Subgroup.range_subtype",
+        "description": "The range of the inclusion N.subtype : N →* G equals N. Supplies the range half of the ker ≤ range equality.",
+        "module": "Mathlib.GroupTheory.Subgroup.Basic"
+      },
+      {
+        "theorem": "isSolvable_of_comm",
+        "description": "A group whose multiplication is commutative is solvable. Used to certify the abelian kernel V₄ and the abelian quotients (G ⧸ commutator G and A₄ ⧸ V₄) as solvable.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Subgroup.Normal.quotient_commutative_iff_commutator_le",
+        "description": "G ⧸ N is commutative iff commutator G ≤ N. Applied with N = commutator G (reflexivity) it gives the free abelianness of G ⧸ commutator G behind the metabelian criterion; applied with N = V₄ it gives A₄ ⧸ V₄ abelian.",
+        "module": "Mathlib.GroupTheory.Commutator.Basic"
+      },
+      {
+        "theorem": "commutator_normal",
+        "description": "The commutator ⁅H₁, H₂⁆ of two normal subgroups is normal; specialized to commutator G = ⁅⊤, ⊤⁆ it supplies the (commutator G).Normal instance the metabelian criterion needs.",
+        "module": "Mathlib.GroupTheory.Commutator.Basic"
+      },
+      {
+        "theorem": "alternatingGroup.kleinFour_eq_commutator",
+        "description": "For Nat.card α = 4, the Klein-four subgroup V₄ equals the commutator subgroup of A₄. Makes A₄ ⧸ V₄ abelian in the re-derived A₄ application.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating.KleinFour"
+      },
+      {
+        "theorem": "mul_comm_of_exponent_two",
+        "description": "A group of exponent two is abelian; converts V₄'s exponent-two property (exponent_kleinFour_of_card_eq_four) into the commutativity giving IsSolvable V₄.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      }
+    ],
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Solvability of a group is preserved under the three basic constructions: subgroups, quotients, and extensions. The subgroup and quotient cases are elementary (the derived series of a subgroup/quotient sits inside the image of the derived series of the ambient group), and Mathlib records them as solvable_of_solvable_injective and solvable_of_surjective. The extension case — N solvable and G/N solvable together force G solvable — is the substantive closure property; it is what makes the class of solvable groups closed under building a composition series with abelian factors, and it is the engine behind every 'metabelian ⟹ solvable' argument. Mathlib proves the fully general form solvable_of_ker_le_range but leaves the canonical normal-subgroup packaging to the user. The parent chain hit this gap directly: closing the Abel–Ruffini threshold at S₄ required exactly this extension step for A₄ ⊳ V₄ ⊳ 1, written out by hand.",
+    "problemStatement": "Abstract the parent A₄ short-exact-sequence argument into a reusable lemma: from [N.Normal], IsSolvable N, and IsSolvable (G ⧸ N), conclude IsSolvable G — the standard extension-closure of solvable groups — and demonstrate that it recovers the A₄ result as its prototypical instance.",
+    "proofStrategy": "isSolvable_of_normal_of_quotient specializes solvable_of_ker_le_range to the inclusion N.subtype : N →* G and the projection QuotientGroup.mk' N : G →* G ⧸ N. The required side condition ker (mk' N) ≤ range (N.subtype) is an equality: QuotientGroup.ker_mk' gives ker (mk' N) = N and Subgroup.range_subtype gives range (N.subtype) = N, so le_of_eq closes it. The hypothesis form isSolvable_of_normal_of_isSolvable_quotient just promotes the two term hypotheses to instances via haveI and delegates. The metabelian corollary isSolvable_of_isSolvable_commutator instantiates N = commutator G: the quotient G ⧸ commutator G is abelian for free (quotient_commutative_iff_commutator_le with commutator G ≤ commutator G by reflexivity), so isSolvable_of_comm makes it solvable and the packaged lemma finishes. The A₄ application reconstructs V₄ = kleinFour (Fin 4) as a normal, solvable (exponent-two, hence abelian) subgroup whose quotient is abelian (V₄ = commutator A₄), then closes with a single exact isSolvable_of_normal_of_quotient.",
+    "keyInsights": [
+      "**The side condition is an equality, not an inequality.** For the specific pair (inclusion of N, projection onto G/N) the kernel of the projection and the range of the inclusion are literally the same subgroup N. So the ker ≤ range hypothesis of the general lemma degenerates to N ≤ N, and the entire short-exact-sequence bookkeeping collapses to le_of_eq of two rewrites — this is precisely the boilerplate worth packaging once.",
+      "**One subgroup, both factors — captured by the commutator corollary.** The metabelian pattern (kernel and abelian-quotient certificate are the same subgroup) is exactly what happens when N = commutator G: the quotient G ⧸ commutator G is abelian by the definition of the commutator, so isSolvable_of_isSolvable_commutator needs only that the derived subgroup is solvable. Iterating it walks up any terminating derived series.",
+      "**Mathlib had the general lemma but not the ergonomic one.** solvable_of_ker_le_range is stated for arbitrary homomorphisms with ker ≤ range — maximally general but awkward to apply, since each use must name two maps and prove the containment. The normal-subgroup form is the shape actually needed in practice (it is how the extension property is stated in every textbook), and packaging it removes the repeated specialization that the parent entry had to inline.",
+      "**The A₄ proof shrinks to one line of real content.** Re-deriving IsSolvable A₄ through isSolvable_of_normal_of_quotient replaces the parent's explicit solvable_of_ker_le_range N.subtype (mk' N) (le_of_eq …) with a bare exact, confirming that the abstraction faithfully subsumes its prototypical instance rather than merely paraphrasing it."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: packaging the extension-closure property",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Header docstring. Recalls that the parent A₄ proof inlined a short-exact-sequence solvability argument via Mathlib's general solvable_of_ker_le_range, and that Mathlib records the subgroup and quotient closure corollaries but not the symmetric normal-subgroup/quotient extension form. Frames the four deliverables: the packaged lemma, its hypothesis variant, the metabelian corollary, and the A₄ re-derivation."
+    },
+    {
+      "id": "packaged-lemma",
+      "title": "The packaged extension-closure lemma",
+      "startLine": 49,
+      "endLine": 72,
+      "summary": "isSolvable_of_normal_of_quotient: from [N.Normal], [IsSolvable N], [IsSolvable (G ⧸ N)] conclude IsSolvable G, by specializing solvable_of_ker_le_range to N.subtype and QuotientGroup.mk' N with the ker ≤ range goal discharged by QuotientGroup.ker_mk' and Subgroup.range_subtype (both equal N). isSolvable_of_normal_of_isSolvable_quotient restates it with the two solvability facts as explicit term hypotheses."
+    },
+    {
+      "id": "metabelian-corollary",
+      "title": "The metabelian corollary",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "isSolvable_of_isSolvable_commutator: a group is solvable whenever its commutator subgroup is. The quotient factor G ⧸ commutator G is abelian for free — quotient_commutative_iff_commutator_le applied to commutator G ≤ commutator G (reflexivity) — so isSolvable_of_comm makes it solvable and the packaged lemma with N = commutator G concludes."
+    },
+    {
+      "id": "a4-application",
+      "title": "A₄ solvable, re-derived through the packaged lemma",
+      "startLine": 86,
+      "endLine": 104,
+      "summary": "alternatingFinFour_isSolvable: reconstructs V₄ = kleinFour (Fin 4) as normal (normal_kleinFour), solvable (exponent two ⟹ abelian via mul_comm_of_exponent_two + isSolvable_of_comm), with abelian quotient A₄ ⧸ V₄ (V₄ = commutator A₄ via kleinFour_eq_commutator + quotient_commutative_iff_commutator_le), then closes with a single exact isSolvable_of_normal_of_quotient N — the parent's inline solvable_of_ker_le_range plus hand-written side goal reduced to one application."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "3rd ed., Wiley",
+      "note": "Solvable groups: closure under subgroups, quotients, and extensions; the derived series and metabelian groups."
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "4th ed., Springer GTM 148",
+      "note": "Extension-closure of solvable groups and the concatenation of derived series across a short exact sequence."
+    }
+  ],
+  "conclusion": {
+    "summary": "Packaged the extension-closure of solvable groups as a reusable lemma isSolvable_of_normal_of_quotient (from N ⊴ G, IsSolvable N, IsSolvable (G ⧸ N) conclude IsSolvable G), supplied its explicit-hypothesis variant, derived the metabelian corollary isSolvable_of_isSolvable_commutator (solvable whenever the commutator subgroup is), and re-derived the parent's A₄ solvability through the packaged lemma. 4 theorems, 0 sorries, 0 axioms.",
+    "implications": "Fills the ergonomic gap between Mathlib's maximally-general solvable_of_ker_le_range and its two one-sided corollaries: the normal-subgroup/quotient form is the shape every textbook extension argument actually uses, so every future metabelian or composition-series solvability proof in the gallery can call it directly instead of re-specializing the general lemma. The metabelian corollary reduces solvability of a group to solvability of its derived subgroup in one step.",
+    "openQuestions": [
+      "State and prove the iterated form: a group is solvable iff its derived series reaches the trivial subgroup in finitely many steps, obtained by induction on isSolvable_of_isSolvable_commutator, and connect it to Mathlib's derivedSeries definition.",
+      "Prove solvability is closed under finite direct/semidirect products with solvable factors as a corollary of the packaged lemma (Mathlib has solvable_prod for direct products; the semidirect case N ⋊ H with N, H solvable is a direct instance of extension-closure)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "abel-ruffini-oq-06-oq-01",
+      "relationship": "parent — closed the Abel–Ruffini threshold at S₄ by proving A₄ solvable through an inline short-exact-sequence (V₄ ⊳ A₄) argument. Its third open question asks to abstract that argument into a reusable extension-closure lemma; this entry provides it and re-derives the A₄ result through the abstraction."
+    },
+    {
+      "proofId": "abel-ruffini-oq-06",
+      "relationship": "grandparent — supplies the reduction Aₙ solvable ⟹ Sₙ solvable and the solvable cases S₂, S₃, all instances of the same extension-of-solvable-groups pattern now packaged here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the third open question of the parent entry `abel-ruffini-oq-06-oq-01`: abstract the inline A₄ short-exact-sequence solvability argument into a reusable lemma — the standard **extension-closure of solvable groups**.

Mathlib supplies the *general* extension lemma `solvable_of_ker_le_range` (arbitrary homomorphism pair with `ker g ≤ range f`) and the two one-sided corollaries `solvable_of_solvable_injective` (subgroups) and `solvable_of_surjective` (quotients), but **not** the symmetric normal-subgroup/quotient packaging that every textbook extension argument actually uses. This entry provides it.

## Theorems (4 total, 0 sorries, 0 axioms)

- **`isSolvable_of_normal_of_quotient`** — instance form: `[N.Normal]`, `[IsSolvable N]`, `[IsSolvable (G ⧸ N)]` ⟹ `IsSolvable G`. Specializes `solvable_of_ker_le_range` to `N.subtype` and `QuotientGroup.mk' N`, where `ker (mk' N) = N = range N.subtype` collapses the side condition to `N ≤ N`.
- **`isSolvable_of_normal_of_isSolvable_quotient`** — same statement with the two solvability facts as explicit term hypotheses.
- **`isSolvable_of_isSolvable_commutator`** — metabelian corollary: a group is solvable whenever its commutator subgroup is (the quotient `G ⧸ commutator G` is abelian for free).
- **`alternatingFinFour_isSolvable`** — re-derives the parent's A₄ result through the packaged lemma; the inline `solvable_of_ker_le_range … (le_of_eq …)` collapses to a single `exact`.

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.AbelRuffiniOQ06OQ01OQ03` against pinned Mathlib v4.26.0 — **7743 jobs, 0 errors**.
- `#print axioms` on all four theorems reports exactly `[propext, Classical.choice, Quot.sound]`. No `native_decide`, no `Lean.ofReduceBool`. Status: **verified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)