### PR TITLE
Newton n=4: all three log-concavity steps via SOS certificates (16→20 thms)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -43,6 +43,10 @@
         `p_1² ≥ p_0 p_2`, i.e. `2 n · e₂ ≤ (n - 1) · e₁²`, for signed reals —
         no enumeration, no appeal to the still-open general Rolle crux (see
         Part III below).
+  * `newton_four_first` / `newton_four_second` / `newton_four_third`  :  ALL
+        THREE Newton log-concavity steps at `n = 4` for signed reals, via explicit
+        SOS certificates (Part IV) — including the middle (`k = 2`) and top
+        (`k = 3`) steps that lie beyond Part III's general `k = 1` reach.
 
   The general SECOND-and-higher steps (`p_k², k ≥ 2`, arbitrary `n`) need the
   crux lemma "differentiation preserves full real-rootedness (counting
@@ -269,5 +273,79 @@ theorem newton_first_general (n : ℕ) (x : ℕ → ℝ) :
         + 2 * (n : ℝ) * (∑ j ∈ range n, ∑ i ∈ range j, x i * x j) := by
     rw [hid]; ring
   nlinarith [hqm, hn]
+
+/-!  ## Part IV — Newton at `n = 4` via explicit SOS certificates
+
+Part III closed the FIRST Newton step (`k = 1`) for every arity, but the higher
+steps `k ≥ 2` at general `n` remain tied to the open iterated-Rolle crux.  Here we
+push the concrete SOS-certificate method of Part II one arity further and discharge
+ALL THREE Newton inequalities at `n = 4`, for arbitrary signed reals — including
+the middle step `k = 2` and the top step `k = 3`, which lie beyond Part III's
+`k = 1` reach.  This answers the "extend the SOS approach to `n = 4`" question and
+supplies the first fully-signed `n = 4` log-concavity chain in the amgm family.
+
+For four real roots `a, b, c, d` the splitting quartic is
+`(X-a)(X-b)(X-c)(X-d) = X⁴ - e₁X³ + e₂X² - e₃X + e₄`, with
+`e₁ = a+b+c+d`, `e₂ = ab+ac+ad+bc+bd+cd`, `e₃ = abc+abd+acd+bcd`, `e₄ = abcd`.
+The three Newton inequalities `p_k² ≥ p_{k-1}p_{k+1}` (`k = 1,2,3`, with
+`p₀=1, p₁=e₁/4, p₂=e₂/6, p₃=e₃/4, p₄=e₄`) become, after clearing denominators:
+
+* `k = 1`:  `8 e₂ ≤ 3 e₁²`   — SOS `∑_{i<j}(xᵢ-xⱼ)²` (the `n = 4` instance of
+  `newton_first_general`);
+* `k = 2`:  `9 e₁ e₃ ≤ 4 e₂²` — SOS
+  `3∑(xᵢxⱼ-xₖxₗ)² + ½∑((xᵢ-xⱼ)(xₖ-xₗ))²` over the three ways to split
+  `{a,b,c,d}` into two opposite pairs;
+* `k = 3`:  `8 e₂ e₄ ≤ 3 e₃²` — SOS `∑_{i<j}(xᵢ-xⱼ)²(xₖxₗ)²`, the image of the
+  `k = 1` certificate under the reciprocal substitution `xᵢ ↦ 1/xᵢ`.
+
+Each certificate is exact (verified symbolically); `nlinarith` closes each from the
+listed squares.  No sign hypothesis anywhere. -/
+
+/-- **Newton's first inequality at `n = 4`** (`p₁² ≥ p₀ p₂`), for arbitrary signed
+reals: `8 e₂ ≤ 3 e₁²`, i.e. `8(ab+ac+ad+bc+bd+cd) ≤ 3(a+b+c+d)²`.  SOS certificate
+`∑_{i<j}(xᵢ-xⱼ)²`.  (Also the `n = 4` instance of `newton_first_general`.) -/
+theorem newton_four_first (a b c d : ℝ) :
+    8 * (a * b + a * c + a * d + b * c + b * d + c * d) ≤ 3 * (a + b + c + d) ^ 2 := by
+  nlinarith [sq_nonneg (a - b), sq_nonneg (a - c), sq_nonneg (a - d),
+    sq_nonneg (b - c), sq_nonneg (b - d), sq_nonneg (c - d)]
+
+/-- **Newton's second (middle) inequality at `n = 4`** (`p₂² ≥ p₁ p₃`), for
+arbitrary signed reals: `9 e₁ e₃ ≤ 4 e₂²`, i.e.
+`9(a+b+c+d)(abc+abd+acd+bcd) ≤ 4(ab+ac+ad+bc+bd+cd)²`.  SOS certificate
+`3[(ab-cd)²+(ac-bd)²+(ad-bc)²] + ½[((a-b)(c-d))²+((a-c)(b-d))²+((a-d)(b-c))²]`.
+This is the `k = 2` step that Part III's general `k = 1` route does not reach. -/
+theorem newton_four_second (a b c d : ℝ) :
+    9 * (a + b + c + d) * (a * b * c + a * b * d + a * c * d + b * c * d)
+      ≤ 4 * (a * b + a * c + a * d + b * c + b * d + c * d) ^ 2 := by
+  nlinarith [sq_nonneg (a * b - c * d), sq_nonneg (a * c - b * d),
+    sq_nonneg (a * d - b * c), sq_nonneg ((a - b) * (c - d)),
+    sq_nonneg ((a - c) * (b - d)), sq_nonneg ((a - d) * (b - c))]
+
+/-- **Newton's third inequality at `n = 4`** (`p₃² ≥ p₂ p₄`), for arbitrary signed
+reals: `8 e₂ e₄ ≤ 3 e₃²`, i.e.
+`8(ab+ac+ad+bc+bd+cd)(abcd) ≤ 3(abc+abd+acd+bcd)²`.  SOS certificate
+`∑_{i<j}(xᵢ-xⱼ)²(xₖxₗ)²`, the image of the `k = 1` certificate under the reciprocal
+substitution `xᵢ ↦ 1/xᵢ`. -/
+theorem newton_four_third (a b c d : ℝ) :
+    8 * (a * b + a * c + a * d + b * c + b * d + c * d) * (a * b * c * d)
+      ≤ 3 * (a * b * c + a * b * d + a * c * d + b * c * d) ^ 2 := by
+  nlinarith [sq_nonneg ((a - b) * (c * d)), sq_nonneg ((a - c) * (b * d)),
+    sq_nonneg ((a - d) * (b * c)), sq_nonneg ((b - c) * (a * d)),
+    sq_nonneg ((b - d) * (a * c)), sq_nonneg ((c - d) * (a * b))]
+
+/-- **Newton at `n = 4` in normalized (`p`) form.**  All three log-concavity steps
+`p_{k-1} p_{k+1} ≤ p_k²` for `k = 1, 2, 3`, with `p₀=1, p₁=e₁/4, p₂=e₂/6,
+p₃=e₃/4, p₄=e₄`, hold for arbitrary signed reals `a, b, c, d`. -/
+theorem newton_four_normalized (a b c d : ℝ) :
+    (1 : ℝ) * ((a * b + a * c + a * d + b * c + b * d + c * d) / 6)
+        ≤ ((a + b + c + d) / 4) ^ 2 ∧
+      ((a + b + c + d) / 4) * ((a * b * c + a * b * d + a * c * d + b * c * d) / 4)
+        ≤ ((a * b + a * c + a * d + b * c + b * d + c * d) / 6) ^ 2 ∧
+      ((a * b + a * c + a * d + b * c + b * d + c * d) / 6) * (a * b * c * d)
+        ≤ ((a * b * c + a * b * d + a * c * d + b * c * d) / 4) ^ 2 := by
+  refine ⟨?_, ?_, ?_⟩
+  · nlinarith [newton_four_first a b c d]
+  · nlinarith [newton_four_second a b c d]
+  · nlinarith [newton_four_third a b c d]
 
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,9 +4,29 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 4 (PART III)
+**Iteration**: 5 (PART IV)
 
