### PR TITLE
Enrich Hexagrammum Mysticum S₆ census: add combinatorial/geometric-boundary keyInsight (3→4)

### DIFF
--- a/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/pascals-hexagon-oq-03-incomplete-01/meta.json
@@ -69,7 +69,8 @@
     "keyInsights": [
       "Every Hexagrammum point and line is indexed by an S₆ conjugacy class, so the geometric counts 60/60/20/20/15/15 are shadows of the class sizes 120/120/40/40/15/15 halved (or self-paired) by the S₆ outer automorphism.",
       "A fixed-point-free permutation of six letters has cycle type (6), (4,2), (3,3), or (2,2,2); adding one or two power conditions pins each type exactly, so no cycleType computation is needed.",
-      "The (4,2) class is the subtle exclusion for six-cycles: its elements satisfy σ⁶ = σ² ≠ 1, so demanding σ⁶ = 1 removes them."
+      "The (4,2) class is the subtle exclusion for six-cycles: its elements satisfy σ⁶ = σ² ≠ 1, so demanding σ⁶ = 1 removes them.",
+      "The entry draws a clean line between the *combinatorial* half of the Hexagrammum — the exact S₆ class sizes 120/40/15, certified here — and its *geometric* half, the projective concurrence that would biject each class onto the actual Pascal/Kirkman/Steiner points and lines, which remains the open oq-03 target. Because the class sizes are pure group theory requiring no projective geometry, they can be pinned down and machine-checked first, giving any later geometric proof a fixed target cardinality to match."
     ],
     "prerequisites": [
       "Symmetric group S₆, cycle types, and conjugacy classes.",


### PR DESCRIPTION
Light-touch enrichment for `pascals-hexagon-oq-03-incomplete-01` (passes: 0, quality: 92).

This entry was already at or above quality targets: 7 annotations all with mathContext/significance/relatedConcepts, rich historicalContext, 3 sections, 6 mainTheorems, 3 references, 2 crossReferences, and correct axiom integrity (`axiomatized`/`axiom`/`axiomCount: 1` reflecting the `native_decide` → `Lean.ofReduceBool` dependency). The single field below the stated aim was `keyInsights` at 3 (aim 4–5).

## Change
- **keyInsights 3 → 4:** added one distinct insight surfacing the verified-vs-open boundary (previously only in `conclusion`) — the exact S₆ class sizes 120/40/15 are pure group theory certified here, whereas the projective bijection onto the actual Hexagrammum points/lines remains the open oq-03 target; because the sizes need no projective geometry they can be pinned down first as a fixed target for any later geometric proof.

No accretion beyond the target; no other field touched, no content removed.

## Verification
- meta.json parses; `gallery:check-size` within caps (14.9 KB ≤ 60 KB).
- `annotations:build`: entry is warning-clean.
- Axiom framing unchanged and accurate.