### PR TITLE
Enrich erdos-136: add mainTheorems (0->11)

### DIFF
--- a/src/data/proofs/erdos-136/meta.json
+++ b/src/data/proofs/erdos-136/meta.json
@@ -150,6 +150,74 @@
     "path": "Proofs/Erdos136Problem.lean",
     "sorries": 0
   },
+  "mainTheorems": [
+    {
+      "name": "erdos_136",
+      "type": "core",
+      "description": "Summary theorem bundling the asymptotic f(n)/n → 5/6 together with the original Erdős-Gyárfás bounds (5/6)(n-1) < f(n) < n.",
+      "leanType": ":\n    -- Asymptotic is 5/6\n    (Filter.Tendsto (fun n => (f n : ℝ) / n) Filter.atTop (nhds (5/6))) ∧\n    -- Original bounds hold\n    (∀ n : ℕ, n ≥ 4 → (f n : ℝ) > (5/6) * (n - 1)) ∧\n    (∀ n : ℕ, n ≥ 4 → (f n : ℕ) < n)"
+    },
+    {
+      "name": "bcdp_asymptotic",
+      "type": "axiom",
+      "description": "Bennett-Cushman-Dudek-Pralat (2022): f(n)/n tends to 5/6 as n → ∞.",
+      "leanType": ":\n    Filter.Tendsto (fun n => (f n : ℝ) / n) Filter.atTop (nhds (5/6))"
+    },
+    {
+      "name": "erdos_gyarfas_lower_bound",
+      "type": "axiom",
+      "description": "Erdős-Gyárfás lower bound: f(n) > (5/6)(n-1) for n ≥ 4.",
+      "leanType": ":\n    ∀ n : ℕ, n ≥ 4 → (f n : ℝ) > (5/6) * (n - 1)"
+    },
+    {
+      "name": "erdos_gyarfas_upper_bound",
+      "type": "axiom",
+      "description": "Erdős-Gyárfás upper bound: f(n) < n for n ≥ 4.",
+      "leanType": ":\n    ∀ n : ℕ, n ≥ 4 → (f n : ℕ) < n"
+    },
+    {
+      "name": "f",
+      "type": "supporting",
+      "description": "The Erdős-Gyárfás function f(n), defined as the least number of colors admitting a valid coloring with at least 5 colors in every K₄.",
+      "leanType": "(n : ℕ) : ℕ"
+    },
+    {
+      "name": "f_exists",
+      "type": "axiom",
+      "description": "For every n a valid edge coloring using some number of colors with at least 5 colors in every K₄ exists, guaranteeing f(n) is well-defined.",
+      "leanType": "(n : ℕ) : ∃ k : ℕ, ∃ c : EdgeColoring n k,\n    isValidColoring c ∧ hasAtLeast5ColorsInEveryK4 c"
+    },
+    {
+      "name": "hasAtLeast5ColorsInEveryK4",
+      "type": "supporting",
+      "description": "The property that every injectively-embedded K₄ uses at least 5 distinct edge colors.",
+      "leanType": "{n k : ℕ} (c : EdgeColoring n k) : Prop"
+    },
+    {
+      "name": "colorsInK4",
+      "type": "supporting",
+      "description": "The finset of the 6 edge colors appearing on an injectively-embedded K₄.",
+      "leanType": "{n k : ℕ} (c : EdgeColoring n k) (v : Fin 4 → Fin n)\n    (hInjective : Function.Injective v) : Finset (Fin k)"
+    },
+    {
+      "name": "EdgeColoring",
+      "type": "supporting",
+      "description": "An edge coloring of Kₙ as an assignment of one of k colors to each ordered pair of vertices.",
+      "leanType": "(n : ℕ) (k : ℕ)"
+    },
+    {
+      "name": "why_five_sixths",
+      "type": "supporting",
+      "description": "Elementary identity explaining the constant 5/6: 6-1=5 and 5/6 = 1 - 1/6.",
+      "leanType": ":\n    (6 : ℕ) - 1 = 5 ∧ (5 : ℚ) / 6 = 1 - 1/6"
+    },
+    {
+      "name": "k4_edges",
+      "type": "supporting",
+      "description": "K₄ has C(4,2) = 6 edges.",
+      "leanType": ": Nat.choose 4 2 = 6"
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-191",


### PR DESCRIPTION
## Enrichment: add `mainTheorems`

Adds a structured `mainTheorems` array (11 declarations) to the gallery entry **Erdős Problem #136: The Erdős-Gyárfás Function f(n,4,5)** (`erdos-136`), extracted directly from the Lean source `Proofs/Erdos136Problem.lean`.

- Breakdown: 1 core, 6 supporting, 4 axiom
- Every `name` verified to appear literally in the source; `leanType` signatures copied exactly (hypothesis order & notation preserved).
- Only the `mainTheorems` field is added — all other meta.json fields are byte-identical to `origin/main`.

Fills a previously empty `mainTheorems` field (0 → 11).
