### PR TITLE
Enrich Burnside-over-Finite (Lagrange OQ): annotation coverage 4→5

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,50 +1,116 @@
 [
   {
+    "id": "ann-lagrange-oq02020101-imports",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 5
+    },
+    "type": "context",
+    "title": "Where the content lives: one load-bearing import",
+    "content": "The entire orbit-counting argument is imported, not rebuilt. Mathlib.GroupTheory.GroupAction.Quotient supplies the finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup : (Σ g, fixedBy X g) ≃ (X/G) × G — the sole piece of mathematics doing real work, and it carries no Fintype or Finite hypothesis. The other imports are pure cardinality plumbing: SetTheory.Cardinal.Finite gives the instance-free Nat.card and its transport lemmas (Nat.card_congr, Nat.card_sigma, Nat.card_prod, Nat.card_eq_fintype_card), and Algebra.BigOperators.Finprod gives finsum_eq_sum_of_fintype to move between ∑ᶠ and Finset sums. That the crux lemma sits in the general GroupAction.Quotient file (not a Fintype-specialised one) is precisely why the generalisation off Fintype costs nothing.",
+    "mathContext": "The bijection $\\Sigma_{g:G}\\,\\operatorname{fixedBy} X\\,g \\;\\simeq\\; (X/G)\\times G$ is stated for an arbitrary $\\mathrm{MulAction}\\ G\\ X$; finiteness enters only when taking $\\mathrm{Nat.card}$ of both sides.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "sigmaFixedByEquivOrbitsProdGroup",
+      "Nat.card transport",
+      "finsum_eq_sum_of_fintype",
+      "Mathlib import hygiene"
+    ],
+    "prerequisites": [
+      "group actions",
+      "Mathlib namespace organisation"
+    ]
+  },
+  {
     "id": "ann-lagrange-oq02020101-header",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
-    "range": { "startLine": 6, "endLine": 54 },
+    "range": {
+      "startLine": 6,
+      "endLine": 54
+    },
     "type": "concept",
     "title": "Burnside off Fintype: the open question",
     "content": "The header poses the parent's OQ-02: Mathlib's Burnside / Cauchy–Frobenius lemma sum_card_fixedBy_eq_card_orbits_mul_card_group is stated with Fintype hypotheses; does it generalise to the merely Finite setting with no constructive Fintype instances? The answer is yes, and the proof lifts essentially unchanged — because the orbit-counting content lives in a finiteness-free bijection. The generalisation replaces Fintype.card by the total, instance-free Nat.card and the finite sum by finsum (∑ᶠ), the canonical 'sum over a Finite type' idiom.",
     "mathContext": "$\\sum^{f}_{g:G} \\#(\\operatorname{fixedBy} X\\,g) = \\#(X/G)\\cdot \\#G$ for $G,X$ merely $\\mathrm{Finite}$ (here $\\#$ is $\\mathrm{Nat.card}$).",
     "significance": "supporting",
-    "relatedConcepts": ["Burnside's lemma", "Cauchy–Frobenius", "Nat.card vs Fintype.card", "Mathlib hygiene"],
-    "prerequisites": ["group actions", "orbit counting"]
+    "relatedConcepts": [
+      "Burnside's lemma",
+      "Cauchy–Frobenius",
+      "Nat.card vs Fintype.card",
+      "Mathlib hygiene"
+    ],
+    "prerequisites": [
+      "group actions",
+      "orbit counting"
+    ]
   },
   {
     "id": "ann-lagrange-oq02020101-setup",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
-    "range": { "startLine": 56, "endLine": 60 },
+    "range": {
+      "startLine": 56,
+      "endLine": 60
+    },
     "type": "definition",
     "title": "Setup: a group action with no finiteness yet",
     "content": "namespace BurnsideFinite, open MulAction, and the ambient variables: an arbitrary group G acting on a type X (MulAction G X), with NO finiteness hypotheses on the variables themselves — those are added per theorem. Stating the action abstractly here is what lets the same fixedBy / orbitRel.Quotient vocabulary carry both the Finite generalisation and the Fintype recovery.",
     "mathContext": "$G$ a group acting on $X$; $\\operatorname{fixedBy} X\\,g = \\{x : g\\cdot x = x\\}$, orbit quotient $X/G = \\operatorname{orbitRel.Quotient} G\\,X$.",
     "significance": "supporting",
-    "relatedConcepts": ["MulAction", "fixed points", "orbit quotient"],
-    "prerequisites": ["group actions"]
+    "relatedConcepts": [
+      "MulAction",
+      "fixed points",
+      "orbit quotient"
+    ],
+    "prerequisites": [
+      "group actions"
+    ]
   },
   {
     "id": "ann-lagrange-oq02020101-finite",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
-    "range": { "startLine": 62, "endLine": 82 },
+    "range": {
+      "startLine": 62,
+      "endLine": 82
+    },
     "type": "insight",
     "title": "The Finite generalisation in four rewrites",
     "content": "sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite [Finite G] [Finite X]: the headline. The proof is a four-step rewrite of the SAME finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup : (Σ g, fixedBy X g) ≃ (X/G) × G. cases nonempty_fintype G extracts a non-constructive Fintype G (the only finiteness actually consumed); then finsum_eq_sum_of_fintype turns ∑ᶠ into a Finset sum, ← Nat.card_sigma folds it into the sigma cardinality, Nat.card_congr transports along the bijection, and Nat.card_prod splits the product — closing by rfl. No Fintype X, no Fintype on the fixed-point sets or the quotient is ever supplied.",
     "mathContext": "$\\sum^{f}_g \\#(\\operatorname{fixedBy} X\\,g) = \\#\\big(\\Sigma_g\\,\\operatorname{fixedBy} X\\,g\\big) = \\#\\big((X/G)\\times G\\big) = \\#(X/G)\\cdot\\#G$.",
     "significance": "key",
-    "relatedConcepts": ["sigmaFixedByEquivOrbitsProdGroup", "Nat.card_congr", "Nat.card_sigma", "finsum", "nonempty_fintype"],
-    "prerequisites": ["the orbit-counting bijection", "Nat.card transport lemmas"]
+    "relatedConcepts": [
+      "sigmaFixedByEquivOrbitsProdGroup",
+      "Nat.card_congr",
+      "Nat.card_sigma",
+      "finsum",
+      "nonempty_fintype"
+    ],
+    "prerequisites": [
+      "the orbit-counting bijection",
+      "Nat.card transport lemmas"
+    ]
   },
   {
     "id": "ann-lagrange-oq02020101-recovered",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
-    "range": { "startLine": 84, "endLine": 104 },
+    "range": {
+      "startLine": 84,
+      "endLine": 104
+    },
     "type": "concept",
     "title": "Recovering Mathlib's Fintype form",
     "content": "sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered shows the generalisation genuinely subsumes the original: supplying the Fintype instances and unfolding Nat.card to Fintype.card returns Mathlib's exact statement. Notably Finite X is DERIVED, not assumed — with Finite G each orbit is the image of a finite type (Set.finite_range), and there are finitely many orbits, so X ≃ Σ ω, orbit … is finite (selfEquivSigmaOrbits). Then finsum_eq_sum_of_fintype + simpa [Nat.card_eq_fintype_card] converts every cardinality. This certifies the Finite form is upstream-ready.",
     "mathContext": "Supplying $\\mathrm{Fintype}$ instances and $\\mathrm{Nat.card} = \\mathrm{Fintype.card}$ recovers $\\sum_g \\mathrm{Fintype.card}(\\operatorname{fixedBy} X\\,g) = \\mathrm{Fintype.card}(X/G)\\cdot\\mathrm{Fintype.card}\\,G$.",
     "significance": "key",
-    "relatedConcepts": ["Nat.card_eq_fintype_card", "selfEquivSigmaOrbits", "subsumption", "Mathlib contribution"],
-    "prerequisites": ["the Finite generalisation", "Fintype/Finite bridging"]
+    "relatedConcepts": [
+      "Nat.card_eq_fintype_card",
+      "selfEquivSigmaOrbits",
+      "subsumption",
+      "Mathlib contribution"
+    ],
+    "prerequisites": [
+      "the Finite generalisation",
+      "Fintype/Finite bridging"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01` (Burnside's lemma generalised off `Fintype`).

**Gap:** entry met every quality minimum except annotation count (4 of ≥5 with `mathContext`). The import block (lines 1–5) was the only meaningful uncovered region.

**Change (annotations.json only, +1 → 5):**
- New `ann-lagrange-oq02020101-imports` (lines 1–5): the entire orbit-counting argument is *imported*, not rebuilt — `Mathlib.GroupTheory.GroupAction.Quotient` supplies the finiteness-free bijection `sigmaFixedByEquivOrbitsProdGroup`, the sole load-bearing piece of mathematics, while `Cardinal.Finite` and `Finprod` are pure `Nat.card`/`finsum` plumbing. That the crux lemma lives in the *general* (not `Fintype`-specialised) file is exactly why the generalisation costs nothing.

All 5 annotations now carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Purely additive; `meta.json` untouched. Committed via origin/main plumbing to avoid clobbering others' work.
