### PR TITLE
research(pythagorean-triples-oq-06-oq-01-oq-01): locate factor 3 + prove 60 is sharp [verified, 0-axiom, 11→15 thm]

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean
@@ -97,6 +97,66 @@ theorem sixty_dvd_prod_of_pythagoreanTriple {x y z : ℤ} (h : PythagoreanTriple
     (60 : ℤ) ∣ x * y * z :=
   sixty_dvd_prod (by have := h.eq; ring_nf; ring_nf at this; linarith)
 
+/-! ### Locating the factor `3`: it never divides the hypotenuse of a primitive triple
+
+The package `sixty_dvd_prod` only says *that* each prime factor is present in the product; it
+does not say *which* side carries it.  For the factor `3` the location is pinned down completely
+by primitivity: if the legs `x, y` are coprime then `3 ∤ z`, so the `3` must fall on a **leg**.
+
+This is genuinely special to `3` (and to `4`).  The factor `5` can land on the hypotenuse — e.g.
+`(3, 4, 5)` has `5 ∣ z` — so no analogous "`5 ∤ z`" statement holds. -/
+
+/-- For a **primitive** triple (coprime legs), `3` never divides the hypotenuse.  If it did, then
+`x² + y² ≡ 0 (mod 3)` would force `3 ∣ x` and `3 ∣ y`, contradicting `IsCoprime x y`. -/
+theorem three_not_dvd_hyp_of_coprime {x y z : ℤ} (hcop : IsCoprime x y)
+    (h : x ^ 2 + y ^ 2 = z ^ 2) : ¬ (3 : ℤ) ∣ z := by
+  intro hz
+  -- Over `ZMod 3` the only solution of `a² + b² = 0` is `a = b = 0`.
+  have key : ∀ a b : ZMod 3, a ^ 2 + b ^ 2 = 0 → a = 0 ∧ b = 0 := by decide
+  have hzz : (z : ZMod 3) = 0 := by
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd]; exact_mod_cast hz
+  have hrel : (x : ZMod 3) ^ 2 + (y : ZMod 3) ^ 2 = 0 := by
+    have := zmod_rel 3 h; rw [hzz] at this; simpa using this
+  obtain ⟨hx0, hy0⟩ := key _ _ hrel
+  have hx : (3 : ℤ) ∣ x := by
+    have := (ZMod.intCast_zmod_eq_zero_iff_dvd x 3).1 hx0; exact_mod_cast this
+  have hy : (3 : ℤ) ∣ y := by
+    have := (ZMod.intCast_zmod_eq_zero_iff_dvd y 3).1 hy0; exact_mod_cast this
+  have hunit : IsUnit (3 : ℤ) := hcop.isUnit_of_dvd' hx hy
+  rw [Int.isUnit_iff] at hunit; omega
+
+/-- **Locating the factor `3`.**  In every primitive Pythagorean triple, `3` divides one of the
+two **legs** `x`, `y` (never the hypotenuse `z`).  Combined with `three_not_dvd_hyp_of_coprime`
+this fully pins the position of the factor `3`. -/
+theorem three_dvd_leg_of_coprime {x y z : ℤ} (hcop : IsCoprime x y)
+    (h : x ^ 2 + y ^ 2 = z ^ 2) : (3 : ℤ) ∣ x ∨ (3 : ℤ) ∣ y := by
+  have hprod := three_dvd_prod h
+  have hznot := three_not_dvd_hyp_of_coprime hcop h
+  rcases (Int.prime_three.dvd_mul.1 hprod) with hxy | hz
+  · exact Int.prime_three.dvd_mul.1 hxy
+  · exact absurd hz hznot
+
+/-! ### Sharpness: `60` is *exactly* the universal divisor
+
+`sixty_dvd_prod` shows `60` divides every Pythagorean product `xyz`.  The instance `(3, 4, 5)`
+with `xyz = 60` shows this is the best possible constant: any integer that divides the product of
+*every* triple must already divide `60`.  The two facts combine into a clean characterization. -/
+
+/-- **Sharpness (upper bound).**  If `d` divides `x·y·z` for *every* Pythagorean triple, then
+`d ∣ 60`.  Proof: specialize to `(3, 4, 5)`, whose product is exactly `60`. -/
+theorem sixty_greatest_universal_divisor (d : ℤ)
+    (hd : ∀ x y z : ℤ, x ^ 2 + y ^ 2 = z ^ 2 → d ∣ x * y * z) : d ∣ 60 := by
+  have := hd 3 4 5 (by norm_num); norm_num at this; exact this
+
+/-- **The universal-divisor characterization.**  An integer `d` divides the product of the sides
+of every Pythagorean triple **iff** `d ∣ 60`.  This is the sharp form of the package: `60` is the
+greatest common divisor of `{ x·y·z : x² + y² = z² }`. -/
+theorem dvd_all_prod_iff_dvd_sixty (d : ℤ) :
+    (∀ x y z : ℤ, x ^ 2 + y ^ 2 = z ^ 2 → d ∣ x * y * z) ↔ d ∣ 60 := by
+  constructor
+  · exact sixty_greatest_universal_divisor d
+  · intro hd x y z h; exact hd.trans (sixty_dvd_prod h)
+
 /-! ### Concrete instances -/
 
 /-- `(3,4,5)`: the product `60` is exactly divisible by `60`. -/

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
@@ -16,11 +16,11 @@
     ]
   },
   "conclusion": {
-    "summary": "A complete 0-axiom Lean 4 formalization that 60 ∣ x·y·z for every Pythagorean triple, with the three prime-power components 3 ∣ xyz, 4 ∣ xyz, 5 ∣ xyz proved as finite congruence obstructions over ZMod 3, ZMod 8 → ZMod 4, and ZMod 5, assembled by coprimality. Includes a PythagoreanTriple-structure wrapper and four concrete instances.",
+    "summary": "A complete 0-axiom Lean 4 formalization that 60 ∣ x·y·z for every Pythagorean triple, with the three prime-power components 3 ∣ xyz, 4 ∣ xyz, 5 ∣ xyz proved as finite congruence obstructions over ZMod 3, ZMod 8 → ZMod 4, and ZMod 5, assembled by coprimality. Includes a PythagoreanTriple-structure wrapper and four concrete instances. Extended with the factor-3 location theorems (three_not_dvd_hyp_of_coprime, three_dvd_leg_of_coprime — 3 falls on a leg of any primitive triple) and the sharpness characterization dvd_all_prod_iff_dvd_sixty (d divides every Pythagorean product iff d ∣ 60).",
     "implications": "Supplies the headline divisibility package missing from Mathlib's Pythagorean-triple library, without any primitivity hypothesis. The proof exemplifies the 'finite congruence obstruction' technique — reducing a Diophantine divisibility to a decidable check over a finite ring — including the subtlety that the 2-adic factor 4 must be read off modulo 8. The reusable lemma dvd_prod_of_zmod can certify other congruence obstructions on quadratic relations.",
     "openQuestions": [
-      "Refine the package structurally for primitive triples: prove that 3 and 5 never divide the hypotenuse z (so the obstruction always falls on a leg), and that the even leg is divisible by 4 — pinning the location of each prime factor rather than only its presence in the product.",
-      "Identify the largest constant C such that C ∣ xyz for every Pythagorean triple, and prove 60 is sharp by exhibiting a triple whose product is divisible by no prime power beyond those in 60 (e.g. (3,4,5) with xyz = 60)."
+      "Pin the even-leg structure for primitive triples: prove which leg is even and that the even leg is divisible by 4 (the factor-3 location and the sharpness of 60 are now resolved in this file — see three_dvd_leg_of_coprime and dvd_all_prod_iff_dvd_sixty).",
+      "Extend the location analysis to 5: characterize exactly when 5 divides a leg versus the hypotenuse (unlike 3, the factor 5 can fall on z, e.g. (3,4,5))."
     ]
   },
   "sections": [
@@ -101,26 +101,30 @@
   "openQuestions": [
     {
       "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
-      "question": "Refine the package structurally for primitive triples: prove that 3 and 5 never divide the hypotenuse z (so the obstruction always falls on a leg), and that the even leg is divisible by 4 — pinning the location of each prime factor rather than only its presence in the product.",
-      "significance": "medium"
+      "question": "Refine the package structurally for primitive triples. RESOLVED for the factor 3: `three_not_dvd_hyp_of_coprime` / `three_dvd_leg_of_coprime` prove that for coprime legs 3 never divides the hypotenuse, so the factor 3 always lands on a leg. NOTE: the original hope that '5 never divides z' is FALSE — 5 can divide the hypotenuse, e.g. (3,4,5) has 5∣z — so only a presence statement (five_dvd_prod) is available for 5. REMAINING: pin the even leg's divisibility by 4 for primitive triples (which leg is even, and that it is a multiple of 4).",
+      "significance": "medium",
+      "status": "partially-resolved"
     },
     {
       "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-02",
-      "question": "Identify the largest constant C such that C ∣ xyz for every Pythagorean triple, and prove 60 is sharp by exhibiting a triple whose product is not divisible by any prime power beyond those in 60 (e.g. (3,4,5) with xyz = 60).",
-      "significance": "low"
+      "question": "RESOLVED: `dvd_all_prod_iff_dvd_sixty` proves that d divides the product xyz of every Pythagorean triple iff d ∣ 60, so 60 is exactly the greatest universal divisor; sharpness is witnessed by (3,4,5) whose product is 60 (`sixty_greatest_universal_divisor`).",
+      "significance": "low",
+      "status": "resolved"
     }
   ],
   "sorries": 0,
   "leanFile": {
     "axiomCount": 0,
     "definitionCount": 0,
-    "imports": ["Mathlib"],
-    "lineCount": 115,
+    "imports": [
+      "Mathlib"
+    ],
+    "lineCount": 175,
     "namespace": "PythagoreanTriples60",
     "opens": [],
     "path": "Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean",
     "sorries": 0,
-    "theoremCount": 11
+    "theoremCount": 15
   },
   "meta": {
     "author": "Lean Genius Research",
@@ -138,8 +142,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 115,
-    "theoremCount": 11,
+    "lineCount": 175,
+    "theoremCount": 15,
     "definitionCount": 0,
     "dateAdded": "2026-06-24",
     "mathlibDependencies": [
@@ -169,7 +173,9 @@
       "four_dvd_prod: 4 ∣ xyz proved via the ZMod 8 → ZMod 4 lift, correctly handling the fact that the factor 4 is invisible modulo 4 alone",
       "three_dvd_prod / five_dvd_prod: the 3- and 5-obstructions as finite ZMod checks via the reusable dvd_prod_of_zmod packaging",
       "dvd_prod_of_zmod: a reusable lemma converting a decidable congruence obstruction over ZMod n into an integer divisibility of the product",
-      "Concrete instances (3,4,5), (5,12,13), (8,15,17), (20,21,29) exercising the general theorem"
+      "Concrete instances (3,4,5), (5,12,13), (8,15,17), (20,21,29) exercising the general theorem",
+      "three_not_dvd_hyp_of_coprime / three_dvd_leg_of_coprime: for a PRIMITIVE triple (coprime legs) the factor 3 never divides the hypotenuse and therefore falls on a leg — locating the factor 3, not merely asserting its presence in the product",
+      "sixty_greatest_universal_divisor / dvd_all_prod_iff_dvd_sixty: an integer d divides x·y·z for EVERY Pythagorean triple iff d ∣ 60 — the sharp form proving 60 is exactly the universal divisor (upper bound witnessed by (3,4,5) with product 60)"
     ],
     "prerequisites": [
       "Pythagorean triples (integer solutions of x² + y² = z²)",


### PR DESCRIPTION
## Summary

Extends the verified `60 ∣ xyz` divisibility package for Pythagorean triples (`PythagoreanTriplesOQ06OQ01OQ01.lean`, from #29137) with **two frontier results** that answer the entry's two recorded open questions. All four new theorems are machine-checked and **0-axiom**.

## New theorems (11 → 15)

**Locating the factor 3 (open question oq-01):**
- `three_not_dvd_hyp_of_coprime` — for a *primitive* triple (`IsCoprime x y`), `3 ∤ z`: if `3 ∣ z` then `x²+y² ≡ 0 (mod 3)` forces `3 ∣ x` and `3 ∣ y`, contradicting coprimality (`IsCoprime.isUnit_of_dvd'` + `Int.isUnit_iff`).
- `three_dvd_leg_of_coprime` — hence `3 ∣ x ∨ 3 ∣ y`: the factor 3 always lands on a **leg**, not just "somewhere in the product."

> ⚠️ **Correction to the stated open question.** The meta had asked to show "3 *and 5* never divide the hypotenuse." That is **false for 5**: `(3,4,5)` has `5 ∣ z`. Only 3 admits the leg-location statement; for 5 the presence result `five_dvd_prod` is the best possible. The open-question text is updated accordingly.

**Sharpness of 60 (open question oq-02):**
- `sixty_greatest_universal_divisor` — if `d ∣ x·y·z` for *every* triple, then `d ∣ 60` (specialize to `(3,4,5)`, product `60`).
- `dvd_all_prod_iff_dvd_sixty` — the clean characterization: `(∀ triple, d ∣ x·y·z) ↔ d ∣ 60`. So **60 is exactly the greatest universal divisor** of `{xyz : x²+y²=z²}`, combining the existing `sixty_dvd_prod` with the new upper bound.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PythagoreanTriplesOQ06OQ01OQ01` → **7743 jobs, exit 0**.
- `#print axioms` on all four new theorems → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`). **0-axiom** per the project axiom-integrity policy.

## Gallery

`meta.json` updated: `theoremCount` 11→15, `lineCount` 115→175, two `originalContributions` added, open questions oq-01 marked *partially-resolved* (factor-3 done; even-leg-÷4 remains) and oq-02 marked *resolved*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)