### PR TITLE
Research: Oppermann split form ⟺ original 1882 two-sided form (legendre-partial-oq-04, 0-axiom)

### DIFF
--- a/proofs/Proofs/LegendrePartialOQ04.lean
+++ b/proofs/Proofs/LegendrePartialOQ04.lean
@@ -39,6 +39,12 @@ New content here:
     implication.  VERIFIED, 0-axiom.
   * `oppermann_implies_four_primes` — its conjecture-level corollary.  VERIFIED,
     0-axiom.
+  * `OppermannClassicalAt`, `OppermannClassical` — Oppermann's *original* 1882
+    two-sided formulation (a prime in each of `(n²−n, n²)` and `(n², n²+n)`).
+  * `oppermann_conjecture_iff_classical` — **faithfulness**: the split-interval
+    `OppermannConjecture` is EQUIVALENT to the historical two-sided
+    `OppermannClassical`, via the re-indexing `(n+1)² − (n+1) = n²+n`.  VERIFIED,
+    0-axiom (the only boundary input, the prime `3 ∈ (2, 4)`, is proved outright).
   * `card_primes_Ioc` — the number of primes in `(a, b]` equals `π(b) − π(a)` for
     Mathlib's `Nat.primeCounting`.  VERIFIED, 0-axiom.
   * `oppermann_at_pi_total`, `oppermann_implies_pi_total` — the total π-count
@@ -79,6 +85,19 @@ def OppermannAt (n : ℕ) : Prop :=
 `n = 1` the lower half `(1, 2)` is empty, so the conjecture is stated for
 `n > 1`.) -/
 def OppermannConjecture : Prop := ∀ n : ℕ, 2 ≤ n → OppermannAt n
+
+/-- **Oppermann's original (1882) two-sided formulation at `n`.** Oppermann's
+1882 statement is customarily phrased about the *two* intervals flanking `n²`:
+for `n > 1` there is a prime in `(n²−n, n²)` (just below `n²`) and a prime in
+`(n², n²+n)` (just above `n²`).  This is the historical form; the split-interval
+`OppermannAt` reorganises the same primes around each square-gap. -/
+def OppermannClassicalAt (n : ℕ) : Prop :=
+  (∃ p, Nat.Prime p ∧ n ^ 2 - n < p ∧ p < n ^ 2) ∧
+  (∃ q, Nat.Prime q ∧ n ^ 2 < q ∧ q < n ^ 2 + n)
+
+/-- **Oppermann's conjecture, original two-sided form.** `OppermannClassicalAt n`
+holds for every `n ≥ 2`. -/
+def OppermannClassical : Prop := ∀ n : ℕ, 2 ≤ n → OppermannClassicalAt n
 
 /-! ## Structural theorems (VERIFIED, 0-axiom)
 
@@ -189,6 +208,59 @@ theorem oppermann_implies_four_primes (h : OppermannConjecture) :
     ∀ n : ℕ, 2 ≤ n →
       4 ≤ ((Finset.Ioo (n ^ 2) ((n + 2) ^ 2)).filter Nat.Prime).card :=
   fun n hn => oppermann_at_four_primes_two_gaps (h n hn) (h (n + 1) (by omega))
