### PR TITLE
Research: erdos-3-incomplete-01 — Roth number monotone in window N + baseline r_k(N) ≤ N+1

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -218,6 +218,39 @@ theorem rothNumber_mono {k m N : ℕ} (hkm : k ≤ m) :
   rw [Finset.mem_filter] at hS ⊢
   exact ⟨hS.1, isAPFree_of_le hkm hS.2⟩
 
+/-- **The Roth number is monotone in the search window `N`.**
+    `r_k(M) ≤ r_k(N)` whenever `M ≤ N`. Enlarging the interval `{0,…,N}` can only add
+    AP-free subsets to the family the supremum ranges over (every AP-free subset of
+    `{0,…,M}` is still an AP-free subset of `{0,…,N}`), so `r_k` only grows. This is the
+    `N`-analogue of `rothNumber_mono` (monotone in the length `k`), and is exactly the
+    monotonicity used implicitly whenever the Roth number is compared across dyadic scales
+    `2^j ≤ 2^{j+1}` in the summation arguments. Fully machine-checked, axiom-free. -/
+theorem rothNumber_mono_size {k M N : ℕ} (hMN : M ≤ N) :
+    rothNumber k M ≤ rothNumber k N := by
+  unfold rothNumber
+  apply Finset.sup_mono
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS ⊢
+  refine ⟨hS.1.trans ?_, hS.2⟩
+  intro x hx
+  rw [Finset.mem_range] at hx ⊢
+  omega
+
+/-- **The trivial upper bound on the Roth number.**
+    `r_k(N) ≤ N + 1`. Every subset of `{0,…,N}` has at most `N + 1` elements, so in
+    particular every AP-free one does, and the supremum defining `r_k(N)` is bounded by the
+    cardinality `N + 1` of the whole interval. This is the baseline density — the entire
+    window `{0,…,N}` — against which every `o(N/log N)` improvement in the Roth/Szemerédi
+    literature is measured; the open content of Erdős #3 is precisely how far below this
+    baseline `r_k(N)` can be forced. Fully machine-checked, axiom-free. -/
+theorem rothNumber_le_window (k N : ℕ) : rothNumber k N ≤ N + 1 := by
+  unfold rothNumber
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter, Finset.mem_powerset] at hS
+  calc S.card ≤ (Finset.range (N + 1)).card := Finset.card_le_card hS.1
+    _ = N + 1 := Finset.card_range (N + 1)
+
 /-- **A genuine `k`-term AP has exactly `k` elements.**
     When the common difference `d` is positive, the generating map `i ↦ a + i·d`
     is injective on `range k`, so `ArithProg a d k` has cardinality `k`.  (This is

--- a/src/data/research/problems/erdos-3-incomplete-01.json
+++ b/src/data/research/problems/erdos-3-incomplete-01.json
@@ -18,7 +18,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-04-03T08:28:28Z",
-    "iteration": 2,
+    "iteration": 3,
     "focus": "Verified StrongRequiredBound reduction; original o(N/log N) sorry is threshold-critical (open)",
     "blockers": [],
     "nextAction": "Leave threshold-critical sorry documented; optional shallow follow-ups",
@@ -29,13 +29,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Structural consolidation: added rothNumber_mono (monotonicity in progression length, previously used implicitly via max k 3 but unstated) + isAPFree_of_le, downward-closure of both threshold hypotheses (strongRequiredBound_mono/requiredBound_mono), and the contrapositive density lower bound countingFunction_frequently_gt_of_divergent. All 5 machine-checked, 0-axiom, 0 new sorry. Threshold-critical o(N/log N) sorry retained.",
+    "progressSummary": "Structural consolidation of the Roth-number monotonicity story. Prior iterations added rothNumber_mono (monotone in progression length k) + isAPFree_of_le, downward-closure of both threshold hypotheses, and the contrapositive density lower bound. This iteration completes the picture with the two structural facts that were still missing: rothNumber_mono_size (monotone in the search window N, the N-analogue of rothNumber_mono used implicitly at dyadic scales) and rothNumber_le_window (the trivial baseline r_k(N) <= N+1 against which all o(N/log N) improvements are measured). All machine-checked, 0-axiom, 0 new sorry. Threshold-critical o(N/log N) sorry retained (as hard as Erdos #3).",
     "builtItems": [
       "containsAP_of_le",
       "summable_of_strongBound",
       "strong_required_bound_implies_conjecture (0-axiom)",
       "isAPFree_of_le (AP-freeness upward-closed in length)",
       "rothNumber_mono (Roth number monotone in progression length k)",
+      "rothNumber_mono_size (Roth number monotone in search window N)",
+      "rothNumber_le_window (trivial baseline r_k(N) <= N+1)",
       "strongRequiredBound_mono / requiredBound_mono (threshold hypotheses downward-closed in k)",
       "countingFunction_frequently_gt_of_divergent (contrapositive density lower bound)"
     ],
@@ -45,11 +47,14 @@
       "The o(N/log N) threshold does NOT obviously imply it: borderline profile N/(log N loglog N) is o(N/log N) with divergent reciprocal sum. That sorry is as hard as Erdos #3.",
       "rothNumber is monotone in k (r_k(N) <= r_m(N) for k<=m): avoiding a longer AP is an easier constraint (isAPFree_of_le), so the sup over the larger AP-free family grows. This is the structural fact the max-k-3 device relies on but never stated.",
       "StrongRequiredBound and RequiredBound are downward-closed in k via rothNumber_mono; requiring the bound for all k>=3 equals requiring it for all sufficiently large k.",
-      "HasDivergentSum A => counting function exceeds C*N/(log N)^{1+delta} infinitely often (contrapositive of summable_of_strongBound), a reusable quantitative density lower bound."
+      "HasDivergentSum A => counting function exceeds C*N/(log N)^{1+delta} infinitely often (contrapositive of summable_of_strongBound), a reusable quantitative density lower bound.",
+      "rothNumber is monotone in the window N as well as in k: r_k(M) <= r_k(N) for M<=N via powerset_mono on the range(M+1) subset range(N+1) inclusion (rothNumber_mono_size). This is the monotonicity used implicitly when comparing r_k across dyadic scales 2^j <= 2^{j+1}.",
+      "Trivial baseline r_k(N) <= N+1 (rothNumber_le_window): the whole window {0..N} caps every AP-free subset's card via Finset.sup_le + card_range. Every published o(N/log N) bound is an improvement below this baseline; Erdos #3's open content is how far below it r_k can be forced."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Do not attack the threshold-critical sorry directly",
+      "Monotonicity story now complete (k-direction + N-direction + baseline bound)",
       "Optional: k<=2 triviality corollary; reuse summable_of_strongBound elsewhere"
     ],
     "markdown": "# Knowledge: erdos-3-incomplete-01\n\n## Research Notes\n\n*No research conducted yet. See problem.md for context.*\n\n## Known Facts\n\n- Lean file: `proofs/Proofs/`\n- Sorries: see problem.md\n\n## Approaches Tried\n\n*None yet.*\n"
