### PR TITLE
Research: Chebyshev antisymmetric mixed product U·T Wronskian (de-moivre-oq-02-oq-02-oq-01-oq-02) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean
@@ -1,0 +1,115 @@
+import Mathlib
+import Proofs.ChebyshevPolynomialsOQ01OQ01
+
+/-
+# De Moivre OQ-02 OQ-02 OQ-01 OQ-02: the antisymmetric mixed Chebyshev product
+
+## Open Question
+
+The sibling file `DeMoivreOQ02OQ02` records the *symmetric* mixed product-to-sum
+identity
+  2·T_m·U_n = U_{m+n} + U_{n−m},
+and the parent `DeMoivreOQ02OQ02OQ01` linearizes the pure second-kind product
+`U_m·U_n` as a `min(m,n)+1`-term sum of `U`'s.  Both are **symmetric** in their
+arguments.  What about the *antisymmetric* mixed combination `U_m·T_n − U_n·T_m`?
+Does it also collapse to a single second-kind polynomial, and can this be done
+without dividing by `2` (i.e. over an arbitrary commutative ring, including
+characteristic `2`)?
+
+## Answer: YES — a division-free single-term closed form
+
+For every `m, n : ℤ`, in `R[X]` over any `CommRing R`,
+
+  **U_m · T_n − U_n · T_m = X · U_{m−n−1}.**            (`U_mul_T_antisymm`)
+
+This is the polynomial shadow of the trigonometric antisymmetry
+  U_m(cosθ)·T_n(cosθ) − U_n(cosθ)·T_m(cosθ)
+      = [sin((m+1)θ)cos(nθ) − sin((n+1)θ)cos(mθ)]/sinθ
+      = cosθ · sin((m−n)θ)/sinθ = cosθ · U_{m−n−1}(cosθ).
+
+Unlike the sibling's `2·T·U` product-to-sum, the antisymmetric form carries **no
+factor of `2`** — it is a genuine identity of `ℤ`-coefficient polynomials and holds
+verbatim in every characteristic.
+
+## Route (fully non-inductive)
+
+Everything reduces, by `linear_combination`, to already-proved building blocks:
+
+1. `T_eq_U_sub_X_U`  : `T_k = U_k − X·U_{k−1}`  — a rearrangement of Mathlib's mixed
+   recurrence `U_eq_X_mul_U_add_T`.  (No `2`.)
+2. `U_mul_T_sub`     : `U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}` — the mixed
+   "subtraction" formula, obtained from the second-kind **addition** formula
+   `ChebyshevPolynomialsOQ01OQ01.U_add` evaluated at `(m−1, −n)` together with the
+   reflections `T_{−n} = T_n` and `U_{−n−1} = −U_{n−1}`.
+3. `U_wronskian`     : `U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}` — the pure
+   second-kind **d'Ocagne / Wronskian** identity, from (2) by eliminating the two
+   `T`'s via (1).
+4. `U_mul_T_antisymm`: the headline, from (1) and (3).
+
+None of these four identities is in Mathlib, and none is the sibling's symmetric
+`2·T·U`; the antisymmetric closed form and the second-kind Wronskian are new.
+-/
+
+open Polynomial Polynomial.Chebyshev
+
+namespace DeMoivreOQ02OQ02OQ01OQ02
+
+variable {R : Type*} [CommRing R]
+
+/-- **First-kind in terms of second-kind** (division-free):
+`T_k = U_k − X·U_{k−1}`.  The polynomial form of
+`cos(kθ) = sin((k+1)θ)/sinθ − cosθ·sin(kθ)/sinθ`.  A rearrangement of Mathlib's
+mixed recurrence `U_eq_X_mul_U_add_T : U_{k+1} = X·U_k + T_{k+1}`. -/
+lemma T_eq_U_sub_X_U (k : ℤ) : T R k = U R k - X * U R (k - 1) := by
+  have h := U_eq_X_mul_U_add_T R (k - 1)
+  rw [show k - 1 + 1 = k from by ring] at h
+  linear_combination -h
+
+/-- **Mixed subtraction formula**:
+`U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}`.  The single-term "linearization into a
+second-kind polynomial" of the antisymmetric mixed product.  It is the polynomial
+form of `sin(mθ)cos(nθ) − cos(mθ)sin(nθ) = sin((m−n)θ)`, obtained from the
+second-kind addition formula at `(m−1, −n)`. -/
+lemma U_mul_T_sub (m n : ℤ) :
+    U R (m - 1) * T R n - T R m * U R (n - 1) = U R (m - n - 1) := by
+  have h := ChebyshevPolynomialsOQ01OQ01.U_add R (m - 1) (-n)
+  rw [show m - 1 + -n = m - n - 1 from by ring,
+      show m - 1 + 1 = m from by ring,
+      T_neg R n, U_neg_sub_one R n] at h
+  linear_combination -h
+
+/-- **Second-kind Wronskian / d'Ocagne identity**:
+`U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}`.  The Casoratian of the two shifted
+second-kind sequences collapses to a single `U`, depending only on the index gap
+`m − n`.  Derived from `U_mul_T_sub` by eliminating both first-kind factors via
+`T_eq_U_sub_X_U`. -/
+lemma U_wronskian (m n : ℤ) :
+    U R (m - 1) * U R n - U R m * U R (n - 1) = U R (m - n - 1) := by
+  have h := U_mul_T_sub (R := R) m n
+  have hTn := T_eq_U_sub_X_U (R := R) n
+  have hTm := T_eq_U_sub_X_U (R := R) m
+  linear_combination h - U R (m - 1) * hTn + U R (n - 1) * hTm
+
+/-- **Antisymmetric mixed product** (headline):
+`U_m·T_n − U_n·T_m = X·U_{m−n−1}`, division-free over any commutative ring.
+The polynomial shadow of
+`sin((m+1)θ)cos(nθ) − sin((n+1)θ)cos(mθ) = cosθ·sin((m−n)θ)`. -/
+theorem U_mul_T_antisymm (m n : ℤ) :
+    U R m * T R n - U R n * T R m = X * U R (m - n - 1) := by
+  have hw := U_wronskian (R := R) m n
+  have hTn := T_eq_U_sub_X_U (R := R) n
+  have hTm := T_eq_U_sub_X_U (R := R) m
+  linear_combination U R m * hTn - U R n * hTm + X * hw
+
+/-! ### Concrete instances (numeric cross-checks over ℤ) -/
+
+/-- `U₂·T₁ − U₁·T₂ = X·U₀`  (both sides equal `X`, since `U₀ = 1`). -/
+example : U ℤ 2 * T ℤ 1 - U ℤ 1 * T ℤ 2 = X * U ℤ (2 - 1 - 1) :=
+  U_mul_T_antisymm 2 1
+
+/-- `U₁·U₂ − U₂·U₁ = U₀`: the Wronskian at `m = 2, n = 2` reads
+`U_{2−1}·U_2 − U_2·U_{2−1} = U_{2−2−1}`, i.e. `0 = U_{−1} = 0`. -/
+example : U ℤ (2 - 1) * U ℤ 2 - U ℤ 2 * U ℤ (2 - 1) = U ℤ (2 - 2 - 1) :=
+  U_wronskian 2 2
+
+end DeMoivreOQ02OQ02OQ01OQ02

