### PR TITLE
research(erdos-1017-oq-04): clique cover vs partition — cc(G) ≤ cp(G) (verified, 0 axioms)

### DIFF
--- a/proofs/Proofs/Erdos1017OQ04.lean
+++ b/proofs/Proofs/Erdos1017OQ04.lean
@@ -1,0 +1,241 @@
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Clique
+import Mathlib.Data.Finset.Card
+import Mathlib.Tactic
+
+/-
+# Erdos Problem #1017 (OQ-04): Clique Cover vs Clique Partition
+
+## The Open Question
+> Can Lovasz's covering result be strengthened to a *partition* result by
+> controlling edge overlaps? The gap between the covering number and the
+> partition number is not well understood.
+
+An **edge clique cover** of a graph `G` is a collection of cliques such that
+every edge lies in *at least one* clique (overlaps allowed). An **edge clique
+partition** is the stronger notion: every edge lies in *exactly one* clique.
+
+Write `cc(G)` for the minimum size of a cover and `cp(G)` for the minimum size
+of a partition. The question of OQ-04 is whether a minimum cover can always be
+converted into an equally small partition. The two numbers are genuinely
+different quantities, and the *direction* that always holds is
+
+    cc(G) <= cp(G).
+
+## What This File Proves (0 axioms, 0 sorries)
+- `EdgeCliqueCover`     : the covering structure (overlaps allowed).
+- `EdgeCliquePartition` : the partition structure (each edge covered exactly
+  once, via `ExistsUnique`).
+- `EdgeCliquePartition.toCover` : every partition is a cover (forget
+  disjointness). This is the structural heart of the "partition => cover"
+  direction.
+- `trivialPartition` : the partition of `G` into its individual edges, giving a
+  witness that a partition always exists (so `partitionNum` is achieved, not the
+  vacuous `sInf` of the empty set).
+- `coverNum_le_partitionNum` : **cc(G) <= cp(G)** for every finite graph.
+- `partitionNum_le_edgeCliquesCard`, `coverNum_le_edgeCliquesCard` : both numbers
+  are at most the number of two-element cliques (each edge as its own clique).
+
+## Relation to OQ-01
+The companion file `Erdos1017OQ01.lean` defines a structure it calls
+`EdgeCliquePartition` whose only constraint is the `covers` field -- with no
+disjointness requirement. That object is in fact an *edge clique cover* in the
+terminology here, and its `cliquePartitionNum` is really `cc(G)`. This file
+makes the cover/partition distinction explicit and pins down the inequality
+relating the two, which is the well-defined mathematical content behind OQ-04's
+"covering vs partition" gap.
+
+## Honest Scope
+This establishes the always-true direction `cc <= cp` rigorously and with zero
+axioms. It does **not** prove the gap can be strict (that requires a lower-bound
+argument on a concrete graph -- see the `nextSteps` in the knowledge file). The
+strict gap is what shows OQ-04's strengthening genuinely fails; the book graph
+`K_4` minus an edge is the intended witness (`cc = 2 < 3 = cp`).
+-/
+
+set_option maxHeartbeats 400000
+
+namespace Erdos1017OQ04
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-
+====================================================================
+PART I: COVER AND PARTITION STRUCTURES
+==================================================================== -/
+
+/-- An **edge clique cover** of `G`: a finite collection of cliques such that
+    every edge of `G` lies in at least one clique. Cliques may overlap. -/
+structure EdgeCliqueCover (G : SimpleGraph V) [DecidableRel G.Adj] where
+  /-- The cliques in the cover. -/
+  cliques : Finset (Finset V)
+  /-- Each listed set is a clique of `G`. -/
+  isClique : ∀ S ∈ cliques, G.IsClique (↑S : Set V)
+  /-- Every edge is covered by some clique. -/
+  covers : ∀ ⦃v w⦄, G.Adj v w → ∃ S ∈ cliques, v ∈ S ∧ w ∈ S
+
+/-- An **edge clique partition** of `G`: a finite collection of cliques such
+    that every edge of `G` lies in *exactly one* clique. This is a cover with
+    the additional (edge-)disjointness constraint, phrased as unique existence. -/
+structure EdgeCliquePartition (G : SimpleGraph V) [DecidableRel G.Adj] where
+  /-- The cliques in the partition. -/
+  cliques : Finset (Finset V)
+  /-- Each listed set is a clique of `G`. -/
+  isClique : ∀ S ∈ cliques, G.IsClique (↑S : Set V)
+  /-- Every edge lies in exactly one clique. -/
+  partitions : ∀ ⦃v w⦄, G.Adj v w → ∃! S, S ∈ cliques ∧ v ∈ S ∧ w ∈ S
+
+variable {G : SimpleGraph V} [DecidableRel G.Adj]
+
+/-- **Every partition is a cover.** Forgetting the disjointness (uniqueness)
+    constraint turns an edge clique partition into an edge clique cover with the
+    same underlying set of cliques. This is the structural core of the
+    always-true direction `cc(G) <= cp(G)`. -/
+def EdgeCliquePartition.toCover (P : EdgeCliquePartition G) : EdgeCliqueCover G where
+  cliques := P.cliques
+  isClique := P.isClique
+  covers := by
+    intro v w hvw
+    obtain ⟨S, ⟨hS, hv, hw⟩, _⟩ := P.partitions hvw
+    exact ⟨S, hS, hv, hw⟩
+
+@[simp] theorem EdgeCliquePartition.toCover_cliques (P : EdgeCliquePartition G) :
+    P.toCover.cliques = P.cliques := rfl
+
+/-
+====================================================================
+PART II: THE COVER AND PARTITION NUMBERS
+==================================================================== -/
+
+/-- The **clique cover number** `cc(G)`: the least number of cliques in an edge
+    clique cover of `G`. -/
+noncomputable def coverNum (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  sInf { m | ∃ C : EdgeCliqueCover G, C.cliques.card = m }
+
+/-- The **clique partition number** `cp(G)`: the least number of cliques in an
+    edge clique partition of `G`. -/
+noncomputable def partitionNum (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  sInf { m | ∃ P : EdgeCliquePartition G, P.cliques.card = m }
+
+/-
+====================================================================
+PART III: THE TRIVIAL PARTITION (EACH EDGE ITS OWN CLIQUE)
+==================================================================== -/
+
+/-- The collection of all two-element cliques of `G`, i.e. its edges viewed as
+    two-element vertex sets. -/
+noncomputable def edgeCliques (G : SimpleGraph V) [DecidableRel G.Adj] :
+    Finset (Finset V) :=
+  Finset.univ.filter (fun S => S.card = 2 ∧ G.IsClique (↑S : Set V))
+
+/-- A pair `{v, w}` of adjacent vertices is a clique of `G`. -/
+theorem isClique_pair {v w : V} (h : G.Adj v w) :
+    G.IsClique (↑({v, w} : Finset V) : Set V) := by
+  rw [SimpleGraph.isClique_iff, Finset.coe_insert, Finset.coe_singleton]
+  intro x hx y hy hxy
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx hy
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · exact absurd rfl hxy
+  · exact h
+  · exact h.symm
+  · exact absurd rfl hxy
+
+/-- The cardinality of a pair of distinct elements is two. -/
+theorem card_pair_eq_two {v w : V} (h : v ≠ w) :
+    ({v, w} : Finset V).card = 2 := by
+  rw [Finset.card_insert_of_not_mem (by rw [Finset.mem_singleton]; exact h)]
+  simp
+
+/-- Membership in `edgeCliques`: the two-element sets that are cliques are
+    exactly the `{v, w}` with `v` and `w` adjacent. -/
+theorem mem_edgeCliques {S : Finset V} :
+    S ∈ edgeCliques G ↔ S.card = 2 ∧ G.IsClique (↑S : Set V) := by
+  simp [edgeCliques]
+
+/-- The **trivial edge clique partition**: every edge is its own clique. This
+    witnesses that an edge clique partition of `G` always exists. -/
+noncomputable def trivialPartition (G : SimpleGraph V) [DecidableRel G.Adj] :
+    EdgeCliquePartition G where
+  cliques := edgeCliques G
+  isClique := by
+    intro S hS
+    exact (mem_edgeCliques.mp hS).2
+  partitions := by
+    intro v w hvw
+    have hvw_ne : v ≠ w := hvw.ne
+    have hcard : ({v, w} : Finset V).card = 2 := card_pair_eq_two hvw_ne
+    refine ⟨{v, w}, ⟨?_, ?_, ?_⟩, ?_⟩
+    · -- {v,w} is a two-element clique, hence in edgeCliques
+      exact mem_edgeCliques.mpr ⟨hcard, isClique_pair hvw⟩
+    · exact Finset.mem_insert_self v {w}
+    · exact Finset.mem_insert_of_mem (Finset.mem_singleton_self w)
+    · -- uniqueness: any two-element clique containing v and w equals {v,w}
+      rintro S ⟨hS, hvS, hwS⟩
+      have hSc : S.card = 2 := (mem_edgeCliques.mp hS).1
+      have hsub : ({v, w} : Finset V) ⊆ S := by
+        intro x hx
+        rcases Finset.mem_insert.mp hx with rfl | hx
+        · exact hvS
+        · rw [Finset.mem_singleton] at hx; rw [hx]; exact hwS
+      exact (Finset.eq_of_subset_of_card_le hsub (hSc.trans hcard.symm).le).symm
+
+/-
+====================================================================
+PART IV: THE MAIN INEQUALITY  cc(G) <= cp(G)
+==================================================================== -/
+
+/-- The partition-number witness set is nonempty: the trivial partition exists. -/
+theorem partitionNum_set_nonempty (G : SimpleGraph V) [DecidableRel G.Adj] :
+    { m | ∃ P : EdgeCliquePartition G, P.cliques.card = m }.Nonempty :=
+  ⟨(trivialPartition G).cliques.card, trivialPartition G, rfl⟩
+
+/-- **Main result.** The clique cover number is at most the clique partition
+    number: `cc(G) <= cp(G)`. Every partition is a cover of the same size, so any
+    partition of size `cp(G)` gives a cover of size `cp(G)`, whence `cc(G)` (the
+    minimum cover size) is at most `cp(G)`. -/
+theorem coverNum_le_partitionNum (G : SimpleGraph V) [DecidableRel G.Adj] :
+    coverNum G ≤ partitionNum G := by
+  -- The partition number is achieved by some partition `P`.
+  obtain ⟨P, hP⟩ := Nat.sInf_mem (partitionNum_set_nonempty G)
+  -- `P.toCover` is a cover of the same size, so `partitionNum G` is a valid
+  -- cover size, and `coverNum G` (an infimum) is at most it.
+  refine Nat.sInf_le ?_
+  exact ⟨P.toCover, by rw [EdgeCliquePartition.toCover_cliques]; exact hP⟩
+
+/-
+====================================================================
+PART V: UPPER BOUNDS BY THE NUMBER OF EDGE-CLIQUES
+==================================================================== -/
+
+/-- The trivial partition uses exactly the two-element cliques, one per edge. -/
+theorem trivialPartition_card (G : SimpleGraph V) [DecidableRel G.Adj] :
+    (trivialPartition G).cliques.card = (edgeCliques G).card := rfl
+
+/-- `cp(G) <= |edgeCliques G|`: partition each edge into its own clique. -/
+theorem partitionNum_le_edgeCliquesCard (G : SimpleGraph V) [DecidableRel G.Adj] :
+    partitionNum G ≤ (edgeCliques G).card :=
+  Nat.sInf_le ⟨trivialPartition G, rfl⟩
+
+/-- `cc(G) <= |edgeCliques G|`: immediate from `cc <= cp <= |edgeCliques|`. -/
+theorem coverNum_le_edgeCliquesCard (G : SimpleGraph V) [DecidableRel G.Adj] :
+    coverNum G ≤ (edgeCliques G).card :=
+  (coverNum_le_partitionNum G).trans (partitionNum_le_edgeCliquesCard G)
+
+/-
+====================================================================
+PART VI: VERIFICATION
+==================================================================== -/
+
+#check @EdgeCliqueCover
+#check @EdgeCliquePartition
+#check @EdgeCliquePartition.toCover
+#check @coverNum
+#check @partitionNum
+#check @trivialPartition
+#check @coverNum_le_partitionNum
+#check @partitionNum_le_edgeCliquesCard
+#check @coverNum_le_edgeCliquesCard
+
+end Erdos1017OQ04

--- a/research/problems/erdos-1017-oq-04/knowledge.md
+++ b/research/problems/erdos-1017-oq-04/knowledge.md
@@ -1,0 +1,43 @@
+# erdos-1017-oq-04: Clique Cover vs Clique Partition
+
+**Question**: Can Lovász's covering result be strengthened to a *partition* result by
+controlling edge overlaps? The gap between the covering number cc(G) and the partition
+number cp(G) is not well understood.
+
+## Summary
+An edge clique **cover** covers each edge by ≥1 clique (overlaps allowed); an edge clique
+**partition** covers each edge by exactly one clique. The always-true relation is
+`cc(G) ≤ cp(G)`. OQ-04 asks whether the reverse conversion (cover → equally small
+partition) is always possible; the answer is no in general, because a minimum cover may
+require overlaps.
+
+## Session 2026-07-04 (Session 1) — Formalize cover/partition distinction + cc ≤ cp
+
+**Mode**: FRESH
+**Outcome**: progress (VERIFIED lemma, 0 axioms / 0 sorries)
+
+### What I Did
+- Created `proofs/Proofs/Erdos1017OQ04.lean` (241 lines, builds clean under Docker).
+- Defined `EdgeCliqueCover` (covers field) and `EdgeCliquePartition` (ExistsUnique:
+  each edge in exactly one clique) as distinct structures.
+- `EdgeCliquePartition.toCover`: every partition is a cover (forget disjointness).
+- `trivialPartition`: the edge-by-edge partition, witnessing that `partitionNum` is
+  achieved (its witness set is nonempty), avoiding the vacuous `sInf ∅ = 0`.
+- **Main**: `coverNum_le_partitionNum : cc(G) ≤ cp(G)`, plus upper bounds by the number
+  of two-element cliques.
+
+### Key Findings
+- The companion `Erdos1017OQ01.lean` calls its structure `EdgeCliquePartition` but only
+  imposes the `covers` field (no disjointness) — so its `cliquePartitionNum` is really
+  the **cover** number cc(G). This file makes the distinction explicit.
+- The strict-gap witness is the book graph B₂ = K₄ minus an edge: two triangles
+  {0,1,2},{0,1,3} overlap on {0,1} and cover all 5 edges (cc=2), but a partition can use
+  at most one triangle, forcing cp=3. So cc < cp and OQ-04's strengthening fails.
+
+### Files Modified
+- `proofs/Proofs/Erdos1017OQ04.lean` (new)
+- `src/data/research/problems/erdos-1017-oq-04.json` (knowledge, leanFiles, phase)
+
+### Next Steps
+- Formalize the counting identity `∑_{C} C(|C|,2) = |E(G)|` for a true partition, then
+  instantiate B₂ on `Fin 4` to get a VERIFIED strict gap `cc = 2 < 3 = cp`.

--- a/research/problems/erdos-1017-oq-04/problem.md
+++ b/research/problems/erdos-1017-oq-04/problem.md
@@ -1,0 +1,39 @@
+# Problem: Can Lovász's covering result be strengthened to a partition result by control...
+
+## Statement
+
+### Plain Language
+AVAILABLE: Can Lovász's covering result be strengthened to a partition result by controlling edge overlaps? The gap between Lovász's covering number and the partition number is not well understood.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 5
+tractability: 5
+tags:
+  - clique-partition
+  - erdos
+  - extremal-combinatorics
+  - graph-decomposition
+  - graph-theory
+  - seeker-selected
+```
+
+**Significance**: 5/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: Can Lovász's covering result be strengthened to a partition result by controlling edge overlaps? The gap between Lovász's covering number and the partition number is not well understood
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/erdos-1017-oq-04/state.md
+++ b/research/problems/erdos-1017-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-07-04T13:10:19-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/research/problems/erdos-1017-oq-04.json
+++ b/src/data/research/problems/erdos-1017-oq-04.json
@@ -1,0 +1,164 @@
+{
+  "slug": "erdos-1017-oq-04",
+  "title": "Can Lovász's covering result be strengthened to a partition result by control...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Can Lovász's covering result be strengthened to a partition result by controlling edge overlaps? The gap between Lovász's covering number and the partition number is not well understood.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-02T23:52:36.442Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Verified (0 axioms) the always-true direction cc(G)<=cp(G) and the genuine cover/partition distinction; clarified that OQ01 cliquePartitionNum is really the cover number. Strict gap (book graph) is the next rung, needs the sum-of-C(|C|,2)=|E| counting identity.",
+    "builtItems": [
+      "EdgeCliqueCover / EdgeCliquePartition structures (Erdos1017OQ04.lean) — cover vs exactly-once partition",
+      "EdgeCliquePartition.toCover : every partition is a cover (Erdos1017OQ04.lean)",
+      "trivialPartition : edge-by-edge partition witnessing partitionNum is achieved (nonempty witness set)",
+      "coverNum_le_partitionNum : cc(G) <= cp(G), VERIFIED 0 axioms 0 sorries (Erdos1017OQ04.lean)",
+      "partitionNum_le_edgeCliquesCard / coverNum_le_edgeCliquesCard upper bounds"
+    ],
+    "insights": [
+      "The companion file Erdos1017OQ01.lean names its structure EdgeCliquePartition but its only constraint is the covers field (every edge in SOME clique) with no disjointness — so its cliquePartitionNum is really the clique COVER number cc(G), not the partition number cp(G). This conflation is exactly the cover-vs-partition ambiguity OQ-04 is about.",
+      "The always-true direction is cc(G) <= cp(G): every edge clique partition is in particular a cover (forget the uniqueness/disjointness), so the minimum cover size is at most the minimum partition size.",
+      "Formalizing a genuine partition via ExistsUnique (each edge lies in exactly one clique) cleanly separates it from a cover (ExistsUnique weakens to Exists), making toCover a one-line structure map.",
+      "The intended strict-gap witness is the book graph B2 = K4 minus an edge: its two triangles {0,1,2},{0,1,3} overlap on edge {0,1} and cover all 5 edges (cc=2), but a partition cannot use both triangles, forcing cp=3. This shows OQ-04 strengthening genuinely fails."
+    ],
+    "mathlibGaps": [
+      "No off-the-shelf Mathlib notion of edge clique cover/partition number; built locally (~230 lines).",
+      "Exact clique-partition lower bounds (e.g. cp(book graph)=3) need a double-counting identity sum over cliques of C(|C|,2) = |E|, not yet formalized."
+    ],
+    "nextSteps": [
+      "Formalize the counting identity: for a true EdgeCliquePartition, sum over cliques of (card choose 2) equals edgeFinset.card (each edge counted once). This gives verifiable clique-partition lower bounds.",
+      "Instantiate the book graph B2 = K4 minus an edge on Fin 4; prove cc=2 (two overlapping triangles) and cp>=3 via the counting identity, giving a VERIFIED strict gap cc<cp that answers OQ-04 negatively.",
+      "State the general principle: a min cover converts to an equal-size partition iff some min cover is edge-disjoint; overlaps are the obstruction."
+    ]
+  },
+  "tags": [
+    "clique-partition",
+    "erdos",
+    "extremal-combinatorics",
+    "graph-decomposition",
+    "graph-theory",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-101",
+    "erdos-1017",
+    "erdos-1017-oq-01",
+    "erdos-1017-oq-02",
+    "erdos-1017-oq-03",
+    "erdos-1017-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-03T06:52:01.409Z",
+  "lastUpdate": "2026-07-04T20:00:00.000Z",
+  "significance": 5,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1017OQ01.lean",
+      "filename": "Erdos1017OQ01.lean",
+      "lineCount": 697,
+      "theoremCount": 30,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017OQ02.lean",
+      "filename": "Erdos1017OQ02.lean",
+      "lineCount": 150,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017OQ03.lean",
+      "filename": "Erdos1017OQ03.lean",
+      "lineCount": 201,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017OQ03OQ01.lean",
+      "filename": "Erdos1017OQ03OQ01.lean",
+      "lineCount": 147,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017OQ04.lean",
+      "filename": "Erdos1017OQ04.lean",
+      "lineCount": 242,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017Problem.lean",
+      "filename": "Erdos1017Problem.lean",
+      "lineCount": 2,
+      "theoremCount": 0,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1017OQ04.lean",
+      "filename": "Erdos1017OQ04.lean",
+      "lineCount": 241,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1017OQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Formalizes the well-defined mathematical content behind **Erdős #1017 OQ-04** (*"Can Lovász's covering result be strengthened to a partition result by controlling edge overlaps?"*).

New file `proofs/Proofs/Erdos1017OQ04.lean` (241 lines, **0 sorries, 0 axioms**, builds clean under Docker):

- `EdgeCliqueCover` — each edge lies in **≥ 1** clique (overlaps allowed)
- `EdgeCliquePartition` — each edge lies in **exactly one** clique (`ExistsUnique`)
- `EdgeCliquePartition.toCover` — every partition is a cover (forget disjointness)
- `trivialPartition` — the edge-by-edge partition, so the partition witness set is nonempty (avoids the vacuous `sInf ∅`)
- **`coverNum_le_partitionNum : cc(G) ≤ cp(G)`** — the always-true direction
- `partitionNum_le_edgeCliquesCard`, `coverNum_le_edgeCliquesCard`

## Why this matters
The companion `Erdos1017OQ01.lean` names its structure `EdgeCliquePartition`, but its only constraint is the `covers` field (no disjointness) — so its `cliquePartitionNum` is really the clique **cover** number `cc(G)`. This PR makes the cover/partition distinction explicit and pins down the inequality relating the two.

## Honest scope
Proves the always-true `cc ≤ cp` only. The **strict** gap (which is what shows OQ-04's strengthening genuinely fails) is documented as the next rung: instantiate the book graph `B₂ = K₄ − e` on `Fin 4` and use the counting identity `∑_C (|C| choose 2) = |E|` to get `cc = 2 < 3 = cp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)