### PR TITLE
Enrich PAC/VC Monotonicity (pac-learning-bounds-wip-01-oq-01): +4 canonical references

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/meta.json
@@ -145,6 +145,34 @@
       "year": "1971",
       "venue": "Theory Probab. Appl.",
       "note": "Origin of VC dimension and shattering"
+    },
+    {
+      "authors": "L. G. Valiant",
+      "title": "A theory of the learnable",
+      "year": "1984",
+      "venue": "Communications of the ACM 27(11)",
+      "note": "Introduces the PAC (probably approximately correct) learning framework that VC dimension quantifies"
+    },
+    {
+      "authors": "A. Blumer, A. Ehrenfeucht, D. Haussler, M. K. Warmuth",
+      "title": "Learnability and the Vapnik-Chervonenkis dimension",
+      "year": "1989",
+      "venue": "Journal of the ACM 36(4)",
+      "note": "Establishes finite VC dimension as the characterization of PAC-learnability; source of the VC-dimension sample-complexity bounds"
+    },
+    {
+      "authors": "N. Sauer",
+      "title": "On the density of families of sets",
+      "year": "1972",
+      "venue": "Journal of Combinatorial Theory, Series A 13",
+      "note": "Sauer-Shelah lemma: the growth function of a class is polynomial of degree its VC dimension — the combinatorial core behind VC bounds"
+    },
+    {
+      "authors": "S. Shalev-Shwartz, S. Ben-David",
+      "title": "Understanding Machine Learning: From Theory to Algorithms",
+      "year": "2014",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference where VC-dimension monotonicity under hypothesis-class inclusion appears as a basic structural fact"
     }
   ],
   "sorries": [],


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-wip-01-oq-01` (Monotonicity of the VC Dimension).

**Change:** `references` 1 → 5. The entry cited only the founding Vapnik–Chervonenkis (1971) paper; added the four canonical references that give a reader the full VC-dimension / PAC-learning context this result sits in:

- **Valiant (1984)** — introduces the PAC framework that VC dimension quantifies.
- **Blumer, Ehrenfeucht, Haussler, Warmuth (1989)** — finite VC dimension characterizes PAC-learnability; source of the VC sample-complexity bounds.
- **Sauer (1972)** — Sauer–Shelah lemma, the combinatorial core (growth function polynomial of degree = VC dim) behind those bounds.
- **Shalev-Shwartz & Ben-David (2014)** — standard textbook where VC-dimension monotonicity under class inclusion appears as a basic structural fact (exactly this entry's theorem).

All four are genuine, load-bearing references verified accurate. Meta-only, purely additive; no other fields touched. ~14.7 KB, well under the size cap; references count 5 ≤ 25 cap.
