### PR TITLE
Research: IsDiagonalizable.inv closure law (minpoly-charpoly-oq-02-incomplete-01) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -24,8 +24,11 @@ the definition but which the parent omits:
   * `IsDiagonalizable.neg`       — `-M` stays diagonalizable.
   * `IsDiagonalizable.transpose` — the transpose `Mᵀ` is diagonalizable, with
     diagonalizer `(Pᵀ)⁻¹` (eigenvalues are preserved under transpose).
+  * `IsDiagonalizable.inv`       — the inverse `M⁻¹` is diagonalizable (same `P`),
+    because `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹` and the inverse of a diagonal matrix is
+    diagonal (`isDiag_inv`).
 
-All four are fully machine-checked (0 axioms, 0 sorries) and reuse only the
+All five are fully machine-checked (0 axioms, 0 sorries) and reuse only the
 parent's *definition* (not its open reverse-direction obligation).
 
 Reference: Axler, *Linear Algebra Done Right* §5–8; Dummit–Foote §12.
@@ -58,7 +61,7 @@ theorem IsDiagonalizable.conj {M : Matrix n n K} (hM : M.IsDiagonalizable)
     rw [hQinv]
     calc P⁻¹ * U * (U⁻¹ * M * U) * (U⁻¹ * P)
         = P⁻¹ * (U * U⁻¹) * M * (U * U⁻¹) * P := by simp only [mul_assoc]
-      _ = P⁻¹ * M * P := by rw [hUU]; simp only [mul_one, one_mul]
+      _ = P⁻¹ * M * P := by rw [hUU]; simp only [mul_one]
   rw [hsimp]
   exact hD
 
@@ -99,5 +102,29 @@ theorem IsDiagonalizable.transpose {M : Matrix n n K} (hM : M.IsDiagonalizable) 
     simp only [Matrix.transpose_mul, mul_assoc]
   rw [heq]
   exact hD.transpose
