### PR TITLE
Oppermann (legendre-partial-oq-04): π-counting form of the conjecture (0-axiom bridge)

### DIFF
--- a/proofs/Proofs/LegendrePartialOQ04.lean
+++ b/proofs/Proofs/LegendrePartialOQ04.lean
@@ -141,21 +141,25 @@ theorem card_primes_Ioc {a b : ℕ} (hab : a ≤ b) :
     simp only [Nat.primeCounting, Nat.primeCounting']
     rw [Nat.count_eq_card_filter_range]
   rw [key a, key b]
-  have hsub : (Finset.range (a + 1)).filter Nat.Prime ⊆
-      (Finset.range (b + 1)).filter Nat.Prime :=
-    Finset.filter_subset_filter _ (Finset.range_subset.mpr (by omega))
-  rw [← Finset.card_sdiff hsub]
-  congr 1
-  ext x
-  simp only [Finset.mem_sdiff, Finset.mem_filter, Finset.mem_range, Finset.mem_Ioc]
-  constructor
-  · rintro ⟨⟨hxb, hpx⟩, hx⟩
-    have hax : a < x := by
-      by_contra h
-      exact hx ⟨by omega, hpx⟩
-    exact ⟨⟨hax, by omega⟩, hpx⟩
-  · rintro ⟨⟨hax, hxb⟩, hpx⟩
-    exact ⟨⟨by omega, hpx⟩, fun h => absurd h.1 (by omega)⟩
+  have hdisj : Disjoint ((Finset.range (a + 1)).filter Nat.Prime)
+      ((Finset.Ioc a b).filter Nat.Prime) := by
+    apply Finset.disjoint_left.mpr
+    intro x hx hx'
+    simp only [Finset.mem_filter, Finset.mem_range] at hx
+    simp only [Finset.mem_filter, Finset.mem_Ioc] at hx'
+    obtain ⟨hx1, _⟩ := hx
+    obtain ⟨⟨hx2, _⟩, _⟩ := hx'
+    omega
+  have hunion : ((Finset.range (a + 1)).filter Nat.Prime) ∪
+      ((Finset.Ioc a b).filter Nat.Prime) = (Finset.range (b + 1)).filter Nat.Prime := by
+    rw [← Finset.filter_union]
+    congr 1
+    ext x
+    simp only [Finset.mem_union, Finset.mem_range, Finset.mem_Ioc]
+    omega
+  have hcard := Finset.card_union_of_disjoint hdisj
+  rw [hunion] at hcard
+  omega
 
 /-- Removing a **non-prime** right endpoint does not change the prime count:
 `#{primes in (a, b)} = #{primes in (a, b]}` when `b` is composite. -/

--- a/proofs/Proofs/LegendrePartialOQ04.lean
+++ b/proofs/Proofs/LegendrePartialOQ04.lean
@@ -31,6 +31,13 @@ New content here:
   * `oppermann_implies_legendre`, `oppermann_implies_two_primes` — the
     conjecture-level corollaries.  VERIFIED, 0-axiom (they take the conjecture
     as a hypothesis; they do not assert it).
+  * `card_primes_Ioc` — the number of primes in `(a, b]` equals `π(b) − π(a)` for
+    Mathlib's `Nat.primeCounting`.  VERIFIED, 0-axiom.
+  * `oppermann_at_iff_pi`, `oppermann_conjecture_iff_pi` — Oppermann in
+    **π-counting form**: for `n ≥ 2`, `OppermannAt n ⟺ π(n²+n) − π(n²) ≥ 1 ∧
+    π((n+1)²) − π(n²+n) ≥ 1` (the composite endpoints `n²+n` and `(n+1)²` make the
+    half-open `π`-difference count exactly the open-interval primes).  VERIFIED,
+    0-axiom.
   * `oppermann_2, …, oppermann_20` — `OppermannAt n` checked with explicit
     witnesses for `n = 2, …, 20` by `native_decide`.
   * `oppermann_conjecture` — the open conjecture stated as an `axiom`.
@@ -114,6 +121,109 @@ theorem oppermann_implies_two_primes (h : OppermannConjecture) :
       2 ≤ ((Finset.Ioo (n ^ 2) ((n + 1) ^ 2)).filter Nat.Prime).card :=
   fun n hn => oppermann_at_two_primes (h n hn)
 
+/-! ## π-counting form (VERIFIED, 0-axiom)
+
+Bridging the interval-existence statement to Mathlib's prime-counting function
+`Nat.primeCounting` (`π(n) = #{p ≤ n : p prime}`).  The number of primes in a
+half-open interval is exactly a difference of `π` values, and Oppermann's
+conjecture becomes a pair of lower bounds on such differences.  All lemmas here
+are elementary and fully machine-checked with no axioms. -/
+
+open Nat (primeCounting)
+
+/-- **Prime count of an interval as a difference of `π`.** For `a ≤ b`, the number
+of primes in the half-open interval `(a, b]` equals `π(b) − π(a)`. -/
+theorem card_primes_Ioc {a b : ℕ} (hab : a ≤ b) :
+    ((Finset.Ioc a b).filter Nat.Prime).card = primeCounting b - primeCounting a := by
+  have key : ∀ m : ℕ,
+      primeCounting m = ((Finset.range (m + 1)).filter Nat.Prime).card := by
+    intro m
+    simp only [Nat.primeCounting, Nat.primeCounting']
+    rw [Nat.count_eq_card_filter_range]
+  rw [key a, key b]
+  have hsub : (Finset.range (a + 1)).filter Nat.Prime ⊆
+      (Finset.range (b + 1)).filter Nat.Prime :=
+    Finset.filter_subset_filter _ (Finset.range_subset.mpr (by omega))
+  rw [← Finset.card_sdiff hsub]
+  congr 1
+  ext x
+  simp only [Finset.mem_sdiff, Finset.mem_filter, Finset.mem_range, Finset.mem_Ioc]
+  constructor
+  · rintro ⟨⟨hxb, hpx⟩, hx⟩
+    have hax : a < x := by
+      by_contra h
+      exact hx ⟨by omega, hpx⟩
+    exact ⟨⟨hax, by omega⟩, hpx⟩
+  · rintro ⟨⟨hax, hxb⟩, hpx⟩
+    exact ⟨⟨by omega, hpx⟩, fun h => absurd h.1 (by omega)⟩
+
+/-- Removing a **non-prime** right endpoint does not change the prime count:
+`#{primes in (a, b)} = #{primes in (a, b]}` when `b` is composite. -/
+theorem card_primes_Ioo_eq_Ioc {a b : ℕ} (hb : ¬ Nat.Prime b) :
+    ((Finset.Ioo a b).filter Nat.Prime).card
+      = ((Finset.Ioc a b).filter Nat.Prime).card := by
+  congr 1
+  ext x
+  simp only [Finset.mem_filter, Finset.mem_Ioo, Finset.mem_Ioc]
+  constructor
+  · rintro ⟨⟨hax, hxb⟩, hpx⟩; exact ⟨⟨hax, le_of_lt hxb⟩, hpx⟩
+  · rintro ⟨⟨hax, hxb⟩, hpx⟩
+    refine ⟨⟨hax, ?_⟩, hpx⟩
+    rcases lt_or_eq_of_le hxb with h | h
+    · exact h
+    · exact absurd (h ▸ hpx) hb
+
+/-- **Existence of a prime in an open interval, as a count bound.** -/
+theorem exists_prime_Ioo_iff_card {a b : ℕ} :
+    (∃ p, Nat.Prime p ∧ a < p ∧ p < b) ↔
+      1 ≤ ((Finset.Ioo a b).filter Nat.Prime).card := by
+  rw [Nat.one_le_iff_ne_zero, ne_eq, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  push_neg
+  constructor
+  · rintro ⟨p, hp, ha, hb⟩
+    exact ⟨p, Finset.mem_Ioo.mpr ⟨ha, hb⟩, hp⟩
+  · rintro ⟨p, hmem, hp⟩
+    obtain ⟨ha, hb⟩ := Finset.mem_Ioo.mp hmem
+    exact ⟨p, hp, ha, hb⟩
+
+/-- **Oppermann's conjecture at `n`, π-counting form.** For `n ≥ 2`,
+`OppermannAt n` is equivalent to the pair of prime-counting lower bounds
+`π(n²+n) − π(n²) ≥ 1` (lower half) and `π((n+1)²) − π(n²+n) ≥ 1` (upper half).
+Both half-open right endpoints `n²+n = n(n+1)` and `(n+1)²` are composite for
+`n ≥ 2`, so the half-open `π`-difference counts exactly the open-interval primes
+of `OppermannAt`. VERIFIED, 0-axiom. -/
+theorem oppermann_at_iff_pi {n : ℕ} (hn : 2 ≤ n) :
+    OppermannAt n ↔
+      (1 ≤ primeCounting (n ^ 2 + n) - primeCounting (n ^ 2)) ∧
+      (1 ≤ primeCounting ((n + 1) ^ 2) - primeCounting (n ^ 2 + n)) := by
+  have hcomp1 : ¬ Nat.Prime (n ^ 2 + n) := by
+    have h : n ^ 2 + n = n * (n + 1) := by ring
+    rw [h]; exact Nat.not_prime_mul (by omega) (by omega)
+  have hcomp2 : ¬ Nat.Prime ((n + 1) ^ 2) := by
+    have h : (n + 1) ^ 2 = (n + 1) * (n + 1) := by ring
+    rw [h]; exact Nat.not_prime_mul (by omega) (by omega)
+  have hle1 : n ^ 2 ≤ n ^ 2 + n := by omega
+  have hle2 : n ^ 2 + n ≤ (n + 1) ^ 2 := by nlinarith
+  have lower : (∃ p, Nat.Prime p ∧ n ^ 2 < p ∧ p < n ^ 2 + n) ↔
+      1 ≤ primeCounting (n ^ 2 + n) - primeCounting (n ^ 2) := by
+    rw [exists_prime_Ioo_iff_card, card_primes_Ioo_eq_Ioc hcomp1, card_primes_Ioc hle1]
+  have upper : (∃ q, Nat.Prime q ∧ n ^ 2 + n < q ∧ q < (n + 1) ^ 2) ↔
+      1 ≤ primeCounting ((n + 1) ^ 2) - primeCounting (n ^ 2 + n) := by
+    rw [exists_prime_Ioo_iff_card, card_primes_Ioo_eq_Ioc hcomp2, card_primes_Ioc hle2]
+  unfold OppermannAt
+  rw [lower, upper]
+
+/-- **Oppermann's conjecture, π-counting form.** Equivalent to: for every `n ≥ 2`,
+`π(n²+n) − π(n²) ≥ 1` and `π((n+1)²) − π(n²+n) ≥ 1`. VERIFIED, 0-axiom. -/
+theorem oppermann_conjecture_iff_pi :
+    OppermannConjecture ↔
+      ∀ n : ℕ, 2 ≤ n →
+        (1 ≤ primeCounting (n ^ 2 + n) - primeCounting (n ^ 2)) ∧
+        (1 ≤ primeCounting ((n + 1) ^ 2) - primeCounting (n ^ 2 + n)) := by
+  constructor
+  · intro h n hn; exact (oppermann_at_iff_pi hn).mp (h n hn)
+  · intro h n hn; exact (oppermann_at_iff_pi hn).mpr (h n hn)
+
 /-! ## Computational verification (axiomatized via `native_decide`)
 
 Each `OppermannAt n` is witnessed by an explicit pair (lower-half prime,
@@ -164,6 +274,14 @@ theorem). -/
 theorem two_primes_2 :
     2 ≤ ((Finset.Ioo (2 ^ 2) (3 ^ 2)).filter Nat.Prime).card :=
   oppermann_at_two_primes oppermann_2
+
+/-- π-counting sanity corollary at `n = 2`: `π(6) − π(4) ≥ 1` (lower half) and
+`π(9) − π(6) ≥ 1` (upper half), derived from the verified instance `oppermann_2`
+through the `π`-equivalence. -/
+theorem pi_bounds_2 :
+    (1 ≤ primeCounting (2 ^ 2 + 2) - primeCounting (2 ^ 2)) ∧
+    (1 ≤ primeCounting ((2 + 1) ^ 2) - primeCounting (2 ^ 2 + 2)) :=
+  (oppermann_at_iff_pi (by norm_num)).mp oppermann_2
 
 /-! ## The open conjecture -/
 

--- a/src/data/proofs/legendre-partial-oq-04/meta.json
+++ b/src/data/proofs/legendre-partial-oq-04/meta.json
@@ -37,10 +37,10 @@
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 2,
-    "lineCount": 179,
+    "lineCount": 301,
     "assumptions": "2 assumptions. (1) `oppermann_conjecture : OppermannConjecture` — the OPEN Oppermann conjecture, stated as an axiom; results downstream of it (e.g. `legendre_of_oppermann`) inherit it. (2) `Lean.ofReduceBool` — the n = 2..20 verifications use `native_decide`, which trusts the Lean compiler's kernel reduction. The four structural theorems (`oppermann_at_implies_legendre_at`, `oppermann_at_two_primes`, `oppermann_implies_legendre`, `oppermann_implies_two_primes`) are fully machine-checked with NO assumptions: #print axioms reports only propext, Classical.choice, Quot.sound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 31,
     "definitionCount": 2,
     "parentId": "legendre-partial"
   },
@@ -60,6 +60,52 @@
       "Prime numbers and decidable primality (Nat.Prime)",
       "Perfect squares and elementary interval arithmetic",
       "Finset cardinality and the prime-gap conjecture hierarchy"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring for Oppermann's conjecture (Legendre-partial OQ-04): both halves of every square-gap (n², (n+1)²), split at the composite point n²+n, contain a prime. Frames the file as honest structural implications from Oppermann plus native_decide spot-checks, with the conjecture itself left as an axiom. Imports Mathlib and the parent LegendrePartial, and works in namespace Legendre.Oppermann."
+    },
+    {
+      "id": "sec-statement",
+      "title": "Statement",
+      "startLine": 51,
+      "endLine": 64,
+      "summary": "OppermannAt n: a prime in the lower half (n², n²+n) and a prime in the upper half (n²+n, (n+1)²). OppermannConjecture: OppermannAt n for every n ≥ 2 (n = 1 excluded since the lower half (1,2) is empty)."
+    },
+    {
+      "id": "sec-structural",
+      "title": "Structural Theorems (0-axiom Implications)",
+      "startLine": 66,
+      "endLine": 115,
+      "summary": "Honest hypothesis-taking implications, none asserting Oppermann is true. oppermann_at_implies_legendre_at: the lower-half prime already witnesses Legendre at n. oppermann_at_two_primes: the distinct lower/upper primes give ≥ 2 primes in (n², (n+1)²), strengthening Legendre. The two conjecture-level forms (oppermann_implies_legendre, oppermann_implies_two_primes) lift these to all n ≥ 2 — all by elementary interval arithmetic (omega)."
+    },
+    {
+      "id": "sec-computational",
+      "title": "Computational Verification (native_decide)",
+      "startLine": 117,
+      "endLine": 166,
+      "summary": "OppermannAt n verified for 2 ≤ n ≤ 20 (oppermann_2 … oppermann_20) by exhibiting an explicit (lower-half prime, upper-half prime) pair and discharging primality/interval bounds with native_decide (which introduces the Lean.ofReduceBool axiom). two_primes_2 combines a verified instance with the 0-axiom structural theorem to conclude two primes in a concrete gap."
+    },
+    {
+      "id": "sec-open",
+      "title": "The Open Conjecture",
+      "startLine": 168,
+      "endLine": 179,
+      "summary": "oppermann_conjecture is stated as an axiom (open since 1882; strictly stronger than both Legendre's and the open Brocard conjecture). legendre_of_oppermann derives Legendre for all n ≥ 2 as a downstream consequence, inheriting the axiom."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
+    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
+    "openQuestions": [
+      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
+      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
+      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
     ]
   },
   "sections": [
@@ -96,15 +142,6 @@
       "mathContext": "$\\mathrm{oppermann\\_conjecture}:\\mathrm{OppermannConjecture}$ (declared axiom, the open case); $\\mathrm{legendre\\_of\\_oppermann}:\\forall n\\ge 2,\\ \\mathrm{LegendreAt}(n)$ inherits the assumption."
     }
   ],
