### PR TITLE
Enrich Burnside-over-Finite: cross-ref orbit-stabiliser child entry

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -215,6 +215,11 @@
       "proofId": "derangements-oq-02-oq-02",
       "relationship": "related",
       "description": "Another in-tree application of `sum_card_fixedBy_eq_card_orbits_mul_card_group`, here over `Equiv.Perm (Fin n) ↷ Fin n`. Shares the orbit-counting machinery generalised in this entry."
+    },
+    {
+      "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Child entry that carries the same off-Fintype programme to the orbit-stabiliser identity, lifting it to the instance-free `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G`. Directly answers this entry's open question on whether the finiteness-free lift applies verbatim to the orbit-stabiliser theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment — Burnside's Lemma over Finite (`lagrange-theorem-oq-02-oq-02-oq-01-oq-01`)

Already a comprehensive quality-93 entry (5 keyInsights, 4 full annotations, 6 references). The one genuine gap: it didn't link the child entry that answers its own open question.

**Change (meta.json only):** `crossReferences` 3 → 4, adding **`lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01`** ("The Orbit-Stabilizer Family over Nat.card"). That child carries this entry's exact "generalise off `Fintype`" programme to the orbit-stabiliser identity, so it directly answers this entry's second open question ("Does the same off-Fintype lift apply verbatim to the orbit-stabiliser identity…?").

Built deterministically from the current `origin/main` blob. Verified: JSON parses; diff is purely additive.
