### PR TITLE
Research: konigsberg-oq-02-oq-01-oq-02-oq-01 — Hierholzer bridge lemma (boundary edge, 0-axiom)

### DIFF
--- a/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Boundary.lean
+++ b/proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Boundary.lean
@@ -1,0 +1,99 @@
+/-
+# Undirected Hierholzer — Bridge lemma: a partial closed trail has a boundary edge
+
+Companion development file for `KonigsbergOQ02OQ01OQ02OQ01.lean`, whose main theorem
+`undirected_euler_circuit_sufficient` (the undirected Hierholzer sufficiency
+direction) still carries a single `sorry`. The standard proof is strong induction on
+`G.edgeFinset.card`, and its three structural ingredients are already verified:
+
+* **Sub-lemma A** — a maximal trail is closed (`eq_of_isTrail_edgeMaximal`, `Dev`).
+* **Sub-lemma B** — deleting a closed trail's edges preserves all-even-degree (#34714).
+* **Sub-lemma C** — splicing a residual sub-circuit into a closed trail (#34731,
+  `Splice`).
+
+The inductive step needs one more glue fact, supplied here: whenever a closed trail
+`c` fails to be Eulerian (it misses at least one edge of a *connected* `G`), the missing
+edge cannot be "far away" — connectivity forces a **boundary edge**: an edge of `G` that
+is unused by `c` yet incident to a vertex lying on `c.support`. This is exactly the
+vertex `w ∈ c.support` at which the residual Eulerian sub-circuit (obtained from the
+induction hypothesis on `G.deleteEdges c.edges`) is spliced back in via
+`exists_isTrail_splice_of_mem_support`.
+
+The proof is the classical connectivity argument: were *every* edge incident to
+`c.support` already used by `c`, then `c.support` would be closed under adjacency (a used
+edge keeps both its endpoints on the support, `snd_mem_support_of_mem_edges`); being
+nonempty (`u` is on it) and `G` connected, it would then be all of `V`; but then the
+missing edge, having an endpoint in `V = c.support`, would itself be incident to the
+support and hence used — a contradiction.
+
+Depends only on Mathlib's `SimpleGraph.Walk`/connectivity API (0 sorries, 0 new
+axioms); it is kept in its own file to avoid edit conflicts with the parallel `Dev` and
+`Splice` development.
+-/
+import Mathlib.Combinatorics.SimpleGraph.Trails
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+import Mathlib.Tactic
+
+open SimpleGraph SimpleGraph.Walk
+
+namespace UndirectedEulerBoundary
+
+variable {V : Type*} {G : SimpleGraph V}
+
+/-- **Adjacency-closed predicates are walk-closed.**
+If a vertex predicate `P` is closed under taking neighbours (whenever `P w` and
+`G.Adj w x` then `P x`), then it is closed along entire walks: any walk starting at a
+vertex satisfying `P` ends at a vertex satisfying `P`. Structural recursion on the walk.
+
+Stated for an arbitrary predicate `P : V → Prop` (rather than a `Set V`) so it applies
+directly to `fun v => v ∈ c.support`, whose membership is `List` membership. -/
+theorem forall_walk_of_adjClosed {P : V → Prop}
+    (hcl : ∀ ⦃w x : V⦄, P w → G.Adj w x → P x) :
+    ∀ {a b : V}, G.Walk a b → P a → P b
+  | _, _, Walk.nil, ha => ha
+  | _, _, Walk.cons h q, ha => forall_walk_of_adjClosed hcl q (hcl ha h)
+
+/-- **A nonempty adjacency-closed predicate in a connected graph holds everywhere.**
+If `G` is connected, `P` is closed under adjacency, and `P` holds at some vertex `a`,
+then `P` holds at every vertex: each `v` is reachable from `a` by a walk, and walks
+preserve `P` by `forall_walk_of_adjClosed`. -/
+theorem forall_of_adjClosed (hconn : G.Connected) {P : V → Prop}
+    (hcl : ∀ ⦃w x : V⦄, P w → G.Adj w x → P x) {a : V} (ha : P a) :
+    ∀ v, P v := by
+  intro v
+  obtain ⟨p⟩ := hconn.preconnected a v
+  exact forall_walk_of_adjClosed hcl p ha
+
+/-- **Boundary edge for a non-Eulerian closed trail (Hierholzer bridge lemma).**
+Let `G` be connected and let `c : G.Walk u u` be a walk that misses at least one edge of
+`G` (`hmiss`). Then some edge of `G` unused by `c` is incident to a vertex of
+`c.support`: there exist `w ∈ c.support` and a neighbour `x` with `G.Adj w x` and
+`s(w, x) ∉ c.edges`.
+
+This is the vertex at which the residual Eulerian sub-circuit is spliced into `c` in the
+inductive step of the undirected Hierholzer proof. Axiom-free, no `sorry`. -/
+theorem exists_boundary_edge_of_missing
+    (hconn : G.Connected) {u : V} {c : G.Walk u u}
+    (hmiss : ∃ e ∈ G.edgeSet, e ∉ c.edges) :
+    ∃ w x : V, w ∈ c.support ∧ G.Adj w x ∧ s(w, x) ∉ c.edges := by
+  by_contra hcon
+  push_neg at hcon
+  -- `hcon : ∀ w x, w ∈ c.support → G.Adj w x → s(w, x) ∈ c.edges`.
+  -- The support of `c` is then closed under adjacency: a used edge keeps both endpoints
+  -- on the support (`snd_mem_support_of_mem_edges`).
+  have hcl : ∀ ⦃w x : V⦄, w ∈ c.support → G.Adj w x → x ∈ c.support := by
+    intro w x hw hadj
+    exact snd_mem_support_of_mem_edges c (hcon w x hw hadj)
+  -- Hence, `G` being connected and `u ∈ c.support`, the support is all of `V`.
+  have hall : ∀ v, v ∈ c.support :=
+    forall_of_adjClosed hconn hcl c.start_mem_support
+  -- The missing edge has an endpoint in `V = c.support`, so it is incident to the support
+  -- and therefore used — contradicting that it is missing.
+  obtain ⟨e, heG, hec⟩ := hmiss
+  induction e using Sym2.ind with
+  | _ a b =>
+    -- `s(a, b) ∈ G.edgeSet` is definitionally `G.Adj a b` (`mem_edgeSet` is `Iff.rfl`).
+    have hadj : G.Adj a b := heG
+    exact hec (hcon a b (hall a) hadj)
+
+end UndirectedEulerBoundary

