### PR TITLE
Erdős #3: arithProg_card + infinite_of_containsArbitrarilyLongAP (8→10 thms)

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -188,6 +188,44 @@ theorem containsAP_of_le {A : Set ℕ} {k m : ℕ} (hkm : k ≤ m)
   rw [Finset.mem_range] at hx ⊢
   omega
 
+/-- **A genuine `k`-term AP has exactly `k` elements.**
+    When the common difference `d` is positive, the generating map `i ↦ a + i·d`
+    is injective on `range k`, so `ArithProg a d k` has cardinality `k`.  (This is
+    exactly why `ContainsAP` insists on `d > 0`: without it the progression can
+    collapse to a single point.)  A reusable counting fact for turning
+    AP-containment into cardinality lower bounds. -/
+theorem arithProg_card (a d k : ℕ) (hd : 0 < d) :
+    (ArithProg a d k).card = k := by
+  have hinj : Function.Injective (fun i => a + i * d) := by
+    intro i j hij
+    dsimp only at hij
+    exact Nat.eq_of_mul_eq_mul_right hd (Nat.add_left_cancel hij)
+  unfold ArithProg
+  rw [Finset.card_image_of_injective _ hinj, Finset.card_range]
+
+/-- **Only infinite sets contain arbitrarily long APs.**
+    If `A` contains a `k`-term arithmetic progression (with positive common
+    difference) for every `k`, then `A` is infinite.  Indeed, were `A` finite with
+    `n = |A|` elements, the `(n+1)`-term AP it must contain would be an
+    `(n+1)`-element subset of `A` (`arithProg_card`), contradicting `|A| = n`.
+
+    A basic sanity check on the *conclusion* of Erdős #3: the property
+    `ContainsArbitrarilyLongAP` can only hold for infinite sets, matching the
+    hypothesis side (`HasDivergentSum` likewise forces infinitude).  Elementary,
+    `sorry`-free and axiom-free. -/
+theorem infinite_of_containsArbitrarilyLongAP {A : Set ℕ}
+    (h : ContainsArbitrarilyLongAP A) : A.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  obtain ⟨a, d, hd, hsub⟩ := h (hfin.toFinset.card + 1)
+  have hsubF : ArithProg a d (hfin.toFinset.card + 1) ⊆ hfin.toFinset := by
+    intro x hx
+    rw [Set.Finite.mem_toFinset]
+    exact hsub (Finset.mem_coe.mpr hx)
+  have hcard := Finset.card_le_card hsubF
+  rw [arithProg_card a d _ hd] at hcard
+  omega
+
 /-- **Analytic core of the reduction.**
     If the counting function of `A` obeys `f_A(N) ≤ C · N / (log N)^{1+δ}` for all
     large `N` (`δ > 0`), then `∑_{a ∈ A} 1/a` converges. Proof by dyadic blocking:

--- a/src/data/proofs/erdos-3/meta.json
+++ b/src/data/proofs/erdos-3/meta.json
@@ -46,7 +46,9 @@
       "Axiomatization of major results (Szemeredi, Gowers, Kelley-Meka, Leng-Sah-Sawhney)",
       "Connection to Green-Tao theorem on primes",
       "Behrend and Elkin constructions axiomatized",
-      "Formal proof that Erdos #3 implies Green-Tao"
+      "Formal proof that Erdos #3 implies Green-Tao",
+      "arithProg_card: a genuine k-term AP (d > 0) has exactly k elements, via injectivity of i ↦ a + i·d on range k — a reusable counting fact turning AP-containment into cardinality lower bounds",
+      "infinite_of_containsArbitrarilyLongAP: only infinite sets contain arbitrarily long APs (a finite set of size n cannot contain the (n+1)-element AP it would need), a sorry-free axiom-free sanity check on the conjecture's conclusion side"
     ],
     "axiomCount": 0,
     "lineCount": 163,
@@ -233,9 +235,9 @@
       "Finset"
     ],
     "namespace": "Erdos3",
-    "lineCount": 448,
+    "lineCount": 486,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Erdos3Problem.lean",
     "sorries": 1


### PR DESCRIPTION
## Summary

Two elementary, **sorry-free and axiom-free** structural lemmas for the Erdős Problem #3 entry (*Arithmetic Progressions in Large Sets*, `Proofs/Erdos3Problem.lean`):

- **`arithProg_card`** — a genuine `k`-term AP (common difference `d > 0`) has exactly `k` elements, proved via injectivity of `i ↦ a + i·d` on `range k`. A reusable counting fact for turning AP-containment into cardinality lower bounds (and the precise reason `ContainsAP` requires `d > 0`).
- **`infinite_of_containsArbitrarilyLongAP`** — only infinite sets can contain arbitrarily long APs: a finite set of size `n` cannot contain the `(n+1)`-element AP it would need. A basic sanity check on the *conclusion* side of the conjecture, mirroring the divergent-sum hypothesis side (which likewise forces infinitude).

## Scope / honesty

This is a **modest** increment. It deliberately does **not** touch the threshold-critical `required_bound_implies_conjecture` sorry, which is as hard as Erdős #3 itself (documented in the entry's research notes). The entry remains `axiomatized` with its one pre-existing, documented threshold sorry.

## Verification

- `LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.Erdos3Problem` — **clean (7743 jobs)**.
- Both new theorems compile with no errors and introduce no new sorry/axiom; the only `sorry` warning is the pre-existing line-156 threshold lemma.
- `meta.json`: `leanFile.theoremCount` 8 → 10, `lineCount` 448 → 486, `originalContributions` updated. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)