### PR TITLE
Enrich Urysohn/Tietze OQ-01³: annotation coverage 4→5

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-urysohns-oq010101-scope",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Scope: removing Mathlib's TietzeExtension black box",
+    "content": "The docstring fixes the contribution precisely against the parent entry. The parent (urysohns-lemma-oq-01-oq-01) isolates the engine — the one-step Urysohn approximation urysohn_approx_step and the quantitative iterate urysohn_approx_iterate — but then assembles the final extension by calling Mathlib's TietzeExtension.exists_restrict_eq, which hides the limit behind a black box. This entry removes that black box: it builds the extension by hand as a genuinely convergent series G = ∑' n, gₙ in the Banach space C_b(X, ℝ), where each correction gₙ comes from one application of Urysohn's lemma to the current residual and satisfies ‖gₙ‖ ≤ (2/3)ⁿ·(M/3). The geometric majorant forces absolute convergence (the space is complete), the partial sums approximate f on the closed set s with error (2/3)ⁿ·M → 0, and summing the majorant gives ‖G‖ ≤ M — so the extension lands in the same sup-bound [-M, M] as the data, with no sorry and no use of Mathlib's TietzeExtension API.",
+    "mathContext": "$G = \\sum_{n} g_n$ in $C_b(X,\\mathbb{R})$ with $\\|g_n\\| \\le (2/3)^n\\,(M/3)$, so $\\|G\\| \\le \\sum_n (2/3)^n (M/3) = M$ and $G|_s = f$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Tietze extension theorem",
+      "Urysohn's lemma",
+      "geometric majorant",
+      "Banach space completeness",
+      "tsum in C_b(X,ℝ)"
+    ],
+    "prerequisites": [
+      "normal topological spaces",
+      "bounded continuous function spaces",
+      "absolute convergence"
+    ]
+  },
+  {
     "id": "ann-residual-recursion",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `urysohns-lemma-oq-01-oq-01-oq-01` (explicit series form of the Tietze extension).

**Gap:** entry met every quality minimum except annotation count (4 of ≥5 with `mathContext`). Lines 4–43 (the entire docstring + setup) were unannotated.

**Change (annotations.json only, +1 → 5):**
- New `ann-urysohns-oq010101-scope` (lines 4–43): documents the contribution against the parent entry — the parent isolates the Urysohn approximation engine but assembles the extension via Mathlib's `TietzeExtension.exists_restrict_eq` (a black box); this entry *removes* that black box and builds `G = ∑' n, gₙ` by hand in the Banach space `C_b(X, ℝ)`. The geometric majorant `‖gₙ‖ ≤ (2/3)ⁿ·(M/3)` forces absolute convergence and yields `‖G‖ ≤ M` with `G|_s = f`, no `sorry`, no `TietzeExtension` API.

All 5 annotations now carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Purely additive; `meta.json` untouched. Committed via origin/main plumbing.