+
+/-! ## Faithfulness: split form ⟺ Oppermann's original 1882 two-sided form
+(VERIFIED, 0-axiom)
+
+The definition `OppermannAt` splits the square-gap `(n², (n+1)²)` at its midpoint
+`n²+n`; Oppermann's own 1882 statement instead flanks each square `n²` with the
+two intervals `(n²−n, n²)` and `(n², n²+n)` (`OppermannClassicalAt`).  The two are
+re-indexings of the same family of half-intervals: the interval `(n²−n, n²)` just
+below `n²` is exactly the *upper* half `((n−1)²+(n−1), n²)` of the square-gap at
+`n−1`, since `(n−1)² + (n−1) = n² − n`.  This section proves the two conjecture
+forms are *equivalent*, certifying that the split-interval formalisation is
+faithful to the historical statement — the only boundary input is the trivial
+prime `3 ∈ (2, 4)` (the upper half of the gap at `n = 1`). -/
+
+/-- **Re-indexing identity.** The lower interval `((n+1)²−(n+1), (n+1)²)` of the
+original form at `n+1` is *literally* the upper half `(n²+n, (n+1)²)` of the
+square-gap at `n`, because `(n+1)² − (n+1) = n²+n`. -/
+theorem classical_first_succ_iff_upper (n : ℕ) :
+    (∃ p, Nat.Prime p ∧ (n + 1) ^ 2 - (n + 1) < p ∧ p < (n + 1) ^ 2) ↔
+    (∃ q, Nat.Prime q ∧ n ^ 2 + n < q ∧ q < (n + 1) ^ 2) := by
+  have h : (n + 1) ^ 2 - (n + 1) = n ^ 2 + n := by
+    have : (n + 1) ^ 2 = n ^ 2 + 2 * n + 1 := by ring
+    omega
+  rw [h]
+
+/-- **Boundary input.** The upper half of the gap at `n = 1`, `(2, 4)`, contains
+the prime `3`.  This is the one instance the split form does not carry but the
+original two-sided form (starting at `n = 2`) requires. -/
+theorem upper_half_one :
+    ∃ q, Nat.Prime q ∧ 1 ^ 2 + 1 < q ∧ q < (1 + 1) ^ 2 :=
+  ⟨3, by norm_num, by norm_num, by norm_num⟩
+
+/-- **The split form and Oppermann's original 1882 form are equivalent.** For
+every `n ≥ 2`, `OppermannClassicalAt n` (prime in each of `(n²−n, n²)` and
+`(n², n²+n)`) matches the half-intervals of the split form: the second component
+is the *lower* half of the gap at `n`, and the first component is the *upper* half
+of the gap at `n−1`.  Hence `OppermannConjecture ⟺ OppermannClassical`.  VERIFIED,
+0-axiom (the sole boundary fact `upper_half_one` is proved outright). -/
+theorem oppermann_conjecture_iff_classical :
+    OppermannConjecture ↔ OppermannClassical := by
+  constructor
+  · intro h n hn
+    obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+    have hupper : ∃ q, Nat.Prime q ∧ m ^ 2 + m < q ∧ q < (m + 1) ^ 2 := by
+      rcases Nat.lt_or_ge m 2 with hm | hm
+      · interval_cases m
+        · exact absurd hn (by omega)
+        · exact upper_half_one
+      · exact (h m hm).2
+    exact ⟨(classical_first_succ_iff_upper m).mpr hupper, (h (m + 1) hn).1⟩
+  · intro h m hm
+    exact ⟨(h m hm).2,
+      (classical_first_succ_iff_upper m).mp (h (m + 1) (by omega)).1⟩
 
 /-! ## π-counting form (VERIFIED, 0-axiom)
 

--- a/research/problems/legendre-partial-oq-04/knowledge.md
+++ b/research/problems/legendre-partial-oq-04/knowledge.md
@@ -52,3 +52,39 @@ session added new **0-axiom** structural content on top:
 Full Brocard (over consecutive primes) = package this mechanism: consecutive
 primes `p<q≥3` are both odd so `q ≥ p+2`, then sum the adjacent-gap bound over
 `p..q-1` to reach `π(q²)−π(p²) ≥ 4`. Recorded in nextSteps.
