### PR TITLE
Enrich prime-degree divides Galois cardinality (angle-trisection-oq-02-oq-01-oq-01): add mainTheorems (0->1)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01/meta.json
@@ -172,5 +172,13 @@
       "Proofs.AngleTrisectionOQ02OQ01"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "prime_degree_dvd_card_from_general",
+      "type": "core",
+      "description": "Mathlib's prime_degree_dvd_card is recovered as a trivial corollary of the generalized result: for an irreducible polynomial over a characteristic-zero field, its natDegree divides the cardinality of its Galois group, with the prime-degree hypothesis entirely unused.",
+      "leanType": "{F : Type*} [Field F] [CharZero F] {p : F[X]} (p_irr : Irreducible p) (p_deg : p.natDegree.Prime) : p.natDegree ∣ Fintype.card p.Gal"
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Adds a `mainTheorems` array (0→1) to the **prime-degree divides Galois cardinality** (`angle-trisection-oq-02-oq-01-oq-01`) gallery entry.

Each entry is drawn directly from the entry's `.lean` source on `origin/main` with its exact Lean signature and `type` (`core`/`supporting`/`axiom`).

Structural enrichment only: fills the previously empty `mainTheorems` field. All other meta.json fields are byte-identical to `origin/main`; no Lean source changed.
