### PR TITLE
Enrich Abel–Ruffini threshold (abel-ruffini-oq-06): section coverage of module preamble

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-06/meta.json
@@ -75,6 +75,13 @@
   },
   "sections": [
     {
+      "id": "overview-setup",
+      "title": "Threshold Context and Namespace Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring framing the group-theoretic core of Abel–Ruffini: the dichotomy Sₙ solvable ⇔ n ≤ 4. The non-solvable half (n ≥ 5) lives in AbelRuffiniObstructionOQ06.lean; this file supplies the positive half that Mathlib does not package. Imports Mathlib, opens the AbelRuffiniOQ06 namespace with Equiv, and states the reduction lemma's docstring: Aₙ = ker(sign) is normal in Sₙ with abelian quotient Sₙ/Aₙ ↪ ℤˣ, so solvability of Aₙ lifts to Sₙ via solvable_of_ker_le_range. The characteristic-p / Abhyankar reading of the title is explicitly scoped out."
+    },
+    {
       "id": "reduction",
       "title": "The Aₙ → Sₙ Reduction",
       "startLine": 57,


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-06` (Abel–Ruffini threshold, solvable side).

**Gap fixed:** section coverage. The Lean file is 94 lines, but `sections` only covered lines 57–92, leaving the entire 56-line preamble (module docstring + namespace/open + reduction-lemma docstring) with no section. Annotations already covered lines 1–56, so the content was documented but not reflected in the section map.

**Change:** added an `overview-setup` section (lines 1–56) summarizing the threshold-dichotomy framing (Sₙ solvable ⇔ n ≤ 4), the split with the non-solvable half in `AbelRuffiniObstructionOQ06.lean`, imports/namespace setup, the `Aₙ = ker(sign)` reduction outline, and the explicit scoping-out of the characteristic-p / Abhyankar reading.

Sections now tile 1→92 (was 57→92). meta-only change; no annotation or Lean edits. JSON validated.
