### PR TITLE
Enrich Inverse Galois OQ-04: cross-reference child Kummer–Dedekind step entries

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04/meta.json
@@ -119,6 +119,16 @@
       "targetId": "inverse-galois-oq-06",
       "relationship": "related",
       "description": "Sister entry realizing A₅ over ℚ, anchored on the same InverseGaloisA5 development"
+    },
+    {
+      "targetId": "inverse-galois-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Child entry that formalizes step (1) — the Kummer\u2013Dedekind Step-1 brick showing the prime matching an irreducible factor of a polynomial mod p has that factor's degree as its inertia degree — directly answering this entry's first open question."
+    },
+    {
+      "targetId": "inverse-galois-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Child entry supplying the concrete Kummer\u2013Dedekind input for the A\u2085 quintic at p = 7 (the irreducible cubic factor of q mod 7 that this entry's reduction form consumes), advancing the composition toward discharging three_dvd_gal_card."
     }
   ],
   "references": [


### PR DESCRIPTION
## Enrichment — Inverse Galois OQ-04 (`inverse-galois-oq-04`)

This entry is already high-quality (quality 93; 4 full annotations covering the whole 85-line file, comprehensive meta.json under caps). The one genuine gap: its `crossReferences` didn't link the two child entries that directly answer its *own* open questions.

**Change (meta.json only):** `crossReferences` 3 → 5, adding:
- **`inverse-galois-oq-04-oq-01`** — the Kummer–Dedekind **Step-1** brick (splitting datum ⇒ inertia degree), which answers this entry's first open question ("formalize the remaining step 1").
- **`inverse-galois-oq-04-oq-02`** — the concrete Kummer–Dedekind input for the A₅ quintic at p = 7, the input this entry's reduction form consumes.

**Deliberately NOT added:** `kummer-theorem` — that is Kummer's theorem on binomial-coefficient p-adic valuations (carries in base p), unrelated to the Kummer–**Dedekind** prime-factorization theorem referenced here. Linking it would be misleading.

Built deterministically from the current `origin/main` blob (not a working-tree copy). Validated: JSON parses; 5 crossReferences, additive diff only.
