### PR TITLE
Enrich Hurwitz composition identities: de-bundle annotation 4→5 + fix range overlap

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
@@ -1,15 +1,30 @@
 [
   {
-    "id": "ann-norm-and-products",
+    "id": "ann-norm",
     "proofId": "hurwitz-theorem-oq-03-incomplete-01",
     "range": {
-      "startLine": 39,
-      "endLine": 84
+      "startLine": 37,
+      "endLine": 47
+    },
+    "type": "definition",
+    "title": "The Squared Norm as a Quadratic Form",
+    "content": "Over a generic `CommRing R`, `normSq v = ∑ i, (v i)^2` is the squared norm (a diagonal quadratic form) of an n-vector. It carries no metric or positivity — it is a purely formal sum of coordinate squares — which is exactly what lets the composition identities below hold over any commutative ring rather than only over an ordered or real field. This form is the object whose multiplicativity, normSq a · normSq b = normSq (nMul a b), is the whole content of the file.",
+    "mathContext": "$\\mathrm{normSq}(v) = \\sum_{i} v_i^2$ — the diagonal quadratic form $q(v)=\\sum v_i^2$ on $R^n$, defined over any commutative ring with no appeal to positivity or a norm topology.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic form", "norm form", "composition algebra", "diagonal form"],
+    "prerequisites": ["commutative rings", "quadratic forms", "finite-dimensional modules"]
+  },
+  {
+    "id": "ann-products",
+    "proofId": "hurwitz-theorem-oq-03-incomplete-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 78
     },
     "type": "concept",
-    "title": "The Norm and the Four Multiplication Tables",
-    "content": "Over a generic `CommRing R`, `normSq v = ∑ i, (v i)^2` is the squared norm of an n-vector. The four bilinear products oneMul, twoMul, fourMul, eightMul are exactly the multiplication tables of the real numbers ℝ (n=1), the complex numbers ℂ (n=2), the quaternions ℍ (n=4), and the octonions 𝕆 (n=8). Crucially, every coefficient in these tables is ±1, an integer — so the products, and the identities they satisfy, are formal expressions valid over any commutative ring, with no appeal to ℝ or to a division-algebra structure.",
-    "mathContext": "$\\mathrm{normSq}(v) = \\sum_{i} v_i^2$; the products realise $|ab|^2 = |a|^2|b|^2$ for $\\mathbb{R},\\mathbb{C},\\mathbb{H},\\mathbb{O}$ at $n=1,2,4,8$, e.g. $n=2$: $(a_0b_0-a_1b_1,\\ a_0b_1+a_1b_0)$, the complex product.",
+    "title": "The Four Multiplication Tables (ℝ, ℂ, ℍ, 𝕆)",
+    "content": "The four bilinear products oneMul, twoMul, fourMul, eightMul are exactly the multiplication tables of the real numbers ℝ (n=1), the complex numbers ℂ (n=2), the quaternions ℍ (n=4), and the octonions 𝕆 (n=8) — the four real normed division algebras of Hurwitz's theorem. Crucially, every coefficient in these tables is ±1, an integer, so the products (and the composition identities they satisfy) are formal expressions valid over any commutative ring, with no appeal to ℝ or to an actual division-algebra structure. This is what makes the file's universality possible: the arithmetic of ℂ/ℍ/𝕆 is separated from their analysis.",
+    "mathContext": "The products realise $|ab|^2 = |a|^2|b|^2$ for $\\mathbb{R},\\mathbb{C},\\mathbb{H},\\mathbb{O}$ at $n=1,2,4,8$; e.g. $n=2$: $(a_0b_0-a_1b_1,\\ a_0b_1+a_1b_0)$, the complex product, and $n=4$ Euler's quaternion product.",
     "significance": "key",
     "relatedConcepts": ["composition algebra", "normed division algebra", "quaternions", "octonions", "Cayley–Dickson construction"],
     "prerequisites": ["commutative rings", "bilinear forms", "finite-dimensional algebras"]


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-03-incomplete-01` (universal composition / sum-of-squares identities over any `CommRing`).

**Two fixes in one:**
1. **Range-overlap bug fixed.** The old `ann-norm-and-products` spanned `[39-84]` while `ann-universal-identities` spans `[80-116]` — they overlapped on lines 80–84 (the `_square` theorems begin at line 80). Corrected.
2. **Annotation coverage 4 → 5 via a natural de-bundle.** The old annotation bundled two genuinely distinct ideas:
   - `ann-norm` `[37-47]` — the squared norm as a **diagonal quadratic form** `normSq v = ∑ vᵢ²` (no positivity/metric, which is what allows the identities to hold over any commutative ring).
   - `ann-products` `[48-78]` — the four **multiplication tables** of ℝ, ℂ, ℍ, 𝕆 (`oneMul/twoMul/fourMul/eightMul`), whose ±1 integer coefficients make them formal over any `CommRing`.

All 5 annotations retain full `mathContext` / `significance` / `relatedConcepts` / `prerequisites`. Only `annotations.json` changed; `meta.json` untouched. No inflation — this is a de-bundle plus an overlap fix, not added prose.
