### PR TITLE
Konigsberg OQ02OQ01OQ02OQ01: verify Hierholzer 'maximal trail is closed' core (0-axiom)

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -139,4 +139,22 @@ theorem eq_of_isTrail_edgeMaximal
   obtain ⟨e, hmem, hnot⟩ := exists_unused_incident_edge_at_endpoint hp hne heven
   exact hnot (hmax e hmem)
 
+/-- **A closed trail uses an even number of edges incident to every vertex.**
+For a *closed* trail `p : G.Walk u u`, the number of edges of `p` incident to any
+vertex `x` is even. This is the parity ingredient of Hierholzer's edge-removal step
+(Sub-lemma B): deleting a closed trail's edges changes each vertex's degree by an even
+amount, so the "every vertex has even degree" invariant survives the induction.
+
+The proof specializes `SimpleGraph.Walk.IsTrail.even_countP_edges_iff` at a closed
+trail: its right-hand side `(u ≠ u → x ≠ u ∧ x ≠ u)` is vacuously true because
+`u ≠ u` is false, so the incident-edge count is even with no hypothesis on `x`.
+Contrast `exists_unused_incident_edge_at_endpoint`, where the *open* case (`u ≠ v`)
+forces the count at `v` to be odd. -/
+theorem even_countP_edges_of_closed
+    {u : V} {p : G.Walk u u} (hp : p.IsTrail) (x : V) :
+    Even (p.edges.countP (fun e => x ∈ e)) := by
+  rw [hp.even_countP_edges_iff]
+  intro huu
+  exact absurd rfl huu
+
 end UndirectedEulerDev

--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -44,4 +44,27 @@ theorem euler_circuit_of_edgeSet_empty
   rw [hE] at he
   exact absurd he (Set.notMem_empty e)
 
+/-- **Hierholzer's continuation invariant.**
+In a *nontrivial* connected simple graph in which every vertex has even degree, every
+vertex has degree at least `2`.
+
+This is the structural fact underpinning the "a maximal trail is closed" step of the
+undirected Hierholzer induction. When a trail arrives at a vertex `v ≠ start` it has
+used an *odd* number of `v`'s incident edges (one on each earlier visit plus the edge
+just traversed); since `G.degree v` is even there is always an unused incident edge to
+continue along, so a trail can only get *stuck* — become maximal — back at its start
+vertex, i.e. it is closed. The `2 ≤ G.degree v` bound below is the base quantitative
+form of that parity slack: a positive even number is at least `2`.
+
+`Nontrivial V` is necessary: the one-vertex connected graph has `G.degree v = 0`. In
+the induction this hypothesis holds in exactly the inductive (edge-containing) case;
+the edgeless base case is handled by `euler_circuit_of_edgeSet_empty` above. -/
+theorem two_le_degree_of_even_of_connected
+    [Fintype V] [DecidableRel G.Adj] [Nontrivial V]
+    (hconn : G.Connected) (heven : ∀ v, Even (G.degree v)) (v : V) :
+    2 ≤ G.degree v := by
+  have hpos : 0 < G.degree v := hconn.preconnected.degree_pos_of_nontrivial v
+  obtain ⟨k, hk⟩ := heven v
+  omega
+
 end UndirectedEulerDev

--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -67,4 +67,76 @@ theorem two_le_degree_of_even_of_connected
   obtain ⟨k, hk⟩ := heven v
   omega
 
