### PR TITLE
Konigsberg OQ02OQ01OQ02OQ01: verify Hierholzer continuation invariant

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -1,0 +1,47 @@
+/-
+# Undirected Hierholzer — development scaffolding (base case)
+
+Companion development file for `KonigsbergOQ02OQ01OQ02OQ01.lean`, whose main
+theorem `undirected_euler_circuit_sufficient` (the undirected Hierholzer
+sufficiency direction) still carries a single `sorry`.
+
+Mathlib provides the *necessity* direction only
+(`SimpleGraph.Walk.IsEulerian.even_degree_iff`,
+`SimpleGraph.Walk.IsEulerian.card_odd_degree`); it has **no** existence/Hierholzer
+construction, so sufficiency must be built natively in the `SimpleGraph.Walk` API.
+The `Digraph`-based directed proof in `KonigsbergOQ02OQ01.lean` is **not** reusable
+here: it is built on a bespoke `Digraph` structure with its own `Walk`, `splice`,
+`removeArcList` and `arcCount`, none of which are `SimpleGraph.Walk` objects.
+
+The standard proof is strong induction on `G.edgeFinset.card`. This file discharges
+the **base case** natively (0 edges ⇒ the trivial `nil` walk is Eulerian); the
+remaining inductive core (a maximal trail is closed, edge-removal preserves the
+all-even-degree invariant, and connectivity lets residual circuits splice in) is the
+~600–1000 line classical construction still to be built or delegated.
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+import Mathlib.Tactic
+
+open SimpleGraph SimpleGraph.Walk
+
+namespace UndirectedEulerDev
+
+variable {V : Type*} [DecidableEq V] {G : SimpleGraph V}
+
+/-- **Base case of the undirected Hierholzer induction.**
+A connected simple graph with no edges has an Eulerian circuit: the trivial `nil`
+walk at any of its vertices. Mathlib defines `p.IsEulerian` as
+`∀ e ∈ G.edgeSet, p.edges.count e = 1`, which holds vacuously here since `G` has no
+edges. -/
+theorem euler_circuit_of_edgeSet_empty
+    (hconn : G.Connected) (hE : G.edgeSet = ∅) :
+    ∃ (u : V) (p : G.Walk u u), p.IsEulerian := by
+  obtain ⟨u⟩ := hconn.nonempty
+  refine ⟨u, Walk.nil, ?_⟩
+  -- `IsEulerian` unfolds to `∀ e ∈ G.edgeSet, ...`; vacuous as there are no edges.
+  intro e he
+  rw [hE] at he
+  exact absurd he (Set.notMem_empty e)
+
+end UndirectedEulerDev

--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -44,4 +44,27 @@ theorem euler_circuit_of_edgeSet_empty
   rw [hE] at he
   exact absurd he (Set.notMem_empty e)
 
+/-- **Hierholzer's continuation invariant.**
+In a *nontrivial* connected simple graph in which every vertex has even degree, every
+vertex has degree at least `2`.
+
+This is the structural fact underpinning the "a maximal trail is closed" step of the
+undirected Hierholzer induction. When a trail arrives at a vertex `v ≠ start` it has
+used an *odd* number of `v`'s incident edges (one on each earlier visit plus the edge
+just traversed); since `G.degree v` is even there is always an unused incident edge to
+continue along, so a trail can only get *stuck* — become maximal — back at its start
+vertex, i.e. it is closed. The `2 ≤ G.degree v` bound below is the base quantitative
+form of that parity slack: a positive even number is at least `2`.
+
+`Nontrivial V` is necessary: the one-vertex connected graph has `G.degree v = 0`. In
+the induction this hypothesis holds in exactly the inductive (edge-containing) case;
+the edgeless base case is handled by `euler_circuit_of_edgeSet_empty` above. -/
+theorem two_le_degree_of_even_of_connected
+    [Fintype V] [DecidableRel G.Adj] [Nontrivial V]
+    (hconn : G.Connected) (heven : ∀ v, Even (G.degree v)) (v : V) :
+    2 ≤ G.degree v := by
+  have hpos : 0 < G.degree v := hconn.preconnected.degree_pos_of_nontrivial v
+  obtain ⟨k, hk⟩ := heven v
+  omega
+
 end UndirectedEulerDev

