### PR TITLE
Enrich Newton's rung S₂²≥S₁S₃ (all reals, n=3): add annotations.json (0→6)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-05-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Newton's k = 2 rung, cleared and specialized to n = 3",
+    "content": "The docstring states Newton's log-concavity rung S₂² ≥ S₁S₃ for the normalized (Maclaurin) symmetric means Sₖ = eₖ/C(n,k), and clears the binomial denominators to the integer form 2(n-2)·e₂² ≥ 3(n-1)·e₁e₃. It emphasizes that Newton's inequalities hold for ALL real xᵢ (they descend from the real-rootedness of ∏(t−xᵢ) and its derivatives, never from a sign hypothesis), so this all-reals n = 3 statement strictly strengthens the gallery's nonnegative NewtonLC.newton_ineq. At n = 3 the cleared constant is 2(n-2) = 2, 3(n-1) = 6, giving e₂² ≥ 3e₁e₃. Note: the docstring's parenthetical claiming the square-sum vanishes on the diagonal x = y = z is imprecise — the theorem newton_k2_equality_iff establishes the honest locus xy = yz = zx (see the equality-locus annotation).",
+    "mathContext": "$S_2^2 \\ge S_1 S_3$ with $S_k = e_k/\\binom{n}{k}$; cleared: $2(n-2)\\,e_2^2 \\ge 3(n-1)\\,e_1 e_3$; at $n=3$: $e_2^2 \\ge 3 e_1 e_3$.",
+    "significance": "context",
+    "relatedConcepts": ["Newton's inequalities", "Maclaurin's inequality", "log-concavity", "real-rooted polynomials", "elementary symmetric means"],
+    "prerequisites": ["elementary symmetric polynomials", "binomial coefficients"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 33, "endLine": 40 },
+    "type": "definition",
+    "title": "The three elementary symmetric polynomials",
+    "content": "Defines e₁ = x + y + z, e₂ = xy + yz + zx, and e₃ = xyz for three reals. These are the elementary symmetric polynomials in the variables x, y, z — the coefficients (up to sign) of the monic cubic ∏(t − xᵢ) = t³ − e₁t² + e₂t − e₃. All subsequent theorems are stated purely in terms of e1, e2, e3 and unfolded via `simp only [e1, e2, e3]` before the algebra closes them.",
+    "mathContext": "$e_1 = x+y+z,\\ e_2 = xy+yz+zx,\\ e_3 = xyz$; $\\prod_i (t - x_i) = t^3 - e_1 t^2 + e_2 t - e_3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["elementary symmetric polynomials", "Vieta's formulas", "monic polynomial coefficients"],
+    "prerequisites": ["polynomials in several variables"]
+  },
+  {
+    "id": "ann-sos-identity",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 42, "endLine": 48 },
+    "type": "insight",
+    "title": "The explicit SOS certificate (a `ring` identity)",
+    "content": "newton_k2_sos_identity is the heart of the proof: the Newton defect e₂² − 3e₁e₃ equals exactly half the sum of the three squared pair-product differences. This is a pure polynomial identity over ℝ, closed by `simp only [e1, e2, e3]; ring`, and holds independently of any sign of x, y, z. Because the right-hand side is manifestly a sum of squares, nonnegativity of the defect is immediate — no analysis, no case split, no sign hypothesis. This exemplifies Hilbert's theorem that a nonnegative quartic in ≤ 3 variables is always a sum of squares.",
+    "mathContext": "$e_2^2 - 3 e_1 e_3 = \\tfrac12\\big[(xy-yz)^2 + (yz-zx)^2 + (zx-xy)^2\\big]$.",
+    "significance": "key",
+    "relatedConcepts": ["sum-of-squares certificate", "Hilbert's SOS theorem", "positive semidefinite quartics", "Positivstellensatz"],
+    "prerequisites": ["polynomial identities", "sum-of-squares decompositions", "Lean `ring` tactic"]
+  },
+  {
+    "id": "ann-main-inequality",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 50, "endLine": 59 },
+    "type": "technique",
+    "title": "Newton's k = 2 inequality for all reals (n = 3)",
+    "content": "newton_k2_allreals_three proves e₂² ≥ 3e₁e₃ for every x, y, z : ℝ with no nonnegativity hypothesis. The proof is two lines: instantiate the SOS identity, note its right-hand side is ≥ 0 by `positivity` (a sum of squared reals divided by 2), then `linarith` chains identity + nonnegativity into the inequality. The strength of the SOS approach is that the hard content lives entirely in the algebraic identity — the inequality step is mechanical.",
+    "mathContext": "$e_2^2 \\ge 3 e_1 e_3$ for all $x,y,z\\in\\mathbb{R}$, since the SOS right-hand side is $\\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["sum-of-squares certificate", "Newton's inequalities", "log-concavity of symmetric means"],
+    "prerequisites": ["Lean `positivity` and `linarith` tactics", "nonnegativity of squares"]
+  },
+  {
+    "id": "ann-cleared-form",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 61, "endLine": 66 },
+    "type": "technique",
+    "title": "The integer-cleared form matching the general n statement",
+    "content": "newton_k2_allreals_three_cleared repackages the inequality as 2·e₂² ≥ 6·(e₁e₃), matching the general cleared statement 2(n-2)·e₂² ≥ 3(n-1)·e₁e₃ specialized at n = 3 (constants 2 and 6). This makes explicit that the n = 3 result is the base dimension of a uniform family, and pins down the corrected constant 3(n-1)/(2(n-2)) — not its reciprocal. Proved by `nlinarith` from the main inequality.",
+    "mathContext": "$2\\,e_2^2 \\ge 6\\,(e_1 e_3)$; general: $2(n-2)\\,e_2^2 \\ge 3(n-1)\\,e_1 e_3$, constant $\\tfrac{3(n-1)}{2(n-2)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Newton's inequalities general n", "Maclaurin normalization constants", "binomial coefficient ratios"],
+    "prerequisites": ["Lean `nlinarith` tactic", "binomial coefficient identities"]
+  },
+  {
+    "id": "ann-equality-locus",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-05-oq-01",
+    "range": { "startLine": 68, "endLine": 104 },
+    "type": "insight",
+    "title": "The exact equality locus: all pair products equal",
+    "content": "newton_k2_equality_iff characterizes when e₂² = 3e₁e₃ holds with equality: exactly when all three pair products agree, xy = yz = zx. The forward direction sets the defect to 0, which forces the sum of three squares to 0, hence each square to 0 (via `nlinarith` with the other two `sq_nonneg` terms, then `by_contra` + `positivity`), giving xy = yz = zx. The backward direction is immediate: equal pair products make every squared difference vanish. Crucially this locus is strictly larger than the diagonal x = y = z — e.g. (1, 0, 0) has all pair products 0 and attains equality without the variables being equal. The SOS certificate exposes this exactly, correcting the imprecise 'x = y = z' remark in the Lean docstring.",
+    "mathContext": "$e_2^2 = 3 e_1 e_3 \\iff xy = yz = zx$; strictly larger than $x=y=z$, e.g. $(1,0,0)$.",
+    "significance": "key",
+    "relatedConcepts": ["equality locus", "sum-of-squares vanishing set", "Newton equality case", "degenerate configurations"],
+    "prerequisites": ["Lean `nlinarith` / `by_contra` / `positivity` tactics", "vanishing of a sum of squares"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-05-oq-01` (Newton's rung S₂² ≥ S₁S₃ for all reals, n = 3).

**Gap addressed:** the entry had a comprehensive `meta.json` but **no `annotations.json`** (quality 41, passes 0) — zero inline annotation coverage of the 105-line Lean file.

**Added:** `annotations.json` with **6 annotations** covering lines 1–104 (full file), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- `ann-docstring` (1–28): Newton's cleared rung + all-reals framing
- `ann-defs` (33–40): the three elementary symmetric polynomials
- `ann-sos-identity` (42–48): the explicit SOS certificate `e₂²−3e₁e₃ = ½Σ(pair-diff)²` — the key insight
- `ann-main-inequality` (50–59): all-reals inequality via `positivity`+`linarith`
- `ann-cleared-form` (61–66): integer-cleared `2e₂² ≥ 6e₁e₃` matching general n
- `ann-equality-locus` (68–104): honest locus `xy = yz = zx` (strictly larger than the diagonal; corrects the imprecise `x=y=z` remark in the Lean docstring)

Additive only (new file; no `annotations.json` existed on main). `meta.json` unchanged. Size check passes. Built via git plumbing off `origin/main`.
