### PR TITLE
Enrich Fibonacci sum-of-squares (oq-03-oq-02): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02/annotations.json
@@ -2,49 +2,121 @@
   {
     "id": "ann-fiboq0302-1",
     "proofId": "fibonacci-identities-oq-03-oq-02",
-    "range": { "startLine": 3, "endLine": 28 },
+    "range": {
+      "startLine": 3,
+      "endLine": 28
+    },
     "type": "concept",
     "title": "The Square-Sum Identity and Its Rectangle Tiling",
     "content": "**Module framing.** The sum of the squares of the first $n$ Fibonacci numbers equals the product of consecutive Fibonacci numbers, $F_1^2 + F_2^2 + \\cdots + F_n^2 = F_n F_{n+1}$. Geometrically the squares of side $F_1,\\dots,F_n$ tile an $F_n \\times F_{n+1}$ rectangle — the picture behind the Fibonacci/golden spiral. Mathlib records the *linear* sum (`Nat.fib_succ_eq_succ_sum`) but **not** the sum of squares, so this is a genuine gap. Because Mathlib's `fib` is $0$-indexed with $F_0 = 0$, the $i=0$ term vanishes and the $1$-indexed classical sum coincides with the $0$-indexed `∑_{i ∈ range (n+1)} fib i²`.",
     "mathContext": "$\\sum_{i=1}^{n} F_i^2 = F_n F_{n+1}$; the squares of sides $F_1,\\dots,F_n$ tile an $F_n \\times F_{n+1}$ rectangle. With Mathlib's $0$-indexed $F_0 = 0$, $\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2 = \\sum_{i=1}^{n} F_i^2$.",
     "significance": "supporting",
-    "relatedConcepts": ["Fibonacci numbers", "telescoping identity", "rectangle tiling", "golden spiral", "0- vs 1-indexing"],
-    "prerequisites": ["Fibonacci recurrence", "finite sums over Finset.range", "Lean 4 / Mathlib basics"]
+    "relatedConcepts": [
+      "Fibonacci numbers",
+      "telescoping identity",
+      "rectangle tiling",
+      "golden spiral",
+      "0- vs 1-indexing"
+    ],
+    "prerequisites": [
+      "Fibonacci recurrence",
+      "finite sums over Finset.range",
+      "Lean 4 / Mathlib basics"
+    ]
   },
   {
     "id": "ann-fiboq0302-2",
     "proofId": "fibonacci-identities-oq-03-oq-02",
-    "range": { "startLine": 32, "endLine": 47 },
+    "range": {
+      "startLine": 32,
+      "endLine": 47
+    },
     "type": "insight",
     "title": "One-Line Induction: ∑ fib i² = fib n · fib(n+1)",
     "content": "**Telescoping is the whole proof.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} F_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} F_i^2\\big) + F_{k+1}^2$. The induction hypothesis rewrites the first summand to $F_k F_{k+1}$, and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) plus `ring` close $F_k F_{k+1} + F_{k+1}^2 = F_{k+1} F_{k+2}$ — i.e. adding the next square advances the consecutive product by exactly one index. No Fibonacci machinery beyond the defining recurrence is used.",
     "mathContext": "Step: $F_k F_{k+1} + F_{k+1}^2 = F_{k+1}(F_k + F_{k+1}) = F_{k+1} F_{k+2}$, using $F_{k+2} = F_k + F_{k+1}$ — closed by `ring`.",
     "significance": "key",
-    "relatedConcepts": ["induction on ℕ", "Finset.sum_range_succ", "Nat.fib_add_two", "ring tactic"],
-    "prerequisites": ["proof by induction", "Fibonacci recurrence", "Finset sum manipulation"]
+    "relatedConcepts": [
+      "induction on ℕ",
+      "Finset.sum_range_succ",
+      "Nat.fib_add_two",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "proof by induction",
+      "Fibonacci recurrence",
+      "Finset sum manipulation"
+    ]
   },
   {
     "id": "ann-fiboq0302-3",
     "proofId": "fibonacci-identities-oq-03-oq-02",
-    "range": { "startLine": 49, "endLine": 62 },
+    "range": {
+      "startLine": 49,
+      "endLine": 62
+    },
     "type": "tactic",
     "title": "Reconciling the 1-indexed Classical Form",
     "content": "**The vanishing $i=0$ term.** To recover the textbook statement $\\sum_{i=1}^n F_i^2 = F_n F_{n+1}$ over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is $F_0^2 = 0$, so `simp` reduces the `Icc` form to `fib_sum_sq`. This is exactly where Mathlib's $0$-indexing and the classical $1$-indexing are reconciled.",
     "mathContext": "$\\mathrm{range}(n+1) = \\{0\\} \\sqcup \\mathrm{Icc}\\,1\\,n$; splitting off $i=0$ contributes $F_0^2 = 0$, so $\\sum_{\\mathrm{Icc}\\,1\\,n} F_i^2 = \\sum_{\\mathrm{range}(n+1)} F_i^2$.",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.sum_insert", "index-set rewriting", "Finset.Icc vs range", "indexing conventions"],
-    "prerequisites": ["Finset membership (ext/omega)", "splitting a sum over a partition"]
+    "relatedConcepts": [
+      "Finset.sum_insert",
+      "index-set rewriting",
+      "Finset.Icc vs range",
+      "indexing conventions"
+    ],
+    "prerequisites": [
+      "Finset membership (ext/omega)",
+      "splitting a sum over a partition"
+    ]
   },
   {
     "id": "ann-fiboq0302-4",
     "proofId": "fibonacci-identities-oq-03-oq-02",
-    "range": { "startLine": 64, "endLine": 95 },
+    "range": {
+      "startLine": 64,
+      "endLine": 79
+    },
     "type": "concept",
-    "title": "Integer, Telescoping, and Oblong Readings",
-    "content": "**Packaging.** `fib_sum_sq_int` casts the identity to $\\mathbb{Z}$ by `exact_mod_cast` (for combination with subtractive Fibonacci identities). `fib_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2\\big) + F_{n+1}^2 = F_{n+1} F_{n+2}$, exhibiting the partial sums as the consecutive products $F_n F_{n+1}$. `fib_sum_sq_isConsecutiveProduct` reads each partial sum as a Fibonacci oblong number $F_m F_{m+1}$. The numerical check $F_6 F_7 = 104 = 0+1+1+4+9+25+64$ uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom.",
-    "mathContext": "Partial sums are oblong numbers $F_m F_{m+1}$; check at $n=6$: $0+1+1+4+9+25+64 = 104 = F_6 F_7 = 8\\cdot 13$, verified by `decide` (no `Lean.ofReduceBool`).",
+    "title": "Integer Form and the Telescoping Step",
+    "content": "**Two ℤ-friendly repackagings.** `fib_sum_sq_int` casts the whole identity to $\\mathbb{Z}$ in one line via `exact_mod_cast fib_sum_sq n`; the integer version is what downstream files need when the square-sum is combined with *subtractive* Fibonacci identities (e.g. $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$, Catalan's identity), where staying in $\\mathbb{N}$ would force awkward truncated subtraction. `fib_sum_sq_succ` isolates the inductive step as a standalone theorem, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2\\big) + F_{n+1}^2 = F_{n+1} F_{n+2}$: adding the next square advances the running product by exactly one Fibonacci index, so the sequence of partial sums is precisely the consecutive-product sequence $F_n F_{n+1}$. Its proof is `rw [fib_sum_sq, Nat.fib_add_two]; ring` — the same telescoping algebra $F_{n+1}(F_n + F_{n+1}) = F_{n+1}F_{n+2}$ that drives the induction, now exposed without the induction wrapper.",
+    "mathContext": "$\\big(\\sum_{i<n+1} F_i^2\\big) + F_{n+1}^2 = F_{n+1}F_{n+2}$, since $F_nF_{n+1} + F_{n+1}^2 = F_{n+1}(F_n+F_{n+1}) = F_{n+1}F_{n+2}$. The ℤ cast is definitional: $\\sum (F_i:\\mathbb{Z})^2 = (F_n:\\mathbb{Z})(F_{n+1}:\\mathbb{Z})$.",
     "significance": "supporting",
-    "relatedConcepts": ["oblong (pronic) numbers", "exact_mod_cast", "decide vs native_decide", "ℤ-valued identities"],
-    "prerequisites": ["casting ℕ identities to ℤ", "existential corollaries", "kernel-checked decidability"]
+    "relatedConcepts": [
+      "telescoping sums",
+      "exact_mod_cast",
+      "ℤ-valued Fibonacci identities",
+      "Catalan / d'Ocagne subtractive identities"
+    ],
+    "prerequisites": [
+      "casting ℕ identities to ℤ",
+      "the Fibonacci recurrence F(n+2)=F(n)+F(n+1)",
+      "ring normalization"
+    ]
+  },
+  {
+    "id": "ann-fiboq0302-5",
+    "proofId": "fibonacci-identities-oq-03-oq-02",
+    "range": {
+      "startLine": 81,
+      "endLine": 95
+    },
+    "type": "concept",
+    "title": "Oblong Corollary and the Kernel-Checked Numerical Witness",
+    "content": "**Every partial sum is an oblong number.** `fib_sum_sq_isConsecutiveProduct` repackages the identity existentially: $\\exists m,\\ \\sum_{i \\in \\mathrm{range}(n+1)} F_i^2 = F_m F_{m+1}$, witnessed trivially by $m = n$. A product of two *consecutive* Fibonacci numbers is a Fibonacci \"oblong\" (pronic) number, so the theorem says the partial sums of squares never leave that sequence $0,1,2,6,15,40,104,\\dots$ ($F_nF_{n+1}$). **Numerical witness.** The closing `example`s pin the abstract statement to a concrete case: at $n=6$ the sum $0+1+1+4+9+25+64 = 104$ equals $F_6 F_7 = 8\\cdot 13 = 104$. The sum side is literally the theorem instance `fib_sum_sq 6`, while the arithmetic value $8\\cdot 13 = 104$ is discharged by `decide` — *kernel* reduction, deliberately not `native_decide`, so the proof never invokes the compiler and the entry stays free of `Lean.ofReduceBool`.",
+    "mathContext": "$\\sum_{i<n+1} F_i^2 = F_m F_{m+1}$ with $m=n$; oblong values $F_nF_{n+1}: 0,1,2,6,15,40,104,\\dots$. Check: $0+1+1+4+9+25+64 = 104 = F_6F_7 = 8\\cdot13$, verified by kernel `decide` (no `Lean.ofReduceBool`).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "oblong (pronic) numbers",
+      "existential corollaries",
+      "decide vs native_decide",
+      "kernel reduction"
+    ],
+    "prerequisites": [
+      "existential witnesses in Lean",
+      "kernel-checked decidability",
+      "the ofReduceBool axiom"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-02` (∑ Fᵢ² = Fₙ·Fₙ₊₁).

## Change
De-bundle the annotation set from **4 → 5** so no single annotation spans three distinct theorems.

The former annotation #4 covered lines **64–95**, folding together `fib_sum_sq_int`, the telescoping step `fib_sum_sq_succ`, the oblong corollary `fib_sum_sq_isConsecutiveProduct`, *and* the numerical `decide` checks. It is split into:

- **Integer Form and the Telescoping Step** (64–79) — `fib_sum_sq_int` (ℤ cast for subtractive downstream identities like Catalan's) + `fib_sum_sq_succ` (running product advances one index).
- **Oblong Corollary and the Kernel-Checked Numerical Witness** (81–95) — partial sums are Fibonacci pronic numbers `FₘFₘ₊₁`; the `n=6` check uses **kernel `decide`**, not `native_decide`, so the entry stays free of `Lean.ofReduceBool`.

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Full line coverage 3–95 preserved; no gaps introduced.
- `meta.json` unchanged (15.3 KB, under cap). Axiom status untouched — proof remains 0-axiom.
