### PR TITLE
Erdős 659: verify norm-form multiplicativity for x²+2y² (5 lemmas, 0 new axioms)

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -243,6 +243,48 @@ The representable integers are exactly those whose prime factorization has
 all primes ≡ 5, 7 (mod 8) appearing to even powers.
 -/
 
+/-! ### Multiplicative structure of the norm form `x² + 2y²`
+
+The set of integers represented by `x² + 2y²` is exactly the set of norms
+`N(x + y√-2) = x² + 2y²` of elements of the ring of integers `ℤ[√-2]` of `ℚ(√-2)`.
+Because this norm is multiplicative, the representable set is closed under
+multiplication — this is the algebraic reason behind the arithmetic
+characterization cited above (a number is representable iff every prime
+`≡ 5, 7 (mod 8)` divides it to an even power). The lemmas below verify the
+Brahmagupta–Fibonacci-type composition identity for discriminant `-8` and its
+consequence, fully (no axioms, no sorries). They are elementary but capture a
+genuine structural fact underlying the deep analytic input `moreeOsburnWorks`. -/
+
+/-- **Composition identity for the form `x² + 2y²`** (multiplicativity of the norm
+    on `ℤ[√-2]`): the product of two values of the form is again a value of the form.
+    This is the discriminant `-8` analogue of the Brahmagupta–Fibonacci identity. -/
+theorem repr_mul_identity (a b c d : ℤ) :
+    (a ^ 2 + 2 * b ^ 2) * (c ^ 2 + 2 * d ^ 2)
+      = (a * c + 2 * b * d) ^ 2 + 2 * (a * d - b * c) ^ 2 := by
+  ring
+
+/-- The set of integers representable as `x² + 2y²` is **closed under multiplication**.
+    Combined with `one_representable`/`two_representable` this shows, e.g., every power
+    of `2` is representable. This is the norm-multiplicativity of `ℤ[√-2]`. -/
+theorem representable_mul {m n : ℕ} (hm : m ∈ representable_x2_2y2)
+    (hn : n ∈ representable_x2_2y2) : m * n ∈ representable_x2_2y2 := by
+  simp only [representable_x2_2y2, Set.mem_setOf_eq] at hm hn ⊢
+  obtain ⟨a, b, hab⟩ := hm
+  obtain ⟨c, d, hcd⟩ := hn
+  refine ⟨a * c + 2 * b * d, a * d - b * c, ?_⟩
+  have hmn : ((m * n : ℕ) : ℤ) = (a ^ 2 + 2 * b ^ 2) * (c ^ 2 + 2 * d ^ 2) := by
+    push_cast; rw [hab, hcd]
+  rw [hmn, repr_mul_identity]
+
+/-- `1 = 1² + 2·0²` is representable (the norm of a unit). -/
+theorem one_representable : 1 ∈ representable_x2_2y2 := ⟨1, 0, by norm_num⟩
+
+/-- `2 = 0² + 2·1²` is representable (the ramified prime `√-2` has norm `2`). -/
+theorem two_representable : 2 ∈ representable_x2_2y2 := ⟨0, 1, by norm_num⟩
+
+/-- `3 = 1² + 2·1²` is representable (`3 ≡ 3 (mod 8)` splits in `ℤ[√-2]`). -/
+theorem three_representable : 3 ∈ representable_x2_2y2 := ⟨1, 1, by norm_num⟩
+
 /-- The 4-point property follows from avoiding all six two-distance configurations,
     **together with** the geometric lower bound that no 4-point subset collapses to
     fewer than two distinct distances.

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -41,3 +41,21 @@ Initial knowledge for problem `erdos-659-incomplete-01`.
   axiomatized. Value added = removing a *false-as-stated* sorry and making
   its hypotheses sound, plus real (if small) verified algebra on the
   defining form.
+
+## Session 2026-07-04 (researcher-8)
+
+### Added (verified, no axioms/sorries)
+- `repr_mul_identity`: `(a²+2b²)(c²+2d²) = (ac+2bd)² + 2(ad−bc)²` (composition
+  identity for discriminant −8; norm form of ℤ[√-2]).
+- `representable_mul`: representable set closed under multiplication.
+- `one/two/three_representable`: 1, 2, 3 are representable.
+
+### Status
+- Still 0 sorries, 1 axiom (`moreeOsburnWorks`). Docker build EXIT 0.
+- theoremCount 5→10, lineCount 280→322 (meta.json synced).
+
+### Note on metric subtlety (for future work)
+`isConfiguration` characterizations (`{a, a√2}`, `{a, a√3}`, `{a, aφ}`) implicitly
+assume the *Euclidean* metric, but Lean's default `dist` on `ℝ × ℝ` is the sup/
+Chebyshev metric. Sharpening those predicates properly requires switching to
+`EuclideanSpace ℝ (Fin 2)` — a substantial refactor, deferred.