--- a/research/problems/de-moivre-oq-02-oq-02-oq-01-oq-02/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-02-oq-01-oq-02/knowledge.md
@@ -1,0 +1,83 @@
+# de-moivre-oq-02-oq-02-oq-01-oq-02: Chebyshev antisymmetric mixed product (U·T Wronskian)
+
+**Target**: linearize the *mixed* product `U_m·T_n` purely into second-kind
+polynomials. The obvious symmetric reading (`½(U_{m+n}+U_{m−n})`, equivalently
+`2·T_m·U_n = U_{m+n}+U_{n−m}`) is already proved in the sibling
+`DeMoivreOQ02OQ02.T_mul_U_product` — so a plain U·T product-to-sum would be a
+duplicate. The genuinely new content is the **antisymmetric** combination.
+
+## Result (VERIFIED, 0-axiom, Tier-A)
+
+For every `CommRing R` and all `m, n : ℤ`, in `R[X]`:
+
+  **U_m · T_n − U_n · T_m = X · U_{m−n−1}.**   (`U_mul_T_antisymm`)
+
+Division-free — no factor of 2 anywhere — so it holds in every characteristic
+(unlike the symmetric product-to-sum formulas). Machine-checked:
+`docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01OQ02` → 7744 jobs, clean; axioms are
+only `propext / Classical.choice / Quot.sound`.
+
+Supporting new identities in the same file:
+- `U_wronskian`: `U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}` — the second-kind
+  Chebyshev **Wronskian / d'Ocagne / Casoratian** identity (not in Mathlib).
+- `U_mul_T_sub`: `U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}` — mixed subtraction
+  formula (polynomial `sin(mθ)cos(nθ) − cos(mθ)sin(nθ) = sin((m−n)θ)`).
+- `T_eq_U_sub_X_U`: `T_k = U_k − X·U_{k−1}` — division-free first-from-second.
+
+## Key idea (why it is division-free, and non-inductive)
+
+Symmetric product-to-sum formulas *average* two angle-addition formulas, so a
+factor 2 is baked in. The antisymmetric combination *subtracts* them and the 2
+cancels. Concretely, writing `T_k = U_k − X·U_{k−1}` (integer coefficients!):
+
+  U_m T_n − U_n T_m = U_m(U_n − X U_{n−1}) − U_n(U_m − X U_{m−1})
+                    = X·(U_{m−1} U_n − U_m U_{n−1})   [the U·U terms cancel]
+                    = X·U_{m−n−1}.                    [Wronskian]
+
+The Wronskian itself is proved **without induction** by evaluating the second-kind
+addition formula `U_{a+b} = U_a T_b + T_{a+1} U_{b−1}`
+(`ChebyshevPolynomialsOQ01OQ01.U_add`, already verified in the gallery) at
+`(a,b) = (m−1, −n)` and reflecting via `T_{−n}=T_n` (`T_neg`) and
+`U_{−n−1}=−U_{n−1}` (`U_neg_sub_one`). Every lemma closes by `linear_combination`.
+
+Numeric cross-checks (over ℤ): (m,n)=(2,1): U_2 T_1 − U_1 T_2 = (4x²−1)x − 2x(2x²−1)
+= x = X·U_0 ✓. (m,n)=(2,0): U_2 − U_0·T_2 = (4x²−1)−(2x²−1) = 2x² = X·U_1 ✓.
+
+## Sessions
+
+### Session 2026-07-04 (Session 1) — FRESH, ORIENT→ACT→VERIFY
+
+**Mode**: FRESH  **Outcome**: SHIPPED (verified, 0-axiom)
+
+#### What I Did
+- Claimed the EMPTY problem (tractability 7). Confirmed via the sibling
+  `DeMoivreOQ02OQ02.T_mul_U_product` that the *symmetric* U·T linearization already
+  exists — so I targeted the antisymmetric closed form instead (a real gallery gap).
+- Derived `U_m T_n − U_n T_m = X·U_{m−n−1}` and verified it by hand-trig and small
+  numeric cases before formalizing.
+- Found the division-free route through `T_k = U_k − X·U_{k−1}` and the second-kind
+  Wronskian, letting the whole file be `linear_combination` on top of the already-
+  proven `U_add` (no fresh induction).
+- Wrote `proofs/Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean` (lemmas `T_eq_U_sub_X_U`,
+  `U_mul_T_sub`, `U_wronskian`; theorem `U_mul_T_antisymm`; two ℤ examples).
+- Built green: `docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01OQ02` → 7744 jobs.
+- Created gallery data (`meta.json`, `annotations.json`) as `verified/original`.
+
+#### Key Findings
+- The antisymmetric mixed product carries **no factor of 2** — genuinely stronger
+  (characteristic-free) than the sibling's symmetric `2·T·U`.
+- The second-kind **Wronskian** `U_{m−1}U_n − U_m U_{n−1} = U_{m−n−1}` is the engine;
+  it is a clean reusable identity absent from Mathlib.
+- Evaluating an addition formula at a **negative argument** + reflection replaces a
+  fresh two-step ℤ induction entirely.
+
+#### Files Modified
+- `proofs/Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean` (new, 115 lines)
+- `src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/{meta,annotations}.json` (new)
+
+#### Next Steps / Open Directions
+- Antisymmetric first-kind analogue `T_m U_{n−1} − T_n U_{m−1}`: does it also give a
+  single-term closed form, and how does it relate to this Wronskian?
+- Christoffel–Darboux summation `∑_k U_k(x)U_k(y)` for the second-kind family.
+- Dickson-polynomial / associated-Chebyshev generalization of the division-free
+  antisymmetric identity.

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "demoivre-ut-ann-question",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 57 },
+    "type": "concept",
+    "title": "The Antisymmetric Mixed-Product Open Question",
+    "content": "The sibling entry linearized the symmetric product 2·T_m·U_n = U_{m+n} + U_{n−m}, where a factor of 2 is unavoidable. This entry asks the complementary question: does the antisymmetric combination U_m·T_n − U_n·T_m also collapse to a single second-kind polynomial, and can it be done division-free — valid even in characteristic 2? The answer is YES: U_m·T_n − U_n·T_m = X·U_{m−n−1}, an identity of ℤ-coefficient polynomials holding in every characteristic.",
+    "mathContext": "$U_m T_n - U_n T_m = X\\,U_{m-n-1}$ in $R[X]$, with no factor of 2.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials", "antisymmetric combinations", "characteristic-free identities"],
+    "prerequisites": ["first- and second-kind Chebyshev polynomials T_n, U_n"]
+  },
+  {
+    "id": "demoivre-ut-ann-t-from-u",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 59, "endLine": 66 },
+    "type": "insight",
+    "title": "First Kind from Second Kind, Division-Free",
+    "content": "T_eq_U_sub_X_U rearranges Mathlib's mixed recurrence U_eq_X_mul_U_add_T (U_{k+1} = X·U_k + T_{k+1}) into T_k = U_k − X·U_{k−1}. Crucially this expresses the first kind through the second with integer coefficients — contrast 2·T_k = U_k − U_{k−2}, which needs a 2. Substituting this relation is what later eliminates every first-kind factor and keeps the whole derivation characteristic-independent.",
+    "mathContext": "$T_k = U_k - X\\,U_{k-1}$, obtained by shifting $U_{k+1} = X\\,U_k + T_{k+1}$ to index $k-1$.",
+    "significance": "key",
+    "relatedConcepts": ["mixed Chebyshev recurrence", "linear_combination tactic"],
+    "prerequisites": ["Polynomial.Chebyshev.U_eq_X_mul_U_add_T"]
+  },
+  {
+    "id": "demoivre-ut-ann-mixed-sub",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 79 },
+    "type": "insight",
+    "title": "The Mixed Subtraction Formula via a Negative Argument",
+    "content": "U_mul_T_sub evaluates the second-kind addition formula U_{a+b} = U_a·T_b + T_{a+1}·U_{b−1} at (a,b) = (m−1, −n), then applies the reflections T_{−n} = T_n and U_{−n−1} = −U_{n−1}. The result, U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}, is already a single-term linearization — the polynomial form of sin(mθ)cos(nθ) − cos(mθ)sin(nθ) = sin((m−n)θ). Evaluating the addition formula at a negative argument does the work a fresh two-step induction would otherwise require.",
+    "mathContext": "$U_{m-1}T_n - T_mU_{n-1} = U_{m-n-1}$, from $U_{(m-1)+(-n)}$ with $T_{-n}=T_n$, $U_{-n-1}=-U_{n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["addition formula", "reflection/parity lemmas", "negative-index Chebyshev conventions"],
+    "prerequisites": ["ChebyshevPolynomialsOQ01OQ01.U_add", "Polynomial.Chebyshev.T_neg", "Polynomial.Chebyshev.U_neg_sub_one"]
+  },
+  {
+    "id": "demoivre-ut-ann-wronskian",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 81, "endLine": 91 },
+    "type": "insight",
+    "title": "The Second-Kind Wronskian (d'Ocagne Identity)",
+    "content": "U_wronskian eliminates both first-kind factors from the mixed subtraction formula by substituting T_eq_U_sub_X_U twice. The X·U_{m−1}·U_{n−1} cross-terms cancel exactly, leaving the pure second-kind identity U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}. This is the Casoratian (discrete Wronskian) of the two shifted solutions (U_{n−1}, U_n) and (U_{m−1}, U_m) of the recurrence p_{k+1} = 2X·p_k − p_{k−1}; that it depends only on the index gap m−n is the discrete analogue of a two-solution Wronskian being constant.",
+    "mathContext": "$U_{m-1}U_n - U_mU_{n-1} = U_{m-n-1}$, a d'Ocagne / Casoratian identity for the Chebyshev recurrence.",
+    "significance": "key",
+    "relatedConcepts": ["Wronskian / Casoratian", "d'Ocagne identity", "Fibonacci–Lucas specialization"],
+    "prerequisites": ["U_mul_T_sub", "T_eq_U_sub_X_U"]
+  },
+  {
+    "id": "demoivre-ut-ann-main",
+    "proofId": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 115 },
+    "type": "insight",
+    "title": "The Antisymmetric Mixed Product (Headline)",
+    "content": "U_mul_T_antisymm substitutes T_eq_U_sub_X_U into U_m·T_n − U_n·T_m; the expression collapses to X·(U_{m−1}·U_n − U_m·U_{n−1}), which is X times the Wronskian, giving U_m·T_n − U_n·T_m = X·U_{m−n−1}. The subtraction is what makes the factor of 2 disappear, so the identity holds over any commutative ring including characteristic 2. Two concrete ℤ instances (m,n)=(2,1) and the m=n=2 Wronskian cross-check the formula numerically.",
+    "mathContext": "$U_m T_n - U_n T_m = X(U_{m-1}U_n - U_mU_{n-1}) = X\\,U_{m-n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["antisymmetric product", "characteristic-free identity", "linear_combination tactic"],
+    "prerequisites": ["U_wronskian", "T_eq_U_sub_X_U"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+  "title": "Chebyshev Antisymmetric Mixed Product (U·T Wronskian)",
+  "slug": "de-moivre-oq-02-oq-02-oq-01-oq-02",
+  "description": "Proves the division-free antisymmetric mixed Chebyshev identity U_m·T_n − U_n·T_m = X·U_{m−n−1} as a polynomial identity over any commutative ring R[X], for m, n : ℤ. Where the sibling entry linearizes the symmetric product 2·T_m·U_n = U_{m+n} + U_{n−m}, the antisymmetric combination collapses to a single second-kind polynomial scaled by X — carrying no factor of 2, so it holds verbatim in every characteristic. Along the way it establishes the second-kind Wronskian / d'Ocagne identity U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}, neither of which is in Mathlib.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials#Products_of_Chebyshev_polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "wronskian",
+      "dOcagne-identity",
+      "antisymmetric",
+      "linearization",
+      "polynomial-identity",
+      "second-kind",
+      "commutative-ring",
+      "characteristic-free",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 115,
+    "assumptions": "0 axioms, 0 sorries. Machine-checked with docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01OQ02 (7744 jobs, clean). Tier-A: depends only on the foundational axioms propext / Classical.choice / Quot.sound — no native_decide, no assumption-carrying structures. Polynomial identity over an arbitrary commutative ring R, for m, n : ℤ.",
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "U_mul_T_antisymm: U_m·T_n − U_n·T_m = X·U_{m−n−1} as a polynomial identity in R[X] for any CommRing R and m, n : ℤ — a division-free (characteristic-independent) closed form for the antisymmetric mixed Chebyshev product; not in Mathlib",
+      "U_wronskian: U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}, the second-kind Chebyshev Wronskian / d'Ocagne identity — the Casoratian of two shifted U-sequences collapses to a single U depending only on the index gap; not in Mathlib",
+      "U_mul_T_sub: U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}, the mixed subtraction formula (polynomial form of sin(mθ)cos(nθ) − cos(mθ)sin(nθ) = sin((m−n)θ)), obtained from the second-kind addition formula at (m−1, −n)",
+      "T_eq_U_sub_X_U: T_k = U_k − X·U_{k−1}, a division-free expression of the first kind in terms of the second, extracted from Mathlib's mixed recurrence U_eq_X_mul_U_add_T"
+    ],
+    "historicalContext": "The de Moivre / Chebyshev family in this gallery has built up the multiplication table of the two Chebyshev kinds as polynomial identities over an arbitrary commutative ring: the first-kind product-to-sum 2·T_m·T_n = T_{m+n} + T_{m−n} (Mathlib's T_mul_T), the mixed 2·T_m·U_n = U_{m+n} + U_{n−m} (sibling de-moivre-oq-02-oq-02), and the second-kind linearization U_m·U_n = ∑_{k} U_{m+n−2k} (parent de-moivre-oq-02-oq-02-oq-01). All of those are symmetric in their two indices. This entry treats the complementary antisymmetric combination U_m·T_n − U_n·T_m, showing it collapses to a single second-kind term X·U_{m−n−1}. The key technical device is a Wronskian (Casoratian): U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}, the discrete analogue of the constancy of a two-solution Wronskian for a second-order linear recurrence, here made completely explicit. This is a d'Ocagne-type identity, classical for Fibonacci/Lucas sequences and their Chebyshev generalizations (Mason–Handscomb, §2), but absent from Mathlib and — unlike the symmetric product-to-sum formulas — requiring no division by 2.",
+    "problemStatement": "**The Open Question** (mixed U·T, antisymmetric case)\n\nThe sibling entry proved the *symmetric* product-to-sum 2·T_m·U_n = U_{m+n} + U_{n−m}, which needs a factor of 2. What about the *antisymmetric* combination U_m·T_n − U_n·T_m? Does it also linearize into a single second-kind polynomial, and can it be done division-free (valid in characteristic 2)?\n\n**Answer: YES**\n\nFor every commutative ring $R$ and all $m, n \\in \\mathbb{Z}$:\n$$U_m \\cdot T_n - U_n \\cdot T_m = X \\cdot U_{m-n-1} \\quad\\text{in } R[X],$$\nwith no factor of 2 anywhere — an identity of $\\mathbb{Z}$-coefficient polynomials holding in every characteristic.",
+    "proofStrategy": "**Reflection + Wronskian, entirely by linear_combination (no induction in this file)**\n\n1. `T_eq_U_sub_X_U`: rearrange Mathlib's mixed recurrence $U_{k+1} = X\\,U_k + T_{k+1}$ into $T_k = U_k - X\\,U_{k-1}$ (division-free).\n2. `U_mul_T_sub`: evaluate the second-kind addition formula $U_{a+b} = U_a T_b + T_{a+1} U_{b-1}$ (from ChebyshevPolynomialsOQ01OQ01.U_add) at $(a,b) = (m-1, -n)$; apply the reflections $T_{-n} = T_n$ and $U_{-n-1} = -U_{n-1}$ to get $U_{m-1} T_n - T_m U_{n-1} = U_{m-n-1}$.\n3. `U_wronskian`: eliminate both first-kind factors in step 2 via step 1; the $X\\,U_{m-1}U_{n-1}$ cross-terms cancel, leaving $U_{m-1}U_n - U_m U_{n-1} = U_{m-n-1}$.\n4. `U_mul_T_antisymm`: substitute step 1 into $U_m T_n - U_n T_m$; it becomes $X(U_{m-1}U_n - U_m U_{n-1})$, which is $X$ times step 3.",
+    "keyInsights": [
+      "**Antisymmetric ⇒ division-free**: The symmetric product-to-sum formulas $2T_mU_n = \\dots$ inherently carry a factor of 2 (they average two angle-addition formulas). The antisymmetric combination instead *subtracts* them, and the 2 never appears — so the identity is a genuine statement over any commutative ring, characteristic 2 included, with no need to invert 2.",
+      "**A Wronskian at the heart**: $U_{m-1}U_n - U_m U_{n-1}$ is the Casoratian of the two shifted solutions $(U_{n-1}, U_n)$ and $(U_{m-1}, U_m)$ of the second-order recurrence $p_{k+1} = 2X p_k - p_{k-1}$. That it collapses to a single $U_{m-n-1}$ depending only on the index gap is the discrete analogue of a Wronskian being constant — here pinned to an exact polynomial.",
+      "**No induction needed here**: All four identities close by `linear_combination` on top of one already-proved inductive lemma (`U_add`) and Mathlib's reflections `T_neg`, `U_neg_sub_one`. Evaluating the addition formula at a negative argument does the work that a fresh two-step induction would otherwise require.",
+      "**T in terms of U, division-free**: $T_k = U_k - X\\,U_{k-1}$ expresses the first kind through the second with integer coefficients (contrast $2T_k = U_k - U_{k-2}$, which needs a 2). This is what keeps the whole derivation characteristic-independent.",
+      "**Integer indices throughout**: With $m, n : \\mathbb{Z}$ and Mathlib's ℤ-indexed $T, U$, the negative-index conventions ($U_{-1}=0$, $T_{-n}=T_n$, $U_{-n-1}=-U_{n-1}$) are handled by named reflection lemmas, so no $m \\ge n$ side condition is ever needed."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevPolynomialsOQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Polynomial.Chebyshev"
+    ],
+    "namespace": "DeMoivreOQ02OQ02OQ01OQ02",
+    "lineCount": 115,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean",
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "U_mul_T_antisymm",
+        "statement": "∀ {R : Type*} [CommRing R] (m n : ℤ), U R m * T R n - U R n * T R m = X * U R (m - n - 1)",
+        "description": "The antisymmetric mixed Chebyshev product, division-free over any CommRing R"
+      },
+      {
+        "name": "U_wronskian",
+        "statement": "∀ {R : Type*} [CommRing R] (m n : ℤ), U R (m - 1) * U R n - U R m * U R (n - 1) = U R (m - n - 1)",
+        "description": "The second-kind Chebyshev Wronskian / d'Ocagne identity"
+      },
+      {
+        "name": "U_mul_T_sub",
+        "statement": "∀ {R : Type*} [CommRing R] (m n : ℤ), U R (m - 1) * T R n - T R m * U R (n - 1) = U R (m - n - 1)",
+        "description": "The mixed subtraction formula, from the second-kind addition formula at (m−1, −n)"
+      },
+      {
+        "name": "T_eq_U_sub_X_U",
+        "statement": "∀ {R : Type*} [CommRing R] (k : ℤ), T R k = U R k - X * U R (k - 1)",
+        "description": "First kind in terms of second kind, division-free"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "**Symmetric vs antisymmetric Chebyshev products**\n\nBoth Chebyshev families obey $p_{k+2} = 2x p_{k+1} - p_k$: the first kind $T_n(\\cos\\theta)=\\cos(n\\theta)$ and the second kind $U_n(\\cos\\theta)\\sin\\theta = \\sin((n+1)\\theta)$. Their *symmetric* products linearize by product-to-sum: $2T_mT_n = T_{m+n}+T_{m-n}$, $2T_mU_n = U_{m+n}+U_{n-m}$, and $U_mU_n = \\sum_k U_{m+n-2k}$. Each of these is the polynomial shadow of averaging two angle-addition formulas, and each carries a factor of 2 or a sum of many terms. The *antisymmetric* combination $U_mT_n - U_nT_m$ is different: subtracting the two angle-addition formulas makes the factor of 2 cancel, and the result is the single term $X\\cdot U_{m-n-1}$ — the polynomial form of $\\sin((m+1)\\theta)\\cos(n\\theta) - \\sin((n+1)\\theta)\\cos(m\\theta) = \\cos\\theta\\,\\sin((m-n)\\theta)$. The engine is a Wronskian (Casoratian) identity $U_{m-1}U_n - U_mU_{n-1} = U_{m-n-1}$, a d'Ocagne-type formula classical for Fibonacci–Lucas and their Chebyshev parents (Mason–Handscomb, *Chebyshev Polynomials*, 2003, §2) but not present in Mathlib. Unlike the symmetric identities it is genuinely characteristic-free.",
+    "problemStatement": "**The Open Question**\n\nThe sibling T·U entry linearized the *symmetric* product $2T_mU_n = U_{m+n}+U_{n-m}$ (a factor of 2 is unavoidable there). Does the *antisymmetric* combination $U_mT_n - U_nT_m$ linearize into a single second-kind polynomial, division-free?\n\n**Answer: YES** — $U_mT_n - U_nT_m = X\\,U_{m-n-1}$ for every commutative ring $R$ and all $m,n\\in\\mathbb{Z}$.",
+    "text": "Proves U_m·T_n − U_n·T_m = X·U_{m−n−1} as a polynomial identity over any commutative ring R, division-free. The core is the second-kind Wronskian U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}; the mixed product reduces to it after writing T_k = U_k − X·U_{k−1}. Every step closes by linear_combination on top of the second-kind addition formula and Mathlib's reflection lemmas — no induction in this file.",
+    "proofStrategy": "**Reflection + Wronskian**\n\n1. `T_eq_U_sub_X_U`: $T_k = U_k - X U_{k-1}$ from Mathlib's $U_{k+1} = X U_k + T_{k+1}$.\n2. `U_mul_T_sub`: the addition formula $U_{a+b} = U_a T_b + T_{a+1}U_{b-1}$ at $(m-1,-n)$ with $T_{-n}=T_n$, $U_{-n-1}=-U_{n-1}$ gives $U_{m-1}T_n - T_mU_{n-1} = U_{m-n-1}$.\n3. `U_wronskian`: eliminate the $T$'s via step 1; cross terms cancel, leaving $U_{m-1}U_n - U_mU_{n-1} = U_{m-n-1}$.\n4. `U_mul_T_antisymm`: substitute step 1 into $U_mT_n - U_nT_m = X(U_{m-1}U_n - U_mU_{n-1})$ = $X$·(step 3).",
+    "keyInsights": [
+      "**Subtraction kills the 2**: symmetric product-to-sum formulas average two angle-addition identities (hence a factor 2); the antisymmetric difference cancels it, giving a characteristic-free identity.",
+      "**Wronskian collapses to one term**: $U_{m-1}U_n - U_mU_{n-1}$, the Casoratian of two shifted U-sequences, equals $U_{m-n-1}$ — it depends only on the index gap, the discrete Wronskian-is-constant phenomenon made exact.",
+      "**Negative-argument evaluation replaces induction**: applying the addition formula at $(m-1,-n)$ and reflecting does the job a fresh two-step ℤ induction would otherwise require; the whole file is `linear_combination`.",
+      "**Division-free T-from-U**: $T_k = U_k - X U_{k-1}$ (integer coefficients) is what keeps every downstream identity valid in every characteristic.",
+      "**Identity over any CommRing**: established in $R[X]$ via `variable {R : Type*} [CommRing R]`, so it specializes to ℝ, ℂ, ℤ, or 𝔽₂ unchanged."
+    ],
+    "prerequisites": [
+      "Second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1} (ChebyshevPolynomialsOQ01OQ01.U_add)",
+      "Mathlib mixed recurrence U_eq_X_mul_U_add_T and reflections T_neg, U_neg_sub_one",
+      "linear_combination tactic",
+      "ℤ-indexed Chebyshev polynomials with negative-index conventions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-and-strategy",
+      "title": "Open Question, Answer, and Strategy",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Imports (Mathlib and the sibling addition-formula file), module docstring, and setup. States the antisymmetric open question left implicit by the symmetric sibling — does U_m·T_n − U_n·T_m collapse to a single second-kind polynomial, division-free? — and answers YES with U_m·T_n − U_n·T_m = X·U_{m−n−1}. Records the four-step reflection+Wronskian plan and fixes the ambient commutative ring R.",
+      "mathContext": "$U_m T_n - U_n T_m = X\\,U_{m-n-1}$ in $R[X]$, no factor of 2."
+    },
+    {
+      "id": "t-from-u",
+      "title": "First Kind from Second Kind (T_eq_U_sub_X_U)",
+      "startLine": 59,
+      "endLine": 66,
+      "summary": "Rearranges Mathlib's mixed recurrence U_eq_X_mul_U_add_T (U_{k+1} = X·U_k + T_{k+1}) into the division-free form T_k = U_k − X·U_{k−1}, expressing the first kind through the second with integer coefficients. This is the substitution that later eliminates all first-kind factors and keeps everything characteristic-free.",
+      "mathContext": "$T_k = U_k - X\\,U_{k-1}$; contrast $2T_k = U_k - U_{k-2}$, which needs a 2."
+    },
+    {
+      "id": "mixed-subtraction",
+      "title": "The Mixed Subtraction Formula (U_mul_T_sub)",
+      "startLine": 68,
+      "endLine": 79,
+      "summary": "Evaluates the second-kind addition formula U_{a+b} = U_a·T_b + T_{a+1}·U_{b−1} at (a,b) = (m−1, −n) and applies the reflections T_{−n} = T_n and U_{−n−1} = −U_{n−1}, yielding U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}. This is the polynomial form of sin(mθ)cos(nθ) − cos(mθ)sin(nθ) = sin((m−n)θ) — a single-term linearization already.",
+      "mathContext": "$U_{m-1}T_n - T_mU_{n-1} = U_{m-n-1}$, from the addition formula at a negative argument."
+    },
+    {
+      "id": "wronskian",
+      "title": "The Second-Kind Wronskian (U_wronskian)",
+      "startLine": 81,
+      "endLine": 91,
+      "summary": "Eliminates both first-kind factors from the mixed subtraction formula using T_eq_U_sub_X_U twice. The X·U_{m−1}·U_{n−1} cross-terms cancel, leaving the pure second-kind Wronskian / d'Ocagne identity U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1} — the Casoratian of two shifted U-sequences depending only on the index gap.",
+      "mathContext": "$U_{m-1}U_n - U_mU_{n-1} = U_{m-n-1}$, a d'Ocagne / Casoratian identity."
+    },
+    {
+      "id": "main-antisymm",
+      "title": "The Antisymmetric Mixed Product (U_mul_T_antisymm)",
+      "startLine": 93,
+      "endLine": 115,
+      "summary": "Substitutes T_eq_U_sub_X_U into U_m·T_n − U_n·T_m; the expression becomes X·(U_{m−1}·U_n − U_m·U_{n−1}), which is X times the Wronskian, giving the headline identity U_m·T_n − U_n·T_m = X·U_{m−n−1}. Closed by linear_combination. Two concrete ℤ instances cross-check the formula numerically.",
+      "mathContext": "$U_m T_n - U_n T_m = X(U_{m-1}U_n - U_mU_{n-1}) = X\\,U_{m-n-1}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the division-free antisymmetric mixed Chebyshev identity U_m·T_n − U_n·T_m = X·U_{m−n−1} over any commutative ring R, with 0 sorries and 0 axioms, machine-checked. The engine is the second-kind Wronskian U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}; the whole file closes by linear_combination on top of the addition formula and Mathlib's reflection lemmas.",
+    "implications": "**Theoretical Significance**\n\n1. **Completes the Chebyshev product table with its antisymmetric entry**: alongside the symmetric T·T, T·U, and U·U linearizations, the antisymmetric U·T combination now has an explicit single-term closed form.\n\n2. **A characteristic-free identity**: unlike the symmetric product-to-sum formulas (which carry a factor of 2), the antisymmetric one holds over any commutative ring including characteristic 2 — a genuinely stronger statement.\n\n3. **The Chebyshev Wronskian as a reusable tool**: U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1} is the discrete Wronskian-constancy for the Chebyshev recurrence, useful wherever a Casoratian of two shifted U-solutions appears (continued fractions, orthogonal-polynomial kernels, Fibonacci/Lucas specializations at X = 1/2).",
+    "openQuestions": [
+      "Does the antisymmetric first-kind combination T_m·U_{n−1} − T_n·U_{m−1} admit an equally clean single-term form, and how does it relate to the Wronskian here?",
+      "Can the Chebyshev Wronskian be upgraded to a Christoffel–Darboux-type summation formula ∑_k U_k(x)U_k(y) for the second-kind family?",
+      "Does an analogous division-free antisymmetric identity hold for the associated (shifted) Chebyshev polynomials or for the Dickson-polynomial generalization?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-02-oq-02-oq-01",
+      "relationship": "Parent entry; this complements its symmetric U·U linearization with the antisymmetric U·T identity."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry linearized the symmetric second-kind product U_m·U_n = ∑_k U_{m+n−2k}; this entry treats the antisymmetric mixed product U_m·T_n − U_n·T_m and reuses the second-kind addition formula infrastructure."
+    },
+    {
+      "targetId": "de-moivre-oq-02-oq-02",
+      "relationship": "ancestor",
+      "description": "Established the symmetric mixed product-to-sum 2·T_m·U_n = U_{m+n} + U_{n−m}; the antisymmetric complement proved here needs no factor of 2."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01",
+      "relationship": "uses",
+      "description": "Supplies the second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}, evaluated at a negative argument to drive the mixed subtraction formula."
+    }
+  ],
+  "references": [
+    {
+      "authors": "J. C. Mason, D. C. Handscomb",
+      "title": "Chebyshev Polynomials",
+      "year": "2003",
+      "venue": "CRC Press",
+      "note": "Product, linearization, and recurrence identities, Section 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry for **de-moivre-oq-02-oq-02-oq-01-oq-02** — the *antisymmetric*
mixed Chebyshev product, division-free over any commutative ring:

$$U_m \cdot T_n - U_n \cdot T_m = X \cdot U_{m-n-1} \quad\text{in } R[X],\ m,n\in\mathbb{Z}.$$

The sibling `DeMoivreOQ02OQ02.T_mul_U_product` already linearizes the **symmetric**
product `2·T_m·U_n = U_{m+n} + U_{n−m}` (a factor of 2 is unavoidable there), so a
plain U·T product-to-sum would be a duplicate. The **antisymmetric** combination is
genuinely new: subtracting the two angle-addition formulas cancels the 2, so the
result is a single second-kind term scaled by `X` and holds in **every characteristic**
(including char 2).

## What's proved (all new, none in Mathlib; every step by `linear_combination`, no fresh induction)

| Lemma | Statement |
|-------|-----------|
| `T_eq_U_sub_X_U`   | `T_k = U_k − X·U_{k−1}` (division-free first-from-second) |
| `U_mul_T_sub`      | `U_{m−1}·T_n − T_m·U_{n−1} = U_{m−n−1}` (mixed subtraction formula) |
| `U_wronskian`      | `U_{m−1}·U_n − U_m·U_{n−1} = U_{m−n−1}` (second-kind Chebyshev **Wronskian / d'Ocagne** identity) |
| `U_mul_T_antisymm` | `U_m·T_n − U_n·T_m = X·U_{m−n−1}` (headline) |

**Route.** Evaluate the already-verified second-kind addition formula
`ChebyshevPolynomialsOQ01OQ01.U_add` (`U_{a+b} = U_a·T_b + T_{a+1}·U_{b−1}`) at
`(a,b) = (m−1, −n)`, reflect via `T_neg` / `U_neg_sub_one` to get `U_mul_T_sub`;
eliminate the `T`'s via `T_eq_U_sub_X_U` (cross-terms cancel) to get the Wronskian;
multiply by `X` for the headline. Evaluating an addition formula at a negative
argument replaces what would otherwise be a fresh two-step ℤ induction.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.DeMoivreOQ02OQ02OQ01OQ02` → **7744 jobs, clean**.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.** Tier-A axiom-free
  (`propext / Classical.choice / Quot.sound` only).
- Numeric cross-checks over ℤ included as `example`s: `(m,n)=(2,1)` gives `X`.

## Files

- `proofs/Proofs/DeMoivreOQ02OQ02OQ01OQ02.lean` (new, 115 lines)
- `src/data/proofs/de-moivre-oq-02-oq-02-oq-01-oq-02/{meta,annotations}.json` (new)
- `research/problems/de-moivre-oq-02-oq-02-oq-01-oq-02/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)