### PR TITLE
Research: Newton's rung S₂²≥S₁S₃ for all reals (n=3) — 0-axiom SOS certificate

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean
@@ -1,0 +1,105 @@
+/-
+  Newton's k = 2 inequality S₂² ≥ S₁S₃ — the ALL-REALS case for n = 3.
+
+  Open Question (amgm-inequality-oq-02-oq-01-oq-05-oq-01):
+  For reals x₁,…,xₙ (n ≥ 3), with the normalized (Maclaurin) symmetric means
+    Sₖ = eₖ / C(n,k),
+  Newton's log-concavity rung k = 2 asserts
+    S₂² ≥ S₁ S₃.
+  Clearing the binomial denominators (C(n,2)²/(C(n,1)·C(n,3)) = 3(n-1)/(2(n-2))),
+  this is the integer-cleared inequality
+    2(n-2) · e₂²  ≥  3(n-1) · e₁ e₃.
+
+  Newton's inequalities hold for ALL real xᵢ — they follow from the real-rootedness of
+  ∏(t − xᵢ) and its derivatives, never from any sign hypothesis.  The gallery's existing
+  `NewtonLC.newton_ineq` proves the *nonnegative* case (it genuinely uses eₖ ≥ 0), so the
+  all-reals statement is a strict strengthening not otherwise present.
+
+  This file establishes the base rung n = 3 unconditionally (no sign hypothesis) via an
+  EXPLICIT sum-of-squares certificate, verified axiom-free.  Specializing the cleared
+  constant at n = 3 gives 2(n-2) = 2, 3(n-1) = 6, i.e.
+    2 e₂²  ≥  6 e₁ e₃      ⟺      e₂²  ≥  3 e₁ e₃,
+  and the exact identity
+    e₂² − 3 e₁ e₃ = ½[(xy − yz)² + (yz − zx)² + (zx − xy)²] ≥ 0
+  is the certificate (the right-hand square-sum vanishes exactly on the Newton equality
+  locus x = y = z).
+
+  No sorries, no axioms.
+-/
+import Mathlib
+
+namespace AmgmInequalityOQ02OQ01OQ05OQ01
+
+/-- First elementary symmetric polynomial of three reals, e₁ = x + y + z. -/
+def e1 (x y z : ℝ) : ℝ := x + y + z
+
+/-- Second elementary symmetric polynomial, e₂ = xy + yz + zx. -/
+def e2 (x y z : ℝ) : ℝ := x * y + y * z + z * x
+
+/-- Third elementary symmetric polynomial, e₃ = xyz. -/
+def e3 (x y z : ℝ) : ℝ := x * y * z
+
+/-- **Explicit SOS certificate (a `ring` identity).**  The Newton defect
+`e₂² − 3 e₁e₃` is exactly half the sum of the three squared pair-product differences.
+This is an algebraic identity over ℝ, independent of any sign of `x, y, z`. -/
+theorem newton_k2_sos_identity (x y z : ℝ) :
+    e2 x y z ^ 2 - 3 * e1 x y z * e3 x y z
+      = ((x * y - y * z) ^ 2 + (y * z - z * x) ^ 2 + (z * x - x * y) ^ 2) / 2 := by
+  simp only [e1, e2, e3]; ring
+
+/-- **Newton's k = 2 inequality for n = 3, ALL reals (0-axiom).**
+`e₂² ≥ 3 e₁ e₃` for every `x, y, z : ℝ` — no nonnegativity needed — as the
+right-hand side of `newton_k2_sos_identity` is a sum of squares. -/
+theorem newton_k2_allreals_three (x y z : ℝ) :
+    e2 x y z ^ 2 ≥ 3 * e1 x y z * e3 x y z := by
+  have h := newton_k2_sos_identity x y z
+  have hnn : (0 : ℝ) ≤
+      ((x * y - y * z) ^ 2 + (y * z - z * x) ^ 2 + (z * x - x * y) ^ 2) / 2 := by
+    positivity
+  linarith [h, hnn]
+
+/-- The integer-cleared form matching the general statement `2(n-2)e₂² ≥ 3(n-1)e₁e₃`
+specialized at `n = 3` (constants `2` and `6`). -/
+theorem newton_k2_allreals_three_cleared (x y z : ℝ) :
+    2 * e2 x y z ^ 2 ≥ 6 * (e1 x y z * e3 x y z) := by
+  have h := newton_k2_allreals_three x y z
+  nlinarith [h]
+
+/-- **Exact equality locus.**  The SOS certificate makes the Newton equality set explicit:
+the defect `e₂² − 3e₁e₃` vanishes **iff all three pair products agree**, `xy = yz = zx`.
+(Note this is strictly larger than the diagonal `x = y = z`: e.g. `x = 1, y = z = 0` has all
+pair products `0`, so equality holds without the variables being equal — the pair-product
+characterization is the honest one.) -/
+theorem newton_k2_equality_iff (x y z : ℝ) :
+    e2 x y z ^ 2 = 3 * e1 x y z * e3 x y z ↔ x * y = y * z ∧ y * z = z * x := by
+  have hid := newton_k2_sos_identity x y z
+  constructor
+  · intro heq
+    -- defect = 0 forces the sum of three squares to 0, hence each square to 0.
+    have hsum : (x * y - y * z) ^ 2 + (y * z - z * x) ^ 2 + (z * x - x * y) ^ 2 = 0 := by
+      have hz : e2 x y z ^ 2 - 3 * e1 x y z * e3 x y z = 0 := by linarith [heq]
+      linarith [hid, hz]
+    have hs1 : (x * y - y * z) ^ 2 = 0 := by
+      nlinarith [sq_nonneg (y * z - z * x), sq_nonneg (z * x - x * y)]
+    have hs2 : (y * z - z * x) ^ 2 = 0 := by
+      nlinarith [sq_nonneg (x * y - y * z), sq_nonneg (z * x - x * y)]
+    refine ⟨?_, ?_⟩
+    · by_contra h
+      have hne : x * y - y * z ≠ 0 := sub_ne_zero.mpr h
+      have : (0 : ℝ) < (x * y - y * z) ^ 2 := by positivity
+      linarith [hs1]
+    · by_contra h
+      have hne : y * z - z * x ≠ 0 := sub_ne_zero.mpr h
+      have : (0 : ℝ) < (y * z - z * x) ^ 2 := by positivity
+      linarith [hs2]
+  · rintro ⟨hxy, hyz⟩
+    -- all pair products equal ⟹ every squared difference is 0 ⟹ defect 0.
+    have hzx : z * x = x * y := by linarith [hxy, hyz]
+    have d1 : x * y - y * z = 0 := by linarith [hxy]
+    have d2 : y * z - z * x = 0 := by linarith [hyz]
+    have d3 : z * x - x * y = 0 := by linarith [hzx]
+    have hz : ((x * y - y * z) ^ 2 + (y * z - z * x) ^ 2 + (z * x - x * y) ^ 2) / 2 = 0 := by
+      rw [d1, d2, d3]; norm_num
+    linarith [hid, hz]
+
+end AmgmInequalityOQ02OQ01OQ05OQ01

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-05-oq-01/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-05-oq-01/knowledge.md
@@ -1,0 +1,150 @@
+# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-05-oq-01
+
+Newton's k=2 rung  S₂² ≥ S₁S₃.
+
+---
+
+## Problem Understanding
+
+Target as stated: for nonnegative reals x₁,…,xₙ (n ≥ 3), with Sₖ = eₖ/C(n,k),
+prove S₂² ≥ S₁S₃ — the k=2 case of Newton log-concavity.
+
+**Cleared / un-averaged form (corrected constant).**
+S₂² ≥ S₁S₃  ⟺  e₂² ≥ [C(n,2)²/(C(n,1)C(n,3))]·e₁e₃.
+Now C(n,2)²/(C(n,1)C(n,3)) = ( n(n-1)/2 )² / ( n · n(n-1)(n-2)/6 ) = 3(n-1)/(2(n-2)).
+So the integer-cleared inequality is
+
+    2(n-2)·e₂²  ≥  3(n-1)·e₁e₃          (n ≥ 2)
+
+equivalently e₁e₃ ≤ (2(n-2)/(3(n-1)))·e₂².
+NOTE: problem.md stated the constant as 2(n-1)/(3(n-2)); that is the
+reciprocal-swapped value and is WRONG. The correct constant is 2(n-2)/(3(n-1)).
+Sanity check xᵢ≡1: LHS 2(n-2)·C(n,2)² = RHS 3(n-1)·n·C(n,3), equality (as expected,
+Newton equality is xᵢ all equal). ✓
+
+---
+
+## Key finding: the nonnegative case is ALREADY fully proved in the gallery
+
+The literal target (nonnegative reals) is the k=2 instance of the already-existing,
+axiom-free theorem
+
+    NewtonLC.newton_ineq        (proofs/Proofs/NewtonLogConcavity.lean:95)
+    newton_log_concavity_proved (proofs/Proofs/AmgmInequalityOQ02OQ02.lean:811)
+
+which proves (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)) for ALL 1 ≤ k, k+1 ≤ n
+and nonnegative x, via cleared-denominator induction whose inductive step
+`newton_cleared_denom_inductive_step` (line 395) is a *proved theorem*
+(quadratic_nonneg + binomial absorption identities), NOT an axiom.
+
+Caveat on the axiom hygiene: `AmgmInequalityOQ02.lean:285` still declares the LEGACY
+placeholder `axiom newton_log_concavity`, but `newton_ineq` routes through the *proved*
+`newton_log_concavity_proved`, so the k=2 rung is axiom-free. (Several docstrings in
+NewtonLogConcavity.lean / OQ02OQ02.lean claiming "one axiom remaining" are STALE — the
+inductive step was subsequently proved. Worth a cleanup pass by an enricher/auditor.)
+
+**Consequence:** re-proving the nonnegative S₂²≥S₁S₃ would be pure redundancy
+(anti-pattern: busywork). The Seeker-flagged "gallery gap" does not actually exist for
+the nonnegative statement.
+
+---
+
+## Insights: the genuinely new direction — drop nonnegativity
+
+Newton's inequalities hold for ALL real xᵢ (they follow from real-rootedness of
+∏(t−xᵢ) and its derivatives, never from a sign hypothesis). The gallery's
+`newton_ineq` genuinely USES eₖ ≥ 0, so it does NOT give the all-reals statement.
+The all-reals k=2 inequality 2(n-2)e₂² ≥ 3(n-1)e₁e₃ is therefore a strict
+strengthening not currently in the gallery.
+
+**Monomial-basis reduction (all reals).** With
+m₂₂ = Σ xᵢ²xⱼ², m₂₁₁ = Σ xₐ²xᵦx_c (a distinct from b<c), e₄ = Σ_{i<j<k<l} xᵢxⱼxₖxₗ:
+
+    e₂²  = m₂₂ + 2·m₂₁₁ + 6·e₄
+    e₁e₃ = m₂₁₁ + 4·e₄
+  ⟹ Fₙ := 2(n-2)e₂² − 3(n-1)e₁e₃ = 2(n-2)·m₂₂ + (n-5)·m₂₁₁ − 12·e₄.
+
+**Spectral SOS certificate (complete paper proof, general n).** Fₙ is a quadratic form
+in the C(n,2) pair-products x_P = xᵢxⱼ. Its Gram matrix M = μ₂I + μ₁A₁ + μ₀A₀ with
+μ₂ = 2(n-2), μ₁ = (n-5)/2, μ₀ = −2 lies in the Johnson scheme J(n,2) (triangular graph
+T(n): A₁ = "share one index", A₀ = "disjoint"). Using the T(n) eigenvalues
+A₁ ↦ {2(n-2), n-4, −2} on eigenspaces V₀,V₁,V₂ (dims 1, n-1, n(n-3)/2) and
+A₀ = J − I − A₁ ↦ {C(n-2,2), 3-n, 1}, the eigenvalues of M are
+
+    V₀ : 0            V₁ : n(n-1)/2            V₂ : n-1
+
+all ≥ 0  ⟹  M ⪰ 0  ⟹  Fₙ is a sum of squares  ⟹  2(n-2)e₂² ≥ 3(n-1)e₁e₃ for all reals.
+(The V₀ zero eigenvalue is exactly the equality locus xᵢ all equal.)
+
+This is a clean, self-contained proof. Since nonneg quartics in any number of variables
+are SOS (Hilbert, degree 4), existence of the certificate was guaranteed; the Johnson
+scheme makes it explicit.
+
+---
+
+## Dead Ends
+
+- **Naive "sum over triples"**: Σ_{triples} Newton(i,j,k) = 2(n-2)m₂₂ − 2m₂₁₁ =: G₁ ≥ 0
+  undershoots Fₙ by (n-3)m₂₁₁ − 12e₄, which is INDEFINITE (e.g. x=(1,1,-1,-1),
+  n=4 gives −16). So Newton k=2 is strictly stronger than the sum of its 3-variable
+  restrictions — the joint real-rootedness of all n variables is essential.
+- **Nonneg combination of the "simple" blocks** {e₂², G₁, T=Σ_{triples}(xᵢxⱼ+…)²,
+  H=Σ_{4-sets}(xᵢxⱼ−xₖxₗ)²+…, L=Σ xₐ²(e₁−xₐ)²}: the m₂₂/|e₄| cost of cancelling e₄ via
+  4-subset squares grows like n² while the target's m₂₂ coeff is only 2(n-2); the reduced
+  linear system forces a weight = (5-n)/2 < 0 for n ≥ 6. So NO nonneg combination of
+  difference-of-two-monomial squares works for large n — the true SOS needs squares of
+  genuine linear combinations over many pair-products (exactly what the Gram/eigenvalue
+  route supplies).
+
+---
+
+## Built this session
+
+- `proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean` — all-reals k=2 Newton,
+  verified axiom-free for n = 3, 4, 5 via explicit SOS witnesses (no sign hypothesis),
+  plus the corrected constant, the reduction identity (n=3 form as a `ring` identity),
+  and the general Johnson-scheme certificate documented.
+
+---
+
+## Next steps
+
+- Formalize the general-n all-reals Fₙ ≥ 0 via the Johnson-scheme SOS (heavier: needs the
+  T(n) eigen-projections; candidate for a dedicated multi-session effort or Aristotle).
+  Alternatively via `card_roots_le_derivative` (real-rootedness preserved under
+  differentiation — see reference-lean-rolle-derivative-roots) + discriminant of the
+  quadratic slice.
+- Enricher/auditor cleanup: remove the STALE "one axiom remaining" docstrings in
+  NewtonLogConcavity.lean and AmgmInequalityOQ02OQ02.lean; consider retiring the legacy
+  `axiom newton_log_concavity` in AmgmInequalityOQ02.lean now that the proved version exists.
+
+## Session 2026-07-04 (researcher-11) — n=3 all-reals file ACTUALLY built & verified
+
+**Correction to the record:** the prior "## Built this session" note claimed
+`proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean` (n=3,4,5 SOS) was built — but that
+file existed **nowhere** in the repo (never committed / lost with a reaped worktree),
+while state.md still read OBSERVE / iteration 1. This session actually creates and
+Docker-verifies the n=3 core.
+
+**Delivered (verified, 0-axiom, green Docker build — exit 0, 7743 jobs, Mathlib v4.26):**
+`proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean` (105 lines, 4 theorems, 3 defs):
+- `newton_k2_sos_identity` — the exact `ring` certificate
+  `e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²]`.
+- `newton_k2_allreals_three` — `e₂² ≥ 3e₁e₃` for ALL reals (positivity + linarith on the
+  identity); a strict strengthening of the gallery's nonneg `NewtonLC.newton_ineq`.
+- `newton_k2_allreals_three_cleared` — `2e₂² ≥ 6(e₁e₃)`, matching the general cleared
+  constant `2(n-2)e₂² ≥ 3(n-1)e₁e₃` at n=3.
+- `newton_k2_equality_iff` — **corrected equality locus**: `e₂²=3e₁e₃ ⟺ xy=yz=zx`
+  (all pair products equal), which is strictly LARGER than the diagonal `x=y=z`
+  (counterexample `(1,0,0)`: all pair products 0, equality holds, variables unequal).
+  An earlier draft that claimed `⟺ x=y=z` was mathematically FALSE and was fixed before build.
+
+Gallery entry added: `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/meta.json`
+(status verified, badge original — main theorem proved from first principles, not delegated
+to a Mathlib inequality). PR from branch `research/amgm-oq02010501-newton-k2-n3-v2`.
+
+**Still open (unchanged):** general-n all-reals `2(n-2)e₂² ≥ 3(n-1)e₁e₃` via the
+Johnson-scheme SOS (Gram eigenvalues 0, n(n-1)/2, n-1 on the T(n) eigenspaces — see the
+"Spectral SOS certificate" section above), or via real-rootedness-under-differentiation.
+n=4,5 explicit SOS witnesses remain a good stepping-stone (were CLAIMED before but never
+committed — treat as not done).

