### PR TITLE
Research: amgm-inequality-oq-02-oq-02-oq-05 (VIII) — Vieta closure of TOP Newton step (calculus route → esymm inequality, 28→30)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -616,4 +616,119 @@ theorem newton_first_general_normalized (n : ℕ) (hn : 2 ≤ n) (x : ℕ → �
   rw [div_le_div_iff₀ hCpos hn2pos]
   nlinarith [h, hnpos]
 
+/-!  ## Part VIII — Vieta closure of the TOP step: the calculus route reaches
+Newton's inequality on the elementary symmetric functions of the roots
+
+Part VII proved `newton_top_coeff_ineq`, the honest calculus/Rolle discriminant
+inequality on the top three *coefficients* `p.coeff (m+2), p.coeff (m+1),
+p.coeff m` of an arbitrary real-rooted (`Splits`) polynomial `p`.  The single
+remaining increment documented in `state.md` was purely algebraic: **substitute
+the top coefficients via Vieta** — for a split polynomial
+`p.coeff k = leadingCoeff · (-1)^{n-k} · eₙ₋ₖ(roots)` — to turn that coefficient
+inequality into the classical Newton log-concavity statement on the elementary
+symmetric functions of the roots.
+
+Mathlib's `Polynomial.coeff_eq_esymm_roots_of_splits` supplies exactly this Vieta
+substitution.  Reading the top three coefficients of a split degree-`(m+2)`
+polynomial as `leadingCoeff`, `-leadingCoeff · e₁(roots)`, `leadingCoeff ·
+e₂(roots)` (with `e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2`) turns
+`newton_top_coeff_ineq` into a discriminant inequality in `e₁, e₂`, and the
+`descFactorial` weights collapse — via `Nat.succ_descFactorial` — to the
+recognizable classical constants, giving in the monic case
+
+    `2 (m+2) · e₂ ≤ (m+1) · e₁²`,
+
+i.e. the first Newton/Maclaurin inequality `e₁² ≥ (2n/(n-1)) e₂` for every arity
+`n = m+2`, now as the END PRODUCT of the genuine Rolle/discriminant engine the
+entry asks for (the same inequality Part III obtained independently by QM–AM).
+This closes the "coefficient bookkeeping" gap for the top step: the classical
+calculus proof now runs end-to-end, on one split polynomial of arbitrary degree,
+all the way to a symmetric-function inequality in the roots. -/
+
+/-- **Vieta substitution into the top Newton step (`coeff` → `esymm` of roots).**
+For any `p : ℝ[X]` that splits over `ℝ` with `natDegree = m + 2`, the
+top-coefficient Newton inequality `newton_top_coeff_ineq` becomes a log-concavity
+inequality in the first two elementary symmetric functions
+`e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2` of the roots:
+`4 · (m+2)!desc · m!desc · lc² · e₂ ≤ ((m+1)!desc)² · lc² · e₁²`, with
+`lc = p.leadingCoeff` and the `descFactorial` weights `(m+2).descFactorial m`,
+`m.descFactorial m`, `(m+1).descFactorial m`.  Proof: `p.coeff (m+2) = lc`
+(`coeff_natDegree`), and `p.coeff (m+1) = -lc · e₁`, `p.coeff m = lc · e₂` by
+`coeff_eq_esymm_roots_of_splits`, substituted into `newton_top_coeff_ineq`. -/
+theorem newton_top_esymm_roots (m : ℕ) {p : ℝ[X]}
+    (hp : p.Splits) (hdeg : p.natDegree = m + 2) :
+    4 * ((m + 2).descFactorial m : ℝ) * ((m).descFactorial m : ℝ)
+        * p.leadingCoeff ^ 2 * p.roots.esymm 2
+      ≤ ((m + 1).descFactorial m : ℝ) ^ 2 * p.leadingCoeff ^ 2
+        * p.roots.esymm 1 ^ 2 := by
+  have h := newton_top_coeff_ineq m hp hdeg
+  rw [show (2 : ℕ) + m = m + 2 from by omega, show (1 : ℕ) + m = m + 1 from by omega,
+    show (0 : ℕ) + m = m from by omega] at h
+  have hc2 : p.coeff (m + 2) = p.leadingCoeff := by rw [← coeff_natDegree, hdeg]
+  have hc1 : p.coeff (m + 1) = -(p.leadingCoeff * p.roots.esymm 1) := by
+    rw [coeff_eq_esymm_roots_of_splits hp (show m + 1 ≤ p.natDegree from by omega),
+      show p.natDegree - (m + 1) = 1 from by omega]
+    ring
+  have hc0 : p.coeff m = p.leadingCoeff * p.roots.esymm 2 := by
+    rw [coeff_eq_esymm_roots_of_splits hp (show m ≤ p.natDegree from by omega),
+      show p.natDegree - m = 2 from by omega]
+    ring
+  rw [hc2, hc1, hc0] at h
+  nlinarith [h]
+
+/-- **The classical TOP Newton inequality for a monic real-rooted polynomial,
+via the calculus route.**  If `p : ℝ[X]` is monic, splits over `ℝ`, and has
+`natDegree = m + 2`, then its roots' first two elementary symmetric functions
+satisfy Newton's first log-concavity inequality
+    `2 (m+2) · e₂ ≤ (m+1) · e₁²`,   `e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2`.
+This is `newton_top_esymm_roots` with `leadingCoeff = 1`, after collapsing the
+`descFactorial` weights with the two identities `2·(m+2).descFactorial m =
+(m+2)·(m+1).descFactorial m` and `(m+1).descFactorial m = (m+1)·m.descFactorial m`
+(both from `Nat.succ_descFactorial`).  It is the honest end product of the
+Rolle/discriminant engine — the same first Newton inequality Part III proves by
+QM–AM, here reached through the calculus route the entry asks for. -/
+theorem newton_top_esymm_roots_monic (m : ℕ) {p : ℝ[X]}
+    (hp : p.Splits) (hmonic : p.Monic) (hdeg : p.natDegree = m + 2) :
+    2 * ((m : ℝ) + 2) * p.roots.esymm 2 ≤ ((m : ℝ) + 1) * p.roots.esymm 1 ^ 2 := by
+  have hlc : p.leadingCoeff = 1 := hmonic.leadingCoeff
+  have h := newton_top_esymm_roots m hp hdeg
+  simp only [hlc, one_pow, mul_one] at h
+  -- the two `descFactorial` collapse identities (over ℕ, then cast to ℝ)
+  have id1 : 2 * (m + 2).descFactorial m = (m + 2) * (m + 1).descFactorial m := by
+    have e := Nat.succ_descFactorial (m + 1) m
+    rw [show m + 1 + 1 - m = 2 from by omega] at e
+    exact e
+  have id2 : (m + 1).descFactorial m = (m + 1) * m.descFactorial m := by
+    have e := Nat.succ_descFactorial m m
+    rw [show m + 1 - m = 1 from by omega, one_mul] at e
+    exact e
+  have id1R : 2 * ((m + 2).descFactorial m : ℝ) = ((m : ℝ) + 2) * ((m + 1).descFactorial m : ℝ) := by
+    exact_mod_cast id1
+  have id2R : ((m + 1).descFactorial m : ℝ) = ((m : ℝ) + 1) * (m.descFactorial m : ℝ) := by
+    exact_mod_cast id2
+  set A : ℝ := ((m + 2).descFactorial m : ℝ) with hA
+  set B : ℝ := ((m + 1).descFactorial m : ℝ) with hB
+  set C : ℝ := (m.descFactorial m : ℝ) with hC
+  set e1 : ℝ := p.roots.esymm 1 with he1
+  set e2 : ℝ := p.roots.esymm 2 with he2
+  -- h : 4 * A * C * e2 ≤ B ^ 2 * e1 ^ 2
+  have hm1 : (0 : ℝ) ≤ (m : ℝ) + 1 := by positivity
+  have hBpos : (0 : ℝ) < B := by
+    rw [hB]; exact_mod_cast Nat.descFactorial_pos.mpr (by omega)
+  -- the key weight collapse: `2 (m+2) B² = (m+1) · 4 A C`
+  have hident : 2 * ((m : ℝ) + 2) * B ^ 2 = ((m : ℝ) + 1) * (4 * A * C) := by
+    linear_combination (-2 * B) * id1R + (4 * A) * id2R
+  -- multiply the coefficient inequality by `(m+1) ≥ 0`
+  have hmul : ((m : ℝ) + 1) * (4 * A * C * e2) ≤ ((m : ℝ) + 1) * (B ^ 2 * e1 ^ 2) :=
+    mul_le_mul_of_nonneg_left h hm1
+  -- assemble the `B²`-scaled target, then cancel `B² > 0`
+  have key : 2 * ((m : ℝ) + 2) * e2 * B ^ 2 ≤ ((m : ℝ) + 1) * e1 ^ 2 * B ^ 2 := by
+    have eL : 2 * ((m : ℝ) + 2) * e2 * B ^ 2 = ((m : ℝ) + 1) * (4 * A * C * e2) := by
+      rw [show 2 * ((m : ℝ) + 2) * e2 * B ^ 2
+            = e2 * (2 * ((m : ℝ) + 2) * B ^ 2) from by ring, hident]; ring
+    have eR : ((m : ℝ) + 1) * e1 ^ 2 * B ^ 2 = ((m : ℝ) + 1) * (B ^ 2 * e1 ^ 2) := by ring
+    rw [eL, eR]; exact hmul
+  have hBsq : (0 : ℝ) < B ^ 2 := by positivity
+  exact le_of_mul_le_mul_right key hBsq
+
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
@@ -221,3 +221,70 @@ The ONLY remaining piece for the general TOP step is the Vieta substitution
 `pₙ₋₁² ≥ pₙ₋₂ pₙ`. General *interior* steps need the same machinery on a
 sub-window derivative (isolating `eₖ₋₁,eₖ,eₖ₊₁` instead of the top three). Both
 are purely algebraic — no analysis blocker remains.
+
+## PART VIII — Vieta closure of the TOP step: the calculus route reaches Newton's inequality on esymm(roots) (researcher-5, 2026-07-04)
+
+**Mode**: ACT (MODERATE, score 13). **Outcome**: progress — CLOSES the
+"coefficient bookkeeping / Vieta" gap for the TOP Newton step at arbitrary arity.
+**+2 verified theorems (28 → 30), 0 sorries, 0 axioms** (foundational only; no
+`decide`/`native_decide`). docker-build clean, 7743 jobs, Lean 4.26.0.
+
+### What this closes
+Part VII left the top step one purely-algebraic increment short: substitute the
+top coefficients of the split polynomial via Vieta to turn the coefficient
+inequality `newton_top_coeff_ineq` into the classical Newton inequality on the
+elementary symmetric functions of the *roots*. Part VIII does exactly that, so
+the classical calculus proof now runs end-to-end (differentiate → discriminant →
+Vieta) to a symmetric-function inequality for every arity `n = m + 2`:
+
+- **`newton_top_esymm_roots (m) {p} (hp : p.Splits) (hdeg : p.natDegree = m + 2)`** :
+  `4·(m+2)!desc·m!desc·lc²·e₂ ≤ ((m+1)!desc)²·lc²·e₁²`, with `lc = p.leadingCoeff`,
+  `e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2`. The Vieta substitution of
+  `newton_top_coeff_ineq`'s three coefficients.
+- **`newton_top_esymm_roots_monic (m) {p} (hp : p.Splits) (hmonic : p.Monic)
+  (hdeg : p.natDegree = m + 2)`** : the recognizable classical form
+  `2·(m+2)·e₂ ≤ (m+1)·e₁²`, i.e. the first Newton/Maclaurin inequality
+  `e₁² ≥ (2n/(n-1))·e₂` for every `n = m+2` — reached via the calculus route (the
+  same inequality Part III proves independently by QM–AM).
+
+### Key Lean facts (Mathlib API confirmed, Mathlib 4.26.0)
+- **`Polynomial.coeff_eq_esymm_roots_of_splits {F} [Field F] {p : F[X]}
+  (hsplit : p.Splits) {k} (h : k ≤ p.natDegree) : p.coeff k = p.leadingCoeff *
+  (-1)^(p.natDegree - k) * p.roots.esymm (p.natDegree - k)`** (in
+  `RingTheory/Polynomial/Vieta.lean`) — THE Vieta substitution, ready-made for a
+  split polynomial's coefficients. No need to build `∏(X−xᵢ)` by hand.
+- `Polynomial.coeff_natDegree : p.coeff p.natDegree = p.leadingCoeff` — the top
+  coefficient directly (avoid Vieta at `k = natDegree`, where `esymm 0` needs
+  extra unfolding).
+- **`Nat.succ_descFactorial (n) (k) : (n+1-k)*(n+1).descFactorial k =
+  (n+1)*n.descFactorial k`** collapses the three `descFactorial` weights: with
+  `n=m+1,k=m` it gives `2·(m+2).descFactorial m = (m+2)·(m+1).descFactorial m`;
+  with `n=m,k=m` it gives `(m+1).descFactorial m = (m+1)·m.descFactorial m`. These
+  two identities (cast to ℝ) reduce the raw weights to the clean `2(m+2)` / `(m+1)`.
+- `Polynomial.Monic.leadingCoeff : p.Monic → p.leadingCoeff = 1`;
+  `Nat.descFactorial_pos : 0 < n.descFactorial k ↔ k ≤ n` (positivity for the
+  `B²`-cancellation).
+
+### Reusable Lean gotchas (researcher-5, Part VIII)
+- `newton_top_coeff_ineq` states its indices/weights in `(2+m),(1+m),(0+m)` form.
+  `2+m` is a STUCK nat term (add recurses on 2nd arg), so `Nat.succ_descFactorial`
+  can't fire on it. Normalize first: `rw [show (2:ℕ)+m = m+2 from by omega, …] at h`
+  to get the `succ`-reducible `(m+2)` bases. `(m+1)+1` IS defeq `m+2`, so
+  `exact e` closes the cast identities without extra rewriting.
+- The weight collapse `2(m+2)B² = (m+1)·4AC` is one `linear_combination
+  (-2*B)*id1R + (4*A)*id2R` from the two cast identities `id1R : 2A=(m+2)B`,
+  `id2R : B=(m+1)C`. Then multiply the coeff inequality by `(m+1) ≥ 0`
+  (`mul_le_mul_of_nonneg_left`) and cancel `B² > 0`
+  (`le_of_mul_le_mul_right … hBsq`) — no `nlinarith` blowup on the esymm atoms.
+- `set A/B/C/e1/e2` BEFORE the arithmetic so `linear_combination`/`ring` see small
+  opaque variables rather than `((m+2).descFactorial m : ℝ)` / `p.roots.esymm _`.
+
+### Still open (narrowed to interior steps)
+The TOP step is now fully closed via the calculus route for every arity. What
+remains is the GENERAL *interior* Newton step `pₖ² ≥ pₖ₋₁pₖ₊₁` for `2 ≤ k ≤ n−2`:
+apply the same engine to a *sub-window* iterated derivative that isolates
+`eₖ₋₁,eₖ,eₖ₊₁` (rather than the top three). The reciprocal polynomial
+`Xⁿ·p(1/X)` maps the bottom window to a top window, so the top-step machinery plus
+a reciprocal-coefficient (`reverse`) bridge should reach the second-from-top and
+second-from-bottom steps next; the strictly interior windows need differentiating
+both `p` and its reverse. Purely algebraic — no analysis blocker.

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,7 +4,47 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 8 (PART VII)
+**Iteration**: 9 (PART VIII)
+
+## Iteration 9 (PART VIII — Vieta closure of the TOP step: calculus route reaches Newton's inequality on esymm(roots)), researcher-5
+Two verified additions (28 → 30 theorems; 0 sorries, 0 axioms; docker-build clean,
+7743 jobs, Lean 4.26.0). **CLOSES the documented Vieta gap for the TOP step** —
+substitutes the top three coefficients of the split polynomial via Mathlib's
+`Polynomial.coeff_eq_esymm_roots_of_splits`, turning Part VII's coefficient
+inequality `newton_top_coeff_ineq` into the classical Newton inequality on the
+elementary symmetric functions of the roots. The calculus proof (differentiate →
+discriminant → Vieta) now runs end-to-end to a symmetric-function inequality for
+every arity `n = m + 2`:
+- `newton_top_esymm_roots (m) {p} (hp : p.Splits) (hdeg : p.natDegree = m + 2)` :
+  `4·(m+2)!desc·m!desc·lc²·e₂ ≤ ((m+1)!desc)²·lc²·e₁²`, `lc = p.leadingCoeff`,
+  `e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2`. The Vieta substitution.
+- `newton_top_esymm_roots_monic (m) {p} (hp : p.Splits) (hmonic : p.Monic)
+  (hdeg : p.natDegree = m + 2)` : the recognizable classical `2·(m+2)·e₂ ≤
+  (m+1)·e₁²`, i.e. the first Newton/Maclaurin inequality for every arity — via the
+  calculus route (matching Part III's QM–AM proof of the same inequality).
+
+**What remains (interior steps):** the general interior Newton step
+`pₖ² ≥ pₖ₋₁pₖ₊₁` for `2 ≤ k ≤ n−2` needs the same engine on a *sub-window*
+iterated derivative isolating `eₖ₋₁,eₖ,eₖ₊₁`. The reciprocal polynomial
+`Xⁿ·p(1/X)` (`Polynomial.reverse`) maps the bottom window to the top window, so
+the top-step machinery plus a `reverse`-coefficient bridge should reach the
+second-from-top / second-from-bottom steps next; strictly interior windows
+differentiate both `p` and its reverse. Purely algebraic — no analysis blocker.
+
+**Reusable Lean gotchas (researcher-5, Part VIII):**
+- `Polynomial.coeff_eq_esymm_roots_of_splits (hsplit : p.Splits) (h : k ≤
+  p.natDegree) : p.coeff k = p.leadingCoeff·(-1)^(natDegree−k)·p.roots.esymm
+  (natDegree−k)` (in `RingTheory/Polynomial/Vieta.lean`) is the ready-made Vieta
+  substitution for a split polynomial's coefficients — no need to construct
+  `∏(X−xᵢ)` by hand. Use `coeff_natDegree` for the top coefficient (`k =
+  natDegree`) to avoid unfolding `esymm 0`.
+- `newton_top_coeff_ineq` weights are in `(2+m),(1+m),(0+m)` form; `2+m` is a
+  STUCK nat, so `rw [show (2:ℕ)+m = m+2 from by omega, …] at h` first to get the
+  `succ`-reducible `(m+2)` bases before `Nat.succ_descFactorial` can collapse them.
+- Weight collapse `2·(m+2).descFactorial m = (m+2)·(m+1).descFactorial m` and
+  `(m+1).descFactorial m = (m+1)·m.descFactorial m` both fall out of
+  `Nat.succ_descFactorial`; cast to ℝ then `linear_combination` for
+  `2(m+2)B² = (m+1)·4AC`, multiply the inequality by `(m+1)≥0`, cancel `B²>0`.
 
 ## Iteration 8 (PART VII — the general-`n` TOP Newton step via the actual Rolle route), researcher-8
 Two verified additions (26 → 28 theorems; 0 sorries, 0 axioms; docker-build clean,


### PR DESCRIPTION
## Summary

**Problem**: `amgm-inequality-oq-02-oq-02-oq-05` — *Newton's Inequality via Real-Rooted Polynomials and Rolle's Theorem*.

Part VIII **closes the documented Vieta gap for the TOP Newton step** at arbitrary arity. Part VII (already merged) proved `newton_top_coeff_ineq`: the honest calculus/Rolle discriminant inequality on the top three *coefficients* `p.coeff (m+2), p.coeff (m+1), p.coeff m` of an arbitrary real-rooted polynomial. The single remaining increment recorded in `state.md` was the purely-algebraic **Vieta substitution** of those coefficients. This PR does it, so the classical calculus proof (differentiate → discriminant → Vieta) now runs **end-to-end** to a symmetric-function inequality for every arity `n = m + 2`.

## What's new (2 theorems, 28 → 30)

- **`newton_top_esymm_roots (m) {p} (hp : p.Splits) (hdeg : p.natDegree = m + 2)`** — the Vieta substitution via Mathlib's `Polynomial.coeff_eq_esymm_roots_of_splits`:
  `4·(m+2)!desc·m!desc·lc²·e₂ ≤ ((m+1)!desc)²·lc²·e₁²`, with `lc = p.leadingCoeff`, `e₁ = p.roots.esymm 1`, `e₂ = p.roots.esymm 2`.
- **`newton_top_esymm_roots_monic (m) {p} (hp : p.Splits) (hmonic : p.Monic) (hdeg : p.natDegree = m + 2)`** — the recognizable classical form
  `2·(m+2)·e₂ ≤ (m+1)·e₁²`, i.e. the first Newton/Maclaurin inequality `e₁² ≥ (2n/(n-1))·e₂` for every arity, reached via the calculus route (the same inequality Part III proves independently by QM–AM). The `descFactorial` weights collapse to the clean `2(m+2)` / `(m+1)` constants via `Nat.succ_descFactorial`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` — **clean, 7743 jobs**, Lean 4.26.0.
- **0 sorries, 0 `axiom` declarations, 0 `native_decide`** — foundational axioms only.

## Still open

General **interior** steps `pₖ² ≥ pₖ₋₁pₖ₊₁` for `2 ≤ k ≤ n−2`: same engine on a sub-window / `reverse`-polynomial derivative. Purely algebraic — no analysis blocker remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)