### PR TITLE
Enrich Gerretsen's inequality: add primary-source references

### DIFF
--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -114,6 +114,18 @@
   ],
   "references": [
     {
+      "authors": "Gerretsen, J. C. H.",
+      "title": "Ongelijkheden in de driehoek (Inequalities in the triangle)",
+      "year": "1953",
+      "note": "Original source of the two Gerretsen inequalities s² ≤ 4R² + 4Rr + 3r² and s² ≥ 16Rr − 5r²; Nieuw Tijdschrift voor Wiskunde 41, 1–7."
+    },
+    {
+      "authors": "Blundon, W. J.",
+      "title": "Inequalities associated with the triangle",
+      "year": "1965",
+      "note": "Establishes the sharp bounds s ≤ 2R + (3√3 − 4)r and the fundamental (s, R, r) region; the Blundon upper bound named in the open questions. Canadian Mathematical Bulletin 8, 615–626."
+    },
+    {
       "title": "Gerretsen's inequality / fundamental triangle inequalities",
       "url": "https://en.wikipedia.org/wiki/List_of_triangle_inequalities"
     },


### PR DESCRIPTION
## Enrichment pass — `herons-formula-oq-06-oq-02` (pass 0, quality 93)

The entry is already comprehensive (4 sections, 6 mainTheorems, 4 keyInsights, conclusion with open questions). The one clear gap: `references` held only **two bare Wikipedia links** with no authors/years, even though the prose relies on named primary sources.

This pass adds the two primary citations:
- **Gerretsen, J. C. H. (1953)** — *Ongelijkheden in de driehoek*, the original source of s² ≤ 4R²+4Rr+3r² (cited by name in `historicalContext`).
- **Blundon, W. J. (1965)** — *Inequalities associated with the triangle*, the sharp s-bound named in the `openQuestions`.

Both include authors/title/year/note; the Wikipedia links are retained.

- meta.json 13.8 KB → 14.5 KB (well under the ~60 KB cap)
- No content deleted; only two references prepended
- `status`/`badge`/`axiomCount` unchanged — verified, 0 sorries, 0 axioms (accurate)
- `pnpm build` passes

Note: pushed to `feature/enricher-5-gerretsen` because the prior enricher-5 PR #34609 is still open on `feature/enricher-5`.