### PR TITLE
Konigsberg: state undirected Hierholzer sufficiency + full Eulerian-circuit iff

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean
@@ -1,0 +1,86 @@
+/-
+# Undirected Eulerian Circuit Theorem — Degree Characterization (Sufficiency)
+
+This file states and (via Aristotle proof search) aims to prove the **sufficiency**
+half of Euler's theorem on Eulerian circuits for *undirected* simple graphs — the
+undirected **Hierholzer** direction:
+
+> If a finite, connected undirected simple graph `G` has every vertex of even
+> degree, then `G` has an Eulerian circuit (a closed trail using every edge
+> exactly once).
+
+Together with the **necessity** results in `KonigsbergOQ02OQ01OQ02.lean`
+(`eulerian_circuit_forall_even`) this completes Euler's characterization:
+
+* `G` (connected) has an Eulerian **circuit** iff every vertex has **even** degree.
+
+## Relationship to the directed case
+
+The *directed* analogue is fully machine-checked in `KonigsbergOQ02OQ01.lean`
+(`directed_euler_circuit_sufficient_corrected`, 0 sorries), built from a splice
+constructor, an arc-removal operation preserving balance, and the key sub-lemma
+`maximal_balanced_trail_is_circuit`.
+
+**Note on why the naive reduction fails.** One might hope to reduce the undirected
+theorem to the directed one by replacing every undirected edge `{u,v}` with the two
+directed arcs `(u,v)` and `(v,u)`. The resulting digraph is balanced
+(in-degree = out-degree = undirected degree) and strongly connected, so the directed
+theorem yields a directed Eulerian circuit. But that circuit traverses each
+undirected edge **twice** (once in each direction), so it is *not* an undirected
+Eulerian circuit. A native undirected Hierholzer argument is therefore required,
+mirroring the directed sub-lemma structure:
+
+1. from an even-degree graph, any maximal trail from a vertex is closed (the
+   current endpoint always has an unused incident edge by a parity/handshake count);
+2. removing the edges of a closed trail preserves the all-even-degree property;
+3. splice a residual closed trail (through a shared vertex, which exists by
+   connectivity) into the main circuit; induct on the number of edges.
+
+The undirected book-keeping differs from the directed case because incidence is
+symmetric: the relevant parity invariant is `Even (G.degree v)` rather than the
+`inDegree = outDegree` balance condition.
+
+## Status
+
+The main theorem currently carries a single `sorry` and is submitted to Aristotle
+for proof search as a KNOWN classical result. The statement is pinned here so the
+gallery entry can track progress and integrate a completed proof.
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+import Mathlib.Tactic
+
+open SimpleGraph SimpleGraph.Walk
+
+namespace UndirectedEuler
+
+variable {V : Type*} {G : SimpleGraph V} [Fintype V] [DecidableEq V] [DecidableRel G.Adj]
+
+/-- **Sufficiency for Eulerian circuits (undirected Hierholzer).**
+A finite, connected undirected simple graph in which every vertex has even degree
+possesses an Eulerian circuit: a closed walk using every edge exactly once.
+
+This is the converse of `eulerian_circuit_forall_even` (in
+`KonigsbergOQ02OQ01OQ02.lean`); together they give Euler's full characterization of
+Eulerian circuits for connected undirected graphs. -/
+theorem undirected_euler_circuit_sufficient
+    (hconn : G.Connected) (heven : ∀ v, Even (G.degree v)) :
+    ∃ (u : V) (p : G.Walk u u), p.IsEulerian := by
+  sorry
+
+/-- **Euler's characterization of Eulerian circuits (undirected).**
+For a connected undirected simple graph, an Eulerian circuit exists iff every vertex
+has even degree. Combines the necessity direction with the sufficiency direction
+above. -/
+theorem undirected_euler_circuit_iff (hconn : G.Connected) :
+    (∃ (u : V) (p : G.Walk u u), p.IsEulerian) ↔ (∀ v, Even (G.degree v)) := by
+  constructor
+  · rintro ⟨u, p, hp⟩ x
+    -- necessity: an Eulerian circuit forces every degree even
+    rw [hp.even_degree_iff]
+    intro huu
+    exact absurd rfl huu
+  · intro heven
+    exact undirected_euler_circuit_sufficient hconn heven
+
+end UndirectedEuler

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -158,3 +158,49 @@ unchanged. No scaffolding added.
   the recurrence submission first — or (b) a dedicated multi-session build of the Finpartition
   non-crossing infrastructure is undertaken (track 1 above is the closest to the file's stated
   approach).
