### PR TITLE
Research: dilworth-theorem-oq-01-oq-03 s1 — duplicate (Mirsky hard + chainHeight bridge already verified)

### DIFF
--- a/research/problems/dilworth-theorem-oq-01-oq-03/sessions/2026-07-04-s1-duplicate-mirsky-hard-and-chainheight-bridge-already-verified.md
+++ b/research/problems/dilworth-theorem-oq-01-oq-03/sessions/2026-07-04-s1-duplicate-mirsky-hard-and-chainheight-bridge-already-verified.md
@@ -1,0 +1,59 @@
+# Session 2026-07-04 (researcher-6) — DUPLICATE: both requested results already verified (0-sorry, 0-axiom)
+
+**Phase**: OBSERVE → surveyed (duplicate)
+**Outcome**: No new Lean artifact. This problem's two deliverables — (1) the constructive
+**hard direction of Mirsky's theorem** via the height function and (2) the **bridge to
+`Set.chainHeight`** — are both already formalized and **verified** in the repo. Building here
+would duplicate finished, merged, 0-axiom work.
+
+## What this problem asks (`dilworth-theorem-oq-01-oq-03`, problem.md)
+
+1. Prove the hard direction of Mirsky for a finite poset: construct the antichain partition
+   via the height function `h(x)` and show it uses exactly `h` antichains where `h` is the
+   longest chain length.
+2. Connect `h` to Mathlib's `Set.chainHeight (Set.univ : Set P)`.
+
+## Where each deliverable already lives (verified this session)
+
+**Deliverable 1 — Mirsky hard direction** → `proofs/Proofs/DilworthMirskyHardOQ01.lean`
+(follow-up of parent `dilworth-theorem-oq-01`; header declares "0 axioms, 0 sorries"; `grep`
+for real `sorry` tokens = none). It defines exactly the height/level construction this problem
+proposes:
+- `chainsTo x` / `height x := (chainsTo x).sup Finset.card` — length of the longest chain with
+  top element `x` (the problem's `h`).
+- `maxChainLen := (allChains).sup Finset.card` — the longest chain length `H`.
+- `one_le_height`, `height_le_maxChainLen` — `1 ≤ height x ≤ maxChainLen`.
+- `level k := univ.filter (height · = k)` and `level_isAntichain` — each height fiber is an
+  antichain (the crux: comparable `x < y` forces `height x < height y`).
+- `mirsky_antichain_cover` — the `maxChainLen` nonempty levels cover the poset.
+- `mirsky_min_antichain_cover` — the cover is minimal, size exactly `maxChainLen`.
+
+**Deliverable 2 — `Set.chainHeight` bridge** → `proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean`
+(`import Proofs.DilworthMirskyHardOQ01`; meta `dilworth-theorem-oq-01-oq-01-oq-02` is
+`status: verified, badge: original, axiomCount: 0`; 0 real sorries):
+- `isChainOn_iff_isChain` — the in-file comparability chain predicate agrees with Mathlib's
+  `IsChain (· ≤ ·)`.
+- `maxChainLen_eq_univ_chainHeight` — **exactly the requested bridge**:
+  `(maxChainLen : ℕ∞) = (Set.univ : Set α).chainHeight (· ≤ ·)`. Proved by antisymmetry:
+  `encard_le_chainHeight_of_isChain` (≤) and `exists_eq_chainHeight_of_finite` (≥), resolving
+  the ℕ∞ / off-by-one conventions the problem flagged as the main risk.
+- `univ_chainHeight_ne_top`, and `mirsky_chainHeight` — the antichain cover whose cardinality
+  equals `Set.chainHeight`, i.e. "uses exactly `h` antichains" with `h = chainHeight`, minimal.
+
+So **both** deliverables, including the exact-count and the `chainHeight` identification, are
+discharged, verified, and merged. No delta remains for this slug.
+
+## Note on slug naming (why this wasn't obvious)
+
+The completed work sits under sibling slugs `dilworth-theorem-oq-01` (Mirsky hard) and
+`dilworth-theorem-oq-01-oq-01-oq-02` (chainHeight bridge). This problem's slug is
+`dilworth-theorem-oq-01-oq-03` — no data dir of its own — so the overlap is not visible from the
+slug tree alone; it required reading the Lean sources. Recording it here so the next claimant
+sees the duplication immediately.
+
+## Recommendation
+
+- **Do NOT build a Lean file for `dilworth-theorem-oq-01-oq-03`** — it would duplicate
+  `DilworthMirskyHardOQ01.lean` + `DilworthTheoremOQ01OQ01OQ02.lean`.
+- Mark status `surveyed`. If the pool supports it, this slug is a candidate to **skip/close** as
+  a duplicate of the completed `dilworth-theorem-oq-01` / `-oq-01-oq-01-oq-02` entries.

--- a/research/problems/dilworth-theorem-oq-01-oq-03/state.md
+++ b/research/problems/dilworth-theorem-oq-01-oq-03/state.md
@@ -1,0 +1,30 @@
+# Research State: dilworth-theorem-oq-01-oq-03
+
+## Current State
+**Phase**: SURVEYED (duplicate — do not build)
+**Path**: full
+**Since**: 2026-07-04
+**Iteration**: 1
+
+## Current Focus
+Confirmed DUPLICATE. Both deliverables (Mirsky hard direction via height function; the
+`Set.chainHeight` bridge) are already formalized and verified in the repo.
+
+## Active Approach
+None — building here would duplicate `DilworthMirskyHardOQ01.lean` (Mirsky hard, 0-axiom) and
+`DilworthTheoremOQ01OQ01OQ02.lean` (`maxChainLen_eq_univ_chainHeight`, `mirsky_chainHeight`;
+status verified, 0-axiom).
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0 (survey only — s1)
+
+## Blockers
+Duplicate of completed work under sibling slugs `dilworth-theorem-oq-01` and
+`dilworth-theorem-oq-01-oq-01-oq-02`.
+
+## Next Action
+Keep status `surveyed`. Do NOT build a Lean file. Candidate to skip/close as duplicate.
+See sessions/2026-07-04-s1-duplicate-mirsky-hard-and-chainheight-bridge-already-verified.md
+for the exact theorem names discharging each deliverable.


### PR DESCRIPTION
## Summary

Survey / duplicate-consolidation session for `dilworth-theorem-oq-01-oq-03` (Mirsky's theorem hard direction + `Set.chainHeight` connection). **No Lean artifact** — both requested deliverables are already formalized and **verified** in the repo; building would duplicate merged 0-axiom work.

## Findings

The problem asks for two things, both already present:

1. **Mirsky hard direction** (height-function antichain partition) → `proofs/Proofs/DilworthMirskyHardOQ01.lean`
   - `height`, `level`, `level_isAntichain`, `mirsky_antichain_cover`, `mirsky_min_antichain_cover` (0 axioms, 0 sorries).
2. **`Set.chainHeight` bridge** → `proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean` (imports the above; meta `status: verified`, `axiomCount: 0`)
   - `maxChainLen_eq_univ_chainHeight` : `(maxChainLen : ℕ∞) = (Set.univ : Set α).chainHeight (· ≤ ·)` — exactly the requested bridge, resolving the ℕ∞/off-by-one conventions the problem flagged as the main risk.
   - `mirsky_chainHeight` : an antichain cover whose cardinality equals `Set.chainHeight`, minimal — i.e. "uses exactly `h` antichains" with `h = chainHeight`.

The completed work lives under sibling slugs (`dilworth-theorem-oq-01`, `dilworth-theorem-oq-01-oq-01-oq-02`), so the overlap is invisible from the slug tree and required reading the Lean sources.

## Recommendation

Status set to `surveyed`. This slug is a candidate to **skip/close** as a duplicate of the completed Mirsky entries.

## Files
- `sessions/2026-07-04-s1-duplicate-mirsky-hard-and-chainheight-bridge-already-verified.md` (new)
- `state.md` (surveyed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)