### PR TITLE
Enrich PAC-Learning VC-dimension monotonicity: add mainTheorems (0→5)

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
@@ -162,5 +162,37 @@
     "definitionCount": 0,
     "path": "Proofs/PACLearningBoundsWIP01OQ01.lean",
     "sorries": 0
-  }
+  },
+  "mainTheorems": [
+    {
+      "name": "vcDim_mono",
+      "type": "core",
+      "description": "Monotonicity of the VC dimension: if H ⊆ H' then VCDim H ≤ VCDim H'. Every set shattered by the smaller class is shattered by the larger (shatters_mono), so every cardinality in the set defining VCDim H is bounded by VCDim H' and the supremum inherits the bound; the empty-witness case gives 0.",
+      "leanType": "{H H' : Finset (Finset α)} → (hHH : H ⊆ H') → VCDim H ≤ VCDim H'"
+    },
+    {
+      "name": "vcDim_powerset_le",
+      "type": "core",
+      "description": "The powerset class is capacity-maximal among subfamilies of 2^α: any class H whose members are all subsets of a fixed finite S (H ⊆ S.powerset) has VC dimension at most |S| = VCDim(2^S). Monotonicity turns the containment into a capacity bound.",
+      "leanType": "{H : Finset (Finset α)} → {S : Finset α} → (hH : H ⊆ S.powerset) → VCDim H ≤ S.card"
+    },
+    {
+      "name": "vcDim_le_of_subset",
+      "type": "supporting",
+      "description": "Restatement of vcDim_mono in implication form for convenient rewriting / gcongr-style use.",
+      "leanType": "{H H' : Finset (Finset α)} → (hHH : H ⊆ H') → VCDim H ≤ VCDim H'"
+    },
+    {
+      "name": "vcDim_union_left",
+      "type": "supporting",
+      "description": "The VC dimension of a class is at most that of any union containing it (left): VCDim H ≤ VCDim (H ∪ H').",
+      "leanType": "(H H' : Finset (Finset α)) → VCDim H ≤ VCDim (H ∪ H')"
+    },
+    {
+      "name": "vcDim_union_right",
+      "type": "supporting",
+      "description": "The VC dimension of a class is at most that of any union containing it (right): VCDim H' ≤ VCDim (H ∪ H').",
+      "leanType": "(H H' : Finset (Finset α)) → VCDim H' ≤ VCDim (H ∪ H')"
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-wip-01-oq-01` (monotonicity of VC dimension and the powerset capacity ceiling).

**Structural gap closed:** added the `mainTheorems` array (0 → 5), each with `name`, `type`, `description`, and exact `leanType`:
- **core:** `vcDim_mono` (H ⊆ H′ ⟹ VCDim H ≤ VCDim H′), `vcDim_powerset_le` (H ⊆ S.powerset ⟹ VCDim H ≤ |S|)
- **supporting:** `vcDim_le_of_subset`, `vcDim_union_left`, `vcDim_union_right`

**Axiom integrity checked:** `status: verified, axiomCount: 0` is accurate — the proofs use `csSup_le` / `shatters_mono`, and the sole `native_decide` string in the file is a docstring line stating the proof uses *no* `native_decide` (not an actual tactic call). `leanFile` present (theoremCount 5, axiomCount 0, sorries 0). Annotations untouched; well under the size cap.
