### PR TITLE
Enrich Kummer/Legendre carry-count: de-bundle central-binomial annotation 4→5

### DIFF
--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-01/annotations.json
@@ -71,20 +71,43 @@
     "proofId": "legendre-factorial-formula-oq-01-oq-01",
     "range": {
       "startLine": 82,
-      "endLine": 115
+      "endLine": 93
     },
     "type": "theorem",
-    "title": "Central Binomial Coefficient and Worked Instance",
-    "content": "Specialising to C(2n,n) makes both summands equal: `padicValNat_centralBinom_eq_carryCount` proves vₚ(C(2n,n)) = carryCount p n n b (the carries in the self-addition n + n), by unfolding centralBinom n to (2n).choose n, running the factorization_choose bridge with k = n, and rewriting 2n − n = n. The divisibility form `prime_dvd_centralBinom_iff_carryCount_pos` (via Nat.centralBinom_pos) recovers the classical fact that any prime n < p ≤ 2n forces a carry (since n mod p = n and p ≤ 2n = n + n), hence divides C(2n,n) — the engine behind Erdős's elementary Bertrand-postulate proof. The instance v₂(C(4,2)) = 1 (adding 2 + 2 = 100₂ carries once) is checked by kernel decide on the concrete Finset filter card.",
-    "mathContext": "$v_p\\!\\binom{2n}{n} = \\#\\{\\text{carries in } n+n \\text{ base } p\\}; \\qquad n < p \\le 2n \\implies p \\mid \\binom{2n}{n}.$",
+    "title": "Central Binomial Coefficient: Valuation as a Self-Addition Carry Count",
+    "content": "Specialising to the central binomial coefficient C(2n,n) makes both Kummer summands equal, so the two addends of the base-p sum coincide: `padicValNat_centralBinom_eq_carryCount` proves vₚ(C(2n,n)) = carryCount p n n b — the number of carries in the base-p *self*-addition n + n. The proof unfolds centralBinom n to (2n).choose n, runs the same factorization_choose bridge as the headline with k := n, rewrites 2n − n = n, and closes by rfl. The bound is b > log p (2n), the log now taken at 2n rather than n to cover the larger argument.",
+    "mathContext": "$v_p\\!\\binom{2n}{n} = \\#\\{\\text{carries in the base-}p\\text{ self-addition } n+n\\} = \\mathrm{carryCount}\\,p\\,n\\,n\\,b, \\qquad b > \\log_p(2n).$",
     "significance": "supporting",
     "relatedConcepts": [
       "central binomial coefficient",
-      "Bertrand's postulate",
-      "kernel decide"
+      "self-addition carries",
+      "Nat.centralBinom"
     ],
     "prerequisites": [
       "Nat.centralBinom",
+      "carry count"
+    ]
+  },
+  {
+    "id": "legendre-fact-oq01-oq01-ann-central-dvd",
+    "proofId": "legendre-factorial-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Divisibility of C(2n,n): the Bertrand-Postulate Engine",
+    "content": "`prime_dvd_centralBinom_iff_carryCount_pos` turns the valuation into a divisibility test: p ∣ C(2n,n) ⟺ 0 < carryCount p n n b, proved (via Nat.centralBinom_pos to get C(2n,n) ≠ 0) by the same dvd_iff_one_le_factorization / factorization_def rewrite chain closed by omega. This recovers the classical fact that *every* prime in the half-open range (n, 2n] divides C(2n,n): for such a p, n mod p = n and p ≤ 2n = n + n, so the self-addition carries at least once. That divisibility is exactly the arithmetic lever in Erdős's elementary proof of Bertrand's postulate (a prime always lies in (n, 2n]). The worked instance v₂(C(4,2)) = 1 — adding 2 + 2 = 100₂ carries once, out of the units place into the fours place — is verified by kernel `decide` on the concrete Finset.filter cardinality, tying the abstract count to a computation.",
+    "mathContext": "$p \\mid \\binom{2n}{n} \\iff \\text{the base-}p\\text{ addition } n+n \\text{ carries}; \\qquad n < p \\le 2n \\implies p \\mid \\binom{2n}{n}$ — the divisibility fact underlying Bertrand's postulate.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bertrand's postulate",
+      "Erdős's proof",
+      "Nat.centralBinom_pos",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "Nat.Prime.dvd_iff_one_le_factorization",
       "Nat.centralBinom_pos"
     ]
   }


### PR DESCRIPTION
Enrichment pass for `legendre-factorial-formula-oq-01-oq-01` (Kummer's theorem as a base-p carry count).

**Change (annotations.json only):** the final annotation bundled three distinct results across lines 82–115 — the central-binomial valuation formula, its divisibility criterion, and a worked `decide` instance. De-bundled into two focused, fully-enriched annotations (4 → 5 total):

- **`...-ann-central` (lines 82–93)** — `padicValNat_centralBinom_eq_carryCount`: v_p(C(2n,n)) = carries in the base-p *self*-addition n+n.
- **`...-ann-central-dvd` (lines 94–115)** — `prime_dvd_centralBinom_iff_carryCount_pos`: the divisibility test p ∣ C(2n,n) ⟺ a carry occurs, from which every prime in (n, 2n] divides C(2n,n) — the arithmetic lever in Erdős's elementary proof of Bertrand's postulate — plus the worked instance v₂(C(4,2)) = 1 verified by kernel `decide`.

Both new annotations carry `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`; all 5 annotations now have the full field set and coverage spans the whole file (1–48, 49–64, 65–81, 82–93, 94–115). No change to meta.json; no mathematical claims altered.
