### PR TITLE
Enrich Dihedral-Solvable: add module-header section for full-file coverage

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
@@ -51,6 +51,14 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header: Dihedral Groups Are Solvable",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring settling the dihedral half of the parent entry's open question: DihedralGroup n is solvable for every n (including n = 0, the infinite dihedral group), an infinite solvable family that contrasts with Sₙ becoming non-solvable at n = 5 — showing the Abel–Ruffini obstruction is special to the symmetric groups. States the structural reason (Dₙ is metabelian: a cyclic normal rotation subgroup ⟨r⟩ ≅ ℤ/n of index 2 with abelian quotient ℤ/2), the proof plan via solvable_of_ker_le_range, and that Mathlib had no prior DihedralGroup solvability result. Notes the GLₙ(𝔽ₚ) non-solvability half is left open.",
+      "mathContext": "$D_n$ metabelian: $1 \\to \\mathbb{Z}/n \\to D_n \\to \\mathbb{Z}/2 \\to 1$ with both ends abelian $\\Rightarrow \\mathrm{IsSolvable}(D_n)$ for all $n$; contrast $S_5$ not solvable."
+    },
+    {
       "id": "two-homomorphisms",
       "title": "The Parity Hom and the Rotation Inclusion",
       "startLine": 50,


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-04` (Dihedral Groups Are Solvable).

**Change (meta.json only):** The three existing `sections` accurately cover lines 50–112, but the 49-line module header (imports + docstring) had no section. Added a **Module Header** section (1–49) with an accurate summary and `mathContext`, completing coverage of the full 113-line Lean file — the docstring settles the dihedral half of the parent's open question (Dₙ metabelian ⇒ solvable for all n, contrasting Sₙ) and flags the GLₙ(𝔽ₚ) half as still open.

Built from fresh `origin/main`; no other fields touched. All 3 cross-reference targets verified present. meta.json remains well under the ~60 KB cap. No annotation or Lean-source changes; axiom/status fields unchanged.
