### PR TITLE
Enrich Lagrange OQ09 (center dichotomy for |G|=pq): coverage 4→5 (roadmap docstring)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-09/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-09/annotations.json
@@ -1,8 +1,35 @@
 [
   {
+    "id": "ann-oq09-roadmap",
+    "proofId": "lagrange-theorem-oq-09",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "context",
+    "title": "The Center Dichotomy for |G| = pq, and Why the Middle Is Forbidden",
+    "content": "The docstring states OQ-09 and its answer: for |G| = pq with p ≠ q prime, the center has order |Z(G)| ∈ {1, pq} — never the intermediate p or q. The argument is entirely index-theoretic. By Lagrange |Z(G)| divides pq, so it is 1, p, q, or pq. The forbidden case |Z(G)| = p gives index [G:Z(G)] = q, a prime, so G/Z(G) is cyclic; a group with cyclic central quotient is abelian, forcing Z(G) = G and |Z(G)| = pq — contradicting |Z(G)| = p. The case q is symmetric. The headline consequence, a nonabelian group of order pq has trivial center, is the structural entry point for the Sylow classification in the sibling entry lagrange-theorem-oq-01-oq-01. Mathlib's card_center_eq_prime_pow handles prime-power orders only, so the two-distinct-prime case is proved here from scratch.",
+    "mathContext": "$|Z(G)| \\in \\{1, pq\\}$ for $|G| = pq$, $p \\neq q$ prime; the divisors $p, q$ are impossible because prime index forces $G/Z(G)$ cyclic hence $G$ abelian.",
+    "significance": "context",
+    "relatedConcepts": [
+      "center of a group",
+      "Lagrange's theorem",
+      "index of a subgroup",
+      "cyclic quotient",
+      "groups of order pq"
+    ],
+    "prerequisites": [
+      "Lagrange's theorem",
+      "center and quotient groups"
+    ]
+  },
+  {
     "id": "ann-oq09-divisors",
     "proofId": "lagrange-theorem-oq-09",
-    "range": { "startLine": 44, "endLine": 66 },
+    "range": {
+      "startLine": 44,
+      "endLine": 66
+    },
     "type": "insight",
     "title": "Divisors of p·q via the Coprime gcd Split",
     "content": "The divisor structure of p·q is obtained without case-bashing on factorizations: for any n | p·q one has n = gcd(n,p)·gcd(n,q), because p and q are coprime (Nat.Coprime.gcd_mul) and gcd(n, p·q) = n. Each factor gcd(n,p), gcd(n,q) divides a prime, so is 1 or that prime, leaving exactly the four products 1, q, p, p·q.",
@@ -13,12 +40,18 @@
       "Nat.Prime.eq_one_or_self_of_dvd",
       "Nat.gcd_eq_left"
     ],
-    "prerequisites": ["coprimality", "prime divisors"]
+    "prerequisites": [
+      "coprimality",
+      "prime divisors"
+    ]
   },
   {
     "id": "ann-oq09-cyclic-quotient",
     "proofId": "lagrange-theorem-oq-09",
-    "range": { "startLine": 72, "endLine": 87 },
+    "range": {
+      "startLine": 72,
+      "endLine": 87
+    },
     "type": "insight",
     "title": "Prime Index ⟹ Cyclic Central Quotient ⟹ Abelian",
     "content": "The engine of the whole argument. If the index [G:Z(G)] is a prime r, then the quotient G/Z(G) has order r, hence is cyclic (isCyclic_of_prime_card). A group whose quotient by its center is cyclic is abelian — Mathlib's commutative_of_cyclic_center_quotient, applied to the canonical projection QuotientGroup.mk' whose kernel is exactly the center. So prime index abelianizes G, which means Z(G) is everything.",
@@ -30,12 +63,19 @@
       "QuotientGroup.ker_mk'",
       "Subgroup.index_eq_card"
     ],
-    "prerequisites": ["quotient groups", "cyclic groups", "center of a group"]
+    "prerequisites": [
+      "quotient groups",
+      "cyclic groups",
+      "center of a group"
+    ]
   },
   {
     "id": "ann-oq09-dichotomy",
     "proofId": "lagrange-theorem-oq-09",
-    "range": { "startLine": 91, "endLine": 130 },
+    "range": {
+      "startLine": 91,
+      "endLine": 130
+    },
     "type": "insight",
     "title": "Killing the Middle Divisors",
     "content": "Lagrange gives |Z(G)| | pq, so the divisor lemma leaves |Z(G)| ∈ {1, p, q, pq}. The two middle values fall: if |Z(G)| = p then |Z(G)|·[G:Z(G)] = pq forces [G:Z(G)] = q, prime, so by the cyclic-quotient engine G is abelian and |Z(G)| = pq — impossible since q > 1 makes pq ≠ p. The case |Z(G)| = q is symmetric with index p. Only the extremes 1 and pq remain.",
@@ -47,12 +87,18 @@
       "Subgroup.card_top",
       "Nat.eq_of_mul_eq_mul_left"
     ],
-    "prerequisites": ["Lagrange's theorem", "index of a subgroup"]
+    "prerequisites": [
+      "Lagrange's theorem",
+      "index of a subgroup"
+    ]
   },
   {
     "id": "ann-oq09-corollaries",
     "proofId": "lagrange-theorem-oq-09",
-    "range": { "startLine": 132, "endLine": 160 },
+    "range": {
+      "startLine": 132,
+      "endLine": 160
+    },
     "type": "concept",
     "title": "Trivial Center of the Nonabelian Group",
     "content": "The dichotomy specializes to the structural fact behind the pq-classification: a nonabelian group of order pq has trivial center. If |Z(G)| were pq it would equal |G|, making Z(G) = ⊤ and G abelian — contradicting nonabelianness. center_eq_bot_or_top restates the dichotomy at the subgroup level: Z(G) = ⊥ or Z(G) = ⊤.",
@@ -63,6 +109,9 @@
       "Subgroup.eq_bot_of_card_eq",
       "Subgroup.mem_center_iff"
     ],
-    "prerequisites": ["center of a group", "abelian groups"]
+    "prerequisites": [
+      "center of a group",
+      "abelian groups"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-09` (quality 93, passes 0).

**Coverage 4→5 (real gap).** Annotations started at line 44; the **27-line file docstring** — stating OQ-09, the answer |Z(G)| ∈ {1, pq}, and the index-theoretic reason the intermediate divisors p, q are impossible (prime index ⇒ G/Z(G) cyclic ⇒ G abelian ⇒ Z(G)=G) — was entirely unannotated. Added `ann-oq09-roadmap` (1–27) giving readers the whole answer and its logic up front, plus the connection to the sibling Sylow-classification entry and to Mathlib's prime-power-only `card_center_eq_prime_pow`. Full `mathContext`/`significance`/`relatedConcepts`/`prerequisites`.

Annotations-only; meta.json untouched (11.8 KB). JSON validated; size guardrail passes.