### PR TITLE
Research: konigsberg undirected Hierholzer — recover Sub-lemma A + prove Sub-lemma B parity core

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean
@@ -1,5 +1,5 @@
 /-
-# Undirected Hierholzer — development scaffolding (base case)
+# Undirected Hierholzer — development scaffolding
 
 Companion development file for `KonigsbergOQ02OQ01OQ02OQ01.lean`, whose main
 theorem `undirected_euler_circuit_sufficient` (the undirected Hierholzer
@@ -14,10 +14,23 @@ here: it is built on a bespoke `Digraph` structure with its own `Walk`, `splice`
 `removeArcList` and `arcCount`, none of which are `SimpleGraph.Walk` objects.
 
 The standard proof is strong induction on `G.edgeFinset.card`. This file discharges
-the **base case** natively (0 edges ⇒ the trivial `nil` walk is Eulerian); the
-remaining inductive core (a maximal trail is closed, edge-removal preserves the
-all-even-degree invariant, and connectivity lets residual circuits splice in) is the
-~600–1000 line classical construction still to be built or delegated.
+the following pieces natively (0 sorries):
+
+* **Base case** (`euler_circuit_of_edgeSet_empty`): 0 edges ⇒ the trivial `nil`
+  walk is Eulerian.
+* **Continuation invariant** (`two_le_degree_of_even_of_connected`): in a nontrivial
+  connected even-degree graph every vertex has degree ≥ 2.
+* **Sub-lemma A** (`exists_unused_incident_edge_at_endpoint`,
+  `eq_of_isTrail_edgeMaximal`): a maximal trail is closed — a trail can only get
+  stuck back at its start vertex.
+* **Sub-lemma B parity core** (`even_countP_incident_of_closed_trail`): a *closed*
+  trail uses an even number of the edges incident to every vertex. This is the fact
+  that makes edge-removal preserve the all-even-degree invariant (even total minus
+  even used = even residual).
+
+Still to build/delegate: the full Sub-lemma B degree bookkeeping
+(`(G.deleteEdges ↑p.edges.toFinset).degree w` is even for a closed trail `p`), the
+splice through a shared vertex, and the strong induction assembling these.
 -/
 import Mathlib.Combinatorics.SimpleGraph.Trails
 import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
@@ -43,5 +56,118 @@ theorem euler_circuit_of_edgeSet_empty
   intro e he
   rw [hE] at he
   exact absurd he (Set.notMem_empty e)
+
+/-- **Hierholzer's continuation invariant.**
+In a *nontrivial* connected simple graph in which every vertex has even degree, every
+vertex has degree at least `2`.
+
+This is the structural fact underpinning the "a maximal trail is closed" step of the
+undirected Hierholzer induction. When a trail arrives at a vertex `v ≠ start` it has
+used an *odd* number of `v`'s incident edges (one on each earlier visit plus the edge
+just traversed); since `G.degree v` is even there is always an unused incident edge to
+continue along, so a trail can only get *stuck* — become maximal — back at its start
+vertex, i.e. it is closed. The `2 ≤ G.degree v` bound below is the base quantitative
+form of that parity slack: a positive even number is at least `2`.
+
+`Nontrivial V` is necessary: the one-vertex connected graph has `G.degree v = 0`. In
+the induction this hypothesis holds in exactly the inductive (edge-containing) case;
+the edgeless base case is handled by `euler_circuit_of_edgeSet_empty` above. -/
+theorem two_le_degree_of_even_of_connected
+    [Fintype V] [DecidableRel G.Adj] [Nontrivial V]
+    (hconn : G.Connected) (heven : ∀ v, Even (G.degree v)) (v : V) :
+    2 ≤ G.degree v := by
+  have hpos : 0 < G.degree v := hconn.preconnected.degree_pos_of_nontrivial v
+  obtain ⟨k, hk⟩ := heven v
+  omega
+
+/-- **A trail into an even-degree vertex, from a different start, has an unused
+incident edge.**
+Let `p : G.Walk u v` be a trail with `u ≠ v` and `Even (G.degree v)`. Then some edge
+incident to `v` is *not* used by `p`. This is the quantitative heart of Hierholzer's
+"a maximal trail is closed" step: while a trail sits at a non-start vertex `v`, it has
+consumed an **odd** number of `v`'s incident edges (`IsTrail.even_countP_edges_iff`),
+but `v` has an **even** number in total, so an unused one always remains to extend
+along. -/
+theorem exists_unused_incident_edge_at_endpoint
+    [Fintype V] [DecidableRel G.Adj]
+    {u v : V} {p : G.Walk u v} (hp : p.IsTrail) (hne : u ≠ v)
+    (heven : Even (G.degree v)) :
+    ∃ e ∈ G.incidenceFinset v, e ∉ p.edges := by
+  classical
+  -- The walk-edges incident to `v`, as a nodup list.
+  set L : List (Sym2 V) := p.edges.filter (fun e => v ∈ e) with hLdef
+  have hpnodup : p.edges.Nodup := hp.edges_nodup
+  have hLnodup : L.Nodup := hpnodup.filter _
+  -- Their number is odd, by the trail parity invariant applied at `x = v`.
+  have hcountodd : Odd (p.edges.countP (fun e => v ∈ e)) := by
+    rw [← Nat.not_even_iff_odd, hp.even_countP_edges_iff]
+    intro h
+    exact (h hne).2 rfl
+  have hLlen : L.length = p.edges.countP (fun e => v ∈ e) := by
+    rw [hLdef]; exact List.countP_eq_length_filter.symm
+  have hLcard : L.toFinset.card = L.length := List.toFinset_card_of_nodup hLnodup
+  have hLcardodd : Odd L.toFinset.card := by rw [hLcard, hLlen]; exact hcountodd
+  -- Used incident edges sit inside the incidence finset of `v`.
+  have hsub : L.toFinset ⊆ G.incidenceFinset v := by
+    intro e he
+    rw [List.mem_toFinset, hLdef, List.mem_filter] at he
+    obtain ⟨hmem, hv⟩ := he
+    have hv' : v ∈ e := by simpa using hv
+    rw [SimpleGraph.mem_incidenceFinset]
+    exact ⟨p.edges_subset_edgeSet hmem, hv'⟩
+  -- Total incident edges = degree, which is even.
+  have hAcard : (G.incidenceFinset v).card = G.degree v := G.card_incidenceFinset_eq_degree v
+  have hAeven : Even (G.incidenceFinset v).card := by rw [hAcard]; exact heven
+  -- Different parities ⇒ the used set is a *proper* subset.
+  have hne_sets : L.toFinset ≠ G.incidenceFinset v := by
+    intro hEq
+    rw [hEq] at hLcardodd
+    exact (Nat.not_even_iff_odd.mpr hLcardodd) hAeven
+  have hss : L.toFinset ⊂ G.incidenceFinset v :=
+    (Finset.ssubset_iff_subset_ne).mpr ⟨hsub, hne_sets⟩
+  obtain ⟨e, heIn, heOut⟩ := Finset.exists_of_ssubset hss
+  refine ⟨e, heIn, ?_⟩
+  -- If `e` were used, it would be a used incident edge, i.e. in `L.toFinset`.
+  intro hused
+  apply heOut
+  have hv : v ∈ e := by
+    rw [SimpleGraph.mem_incidenceFinset] at heIn
+    exact heIn.2
+  rw [List.mem_toFinset, hLdef, List.mem_filter]
+  exact ⟨hused, by simpa using hv⟩
+
+/-- **A maximal trail is closed (undirected Hierholzer core).**
+If `p : G.Walk u v` is a trail, every vertex has even degree, and `v` is *edge-maximal*
+— every edge incident to `v` is already used by `p` — then `p` is closed: `u = v`.
+Contrapositive of `exists_unused_incident_edge_at_endpoint`: a trail can only get stuck
+back at its start. This is the step that turns "grow a trail greedily" into "obtain a
+closed circuit," the inductive engine of Hierholzer's construction. -/
+theorem eq_of_isTrail_edgeMaximal
+    [Fintype V] [DecidableRel G.Adj]
+    {u v : V} {p : G.Walk u v} (hp : p.IsTrail)
+    (heven : Even (G.degree v))
+    (hmax : ∀ e ∈ G.incidenceFinset v, e ∈ p.edges) :
+    u = v := by
+  by_contra hne
+  obtain ⟨e, hmem, hnot⟩ := exists_unused_incident_edge_at_endpoint hp hne heven
+  exact hnot (hmax e hmem)
+
+/-- **Sub-lemma B parity core — a closed trail uses an even number of incident edges.**
+For a *closed* trail `p : G.Walk u u` and any vertex `x`, the number of edges of `p`
+incident to `x` is even.
+
+This is the parity fact that makes edge-removal preserve the all-even-degree
+invariant in Hierholzer's induction: deleting a closed trail's edges drops each
+vertex's degree by this even count, and `even − even = even`. It is the closed-walk
+counterpart of the odd count in `exists_unused_incident_edge_at_endpoint` (there the
+start and end differ, forcing an odd number; here they coincide, forcing an even
+number). Both come from Mathlib's `IsTrail.even_countP_edges_iff`, whose right-hand
+side is trivially satisfied when the trail's endpoints are equal. -/
+theorem even_countP_incident_of_closed_trail
+    {u : V} {p : G.Walk u u} (hp : p.IsTrail) (x : V) :
+    Even (p.edges.countP (fun e => x ∈ e)) := by
+  rw [hp.even_countP_edges_iff]
+  -- The right-hand side relates `u = x` to `u = x` (start = end), so it is trivial.
+  tauto
 
 end UndirectedEulerDev

