### PR TITLE
audit: correct theoremCount 11->13 for arsinh-log-formula-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-02/meta.json
@@ -13,7 +13,7 @@
     "namespace": "ArsinhLogFormulaOQ01OQ01OQ02",
     "lineCount": 173,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean",
     "sorries": 0
@@ -42,7 +42,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 173,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 0,
     "badge": "original",
     "originalContributions": [


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: arsinh-log-formula-oq-01-oq-01-oq-02
**Problem**: `theoremCount` metadata mismatch (LOW severity)

## Evidence

**meta.json claimed**: `theoremCount: 11` (in both `meta.theoremCount` and `leanFile.theoremCount`)
**Lean file shows**: 13 theorems in `Proofs/ArsinhLogFormulaOQ01OQ01OQ02.lean`

Full list (`grep -E '^(theorem|lemma) '`):
`sqrt_one_add_sq_pos`, `sq_sqrt_one_add_sq`, `hasDerivAt_sqrtAntideriv`, `intervalIntegrable_sqrt_integrand`, `integral_sqrt_one_add_sq_zero_to`, `integral_sqrt_one_add_sq_log`, `integral_sqrt_one_add_sq_zero_to_one_log`, `sqrt_one_add_sinh_sq`, `hasDerivAt_coshSqAntideriv`, `intervalIntegrable_cosh_sq`, `integral_cosh_sq_zero_to`, `catenoid_surface_area`, `catenoid_surface_area_zero_to_one`.

## What is NOT affected

All credibility-critical claims are accurate and unchanged:
- `sorries: 0` ✓ (0 real occurrences)
- `axiomCount: 0` ✓ (no `axiom`, no `native_decide` → no `Lean.ofReduceBool`)
- `status: verified`, `badge: original` ✓ — justified: the √(1+t²) and cosh² antiderivatives are hand-built from Mathlib's product/chain rules; Mathlib lacks them. Not a wrapper.
- `lineCount: 173` ✓, `definitionCount: 0` ✓

## Fix

`theoremCount` 11 → 13 in both fields.

---
Discovered during gallery integrity audit.