### PR TITLE
Research: legendre-partial-oq-04 — the Brocard mechanism (Oppermann ⟹ 4 primes per double gap, 0-axiom)

### DIFF
--- a/proofs/Proofs/LegendrePartialOQ04.lean
+++ b/proofs/Proofs/LegendrePartialOQ04.lean
@@ -31,8 +31,18 @@ New content here:
   * `oppermann_implies_legendre`, `oppermann_implies_two_primes` — the
     conjecture-level corollaries.  VERIFIED, 0-axiom (they take the conjecture
     as a hypothesis; they do not assert it).
+  * `oppermann_at_four_primes_two_gaps` — **the Brocard mechanism**: Oppermann at
+    two *adjacent* gaps `n`, `n+1` forces `≥ 4` primes in the double gap
+    `(n², (n+2)²)` (the four half-interval primes are kept distinct by the
+    composite separators `n²+n`, `(n+1)²`, `(n+1)²+(n+1)`).  This is the
+    elementary combinatorial core of the classical **Oppermann ⟹ Brocard**
+    implication.  VERIFIED, 0-axiom.
+  * `oppermann_implies_four_primes` — its conjecture-level corollary.  VERIFIED,
+    0-axiom.
   * `card_primes_Ioc` — the number of primes in `(a, b]` equals `π(b) − π(a)` for
     Mathlib's `Nat.primeCounting`.  VERIFIED, 0-axiom.
+  * `oppermann_at_pi_total`, `oppermann_implies_pi_total` — the total π-count
+    form: Oppermann forces `π((n+1)²) − π(n²) ≥ 2`.  VERIFIED, 0-axiom.
   * `oppermann_at_iff_pi`, `oppermann_conjecture_iff_pi` — Oppermann in
     **π-counting form**: for `n ≥ 2`, `OppermannAt n ⟺ π(n²+n) − π(n²) ≥ 1 ∧
     π((n+1)²) − π(n²+n) ≥ 1` (the composite endpoints `n²+n` and `(n+1)²` make the
@@ -120,6 +130,65 @@ theorem oppermann_implies_two_primes (h : OppermannConjecture) :
     ∀ n : ℕ, 2 ≤ n →
       2 ≤ ((Finset.Ioo (n ^ 2) ((n + 1) ^ 2)).filter Nat.Prime).card :=
   fun n hn => oppermann_at_two_primes (h n hn)
+
+/-! ### The Brocard mechanism (VERIFIED, 0-axiom)
+
+**Brocard's conjecture** (1904, OPEN): between the squares of two consecutive
+primes `p < q` (with `p ≥ 3`) there are at least four primes.  It is a classical
+observation that **Oppermann's conjecture implies Brocard's**, and the argument is
+purely combinatorial: two consecutive primes `≥ 3` are both odd, so `q ≥ p + 2`,
+hence the interval `(p², q²)` contains at least the two *adjacent* square-gaps
+`(p², (p+1)²)` and `((p+1)², (p+2)²)`; Oppermann puts two primes in each, and the
+composite square `(p+1)²` separating them keeps all four distinct.
+
+The theorem below isolates exactly this mechanism at the level of an arbitrary
+pair of adjacent gaps — no consecutive-prime bookkeeping required — and is the
+provable core of the Oppermann ⟹ Brocard implication. -/
+
+/-- **Oppermann ⟹ four primes across two adjacent square-gaps.** If Oppermann
+holds at both `n` and `n+1`, the double gap `(n², (n+2)²)` contains at least FOUR
+primes: the lower/upper-half primes of `(n², (n+1)²)` and those of
+`((n+1)², (n+2)²)`, all four distinct (they are separated by the composite
+points `n²+n`, `(n+1)²`, `(n+1)²+(n+1)`).  This is the elementary combinatorial
+core of **Brocard's conjecture**. VERIFIED, 0-axiom. -/
+theorem oppermann_at_four_primes_two_gaps {n : ℕ}
+    (h₀ : OppermannAt n) (h₁ : OppermannAt (n + 1)) :
+    4 ≤ ((Finset.Ioo (n ^ 2) ((n + 2) ^ 2)).filter Nat.Prime).card := by
+  obtain ⟨⟨p, hp, hplo, hphi⟩, ⟨q, hq, hqlo, hqhi⟩⟩ := h₀
+  obtain ⟨⟨r, hr, hrlo, hrhi⟩, ⟨s, hs, hslo, hshi⟩⟩ := h₁
+  -- polynomial expansions so `omega` can compare the interval endpoints
+  have e1 : (n + 1) ^ 2 = n ^ 2 + 2 * n + 1 := by ring
+  have e2 : (n + 2) ^ 2 = n ^ 2 + 4 * n + 4 := by ring
+  have e2' : (n + 1 + 1) ^ 2 = n ^ 2 + 4 * n + 4 := by ring
+  have hsub : ({p, q, r, s} : Finset ℕ) ⊆
+      (Finset.Ioo (n ^ 2) ((n + 2) ^ 2)).filter Nat.Prime := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rw [Finset.mem_filter, Finset.mem_Ioo]
+    rcases hx with rfl | rfl | rfl | rfl
+    · exact ⟨⟨by omega, by omega⟩, hp⟩
+    · exact ⟨⟨by omega, by omega⟩, hq⟩
+    · exact ⟨⟨by omega, by omega⟩, hr⟩
+    · exact ⟨⟨by omega, by omega⟩, hs⟩
+  have h4 : ({p, q, r, s} : Finset ℕ).card = 4 := by
+    have hpne : p ∉ ({q, r, s} : Finset ℕ) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]; omega
+    have hqne : q ∉ ({r, s} : Finset ℕ) := by
+      simp only [Finset.mem_insert, Finset.mem_singleton]; omega
+    have hrne : r ∉ ({s} : Finset ℕ) := by
+      simp only [Finset.mem_singleton]; omega
+    rw [Finset.card_insert_of_notMem hpne, Finset.card_insert_of_notMem hqne,
+        Finset.card_insert_of_notMem hrne, Finset.card_singleton]
+  calc 4 = ({p, q, r, s} : Finset ℕ).card := h4.symm
+    _ ≤ _ := Finset.card_le_card hsub
+
+/-- **Oppermann ⟹ four primes per double gap.** Conjecture-level form of
+`oppermann_at_four_primes_two_gaps`: under Oppermann, every double gap
+`(n², (n+2)²)` with `n ≥ 2` contains at least four primes. -/
+theorem oppermann_implies_four_primes (h : OppermannConjecture) :
+    ∀ n : ℕ, 2 ≤ n →
+      4 ≤ ((Finset.Ioo (n ^ 2) ((n + 2) ^ 2)).filter Nat.Prime).card :=
+  fun n hn => oppermann_at_four_primes_two_gaps (h n hn) (h (n + 1) (by omega))
 
 /-! ## π-counting form (VERIFIED, 0-axiom)
 
