### PR TITLE
Research: amgm-inequality-oq-02-oq-02-oq-05 - general Rolle crux (derivative preserves real-rootedness) via Mathlib

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -348,4 +348,104 @@ theorem newton_four_normalized (a b c d : ℝ) :
   · nlinarith [newton_four_second a b c d]
   · nlinarith [newton_four_third a b c d]
 
+/-!  ## Part V — the general Rolle crux: differentiation preserves real-rootedness
+
+Parts I–IV give per-arity certificates (`n = 2, 3, 4`) and the general `k = 1`
+step.  The recurring *blocker* documented across every prior iteration was the
+GENERAL, arbitrary-`n` engine: the classical statement
+
+  "each derivative of a fully-real-rooted polynomial is again fully real-rooted
+   (counting multiplicity)"
+
+— iterated Rolle on `∏(X - xᵢ)` — which `problem.md` estimated at multi-week
+formalization difficulty and knowledge.md recorded as "not in Mathlib".
+
+It turns out Mathlib DOES supply the hard half:
+`Polynomial.card_roots_le_derivative` (in `Mathlib/Analysis/Calculus/LocalExtr/
+Polynomial.lean`), the multiplicity-counted bound
+`card p.roots ≤ card (derivative p).roots + 1`.  Combined with the two elementary
+degree facts `card q.roots ≤ q.natDegree` (`card_roots'`) and
+`(derivative p).natDegree < p.natDegree` (`natDegree_derivative_lt`), a full
+real-rooted `p` (`card p.roots = p.natDegree`) is squeezed to EQUALITY for its
+derivative:
+
+  `natDegree p - 1 ≤ card (derivative p).roots ≤ (derivative p).natDegree
+                   ≤ natDegree p - 1`,
+
+so `card (derivative p).roots = (derivative p).natDegree` — the derivative splits.
+This packages the flagged crux as a short, general, reusable lemma (all `n`, all
+`k`), and it is the honest general engine the per-arity SOS certificates were
+standing in for.
+
+What this Part does NOT yet do: turn the crux into the general Newton *coefficient*
+inequality `pₖ² ≥ pₖ₋₁ pₖ₊₁` for `k ≥ 2`.  That final reduction still needs the
+coefficient bookkeeping "the appropriate iterated derivative of the (reversed)
+splitting polynomial is the quadratic `a eₖ₋₁ X² - b eₖ X + c eₖ₊₁`", whose
+real-rootedness (now supplied by `derivative_roots_card_eq` / `splits_derivative`)
+gives `discrim ≥ 0` via the Part I atom `discrim_nonneg_of_roots_nonempty`.  That
+Vieta-coefficient step is the remaining honest gap; the real-rootedness half of
+the classical proof is closed here. -/
+
+open Set in
+/-- **Rolle's theorem for polynomials.**  Between two roots `a < b` of a real
+polynomial `p` lies a root of its derivative.  This is the single per-gap step of
+the classical Newton/Rolle argument, packaged directly for the `Polynomial` API
+(Mathlib has Rolle `exists_hasDerivAt_eq_zero` and `Polynomial.hasDerivAt`, but
+not this bridge as a named lemma). -/
+theorem exists_isRoot_derivative_Ioo {p : ℝ[X]} {a b : ℝ} (hab : a < b)
+    (ha : p.IsRoot a) (hb : p.IsRoot b) :
+    ∃ c ∈ Ioo a b, (derivative p).IsRoot c := by
+  have ha' : p.eval a = 0 := ha
+  have hb' : p.eval b = 0 := hb
+  have hfI : p.eval a = p.eval b := by rw [ha', hb']
+  obtain ⟨c, hc, hc0⟩ :=
+    exists_hasDerivAt_eq_zero hab p.continuousOn hfI (fun x _ => p.hasDerivAt x)
+  exact ⟨c, hc, hc0⟩
+
+/-- **Differentiation preserves full real-rootedness (counting multiplicity).**
+If a real polynomial `p` has as many roots with multiplicity as its degree —
+`card p.roots = p.natDegree`, i.e. `p` splits over `ℝ` — then its derivative does
+too: `card (derivative p).roots = (derivative p).natDegree`.
+
+This is the long-flagged general crux of the real-rootedness route to Newton's
+inequalities.  Proof: the Mathlib bound `card_roots_le_derivative`
+(`card p.roots ≤ card (derivative p).roots + 1`) together with
+`card_roots' : card q.roots ≤ q.natDegree` and
+`natDegree_derivative_lt : (derivative p).natDegree < p.natDegree`
+sandwich `card (derivative p).roots` between `natDegree p - 1` and itself; `omega`
+closes the arithmetic.  The constant case `natDegree p = 0` is separate
+(`derivative (C a) = 0`). -/
+theorem derivative_roots_card_eq {p : ℝ[X]}
+    (hp : Multiset.card p.roots = p.natDegree) :
+    Multiset.card (derivative p).roots = (derivative p).natDegree := by
+  rcases eq_or_ne p.natDegree 0 with h0 | h0
+  · obtain ⟨a, rfl⟩ := natDegree_eq_zero.mp h0
+    simp [derivative_C]
+  · have h1 : Multiset.card (derivative p).roots ≤ (derivative p).natDegree :=
+      card_roots' _
+    have h2 : Multiset.card p.roots ≤ Multiset.card (derivative p).roots + 1 :=
+      card_roots_le_derivative p
+    have h3 : (derivative p).natDegree < p.natDegree := natDegree_derivative_lt h0
+    omega
+
+/-- **`Splits`-level phrasing of the crux.**  If `p : ℝ[X]` splits over `ℝ`
+(factors into real linear factors), so does its derivative. -/
+theorem splits_derivative {p : ℝ[X]} (hp : Splits p) : Splits (derivative p) := by
+  rw [splits_iff_card_roots] at hp ⊢
+  exact derivative_roots_card_eq hp
+
+/-- **Every derivative of a split real polynomial splits.**  Iterating
+`splits_derivative`: the full conclusion of the classical Newton/Rolle program —
+all `k` successive derivatives of a real-rooted `∏(X - xᵢ)` are again real-rooted.
+Combined with the Part I discriminant atom this reduces Newton's inequalities to
+the (still open) coefficient identification of the `(n-k-1)`-th derivative as the
+quadratic in `eₖ₋₁, eₖ, eₖ₊₁`. -/
+theorem splits_iterate_derivative {p : ℝ[X]} (hp : Splits p) (k : ℕ) :
+    Splits (derivative^[k] p) := by
+  induction k with
+  | zero => simpa using hp
+  | succ k ih =>
+      rw [Function.iterate_succ', Function.comp_apply]
+      exact splits_derivative ih
+
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
@@ -121,3 +121,64 @@ The GENERAL (arbitrary-`n`) Newton still needs "differentiation preserves full
 real-rootedness counting multiplicity" (iterated Rolle) — not in Mathlib, multi-week
 (`problem.md`). The per-arity SOS route works for each fixed small `n` but does not scale
 symbolically; n=4 would be a further concrete instance approaching enumeration.
+
+## PART V — the GENERAL Rolle crux, closed via Mathlib (researcher-5, 2026-07-04)
+
+**Mode**: ACT (MODERATE, score 13). **Outcome**: progress — retires the
+long-flagged "multi-week" blocker. **+4 verified theorems (20 → 24), 0 sorries,
+0 axioms** (foundational only; no `decide`/`native_decide`). docker-build clean,
+7743 jobs.
+
+### The key discovery
+The blocker recorded across Parts I–IV — "differentiation preserves full
+real-rootedness counting multiplicity" (iterated Rolle on `∏(X−xᵢ)`), estimated
+multi-week in `problem.md` and "not in Mathlib" in this knowledge base — is
+WRONG about Mathlib. Mathlib supplies the hard half directly:
+
+- **`Polynomial.card_roots_le_derivative (p : ℝ[X]) :
+  Multiset.card p.roots ≤ Multiset.card (derivative p).roots + 1`**
+  in `Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean` (Benjamin Davidson,
+  Yury Kudryashov) — the multiplicity-counted Rolle bound. Also there:
+  `card_roots_toFinset_le_derivative`, `card_rootSet_le_derivative`.
+
+### Shipped (`Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, Part V)
+- **`derivative_roots_card_eq {p : ℝ[X]}
+  (hp : card p.roots = p.natDegree) : card (derivative p).roots =
+  (derivative p).natDegree`** — THE CRUX, general (all `n`). A full-real-rooted
+  `p` forces its derivative to be full-real-rooted. Proof is a 4-line sandwich:
+  `card_roots_le_derivative` gives `card(p') ≥ natDegree p − 1`;
+  `card_roots'` gives `card(p') ≤ natDegree p'`; `natDegree_derivative_lt` gives
+  `natDegree p' < natDegree p` (so `≤ natDegree p − 1`); `omega` closes. Constant
+  case `natDegree p = 0` handled via `natDegree_eq_zero.mp` + `derivative_C`.
+- **`splits_derivative {p : ℝ[X]} (hp : Splits p) : Splits (derivative p)`** — the
+  `Splits`-level phrasing, via `splits_iff_card_roots` (note: modern Mathlib
+  `Splits` is the single-argument `Polynomial.Splits (f : R[X])` in
+  `Algebra/Polynomial/Factors.lean`, NOT the classical `Splits (i : K →+* L) f`).
+- **`splits_iterate_derivative {p} (hp : Splits p) (k : ℕ) :
+  Splits (derivative^[k] p)`** — trivial induction; the full program output
+  (all k derivatives of `∏(X−xᵢ)` split).
+- **`exists_isRoot_derivative_Ioo {p} (hab : a < b) (ha : p.IsRoot a)
+  (hb : p.IsRoot b) : ∃ c ∈ Ioo a b, (derivative p).IsRoot c`** — the per-gap
+  Rolle atom, packaged for the `Polynomial` API from `exists_hasDerivAt_eq_zero`
+  + `Polynomial.hasDerivAt` + `Polynomial.continuousOn`.
+
+### Reusable Lean gotchas (researcher-5, Part V)
+- `Polynomial.hasDerivAt (x) : HasDerivAt (fun x => p.eval x) ((derivative p).eval x) x`
+  (in `Analysis/Calculus/Deriv/Polynomial.lean`) is the analytic-derivative
+  bridge; feed it to Rolle's `exists_hasDerivAt_eq_zero` as
+  `fun x _ => p.hasDerivAt x`, with `p.continuousOn` for the `ContinuousOn` arg.
+- `IsRoot p a` is DEFEQ to `p.eval a = 0`, so `have h : p.eval a = 0 := ha`
+  coerces directly (no `unfold`); then plain `rw` works.
+- `card_roots'` (NOT `card_roots`, which is the `≠0` degree-eq form) is the
+  unconditional `card q.roots ≤ q.natDegree`.
+- The whole crux is `omega` after three `have`s — the Nat sandwich is linear.
+
+### Still open (narrowed)
+The real-rootedness HALF of the classical Newton proof is now closed for all `n`.
+What remains is purely the **coefficient bookkeeping**: identifying the
+`(n−k−1)`-th derivative of the (reversed) splitting polynomial as the quadratic
+`a eₖ₋₁ X² − b eₖ X + c eₖ₊₁`, so that its real-rootedness
+(`derivative_roots_card_eq`) feeds the Part I discriminant atom
+`discrim_nonneg_of_roots_nonempty` to yield `pₖ² ≥ pₖ₋₁ pₖ₊₁` for general `k`.
+This is Vieta/`coeff`-level algebra (no more analysis), and is the honest next
+increment — no longer blocked on the "multi-week" real-rootedness lemma.

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,7 +4,26 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 5 (PART IV)
+**Iteration**: 6 (PART V)
+
+## Iteration 6 (PART V — general Rolle crux, closed via Mathlib)
+**Retired the long-standing "multi-week" blocker.** The iterated-Rolle crux
+"differentiation preserves full real-rootedness counting multiplicity" was
+recorded as "not in Mathlib" — but Mathlib's
+`Polynomial.card_roots_le_derivative`
+(`Analysis/Calculus/LocalExtr/Polynomial.lean`) supplies exactly the hard,
+multiplicity-counted half. Four new theorems (20 → 24; docker-build clean, 7743
+jobs; 0 sorries, 0 axioms):
+- `derivative_roots_card_eq`: `card p.roots = natDegree p ⇒
+  card (derivative p).roots = natDegree (derivative p)` — THE CRUX, all `n`. A
+  4-line `omega` sandwich of `card_roots_le_derivative`, `card_roots'`,
+  `natDegree_derivative_lt`.
+- `splits_derivative` / `splits_iterate_derivative`: `Splits`-level and iterated
+  forms (all `k` derivatives of `∏(X−xᵢ)` split).
+- `exists_isRoot_derivative_Ioo`: the per-gap Rolle atom for the `Polynomial` API.
+The real-rootedness half of the classical Newton proof is now general. Remaining:
+pure coefficient bookkeeping (identify the `(n−k−1)`-th derivative as the quadratic
+in `eₖ₋₁,eₖ,eₖ₊₁`, then feed the Part I discriminant atom).
 
 ## Iteration 5 (PART IV — n = 4 via SOS), PR #34576
 Discharged **ALL THREE** Newton log-concavity steps at `n = 4` for arbitrary
@@ -59,24 +78,27 @@ iterated-Rolle lemma "differentiation preserves full real-rootedness counting
 multiplicity".
 
 ## Attempt Count
-- Total attempts: 3
+- Total attempts: 5
 - Current approach attempts: 1 (QM–AM route)
 - Approaches tried: real-rooted/discriminant atom + n=2 (I); n=3 both steps via
   SOS (II); general-n first step via QM–AM + square-of-sum identity (III)
 
 ## Blockers
-- **MATH**: general (arbitrary-`n`) HIGHER Newton steps (`k ≥ 2`) need the packaged
-  lemma "differentiation preserves full real-rootedness counting multiplicity"
-  (iterated Rolle on `∏(X - xᵢ)`) — not in Mathlib; `problem.md` estimates
-  multi-week. The `k = 1` step is now closed for all `n` (Part III), so this
-  blocker is narrowed to the higher steps only.
+- **RESOLVED (Part V)**: the "differentiation preserves full real-rootedness
+  counting multiplicity" crux — previously flagged multi-week / "not in Mathlib"
+  — is now `derivative_roots_card_eq`, assembled from Mathlib's
+  `card_roots_le_derivative`. No longer a blocker.
+- **REMAINING (algebra, not analysis)**: the coefficient reduction turning the
+  crux into the general `k ≥ 2` Newton *inequality* — identify the `(n−k−1)`-th
+  derivative of the reversed splitting polynomial as `a eₖ₋₁X² − b eₖX + c eₖ₊₁`
+  (Vieta / `Polynomial.coeff` bookkeeping), then apply the Part I discriminant
+  atom. This is `coeff`-level algebra, medium difficulty, no analysis blocker.
 
 ## Next Action
-1. The genuine next general increment: the iterated-Rolle crux
-   (derivative-of-fully-real-rooted is fully-real-rooted), which unlocks `k ≥ 2`
-   at arbitrary `n`. Mathlib has `Rolle` (`exists_hasDerivAt_eq_zero`) and
-   `Polynomial.derivative`/`roots` but not the packaged multiplicity-counting
-   statement.
-2. Alternatively, a general `k = 1` Maclaurin corollary in explicit
-   `p₁ = e₁/n`, `p₂ = e₂/C(n,2)` normalized form (currently stated in the
-   cleared-denominator equivalent).
+1. Prove the coefficient-extraction lemma: `coeff` of the `m`-fold derivative of
+   `∏(X−xᵢ)` in terms of `esymm`, specialised to isolate three consecutive
+   `eₖ₋₁,eₖ,eₖ₊₁` (use `Polynomial.coeff_iterate_derivative` /
+   `Mathlib.RingTheory.Polynomial.Vieta`).
+2. Feed the resulting real-rooted quadratic (real-rooted by
+   `derivative_roots_card_eq`) into `discrim_nonneg_of_roots_nonempty` to close
+   general `k ≥ 2` Newton.

--- a/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02-oq-05/meta.json
@@ -132,8 +132,8 @@
       "Mathlib"
     ],
     "additionalFiles": [],
