### PR TITLE
Muirhead two-variable bunching step (amgm-oq-02-oq-02-oq-03): 0 axioms, 0 sorries

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ03.lean
@@ -1,0 +1,188 @@
+/-
+  Muirhead's Inequality via Majorization — The Two-Variable Bunching Step
+  Research: amgm-inequality-oq-02-oq-02-oq-03
+
+  The parent formalization `amgm-inequality-oq-02-oq-02`
+  (`Proofs.AmgmInequalityOQ02`, `Proofs.AmgmInequalityOQ02OQ02`) proves
+  Newton's log-concavity and the Maclaurin step Mₖ(x) ≥ Mₖ₊₁(x) for the
+  elementary symmetric means.  Maclaurin's chain is a special case of the
+  Muirhead / Hardy–Littlewood–Pólya inequality, which orders the power-sum
+  symmetric means
+
+      [a](x) = (1/n!) · Σ_{σ ∈ Sₙ} ∏ᵢ xᵢ^{a_{σ(i)}}
+
+  by *majorization* on the exponent vector a.  The open question OQ-03 asks
+  to formalize this majorization ordering.
+
+  The engine of Muirhead's theorem is the **atomic bunching step**: a single
+  "Robin-Hood" transfer between two coordinates, which is precisely the
+  two-variable inequality.  The full n-variable statement follows by iterating
+  this step along the sequence of T-transforms that carries the majorizing
+  vector down to the majorized one (Muirhead's lemma: a ⪰ b iff b is reachable
+  from a by finitely many such transfers).
+
+  This file proves that atomic step in full generality (0 axioms, 0 sorries),
+  isolating the single algebraic identity on which all of Muirhead rests:
+
+      x^{q+α} y^{q+β} + x^{q+β} y^{q+α}   ≤   x^{q+α+β} y^{q} + x^{q} y^{q+α+β}
+
+  which holds for all x, y ≥ 0 and all q, α, β ∈ ℕ because the difference
+  factors as
+
+      x^q y^q · (x^α − y^α)(x^β − y^β)  ≥  0.
+
+  Main results:
+  1. `same_sign_pow`      — (x^α − y^α)(x^β − y^β) ≥ 0 for x, y ≥ 0
+  2. `bunching_identity`  — the exact factorization above (pure `ring`)
+  3. `muirhead_swap`      — the atomic bunching inequality (unconditional)
+  4. `Majorizes2` / `muirhead_two_var`
+                          — two-variable Muirhead in majorization form
+  5. `amgm_two_var`, `muirhead_3_1_vs_2_2`
+                          — sample corollaries (AM–GM and a genuine transfer)
+
+  Scope note (honesty): this file settles the two-variable case only — the
+  atomic transfer that is the heart of Muirhead's theorem.  The general
+  n-variable Muirhead inequality, which composes these transfers via the
+  permutation-pairing argument, is left for a follow-up problem.
+
+  References:
+  - Hardy, Littlewood, Pólya "Inequalities" (1934) §2.18 (Muirhead's theorem)
+  - Muirhead, R. F. "Some methods applicable to identities and inequalities of
+    symmetric algebraic functions of n letters" (1903)
+  - AmgmInequalityOQ02OQ02.lean (Newton / Maclaurin parent)
+-/
+
+import Mathlib
+
+open Finset
+
+namespace MuirheadBunching
+
+/-!
+## Part I: Same-sign power products
+
+For non-negative `x, y` the two factors `x^α − y^α` and `x^β − y^β` always
+have the same sign (both determined by whether `x ≤ y`), so their product is
+non-negative.  This is the sole inequality input to the whole development.
+-/
+
+/-- For `x, y ≥ 0` and any natural exponents `α, β`, the product
+`(x^α − y^α)(x^β − y^β)` is non-negative: both factors share the sign of
+`x − y`. -/
+theorem same_sign_pow (x y : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (α β : ℕ) :
+    0 ≤ (x ^ α - y ^ α) * (x ^ β - y ^ β) := by
+  rcases le_total x y with h | h
+  · -- x ≤ y ⇒ both factors ≤ 0 ⇒ product ≥ 0
+    have hα : x ^ α ≤ y ^ α := by gcongr
+    have hβ : x ^ β ≤ y ^ β := by gcongr
+    nlinarith [hα, hβ]
+  · -- y ≤ x ⇒ both factors ≥ 0 ⇒ product ≥ 0
+    have hα : y ^ α ≤ x ^ α := by gcongr
+    have hβ : y ^ β ≤ x ^ β := by gcongr
+    nlinarith [hα, hβ]
+
+/-!
+## Part II: The bunching identity and the atomic swap
+
+The difference between the "more spread" pair `(q+α+β, q)` and the "less
+spread" pair `(q+α, q+β)` is an exact algebraic identity — no inequality yet.
+-/
+
+/-- The exact factorization underlying Muirhead's atomic step.  Pure algebra,
+closed by `ring` (which expands the natural-number exponent sums). -/
+theorem bunching_identity (x y : ℝ) (q α β : ℕ) :
+    x ^ (q + α + β) * y ^ q + x ^ q * y ^ (q + α + β)
+        - (x ^ (q + α) * y ^ (q + β) + x ^ (q + β) * y ^ (q + α))
+      = x ^ q * y ^ q * ((x ^ α - y ^ α) * (x ^ β - y ^ β)) := by
+  ring
+
+/-- **Atomic bunching inequality** (the engine of Muirhead's theorem).
+
+For `x, y ≥ 0` and any `q, α, β ∈ ℕ`, spreading the exponent pair from
+`(q+α, q+β)` out to `(q+α+β, q)` can only *increase* the symmetric sum:
+
+  `x^{q+α} y^{q+β} + x^{q+β} y^{q+α} ≤ x^{q+α+β} y^q + x^q y^{q+α+β}`.
+
+No ordering hypothesis on `α, β` is needed: the difference is a non-negative
+multiple of `same_sign_pow`. -/
+theorem muirhead_swap (x y : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) (q α β : ℕ) :
+    x ^ (q + α) * y ^ (q + β) + x ^ (q + β) * y ^ (q + α)
+      ≤ x ^ (q + α + β) * y ^ q + x ^ q * y ^ (q + α + β) := by
+  have key : 0 ≤ x ^ q * y ^ q * ((x ^ α - y ^ α) * (x ^ β - y ^ β)) :=
+    mul_nonneg (mul_nonneg (pow_nonneg hx q) (pow_nonneg hy q))
+      (same_sign_pow x y hx hy α β)
+  have hid := bunching_identity x y q α β
+  linarith [key, hid]
+
+/-!
+## Part III: Two-variable Muirhead in majorization form
+
+We package the atomic step as an honest majorization statement for pairs of
+natural exponents.  `Majorizes2 a b c d` says the ordered pair `(a, b)`
+majorizes `(c, d)`; the theorem then says the symmetric sum for the dominant
+pair is at least that for the dominated one.
+-/
+
+/-- `Majorizes2 a b c d` : the exponent pair `(a, b)` (with `a ≥ b`) majorizes
+the pair `(c, d)` (with `c ≥ d`).  For pairs of equal sum this is exactly
+`c ≤ a` (equivalently `max` dominates `max`). -/
+structure Majorizes2 (a b c d : ℕ) : Prop where
+  /-- the first pair is written largest-first -/
+  fst_ordered : b ≤ a
+  /-- the second pair is written largest-first -/
+  snd_ordered : d ≤ c
+  /-- majorization preserves the total -/
+  sum_eq : a + b = c + d
+  /-- the dominant coordinate of `(a,b)` dominates that of `(c,d)` -/
+  dom : c ≤ a
+
+/-- **Two-variable Muirhead inequality.**  If `(a, b)` majorizes `(c, d)`,
+then for all `x, y ≥ 0` the symmetric sum is monotone under majorization:
+
+  `x^c y^d + x^d y^c ≤ x^a y^b + x^b y^a`.
+
+Proof: with `b` the common minimum, write `c = b + α`, `d = b + β`,
+`a = b + α + β` and apply `muirhead_swap`. -/
+theorem muirhead_two_var (x y : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y)
+    {a b c d : ℕ} (h : Majorizes2 a b c d) :
+    x ^ c * y ^ d + x ^ d * y ^ c ≤ x ^ a * y ^ b + x ^ b * y ^ a := by
+  obtain ⟨hba, hdc, hsum, hca⟩ := h
+  -- `b` is the minimum of all four exponents
+  have hbd : b ≤ d := by omega
+  have hbc : b ≤ c := by omega
+  obtain ⟨α, hα⟩ := Nat.exists_eq_add_of_le hbc   -- c = b + α
+  obtain ⟨β, hβ⟩ := Nat.exists_eq_add_of_le hbd   -- d = b + β
+  subst hα hβ
+  have ha : a = b + α + β := by omega
+  subst ha
+  exact muirhead_swap x y hx hy b α β
+
+/-!
+## Part IV: Sample corollaries
+
+Concrete instances that fall straight out of the two-variable theorem,
+demonstrating that the majorization ordering has real content.
+-/
+
+/-- AM–GM for two variables as the majorization `(2, 0) ⪰ (1, 1)`:
+`2xy ≤ x² + y²`. -/
+theorem amgm_two_var (x y : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) :
+    2 * (x * y) ≤ x ^ 2 + y ^ 2 := by
+  have h := muirhead_two_var x y hx hy
+    (a := 2) (b := 0) (c := 1) (d := 1)
+    ⟨by norm_num, by norm_num, by norm_num, by norm_num⟩
+  simp only [pow_one, pow_zero, mul_one, one_mul] at h
+  linarith [h]
+
+/-- A genuine (non-degenerate) transfer, `(3, 1) ⪰ (2, 2)`:
+`2 x² y² ≤ x³ y + x y³`.  Here both pairs have positive minimum, so it is not
+reducible to a bare AM–GM. -/
+theorem muirhead_3_1_vs_2_2 (x y : ℝ) (hx : 0 ≤ x) (hy : 0 ≤ y) :
+    2 * (x ^ 2 * y ^ 2) ≤ x ^ 3 * y + x * y ^ 3 := by
+  have h := muirhead_two_var x y hx hy
+    (a := 3) (b := 1) (c := 2) (d := 2)
+    ⟨by norm_num, by norm_num, by norm_num, by norm_num⟩
+  simp only [pow_one] at h
+  linarith [h]
+
+end MuirheadBunching

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-amgm020203-intro",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "Setup: Muirhead's inequality and its atomic bunching step",
+    "content": "Muirhead's inequality orders the symmetric means [a](x) = (1/n!)·Σ_{σ∈Sₙ} ∏ᵢ xᵢ^{a_{σ(i)}} by majorization on the exponent vector a: for non-negative x, [a] ≥ [b] for all x iff a majorizes b (Hardy–Littlewood–Pólya §2.18). The parent formalization amgm-inequality-oq-02-oq-02 proves Newton's log-concavity and the Maclaurin chain M₁ ≥ ⋯ ≥ Mₙ, which is a special case; open question OQ-03 asks to formalize the majorization ordering. Its engine is a single 'Robin-Hood' transfer between two coordinates — the two-variable case. This file settles that atomic step in full generality (0 axioms, 0 sorries) and is explicit that only the two-variable case is closed here; the general n-variable statement, which composes transfers along a T-transform chain, is left for a follow-up."
+  },
+  {
+    "id": "ann-amgm020203-samesign",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 61, "endLine": 82 },
+    "type": "insight",
+    "title": "The one sign fact: (x^α − y^α)(x^β − y^β) ≥ 0",
+    "content": "same_sign_pow is the sole inequality input to the whole development. For x, y ≥ 0 the map t ↦ tⁿ is monotone, so both differences x^α − y^α and x^β − y^β carry the sign of x − y; their product is therefore non-negative regardless of how α and β compare. The proof is a le_total x y split: in each branch gcongr supplies the two power comparisons (discharging the base non-negativity from x, y ≥ 0) and nlinarith multiplies the same-sign factors. Everything downstream is exact algebra layered on this single monotonicity."
+  },
+  {
+    "id": "ann-amgm020203-identity",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 84, "endLine": 106 },
+    "type": "proof-step",
+    "title": "Exact factorization of the bunching difference",
+    "content": "bunching_identity records that the difference between the more-spread pair (q+α+β, q) and the less-spread pair (q+α, q+β) is not merely bounded but factors exactly: x^(q+α+β)·y^q + x^q·y^(q+α+β) − (x^(q+α)·y^(q+β) + x^(q+β)·y^(q+α)) = x^q·y^q·(x^α − y^α)(x^β − y^β). It is closed by a single `ring`, which normalizes the natural-number exponent sums via pow_add. This is what lets the analysis (one sign lemma) and the algebra (one ring identity) be completely separated."
+  },
+  {
+    "id": "ann-amgm020203-swap",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 108, "endLine": 116 },
+    "type": "key-theorem",
+    "title": "muirhead_swap — the atomic transfer inequality",
+    "content": "The engine of Muirhead's theorem: for x, y ≥ 0 and any q, α, β ∈ ℕ, spreading the exponent pair from (q+α, q+β) out to (q+α+β, q) increases the symmetric sum. The prefactor x^q·y^q is non-negative (pow_nonneg) and the bracket is non-negative (same_sign_pow), so by bunching_identity the difference is ≥ 0 and linarith closes the goal. No ordering hypothesis on α, β is needed — the direction of the inequality is built into the factorization. Every case of Muirhead's inequality is an iterate of this one step."
+  },
+  {
+    "id": "ann-amgm020203-majorizes",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 117, "endLine": 158 },
+    "type": "key-theorem",
+    "title": "muirhead_two_var — the swap as a majorization theorem",
+    "content": "The Majorizes2 a b c d structure records that the ordered pair (a,b) majorizes (c,d): both pairs written largest-first, equal total a+b = c+d, and dominant coordinate c ≤ a. muirhead_two_var then gives x^c·y^d + x^d·y^c ≤ x^a·y^b + x^b·y^a. The derivation identifies b as the common minimum of the four exponents (omega from the majorization data), writes c = b+α and d = b+β via Nat.exists_eq_add_of_le, and computes a = b+α+β (omega), after which the goal is literally muirhead_swap x y hx hy b α β."
+  },
+  {
+    "id": "ann-amgm020203-corollaries",
+    "proofId": "amgm-inequality-oq-02-oq-02-oq-03",
+    "range": { "startLine": 160, "endLine": 188 },
+    "type": "context",
+    "title": "Corollaries: AM–GM and a genuine transfer",
+    "content": "amgm_two_var instantiates the majorization (2,0) ⪰ (1,1) to recover the two-variable AM–GM 2xy ≤ x² + y² — the extreme case where the minority exponent drops to 0. muirhead_3_1_vs_2_2 instantiates the non-degenerate transfer (3,1) ⪰ (2,2) to obtain 2x²y² ≤ x³y + xy³; because both pairs have a positive minimum exponent this is a strictly two-variable Muirhead inequality, not a rescaled AM–GM. Both discharge the Majorizes2 hypothesis by norm_num and simplify powers before linarith, demonstrating that the majorization ordering has content of its own."
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "amgm-inequality-oq-02-oq-02-oq-03",
+  "title": "Muirhead's Inequality: The Two-Variable Bunching Step",
+  "slug": "amgm-inequality-oq-02-oq-02-oq-03",
+  "description": "The atomic majorization step underlying Muirhead's inequality — a single Robin-Hood transfer on two coordinates. For x, y ≥ 0 and any q, α, β ∈ ℕ, spreading the exponent pair (q+α, q+β) out to (q+α+β, q) can only increase the symmetric sum, because the difference factors exactly as x^q·y^q·(x^α − y^α)(x^β − y^β) ≥ 0. Packaged as a majorization theorem for pairs, with AM–GM and a genuine (3,1)⪰(2,2) transfer as corollaries. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Muirhead%27s_inequality",
+    "date": "Classical result (Muirhead 1903; Hardy–Littlewood–Pólya 1934); formalized 2026",
+    "status": "verified",
+    "tags": [
+      "inequalities",
+      "symmetric-polynomials",
+      "muirhead",
+      "majorization",
+      "maclaurin",
+      "am-gm"
+    ],
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ02OQ03.lean",
+    "additionalFiles": [],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 6 theorems verified with 0 sorries and 0 axioms (standard Lean axioms propext / Classical.choice / Quot.sound only). Self-contained: imports only Mathlib.",
+    "originalContributions": [
+      "same_sign_pow: (x^α − y^α)(x^β − y^β) ≥ 0 for x, y ≥ 0 — both factors share the sign of x − y, proved by a le_total split with gcongr monotonicity",
+      "bunching_identity: the exact factorization x^(q+α+β)·y^q + x^q·y^(q+α+β) − (x^(q+α)·y^(q+β) + x^(q+β)·y^(q+α)) = x^q·y^q·(x^α − y^α)(x^β − y^β), closed by ring over natural-number exponent sums",
+      "muirhead_swap: the atomic bunching inequality x^(q+α)·y^(q+β) + x^(q+β)·y^(q+α) ≤ x^(q+α+β)·y^q + x^q·y^(q+α+β), holding unconditionally in α, β via same_sign_pow and the identity",
+      "Majorizes2 (structure) + muirhead_two_var: two-variable Muirhead in honest majorization form — if the ordered pair (a,b) majorizes (c,d) (equal sum, c ≤ a) then x^c·y^d + x^d·y^c ≤ x^a·y^b + x^b·y^a; derived from muirhead_swap by writing the common minimum as b and c = b+α, d = b+β, a = b+α+β",
+      "amgm_two_var: AM–GM for two variables as the majorization (2,0) ⪰ (1,1), giving 2xy ≤ x² + y²",
+      "muirhead_3_1_vs_2_2: a non-degenerate transfer (3,1) ⪰ (2,2), i.e. 2x²y² ≤ x³y + xy³, not reducible to a bare AM–GM since both pairs have positive minimum"
+    ],
+    "dateAdded": "2026-07-04",
+    "lineCount": 188,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "problemStatement": "**Muirhead's inequality via majorization.** For an exponent vector a = (a₁,…,aₙ) the symmetric mean is [a](x) = (1/n!)·Σ_{σ∈Sₙ} ∏ᵢ xᵢ^{a_{σ(i)}}. Muirhead's theorem (Hardy–Littlewood–Pólya §2.18) states that for non-negative x, [a](x) ≥ [b](x) for all x iff a majorizes b. The parent problem (amgm-inequality-oq-02-oq-02) proves Newton's log-concavity and the Maclaurin chain M₁ ≥ ⋯ ≥ Mₙ, which is a special case of Muirhead; open question OQ-03 asks to formalize the majorization ordering itself. Its engine is a single 'Robin-Hood' transfer between two coordinates — the two-variable case settled here.",
+    "proofStrategy": "The whole development rests on one algebraic identity. The difference between the more-spread pair (q+α+β, q) and the less-spread pair (q+α, q+β) factors exactly as x^q·y^q·(x^α − y^α)(x^β − y^β) (`bunching_identity`, pure `ring`). The scalar prefactor x^q·y^q is non-negative, and the bracket is non-negative because both factors x^α − y^α and x^β − y^β carry the sign of x − y (`same_sign_pow`, a `le_total` split closed by `gcongr` + `nlinarith`). Multiplying gives the atomic swap `muirhead_swap` with no ordering hypothesis on α, β. To state it as a majorization theorem (`muirhead_two_var`) the common minimum of the four exponents is identified as b, and c, d, a are written as b + α, b + β, b + α + β via `Nat.exists_eq_add_of_le` and `omega`, reducing the goal verbatim to `muirhead_swap`.",
+    "keyInsights": [
+      "Muirhead's theorem, however it is stated, reduces to a single scalar fact: for x, y ≥ 0 and naturals α, β, the product (x^α − y^α)(x^β − y^β) is non-negative because both factors are monotone in the same direction. Everything else is bookkeeping.",
+      "The bunching difference is an *exact* factorization, not merely a bound — so `ring` proves the identity and the only genuine inequality input is the one-line sign lemma. This cleanly separates the algebra from the analysis.",
+      "The atomic swap needs no hypothesis relating α and β: (x^α − y^α)(x^β − y^β) ≥ 0 regardless of which exponent is larger, so the direction of Muirhead's inequality is built into the factorization rather than assumed.",
+      "The (3,1) ⪰ (2,2) corollary shows the ordering has content beyond AM–GM: because both pairs have a positive minimum exponent, x³y + xy³ ≥ 2x²y² is a strictly-two-variable Muirhead transfer, not a rescaled instance of x² + y² ≥ 2xy."
+    ],
+    "historicalContext": "Robert Franklin Muirhead introduced the majorization ordering on exponent vectors in 1903, and Hardy, Littlewood and Pólya gave it its canonical treatment in *Inequalities* (1934, §2.18), showing a ⪰ b is exactly the condition for the symmetric-mean inequality [a] ≥ [b] to hold for all non-negative inputs. The proof proceeds by decomposing majorization into finitely many elementary transfers (T-transforms), each of which is the two-variable bunching step formalized here. Maclaurin's chain of means and the classical AM–GM inequality are both special cases obtained by choosing particular exponent vectors, tying this entry back to the parent Maclaurin formalization."
+  },
+  "references": [
+    {
+      "authors": "Muirhead, Robert F.",
+      "title": "Some methods applicable to identities and inequalities of symmetric algebraic functions of n letters",
+      "year": "1903",
+      "venue": "Proceedings of the Edinburgh Mathematical Society 21, 144–157",
+      "note": "Introduces the majorization ordering on exponent vectors and the symmetric-function inequality now bearing Muirhead's name; the elementary transfer step decomposed here is Muirhead's basic move."
+    },
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "§2.18 states and proves Muirhead's theorem: [a] ≥ [b] for all non-negative x iff a majorizes b, via reduction to elementary transfers. §2.22 develops the Newton/Maclaurin special cases."
+    },
+    {
+      "authors": "Marshall, A. W.; Olkin, I.; Arnold, B. C.",
+      "title": "Inequalities: Theory of Majorization and Its Applications",
+      "year": "2011",
+      "venue": "Springer (2nd ed.)",
+      "note": "Modern reference on majorization; Chapter 1 gives the T-transform decomposition (a ⪰ b iff b is reachable from a by finitely many Robin-Hood transfers) that lifts the two-variable step proved here to the general n-variable Muirhead inequality."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Answers open question OQ-03: the Muirhead majorization ordering that generalizes the parent's Newton log-concavity and Maclaurin step. This entry settles the atomic two-variable transfer on which Muirhead's theorem is built."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "ancestor",
+      "description": "The Maclaurin mean chain M₁ ≥ ⋯ ≥ Mₙ is a special case of Muirhead's inequality obtained from a particular family of exponent vectors."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "ancestor",
+      "description": "AM ≥ GM is the Muirhead instance (1,0,…,0) ⪰ (1/n,…,1/n); its two-variable form 2xy ≤ x² + y² is derived here as the corollary amgm_two_var from the majorization (2,0) ⪰ (1,1)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "muirhead_swap",
+      "type": "core",
+      "statement": "$\\forall x, y \\ge 0,\\ \\forall q, \\alpha, \\beta \\in \\mathbb{N},\\quad x^{q+\\alpha} y^{q+\\beta} + x^{q+\\beta} y^{q+\\alpha} \\ \\le\\ x^{q+\\alpha+\\beta} y^{q} + x^{q} y^{q+\\alpha+\\beta}$",
+      "significance": "**The engine of Muirhead's theorem.** A single Robin-Hood transfer: spreading the exponent pair from (q+α, q+β) to (q+α+β, q) increases the symmetric sum. Holds unconditionally in α, β because the difference equals x^q·y^q·(x^α − y^α)(x^β − y^β) ≥ 0. Every case of Muirhead's inequality is an iterate of this step."
+    },
+    {
+      "name": "bunching_identity",
+      "type": "supporting",
+      "statement": "$x^{q+\\alpha+\\beta} y^{q} + x^{q} y^{q+\\alpha+\\beta} - \\bigl(x^{q+\\alpha} y^{q+\\beta} + x^{q+\\beta} y^{q+\\alpha}\\bigr) = x^{q} y^{q}\\,(x^{\\alpha} - y^{\\alpha})(x^{\\beta} - y^{\\beta})$",
+      "significance": "The exact algebraic factorization underlying the swap — pure `ring` over natural-number exponent sums. It reduces the entire inequality to the single sign fact `same_sign_pow`, cleanly separating algebra from analysis."
+    },
+    {
+      "name": "same_sign_pow",
+      "type": "supporting",
+      "statement": "$\\forall x, y \\ge 0,\\ \\forall \\alpha, \\beta \\in \\mathbb{N},\\quad 0 \\le (x^{\\alpha} - y^{\\alpha})(x^{\\beta} - y^{\\beta})$",
+      "significance": "The sole inequality input to the development: both factors carry the sign of x − y, so their product is non-negative. Proved by a `le_total` split with `gcongr` monotonicity of `x ↦ xⁿ`."
+    },
+    {
+      "name": "muirhead_two_var",
+      "type": "core",
+      "statement": "$\\text{Majorizes2}(a,b,c,d) \\Rightarrow \\forall x, y \\ge 0,\\quad x^{c} y^{d} + x^{d} y^{c} \\ \\le\\ x^{a} y^{b} + x^{b} y^{a}$",
+      "significance": "**Two-variable Muirhead in majorization form.** If the exponent pair (a,b) majorizes (c,d) (equal total, dominant coordinate c ≤ a), the symmetric sum is monotone under majorization. Obtained from `muirhead_swap` by writing the common minimum as b and c = b+α, d = b+β, a = b+α+β."
+    },
+    {
+      "name": "amgm_two_var",
+      "type": "corollary",
+      "statement": "$\\forall x, y \\ge 0,\\quad 2xy \\le x^{2} + y^{2}$",
+      "significance": "AM–GM for two variables realized as the majorization (2,0) ⪰ (1,1) — the extreme instance where the minority exponent drops to 0."
+    },
+    {
+      "name": "muirhead_3_1_vs_2_2",
+      "type": "corollary",
+      "statement": "$\\forall x, y \\ge 0,\\quad 2x^{2}y^{2} \\le x^{3}y + xy^{3}$",
+      "significance": "A genuine non-degenerate transfer (3,1) ⪰ (2,2): both pairs have positive minimum exponent, so this is a strictly two-variable Muirhead inequality, not a rescaled AM–GM."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "MuirheadBunching",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/AmgmInequalityOQ02OQ02OQ03.lean",
+    "additionalFiles": [],
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "overview-setup",
+      "title": "Overview and setup",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Header docstring placing the entry in the Muirhead/majorization hierarchy: the parent `Proofs.AmgmInequalityOQ02OQ02` proves Newton log-concavity and the Maclaurin step, a special case of Muirhead's inequality; OQ-03 asks for the majorization ordering, whose engine is the two-variable bunching step formalized here. States the target identity and inequality, includes an honesty note that only the two-variable case is settled, and enters namespace `MuirheadBunching`."
+    },
+    {
+      "id": "same-sign-pow",
+      "title": "Part I: Same-sign power products",
+      "startLine": 61,
+      "endLine": 82,
+      "summary": "`same_sign_pow`: for x, y ≥ 0 and naturals α, β, (x^α − y^α)(x^β − y^β) ≥ 0. A `le_total x y` split; in each branch `gcongr` gives the two monotone power comparisons (using x, y ≥ 0) and `nlinarith` multiplies out the same-sign factors. This is the only inequality input to the whole file."
+    },
+    {
+      "id": "bunching-swap",
+      "title": "Part II: The bunching identity and the atomic swap",
+      "startLine": 84,
+      "endLine": 116,
+      "summary": "`bunching_identity` establishes the exact factorization of the spread-minus-unspread difference as x^q·y^q·(x^α − y^α)(x^β − y^β), closed by `ring` (which expands the natural-number exponent sums via pow_add). `muirhead_swap` combines this identity with the non-negativity of the prefactor (`pow_nonneg`) and the bracket (`same_sign_pow`) through `linarith`, giving the atomic transfer inequality with no ordering hypothesis on α, β."
+    },
+    {
+      "id": "majorization-two-var",
+      "title": "Part III: Two-variable Muirhead in majorization form",
+      "startLine": 117,
+      "endLine": 158,
+      "summary": "The `Majorizes2 a b c d` structure records that the ordered pair (a,b) majorizes (c,d): both pairs largest-first, equal total a+b = c+d, and dominant coordinate c ≤ a. `muirhead_two_var` derives the symmetric-sum inequality: from the majorization data `omega` shows b is the common minimum, `Nat.exists_eq_add_of_le` writes c = b+α, d = b+β, and `omega` gives a = b+α+β, reducing the goal verbatim to `muirhead_swap`."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part IV: Sample corollaries",
+      "startLine": 160,
+      "endLine": 188,
+      "summary": "`amgm_two_var` instantiates the majorization (2,0) ⪰ (1,1) to recover 2xy ≤ x² + y² (two-variable AM–GM), and `muirhead_3_1_vs_2_2` instantiates the non-degenerate transfer (3,1) ⪰ (2,2) to obtain 2x²y² ≤ x³y + xy³. Both discharge the `Majorizes2` hypothesis by `norm_num` and simplify the resulting powers before `linarith`."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof of the two-variable Muirhead / bunching inequality — the atomic majorization transfer on which the general Muirhead theorem is built. The development isolates a single algebraic identity (the spread-minus-unspread difference factors as x^q·y^q·(x^α − y^α)(x^β − y^β)) so that the only inequality input is the one-line sign lemma same_sign_pow. It is packaged as an honest majorization statement for pairs (muirhead_two_var) with AM–GM and a non-degenerate (3,1) ⪰ (2,2) transfer as corollaries.",
+    "implications": "This provides the elementary transfer step that, iterated along the T-transform decomposition of a majorization, yields the full n-variable Muirhead inequality — the natural generalization of the parent's Maclaurin chain. The clean identity-plus-sign structure means the two-variable case carries all the analytic content; what remains for the general case is purely combinatorial.",
+    "openQuestions": [
+      "**General n-variable Muirhead.** Lift the atomic swap to arbitrary exponent vectors: prove [a](x) ≥ [b](x) for all non-negative x whenever a majorizes b, by pairing each permutation σ with σ∘(i j) on the two transferred coordinates and applying muirhead_swap termwise, then iterating over the finite chain of T-transforms carrying a down to b (Marshall–Olkin–Arnold, Ch. 1).",
+      "**Muirhead ⟹ Maclaurin.** Instantiate the general inequality at the specific exponent vectors that produce the Maclaurin means, recovering the parent's chain M₁ ≥ ⋯ ≥ Mₙ as a corollary of majorization and closing the loop with amgm-inequality-oq-02-oq-02.",
+      "**Equality case.** Characterize when muirhead_swap is an equality — precisely when x = y or α = 0 or β = 0 — and propagate this to the two-variable Muirhead equality condition, mirroring the Maclaurin equality analysis in the sibling entry amgm-inequality-oq-02-oq-02-oq-02."
+    ]
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Formalizes the **atomic majorization transfer** underlying Muirhead's inequality (Hardy–Littlewood–Pólya §2.18) — the generalization of the parent Maclaurin chain (`amgm-inequality-oq-02-oq-02`, open question OQ-03). Fully verified: **0 axioms, 0 sorries**.

The whole development rests on a single exact factorization:

```
x^(q+α+β)·y^q + x^q·y^(q+α+β) − (x^(q+α)·y^(q+β) + x^(q+β)·y^(q+α))
    = x^q·y^q·(x^α − y^α)(x^β − y^β)  ≥  0
```

so the only inequality input is the one-line sign lemma `same_sign_pow`; the rest is `ring` + `linarith`.

## Results (`Proofs/AmgmInequalityOQ02OQ02OQ03.lean`, 6 theorems + 1 structure)

- `same_sign_pow` — `(x^α − y^α)(x^β − y^β) ≥ 0` for `x, y ≥ 0`
- `bunching_identity` — the exact factorization (pure `ring`)
- `muirhead_swap` — the atomic bunching inequality, **unconditional** in α, β
- `Majorizes2` + `muirhead_two_var` — two-variable Muirhead in honest majorization form
- `amgm_two_var` — AM–GM as `(2,0) ⪰ (1,1)`
- `muirhead_3_1_vs_2_2` — a non-degenerate transfer `(3,1) ⪰ (2,2)`, i.e. `2x²y² ≤ x³y + xy³`

## Scope / honesty

This settles the **two-variable case only** — the atomic transfer that is the heart of Muirhead's theorem. The general n-variable inequality (composing transfers along a T-transform chain) is spawned as a follow-up open question in the entry's conclusion.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ03` → builds clean (7743 jobs)
- `pnpm build` → gallery builds; new entry `amgm-inequality-oq-02-oq-02-oq-03` renders
- `grep sorry/axiom/native_decide` → none

🤖 Generated with [Claude Code](https://claude.com/claude-code)