### PR TITLE
Enrich Hexagrammum Mysticum S₆ census: add annotations.json (0→7) + self-dual 95/95 keyInsight

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-conway-ryba-index",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 5, "endLine": 62 },
+    "type": "context",
+    "title": "Conway–Ryba: indexing the 95/95 configuration by S₆ conjugacy classes",
+    "content": "The docstring records the key structural idea behind the whole file. Conway and Ryba (2012) observed that every point and line of the Hexagrammum Mysticum is indexed by a conjugacy class of the symmetric group S₆: six-cycles index the 60 Pascal lines and 60 Kirkman points, products of two 3-cycles index the 20 Steiner points and 20 Cayley–Salmon lines, and products of three 2-cycles index the 15 Plücker lines and 15 Salmon points. The exceptional outer automorphism of S₆ exchanges the point and line members of each class, so a class of size 2k splits into k points and k lines. This reduces the geometric census to a finite group-theoretic count.",
+    "mathContext": "Cycle types of fixed-point-free elements of $S_6$: $(6)$, $(4,2)$, $(3,3)$, $(2,2,2)$. Conway–Ryba pair $|(6)\\text{-class}| = 120 = 2\\cdot 60$, $|(3,3)\\text{-class}| = 40 = 2\\cdot 20$, and the self-paired $|(2,2,2)\\text{-class}| = 15$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugacy classes", "outer automorphism of S₆", "Hexagrammum Mysticum", "incidence geometry"],
+    "prerequisites": ["symmetric group", "cycle types", "conjugacy classes"]
+  },
+  {
+    "id": "ann-fixed-point-free",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 68, "endLine": 72 },
+    "type": "definition",
+    "title": "Fixed-point-free permutations of Fin 6",
+    "content": "The shared building block: a permutation whose support is all of Fin 6, i.e. one with no fixed point. A fixed-point-free element of S₆ must have cycle type (6), (4,2), (3,3), or (2,2,2) — every one of the classes that index the Hexagrammum objects is fixed-point-free, so this single predicate underlies all three census theorems. The hand-supplied `Decidable` instance (just `inferInstanceAs` on the bounded ∀) is what lets `native_decide` evaluate the filters quickly.",
+    "mathContext": "$\\mathrm{FixedPointFree}(\\sigma) \\iff \\forall i,\\ \\sigma(i) \\neq i \\iff \\mathrm{supp}(\\sigma) = \\mathrm{Fin}\\,6$. Fixed-point-free $\\Rightarrow$ cycle type is a partition of $6$ with all parts $\\geq 2$: $(6), (4,2), (3,3), (2,2,2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["support of a permutation", "cycle type", "derangement"],
+    "prerequisites": ["permutations", "decidability"]
+  },
+  {
+    "id": "ann-six-cycle",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "technique",
+    "title": "Isolating 6-cycles by power conditions (the subtle (4,2) exclusion)",
+    "content": "Rather than call the `cycleType` API, a 6-cycle is pinned by elementary power/fixed-point conditions: fixed-point-free with σ⁶=1, σ²≠1, σ³≠1. Among fixed-point-free types, σ²≠1 removes (2,2,2), σ³≠1 removes (3,3), and — the subtle step — σ⁶=1 removes (4,2). A (4,2) element has order lcm(4,2)=4, so σ⁶=σ²≠1; demanding σ⁶=1 is exactly what excludes it. Only genuine 6-cycles (order 6) survive.",
+    "mathContext": "$\\mathrm{IsSixCycle}(\\sigma) \\iff \\mathrm{FixedPointFree}(\\sigma) \\wedge \\sigma^6=1 \\wedge \\sigma^2\\neq 1 \\wedge \\sigma^3\\neq 1$. For a $(4,2)$ element, $\\mathrm{ord}(\\sigma)=\\mathrm{lcm}(4,2)=4$, hence $\\sigma^6=\\sigma^{6\\bmod 4}=\\sigma^2\\neq 1$; the $\\sigma^6=1$ clause rules it out.",
+    "significance": "key",
+    "relatedConcepts": ["order of a permutation", "least common multiple", "cycle type (6)"],
+    "prerequisites": ["group element order", "cyclic groups"]
+  },
+  {
+    "id": "ann-double-three-cycle",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 85, "endLine": 93 },
+    "type": "definition",
+    "title": "Products of two 3-cycles: fixed-point-free with σ³=1",
+    "content": "The (3,3) class is captured by just two conditions: fixed-point-free and σ³=1. No fixed points plus order dividing 3 forces every cycle length to divide 3 and exceed 1, so all cycles have length 3; since 3+3=6 this means exactly two 3-cycles. These 40 elements index the 20 Steiner points and 20 Cayley–Salmon lines.",
+    "mathContext": "$\\mathrm{IsDoubleThreeCycle}(\\sigma) \\iff \\mathrm{FixedPointFree}(\\sigma)\\wedge\\sigma^3=1$. Order divides $3$ and no $1$-cycles $\\Rightarrow$ every cycle length $\\in\\{3\\}$; partition of $6$ into $3$s is $(3,3)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["3-cycles", "cycle type (3,3)", "Steiner points"],
+    "prerequisites": ["group element order", "cycle decomposition"]
+  },
+  {
+    "id": "ann-triple-transposition",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 95, "endLine": 103 },
+    "type": "definition",
+    "title": "Products of three 2-cycles: fixed-point-free involutions",
+    "content": "The (2,2,2) class is the fixed-point-free involutions: σ²=1 with no fixed points forces every cycle to have length exactly 2, and 2+2+2=6 gives three transpositions. This class is self-paired under the outer automorphism, so its single size 15 accounts for both the 15 Plücker lines and the 15 Salmon points.",
+    "mathContext": "$\\mathrm{IsTripleTransposition}(\\sigma) \\iff \\mathrm{FixedPointFree}(\\sigma)\\wedge\\sigma^2=1$. An involution with no fixed points has all cycles of length $2$; $6/2=3$ transpositions, cycle type $(2,2,2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["involutions", "transpositions", "cycle type (2,2,2)", "self-paired class"],
+    "prerequisites": ["involutions", "cycle decomposition"]
+  },
+  {
+    "id": "ann-census-native-decide",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 105, "endLine": 128 },
+    "type": "technique",
+    "title": "The census by native_decide: 720 / 120 / 40 / 15",
+    "content": "Each class size is certified by enumerating all 720 elements of Sym(6) via Finset.univ, filtering by the decidable predicate, and computing the cardinality with `native_decide`. This compiles the decision procedure to native code and evaluates it, trusting the Lean compiler — hence the proof depends on the `Lean.ofReduceBool` axiom and the entry is `axiomatized`, not axiom-free. The anchor card_sym6 = 720 confirms the enumeration is over the full group; 120 + 40 + 15 = 175 fixed-point-free elements of these three types.",
+    "mathContext": "$|S_6| = 720$; $|\\{\\text{6-cycles}\\}| = 120$, $|\\{(3,3)\\}| = 40$, $|\\{(2,2,2)\\}| = 15$. Class sizes: $\\tfrac{6!}{6}=120$, $\\tfrac{6!}{3\\cdot 3\\cdot 2}=40$, $\\tfrac{6!}{2^3\\cdot 3!}=15$. `native_decide` introduces the `Lean.ofReduceBool` trust axiom.",
+    "significance": "key",
+    "relatedConcepts": ["native_decide", "Lean.ofReduceBool", "conjugacy class size formula", "Finset.card"],
+    "prerequisites": ["decidability", "finite enumeration", "orbit-stabilizer / class-size formula"]
+  },
+  {
+    "id": "ann-conway-ryba-pairing",
+    "proofId": "pascals-hexagon-oq-03-incomplete-01",
+    "range": { "startLine": 137, "endLine": 156 },
+    "type": "insight",
+    "title": "Outer-automorphism pairing yields the (95₃, 95₃) configuration",
+    "content": "The geometric object counts are arithmetic corollaries of the census under the Conway–Ryba pairing: the size-120 six-cycle class splits 2:1 into 60 Pascal lines and 60 Kirkman points; the size-40 (3,3) class into 20 Steiner points and 20 Cayley–Salmon lines; the size-15 (2,2,2) class is self-paired as 15 Plücker lines and 15 Salmon points. Summing the point classes gives 60+20+15 = 95 points and, dually, 95 lines — the classical (95₃, 95₃) self-dual configuration, with the point/line duality realized by the exceptional outer automorphism of S₆.",
+    "mathContext": "Points: $60_{\\text{Kirkman}} + 20_{\\text{Steiner}} + 15_{\\text{Salmon}} = 95$. Lines: $60_{\\text{Pascal}} + 20_{\\text{Cayley}} + 15_{\\text{Plücker}} = 95$. A $(95_3, 95_3)$ configuration: $3$ points per line, $3$ lines per point, incidences $95\\cdot 3 = 285$.",
+    "significance": "key",
+    "relatedConcepts": ["outer automorphism of S₆", "self-dual configuration", "(95₃, 95₃) configuration", "point-line duality"],
+    "prerequisites": ["projective configurations", "duality"]
+  }
+]


