### PR TITLE
Enrich Cantelli/second-moment (oq-04): de-bundle annotations 4→5

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-04/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-04/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-pmsm-oq04-header",
     "proofId": "prob-method-second-moment-oq-04",
-    "range": { "startLine": 1, "endLine": 49 },
+    "range": {
+      "startLine": 1,
+      "endLine": 49
+    },
     "type": "concept",
     "title": "Scope: Cantelli's one-sided bound and the scaled-shift strategy",
     "content": "The opening docstring fixes the working setting — a Finset $s$ with the uniform counting measure and a random variable $f : \\alpha \\to \\mathbb{Q}$ — and states the target $P(f - \\mu \\geq a) \\leq \\sigma^2/(\\sigma^2 + a^2)$ for $a > 0$, where the upper tail is the fraction $\\#\\{i \\in s : f(i) - \\mu \\geq a\\}/\\#s$. The key methodological choice is announced here: the textbook proof minimizes the rational function $(\\sigma^2 + t^2)/(a + t)^2$ over the shift $t \\geq 0$ (optimum $t = \\sigma^2/a$), but to stay polynomial the file substitutes the *scaled* shift $g(i) = a\\,(f(i) - \\mu) + \\sigma^2 = a\\,(d_i + \\sigma^2/a)$, clearing all denominators until the final cross-multiplication.",
