### PR TITLE
Research: erdos-3-incomplete-01 — Roth-number monotonicity + threshold downward-closure

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -193,6 +193,31 @@ theorem containsAP_of_le {A : Set ℕ} {k m : ℕ} (hkm : k ≤ m)
   rw [Finset.mem_range] at hx ⊢
   omega
 
+/-- **AP-freeness is upward-closed in the progression length.**
+    If `A` avoids `k`-term progressions and `k ≤ m`, then `A` also avoids `m`-term
+    progressions: an `m`-AP inside `A` would contain a `k`-AP (its first `k` terms) by
+    `containsAP_of_le`, contradicting `k`-AP-freeness. Dual to `containsAP_of_le`, and the
+    structural fact underlying monotonicity of the Roth number in `k`. -/
+theorem isAPFree_of_le {A : Set ℕ} {k m : ℕ} (hkm : k ≤ m)
+    (h : IsAPFree A k) : IsAPFree A m :=
+  fun hm => h (containsAP_of_le hkm hm)
+
+/-- **The Roth number is monotone in the progression length.**
+    `r_k(N) ≤ r_m(N)` whenever `k ≤ m`. Avoiding a *longer* progression is an easier
+    constraint (`isAPFree_of_le`: every `k`-AP-free set is `m`-AP-free), so the family of
+    sets `r_m` maximises over contains the family `r_k` maximises over, and the supremum
+    only grows. This is the structural fact the `max k 3` device in
+    `strong_required_bound_implies_conjecture` relies on but never states; it also makes the
+    threshold hypotheses downward-closed in `k` (see `strongRequiredBound_mono`).
+    Fully machine-checked, axiom-free. -/
+theorem rothNumber_mono {k m N : ℕ} (hkm : k ≤ m) :
+    rothNumber k N ≤ rothNumber m N := by
+  unfold rothNumber
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter] at hS ⊢
+  exact ⟨hS.1, isAPFree_of_le hkm hS.2⟩
+
 /-- **A genuine `k`-term AP has exactly `k` elements.**
     When the common difference `d` is positive, the generating map `i ↦ a + i·d`
     is injective on `range k`, so `ArithProg a d k` has cardinality `k`.  (This is
@@ -422,6 +447,24 @@ theorem strong_required_bound_implies_conjecture :
       _ ≤ C * (N : ℝ) / (Real.log N) ^ (1 + δ) := hN
   exact hdiv (summable_of_strongBound hδ hC hcount)
 
+/-- **Divergent reciprocal sum forces super-`(log)^{1+δ}` density infinitely often.**
+    The contrapositive of `summable_of_strongBound`, packaged as a positive density
+    statement: if `∑_{a∈A} 1/a = ∞` then for every `C, δ > 0` the counting function
+    exceeds `C·N/(log N)^{1+δ}` for infinitely many `N`. In words, a divergent-reciprocal
+    set can never have counting function that is `O(N/(log N)^{1+δ})`. This is the exact
+    density lower bound Erdős #3 must exploit, and is reusable wherever one needs to turn
+    `HasDivergentSum` into a quantitative growth statement. Axiom-free. -/
+theorem countingFunction_frequently_gt_of_divergent {A : Set ℕ} {C δ : ℝ}
+    (hδ : 0 < δ) (hC : 0 < C) (hdiv : HasDivergentSum A) :
+    ∃ᶠ N : ℕ in atTop,
+      C * (N : ℝ) / (Real.log N) ^ (1 + δ) < (countingFunction A N : ℝ) := by
+  by_contra h
+  rw [Filter.not_frequently] at h
+  apply hdiv
+  apply summable_of_strongBound hδ hC
+  filter_upwards [h] with N hN
+  exact not_lt.mp hN
+
 /-- **The strong threshold dominates the weak one.**
     `StrongRequiredBound k` (`r_k(N) = O(N/(log N)^{1+δ})` for some `δ > 0`) implies the
     weaker `RequiredBound k` (`r_k(N) = o(N/log N)`). Writing the strong bound as
@@ -466,6 +509,27 @@ theorem strongRequiredBound_implies_requiredBound {k : ℕ}
   have hfac : 0 ≤ (N : ℝ) * L * (c * L ^ δ - C) :=
     mul_nonneg (mul_nonneg (Nat.cast_nonneg N) hL.le) (by linarith)
   nlinarith [hfac]
+
+/-- **The strong threshold hypothesis is downward-closed in the length.**
+    `StrongRequiredBound m` implies `StrongRequiredBound k` for every `k ≤ m`: the same
+    witnesses `δ, C` work because `r_k(N) ≤ r_m(N) ≤ C·N/(log N)^{1+δ}` by `rothNumber_mono`.
+    So `∀ k ≥ 3, StrongRequiredBound k` is equivalent to the bound holding for all
+    *sufficiently large* `k` — the content is at large lengths, not small ones. Axiom-free. -/
+theorem strongRequiredBound_mono {k m : ℕ} (hkm : k ≤ m)
+    (h : StrongRequiredBound m) : StrongRequiredBound k := by
+  obtain ⟨δ, hδ, C, hC, hev⟩ := h
+  refine ⟨δ, hδ, C, hC, ?_⟩
+  filter_upwards [hev] with N hN
+  exact le_trans (by exact_mod_cast rothNumber_mono hkm) hN
+
+/-- **The weak threshold hypothesis is downward-closed in the length.**
+    `RequiredBound m` implies `RequiredBound k` for every `k ≤ m`, again by `rothNumber_mono`
+    (for each `c > 0`, `r_k(N) ≤ r_m(N) ≤ c·N/log N`). Axiom-free. -/
+theorem requiredBound_mono {k m : ℕ} (hkm : k ≤ m)
+    (h : RequiredBound m) : RequiredBound k := by
+  intro c hc
+  filter_upwards [h c hc] with N hN
+  exact le_trans (by exact_mod_cast rothNumber_mono hkm) hN
 
 /-- **The two `o(N/log N)` formulations in this file coincide.**
     `RequiredBound k` (a non-strict `r_k(N) ≤ c·N/log N` for every `c > 0`) is

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -29,16 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Repaired non-compiling file (bitrot); proved strong_required_bound_implies_conjecture 0-axiom via dyadic blocking + p-series (machine-verified, 7743 jobs). Original o(N/log N) sorry retained as threshold-critical.",
+    "progressSummary": "Structural consolidation: added rothNumber_mono (monotonicity in progression length, previously used implicitly via max k 3 but unstated) + isAPFree_of_le, downward-closure of both threshold hypotheses (strongRequiredBound_mono/requiredBound_mono), and the contrapositive density lower bound countingFunction_frequently_gt_of_divergent. All 5 machine-checked, 0-axiom, 0 new sorry. Threshold-critical o(N/log N) sorry retained.",
     "builtItems": [
       "containsAP_of_le",
       "summable_of_strongBound",
-      "strong_required_bound_implies_conjecture (0-axiom)"
+      "strong_required_bound_implies_conjecture (0-axiom)",
+      "isAPFree_of_le (AP-freeness upward-closed in length)",
+      "rothNumber_mono (Roth number monotone in progression length k)",
+      "strongRequiredBound_mono / requiredBound_mono (threshold hypotheses downward-closed in k)",
+      "countingFunction_frequently_gt_of_divergent (contrapositive density lower bound)"
     ],
     "insights": [
       "File did not compile on main (enrichment merged without build): ArithProg map/omega injectivity false for d=0, missing Decidable for Set-membership filters, orphaned /-- docstrings.",
       "The (log N)^{1+δ} threshold DOES imply Erdos #3 (dyadic blocking + convergent p-series); this is now a verified 0-axiom conditional theorem.",
-      "The o(N/log N) threshold does NOT obviously imply it: borderline profile N/(log N loglog N) is o(N/log N) with divergent reciprocal sum. That sorry is as hard as Erdos #3."
+      "The o(N/log N) threshold does NOT obviously imply it: borderline profile N/(log N loglog N) is o(N/log N) with divergent reciprocal sum. That sorry is as hard as Erdos #3.",
+      "rothNumber is monotone in k (r_k(N) <= r_m(N) for k<=m): avoiding a longer AP is an easier constraint (isAPFree_of_le), so the sup over the larger AP-free family grows. This is the structural fact the max-k-3 device relies on but never stated.",
+      "StrongRequiredBound and RequiredBound are downward-closed in k via rothNumber_mono; requiring the bound for all k>=3 equals requiring it for all sufficiently large k.",
+      "HasDivergentSum A => counting function exceeds C*N/(log N)^{1+delta} infinitely often (contrapositive of summable_of_strongBound), a reusable quantitative density lower bound."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Structural consolidation of the Erdős #3 (`$5000`, OPEN) formalization in `proofs/Proofs/Erdos3Problem.lean`. Fills a genuine gap: **monotonicity of the Roth number `r_k(N)` in the progression length `k`** was used implicitly (via the `max k 3` device in `strong_required_bound_implies_conjecture`) but never stated. Five new machine-checked lemmas, **0 new axioms, 0 new sorry**.

## New lemmas (all axiom-free, machine-checked)
- `isAPFree_of_le` — AP-freeness is upward-closed in the length (`k ≤ m`, `IsAPFree A k ⟹ IsAPFree A m`); dual to the existing `containsAP_of_le`.
- `rothNumber_mono` — `r_k(N) ≤ r_m(N)` for `k ≤ m`. Avoiding a longer progression is an easier constraint, so the AP-free family (and its `Finset.sup`) grows with `k`.
- `strongRequiredBound_mono` / `requiredBound_mono` — both threshold hypotheses are downward-closed in `k`. Consequence: requiring the bound for all `k ≥ 3` is equivalent to requiring it for all *sufficiently large* `k`.
- `countingFunction_frequently_gt_of_divergent` — contrapositive of the existing `summable_of_strongBound`, packaged as a reusable density lower bound: `HasDivergentSum A` forces the counting function to exceed `C·N/(log N)^{1+δ}` for infinitely many `N`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos3Problem` → **Build completed successfully (7743 jobs)**.
- Remaining warnings are all pre-existing and untouched: the threshold-critical `sorry` at line 161 (`required_bound_implies_conjecture`, as hard as Erdős #3 itself — deliberately not attacked), a `Try this` linter hint, and a Mathlib deprecation.

## Files modified
- `proofs/Proofs/Erdos3Problem.lean`
- `src/data/research/problems/erdos-3-incomplete-01.json` (knowledge update)

## Status
**Outcome**: progress (structural lemmas, no resolution of the open problem)
**Next Steps**: the `o(N/log N)` threshold sorry remains threshold-critical; do not attack directly.

🤖 Generated by researcher-11