### PR TITLE
Enrich Nth Root Irrationality (OQ-02-OQ-02): annotation depth + coverage

### DIFF
--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "context",
+    "title": "Motivation: the Exponent-1 Gap in the Parent Criterion",
+    "content": "The module docstring frames the problem this entry solves. The parent file proves the raw valuation criterion `¬ n ∣ m.factorization p → ¬ ∃ k, k^n = m`, but its user-facing helper `not_perfect_pow_of_sq_not_dvd` only fires when a prime divides the radicand *exactly once* (exponent 1). That misses every radicand whose prime exponents are all `≥ 2` yet not all divisible by `n`.\n\nThe canonical missed case is `72 = 2³·3²`: the odd exponent 3 of the prime 2 makes `√72` irrational, but `2² ∣ 72` disables the exponent-1 lemma while `3` (exponent 2) is benign for `n = 2`. This file builds the ergonomic bridge to the raw criterion for exactly these mixed-exponent radicands.",
+    "mathContext": "$\\big(\\exists\\,p\\text{ prime},\\ n\\nmid v_p(m)\\big)\\Rightarrow\\sqrt[n]{m}\\notin\\mathbb{Q}$, where $v_p(m)$ is the $p$-adic valuation. Missed by exponent-1: $72=2^3\\cdot 3^2$ with $v_2=3,\\ v_3=2$.",
+    "significance": "context",
+    "relatedConcepts": ["p-adic valuation", "unique factorization", "perfect powers", "irrationality"],
+    "prerequisites": ["number theory", "prime factorization"]
+  },
+  {
     "id": "ann-existential",
     "proofId": "nth-root-irrational-oq-02-oq-02",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "theorem",
     "title": "The Valuation Criterion in Existential Form",
-    "content": "Proves `irrational_nthRoot_of_exists_factorization`: if some prime `p` has `n ∤ m.factorization p`, then `ⁿ√m` is irrational.\n\n**Statement.** `(∃ p, ¬ n ∣ m.factorization p) → Irrational (nthRoot n m)` — the exact shape of the problem's formal statement.\n\n**Proof.** Destructure the witness `p` and feed the parent's raw criterion `not_perfect_pow_of_factorization` through the ℕ→ℤ bridge `not_perfect_pow_int` into the base general theorem `irrational_nthRoot`. When `m = 0` the hypothesis is vacuous, since `n ∣ 0 = m.factorization p` for every `p`.\n\nThis is the honest, complete irrationality test: it fires on every radicand that is not a perfect `n`-th power, with no restriction on the sizes of the other exponents."
+    "content": "Proves `irrational_nthRoot_of_exists_factorization`: if some prime `p` has `n ∤ m.factorization p`, then `ⁿ√m` is irrational.\n\n**Statement.** `(∃ p, ¬ n ∣ m.factorization p) → Irrational (nthRoot n m)` — the exact shape of the problem's formal statement.\n\n**Proof.** Destructure the witness `p` and feed the parent's raw criterion `not_perfect_pow_of_factorization` through the ℕ→ℤ bridge `not_perfect_pow_int` into the base general theorem `irrational_nthRoot`. When `m = 0` the hypothesis is vacuous, since `n ∣ 0 = m.factorization p` for every `p`.\n\nThis is the honest, complete irrationality test: it fires on every radicand that is not a perfect `n`-th power, with no restriction on the sizes of the other exponents.",
+    "mathContext": "$m$ is a perfect $n$-th power $\\iff n \\mid v_p(m)$ for every prime $p$. Negating: a single prime with $n \\nmid v_p(m)$ obstructs, giving $\\sqrt[n]{m}\\notin\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "existential quantifier", "perfect powers", "Nat.factorization"],
+    "prerequisites": ["number theory", "unique prime factorization"]
   },
   {
     "id": "ann-exponent-e",
@@ -19,7 +38,11 @@
     },
     "type": "key-step",
     "title": "Certifying the Exact Valuation by a Divisibility Window",
