### PR TITLE
Research(erdos-3): unconditional low-length regime (k ≤ 2), 0-axiom

### DIFF
--- a/proofs/Proofs/Erdos3Problem.lean
+++ b/proofs/Proofs/Erdos3Problem.lean
@@ -336,6 +336,74 @@ theorem infinite_of_containsArbitrarilyLongAP {A : Set ℕ}
   rw [arithProg_card a d _ hd] at hcard
   omega
 
+/- ## The unconditional low-length regime (`k ≤ 2`)
+
+   Erdős #3 is only *open* for progressions of length `k ≥ 3`. Its conclusion at
+   lengths `k ≤ 2` is a triviality that holds for *any* set with divergent
+   reciprocal sum, with no Roth-type input whatsoever. The lemmas below make this
+   boundary explicit: a divergent reciprocal sum forces infinitude
+   (`infinite_of_hasDivergentSum` — the hypothesis-side companion promised in the
+   `infinite_of_containsArbitrarilyLongAP` docstring), and an infinite set contains
+   a genuine `2`-term progression (`containsAP_two_of_infinite`). Combining them,
+   `hasDivergentSum_containsAP_le_two` proves Erdős #3 verbatim for every `k ≤ 2`.
+   This pins the difficulty of the conjecture entirely at `k ≥ 3`, matching the
+   Roth-number floor `k - 1` (`rothNumber_ge_min`): below length `3` there is no
+   arithmetic content to exploit on either side of the implication. -/
+
+/-- **Divergent reciprocal sum forces infinitude.**
+    If `∑_{a ∈ A} 1/a` diverges then `A` is infinite: a finite set carries a
+    finite (hence summable) reciprocal sum. This is the hypothesis-side companion
+    to `infinite_of_containsArbitrarilyLongAP`; together they confirm both sides of
+    Erdős #3 can only be nontrivial for infinite `A`. Elementary, `sorry`-free and
+    axiom-free. -/
+theorem infinite_of_hasDivergentSum {A : Set ℕ} (h : HasDivergentSum A) :
+    A.Infinite := by
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  have : Fintype ↥A := hfin.fintype
+  exact h (hasSum_fintype (fun n : A => (1 : ℝ) / n)).summable
+
+/-- **Two ordered elements yield a `2`-term progression.**
+    If `a, b ∈ A` with `a < b`, then `{a, b} = ArithProg a (b - a) 2` is a genuine
+    `2`-AP (common difference `b - a > 0`) inside `A`. The elementary building block
+    of the low-length regime. -/
+theorem containsAP_two_of_lt {A : Set ℕ} {a b : ℕ}
+    (ha : a ∈ A) (hb : b ∈ A) (hab : a < b) : ContainsAP A 2 := by
+  refine ⟨a, b - a, by omega, ?_⟩
+  intro x hx
+  rw [Finset.mem_coe, ArithProg, Finset.mem_image] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range] at hi
+  interval_cases i
+  · simpa using ha
+  · have hb' : a + 1 * (b - a) = b := by omega
+    rw [hb']; exact hb
+
+/-- **Every infinite set contains a `2`-term progression.**
+    An infinite `A ⊆ ℕ` has two distinct elements; the smaller and larger form a
+    genuine `2`-AP (`containsAP_two_of_lt`). `sorry`-free, axiom-free. -/
+theorem containsAP_two_of_infinite {A : Set ℕ} (h : A.Infinite) :
+    ContainsAP A 2 := by
+  obtain ⟨a, ha⟩ := h.nonempty
+  obtain ⟨b, hb⟩ := (h.diff (Set.finite_singleton a)).nonempty
+  rw [Set.mem_diff, Set.mem_singleton_iff] at hb
+  obtain ⟨hbA, hbne⟩ := hb
+  rcases lt_trichotomy a b with hlt | heq | hgt
+  · exact containsAP_two_of_lt ha hbA hlt
+  · exact absurd heq.symm hbne
+  · exact containsAP_two_of_lt hbA ha hgt
+
+/-- **Erdős #3 holds unconditionally for `k ≤ 2`.**
+    Any set with divergent reciprocal sum contains a `k`-term arithmetic
+    progression for every `k ≤ 2` — no Roth-type bound required. Proof: such a set
+    is infinite (`infinite_of_hasDivergentSum`), hence contains a `2`-AP
+    (`containsAP_two_of_infinite`), which downward-closes to all `k ≤ 2`
+    (`containsAP_of_le`). This is exactly the portion of the conjecture that is not
+    open: the content lives entirely at `k ≥ 3`. `sorry`-free, axiom-free. -/
+theorem hasDivergentSum_containsAP_le_two {A : Set ℕ} (h : HasDivergentSum A)
+    {k : ℕ} (hk : k ≤ 2) : ContainsAP A k :=
+  containsAP_of_le hk (containsAP_two_of_infinite (infinite_of_hasDivergentSum h))
+
 /-- **Analytic core of the reduction.**
     If the counting function of `A` obeys `f_A(N) ≤ C · N / (log N)^{1+δ}` for all
     large `N` (`δ > 0`), then `∑_{a ∈ A} 1/a` converges. Proof by dyadic blocking:

--- a/research/problems/erdos-3-incomplete-01/knowledge.md
+++ b/research/problems/erdos-3-incomplete-01/knowledge.md
@@ -94,8 +94,12 @@ Leng–Sah–Sawhney 2024) are far from even `o(N/log N)`, let alone the
   `countingFunction`, `SublogarithmicGrowth`, `Erdos3Conjecture`,
   `RequiredBound`, `StrongRequiredBound`.
 - Proved (0 new axioms): `countingFunction_le_rothNumber`, `containsAP_of_le`,