+
+## Session 2026-07-04 (researcher-11) — n=4 direct computation ruled out (decide AND native_decide overflow)
+
+**Mode:** REVISIT (problem was `blocked`; Aristotle re-checked and still down).
+**Outcome:** no Lean progress on the crux (unchanged), but a **definitive negative result** that
+closes off the most obvious "next case" idea and saves future sessions two Docker builds.
+
+### What I checked
+- **Aristotle still DOWN.** `scripts/aristotle/mcp-smoke-test.sh` still 404s on
+  `https://aristotle.harmonic.fun/api/v1/project?project_type=2` (4th consecutive session). The
+  MCP server *connects* now but the underlying endpoint is unchanged. Do not submit until the
+  smoke test passes.
+
+### The idea I tried (and why it's dead)
+The prior anchor `nonCrossingCount_eq_catalan_of_le_three` covers `n ≤ 3` (all partitions
+non-crossing → Bell number, kernel `decide`). The natural *strengthening* is the exact value at
+the **first divergence** `n = 4`: prove `nonCrossingCount 4 = 14 = catalan 4` unconditionally
+(the sibling only has the *inequality* `nonCrossingCount_four_lt : nonCrossingCount 4 < 15`,
+proved abstractly via `Fintype.card_subtype_lt` — never the exact value). This would verify the
+conjecture on all of `0 ≤ n ≤ 4`, through the first Bell/Catalan split.
+
+**Both computational routes overflow — confirmed by Docker build, not speculation:**
+- **Kernel `decide`** (even `set_option maxRecDepth 100000`): `Stack overflow detected. Aborting.`
+  (Lean exit 134) after 43s. Kernel cannot reduce the `Fintype (Finpartition (Fin 4))`
+  enumeration.
+- **`native_decide`**: ALSO overflows — `interpreter stacktrace` through
+  `Fintype.card ... nonCrossingCount.spec_0` → `Finset.image._redArg` → `List.dedup` →
+  `List.pwFilter` (exit 134). The `Fintype (Finpartition α)` instance builds the partition set by
+  `image`/`dedup`/`pwFilter` over a huge candidate set and blows the interpreter stack even
+  compiled. So `nonCrossingCount 4` (and even the plain Bell count `Fintype.card (Finpartition
+  (Fin 4)) = 15`) is **not** obtainable by `decide` OR `native_decide`. n≤3 worked only because
+  `Finpartition (Fin 3)` is tiny (Bell 3 = 5).
+
+### Consequence for future sessions
+- **Do NOT retry `decide`/`native_decide` on `nonCrossingCount 4`** (or any `n ≥ 4`) — proven
+  infeasible here. The `n ≤ 3` anchor is the computational ceiling for this Fintype instance.
+- A non-computational `nonCrossingCount 4 = 14` would need either (a) Mathlib Bell-number theory
+  (`Fintype.card (Finpartition (Fin 4)) = 15`, which Mathlib does not provide as a closed value
+  reachable without the same overflow) plus a *uniqueness-of-the-crosser* lemma (crossing4Fp is
+  the only crossing partition of Fin 4), or (b) the general first-return bijection itself. Both
+  are foundational builds, not tactical targets.
+- **Verdict UNCHANGED: BLOCKED.** The crux `nonempty_firstReturnEquiv` still needs the
+  non-crossing-partition / Finpartition interval-restriction infrastructure Mathlib lacks, and
+  the tempting computational shortcut at the divergence point is now ruled out. Re-open when
+  Aristotle recovers (retry the recurrence sorry first) or for a dedicated multi-session infra
+  build (track 1: Finpartition first-return decomposition).

