### PR TITLE
Enrich Unipotent Sylow-p Subgroup of SL(2,p): annotation depth, mainTheorems, references

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 1, "endLine": 40 },
     "type": "concept",
     "title": "An Honest Fragment of an Open Problem",
-    "content": "The parent open question asks whether PSL(2, p) is simple for every prime p ≥ 5 — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on a large body of missing Mathlib infrastructure: the action of PSL(2, p) on the projective line P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5. Rather than sorry-out the whole statement, this file isolates and fully verifies ONE reusable building block: the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p}. U is simultaneously the abelian normal subgroup of the Borel that Iwasawa's criterion requires AND the order-p Sylow subgroup of SL(2, p). Everything here is sorry-free and axiom-free; the deep simplicity theorem remains open."
+    "content": "The parent open question asks whether PSL(2, p) is simple for every prime p ≥ 5 — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on a large body of missing Mathlib infrastructure: the action of PSL(2, p) on the projective line P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5. Rather than sorry-out the whole statement, this file isolates and fully verifies ONE reusable building block: the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p}. U is simultaneously the abelian normal subgroup of the Borel that Iwasawa's criterion requires AND the order-p Sylow subgroup of SL(2, p). Everything here is sorry-free and axiom-free; the deep simplicity theorem remains open.",
+    "mathContext": "$\\mathrm{PSL}(2,p) = \\mathrm{SL}(2,\\mathbb{F}_p)/\\{\\pm I\\}$ is simple for every prime $p \\ge 5$; $|\\mathrm{SL}(2,p)| = p(p-1)(p+1)$, so its $p$-part is exactly $p$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "projective special linear group PSL(2, p)",
+      "finite simple groups",
+      "Iwasawa's simplicity criterion",
+      "Borel subgroup"
+    ],
+    "prerequisites": [
+      "special linear group SL(2, 𝔽_p)",
+      "definition of a simple group"
+    ]
   },
   {
     "id": "ann-sylow-oq0403-det",
@@ -13,7 +25,19 @@
     "range": { "startLine": 54, "endLine": 62 },
     "type": "concept",
     "title": "Landing in SL(2, 𝔽_p): the Determinant-1 Condition",
-    "content": "`unipotentUpper t` packages the matrix [[1,t],[0,1]] as an element of `Matrix.SpecialLinearGroup (Fin 2) (ZMod p)`. The membership obligation is det = 1, discharged by `Matrix.det_fin_two_of`: the determinant of [[a,b],[c,d]] is a·d − b·c = 1·1 − t·0 = 1. This is the smallest non-diagonal unipotent — every entry is fixed except the top-right, which carries the parameter t."
+    "content": "`unipotentUpper t` packages the matrix [[1,t],[0,1]] as an element of `Matrix.SpecialLinearGroup (Fin 2) (ZMod p)`. The membership obligation is det = 1, discharged by `Matrix.det_fin_two_of`: the determinant of [[a,b],[c,d]] is a·d − b·c = 1·1 − t·0 = 1. This is the smallest non-diagonal unipotent — every entry is fixed except the top-right, which carries the parameter t.",
+    "mathContext": "$\\det \\begin{pmatrix} 1 & t \\\\ 0 & 1 \\end{pmatrix} = 1\\cdot 1 - t\\cdot 0 = 1$, so the matrix lies in $\\mathrm{SL}(2,\\mathbb{F}_p)$ for every $t$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unipotent matrix",
+      "determinant of a 2×2 matrix",
+      "Matrix.det_fin_two_of",
+      "Matrix.SpecialLinearGroup"
+    ],
+    "prerequisites": [
+      "determinant of a 2×2 matrix",
+      "the SpecialLinearGroup subtype (det = 1)"
+    ]
   },
   {
     "id": "ann-sylow-oq0403-additivity",
@@ -21,15 +45,39 @@
     "range": { "startLine": 64, "endLine": 88 },
     "type": "insight",
     "title": "The Group Law is Addition: [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]]",
-    "content": "`unipotentUpper_mul` proves the one-parameter subgroup multiplies by adding parameters, verified entrywise via `fin_cases i <;> fin_cases j` over the four 2×2 positions and `Matrix.mul_apply` / `Fin.sum_univ_two`. Together with `unipotentUpper_zero` (the identity is [[1,0],[0,1]]), this exhibits U as a homomorphic image of the additive group (ℤ/p, +): in particular it is abelian (`unipotentUpper_comm` follows by `add_comm`). No Sylow counting is needed — the abelian structure is read directly off the matrix arithmetic."
+    "content": "`unipotentUpper_mul` proves the one-parameter subgroup multiplies by adding parameters, verified entrywise via `fin_cases i <;> fin_cases j` over the four 2×2 positions and `Matrix.mul_apply` / `Fin.sum_univ_two`. Together with `unipotentUpper_zero` (the identity is [[1,0],[0,1]]), this exhibits U as a homomorphic image of the additive group (ℤ/p, +): in particular it is abelian (`unipotentUpper_comm` follows by `add_comm`). No Sylow counting is needed — the abelian structure is read directly off the matrix arithmetic.",
+    "mathContext": "$\\begin{pmatrix} 1 & s \\\\ 0 & 1 \\end{pmatrix}\\begin{pmatrix} 1 & t \\\\ 0 & 1 \\end{pmatrix} = \\begin{pmatrix} 1 & s+t \\\\ 0 & 1 \\end{pmatrix}$, so $t \\mapsto U_t$ turns $+$ in $\\mathbb{Z}/p$ into matrix product; commutativity is $s+t = t+s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "one-parameter subgroup",
+      "abelian group",
+      "matrix multiplication (Fin.sum_univ_two)",
+      "homomorphic image of (ℤ/p, +)"
+    ],
+    "prerequisites": [
+      "matrix multiplication",
+      "additive group ℤ/p"
+    ]
   },
   {
     "id": "ann-sylow-oq0403-hom",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 90, "endLine": 111 },
