### PR TITLE
Enrich Rational Root Theorem: cross-ref nth-root-irrational generalization

### DIFF
--- a/src/data/proofs/integral-root-theorem-oq-01/meta.json
+++ b/src/data/proofs/integral-root-theorem-oq-01/meta.json
@@ -100,6 +100,11 @@
       "proofId": "fourth-root-2-irrational",
       "relationship": "related",
       "description": "Pushes the irrationality of ⁴√2 to a full minimal-polynomial statement: X⁴ − 2 is not merely rootless over ℚ but irreducible (via Eisenstein + Gauss), giving [ℚ(⁴√2):ℚ] = 4. It shows where the rational root theorem stops (ruling out linear factors) and irreducibility criteria take over (ruling out all factorizations)."
+    },
+    {
+      "proofId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "The full generalization flagged in this entry's open questions: for any n ≥ 2 and m ≥ 1 not a perfect nth power, ⁿ√m is irrational. It is the rational-root engine here run at arbitrary degree — ⁿ√m is a root of the monic Xⁿ − m, so by monic_root_isInteger it would be an integer, contradicting m not being a perfect nth power. This file instantiates that template at n = 2, m = 2 (√2); nth-root-irrational states it once and for all."
     }
   ],
   "leanFile": {
@@ -176,7 +181,7 @@
     "summary": "Formalizes the rational root theorem over ℤ ⊂ ℚ — the numerator of a rational root divides the constant term (num_dvd_of_root) and the denominator divides the leading coefficient (den_dvd_of_root) — and the monic corollary that rational roots are integers (monic_root_isInteger). As an application it proves √2 irrational (no_rat_sq_eq_two), via the monic polynomial X² − 2 and the finite check that no integer squares to 2 (no_int_sq_eq_two). All 6 theorems verified with 0 sorries and 0 axioms, no native_decide.",
     "implications": "The rational root theorem restricts rational roots of integer polynomials to a finite, computable candidate set, and its monic case expresses the integral closedness of ℤ in ℚ. It mechanizes a whole family of irrationality proofs (√2, ∛2, ⁿ√p) and complements Eisenstein's criterion: one rules out roots, the other certifies irreducibility.",
     "openQuestions": [
-      "Generalize the irrationality application to ⁿ√p for an arbitrary prime p and n ≥ 2 via the monic Xⁿ − p",
+      "Generalize the irrationality application to ⁿ√m for arbitrary n ≥ 2 and non-perfect-power m via the monic Xⁿ − m (realized in the gallery as nth-root-irrational); here the argument is instantiated at n = 2, m = 2",
       "State the full candidate-enumeration corollary: a rational root a/b has a ∣ p.coeff 0 and b ∣ p.leadingCoeff with gcd(a,b) = 1",
       "Connect to Gauss's lemma and Eisenstein: a monic integer polynomial with no rational root and degree ≤ 3 is irreducible over ℚ"
     ]


### PR DESCRIPTION
Enrichment pass for `integral-root-theorem-oq-01` (The Rational Root Theorem and Integrality of Monic Roots).

**Changes (meta.json only):**
- Added a cross-reference to `nth-root-irrational` — the full ⁿ√m generalization this entry flags in its open questions. That entry runs the same monic-roots-are-integers engine (`monic_root_isInteger` on the monic Xⁿ − m) at arbitrary degree; this file instantiates it at n = 2, m = 2 (√2).
- Refined the first open question to note the generalization is realized in the gallery as `nth-root-irrational`, rather than presenting it as unrealized.

Built from fresh `origin/main` content; no other fields touched. All cross-reference targets verified present. meta.json 15.7 KB (well under the ~60 KB cap); cross-references now 5 (cap 20). No annotation or Lean-source changes; axiom/status fields unchanged (0 sorries, 0 axioms, no native_decide).

(Supersedes the earlier no-op PR #34730, which was accidentally shipped empty due to a working-tree race.)
