### PR TITLE
Enrich Cauchy Interlacing OQ-01-02-01 (Ky Fan trace interlacing): add mainTheorems (0->6)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -101,6 +101,56 @@
       "content": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "trace_interlacing",
+      "type": "core",
+      "description": "**Two-sided trace interlacing** — the trace of the compression TH of T onto a codimension-m subspace is trapped between the sum of the n smallest and the sum of the n largest eigenvalues of T: ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j. Packages both trace bounds; the content is entirely the Poincaré separation theorem summed over univ.",
+      "leanType": "(∑ k : Fin n, lam ⟨k + m, _⟩ ≤ ∑ k : Fin n, mu k) ∧ (∑ k : Fin n, mu k ≤ ∑ k : Fin n, lam ⟨k, _⟩)  [given the Poincaré-separation data T, b, lam, hlam, H, hHdim, TH, bH, mu, hmu, hRayleigh]",
+      "line": 110,
+      "endLine": 114
+    },
+    {
+      "name": "partial_sum_mu_le_partial_sum_lam",
+      "type": "core",
+      "description": "**Ky Fan weak majorization** — for every j, ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k: every top-j partial sum of the compression spectrum is dominated by the top-j partial sum of T's spectrum. The descending eigenvalues of a compression are weakly majorized by the largest eigenvalues of the full operator.",
+      "leanType": "(j : ℕ) : ∑ k ∈ univ.filter (·.val < j), mu k ≤ ∑ k ∈ univ.filter (·.val < j), lam ⟨k, _⟩",
+      "line": 87,
+      "endLine": 91
+    },
+    {
+      "name": "sum_mu_le_sum_top_lam",
+      "type": "key",
+      "description": "**Ky Fan upper sum bound (arbitrary index set)** — summing the upper Poincaré inequality μ_k ≤ λ_⟨k⟩ over any s : Finset (Fin n). The general monotone-sum bound from which weak majorization and the trace upper bound both specialise.",
+      "leanType": "(s : Finset (Fin n)) : ∑ k ∈ s, mu k ≤ ∑ k ∈ s, lam ⟨k, _⟩",
+      "line": 66,
+      "endLine": 69
+    },
+    {
+      "name": "sum_bot_lam_le_sum_mu",
+      "type": "key",
+      "description": "**Ky Fan lower sum bound (arbitrary index set)** — summing the lower Poincaré inequality λ_⟨k+m⟩ ≤ μ_k over any s : Finset (Fin n). The matching lower monotone-sum bound.",
+      "leanType": "(s : Finset (Fin n)) : ∑ k ∈ s, lam ⟨k + m, _⟩ ≤ ∑ k ∈ s, mu k",
+      "line": 73,
+      "endLine": 76
+    },
+    {
+      "name": "trace_compress_le",
+      "type": "supporting",
+      "description": "**Trace upper bound** — the trace of the compression (sum of all its eigenvalues) is at most the sum of the n largest eigenvalues of T. The s = univ specialisation of sum_mu_le_sum_top_lam.",
+      "leanType": "∑ k : Fin n, mu k ≤ ∑ k : Fin n, lam ⟨k, _⟩",
+      "line": 95,
+      "endLine": 97
+    },
+    {
+      "name": "trace_compress_ge",
+      "type": "supporting",
+      "description": "**Trace lower bound** — the trace of the compression is at least the sum of the n smallest eigenvalues of T (indices m, …, n+m-1). The s = univ specialisation of sum_bot_lam_le_sum_mu.",
+      "leanType": "∑ k : Fin n, lam ⟨k + m, _⟩ ≤ ∑ k : Fin n, mu k",
+      "line": 101,
+      "endLine": 103
+    }
+  ],
   "references": [
     {
       "authors": "Fan, K.",


### PR DESCRIPTION
## Enrichment: Cauchy Interlacing OQ-01-02-01 (Ky Fan trace interlacing) — add `mainTheorems`

Adds a `mainTheorems` array (0 → 6) to `meta.json`, surfacing the file's named results with conclusion-focused Lean signatures and line anchors (all six share the Poincaré-separation hypothesis block). The entry had rich overview/annotations/conclusion but exposed **none** of its theorems.

Curated from `Proofs/CauchyInterlacingKyFan.lean` (0 sorries):

**core**
- `trace_interlacing` — two-sided trace trap ∑_{j≥m} λ_j ≤ tr(TH) ≤ ∑_{j<n} λ_j
- `partial_sum_mu_le_partial_sum_lam` — Ky Fan weak majorization ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k

**key**
- `sum_mu_le_sum_top_lam`, `sum_bot_lam_le_sum_mu` — the arbitrary-index-set monotone-sum bounds

**supporting**
- `trace_compress_le`, `trace_compress_ge` — the s = univ trace bounds

meta.json: 12.6 KB → ~16 KB (well under the 60 KB cap). Additive, meta-only. Shipped via origin/main git plumbing.
