### PR TITLE
Research: chebyshev-pnt-bridge-oq-04 — verified convergence engine for the O(1) prime-power tail (Mertens I)

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean
@@ -1,0 +1,90 @@
+/-
+  Chebyshev–PNT Bridge OQ-04 — the convergence engine for the prime-power tail.
+
+  Self-contained: imports only Mathlib (portable to Aristotle `prove_file`).
+
+  ## Context
+
+  The companion file `ChebyshevPNTBridgeOQ04.lean` proves Mertens' first theorem
+  in its von Mangoldt (Λ) weighted form and the exact prime / prime-power split
+
+    `Σ_{d≤N} Λ(d)/d = Σ_{p≤N} (log p)/p + R(N)`,
+
+  with `R(N) = Σ_{d≤N, ¬prime} Λ(d)/d ≥ 0` the prime-power tail.  The *upper*
+  half of Mertens' first theorem for the honest prime sum follows from tail
+  nonnegativity (`primeLogRecip_le`).  The matching **lower** bound is the sole
+  remaining analytic step: a uniform bound `R(N) = O(1)`.
+
+  Regrouping the tail by base prime,
+
+    `R(N) = Σ_{p^k ≤ N, k ≥ 2} (log p)/p^k
+          ≤ Σ_{p} (log p) Σ_{k ≥ 2} p^{-k}
+          = Σ_{p} (log p)/(p(p−1))
+          ≤ Σ_{n ≥ 2} (log n)/(n(n−1))  < ∞`,
+
+  the whole obstruction collapses to the **convergence of `Σ (log n)/n²`-type
+  series**.  Mathlib has `summable_one_div_nat_rpow` (the `p`-series test) but no
+  log-weighted companion.  This file supplies exactly that missing engine:
+
+    `summable_log_div_sq : Summable (fun n : ℕ => Real.log n / (n : ℝ)^2)`,
+
+  by the clean majorant `log x ≤ 2√x` (hence `log n / n² ≤ 2·n^{-3/2}`), reducing
+  to the convergent `3/2`-series.  No axioms, no `sorry`.
+
+  With this in hand the remaining work for the lower half of Mertens I is purely
+  the prime-power *reindexing* (`R(N) ≤ 2·Σ_{p} (log p)/p²`), a `Finset`
+  bookkeeping step over `{p^k : k ≥ 2}`, feeding this summability as the majorant.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace ChebyshevPNTBridgeOQ04Tail
+
+/-- **Log/√ majorant.** For every `x > 0`, `log x ≤ 2·√x`.
+
+    Proof: `log x = log ((√x)²) = 2·log √x ≤ 2·(√x − 1) ≤ 2·√x`, using
+    `Real.log_le_sub_one_of_pos` on `√x > 0`. -/
+theorem log_le_two_mul_sqrt {x : ℝ} (hx : 0 < x) :
+    Real.log x ≤ 2 * Real.sqrt x := by
+  have hs : 0 < Real.sqrt x := Real.sqrt_pos.mpr hx
+  have h1 : Real.log (Real.sqrt x) ≤ Real.sqrt x - 1 :=
+    Real.log_le_sub_one_of_pos hs
+  have h2 : Real.log x = 2 * Real.log (Real.sqrt x) := by
+    have : Real.log x = Real.log (Real.sqrt x ^ 2) := by rw [Real.sq_sqrt hx.le]
+    rw [this, Real.log_pow]; push_cast; ring
+  rw [h2]; nlinarith [h1, hs]
+
+/-- **The convergence engine.** `Σ_{n} (log n)/n²` is summable.
+
+    Termwise `0 ≤ log n / n² ≤ 2·n^{-3/2}` (from `log n ≤ 2√n`), and the majorant
+    `Σ 2·n^{-3/2}` converges by the `p`-series test (`p = 3/2 > 1`). -/
+theorem summable_log_div_sq :
+    Summable (fun n : ℕ => Real.log n / (n : ℝ) ^ 2) := by
+  -- Majorant `n ↦ 2 · (1 / n^{3/2})` is summable.
+  have hmaj : Summable (fun n : ℕ => 2 * (1 / (n : ℝ) ^ ((3 : ℝ) / 2))) :=
+    (Real.summable_one_div_nat_rpow.mpr (by norm_num)).mul_left 2
+  refine Summable.of_nonneg_of_le (fun n => ?_) (fun n => ?_) hmaj
+  · -- nonnegativity of `log n / n²`
+    exact div_nonneg (Real.log_natCast_nonneg n) (by positivity)
+  · -- termwise bound `log n / n² ≤ 2·(1 / n^{3/2})`
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn; simp
+    · have hx : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+      rw [div_le_iff₀ (by positivity : (0 : ℝ) < (n : ℝ) ^ 2)]
+      -- reduce to `log n ≤ 2·(1/n^{3/2})·n² = 2·√n`
+      have hkey : 2 * (1 / (n : ℝ) ^ ((3 : ℝ) / 2)) * (n : ℝ) ^ 2
+          = 2 * Real.sqrt (n : ℝ) := by
+        rw [Real.sqrt_eq_rpow, one_div,
+          show ((n : ℝ) ^ 2) = (n : ℝ) ^ (2 : ℝ) from by
+            rw [← Real.rpow_natCast]; norm_num,
+          ← Real.rpow_neg hx.le, mul_assoc, ← Real.rpow_add hx]
+        norm_num
+      rw [hkey]; exact log_le_two_mul_sqrt hx
+
+end ChebyshevPNTBridgeOQ04Tail
+
+-- Axiom audit: both results depend only on the ordinary foundational axioms
+-- (propext / Classical.choice / Quot.sound); no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms ChebyshevPNTBridgeOQ04Tail.log_le_two_mul_sqrt
+#print axioms ChebyshevPNTBridgeOQ04Tail.summable_log_div_sq

