### PR TITLE
Enrich GCD/Gauss–Kuzmin (oq-05): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-05/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-05/annotations.json
@@ -2,49 +2,115 @@
   {
     "id": "gcd-oq05-ann-overview",
     "proofId": "gcd-algorithm-oq-05",
-    "range": { "startLine": 1, "endLine": 60 },
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
     "type": "concept",
     "title": "The Gauss–Kuzmin Distribution and the Scope of OQ-05",
     "content": "The header frames the parent's OQ-05: the Euclidean-algorithm quotients qᵢ = ⌊r_{i-1}/rᵢ⌋ are the continued-fraction digits of r₀/r₁, and the Gauss–Kuzmin distribution P(k) = log₂(1 + 1/(k(k+2))) is their limiting law. The full Gauss–Kuzmin–Lévy theorem (that the digits ARE asymptotically Gauss–Kuzmin distributed) needs the ergodicity of the Gauss map x ↦ {1/x} and the invariance of the Gauss measure — not yet in Mathlib. This file formalizes the foundational prerequisite: that the weights P(k) form a genuine probability distribution. Definitions: gaussKuzmin n = log₂(1 + 1/((n+1)(n+3))) (quotient value k = n+1) and the telescoping antiderivative G(n) = log₂((n+2)/(n+1)).",
     "mathContext": "$P(k) = \\log_2\\!\\left(1 + \\tfrac{1}{k(k+2)}\\right)$, the limiting law of continued-fraction digits.",
     "significance": "supporting",
-    "relatedConcepts": ["continued fractions", "Euclidean algorithm", "Gauss map", "ergodic theory"],
-    "prerequisites": ["continued-fraction expansion", "logarithms", "infinite series"]
+    "relatedConcepts": [
+      "continued fractions",
+      "Euclidean algorithm",
+      "Gauss map",
+      "ergodic theory"
+    ],
+    "prerequisites": [
+      "continued-fraction expansion",
+      "logarithms",
+      "infinite series"
+    ]
   },
   {
     "id": "gcd-oq05-ann-telescope",
     "proofId": "gcd-algorithm-oq-05",
-    "range": { "startLine": 61, "endLine": 81 },
+    "range": {
+      "startLine": 61,
+      "endLine": 81
+    },
     "type": "insight",
     "title": "Positivity and the Telescoping Identity",
     "content": "gaussKuzmin_pos: each weight is positive because 1 + 1/((n+1)(n+3)) > 1 and the base 2 > 1 (Real.logb_pos). gaussKuzmin_eq_sub is the crux: the transcendental-looking weight telescopes, because 1 + 1/((n+1)(n+3)) = (n+2)²/((n+1)(n+3)) = ((n+2)/(n+1)) / ((n+3)/(n+2)). Via Real.logb_div, P(n) = log₂((n+2)/(n+1)) − log₂((n+3)/(n+2)) = G(n) − G(n+1). So the seemingly hard series is a second difference of log₂(n).",
     "mathContext": "$1 + \\tfrac{1}{(n+1)(n+3)} = \\tfrac{(n+2)^2}{(n+1)(n+3)}$, so $P(n) = G(n) - G(n+1)$.",
     "significance": "critical",
-    "relatedConcepts": ["telescoping series", "logarithm of a quotient", "second differences"],
-    "prerequisites": ["log identities", "algebraic manipulation"]
+    "relatedConcepts": [
+      "telescoping series",
+      "logarithm of a quotient",
+      "second differences"
+    ],
+    "prerequisites": [
+      "log identities",
+      "algebraic manipulation"
+    ]
   },
   {
     "id": "gcd-oq05-ann-partial",
     "proofId": "gcd-algorithm-oq-05",
-    "range": { "startLine": 82, "endLine": 121 },
+    "range": {
+      "startLine": 82,
+      "endLine": 121
+    },
     "type": "insight",
     "title": "Closed Form of the Partial Sums",
     "content": "gaussKuzmin_partial collapses the telescoping sum (Finset.sum_range_sub') to ∑_{n<N} P(n) = G(0) − G(N) = 1 − log₂((N+2)/(N+1)). G_zero computes G(0) = log₂(2) = 1; G_nonneg shows G(N) ≥ 0 (the ratio ≥ 1); and G_tendsto_zero proves G(N) → 0, since (n+2)/(n+1) = 1 + 1/(n+1) → 1 (tendsto_one_div_add_atTop_nhds_zero_nat) and log₂ is continuous at 1 (continuity of log at a nonzero point). The closed form even exhibits the rate of convergence to the total mass 1.",
     "mathContext": "$\\sum_{n<N} P(n) = 1 - \\log_2\\!\\tfrac{N+2}{N+1} \\to 1$.",
     "significance": "key",
-    "relatedConcepts": ["telescoping sum", "limit of a ratio", "continuity of log"],
-    "prerequisites": ["partial sums", "limits of sequences"]
+    "relatedConcepts": [
+      "telescoping sum",
+      "limit of a ratio",
+      "continuity of log"
+    ],
+    "prerequisites": [
+      "partial sums",
+      "limits of sequences"
+    ]
+  },
+  {
+    "id": "gcd-oq05-ann-convergence",
+    "proofId": "gcd-algorithm-oq-05",
+    "range": {
+      "startLine": 122,
+      "endLine": 130
+    },
+    "type": "insight",
+    "title": "Partial Sums Converge to 1",
+    "content": "`gaussKuzmin_partial_tendsto_one` passes the closed form to the limit. The partial sum was shown to equal $G(0) - G(N)$ (the telescoping identity `gaussKuzmin_partial`), so rewriting by that `funext` and $G(0) = 1$ (`G_zero`) reduces the goal to $1 - G(N) \\to 1$; since $G(N) = \\log_2\\frac{N+2}{N+1} \\to 0$ (`G_tendsto_zero`), `tendsto_const_nhds.sub` closes it. This isolates *convergence of the partial sums* — the analytic core — before the summability and normalization statements repackage it in the language of `tsum`.",
+    "mathContext": "$\\sum_{n<N} P(n) = 1 - G(N) \\to 1$ as $N \\to \\infty$, since $G(N) = \\log_2\\frac{N+2}{N+1} \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sums",
+      "Filter.Tendsto",
+      "logarithm asymptotics"
+    ],
+    "prerequisites": [
+      "limits of sequences",
+      "the telescoping partial-sum identity"
+    ]
   },
   {
     "id": "gcd-oq05-ann-normalization",
     "proofId": "gcd-algorithm-oq-05",
-    "range": { "startLine": 122, "endLine": 167 },
+    "range": {
+      "startLine": 131,
+      "endLine": 167
+    },
     "type": "insight",
-    "title": "Convergence, Summability, and Normalization",
-    "content": "gaussKuzmin_partial_tendsto_one passes the closed form to the limit: the partial sums → 1. gaussKuzmin_summable uses the nonneg terms and the uniform bound 1 − G(N) ≤ 1 (summable_of_sum_range_le). Finally gaussKuzmin_tsum identifies ∑' P(k) = 1 by uniqueness of limits (tendsto_nhds_unique against the range-sum convergence of HasSum). Together with positivity, this is precisely the statement that the Gauss–Kuzmin weights are a genuine probability distribution — the normalization the OQ-05 question presupposes.",
-    "mathContext": "$\\sum_{k\\ge 1} P(k) = 1$ and $P(k) > 0$: a probability distribution.",
+    "title": "Summability and Normalization: a Genuine Probability Distribution",
+    "content": "`gaussKuzmin_summable` upgrades convergence to unconditional summability: the terms are nonnegative and every partial sum satisfies $1 - G(N) \\le 1$, so `summable_of_sum_range_le` applies with bound $c = 1$. `gaussKuzmin_tsum` then identifies $\\sum'_k P(k) = 1$ by uniqueness of limits (`tendsto_nhds_unique`) against the range-sum convergence of `HasSum`. Together with positivity (`gaussKuzmin_pos`), this is exactly the statement that the Gauss–Kuzmin weights form a genuine **probability distribution** — the normalization the OQ-05 question presupposes. The closing summary flags the scope boundary: the asymptotic Gauss–Kuzmin–Lévy distribution statement further needs ergodicity of the Gauss map and invariance of the Gauss measure, not yet in Mathlib.",
+    "mathContext": "$\\sum_{k\\ge 1} P(k) = 1$ with $P(k) > 0$: a probability distribution. Summability from $\\sum_{n<N} P(n) \\le 1$ and nonnegativity.",
     "significance": "critical",
-    "relatedConcepts": ["summability", "tsum", "probability distribution", "normalization"],
-    "prerequisites": ["infinite series", "summable families"]
+    "relatedConcepts": [
+      "summability",
+      "tsum",
+      "probability distribution",
+      "Gauss–Kuzmin–Lévy theorem"
+    ],
+    "prerequisites": [
+      "summable families",
+      "uniqueness of limits",
+      "HasSum and tsum"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `gcd-algorithm-oq-05` (Gauss–Kuzmin weights form a probability distribution).

## Change
De-bundle annotations **4 → 5**. The final annotation spanned lines **122–167**, covering convergence, summability, and normalization together. Split the analytic convergence from the `tsum` packaging:

- **Partial Sums Converge to 1** (122–130) — `gaussKuzmin_partial_tendsto_one` (the telescoping partial sum `1 − G(N) → 1`).
- **Summability and Normalization: a Genuine Probability Distribution** (131–167) — `gaussKuzmin_summable` + `gaussKuzmin_tsum` (∑′ P(k) = 1), plus the scope note on Gauss–Kuzmin–Lévy.

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Coverage unchanged (1–167).
- `meta.json` unchanged (17.0 KB, under cap). Proof remains 0-axiom.