@@ -228,6 +297,27 @@ theorem oppermann_conjecture_iff_pi :
   · intro h n hn; exact (oppermann_at_iff_pi hn).mp (h n hn)
   · intro h n hn; exact (oppermann_at_iff_pi hn).mpr (h n hn)
 
+/-- **Oppermann ⟹ `π((n+1)²) − π(n²) ≥ 2`, π-counting total form.** The whole
+square-gap contributes at least two to the prime-counting difference: the
+`π`-difference form of `oppermann_at_two_primes`, obtained by folding the
+open-interval two-prime count through the composite right endpoint `(n+1)²`.
+VERIFIED, 0-axiom. -/
+theorem oppermann_at_pi_total {n : ℕ} (hn : 1 ≤ n) (h : OppermannAt n) :
+    2 ≤ primeCounting ((n + 1) ^ 2) - primeCounting (n ^ 2) := by
+  have hcomp2 : ¬ Nat.Prime ((n + 1) ^ 2) := by
+    have hh : (n + 1) ^ 2 = (n + 1) * (n + 1) := by ring
+    rw [hh]; exact Nat.not_prime_mul (by omega) (by omega)
+  have hle : n ^ 2 ≤ (n + 1) ^ 2 := by nlinarith
+  have hcard := oppermann_at_two_primes h
+  rwa [← card_primes_Ioc hle, ← card_primes_Ioo_eq_Ioc hcomp2]
+
+/-- Conjecture-level form of `oppermann_at_pi_total`: under Oppermann,
+`π((n+1)²) − π(n²) ≥ 2` for every `n ≥ 2`. VERIFIED, 0-axiom. -/
+theorem oppermann_implies_pi_total (h : OppermannConjecture) :
+    ∀ n : ℕ, 2 ≤ n →
+      2 ≤ primeCounting ((n + 1) ^ 2) - primeCounting (n ^ 2) :=
+  fun n hn => oppermann_at_pi_total (by omega) (h n hn)
+
 /-! ## Computational verification (axiomatized via `native_decide`)
 
 Each `OppermannAt n` is witnessed by an explicit pair (lower-half prime,
@@ -278,6 +368,14 @@ theorem). -/
 theorem two_primes_2 :
     2 ≤ ((Finset.Ioo (2 ^ 2) (3 ^ 2)).filter Nat.Prime).card :=
   oppermann_at_two_primes oppermann_2