-  "conclusion": {
-    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
-    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
-    "openQuestions": [
-      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
-      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
-      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
-    ]
-  },
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -170,7 +207,7 @@
     {
       "name": "oppermann_at_iff_pi",
       "type": "core",
-      "description": "VERIFIED (0-axiom): π-counting form. For n ≥ 2, OppermannAt n is equivalent to π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1, using Mathlib's Nat.primeCounting (the composite endpoints n²+n and (n+1)² make the half-open π-difference count exactly the open-interval primes).",
+      "description": "VERIFIED (0-axiom): π-counting form. For n ≥ 2, OppermannAt n is equivalent to π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1, using Mathlib's Nat.primeCounting. The composite endpoints n²+n and (n+1)² make the half-open π-difference count exactly the open-interval primes. Rests on the reusable bridge card_primes_Ioc: #{primes in (a,b]} = π(b) − π(a).",
       "leanType": "2 ≤ n -> (OppermannAt n <-> 1 ≤ primeCounting (n^2+n) - primeCounting (n^2) ∧ 1 ≤ primeCounting ((n+1)^2) - primeCounting (n^2+n))"
     }
   ],

--- a/src/data/proofs/legendre-partial-oq-04/meta.json
+++ b/src/data/proofs/legendre-partial-oq-04/meta.json
@@ -64,52 +64,6 @@
   },
   "sections": [
     {
-      "id": "sec-header",
-      "title": "Header and Imports",
-      "startLine": 1,
-      "endLine": 49,
-      "summary": "Module docstring for Oppermann's conjecture (Legendre-partial OQ-04): both halves of every square-gap (n², (n+1)²), split at the composite point n²+n, contain a prime. Frames the file as honest structural implications from Oppermann plus native_decide spot-checks, with the conjecture itself left as an axiom. Imports Mathlib and the parent LegendrePartial, and works in namespace Legendre.Oppermann."
-    },
-    {
-      "id": "sec-statement",
-      "title": "Statement",
-      "startLine": 51,
-      "endLine": 64,
-      "summary": "OppermannAt n: a prime in the lower half (n², n²+n) and a prime in the upper half (n²+n, (n+1)²). OppermannConjecture: OppermannAt n for every n ≥ 2 (n = 1 excluded since the lower half (1,2) is empty)."
-    },
-    {
-      "id": "sec-structural",
-      "title": "Structural Theorems (0-axiom Implications)",
-      "startLine": 66,
-      "endLine": 115,
-      "summary": "Honest hypothesis-taking implications, none asserting Oppermann is true. oppermann_at_implies_legendre_at: the lower-half prime already witnesses Legendre at n. oppermann_at_two_primes: the distinct lower/upper primes give ≥ 2 primes in (n², (n+1)²), strengthening Legendre. The two conjecture-level forms (oppermann_implies_legendre, oppermann_implies_two_primes) lift these to all n ≥ 2 — all by elementary interval arithmetic (omega)."
-    },
-    {
-      "id": "sec-computational",
-      "title": "Computational Verification (native_decide)",
-      "startLine": 117,
-      "endLine": 166,
-      "summary": "OppermannAt n verified for 2 ≤ n ≤ 20 (oppermann_2 … oppermann_20) by exhibiting an explicit (lower-half prime, upper-half prime) pair and discharging primality/interval bounds with native_decide (which introduces the Lean.ofReduceBool axiom). two_primes_2 combines a verified instance with the 0-axiom structural theorem to conclude two primes in a concrete gap."
-    },
-    {
-      "id": "sec-open",
-      "title": "The Open Conjecture",
-      "startLine": 168,
-      "endLine": 179,
-      "summary": "oppermann_conjecture is stated as an axiom (open since 1882; strictly stronger than both Legendre's and the open Brocard conjecture). legendre_of_oppermann derives Legendre for all n ≥ 2 as a downstream consequence, inheriting the axiom."
-    }
-  ],
-  "conclusion": {
-    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
-    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
-    "openQuestions": [
-      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
-      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
-      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
-    ]
-  },
-  "sections": [
-    {
       "id": "statement",
       "title": "Statement: OppermannAt and OppermannConjecture",
       "summary": "OppermannAt n asserts a prime in each half of the square-gap (n², (n+1)²) split at n²+n; OppermannConjecture quantifies it over all n ≥ 2",
@@ -142,6 +96,15 @@
       "mathContext": "$\\mathrm{oppermann\\_conjecture}:\\mathrm{OppermannConjecture}$ (declared axiom, the open case); $\\mathrm{legendre\\_of\\_oppermann}:\\forall n\\ge 2,\\ \\mathrm{LegendreAt}(n)$ inherits the assumption."
     }
   ],
