### PR TITLE
pipeline: harden anti-churn reap/guard (Judge follow-ups for #33943)

### DIFF
--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -558,7 +558,11 @@ That is wasted effort. **Do not open such a PR.**
 Run the guard before creating the PR:
 
 ```bash
-verdict=$("$REPO_ROOT/scripts/research/check-superseded.sh" --base origin/main --quiet | tail -1)
+# The `|| echo ""` guard matters: check-superseded.sh exits non-zero on a
+# SUPERSEDED verdict (exit 3) or a git error, which under `set -o pipefail` +
+# `set -e` would otherwise abort your session here before the `if` runs. The
+# guard ensures $verdict is always assigned so the `if` below does the deciding.
+verdict=$("$REPO_ROOT/scripts/research/check-superseded.sh" --base origin/main --quiet | tail -1 || echo "")
 if [[ "$verdict" == "SUPERSEDED" ]]; then
   echo "$(date +%H:%M): ABORT — $PROBLEM_ID already formalized on main (add/add). Not opening PR." \
     >> "$REPO_ROOT/.loom/logs/$RESEARCHER_ID.actions.log"

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -355,23 +355,33 @@ merge_prs() {
         # same-problem race between two agents. No rebase can ever land it; close
         # it so the backlog drains instead of accumulating dead duplicates.
         if [[ -x "$REPO_ROOT/scripts/research/check-superseded.sh" ]]; then
-            git fetch origin "$branch" --quiet 2>/dev/null || true
-            local sup_verdict
-            sup_verdict=$("$REPO_ROOT/scripts/research/check-superseded.sh" \
-                --ref FETCH_HEAD --base origin/main --quiet 2>/dev/null | tail -1 || echo "")
-            if [[ "$sup_verdict" == "SUPERSEDED" ]]; then
-                if $DRY_RUN; then
-                    echo "  Would close #$pr as superseded (proof file already on main)"
-                else
-                    print_warning "Closing #$pr as superseded — proof file already on main (add/add duplicate)"
-                    gh pr close "$pr" --delete-branch --comment "Closing as **superseded** — automated race-condition cleanup by the deployer.
+            # Fetch the PR head into an explicit ref rather than relying on
+            # FETCH_HEAD (issue #34555): a swallowed fetch failure would otherwise
+            # leave FETCH_HEAD pointing at a *previous* branch, so the check would
+            # silently compare the wrong tree. Only run the reap check when this
+            # fetch actually succeeds; on failure, fall through to the rebase path.
+            local reap_ref="refs/tmp/reap-check-$pr"
+            if git fetch origin "$branch:$reap_ref" --force --quiet 2>/dev/null; then
+                local sup_verdict
+                sup_verdict=$("$REPO_ROOT/scripts/research/check-superseded.sh" \
+                    --ref "$reap_ref" --base origin/main --quiet 2>/dev/null | tail -1 || echo "")
+                git update-ref -d "$reap_ref" 2>/dev/null || true
+                if [[ "$sup_verdict" == "SUPERSEDED" ]]; then
+                    if $DRY_RUN; then
+                        echo "  Would close #$pr as superseded (proof file already on main)"
+                    else
+                        print_warning "Closing #$pr as superseded — proof file already on main (add/add duplicate)"
+                        gh pr close "$pr" --delete-branch --comment "Closing as **superseded** — automated race-condition cleanup by the deployer.
 
 Every new proof file this PR adds already exists on \`main\` (landed via a competing PR that won the merge race). This branch is an unmergeable add/add duplicate of an already-formalized result, so no rebase can land it.
 
-If you believe this version carries unique content main lacks, reopen and rebase onto main. See the pre-submission guard (\`scripts/research/check-superseded.sh\`) that now prevents most of these." 2>/dev/null \
-                        && print_success "Closed superseded #$pr" || print_warning "Could not close #$pr"
+This branch has been deleted. If you believe this version carries unique content \`main\` lacks, re-push the branch and open a fresh PR rebased onto \`main\`. See the pre-submission guard (\`scripts/research/check-superseded.sh\`) that now prevents most of these." 2>/dev/null \
+                            && print_success "Closed superseded #$pr" || print_warning "Could not close #$pr"
+                    fi
+                    continue
                 fi
-                continue
+            else
+                print_warning "  Could not fetch $branch for reap check on #$pr; proceeding to rebase"
             fi
         fi
 


### PR DESCRIPTION
Sweeps the three non-blocking findings from the Loom Judge review of #33943 into one hardening PR.

## Fixes

**#34554 — researcher guard could abort early** (`.lean/roles/researcher.md` Step 5.5)
The pre-submission supersession guard now uses `| tail -1 || echo ""`, matching the deployer. Without it, a non-zero exit from `check-superseded.sh` (exit 3 = SUPERSEDED, or a git error) could abort the research session under `set -o pipefail` + `set -e` before the `if` ran. Now `$verdict` is always assigned and the `if` does the deciding.

**#34555 — deployer reap could compare the wrong tree** (`scripts/deploy/sync-and-deploy.sh`)
The reap now fetches the PR head into an explicit ref (`refs/tmp/reap-check-$pr`) and only runs the supersession check when that fetch succeeds, cleaning the ref up afterward. Previously `git fetch ... || true` swallowed failures, leaving `FETCH_HEAD` pointing at a *previous* branch — so `check-superseded --ref FETCH_HEAD` could mis-verdict a PR. Since the reap auto-closes PRs, a wrong verdict is worth preventing. On fetch failure it now falls through to the normal rebase path with a warning.

**#34556 — misleading close comment** (`scripts/deploy/sync-and-deploy.sh`)
The superseded-close comment no longer says "reopen and rebase" (un-actionable — `--delete-branch` disables GitHub's Reopen button). It now states the branch was deleted and to re-push + open a fresh PR rebased onto main.

## Verification
- `bash -n scripts/deploy/sync-and-deploy.sh` passes.
- The fetch-into-ref → `check-superseded.sh` → `update-ref -d` cleanup sequence works end-to-end against a live remote branch.

Closes #34554, #34555, #34556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)