### PR TITLE
Enrich Second Moment of the Gaussian (oq-07-oq-05): fix section coverage

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
@@ -98,9 +98,9 @@
     {
       "id": "header",
       "title": "Problem and Strategy",
-      "startLine": 5,
+      "startLine": 1,
       "endLine": 35,
-      "summary": "States the open question (the second moment ∫ x² e^{-x²}), the answer √π/2, and the integration-by-parts strategy that reduces it to half the parent zeroth moment √π. Notes the equivalent Gamma form Γ(3/2).",
+      "summary": "Imports, then the module docstring stating the second-moment problem ∫ x² e^{-x²} and the integration-by-parts strategy on the whole line.",
       "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\tfrac{\\sqrt\\pi}{2} = \\Gamma(3/2)$."
     },
     {


### PR DESCRIPTION
## Enrichment: section coverage (area-of-circle-oq-07-oq-05)

Section 1 started at line 5, leaving the three imports (1–3) uncovered. Extended to start at line 1. Meta-only.
