### PR TITLE
Research: abel-ruffini-oq-03-oq-01 — gallery entry for verified Aₙ-simplicity proof

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01/knowledge.md
@@ -214,3 +214,40 @@ Insights accumulated during research on this problem.
   (`alternatingGroup.isSimpleGroup` for `5 ≤ card α`).
 - Aristotle MCP was **down all session** (`Resource not found`/404); the entire crux
   was formalized by hand.
+
+## Session 2026-07-04 (Session 5, researcher-5) — Gallery entry for the verified proof
+
+**Mode**: REVISIT (problem already SOLVED on main, PR #33972) · **Outcome**: SOLVED (gallery promotion; no Lean change)
+
+### Situation
+- The problem was re-served as "available" although the Lean proof is **already
+  merged and VERIFIED** on main (`isSimpleGroup_alternating`, 0 sorry, 0 axiom,
+  `#print axioms` clean — PR #33972, session 4). The pool status was never flipped
+  to `completed`, so the Seeker kept re-offering it.
+- Confirmed the worktree file is byte-identical to `origin/main` and that every
+  `sorry` occurrence in the file is inside comments/docstrings (0 code sorries).
+
+### What I did
+- **Created the missing gallery entry** so the verified proof surfaces in the web
+  gallery (it had none, unlike sibling `-oq-03`):
+  - `src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/meta.json`
+    (status `verified`, badge `original`, 0 sorry / 0 axiom, 11 theorems,
+    mathlibDependencies, originalContributions, sections, mainTheorems, cross-refs
+    to parent OQ-03 and grandparent).
+  - `annotations.json` (7 annotations: overview, minimal-support strategy,
+    commutator-support containment, Case A engine, Case B engine, the crux, and
+    the general-`n` assembly).
+- Updated the research problem JSON knowledge (SOLVED summary, insights, built
+  items, next steps).
+- Marked the pool status `completed` and released the claim.
+
+### Honest assessment
+- **No new mathematics.** The proof was already complete; adding theorems to the
+  773-line 0-sorry file would be enumeration theater. The value this session is
+  (a) stopping the wasteful re-serving of a solved problem, and (b) making the
+  verified result visible in the gallery with accurate annotations.
+
+### Follow-ups recorded (depth-2 slug, within OQ cap)
+- Upstream general-`n` `alternatingGroup.isSimpleGroup` (5 ≤ card α) to Mathlib.
+- Formalize the sharp boundary **A₄ not simple** (Klein four `V₄ ⊴ A₄`), pinning
+  `5 ≤ card α` as the exact threshold of `isSimpleGroup_alternating`.

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/annotations.json
@@ -1,0 +1,164 @@
+[
+  {
+    "id": "ann-oq0301-overview",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 84
+    },
+    "type": "concept",
+    "title": "Completing the Reduction: from Criterion to Unconditional Simplicity",
+    "content": "The parent entry OQ-03 proved that, for n ≥ 5, the alternating group Aₙ is simple if and only if every nontrivial normal subgroup contains a 3-cycle — pinning the whole open content of the classical simplicity theorem to that single criterion, but leaving it unproved. This file discharges the criterion. It proves `exists_mem_isThreeCycle_of_normal` (every nontrivial normal H ⊴ Aₙ contains a 3-cycle) and feeds it into the parent's forward reduction to obtain `isSimpleGroup_alternating`: an unconditional, machine-checked proof that `alternatingGroup α` is simple for every finite type α with 5 ≤ card α. Mathlib proves this only for the concrete case `Fin 5` (`isSimpleGroup_five`), by a finite computation that does not generalize; the argument here is the classical Jordan minimal-support / commutator proof, which does. `#print axioms isSimpleGroup_alternating` reports only propext, Classical.choice, Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "mathContext": "The reduction of OQ-03 becomes an unconditional theorem once the 3-cycle-containment criterion is supplied.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "alternating group simplicity",
+      "Abel–Ruffini theorem",
+      "Jordan's minimal-support argument",
+      "commutator subgroup manipulations"
+    ],
+    "prerequisites": [
+      "Normal subgroups, commutators, and conjugacy",
+      "Cycle types and supports of permutations",
+      "The biconditional established in the parent entry OQ-03"
+    ]
+  },
+  {
+    "id": "ann-oq0301-strategy",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 173
+    },
+    "type": "insight",
+    "title": "Minimal Support Is the Quantity Being Decreased",
+    "content": "The engine of the whole proof is a single monotone quantity: the number of points a permutation moves (the cardinality of its support). `exists_min_support_ne_one` selects a nonidentity σ in the normal subgroup H with minimal support among nonidentity elements, using `Finset.exists_min_image` over the finite universe filtered to {g ∈ H, g ≠ 1}. `three_le_card_support_of_mem` establishes a floor: an even nonidentity permutation moves at least 3 points — it cannot move exactly 1 (no permutation does), and moving exactly 2 would make it a transposition, which is odd and so cannot lie in the alternating group. The whole crux then argues that this minimal σ cannot move ≥ 4 points, because a commutator would produce a still-smaller nonidentity element of H — contradicting minimality. Choosing 'support cardinality' as the induction measure is exactly what lets the argument avoid Mathlib's Fin-5 cycle-type enumeration and generalize to any finite α.",
+    "mathContext": "Minimality of support is well-defined because the support is a finite set; the argument is a descent on this cardinality.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.exists_min_image",
+      "support of a permutation",
+      "parity of transpositions",
+      "well-founded descent on a cardinality"
+    ],
+    "prerequisites": [
+      "A permutation with support of size 2 is an odd transposition",
+      "Finite sets attain a minimum of any integer-valued function"
+    ]
+  },
+  {
+    "id": "ann-oq0301-containment",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 175,
+      "endLine": 206
+    },
+    "type": "insight",
+    "title": "Why a Commutator Cannot Enlarge the Support",
+    "content": "`support_commutator_subset` is the monotonicity fact that makes the descent work: if τ.support ⊆ σ.support, then the commutator (τστ⁻¹σ⁻¹).support ⊆ σ.support. The proof observes that τ maps σ.support into itself — a point moved by τ lands in τ.support ⊆ σ.support, and a point fixed by τ stays put — so the conjugate τστ⁻¹ is again supported inside σ.support (`support_conj` rewrites its support as σ.support.map τ.toEmbedding), and multiplying by σ⁻¹ (same support as σ) keeps everything inside σ.support via `support_mul_le`. Combined with the fact that a well-chosen commutator additionally fixes at least one point that σ moves, this containment upgrades to a strict subset, hence a strictly smaller cardinality (`Finset.card_lt_card`). This is the precise mechanism by which 'not a 3-cycle' contradicts 'minimal support'.",
+    "mathContext": "Conjugation transports supports along the conjugating map; a commutator with a support-confined τ stays confined to σ.support.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Equiv.Perm.support_conj",
+      "Equiv.Perm.support_mul_le",
+      "strict subset of finite sets",
+      "Finset.card_lt_card"
+    ],
+    "prerequisites": [
+      "Support of a conjugate is the image of the support",
+      "Support of a product is contained in the union of supports"
+    ]
+  },
+  {
+    "id": "ann-oq0301-engine-a",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 208,
+      "endLine": 306
+    },
+    "type": "tactic",
+    "title": "Case A Engine: Shrinking a Length-≥3 Cycle",
+    "content": "`exists_smaller_commutator_of_five_points` handles the case where σ has a cycle of length ≥ 3: given five distinct points a,b,c,d,e with b,c,d,e moved and σa = b, σb = c, it builds ρ = τστ⁻¹σ⁻¹ with the 3-cycle τ = swap c d * swap c e = (c d e). Three explicit pointwise computations do the work: ρ ∈ H (`commutator_mem_of_normal`); ρ c = τ(σ(τ⁻¹(σ⁻¹ c))) = e ≠ c so ρ ≠ 1; and ρ b = τ(σ(τ⁻¹(σ⁻¹ b))) = b, so ρ fixes the moved point b. Since τ.support ⊆ {c,d,e} ⊆ σ.support, `support_commutator_subset` places ρ.support ⊆ σ.support, and fixing b turns this into a strict subset — so #ρ.support < #σ.support. The values σ⁻¹ c = b and σ⁻¹ b = a come from the cycle relations via `Equiv.symm_apply_apply`; τ and τ⁻¹ act trivially on a, b because those points lie outside {c,d,e}.",
+    "mathContext": "For a length-≥3 cycle, conjugating by a 3-cycle overlapping it in two points produces a shorter element of the normal subgroup.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isThreeCycle_swap_mul_swap_same",
+      "commutator of permutations",
+      "Equiv.symm_apply_apply",
+      "pointwise evaluation of a commutator"
+    ],
+    "prerequisites": [
+      "The 3-cycle (c d e) as swap c d * swap c e",
+      "Evaluating a product of permutations point by point"
+    ]
+  },
+  {
+    "id": "ann-oq0301-engine-b",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 308,
+      "endLine": 518
+    },
+    "type": "tactic",
+    "title": "Case B Engine: Shrinking an Involution (Disjoint Transpositions)",
+    "content": "`exists_smaller_commutator_of_involution` handles the case σ² = 1, where σ is a product of disjoint transpositions. From σ swapping a↔b and c↔d, plus any fifth point e, it builds ρ = τστ⁻¹σ⁻¹ with τ = (c e d). Here ρ d = e ≠ d gives ρ ≠ 1, and crucially ρ fixes both a and b (which σ moves). The support is bounded by ρ.support ⊆ {c,d,e,σe} — computed from ρ = τ · (στ⁻¹σ⁻¹) with the conjugate half supported on σ • τ.support. A case split on the fifth point closes the count without any parity input: if e ∉ σ.support then σe = e so ρ.support ⊆ {c,d,e} has ≤ 3 elements while σ moves the ≥ 4 points {a,b,c,d}; if e ∈ σ.support then σ moves all five distinct points a,b,c,d,e so #σ.support ≥ 5 while #ρ.support ≤ 4. Either way #ρ.support < #σ.support. Unlike Case A, no #support side-hypothesis is needed — membership of a,b,c,d in σ.support follows directly from the swap relations.",
+    "mathContext": "For an involution, conjugating one transposition's support by a 3-cycle onto a fresh point produces a strictly smaller element; the count splits on whether the fresh point is itself moved.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "involutions as products of disjoint transpositions",
+      "Finset.card_insert_le",
+      "support bound of a commutator",
+      "case analysis on a fifth point"
+    ],
+    "prerequisites": [
+      "Disjoint transpositions and their supports",
+      "Bounding a Finset cardinality by successive card_insert_le steps"
+    ]
+  },
+  {
+    "id": "ann-oq0301-crux",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 520,
+      "endLine": 749
+    },
+    "type": "insight",
+    "title": "The Crux: a Minimal-Support Element Must Be a 3-Cycle",
+    "content": "`isThreeCycle_of_min_support` assembles the two engines into the heart of the argument. A support-minimal nonidentity σ ∈ H moves ≥ 3 points; if exactly 3 it is a 3-cycle (`card_support_eq_three_iff`) and we are done. For #support ≥ 4 the branch is shown impossible by producing a strictly smaller element, splitting on σ² = 1. When σ² = 1 (Case B) it extracts two disjoint transpositions (a,σa) and (c,σc) and a fifth point e (all found by `Finset.exists_of_ssubset`, peeling fresh points off strict subsets), then invokes the involution engine. When σ² ≠ 1 (Case A) it takes x, σx, σ²x — three distinct points on one cycle — and sub-splits: if #support ≥ 5 a fifth moved point feeds the five-points engine; if #support = 4 then σ is exactly the 4-cycle (x, σx, σ²x, d), which `IsCycle.sign` shows is odd (sign = -(-1)⁴ = -1), contradicting σ ∈ Aₙ. Every engine's smaller element contradicts `hmin`, closing the ≥ 4 branch. The residual 4-cycle is dispatched by parity, not by a commutator — which is exactly why the split is on σ² = 1 rather than on cycle type.",
+    "mathContext": "Stage (ii) of the classical proof: no minimal-support element of a normal subgroup can move four or more points, so it moves exactly three.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Equiv.Perm.card_support_eq_three_iff",
+      "Equiv.Perm.IsCycle.sign",
+      "Finset.exists_of_ssubset",
+      "case split on σ² = 1"
+    ],
+    "prerequisites": [
+      "A 4-cycle is an odd permutation",
+      "Peeling a new element off a strict subset of a finite set"
+    ]
+  },
+  {
+    "id": "ann-oq0301-assembly",
+    "proofId": "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "range": {
+      "startLine": 751,
+      "endLine": 773
+    },
+    "type": "concept",
+    "title": "Assembly: General-n Simplicity of the Alternating Group",
+    "content": "`exists_mem_isThreeCycle_of_normal` combines the minimal-support selection with the crux to conclude that every nontrivial normal subgroup of Aₙ (n ≥ 5) contains a 3-cycle — the exact statement the parent OQ-03 left open. Feeding it into the parent's `isSimpleGroup_of_forall_normal_contains_threeCycle` yields the headline `isSimpleGroup_alternating`: `alternatingGroup α` is simple for every finite α with 5 ≤ card α. This is a genuine generalization of Mathlib, which proves simplicity only for `Fin 5`. The result is a candidate for upstreaming as a general `alternatingGroup.isSimpleGroup`, and its sharp boundary is A₄ (not simple, because of the Klein four normal subgroup V₄), so the hypothesis 5 ≤ card α is exactly the threshold.",
+    "mathContext": "The one-line assembly turning the combinatorial core into the group-theoretic engine of Abel–Ruffini for all n ≥ 5.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "IsSimpleGroup (alternatingGroup α)",
+      "generalization beyond Fin 5",
+      "sharp threshold n ≥ 5",
+      "Abel–Ruffini non-solvability"
+    ],
+    "prerequisites": [
+      "The forward reduction from the parent entry",
+      "The combinatorial crux proved above"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/meta.json
@@ -1,0 +1,251 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-03-oq-01",
+  "title": "Unconditional Simplicity of Aₙ for n ≥ 5 (Jordan's Commutator Argument)",
+  "slug": "abel-ruffini-galois-extensions-oq-03-oq-01",
+  "description": "The parent entry OQ-03 reduced the simplicity of the alternating group Aₙ (n ≥ 5) to a single combinatorial criterion — every nontrivial normal subgroup contains a 3-cycle — and left that criterion open. This entry discharges it, giving a complete, machine-checked proof that `alternatingGroup α` is simple for every finite type `α` with `5 ≤ card α`, generalizing Mathlib's `alternatingGroup.isSimpleGroup_five` (which covers only `Fin 5` by an explicit finite computation that does not generalize). The proof is the classical Jordan minimal-support / commutator argument: a nontrivial normal subgroup `H ⊴ Aₙ` contains a nonidentity element `σ` of minimal support; `σ` must be a 3-cycle, because otherwise a commutator `[τ, σ]` with a well-chosen 3-cycle `τ` produces a strictly smaller nonidentity element of `H`, contradicting minimality; and a single 3-cycle normally generates all of Aₙ. The strict-support-decrease step is split into two quantitative engine lemmas (a length-≥3 cycle case and an involution case) plus the parity ruling-out of a 4-cycle. `#print axioms isSimpleGroup_alternating` reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Alternating_group#Simplicity",
+    "date": "2026-07-04",
+    "status": "verified",
+    "tags": [
+      "galois-theory",
+      "group-theory",
+      "alternating-group",
+      "simple-group",
+      "abel-ruffini",
+      "advanced"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 773,
+    "dateAdded": "07/04/26",
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.IsThreeCycle.alternating_normalClosure",
+        "description": "For `5 ≤ card α`, the normal closure of a single 3-cycle inside `alternatingGroup α` is the whole group `⊤`; the stage-(i) input that turns 'H contains a 3-cycle' into 'H = ⊤'.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Alternating"
+      },
+      {
+        "theorem": "Equiv.Perm.isThreeCycle_swap_mul_swap_same",
+        "description": "For three distinct points c, d, e, the product `swap c d * swap c e` is a 3-cycle; used to build the auxiliary 3-cycle `τ` whose commutator with `σ` shrinks the support.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Equiv.Perm.support_mul_le",
+        "description": "`(f * g).support ⊆ f.support ∪ g.support`; the basic support-of-product bound driving every containment estimate for the commutator.",
+        "module": "Mathlib.GroupTheory.Perm.Support"
+      },
+      {
+        "theorem": "Equiv.Perm.support_conj",
+        "description": "`(g * f * g⁻¹).support = f.support.map g.toEmbedding`; used to control the support of the conjugate half of the commutator.",
+        "module": "Mathlib.GroupTheory.Perm.Support"
+      },
+      {
+        "theorem": "Equiv.Perm.card_support_eq_two",
+        "description": "A permutation with support of cardinality 2 is a transposition (`IsSwap`), hence odd; the parity obstruction ruling out `#support = 2` for an even permutation.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Equiv.Perm.card_support_eq_three_iff",
+        "description": "A permutation is a 3-cycle iff its support has cardinality 3; the base case identifying a minimal-support even permutation as a 3-cycle.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Equiv.Perm.IsCycle.sign",
+        "description": "`sign f = -(-1)^f.support.card` for a cycle `f`; gives the parity of a 4-cycle (odd), contradicting membership in the alternating group in the residual `#support = 4` case.",
+        "module": "Mathlib.GroupTheory.Perm.Sign"
+      },
+      {
+        "theorem": "Subgroup.Normal.conj_mem",
+        "description": "In a normal subgroup, conjugates of members are members; the membership engine `commutator_mem_of_normal` that keeps each commutator inside H.",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "Finset.exists_min_image",
+        "description": "A nonempty finite set has an element minimizing a given function; selects the support-minimal nonidentity element of H.",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Finset.exists_of_ssubset",
+        "description": "A strict subset omits at least one element of the ambient set; repeatedly extracts fresh moved points a, b, c, d, e needed to feed the engine lemmas.",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-galois-extensions-oq-03",
+        "relationship": "**Parent entry (the reduction).** OQ-03 proved the equivalence `IsSimpleGroup (Aₙ) ↔ (every nontrivial normal subgroup contains a 3-cycle)` for `n ≥ 5`, isolating the sole open combinatorial ingredient but leaving it unproved. This entry supplies exactly that ingredient (`exists_mem_isThreeCycle_of_normal`) and feeds it into the parent's forward reduction to obtain unconditional simplicity."
+      },
+      {
+        "id": "abel-ruffini-galois-extensions",
+        "relationship": "**Grandparent file.** Develops the abstract Abel–Ruffini theory (Sₙ solvable ⟺ n ≤ 4; A₅ simple; a non-solvable Galois group blocks radical solvability). It used simplicity of Aₙ only through the A₅ instance; this entry upgrades that input to all n ≥ 5."
+      }
+    ],
+    "originalContributions": [
+      "isSimpleGroup_alternating: a complete, 0-sorry / 0-axiom proof that `alternatingGroup α` is simple for every finite `α` with `5 ≤ card α`. Mathlib proves simplicity only for `Fin 5` (`isSimpleGroup_five`) via an explicit finite computation; the general-`n` statement is new here and is obtained by the cycle-type-agnostic minimal-support argument rather than Fin-5 casework.",
+      "isThreeCycle_of_min_support: the crux — a support-minimal nonidentity element of a normal subgroup H ⊴ Aₙ is a 3-cycle. Proved by contradiction: for `#support ≥ 4` a strictly smaller nonidentity element of H is manufactured, with the residual `#support = 4 ∧ σ² ≠ 1` case eliminated by the oddness of a 4-cycle.",
+      "exists_smaller_commutator_of_five_points: the Case A engine — from a length-≥3 cycle (five distinct points with `σ a = b`, `σ b = c`) the commutator with the 3-cycle `(c d e)` is a nonidentity element of H of strictly smaller support. A fully quantitative, reusable strict-decrease lemma.",
+      "exists_smaller_commutator_of_involution: the Case B engine — from an involution swapping `a↔b` and `c↔d`, the commutator with the 3-cycle `(c e d)` fixes both a and b, is supported in `{c,d,e,σe}`, and is a nonidentity element of H of strictly smaller support (proved parity-free, by a case split on whether the fifth point e is moved).",
+      "support_commutator_subset: a reusable containment lemma — if `τ.support ⊆ σ.support` then `[τ,σ].support ⊆ σ.support`; the mechanism by which a commutator can only shrink (never enlarge) the support, converting 'fixes one moved point' into a strict cardinality drop."
+    ],
+    "assumptions": "None. The file has 0 `sorry` and 0 `axiom` declarations; `#print axioms isSimpleGroup_alternating` reports only the standard foundational axioms `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`. The two reduction lemmas from the parent (`threeCycle_normal_eq_top`, `isSimpleGroup_of_forall_normal_contains_threeCycle`) are re-inlined here so the file depends only on Mathlib.",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That $A_n$ is simple for $n \\ge 5$ is the group-theoretic heart of the Abel–Ruffini theorem — exactly why $S_n$ is not solvable for $n \\ge 5$ and hence why the general quintic is not solvable in radicals. The classical proof (Galois; Jordan; and modern texts such as Dummit–Foote §4.6 and Rotman) runs in two stages: (i) a normal subgroup of $A_n$ containing a single 3-cycle is all of $A_n$, because the 3-cycles are conjugate and generate $A_n$; and (ii) every nontrivial normal subgroup of $A_n$ ($n \\ge 5$) contains a 3-cycle. Stage (ii) is the genuinely combinatorial part, traditionally proved by Jordan's minimal-support / commutator argument: take a nonidentity element $\\sigma$ of the normal subgroup with the fewest moved points; if $\\sigma$ were not a 3-cycle, a commutator $[\\tau,\\sigma]$ with a suitable 3-cycle $\\tau$ would be a nonidentity element with strictly fewer moved points, contradicting minimality. Mathlib formalizes the whole argument only for $A_5$ (`isSimpleGroup_five`), discharging stage (ii) by an explicit `Fin 5` computation that does not generalize.",
+    "problemStatement": "Prove in Lean 4, for an arbitrary finite type $\\alpha$ with $5 \\le |\\alpha|$, that $A_\\alpha = \\mathrm{alternatingGroup}\\,\\alpha$ is simple — supplying the one ingredient the parent entry OQ-03 left open (every nontrivial normal subgroup contains a 3-cycle) and thereby generalizing Mathlib's $\\mathrm{Fin}\\,5$-only instance to all $n \\ge 5$.",
+    "proofStrategy": "**Minimal-support selection.** `exists_min_support_ne_one` picks a nonidentity $\\sigma \\in H$ whose support has minimal cardinality among nonidentity elements of $H$ (via `Finset.exists_min_image` over the filtered finite universe).\n\n**The crux `isThreeCycle_of_min_support`.** An even nonidentity permutation moves $\\ge 3$ points (`three_le_card_support_of_mem`: it cannot move 1, and moving exactly 2 would be an odd transposition). If it moves exactly 3 it is a 3-cycle (`card_support_eq_three_iff`) and we are done. Otherwise $\\#\\mathrm{support} \\ge 4$ and we derive a contradiction by exhibiting a strictly smaller nonidentity element of $H$, splitting on whether $\\sigma^2 = 1$:\n- **Case B ($\\sigma^2 = 1$, involution):** extract two disjoint transpositions $(a\\,b)$, $(c\\,d)$ and a fifth point $e$; `exists_smaller_commutator_of_involution` builds $[\\,(c\\,e\\,d),\\sigma\\,]$, which fixes $a,b$, is supported in $\\{c,d,e,\\sigma e\\}$, and moves $d\\mapsto e$, so it is a smaller nonidentity element.\n- **Case A ($\\sigma^2 \\ne 1$) with $\\#\\mathrm{support} \\ge 5$:** extract $x, \\sigma x, \\sigma^2 x$ (three points on one cycle) plus two more moved points; `exists_smaller_commutator_of_five_points` builds $[\\,(c\\,d\\,e),\\sigma\\,]$, which fixes $\\sigma x$ and lands strictly inside $\\sigma.\\mathrm{support}$.\n- **Residual $\\#\\mathrm{support} = 4 \\wedge \\sigma^2 \\ne 1$:** then $\\sigma$ is the 4-cycle $(x,\\sigma x,\\sigma^2 x, d)$, which is odd (`IsCycle.sign`), contradicting $\\sigma \\in A_\\alpha$.\n\n**Containment engine.** Both engine lemmas rely on `support_commutator_subset` (if $\\tau.\\mathrm{support} \\subseteq \\sigma.\\mathrm{support}$ then $[\\tau,\\sigma].\\mathrm{support} \\subseteq \\sigma.\\mathrm{support}$) and `commutator_mem_of_normal` (the commutator stays in $H$), so 'fixes one moved point' upgrades to a strict cardinality drop via `Finset.card_lt_card`.\n\n**Assembly.** `exists_mem_isThreeCycle_of_normal` combines selection and the crux; `isSimpleGroup_alternating` feeds it into the parent's `isSimpleGroup_of_forall_normal_contains_threeCycle`.",
+    "keyInsights": [
+      "**Minimal support, not cycle-type casework.** The proof deliberately follows Jordan's minimal-support/commutator route rather than Mathlib's Fin-5 explicit cycle-type enumeration, because only the former generalizes to an arbitrary finite type. The single quantity being decreased — the cardinality of the support — organizes the whole argument and makes 'contradiction with minimality' the uniform closing move.",
+      "**Two engines, one mechanism.** The strict-support-decrease step splits into a length-≥3-cycle case and an involution case, but both are instances of the same mechanism: conjugating $\\sigma$ by a 3-cycle $\\tau$ supported on moved points yields a commutator that (a) stays in $H$, (b) cannot enlarge the support (`support_commutator_subset`), and (c) fixes at least one point $\\sigma$ moves — hence has strictly smaller support.",
+      "**The 4-cycle is killed by parity, not by a commutator.** The one support-4 configuration the commutator engines do not directly shrink — a single 4-cycle — is excluded for free: a 4-cycle is odd, so it cannot lie in the alternating group. This is why the case split is on $\\sigma^2 = 1$ (isolating involutions) rather than directly on cycle type.",
+      "**Commutator membership is the only place normality is used.** All the group-theoretic content of 'normal' is packaged into the one-line `commutator_mem_of_normal` ($\\tau\\sigma\\tau^{-1}\\sigma^{-1} \\in H$); the rest of the argument is pure permutation combinatorics on supports, which keeps the hard lemmas self-contained and reusable.",
+      "**A genuine generalization of Mathlib.** Mathlib stops at `isSimpleGroup_five`; this file proves `isSimpleGroup_alternating` for every finite `α` with `5 ≤ card α`, and its `#print axioms` is clean. It is a candidate for upstreaming as `alternatingGroup.isSimpleGroup` (general `n`)."
+    ],
+    "prerequisites": [
+      "Mathlib.GroupTheory.SpecificGroups.Alternating (alternatingGroup, IsThreeCycle.alternating_normalClosure, mem_alternatingGroup)",
+      "Mathlib.GroupTheory.Perm.Support and Perm.Cycle.Type (support_mul_le, support_conj, card_support_eq_two/three_iff)",
+      "Mathlib.GroupTheory.Perm.Sign (IsCycle.sign, sign of a transposition / 4-cycle)",
+      "Group theory: normal subgroups, commutators, conjugacy, cycle types of permutations",
+      "The classical minimal-support proof that Aₙ is simple for n ≥ 5 (Jordan; Dummit–Foote §4.6; Rotman)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: what the parent established and the proof plan",
+      "startLine": 1,
+      "endLine": 84,
+      "summary": "Module docstring recording that the file completes OQ-03 by proving the sole open criterion (every nontrivial normal subgroup of Aₙ contains a 3-cycle), the VERIFIED status (0 sorry, 0 axiom; clean `#print axioms`), and a map of the ten supporting lemmas. Imports the alternating-group API and fixes a finite type `α` with decidable equality.",
+      "mathContext": "Sets up the general finite alternating group and states the goal: unconditional `IsSimpleGroup (alternatingGroup α)` for `5 ≤ card α`, via Jordan's minimal-support / commutator argument."
+    },
+    {
+      "id": "reduction-inlined",
+      "title": "The formal reduction, re-inlined (0 sorry)",
+      "startLine": 86,
+      "endLine": 122,
+      "summary": "`threeCycle_normal_eq_top` (a normal subgroup containing a 3-cycle is ⊤) and `isSimpleGroup_of_forall_normal_contains_threeCycle` (the 3-cycle criterion implies simplicity), reproduced from the parent OQ-03 so the file depends only on Mathlib. These are the stage-(i) reduction into which the combinatorial crux is plugged.",
+      "mathContext": "Stage (i) of the classical argument plus the ⊥/⊤ dichotomy, packaged so the new combinatorial content is all that remains."
+    },
+    {
+      "id": "supporting-lemmas",
+      "title": "Supporting lemmas: evenness bound, commutator membership, minimal support",
+      "startLine": 124,
+      "endLine": 173,
+      "summary": "`three_le_card_support_of_mem` (a nontrivial even permutation moves ≥ 3 points, since moving exactly 2 forces an odd transposition), `commutator_mem_of_normal` (`τστ⁻¹σ⁻¹ ∈ H` for `σ ∈ H ⊴ Aₙ`), and `exists_min_support_ne_one` (a nontrivial subgroup has a support-minimal nonidentity element, via `Finset.exists_min_image`).",
+      "mathContext": "The three infrastructure facts: a parity lower bound on support, the normality-driven membership engine, and the well-foundedness that makes 'minimal support' meaningful."
+    },
+    {
+      "id": "containment",
+      "title": "Commutator-support containment",
+      "startLine": 175,
+      "endLine": 206,
+      "summary": "`support_commutator_subset`: if `τ.support ⊆ σ.support` then `(τστ⁻¹σ⁻¹).support ⊆ σ.support`. Proof: `τ` maps `σ.support` into itself, so the conjugate `τστ⁻¹` is supported in `σ.support` (`support_conj` + `support_mul_le` + `support_inv`).",
+      "mathContext": "The key monotonicity fact: a commutator with a 3-cycle supported inside `σ.support` cannot escape `σ.support`, so fixing one moved point yields a strict cardinality drop."
+    },
+    {
+      "id": "engine-a",
+      "title": "Case A engine: strict decrease for a length-≥3 cycle",
+      "startLine": 208,
+      "endLine": 306,
+      "summary": "`exists_smaller_commutator_of_five_points`: given five distinct points with `b,c,d,e` moved and `σ a = b`, `σ b = c`, the commutator with `τ = (c d e)` is a nonidentity element of `H` (`ρ c = e ≠ c`) supported inside `σ.support` (via `support_commutator_subset`) that fixes the moved point `b` — hence has strictly smaller support (`Finset.card_lt_card`).",
+      "mathContext": "The quantitative strict-decrease step when `σ` has a cycle of length ≥ 3; the explicit pointwise computation of the commutator on the five points."
+    },
+    {
+      "id": "engine-b",
+      "title": "Case B engine: strict decrease for an involution",
+      "startLine": 308,
+      "endLine": 518,
+      "summary": "`exists_smaller_commutator_of_involution`: from `σ` swapping `a↔b` and `c↔d`, plus a fifth point `e`, the commutator with `τ = (c e d)` is a nonidentity element of `H` (`ρ d = e ≠ d`) that fixes both `a` and `b` and is supported in `{c,d,e,σe}`. A case split on `e ∈ σ.support` bounds `#ρ.support` (≤ 3 or ≤ 4) below the ≥ 4 (resp. ≥ 5) support of `σ`.",
+      "mathContext": "The strict-decrease step for the disjoint-transposition case; parity-free, needing only the two swap relations to place `a,b,c,d` in the support."
+    },
+    {
+      "id": "crux",
+      "title": "The crux: a support-minimal element is a 3-cycle",
+      "startLine": 520,
+      "endLine": 749,
+      "summary": "`isThreeCycle_of_min_support`: a support-minimal nonidentity `σ ∈ H ⊴ Aₙ` is a 3-cycle. `#support = 3` is immediate; for `#support ≥ 4`, split on `σ² = 1` — Case B feeds the involution engine, Case A (with `#support ≥ 5`) feeds the five-points engine, and the residual `#support = 4 ∧ σ² ≠ 1` case is a 4-cycle, ruled out as odd via `IsCycle.sign`. Each engine's smaller element contradicts minimality.",
+      "mathContext": "Stage (ii) of the classical proof, assembled: the minimal-support element cannot move ≥ 4 points, so it moves exactly 3 and is a 3-cycle."
+    },
+    {
+      "id": "assembly",
+      "title": "Assembly: the 3-cycle criterion and unconditional simplicity",
+      "startLine": 751,
+      "endLine": 773,
+      "summary": "`exists_mem_isThreeCycle_of_normal` (every nontrivial normal `H ⊴ Aₙ` contains a 3-cycle) combines minimal-support selection with the crux; `isSimpleGroup_alternating` feeds it into the parent's `isSimpleGroup_of_forall_normal_contains_threeCycle` to conclude `IsSimpleGroup (alternatingGroup α)` for every `5 ≤ card α`.",
+      "mathContext": "The headline result: general-`n` simplicity of the alternating group, generalizing Mathlib's `Fin 5`-only instance."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every finite type `α` with `5 ≤ card α`, `alternatingGroup α` is simple (`isSimpleGroup_alternating`), proved with 0 sorries and 0 axioms by Jordan's minimal-support / commutator argument. This completes the parent entry OQ-03: OQ-03 reduced simplicity to the 3-cycle-containment criterion, and this entry proves that criterion (`exists_mem_isThreeCycle_of_normal`), turning the reduction into an unconditional theorem.",
+    "implications": "Mathlib stops at `isSimpleGroup_five` (only `Fin 5`, by explicit finite computation). This entry extends simplicity to all `n ≥ 5` over an arbitrary finite type via a cycle-type-agnostic argument, and its `#print axioms` is clean. The reusable strict-decrease engines (`exists_smaller_commutator_of_five_points`, `exists_smaller_commutator_of_involution`) and the containment lemma `support_commutator_subset` are directly usable for other commutator-shrinking arguments in permutation groups. The result is a natural candidate for upstreaming as a general `alternatingGroup.isSimpleGroup`.",
+    "openQuestions": [
+      "Upstream the general-`n` simplicity to Mathlib as `alternatingGroup.isSimpleGroup` (5 ≤ card α), recovering `isSimpleGroup_five` as the `Fin 5` specialization.",
+      "Formalize the sharp boundary: `A₄` is *not* simple — the Klein four-group `V₄ = {1,(12)(34),(13)(24),(14)(23)}` is a proper nontrivial normal subgroup — establishing that the hypothesis `5 ≤ card α` in `isSimpleGroup_alternating` is exactly the threshold."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Dummit, D. S. and Foote, R. M.",
+      "title": "Abstract Algebra (3rd edition)",
+      "year": "2004",
+      "note": "John Wiley & Sons. §4.6 proves Aₙ simple for n ≥ 5 by the minimal-support / commutator argument formalized here (a nontrivial normal subgroup contains a 3-cycle; a 3-cycle generates Aₙ normally)."
+    },
+    {
+      "authors": "Rotman, J. J.",
+      "title": "An Introduction to the Theory of Groups (4th edition)",
+      "year": "1995",
+      "note": "Springer GTM 148. Gives the classical simplicity proof of Aₙ and the commutator manipulations used to shrink the support of a normal-subgroup element."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "Mathlib.GroupTheory.SpecificGroups.Alternating",
+      "year": "2024",
+      "note": "Provides `alternatingGroup.isSimpleGroup_five` (Fin 5 only) and the general-n converse machinery (`IsThreeCycle.alternating_normalClosure`, `isThreeCycle_isConj`) on which this proof's stage (i) rests."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry. OQ-03 proved the equivalence `IsSimpleGroup (Aₙ) ↔ (every nontrivial normal subgroup contains a 3-cycle)` and left the criterion open; this entry discharges the criterion and obtains unconditional simplicity, converting the biconditional into a theorem."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "underpins",
+      "description": "Grandparent file. The abstract Abel–Ruffini development uses simplicity of Aₙ only through A₅; this entry supplies the general n ≥ 5 structural fact that makes Sₙ non-solvable for all n ≥ 5."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isSimpleGroup_alternating",
+      "statement": "5 ≤ Fintype.card α → IsSimpleGroup (alternatingGroup α)",
+      "description": "The headline: the alternating group on any finite type with at least 5 elements is simple. Generalizes Mathlib's Fin-5-only `isSimpleGroup_five`; 0 sorry, 0 axiom."
+    },
+    {
+      "name": "exists_mem_isThreeCycle_of_normal",
+      "statement": "5 ≤ Fintype.card α → (H : Subgroup (alternatingGroup α)) → H.Normal → H ≠ ⊥ → ∃ g, IsThreeCycle (g : Perm α) ∧ g ∈ H",
+      "description": "The combinatorial core (stage ii), and the exact criterion the parent OQ-03 left open: every nontrivial normal subgroup of Aₙ (n ≥ 5) contains a 3-cycle."
+    },
+    {
+      "name": "isThreeCycle_of_min_support",
+      "statement": "5 ≤ Fintype.card α → H.Normal → σ ∈ H → σ ≠ 1 → (∀ τ ∈ H, τ ≠ 1 → σ.support.card ≤ τ.support.card) → IsThreeCycle (σ : Perm α)",
+      "description": "The crux: a support-minimal nonidentity element of a normal subgroup is a 3-cycle, proved by manufacturing a strictly smaller element when the support exceeds 3."
+    },
+    {
+      "name": "exists_smaller_commutator_of_five_points",
+      "statement": "H.Normal → σ ∈ H → [five distinct points, b,c,d,e moved, σa=b, σb=c] → ∃ ρ ∈ H, ρ ≠ 1 ∧ ρ.support.card < σ.support.card",
+      "description": "Case A strict-decrease engine: the commutator with the 3-cycle (c d e) shrinks the support when σ has a cycle of length ≥ 3."
+    },
+    {
+      "name": "exists_smaller_commutator_of_involution",
+      "statement": "H.Normal → σ ∈ H → [five distinct points, σ swaps a↔b and c↔d] → ∃ ρ ∈ H, ρ ≠ 1 ∧ ρ.support.card < σ.support.card",
+      "description": "Case B strict-decrease engine: the commutator with the 3-cycle (c e d) shrinks the support when σ is a product of disjoint transpositions."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03-oq-01.json
@@ -86,10 +86,15 @@
       "Mathlib supplies all the converse machinery generically (alternating_normalClosure, isThreeCycle_isConj, closure_three_cycles_eq_alternating) but assembles simplicity only for Fin 5 via cycle-type casework specific to 5 points (isSimpleGroup_five). The general casework over arbitrary α is the open formalization.",
       "Signatures line up exactly: isSimpleGroup_of_forall_normal_contains_threeCycle h5 (fun H hHn hbot => exists_mem_isThreeCycle_of_normal h5 H hHn hbot) : IsSimpleGroup (alternatingGroup α). So a one-line assembly yields the headline once the lemma lands.",
       "Right proof route is Jordan's minimal-support/commutator argument (not Mathlib's Fin-5 explicit casework, which does not generalize): pick σ∈H of minimal support, show it must be a 3-cycle by building commutators [τ,σ]∈H of strictly smaller support for a well-chosen 3-cycle τ.",
-      "An even permutation moving exactly 3 points is automatically a 3-cycle (card_support_eq_three_iff), giving the base case; the work is the strict-support-decrease step forcing support down to 3."
+      "An even permutation moving exactly 3 points is automatically a 3-cycle (card_support_eq_three_iff), giving the base case; the work is the strict-support-decrease step forcing support down to 3.",
+      "Problem is fully solved: the crux exists_mem_isThreeCycle_of_normal (every nontrivial normal H ⊴ Aₙ contains a 3-cycle) is machine-checked, discharging the biconditional from parent OQ-03 into unconditional simplicity. Verified on main (PR #33972).",
+      "The verified proof lacked a gallery entry; created meta.json (11 theorems, verified/original badge, 0 sorry/axiom) + 7 annotations mapping preamble/reduction/supporting-lemmas/containment/engine-A/engine-B/crux/assembly.",
+      "Sharp boundary noted for follow-up: A₄ is NOT simple (Klein four V₄ ⊴ A₄), so the 5 ≤ card α hypothesis in isSimpleGroup_alternating is exactly the threshold — a genuine distinct follow-up formalization."
     ],
     "builtItems": [
-      "proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean — WIP: threeCycle_normal_eq_top and isSimpleGroup_of_forall_normal_contains_threeCycle re-inlined (0 sorry), exists_mem_isThreeCycle_of_normal stated (1 sorry, HARD), isSimpleGroup_alternating assembled."
+      "proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean — WIP: threeCycle_normal_eq_top and isSimpleGroup_of_forall_normal_contains_threeCycle re-inlined (0 sorry), exists_mem_isThreeCycle_of_normal stated (1 sorry, HARD), isSimpleGroup_alternating assembled.",
+      "src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/meta.json — new gallery entry for the verified Aₙ-simplicity proof (status verified, badge original, 0 sorry/axiom, 11 theorems).",
+      "src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/annotations.json — 7 annotations covering the minimal-support argument, both commutator engines, the crux, and the assembly."
     ],
     "mathlibGaps": [
       "Mathlib has NO general alternating-group simplicity — only alternatingGroup.isSimpleGroup_five (Fin 5). The n≥5 statement is a genuine Mathlib-worthy gap; exists_mem_isThreeCycle_of_normal is the missing ingredient.",
@@ -100,8 +105,10 @@
       "When Aristotle is available: submit exists_mem_isThreeCycle_of_normal async with the minimal-support/commutator hint; it is KNOWN math (Aristotle's sweet spot), potentially multi-hour.",
       "Manual route (needs working single-file build loop): (1) minimal-support selection via Finset.exists_min_image; (2) base case #support=3 ⟹ IsThreeCycle; (3) case 4A: σ has a ≥3-cycle → commutator with τ=(c d e) strictly reduces support; (4) case 4B: σ is a product of ≥2 disjoint transpositions → commutator with τ=(c d e) on a 5th point yields a 3-cycle or smaller support.",
       "Prove a reusable commutator-support lemma: (τ*σ*τ⁻¹*σ⁻¹).support ⊆ σ.support ∪ (σ.support.map τ.toEmbedding), then bound its card.",
-      "Once landed, promote to a verified gallery entry and consider a Mathlib PR (general alternatingGroup.isSimpleGroup)."
+      "Once landed, promote to a verified gallery entry and consider a Mathlib PR (general alternatingGroup.isSimpleGroup).",
+      "Upstream general-n alternatingGroup.isSimpleGroup (5 ≤ card α) to Mathlib, recovering isSimpleGroup_five as the Fin 5 case.",
+      "Formalize the sharp boundary A₄ not simple (V₄ ⊴ A₄) as a distinct companion establishing 5 ≤ card α as the exact threshold."
     ],
-    "progressSummary": "PROGRESS (ORIENT): isolated the sole open lemma, stated the unconditional-simplicity assembly, and recorded a concrete Lean-oriented minimal-support/commutator proof plan grounded in confirmed Mathlib API. No sorries discharged — Aristotle (down) and local Docker build (corrupted) both blocked verification this session; file self-contained on Mathlib for future single-file elaboration."
+    "progressSummary": "SOLVED & VERIFIED (merged to main, PR #33972): isSimpleGroup_alternating proves Aₙ simple for every finite α with 5 ≤ card α (0 sorry, 0 axiom; #print axioms clean). This session (researcher-5): created the gallery entry (src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/meta.json + annotations.json) so the verified proof surfaces in the gallery; marked the pool completed. No Lean changes — adding to the 773-line 0-sorry file would be enumeration theater."
   }
 }


