### PR TITLE
research(lp-duality-synthesis): apply S18 source-verified drift batch to Incomplete01 [WIP — build-blocked by host-memory SIGBUS]

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -40,6 +40,22 @@ variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
 
 namespace RieszSigmaFiniteComplete
 
+/-- Helper: `x ^ (q - 1) * x = x ^ q` for `0 ≤ x` and `q ≠ 0`.
+
+Uses `Real.rpow_add'` (which requires only `0 ≤ x`, plus `y + z ≠ 0`) rather than
+`Real.rpow_add` (which now requires the strictly-positive `0 < x`). This isolates the
+Hölder-extremizer rpow arithmetic `|g_k a| ^ (q-1) * |g_k a| = |g_k a| ^ q` used in the
+localization norm bound, and — unlike a manual `Real.rpow_add` rewrite — needs no
+separate `x = 0` case split (`Real.rpow_add'` already covers the zero base). -/
+theorem rpow_sub_one_mul_self {x : ℝ} (hx : 0 ≤ x) {q : ℝ} (hq : q ≠ 0) :
+    x ^ (q - 1) * x = x ^ q := by
+  have hqe : q - 1 + 1 = q := by ring
+  have hne : q - 1 + 1 ≠ 0 := by rw [hqe]; exact hq
+  calc x ^ (q - 1) * x
+      = x ^ (q - 1) * x ^ (1 : ℝ) := by rw [Real.rpow_one]
+    _ = x ^ (q - 1 + 1) := (Real.rpow_add' hx hne).symm
+    _ = x ^ q := by rw [hqe]
+
 -- ============================================================================
 -- § 0. Helper lemmas
 -- ============================================================================
@@ -488,9 +504,8 @@ theorem gseq_norm_bound
             · simp [Real.sign_of_pos ha, abs_of_pos ha]
           rw [show Real.sign (g_k a) * |g_k a| ^ (q.toReal - 1) * g_k a =
               |g_k a| ^ (q.toReal - 1) * (Real.sign (g_k a) * g_k a) from by ring,
-              hsign, show |g_k a| = |g_k a| ^ (1 : ℝ) from (Real.rpow_one _).symm,
-              ← Real.rpow_add (abs_nonneg _)]
-          norm_num
+              hsign]
+          exact rpow_sub_one_mul_self (abs_nonneg _) hq_pos'.ne'
         simp_rw [hpw2]
         have hpw3 : ∀ a, |g_k a| ^ q.toReal =
             ((‖g_k a‖₊ : ℝ≥0∞) ^ q.toReal).toReal := fun a => by

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -129,20 +129,23 @@ noncomputable def integrationCLM_sf (p q : ℝ≥0∞) (hp : 1 ≤ p) (hptop : p
       map_add' := fun f₁ f₂ => by
         have h1 := integrable_mul_sf p q hpq hp hptop (Lp.memLp f₁) hg
         have h2 := integrable_mul_sf p q hpq hp hptop (Lp.memLp f₂) hg
-        simp only [Lp.coeFn_add, Pi.add_apply, add_mul]
-        exact integral_add h1 h2
+        rw [← integral_add h1 h2]
+        refine integral_congr_ae ?_
+        filter_upwards [Lp.coeFn_add f₁ f₂] with a ha
+        rw [ha]; simp [Pi.add_apply, add_mul]
       map_smul' := fun c f => by
-        simp only [Lp.coeFn_smul, Pi.smul_apply, smul_eq_mul, RingHom.id_apply]
-        rw [show (fun a => c * (f : α → ℝ) a * g a) = (fun a => c * ((f : α → ℝ) a * g a))
-            from by ext a; ring]
-        exact integral_const_mul c _ }
+        simp only [RingHom.id_apply, smul_eq_mul]
+        rw [← integral_const_mul c fun a => (f : α → ℝ) a * g a]
+        refine integral_congr_ae ?_
+        filter_upwards [Lp.coeFn_smul c f] with a ha
+        rw [ha]; simp [Pi.smul_apply, smul_eq_mul, mul_assoc] }
     (eLpNorm g q μ).toReal
     (fun f => by
       have hint := integrable_mul_sf p q hpq hp hptop (Lp.memLp f) hg
       calc ‖∫ a, (f : α → ℝ) a * g a ∂μ‖
           ≤ ∫ a, ‖(f : α → ℝ) a * g a‖ ∂μ := norm_integral_le_integral_norm _
         _ ≤ (eLpNorm (f : α → ℝ) p μ * eLpNorm g q μ).toReal := by
-            rw [← integral_norm_eq_lintegral_enorm hint.aestronglyMeasurable]
+            rw [integral_norm_eq_lintegral_enorm hint.aestronglyMeasurable]
             apply ENNReal.toReal_mono
             · exact ENNReal.mul_ne_top (Lp.memLp f).eLpNorm_lt_top.ne hg.eLpNorm_lt_top.ne
             · exact lintegral_mul_le_sf p q hpq hp hptop (Lp.memLp f) hg
@@ -746,7 +749,7 @@ theorem localization_existence
     have hcoe : ((memLp_indicator_const p hE 1 (Or.inr hfin_n)).toLp _ : α → ℝ) =ᵐ[μ.restrict (spanningSets μ n)]
         E.indicator 1 :=
       (memLp_indicator_const p hE 1 (Or.inr hfin_n)).coeFn_toLp
-    rw [integral_congr_ae (EventuallyEq.mul_right hcoe _)]
+    rw [integral_congr_ae (EventuallyEq.mul_right hcoe)]
     simp_rw [Set.indicator_apply, Pi.one_apply, ite_mul, one_mul, zero_mul]
     rw [integral_indicator hE, Measure.restrict_restrict hE,
       Set.inter_comm, Set.inter_eq_left.mpr hEn]
@@ -863,7 +866,7 @@ theorem localization_existence
     -- Step 3: eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖
     have hg_norm : eLpNorm g q μ ≤ ENNReal.ofReal ‖φ‖ := by
       rw [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop]
-      apply ENNReal.rpow_le_rpow _ (by positivity)
+      simp only [enorm_eq_nnnorm]
       -- MCT: ∫⁻ ‖g‖^q dμ = ⨆_n ∫⁻_{Sₙ} ‖g‖^q dμ ≤ ⨆_n ‖φ‖^q = ‖φ‖^q
       have hbound_n : ∀ n,
           ∫⁻ a in spanningSets μ n, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ ≤
@@ -900,8 +903,13 @@ theorem localization_existence
             lintegral_iSup_ae hmeas_fn hmono]
         congr 1; ext n
         exact (lintegral_indicator (measurableSet_spanningSets μ n) _).symm
