### PR TITLE
Research: erdos-1017-oq-04 — edge-disjointness keystone + positivity lower bounds toward strict gap cc<cp

### DIFF
--- a/proofs/Proofs/Erdos1017OQ04.lean
+++ b/proofs/Proofs/Erdos1017OQ04.lean
@@ -35,6 +35,12 @@ different quantities, and the *direction* that always holds is
 - `coverNum_le_partitionNum` : **cc(G) <= cp(G)** for every finite graph.
 - `partitionNum_le_edgeCliquesCard`, `coverNum_le_edgeCliquesCard` : both numbers
   are at most the number of two-element cliques (each edge as its own clique).
+- `EdgeCliquePartition.edge_unique_clique` : the edge-disjointness core of a
+  partition (an edge lies in a unique partition clique) -- the keystone every
+  partition-number lower bound is built on, and the structural reason `cp` can
+  exceed `cc`. See Part VI.
+- `coverNum_pos_of_edge`, `partitionNum_pos_of_edge` : both numbers are >= 1 once
+  `G` has an edge (the base case of the lower-bound ladder toward the strict gap).
 
 ## Relation to OQ-01
 The companion file `Erdos1017OQ01.lean` defines a structure it calls
@@ -225,7 +231,75 @@ theorem coverNum_le_edgeCliquesCard (G : SimpleGraph V) [DecidableRel G.Adj] :
 
 /-
 ====================================================================
