### PR TITLE
Enrich Two-Sided Oresme Sandwich (H_2ⁿ ≤ 1+n): de-bundle annotation 4→5, add ln 2 window insight

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-01/annotations.json
@@ -74,22 +74,45 @@
     "proofId": "harmonic-divergence-oq-05-oq-01",
     "range": {
       "startLine": 112,
-      "endLine": 122
+      "endLine": 114
     },
     "type": "concept",
-    "title": "The Two-Sided Sandwich and Its Width",
-    "content": "harmonic_two_pow_sandwich simply pairs this entry's upper bound with the parent's harmonic_two_pow_ge to deliver 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n in one statement — answering the open question posed verbatim in the parent OQ-05's conclusion. harmonic_two_pow_window records that the gap between the two bounds is exactly (1 + n) − (1 + n/2) = n/2 (by ring), so the dyadic partial sums are localised to an interval of length n/2. This is the elementary, constant-free witness that H_N grows like log N: at N = 2ⁿ the sum sits between 1 + (log₂ N)/2 and 1 + log₂ N.",
-    "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$, gap $= n/2$. Equivalently $1 + \\tfrac{\\log_2 N}{2} \\le H_N \\le 1 + \\log_2 N$ at the dyadic points $N = 2^n$.",
+    "title": "The Two-Sided Sandwich",
+    "content": "harmonic_two_pow_sandwich simply pairs this entry's upper bound harmonic_two_pow_le with the parent's lower bound harmonic_two_pow_ge to deliver 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n in one statement — the answer to the open question posed verbatim in the parent OQ-05's conclusion. The proof is an anonymous constructor ⟨harmonic_two_pow_ge n, harmonic_two_pow_le n⟩: the sandwich carries no new mathematical content beyond conjoining two already-proved facts, which is exactly why keeping both bounds phrased over the same H (from the shared parent namespace) matters — the conjunction is only meaningful because both sides speak about the identical partial-sum object. This is the elementary, constant-free witness that H_N grows like log N: at N = 2ⁿ the sum sits between 1 + (log₂ N)/2 and 1 + log₂ N.",
+    "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$. Equivalently $1 + \\tfrac{\\log_2 N}{2} \\le H_N \\le 1 + \\log_2 N$ at the dyadic points $N = 2^n$.",
     "significance": "key",
     "relatedConcepts": [
       "two-sided bounds",
       "logarithmic growth",
       "harmonic_two_pow_ge",
-      "sandwich theorem"
+      "sandwich theorem",
+      "anonymous constructor"
     ],
     "prerequisites": [
-      "conjunction of inequalities",
-      "ring normalization"
+      "conjunction of inequalities"
+    ]
+  },
+  {
+    "id": "ann-window",
+    "proofId": "harmonic-divergence-oq-05-oq-01",
+    "range": {
+      "startLine": 116,
+      "endLine": 120
+    },
+    "type": "insight",
+    "title": "Width of the Sandwich: the Gap Is Exactly n/2",
+    "content": "harmonic_two_pow_window records that the two bounds are not merely both correct but quantitatively tight together: their difference is exactly (1 + n) − (1 + n/2) = n/2, discharged by a single ring call. This turns the qualitative sandwich into a localisation statement — the dyadic partial sums H_{2ⁿ} are pinned to an interval of length n/2 (equivalently width (log₂ N)/2 at N = 2ⁿ), centred at 1 + 3n/4. It is the sharpest elementary, constant-free control one gets from the pure Oresme block estimates; closing the gap further, toward the true H_{2ⁿ} = (ln 2)·n + γ + o(1), requires finer, non-elementary input.",
+    "mathContext": "$(1 + n) - (1 + n/2) = n/2$, so $H_{2^n}$ lies in an interval of width $n/2$ centred at $1 + 3n/4$. The true asymptotic is $H_{2^n} = (\\ln 2)\\, n + \\gamma + o(1)$ with $\\ln 2 \\approx 0.693 \\in [1/2, 1]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "localisation width",
+      "ring normalization",
+      "Euler–Mascheroni constant",
+      "logarithmic growth"
+    ],
+    "prerequisites": [
+      "ring normalization",
+      "subtraction of linear bounds"
     ]
   }
 ]

--- a/src/data/proofs/harmonic-divergence-oq-05-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-01/meta.json
@@ -65,7 +65,8 @@
       "**Completes the sandwich**: combined with the parent, 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n. The two bounds straddle H_{2ⁿ} with a gap of exactly n/2, the elementary shadow of H_N ~ ln N at the dyadic sampling points.",
       "**Not a Mathlib lemma**: Mathlib offers only the existence-form divergence (Real.tendsto_sum_range_one_div_nat_succ_atTop) and no closed two-sided bound; both directions are original to this gallery family.",
       "**Reuses parent infrastructure**: the induction reuses the parent's range→range+Ico split H_two_pow_succ verbatim, isolating the only new ingredient as the dual block estimate.",
