### PR TITLE
Enrich Sperner-Tucker hexagon interior-seed witness gap: add mainTheorems (0→8)

### DIFF
--- a/src/data/proofs/sperner-mathlib4-oq-02-oq-09/meta.json
+++ b/src/data/proofs/sperner-mathlib4-oq-02-oq-09/meta.json
@@ -46,6 +46,56 @@
     ],
     "additionalFiles": []
   },
+  "mainTheorems": [
+    {
+      "name": "interior_seed_can_be_witness_free",
+      "type": "main",
+      "description": "Headline separation. At the antipodal labelling a=b=c=+1, centre d=+2, the directed rule fires interiorDeg1 = 3 degree-1 interior rooms yet NONE of their doors is genuinely complementary (interiorComplDoor = 0): no boundary vertex is antipodal to the centre +2 whose partner −2 is absent. So the seed count 3 is not a lower bound on the true interior Tucker witnesses.",
+      "leanType": "interiorDeg1 0 0 0 1 = 3 ∧ interiorComplDoor 0 0 0 1 = 0"
+    },
+    {
+      "name": "hexagon_tucker_directed",
+      "type": "main",
+      "description": "n = 2 Tucker in the directed hexagon model: for every antipodal labelling (a,b,c) and centre d, some room side is genuinely complementary — a boundary edge vᵢ–v_{i+1} or an interior spoke d–vᵢ. This is the true conclusion the seed-witness obstruction is read against.",
+      "leanType": "∀ a b c d : Fin 4, ∃ i : Fin 6, Compl (V a b c i) (V a b c (rot i)) ∨ Compl d (V a b c i) ∨ Compl (V a b c i) d"
+    },
+    {
+      "name": "tucker_witness_is_on_boundary_there",
+      "type": "key",
+      "description": "At the witness-free-seed labelling the genuine complementary edge the interior seed missed is the boundary edge v₂–v₃ = (+1,−1), not any interior spoke — showing the terminal room cannot be identified with the Tucker witness by the sign door alone.",
+      "leanType": "Compl (V 0 0 0 2) (V 0 0 0 (rot 2))"
+    },
+    {
+      "name": "interiorComplDoor_not_constant",
+      "type": "key",
+      "description": "The complementary interior count is a genuine function of the labelling (0 at (+1,+1,+1,+2), 3 at (+1,+1,+1,+1)) even though interiorDeg1 is constantly 3, so the sign-door count carries no information about how many interior rooms are true witnesses.",
+      "leanType": "interiorComplDoor 0 0 0 1 = 0 ∧ interiorComplDoor 0 0 0 0 = 3"
+    },
+    {
+      "name": "orientation_blind_witness",
+      "type": "key",
+      "description": "Orientation blindness, concretely: at a=b=c=d=+1 the interior spoke v₃→d = (−1)→(+1) is genuinely complementary but its directed door is 0 — the (+ → −) rule does not count the (− → +) orientation. This is how the directed seed under-counts complementary spokes.",
+      "leanType": "Compl (V 0 0 0 3) 0 ∧ dir (sgn (V 0 0 0 3)) (sgn 0) = 0"
+    },
+    {
+      "name": "interiorComplDoor_le_interiorDeg1",
+      "type": "supporting",
+      "description": "Pointwise domination: the genuine complementary interior count never exceeds the seed count, so the seed CONTAINS whatever true interior witnesses exist (an upper-bound envelope, not a lower bound).",
+      "leanType": "∀ a b c d, interiorComplDoor a b c d ≤ interiorDeg1 a b c d"
+    },
+    {
+      "name": "interiorDeg1_eq_three",
+      "type": "supporting",
+      "description": "The interior degree-1 seed count is the constant 3 across all labellings — the fixed quantity against which the variable genuine-witness count is contrasted.",
+      "leanType": "∀ a b c d, interiorDeg1 a b c d = 3"
+    },
+    {
+      "name": "compl_imp_opposite_sign",
+      "type": "supporting",
+      "description": "Complementarity forces opposite ZMod-2 signs: if x = negL y then sgn x = sgn y + 1. The sign-door heuristic keys off this necessary (but not sufficient) condition, which is the root of the over/under-counting gap.",
+      "leanType": "∀ x y : Fin 4, Compl x y → sgn x = sgn y + 1"
+    }
+  ],
   "overview": {
     "historicalContext": "Tucker's lemma (Albert W. Tucker, 1945) is the combinatorial heart of the Borsuk–Ulam theorem, the antipodal analogue of the way Sperner's lemma underlies Brouwer's fixed-point theorem. Its constructive proofs (Freund–Todd 1981; Prescott–Su 2005) proceed by an oriented path-following (signed pivot) argument: one follows a sequence of almost-complementary simplices from a forced boundary door to an interior degree-1 terminal room, which is asserted to be the Tucker complementary simplex. The sperner-mathlib4-oq-02 program verifies the abstract door-counting engine and the dimension recursion; the remaining obligation is the geometric door construction. The sibling oq-02-oq-08 fired the engine's parity mechanism on the concrete hexagon disc under the directed pos→neg sign door rule and reached a POSITIVE interior degree-1 count (exactly three rooms) — the structural conclusion the undirected sign-flip engine provably could not deliver. What remained flagged in that entry's honest status was the identification step: does the pivot-terminal room actually carry a genuine complementary edge? This entry answers that question on the concrete triangulation.",
     "problemStatement": "On the standard antipodally symmetric hexagon + centre triangulation of B², encode labels {+1,+2,−1,−2} as Fin 4 with negation negL, sign map sgn : Fin 4 → ZMod 2 (±1↦0, ±2... {+1,+2}↦0, {−1,−2}↦1), and genuine complementarity Compl x y := x = negL y (exact antipodes). The directed door rule fires on any oriented +→− sign side; the interior directed seed (from oq-02-oq-08) is the set of degree-1 rooms whose single directed door lies on an interior spoke, always exactly three. Define interiorComplDoor as the number of those three rooms whose interior door is GENUINELY complementary. Prove: (1) Compl x y ⇒ sgn x = sgn y + 1 (complementarity forces opposite signs — the sign door never misses a witness on sign); (2) interiorComplDoor ≤ interiorDeg1 (= 3) pointwise; (3) at a = b = c = +1, d = +2 one has interiorDeg1 = 3 yet interiorComplDoor = 0 — the interior seed is entirely witness-free; (4) at that labelling Tucker still holds, with its complementary edge on the BOUNDARY (v₂–v₃ = (+1,−1)); (5) interiorComplDoor is not a constant multiple of the seed (0 at (+1,+1,+1,+2), 3 at (+1,+1,+1,+1)); and (6) an explicit complementary interior spoke oriented −→+ whose directed door is 0 (orientation blindness). All by kernel decide over 256 antipodal labellings.",


### PR DESCRIPTION
Enrichment pass for `sperner-mathlib4-oq-02-oq-09` (Sperner–Tucker hexagon: the interior seed can be witness-free).

**mainTheorems 0→8.** The `mainTheorems` array was empty. Added all eight results with exact `leanType` signatures:

- **main**: `interior_seed_can_be_witness_free` (the headline separation: interiorDeg1 = 3 but interiorComplDoor = 0 at the antipodal labelling), `hexagon_tucker_directed` (n=2 Tucker in the directed model).
- **key**: `tucker_witness_is_on_boundary_there`, `interiorComplDoor_not_constant`, `orientation_blind_witness` — the three facts establishing that the sign-door seed count carries no information about the true interior-witness count.
- **supporting**: `interiorComplDoor_le_interiorDeg1`, `interiorDeg1_eq_three`, `compl_imp_opposite_sign`.

**Axiom integrity:** all eight are discharged by plain `decide` (grep confirms 0 `native_decide` occurrences), so `#print axioms` reports only the foundational trio — `status: verified` / `axiomCount: 0` is accurate and unchanged.

meta.json 18.9→22.2KB (well under the ~60KB cap). No other fields changed; annotations untouched.