+/-- **A trail into an even-degree vertex, from a different start, has an unused
+incident edge.**
+Let `p : G.Walk u v` be a trail with `u ≠ v` and `Even (G.degree v)`. Then some edge
+incident to `v` is *not* used by `p`. This is the quantitative heart of Hierholzer's
+"a maximal trail is closed" step: while a trail sits at a non-start vertex `v`, it has
+consumed an **odd** number of `v`'s incident edges (`IsTrail.even_countP_edges_iff`),
+but `v` has an **even** number in total, so an unused one always remains to extend
+along. -/
+theorem exists_unused_incident_edge_at_endpoint
+    [Fintype V] [DecidableRel G.Adj]
+    {u v : V} {p : G.Walk u v} (hp : p.IsTrail) (hne : u ≠ v)
+    (heven : Even (G.degree v)) :
+    ∃ e ∈ G.incidenceFinset v, e ∉ p.edges := by
+  classical
+  -- The walk-edges incident to `v`, as a nodup list.
+  set L : List (Sym2 V) := p.edges.filter (fun e => v ∈ e) with hLdef
+  have hpnodup : p.edges.Nodup := hp.edges_nodup
+  have hLnodup : L.Nodup := hpnodup.filter _
+  -- Their number is odd, by the trail parity invariant applied at `x = v`.
+  have hcountodd : Odd (p.edges.countP (fun e => v ∈ e)) := by
+    rw [← Nat.not_even_iff_odd, hp.even_countP_edges_iff]
+    intro h
+    exact (h hne).2 rfl
+  have hLlen : L.length = p.edges.countP (fun e => v ∈ e) := by
+    rw [hLdef]; exact List.countP_eq_length_filter.symm
+  have hLcard : L.toFinset.card = L.length := List.toFinset_card_of_nodup hLnodup
+  have hLcardodd : Odd L.toFinset.card := by rw [hLcard, hLlen]; exact hcountodd
+  -- Used incident edges sit inside the incidence finset of `v`.
+  have hsub : L.toFinset ⊆ G.incidenceFinset v := by
+    intro e he
+    rw [List.mem_toFinset, hLdef, List.mem_filter] at he
+    obtain ⟨hmem, hv⟩ := he
+    have hv' : v ∈ e := by simpa using hv
+    rw [SimpleGraph.mem_incidenceFinset]
+    exact ⟨p.edges_subset_edgeSet hmem, hv'⟩
+  -- Total incident edges = degree, which is even.
+  have hAcard : (G.incidenceFinset v).card = G.degree v := G.card_incidenceFinset_eq_degree v
+  have hAeven : Even (G.incidenceFinset v).card := by rw [hAcard]; exact heven
+  -- Different parities ⇒ the used set is a *proper* subset.
+  have hne_sets : L.toFinset ≠ G.incidenceFinset v := by
+    intro hEq
+    rw [hEq] at hLcardodd
+    exact (Nat.not_even_iff_odd.mpr hLcardodd) hAeven
+  have hss : L.toFinset ⊂ G.incidenceFinset v :=
+    (Finset.ssubset_iff_subset_ne).mpr ⟨hsub, hne_sets⟩
+  obtain ⟨e, heIn, heOut⟩ := Finset.exists_of_ssubset hss
+  refine ⟨e, heIn, ?_⟩
+  -- If `e` were used, it would be a used incident edge, i.e. in `L.toFinset`.
+  intro hused
+  apply heOut
+  have hv : v ∈ e := by
+    rw [SimpleGraph.mem_incidenceFinset] at heIn
+    exact heIn.2
+  rw [List.mem_toFinset, hLdef, List.mem_filter]
+  exact ⟨hused, by simpa using hv⟩
+
+/-- **A maximal trail is closed (undirected Hierholzer core).**
+If `p : G.Walk u v` is a trail, every vertex has even degree, and `v` is *edge-maximal*
+— every edge incident to `v` is already used by `p` — then `p` is closed: `u = v`.
+Contrapositive of `exists_unused_incident_edge_at_endpoint`: a trail can only get stuck
+back at its start. This is the step that turns "grow a trail greedily" into "obtain a
+closed circuit," the inductive engine of Hierholzer's construction. -/
+theorem eq_of_isTrail_edgeMaximal
+    [Fintype V] [DecidableRel G.Adj]
+    {u v : V} {p : G.Walk u v} (hp : p.IsTrail)
+    (heven : Even (G.degree v))
+    (hmax : ∀ e ∈ G.incidenceFinset v, e ∈ p.edges) :
+    u = v := by
+  by_contra hne
+  obtain ⟨e, hmem, hnot⟩ := exists_unused_incident_edge_at_endpoint hp hne heven
+  exact hnot (hmax e hmem)
+
 end UndirectedEulerDev

--- a/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -85,3 +85,56 @@ Insights accumulated during research on this problem.
 - Sub-lemma C: splice residual circuit via shared vertex; strong induction on
   `edgeFinset.card` using the verified base case.
 - Resubmit the single sorry to Aristotle once the backend recovers.
