### PR TITLE
Add Baire-category generalization: perfect complete metric spaces are uncountable

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02OQ03.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02OQ03.lean
@@ -1,0 +1,103 @@
+/-
+Baire-Category Generalization of Uncountability:
+Every nonempty complete metric space with no isolated points is uncountable.
+
+**Open Question (algebraic-numbers-countable-oq-02-oq-02-oq-03)**:
+The gallery's `algebraic-numbers-countable` entry (and its sibling
+`oq-02-oq-02`, Cantor's 1874 nested-interval argument) shows that ℝ is
+uncountable. What is the RIGHT level of generality for that phenomenon?
+
+The answer is topological, not arithmetic: uncountability of ℝ is a special
+case of the fact that any nonempty complete metric space without isolated
+points (a *perfect* space) is uncountable. The reals inherit uncountability
+purely because they are complete, connected, and have more than one point —
+no special feature of the real line is needed.
+
+**What This Proves** (0 axioms):
+1. `card_nat_bool` — #(ℕ → Bool) = 𝔠 (the Cantor space has continuum cardinality)
+2. `nat_bool_uncountable` — the Cantor space `ℕ → Bool` is uncountable
+3. `perfect_nonempty_uncountable` — any nonempty perfect subset of a complete
+   metric space is uncountable (the core theorem, subtype form)
+4. `perfectSpace_uncountable` — a nonempty complete metric space with no
+   isolated points is uncountable (main theorem, whole-space form)
+5. `uncountable_of_connected` — a nonempty complete metric space that is
+   connected and nontrivial is uncountable (corollary)
+6. `real_uncountable` — ℝ is uncountable (recovered from the general theorem)
+
+**Proof Strategy**:
+The engine is Mathlib's `Perfect.exists_nat_bool_injection`: a nonempty perfect
+set `C` in a complete metric space admits a continuous injection from the Cantor
+space `ℕ → Bool`. Since `#(ℕ → Bool) = 2^ℵ₀ = 𝔠 > ℵ₀`, the Cantor space is
+uncountable, and an injection out of an uncountable type forces the target to be
+uncountable as well. The construction of the injection is a Cantor scheme: split
+`C` into two disjoint nonempty perfect pieces of small diameter, recurse along a
+binary address `ℕ → Bool`, and take the (necessarily unique, by completeness)
+point in the nested intersection.
+
+This is exactly the mechanism behind the classical Baire-category corollary that
+a nonempty perfect Polish space is uncountable; here it is packaged for the
+metric setting directly.
+
+References:
+- Mathlib: `Perfect.exists_nat_bool_injection` (Topology/MetricSpace/Perfect.lean)
+- Kechris, A. "Classical Descriptive Set Theory" (1995), §6.A (perfect sets and
+  the Cantor–Bendixson theorem): a nonempty perfect Polish space has cardinality 𝔠.
+- Sibling `algebraic-numbers-countable-oq-02-oq-02`: Cantor's 1874 nested-interval
+  proof of ℝ uncountability — the ℝ-specific instance of this general theorem.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+
+namespace BaireCategoryUncountable
+
+open Cardinal Set Function
+
+/-- The Cantor space `ℕ → Bool` has continuum cardinality: `#(ℕ → Bool) = 2^ℵ₀ = 𝔠`. -/
+theorem card_nat_bool : #(ℕ → Bool) = 𝔠 := by
+  rw [Cardinal.mk_arrow, Cardinal.mk_bool, Cardinal.mk_nat, Cardinal.lift_two,
+    Cardinal.lift_aleph0, Cardinal.two_power_aleph0]
+
+/-- The Cantor space `ℕ → Bool` is uncountable. -/
+theorem nat_bool_uncountable : Uncountable (ℕ → Bool) := by
+  rw [← Cardinal.aleph0_lt_mk_iff, card_nat_bool]
+  exact Cardinal.aleph0_lt_continuum
+
+/-- **Core theorem (subtype form).** Any nonempty perfect subset of a complete metric
+space is uncountable. The injection from the (uncountable) Cantor space is supplied
+by `Perfect.exists_nat_bool_injection`. -/
+theorem perfect_nonempty_uncountable {X : Type*} [MetricSpace X] [CompleteSpace X]
+    {C : Set X} (hC : Perfect C) (hne : C.Nonempty) : Uncountable ↥C := by
+  obtain ⟨f, hrange, -, hinj⟩ := hC.exists_nat_bool_injection hne
+  haveI : Uncountable (ℕ → Bool) := nat_bool_uncountable
+  -- Lift the injection `f : (ℕ → Bool) → X` to land in the subtype `↥C`.
+  let g : (ℕ → Bool) → C := fun x => ⟨f x, hrange (mem_range_self x)⟩
+  have hg : Function.Injective g := fun a b h => hinj (congrArg Subtype.val h)
+  -- An injection out of the uncountable Cantor space forces `↥C` uncountable.
+  exact hg.uncountable
+
+/-- **Main theorem (whole-space form).** A nonempty complete metric space with no
+isolated points (i.e. a `PerfectSpace`) is uncountable. -/
+theorem perfectSpace_uncountable {X : Type*} [MetricSpace X] [CompleteSpace X]
+    [Nonempty X] [PerfectSpace X] : Uncountable X := by
+  haveI : Uncountable (ℕ → Bool) := nat_bool_uncountable
+  obtain ⟨f, -, -, hinj⟩ :=
+    (PerfectSpace.univ_perfect (α := X)).exists_nat_bool_injection Set.univ_nonempty
+  exact hinj.uncountable
+
+/-- **Corollary.** A nonempty complete metric space that is connected and has more
+than one point is uncountable. (A connected `T1` space with two distinct points is
+automatically perfect, so this follows from the main theorem.) -/
+theorem uncountable_of_connected {X : Type*} [MetricSpace X] [CompleteSpace X]
+    [Nonempty X] [ConnectedSpace X] [Nontrivial X] : Uncountable X :=
+  perfectSpace_uncountable
+
+/-- **Application.** The classical result: ℝ is uncountable, recovered as the
+instance of the general theorem at the complete, connected, nontrivial metric
+space `ℝ`. -/
+theorem real_uncountable : Uncountable ℝ :=
+  uncountable_of_connected
+
+end BaireCategoryUncountable

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "ann-algcount-oq020203-01",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "The Right Generality: Uncountability is Topological, not Arithmetic",
+    "content": "The sibling entries prove ℝ uncountable using features of the real line (nested intervals, the diagonal argument, cardinal arithmetic on 2^ℵ₀). This file asks what those proofs are really about. The answer belongs to topology: any nonempty complete metric space with no isolated points — a perfect space — is uncountable. ℝ inherits uncountability only because it is complete, connected, and has more than one point. The general theorem never mentions the order or field structure of ℝ; the real line appears only in the final one-line application `real_uncountable`.",
+    "mathContext": "A space is *perfect* if it has no isolated points. The theorem: nonempty + complete metric + perfect ⟹ uncountable. ℝ is complete and connected with $|\\mathbb{R}| \\geq 2$, so it is perfect, so it is uncountable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect sets",
+      "complete metric spaces",
+      "Cantor–Bendixson theorem",
+      "descriptive set theory"
+    ],
+    "prerequisites": [
+      "metric space topology",
+      "isolated points",
+      "countability"
+    ]
+  },
+  {
+    "id": "ann-algcount-oq020203-02",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+    "range": { "startLine": 58, "endLine": 66 },
+    "type": "theorem",
+    "title": "The Cantor Space ℕ → Bool Has Cardinality 𝔠",
+    "content": "`card_nat_bool` computes #(ℕ → Bool) = 𝔠 by rewriting through Mathlib's cardinal-arithmetic lemmas: mk_arrow reduces the function space to #Bool ^ #ℕ, mk_bool and mk_nat give 2 and ℵ₀, the lift lemmas normalize universes, and two_power_aleph0 collapses 2^ℵ₀ to 𝔠. `nat_bool_uncountable` then converts this cardinal equation into the `Uncountable (ℕ → Bool)` typeclass instance via aleph0_lt_mk_iff and aleph0_lt_continuum. The Cantor space is the universal uncountable witness that the rest of the proof injects into its target.",
+    "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = 2^{\\aleph_0} = \\mathfrak{c}$, and $\\aleph_0 < \\mathfrak{c}$ gives $\\mathrm{Uncountable}\\,(\\mathbb{N} \\to \\mathrm{Bool})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "continuum cardinality",
+      "Cantor space",
+      "cardinal arithmetic"
+    ],
+    "prerequisites": [
+      "Cardinal.two_power_aleph0",
+      "Cardinal.aleph0_lt_continuum"
+    ]
+  },
+  {
+    "id": "ann-algcount-oq020203-03",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "theorem",
+    "title": "Core Theorem: Nonempty Perfect Sets are Uncountable",
+    "content": "`perfect_nonempty_uncountable` is the mathematical heart. Mathlib's `Perfect.exists_nat_bool_injection` supplies a continuous injection f : (ℕ → Bool) → X whose range lies inside the perfect set C — this is the Cantor scheme, which recursively splits C into two disjoint nonempty perfect pieces of shrinking diameter and reads off the unique nested-intersection point for each binary address. Because the domain ℕ → Bool is uncountable, the codomain of any injection out of it is uncountable too. The one subtlety is landing in the subtype: f maps into X, so it is lifted to g : (ℕ → Bool) → ↥C using the range hypothesis, and `Function.Injective.uncountable` yields `Uncountable ↥C`.",
+    "mathContext": "Given $f : (\\mathbb{N}\\to\\mathrm{Bool}) \\hookrightarrow X$ with $\\mathrm{range}\\,f \\subseteq C$, define $g(x) = \\langle f(x),\\, \\cdot\\rangle : (\\mathbb{N}\\to\\mathrm{Bool}) \\hookrightarrow \\uparrow C$. Injectivity of $g$ plus uncountability of the domain gives $\\mathrm{Uncountable}\\,\\uparrow C$, i.e. $\\neg\\, C.\\mathrm{Countable}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Perfect.exists_nat_bool_injection",
+      "Cantor scheme",
+      "subtype coercion",
+      "Function.Injective.uncountable"
+    ],
+    "prerequisites": [
+      "perfect sets in complete metric spaces",
+      "the Uncountable typeclass"
+    ]
+  },
+  {
+    "id": "ann-algcount-oq020203-04",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+    "range": { "startLine": 81, "endLine": 103 },
+    "type": "theorem",
+    "title": "Main Theorem, Connected Corollary, and ℝ Recovered",
+    "content": "Three specializations close the file. `perfectSpace_uncountable` applies the core theorem to C := univ using `PerfectSpace.univ_perfect`, giving the whole-space statement: a nonempty complete metric space with no isolated points is uncountable. `uncountable_of_connected` needs no new topology — Mathlib's instance that a connected T1 space with two distinct points has no isolated points makes it definitionally the main theorem. Finally `real_uncountable` observes that ℝ is a complete, connected, nontrivial metric space, so uncountability follows in a single line — recovering the classical result of the sibling entries with no property of the real line beyond these three.",
+    "mathContext": "A connected $T_1$ space with $\\geq 2$ points is perfect (an isolated point would be clopen). $\\mathbb{R}$ is complete, connected, and nontrivial, hence perfect, hence uncountable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "PerfectSpace",
+      "connectedness implies perfect",
+      "ℝ uncountable"
+    ],
+    "prerequisites": [
+      "PerfectSpace.univ_perfect",
+      "connected T1 spaces"
+    ]
+  }
+]

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,229 @@
+{
+  "id": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+  "title": "Baire-Category Generalization: Perfect Complete Metric Spaces are Uncountable",
+  "slug": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+  "description": "Locates the RIGHT level of generality for the uncountability of ℝ. The reals are uncountable not for any arithmetic reason but because they form a nonempty complete metric space with no isolated points (a perfect space). Using Mathlib's Perfect.exists_nat_bool_injection, this proof shows any nonempty perfect subset of a complete metric space admits an injection from the Cantor space ℕ → Bool (which has continuum cardinality), hence is uncountable — recovering ℝ uncountable as a one-line corollary via completeness, connectedness, and nontriviality alone.",
+  "sorries": 0,
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_set_property",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ03.lean",
+    "tags": [
+      "set-theory",
+      "topology",
+      "metric-spaces",
+      "uncountability",
+      "cardinality",
+      "perfect-sets",
+      "baire-category",
+      "descriptive-set-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Perfect.exists_nat_bool_injection",
+        "description": "A nonempty perfect set in a complete metric space admits a continuous injection from the Cantor space ℕ → Bool (the Cantor scheme)",
+        "module": "Mathlib.Topology.MetricSpace.Perfect"
+      },
+      {
+        "theorem": "Cardinal.two_power_aleph0",
+        "description": "2 ^ ℵ₀ = 𝔠, the cardinality of the continuum",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.aleph0_lt_continuum",
+        "description": "ℵ₀ < 𝔠, so continuum-sized types are uncountable",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.aleph0_lt_mk_iff",
+        "description": "ℵ₀ < #α ↔ Uncountable α, bridging cardinal inequality and the Uncountable typeclass",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Function.Injective.uncountable",
+        "description": "An injection out of an uncountable type forces its codomain uncountable",
+        "module": "Mathlib.Logic.Small.Basic"
+      },
+      {
+        "theorem": "PerfectSpace.univ_perfect",
+        "description": "In a PerfectSpace, the universal set is perfect (no isolated points)",
+        "module": "Mathlib.Topology.Perfect"
+      }
+    ],
+    "originalContributions": [
+      "card_nat_bool: computes #(ℕ → Bool) = 𝔠 via the mk_arrow / two_power_aleph0 chain",
+      "nat_bool_uncountable: the Cantor space is uncountable (ℵ₀ < 𝔠)",
+      "perfect_nonempty_uncountable: PROVED any nonempty perfect subset of a complete metric space is uncountable, by lifting the Cantor-space injection to the subtype",
+      "perfectSpace_uncountable: PROVED the whole-space form — a nonempty complete metric space with no isolated points is uncountable",
+      "uncountable_of_connected: PROVED the connected corollary via Mathlib's [T1Space][ConnectedSpace][Nontrivial] → PerfectSpace instance",
+      "real_uncountable: recovers ℝ uncountable as a one-line instance of the general theorem"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Complete metric spaces and the Cantor scheme (Perfect.exists_nat_bool_injection)",
+      "Cardinal arithmetic (2^ℵ₀ = 𝔠, ℵ₀ < 𝔠)",
+      "The Uncountable typeclass and injective maps"
+    ],
+    "assumptions": "0 axioms. Depends only on propext / Classical.choice / Quot.sound (the ordinary Mathlib foundations), confirmed by #print axioms on all six theorems. Relies on Mathlib's Perfect.exists_nat_bool_injection and standard cardinal arithmetic.",
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "relatedProblems": [
+      {
+        "id": "algebraic-numbers-countable-oq-02-oq-02",
+        "relationship": "Sibling: Cantor's 1874 nested-interval proof of ℝ uncountability — the ℝ-specific instance of this general theorem"
+      },
+      {
+        "id": "algebraic-numbers-countable-oq-02",
+        "relationship": "Ancestor: cardinality-based (ℵ₀ < 𝔠) proof of ℝ uncountability"
+      },
+      {
+        "id": "algebraic-numbers-countable",
+        "relationship": "Root: algebraic numbers are countable"
+      }
+    ],
+    "lineCount": 103
+  },
+  "leanFile": {
+    "lineCount": 103,
+    "namespace": "BaireCategoryUncountable",
+    "opens": ["Cardinal", "Set", "Function"],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": ["Mathlib"],
+    "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "card_nat_bool",
+      "type": "supporting",
+      "description": "The Cantor space ℕ → Bool has continuum cardinality: #(ℕ → Bool) = 2^ℵ₀ = 𝔠.",
+      "leanType": "#(ℕ → Bool) = 𝔠"
+    },
+    {
+      "name": "nat_bool_uncountable",
+      "type": "supporting",
+      "description": "The Cantor space ℕ → Bool is uncountable (since ℵ₀ < 𝔠).",
+      "leanType": "Uncountable (ℕ → Bool)"
+    },
+    {
+      "name": "perfect_nonempty_uncountable",
+      "type": "core",
+      "description": "Any nonempty perfect subset of a complete metric space is uncountable. The engine is a Cantor-space injection lifted to the subtype.",
+      "leanType": "∀ {X : Type*} [MetricSpace X] [CompleteSpace X] {C : Set X}, Perfect C → C.Nonempty → Uncountable ↥C"
+    },
+    {
+      "name": "perfectSpace_uncountable",
+      "type": "main",
+      "description": "Main theorem (whole-space form): a nonempty complete metric space with no isolated points (a PerfectSpace) is uncountable.",
+      "leanType": "∀ {X : Type*} [MetricSpace X] [CompleteSpace X] [Nonempty X] [PerfectSpace X], Uncountable X"
+    },
+    {
+      "name": "uncountable_of_connected",
+      "type": "corollary",
+      "description": "A nonempty complete metric space that is connected and has more than one point is uncountable (a connected T1 space with two points is automatically perfect).",
+      "leanType": "∀ {X : Type*} [MetricSpace X] [CompleteSpace X] [Nonempty X] [ConnectedSpace X] [Nontrivial X], Uncountable X"
+    },
+    {
+      "name": "real_uncountable",
+      "type": "application",
+      "description": "ℝ is uncountable, recovered as the instance of the general theorem at the complete, connected, nontrivial metric space ℝ.",
+      "leanType": "Uncountable ℝ"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The uncountability of ℝ was first proved by Cantor in 1874 via nested intervals, then again in 1891 via the diagonal argument. Both proofs are usually presented as facts about the real line. The 20th-century development of descriptive set theory (Cantor–Bendixson, Kechris) revealed that neither the ordering nor the arithmetic of ℝ is essential: what matters is that ℝ is a nonempty complete metric space with no isolated points — a *perfect* space. Every such space contains a topological copy of the Cantor set and therefore has cardinality at least 𝔠. This entry formalizes that general phenomenon and recovers ℝ uncountable as a corollary.",
+    "problemStatement": "Identify the correct level of generality for the uncountability of ℝ established in the sibling entries, and prove it in Lean: a nonempty complete metric space without isolated points is uncountable.",
+    "proofStrategy": "The core is Mathlib's Perfect.exists_nat_bool_injection: a nonempty perfect set C in a complete metric space admits a continuous injection f : (ℕ → Bool) → X with range ⊆ C, built by a Cantor scheme (recursively split C into two disjoint nonempty perfect pieces of shrinking diameter and read off the unique nested-intersection point along a binary address). Because #(ℕ → Bool) = 2^ℵ₀ = 𝔠 > ℵ₀, the Cantor space is uncountable; lifting the injection to the subtype ↥C and applying Function.Injective.uncountable forces ↥C uncountable. The whole-space form specializes C := univ via PerfectSpace.univ_perfect; the connected corollary uses Mathlib's instance that a connected T1 space with ≥ 2 points is perfect; and ℝ satisfies all hypotheses, giving real_uncountable in one line.",
+    "keyInsights": [
+      "**Uncountability of ℝ is topological, not arithmetic.** The reals are uncountable purely because they are complete, connected, and have more than one point. No feature of the real line — its order, its field structure, its specific construction — is used in the general theorem; ℝ appears only in the final one-line application.",
+      "**The Cantor space is the universal witness.** Every nonempty perfect complete metric space contains an injective image of ℕ → Bool. Since #(ℕ → Bool) = 𝔠, this single embedding simultaneously bounds the cardinality of ℝ, of Cantor's middle-thirds set, of [0,1], and of any perfect Polish space from below by the continuum.",
+      "**Subtype uncountability vs. set uncountability.** This Mathlib version has no Set.Uncountable predicate; the natural statement of the core theorem is Uncountable ↥C for the coercion subtype, which is definitionally ¬ C.Countable. Lifting the ambient injection f : (ℕ → Bool) → X to g : (ℕ → Bool) → ↥C keeps the argument entirely at the typeclass level.",
+      "**Connectedness implies perfect.** A connected T1 space with at least two points has no isolated points: an isolated point would be clopen, contradicting connectedness. Mathlib packages this as an instance, so the connected corollary needs no separate topological argument — it is definitionally the main theorem."
+    ],
+    "prerequisites": [
+      "Perfect sets and the Cantor scheme in complete metric spaces",
+      "Cardinal arithmetic: 2^ℵ₀ = 𝔠 and ℵ₀ < 𝔠",
+      "The Uncountable typeclass and injections"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: The Right Generality for ℝ Uncountable",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "File docstring, import, namespace, and opens. Frames the open question — the uncountability of ℝ is a special case of the topological fact that any nonempty complete metric space with no isolated points is uncountable — and inventories the six results and the Cantor-scheme proof strategy."
+    },
+    {
+      "id": "cantor-space-cardinality",
+      "title": "The Cantor Space has Continuum Cardinality",
+      "startLine": 58,
+      "endLine": 66,
+      "summary": "card_nat_bool computes #(ℕ → Bool) = 2^ℵ₀ = 𝔠 through the mk_arrow / mk_bool / mk_nat / two_power_aleph0 chain; nat_bool_uncountable then reads off Uncountable (ℕ → Bool) from ℵ₀ < 𝔠.",
+      "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$, so the Cantor space is uncountable."
+    },
+    {
+      "id": "core-theorem",
+      "title": "Core Theorem: Nonempty Perfect Sets are Uncountable",
+      "startLine": 68,
+      "endLine": 80,
+      "summary": "perfect_nonempty_uncountable obtains the Cantor-space injection from Perfect.exists_nat_bool_injection, lifts it to the coercion subtype ↥C, and concludes Uncountable ↥C via Function.Injective.uncountable.",
+      "mathContext": "From $f : (\\mathbb{N} \\to \\mathrm{Bool}) \\hookrightarrow X$ with range $\\subseteq C$, lift to $g : (\\mathbb{N} \\to \\mathrm{Bool}) \\hookrightarrow \\; \\uparrow C$; an injection out of an uncountable type makes $\\uparrow C$ uncountable."
+    },
+    {
+      "id": "main-and-corollaries",
+      "title": "Main Theorem, Connected Corollary, and ℝ",
+      "startLine": 81,
+      "endLine": 103,
+      "summary": "perfectSpace_uncountable specializes the core theorem to C := univ via PerfectSpace.univ_perfect; uncountable_of_connected derives the connected/nontrivial case from Mathlib's perfect-space instance; real_uncountable recovers ℝ uncountable as a one-line application.",
+      "mathContext": "$\\mathbb{R}$ is a complete, connected, nontrivial metric space, hence perfect, hence uncountable — no property of the real line beyond these three is used."
+    }
+  ],
+  "conclusion": {
+    "summary": "A single topological mechanism — the Cantor scheme embedding ℕ → Bool into any nonempty perfect complete metric space — explains the uncountability of ℝ and of every perfect Polish space at once. The formalization proves the general theorem (0 sorries, 0 axioms beyond the Mathlib foundations) and recovers ℝ uncountable as a one-line corollary, making explicit that completeness + no-isolated-points, not any arithmetic of ℝ, is what forces uncountability.",
+    "implications": [
+      "Cantor's middle-thirds set, [0,1], the irrationals, and any perfect Polish space are all uncountable for the same reason and by the same one-line argument.",
+      "The result is the metric-space core of the Cantor–Bendixson analysis: a perfect Polish space has cardinality exactly 𝔠.",
+      "It cleanly separates the two ingredients of ℝ's uncountability — completeness (Cauchy limits exist) and no isolated points (every ball splits) — from the irrelevant order and field structure."
+    ],
+    "openQuestions": [
+      "Can the reverse cardinality bound (#X ≤ 𝔠 for a separable such space) be added to prove #X = 𝔠 exactly, matching the Cantor–Bendixson conclusion?",
+      "Does an analogous elementary argument give uncountability for perfect sets in complete uniform (non-metrizable) spaces?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Kechris, Alexander S.",
+      "title": "Classical Descriptive Set Theory",
+      "year": "1995",
+      "venue": "Graduate Texts in Mathematics 156, Springer",
+      "note": "§6.A: a nonempty perfect Polish space contains a Cantor set and has cardinality 𝔠."
+    },
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, 77",
+      "note": "Pages 258-262. The original ℝ-uncountability proof; the ℝ-specific instance of the general theorem formalized here."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Perfect.exists_nat_bool_injection (Mathlib.Topology.MetricSpace.Perfect)",
+      "year": "2026",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/MetricSpace/Perfect.html",
+      "note": "The Cantor-scheme injection ℕ → Bool ↪ X out of a nonempty perfect set in a complete metric space."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes research problem **algebraic-numbers-countable-oq-02-oq-02-oq-03**: the uncountability of ℝ is a special case of a purely topological fact — **any nonempty complete metric space with no isolated points (a *perfect* space) is uncountable.** ℝ is uncountable only because it is complete, connected, and has more than one point; no property of the real line is used in the general theorem.

## What is proved (`proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02OQ03.lean`, 103 lines)

Six theorems, **0 sorries, 0 axioms**:

1. `card_nat_bool` — `#(ℕ → Bool) = 2^ℵ₀ = 𝔠`
2. `nat_bool_uncountable` — the Cantor space `ℕ → Bool` is uncountable
3. `perfect_nonempty_uncountable` — **core:** any nonempty perfect subset of a complete metric space is uncountable
4. `perfectSpace_uncountable` — **main:** a nonempty complete metric space with no isolated points is uncountable
5. `uncountable_of_connected` — corollary for connected, nontrivial spaces
6. `real_uncountable` — ℝ uncountable, recovered as a one-line instance

## Proof engine

Mathlib's `Perfect.exists_nat_bool_injection` (the Cantor scheme): a nonempty perfect set in a complete metric space admits a continuous injection from the continuum-sized Cantor space `ℕ → Bool`. An injection out of an uncountable type forces the target uncountable.

## Verification

- Built via `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ02OQ03` — ✔ builds clean.
- `#print axioms` on **all six** theorems: depends only on `propext`, `Classical.choice`, `Quot.sound` (the ordinary Mathlib foundations). No `sorryAx`, no `Lean.ofReduceBool`.
- Status `verified`, badge `original`, `axiomCount` 0.
- Gallery data (`meta.json` + `annotations.json`) passes `annotations:validate` with 0 errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)