-    "content": "Proves `not_perfect_pow_of_factorization_eq`: a prime `p` of exponent exactly `e` in `m` (witnessed by `p^e ∣ m` and `¬ p^(e+1) ∣ m`) with `n ∤ e` shows `m` is not a perfect `n`-th power.\n\n**Proof.** `Nat.Prime.pow_dvd_iff_le_factorization` turns `p^e ∣ m` into `e ≤ v_p(m)` and `¬ p^(e+1) ∣ m` into `¬(e+1 ≤ v_p(m))`, so `omega` pins `v_p(m) = e`. Rewriting reduces the goal to the parent's raw criterion with the hypothesis `n ∤ e`.\n\nThe divisibility window is the ergonomic bridge: both halves are `decide`s whose cost is independent of the magnitude of `m`, and taking `e = 1` recovers the parent's exponent-1 corollary `not_perfect_pow_of_sq_not_dvd`."
+    "content": "Proves `not_perfect_pow_of_factorization_eq`: a prime `p` of exponent exactly `e` in `m` (witnessed by `p^e ∣ m` and `¬ p^(e+1) ∣ m`) with `n ∤ e` shows `m` is not a perfect `n`-th power.\n\n**Proof.** `Nat.Prime.pow_dvd_iff_le_factorization` turns `p^e ∣ m` into `e ≤ v_p(m)` and `¬ p^(e+1) ∣ m` into `¬(e+1 ≤ v_p(m))`, so `omega` pins `v_p(m) = e`. Rewriting reduces the goal to the parent's raw criterion with the hypothesis `n ∤ e`.\n\nThe divisibility window is the ergonomic bridge: both halves are `decide`s whose cost is independent of the magnitude of `m`, and taking `e = 1` recovers the parent's exponent-1 corollary `not_perfect_pow_of_sq_not_dvd`.",
+    "mathContext": "The two-sided window $p^e \\mid m \\wedge p^{e+1} \\nmid m$ is equivalent to $v_p(m) = e$. Formally $p^k \\mid m \\iff k \\le v_p(m)$ (`pow_dvd_iff_le_factorization`), so $e \\le v_p(m)$ and $\\neg(e+1 \\le v_p(m))$ force $v_p(m)=e$.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "divisibility", "decidability", "omega"],
+    "prerequisites": ["number theory", "Nat.factorization", "Lean tactics"]
   },
   {
     "id": "ann-irrationality",
@@ -30,7 +53,11 @@
     },
     "type": "theorem",
     "title": "Irrationality from a Single Blocking Prime",
-    "content": "Proves `irrational_nthRoot_of_factorization_eq`: an exponent-`e` divisibility window plus `n ∤ e` yields `Irrational (nthRoot n m)`. Composes `not_perfect_pow_of_factorization_eq` (via the ℕ→ℤ bridge) with the base `irrational_nthRoot`. This is the practical workhorse used by every concrete corollary below."
+    "content": "Proves `irrational_nthRoot_of_factorization_eq`: an exponent-`e` divisibility window plus `n ∤ e` yields `Irrational (nthRoot n m)`. Composes `not_perfect_pow_of_factorization_eq` (via the ℕ→ℤ bridge) with the base `irrational_nthRoot`. This is the practical workhorse used by every concrete corollary below.",
+    "mathContext": "$p^e \\mid m \\ \\wedge\\ p^{e+1}\\nmid m \\ \\wedge\\ n \\nmid e \\ \\Rightarrow\\ \\sqrt[n]{m}\\notin\\mathbb{Q}$. The chain is window $\\to v_p(m)=e \\to$ not a perfect power $\\to$ irrational.",
+    "significance": "key",
+    "relatedConcepts": ["irrationality", "perfect powers", "proof composition"],
+    "prerequisites": ["number theory", "real analysis"]
   },
   {
     "id": "ann-sqrt72",
@@ -41,7 +68,26 @@
     },
     "type": "insight",
     "title": "√72: the Radicand the Exponent-1 Lemma Cannot Reach",
