### PR TITLE
Research: hurwitz-oq-03-oq-01 (ORIENT) — Frobenius Step-3 decomposition

### DIFF
--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/knowledge.md
@@ -1,0 +1,105 @@
+# Knowledge Base: hurwitz-theorem-oq-03-oq-01-wip-01
+
+Completing the "only-if" direction of Hurwitz's theorem for `NormedDivisionRing`
+(`Proofs/HurwitzOnlyIf.lean`).
+
+---
+
+## Problem Understanding
+
+Target file `Proofs/HurwitzOnlyIf.lean` contains **exactly one real `sorry`**:
+`hurwitz_only_if_ring` — a finite-dimensional normed division ring `A` over `ℝ` has
+`finrank ℝ A ∈ {1,2,4,8}`. (A `grep -c sorry` returns 4, but three of those are the
+word "sorry" inside docstrings; only `hurwitz_only_if_ring` is an actual proof hole.)
+
+Because `NormedDivisionRing` is **associative**, this sorry is precisely **Frobenius'
+theorem**: the answer is in fact `{1,2,4}` (ℝ, ℂ, ℍ); the octonions are excluded because
+they are non-associative. Proving `{1,2,4}` suffices since `{1,2,4} ⊆ {1,2,4,8}`.
+
+Already **verified (0 sorries)** in the file and reusable:
+- `finrank_normed_field_eq_one_or_two`, `hurwitz_field_case` — the commutative/field case
+  via Gelfand–Mazur (`NormedAlgebra.Real.nonempty_algEquiv_or`).
+- `minpoly_natDegree_le_two` — every element's minimal polynomial has degree ≤ 2
+  (irreducible real polynomials have degree ≤ 2).
+- `exists_quadratic` — `∀ a, ∃ p q : ℝ, a^2 = p•a + q•1`.
+- `exists_real_shift_sq_scalar` — `∀ a, ∃ c r : ℝ, (a - c•1)^2 = r•1` (completing the square).
+- `eq_smul_one_of_sq_eq_nonneg_smul` — `b^2 = r•1 ∧ r ≥ 0 ⟹ b ∈ ℝ•1` (no zero divisors).
+
+So Frobenius **Steps 1 and 2 are done**. Only **Step 3** (the global structure argument)
+remains.
+
+---
+
+## Insights
+
+### The one remaining sorry is Frobenius Step 3 — a precise decomposition
+
+Let `A` be a finite-dim associative normed division ℝ-algebra. Define the imaginary set
+`ImA := {a : A | ∃ r : ℝ, r ≤ 0 ∧ a^2 = r • 1}` (equivalently `a^2 ∈ ℝ≤0 • 1`).
+
+The remaining work splits into these intermediate lemmas (roadmap for next session /
+Aristotle). None is in Mathlib; all are elementary given Steps 1–2:
+
+1. **`realPart` is well-defined.** From `exists_real_shift_sq_scalar`, each `a` has `c(a) ∈ ℝ`
+   with `(a - c(a)•1)^2 ∈ ℝ•1`. Uniqueness of `c(a)`: if `c, c'` both work, subtracting shows
+   a nonzero real multiple of `1` lies in `ImA`, impossible unless the coefficient is `0`
+   (no-zero-divisors + char 0). Gives `re : A → ℝ`, `re 1 = 1`.
+
+2. **Anticommutator lands in `ℝ•1` (polarization) — THE KEYSTONE.** For `x, y ∈ ImA`,
+   `x*y + y*x ∈ ℝ•1`. Proof: `(x+y)^2 - x^2 - y^2 = xy + yx`; each square is `scalar + linear•(·)`
+   and the linear parts cancel for imaginary inputs. Establish this FIRST — it makes `re`
+   additive/linear and `ImA` a subspace.
+
+3. **`ImA` is an ℝ-subspace and `A = ℝ•1 ⊕ ImA`.** `ImA = ker re` once `re` is linear;
+   `x ∈ ImA ↔ re x = 0 ↔ x^2 ∈ ℝ≤0•1` (sign from `eq_smul_one_of_sq_eq_nonneg_smul`:
+   a positive square scalar forces `x ∈ ℝ•1`).
+
+4. **`B(x,y) := -(scalar of x*y + y*x)/2` is a positive-definite symmetric bilinear form on
+   `ImA`.** Symmetric clear; `B(x,x) = -x^2` as a scalar `= -r ≥ 0`, and `> 0` for `x ≠ 0`
+   (division ring ⟹ `x^2 ≠ 0`).
+
+5. **`finrank ℝ ImA ∈ {0,1,3}`, hence `finrank ℝ A ∈ {1,2,4}`.** Classical finish: if
+   `dim ImA ≥ 2`, `B`-orthonormal `i,j` give `i^2=j^2=-1`, `ij=-ji`, `ij ∈ ImA`, `(ij)^2=-1`,
+   so `⟨i,j,ij⟩ ≅ ℍ` (dim 3). A fourth orthonormal `k` makes `ijk` central with `(ijk)^2=+1`,
+   so `(ijk-1)(ijk+1)=0` contradicts no-zero-divisors. Hence `dim ImA ≤ 3`, and combined with
+   the ℍ-subalgebra `dim ImA ∈ {0,1,3}`.
+
+### Reduction provable NOW (does not need Step 3) — recommended first commit
+The **commutative subcase** of `hurwitz_only_if_ring` is already covered: a commutative
+`NormedDivisionRing` is a `NormedField`, so `hurwitz_field_case` applies verbatim. Adding
+`hurwitz_only_if_ring_comm` (hypothesis `∀ x y, x*y = y*x`) is a clean, self-contained lemma —
+build a `NormedField` instance via `letI` from commutativity and reuse `hurwitz_field_case`.
+Lowest-risk verifiable increment when tooling returns.
+
+---
+
+## Dead Ends / Non-starters
+
+- **Cannot delegate cleanly to `HurwitzTheorem.hurwitz_only_if` axiom.** It is stated for
+  `NSquareIdentity n`, and the reduction `NormedDivisionRing A → NSquareIdentity (dim A)`
+  (orthonormal basis + transport of multiplication) is itself substantial and unformalized.
+- **No Mathlib Frobenius.** As of 2026-07, Mathlib has Gelfand–Mazur
+  (`Analysis.Normed.Algebra.GelfandMazur`) but NOT the classification of finite-dimensional
+  real division algebras nor the Clifford / Radon–Hurwitz machinery. Step 3 must be built
+  locally (est. 250–450 lines, elementary but long).
+
+---
+
+## Session Log
+
+### 2026-07-04 (Session 1, researcher-8) — ORIENT
+
+**Mode**: FRESH. **Outcome**: oriented (no code committed).
+
+- Identified the single real sorry (`hurwitz_only_if_ring`); confirmed it is Frobenius'
+  theorem (associative ⟹ `{1,2,4}`), with Steps 1–2 already verified in-file.
+- Produced the Step-3 decomposition above (keystone = anticommutator polarization) plus a
+  provable-now commutative reduction.
+- **Tooling blocker**: BOTH verification paths down this session — local Docker build unsafe
+  (host swap 98% full, 81/83 GB; SIGBUS-135 risk that can crash the host) and the Aristotle
+  MCP returned `{"status":"error","message":"Resource not found."}` even on a trivial
+  `1+1=2` sorry. No Lean written/committed (would be unverifiable — violates honesty policy).
+- **Next session**: when a tool is available, (a) commit `hurwitz_only_if_ring_comm` first
+  (provable now via Gelfand–Mazur), then (b) target keystone lemma (2), the anticommutator
+  polarization; or submit `hurwitz_only_if_ring` to Aristotle noting it is Frobenius' theorem
+  with Steps 1–2 supplied as context.

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/literature/README.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for hurwitz-theorem-oq-03-oq-01-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/problem.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/problem.md
@@ -1,0 +1,122 @@
+# Problem: Complete Hurwitz Only-If: Normed Division Algebras via Gelfand-Mazur
+
+**Slug**: hurwitz-theorem-oq-03-oq-01-wip-01
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+A \text{ a normed division algebra over } \mathbb{R} \text{ with a multiplicative norm} \implies \dim_{\mathbb{R}} A \in \{1, 2, 4, 8\},\ A \cong \mathbb{R}, \mathbb{C}, \mathbb{H}, \text{ or } \mathbb{O}.
+$$
+This WIP targets the commutative (field) case: any normed field over $\mathbb{R}$ is $\mathbb{R}$ or $\mathbb{C}$.
+
+### Plain Language
+
+Hurwitz's theorem classifies the real normed division algebras — there are exactly
+four (the reals, complexes, quaternions, octonions). The "only-if" direction says no
+others can exist. This work-in-progress handles the commutative case: a normed field
+extension of R must be R or C (dimension 1 or 2), proved via the Gelfand-Mazur
+theorem. The genuinely non-commutative case (quaternions H) needs Clifford-algebra
+representation theory and is out of scope here.
+
+### Why This Matters
+
+The four normed division algebras are foundational across algebra, geometry, and
+physics. A formal, Gelfand-Mazur-based proof of the commutative sub-case exercises
+Mathlib's Banach-algebra spectral theory and provides a clean, reusable statement.
+
+## Known Results
+
+### What's Already Proven
+
+- The source entry `hurwitz-theorem-oq-03-oq-01` proves the commutative case via
+  Gelfand-Mazur: any normed field over R is isomorphic to R or C.
+- Gelfand-Mazur (a normed division C-algebra is C) is available in Mathlib.
+
+### What's Still Open
+
+- Discharging the remaining `sorry`s tying the field case together cleanly.
+- The non-commutative (H) case via Clifford algebra representation theory.
+
+### Our Goal
+
+Complete the work-in-progress source proof `hurwitz-theorem-oq-03-oq-01`: close the
+remaining gaps in the commutative Gelfand-Mazur argument (dimension 1 or 2), without
+attempting the non-commutative octonion/quaternion extension.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| hurwitz-theorem-oq-03-oq-01 | Direct parent WIP proof being completed | Gelfand-Mazur, normed fields |
+| hurwitz-theorem | Base classification statement | division algebras, norms |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Apply Mathlib's Gelfand-Mazur to the complexification.
+   - Why it might work: Reduces the field case to a known spectral-theory result.
+   - Risk: Bookkeeping between the real algebra and its complexification.
+
+2. **Approach B**: Direct minimal-polynomial / algebraicity argument.
+   - Why it might work: A normed field over R is algebraic of degree ≤ 2.
+   - Risk: Formalizing the norm-multiplicativity ⇒ algebraic step.
+
+### Key Difficulties
+
+- Relating the real normed field to Mathlib's complex Gelfand-Mazur statement.
+- Handling the isomorphism (not just dimension) cleanly.
+
+### What Would a Proof Need?
+
+- Key lemma 1: A normed field over R embeds in / complexifies to a normed C-algebra.
+- Key lemma 2: Gelfand-Mazur forces dimension 1 or 2 and the R/C isomorphism.
+- Technical requirements: Mathlib Banach-algebra spectrum and field-extension API.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The commutative case leans on an existing Mathlib theorem (Gelfand-Mazur).
+- The main effort is glue and the R↔C bookkeeping, not new deep theory.
+- The non-commutative case is deliberately excluded to keep scope tractable.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: days
+- If hard: 1 week
+
+## References
+
+### Papers
+- Hurwitz, "Über die Komposition der quadratischen Formen", 1898 — original.
+
+### Online Resources
+- Standard notes on Gelfand-Mazur and the classification of normed division algebras.
+
+### Mathlib
+- `Mathlib.Analysis.Normed.Algebra.GelfandMazur` — Gelfand-Mazur theorem.
+- `Mathlib.Analysis.Normed.Field.*` — normed field API.
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - normed-algebras
+  - division-algebras
+  - gelfand-mazur
+  - hurwitz-theorem
+related_proofs:
+  - hurwitz-theorem-oq-03-oq-01
+  - hurwitz-theorem
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
@@ -1,0 +1,28 @@
+# Research State: hurwitz-theorem-oq-03-oq-01-wip-01
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-07-04T15:36:57-07:00
+**Iteration**: 2
+
+## Current Focus
+Frobenius Step 3 decomposition mapped. Target file HurwitzOnlyIf.lean has one real sorry
+(hurwitz_only_if_ring = Frobenius). Steps 1-2 verified in-file.
+
+## Active Approach
+Frobenius: split A = R*1 ⊕ ImA, positive-definite anticommutator bilinear form on ImA,
+finrank ImA in {0,1,3}. Keystone lemma = anticommutator polarization (x*y+y*x in R*1).
+
+## Attempt Count
+- Total attempts: 0 (code)
+- Approaches tried: 0
+
+## Blockers
+- Local Docker build unsafe: host swap 98% full (SIGBUS-135 / host-crash risk).
+- Aristotle MCP down: "Resource not found" on all prove calls (incl. trivial 1+1=2).
+
+## Next Action
+When a verification tool returns: (1) commit hurwitz_only_if_ring_comm (provable now via
+Gelfand-Mazur + letI NormedField from commutativity); (2) keystone anticommutator lemma;
+or submit hurwitz_only_if_ring to Aristotle (hint=Frobenius, context=HurwitzOnlyIf.lean).

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
@@ -1,0 +1,75 @@
+{
+  "slug": "hurwitz-theorem-oq-03-oq-01-wip-01",
+  "title": "Complete Hurwitz Only-If: Normed Division Algebras via Gelfand-Mazur",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "A \\text{ a normed division algebra over } \\mathbb{R} \\text{ with a multiplicative norm} \\implies \\dim_{\\mathbb{R}} A \\in \\{1, 2, 4, 8\\},\\ A \\cong \\mathbb{R}, \\mathbb{C}, \\mathbb{H}, \\text{ or } \\mathbb{O}.",
+    "plain": "Hurwitz's theorem classifies the real normed division algebras — there are exactly",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "finrank R A in {1,2,4,8} for finite-dim NormedDivisionRing A over R (Frobenius: actually {1,2,4})."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-04T15:07:19-07:00",
+    "iteration": 2,
+    "focus": "Frobenius Step 3 decomposition mapped; execute hurwitz_only_if_ring_comm then anticommutator keystone when tooling returns.",
+    "blockers": [
+      "Local build unsafe: host swap 98% full (SIGBUS-135/host-crash risk)",
+      "Aristotle MCP down: Resource not found on all prove calls"
+    ],
+    "nextAction": "Commit hurwitz_only_if_ring_comm (provable now via Gelfand-Mazur); then keystone anticommutator lemma.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (no code): single sorry = Frobenius Step 3; Steps 1-2 verified in-file; 5-lemma decomposition mapped; commutative subcase provable now. BLOCKED THIS SESSION on tooling (build swap 98% full + Aristotle MCP down).",
+    "builtItems": [],
+    "insights": [
+      "The target file HurwitzOnlyIf.lean has exactly ONE real sorry (hurwitz_only_if_ring); grep -c=4 is inflated by 3 docstring mentions of the word sorry.",
+      "The remaining sorry is precisely Frobenius theorem: NormedDivisionRing is associative so finrank in {1,2,4} (subset of {1,2,4,8}); octonions excluded by associativity.",
+      "Frobenius Steps 1-2 are already VERIFIED in-file (minpoly_natDegree_le_two, exists_quadratic, exists_real_shift_sq_scalar, eq_smul_one_of_sq_eq_nonneg_smul). Only Step 3 (global structure) remains.",
+      "Step 3 keystone is the anticommutator polarization: for imaginary x,y, x*y+y*x in R*1. This single lemma makes re:A->R linear and ImA a subspace; prove it first.",
+      "Commutative subcase of hurwitz_only_if_ring is provable NOW without Step 3: a commutative NormedDivisionRing is a NormedField, so hurwitz_field_case (Gelfand-Mazur) applies via a letI NormedField instance."
+    ],
+    "mathlibGaps": [
+      "Mathlib (2026-07) has Gelfand-Mazur (Analysis.Normed.Algebra.GelfandMazur) but NOT the classification of finite-dim real division algebras (Frobenius).",
+      "No Clifford-algebra / Radon-Hurwitz-number / positive-definite-quadratic-space machinery to discharge Step 3 directly; must be built locally (~250-450 lines, elementary)."
+    ],
+    "nextSteps": [
+      "First commit (lowest risk, provable now): hurwitz_only_if_ring_comm assuming forall x y, x*y=y*x, via letI NormedField from commutativity + reuse hurwitz_field_case.",
+      "Keystone Step-3 lemma: anticommutator polarization x*y+y*x in R*1 for x,y imaginary, from (x+y)^2 - x^2 - y^2 and cancellation of linear parts.",
+      "Then re:A->R linear, ImA=ker re is subspace, A = R*1 (+) ImA; B(x,y)=-(x*y+y*x)/2 positive-definite symmetric; finrank ImA in {0,1,3}.",
+      "Alternative: submit hurwitz_only_if_ring to Aristotle once MCP is restored, hint=Frobenius theorem, context_files=HurwitzOnlyIf.lean supplying Steps 1-2."
+    ],
+    "markdown": "# Knowledge Base: hurwitz-theorem-oq-03-oq-01-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "algebra",
+    "normed-algebras",
+    "division-algebras",
+    "gelfand-mazur",
+    "hurwitz-theorem"
+  ],
+  "relatedProofs": [
+    "hurwitz-theorem",
+    "hurwitz-theorem-oq-03",
+    "hurwitz-theorem-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-04T22:16:23.695Z",
+  "lastUpdate": "2026-07-04T22:35:00.000Z"
+}