-      "**Answers the parent's open question**: OQ-05 explicitly asked whether a matching elementary upper bound H_{2ⁿ} ≤ 1 + n could be formalized to sandwich the partial sums; this entry does exactly that."
+      "**Answers the parent's open question**: OQ-05 explicitly asked whether a matching elementary upper bound H_{2ⁿ} ≤ 1 + n could be formalized to sandwich the partial sums; this entry does exactly that.",
+      "**Why the window is valid a posteriori**: the true asymptotic is H_{2ⁿ} = (ln 2)·n + γ + o(1), a line of slope ln 2 ≈ 0.693. The block estimates bracket the slope crudely between 1/2 and 1, and 0.693 lies safely inside [1/2, 1] — so the elementary sandwich must hold, while its width n/2 reflects exactly the looseness of using the block endpoints 1/2ⁿ⁺¹ and 1/2ⁿ instead of the true per-block increment."
     ],
     "prerequisites": [
       "Real analysis (partial sums, series bounds)",
@@ -100,11 +101,19 @@
     },
     {
       "id": "sandwich",
-      "title": "The Two-Sided Sandwich and Its Width",
+      "title": "The Two-Sided Sandwich",
       "startLine": 112,
-      "endLine": 122,
-      "summary": "harmonic_two_pow_sandwich: pairs this entry's upper bound with the parent's harmonic_two_pow_ge to give 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n. harmonic_two_pow_window: the bounds differ by exactly n/2.",
-      "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$ with gap $(1+n) - (1+n/2) = n/2$, localising the dyadic partial sums to an interval of length n/2."
+      "endLine": 114,
+      "summary": "harmonic_two_pow_sandwich: pairs this entry's upper bound with the parent's harmonic_two_pow_ge to give 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n in one statement, answering OQ-05's open question via the anonymous constructor ⟨harmonic_two_pow_ge n, harmonic_two_pow_le n⟩.",
+      "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$, i.e. $1 + \\tfrac{\\log_2 N}{2} \\le H_N \\le 1 + \\log_2 N$ at $N = 2^n$."
+    },
+    {
+      "id": "window",
+      "title": "Width of the Sandwich",
+      "startLine": 116,
+      "endLine": 120,
+      "summary": "harmonic_two_pow_window: the upper and lower bounds differ by exactly (1+n)−(1+n/2) = n/2 (by ring), localising H_{2ⁿ} to an interval of width n/2 centred at 1 + 3n/4 — the sharpest control obtainable from the pure Oresme block estimates.",
+      "mathContext": "$(1+n) - (1+n/2) = n/2$. The true value $H_{2^n} = (\\ln 2)\\,n + \\gamma + o(1)$ has slope $\\ln 2 \\approx 0.693 \\in [1/2, 1]$, safely inside the window."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-05-oq-01` (**The Dyadic Upper Bound H_2ⁿ ≤ 1 + n — Two-Sided Oresme Sandwich**).

The entry was already high quality (quality 93, passes 0), so this is a focused curation pass, not accretion. `meta.json` grew 10.5 KB → 11.5 KB, well under the 60 KB cap.

**Changes**

- **De-bundled the sandwich annotation 4 → 5.** The old `ann-sandwich` (lines 112–122) covered two distinct theorems at once. Split into:
  - `ann-sandwich` (112–114): the conjunction `harmonic_two_pow_sandwich`, now noting the anonymous-constructor proof `⟨harmonic_two_pow_ge n, harmonic_two_pow_le n⟩` and why both bounds must share the parent's `H`.
  - `ann-window` (116–120): the exact gap `harmonic_two_pow_window`, the `n/2` localisation and its relation to the true asymptotic.
- **Split the matching `sections` entry** `sandwich` → `sandwich` + `window` to keep sections aligned with the annotations.
- **Added one keyInsight** (5 → 6, cap 12): the true asymptotic slope `ln 2 ≈ 0.693` lies inside `[1/2, 1]`, explaining *a posteriori* why the elementary sandwich must hold and why its width `n/2` reflects the looseness of the block endpoints.

**Verification**: both JSON files parse; annotations count = 5; annotation ranges cover the 122-line file without regressions; `axiomCount`/`status`/`badge` unchanged (still `verified`, 0 axioms — accurate). No `index.ts` created.
