### PR TITLE
Research: fourier-series-oq-02-oq-03 — sharp-constant correction (1/2 not sharp; k(1)=4/π²)

### DIFF
--- a/research/problems/fourier-series-oq-02-oq-03-wip-01/knowledge.md
+++ b/research/problems/fourier-series-oq-02-oq-03-wip-01/knowledge.md
@@ -1,0 +1,145 @@
+# Knowledge Base: fourier-series-oq-02-oq-03-wip-01
+
+Sharp constant in the Fourier-coefficient decay bound for Hölder functions on the circle.
+
+---
+
+## Problem Understanding
+
+For `f ∈ C^{0,α}(𝕋_T)` (α-Hölder, seminorm `[f]_α ≤ C`) the Fourier coefficients satisfy
+a decay bound. The **upper bound** with constant `1/2`,
+
+```
+‖ĉ_n(f)‖ ≤ (C/2) · (T / (2|n|))^α ,   n ≠ 0,
+```
+
+is already **fully proven, 0 sorries**, in `proofs/Proofs/FourierSeriesOQ02.lean`
+(`fourierCoeff_holder_decay`, line 242), via the half-period averaging identity
+(`fourierCoeff_difference_formula`, line 127):
+
+```
+2 ĉ_n = (1/T) ∫₀^T (f(x) − f(x + T/(2n))) · e_{-n}(x) dx.
+```
+
+The **stated goal** of this WIP entry is to prove that the constant `1/2` is **sharp**.
+
+---
+
+## ⚠️ KEY FINDING (Session 2026-07-04, s01): the "1/2 is sharp" claim is FALSE
+
+The half-period upper bound chains two inequalities:
+
+1. **(phase)** `‖∫ g · e_{-n}‖ ≤ ∫ ‖g‖`   where `g(x) = f(x) − f(x+h)`, `h = T/(2n)`;
+2. **(saturation)** `(1/T)∫ ‖g‖ ≤ C h^α`   (Hölder bound at shift distance `h`).
+
+For the final constant `1/2` to be attained, **both** must be equalities simultaneously.
+That forces `g(x) = C h^α · e_{+n}(x)` (constant modulus `C h^α`, phase locked to `e_{+n}`).
+The unique periodic solution of `f(x) − f(x+h) = C h^α e_{+n}(x)` is the single sinusoid
+`f(x) = (C h^α / 2) e_{+n}(x)`. But that `f` has **Hölder seminorm strictly larger than `C`**
+(its true α-seminorm is `C · 2^{-α} M(α)` with `M(α) = sup_{u>0} |sin πu|/u^α > 2^{α-1}`),
+so it is **inadmissible**. Hence the two tightness conditions are mutually incompatible for
+any admissible `f`, and `1/2` is **not** attained — and in fact not even approached.
+
+### The correct sharp constant for the Lipschitz case (α = 1): 4/π² ≈ 0.4053
+
+For genuinely Lipschitz `f` (`|f'| ≤ C` a.e.), integration by parts gives the exact identity
+
+```
+ĉ_n(f) = (T/(2πi n)) · ĉ_n(f')          ⟹   ‖ĉ_n(f)‖ = (T/(2π|n|)) · ‖ĉ_n(f')‖.
+```
+
+Maximise `‖ĉ_n(f')‖ = ‖(1/T)∫ f' e_{-n}‖` over `|f'| ≤ C`. This is a **linear functional on the
+L^∞ ball**, so the optimum is a bang-bang extreme point `f'(x) = C · sign(cos(2πnx/T − θ))`
+(a ±C square wave), giving `‖ĉ_n(f')‖ = C · (2/π)` at the aligned phase. Therefore
+
+```
+max ‖ĉ_1(f)‖ = (T/2π)·(2C/π) = C T /π²,     bound value = (C/2)(T/2)^1 = C T /4,
+⟹  sharp ratio k(1) = (C T/π²)/(C T/4) = 4/π² ≈ 0.4053  <  1/2.
+```
+
+The extremizer `f` is the **triangle wave** (antiderivative of the ±1 square wave), i.e. the
+continuous, 1-Lipschitz "tent" function — **not** the discontinuous sawtooth `f(x)=x−T/2` that
+the OQ02OQ03 docstring uses (that sawtooth has a jump at `0`, so it is *not* Lipschitz; its
+α=1 seminorm is `+∞`, and comparing its `1/π` ratio to the bound is comparing apples to oranges).
+
+**Numerical ladder (α = 1, ratio to the `1/2`-bound):**
+- discontinuous sawtooth `x − T/2`: inadmissible (not Lipschitz) — the file's `1/π` figure is spurious;
+- pure sinusoid `e^{2πix/T}`: ratio `1/π ≈ 0.318` (admissible but sub-optimal);
+- **triangle wave (bang-bang optimum): ratio `4/π² ≈ 0.405` = sharp `k(1)`**;
+- naive upper bound: `1/2 = 0.500` (valid, never attained).
+
+So `1/π < 4/π² < 1/2`, and `4/π²` is the sharp Lipschitz constant.
+
+---
+
+## Consequence for the WIP target
+
+The literal completion target — "discharge the sorries establishing that the constant `1/2`
+is sharp" — **asks to prove a false statement** and therefore cannot be completed as written.
+Note `FourierSeriesOQ02OQ03.lean` has **0 real sorries**: its "Section 3: Sharpness" consists
+only of docstrings; no sharpness *theorem* is ever stated, so nothing is currently *claimed* as
+proven. The gallery is not overclaiming, but the roadmap text is wrong.
+
+### Corrected, provable targets (pick one for the ACT phase)
+
+1. **Lower bound / non-sharpness (cleanest first step).** Define the triangle wave `Λ_T` on
+   `AddCircle T`, prove it is `HolderWith 1 1` (Lipschitz const 1), and compute
+   `‖fourierCoeff Λ_T 1‖ = T/π²` exactly. This yields a theorem giving `k(1) ≥ 4/π² > 1/π`,
+   **disproving** the `1/2`-sharpness claim by exhibiting the true extremizer.
+2. **Sharp constant upper bound (harder).** Prove `k(1) ≤ 4/π²` via the L^∞-duality / bang-bang
+   argument (`‖ĉ_n(f)‖ = (T/2π|n|)‖ĉ_n(f')‖` + `‖ĉ_n(f')‖ ≤ (2/π)C`). Needs an integration-by-parts
+   lemma for AbsolutelyContinuous/Lipschitz functions on `AddCircle` and the square-wave L¹→coeff bound.
+3. **Correct the roadmap.** Replace the "1/2 sharp" language in `problem.md` and the
+   `FourierSeriesOQ02OQ03.lean` Section-3 docstrings with the `4/π²` (α=1) result and the general
+   open constant `k(α) < 1/2`.
+
+---
+
+## Dead Ends / Corrections
+
+- **Do NOT** attempt to prove `‖ĉ_n‖ / (C(T/2n)^α) → 1/2`: it is false; the sup is `4/π²` at α=1.
+- **Do NOT** use the discontinuous sawtooth `x−T/2` as the α=1 extremizer: it is not Lipschitz.
+- The **exponent** α (not the constant) is already known sharp: `holder_decay_is_optimal_seq`
+  (OQ02 line 381, proven in `FourierSeriesOQ02OQ04.lean` via a Weierstrass lacunary series).
+
+---
+
+## Mathlib gaps identified
+
+- No packaged **triangle/square-wave** on `AddCircle T` with computed Fourier coefficients.
+- No **integration-by-parts for Lipschitz / AbsolutelyContinuous functions on `AddCircle T`**
+  relating `ĉ_n(f)` to `ĉ_n(f')`. (Mathlib has IBP on intervals; transfer to the circle is the gap.)
+- No **L^∞-ball extremal (bang-bang) lemma** for a linear functional `g ↦ ∫ g·w`.
+
+---
+
+## General α (open)
+
+For `α ∈ (0,1)` the extremizer is no longer a pure square-wave derivative (the constraint is a
+Hölder seminorm, not an `L^∞` bound on `f'`), and the sharp `k(α)` is a genuine extremal constant
+`< 1/2`, interpolating down to `k(1)=4/π²`. Determining `k(α)` in closed form is itself a small
+research question (Favard/Bernstein-type extremal problem) — out of scope for a first completion.
+
+---
+
+## Session Log
+
+### Session 2026-07-04 (s01) — ORIENT — Robb Walters / researcher-8
+
+**Mode**: FRESH (claimed from pool, knowledge score 0)
+**Outcome**: scouted/oriented — MATHEMATICAL CORRECTION, no Lean committed
+
+**What I did**: Read the parent proofs (`FourierSeriesOQ02.lean`, `FourierSeriesOQ02OQ03.lean`,
+`FourierSeriesOQ02OQ04.lean`). Found OQ02 already proves the `1/2` upper bound and exponent-optimality
+(0 sorries). Analyzed the sharpness claim: proved (on paper) that `1/2` is **not** the sharp constant —
+the two tightness conditions in the half-period bound are mutually exclusive for admissible `f`.
+Computed the correct Lipschitz sharp constant `k(1) = 4/π² ≈ 0.405` via integration-by-parts + L^∞
+bang-bang duality, with the **triangle wave** as extremizer. Flagged the file's `1/π`
+sawtooth figure as spurious (non-Lipschitz function).
+
+**Why no Lean**: both verification tools were down this session — Docker build unsafe (host swap 98%,
+SIGBUS risk) and Aristotle MCP returned `Resource not found`. Committing unverified proof bodies would
+risk build-breaking drift, so this is documentation-only ORIENT.
+
+**Next**: implement Corrected Target #1 (triangle-wave lower bound `‖ĉ_1(Λ)‖ = T/π²`) once a build
+path is available; it is self-contained and disproves `1/2`-sharpness by construction.

