### PR TITLE
Enrich abel-ruffini-oq-06: mainTheorems 0->3 + fix duplicate references key

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06/meta.json
@@ -104,57 +104,6 @@
       "Package the full equivalence 'IsSolvable (Equiv.Perm (Fin n)) ⟺ n ≤ 4' as a single theorem once n = 4 is closed, combining this file's positive instances with the uniform n ≥ 5 non-solvability."
     ]
   },
-  "references": [
-    {
-      "authors": "Galois, Évariste",
-      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
-      "year": "1846",
-      "venue": "Journal de Mathématiques Pures et Appliquées, vol. 11",
-      "note": "The origin of the notion of a solvable group: Galois showed an equation is solvable by radicals iff its group admits a chain of normal subgroups with abelian (prime-cyclic) successive quotients — exactly the structure this file transfers along the sign exact sequence 1 → Aₙ → Sₙ → ℤˣ."
-    },
-    {
-      "authors": "Jordan, Camille",
-      "title": "Traité des substitutions et des équations algébriques",
-      "year": "1870",
-      "venue": "Gauthier-Villars, Paris",
-      "note": "The first systematic theory of composition series and solvable permutation groups, and the source of the Jordan–Hölder framework underlying the claim that Sₙ is solvable exactly for n ≤ 4."
-    },
-    {
-      "authors": "Dummit, David S.; Foote, Richard M.",
-      "title": "Abstract Algebra (3rd ed.)",
-      "year": "2004",
-      "venue": "John Wiley & Sons",
-      "note": "Standard graduate reference. §3.4 and §6.1 prove Sₙ is solvable iff n ≤ 4, including the small-case tower A₄ ⊳ V₄ ⊳ 1 and the reduction of solvability of Sₙ to that of Aₙ via the index-2 sign subgroup used here."
-    },
-    {
-      "authors": "Rotman, Joseph J.",
-      "title": "An Introduction to the Theory of Groups (4th ed.)",
-      "year": "1995",
-      "venue": "Springer GTM 148",
-      "note": "Develops solvable series, the extension property 'solvable is closed under extensions' (the abstract form of Mathlib's solvable_of_ker_le_range), and the solvability of S₂, S₃, S₄ from that of their alternating subgroups."
-    },
-    {
-      "authors": "Isaacs, I. Martin",
-      "title": "Finite Group Theory",
-      "year": "2008",
-      "venue": "American Mathematical Society, GSM 92",
-      "note": "Detailed treatment of solvable groups and their closure under subgroups, quotients, and extensions — the closure properties that make the Aₙ ↪ Sₙ ↠ ℤˣ short exact sequence yield Sₙ solvable from Aₙ solvable."
-    },
-    {
-      "authors": "Stewart, Ian",
-      "title": "Galois Theory (4th ed.)",
-      "year": "2015",
-      "venue": "CRC Press / Chapman & Hall",
-      "note": "Accessible account tying the group-theoretic threshold to solvability of polynomials, with explicit verification that S₂, S₃, S₄ are solvable (enabling the quadratic, Cardano, and Ferrari formulas) while S₅ is not."
-    },
-    {
-      "authors": "The mathlib Community",
-      "title": "Mathlib.GroupTheory.Solvable and Mathlib.GroupTheory.SpecificGroups.Alternating",
-      "year": "2024",
-      "venue": "Lean 4 mathematical library (mathlib4)",
-      "note": "Source of the building blocks: solvable_of_ker_le_range (solvability under extensions), alternatingGroup_eq_sign_ker (Aₙ = ker sign), nat_card_alternatingGroup (|Aₙ| = n!/2), and Equiv.Perm.fin_5_not_solvable for the complementary non-solvable side."
-    }
-  ],
   "crossReferences": [
     {
       "targetId": "abel-ruffini-obstruction-oq-06",
@@ -216,6 +165,26 @@
       "year": "2020",
       "venue": "Proceedings of CPP 2020, pp. 367–381 (ACM)",
       "note": "Source of the reused lemmas solvable_of_ker_le_range, alternatingGroup_eq_sign_ker, nat_card_alternatingGroup, and the negative instance Equiv.Perm.fin_5_not_solvable; the positive instances IsSolvable (Equiv.Perm (Fin n)) for n ∈ {2,3} are not in Mathlib and are contributed by this file."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "permSolvable_of_alternatingSolvable",
+      "type": "key",
+      "description": "Reduction lemma: Sₙ is solvable whenever the alternating group Aₙ is. Since Aₙ = ker(sign) is normal in Sₙ with abelian quotient (Sₙ/Aₙ ↪ ℤˣ), the short exact sequence 1 → Aₙ → Sₙ → ℤˣ makes Sₙ a solvable-by-solvable extension via solvable_of_ker_le_range. This reusable core is not packaged by Mathlib.",
+      "leanType": "(n : ℕ) [IsSolvable (alternatingGroup (Fin n))] : IsSolvable (Equiv.Perm (Fin n))"
+    },
+    {
+      "name": "permFinThree_isSolvable",
+      "type": "key",
+      "description": "S₃ = Equiv.Perm (Fin 3) is solvable — the n = 3 case of the solvable side of the Abel–Ruffini threshold. A₃ has prime order 3, hence is cyclic (isCyclic_of_prime_card), hence abelian, hence solvable; the reduction then lifts solvability to S₃.",
+      "leanType": "IsSolvable (Equiv.Perm (Fin 3))"
+    },
+    {
+      "name": "permFinTwo_isSolvable",
+      "type": "supporting",
+      "description": "S₂ = Equiv.Perm (Fin 2) is solvable, re-derived through the same uniform reduction (A₂ is trivial of order 1), showing the reduction subsumes the abelian endpoint.",
+      "leanType": "IsSolvable (Equiv.Perm (Fin 2))"
     }
   ]
 }


### PR DESCRIPTION
Enrichment + correctness fix for `abel-ruffini-oq-06` (solvable side of the Sₙ threshold).

**1. Added `mainTheorems` 0 → 3** — the entry had no `mainTheorems` array; the gallery's "Main Theorems" section was empty. Populated with the three `theorem` declarations of `Proofs/AbelRuffiniOQ06.lean`, exact names and Lean types verified against the source:
- `permSolvable_of_alternatingSolvable` (key) — the reusable Aₙ-solvable ⟹ Sₙ-solvable reduction via `solvable_of_ker_le_range`.
- `permFinThree_isSolvable` (key) — S₃ solvable (A₃ prime-order ⟹ cyclic ⟹ abelian).
- `permFinTwo_isSolvable` (supporting) — S₂ solvable through the same reduction.

**2. Fixed a duplicate-`references`-key JSON bug** — the file declared the `references` key **twice** (two 7-entry blocks). Under `JSON.parse` (and `jq`/node) the first block was silently shadowed and never rendered; only the second (Ruffini 1799 / Abel 1826 / Galois / Rotman / Dummit–Foote / Stewart / Mathlib-CPP) was live. Removed the dead first block so the object is valid JSON with a single `references` key. **This is a no-op for rendered content** — the live reference set is unchanged (still 7).

Note: the removed dead block uniquely contained Jordan (1870, *Traité des substitutions*) and Isaacs (*Finite Group Theory*); they were already invisible on the live site. They can be merged into the live `references` in a follow-up if desired.

Meta-only; validated with `node`/`jq` (parses, 7 refs, 3 mainTheorems). ~16.7 KB, well under the size cap.
