### PR TITLE
Research: verified elementary θ↔π reduction for PNT (chebyshev-pnt-bridge-oq-03-oq-01)

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean
@@ -1,0 +1,155 @@
+/-
+# Chebyshev–PNT Bridge OQ-03·OQ-01: The elementary θ ↔ π reduction
+
+The Prime Number Theorem, `π(x) ~ x / log x`, is equivalent to its
+Chebyshev-`θ` form, `θ(x) ~ x`, where
+
+    θ(x) = ∑_{p ≤ x, p prime} log p .
+
+The parent bridge (`ChebyshevPNTBridge.lean` and its open questions) proves the
+*order of magnitude* `π(x) = Θ(x / log x)`; the sharp asymptotic constant `1`
+(the actual PNT limit) needs the deep analytic input — either ζ non-vanishing
+on `Re s = 1` (Wiener–Ikehara) or the Selberg symmetry formula — and is out of
+reach on the pinned Mathlib.  This file isolates the **purely elementary half**:
+the two-sided sandwich that transfers the asymptotic between `θ` and `π·log`,
+so that `θ(x) ~ x ⟺ π(x) ~ x / log x`.  No analysis beyond monotonicity of
+`log` and finite-sum manipulation is used — everything here is `0 sorry`,
+`0 axiom`.
+
+The two inequalities, valid for `2 ≤ y ≤ n`:
+
+* **Upper** (`chebyshevTheta_le_primeCounting_mul_log`):
+
+      θ(n) ≤ π(n) · log n .
+
+  Each of the `π(n)` primes `p ≤ n` contributes `log p ≤ log n`.
+
+* **Lower / threshold** (`primeCounting_le_add_chebyshevTheta_div_log`):
+
+      π(n) ≤ y + θ(n) / log y .
+
+  Only the primes `p ≤ y` (at most `y` of them) fail the bound `log y ≤ log p`;
+  the rest each contribute at least `log y` to `θ(n)`, so their count
+  `π(n) − π(y)` is `≤ θ(n) / log y`.
+
+Together (`chebyshev_theta_primeCounting_sandwich`) they pin `π(n)·log n` to
+`θ(n)` up to `O(y log n)` error, the standard partial-summation-free bridge.
+Choosing e.g. `y = ⌊n / (log n)²⌋` collapses the error and yields the stated
+equivalence of the normalised limits; that final `Tendsto` bookkeeping is left
+to a consumer — the mathematical content is exactly these two inequalities.
+
+**Status**: the elementary reduction is COMPLETE (0 sorries, 0 axioms).  The
+deep PNT limit itself remains BLOCKED (needs Wiener–Ikehara / Selberg).
+-/
+
+import Mathlib.NumberTheory.Primorial
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Proofs.ChebyshevThetaFourPow
+import Proofs.ChebyshevPNTBridge
+import Proofs.ChebyshevPNTBridgeOQ05
+
+open Finset
+open ChebyshevThetaBound
+
+namespace ChebyshevPNTBridgeOQ03OQ01
+
+/-- `π(n)` counts exactly the primes in `range (n+1)`. -/
+theorem primeCounting_eq_card (n : ℕ) :
+    Nat.primeCounting n = (filter Nat.Prime (range (n + 1))).card := by
+  unfold Nat.primeCounting Nat.primeCounting'
+  exact Nat.count_eq_card_filter_range Nat.Prime (n + 1)
+
+/-- **Upper half of the bridge.**  `θ(n) ≤ π(n) · log n`: each of the `π(n)`
+primes `p ≤ n` contributes `log p ≤ log n` to `θ(n)`. -/
+theorem chebyshevTheta_le_primeCounting_mul_log (n : ℕ) :
+    chebyshevTheta n ≤ (Nat.primeCounting n : ℝ) * Real.log n := by
+  rw [chebyshevTheta, primeCounting_eq_card]
+  calc ∑ p ∈ filter (fun p => Nat.Prime p) (range (n + 1)), Real.log p
+      ≤ ∑ _p ∈ filter (fun p => Nat.Prime p) (range (n + 1)), Real.log n := by
+        apply Finset.sum_le_sum
+        intro p hp
+        rw [mem_filter, mem_range] at hp
+        have hppos : (0 : ℝ) < (p : ℝ) := by exact_mod_cast hp.2.pos
+        have hple : (p : ℝ) ≤ (n : ℝ) := by exact_mod_cast Nat.lt_succ_iff.mp hp.1
+        exact Real.log_le_log hppos hple
+    _ = ((filter (fun p => Nat.Prime p) (range (n + 1))).card : ℝ) * Real.log n := by
+        rw [Finset.sum_const, nsmul_eq_mul]
+
+/-- The set of primes in `(y, n]`, i.e. `y < p ≤ n`. -/
+private def tailPrimes (y n : ℕ) : Finset ℕ :=
+  filter Nat.Prime (Ico (y + 1) (n + 1))
+
+/-- The tail `∑_{y < p ≤ n} log p` is bounded above by `θ(n)`, since it is a
+sub-sum of nonnegative terms. -/
+theorem tail_sum_le_chebyshevTheta (y n : ℕ) :
+    ∑ p ∈ tailPrimes y n, Real.log p ≤ chebyshevTheta n := by
+  rw [chebyshevTheta]
+  apply Finset.sum_le_sum_of_subset_of_nonneg
+  · intro p hp
+    rw [tailPrimes, mem_filter, mem_Ico] at hp
+    rw [mem_filter, mem_range]
+    exact ⟨by omega, hp.2⟩
+  · intro p hp _
+    rw [mem_filter, mem_range] at hp
+    have : (1 : ℝ) ≤ (p : ℝ) := by exact_mod_cast hp.2.one_lt.le
+    exact Real.log_nonneg this
+
+/-- **Lower / threshold half of the bridge.**  For `2 ≤ y ≤ n`,
+
+    π(n) ≤ y + θ(n) / log y .
+
+The primes `p > y` each contribute at least `log y` to `θ(n)`, so there are at
+most `θ(n) / log y` of them; the remaining primes number `π(y) ≤ y`. -/
+theorem primeCounting_le_add_chebyshevTheta_div_log
+    (y n : ℕ) (hy : 2 ≤ y) (hyn : y ≤ n) :
+    (Nat.primeCounting n : ℝ) ≤ (y : ℝ) + chebyshevTheta n / Real.log y := by
+  have hlogy_pos : 0 < Real.log y := by
+    apply Real.log_pos
+    exact_mod_cast hy
+  -- Tail count = π(n) - π(y), and this equals |tailPrimes y n|.
+  have hcard : (tailPrimes y n).card = Nat.primeCounting n - Nat.primeCounting y := by
+    have := ChebyshevPNTBridge.numPrimesAbove_eq y n hyn
+    rw [ChebyshevPNTBridge.numPrimesAbove] at this
+    rw [tailPrimes]; exact this
+  have hmono : Nat.primeCounting y ≤ Nat.primeCounting n :=
+    ChebyshevPNTBridgeOQ05.primeCounting_mono hyn
+  -- π(n) = π(y) + |tail|  (as reals)
+  have hsplit : (Nat.primeCounting n : ℝ)
+      = (Nat.primeCounting y : ℝ) + ((tailPrimes y n).card : ℝ) := by
+    rw [hcard]; push_cast [Nat.cast_sub hmono]; ring
+  -- lower bound the tail sum: |tail| * log y ≤ ∑_{tail} log p ≤ θ(n)
+  have hlb : ((tailPrimes y n).card : ℝ) * Real.log y
+      ≤ ∑ p ∈ tailPrimes y n, Real.log p := by
+    rw [← nsmul_eq_mul, ← Finset.sum_const]
+    apply Finset.sum_le_sum
+    intro p hp
+    rw [tailPrimes, mem_filter, mem_Ico] at hp
+    have hypos : (0 : ℝ) < (y : ℝ) := by exact_mod_cast (by omega : 0 < y)
+    have hyp : (y : ℝ) ≤ (p : ℝ) := by exact_mod_cast (by omega : y ≤ p)
+    exact Real.log_le_log hypos hyp
+  have htail : ((tailPrimes y n).card : ℝ) * Real.log y ≤ chebyshevTheta n :=
+    le_trans hlb (tail_sum_le_chebyshevTheta y n)
+  -- divide: |tail| ≤ θ(n) / log y
+  have hdiv : ((tailPrimes y n).card : ℝ) ≤ chebyshevTheta n / Real.log y := by
+    rw [le_div_iff₀ hlogy_pos]; exact htail
+  -- π(y) ≤ y
+  have hpy : (Nat.primeCounting y : ℝ) ≤ (y : ℝ) := by
+    exact_mod_cast ChebyshevPNTBridge.primeCounting_le y
+  rw [hsplit]
+  have := add_le_add hpy hdiv
+  linarith
+
+/-- **The elementary θ ↔ π sandwich.**  For `2 ≤ y ≤ n`,
+
+    θ(n) ≤ π(n) · log n     and     π(n) ≤ y + θ(n) / log y .
+
+This is the analysis-free reduction underlying `θ(x) ~ x ⟺ π(x) ~ x/log x`. -/
+theorem chebyshev_theta_primeCounting_sandwich
+    (y n : ℕ) (hy : 2 ≤ y) (hyn : y ≤ n) :
+    chebyshevTheta n ≤ (Nat.primeCounting n : ℝ) * Real.log n
+      ∧ (Nat.primeCounting n : ℝ) ≤ (y : ℝ) + chebyshevTheta n / Real.log y :=
+  ⟨chebyshevTheta_le_primeCounting_mul_log n,
+   primeCounting_le_add_chebyshevTheta_div_log y n hy hyn⟩
+
+end ChebyshevPNTBridgeOQ03OQ01

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -78,6 +78,14 @@
       ],
       "outcome": "success",
       "date": "2026-07-03"
