### PR TITLE
gallery(roth-oq-03-oq-01): entry for verified Gowers norm / Λ_k foundational identities

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "roth-oq0301-operators",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 49, "endLine": 75 },
+    "type": "definition",
+    "title": "The operators: Gowers norm and k-AP count, re-declared",
+    "content": "The file re-declares, constructively, the two analytic operators at the heart of the density-increment approach to Szemerédi's theorem. `hypercubeShift h ω = Σᵢ (if ωᵢ then hᵢ else 0)` is the shift determined by a hypercube vertex ω ∈ {0,1}^s and shift vectors h. `conjugateByWeight ω z` conjugates z exactly when the Hamming weight |ω| is odd. `gowersNorm N s f` is ‖f‖_{U^s} written as the modulus of the normalized sum `(N⁻¹)^{s+1} · ∑_{x,h} ∏_ω C^{|ω|} f(x+ω·h)`. `kAPCount k f` is Λ_k as the normalized double average `(N⁻¹)² · ∑_{x,d} ∏ᵢ fᵢ(x+i·d)`. Re-declaring with the current Mathlib norm ‖·‖ (rather than the parent's Complex.abs) makes the file robust to merge order and toolchain drift.",
+    "mathContext": "$\\Lambda_k(f_0,\\dots,f_{k-1}) = (N^{-1})^2\\sum_{x,d}\\prod_{i<k} f_i(x+i\\cdot d)$",
+    "significance": "supporting",
+    "prerequisites": ["finite sums/products over Fin s and ZMod N", "ZMod N as a finite ring", "starRingEnd ℂ (complex conjugation)"],
+    "relatedConcepts": ["Gowers uniformity norm", "k-term arithmetic progression", "averaging operator E", "hypercube {0,1}^s"]
+  },
+  {
+    "id": "roth-oq0301-conj-zero",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 81, "endLine": 86 },
+    "type": "theorem",
+    "title": "conjugateByWeight_zero — the conjugation factor fixes 0",
+    "content": "The weight-conjugation factor `conjugateByWeight ω` sends 0 to 0 regardless of the parity of |ω|: the even branch is the identity and the odd branch is `starRingEnd ℂ` (complex conjugation), and both fix the origin. Marked `@[simp]` so it feeds the vanishing arguments downstream. The proof is `unfold; split <;> simp`.",
+    "mathContext": "$C^{|\\omega|}(0)=0$ for either parity of $|\\omega|$",
+    "significance": "supporting",
+    "prerequisites": ["starRingEnd ℂ fixes 0", "if-then-else split"],
+    "relatedConcepts": ["complex conjugation", "Gowers norm factor"]
+  },
+  {
+    "id": "roth-oq0301-gowers-zero",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 88, "endLine": 101 },
+    "type": "theorem",
+    "title": "gowersNorm_zero — ‖0‖_{U^s} = 0",
+    "content": "The Gowers U^s norm of the zero function is 0. Every hypercube factor is `conjugateByWeight ω ((0) (x + hypercubeShift h ω)) = conjugateByWeight ω 0 = 0`, so `Finset.prod_eq_zero` (using the distinguished vertex `default : Fin s → Bool`) collapses each 2^s-fold product to 0; the double averaging sum over x and h is then 0, and `‖0‖ = 0`. This is the first metric datum of the Gowers norm.",
+    "mathContext": "$\\|0\\|_{U^s} = 0$",
+    "significance": "key",
+    "prerequisites": ["Finset.prod_eq_zero", "Finset.sum_congr", "norm of 0"],
+    "relatedConcepts": ["seminorm axioms", "vanishing product"]
+  },
+  {
+    "id": "roth-oq0301-const",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 103, "endLine": 121 },
+    "type": "theorem",
+    "title": "kAPCount_const — Λ_k(c,…,c) = cᵏ and the normalization",
+    "content": "The k-AP count of the constant tuple (c,…,c) equals cᵏ. The inner product `∏ i : Fin k, c` collapses to `c ^ k` via `Finset.prod_const` (card of Fin k is k). The double sum over ZMod N × ZMod N of the constant cᵏ evaluates to `N · (N · cᵏ)` through `Finset.sum_const`, `ZMod.card`, and `nsmul_eq_mul`. The prefactor is then cleared by the algebraic identity `(N⁻¹)² · (N·(N·cᵏ)) = (N⁻¹·N)² · cᵏ` (a `ring` rewrite) followed by `inv_mul_cancel₀` — valid since `N ≠ 0` from the `NeZero N` instance. This is the (N⁻¹)²·N² = 1 normalization that certifies Λ_k is a genuine expectation E_{x,d}, not an unnormalized sum.",
+    "mathContext": "$\\Lambda_k(c,\\dots,c) = (N^{-1})^2\\cdot N^2\\cdot c^k = c^k$",
+    "significance": "critical",
+    "prerequisites": ["Finset.prod_const / Finset.sum_const", "ZMod.card", "inv_mul_cancel₀", "NeZero N"],
+    "relatedConcepts": ["normalized average", "expectation operator", "counting operator"]
+  },
+  {
+    "id": "roth-oq0301-const-one",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 123, "endLine": 128 },
+    "type": "theorem",
+    "title": "kAPCount_const_one — Λ_k(1,…,1) = 1 (total normalized mass)",
+    "content": "The count of the all-ones tuple is 1: the c = 1 specialization of `kAPCount_const` (rewrite then `simp` on `1 ^ k = 1`). This is the total normalized k-AP mass and the base point of the decomposition `1_A = δ·1 + (1_A − δ)` that opens the generalized von Neumann argument — Λ_k(1,…,1) = 1 supplies the main term when expanding Λ_k(1_A,…,1_A) multilinearly.",
+    "mathContext": "$\\Lambda_k(1,\\dots,1) = 1$",
+    "significance": "key",
+    "prerequisites": ["kAPCount_const", "1 ^ k = 1"],
+    "relatedConcepts": ["density-increment decomposition", "main term δᵏ", "generalized von Neumann inequality"]
+  },
+  {
+    "id": "roth-oq0301-annihilate",
+    "proofId": "roth-theorem-k3-oq-03-oq-01",
+    "range": { "startLine": 130, "endLine": 141 },
+    "type": "theorem",
+    "title": "kAPCount_eq_zero_of_zero — a single zero slot annihilates Λ_k",
+    "content": "If the function in slot j is identically zero (`f j = 0`) then the whole count vanishes: `Λ_k(f₀,…,f_{k-1}) = 0`. For every (x,d) the product `∏ i : Fin k, f i (x + i·d)` has its j-th factor equal to 0, so `Finset.prod_eq_zero` (at index j ∈ univ) collapses it; the double average of 0 is 0. Together with the constant identity this is the zero base case of the multilinear expansion — a decomposition slot that is identically 0 contributes nothing.",
+    "mathContext": "$f_j = 0 \\Rightarrow \\Lambda_k(f_0,\\dots,f_{k-1}) = 0$",
+    "significance": "key",
+    "prerequisites": ["Finset.prod_eq_zero", "Finset.mem_univ", "Finset.sum_congr"],
+    "relatedConcepts": ["multilinear expansion", "vanishing slot", "counting operator"]
+  }
+]

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "roth-theorem-k3-oq-03-oq-01",
+  "title": "Roth/Szemerédi OQ-03-OQ-01: Foundational Identities for the Gowers Norm and the k-AP Counting Operator",
+  "slug": "roth-theorem-k3-oq-03-oq-01",
+  "description": "Building on the parent file's constructive Gowers U^s norm and k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d), this entry proves the degenerate/normalization identities every later argument relies on: the conjugation factor fixes 0, ‖0‖_{U^s}=0, Λ_k(c,…,c)=cᵏ, Λ_k(1,…,1)=1 (total normalized mass), and a single zero slot annihilates Λ_k. These pin the operators down as genuine normalized averages and supply the constant/zero base cases of the 1_A = δ·1 + (1_A − δ) decomposition opening the generalized von Neumann argument. 0-axiom verified.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RothTheoremOQ03OQ01.lean",
+    "tags": [
+      "roth-theorem",
+      "szemeredi",
+      "gowers-norm",
+      "additive-combinatorics",
+      "counting-operator",
+      "normalization",
+      "ZMod"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_eq_zero",
+        "description": "a ∈ s and f a = 0 ⇒ ∏ x∈s, f x = 0 — a single zero factor annihilates a finite product",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.prod_const",
+        "description": "∏ x∈s, c = c ^ s.card — a constant finite product is a power",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const / ZMod.card",
+        "description": "∑ x∈s, c = s.card • c and Fintype.card (ZMod N) = N — evaluate the double average over ZMod N × ZMod N",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "inv_mul_cancel₀",
+        "description": "a ≠ 0 ⇒ a⁻¹ * a = 1 — cancels the (N⁻¹)² prefactor against the N² pairs",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "norm_nonneg",
+        "description": "0 ≤ ‖z‖ — the Gowers norm is a genuine modulus",
+        "module": "Mathlib.Analysis.Normed.Group.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Self-contained re-declaration of the two analytic operators using the current Mathlib norm ‖·‖ (robust to merge order / toolchain drift): hypercubeShift, conjugateByWeight, the Gowers U^s norm gowersNorm, and the k-AP counting operator kAPCount (Λ_k)",
+      "conjugateByWeight_zero: the conjugation-by-weight factor fixes 0 — both branches (identity and complex conjugation) send 0 ↦ 0",
+      "gowersNorm_zero: ‖0‖_{U^s} = 0 — every hypercube factor is conjugateByWeight ω 0 = 0, so each 2^s-fold product vanishes and the average is 0",
+      "kAPCount_const: Λ_k(c,…,c) = cᵏ — the inner product is ∏ᵢ c = cᵏ and the normalized double average (N⁻¹)²·∑_{x,d} cᵏ cancels the N² pairs against the (N⁻¹)² prefactor",
+      "kAPCount_const_one: Λ_k(1,…,1) = 1 — the total normalized k-AP mass, base point of the 1_A = δ·1 + (1_A − δ) decomposition",
+      "kAPCount_eq_zero_of_zero: a single zero slot annihilates the count — if f j = 0 then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes"
+    ],
+    "axiomCount": 0,
+    "lineCount": 143,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide, no sorryAx, no Lean.ofReduceBool. The operators are re-declared self-containedly in this file's namespace; the file imports Mathlib.",
+    "theoremCount": 5,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "**Normalization identities for the counting operator.** In the Gowers-norm approach to Roth's and Szemerédi's theorems the central objects are the Gowers U^s uniformity norm ‖f‖_{U^s} and the normalized k-term arithmetic-progression count Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). Before any density-increment or generalized von Neumann argument can run, one needs the base identities that certify these are genuine normalized averages: constants map to powers, the all-ones tuple has count 1, a zero slot kills the count, and the norm of 0 is 0. The parent file `RothTheoremOQ03` defined the operators but recorded no algebraic properties; this entry supplies those foundational checks, fully machine-checked.",
+    "problemStatement": "**Degenerate and normalization identities.** For the Gowers norm `gowersNorm` and the k-AP counting operator `kAPCount` (Λ_k) over `ZMod N`:\n\n- `conjugateByWeight_zero`: the weight-conjugation factor fixes 0;\n- `gowersNorm_zero`: ‖0‖_{U^s} = 0;\n- `kAPCount_const`: Λ_k(c,…,c) = cᵏ;\n- `kAPCount_const_one`: Λ_k(1,…,1) = 1;\n- `kAPCount_eq_zero_of_zero`: f j = 0 for some slot j ⇒ Λ_k(f) = 0.",
+    "text": "Building on the parent file's Gowers U^s norm and k-AP counting operator Λ_k, this entry proves the degenerate/normalization identities every later argument relies on — the conjugation factor fixes 0, ‖0‖_{U^s}=0, Λ_k(c,…,c)=cᵏ, Λ_k(1,…,1)=1, and a single zero slot annihilates Λ_k — pinning the operators down as genuine normalized averages. 0-axiom verified.",
+    "proofStrategy": "**Normalization cancellation.** In `kAPCount_const` the inner product `∏ i : Fin k, c` collapses to `c ^ k` via `Finset.prod_const` (card of `Fin k` is k); the double sum over `ZMod N × ZMod N` becomes `N² · cᵏ` via `Finset.sum_const` and `ZMod.card`, and the prefactor identity `(N⁻¹)² · (N · (N · cᵏ)) = (N⁻¹·N)² · cᵏ` closes with `inv_mul_cancel₀` (N ≠ 0 from `NeZero`). `kAPCount_const_one` is the c = 1 specialization.\n\n**Annihilation.** `gowersNorm_zero` and `kAPCount_eq_zero_of_zero` both reduce every inner product to 0 through `Finset.prod_eq_zero` (a distinguished factor is 0), then collapse the averaging sums; nonnegativity/finality is `simp`.\n\n**Conjugation base case.** `conjugateByWeight_zero` splits on the parity branch and simplifies, since both the identity and `starRingEnd ℂ` fix 0.",
+    "keyInsights": [
+      "**Normalized averages, certified:** kAPCount_const with c = 1 gives Λ_k(1,…,1) = 1 — the (N⁻¹)²·N² = 1 normalization that makes Λ_k a genuine expectation E_{x,d} rather than an unnormalized sum.",
+      "**Zero base cases open the argument:** the constant and single-zero-slot identities are exactly the base points of the multilinear expansion 1_A = δ·1 + (1_A − δ) that starts the generalized von Neumann / density-increment proof.",
+      "**A single zero factor annihilates:** both the Gowers norm of 0 and a count with one zero slot vanish through the same Finset.prod_eq_zero move — the multiplicative structure of the operators.",
+      "**Self-contained and drift-robust:** re-declaring the operators with the current Mathlib ‖·‖ norm insulates this file from the parent's Complex.abs and from merge order."
+    ],
+    "prerequisites": [
+      "The parent construction: the Gowers norm and k-AP counting operator (Proofs.RothTheoremOQ03)",
+      "Finite products/sums over Fin k and ZMod N",
+      "ZMod N as a finite ring; NeZero N and ZMod.card",
+      "Additive combinatorics: Gowers norms and the generalized von Neumann inequality (motivation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "operators",
+      "title": "The Operators (constructive; norm via ‖·‖)",
+      "summary": "Self-contained re-declaration of hypercubeShift (the ω·h shift), conjugateByWeight (conjugate when the Hamming weight is odd), gowersNorm (the U^s norm as a modulus of a normalized sum), and kAPCount (Λ_k, the normalized double average over ZMod N).",
+      "startLine": 45,
+      "endLine": 75,
+      "mathContext": "$\\Lambda_k(f_0,\\dots,f_{k-1}) = \\mathbb{E}_{x,d\\in\\mathbb{Z}/N\\mathbb{Z}}\\prod_{i<k} f_i(x+i\\cdot d)$; $\\|f\\|_{U^s}^{2^s} = |\\mathbb{E}_{x,h}\\prod_\\omega C^{|\\omega|} f(x+\\omega\\cdot h)|$."
+    },
+    {
+      "id": "conjugation",
+      "title": "The Conjugation Factor Fixes 0",
+      "summary": "conjugateByWeight_zero: both branches — identity (even weight) and complex conjugation (odd weight) — send 0 to 0.",
+      "startLine": 81,
+      "endLine": 86,
+      "mathContext": "$C^{|\\omega|}(0) = 0$ for either parity of $|\\omega|$."
+    },
+    {
+      "id": "gowers-zero",
+      "title": "Gowers Norm of Zero",
+      "summary": "gowersNorm_zero: ‖0‖_{U^s} = 0 — every hypercube factor is conjugateByWeight ω 0 = 0, so each 2^s-fold product vanishes (Finset.prod_eq_zero), the average is 0, and ‖0‖ = 0.",
+      "startLine": 88,
+      "endLine": 101,
+      "mathContext": "$\\|0\\|_{U^s} = 0$ via a vanishing factor in every hypercube product."
+    },
+    {
+      "id": "const-count",
+      "title": "Λ_k on Constant Tuples and Normalization",
+      "summary": "kAPCount_const: Λ_k(c,…,c) = cᵏ, the (N⁻¹)²·N² = 1 normalization cancelling the double average; kAPCount_const_one: the c = 1 specialization Λ_k(1,…,1) = 1, the total normalized k-AP mass.",
+      "startLine": 103,
+      "endLine": 128,
+      "mathContext": "$\\Lambda_k(c,\\dots,c) = c^k$, so $\\Lambda_k(1,\\dots,1) = 1$."
+    },
+    {
+      "id": "annihilation",
+      "title": "A Single Zero Slot Annihilates Λ_k",
+      "summary": "kAPCount_eq_zero_of_zero: if f j = 0 for some slot j then Λ_k(f₀,…,f_{k-1}) = 0, since the j-th factor of every product term vanishes (Finset.prod_eq_zero at index j).",
+      "startLine": 130,
+      "endLine": 141,
+      "mathContext": "$f_j = 0 \\Rightarrow \\Lambda_k(f) = 0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry equips the parent file's Gowers U^s norm and k-AP counting operator Λ_k with the foundational degenerate/normalization identities that every later additive-combinatorics argument relies on: the conjugation factor fixes 0, ‖0‖_{U^s} = 0, Λ_k(c,…,c) = cᵏ, Λ_k(1,…,1) = 1, and a single zero slot annihilates Λ_k. The constant identity certifies the (N⁻¹)²·N² = 1 normalization that makes Λ_k a genuine expectation, and the constant/zero base cases open the multilinear expansion 1_A = δ·1 + (1_A − δ). All 0-axiom and machine-checked, with the operators re-declared self-containedly using the current Mathlib ‖·‖ norm.",
+    "implications": "These identities are the base cases invoked whenever one expands Λ_k(1_A,…,1_A) along a decomposition 1_A = δ·1 + g in the density-increment / generalized von Neumann proof of Roth's and Szemerédi's theorems: Λ_k(1,…,1) = 1 supplies the main term δᵏ, and the annihilation/constant lemmas control the boundary of the expansion. With them verified, the multilinearity layer (child entry) and eventually the generalized von Neumann inequality can cite them directly.",
+    "openQuestions": [
+      "Multilinearity of Λ_k: additivity and homogeneity in each slot (established in the child entry)",
+      "Generalized von Neumann inequality: bound a Λ_k term with a non-trivial slot by a Gowers norm ‖g‖_{U^{k-1}}",
+      "Conjugate-symmetry and the s-fold-average positivity ‖f‖_{U^s} ≥ 0 of the Gowers norm",
+      "Translation-invariance of Λ_k and the k = 3 (Roth) specialization Λ_3"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "RothTheoremOQ03OQ01",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "path": "Proofs/RothTheoremOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "extends",
+      "description": "Parent: defines the Gowers norm and the k-AP counting operator Λ_k for Roth's theorem; this entry supplies their foundational identities."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+      "relationship": "specializes",
+      "description": "Child: proves multilinearity (additivity + homogeneity) of Λ_k, building on the identities established here."
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "extends",
+      "description": "Root entry: Roth's theorem (Szemerédi k=3), the density result whose modern proof drives the density-increment expansions these identities anchor."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

`proofs/Proofs/RothTheoremOQ03OQ01.lean` — the foundational-identities layer of the Roth/Szemerédi Gowers-norm chain (5 theorems, 4 definitions, 0 sorry, 0 axiom, **verified**) — had **no gallery entry**, even though its parent (`roth-theorem-k3-oq-03`) and its children (`roth-theorem-k3-oq-03-oq-01-oq-01` and deeper) are all in the gallery. This PR fills that gap with `meta.json` + `annotations.json`.

## What the proof contains

Self-contained re-declaration (using the current Mathlib `‖·‖` norm) of the Gowers `U^s` norm and the k-AP counting operator `Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d)`, plus the degenerate/normalization identities every later additive-combinatorics argument relies on:

- `conjugateByWeight_zero` — the weight-conjugation factor fixes 0;
- `gowersNorm_zero` — ‖0‖_{U^s} = 0;
- `kAPCount_const` — Λ_k(c,…,c) = cᵏ (the (N⁻¹)²·N² = 1 normalization);
- `kAPCount_const_one` — Λ_k(1,…,1) = 1 (total normalized mass, main term of the 1_A = δ·1 + (1_A − δ) expansion);
- `kAPCount_eq_zero_of_zero` — a single zero slot annihilates Λ_k.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ03OQ01` → **Build completed successfully** (7743 jobs).
- No `native_decide`, `sorry`, or `axiom`; only `propext` / `Classical.choice` / `Quot.sound`. Status `verified`, badge `verified`, axiomCount 0.
- `pnpm annotations:validate` — clean for this entry (all 6 annotations resolve to the correct constructs); `pnpm gallery:check-size` — no size issues.

Gallery-data only; the Lean proof file is already on `main` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)