+
+## Session 2026-07-04 (Session 3) — Sub-lemma A VERIFIED (maximal trail is closed)
+
+**Mode**: REVISIT (depth line) | **Outcome**: progress (2 lemmas VERIFIED, 0 sorries)
+
+### What I Did
+- Wrote the parity core of **Sub-lemma A** ("a maximal trail is closed") natively in
+  the `SimpleGraph.Walk` API, leveraging Mathlib's necessity-direction engine
+  `SimpleGraph.Walk.IsTrail.even_countP_edges_iff` (the same lemma behind
+  `IsEulerian.even_degree_iff`). Two new lemmas in the Dev file:
+  - `exists_unused_incident_edge_at_endpoint` — a trail `p : G.Walk u v` with `u ≠ v`
+    and `Even (G.degree v)` always has an edge incident to `v` that it has NOT used.
+  - `eq_of_isTrail_edgeMaximal` — contrapositive: a trail that is edge-maximal at `v`
+    (every incident edge used) in an even-degree graph must be closed (`u = v`).
+- Verified Aristotle is STILL down (7th consecutive session): inline `2+2=4` returns
+  `Resource not found`.
+
+### Proof idea (machine-checked, docker build clean)
+- `IsTrail.even_countP_edges_iff` at `x = v` gives: the number of `p`-edges incident
+  to `v` is EVEN iff `(u ≠ v → v ≠ u ∧ v ≠ v)`. Since `v ≠ v` is false, with `u ≠ v`
+  the count is ODD.
+- `G.card_incidenceFinset_eq_degree` + `heven` gives EVEN total incident edges.
+- Used-incident edges (nodup, via `IsTrail.edges_nodup`) form a subFinset of
+  `G.incidenceFinset v`; odd `<` even ⇒ proper subset ⇒ a witness incident edge is
+  unused. `Finset.ssubset_iff_subset_ne` + `Finset.exists_of_ssubset`.
+
+### Environmental turbulence overcome (recorded for future sessions)
+- Host disk hit **100% full** (3.3Gi free) mid-build → Docker daemon crashed with
+  containerd metadata I/O errors. Space recovered to ~30-38Gi on its own after the
+  aborted-build temp data was cleaned up.
+- The shared `lean-mathlib-packages` docker volume threw `could not resolve 'HEAD'`
+  — a **concurrency race** (my read collided with another agent's re-resolve write on
+  the shared volume), NOT permanent corruption. Do NOT force-remove the volume; just
+  WAIT until `docker ps` shows no `lean-build*` container, then rebuild. Worked.
+- Lemma-name fixes applied during verification: `Nat.odd_iff_not_even` →
+  `Nat.not_even_iff_odd`; `List.countP_eq_length_filter` takes implicit args (no
+  `_ _`). All other guessed names (`IsTrail.edges_nodup`, `List.Nodup.filter`,
+  `List.toFinset_card_of_nodup`, `SimpleGraph.mem_incidenceFinset`,
+  `card_incidenceFinset_eq_degree`, `Finset.ssubset_iff_subset_ne`,
+  `Finset.exists_of_ssubset`) were CORRECT.
+- Net: the 2 new lemmas BUILD CLEAN (0 sorries). One pre-existing cosmetic
+  linter warning on `two_le_degree_of_even_of_connected` (unused `[DecidableEq V]`)
+  remains — harmless, from Session 2.
+
+### Files Modified
+- proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (2 lemmas added — VERIFIED)
+- research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
+
+### Next Steps
+- Sub-lemma B: `G.deleteEdges (closed-trail edges)` preserves `∀ v, Even (degree v)`.
+- Sub-lemma C: splice residual circuit via shared vertex; strong induction on
+  `edgeFinset.card` off the verified base case.
+- Resubmit the single main-theorem sorry to Aristotle once the backend recovers.

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -29,10 +29,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: base case of undirected Hierholzer induction VERIFIED (euler_circuit_of_edgeSet_empty, 0 sorries, in ...Dev.lean). Corrected key fact: IsEulerian = (∀ e ∈ edgeSet, count e = 1), trail derived. Directed Digraph template confirmed NON-reusable. Mathlib confirmed lacking sufficiency. Aristotle backend down this session. Remaining: inductive step (sub-lemmas A maximal-trail-closed, B edge-removal-preserves-even, C splice) — the ~600-1000 line core.",
+    "progressSummary": "PROGRESS: Hierholzer base case + continuation invariant + Sub-lemma A (maximal trail is closed) all VERIFIED; remaining: edge-removal preserves even-degree (B), splice+induction (C).",
     "builtItems": [
       "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning).",
-      "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries."
+      "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries.",
+      "exists_unused_incident_edge_at_endpoint + eq_of_isTrail_edgeMaximal (Sub-lemma A: a maximal trail is closed) — VERIFIED 0 sorries in KonigsbergOQ02OQ01OQ02OQ01Dev.lean"
     ],
     "insights": [
       "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
@@ -42,7 +43,8 @@
       "IsEulerian is defined in Mathlib as (∀ e ∈ G.edgeSet, p.edges.count e = 1) — NOT (IsTrail ∧ covers all edges). Trail-ness is a DERIVED consequence (IsEulerian.isTrail). The construction invariant to maintain is therefore the per-edge count=1 condition; this corrects the earlier plan framing.",
       "Confirmed (web search + local check): Mathlib4 Trails module has only the necessity/property lemmas (IsEulerian.even_degree_iff, IsEulerian.card_odd_degree). No Eulerian existence/Hierholzer construction exists upstream, so sufficiency must be built natively.",
       "The directed Digraph proof in KonigsbergOQ02OQ01.lean is NOT reusable: it is built on a bespoke Digraph structure with its own Walk/splice/removeArcList/arcCount — none are SimpleGraph.Walk objects. A native SimpleGraph mirror is required.",
-      "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target)."
+      "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target).",
+      "Sub-lemma A reduces to Mathlib IsTrail.even_countP_edges_iff: p-edges incident to a non-start vertex v number ODD, total incident = degree is EVEN, so an unused incident edge always exists (proper-subset parity argument)."
     ],
     "mathlibGaps": [
       "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."


### PR DESCRIPTION
## Summary

Adds the **parity core of undirected Hierholzer's construction** — "a maximal trail is closed" plus the edge-removal parity ingredient — natively in the `SimpleGraph.Walk` API, as verified supporting lemmas for the open problem `konigsberg-oq-02-oq-01-oq-02-oq-01` (Euler's theorem sufficiency direction).

