### PR TITLE
Research: hurwitz-oq-03-oq-01 — anticommutator is real-affine (Frobenius Step 3 prep, 0-axiom)

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -46,6 +46,8 @@ by choosing an orthonormal basis and transporting multiplication through coordin
 - `exists_real_shift_sq_scalar`, `eq_smul_one_of_sq_eq_nonneg_smul`: proved (0 sorries) —
   Frobenius Step 2 (completing the square; nonnegative square ⟹ real, so the imaginary
   part squares to a *negative* scalar)
+- `anticommutator_real_affine`: proved (0 sorries) — Frobenius Step 3 preparation
+  (`x*y + y*x ∈ span_ℝ {x, y, 1}` for all `x, y`, via polarisation of the Step-1 quadratics)
 - `hurwitz_only_if_ring`: 1 sorry — the remaining global structure argument (Step 3:
   `Im A` is a subspace with a positive-definite bilinear form / Clifford structure)
 -/
@@ -185,6 +187,32 @@ theorem eq_smul_one_of_sq_eq_nonneg_smul (A : Type*) [NormedDivisionRing A]
   rcases mul_eq_zero.mp factored with h | h
   · exact ⟨s, by linear_combination (norm := module) h⟩
   · exact ⟨-s, by linear_combination (norm := module) h⟩
