### PR TITLE
Research: erdos-3 — trivial Roth-number lower bound (0-axiom)

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -266,6 +266,53 @@ theorem arithProg_card (a d k : ℕ) (hd : 0 < d) :
   unfold ArithProg
   rw [Finset.card_image_of_injective _ hinj, Finset.card_range]
 
+/-- **Sets too small to contain a `k`-AP are vacuously `k`-AP-free.**
+    Any finite set `S` with fewer than `k` elements avoids `k`-term arithmetic
+    progressions: a genuine `k`-AP (positive common difference) has exactly `k`
+    distinct elements (`arithProg_card`), so it cannot fit inside a set of size
+    `< k`. This is the structural fact behind the trivial lower bound on the Roth
+    number (`rothNumber_ge_min`): below cardinality `k` the AP-freeness constraint
+    is empty. Fully machine-checked, axiom-free. -/
+theorem isAPFree_of_card_lt {S : Finset ℕ} {k : ℕ} (h : S.card < k) :
+    IsAPFree (↑S : Set ℕ) k := by
+  intro hAP
+  obtain ⟨a, d, hd, hsub⟩ := hAP
+  rw [Finset.coe_subset] at hsub
+  have hcard := Finset.card_le_card hsub
+  rw [arithProg_card a d k hd] at hcard
+  omega
+
+/-- **The trivial lower bound on the Roth number.**
+    `min (k - 1) (N + 1) ≤ r_k(N)`. The initial segment `{0, …, min(k-1,N+1)-1}`
+    fits inside the window `{0,…,N}` and has fewer than `k` elements, so it is
+    `k`-AP-free (`isAPFree_of_card_lt`) and enters the family `r_k(N)` maximises
+    over. Together with `rothNumber_le_window` (`r_k(N) ≤ N + 1`) this brackets the
+    Roth number as `min(k-1, N+1) ≤ r_k(N) ≤ N + 1`; in particular `r_k(N) ≥ k - 1`
+    once `N ≥ k - 1`, so all of the `o(N/log N)` content of Erdős #3 lives at large
+    `N` — there is never a sub-constant floor to exploit. Fully machine-checked,
+    axiom-free. -/
+theorem rothNumber_ge_min {k N : ℕ} : min (k - 1) (N + 1) ≤ rothNumber k N := by
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    have hz : min (0 - 1) (N + 1) = 0 := by omega
+    rw [hz]; exact Nat.zero_le _
+  set m := min (k - 1) (N + 1) with hm
+  have hmN : m ≤ N + 1 := min_le_right _ _
+  have hmk : m < k := lt_of_le_of_lt (min_le_left _ _) (by omega)
+  have hsub : Finset.range m ⊆ Finset.range (N + 1) := by
+    intro x hx
+    rw [Finset.mem_range] at hx ⊢
+    omega
+  have hmem : Finset.range m ∈
+      ((Finset.range (N + 1)).powerset.filter
+        (fun S : Finset ℕ => IsAPFree (↑S : Set ℕ) k)) := by
+    rw [Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨hsub, ?_⟩
+    apply isAPFree_of_card_lt
+    rw [Finset.card_range]; exact hmk
+  calc m = (Finset.range m).card := (Finset.card_range m).symm
+    _ ≤ rothNumber k N := by unfold rothNumber; exact Finset.le_sup hmem
+
 /-- **Only infinite sets contain arbitrarily long APs.**
     If `A` contains a `k`-term arithmetic progression (with positive common
     difference) for every `k`, then `A` is infinite.  Indeed, were `A` finite with

--- a/research/problems/erdos-3-incomplete-01/knowledge.md
+++ b/research/problems/erdos-3-incomplete-01/knowledge.md
@@ -99,6 +99,31 @@ Leng–Sah–Sawhney 2024) are far from even `o(N/log N)`, let alone the
 - 1 axiom: `euler_prime_sum_diverges` (Euler 1737; deep, kept).
 - 1 sorry: `required_bound_implies_conjecture` (threshold-critical; open).
 