+
+---
+
+## Session 2026-07-04 (researcher-6) — faithfulness to Oppermann's 1882 form (0-axiom)
+
+The file defines `OppermannConjecture` via the *split-interval* form (a prime in
+each half of `(n²,(n+1)²)`, split at the composite midpoint `n²+n`). Oppermann's
+**original 1882 statement** is instead two-sided about each square `n²`: for
+`n > 1`, a prime in `(n²−n, n²)` AND a prime in `(n², n²+n)`. The problem.md notes
+these "coincide after re-indexing"; this session turns that informal remark into a
+machine-checked equivalence.
+
+- **`OppermannClassicalAt n`** / **`OppermannClassical`** — the 1882 two-sided form.
+- **`classical_first_succ_iff_upper n`**: the lower interval of the classical form
+  at `n+1`, `((n+1)²−(n+1), (n+1)²)`, is *literally* the upper half `(n²+n,(n+1)²)`
+  of the split gap at `n`. Proof is a one-line `rw` after the Nat identity
+  `(n+1)²−(n+1) = n²+n` (get it from `ring`-expanding `(n+1)²` then `omega`; omega
+  handles the truncated subtraction). Both sides become α-equal, so `rw` closes it.
+- **`oppermann_conjecture_iff_classical`**: `OppermannConjecture ⟺ OppermannClassical`.
+
+### Key subtlety — the index boundary
+The two forms are NOT term-for-term identical at the edge. Writing `H` for
+"prime in the upper half of the split gap at m" and `L` for "prime in the lower
+half at m":
+- `OppermannConjecture` = `∀ m≥2, L(m) ∧ H(m)`.
+- `OppermannClassical`  = `∀ n≥2, H(n−1) ∧ L(n)` = `(∀ m≥1, H(m)) ∧ (∀ m≥2, L(m))`.
+So Classical additionally demands `H(1)` = a prime in `(2,4)`. It's not handed to
+you by the split conjecture (which starts at m≥2), so the forward direction must
+prove `H(1)` outright — **`upper_half_one`** := `⟨3, norm_num, norm_num, norm_num⟩`
+(0-axiom, no `native_decide`). Handle the `m<2` case with `interval_cases m`; the
+`m=0` branch is killed by `absurd hn (by omega)`.
+
+### Verified
+`docker-build.sh Proofs.LegendrePartialOQ04` → exit 0, 7744 jobs.
+`#print axioms oppermann_conjecture_iff_classical` → `propext, Classical.choice,
+Quot.sound` only (genuinely 0-axiom).

--- a/research/problems/legendre-partial-oq-04/state.md
+++ b/research/problems/legendre-partial-oq-04/state.md
@@ -4,35 +4,44 @@
 **Phase**: COMPLETED (extended)
 **Path**: full
 **Since**: 2026-06-27T11:33:01-07:00
-**Iteration**: extension session 2026-07-04 (researcher-11)
+**Iteration**: extension session 2026-07-04 (researcher-6)
 
 ## Current Focus
-Enriching the completed Oppermann entry with new 0-axiom structural theorems.
-This session added **the Brocard mechanism** and the **total π-count form**.
+Faithfulness of the formalization: proved the split-interval `OppermannConjecture`
+is EQUIVALENT to Oppermann's original 1882 two-sided formulation
+`OppermannClassical` (a prime in each of `(n²−n, n²)` and `(n², n²+n)` for all
+`n > 1`). This certifies the file's split statement is a faithful rendering of the
+historical conjecture.
 
 ## Active Approach
-Honest hypothesis-taking implications from `OppermannAt` (never asserting the
-open conjecture), proved by elementary interval arithmetic + `Finset.card`.
+Elementary re-indexing: the lower interval `((n+1)²−(n+1), (n+1)²)` of the
+classical form at `n+1` equals the upper half `(n²+n, (n+1)²)` of the split gap at
+`n`, since `(n+1)² − (n+1) = n²+n`. The only boundary input is the trivial prime
+`3 ∈ (2,4)` (the upper half of the gap at `n = 1`), proved outright.
 
 ## What was added this session (all VERIFIED, 0-axiom)