+  "conclusion": {
+    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
+    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
+    "openQuestions": [
+      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
+      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
+      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -151,9 +114,9 @@
       "Finset"
     ],
     "namespace": "Legendre.Oppermann",
-    "lineCount": 179,
+    "lineCount": 301,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 31,
     "definitionCount": 2,
     "path": "Proofs/LegendrePartialOQ04.lean",
     "sorries": 0
@@ -203,6 +166,12 @@
       "type": "core",
       "description": "VERIFIED (0-axiom): Oppermann at n implies Legendre at n via the lower-half prime.",
       "leanType": "OppermannAt n -> Legendre.LegendreAt n"
+    },
+    {
+      "name": "oppermann_at_iff_pi",
+      "type": "core",
+      "description": "VERIFIED (0-axiom): π-counting form. For n ≥ 2, OppermannAt n is equivalent to π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1, using Mathlib's Nat.primeCounting (the composite endpoints n²+n and (n+1)² make the half-open π-difference count exactly the open-interval primes).",
+      "leanType": "2 ≤ n -> (OppermannAt n <-> 1 ≤ primeCounting (n^2+n) - primeCounting (n^2) ∧ 1 ≤ primeCounting ((n+1)^2) - primeCounting (n^2+n))"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/legendre-partial-oq-04.json
+++ b/src/data/research/problems/legendre-partial-oq-04.json
@@ -20,29 +20,35 @@
   },
   "currentState": "SOLVED (axiomatized): Oppermann stated; structural theorems Oppermann ⟹ Legendre and Oppermann ⟹ ≥2 primes per square-gap proved 0-axiom; Oppermann verified for n = 2..20 via native_decide; general conjecture stated as axiom. Proofs/LegendrePartialOQ04.lean.",
   "knowledge": {
-    "progressSummary": "COMPLETE: Oppermann's conjecture formalized. Two fully verified (0-axiom) structural theorems pin its relationship to Legendre — it implies Legendre and implies at least two primes between consecutive squares. Computational evidence for n = 2..20 (native_decide, axiomatized via Lean.ofReduceBool); general conjecture stated as axiom.",
+    "progressSummary": "COMPLETE + EXTENDED: Oppermann formalized; now recast in π-counting form (oppermann_at_iff_pi / oppermann_conjecture_iff_pi) tied to Mathlib's Nat.primeCounting, plus a reusable interval-prime-count bridge card_primes_Ioc. All new content VERIFIED 0-axiom.",
     "builtItems": [
       "OppermannAt / OppermannConjecture: prime in both halves of (n²,(n+1)²) split at n²+n (LegendrePartialOQ04.lean:57,64)",
       "oppermann_at_implies_legendre_at: Oppermann ⟹ Legendre pointwise, 0-axiom (LegendrePartialOQ04.lean:75)",
       "oppermann_at_two_primes: Oppermann ⟹ ≥2 primes in (n²,(n+1)²), 0-axiom (LegendrePartialOQ04.lean:85)",
       "oppermann_implies_legendre / oppermann_implies_two_primes: conjecture-level corollaries, 0-axiom (LegendrePartialOQ04.lean:106,112)",
       "oppermann_2 .. oppermann_20: native_decide verification with explicit lower/upper-half prime witnesses (LegendrePartialOQ04.lean:123-159)",
-      "oppermann_conjecture: open conjecture as axiom; legendre_of_oppermann derives Legendre from it (LegendrePartialOQ04.lean:173,176)"
+      "oppermann_conjecture: open conjecture as axiom; legendre_of_oppermann derives Legendre from it (LegendrePartialOQ04.lean:173,176)",
+      "card_primes_Ioc (LegendrePartialOQ04.lean) — #{primes in (a,b]} = π(b)−π(a); VERIFIED 0-axiom",
+      "card_primes_Ioo_eq_Ioc, exists_prime_Ioo_iff_card (LegendrePartialOQ04.lean) — interval prime-count helpers; VERIFIED 0-axiom",
+      "oppermann_at_iff_pi, oppermann_conjecture_iff_pi (LegendrePartialOQ04.lean) — Oppermann in π-counting form; VERIFIED 0-axiom (propext/Choice/Quot only)",
+      "pi_bounds_2 (LegendrePartialOQ04.lean) — π-form sanity corollary at n=2 (via native_decide witness, Lean.ofReduceBool)"
     ],
     "insights": [
       "Splitting (n²,(n+1)²) at n²+n = n·(n+1) loses no primes since the split point is composite for n ≥ 1; the two halves have widths n and n+1.",
       "Oppermann ⟹ Legendre is immediate from the lower-half prime: (n², n²+n) ⊂ (n², (n+1)²); the containment closes under omega after expanding (n+1)².",
       "The 'strictly stronger' claim is made precise and verified: distinct lower/upper-half primes give #{primes in the gap} ≥ 2, via {p,q} ⊆ filter and card_le_card.",
       "Structural theorems are honest implications taking the conjecture as a hypothesis; only native_decide (Lean.ofReduceBool) and the explicit oppermann_conjecture axiom carry assumptions.",
-      "OppermannAt 1 is false (lower half (1,2) empty) — the boundary that forces the classical n > 1 statement."
+      "OppermannAt 1 is false (lower half (1,2) empty) — the boundary that forces the classical n > 1 statement.",
+      "π-counting form of Oppermann: OppermannAt n ⟺ π(n²+n)−π(n²) ≥ 1 ∧ π((n+1)²)−π(n²+n) ≥ 1 for n ≥ 2. The equivalence is exact because both half-open right endpoints n²+n = n(n+1) and (n+1)² are composite, so #{primes in (a,b]} = #{primes in (a,b)} there.",
+      "Bridge lemma card_primes_Ioc: #{primes in (a,b]} = π(b)−π(a) for Mathlib's Nat.primeCounting, proved via Nat.count_eq_card_filter_range + a disjoint-union card identity (range(a+1) ⊔ Ioc a b = range(b+1)). Avoid Finset.card_sdiff here — in the pinned Mathlib its signature is #(t\\s)=#t−#(s∩t), not the subset-hypothesis form."
     ],
     "mathlibGaps": [
       "No scalable certified primality (Pratt/Lucas certificates) wired up — native_decide does not extend much beyond n = 20."
     ],
     "nextSteps": [
-      "Formalize the π-counting equivalent: π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1.",
-      "Extend computational verification with certified primality certificates to reach larger n.",
-      "Add the related Brocard conjecture (≥4 primes between consecutive prime squares) as a further strengthening."
+      "Formalize the Brocard conjecture (≥4 primes between consecutive PRIME squares p², q²) as a further strengthening, with the analogous π-counting form π(q²)−π(p²) ≥ 4.",
+      "Extend computational verification with certified primality certificates (Lucas/Pratt) to remove the native_decide (Lean.ofReduceBool) dependence and reach larger n.",
+      "Relate the π-counting form to PNT heuristics: π(n²+n)−π(n²) ~ n/(2 log n) → ∞, giving the standard (non-rigorous) evidence for Oppermann."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Extends the **Oppermann's conjecture** entry (`legendre-partial-oq-04`) with a **π-counting reformulation** tied to Mathlib's `Nat.primeCounting`, plus a reusable interval-prime-count bridge lemma. All new content is **VERIFIED, 0-axiom** (`#print axioms` reports only `propext, Classical.choice, Quot.sound`).

## New theorems (`proofs/Proofs/LegendrePartialOQ04.lean`)

- **`card_primes_Ioc`** — for `a ≤ b`, `#{primes in (a, b]} = π(b) − π(a)`, where `π = Nat.primeCounting`. Proved via `Nat.count_eq_card_filter_range` and a disjoint-union cardinality identity (`range(a+1) ⊔ Ioc a b = range(b+1)`). *(reusable beyond this entry)*
- **`card_primes_Ioo_eq_Ioc`**, **`exists_prime_Ioo_iff_card`** — interval prime-count helpers.
- **`oppermann_at_iff_pi`** — for `n ≥ 2`, `OppermannAt n ⟺ π(n²+n) − π(n²) ≥ 1 ∧ π((n+1)²) − π(n²+n) ≥ 1`. The equivalence is *exact* because both half-open right endpoints `n²+n = n(n+1)` and `(n+1)²` are composite, so the half-open π-difference counts precisely the open-interval primes of `OppermannAt`.
- **`oppermann_conjecture_iff_pi`** — the conjecture-level form.
- **`pi_bounds_2`** — π-form sanity corollary at `n = 2` (via the `native_decide` witness `oppermann_2`, hence `Lean.ofReduceBool`).

This directly answers the entry's open question *"Does Oppermann admit a clean equivalent in terms of π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"*

## Verification

- `./proofs/scripts/docker-build.sh Proofs.LegendrePartialOQ04` — **build OK (7744 jobs)**.
- Axiom audit: `card_primes_Ioc`, `oppermann_at_iff_pi`, `oppermann_conjecture_iff_pi` depend only on `propext, Classical.choice, Quot.sound` (0-axiom). `pi_bounds_2` additionally depends on `Lean.ofReduceBool` (documented).
- No new `axiom` declarations; `sorry`-free. Entry status remains `axiomatized` (the open `oppermann_conjecture` axiom + `native_decide` unchanged; `axiomCount` stays 2).

## Gallery metadata

- `meta.json`: `lineCount` 179→301, `theoremCount` 25→31, added `oppermann_at_iff_pi` to `mainTheorems` (surgical edits only, no reserialization).
- Research knowledge updated with insights, built items, and refreshed next steps (Brocard analogue; certified primality to drop `native_decide`; PNT heuristic).