### PR DESCRIPTION
## Enrichment: Hexagrammum Mysticum — S₆ Cycle-Type Census

Entry `pascals-hexagon-oq-03-incomplete-01` had a rich `meta.json` but **no `annotations.json` at all** (zero inline coverage). This pass fills that gap and adds one keyInsight.

### Added `annotations.json` — 7 annotations covering the full file
All with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. **Conway–Ryba conjugacy-class indexing** (docstring 5–62) — the structural idea behind the file
2. **Fixed-point-free predicate** (68–72) — the shared building block; cycle types (6)/(4,2)/(3,3)/(2,2,2)
3. **Isolating 6-cycles by power conditions** (74–83) — the subtle (4,2) exclusion (σ⁶=σ²≠1)
4. **Products of two 3-cycles** (85–93) — fixed-point-free with σ³=1
5. **Products of three 2-cycles** (95–103) — fixed-point-free involutions, self-paired
6. **The census by native_decide** (105–128) — 720/120/40/15, discloses `Lean.ofReduceBool`
7. **Outer-automorphism pairing → (95₃, 95₃)** (137–156) — the self-dual configuration

### `meta.json`
- Added a 4th `keyInsight` on the self-dual (95₃, 95₃) configuration and the point/line duality realized by the S₆ outer automorphism (3→4 insights).

Build passes (`pnpm build`). meta.json 14.7 KB (well under 60 KB cap). Axiom integrity unchanged: `axiomatized` / `Lean.ofReduceBool` correctly disclosed in the new native_decide annotation.