-## Current Focus
+## Iteration 5 (PART IV — n = 4 via SOS), PR #34576
+Discharged **ALL THREE** Newton log-concavity steps at `n = 4` for arbitrary
+SIGNED reals, via explicit SOS certificates (docker-build clean, 7743 jobs; 0
+sorries, 0 axioms). This reaches the middle (`k = 2`) and top (`k = 3`) steps
+that Part III's general `k = 1` QM–AM route does not cover, answering the
+entry's "extend the SOS approach to n = 4" open question. Four new theorems
+(16 → 20):
+- `newton_four_first`:  `8 e₂ ≤ 3 e₁²`   — SOS `∑_{i<j}(xᵢ−xⱼ)²`.
+- `newton_four_second`: `9 e₁ e₃ ≤ 4 e₂²` — SOS
+  `3∑(xᵢxⱼ−xₖxₗ)² + ½∑((xᵢ−xⱼ)(xₖ−xₗ))²` (three opposite-pair splittings).
+- `newton_four_third`:  `8 e₂ e₄ ≤ 3 e₃²` — SOS `∑_{i<j}(xᵢ−xⱼ)²(xₖxₗ)²`, the
+  reciprocal-polynomial image of the `k = 1` certificate.
+- `newton_four_normalized`: all three in normalized p-form.
+Certificates derived + verified symbolically (sympy: exact identities, 0
+numerical violations over 30k random signed samples). Method: the general Rolle
+crux is NOT needed at fixed arity — each Newton inequality at `n = 4` is a PSD
+quartic form whose SOS decomposition `nlinarith` verifies from the listed
+squares. Next SOS increment would be `n = 5` (degrees rise; feasibility of
+explicit certificates is the open question).
+
+## Iteration 4 (PART III) Focus
 Proved the genuinely **arbitrary-`n`** first Newton (= first Maclaurin)
 inequality `p₁² ≥ p₀ p₂` for SIGNED reals — no enumeration, no appeal to the
 still-open iterated-Rolle crux. Three new theorems in

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -18,7 +18,7 @@
     ]
   },
   "conclusion": {
-    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. Finally, Part III proves the FIRST Newton inequality k = 1 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — from the square-of-sum identity e_1^2 = p_2 + 2 e_2 (sq_sum_eq, a clean induction) together with the QM-AM bound e_1^2 <= n p_2 (Mathlib's sq_sum_le_card_mul_sum_sq), needing no Rolle-iteration lemma. All 16 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
+    "summary": "For all real x, y the entry proves x*y <= ((x+y)/2)^2 — Newton's inequality p_1^2 >= p_0 p_2 at n = 2 — obtained as the nonnegative discriminant of the real-rooted polynomial (X - x)(X - y). The reusable atom 'real-rooted quadratic => nonnegative discriminant' is proved through Mathlib's discrim_eq_sq_of_quadratic_eq_zero and phrased via the Polynomial.roots API. The file then discharges the FULL n = 3 case for arbitrary signed reals: both log-concavity steps e_1^2 >= 3 e_2 and e_2^2 >= 3 e_1 e_3 (and their normalized p-form), each realized as the nonnegative discriminant of a derivative quadratic and certified by an explicit sum-of-squares. Finally, Part III proves the FIRST Newton inequality k = 1 for arbitrary n and signed reals — 2 n e_2 <= (n-1) e_1^2 — from the square-of-sum identity e_1^2 = p_2 + 2 e_2 (sq_sum_eq, a clean induction) together with the QM-AM bound e_1^2 <= n p_2 (Mathlib's sq_sum_le_card_mul_sum_sq), needing no Rolle-iteration lemma. Part IV then discharges ALL THREE Newton steps at n = 4 for signed reals — 8 e_2 <= 3 e_1^2, 9 e_1 e_3 <= 4 e_2^2, and 8 e_2 e_4 <= 3 e_3^2 — via explicit sum-of-squares certificates, reaching the middle (k = 2) and top (k = 3) steps that the general k = 1 route does not cover. All 20 theorems are machine-checked with 0 sorries and 0 axioms (foundational axioms only).",
     "implications": [
       "Provides a reusable, signed-input building block — 'a real-rooted quadratic has nonnegative discriminant' — that any log-concavity/Newton-inequality development can differentiate down onto, decoupling the arithmetic atom from the (harder) real-rootedness-preservation step.",
       "Demonstrates that the n = 2 and n = 3 Newton inequalities need no positivity hypothesis at all: they are facts about real roots, not about positive numbers, and hence strictly generalize the AM-GM-style statements that assume x_i >= 0.",
@@ -26,7 +26,7 @@
     ],
     "openQuestions": [
       "Formalize the crux lemma that differentiating a fully real-rooted real polynomial yields a fully real-rooted polynomial (counting multiplicity) — the iterated-Rolle step — which would upgrade the atom to a proof of the HIGHER Newton inequalities (k >= 2) for every n; the first step k = 1 is already proved at arbitrary n in Part III via QM-AM.",
-      "Extend the SOS-certificate approach used at n = 3 to n = 4 and beyond, or show that beyond some degree explicit sum-of-squares certificates for the derivative-quadratic discriminants become impractical, forcing the general Rolle route.",
+      "Extend the SOS-certificate approach beyond n = 4 (the n = 4 case is now done in Part IV, all three steps) to n = 5 and up, or show that beyond some degree explicit sum-of-squares certificates for the derivative-quadratic discriminants become impractical, forcing the general Rolle route.",
       "Connect this real-rootedness proof to the modern Lorentzian/hyperbolic-polynomial framework (Branden-Huh), where log-concavity of the elementary symmetric coefficients is a special case of a much broader phenomenon."
     ]
   },
@@ -37,7 +37,11 @@
     "newton_three_first",
     "newton_three_second",
     "newton_three_normalized",
-    "newton_first_general"
+    "newton_first_general",
+    "newton_four_first",
+    "newton_four_second",
+    "newton_four_third",
+    "newton_four_normalized"
   ],
   "sorries": [],
   "sections": [
@@ -96,6 +100,13 @@
       "startLine": 191,
       "endLine": 273,
       "summary": "The arbitrary-n first Newton/Maclaurin inequality, avoiding both enumeration and the open Rolle crux. sq_sum_eq: (sum_{i<n} x_i)^2 = sum_{i<n} x_i^2 + 2 sum_{j<n} sum_{i<j} x_i x_j (i.e. e_1^2 = p_2 + 2 e_2), proved by a clean induction on n that sidesteps any triangular reindexing. sq_sum_le_nat_mul_sum_sq: the QM-AM bound (sum x_i)^2 <= n * sum x_i^2, from Mathlib's Chebyshev lemma sq_sum_le_card_mul_sum_sq on range n with card_range. newton_first_general: substituting p_2 = e_1^2 - 2 e_2 into e_1^2 <= n p_2 gives 2 n e_2 <= (n-1) e_1^2 — the normalized p_1^2 >= p_0 p_2 after clearing denominators — for signed reals at every arity."
+    },
+    {
+      "id": "part-iv-newton-n4-sos",
+      "title": "Part IV: Newton at n = 4 via explicit SOS certificates",
+      "startLine": 278,
+      "endLine": 351,
+      "summary": "All THREE Newton log-concavity steps at n = 4 for arbitrary signed reals, extending the Part II SOS method one arity further and covering the middle (k = 2) and top (k = 3) steps that Part III's general k = 1 route does not reach. newton_four_first: 8 e_2 <= 3 e_1^2, SOS sum_{i<j}(x_i - x_j)^2 (also the n = 4 instance of newton_first_general). newton_four_second: 9 e_1 e_3 <= 4 e_2^2, SOS 3[(ab-cd)^2+(ac-bd)^2+(ad-bc)^2] + (1/2)[((a-b)(c-d))^2+((a-c)(b-d))^2+((a-d)(b-c))^2] over the three opposite-pair splittings of {a,b,c,d}. newton_four_third: 8 e_2 e_4 <= 3 e_3^2, SOS sum_{i<j}(x_i - x_j)^2 (x_k x_l)^2, the reciprocal-polynomial image of the k = 1 certificate. newton_four_normalized assembles all three steps in normalized p-form (p_0=1, p_1=e_1/4, p_2=e_2/6, p_3=e_3/4, p_4=e_4). Each certificate is exact (verified symbolically) and closed by nlinarith; no sign hypothesis."
     }
   ],
   "crossReferences": [
@@ -121,8 +132,8 @@
       "Mathlib"
     ],
     "additionalFiles": [],
