### PR TITLE
Audit fix: badge original→mathlib for algebraic-numbers-countable-oq-02-oq-02-oq-03

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
       "baire-category",
       "descriptive-set-theory"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `algebraic-numbers-countable-oq-02-oq-02-oq-03` (Baire-Category Generalization: Perfect Complete Metric Spaces are Uncountable)

**Problem**: Mathlib wrapper claimed as `original` (MEDIUM severity).

## Evidence

The core theorem `perfect_nonempty_uncountable` obtains its result directly from Mathlib's `Perfect.exists_nat_bool_injection`:

```lean
theorem perfect_nonempty_uncountable ... : Uncountable ↥C := by
  obtain ⟨f, hrange, -, hinj⟩ := hC.exists_nat_bool_injection hne
  ...
```

`Perfect.exists_nat_bool_injection` performs the entire Cantor-scheme construction (the mathematical heavy lifting). It is listed first in `mathlibDependencies`, and the `assumptions`, `description`, and `proofStrategy` fields all openly credit it. The file's own contribution is the bridge (lifting the injection to the subtype + cardinality bookkeeping).

Per the auditor wrapper-detection rule, a proof whose main result is obtained by calling a Mathlib theorem is **Tier B** and must use `badge: "mathlib"`, not `"original"`.

## Fix

`meta.json`: `"badge": "original"` → `"badge": "mathlib"`. No other change. Still 0 sorries, 0 axioms, machine-checked; the only inaccuracy was the independence signal in the badge.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)