+
+/-! ### Frobenius Step 3 preparation: the anticommutator is real-affine
+
+The Clifford structure that pins `finrank ℝ (Im A)` down begins with a single algebraic
+constraint on the anticommutator `x*y + y*x`.  The following lemma is the first honest step
+towards it and is fully verified: applying the Step-1 quadratic relation to `x`, `y` and
+`x + y` and polarising (`(x+y)² = x² + (xy+yx) + y²`) expresses the anticommutator as a
+*real-linear* combination of `x`, `y` and `1`.  Equivalently, `x*y + y*x ∈ span_ℝ {x, y, 1}`
+for all `x, y` — no commutativity assumed.  This is exactly the algebra that, once restricted
+to imaginary `x, y` (where the `x` and `y` coefficients drop out by trace-additivity), yields
+the scalar-valued anticommutator `x*y + y*x ∈ ℝ•1` underpinning the Clifford relations. -/
+theorem anticommutator_real_affine (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (x y : A) :
+    ∃ c₁ c₂ c₃ : ℝ, x * y + y * x = c₁ • x + c₂ • y + c₃ • (1 : A) := by
+  obtain ⟨px, qx, hx⟩ := exists_quadratic A x
+  obtain ⟨py, qy, hy⟩ := exists_quadratic A y
+  obtain ⟨ps, qs, hs⟩ := exists_quadratic A (x + y)
+  refine ⟨ps - px, ps - py, qs - qx - qy, ?_⟩
+  -- polarisation: (x + y)² = x² + (xy + yx) + y²
+  have hpol : (x + y) ^ 2 = x ^ 2 + (x * y + y * x) + y ^ 2 := by
+    simp only [pow_two]; noncomm_ring
+  -- rewrite each square by its Step-1 quadratic and read off the coefficients
+  have key : x ^ 2 + (x * y + y * x) + y ^ 2 = ps • (x + y) + qs • (1 : A) := by
+    rw [← hpol]; exact hs
+  rw [hx, hy] at key
+  linear_combination (norm := module) key
 
 /-! ### The General (Division Ring) Case -/
 

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/state.md
@@ -4,28 +4,34 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Frobenius Step 3 commutative subcase VERIFIED. HurwitzOnlyIf.lean sorry now scoped
-to the strictly non-commutative case only.
+Frobenius Step 3 *preparation* lemma VERIFIED: `anticommutator_real_affine`
+(`x*y + y*x ∈ span_ℝ {x, y, 1}` for all x, y). The one remaining sorry is still the
+strictly non-commutative global-structure argument.
 
 ## Active Approach
-Case split in hurwitz_only_if_ring on commutativity:
-- commutative → hurwitz_only_if_ring_comm (NEW, 0 sorry): promote NormedDivisionRing +
-  mul_comm to NormedField, apply hurwitz_field_case (Gelfand-Mazur). VERIFIED.
+Whittling the Clifford structure down from provable pieces:
+- commutative → hurwitz_only_if_ring_comm (0 sorry): Gelfand-Mazur. VERIFIED (iter 3).
+- `anticommutator_real_affine` (0 sorry, NEW iter 4): polarise the Step-1 quadratics of
+  x, y, x+y ⟹ x*y + y*x = c₁•x + c₂•y + c₃•1. The first algebraic constraint toward the
+  Clifford relations. VERIFIED.
 - non-commutative → remaining sorry (Clifford / Radon-Hurwitz, blocked on Mathlib).
 
 ## Attempt Count
-- Total attempts: 1 (code, shipped)
-- Approaches tried: 1
+- Total attempts: 2 (code, shipped)
+- Approaches tried: 2
 
 ## Blockers
 - Non-commutative case genuinely open: needs Clifford-algebra / positive-definite
   anticommutator bilinear-form machinery not yet in Mathlib.
-- The keystone anticommutator lemma (xy+yx ∈ ℝ·1 for imaginary x,y) is entangled with
-  Im A subspace-closure; not cleanly provable in isolation.
+- The keystone anticommutator lemma (xy+yx ∈ ℝ·1 for *imaginary* x,y) still needs the
+  trace-additivity / Im A subspace-closure that drops the x,y coefficients in
+  `anticommutator_real_affine` to 0. That closure is the remaining hard step.
 
 ## Next Action
-Non-commutative case: build the Im A := {a | a² ∈ ℝ≤0·1} subspace-closure lemma, or
-wait for Mathlib Clifford/quadratic-form infra. Aristotle unusable (OPEN, not tactical).
+Prove trace-additivity: define the real-part functional `re : A → ℝ` (from Step-1's `p/2`)
+and show it is ℝ-linear, so imaginary x, y ⟹ x+y imaginary ⟹ c₁ = c₂ = 0 in
+`anticommutator_real_affine`, yielding `x*y + y*x ∈ ℝ•1`. Then Im A is a subspace and the
+bilinear form `-(xy+yx)` is defined. Aristotle unusable (OPEN, not tactical).


### PR DESCRIPTION
## Summary

Advances the Frobenius Step-3 frontier in `HurwitzOnlyIf.lean` (the "only-if" direction of the Hurwitz normed-division-ring classification, `finrank ℝ A ∈ {1,2,4,8}`). Prior iterations verified Step 1 (every element is quadratic over ℝ), Step 2 (completing the square; nonneg square ⟹ real), and the **commutative** subcase of Step 3 (Gelfand–Mazur). This PR adds the first verified algebraic constraint toward the **non-commutative** Clifford structure.

## New result (0 new sorries, 0 axioms)

- **`anticommutator_real_affine`** — for any `x y : A` in a finite-dimensional normed division ring over ℝ,
  ```
  x * y + y * x = c₁ • x + c₂ • y + c₃ • 1   for some reals c₁, c₂, c₃,
  ```
  i.e. `x*y + y*x ∈ span_ℝ {x, y, 1}`. No commutativity assumed.

**Proof.** Apply the Step-1 quadratic relation (`exists_quadratic`) to `x`, `y` and `x + y`, then polarise via `(x+y)² = x² + (xy + yx) + y²`. Reading off coefficients gives `c₁ = pₓ₊ᵧ − pₓ`, `c₂ = pₓ₊ᵧ − p_y`, `c₃ = qₓ₊ᵧ − qₓ − q_y`.

## Why it matters

This is the first algebraic step of the Clifford relations `eᵢeⱼ + eⱼeᵢ = −2δᵢⱼ`. Restricted to **imaginary** `x, y` — where trace-additivity forces the `x` and `y` coefficients to vanish — it collapses to the scalar anticommutator `x*y + y*x ∈ ℝ•1`, which underpins the positive-definite bilinear form on `Im A`. The next step (documented in `state.md`) is trace-additivity: showing the real-part functional `re : A → ℝ` is ℝ-linear.

## Scope

The single remaining `sorry` (strictly non-commutative global structure) is **unchanged** — it stays blocked on Mathlib's missing Clifford / quadratic-form machinery. This PR does not close it; it reduces the surface. The underlying problem (Hurwitz OQ-03-OQ-01) remains open.

## Verification

`./proofs/scripts/docker-build.sh Proofs.HurwitzOnlyIf` — compiles; the only `sorry` warning is the pre-existing line-248 non-commutative case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)