### PR TITLE
Research: amgm-oq020205 (IX) — general-n INTERIOR Newton step, any coefficient window (36→38)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ02OQ05.lean
@@ -841,4 +841,120 @@ theorem newton_top_esymm_roots_monic (m : ℕ) {p : ℝ[X]}
   have hBsq : (0 : ℝ) < B ^ 2 := by positivity
   exact le_of_mul_le_mul_right key hBsq
 
+/-!  ## Part IX — the general-`n` INTERIOR Newton step: an arbitrary window
+
+Parts VII/VIII closed the TOP step (`discrim_iterate_derivative_top`, the
+discriminant of `p`'s three *top* coefficients) and the BOTTOM step
+(`discrim_reverse_bottom`, its reversal-mirror on the three *bottom* coefficients).
+The one remaining piece of the classical calculus proof is the general *interior*
+window `p.coeff j, p.coeff (j+1), p.coeff (j+2)` for any `j` with
+`j + 2 ≤ natDegree p`.  It is reached by composing the two engine atoms already
+built:
+
+* differentiate `p` exactly `j` times (Part V: `derivative^[j] p` still splits,
+  and by `coeff_iterate_derivative` its three *bottom* coefficients are the
+  `descFactorial`-weighted `p.coeff j, p.coeff (j+1), p.coeff (j+2)`);
+* then reverse (Part VIII: reversal preserves splitting, and turns that bottom
+  window into the *top* window of a genuine quadratic), and read off the
+  discriminant with the top-step engine `discrim_iterate_derivative_top`.
+
+For `j = 0` this is exactly `discrim_reverse_bottom`; for general `j` it is
+Newton's log-concavity inequality on an *arbitrary* consecutive coefficient
+window of any real-rooted polynomial — closing every interior step of the
+classical calculus proof at once, for all arities.  The only side hypothesis is
+`p.coeff j ≠ 0` (the window's bottom coefficient nonzero, so `derivative^[j] p`
+has nonzero constant term and its reversal keeps degree `m + 2`); for the monic
+splitting polynomial `∏(X - xᵢ)` with all roots nonzero every coefficient is
+`± eₖ ≠ 0`, so this covers every window. -/
+
+/-- **General-`n` interior Newton discriminant inequality.**  For a real-rooted
+`p : ℝ[X]` with `natDegree = j + (m + 2)` and nonzero window-bottom coefficient
+`p.coeff j ≠ 0`, the three consecutive coefficients `p.coeff j, p.coeff (j+1),
+p.coeff (j+2)` (each weighted by the `descFactorial` factors of the two
+differentiation passes) have nonnegative discriminant.  Proof: apply the top-step
+engine `discrim_iterate_derivative_top` to `reverse (derivative^[j] p)`, whose top
+three coefficients are `(derivative^[j] p)`'s bottom three, i.e. `p`'s window
+`j, j+1, j+2` (`coeff_reverse` + `revAt_le` + `coeff_iterate_derivative`).  This
+generalizes `discrim_reverse_bottom` — its `j = 0` case — to every interior
+window. -/
+theorem discrim_reverse_interior (j m : ℕ) {p : ℝ[X]}
+    (hp : Splits p) (hcj : p.coeff j ≠ 0) (hdeg : p.natDegree = j + (m + 2)) :
+    0 ≤ discrim
+        (((2 + m).descFactorial m * (0 + j).descFactorial j) • p.coeff (0 + j))
+        (((1 + m).descFactorial m * (1 + j).descFactorial j) • p.coeff (1 + j))
+        (((0 + m).descFactorial m * (2 + j).descFactorial j) • p.coeff (2 + j)) := by
+  set q := derivative^[j] p with hq
+  have hpne : p ≠ 0 := by
+    intro h; rw [h, natDegree_zero] at hdeg; omega
+  -- `q = derivative^[j] p` splits (Part V)
+  have hqsplit : Splits q := splits_iterate_derivative hp j
+  -- `q` has a nonzero constant term: `q.coeff 0 = j! · p.coeff j`
+  have hq0 : q.coeff 0 ≠ 0 := by
+    rw [hq, coeff_iterate_derivative, nsmul_eq_mul, Nat.zero_add]
+    exact mul_ne_zero
+      (by exact_mod_cast (Nat.descFactorial_pos.mpr (by omega)).ne') hcj
+  have htrail : q.natTrailingDegree = 0 :=
+    Nat.le_zero.mp (natTrailingDegree_le_of_ne_zero hq0)
+  -- `q`'s `coeff (m + 2)` is the weighted leading coefficient of `p`, hence nonzero
+  have hqtop : q.coeff (m + 2) ≠ 0 := by
+    rw [hq, coeff_iterate_derivative, nsmul_eq_mul]
+    apply mul_ne_zero
+    · exact_mod_cast (Nat.descFactorial_pos.mpr (by omega)).ne'
+    · have hidx : (m + 2) + j = p.natDegree := by rw [hdeg]; omega
+      rw [hidx]; exact leadingCoeff_ne_zero.mpr hpne
+  -- so `q` is a genuine degree-`(m+2)` polynomial
+  have hqdeg : q.natDegree = m + 2 := by
+    have hle := natDegree_iterate_derivative p j
+    rw [← hq, hdeg] at hle
+    have hge : m + 2 ≤ q.natDegree := le_natDegree_of_ne_zero hqtop
+    omega
+  -- its reversal splits (Part VIII) and keeps degree `m + 2` (nonzero constant term)
+  have hrdeg : (reverse q).natDegree = m + 2 := by
+    rw [reverse_natDegree, hqdeg, htrail, Nat.sub_zero]
+  have h := discrim_iterate_derivative_top m (splits_reverse hqsplit) hrdeg
+  -- the top three coefficients of `reverse q` are `q`'s bottom three, i.e. `p`'s window
+  have ea : (reverse q).coeff (2 + m) = ((0 + j).descFactorial j) • p.coeff (0 + j) := by
+    rw [coeff_reverse, hqdeg, revAt_le (by omega),
+      show (m + 2) - (2 + m) = 0 from by omega, hq, coeff_iterate_derivative]
+  have eb : (reverse q).coeff (1 + m) = ((1 + j).descFactorial j) • p.coeff (1 + j) := by
+    rw [coeff_reverse, hqdeg, revAt_le (by omega),
+      show (m + 2) - (1 + m) = 1 from by omega, hq, coeff_iterate_derivative]
+  have ec : (reverse q).coeff (0 + m) = ((2 + j).descFactorial j) • p.coeff (2 + j) := by
+    rw [coeff_reverse, hqdeg, revAt_le (by omega),
+      show (m + 2) - (0 + m) = 2 from by omega, hq, coeff_iterate_derivative]
+  rw [ea, eb, ec, ← mul_smul, ← mul_smul, ← mul_smul] at h
+  exact h
+
+/-- **General-`n` interior Newton inequality on the coefficients of a real-rooted
+polynomial.**  For any `p : ℝ[X]` that splits with `natDegree = j + (m + 2)` and
+nonzero window-bottom coefficient `p.coeff j`, three arbitrary consecutive
+coefficients satisfy the log-concavity inequality `b² ≥ 4ac`:
+`4 · (weights) · p.coeff j · p.coeff (j+2) ≤ (weight)² · p.coeff (j+1)²`.
+This is `discrim_reverse_interior` written as Newton's recognizable step, valid for
+every arity, every interior window, and all signed inputs (only the window's bottom
+coefficient must be nonzero).  Generalizes both `newton_top_coeff_ineq` and
+`newton_bottom_coeff_ineq`. -/
+theorem newton_interior_coeff_ineq (j m : ℕ) {p : ℝ[X]}
+    (hp : Splits p) (hcj : p.coeff j ≠ 0) (hdeg : p.natDegree = j + (m + 2)) :
+    4 * ((2 + m).descFactorial m : ℝ) * ((0 + j).descFactorial j : ℝ)
+        * ((0 + m).descFactorial m : ℝ) * ((2 + j).descFactorial j : ℝ)
+        * p.coeff (0 + j) * p.coeff (2 + j)
+      ≤ ((1 + m).descFactorial m : ℝ) ^ 2 * ((1 + j).descFactorial j : ℝ) ^ 2
+        * p.coeff (1 + j) ^ 2 := by
+  have h := discrim_reverse_interior j m hp hcj hdeg
+  rw [discrim] at h
+  simp only [nsmul_eq_mul, Nat.cast_mul] at h
+  -- abstract the six `descFactorial` casts and three coefficients to small opaque
+  -- atoms BEFORE `nlinarith`, so it does not blow up on the cast/`coeff` subterms
+  set A := ((2 + m).descFactorial m : ℝ)
+  set B := ((0 + j).descFactorial j : ℝ)
+  set C := ((0 + m).descFactorial m : ℝ)
+  set D := ((2 + j).descFactorial j : ℝ)
+  set E := ((1 + m).descFactorial m : ℝ)
+  set F := ((1 + j).descFactorial j : ℝ)
+  set c0 := p.coeff (0 + j)
+  set c1 := p.coeff (1 + j)
+  set c2 := p.coeff (2 + j)
+  nlinarith [h]
+
 end NewtonRealRooted

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/knowledge.md
@@ -288,3 +288,76 @@ apply the same engine to a *sub-window* iterated derivative that isolates
 a reciprocal-coefficient (`reverse`) bridge should reach the second-from-top and
 second-from-bottom steps next; the strictly interior windows need differentiating
 both `p` and its reverse. Purely algebraic — no analysis blocker.
+
+## PART IX — the general-`n` INTERIOR Newton step: an arbitrary window (researcher-5, 2026-07-04)
+
+**Mode**: REVISIT/continue (RICH). **Outcome**: progress — **CLOSES the last
+documented gap**, the general interior Newton step, for every window and every
+arity at once. **+2 verified theorems (36 → 38), 0 sorries, 0 axioms**
+(foundational only; no `decide`/`native_decide`). docker-build clean, 7743 jobs,
+Lean 4.26.0. (The BOTTOM step `splits_reverse` / `discrim_reverse_bottom` /
+`newton_bottom_coeff_ineq` — Part VIII, reversal-mirror of the top step — is
+already merged into the Lean file, though its knowledge section was lost in a
+concurrent merge; Part IX below generalizes it to every window.)
+
+### What this closes
+Parts VII/VIII gave the TOP window (`discrim_iterate_derivative_top`, `p`'s three
+top coefficients) and the BOTTOM window (`discrim_reverse_bottom`, `j = 0`). The
+strictly interior windows `p.coeff j, p.coeff (j+1), p.coeff (j+2)` (any `j` with
+`j + 2 ≤ natDegree p`) needed the differentiate-**and**-reverse composition the
+prior "Still open" note anticipated. Part IX supplies exactly that, so the honest
+calculus route now reaches Newton's log-concavity inequality on *every*
+consecutive coefficient window of an arbitrary real-rooted polynomial.
+
+### Shipped (`Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, Part IX)
+- **`discrim_reverse_interior (j m) {p} (hp : Splits p) (hcj : p.coeff j ≠ 0)
+  (hdeg : p.natDegree = j + (m + 2))`** : `0 ≤ discrim` of the three consecutive
+  coefficients `p.coeff j, p.coeff (j+1), p.coeff (j+2)`, each weighted by the
+  `descFactorial` factors `(i+m).descFactorial m · (i+j).descFactorial j` of the
+  two differentiation passes. Proof: `q := derivative^[j] p` splits (Part V) and
+  has `q.coeff 0 = j!·p.coeff j ≠ 0` (so `natTrailingDegree q = 0`) and
+  `q.natDegree = m+2`; apply the TOP engine `discrim_iterate_derivative_top` to
+  `reverse q` (splits by Part VIII, degree `m+2`), whose top three coefficients
+  are `q`'s bottom three = `p`'s window (`coeff_reverse` + `revAt_le` +
+  `coeff_iterate_derivative`), then fold the two nested `•` weights with
+  `← mul_smul`. The `j = 0` case is definitionally `discrim_reverse_bottom`.
+- **`newton_interior_coeff_ineq (j m) {p} …`** : the recognizable
+  `4·(weights)·p.coeff j·p.coeff (j+2) ≤ (weight)²·p.coeff (j+1)²` — Newton's
+  log-concavity step on an arbitrary window, subsuming both `newton_top_coeff_ineq`
+  and `newton_bottom_coeff_ineq`.
+
+### Key realization
+Differentiation alone can never reach an interior window: for `q = derivative^[r] p`,
+`coeff_iterate_derivative` sends `q`'s *top* three coefficients back to `p`'s top
+three (always). To slide the window down you must reverse. The clean composition is
+"differentiate `j` times → reverse → apply the top engine": after `j` derivatives
+the window `p.coeff j, j+1, j+2` sits at the *bottom* of `q`, and reversing lifts it
+to the top of a genuine quadratic where the discriminant is read off. This is why a
+single `reverse` (Part VIII, `j = 0`) only reached the very bottom, while general
+`j` needs the derivative pass first.
+
+### Reusable Lean gotchas (researcher-5, Part IX)
+- `coeff_iterate_derivative` emits the base/index in `0 + j` form (NOT normalized
+  to `j`). When the result must unify with a hypothesis stated on `p.coeff j`
+  (here `hcj`), insert `Nat.zero_add` in the same `rw` chain
+  (`rw […, nsmul_eq_mul, Nat.zero_add]`) — one rewrite fixes both the `descFactorial`
+  base and the `coeff` index (rw hits all `0 + j` occurrences of that instantiation).
+- Nested `ℕ`-scalar weights `a • (b • x)` from composing two `coeff_iterate_derivative`
+  / reverse passes fold to `(a * b) • x` with **`← mul_smul`** (`mul_smul : (a*b)•x =
+  a•b•x`); apply once per discriminant slot.
+- The coefficient-inequality corollary's `nlinarith` **SIGBUS-crashes the elaborator
+  (exit 135)** on the raw `↑((i+m).descFactorial m · (i+j).descFactorial j)` casts and
+  `p.coeff` subterms. Fix (same as Part VI): `simp only [nsmul_eq_mul, Nat.cast_mul]`
+  to split the cast product, then `set A := …` each of the six `descFactorial` casts
+  and three coefficients to opaque atoms BEFORE `nlinarith [h]`.
+- `set q := derivative^[j] p with hq` does NOT auto-fold `derivative^[j] p` in
+  hypotheses generated *after* the `set` (e.g. `natDegree_iterate_derivative p j`);
+  fold them manually with `rw [← hq] at hle`.
+
+### Still open (the remaining Vieta polish)
+The interior *coefficient* inequality is closed for all windows. The only remaining
+increment mirrors Part VIII's TOP Vieta closure: substitute
+`p.coeff k = lc·(-1)^(n-k)·eₙ₋ₖ` (`coeff_eq_esymm_roots_of_splits`) into
+`newton_interior_coeff_ineq` to state the interior step directly on the elementary
+symmetric functions `eₖ₋₁, eₖ, eₖ₊₁` of the roots (the classical `eₖ² ≥ eₖ₋₁eₖ₊₁`
+form). Purely algebraic — the calculus engine is complete.

--- a/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-02-oq-05/state.md
@@ -4,7 +4,41 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 9 (PART VIII)
+**Iteration**: 10 (PART IX)
+
+## Iteration 10 (PART IX — the general-`n` INTERIOR Newton step: an arbitrary coefficient window), researcher-5
+Two verified additions (36 → 38 theorems; 0 sorries, 0 axioms; docker-build clean,
+7743 jobs, Lean 4.26.0). **CLOSES the last documented gap** — the general interior
+Newton step `pₖ² ≥ pₖ₋₁pₖ₊₁` for every window and every arity, via the honest
+calculus route the entry asks for. The engine (differentiate → reverse → discriminant)
+now reaches EVERY consecutive coefficient window of an arbitrary real-rooted
+polynomial, not just the top (Part VII) and bottom (Part VIII) extremes:
+- `discrim_reverse_interior (j m) {p} (hp : Splits p) (hcj : p.coeff j ≠ 0)
+  (hdeg : p.natDegree = j + (m + 2))` : `0 ≤ discrim` of the window
+  `p.coeff j, p.coeff (j+1), p.coeff (j+2)` (each weighted by the two
+  differentiation passes' `descFactorial` factors). Differentiate `p` exactly `j`
+  times (Part V) to drop the window to the bottom of `derivative^[j] p`, reverse
+  (Part VIII) to lift it to the top of a quadratic, then apply the top engine
+  `discrim_iterate_derivative_top`. `j = 0` is definitionally `discrim_reverse_bottom`.
+- `newton_interior_coeff_ineq (j m) {p} …` : the recognizable
+  `4·(weights)·p.coeff j·p.coeff (j+2) ≤ (weight)²·p.coeff (j+1)²`, subsuming both
+  `newton_top_coeff_ineq` and `newton_bottom_coeff_ineq`.
+
+**What remains (Vieta polish only):** substitute
+`p.coeff k = lc·(-1)^(n-k)·eₙ₋ₖ` (`coeff_eq_esymm_roots_of_splits`, exactly as
+Part VIII did for the top step) to restate the interior step directly on the roots'
+elementary symmetric functions `eₖ₋₁, eₖ, eₖ₊₁` (classical `eₖ² ≥ eₖ₋₁eₖ₊₁`).
+Purely algebraic — the calculus engine itself is now complete for all windows.
+
+**Reusable Lean gotchas (researcher-5, Part IX):**
+- `coeff_iterate_derivative` emits indices in `0 + j` (un-normalized) form; add
+  `Nat.zero_add` to the same `rw` chain to unify against a `p.coeff j` hypothesis.
+- Fold nested `ℕ`-scalar weights `a • b • x → (a*b) • x` with `← mul_smul`.
+- The corollary's `nlinarith` SIGBUS-crashes (exit 135) on raw `descFactorial`
+  casts / `coeff` atoms; `simp only [nsmul_eq_mul, Nat.cast_mul]` then `set` each
+  atom to an opaque variable before `nlinarith` (same fix as Part VI).
+- `set q := derivative^[j] p with hq` doesn't fold `derivative^[j] p` in
+  later-generated hypotheses; use `rw [← hq] at …`.
 
 ## Iteration 9 (PART VIII — Vieta closure of the TOP step: calculus route reaches Newton's inequality on esymm(roots)), researcher-5
 Two verified additions (28 → 30 theorems; 0 sorries, 0 axioms; docker-build clean,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-02-oq-05.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Part VIII, researcher-5): built splits_reverse (Splits p → Splits (reverse p)), the reversal counterpart of Part V that Mathlib lacked, and used it to prove the general-n BOTTOM Newton step (newton_bottom_coeff_ineq / discrim_reverse_bottom) on a real-rooted polynomials three bottom coefficients — genuinely new arbitrary-n content unreachable from Parts III/VII (which only give the first/top step). 33 theorems, 0 sorries, 0 axioms (foundational only), docker-build clean 7743 jobs. Remaining: general interior steps (reverse+derivative) and the Vieta substitution to elementary-symmetric mean form.",
+    "progressSummary": "PROGRESS (Part IX, researcher-5): closed the last documented gap — the general-n INTERIOR Newton step for every coefficient window, via discrim_reverse_interior / newton_interior_coeff_ineq (differentiate j times → reverse → top-step discriminant engine). Subsumes the top (Part VII) and bottom (Part VIII) extremes. 38 theorems, 0 sorries, 0 axioms (foundational only), docker-build clean 7743 jobs, Lean 4.26.0. Remaining: only the Vieta substitution to elementary-symmetric mean form (algebraic polish).",
     "builtItems": [
       "discrim_nonneg_of_root in Proofs/AmgmInequalityOQ02OQ02OQ05.lean (real quadratic with a real root has 0 <= discrim)",
       "monic_quadratic_discrim_nonneg / discrim_nonneg_of_roots_nonempty (same via Polynomial.IsRoot and nonempty Polynomial.roots)",
@@ -40,7 +40,9 @@
       "splits_reverse_prod (s : Multiset ℝ) : Splits (reverse ((s.map (X - C ·)).prod)) — multiset induction using reverse_mul_of_domain",
       "splits_reverse {p} (hp : Splits p) : Splits (reverse p) — THE new infra Mathlib lacks; reversal preserves real-rootedness",
       "discrim_reverse_bottom (m) {p} (hp : Splits p) (h0 : p.coeff 0 ≠ 0) (hdeg : natDegree p = m+2) : 0 ≤ discrim of p bottom three coeffs (descFactorial-weighted) — general-n BOTTOM Newton step via one reversal",
-      "newton_bottom_coeff_ineq (m) {p} … : 4·(2+m)!desc·m!desc·p.coeff 0·p.coeff 2 ≤ ((1+m)!desc)²·p.coeff 1² — readable b²≥4ac bottom step"
+      "newton_bottom_coeff_ineq (m) {p} … : 4·(2+m)!desc·m!desc·p.coeff 0·p.coeff 2 ≤ ((1+m)!desc)²·p.coeff 1² — readable b²≥4ac bottom step",
+      "discrim_reverse_interior (Part IX): 0 ≤ discrim of any consecutive window p.coeff j, j+1, j+2 of a real-rooted p — differentiate j times then reverse then apply the top engine; j=0 recovers discrim_reverse_bottom (AmgmInequalityOQ02OQ02OQ05.lean)",
+      "newton_interior_coeff_ineq (Part IX): Newtons log-concavity 4·(weights)·p.coeff j·p.coeff (j+2) ≤ (weight)²·p.coeff (j+1)² on an arbitrary window, subsuming both top and bottom coeff inequalities (AmgmInequalityOQ02OQ02OQ05.lean)"
     ],
     "insights": [
       "Mathlib packages the completed-square identity as discrim_eq_sq_of_quadratic_eq_zero (h : a*(x*x)+b*x+c=0) : discrim a b c = (2*a*x+b)^2, so real-root implies nonneg discriminant is a 2-line proof (rw + sq_nonneg). This is the per-derivative atom of the whole Newton/Rolle program.",
@@ -49,14 +51,14 @@
       "The remaining crux is exactly differentiation preserves full real-rootedness counting multiplicity (iterated Rolle on prod (X - x_i)); Mathlib has Rolle (exists_hasDerivAt_eq_zero) and Polynomial.derivative/roots but not this packaged lemma.",
       "Reversal preserves splitting over ℝ: reverse (X - C r) has degree ≤1 with leadingCoeff = trailingCoeff(X - C r) ≠ 0 (invertible), so splits via splits_of_natDegree_le_one_of_invertible; distribute reverse over the multiset product (reverse_mul_of_domain) to get splits_reverse: Splits p → Splits (reverse p). Mathlib lacked this; it is the reversal counterpart of Part V splits_derivative.",
       "Part VII TOP step specialised to the monic splitting poly ∏(X-xᵢ) (top coeffs 1,-e₁,e₂) only reproduces the FIRST Newton inequality (already general in Part III). Genuinely new arbitrary-n content lives in the non-top steps, reached by REVERSING p so its bottom coefficients become the top coefficients of reverse p.",
-      "The BOTTOM Newton step (discrim on p.coeff 0,1,2) is obtained by applying the Part VII engine discrim_iterate_derivative_top to reverse p: needs only Splits(reverse p) + natDegree(reverse p)=m+2, the latter from coeff 0 ≠ 0 ⇒ natTrailingDegree = 0 (natTrailingDegree_le_of_ne_zero). coeff_reverse + revAt_le read the three top coeffs of reverse p back as p.coeff 0,1,2."
+      "The BOTTOM Newton step (discrim on p.coeff 0,1,2) is obtained by applying the Part VII engine discrim_iterate_derivative_top to reverse p: needs only Splits(reverse p) + natDegree(reverse p)=m+2, the latter from coeff 0 ≠ 0 ⇒ natTrailingDegree = 0 (natTrailingDegree_le_of_ne_zero). coeff_reverse + revAt_le read the three top coeffs of reverse p back as p.coeff 0,1,2.",
+      "Differentiation alone can never reach an interior coefficient window: coeff_iterate_derivative always maps a derivatives top three coeffs back to p top three. Sliding the window down requires reverse. The general interior step = differentiate j times (window drops to the bottom of derivative^[j] p) → reverse (lifts it to the top of a quadratic) → top-step discriminant engine. A single reverse (Part VIII) only reaches j=0."
     ],
     "mathlibGaps": [
       "No packaged lemma: over R, p.roots.card = p.natDegree implies (derivative p).roots.card = (derivative p).natDegree (Rolle + multiplicity). This is the crux for general n."
     ],
     "nextSteps": [
-      "General INTERIOR steps (2 ≤ k ≤ n-2): compose reverse with iterated derivative — apply discrim_iterate_derivative_top to reverse(derivative^[j] p) to read an interior coefficient triple. Needs a nonvanishing hypothesis on the relevant coefficient (reversal drops degree if leading/constant term vanishes).",
-      "Vieta bridge: specialise splits polynomial p = ∏(X-xᵢ) so p.coeff(n-k) = (-1)^k eₖ (Polynomial.coeff_prod_X_sub_C / Multiset.esymm), turning newton_top_coeff_ineq / newton_bottom_coeff_ineq into the classical eₖ² ≥ eₖ₋₁ eₖ₊₁ mean form."
+      "Vieta polish: substitute p.coeff k = lc·(-1)^(n-k)·e_{n-k} (coeff_eq_esymm_roots_of_splits, as Part VIII did for the top step) into newton_interior_coeff_ineq to state the interior step directly on the roots elementary symmetric functions e_{k-1}, e_k, e_{k+1} (classical e_k² ≥ e_{k-1}e_{k+1}). Purely algebraic; the calculus engine is complete for all windows."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-02-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -123,7 +125,7 @@
     "mathlib": []
   },
   "started": "2026-07-04T09:09:15.544Z",
-  "lastUpdate": "2026-07-04T10:00:00.000Z",
+  "lastUpdate": "2026-07-04",
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02OQ05.lean",


### PR DESCRIPTION
## Summary

Closes the **last documented gap** in the real-rootedness/calculus proof of Newton's inequalities for `amgm-inequality-oq-02-oq-02-oq-05`: the **general interior Newton step** `pₖ² ≥ pₖ₋₁pₖ₊₁` for *every* coefficient window and *every* arity.

Parts VII/VIII had the two extremes — the TOP window (`discrim_iterate_derivative_top`) and the BOTTOM window (`discrim_reverse_bottom`, `j = 0`). Part IX supplies the strictly interior windows by composing the two engine atoms already in the file.

## What's new (`Proofs/AmgmInequalityOQ02OQ02OQ05.lean`, 36 → 38 theorems)

- **`discrim_reverse_interior (j m) {p} (hp : Splits p) (hcj : p.coeff j ≠ 0) (hdeg : p.natDegree = j + (m + 2))`** — `0 ≤ discrim` of an arbitrary consecutive window `p.coeff j, p.coeff (j+1), p.coeff (j+2)` of a real-rooted polynomial. Proof: differentiate `p` exactly `j` times (Part V — window drops to the *bottom* of `derivative^[j] p`), reverse (Part VIII — lifts it to the *top* of a genuine quadratic), then read off the discriminant with the top-step engine. The `j = 0` case is definitionally `discrim_reverse_bottom`.
- **`newton_interior_coeff_ineq (j m) {p} …`** — the recognizable `4·(weights)·p.coeff j·p.coeff (j+2) ≤ (weight)²·p.coeff (j+1)²`, subsuming both `newton_top_coeff_ineq` and `newton_bottom_coeff_ineq`.

## Key idea

Differentiation alone can never reach an interior window — `coeff_iterate_derivative` always maps a derivative's top three coefficients back to `p`'s top three. Sliding the window down requires `reverse`. A single reverse (Part VIII) reaches only `j = 0`; general `j` needs the derivative pass *first*.

## Verification

- **0 sorries, 0 axioms** (foundational only — no `decide`/`native_decide`).
- `docker-build.sh Proofs.AmgmInequalityOQ02OQ02OQ05` clean, 7743 jobs, Lean 4.26.0.

## Remaining (algebraic polish only)

Substitute Vieta (`coeff_eq_esymm_roots_of_splits`, as Part VIII did for the top step) to restate the interior step directly on the roots' elementary symmetric functions `eₖ₋₁, eₖ, eₖ₊₁`. The calculus engine itself is now complete for all windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)