### PR TITLE
Enrich Rational Root Theorem (integral-root-theorem-oq-01): fix section coverage

### DIFF
--- a/src/data/proofs/integral-root-theorem-oq-01/meta.json
+++ b/src/data/proofs/integral-root-theorem-oq-01/meta.json
@@ -67,7 +67,7 @@
       "id": "sec-divisibility",
       "title": "The Rational Root Theorem over Z ⊂ Q",
       "startLine": 30,
-      "endLine": 47,
+      "endLine": 54,
       "summary": "num_dvd_of_root (numerator of a rational root divides p.coeff 0) and den_dvd_of_root (denominator divides p.leadingCoeff), specializing Mathlib's num_dvd_of_is_root / den_dvd_of_is_root to Z ⊂ Q via IsFractionRing.num/.den. Also isInteger_of_monic_root and monic_root_isInteger: a rational root of a monic integer polynomial is an integer.",
       "mathContext": "$a\\mid p.\\mathrm{coeff}\\,0$, $b\\mid p.\\mathrm{leadingCoeff}$; monic $\\Rightarrow \\exists z\\in\\mathbb{Z},(z:\\mathbb{Q})=r$."
     },


### PR DESCRIPTION
Enrichment pass for `integral-root-theorem-oq-01` (Rational Root Theorem).

**Accuracy fix**: the `sec-divisibility` section claimed (in its summary) to cover `monic_root_isInteger` — the headline monic-roots-are-integers corollary — but its `endLine` was 47, stopping before that theorem's body (lines 49–54). This left the corollary uncovered by any section (gap between `endLine: 47` and `sec-sqrt2`'s `startLine: 56`). Extended `endLine` to 54 so the three sections now fully tile the 79-line Lean file (1–23, 30–54, 56–79).

Entry already meets all quality targets (5 annotations with mathContext/significance/relatedConcepts/prerequisites, 5 keyInsights, 5 cross-references, conclusion with implications + 3 open questions, 6 documented main theorems); verified accurate against `Proofs/IntegralRootTheoremOQ01.lean`. meta.json 15.7 KB, within the 60 KB cap. No content inflation.
