### PR TITLE
Enrich Baire uncountability (perfect complete metric spaces): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02-oq-03/annotations.json
@@ -62,20 +62,41 @@
   {
     "id": "ann-algcount-oq020203-04",
     "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
-    "range": { "startLine": 81, "endLine": 103 },
+    "range": { "startLine": 81, "endLine": 88 },
     "type": "theorem",
-    "title": "Main Theorem, Connected Corollary, and ℝ Recovered",
-    "content": "Three specializations close the file. `perfectSpace_uncountable` applies the core theorem to C := univ using `PerfectSpace.univ_perfect`, giving the whole-space statement: a nonempty complete metric space with no isolated points is uncountable. `uncountable_of_connected` needs no new topology — Mathlib's instance that a connected T1 space with two distinct points has no isolated points makes it definitionally the main theorem. Finally `real_uncountable` observes that ℝ is a complete, connected, nontrivial metric space, so uncountability follows in a single line — recovering the classical result of the sibling entries with no property of the real line beyond these three.",
-    "mathContext": "A connected $T_1$ space with $\\geq 2$ points is perfect (an isolated point would be clopen). $\\mathbb{R}$ is complete, connected, and nontrivial, hence perfect, hence uncountable.",
+    "title": "Main Theorem: Perfect Complete Metric Spaces are Uncountable",
+    "content": "`perfectSpace_uncountable` promotes the core set-level result to the whole space. It specializes C := univ, whose perfectness is exactly the `PerfectSpace` typeclass repackaged by `PerfectSpace.univ_perfect`, and univ is nonempty from the `Nonempty X` instance. The core theorem then hands back `Uncountable ↥(univ)`, which is definitionally `Uncountable X`. The proof is four lines: register the Cantor space's uncountability, extract the injection out of `(PerfectSpace.univ_perfect).exists_nat_bool_injection Set.univ_nonempty`, and close with `hinj.uncountable`. This is the headline statement of the entry — the point at which 'no isolated points' becomes 'uncountable' with no mention of ℝ.",
+    "mathContext": "Take $C = \\mathrm{univ}$: a `PerfectSpace` is one whose whole space has no isolated points, so `PerfectSpace.univ_perfect` gives `Perfect univ`, and $\\uparrow\\mathrm{univ} \\cong X$. Hence nonempty + complete + perfect $\\Rightarrow$ $\\mathrm{Uncountable}\\,X$.",
     "significance": "key",
     "relatedConcepts": [
       "PerfectSpace",
-      "connectedness implies perfect",
-      "ℝ uncountable"
+      "PerfectSpace.univ_perfect",
+      "perfect sets",
+      "complete metric spaces"
     ],
     "prerequisites": [
-      "PerfectSpace.univ_perfect",
-      "connected T1 spaces"
+      "the PerfectSpace typeclass",
+      "perfect sets in complete metric spaces"
+    ]
+  },
+  {
+    "id": "ann-algcount-oq020203-05",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-02-oq-03",
+    "range": { "startLine": 89, "endLine": 103 },
+    "type": "theorem",
+    "title": "Connected Corollary and ℝ Recovered in One Line",
+    "content": "The two payoff results need no new mathematics. `uncountable_of_connected` is literally `perfectSpace_uncountable` with a different hypothesis bundle: Mathlib supplies the instance that a connected `T1` space with at least two distinct points has no isolated points (an isolated point would be clopen, splitting the space), so `[ConnectedSpace X] [Nontrivial X]` already synthesizes `[PerfectSpace X]` and the corollary is a bare term-mode reference to the main theorem. `real_uncountable` is then a one-liner: ℝ is a complete, connected, nontrivial metric space, so all instances fire and `uncountable_of_connected` closes it — recovering the classical theorem of the sibling entries with no property of the real line beyond these three used anywhere.",
+    "mathContext": "A connected $T_1$ space with $\\geq 2$ points is perfect (an isolated point would be clopen, contradicting connectedness). $\\mathbb{R}$ is complete, connected, and nontrivial, hence perfect, hence uncountable — order and field structure never enter.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "connectedness implies perfect",
+      "T1 spaces",
+      "ℝ uncountable",
+      "instance resolution"
+    ],
+    "prerequisites": [
+      "connected T1 spaces",
+      "typeclass instance synthesis"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-02-oq-03` (Baire-Category Generalization: Perfect Complete Metric Spaces are Uncountable).

**Change (annotations.json only):** de-bundled the final annotation (which covered three distinct theorems across lines 81–103) into two focused, fully-enriched annotations, taking the coverage from 4 → 5 annotations:

- **`ann-...-04` (lines 81–88)** — the headline `perfectSpace_uncountable`: the whole-space form where "no isolated points" (`PerfectSpace`) becomes "uncountable", specializing the core theorem to `C := univ` via `PerfectSpace.univ_perfect`, with no mention of ℝ.
- **`ann-...-05` (lines 89–103)** — the two payoff results `uncountable_of_connected` (connected `T1` + `Nontrivial` synthesizes `PerfectSpace` by instance resolution, so the corollary is a bare reference to the main theorem) and `real_uncountable` (ℝ recovered in one line from completeness + connectedness + nontriviality).

Both new annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. All 5 annotations now have the full enrichment field set; line coverage (1–56, 58–66, 68–80, 81–88, 89–103) spans the whole 103-line file. No change to meta.json; no mathematical claims altered.
