### PR TITLE
Newton via real-rootedness (Part VIII): reversal preserves splitting → general-n BOTTOM Newton step

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -584,6 +584,116 @@ theorem newton_top_coeff_ineq (m : ℕ) {p : ℝ[X]}
   simp only [nsmul_eq_mul] at h
   nlinarith [h]
 
+/-!  ## Part VIII — the general-`n` BOTTOM Newton step via a single reversal
+
+Part VII closed the general TOP Newton step (the discriminant of `p`'s three
+*top* coefficients), but when specialised to the monic splitting polynomial
+`∏(X - xᵢ)` — whose top three coefficients are `1, -e₁, e₂` — that top step only
+reproduces the FIRST Newton inequality (`e₁² ≥ … e₂`), already general in Part III.
+Genuinely new arbitrary-`n` content lives in the *other* steps, and the classical
+route reaches them by REVERSING the polynomial: `reverse p` reads `p`'s
+coefficients bottom-up, so applying the Part VII top-step engine to `reverse p`
+yields Newton's discriminant inequality on `p`'s three *bottom* coefficients
+`coeff 0, coeff 1, coeff 2`.  For `p = ∏(X - xᵢ)` (all roots nonzero, so
+`coeff 0 = ±eₙ ≠ 0`) this is the classical BOTTOM step `eₙ₋₁² ≥ eₙ₋₂ eₙ` — NOT
+reachable from Parts III or VII.
+
+The one piece of infrastructure this needs, and which Mathlib does not package, is
+that reversal preserves splitting: **a real-rooted polynomial has a real-rooted
+reversal**.  We build it here from `splits_iff_exists_multiset` (`p` factors as
+`C (leadingCoeff p) · ∏ (X - rᵢ)`), `reverse_mul_of_domain` (reverse distributes
+over products in a domain), and the fact that each `reverse (X - C rᵢ)` has degree
+`≤ 1` with invertible leading coefficient (`= trailingCoeff (X - C rᵢ) ≠ 0`), hence
+splits.  No sign hypothesis on the roots for splitting itself; the reversal reading
+`p`'s bottom coefficients needs only `p.coeff 0 ≠ 0` (nonzero constant term, i.e.
+`natTrailingDegree p = 0`). -/
+
+/-- **The reversal of a real linear factor splits.**  `reverse (X - C a)` has
+degree `≤ 1` and leading coefficient `trailingCoeff (X - C a) ≠ 0` (invertible in
+the field `ℝ`), so it splits.  This is the per-factor atom for `splits_reverse`. -/
+theorem splits_reverse_linear (a : ℝ) : Splits (reverse (X - C a : ℝ[X])) := by
+  apply splits_of_natDegree_le_one_of_invertible
+  · exact (reverse_natDegree_le _).trans (by rw [natDegree_X_sub_C])
+  · rw [reverse_leadingCoeff]
+    exact invertibleOfNonzero (mt trailingCoeff_eq_zero.mp (X_sub_C_ne_zero a))
+
+/-- **The reversal of a product of real linear factors splits.**  `reverse`
+distributes over the multiset product (domain), and each factor's reversal splits
+(`splits_reverse_linear`), so the whole reversal splits.  Multiset induction. -/
+theorem splits_reverse_prod (s : Multiset ℝ) :
+    Splits (reverse ((s.map (fun r => X - C r)).prod)) := by
+  induction s using Multiset.induction with
+  | empty =>
+      simp only [Multiset.map_zero, Multiset.prod_zero]
+      rw [show (1 : ℝ[X]) = C 1 from C_1.symm, reverse_C]
+      exact Splits.C 1
+  | cons a t ih =>
+      rw [Multiset.map_cons, Multiset.prod_cons, reverse_mul_of_domain]
+      exact (splits_reverse_linear a).mul ih
+
+/-- **Reversal preserves splitting.**  If `p : ℝ[X]` splits over `ℝ` (is
+real-rooted), so does its reversal `reverse p`.  This is the reversal counterpart
+of Part V's `splits_derivative`, and the infrastructure Mathlib lacks that unlocks
+the bottom/interior Newton steps.  Proof: factor `p = C (leadingCoeff p) · ∏(X-rᵢ)`
+via `splits_iff_exists_multiset`, distribute `reverse` over the product
+(`reverse_mul_of_domain`), and split each reversed factor (`splits_reverse_prod`,
+with `reverse (C _) = C _`). -/
+theorem splits_reverse {p : ℝ[X]} (hp : Splits p) : Splits (reverse p) := by
+  obtain ⟨m, hm⟩ := splits_iff_exists_multiset.mp hp
+  rw [hm, reverse_mul_of_domain, reverse_C]
+  exact (Splits.C _).mul (splits_reverse_prod m)
+
+/-- **A split real polynomial with nonzero constant term has nonnegative
+discriminant in its three BOTTOM coefficients** — read directly on
+`p.coeff 0, p.coeff 1, p.coeff 2`.
+
+If `p : ℝ[X]` splits (is real-rooted over `ℝ`), has `natDegree = m + 2`, and has a
+nonzero constant term `p.coeff 0 ≠ 0` (so `natTrailingDegree p = 0`), then applying
+the Part VII top-step engine `discrim_iterate_derivative_top` to `reverse p` — which
+splits (`splits_reverse`), still has `natDegree = m + 2`, and whose top three
+coefficients are `p`'s bottom three (`coeff_reverse` + `revAt_le`) — gives
+`0 ≤ discrim` of `p`'s bottom three coefficients.  For `p = ∏(X - xᵢ)` this is the
+classical BOTTOM Newton log-concavity step `eₙ₋₁² ≥ eₙ₋₂ eₙ`, the reversal-mirror of
+Part VII's top step and unreachable from Parts III/VII.  No sign hypothesis beyond
+`coeff 0 ≠ 0` (all roots nonzero). -/
+theorem discrim_reverse_bottom (m : ℕ) {p : ℝ[X]}
+    (hp : Splits p) (h0 : p.coeff 0 ≠ 0) (hdeg : p.natDegree = m + 2) :
+    0 ≤ discrim
+        ((2 + m).descFactorial m • p.coeff 0)
+        ((1 + m).descFactorial m • p.coeff 1)
+        ((0 + m).descFactorial m • p.coeff 2) := by
+  have htrail : p.natTrailingDegree = 0 := Nat.le_zero.mp (natTrailingDegree_le_of_ne_zero h0)
+  have hqdeg : (reverse p).natDegree = m + 2 := by
+    rw [reverse_natDegree, hdeg, htrail, Nat.sub_zero]
+  have h := discrim_iterate_derivative_top m (splits_reverse hp) hqdeg
+  -- the top three coefficients of `reverse p` are `p`'s bottom three
+  have e2 : (reverse p).coeff (2 + m) = p.coeff 0 := by
+    rw [coeff_reverse, hdeg, revAt_le (by omega)]; congr 1; omega
+  have e1 : (reverse p).coeff (1 + m) = p.coeff 1 := by
+    rw [coeff_reverse, hdeg, revAt_le (by omega)]; congr 1; omega
+  have e0 : (reverse p).coeff (0 + m) = p.coeff 2 := by
+    rw [coeff_reverse, hdeg, revAt_le (by omega)]; congr 1; omega
+  rwa [e2, e1, e0] at h
+
+/-- **General-`n` bottom Newton inequality on the coefficients of a real-rooted
+polynomial.**  For any `p : ℝ[X]` that splits with `natDegree = m + 2` and nonzero
+constant term, the three bottom coefficients satisfy
+`4 · (2+m).descFactorial m · m.descFactorial m · p.coeff 0 · p.coeff 2
+  ≤ ((1+m).descFactorial m)² · p.coeff 1 ²`.
+This is `discrim_reverse_bottom` written as the recognizable log-concavity
+inequality `b² ≥ 4ac` on the bottom three coefficients — the honest calculus proof
+of Newton's BOTTOM step, valid for every arity and all signed inputs (only the
+constant term must be nonzero). -/
+theorem newton_bottom_coeff_ineq (m : ℕ) {p : ℝ[X]}
+    (hp : Splits p) (h0 : p.coeff 0 ≠ 0) (hdeg : p.natDegree = m + 2) :
+    4 * ((2 + m).descFactorial m : ℝ) * ((0 + m).descFactorial m : ℝ)
+        * p.coeff 0 * p.coeff 2
+      ≤ ((1 + m).descFactorial m : ℝ) ^ 2 * p.coeff 1 ^ 2 := by
+  have h := discrim_reverse_bottom m hp h0 hdeg
+  rw [discrim] at h
+  simp only [nsmul_eq_mul] at h
+  nlinarith [h]
+
 /-!  ## Part III, in explicit normalized (`p`) form
 
 `newton_first_general` states the first Newton inequality in cleared-denominator

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
@@ -29,27 +29,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: New proof route (real-rootedness/discriminant) established in the amgm family and complete for the quadratic/n=2 base case, valid for SIGNED inputs. AmgmInequalityOQ02OQ02OQ05.lean: 8 theorems, 0 sorries, 0 axioms (foundational only). General n>=3 retained open (iterated-Rolle crux).",
+    "progressSummary": "PROGRESS (Part VIII, researcher-5): built splits_reverse (Splits p → Splits (reverse p)), the reversal counterpart of Part V that Mathlib lacked, and used it to prove the general-n BOTTOM Newton step (newton_bottom_coeff_ineq / discrim_reverse_bottom) on a real-rooted polynomials three bottom coefficients — genuinely new arbitrary-n content unreachable from Parts III/VII (which only give the first/top step). 33 theorems, 0 sorries, 0 axioms (foundational only), docker-build clean 7743 jobs. Remaining: general interior steps (reverse+derivative) and the Vieta substitution to elementary-symmetric mean form.",
     "builtItems": [
       "discrim_nonneg_of_root in Proofs/AmgmInequalityOQ02OQ02OQ05.lean (real quadratic with a real root has 0 <= discrim)",
       "monic_quadratic_discrim_nonneg / discrim_nonneg_of_roots_nonempty (same via Polynomial.IsRoot and nonempty Polynomial.roots)",
       "realRooted_quadratic_coeff_ineq (4*c <= b^2)",
       "prod_two_linear_eq + root_of_prod_two_linear (Vieta for (X-x)(X-y))",
-      "newton_two_vars: x*y <= ((x+y)/2)^2 for signed reals, via the discriminant of the real-rooted (X-x)(X-y)"
+      "newton_two_vars: x*y <= ((x+y)/2)^2 for signed reals, via the discriminant of the real-rooted (X-x)(X-y)",
+      "splits_reverse_linear (a) : Splits (reverse (X - C a)) in Proofs/AmgmInequalityOQ02OQ02OQ05.lean (Part VIII) — per-factor atom via splits_of_natDegree_le_one_of_invertible + reverse_leadingCoeff + trailingCoeff_eq_zero",
+      "splits_reverse_prod (s : Multiset ℝ) : Splits (reverse ((s.map (X - C ·)).prod)) — multiset induction using reverse_mul_of_domain",
+      "splits_reverse {p} (hp : Splits p) : Splits (reverse p) — THE new infra Mathlib lacks; reversal preserves real-rootedness",
+      "discrim_reverse_bottom (m) {p} (hp : Splits p) (h0 : p.coeff 0 ≠ 0) (hdeg : natDegree p = m+2) : 0 ≤ discrim of p bottom three coeffs (descFactorial-weighted) — general-n BOTTOM Newton step via one reversal",
+      "newton_bottom_coeff_ineq (m) {p} … : 4·(2+m)!desc·m!desc·p.coeff 0·p.coeff 2 ≤ ((1+m)!desc)²·p.coeff 1² — readable b²≥4ac bottom step"
     ],
     "insights": [
       "Mathlib packages the completed-square identity as discrim_eq_sq_of_quadratic_eq_zero (h : a*(x*x)+b*x+c=0) : discrim a b c = (2*a*x+b)^2, so real-root implies nonneg discriminant is a 2-line proof (rw + sq_nonneg). This is the per-derivative atom of the whole Newton/Rolle program.",
       "The real-rootedness route needs only REAL (not positive) roots, so Newton at n=2 (newton_two_vars: x*y <= ((x+y)/2)^2) holds for SIGNED x,y, a genuine generalization over the parent amgm-inequality-oq-02-oq-02 whose induction assumes 0 <= x_i.",
       "Nobody else in the ~50-file amgm family used Polynomial.roots / Rolle / the quadratic discriminant of a splitting polynomial; the sibling oq-02-oq-03-oq-03-oq-01 uses a Cauchy-Schwarz SOS discriminant metaphor, a different mechanism.",
-      "The remaining crux is exactly differentiation preserves full real-rootedness counting multiplicity (iterated Rolle on prod (X - x_i)); Mathlib has Rolle (exists_hasDerivAt_eq_zero) and Polynomial.derivative/roots but not this packaged lemma."
+      "The remaining crux is exactly differentiation preserves full real-rootedness counting multiplicity (iterated Rolle on prod (X - x_i)); Mathlib has Rolle (exists_hasDerivAt_eq_zero) and Polynomial.derivative/roots but not this packaged lemma.",
+      "Reversal preserves splitting over ℝ: reverse (X - C r) has degree ≤1 with leadingCoeff = trailingCoeff(X - C r) ≠ 0 (invertible), so splits via splits_of_natDegree_le_one_of_invertible; distribute reverse over the multiset product (reverse_mul_of_domain) to get splits_reverse: Splits p → Splits (reverse p). Mathlib lacked this; it is the reversal counterpart of Part V splits_derivative.",
+      "Part VII TOP step specialised to the monic splitting poly ∏(X-xᵢ) (top coeffs 1,-e₁,e₂) only reproduces the FIRST Newton inequality (already general in Part III). Genuinely new arbitrary-n content lives in the non-top steps, reached by REVERSING p so its bottom coefficients become the top coefficients of reverse p.",
+      "The BOTTOM Newton step (discrim on p.coeff 0,1,2) is obtained by applying the Part VII engine discrim_iterate_derivative_top to reverse p: needs only Splits(reverse p) + natDegree(reverse p)=m+2, the latter from coeff 0 ≠ 0 ⇒ natTrailingDegree = 0 (natTrailingDegree_le_of_ne_zero). coeff_reverse + revAt_le read the three top coeffs of reverse p back as p.coeff 0,1,2."
     ],
     "mathlibGaps": [
       "No packaged lemma: over R, p.roots.card = p.natDegree implies (derivative p).roots.card = (derivative p).natDegree (Rolle + multiplicity). This is the crux for general n."
     ],
     "nextSteps": [
-      "Prove: derivative of a fully-real-rooted real polynomial is fully real-rooted (Rolle between consecutive roots + multiplicity at repeated roots).",
-      "Reduce three consecutive coefficients to a quadratic by reversing/differentiating, then apply discrim_nonneg_of_root to get the general Newton inequality for signed reals.",
-      "Prove Newton at n=3 as the first nontrivial instance (cubic derivative is a quadratic; Rolle gives its two real roots directly)."
+      "General INTERIOR steps (2 ≤ k ≤ n-2): compose reverse with iterated derivative — apply discrim_iterate_derivative_top to reverse(derivative^[j] p) to read an interior coefficient triple. Needs a nonvanishing hypothesis on the relevant coefficient (reversal drops degree if leading/constant term vanishes).",
+      "Vieta bridge: specialise splits polynomial p = ∏(X-xᵢ) so p.coeff(n-k) = (-1)^k eₖ (Polynomial.coeff_prod_X_sub_C / Multiset.esymm), turning newton_top_coeff_ineq / newton_bottom_coeff_ineq into the classical eₖ² ≥ eₖ₋₁ eₖ₊₁ mean form."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Extends the classical calculus route to Newton's inequalities (`amgm-inequality-oq-02-oq-02-oq-05`) with **Part VIII**: the reversal counterpart of Part V's `splits_derivative`, and the first genuinely-new **arbitrary-`n`** Newton content beyond the first/top step.

**Key realization.** Part VII's TOP step, specialised to the monic splitting polynomial `∏(X-xᵢ)` (top coefficients `1, -e₁, e₂`), only reproduces the FIRST Newton inequality — already general in Part III. New arbitrary-`n` content lives in the *non-top* steps, reached by **reversing** the polynomial so its bottom coefficients become the top coefficients of `reverse p`.

## New theorems (28 → 33; 0 sorries, 0 `axiom`s, foundational axioms only)

- **`splits_reverse : Splits p → Splits (reverse p)`** — reversal preserves real-rootedness over ℝ. This is the infrastructure **Mathlib does not package** (a source survey confirmed no `roots_reverse`/`splits_reverse`). Proof: `splits_iff_exists_multiset` factors `p = C (leadingCoeff p)·∏(X-rᵢ)`, `reverse_mul_of_domain` distributes `reverse` over the product, and each `reverse (X - C r)` splits (`splits_of_natDegree_le_one_of_invertible`, leading coeff `= trailingCoeff ≠ 0`). Helpers `splits_reverse_linear`, `splits_reverse_prod`.
- **`discrim_reverse_bottom`** — `0 ≤ discrim` of `p`'s three bottom coefficients (`descFactorial`-weighted `p.coeff 0,1,2`), by running the Part VII engine `discrim_iterate_derivative_top` on `reverse p`; `coeff_reverse` + `revAt_le` read the reduced quadratic's coefficients back on `p`. Needs only `p.coeff 0 ≠ 0` (nonzero constant term).
- **`newton_bottom_coeff_ineq`** — the recognizable `b² ≥ 4ac` form. For `p = ∏(X-xᵢ)` with all roots nonzero this is the classical **BOTTOM** Newton step `eₙ₋₁² ≥ eₙ₋₂ eₙ`, the reversal mirror of Part VII's top step and unreachable from Parts III/VII.

## Verification

`./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` — clean, 7743 jobs, Lean 4.26.0. No sign hypothesis beyond the nonzero constant term.

## Remaining (documented in knowledge.md)

- General *interior* steps (`2 ≤ k ≤ n-2`): compose reversal with iterated derivative.
- Vieta bridge `p.coeff (n−k) = (−1)^k eₖ` to the elementary-symmetric mean form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)