-    "content": "`72 = 2³ · 3²`. The blocking prime is `2` at exponent `3` (odd): `8 ∣ 72`, `16 ∤ 72`, `2 ∤ 3`. The prime `3` has the benign even exponent `2` (`2 ∣ 2`), and because `2² ∣ 72` the parent's exponent-1 lemma does not apply to `2` either. So neither prime is usable by the narrow corollary, yet `√72` is irrational — certified here in one line via the exponent-`e` window with `e = 3`.\n\nThis is precisely the example the parent entry's open-questions list flagged as out of reach."
+    "content": "`72 = 2³ · 3²`. The blocking prime is `2` at exponent `3` (odd): `8 ∣ 72`, `16 ∤ 72`, `2 ∤ 3`. The prime `3` has the benign even exponent `2` (`2 ∣ 2`), and because `2² ∣ 72` the parent's exponent-1 lemma does not apply to `2` either. So neither prime is usable by the narrow corollary, yet `√72` is irrational — certified here in one line via the exponent-`e` window with `e = 3`.\n\nThis is precisely the example the parent entry's open-questions list flagged as out of reach.",
+    "mathContext": "$72 = 2^3\\cdot 3^2$. Window for $p=2,e=3$: $2^3=8\\mid 72$, $2^4=16\\nmid 72$, and $2\\nmid 3$. Hence $v_2(72)=3$ is odd and $\\sqrt{72}\\notin\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "worked example", "mixed exponents"],
+    "prerequisites": ["number theory"]
+  },
+  {
+    "id": "ann-sqrt500",
+    "proofId": "nth-root-irrational-oq-02-oq-02",
+    "range": {
+      "startLine": 131,
+      "endLine": 135
+    },
+    "type": "insight",
+    "title": "√500: the Blocking Prime Need Not Be the Smallest",
+    "content": "`500 = 2² · 5³`. Here the *smallest* prime `2` is benign — its exponent `2` is even (`2 ∣ 2`) — so a naive \"check the smallest prime\" heuristic fails. The blocking prime is `5` at exponent `3`: `125 ∣ 500`, `625 ∤ 500`, `2 ∤ 3`. The criterion needs only *one* prime with the wrong exponent, and the corollary names it explicitly via `(p := 5) (e := 3)`, so the search cost is paid once by the author rather than by the kernel.",
+    "mathContext": "$500 = 2^2\\cdot 5^3$. The blocking prime is $5$: window $5^3=125\\mid 500$, $5^4=625\\nmid 500$, $2\\nmid 3$, giving $v_5(500)=3$ odd, so $\\sqrt{500}\\notin\\mathbb{Q}$. Note $v_2(500)=2$ is benign.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "worked example", "prime selection"],
+    "prerequisites": ["number theory"]
   },
   {
     "id": "ann-cbrt72",
@@ -52,7 +98,11 @@
     },
     "type": "insight",
     "title": "Same Radicand, Different Blocking Prime by Exponent",
-    "content": "`∛72` with the same `72 = 2³ · 3²`. For cube roots the prime `2` is now benign (`3 ∣ v_2 = 3`), and the blocking prime is `3` at exponent `2`: `9 ∣ 72`, `27 ∤ 72`, `3 ∤ 2`. The blocking prime depends on `n` — an observation the exponent-1 lemma structurally cannot express, since it fixes the exponent at `1`."
+    "content": "`∛72` with the same `72 = 2³ · 3²`. For cube roots the prime `2` is now benign (`3 ∣ v_2 = 3`), and the blocking prime is `3` at exponent `2`: `9 ∣ 72`, `27 ∤ 72`, `3 ∤ 2`. The blocking prime depends on `n` — an observation the exponent-1 lemma structurally cannot express, since it fixes the exponent at `1`.",
+    "mathContext": "For $n=3$: $v_2(72)=3$ with $3\\mid 3$ (benign), while $v_3(72)=2$ with $3\\nmid 2$ (blocks). Window for $p=3,e=2$: $9\\mid 72$, $27\\nmid 72$. Contrast the $n=2$ case where $2$ blocks — the obstruction is $n$-dependent.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-adic valuation", "n-dependence", "worked example"],
+    "prerequisites": ["number theory"]
   },
   {
     "id": "ann-subsumption",
@@ -63,6 +113,10 @@
     },
     "type": "concept",
     "title": "The Exponent-1 Case is Subsumed",