@@ -23,7 +26,10 @@
   {
     "id": "ann-pmsm-oq04-centering",
     "proofId": "prob-method-second-moment-oq-04",
-    "range": { "startLine": 50, "endLine": 62 },
+    "range": {
+      "startLine": 50,
+      "endLine": 62
+    },
     "type": "definition",
     "title": "Centering identity: deviations sum to zero",
     "content": "`sum_sub_mean_eq_zero` proves $\\sum_{i \\in s} (f(i) - \\mu) = 0$, where $\\mu = \\text{mean}\\,s\\,f$. The proof splits the sum as $\\sum_{i \\in s} f(i) - \\#s \\cdot \\mu$ via `Finset.sum_sub_distrib` and `Finset.sum_const`, then unfolds the definition of mean (which divides $\\sum f$ by $\\#s$) so the two terms cancel. This identity is the workhorse that annihilates the linear cross-term $2a\\sigma^2 \\sum (f(i) - \\mu)$ when the square of the scaled shift is expanded and summed — without it the second-moment identity would carry an extra first-moment term.",
@@ -42,7 +48,10 @@
   {
     "id": "ann-pmsm-oq04-cantelli-key",
     "proofId": "prob-method-second-moment-oq-04",
-    "range": { "startLine": 63, "endLine": 129 },
+    "range": {
+      "startLine": 63,
+      "endLine": 129
+    },
     "type": "insight",
     "title": "The cleared inequality: a polynomial certificate for Cantelli",
     "content": "`cantelli_key` is the division-free heart of the argument, proving $\\#\\text{tail} \\cdot (\\sigma^2 + a^2) \\leq \\#s \\cdot \\sigma^2$ where $\\#\\text{tail} = \\#\\{i : f(i) - \\mu \\geq a\\}$. Two ingredients combine. First, the second-moment identity for the scaled shift: expanding $g(i)^2 = a^2 (f(i)-\\mu)^2 + 2a\\sigma^2(f(i)-\\mu) + \\sigma^4$ and summing, the linear term dies by the centering identity and the quadratic term uses $\\sum (f(i)-\\mu)^2 = \\sigma^2 \\#s$, giving $\\sum g(i)^2 = \\#s\\,\\sigma^2(a^2 + \\sigma^2)$. Second, the tail lower bound: on the event $d_i \\geq a > 0$ one has $g(i) = a\\,d_i + \\sigma^2 \\geq a^2 + \\sigma^2 \\geq 0$, so $g(i)^2 \\geq (a^2 + \\sigma^2)^2$; since every $g(i)^2 \\geq 0$, summing over the tail subset and comparing to the full sum (`Finset.sum_le_sum_of_subset_of_nonneg`) gives $\\#\\text{tail}(a^2+\\sigma^2)^2 \\leq \\sum g(i)^2$. Cancelling the positive factor $a^2 + \\sigma^2$ (`le_of_mul_le_mul_right`) yields the cleared bound. The sharpness of Cantelli lives entirely in the single square $g(i)^2 \\geq (a^2+\\sigma^2)^2$ — there is no further slack.",
@@ -63,21 +72,49 @@
   {
     "id": "ann-pmsm-oq04-probability",
     "proofId": "prob-method-second-moment-oq-04",
-    "range": { "startLine": 130, "endLine": 171 },
+    "range": {
+      "startLine": 130,
+      "endLine": 158
+    },
     "type": "insight",
-    "title": "Probability statement and the strict gain over Chebyshev",
-    "content": "`tailProb` packages the upper-tail counting-measure probability $\\#\\{i \\in s : f(i)-\\mu \\geq a\\}/\\#s$. `cantelli` converts the cleared inequality into the probability bound $\\text{tailProb} \\leq \\sigma^2/(\\sigma^2 + a^2)$ by a single cross-multiplication: `div_le_div_iff` applies because both the sample size $\\#s$ and the denominator $\\sigma^2 + a^2$ are positive, reducing the goal to `cantelli_key`. Finally `tailProb_le_chebyshev` derives the classical one-sided Chebyshev bound $\\sigma^2/a^2$ from Cantelli by transitivity through $\\sigma^2/(\\sigma^2 + a^2) \\leq \\sigma^2/a^2$, making the strict-sharpness gap explicit: Cantelli always wins, and the gain is largest when $a$ is comparable to $\\sigma$.",
-    "mathContext": "$P(f - \\mu \\geq a) \\leq \\dfrac{\\sigma^2}{\\sigma^2 + a^2} \\leq \\dfrac{\\sigma^2}{a^2}$ — the middle term is Cantelli (sharp, tight for a two-point law), the right is one-sided Chebyshev.",
+    "title": "Cantelli's One-Sided Inequality as a Probability Bound",
+    "content": "`tailProb` packages the upper-tail counting-measure probability $\\#\\{i \\in s : f(i)-\\mu \\ge a\\}/\\#s$ — the fraction of sample points where $f$ exceeds its mean by at least $a$. `cantelli` converts the cleared polynomial certificate into the probability bound $\\text{tailProb} \\le \\sigma^2/(\\sigma^2 + a^2)$ by a single cross-multiplication: `div_le_div_iff` applies because both the sample size $\\#s$ and the denominator $\\sigma^2 + a^2$ are strictly positive (variance $\\ge 0$, $a^2 > 0$), reducing the goal to `cantelli_key`. This is the finite, rational-arithmetic form of Cantelli's inequality — sharper than Chebyshev and, unlike it, one-sided.",
+    "mathContext": "$P(f - \\mu \\ge a) = \\text{tailProb} \\le \\dfrac{\\sigma^2}{\\sigma^2 + a^2}$ for $a > 0$; cross-multiplying by the positive $\\#s$ and $\\sigma^2 + a^2$ reduces to `cantelli_key`.",
     "significance": "key",
     "relatedConcepts": [
       "Cantelli's inequality",
-      "Chebyshev's inequality",
-      "sharp concentration bounds",
-      "two-point extremizer"
+      "counting measure",
+      "div_le_div_iff",
+      "upper-tail probability"
     ],
     "prerequisites": [
-      "div_le_div_iff",
+      "the cleared key inequality (cantelli_key)",
+      "positivity of variance and a²",
+      "cross-multiplying inequalities"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq04-chebyshev",
+    "proofId": "prob-method-second-moment-oq-04",
+    "range": {
+      "startLine": 159,
+      "endLine": 171
+    },
+    "type": "insight",
+    "title": "The Strict Gain Over One-Sided Chebyshev",
+    "content": "`tailProb_le_chebyshev` derives the classical one-sided Chebyshev tail bound $\\sigma^2/a^2$ from Cantelli by transitivity: since $\\sigma^2 + a^2 \\ge a^2$, we have $\\sigma^2/(\\sigma^2 + a^2) \\le \\sigma^2/a^2$ (`hcomp`, closed by `nlinarith`), and chaining with `cantelli` via `le_trans` gives the weaker Chebyshev bound. This makes the sharpness gap explicit: Cantelli's denominator carries the extra $+\\sigma^2$, so it **always** beats Chebyshev, and the improvement is largest when the deviation $a$ is comparable to the standard deviation $\\sigma$. The Cantelli bound is tight — attained by a two-point distribution — so no constant-free one-sided improvement is possible.",
+    "mathContext": "$\\dfrac{\\sigma^2}{\\sigma^2 + a^2} \\le \\dfrac{\\sigma^2}{a^2}$; the left (Cantelli) is sharp for a two-point law, the right is one-sided Chebyshev. Gain $= \\dfrac{\\sigma^2}{a^2} - \\dfrac{\\sigma^2}{\\sigma^2+a^2} = \\dfrac{\\sigma^4}{a^2(\\sigma^2+a^2)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev's inequality",
+      "sharp concentration bounds",
+      "two-point extremizer",
       "transitivity of order"
+    ],
+    "prerequisites": [
+      "Cantelli's inequality",
+      "monotonicity of x ↦ σ²/x",
+      "nlinarith"
     ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `prob-method-second-moment-oq-04` (finite Cantelli one-sided inequality).

## Change
De-bundle annotations **4 → 5**. The final annotation spanned lines **130–171**, covering the probability statement and the Chebyshev comparison in one block (its title already named two results). Split at line 159:

- **Cantelli's One-Sided Inequality as a Probability Bound** (130–158) — `tailProb` (def) + `cantelli` (`P(f−μ≥a) ≤ σ²/(σ²+a²)`).
- **The Strict Gain Over One-Sided Chebyshev** (159–171) — `tailProb_le_chebyshev` (`σ²/(σ²+a²) ≤ σ²/a²`, so Cantelli always beats Chebyshev).

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Coverage unchanged (1–171).
- `meta.json` unchanged (19.7 KB, under cap). Proof remains 0-axiom.