+---
+
+## ADDENDUM (2026-07-04, attempt 3): trivial lower bound on the Roth number
+
+The file already had `rothNumber_le_window : r_k(N) ≤ N + 1` (the whole window is
+the crudest AP-free-agnostic ceiling) but **no matching lower bound**. Added two
+axiom-free, `sorry`-free lemmas (verified, 7743 jobs):
+
+- **`isAPFree_of_card_lt {S : Finset ℕ} (h : S.card < k) : IsAPFree ↑S k`** — a
+  set smaller than `k` cannot contain a genuine `k`-AP, since such an AP has
+  exactly `k` distinct elements (`arithProg_card`, needs `d > 0`). Proof:
+  `↑(ArithProg a d k) ⊆ ↑S` ⟹ (via `Finset.coe_subset`, `card_le_card`)
+  `k = (ArithProg a d k).card ≤ S.card < k`, `omega`.
+- **`rothNumber_ge_min : min (k-1) (N+1) ≤ r_k(N)`** — take `S = range (min (k-1)
+  (N+1))`: it fits in `range (N+1)` and has `< k` elements, so it is AP-free
+  (`isAPFree_of_card_lt`) and lies in the family `rothNumber` sups over; then
+  `Finset.le_sup`. `k = 0` handled separately (`min (0-1)(N+1) = 0`, omega).
+
+**Consequence.** `min(k-1, N+1) ≤ r_k(N) ≤ N+1`. For `N ≥ k-1` this is
+`k-1 ≤ r_k(N) ≤ N+1`: the Roth number has a constant floor `k-1` (the AP-freeness
+constraint is vacuous below cardinality `k`), so the entire `o(N/log N)` content
+of Erdős #3 is an asymptotic statement at large `N`. No sub-constant floor exists
+to exploit. This is the natural companion to `rothNumber_le_window` and completes
+the elementary bracketing of `r_k(N)`.
+
 ## Status
 
 PROGRESS. Delivered this session: (1) repaired a non-compiling file (bitrot);

--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -1,26 +1,36 @@
 # State: erdos-3-incomplete-01
 
-**Phase**: ACT (verified reduction landed)
+**Phase**: ACT (Roth-number lower bound landed)
 **Since**: 2026-07-04
-**Attempts**: 2
+**Attempts**: 3
 **Status**: progress
 
 ## Current Focus
 
-The `(log N)^{1+δ}` threshold reduction for Erdős #3, now machine-verified.
+Structural lower bound on the Roth number, bracketing it with the existing
+upper bound. Formalizes the "trivial regime" of Erdős #3.
 
-## Result this iteration
+## Result this iteration (attempt 3)
 
-1. **Bitrot repair.** `Proofs/Erdos3Problem.lean` did not compile on `main`
-   (enrichment merged without a build): `ArithProg` used `Finset.map` with a
-   false `omega` injectivity proof; filters over `Set` membership lacked
-   `Decidable` instances; three orphaned `/--` docstrings. Fixed → builds
-   cleanly (7743 jobs).
+Two axiom-free, `sorry`-free lemmas added (build: 7743 jobs, verified):
+
+1. **`isAPFree_of_card_lt`** — any finite `S` with `S.card < k` is vacuously
+   `k`-AP-free: a genuine `k`-AP has exactly `k` distinct elements
+   (`arithProg_card`), so cannot fit in a smaller set. Reusable structural fact.
+2. **`rothNumber_ge_min`** — `min (k-1) (N+1) ≤ r_k(N)`: the initial segment
+   `{0,…,min(k-1,N+1)-1}` is AP-free and enters the family `r_k(N)` maximises
+   over. Together with the existing `rothNumber_le_window` (`r_k(N) ≤ N+1`) this
+   *brackets* the Roth number: `min(k-1,N+1) ≤ r_k(N) ≤ N+1`. In particular
+   `r_k(N) ≥ k-1` for `N ≥ k-1`, so all of the `o(N/log N)` content lives at
+   large `N` — there is never a sub-constant floor to exploit.
+
+## Prior results (attempts 1–2)
+
+1. **Bitrot repair.** Non-compiling file fixed (`ArithProg` via `image`,
+   `Decidable` instances, docstrings).
 2. **0-axiom reduction proved.** `strong_required_bound_implies_conjecture`:
