### PR TITLE
Enrich erdos-236: add mainTheorems (0->10)

### DIFF
--- a/src/data/proofs/erdos-236/meta.json
+++ b/src/data/proofs/erdos-236/meta.json
@@ -137,6 +137,68 @@
     "path": "Proofs/Erdos236Problem.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "f",
+      "type": "core",
+      "description": "Counts the solutions to n = p + 2^k with p prime and k ≥ 0 as the number of exponents k for which n - 2^k is prime.",
+      "leanType": "(n : ℕ) : ℕ"
+    },
+    {
+      "name": "Erdos236_Conjecture",
+      "type": "core",
+      "description": "Formalizes Erdős Problem #236, the conjecture that f(n) = o(log n).",
+      "leanType": ": Prop"
+    },
+    {
+      "name": "f_trivial_upper_bound",
+      "type": "supporting",
+      "description": "Gives the trivial bound f(n) ≤ log₂(n) + 1.",
+      "leanType": "(n : ℕ) :\n    f n ≤ Nat.log2 n + 1"
+    },
+    {
+      "name": "f_nine",
+      "type": "supporting",
+      "description": "Verifies that f(9) = 2, since 9 = 7 + 2 = 5 + 4.",
+      "leanType": ": f 9 = 2"
+    },
+    {
+      "name": "f_fifteen",
+      "type": "supporting",
+      "description": "Verifies that f(15) = 3, since 15 = 13 + 2 = 11 + 4 = 7 + 8.",
+      "leanType": ": f 15 = 3"
+    },
+    {
+      "name": "HasAllPrimeProperty",
+      "type": "core",
+      "description": "States that n - 2^k is prime for all k with 1 < 2^k < n, capturing the rare all-prime numbers.",
+      "leanType": "(n : ℕ) : Prop"
+    },
+    {
+      "name": "fifteen_all_prime",
+      "type": "supporting",
+      "description": "Shows 15 has the all-prime property, since 15 - 2, 15 - 4, and 15 - 8 are all prime.",
+      "leanType": ": HasAllPrimeProperty 15"
+    },
+    {
+      "name": "twentyone_all_prime",
+      "type": "supporting",
+      "description": "Shows 21 has the all-prime property, since 21 - 2, 21 - 4, 21 - 8, and 21 - 16 are all prime.",
+      "leanType": ": HasAllPrimeProperty 21"
+    },
+    {
+      "name": "no_representation_iff_f_zero",
+      "type": "supporting",
+      "description": "Establishes that n has no p + 2^k representation exactly when f(n) = 0.",
+      "leanType": "(n : ℕ) :\n    ¬HasRepresentation n ↔ f n = 0"
+    },
+    {
+      "name": "summary",
+      "type": "supporting",
+      "description": "Bundles the key verified results: f(9) = 2, that 15 is all-prime, and a restatement of the main conjecture.",
+      "leanType": ":\n    f 9 = 2 ∧ HasAllPrimeProperty 15 ∧\n    (Erdos236_Conjecture ↔ (fun n => (f n : ℝ)) =o[atTop] (fun n => Real.log n))"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-141",


### PR DESCRIPTION
## Enrichment: add `mainTheorems`

Adds a structured `mainTheorems` array (10 declarations) to the gallery entry **Erdős Problem #236: Growth of Prime Plus Power Representations** (`erdos-236`), extracted directly from the Lean source `Proofs/Erdos236Problem.lean`.

- Breakdown: 3 core, 7 supporting, 0 axiom
- Every `name` verified to appear literally in the source; `leanType` signatures copied exactly (hypothesis order & notation preserved).
- Only the `mainTheorems` field is added — all other meta.json fields are byte-identical to `origin/main`.

Fills a previously empty `mainTheorems` field (0 → 10).
