### PR TITLE
Enrich Kummer OQ05 (digit-sum criterion): annotation coverage 4→5 (roadmap docstring)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-05/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-05/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-roadmap-strategy",
+    "proofId": "kummer-theorem-oq-05",
+    "range": {
+      "startLine": 3,
+      "endLine": 58
+    },
+    "type": "context",
+    "title": "Roadmap: From One Valuation Identity to Four Results",
+    "content": "The file docstring lays out the whole strategy, completing the binomial side that the parent entry kummer-theorem left as a remark. The single engine is the elementary factorization C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial): taking p-adic valuations turns the product into the sum ν_p C(n,k) + ν_p(k!) + ν_p((n-k)!) = ν_p(n!), and substituting Legendre's factorial identity three times (multiplied by p-1) cancels k+(n-k)=n to give the exact untruncated identity S_p(n) + (p-1)·ν_p C(n,k) = S_p(k) + S_p(n-k). From that one equation, linear arithmetic yields all four theorems below: the classical Kummer formula, digit-sum subadditivity, and the carry-free divisibility criterion. The valuation identity itself is already in Mathlib (sub_one_mul_padicValNat_choose_eq_sub_sum_digits); the contribution here is the untruncated ordered form and the two corollaries assembled over the parent's Legendre identity.",
+    "mathContext": "$S_p(n) + (p-1)\\,\\nu_p\\binom{n}{k} = S_p(k) + S_p(n-k)$, from $\\nu_p$ applied to $\\binom{n}{k}k!(n-k)! = n!$ plus Legendre thrice.",
+    "significance": "context",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "Legendre's formula",
+      "base-p digit sum",
+      "binomial coefficients",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "Legendre's factorial formula"
+    ]
+  },
+  {
     "id": "ann-kummer-oq05-untruncated-identity",
     "proofId": "kummer-theorem-oq-05",
     "range": {


### PR DESCRIPTION
Enrichment pass for `kummer-theorem-oq-05` (quality 93, passes 0).

**Coverage 4→5 (real gap).** The four theorems each had an annotation, but annotations started at line 63 — the substantial **58-line file docstring** (the whole strategy/roadmap) was completely unhighlighted. Added `ann-roadmap-strategy` (3–58) explaining the single engine: C(n,k)·k!·(n-k)!=n! → p-adic valuation additivity → Legendre's identity applied three times → the exact untruncated identity, from which all four downstream results follow by linear arithmetic. Notes the relationship to Mathlib's existing `sub_one_mul_padicValNat_choose_eq_sub_sum_digits`. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

Annotations-only; meta.json untouched (16.4 KB). JSON validated; size guardrail passes.