-    "lineCount": 351,
-    "theoremCount": 20,
+    "lineCount": 451,
+    "theoremCount": 24,
     "definitionCount": 0,
     "axiomCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary
Research session (Part V) for `amgm-inequality-oq-02-oq-02-oq-05` (Newton's
inequalities via real-rooted polynomials / Rolle). **Retires the entry's
long-standing "multi-week" blocker.**

## Key finding
Every prior iteration (Parts I–IV) recorded the general engine —
*"differentiation preserves full real-rootedness counting multiplicity"* (iterated
Rolle on `∏(X − xᵢ)`) — as the crux, estimated multi-week in `problem.md` and
"not in Mathlib" in `knowledge.md`. That assessment of Mathlib was wrong:
`Polynomial.card_roots_le_derivative` (in
`Mathlib/Analysis/Calculus/LocalExtr/Polynomial.lean`) already supplies the hard,
multiplicity-counted half `card p.roots ≤ card (derivative p).roots + 1`.

## Progress
4 new theorems (20 → 24 in `Proofs/AmgmInequalityOQ02OQ02OQ05.lean`), **0 sorries,
0 axioms** (foundational only; no `decide`/`native_decide`), docker-build clean
(7743 jobs):

- **`derivative_roots_card_eq`** — THE CRUX, all `n`:
  `card p.roots = natDegree p ⇒ card (derivative p).roots = natDegree (derivative p)`.
  A 4-line `omega` sandwich of `card_roots_le_derivative`, `card_roots'`,
  `natDegree_derivative_lt`.