-PART VI: VERIFICATION
+PART VI: TOWARD THE STRICT GAP  cc(G) < cp(G)
+
+The always-true direction `cc(G) <= cp(G)` is Part IV.  The genuinely open
+content of OQ-04 is that this inequality can be *strict*: converting a minimum
+cover into a partition can force strictly more cliques.  The intended witness is
+the book graph `K_4` minus an edge (`cc = 2 < 3 = cp`).
+
+The results below are the reusable keystones for that lower-bound program, stated
+for arbitrary graphs (no concrete witness yet):
+
+* `EdgeCliquePartition.edge_unique_clique` : the *edge-disjointness* core of a
+  partition -- an edge lies in a UNIQUE partition clique, so two partition
+  cliques sharing an edge coincide.  This is exactly the property a cover lacks,
+  and the structural reason `cp` can exceed `cc`.  It is the hypothesis every
+  partition-number lower bound (including the counting identity
+  `sum_{C} C(|C|,2) = |E|`) is built on.
+* `coverNum_pos_of_edge` / `partitionNum_pos_of_edge` : both numbers are at least
+  one once `G` has an edge (an edge cannot be covered by zero cliques) -- the base
+  case of any lower-bound ladder.
+==================================================================== -/
+
+omit [Fintype V] [DecidableEq V] in
+/-- **An edge determines its partition clique uniquely.**  In an edge clique
+    *partition*, if an edge `{v, w}` (with `G.Adj v w`) lies in two listed cliques
+    `S` and `T`, then `S = T`.  This is the edge-disjointness that distinguishes a
+    partition from a cover: distinct partition cliques share no edge.  It is the
+    structural obstruction behind a strict gap `cc(G) < cp(G)` and the keystone for
+    every partition-number lower bound (e.g. the counting identity
+    `sum_{C in P} C(|C|,2) = |E(G)|`). -/
+theorem EdgeCliquePartition.edge_unique_clique (P : EdgeCliquePartition G)
+    {v w : V} (hvw : G.Adj v w) {S T : Finset V}
+    (hSmem : S ∈ P.cliques) (hvS : v ∈ S) (hwS : w ∈ S)
+    (hTmem : T ∈ P.cliques) (hvT : v ∈ T) (hwT : w ∈ T) : S = T := by
+  obtain ⟨_, _, huniq⟩ := P.partitions hvw
+  rw [huniq S ⟨hSmem, hvS, hwS⟩, huniq T ⟨hTmem, hvT, hwT⟩]
+
+/-- **`cc(G) >= 1` whenever `G` has an edge.**  An edge must be covered by at
+    least one clique, so the empty cover is invalid and the cover number is
+    positive.  Base case of the cover-number lower-bound ladder. -/
+theorem coverNum_pos_of_edge {v w : V} (h : G.Adj v w) : 0 < coverNum G := by
+  have hne : {m | ∃ C : EdgeCliqueCover G, C.cliques.card = m}.Nonempty :=
+    ⟨_, (trivialPartition G).toCover, rfl⟩
+  obtain ⟨C, hC⟩ := Nat.sInf_mem hne
+  have hC' : C.cliques.card = coverNum G := hC
+  rcases Nat.eq_zero_or_pos (coverNum G) with h0 | hpos
+  · exfalso
+    rw [h0, Finset.card_eq_zero] at hC'
+    obtain ⟨S, hS, _, _⟩ := C.covers h
+    rw [hC'] at hS
+    exact Finset.notMem_empty S hS
+  · exact hpos
+
+/-- **`cp(G) >= 1` whenever `G` has an edge.**  An edge must lie in some clique of
+    any partition, so the empty partition is invalid and the partition number is
+    positive.  Base case of the partition-number lower-bound ladder. -/
+theorem partitionNum_pos_of_edge {v w : V} (h : G.Adj v w) : 0 < partitionNum G := by
+  obtain ⟨P, hP⟩ := Nat.sInf_mem (partitionNum_set_nonempty G)
+  have hP' : P.cliques.card = partitionNum G := hP
+  rcases Nat.eq_zero_or_pos (partitionNum G) with h0 | hpos
+  · exfalso
+    rw [h0, Finset.card_eq_zero] at hP'
+    obtain ⟨S, ⟨hS, _, _⟩, _⟩ := P.partitions h
+    rw [hP'] at hS
+    exact Finset.notMem_empty S hS
+  · exact hpos
+
+/-
+====================================================================
+PART VII: VERIFICATION
 ==================================================================== -/
 
 #check @EdgeCliqueCover
@@ -237,5 +311,8 @@ PART VI: VERIFICATION
 #check @coverNum_le_partitionNum
 #check @partitionNum_le_edgeCliquesCard
 #check @coverNum_le_edgeCliquesCard
+#check @EdgeCliquePartition.edge_unique_clique
+#check @coverNum_pos_of_edge
+#check @partitionNum_pos_of_edge
 
 end Erdos1017OQ04

--- a/src/data/research/problems/erdos-1017-oq-04.json
+++ b/src/data/research/problems/erdos-1017-oq-04.json
@@ -31,19 +31,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Verified (0 axioms) the always-true direction cc(G)<=cp(G) and the genuine cover/partition distinction; clarified that OQ01 cliquePartitionNum is really the cover number. Strict gap (book graph) is the next rung, needs the sum-of-C(|C|,2)=|E| counting identity.",
+    "progressSummary": "PROGRESS: cc(G)<=cp(G) verified (Part IV). Added the strict-gap lower-bound keystones (Part VI): edge_unique_clique (partition edge-disjointness) + positivity lower bounds coverNum/partitionNum >=1 given an edge. Build clean (3078 jobs), 0 sorries/0 axioms. NEXT rung unchanged: the counting identity sum_C C(|C|,2)=|E| and the concrete book-graph K4-e witness giving cc=2<3=cp.",
     "builtItems": [
       "EdgeCliqueCover / EdgeCliquePartition structures (Erdos1017OQ04.lean) — cover vs exactly-once partition",
       "EdgeCliquePartition.toCover : every partition is a cover (Erdos1017OQ04.lean)",
       "trivialPartition : edge-by-edge partition witnessing partitionNum is achieved (nonempty witness set)",
       "coverNum_le_partitionNum : cc(G) <= cp(G), VERIFIED 0 axioms 0 sorries (Erdos1017OQ04.lean)",
-      "partitionNum_le_edgeCliquesCard / coverNum_le_edgeCliquesCard upper bounds"
+      "partitionNum_le_edgeCliquesCard / coverNum_le_edgeCliquesCard upper bounds",
+      "EdgeCliquePartition.edge_unique_clique in Proofs/Erdos1017OQ04.lean (edge-disjointness keystone)",
+      "coverNum_pos_of_edge, partitionNum_pos_of_edge in Proofs/Erdos1017OQ04.lean (positivity lower bounds)"
     ],
     "insights": [
       "The companion file Erdos1017OQ01.lean names its structure EdgeCliquePartition but its only constraint is the covers field (every edge in SOME clique) with no disjointness — so its cliquePartitionNum is really the clique COVER number cc(G), not the partition number cp(G). This conflation is exactly the cover-vs-partition ambiguity OQ-04 is about.",
       "The always-true direction is cc(G) <= cp(G): every edge clique partition is in particular a cover (forget the uniqueness/disjointness), so the minimum cover size is at most the minimum partition size.",
       "Formalizing a genuine partition via ExistsUnique (each edge lies in exactly one clique) cleanly separates it from a cover (ExistsUnique weakens to Exists), making toCover a one-line structure map.",
-      "The intended strict-gap witness is the book graph B2 = K4 minus an edge: its two triangles {0,1,2},{0,1,3} overlap on edge {0,1} and cover all 5 edges (cc=2), but a partition cannot use both triangles, forcing cp=3. This shows OQ-04 strengthening genuinely fails."
+      "The intended strict-gap witness is the book graph B2 = K4 minus an edge: its two triangles {0,1,2},{0,1,3} overlap on edge {0,1} and cover all 5 edges (cc=2), but a partition cannot use both triangles, forcing cp=3. This shows OQ-04 strengthening genuinely fails.",
+      "edge_unique_clique: in an EdgeCliquePartition an edge lies in a UNIQUE clique, so two partition cliques sharing an edge coincide. This edge-disjointness is exactly what a cover lacks and the structural reason cp(G) can exceed cc(G); it is the hypothesis every partition-number lower bound (incl. the counting identity sum_C C(|C|,2)=|E|) is built on.",
+      "coverNum_pos_of_edge / partitionNum_pos_of_edge: both numbers are >=1 once G has an edge (empty cover/partition cannot cover an edge) -- base case of the lower-bound ladder."
     ],
     "mathlibGaps": [
       "No off-the-shelf Mathlib notion of edge clique cover/partition number; built locally (~230 lines).",


### PR DESCRIPTION
## Summary
Research session for **erdos-1017-oq-04** (Clique Cover vs Clique Partition, Erdős #1017). Extends the verified `Erdos1017OQ04.lean` (which proved the always-true direction `cc(G) ≤ cp(G)`) with the reusable lower-bound keystones for the genuinely open strict-gap direction `cc(G) < cp(G)`.

## Progress (Part VI added)
- **`EdgeCliquePartition.edge_unique_clique`** — an edge lies in a *unique* partition clique, so two partition cliques sharing an edge coincide. This edge-disjointness is exactly the property a *cover* lacks, and the structural reason `cp` can exceed `cc`. It is the hypothesis every partition-number lower bound is built on (including the counting identity `∑_C C(|C|,2) = |E|`).
- **`coverNum_pos_of_edge` / `partitionNum_pos_of_edge`** — both numbers are `≥ 1` once `G` has an edge (an empty cover/partition cannot cover an edge). Base case of the lower-bound ladder.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ04` — **clean, 3078 jobs, 0 sorries, 0 axioms**.
- 78-line addition to the existing verified file; no changes to prior theorems.

## Status
**Outcome**: progress (infrastructure toward the strict gap; the headline `cc < cp` is not yet proved).
**Next rung** (unchanged): the counting identity `∑_{C ∈ P} C(|C|,2) = |E(G)|` and the concrete book-graph `K₄−e` witness giving `cc = 2 < 3 = cp`, which would show OQ-04's strengthening genuinely fails.

🤖 Generated by researcher-8