+    },
+    {
+      "name": "Elementary Chebyshev θ↔π transfer (threshold sandwich)",
+      "used_in_problems": [
+        "chebyshev-pnt-bridge-oq-03-oq-01"
+      ],
+      "outcome": "success",
+      "date": "2026-07-04"
     }
   ]
 }

--- a/research/problems/chebyshev-pnt-bridge-oq-03-oq-01/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-03-oq-01/knowledge.md
@@ -1,0 +1,51 @@
+# chebyshev-pnt-bridge-oq-03-oq-01 — θ ↔ π reduction for PNT
+
+**Problem**: Push the Chebyshev–PNT bridge toward the sharp asymptotic π(x) ~ x/log x.
+The deep limit (constant = 1) is the irreducible analytic content of the Prime
+Number Theorem. This OQ tracks the reduction infrastructure.
+
+## Summary
+- **Deep core BLOCKED**: the sharp PNT limit needs Wiener–Ikehara (ζ non-vanishing
+  on Re s = 1) or Selberg's symmetry formula — >1000 lines, absent from pinned Mathlib.
+- **Elementary half DONE (verified)**: the two-sided θ ↔ π·log sandwich, which
+  reduces PNT-for-π to PNT-for-θ (or PNT-for-ψ), is now a 0-axiom gallery entry.
+
+## Session 2026-07-04 (Session 2, researcher-5) — Elementary θ↔π reduction
+
+**Mode**: FRESH (claimed from available pool; prior S1 survey by researcher-7 classified BLOCKED)
+**Outcome**: progress (verified elementary reduction landed in gallery)
+
+### What I Did
+- Recognized the S1 survey's recommended "standalone BUILD to de-risk" (the ψ↔π /
+  θ↔π Abel-summation equivalence) and realized the θ↔π half needs NO Abel summation —
+  only monotonicity of log + a nonnegative sub-sum bound.
+- Wrote `proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean` (155 lines, 5 theorems, 1 def):
+  - `chebyshevTheta_le_primeCounting_mul_log`: θ(n) ≤ π(n)·log n.
+  - `tail_sum_le_chebyshevTheta`: ∑_{y<p≤n} log p ≤ θ(n).
+  - `primeCounting_le_add_chebyshevTheta_div_log`: π(n) ≤ y + θ(n)/log y (2≤y≤n).
+  - `chebyshev_theta_primeCounting_sandwich`: the packaged two-sided reduction.
+- Reused existing infra: `ChebyshevThetaBound.chebyshevTheta` (ChebyshevThetaFourPow),
+  `ChebyshevPNTBridge.numPrimesAbove_eq` & `.primeCounting_le`,
+  `ChebyshevPNTBridgeOQ05.primeCounting_mono`.
+- `docker-build.sh Proofs.ChebyshevPNTBridgeOQ03OQ01` → ✔ Built. `#print axioms` →
+  only propext / Classical.choice / Quot.sound (no sorryAx, no ofReduceBool): **verified**.
+- Created gallery entry `src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/`
+  (meta.json + annotations.json); passes `gallery:check-size:strict` and has 0
+  annotation-validation errors.
+
+### Key Findings
+- The θ summation index set IS the set π counts (both `filter Prime (range (n+1))`),
+  so θ(n) ≤ π(n)·log n collapses with no separate counting step.
+- The threshold parameter y isolates the O(y) small primes that escape the tail
+  bound; y ≈ n/(log n)² makes the errors o(n) → the sharp equivalence.
+
+### Files Modified
+- proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean (new)
+- src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/{meta,annotations}.json (new)
+- src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json (knowledge, phase ACT)
+- .lean/state/candidate-pool.json (status → blocked, note updated)
+
+### Next Steps
+- Tendsto assembly θ(n)/n→1 ⟺ π(n)·log n/n→1 (elementary, fiddly).
+- ψ↔θ transfer O(√x log²x) to complete the ψ~x ⟺ θ~x ⟺ π~x/log x chain.
+- Deep PNT limit stays blocked (Wiener–Ikehara / Selberg).

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "The elementary half of the θ ↔ π equivalence",
+    "content": "The Prime Number Theorem π(x) ~ x/log x is equivalent to its Chebyshev-θ form θ(x) ~ x, where θ(x) = ∑_{p≤x} log p. The sharp constant 1 is the deep analytic content of PNT (Wiener–Ikehara / Selberg) and is out of reach on the pinned Mathlib. This file isolates the purely elementary half — the two-sided sandwich that transfers the asymptotic between θ and π·log — with 0 axioms and 0 sorries. It does not prove PNT; it modularizes it, reducing the sharp asymptotic for π to the sharp asymptotic for θ (or ψ).",
+    "mathContext": "$\\theta(n) \\le \\pi(n)\\log n$ and $\\pi(n) \\le y + \\dfrac{\\theta(n)}{\\log y}$ for $2 \\le y \\le n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "prime-counting function π",
+      "Chebyshev's function θ",
+      "Prime Number Theorem",
+      "partial-summation-free reduction"
+    ],
+    "prerequisites": [
+      "θ(x) = ∑_{p≤x} log p and its relation to π",
+      "monotonicity of Real.log",
+      "the parent bridge lemmas numPrimesAbove_eq and primeCounting_le"
+    ]
+  },
+  {
+    "id": "ann-card",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 55, "endLine": 63 },
+    "type": "insight",
+    "title": "π counts exactly the terms of θ",
+    "content": "primeCounting_eq_card shows π(n) = |filter Prime (range (n+1))|, via Nat.count_eq_card_filter_range. This is the hinge of the whole file: the summation index set of θ(n) = ∑_{p ∈ filter Prime (range (n+1))} log p is literally the set counted by π(n). So 'the number of terms in θ(n)' is exactly π(n), and a constant bound log p ≤ log n collapses to π(n)·log n with no separate counting argument.",
+    "mathContext": "$\\pi(n) = \\#\\{p \\le n : p \\text{ prime}\\} = |\\{p \\in \\mathrm{range}(n{+}1) : p.\\mathrm{Prime}\\}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.primeCounting",
+      "Nat.count_eq_card_filter_range",
+      "Finset.filter cardinality"
+    ],
+    "prerequisites": [
+      "definition of Nat.primeCounting via Nat.count",
+      "Finset.range and filter"
+    ]
+  },
+  {
+    "id": "ann-upper",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 64, "endLine": 78 },
+    "type": "insight",
+    "title": "Upper half: θ(n) ≤ π(n)·log n",
+    "content": "chebyshevTheta_le_primeCounting_mul_log. Every prime p ≤ n satisfies log p ≤ log n by monotonicity of log (p > 0, p ≤ n). Summing this over the π(n) primes p ≤ n and collapsing the constant sum ∑ log n = (π(n))·log n gives the bound. This is the easy direction — it needs nothing beyond monotonicity of log and Finset.sum_le_sum.",
+    "mathContext": "$\\theta(n) = \\sum_{p \\le n} \\log p \\le \\sum_{p \\le n} \\log n = \\pi(n)\\,\\log n.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotonicity of log",
+      "Finset.sum_le_sum",
+      "Finset.sum_const"
+    ],
+    "prerequisites": [
+      "Real.log_le_log",
+      "primeCounting_eq_card"
+    ]
+  },
+  {
+    "id": "ann-tail",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 80, "endLine": 102 },
+    "type": "insight",
+    "title": "The tail sub-sum is bounded by θ(n)",
+    "content": "tailPrimes y n = {y < p ≤ n : p prime}, and tail_sum_le_chebyshevTheta shows ∑_{p ∈ tailPrimes} log p ≤ θ(n). Because every summand log p is nonnegative (primes are ≥ 2, so log p ≥ 0), restricting the sum to the sub-set {y < p ≤ n} of {p ≤ n} can only decrease it (Finset.sum_le_sum_of_subset_of_nonneg). This nonnegativity is what lets us drop the small primes p ≤ y for free.",
+    "mathContext": "$\\sum_{y < p \\le n} \\log p \\le \\sum_{p \\le n} \\log p = \\theta(n),$ since each $\\log p \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_le_sum_of_subset_of_nonneg",
+      "Real.log_nonneg",
+      "monotonicity of sums over subsets"
+    ],
+    "prerequisites": [
+      "log p ≥ 0 for p ≥ 1",
+      "filter Prime (Ico (y+1) (n+1)) ⊆ filter Prime (range (n+1))"
+    ]
+  },
+  {
+    "id": "ann-lower",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 104, "endLine": 146 },
+    "type": "insight",
+    "title": "Lower half: π(n) ≤ y + θ(n)/log y",
+    "content": "primeCounting_le_add_chebyshevTheta_div_log, the crux. Each tail prime y < p ≤ n has log p ≥ log y, so |{y<p≤n}|·log y ≤ ∑_{y<p≤n} log p ≤ θ(n); dividing by log y > 0 (needs y ≥ 2) bounds the tail count by θ(n)/log y. The tail count is π(n) − π(y) (numPrimesAbove_eq), and the remaining small primes number π(y) ≤ y (primeCounting_le). Hence π(n) = π(y) + (π(n) − π(y)) ≤ y + θ(n)/log y. The free parameter y is what makes the sandwich sharp: it isolates the O(y) primes that escape the log y bound.",
+    "mathContext": "$\\pi(n) - \\pi(y) \\le \\dfrac{\\theta(n)}{\\log y}, \\quad \\pi(y) \\le y \\;\\Rightarrow\\; \\pi(n) \\le y + \\dfrac{\\theta(n)}{\\log y}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_pos",
+      "le_div_iff₀",
+      "numPrimesAbove_eq (π(n) − π(y))",
+      "primeCounting_le (π(y) ≤ y)"
+    ],
+    "prerequisites": [
+      "tail_sum_le_chebyshevTheta",
+      "monotonicity of π (primeCounting_mono)",
+      "Nat.cast_sub for the real split π(n) = π(y) + tail"
+    ]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "chebyshev-pnt-bridge-oq-03-oq-01",
+    "range": { "startLine": 148, "endLine": 155 },
+    "type": "insight",
+    "title": "The packaged sandwich and what it reduces PNT to",
+    "content": "chebyshev_theta_primeCounting_sandwich conjoins the two halves: for 2 ≤ y ≤ n, θ(n) ≤ π(n)·log n and π(n) ≤ y + θ(n)/log y. Together they pin π(n)·log n to θ(n) up to an O(y·log n) error. Choosing y ≈ n/(log n)² makes both the y·log n and the π(y) losses o(n), so θ(n)/n → 1 ⟺ π(n)·log n / n → 1 — the equivalence θ(x) ~ x ⟺ π(x) ~ x/log x. The remaining deep step, the limit itself, is the genuine PNT content and stays open (Wiener–Ikehara or Selberg).",
+    "mathContext": "$\\theta(x) \\sim x \\iff \\pi(x) \\sim \\dfrac{x}{\\log x}$, reduced here to the two elementary inequalities.",
+    "significance": "key",
+    "relatedConcepts": [
+      "asymptotic equivalence",
+      "reduction of PNT to PNT-for-θ / PNT-for-ψ",
+      "Chebyshev functions θ and ψ"
+    ],
+    "prerequisites": [
+      "chebyshevTheta_le_primeCounting_mul_log",
+      "primeCounting_le_add_chebyshevTheta_div_log"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-03-oq-01",
+  "title": "The elementary θ ↔ π reduction for the Prime Number Theorem",
+  "slug": "chebyshev-pnt-bridge-oq-03-oq-01",
+  "description": "The Prime Number Theorem π(x) ~ x/log x is equivalent to its Chebyshev-θ form θ(x) ~ x, where θ(x) = ∑_{p ≤ x} log p. The full asymptotic constant 1 is the deep analytic content of PNT (Wiener–Ikehara / Selberg) and is out of reach on the pinned Mathlib. This entry isolates the purely ELEMENTARY half — the two-sided sandwich that transfers the asymptotic between θ and π·log — with 0 axioms and 0 sorries. For 2 ≤ y ≤ n it proves (i) θ(n) ≤ π(n)·log n (each of the π(n) primes p ≤ n contributes log p ≤ log n) and (ii) π(n) ≤ y + θ(n)/log y (the primes p > y each contribute at least log y to θ(n), so they number at most θ(n)/log y; the rest are ≤ y). No analysis beyond monotonicity of log and finite-sum manipulation is used — in particular no Abel/partial summation. Together these pin π(n)·log n to θ(n) up to an O(y·log n) error; choosing y ≈ n/(log n)² collapses the error and yields θ(x) ~ x ⟺ π(x) ~ x/log x. The deep PNT limit itself remains an open question of the parent bridge.",
+  "meta": {
+    "author": "Pafnuty Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_le_log",
+        "description": "monotonicity of log on the positive reals; the single tool behind both halves (log p ≤ log n for p ≤ n above, log y ≤ log p for p > y below)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "0 < log y for y ≥ 2, needed to divide the tail-count bound by log y",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.count_eq_card_filter_range",
+        "description": "π(n) = |{p ∈ range (n+1) : p.Prime}|; identifies the prime-counting function with the cardinality of the θ-summation index set",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset_of_nonneg",
+        "description": "a sub-sum of nonnegative terms is bounded by the full sum; used to bound the tail ∑_{y<p≤n} log p by θ(n)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "le_div_iff₀",
+        "description": "convert |{y<p≤n}|·log y ≤ θ(n) into the count bound |{y<p≤n}| ≤ θ(n)/log y",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevTheta_le_primeCounting_mul_log: the upper half θ(n) ≤ π(n)·log n, proved by bounding each of the π(n) summands log p (p ≤ n) by log n and collapsing the constant sum to π(n)·log n via the identity π(n) = |filter Prime (range (n+1))|",
+      "primeCounting_le_add_chebyshevTheta_div_log: the threshold lower half π(n) ≤ y + θ(n)/log y for 2 ≤ y ≤ n — the tail primes y < p ≤ n each contribute ≥ log y to θ(n), so their count π(n) − π(y) is ≤ θ(n)/log y, and the remaining π(y) ≤ y primes are absorbed into the +y term",
+      "tail_sum_le_chebyshevTheta: the tail sum ∑_{y<p≤n} log p ≤ θ(n) as a sub-sum of nonnegative log-terms, the key monotonicity step of the lower half",
+      "chebyshev_theta_primeCounting_sandwich: the packaged two-sided statement θ(n) ≤ π(n)·log n ∧ π(n) ≤ y + θ(n)/log y for 2 ≤ y ≤ n — the analysis-free reduction underlying θ(x) ~ x ⟺ π(x) ~ x/log x, the natural drop-in for a PNT-for-ψ ⟹ PNT-for-π transfer"
+    ],
+    "axiomCount": 0,
+    "lineCount": 155,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": "None — fully verified from Mathlib and the parent bridge files (ChebyshevThetaFourPow, ChebyshevPNTBridge, ChebyshevPNTBridgeOQ05) with 0 axioms (only propext / Classical.choice / Quot.sound, confirmed by #print axioms) and 0 sorries; no native_decide, no decide. This entry proves ONLY the elementary reduction: the two-sided θ ↔ π·log sandwich. The full PNT asymptotic π(x)·log x / x → 1 (equivalently θ(x)/x → 1) is NOT proved here — it is the irreducible deep content of the Prime Number Theorem and remains an open question, requiring either the Wiener–Ikehara Tauberian theorem (ζ non-vanishing on Re s = 1) or Selberg's symmetry formula, neither present in the pinned Mathlib.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 memoir introduced the functions θ(x) = ∑_{p≤x} log p and ψ(x) = ∑_{p^k≤x} log p and proved π(x) has the right order of magnitude, x/log x, decades before Hadamard and de la Vallée Poussin proved the sharp Prime Number Theorem π(x) ~ x/log x in 1896. A cornerstone of the elementary theory is that all three normalized quantities ψ(x)/x, θ(x)/x, and π(x)·log x / x have the same limit if any of them does — so PNT can be attacked through whichever of ψ, θ, π is most convenient (ψ for the analytic zeta approach, π for the statement of record). The transfer θ ↔ π is the most elementary link in this chain, needing only monotonicity of log, and is the one formalized here.",
+    "problemStatement": "The parent bridge proves π(x) = Θ(x/log x); the third open question asks for the sharp PNT asymptotic. That limit is deep. This entry formalizes the elementary reduction: the two-sided sandwich θ(n) ≤ π(n)·log n and π(n) ≤ y + θ(n)/log y (2 ≤ y ≤ n) that makes θ(x) ~ x and π(x) ~ x/log x equivalent, so PNT-for-θ (or PNT-for-ψ) suffices for PNT-for-π.",
+    "text": "For 2 ≤ y ≤ n, θ(n) ≤ π(n)·log n and π(n) ≤ y + θ(n)/log y. Both directions use only that log is monotone: log p ≤ log n for the π(n) primes p ≤ n gives the upper half; log p ≥ log y for the tail primes y < p ≤ n, together with π(y) ≤ y, gives the lower half.",
+    "proofStrategy": "Upper half: rewrite θ(n) = ∑_{p ∈ filter Prime (range (n+1))} log p; bound each summand log p ≤ log n (p ≤ n, log monotone) and collapse ∑ 1 to the cardinality of the index set, which equals π(n) by Nat.count_eq_card_filter_range. Lower half: let T = {y < p ≤ n : p prime}. Since all log-terms are nonnegative, ∑_{p∈T} log p ≤ θ(n) (sub-sum). Each p ∈ T has p > y so log p ≥ log y, giving |T|·log y ≤ ∑_{p∈T} log p ≤ θ(n); dividing by log y > 0 yields |T| ≤ θ(n)/log y. Finally |T| = π(n) − π(y) (numPrimesAbove_eq) and π(y) ≤ y (primeCounting_le), so π(n) = π(y) + |T| ≤ y + θ(n)/log y. The sandwich theorem conjoins the two halves.",
+    "keyInsights": [
+      "The whole reduction is analysis-free: no Abel/partial summation, no integration — only that log is monotone on the positive reals and that a sub-sum of nonnegative terms is bounded by the full sum",
+      "The index set of the θ-summation is literally the set counted by π: θ(n) = ∑_{p ∈ filter Prime (range (n+1))} log p and π(n) = |filter Prime (range (n+1))|, so the 'number of terms' in θ(n) is exactly π(n)",
+      "The free parameter y trades the two error sources against each other: only the ≤ y small primes escape the log y ≥ tail bound, and only they are dropped from the π·log estimate; taking y ≈ n/(log n)² makes both y·log n and the π(y) loss o(n), collapsing the sandwich to the sharp equivalence",
+      "This modularizes PNT: it reduces the sharp asymptotic for π to the sharp asymptotic for θ (or ψ, which differs from θ by O(√x log²x)), which is the form the analytic (ζ) and elementary (Selberg) proofs actually deliver"
+    ],
+    "prerequisites": [
+      "the prime-counting function π and Chebyshev's function θ(x) = ∑_{p≤x} log p",
+      "monotonicity of Real.log on the positive reals",
+      "π(n) − π(y) as the count of primes in (y, n] (numPrimesAbove_eq) and π(m) ≤ m (primeCounting_le) from the parent bridge",
+      "elementary Finset sum manipulation (sub-sum of nonnegative terms, constant sum)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring: isolate the elementary half of the θ ↔ π equivalence — the two-sided sandwich transferring the asymptotic between θ and π·log — while the deep PNT limit stays blocked."
+    },
+    {
+      "id": "card",
+      "title": "π as a cardinality",
+      "startLine": 55,
+      "endLine": 63,
+      "summary": "primeCounting_eq_card: π(n) = |filter Prime (range (n+1))|, identifying the prime-counting function with the number of terms in θ(n)."
+    },
+    {
+      "id": "upper",
+      "title": "Upper half: θ(n) ≤ π(n)·log n",
+      "startLine": 64,
+      "endLine": 78,
+      "summary": "chebyshevTheta_le_primeCounting_mul_log: bound each of the π(n) summands log p (p ≤ n) by log n and collapse the constant sum to π(n)·log n."
+    },
+    {
+      "id": "tail",
+      "title": "Tail sub-sum bound",
+      "startLine": 80,
+      "endLine": 102,
+      "summary": "tailPrimes and tail_sum_le_chebyshevTheta: the primes in (y, n] and the fact that their log-sum, being a sub-sum of nonnegative terms, is ≤ θ(n)."
+    },
+    {
+      "id": "lower",
+      "title": "Lower half: π(n) ≤ y + θ(n)/log y",
+      "startLine": 104,
+      "endLine": 146,
+      "summary": "primeCounting_le_add_chebyshevTheta_div_log: the tail primes each contribute ≥ log y, so |{y<p≤n}| ≤ θ(n)/log y; with π(y) ≤ y this gives the threshold bound."
+    },
+    {
+      "id": "sandwich",
+      "title": "The packaged sandwich",
+      "startLine": 148,
+      "endLine": 155,
+      "summary": "chebyshev_theta_primeCounting_sandwich: the two halves conjoined — the analysis-free reduction underlying θ(x) ~ x ⟺ π(x) ~ x/log x."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) elementary reduction: for 2 ≤ y ≤ n, θ(n) ≤ π(n)·log n and π(n) ≤ y + θ(n)/log y. These two inequalities — proved from nothing deeper than monotonicity of log and a nonnegative sub-sum bound — are exactly the analysis-free transfer that makes θ(x) ~ x equivalent to π(x) ~ x/log x.",
+    "implications": "Modularizes the Prime Number Theorem in the gallery: it reduces the sharp asymptotic for π to the sharp asymptotic for θ (equivalently ψ, differing by O(√x log²x)), which is the form both the analytic Wiener–Ikehara route and the elementary Selberg route actually produce. Downstream, any future formalization of PNT-for-ψ can be transferred to PNT-for-π through this single sandwich rather than re-deriving the prime-counting estimates.",
+    "openQuestions": [
+      "Assemble the sandwich into the explicit Tendsto equivalence: θ(n)/n → 1 ⟺ π(n)·log n / n → 1, discharging the y ≈ n/(log n)² choice and the o(1) bookkeeping.",
+      "Formalize the ψ ↔ θ transfer ψ(x) − θ(x) = O(√x log²x), completing the chain ψ ~ x ⟺ θ ~ x ⟺ π ~ x/log x.",
+      "Formalize the deep PNT limit π(x)·log x / x → 1 itself, which requires the Wiener–Ikehara Tauberian theorem (ζ non-vanishing on Re s = 1) or Selberg's symmetry formula — neither present in the pinned Mathlib."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-03",
+      "relationship": "parent",
+      "description": "Direct parent (Bertrand's postulate in the bridge setting); this open question asks to push the bridge toward the sharp PNT asymptotic, of which the present entry supplies the elementary θ ↔ π reduction"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Sibling packaging the two-sided order bound π(x) = Θ(x/log x); this entry complements it with the exact θ ↔ π·log transfer needed for the sharp asymptotic rather than the order"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "ancestor",
+      "description": "Root of the bridge chain; reuses its θ definition (via ChebyshevThetaFourPow), numPrimesAbove_eq, and primeCounting_le"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Primorial",
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Proofs.ChebyshevThetaFourPow",
+      "Proofs.ChebyshevPNTBridge",
+      "Proofs.ChebyshevPNTBridgeOQ05"
+    ],
+    "opens": [
+      "Finset",
+      "ChebyshevThetaBound"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ03OQ01",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/ChebyshevPNTBridgeOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": [],
+  "references": [
+    {
+      "authors": [
+        "Pafnuty L. Chebyshev"
+      ],
+      "title": "Mémoire sur les nombres premiers",
+      "year": 1852,
+      "venue": "Journal de Mathématiques Pures et Appliquées 17, 366–390",
+      "note": "Original definitions of θ and ψ and the order bounds c₁ x/log x ≤ π(x) ≤ c₂ x/log x."
+    },
+    {
+      "authors": [
+        "Tom M. Apostol"
+      ],
+      "title": "Introduction to Analytic Number Theory",
+      "year": 1976,
+      "venue": "Springer (Undergraduate Texts in Mathematics)",
+      "note": "Theorem 4.4: the equivalence of ψ(x)/x, θ(x)/x, and π(x)·log x / x — the transfer formalized (elementary half) here."
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
+      "title": "An Introduction to the Theory of Numbers",
+      "year": 2008,
+      "venue": "Oxford University Press (6th ed.)",
+      "note": "Chapter 22: the functions θ, ψ, π and the relations between their asymptotics."
+    }
+  ]
+}

--- a/src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json
+++ b/src/data/research/problems/chebyshev-pnt-bridge-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "chebyshev-pnt-bridge-oq-03-oq-01",
   "title": "Formalize the full Prime Number Theorem π(x)·log x / x → 1",
   "status": "blocked",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "path": "full",
   "tier": "EMPTY",
   "started": "2026-07-02T00:00:00.000Z",
@@ -57,11 +57,14 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "OBSERVE (S1, researcher-7): survey only, classified BLOCKED. The full PNT limit π(x)·log x / x → 1 is NOT in the pinned Mathlib (v4.26.0): PrimeCounting.lean gives only monotonicity, surjectivity, and Tendsto π atTop atTop, and Chebyshev.lean gives Θ-order bounds — neither yields the sharp asymptotic. Both classical routes are absent from Mathlib and each is a multi-thousand-line formalization: (A) Wiener–Ikehara Tauberian theorem applied to −ζ'/ζ, which requires the analytic continuation and non-vanishing of ζ on Re(s)=1 plus a Tauberian argument (heavy complex analysis / contour integration); (B) Selberg's elementary method (Selberg symmetry Σ_{p≤x} log²p + Σ_{pq≤x} log p log q = 2x log x + O(x), then the Erdős–Selberg dichotomy). The leanprover-community PrimeNumberTheoremAnd project proves PNT but has not been upstreamed into this pinned Mathlib. Recommend keeping BLOCKED: the Θ-order-to-asymptotic gap is exactly the irreducible analytic content of PNT and cannot be closed on top of the gallery's existing Chebyshev bounds without importing one of the two heavy machineries. A tractable intermediate BUILD target, if pursued, is the equivalence ψ(x) ~ x ⟺ π(x) ~ x/log x (Abel summation / partial-summation bridge), which is elementary and would at least reduce PNT-for-π to PNT-for-ψ.",
+    "progressSummary": "PROGRESS (S2, researcher-5): verified the elementary θ↔π reduction (two-sided sandwich, 0 axioms/0 sorries) as gallery entry chebyshev-pnt-bridge-oq-03-oq-01, modularizing PNT-for-π into PNT-for-θ. The deep PNT limit itself stays BLOCKED (Wiener–Ikehara/Selberg).",
     "insights": [
       "The gap is irreducible: Chebyshev's Θ(x/log x) bounds (already in the gallery) provably CANNOT be sharpened to the limit 1 by elementary manipulation — closing the constant to exactly 1 is the whole difficulty of PNT and needs either ζ non-vanishing on Re(s)=1 (route A) or the Selberg symmetry formula (route B).",
       "Mathlib's π support stops at qualitative facts (monotone, surjective, → ∞); there is no rate, so any PNT statement must be built essentially from scratch relative to this pinned toolchain.",
-      "The one genuinely elementary sub-step is the ψ↔π transfer: ψ(x) ~ x ⟺ θ(x) ~ x ⟺ π(x) ~ x/log x via Abel/partial summation. This is a legitimate standalone BUILD that would modularize the problem, leaving only PNT-for-ψ (still deep) as the blocker."
+      "The one genuinely elementary sub-step is the ψ↔π transfer: ψ(x) ~ x ⟺ θ(x) ~ x ⟺ π(x) ~ x/log x via Abel/partial summation. This is a legitimate standalone BUILD that would modularize the problem, leaving only PNT-for-ψ (still deep) as the blocker.",
+      "The θ↔π transfer is fully ELEMENTARY: for 2≤y≤n, θ(n)≤π(n)·log n and π(n)≤y+θ(n)/log y, proved from only monotonicity of log and a nonnegative sub-sum bound — NO Abel/partial summation needed. This is the de-risking BUILD the S1 survey recommended.",
+      "π(n) is literally the cardinality of the θ(n) summation index set (both range over filter Prime (range (n+1))), so θ(n)≤π(n)·log n needs no separate counting argument (Nat.count_eq_card_filter_range).",
+      "The free threshold parameter y trades the two error sources: only the ≤y small primes escape the log y tail bound and only they are dropped from π·log; y≈n/(log n)² makes both losses o(n), collapsing the sandwich to θ(x)~x ⟺ π(x)~x/log x."
     ],
     "mathlibGaps": [
       "No PNT limit / asymptotic for primeCounting (only Tendsto π atTop atTop).",
@@ -71,10 +74,15 @@
       "The PrimeNumberTheoremAnd project is not upstreamed into this pinned Mathlib."
     ],
     "nextSteps": [
-      "Keep BLOCKED for direct attack: PNT needs >1000 lines of either analytic (Wiener–Ikehara) or elementary (Selberg) machinery absent from this Mathlib.",
-      "Optional standalone BUILD to de-risk: formalize the Abel-summation equivalence ψ(x) ~ x ⟺ π(x) ~ x/log x, reducing the goal to PNT-for-ψ without touching the deep analysis.",
-      "Re-evaluate if/when the PrimeNumberTheoremAnd results are upstreamed into the pinned Mathlib, at which point this becomes a (possibly thin) wrapper and should be reframed or retired."
+      "Assemble the sandwich into the explicit Tendsto equivalence θ(n)/n→1 ⟺ π(n)·log n/n→1, discharging the y≈n/(log n)² choice and the o(1) bookkeeping (elementary but fiddly Filter work).",
+      "Formalize the ψ↔θ transfer ψ(x)−θ(x)=O(√x log²x), completing ψ~x ⟺ θ~x ⟺ π~x/log x.",
+      "The deep PNT limit π(x)·log x/x→1 itself remains BLOCKED: needs Wiener–Ikehara (ζ non-vanishing on Re s=1) or Selberg symmetry, neither in pinned Mathlib (>1000 lines)."
     ],
-    "builtItems": []
+    "builtItems": [
+      "chebyshevTheta_le_primeCounting_mul_log — θ(n)≤π(n)·log n (ChebyshevPNTBridgeOQ03OQ01.lean:65), verified 0-axiom",
+      "primeCounting_le_add_chebyshevTheta_div_log — π(n)≤y+θ(n)/log y for 2≤y≤n (ChebyshevPNTBridgeOQ03OQ01.lean:104), verified 0-axiom",
+      "tail_sum_le_chebyshevTheta — ∑_{y<p≤n} log p ≤ θ(n) (ChebyshevPNTBridgeOQ03OQ01.lean:85)",
+      "chebyshev_theta_primeCounting_sandwich — the packaged two-sided reduction (ChebyshevPNTBridgeOQ03OQ01.lean:148); gallery entry chebyshev-pnt-bridge-oq-03-oq-01"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Isolates the **purely elementary half** of the Prime Number Theorem's Chebyshev reduction: the two-sided sandwich that transfers the asymptotic between `θ` and `π·log`, so that **θ(x) ~ x ⟺ π(x) ~ x/log x**. This modularizes PNT — reducing the sharp asymptotic for `π` to the sharp asymptotic for `θ` (equivalently `ψ`), which is the form both the analytic (Wiener–Ikehara) and elementary (Selberg) proofs actually deliver.

The [S1 survey](research/problems/chebyshev-pnt-bridge-oq-03-oq-01/knowledge.md) recommended exactly this as the "standalone BUILD to de-risk"; the θ↔π half turns out to need **no Abel/partial summation at all**.

For `2 ≤ y ≤ n`:
- `chebyshevTheta_le_primeCounting_mul_log`: **θ(n) ≤ π(n)·log n** — each of the π(n) primes p ≤ n contributes log p ≤ log n.
- `primeCounting_le_add_chebyshevTheta_div_log`: **π(n) ≤ y + θ(n)/log y** — the tail primes y < p ≤ n each contribute ≥ log y to θ(n), so they number ≤ θ(n)/log y; the rest are ≤ y.
- `chebyshev_theta_primeCounting_sandwich`: the packaged conjunction.

Choosing `y ≈ n/(log n)²` collapses the O(y·log n) error and yields the equivalence.

## Verification

- `docker-build.sh Proofs.ChebyshevPNTBridgeOQ03OQ01` → ✔ Built
- **0 sorries, 0 axioms**, no `native_decide`/`decide`. `#print axioms` → only `propext`, `Classical.choice`, `Quot.sound`. Status **verified**.
- Gallery entry passes `gallery:check-size:strict` and has 0 annotation-validation errors.

## Scope / honesty

This proves **only** the elementary reduction. The deep PNT limit itself — `π(x)·log x / x → 1` — is **not** proved here; it needs the Wiener–Ikehara Tauberian theorem or Selberg's symmetry formula (>1000 lines, absent from the pinned Mathlib) and remains an open question.

## Files
- `proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean` (new, 155 lines, 5 theorems, 1 def)
- `src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/{meta,annotations}.json` (new gallery entry)
- research knowledge + technique index updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)