### PR TITLE
Enrich Rational Root Theorem: +3 cross-references (1→4)

### DIFF
--- a/src/data/proofs/integral-root-theorem-oq-01/meta.json
+++ b/src/data/proofs/integral-root-theorem-oq-01/meta.json
@@ -85,6 +85,21 @@
       "proofId": "eisenstein-criterion-oq-01",
       "relationship": "related",
       "description": "Two complementary tools for integer polynomials: Eisenstein's criterion certifies irreducibility (no factorization), while the rational root theorem constrains and rules out roots (no linear factors). Both feed into Gauss's lemma and the study of irreducibility over ℚ; the X² − 2 example is irreducible by either route."
+    },
+    {
+      "proofId": "gauss-lemma-primitive-oq-01",
+      "relationship": "depends-on",
+      "description": "Gauss's lemma (a primitive integer polynomial is irreducible over ℤ iff over ℚ) is the structural result underlying the rational root theorem: it is what lets root-divisibility over ℚ be read off the ℤ-coefficients, and equivalently expresses that ℤ is integrally closed in ℚ — the exact content of the monic-roots-are-integers corollary here."
+    },
+    {
+      "proofId": "cube-root-2-irrational",
+      "relationship": "related",
+      "description": "The ⁿ√p irrationality template of this entry made concrete: ∛2 is irrational because it is a root of the monic X³ − 2, which has no integer root. Where this file runs the argument for √2 via X² − 2, that entry runs the same monic-roots-are-integers engine one degree up — the generalization flagged in the open questions."
+    },
+    {
+      "proofId": "fourth-root-2-irrational",
+      "relationship": "related",
+      "description": "Pushes the irrationality of ⁴√2 to a full minimal-polynomial statement: X⁴ − 2 is not merely rootless over ℚ but irreducible (via Eisenstein + Gauss), giving [ℚ(⁴√2):ℚ] = 4. It shows where the rational root theorem stops (ruling out linear factors) and irreducibility criteria take over (ruling out all factorizations)."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `integral-root-theorem-oq-01` (The Rational Root Theorem and Integrality of Monic Roots).

**Change:** expanded `crossReferences` from 1 to 4, linking the entry into its natural neighborhood in the gallery:

- **gauss-lemma-primitive-oq-01** (`depends-on`) — Gauss's lemma is the structural result underlying the rational root theorem and the integral-closedness of ℤ in ℚ.
- **cube-root-2-irrational** (`related`) — the ⁿ√p irrationality template made concrete one degree up (∛2 via monic X³ − 2), realizing the generalization flagged in the open questions.
- **fourth-root-2-irrational** (`related`) — pushes past rootlessness to full irreducibility of X⁴ − 2 (Eisenstein + Gauss), showing where RRT stops and irreducibility criteria take over.

Existing eisenstein-criterion-oq-01 link retained. No content removed. meta.json 13.6 KB → 15 KB (well under the 60 KB cap; all collections within caps). `pnpm build` passes; Lean file re-verified as matching the stated theorems (6 theorems, 0 sorries, 0 axioms, no native_decide).