-    "lineCount": 273,
-    "theoremCount": 16,
+    "lineCount": 351,
+    "theoremCount": 20,
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0
@@ -146,7 +157,7 @@
     "additionalFiles": [],
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 16 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
+    "assumptions": "None. All 20 theorems verified with 0 sorries and 0 axioms; #print axioms lists only propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Imports Mathlib only.",
     "originalContributions": [
       "discrim_nonneg_of_root: a real quadratic a*x^2 + b*x + c with a real root has 0 <= discrim a b c — the reusable per-derivative 'real-rooted => log-concave coefficients' atom of the Rolle program",
       "monic_quadratic_discrim_nonneg: the same via Polynomial.IsRoot for the monic quadratic X^2 + C b * X + C c",
@@ -159,11 +170,13 @@
       "newton_three_normalized: both n = 3 log-concavity steps in normalized p-form, confirming p_1^2 >= p_0 p_2 and p_2^2 >= p_1 p_3 for all signed reals",
       "sq_sum_eq: the square-of-sum / elementary-symmetric identity (sum_{i<n} x_i)^2 = sum_{i<n} x_i^2 + 2 sum_{j<n} sum_{i<j} x_i x_j (e_1^2 = p_2 + 2 e_2) for any real sequence, proved by a clean induction on n with no triangular reindexing",
       "sq_sum_le_nat_mul_sum_sq: the QM-AM bound (sum_{i<n} x_i)^2 <= n * sum_{i<n} x_i^2, specializing Mathlib's Chebyshev inequality sq_sum_le_card_mul_sum_sq to range n",
-      "newton_first_general: the FIRST Newton/Maclaurin inequality 2 n e_2 <= (n-1) e_1^2 (normalized p_1^2 >= p_0 p_2) for ARBITRARY n and signed reals, derived by substituting e_1^2 = p_2 + 2 e_2 into the QM-AM bound — no enumeration and no appeal to the open iterated-Rolle crux, generalising the per-arity n=2/n=3 first steps to every arity at once"
+      "newton_first_general: the FIRST Newton/Maclaurin inequality 2 n e_2 <= (n-1) e_1^2 (normalized p_1^2 >= p_0 p_2) for ARBITRARY n and signed reals, derived by substituting e_1^2 = p_2 + 2 e_2 into the QM-AM bound — no enumeration and no appeal to the open iterated-Rolle crux, generalising the per-arity n=2/n=3 first steps to every arity at once",
+      "newton_four_first / newton_four_second / newton_four_third: ALL THREE Newton log-concavity steps at n = 4 for arbitrary signed reals (8 e_2 <= 3 e_1^2, 9 e_1 e_3 <= 4 e_2^2, 8 e_2 e_4 <= 3 e_3^2), each closed by nlinarith with an explicit, symbolically-verified SOS certificate — extending the Part II n=3 SOS method one arity further and, crucially, covering the middle (k=2) and top (k=3) steps that the general k=1 route of Part III does not reach; the k=2 certificate is 3*sum(x_i x_j - x_k x_l)^2 + (1/2)*sum((x_i-x_j)(x_k-x_l))^2 over the three opposite-pair splittings, and the k=3 certificate sum(x_i-x_j)^2 (x_k x_l)^2 is the reciprocal-polynomial image of the k=1 certificate",
+      "newton_four_normalized: all three n = 4 log-concavity steps assembled in normalized p-form (p_0=1, p_1=e_1/4, p_2=e_2/6, p_3=e_3/4, p_4=e_4), the first fully-signed n=4 Newton chain in the amgm family"
     ],
     "dateAdded": "2026-07-04",
