### PR TITLE
Research: nth-root-irrational-oq-02-oq-02 — ergonomic valuation criterion for mixed prime exponents [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/NthRootIrrationalOQ02OQ02.lean
+++ b/proofs/Proofs/NthRootIrrationalOQ02OQ02.lean
@@ -1,0 +1,170 @@
+/-
+  Nth Root Irrationality OQ-02-OQ-02:
+  Ergonomic valuation criterion for mixed prime exponents
+
+  The parent file `NthRootIrrationalOQ02.lean` proves the *raw* valuation
+  criterion
+
+      not_perfect_pow_of_factorization :
+        ¬ n ∣ m.factorization p  →  ¬ ∃ k, k ^ n = m,
+
+  and packages it into two ergonomic corollaries.  But its user-facing composite
+  helper `not_perfect_pow_of_sq_not_dvd` fires only when a prime divides `m`
+  *exactly once* (`p ∣ m`, `p² ∤ m`, i.e. exponent `1`).  That is a convenient
+  but narrow trigger: it misses radicands all of whose prime exponents are `≥ 2`
+  yet not all divisible by `n`.  The canonical example is
+
+      72 = 2³ · 3²,      √72 irrational,
+
+  where the blocking prime is `2` with exponent `3` (odd), while `3` has the
+  benign even exponent `2`.  Prime `2` satisfies `2² ∣ 72`, so the exponent-`1`
+  lemma does not apply, and prime `3` has an exponent divisible by `n = 2`, so it
+  does not block.  The raw criterion *can* certify `√72` (via `v_2(72) = 3`), but
+  there is no ergonomic bridge to it in the parent.
+
+  This file supplies that bridge.  The idea: for a concrete radicand, the exact
+  `p`-adic valuation `v_p(m) = e` is certified by the two *size-independent*
+  divisibility `decide`s
+
+      p ^ e ∣ m       and       ¬ p ^ (e+1) ∣ m,
+
+  which pin `m.factorization p = e` through Mathlib's
+  `Nat.Prime.pow_dvd_iff_le_factorization`.  From `n ∤ e` the raw criterion then
+  fires.  This handles every "some exponent not a multiple of `n`" radicand — the
+  exponent-`1` corollary of the parent becomes the special case `e = 1`.
+
+  Results (0 axioms, 0 sorries):
+  - irrational_nthRoot_of_exists_factorization  (headline: the ∃-form criterion,
+    matching the problem's formal statement `(∃ p, n ∤ v_p(m)) → Irrational ⁿ√m`)
+  - not_perfect_pow_of_factorization_eq         (the ergonomic exponent-`e`
+    criterion via a divisibility window)
+  - irrational_nthRoot_of_factorization_eq      (its irrationality corollary)
+  - Concrete corollaries the parent's exponent-`1` lemma cannot reach:
+    √72, √288, √500, ∛72, ∛108 — and a re-derivation of √12 showing the `e = 1`
+    case is subsumed.
+-/
+
+import Mathlib
+import Proofs.NthRootIrrational
+import Proofs.NthRootIrrationalOQ02
+
+set_option maxHeartbeats 1000000
+
+namespace NthRootIrrationalOQ02OQ02
+
+open NthRootIrrational NthRootIrrationalOQ02
+
+/-! ## Part 1: The valuation criterion in existential form
+
+The problem's formal statement is `(∃ p prime, n ∤ v_p(m)) → Irrational (ⁿ√m)`.
+The parent's raw `not_perfect_pow_of_factorization` already contains the
+mathematical content; here we simply package it into the exact existential shape,
+fed through the base `irrational_nthRoot`.  (When `m = 0` the hypothesis is
+vacuous, since `n ∣ 0 = m.factorization p` for every `p`.) -/
+
+/-- **Headline valuation criterion.**  If *some* prime `p` has a `p`-adic
+valuation `v_p(m) = m.factorization p` that is not divisible by `n`, then `ⁿ√m`
+is irrational.  This is the honest, complete form of the irrationality test:
+it fires for every radicand that is not a perfect `n`-th power, without any
+restriction on the sizes of the other exponents. -/
+theorem irrational_nthRoot_of_exists_factorization {m n : ℕ} (hn : 1 < n)
+    (h : ∃ p, ¬ n ∣ m.factorization p) : Irrational (nthRoot n m) := by
+  obtain ⟨p, hp⟩ := h
+  exact irrational_nthRoot n m hn
+    (not_perfect_pow_int (not_perfect_pow_of_factorization hp))
+
+/-! ## Part 2: The ergonomic exponent-`e` criterion
+
+Computing `m.factorization p` on a literal is awkward; instead we certify the
+exact exponent `e` by a *divisibility window* `p ^ e ∣ m ∧ ¬ p ^ (e+1) ∣ m`.
+Both halves are cheap `decide`s whose cost is independent of the magnitude of
+`m`, so the criterion scales to large radicands and large exponents alike. -/
+
+/-- **Exponent-`e` not-a-perfect-power criterion.**  Suppose the prime `p`
+appears in `m` to exponent exactly `e`, witnessed by the divisibility window
+`p ^ e ∣ m` and `¬ p ^ (e+1) ∣ m`.  If `n ∤ e`, then `m` is not a perfect
+`n`-th power.  Taking `e = 1` recovers the parent's `not_perfect_pow_of_sq_not_dvd`,
+but `e` is now arbitrary, so mixed-exponent radicands such as `72 = 2³ · 3²`
+are covered. -/
+theorem not_perfect_pow_of_factorization_eq {m n p e : ℕ} (hp : p.Prime)
+    (hm : m ≠ 0) (hpe : p ^ e ∣ m) (hpe1 : ¬ p ^ (e + 1) ∣ m) (hndvd : ¬ n ∣ e) :
+    ¬ ∃ k : ℕ, k ^ n = m := by
+  have hval : m.factorization p = e := by
+    have h1 : e ≤ m.factorization p := (hp.pow_dvd_iff_le_factorization hm).mp hpe
+    have h2 : ¬ (e + 1 ≤ m.factorization p) := fun h =>
+      hpe1 ((hp.pow_dvd_iff_le_factorization hm).mpr h)
+    omega
+  exact not_perfect_pow_of_factorization (by rw [hval]; exact hndvd)
+
+/-! ## Part 3: Irrationality from the exponent-`e` criterion -/
+
+/-- **Irrationality via a single blocking prime of exponent `e`.**  If `p` appears
+in `m` to exponent exactly `e` (a divisibility window) and `n ∤ e`, then `ⁿ√m` is
+irrational. -/
+theorem irrational_nthRoot_of_factorization_eq {m n p e : ℕ} (hn : 1 < n)
+    (hp : p.Prime) (hm : m ≠ 0) (hpe : p ^ e ∣ m) (hpe1 : ¬ p ^ (e + 1) ∣ m)
+    (hndvd : ¬ n ∣ e) : Irrational (nthRoot n m) :=
+  irrational_nthRoot n m hn
+    (not_perfect_pow_int (not_perfect_pow_of_factorization_eq hp hm hpe hpe1 hndvd))
+
+/-! ## Part 4: Concrete corollaries the exponent-`1` lemma cannot reach
+
+Each radicand below has *every* prime exponent `≥ 2`, so the parent's
+`irrational_nthRoot_of_sq_not_dvd` (which needs a prime of exponent exactly `1`)
+does not apply.  The blocking prime is named explicitly via `(p := …) (e := …)`;
+the three divisibility side-conditions are `decide`s. -/
+
+/-- `√72` irrational — `72 = 2³ · 3²`.  Blocked by `2` at exponent `3` (odd):
+`8 ∣ 72`, `16 ∤ 72`, `2 ∤ 3`.  Prime `3` has the benign even exponent `2`, and
+`2² ∣ 72` rules out the parent's exponent-`1` lemma.  This is the canonical
+radicand the narrow corollary silently excludes. -/
+theorem irrational_sqrt_72 : Irrational (nthRoot 2 72) :=
+  irrational_nthRoot_of_factorization_eq (m := 72) (n := 2) (p := 2) (e := 3)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+/-- `√288` irrational — `288 = 2⁵ · 3²`.  Blocked by `2` at exponent `5`:
+`32 ∣ 288`, `64 ∤ 288`, `2 ∤ 5`. -/
+theorem irrational_sqrt_288 : Irrational (nthRoot 2 288) :=
+  irrational_nthRoot_of_factorization_eq (m := 288) (n := 2) (p := 2) (e := 5)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+/-- `√500` irrational — `500 = 2² · 5³`.  Here the square factor `2²` is benign;
+the blocking prime is `5` at exponent `3`: `125 ∣ 500`, `625 ∤ 500`, `2 ∤ 3`. -/
+theorem irrational_sqrt_500 : Irrational (nthRoot 2 500) :=
+  irrational_nthRoot_of_factorization_eq (m := 500) (n := 2) (p := 5) (e := 3)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+/-- `∛72` irrational — `72 = 2³ · 3²`, cube root.  Now `2³` is benign (`3 ∣ 3`),
+and the blocking prime is `3` at exponent `2`: `9 ∣ 72`, `27 ∤ 72`, `3 ∤ 2`.
+The *same* radicand `72` is blocked by a *different* prime depending on `n` —
+exactly what the exponent-`1` lemma cannot express. -/
+theorem irrational_cbrt_72 : Irrational (nthRoot 3 72) :=
+  irrational_nthRoot_of_factorization_eq (m := 72) (n := 3) (p := 3) (e := 2)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+/-- `∛108` irrational — `108 = 2² · 3³`.  The cube factor `3³` is benign; the
+blocking prime is `2` at exponent `2`: `4 ∣ 108`, `8 ∤ 108`, `3 ∤ 2`. -/
+theorem irrational_cbrt_108 : Irrational (nthRoot 3 108) :=
+  irrational_nthRoot_of_factorization_eq (m := 108) (n := 3) (p := 2) (e := 2)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+/-! ### Subsumption of the exponent-`1` case
+
+The parent's exponent-`1` corollary is the special case `e = 1` of the criterion
+above, so nothing is lost by generalizing.  For instance `√12` (`12 = 2² · 3`,
+blocked by `3` at exponent `1`) is still a one-liner here. -/
+
+/-- `√12` irrational via the general criterion at `e = 1` (`12 = 2² · 3`, blocked
+by `3`): `3 ∣ 12`, `9 ∤ 12`, `2 ∤ 1`.  Demonstrates that the exponent-`1` trigger
+of the parent is recovered as a special case. -/
+theorem irrational_sqrt_12 : Irrational (nthRoot 2 12) :=
+  irrational_nthRoot_of_factorization_eq (m := 12) (n := 2) (p := 3) (e := 1)
+    (by norm_num) (by norm_num) (by norm_num) (by decide) (by decide) (by decide)
+
+end NthRootIrrationalOQ02OQ02
+
+-- Axiom audit (kept as a comment; uncomment locally to re-verify): the results below
+-- depend only on `propext / Classical.choice / Quot.sound` — no `sorryAx`, no
+-- `Lean.ofReduceBool` (the `decide`s are kernel-checked, not `native_decide`).
+-- #print axioms NthRootIrrationalOQ02OQ02.irrational_nthRoot_of_exists_factorization
+-- #print axioms NthRootIrrationalOQ02OQ02.irrational_sqrt_72

--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-existential",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "The Valuation Criterion in Existential Form",
+    "content": "Proves `irrational_nthRoot_of_exists_factorization`: if some prime `p` has `n ∤ m.factorization p`, then `ⁿ√m` is irrational.\n\n**Statement.** `(∃ p, ¬ n ∣ m.factorization p) → Irrational (nthRoot n m)` — the exact shape of the problem's formal statement.\n\n**Proof.** Destructure the witness `p` and feed the parent's raw criterion `not_perfect_pow_of_factorization` through the ℕ→ℤ bridge `not_perfect_pow_int` into the base general theorem `irrational_nthRoot`. When `m = 0` the hypothesis is vacuous, since `n ∣ 0 = m.factorization p` for every `p`.\n\nThis is the honest, complete irrationality test: it fires on every radicand that is not a perfect `n`-th power, with no restriction on the sizes of the other exponents."
+  },
+  {
+    "id": "ann-exponent-e",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 97
+    },
+    "type": "key-step",
+    "title": "Certifying the Exact Valuation by a Divisibility Window",
+    "content": "Proves `not_perfect_pow_of_factorization_eq`: a prime `p` of exponent exactly `e` in `m` (witnessed by `p^e ∣ m` and `¬ p^(e+1) ∣ m`) with `n ∤ e` shows `m` is not a perfect `n`-th power.\n\n**Proof.** `Nat.Prime.pow_dvd_iff_le_factorization` turns `p^e ∣ m` into `e ≤ v_p(m)` and `¬ p^(e+1) ∣ m` into `¬(e+1 ≤ v_p(m))`, so `omega` pins `v_p(m) = e`. Rewriting reduces the goal to the parent's raw criterion with the hypothesis `n ∤ e`.\n\nThe divisibility window is the ergonomic bridge: both halves are `decide`s whose cost is independent of the magnitude of `m`, and taking `e = 1` recovers the parent's exponent-1 corollary `not_perfect_pow_of_sq_not_dvd`."
+  },
+  {
+    "id": "ann-irrationality",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 104,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "Irrationality from a Single Blocking Prime",
+    "content": "Proves `irrational_nthRoot_of_factorization_eq`: an exponent-`e` divisibility window plus `n ∤ e` yields `Irrational (nthRoot n m)`. Composes `not_perfect_pow_of_factorization_eq` (via the ℕ→ℤ bridge) with the base `irrational_nthRoot`. This is the practical workhorse used by every concrete corollary below."
+  },
+  {
+    "id": "ann-sqrt72",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 121,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "√72: the Radicand the Exponent-1 Lemma Cannot Reach",
+    "content": "`72 = 2³ · 3²`. The blocking prime is `2` at exponent `3` (odd): `8 ∣ 72`, `16 ∤ 72`, `2 ∤ 3`. The prime `3` has the benign even exponent `2` (`2 ∣ 2`), and because `2² ∣ 72` the parent's exponent-1 lemma does not apply to `2` either. So neither prime is usable by the narrow corollary, yet `√72` is irrational — certified here in one line via the exponent-`e` window with `e = 3`.\n\nThis is precisely the example the parent entry's open-questions list flagged as out of reach."
+  },
+  {
+    "id": "ann-cbrt72",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 141,
+      "endLine": 143
+    },
+    "type": "insight",
+    "title": "Same Radicand, Different Blocking Prime by Exponent",
+    "content": "`∛72` with the same `72 = 2³ · 3²`. For cube roots the prime `2` is now benign (`3 ∣ v_2 = 3`), and the blocking prime is `3` at exponent `2`: `9 ∣ 72`, `27 ∤ 72`, `3 ∤ 2`. The blocking prime depends on `n` — an observation the exponent-1 lemma structurally cannot express, since it fixes the exponent at `1`."
+  },
+  {
+    "id": "ann-subsumption",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 160,
+      "endLine": 162
+    },
+    "type": "concept",
+    "title": "The Exponent-1 Case is Subsumed",
+    "content": "`√12` (`12 = 2² · 3`, blocked by `3` at exponent `1`) is still a one-liner here: `3 ∣ 12`, `9 ∤ 12`, `2 ∤ 1`. Instantiating the general criterion at `e = 1` reproduces the parent's exponent-1 corollary, confirming the generalization loses nothing."
+  }
+]

