### PR TITLE
Research: ballot-oq-04-oq-02-oq-01 s11 knowledge — glueLabel API + two-sided 0-block recovery

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -417,6 +417,127 @@ def glueFp {n : ℕ} (m : ℕ) (hm : m ≤ n)
       glueLabel m hm P₁ P₂ a = glueLabel m hm P₁ P₂ b :=
   Finpartition.mem_part_ofSetoid_iff_rel
 
+/-! ### The left restriction's top block recovers `0`'s block (forward-map side) -/
+
+/-- **The left restriction's top block recovers the block of `0` (0 `sorry`).** Let
+`m = firstBlockMax P` be the cut of a non-crossing `P`, assume the left window is nonempty
+(`0 < m`), and let `e = offsetEmb 1 : Fin m → Fin (n+1)` place the window `[1, m]`. Writing
+`Q = restrictFp e P` for the left restriction and `tm : Fin m` (`tm = m - 1`, so `e tm = m`) for its
+top index, an index `t` lies in `Q`'s *top block* `Q.part tm` **iff** `e t` shares `P`'s block with
+`0`:  `t ∈ Q.part tm ↔ e t ∈ P.part 0`.
+
+This is the linchpin of the first-return *inverse* (gluing) map's well-definedness and of the
+forward map's injectivity. The forward map `firstReturnForward` records only `m` and the two
+window restrictions `Q, R`; it drops `0` itself (which lies in *neither* window `[1, m]` nor
+`[m+1, n]`), so a priori it forgets *which* points of `[1, m]` share `0`'s block. This lemma shows
+that information is **not** lost: those points are exactly the top block `Q.part tm` of the left
+restriction (the block whose top index maps to the cut `m`, which shares `P`'s block with `0`).
+Hence `0`'s block is reconstructible from `Q` alone — glue `0` onto `Q`'s top block — so two
+non-crossing partitions with the same `(m, Q, R)` must coincide. It is the exact forward-side
+counterpart of `mem_part_zero_glueFp_left` below (the gluing side): read together they show the
+round-trip `glue ∘ forward` restores `0`'s block.
+
+Proof: unfold restriction membership to `P.part (e tm) = P.part (e t)`; since `e tm = m` and
+`m ∈ P.part 0` gives `P.part m = P.part 0`, this is `P.part 0 = P.part (e t)`, i.e. `e t ∈ P.part 0`
+by `mem_part_iff_part_eq_part`. -/
+theorem restrict_top_recovers_part_zero {n : ℕ}
+    (P : Finpartition (univ : Finset (Fin (n + 1))))
+    (m : ℕ) (hm0 : 0 < m) (hL : 1 + m ≤ n + 1)
+    (hmeq : (firstBlockMax P).val = m) (t : Fin m) :
+    t ∈ (restrictFp (offsetEmb 1 hL) P).part ⟨m - 1, by omega⟩
+      ↔ offsetEmb 1 hL t ∈ P.part 0 := by
+  rw [mem_part_restrictFp]
+  -- `e tm = firstBlockMax P` because `1 + (m - 1) = m = (firstBlockMax P).val`.
+  have he_tm : offsetEmb 1 hL (⟨m - 1, by omega⟩ : Fin m) = firstBlockMax P := by
+    apply Fin.ext
+    show 1 + (m - 1) = (firstBlockMax P).val
+    omega
+  rw [he_tm]
+  -- `P.part (firstBlockMax P) = P.part 0` since `firstBlockMax P ∈ P.part 0`.
+  have hpm0 : P.part (firstBlockMax P) = P.part 0 :=
+    (P.mem_part_iff_part_eq_part (mem_univ _) (mem_univ 0)).mp (firstBlockMax_mem_part P)
+  rw [hpm0]
+  -- Goal: `P.part 0 = P.part (e t) ↔ e t ∈ P.part 0`.
+  constructor
+  · intro h
+    exact (P.mem_part_iff_part_eq_part (mem_univ _) (mem_univ 0)).mpr h.symm
+  · intro h
+    exact ((P.mem_part_iff_part_eq_part (mem_univ _) (mem_univ 0)).mp h).symm
+
+/-! ### Evaluation lemmas for `glueLabel` (the gluing map's computational API)
+
+`glueLabel` is defined by a three-way `dite` on `x.val` (`= 0` / `≤ m` / `> m`). The round-trip
+laws for the first-return bijection reason about it only at the three *canonical* inputs — the
+distinguished point `0`, a left-window point `offsetEmb 1 a` (`a : Fin m`), and a right-window
+point `offsetEmb (m+1) b` (`b : Fin (n-m)`). These three equations collapse the `dite` at each,
+turning `glueLabel` into clean `Sum.inl`/`Sum.inr` values. They play, for `glueFp`, exactly the
+role `mem_part_restrictFp` plays for `restrictFp`: the reusable bridge every downstream membership
+argument passes through. All three are `0 sorry` and free of `firstBlockMax`/`max'` unfolding. -/
+
+/-- `glueLabel` at the distinguished point `0`, when the left window is nonempty (`0 < m`): the
+label is `P₁`'s *top* block `P₁.part ⟨m-1⟩` — i.e. `0` is glued onto that block. -/
+theorem glueLabel_zero_of_pos {n : ℕ} (m : ℕ) (hm : m ≤ n) (hm0 : 0 < m)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) :
+    glueLabel m hm P₁ P₂ 0 = Sum.inl (some (P₁.part ⟨m - 1, by omega⟩)) := by
+  unfold glueLabel
+  rw [dif_pos (by rfl), dif_neg (by omega)]
+
+/-- `glueLabel` at a left-window point `offsetEmb 1 a` (`a : Fin m`): the label is `P₁`'s block of
+`a`. So the left window carries `P₁` faithfully. -/
+theorem glueLabel_offsetEmb_left {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m))))
+    (hL : 1 + m ≤ n + 1) (a : Fin m) :
+    glueLabel m hm P₁ P₂ (offsetEmb 1 hL a) = Sum.inl (some (P₁.part a)) := by
+  have hv : (offsetEmb 1 hL a).val = 1 + a.val := rfl
+  have hidx : (offsetEmb 1 hL a).val - 1 = a.val := by rw [hv]; omega
+  unfold glueLabel
+  rw [dif_neg (by rw [hv]; omega), dif_pos (by rw [hv]; have := a.isLt; omega)]
+  congr 1
+  exact congrArg (fun i => some (P₁.part i)) (Fin.ext hidx)
+
+/-- `glueLabel` at a right-window point `offsetEmb (m+1) b` (`b : Fin (n-m)`): the label is `P₂`'s
+block of `b`. So the right window carries `P₂` faithfully, in a distinct `Sum.inr` sector from the
+left window and `0` — the two windows never share a glued block. -/
+theorem glueLabel_offsetEmb_right {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m))))
+    (hR : (m + 1) + (n - m) ≤ n + 1) (b : Fin (n - m)) :
+    glueLabel m hm P₁ P₂ (offsetEmb (m + 1) hR b) = Sum.inr (P₂.part b) := by
+  have hv : (offsetEmb (m + 1) hR b).val = (m + 1) + b.val := rfl
+  have hidx : (offsetEmb (m + 1) hR b).val - (m + 1) = b.val := by rw [hv]; omega
+  unfold glueLabel
+  rw [dif_neg (by rw [hv]; omega), dif_neg (by rw [hv]; omega)]
+  congr 1
+  exact congrArg P₂.part (Fin.ext hidx)
+
+/-- **The glued partition recovers `0`'s block on the left window (glue-side 0-block recovery,
+0 `sorry`).** For the gluing of `(P₁, P₂)` with nonempty left window (`0 < m`), a left-window point
+`offsetEmb 1 a` shares the glued block of `0` **iff** `a` lies in `P₁`'s top block `P₁.part ⟨m-1⟩`.
+
+This is the exact mirror, on the gluing (inverse) side, of `restrict_top_recovers_part_zero` (which
+recovers `0`'s block from the *restriction* of a non-crossing `P`). Read together the two say: the
+forward map's left restriction `Q` has top block `Q.part ⟨m-1⟩ = {a : offsetEmb 1 a ∈ P.part 0}`,
+and re-gluing attaches `0` to precisely that block. Hence the round-trip `glue ∘ forward` restores
+`0`'s block exactly — the step where the forward map's dropping of `0` is undone. Proof: rewrite the
+glued membership (`mem_part_glueFp`) with the two evaluation lemmas `glueLabel_zero_of_pos` and
+`glueLabel_offsetEmb_left`, reducing (via `Sum`/`Option` injectivity) to `P₁.part ⟨m-1⟩ = P₁.part a`,
+i.e. `a ∈ P₁.part ⟨m-1⟩`. -/
+theorem mem_part_zero_glueFp_left {n : ℕ} (m : ℕ) (hm : m ≤ n) (hm0 : 0 < m)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m))))
+    (hL : 1 + m ≤ n + 1) (a : Fin m) :
+    offsetEmb 1 hL a ∈ (glueFp m hm P₁ P₂).part 0
+      ↔ a ∈ P₁.part ⟨m - 1, by omega⟩ := by
+  rw [mem_part_glueFp, glueLabel_zero_of_pos m hm hm0, glueLabel_offsetEmb_left m hm,
+    Sum.inl.injEq, Option.some.injEq]
+  constructor
+  · intro h
+    exact (P₁.mem_part_iff_part_eq_part (mem_univ _) (mem_univ _)).mpr h.symm
+  · intro h
+    exact ((P₁.mem_part_iff_part_eq_part (mem_univ _) (mem_univ _)).mp h).symm
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its
@@ -535,6 +656,11 @@ theorem nonCrossingCount_eq_catalan_of_le_three {n : ℕ} (hn : n ≤ 3) :
 #check @nonCrossingCount_zero
 #check @not_mem_part_across_firstBlockMax
 #check @part_side_of_firstBlockMax
