### PR TITLE
Enrich Complex Gaussian (oq-07-oq-01): fix section coverage

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -36,9 +36,9 @@
     {
       "id": "open-question-context",
       "title": "Open Question & Analytic-Continuation Context",
-      "startLine": 4,
-      "endLine": 28,
-      "summary": "The module docstring states the open question — extend the real Gaussian ∫_ℝ e^{-x²} = √π (the b = 1 parent) to complex b with 0 < re b — and answers YES via Mathlib's integral_gaussian_complex. It frames the move to complex b as the analytic continuation into the right half-plane {re b > 0} underlying the Fresnel oscillatory integrals, and notes the value is now a principal (1/2)-power rather than a real square root."
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Imports, the module docstring framing the open question and analytic-continuation context, and `open Real Complex MeasureTheory` — the setup for restating Mathlib's complex Gaussian integral."
     },
     {
       "id": "complex-gaussian",


### PR DESCRIPTION
## Enrichment: section coverage (area-of-circle-oq-07-oq-01)

Section 1 spanned lines 4–28, leaving the imports (1–3) and the `open` line (30) uncovered. Extended to 1–31 so the sections cover the imports, docstring, and setup block. Meta-only.
