### PR TITLE
Research: split torus & normalizer of SL(2,p) (sylow-theorem-oq-04-oq-03) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/SylowTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/SylowTheoremOQ04OQ03.lean
@@ -26,6 +26,27 @@
     (`unipotentHom`), so its image is abelian and isomorphic to `ZMod p`;
   * the image has cardinality exactly `p` (the order-p Sylow / unipotent subgroup).
 
+  We then build the **split diagonal torus**
+
+      T = { [[a, 0], [0, a⁻¹]] : a ∈ 𝔽_pˣ } ⊆ SL(2, 𝔽_p),
+
+  the second factor of the Borel `B = U ⋊ T`, and prove the two facts Iwasawa's
+  criterion needs about the pair `(U, T)`:
+
+  * `t ↦ torusDiag a` is an injective group homomorphism `(ZMod p)ˣ →* SL(2, ZMod p)`
+    (`torusHom`), so its image is the abelian torus of cardinality exactly `p − 1`
+    (`card_torus_range`);
+  * **T normalizes U** with the conjugation acting through the square map: for every
+    `a ∈ 𝔽_pˣ` and `t ∈ 𝔽_p`,
+
+        diag(a) · [[1, t], [0, 1]] · diag(a)⁻¹ = [[1, a²·t], [0, 1]]
+
+    (`torusHom_conj_unipotent`), so each `T`-conjugate of a unipotent element is
+    again unipotent (`torus_normalizes_unipotent`). This is precisely the
+    `U ⊴ B` normality that makes `B = U ⋊ T` the point stabiliser required by
+    Iwasawa's lemma, and it exhibits the `a ↦ a²` action of the torus on the root
+    group that governs the whole SL(2) structure theory.
+
   Everything here is `sorry`-free and axiom-free; the deep simplicity theorem
   remains open.
 
