### PR TITLE
Enrich Pythagorean Triples (Gaussian): link elementary classification sibling

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
@@ -119,6 +119,11 @@
       "relationship": "related",
       "description": "The hypotenuse corollary here — every positive primitive triple has z = m²+n² = N(m+ni), a sum of two squares — is the Pythagorean shadow of Fermat's two-squares theorem. Both rest on the same arithmetic of ℤ[i]: this entry exhibits sums of two squares as Gaussian norms of squares z², while that entry characterizes exactly which primes (and integers) are sums of two squares. Named in open question 1.",
       "targetId": "fermat-two-squares"
+    },
+    {
+      "relationship": "related",
+      "description": "A sibling classification of the very same theorem — every primitive triple is (m²−n², 2mn, m²+n²) — but framed through the elementary Euclid identity rather than the Gaussian-square narrative used here. Both bridge Mathlib's PythagoreanTriple.coprime_classification; reading the two side by side separates the conceptual content (why ℤ[i] makes the parametrization inevitable) from the bare algebraic statement, and its standard-form theorem mirrors this entry's primitive_classification_pos.",
+      "targetId": "pythagorean-triples-oq-06"
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-02-oq-01` (Pythagorean Triples: Complete Classification via Gaussian Integers).

**Change (meta.json only):**
- Added a cross-reference to `pythagorean-triples-oq-06`, a sibling that classifies the *same* primitive-triple theorem via the elementary Euclid framing rather than this entry's Gaussian-square narrative. Both bridge Mathlib's `PythagoreanTriple.coprime_classification`; the link lets a reader compare the conceptual (ℤ[i]-UFD) account here against the bare algebraic statement there, and pairs this entry's `primitive_classification_pos` with the sibling's standard form.

Built from fresh `origin/main` content, so no other fields are touched. meta.json 15.0 KB (well under the ~60 KB cap); crossReferences now 4 (cap 20). All four cross-reference targets verified present in the gallery. No annotation or Lean-source changes; axiom/status fields unchanged.