@@ -64,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.083Z",
-  "lastUpdate": "2026-04-03T08:30:19.059Z",
+  "lastUpdate": "2026-07-04T22:30:00.000Z",
   "significance": 8,
   "tractability": 4
 }


### PR DESCRIPTION
## Summary

Two new verified structural lemmas for **Erdős Problem #3** (`Proofs/Erdos3Problem.lean`), completing the Roth-number monotonicity story. Prior iterations proved `rothNumber_mono` (monotone in progression length `k`); this adds the two facts that were still implicit:

- **`rothNumber_mono_size`** — `r_k(M) ≤ r_k(N)` for `M ≤ N`. Monotonicity in the *search window*: enlarging `{0,…,N}` only adds AP-free subsets to the family the supremum ranges over. This is exactly the monotonicity used implicitly whenever `r_k` is compared across dyadic scales `2^j ≤ 2^{j+1}` in the summation arguments already in the file.
- **`rothNumber_le_window`** — `r_k(N) ≤ N + 1`, the trivial baseline (the whole window `{0,…,N}` caps every AP-free subset's cardinality). Every published `o(N/log N)` improvement is measured below this baseline; the open content of Erdős #3 is precisely how far below it `r_k` can be forced.

## Verification

- Docker build **succeeds** (`./proofs/scripts/docker-build.sh Proofs.Erdos3Problem`).
- Both lemmas: **0 new sorry, 0 axioms** (elementary `Finset.sup_mono` / `Finset.sup_le` arguments).
- The pre-existing threshold-critical `required_bound_implies_conjecture` sorry (as hard as Erdős #3 itself) is **retained** and untouched — not attacked, per the problem's ACT-phase guidance.

## Files

- `proofs/Proofs/Erdos3Problem.lean` — two new theorems after `rothNumber_mono`.
- `src/data/research/problems/erdos-3-incomplete-01.json` — knowledge update (builtItems, insights, iteration 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)