Four new theorems in `KonigsbergOQ02OQ01OQ02OQ01Dev.lean` (0 sorries, 0 axioms):

- **`two_le_degree_of_even_of_connected`** — in a nontrivial connected even-degree graph, every vertex has degree ≥ 2 (positive even ⇒ ≥ 2). The base quantitative form of the parity slack.
- **`exists_unused_incident_edge_at_endpoint`** — a trail `p : G.Walk u v` with `u ≠ v` and `Even (G.degree v)` always has an edge incident to `v` it has *not* used. The quantitative heart: a trail at a non-start vertex has consumed an **odd** number of incident edges (`IsTrail.even_countP_edges_iff`), but `v` has an **even** total, so an unused one always remains.
- **`eq_of_isTrail_edgeMaximal`** — contrapositive: an edge-maximal trail in an even-degree graph must be closed (`u = v`). This is the inductive engine turning "grow a trail greedily" into "obtain a closed circuit."
- **`even_countP_edges_of_closed`** — Sub-lemma B parity ingredient: a *closed* trail `p : G.Walk u u` uses an **even** number of edges incident to *every* vertex `x`. Specializes `IsTrail.even_countP_edges_iff` at a closed trail, whose RHS `(u ≠ u → …)` is vacuously true. This is why deleting a closed trail's edges changes each vertex's degree by an even amount, so the all-even-degree invariant survives the induction.

## Verification

Docker build clean: `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ02OQ01OQ02OQ01Dev` → **3076 jobs, exit 0**, no errors. Only one pre-existing cosmetic linter warning (unused `[DecidableEq V]` section variable). Proofs use only standard Mathlib (`IsTrail.even_countP_edges_iff`, `card_incidenceFinset_eq_degree`, `Finset.ssubset_iff_subset_ne`, `Finset.exists_of_ssubset`) — **0-axiom, 0-sorry**.

## Context

Re-opened after PR #34697 was auto-closed as "superseded" by the deployer's race-cleanup heuristic. That heuristic misfired: the *main* proof file was already on `main` (identical), but these theorems live only in the `Dev` scratch file and are unique. This branch is rebased cleanly onto current `main`.

Remaining frontier: Sub-lemma B completion (`deleteEdges` preserves even-degree, using `even_countP_edges_of_closed`) and Sub-lemma C (splice residual circuit) toward discharging the single main-theorem sorry.