+    "range": { "startLine": 91, "endLine": 111 },
     "type": "tactic",
     "title": "Writing (ℤ/p, +) Multiplicatively to get a genuine MonoidHom",
-    "content": "`unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` upgrades the embedding to a bundled group homomorphism. The trick is `Multiplicative (ZMod p)`: it is (ℤ/p, +) presented with multiplicative notation, so `map_mul'` is literally the additivity identity `unipotentUpper_mul` and `map_one'` is `unipotentUpper_zero`. Injectivity (`unipotentHom_injective`) reduces to injectivity of `unipotentUpper`, which is immediate from a single matrix entry — the top-right coordinate is exactly t (`unipotentUpper_injective`)."
+    "content": "`unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` upgrades the embedding to a bundled group homomorphism. The trick is `Multiplicative (ZMod p)`: it is (ℤ/p, +) presented with multiplicative notation, so `map_mul'` is literally the additivity identity `unipotentUpper_mul` and `map_one'` is `unipotentUpper_zero`. Injectivity (`unipotentHom_injective`) reduces to injectivity of `unipotentUpper`, which is immediate from a single matrix entry — the top-right coordinate is exactly t (`unipotentUpper_injective`).",
+    "mathContext": "$U_s = U_t \\Rightarrow (U_s)_{01} = (U_t)_{01} \\Rightarrow s = t$; the bundled map $\\mathrm{Multiplicative}(\\mathbb{Z}/p) \\to^* \\mathrm{SL}(2,\\mathbb{F}_p)$ has $\\mathrm{map\\_mul}$ equal to the additivity identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Multiplicative (ZMod p)",
+      "MonoidHom / group homomorphism",
+      "injective homomorphism",
+      "type-synonym additive-to-multiplicative"
+    ],
+    "prerequisites": [
+      "monoid homomorphisms (map_one, map_mul)",
+      "the Multiplicative type synonym"
+    ]
   },
   {
     "id": "ann-sylow-oq0403-card",
@@ -37,6 +85,18 @@
     "range": { "startLine": 113, "endLine": 122 },
     "type": "insight",
     "title": "Cardinality Exactly p: the Order-p Sylow Subgroup",
-    "content": "`card_unipotent_range` computes |U| = p by transporting the cardinality of ℤ/p through the injection with `Equiv.ofInjective`, then `Nat.card_congr` and `ZMod.card`. Since |SL(2, 𝔽_p)| = p(p−1)(p+1) has p-part exactly p, this identifies U as a full Sylow-p subgroup of SL(2, p). This is the object on which the modern Iwasawa-criterion proof of PSL(2, p) simplicity is built — the abelian normal subgroup of the Borel stabiliser whose conjugates generate the group."
+    "content": "`card_unipotent_range` computes |U| = p by transporting the cardinality of ℤ/p through the injection with `Equiv.ofInjective`, then `Nat.card_congr` and `ZMod.card`. Since |SL(2, 𝔽_p)| = p(p−1)(p+1) has p-part exactly p, this identifies U as a full Sylow-p subgroup of SL(2, p). This is the object on which the modern Iwasawa-criterion proof of PSL(2, p) simplicity is built — the abelian normal subgroup of the Borel stabiliser whose conjugates generate the group.",
+    "mathContext": "$|U| = |\\mathbb{Z}/p| = p$ via $\\mathbb{Z}/p \\simeq \\mathrm{range}(U)$; and $\\nu_p(|\\mathrm{SL}(2,p)|) = \\nu_p(p(p-1)(p+1)) = 1$, so $U$ is a Sylow $p$-subgroup.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sylow p-subgroup",
+      "Equiv.ofInjective",
+      "Nat.card / ZMod.card",
+      "p-part of a group order"
+    ],
+    "prerequisites": [
+      "cardinality via bijection (Nat.card_congr)",
+      "Sylow's theorems (p-part of the group order)"
+    ]
   }
 ]

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -31,6 +31,38 @@
       "card_unipotent_range: the image has cardinality exactly p, identifying it as the order-p Sylow subgroup of SL(2, p)"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "card_unipotent_range",
