### PR TITLE
area-of-circle: add/extend sections over uncovered theorems (6 entries)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -145,8 +145,8 @@
       "id": "thin-shell",
       "title": "Thin Shell Concentration and Summary",
       "startLine": 142,
-      "endLine": 156,
-      "summary": "Proves the thin shell concentration: for $0 < \\varepsilon < 1$, $1 - (1-\\varepsilon)^n \\to 1$ as $n \\to \\infty$. This shows that most volume of a high-dimensional ball lies near its boundary. Concluding summary of all 7 theorems.",
+      "endLine": 195,
+      "summary": "Proves the thin shell concentration: for $0 < \\varepsilon < 1$, $1 - (1-\\varepsilon)^n \\to 1$ as $n \\to \\infty$. This shows that most volume of a high-dimensional ball lies near its boundary. Concluding summary of all 7 theorems. The section closes with `thin_shell_concentration`, the quantitative statement that for large n the ball's mass concentrates in an O(1/√n) shell near the boundary.",
       "mathContext": "$(1-\\varepsilon)^n \\to 0$ since $|1-\\varepsilon| < 1$, so the shell fraction $1 - (1-\\varepsilon)^n \\to 1$."
     }
   ],

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
@@ -141,8 +141,8 @@
       "id": "corollaries",
       "title": "Section VII: Corollaries — Interface for the Isoperimetric Proof",
       "startLine": 673,
-      "endLine": 712,
-      "summary": "reparam_circumference_eq (circumference preserved), reparam_speed_is_L_over_2pi (|γ'(t)| = L/(2π) as sqrt form), arcLength_grows_by_L (s(t+2π)-s(t) = L), arcLength_bijection (bijectivity + continuity packaged together).",
+      "endLine": 724,
+      "summary": "reparam_circumference_eq (circumference preserved), reparam_speed_is_L_over_2pi (|γ'(t)| = L/(2π) as sqrt form), arcLength_grows_by_L (s(t+2π)-s(t) = L), arcLength_bijection (bijectivity + continuity packaged together). Includes `arcLength_bijection`: for a regular closed curve the arc-length map ℝ → ℝ is a homeomorphism (continuous, bijective), the interface fact consumed by the isoperimetric reparametrization.",
       "mathContext": "With constant speed $c = L/(2\\pi)$, the Fourier series of $\\gamma'$ satisfies Parseval's equality in a form equivalent to the Wirtinger inequality $\\|f'\\|^2 \\ge \\|f\\|^2$, yielding the isoperimetric inequality $L^2 \\ge 4\\pi A$."
     }
   ],

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-01/meta.json
@@ -155,6 +155,14 @@
       "startLine": 311,
       "endLine": 329,
       "mathContext": "The bundled result asserts the doubling radical holds for all $n \\ge 1$, $p(6) = 3$, $p(n) < p(2n)$, $p(m) < \\pi$, and $p(m) \\to \\pi$ — Archimedes' method, formalized end to end."
