### PR TITLE
Enrich PAC-learning wip-01 oq-01 (VC monotonicity): annotation coverage 4→5

### DIFF
--- a/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-wip-01-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-pac-wip01oq01-imports",
+    "proofId": "pac-learning-bounds-wip-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 2
+    },
+    "type": "context",
+    "title": "One import: a monotonicity layer on the parent's VC foundations",
+    "content": "The file imports only its parent, Proofs.PACLearningBoundsWIP01 — no fresh Mathlib surface. That parent supplies the primitives this entry reasons about: the trace Π_H(S) = {h ∩ S : h ∈ H}, the shattering relation Shatters H S, the VC dimension VCDim H = sSup {n | ∃ S, |S| = n ∧ Shatters H S}, and the powerset benchmark vcDim_powerset. Everything proved here — vcDim_mono, the union corollaries, and the powerset ceiling — is a thin monotonicity layer assembled from those foundations, each a one- or two-line consequence, so the entry inherits the parent's 0-axiom status without adding any new assumptions.",
+    "mathContext": "$H \\subseteq H' \\Rightarrow \\mathrm{VCDim}\\,H \\le \\mathrm{VCDim}\\,H'$; specialised to $H \\subseteq H \\cup H'$ and to $H \\subseteq 2^S$ giving $\\mathrm{VCDim}\\,H \\le |S|$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "VC dimension",
+      "shattering",
+      "trace / growth function",
+      "monotonicity",
+      "axiom-free layering"
+    ],
+    "prerequisites": [
+      "the parent VC foundations",
+      "Finset order lemmas"
+    ]
+  },
+  {
     "id": "ann-pac-wip01-oq01-01-header",
     "proofId": "pac-learning-bounds-wip-01-oq-01",
     "range": {


### PR DESCRIPTION
Enrichment pass for `pac-learning-bounds-wip-01-oq-01` (monotonicity of the VC dimension).

**Gap:** entry met every quality minimum except annotation count (4 of ≥5 with `mathContext`). The import line was the only meaningful uncovered region.

**Change (annotations.json only, +1 → 5):**
- New `ann-pac-wip01oq01-imports` (lines 1–2): the file imports *only* its parent `Proofs.PACLearningBoundsWIP01` — no fresh Mathlib surface. That parent supplies the trace `Π_H(S)`, `Shatters H S`, `VCDim`, and `vcDim_powerset`; everything here (`vcDim_mono`, the union corollaries, the powerset ceiling `VCDim H ≤ |S|`) is a thin one-to-two-line monotonicity layer that inherits the parent's `0`-axiom status without new assumptions.

All 5 annotations now carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Purely additive; `meta.json` untouched. Committed via origin/main plumbing.