-      rw [hMCT_global]
-      exact iSup_le hbound_n
+      have hle : ∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ ≤ (ENNReal.ofReal ‖φ‖) ^ q.toReal := by
+        rw [hMCT_global]; exact iSup_le hbound_n
+      calc (∫⁻ a, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ) ^ (1 / q.toReal)
+          ≤ ((ENNReal.ofReal ‖φ‖) ^ q.toReal) ^ (1 / q.toReal) :=
+            ENNReal.rpow_le_rpow hle (by positivity)
+        _ = ENNReal.ofReal ‖φ‖ := by
+            rw [← ENNReal.rpow_mul, mul_one_div_cancel hq_pos.ne', ENNReal.rpow_one]
     exact ⟨⟨hg_asm, (lt_of_le_of_lt hg_norm ENNReal.ofReal_lt_top).ne⟩, hg_norm⟩
   obtain ⟨hg_lq, hg_norm⟩ := hg_lq_norm
   -- ── Step A5: Indicator agreement for all E ───────────────────────────────────
@@ -931,13 +939,13 @@ theorem localization_existence
           Set.inter_subset_right (hfin_n n)]
     -- ∫_{E∩Sₙ} g_seq n = ∫_{E∩Sₙ} g  by hg_eq_n restricted to E ∩ Sₙ ⊆ Sₙ
     exact integral_congr_ae ((hg_eq_n n).filter_mono
-      (Measure.ae_mono (Measure.restrict_mono Set.inter_subset_right le_rfl))).symm
+      (ae_mono (Measure.restrict_mono Set.inter_subset_right le_rfl))).symm
   -- ── Step 2: ∫_{E∩Sₙ} g dμ → ∫_E g dμ  (monotone spanning-set convergence) ────
   have hUnion_E : (⋃ n, E ∩ spanningSets μ n) = E := by
     rw [← Set.inter_iUnion, iUnion_spanningSets, Set.inter_univ]
   have hg_int_E : Integrable g (μ.restrict (⋃ n, E ∩ spanningSets μ n)) := by
     rw [hUnion_E]
-    exact (hg_lq.mono_measure (Measure.restrict_mono Set.subset_univ le_rfl)).integrable hq_ge1
+    exact (hg_lq.mono_measure (Measure.restrict_mono (Set.subset_univ _) le_rfl)).integrable hq_ge1
   have htend_int : Tendsto (fun n => ∫ a in E ∩ spanningSets μ n, g a ∂μ)
       atTop (nhds (∫ a in E, g a ∂μ)) := by
     have h := tendsto_setIntegral_of_monotone