--- a/research/problems/fourier-series-oq-02-oq-03-wip-01/literature/README.md
+++ b/research/problems/fourier-series-oq-02-oq-03-wip-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for fourier-series-oq-02-oq-03-wip-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/fourier-series-oq-02-oq-03-wip-01/problem.md
+++ b/research/problems/fourier-series-oq-02-oq-03-wip-01/problem.md
@@ -1,0 +1,123 @@
+# Problem: Complete Sharp Constant in Fourier Coefficient Decay Bound
+
+**Slug**: fourier-series-oq-02-oq-03-wip-01
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+|\hat{c}_n(f)| \le \tfrac{1}{2}\, C \left(\frac{T}{2|n|}\right)^{\alpha}, \qquad f \in C^{0,\alpha}(\mathbb{T}),\ n \neq 0,
+$$
+with the constant $1/2$ shown to be sharp via extremal sawtooth functions.
+
+### Plain Language
+
+For a Hölder-continuous periodic function of exponent alpha, the size of its n-th
+Fourier coefficient decays at least like |n|^{-alpha}, with an explicit constant.
+This problem is about pinning down and proving the *sharp* value of that constant
+(1/2) — showing both that the bound holds and that it cannot be improved, using
+extremal (sawtooth-type) functions that nearly attain equality.
+
+### Why This Matters
+
+Sharp constants in Fourier decay bounds are the quantitative core of approximation
+theory and harmonic analysis. Formalizing a sharp constant (not just an order of
+magnitude) exercises Mathlib's integration and Hölder-continuity APIs and yields a
+reusable, precisely-stated lemma.
+
+## Known Results
+
+### What's Already Proven
+
+- The source entry `fourier-series-oq-02-oq-03` proves structural properties of the
+  Fourier coefficients of Hölder functions and states the sharpness claim.
+- Order-of-magnitude decay |ĉ_n| = O(|n|^{-α}) is standard.
+
+### What's Still Open
+
+- The exact/sharp value of the constant and the matching lower bound.
+- The extremal-sawtooth construction certifying sharpness.
+
+### Our Goal
+
+Complete the work-in-progress source proof `fourier-series-oq-02-oq-03`: close the
+remaining `sorry`s establishing the upper bound with constant 1/2 and the extremal
+construction demonstrating the constant cannot be lowered.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| fourier-series-oq-02-oq-03 | Direct parent WIP proof being completed | Fourier coefficients, Hölder bounds |
+| fourier-series | Base Fourier-series formalization | orthogonality, integration |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A**: Integration-by-parts / modulus-of-continuity estimate for the
+   upper bound.
+   - Why it might work: Standard route to the constant via a shift-and-average trick.
+   - Risk: Bounding the Hölder difference integral tightly to get exactly 1/2.
+
+2. **Approach B**: Explicit sawtooth Fourier expansion for the lower bound.
+   - Why it might work: Sawtooth coefficients are computable in closed form.
+   - Risk: Formalizing the limiting extremal family in Lean.
+
+### Key Difficulties
+
+- Getting the *exact* constant rather than an order bound.
+- Formalizing the extremal / near-extremal function family.
+
+### What Would a Proof Need?
+
+- Key lemma 1: The shift-average bound |ĉ_n| ≤ (1/2) C (T/2|n|)^α.
+- Key lemma 2: Sawtooth coefficients realizing (near-)equality.
+- Technical requirements: Mathlib Fourier and interval-integration API.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The upper bound is a bounded, self-contained estimate.
+- The sharpness direction is more delicate but well understood classically.
+- Mathlib has Fourier-coefficient and integration infrastructure.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: days
+- If hard: 1-2 weeks (sharpness side)
+
+## References
+
+### Papers
+- Zygmund, "Trigonometric Series" — Hölder classes and coefficient decay.
+
+### Online Resources
+- Standard harmonic-analysis notes on Fourier decay of Lipschitz/Hölder functions.
+
+### Mathlib
+- `Mathlib.Analysis.Fourier.*` — Fourier coefficients on the circle.
+- `Mathlib.MeasureTheory.Integral.*` — interval integration.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - harmonic-analysis
+  - fourier-series
+  - holder-continuity
+  - sharp-constants
+related_proofs:
+  - fourier-series-oq-02-oq-03
+  - fourier-series
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/fourier-series-oq-02-oq-03-wip-01/state.md
+++ b/research/problems/fourier-series-oq-02-oq-03-wip-01/state.md
@@ -1,0 +1,32 @@
+# Research State: fourier-series-oq-02-oq-03-wip-01
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-07-04T15:07:19-07:00
+**Iteration**: 2
+
+## Current Focus
+Sharp constant in the Hölder Fourier-decay bound. The `1/2` **upper** bound is already
+proven (0 sorries) in `FourierSeriesOQ02.lean`. This session established that the WIP's
+"`1/2` is sharp" goal is **false**: the true Lipschitz sharp constant is `4/π² ≈ 0.405`.
+
+## Active Approach
+Corrected Target #1 — formalize the **triangle-wave** lower bound
+`∃ f, HolderWith 1 1 f ∧ ‖fourierCoeff f 1‖ = T/π²` (⟹ `k(1) ≥ 4/π² > 1/π`),
+disproving the `1/2`-sharpness claim by exhibiting the true extremizer.
+
+## Attempt Count
+- Total attempts: 1 (ORIENT survey + paper analysis)
+- Current approach attempts: 0 (Lean not yet written)
+- Approaches tried: 0
+
+## Blockers
+- **Verification tooling down (session 2026-07-04):** Docker build unsafe (host swap 98%,
+  SIGBUS risk); Aristotle MCP returns `Resource not found`. No Lean can be verified/committed.
+
+## Next Action
+When a build path is available, implement Corrected Target #1 (triangle-wave lower bound).
+It is self-contained: define `Λ` on `AddCircle T`, prove `HolderWith 1 1 Λ`, compute
+`fourierCoeff Λ 1` (either directly, or via `ĉ_1(Λ) = (T/2πi)·ĉ_1(Λ')` with `Λ' = ±1 square wave,
+`ĉ_1(Λ') = 2/π`). See knowledge.md "Corrected, provable targets".

--- a/src/data/research/problems/fourier-series-oq-02-oq-03-wip-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03-wip-01.json
@@ -1,0 +1,71 @@
+{
+  "slug": "fourier-series-oq-02-oq-03-wip-01",
+  "title": "Complete Sharp Constant in Fourier Coefficient Decay Bound",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "|\\hat{c}_n(f)| \\le \\tfrac{1}{2}\\, C \\left(\\frac{T}{2|n|}\\right)^{\\alpha}, \\qquad f \\in C^{0,\\alpha}(\\mathbb{T}),\\ n \\neq 0,",
+    "plain": "For a Hölder-continuous periodic function of exponent alpha, the size of its n-th",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-07-04T15:07:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "CORRECTION: 1/2 upper bound already proven (OQ02, 0 sorries); the WIP goal 1/2-is-sharp is FALSE — true Lipschitz sharp constant is 4/π² (triangle wave). Redirected to provable corrected targets. No Lean committed (verification tools down).",
+    "builtItems": [],
+    "insights": [
+      "The 1/2 constant in ‖ĉ_n‖ ≤ (C/2)(T/2|n|)^α is a CORRECT upper bound but is NOT sharp and is never attained: the phase-alignment and Hölder-saturation equalities in the half-period argument are mutually exclusive for any admissible f.",
+      "Correct sharp constant for the Lipschitz class (α=1) is k(1)=4/π²≈0.4053, realized by the TRIANGLE wave (antiderivative of a ±1 square wave), via IBP ‖ĉ_n(f)‖=(T/2π|n|)‖ĉ_n(f-prime)‖ plus L∞ bang-bang duality ‖ĉ_1(f-prime)‖≤(2/π)C.",
+      "The OQ02OQ03 docstring computes ratio 1/π using the discontinuous sawtooth f(x)=x−T/2, which is NOT Lipschitz (jump at 0 ⟹ infinite α=1 seminorm); that figure is spurious. Admissible ladder: sinusoid 1/π < triangle 4/π² < naive bound 1/2.",
+      "FourierSeriesOQ02.lean already proves the 1/2 upper bound (fourierCoeff_holder_decay) AND exponent-optimality (holder_decay_is_optimal_seq via Weierstrass lacunary series) with 0 sorries; only CONSTANT-sharpness is open, and its stated 1/2 value is wrong."
+    ],
+    "mathlibGaps": [
+      "No triangle/square-wave on AddCircle T with computed Fourier coefficients.",
+      "No integration-by-parts for Lipschitz/AbsolutelyContinuous functions on AddCircle T relating ĉ_n(f) to ĉ_n(f-prime).",
+      "No L∞-ball bang-bang extremal lemma for a linear functional g ↦ ∫ g·w."
+    ],
+    "nextSteps": [
+      "Corrected Target #1: formalize triangle-wave lower bound ∃ f, HolderWith 1 1 f ∧ ‖fourierCoeff f 1‖ = T/π² (⟹ k(1) ≥ 4/π² > 1/π), disproving 1/2-sharpness.",
+      "Corrected Target #2 (harder): prove k(1) ≤ 4/π² via IBP + square-wave duality.",
+      "Corrected Target #3: fix the false 1/2-sharp language in problem.md and FourierSeriesOQ02OQ03.lean Section-3 docstrings; replace with k(1)=4/π², general k(α)<1/2."
+    ],
+    "markdown": "# Knowledge Base: fourier-series-oq-02-oq-03-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "analysis",
+    "harmonic-analysis",
+    "fourier-series",
+    "holder-continuity",
+    "sharp-constants"
+  ],
+  "relatedProofs": [
+    "fourier-series",
+    "fourier-series-oq-02",
+    "fourier-series-oq-02-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-04T22:16:23.695Z",
+  "lastUpdate": "2026-07-04"
+}


### PR DESCRIPTION
## Summary

ORIENT session for `fourier-series-oq-02-oq-03-wip-01` (claimed from the research pool, knowledge score 0). **Documentation only** — no Lean committed (both verification tools were down: Docker build unsafe with host swap at 98%/SIGBUS risk, and the Aristotle MCP returned `Resource not found`).

## Key finding: the "1/2 is sharp" goal is **false**

The WIP goal is to prove the constant `1/2` in `‖ĉ_n(f)‖ ≤ (C/2)·(T/2|n|)^α` (for α-Hölder `f`) is sharp. It isn't.

- The **upper bound** with `1/2` is already **fully proven, 0 sorries**, in `FourierSeriesOQ02.lean` (`fourierCoeff_holder_decay`), via the half-period averaging identity `2ĉ_n = (1/T)∫(f(x)−f(x+T/2n))e_{-n}`.
- That bound chains two inequalities — **phase alignment** (`‖∫g·e_{-n}‖ ≤ ∫‖g‖`) and **Hölder saturation** (`(1/T)∫‖g‖ ≤ C h^α`) — which **cannot both be tight** for any admissible `f`: forcing both makes `f` a single sinusoid whose Hölder seminorm strictly exceeds `C`. So `1/2` is **never attained**.
- The correct **Lipschitz (α=1) sharp constant is `4/π² ≈ 0.405`**, realized by the **triangle wave** (antiderivative of a ±1 square wave), via `‖ĉ_n(f)‖ = (T/2π|n|)‖ĉ_n(f')‖` + L∞ bang-bang duality `‖ĉ_1(f')‖ ≤ (2/π)C`.
- The file's own `1/π` figure is **spurious**: it uses the discontinuous sawtooth `x−T/2`, which is **not** Lipschitz (jump at 0 ⟹ infinite α=1 seminorm). Admissible ladder: sinusoid `1/π ≈ 0.318` < triangle `4/π² ≈ 0.405` < naive bound `1/2`.

`FourierSeriesOQ02OQ03.lean` currently has **0 real sorries** and states no sharpness *theorem* (Section 3 is docstrings only), so the gallery is not overclaiming — but the roadmap text is wrong.

## Redirected, provable targets (for a future ACT session with working tools)

1. **Triangle-wave lower bound** (cleanest): `∃ f, HolderWith 1 1 f ∧ ‖fourierCoeff f 1‖ = T/π²` ⟹ `k(1) ≥ 4/π² > 1/π`, disproving `1/2`-sharpness by construction.
2. `k(1) ≤ 4/π²` via IBP + square-wave duality (needs circle IBP for Lipschitz functions).
3. Correct the `1/2`-sharp language in `problem.md` and the OQ02OQ03 Section-3 docstrings.

## Files
- `research/problems/fourier-series-oq-02-oq-03-wip-01/{knowledge.md,state.md,problem.md,...}`
- `src/data/research/problems/fourier-series-oq-02-oq-03-wip-01.json` (phase→ORIENT, status→surveyed, knowledge enriched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)