### PR TITLE
Erdős #1003 OQ-04: formalize infinitude reduction to open #1003 [build-pending]

### DIFF
--- a/proofs/Proofs/Erdos1003OQ04.lean
+++ b/proofs/Proofs/Erdos1003OQ04.lean
@@ -26,10 +26,16 @@ with the concrete numerical record.
      single consecutive *pair* infinitely often — a four-run needs a consecutive
      *triple*.
 
-  2. **Existence equivalences.**  The OQ-04 existence question is equivalent to
-     "`CKE 3` is nonempty", i.e. to "A001274 contains three consecutive
-     integers", tying it cleanly into the `CKE` hierarchy of the sibling OQ-02
-     file and to Erdős's strong conjecture at `k = 3`.
+  2. **Existence equivalences and the infinitude reduction.**  The OQ-04 existence
+     question is equivalent to "`CKE 3` is nonempty", i.e. to "A001274 contains
+     three consecutive integers", tying it cleanly into the `CKE` hierarchy of the
+     sibling OQ-02 file and to Erdős's strong conjecture at `k = 3`.  At the
+     infinitude level the reduction is one-directional and sharp: since every
+     four-run starts at an A001274 member (`fcet_subset_cet`), infinitely many
+     four-runs would force A001274 itself to be infinite
+     (`infinite_cet_of_infinite_fcet` / `oq04_conjecture_imp_1003`).  So OQ-04 is
+     *strictly harder* than the open base #1003 — any affirmative resolution
+     resolves #1003 as a corollary.
 
   3. **The record run.**  `5186` realises a run of length **3**
      (`φ 5186 = φ 5187 = φ 5188 = 2592`) — the longest run of consecutive equal
@@ -175,6 +181,31 @@ theorem fcet_subset_cke_two :
   rw [fcet_eq_cke_three]
   intro n hn i hi
   exact hn i (by omega)
+
+/-- Every four-run starts at a member of the Erdős #1003 set: `FCET ⊆ A001274`.
+(The first of the three consecutive-membership conditions of
+`mem_fcet_iff_three_consecutive`.) -/
+theorem fcet_subset_cet :
+    FourConsecutiveEqualTotients ⊆ ConsecutiveEqualTotients :=
+  fun _ hn => (mem_fcet_iff_three_consecutive.mp hn).1
+
+/-- **OQ-04 infinitude ⟹ #1003 (infinitude level).**  If there are infinitely
+many four-term runs of equal totients, then the base Erdős #1003 set A001274 is
+infinite — i.e. `φ n = φ (n+1)` holds infinitely often.  This makes machine-checked
+the file's thesis that OQ-04 is *strictly harder* than the already-open #1003: any
+affirmative resolution of the four-run infinitude conjecture resolves #1003 as a
+corollary. -/
+theorem infinite_cet_of_infinite_fcet
+    (h : FourConsecutiveEqualTotients.Infinite) :
+    ConsecutiveEqualTotients.Infinite :=
+  h.mono fcet_subset_cet
+
+/-- Restatement of `infinite_cet_of_infinite_fcet` against the named conjecture
+objects: the OQ-04 (`k = 3`) infinitude conjecture implies the #1003 base
+infinitude. -/
+theorem oq04_conjecture_imp_1003 (h : oq04_infinitude_conjecture) :
+    ConsecutiveEqualTotients.Infinite :=
+  infinite_cet_of_infinite_fcet h
 
 /-! ## §3  The concrete record: a run of length three
 


### PR DESCRIPTION
## Summary

Small, focused enhancement to the already-merged OQ-04 entry (`Proofs.Erdos1003OQ04`, PR #34685). That file proves the *run reduction* (a four-run of equal totients = three consecutive members of the #1003 set A001274) and asserts in prose that OQ-04 is **strictly harder** than the open base #1003 — but the **infinitude-level reduction** was never formalized. The file only had the subset relation into `CKE 2`, not into the base set `ConsecutiveEqualTotients` at the `Set.Infinite` level.

This PR adds the three missing lemmas that make that thesis machine-checked:

- `fcet_subset_cet : FourConsecutiveEqualTotients ⊆ ConsecutiveEqualTotients` — every four-run starts at an A001274 member (first component of the already-proven `mem_fcet_iff_three_consecutive`).
- `infinite_cet_of_infinite_fcet : FourConsecutiveEqualTotients.Infinite → ConsecutiveEqualTotients.Infinite` — infinitely many four-runs force the base #1003 set to be infinite (`.mono` of the subset).
- `oq04_conjecture_imp_1003` — the same, stated against the named `oq04_infinitude_conjecture` object.

All three are trivial term-mode consequences of lemmas already in the file (no new `native_decide`, no new axioms). Header docstring §2 updated to reference them.

## ⚠️ Build status: NOT machine-verified this session

The Docker build environment failed with disk **input/output errors** (containerd `meta.db` I/O error) and the Docker daemon went down mid-session, so `docker-build.sh Proofs.Erdos1003OQ04` could not complete. Observed only environmental `exit code 135` (SIGBUS) crashes — **no Lean elaboration errors** at any point; a `native_decide`→`sorry` stubbed variant crashed identically at the same environmental point, confirming the failure is infrastructure, not code.

**Kept as a draft PR** so it is not auto-merged before a clean build. Please rebuild `Proofs.Erdos1003OQ04` once Docker infra recovers, then mark ready. The additions are simple and expected to compile, but should be verified before merge.

## Notes
- Complements (does not duplicate) the merged OQ-04 file.
- Corroborating computation this session: a `φ` sieve to `2·10⁷` finds exactly one three-run (n=5186) and zero four-runs — consistent with the file's cited `10^15` literature bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)