--- a/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,54 @@
+# Knowledge Base: konigsberg-oq-02-oq-01-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]
+
+## Session 2026-07-04 (Session 1) — Statement + reduction analysis
+
+**Mode**: FRESH
+**Outcome**: progress (ORIENT→ACT: compiling statement, sufficiency sorry)
+
+### What I Did
+- Claimed the problem (undirected Hierholzer sufficiency).
+- Created `proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean` stating
+  `undirected_euler_circuit_sufficient` (1 sorry) and the full characterization
+  `undirected_euler_circuit_iff` (necessity half fully proved via
+  `IsEulerian.even_degree_iff`).
+- Verified it builds in Docker (only the expected `sorry` warning); needed
+  `import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected`.
+
+### Key Findings
+- Mathlib has Eulerian degree bookkeeping but no undirected existence/Hierholzer.
+- The fully-proved DIRECTED analogue (`directed_euler_circuit_sufficient_corrected`
+  in `KonigsbergOQ02OQ01.lean`, ~900 lines) is a structural template.
+- **Naive doubling reduction FAILS**: splitting each undirected edge into two
+  opposite arcs makes the digraph balanced/strongly-connected, but the resulting
+  directed Eulerian circuit uses each undirected edge twice — not an undirected
+  Eulerian circuit. A native undirected argument is required.
+
+### Files Modified
+- proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean (new)
+- src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json (knowledge)
+
+### Next Steps
+- Port the 3-step Hierholzer sub-lemma structure (maximal trail is closed →
+  edge removal preserves even degree → splice via shared vertex → induct on edges).
+- Re-submit the sorry file to Aristotle from the main repo (MCP "Resource not
+  found" from the worktree) as a KNOWN result.

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -1,0 +1,248 @@
+{
+  "slug": "konigsberg-oq-02-oq-01-oq-02-oq-01",
+  "title": "Hierholzer undirected sufficiency — even-degree connected graph has an Eulerian circuit",
+  "phase": "OBSERVE",
+  "status": "blocked",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "G \\text{ connected} \\ \\wedge\\ (\\forall v,\\ \\deg(v)\\text{ even}) \\ \\Longrightarrow\\ \\exists\\ \\text{Eulerian circuit in } G.",
+    "plain": "The famous Königsberg-bridges result has an easy necessity direction (an Eulerian circuit forces all degrees even). This problem is the harder **sufficiency** direction via Hierholzer's algorithm: if a connected graph has all even degrees, you can actually build a single closed tour using every edge once by splicing together cycles.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-02T15:04:52-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT/ACT: undirected Hierholzer sufficiency stated + iff-necessity proved (compiles, 1 sorry). Directed template identified; naive doubling reduction shown to fail. Sufficiency construction (~600-1000 lines) is the remaining work; delegate to Aristotle or build natively.",
+    "builtItems": [
+      "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning)."
+    ],
+    "insights": [
+      "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
+      "A fully-proved DIRECTED analogue exists in KonigsbergOQ02OQ01.lean (directed_euler_circuit_sufficient_corrected, 0 sorries, ~900 lines) with reusable machinery: splice constructor, removeArcList (arc removal preserving balance), and maximal_balanced_trail_is_circuit. This is a strong structural template for the undirected argument.",
+      "KEY INSIGHT (reduction failure): the naive reduction replacing each undirected edge {u,v} with two directed arcs (u,v),(v,u) yields a balanced strongly-connected digraph, so the directed theorem gives a directed Eulerian circuit -- but that circuit traverses each undirected edge TWICE (once per direction). It is therefore NOT an undirected Eulerian circuit. A native undirected Hierholzer argument is required.",
+      "The undirected parity invariant is Even (G.degree v) (from Mathlib IsEulerian.even_degree_iff / card_odd_degree) rather than the directed inDegree=outDegree balance, because undirected incidence is symmetric."
+    ],
+    "mathlibGaps": [
+      "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."
+    ],
+    "nextSteps": [
+      "Port the directed sub-lemma structure to undirected: (1) from an all-even-degree graph, any MAXIMAL trail from a vertex is closed (current endpoint always has an unused incident edge by a parity/handshake count); (2) removing the edges of a closed trail preserves all-even-degree; (3) splice a residual closed trail through a shared vertex (exists by connectivity) into the main circuit; induct on edge count.",
+      "Aristotle submission of the sorry file failed with MCP error Resource not found (likely worktree/lake-project resolution). Re-submit from the main repo via research/scripts/aristotle-submit.sh once the PR merges, as a KNOWN classical result.",
+      "Consider building an undirected splice + edgeRemoval operation mirroring KonigsbergOQ02OQ01.lean removeArcList; estimate 600-1000 lines. This is the main effort and may warrant Aristotle or a dedicated multi-session build."
+    ],
+    "markdown": "# Knowledge Base: konigsberg-oq-02-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "graph-theory",
+    "eulerian",
+    "hierholzer",
+    "konigsberg"
+  ],
+  "relatedProofs": [
+    "konigsberg",
+    "konigsberg-oq-01",
+    "konigsberg-oq-01-oq-02",
+    "konigsberg-oq-01-oq-02-incomplete-01",
+    "konigsberg-oq-02",
+    "konigsberg-oq-02-oq-01",
+    "konigsberg-oq-02-oq-01-oq-02",
+    "konigsberg-oq-03",
+    "konigsberg-oq-03-oq-01",
+    "konigsberg-oq-03-oq-02",
+    "konigsberg-oq-04",
+    "konigsberg-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-02T23:38:28.291Z",
+  "lastUpdate": "2026-07-02T23:38:28.334Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Konigsberg.lean",
+      "filename": "Konigsberg.lean",
+      "lineCount": 221,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Konigsberg.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01.lean",
+      "filename": "KonigsbergOQ01.lean",
+      "lineCount": 405,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01OQ02.lean",
+      "filename": "KonigsbergOQ01OQ02.lean",
+      "lineCount": 1203,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 9,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01OQ02Incomplete01.lean",
+      "filename": "KonigsbergOQ01OQ02Incomplete01.lean",
+      "lineCount": 240,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02Incomplete01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ01OQ02Recipe.lean",
+      "filename": "KonigsbergOQ01OQ02Recipe.lean",
+      "lineCount": 814,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ01OQ02Recipe.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02.lean",
+      "filename": "KonigsbergOQ02.lean",
+      "lineCount": 814,
+      "theoremCount": 30,
+      "axiomCount": 2,
+      "defCount": 11,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02OQ01.lean",
+      "filename": "KonigsbergOQ02OQ01.lean",
+      "lineCount": 955,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02OQ01Aristotle.lean",
+      "filename": "KonigsbergOQ02OQ01Aristotle.lean",
+      "lineCount": 239,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ02OQ01OQ02.lean",
+      "filename": "KonigsbergOQ02OQ01OQ02.lean",
+      "lineCount": 110,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ03.lean",
+      "filename": "KonigsbergOQ03.lean",
+      "lineCount": 303,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ03.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ03OQ01.lean",
+      "filename": "KonigsbergOQ03OQ01.lean",
+      "lineCount": 314,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 16,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ03OQ02.lean",
+      "filename": "KonigsbergOQ03OQ02.lean",
+      "lineCount": 185,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ04.lean",
+      "filename": "KonigsbergOQ04.lean",
+      "lineCount": 339,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ04.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ04OQ01MatrixTree.lean",
+      "filename": "KonigsbergOQ04OQ01MatrixTree.lean",
+      "lineCount": 220,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ04OQ01MatrixTree.lean"
+    },
+    {
+      "path": "Proofs/KonigsbergOQ05.lean",
+      "filename": "KonigsbergOQ05.lean",
+      "lineCount": 131,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Advances research problem **konigsberg-oq-02-oq-01-oq-02-oq-01** — undirected Hierholzer sufficiency (the open direction of Euler's theorem for undirected graphs).

- New `proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean`:
  - `undirected_euler_circuit_sufficient` — *connected + every vertex even degree ⟹ an Eulerian circuit exists* (currently `sorry`, a KNOWN classical result targeted for Aristotle proof search).
  - `undirected_euler_circuit_iff` — the full characterization; its **necessity half is fully proved** via `IsEulerian.even_degree_iff`, sufficiency delegates to the theorem above.
  - Builds in Docker with only the expected `sorry` warning.

## ORIENT findings (recorded in knowledge base)

- The fully-proved **directed** analogue `directed_euler_circuit_sufficient_corrected` (`KonigsbergOQ02OQ01.lean`, ~900 lines, 0 sorries) is a structural template.
- **The naive edge-doubling reduction fails**: replacing each undirected edge `{u,v}` with arcs `(u,v),(v,u)` gives a balanced strongly-connected digraph, but the resulting directed Eulerian circuit traverses each undirected edge *twice* — not an undirected Eulerian circuit. A native undirected argument is required.
- Mathlib supplies Eulerian degree bookkeeping (`IsEulerian.even_degree_iff`, `.card_odd_degree`) but no undirected existence/Hierholzer construction.

## Next steps

Port the 3-step Hierholzer structure (maximal trail is closed → edge removal preserves even degree → splice via a shared vertex → induct on edge count), or submit the `sorry` file to Aristotle from the main repo as a known result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)