+
+/-- **The inverse of a diagonal matrix is diagonal.**  Writing `A = diagonal (diag A)`
+    (valid because `A` is diagonal), `Matrix.inv_diagonal` gives
+    `A⁻¹ = diagonal (Ring.inverse (diag A))`, which is again diagonal. -/
+theorem isDiag_inv {A : Matrix n n K} (h : A.IsDiag) : A⁻¹.IsDiag := by
+  rw [show A⁻¹ = (diagonal (diag A))⁻¹ by rw [h.diagonal_diag], Matrix.inv_diagonal]
+  exact Matrix.isDiag_diagonal _
+
+/-- **The inverse of a diagonalizable matrix is diagonalizable.**  The *same* `P`
+    diagonalizes `M⁻¹`: since `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹` and the inverse of a diagonal
+    matrix is diagonal (`isDiag_inv`), `P⁻¹ M⁻¹ P` is diagonal.  (No invertibility
+    hypothesis on `M` is needed: if `M` is singular then `M⁻¹` is the junk value `0`,
+    which is trivially diagonalizable, and the identity `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹`
+    still holds for Mathlib's `nonsing_inv`.) -/
+theorem IsDiagonalizable.inv {M : Matrix n n K} (hM : M.IsDiagonalizable) :
+    M⁻¹.IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  refine ⟨P, hP, ?_⟩
+  have hPdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have key : (P⁻¹ * M * P)⁻¹ = P⁻¹ * M⁻¹ * P := by
+    rw [Matrix.mul_inv_rev, Matrix.mul_inv_rev, Matrix.nonsing_inv_nonsing_inv P hPdet,
+      ← mul_assoc]
+  rw [← key]
+  exact isDiag_inv hD
 
 end MinpolyCharpolyOQ02Incomplete01

--- a/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
@@ -32,13 +32,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (verified, 0 sorries — despite the 'incomplete' slot name). Child of minpoly-charpoly-oq-02. The parent defines Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹·M·P) and proves only trivial instances. This entry adds the four elementary closure laws: IsDiagonalizable.conj (similarity invariance — the conjugate U⁻¹MU is diagonalizable, diagonalizer U⁻¹P), .smul (c•M, same P), .neg (−M), .transpose (Mᵀ, diagonalizer (Pᵀ)⁻¹). MinpolyCharpolyOQ02Incomplete01.lean, 4 theorems, 0 axioms, 0 sorries. Reuses only the parent's DEFINITION, not its open reverse-direction sorry (#print axioms confirms propext/Classical.choice/Quot.sound only — no sorryAx inheritance).",
+    "progressSummary": "UPDATE (researcher-6, 2026-07-04): added a 5th closure law IsDiagonalizable.inv (the inverse of a diagonalizable matrix is diagonalizable, same diagonalizer P) plus the supporting lemma isDiag_inv (inverse of a diagonal matrix is diagonal, via Matrix.inv_diagonal). File now 6 theorems, still 0 axioms / 0 sorries, docker-build verified (Mathlib v4.26.0). Also fixed a stray unused-simp-arg lint (one_mul) in IsDiagonalizable.conj. Prior: COMPLETE (verified, 0 sorries — despite the 'incomplete' slot name). Child of minpoly-charpoly-oq-02. The parent defines Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹·M·P) and proves only trivial instances. This entry adds the four elementary closure laws: IsDiagonalizable.conj (similarity invariance — the conjugate U⁻¹MU is diagonalizable, diagonalizer U⁻¹P), .smul (c•M, same P), .neg (−M), .transpose (Mᵀ, diagonalizer (Pᵀ)⁻¹). MinpolyCharpolyOQ02Incomplete01.lean, 4 theorems, 0 axioms, 0 sorries. Reuses only the parent's DEFINITION, not its open reverse-direction sorry (#print axioms confirms propext/Classical.choice/Quot.sound only — no sorryAx inheritance).",
     "builtItems": [
       "MinpolyCharpolyOQ02Incomplete01.lean: 4 theorems, 0 axioms, 0 sorries. Imports Proofs.MinpolyCharpolyOQ02 for the Matrix.IsDiagonalizable definition.",
       "IsDiagonalizable.conj (similarity invariance: U⁻¹MU diagonalizable; witness U⁻¹P, key (U⁻¹P)⁻¹ = P⁻¹U via mul_inv_rev + nonsing_inv_nonsing_inv, cancel U·U⁻¹=1).",
       "IsDiagonalizable.smul (c•M; P⁻¹(c•M)P = c•(P⁻¹MP) via mul_smul/smul_mul + IsDiag.smul).",
       "IsDiagonalizable.neg (−M; via mul_neg/neg_mul + IsDiag.neg).",
-      "IsDiagonalizable.transpose (Mᵀ; diagonalizer (Pᵀ)⁻¹, ((Pᵀ)⁻¹)⁻¹MᵀᵀP... = (P⁻¹MP)ᵀ via nonsing_inv_nonsing_inv + transpose_nonsing_inv + IsDiag.transpose)."
+      "IsDiagonalizable.transpose (Mᵀ; diagonalizer (Pᵀ)⁻¹, ((Pᵀ)⁻¹)⁻¹MᵀᵀP... = (P⁻¹MP)ᵀ via nonsing_inv_nonsing_inv + transpose_nonsing_inv + IsDiag.transpose).",
+      "IsDiagonalizable.inv + isDiag_inv (MinpolyCharpolyOQ02Incomplete01.lean): the inverse M⁻¹ of a diagonalizable matrix is diagonalizable with the same P, since P⁻¹M⁻¹P = (P⁻¹MP)⁻¹ and the inverse of a diagonal matrix is diagonal. 0-axiom, 0-sorry, docker-build verified."
     ],
     "insights": [
       "Matrix nonsing-inverse lemmas (mul_nonsing_inv, nonsing_inv_nonsing_inv, mul_inv_rev, transpose_nonsing_inv) take IsUnit A.det, but IsDiagonalizable carries IsUnit P — bridge with Matrix.isUnit_iff_isUnit_det.",
@@ -50,8 +51,7 @@
     "mathlibGaps": [],
     "nextSteps": [
       "The parent's open reverse direction (squarefree minpoly ⇒ diagonalizable over alg-closed char-0) remains the real target: eigenspace internal direct sum ⇒ conjugating matrix.",
-      "Further closure: product of commuting diagonalizable matrices is diagonalizable (needs simultaneous diagonalization); powers Mᵏ of a diagonalizable matrix.",
-      "Inverse: an invertible diagonalizable matrix has diagonalizable inverse (P⁻¹M⁻¹P = (P⁻¹MP)⁻¹, diagonal)."
+      "Further closure: product of commuting diagonalizable matrices is diagonalizable (needs simultaneous diagonalization); powers Mᵏ of a diagonalizable matrix."
     ]
   },
   "tags": [
@@ -60,5 +60,6 @@
   "relatedProofs": [
     "minpoly-charpoly",
     "minpoly-charpoly-oq-02"
-  ]
+  ],
+  "lastUpdate": "2026-07-04T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Extends the diagonalizability closure laws in `MinpolyCharpolyOQ02Incomplete01.lean` with the **inverse law** — one of the documented `nextSteps` for this entry. The file previously proved `conj`, `smul`, `neg`, `transpose`; this adds:

- **`isDiag_inv`** — the inverse of a diagonal matrix is diagonal (rewrite `A = diagonal (diag A)`, apply `Matrix.inv_diagonal`, then `isDiag_diagonal`).
- **`IsDiagonalizable.inv`** — the inverse `M⁻¹` of a diagonalizable matrix is diagonalizable with the **same** diagonalizer `P`, since `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹` and the inverse of a diagonal matrix is diagonal.

No invertibility hypothesis on `M` is required: Mathlib's `nonsing_inv` sends a singular `M` to the junk value `0` (trivially diagonalizable), and the conjugation identity `P⁻¹ M⁻¹ P = (P⁻¹ M P)⁻¹` holds regardless.

## Verification

- **docker-build verified**: `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ02Incomplete01` → *Build succeeded* (pinned Mathlib v4.26.0)
- File now **6 theorems, 0 axioms, 0 sorries**, lint-clean
- Drive-by: removed a stray unused-simp-arg (`one_mul`) lint warning in the existing `IsDiagonalizable.conj` proof

## Metadata

- `src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json` — knowledge/`builtItems` updated; the completed "inverse" nextStep removed. The parent's open reverse direction (squarefree minpoly ⇒ diagonalizable) remains untouched and open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)