--- a/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -52,3 +52,36 @@ Insights accumulated during research on this problem.
   edge removal preserves even degree → splice via shared vertex → induct on edges).
 - Re-submit the sorry file to Aristotle from the main repo (MCP "Resource not
   found" from the worktree) as a KNOWN result.
+
+## Session 2026-07-04 (Session 2) — Base case verified; plan corrected
+
+**Mode**: REVISIT (depth line) | **Outcome**: progress (1 verified lemma)
+
+### What I Did
+- Confirmed via web search + local check that Mathlib4 still has NO undirected
+  Eulerian existence/Hierholzer construction (only `even_degree_iff`,
+  `card_odd_degree`).
+- Confirmed the directed `Digraph` proof is NOT reusable: it is built on a bespoke
+  `Digraph` type (own Walk/splice/removeArcList/arcCount), not `SimpleGraph.Walk`.
+- Wrote and **verified** the induction base case in a new dev file:
+  `euler_circuit_of_edgeSet_empty` (connected + `G.edgeSet = ∅` ⇒ Eulerian circuit
+  via the `nil` walk). Compiles clean, 0 sorries.
+- Aristotle backend was fully DOWN (`Resource not found` even for inline `1+1=2`),
+  so the known-result delegation could not run this session.
+
+### Key Findings
+- **Definition correction**: Mathlib's `IsEulerian p := ∀ e ∈ G.edgeSet,
+  p.edges.count e = 1` — a per-edge count condition, NOT `IsTrail ∧ covers-all`.
+  Trail-ness is derived (`IsEulerian.isTrail`). The construction invariant is the
+  count=1 condition. `IsEulerian` needs `[DecidableEq V]`.
+
+### Files Modified
+- proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (new — base case, verified)
+- src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json (knowledge)
+
+### Next Steps
+- Sub-lemma A: maximal trail in an all-even graph is closed (parity/handshake).
+- Sub-lemma B: `G.deleteEdges (closed trail edges)` preserves `∀ v, Even (degree v)`.
+- Sub-lemma C: splice residual circuit via shared vertex; strong induction on
+  `edgeFinset.card` using the verified base case.
+- Resubmit the single sorry to Aristotle once the backend recovers.

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -29,15 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT/ACT: undirected Hierholzer sufficiency stated + iff-necessity proved (compiles, 1 sorry). Directed template identified; naive doubling reduction shown to fail. Sufficiency construction (~600-1000 lines) is the remaining work; delegate to Aristotle or build natively.",
+    "progressSummary": "ACT: base case of undirected Hierholzer induction VERIFIED (euler_circuit_of_edgeSet_empty, 0 sorries, in ...Dev.lean). Corrected key fact: IsEulerian = (∀ e ∈ edgeSet, count e = 1), trail derived. Directed Digraph template confirmed NON-reusable. Mathlib confirmed lacking sufficiency. Aristotle backend down this session. Remaining: inductive step (sub-lemmas A maximal-trail-closed, B edge-removal-preserves-even, C splice) — the ~600-1000 line core.",
     "builtItems": [
-      "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning)."
+      "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning).",
+      "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries."
     ],
     "insights": [
       "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
       "A fully-proved DIRECTED analogue exists in KonigsbergOQ02OQ01.lean (directed_euler_circuit_sufficient_corrected, 0 sorries, ~900 lines) with reusable machinery: splice constructor, removeArcList (arc removal preserving balance), and maximal_balanced_trail_is_circuit. This is a strong structural template for the undirected argument.",
       "KEY INSIGHT (reduction failure): the naive reduction replacing each undirected edge {u,v} with two directed arcs (u,v),(v,u) yields a balanced strongly-connected digraph, so the directed theorem gives a directed Eulerian circuit -- but that circuit traverses each undirected edge TWICE (once per direction). It is therefore NOT an undirected Eulerian circuit. A native undirected Hierholzer argument is required.",
-      "The undirected parity invariant is Even (G.degree v) (from Mathlib IsEulerian.even_degree_iff / card_odd_degree) rather than the directed inDegree=outDegree balance, because undirected incidence is symmetric."
+      "The undirected parity invariant is Even (G.degree v) (from Mathlib IsEulerian.even_degree_iff / card_odd_degree) rather than the directed inDegree=outDegree balance, because undirected incidence is symmetric.",
+      "IsEulerian is defined in Mathlib as (∀ e ∈ G.edgeSet, p.edges.count e = 1) — NOT (IsTrail ∧ covers all edges). Trail-ness is a DERIVED consequence (IsEulerian.isTrail). The construction invariant to maintain is therefore the per-edge count=1 condition; this corrects the earlier plan framing.",
+      "Confirmed (web search + local check): Mathlib4 Trails module has only the necessity/property lemmas (IsEulerian.even_degree_iff, IsEulerian.card_odd_degree). No Eulerian existence/Hierholzer construction exists upstream, so sufficiency must be built natively.",
+      "The directed Digraph proof in KonigsbergOQ02OQ01.lean is NOT reusable: it is built on a bespoke Digraph structure with its own Walk/splice/removeArcList/arcCount — none are SimpleGraph.Walk objects. A native SimpleGraph mirror is required.",
+      "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target)."
     ],
     "mathlibGaps": [
       "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."
@@ -45,7 +50,10 @@
     "nextSteps": [
       "Port the directed sub-lemma structure to undirected: (1) from an all-even-degree graph, any MAXIMAL trail from a vertex is closed (current endpoint always has an unused incident edge by a parity/handshake count); (2) removing the edges of a closed trail preserves all-even-degree; (3) splice a residual closed trail through a shared vertex (exists by connectivity) into the main circuit; induct on edge count.",
       "Aristotle submission of the sorry file failed with MCP error Resource not found (likely worktree/lake-project resolution). Re-submit from the main repo via research/scripts/aristotle-submit.sh once the PR merges, as a KNOWN classical result.",
-      "Consider building an undirected splice + edgeRemoval operation mirroring KonigsbergOQ02OQ01.lean removeArcList; estimate 600-1000 lines. This is the main effort and may warrant Aristotle or a dedicated multi-session build."
+      "Consider building an undirected splice + edgeRemoval operation mirroring KonigsbergOQ02OQ01.lean removeArcList; estimate 600-1000 lines. This is the main effort and may warrant Aristotle or a dedicated multi-session build.",
+      "Prove inductive step sub-lemma A: in an all-even-degree graph with ≥1 edge, a maximal trail from any positive-degree vertex is CLOSED (parity/handshake: current endpoint always has an unused incident edge unless back at start).",
+      "Prove sub-lemma B: deleting the edges of a closed trail (G.deleteEdges on the trail edge set) preserves ∀ v, Even (degree v) — each vertex loses an even number of incident trail-edges.",
+      "Prove sub-lemma C (splice): a residual closed trail sharing a vertex with the main circuit can be spliced in, maintaining the per-edge count=1 invariant; combine with strong induction on G.edgeFinset.card using the verified base case."
     ],
     "markdown": "# Knowledge Base: konigsberg-oq-02-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds one natively-verified lemma to the undirected **Hierholzer** scaffolding
file `KonigsbergOQ02OQ01OQ02OQ01Dev.lean`, advancing the sufficiency direction of
Euler's Eulerian-circuit characterization (whose main theorem
`undirected_euler_circuit_sufficient` still carries a single `sorry`).

**`two_le_degree_of_even_of_connected`** — in a *nontrivial* connected simple
graph in which every vertex has even degree, every vertex has degree `≥ 2`.

This is the base quantitative form of the parity slack behind the "a maximal
trail is closed" step of the Hierholzer induction: on arriving at any vertex
`v ≠ start`, a trail has used an *odd* number of `v`'s incident edges, and
evenness always leaves an unused one to continue along — so a trail can only get
stuck back at its start vertex (i.e. it is closed).

## Proof

Native `SimpleGraph.Walk` API — no new axioms, no `sorry`:
`Preconnected.degree_pos_of_nontrivial` gives positivity, then `omega` closes
`0 < n ∧ Even n → 2 ≤ n`. The `Nontrivial V` hypothesis is necessary (the
one-vertex connected graph has degree `0`); in the induction it holds exactly in
the edge-containing case, the edgeless base being `euler_circuit_of_edgeSet_empty`.

## Verification

`./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ02OQ01OQ02OQ01Dev` — build
succeeds (3076 jobs). Note: Aristotle proof search remains unavailable
("Resource not found"), so the remaining ~600–1000-line inductive core is being
built natively piece by piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)