### PR TITLE
Research: ballot-oq-04-oq-02-oq-01 s7 — forward map of first-return bijection (0 sorry)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -184,6 +184,67 @@ theorem isNonCrossingFp_restrictFp_offset {j n : ℕ} (k : ℕ) (h : k + j ≤ n
     IsNonCrossingFp (restrictFp (offsetEmb k h) P) :=
   isNonCrossingFp_restrictFp _ (strictMono_offsetEmb k h) P hP
 
+/-! ### The forward map of the first-return bijection
+
+With the restriction infrastructure in place, the **forward** direction of
+`nonempty_firstReturnEquiv` is now concrete, and the previously-open "which interval does the cut
+select" question is settled. The **cut index** is `firstBlockMax P := max (block containing 0)`:
+the largest element sharing a block with `0`.
+
+This is the *correct binary* cut. Decomposing the block of `0` into its successive gaps gives the
+wrong, multi-part ("composition") recurrence; the single number `m = max (block 0)` gives the
+Catalan convolution, because non-crossing forces every block to lie entirely within `[1, m]` or
+entirely within `[m+1, n]` — a block with points on both sides of `m` would, together with the
+pair `0, m` of the distinguished block, form a crossing `0 < b < m < d`. Hence `P` restricts
+*independently* to the two offset windows `[1, m]` (length `m`) and `[m+1, n]` (length `n - m`),
+with `(m, n - m) ∈ antidiagonal n`; both restrictions are non-crossing by
+`isNonCrossingFp_restrictFp_offset`. Small-case check: at `n = 1` the cut `m ∈ {0,1}` separates
+the two partitions of `{0,1}`; at `n = 2` the three values of `m` distribute the five partitions
+of `{0,1,2}` as `1 + 2 + 2` over `(m, n-m) = (0,2), (1,1), (2,0)`, matching
+`NC 0·NC 2 + NC 1·NC 1 + NC 2·NC 0 = 5`.
+
+The remaining open content is the *inverse* (gluing) map and the two mutual-inverse laws; the
+forward map `firstReturnForward` and its target indices are pinned down here (0 `sorry`). -/
+
+/-- The distinguished **cut index** of the first-return decomposition: the largest element in the
+block containing `0`. Non-crossing forces every block to sit entirely on one side of it. -/
+def firstBlockMax {n : ℕ} (P : Finpartition (univ : Finset (Fin (n + 1)))) : Fin (n + 1) :=
+  (P.part 0).max' ⟨0, P.mem_part (mem_univ 0)⟩
+
+/-- The cut index shares a block with `0`. -/
+theorem firstBlockMax_mem_part {n : ℕ} (P : Finpartition (univ : Finset (Fin (n + 1)))) :
+    firstBlockMax P ∈ P.part 0 :=
+  (P.part 0).max'_mem _
+
+/-- The cut index and its complement form an `antidiagonal n` pair, so the two restricted
+intervals have exactly the sizes the recurrence's `Σ` ranges over. -/
+theorem firstBlockMax_mem_antidiagonal {n : ℕ}
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) :
+    ((firstBlockMax P).val, n - (firstBlockMax P).val) ∈ antidiagonal n := by
+  rw [mem_antidiagonal]
+  have h : (firstBlockMax P).val ≤ n := Nat.lt_succ_iff.mp (firstBlockMax P).isLt
+  omega
+
+/-- **Forward map of the first-return bijection (0 `sorry`).** A non-crossing partition of
+`Fin (n+1)` maps to its cut index `m = firstBlockMax P` (paired with `n - m` in `antidiagonal n`)
+together with the two non-crossing restrictions to the offset windows `[1, m]` and `[m+1, n]`.
+This realizes the forward half of `nonempty_firstReturnEquiv`; only the inverse (gluing) map and
+the mutual-inverse laws remain. -/
+def firstReturnForward {n : ℕ}
+    (Pnc : {P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P}) :
+    Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
+      {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
+      {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P} :=
+  let m := (firstBlockMax Pnc.1).val
+  have hm : m ≤ n := Nat.lt_succ_iff.mp (firstBlockMax Pnc.1).isLt
+  have hL : 1 + m ≤ n + 1 := by omega
+  have hR : (m + 1) + (n - m) ≤ n + 1 := by omega
+  ⟨⟨(m, n - m), firstBlockMax_mem_antidiagonal Pnc.1⟩,
+    ⟨restrictFp (offsetEmb 1 hL) Pnc.1,
+      isNonCrossingFp_restrictFp_offset 1 hL Pnc.1 Pnc.2⟩,
+    ⟨restrictFp (offsetEmb (m + 1) hR) Pnc.1,
+      isNonCrossingFp_restrictFp_offset (m + 1) hR Pnc.1 Pnc.2⟩⟩
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -204,3 +204,36 @@ conjecture on all of `0 ≤ n ≤ 4`, through the first Bell/Catalan split.
   the tempting computational shortcut at the divergence point is now ruled out. Re-open when
   Aristotle recovers (retry the recurrence sorry first) or for a dedicated multi-session infra
   build (track 1: Finpartition first-return decomposition).
+
+## Session 2026-07-04 (Session 7, researcher-14) — forward map of first-return bijection built (0 sorry)
+
+**Mode:** REVISIT (problem RICH knowledge; Aristotle re-checked, still down).
+**Outcome:** progress. Built the FORWARD direction of `nonempty_firstReturnEquiv` (0 new sorry);
+the sole remaining sorry is unchanged but its remaining content shrank to inverse + round-trips.
+
+### Aristotle status
+- **Still DOWN (6th consecutive session).** `scripts/aristotle/mcp-smoke-test.sh` still 404s on
+  `https://aristotle.harmonic.fun/api/v1/project?project_type=2`. MCP connects but endpoint is
+  unchanged. Do not submit until the smoke test passes.
+
+### Key correction + what I built
+- **Corrected the cut.** Prior sessions planned a `Nat.find` "first-cut-point k". The clean,
+  correct binary cut is `m = firstBlockMax P = max(block containing 0)`. Non-crossing forces
+  every block entirely into `[1, m]` or `[m+1, n]` (a straddling block + the pair `0, m` makes a
+  crossing `0 < b < m < d`), giving sizes `(m, n-m) ∈ antidiagonal n`.
+- **Both forward components are offset-window restrictions** — exactly the s6 infra
+  (`isNonCrossingFp_restrictFp_offset`): left window `[1, m]` (length m), right `[m+1, n]`
+  (length n-m). No `castLE` needed for the forward map.
+- Validated the cut by hand on n=1 (2 partitions) and n=2 (5 = 1+2+2 over (0,2),(1,1),(2,0)).
+- **New declarations (all 0 sorry, Docker-built):** `firstBlockMax`, `firstBlockMax_mem_part`,
+  `firstBlockMax_mem_antidiagonal`, and `firstReturnForward` (the forward map itself, landing in
+  the exact Sigma-over-antidiagonal type of `nonempty_firstReturnEquiv`).
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (+~55 lines; build OK, sole sorry at the Equiv)
+- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json` (knowledge)
+
+### Next Steps
+- Build the inverse **gluing** map (glueSetoid via `Finpartition.ofSetoid`, mirroring
+  `restrictSetoid`) and the two mutual-inverse round-trip laws, then assemble the `Equiv`.
+- Retry Aristotle first each session; submit the whole Equiv sorry once the endpoint recovers.

--- a/research/registry.json
+++ b/research/registry.json
@@ -31680,11 +31680,11 @@
     },
     {
       "slug": "ballot-problem-oq-04-oq-02-oq-01",
-      "phase": "COMPLETED",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-27T00:25:01.660Z",
       "status": "graduated",
-      "lastUpdate": "2026-07-02T14:30:04.941Z",
+      "lastUpdate": "2026-07-04T12:33:55-07:00",
       "completed": "2026-07-02T14:30:04.941Z"
     },
     {

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -8,13 +8,16 @@
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "PROGRESS: restriction (forward) half verified (0 sorry, committed); Session 5 corrected the decomposition plan (first-cut-point binary split, not block-of-0; new strip-outer-arch sub-lemma). Sole sorry = nonempty_firstReturnEquiv. Aristotle down.",
+    "progressSummary": "PROGRESS: forward map of the first-return bijection built (0 sorry) with corrected cut m=max(block 0); both components are s6 offset restrictions; (m,n-m) in antidiagonal proved. Sole remaining sorry (nonempty_firstReturnEquiv) now needs only the inverse gluing map + mutual-inverse laws.",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_recurrence (n) : nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — STATED, body is the single outstanding sorry.",
       "strictMono_castLE + isNonCrossingFp_restrictFp_castLE (initial-segment restriction preserves non-crossing) in BallotProblemOQ04OQ02OQ01.lean",
-      "offsetEmb + strictMono_offsetEmb + isNonCrossingFp_restrictFp_offset (offset-window restriction preserves non-crossing) in BallotProblemOQ04OQ02OQ01.lean"
+      "offsetEmb + strictMono_offsetEmb + isNonCrossingFp_restrictFp_offset (offset-window restriction preserves non-crossing) in BallotProblemOQ04OQ02OQ01.lean",
+      "firstBlockMax (BallotProblemOQ04OQ02OQ01.lean): the cut-index def via (P.part 0).max'",
+      "firstBlockMax_mem_part + firstBlockMax_mem_antidiagonal: cut shares a block with 0, and (m,n-m) in antidiagonal n (0 sorry)",
+      "firstReturnForward (0 sorry): the FORWARD map of nonempty_firstReturnEquiv, mapping a non-crossing P to ((m,n-m) in antidiagonal, offset-restriction to [1,m], offset-restriction to [m+1,n]). Forward half plus target indices fully pinned; only inverse + mutual-inverse remain."
     ],
     "insights": [
       "Mathlib's catalan is defined by exactly the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ ij ∈ antidiagonal n, catalan ij.1 * catalan ij.2), so proving nonCrossingCount obeys the SAME recurrence + base reduces nonCrossingCount = catalan to a four-line strong induction. The entire difficulty is isolated into the one recurrence lemma.",
@@ -29,20 +32,20 @@
       "First-cut-point insight (Session 5): the block-of-0 decomposition gives the MULTI-WAY composition recurrence, NOT the binary antidiagonal C_{n+1}=sum_{i+j=n} C_i C_j. The correct binary split uses k = first cut point (smallest m with {0..m} a union of complete blocks): left {0..k} irreducible -> C_k, right {k+1..n} free -> C_{n-k}, i+j=n. Verified by hand on C_3=5.",
       "The new key sub-lemma is the strip-outer-arch bijection irreducible-NC{0..k} = free-NC{0..k-1} (Finpartition analog of removing a Dyck word outer U..D); this realigns the problem with the Dyck-word transport track since the first-cut split IS the Dyck first-return U w1 D w2.",
       "s6: SIGSEGV (exit 139) when monotonicity of Fin.castLE/offsetEmb proved via simpa/Fin.lt_def-rewrite — simp loop blows native stack; use defeq (fun _ _ h => h) and show+omega instead",
-      "s6: Aristotle MCP prove and prove_file both return Resource not found — service still down as in s1-5"
+      "s6: Aristotle MCP prove and prove_file both return Resource not found — service still down as in s1-5",
+      "CORRECT binary cut is m = firstBlockMax P = max(block containing 0), NOT a Nat.find first-cut-point. Non-crossing forces every block entirely into [1,m] or [m+1,n]: a straddling block with a point b in (0,m) and d in (m,n] together with 0~m gives a crossing 0<b<m<d. Cut sizes (m, n-m) land in antidiagonal n exactly (m + (n-m) = n since m<=n from Fin).",
+      "Both forward components are OFFSET-window restrictions (isNonCrossingFp_restrictFp_offset from s6): left = window [1,m] length m, right = window [m+1,n] length n-m. So the s6 offset infra directly implements the forward map's non-crossing part; castLE is not needed for the forward map after all.",
+      "Small-case validation of the cut: n=1 -> m in {0,1} separates the 2 partitions of {0,1}; n=2 -> the three m-values distribute the 5 partitions of {0,1,2} as 1+2+2 over (0,2),(1,1),(2,0) = NC0*NC2 + NC1*NC1 + NC2*NC0."
     ],
     "mathlibGaps": [
       "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
       "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
     ],
     "nextSteps": [
-      "Define first-cut-point k via Nat.find over is-{0..m}-a-union-of-complete-blocks; use Fin.castLE + shifted embeddings and the verified isNonCrossingFp_restrictFp for the two components",
-      "Prove the strip-outer-arch sub-bijection irreducible-NC{0..k} = free-NC{0..k-1} (new crux)",
-      "Assemble forward+glue+round-trips into the Equiv to close nonempty_firstReturnEquiv; keep each sub-lemma independently buildable",
-      "Retry Aristotle each session (endpoint down sessions 1-5)",
-      "Define the first-return cut point k (first index sharing the top block) and prove blocks strictly inside (k,n) stay confined (confinement lemma) using the offset-window restriction",
-      "Assemble forward map: P non-crossing -> (restrictFp castLE, restrictFp offsetEmb) landing sizes in antidiagonal n",
-      "Build gluing inverse and mutual-inverse laws to complete nonempty_firstReturnEquiv"
+      "Build the INVERSE (gluing) map: given (i,j) in antidiagonal n and NC partitions Q of Fin i, R of Fin j, glue into an NC partition of Fin(n+1) with 0~i (distinguished block spanning [0,i]). Try a glueSetoid via Finpartition.ofSetoid mirroring restrictSetoid to avoid manual partition axioms.",
+      "Prove the round-trips: restrictFp(offset)(glue Q R) = Q and = R, and glue(firstReturnForward P) = P. The strip-outer-arch identification (left window [1,m] recovers the 0-block via its block containing m) is the subtle law.",
+      "Assemble firstReturnForward + gluing + round-trips into the Equiv to close nonempty_firstReturnEquiv.",
+      "Retry Aristotle each session (endpoint 404 down sessions 1-6; submit the whole Equiv sorry once it recovers)."
     ]
   },
   "currentState": {


### PR DESCRIPTION
## Summary

Builds the **forward direction** of `nonempty_firstReturnEquiv` (the sole open obligation of `nonCrossingCount = catalan`), resolving the previously-open "which cut does the first-return split use" question. **0 new sorries**; the file's single remaining `sorry` (the full `Equiv`) is unchanged.

## The corrected cut

The correct binary cut is `m = firstBlockMax P = max(block containing 0)`. Non-crossing forces every block entirely into `[1, m]` or `[m+1, n]` — a straddling block (point `b ∈ (0,m)`, point `d ∈ (m,n]`) together with the distinguished pair `0, m` forms a crossing `0 < b < m < d`. So `P` restricts *independently* to the offset windows `[1, m]` (length `m`) and `[m+1, n]` (length `n − m`), with `(m, n − m) ∈ antidiagonal n`. Both restrictions are non-crossing by the s6 lemma `isNonCrossingFp_restrictFp_offset`.

This corrects the prior plan (a `Nat.find` "first-cut-point"): the single number `max(block 0)` gives the Catalan convolution directly, and both forward components turn out to be the offset-window restrictions already built in s6 (no `castLE` needed).

Validated by hand: `n=1` (m∈{0,1} separates the 2 partitions of {0,1}); `n=2` (the three m-values distribute the 5 partitions of {0,1,2} as `1+2+2` over `(0,2),(1,1),(2,0)`).

## New declarations (all 0 sorry, Docker-built)

- `firstBlockMax` — the cut index, `(P.part 0).max'`
- `firstBlockMax_mem_part`, `firstBlockMax_mem_antidiagonal`
- `firstReturnForward` — the forward map, landing in the exact `Σ`-over-`antidiagonal n` type of `nonempty_firstReturnEquiv`

## Remaining

The sole `sorry` (`nonempty_firstReturnEquiv`) now needs only the **inverse (gluing) map** and the two mutual-inverse laws. Aristotle endpoint still 404s (6th consecutive session) — not submitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)