### PR TITLE
Research: ballot-oq-04-oq-02-oq-01 s8 — no-straddle structural lemma (0 sorry)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -245,6 +245,65 @@ def firstReturnForward {n : ℕ}
     ⟨restrictFp (offsetEmb (m + 1) hR) Pnc.1,
       isNonCrossingFp_restrictFp_offset (m + 1) hR Pnc.1 Pnc.2⟩⟩
 
+/-- **No block straddles the cut (the structural heart of the split).** Let `m` be the *maximum*
+of the block containing `0` (`hm0 : m ∈ P.part 0`, `hmax : m` dominates that block). Then in a
+non-crossing partition `P` of `Fin (n+1)`, no block contains points on *both* sides of `m`: there
+are no two points `x, y` of one block with `x ≤ m < y`.
+
+This is exactly what makes `m = firstBlockMax P` the *correct* binary cut, and what a future
+gluing (inverse) map consumes for injectivity: every block lies entirely in the window `[0, m]`
+or entirely in `[m+1, n]`, so restricting `P` to the two offset windows loses no block and the
+pieces recombine uniquely. Stated for an abstract max element `m` (rather than `firstBlockMax P`
+directly) so the proof is a pure order/partition argument, free of `Finset.max'` unfolding.
+
+Proof: if the straddling block is `0`'s block, then `y ≤ m` (maximality) contradicts `m < y`.
+Otherwise `0 < x < m < y` with `m ∈ P.part 0` and `y ∈ P.part x`, so non-crossing forces
+`x ∈ P.part 0` — but then `0` and `x` share a block, contradicting that this block is not
+`0`'s. -/
+theorem noStraddle_of_isMax {n : ℕ} (P : Finpartition (univ : Finset (Fin (n + 1))))
+    (hP : IsNonCrossingFp P) (m : Fin (n + 1)) (hm0 : m ∈ P.part 0)
+    (hmax : ∀ z ∈ P.part 0, z ≤ m) (a x y : Fin (n + 1))
+    (hx : x ∈ P.part a) (hy : y ∈ P.part a) (hxm : x ≤ m) (hmy : m < y) : False := by
+  by_cases hcase : (0 : Fin (n + 1)) ∈ P.part a
+  · -- `a`'s block is `0`'s block: `y ∈ P.part 0`, so `y ≤ m`, contradicting `m < y`.
+    have h0a : P.part a = P.part 0 :=
+      ((P.mem_part_iff_part_eq_part (mem_univ 0) (mem_univ a)).mp hcase).symm
+    have hy0 : y ∈ P.part 0 := h0a ▸ hy
+    exact absurd (hmax y hy0) (not_le.mpr hmy)
+  · -- `0 ∉ P.part a`: build the crossing `0 < x < m < y`.
+    have hpartx : P.part a = P.part x :=
+      ((P.mem_part_iff_part_eq_part (mem_univ x) (mem_univ a)).mp hx).symm
+    -- `0 ∉ P.part x` (else `0 ∈ P.part a`).
+    have zeroNotX : (0 : Fin (n + 1)) ∉ P.part x := by
+      intro h0x
+      have hx0eq : P.part x = P.part 0 :=
+        ((P.mem_part_iff_part_eq_part (mem_univ 0) (mem_univ x)).mp h0x).symm
+      exact hcase (by rw [hpartx, hx0eq]; exact P.mem_part (mem_univ 0))
+    have hxne : x ≠ 0 := fun hh => hcase (hh ▸ hx)
+    -- `x ≠ m`: else `x = m ∈ P.part 0`, forcing `0 ∈ P.part x`.
+    have hxnem : x ≠ m := by
+      intro hh
+      have hxm0 : x ∈ P.part 0 := hh ▸ hm0
+      have heq : P.part 0 = P.part x :=
+        ((P.mem_part_iff_part_eq_part (mem_univ x) (mem_univ 0)).mp hxm0).symm
+      exact zeroNotX (heq ▸ P.mem_part (mem_univ 0))
+    have hyx : y ∈ P.part x := hpartx ▸ hy
+    have hlt1 : (0 : Fin (n + 1)) < x := Fin.pos_iff_ne_zero.mpr hxne
+    have hlt2 : x < m := lt_of_le_of_ne hxm hxnem
+    have hcross : x ∈ P.part 0 := hP 0 x m y hlt1 hlt2 hmy hm0 hyx
+    have hx0eq : P.part 0 = P.part x :=
+      ((P.mem_part_iff_part_eq_part (mem_univ x) (mem_univ 0)).mp hcross).symm
+    exact zeroNotX (hx0eq ▸ P.mem_part (mem_univ 0))
+
+/-- **No block straddles `firstBlockMax P`.** The concrete instance of `noStraddle_of_isMax` at
+the cut index `m = firstBlockMax P`: its maximality over the block of `0` is `Finset.le_max'`. -/
+theorem noStraddle {n : ℕ} (P : Finpartition (univ : Finset (Fin (n + 1))))
+    (hP : IsNonCrossingFp P) (a x y : Fin (n + 1))
+    (hx : x ∈ P.part a) (hy : y ∈ P.part a)
+    (hxm : x ≤ firstBlockMax P) (hmy : firstBlockMax P < y) : False :=
+  noStraddle_of_isMax P hP (firstBlockMax P) (firstBlockMax_mem_part P)
+    (fun z hz => Finset.le_max' _ z hz) a x y hx hy hxm hmy
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -237,3 +237,48 @@ the sole remaining sorry is unchanged but its remaining content shrank to invers
 - Build the inverse **gluing** map (glueSetoid via `Finpartition.ofSetoid`, mirroring
   `restrictSetoid`) and the two mutual-inverse round-trip laws, then assemble the `Equiv`.
 - Retry Aristotle first each session; submit the whole Equiv sorry once the endpoint recovers.
+
+## Session 2026-07-04 (Session 8, researcher-14) — no-straddle structural lemma proved (0 sorry)
+
+**Mode:** REVISIT (continuation of s7). **Outcome:** progress. Proved the **no-straddle** lemma
+— the combinatorial heart the inverse/gluing map's injectivity consumes — with 0 new sorry
+(Docker-built). Sole sorry (`nonempty_firstReturnEquiv`) unchanged.
+
+### Aristotle status
+- **Still DOWN (7th consecutive session).** `mcp__aristotle__prove_file` returns
+  `{"status":"error","message":"Resource not found."}` from BOTH a worktree path and the main
+  repo path (so it is the endpoint, not the worktree-path issue from Researcher-11's note). Do
+  not submit until the smoke test passes.
+
+### What I built (both 0 sorry, Docker-built)
+- **`noStraddle_of_isMax`** — the abstract structural lemma: for `P` non-crossing and `m` the
+  *max* of the block of `0` (`hm0 : m ∈ P.part 0`, `hmax : ∀ z ∈ P.part 0, z ≤ m`), no block has
+  points `x ≤ m` and `y > m`. Proof: two `by_cases` on `0 ∈ P.part a`. If yes, `y ∈ P.part 0`
+  ⇒ `y ≤ m` (hmax) contradicts `m < y`. If no, then `0 < x < m < y` with `m ∈ P.part 0`,
+  `y ∈ P.part x`, so `hP 0 x m y` forces `x ∈ P.part 0` — contradicting `0 ∉ P.part a`
+  (= `P.part x`).
+- **`noStraddle`** — the concrete instance at `m = firstBlockMax P`; maximality is
+  `Finset.le_max'`.
+
+### Reusable gotchas (IMPORTANT — these cost 4 failed Docker builds this session)
+- **`mem_part_iff_part_eq_part` argument order:** `P.mem_part_iff_part_eq_part (hi) (hj) :
+  i ∈ P.part j ↔ P.part i = P.part j`. The FIRST `mem_univ` arg is the ELEMENT (left of `∈`),
+  the SECOND is the PART INDEX. Getting it backwards is a clean type error (easy to spot).
+- **OOM / SIGSEGV (Lean exit 135, then 32GB kill) on this file's Fin work:** an earlier version
+  of the proof crashed the elaborator hard. The culprits were the `Fin.val`-level tactics —
+  `omega` over `(firstBlockMax P).val`, `Fin.lt_def`/`Fin.le_def`/`Fin.val_zero` rewrites, and
+  `simpa`/`simp` on Fin goals (matches the s6 note "Fin monotonicity via simpa SIGSEGVs"). The
+  FIX that built cleanly: **stay at Fin `≤`/`<` level** — `lt_of_le_of_ne`, `not_le.mpr`,
+  `Fin.pos_iff_ne_zero.mpr` — with **no `Fin.val` conversions, no `omega`, no `simp`**. Abstract
+  `firstBlockMax`/`Finset.max'` behind a hypothesis (`noStraddle_of_isMax` takes `m` + `hmax`) so
+  the substantive proof never unfolds `max'`; the concrete corollary supplies `Finset.le_max'`
+  separately and compiles fine (so `max'` defeq was NOT the OOM — the Fin.val tactics were).
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (+~50 lines; build OK, sole sorry unchanged)
+
+### Next Steps
+- Inverse **gluing** map: given `(Q1, Q2)` non-crossing on the two windows, glue by joining `0`
+  to `Q1`'s block-of-top-element (index `m`); `noStraddle` gives injectivity (no block lost on
+  restriction). Then the two round-trips + assemble `Equiv`.
+- Retry Aristotle first each session.


### PR DESCRIPTION
## Summary

Continuation of the first-return-bijection program for **non-crossing partitions are counted by Catalan** (`nonCrossingCount = catalan`). Session 7 (#34687, merged) built the *forward* map. This session proves the **structural heart** the inverse/gluing map's injectivity depends on, with **0 new sorry** (Docker-built).

### New declarations (both 0 sorry)
- **`noStraddle_of_isMax`** — abstract form: for `P` non-crossing and `m` the maximum of the block of `0`, **no block straddles `m`** (no two points `x ≤ m < y` share a block). Pure order/partition argument: two `by_cases` on `0 ∈ P.part a`; the off-block case builds the crossing `0 < x < m < y` and applies non-crossing `hP 0 x m y` to force `x ∈ P.part 0`, contradicting `0 ∉ P.part a`.
- **`noStraddle`** — the concrete instance at `m = firstBlockMax P` (maximality via `Finset.le_max'`).

This is exactly what injectivity of the future gluing map consumes: every block lies entirely in `[0, m]` or `[m+1, n]`, so restricting `P` to the two offset windows loses no block and the pieces recombine uniquely.

### Status
- Sole sorry (`nonempty_firstReturnEquiv`, the full first-return `Equiv`) **unchanged**. Gallery status remains `formalized`.
- File Docker-builds; the only sorry warning is the pre-existing one.

### Notes
- Recorded a reusable gotcha: `Fin.val`-level tactics (`omega` over `(firstBlockMax P).val`, `Fin.lt_def`/`le_def`/`val_zero` rewrites, `simpa` on Fin) OOM the elaborator here (exit 135 / 32GB kill); staying at Fin `≤`/`<` level (`lt_of_le_of_ne`, `not_le`, `Fin.pos_iff_ne_zero`) and abstracting `max'` behind a hypothesis builds cleanly.
- Aristotle still down (7th session; `Resource not found` from both worktree and main-repo paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)