-  `summable_of_strongBound`, `strong_required_bound_implies_conjecture`,
-  `erdos3_implies_green_tao`, `erdos_3_open`.
+  `isAPFree_of_card_lt`, `rothNumber_ge_min`, `arithProg_card`,
+  `infinite_of_containsArbitrarilyLongAP`, `infinite_of_hasDivergentSum`,
+  `containsAP_two_of_lt`, `containsAP_two_of_infinite`,
+  `hasDivergentSum_containsAP_le_two`, `summable_of_strongBound`,
+  `strong_required_bound_implies_conjecture`, `erdos3_implies_green_tao`,
+  `erdos_3_open`.
 - 1 axiom: `euler_prime_sum_diverges` (Euler 1737; deep, kept).
 - 1 sorry: `required_bound_implies_conjecture` (threshold-critical; open).
 
@@ -124,6 +128,35 @@ of Erdős #3 is an asymptotic statement at large `N`. No sub-constant floor exis
 to exploit. This is the natural companion to `rothNumber_le_window` and completes
 the elementary bracketing of `r_k(N)`.
 
+## ADDENDUM (2026-07-04, attempt 4): the unconditional low-length regime (`k ≤ 2`)
+
+The conjecture's *conclusion* is a triviality for progressions of length `k ≤ 2`,
+holding for any divergent-sum set with **no Roth-type input**. Four axiom-free,
+`sorry`-free lemmas added (verified, 7743 jobs):
+
+- **`infinite_of_hasDivergentSum : HasDivergentSum A → A.Infinite`** — a finite
+  `A` gives `Fintype ↥A` (`Set.Finite.fintype`), and `hasSum_fintype` makes the
+  reciprocal sum summable, contradicting divergence. This fills the
+  hypothesis-side gap the `infinite_of_containsArbitrarilyLongAP` docstring
+  already *claimed* ("`HasDivergentSum` likewise forces infinitude") but never
+  proved.
+- **`containsAP_two_of_lt {a b} (ha : a∈A)(hb : b∈A)(hab : a<b) : ContainsAP A 2`**
+  — `{a,b} = ↑(ArithProg a (b-a) 2)` with `b-a > 0`. Proof unfolds the image over
+  `range 2` and does `interval_cases i` (i=0 ↦ a, i=1 ↦ `a+1·(b-a)=b` by omega).
+- **`containsAP_two_of_infinite : A.Infinite → ContainsAP A 2`** — `h.nonempty`
+  gives `a`; `(h.diff (finite_singleton a)).nonempty` gives `b ≠ a`;
+  `lt_trichotomy` + `containsAP_two_of_lt`.
+- **`hasDivergentSum_containsAP_le_two : HasDivergentSum A → ∀ k ≤ 2, ContainsAP A k`**
+  — `containsAP_of_le` downward-closes the 2-AP. **This is Erdős #3 proved
+  verbatim and unconditionally for every `k ≤ 2`.**
+
+**Significance (honest).** Elementary — none of this is close to the open
+content. Its value is *delineation*: it certifies in Lean that the difficulty of
+Erdős #3 lives entirely at `k ≥ 3`, the exact regime where the Roth number first
+acquires nontrivial content (`rothNumber_ge_min`: floor `k-1`). Completes the
+elementary bracketing of the problem on the AP-length axis, complementing the
+Roth-number bracketing of attempt 3.
+
 ## Status
 
 PROGRESS. Delivered this session: (1) repaired a non-compiling file (bitrot);