@@ -33,7 +54,8 @@
   - Rotman, An Introduction to the Theory of Groups (4th ed.), §9.
   - Dixon & Mortimer, Permutation Groups, §3.3 (Iwasawa's lemma), §2.8.
 
-  Tags: group-theory, sylow, PSL, special-linear-group, unipotent, iwasawa
+  Tags: group-theory, sylow, PSL, special-linear-group, unipotent, iwasawa,
+        borel, torus, normalizer
 -/
 
 import Mathlib
@@ -118,5 +140,126 @@ theorem card_unipotent_range :
   have e : ZMod p ≃ Set.range (unipotentUpper (p := p)) :=
     Equiv.ofInjective _ unipotentUpper_injective
   rw [← Nat.card_congr e, Nat.card_eq_fintype_card, ZMod.card]
+
+/-!
+## The split diagonal torus and its normalizing action on `U`
+
+We now build the split maximal torus
+
+    T = { [[a, 0], [0, a⁻¹]] : a ∈ (ZMod p)ˣ } ⊆ SL(2, ZMod p),
+
+the second factor of the Borel `B = U ⋊ T`, and prove that `T` normalizes the
+unipotent subgroup `U` by conjugation through the square map `a ↦ a²`.
+-/
+
+/-- The split diagonal matrix `[[a, 0], [0, a⁻¹]]` for a unit `a`, viewed as an
+element of `SL(2, ZMod p)`. Its determinant is `a · a⁻¹ − 0 · 0 = 1`. -/
+def torusDiag (a : (ZMod p)ˣ) : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) :=
+  ⟨!![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)], by
+    rw [Matrix.det_fin_two_of, mul_zero, sub_zero]; exact Units.mul_inv a⟩
+
+@[simp] theorem val_torusDiag (a : (ZMod p)ˣ) :
+    (torusDiag a : Matrix (Fin 2) (Fin 2) (ZMod p))
+      = !![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)] := rfl
+
+/-- The diagonal embedding is multiplicative:
+`[[a,0],[0,a⁻¹]] · [[b,0],[0,b⁻¹]] = [[ab,0],[0,(ab)⁻¹]]`. -/
+theorem torusDiag_mul (a b : (ZMod p)ˣ) :
+    torusDiag a * torusDiag b = torusDiag (a * b) := by
+  apply Subtype.ext
+  have hab : (((a * b)⁻¹ : (ZMod p)ˣ) : ZMod p)
+      = ((a⁻¹ : (ZMod p)ˣ) : ZMod p) * ((b⁻¹ : (ZMod p)ˣ) : ZMod p) := by
+    rw [mul_inv, Units.val_mul]
+  show ((!![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)]
+        : Matrix (Fin 2) (Fin 2) (ZMod p))
+        * !![(b : ZMod p), 0; 0, ((b⁻¹ : (ZMod p)ˣ) : ZMod p)])
+      = !![((a * b : (ZMod p)ˣ) : ZMod p), 0; 0, (((a * b)⁻¹ : (ZMod p)ˣ) : ZMod p)]
+  rw [Units.val_mul, hab]
+  set x := (a : ZMod p)
+  set y := (b : ZMod p)
+  set xi := ((a⁻¹ : (ZMod p)ˣ) : ZMod p)
+  set yi := ((b⁻¹ : (ZMod p)ˣ) : ZMod p)
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
+/-- The diagonal embedding sends the unit `1` to the identity matrix. -/
+theorem torusDiag_one : torusDiag (1 : (ZMod p)ˣ) = 1 := by
+  apply Subtype.ext
+  show (!![((1 : (ZMod p)ˣ) : ZMod p), 0; 0, (((1 : (ZMod p)ˣ)⁻¹ : (ZMod p)ˣ) : ZMod p)]
+      : Matrix (Fin 2) (Fin 2) (ZMod p)) = 1
+  rw [Matrix.one_fin_two]
+  simp
+
+/-- The split torus packaged as a group homomorphism from the unit group
+`(ZMod p)ˣ` into `SL(2, ZMod p)`. Its image is the split maximal torus `T`. -/
+def torusHom : (ZMod p)ˣ →* Matrix.SpecialLinearGroup (Fin 2) (ZMod p) where
+  toFun := torusDiag
+  map_one' := torusDiag_one
+  map_mul' a b := (torusDiag_mul a b).symm
+
+@[simp] theorem torusHom_apply (a : (ZMod p)ˣ) : torusHom a = torusDiag a := rfl
+
+/-- The diagonal embedding is injective (read off the top-left entry). -/
+theorem torusDiag_injective : Function.Injective (torusDiag (p := p)) := by
+  intro a b h
+  apply Units.ext
+  -- `↑(torusDiag a) 0 0` reduces definitionally to `↑a`, so the top-left entry
+  -- gives `↑a = ↑b` directly.
+  exact congrArg
+    (fun M : Matrix.SpecialLinearGroup (Fin 2) (ZMod p) =>
+      (M : Matrix (Fin 2) (Fin 2) (ZMod p)) 0 0) h
+
+/-- `torusHom` is injective, so its range is a subgroup of `SL(2, ZMod p)`
+isomorphic to `(ZMod p)ˣ`. -/
+theorem torusHom_injective : Function.Injective (torusHom (p := p)) :=
+  torusDiag_injective
+
+/-- The split torus has cardinality exactly `p − 1`: it is the maximal split
+torus `T`, the complement of `U` in the Borel `B = U ⋊ T`. -/
+theorem card_torus_range :
+    Nat.card (Set.range (torusDiag (p := p))) = p - 1 := by
+  have e : (ZMod p)ˣ ≃ Set.range (torusDiag (p := p)) :=
+    Equiv.ofInjective _ torusDiag_injective
+  rw [← Nat.card_congr e, Nat.card_eq_fintype_card, ZMod.card_units]
+
+/-- **The torus normalizes the unipotent subgroup, acting by squares.** For every
+unit `a` and every `t`, conjugating the unipotent element `[[1, t], [0, 1]]` by the
+diagonal `diag(a) = [[a, 0], [0, a⁻¹]]` returns the unipotent element `[[1, a²t],
+[0, 1]]`:
+
+    diag(a) · [[1, t], [0, 1]] · diag(a)⁻¹ = [[1, a²·t], [0, 1]].
+
+This is the `U ⊴ B` normality that makes the Borel `B = U ⋊ T` the point
+stabiliser required by Iwasawa's simplicity criterion, and exhibits the `a ↦ a²`
+action of the split torus on the root group `U`. -/
+theorem torusHom_conj_unipotent (a : (ZMod p)ˣ) (t : ZMod p) :
+    torusHom a * unipotentUpper t * (torusHom a)⁻¹
+      = unipotentUpper ((a : ZMod p) ^ 2 * t) := by
+  have ha : (a : ZMod p) * ((a⁻¹ : (ZMod p)ˣ) : ZMod p) = 1 := Units.mul_inv a
+  have ha' : ((a⁻¹ : (ZMod p)ˣ) : ZMod p) * (a : ZMod p) = 1 := Units.inv_mul a
+  have haa : (((a⁻¹ : (ZMod p)ˣ)⁻¹ : (ZMod p)ˣ) : ZMod p) = (a : ZMod p) := by
+    rw [inv_inv]
+  rw [← map_inv torusHom]
+  apply Subtype.ext
+  show (((!![(a : ZMod p), 0; 0, ((a⁻¹ : (ZMod p)ˣ) : ZMod p)]
+        : Matrix (Fin 2) (Fin 2) (ZMod p))
+        * !![1, t; 0, 1])
+        * !![((a⁻¹ : (ZMod p)ˣ) : ZMod p), 0; 0,
+            (((a⁻¹ : (ZMod p)ˣ)⁻¹ : (ZMod p)ˣ) : ZMod p)])
+      = !![1, (a : ZMod p) ^ 2 * t; 0, 1]
+  rw [haa]
+  set x := (a : ZMod p)
+  set xi := ((a⁻¹ : (ZMod p)ˣ) : ZMod p)
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, ha, ha'] <;> ring
+
+/-- Each `T`-conjugate of a unipotent element is again unipotent: the torus maps
+the unipotent subgroup `U` into itself under conjugation. -/
+theorem torus_normalizes_unipotent (a : (ZMod p)ˣ) (t : ZMod p) :
+    torusHom a * unipotentUpper t * (torusHom a)⁻¹
+      ∈ Set.range (unipotentUpper (p := p)) :=
+  ⟨(a : ZMod p) ^ 2 * t, (torusHom_conj_unipotent a t).symm⟩
 
 end SylowOQ04OQ03

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/annotations.json
@@ -2,17 +2,17 @@
   {
     "id": "ann-sylow-oq0403-overview",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 1, "endLine": 40 },
