### PR TITLE
Research: erdos-1017-oq-04 — VERIFIED strict gap cc(G) < cp(G) (counting identity + book graph K4-e)

### DIFF
--- a/proofs/Proofs/Erdos1017OQ04.lean
+++ b/proofs/Proofs/Erdos1017OQ04.lean
@@ -51,12 +51,26 @@ makes the cover/partition distinction explicit and pins down the inequality
 relating the two, which is the well-defined mathematical content behind OQ-04's
 "covering vs partition" gap.
 
+## The Strict Gap (Part VII-VIII, 0 axioms, 0 sorries)
+- `partition_card_choose_two_sum` : the **counting identity**
+  `sum_{C in P} (C.card choose 2) = (edgeCliques G).card = |E(G)|` for every edge
+  clique partition `P`. This is the quantitative keystone of every partition-number
+  lower bound.
+- `bookGraph` : the book graph `B2 = K_4 - e` on `Fin 4` (delete the edge `{2,3}`).
+- `coverNum_bookGraph_le_two` : `cc(B2) <= 2` via the two-triangle cover.
+- `partitionNum_bookGraph_ge_three` : `cp(B2) >= 3` via the counting identity
+  (each clique has `<= 3` vertices, so each term is in `{0,1,3}`, and two such
+  terms cannot sum to `5`).
+- `coverNum_lt_partitionNum_bookGraph` : **`cc(B2) < cp(B2)`**, a fully verified
+  strict gap. This answers OQ-04 in the negative: a minimum clique cover cannot in
+  general be converted into an equally small partition.
+
 ## Honest Scope
-This establishes the always-true direction `cc <= cp` rigorously and with zero
-axioms. It does **not** prove the gap can be strict (that requires a lower-bound
-argument on a concrete graph -- see the `nextSteps` in the knowledge file). The
-strict gap is what shows OQ-04's strengthening genuinely fails; the book graph
-`K_4` minus an edge is the intended witness (`cc = 2 < 3 = cp`).
+Everything here is machine-checked with zero axioms and zero sorries. The result
+`cc(B2) < cp(B2)` is an exact strict gap on a concrete graph, not merely the
+always-true inequality `cc <= cp`. What remains open in the broader OQ-04 program
+is the *quantitative* question of how large the gap `cp(G) - cc(G)` can be as a
+function of `|V|` or `|E|`; the book graph only exhibits gap `>= 1`.
 -/
 
 set_option maxHeartbeats 400000
@@ -299,7 +313,218 @@ theorem partitionNum_pos_of_edge {v w : V} (h : G.Adj v w) : 0 < partitionNum G 
 
 /-
 ====================================================================
