### PR TITLE
Research: chebyshev-pnt-bridge — limit-ready ratio form of the θ↔π sandwich

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ03OQ01.lean
@@ -152,4 +152,38 @@ theorem chebyshev_theta_primeCounting_sandwich
   ⟨chebyshevTheta_le_primeCounting_mul_log n,
    primeCounting_le_add_chebyshevTheta_div_log y n hy hyn⟩
 
+/-- **Limit-ready ratio form of the θ ↔ π sandwich.**  Dividing the two inequalities of
+`chebyshev_theta_primeCounting_sandwich` by `n` puts the reduction in exactly the shape the
+prime-number-theorem limit consumes: the normalized prime count `π(n)·log n / n` is squeezed
+between `θ(n)/n` and `θ(n)/n · (log n / log y) + y·log n / n`.
+
+Choosing `y = y(n)` with `y/n → 0` and `log n / log y → 1` (e.g. `y ≈ n/(log n)²`) then
+forces `π(n)·log n / n → 1 ⟺ θ(n)/n → 1`; only that elementary `o(1)` bookkeeping remains,
+the deep input `θ(n)/n → 1` being Wiener–Ikehara-level (and blocked in the pinned Mathlib). -/
+theorem primeCounting_mul_log_div_sandwich
+    (y n : ℕ) (hy : 2 ≤ y) (hyn : y ≤ n) :
+    chebyshevTheta n / (n : ℝ) ≤ (Nat.primeCounting n : ℝ) * Real.log n / (n : ℝ)
+      ∧ (Nat.primeCounting n : ℝ) * Real.log n / (n : ℝ)
+          ≤ chebyshevTheta n / (n : ℝ) * (Real.log n / Real.log y)
+            + (y : ℝ) * Real.log n / (n : ℝ) := by
+  obtain ⟨hlo, hhi⟩ := chebyshev_theta_primeCounting_sandwich y n hy hyn
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (show 0 < n by omega)
+  have hn_ne : (n : ℝ) ≠ 0 := ne_of_gt hn_pos
+  have hlogy_pos : 0 < Real.log y := Real.log_pos (by exact_mod_cast hy)
+  have hlogy_ne : Real.log y ≠ 0 := ne_of_gt hlogy_pos
+  have hlogn_pos : 0 < Real.log n := Real.log_pos (by exact_mod_cast (show 1 < n by omega))
+  refine ⟨by gcongr, ?_⟩
+  -- multiply the upper bound `π(n) ≤ y + θ(n)/log y` by the nonnegative factor `log n / n`
+  have hfac : (0 : ℝ) ≤ Real.log n / (n : ℝ) := by positivity
+  have key := mul_le_mul_of_nonneg_right hhi hfac
+  have eL : (Nat.primeCounting n : ℝ) * (Real.log n / (n : ℝ))
+      = (Nat.primeCounting n : ℝ) * Real.log n / (n : ℝ) := by ring
+  have eR : ((y : ℝ) + chebyshevTheta n / Real.log y) * (Real.log n / (n : ℝ))
+      = chebyshevTheta n / (n : ℝ) * (Real.log n / Real.log y)
+        + (y : ℝ) * Real.log n / (n : ℝ) := by
+    field_simp
+    ring
+  rw [eL, eR] at key
+  exact key
+
 end ChebyshevPNTBridgeOQ03OQ01

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-03-oq-01/meta.json
@@ -50,11 +50,12 @@
       "chebyshevTheta_le_primeCounting_mul_log: the upper half θ(n) ≤ π(n)·log n, proved by bounding each of the π(n) summands log p (p ≤ n) by log n and collapsing the constant sum to π(n)·log n via the identity π(n) = |filter Prime (range (n+1))|",
       "primeCounting_le_add_chebyshevTheta_div_log: the threshold lower half π(n) ≤ y + θ(n)/log y for 2 ≤ y ≤ n — the tail primes y < p ≤ n each contribute ≥ log y to θ(n), so their count π(n) − π(y) is ≤ θ(n)/log y, and the remaining π(y) ≤ y primes are absorbed into the +y term",
       "tail_sum_le_chebyshevTheta: the tail sum ∑_{y<p≤n} log p ≤ θ(n) as a sub-sum of nonnegative log-terms, the key monotonicity step of the lower half",
