### PR TITLE
Research: ballot-oq-04-oq-02-oq-01 COMPLETE — nonCrossingCount n = catalan n proved (0 sorry, verified)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -40,19 +40,20 @@ reduction in the spirit of "one structural theorem in place of an explicit bijec
 
 ## Status
 
-**Sorry count**: 1 (`nonempty_firstReturnEquiv` — the first-return bijection). The numeric
-recurrence `nonCrossingCount_recurrence` and its counting reduction
-`nonCrossingCount_recurrence_of_equiv` are now **proved (0 `sorry`)**; the open content is
-exactly the existence of the bijection, with all cardinality arithmetic discharged.
+**Sorry count**: 0. The conjecture `nonCrossingCount n = catalan n` is now **fully proved**
+(`nonCrossingCount_eq_catalan`). The first-return bijection `nonempty_firstReturnEquiv` — the
+formerly-open combinatorial heart — is discharged by an equinumerosity count
+(`card_lhs_eq_card_rhs`): the two sides of the decomposition are shown to have equal cardinality
+via antisymmetry of two explicit injections (`fwdMid` / `glMid`), and `Fintype.equivOfCardEq`
+then supplies the (noncomputable) bijection. This sidesteps the dependent-`HEq` casts a *natural*
+equiv would require by routing through the `Fin (n+1)`-indexed intermediate type `MidNc`, whose
+window fibers match `glueFp`'s signature definitionally.
 