--- a/research/problems/erdos-659-incomplete-01/sessions/2026-07-04-s2-act-normform-multiplicativity.md
+++ b/research/problems/erdos-659-incomplete-01/sessions/2026-07-04-s2-act-normform-multiplicativity.md
@@ -1,0 +1,41 @@
+# Session 2026-07-04 (researcher-8) — ACT: norm-form multiplicativity
+
+## Context
+Problem was already at 0 sorries / 1 axiom (completion item resolved 2026-06-25).
+The single remaining assumption `moreeOsburnWorks` packages Landau's 1908 theorem
+for `x²+2y²`. state.md's "Next Action" listed sharpening `isConfiguration` OR
+formalizing the Landau count. This session added verified *algebraic* infrastructure
+toward the latter without touching the (fragile, sup-metric-dependent) `isConfiguration`
+predicates.
+
+## What was done
+Added 5 fully-verified theorems (no axioms, no sorries) to `Erdos659Problem.lean`,
+in the number-theory section around `representable_x2_2y2`:
+
+- `repr_mul_identity` — the composition identity for discriminant −8 (analogue of
+  Brahmagupta–Fibonacci):
+  `(a²+2b²)(c²+2d²) = (ac+2bd)² + 2(ad−bc)²`. Proof: `ring`.
+- `representable_mul` — the set of integers representable as `x²+2y²` is closed under
+  multiplication (norm-multiplicativity of `ℤ[√-2]`). Proof: destructure witnesses,
+  `push_cast`, apply the identity.
+- `one_representable`, `two_representable`, `three_representable` — `1=1²+2·0²`,
+  `2=0²+2·1²`, `3=1²+2·1²`.
+
+## Why this matters (honest framing)
+This is *elementary* content (the hard proof is `ring`), but it is the genuine
+algebraic backbone of the arithmetic characterization the file already cites in
+comments ("representable iff every prime ≡ 5,7 mod 8 divides to even power"):
+that characterization follows from norm-multiplicativity + the behavior of primes.
+It de-abstracts a real piece of the number theory currently hidden inside the
+`moreeOsburnWorks` axiom. It does NOT reduce the axiom count — Landau's asymptotic
+`O(N/√log N)` remains axiomatized.
+
+## Verified
+- `./proofs/scripts/docker-build.sh Proofs.Erdos659Problem` → EXIT 0 (3058 jobs).
+- Still 1 `axiom` decl (`moreeOsburnWorks`), 0 sorries.
+- theoremCount 5→10, lineCount 280→322. meta.json updated to match.
+
+## Next Action (unchanged, major)
+Formalize Landau's count for `x²+2y²` (the asymptotic), or supply the prime-behavior
+lemmas (primes ≡ 1,3 mod 8 representable; 5,7 mod 8 to even powers) to build toward the
+full characterization on top of `representable_mul`.

--- a/research/problems/erdos-659-incomplete-01/state.md
+++ b/research/problems/erdos-659-incomplete-01/state.md
@@ -4,7 +4,7 @@
 
 **Phase**: ACT → COMPLETED
 **Status**: sorry resolved; main result remains axiomatized
-**Last Updated**: 2026-06-25
+**Last Updated**: 2026-07-04
 
 ## Progress Summary
 
