### PR TITLE
Enrich p-series dyadic bounds (harmonic-oq-05-oq-02): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-02/annotations.json
@@ -68,27 +68,51 @@
     ]
   },
   {
-    "id": "ann-convergent-regime",
+    "id": "ann-convergent-block-geom",
     "proofId": "harmonic-divergence-oq-05-oq-02",
     "range": {
       "startLine": 166,
+      "endLine": 208
+    },
+    "type": "technique",
+    "title": "Convergent Regime p > 1: Each Block is a Geometric Term",
+    "content": "On the convergent side the per-block estimate flips direction. In `block_le_geom`, for $k \\ge 2^n$ we have $2^n \\le k+1$, so $(2^n)^p \\le (k+1)^p$ (`Real.rpow_le_rpow`, valid since the exponent $p \\ge 0$) and hence $1/(k+1)^p \\le 1/(2^n)^p$; summing the $2^n$ equal-sized terms in the block and applying the ratio identity $2^n/(2^n)^p = (2^{1-p})^n$ bounds the whole block above by $(2^{1-p})^n$. The companion `geom_partial_le` bounds the resulting geometric partial sum, $\\sum_{i<n} r^i \\le 1/(1-r)$ for $0 \\le r < 1$: multiply through by $(1-r) > 0$ and use the telescoping identity `geom_sum_mul` ($\\sum_{i<n} r^i \\cdot (1-r) = 1 - r^n$), then drop the non-negative $r^n$. These two lemmas are the convergent-regime analogues of the divergent side's `block_ge_half` — the same dyadic block, now majorised instead of minorised.",
+    "mathContext": "For $k \\ge 2^n$: $1/(k+1)^p \\le 1/(2^n)^p$, so block $\\le 2^n \\cdot (2^n)^{-p} = (2^{1-p})^n$; and $\\sum_{i<n} r^i \\le \\frac{1}{1-r}$ for $0 \\le r < 1$ via $\\sum r^i (1-r) = 1 - r^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_le_rpow",
+      "geom_sum_mul",
+      "finite geometric series bound",
+      "dyadic block majorisation"
+    ],
+    "prerequisites": [
+      "rpow monotonicity in the base",
+      "finite geometric series",
+      "telescoping identities"
+    ]
+  },
+  {
+    "id": "ann-convergent-regime",
+    "proofId": "harmonic-divergence-oq-05-oq-02",
+    "range": {
+      "startLine": 209,
       "endLine": 242
     },
     "type": "insight",
-    "title": "Convergent Regime p > 1: the Uniform Explicit Ceiling",
-    "content": "On the convergent side the per-block estimate flips direction. In block_le_geom, for k ≥ 2ⁿ we have 2ⁿ ≤ k+1, so (2ⁿ)^p ≤ (k+1)^p (Real.rpow_le_rpow, exponent p ≥ 0) and hence 1/(k+1)^p ≤ 1/(2ⁿ)^p; summing the 2ⁿ terms and applying two_pow_div_rpow bounds the block by (2^{1-p})ⁿ. geom_partial_le bounds the resulting geometric partial sum ∑_{i<n} rⁱ ≤ 1/(1−r) for 0 ≤ r < 1, proved by multiplying through by (1−r) > 0 and using the telescoping identity geom_sum_mul. Hp_two_pow_le inducts to get H_p(2ⁿ) ≤ 1 + ∑_{i<n} (2^{1-p})ⁱ ≤ 1 + 1/(1 − 2^{1-p}); the ratio is < 1 because 2 > 1 and the exponent 1 − p < 0 (Real.rpow_lt_one_of_one_lt_of_neg). Finally Hp_bddAbove uses N ≤ 2ᴺ together with Hp_mono to extend the ceiling from the dyadic subsequence to every partial sum — the boundedness that underlies convergence of the p-series, now with an explicit n-independent constant.",
-    "mathContext": "$p > 1 \\Rightarrow$ block $\\le (2^{1-p})^n$ and $\\sum_{i<n}(2^{1-p})^i \\le \\frac{1}{1-2^{1-p}}$, so $H_p(2^n) \\le 1 + \\frac{1}{1 - 2^{1-p}}$ uniformly in $n$.",
+    "title": "The Uniform Explicit Ceiling and Bounded Partial Sums",
+    "content": "`Hp_two_pow_le` assembles the pieces by induction on $n$: peeling the top dyadic block via `Hp_two_pow_succ`, bounding it by $(2^{1-p})^n$ with `block_le_geom`, gives $H_p(2^n) \\le 1 + \\sum_{i<n}(2^{1-p})^i \\le 1 + \\frac{1}{1 - 2^{1-p}}$. The geometric ratio is genuinely $< 1$ because the base $2 > 1$ and the exponent $1 - p < 0$ (`Real.rpow_lt_one_of_one_lt_of_neg`), so the ceiling is a finite constant independent of $n$. `Hp_bddAbove` then extends the bound from the dyadic subsequence to *every* partial sum: for arbitrary $N$, monotonicity `Hp_mono` and $N \\le 2^N$ give $H_p(N) \\le H_p(2^N) \\le 1 + \\frac{1}{1-2^{1-p}}$. This n-independent ceiling is the quantitative heart of the $p$-series convergence test — Mathlib has the qualitative dichotomy but not this explicit constant.",
+    "mathContext": "$p > 1 \\Rightarrow H_p(2^n) \\le 1 + \\frac{1}{1 - 2^{1-p}}$ uniformly in $n$; via $N \\le 2^N$ and monotonicity, every $H_p(N) \\le 1 + \\frac{1}{1-2^{1-p}}$, so the partial sums are bounded above.",
     "significance": "critical",
     "relatedConcepts": [
       "Real.rpow_lt_one_of_one_lt_of_neg",
-      "geom_sum_mul",
-      "geometric series bound",
+      "bounded monotone sequences",
+      "p-series convergence test",
       "Cauchy condensation test"
     ],
     "prerequisites": [
-      "finite geometric series",
-      "rpow monotonicity",
-      "bounded monotone sequences"
+      "induction on dyadic blocks",
+      "monotone bounded ⇒ bounded above",
+      "geometric series sum 1/(1-r)"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-05-oq-02` (explicit dyadic-block bounds for the real p-series).

## Change
De-bundle annotations **4 → 5**. The convergent-regime annotation spanned lines **166–242** — 76 lines covering *three* theorems (`block_le_geom`, `geom_partial_le`, `Hp_two_pow_le`, `Hp_bddAbove`). Split at the seam between the per-block ingredients and the assembled uniform ceiling:

- **Convergent Regime p > 1: Each Block is a Geometric Term** (166–208) — `block_le_geom` (per-block geometric majorisation) + `geom_partial_le` (finite geometric-sum bound `∑ rⁱ ≤ 1/(1−r)`).
- **The Uniform Explicit Ceiling and Bounded Partial Sums** (209–242) — `Hp_two_pow_le` (`H_p(2ⁿ) ≤ 1 + 1/(1−2^{1−p})`, uniform in n) + `Hp_bddAbove` (extends to every partial sum via `N ≤ 2ᴺ` + monotonicity).

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Coverage unchanged (57–242); no annotation now spans three theorems.
- `meta.json` unchanged (15.7 KB, under cap). Proof remains 0-axiom.
