### PR TITLE
Research: ballot-oq-04-oq-02-oq-01 — verified restriction half + corrected first-return plan

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -77,6 +77,71 @@ theorem nonCrossingCount_zero : nonCrossingCount 0 = 1 := by
   simp only [hbot]
   exact Fintype.card_unique
 
+/-! ## First-return infrastructure: restriction of non-crossing partitions
+
+The outstanding bijection `nonempty_firstReturnEquiv` decomposes a non-crossing partition of
+`Fin (n+1)` into the induced partitions on the two sub-intervals cut out by a distinguished
+block. Building those induced partitions is where the earlier survey estimated "several hundred
+lines" of manual `Finpartition` construction (providing `SupIndep`, `sup_parts`, `not_bot`
+by hand). This section removes that obstacle with a short, reusable construction:
+
+* the *same-part* relation of any `Finpartition (univ : Finset (Fin n))` is exactly
+  `Setoid.ker P.part` (relation `P.part a = P.part b`), by `mem_part_iff_part_eq_part`;
+* pulling it back along an index embedding `emb : Fin i → Fin (n+1)` (`Setoid.comap`) and
+  re-materialising it with `Finpartition.ofSetoid` yields the restricted partition `restrictFp`
+  **without any manual partition-axiom proof** — `ofSetoid` supplies them;
+* and restriction *preserves* non-crossing whenever `emb` is strictly monotone
+  (`isNonCrossingFp_restrictFp`): a crossing in the restriction lifts, through the
+  order-embedding, to a crossing in `P`.
+
+This is the forward (restriction) half of the first-return decomposition, proved with `0`
+`sorry`; the remaining work for the bijection is the gluing (inverse) map and the mutual-inverse
+laws (see the entry's research notes). -/
+
+/-- The *same-part* relation of `P`, pulled back along an index map `emb`, as a `Setoid`.
+Its relation is `P.part (emb a) = P.part (emb b)` (`Setoid.ker P.part` is the same-part relation
+by `Finpartition.mem_part_iff_part_eq_part`). -/
+def restrictSetoid {i n : ℕ} (emb : Fin i → Fin (n + 1))
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) : Setoid (Fin i) :=
+  Setoid.comap emb (Setoid.ker P.part)
+
+instance instDecidableRestrictRel {i n : ℕ} (emb : Fin i → Fin (n + 1))
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) :
+    DecidableRel (restrictSetoid emb P).r :=
+  fun a b => (inferInstance : Decidable (P.part (emb a) = P.part (emb b)))
+
+/-- **Restriction of a finpartition along an index embedding.** The finpartition of `Fin i`
+whose blocks are the `emb`-preimages of the blocks of `P`. Built via `Finpartition.ofSetoid`, so
+the partition axioms come for free. -/
+def restrictFp {i n : ℕ} (emb : Fin i → Fin (n + 1))
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) :
+    Finpartition (univ : Finset (Fin i)) :=
+  Finpartition.ofSetoid (restrictSetoid emb P)
+
+/-- Membership in a block of the restriction is same-block-under-`emb` in `P`. -/
+@[simp] theorem mem_part_restrictFp {i n : ℕ} (emb : Fin i → Fin (n + 1))
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) (a b : Fin i) :
+    b ∈ (restrictFp emb P).part a ↔ P.part (emb a) = P.part (emb b) :=
+  Finpartition.mem_part_ofSetoid_iff_rel
+
+/-- **Restriction preserves non-crossing (forward half of the first-return decomposition).**
+If `emb : Fin i → Fin (n+1)` is strictly monotone (an order-embedding of an index interval) and
+`P` is non-crossing, then the restricted partition `restrictFp emb P` is non-crossing. A crossing
+`a < b < c < d` in the restriction maps, through the order-embedding, to a crossing
+`emb a < emb b < emb c < emb d` in `P`; the same-block hypotheses transport along `emb`, so
+non-crossing of `P` forces `emb a, emb b` into a common block, i.e. `a, b` into a common block of
+the restriction. -/
+theorem isNonCrossingFp_restrictFp {i n : ℕ} (emb : Fin i → Fin (n + 1))
+    (hmono : StrictMono emb) (P : Finpartition (univ : Finset (Fin (n + 1))))
+    (hP : IsNonCrossingFp P) : IsNonCrossingFp (restrictFp emb P) := by
+  intro a b c d hab hbc hcd hca hdb
+  rw [mem_part_restrictFp] at hca hdb ⊢
+  have Hca : emb c ∈ P.part (emb a) := by rw [hca]; exact P.mem_part (mem_univ _)
+  have Hdb : emb d ∈ P.part (emb b) := by rw [hdb]; exact P.mem_part (mem_univ _)
+  have hb_in_a : emb b ∈ P.part (emb a) :=
+    hP (emb a) (emb b) (emb c) (emb d) (hmono hab) (hmono hbc) (hmono hcd) Hca Hdb
+  exact ((P.mem_part_iff_part_eq_part (mem_univ _) (mem_univ _)).mp hb_in_a).symm
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -8,7 +8,7 @@
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "BLOCKED (Aristotle outage persists 2026-07-01): sole sorry `nonempty_firstReturnEquiv` (first-return Catalan bijection) is a HARD known-math construction awaiting proof-search offload; file builds clean, n=4 decide route ruled out.",
+    "progressSummary": "PROGRESS: restriction (forward) half verified (0 sorry, committed); Session 5 corrected the decomposition plan (first-cut-point binary split, not block-of-0; new strip-outer-arch sub-lemma). Sole sorry = nonempty_firstReturnEquiv. Aristotle down.",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
@@ -23,16 +23,19 @@
       "Session 3 (2026-06-30, researcher-6): Aristotle service STILL down (prove health-probe returns 404 \"Resource not found\"). Confirms the recurrence cannot be delegated. Per the 3-sessions-stuck rule, problem moved to BLOCKED in the pool — the first-return decomposition Equiv on Finpartitions of Fin n is genuinely >1000 lines with zero Mathlib support (no restriction-to-interval, no block-of-0 split). Recommend revisit only when (a) Aristotle returns, or (b) someone builds the Dyck-word ↔ NC-partition bridge to reuse Mathlib DyckWord catalan counting.",
       "2026-07-01 (REVISIT): Aristotle MCP still returns \"Resource not found\" on every call (even a trivial ping) — the intended proof-search offload for the sole sorry `nonempty_firstReturnEquiv` remains blocked, the same outage that stalled sessions on 06-27/06-28. No change since prior blocked flags.",
       "2026-07-01: File builds CLEANLY under Lean v4.26.0 via `lake env lean Proofs/BallotProblemOQ04OQ02OQ01.lean` (only the expected sorry warning at L105); deps BallotProblemOQ04/OQ04OQ02 oleans present. Docker containerd broken (I/O error) — use lake env lean.",
