### PR TITLE
Fix section line ranges for 4 area-of-circle entries (duplicate-references-key safe)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -154,7 +154,7 @@
       "id": "corollaries",
       "title": "Part V: Corollaries",
       "startLine": 134,
-      "endLine": 159,
+      "endLine": 163,
       "summary": "Even and odd subsequences tend to 0; eventually all volumes < 1",
       "mathContext": "Follow by composition from omega_tendsto_zero"
     }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
@@ -129,7 +129,7 @@
     {
       "id": "definitions",
       "title": "Core Definitions: circleArea and circumference",
-      "startLine": 41,
+      "startLine": 1,
       "endLine": 50,
       "summary": "Defines circleArea(r) = π·r² and circumference(ρ) = 2π·ρ. These are the antiderivative/integrand pair at the heart of the FTC proof: A'(r) = C(r).",
       "mathContext": "$A(r) = \\pi r^2$, $C(\\rho) = 2\\pi\\rho$, $A'(r) = C(r)$. The circumference is the derivative of the area — the fundamental geometric identity that connects the FTC proof to Archimedes' exhaustion."

--- a/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
@@ -71,7 +71,7 @@
     {
       "id": "inscribed-area-def",
       "title": "Inscribed Area Definition",
-      "startLine": 50,
+      "startLine": 1,
       "endLine": 60,
       "summary": "Defines inscribedArea n r = n * r² / 2 * sin(2π/n) — the area of a regular n-gon inscribed in a circle of radius r, obtained by splitting into n isoceles triangles each with vertex angle 2π/n.",
       "mathContext": "$A_n(r) = n \\cdot \\frac{r^2}{2} \\cdot \\sin\\frac{2\\pi}{n}$. For $n=4$: $A_4 = 2r^2$ (square). For $n=6$: $A_6 = 3\\sqrt{3}r^2/2 \\approx 2.598r^2$, vs $\\pi r^2 \\approx 3.14159r^2$. As $n \\to \\infty$: $A_n \\to \\pi r^2$ since $n\\sin(2\\pi/n) \\to 2\\pi$."

--- a/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
@@ -81,7 +81,7 @@
     {
       "id": "sec-fubini-scaled",
       "title": "Section I: Fubini — Square of the Scaled Gaussian as a Double Integral",
-      "startLine": 44,
+      "startLine": 1,
       "endLine": 60,
       "summary": "Proves gaussian_sq_eq_double_integral_scaled: (∫ e^{-a x²})² = ∫∫ e^{-a(x²+y²)}. Uses integrable_exp_neg_mul_sq ha, Integrable.mul_prod, integral_prod, and integral_mul_left/right after factoring exp(-a(x²+y²)) = exp(-a x²)·exp(-a y²). Compiles with 0 sorries.",
       "mathContext": "$(\\int e^{-a x^2} dx)^2 = \\int\\int e^{-a(x^2+y^2)} dx\\, dy$ by Fubini, factoring the exponential."


### PR DESCRIPTION
## Section line-range fix for 4 area-of-circle entries with a duplicate `references` key

Companion to #34758 (same systematic section-coverage defect), split out because these 4 entries have a **pre-existing duplicate `"references"` JSON key**. A normal JSON round-trip would silently drop one of the two `references` blocks, so the section line number here was edited as **raw text** — the duplicate key is preserved byte-for-byte.

| Entry | Change |
|-------|--------|
| `oq-01-oq-02-oq-01-oq-01-oq-01` | last `endLine` 159 → 163 (tail to EOF) |
| `oq-01-oq-02-oq-03` | first `startLine` 41 → 1 |
| `oq-03-oq-01` | first `startLine` 50 → 1 |
| `oq-05-oq-01-incomplete-01` | first `startLine` 44 → 1 |

⚠️ **Flag for separate cleanup:** all 4 files contain a duplicate top-level `"references"` key (only the second survives `JSON.parse`). That data-integrity issue is intentionally **not** addressed here to keep this PR scoped to section coverage. Worth a mechanic/auditor pass.

Meta-only, one line changed per file. Built off `origin/main`.
