### PR TITLE
Enrich Galois degree divisibility for trisection (angle-trisection-oq-02-oq-01): add mainTheorems (0->4)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -302,5 +302,31 @@
     "path": "Proofs/AngleTrisectionOQ02OQ01.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "natDegree_dvd_card_gal",
+      "type": "core",
+      "description": "For any irreducible polynomial over a characteristic-zero field, the natural degree of the polynomial divides the cardinality of its Galois group. This generalizes Mathlib's prime_degree_dvd_card from prime degrees to all degrees, via the tower law on F ⊂ F⟮α⟯ ⊂ SplittingField(p).",
+      "leanType": "{F : Type*} [Field F] [CharZero F] {p : F[X]} (p_irr : Irreducible p) : p.natDegree ∣ Nat.card p.Gal"
+    },
+    {
+      "name": "galois_2group_implies_degree_pow2",
+      "type": "core",
+      "description": "If the Galois group of the minimal polynomial of α over ℚ is a 2-group, then the natural degree of that minimal polynomial divides 2^n for some n. This eliminates the axiom galois_2group_implies_degree_pow2 from OQ02.",
+      "leanType": "(α : ℝ) (hα : IsIntegral ℚ α) (hGal : IsPGroup 2 (minpoly ℚ α).Gal) : ∃ n : ℕ, (minpoly ℚ α).natDegree ∣ 2 ^ n"
+    },
+    {
+      "name": "galois_2group_implies_degree_is_pow2",
+      "type": "core",
+      "description": "Strengthening: if the Galois group of the minimal polynomial of α over ℚ is a 2-group, then the natural degree of that minimal polynomial is exactly a power of 2. Uses dvd_pow_two_is_pow_two from OQ01.",
+      "leanType": "(α : ℝ) (hα : IsIntegral ℚ α) (hGal : IsPGroup 2 (minpoly ℚ α).Gal) : ∃ k : ℕ, (minpoly ℚ α).natDegree = 2 ^ k"
+    },
+    {
+      "name": "galois_criterion_implies_degree_criterion",
+      "type": "supporting",
+      "description": "Connects the Galois criterion (2-group Galois group) to the degree criterion (degree a power of 2), tying OQ02 back to OQ01 for constructibility.",
+      "leanType": "(α : ℝ) (hα : IsIntegral ℚ α) (hGal : IsPGroup 2 (minpoly ℚ α).Gal) : ∃ k : ℕ, (minpoly ℚ α).natDegree = 2 ^ k"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Adds a `mainTheorems` array (0→4) to the **Galois degree divisibility for trisection** (`angle-trisection-oq-02-oq-01`) gallery entry.

Each entry is drawn directly from the entry's `.lean` source on `origin/main` with its exact Lean signature and `type` (`core`/`supporting`/`axiom`).

Structural enrichment only: fills the previously empty `mainTheorems` field. All other meta.json fields are byte-identical to `origin/main`; no Lean source changed.