-      "chebyshev_theta_primeCounting_sandwich: the packaged two-sided statement θ(n) ≤ π(n)·log n ∧ π(n) ≤ y + θ(n)/log y for 2 ≤ y ≤ n — the analysis-free reduction underlying θ(x) ~ x ⟺ π(x) ~ x/log x, the natural drop-in for a PNT-for-ψ ⟹ PNT-for-π transfer"
+      "chebyshev_theta_primeCounting_sandwich: the packaged two-sided statement θ(n) ≤ π(n)·log n ∧ π(n) ≤ y + θ(n)/log y for 2 ≤ y ≤ n — the analysis-free reduction underlying θ(x) ~ x ⟺ π(x) ~ x/log x, the natural drop-in for a PNT-for-ψ ⟹ PNT-for-π transfer",
+      "primeCounting_mul_log_div_sandwich: the limit-ready ratio form — dividing the sandwich by n squeezes the normalized count π(n)·log n/n between θ(n)/n and θ(n)/n·(log n/log y) + y·log n/n, the exact shape the PNT limit consumes (choose y ≈ n/(log n)² so y/n → 0 and log n/log y → 1, reducing π(n)·log n/n → 1 to θ(n)/n → 1); isolates the remaining elementary o(1) bookkeeping from the deep θ(n)/n → 1 input"
     ],
     "axiomCount": 0,
-    "lineCount": 155,
-    "theoremCount": 5,
+    "lineCount": 189,
+    "theoremCount": 6,
     "definitionCount": 1,
     "assumptions": "None — fully verified from Mathlib and the parent bridge files (ChebyshevThetaFourPow, ChebyshevPNTBridge, ChebyshevPNTBridgeOQ05) with 0 axioms (only propext / Classical.choice / Quot.sound, confirmed by #print axioms) and 0 sorries; no native_decide, no decide. This entry proves ONLY the elementary reduction: the two-sided θ ↔ π·log sandwich. The full PNT asymptotic π(x)·log x / x → 1 (equivalently θ(x)/x → 1) is NOT proved here — it is the irreducible deep content of the Prime Number Theorem and remains an open question, requiring either the Wiener–Ikehara Tauberian theorem (ζ non-vanishing on Re s = 1) or Selberg's symmetry formula, neither present in the pinned Mathlib.",
     "mathlib_version": "4.26.0"
@@ -161,9 +162,9 @@
       "ChebyshevThetaBound"
     ],
     "namespace": "ChebyshevPNTBridgeOQ03OQ01",
-    "lineCount": 155,
+    "lineCount": 189,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 1,
     "path": "Proofs/ChebyshevPNTBridgeOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Follow-up to the merged θ↔π sandwich (#34640) for `chebyshev-pnt-bridge-oq-03-oq-01`
(*Formalize the full PNT `π(x)·log x/x → 1`*). Adds one verified theorem,
`primeCounting_mul_log_div_sandwich`, that divides the existing two-sided sandwich by `n`
to obtain the **limit-ready ratio form**:

```
θ(n)/n ≤ π(n)·log n/n ≤ θ(n)/n·(log n / log y) + y·log n/n      (2 ≤ y ≤ n)
```

This is exactly the shape the prime-number-theorem limit consumes: choosing `y ≈ n/(log n)²`
(so `y/n → 0` and `log n/log y → 1`) collapses the squeeze to
`π(n)·log n/n → 1 ⟺ θ(n)/n → 1`. The PR isolates the remaining **elementary `o(1)`
bookkeeping** from the genuinely deep input `θ(n)/n → 1` (Wiener–Ikehara / Selberg level,
absent from the pinned Mathlib — the problem stays appropriately blocked on that).

## Verification

- Pure algebra from `chebyshev_theta_primeCounting_sandwich` + positivity of `n`, `log y`, `log n`.
- **0 axioms, 0 sorries**; 155→189 lines, 5→6 theorems.
- `./proofs/scripts/docker-build.sh Proofs.ChebyshevPNTBridgeOQ03OQ01` — **builds** against Mathlib 4.26.
- Gallery meta updated (line/theorem counts, new contribution entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)