### PR TITLE
Enrich Pascal's Hexagon (incomplete-01): annotation coverage 4→6

### DIFF
--- a/src/data/proofs/pascals-hexagon-incomplete-01/annotations.json
+++ b/src/data/proofs/pascals-hexagon-incomplete-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-overview",
+    "proofId": "pascals-hexagon-incomplete-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "Why this file exists: the essential real-point hypothesis",
+    "content": "The parent PascalsHexagon.lean reduces Pascal's theorem (for symmetric non-degenerate conics) to a single remaining `sorry`, the Sylvester reduction `sylvester_stdConic_of_isotropic`: a non-degenerate symmetric real conic carrying a REAL point p\u2080 is projectively equivalent to stdConic = diag(1,1,-1). Its docstring asserts \u2014 informally, without proof \u2014 that this real-point hypothesis is essential and not removable, because a definite conic (signature (3,0)/(0,3)) has only the trivial zero while stdConic has a whole cone of real zeros. This file proves that necessity claim rigorously. Honest scope: it does NOT discharge the `sorry` (the hard Sylvester direction for conics that DO carry a real point); it proves the complementary statement that the hypothesis cannot be dropped. The conic definitions below are reproduced locally because the parent is currently bit-rotted under the 4.26.0 toolchain and cannot be imported.",
+    "mathContext": "Necessity of `hp\u2080`: a positive-definite $C$ (signature $(3,0)$) is anisotropic ($p^\\top C p = 0 \\Rightarrow p = 0$), whereas $\\mathrm{stdConic}$ (signature $(2,1)$) is isotropic, so no invertible $M$ can relate them.",
+    "significance": "context",
+    "relatedConcepts": ["Pascal's theorem", "Sylvester's law of inertia", "signature of a quadratic form", "necessity of a hypothesis", "bit-rot / toolchain drift"],
+    "prerequisites": ["projective conics", "quadratic form signature", "Pascal's hexagon theorem"]
+  },
+  {
     "id": "ann-api",
     "proofId": "pascals-hexagon-incomplete-01",
     "range": {
@@ -13,6 +28,21 @@
     "significance": "supporting",
     "relatedConcepts": ["projective conic", "symmetric matrix", "quadratic form", "projective transformation"],
     "prerequisites": ["conics as symmetric matrices", "matrix–vector products"]
+  },
+  {
+    "id": "ann-form-one",
+    "proofId": "pascals-hexagon-incomplete-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 79
+    },
+    "type": "technique",
+    "title": "The identity conic's form is the plain sum of squares",
+    "content": "`conicQuadraticForm_one` is the computational bridge feeding the anisotropy argument: it evaluates the double sum \u2211\u1d62\u2211\u2c7c C\u1d62\u2c7c p\u1d62 p\u2c7c at C = (1 : Conic) (the identity matrix) down to the single sum \u2211\u1d62 p\u1d62\u00b2. The off-diagonal terms vanish because `Matrix.one_apply_ne'` makes 1\u1d62\u2c7c = 0 for i \u2260 j (killed by `ring` after `Finset.sum_eq_single` isolates the j = i term), and the diagonal contributes 1\u1d62\u1d62\u00b7p\u1d62\u00b7p\u1d62 = p\u1d62\u00b2 via `Matrix.one_apply_eq`. Reducing the matrix form to a bare sum of squares is exactly what lets the next lemma invoke nonnegativity.",
+    "mathContext": "$\\mathrm{conicQuadraticForm}\\,(1)\\,p = \\sum_{i,j} \\mathbf{1}_{ij} p_i p_j = \\sum_i p_i^2$, since $\\mathbf{1}_{ij} = 0$ for $i \\neq j$ and $1$ for $i = j$.",
+    "significance": "supporting",
+    "relatedConcepts": ["identity matrix", "Finset.sum_eq_single", "Matrix.one_apply", "diagonal quadratic form"],
+    "prerequisites": ["double sums over Finset", "the identity matrix entries", "matrix quadratic forms"]
   },
   {
     "id": "ann-identity-conic",


### PR DESCRIPTION
Enrichment pass for `pascals-hexagon-incomplete-01` (PascalsHexagonIncomplete01.lean, 152 lines, 5 theorems).

**Gap:** annotations covered only lines 47-134, leaving two real coverage holes. Coverage 4 → 6 (purely additive; the existing four annotations are byte-unchanged):

- **`ann-overview` (3-41):** the opening docstring — which states *why the file exists* (the parent's `sylvester_stdConic_of_isotropic` sorry, and the informal claim that its real-point hypothesis is essential) and the *honest scope* (this file proves the necessity, it does **not** discharge the sorry) — was entirely unannotated.
- **`ann-form-one` (71-79):** the helper theorem `conicQuadraticForm_one` (the identity conic's form reduces to ∑ᵢ pᵢ²) fell in the gap between `ann-api` (ends 69) and `ann-identity-conic` (starts 81). It is the 5th theorem and the computational bridge feeding the anisotropy argument — previously uncovered.

Both new annotations carry `mathContext`/`significance`/`relatedConcepts`/`prerequisites`. Non-overlapping, in order; the trailing recap docstring (138-151) is left uncovered as it merely restates already-annotated results.