-- `oppermann_at_four_primes_two_gaps` — Oppermann at two *adjacent* gaps `n`,
-  `n+1` ⟹ ≥ 4 primes in the double gap `(n², (n+2)²)`. The elementary
-  combinatorial core of the classical **Oppermann ⟹ Brocard** implication.
-- `oppermann_implies_four_primes` — its conjecture-level corollary.
-- `oppermann_at_pi_total` / `oppermann_implies_pi_total` — total π-count form
-  `π((n+1)²) − π(n²) ≥ 2`.
-- `four_primes_2` — sanity corollary (≥ 4 primes in `(4,16)`) from `oppermann_2`,
-  `oppermann_3`.
+- `OppermannClassicalAt`, `OppermannClassical` — Oppermann's original 1882
+  two-sided formulation.
+- `classical_first_succ_iff_upper` — the re-indexing identity.
+- `upper_half_one` — the boundary prime `3 ∈ (2,4)`.
+- `oppermann_conjecture_iff_classical` — `OppermannConjecture ⟺ OppermannClassical`.
 
-`#print axioms` on the two new structural theorems reports only
+`#print axioms oppermann_conjecture_iff_classical` reports only
 `propext, Classical.choice, Quot.sound` (genuinely 0-axiom). Build:
 `docker-build.sh Proofs.LegendrePartialOQ04` → exit 0, 7744 jobs.
 
+## Prior sessions (already on main)
+- Statement + bounded `native_decide` verification (n ≤ 20); open conjecture as
+  an `axiom`.
+- `oppermann_at_implies_legendre_at`, `oppermann_at_two_primes` (Legendre + two
+  primes per gap).
+- Brocard mechanism `oppermann_at_four_primes_two_gaps` + total π-count form.
+- π-counting equivalence `oppermann_at_iff_pi`.
+
 ## Blockers
-None. The remaining frontier (full Brocard over consecutive primes) is a
-packaging step, recorded in `nextSteps`.
+None.
 
 ## Next Action
-To assemble full Brocard from the mechanism: prove consecutive primes `p<q≥3`
-satisfy `q ≥ p+2` (both odd) and sum `oppermann_at_four_primes_two_gaps`-style
-adjacent-gap contributions over `p..q-1` to get `π(q²) − π(p²) ≥ 4`.
+Remaining out-of-scope frontier: full Brocard over consecutive primes (sum the
+adjacent-gap mechanism over `p..q-1`); or extend the computational range beyond
+n = 20 with a fast certified sieve.