+
+/-- Brocard-mechanism sanity corollary: the double gap `(4, 16) = (2², 4²)`
+contains at least four primes (namely `5, 7, 11, 13`), obtained from the verified
+instances `oppermann_2`, `oppermann_3` through the 0-axiom structural theorem
+`oppermann_at_four_primes_two_gaps`. -/
+theorem four_primes_2 :
+    4 ≤ ((Finset.Ioo (2 ^ 2) ((2 + 2) ^ 2)).filter Nat.Prime).card :=
+  oppermann_at_four_primes_two_gaps oppermann_2 oppermann_3
 
 /-- π-counting sanity corollary at `n = 2`: `π(6) − π(4) ≥ 1` (lower half) and
 `π(9) − π(6) ≥ 1` (upper half), derived from the verified instance `oppermann_2`

--- a/research/problems/legendre-partial-oq-04/knowledge.md
+++ b/research/problems/legendre-partial-oq-04/knowledge.md
@@ -19,3 +19,36 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Session 2026-07-04 (researcher-11) — the Brocard mechanism (0-axiom)
+
+The base entry was already `completed` (statement + Oppermann⟹Legendre +
+Oppermann⟹≥2 primes + π-counting form + native_decide n=2..20 + axiom). This
+session added new **0-axiom** structural content on top:
+
+- **`oppermann_at_four_primes_two_gaps`**: `OppermannAt n → OppermannAt (n+1) →
+  4 ≤ #{primes in (n²,(n+2)²)}`. Four explicit half-interval primes `p<q<r<s`,
+  kept pairwise distinct by the composite separators `n²+n`, `(n+1)²`,
+  `(n+1)²+(n+1)`; `{p,q,r,s} ⊆ prime-filter` gives card ≥ 4. This is the
+  elementary combinatorial core of **Oppermann ⟹ Brocard**.
+- **`oppermann_at_pi_total`**: `OppermannAt n → π((n+1)²)−π(n²) ≥ 2`, the total
+  π-count form of `oppermann_at_two_primes` (no monotonicity lemma needed —
+  transport through `card_primes_Ioc` + the composite endpoint `(n+1)²`).
+- Conjecture-level corollaries and a `four_primes_2` sanity instance.
+
+### Technical notes
+- **omega + nonlinear terms**: `(n+1+1)²` and `(n+2)²` are DISTINCT terms to
+  omega (it does not do nonlinear reasoning), so when `OppermannAt (n+1)`
+  unfolds its upper bound to `s < (n+1+1)²` you must supply BOTH `ring`
+  expansions `(n+1+1)² = n²+4n+4` and `(n+2)² = n²+4n+4` for omega to link them.
+- `Finset.card_insert_of_not_mem` is deprecated → use
+  `Finset.card_insert_of_notMem` (the `not_mem`→`notMem` rename).
+- Verified 0-axiom: `#print axioms` on both new structural theorems reports only
+  `propext, Classical.choice, Quot.sound`.
+
+### Frontier
+Full Brocard (over consecutive primes) = package this mechanism: consecutive
+primes `p<q≥3` are both odd so `q ≥ p+2`, then sum the adjacent-gap bound over
+`p..q-1` to reach `π(q²)−π(p²) ≥ 4`. Recorded in nextSteps.

--- a/research/problems/legendre-partial-oq-04/state.md
+++ b/research/problems/legendre-partial-oq-04/state.md
@@ -1,25 +1,38 @@
 # Research State: legendre-partial-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED (extended)
 **Path**: full
 **Since**: 2026-06-27T11:33:01-07:00
