### PR TITLE
Erdős #1003 OQ-04: gallery entry for four-consecutive-equal-totients (ungalleried verified proof)

### DIFF
--- a/src/data/proofs/erdos-1003-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1003-oq-04/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-e1003-oq04-defs",
+    "proofId": "erdos-1003-oq-04",
+    "range": {
+      "startLine": 64,
+      "endLine": 85
+    },
+    "type": "definition",
+    "title": "The #1003 set, the run-length family, and the OQ-04 target",
+    "content": "Three definitions mirror the parent #1003 entry verbatim, keeping the whole family compatible. ConsecutiveEqualTotients = {n | φ(n) = φ(n+1)} is the Erdős #1003 solution set (OEIS A001274). ConsecutiveKEqualTotients k = {n | ∀ i ≤ k, φ n = φ(n+i)} is the run-length hierarchy: n starts a run of k+1 equal totients. FourConsecutiveEqualTotients is the OQ-04 target, and oq04_infinitude_conjecture is the (open) Infinite version. Writing CKE with an explicit index k is what lets §1 state the run reduction once, in full generality, and then specialize to k = 3.",
+    "mathContext": "$\\text{CKE}\\,k = \\{n \\mid \\forall i \\le k,\\ \\varphi(n)=\\varphi(n+i)\\}$; the OQ-04 target FCET is the $k=3$ slice.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euler totient φ (Nat.totient)",
+      "consecutive-equal-totient set A001274",
+      "run-length hierarchy of equal totients",
+      "Erdős's strong conjecture on long runs"
+    ],
+    "prerequisites": [
+      "Euler's totient function",
+      "set-builder notation over ℕ",
+      "the parent Erdős #1003 solution set"
+    ]
+  },
+  {
+    "id": "ann-e1003-oq04-telescope",
+    "proofId": "erdos-1003-oq-04",
+    "range": {
+      "startLine": 87,
+      "endLine": 118
+    },
+    "type": "insight",
+    "title": "Telescoping: a run is a chain of adjacent equalities",
+    "content": "mem_cke_iff_run is the combinatorial backbone. Being in CKE k — all of φ n, φ(n+1), …, φ(n+k) equal — is equivalent to the vanishing of every one of the k consecutive differences, φ(n+i) = φ(n+i+1) for i < k. The reverse direction is an induction on the run length: each new adjacent equality extends the common value one step further. mem_cke_iff_consecutive_cet then just unfolds set membership: a run is exactly a block of consecutive members of the #1003 set A001274. This telescoping is what makes 'a run of equal totients' a purely local object — a chain of #1003 solutions — rather than a global coincidence.",
+    "mathContext": "$n \\in \\text{CKE}\\,k \\iff \\forall i<k,\\ \\varphi(n+i)=\\varphi(n+i+1)$, i.e. $n,\\dots,n+k-1 \\in$ A001274.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescoping sum / chain of equalities",
+      "induction on run length",
+      "consecutive members of A001274"
+    ],
+    "prerequisites": [
+      "induction over ℕ",
+      "transitivity of equality",
+      "set-builder membership unfolding"
+    ]
+  },
+  {
+    "id": "ann-e1003-oq04-fourrun",
+    "proofId": "erdos-1003-oq-04",
+    "range": {
+      "startLine": 119,
+      "endLine": 148
+    },
+    "type": "insight",
+    "title": "A four-run is three consecutive #1003 solutions",
+    "content": "fcet_eq_cke_three identifies the OQ-04 target with the k = 3 slice CKE 3 (interval_cases handles the finite index range i ≤ 3). mem_fcet_iff_three_consecutive then delivers the headline reduction: φ(n) = φ(n+1) = φ(n+2) = φ(n+3) holds iff n, n+1, n+2 are three consecutive members of A001274. This is the reason four-runs are so elusive: a single consecutive pair in A001274 is already open and exceedingly rare, and a four-run demands a consecutive triple — so OQ-04 is strictly harder than #1003 itself.",
+    "mathContext": "four-run at $n \\iff n, n+1, n+2 \\in$ A001274 (three consecutive members).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "k = 3 slice of Erdős's strong conjecture",
+      "three consecutive members of A001274",
+      "reduction of an existence question to its arithmetic content"
+    ],
+    "prerequisites": [
+      "the telescoping run reduction (§1)",
+      "interval_cases / finite case analysis",
+      "the #1003 pair set A001274"
+    ]
+  },
+  {
+    "id": "ann-e1003-oq04-existence",
+    "proofId": "erdos-1003-oq-04",
+    "range": {
+      "startLine": 150,
+      "endLine": 177
+    },
+    "type": "theorem",
+    "title": "Existence equivalences and CKE monotonicity",
+    "content": "The open OQ-04 existence question is repackaged against the hierarchy. fcet_nonempty_iff_cke_three_nonempty rewrites it as CKE 3 nonemptiness; fcet_nonempty_iff_three_consecutive_cet rewrites it as A001274 containing three consecutive members — the exact arithmetic content any eventual resolution must supply. fcet_subset_cke_two records the monotonicity of the run-length chain: a four-run is in particular a three-run (CKE 3 ⊆ CKE 2). None of these resolves the question; they locate it precisely.",
+    "mathContext": "$\\text{FCET} \\ne \\varnothing \\iff \\exists n,\\ n,n+1,n+2 \\in$ A001274; and $\\text{FCET} \\subseteq \\text{CKE}\\,2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reduction of existence to nonemptiness of a nested slice",
+      "monotonicity of the CKE run-length chain",
+      "framing an open question"
+    ],
+    "prerequisites": [
+      "the run reduction (§1)",
+      "set nonemptiness and subset reasoning"
+    ]
+  },
+  {
+    "id": "ann-e1003-oq04-record",
+    "proofId": "erdos-1003-oq-04",
+    "range": {
+      "startLine": 179,
+      "endLine": 227
+    },
+    "type": "theorem",
+    "title": "The record run 5186, 5187, 5188 (native_decide)",
+    "content": "The concrete closest-known approach to a four-run. totient_5186 = totient_5187 = totient_5188 = 2592 exhibit a length-3 run, and totient_5189 = 5188 shows it breaks (5189 is prime). mem_cet_5186 and mem_cet_5187 record that 5186, 5187 are the record consecutive pair in A001274; mem_cke_two_5186 and cke_two_nonempty confirm that three consecutive equal totients DO exist (CKE 2 is nonempty), while not_mem_fcet_5186 confirms the record is NOT a four-run — so 5186 is not an OQ-04 witness. These numerical facts are discharged by native_decide, which trusts kernel/compiler evaluation of Nat.totient and therefore invokes the Lean.ofReduceBool axiom (the reason this entry is marked axiomatized); they are isolated from the axiom-free structural results in §1–§2.",
+    "mathContext": "$\\varphi(5186)=\\varphi(5187)=\\varphi(5188)=2592$, $\\varphi(5189)=5188 \\ne 2592$: a length-3 run, not a four-run.",
+    "significance": "key",
+    "relatedConcepts": [
+      "native_decide and Lean.ofReduceBool",
+      "the record consecutive pair (5186, 5187) in A001274",
+      "witnessed nonemptiness of CKE 2",
+      "no four-run below 10^15"
+    ],
+    "prerequisites": [
+      "kernel/compiler evaluation of Nat.totient",
+      "native_decide as a proof of decidable propositions",
+      "the CKE hierarchy and the four-run target"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1003-oq-04/meta.json
+++ b/src/data/proofs/erdos-1003-oq-04/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "erdos-1003-oq-04",
+  "title": "Four Consecutive Equal Totients (Erdős #1003, OQ-04): The Run-Reduction Layer",
+  "slug": "erdos-1003-oq-04",
+  "description": "Open question OQ-04 of Erdős #1003 asks whether there is an n with φ(n) = φ(n+1) = φ(n+2) = φ(n+3) — four consecutive integers of equal Euler totient. This is the k = 3 slice of Erdős's strong conjecture (arbitrarily long runs of equal consecutive totients) and is open even as an existence statement: no such n is known. This entry formalizes the honest structural layer. Its heart is the run reduction: a length-(k+1) run of equal totients starting at n is exactly a block of k consecutive members of the Erdős #1003 solution set {m | φ(m) = φ(m+1)} (OEIS A001274). Specialized to k = 3, a four-run at n is precisely the statement that n, n+1, n+2 are three consecutive members of A001274 — which explains the extreme rarity: a single consecutive pair in A001274 is already exceedingly rare, and a four-run demands a consecutive triple. The existence question is then repackaged against the CKE run-length hierarchy, and the concrete record — 5186, 5187, 5188 all with totient 2592, the longest run currently known — is verified by native_decide (which does NOT extend to a four-run: φ(5189) = 5188 ≠ 2592). The structural results (§1–§2) are machine-checked with 0 sorries and 0 axioms; the §3 record witnesses use native_decide (Lean.ofReduceBool). Does NOT resolve OQ-04.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1003OQ04.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "consecutive-integers",
+      "erdos",
+      "open-question",
+      "extension",
+      "native-decide"
+    ],
+    "badge": "axiom",
+    "axiomCount": 1,
+    "sorries": 0,
+    "lineCount": 228,
+    "theoremCount": 16,
+    "definitionCount": 4,
+    "dateAdded": "2026-07-04",
+    "assumptions": "0 sorries and 0 `axiom` declarations. The structural core (§1 run reduction, §2 existence equivalences) is fully machine-verified with only the foundational Lean axioms (propext / Classical.choice / Quot.sound). The §3 record theorems (the length-3 run 5186, 5187, 5188 and the witnessed nonemptiness cke_two_nonempty) are discharged by `native_decide`, which additionally invokes `Lean.ofReduceBool` (kernel-trusted compiler reduction of Nat.totient); counted here as axiomCount 1 (meta), while leanFile.axiomCount is 0 (no literal axiom declarations). Does NOT resolve OQ-04: existence of a four-run is genuinely open (Erdős's strong conjecture, k = 3 slice); no example is known below 10^15.",
+    "originalContributions": [
+      "mem_cke_iff_run: the telescoping backbone. Membership in CKE k (all of φ n, φ(n+1), …, φ(n+k) equal) is equivalent to the vanishing of all k consecutive differences φ(n+i) = φ(n+i+1). Proved elementarily by induction on the run length — the purely combinatorial core that turns a run of equalities into a chain of adjacent equalities.",
+      "mem_cke_iff_consecutive_cet: the run reduction (set form). n begins a length-(k+1) run of equal totients iff each of n, n+1, …, n+k-1 lies in the Erdős #1003 set ConsecutiveEqualTotients = {m | φ(m) = φ(m+1)} — i.e. a run is exactly a block of k consecutive #1003 solutions (consecutive members of A001274).",
+      "fcet_eq_cke_three and mem_fcet_iff_three_consecutive: the OQ-04 target FourConsecutiveEqualTotients is exactly the k = 3 slice CKE 3, and a four-run at n is precisely the statement that n, n+1, n+2 are three consecutive members of A001274. This is the reason four-runs are so hard to exhibit: a single consecutive pair in A001274 is already rare, and a four-run demands a consecutive triple.",
+      "fcet_nonempty_iff_cke_three_nonempty and fcet_nonempty_iff_three_consecutive_cet: OQ-04 existence, packaged against the CKE hierarchy and against A001274. The second isolates the exact arithmetic content an eventual resolution must supply — three consecutive integers n, n+1, n+2 all satisfying φ = φ(·+1).",
+      "fcet_subset_cke_two: a four-run is in particular a three-run (and a pair, and a point) — the monotonicity of the CKE run-length chain, specialized to CKE 3 ⊆ CKE 2.",
+      "The record run (native_decide, Lean.ofReduceBool): totient_5186 / totient_5187 / totient_5188 (all = 2592) and totient_5189 (= 5188, where the run breaks); mem_cet_5186 / mem_cet_5187 (5186, 5187 are the record consecutive pair in A001274); mem_cke_two_5186 and cke_two_nonempty (three consecutive equal totients DO exist — the longest known run); not_mem_fcet_5186 (the record does not extend to a four-run, so 5186 is not an OQ-04 witness)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient",
+        "description": "Euler's totient function φ. The object of the entire #1003 family; the run reduction and the record witnesses are all statements about equalities of φ on consecutive integers.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Set.mem_setOf_eq",
+        "description": "Unfolds set-builder membership. Threads the definitional identities between CKE k, ConsecutiveEqualTotients and FourConsecutiveEqualTotients through the reduction proofs.",
+        "module": "Mathlib.Data.Set.Basic"
+      },
+      {
+        "theorem": "Nat.le_of_lt / interval_cases",
+        "description": "Bounded case analysis on the run index i < k (and the explicit i ≤ 3 unfolding in fcet_eq_cke_three), the finite bookkeeping behind the telescoping reduction.",
+        "module": "Mathlib.Tactic"
+      }
+    ],
+    "prerequisites": [
+      "Euler's totient function φ (Nat.totient)",
+      "The main Erdős #1003 set {n | φ(n) = φ(n+1)} = A001274 and its conjectured infinitude (parent entry erdos-1003)",
+      "Sibling OQ-02: the nested CKE-chain reduction of the infinitude family",
+      "Erdős's strong conjecture (arbitrarily long runs of equal consecutive totients); OQ-04 is its k = 3 slice",
+      "native_decide / kernel evaluation of Nat.totient and the Lean.ofReduceBool axiom"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős #1003 asks whether there are infinitely many n with φ(n) = φ(n+1), open even in this base case. Erdős further conjectured that there are arbitrarily long runs of equal consecutive totients — for every k, infinitely many n with φ(n) = φ(n+1) = … = φ(n+k). Open question OQ-04 is the first unsettled instance of the existence half of this strong conjecture: is there even a single four-run φ(n) = φ(n+1) = φ(n+2) = φ(n+3)? None is known. The consecutive-pair set A001274 (φ(k) = φ(k+1)) is itself sparse and its only known consecutive pair up to 10^15 is (5186, 5187) (Kinlaw–Kobayashi–Pomerance 2020; McCranie, OEIS), so no four-run exists below 10^15. This entry does not exhibit a four-run; it formalizes the exact reduction that any eventual answer must engage.",
+    "problemStatement": "Is there an n with φ(n) = φ(n+1) = φ(n+2) = φ(n+3)?",
+    "text": "The entry introduces ConsecutiveEqualTotients = {n | φ(n) = φ(n+1)}, the run-length family ConsecutiveKEqualTotients k = {n | ∀ i ≤ k, φ n = φ(n+i)}, and the OQ-04 target FourConsecutiveEqualTotients. §1 proves the run reduction: CKE k membership telescopes to k adjacent equalities, hence to a block of k consecutive #1003 solutions; specialized, a four-run at n means n, n+1, n+2 are three consecutive members of A001274. §2 repackages OQ-04 existence against the CKE hierarchy and against A001274. §3 verifies, by native_decide, the concrete record run 5186, 5187, 5188 (all φ = 2592) and that it breaks at 5189, so three consecutive equal totients exist but the record is not a four-run.",
+    "proofStrategy": "The run reduction is a telescoping induction (mem_cke_iff_run): all totients in a window are equal iff every adjacent pair is equal. Unfolding set-builder membership then identifies a run with a block of consecutive #1003 solutions (mem_cke_iff_consecutive_cet), and interval_cases specializes k = 3 to the three-consecutive-A001274 form (fcet_eq_cke_three, mem_fcet_iff_three_consecutive). The existence equivalences are direct rewrites of these. The record run is a finite computation on Nat.totient discharged by native_decide.",
+    "keyInsights": [
+      "A run of equal totients is a purely local object: all of φ n, …, φ(n+k) are equal iff every adjacent pair φ(n+i), φ(n+i+1) is equal (telescoping).",
+      "Hence a four-run is exactly three consecutive members of the Erdős #1003 set A001274 — the reduction that both explains the rarity and pins the arithmetic content of OQ-04.",
+      "A single consecutive pair in A001274 is already open/rare; a four-run demands a consecutive triple, so OQ-04 is strictly harder than #1003 itself.",
+      "The record 5186, 5187, 5188 (φ = 2592) is a genuine length-3 run and shows CKE 2 is nonempty — the closest the totient is currently known to come to a four-run — but it stops at 5189 (prime), so it is not an OQ-04 witness.",
+      "The §3 record uses native_decide (Lean.ofReduceBool); the §1–§2 structural reduction is axiom-free."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the #1003 solution set (parent entry erdos-1003)",
+      "Sibling OQ-02 (the CKE nested-chain reduction of the infinitude family)",
+      "Erdős's strong conjecture on long runs of equal consecutive totients"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header — Question and Honest Scope",
+      "summary": "The block comment states OQ-04 (four consecutive integers with equal totient), records that it is open even as existence and is the k = 3 slice of Erdős's strong conjecture, cites A001274 / OEIS, and separates the axiom-free structural results (§1–§2) from the native_decide record (§3).",
+      "startLine": 1,
+      "endLine": 54,
+      "mathContext": "Is there $n$ with $\\varphi(n)=\\varphi(n+1)=\\varphi(n+2)=\\varphi(n+3)$? Open; no example known below $10^{15}$."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions — the #1003 set, the run-length family, and the OQ-04 target",
+      "summary": "ConsecutiveEqualTotients = {n | φ(n)=φ(n+1)} (A001274), ConsecutiveKEqualTotients k = {n | ∀ i ≤ k, φ n = φ(n+i)} (the run-length hierarchy), FourConsecutiveEqualTotients (the OQ-04 target), and oq04_infinitude_conjecture (the open Infinite statement). They mirror the parent #1003 entry verbatim.",
+      "startLine": 64,
+      "endLine": 85,
+      "mathContext": "$\\text{CKE}\\,k = \\{n \\mid \\forall i \\le k,\\ \\varphi(n)=\\varphi(n+i)\\}$; the OQ-04 target is the $k=3$ slice."
+    },
+    {
+      "id": "run-reduction",
+      "title": "§1 The Run Reduction — a run is a block of consecutive #1003 solutions",
+      "summary": "mem_cke_iff_run telescopes CKE k membership to the vanishing of all k adjacent differences (induction on run length). mem_cke_iff_consecutive_cet reads this as: n, …, n+k-1 all lie in A001274. fcet_eq_cke_three and mem_fcet_iff_three_consecutive specialize k = 3: a four-run at n is exactly n, n+1, n+2 being three consecutive members of A001274.",
+      "startLine": 87,
+      "endLine": 148,
+      "mathContext": "$n \\in \\text{CKE}\\,k \\iff \\forall i<k,\\ \\varphi(n+i)=\\varphi(n+i+1)$; four-run at $n \\iff n,n+1,n+2 \\in$ A001274."
+    },
+    {
+      "id": "existence",
+      "title": "§2 Existence Equivalences — OQ-04 against the hierarchy",
+      "summary": "fcet_nonempty_iff_cke_three_nonempty (existence ⇔ CKE 3 nonempty) and fcet_nonempty_iff_three_consecutive_cet (existence ⇔ A001274 has three consecutive members) package the open question; fcet_subset_cke_two records that a four-run is in particular a three-run (monotonicity of the CKE chain).",
+      "startLine": 150,
+      "endLine": 177,
+      "mathContext": "$\\text{FCET} \\ne \\varnothing \\iff \\exists n,\\ n,n+1,n+2 \\in$ A001274; $\\text{FCET} \\subseteq \\text{CKE}\\,2$."
+    },
+    {
+      "id": "record",
+      "title": "§3 The Concrete Record — a run of length three (native_decide)",
+      "summary": "totient_5186/5187/5188 = 2592 and totient_5189 = 5188 (run breaks); mem_cet_5186/5187 (the record consecutive pair in A001274); mem_cke_two_5186 and cke_two_nonempty (three consecutive equal totients exist); not_mem_fcet_5186 (the record is not a four-run). All discharged by native_decide (Lean.ofReduceBool).",
+      "startLine": 179,
+      "endLine": 227,
+      "mathContext": "$\\varphi(5186)=\\varphi(5187)=\\varphi(5188)=2592$, $\\varphi(5189)=5188$: a length-3 run, not a four-run."
+    }
+  ],
+  "conclusion": {
+    "summary": "The honest structural layer of Erdős #1003's open question OQ-04 (four consecutive equal totients). The core reduction — a length-(k+1) run of equal totients is exactly a block of k consecutive members of A001274, so a four-run is three consecutive #1003 solutions — is machine-verified with 0 sorries and 0 axioms. The concrete record (5186, 5187, 5188 all with totient 2592, the longest known run, which stops at 5189) is verified by native_decide. OQ-04 itself is not resolved: existence of a four-run is genuinely open and no example is known below 10^15.",
+    "implications": "**Frames an open question**: the run reduction pins the exact arithmetic content OQ-04 must supply (three consecutive members of A001274) and explains its difficulty relative to #1003 (a consecutive triple versus a single pair). **Connects siblings**: shares the #1003 definitions with the parent and the CKE-hierarchy view with OQ-02. **Honest scope**: no four-run is exhibited; the §3 record is a length-3 run only, and its verification relies on native_decide (Lean.ofReduceBool), disclosed as axiomatized.",
+    "openQuestions": [
+      "OQ-04 itself: exhibit a four-run φ(n) = φ(n+1) = φ(n+2) = φ(n+3), or prove none exists. By mem_fcet_iff_three_consecutive this is exactly finding (or excluding) three consecutive members of A001274 — none known below 10^15.",
+      "Formalize a verified search establishing that no four-run exists below an explicit bound (e.g. that 5186 is the least three-run), strengthening the record from a single witness to a certified minimality statement."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1003",
+      "relationship": "extends",
+      "description": "Parent entry: the #1003 solution set {n | φ(n)=φ(n+1)} and its conjectured infinitude; this entry formalizes the four-consecutive extension OQ-04 built on the same definitions."
+    },
+    {
+      "targetId": "erdos-1003-oq-02",
+      "relationship": "related",
+      "description": "Sibling: the nested CKE-chain reduction of the infinitude family. OQ-04 studies the k = 3 slice of the same run-length hierarchy from the existence side."
+    },
+    {
+      "targetId": "erdos-1003-oq-03",
+      "relationship": "related",
+      "description": "Sibling: the density layer of #1003. OQ-03 asks for the asymptotic density of the pair set A001274; OQ-04 asks whether that set contains three consecutive members (a four-run)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Set.Finite.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Set"
+    ],
+    "namespace": "Erdos1003.OQ04",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1003OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P. Erdős",
+      "title": "Erdős Problem #1003",
+      "year": "",
+      "venue": "erdosproblems.com/1003",
+      "note": "The source problem: are there infinitely many n with φ(n) = φ(n+1)? Open. Erdős further conjectured arbitrarily long runs of equal consecutive totients; OQ-04 asks for a single four-run."
+    },
+    {
+      "authors": "P. Kinlaw, M. Kobayashi, C. Pomerance",
+      "title": "On the equation φ(n) = φ(n+1)",
+      "year": "2020",
+      "venue": "Acta Arithmetica 196, 69–92",
+      "note": "Studies the consecutive-equal-totient set A001274; consistent with (5186, 5187) being the only consecutive pair up to 10^15, so no four-run below 10^15."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A001274: Numbers k such that φ(k) = φ(k+1)",
+      "year": "",
+      "venue": "oeis.org/A001274",
+      "note": "The pair set underlying the run reduction; a four-run corresponds to three consecutive members. Records the record run 5186, 5187, 5188."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1003-oq-04.json
+++ b/src/data/research/problems/erdos-1003-oq-04.json
@@ -76,14 +76,16 @@
       "OQ-04 (four consecutive equal totients) is the k=3 slice of Erdos strong conjecture; OPEN even as existence — no example known. Not a witness-hunt.",
       "KEY REDUCTION: n in CKE k <-> forall i<k, (n+i) in CET={m|phi m=phi(m+1)} (A001274). Four-run <=> three CONSECUTIVE members n,n+1,n+2 of A001274. Explains rarity: a single consecutive pair is already open/rare; four-run needs a consecutive triple.",
       "Computational (this session): NO four-run below 10^8 (numpy totient sieve); only ONE three-run below 10^8, at 5186 (phi=2592). Literature (Kinlaw-Kobayashi-Pomerance 2020; Resta; McCranie, OEIS A001274): (5186,5187) is the ONLY consecutive pair in A001274 up to 10^15 => no four-run below 10^15.",
-      "Record run 5186,5187,5188 all phi=2592 (5186=2*2593, 5187=3*7*13*19, 5188=2^2*1297); breaks at 5189 (prime, phi=5188)."
+      "Record run 5186,5187,5188 all phi=2592 (5186=2*2593, 5187=3*7*13*19, 5188=2^2*1297); breaks at 5189 (prime, phi=5188).",
+      "Convention: galleried #1003 OQ siblings are pool-status completed even though the underlying existence/density questions stay open — the deliverable is the verified formalization + gallery entry, not resolving the conjecture."
     ],
     "builtItems": [
       "mem_cke_iff_run (0-axiom): n in CKE k <-> forall i<k, phi(n+i)=phi(n+i+1). Erdos1003OQ04.lean",
       "mem_cke_iff_consecutive_cet (0-axiom): run = block of k consecutive #1003 solutions. Erdos1003OQ04.lean",
       "mem_fcet_iff_three_consecutive (0-axiom): four-run at n <=> n,n+1,n+2 in A001274. Erdos1003OQ04.lean",
       "fcet_eq_cke_three / fcet_nonempty_iff_cke_three_nonempty / fcet_nonempty_iff_three_consecutive_cet / fcet_subset_cke_two (0-axiom): existence packaged against CKE hierarchy. Erdos1003OQ04.lean",
-      "Record witness (native_decide, Lean.ofReduceBool): mem_cke_two_5186, not_mem_fcet_5186, totient_5186/7/8/9, cke_two_nonempty. Erdos1003OQ04.lean"
+      "Record witness (native_decide, Lean.ofReduceBool): mem_cke_two_5186, not_mem_fcet_5186, totient_5186/7/8/9, cke_two_nonempty. Erdos1003OQ04.lean",
+      "Gallery entry created (PR #34698): src/data/proofs/erdos-1003-oq-04/{meta.json,annotations.json}. Was ungalleried while siblings OQ-02/OQ-03 had entries. status=axiomatized/badge=axiom/axiomCount=1 (native_decide record uses Lean.ofReduceBool); leanFile.axiomCount=0. 5 annotations validate clean."
     ],
     "mathlibGaps": [
       "Mathlib has Nat.totient but no runs-of-equal-totients theory; the run<->consecutive-#1003-solutions reduction built from scratch."
@@ -92,6 +94,6 @@
       "Existence of a four-run is genuinely open (Erdos). Any resolution reduces (mem_fcet_iff_three_consecutive) to three consecutive A001274 members — none known below 10^15.",
       "Optional: unify with sibling OQ-02 CKE-hierarchy file (currently self-contained re-definitions)."
     ],
