### PR TITLE
Enrich Gamma reflection (oq-01): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/gamma-reflection-formula-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01/annotations.json
@@ -2,49 +2,122 @@
   {
     "id": "ann-gamma-refl-oq01-docstring",
     "proofId": "gamma-reflection-formula-oq-01",
-    "range": { "startLine": 3, "endLine": 24 },
+    "range": {
+      "startLine": 3,
+      "endLine": 24
+    },
     "type": "concept",
     "title": "Euler's Reflection Formula and Its Reach",
     "content": "The docstring states Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs) for real and complex s. The core identity is Mathlib's Real./Complex.Gamma_mul_Gamma_one_sub, re-exported here under stable names — hence the mathlib badge. The file then derives the genuine new content: concrete special-value PRODUCTS obtained by feeding rational arguments into reflection and evaluating sin at the corresponding special angle (Γ(1/2)²=π, Γ(1/4)Γ(3/4)=π√2, Γ(1/3)Γ(2/3)=2π/√3, Γ(1/6)Γ(5/6)=2π), and the non-vanishing corollary that sin(πs) ≠ 0 ⟹ Γ s ≠ 0. The striking point: reflection evaluates these products exactly even though the individual values Γ(1/4), Γ(1/3) are not elementary.",
     "mathContext": "$\\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s)$, equivalent to $\\sin(\\pi s) = \\pi s\\prod_{n\\ge1}(1 - s^2/n^2)$ and to the cotangent partial-fraction expansion.",
     "significance": "supporting",
-    "relatedConcepts": ["Euler reflection formula", "Gamma function", "sine product formula", "transcendental values", "special functions"],
-    "prerequisites": ["the Gamma function", "the sine function", "complex analysis basics"]
+    "relatedConcepts": [
+      "Euler reflection formula",
+      "Gamma function",
+      "sine product formula",
+      "transcendental values",
+      "special functions"
+    ],
+    "prerequisites": [
+      "the Gamma function",
+      "the sine function",
+      "complex analysis basics"
+    ]
   },
   {
     "id": "ann-gamma-refl-oq01-reflection",
     "proofId": "gamma-reflection-formula-oq-01",
-    "range": { "startLine": 26, "endLine": 41 },
+    "range": {
+      "startLine": 26,
+      "endLine": 41
+    },
     "type": "theorem",
     "title": "The Reflection Identity, Real and Complex",
     "content": "gamma_reflection re-exports Γ(s)·Γ(1−s) = π/sin(πs) for the real Gamma function (Real.Gamma_mul_Gamma_one_sub), and gamma_reflection_complex does the same for the complex Gamma function with Complex.sin. These stable re-exports are the foundation every downstream result rewrites against. Delegating the deep identity to Mathlib is exactly what the mathlib badge records; the value added here is the catalogue of consequences built on top.",
     "mathContext": "Real: $\\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s)$. Complex: $\\Gamma(z)\\Gamma(1-z) = \\pi/\\sin(\\pi z)$, the analytic continuation valid off the poles.",
     "significance": "supporting",
-    "relatedConcepts": ["Real.Gamma_mul_Gamma_one_sub", "Complex.Gamma_mul_Gamma_one_sub", "re-export", "analytic continuation"],
-    "prerequisites": ["Mathlib Gamma API", "real vs complex Gamma"]
+    "relatedConcepts": [
+      "Real.Gamma_mul_Gamma_one_sub",
+      "Complex.Gamma_mul_Gamma_one_sub",
+      "re-export",
+      "analytic continuation"
+    ],
+    "prerequisites": [
+      "Mathlib Gamma API",
+      "real vs complex Gamma"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq01-half",
+    "proofId": "gamma-reflection-formula-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 58
+    },
+    "type": "insight",
+    "title": "The Self-Paired Value Γ(1/2)² = π",
+    "content": "The archetypal special value, and the only one where the reflection argument pairs $s$ with *itself*. At $s = 1/2$ the complement $1 - s$ is again $1/2$, so `Real.Gamma_mul_Gamma_one_sub` collapses to $\\Gamma(1/2)^2$; with $\\sin(\\pi/2) = 1$ the right side is $\\pi/1 = \\pi$. This recovers the squared form of the classical $\\Gamma(1/2) = \\sqrt\\pi$ **purely from the reflection identity**, bypassing the usual Gaussian-integral evaluation $\\int_{\\mathbb R} e^{-x^2}\\,dx = \\sqrt\\pi$. It is the base case of the recipe applied to the other rational arguments below, where the two factors are genuinely distinct.",
+    "mathContext": "At $s = 1/2$: $1 - s = 1/2$, $\\sin(\\pi/2) = 1$, so $\\Gamma(1/2)^2 = \\pi/\\sin(\\pi/2) = \\pi$; hence $\\Gamma(1/2) = \\sqrt\\pi$ without the Gaussian integral.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gaussian integral",
+      "Real.sin_pi_div_two",
+      "Gamma_mul_Gamma_one_sub",
+      "fixed point of s ↦ 1−s"
+    ],
+    "prerequisites": [
+      "reflection formula",
+      "sin(π/2) = 1",
+      "Γ(1/2) = √π"
+    ]
   },
   {
     "id": "ann-gamma-refl-oq01-special",
     "proofId": "gamma-reflection-formula-oq-01",
-    "range": { "startLine": 43, "endLine": 80 },
+    "range": {
+      "startLine": 59,
+      "endLine": 80
+    },
     "type": "insight",
-    "title": "Four Special-Value Products from One Recipe",
-    "content": "Each product is the same three-step specialization of reflection. gamma_half_sq: at s=1/2, the complement is also 1/2 and sin(π/2)=1, so Γ(1/2)² = π/1 = π — recovering the squared form of Γ(1/2)=√π WITHOUT the Gaussian integral. gamma_quarter_mul: at s=1/4, sin(π/4)=√2/2, and clearing the surd (Real.mul_self_sqrt) gives Γ(1/4)Γ(3/4)=π√2. gamma_third_mul: at s=1/3, sin(π/3)=√3/2 gives 2π/√3. gamma_sixth_mul: at s=1/6, sin(π/6)=1/2 gives 2π. The denominators k ∈ {2,4,3,6} are precisely those for which sin(π/k) has an elementary surd value. None of these product evaluations are in Mathlib.",
-    "mathContext": "$\\Gamma(1/2)^2=\\pi$; $\\Gamma(1/4)\\Gamma(3/4)=\\pi\\sqrt2$; $\\Gamma(1/3)\\Gamma(2/3)=2\\pi/\\sqrt3$; $\\Gamma(1/6)\\Gamma(5/6)=2\\pi$ — products elementary though the factors are transcendental.",
+    "title": "The Distinct-Argument Family: Quarter, Third, Sixth",
+    "content": "The remaining products each pair two *distinct* arguments via the same three-step specialization of reflection, then clear a surd. `gamma_quarter_mul`: at $s = 1/4$, $\\sin(\\pi/4) = \\sqrt2/2$, and clearing the surd (`Real.mul_self_sqrt`) gives $\\Gamma(1/4)\\Gamma(3/4) = \\pi\\sqrt2$. `gamma_third_mul`: at $s = 1/3$, $\\sin(\\pi/3) = \\sqrt3/2$ gives $2\\pi/\\sqrt3$. `gamma_sixth_mul`: at $s = 1/6$, $\\sin(\\pi/6) = 1/2$ gives $2\\pi$. The denominators $k \\in \\{4,3,6\\}$ (with $2$ from the half-value) are exactly those for which $\\sin(\\pi/k)$ has an elementary surd value — the constructible angles. Although each individual $\\Gamma(j/k)$ is transcendental, these *products* are elementary closed forms; none are in Mathlib.",
+    "mathContext": "$\\Gamma(1/4)\\Gamma(3/4)=\\pi\\sqrt2$; $\\Gamma(1/3)\\Gamma(2/3)=2\\pi/\\sqrt3$; $\\Gamma(1/6)\\Gamma(5/6)=2\\pi$ — from $\\sin(\\pi/k)$ at the constructible denominators $k\\in\\{3,4,6\\}$.",
     "significance": "key",
-    "relatedConcepts": ["special angles of sine", "Real.sin_pi_div_two/four/three/six", "Real.mul_self_sqrt", "transcendental factors", "elementary products"],
-    "prerequisites": ["reflection formula", "special values of sine", "surd manipulation"]
+    "relatedConcepts": [
+      "constructible angles",
+      "Real.sin_pi_div_four/three/six",
+      "Real.mul_self_sqrt",
+      "transcendental factors, elementary products"
+    ],
+    "prerequisites": [
+      "reflection formula",
+      "special values of sine",
+      "surd manipulation"
+    ]
   },
   {
     "id": "ann-gamma-refl-oq01-nonvanish",
     "proofId": "gamma-reflection-formula-oq-01",
-    "range": { "startLine": 82, "endLine": 106 },
+    "range": {
+      "startLine": 82,
+      "endLine": 106
+    },
     "type": "theorem",
     "title": "Non-Vanishing of Γ via Reflection",
     "content": "gamma_ne_zero_of_sin_ne_zero argues by contradiction: if Γ(s)=0 then the reflection product Γ(s)Γ(1−s) is 0, but it equals π/sin(πs), which is nonzero when sin(πs) ≠ 0 (div_ne_zero with π ≠ 0) — contradiction. gamma_ne_zero_of_not_int upgrades this: for a non-integer s, Real.sin_eq_zero_iff says a zero of sin(πs) would force s ∈ ℤ (the obtained n with n·π = π·s cancels to n = s via mul_right_cancel₀), so sin(πs) ≠ 0 and hence Γ(s) ≠ 0. This is the analytic fact that 1/Γ is entire — Γ never vanishes, its reciprocal having only the zeros at non-positive integers where Γ has poles.",
     "mathContext": "$\\sin(\\pi s)\\ne0 \\Rightarrow \\Gamma(s)\\Gamma(1-s)=\\pi/\\sin(\\pi s)\\ne0 \\Rightarrow \\Gamma(s)\\ne0$. Zeros of $\\sin(\\pi s)$ are exactly $s\\in\\mathbb Z$.",
     "significance": "key",
-    "relatedConcepts": ["non-vanishing of Gamma", "1/Γ entire", "Real.sin_eq_zero_iff", "div_ne_zero", "mul_right_cancel₀"],
-    "prerequisites": ["reflection formula", "zeros of sine", "proof by contradiction"]
+    "relatedConcepts": [
+      "non-vanishing of Gamma",
+      "1/Γ entire",
+      "Real.sin_eq_zero_iff",
+      "div_ne_zero",
+      "mul_right_cancel₀"
+    ],
+    "prerequisites": [
+      "reflection formula",
+      "zeros of sine",
+      "proof by contradiction"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `gamma-reflection-formula-oq-01` (special values of Γ from Euler's reflection formula).

## Change
De-bundle annotations **4 → 5**. The special-values annotation spanned lines **43–80**, covering four Γ-product theorems. Split the self-paired archetype from the distinct-argument family:

- **The Self-Paired Value Γ(1/2)² = π** (43–58) — `gamma_half_sq`; the only case where reflection pairs `s` with itself, recovering `Γ(1/2)=√π` without the Gaussian integral.
- **The Distinct-Argument Family: Quarter, Third, Sixth** (59–80) — `gamma_quarter_mul` (π√2), `gamma_third_mul` (2π/√3), `gamma_sixth_mul` (2π); the constructible denominators k∈{3,4,6}.

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Coverage unchanged (3–106).
- `meta.json` unchanged (19.1 KB, under cap). Proof remains 0-axiom.
