### PR TITLE
Research: konigsberg undirected Hierholzer — Sub-lemma C (splice), VERIFIED 0-axiom

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean
@@ -1,0 +1,124 @@
+/-
+# Undirected Hierholzer — Sub-lemma C: splicing a sub-circuit into a closed trail
+
+Companion development file for `KonigsbergOQ02OQ01OQ02OQ01.lean`, whose main theorem
+`undirected_euler_circuit_sufficient` (the undirected Hierholzer sufficiency
+direction) still carries a single `sorry`. The standard proof is strong induction on
+`G.edgeFinset.card`; its three structural ingredients are:
+
+* **Sub-lemma A** — a maximal trail is closed (`eq_of_isTrail_edgeMaximal`, done in the
+  `Dev` companion): greedily extending a trail can only get stuck back at its start.
+* **Sub-lemma B** — deleting a closed trail's edges preserves the all-even-degree
+  hypothesis (`even_degree_deleteEdges_of_closed_trail`): so the induction hypothesis
+  applies to the residual graph, yielding a smaller Eulerian circuit through some shared
+  vertex.
+* **Sub-lemma C** — *splicing*: fuse that residual circuit back into the main closed
+  trail at the shared vertex to get one longer closed trail covering both edge sets.
+  This file discharges Sub-lemma C natively (0 sorries).
+
+Mathlib supplies only the *decomposition* direction for trails under `append`
+(`SimpleGraph.Walk.IsTrail.of_append_left` / `of_append_right`) — it has **no**
+construction lemma and no splice. We build both here:
+
+* `isTrail_append` — the missing converse: two trails sharing an endpoint with disjoint
+  edge lists concatenate to a trail.
+* `exists_isTrail_splice` — insert a closed trail `d` rooted at `w ∈ c.support` into a
+  closed trail `c`, producing a closed trail whose edge set is exactly `c`'s ∪ `d`'s.
+* `exists_isTrail_splice_of_mem_support` — the same, but for a residual circuit `d`
+  rooted anywhere with `w` on its support: rotate `d` to base it at `w`
+  (`SimpleGraph.Walk.IsTrail.rotate`, `rotate_edges`) and splice.
+
+All three build cleanly against Mathlib's `SimpleGraph.Walk` API with 0 sorries and 0
+new axioms.
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Combinatorics.SimpleGraph.Paths
+import Mathlib.Tactic
+
+open SimpleGraph SimpleGraph.Walk
+
+namespace UndirectedEulerSplice
+
+variable {V : Type*} {G : SimpleGraph V}
+
+/-- **Construction direction for trails under `append`.**
+Mathlib provides only the decomposition lemmas `IsTrail.of_append_left` and
+`IsTrail.of_append_right`. This is the missing converse: if `p` and `q` are trails
+sharing the endpoint `v` and their edge lists are disjoint, then `p.append q` is a
+trail. Immediate from `edges_append` and `List.Nodup.append`, but it is the workhorse
+of the Hierholzer splice below. -/
+theorem isTrail_append {u v w : V} {p : G.Walk u v} {q : G.Walk v w}
+    (hp : p.IsTrail) (hq : q.IsTrail) (hd : p.edges.Disjoint q.edges) :
+    (p.append q).IsTrail := by
+  rw [isTrail_def, edges_append]
+  exact hp.edges_nodup.append hq.edges_nodup hd
+
+/-- **Hierholzer splice (Sub-lemma C core).**
+Let `c : G.Walk x x` be a closed trail, `w` a vertex on `c`, and `d : G.Walk w w` a
+closed trail *rooted at `w`* whose edges are disjoint from those of `c`. Then inserting
+`d` into `c` at `w` — traverse `c` up to `w`, run once around `d`, then finish `c` —
+yields a closed trail `s : G.Walk x x` whose edge set is exactly the union of the edge
+sets of `c` and `d`.
+
+The concrete witness is `s = (c.takeUntil w h).append (d.append (c.dropUntil w h))`.
+Trail-ness uses the disjointness bookkeeping: the two halves of `c` are mutually
+disjoint (`IsTrail.disjoint_edges_takeUntil_dropUntil`) and each half — being a subset
+of `c.edges` — is disjoint from `d` by hypothesis. This is the inductive step that
+grows a partial Eulerian circuit by absorbing a residual sub-circuit. -/
+theorem exists_isTrail_splice [DecidableEq V] {x w : V} {c : G.Walk x x} (hc : c.IsTrail)
+    (h : w ∈ c.support) {d : G.Walk w w} (hd : d.IsTrail)
+    (hdisj : c.edges.Disjoint d.edges) :
+    ∃ s : G.Walk x x, s.IsTrail ∧ ∀ e, e ∈ s.edges ↔ e ∈ c.edges ∨ e ∈ d.edges := by
+  -- The two halves of `c` are subsets of `c.edges` and mutually disjoint.
+  have htk_sub : (c.takeUntil w h).edges ⊆ c.edges := edges_takeUntil_subset c h
+  have hdr_sub : (c.dropUntil w h).edges ⊆ c.edges := edges_dropUntil_subset c h
+  have htk_dr : (c.takeUntil w h).edges.Disjoint (c.dropUntil w h).edges :=
+    hc.disjoint_edges_takeUntil_dropUntil h
+  -- Hence each half is disjoint from `d`.
+  have htk_d : (c.takeUntil w h).edges.Disjoint d.edges :=
+    List.disjoint_of_subset_left htk_sub hdisj
+  have hdr_d : (c.dropUntil w h).edges.Disjoint d.edges :=
+    List.disjoint_of_subset_left hdr_sub hdisj
+  -- Inner walk: run `d`, then finish `c`. It is a trail (disjoint edge lists).
+  have hinner : (d.append (c.dropUntil w h)).IsTrail :=
+    isTrail_append hd (hc.dropUntil h) hdr_d.symm
+  refine ⟨(c.takeUntil w h).append (d.append (c.dropUntil w h)), ?_, ?_⟩
+  · -- The full spliced walk is a trail: the first half is disjoint from the inner walk.
+    refine isTrail_append (hc.takeUntil h) hinner ?_
+    rw [edges_append]
+    exact List.disjoint_append_right.mpr ⟨htk_d, htk_dr⟩
+  · -- Edge-set characterization: `c.edges = takeUntil ++ dropUntil`, reshuffle.
+    intro e
+    have hspec : (c.takeUntil w h).append (c.dropUntil w h) = c := take_spec c h
+    have hc_edges :
+        c.edges = (c.takeUntil w h).edges ++ (c.dropUntil w h).edges := by
+      conv_lhs => rw [← hspec]
+      rw [edges_append]
+    rw [edges_append, edges_append, hc_edges]
+    simp only [List.mem_append]
+    tauto
+
+/-- **Hierholzer splice, residual circuit rooted anywhere.**
+The form actually used in the induction: the residual Eulerian circuit `d : G.Walk y y`
+is discovered rooted at some vertex `y`, and all we know is that the shared vertex `w`
+lies on `d.support`. Rotate `d` to base it at `w` (`IsTrail.rotate` preserves the trail
+property; `rotate_edges` shows the edge list is merely rotated, hence unchanged as a
+set) and apply `exists_isTrail_splice`. The resulting closed trail again covers exactly
+`c.edges ∪ d.edges`. -/
+theorem exists_isTrail_splice_of_mem_support [DecidableEq V] {x w y : V} {c : G.Walk x x}
+    (hc : c.IsTrail)
+    (hw : w ∈ c.support) {d : G.Walk y y} (hd : d.IsTrail) (hwd : w ∈ d.support)
+    (hdisj : c.edges.Disjoint d.edges) :
+    ∃ s : G.Walk x x, s.IsTrail ∧ ∀ e, e ∈ s.edges ↔ e ∈ c.edges ∨ e ∈ d.edges := by
+  -- Rotate `d` to root it at the shared vertex `w`; the edge set is unchanged.
+  have hrot : (d.rotate hwd).IsTrail := hd.rotate hwd
+  have hperm : (d.rotate hwd).edges ~r d.edges := d.rotate_edges hwd
+  have hdisj' : c.edges.Disjoint (d.rotate hwd).edges := fun e he he' =>
+    hdisj he (hperm.mem_iff.mp he')
+  obtain ⟨s, hs, hmem⟩ := exists_isTrail_splice hc hw hrot hdisj'
+  refine ⟨s, hs, fun e => ?_⟩
+  rw [hmem e]
+  -- Membership in `(d.rotate hwd).edges` matches membership in `d.edges`.
+  rw [hperm.mem_iff]
+
+end UndirectedEulerSplice

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "konigsberg-oq-02-oq-01-oq-02-oq-01",
   "title": "Hierholzer undirected sufficiency — even-degree connected graph has an Eulerian circuit",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "blocked",
   "tier": "B",
   "path": "full",
@@ -29,11 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Hierholzer base case + continuation invariant + Sub-lemma A (maximal trail is closed) all VERIFIED; remaining: edge-removal preserves even-degree (B), splice+induction (C).",
+    "progressSummary": "PROGRESS: Hierholzer sufficiency ingredients A (maximal trail closed), B-parity + B-full deleteEdges (#34714), and C splice (#34731) all VERIFIED 0-axiom. Remaining: the strong-induction assembly (Sub-lemma D) into undirected_euler_circuit_sufficient.",
     "builtItems": [
       "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning).",
       "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries.",
-      "exists_unused_incident_edge_at_endpoint + eq_of_isTrail_edgeMaximal (Sub-lemma A: a maximal trail is closed) — VERIFIED 0 sorries in KonigsbergOQ02OQ01OQ02OQ01Dev.lean"
+      "exists_unused_incident_edge_at_endpoint + eq_of_isTrail_edgeMaximal (Sub-lemma A: a maximal trail is closed) — VERIFIED 0 sorries in KonigsbergOQ02OQ01OQ02OQ01Dev.lean",
+      "Sub-lemma C (splice) VERIFIED in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean (0 sorry, 0 axiom, 3 thms): isTrail_append (construction converse Mathlib omits), exists_isTrail_splice (insert closed trail d rooted at w∈c.support into closed trail c, edge set = c∪d, witness (c.takeUntil w).append (d.append (c.dropUntil w))), exists_isTrail_splice_of_mem_support (residual circuit rooted anywhere; rotate to w then splice)"
     ],
     "insights": [
       "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
@@ -44,7 +45,10 @@
       "Confirmed (web search + local check): Mathlib4 Trails module has only the necessity/property lemmas (IsEulerian.even_degree_iff, IsEulerian.card_odd_degree). No Eulerian existence/Hierholzer construction exists upstream, so sufficiency must be built natively.",
       "The directed Digraph proof in KonigsbergOQ02OQ01.lean is NOT reusable: it is built on a bespoke Digraph structure with its own Walk/splice/removeArcList/arcCount — none are SimpleGraph.Walk objects. A native SimpleGraph mirror is required.",
       "Aristotle backend returned Resource not found for prove, prove_file, and a trivial inline (1+1=2) prove this session — full backend outage, delegation unavailable. Resubmit the single sorry when backend recovers (known classical result, ideal Aristotle target).",
-      "Sub-lemma A reduces to Mathlib IsTrail.even_countP_edges_iff: p-edges incident to a non-start vertex v number ODD, total incident = degree is EVEN, so an unused incident edge always exists (proper-subset parity argument)."
+      "Sub-lemma A reduces to Mathlib IsTrail.even_countP_edges_iff: p-edges incident to a non-start vertex v number ODD, total incident = degree is EVEN, so an unused incident edge always exists (proper-subset parity argument).",
+      "Mathlib has only the DECOMPOSITION direction for trails under append (IsTrail.of_append_left/of_append_right); the CONSTRUCTION direction (disjoint-edge trails concatenate to a trail) and the splice are absent and were built natively.",
+      "Splice needs [DecidableEq V] because takeUntil/dropUntil/rotate require it; isTrail_append does not.",
+      "rotate_edges gives (d.rotate h).edges ~r d.edges (List.IsRotated), so .mem_iff transports edge membership — lets a residual circuit rooted anywhere be re-based at the shared vertex without changing its edge set."
     ],
     "mathlibGaps": [
       "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."
@@ -55,7 +59,9 @@
       "Consider building an undirected splice + edgeRemoval operation mirroring KonigsbergOQ02OQ01.lean removeArcList; estimate 600-1000 lines. This is the main effort and may warrant Aristotle or a dedicated multi-session build.",
       "Prove inductive step sub-lemma A: in an all-even-degree graph with ≥1 edge, a maximal trail from any positive-degree vertex is CLOSED (parity/handshake: current endpoint always has an unused incident edge unless back at start).",
       "Prove sub-lemma B: deleting the edges of a closed trail (G.deleteEdges on the trail edge set) preserves ∀ v, Even (degree v) — each vertex loses an even number of incident trail-edges.",
-      "Prove sub-lemma C (splice): a residual closed trail sharing a vertex with the main circuit can be spliced in, maintaining the per-edge count=1 invariant; combine with strong induction on G.edgeFinset.card using the verified base case."
+      "Prove sub-lemma C (splice): a residual closed trail sharing a vertex with the main circuit can be spliced in, maintaining the per-edge count=1 invariant; combine with strong induction on G.edgeFinset.card using the verified base case.",
+      "Sub-lemma D / assembly: strong induction on G.edgeFinset.card wiring A (maximal trail closed) + B (deleteEdges preserves even degree, #34714) + C (splice, #34731). Grow a maximal closed trail c; if it misses an edge, connectivity gives a shared vertex w on c.support incident to the residual graph; the IH on the smaller residual graph yields a closed Eulerian sub-circuit d through w; exists_isTrail_splice_of_mem_support fuses them; the edge-set union closes the induction.",
+      "Need: a bridge lemma that the residual circuit d has edges disjoint from c (immediate: d lives in G.deleteEdges c.edges) and that if a maximal trail is not Eulerian, connectivity supplies a support vertex incident to an unused edge."
     ],
     "markdown": "# Knowledge Base: konigsberg-oq-02-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Adds the **third structural ingredient** of the undirected Hierholzer sufficiency
induction — the **splice** (Sub-lemma C) — as a new self-contained, VERIFIED file
`proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean` (3 theorems, 124 lines, **0 sorries, 0 axioms**).

This complements the existing pieces for `undirected_euler_circuit_sufficient`:
- **Sub-lemma A** — a maximal trail is closed (`eq_of_isTrail_edgeMaximal`, in the `Dev` companion).
- **Sub-lemma B** — deleting a closed trail's edges preserves all-even-degree (PR #34714).
- **Sub-lemma C** — *splice* a residual sub-circuit back into the main closed trail (this PR).

## What's proved

Mathlib ships only the **decomposition** direction for trails under `append`
(`IsTrail.of_append_left` / `of_append_right`) — no construction lemma and no splice.
Both are built here:

- `isTrail_append` — the missing converse: two trails sharing an endpoint with disjoint
  edge lists concatenate to a trail.
- `exists_isTrail_splice` — insert a closed trail `d : G.Walk w w` rooted at a shared
  vertex `w ∈ c.support` into a closed trail `c : G.Walk x x`, producing a closed trail
  whose edge set is exactly `c.edges ∪ d.edges`.
  Witness: `(c.takeUntil w).append (d.append (c.dropUntil w))`.
- `exists_isTrail_splice_of_mem_support` — the induction-facing form: the residual
  circuit `d : G.Walk y y` is discovered rooted anywhere with `w` merely on `d.support`;
  rotate `d` to base it at `w` (`IsTrail.rotate` + `rotate_edges`, so the edge set is
  unchanged) and splice.

## Notes

- New file only — **no overlap** with the `Dev` companion or PR #34714, so no merge conflict.
- Builds cleanly via `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ02OQ01OQ02OQ01Splice`
  (one transient SIGBUS/codegen flake on first attempt; clean on retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)