### PR TITLE
Enrich Grandi/geometric series (Abel summability): fix overlapping ranges, annotations 4→5

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01/annotations.json
@@ -2,14 +2,25 @@
   {
     "id": "ann-grandi-overview",
     "proofId": "geometric-series-oq-01-oq-01",
-    "range": { "startLine": 3, "endLine": 30 },
+    "range": {
+      "startLine": 3,
+      "endLine": 30
+    },
     "type": "concept",
     "title": "Grandi's series and the two summation methods",
     "content": "Grandi's series 1 − 1 + 1 − 1 + ⋯ has partial sums oscillating between 1 and 0, so it diverges in the ordinary sense. Two classical regularization methods nonetheless assign it the value 1/2: Cesàro summation (the limit of the averaged partial sums, treated in a sibling) and Abel summation (the radial limit of the power series ∑(−1)ⁿxⁿ = 1/(1+x) as x → 1⁻, formalized here). Their agreement is not a coincidence — Frobenius's theorem guarantees that any Cesàro-summable series is Abel-summable to the same value. This entry answers the parent's open question by carrying out the Abel route in Lean, 0-sorry and 0-axiom.",
     "mathContext": "$1 - 1 + 1 - 1 + \\cdots \\;\\overset{A}{=}\\; \\lim_{x\\to 1^-}\\sum_{n} (-1)^n x^n = \\tfrac{1}{2}$",
     "significance": "supporting",
-    "relatedConcepts": ["Grandi's series 1−1+1−⋯", "divergent series", "Cesàro vs Abel summation", "Frobenius's theorem"],
-    "prerequisites": ["partial sums and divergence", "regularization / summation methods"]
+    "relatedConcepts": [
+      "Grandi's series 1−1+1−⋯",
+      "divergent series",
+      "Cesàro vs Abel summation",
+      "Frobenius's theorem"
+    ],
+    "prerequisites": [
+      "partial sums and divergence",
+      "regularization / summation methods"
+    ]
   },
   {
     "id": "ann-closed-form",
@@ -40,7 +51,7 @@
     "proofId": "geometric-series-oq-01-oq-01",
     "range": {
       "startLine": 44,
-      "endLine": 70
+      "endLine": 60
     },
     "type": "insight",
     "title": "The Abel Sum Is the Boundary Value",
@@ -62,13 +73,46 @@
   {
     "id": "ann-grandi-value",
     "proofId": "geometric-series-oq-01-oq-01",
-    "range": { "startLine": 61, "endLine": 63 },
+    "range": {
+      "startLine": 62,
+      "endLine": 64
+    },
     "type": "theorem",
     "title": "The headline result, named",
     "content": "grandi_abel_value is the clean restatement (definitionally grandi_abel_tendsto) packaging the conclusion: Grandi's series 1 − 1 + 1 − ⋯ is Abel summable to 1/2, matching its Cesàro value. Exposing it under a result-oriented name gives downstream entries a stable handle on the boundary value without depending on the proof-shaped statement.",
     "mathContext": "$1 - 1 + 1 - 1 + \\cdots \\;\\overset{A}{=}\\; \\tfrac{1}{2}$",
     "significance": "supporting",
-    "relatedConcepts": ["Abel summability", "named API lemma", "Grandi's series"],
-    "prerequisites": ["grandi_abel_tendsto"]
+    "relatedConcepts": [
+      "Abel summability",
+      "named API lemma",
+      "Grandi's series"
+    ],
+    "prerequisites": [
+      "grandi_abel_tendsto"
+    ]
+  },
+  {
+    "id": "ann-frobenius-consistency",
+    "proofId": "geometric-series-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 79
+    },
+    "type": "context",
+    "title": "Why Abel Agreement Confirms the Cesàro Value",
+    "content": "The summary frames the file as an independent confirmation of Grandi's Cesàro value 1/2. This is not circular: Frobenius's theorem says Cesàro (C,1) summability implies Abel summability to the *same* value, so once the series is known Cesàro-summable to 1/2 its Abel sum is forced to be 1/2. Computing the Abel sum directly here (via the closed form 1/(1+x) and its boundary value) and getting 1/2 is therefore a consistency check on the whole regularization framework. The converse fails — Abel summability is strictly stronger, so an Abel value alone would not recover the Cesàro one — which is exactly why matching values across the two methods is meaningful rather than automatic.",
+    "mathContext": "Frobenius: $\\lim_{n}\\frac{s_0+\\cdots+s_n}{n+1}=L \\ \\Rightarrow\\ \\lim_{x\\to1^-}\\sum a_k x^k = L$. Here $L=\\tfrac12$ for $1-1+1-\\cdots$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Abel summation",
+      "Cesàro summation",
+      "Frobenius theorem",
+      "summability methods",
+      "Tauberian theorems"
+    ],
+    "prerequisites": [
+      "divergent series",
+      "regularization methods"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-01-oq-01` (quality 93, passes 0).

**Range hygiene (correctness fix).** `ann-abel-limit` spanned 44–70, overlapping `ann-grandi-value` (61–63); both claimed lines 61–70. Fixed:
- `ann-abel-limit`: 44–70 → **44–60** (`grandi_abel_tendsto` only)
- `ann-grandi-value`: 61–63 → **62–64** (aligned to the `grandi_abel_value` theorem)

**Coverage 4→5.** Lines 66–79 (the Frobenius summary) were unannotated. Added `ann-frobenius-consistency` explaining *why* the Abel computation confirms the Cesàro value **non-circularly**: Frobenius's theorem gives Cesàro ⇒ Abel to the same value, and the converse fails, so matching values across the two methods is meaningful rather than automatic. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

Annotations-only change; meta.json untouched (11 KB, well under cap). JSON validated; size guardrail passes.