### PR TITLE
sperner-ndim-oq-02 s19: exact top-miss height of facet-0 partner + explicit descent length

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -3147,4 +3147,41 @@ theorem zeroPivotCell_feasible_iff_base_miss_ge (s : GridSimplex d N) (hd1 : 0 <
   have hge := s.base_miss_ge_d
   omega
 
+/-- **Exact top-`miss` height of the facet-`0` partner.**  Sharpens the iff-form
+`zeroPivotCell_feasible_iff_base_miss_ge` to an exact value: the partner cell's
+top vertex sits exactly `d + 1` below `s`'s base vertex in the shared `miss`
+direction.  Its top vertex is `zeroPivotTop`, one below the top of `s`'s chain
+(`zeroPivotTop_coords_miss`), and that chain-top is `base_miss − d`
+(`last_coord_miss`); so the new apex is pinned to a definite height.  Together
+with `zeroPivotCell_base_miss` (partner base = `base_miss − 1`) this makes the
+`base_miss` descent fully quantitative rather than merely monotone: the whole
+partner cell is a `miss`-shifted copy of `s`'s upper chain capped one step lower. -/
+theorem zeroPivotCell_top_miss (s : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (s.verts (Fin.last d)).coords s.miss) :
+    ((zeroPivotCell s hd1 hfeas).verts (Fin.last d)).coords
+        (zeroPivotCell s hd1 hfeas).miss
+      = (s.verts 0).coords s.miss - (d + 1) := by
+  rw [zeroPivotCell_miss, zeroPivotCell_verts_last, zeroPivotTop_coords_miss,
+      s.last_coord_miss]
+  omega
+
+/-- **The facet-`0` pivot chain reaches the boundary door in exactly one more
+step from a `base_miss = d + 1` cell.**  The partner cell `zeroPivotCell s` is
+itself the *extremal* cell of the descent — its own same-`miss` facet-`0` pivot is
+infeasible (top vertex already on the geometric `miss`-face) — exactly when `s`'s
+base `miss` coordinate is `d + 1`, one above the floor `d`.  Combined with
+`zeroPivotCell_base_miss` (each pivot lowers `base_miss` by one) and
+`base_miss_ge_d` (floor `d`), this pins the descent length: from a cell with base
+`miss = m` the same-`miss` facet-`0` pivot fires exactly `m − d` times before
+halting at the extremal cell whose top vertex sits on the `miss`-face — the
+terminal door where the cross-`miss` partner must attach. -/
+theorem zeroPivotCell_extremal_iff_base_miss_eq (s : GridSimplex d N) (hd1 : 0 < d)
+    (hfeas : 1 ≤ (s.verts (Fin.last d)).coords s.miss) :
+    ¬ (1 ≤ ((zeroPivotCell s hd1 hfeas).verts (Fin.last d)).coords
+              (zeroPivotCell s hd1 hfeas).miss)
+      ↔ (s.verts 0).coords s.miss = d + 1 := by
+  rw [zeroPivotCell_top_miss]
+  have hfe := (zeroPivot_feasible_iff s).mp hfeas
+  omega
+
 end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,8 +4,14 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 17
+**Iteration**: 19
 
+> **Session 19 (2026-07-04, researcher-11): exact top-`miss` height of the facet-`0` partner + explicit descent length (VERIFIED 0-axiom, `docker-build.sh Proofs.SpernerNDimOQ02` exit 0, 7745 jobs).** Upgraded Session 18's *iff-form* pivot-feasibility lemmas to **exact coordinate formulas**, making the `base_miss` descent quantitative. Added 2 theorems (+43 L) to `SpernerNDimOQ02.lean`:
+> - `zeroPivotCell_top_miss` — the partner cell's top vertex sits *exactly* `d + 1` below `s`'s base in the shared `miss` direction: `top miss = base_miss − (d + 1)`. Sharpens S18's iff-form `zeroPivotCell_feasible_iff_base_miss_ge` to a definite value; the whole partner is a `miss`-shifted copy of `s`'s upper chain capped one step lower.
+> - `zeroPivotCell_extremal_iff_base_miss_eq` — the partner is *itself* the terminal boundary-door cell (own facet-`0` pivot infeasible) ⟺ `base_miss = d + 1`. With `zeroPivotCell_base_miss` (step −1) + `base_miss_ge_d` (floor `d`) this pins the descent length: from base `miss = m` the same-`miss` facet-`0` pivot fires exactly `m − d` times before halting at the extremal cell whose top vertex lies on the geometric `miss`-face — where the cross-`miss` partner (crux 2) must attach. **Frontier UNCHANGED** (dual top-facet pivot involution + cross-`miss` terminal partner). Docker channel RESTORED this session. File 3150 → 3193 L. PR #34636 (research/sperner-ndim-oq02-top-miss-exact, stacked on S18's #34635).
+>
+> **Session 18 (2026-07-04, researcher-11): facet-`0` pivot miss-descent + termination at boundary door (VERIFIED 0-axiom, docker exit 0, 7745 jobs).** 4 theorems characterizing the same-`miss` facet-`0` pivot as a finite monotone `base_miss` descent: `zeroPivotCell_base_miss` (partner base = `base_miss − 1`), `zeroPivotCell_base_miss_lt` (strict), `zeroPivot_infeasible_iff_base_miss_eq_d` (halts ⟺ `base_miss = d`), `zeroPivotCell_feasible_iff_base_miss_ge` (re-feasible ⟺ `base_miss ≥ d+2`). PR #34635 (research/sperner-ndim-oq02-miss-descent).
+>
 > **Session 17 (2026-07-04, researcher-11): facet-`0` gluing site proven to be a pseudomanifold-local TWO-CELL MEETING (VERIFIED 0-axiom, `docker-build.sh Proofs.SpernerNDimOQ02` exit 0, 7745 jobs).** Built directly on Session 16's `zeroPivotCell` (the facet-`0` cross-chain partner, feasible regime). Added 3 theorems (+~75 L) to `SpernerNDimOQ02.lean` proving `s` and `zeroPivotCell` intersect in EXACTLY the shared facet:
 > - `gridVertices_zero_not_mem_zeroPivotCell_image` — `s`'s deleted apex `gridVertices s 0` is absent from the partner's whole vertex set (chain injectivity kills the reused lower vertices; `zeroPivotTop_not_mem_chain` kills the new apex).
 > - `zeroPivotCell_apex_not_mem_s_image` — dually, the partner's apex (Kuhn image of `zeroPivotTop`) is absent from `s`'s vertex set.


### PR DESCRIPTION
## sperner-ndim-oq-02 — Session 19 (researcher-11)

Upgrades Session 18's *iff-form* facet-`0` pivot feasibility lemmas to **exact coordinate formulas**, making the `base_miss` descent fully quantitative.

**+2 theorems, 0-sorry, 0-axiom.** `docker-build.sh Proofs.SpernerNDimOQ02` → exit 0, 7745 jobs.

### What's new
Built on the Session 16/17 `zeroPivotCell` (facet-`0` cross-chain partner, feasible regime) and Session 18's monotone `base_miss` descent:

- **`zeroPivotCell_top_miss`** — the partner cell's top vertex sits *exactly* `d + 1` below `s`'s base vertex in the shared `miss` direction: `((zeroPivotCell s).verts (last)).coords miss = base_miss − (d + 1)`. Sharpens the iff-form `zeroPivotCell_feasible_iff_base_miss_ge` to an exact value (top vertex is `zeroPivotTop`, one below the chain-top `base_miss − d`).
- **`zeroPivotCell_extremal_iff_base_miss_eq`** — the partner cell is *itself* the terminal (boundary-door) cell of the descent — its own same-`miss` facet-`0` pivot is infeasible — exactly when `base_miss = d + 1`, one above the floor `d`. Combined with `zeroPivotCell_base_miss` (each pivot lowers `base_miss` by one) this pins the **descent length to `base_miss − d` steps**, halting at the extremal cell whose top vertex sits on the geometric `miss`-face — the terminal door where the cross-`miss` partner must attach.

### Frontier (unchanged crux)
1. Dual top-facet pivot (mirror across facet `Fin.last d`) → involution reciprocity.
2. Cross-`miss` terminal partner for the extremal `base_miss = d` cell.
Then assemble total `adj`; Phase-2 door-oddness induction on `d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)