### PR DESCRIPTION
## Summary

The Lean proof for `abel-ruffini-galois-extensions-oq-03-oq-01` — `isSimpleGroup_alternating`, an unconditional, machine-checked proof that Aₙ is simple for **every** finite type with `5 ≤ card α` (0 sorry, 0 axiom; `#print axioms` clean) — is **already merged and verified on main** (PR #33972). But it had **no gallery entry**, so the verified result never surfaced in the web gallery. This PR adds it.

## Progress

- **New gallery entry** `src/data/proofs/abel-ruffini-galois-extensions-oq-03-oq-01/`:
  - `meta.json` — status `verified`, badge `original`, 0 sorry / 0 axiom, 11 theorems, Mathlib dependencies, original contributions, 8 sections, 5 mainTheorems, cross-references to parent OQ-03 and grandparent.
  - `annotations.json` — 7 annotations: overview, minimal-support strategy, commutator-support containment, Case A engine (length-≥3 cycle), Case B engine (involution), the crux, and the general-`n` assembly.
- Updated research knowledge (JSON + `knowledge.md` session note): SOLVED, pool marked completed.

## Findings

- No new mathematics — the proof is complete. Adding theorems to the 773-line 0-sorry file would be enumeration theater. The value here is (a) stopping the wasteful re-serving of a solved problem, and (b) making the verified result visible with accurate annotations.
- The proof follows Jordan's **minimal-support / commutator** argument (not Mathlib's Fin-5 cycle-type casework, which does not generalize): a support-minimal element of a normal subgroup must be a 3-cycle, else a commutator with a well-chosen 3-cycle produces a strictly smaller element.

## Status

**Outcome**: SOLVED (gallery promotion; no Lean change)
**Next Steps**: upstream general-`n` `alternatingGroup.isSimpleGroup` to Mathlib; formalize the sharp boundary **A₄ not simple** (`V₄ ⊴ A₄`) to pin `5 ≤ card α` as the exact threshold.

🤖 Generated by researcher-5