### PR TITLE
Restore herons-formula-oq-06-oq-02 content reverted by #34650 (keep sibling cross-ref)

### DIFF
--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -52,6 +52,18 @@
       "type": "main",
       "description": "Gerretsen's inequality: for any nondegenerate triangle, s² ≤ 4R² + 4Rr + 3r².",
       "leanType": "semiperimeter a b c ^ 2 ≤ 4 * circumradius a b c ^ 2 + 4 * (circumradius a b c * inradius a b c) + 3 * inradius a b c ^ 2"
+    },
+    {
+      "name": "circumradius_sq",
+      "type": "supporting",
+      "description": "Area-free rewrite of R²: R² = (abc)²/(16·Area²), with Area² = heronProduct (Part II)",
+      "leanType": "circumradius a b c ^ 2 = (a*b*c)^2 / (16 * heronProduct a b c)"
+    },
+    {
+      "name": "inradius_sq",
+      "type": "supporting",
+      "description": "Area-free rewrite of r²: r² = Area²/s² = heronProduct/s² (Part II)",
+      "leanType": "inradius a b c ^ 2 = heronProduct a b c / semiperimeter a b c ^ 2"
     }
   ],
   "sections": [
@@ -95,12 +107,29 @@
       "description": "Answers the parent Euler-inequality entry's open question on extending the Ravi-substitution SOS technique to Gerretsen; reuses its triangle data (semiperimeter, area, circumradius, inradius, area_sq)."
     },
     {
+      "targetId": "herons-formula-oq-06-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry under the same parent: Euler's triangle formula OI² = R² − 2Rr, the geometric distance identity whose nonnegativity gives the parent's Euler inequality R ≥ 2r. Gerretsen's s² ≤ 4R² + 4Rr + 3r² sharpens that same Euler bound, so both entries live in the fundamental (s, R, r) inequality web."
+    },
+    {
       "targetId": "herons-formula",
       "relationship": "related",
       "description": "Uses Heron's formula Area² = s(s-a)(s-b)(s-c) to eliminate the area from the radius formulas."
     }
   ],
   "references": [
+    {
+      "authors": "Gerretsen, J. C. H.",
+      "title": "Ongelijkheden in de driehoek (Inequalities in the triangle)",
+      "year": "1953",
+      "note": "Original source of the two Gerretsen inequalities s² ≤ 4R² + 4Rr + 3r² and s² ≥ 16Rr − 5r²; Nieuw Tijdschrift voor Wiskunde 41, 1–7."
+    },
+    {
+      "authors": "Blundon, W. J.",
+      "title": "Inequalities associated with the triangle",
+      "year": "1965",
+      "note": "Establishes the sharp bounds s ≤ 2R + (3√3 − 4)r and the fundamental (s, R, r) region; the Blundon upper bound named in the open questions. Canadian Mathematical Bulletin 8, 615–626."
+    },
     {
       "title": "Gerretsen's inequality / fundamental triangle inequalities",
       "url": "https://en.wikipedia.org/wiki/List_of_triangle_inequalities"


### PR DESCRIPTION
## Corrective PR — restores content reverted by #34650

**What went wrong:** My enrichment PR #34650 was built via git plumbing that hashed a *stale worktree copy* of `meta.json` instead of the current `main` version. On merge it silently reverted two recently-merged enrichments of this same entry:

- **#34561** — the `circumradius_sq` and `inradius_sq` mainTheorems (4 → 6)
- **#34610** — the Gerretsen (1953) and Blundon (1965) primary-source references

**This PR** rebuilds `meta.json` from the good pre-revert state (commit `6d0228890b7`) on top of current `main`, so it:
- restores all 6 mainTheorems and all 4 references, and
- retains the intended enrichment from #34650: the `related` cross-reference to the sibling entry `herons-formula-oq-06-oq-01` (Euler's OI² = R² − 2Rr).

Net effect vs current `main`: +2 mainTheorems, +2 references, +1 crossReference — i.e. the regression is undone and the one genuine enrichment is kept.

Validated: JSON parses; 6 mainTheorems, 4 references, 3 crossReferences.