-**Iteration**: 1
+**Iteration**: extension session 2026-07-04 (researcher-11)
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Enriching the completed Oppermann entry with new 0-axiom structural theorems.
+This session added **the Brocard mechanism** and the **total π-count form**.
 
 ## Active Approach
-None yet.
+Honest hypothesis-taking implications from `OppermannAt` (never asserting the
+open conjecture), proved by elementary interval arithmetic + `Finset.card`.
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+## What was added this session (all VERIFIED, 0-axiom)
+- `oppermann_at_four_primes_two_gaps` — Oppermann at two *adjacent* gaps `n`,
+  `n+1` ⟹ ≥ 4 primes in the double gap `(n², (n+2)²)`. The elementary
+  combinatorial core of the classical **Oppermann ⟹ Brocard** implication.
+- `oppermann_implies_four_primes` — its conjecture-level corollary.
+- `oppermann_at_pi_total` / `oppermann_implies_pi_total` — total π-count form
+  `π((n+1)²) − π(n²) ≥ 2`.
+- `four_primes_2` — sanity corollary (≥ 4 primes in `(4,16)`) from `oppermann_2`,
+  `oppermann_3`.
+
+`#print axioms` on the two new structural theorems reports only
+`propext, Classical.choice, Quot.sound` (genuinely 0-axiom). Build:
+`docker-build.sh Proofs.LegendrePartialOQ04` → exit 0, 7744 jobs.
 
 ## Blockers
-None.
+None. The remaining frontier (full Brocard over consecutive primes) is a
+packaging step, recorded in `nextSteps`.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+To assemble full Brocard from the mechanism: prove consecutive primes `p<q≥3`
+satisfy `q ≥ p+2` (both odd) and sum `oppermann_at_four_primes_two_gaps`-style
+adjacent-gap contributions over `p..q-1` to get `π(q²) − π(p²) ≥ 4`.

--- a/src/data/proofs/legendre-partial-oq-04/meta.json
+++ b/src/data/proofs/legendre-partial-oq-04/meta.json
@@ -33,14 +33,16 @@
       "Formal statement of Oppermann's conjecture (prime in both halves of each square-gap)",
       "VERIFIED (0-axiom): Oppermann ⟹ Legendre, pointwise and conjecture-level",
       "VERIFIED (0-axiom): Oppermann ⟹ at least two primes between consecutive squares (strict strengthening of Legendre)",
+      "VERIFIED (0-axiom): the Brocard mechanism — Oppermann at two adjacent gaps forces ≥ 4 primes in the double gap (n², (n+2)²), the elementary combinatorial core of the classical Oppermann ⟹ Brocard implication",
+      "VERIFIED (0-axiom): total π-count form, Oppermann ⟹ π((n+1)²) − π(n²) ≥ 2",
       "Computational verification of Oppermann for n = 2 to 20 with explicit lower/upper-half prime witnesses"
     ],
     "dateAdded": "2026-06-27",
     "axiomCount": 2,
-    "lineCount": 301,
-    "assumptions": "2 assumptions. (1) `oppermann_conjecture : OppermannConjecture` — the OPEN Oppermann conjecture, stated as an axiom; results downstream of it (e.g. `legendre_of_oppermann`) inherit it. (2) `Lean.ofReduceBool` — the n = 2..20 verifications use `native_decide`, which trusts the Lean compiler's kernel reduction. The four structural theorems (`oppermann_at_implies_legendre_at`, `oppermann_at_two_primes`, `oppermann_implies_legendre`, `oppermann_implies_two_primes`) are fully machine-checked with NO assumptions: #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "lineCount": 399,
+    "assumptions": "2 assumptions. (1) `oppermann_conjecture : OppermannConjecture` — the OPEN Oppermann conjecture, stated as an axiom; results downstream of it (e.g. `legendre_of_oppermann`) inherit it. (2) `Lean.ofReduceBool` — the n = 2..20 verifications use `native_decide`, which trusts the Lean compiler's kernel reduction. All structural theorems — including the Brocard mechanism (`oppermann_at_four_primes_two_gaps`, `oppermann_implies_four_primes`), the π-counting forms (`oppermann_at_iff_pi`, `oppermann_conjecture_iff_pi`, `oppermann_at_pi_total`, `oppermann_implies_pi_total`), and the Legendre/two-primes implications — are fully machine-checked with NO assumptions: #print axioms reports only propext, Classical.choice, Quot.sound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 36,
     "definitionCount": 2,
     "parentId": "legendre-partial"
   },
