### PR TITLE
Enrich Hurwitz's theorem (sum-of-squares identities): add mainTheorems 0→6

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
@@ -152,5 +152,43 @@
     "path": "Proofs/HurwitzUniversal.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "eight_square",
+      "type": "main",
+      "description": "Degen's eight-square identity: normSq a * normSq b = normSq (eightMul a b) over any commutative ring — the n=8 case, the largest dimension for which such a bilinear sum-of-squares identity exists (Hurwitz's 1,2,4,8 theorem)",
+      "leanType": "(a b : Fin 8 → R) → normSq a * normSq b = normSq (eightMul a b)"
+    },
+    {
+      "name": "four_square",
+      "type": "key",
+      "description": "Euler's four-square identity over any commutative ring; the algebraic engine behind Lagrange's four-square theorem",
+      "leanType": "(a b : Fin 4 → R) → normSq a * normSq b = normSq (fourMul a b)"
+    },
+    {
+      "name": "two_square",
+      "type": "key",
+      "description": "Brahmagupta–Fibonacci two-square identity over any commutative ring (the norm form of the Gaussian integers)",
+      "leanType": "(a b : Fin 2 → R) → normSq a * normSq b = normSq (twoMul a b)"
+    },
+    {
+      "name": "one_square",
+      "type": "supporting",
+      "description": "Trivial n=1 identity x²·y² = (xy)² — the degenerate base case of the 1,2,4,8 family",
+      "leanType": "(a b : Fin 1 → R) → normSq a * normSq b = normSq (oneMul a b)"
+    },
+    {
+      "name": "isSumOfSquares_four_mul",
+      "type": "supporting",
+      "description": "Sums of four squares are closed under multiplication in any commutative ring (immediate corollary of four_square)",
+      "leanType": "IsSumOfSquares 4 x → IsSumOfSquares 4 y → IsSumOfSquares 4 (x*y)"
+    },
+    {
+      "name": "int_sumFourSq_mul",
+      "type": "supporting",
+      "description": "Over ℤ, a product of two sums of four squares is a sum of four squares — the multiplicative step in Lagrange's four-square theorem",
+      "leanType": "IsSumOfSquares (R:=ℤ) 4 x → IsSumOfSquares (R:=ℤ) 4 y → IsSumOfSquares (R:=ℤ) 4 (x*y)"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: add mainTheorems (0 → 6)

This entry had an **empty** `mainTheorems` array despite formalizing the classical sum-of-squares identities behind Hurwitz's 1-2-4-8 theorem. This PR curates six headline results:

**The universal square identities** (over any commutative ring, via `ring`):
- **`eight_square`** — Degen's eight-square identity (n=8, the maximal dimension).
- **`four_square`** — Euler's four-square identity.
- **`two_square`** — Brahmagupta–Fibonacci two-square identity.
- **`one_square`** — the trivial n=1 base case.

**Arithmetic payoff** (multiplicative closure of sums of squares):
- **`isSumOfSquares_four_mul`** — sums of four squares are closed under multiplication.
- **`int_sumFourSq_mul`** — over ℤ, the multiplicative step in Lagrange's four-square theorem.

Curated to the essential 1/2/4/8 identities plus their classical consequences rather than every declaration. Only `meta.json` changes. Size 11.7 KB → 13.6 KB (well under the 60 KB cap).