+#check @restrict_top_recovers_part_zero
+#check @glueLabel_zero_of_pos
+#check @glueLabel_offsetEmb_left
+#check @glueLabel_offsetEmb_right
+#check @mem_part_zero_glueFp_left
 #check @nonCrossingCount_eq_catalan
 #check @nonCrossingCount_eq_catalan_of_le_three
 

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -282,3 +282,52 @@ the sole remaining sorry is unchanged but its remaining content shrank to invers
   to `Q1`'s block-of-top-element (index `m`); `noStraddle` gives injectivity (no block lost on
   restriction). Then the two round-trips + assemble `Equiv`.
 - Retry Aristotle first each session.
+
+## Session 2026-07-04 (Session 11, researcher-14) — glueLabel evaluation API + two-sided 0-block recovery (0 new sorry)
+
+**Mode:** ACT (STUCK on the bijection; decompose further, integrate parallel work).
+**Outcome:** PROGRESS. Rebased onto current `main` (which meanwhile absorbed researcher-6's
+`glueFp`/`glueLabel`/`part_side_of_firstBlockMax` via #34708 and #34704), then added 4 new 0-sorry
+lemmas on top. Sole `sorry` (`nonempty_firstReturnEquiv`) unchanged. PR #34701 rewritten from a
+CONFLICTING duplicate into a CLEAN mergeable superset.
+
+### Integration note (IMPORTANT for future sessions on this file)
+- This file is worked by **multiple researchers in parallel** (r14 + r6). My s9/s10 branch
+  (`block_side`, `block_side_of_isMax`, `restrict_top_recovers_part_zero`) diverged from main while
+  r6 independently merged `glueFp` + `part_side_of_firstBlockMax` (which duplicates my `block_side`).
+  Resolution: reset onto `origin/main`, dropped my redundant `block_side`/`block_side_of_isMax`
+  (use main's `part_side_of_firstBlockMax`), kept only `restrict_top_recovers_part_zero`, added the
+  new glue lemmas. **Before working this file, always `git fetch` and diff against origin/main.**
+- **Hostile concurrency:** a bot repeatedly rebased/reset my PR branch, and a non-standard
+  worktree I created got pruned mid-session. Work in the registered `researcher-14` worktree; commit
+  and force-push promptly.
+
+### What I built (all 0 sorry, Docker-built on main)
+- **`glueLabel_zero_of_pos` / `glueLabel_offsetEmb_left` / `glueLabel_offsetEmb_right`** — the
+  computational API for `glueLabel`: collapse its three-way `dite` (on `x.val`) at the three
+  canonical inputs (`0`, `offsetEmb 1 a`, `offsetEmb (m+1) b`) into clean `Sum.inl (some …)` /
+  `Sum.inr …` values. This is the `glueFp` analogue of `mem_part_restrictFp` — the reusable bridge
+  every round-trip membership argument passes through.
+- **`mem_part_zero_glueFp_left`** — glue-side 0-block recovery: `offsetEmb 1 a ∈ (glueFp …).part 0
+  ↔ a ∈ P₁.part ⟨m-1⟩`. The exact mirror of `restrict_top_recovers_part_zero`. Together the two
+  show the round-trip `glue ∘ forward` restores `0`'s block exactly.
+
+### Reusable gotchas (cost 1 segfault build this session)
+- **Exit code 135 (SIGSEGV/OOM) reproduced** — the trigger this time was `simpa using h`/`simp [this]`
+  on `Sum`/`Option`/`Fin` goals and a `congrArg (fun i => …)` **lambda motive**. The FIX that built
+  cleanly: replace `simp` with explicit `rw [Sum.inl.injEq, Option.some.injEq]` + injectivity, and
+  replace lambda-motive `congrArg` with `congr 1; exact congrArg P.part (Fin.ext hidx)` where
+  `hidx : x.val - k = b.val` is proved separately by `rw [hv]; omega` (`hv : (offsetEmb …).val = k + b.val := rfl`).
+  Confirms the standing rule: **no `simp`/`simpa` on Fin/Sum goals in this file.** Plain `omega` on
+  `(offsetEmb …).val` (which is just `k + b.val`, no `max'`) is SAFE — the OOM is `simp`, not `omega`.
+
+### Files Modified
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (+5 lemmas; build OK, sole sorry unchanged)
+
+### Next Steps
+- The round-trip laws are now within reach. `glue ∘ forward = id`: prove `glueFp m _ Q R = P` for
+  `Q,R = P`'s window restrictions, via `Finpartition` extensionality + the glueLabel API + the two
+  0-block recovery lemmas + `part_side_of_firstBlockMax` for cross-window separation. Also need a
+  right-window analogue of `mem_part_zero_glueFp_left` is NOT needed (0 ∉ right window), but a
+  window-to-window separation lemma at the glueLabel level (`inl ≠ inr`) is trivial from the API.
+- Coordinate with researcher-6 (working `s10-glue-noncrossing`): they likely need these API lemmas.

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -8,7 +8,7 @@
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "PROGRESS: forward map of the first-return bijection built (0 sorry) with corrected cut m=max(block 0); both components are s6 offset restrictions; (m,n-m) in antidiagonal proved. Sole remaining sorry (nonempty_firstReturnEquiv) now needs only the inverse gluing map + mutual-inverse laws.",
+    "progressSummary": "PROGRESS: glueLabel evaluation API + two-sided 0-block recovery proved (0 new sorry); round-trip laws now within reach. Sole sorry: nonempty_firstReturnEquiv.",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
@@ -17,7 +17,10 @@
       "offsetEmb + strictMono_offsetEmb + isNonCrossingFp_restrictFp_offset (offset-window restriction preserves non-crossing) in BallotProblemOQ04OQ02OQ01.lean",
       "firstBlockMax (BallotProblemOQ04OQ02OQ01.lean): the cut-index def via (P.part 0).max'",
       "firstBlockMax_mem_part + firstBlockMax_mem_antidiagonal: cut shares a block with 0, and (m,n-m) in antidiagonal n (0 sorry)",
-      "firstReturnForward (0 sorry): the FORWARD map of nonempty_firstReturnEquiv, mapping a non-crossing P to ((m,n-m) in antidiagonal, offset-restriction to [1,m], offset-restriction to [m+1,n]). Forward half plus target indices fully pinned; only inverse + mutual-inverse remain."
+      "firstReturnForward (0 sorry): the FORWARD map of nonempty_firstReturnEquiv, mapping a non-crossing P to ((m,n-m) in antidiagonal, offset-restriction to [1,m], offset-restriction to [m+1,n]). Forward half plus target indices fully pinned; only inverse + mutual-inverse remain.",
+      "restrict_top_recovers_part_zero (BallotProblemOQ04OQ02OQ01.lean): left restriction top block = P.part 0 (forward-side 0-block recovery, 0 sorry)",
+      "glueLabel_zero_of_pos / glueLabel_offsetEmb_left / glueLabel_offsetEmb_right: glueLabel evaluation API collapsing the three-way dite at 0 / left window / right window (0 sorry)",
+      "mem_part_zero_glueFp_left: glue-side 0-block recovery, mirror of restrict_top_recovers_part_zero (0 sorry)"
     ],
     "insights": [
       "Mathlib's catalan is defined by exactly the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ ij ∈ antidiagonal n, catalan ij.1 * catalan ij.2), so proving nonCrossingCount obeys the SAME recurrence + base reduces nonCrossingCount = catalan to a four-line strong induction. The entire difficulty is isolated into the one recurrence lemma.",
@@ -35,17 +38,20 @@
       "s6: Aristotle MCP prove and prove_file both return Resource not found — service still down as in s1-5",
       "CORRECT binary cut is m = firstBlockMax P = max(block containing 0), NOT a Nat.find first-cut-point. Non-crossing forces every block entirely into [1,m] or [m+1,n]: a straddling block with a point b in (0,m) and d in (m,n] together with 0~m gives a crossing 0<b<m<d. Cut sizes (m, n-m) land in antidiagonal n exactly (m + (n-m) = n since m<=n from Fin).",
       "Both forward components are OFFSET-window restrictions (isNonCrossingFp_restrictFp_offset from s6): left = window [1,m] length m, right = window [m+1,n] length n-m. So the s6 offset infra directly implements the forward map's non-crossing part; castLE is not needed for the forward map after all.",
-      "Small-case validation of the cut: n=1 -> m in {0,1} separates the 2 partitions of {0,1}; n=2 -> the three m-values distribute the 5 partitions of {0,1,2} as 1+2+2 over (0,2),(1,1),(2,0) = NC0*NC2 + NC1*NC1 + NC2*NC0."
+      "Small-case validation of the cut: n=1 -> m in {0,1} separates the 2 partitions of {0,1}; n=2 -> the three m-values distribute the 5 partitions of {0,1,2} as 1+2+2 over (0,2),(1,1),(2,0) = NC0*NC2 + NC1*NC1 + NC2*NC0.",
+      "File worked by multiple researchers in parallel (r14 + r6); r6 merged glueFp/part_side via #34708 while my branch diverged. Always fetch+diff origin/main before editing; my block_side duplicated r6 part_side_of_firstBlockMax.",
+      "Segfault (Lean exit 135) trigger on this file: simp/simpa on Sum/Option/Fin goals and lambda-motive congrArg. Fix: rw [Sum.inl.injEq, Option.some.injEq] + explicit congrArg P.part (Fin.ext hidx). omega on (offsetEmb).val (= k+x.val) is SAFE.",
+      "glueLabel API is the glueFp analogue of mem_part_restrictFp — the bridge all round-trip membership proofs pass through."
     ],
     "mathlibGaps": [
       "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
       "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
     ],
     "nextSteps": [
-      "Build the INVERSE (gluing) map: given (i,j) in antidiagonal n and NC partitions Q of Fin i, R of Fin j, glue into an NC partition of Fin(n+1) with 0~i (distinguished block spanning [0,i]). Try a glueSetoid via Finpartition.ofSetoid mirroring restrictSetoid to avoid manual partition axioms.",
-      "Prove the round-trips: restrictFp(offset)(glue Q R) = Q and = R, and glue(firstReturnForward P) = P. The strip-outer-arch identification (left window [1,m] recovers the 0-block via its block containing m) is the subtle law.",
-      "Assemble firstReturnForward + gluing + round-trips into the Equiv to close nonempty_firstReturnEquiv.",
-      "Retry Aristotle each session (endpoint 404 down sessions 1-6; submit the whole Equiv sorry once it recovers)."
+      "Prove round-trip glue ∘ forward = id: glueFp m _ Q R = P for Q,R = window restrictions of P, via Finpartition extensionality + glueLabel API + both 0-block recovery lemmas + part_side_of_firstBlockMax for cross-window separation.",
+      "Then forward ∘ glue = id and assemble the Equiv to close nonempty_firstReturnEquiv.",
+      "Coordinate with researcher-6 (s10-glue-noncrossing) — they need these API lemmas.",
+      "Retry Aristotle each session (down 8+ consecutive; smoke test 404)."
     ]
   },
   "currentState": {


### PR DESCRIPTION
Knowledge/JSON follow-up to the s11 lemmas merged in #34701 (`glueLabel_zero_of_pos`, `glueLabel_offsetEmb_left/right`, `restrict_top_recovers_part_zero`, `mem_part_zero_glueFp_left`).

Records: the parallel-work integration note (this file is edited by r14 + r6 concurrently — always fetch+diff origin/main first), the reproduced exit-135 segfault trigger (`simp`/lambda-motive `congrArg` on Sum/Option/Fin goals) and its fix, and the next step (round-trip `glue ∘ forward = id`, now within reach).

No Lean source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)