### PR TITLE
Gallery integrity: abel-ruffini-oq-06-oq-01-oq-03 badge verified→mathlib

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06-oq-01-oq-03/meta.json
@@ -21,7 +21,7 @@
       "normal-subgroup",
       "quotient-group"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 104,


### PR DESCRIPTION
## Integrity Issue

**Proof**: abel-ruffini-oq-06-oq-01-oq-03
**Problem**: badge `verified` (Tier A) on a Mathlib-bridge entry whose core result is a direct specialization of a Mathlib theorem.

## Evidence

**meta.json claims**: `"badge": "verified"`

**Lean file shows** (`Proofs/AbelRuffiniOQ06OQ01OQ03.lean`): the headline theorem is a one-line wrapper —
```lean
theorem isSolvable_of_normal_of_quotient {G : Type*} [Group G] (N : Subgroup G) [N.Normal]
    [IsSolvable N] [IsSolvable (G ⧸ N)] : IsSolvable G :=
  solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
    (le_of_eq (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype]))
```
The core solvability closure comes from Mathlib's `solvable_of_ker_le_range`. Per auditor skill section 3 (Mathlib wrapper detection) and failure mode #5 ("0 sorries with hidden imports"), badge must be `mathlib`, not `verified`.

## Fix

`badge`: `verified` → `mathlib`. `status` stays `verified` (0 sorries, 0 axioms, fully machine-checked; `#print axioms` reports only propext/Classical.choice/Quot.sound). The description already transparently credits Mathlib, so no narrative changes are needed — only the badge tier is corrected.

Severity: MEDIUM.

---
Discovered during gallery integrity audit.