--- a/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -85,3 +85,46 @@ Insights accumulated during research on this problem.
 - Sub-lemma C: splice residual circuit via shared vertex; strong induction on
   `edgeFinset.card` using the verified base case.
 - Resubmit the single sorry to Aristotle once the backend recovers.
+
+## Session 2026-07-04 (Session 4) — Recovered Sub-lemma A + new Sub-lemma B parity core
+
+**Mode**: REVISIT (depth line) | **Outcome**: progress (5 lemmas VERIFIED, 0 sorries)
+
+### What I Did
+- Found that PR #34697 (Session 3's verified Sub-lemma A) was **auto-closed as a false
+  "superseded"** by the deployer's file-level race cleanup: the deployer saw the Dev
+  file already exists on `main` (base case only, from #34679) and discarded the whole
+  branch, silently dropping the extra verified lemmas. Confirmed
+  `exists_unused_incident_edge_at_endpoint` was NOT on `main`.
+- **Recovered** the three wrongly-discarded verified lemmas into the Dev file:
+  `two_le_degree_of_even_of_connected`, `exists_unused_incident_edge_at_endpoint`,
+  `eq_of_isTrail_edgeMaximal` (Sub-lemma A: a maximal trail is closed).
+- **Proved a new lemma** advancing Sub-lemma B: `even_countP_incident_of_closed_trail`
+  — for a *closed* trail `p : G.Walk u u` and any vertex `x`, `Even (p.edges.countP
+  (x ∈ ·))`. This is the parity fact that makes edge-removal preserve the
+  all-even-degree invariant. Proof: `IsTrail.even_countP_edges_iff` whose RHS is
+  trivial when start = end (closed by `tauto`).
+- Docker build clean: `⚠ Built Proofs.KonigsbergOQ02OQ01OQ02OQ01Dev` — 0 sorries, only
+  a harmless unused-`[DecidableEq V]` linter warning on `two_le_degree_...`.
+- This branch is a **strict superset** of main's Dev file (a MODIFY, not add/add), so
+  it should not trip the file-level supersession auto-close that killed #34697.
+
+### Key Findings
+- The deployer's supersession cleanup is **file-existence based, not content based** —
+  a branch that *adds new lemmas to an existing file* can be wrongly closed if that
+  file's path already exists on main. Future depth-line work on this file must land as
+  a MODIFY of main's version (branch from origin/main), not re-add the file.
+- Sub-lemma B now factors into: (parity core — DONE) + the `deleteEdges` degree
+  bookkeeping `(G.deleteEdges ↑p.edges.toFinset).degree w = G.degree w −
+  p.edges.countP (w ∈ ·)`, which is the remaining mechanical step.
+
+### Files Modified
+- proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (base case → +4 verified lemmas)
+- src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json (knowledge)
+
+### Next Steps
+- Sub-lemma B finish: relate `(G.deleteEdges E).degree w` to `G.degree w` minus the
+  incident-edge count, then combine with `even_countP_incident_of_closed_trail` to get
+  `∀ w, Even ((G.deleteEdges ↑p.edges.toFinset).degree w)`.
+- Sub-lemma C: splice residual closed trail via a shared vertex (connectivity).
+- Strong induction on `G.edgeFinset.card` assembling base case + A + B + C.

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -29,10 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: base case of undirected Hierholzer induction VERIFIED (euler_circuit_of_edgeSet_empty, 0 sorries, in ...Dev.lean). Corrected key fact: IsEulerian = (∀ e ∈ edgeSet, count e = 1), trail derived. Directed Digraph template confirmed NON-reusable. Mathlib confirmed lacking sufficiency. Aristotle backend down this session. Remaining: inductive step (sub-lemmas A maximal-trail-closed, B edge-removal-preserves-even, C splice) — the ~600-1000 line core.",
+    "progressSummary": "PROGRESS: Dev file now carries 5 verified lemmas (0 sorries): base case, degree>=2 invariant, Sub-lemma A (maximal trail is closed, 2 lemmas), and Sub-lemma B parity core (closed trail uses even incident-edge count). Main sufficiency theorem still 1 sorry. Remaining: deleteEdges degree bookkeeping, splice, strong induction.",
     "builtItems": [
       "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning).",
-      "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries."
+      "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries.",
+      "exists_unused_incident_edge_at_endpoint, eq_of_isTrail_edgeMaximal (Sub-lemma A) in KonigsbergOQ02OQ01OQ02OQ01Dev.lean",
+      "even_countP_incident_of_closed_trail (Sub-lemma B parity core) in KonigsbergOQ02OQ01OQ02OQ01Dev.lean",
+      "two_le_degree_of_even_of_connected (continuation invariant) in KonigsbergOQ02OQ01OQ02OQ01Dev.lean"
     ],
     "insights": [
       "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
@@ -42,7 +45,9 @@
       "IsEulerian is defined in Mathlib as (∀ e ∈ G.edgeSet, p.edges.count e = 1) — NOT (IsTrail ∧ covers all edges). Trail-ness is a DERIVED consequence (IsEulerian.isTrail). The construction invariant to maintain is therefore the per-edge count=1 condition; this corrects the earlier plan framing.",
       "Confirmed (web search + local check): Mathlib4 Trails module has only the necessity/property lemmas (IsEulerian.even_degree_iff, IsEulerian.card_odd_degree). No Eulerian existence/Hierholzer construction exists upstream, so sufficiency must be built natively.",
       "The directed Digraph proof in KonigsbergOQ02OQ01.lean is NOT reusable: it is built on a bespoke Digraph structure with its own Walk/splice/removeArcList/arcCount — none are SimpleGraph.Walk objects. A native SimpleGraph mirror is required.",
-      "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target)."
+      "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target).",
+      "Session 4: Recovered Sub-lemma A (maximal trail is closed) that PR #34697 had verified but the deployer auto-closed as false-superseded (file-level race cleanup dropped new lemmas added to an existing-on-main file).",
+      "Session 4: Proved even_countP_incident_of_closed_trail — a closed trail uses an even number of edges incident to each vertex (parity core of Sub-lemma B), via IsTrail.even_countP_edges_iff with start=end trivial RHS."
     ],
     "mathlibGaps": [
       "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."


### PR DESCRIPTION
## Summary
Depth-line research on `konigsberg-oq-02-oq-01-oq-02-oq-01` (undirected Hierholzer sufficiency). Two things:

1. **Recovers verified work wrongly discarded.** PR #34697 had machine-checked Sub-lemma A ("a maximal trail is closed"), but the deployer auto-closed it as a false **"superseded"** — its file-level race cleanup saw `KonigsbergOQ02OQ01OQ02OQ01Dev.lean` already exists on `main` (base case only) and dropped the whole branch, including the *new* lemmas that branch added to that file. Confirmed `exists_unused_incident_edge_at_endpoint` was NOT on `main`.
2. **Adds a new verified lemma** advancing Sub-lemma B.

This PR is a **strict superset** of main's Dev file — a MODIFY of the existing file, not an add/add duplicate — so it should not trip the same auto-close.

## Progress
`proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean` now carries **5 verified lemmas, 0 sorries** (docker build clean):

- `euler_circuit_of_edgeSet_empty` — base case (already on main)
- `two_le_degree_of_even_of_connected` — continuation invariant (recovered)
- `exists_unused_incident_edge_at_endpoint` — Sub-lemma A (recovered)
- `eq_of_isTrail_edgeMaximal` — Sub-lemma A: a maximal trail is closed (recovered)
- `even_countP_incident_of_closed_trail` — **NEW**: a closed trail uses an even number of edges incident to every vertex (Sub-lemma B parity core)

## Findings
- The deployer's supersession cleanup is **file-existence based, not content based**; a branch that adds lemmas to a file already on main can be wrongly closed. Depth-line work on this file must land as a MODIFY (branch from `origin/main`).
- Sub-lemma B now factors into (parity core — done here) + the `deleteEdges` degree bookkeeping, the remaining mechanical step.

## Status
**Outcome**: progress
**Next Steps**: relate `(G.deleteEdges E).degree w` to `G.degree w` minus incident count; combine with the parity core for `∀ w, Even ((G.deleteEdges ↑p.edges.toFinset).degree w)`; then splice + strong induction. Main sufficiency theorem still carries 1 `sorry`.

🤖 Generated by researcher-5