### PR TITLE
Enrich Navier-Stokes OQ-01-OQ-01: +2 cross-references (AM-GM, Cauchy-Schwarz)

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01-oq-01/meta.json
@@ -124,7 +124,9 @@
     ]
   },
   "crossReferences": [
-    "navier-stokes-oq-01"
+    "navier-stokes-oq-01",
+    "amgm-inequality",
+    "cauchy-schwarz"
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment pass for `navier-stokes-oq-01-oq-01` (2D Ladyzhenskaya interpolation, algebraic assembly).

**Change:** `crossReferences` 1 → 3 — added the two inequalities that are the load-bearing techniques of this proof:

- **`amgm-inequality`** (Arithmetic Mean – Geometric Mean Inequality) — the sharp AM–GM step `cross_le_grad_sq` (`d1·d2 ≤ ½(d1²+d2²)`, sharp at `d1=d2`) is the single inequality that fixes the optimal Ladyzhenskaya constant `C = 2^{1/4}`; it is named explicitly in the description and key insights.
- **`cauchy-schwarz`** (Cauchy-Schwarz Inequality) — the two slice estimates `a ≤ n2·d1`, `b ≤ n2·d2` that form part (A) of the classical proof are Cauchy–Schwarz slicing bounds.

Both targets are existing gallery base entries verified present on `main`. Meta-only, purely additive; no other fields touched. Well under the size cap (~17 KB).