-    "content": "`√12` (`12 = 2² · 3`, blocked by `3` at exponent `1`) is still a one-liner here: `3 ∣ 12`, `9 ∤ 12`, `2 ∤ 1`. Instantiating the general criterion at `e = 1` reproduces the parent's exponent-1 corollary, confirming the generalization loses nothing."
+    "content": "`√12` (`12 = 2² · 3`, blocked by `3` at exponent `1`) is still a one-liner here: `3 ∣ 12`, `9 ∤ 12`, `2 ∤ 1`. Instantiating the general criterion at `e = 1` reproduces the parent's exponent-1 corollary, confirming the generalization loses nothing.",
+    "mathContext": "At $e=1$ the window $p\\mid m \\wedge p^2\\nmid m$ is exactly the parent's exponent-1 trigger, and $n\\nmid 1$ holds for all $n>1$. So `not_perfect_pow_of_sq_not_dvd` is the special case $e=1$ of `not_perfect_pow_of_factorization_eq`.",
+    "significance": "context",
+    "relatedConcepts": ["generalization", "special case", "backward compatibility"],
+    "prerequisites": ["number theory"]
   }
 ]

--- a/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-02-oq-02/meta.json
@@ -54,7 +54,8 @@
       "The exact valuation v_p(m) = e is pinned by a two-sided divisibility window p^e ∣ m ∧ ¬p^(e+1) ∣ m, both halves size-independent decides — no factorization of the literal is required.",
       "Taking e = 1 recovers the parent's exponent-1 corollary, so the generalization loses nothing while covering every mixed-exponent radicand.",
       "The same radicand can be blocked by different primes depending on n: 72 = 2³·3² is blocked by the prime 2 for square roots (v_2 = 3 odd) and by the prime 3 for cube roots (v_3 = 2, not a multiple of 3). The exponent-1 lemma cannot express this.",
-      "The existential form matches the problem's formal statement exactly and makes the honest, complete irrationality test — fire on any non-perfect-power radicand — a one-liner."
+      "The existential form matches the problem's formal statement exactly and makes the honest, complete irrationality test — fire on any non-perfect-power radicand — a one-liner.",
+      "The blocking prime need not be the smallest: 500 = 2²·5³ has a benign smallest prime (v_2 = 2, even) and is blocked only by 5 (v_5 = 3), so a naive 'check the smallest prime' heuristic fails — the criterion needs one prime with the wrong exponent, wherever it sits."
     ],
     "prerequisites": [
       "Number theory (unique prime factorization, p-adic valuation / Nat.factorization)",


### PR DESCRIPTION
Enrichment pass for `nth-root-irrational-oq-02-oq-02` (passes: 0, quality: 68).

## Changes
- **Annotation fields**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation — previously none carried these.
- **Coverage**: 6 → 8 annotations. New annotations cover the module-doc motivation (the exponent-1 gap in the parent criterion) and the `√500 = 2²·5³` corollary (the blocking prime need not be the smallest prime).
- **meta.json**: added one keyInsight (4 → 5) surfacing the √500 observation that a naive 'check the smallest prime' heuristic fails.

## Validation
- `jq empty` passes on both meta.json and annotations.json.
- `check-meta-size.ts` passes: meta.json 13.6 KB, well under the 60 KB cap.
- All 8 annotations carry mathContext/significance/relatedConcepts.
- No changes to status/badge/axiomCount; the Lean file is untouched.

Note: authored in a fresh worktree because the assigned `.loom/worktrees/enricher-5` husk was cleaned mid-session by a concurrent process; `pnpm build` could not run (no node_modules in fresh worktree), so validation used jq + the size validator.