@@ -151,9 +153,9 @@
       "Finset"
     ],
     "namespace": "Legendre.Oppermann",
-    "lineCount": 301,
+    "lineCount": 399,
     "axiomCount": 1,
-    "theoremCount": 31,
+    "theoremCount": 36,
     "definitionCount": 2,
     "path": "Proofs/LegendrePartialOQ04.lean",
     "sorries": 0
@@ -209,6 +211,12 @@
       "type": "core",
       "description": "VERIFIED (0-axiom): π-counting form. For n ≥ 2, OppermannAt n is equivalent to π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1, using Mathlib's Nat.primeCounting. The composite endpoints n²+n and (n+1)² make the half-open π-difference count exactly the open-interval primes. Rests on the reusable bridge card_primes_Ioc: #{primes in (a,b]} = π(b) − π(a).",
       "leanType": "2 ≤ n -> (OppermannAt n <-> 1 ≤ primeCounting (n^2+n) - primeCounting (n^2) ∧ 1 ≤ primeCounting ((n+1)^2) - primeCounting (n^2+n))"
+    },
+    {
+      "name": "oppermann_at_four_primes_two_gaps",
+      "type": "core",
+      "description": "VERIFIED (0-axiom): the Brocard mechanism. If Oppermann holds at both n and n+1, the double gap (n², (n+2)²) contains at least FOUR primes — the two half-interval primes of (n², (n+1)²) and the two of ((n+1)², (n+2)²), kept distinct by the composite separators n²+n, (n+1)², (n+1)²+(n+1). This is the elementary combinatorial core of the classical Oppermann ⟹ Brocard implication (consecutive primes ≥ 3 differ by ≥ 2, so their squares always straddle two adjacent square-gaps).",
+      "leanType": "OppermannAt n -> OppermannAt (n+1) -> 4 ≤ ((Finset.Ioo (n^2) ((n+2)^2)).filter Nat.Prime).card"
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/legendre-partial-oq-04.json
+++ b/src/data/research/problems/legendre-partial-oq-04.json
@@ -18,9 +18,9 @@
     "open": [],
     "goal": ""
   },