+    "range": { "startLine": 1, "endLine": 59 },
     "type": "concept",
     "title": "An Honest Fragment of an Open Problem",
-    "content": "The parent open question asks whether PSL(2, p) is simple for every prime p ≥ 5 — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on a large body of missing Mathlib infrastructure: the action of PSL(2, p) on the projective line P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5. Rather than sorry-out the whole statement, this file isolates and fully verifies ONE reusable building block: the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p}. U is simultaneously the abelian normal subgroup of the Borel that Iwasawa's criterion requires AND the order-p Sylow subgroup of SL(2, p). Everything here is sorry-free and axiom-free; the deep simplicity theorem remains open.",
-    "mathContext": "$\\mathrm{PSL}(2,p) = \\mathrm{SL}(2,\\mathbb{F}_p)/\\{\\pm I\\}$ is simple for every prime $p \\ge 5$; $|\\mathrm{SL}(2,p)| = p(p-1)(p+1)$, so its $p$-part is exactly $p$.",
+    "content": "The parent open question asks whether PSL(2, p) is simple for every prime p ≥ 5 — the first infinite family of finite non-abelian simple groups. The full theorem is genuinely blocked on a large body of missing Mathlib infrastructure: the action of PSL(2, p) on the projective line P¹(𝔽_p), its 2-transitivity, an Iwasawa structure, and perfectness for p ≥ 5. Rather than sorry-out the whole statement, this file isolates and fully verifies reusable building blocks: the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p}, the split diagonal torus T = {[[a,0],[0,a⁻¹]] : a ∈ 𝔽_pˣ}, and the normalizer relation that makes the Borel B = U ⋊ T. Everything here is sorry-free and axiom-free; the deep simplicity theorem remains open.",
+    "mathContext": "$\\mathrm{PSL}(2,p) = \\mathrm{SL}(2,\\mathbb{F}_p)/\\{\\pm I\\}$ is simple for every prime $p \\ge 5$; $|\\mathrm{SL}(2,p)| = p(p-1)(p+1)$, so its $p$-part is exactly $p$ and $|U|=p$, $|T|=p-1$.",
     "significance": "context",
     "relatedConcepts": [
       "projective special linear group PSL(2, p)",
       "finite simple groups",
       "Iwasawa's simplicity criterion",
-      "Borel subgroup"
+      "Borel subgroup B = U ⋊ T"
     ],
     "prerequisites": [
       "special linear group SL(2, 𝔽_p)",
@@ -22,7 +22,7 @@
   {
     "id": "ann-sylow-oq0403-det",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 54, "endLine": 62 },
+    "range": { "startLine": 76, "endLine": 82 },
     "type": "concept",
     "title": "Landing in SL(2, 𝔽_p): the Determinant-1 Condition",
     "content": "`unipotentUpper t` packages the matrix [[1,t],[0,1]] as an element of `Matrix.SpecialLinearGroup (Fin 2) (ZMod p)`. The membership obligation is det = 1, discharged by `Matrix.det_fin_two_of`: the determinant of [[a,b],[c,d]] is a·d − b·c = 1·1 − t·0 = 1. This is the smallest non-diagonal unipotent — every entry is fixed except the top-right, which carries the parameter t.",
@@ -42,7 +42,7 @@
   {
     "id": "ann-sylow-oq0403-additivity",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 64, "endLine": 88 },
+    "range": { "startLine": 84, "endLine": 103 },
     "type": "insight",
     "title": "The Group Law is Addition: [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]]",
     "content": "`unipotentUpper_mul` proves the one-parameter subgroup multiplies by adding parameters, verified entrywise via `fin_cases i <;> fin_cases j` over the four 2×2 positions and `Matrix.mul_apply` / `Fin.sum_univ_two`. Together with `unipotentUpper_zero` (the identity is [[1,0],[0,1]]), this exhibits U as a homomorphic image of the additive group (ℤ/p, +): in particular it is abelian (`unipotentUpper_comm` follows by `add_comm`). No Sylow counting is needed — the abelian structure is read directly off the matrix arithmetic.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-sylow-oq0403-hom",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 91, "endLine": 111 },
+    "range": { "startLine": 105, "endLine": 133 },
     "type": "tactic",
     "title": "Writing (ℤ/p, +) Multiplicatively to get a genuine MonoidHom",
     "content": "`unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` upgrades the embedding to a bundled group homomorphism. The trick is `Multiplicative (ZMod p)`: it is (ℤ/p, +) presented with multiplicative notation, so `map_mul'` is literally the additivity identity `unipotentUpper_mul` and `map_one'` is `unipotentUpper_zero`. Injectivity (`unipotentHom_injective`) reduces to injectivity of `unipotentUpper`, which is immediate from a single matrix entry — the top-right coordinate is exactly t (`unipotentUpper_injective`).",