--- a/research/problems/amgm-inequality-oq-02-oq-01-oq-05-oq-01/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-01-oq-05-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: amgm-inequality-oq-02-oq-01-oq-05-oq-01
+
+## Current State
+**Phase**: ACT (increment shipped)
+**Path**: full
+**Since**: 2026-07-04
+**Iteration**: 2
+
+## Current Focus
+n=3 all-reals Newton k=2 rung is DONE and Docker-verified (0-axiom). Next: general-n
+Johnson-scheme SOS, or n=4/5 explicit witnesses as stepping stones.
+
+## Active Approach
+Explicit SOS certificates for Newton's k=2 log-concavity rung, all reals.
+
+## Attempt Count
+- Total attempts: 1 (n=3 verified)
+- Approaches tried: SOS certificate (n=3) — SUCCESS
+
+## Blockers
+General-n requires the T(n) eigen-projection machinery (multi-session or Aristotle).
+
+## Next Action
+Formalize general-n Fₙ ≥ 0 via the Johnson-scheme SOS, or prove n=4,5 explicit SOS
+witnesses. See knowledge.md "Spectral SOS certificate" section.

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+  "title": "Newton's Rung S₂² ≥ S₁S₃ for all reals (n = 3) via an explicit SOS certificate",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+  "description": "Proves the second Maclaurin/Newton rung S₂² ≥ S₁S₃ — Newton's log-concavity of the elementary symmetric means — for THREE real variables with NO nonnegativity hypothesis, via an explicit sum-of-squares certificate. Cleared of binomial denominators the rung is 2(n-2)·e₂² ≥ 3(n-1)·e₁e₃; specialized at n = 3 this is e₂² ≥ 3e₁e₃, and the exact identity e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²] makes nonnegativity manifest and independent of the signs of x, y, z. The existing gallery proof of this rung (NewtonLC.newton_ineq) genuinely uses eₖ ≥ 0, so the all-reals statement is a strict strengthening. Includes the exact equality locus (all pair products equal — strictly larger than x = y = z). 4 theorems, 3 definitions, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "namespace": "AmgmInequalityOQ02OQ01OQ05OQ01",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean",
+    "tags": [
+      "inequalities",
+      "symmetric-polynomials",
+      "newton-inequality",
+      "maclaurin",
+      "sum-of-squares",
+      "log-concavity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Green Docker build confirmed on the Mathlib v4.26 pin (docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ05OQ01 → exit 0, 7743 jobs, only builds through ring/linarith/nlinarith/positivity/norm_num — no native_decide, no custom axiom, so axiom-free in the project sense). The main inequality newton_k2_allreals_three is proved from first principles via the explicit SOS identity newton_k2_sos_identity (a pure `ring` identity), NOT delegated to any Mathlib inequality lemma — hence badge 'original'. Correctness note recorded during authoring: the equality locus is NOT the diagonal x = y = z; the honest characterization is 'all three pair products equal' (xy = yz = zx), e.g. x = 1, y = z = 0 attains equality without the variables being equal. newton_k2_equality_iff states the correct pair-product form.",
+    "lineCount": 105,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "originalContributions": [
+      "newton_k2_allreals_three: Newton's k = 2 rung e₂² ≥ 3e₁e₃ for THREE arbitrary reals (no sign hypothesis) — a strict strengthening of the gallery's nonnegative NewtonLC.newton_ineq, which genuinely uses eₖ ≥ 0",
+      "newton_k2_sos_identity: the exact algebraic certificate e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²], a `ring` identity over ℝ that makes the inequality a manifest sum of squares",
+      "newton_k2_allreals_three_cleared: the integer-cleared form 2·e₂² ≥ 6·(e₁e₃) matching the general statement 2(n-2)e₂² ≥ 3(n-1)e₁e₃ specialized at n = 3 (with the corrected constant 3(n-1)/(2(n-2)), not the reciprocal-swapped value)",
+      "newton_k2_equality_iff: the exact equality locus e₂² = 3e₁e₃ ⟺ xy = yz = zx (all pair products equal), noting this is strictly larger than the diagonal x = y = z"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's inequalities strengthen Maclaurin's chain: for the normalized symmetric means Sₖ = eₖ/C(n,k) of reals, the sequence (Sₖ) is log-concave, Sₖ² ≥ Sₖ₋₁Sₖ₊₁. The rung k = 2, S₂² ≥ S₁S₃, is the first that carries genuine content beyond the Cauchy-Schwarz base step S₁² ≥ S₂. Crucially, Newton's inequalities hold for ALL real xᵢ — they follow from the real-rootedness of the polynomial ∏(t − xᵢ) and its derivatives, never from a sign hypothesis. This entry formalizes the base dimension n = 3 unconditionally through an explicit sum-of-squares certificate, complementing the gallery's nonnegative-case proof (which does use eₖ ≥ 0).",
+    "problemStatement": "For reals $x, y, z$, with $e_1 = x+y+z$, $e_2 = xy+yz+zx$, $e_3 = xyz$, Newton's rung $k=2$ (cleared of denominators, $n=3$) is $e_2^2 \\ge 3\\,e_1 e_3$. This holds for all reals, with equality iff $xy = yz = zx$.",
+    "text": "Clearing the binomial denominators, S₂² ≥ S₁S₃ becomes 2(n-2)·e₂² ≥ 3(n-1)·e₁e₃; at n = 3 this is e₂² ≥ 3e₁e₃. The proof is a single explicit SOS identity: e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²], whose right-hand side is a manifest sum of squares, so the inequality holds for all reals with no nonnegativity hypothesis.",
+    "proofStrategy": "One certificate, verified in two lines. (1) newton_k2_sos_identity: unfold e₁,e₂,e₃ and close the polynomial identity e₂² − 3e₁e₃ = ½·Σ(pair-product differences)² by `ring`. (2) newton_k2_allreals_three: the RHS is ≥ 0 by `positivity`, so `linarith` on the identity gives e₂² ≥ 3e₁e₃. (3) newton_k2_allreals_three_cleared: multiply by 2 (nlinarith). (4) newton_k2_equality_iff: defect = 0 forces the sum of three squares to 0, hence (by positivity/by_contra) each squared pair-product difference to 0, i.e. xy = yz = zx; conversely equal pair products make every square vanish.",
+    "keyInsights": [
+      "The all-reals rung needs no analysis, just an SOS certificate. Because e₂² − 3e₁e₃ is exactly half the sum of the three squared pair-product differences, the inequality is a manifest sum of squares — the same phenomenon that guarantees, by Hilbert's theorem, that any nonnegative quartic in ≤ 3 variables is SOS.",
+      "This strengthens the existing nonnegative proof. The gallery's NewtonLC.newton_ineq proves the rung using eₖ ≥ 0; dropping that hypothesis (as here for n = 3) is a genuine strengthening, since Newton's inequalities are really facts about real-rooted polynomials, not about signs.",
+      "The equality locus is subtler than the diagonal. e₂² = 3e₁e₃ holds iff all three pair products agree (xy = yz = zx), which is strictly larger than x = y = z: e.g. (1,0,0) attains equality. The SOS certificate exposes this exactly, since the defect vanishes iff each pair-product difference does.",
+      "The cleared constant is 3(n-1)/(2(n-2)), not its reciprocal. Averaging S₂² ≥ S₁S₃ back to elementary symmetric sums gives C(n,2)²/(C(n,1)C(n,3)) = 3(n-1)/(2(n-2)); at n = 3 this is 3, matching e₂² ≥ 3e₁e₃."
+    ],
+    "prerequisites": [
+      "Elementary symmetric polynomials e₁ = x+y+z, e₂ = xy+yz+zx, e₃ = xyz",
+      "Newton's / Maclaurin's inequalities and the normalized means Sₖ = eₖ/C(n,k)",
+      "Sum-of-squares (SOS) certificates for nonnegative polynomials",
+      "Lean tactics: ring (polynomial identities), positivity (nonnegativity of squares), linarith/nlinarith"
+    ]
+  },
+  "conclusion": {
+    "summary": "Newton's rung S₂² ≥ S₁S₃, cleared and specialized to n = 3, holds for all reals x, y, z via the explicit SOS identity e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²]. Fully machine-checked: 4 theorems, 3 definitions, 0 axioms, 0 sorries, green Docker build on Mathlib v4.26.",
+    "implications": "Provides the all-reals base dimension for Newton's k = 2 log-concavity rung, strengthening the gallery's nonnegative proof (NewtonLC.newton_ineq). The SOS certificate is explicit and, via the Johnson-scheme (triangular-graph T(n)) eigenvalue analysis recorded in the problem's research notes, generalizes to all n — the Gram matrix of the quartic form Fₙ = 2(n-2)e₂² − 3(n-1)e₁e₃ has eigenvalues 0, n(n-1)/2, n-1 (all ≥ 0) on the three T(n) eigenspaces.",
+    "openQuestions": [
+      "Formalize the general-n all-reals rung 2(n-2)e₂² ≥ 3(n-1)e₁e₃ via the Johnson-scheme SOS certificate (heavier: needs the T(n) eigen-projections), or via real-rootedness preserved under differentiation (card_roots_le_derivative) plus the discriminant of the quadratic slice.",
+      "Prove the n = 4, 5 dimensions with explicit SOS witnesses as intermediate stepping stones toward the general certificate.",
+      "State the corresponding all-reals equality locus for general n (the V₀ zero-eigenspace of the Gram matrix, i.e. the equal-variables diagonal, together with the degenerate lower-dimensional faces)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-defs",
+      "title": "Docstring, Definitions, and the Cleared Constant",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "States Newton's rung S₂² ≥ S₁S₃, the cleared form 2(n-2)e₂² ≥ 3(n-1)e₁e₃ with the corrected constant, and its n = 3 specialization e₂² ≥ 3e₁e₃. Defines e1 = x+y+z, e2 = xy+yz+zx, e3 = xyz for three reals."
+    },
+    {
+      "id": "sos-identity",
+      "title": "The SOS Certificate (a ring identity)",
+      "startLine": 42,
+      "endLine": 48,
+      "summary": "newton_k2_sos_identity: e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²], closed by `ring` after unfolding the symmetric-polynomial definitions. Independent of any sign of x, y, z."
+    },
+    {
+      "id": "main-inequality",
+      "title": "Newton's k = 2 rung for all reals (n = 3)",
+      "startLine": 50,
+      "endLine": 66,
+      "summary": "newton_k2_allreals_three: e₂² ≥ 3e₁e₃ — the RHS of the SOS identity is ≥ 0 by `positivity`, so `linarith` closes it. newton_k2_allreals_three_cleared repackages it as 2·e₂² ≥ 6·(e₁e₃) to match the general cleared constant."
+    },
+    {
+      "id": "equality-locus",
+      "title": "Exact Equality Locus",
+      "startLine": 68,
+      "endLine": 105,
+      "summary": "newton_k2_equality_iff: e₂² = 3e₁e₃ ⟺ xy = yz = zx. Forward: defect 0 forces the sum of three squares to 0, hence each square to 0 (by_contra + positivity). Backward: equal pair products make every squared difference vanish. Notes the locus is strictly larger than x = y = z."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-05",
+      "relationship": "parent-problem",
+      "description": "The previous rung, the Maclaurin base step S₁² ≥ S₂ (Cauchy-Schwarz in disguise). Its open-questions list explicitly names 'Prove the next Maclaurin rung S₂² ≥ S₁S₃ (Newton's inequality / log-concavity), the first rung requiring genuinely more than Cauchy-Schwarz' — exactly the result formalized here (all reals, n = 3)."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "parent-problem",
+      "description": "Maclaurin's inequalities via elementary symmetric polynomials; S₂² ≥ S₁S₃ is the second rung of that chain and the first instance of Newton's log-concavity."
+    }
+  ],
+  "references": [
+    {
+      "title": "Newton's inequalities",
+      "url": "https://en.wikipedia.org/wiki/Newton%27s_inequalities",
+      "description": "Log-concavity Sₖ² ≥ Sₖ₋₁Sₖ₊₁ of the normalized elementary symmetric means, valid for all real xᵢ via real-rootedness; this entry formalizes the k = 2 rung for n = 3."
+    },
+    {
+      "title": "Maclaurin's inequality",
+      "url": "https://en.wikipedia.org/wiki/Maclaurin%27s_inequality",
+      "description": "The chain S₁ ≥ √S₂ ≥ ∛S₃ ≥ ⋯ of symmetric means refining AM-GM, refined further by Newton's inequalities."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New verified gallery entry for **amgm-inequality-oq-02-oq-01-oq-05-oq-01**: Newton's k=2 log-concavity rung **S₂² ≥ S₁S₃**, proved for **all real** `x, y, z` (n=3, no nonnegativity hypothesis) via an **explicit sum-of-squares certificate**.

`proofs/Proofs/AmgmInequalityOQ02OQ01OQ05OQ01.lean` — 105 lines, 4 theorems, 3 defs, **0 axioms, 0 sorries**.

### The math
Cleared of binomial denominators, the rung is `2(n-2)·e₂² ≥ 3(n-1)·e₁e₃`; at n=3 (constant 3) this is `e₂² ≥ 3e₁e₃`, and the exact identity
```
e₂² − 3e₁e₃ = ½[(xy−yz)² + (yz−zx)² + (zx−xy)²]
```
(a pure `ring` identity) makes nonnegativity manifest and sign-independent. This strictly **strengthens** the gallery's nonnegative `NewtonLC.newton_ineq`, which genuinely uses `eₖ ≥ 0`.

Theorems: `newton_k2_sos_identity`, `newton_k2_allreals_three`, `newton_k2_allreals_three_cleared`, `newton_k2_equality_iff`.

### Correctness note
The **equality locus** is `e₂² = 3e₁e₃ ⟺ xy = yz = zx` (all pair products equal), which is **strictly larger** than the diagonal `x=y=z` — e.g. `(1,0,0)` attains equality without the variables being equal. An earlier draft claiming `⟺ x=y=z` was mathematically false and was corrected before building.

### Verification
`docker-build.sh Proofs.AmgmInequalityOQ02OQ01OQ05OQ01` → **exit 0, 7743 jobs**, Mathlib v4.26. Proof uses only `ring`/`positivity`/`linarith`/`nlinarith`/`norm_num` — no `native_decide`, no custom axiom → axiom-free. Main theorem from first principles → badge `original`, status `verified`.

### Also
Corrects the problem `knowledge.md`/`state.md`: the prior "Built this session" note referenced a file that existed nowhere (lost/never committed) while state read OBSERVE/iter1. The n=3 core is now actually built and verified. General-n (Johnson-scheme SOS) and n=4,5 explicit witnesses remain open (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)