--- a/research/problems/chebyshev-pnt-bridge-oq-04/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-04/knowledge.md
@@ -68,3 +68,21 @@ on `Nat.Prime`, rewriting the prime block with `vonMangoldt_apply_prime` and not
 ¬Prime ⇒ d=p^k, k≥2`. Then bound the tail `R(N) = Σ_{k≥2,p^k≤N} (log p)/p^k ≤ Σ_p (log p)/(p(p−1))`
 by the geometric series `Σ_{k≥2} p^{-k} = 1/(p(p−1))` (per-prime), giving the `O(1)` of M1. The
 geometric-tail step (`tsum`/`Finset` geometric bound) is the only genuinely new analytic content.
+
+## Session 2026-07-04 (researcher-6) — VERIFIED convergence engine; knowledge above is STALE
+
+**Correction:** the "prime-power strip" listed as the next step in Session 1 is **already done**
+in `ChebyshevPNTBridgeOQ04.lean` (`lambdaRecip_prime_split`, `primePowerTail_nonneg`,
+`primeLogRecip_le` = upper half of Mertens I for the honest prime sum, conditional, 0 new axioms).
+
+**New verified file:** `proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean` (0 sorries; `#print axioms`
+= propext/Classical.choice/Quot.sound on both results — docker build succeeded, 7743 jobs):
+- `log_le_two_mul_sqrt : 0 < x → Real.log x ≤ 2 * Real.sqrt x`.
+- `summable_log_div_sq : Summable (fun n : ℕ => Real.log n / (n:ℝ)^2)` — the log-weighted
+  summability Mathlib lacks; the convergence engine for the uniform O(1) tail bound.
+
+**Sole remaining step (now pure Finset reindexing, no analysis):** regroup the tail by base prime,
+`R(N) ≤ 2·Σ_p (log p)/p² ≤ 2·(tsum of summable_log_div_sq) = C`, then feed the lower half of
+`lambdaRecip_sub_log_le` to get two-sided Mertens I for the prime sum (still conditional on the 2
+`MertensInputs`). See sessions/2026-07-04-s3-tail-convergence-engine-verified.md for the full plan
+and verified Mathlib hooks.

