### PR TITLE
Research: erdos-153-oq-03 — B_h translation + affine invariance (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -35,6 +35,8 @@ constrained* as the Sidon (h = 2) case, because every B_h set is Sidon.
 - `isBhSet_empty`          : the empty set is B_h for every h
 - `isBhSet_singleton`      : every singleton is B_h for every h
 - `isBhSet_smul`           : dilation invariance — c·A is B_h whenever A is (c ≥ 1)
+- `isBhSet_add`            : translation invariance — A+t is B_h whenever A is
+- `isBhSet_affine`         : affine invariance — {c·a+t} is B_h whenever A is (c ≥ 1)
 -/
 import Mathlib
 
@@ -318,5 +320,76 @@ theorem isBhSet_smul {h c : ℕ} {A : Finset ℕ} (hc : 0 < c)
   -- `B_h` upstairs forces `s₀ = t₀`; re-dilating both sides gives `s = t`.
   have h0 : s₀ = t₀ := H s₀ t₀ hsA htA hcs₀ hct₀ hsum₀
   rw [← hs_rec, ← ht_rec, h0]
+
+/-- **Translation invariance.** If `A` is a `B_h` set, then the translate
+`A + t = {a+t : a ∈ A}` (here `A.image (· + t)`) is again a `B_h` set.  The
+companion to `isBhSet_smul`: where dilation scales every `h`-fold sum by `c`,
+translation shifts every `h`-fold sum by the *constant* `h·t` (each of the `h`
+summands gains `t`).  That shift cancels between two competing size-`h` sums, so
+equal sums downstairs pull back to equal sums upstairs, where the `B_h` property
+of `A` closes the gap and re-translating transports the equality back down.
+Unlike the nesting lemmas this needs no nonemptiness hypothesis. -/
+theorem isBhSet_add {h t : ℕ} {A : Finset ℕ}
+    (H : IsBhSet h A) : IsBhSet h (A.image (fun a => a + t)) := by
+  -- `Multiset.sum` shifts by `card · t` under an elementwise `+ t`.
+  have hshift : ∀ m : Multiset ℕ,
+      (m.map (fun x => x + t)).sum = m.sum + Multiset.card m * t := by
+    intro m
+    refine Multiset.induction_on m ?_ ?_
+    · simp
+    · intro a m ih
+      simp only [Multiset.map_cons, Multiset.sum_cons, Multiset.card_cons, ih,
+        Nat.add_mul, Nat.one_mul]
+      ring
+  -- subtracting `t` inverts the translation on elements of the translated set:
+  -- re-translating the pulled-back multiset recovers it, and its elements lie in `A`.
+  have hinv : ∀ m : Multiset ℕ, (∀ x ∈ m, x ∈ A.image (fun a => a + t)) →
+      (m.map (fun x => x - t)).map (fun x => x + t) = m ∧
+      (∀ y ∈ m.map (fun x => x - t), y ∈ A) := by
+    intro m hm
+    refine ⟨?_, ?_⟩
+    · rw [Multiset.map_map]
+      conv_rhs => rw [← Multiset.map_id' m]
+      apply Multiset.map_congr rfl
+      intro x hx
+      obtain ⟨a, _, rfl⟩ := Finset.mem_image.mp (hm x hx)
+      show a + t - t + t = a + t
+      omega
+    · intro y hy
+      obtain ⟨x, hx, rfl⟩ := Multiset.mem_map.mp hy
+      obtain ⟨a, ha, rfl⟩ := Finset.mem_image.mp (hm x hx)
+      have : a + t - t = a := by omega
+      rw [this]; exact ha
+  intro s u hs hu hcs hcu hsum
+  obtain ⟨hs_rec, hsA⟩ := hinv s hs
+  obtain ⟨hu_rec, huA⟩ := hinv u hu
+  set s₀ : Multiset ℕ := s.map (fun x => x - t) with hs₀
+  set u₀ : Multiset ℕ := u.map (fun x => x - t) with hu₀
+  -- the pulled-back multisets keep size `h`
+  have hcs₀ : Multiset.card s₀ = h := by rw [hs₀, Multiset.card_map]; exact hcs
+  have hcu₀ : Multiset.card u₀ = h := by rw [hu₀, Multiset.card_map]; exact hcu
+  -- and share a sum, after cancelling the common shift `h·t`
+  have hsum₀ : s₀.sum = u₀.sum := by
+    have es : s.sum = s₀.sum + Multiset.card s₀ * t := by rw [← hs_rec, hshift]
+    have eu : u.sum = u₀.sum + Multiset.card u₀ * t := by rw [← hu_rec, hshift]
+    rw [hcs₀] at es; rw [hcu₀] at eu; omega
+  -- `B_h` upstairs forces `s₀ = u₀`; re-translating both sides gives `s = u`.
+  have h0 : s₀ = u₀ := H s₀ u₀ hsA huA hcs₀ hcu₀ hsum₀
+  rw [← hs_rec, ← hu_rec, h0]
+
+/-- **Affine invariance.** If `A` is a `B_h` set and `c ≥ 1`, then the affine image
+`{c·a + t : a ∈ A}` (here `A.image (fun a => c·a + t)`) is again a `B_h` set.  This is
+the structural payoff of Section V: the class of `B_h` sets is closed under every
+order-preserving affine map `a ↦ c·a + t`, so "being a `B_h` set" depends only on the
+*affine geometry* of `A`, not its position (`t`) or scale (`c`).  Proved by composing
+dilation (`isBhSet_smul`) with translation (`isBhSet_add`), since
+`a ↦ c·a + t = (· + t) ∘ (c · ·)`. -/
+theorem isBhSet_affine {h c t : ℕ} {A : Finset ℕ} (hc : 0 < c)
+    (H : IsBhSet h A) : IsBhSet h (A.image (fun a => c * a + t)) := by
+  have himg : (A.image (fun a => c * a)).image (fun x => x + t)
+            = A.image (fun a => c * a + t) := by
+    rw [Finset.image_image]; rfl
+  rw [← himg]
+  exact isBhSet_add (isBhSet_smul hc H)
 
 end Erdos153OQ03


### PR DESCRIPTION
## Summary

Completes the **affine-structure claim** of Section V in `Erdos153OQ03.lean`. Dilation invariance (`isBhSet_smul`, `c·A`) was already proved; the docstring promised that translation + dilation together make "being a B_h set" a property of the affine geometry of `A`, but **translation** was missing. This PR adds it plus the combined affine corollary.

### New theorems (both 0 sorry / 0 axiom)

- **`isBhSet_add`** — translation invariance: `A + t = {a+t : a ∈ A}` is `B_h` whenever `A` is. Every `h`-fold sum shifts by the *constant* `h·t` (each of the `h` summands gains `t`); that shift cancels between two competing size-`h` sums, so equal sums downstairs pull back to equal sums upstairs where `A`'s `B_h` property closes the gap. No nonemptiness hypothesis needed. Structurally parallel to `isBhSet_smul` (scale by `c` ↔ shift by `h·t`).
- **`isBhSet_affine`** — affine invariance: `{c·a + t : a ∈ A}` is `B_h` whenever `A` is and `c ≥ 1`. Proved by composing dilation with translation, since `a ↦ c·a+t = (·+t) ∘ (c··)`.

### Significance

Honest scope: this is **structural infrastructure**, not a resolution. The B_h gap-variance conjecture (the actual open problem OQ-03) remains **OPEN**. The contribution is that B_h membership is now shown to depend *only* on the affine geometry of `A` — invariant under position (`t`) and scale (`c`) — which is the invariance underlying the standard reduction of B_h problems to normalized sets starting at 0.

### Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03` — builds clean, 0 sorries, 0 axioms. (One transient SIGBUS on a codegen retry due to host swap pressure; the proof elaborates and builds successfully.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)