-  "currentState": "SOLVED (axiomatized): Oppermann stated; structural theorems Oppermann ⟹ Legendre and Oppermann ⟹ ≥2 primes per square-gap proved 0-axiom; Oppermann verified for n = 2..20 via native_decide; general conjecture stated as axiom. Proofs/LegendrePartialOQ04.lean.",
+  "currentState": "SOLVED (axiomatized) + EXTENDED: Oppermann stated; structural theorems Oppermann ⟹ Legendre and Oppermann ⟹ ≥2 primes per square-gap proved 0-axiom; π-counting form (oppermann_at_iff_pi); the Brocard mechanism (oppermann_at_four_primes_two_gaps: two adjacent gaps ⟹ ≥4 primes in (n²,(n+2)²)) and total π-count (oppermann_at_pi_total) added, all 0-axiom; Oppermann verified for n = 2..20 via native_decide; general conjecture stated as axiom. Proofs/LegendrePartialOQ04.lean.",
   "knowledge": {
-    "progressSummary": "COMPLETE + EXTENDED: Oppermann formalized; now recast in π-counting form (oppermann_at_iff_pi / oppermann_conjecture_iff_pi) tied to Mathlib's Nat.primeCounting, plus a reusable interval-prime-count bridge card_primes_Ioc. All new content VERIFIED 0-axiom.",
+    "progressSummary": "COMPLETE + EXTENDED (twice): Oppermann formalized; recast in π-counting form (oppermann_at_iff_pi / oppermann_conjecture_iff_pi) via Mathlib's Nat.primeCounting and the reusable bridge card_primes_Ioc; then extended with the Brocard mechanism — Oppermann at two adjacent gaps forces ≥4 primes in (n²,(n+2)²) (oppermann_at_four_primes_two_gaps) — and a total π-count form (oppermann_at_pi_total: π((n+1)²)−π(n²) ≥ 2). All new content VERIFIED 0-axiom (propext/Choice/Quot only).",
     "builtItems": [
       "OppermannAt / OppermannConjecture: prime in both halves of (n²,(n+1)²) split at n²+n (LegendrePartialOQ04.lean:57,64)",
       "oppermann_at_implies_legendre_at: Oppermann ⟹ Legendre pointwise, 0-axiom (LegendrePartialOQ04.lean:75)",
@@ -31,7 +31,10 @@
       "card_primes_Ioc (LegendrePartialOQ04.lean) — #{primes in (a,b]} = π(b)−π(a); VERIFIED 0-axiom",
       "card_primes_Ioo_eq_Ioc, exists_prime_Ioo_iff_card (LegendrePartialOQ04.lean) — interval prime-count helpers; VERIFIED 0-axiom",
       "oppermann_at_iff_pi, oppermann_conjecture_iff_pi (LegendrePartialOQ04.lean) — Oppermann in π-counting form; VERIFIED 0-axiom (propext/Choice/Quot only)",
-      "pi_bounds_2 (LegendrePartialOQ04.lean) — π-form sanity corollary at n=2 (via native_decide witness, Lean.ofReduceBool)"
+      "pi_bounds_2 (LegendrePartialOQ04.lean) — π-form sanity corollary at n=2 (via native_decide witness, Lean.ofReduceBool)",
+      "oppermann_at_four_primes_two_gaps / oppermann_implies_four_primes (LegendrePartialOQ04.lean) — the Brocard mechanism: Oppermann at n and n+1 ⟹ ≥4 primes in (n²,(n+2)²); VERIFIED 0-axiom",
+      "oppermann_at_pi_total / oppermann_implies_pi_total (LegendrePartialOQ04.lean) — total π-count form: Oppermann ⟹ π((n+1)²)−π(n²) ≥ 2; VERIFIED 0-axiom",
+      "four_primes_2 (LegendrePartialOQ04.lean) — Brocard-mechanism sanity corollary: ≥4 primes in (4,16) from oppermann_2, oppermann_3"
     ],
     "insights": [
       "Splitting (n²,(n+1)²) at n²+n = n·(n+1) loses no primes since the split point is composite for n ≥ 1; the two halves have widths n and n+1.",
@@ -40,13 +43,15 @@
       "Structural theorems are honest implications taking the conjecture as a hypothesis; only native_decide (Lean.ofReduceBool) and the explicit oppermann_conjecture axiom carry assumptions.",
       "OppermannAt 1 is false (lower half (1,2) empty) — the boundary that forces the classical n > 1 statement.",
       "π-counting form of Oppermann: OppermannAt n ⟺ π(n²+n)−π(n²) ≥ 1 ∧ π((n+1)²)−π(n²+n) ≥ 1 for n ≥ 2. The equivalence is exact because both half-open right endpoints n²+n = n(n+1) and (n+1)² are composite, so #{primes in (a,b]} = #{primes in (a,b)} there.",
-      "Bridge lemma card_primes_Ioc: #{primes in (a,b]} = π(b)−π(a) for Mathlib's Nat.primeCounting, proved via Nat.count_eq_card_filter_range + a disjoint-union card identity (range(a+1) ⊔ Ioc a b = range(b+1)). Avoid Finset.card_sdiff here — in the pinned Mathlib its signature is #(t\\s)=#t−#(s∩t), not the subset-hypothesis form."
+      "Bridge lemma card_primes_Ioc: #{primes in (a,b]} = π(b)−π(a) for Mathlib's Nat.primeCounting, proved via Nat.count_eq_card_filter_range + a disjoint-union card identity (range(a+1) ⊔ Ioc a b = range(b+1)). Avoid Finset.card_sdiff here — in the pinned Mathlib its signature is #(t\\s)=#t−#(s∩t), not the subset-hypothesis form.",
+      "The Brocard mechanism factors cleanly through TWO adjacent gaps, avoiding consecutive-prime bookkeeping: OppermannAt n and OppermannAt (n+1) give four explicit primes p<q<r<s (the four half-interval witnesses), all in (n²,(n+2)²) and pairwise distinct because the composite separators n²+n, (n+1)², (n+1)²+(n+1) sit strictly between successive witnesses; {p,q,r,s} ⊆ prime-filter then gives card ≥ 4. omega needs (n+1)², (n+2)² AND (n+1+1)² each expanded as separate `ring` facts — (n+1+1)² and (n+2)² are distinct terms to omega (nonlinear), so both expansions are required.",
+      "Total π-count form (oppermann_at_pi_total) reuses oppermann_at_two_primes without any primeCounting-monotonicity lemma: #{primes in Ioo(n²,(n+1)²)} = #{primes in Ioc} (since (n+1)² composite) = π((n+1)²)−π(n²) via card_primes_Ioc; the ≥2 bound transports by two rewrites."
     ],
     "mathlibGaps": [
       "No scalable certified primality (Pratt/Lucas certificates) wired up — native_decide does not extend much beyond n = 20."
     ],
     "nextSteps": [
-      "Formalize the Brocard conjecture (≥4 primes between consecutive PRIME squares p², q²) as a further strengthening, with the analogous π-counting form π(q²)−π(p²) ≥ 4.",
+      "DONE (this session): the Brocard MECHANISM — Oppermann at two adjacent gaps ⟹ ≥4 primes in (n²,(n+2)²) — is proved 0-axiom (oppermann_at_four_primes_two_gaps). Remaining for full Brocard: package it over CONSECUTIVE PRIMES p<q≥3 by proving q ≥ p+2 (both odd) and summing the mechanism over the p..q-1 adjacent gaps to get ≥4 primes in (p²,q²), with the π-form π(q²)−π(p²) ≥ 4.",
       "Extend computational verification with certified primality certificates (Lucas/Pratt) to remove the native_decide (Lean.ofReduceBool) dependence and reach larger n.",
       "Relate the π-counting form to PNT heuristics: π(n²+n)−π(n²) ~ n/(2 log n) → ∞, giving the standard (non-rigorous) evidence for Oppermann."
     ]


### PR DESCRIPTION
## Summary

Extends the **completed** Oppermann's-conjecture entry (`legendre-partial-oq-04`) with new **fully machine-checked, 0-axiom** structural theorems. The existing content (statement, Oppermann ⟹ Legendre, Oppermann ⟹ ≥2 primes, π-counting form, `native_decide` n=2..20, open conjecture as axiom) is unchanged; this adds the next honest rung.

### New theorems (all VERIFIED, 0-axiom)

- **`oppermann_at_four_primes_two_gaps`** — the **Brocard mechanism**: if Oppermann holds at two *adjacent* gaps `n` and `n+1`, the double gap `(n², (n+2)²)` contains at least **four** primes. The four half-interval primes `p<q<r<s` are kept pairwise distinct by the composite separators `n²+n`, `(n+1)²`, `(n+1)²+(n+1)`. This is the elementary combinatorial core of the classical **Oppermann ⟹ Brocard** implication (consecutive primes ≥ 3 differ by ≥ 2, so their squares always straddle two adjacent square-gaps).
- **`oppermann_implies_four_primes`** — its conjecture-level corollary.
- **`oppermann_at_pi_total` / `oppermann_implies_pi_total`** — total π-count form: Oppermann ⟹ `π((n+1)²) − π(n²) ≥ 2`.
- **`four_primes_2`** — sanity corollary (≥ 4 primes in `(4, 16)`) from the verified instances `oppermann_2`, `oppermann_3`.

### Verification

- `#print axioms` on both new structural theorems → `[propext, Classical.choice, Quot.sound]` only (genuinely 0-axiom: no `Lean.ofReduceBool`, no `sorryAx`).
- `./proofs/scripts/docker-build.sh Proofs.LegendrePartialOQ04` → **exit 0, 7744 jobs**, no warnings.
- Overall entry status **unchanged** (`axiomatized`): the only assumptions remain the open `oppermann_conjecture` axiom and `Lean.ofReduceBool` from the `native_decide` spot-checks.

### Bookkeeping

- `meta.json`: `lineCount` 301→399, `theoremCount` 31→36, new `originalContributions` + `mainTheorem`, refreshed `assumptions` note.
- Research tracking (`state.md`, `knowledge.md`, data JSON): the "formalize Brocard" next-step is now advanced — the *mechanism* is done; the remaining packaging over consecutive primes (`q ≥ p+2`, sum over `p..q-1`) is recorded as the frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)