### PR TITLE
Enrich inverse-Galois A₅ (inertia-degree tower brick): add mainTheorems 0→2

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04/meta.json
@@ -134,5 +134,19 @@
     ],
     "lemmaCount": 0,
     "additionalFiles": []
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "inertiaDeg_dvd_inertiaDegIn",
+      "type": "main",
+      "description": "Tower + Galois-uniformity brick: for a tower R ⊆ S ⊆ T with T/R Galois (group G) and matching primes p, P, Q, the intermediate inertia degree inertiaDeg p P divides the Galois-invariant inertiaDegIn p T. No Galois hypothesis is needed on the (possibly non-normal) middle ring S.",
+      "leanType": "inertiaDeg p P ∣ inertiaDegIn p T"
+    },
+    {
+      "name": "dvd_inertiaDegIn_of_dvd_inertiaDeg",
+      "type": "key",
+      "description": "Reduction form consumed by the A₅ inverse-Galois argument: to show d ∣ inertiaDegIn p T it suffices to exhibit one intermediate prime P with d ∣ inertiaDeg p P — exactly what the Kummer–Dedekind cubic factor supplies (d = 3).",
+      "leanType": "d ∣ inertiaDeg p P → d ∣ inertiaDegIn p T"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: add mainTheorems (0 → 2)

This entry had an empty `mainTheorems` array. The file packages a fully proven (0-axiom, 0-sorry) reusable brick for the inverse-Galois A₅ program. This PR documents its two public results:

- **`inertiaDeg_dvd_inertiaDegIn`** — the tower + Galois-uniformity brick: for `R ⊆ S ⊆ T` with `T/R` Galois, `inertiaDeg p P ∣ inertiaDegIn p T`, needing no Galois hypothesis on the (possibly non-normal) middle ring `S`.
- **`dvd_inertiaDegIn_of_dvd_inertiaDeg`** — the reduction form consumed by the A₅ argument: exhibiting one intermediate prime `P` with `d ∣ inertiaDeg p P` promotes to `d ∣ inertiaDegIn p T`.

(The `axiom` seen by a plain grep is a docstring reference to the *separate* `InverseGaloisA5.lean`; this file itself is axiom-free — `axiomCount` stays 0.)

Only `meta.json` changes. Size 12.1 KB → ~13 KB (well under the 60 KB cap).