-      "2026-07-01 NEGATIVE FINDING: extending the unconditional `nonCrossingCount_eq_catalan_of_le_three` (n≤3) to the first divergence point n=4 is INFEASIBLE via `decide`: `nonCrossingCount 4 = 14` stack-overflows the kernel (even with maxRecDepth 100000). The Finpartition (Fin 4) Fintype enumeration is too large for kernel reduction. Note the parent proved only the INEQUALITY nonCrossingCount_four_lt via Fintype.card_subtype_lt precisely to avoid this computation. So n=4 cannot be cheaply added as an unconditional data point."
+      "2026-07-01 NEGATIVE FINDING: extending the unconditional `nonCrossingCount_eq_catalan_of_le_three` (n≤3) to the first divergence point n=4 is INFEASIBLE via `decide`: `nonCrossingCount 4 = 14` stack-overflows the kernel (even with maxRecDepth 100000). The Finpartition (Fin 4) Fintype enumeration is too large for kernel reduction. Note the parent proved only the INEQUALITY nonCrossingCount_four_lt via Fintype.card_subtype_lt precisely to avoid this computation. So n=4 cannot be cheaply added as an unconditional data point.",
+      "First-cut-point insight (Session 5): the block-of-0 decomposition gives the MULTI-WAY composition recurrence, NOT the binary antidiagonal C_{n+1}=sum_{i+j=n} C_i C_j. The correct binary split uses k = first cut point (smallest m with {0..m} a union of complete blocks): left {0..k} irreducible -> C_k, right {k+1..n} free -> C_{n-k}, i+j=n. Verified by hand on C_3=5.",
+      "The new key sub-lemma is the strip-outer-arch bijection irreducible-NC{0..k} = free-NC{0..k-1} (Finpartition analog of removing a Dyck word outer U..D); this realigns the problem with the Dyck-word transport track since the first-cut split IS the Dyck first-return U w1 D w2."
     ],
     "mathlibGaps": [
       "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
       "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
     ],
     "nextSteps": [
-      "When Aristotle returns: submit the self-contained snippet for `nonempty_firstReturnEquiv` (inline IsNonCrossingFp + instDecidable; import Mathlib only) — confirmed to typecheck with just the sorry. This is the isolated, well-scoped, KNOWN-math bijection (Catalan first-return decomposition), exactly the proof-search regime.",
-      "Manual alternative is not one-session tractable: the bijection needs Finpartition-of-Fin surgery (restrict/relabel along Fin i ↪ Fin (n+1), preserve non-crossing, build inverse) — ~500+ lines, no Mathlib support for restricting Finpartition to a distinguished-block gap.",
-      "No Mathlib shortcut: relating {P // IsNonCrossingFp P} to a Catalan-counted Mathlib family (treesOfNumNodesEq n, card=catalan n) is an equally-hard bijection."
+      "Define first-cut-point k via Nat.find over is-{0..m}-a-union-of-complete-blocks; use Fin.castLE + shifted embeddings and the verified isNonCrossingFp_restrictFp for the two components",
+      "Prove the strip-outer-arch sub-bijection irreducible-NC{0..k} = free-NC{0..k-1} (new crux)",
+      "Assemble forward+glue+round-trips into the Equiv to close nonempty_firstReturnEquiv; keep each sub-lemma independently buildable",
+      "Retry Aristotle each session (endpoint down sessions 1-5)"
     ]
   },
   "currentState": {


### PR DESCRIPTION
## Non-crossing partitions = Catalan (`ballot-problem-oq-04-oq-02-oq-01`)

Two research commits on the sole open obligation `nonempty_firstReturnEquiv` (the first-return Catalan decomposition of a non-crossing `Finpartition (Fin (n+1))`).

### Session 4 (Lean, verified — 0 sorry added)
Landed the **restriction (forward) half** of the bijection via the setoid model, obsoleting the prior 'several hundred lines' estimate for it:
- `restrictSetoid emb P := Setoid.comap emb (Setoid.ker P.part)`
- `restrictFp emb P := Finpartition.ofSetoid (restrictSetoid emb P)`
- `mem_part_restrictFp` (@[simp]), `isNonCrossingFp_restrictFp` (restriction along a strictly-monotone embedding preserves non-crossing).

Guarded Docker build passed. File's only remaining `sorry` stays `nonempty_firstReturnEquiv`; gallery status stays `formalized`.

### Session 5 (research notes — plan correction, hand-verified)
Working the combinatorics on small cases surfaced a genuine error in the recorded plan:
- **Block-of-0 ≠ binary antidiagonal.** The recorded 'block containing 0' split yields the *multi-way composition* recurrence, **not** `catalan_succ'`'s binary `C_{n+1}=∑_{i+j=n} C_i C_j`. Verified on `C₃=5`.
- **Correct primitive = first *cut point* `k`** (smallest `m` with `{0..m}` a union of complete blocks): left `{0..k}` irreducible → `C_k`, right `{k+1..n}` free → `C_{n-k}`, `i+j=n`. Full `C₃` tally + `irreducible-on-3-points = 2 = C₂` checked by hand.
- **New key sub-lemma**: strip-outer-arch bijection `irreducible-NC{0..k} ≃ free-NC{0..k-1}` (Finpartition analog of stripping a Dyck word's outer `U…D`), which also realigns the problem with the Dyck-word transport track.

### Status
- Sole `sorry`: `nonempty_firstReturnEquiv` (unchanged).
- Aristotle re-tested each session: still `Resource not found` (endpoint down sessions 1–5).
- No speculative build gambled in s5; Lean file kept at verified 1-sorry state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)