@@ -82,7 +82,7 @@
   {
     "id": "ann-sylow-oq0403-card",
     "proofId": "sylow-theorem-oq-04-oq-03",
-    "range": { "startLine": 113, "endLine": 122 },
+    "range": { "startLine": 135, "endLine": 142 },
     "type": "insight",
     "title": "Cardinality Exactly p: the Order-p Sylow Subgroup",
     "content": "`card_unipotent_range` computes |U| = p by transporting the cardinality of ℤ/p through the injection with `Equiv.ofInjective`, then `Nat.card_congr` and `ZMod.card`. Since |SL(2, 𝔽_p)| = p(p−1)(p+1) has p-part exactly p, this identifies U as a full Sylow-p subgroup of SL(2, p). This is the object on which the modern Iwasawa-criterion proof of PSL(2, p) simplicity is built — the abelian normal subgroup of the Borel stabiliser whose conjugates generate the group.",
@@ -97,6 +97,46 @@
     "prerequisites": [
       "cardinality via bijection (Nat.card_congr)",
       "Sylow's theorems (p-part of the group order)"
+    ]
+  },
+  {
+    "id": "ann-sylow-oq0403-torus",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 155, "endLine": 234 },
+    "type": "concept",
+    "title": "The Split Torus T and Its Cardinality p−1",
+    "content": "`torusDiag a = [[a,0],[0,a⁻¹]]` for a unit a ∈ 𝔽_pˣ has determinant a·a⁻¹ = 1 (`Units.mul_inv`), so it lands in SL(2, 𝔽_p). Multiplicativity `torusDiag_mul` (handling (ab)⁻¹ via `mul_inv` and `Units.val_mul`) and identity `torusDiag_one` package it as the bundled homomorphism `torusHom : (ZMod p)ˣ →* SL(2, ZMod p)`. Injectivity is read off the top-left entry a (`torusDiag_injective`), and `card_torus_range` gives |T| = p−1 via `ZMod.card_units`. T is the split maximal torus — the p′-part complement of the unipotent radical U inside the Borel B = U ⋊ T.",
+    "mathContext": "$\\det \\begin{pmatrix} a & 0 \\\\ 0 & a^{-1} \\end{pmatrix} = a\\cdot a^{-1} = 1$; $|T| = |\\mathbb{F}_p^\\times| = p-1$, the $p'$-part of $|B| = p(p-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "split maximal torus",
+      "unit group 𝔽_pˣ",
+      "ZMod.card_units",
+      "Borel factorisation B = U ⋊ T"
+    ],
+    "prerequisites": [
+      "units of a finite field",
+      "cardinality via bijection (Equiv.ofInjective)"
+    ]
+  },
+  {
+    "id": "ann-sylow-oq0403-normalizer",
+    "proofId": "sylow-theorem-oq-04-oq-03",
+    "range": { "startLine": 236, "endLine": 264 },
+    "type": "insight",
+    "title": "T Normalizes U by the Square Map: diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]]",
+    "content": "`torusHom_conj_unipotent` is the algebraic heart of the Borel's semidirect-product structure. Rewriting (torusHom a)⁻¹ = torusHom a⁻¹ with `map_inv` exposes diag(a)⁻¹ = [[a⁻¹,0],[0,a]], and the triple matrix product is computed entrywise: the diagonal entries collapse through a·a⁻¹ = 1 and a⁻¹·a = 1 (`Units.mul_inv`, `Units.inv_mul`), while the top-right entry is a·t·a = a²·t by `ring`. The result [[1,a²t],[0,1]] lies back in U, so T normalizes U (`torus_normalizes_unipotent`) — this is the U ⊴ B normality Iwasawa's criterion needs, and it shows the torus acts on the root group through the square map a ↦ a². A formalisation note: `simp` loops on the unit coercions ↑a, ↑a⁻¹ unless they are frozen as opaque locals with `set` first.",
+    "mathContext": "$\\begin{pmatrix} a & 0 \\\\ 0 & a^{-1} \\end{pmatrix}\\begin{pmatrix} 1 & t \\\\ 0 & 1 \\end{pmatrix}\\begin{pmatrix} a^{-1} & 0 \\\\ 0 & a \\end{pmatrix} = \\begin{pmatrix} 1 & a^2 t \\\\ 0 & 1 \\end{pmatrix}$, so conjugation by $\\mathrm{diag}(a)$ acts on $U$ by $t \\mapsto a^2 t$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "normalizer / normal subgroup U ⊴ B",
+      "semidirect product B = U ⋊ T",
+      "root group and the square-map action a ↦ a²",
+      "map_inv for group homomorphisms"
+    ],
+    "prerequisites": [
+      "conjugation and normal subgroups",
+      "matrix multiplication and inverses in SL(2)"
     ]
   }
 ]

--- a/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-04-oq-03/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "sylow-theorem-oq-04-oq-03",
-  "title": "The Unipotent Sylow-p Subgroup of SL(2, p)",
+  "title": "The Unipotent Sylow-p Subgroup and Split Torus of SL(2, p)",
   "slug": "sylow-theorem-oq-04-oq-03",