-   `(∀ k≥3, StrongRequiredBound k) → Erdos3Conjecture`, `sorry`-free and
-   axiom-free, via dyadic blocking + convergent p-series
-   (`summable_of_strongBound`) and the bridge lemma. Plus `containsAP_of_le`
-   (length monotonicity). See knowledge.md for the full argument.
+   `(∀ k≥3, StrongRequiredBound k) → Erdos3Conjecture`, via dyadic blocking +
+   convergent p-series (`summable_of_strongBound`). See knowledge.md.
 
 ## Blockers
 
@@ -31,13 +41,16 @@ The `(log N)^{1+δ}` threshold reduction for Erdős #3, now machine-verified.
 
 ## Next Action
 
-Leave the threshold-critical sorry documented. Optional shallow follow-ups:
-a `k ≤ 2` triviality corollary, or reusing `summable_of_strongBound` as a
-density→convergence lemma elsewhere. The environment recipe (external worktree,
-`LEAN_SKIP_CACHE=true`, 16 GB) is proven to work for this file.
+Leave the threshold-critical sorry documented. Remaining shallow follow-ups
+(optional): expose `summable_of_strongBound` as a reusable density→convergence
+lemma elsewhere, or a small-`k` triviality (`ContainsAP A 0` always;
+`ContainsAP A 1 ↔ A.Nonempty`). The environment recipe (external worktree,
+`LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true`) is proven to work for this file.
 
 ## Attempts
 
 - 1: threshold analysis + StrongBound design (verification deferred — no build).
 - 2: repaired non-compiling file; compiled & verified the StrongBound reduction
   (0-axiom, 7743 jobs); memory bump to 16 GB needed (transient SIGBUS at 8 GB).
+- 3: added `isAPFree_of_card_lt` + `rothNumber_ge_min` (trivial Roth lower
+  bound, brackets `rothNumber_le_window`); 0-axiom, 0-sorry, 7743 jobs verified.


### PR DESCRIPTION
## Summary

Adds the missing **lower bound** on the Roth number `r_k(N)` in
`proofs/Proofs/Erdos3Problem.lean` (Erdős Problem #3). The file already had an
upper bound (`rothNumber_le_window : r_k(N) ≤ N + 1`) but nothing below; this PR
supplies the matching lower bound, bracketing `r_k(N)`.

Two new lemmas, both **0-axiom** and **sorry-free** (Docker build verified, 7743 jobs):

- **`isAPFree_of_card_lt {S : Finset ℕ} (h : S.card < k) : IsAPFree ↑S k`** — a
  finite set smaller than `k` is vacuously `k`-AP-free: a genuine `k`-AP (with
  `d > 0`) has exactly `k` distinct elements (`arithProg_card`), so it cannot fit
  inside a set of size `< k`. A reusable structural fact.
- **`rothNumber_ge_min : min (k - 1) (N + 1) ≤ r_k(N)`** — the initial segment
  `{0, …, min(k-1,N+1)-1}` fits in the window `{0,…,N}` and has `< k` elements,
  hence is AP-free and enters the family `r_k(N)` maximises over (`Finset.le_sup`).

## Why it matters

Combined with `rothNumber_le_window` this brackets the Roth number:

```
min(k-1, N+1)  ≤  r_k(N)  ≤  N + 1
```

so `r_k(N) ≥ k - 1` for `N ≥ k - 1`. The AP-freeness constraint is *vacuous*
below cardinality `k`, which means the entire `o(N/log N)` content of Erdős #3
is a genuinely asymptotic statement at large `N` — there is no sub-constant floor
to exploit. This is the natural companion to the existing upper bound and
completes the elementary bracketing of `r_k(N)`.

## Verification

- `LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.Erdos3Problem`
  → **Build succeeded (7743 jobs)**.
- No new axioms, no new sorries. The only warnings are pre-existing (the
  intentional threshold-critical `sorry` in `required_bound_implies_conjecture`
  and an unrelated Mathlib deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)