### PR TITLE
audit(abundant-number-oq-03-oq-01-oq-03): correct theoremCount 11->8

### DIFF
--- a/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/abundant-number-oq-03-oq-01-oq-03/meta.json
@@ -23,7 +23,7 @@
   "sorries": 0,
   "axiomCount": 0,
   "lineCount": 187,
-  "theoremCount": 11,
+  "theoremCount": 8,
   "definitionCount": 1,
   "dateAdded": "2026-07-03",
   "mathlib_version": "4.26.0",
@@ -157,7 +157,7 @@
   "lineCount": 187,
   "axiomCount": 0,
   "sorries": 0,
-  "theoremCount": 11,
+  "theoremCount": 8,
   "definitionCount": 1
  },
  "sorries": 0,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: abundant-number-oq-03-oq-01-oq-03 ("A Sharper Lower Density for Odd Abundant Numbers")
**Problem**: `theoremCount` overstated as 11; actual is 8.

## Evidence

`proofs/Proofs/AbundantOddDensityOQ030103.lean` (187 lines) declares exactly **8** theorems:
`abundant_1575`, `R_card`, `R_pos`, `R_lt`, `tile_odd_abundant`, `count_lower_bound_1350`, `oddAbundantCount_ge_div_1350`, `density_strictly_better` — plus 1 definition (`R`).

meta.json listed `theoremCount: 11` in both the top-level meta block (line 26) and the `leanFile` subobject (line 160).

## Fix

Corrected both `theoremCount` fields to 8. All other integrity fields verified accurate: `lineCount` (187), `definitionCount` (1), `sorries` (0), `axiomCount` (0), no `native_decide` (abundance via kernel `decide` on `sigmaFast`). Badge `verified/verified` remains warranted.

---
Discovered during gallery integrity audit.