### PR TITLE
Enrich Eulerian⇆Stirling inverse (geo-oq-07…oq-01): annotations 4→5, fix example bundling

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/annotations.json
@@ -1,13 +1,13 @@
 [
   {
-    "id": "ann-docstring",
+    "id": "ann-geoseries-oq07inv-problem",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
-    "range": { "startLine": 1, "endLine": 56 },
-    "type": "concept",
-    "title": "Problem Statement and the Corrected Inverse Formula",
-    "content": "The docstring states open question oq-06-oq-01: the binomial inverse of the parent's forward Eulerian → Stirling identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩. Crucially, it records that the open question's proposed inverse ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j) is incorrect — for n=3, k=0 every term but j=0 vanishes (negative lower binomial index) and the surviving term carries 0!·S(3,0) = 0, giving 0 ≠ ⟨3,0⟩ = 1. The corrected and proved statement is ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i), verified numerically for all rows n ≤ 7. The proof is previewed as binomial inversion driven by the orthogonality ∑_m (−1)^{m−k}·C(m,k)·C(j,m) = [j=k].",
-    "mathContext": "Forward: $i!\\,S(n,i) = \\sum_{j<n}\\binom{j}{n-i}\\langle n,j\\rangle$. Inverse (corrected): $\\langle n,k\\rangle = \\sum_{i\\le n}(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i)$.",
-    "significance": "supporting",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "context",
+    "title": "The Open Question and the Corrected Inverse Formula",
+    "content": "The parent entry proved the **forward** Eulerian → Stirling identity $i!\\,S(n,i) = \\sum_{j<n} \\binom{j}{n-i}\\langle n,j\\rangle$, expressing the factorial-weighted Stirling row over the Eulerian row through plain binomial weights. This entry settles open question `oq-01`: the **inverse pairing**, recovering the Eulerian numbers from the Stirling row, so the two rows are mutually inverse under the binomial triangle. A subtlety recorded up front: the open question's *proposed* inverse $\\langle n,k\\rangle = \\sum_j (-1)^{k-j}\\binom{n-j}{k-j}\\,j!\\,S(n,j)$ is **incorrect** — at $n=3, k=0$ it gives $0$ whereas $\\langle 3,0\\rangle = 1$. The genuine binomial inverse proved here is `eulerian_inverse`: $\\langle n,k\\rangle = \\sum_{i\\le n}(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i)$ for $1\\le n$, $k\\le n-1$, numerically verified for all rows $n\\le 7$.",
+    "mathContext": "Corrected inverse: $\\langle n,k\\rangle = \\sum_{i\\le n}(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i)$. The OQ's proposal $\\sum_j(-1)^{k-j}\\binom{n-j}{k-j}j!\\,S(n,j)$ fails already at $n=3,k=0$ ($0 \\ne \\langle 3,0\\rangle = 1$).",
+    "significance": "context",
     "relatedConcepts": [
       "Eulerian numbers",
       "Stirling numbers of the second kind",
@@ -15,68 +15,33 @@
       "Worpitzky's identity"
     ],
     "prerequisites": [
-      "combinatorics",
-      "binomial coefficients",
-      "binomial transforms"
+      "Eulerian and Stirling triangles",
+      "the parent forward identity",
+      "binomial coefficients"
     ]
   },
   {
-    "id": "ann-binom-ortho",
+    "id": "ann-geoseries-oq07inv-strategy",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
-    "range": { "startLine": 58, "endLine": 121 },
-    "type": "tactic",
-    "title": "Binomial Orthogonality: the Inversion Kernel",
-    "content": "binom_ortho proves ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] for j ≤ N — the statement that the binomial-triangle matrix (C(m,k)) and its signed transpose ((−1)^{m−k}·C(m,k)) are mutually inverse (the discrete analogue of Möbius inversion on the binomial lattice). The branch j<k is dispatched directly: every term vanishes (C(m,k)=0 for m≤j<k, C(j,m)=0 for m>j). For k≤j the sum over range(N+1) is split into range k (zero since C(m,k)=0 for m<k) and Ico k (N+1); the survivors are reindexed m = k+t (Finset.sum_Ico_eq_sum_range) and each term rewritten by the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul). Factoring out C(j,k) leaves ∑_t (−1)^t·C(j−k,t), extended to the full row range(j−k+1) (the extra terms vanish) and evaluated to [j−k=0] by Int.alternating_sum_range_choose. Truncated ℕ subtraction in the exponent is harmless because C(m,k) already kills the m<k terms.",
-    "mathContext": "$\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = \\binom{j}{k}\\sum_{t}(-1)^t\\binom{j-k}{t} = \\binom{j}{k}(1-1)^{j-k} = [j=k]$.",
-    "significance": "key",
-    "relatedConcepts": [
-      "binomial inversion",
-      "subset-of-a-subset identity",
-      "alternating binomial sum",
-      "Möbius inversion"
-    ],
-    "prerequisites": [
-      "binomial coefficient identities",
-      "Finset reindexing",
-      "natural number subtraction in Lean"
-    ]
-  },
-  {
-    "id": "ann-eulerian-inverse",
-    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
-    "range": { "startLine": 123, "endLine": 184 },
-    "type": "insight",
-    "title": "The Inverse Pairing by Binomial Inversion",
-    "content": "eulerian_inverse proves ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) for 1 ≤ n and k ≤ n−1. It substitutes the parent's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩ (cast to ℤ via push_cast) into each summand (hsub), swaps the i- and j-summations with Finset.sum_comm, and for each fixed j factors ⟨n,j⟩ out and reflects the summation index i ↦ n−i with Finset.sum_range_reflect — turning the inner sum into the standard orthogonality form so binom_ortho evaluates it to [j=k] (hinner). The outer sum ∑_{j<n} ⟨n,j⟩·[j=k] then collapses to ⟨n,k⟩ via Finset.sum_ite_eq', using k ∈ range n (k ≤ n−1). The only substantive input is the forward identity; everything else is the inversion machinery.",
-    "mathContext": "$\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i) = \\sum_j\\langle n,j\\rangle\\!\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\binom{j}{n-i} = \\sum_j\\langle n,j\\rangle[j=k] = \\langle n,k\\rangle$.",
-    "significance": "critical",
-    "relatedConcepts": [
-      "binomial inversion",
-      "double sum interchange",
-      "index reflection",
-      "Eulerian–Stirling duality"
-    ],
-    "prerequisites": [
-      "Finset.sum_comm",
-      "Finset.sum_range_reflect",
-      "casting ℕ sums to ℤ"
-    ]
-  },
-  {
-    "id": "ann-concrete-rows",
-    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
-    "range": { "startLine": 186, "endLine": 190 },
-    "type": "concept",
-    "title": "Corroboration on Concrete Rows",
-    "content": "Three kernel-decidable sanity checks confirm the inverse formula on small rows: ⟨3,1⟩ = 4, ⟨4,1⟩ = 11, and ⟨4,2⟩ = 11, each equated to its signed Stirling sum ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i). All use kernel decide rather than native_decide, so they add no axiom dependency (no Lean.ofReduceBool).",
-    "mathContext": "$\\langle 4,2\\rangle = 11 = \\sum_{i\\le 4}(-1)^{4-i-2}\\binom{4-i}{2}\\,i!\\,S(4,i)$.",
+    "range": { "startLine": 26, "endLine": 56 },
+    "type": "technique",
+    "title": "Proof Strategy: Binomial Inversion of the Upper Transform",
+    "content": "The forward identity reads $c_i := i!\\,S(n,i) = \\sum_j \\binom{j}{n-i}E_j$ with $E_j := \\langle n,j\\rangle$; writing $m = n-i$ this is the *upper* binomial transform $f(m) = \\sum_j \\binom{j}{m}E_j$ of the Eulerian row. Its inverse is governed by orthogonality of the binomial triangle under the alternating weight, $\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = [j=k]$ (`binom_ortho`, the inversion kernel proved next). The plan: substitute the forward identity into the claimed inverse sum, swap the order of summation, reflect the index $i \\mapsto n-i$ to expose each inner sum as the orthogonality kernel, which collapses the double sum to the single term $\\langle n,k\\rangle$. This file imports the parent (forward identity) and grandparent, and everything is 0-axiom (`propext`/`Classical.choice`/`Quot.sound` only) and `sorry`-free.",
+    "mathContext": "Upper binomial transform $f(m) = \\sum_j\\binom{j}{m}E_j$ inverted via $\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = [j=k]$; substitute → swap → reflect → collapse.",
     "significance": "supporting",
     "relatedConcepts": [
-      "decidable verification",
-      "kernel decide"
+      "upper binomial transform",
+      "Möbius/binomial inversion",
+      "orthogonality kernel",
+      "double-sum interchange"
     ],
     "prerequisites": [
-      "Eulerian and Stirling number values"
+      "binomial transforms",
+      "alternating-sign orthogonality",
+      "the forward Eulerian–Stirling identity"
     ]
-  }
+  },
+  {"id":"ann-binom-ortho","proofId":"geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01","range":{"startLine":58,"endLine":121},"type":"tactic","title":"Binomial Orthogonality: the Inversion Kernel","content":"binom_ortho proves ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] for j ≤ N — the statement that the binomial-triangle matrix (C(m,k)) and its signed transpose ((−1)^{m−k}·C(m,k)) are mutually inverse (the discrete analogue of Möbius inversion on the binomial lattice). The branch j<k is dispatched directly: every term vanishes (C(m,k)=0 for m≤j<k, C(j,m)=0 for m>j). For k≤j the sum over range(N+1) is split into range k (zero since C(m,k)=0 for m<k) and Ico k (N+1); the survivors are reindexed m = k+t (Finset.sum_Ico_eq_sum_range) and each term rewritten by the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul). Factoring out C(j,k) leaves ∑_t (−1)^t·C(j−k,t), extended to the full row range(j−k+1) (the extra terms vanish) and evaluated to [j−k=0] by Int.alternating_sum_range_choose. Truncated ℕ subtraction in the exponent is harmless because C(m,k) already kills the m<k terms.","mathContext":"$\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = \\binom{j}{k}\\sum_{t}(-1)^t\\binom{j-k}{t} = \\binom{j}{k}(1-1)^{j-k} = [j=k]$.","significance":"key","relatedConcepts":["binomial inversion","subset-of-a-subset identity","alternating binomial sum","Möbius inversion"],"prerequisites":["binomial coefficient identities","Finset reindexing","natural number subtraction in Lean"]},
+  {"id":"ann-eulerian-inverse","proofId":"geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01","range":{"startLine":123,"endLine":172},"type":"insight","title":"The Inverse Pairing by Binomial Inversion","content":"eulerian_inverse proves ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) for 1 ≤ n and k ≤ n−1. It substitutes the parent's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩ (cast to ℤ via push_cast) into each summand (hsub), swaps the i- and j-summations with Finset.sum_comm, and for each fixed j factors ⟨n,j⟩ out and reflects the summation index i ↦ n−i with Finset.sum_range_reflect — turning the inner sum into the standard orthogonality form so binom_ortho evaluates it to [j=k] (hinner). The outer sum ∑_{j<n} ⟨n,j⟩·[j=k] then collapses to ⟨n,k⟩ via Finset.sum_ite_eq', using k ∈ range n (k ≤ n−1). The only substantive input is the forward identity; everything else is the inversion machinery.","mathContext":"$\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i) = \\sum_j\\langle n,j\\rangle\\!\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\binom{j}{n-i} = \\sum_j\\langle n,j\\rangle[j=k] = \\langle n,k\\rangle$.","significance":"critical","relatedConcepts":["binomial inversion","double sum interchange","index reflection","Eulerian–Stirling duality"],"prerequisites":["Finset.sum_comm","Finset.sum_range_reflect","casting ℕ sums to ℤ"]},
+  {"id":"ann-concrete-rows","proofId":"geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01","range":{"startLine":173,"endLine":190},"type":"concept","title":"Corroboration on Concrete Rows","content":"Three kernel-decidable sanity checks confirm the inverse formula on small rows: ⟨3,1⟩ = 4, ⟨4,1⟩ = 11, and ⟨4,2⟩ = 11, each equated to its signed Stirling sum ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i). All use kernel decide rather than native_decide, so they add no axiom dependency (no Lean.ofReduceBool).","mathContext":"$\\langle 4,2\\rangle = 11 = \\sum_{i\\le 4}(-1)^{4-i-2}\\binom{4-i}{2}\\,i!\\,S(4,i)$.","significance":"supporting","relatedConcepts":["decidable verification","kernel decide"],"prerequisites":["Eulerian and Stirling number values"]}
 ]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01` (inverse Eulerian⇆Stirling binomial pairing).

## Change
Annotations **4 → 5**, also fixing an awkward split. Previously the `eulerian_inverse` annotation (123–184) spilled over two of the three corroboration examples while the third example sat alone (186–190). New structure:

- **The Open Question and the Corrected Inverse Formula** (1–25) — the OQ, and why its *proposed* inverse is wrong (fails at n=3,k=0).
- **Proof Strategy: Binomial Inversion of the Upper Transform** (26–56) — substitute → swap → reflect → collapse via the orthogonality kernel.
- **Binomial Orthogonality: the Inversion Kernel** (58–121) — `binom_ortho` (unchanged).
- **The Inverse Pairing by Binomial Inversion** (123–172) — `eulerian_inverse` alone (retrimmed).
- **Corroboration on Concrete Rows** (173–190) — all three kernel-`decide` examples ⟨3,1⟩,⟨4,1⟩,⟨4,2⟩.

## Quality
- All **5** annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- Coverage 1–190; no annotation now mixes the theorem with its numeric checks.
- `meta.json` unchanged (20.6 KB, under cap). Proof remains 0-axiom.