--- a/src/data/proofs/legendre-partial-oq-04/meta.json
+++ b/src/data/proofs/legendre-partial-oq-04/meta.json
@@ -66,52 +66,6 @@
   },
   "sections": [
     {
-      "id": "sec-header",
-      "title": "Header and Imports",
-      "startLine": 1,
-      "endLine": 49,
-      "summary": "Module docstring for Oppermann's conjecture (Legendre-partial OQ-04): both halves of every square-gap (n², (n+1)²), split at the composite point n²+n, contain a prime. Frames the file as honest structural implications from Oppermann plus native_decide spot-checks, with the conjecture itself left as an axiom. Imports Mathlib and the parent LegendrePartial, and works in namespace Legendre.Oppermann."
-    },
-    {
-      "id": "sec-statement",
-      "title": "Statement",
-      "startLine": 51,
-      "endLine": 64,
-      "summary": "OppermannAt n: a prime in the lower half (n², n²+n) and a prime in the upper half (n²+n, (n+1)²). OppermannConjecture: OppermannAt n for every n ≥ 2 (n = 1 excluded since the lower half (1,2) is empty)."
-    },
-    {
-      "id": "sec-structural",
-      "title": "Structural Theorems (0-axiom Implications)",
-      "startLine": 66,
-      "endLine": 115,
-      "summary": "Honest hypothesis-taking implications, none asserting Oppermann is true. oppermann_at_implies_legendre_at: the lower-half prime already witnesses Legendre at n. oppermann_at_two_primes: the distinct lower/upper primes give ≥ 2 primes in (n², (n+1)²), strengthening Legendre. The two conjecture-level forms (oppermann_implies_legendre, oppermann_implies_two_primes) lift these to all n ≥ 2 — all by elementary interval arithmetic (omega)."
-    },
-    {
-      "id": "sec-computational",
-      "title": "Computational Verification (native_decide)",
-      "startLine": 117,
-      "endLine": 166,
-      "summary": "OppermannAt n verified for 2 ≤ n ≤ 20 (oppermann_2 … oppermann_20) by exhibiting an explicit (lower-half prime, upper-half prime) pair and discharging primality/interval bounds with native_decide (which introduces the Lean.ofReduceBool axiom). two_primes_2 combines a verified instance with the 0-axiom structural theorem to conclude two primes in a concrete gap."
-    },
-    {
-      "id": "sec-open",
-      "title": "The Open Conjecture",
-      "startLine": 168,
-      "endLine": 179,
-      "summary": "oppermann_conjecture is stated as an axiom (open since 1882; strictly stronger than both Legendre's and the open Brocard conjecture). legendre_of_oppermann derives Legendre for all n ≥ 2 as a downstream consequence, inheriting the axiom."
-    }
-  ],
-  "conclusion": {
-    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
-    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
-    "openQuestions": [
-      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
-      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
-      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
-    ]
-  },
-  "sections": [
-    {
       "id": "statement",
       "title": "Statement: OppermannAt and OppermannConjecture",
       "summary": "OppermannAt n asserts a prime in each half of the square-gap (n², (n+1)²) split at n²+n; OppermannConjecture quantifies it over all n ≥ 2",
@@ -144,6 +98,15 @@
       "mathContext": "$\\mathrm{oppermann\\_conjecture}:\\mathrm{OppermannConjecture}$ (declared axiom, the open case); $\\mathrm{legendre\\_of\\_oppermann}:\\forall n\\ge 2,\\ \\mathrm{LegendreAt}(n)$ inherits the assumption."
     }
   ],
+  "conclusion": {
+    "summary": "This entry formalizes Oppermann's conjecture — a prime in both halves of every square-gap — as the natural strengthening of Legendre's conjecture requested by the base entry. It contributes two fully machine-checked (0-axiom) structural theorems: Oppermann implies Legendre, and Oppermann implies at least two primes between every pair of consecutive squares. Oppermann itself is verified computationally for n = 2 to 20 and stated as an axiom for the general case.",
+    "implications": "Locating Oppermann precisely above Legendre in the prime-gap hierarchy (Cramér ⟹ Oppermann ⟹ Legendre ⟺ Andrica ⟹ Bertrand) and supplying the verified Oppermann ⟹ Legendre link turns an informal 'strictly stronger' remark into a checked implication. The two-primes corollary quantifies the strengthening: any proof of Oppermann would immediately yield ≥ 2 primes in each (n², (n+1)²), a statement well beyond what Legendre alone provides.",
+    "openQuestions": [
+      "Is Oppermann's conjecture true for all n ≥ 2? It remains open, strictly between the proved Bertrand postulate and the conjectural Cramér bound.",
+      "Can the computational verification be pushed far beyond n = 20 using certified primality certificates instead of native_decide?",
+      "Does Oppermann's conjecture admit a clean equivalent in terms of the prime-counting function π, formalizable as π(n²+n) − π(n²) ≥ 1 and π((n+1)²) − π(n²+n) ≥ 1?"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -153,10 +116,10 @@
       "Finset"
     ],
     "namespace": "Legendre.Oppermann",
-    "lineCount": 399,
+    "lineCount": 471,
     "axiomCount": 1,
-    "theoremCount": 36,
-    "definitionCount": 2,
+    "theoremCount": 39,
+    "definitionCount": 4,
     "path": "Proofs/LegendrePartialOQ04.lean",
     "sorries": 0
   },
