### PR TITLE
Enrich Inverse Galois OQ-04: de-bundle annotations 4→5, fix mis-tiling

### DIFF
--- a/src/data/proofs/inverse-galois-oq-04/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-04/annotations.json
@@ -4,24 +4,49 @@
     "proofId": "inverse-galois-oq-04",
     "range": {
       "startLine": 3,
-      "endLine": 38
+      "endLine": 21
     },
     "type": "concept",
-    "title": "OQ-04: the three-step route to eliminating the last A₅ axiom",
-    "content": "The docstring frames the parent's open question OQ-04 — can Dedekind's theorem be formalized to eliminate the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309)? The companion file `InverseGaloisA5DedekindInstantiation` already reduces that axiom to a single sharp arithmetic fact, `3 ∣ inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)` at an unramified prime Q over 7, and its 'residual gap' note lays out a three-step Kummer–Dedekind route: (1) the prime of 𝓞 ℚ(α) matching the irreducible cubic factor of q mod 7 has inertia degree 3 (`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`); (2) inertia degrees multiply in a tower (`inertiaDeg_algebra_tower`, needing NO Galois hypothesis on the non-normal middle field ℚ(α)); (3) Galois uniformity spreads the degree to all primes of the splitting field over 7 (`inertiaDegIn_eq_inertiaDeg`). This file machine-checks the abstract heart — steps (2) and (3) — with only the foundational axioms (propext, Classical.choice, Quot.sound): no sorry, no new axiom.",
-    "mathContext": "Inertia (residue) degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. For a Galois extension all primes over $p$ share one inertia degree, denoted $\\mathrm{inertiaDegIn}\\,p\\,T$. The route factors the target $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$ through the tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$.",
+    "title": "OQ-04: eliminating the last A₅ axiom via one inertia fact",
+    "content": "The docstring opens by framing the parent's open question OQ-04 — can Dedekind's theorem be formalized to discharge the last A₅ axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` (InverseGaloisA5.lean:309), the sole remaining assumption in the realization of A₅ as a Galois group over ℚ? The companion file `InverseGaloisA5DedekindInstantiation` has already reduced that axiom to a single sharp arithmetic fact, `3 ∣ inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)`, evaluated at an unramified prime Q over the rational prime 7. This file's job is to machine-check the abstract engine behind that reduced fact.",
+    "mathContext": "Target axiom $\\text{three\\_dvd\\_gal\\_card}:\\; 3 \\mid |q.\\mathrm{Gal}|$ is reduced by the companion file to $3 \\mid \\mathrm{inertiaDegIn}\\,(7)\\,(\\mathcal{O}_{q.\\mathrm{SplittingField}})$, where $\\mathrm{inertiaDegIn}\\,p\\,T$ is the common inertia degree of the primes of $T$ over $p$ in a Galois extension.",
     "significance": "critical",
     "relatedConcepts": [
       "inverse Galois problem",
-      "inertia degree",
-      "Kummer–Dedekind",
+      "three_dvd_gal_card",
       "residual gap reduction",
-      "residue field degree"
+      "inertia degree",
+      "A₅ realizability"
     ],
     "prerequisites": [
       "the inverse Galois problem and Galois groups over ℚ",
-      "Dedekind's factorization / Kummer–Dedekind theorem",
+      "realizing A₅ as a Galois group (three_dvd_gal_card)",
       "inertia (residue) degree of a prime in a number field"
+    ]
+  },
+  {
+    "id": "ann-three-step-route",
+    "proofId": "inverse-galois-oq-04",
+    "range": {
+      "startLine": 23,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "The three-step Kummer–Dedekind route; this file supplies steps 2 & 3",
+    "content": "The companion file's 'residual gap' note lays out a three-step Kummer–Dedekind route to the reduced fact: (1) the prime of 𝒪 ℚ(α) matching the irreducible cubic factor of q mod 7 has inertia degree 3 (`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`); (2) inertia degrees multiply in a tower (`inertiaDeg_algebra_tower`, which needs NO Galois hypothesis on the non-normal middle field ℚ(α)); (3) Galois uniformity spreads that degree to all primes of the splitting field over 7 (`inertiaDegIn_eq_inertiaDeg`). This file packages the abstract heart — steps (2) and (3) — as the single divisibility statement `inertiaDeg_dvd_inertiaDegIn`, in full generality for a tower R ⊆ S ⊆ T with T/R Galois and S possibly non-normal, using only the foundational axioms (propext, Classical.choice, Quot.sound): no sorry, no new axiom.",
+    "mathContext": "Inertia (residue) degree $f(\\mathfrak{P}\\mid p) = [\\mathcal{O}/\\mathfrak{P} : \\mathcal{O}_R/p]$. The route factors $3 \\mid \\mathrm{inertiaDegIn}_{(7)}$ through the tower $\\mathbb{Z} \\subseteq \\mathcal{O}_{\\mathbb{Q}(\\alpha)} \\subseteq \\mathcal{O}_{q.\\mathrm{SplittingField}}$, with step (1) supplying $f(P\\mid 7)=3$ and steps (2)–(3) promoting it to the Galois-invariant degree.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Kummer–Dedekind",
+      "inertia degree multiplicativity",
+      "Galois uniformity",
+      "non-normal middle field",
+      "residue field degree"
+    ],
+    "prerequisites": [
+      "Dedekind's factorization / Kummer–Dedekind theorem",
+      "multiplicativity of inertia degree in a tower",
+      "Galois uniformity of inertia degrees over a prime"
     ]
   },
   {
@@ -54,7 +79,7 @@
     "proofId": "inverse-galois-oq-04",
     "range": {
       "startLine": 55,
-      "endLine": 79
+      "endLine": 72
     },
     "type": "technique",
     "title": "The brick: inertiaDeg p P ∣ inertiaDegIn p T",
@@ -76,7 +101,7 @@
     "id": "ann-reduction-form",
     "proofId": "inverse-galois-oq-04",
     "range": {
-      "startLine": 81,
+      "startLine": 74,
       "endLine": 85
     },
     "type": "concept",


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-04` (DedekindInertiaTower.lean, 85 lines, 2 theorems).

**Annotations 4 → 5, with a mis-tiling fix (annotations-only, additive):**

- **De-bundle the overview.** The single 36-line overview annotation (lines 3-38) bundled the *motivation* (which A₅ axiom is being discharged and its prior reduction to one arithmetic fact) with the *three-step mathematical route*. Split into:
  - `ann-header-oq04` (3-21): OQ-04 and the reduction of `three_dvd_gal_card` to `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`.
  - `ann-three-step-route` (23-38): the three-step Kummer–Dedekind route; this file supplies the abstract steps 2 & 3.
- **Fix mis-tiling.** `ann-tower-brick` was `55-79`, wrongly claiming the reduction theorem's docstring (74-80). Retiled to `55-72` (the brick theorem exactly); `ann-reduction-form` extended `81-85 → 74-85` to cover its own docstring.

Result: 5 non-overlapping, fully-fielded annotations (`mathContext`/`significance`/`relatedConcepts`/`prerequisites`) covering lines 3-85. meta.json untouched; no content deleted.
