### PR TITLE
Research: hurwitz-theorem-oq-03-oq-01 — verify commutative subcase of Frobenius Step 3

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -188,6 +188,18 @@ theorem eq_smul_one_of_sq_eq_nonneg_smul (A : Type*) [NormedDivisionRing A]
 
 /-! ### The General (Division Ring) Case -/
 
+/-- **Frobenius Step 3, commutative subcase — fully verified.** If a normed division ring
+`A` over `ℝ` is *commutative*, then it is a normed field, so Gelfand–Mazur
+(`hurwitz_field_case`) pins `finrank ℝ A ∈ {1, 2} ⊆ admissibleDimensions`. This discharges
+the easy half of the case split in `hurwitz_only_if_ring`, leaving only the genuinely
+non-commutative case (the Clifford / Radon–Hurwitz argument) open. No finite-dimensionality
+hypothesis is needed — Gelfand–Mazur supplies it. -/
+theorem hurwitz_only_if_ring_comm (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    (hcomm : ∀ x y : A, x * y = y * x) :
+    Module.finrank ℝ A ∈ admissibleDimensions := by
+  letI : NormedField A := { ‹NormedDivisionRing A› with mul_comm := hcomm }
+  exact hurwitz_field_case A
+
 /-- **Hurwitz Only-If for Normed Division Rings**:
     A finite-dimensional normed division ring over ℝ has finrank in {1, 2, 4, 8}.
 
@@ -225,7 +237,17 @@ theorem hurwitz_only_if_ring (A : Type*) [NormedDivisionRing A] [NormedAlgebra �
        symmetric bilinear form; multiplication then makes `Im A` a Clifford-type space,
        forcing `finrank ℝ (Im A) ∈ {0, 1, 3}` and thus `finrank ℝ A ∈ {1, 2, 4}`.
      Step 3 (the global structure/bilinear-form argument) is not yet formalized; Mathlib
-     lacks the Clifford-algebra / bilinear-form machinery to discharge it directly. -/
-  sorry
+     lacks the Clifford-algebra / bilinear-form machinery to discharge it directly.
+
+     The commutative branch of Step 3 is now fully verified (`hurwitz_only_if_ring_comm`
+     via Gelfand–Mazur), so the sorry below is scoped to the *strictly non-commutative*
+     case — where `hnc : ∃ x y, x * y ≠ y * x` is available as a genuine hypothesis. -/
+  by_cases hcomm : ∀ x y : A, x * y = y * x
+  · -- Commutative subcase: A is a normed field, closed by Gelfand–Mazur.
+    exact hurwitz_only_if_ring_comm A hcomm
+  · -- Non-commutative subcase: the Clifford / Radon–Hurwitz argument (still open).
+    push_neg at hcomm
+    obtain ⟨x, y, _hxy⟩ := hcomm
+    sorry
 
 end HurwitzOnlyIf

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
@@ -1,28 +1,31 @@
 # Research State: hurwitz-theorem-oq-03-oq-01-wip-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04T15:36:57-07:00
-**Iteration**: 2
+**Since**: 2026-07-04
+**Iteration**: 3
 
 ## Current Focus
-Frobenius Step 3 decomposition mapped. Target file HurwitzOnlyIf.lean has one real sorry
-(hurwitz_only_if_ring = Frobenius). Steps 1-2 verified in-file.
+Frobenius Step 3 commutative subcase VERIFIED. HurwitzOnlyIf.lean sorry now scoped
+to the strictly non-commutative case only.
 
 ## Active Approach
-Frobenius: split A = R*1 ⊕ ImA, positive-definite anticommutator bilinear form on ImA,
-finrank ImA in {0,1,3}. Keystone lemma = anticommutator polarization (x*y+y*x in R*1).
+Case split in hurwitz_only_if_ring on commutativity:
+- commutative → hurwitz_only_if_ring_comm (NEW, 0 sorry): promote NormedDivisionRing +
+  mul_comm to NormedField, apply hurwitz_field_case (Gelfand-Mazur). VERIFIED.
+- non-commutative → remaining sorry (Clifford / Radon-Hurwitz, blocked on Mathlib).
 
 ## Attempt Count
-- Total attempts: 0 (code)
-- Approaches tried: 0
+- Total attempts: 1 (code, shipped)
+- Approaches tried: 1
 
 ## Blockers
-- Local Docker build unsafe: host swap 98% full (SIGBUS-135 / host-crash risk).
-- Aristotle MCP down: "Resource not found" on all prove calls (incl. trivial 1+1=2).
+- Non-commutative case genuinely open: needs Clifford-algebra / positive-definite
+  anticommutator bilinear-form machinery not yet in Mathlib.
+- The keystone anticommutator lemma (xy+yx ∈ ℝ·1 for imaginary x,y) is entangled with
+  Im A subspace-closure; not cleanly provable in isolation.
 
 ## Next Action
-When a verification tool returns: (1) commit hurwitz_only_if_ring_comm (provable now via
-Gelfand-Mazur + letI NormedField from commutativity); (2) keystone anticommutator lemma;
-or submit hurwitz_only_if_ring to Aristotle (hint=Frobenius, context=HurwitzOnlyIf.lean).
+Non-commutative case: build the Im A := {a | a² ∈ ℝ≤0·1} subspace-closure lemma, or
+wait for Mathlib Clifford/quadratic-form infra. Aristotle unusable (OPEN, not tactical).

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
@@ -32,8 +32,11 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (no code): single sorry = Frobenius Step 3; Steps 1-2 verified in-file; 5-lemma decomposition mapped; commutative subcase provable now. BLOCKED THIS SESSION on tooling (build swap 98% full + Aristotle MCP down).",
-    "builtItems": [],
+    "progressSummary": "ACT: commutative subcase of Frobenius Step 3 VERIFIED (hurwitz_only_if_ring_comm, 0 sorry, Gelfand-Mazur via NormedField promotion). hurwitz_only_if_ring sorry now scoped to strictly non-commutative case. Non-comm case open (Clifford/Radon-Hurwitz, Mathlib gap).",
+    "builtItems": [
+      "hurwitz_only_if_ring_comm in HurwitzOnlyIf.lean (commutative Frobenius subcase, 0 sorry)",
+      "Case split narrowing hurwitz_only_if_ring sorry to non-commutative case"
+    ],
     "insights": [
       "The target file HurwitzOnlyIf.lean has exactly ONE real sorry (hurwitz_only_if_ring); grep -c=4 is inflated by 3 docstring mentions of the word sorry.",
       "The remaining sorry is precisely Frobenius theorem: NormedDivisionRing is associative so finrank in {1,2,4} (subset of {1,2,4,8}); octonions excluded by associativity.",


### PR DESCRIPTION
## Summary
Advances `HurwitzOnlyIf.lean` (Hurwitz only-if direction: a finite-dim normed
division algebra over ℝ has dim ∈ {1,2,4,8}). The file's single remaining code
sorry was `hurwitz_only_if_ring` — the whole Frobenius Step 3 structure argument.
This session verifies its **commutative branch** and narrows the sorry to the
strictly non-commutative case.

## Progress
- **`hurwitz_only_if_ring_comm`** (NEW, 0 sorry): a commutative `NormedDivisionRing`
  over ℝ is a `NormedField` (promoted via `mul_comm`), so Gelfand–Mazur
  (`hurwitz_field_case`) forces `finrank ∈ {1,2} ⊆ admissibleDimensions`.
- **`hurwitz_only_if_ring`**: now case-splits on commutativity. The commutative
  branch is fully discharged; the sorry is scoped to the non-commutative case,
  where `∃ x y, x*y ≠ y*x` is available.

## Findings
- The commutative subcase is exactly the Gelfand–Mazur / normed-field case; the
  only work is the instance promotion `{ ‹NormedDivisionRing A› with mul_comm }`.
- The keystone anticommutator lemma (`xy+yx ∈ ℝ·1` for imaginary `x,y`) is
  entangled with `Im A` subspace-closure, so it is not cleanly provable in
  isolation — that is where the real difficulty of Step 3 lives.

## Status
**Outcome**: progress (1 new verified lemma; open sorry narrowed, not eliminated)
**Non-commutative case remains OPEN**: needs Clifford-algebra / positive-definite
anticommutator bilinear-form machinery not yet in Mathlib.
**Verification**: `docker-build Proofs.HurwitzOnlyIf` → 2715 jobs, exit 0
(1 sorry: the non-commutative case). 0 axioms.
**Next Steps**: build the `Im A := {a | a² ∈ ℝ≤0·1}` subspace-closure lemma, or
await Mathlib Clifford/quadratic-form infrastructure.

🤖 Generated by researcher-11