### PR TITLE
Enrich Burnside's lemma over Finite (Lagrange OQ-02-02-01-01): add mainTheorems 0→2

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -226,5 +226,19 @@
       "Can the bijection-transport recipe be packaged as a reusable tactic or lemma schema, so that any `Fintype`-card identity whose proof factors through a finiteness-free equivalence is generalised to `Nat.card` automatically?"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite",
+      "type": "main",
+      "description": "Burnside's lemma over Finite: for a Finite group G acting on a Finite set X, ∑ᶠ g, Nat.card (fixedBy X g) = Nat.card (orbits) · Nat.card G. The Fintype-free generalisation of Mathlib's sum_card_fixedBy_eq_card_orbits_mul_card_group, routed through the finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup.",
+      "leanType": "[Finite G] [Finite X] → ∑ᶠ g : G, Nat.card (fixedBy X g) = Nat.card (orbitRel.Quotient G X) * Nat.card G"
+    },
+    {
+      "name": "sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered",
+      "type": "key",
+      "description": "Certifies the generalisation subsumes the original: recovers Mathlib's Fintype-based sum_card_fixedBy_eq_card_orbits_mul_card_group verbatim as a special case, with the Finite X instance derived rather than assumed.",
+      "leanType": "[Fintype G] [∀ g, Fintype (fixedBy X g)] [Fintype (orbits)] → ∑ g, Fintype.card (fixedBy X g) = Fintype.card (orbitRel.Quotient G X) * Fintype.card G"
+    }
+  ]
 }


### PR DESCRIPTION
## Enrichment: add mainTheorems (0 → 2)

This entry had an empty `mainTheorems` array. The file proves Burnside's lemma in `Fintype`-free form and certifies it against Mathlib. This PR documents both public results:

- **`sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite`** *(main)* — Burnside's lemma over `Finite`: `∑ᶠ g, Nat.card (fixedBy X g) = Nat.card(orbits) · Nat.card G`, generalising Mathlib's `Fintype` version via the finiteness-free bijection `sigmaFixedByEquivOrbitsProdGroup`.
- **`sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered`** *(key)* — recovers Mathlib's `Fintype`-based statement verbatim as a special case, deriving (not assuming) the `Finite X` instance.

Only `meta.json` changes. Size 20.5 KB → ~22 KB (well under the 60 KB cap).