@@ -217,6 +180,12 @@
       "type": "core",
       "description": "VERIFIED (0-axiom): the Brocard mechanism. If Oppermann holds at both n and n+1, the double gap (n², (n+2)²) contains at least FOUR primes — the two half-interval primes of (n², (n+1)²) and the two of ((n+1)², (n+2)²), kept distinct by the composite separators n²+n, (n+1)², (n+1)²+(n+1). This is the elementary combinatorial core of the classical Oppermann ⟹ Brocard implication (consecutive primes ≥ 3 differ by ≥ 2, so their squares always straddle two adjacent square-gaps).",
       "leanType": "OppermannAt n -> OppermannAt (n+1) -> 4 ≤ ((Finset.Ioo (n^2) ((n+2)^2)).filter Nat.Prime).card"
+    },
+    {
+      "name": "oppermann_conjecture_iff_classical",
+      "type": "core",
+      "description": "VERIFIED (0-axiom): faithfulness of the formalization. The split-interval OppermannConjecture (a prime in each half of every square-gap (n²,(n+1)²)) is EQUIVALENT to Oppermann's original 1882 two-sided formulation OppermannClassical (a prime in each of (n²−n,n²) and (n²,n²+n) for all n>1). The bridge is the re-indexing identity (n+1)²−(n+1) = n²+n, which shows the lower interval of the classical form at n+1 is literally the upper half of the split gap at n; the sole boundary input, the prime 3 ∈ (2,4), is proved outright. This certifies the file's split statement is a faithful rendering of the historical conjecture.",
+      "leanType": "OppermannConjecture ↔ OppermannClassical"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Extends the **Oppermann's conjecture** entry (`legendre-partial-oq-04`) with a machine-checked **faithfulness** result: the file's split-interval `OppermannConjecture` is proved EQUIVALENT to Oppermann's *original 1882 two-sided formulation*. The `problem.md` only noted informally that the two "coincide after re-indexing"; this PR turns that remark into a 0-axiom theorem.

## New content (all VERIFIED, 0-axiom)

- `OppermannClassicalAt` / `OppermannClassical` — the historical two-sided form: for `n > 1`, a prime in `(n²−n, n²)` **and** a prime in `(n², n²+n)`.
- `classical_first_succ_iff_upper` — the re-indexing identity `(n+1)² − (n+1) = n²+n`, showing the classical *lower* interval at `n+1` is literally the split *upper* half at `n`.
- `upper_half_one` — the sole boundary input, the prime `3 ∈ (2,4)` (upper half of the gap at `n=1`), proved outright with `norm_num` (no `native_decide`).
- `oppermann_conjecture_iff_classical` — **`OppermannConjecture ⟺ OppermannClassical`**.

### The subtlety this handles
The two forms are not term-for-term identical at the index boundary: `OppermannClassical` (starting `n≥2`) additionally requires a prime in the upper half of the gap at `n=1`, which the split conjecture (`m≥2`) does not hand over. The forward direction proves that instance outright (`upper_half_one`), so the equivalence is exact.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.LegendrePartialOQ04` → **exit 0, 7744 jobs**.
- `#print axioms oppermann_conjecture_iff_classical` → `propext, Classical.choice, Quot.sound` only (no `Lean.ofReduceBool`) — genuinely 0-axiom.

The file remains `axiomatized` overall (the `n ≤ 20` `native_decide` checks and the open `oppermann_conjecture` axiom are unchanged); the new theorems are all fully verified.

## Files
- `proofs/Proofs/LegendrePartialOQ04.lean` — new defs + theorems (+ header docs)
- `src/data/proofs/legendre-partial-oq-04/meta.json` — `mainTheorems` entry + updated line/theorem/def counts
- `research/problems/legendre-partial-oq-04/{state,knowledge}.md` — session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)