@@ -40,3 +40,12 @@ The file now compiles cleanly (it previously did not — five floating
   or sharpen `isConfiguration` (replace the three `True` placeholders for
   isosceles trapezoids / kite with genuine characterizations and prove the
   classification under the Euclidean metric).
+
+
+## Session 2026-07-04 (researcher-8)
+
+Added 5 verified theorems on the multiplicative structure of the norm form
+`x²+2y²` (`repr_mul_identity`, `representable_mul`, `one/two/three_representable`)
+— the norm-multiplicativity of `ℤ[√-2]` underlying the arithmetic characterization
+Landau's theorem relies on. No axiom/sorry change (still 1 axiom, 0 sorries);
+docker build EXIT 0. theoremCount 5→10, lineCount 280→322.

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -1,205 +1,206 @@
 {
-  "id": "erdos-659",
-  "title": "Erdős Problem #659: Point Configurations with Few Distances",
-  "slug": "erdos-659",
-  "description": "Is there a set of n points in R² such that every 4-point subset determines at least 3 distances, yet the total distinct distances is O(n/√log n)? Answer: Yes, via the Moree-Osburn lattice.",
-  "meta": {
-    "author": "Moree-Osburn (2006), Lund-Sheffer",
-    "sourceUrl": "https://erdosproblems.com/659",
-    "date": "2006",
-    "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos659Problem.lean",
-    "tags": [
-      "erdos",
-      "combinatorial-geometry",
-      "distance-problems",
-      "lattices"
-    ],
-    "badge": "axiom",
-    "sorries": 0,
-    "erdosNumber": 659,
-    "erdosUrl": "https://erdosproblems.com/659",
-    "erdosProblemStatus": "proved",
-    "mathlib_version": "4.26.0",
-    "mathlibDependencies": [
-      {
-        "theorem": "Real.sqrt",
-        "description": "Square root function on reals",
-        "module": "Mathlib.Data.Real.Sqrt"
-      },
-      {
-        "theorem": "Real.log",
-        "description": "Natural logarithm",
-        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
-      },
-      {
-        "theorem": "dist",
-        "description": "Metric space distance function",
-        "module": "Mathlib.Topology.MetricSpace.Basic"
-      }
-    ],
-    "originalContributions": [
-      "Formalization of the 4-point distance property",
-      "Definition of distinct distances for finite point sets",
-      "Verified positive-definiteness of the defining quadratic form x²+2y² (latticeDistSq_symm / _nonneg / _eq_zero_iff), guaranteeing distinct lattice points",
-      "Resolved the former classification sorry: fourPointProperty_from_avoiding_configs is now a fully verified conditional, with the necessary geometric lower bound made explicit (the original statement was false under the product/Chebyshev metric — mutually-equidistant 4-point sets exist)",
-      "Partial classification of 6 two-distance configurations: square, 60° rhombus, and pentagon subset formally characterized; isosceles trapezoid (2 types) and kite left as True placeholders",
-      "Educational explanation of Moree-Osburn lattice construction"
-    ],
-    "axiomCount": 1,
-    "lineCount": 280,
-    "assumptions": "1 axiom: moreeOsburnWorks (encodes Landau's 1908 theorem on the count of integers representable as x²+2y², together with the full 4-point classification; not available in Mathlib 4.26). 0 sorries.",
-    "theoremCount": 5,
-    "definitionCount": 10
-  },
-  "overview": {
-    "historicalContext": "This problem explores the interplay between local constraints (every 4 points determine many distances) and global behavior (few total distances). It belongs to the rich tradition of Erdős distance problems, initiated by Erdős himself in 1946 when he asked for the minimum number of distinct distances determined by $n$ points in the plane — a question that drove combinatorial geometry for decades and was finally resolved by Guth and Katz (2015) who proved the $\\Omega(n/\\log n)$ lower bound using algebraic methods.\n\nErdős believed configurations satisfying the 4-point property with few distances should exist, and that their study would illuminate the structure of extremal distance sets. The solution came from an unexpected direction: algebraic number theory. Moree and Osburn (2006) discovered that points on a 'stretched' integer lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ have the remarkable property of avoiding regular geometric configurations while having few distinct distances. The key insight is that squared distances in this lattice are integers of the form $x^2 + 2y^2$ — a positive definite binary quadratic form of discriminant $-8$.\n\nBy Landau's theorem (1908), the count of positive integers $\\leq N$ representable as $x^2 + Dy^2$ is asymptotic to $C_D \\cdot N/\\sqrt{\\log N}$, where $C_D$ depends on the class number of $\\mathbb{Q}(\\sqrt{-D})$. For $D = 2$, the class number of $\\mathbb{Q}(\\sqrt{-2})$ is 1, and $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$. This controls the distinct distance count.\n\nLund and Sheffer independently found this construction. The 4-point property was verified by classifying all six configurations of 4 points with exactly 2 distances (the square, two types of rhombus, two isosceles trapezoids, and a pentagon subset) and showing the $\\sqrt{2}$-stretching eliminates each. Grayzel later completed the proof by ruling out the pentagon configuration using computer-assisted verification.",
-    "problemStatement": "Is there a set of $n$ points in $\\mathbb{R}^2$ such that every subset of $4$ points determines at least $3$ distances, yet the total number of distinct distances is $\\ll \\frac{n}{\\sqrt{\\log n}}$?\n\n**Answer:** Yes. The truncated lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ achieves this bound.",
-    "text": "Is there a set of n points in R² such that every 4-point subset determines at least 3 distances, yet the total distinct distances is O(n/√log n)? Answer: Yes, via the Moree-Osburn lattice.",
-    "proofStrategy": "The proof uses the Moree-Osburn lattice construction. The strategy has two parts:\n\n1. **Few total distances**: Distances between lattice points have form √(x² + 2y²). By Landau's theorem on sums of two squares (generalized), the count of such integers ≤ N is O(N/√log N).\n\n2. **4-point property**: There are exactly 6 configurations of 4 points with only 2 distances. Five contain squares or equilateral triangles (impossible in this lattice due to √2 stretching). The sixth is 4 vertices of a regular pentagon, ruled out by explicit calculation.",
-    "keyInsights": [
-      "**Moree-Osburn lattice**: The set {(a, b√2) : a,b ∈ ℤ} 'stretches' the integer lattice by √2 in one direction, breaking symmetries that would create regular polygons",
-      "**Landau's theorem**: The number of integers ≤ N representable as x² + 2y² is Θ(N/√log N), controlling the distance count",
-      "**Configuration classification**: Only 6 ways exist for 4 points to have exactly 2 distances; this lattice avoids all of them",
-      "**Quadratic forms**: Distances are √(x² + 2y²) - a positive definite binary quadratic form whose representation theory is well understood",
-      "**Near-optimality**: The Guth-Katz theorem (2015) shows any n points determine ≥ Ω(n/log n) distinct distances, so this construction achieves the optimal order — the 4-point property comes 'for free' from the lattice structure"
-    ],
-    "prerequisites": [
-      "Combinatorial geometry (point configurations, distance problems in the plane)",
-      "Algebraic number theory (binary quadratic forms, representation of integers as $x^2 + Dy^2$)",
-      "Analytic number theory (Landau's theorem on the distribution of representable integers)"
-    ]
-  },
-  "sections": [
-    {
-      "id": "setup",
-      "title": "Imports and Definitions",
-      "startLine": 24,
-      "endLine": 43,
-      "summary": "Import Mathlib dependencies for real analysis, metric spaces, and tactics"
+    "id": "erdos-659",
+    "title": "Erdős Problem #659: Point Configurations with Few Distances",
+    "slug": "erdos-659",
+    "description": "Is there a set of n points in R² such that every 4-point subset determines at least 3 distances, yet the total distinct distances is O(n/√log n)? Answer: Yes, via the Moree-Osburn lattice.",
+    "meta": {
+        "author": "Moree-Osburn (2006), Lund-Sheffer",
+        "sourceUrl": "https://erdosproblems.com/659",
+        "date": "2006",
+        "status": "axiomatized",
+        "proofRepoPath": "Proofs/Erdos659Problem.lean",
+        "tags": [
+            "erdos",
+            "combinatorial-geometry",
+            "distance-problems",
+            "lattices"
+        ],
+        "badge": "axiom",
+        "sorries": 0,
+        "erdosNumber": 659,
+        "erdosUrl": "https://erdosproblems.com/659",
+        "erdosProblemStatus": "proved",
+        "mathlib_version": "4.26.0",
+        "mathlibDependencies": [
+            {
+                "theorem": "Real.sqrt",
+                "description": "Square root function on reals",
+                "module": "Mathlib.Data.Real.Sqrt"
+            },
+            {
+                "theorem": "Real.log",
+                "description": "Natural logarithm",
+                "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+            },
+            {
+                "theorem": "dist",
+                "description": "Metric space distance function",
+                "module": "Mathlib.Topology.MetricSpace.Basic"
+            }
+        ],
+        "originalContributions": [
+            "Formalization of the 4-point distance property",
+            "Definition of distinct distances for finite point sets",
+            "Verified positive-definiteness of the defining quadratic form x²+2y² (latticeDistSq_symm / _nonneg / _eq_zero_iff), guaranteeing distinct lattice points",
+            "Resolved the former classification sorry: fourPointProperty_from_avoiding_configs is now a fully verified conditional, with the necessary geometric lower bound made explicit (the original statement was false under the product/Chebyshev metric — mutually-equidistant 4-point sets exist)",
+            "Partial classification of 6 two-distance configurations: square, 60° rhombus, and pentagon subset formally characterized; isosceles trapezoid (2 types) and kite left as True placeholders",
+            "Educational explanation of Moree-Osburn lattice construction",
+            "Verified multiplicative structure of the norm form x²+2y² (repr_mul_identity composition identity + representable_mul closure, plus representability of 1, 2, 3): the norm-multiplicativity of ℤ[√-2] underlying the arithmetic characterization used by Landau's theorem"
+        ],
+        "axiomCount": 1,
+        "lineCount": 322,
+        "assumptions": "1 axiom: moreeOsburnWorks (encodes Landau's 1908 theorem on the count of integers representable as x²+2y², together with the full 4-point classification; not available in Mathlib 4.26). 0 sorries.",
+        "theoremCount": 10,
+        "definitionCount": 10
     },
-    {
-      "id": "definitions",
-      "title": "Core Definitions",
-      "startLine": 44,
-      "endLine": 62,
-      "summary": "Define distinct distances, the 4-point property, and the lattice quadratic form latticeDistSq"
+    "overview": {
+        "historicalContext": "This problem explores the interplay between local constraints (every 4 points determine many distances) and global behavior (few total distances). It belongs to the rich tradition of Erdős distance problems, initiated by Erdős himself in 1946 when he asked for the minimum number of distinct distances determined by $n$ points in the plane — a question that drove combinatorial geometry for decades and was finally resolved by Guth and Katz (2015) who proved the $\\Omega(n/\\log n)$ lower bound using algebraic methods.\n\nErdős believed configurations satisfying the 4-point property with few distances should exist, and that their study would illuminate the structure of extremal distance sets. The solution came from an unexpected direction: algebraic number theory. Moree and Osburn (2006) discovered that points on a 'stretched' integer lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ have the remarkable property of avoiding regular geometric configurations while having few distinct distances. The key insight is that squared distances in this lattice are integers of the form $x^2 + 2y^2$ — a positive definite binary quadratic form of discriminant $-8$.\n\nBy Landau's theorem (1908), the count of positive integers $\\leq N$ representable as $x^2 + Dy^2$ is asymptotic to $C_D \\cdot N/\\sqrt{\\log N}$, where $C_D$ depends on the class number of $\\mathbb{Q}(\\sqrt{-D})$. For $D = 2$, the class number of $\\mathbb{Q}(\\sqrt{-2})$ is 1, and $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$. This controls the distinct distance count.\n\nLund and Sheffer independently found this construction. The 4-point property was verified by classifying all six configurations of 4 points with exactly 2 distances (the square, two types of rhombus, two isosceles trapezoids, and a pentagon subset) and showing the $\\sqrt{2}$-stretching eliminates each. Grayzel later completed the proof by ruling out the pentagon configuration using computer-assisted verification.",
+        "problemStatement": "Is there a set of $n$ points in $\\mathbb{R}^2$ such that every subset of $4$ points determines at least $3$ distances, yet the total number of distinct distances is $\\ll \\frac{n}{\\sqrt{\\log n}}$?\n\n**Answer:** Yes. The truncated lattice $\\{(a, b\\sqrt{2}) : a,b \\in \\mathbb{Z}\\}$ achieves this bound.",
+        "text": "Is there a set of n points in R² such that every 4-point subset determines at least 3 distances, yet the total distinct distances is O(n/√log n)? Answer: Yes, via the Moree-Osburn lattice.",
+        "proofStrategy": "The proof uses the Moree-Osburn lattice construction. The strategy has two parts:\n\n1. **Few total distances**: Distances between lattice points have form √(x² + 2y²). By Landau's theorem on sums of two squares (generalized), the count of such integers ≤ N is O(N/√log N).\n\n2. **4-point property**: There are exactly 6 configurations of 4 points with only 2 distances. Five contain squares or equilateral triangles (impossible in this lattice due to √2 stretching). The sixth is 4 vertices of a regular pentagon, ruled out by explicit calculation.",
+        "keyInsights": [
+            "**Moree-Osburn lattice**: The set {(a, b√2) : a,b ∈ ℤ} 'stretches' the integer lattice by √2 in one direction, breaking symmetries that would create regular polygons",
+            "**Landau's theorem**: The number of integers ≤ N representable as x² + 2y² is Θ(N/√log N), controlling the distance count",
+            "**Configuration classification**: Only 6 ways exist for 4 points to have exactly 2 distances; this lattice avoids all of them",
+            "**Quadratic forms**: Distances are √(x² + 2y²) - a positive definite binary quadratic form whose representation theory is well understood",
+            "**Near-optimality**: The Guth-Katz theorem (2015) shows any n points determine ≥ Ω(n/log n) distinct distances, so this construction achieves the optimal order — the 4-point property comes 'for free' from the lattice structure"
+        ],
+        "prerequisites": [
+            "Combinatorial geometry (point configurations, distance problems in the plane)",
+            "Algebraic number theory (binary quadratic forms, representation of integers as $x^2 + Dy^2$)",
+            "Analytic number theory (Landau's theorem on the distribution of representable integers)"
+        ]
     },
-    {
-      "id": "quadratic-form",
-      "title": "Positive-Definiteness of x²+2y²",
-      "startLine": 64,
-      "endLine": 113,
-      "summary": "Verified algebraic lemmas: latticeDistSq is symmetric, non-negative, and vanishes only on the diagonal (positive-definite)"
-    },
-    {
-      "id": "axiom",
-      "title": "Main Axiom",
-      "startLine": 120,
-      "endLine": 138,
-      "summary": "State the Moree-Osburn construction works (requires deep number theory: Landau's theorem + classification); axiom moreeOsburnWorks at lines 133–138"
-    },
-    {
-      "id": "theorem",
-      "title": "Main Theorem",
-      "startLine": 140,
-      "endLine": 157,
-      "summary": "Derive the answer to Erdős #659 from the axiom; theorem erdos_659 at lines 144–157"
-    },
-    {
-      "id": "configurations",
-      "title": "Two-Distance Configurations",
-      "startLine": 162,
-      "endLine": 280,
-      "summary": "Enumerate the 6 two-distance configurations and prove fourPointProperty_from_avoiding_configs (verified, 0 sorries)"
-    }
-  ],
-  "conclusion": {
-    "summary": "Erdős Problem #659 is answered affirmatively: large point sets exist with the 4-point property and few distinct distances. The Moree-Osburn lattice construction achieves O(n/√log n) distances while ensuring every 4-point subset determines at least 3 distances.",
-    "implications": "This result connects discrete geometry to algebraic number theory, showing how arithmetic properties of quadratic forms control geometric configurations. It also provides effective bounds for related Erdős problems about squares in point sets.",
-    "openQuestions": [
-      "Can the $O(n/\\sqrt{\\log n})$ bound be improved while maintaining the 4-point property? The Guth–Katz lower bound $\\Omega(n/\\log n)$ applies to *all* point sets, so the gap between the construction ($n/\\sqrt{\\log n}$) and the universal lower bound ($n/\\log n$) is a factor of $\\sqrt{\\log n}$.",
-      "Are there constructions based on other quadratic forms $x^2 + Dy^2$ with $D \\neq 2$ that achieve the 4-point property? Different values of $D$ yield different distance spectra and may avoid different configuration families.",
-      "What is the exact asymptotic constant $C_2$ in the distance count? Landau's theorem gives $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$, but the relationship between this analytic constant and the geometric configuration count is not fully understood.",
-      "Can the 4-point property be strengthened to a $k$-point property (every $k$ points determine $\\geq k-1$ distances) while maintaining $O(n/\\sqrt{\\log n})$ total distances? For $k = 5$ the classification of configurations becomes much more complex.",
-      "Can the Moree–Osburn construction be formalized in Lean without axioms, by proving Landau's theorem and the configuration classification purely in Mathlib? This would require formalizing the analytic theory of binary quadratic forms."
-    ]
-  },
-  "leanFile": {
-    "imports": [
-      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
-      "Mathlib.Data.Real.Sqrt",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Topology.MetricSpace.Basic",
-      "Mathlib.Tactic"
+    "sections": [
+        {
+            "id": "setup",
+            "title": "Imports and Definitions",
+            "startLine": 24,
+            "endLine": 43,
+            "summary": "Import Mathlib dependencies for real analysis, metric spaces, and tactics"
+        },
+        {
+            "id": "definitions",
+            "title": "Core Definitions",
+            "startLine": 44,
+            "endLine": 62,
+            "summary": "Define distinct distances, the 4-point property, and the lattice quadratic form latticeDistSq"
+        },
+        {
+            "id": "quadratic-form",
+            "title": "Positive-Definiteness of x²+2y²",
+            "startLine": 64,
+            "endLine": 113,
+            "summary": "Verified algebraic lemmas: latticeDistSq is symmetric, non-negative, and vanishes only on the diagonal (positive-definite)"
+        },
+        {
+            "id": "axiom",
+            "title": "Main Axiom",
+            "startLine": 120,
+            "endLine": 138,
+            "summary": "State the Moree-Osburn construction works (requires deep number theory: Landau's theorem + classification); axiom moreeOsburnWorks at lines 133–138"
+        },
+        {
+            "id": "theorem",
+            "title": "Main Theorem",
+            "startLine": 140,
+            "endLine": 157,
+            "summary": "Derive the answer to Erdős #659 from the axiom; theorem erdos_659 at lines 144–157"
+        },
+        {
+            "id": "configurations",
+            "title": "Two-Distance Configurations",
+            "startLine": 162,
+            "endLine": 280,
+            "summary": "Enumerate the 6 two-distance configurations and prove fourPointProperty_from_avoiding_configs (verified, 0 sorries)"
+        }
     ],
-    "opens": [
-      "Real"
+    "conclusion": {
+        "summary": "Erdős Problem #659 is answered affirmatively: large point sets exist with the 4-point property and few distinct distances. The Moree-Osburn lattice construction achieves O(n/√log n) distances while ensuring every 4-point subset determines at least 3 distances.",
+        "implications": "This result connects discrete geometry to algebraic number theory, showing how arithmetic properties of quadratic forms control geometric configurations. It also provides effective bounds for related Erdős problems about squares in point sets.",
+        "openQuestions": [
+            "Can the $O(n/\\sqrt{\\log n})$ bound be improved while maintaining the 4-point property? The Guth–Katz lower bound $\\Omega(n/\\log n)$ applies to *all* point sets, so the gap between the construction ($n/\\sqrt{\\log n}$) and the universal lower bound ($n/\\log n$) is a factor of $\\sqrt{\\log n}$.",
+            "Are there constructions based on other quadratic forms $x^2 + Dy^2$ with $D \\neq 2$ that achieve the 4-point property? Different values of $D$ yield different distance spectra and may avoid different configuration families.",
+            "What is the exact asymptotic constant $C_2$ in the distance count? Landau's theorem gives $C_2 = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3,5 \\pmod{8}} (1 - p^{-2})^{-1/2}$, but the relationship between this analytic constant and the geometric configuration count is not fully understood.",
+            "Can the 4-point property be strengthened to a $k$-point property (every $k$ points determine $\\geq k-1$ distances) while maintaining $O(n/\\sqrt{\\log n})$ total distances? For $k = 5$ the classification of configurations becomes much more complex.",
+            "Can the Moree–Osburn construction be formalized in Lean without axioms, by proving Landau's theorem and the configuration classification purely in Mathlib? This would require formalizing the analytic theory of binary quadratic forms."
+        ]
+    },
+    "leanFile": {
+        "imports": [
+            "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+            "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+            "Mathlib.Data.Real.Sqrt",
+            "Mathlib.Data.Finset.Card",
+            "Mathlib.Topology.MetricSpace.Basic",
+            "Mathlib.Tactic"
+        ],
+        "opens": [
+            "Real"
+        ],
+        "namespace": "Erdos659",
+        "lineCount": 322,
+        "axiomCount": 1,
+        "theoremCount": 10,
+        "definitionCount": 10,
+        "path": "Proofs/Erdos659Problem.lean",
+        "sorries": 0
+    },
+    "crossReferences": [
+        {
+            "targetId": "erdos-132",
+            "relationship": "related",
+            "description": "Distance multiplicities in planar point sets: asks how often a given distance can occur among $n$ points. Problem 659 constrains the *number* of distinct distances while Problem 132 constrains the *multiplicity* of each distance — dual perspectives on the same distance geometry landscape."
+        },
+        {
+            "targetId": "erdos-662",
+            "relationship": "related",
+            "description": "Distances in separated point sets: imposes geometric separation constraints on point configurations, complementing Problem 659's constraint that 4-point subsets avoid degenerate distance patterns. Both problems study how structural constraints interact with distance counting."
+        }
     ],
-    "namespace": "Erdos659",
-    "lineCount": 280,
-    "axiomCount": 1,
-    "theoremCount": 5,
-    "definitionCount": 10,
-    "path": "Proofs/Erdos659Problem.lean",
+    "references": [
+        {
+            "authors": "Moree, Pieter; Osburn, Robert",
+            "title": "Two-dimensional lattices with few distances",
+            "year": "2006",
+            "venue": "L'Enseignement Mathématique (2), vol. 52, pp. 361–380",
+            "note": "The key paper solving Erdős Problem 659: shows that the lattice {(a, b√2)} has the 4-point property and O(n/√log n) distinct distances, using Landau's theorem on the quadratic form x² + 2y²."
+        },
+        {
+            "authors": "Landau, Edmund",
+            "title": "Über die Einteilung der positiven ganzen Zahlen in vier Klassen nach der Mindestzahl der zu ihrer additiven Zusammensetzung erforderlichen Quadrate",
+            "year": "1908",
+            "venue": "Archiv der Mathematik und Physik, vol. 13, pp. 305–312",
+            "note": "Proves that the number of positive integers ≤ N representable as x² + Dy² is asymptotic to C·N/√(log N), the fundamental counting result underlying the distance bound in the Moree–Osburn construction."
+        },
+        {
+            "authors": "Guth, Larry; Katz, Nets Hawk",
+            "title": "On the Erdős distinct distances problem in the plane",
+            "year": "2015",
+            "venue": "Annals of Mathematics, vol. 181, no. 1, pp. 155–190",
+            "note": "Proves any n points in the plane determine Ω(n/log n) distinct distances, nearly matching the O(n/√log n) upper bound achieved by lattice constructions like Moree–Osburn. The gap of √log n between upper and lower bounds remains open."
+        },
+        {
+            "authors": "Erdős, Paul",
+            "title": "On sets of distances of n points",
+            "year": "1946",
+            "venue": "American Mathematical Monthly, vol. 53, no. 5, pp. 248–250",
+            "note": "The foundational paper posing the distinct distances problem: what is the minimum number of distinct distances determined by n points in the plane? Conjectured Ω(n/√log n), which the Moree–Osburn construction shows is tight up to the 4-point constraint."
+        },
+        {
+            "authors": "Cox, David A.",
+            "title": "Primes of the Form x² + ny²: Fermat, Class Field Theory, and Complex Multiplication",
+            "year": "2013",
+            "venue": "John Wiley & Sons, 2nd edition",
+            "note": "Standard reference for the arithmetic of binary quadratic forms x² + Dy², including Landau's counting theorem and the connection to class numbers of imaginary quadratic fields — the number-theoretic machinery underlying the Moree–Osburn distance count."
+        },
+        {
+            "authors": "Pach, János; Sharir, Micha",
+            "title": "Repeated angles in the plane and related problems",
+            "year": "1992",
+            "venue": "Journal of Combinatorial Theory, Series A, vol. 59, no. 1, pp. 12–22",
+            "note": "Studies the combinatorial geometry of repeated patterns in point configurations, including the classification of configurations with few distances that appears in the 4-point property verification of Problem 659."
+        }
+    ],
     "sorries": 0
-  },
-  "crossReferences": [
-    {
-      "targetId": "erdos-132",
-      "relationship": "related",
-      "description": "Distance multiplicities in planar point sets: asks how often a given distance can occur among $n$ points. Problem 659 constrains the *number* of distinct distances while Problem 132 constrains the *multiplicity* of each distance — dual perspectives on the same distance geometry landscape."
-    },
-    {
-      "targetId": "erdos-662",
-      "relationship": "related",
-      "description": "Distances in separated point sets: imposes geometric separation constraints on point configurations, complementing Problem 659's constraint that 4-point subsets avoid degenerate distance patterns. Both problems study how structural constraints interact with distance counting."
-    }
-  ],
-  "references": [
-    {
-      "authors": "Moree, Pieter; Osburn, Robert",
-      "title": "Two-dimensional lattices with few distances",
-      "year": "2006",
-      "venue": "L'Enseignement Mathématique (2), vol. 52, pp. 361–380",
-      "note": "The key paper solving Erdős Problem 659: shows that the lattice {(a, b√2)} has the 4-point property and O(n/√log n) distinct distances, using Landau's theorem on the quadratic form x² + 2y²."
-    },
-    {
-      "authors": "Landau, Edmund",
-      "title": "Über die Einteilung der positiven ganzen Zahlen in vier Klassen nach der Mindestzahl der zu ihrer additiven Zusammensetzung erforderlichen Quadrate",
-      "year": "1908",
-      "venue": "Archiv der Mathematik und Physik, vol. 13, pp. 305–312",
-      "note": "Proves that the number of positive integers ≤ N representable as x² + Dy² is asymptotic to C·N/√(log N), the fundamental counting result underlying the distance bound in the Moree–Osburn construction."
-    },
-    {
-      "authors": "Guth, Larry; Katz, Nets Hawk",
-      "title": "On the Erdős distinct distances problem in the plane",
-      "year": "2015",
-      "venue": "Annals of Mathematics, vol. 181, no. 1, pp. 155–190",
-      "note": "Proves any n points in the plane determine Ω(n/log n) distinct distances, nearly matching the O(n/√log n) upper bound achieved by lattice constructions like Moree–Osburn. The gap of √log n between upper and lower bounds remains open."
-    },
-    {
-      "authors": "Erdős, Paul",
-      "title": "On sets of distances of n points",
-      "year": "1946",
-      "venue": "American Mathematical Monthly, vol. 53, no. 5, pp. 248–250",
-      "note": "The foundational paper posing the distinct distances problem: what is the minimum number of distinct distances determined by n points in the plane? Conjectured Ω(n/√log n), which the Moree–Osburn construction shows is tight up to the 4-point constraint."
-    },
-    {
-      "authors": "Cox, David A.",
-      "title": "Primes of the Form x² + ny²: Fermat, Class Field Theory, and Complex Multiplication",
-      "year": "2013",
-      "venue": "John Wiley & Sons, 2nd edition",
-      "note": "Standard reference for the arithmetic of binary quadratic forms x² + Dy², including Landau's counting theorem and the connection to class numbers of imaginary quadratic fields — the number-theoretic machinery underlying the Moree–Osburn distance count."
-    },
-    {
-      "authors": "Pach, János; Sharir, Micha",
-      "title": "Repeated angles in the plane and related problems",
-      "year": "1992",
-      "venue": "Journal of Combinatorial Theory, Series A, vol. 59, no. 1, pp. 12–22",
-      "note": "Studies the combinatorial geometry of repeated patterns in point configurations, including the classification of configurations with few distances that appears in the 4-point property verification of Problem 659."
-    }
-  ],
-  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Problem `erdos-659-incomplete-01` was already at **0 sorries / 1 axiom** — the
completion item (a false-as-stated classification sorry) was resolved 2026-06-25,
and the lone remaining assumption `moreeOsburnWorks` packages **Landau's 1908
theorem** on the count of integers representable as `x²+2y²` (not in Mathlib 4.26).

This session adds **verified algebraic infrastructure** toward that axiom, in the
number-theory section of `Erdos659Problem.lean`:

- **`repr_mul_identity`** — the discriminant `−8` composition identity
  `(a²+2b²)(c²+2d²) = (ac+2bd)² + 2(ad−bc)²` (Brahmagupta–Fibonacci analogue,
  i.e. norm-multiplicativity of `ℤ[√-2]`). Proof: `ring`.
- **`representable_mul`** — the set of integers representable as `x²+2y²` is
  **closed under multiplication**. Proof: destructure witnesses, `push_cast`,
  apply the identity.
- **`one/two/three_representable`** — `1=1²+2·0²`, `2=0²+2·1²`, `3=1²+2·1²`.

## Honest assessment

Elementary content — the hard proofs are `ring`/`norm_num`. But it de-abstracts a
real piece of number theory the file currently states only in comments: the
arithmetic characterization *"representable iff every prime `≡ 5,7 (mod 8)` divides
to an even power"* rests precisely on this multiplicativity. **It does not reduce
the axiom count**: Landau's asymptotic `O(N/√log N)` remains axiomatized.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos659Problem` → **EXIT 0** (3058 jobs)
- Still **1 axiom** (`moreeOsburnWorks`), **0 sorries**
- `meta.json` synced: theoremCount 5→10, lineCount 280→322; status stays
  `axiomatized`/`axiom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)