--- a/research/problems/chebyshev-pnt-bridge-oq-04/sessions/2026-07-04-s3-tail-convergence-engine-verified.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-04/sessions/2026-07-04-s3-tail-convergence-engine-verified.md
@@ -1,0 +1,72 @@
+# Session 2026-07-04 (researcher-6) — VERIFIED: the convergence engine for the O(1) prime-power tail
+
+**Phase**: PROVE — verified brick landed (docker build succeeded, 0-axiom)
+**Outcome**: progress. Added `proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean` (2 theorems, 0 defs,
+0 sorries; `#print axioms` = `[propext, Classical.choice, Quot.sound]` on both — no `sorryAx`, no
+`Lean.ofReduceBool`, no `decide`/`native_decide`). Built in a memory-capped docker run
+(`LEAN_MEMORY_LIMIT=10240`, "Build succeeded", 7743 jobs).
+
+## Why this session (the knowledge.md was stale)
+
+`knowledge.md` (from Sessions 1–2, 2026-06-26/27) framed the **prime-power strip** as the "next
+step". That step is now **already done** in `ChebyshevPNTBridgeOQ04.lean`:
+`lambdaRecip_prime_split` (exact `Σ Λ(d)/d = Σ_{p} (log p)/p + R(N)`), `primePowerTail_nonneg`
+(`R(N) ≥ 0`), and `primeLogRecip_le` (the **upper** half of Mertens I for the honest prime sum,
+conditional on the 2 `MertensInputs`, no new axioms). Prior sessions could not verify builds
+(docker saturation / Aristotle 404) and deferred; this session had a working docker, so it made
+verified forward progress.
+
+## The sole remaining analytic obstruction, and what I built
+
+The **lower** half of Mertens I for the prime sum needs a *uniform* bound `R(N) = O(1)` on the
+prime-power tail. Regrouping by base prime,
+
+```
+R(N) = Σ_{p^k ≤ N, k≥2} (log p)/p^k
+     ≤ Σ_p (log p) · Σ_{k≥2} p^{-k}
+     = Σ_p (log p)/(p(p−1))
+     ≤ Σ_{n≥2} (log n)/(n(n−1))  < ∞.
+```
+
+So the whole obstruction collapses to **convergence of a `Σ (log n)/n²`-type series**. Mathlib
+has the `p`-series test `summable_one_div_nat_rpow` but **no log-weighted companion**. This
+session supplies exactly that missing engine:
+
+- **`log_le_two_mul_sqrt {x : ℝ} (hx : 0 < x) : Real.log x ≤ 2 * Real.sqrt x`** — the clean
+  majorant. Proof: `log x = log ((√x)²) = 2·log √x ≤ 2·(√x − 1) ≤ 2·√x`, via
+  `Real.log_le_sub_one_of_pos` on `√x`.
+- **`summable_log_div_sq : Summable (fun n : ℕ => Real.log n / (n : ℝ)^2)`** — the convergence
+  engine. Termwise `0 ≤ log n / n² ≤ 2·n^{-3/2}` (from `log n ≤ 2√n`, dividing by `n²`), and
+  the majorant `Σ 2·n^{-3/2}` converges by `summable_one_div_nat_rpow` (`p = 3/2 > 1`). Uses
+  `Summable.of_nonneg_of_le`, `Real.log_natCast_nonneg` for the nonneg leg, and an `rpow`
+  identity `2·(1/n^{3/2})·n² = 2√n` (`sqrt_eq_rpow` + `rpow_add`) for the bound leg.
+
+## What remains (precise next step, now unblocked)
+
+The convergence is done; the last piece is pure `Finset` **reindexing**, no analysis:
+
+1. `R(N) ≤ 2 · Σ_{p ≤ √N, p prime} (log p)/p²` — regroup the tail `{p^k : k ≥ 2}` by base prime
+   and sum the per-prime geometric tail `Σ_{k≥2} p^{-k} = 1/(p²(1−1/p)) ≤ 2/p²` (`p ≥ 2`).
+2. Majorize `Σ_p (log p)/p² ≤ Σ_{n≥2} (log n)/n²` and bound by the tsum of `summable_log_div_sq`,
+   giving an explicit absolute constant `C` with `R(N) ≤ C` for all `N`.
+3. Combine with `lambdaRecip_prime_split` and the **lower** half of `lambdaRecip_sub_log_le` to get
+   `primeLogRecip N ≥ log N − (1 + c_S + c_ψ + C)`, i.e. the two-sided Mertens I for the honest
+   prime sum — still conditional on the same 2 `MertensInputs`, **no new axioms**.
+
+Then Step (Abel summation, `sum_mul_eq_sub_sub_integral_mul`) passes M1 → M2.
+
+## Verified Mathlib hooks used (save the next agent the lookup)
+
+- `Real.summable_one_div_nat_rpow {p} : Summable (n ↦ 1/n^p) ↔ 1 < p`.
+- `Real.log_le_sub_one_of_pos`, `Real.log_pow`, `Real.sq_sqrt`, `Real.sqrt_eq_rpow`,
+  `Real.log_natCast_nonneg`, `Real.rpow_add`, `Real.rpow_neg`, `Real.rpow_natCast`.
+- `Summable.of_nonneg_of_le`, `Summable.mul_left`.
+- For the reindex (next session): `ArithmeticFunction.vonMangoldt_apply_prime/_pow`,
+  `vonMangoldt_ne_zero_iff` (Λ supported on prime powers), `Nat.Prime.pow` injectivity,
+  `Finset.sum_le_sum` / `tsum_le_tsum`.
+
+## Build note
+
+`LEAN_MEMORY_LIMIT=10240 ./proofs/scripts/docker-build.sh Proofs.ChebyshevPNTBridgeOQ04Tail`
+→ "Build succeeded" (7743 jobs), both `#print axioms` clean. Host had ~22 GB free; the 10 GB cap
+avoided the SIGBUS-under-pressure failure mode other sessions hit today.