-PART VII: VERIFICATION
+PART VII: THE COUNTING IDENTITY  sum_{C in P} C(|C|,2) = |E(G)|
+
+This is the quantitative keystone of every clique-partition lower bound.
+In an edge clique *partition* each edge lies in exactly one clique, and inside
+a clique `C` every one of its `C(|C|,2)` vertex-pairs is an edge.  Summing the
+internal edge-counts over the partition therefore counts each edge of `G`
+exactly once:
+
+    sum_{C in P.cliques} (C.card choose 2) = (edgeCliques G).card = |E(G)|.
+
+Here `edgeCliques G` is the set of two-element cliques of `G`, i.e. its edges
+represented as two-element vertex sets -- so `(edgeCliques G).card` is the
+number of edges of `G`.  The whole identity is developed at this level, avoiding
+`Sym2` entirely: the internal edges of a clique `C` are exactly the members of
+`C.powersetCard 2`, and the partition property makes the union over cliques a
+*disjoint* union covering `edgeCliques G`.
+==================================================================== -/
+
+/-- Two mutually-adjacent (distinct) vertices of a clique are adjacent in `G`.
+    A convenience unfolding of `IsClique` (which is `Set.Pairwise G.Adj`). -/
+theorem adj_of_mem_clique {C : Finset V} (hC : G.IsClique (↑C : Set V))
+    {v w : V} (hv : v ∈ C) (hw : w ∈ C) (hvw : v ≠ w) : G.Adj v w :=
+  hC (Finset.mem_coe.mpr hv) (Finset.mem_coe.mpr hw) hvw
+
+/-- **Every two-element subset of a clique is an edge.**  If `C` is a clique of
+    `G`, each of its `C(|C|,2)` two-element subsets is itself a two-element clique,
+    hence a member of `edgeCliques G`. -/
+theorem powersetCard_two_subset_edgeCliques {C : Finset V}
+    (hC : G.IsClique (↑C : Set V)) : C.powersetCard 2 ⊆ edgeCliques G := by
+  intro S hS
+  rw [Finset.mem_powersetCard] at hS
+  obtain ⟨hSsub, hScard⟩ := hS
+  rw [mem_edgeCliques]
+  exact ⟨hScard, hC.subset (Finset.coe_subset.mpr hSsub)⟩
+
+/-- **The partition cliques carve `edgeCliques G` into disjoint two-subset blocks.**
+    Every edge (two-element clique) of `G` is a two-element subset of exactly one
+    partition clique, so `edgeCliques G` is the (disjoint) union over `P.cliques`
+    of the two-element subsets of each clique. -/
+theorem edgeCliques_eq_biUnion (P : EdgeCliquePartition G) :
+    edgeCliques G = P.cliques.biUnion (fun C => C.powersetCard 2) := by
+  ext S
+  simp only [Finset.mem_biUnion]
+  constructor
+  · intro hS
+    rw [mem_edgeCliques] at hS
+    obtain ⟨hScard, hSclique⟩ := hS
+    obtain ⟨v, w, hvw, rfl⟩ := Finset.card_eq_two.mp hScard
+    have hadj : G.Adj v w :=
+      adj_of_mem_clique hSclique (Finset.mem_insert_self v {w})
+        (Finset.mem_insert_of_mem (Finset.mem_singleton_self w)) hvw
+    obtain ⟨C, ⟨hCmem, hvC, hwC⟩, _⟩ := P.partitions hadj
+    refine ⟨C, hCmem, ?_⟩
+    rw [Finset.mem_powersetCard]
+    refine ⟨?_, hScard⟩
+    intro x hx
+    rcases Finset.mem_insert.mp hx with rfl | hx
+    · exact hvC
+    · rw [Finset.mem_singleton] at hx; rw [hx]; exact hwC
+  · rintro ⟨C, hCmem, hSC⟩
+    exact powersetCard_two_subset_edgeCliques (P.isClique C hCmem) hSC
+
+/-- **The two-subset blocks of distinct partition cliques are disjoint.**  If a
+    two-element set `{v, w}` lies in two partition cliques `C` and `D`, then the
+    edge `{v, w}` is common to both, so `edge_unique_clique` forces `C = D`.  This
+    is where the partition (as opposed to cover) hypothesis is used. -/
+theorem powersetCard_two_pairwiseDisjoint (P : EdgeCliquePartition G) :
+    (P.cliques : Set (Finset V)).PairwiseDisjoint (fun C => C.powersetCard 2) := by
+  intro C hC D hD hCD
+  simp only [Finset.mem_coe] at hC hD
+  show Disjoint (C.powersetCard 2) (D.powersetCard 2)
+  rw [Finset.disjoint_left]
+  intro S hSC hSD
+  rw [Finset.mem_powersetCard] at hSC hSD
+  obtain ⟨hSsubC, hScard⟩ := hSC
+  obtain ⟨hSsubD, _⟩ := hSD
+  obtain ⟨v, w, hvw, rfl⟩ := Finset.card_eq_two.mp hScard
+  have hvC : v ∈ C := hSsubC (Finset.mem_insert_self v {w})
+  have hwC : w ∈ C := hSsubC (Finset.mem_insert_of_mem (Finset.mem_singleton_self w))
+  have hvD : v ∈ D := hSsubD (Finset.mem_insert_self v {w})
+  have hwD : w ∈ D := hSsubD (Finset.mem_insert_of_mem (Finset.mem_singleton_self w))
+  have hadj : G.Adj v w := adj_of_mem_clique (P.isClique C hC) hvC hwC hvw
+  exact hCD (P.edge_unique_clique hadj hC hvC hwC hD hvD hwD)
+
+/-- **The clique-partition counting identity.**  For any edge clique partition `P`
+    of `G`,
+
+        sum_{C in P.cliques} (C.card choose 2) = (edgeCliques G).card = |E(G)|.
+
+    Each clique `C` contributes its `C(|C|,2)` internal edges, and the partition
+    property guarantees these blocks are disjoint and exhaust every edge.  This
+    turns clique-partition lower bounds into arithmetic: any bound on the possible
+    clique sizes bounds the number of cliques needed to reach `|E(G)|`. -/
+theorem partition_card_choose_two_sum (P : EdgeCliquePartition G) :
+    ∑ C ∈ P.cliques, C.card.choose 2 = (edgeCliques G).card := by
+  rw [edgeCliques_eq_biUnion P,
+      Finset.card_biUnion (powersetCard_two_pairwiseDisjoint P)]
+  exact Finset.sum_congr rfl (fun C _ => (Finset.card_powersetCard 2 C).symm)
+
+/-
+====================================================================
+PART VIII: A VERIFIED STRICT GAP  cc(G) < cp(G)  (BOOK GRAPH K4 - e)
+
+The always-true direction `cc(G) <= cp(G)` (Part IV) can be *strict*: this
+answers OQ-04 in the negative -- a minimum cover cannot in general be converted
+into an equally small partition.  The witness is the **book graph**
+`B2 = K4 - e`, the complete graph on `{0,1,2,3}` with the single edge `{2,3}`
+removed.  It has `5` edges and its two triangles `{0,1,2}`, `{0,1,3}` overlap on
+the edge `{0,1}`:
+
+* `cc(B2) <= 2`: the two triangles cover all `5` edges (`bookCover`).
+* `cp(B2) >= 3`: a partition cannot use both triangles (they share `{0,1}`), and
+  by the counting identity its cliques' sizes must satisfy
+  `sum (C(|C|,2)) = 5`.  Every clique has `<= 3` vertices (no `K4`, since `2,3`
+  are non-adjacent), so each term is in `{0,1,3}`; two such terms never sum to
+  `5`, forcing at least `3` cliques.
+
+Hence `cc(B2) <= 2 < 3 <= cp(B2)`, a *verified* strict gap.
+==================================================================== -/
+
+/-- The **book graph** `B2 = K4 - e`: the complete graph on `Fin 4` with the edge
+    `{2, 3}` deleted.  Two vertices are adjacent iff they are distinct and not the
+    removed pair `{2, 3}`. -/
+def bookGraph : SimpleGraph (Fin 4) where
+  Adj a b := a ≠ b ∧ ¬ (a = 2 ∧ b = 3) ∧ ¬ (a = 3 ∧ b = 2)
+  symm := by
+    intro a b h
+    exact ⟨h.1.symm, fun hc => h.2.2 ⟨hc.2, hc.1⟩, fun hc => h.2.1 ⟨hc.2, hc.1⟩⟩
+  loopless := by intro a h; exact h.1 rfl
+
+instance : DecidableRel bookGraph.Adj := fun a b =>
+  inferInstanceAs (Decidable (a ≠ b ∧ ¬ (a = 2 ∧ b = 3) ∧ ¬ (a = 3 ∧ b = 2)))
+
+/-- **The two triangles cover `B2`.**  `{0,1,2}` and `{0,1,3}` are triangles whose
+    union covers all five edges, so they form an edge clique cover of size `2`. -/
+def bookCover : EdgeCliqueCover bookGraph where
+  cliques := {{0, 1, 2}, {0, 1, 3}}
+  isClique := by decide
+  covers := by decide
+
+/-- **`cc(B2) <= 2`.**  The two-triangle cover witnesses that the cover number is
+    at most `2`. -/
+theorem coverNum_bookGraph_le_two : coverNum bookGraph ≤ 2 :=
+  Nat.sInf_le ⟨bookCover, by decide⟩
+
+/-- **No clique of `B2` has more than three vertices.**  A four-vertex clique would
+    be all of `{0,1,2,3}`, forcing `2` and `3` adjacent -- but that edge was
+    deleted.  This caps each term of the counting identity at `C(3,2) = 3`. -/
+theorem bookGraph_clique_card_le_three {C : Finset (Fin 4)}
+    (hC : bookGraph.IsClique (↑C : Set (Fin 4))) : C.card ≤ 3 := by
+  by_contra h
+  push_neg at h
+  have hub : C.card ≤ 4 := by have := Finset.card_le_univ C; simpa using this
+  have h4 : C.card = 4 := by omega
+  have huniv : C = Finset.univ :=
+    Finset.eq_univ_of_card C (by rw [h4, Fintype.card_fin])
+  have h2 : (2 : Fin 4) ∈ C := by rw [huniv]; exact Finset.mem_univ _
+  have h3 : (3 : Fin 4) ∈ C := by rw [huniv]; exact Finset.mem_univ _
+  have hadj : bookGraph.Adj 2 3 := adj_of_mem_clique hC h2 h3 (by decide)
+  exact absurd hadj (by decide)
+
+/-- **Any edge clique partition of `B2` uses at least three cliques.**  By the
+    counting identity `sum (C(|C|,2)) = |E(B2)| = 5`, with each clique of size
+    `<= 3` so each term in `{0,1,3}`.  A finset of at most two such terms cannot
+    sum to `5`, so the partition has at least three cliques. -/
+theorem bookGraph_partition_card_ge_three (P : EdgeCliquePartition bookGraph) :
+    3 ≤ P.cliques.card := by
+  have hsum : ∑ C ∈ P.cliques, C.card.choose 2 = 5 := by
+    rw [partition_card_choose_two_sum P]; decide
+  have hf : ∀ C ∈ P.cliques,
+      C.card.choose 2 = 0 ∨ C.card.choose 2 = 1 ∨ C.card.choose 2 = 3 := by
+    intro C hC
+    have hle : C.card ≤ 3 := bookGraph_clique_card_le_three (P.isClique C hC)
+    have : C.card = 0 ∨ C.card = 1 ∨ C.card = 2 ∨ C.card = 3 := by omega
+    rcases this with h | h | h | h <;> rw [h] <;> decide
+  by_contra hlt
+  push_neg at hlt
+  rcases (show P.cliques.card = 0 ∨ P.cliques.card = 1 ∨ P.cliques.card = 2
+      from by omega) with h | h | h
+  · rw [Finset.card_eq_zero] at h
+    rw [h, Finset.sum_empty] at hsum
+    exact absurd hsum (by decide)
+  · obtain ⟨a, ha⟩ := Finset.card_eq_one.mp h
+    have hmem : a ∈ P.cliques := by rw [ha]; exact Finset.mem_singleton_self a
+    rw [ha, Finset.sum_singleton] at hsum
+    rcases hf a hmem with h1 | h1 | h1 <;> omega
+  · obtain ⟨a, b, hab, hs⟩ := Finset.card_eq_two.mp h
+    have hma : a ∈ P.cliques := by rw [hs]; exact Finset.mem_insert_self a {b}
+    have hmb : b ∈ P.cliques := by
+      rw [hs]; exact Finset.mem_insert_of_mem (Finset.mem_singleton_self b)
+    rw [hs, Finset.sum_pair hab] at hsum
+    rcases hf a hma with h1 | h1 | h1 <;> rcases hf b hmb with h2 | h2 | h2 <;> omega
+
+/-- **`cp(B2) >= 3`.**  Every partition of `B2` uses at least three cliques, so the
+    partition number (the minimum such count) is at least `3`. -/
+theorem partitionNum_bookGraph_ge_three : 3 ≤ partitionNum bookGraph := by
+  obtain ⟨P, hP⟩ := Nat.sInf_mem (partitionNum_set_nonempty bookGraph)
+  rw [show partitionNum bookGraph = P.cliques.card from hP.symm]
+  exact bookGraph_partition_card_ge_three P
+
+/-- **Verified strict gap `cc(B2) < cp(B2)`.**  Combining `cc(B2) <= 2` with
+    `cp(B2) >= 3` gives `cc(B2) <= 2 < 3 <= cp(B2)`.  This is a fully machine-checked
+    (0 axioms, 0 sorries) counterexample to strengthening the cover inequality to a
+    partition equality -- the negative answer to OQ-04. -/
+theorem coverNum_lt_partitionNum_bookGraph :
+    coverNum bookGraph < partitionNum bookGraph :=
+  lt_of_le_of_lt coverNum_bookGraph_le_two
+    (lt_of_lt_of_le (by norm_num) partitionNum_bookGraph_ge_three)
+
+/-
+====================================================================
+PART IX: VERIFICATION
 ==================================================================== -/
 
 #check @EdgeCliqueCover
