### PR TITLE
Research: hurwitz-oq-03-oq-01 — commutative subcase proved (0-sorry)

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -188,6 +188,23 @@ theorem eq_smul_one_of_sq_eq_nonneg_smul (A : Type*) [NormedDivisionRing A]
 
 /-! ### The General (Division Ring) Case -/
 
+/-- **Hurwitz Only-If, commutative subcase (fully proved, 0 sorries).**
+    A finite-dimensional normed division ring over `ℝ` that is *commutative* has finrank in
+    `{1, 2, 4, 8}` — in fact in `{1, 2}`. A commutative normed division ring is a normed
+    field, so this is exactly `hurwitz_field_case` (Gelfand-Mazur); the only work is
+    promoting the `NormedDivisionRing` instance to a `NormedField` by supplying `mul_comm`
+    (every other field is shared, and the underlying ring data is unchanged, so the ambient
+    `NormedAlgebra ℝ A` still applies).
+
+    This isolates the commutative half of `hurwitz_only_if_ring` as an unconditional theorem:
+    the remaining `sorry` there is entirely the *non-commutative* Frobenius/Clifford content
+    (`finrank ∈ {4}` for the quaternions), never the field case. -/
+theorem hurwitz_only_if_ring_comm (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    (hcomm : ∀ x y : A, x * y = y * x) :
+    Module.finrank ℝ A ∈ admissibleDimensions := by
+  letI : NormedField A := { (inferInstance : NormedDivisionRing A) with mul_comm := hcomm }
+  exact hurwitz_field_case A
+
 /-- **Hurwitz Only-If for Normed Division Rings**:
     A finite-dimensional normed division ring over ℝ has finrank in {1, 2, 4, 8}.
 

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
@@ -1,28 +1,39 @@
 # Research State: hurwitz-theorem-oq-03-oq-01-wip-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT (commutative subcase landed)
 **Path**: full
 **Since**: 2026-07-04T15:36:57-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Frobenius Step 3 decomposition mapped. Target file HurwitzOnlyIf.lean has one real sorry
-(hurwitz_only_if_ring = Frobenius). Steps 1-2 verified in-file.
+`hurwitz_only_if_ring_comm` now proved (0 sorries). The one remaining sorry
+(`hurwitz_only_if_ring`, Step 3) is purely the non-commutative Frobenius/Clifford
+content — the commutative half is now an unconditional theorem.
 
 ## Active Approach
 Frobenius: split A = R*1 ⊕ ImA, positive-definite anticommutator bilinear form on ImA,
 finrank ImA in {0,1,3}. Keystone lemma = anticommutator polarization (x*y+y*x in R*1).
 
 ## Attempt Count
-- Total attempts: 0 (code)
-- Approaches tried: 0
+- Total attempts: 1 (code)
+- Approaches tried: 1 (commutative reduction via NormedField instance promotion)
+
+## Result this iteration (attempt 1)
+**`hurwitz_only_if_ring_comm`** — a commutative finite-dim normed division ring over ℝ
+has finrank ∈ {1,2,4,8}. Proof: promote `NormedDivisionRing A` to `NormedField A` via
+`letI := { inferInstance with mul_comm := hcomm }` (all other fields shared, ring data
+unchanged so ambient `NormedAlgebra ℝ A` still applies), then apply `hurwitz_field_case`
+(Gelfand-Mazur). Docker build verified (2715 jobs, HurwitzOnlyIf).
 
 ## Blockers
-- Local Docker build unsafe: host swap 98% full (SIGBUS-135 / host-crash risk).
-- Aristotle MCP down: "Resource not found" on all prove calls (incl. trivial 1+1=2).
+- Aristotle MCP was down earlier ("Resource not found"); recheck before submitting the
+  hard sorry.
+- Host swap ~98% full — but incremental single-file Docker builds (~5s) succeed; keep an
+  eye on `vm.swapusage` before each build.
 
 ## Next Action
-When a verification tool returns: (1) commit hurwitz_only_if_ring_comm (provable now via
-Gelfand-Mazur + letI NormedField from commutativity); (2) keystone anticommutator lemma;
-or submit hurwitz_only_if_ring to Aristotle (hint=Frobenius, context=HurwitzOnlyIf.lean).
+Remaining sorry is the non-commutative Frobenius Step 3 (Clifford structure on Im A) —
+genuinely out of scope here. Options: (1) keystone anticommutator lemma
+`x*y + y*x ∈ ℝ•1` for imaginary x,y; or (2) submit `hurwitz_only_if_ring` to Aristotle
+(hint=Frobenius, context=HurwitzOnlyIf.lean) once the MCP is back.


### PR DESCRIPTION
## Summary

Proves the **commutative subcase** of the Hurwitz only-if theorem in
`proofs/Proofs/HurwitzOnlyIf.lean`, as an unconditional (0-sorry) theorem.

New theorem:

- **`hurwitz_only_if_ring_comm`** — a finite-dimensional *commutative*
  `NormedDivisionRing` over `ℝ` has `finrank ℝ A ∈ {1, 2, 4, 8}` (in fact `{1, 2}`).

## Proof

A commutative normed division ring is a normed field, so the result is exactly the
already-proven `hurwitz_field_case` (Gelfand-Mazur). The only work is promoting the
`NormedDivisionRing A` instance to a `NormedField A`:

```lean
letI : NormedField A := { (inferInstance : NormedDivisionRing A) with mul_comm := hcomm }
exact hurwitz_field_case A
```

`NormedField` and `NormedDivisionRing` share every field except `mul_comm`, and the
underlying ring data is unchanged, so the ambient `NormedAlgebra ℝ A` instance still
applies.

## Why it matters

This isolates the commutative half of `hurwitz_only_if_ring` as a fully verified
theorem. The single remaining `sorry` in that file is therefore entirely the
*non-commutative* Frobenius/Clifford content (the quaternion case, `finrank = 4`) —
never the field case. It sharpens exactly where the remaining difficulty lives.

## Verification

- `LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.HurwitzOnlyIf`
  → **Build succeeded (2715 jobs)**.
- No new axioms, no new sorries. The only warning is the pre-existing, out-of-scope
  non-commutative `sorry` in `hurwitz_only_if_ring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)