-    "progressSummary": "PROGRESS (structural, honest): OQ-04 four-consecutive-equal-totients is OPEN even as existence (Erdos strong conjecture k=3). Formalized run-reduction (four-run <=> three consecutive A001274 members) + existence equivalences, 0-axiom, plus the record length-3 run at 5186 (native_decide). No four-run below 10^15 (computation + literature). Erdos1003OQ04.lean builds (docker)."
+    "progressSummary": "COMPLETE (galleried): structural run-reduction layer verified on main (PR #34685) and now presented in the gallery (PR #34698). OQ-04 existence itself remains OPEN (Erdős strong conjecture k=3)."
   }
 }


### PR DESCRIPTION
## Summary

`Erdos1003OQ04.lean` was merged to `main` an hour ago (PR #34685) but had **no gallery entry**, while its siblings `erdos-1003-oq-02` and `erdos-1003-oq-03` both do. This fills that gap so the verified proof is actually presented in the gallery.

Adds `src/data/proofs/erdos-1003-oq-04/`:
- `meta.json` — full entry (description, overview, 5 sections, conclusion, cross-references to parent #1003 and siblings OQ-02/OQ-03, references)
- `annotations.json` — 5 annotations, one per section

No Lean or index files touched; `listings.json` / `data-manifest.json` are regenerated by the deployer's `research:sync`.

## The proof (already on main)

OQ-04 asks whether there is an `n` with `φ(n) = φ(n+1) = φ(n+2) = φ(n+3)` — the k=3 slice of Erdős's strong conjecture, **open even as existence** (no example known below 10¹⁵).

- **§1 Run reduction** (0-axiom): a length-(k+1) run of equal totients is exactly a block of `k` consecutive members of the #1003 set A001274; specialized, a four-run at `n` ⟺ `n, n+1, n+2` are three consecutive members of A001274.
- **§2 Existence equivalences** (0-axiom): OQ-04 packaged against the CKE hierarchy and against A001274.
- **§3 Record** (`native_decide`): the length-3 run `5186, 5187, 5188` (all φ = 2592), which breaks at 5189 — the longest known run, but **not** a four-run.

16 theorems, 4 definitions, 228 lines, 0 sorries.

## Honest axiom accounting

Per the Axiom Integrity Policy: the §3 record witnesses (incl. `cke_two_nonempty`) are discharged by `native_decide`, which invokes `Lean.ofReduceBool`. This is a substantive presented-as-verified result, so the entry is:
- `status: "axiomatized"`, `badge: "axiom"`, `meta.axiomCount: 1` (discloses `Lean.ofReduceBool` in `assumptions`)
- `leanFile.axiomCount: 0` (no literal `axiom` declarations)

The structural core (§1–§2) is axiom-free. The entry does **not** claim to resolve OQ-04.

## Validation

`pnpm annotations:validate` reports **0 errors for this entry** (all 5 annotation ranges resolve to Lean constructs). Meta modeled on the sibling OQ-03 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)