@@ -314,5 +539,10 @@ PART VII: VERIFICATION
 #check @EdgeCliquePartition.edge_unique_clique
 #check @coverNum_pos_of_edge
 #check @partitionNum_pos_of_edge
+#check @partition_card_choose_two_sum
+#check @bookGraph
+#check @coverNum_bookGraph_le_two
+#check @partitionNum_bookGraph_ge_three
+#check @coverNum_lt_partitionNum_bookGraph
 
 end Erdos1017OQ04

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -86,6 +86,14 @@
       ],
       "outcome": "success",
       "date": "2026-07-04"
+    },
+    {
+      "name": "Double counting (clique-partition edge identity)",
+      "used_in_problems": [
+        "erdos-1017-oq-04"
+      ],
+      "outcome": "success",
+      "date": "2026-07-04"
     }
   ]
 }

--- a/research/problems/erdos-1017-oq-04/knowledge.md
+++ b/research/problems/erdos-1017-oq-04/knowledge.md
@@ -41,3 +41,51 @@ require overlaps.
 ### Next Steps
 - Formalize the counting identity `∑_{C} C(|C|,2) = |E(G)|` for a true partition, then
   instantiate B₂ on `Fin 4` to get a VERIFIED strict gap `cc = 2 < 3 = cp`.