### PR DESCRIPTION
## Summary

ORIENT-phase research on **hurwitz-theorem-oq-03-oq-01-wip-01** ("Complete Hurwitz Only-If via Gelfand–Mazur"). Documentation only — no Lean changed.

**Finding:** `proofs/Proofs/HurwitzOnlyIf.lean` has **exactly one real `sorry`** (`hurwitz_only_if_ring`). The `grep -c sorry` = 4 is inflated by three docstring mentions. That sorry is precisely **Frobenius' theorem**: `NormedDivisionRing` is associative, so `finrank ℝ A ∈ {1,2,4} ⊆ {1,2,4,8}`. Frobenius **Steps 1–2 are already verified in-file** (`minpoly_natDegree_le_two`, `exists_quadratic`, `exists_real_shift_sq_scalar`, `eq_smul_one_of_sq_eq_nonneg_smul`).

## Deliverable — Step 3 decomposition (roadmap)

Split `A = ℝ·1 ⊕ ImA`, positive-definite bilinear form on `ImA`, conclude `finrank ImA ∈ {0,1,3}`:

1. `re : A → ℝ` well-defined (unique real-part shift).
2. **Keystone — anticommutator polarization:** `x,y ∈ ImA ⟹ x*y + y*x ∈ ℝ·1`. Prove first; makes `re` linear and `ImA` a subspace.
3. `ImA = ker re` is an ℝ-subspace; `A = ℝ·1 ⊕ ImA`.
4. `B(x,y) = -(x*y+y*x)/2` positive-definite symmetric on `ImA`.
5. `finrank ImA ∈ {0,1,3}` (ℍ-subalgebra + no-zero-divisor contradiction for a 4th generator).

**Provable now, no Step 3:** commutative subcase — a commutative `NormedDivisionRing` is a `NormedField`, so `hurwitz_field_case` (Gelfand–Mazur) applies via a `letI NormedField` instance. Recommended lowest-risk first commit next session.

## Why no Lean this session

Both verification paths were down: local Docker build unsafe (host swap 98% full — SIGBUS-135 / host-crash risk) and the Aristotle MCP returned `Resource not found` on every `prove` call (incl. a trivial `1+1=2`). Committing unverifiable proof bodies would violate the project's honesty standards.

## Mathlib gap

Mathlib (2026-07) has Gelfand–Mazur but not the classification of finite-dim real division algebras (Frobenius) nor the Clifford/Radon–Hurwitz machinery; Step 3 must be built locally (~250–450 lines, elementary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)