### PR TITLE
Research: unipotent Sylow-p subgroup of SL(2,p) (sylow-theorem-oq-04-oq-03) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -1,0 +1,122 @@
+/-
+  Toward the simplicity of PSL(2, p) for primes p ≥ 5 (Sylow OQ-04 OQ-03)
+
+  Parent open question sylow-theorem-oq-04-oq-03: prove that PSL(2, p) is simple
+  for every prime p ≥ 5, generalizing the parent entry's A₅ = PSL(2,5) result to
+  the first infinite family of finite simple groups.
+
+  The full theorem is genuinely blocked on a large body of missing Mathlib
+  infrastructure (the action of PSL(2,p) on the projective line P¹(𝔽_p), its
+  2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5). The standard
+  modern route is *not* a raw Sylow count but Iwasawa's criterion applied to that
+  action; see the research knowledge file for the full assessment.
+
+  This file builds one clean, fully verified piece of that infrastructure: the
+  **unipotent one-parameter subgroup**
+
+      U = { [[1, t], [0, 1]] : t ∈ 𝔽_p } ⊆ SL(2, 𝔽_p).
+
+  U is exactly the abelian normal subgroup of the Borel (stabilizer of ∞) that the
+  Iwasawa criterion requires, and it is the order-p Sylow subgroup of SL(2, p).
+  We show:
+
+  * `unipotentUpper t` is a genuine element of `SL(2, ZMod p)` (determinant 1);
+  * `t ↦ unipotentUpper t` is an injective group homomorphism from the additive
+    group `(ZMod p, +)` (written multiplicatively) into `SL(2, ZMod p)`
+    (`unipotentHom`), so its image is abelian and isomorphic to `ZMod p`;
+  * the image has cardinality exactly `p` (the order-p Sylow / unipotent subgroup).
+
+  Everything here is `sorry`-free and axiom-free; the deep simplicity theorem
+  remains open.
+
+  References:
+  - Rotman, An Introduction to the Theory of Groups (4th ed.), §9.
+  - Dixon & Mortimer, Permutation Groups, §3.3 (Iwasawa's lemma), §2.8.
+
+  Tags: group-theory, sylow, PSL, special-linear-group, unipotent, iwasawa
+-/
+
+import Mathlib
+
+open Matrix
+
+namespace SylowOQ04OQ03
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-!
+## The unipotent one-parameter subgroup of `SL(2, ZMod p)`
+
+We embed `(ZMod p, +)` into `SL(2, ZMod p)` via the upper-triangular unipotent
+matrices `[[1, t], [0, 1]]`.
+-/
+
+/-- The upper unipotent matrix `[[1, t], [0, 1]]`, viewed as an element of
+`SL(2, ZMod p)`. Its determinant is `1 · 1 − t · 0 = 1`. -/
+def unipotentUpper (t : ZMod p) : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) :=
+  ⟨!![1, t; 0, 1], by simp [Matrix.det_fin_two_of]⟩
+
+@[simp] theorem val_unipotentUpper (t : ZMod p) :
+    (unipotentUpper t : Matrix (Fin 2) (Fin 2) (ZMod p)) = !![1, t; 0, 1] := rfl
+
+/-- The unipotent embedding is additive: `[[1,s],[0,1]] · [[1,t],[0,1]] = [[1,s+t],[0,1]]`. -/
+theorem unipotentUpper_mul (s t : ZMod p) :
+    unipotentUpper s * unipotentUpper t = unipotentUpper (s + t) := by
+  apply Subtype.ext
+  show (!![1, s; 0, 1] : Matrix (Fin 2) (Fin 2) (ZMod p)) * !![1, t; 0, 1]
+      = !![1, s + t; 0, 1]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, add_comm]
+
+/-- The unipotent embedding sends `0` to the identity matrix. -/
+theorem unipotentUpper_zero : unipotentUpper (0 : ZMod p) = 1 := by
+  apply Subtype.ext
+  show (!![1, (0 : ZMod p); 0, 1] : Matrix (Fin 2) (Fin 2) (ZMod p)) = 1
+  rw [Matrix.one_fin_two]
+
+/-- Elements of the unipotent subgroup commute (it is abelian). -/
+theorem unipotentUpper_comm (s t : ZMod p) :
+    unipotentUpper s * unipotentUpper t = unipotentUpper t * unipotentUpper s := by
+  rw [unipotentUpper_mul, unipotentUpper_mul, add_comm]
+
+/-- The unipotent embedding is injective (read off the top-right entry). -/
+theorem unipotentUpper_injective :
+    Function.Injective (unipotentUpper (p := p)) := by
+  intro s t h
+  have h' : (unipotentUpper s : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 1
+      = (unipotentUpper t : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 1 := by rw [h]
+  simpa using h'
+
+/-- The unipotent one-parameter subgroup packaged as a group homomorphism from the
+additive group `(ZMod p, +)` (written multiplicatively) into `SL(2, ZMod p)`.
+
+This is the abelian normal subgroup of the Borel stabilizer required by Iwasawa's
+simplicity criterion for `PSL(2, p)`. -/
+def unipotentHom :
+    Multiplicative (ZMod p) →* Matrix.SpecialLinearGroup (Fin 2) (ZMod p) where
+  toFun t := unipotentUpper (Multiplicative.toAdd t)
+  map_one' := by simpa using unipotentUpper_zero
+  map_mul' s t := by
+    simpa using
+      (unipotentUpper_mul (Multiplicative.toAdd s) (Multiplicative.toAdd t)).symm
+
+@[simp] theorem unipotentHom_apply (t : Multiplicative (ZMod p)) :
+    unipotentHom t = unipotentUpper (Multiplicative.toAdd t) := rfl
+
+/-- `unipotentHom` is injective, so its range is a subgroup of `SL(2, ZMod p)`
+isomorphic to `(ZMod p, +)`. -/
+theorem unipotentHom_injective : Function.Injective (unipotentHom (p := p)) := by
+  intro s t h
+  exact Multiplicative.toAdd.injective (unipotentUpper_injective h)
+
+/-- The unipotent subgroup has cardinality exactly `p`: it is the order-`p`
+Sylow-`p` subgroup of `SL(2, p)`. -/
+theorem card_unipotent_range :
+    Nat.card (Set.range (unipotentUpper (p := p))) = p := by
+  haveI : NeZero p := ⟨(Fact.out (p := p.Prime)).pos.ne'⟩
+  have e : ZMod p ≃ Set.range (unipotentUpper (p := p)) :=
+    Equiv.ofInjective _ unipotentUpper_injective
+  rw [← Nat.card_congr e, Nat.card_eq_fintype_card, ZMod.card]
+
+end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-sylow-oq0403-overview",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "An Honest Fragment of an Open Problem",
+    "content": "The parent open question asks whether PSL(2, p) is simple for every prime p ≥ 5 — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on a large body of missing Mathlib infrastructure: the action of PSL(2, p) on the projective line P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5. Rather than sorry-out the whole statement, this file isolates and fully verifies ONE reusable building block: the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p}. U is simultaneously the abelian normal subgroup of the Borel that Iwasawa's criterion requires AND the order-p Sylow subgroup of SL(2, p). Everything here is sorry-free and axiom-free; the deep simplicity theorem remains open."
+  },
+  {
+    "id": "ann-sylow-oq0403-det",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 54, "endLine": 62 },
+    "type": "concept",
+    "title": "Landing in SL(2, 𝔽_p): the Determinant-1 Condition",
+    "content": "`unipotentUpper t` packages the matrix [[1,t],[0,1]] as an element of `Matrix.SpecialLinearGroup (Fin 2) (ZMod p)`. The membership obligation is det = 1, discharged by `Matrix.det_fin_two_of`: the determinant of [[a,b],[c,d]] is a·d − b·c = 1·1 − t·0 = 1. This is the smallest non-diagonal unipotent — every entry is fixed except the top-right, which carries the parameter t."
+  },
+  {
+    "id": "ann-sylow-oq0403-additivity",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 64, "endLine": 88 },
+    "type": "insight",
+    "title": "The Group Law is Addition: [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]]",
+    "content": "`unipotentUpper_mul` proves the one-parameter subgroup multiplies by adding parameters, verified entrywise via `fin_cases i <;> fin_cases j` over the four 2×2 positions and `Matrix.mul_apply` / `Fin.sum_univ_two`. Together with `unipotentUpper_zero` (the identity is [[1,0],[0,1]]), this exhibits U as a homomorphic image of the additive group (ℤ/p, +): in particular it is abelian (`unipotentUpper_comm` follows by `add_comm`). No Sylow counting is needed — the abelian structure is read directly off the matrix arithmetic."
+  },
+  {
+    "id": "ann-sylow-oq0403-hom",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 90, "endLine": 111 },
+    "type": "tactic",
+    "title": "Writing (ℤ/p, +) Multiplicatively to get a genuine MonoidHom",
+    "content": "`unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` upgrades the embedding to a bundled group homomorphism. The trick is `Multiplicative (ZMod p)`: it is (ℤ/p, +) presented with multiplicative notation, so `map_mul'` is literally the additivity identity `unipotentUpper_mul` and `map_one'` is `unipotentUpper_zero`. Injectivity (`unipotentHom_injective`) reduces to injectivity of `unipotentUpper`, which is immediate from a single matrix entry — the top-right coordinate is exactly t (`unipotentUpper_injective`)."
+  },
+  {
+    "id": "ann-sylow-oq0403-card",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 113, "endLine": 122 },
+    "type": "insight",
+    "title": "Cardinality Exactly p: the Order-p Sylow Subgroup",
+    "content": "`card_unipotent_range` computes |U| = p by transporting the cardinality of ℤ/p through the injection with `Equiv.ofInjective`, then `Nat.card_congr` and `ZMod.card`. Since |SL(2, 𝔽_p)| = p(p−1)(p+1) has p-part exactly p, this identifies U as a full Sylow-p subgroup of SL(2, p). This is the object on which the modern Iwasawa-criterion proof of PSL(2, p) simplicity is built — the abelian normal subgroup of the Borel stabiliser whose conjugates generate the group."
+  }
+]

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "sylow-theorem-oq-04-oq-03",
+  "title": "The Unipotent Sylow-p Subgroup of SL(2, p)",
+  "slug": "sylow-theorem-oq-04-oq-03",
+  "description": "A fully verified, axiom-free construction of the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} of SL(2, 𝔽_p). U is embedded as an injective group homomorphism from the additive group (ℤ/p, +), proving it is abelian, isomorphic to ℤ/p, and of cardinality exactly p — the order-p Sylow subgroup of SL(2, p) and the abelian normal subgroup of the Borel that Iwasawa's criterion requires for the simplicity of PSL(2, p). One clean piece of infrastructure toward the open question that PSL(2, p) is simple for every prime p ≥ 5.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylowTheoremOQ04OQ03.lean",
+    "tags": [
+      "group-theory",
+      "sylow-theorems",
+      "special-linear-group",
+      "PSL",
+      "unipotent",
+      "iwasawa"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). Every result is machine-checked from Mathlib over the ordinary foundational axioms only. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup infrastructure and makes no claim about the open question itself.",
+    "lineCount": 122,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "originalContributions": [
+      "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
+      "unipotentUpper_mul: additivity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]], giving an abelian one-parameter subgroup",
+      "unipotentHom: the injective group homomorphism Multiplicative(ZMod p) →* SL(2, ZMod p) whose image is the unipotent subgroup",
+      "card_unipotent_range: the image has cardinality exactly p, identifying it as the order-p Sylow subgroup of SL(2, p)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The projective special linear groups PSL(2, p) form the first infinite family of finite non-abelian simple groups, with PSL(2, 5) ≅ A₅ the smallest. Their simplicity for p ≥ 5 was known to Évariste Galois (1832), who studied the exceptional behaviour at p = 5, 7, 11. Camille Jordan established the simplicity systematically in his Traité (1870). The modern textbook route is not a raw Sylow count but Iwasawa's simplicity criterion (Iwasawa 1941; see Dixon & Mortimer, Permutation Groups §3.3), applied to the natural action of PSL(2, p) on the projective line P¹(𝔽_p). That criterion requires exhibiting an abelian normal subgroup of a point stabiliser (the Borel subgroup) whose conjugates generate the whole group. The upper-unipotent subgroup U constructed here is exactly that abelian normal subgroup — and simultaneously the order-p Sylow subgroup of SL(2, p), since |SL(2, p)| = p(p−1)(p+1) has p-part exactly p.",
+    "problemStatement": "**Open question (parent):** PSL(2, p) is simple for every prime p ≥ 5.\n\n**This entry (verified fragment):** Construct the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} ⊆ SL(2, 𝔽_p) and prove that t ↦ [[1,t],[0,1]] is an injective group homomorphism from (ℤ/p, +), so that U is abelian, isomorphic to ℤ/p, and has cardinality exactly p.",
+    "proofStrategy": "The matrix [[1,t],[0,1]] has determinant 1·1 − t·0 = 1, so `unipotentUpper t` lands in SL(2, ZMod p) (`Matrix.det_fin_two_of`). Matrix multiplication gives [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]] (`unipotentUpper_mul`, proved entrywise by `fin_cases` + `ring`), and [[1,0],[0,1]] = 1 (`unipotentUpper_zero`). These package into a monoid homomorphism `unipotentHom` from Multiplicative(ZMod p): map_one from unipotentUpper_zero, map_mul from unipotentUpper_mul. Injectivity is read off the top-right entry (`unipotentUpper_injective`). Finally `Equiv.ofInjective` transports the cardinality of ZMod p through the injection, and `ZMod.card` gives |U| = p (`card_unipotent_range`).",
+    "keyInsights": [
+      "The unipotent subgroup is simultaneously (a) the abelian normal subgroup of the Borel required by Iwasawa's criterion and (b) the order-p Sylow subgroup of SL(2, p) — the same object plays both roles.",
+      "Writing the additive group (ℤ/p, +) multiplicatively via `Multiplicative (ZMod p)` lets the one-parameter subgroup be a genuine `MonoidHom`, so that `map_mul` is literally the additivity identity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]].",
+      "Injectivity is immediate from a single matrix entry (the top-right coordinate is t), so the subgroup structure and its cardinality p follow with no counting argument.",
+      "This is the honest boundary between what is verified and what is open: the deep simplicity theorem is genuinely blocked on the PSL(2, p) action on P¹, its 2-transitivity, and perfectness — none of which are claimed here."
+    ],
+    "prerequisites": [
+      "Special linear groups SL(n, R) and the determinant-1 condition",
+      "The additive group ℤ/p and its multiplicative shadow Multiplicative(ZMod p)",
+      "Monoid homomorphisms and injectivity",
+      "Iwasawa's simplicity criterion (background motivation only)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-sylow-oq04oq03-header",
+      "title": "Header and Motivation",
+      "startLine": 1,
+      "endLine": 52,
+      "description": "Module docstring framing the open question (simplicity of PSL(2, p) for p ≥ 5), explaining why the standard route is Iwasawa's criterion rather than a raw Sylow count, and stating precisely which verified fragment this file delivers: the upper-unipotent subgroup U as the abelian normal subgroup of the Borel and the order-p Sylow subgroup. References Rotman §9 and Dixon & Mortimer §3.3, §2.8."
+    },
+    {
+      "id": "sec-sylow-oq04oq03-def",
+      "title": "The Unipotent Matrix and Its Group Law",
+      "startLine": 54,
+      "endLine": 89,
+      "description": "Defines `unipotentUpper t = [[1,t],[0,1]]` as an element of SL(2, ZMod p) (determinant 1 via `Matrix.det_fin_two_of`), with the simp lemma `val_unipotentUpper`. Proves additivity `unipotentUpper_mul` (entrywise `fin_cases`/`ring`), identity `unipotentUpper_zero`, commutativity `unipotentUpper_comm`, and injectivity `unipotentUpper_injective` (from the top-right entry)."
+    },
+    {
+      "id": "sec-sylow-oq04oq03-hom",
+      "title": "The One-Parameter Subgroup as a Homomorphism and Its Cardinality",
+      "startLine": 90,
+      "endLine": 122,
+      "description": "Packages the embedding as `unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` (map_one from `unipotentUpper_zero`, map_mul from `unipotentUpper_mul`), proves it injective (`unipotentHom_injective`), and computes the cardinality of the image as exactly p (`card_unipotent_range`) via `Equiv.ofInjective` and `ZMod.card` — identifying U as the order-p Sylow subgroup of SL(2, p)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The upper-unipotent one-parameter subgroup of SL(2, 𝔽_p) is constructed and verified, axiom-free, as an injective homomorphic image of (ℤ/p, +): abelian, isomorphic to ℤ/p, of cardinality exactly p. This is the abelian normal subgroup of the Borel that Iwasawa's criterion needs and the order-p Sylow subgroup of SL(2, p).",
+    "implications": "This isolates and machine-verifies one reusable building block of the standard Iwasawa-criterion route to the simplicity of PSL(2, p) for primes p ≥ 5, the first infinite family of finite simple groups. The remaining ingredients — the action on P¹(𝔽_p), 2-transitivity, perfectness, and the assembly via Iwasawa's lemma — remain open in Mathlib.",
+    "openQuestions": [
+      "Formalize the action of PSL(2, p) on the projective line P¹(𝔽_p) and its 2-transitivity.",
+      "Prove that the conjugates of the unipotent subgroup U generate SL(2, p) (perfectness for p ≥ 5).",
+      "Assemble the pieces via Iwasawa's simplicity criterion to prove PSL(2, p) simple for every prime p ≥ 5."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sylow-theorem-oq-04",
+      "relationship": "extends",
+      "description": "The parent entry proves simplicity of A₅ ≅ PSL(2,5) by exact Sylow counting. This entry begins the generalization to the whole family PSL(2, p), p ≥ 5, by verifying the order-p unipotent Sylow subgroup of SL(2, p) — the object the modern Iwasawa-criterion proof is built on."
+    },
+    {
+      "targetId": "sylow-theorem",
+      "relationship": "uses",
+      "description": "The unipotent subgroup U constructed here is the Sylow p-subgroup of SL(2, p): since |SL(2, p)| = p(p−1)(p+1), the p-part is exactly p, and |U| = p."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "foundational",
+      "description": "PSL(2,5) ≅ A₅ is the composition factor whose non-abelian simplicity underlies Abel-Ruffini. This entry starts the program of proving simplicity for the entire PSL(2, p) family, of which A₅ is the smallest member."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 122,
+    "path": "Proofs/SylowTheoremOQ04OQ03.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 8
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/sylow-theorem-oq-04-oq-03.json
@@ -2,11 +2,11 @@
   "slug": "sylow-theorem-oq-04-oq-03",
   "title": "Simplicity of PSL(2,p) for primes p ≥ 5 by a Sylow counting argument",
   "status": "blocked",
-  "phase": "OBSERVE",
+  "phase": "BUILD",
   "path": "full",
-  "tier": "EMPTY",
+  "tier": "MODERATE",
   "started": "2026-04-05T03:59:25.465Z",
-  "lastUpdate": "2026-07-02T00:00:00.000Z",
+  "lastUpdate": "2026-07-04T00:00:00.000Z",
   "significance": 7,
   "tractability": 2,
   "tags": [
@@ -56,7 +56,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The Sylow 'counting' framing in the parent's open question is a slight red herring: the parent's A₅ argument counts Sylow-5 subgroups, but the standard proof of PSL(2,p) simplicity for the whole family p ≥ 5 is NOT a direct Sylow count — it is the Iwasawa criterion applied to the 2-transitive action of PSL(2,p) on the projective line P¹(𝔽_p) (p+1 points). Mathlib supplies the Iwasawa criterion (IwasawaStructure.isSimpleGroup) and the bare PSL abbreviation, but essentially none of the connective infrastructure. Required and MISSING in Mathlib: (1) the order |SL(2,𝔽_p)| = p(p²−1) and |PSL(2,p)| = p(p²−1)/2 for odd p; (2) the action of PSL(2,p) on P¹(𝔽_p) with 2-transitivity and Borel point-stabilizers; (3) an Iwasawa structure — the unipotent subgroup {[[1,t],[0,1]]} (abelian, normal in the Borel stabilizer) whose conjugates generate PSL(2,p); (4) perfectness of PSL(2,p) for p ≥ 5 (fails for p = 2,3). Each is nontrivial; together this is a >1000-line formalization. Recommend keeping BLOCKED until the SL(2)/P¹ action infrastructure is built (a natural standalone BUILD target), then discharge simplicity via the Iwasawa criterion.",
+    "progressSummary": "BUILD (researcher-6, 2026-07-04): built and verified the first standalone infrastructure fragment — the unipotent Sylow-p subgroup U of SL(2, ZMod p) as an injective additive homomorphism with |U|=p (SylowTheoremOQ04OQ03.lean, 0-axiom/0-sorry, docker-build verified; gallery entry added). This is item (3)'s abelian-normal building block and item (2)'s Sylow-p subgroup from the nextSteps list. STILL BLOCKED on the deep theorem: the PSL(2,p) action on P¹(𝔽_p), 2-transitivity, perfectness for p≥5, and the Iwasawa assembly all remain missing in Mathlib (>1000 lines). Prior: OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The Sylow 'counting' framing in the parent's open question is a slight red herring: the parent's A₅ argument counts Sylow-5 subgroups, but the standard proof of PSL(2,p) simplicity for the whole family p ≥ 5 is NOT a direct Sylow count — it is the Iwasawa criterion applied to the 2-transitive action of PSL(2,p) on the projective line P¹(𝔽_p) (p+1 points). Mathlib supplies the Iwasawa criterion (IwasawaStructure.isSimpleGroup) and the bare PSL abbreviation, but essentially none of the connective infrastructure. Required and MISSING in Mathlib: (1) the order |SL(2,𝔽_p)| = p(p²−1) and |PSL(2,p)| = p(p²−1)/2 for odd p; (2) the action of PSL(2,p) on P¹(𝔽_p) with 2-transitivity and Borel point-stabilizers; (3) an Iwasawa structure — the unipotent subgroup {[[1,t],[0,1]]} (abelian, normal in the Borel stabilizer) whose conjugates generate PSL(2,p); (4) perfectness of PSL(2,p) for p ≥ 5 (fails for p = 2,3). Each is nontrivial; together this is a >1000-line formalization. Recommend keeping BLOCKED until the SL(2)/P¹ action infrastructure is built (a natural standalone BUILD target), then discharge simplicity via the Iwasawa criterion.",
     "insights": [
       "The right tool is Iwasawa's criterion, not raw Sylow counting: PSL(2,p) acts 2-transitively (hence primitively and faithfully) on the p+1 points of P¹(𝔽_p); the unipotent upper-triangular subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} is abelian, normal in the stabilizer of ∞, and its PSL-conjugates generate PSL(2,p); with perfectness for p ≥ 5, IwasawaStructure.isSimpleGroup concludes.",
       "Mathlib's PSL support is a single 39-line abbreviation with no order, no group action, and no simplicity lemmas — so the bottleneck is entirely the missing connective infrastructure, not the final criterion.",
@@ -75,6 +75,8 @@
       "Assemble the Iwasawa structure (U abelian-normal-in-stabilizer, conjugates generate) and prove perfectness for p ≥ 5, then apply IwasawaStructure.isSimpleGroup.",
       "Until the P¹ action infrastructure exists, keep this entry BLOCKED rather than attempting the simplicity theorem directly on top of missing foundations."
     ],
-    "builtItems": []
+    "builtItems": [
+      "SylowTheoremOQ04OQ03.lean (VERIFIED, 0-axiom, 0-sorry, 122 lines): the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]]} of SL(2, ZMod p). Proves unipotentUpper lands in SL(2) (det=1), unipotentUpper_mul additivity, unipotentUpper_zero/comm, unipotentHom : Multiplicative(ZMod p) →* SL(2,ZMod p) as an injective group hom, and card_unipotent_range: |U| = p. This is the abelian normal subgroup of the Borel required by Iwasawa's criterion and the order-p Sylow subgroup of SL(2,p). Gallery entry added (status verified, badge original)."
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Open question `sylow-theorem-oq-04-oq-03`: **PSL(2, p) is simple for every prime p ≥ 5** — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on >1000 lines of missing Mathlib infrastructure (the PSL(2,p) action on P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5). The modern route is Iwasawa's criterion, **not** a raw Sylow count.

Rather than `sorry` the whole statement, this PR isolates and **fully verifies one reusable building block**: the upper-unipotent one-parameter subgroup

    U = { [[1, t], [0, 1]] : t ∈ 𝔽_p } ⊆ SL(2, 𝔽_p).

U is simultaneously the abelian normal subgroup of the Borel that Iwasawa's criterion requires **and** the order-p Sylow subgroup of SL(2, p).

## What's proved (`proofs/Proofs/SylowTheoremOQ04OQ03.lean`, 122 lines)

- `unipotentUpper t` — [[1,t],[0,1]] as a determinant-1 element of `SL(2, ZMod p)`
- `unipotentUpper_mul` — additivity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]] (abelian one-parameter subgroup), plus `_zero`, `_comm`, `_injective`
- `unipotentHom` — injective `MonoidHom`  Multiplicative(ZMod p) →* SL(2, ZMod p)
- `card_unipotent_range` — |U| = p (the order-p Sylow subgroup)

## Verification

- **docker-build verified** (`./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ04OQ03` → *Build succeeded*)
- **0 sorries, 0 axiom declarations, no `native_decide`** → verified over the ordinary foundational axioms only (no `Lean.ofReduceBool`)
- 8 theorems / 2 definitions

## Gallery + research metadata

- `src/data/proofs/sylow-theorem-oq-04-oq-03/{meta.json,annotations.json}` — status `verified`, badge `original`, 5 annotations
- `src/data/research/problems/sylow-theorem-oq-04-oq-03.json` — phase → BUILD, `builtItems` recorded; the deep simplicity theorem remains **BLOCKED** and is not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)