+
+## Session 2026-07-04 (Session 4) — Counting identity + VERIFIED strict gap cc < cp
+
+**Mode**: REVISIT (RICH knowledge, 18 items)
+**Outcome**: COMPLETE — the strict-gap answer to OQ-04 is now machine-checked
+(0 axioms, 0 sorries, 3078 jobs clean). File grew 318 → 548 lines.
+
+### What I Did
+- **Counting identity** `partition_card_choose_two_sum`:
+  `∑_{C ∈ P.cliques} (C.card choose 2) = (edgeCliques G).card = |E(G)|`.
+  Formalized *without* `Sym2`: edges are the two-element cliques `edgeCliques G`, a
+  clique's internal edges are exactly `C.powersetCard 2`, and the partition property
+  makes the union over cliques disjoint + exhaustive.
+  - Supporting: `powersetCard_two_subset_edgeCliques` (2-subset of a clique is an edge),
+    `edgeCliques_eq_biUnion` (edges = ⋃ two-subsets of cliques),
+    `powersetCard_two_pairwiseDisjoint` (distinct cliques' 2-subsets disjoint, via
+    `edge_unique_clique`), `adj_of_mem_clique`.
+  - Assembly: `Finset.card_biUnion` (disjoint) + `Finset.card_powersetCard`.
+- **Book graph** `bookGraph = B₂ = K₄ − e` on `Fin 4` (delete `{2,3}`), with a
+  `DecidableRel` instance.
+- `coverNum_bookGraph_le_two` — `cc(B₂) ≤ 2` via the two-triangle `bookCover`.
+- `bookGraph_clique_card_le_three` — no `K₄` in `B₂` (`2,3` nonadjacent), so each
+  counting-identity term `C(|C|,2) ∈ {0,1,3}`.
+- `partitionNum_bookGraph_ge_three` — `cp(B₂) ≥ 3`: `∑ C(|C|,2) = 5` with each term in
+  `{0,1,3}` and ≤ 2 cliques gives sums in `{0,1,2,3,4,6}`, never 5 → ≥ 3 cliques.
+- **`coverNum_lt_partitionNum_bookGraph`** — `cc(B₂) ≤ 2 < 3 ≤ cp(B₂)`. **VERIFIED
+  strict gap.** OQ-04's strengthening genuinely fails.
+
+### Key Findings
+- The `cp` lower bound is *purely arithmetic* once the counting identity is in place:
+  no casework on which specific cliques a partition uses, only the clique-size cap.
+- Kernel `decide` (not `native_decide`) discharges every concrete `B₂` fact via
+  Mathlib's `Decidable (G.IsClique s)` Finset instance — the file stays axiom-free
+  (no `Lean.ofReduceBool`). One transient SIGBUS (exit 135) in the native codegen
+  step; a plain rebuild succeeded (known flaky-clang issue).
+- Started this session from a stale worktree (branch was reset to the 241-line
+  cc≤cp version); rebuilt on `origin/main` which already had the 318-line Part VI.
+
+### Files Modified
+- `proofs/Proofs/Erdos1017OQ04.lean` (318 → 548 lines; Parts VII–IX added)
+- `src/data/research/problems/erdos-1017-oq-04.json` (knowledge)
+
+### Next Steps (remaining open sub-question)
+- **Quantitative gap**: how large can `cp(G) − cc(G)` (or the ratio) be vs `|V|`/`|E|`?
+  B₂ only gives gap ≥ 1. Try the `k`-page book graph (k triangles sharing one edge) or
+  `K_n` minus a matching for growing gaps.
+- Optional: `(edgeCliques G).card = G.edgeFinset.card` bridge so the identity reads
+  literally as `|E(G)|`.