- **`splits_derivative`** — `Splits`-level phrasing (via `splits_iff_card_roots`;
  note modern Mathlib's single-argument `Polynomial.Splits`).
- **`splits_iterate_derivative`** — all `k` successive derivatives of a split
  polynomial split (the full Newton/Rolle program output).
- **`exists_isRoot_derivative_Ioo`** — the per-gap Rolle atom packaged for the
  `Polynomial` API (`exists_hasDerivAt_eq_zero` + `Polynomial.hasDerivAt`).

## Findings
- The real-rootedness half of the classical Newton proof is now **general** (all
  `n`, all `k`), replacing the per-arity SOS certificates (Parts I–IV) as the
  honest engine they were standing in for.
- **Remaining gap is algebra, not analysis**: identify the `(n−k−1)`-th derivative
  of the reversed splitting polynomial as the quadratic `a eₖ₋₁X² − b eₖX + c eₖ₊₁`
  (Vieta / `Polynomial.coeff` bookkeeping), then feed its real-rootedness (now
  supplied here) into the Part I discriminant atom `discrim_nonneg_of_roots_nonempty`
  to close general `k ≥ 2` Newton.

## Status
**Outcome**: progress (blocker retired; real-rootedness engine now general)
**Next Steps**: coefficient-extraction lemma (`coeff` of iterated derivative in
terms of `esymm`) to convert the crux into the general `k ≥ 2` Newton inequality.

🤖 Generated by researcher-5