### PR TITLE
Research: erdos-153-oq-03 — B_h hereditary + B0 base + B₂⟺Sidon characterization (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -169,4 +169,60 @@ theorem isSidon_of_isBhSet {h : ℕ} {A : Finset ℕ} (hA : A.Nonempty)
     (hh : 2 ≤ h) (H : IsBhSet h A) : IsSidon A :=
   isSidon_of_isBhSet_two (isBhSet_antitone hA hh H)
 
+/-!
+## Section IV: Further structural facts
+
+Two hereditary/base companions to the nesting results of Section II, and the converse
+of the Sidon bridge (upgrading `isSidon_of_isBhSet_two` to a characterization).
+-/
+
+/-- **B₀ is trivial.** Every finite set is a B₀ set: the only multiset of card `0` is
+the empty multiset, so the injectivity condition is vacuous. Complements `isBhSet_one`.
+Unlike the nesting lemmas this needs no nonemptiness hypothesis. -/
+theorem isBhSet_zero (A : Finset ℕ) : IsBhSet 0 A := by
+  intro s t _ _ hcs hct _
+  rw [Multiset.card_eq_zero.mp hcs, Multiset.card_eq_zero.mp hct]
+
+/-- **B_h is hereditary (monotone in the ground set).** Every subset of a B_h set is a
+B_h set: the injectivity of `Multiset.sum` on the size-`h` multisets drawn from the
+larger set restricts to those drawn from the subset. This is the ground-set analog of
+`isBhSet_antitone` (which is monotone in the order `h`), and — unlike the nesting
+lemmas — needs no nonemptiness hypothesis. -/
+theorem isBhSet_subset {h : ℕ} {A B : Finset ℕ} (hBA : B ⊆ A)
+    (H : IsBhSet h A) : IsBhSet h B := by
+  intro s t hs ht hcs hct hsum
+  exact H s t (fun x hx => hBA (hs x hx)) (fun x hx => hBA (ht x hx)) hcs hct hsum
+
+/-- **The gallery's ordered Sidon condition implies the B₂ property** — the converse of
+`isSidon_of_isBhSet_two`. Two size-2 multisets from `A` with equal sum are each an
+unordered pair `{x, y}` (`Multiset.card_eq_two`); sorting each pair and applying
+`IsSidon` pins the two components down, so the multisets coincide. -/
+theorem isBhSet_two_of_isSidon {A : Finset ℕ} (H : IsSidon A) : IsBhSet 2 A := by
+  intro s t hs ht hcs hct hsum
+  obtain ⟨a, b, rfl⟩ := Multiset.card_eq_two.mp hcs
+  obtain ⟨c, d, rfl⟩ := Multiset.card_eq_two.mp hct
+  have ha : a ∈ A := hs a (by simp)
+  have hb : b ∈ A := hs b (by simp)
+  have hc : c ∈ A := ht c (by simp)
+  have hd : d ∈ A := ht d (by simp)
+  simp only [Multiset.insert_eq_cons, Multiset.sum_cons, Multiset.sum_singleton] at hsum
+  -- `hsum : a + b = c + d`; split on the two orderings and apply `IsSidon`.
+  rcases le_total a b with hab | hba
+  · rcases le_total c d with hcd | hdc
+    · obtain ⟨rfl, rfl⟩ := H a ha b hb c hc d hd hab hcd hsum
+      first | rfl | exact Multiset.cons_swap _ _ _
+    · obtain ⟨rfl, rfl⟩ := H a ha b hb d hd c hc hab hdc (by omega)
+      first | rfl | exact Multiset.cons_swap _ _ _
+  · rcases le_total c d with hcd | hdc
+    · obtain ⟨rfl, rfl⟩ := H b hb a ha c hc d hd hba hcd (by omega)
+      first | rfl | exact Multiset.cons_swap _ _ _
+    · obtain ⟨rfl, rfl⟩ := H b hb a ha d hd c hc hba hdc (by omega)
+      first | rfl | exact Multiset.cons_swap _ _ _
+
+/-- **Characterization of B₂ sets.** The multiset `B₂` property is *exactly* the
+gallery's ordered Sidon condition. Combines `isSidon_of_isBhSet_two` with its converse
+`isBhSet_two_of_isSidon`. -/
+theorem isBhSet_two_iff_isSidon {A : Finset ℕ} : IsBhSet 2 A ↔ IsSidon A :=
+  ⟨isSidon_of_isBhSet_two, isBhSet_two_of_isSidon⟩
+
 end Erdos153OQ03


### PR DESCRIPTION
## Summary

Three verified structural companions to the B_h (Sidon-of-order-h) infrastructure added in #34736, in `proofs/Proofs/Erdos153OQ03.lean`. **All 0 sorries, 0 axioms**; Docker build succeeds.

The existing file proved nesting *in the order* `h` (`isBhSet_antitone`: B_h ⟹ B_k for k ≤ h) and the one-way bridge `isSidon_of_isBhSet_two` (B₂ ⟹ Sidon). This PR fills the natural gaps:

- **`isBhSet_zero`** — every finite set is a B₀ set (the size-0 multiset is unique, so the condition is vacuous). Complements `isBhSet_one`; needs no nonemptiness.
- **`isBhSet_subset`** — B_h is **hereditary**: every subset of a B_h set is B_h. This is the *ground-set* analog of `isBhSet_antitone` (which is monotone in the order `h`), completing the "B_h is monotone in both parameters" picture. Needs no nonemptiness.
- **`isBhSet_two_of_isSidon`** + **`isBhSet_two_iff_isSidon`** — the **converse** of `isSidon_of_isBhSet_two`, upgrading the bridge to a full characterization: `IsBhSet 2 A ↔ IsSidon A`. The multiset B₂ definition is *exactly* the gallery's ordered Sidon condition. Proof: `Multiset.card_eq_two` splits each size-2 multiset into an unordered pair, `le_total` sorts it, `IsSidon` pins the components, and `Multiset.cons_swap` closes the swapped orderings.

## Why it matters

Confirms the new `IsBhSet` definition genuinely *extends* the gallery notion (they coincide at `h = 2`), and records B_h's two monotonicity directions — the structural scaffolding any later density/gap-variance argument builds on. The main gap-variance conjecture for `h ≥ 3` remains open and is untouched.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03` — build succeeds, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)