-    "lineCount": 273,
-    "theoremCount": 16,
+    "lineCount": 351,
+    "theoremCount": 20,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   }


### PR DESCRIPTION
## Summary

Extends the gallery entry **amgm-inequality-oq-02-oq-02-oq-05** ("Newton's Inequality via Real-Rooted Polynomials and Rolle's Theorem") with a new **Part IV** proving **all three Newton log-concavity steps at n = 4** for arbitrary **signed** reals, via explicit sum-of-squares certificates.

Prior state: the file proved n = 2 and n = 3 (both steps) per-arity, plus the general k = 1 (first) Newton inequality for every n (Part III, via QM–AM). The **middle (k = 2)** and **top (k = 3)** Newton steps at n = 4 lie beyond that general k = 1 route — they were exactly the "extend the SOS approach to n = 4" open question in the entry's `openQuestions`.

## New theorems (all signed reals, no positivity hypothesis)

| Theorem | Statement | SOS certificate |
|---|---|---|
| `newton_four_first`  | `8 e₂ ≤ 3 e₁²` | `∑_{i<j}(xᵢ−xⱼ)²` |
| `newton_four_second` | `9 e₁ e₃ ≤ 4 e₂²` | `3∑(xᵢxⱼ−xₖxₗ)² + ½∑((xᵢ−xⱼ)(xₖ−xₗ))²` |
| `newton_four_third`  | `8 e₂ e₄ ≤ 3 e₃²` | `∑_{i<j}(xᵢ−xⱼ)²(xₖxₗ)²` (reciprocal of the k=1 cert) |
| `newton_four_normalized` | all three in normalized p-form | — |

Each certificate was derived and verified symbolically (sympy: exact identities, 0 numerical violations over 30k random signed samples), then `nlinarith` closes each theorem from the listed squares.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` — **clean (7743 jobs)**
- 0 sorries, 0 axioms (foundational only: propext / Classical.choice / Quot.sound)
- `meta.json` updated: theoremCount 16 → 20, new Part IV section, mainTheorems, originalContributions, conclusion summary, and open-question refresh (n=4 now done; n≥5 remains open). JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)