@@ -136,6 +169,7 @@ threshold-critical (as hard as Erdős #3).
 
 - The remaining `sorry` should NOT be attacked directly — it is as hard as
   Erdős #3. Leave it documented.
-- Possible follow-ups (shallow, optional): a `k ≤ 2` corollary that any infinite
-  set trivially contains 2-APs; or expose `summable_of_strongBound` as a reusable
+- DONE (attempt 4): the `k ≤ 2` corollary — an infinite / divergent-sum set
+  trivially contains 2-APs (`hasDivergentSum_containsAP_le_two`).
+- Only remaining shallow follow-up: expose `summable_of_strongBound` as a reusable
   density→convergence lemma for other reciprocal-sum problems.

--- a/research/problems/erdos-3-incomplete-01/state.md
+++ b/research/problems/erdos-3-incomplete-01/state.md
@@ -1,16 +1,38 @@
 # State: erdos-3-incomplete-01
 
-**Phase**: ACT (Roth-number lower bound landed)
+**Phase**: ACT (low-length regime landed)
 **Since**: 2026-07-04
-**Attempts**: 3
+**Attempts**: 4
 **Status**: progress
 
 ## Current Focus
 
-Structural lower bound on the Roth number, bracketing it with the existing
-upper bound. Formalizes the "trivial regime" of Erdős #3.
+Elementary boundary results delineating where Erdős #3 is genuinely open
+(`k ≥ 3`) from where its conclusion is a triviality (`k ≤ 2`).
 
-## Result this iteration (attempt 3)
+## Result this iteration (attempt 4)
+
+Four axiom-free, `sorry`-free lemmas added (build: 7743 jobs, verified) — the
+**unconditional low-length regime** `k ≤ 2`:
+
+1. **`infinite_of_hasDivergentSum`** — `HasDivergentSum A → A.Infinite`
+   (contrapositive: a finite set has a `Fintype`-summable reciprocal sum via
+   `hasSum_fintype`). This is the *hypothesis-side* companion explicitly promised
+   in the `infinite_of_containsArbitrarilyLongAP` docstring but previously absent.
+2. **`containsAP_two_of_lt`** — `a,b ∈ A`, `a < b` ⟹ `ContainsAP A 2`
+   (`{a,b} = ArithProg a (b-a) 2`, common difference `b-a > 0`).
+3. **`containsAP_two_of_infinite`** — an infinite `A ⊆ ℕ` has two distinct
+   elements (`h.diff (finite_singleton a)` nonempty), hence a genuine 2-AP.
+4. **`hasDivergentSum_containsAP_le_two`** — the payoff: `HasDivergentSum A →
+   ∀ k ≤ 2, ContainsAP A k` (via `containsAP_of_le`). This is Erdős #3 proved
+   *verbatim and unconditionally* on the low-length regime — no Roth bound. The
+   entire open content of the conjecture lives at `k ≥ 3`, matching the Roth
+   floor `k-1` (`rothNumber_ge_min`): below length 3 there is no arithmetic
+   content on either side of the implication.
+
+## Result attempt 3
+
+Two axiom-free, `sorry`-free lemmas added (build: 7743 jobs, verified):
 
 Two axiom-free, `sorry`-free lemmas added (build: 7743 jobs, verified):
 
@@ -41,10 +63,13 @@ Two axiom-free, `sorry`-free lemmas added (build: 7743 jobs, verified):
 
 ## Next Action
 
-Leave the threshold-critical sorry documented. Remaining shallow follow-ups
-(optional): expose `summable_of_strongBound` as a reusable density→convergence
-lemma elsewhere, or a small-`k` triviality (`ContainsAP A 0` always;
-`ContainsAP A 1 ↔ A.Nonempty`). The environment recipe (external worktree,
+Leave the threshold-critical sorry documented. The elementary bracketing is now
+complete on both axes: Roth number (`rothNumber_ge_min`/`_le_window`) and AP
+length (`hasDivergentSum_containsAP_le_two` for `k ≤ 2`). Only remaining shallow
+follow-up: expose `summable_of_strongBound` as a reusable density→convergence
+lemma elsewhere. The environment recipe (external `/tmp` worktree — the managed
+`.loom/worktrees/researcher-5` was hard-reset AND deleted mid-session by the
+daemon; commit in `/tmp` immediately —
 `LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true`) is proven to work for this file.
 
 ## Attempts
@@ -54,3 +79,6 @@ lemma elsewhere, or a small-`k` triviality (`ContainsAP A 0` always;
   (0-axiom, 7743 jobs); memory bump to 16 GB needed (transient SIGBUS at 8 GB).
 - 3: added `isAPFree_of_card_lt` + `rothNumber_ge_min` (trivial Roth lower
   bound, brackets `rothNumber_le_window`); 0-axiom, 0-sorry, 7743 jobs verified.
+- 4: added the low-length regime `k ≤ 2` (`infinite_of_hasDivergentSum`,
+  `containsAP_two_of_lt`, `containsAP_two_of_infinite`,
+  `hasDivergentSum_containsAP_le_two`); 0-axiom, 0-sorry, 7743 jobs verified.


### PR DESCRIPTION
## Erdős Problem #3 — the unconditional low-length regime

Erdős #3 (\$5000, OPEN): if $\sum_{a\in A} 1/a = \infty$ then $A$ contains arbitrarily long APs. The conjecture is genuinely open only for progressions of length $k \ge 3$. This PR certifies in Lean that the conclusion for $k \le 2$ is an unconditional triviality — no Roth-type input — pinning all the difficulty at $k \ge 3$.

### New lemmas (all 0-sorry, 0-axiom, verified — docker build 7743 jobs)

- `infinite_of_hasDivergentSum : HasDivergentSum A → A.Infinite` — a finite set has a `Fintype`-summable reciprocal sum (`hasSum_fintype`), contradicting divergence. **Fills the hypothesis-side gap the `infinite_of_containsArbitrarilyLongAP` docstring already claimed** ("`HasDivergentSum` likewise forces infinitude") but never proved.
- `containsAP_two_of_lt` — two ordered elements `a < b` of `A` form a genuine 2-AP `{a,b} = ArithProg a (b-a) 2` (common difference `b-a > 0`).
- `containsAP_two_of_infinite : A.Infinite → ContainsAP A 2` — an infinite `A ⊆ ℕ` has two distinct elements.
- `hasDivergentSum_containsAP_le_two : HasDivergentSum A → ∀ k ≤ 2, ContainsAP A k` — the payoff: **Erdős #3 proved verbatim and unconditionally for every `k ≤ 2`** (via `containsAP_of_le`).

### Significance (honest)

Elementary — none of this approaches the open content. Its value is *delineation*: it establishes the exact boundary where the problem becomes hard (`k ≥ 3`), matching the Roth-number floor `k-1` (`rothNumber_ge_min`) landed in the prior attempt. Completes the elementary bracketing of the problem on the AP-length axis. The threshold-critical `required_bound_implies_conjecture` sorry (as hard as Erdős #3) is untouched and correctly retained.

### Verification

`LEAN_MEMORY_LIMIT=16384 LEAN_SKIP_CACHE=true ./proofs/scripts/docker-build.sh Proofs.Erdos3Problem` → **Build succeeded (7743 jobs)**. Only pre-existing sorry warning (line 161) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)