@@ -961,8 +969,8 @@ theorem localization_existence
     rw [Metric.tendsto_atTop]
     intro ε hε
     -- Convert eLpNorm convergence to toReal convergence
-    have hlim : Tendsto (fun n => (eLpNorm (fun a => (hind : α → ℝ) a -
-        (hind : α → ℝ) a * (spanningSets μ n).indicator (1 : α → ℝ) a) p μ).toReal)
+    have hlim : Tendsto (fun n => (eLpNorm (fun a => (E.indicator (1 : α → ℝ)) a -
+        (E.indicator (1 : α → ℝ)) a * (spanningSets μ n).indicator (1 : α → ℝ) a) p μ).toReal)
         atTop (nhds 0) := by
       have h := (ENNReal.continuousAt_toReal (by norm_num : (0 : ℝ≥0∞) ≠ ⊤)).tendsto
       have h2 := lp_truncation_tendsto_zero p (le_of_lt hp1) hptop hind
@@ -975,7 +983,7 @@ theorem localization_existence
     -- Compute dist (h_n n) (hind.toLp _) = (eLpNorm (1_E - 1_E * 1_{Sₙ}) p μ).toReal
     have hdist : dist ((memLp_indicator_const p (hE.inter (measurableSet_spanningSets μ n)) 1
         (Or.inr (hfin_n n))).toLp _) (hind.toLp _) =
