### PR TITLE
Enrich Gerretsen's inequality (Heron OQ-06-02): complete area-free rewrite triple 4→6

### DIFF
--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -52,6 +52,18 @@
       "type": "main",
       "description": "Gerretsen's inequality: for any nondegenerate triangle, s² ≤ 4R² + 4Rr + 3r².",
       "leanType": "semiperimeter a b c ^ 2 ≤ 4 * circumradius a b c ^ 2 + 4 * (circumradius a b c * inradius a b c) + 3 * inradius a b c ^ 2"
+    },
+    {
+      "name": "circumradius_sq",
+      "type": "supporting",
+      "description": "Area-free rewrite of R²: R² = (abc)²/(16·Area²), with Area² = heronProduct (Part II)",
+      "leanType": "circumradius a b c ^ 2 = (a*b*c)^2 / (16 * heronProduct a b c)"
+    },
+    {
+      "name": "inradius_sq",
+      "type": "supporting",
+      "description": "Area-free rewrite of r²: r² = Area²/s² = heronProduct/s² (Part II)",
+      "leanType": "inradius a b c ^ 2 = heronProduct a b c / semiperimeter a b c ^ 2"
     }
   ],
   "sections": [


### PR DESCRIPTION
## Enrichment: complete the area-free rewrite triple in mainTheorems (4 → 6)

Part II of `HeronsFormulaOQ06OQ02.lean` rewrites the three circumradius/inradius quantities in area-free form (`R²`, `R·r`, `r²`), which is the crux of eliminating the triangle's area from Gerretsen's inequality. But `mainTheorems` listed only the cross term `circumradius_mul_inradius`, omitting its two siblings. This PR adds them:

- **`circumradius_sq`** — `R² = (abc)²/(16·Area²)` with `Area² = heronProduct`.
- **`inradius_sq`** — `r² = Area²/s² = heronProduct/s²`.

Together with the already-listed `circumradius_mul_inradius`, the trio now fully documents the "Eliminating the Area: Only Area² Appears" step (which the annotation set already flags at lines 113–143).

Only `meta.json` changes; annotations and Lean source untouched. Size 13.3 KB → 13.8 KB (well under the 60 KB cap).
