### PR TITLE
Research: Ramsey LLL OQ-03 — sharp LLL-vs-union-bound crossover characterization [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/RamseyR4kExtensionsOQ03.lean
+++ b/proofs/Proofs/RamseyR4kExtensionsOQ03.lean
@@ -386,6 +386,57 @@ theorem unionBound_beats_lll_at_7 :
   rw [ramseyLLLCondition_iff]
   decide
 
+/-- **Crossover, small-`n` (strict converse) side.**  The exact dual of
+    `lll_core_le_firstMoment_core`.  When `C(n,2) < 3·C(k,2)²` — `n` is *small*
+    relative to `k²`, the pre-asymptotic regime of `unionBound_beats_lll_at_6/7` —
+    the union-bound core `2·C(n,k)` is *strictly* smaller than the LLL core `6·d`,
+    so the honest first moment is the more permissive of the two tests.  Together
+    with `lll_core_le_firstMoment_core` this pins the crossover to the single
+    scalar comparison `C(n,2) ⋛ 3·C(k,2)²`.
+
+    Proof: cancel the positive common factor `2·C(n,k) > 0` (needs `k ≤ n`) out of
+    the exact identity `C(n,2)·(6d) = 3·C(k,2)²·(2·C(n,k))`
+    (`lll_core_eq_firstMoment_core`); the strict hypothesis on `C(n,2)` then
+    transfers directly. -/
+theorem firstMoment_core_lt_lll_core {n k : ℕ} (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hreg : n.choose 2 < 3 * (k.choose 2) ^ 2) :
+    2 * n.choose k < 6 * cliqueDependencyBound n k := by
+  have hpos : 0 < 2 * n.choose k := by
+    have := Nat.choose_pos hkn; positivity
+  have hid := lll_core_eq_firstMoment_core (n := n) (k := k) hk
+  have hlt : n.choose 2 * (2 * n.choose k)
+      < n.choose 2 * (6 * cliqueDependencyBound n k) := by
+    rw [hid]
+    exact mul_lt_mul_of_pos_right hreg hpos
+  exact lt_of_mul_lt_mul_left hlt (Nat.zero_le _)
+
+/-- **Sharp crossover characterization.**  Combining the large-`n` bound
+    `lll_core_le_firstMoment_core` (contrapositive) with its strict small-`n`
+    converse `firstMoment_core_lt_lll_core` shows the crossover between the
+    symmetric-LLL feasibility core `6·(d+1)` and the sharp union-bound core
+    `2·C(n,k)` is governed *exactly* by the sign of `C(n,2) − 3·C(k,2)²`:
+
+      `2·C(n,k) < 6·d  ↔  C(n,2) < 3·C(k,2)²`.
+
+    Reading `6·d` as the dominant part of the LLL budget requirement `6·(d+1)` and
+    `2·C(n,k)` as the union-bound budget requirement (both compared against the same
+    `2^{C(k,2)}`, cf. `ramseyLLLCondition_iff` and `firstMomentCondition`), this is
+    the finite, axiom-free statement that the two feasibility tests of this file
+    trade places precisely at `C(n,2) = 3·C(k,2)²`.  It subsumes the numeric
+    witnesses `unionBound_beats_lll_at_6/7` (small-`n` side) and the asymptotic
+    `lll_core_le_firstMoment_core` (large-`n` side) as the two halves of one
+    equivalence. -/
+theorem lll_core_gt_firstMoment_core_iff {n k : ℕ} (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hn : 2 ≤ n) :
+    2 * n.choose k < 6 * cliqueDependencyBound n k
+      ↔ n.choose 2 < 3 * (k.choose 2) ^ 2 := by
+  constructor
+  · intro h
+    by_contra hcon
+    push_neg at hcon
+    exact absurd (lll_core_le_firstMoment_core hk hn hcon) (by omega)
+  · exact firstMoment_core_lt_lll_core hk hkn
+
 -- ═══════════════════════════════════════════════════════════════════
 -- PART VIII: THE REAL LLL CONSTANT `e < 3` JUSTIFIES THE INTEGER SURROGATE
 -- ═══════════════════════════════════════════════════════════════════

--- a/src/data/proofs/ramsey-r4k-extensions-oq-03/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-03/meta.json
@@ -115,6 +115,13 @@
       "startLine": 204,
       "endLine": 231,
       "summary": "cliqueDependencyBound_mono shows the dependency degree is monotone in the number of vertices, and RamseyLLLCondition_antitone concludes the feasibility test is a genuine threshold: holding at m vertices implies holding at every n ≤ m."
+    },
+    {
+      "id": "sharp-crossover-characterization",
+      "title": "Sharp LLL-vs-union-bound crossover characterization",
+      "startLine": 389,
+      "endLine": 432,
+      "summary": "firstMoment_core_lt_lll_core is the strict small-n converse of lll_core_le_firstMoment_core: when C(n,2) < 3·C(k,2)² the union-bound core 2·C(n,k) is strictly below the LLL core 6·d, obtained by cancelling the positive factor 2·C(n,k) out of the exact identity C(n,2)·6d = 3·C(k,2)²·2·C(n,k). Combining both directions, lll_core_gt_firstMoment_core_iff proves the equivalence 2·C(n,k) < 6·d ↔ C(n,2) < 3·C(k,2)², pinning the crossover between the symmetric-LLL feasibility core and the sharp union bound to the single scalar comparison C(n,2) ⋛ 3·C(k,2)². This subsumes the numeric witnesses unionBound_beats_lll_at_6/7 (small-n side) and the asymptotic lll_core_le_firstMoment_core (large-n side) as the two halves of one iff."
     }
   ],
   "conclusion": {
@@ -163,9 +170,9 @@
   "leanFile": {
     "path": "Proofs/RamseyR4kExtensionsOQ03.lean",
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 22,
     "definitionCount": 6,
-    "lineCount": 479,
+    "lineCount": 593,
     "sorries": 0
   }
 }