-**Axiom count**: 0 literal `axiom` declarations; the proved results use only the foundational
-`propext`/`Classical.choice`/`Quot.sound` (the latter via `.some` on the bijection's
-`Nonempty`). Because a `sorry` remains, the gallery status of this entry is `formalized`, not
-`verified`.
-
-The outstanding bijection is the natural target for proof search: it is *known* mathematics
-(the non-crossing-partition Catalan decomposition) requiring a delicate but standard
-construction, exactly the regime where automated formalization is appropriate.
+**Axiom count**: 0 literal `axiom` declarations and 0 structure-encoded assumptions. The proof
+uses only the foundational `propext`/`Classical.choice`/`Quot.sound` (`Classical.choice` via
+`Fintype.equivOfCardEq` and `.some` on the bijection's `Nonempty`) — no `sorryAx`, no
+`Lean.ofReduceBool` (the `n ≤ 3` corollary uses kernel `decide`, not `native_decide`). The
+gallery status of this entry is therefore `verified`.
 -/
 
 import Mathlib
@@ -935,6 +936,129 @@ theorem glueFp_restrictFp_eq_self {n : ℕ}
   rw [hkey, P.mem_part_iff_part_eq_part (mem_univ b) (mem_univ a)]
   exact eq_comm
 
+/-! ### Assembling the first-return bijection via a cardinality count
+
+The round-trip laws above (`glueFp_restrictFp_eq_self`, `restrictFp_glueFp_left`/`_right`,
+`firstBlockMax_glueFp_val`) are now packaged into the existence of `nonempty_firstReturnEquiv`.
+
+Rather than fight the dependent-`HEq` casts a *natural* `Equiv` between the antidiagonal-indexed
+`Σ`-type and the non-crossing partitions would demand — the forward map's cut index equals the
+target index only *propositionally*, so matching the two dependent fibers needs transport — we route
+through an intermediate type `MidNc n` indexed by `m : Fin (n+1)`, whose right fiber `Fin (n - m)`
+matches `glueFp`'s argument type **definitionally**. Gluing then needs no cast, both round-trips are
+clean, and `card (LhsNc) = card (MidNc)` follows by antisymmetry of two injections
+(`fwdMid` with left inverse `glMid`; `glMid` injective by recovering the cut and both factors).
+A pure `antidiagonal ↔ range` reindexing gives `card (MidNc) = card (Rhs)`, and
+`Fintype.equivOfCardEq` finally produces the (noncomputable) bijection — no cast bookkeeping. -/
+
+/-- Non-crossing partitions of `Fin k`, as a subtype (the fibers of the first-return split). -/
+abbrev NcFp (k : ℕ) := {P : Finpartition (univ : Finset (Fin k)) // IsNonCrossingFp P}
+
+/-- The intermediate `Fin (n+1)`-indexed home of the first-return split: a cut index `m` together
+with non-crossing partitions of the two windows `Fin m` and `Fin (n - m)`. Its right fiber matches
+`glueFp`'s argument type definitionally, so gluing needs no cast. -/
+abbrev MidNc (n : ℕ) := Σ m : Fin (n + 1), NcFp m.val × NcFp (n - m.val)
+
+/-- Forward map into the intermediate type: cut a non-crossing `P` at `m = firstBlockMax P` and
+restrict to the two offset windows `[1, m]` and `[m+1, n]`. -/
+def fwdMid {n : ℕ} (P : NcFp (n + 1)) : MidNc n :=
+  let m := firstBlockMax P.1
+  have hm : m.val ≤ n := Nat.lt_succ_iff.mp m.isLt
+  have hL : 1 + m.val ≤ n + 1 := by omega
+  have hR : (m.val + 1) + (n - m.val) ≤ n + 1 := by omega
+  ⟨m,
+    ⟨restrictFp (offsetEmb 1 hL) P.1, isNonCrossingFp_restrictFp_offset 1 hL P.1 P.2⟩,
+    ⟨restrictFp (offsetEmb (m.val + 1) hR) P.1,
+      isNonCrossingFp_restrictFp_offset (m.val + 1) hR P.1 P.2⟩⟩
+
+/-- Inverse (gluing) map from the intermediate type: glue the two windows back at the cut. -/
+def glMid {n : ℕ} (x : MidNc n) : NcFp (n + 1) :=
+  ⟨glueFp x.1.val (Nat.lt_succ_iff.mp x.1.isLt) x.2.1.1 x.2.2.1,
+    isNonCrossingFp_glueFp x.1.val (Nat.lt_succ_iff.mp x.1.isLt) x.2.1.1 x.2.2.1 x.2.1.2 x.2.2.2⟩
+
+/-- `glMid ∘ fwdMid = id`: gluing the two window restrictions recovers `P` (the `left_inv` core,
+`glueFp_restrictFp_eq_self`). -/
+theorem glMid_fwdMid {n : ℕ} (P : NcFp (n + 1)) : glMid (fwdMid P) = P := by
+  apply Subtype.ext
+  exact glueFp_restrictFp_eq_self P.1 P.2 _ _ _
+
+/-- The forward map is injective (it has a left inverse). -/
+theorem fwdMid_injective {n : ℕ} : Function.Injective (fwdMid (n := n)) :=
+  Function.LeftInverse.injective glMid_fwdMid
+
+/-- The gluing map is injective: from `glMid x = glMid x'` the cut index is recovered by
+`firstBlockMax_glueFp_val` (an `ℕ`-level equality, so no `HEq`), and after substituting it the two
+factors are recovered by `restrictFp_glueFp_left`/`_right`. -/
+theorem glMid_injective {n : ℕ} : Function.Injective (glMid (n := n)) := by
+  rintro ⟨m, ⟨P₁, h₁⟩, ⟨P₂, h₂⟩⟩ ⟨m', ⟨P₁', h₁'⟩, ⟨P₂', h₂'⟩⟩ hEq
+  have hg : glueFp m.val (Nat.lt_succ_iff.mp m.isLt) P₁ P₂
+      = glueFp m'.val (Nat.lt_succ_iff.mp m'.isLt) P₁' P₂' := congrArg Subtype.val hEq
+  have hmm : m.val = m'.val := by
+    have e1 := firstBlockMax_glueFp_val m.val (Nat.lt_succ_iff.mp m.isLt) P₁ P₂
+    have e2 := firstBlockMax_glueFp_val m'.val (Nat.lt_succ_iff.mp m'.isLt) P₁' P₂'
+    rw [hg] at e1
+    exact e1.symm.trans e2
+  have hm_eq : m = m' := Fin.ext hmm
+  subst hm_eq
+  have hL : 1 + m.val ≤ n + 1 := by omega
+  have hR : (m.val + 1) + (n - m.val) ≤ n + 1 := by omega
+  have hP₁ : P₁ = P₁' :=
+    (restrictFp_glueFp_left m.val (Nat.lt_succ_iff.mp m.isLt) hL P₁ P₂).symm.trans
+      (by rw [hg]; exact restrictFp_glueFp_left m.val (Nat.lt_succ_iff.mp m.isLt) hL P₁' P₂')
+  have hP₂ : P₂ = P₂' :=
+    (restrictFp_glueFp_right m.val (Nat.lt_succ_iff.mp m.isLt) hR P₁ P₂).symm.trans
+      (by rw [hg]; exact restrictFp_glueFp_right m.val (Nat.lt_succ_iff.mp m.isLt) hR P₁' P₂')
+  subst hP₁; subst hP₂; rfl
+
+/-- `card (MidNc n)` as an explicit convolution sum over `range (n+1)`. -/
+theorem card_midNc_eq (n : ℕ) :
+    Fintype.card (MidNc n)
+      = ∑ k ∈ Finset.range (n + 1),
+          Fintype.card {P : Finpartition (univ : Finset (Fin k)) // IsNonCrossingFp P}
+        * Fintype.card {P : Finpartition (univ : Finset (Fin (n - k))) // IsNonCrossingFp P} := by
+  show Fintype.card (Σ m : Fin (n + 1),
+      {P : Finpartition (univ : Finset (Fin m.val)) // IsNonCrossingFp P} ×
+      {P : Finpartition (univ : Finset (Fin (n - m.val))) // IsNonCrossingFp P}) = _
+  rw [Fintype.card_sigma]
+  simp only [Fintype.card_prod]
+  rw [Fin.sum_univ_eq_sum_range
+    (fun k => Fintype.card {P : Finpartition (univ : Finset (Fin k)) // IsNonCrossingFp P}
+            * Fintype.card {P : Finpartition (univ : Finset (Fin (n - k))) // IsNonCrossingFp P})
+    (n + 1)]
+
+/-- `card` of the antidiagonal-indexed `Σ`-type as the same convolution sum over `range (n+1)`. -/
+theorem card_rhs_eq (n : ℕ) :
+    Fintype.card (Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
+        {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
+        {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P})
+      = ∑ k ∈ Finset.range (n + 1),
+          Fintype.card {P : Finpartition (univ : Finset (Fin k)) // IsNonCrossingFp P}
+        * Fintype.card {P : Finpartition (univ : Finset (Fin (n - k))) // IsNonCrossingFp P} := by
+  rw [Fintype.card_sigma]
+  simp only [Fintype.card_prod]
+  rw [Finset.sum_coe_sort (antidiagonal n)
+    (fun ij => Fintype.card {P : Finpartition (univ : Finset (Fin ij.1)) // IsNonCrossingFp P}
+             * Fintype.card {P : Finpartition (univ : Finset (Fin ij.2)) // IsNonCrossingFp P})]
+  rw [Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+    (fun ij => Fintype.card {P : Finpartition (univ : Finset (Fin ij.1)) // IsNonCrossingFp P}
+             * Fintype.card {P : Finpartition (univ : Finset (Fin ij.2)) // IsNonCrossingFp P}) n]
+
+/-- **The two sides of the first-return decomposition are equinumerous.** The non-crossing
+partitions of `Fin (n+1)` and the antidiagonal-indexed pairs of non-crossing partitions of the two
+windows have equal cardinality. Proved by `card LhsNc = card MidNc` (antisymmetry of the two
+injections `fwdMid`/`glMid`) composed with `card MidNc = card Rhs` (the `antidiagonal ↔ range`
+reindexing). -/
+theorem card_lhs_eq_card_rhs (n : ℕ) :
+    Fintype.card {P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P}
+      = Fintype.card (Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
+          {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
+          {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P}) := by
+  have hmid : Fintype.card {P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P}
+      = Fintype.card (MidNc n) :=
+    le_antisymm (Fintype.card_le_of_injective fwdMid fwdMid_injective)
+                (Fintype.card_le_of_injective glMid glMid_injective)
+  rw [hmid, card_midNc_eq, ← card_rhs_eq]
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its
@@ -950,22 +1074,24 @@ The recurrence is now split into two parts that separate its *counting* content 
 
 `nonCrossingCount_recurrence` is then a corollary of the two. -/
 
-/-- **First-return bijection (the sole open obligation).** A non-crossing partition of the
-linearly ordered set `Fin (n+1)` decomposes — via the classical "first return" of the block
-structure around a distinguished point — into an independent pair of non-crossing partitions of
-an `i`-element and a `j`-element interval, with `(i, j)` ranging over `antidiagonal n`. We
-record the decomposition as a bijection (existence suffices for the count).
+/-- **First-return bijection (now proved).** A non-crossing partition of the linearly ordered set
+`Fin (n+1)` decomposes — via the classical "first return" of the block structure around a
+distinguished point — into an independent pair of non-crossing partitions of an `i`-element and a
+`j`-element interval, with `(i, j)` ranging over `antidiagonal n`. We record the decomposition as
+a bijection (existence suffices for the count).
 
-This is the genuine combinatorial content of `nonCrossing = Catalan`; the analogous
-decomposition is *not* available in Mathlib in any form (Mathlib has no theory of non-crossing
-partitions, nor of restricting a `Finpartition` of `Fin (n+1)` to the gaps cut out by a
-distinguished block). **Outstanding `sorry`** (HARD, bijection-level). -/
+This is the genuine combinatorial content of `nonCrossing = Catalan`; the analogous decomposition
+is *not* available in Mathlib in any form (Mathlib has no theory of non-crossing partitions, nor of
+restricting a `Finpartition` of `Fin (n+1)` to the gaps cut out by a distinguished block). It is
+discharged here by `card_lhs_eq_card_rhs` (the two sides are equinumerous, by antisymmetry of the
+two injections `fwdMid`/`glMid`) fed to `Fintype.equivOfCardEq` — the existence of the bijection
+without the dependent-`HEq` cast bookkeeping a natural equiv would demand. -/
 theorem nonempty_firstReturnEquiv (n : ℕ) :
     Nonempty ({P : Finpartition (univ : Finset (Fin (n + 1))) // IsNonCrossingFp P} ≃
       Σ ij : (antidiagonal n : Finset (ℕ × ℕ)),
         {P : Finpartition (univ : Finset (Fin ij.1.1)) // IsNonCrossingFp P} ×
-        {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P}) := by
-  sorry
+        {P : Finpartition (univ : Finset (Fin ij.1.2)) // IsNonCrossingFp P}) :=
+  ⟨Fintype.equivOfCardEq (card_lhs_eq_card_rhs n)⟩
 
 /-- **Counting half of the recurrence (proved, 0 `sorry`).** Any first-return bijection
 splitting the non-crossing partitions of `Fin (n+1)` over `antidiagonal n` already forces the
@@ -1061,7 +1187,12 @@ theorem nonCrossingCount_eq_catalan_of_le_three {n : ℕ} (hn : n ≤ 3) :
 #check @firstBlockMax_glueFp_val
 #check @restrictFp_glueFp_left
 #check @restrictFp_glueFp_right
+#check @card_lhs_eq_card_rhs
 #check @nonCrossingCount_eq_catalan
 #check @nonCrossingCount_eq_catalan_of_le_three
+
+-- Axiom audit: the full theorem depends only on the foundational axioms
+-- (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms nonCrossingCount_eq_catalan
 
 end BallotProblemOQ04OQ02OQ01

--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -727,6 +727,75 @@ theorem firstBlockMax_glueFp_val {n : ℕ} (m : ℕ) (hm : m ≤ n)
         glueLabel_of_pos_le m hm P₁ P₂ ⟨m, by omega⟩ hmpos (le_refl m)]
     exact Fin.le_def.mp (Finset.le_max' (Q.part 0) ⟨m, by omega⟩ hmmem)
 
+/-! ### Restriction recovers each glued factor (round-trip `right_inv`, factor half)
+
+`firstBlockMax_glueFp_val` recovered the cut index `m` from a glued partition. The forward map
+`firstReturnForward` then restricts to the two offset windows `[1, m]` and `[m+1, n]`. For the
+round-trip `forward ∘ glue = id` (`right_inv`), those two restrictions must return exactly the
+factors `P₁, P₂` that `glue` consumed. `restrictFp_glueFp_left`/`_right` prove precisely that:
+restricting the glued partition to each window recovers the corresponding factor *on the nose*.
+Together with `firstBlockMax_glueFp_val` they discharge the mathematical content of `right_inv`;
+only the `Sigma`/`Subtype` packaging of `firstReturnForward` would then remain. -/
+
+/-- **Finpartition extensionality via the block function.** Two finpartitions of `univ` (over a
+`Fintype`) that assign every point the same block are equal. Every part is `P.part a` for some
+point `a ∈ t` it contains, so equal block functions give equal `parts` finsets. -/
+theorem finpartition_eq_of_part {α : Type*} [Fintype α] [DecidableEq α]
+    {P Q : Finpartition (univ : Finset α)} (h : ∀ a, P.part a = Q.part a) : P = Q := by
+  ext t
+  constructor
+  · intro ht
+    obtain ⟨a, ha⟩ : t.Nonempty :=
+      Finset.nonempty_iff_ne_empty.mpr fun he => P.empty_notMem_parts (he ▸ ht)
+    have hta : P.part a = t := P.part_eq_of_mem ht ha
+    rw [← hta, h a]
+    exact Q.part_mem.2 (mem_univ a)
+  · intro ht
+    obtain ⟨a, ha⟩ : t.Nonempty :=
+      Finset.nonempty_iff_ne_empty.mpr fun he => Q.empty_notMem_parts (he ▸ ht)
+    have hta : Q.part a = t := Q.part_eq_of_mem ht ha
+    rw [← hta, ← h a]
+    exact P.part_mem.2 (mem_univ a)
+
+/-- Two points share a glued block iff they carry the same `glueLabel` — in `part`-equality form
+(the companion of `mem_part_glueFp`, phrased for the block *function* rather than membership). -/
+theorem part_glueFp_eq_iff {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x y : Fin (n + 1)) :
+    (glueFp m hm P₁ P₂).part x = (glueFp m hm P₁ P₂).part y ↔
+      glueLabel m hm P₁ P₂ x = glueLabel m hm P₁ P₂ y := by
+  rw [eq_comm, ← (glueFp m hm P₁ P₂).mem_part_iff_part_eq_part (mem_univ y) (mem_univ x),
+      mem_part_glueFp]
+
+/-- **Left restriction recovers `P₁` (round-trip `right_inv`, left factor).** Restricting the glued
+partition `glueFp m hm P₁ P₂` to the left offset window `[1, m]` returns `P₁` exactly. The window
+`[1, m]` carries the shifted `P₁` labels verbatim (`glueLabel_offsetEmb_left`), so its induced block
+structure *is* `P₁`; point `0` (attached to `P₁`'s top block) lies outside the window and is
+dropped, leaving `P₁` untouched. -/
+theorem restrictFp_glueFp_left {n : ℕ} (m : ℕ) (hm : m ≤ n) (hL : 1 + m ≤ n + 1)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) :
+    restrictFp (offsetEmb 1 hL) (glueFp m hm P₁ P₂) = P₁ := by
+  refine finpartition_eq_of_part fun a => Finset.ext fun b => ?_
+  rw [mem_part_restrictFp, part_glueFp_eq_iff,
+      glueLabel_offsetEmb_left m hm P₁ P₂ hL a, glueLabel_offsetEmb_left m hm P₁ P₂ hL b,
+      Sum.inl.injEq, Option.some.injEq, eq_comm]
+  exact (P₁.mem_part_iff_part_eq_part (mem_univ b) (mem_univ a)).symm
+
+/-- **Right restriction recovers `P₂` (round-trip `right_inv`, right factor).** Restricting the
+glued partition `glueFp m hm P₁ P₂` to the right offset window `[m+1, n]` returns `P₂` exactly: the
+window carries the shifted `P₂` labels verbatim (`glueLabel_offsetEmb_right`), so its induced block
+structure is `P₂`. -/
+theorem restrictFp_glueFp_right {n : ℕ} (m : ℕ) (hm : m ≤ n) (hR : (m + 1) + (n - m) ≤ n + 1)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) :
+    restrictFp (offsetEmb (m + 1) hR) (glueFp m hm P₁ P₂) = P₂ := by
+  refine finpartition_eq_of_part fun a => Finset.ext fun b => ?_
+  rw [mem_part_restrictFp, part_glueFp_eq_iff,
+      glueLabel_offsetEmb_right m hm P₁ P₂ hR a, glueLabel_offsetEmb_right m hm P₁ P₂ hR b,
+      Sum.inr.injEq, eq_comm]
+  exact (P₂.mem_part_iff_part_eq_part (mem_univ b) (mem_univ a)).symm
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its
@@ -851,6 +920,8 @@ theorem nonCrossingCount_eq_catalan_of_le_three {n : ℕ} (hn : n ≤ 3) :
 #check @glueLabel_offsetEmb_right
 #check @mem_part_zero_glueFp_left
 #check @firstBlockMax_glueFp_val
+#check @restrictFp_glueFp_left
+#check @restrictFp_glueFp_right
 #check @nonCrossingCount_eq_catalan
 #check @nonCrossingCount_eq_catalan_of_le_three
 

--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -538,6 +538,160 @@ theorem mem_part_zero_glueFp_left {n : ℕ} (m : ℕ) (hm : m ≤ n) (hm0 : 0 < 
   · intro h
     exact ((P₁.mem_part_iff_part_eq_part (mem_univ _) (mem_univ _)).mp h).symm
 
+/-! ### The glued partition is non-crossing (injectivity-side structural fact)
+
+The gluing map `glueFp` must land in the *non-crossing* subtype for it to serve as the inverse
+of `firstReturnForward`. This section proves exactly that: gluing two non-crossing partitions of
+the windows `Fin m` and `Fin (n-m)` yields a non-crossing partition of `Fin (n+1)`.
+
+The proof is a case split by the window a straddle-free block lands in. Since window-`A` points
+carry `Sum.inl` labels and window-`B` points carry `Sum.inr` labels, a same-label pair lies in a
+single window, and the linear order `a < b < c < d` forces *all four* of a crossing candidate
+into one window (`glueLabel_le_iff`). Inside window `B` the labels are literally the shifted `P₂`,
+so non-crossing transports directly. Inside window `A` the labels are the shifted `P₁` **with
+point `0` attached to the top block `m-1`** — and it is precisely this "attach to the top" choice
+that keeps `A` non-crossing: a crossing through `0` would pair `(0, c)` with `(b, d)` at
+`0 < b < c < d ≤ m`, and `0 ~ m-1` turns it into the `P₁`-crossing `(b-1, c-1, d-1, m-1)`, whose
+resolution forces `0 ~ b`. -/
+
+/-- **Non-crossing in `Finpartition.part`-equality form.** A convenience restatement of
+`IsNonCrossingFp` avoiding the membership `↔ part-equality` bookkeeping at every call site: from
+`P.part w = P.part y` and `P.part x = P.part z` at `w < x < y < z`, non-crossing yields
+`P.part w = P.part x`. -/
+theorem ncf_part_eq {k : ℕ} {P : Finpartition (univ : Finset (Fin k))}
+    (hP : IsNonCrossingFp P) {w x y z : Fin k} (hwx : w < x) (hxy : x < y) (hyz : y < z)
+    (h1 : P.part w = P.part y) (h2 : P.part x = P.part z) : P.part w = P.part x := by
+  have hy : y ∈ P.part w := h1.symm ▸ P.mem_part (mem_univ y)
+  have hz : z ∈ P.part x := h2.symm ▸ P.mem_part (mem_univ z)
+  have hx : x ∈ P.part w := hP w x y z hwx hxy hyz hy hz
+  exact ((P.mem_part_iff_part_eq_part (mem_univ x) (mem_univ w)).mp hx).symm
+
+/-- Window-`B` label (`m < x.val`): the `Sum.inr` `P₂`-block of the shifted index. -/
+theorem glueLabel_of_gt {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x : Fin (n + 1)) (hx : m < x.val) :
+    glueLabel m hm P₁ P₂ x = Sum.inr (P₂.part ⟨x.val - (m + 1), by have := x.isLt; omega⟩) := by
+  unfold glueLabel
+  rw [dif_neg (by omega : x.val ≠ 0), dif_neg (by omega : ¬ x.val ≤ m)]
+
+/-- Window-`A` label, nonzero point (`0 < x.val ≤ m`): the `Sum.inl` `P₁`-block of `x-1`. -/
+theorem glueLabel_of_pos_le {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x : Fin (n + 1))
+    (hx0 : 0 < x.val) (hxm : x.val ≤ m) :
+    glueLabel m hm P₁ P₂ x = Sum.inl (some (P₁.part ⟨x.val - 1, by omega⟩)) := by
+  unfold glueLabel
+  rw [dif_neg (by omega : x.val ≠ 0), dif_pos hxm]
+
+/-- Label of a `0`-valued point with `m ≥ 1`: the `Sum.inl` `P₁`-block of the top index `m-1`
+(this "attach `0` to the top block" is what keeps the glued window `A` non-crossing). -/
+theorem glueLabel_of_zero {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x : Fin (n + 1))
+    (hx0 : x.val = 0) (hmpos : 0 < m) :
+    glueLabel m hm P₁ P₂ x = Sum.inl (some (P₁.part ⟨m - 1, by omega⟩)) := by
+  unfold glueLabel
+  rw [dif_pos hx0, dif_neg (by omega : m ≠ 0)]
+
+/-- Any window-`A` point (`x.val ≤ m`) carries a `Sum.inl` label. -/
+theorem glueLabel_isLeft_of_le {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x : Fin (n + 1)) (hx : x.val ≤ m) :
+    (glueLabel m hm P₁ P₂ x).isLeft = true := by
+  rcases Nat.eq_zero_or_pos x.val with h0 | hpos
+  · unfold glueLabel; rw [dif_pos h0]; split_ifs <;> rfl
+  · unfold glueLabel; rw [dif_neg (by omega : x.val ≠ 0), dif_pos hx]; rfl
+
+/-- Two same-label points lie in the same window: a shared `glueLabel` forces the two points to
+the same side of the cut `m`. (`Sum.inl` labels are window `A`, `Sum.inr` labels window `B`.) -/
+theorem glueLabel_le_iff {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) (x y : Fin (n + 1))
+    (h : glueLabel m hm P₁ P₂ x = glueLabel m hm P₁ P₂ y) : x.val ≤ m ↔ y.val ≤ m := by
+  constructor
+  · intro hx
+    by_contra hy; push_neg at hy
+    have hxL := glueLabel_isLeft_of_le m hm P₁ P₂ x hx
+    rw [h, glueLabel_of_gt m hm P₁ P₂ y hy] at hxL
+    simp at hxL
+  · intro hy
+    by_contra hx; push_neg at hx
+    have hyL := glueLabel_isLeft_of_le m hm P₁ P₂ y hy
+    rw [← h, glueLabel_of_gt m hm P₁ P₂ x hx] at hyL
+    simp at hyL
+
+/-- **The glued partition is non-crossing.** If `P₁` and `P₂` are non-crossing partitions of the
+two windows `Fin m` and `Fin (n-m)`, their gluing `glueFp m hm P₁ P₂` is a non-crossing partition
+of `Fin (n+1)`. This is the structural fact the inverse (gluing) map needs to land in the
+non-crossing subtype `{P // IsNonCrossingFp P}` — half of the still-open bijection
+`nonempty_firstReturnEquiv`. -/
+theorem isNonCrossingFp_glueFp {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m))))
+    (h₁ : IsNonCrossingFp P₁) (h₂ : IsNonCrossingFp P₂) :
+    IsNonCrossingFp (glueFp m hm P₁ P₂) := by
+  intro a b c d hab hbc hcd hca hdb
+  rw [mem_part_glueFp] at hca hdb ⊢
+  have vab : a.val < b.val := Fin.lt_def.mp hab
+  have vbc : b.val < c.val := Fin.lt_def.mp hbc
+  have vcd : c.val < d.val := Fin.lt_def.mp hcd
+  by_cases hAm : a.val ≤ m
+  · -- Window A: all four points land at value ≤ m.
+    have hCm : c.val ≤ m := (glueLabel_le_iff m hm P₁ P₂ a c hca).mp hAm
+    have hBm : b.val ≤ m := by omega
+    have hDm : d.val ≤ m := (glueLabel_le_iff m hm P₁ P₂ b d hdb).mp hBm
+    have hb1 : 1 ≤ b.val := by omega
+    have hc1 : 1 ≤ c.val := by omega
+    have hd1 : 1 ≤ d.val := by omega
+    rcases Nat.eq_zero_or_pos a.val with ha0 | ha1
+    · -- a is the special point 0: its label is the top block m-1 (m ≥ 1 since d.val ≥ 3).
+      have hm1 : 0 < m := by omega
+      rw [glueLabel_of_zero m hm P₁ P₂ a ha0 hm1,
+          glueLabel_of_pos_le m hm P₁ P₂ c (by omega) hCm] at hca
+      rw [glueLabel_of_pos_le m hm P₁ P₂ b (by omega) hBm,
+          glueLabel_of_pos_le m hm P₁ P₂ d (by omega) hDm] at hdb
+      rw [glueLabel_of_zero m hm P₁ P₂ a ha0 hm1,
+          glueLabel_of_pos_le m hm P₁ P₂ b (by omega) hBm]
+      simp only [Sum.inl.injEq, Option.some.injEq] at hca hdb ⊢
+      rcases Nat.lt_or_ge d.val m with hdlt | hdge
+      · -- d-1 < m-1: the crossing (b-1, c-1, d-1, m-1) resolves in P₁.
+        have key : P₁.part (⟨b.val - 1, by omega⟩ : Fin m) = P₁.part ⟨c.val - 1, by omega⟩ :=
+          ncf_part_eq h₁ (Fin.mk_lt_mk.mpr (show b.val - 1 < c.val - 1 by omega))
+            (Fin.mk_lt_mk.mpr (show c.val - 1 < d.val - 1 by omega))
+            (Fin.mk_lt_mk.mpr (show d.val - 1 < m - 1 by omega)) hdb hca.symm
+        exact hca.trans key.symm
+      · -- d.val = m: d and the special point 0 already share the top block m-1.
+        have hdm : d.val = m := le_antisymm hDm hdge
+        have efin : (⟨d.val - 1, by omega⟩ : Fin m) = ⟨m - 1, by omega⟩ := by
+          simp only [Fin.mk.injEq]; omega
+        exact ((congrArg P₁.part efin).symm).trans hdb.symm
+    · -- a is an ordinary window-A point: the crossing (a-1, b-1, c-1, d-1) resolves in P₁.
+      rw [glueLabel_of_pos_le m hm P₁ P₂ a ha1 hAm,
+          glueLabel_of_pos_le m hm P₁ P₂ c (by omega) hCm] at hca
+      rw [glueLabel_of_pos_le m hm P₁ P₂ b (by omega) hBm,
+          glueLabel_of_pos_le m hm P₁ P₂ d (by omega) hDm] at hdb
+      rw [glueLabel_of_pos_le m hm P₁ P₂ a ha1 hAm,
+          glueLabel_of_pos_le m hm P₁ P₂ b (by omega) hBm]
+      simp only [Sum.inl.injEq, Option.some.injEq] at hca hdb ⊢
+      exact ncf_part_eq h₁ (Fin.mk_lt_mk.mpr (show a.val - 1 < b.val - 1 by omega))
+        (Fin.mk_lt_mk.mpr (show b.val - 1 < c.val - 1 by omega))
+        (Fin.mk_lt_mk.mpr (show c.val - 1 < d.val - 1 by omega)) hca hdb
+  · -- Window B: all four points land at value > m; labels are the shifted P₂.
+    push_neg at hAm
+    have hCm : m < c.val := by
+      have hiff := glueLabel_le_iff m hm P₁ P₂ a c hca
+      by_contra h; push_neg at h
+      exact absurd (hiff.mpr (by omega)) (by omega)
+    have hBm : m < b.val := by omega
+    have hDm : m < d.val := by omega
+    rw [glueLabel_of_gt m hm P₁ P₂ a hAm, glueLabel_of_gt m hm P₁ P₂ c hCm] at hca
+    rw [glueLabel_of_gt m hm P₁ P₂ b hBm, glueLabel_of_gt m hm P₁ P₂ d hDm] at hdb
+    rw [glueLabel_of_gt m hm P₁ P₂ a hAm, glueLabel_of_gt m hm P₁ P₂ b hBm]
+    simp only [Sum.inr.injEq] at hca hdb ⊢
+    exact ncf_part_eq h₂ (Fin.mk_lt_mk.mpr (show a.val - (m + 1) < b.val - (m + 1) by omega))
+      (Fin.mk_lt_mk.mpr (show b.val - (m + 1) < c.val - (m + 1) by omega))
+      (Fin.mk_lt_mk.mpr (show c.val - (m + 1) < d.val - (m + 1) by omega)) hca hdb
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its

--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -796,6 +796,145 @@ theorem restrictFp_glueFp_right {n : ℕ} (m : ℕ) (hm : m ≤ n) (hR : (m + 1)
       Sum.inr.injEq, eq_comm]
   exact (P₂.mem_part_iff_part_eq_part (mem_univ b) (mem_univ a)).symm
 
+/-! ### Gluing the forward restrictions recovers `P` (round-trip `left_inv`, the core)
+
+`restrictFp_glueFp_left`/`_right` and `firstBlockMax_glueFp_val` discharge the *other* round-trip
+(`forward ∘ glue = id`). The law below is the harder direction — `glue ∘ forward = id` — and the
+one where non-crossing is essential. It says: cutting a non-crossing `P` at `m = firstBlockMax P`,
+restricting to the two windows, and gluing the pieces back reconstructs `P` exactly. -/
+
+/-- **Gluing the forward restrictions recovers `P` (round-trip `left_inv`, the core).** For a
+non-crossing `P` of `Fin (n+1)` with cut `m = firstBlockMax P`, gluing the two window restrictions
+`restrictFp (offsetEmb 1) P` (on `[1, m]`) and `restrictFp (offsetEmb (m+1)) P` (on `[m+1, n]`)
+reconstructs `P` on the nose: `glueFp m hm (restrictFp e₁ P) (restrictFp e₂ P) = P`.
+
+This is the substantive round-trip law `glue ∘ forward = id` (the `left_inv` of
+`nonempty_firstReturnEquiv`), and the hard direction — it is where non-crossing is used. Two points
+share a glued block iff they carry the same `glueLabel`; the proof shows that is equivalent to
+sharing `P`'s block, by three cases on the cut `m`:
+* both in the closed lower window `[0, m]` — labels are `Sum.inl` of the shifted `P₁ = restrict`
+  block, which tracks `P` on `[1, m]`; and point `0` is glued onto the top block `⟨m-1⟩`, whose
+  members are exactly `0`'s `P`-block (`firstBlockMax` shares `P`'s block with `0`), so the label
+  tracks `P.part 0` too;
+* both in the upper window `[m+1, n]` — labels are `Sum.inr` of the shifted `P₂ = restrict` block,
+  tracking `P` verbatim;
+* opposite sides (`a ≤ m < b`) — the labels live in distinct `Sum` sectors, so differ, and
+  `P.part a = P.part b` is impossible: it would straddle the cut (`noStraddle`).
+Combined with `restrictFp_glueFp_left`/`_right` and `firstBlockMax_glueFp_val` (the `right_inv`
+ingredients), only the `Sigma`/`Subtype` packaging remains to assemble the still-open
+`nonempty_firstReturnEquiv`. -/
+theorem glueFp_restrictFp_eq_self {n : ℕ}
+    (P : Finpartition (univ : Finset (Fin (n + 1)))) (hP : IsNonCrossingFp P)
+    (hm : (firstBlockMax P).val ≤ n)
+    (hL : 1 + (firstBlockMax P).val ≤ n + 1)
+    (hR : ((firstBlockMax P).val + 1) + (n - (firstBlockMax P).val) ≤ n + 1) :
+    glueFp (firstBlockMax P).val hm
+      (restrictFp (offsetEmb 1 hL) P)
+      (restrictFp (offsetEmb ((firstBlockMax P).val + 1) hR) P) = P := by
+  set m := (firstBlockMax P).val with hm_def
+  set Q₁ := restrictFp (offsetEmb 1 hL) P with hQ₁def
+  set Q₂ := restrictFp (offsetEmb (m + 1) hR) P with hQ₂def
+  -- Lower-window label evaluation: for `x ≤ m` (`m > 0`), the glued label is `Sum.inl (some ·)`
+  -- of a `Q₁`-block whose lifted `P`-block is `P.part x` (`0` lifts to the cut, sharing `0`'s block).
+  have hlabL : ∀ x : Fin (n + 1), x.val ≤ m → 0 < m →
+      ∃ j : Fin m, glueLabel m hm Q₁ Q₂ x = Sum.inl (some (Q₁.part j))
+        ∧ P.part (offsetEmb 1 hL j) = P.part x := by
+    intro x hx hmpos
+    rcases Nat.eq_zero_or_pos x.val with hx0 | hxpos
+    · refine ⟨⟨m - 1, by omega⟩, glueLabel_of_zero m hm Q₁ Q₂ x hx0 hmpos, ?_⟩
+      have hemb : offsetEmb 1 hL (⟨m - 1, by omega⟩ : Fin m) = firstBlockMax P := by
+        have hv : (offsetEmb 1 hL (⟨m - 1, by omega⟩ : Fin m)).val = 1 + (m - 1) := rfl
+        apply Fin.ext; rw [hv]; omega
+      have hx0' : x = 0 := Fin.ext hx0
+      rw [hemb, hx0']
+      exact (P.mem_part_iff_part_eq_part (mem_univ _) (mem_univ 0)).mp (firstBlockMax_mem_part P)
+    · refine ⟨⟨x.val - 1, by omega⟩, glueLabel_of_pos_le m hm Q₁ Q₂ x hxpos hx, ?_⟩
+      have hv : (offsetEmb 1 hL (⟨x.val - 1, by omega⟩ : Fin m)).val = 1 + (x.val - 1) := rfl
+      have hemb : offsetEmb 1 hL (⟨x.val - 1, by omega⟩ : Fin m) = x := by
+        apply Fin.ext; rw [hv]; omega
+      rw [hemb]
+  -- Upper-window label evaluation: for `x > m`, the glued label is `Sum.inr ·` of a `Q₂`-block
+  -- whose lifted `P`-block is `P.part x`.
+  have hlabR : ∀ x : Fin (n + 1), m < x.val →
+      ∃ k : Fin (n - m), glueLabel m hm Q₁ Q₂ x = Sum.inr (Q₂.part k)
+        ∧ P.part (offsetEmb (m + 1) hR k) = P.part x := by
+    intro x hx
+    refine ⟨⟨x.val - (m + 1), by have := x.isLt; omega⟩, glueLabel_of_gt m hm Q₁ Q₂ x hx, ?_⟩
+    have hv : (offsetEmb (m + 1) hR (⟨x.val - (m + 1), by have := x.isLt; omega⟩ : Fin (n - m))).val
+        = (m + 1) + (x.val - (m + 1)) := rfl
+    have hemb : offsetEmb (m + 1) hR (⟨x.val - (m + 1), by have := x.isLt; omega⟩ : Fin (n - m))
+        = x := by
+      apply Fin.ext; rw [hv]; omega
+    rw [hemb]
+  -- Same-side (lower window) label equality ⟺ same `P`-block.
+  have keyL : ∀ a b : Fin (n + 1), a.val ≤ m → b.val ≤ m →
+      (glueLabel m hm Q₁ Q₂ a = glueLabel m hm Q₁ Q₂ b ↔ P.part a = P.part b) := by
+    intro a b ha hb
+    rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+    · have hab : a = b := Fin.ext (by omega)
+      subst hab; simp
+    · obtain ⟨ja, hlaba, hPa⟩ := hlabL a ha hmpos
+      obtain ⟨jb, hlabb, hPb⟩ := hlabL b hb hmpos
+      rw [hlaba, hlabb, Sum.inl.injEq, Option.some.injEq]
+      have hmem : (jb ∈ Q₁.part ja) ↔
+          (P.part (offsetEmb 1 hL ja) = P.part (offsetEmb 1 hL jb)) := by
+        rw [hQ₁def]; exact mem_part_restrictFp (offsetEmb 1 hL) P ja jb
+      constructor
+      · intro h
+        have hin : jb ∈ Q₁.part ja :=
+          (Q₁.mem_part_iff_part_eq_part (mem_univ jb) (mem_univ ja)).mpr h.symm
+        rw [hmem, hPa, hPb] at hin; exact hin
+      · intro h
+        have hin : jb ∈ Q₁.part ja := by rw [hmem, hPa, hPb]; exact h
+        exact ((Q₁.mem_part_iff_part_eq_part (mem_univ jb) (mem_univ ja)).mp hin).symm
+  -- Same-side (upper window) label equality ⟺ same `P`-block.
+  have keyR : ∀ a b : Fin (n + 1), m < a.val → m < b.val →
+      (glueLabel m hm Q₁ Q₂ a = glueLabel m hm Q₁ Q₂ b ↔ P.part a = P.part b) := by
+    intro a b ha hb
+    obtain ⟨ka, hlaba, hPa⟩ := hlabR a ha
+    obtain ⟨kb, hlabb, hPb⟩ := hlabR b hb
+    rw [hlaba, hlabb, Sum.inr.injEq]
+    have hmem : (kb ∈ Q₂.part ka) ↔
+        (P.part (offsetEmb (m + 1) hR ka) = P.part (offsetEmb (m + 1) hR kb)) := by
+      rw [hQ₂def]; exact mem_part_restrictFp (offsetEmb (m + 1) hR) P ka kb
+    constructor
+    · intro h
+      have hin : kb ∈ Q₂.part ka :=
+        (Q₂.mem_part_iff_part_eq_part (mem_univ kb) (mem_univ ka)).mpr h.symm
+      rw [hmem, hPa, hPb] at hin; exact hin
+    · intro h
+      have hin : kb ∈ Q₂.part ka := by rw [hmem, hPa, hPb]; exact h
+      exact ((Q₂.mem_part_iff_part_eq_part (mem_univ kb) (mem_univ ka)).mp hin).symm
+  -- Opposite sides: labels differ (distinct `Sum` sectors) AND a shared `P`-block would straddle.
+  have keyCross : ∀ a b : Fin (n + 1), a.val ≤ m → m < b.val →
+      (glueLabel m hm Q₁ Q₂ a = glueLabel m hm Q₁ Q₂ b ↔ P.part a = P.part b) := by
+    intro a b ha hb
+    have haleft : (glueLabel m hm Q₁ Q₂ a).isLeft = true := glueLabel_isLeft_of_le m hm Q₁ Q₂ a ha
+    constructor
+    · intro h
+      rw [h, glueLabel_of_gt m hm Q₁ Q₂ b hb] at haleft
+      simp at haleft
+    · intro h
+      have hb_in : b ∈ P.part a := by rw [h]; exact P.mem_part (mem_univ b)
+      exact (noStraddle P hP a a b (P.mem_part (mem_univ a)) hb_in
+        (Fin.le_def.mpr (by omega)) (Fin.lt_def.mpr (by omega))).elim
+  -- Assemble: for every pair, glued-block ⟺ `P`-block.
+  refine finpartition_eq_of_part fun a => Finset.ext fun b => ?_
+  rw [mem_part_glueFp]
+  have hkey : glueLabel m hm Q₁ Q₂ a = glueLabel m hm Q₁ Q₂ b ↔ P.part a = P.part b := by
+    by_cases hAa : a.val ≤ m
+    · by_cases hBb : b.val ≤ m
+      · exact keyL a b hAa hBb
+      · push_neg at hBb; exact keyCross a b hAa hBb
+    · push_neg at hAa
+      by_cases hBb : b.val ≤ m
+      · constructor
+        · intro h; exact ((keyCross b a hBb hAa).mp h.symm).symm
+        · intro h; exact ((keyCross b a hBb hAa).mpr h.symm).symm
+      · push_neg at hBb; exact keyR a b hAa hBb
+  rw [hkey, P.mem_part_iff_part_eq_part (mem_univ b) (mem_univ a)]
+  exact eq_comm
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its

--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -692,6 +692,41 @@ theorem isNonCrossingFp_glueFp {n : ℕ} (m : ℕ) (hm : m ≤ n)
       (Fin.mk_lt_mk.mpr (show b.val - (m + 1) < c.val - (m + 1) by omega))
       (Fin.mk_lt_mk.mpr (show c.val - (m + 1) < d.val - (m + 1) by omega)) hca hdb
 
+/-! ### The glued partition recovers the cut index (round-trip linchpin)
+
+`firstReturnForward` cuts a non-crossing `P` at `m = firstBlockMax P`. For the round-trip
+`forward ∘ glue = id` (the `right_inv` law), the first thing the forward map must recover from a
+glued partition `glueFp m hm P₁ P₂` is that same cut index `m`. `firstBlockMax_glueFp_val` proves
+exactly this: the maximum of the block of `0` in the glued partition is again `m`.
+
+Why: the glued block of `0` carries a `Sum.inl` label (`glueLabel_isLeft_of_le` / the `m = 0`
+singleton case), and every `Sum.inl`-labelled point lies in the window `[0, m]` (`glueLabel_le_iff`),
+so no block-of-`0` point exceeds `m` — giving `≤ m`. Conversely, when `m > 0` the point `m` itself
+carries `0`'s label (`0` was glued onto `P₁`'s top block `⟨m-1⟩`, and `m`'s label is that same top
+block via `glueLabel_of_pos_le`), so `m` sits in the block and `m ≤ firstBlockMax`. Together the two
+force `firstBlockMax (glueFp …) = m`. This pins the forward map's cut, hence its two offset windows
+`[1, m]` and `[m+1, n]`, back to the sizes `(m, n-m)` that `glue` consumed — the first step of the
+`right_inv` law. -/
+theorem firstBlockMax_glueFp_val {n : ℕ} (m : ℕ) (hm : m ≤ n)
+    (P₁ : Finpartition (univ : Finset (Fin m)))
+    (P₂ : Finpartition (univ : Finset (Fin (n - m)))) :
+    (firstBlockMax (glueFp m hm P₁ P₂)).val = m := by
+  set Q := glueFp m hm P₁ P₂ with hQ
+  -- Every point sharing `0`'s glued block sits in the window `[0, m]`.
+  have hle : ∀ p ∈ Q.part 0, p.val ≤ m := by
+    intro p hp
+    have hlabel : glueLabel m hm P₁ P₂ (0 : Fin (n + 1)) = glueLabel m hm P₁ P₂ p :=
+      (mem_part_glueFp m hm P₁ P₂ 0 p).mp hp
+    exact (glueLabel_le_iff m hm P₁ P₂ 0 p hlabel).mp (by simp)
+  refine le_antisymm (hle _ (firstBlockMax_mem_part Q)) ?_
+  -- The cut index is `≥ m`: for `m > 0`, the point `m` itself shares `0`'s block.
+  rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+  · omega
+  · have hmmem : (⟨m, by omega⟩ : Fin (n + 1)) ∈ Q.part 0 := by
+      rw [mem_part_glueFp, glueLabel_zero_of_pos m hm hmpos,
+        glueLabel_of_pos_le m hm P₁ P₂ ⟨m, by omega⟩ hmpos (le_refl m)]
+    exact Fin.le_def.mp (Finset.le_max' (Q.part 0) ⟨m, by omega⟩ hmmem)
+
 /-! ## The combinatorial recurrence (HARD)
 
 The recurrence is now split into two parts that separate its *counting* content from its
@@ -815,6 +850,7 @@ theorem nonCrossingCount_eq_catalan_of_le_three {n : ℕ} (hn : n ≤ 3) :
 #check @glueLabel_offsetEmb_left
 #check @glueLabel_offsetEmb_right
 #check @mem_part_zero_glueFp_left
+#check @firstBlockMax_glueFp_val
 #check @nonCrossingCount_eq_catalan
 #check @nonCrossingCount_eq_catalan_of_le_three
 

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01-incomplete-01/knowledge.md
@@ -1,9 +1,11 @@
-# Knowledge: Non-crossing partitions counted by Catalan — recurrence reduction (1 sorry)
+# Knowledge: Non-crossing partitions counted by Catalan — COMPLETE (0 sorry, verified)
 
 **Problem id**: `ballot-problem-oq-04-oq-02-oq-01-incomplete-01`
 **Gallery entry / Lean file**: `ballot-problem-oq-04-oq-02-oq-01` →
 `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean`
-**Goal**: discharge the single remaining `sorry`, `nonempty_firstReturnEquiv`.
+**Status (2026-07-04, s15): DONE.** `nonCrossingCount n = catalan n` fully proved — 0 sorry,
+`#print axioms` = `[propext, Classical.choice, Quot.sound]` only. The last obligation
+`nonempty_firstReturnEquiv` was discharged by an equinumerosity count (see s15 log below).
 
 ## Summary
 
@@ -105,6 +107,53 @@ Consequences:
   above.
 
 ## Session log
+
+### Session 2026-07-04 (Session 15) — ACT: bijection packaged, theorem COMPLETE
+
+**Mode**: REVISIT · **Outcome**: **DONE** — sole `sorry` discharged, 0 sorry, verified.
+
+**What I did**
+- Discharged `nonempty_firstReturnEquiv` (the last `sorry`) and thereby proved
+  `nonCrossingCount n = catalan n` in full.
+- Key move: instead of building a *natural* `Equiv` between the antidiagonal-indexed `Σ`-type and
+  the non-crossing partitions — which needs dependent-`HEq` transport, because the forward map's cut
+  index `firstBlockMax(glue) = m` holds only *propositionally* — I proved
+  `card LHS = card RHS` and applied `Fintype.equivOfCardEq`.
+- Route: an intermediate type `MidNc n := Σ m : Fin (n+1), NcFp m.val × NcFp (n - m.val)` whose right
+  fiber `Fin (n - m)` matches `glueFp`'s argument type **definitionally** (no cast). Maps `fwdMid`
+  (cut + restrict) and `glMid` (glue). `card LhsNc = card MidNc` by `le_antisymm` of two injections:
+  `fwdMid` injective via its left inverse `glMid` (= `glueFp_restrictFp_eq_self`); `glMid` injective
+  by recovering the cut as an **ℕ-equality** (`firstBlockMax_glueFp_val`, so `subst` dodges `HEq`)
+  then both factors (`restrictFp_glueFp_left/right`). `card MidNc = card Rhs` by a pure
+  `antidiagonal ↔ range` reindexing (`Fin.sum_univ_eq_sum_range` +
+  `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`) — no partition casts at all.
+- Docker build **clean on the first try** (7745 jobs, no SIGBUS despite swap at 98%). Axiom audit
+  `#print axioms nonCrossingCount_eq_catalan` = `[propext, Classical.choice, Quot.sound]`.
+- Updated gallery `meta.json` (status → verified, badge → verified, sorries 0, counts, sections,
+  narrative) and the research tracking json (status → completed).
+
+**Key findings**
+- **Equinumerosity beats a natural Equiv** when the forward map's index is *computed* (only
+  propositionally equal to the target). `Fintype.equivOfCardEq` needs no explicit inverse or
+  `Sigma.ext`/`HEq`; the two `card ≤` directions are clean injectivity proofs.
+- **Injectivity of `glMid` dodges `HEq`**: recover the index as `m.val = m'.val : ℕ` first, then
+  `subst` (via `Fin.ext`) so the dependent fibers become defeq *before* comparing the factors.
+  This is the crucial trick that made the packaging tractable without cast bookkeeping.
+- **Definitional-proof-irrelevance carried the round-trips**: `glMid ∘ fwdMid` matched
+  `glueFp_restrictFp_eq_self` up to the `≤` proof arguments with no massaging (`exact` sufficed).
+- A build succeeded despite swap at 98% — the SIGBUS in prior sessions is transient, not
+  deterministic at high swap.
+
+**Files modified**
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (+~150 lines: `NcFp`/`MidNc`, `fwdMid`/`glMid`,
+  `glMid_fwdMid`, `fwdMid_injective`, `glMid_injective`, `card_midNc_eq`, `card_rhs_eq`,
+  `card_lhs_eq_card_rhs`; `nonempty_firstReturnEquiv` sorry → proof; docstrings/status; axiom check)
+- `src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json` (verified, 0 sorry)
+- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json` (completed)
+
+**Next steps**
+- None for this theorem. Optional: upstream the non-crossing restriction/gluing calculus to Mathlib;
+  relate to the sibling Dyck-word bijection (`ballot-problem-oq-04-oq-01`).
 
 ### Session 2026-07-04 (Session 13) — ACT: right_inv factor recovery
 

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01-incomplete-01/knowledge.md
@@ -106,6 +106,37 @@ Consequences:
 
 ## Session log
 
+### Session 2026-07-04 (Session 13) — ACT: right_inv factor recovery
+
+**Mode**: REVISIT · **Outcome**: progress (2 new verified lemmas + 2 helpers, 0 new sorry)
+
+**What I did**
+- Proved `restrictFp_glueFp_left` / `restrictFp_glueFp_right`: restricting the glued partition
+  `glueFp m hm P₁ P₂` to the left window `[1,m]` (resp. right `[m+1,n]`) returns `P₁` (resp. `P₂`)
+  **exactly** — the *factor half* of the `right_inv` round-trip law.
+- Added reusable helpers `finpartition_eq_of_part` (Finpartition extensionality via the block
+  function) and `part_glueFp_eq_iff` (`part`-equality form of `mem_part_glueFp`).
+- Docker build verified (SIGBUS-135 on first attempt, clean on retry): single expected sorry
+  (`nonempty_firstReturnEquiv`), 0 new sorry.
+
+**Key findings**
+- `right_inv` (`forward ∘ glue = id`) **mathematical content is now complete**: cut index via
+  `firstBlockMax_glueFp_val` (s12) + both factors via the new lemmas. Only `Equiv`/`Sigma`/`Subtype`
+  packaging of `firstReturnForward` remains for `right_inv`.
+- Factor recovery is **unconditional** (no non-crossing hypothesis): restriction of a glue is a pure
+  `glueLabel` computation; each window carries the shifted `Pᵢ` labels verbatim; dropped `0` is
+  outside both windows.
+- Remaining genuine content is **`left_inv`** (`glue ∘ forward = id`); infrastructure ready
+  (`restrict_top_recovers_part_zero`, `part_side_of_firstBlockMax`).
+
+**Files modified**
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (+4 declarations, still 1 sorry)
+- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json`
+
+**Next steps**
+- Assemble the `Equiv` (`firstReturnForward` ↔ `glueFp`), discharge `right_inv`, then attack
+  `left_inv`.
+
 ### Session 2026-07-03 (Session 1) — ORIENT
 
 **Mode**: FRESH · **Outcome**: progress (ORIENT; no sorry closed)

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -12,7 +12,53 @@ This is **openQuestion[2]** of the sibling entry `ballot-problem-oq-04-oq-02`:
 ## Summary of state
 
 The open counting statement has been **reduced to one combinatorial recurrence**. Everything
-except that recurrence is proved with 0 sorry.
+except that recurrence is proved with 0 sorry. The recurrence is packaged as the first-return
+bijection `nonempty_firstReturnEquiv` (the sole `sorry`). Since 2026-07 that bijection's two
+round-trip laws have been de-risked to *assembly only*: `right_inv` ingredients
+(`firstBlockMax_glueFp_val`, `restrictFp_glueFp_left`/`_right`) and now the harder `left_inv`
+core (`glueFp_restrictFp_eq_self`, s14) are all proved (0 sorry). Only the `Sigma`/`Subtype`
+packaging (with the `Fin ij.1.2 = Fin (n − ij.1.1)` cast) remains before the `Equiv` closes.
+
+## Session 2026-07-04 (researcher-6, s14) — `left_inv` core: gluing recovers `P`
+
+**Mode:** REVISIT (continue the first-return bijection assembly). **Outcome:** PROGRESS (new
+0-sorry theorem; the sole `sorry` `nonempty_firstReturnEquiv` unchanged).
+
+- Added **`glueFp_restrictFp_eq_self`** — the substantive round-trip law `glue ∘ forward = id`
+  (`left_inv`): for non-crossing `P` with cut `m = firstBlockMax P`, gluing the two window
+  restrictions `restrictFp (offsetEmb 1) P` and `restrictFp (offsetEmb (m+1)) P` reconstructs
+  `P` on the nose. This is the *hard* round-trip direction — the one where non-crossing is
+  essential (the opposite-sides case is exactly `noStraddle`).
+- **Proof shape** (`finpartition_eq_of_part` → per-pair `glueLabel a = glueLabel b ↔ P.part a =
+  P.part b`), three cases on the cut via `by_cases · .val ≤ m`:
+  - `keyL` (both `≤ m`): labels `Sum.inl (some ·)` track `P₁ = restrict` on `[1,m]`; point `0`
+    lifts to the cut `m` (via `firstBlockMax_mem_part`), so its label tracks `P.part 0` too.
+  - `keyR` (both `> m`): labels `Sum.inr ·` track `P₂ = restrict` verbatim.
+  - `keyCross` (`a ≤ m < b`): labels in distinct `Sum` sectors (`glueLabel_isLeft_of_le` vs
+    `glueLabel_of_gt`) so differ; and `P.part a = P.part b` is refuted by `noStraddle`.
+  - Two local `have`s `hlabL`/`hlabR` evaluate the glued label on each window into a
+    `Q_i`-block whose lifted `P`-block is `P.part x` (the emb value `1+(x−1)=x`, resp.
+    `(m+1)+(x−(m+1))=x`, both `rfl` on `offsetEmb`).
+- **Verified**: docker build EXIT 0 (`LEAN_MEMORY_LIMIT=16384`, 6.2 s replay), 7745 jobs, only
+  the pre-existing line-968 `sorry` warning; **0 new sorry, 0 new axiom**.
+
+### Reusable gotchas (s14)
+- State the theorem taking `hm : (firstBlockMax P).val ≤ n` as an explicit hypothesis (not an
+  inline `Nat.lt_succ_iff.mp … .isLt` term): otherwise `set m` folds only `.val`, and the
+  glueLabel lemmas' `hm` arg fails to `rw`-match the inline term. Explicit `hm` → clean rewrites.
+- `set m := (firstBlockMax P).val with hm_def` leaves `firstBlockMax P` (the `Fin`) unfolded, so
+  `noStraddle`'s `x ≤ firstBlockMax P` obligations discharge via `Fin.le_def.mpr (by omega)` /
+  `Fin.lt_def.mpr (by omega)` — `omega` bridges `.val` and `m` through `hm_def`.
+- `(offsetEmb k h x).val = k + x.val` is `rfl` (used to expose the emb value for `omega`).
+- Proof irrelevance lets `glueLabel_of_zero`/`_pos_le`/`_gt` fill an anonymous-constructor
+  `⟨⟨idx, by omega⟩, <lemma>, ?_⟩` slot directly (the `Fin.mk` proofs need not match).
+
+### Next step (assembly)
+Package the `Equiv`: `toFun = firstReturnForward`, `invFun` = glue (needs the
+`Fin ij.1.2 → Fin (n − ij.1.1)` cast from `mem_antidiagonal`), `left_inv =
+glueFp_restrictFp_eq_self`, `right_inv` = the three glue-recovery lemmas modulo `Sigma`/`Subtype`
+extensionality. This closes `nonempty_firstReturnEquiv` and hence `nonCrossingCount_eq_catalan`
+unconditionally.
 
 ## Session 2026-06-30 (researcher-2) — unconditional `n ≤ 3` anchor (the sorry stays BLOCKED)
 

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
@@ -2,12 +2,12 @@
   "id": "ballot-problem-oq-04-oq-02-oq-01",
   "title": "Non-Crossing Partitions are Counted by the Catalan Numbers: the Recurrence Reduction",
   "slug": "ballot-problem-oq-04-oq-02-oq-01",
-  "description": "Answers openQuestion[2] of the sibling ballot-problem-oq-04-oq-02 up to a single combinatorial recurrence. That entry built nonCrossingCount n := Fintype.card {P : Finpartition (univ : Finset (Fin n)) // IsNonCrossingFp P}, a well-typed count of the non-crossing partitions of Fin n, and located their first divergence from the Bell numbers at n = 4, but left the exact value nonCrossingCount n = catalan n open. This entry supplies the STRUCTURAL REDUCTION of that statement to one lemma. Mathlib's Catalan numbers are defined by the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ (i,j) ∈ antidiagonal n, catalan i · catalan j), so nonCrossingCount = catalan follows by strong induction the moment nonCrossingCount obeys the same two laws. We prove the base case nonCrossingCount 0 = 1 (the empty set has a unique, vacuously non-crossing partition) and the reduction nonCrossingCount_eq_catalan (a four-line Nat.strong_induction_on matching the antidiagonal shape of catalan_succ' term-by-term), discharging everything EXCEPT the recurrence nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j. That recurrence — the classical block / first-return decomposition of a non-crossing partition of a linearly ordered (n+1)-element set into two independent non-crossing partitions whose sizes sum to n — is the genuine combinatorial content, is not in Mathlib in any form, and remains a single sorry. The contribution is the isolation of the entire difficulty of 'non-crossing = Catalan' into that one recurrence: a reduction in the spirit of replacing an explicit bijection with one structural identity.",
+  "description": "Answers openQuestion[2] of the sibling ballot-problem-oq-04-oq-02 IN FULL: nonCrossingCount n = catalan n, machine-checked with 0 sorries and only the foundational axioms. That entry built nonCrossingCount n := Fintype.card {P : Finpartition (univ : Finset (Fin n)) // IsNonCrossingFp P}, a well-typed count of the non-crossing partitions of Fin n, and located their first divergence from the Bell numbers at n = 4, but left the exact value open. Mathlib's Catalan numbers are defined by the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ (i,j) ∈ antidiagonal n, catalan i · catalan j), so nonCrossingCount = catalan follows by strong induction once nonCrossingCount obeys the base case nonCrossingCount 0 = 1 and the same convolution recurrence. The recurrence is the genuine combinatorial content — the classical block / first-return decomposition of a non-crossing partition of a linearly ordered (n+1)-element set into two independent non-crossing partitions whose sizes sum to n — and is NOT in Mathlib in any form. This entry builds it from scratch: a restriction operation restrictFp (a Finpartition of Fin (n+1) restricted along an index embedding), an inverse gluing operation glueFp, proofs that both preserve non-crossing (the hard direction uses that no block straddles the cut m = firstBlockMax P), and the two round-trip laws. These are packaged into the first-return bijection by an equinumerosity count: the two sides are shown equal in cardinality via antisymmetry of two explicit injections through a Fin (n+1)-indexed intermediate type (whose window fibers match glueFp's signature definitionally, avoiding dependent-HEq casts), and Fintype.equivOfCardEq supplies the bijection. The whole development — restriction, gluing, non-crossing preservation both ways, and the count — is roughly 1200 lines with no Mathlib support for non-crossing partitions.",
   "meta": {
     "author": "Non-crossing partitions (Kreweras 1972); formalized via Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Noncrossing_partition",
     "date": "1972",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
     "tags": [
       "combinatorics",
@@ -17,17 +17,17 @@
       "recurrence",
       "strong-induction",
       "ballot-problem",
-      "research",
-      "open-problem"
+      "bijection",
+      "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "1 sorry: nonCrossingCount_recurrence (the combinatorial Catalan convolution recurrence for non-crossing Finpartitions; HARD, bijection-level, no Mathlib support). 0 literal `axiom` declarations. The proved parts (nonCrossingCount_zero, and the nonCrossingCount_eq_catalan reduction) depend only on the foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Because a sorry remains, this entry is `formalized`, not `verified` — the headline equality nonCrossingCount n = catalan n is proved CONDITIONAL on the outstanding recurrence.",
+    "assumptions": "None. 0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. The full theorem nonCrossingCount n = catalan n (nonCrossingCount_eq_catalan) is machine-checked and depends only on the foundational axioms propext / Classical.choice / Quot.sound (Classical.choice enters via Fintype.equivOfCardEq and .some on the first-return bijection's Nonempty). No native_decide and no Lean.ofReduceBool — the n ≤ 3 corollary uses kernel `decide`, not native_decide. Confirmed by `#print axioms nonCrossingCount_eq_catalan`. Status verified.",
     "dateAdded": "2026-06-26",
-    "lineCount": 199,
-    "theoremCount": 6,
-    "definitionCount": 0,
+    "lineCount": 1198,
+    "theoremCount": 41,
+    "definitionCount": 12,
     "mathlibDependencies": [
       {
         "theorem": "catalan_succ'",
@@ -69,12 +69,41 @@
       {
         "theorem": "Finset.sum_coe_sort",
         "purpose": "reindex the univ-sum over the antidiagonal subtype back to a Finset sum"
+      },
+      {
+        "theorem": "Finpartition.ofSetoid",
+        "description": "build a Finpartition from a Setoid with decidable relation; underlies both restrictFp (Setoid.comap of P.part's kernel along the index embedding) and glueFp (the glueLabel setoid)",
+        "module": "Mathlib.Order.Partition.Finpartition"
+      },
+      {
+        "theorem": "Fintype.card_le_of_injective",
+        "description": "an injection α ↪ β gives card α ≤ card β; used both ways (fwdMid and glMid) so le_antisymm yields card LHS = card MidNc",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Fintype.equivOfCardEq",
+        "description": "equal Fintype cards give a (noncomputable, choice-backed) Equiv; turns card_lhs_eq_card_rhs into nonempty_firstReturnEquiv without constructing a cast-heavy natural bijection",
+        "module": "Mathlib.Logic.Equiv.Fintype"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk",
+        "description": "∑ ij ∈ antidiagonal n, f ij = ∑ k ∈ range (n+1), f (k, n-k); converts the antidiagonal-indexed card sum to the range-indexed one matching the MidNc count (pure ℕ arithmetic, no type casts)",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Fin.sum_univ_eq_sum_range",
+        "description": "∑ i : Fin n, f i = ∑ i ∈ range n, f i; rewrites the MidNc fibre-card sum over Fin (n+1) into the range form",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
       }
     ],
     "originalContributions": [
-      "nonCrossingCount_zero : nonCrossingCount 0 = 1 — the empty set has a unique, vacuously non-crossing partition (via nonCrossingCount_eq_card_of_n_le_three, Unique (Finpartition ⊥), Fintype.card_unique). 0 sorry.",
-      "nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n — the reduction: a Nat.strong_induction_on whose step rewrites nonCrossingCount (n+1) by the recurrence, rewrites catalan (n+1) by catalan_succ', and matches the two antidiagonal sums term-by-term using the inductive hypothesis on each factor (both < n+1). 0 sorry beyond its dependence on the recurrence.",
-      "nonCrossingCount_recurrence (statement): nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the Catalan convolution for the Finpartition model, stated to match catalan_succ' so the reduction is purely formal. Its proof (the block/first-return decomposition) is the single outstanding sorry and the entire remaining combinatorial content."
+      "nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n — the full theorem, now machine-checked with 0 sorries: a Nat.strong_induction_on whose step rewrites nonCrossingCount (n+1) by the (now-proved) recurrence, rewrites catalan (n+1) by catalan_succ', and matches the two antidiagonal sums term-by-term using the inductive hypothesis on each factor (both < n+1).",
+      "nonCrossingCount_recurrence : nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the Catalan convolution for the Finpartition model, PROVED (formerly the sole sorry) via nonempty_firstReturnEquiv and the counting reduction nonCrossingCount_recurrence_of_equiv.",
+      "restrictFp / glueFp — a restriction operation (a Finpartition of Fin (n+1) restricted along a strictly monotone index embedding, via Setoid.comap + Finpartition.ofSetoid) and its inverse gluing operation (built from a three-way glueLabel on the distinguished point 0, the left window [1,m], and the right window [m+1,n]). Neither exists in Mathlib.",
+      "firstBlockMax P := (P.part 0).max' and the separation lemmas noStraddle_of_isMax / part_side_of_firstBlockMax : for a non-crossing P, no block straddles the cut m = firstBlockMax P — the structural fact that makes the first-return split BINARY (Catalan) rather than multi-part. This is where the non-crossing hypothesis is genuinely used.",
+      "isNonCrossingFp_restrictFp / isNonCrossingFp_glueFp — restriction and gluing both preserve non-crossing (gluing needs the 'attach 0 to the top block m-1' choice to keep window A non-crossing through the special point).",
+      "The round-trip laws glueFp_restrictFp_eq_self (glue ∘ forward = id, the hard direction), restrictFp_glueFp_left/right and firstBlockMax_glueFp_val (forward ∘ glue = id), assembled by card_lhs_eq_card_rhs: an equinumerosity count via antisymmetry of two injections (fwdMid with left inverse glMid; glMid injective by recovering the cut as an ℕ-equality then both factors), routed through the Fin (n+1)-indexed intermediate type MidNc whose fibers match glueFp definitionally — so no dependent-HEq casts. Fintype.equivOfCardEq then yields nonempty_firstReturnEquiv.",
+      "nonCrossingCount_eq_catalan_of_le_three : an unconditional kernel-decide check for n ≤ 3 (Bell = Catalan up to 3, the regime just before the first divergence Bell 4 = 15 > 14 = catalan 4)."
     ]
   },
   "references": [
@@ -102,10 +131,11 @@
     "problemStatement": "Prove nonCrossingCount n = catalan n. Reduce it, with full rigour, to the single recurrence nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j, matching Mathlib's catalan recurrence.",
     "proofStrategy": "Mathlib's catalan is DEFINED by the antidiagonal convolution and catalan_succ' exposes it. So if nonCrossingCount satisfies (i) nonCrossingCount 0 = 1 and (ii) the same convolution recurrence, then nonCrossingCount = catalan by strong induction. (i) is proved here: univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, and for n ≤ 3 every partition is non-crossing, so nonCrossingCount 0 = Fintype.card (Finpartition ⊥) = 1. (ii) is STATED as nonCrossingCount_recurrence and used to prove nonCrossingCount_eq_catalan: Nat.strong_induction_on n; the n=0 case is (i); the n=m+1 case rewrites the left side by the recurrence, the right by catalan_succ', and applies Finset.sum_congr over antidiagonal m, rewriting each factor nonCrossingCount i (resp. j) to catalan i (resp. j) by the inductive hypothesis, valid because i, j < m+1. The recurrence's own proof — decomposing a non-crossing Finpartition of Fin (n+1) by the block structure around a distinguished point into independent non-crossing partitions of complementary intervals — is the outstanding sorry.",
     "keyInsights": [
-      "**The whole problem collapses to one recurrence.** Because Mathlib's catalan IS the antidiagonal convolution (catalan_succ'), proving nonCrossingCount obeys the identical convolution plus the base case settles nonCrossingCount = catalan by a four-line strong induction. The reduction isolates 100% of the difficulty into nonCrossingCount_recurrence.",
-      "**The recurrence cannot be assumed.** Deriving it requires an independent combinatorial argument (the block / first-return decomposition); using nonCrossingCount = catalan to obtain it would be circular. This is why it is the genuine content and the honest sorry.",
-      "**Base case via uniqueness, not computation.** nonCrossingCount 0 = 1 falls out of Unique (Finpartition ⊥) once univ : Finset (Fin 0) is identified with ⊥ — no enumeration, and it matches catalan 0 = 1 exactly.",
-      "**Mathlib has no non-crossing partition theory.** There is no nonCrossing/NonCrossingPartition anywhere in Mathlib and no Finpartition block-gap decomposition lemma, so the recurrence has nothing to transport from and must be built from scratch — the reason it remains open."
+      "**The whole problem collapses to one recurrence.** Because Mathlib's catalan IS the antidiagonal convolution (catalan_succ'), proving nonCrossingCount obeys the identical convolution plus the base case settles nonCrossingCount = catalan by a four-line strong induction. All difficulty concentrates in nonCrossingCount_recurrence — which this entry now proves.",
+      "**The cut m = firstBlockMax P makes the split binary.** Choosing the distinguished point's block-maximum as the cut, non-crossing forces every block entirely into [0,m] or [m+1,n] (noStraddle): a block with points on both sides would cross the pair (0, m). This BINARY separation is exactly what turns the decomposition into the Catalan convolution rather than a multi-part composition — and it is the one place the non-crossing hypothesis is essential.",
+      "**Gluing must attach 0 to the top block.** The inverse glueFp reattaches the dropped point 0 to the top block m-1 of the left window; this specific choice is what keeps window A non-crossing through 0, and its correctness is the mirror pair restrict_top_recovers_part_zero / mem_part_zero_glueFp_left.",
+      "**Equinumerosity dodges the dependent-HEq cast.** A natural Equiv between the antidiagonal-indexed Σ-type and the non-crossing partitions would need to match dependent fibers across a merely-propositional index equality (the forward map's cut is computed, not definitional). Instead we prove card LHS = card RHS by antisymmetry of two injections through a Fin (n+1)-indexed intermediate type whose fibers match glueFp definitionally, and let Fintype.equivOfCardEq produce the bijection — no cast bookkeeping.",
+      "**Mathlib has no non-crossing partition theory.** There is no nonCrossing/NonCrossingPartition anywhere in Mathlib and no Finpartition block-gap decomposition lemma, so the entire restriction/gluing calculus had to be built from scratch."
     ],
     "prerequisites": [
       "The parent's Finpartition model nonCrossingCount and nonCrossingCount_eq_card_of_n_le_three (ballot-problem-oq-04-oq-02)",
@@ -113,50 +143,90 @@
       "Strong induction on ℕ and Finset.sum_congr over antidiagonal",
       "Uniqueness of the partition of the empty set (Unique (Finpartition ⊥)) and Fintype.card_unique"
     ],
-    "what": "A rigorous reduction of the open enumeration nonCrossingCount n = catalan n to a single combinatorial recurrence: the base case nonCrossingCount 0 = 1 and the strong-induction argument nonCrossingCount_eq_catalan are proved (0 sorry), leaving only the Catalan convolution recurrence nonCrossingCount_recurrence (1 sorry) as the entire remaining content.",
-    "how": "State nonCrossingCount_recurrence to match Mathlib's catalan_succ'; prove nonCrossingCount 0 = 1 from Unique (Finpartition ⊥); then prove nonCrossingCount_eq_catalan by strong induction, matching the two antidiagonal sums term-by-term via the inductive hypothesis.",
-    "significance": "Reduces the parent entry's openQuestion[2] to one well-defined lemma, demonstrating that 'non-crossing partitions are counted by Catalan' is, modulo the standard block decomposition, a purely formal consequence of Mathlib's definition of catalan. It pinpoints the exact missing piece (a Finpartition block/first-return decomposition, absent from Mathlib) and packages it as a single sorry suitable for focused proof search, rather than leaving the whole enumeration open."
+    "what": "A complete, machine-checked proof (0 sorries, 0 axioms beyond the foundational ones) of the open enumeration nonCrossingCount n = catalan n: the base case nonCrossingCount 0 = 1, the strong-induction reduction nonCrossingCount_eq_catalan, and — the genuine content — the Catalan convolution recurrence nonCrossingCount_recurrence, built from a from-scratch restriction/gluing calculus for non-crossing Finpartitions and its first-return bijection.",
+    "how": "Build restrictFp (restriction of a Finpartition of Fin (n+1) along a strictly monotone index embedding) and glueFp (its inverse, gluing at the cut m = firstBlockMax P via a three-way glueLabel), prove both preserve non-crossing (the hard direction uses the no-straddle separation lemma), and establish the round-trip laws. Package them into the first-return bijection by an equinumerosity count: card LHS = card RHS by antisymmetry of two injections through the Fin (n+1)-indexed intermediate type MidNc, then Fintype.equivOfCardEq. Feed the resulting recurrence into the strong induction against catalan_succ'.",
+    "significance": "Settles the parent entry's openQuestion[2] outright and supplies Mathlib-free infrastructure for non-crossing partitions of a linearly ordered set (restriction, gluing, the firstBlockMax cut invariant, the no-straddle lemma, and the first-return Catalan decomposition), none of which existed in Mathlib. It also demonstrates a reusable packaging pattern: when a forward map's index is computed (only propositionally equal to the target), route the round-trip through an intermediate type with definitionally-matching fibers and finish with a cardinality count instead of a cast-heavy dependent Equiv."
   },
   "sections": [
     {
       "id": "header",
       "title": "Problem Statement and Reduction Plan",
       "startLine": 1,
-      "endLine": 62,
-      "summary": "Module docstring: the reduction of nonCrossingCount n = catalan n to the base case plus the Catalan convolution recurrence, the strong-induction argument that closes the gap, and an honest status note (1 sorry, the recurrence).",
+      "endLine": 69,
+      "summary": "Module docstring: the reduction of nonCrossingCount n = catalan n to the base case plus the Catalan convolution recurrence, and the status note — 0 sorries, verified, only the foundational axioms.",
       "mathContext": "$\\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$"
     },
     {
       "id": "base-case",
       "title": "The Base Case n = 0",
-      "startLine": 63,
-      "endLine": 73,
-      "summary": "nonCrossingCount_zero : nonCrossingCount 0 = 1 — univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, and every partition for n ≤ 3 is non-crossing, so the count is Fintype.card_unique = 1.",
+      "startLine": 70,
+      "endLine": 80,
+      "summary": "nonCrossingCount_zero : nonCrossingCount 0 = 1 — univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, so the count is Fintype.card_unique = 1 = catalan 0.",
       "mathContext": "$\\mathrm{nonCrossingCount}\\,0 = 1 = \\mathrm{catalan}\\,0$"
     },
     {
+      "id": "restriction",
+      "title": "Restriction of Non-Crossing Partitions (forward map)",
+      "startLine": 81,
+      "endLine": 360,
+      "summary": "restrictFp (a Finpartition of Fin (n+1) restricted along a strictly monotone index embedding, via Setoid.comap + Finpartition.ofSetoid) and its non-crossing preservation isNonCrossingFp_restrictFp; the concrete interval embeddings (castLE, offsetEmb); the cut invariant firstBlockMax P := (P.part 0).max' and the forward map firstReturnForward; the no-straddle separation lemmas (noStraddle_of_isMax, part_side_of_firstBlockMax) — every block lies entirely on one side of the cut.",
+      "mathContext": "$m = \\max(P.\\mathrm{part}\\,0),\\quad \\text{no block straddles } m$"
+    },
+    {
+      "id": "gluing",
+      "title": "The Inverse Gluing Map and its Non-Crossing Preservation",
+      "startLine": 361,
+      "endLine": 695,
+      "summary": "glueFp: the inverse map, gluing two window partitions at the cut via a three-way glueLabel (the point 0, the left window [1,m] carrying P₁ with 0 attached to the top block m-1, the right window [m+1,n] carrying P₂); the glueLabel evaluation lemmas; restrict_top_recovers_part_zero / mem_part_zero_glueFp_left (0's block is reconstructible); and isNonCrossingFp_glueFp — gluing two non-crossing partitions is non-crossing.",
+      "mathContext": "$\\mathrm{glueFp}\\ m\\ P_1\\ P_2 : \\mathrm{Finpartition}(\\mathrm{Fin}\\,(n{+}1))$"
+    },
+    {
+      "id": "round-trips",
+      "title": "The Round-Trip Laws",
+      "startLine": 696,
+      "endLine": 938,
+      "summary": "firstBlockMax_glueFp_val (glue recovers the cut index), restrictFp_glueFp_left/right (restriction recovers each glued factor) — together forward ∘ glue = id; and glueFp_restrictFp_eq_self — glue ∘ forward = id, the hard direction where non-crossing is essential (three cases on the cut, opposite-side pairs ruled out by noStraddle).",
+      "mathContext": "$\\mathrm{glue}\\circ\\mathrm{forward}=\\mathrm{id},\\quad \\mathrm{forward}\\circ\\mathrm{glue}=\\mathrm{id}$"
+    },
+    {
+      "id": "bijection-count",
+      "title": "Assembling the First-Return Bijection via a Cardinality Count",
+      "startLine": 939,
+      "endLine": 1061,
+      "summary": "The Fin (n+1)-indexed intermediate type MidNc (fibers match glueFp definitionally), the maps fwdMid / glMid, their injectivity (fwdMid by left inverse; glMid by recovering the cut as an ℕ-equality then both factors), and card_lhs_eq_card_rhs: card LHS = card MidNc (antisymmetry) = card RHS (antidiagonal ↔ range reindexing). Dodges the dependent-HEq casts a natural Equiv would need.",
+      "mathContext": "$\\#\\,\\mathrm{LHS} = \\#\\,\\mathrm{RHS}$"
+    },
+    {
       "id": "recurrence",
-      "title": "The Combinatorial Recurrence (Outstanding sorry)",
-      "startLine": 74,
-      "endLine": 89,
-      "summary": "nonCrossingCount_recurrence : nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the block/first-return decomposition of a non-crossing partition into independent sub-partitions; stated to match catalan_succ', proof is the single sorry.",
+      "title": "The Combinatorial Recurrence",
+      "startLine": 1062,
+      "endLine": 1127,
+      "summary": "nonempty_firstReturnEquiv (the first-return bijection, from card_lhs_eq_card_rhs via Fintype.equivOfCardEq), the counting reduction nonCrossingCount_recurrence_of_equiv (Fintype.card_congr ∘ card_sigma ∘ card_prod), and their corollary nonCrossingCount_recurrence — the Catalan convolution for the Finpartition model, now PROVED.",
       "mathContext": "$\\mathrm{nonCrossingCount}\\,(n{+}1) = \\sum_{i+j=n} \\mathrm{nonCrossingCount}\\,i \\cdot \\mathrm{nonCrossingCount}\\,j$"
     },
     {
       "id": "counting-theorem",
       "title": "The Counting Theorem via Strong Induction",
-      "startLine": 90,
-      "endLine": 114,
+      "startLine": 1128,
+      "endLine": 1148,
       "summary": "nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n — Nat.strong_induction_on; base case from nonCrossingCount_zero, step rewrites by the recurrence and catalan_succ' and matches the antidiagonal sums term-by-term via the IH (both indices < n+1).",
       "mathContext": "$\\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "n-le-three",
+      "title": "Unconditional Verification for n ≤ 3",
+      "startLine": 1149,
+      "endLine": 1198,
+      "summary": "nonCrossingCount_eq_catalan_of_le_three — an independent kernel-decide check that Bell = Catalan for n ≤ 3 (the regime just before the first divergence Bell 4 = 15 > 14 = catalan 4), plus #check / #print axioms confirming the foundational-only axiom profile.",
+      "mathContext": "$n \\le 3 \\Rightarrow \\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$"
     }
   ],
   "conclusion": {
-    "summary": "Reduces the open enumeration nonCrossingCount n = catalan n to a single combinatorial recurrence. The base case nonCrossingCount 0 = 1 (uniqueness of the empty partition) and the reduction nonCrossingCount_eq_catalan (strong induction matching Mathlib's catalan_succ' term-by-term) are proved with 0 sorry; the Catalan convolution recurrence for the Finpartition model remains a single sorry. Status formalized (not verified): the headline equality is proved conditional on that recurrence.",
-    "implications": "Pinpoints the exact remaining obstacle to the parent's openQuestion[2]: a block/first-return decomposition of non-crossing Finpartitions, which Mathlib lacks entirely. Once that recurrence is proved (by direct decomposition or by transporting the explicit Dyck-word bijection of sibling oq-04-oq-01), nonCrossingCount n = catalan n follows immediately from this file.",
+    "summary": "Proves the parent's openQuestion[2] in full: nonCrossingCount n = catalan n, machine-checked with 0 sorries and only the foundational axioms (propext / Classical.choice / Quot.sound; confirmed by #print axioms). The base case nonCrossingCount 0 = 1 and the strong-induction reduction to the Catalan convolution recurrence are proved, and the recurrence itself — the block / first-return decomposition of a non-crossing Finpartition, absent from Mathlib — is built from scratch here (restrictFp / glueFp, non-crossing preservation both directions, the round-trip laws) and packaged into the first-return bijection by an equinumerosity count. Status verified.",
+    "implications": "Supplies Mathlib-free infrastructure for non-crossing partitions of a linearly ordered set: a restriction/gluing calculus on Finpartition (Fin ·), the cut invariant firstBlockMax with its no-straddle separation lemma, and the first-return Catalan decomposition — the missing piece the parent entry left open. The equinumerosity-via-two-injections packaging (routing through a Fin (n+1)-indexed intermediate type to dodge dependent-HEq casts) is a reusable pattern for turning a computed-index forward map plus round-trip laws into an Equiv.",
     "openQuestions": [
-      "Prove nonCrossingCount_recurrence directly: build the Equiv from non-crossing Finpartitions of Fin (n+1) to Σ (i,j) ∈ antidiagonal n of pairs of non-crossing Finpartitions (via the block of the last/first point and the gaps it induces), then take Fintype.card.",
-      "Alternatively transport DyckWord.card_dyckWord_semilength_eq_catalan along the explicit Dyck-word ↔ non-crossing-partition bijection (sibling ballot-problem-oq-04-oq-01) to obtain the recurrence or the equality directly."
+      "Upstream the non-crossing-partition restriction/gluing calculus (restrictFp, glueFp, firstBlockMax, the no-straddle lemma) to Mathlib, which currently has no non-crossing partition theory.",
+      "Relate this Finpartition-model proof to the explicit Dyck-word ↔ non-crossing-partition bijection of sibling ballot-problem-oq-04-oq-01 (a second, independent route to the same enumeration)."
     ]
   },
   "crossReferences": [
@@ -174,12 +244,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 199,
+    "lineCount": 1198,
     "path": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
     "axiomCount": 0,
-    "sorries": 1,
-    "definitionCount": 0,
-    "theoremCount": 6
+    "sorries": 0,
+    "definitionCount": 12,
+    "theoremCount": 41
   },
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -8,7 +8,7 @@
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "PROGRESS: glueLabel evaluation API + two-sided 0-block recovery proved (0 new sorry); round-trip laws now within reach. Sole sorry: nonempty_firstReturnEquiv.",
+    "progressSummary": "PROGRESS: right_inv factor-recovery DONE (restrictFp_glueFp_left/right, verified, 0 new sorry) on top of cut-index recovery (firstBlockMax_glueFp_val). Sole sorry still nonempty_firstReturnEquiv; remaining = Equiv packaging (right_inv) + left_inv (glue∘forward=id).",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
@@ -20,7 +20,9 @@
       "firstReturnForward (0 sorry): the FORWARD map of nonempty_firstReturnEquiv, mapping a non-crossing P to ((m,n-m) in antidiagonal, offset-restriction to [1,m], offset-restriction to [m+1,n]). Forward half plus target indices fully pinned; only inverse + mutual-inverse remain.",
       "restrict_top_recovers_part_zero (BallotProblemOQ04OQ02OQ01.lean): left restriction top block = P.part 0 (forward-side 0-block recovery, 0 sorry)",
       "glueLabel_zero_of_pos / glueLabel_offsetEmb_left / glueLabel_offsetEmb_right: glueLabel evaluation API collapsing the three-way dite at 0 / left window / right window (0 sorry)",
-      "mem_part_zero_glueFp_left: glue-side 0-block recovery, mirror of restrict_top_recovers_part_zero (0 sorry)"
+      "mem_part_zero_glueFp_left: glue-side 0-block recovery, mirror of restrict_top_recovers_part_zero (0 sorry)",
+      "restrictFp_glueFp_left / restrictFp_glueFp_right (BallotProblemOQ04OQ02OQ01.lean, verified) — restricting the glued partition glueFp to each offset window recovers the original factor P₁ / P₂ exactly; the factor half of the right_inv round-trip law",
+      "finpartition_eq_of_part + part_glueFp_eq_iff (verified helpers) — Finpartition extensionality via the block function; part-equality form of mem_part_glueFp"
     ],
     "insights": [
       "Mathlib's catalan is defined by exactly the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ ij ∈ antidiagonal n, catalan ij.1 * catalan ij.2), so proving nonCrossingCount obeys the SAME recurrence + base reduces nonCrossingCount = catalan to a four-line strong induction. The entire difficulty is isolated into the one recurrence lemma.",
@@ -41,17 +43,18 @@
       "Small-case validation of the cut: n=1 -> m in {0,1} separates the 2 partitions of {0,1}; n=2 -> the three m-values distribute the 5 partitions of {0,1,2} as 1+2+2 over (0,2),(1,1),(2,0) = NC0*NC2 + NC1*NC1 + NC2*NC0.",
       "File worked by multiple researchers in parallel (r14 + r6); r6 merged glueFp/part_side via #34708 while my branch diverged. Always fetch+diff origin/main before editing; my block_side duplicated r6 part_side_of_firstBlockMax.",
       "Segfault (Lean exit 135) trigger on this file: simp/simpa on Sum/Option/Fin goals and lambda-motive congrArg. Fix: rw [Sum.inl.injEq, Option.some.injEq] + explicit congrArg P.part (Fin.ext hidx). omega on (offsetEmb).val (= k+x.val) is SAFE.",
-      "glueLabel API is the glueFp analogue of mem_part_restrictFp — the bridge all round-trip membership proofs pass through."
+      "glueLabel API is the glueFp analogue of mem_part_restrictFp — the bridge all round-trip membership proofs pass through.",
+      "right_inv (forward∘glue=id) mathematical content is COMPLETE: firstBlockMax_glueFp_val recovers the cut index m, restrictFp_glueFp_left/right recover the two factors. Only the Equiv/Sigma/Subtype packaging of firstReturnForward remains for right_inv.",
+      "Factor recovery is unconditional (uses no non-crossing hypothesis): restriction of a glue is a pure glueLabel computation since each window carries the shifted Pᵢ labels verbatim; dropped point 0 lies outside both windows."
     ],
     "mathlibGaps": [
       "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
       "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
     ],
     "nextSteps": [
-      "Prove round-trip glue ∘ forward = id: glueFp m _ Q R = P for Q,R = window restrictions of P, via Finpartition extensionality + glueLabel API + both 0-block recovery lemmas + part_side_of_firstBlockMax for cross-window separation.",
-      "Then forward ∘ glue = id and assemble the Equiv to close nonempty_firstReturnEquiv.",
-      "Coordinate with researcher-6 (s10-glue-noncrossing) — they need these API lemmas.",
-      "Retry Aristotle each session (down 8+ consecutive; smoke test 404)."
+      "Assemble the Equiv (firstReturnForward toFun ↔ glueFp invFun via isNonCrossingFp_glueFp): right_inv now follows from firstBlockMax_glueFp_val + restrictFp_glueFp_left/right (modulo Sigma.ext + heterogeneous Fin i/Fin j window casts).",
+      "left_inv (glue∘forward=id): gluing the two window-restrictions of a non-crossing P must return P; infrastructure ready — restrict_top_recovers_part_zero + part_side_of_firstBlockMax.",
+      "Do NOT retry kernel decide for nonCrossingCount n at n>=4 (kernel stack overflow confirmed)."
     ]
   },
   "currentState": {

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -1,14 +1,14 @@
 {
   "slug": "ballot-problem-oq-04-oq-02-oq-01",
   "title": "Non-Crossing Partitions are Counted by the Catalan Numbers (nonCrossingCount n = catalan n)",
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "DONE",
   "tier": "B",
   "significance": 6,
   "tractability": 8,
   "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
   "knowledge": {
-    "progressSummary": "PROGRESS: right_inv factor-recovery DONE (restrictFp_glueFp_left/right, verified, 0 new sorry) on top of cut-index recovery (firstBlockMax_glueFp_val). Sole sorry still nonempty_firstReturnEquiv; remaining = Equiv packaging (right_inv) + left_inv (glue∘forward=id).",
+    "progressSummary": "COMPLETE (2026-07-04, s15): nonCrossingCount n = catalan n is fully proved — 0 sorries, verified, axioms [propext, Classical.choice, Quot.sound] only (confirmed by #print axioms). The last sorry nonempty_firstReturnEquiv was discharged by an equinumerosity count: card LHS = card RHS via antisymmetry of two injections (fwdMid with left inverse glMid; glMid injective by recovering the cut as an ℕ-equality then both factors) routed through the Fin (n+1)-indexed intermediate type MidNc (fibers match glueFp definitionally, no dependent-HEq casts), then Fintype.equivOfCardEq. Built cleanly under Lean v4.26.0 in Docker.",
     "builtItems": [
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
       "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
@@ -58,18 +58,16 @@
     ]
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-26T00:00:00.000Z",
-    "iteration": 1,
-    "focus": "Structural reduction of nonCrossingCount = catalan to the Catalan convolution recurrence on the Finpartition model.",
-    "blockers": [
-      "The combinatorial recurrence nonCrossingCount_recurrence (block decomposition of non-crossing Finpartitions) — HARD, bijection-level, no Mathlib support."
-    ],
-    "nextAction": "Prove nonCrossingCount_recurrence via the first-return block decomposition, or submit to Aristotle when the endpoint recovers.",
+    "phase": "DONE",
+    "since": "2026-07-04T00:00:00.000Z",
+    "iteration": 15,
+    "focus": "COMPLETE — nonCrossingCount n = catalan n fully proved (0 sorry, verified). The first-return decomposition (restrictFp/glueFp, non-crossing preservation both ways, round-trip laws) is built from scratch and packaged into the bijection by an equinumerosity count.",
+    "blockers": [],
+    "nextAction": "None — theorem complete. Optional follow-ups: upstream the non-crossing restriction/gluing calculus to Mathlib; relate to the sibling Dyck-word bijection (oq-04-oq-01).",
     "attemptCounts": {
-      "total": 1,
+      "total": 15,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 3
     }
   },
   "tags": [
@@ -81,7 +79,7 @@
     "research",
     "open-problem"
   ],
-  "lastUpdate": "2026-06-26T00:00:00.000Z",
+  "lastUpdate": "2026-07-04T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/BallotProblem.lean",
@@ -471,11 +469,11 @@
     {
       "path": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
       "filename": "BallotProblemOQ04OQ02OQ01.lean",
-      "lineCount": 115,
-      "theoremCount": 3,
+      "lineCount": 1198,
+      "theoremCount": 41,
       "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 6,
+      "defCount": 12,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean"
     }


### PR DESCRIPTION
## Summary

**Closes the theorem.** `nonCrossingCount n = catalan n` — the non-crossing partitions of a linearly ordered set are counted by the Catalan numbers — is now **fully proved**: 0 sorries, and `#print axioms nonCrossingCount_eq_catalan` = `[propext, Classical.choice, Quot.sound]` (foundational only; no `sorryAx`, no `Lean.ofReduceBool`). **Status: verified.**

This was the parent entry's `openQuestion[2]`, and there is **no non-crossing-partition theory in Mathlib** — the whole first-return decomposition (restriction, gluing, non-crossing preservation, round-trip laws) is built from scratch (~1200 lines).

## The final step (this session, s15)

The sole remaining `sorry` was `nonempty_firstReturnEquiv`, the first-return bijection. Rather than construct a *natural* `Equiv` between the antidiagonal-indexed `Σ`-type and the non-crossing partitions — which needs dependent-`HEq` transport, since the forward map's cut index equals the target only *propositionally* — it is discharged by an **equinumerosity count**:

- **`MidNc n := Σ m : Fin (n+1), NcFp m.val × NcFp (n - m.val)`** — an intermediate type whose right fiber `Fin (n - m)` matches `glueFp`'s argument type **definitionally**, so gluing needs no cast.
- **`fwdMid`** (cut at `firstBlockMax P` + restrict to the two windows) and **`glMid`** (glue).
- **`card LhsNc = card MidNc`** by `le_antisymm` of two injections: `fwdMid` injective via its left inverse `glMid` (`glueFp_restrictFp_eq_self`); `glMid` injective by recovering the cut as an **ℕ-equality** (`firstBlockMax_glueFp_val`, so `subst` dodges `HEq`) then both factors (`restrictFp_glueFp_left`/`_right`).
- **`card MidNc = card Rhs`** by a pure `antidiagonal ↔ range` reindexing (`Fin.sum_univ_eq_sum_range` + `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`) — no partition casts.
- **`nonempty_firstReturnEquiv := Fintype.equivOfCardEq card_lhs_eq_card_rhs`.**

## Verification

- Docker build clean (7745 jobs), first try.
- `#print axioms nonCrossingCount_eq_catalan → [propext, Classical.choice, Quot.sound]`.

## Files

- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` — packaging block + sorry → proof; status/docstrings.
- `src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json` — status `verified`, 0 sorry.
- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json` — status `completed`.
- research knowledge.md — s15 session log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)