-  "description": "A fully verified, axiom-free construction of the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} of SL(2, 𝔽_p). U is embedded as an injective group homomorphism from the additive group (ℤ/p, +), proving it is abelian, isomorphic to ℤ/p, and of cardinality exactly p — the order-p Sylow subgroup of SL(2, p) and the abelian normal subgroup of the Borel that Iwasawa's criterion requires for the simplicity of PSL(2, p). One clean piece of infrastructure toward the open question that PSL(2, p) is simple for every prime p ≥ 5.",
+  "description": "A fully verified, axiom-free construction of two of the ingredients Iwasawa's criterion needs for the simplicity of PSL(2, p): (1) the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} of SL(2, 𝔽_p), embedded as an injective homomorphism from (ℤ/p, +), hence abelian, ≅ ℤ/p, and of cardinality exactly p (the order-p Sylow subgroup); and (2) the split diagonal torus T = {[[a,0],[0,a⁻¹]] : a ∈ 𝔽_pˣ}, embedded as an injective homomorphism from 𝔽_pˣ, of cardinality exactly p−1. The centrepiece is the normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]], proving that T normalizes U with the torus acting through the square map a ↦ a² — precisely the U ⊴ B = U⋊T normality that makes the Borel the point stabiliser Iwasawa's criterion requires. Clean, reusable infrastructure toward the open question that PSL(2, p) is simple for every prime p ≥ 5.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-04",
@@ -14,24 +14,54 @@
       "special-linear-group",
       "PSL",
       "unipotent",
-      "iwasawa"
+      "iwasawa",
+      "borel",
+      "torus",
+      "normalizer"
     ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-07-04",
     "axiomCount": 0,