--- a/research/problems/erdos-1017-oq-04/state.md
+++ b/research/problems/erdos-1017-oq-04/state.md
@@ -1,7 +1,7 @@
 # Current State
 
-**Phase**: ACT
-**Since**: 2026-07-04T13:10:19-07:00
+**Phase**: COMPLETED
+**Since**: 2026-07-04T15:20:24-07:00
 **Iteration**: 1
 
 ## Current Focus

--- a/research/registry.json
+++ b/research/registry.json
@@ -35246,11 +35246,11 @@
     },
     {
       "slug": "erdos-1017-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-07-03T08:42:59.947Z",
       "status": "active",
-      "lastUpdate": "2026-07-04T20:21:06.902Z"
+      "lastUpdate": "2026-07-04T15:20:24-07:00"
     },
     {
       "slug": "erdos-1018-oq-03",

--- a/src/data/research/problems/erdos-1017-oq-04.json
+++ b/src/data/research/problems/erdos-1017-oq-04.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: cc(G)<=cp(G) verified (Part IV). Added the strict-gap lower-bound keystones (Part VI): edge_unique_clique (partition edge-disjointness) + positivity lower bounds coverNum/partitionNum >=1 given an edge. Build clean (3078 jobs), 0 sorries/0 axioms. NEXT rung unchanged: the counting identity sum_C C(|C|,2)=|E| and the concrete book-graph K4-e witness giving cc=2<3=cp.",
+    "progressSummary": "COMPLETE (strict gap answered): VERIFIED cc(B2)<cp(B2) on book graph K4-e via the clique-partition counting identity sum C(|C|,2)=|E|. 0 axioms, 0 sorries, 3078 jobs clean. OQ-04 strengthening genuinely FAILS. Remaining open: quantitative size of the gap.",
     "builtItems": [
       "EdgeCliqueCover / EdgeCliquePartition structures (Erdos1017OQ04.lean) — cover vs exactly-once partition",
       "EdgeCliquePartition.toCover : every partition is a cover (Erdos1017OQ04.lean)",
@@ -39,7 +39,15 @@
       "coverNum_le_partitionNum : cc(G) <= cp(G), VERIFIED 0 axioms 0 sorries (Erdos1017OQ04.lean)",
       "partitionNum_le_edgeCliquesCard / coverNum_le_edgeCliquesCard upper bounds",
       "EdgeCliquePartition.edge_unique_clique in Proofs/Erdos1017OQ04.lean (edge-disjointness keystone)",
-      "coverNum_pos_of_edge, partitionNum_pos_of_edge in Proofs/Erdos1017OQ04.lean (positivity lower bounds)"
+      "coverNum_pos_of_edge, partitionNum_pos_of_edge in Proofs/Erdos1017OQ04.lean (positivity lower bounds)",
+      "partition_card_choose_two_sum : sum_{C} (C.card choose 2) = (edgeCliques G).card (Erdos1017OQ04.lean, counting identity, 0 axioms)",
+      "edgeCliques_eq_biUnion + powersetCard_two_pairwiseDisjoint + powersetCard_two_subset_edgeCliques : the disjoint-biUnion decomposition underlying the identity",
+      "adj_of_mem_clique : adjacency of two distinct clique members (IsClique unfolding helper)",
+      "bookGraph : B2=K4-e on Fin 4 with DecidableRel instance (Erdos1017OQ04.lean)",
+      "bookCover + coverNum_bookGraph_le_two : cc(B2)<=2 via two-triangle cover",
+      "bookGraph_clique_card_le_three : no K4 in B2 (caps counting-identity terms at 3)",
+      "bookGraph_partition_card_ge_three + partitionNum_bookGraph_ge_three : cp(B2)>=3",
+      "coverNum_lt_partitionNum_bookGraph : VERIFIED strict gap cc(B2)<cp(B2), 0 axioms 0 sorries"
     ],
     "insights": [
       "The companion file Erdos1017OQ01.lean names its structure EdgeCliquePartition but its only constraint is the covers field (every edge in SOME clique) with no disjointness — so its cliquePartitionNum is really the clique COVER number cc(G), not the partition number cp(G). This conflation is exactly the cover-vs-partition ambiguity OQ-04 is about.",
@@ -47,16 +55,20 @@
       "Formalizing a genuine partition via ExistsUnique (each edge lies in exactly one clique) cleanly separates it from a cover (ExistsUnique weakens to Exists), making toCover a one-line structure map.",
       "The intended strict-gap witness is the book graph B2 = K4 minus an edge: its two triangles {0,1,2},{0,1,3} overlap on edge {0,1} and cover all 5 edges (cc=2), but a partition cannot use both triangles, forcing cp=3. This shows OQ-04 strengthening genuinely fails.",
       "edge_unique_clique: in an EdgeCliquePartition an edge lies in a UNIQUE clique, so two partition cliques sharing an edge coincide. This edge-disjointness is exactly what a cover lacks and the structural reason cp(G) can exceed cc(G); it is the hypothesis every partition-number lower bound (incl. the counting identity sum_C C(|C|,2)=|E|) is built on.",
-      "coverNum_pos_of_edge / partitionNum_pos_of_edge: both numbers are >=1 once G has an edge (empty cover/partition cannot cover an edge) -- base case of the lower-bound ladder."
+      "coverNum_pos_of_edge / partitionNum_pos_of_edge: both numbers are >=1 once G has an edge (empty cover/partition cannot cover an edge) -- base case of the lower-bound ladder.",
+      "COUNTING IDENTITY proven (0 axioms): for any EdgeCliquePartition P, sum_{C in P.cliques} (C.card choose 2) = (edgeCliques G).card = |E(G)|. Formalized WITHOUT Sym2 by identifying edges with two-element cliques (edgeCliques G) and internal clique edges with C.powersetCard 2; the partition property makes the union over cliques disjoint (Finset.card_biUnion) and exhaustive.",
+      "STRICT GAP cc<cp is now VERIFIED (0 axioms, 0 sorries) on the book graph B2=K4-e (Fin 4, delete edge {2,3}): coverNum_lt_partitionNum_bookGraph gives cc(B2)<=2<3<=cp(B2). This answers OQ-04 NEGATIVELY — a min cover need not convert to an equal-size partition.",
+      "cp(B2)>=3 falls out of the counting identity purely arithmetically: cliques have <=3 vertices (no K4 since 2,3 nonadjacent), so each term C(|C|,2) in {0,1,3}; two such terms cannot sum to 5, forcing >=3 cliques. No graph-specific casework on which cliques appear.",
+      "decide (kernel, not native_decide) discharges all concrete B2 facts (isClique of the two triangles, covers, edgeCliques card =5, Adj 2 3 false) via the Mathlib Decidable (G.IsClique s) instance for Finsets — keeps the file axiom-free (no Lean.ofReduceBool)."
     ],
     "mathlibGaps": [
       "No off-the-shelf Mathlib notion of edge clique cover/partition number; built locally (~230 lines).",
       "Exact clique-partition lower bounds (e.g. cp(book graph)=3) need a double-counting identity sum over cliques of C(|C|,2) = |E|, not yet formalized."
     ],
     "nextSteps": [
-      "Formalize the counting identity: for a true EdgeCliquePartition, sum over cliques of (card choose 2) equals edgeFinset.card (each edge counted once). This gives verifiable clique-partition lower bounds.",
-      "Instantiate the book graph B2 = K4 minus an edge on Fin 4; prove cc=2 (two overlapping triangles) and cp>=3 via the counting identity, giving a VERIFIED strict gap cc<cp that answers OQ-04 negatively.",
-      "State the general principle: a min cover converts to an equal-size partition iff some min cover is edge-disjoint; overlaps are the obstruction."
+      "Quantitative gap: how large can cp(G)-cc(G) or cp(G)/cc(G) be as a function of |V| or |E|? Book graph only gives gap >=1. Consider the book graph B_k (k triangles sharing a common edge) or K_n minus a matching for growing gaps.",
+      "Optional interpretability bridge: prove (edgeCliques G).card = G.edgeFinset.card (Sym2 bijection) so the counting identity reads literally as |E(G)|; currently everything is phrased via edgeCliques (edges as 2-element cliques).",
+      "Relate to Lovasz: state the general principle a min cover converts to an equal-size partition iff some min cover is edge-disjoint; the overlap on {0,1} is the concrete obstruction in B2."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Answers **Erdős #1017 OQ-04 negatively**: a minimum edge clique **cover** cannot in general be converted into an equally small edge clique **partition**. The always-true direction is `cc(G) ≤ cp(G)` (already in the file); this PR proves the inequality can be **strict**, with a fully machine-checked witness.

## What's new (Parts VII–IX, 0 axioms, 0 sorries)

**The counting identity** — `partition_card_choose_two_sum`:
```
∑_{C ∈ P.cliques} (C.card choose 2) = (edgeCliques G).card = |E(G)|
```
for every `EdgeCliquePartition P`. Formalized **without `Sym2`**: edges are the two-element cliques `edgeCliques G`, a clique's internal edges are exactly `C.powersetCard 2`, and the partition property (`edge_unique_clique`) makes the union over cliques disjoint and exhaustive (`Finset.card_biUnion` + `Finset.card_powersetCard`).

**The book graph** `bookGraph = B₂ = K₄ − e` on `Fin 4` (delete `{2,3}`):
- `coverNum_bookGraph_le_two` — `cc(B₂) ≤ 2` via the two overlapping triangles `{0,1,2}`, `{0,1,3}`.
- `bookGraph_clique_card_le_three` — no `K₄` in `B₂` (since `2,3` non-adjacent), so each counting-identity term `C(|C|,2) ∈ {0,1,3}`.
- `partitionNum_bookGraph_ge_three` — `cp(B₂) ≥ 3`: `∑ C(|C|,2) = 5`, and two terms from `{0,1,3}` sum to `{0,1,2,3,4,6}`, never `5`, so ≥ 3 cliques are needed.
- **`coverNum_lt_partitionNum_bookGraph`** — `cc(B₂) ≤ 2 < 3 ≤ cp(B₂)`. The verified strict gap.

## Verification
- Build clean under Docker: **3078 jobs**, 0 sorries.
- Kernel `decide` only (no `native_decide`) → depends only on the standard foundational axioms; **no `Lean.ofReduceBool`**. Genuinely `verified` / 0 axioms.
- File `proofs/Proofs/Erdos1017OQ04.lean`: 318 → 548 lines.

## Remaining open
The *quantitative* gap (how large `cp(G) − cc(G)` can grow vs `|V|`/`|E|`) — B₂ only exhibits gap ≥ 1. Documented in the knowledge file as the next rung (k-page book graph / `K_n` minus a matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)