+    },
+    {
+      "id": "two-sided-error-and-summary",
+      "title": "Two-Sided Θ(1/m²) Error and Verified Summary",
+      "startLine": 330,
+      "endLine": 386,
+      "summary": "`pi_sub_halfPerimeter_bounds` packages the upper and lower estimates into the two-sided statement that the doubling-method error `π − p_m` is Θ(1/m²), and `archimedes_doubling_method_verified` is the capstone theorem recording that Archimedes' half-angle doubling method, formalized constructively over the computable nested-radical realization, converges to π with this sharp rate.",
+      "mathContext": "$\\pi - p_m = \\Theta(1/m^2)$ — the inscribed half-perimeter of the $m$-gon under repeated doubling approximates $\\pi$ with error bounded above and below by constant multiples of $1/m^2$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -173,7 +173,7 @@
     {
       "id": "sec-fubini",
       "title": "Section I: Fubini — Square of Gaussian as Double Integral",
-      "startLine": 35,
+      "startLine": 1,
       "endLine": 47,
       "summary": "Proves gaussian_sq_eq_double_integral: (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)}. Uses integral_mul_integral (proved via Integrable instance for exp(-x²)) + simp_rw on exp_add. Compiles with 0 sorries.",
       "mathContext": "$(\\int e^{-x^2} dx)^2 = (\\int e^{-x^2} dx)(\\int e^{-y^2} dy) = \\int\\int e^{-(x^2+y^2)} dx\\, dy$ by Fubini."
@@ -225,6 +225,14 @@
       "endLine": 178,
       "summary": "Explains the geometric meaning: angular factor 2π is the circumference, radial factor 1/2 comes from the exponential substitution, product (1/2)·(2π) = π = area of unit circle.",
       "mathContext": "The Gaussian integral computes $\\iint_{\\mathbb{R}^2} e^{-r^2} r\\, dr\\, d\\theta = (\\int_0^\\infty r e^{-r^2} dr)(\\int_{-\\pi}^\\pi d\\theta) = \\pi$, which is the area of the unit disk."
+    },
+    {
+      "id": "gaussian-via-polar",
+      "title": "Section VIII: Gaussian via Polar Coordinates and the Circumference Connection",
+      "startLine": 179,
+      "endLine": 231,
+      "summary": "The polar-decomposition finale: `gaussian_integral_sq_via_polar` and `gaussian_integral_via_polar` recover ∫ e^{-x²} dx = √π by evaluating the squared integral in polar coordinates, `gaussian_sq_eq_radial_times_angular` exhibits the factorization (∫ e^{-x²})² = (radial 1/2)·(angular 2π), and `angular_integral_is_circumference` identifies the angular factor 2π with the circumference of the unit circle — closing the loop back to the area-of-circle theme.",
+      "mathContext": "$\\left(\\int_{\\mathbb R} e^{-x^2}\\,dx\\right)^2 = \\int_0^\\infty r e^{-r^2}\\,dr \\cdot \\int_0^{2\\pi} d\\theta = \\tfrac12 \\cdot 2\\pi = \\pi$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -101,6 +101,14 @@
       "endLine": 150,
       "summary": "gaussian_density_total_mass (standard density integrates to 1) and integral_gaussian_half (∫ e^{-x²/2} = √(2π)), both via t = 0.",
       "mathContext": "The t = 0 shadows of the two Fourier identities recover normalization of the density and the half-variance Gaussian integral."
+    },
+    {
+      "id": "charfun-fourier-identity",
+      "title": "Part V: Characteristic Function and the Fourier Identity for gaussianReal 0 1",
+      "startLine": 151,
+      "endLine": 218,
+      "summary": "`charFun_stdGaussian` proves the characteristic function of the standard normal N(0,1) is e^{-t²/2} (the Gaussian is its own Fourier transform up to normalization), and `gaussianReal_fourier_identity` transports this to Mathlib's concrete `gaussianReal 0 1` measure. The closing discussion frames these as the analytic input a full central-limit-theorem formalization would consume.",
+      "mathContext": "$\\varphi_X(t) = \\mathbb{E}[e^{itX}] = e^{-t^2/2}$ for $X \\sim \\mathcal N(0,1)$ — the standard normal is a fixed point of the Fourier transform."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/meta.json
@@ -97,6 +97,13 @@
   },
   "sections": [
     {
+      "id": "setup-arcsine-density",
+      "title": "Setup and the Arcsine Density",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Imports and the module docstring, then `arcsineDensity`, the unnormalised arcsine weight x ↦ x^{-1/2}(1−x)^{-1/2} on [0,1], and `hasDerivAt_arcsin_affine`, which shows arcsin(2x−1) is an antiderivative of (a multiple of) that density on (0,1) — the change-of-variables engine for the Beta/Gamma evaluation that follows."
+    },
+    {
       "id": "antiderivative",
       "title": "The Antiderivative arcsin(2x−1)",
       "startLine": 64,
@@ -128,7 +135,7 @@
       "id": "gamma-square",
       "title": "Γ(1/2)² = π and Γ(1/2) = √π",
       "startLine": 172,
-      "endLine": 185,
+      "endLine": 184,
       "summary": "complex_Gamma_half_sq and real_Gamma_half_sq: Γ(1/2)² = π through Complex.Gamma_mul_Gamma_eq_betaIntegral and Γ(1) = 1; real_Gamma_half recovers Γ(1/2) = √π; arcsine_density_normalised gives ∫₀¹ 1/(π√(x(1−x))) = 1."
     }
   ],


### PR DESCRIPTION
## area-of-circle: sections for uncovered theorems (6 entries)

Companion to #34758. Where #34758 handled entries whose uncovered region was pure preamble/`end`, **these 6 entries had real `theorem`/`def` declarations sitting outside any section** — so they get a new (or extended) section with a proper summary, not just a range tweak.

| Entry | Fix |
|-------|-----|
| `oq-01-oq-02-oq-01-oq-03` | extend "Thin Shell Concentration" 156→195 (covers `thin_shell_concentration`) |
| `oq-01-oq-03-oq-01` | extend "Corollaries" 712→724 (covers `arcLength_bijection`) |
| `oq-03-oq-02-oq-01` | **new** section 330–386 — two-sided Θ(1/m²) error + `archimedes_doubling_method_verified` |
| `oq-05-oq-01` | head 35→1 + **new** section 179–231 — Gaussian via polar coords / circumference connection |
| `oq-05-oq-03` | **new** section 151–218 — characteristic function e^{−t²/2} + Fourier identity |
| `oq-07-oq-03-oq-02` | **new** first section 1–63 (arcsine density setup) + clamp last 185→184 |

Edited by splicing **only the `sections` array as text**, so the pre-existing duplicate `"references"` key present in two of these files (`oq-01-oq-02-oq-01-oq-03`, `oq-01-oq-03-oq-01` — flag for cleanup) is preserved byte-for-byte. Meta-only. Built off `origin/main`.
