### PR TITLE
research(lp-duality): fix build-blocking drift lintegral_restrict_univ in Incomplete01

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
@@ -873,7 +873,9 @@ theorem localization_existence
           (ENNReal.ofReal ‖φ‖) ^ q.toReal := fun n => by
         have heq : ∫⁻ a in spanningSets μ n, (‖g a‖₊ : ℝ≥0∞) ^ q.toReal ∂μ =
             ∫⁻ a, (‖g_seq n a‖₊ : ℝ≥0∞) ^ q.toReal ∂(μ.restrict (spanningSets μ n)) := by
-          rw [lintegral_restrict_univ]
+          -- `∫⁻ a in s, f a ∂μ` is *notation* for `∫⁻ a, f a ∂(μ.restrict s)`, so both
+          -- sides are already lintegrals over the identical measure `μ.restrict Sₙ`;
+          -- only the integrand differs (`g` vs `g_seq n`), discharged by `hg_eq_n`.
           apply lintegral_congr_ae
           filter_upwards [hg_eq_n n] with a ha
           simp [ha]


### PR DESCRIPTION
## Summary

Fixes a build-blocking drift that landed in `main` via the squash-merge of #34741.

In `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`, theorem `localization_existence` (Step A4, the per-spanning-set MCT bound) rewrites the `heq` goal with:

```lean
rw [lintegral_restrict_univ]
```

`lintegral_restrict_univ` has **zero occurrences anywhere in Mathlib v4.26.0** (verified by grepping the `lean-mathlib-packages` volume) — it is a nonexistent lemma and guarantees a build failure.

## Why the rewrite is unnecessary

`∫⁻ a in s, f a ∂μ` is *pure notation* for `lintegral (Measure.restrict μ s) f` (`Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean:61` — there is no separate `setLIntegral` def). So both sides of `heq` are already lintegrals over the identical measure `μ.restrict (spanningSets μ n)`; only the integrand differs (`g` vs `g_seq n`). `lintegral_congr_ae` unifies the measures directly and the existing `filter_upwards [hg_eq_n n]` discharges the a.e. equality (`hg_eq_n n : g =ᵐ[μ.restrict (spanningSets μ n)] g_seq n`).

## Verification

- **Source-level only** — host is build-blocked (swap 98% full, 57 concurrent lean procs; direct build would SIGBUS).
- Full drift audit: all 396 snake_case + 126 dotted identifiers in the file were checked against Mathlib. Every other name exists in Mathlib, is a local `have`/helper, or is defined in the dependency file `...OQ01`. This `rw` was the only real drift.

Diff is a single hunk (`-1/+3`, the +2 being an explanatory comment).