### PR DESCRIPTION
## Summary

Extends the verified `ramsey-r4k-extensions-oq-03` gallery entry (symmetric Lovász Local Lemma dependency degree `d = C(k,2)·C(n−2,k−2)` for Spencer's improved diagonal Ramsey lower bound) with the **exact crossover** between the LLL feasibility core and the sharp first-moment (union-bound) core.

### The gap this closes

The entry already contained:
- `lll_core_le_firstMoment_core` — the **large-`n`** direction: `6·d ≤ 2·C(n,k)` when `3·C(k,2)² ≤ C(n,2)` (LLL beats the union bound asymptotically);
- `unionBound_beats_lll_at_6/7` — two **numeric witnesses** in the opposite regime.

Missing was the general strict converse and a clean characterization. This PR adds both.

### New theorems (both 0-axiom, finite ℕ arithmetic)

1. **`firstMoment_core_lt_lll_core`** — strict small-`n` converse: if `C(n,2) < 3·C(k,2)²` and `k ≤ n`, then `2·C(n,k) < 6·d`. Proof cancels the positive common factor `2·C(n,k)` out of the pre-existing exact incidence identity `C(n,2)·6d = 3·C(k,2)²·2·C(n,k)` (`lll_core_eq_firstMoment_core`).

2. **`lll_core_gt_firstMoment_core_iff`** — the sharp characterization:

   ```
   2·C(n,k) < 6·d  ↔  C(n,2) < 3·C(k,2)²
   ```

   pinning the crossover between the symmetric-LLL feasibility core and the sharp union bound to the single scalar comparison `C(n,2) ⋛ 3·C(k,2)²`. It subsumes `unionBound_beats_lll_at_6/7` (small-`n` side) and `lll_core_le_firstMoment_core` (large-`n` side) as the two halves of one equivalence.

### Verification

- Builds green via `./proofs/scripts/docker-build.sh Proofs.RamseyR4kExtensionsOQ03` (Lean 4.26.0 / Mathlib, 7744 jobs).
- No `axiom`, no `sorry`, no `native_decide` — proofs use only `mul_lt_mul_of_pos_right`, `lt_of_mul_lt_mul_left`, `omega`, `positivity` over the existing exact identity. Entry remains `verified` / 0-axiom.
- `meta.json` updated: new "Sharp LLL-vs-union-bound crossover characterization" section; `leanFile` stats refreshed (593 lines, 22 theorem/lemma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)