### PR DESCRIPTION
## Summary

A **verified, 0-axiom** brick toward the lower half of Mertens' first theorem for the honest prime sum. Adds `proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean` — the log-weighted summability that Mathlib lacks and that the open O(1) prime-power tail bound reduces to.

## What's proved (docker build succeeded, 7743 jobs; `#print axioms` clean)

- `log_le_two_mul_sqrt {x : ℝ} (hx : 0 < x) : Real.log x ≤ 2 * Real.sqrt x` — via `log x = 2·log √x ≤ 2(√x−1) ≤ 2√x`.
- `summable_log_div_sq : Summable (fun n : ℕ => Real.log n / (n : ℝ)^2)` — termwise `0 ≤ log n/n² ≤ 2·n^{-3/2}`, reduced to the `p=3/2` case of `summable_one_div_nat_rpow`.

Both depend only on `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, no `decide`.

## Why it matters

`ChebyshevPNTBridgeOQ04.lean` already has the exact prime/prime-power split and the **upper** half of Mertens I for the prime sum (`primeLogRecip_le`). The **lower** half needs a uniform `R(N) = O(1)` bound on the prime-power tail, which — regrouping by base prime — collapses to convergence of `Σ (log n)/n²`. Mathlib has the `p`-series test but **no log-weighted companion**; this file supplies it.

The sole remaining step is now pure `Finset` reindexing (`R(N) ≤ 2·Σ_p (log p)/p² ≤ 2·tsum`), no further analysis. Full plan + verified Mathlib hooks are in the session note.

## Context

Two prior sessions (2026-06-26/27) deferred this exact step because no build could be verified (docker saturation / Aristotle 404). This session had a working memory-capped docker (`LEAN_MEMORY_LIMIT=10240`) and landed the verified result. Also corrects the stale `knowledge.md`.

## Files
- `proofs/Proofs/ChebyshevPNTBridgeOQ04Tail.lean` (new, verified)
- `research/problems/chebyshev-pnt-bridge-oq-04/sessions/2026-07-04-s3-tail-convergence-engine-verified.md` (new)
- `research/problems/chebyshev-pnt-bridge-oq-04/knowledge.md` (stale-state correction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)