--- a/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json
@@ -29,12 +29,13 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Hierholzer sufficiency ingredients A (maximal trail closed), B-parity + B-full deleteEdges (#34714), and C splice (#34731) all VERIFIED 0-axiom. Remaining: the strong-induction assembly (Sub-lemma D) into undirected_euler_circuit_sufficient.",
+    "progressSummary": "PROGRESS: Hierholzer sufficiency ingredients A (maximal trail closed), B-parity + B-full deleteEdges (#34714), C splice (#34731), and now the connectivity BRIDGE (boundary edge) all VERIFIED 0-axiom. exists_boundary_edge_of_missing: a closed trail c that misses an edge of connected G must have an unused edge incident to c.support (the splice attachment vertex). Remaining: wire A+B+C+bridge into the strong-induction assembly (Sub-lemma D) for undirected_euler_circuit_sufficient.",
     "builtItems": [
       "proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01.lean: stated undirected_euler_circuit_sufficient (sufficiency, 1 sorry) and undirected_euler_circuit_iff (full characterization). The iff necessity half is fully PROVED; only sufficiency delegates to the sorry. Builds cleanly (import Connectivity.Connected added; only the expected sorry warning).",
       "VERIFIED base case of undirected Hierholzer induction: theorem euler_circuit_of_edgeSet_empty in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Dev.lean (connected + G.edgeSet = ∅ ⇒ ∃ Eulerian circuit, via nil walk; vacuous count condition). Compiles clean, 0 sorries.",
       "exists_unused_incident_edge_at_endpoint + eq_of_isTrail_edgeMaximal (Sub-lemma A: a maximal trail is closed) — VERIFIED 0 sorries in KonigsbergOQ02OQ01OQ02OQ01Dev.lean",
-      "Sub-lemma C (splice) VERIFIED in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean (0 sorry, 0 axiom, 3 thms): isTrail_append (construction converse Mathlib omits), exists_isTrail_splice (insert closed trail d rooted at w∈c.support into closed trail c, edge set = c∪d, witness (c.takeUntil w).append (d.append (c.dropUntil w))), exists_isTrail_splice_of_mem_support (residual circuit rooted anywhere; rotate to w then splice)"
+      "Sub-lemma C (splice) VERIFIED in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Splice.lean (0 sorry, 0 axiom, 3 thms): isTrail_append (construction converse Mathlib omits), exists_isTrail_splice (insert closed trail d rooted at w∈c.support into closed trail c, edge set = c∪d, witness (c.takeUntil w).append (d.append (c.dropUntil w))), exists_isTrail_splice_of_mem_support (residual circuit rooted anywhere; rotate to w then splice)",
+      "Bridge lemma VERIFIED in proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Boundary.lean (0 sorry, 0 axiom, 3 thms): forall_walk_of_adjClosed + forall_of_adjClosed (nonempty adjacency-closed vertex predicate in a connected graph holds everywhere, via walk structural recursion + Connected.preconnected) and exists_boundary_edge_of_missing (a closed trail c missing an edge of connected G has an unused edge s(w,x) with w on c.support — the attach point for exists_isTrail_splice_of_mem_support). Note: mem_edgeSet is Iff.rfl so s(a,b)∈G.edgeSet is defeq G.Adj a b; snd_mem_support_of_mem_edges gives edge-endpoint∈support."
     ],
     "insights": [
       "Target is undirected Hierholzer SUFFICIENCY: connected + all-even-degree implies an Eulerian circuit exists. Necessity is already proved in KonigsbergOQ02OQ01OQ02.lean (eulerian_circuit_forall_even).",
@@ -48,12 +49,14 @@
       "Sub-lemma A reduces to Mathlib IsTrail.even_countP_edges_iff: p-edges incident to a non-start vertex v number ODD, total incident = degree is EVEN, so an unused incident edge always exists (proper-subset parity argument).",
       "Mathlib has only the DECOMPOSITION direction for trails under append (IsTrail.of_append_left/of_append_right); the CONSTRUCTION direction (disjoint-edge trails concatenate to a trail) and the splice are absent and were built natively.",
       "Splice needs [DecidableEq V] because takeUntil/dropUntil/rotate require it; isTrail_append does not.",
-      "rotate_edges gives (d.rotate h).edges ~r d.edges (List.IsRotated), so .mem_iff transports edge membership — lets a residual circuit rooted anywhere be re-based at the shared vertex without changing its edge set."
+      "rotate_edges gives (d.rotate h).edges ~r d.edges (List.IsRotated), so .mem_iff transports edge membership — lets a residual circuit rooted anywhere be re-based at the shared vertex without changing its edge set.",
+      "Connectivity glue for Hierholzer: if a closed trail's support were closed under adjacency (every incident edge used), connectivity forces support=V, so any missing edge would be incident and hence used — contradiction. Formalized as exists_boundary_edge_of_missing. Generic helper forall_of_adjClosed (adjacency-closed predicate + connected + witness ⟹ holds everywhere) is reusable."
     ],
     "mathlibGaps": [
       "Mathlib provides Eulerian degree bookkeeping (SimpleGraph.Walk.IsEulerian.even_degree_iff, .card_odd_degree) but NO existence/sufficiency (Hierholzer construction) for undirected graphs. Confirmed by parent file docstring: sufficiency remains the open direction."
     ],
     "nextSteps": [
+      "Sub-lemma D assembly is now unblocked on ingredients: A + B(#34714) + C(#34731) + bridge(exists_boundary_edge_of_missing). Wire strong induction on G.edgeFinset.card: base euler_circuit_of_edgeSet_empty; step grows maximal closed trail c (A), if not Eulerian use exists_boundary_edge_of_missing to get boundary vertex w∈c.support, apply IH to G.deleteEdges c.edges (smaller by B) rooted near w to get residual circuit d through w, splice via exists_isTrail_splice_of_mem_support; edge-set union closes induction.",
       "Port the directed sub-lemma structure to undirected: (1) from an all-even-degree graph, any MAXIMAL trail from a vertex is closed (current endpoint always has an unused incident edge by a parity/handshake count); (2) removing the edges of a closed trail preserves all-even-degree; (3) splice a residual closed trail through a shared vertex (exists by connectivity) into the main circuit; induct on edge count.",
       "Aristotle submission of the sorry file failed with MCP error Resource not found (likely worktree/lake-project resolution). Re-submit from the main repo via research/scripts/aristotle-submit.sh once the PR merges, as a KNOWN classical result.",
       "Consider building an undirected splice + edgeRemoval operation mirroring KonigsbergOQ02OQ01.lean removeArcList; estimate 600-1000 lines. This is the main effort and may warrant Aristotle or a dedicated multi-session build.",
@@ -91,7 +94,7 @@
     "mathlib": []
   },
   "started": "2026-07-02T23:38:28.291Z",
-  "lastUpdate": "2026-07-02T23:38:28.334Z",
+  "lastUpdate": "2026-07-04T22:50:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Adds the **connectivity bridge lemma** for the undirected Hierholzer assembly — the last structural glue the strong-induction proof of `undirected_euler_circuit_sufficient` needs before the ingredients can be wired together. New self-contained file `proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Boundary.lean` (3 theorems, **0 sorries, 0 axioms**, Mathlib-only, builds clean via Docker).

The three structural ingredients were already verified:
- **Sub-lemma A** — a maximal trail is closed (`Dev`).
- **Sub-lemma B** — deleting a closed trail's edges preserves all-even-degree (#34714).
- **Sub-lemma C** — splicing a residual sub-circuit into a closed trail (#34731).

But the induction also has to *locate* the vertex where the residual sub-circuit attaches. This PR supplies it:

- **`forall_walk_of_adjClosed`** / **`forall_of_adjClosed`** — a nonempty adjacency-closed vertex predicate in a *connected* graph holds everywhere (walk structural recursion + `Connected.preconnected`). A reusable connectivity primitive.
- **`exists_boundary_edge_of_missing`** — the payload: if a closed trail `c` misses at least one edge of a connected `G`, then some **unused** edge `s(w, x) ∉ c.edges` is incident to a vertex `w ∈ c.support`. That `w` is exactly the splice point consumed by `exists_isTrail_splice_of_mem_support` (#34731).

## Proof

Classical Hierholzer connectivity argument: were *every* edge incident to `c.support` already used by `c`, then `c.support` would be closed under adjacency (a used edge keeps both endpoints on the support, `snd_mem_support_of_mem_edges`); nonempty (`u` is on it) + `G` connected ⇒ `c.support` is all of `V`; then the missing edge, having an endpoint in `V = c.support`, would itself be incident and hence used — contradiction.

## Verification

- Docker build **succeeds** (`./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ02OQ01OQ02OQ01Boundary`).
- 0 sorries, 0 axioms.
- Kept in its own file to avoid edit conflicts with the parallel `Dev`/`Splice` development; the main `undirected_euler_circuit_sufficient` sorry is untouched (the assembly is the next step, now unblocked on all ingredients).

## Files

- `proofs/Proofs/KonigsbergOQ02OQ01OQ02OQ01Boundary.lean` — new, verified.
- `src/data/research/problems/konigsberg-oq-02-oq-01-oq-02-oq-01.json` — knowledge update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)