-    "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). Every result is machine-checked from Mathlib over the ordinary foundational axioms only. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup infrastructure and makes no claim about the open question itself.",
-    "lineCount": 122,
-    "theoremCount": 8,
-    "definitionCount": 2,
+    "assumptions": "No assumptions: 0 `axiom` declarations, 0 sorries, 0 structure-encoded hypotheses, no `native_decide` (so no `Lean.ofReduceBool`). `#print axioms` for `torusHom_conj_unipotent` and `card_torus_range` reports only the ordinary foundational axioms `propext`, `Classical.choice`, `Quot.sound`. Every result is machine-checked from Mathlib. The parent simplicity theorem for PSL(2, p) remains open; this entry proves only the verified unipotent-subgroup and split-torus infrastructure and makes no claim about the open question itself.",
+    "lineCount": 265,
+    "theoremCount": 17,
+    "definitionCount": 4,
     "originalContributions": [
       "unipotentUpper: the matrix [[1,t],[0,1]] packaged as a determinant-1 element of SL(2, ZMod p)",
       "unipotentUpper_mul: additivity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]], giving an abelian one-parameter subgroup",
-      "unipotentHom: the injective group homomorphism Multiplicative(ZMod p) →* SL(2, ZMod p) whose image is the unipotent subgroup",
-      "card_unipotent_range: the image has cardinality exactly p, identifying it as the order-p Sylow subgroup of SL(2, p)"
+      "unipotentHom / card_unipotent_range: the injective homomorphism Multiplicative(ZMod p) →* SL(2, ZMod p) whose image is the order-p unipotent Sylow subgroup",
+      "torusDiag / torusHom: the split diagonal torus [[a,0],[0,a⁻¹]] packaged as an injective homomorphism (ZMod p)ˣ →* SL(2, ZMod p)",
+      "card_torus_range: the torus image has cardinality exactly p−1 (via ZMod.card_units)",
+      "torusHom_conj_unipotent: the normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]], proving T normalizes U by conjugation through the square map a ↦ a²",
+      "torus_normalizes_unipotent: each T-conjugate of a unipotent element stays in U (U ⊴ B)"
     ]
   },
   "mainTheorems": [
+    {
+      "name": "torusHom_conj_unipotent",
+      "type": "core",
+      "description": "The split torus normalizes the unipotent subgroup, acting by squares: diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]] for every unit a and every t. Rewriting (torusHom a)⁻¹ = torusHom a⁻¹ via map_inv exposes diag(a)⁻¹ = [[a⁻¹,0],[0,a]]; the triple matrix product is computed entrywise, the diagonal entries collapsing through a·a⁻¹ = 1 and the top-right entry being a·t·a = a²·t by ring. This is the U ⊴ B normality that makes the Borel B = U ⋊ T the point stabiliser Iwasawa's criterion requires.",
+      "leanType": "(a : (ZMod p)ˣ) → (t : ZMod p) → torusHom a * unipotentUpper t * (torusHom a)⁻¹ = unipotentUpper ((a : ZMod p) ^ 2 * t)"
+    },
+    {
+      "name": "card_torus_range",
+      "type": "core",
+      "description": "The split diagonal torus has cardinality exactly p−1: the maximal split torus T, the p′-part complement of the unipotent radical U inside the Borel B = U ⋊ T. Proved by transporting the cardinality of (ZMod p)ˣ through the injection torusDiag with Equiv.ofInjective, then Nat.card_congr and ZMod.card_units.",
+      "leanType": "Nat.card (Set.range (torusDiag (p := p))) = p - 1"
+    },
+    {
+      "name": "torusHom",
+      "type": "core",
+      "description": "The split torus packaged as a group homomorphism (ZMod p)ˣ →* SL(2, ZMod p), a ↦ [[a,0],[0,a⁻¹]]. map_one' is torusDiag_one and map_mul' is torusDiag_mul (which handles (ab)⁻¹ via mul_inv and Units.val_mul). Injective by torusDiag_injective, read off the top-left entry.",
+      "leanType": "(ZMod p)ˣ →* Matrix.SpecialLinearGroup (Fin 2) (ZMod p)"
+    },
+    {
+      "name": "torusDiag",
+      "type": "definition",
+      "description": "The split diagonal matrix [[a,0],[0,a⁻¹]] for a unit a ∈ (ZMod p)ˣ, packaged as a determinant-1 element of SL(2, ZMod p); the membership det = a·a⁻¹ = 1 is discharged by Matrix.det_fin_two_of and Units.mul_inv.",
+      "leanType": "(a : (ZMod p)ˣ) → Matrix.SpecialLinearGroup (Fin 2) (ZMod p)"
+    },
     {
       "name": "card_unipotent_range",
       "type": "core",
@@ -65,12 +95,13 @@
   ],
   "overview": {
     "historicalContext": "The projective special linear groups PSL(2, p) form the first infinite family of finite non-abelian simple groups, with PSL(2, 5) ≅ A₅ the smallest. Their simplicity for p ≥ 5 was known to Évariste Galois (1832), who studied the exceptional behaviour at p = 5, 7, 11. Camille Jordan established the simplicity systematically in his Traité (1870). The modern textbook route is not a raw Sylow count but Iwasawa's simplicity criterion (Iwasawa 1941; see Dixon & Mortimer, Permutation Groups §3.3), applied to the natural action of PSL(2, p) on the projective line P¹(𝔽_p). That criterion requires exhibiting an abelian normal subgroup of a point stabiliser (the Borel subgroup) whose conjugates generate the whole group. The upper-unipotent subgroup U constructed here is exactly that abelian normal subgroup — and simultaneously the order-p Sylow subgroup of SL(2, p), since |SL(2, p)| = p(p−1)(p+1) has p-part exactly p.",
-    "problemStatement": "**Open question (parent):** PSL(2, p) is simple for every prime p ≥ 5.\n\n**This entry (verified fragment):** Construct the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} ⊆ SL(2, 𝔽_p) and prove that t ↦ [[1,t],[0,1]] is an injective group homomorphism from (ℤ/p, +), so that U is abelian, isomorphic to ℤ/p, and has cardinality exactly p.",
-    "proofStrategy": "The matrix [[1,t],[0,1]] has determinant 1·1 − t·0 = 1, so `unipotentUpper t` lands in SL(2, ZMod p) (`Matrix.det_fin_two_of`). Matrix multiplication gives [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]] (`unipotentUpper_mul`, proved entrywise by `fin_cases` + `ring`), and [[1,0],[0,1]] = 1 (`unipotentUpper_zero`). These package into a monoid homomorphism `unipotentHom` from Multiplicative(ZMod p): map_one from unipotentUpper_zero, map_mul from unipotentUpper_mul. Injectivity is read off the top-right entry (`unipotentUpper_injective`). Finally `Equiv.ofInjective` transports the cardinality of ZMod p through the injection, and `ZMod.card` gives |U| = p (`card_unipotent_range`).",
+    "problemStatement": "**Open question (parent):** PSL(2, p) is simple for every prime p ≥ 5.\n\n**This entry (verified fragment):** (1) Construct the upper-unipotent one-parameter subgroup U = {[[1,t],[0,1]] : t ∈ 𝔽_p} ⊆ SL(2, 𝔽_p) as an injective homomorphism from (ℤ/p, +), so U is abelian, ≅ ℤ/p, of cardinality p. (2) Construct the split diagonal torus T = {[[a,0],[0,a⁻¹]] : a ∈ 𝔽_pˣ} as an injective homomorphism from 𝔽_pˣ, of cardinality p−1. (3) Prove the normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]], so T normalizes U (U ⊴ B = U⋊T), the point-stabiliser normality Iwasawa's criterion requires.",
+    "proofStrategy": "**Unipotent U.** The matrix [[1,t],[0,1]] has determinant 1, so `unipotentUpper t` lands in SL(2, ZMod p). Matrix multiplication gives [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]] (`unipotentUpper_mul`, entrywise `fin_cases`), packaged into `unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)`; injectivity from the top-right entry and `Equiv.ofInjective` + `ZMod.card` give |U| = p. **Torus T.** The diagonal [[a,0],[0,a⁻¹]] has determinant a·a⁻¹ = 1 (`Units.mul_inv`), so `torusDiag a ∈ SL(2, ZMod p)`. Multiplicativity `torusDiag a · torusDiag b = torusDiag (a·b)` uses `mul_inv`/`Units.val_mul` to handle (ab)⁻¹, packaged into `torusHom : (ZMod p)ˣ →* SL(2, ZMod p)`; injectivity from the top-left entry and `ZMod.card_units` give |T| = p−1. **Normalizer.** Rewriting (torusHom a)⁻¹ = torusHom a⁻¹ via `map_inv`, the triple matrix product diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ is computed entrywise: the two diagonal entries collapse via a·a⁻¹ = 1 (`Units.mul_inv`, `Units.inv_mul`) and the top-right entry is a·t·a = a²·t by `ring`, yielding [[1,a²t],[0,1]] (`torusHom_conj_unipotent`). A one-line corollary places every conjugate back in the range of U (`torus_normalizes_unipotent`). Throughout, unit coercions are frozen with `set` before the entrywise `simp` so the matrix arithmetic stays in a plain commutative ring.",
     "keyInsights": [
-      "The unipotent subgroup is simultaneously (a) the abelian normal subgroup of the Borel required by Iwasawa's criterion and (b) the order-p Sylow subgroup of SL(2, p) — the same object plays both roles.",
-      "Writing the additive group (ℤ/p, +) multiplicatively via `Multiplicative (ZMod p)` lets the one-parameter subgroup be a genuine `MonoidHom`, so that `map_mul` is literally the additivity identity [[1,s],[0,1]]·[[1,t],[0,1]] = [[1,s+t],[0,1]].",
-      "Injectivity is immediate from a single matrix entry (the top-right coordinate is t), so the subgroup structure and its cardinality p follow with no counting argument.",
+      "The unipotent subgroup is simultaneously (a) the abelian normal subgroup of the Borel required by Iwasawa's criterion and (b) the order-p Sylow subgroup of SL(2, p) — the same object plays both roles; the split torus T is its complement in the Borel factorisation B = U ⋊ T.",
+      "The normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]] is the algebraic core of the semidirect product: it shows T normalizes U and that the torus acts on the root group U through the square map a ↦ a², the action that governs the whole SL(2) structure theory.",
+      "Injectivity of both embeddings is immediate from a single matrix entry (top-right coordinate t for U, top-left coordinate a for T), so the subgroup structure and the cardinalities p and p−1 follow with no counting argument.",
+      "Formalisation detail: `simp`'s entrywise matrix computation loops on the unit coercions ↑a, ↑a⁻¹ unless they are frozen as opaque locals with `set` first — after which the arithmetic reduces exactly as in the plain-ring unipotent case.",
       "This is the honest boundary between what is verified and what is open: the deep simplicity theorem is genuinely blocked on the PSL(2, p) action on P¹, its 2-transitivity, and perfectness — none of which are claimed here."
     ],
     "prerequisites": [
@@ -85,29 +116,36 @@
       "id": "sec-sylow-oq04oq03-header",
       "title": "Header and Motivation",
       "startLine": 1,
-      "endLine": 52,
-      "description": "Module docstring framing the open question (simplicity of PSL(2, p) for p ≥ 5), explaining why the standard route is Iwasawa's criterion rather than a raw Sylow count, and stating precisely which verified fragment this file delivers: the upper-unipotent subgroup U as the abelian normal subgroup of the Borel and the order-p Sylow subgroup. References Rotman §9 and Dixon & Mortimer §3.3, §2.8."
+      "endLine": 59,
+      "description": "Module docstring framing the open question (simplicity of PSL(2, p) for p ≥ 5), explaining why the standard route is Iwasawa's criterion rather than a raw Sylow count, and stating precisely which verified fragments this file delivers: the upper-unipotent subgroup U (abelian normal subgroup of the Borel and order-p Sylow subgroup), the split torus T, and the normalizer relation making B = U ⋊ T. References Rotman §9 and Dixon & Mortimer §3.3, §2.8."
     },
     {
       "id": "sec-sylow-oq04oq03-def",
       "title": "The Unipotent Matrix and Its Group Law",
-      "startLine": 54,
-      "endLine": 89,
-      "description": "Defines `unipotentUpper t = [[1,t],[0,1]]` as an element of SL(2, ZMod p) (determinant 1 via `Matrix.det_fin_two_of`), with the simp lemma `val_unipotentUpper`. Proves additivity `unipotentUpper_mul` (entrywise `fin_cases`/`ring`), identity `unipotentUpper_zero`, commutativity `unipotentUpper_comm`, and injectivity `unipotentUpper_injective` (from the top-right entry)."
+      "startLine": 76,
+      "endLine": 111,
+      "description": "Defines `unipotentUpper t = [[1,t],[0,1]]` as an element of SL(2, ZMod p) (determinant 1 via `Matrix.det_fin_two_of`), with the simp lemma `val_unipotentUpper`. Proves additivity `unipotentUpper_mul` (entrywise `fin_cases`), identity `unipotentUpper_zero`, commutativity `unipotentUpper_comm`, and injectivity `unipotentUpper_injective` (from the top-right entry)."
     },
     {
       "id": "sec-sylow-oq04oq03-hom",
-      "title": "The One-Parameter Subgroup as a Homomorphism and Its Cardinality",
-      "startLine": 90,
-      "endLine": 122,
-      "description": "Packages the embedding as `unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)` (map_one from `unipotentUpper_zero`, map_mul from `unipotentUpper_mul`), proves it injective (`unipotentHom_injective`), and computes the cardinality of the image as exactly p (`card_unipotent_range`) via `Equiv.ofInjective` and `ZMod.card` — identifying U as the order-p Sylow subgroup of SL(2, p)."
+      "title": "The Unipotent Subgroup as a Homomorphism and Its Cardinality",
+      "startLine": 113,
+      "endLine": 142,
+      "description": "Packages the embedding as `unipotentHom : Multiplicative (ZMod p) →* SL(2, ZMod p)`, proves it injective (`unipotentHom_injective`), and computes the cardinality of the image as exactly p (`card_unipotent_range`) via `Equiv.ofInjective` and `ZMod.card` — identifying U as the order-p Sylow subgroup of SL(2, p)."
+    },
+    {
+      "id": "sec-sylow-oq04oq03-torus",
+      "title": "The Split Torus and Its Normalizing Action on U",
+      "startLine": 144,
+      "endLine": 264,
+      "description": "Defines the split diagonal torus `torusDiag a = [[a,0],[0,a⁻¹]]` in SL(2, ZMod p) (determinant a·a⁻¹ = 1 via `Units.mul_inv`), proves multiplicativity `torusDiag_mul` and identity `torusDiag_one`, packages them as `torusHom : (ZMod p)ˣ →* SL(2, ZMod p)`, and shows injectivity (`torusDiag_injective`, from the top-left entry) and cardinality p−1 (`card_torus_range`, via `ZMod.card_units`). The centrepiece `torusHom_conj_unipotent` proves the normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]] (using `map_inv` to expose diag(a)⁻¹ = diag(a⁻¹) and an entrywise computation with a·a⁻¹ = 1), and `torus_normalizes_unipotent` records that every T-conjugate of a unipotent element stays in U."
     }
   ],
   "conclusion": {
-    "summary": "The upper-unipotent one-parameter subgroup of SL(2, 𝔽_p) is constructed and verified, axiom-free, as an injective homomorphic image of (ℤ/p, +): abelian, isomorphic to ℤ/p, of cardinality exactly p. This is the abelian normal subgroup of the Borel that Iwasawa's criterion needs and the order-p Sylow subgroup of SL(2, p).",
-    "implications": "This isolates and machine-verifies one reusable building block of the standard Iwasawa-criterion route to the simplicity of PSL(2, p) for primes p ≥ 5, the first infinite family of finite simple groups. The remaining ingredients — the action on P¹(𝔽_p), 2-transitivity, perfectness, and the assembly via Iwasawa's lemma — remain open in Mathlib.",
+    "summary": "Two verified, axiom-free ingredients of the Iwasawa-criterion route to the simplicity of PSL(2, p) are constructed: the upper-unipotent subgroup U ≅ (ℤ/p, +) of SL(2, 𝔽_p), abelian and of cardinality p (the order-p Sylow subgroup), and the split diagonal torus T ≅ 𝔽_pˣ of cardinality p−1. The normalizer relation diag(a)·[[1,t],[0,1]]·diag(a)⁻¹ = [[1,a²t],[0,1]] proves that T normalizes U by the square-map action a ↦ a², establishing the U ⊴ B = U ⋊ T normality that makes the Borel the point stabiliser Iwasawa's criterion requires.",
+    "implications": "This machine-verifies two reusable building blocks — and the semidirect-product relation binding them — of the standard route to the simplicity of PSL(2, p) for primes p ≥ 5, the first infinite family of finite simple groups. The remaining ingredients — the action on P¹(𝔽_p), 2-transitivity, perfectness, and the assembly via Iwasawa's lemma — remain open in Mathlib.",
     "openQuestions": [
-      "Formalize the action of PSL(2, p) on the projective line P¹(𝔽_p) and its 2-transitivity.",
+      "Formalize the action of PSL(2, p) on the projective line P¹(𝔽_p) and its 2-transitivity, with the Borel B = U ⋊ T as the stabiliser of ∞.",
       "Prove that the conjugates of the unipotent subgroup U generate SL(2, p) (perfectness for p ≥ 5).",
       "Assemble the pieces via Iwasawa's simplicity criterion to prove PSL(2, p) simple for every prime p ≥ 5."
     ]
@@ -162,12 +200,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 122,
+    "lineCount": 265,
     "path": "Proofs/SylowTheoremOQ04OQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "definitionCount": 2,
-    "theoremCount": 8
+    "definitionCount": 4,
+    "theoremCount": 17
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Extends the verified **Unipotent Sylow-p Subgroup of SL(2, p)** entry (`sylow-theorem-oq-04-oq-03`) with the next reusable ingredient of the Iwasawa-criterion route to PSL(2, p) simplicity: the **split diagonal torus** and the **normalizer relation** binding it to the unipotent subgroup.

### New verified content
- `torusDiag a = [[a,0],[0,a⁻¹]]` — the split diagonal matrix as a determinant-1 element of SL(2, ZMod p) (det = a·a⁻¹ = 1).
- `torusHom : (ZMod p)ˣ →* SL(2, ZMod p)` — bundled as an injective group homomorphism (multiplicativity, identity).
- `card_torus_range` — |T| = p−1 via `ZMod.card_units`.
- **`torusHom_conj_unipotent`** (centrepiece) — the normalizer relation
  ```
  diag(a) · [[1, t], [0, 1]] · diag(a)⁻¹ = [[1, a²·t], [0, 1]],
  ```
  proving **T normalizes U**, with the torus acting on the root group through the square map a ↦ a². This is the `U ⊴ B = U ⋊ T` normality that makes the Borel the point stabiliser Iwasawa's criterion requires.
- `torus_normalizes_unipotent` — every T-conjugate of a unipotent element stays in U.

### Verification
- Docker-built (`./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ04OQ03`), 0 errors.
- **Axiom-free**: `#print axioms` on `torusHom_conj_unipotent` and `card_torus_range` reports only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). 0 sorries, 0 `axiom` declarations, 0 structure-encoded hypotheses.
- Counts updated: 8→17 theorems, 2→4 defs, 122→265 lines. Gallery `meta.json` and `annotations.json` updated (preserving the enricher's `mainTheorems`/`references` from #34639, adding torus entries).

### Status
The parent simplicity theorem for PSL(2, p) remains **open** — this entry adds verified infrastructure only and makes no claim about the open question itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)