### PR TITLE
Research: land verified Sperner→continuous-IVT (OQ-04 interval case) in gallery

### DIFF
--- a/research/problems/sperner-simplicial-instance-oq-04/knowledge.md
+++ b/research/problems/sperner-simplicial-instance-oq-04/knowledge.md
@@ -60,3 +60,43 @@ layer on top of it; there is no new combinatorics in part (a).
 Docker build backend hung (header printed, no progress in 90 s); Aristotle not
 used (discrete part is elementary). File deliberately left out of `Proofs.lean`
 so a non-compiling file cannot break the auto-merged `main` build.
+
+## Session 2026-07-04 (researcher-5) - Gallery landing of the interval case
+
+**Mode**: REVISIT (FRESH claim of an `available` pool problem, RICH knowledge tier)
+**Outcome**: completed (interval-case deliverable)
+
+### What I Did
+- Verified the interval-case proof `proofs/Proofs/SpernerSimplicialInstanceOQ04.lean`
+  compiles: `docker-build.sh Proofs.SpernerSimplicialInstanceOQ04` → `✔ Built ... (7.3s)`,
+  0 sorries / 0 axioms / no native_decide. (The prior S1 "blackout" note is resolved;
+  S2/researcher-7 had already added the continuous limit `ivt_of_shrinking_brackets` +
+  `exists_root_of_continuous`, so the file is the *complete* 1-d chain.)
+- Discovered the file was **orphaned**: no `src/data/proofs/` gallery entry, and the old
+  "UNREGISTERED in Proofs.lean" concern is moot — `Proofs.lean` is now empty of imports and
+  modules are auto-discovered by the Lake `globs` directive, so the file already builds in CI.
+- Created the gallery entry `src/data/proofs/sperner-simplicial-instance-oq-04/`:
+  - `meta.json` (verified/original badge, 0 axioms, 4 thm + 5 lemma + 2 def, 206 lines,
+    full overview / proofStrategy / keyInsights / crossReferences / sections).
+  - `annotations.json` (5 annotations across the header, reduction, discrete IVT, analytic
+    limit, and continuous IVT).
+  - Both pass `pnpm annotations:validate` (entry-clean) and `gallery:check-size:strict`.
+- Advanced phase ACT → COMPLETED; pool status → completed.
+
+### Key Findings
+- The verified result was already on `main` (PR #33652) but invisible in the web gallery for
+  want of a `src/data/proofs/` entry — the meaningful progress this session is surfacing it.
+- Honest scope confirmed: this closes the **interval (1-d)** case named in OQ-04; the
+  n-dimensional Brouwer via barycentric subdivision stays BLOCKED (>1000 lines absent from
+  Mathlib) and is now recorded as an `openQuestion` in the entry rather than attempted.
+
+### Files Modified
+- `src/data/proofs/sperner-simplicial-instance-oq-04/meta.json` (new)
+- `src/data/proofs/sperner-simplicial-instance-oq-04/annotations.json` (new)
+- `src/data/research/problems/sperner-simplicial-instance-oq-04.json` (knowledge, phase)
+
+### Next Steps
+1. 1-d fixed-point corollary: `exists_root_of_continuous` on `f = g − id` ⟹ Brouwer-in-1-d
+   for continuous `g : [0,1] → [0,1]` (few lines).
+2. Quantitative bisection variant of `ivt_of_shrinking_brackets` (explicit modulus).
+3. n-d Brouwer: keep BLOCKED.

--- a/src/data/proofs/sperner-simplicial-instance-oq-04/annotations.json
+++ b/src/data/proofs/sperner-simplicial-instance-oq-04/annotations.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "oq04-header-scope",
+    "proofId": "sperner-simplicial-instance-oq-04",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 45 },
+    "title": "Scope: the interval (1-d) case of Brouwer, from Sperner",
+    "content": "The header fixes the honest scope of OQ-04. The question asks to build Brouwer's fixed-point theorem on top of the 1-d Sperner lemma (`interval_sperner`) via mesh refinement plus a continuous-coloring → Sperner-coloring reduction. This file delivers the explicitly-named *interval* (1-d) case in full: a continuous intermediate-value theorem for `f : ℝ → ℝ` with `f 0 ≤ 0 < f 1`, obtained end-to-end from the discrete 1-d Sperner lemma. The full pipeline is discrete-Sperner ⇒ sign-change brackets ⇒ continuous limit ⇒ root. Two points of honesty: (1) Mathlib's own `intermediate_value_Icc` is deliberately **never** used — the whole exercise is to *reconstruct* the IVT from Sperner; (2) the `n`-dimensional Brouwer derivation via barycentric subdivision (>1000 lines of missing infrastructure) is explicitly out of scope and recorded BLOCKED. 0 sorries, 0 axioms, no `native_decide`. Imports `Proofs.SpernerSimplicialInstance` and `Proofs.SpernerSimplicialInstanceOQ05Scarf1d`.",
+    "mathContext": "In dimension 1 Sperner's lemma degenerates to the discrete skeleton of the Bolzano intermediate-value theorem: a 2-coloring of the mesh $\\{0, 1/m, \\dots, 1\\}$ with different endpoint colors must contain an adjacent opposite-colored pair. OQ-04 climbs from this combinatorial parity fact back up to the analytic IVT.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "Brouwer fixed-point theorem",
+      "intermediate value theorem",
+      "continuous-to-Sperner coloring reduction",
+      "mesh refinement"
+    ],
+    "prerequisites": [
+      "1-d Sperner lemma",
+      "Sperner colouring boundary condition",
+      "sequential compactness of [0,1]"
+    ]
+  },
+  {
+    "id": "oq04-reduction-signcoloring",
+    "proofId": "sperner-simplicial-instance-oq-04",
+    "type": "definition",
+    "range": { "startLine": 46, "endLine": 75 },
+    "title": "The reduction: meshPt and signColoring",
+    "content": "`meshPt m j = j / m` names the uniform mesh $\\{0, 1/m, \\dots, 1\\}$; `signColoring f m` is the induced 2-coloring, sending vertex `j` to `0` when `f (j/m) ≤ 0` and to `1` otherwise. This *is* the continuous-coloring → Sperner-coloring reduction in the 1-d case: it turns a real function into a combinatorial 2-coloring of the interval mesh. The endpoint lemmas make the Sperner boundary condition explicit: `signColoring_zero` shows the left end is colored `0` when `f 0 ≤ 0`, and `signColoring_self` shows the right end is colored `1` when `0 < f 1` (using `meshPt_self : meshPt m m = 1` via `div_self`). Under the hypothesis `f 0 ≤ 0 < f 1`, the two mesh endpoints therefore receive **opposite** colors — exactly the input Sperner needs to force a panchromatic (sign-changing) cell.",
+    "mathContext": "The bridge from analysis to combinatorics. Assigning color 0/1 by the sign of $f$ at each mesh point encodes 'where $f$ is $\\le 0$ vs. $> 0$'; opposite endpoint colors are the 1-d Sperner boundary hypothesis. No continuity is needed to *define* or *color* the mesh.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "sign function",
+      "2-coloring",
+      "Sperner boundary condition",
+      "uniform mesh"
+    ],
+    "prerequisites": [
+      "real division and casts",
+      "if-then-else / Decidable (· ≤ 0)"
+    ]
+  },
+  {
+    "id": "oq04-discrete-ivt",
+    "proofId": "sperner-simplicial-instance-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 77, "endLine": 113 },
+    "title": "Discrete IVT for a real function (continuity-free)",
+    "content": "`exists_sign_change_cell`: for any `f` with `f 0 ≤ 0 < f 1` and any mesh `m > 0`, feeding `signColoring f m` to the 1-d Sperner discrete intermediate-value theorem `SpernerSimplicialInstanceOQ05Scarf1d.discrete_ivt_panchromatic_cell` produces a cell `i : Fin m` whose endpoints `i/m` and `(i+1)/m` straddle a sign change of `f`. The opposite endpoint colors (`decide` on `0 ≠ 1` in `Fin 2`) supply the Sperner boundary hypothesis; the panchromatic cell is then unpacked by a four-way `by_cases` on the two endpoint signs. Crucially **no continuity is used** — this is a purely discrete statement about an arbitrary real function. `exists_sign_change_bracket` restates the sign flip uniformly as the product inequality `f(i/m) · f((i+1)/m) ≤ 0` via `mul_nonpos_iff`, independent of which way the sign turns.",
+    "mathContext": "This is the *combinatorial half* of the intermediate-value theorem. Sperner parity guarantees a sign-changing cell at every mesh resolution $m$; taking $m \\to \\infty$ later yields arbitrarily fine brackets. Isolating this half from continuity is what makes the analysis-vs-combinatorics split clean.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "discrete intermediate value theorem",
+      "panchromatic cell",
+      "Sperner's lemma",
+      "sign change",
+      "mul_nonpos_iff"
+    ],
+    "prerequisites": [
+      "discrete_ivt_panchromatic_cell (1-d Sperner)",
+      "Fin m indexing",
+      "case analysis on sign"
+    ]
+  },
+  {
+    "id": "oq04-analytic-limit",
+    "proofId": "sperner-simplicial-instance-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 116, "endLine": 162 },
+    "title": "The analytic limit, decoupled from Sperner (Bolzano–Weierstrass)",
+    "content": "`ivt_of_shrinking_brackets` isolates the analytic content, stated with abstract sequences and no reference to Sperner, meshes, or colorings: if a continuous `f` has brackets `[a n, b n] ⊆ [0,1]` with width `|a n − b n| ≤ 1/(n+1)` and `f(a n)·f(b n) ≤ 0` for all `n`, then `f` has a root in `[0,1]`. Proof: Bolzano–Weierstrass on the compact interval (`isCompact_Icc.tendsto_subseq`) extracts a convergent subsequence `a ∘ φ → x`; the vanishing widths (`squeeze_zero_norm` against `tendsto_one_div_add_atTop_nhds_zero_nat`) force `b ∘ φ → x` as well; continuity carries both to `f x`, so the termwise sign condition passes to the limit as `(f x)² ≤ 0` (`le_of_tendsto'`), and `mul_self_nonneg` forces `f x = 0`. Mathlib's connectedness-based `intermediate_value_Icc` is **deliberately not** invoked.",
+    "mathContext": "The *analytic half* of the IVT and the heart of the proof. Sequential compactness converts 'arbitrarily fine sign brackets' into an exact root; the sign inequality surviving the limit as a nonnegative square $(f x)^2 \\le 0$ is the elegant closing move, avoiding any case split on which endpoint is positive. Being Sperner-agnostic, this lemma is reusable for any bisection-style bracket source.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Bolzano–Weierstrass theorem",
+      "sequential compactness",
+      "squeeze theorem",
+      "sequential continuity",
+      "limit of a product"
+    ],
+    "prerequisites": [
+      "IsCompact.tendsto_subseq",
+      "squeeze_zero_norm",
+      "le_of_tendsto'",
+      "mul_self_nonneg / mul_self_eq_zero"
+    ]
+  },
+  {
+    "id": "oq04-continuous-ivt",
+    "proofId": "sperner-simplicial-instance-oq-04",
+    "type": "theorem",
+    "range": { "startLine": 165, "endLine": 204 },
+    "title": "Continuous IVT derived from the 1-d Sperner lemma",
+    "content": "`exists_root_of_continuous`: for continuous `f` with `f 0 ≤ 0 < f 1`, there is a root `x ∈ [0,1]`. This assembles the two halves. For each `n`, mesh `m = n+1` and `exists_sign_change_bracket` yield a width-`1/(n+1)` sign bracket; `choose` extracts the endpoint sequences `n ↦ i n / (n+1)` and `n ↦ (i n + 1)/(n+1)`; `ivt_of_shrinking_brackets` then passes to the limit. The three hypotheses are discharged inline: the left endpoints lie in `[0,1]` (`div_le_one` with `Fin.isLt`), the bracket width is exactly `1/(n+1)` (`field_simp`/`ring` then `abs_of_pos`), and the endpoints have opposite signs (the chosen `hi`). This completes the interval case of Brouwer entirely on top of the 1-d Sperner lemma.",
+    "mathContext": "The finished continuous intermediate-value theorem — equivalently the interval (1-d) case of Brouwer's fixed-point theorem — reconstructed from the discrete 1-d Sperner lemma with no appeal to Mathlib's ready-made IVT. Applying it to $f = g - \\mathrm{id}$ would give the 1-d fixed-point form for continuous $g : [0,1] \\to [0,1]$. The $n$-dimensional generalization via barycentric subdivision is the blocked frontier.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "intermediate value theorem",
+      "Brouwer fixed-point theorem",
+      "Classical.choose / choose tactic",
+      "mesh refinement",
+      "Fin.isLt"
+    ],
+    "prerequisites": [
+      "exists_sign_change_bracket",
+      "ivt_of_shrinking_brackets",
+      "field_simp / ring on rationals-in-ℝ"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-simplicial-instance-oq-04/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance-oq-04/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "sperner-simplicial-instance-oq-04",
+  "title": "Continuous IVT from the 1-D Sperner Lemma (Sperner OQ-04, interval case of Brouwer)",
+  "slug": "sperner-simplicial-instance-oq-04",
+  "description": "Open-question OQ-04 from `sperner-simplicial-instance` asks to build Brouwer's fixed-point theorem on top of the 1-d Sperner lemma (`interval_sperner`) by combining it with mesh refinement and a continuous-coloring → Sperner-coloring reduction. This entry ships the explicitly-named *interval* (1-d) deliverable and completes it in full: a continuous intermediate-value theorem for `f : ℝ → ℝ` with `f 0 ≤ 0 < f 1`, derived end-to-end from the discrete 1-d Sperner lemma via a limit argument, without ever invoking Mathlib's `intermediate_value_Icc`. The reduction (`signColoring`) turns `f` into the sign 2-coloring of the mesh `{0, 1/m, …, 1}` and feeds it to the discrete IVT (`discrete_ivt_panchromatic_cell` from the sibling Scarf-1d file), producing for every mesh `m > 0` a width-`1/m` cell straddling a sign change (`exists_sign_change_cell` / `exists_sign_change_bracket`). The analytic core `ivt_of_shrinking_brackets` — stated independently of Sperner — takes the limit `m → ∞` via Bolzano–Weierstrass (`IsCompact.tendsto_subseq`) and continuity, carrying the termwise sign condition `f(a)·f(b) ≤ 0` to `(f x)² ≤ 0`, whence `f x = 0`. `exists_root_of_continuous` assembles the two into an actual root `x ∈ [0,1]`, completing the interval case of Brouwer entirely on the 1-d Sperner lemma. The remaining open item — the `n`-dimensional Brouwer derivation via barycentric subdivision (>1000 lines of missing infrastructure) — is documented as BLOCKED in the slug's research tracker and is not in this file. 0 sorries, 0 axioms, no `native_decide`.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib v4.26.0)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
+    "date": "Classical result (Sperner 1928 / Bolzano 1817); OQ-04 interval case formalized 2026-07",
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "lineCount": 206,
+    "imports": [
+      "Proofs.SpernerSimplicialInstance",
+      "Proofs.SpernerSimplicialInstanceOQ05Scarf1d"
+    ],
+    "tags": [
+      "combinatorics",
+      "topology",
+      "sperner-lemma",
+      "intermediate-value-theorem",
+      "brouwer-fixed-point",
+      "analysis",
+      "open-question",
+      "research"
+    ],
+    "assumptions": "None. All 4 theorems + 5 supporting lemmas + 2 defs proven with 0 sorries and 0 axioms, no `native_decide`. Imports `Proofs.SpernerSimplicialInstance` and `Proofs.SpernerSimplicialInstanceOQ05Scarf1d` (both 0 axioms, 0 sorries; the latter supplies the discrete 1-d intermediate-value theorem `discrete_ivt_panchromatic_cell`, transitively depending on SpernerMathlib4.lean).",
+    "proofRepoPath": "Proofs/SpernerSimplicialInstanceOQ04.lean",
+    "additionalFiles": [
+      "Proofs/SpernerSimplicialInstance.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean",
+      "Proofs/SpernerMathlib4.lean"
+    ],
+    "originalContributions": [
+      "signColoring: the continuous-coloring → Sperner-coloring reduction in 1-d — colors mesh vertex j with 0 when f(j/m) ≤ 0 and 1 otherwise",
+      "exists_sign_change_cell: discrete intermediate-value theorem for an arbitrary real f (no continuity needed) — for every mesh m > 0 a cell whose endpoints straddle a sign change of f, obtained by feeding signColoring to the 1-d Sperner discrete IVT",
+      "exists_sign_change_bracket: product form f(a)·f(b) ≤ 0 of the sign-change cell, uniform in the direction of the flip",
+      "ivt_of_shrinking_brackets: the analytic limit step stated independently of Sperner — a continuous f with sign-changing brackets of width → 0 in [0,1] has a root, via Bolzano–Weierstrass (IsCompact.tendsto_subseq) plus continuity, deliberately NOT intermediate_value_Icc",
+      "exists_root_of_continuous: continuous intermediate-value theorem derived from the 1-d Sperner lemma — for continuous f with f 0 ≤ 0 < f 1 there is a root x ∈ [0,1]"
+    ],
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Sperner's lemma (Sperner 1928) is the combinatorial heart of Brouwer's fixed-point theorem: a Sperner-colored triangulation of a simplex always contains a panchromatic (fully-colored) cell. In dimension 1 the lemma degenerates to a discrete parity statement — a 2-coloring of a path `0, 1/m, …, 1` with different endpoint colors must have an adjacent pair of opposite colors — which is the discrete skeleton of the Bolzano intermediate-value theorem (Bolzano 1817). The `sperner-simplicial-instance` program formalizes Sperner at the abstract `CellComplex` level and its concrete `Triangulation` instances; its open question OQ-04 asks to climb from the 1-d Sperner lemma back up to (a case of) Brouwer, i.e. to reconstruct an honest analytic fixed-point / root theorem on top of the purely combinatorial input, rather than importing Mathlib's ready-made `intermediate_value_Icc`. This entry answers OQ-04 for the interval (1-d) case: it exhibits the full pipeline discrete-Sperner ⇒ sign-change brackets ⇒ continuous limit ⇒ root. The `n`-dimensional case (Brouwer proper) requires barycentric subdivision of a d-simplex triangulation and is a multi-thousand-line formalization absent from Mathlib; it is recorded BLOCKED in the slug's research tracker.",
+    "problemStatement": "**OQ-04 (interval case)**: build the intermediate-value theorem — the 1-d case of Brouwer — on top of the 1-d Sperner lemma, via mesh refinement and a continuous-coloring → Sperner-coloring reduction, without invoking Mathlib's `intermediate_value_Icc`. Formalized as:\n\n`theorem exists_root_of_continuous (f : ℝ → ℝ) (hf : Continuous f) (h0 : f 0 ≤ 0) (h1 : 0 < f 1) : ∃ x ∈ Set.Icc (0 : ℝ) 1, f x = 0`\n\nderived through the Sperner-independent analytic limit\n\n`theorem ivt_of_shrinking_brackets (f : ℝ → ℝ) (hf : Continuous f) (a b : ℕ → ℝ) (ha : ∀ n, a n ∈ Set.Icc 0 1) (hwidth : ∀ n, |a n - b n| ≤ 1 / (n + 1)) (hsign : ∀ n, f (a n) * f (b n) ≤ 0) : ∃ x ∈ Set.Icc 0 1, f x = 0`.",
+    "proofStrategy": "**Step 1 (Reduction, `signColoring`)**: color mesh vertex `j` of `{0, 1/m, …, 1}` with `0` if `f (j/m) ≤ 0` and `1` otherwise. Under `f 0 ≤ 0 < f 1` the two endpoints get opposite colors (`signColoring_zero`, `signColoring_self`).\n\n**Step 2 (Discrete IVT, `exists_sign_change_cell`)**: feed `signColoring f m` to the 1-d Sperner discrete IVT `SpernerSimplicialInstanceOQ05Scarf1d.discrete_ivt_panchromatic_cell`. Opposite endpoint colors force a panchromatic cell `i : Fin m` whose two mesh endpoints straddle a sign change of `f`. No continuity is used — this is a discrete statement about an arbitrary real `f`.\n\n**Step 3 (Product form, `exists_sign_change_bracket`)**: restate the sign change uniformly as `f(i/m) · f((i+1)/m) ≤ 0` via `mul_nonpos_iff`.\n\n**Step 4 (Analytic limit, `ivt_of_shrinking_brackets`)**: given brackets `[a n, b n] ⊆ [0,1]` of width `≤ 1/(n+1)` with `f(a n)·f(b n) ≤ 0`, apply Bolzano–Weierstrass `isCompact_Icc.tendsto_subseq` to extract `a ∘ φ → x`. The vanishing widths (`squeeze_zero_norm` against `tendsto_one_div_add_atTop_nhds_zero_nat`) force `b ∘ φ → x` too. Continuity carries both subsequences to `f x`, so `f(a)·f(b) ≤ 0` passes to the limit as `(f x)² ≤ 0` (`le_of_tendsto'`); with `mul_self_nonneg` this gives `f x = 0`.\n\n**Step 5 (Assembly, `exists_root_of_continuous`)**: for each `n` take mesh `m = n+1`, `choose` the bracket from `exists_sign_change_bracket`, verify the three hypotheses of `ivt_of_shrinking_brackets` (endpoints in `[0,1]`; width exactly `1/(n+1)` via `field_simp`/`ring`; opposite signs), and conclude a root `x ∈ [0,1]`.",
+    "keyInsights": [
+      "**The reduction is the whole idea**: `signColoring` is the bridge from analysis to combinatorics. Once a continuous `f` is converted to a mesh 2-coloring, the *existence* of a sign-changing cell is pure Sperner parity — no analysis. Continuity re-enters only at the very end, to upgrade 'arbitrarily fine sign brackets' to 'an exact root'.",
+      "**Discrete-Sperner content is continuity-free**: `exists_sign_change_cell` and `exists_sign_change_bracket` hold for *any* `f : ℝ → ℝ` with `f 0 ≤ 0 < f 1`, continuous or not. This cleanly isolates the combinatorial half of the IVT from the analytic half.",
+      "**The analytic core is deliberately Sperner-agnostic**: `ivt_of_shrinking_brackets` takes abstract sequences `a, b` and knows nothing about meshes or colorings. It is exactly the Bolzano–Weierstrass argument, and would serve any other source of shrinking sign brackets (bisection, regula falsi, …). This separation makes the analytic step reusable and independently checkable.",
+      "**`intermediate_value_Icc` is deliberately avoided**: the point of OQ-04 is to *reconstruct* the IVT from Sperner, so importing Mathlib's connectedness-based `intermediate_value_Icc` would defeat the exercise. The proof instead routes through compactness (`IsCompact.tendsto_subseq`) plus the discrete lemma — an honest, independent derivation.",
+      "**Sign condition survives the limit as a square**: the elegant closing move is that `f(a n)·f(b n) ≤ 0` with both factors converging to the same value `f x` yields `(f x)² ≤ 0`; since squares are nonnegative, `f x = 0`. This sidesteps any case split on which endpoint is positive.",
+      "**Interval case is genuinely complete; n-d is genuinely blocked**: the honest scope is that this closes the 1-d deliverable named in OQ-04, with 0 axioms. The full n-dimensional Brouwer needs barycentric subdivision of simplicial triangulations, which Mathlib lacks and which is a >1000-line build — correctly kept BLOCKED rather than faked with enumeration."
+    ],
+    "prerequisites": [
+      "The 1-d Sperner discrete intermediate-value theorem (discrete_ivt_panchromatic_cell, SpernerSimplicialInstanceOQ05Scarf1d.lean)",
+      "Bolzano–Weierstrass / sequential compactness of [0,1] (IsCompact.tendsto_subseq)",
+      "Convergence of 1/(n+1) → 0 and the squeeze theorem (squeeze_zero_norm)",
+      "Continuity as sequential continuity (Continuous.tendsto) and limits of products (Tendsto.mul, le_of_tendsto')"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sperner-simplicial-instance",
+      "relationship": "extends",
+      "description": "Answers OQ-04 from the parent `sperner-simplicial-instance` (\"build Brouwer on top of the 1-d Sperner lemma via mesh refinement and a continuous→Sperner coloring reduction\"), delivering the explicitly-named interval (1-d) case in full."
+    },
+    {
+      "targetId": "sperner-simplicial-instance-oq-05",
+      "relationship": "depends-on",
+      "description": "Consumes `discrete_ivt_panchromatic_cell` from the sibling OQ-05 Scarf-1d file (SpernerSimplicialInstanceOQ05Scarf1d.lean): the literal 1-d Scarf door-walk that supplies the panchromatic cell fed by `signColoring`."
+    },
+    {
+      "targetId": "sperner-mathlib4",
+      "relationship": "depends-on",
+      "description": "Transitively rests on the abstract Sperner framework `SpernerMathlib4.CellComplex` and the 1-d Sperner lemma it feeds into the discrete intermediate-value theorem."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "applies-to",
+      "description": "Sperner's lemma is the combinatorial route to Brouwer's fixed-point theorem; this entry realizes the 1-d (interval) case of that route as a continuous intermediate-value theorem, the base case of the barycentric-subdivision ladder toward general Brouwer."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.SpernerSimplicialInstance",
+      "Proofs.SpernerSimplicialInstanceOQ05Scarf1d"
+    ],
+    "namespace": "SpernerSimplicialInstanceOQ04",
+    "lineCount": 206,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/SpernerSimplicialInstanceOQ04.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SpernerSimplicialInstance.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean",
+      "Proofs/SpernerMathlib4.lean"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-overview",
+      "title": "Overview: continuous IVT from the 1-d Sperner lemma (OQ-04 interval case)",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "The header states the honest scope: this file formalizes the interval (1-d) deliverable of OQ-04 — build Brouwer's fixed-point theorem on top of the 1-d Sperner lemma. The pipeline is discrete-Sperner ⇒ sign-change brackets ⇒ continuous limit ⇒ root, culminating in a continuous intermediate-value theorem that deliberately does NOT use Mathlib's `intermediate_value_Icc`. The n-dimensional Brouwer derivation via barycentric subdivision is explicitly out of scope and recorded BLOCKED. 0 sorries, 0 axioms.",
+      "mathContext": "In 1-d, Sperner's lemma is the discrete skeleton of the intermediate-value theorem: a 2-coloring of a mesh with different endpoint colors must contain an adjacent opposite-colored pair. OQ-04 asks to reconstruct the analytic IVT from this combinatorial input rather than importing it. The file isolates the combinatorial half (sign-change cells, continuity-free) from the analytic half (Bolzano–Weierstrass limit)."
+    },
+    {
+      "id": "sec-reduction",
+      "title": "The continuous→Sperner coloring reduction: meshPt and signColoring (L46–75)",
+      "startLine": 46,
+      "endLine": 75,
+      "summary": "`meshPt m j = j/m` names the mesh `{0, 1/m, …, 1}`; `signColoring f m` is the 2-coloring sending vertex `j` to `0` when `f (j/m) ≤ 0` and `1` otherwise. The endpoint lemmas `signColoring_zero` (left endpoint is 0 when `f 0 ≤ 0`) and `signColoring_self` (right endpoint is 1 when `0 < f 1`, using `meshPt_self : meshPt m m = 1`) establish that under `f 0 ≤ 0 < f 1` the two ends receive opposite colors — the Sperner boundary condition.",
+      "mathContext": "The reduction is the analysis→combinatorics bridge: a continuous function becomes a discrete 2-coloring of the interval mesh. The opposite endpoint colors are exactly the 1-d Sperner boundary hypothesis that forces a panchromatic (sign-changing) cell."
+    },
+    {
+      "id": "sec-discrete-ivt",
+      "title": "Discrete IVT for a real function: exists_sign_change_cell and exists_sign_change_bracket (L77–113)",
+      "startLine": 77,
+      "endLine": 113,
+      "summary": "`exists_sign_change_cell`: for any `f` with `f 0 ≤ 0 < f 1` and any mesh `m > 0`, feeding `signColoring f m` to the 1-d Sperner discrete IVT `discrete_ivt_panchromatic_cell` yields a cell `i : Fin m` whose endpoints `i/m` and `(i+1)/m` straddle a sign change of `f`. No continuity is used. `exists_sign_change_bracket` restates this uniformly as the product inequality `f(i/m)·f((i+1)/m) ≤ 0` via `mul_nonpos_iff`.",
+      "mathContext": "This is the combinatorial half of the intermediate-value theorem, valid for an arbitrary real `f` (continuity irrelevant). It converts the Sperner parity guarantee into an explicit, arbitrarily-fine bracket across which `f` changes sign — the discrete input to the analytic limit."
+    },
+    {
+      "id": "sec-analytic-limit",
+      "title": "The analytic limit, stated independently of Sperner: ivt_of_shrinking_brackets (L115–162)",
+      "startLine": 115,
+      "endLine": 162,
+      "summary": "For a continuous `f` and abstract sequences `a, b` with `a n ∈ [0,1]`, width `|a n − b n| ≤ 1/(n+1)`, and `f(a n)·f(b n) ≤ 0`, there is a root of `f` in `[0,1]`. Proof: Bolzano–Weierstrass `isCompact_Icc.tendsto_subseq` extracts `a ∘ φ → x`; `squeeze_zero_norm` against `tendsto_one_div_add_atTop_nhds_zero_nat` forces `b ∘ φ → x`; continuity gives `f(a∘φ), f(b∘φ) → f x`, so `f(a)·f(b) ≤ 0` passes to `(f x)² ≤ 0` via `le_of_tendsto'`, and `mul_self_nonneg` closes `f x = 0`. Mathlib's `intermediate_value_Icc` is not used.",
+      "mathContext": "The analytic core, deliberately decoupled from Sperner: it consumes only 'shrinking sign brackets' and produces a root. This is the Bolzano–Weierstrass proof of the IVT via sequential compactness, reusable for any bisection-style bracket source and independently verifiable."
+    },
+    {
+      "id": "sec-continuous-ivt",
+      "title": "Continuous IVT derived from Sperner: exists_root_of_continuous (L164–204)",
+      "startLine": 164,
+      "endLine": 204,
+      "summary": "For continuous `f` with `f 0 ≤ 0 < f 1`, there is a root `x ∈ [0,1]`. For each `n`, mesh `m = n+1` and `exists_sign_change_bracket` give a width-`1/(n+1)` sign bracket; `choose` extracts the sequences and `ivt_of_shrinking_brackets` passes to the limit. The three hypotheses are discharged inline: endpoints in `[0,1]` (`div_le_one`, `Fin.isLt`), width exactly `1/(n+1)` (`field_simp`/`ring` + `abs`), and opposite signs. This completes the 1-d case of Brouwer entirely on top of the 1-d Sperner lemma.",
+      "mathContext": "The assembled continuous intermediate-value theorem — the interval case of Brouwer's fixed-point theorem — proven from the discrete 1-d Sperner lemma without any appeal to Mathlib's connectedness-based IVT. The n-dimensional generalization via barycentric subdivision is the (blocked) frontier recorded in the research tracker."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified 206-line derivation of the continuous intermediate-value theorem from the discrete 1-d Sperner lemma: 4 theorems + 5 supporting lemmas + 2 defs, 0 sorries, 0 axioms, no `native_decide`. The continuous-coloring → Sperner-coloring reduction (`signColoring`) converts a real function into a mesh 2-coloring; the 1-d Sperner discrete IVT yields arbitrarily-fine sign brackets; a Sperner-independent Bolzano–Weierstrass limit (`ivt_of_shrinking_brackets`) turns them into an exact root. Mathlib's `intermediate_value_Icc` is deliberately never invoked.",
+    "implications": "OQ-04's interval deliverable is complete and axiom-free: Brouwer's fixed-point theorem can be reconstructed from the 1-d Sperner lemma in the base dimension. The clean separation of the combinatorial half (continuity-free sign-change cells) from the analytic half (reusable shrinking-bracket limit) is the reusable structure; any finer-mesh bracket source plugs into the same analytic core. The n-dimensional generalization requires barycentric subdivision of d-simplex triangulations — >1000 lines of infrastructure absent from Mathlib — and is correctly kept BLOCKED rather than approximated by enumeration.",
+    "openQuestions": [
+      "n-dimensional Brouwer: replace `intervalTriangulation` with a d-simplex triangulation plus barycentric refinement, and run the same reduction ⇒ Sperner ⇒ limit pipeline. Blocked on missing Mathlib barycentric-subdivision infrastructure (>1000 lines); tracked in the slug's research notes.",
+      "Fixed-point (not just root) form in 1-d: derive `∃ x ∈ [0,1], g x = x` for continuous `g : [0,1] → [0,1]` as an immediate corollary by applying `exists_root_of_continuous` to `f = g − id`, making the Brouwer-in-1-d statement explicit.",
+      "Quantitative / constructive rate: `ivt_of_shrinking_brackets` currently extracts an abstract subsequence via compactness. A bisection variant would give an explicit modulus (root located to width `1/2^k` in `k` steps), turning the existence proof into a computable root-finder.",
+      "Reuse the analytic core: feed `ivt_of_shrinking_brackets` from a non-Sperner bracket source (regula falsi, Brouwer degree) to confirm the decoupling and to compare derivations of the same IVT."
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/sperner-simplicial-instance-oq-04.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "sperner-simplicial-instance-oq-04",
   "title": "Build a Brouwer-fixed-point theorem on top of this: combine `interval_sperner...",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -31,13 +31,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT (S2, researcher-7): the continuous 1-d intermediate-value theorem is now formalized and MACHINE-BUILT in proofs/Proofs/SpernerSimplicialInstanceOQ04.lean (docker build OK, 237s). Added ivt_of_shrinking_brackets (Sperner-independent analytic limit: sign-changing brackets of width->0 in [0,1] + continuity => a root, via Bolzano-Weierstrass, deliberately NOT Mathlib intermediate_value_Icc) and exists_root_of_continuous (continuous IVT for f 0<=0<f 1, derived discrete-Sperner -> sign brackets -> limit). Discharges the ACT-next item from the prior session and completes the 1-d (interval) case of Brouwer on top of the 1-d Sperner lemma. Still 0 sorries, 0 axioms, no native_decide. Remaining OPEN: n-d Brouwer via barycentric subdivision (>1000 lines, BLOCKED).",
+    "progressSummary": "COMPLETE (interval case): continuous IVT from 1-d Sperner lemma is verified (0 sorries/0 axioms, docker build OK 7.3s) AND now landed in the gallery (meta.json + annotations.json, validator-clean). exists_root_of_continuous derives a root of continuous f with f0<=0<f1 via signColoring reduction -> discrete Sperner sign brackets -> Bolzano-Weierstrass limit, deliberately not using intermediate_value_Icc. n-d Brouwer remains BLOCKED and is recorded as an openQuestion.",
     "builtItems": [
       "signColoring/meshPt + signColoring_apply/_zero/_self (SpernerSimplicialInstanceOQ04.lean): the continuous-coloring -> Sperner-coloring reduction in 1-d",
       "exists_sign_change_cell (OQ04.lean): discrete IVT for real f -- for every mesh m>0 a width-1/m cell straddles a sign change, via OQ05Scarf1d.discrete_ivt_panchromatic_cell on the sign coloring",
       "exists_sign_change_bracket (OQ04.lean): product form f(a)*f(b) <= 0 of the sign-change cell",
       "ivt_of_shrinking_brackets (SpernerSimplicialInstanceOQ04.lean): analytic core, Sperner-independent — continuous f with sign-changing brackets of width->0 in [0,1] has a root, via IsCompact.tendsto_subseq (Bolzano-Weierstrass) + continuity, NOT via Mathlib intermediate_value_Icc",
-      "exists_root_of_continuous (SpernerSimplicialInstanceOQ04.lean): the continuous 1-d IVT for f 0 <= 0 < f 1, derived discrete-Sperner -> sign brackets -> limit; completes the interval (1-d) case of Brouwer on top of the 1-d Sperner lemma"
+      "exists_root_of_continuous (SpernerSimplicialInstanceOQ04.lean): the continuous 1-d IVT for f 0 <= 0 < f 1, derived discrete-Sperner -> sign brackets -> limit; completes the interval (1-d) case of Brouwer on top of the 1-d Sperner lemma",
+      "src/data/proofs/sperner-simplicial-instance-oq-04/meta.json (verified, 0-axiom, 4 thm + 5 lemma + 2 def, 206 lines)",
+      "src/data/proofs/sperner-simplicial-instance-oq-04/annotations.json (5 annotations, validator-clean)"
     ],
     "insights": [
       "oq-04 decomposes into (a) discrete sign-change [DONE here, corollary of OQ05 discrete_ivt], (b) continuous 1-d IVT via mesh refinement + Bolzano-Weierstrass [moderate, ~150 lines], (c) n-d Brouwer via barycentric subdivision + sperner-ndim [>1000 lines, BLOCKED].",
@@ -45,7 +47,8 @@
       "Discrete statement needs NO continuity: sign coloring c(j)=if f(j/m)<=0 then 0 else 1 has c(0)=0,c(m)=1 from f(0)<=0<f(1), and discrete_ivt yields a sign change. Continuity is only needed for the m->inf limit to an exact root.",
       "Cert verify_sperner_oq04_bridge.py (transcendental root x-cos x, irrational cubic root, and a multi-root cubic): sign-change cell exists & brackets a true root for every mesh; |f(midpoint)| -> 0 at rate <= L*(1/m).",
       "CONTINUOUS LIMIT STEP DONE (2026-07-02, researcher-7): the m->inf limit the prior session left open is now formalized and machine-built. Decomposition that worked: state the analysis abstractly (ivt_of_shrinking_brackets: brackets width->0 + continuity => root) decoupled from Sperner, then a short assembly feeds it the exists_sign_change_bracket mesh brackets. Key Mathlib: isCompact_Icc.tendsto_subseq, squeeze_zero_norm, tendsto_one_div_add_atTop_nhds_zero_nat pinned to the real field, le_of_tendsto, mul_self_eq_zero.",
-      "GOTCHA: tendsto_one_div_add_atTop_nhds_zero_nat is generic over the field with a ContinuousSMul NNRat instance; simpa-using it leaves the field a metavariable (stuck ContinuousSMul NNRat ?m). Fix: term-mode with an explicit field-type argument so unification pins it to the reals."
+      "GOTCHA: tendsto_one_div_add_atTop_nhds_zero_nat is generic over the field with a ContinuousSMul NNRat instance; simpa-using it leaves the field a metavariable (stuck ContinuousSMul NNRat ?m). Fix: term-mode with an explicit field-type argument so unification pins it to the reals.",
+      "Gallery entry landed: the completed 0-axiom interval-case proof (PR #33652) was orphaned (no gallery dir, and Proofs.lean is now glob-auto-discovered so no manual registration was ever needed). Created src/data/proofs/sperner-simplicial-instance-oq-04/ with meta.json + 5 annotations; both pass annotations:validate and gallery:check-size:strict."
     ],
     "mathlibGaps": [
       "No packaged Sperner->Brouwer bridge in Mathlib; Brouwer exists but is not derived from a discrete Sperner lemma.",
@@ -53,9 +56,9 @@
       "n-d barycentric subdivision / mesh-shrinking for the cube [0,1]^n is not available as reusable infra."
     ],
     "nextSteps": [
-      "ACT next: prove continuous 1-d IVT from exists_sign_change_bracket -- take a_m = meshPt m i_m (bracket left ends), extract convergent subsequence via tendsto_subseq_of_bounded on [0,1], pass continuity through to get f(x*)=0; use intermediate_value_Icc only as cross-check, not the derivation.",
-      "Then n-d: replace intervalTriangulation with sperner-ndim's d-simplex triangulation + barycentric refinement; the >1000-line blocked remainder -- keep BLOCKED until 1-d limit lands.",
-      "Build pending (docker backend blackout this session); file intentionally UNREGISTERED in Proofs.lean to avoid breaking auto-merge until CI verifies."
+      "1-d fixed-point corollary: apply exists_root_of_continuous to f = g - id to state Brouwer-in-1-d for continuous g:[0,1]->[0,1] (few lines, high value, currently only a root theorem).",
+      "Quantitative bisection variant of ivt_of_shrinking_brackets giving an explicit modulus (root to width 1/2^k in k steps) -> computable root-finder.",
+      "n-d Brouwer via barycentric subdivision remains BLOCKED (>1000 lines, Mathlib lacks the infrastructure); keep documented as openQuestion, do not attempt."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

The **interval (1-d) case of `sperner-simplicial-instance-oq-04`** — a continuous intermediate-value theorem derived end-to-end from the discrete 1-d Sperner lemma — was already verified on `main` (PR #33652: **0 sorries, 0 axioms**, `docker-build.sh` ✔ 7.3s this session) but was **orphaned**: it had no `src/data/proofs/` gallery entry, so the result was invisible in the web gallery. (The historical "unregistered in `Proofs.lean`" note is moot — modules are now auto-discovered via the Lake `globs` directive, so the file already builds in CI.)

This PR adds the missing gallery entry so the completed result is surfaced.

## What's the math

`exists_root_of_continuous`: for continuous `f : ℝ → ℝ` with `f 0 ≤ 0 < f 1`, there is a root `x ∈ [0,1]` — proven **without** Mathlib's `intermediate_value_Icc`:

1. `signColoring` reduces `f` to the sign 2-coloring of the mesh `{0, 1/m, …, 1}` (the continuous→Sperner coloring reduction).
2. `exists_sign_change_cell` / `exists_sign_change_bracket` feed it to the 1-d Sperner discrete IVT (`discrete_ivt_panchromatic_cell`), giving a width-`1/m` sign bracket for every mesh — **continuity-free**.
3. `ivt_of_shrinking_brackets` takes the limit `m → ∞` via Bolzano–Weierstrass (`IsCompact.tendsto_subseq`) + continuity, carrying `f(a)·f(b) ≤ 0` to `(f x)² ≤ 0`, hence `f x = 0`.

## Files

- `src/data/proofs/sperner-simplicial-instance-oq-04/meta.json` (new) — verified/original, 0 axioms, 4 theorems + 5 lemmas + 2 defs, 206 lines.
- `src/data/proofs/sperner-simplicial-instance-oq-04/annotations.json` (new) — 5 annotations.
- `src/data/research/problems/sperner-simplicial-instance-oq-04.json` — knowledge + phase ACT → COMPLETED.
- `research/problems/sperner-simplicial-instance-oq-04/knowledge.md` — session log.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialInstanceOQ04` → `✔ Built (7.3s)`, 0 sorries / 0 axioms / no `native_decide`.
- `pnpm annotations:validate` — entry clean.
- `pnpm gallery:check-size:strict` — entry passes (20 KB, smaller than sibling oq-05).

## Scope / honesty

This closes the **interval (1-d)** deliverable named in OQ-04. The **n-dimensional** Brouwer derivation via barycentric subdivision (>1000 lines, absent from Mathlib) remains genuinely BLOCKED and is recorded as an `openQuestion` in the entry — not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)