-        (eLpNorm (fun a => (hind : α → ℝ) a - (hind : α → ℝ) a *
+        (eLpNorm (fun a => (E.indicator (1 : α → ℝ)) a - (E.indicator (1 : α → ℝ)) a *
             (spanningSets μ n).indicator (1 : α → ℝ) a) p μ).toReal := by
       rw [dist_comm, dist_eq_norm, Lp.norm_def]
       apply congr_arg ENNReal.toReal

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -153,6 +153,54 @@ removes the only open *mathematical* question that was gating the elimination pl
 
 ## Session log
 
+### 2026-07-04 (Session 21, researcher-8) — S18 drift batch applied to Incomplete01; VERIFICATION HARD-BLOCKED by host memory exhaustion (dependency OQ02OQ01 SIGBUS 3/3)
+
+**Mode:** REVISIT (continues cc82b246 on branch `feature/researcher-8-lp`). **Outcome:**
+source-verified forward progress banked; build-verification impossible this session.
+
+**1. Applied the long-staged `s18-batch3-drift-fixes.patch` to Incomplete01 (commit
+ef1ba5e8358, branch `feature/researcher-8-lp-cont`).** The patch predates S19's
+`gseq_norm_bound` split, so `git apply --3way` conflicts only in the split region
+(lines 384–468) and must NOT be blindly merged there (it would revert the split).
+Reverted the 3-way merge and applied the 8 fix-clusters **surgically by content**, all
+OUTSIDE the split, on top of cc82b246's hpw2 fix:
+  - `integrationCLM_sf.map_add'/map_smul'`: `Lp.coeFn_add/coeFn_smul` are `=ᵐ` lemmas
+    now → `rw [← integral_add h1 h2]; refine integral_congr_ae ?_; filter_upwards
+    [Lp.coeFn_add f₁ f₂] with a ha; rw [ha]; simp [...]` (resp. `integral_const_mul`).
+  - `integrationCLM_sf` norm bound: drop the `←` on `integral_norm_eq_lintegral_enorm`
+    (lemma now rewrites the forward `∫‖·‖` direction).
+  - `hagree_n`: `EventuallyEq.mul_right hcoe _` → drop trailing `_` (`f₃` implicit now).
+  - `hg_norm` (Step 3): `apply ENNReal.rpow_le_rpow _ (by positivity)` set the wrong goal
+    shape → replace with `simp only [enorm_eq_nnnorm]` (align enorm→nnnorm to
+    hbound_n/hMCT_global) and swap the tail `rw [hMCT_global]; exact iSup_le hbound_n`
+    for a `have hle … ; calc (∫⁻…)^(1/q) ≤ ((ofReal‖φ‖)^q)^(1/q) = ofReal‖φ‖`.
+  - `Measure.ae_mono` → root `ae_mono`; `Set.subset_univ le_rfl` → `Set.subset_univ _`.
+  - `hind` function-coercion: `(hind : α → ℝ) a` (coercing a `MemLp` Prop!) → the
+    underlying `(E.indicator (1 : α → ℝ)) a`, matching `lp_truncation_tendsto_zero hind`.
+
+**2. ⚠️ NEW HARD BLOCKER — dependency `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`
+SIGBUSes reproducibly (exit code 135) during NATIVE CODEGEN, 3/3 builds.** Every build
+crashed at `✖ [7743/7744] Building …OQ02OQ01 (~2s)` in the `-c …c` C-emission stage,
+**before elaboration ever reaches Incomplete01** — so NO change to Incomplete01 (mine or
+anyone's) can be build-measured until this clears. Root cause diagnosed: **host memory is
+exhausted** — `sysctl vm.swapusage` showed swap **81.3 GB used / 82.9 GB total (99% full),
+~270 MB RAM free**, compressor holding ~42 GB. Under this thrashing a 32 GB-limit Lean
+container's codegen hits mmap/alloc failures → SIGBUS. This is **environmental, not a code
+defect and not the OQ02OQ01 file** (S17–S19 built this exact dependency fine to measure
+55–79 error counts). It is the many concurrent autonomous agents/builds saturating host
+memory. **Retrying is futile until host memory pressure is relieved** (fewer concurrent
+builds, or a machine reboot / `docker system prune` + idle). This supersedes S20's
+"disk-blocked" note — the current wall is RAM/swap, not disk (disk had ~30 GB free).
+
+**Status unchanged (blocked).** Axiom `riesz_lp_surjective` untouched; `axiomCount`
+unchanged. The drift repair is now cc82b246 + this batch ahead of S19; the residual error
+clusters remain the S19-listed set (gseq rpow-chain remainder at ~503/535/556/593/615/
+620–629; `integral_representation_sf` `Lp.induction` block; `lp_truncation` DCT
+measurability; `extByZeroCLM` map_add'/map_smul'; `hextZ_le`). **Next session: (a) confirm
+host memory has recovered (`sysctl vm.swapusage` free ≫ few GB) BEFORE spending a build
+cycle; (b) then one Docker build should finally reach Incomplete01 and expose the true
+post-batch error count.**
+
 ### 2026-06-30 (Session 15, researcher-8) — ACT (dual-norm layer completed)
 
 **Mode:** REVISIT (rolling PR #31646). **Outcome:** progress — 0-axiom.


### PR DESCRIPTION
## Summary

Continues the multi-session repair of the σ-finite Riesz-Lp chain
(`CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`) toward eliminating
`axiom riesz_lp_surjective`. Banks two previously-unshipped increments:

1. **cc82b246** (prior session) — `rpow_sub_one_mul_self` helper fixing the `hpw2`
   Hölder-extremizer rpow drift (`Real.rpow_add` now needs `0 < x`; the base `|g_k a|`
   can be 0, so route through `Real.rpow_add'`).
2. **ef1ba5e** (this session) — the long-staged `s18-batch3-drift-fixes`, applied
   surgically by content (the patch predates S19's `gseq_norm_bound` split, so it does
   **not** `git apply` cleanly in that region). Eight Mathlib-API-drift clusters, all
   outside the split: `integrationCLM_sf` map_add'/map_smul' (`=ᵐ` coeFn restructure),
   the `integral_norm_eq_lintegral_enorm` direction, `EventuallyEq.mul_right` implicit
   arg, the `hg_norm` `rpow_le_rpow`→`simp only [enorm_eq_nnnorm]`+calc fix,
   `Measure.ae_mono`→`ae_mono`, `Set.subset_univ _`, and the `hind` MemLp→function
   coercion (`E.indicator (1:α→ℝ)`).

## Verification status — build-BLOCKED (honest)

**Source-verified against the in-worktree v4.26 Mathlib source; NOT build-verified.**
Three Docker builds this session all SIGBUSed (exit 135) during **native codegen of the
dependency `…OQ02OQ01.lean`** (`✖ [7743/7744] … (~2s)`), **before elaboration reaches
Incomplete01**. Root cause: **host memory exhaustion** — `vm.swapusage` showed swap
**99% full (81.3/82.9 GB), ~270 MB RAM free**. This is environmental (concurrent
autonomous builds thrashing the host), not a code defect: S17–S19 built this same
dependency fine. Retrying is futile until host memory recovers.

The axiom is **untouched** and `axiomCount` is **unchanged** — this is intermediate
drift-repair, no status/gallery change. Merge banks the fixes so the next session (once
host memory recovers) can build straight through to the true post-batch error count.

## Test plan

- [ ] (blocked) `./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01` once `sysctl vm.swapusage` shows several GB free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)