+      "type": "core",
+      "description": "The unipotent subgroup has cardinality exactly p, identifying it as the order-p Sylow-p subgroup of SL(2, p). Proved by transporting the cardinality of ZMod p through the injection unipotentUpper with Equiv.ofInjective, then Nat.card_congr and ZMod.card. Since |SL(2, p)| = p(p−1)(p+1) has p-part exactly p, U is a full Sylow p-subgroup.",
+      "leanType": "Nat.card (Set.range (unipotentUpper (p := p))) = p"
+    },
+    {
+      "name": "unipotentHom",
+      "type": "core",
+      "description": "The unipotent one-parameter subgroup packaged as a group homomorphism from the additive group (ZMod p, +) — written multiplicatively via Multiplicative (ZMod p) — into SL(2, ZMod p). map_one' is unipotentUpper_zero and map_mul' is the additivity identity unipotentUpper_mul. This is the abelian normal subgroup of the Borel stabilizer required by Iwasawa's simplicity criterion for PSL(2, p).",
+      "leanType": "Multiplicative (ZMod p) →* Matrix.SpecialLinearGroup (Fin 2) (ZMod p)"
+    },
+    {
+      "name": "unipotentUpper_mul",
+      "type": "lemma",
+      "description": "Additivity of the embedding: [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]]. Proved entrywise by fin_cases over the four 2×2 positions plus Matrix.mul_apply / Fin.sum_univ_two. Exhibits U as a homomorphic image of (ZMod p, +) and, with add_comm, as abelian (unipotentUpper_comm).",
+      "leanType": "(s t : ZMod p) → unipotentUpper s * unipotentUpper t = unipotentUpper (s + t)"
+    },
+    {
+      "name": "unipotentUpper_injective",
+      "type": "lemma",
+      "description": "The unipotent embedding t ↦ [[1,t],[0,1]] is injective, read off the top-right matrix entry (which is exactly t). Upgrades to unipotentHom_injective, so the range is a subgroup of SL(2, ZMod p) isomorphic to (ZMod p, +).",
+      "leanType": "Function.Injective (unipotentUpper (p := p))"
+    },
+    {
+      "name": "unipotentUpper",
+      "type": "definition",
+      "description": "The upper unipotent matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p); the SpecialLinearGroup membership det = 1 = 1·1 − t·0 is discharged by Matrix.det_fin_two_of.",
+      "leanType": "(t : ZMod p) → Matrix.SpecialLinearGroup (Fin 2) (ZMod p)"
+    }
+  ],
   "overview": {
     "historicalContext": "The projective special linear groups PSL(2, p) form the first infinite family of finite non-abelian simple groups, with PSL(2, 5) ≅ A₅ the smallest. Their simplicity for p ≥ 5 was known to Évariste Galois (1832), who studied the exceptional behaviour at p = 5, 7, 11. Camille Jordan established the simplicity systematically in his Traité (1870). The modern textbook route is not a raw Sylow count but Iwasawa's simplicity criterion (Iwasawa 1941; see Dixon & Mortimer, Permutation Groups §3.3), applied to the natural action of PSL(2, p) on the projective line P¹(𝔽_p). That criterion requires exhibiting an abelian normal subgroup of a point stabiliser (the Borel subgroup) whose conjugates generate the whole group. The upper-unipotent subgroup U constructed here is exactly that abelian normal subgroup — and simultaneously the order-p Sylow subgroup of SL(2, p), since |SL(2, p)| = p(p−1)(p+1) has p-part exactly p.",
     "problemStatement": "**Open question (parent):** PSL(2, p) is simple for every prime p ≥ 5.\n\n**This entry (verified fragment):** Construct the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} ⊆ SL(2, 𝔽_p) and prove that t ↦ [[1,t],[0,1]] is an injective group homomorphism from (ℤ/p, +), so that U is abelian, isomorphic to ℤ/p, and has cardinality exactly p.",
@@ -95,6 +127,38 @@
       "targetId": "abel-ruffini",
       "relationship": "foundational",
       "description": "PSL(2,5) ≅ A₅ is the composition factor whose non-abelian simplicity underlies Abel-Ruffini. This entry starts the program of proving simplicity for the entire PSL(2, p) family, of which A₅ is the smallest member."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Galois, Évariste",
+      "title": "Lettre à Auguste Chevalier (and posthumous works)",
+      "year": "1832",
+      "note": "Identified the simplicity of PSL(2, p) for p ≥ 5 and the exceptional behaviour at p = 5, 7, 11 — the origin of the study of this family."
+    },
+    {
+      "authors": "Jordan, Camille",
+      "title": "Traité des substitutions et des équations algébriques",
+      "year": "1870",
+      "note": "Systematic proof of the simplicity of the PSL(2, p) family, establishing them as an infinite family of finite simple groups."
+    },
+    {
+      "authors": "Iwasawa, Kenkichi",
+      "title": "Über die Einfachheit der speziellen projektiven Gruppen",
+      "year": "1941",
+      "note": "Iwasawa's simplicity criterion: a primitive group with an abelian normal subgroup of a point stabiliser whose conjugates generate a perfect group is simple. The modern route to PSL(2, p) simplicity, and the reason the unipotent subgroup constructed here is the key object."
+    },
+    {
+      "authors": "Dixon, John D.; Mortimer, Brian",
+      "title": "Permutation Groups",
+      "year": "1996",
+      "note": "Graduate Texts in Mathematics 163. §3.3 states and proves Iwasawa's lemma; §2.8 covers the action of PSL(2, p) on the projective line. The textbook reference for the intended assembly."
+    },
+    {
+      "authors": "Rotman, Joseph J.",
+      "title": "An Introduction to the Theory of Groups (4th ed.)",
+      "year": "1995",
+      "note": "Graduate Texts in Mathematics 148. §9 develops SL(2, p), PSL(2, p), and their simplicity — the source cited in the Lean module docstring."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-04-oq-03` (passes: 0, quality: 64) — the upper-unipotent one-parameter subgroup of SL(2, 𝔽_p), an axiom-free fragment toward the open simplicity of PSL(2, p) for p ≥ 5.

## Gaps addressed
1. **Annotation depth (biggest gap):** the 5 annotations had only `title`/`content`. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 — meeting the ≥5-annotations-with-mathContext quality target.
2. **`mainTheorems` (0 → 5):** `card_unipotent_range`, `unipotentHom`, `unipotentUpper_mul`, `unipotentUpper_injective`, and the `unipotentUpper` definition, each with accurate `leanType` transcribed from the source.
3. **`references` (0 → 5):** structured the prose citations — Galois 1832, Jordan 1870, Iwasawa 1941, Dixon & Mortimer 1996, Rotman 1995.
4. **Range fix:** `ann-sylow-oq0403-hom` `startLine` 90 → 91 so it lands on the `unipotentHom` docstring (line 90 is blank — a pre-existing `annotations:build` warning that also occurs on main).

## Verification
- Both JSON files parse; `gallery:check-size` within caps (meta now 13 KB ≤ 60 KB).
- `annotations:build`: `sylow-theorem-oq-04-oq-03` is now warning-clean (the pre-existing line-90 warning is resolved).
- All `leanType`/`mathContext` content verified against `proofs/Proofs/SylowTheoremOQ04OQ03.lean`.
- `status`/`badge`/`axiomCount` unchanged and accurate (0 sorries, 0 axioms, no native_decide).

Branch is `feature/enricher-5-sylow` (kept separate from the still-open enricher-5 Lovász PR #34637). No content removed.