--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "nth-root-irrational-oq-02-oq-02",
+  "title": "Nth Root Irrationality: Ergonomic Valuation Criterion for Mixed Prime Exponents",
+  "slug": "nth-root-irrational-oq-02-oq-02",
+  "description": "Closes an open question of the parent entry (nth-root-irrational-oq-02): its composite corollary fires only when a prime divides the radicand exactly once, missing radicands all of whose prime exponents are ≥ 2 but not all divisible by n — e.g. 72 = 2³·3², whose square root is irrational via the odd exponent 3 of the prime 2. This entry supplies the ergonomic bridge: certify the exact p-adic valuation v_p(m) = e by a size-independent divisibility window p^e ∣ m ∧ ¬p^(e+1) ∣ m, then invoke the parent's raw factorization criterion. The exponent-1 corollary becomes the special case e = 1.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "generalization",
+      "prime-factorization",
+      "research"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/NthRootIrrationalOQ02OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "p^k ∣ m ↔ k ≤ m.factorization p, for prime p and m ≠ 0 — turns a divisibility window into the exact valuation v_p(m) = e",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "irrational_nthRoot",
+        "description": "Base-file general theorem: not a perfect nth power over ℤ implies the nth root is irrational",
+        "module": "Proofs.NthRootIrrational"
+      }
+    ],
+    "originalContributions": [
+      "irrational_nthRoot_of_exists_factorization: the valuation criterion in the exact existential form of the problem statement — (∃ p, n ∤ v_p(m)) → Irrational (ⁿ√m)",
+      "not_perfect_pow_of_factorization_eq: an ergonomic exponent-e not-a-perfect-power criterion certified by the size-independent divisibility window p^e ∣ m ∧ ¬p^(e+1) ∣ m, subsuming the parent's exponent-1 lemma as the case e = 1",
+      "irrational_nthRoot_of_factorization_eq: the irrationality corollary keyed on a single blocking prime of arbitrary exponent e",
+      "Concrete corollaries the parent's exponent-1 lemma cannot reach: √72 (=2³·3²), √288 (=2⁵·3²), √500 (=2²·5³), ∛72, ∛108 — including the same radicand 72 blocked by a different prime depending on n"
+    ],
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "lineCount": 170,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (propext / Classical.choice / Quot.sound only; the divisibility side-conditions use kernel-checked decide, not native_decide). Builds on the parent's verified criterion not_perfect_pow_of_factorization and the base general theorem irrational_nthRoot.",
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean",
+      "Proofs/NthRootIrrationalOQ02.lean"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry nth-root-irrational-oq-02 introduced the uniform prime-factorization criterion: m is a perfect n-th power iff every prime exponent v_p(m) is divisible by n. Its user-facing composite corollary, however, requires exhibiting a prime that divides the radicand exactly once (v_p(m) = 1). The parent's own open-questions list flagged the gap: 'Can the general criterion be exposed ergonomically for radicands all of whose prime exponents are ≥ 2 but not all divisible by n (e.g. 72 = 2³·3²)?' This entry answers that question.",
+    "problemStatement": "The parent's exponent-1 corollary cannot certify √72. Writing 72 = 2³·3², the blocking prime is 2 with the odd exponent 3, while 3 has the benign even exponent 2. Because 2² ∣ 72, the exponent-1 lemma does not apply; because 2 ∣ v_3(72) = 2, the prime 3 does not block. The raw criterion can certify √72 via v_2(72) = 3, but the parent offers no ergonomic bridge to it.\n\n$$\\big(\\exists\\, p \\text{ prime},\\ n \\nmid v_p(m)\\big)\\ \\Longrightarrow\\ \\sqrt[n]{m}\\notin\\mathbb{Q}.$$",
+    "text": "An ergonomic valuation criterion for irrationality of nth roots: certify the exact p-adic valuation of the radicand by a size-independent divisibility window, covering mixed-exponent radicands the parent's exponent-1 corollary silently excludes.",
+    "proofStrategy": "1. **Existential criterion** (`irrational_nthRoot_of_exists_factorization`): repackage the parent's raw `not_perfect_pow_of_factorization` into the exact shape (∃ p, n ∤ v_p(m)) → Irrational (ⁿ√m), fed through the base `irrational_nthRoot`.\n\n2. **Exponent-e criterion** (`not_perfect_pow_of_factorization_eq`): to make the criterion usable on literals, certify v_p(m) = e by the divisibility window p^e ∣ m and ¬p^(e+1) ∣ m. Both halves reduce, via `Nat.Prime.pow_dvd_iff_le_factorization`, to e ≤ v_p(m) and ¬(e+1 ≤ v_p(m)), pinning v_p(m) = e by omega. Then n ∤ e fires the raw criterion.\n\n3. **Irrationality** (`irrational_nthRoot_of_factorization_eq`): compose with the base general theorem.\n\n4. **Concrete corollaries**: name the blocking prime and its exponent explicitly; the three divisibility side-conditions are cheap decides whose cost is independent of the radicand's magnitude.",
+    "keyInsights": [
+      "The exact valuation v_p(m) = e is pinned by a two-sided divisibility window p^e ∣ m ∧ ¬p^(e+1) ∣ m, both halves size-independent decides — no factorization of the literal is required.",
+      "Taking e = 1 recovers the parent's exponent-1 corollary, so the generalization loses nothing while covering every mixed-exponent radicand.",
+      "The same radicand can be blocked by different primes depending on n: 72 = 2³·3² is blocked by the prime 2 for square roots (v_2 = 3 odd) and by the prime 3 for cube roots (v_3 = 2, not a multiple of 3). The exponent-1 lemma cannot express this.",
+      "The existential form matches the problem's formal statement exactly and makes the honest, complete irrationality test — fire on any non-perfect-power radicand — a one-liner."
+    ],
+    "prerequisites": [
+      "Number theory (unique prime factorization, p-adic valuation / Nat.factorization)",
+      "The parent entry nth-root-irrational-oq-02 (raw criterion not_perfect_pow_of_factorization)",
+      "The base entry nth-root-irrational (general theorem irrational_nthRoot)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup and Motivation",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module documentation naming the parent's exponent-1 gap and the 72 = 2³·3² example, imports, and namespace opening the base and parent files.",
+      "mathContext": "Imports Mathlib, Proofs.NthRootIrrational (nthRoot, irrational_nthRoot) and Proofs.NthRootIrrationalOQ02 (not_perfect_pow_of_factorization, not_perfect_pow_int). Goal: bridge the raw valuation criterion to mixed-exponent radicands."
+    },
+    {
+      "id": "existential",
+      "title": "The Valuation Criterion in Existential Form",
+      "startLine": 57,
+      "endLine": 75,
+      "summary": "irrational_nthRoot_of_exists_factorization: some prime with n ∤ v_p(m) forces ⁿ√m irrational.",
+      "mathContext": "Repackages the parent's raw criterion into the exact statement (∃ p, n ∤ v_p(m)) → Irrational (ⁿ√m). When m = 0 the hypothesis is vacuous since n ∣ 0 = v_p(0)."
+    },
+    {
+      "id": "exponent-e",
+      "title": "The Ergonomic Exponent-e Criterion",
+      "startLine": 76,
+      "endLine": 98,
+      "summary": "not_perfect_pow_of_factorization_eq: a divisibility window p^e ∣ m ∧ ¬p^(e+1) ∣ m with n ∤ e certifies m is not a perfect nth power.",
+      "mathContext": "Nat.Prime.pow_dvd_iff_le_factorization gives e ≤ v_p(m) from p^e ∣ m and ¬(e+1 ≤ v_p(m)) from ¬p^(e+1) ∣ m, so v_p(m) = e by omega. Rewriting reduces to the parent's criterion with n ∤ e."
+    },
+    {
+      "id": "irrationality",
+      "title": "Irrationality from a Single Blocking Prime",
+      "startLine": 99,
+      "endLine": 109,
+      "summary": "irrational_nthRoot_of_factorization_eq: exponent-e window plus n ∤ e implies ⁿ√m irrational.",
+      "mathContext": "Composes not_perfect_pow_of_factorization_eq (via the ℕ→ℤ bridge not_perfect_pow_int) with the base irrational_nthRoot."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Corollaries the Exponent-1 Lemma Cannot Reach",
+      "startLine": 110,
+      "endLine": 170,
+      "summary": "√72, √288, √500, ∛72, ∛108 — every prime exponent ≥ 2 — plus √12 showing the exponent-1 case is subsumed.",
+      "mathContext": "Each radicand has all prime exponents ≥ 2, so the parent's exponent-1 corollary does not apply. The blocking prime and exponent are named explicitly; √72 and ∛72 show the same radicand blocked by different primes depending on n."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry closes an open question of its parent: the composite irrationality corollary, previously restricted to radicands with a prime of exponent exactly 1, is generalized to every radicand that is not a perfect nth power. The exact p-adic valuation is certified by a size-independent divisibility window, so mixed-exponent radicands such as 72 = 2³·3² — whose square root the parent could not reach — become one-liners, and the exponent-1 corollary is recovered as the special case e = 1.",
+    "implications": "**Completeness**: The existential criterion (∃ p, n ∤ v_p(m)) → Irrational (ⁿ√m) is the honest, complete form of the irrationality test — it fires on every non-perfect-power radicand with no restriction on the other exponents.\n\n**Reusability**: To certify any new radicand it now suffices to exhibit one prime with the wrong exponent, witnessed by a two-sided divisibility window whose cost is independent of the radicand's size.",
+    "openQuestions": [
+      "Can the divisibility-window certification be packaged as a decision procedure / tactic that, given a literal radicand and n, searches for a blocking prime automatically?",
+      "Does the same valuation-window technique give ergonomic irrationality proofs for rational radicands a/b (comparing v_p(a) − v_p(b) mod n)?",
+      "Can the criterion be stated over a general unique-factorization monoid, abstracting away from ℕ?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "nth-root-irrational-oq-02",
+      "relationship": "extends",
+      "description": "Directly answers the parent's open question on exposing the general criterion ergonomically for radicands all of whose prime exponents are ≥ 2 but not all divisible by n (e.g. 72 = 2³·3²). Reuses the parent's raw not_perfect_pow_of_factorization and the ℕ→ℤ bridge not_perfect_pow_int."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "foundational",
+      "description": "Feeds the exponent-e criterion into the base general theorem irrational_nthRoot to conclude irrationality."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Part of the same nth-root irrationality family; here the emphasis is on composite mixed-exponent radicands rather than primes."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.NthRootIrrational",
+      "Proofs.NthRootIrrationalOQ02"
+    ],
+    "opens": [
+      "NthRootIrrational",
+      "NthRootIrrationalOQ02"
+    ],
+    "namespace": "NthRootIrrationalOQ02OQ02",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/NthRootIrrationalOQ02OQ02.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/NthRootIrrational.lean",
+      "Proofs/NthRootIrrationalOQ02.lean"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hardy, G.H.; Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "The unique-factorization characterization of perfect powers underlying the valuation criterion."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "irrational_nthRoot_of_exists_factorization",
+      "type": "core",
+      "description": "If some prime p has n ∤ v_p(m), then the nth root of m is irrational — the complete existential form of the criterion",
+      "leanType": "{m n : Nat} -> 1 < n -> (exists p, not (n ∣ m.factorization p)) -> Irrational (nthRoot n m)"
+    },
+    {
+      "name": "not_perfect_pow_of_factorization_eq",
+      "type": "core",
+      "description": "A prime of exponent exactly e (certified by a divisibility window) with n ∤ e shows m is not a perfect nth power; e = 1 recovers the parent's exponent-1 lemma",
+      "leanType": "{m n p e : Nat} -> p.Prime -> m ≠ 0 -> p^e ∣ m -> not (p^(e+1) ∣ m) -> not (n ∣ e) -> not (exists k : Nat, k^n = m)"
+    },
+    {
+      "name": "irrational_sqrt_72",
+      "type": "application",
+      "description": "√72 irrational (72 = 2³·3², blocked by the prime 2 at exponent 3) — the canonical radicand the parent's exponent-1 corollary cannot reach",
+      "leanType": "Irrational (nthRoot 2 72)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes an **open question of the parent entry** `nth-root-irrational-oq-02`. That entry's own `openQuestions` list asks:

> *"The composite corollary requires a prime appearing to exponent exactly 1. Can the general criterion be exposed ergonomically for radicands all of whose prime exponents are ≥ 2 but not all divisible by n (e.g. 72 = 2³·3²)?"*

This PR answers it. The parent's user-facing corollary `not_perfect_pow_of_sq_not_dvd` fires only when a prime divides the radicand **exactly once** (`v_p(m) = 1`), so it cannot certify `√72`: writing `72 = 2³·3²`, the blocking prime is `2` at the odd exponent `3` (but `2² ∣ 72`, so the exponent-1 lemma fails), while `3` has the benign even exponent `2`.

## What's new

New file `Proofs/NthRootIrrationalOQ02OQ02.lean` — **9 theorems, 0 axioms, 0 sorries** (`propext / Classical.choice / Quot.sound` only; the divisibility side-conditions use kernel-checked `decide`, **not** `native_decide`):

- **`irrational_nthRoot_of_exists_factorization`** — the criterion in the exact existential form of the problem statement: `(∃ p, n ∤ v_p(m)) → Irrational (ⁿ√m)`. The honest, complete irrationality test.
- **`not_perfect_pow_of_factorization_eq`** — ergonomic exponent-`e` criterion. Certifies `v_p(m) = e` by a **size-independent divisibility window** `p^e ∣ m ∧ ¬p^(e+1) ∣ m` (via `Nat.Prime.pow_dvd_iff_le_factorization` + `omega`). Taking `e = 1` recovers the parent's exponent-1 lemma.
- **`irrational_nthRoot_of_factorization_eq`** — the irrationality corollary.
- **Concrete corollaries the exponent-1 lemma cannot reach**: `√72` (2³·3²), `√288` (2⁵·3²), `√500` (2²·5³), `∛72`, `∛108` — plus `√12` demonstrating the `e = 1` case is subsumed. `√72` and `∛72` show the *same* radicand blocked by *different* primes depending on `n`.

Gallery entry `src/data/proofs/nth-root-irrational-oq-02-oq-02/` (`meta.json` + `annotations.json`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.NthRootIrrationalOQ02OQ02` — clean (7745 jobs).
- `#print axioms` on the headline theorem and `irrational_sqrt_72`: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. **Tier-A axiom-free.**
- Gallery `meta.json` within size caps; new annotations pass strict validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)