### PR TITLE
Enrich k-fold angle constructibility (angle-trisection-oq-05-oq-01): add mainTheorems (0->13)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-01/meta.json
@@ -180,6 +180,86 @@
     "path": "Proofs/AngleTrisectionOQ05OQ01.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "IsSmooth",
+      "type": "supporting",
+      "description": "A natural number n is p-smooth if it is positive and every prime factor is at most p.",
+      "leanType": "(p n : ℕ) : Prop := n > 0 ∧ ∀ q : ℕ, q.Prime → q ∣ n → q ≤ p"
+    },
+    {
+      "name": "smooth_mul",
+      "type": "supporting",
+      "description": "The product of two p-smooth numbers is again p-smooth.",
+      "leanType": "{p m n : ℕ} (hm : IsSmooth p m) (hn : IsSmooth p n) : IsSmooth p (m * n)"
+    },
+    {
+      "name": "IsKFoldConstructible",
+      "type": "core",
+      "description": "A degree d is k-fold origami constructible iff k ≥ 1 and d is foldPrimeBound(k)-smooth (all prime factors at most the (k+1)-th prime).",
+      "leanType": "(d k : ℕ) : Prop := k ≥ 1 ∧ IsSmooth (foldPrimeBound k) d"
+    },
+    {
+      "name": "foldPrimeBound",
+      "type": "supporting",
+      "description": "The prime bound for fold level k, defined as the (k+1)-th prime (0-indexed nth prime).",
+      "leanType": "(k : ℕ) : ℕ := Nat.nth Nat.Prime k"
+    },
+    {
+      "name": "strict_hierarchy_1_2",
+      "type": "core",
+      "description": "Degree 5 is 2-fold constructible but not 1-fold constructible, witnessing that 2-fold strictly extends 1-fold origami.",
+      "leanType": "IsKFoldConstructible 5 2 ∧ ¬ IsKFoldConstructible 5 1"
+    },
+    {
+      "name": "strict_hierarchy_2_3",
+      "type": "core",
+      "description": "Degree 7 is 3-fold constructible but not 2-fold constructible, witnessing that 3-fold strictly extends 2-fold origami.",
+      "leanType": "IsKFoldConstructible 7 3 ∧ ¬ IsKFoldConstructible 7 2"
+    },
+    {
+      "name": "strict_hierarchy_3_4",
+      "type": "core",
+      "description": "Degree 11 is 4-fold constructible but not 3-fold constructible, witnessing that 4-fold strictly extends 3-fold origami.",
+      "leanType": "IsKFoldConstructible 11 4 ∧ ¬ IsKFoldConstructible 11 3"
+    },
+    {
+      "name": "constructible_mono",
+      "type": "core",
+      "description": "Monotonicity of the hierarchy: any degree constructible with k folds is also constructible with k+1 folds.",
+      "leanType": "{d k : ℕ} (hk : k ≥ 1) (h : IsKFoldConstructible d k) : IsKFoldConstructible d (k + 1)"
+    },
+    {
+      "name": "eventually_constructible",
+      "type": "core",
+      "description": "Algebraic completeness: every positive degree d is k-fold constructible for some fold level k (take k = d).",
+      "leanType": "(d : ℕ) (hd : d > 0) : ∃ k : ℕ, k ≥ 1 ∧ IsKFoldConstructible d k"
+    },
+    {
+      "name": "fold_1_bound",
+      "type": "supporting",
+      "description": "The 1-fold prime bound is 3, recovering the classical 3-smooth characterization of single-fold origami.",
+      "leanType": "foldPrimeBound 1 = 3"
+    },
+    {
+      "name": "fold_2_bound",
+      "type": "supporting",
+      "description": "The 2-fold prime bound is 5, recovering the Alperin-Lang 5-smooth characterization of two-fold origami.",
+      "leanType": "foldPrimeBound 2 = 5"
+    },
+    {
+      "name": "degree_thirty_2fold",
+      "type": "supporting",
+      "description": "The composite degree 30 = 2·3·5 is 2-fold constructible.",
+      "leanType": "IsKFoldConstructible 30 2"
+    },
+    {
+      "name": "degree_fortytwo_3fold",
+      "type": "supporting",
+      "description": "The composite degree 42 = 2·3·7 is 3-fold constructible.",
+      "leanType": "IsKFoldConstructible 42 3"
+    }
+  ],
   "references": [
     {
       "authors": "Alperin, R.C. & Lang, R.J.",


### PR DESCRIPTION
Adds a `mainTheorems` array (0→13) to the **k-fold angle constructibility** (`angle-trisection-oq-05-oq-01`) gallery entry.

Each entry is drawn directly from the entry's `.lean` source on `origin/main` with its exact Lean signature and `type` (`core`/`supporting`/`axiom`).

Structural enrichment only: fills the previously empty `mainTheorems` field. All other meta.json fields are byte-identical to `origin/main`; no Lean source changed.
