### PR TITLE
Enrich Grandi's series (Abel summation): complete mainTheorems 2→3

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/meta.json
@@ -160,6 +160,12 @@
       "type": "key",
       "description": "∑ (−1)ⁿ xⁿ = 1/(1+x) for |x| < 1 (geometric series, ratio −x)",
       "leanType": "{x : ℝ} → |x| < 1 → ∑' n : ℕ, (-1)^n * x^n = (1 + x)⁻¹"
+    },
+    {
+      "name": "grandi_abel_value",
+      "type": "core",
+      "description": "Grandi's series is Abel summable to 1/2 — the named headline export, restating grandi_abel_tendsto and matching the Cesàro value",
+      "leanType": "Tendsto (fun x : ℝ => ∑' n : ℕ, (-1)^n * x^n) (𝓝[<] 1) (𝓝 (1/2))"
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment: complete mainTheorems coverage (2 → 3)

The Lean file `GeometricSeriesOQ01OQ01.lean` exports **three** public theorems, but `meta.json`'s `mainTheorems` listed only two. This PR adds the missing named headline export:

- **`grandi_abel_value`** — `Tendsto (fun x => ∑' n, (-1)^n xⁿ) (𝓝[<] 1) (𝓝 (1/2))`, the canonically-named result that restates `grandi_abel_tendsto` and matches Grandi's Cesàro value.

Now all three file-level theorems (`grandi_power_series`, `grandi_abel_tendsto`, `grandi_abel_value`) appear in `mainTheorems`, matching the annotation set (whose `theorem`-typed annotation already flags this as "the headline result, named").

Only `meta.json` changes; annotations and the Lean source are untouched. File size 10.8 KB → 11.1 KB (well under the 60 KB cap).
