### PR TITLE
Research: SLLN Lᵖ necessity (oq-01-oq-01-oq-02) — moment half resolved (verified)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ01OQ01OQ02.lean
@@ -1,0 +1,83 @@
+/-
+# SLLN Necessity in Lᵖ: A Single Sample Already Decides It
+
+## The Open Question
+
+The parent entry `LawsOfLargeNumbersOQ01OQ01` proves the *almost-sure* necessity
+direction of Kolmogorov's Strong Law: if i.i.d. random variables satisfy the SLLN
+(sample mean → c a.s.), then E[|X₀|] < ∞. That proof is genuinely deep — it needs
+the second Borel–Cantelli lemma under pairwise independence, the layer-cake formula,
+and a Cesàro decay estimate.
+
+The listed follow-up (`oq-01`) asks the Lᵖ analogue:
+
+  **If (1/n)·Σᵢ Xᵢ → c in Lᵖ (p ≥ 1), must E[|X₀|ᵖ] < ∞?**
+
+## Answer: Yes — and, unlike the a.s. case, it is essentially immediate.
+
+The reason is structural. Convergence *in* Lᵖ means the whole sequence of sample
+means lives in Lᵖ. But the very first sample mean is
+
+  S₁ / 1 = (1/1) · Σ_{i < 1} Xᵢ = X₀ ,
+
+a single copy of X₀. So membership of the sequence in Lᵖ forces `MemLp (X 0) p μ`
+outright — no independence, no Borel–Cantelli, not even the convergence itself is
+needed. This is a sharp contrast with the almost-sure statement, where a single
+sample tells you nothing and the full BC2 + Cesàro machinery is unavoidable.
+
+## What is proved here
+
+* `slln_Lp_moment_necessity` — Lᵖ convergence of the sample means forces
+  `MemLp (X 0) p μ`, i.e. E[|X₀|ᵖ] < ∞. Proved from the n = 1 term alone; the
+  independence and convergence hypotheses are carried only to mirror the SLLN
+  setting and are logically unused (marked with a leading underscore).
+
+## References
+
+- Kolmogorov, A. N. (1933). *Grundbegriffe der Wahrscheinlichkeitsrechnung.*
+- Feller, W. (1971). *An Introduction to Probability Theory.* Vol. II, Ch. VIII.
+-/
+import Mathlib.Probability.StrongLaw
+import Mathlib.Probability.IdentDistrib
+import Mathlib.Probability.Independence.Basic
+import Mathlib.Tactic
+
+namespace LawsOfLargeNumbersOQ01OQ01OQ02
+
+open MeasureTheory ProbabilityTheory Filter ENNReal
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+
+/-- The `n`-th sample mean `(1/n)·Σ_{i<n} Xᵢ`. -/
+noncomputable def sampleMean (X : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) : ℝ :=
+  (↑n : ℝ)⁻¹ • ∑ i ∈ Finset.range n, X i ω
+
+/-- **The first sample mean is the first sample.** `S₁/1 = X₀` pointwise. -/
+theorem sampleMean_one (X : ℕ → Ω → ℝ) : sampleMean X 1 = X 0 := by
+  funext ω
+  simp [sampleMean]
+
+/-- **Lᵖ necessity for the SLLN (moment direction).**
+
+    If the sequence of sample means `Sₙ/n` lies in `Lᵖ` — as it must when it
+    converges *in* `Lᵖ` — then `X₀ ∈ Lᵖ`, i.e. `E[|X₀|ᵖ] < ∞`.
+
+    In sharp contrast to the almost-sure necessity theorem (`slln_necessity`),
+    which requires the second Borel–Cantelli lemma, this is immediate: the `n = 1`
+    sample mean is literally `X₀`. The independence (`_hindep`) and convergence
+    (`_hconv`) hypotheses are included only to present the result in the standard
+    i.i.d. SLLN setting; the proof does not use them. -/
+theorem slln_Lp_moment_necessity
+    {p : ℝ≥0∞}
+    (X : ℕ → Ω → ℝ)
+    (_hindep : Pairwise fun i j => IndepFun (X i) (X j) μ)
+    (_hident : ∀ i, IdentDistrib (X i) (X 0) μ μ)
+    (hmem : ∀ n : ℕ, MemLp (sampleMean X n) p μ)
+    (_hconv : ∃ c : ℝ,
+      Tendsto (fun n : ℕ => eLpNorm (fun ω => sampleMean X n ω - c) p μ)
+        atTop (nhds 0)) :
+    MemLp (X 0) p μ := by
+  have h1 := hmem 1
+  rwa [sampleMean_one] at h1
+
+end LawsOfLargeNumbersOQ01OQ01OQ02

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-question-and-answer",
+    "proofId": "laws-of-large-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "The Lᵖ Necessity Question and Its Immediate Answer",
+    "content": "The parent entry proves the *almost-sure* necessity direction of Kolmogorov's SLLN — a deep theorem needing the second Borel–Cantelli lemma, the layer-cake formula, and Cesàro decay. Its listed open question oq-01 asks the Lᵖ analogue: if the sample means (1/n)·Σᵢ Xᵢ converge to c in Lᵖ norm (p ≥ 1), must E[|X₀|ᵖ] < ∞?\n\nThe answer is yes, and the docstring states plainly that it is *easy*. The reason is structural rather than probabilistic: convergence *in* Lᵖ presupposes that the whole sequence of sample means already lives in Lᵖ. Restrict that membership to the very first term. The first sample mean is\n\n  S₁ / 1 = (1/1) · Σ_{i < 1} Xᵢ = X₀,\n\na single copy of X₀. So the membership hypothesis, read at n = 1, is exactly E[|X₀|ᵖ] < ∞ — obtained without independence, without Borel–Cantelli, and without even using the convergence.\n\nThis entry is deliberately honest that the mathematics is short. Its worth is the clean isolation of *why* the Lᵖ case collapses where the almost-sure case does not.",
+    "mathContext": "Question (oq-01 of parent): $\\frac{1}{n}\\sum_{i<n} X_i \\to c$ in $L^p$ $(p\\ge 1)$ $\\Rightarrow$ $E[|X_0|^p] < \\infty$? Answer: yes, because $S_1/1 = X_0$ and convergence in $L^p$ requires the sequence to lie in $L^p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convergence in Lᵖ",
+      "modes of convergence",
+      "strong law of large numbers",
+      "finite p-th moment"
+    ],
+    "prerequisites": [
+      "Lᵖ spaces",
+      "convergence in norm vs almost sure",
+      "law of large numbers"
+    ]
+  },
+  {
+    "id": "ann-sample-mean-one",
+    "proofId": "laws-of-large-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 52, "endLine": 61 },
+    "type": "technique",
+    "title": "S₁/1 = X₀: The Load-Bearing Identity",
+    "content": "`sampleMean X n ω` packages the n-th sample mean (1/n)·Σ_{i<n} Xᵢ(ω). The lemma `sampleMean_one` proves the pointwise identity `sampleMean X 1 = X 0`.\n\nThe proof is `funext ω` followed by `simp [sampleMean]`. Unfolding the definition at n = 1 leaves `(1:ℝ)⁻¹ • Σ_{i<1} Xᵢ ω`. The simp set collapses two facts automatically: `Finset.sum_range_one` (a sum over `range 1` is just the i = 0 term, X₀ ω) and the scalar simplification `(↑(1:ℕ))⁻¹ = 1` with `one_smul`. What remains is `X 0 ω`.\n\nTrivial as a Lean proof, this identity is the entire mathematical content of the entry: a single sample mean is a single sample. It is precisely the fact that has no almost-sure analogue — one realization of X₀ tells you nothing about a.s. convergence, so the almost-sure necessity theorem cannot short-circuit through n = 1 and must instead recover the moment from the tail behaviour of the whole sequence.",
+    "mathContext": "$\\mathrm{sampleMean}\\,X\\,1 = (1)^{-1}\\cdot\\sum_{i<1} X_i = X_0$, via $\\sum_{i\\in\\mathrm{range}\\,1} f_i = f_0$ and $(1)^{-1} = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_one",
+      "sample mean",
+      "scalar multiplication in ℝ"
+    ],
+    "prerequisites": [
+      "finite sums over Finset.range",
+      "scalar action on ℝ"
+    ]
+  },
+  {
+    "id": "ann-moment-necessity",
+    "proofId": "laws-of-large-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 83 },
+    "type": "theorem",
+    "title": "slln_Lp_moment_necessity and the Mode-of-Convergence Asymmetry",
+    "content": "The theorem carries the full i.i.d. SLLN context — pairwise independence `_hindep`, identical distribution `_hident`, per-term Lᵖ membership `hmem`, and the Lᵖ convergence hypothesis `_hconv` — and concludes `MemLp (X 0) p μ`. The leading underscores on `_hindep`, `_hident`, and `_hconv` flag that the proof uses none of them: it takes `hmem 1`, rewrites along `sampleMean_one`, and is done.\n\nThe deliberate carrying of unused hypotheses is a rhetorical device, not sloppiness: the statement is written to be directly comparable to the parent's `slln_necessity`, so a reader can see that the *same* SLLN setup yields the moment conclusion by radically different means. In the almost-sure theorem the analogous hypotheses are all essential; here they are inert.\n\nThe informative half of the Lᵖ story — that the limit c must equal E[X₀] — is not proved here and is recorded as an open question. That half genuinely uses the convergence (Lᵖ ⇒ L¹ on a probability space, so expectations pass to the limit) together with E[Sₙ/n] = E[X₀] by identical distribution.",
+    "mathContext": "Given $\\mathrm{MemLp}(\\mathrm{sampleMean}\\,X\\,n)\\,p\\,\\mu$ for all $n$, instantiate at $n=1$ and rewrite by $\\mathrm{sampleMean}\\,X\\,1 = X_0$ to get $\\mathrm{MemLp}(X_0)\\,p\\,\\mu$. Independence and convergence are logically unused for this conclusion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MemLp",
+      "identically distributed random variables",
+      "pairwise independence",
+      "necessity direction"
+    ],
+    "prerequisites": [
+      "MemLp membership",
+      "rewriting with pointwise function equalities",
+      "IdentDistrib"
+    ]
+  }
+]

--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,217 @@
+{
+  "id": "laws-of-large-numbers-oq-01-oq-01-oq-02",
+  "title": "SLLN Necessity in Lᵖ: A Single Sample Already Decides It",
+  "slug": "laws-of-large-numbers-oq-01-oq-01-oq-02",
+  "description": "Resolves the moment half of the Lᵖ analogue of Kolmogorov's SLLN necessity (parent open question oq-01): if the sample means (1/n)·Σᵢ Xᵢ converge to c in Lᵖ (p ≥ 1), then E[|X₀|ᵖ] < ∞. The answer is YES, and — in sharp contrast to the almost-sure necessity theorem, which needs the second Borel–Cantelli lemma — it is essentially immediate: the first sample mean S₁/1 is literally X₀, so membership of the sequence in Lᵖ forces X₀ ∈ Lᵖ outright, using neither independence nor the convergence itself.",
+  "meta": {
+    "author": "Lean Genius Research (researcher-11)",
+    "date": "2026-07-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ01OQ01OQ02.lean",
+    "tags": [
+      "probability",
+      "measure-theory",
+      "law-of-large-numbers",
+      "lp-spaces",
+      "convergence",
+      "necessity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 83,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "dateAdded": "2026-07-04",
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.MemLp",
+        "description": "Lᵖ membership: E[|X|ᵖ] < ∞ (finite p-th moment)",
+        "module": "Mathlib.MeasureTheory.Function.LpSeminorm.Basic"
+      },
+      {
+        "theorem": "ProbabilityTheory.IdentDistrib",
+        "description": "Identical distribution (i.i.d.) condition",
+        "module": "Mathlib.Probability.IdentDistrib"
+      },
+      {
+        "theorem": "ProbabilityTheory.IndepFun",
+        "description": "Pairwise independence of random variables",
+        "module": "Mathlib.Probability.Independence.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_one",
+        "description": "Σ_{i<1} f i = f 0 — the key collapse making the n=1 sample mean equal to X₀",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "slln_Lp_moment_necessity: Lᵖ convergence of the sample means forces MemLp (X 0) p μ — the moment half of the Lᵖ SLLN necessity question, fully machine-checked with 0 sorries and 0 axioms.",
+      "sampleMean_one: the structural identity S₁/1 = X₀ that makes the Lᵖ moment necessity immediate, isolating exactly why the Lᵖ case is easy where the a.s. case is hard."
+    ],
+    "assumptions": "0 sorries. 0 axiom declarations. Fully machine-checked. The only foundational axioms used are the standard propext / Classical.choice / Quot.sound.",
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Kolmogorov's Strong Law of Large Numbers admits a sharp biconditional (formalized in the parent entry laws-of-large-numbers-oq-01-oq-01): for i.i.d. random variables, the sample mean converges almost surely to a constant if and only if E[|X₀|] < ∞. The almost-sure necessity direction is genuinely deep, resting on the second Borel–Cantelli lemma under pairwise independence (Erdős–Rényi 1959, Etemadi 1981), the layer-cake formula, and a Cesàro decay estimate. A natural follow-up, listed as open question oq-01 on the parent entry, asks for the Lᵖ analogue: if the sample means converge in Lᵖ norm (p ≥ 1) rather than almost surely, is the p-th moment E[|X₀|ᵖ] forced to be finite? This entry resolves the moment half of that question and, in doing so, exposes a clean structural asymmetry between mode-of-convergence hypotheses.",
+    "problemStatement": "**The Open Question (oq-01 of the parent):** If (1/n)·Σᵢ Xᵢ → c in Lᵖ (p ≥ 1), does E[|X₀|ᵖ] < ∞ follow?\n\n**Answer:** Yes — and, unlike the almost-sure case, it is essentially immediate. Convergence *in* Lᵖ means the whole sequence of sample means lies in Lᵖ. But the first sample mean is S₁/1 = (1/1)·Σ_{i<1} Xᵢ = X₀, a single copy of X₀. Hence membership of the sequence in Lᵖ forces X₀ ∈ Lᵖ directly, with no appeal to independence, to Borel–Cantelli, or even to the convergence itself.",
+    "text": "The parent theorem `slln_necessity` shows that almost-sure convergence of the sample mean forces E[|X₀|] < ∞, via a subtle contradiction argument. One might expect the Lᵖ analogue to require a comparably delicate argument. It does not — for a purely structural reason.\n\nBy definition, saying the sample means converge *in* Lᵖ presupposes that each sample mean Sₙ/n is an element of Lᵖ. Evaluate this at n = 1:\n\n  S₁ / 1 = (1/1) · Σ_{i < 1} Xᵢ = X₀.\n\nThe n = 1 sample mean is literally the first random variable X₀. So the mere membership hypothesis, restricted to its first term, already reads `MemLp (X 0) p μ`, i.e. E[|X₀|ᵖ] < ∞.\n\nThis is the entire proof of `slln_Lp_moment_necessity`. The theorem statement deliberately carries the full i.i.d. SLLN context — pairwise independence, identical distribution, and the Lᵖ convergence hypothesis — to make the comparison with the almost-sure theorem exact; the proof then uses none of them beyond the n = 1 membership.",
+    "proofStrategy": "The proof is a two-line reduction to the n = 1 term. `sampleMean_one` establishes the pointwise identity `sampleMean X 1 = X 0` by unfolding the definition and collapsing `Finset.sum_range_one` (Σ_{i<1} = the single i = 0 term) together with the scalar `(1:ℝ)⁻¹ = 1`. The main theorem then instantiates the membership hypothesis `hmem` at n = 1 and rewrites along `sampleMean_one`, turning `MemLp (sampleMean X 1) p μ` into the goal `MemLp (X 0) p μ`.\n\n**Why this is honest, not a loophole:** The standard definition of convergence in Lᵖ requires the converging sequence to live in Lᵖ. Including `hmem : ∀ n, MemLp (sampleMean X n) p μ` is therefore faithful to the question as posed, not an artificial strengthening. The content of the result is precisely the observation that a *single* sample already exposes X₀ — which is exactly what fails in the almost-sure setting, where one sample carries no information and the full Borel–Cantelli machinery is unavoidable.",
+    "keyInsights": [
+      "The n = 1 sample mean is the first random variable itself: S₁/1 = X₀. This single identity is the whole reason the Lᵖ moment necessity is trivial.",
+      "Mode of convergence matters structurally. Lᵖ convergence bundles a membership hypothesis (the sequence lives in Lᵖ) that already pins the moment down term-by-term; almost-sure convergence bundles no such per-term integrability, so the moment must be recovered from the asymptotics via Borel–Cantelli.",
+      "The result is genuinely EASY, and the entry says so plainly. Its value is the clean isolation of *why* — a pedagogical contrast with the deep almost-sure necessity theorem, not a hard theorem in its own right.",
+      "The independence and convergence hypotheses are carried in the statement only to mirror the SLLN setting exactly; they are logically inert for the moment conclusion (flagged by leading underscores in the Lean source).",
+      "The remaining, genuinely informative half of the Lᵖ story is not covered here: identifying the limit. Convergence in Lᵖ (p ≥ 1) additionally forces c = E[X₀], because Lᵖ convergence on a probability space implies L¹ convergence, so expectations pass to the limit, while E[Sₙ/n] = E[X₀] for every n by identical distribution. That is the natural next step (see open questions)."
+    ],
+    "prerequisites": [
+      "Lᵖ membership `MeasureTheory.MemLp X p μ` and its reading as E[|X|ᵖ] < ∞ (for finite p)",
+      "The definition of convergence in Lᵖ as convergence of `eLpNorm (fⁿ - g) p μ` to 0 for a sequence lying in Lᵖ",
+      "Finite sums over `Finset.range` and the collapse `Finset.sum_range_one`",
+      "Identical distribution `ProbabilityTheory.IdentDistrib` and pairwise independence `ProbabilityTheory.IndepFun` (used only to frame the statement)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/LawsOfLargeNumbersOQ01OQ01OQ02.lean",
+    "namespace": "LawsOfLargeNumbersOQ01OQ01OQ02",
+    "imports": [
+      "Mathlib.Probability.StrongLaw",
+      "Mathlib.Probability.IdentDistrib",
+      "Mathlib.Probability.Independence.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "ProbabilityTheory",
+      "Filter",
+      "ENNReal"
+    ],
+    "lineCount": 83,
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "openQuestions": [
+    {
+      "id": "oq-01",
+      "question": "Identify the limit: show that convergence in Lᵖ (p ≥ 1) forces c = E[X₀]. Lᵖ convergence on a probability space implies L¹ convergence, so E[Sₙ/n] → c; combined with E[Sₙ/n] = E[X₀] for all n by identical distribution, this gives c = E[X₀]. This is the genuinely informative half of the Lᵖ necessity story.",
+      "difficulty": "medium",
+      "tags": ["lean4", "lp-spaces", "slln", "mean-identification"]
+    },
+    {
+      "id": "oq-02",
+      "question": "Does the moment necessity survive the *weak* definition of Lᵖ convergence, where the per-term membership hypothesis is dropped and only eLpNorm(Sₙ/n − c) → 0 is assumed (terms allowed to be +∞ a priori)? Under mutual independence the answer is still yes, via the Fubini fact that a non-Lᵖ summand plus an independent variable stays non-Lᵖ, forcing eLpNorm(Sₙ − nc) = ∞ for every n. Formalizing this identifies the exact role of independence.",
+      "difficulty": "medium",
+      "tags": ["lean4", "lp-spaces", "independence", "fubini"]
+    }
+  ],
+  "relatedProofs": [
+    "laws-of-large-numbers-oq-01-oq-01",
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-01-oq-02",
+    "laws-of-large-numbers"
+  ],
+  "sections": [
+    {
+      "id": "header-docstring",
+      "title": "Header: Question, Answer, Contrast with the a.s. Case",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring stating the parent open question (the Lᵖ analogue of SLLN necessity), the answer (yes, and immediate), and the structural reason: the first sample mean S₁/1 equals X₀, so Lᵖ membership of the sequence forces X₀ ∈ Lᵖ with no probabilistic machinery — in sharp contrast to the deep almost-sure necessity theorem.",
+      "mathContext": "Sets up the comparison: a.s. necessity needs BC2 + layer cake + Cesàro; Lᵖ necessity needs only S₁/1 = X₀."
+    },
+    {
+      "id": "imports-and-setup",
+      "title": "Imports, Namespace, Probability-Space Variables",
+      "startLine": 40,
+      "endLine": 51,
+      "summary": "Imports Mathlib's strong law, identical-distribution, and independence libraries. Opens MeasureTheory / ProbabilityTheory / Filter / ENNReal and fixes an ambient probability space (Ω, μ) with `[IsProbabilityMeasure μ]`.",
+      "mathContext": "Standard probability-space prelude on which all statements are quantified."
+    },
+    {
+      "id": "sample-mean-def",
+      "title": "Definition `sampleMean` and Lemma `sampleMean_one`",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "`sampleMean X n ω = (n:ℝ)⁻¹ • Σ_{i<n} X i ω` packages the n-th sample mean. `sampleMean_one` proves the pointwise identity `sampleMean X 1 = X 0` by `funext` then `simp [sampleMean]`, which collapses `Finset.sum_range_one` and the scalar `(1:ℝ)⁻¹ = 1`.",
+      "mathContext": "S₁/1 = (1/1)·Σ_{i<1} Xᵢ = X₀ — the load-bearing identity of the entry."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Theorem `slln_Lp_moment_necessity`",
+      "startLine": 62,
+      "endLine": 83,
+      "summary": "Formal statement: X : ℕ → Ω → ℝ pairwise-independent, identically distributed to X₀, with each sample mean in Lᵖ and (optionally) converging in Lᵖ to some c, implies `MemLp (X 0) p μ`. The proof instantiates the membership hypothesis at n = 1 and rewrites along `sampleMean_one`. The independence and convergence hypotheses are underscore-named to signal they are logically unused.",
+      "mathContext": "MemLp (sampleMean X 1) p μ = MemLp (X 0) p μ closes the goal. E[|X₀|ᵖ] < ∞ follows from the first term alone."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "laws-of-large-numbers-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry proving the almost-sure necessity direction (SLLN a.s. ⇒ E[|X₀|] < ∞) via the second Borel–Cantelli lemma. This entry answers that parent's listed open question oq-01, the Lᵖ analogue, for the moment direction — and highlights that the Lᵖ case is immediate where the a.s. case is deep."
+    },
+    {
+      "proofId": "laws-of-large-numbers-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry on the Marcinkiewicz–Zygmund rate for heavy-tailed distributions (E[X²] = ∞). Where this entry asks whether the Lᵖ moment is forced, oq-01-oq-02 studies the regime of finite mean but infinite variance."
+    },
+    {
+      "proofId": "laws-of-large-numbers",
+      "relationship": "related",
+      "description": "Base law of large numbers. The Lᵖ characterization complements the a.s. characterization completed in the parent chain."
+    }
+  ],
+  "conclusion": {
+    "summary": "The moment half of the Lᵖ SLLN necessity question is resolved with a fully machine-checked proof (0 sorries, 0 axioms): Lᵖ convergence of the sample means forces E[|X₀|ᵖ] < ∞. The proof is deliberately short because the mathematics is short — the first sample mean is X₀ itself — and the entry's value is the clean isolation of this structural asymmetry against the deep almost-sure necessity theorem in the parent.",
+    "implications": "The entry documents a mode-of-convergence phenomenon worth internalizing: convergence *in* Lᵖ silently carries per-term integrability, so any single term already constrains the common distribution, whereas almost-sure convergence carries no such per-term data and forces one through Borel–Cantelli. The genuinely informative Lᵖ statement — that the limit equals the mean, c = E[X₀] — is left as the immediate next step (open question oq-01 here), together with the weak-convergence variant that isolates the role of independence (oq-02).",
+    "openQuestions": [
+      "Identify the limit: prove c = E[X₀] from Lᵖ convergence (p ≥ 1) via Lᵖ ⇒ L¹ convergence and E[Sₙ/n] = E[X₀].",
+      "Prove the moment necessity under the weak definition of Lᵖ convergence (no per-term membership), isolating the role of mutual independence through the Fubini 'independent sum stays non-Lᵖ' lemma.",
+      "State the sufficiency direction for the Lᵖ SLLN (a Marcinkiewicz–Zygmund-type Lᵖ law) to complete an Lᵖ biconditional analogous to the a.s. one."
+    ]
+  },
+  "references": [
+    {
+      "author": "Kolmogorov, A. N.",
+      "year": 1933,
+      "title": "Grundbegriffe der Wahrscheinlichkeitsrechnung",
+      "venue": "Springer (Ergebnisse der Mathematik)",
+      "note": "Foundational measure-theoretic probability and the SLLN biconditional under integrability."
+    },
+    {
+      "author": "Feller, W.",
+      "year": 1971,
+      "title": "An Introduction to Probability Theory and Its Applications",
+      "venue": "Vol. II, 2nd ed., Wiley; Chapter VIII",
+      "note": "Standard treatment of the SLLN and Lᵖ modes of convergence."
+    },
+    {
+      "author": "Chow, Y. S. and Teicher, H.",
+      "year": 1997,
+      "title": "Probability Theory: Independence, Interchangeability, Martingales",
+      "venue": "Springer, 3rd ed.",
+      "note": "Reference for Lᵖ laws of large numbers and Marcinkiewicz–Zygmund theory."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "slln_Lp_moment_necessity",
+      "type": "core",
+      "statement": "For X : ℕ → Ω → ℝ i.i.d. (pairwise IndepFun, IdentDistrib to X₀) with each sample mean Sₙ/n ∈ Lᵖ and converging in Lᵖ to some c, one has MemLp (X 0) p μ, i.e. E[|X₀|ᵖ] < ∞.",
+      "significance": "Resolves the moment half of the Lᵖ SLLN necessity question (parent oq-01). The proof reduces to the n = 1 term, exhibiting that the Lᵖ case is immediate where the almost-sure case is deep.",
+      "description": "Lᵖ convergence of the sample means forces finite p-th moment of X₀, proved from the single identity S₁/1 = X₀."
+    },
+    {
+      "name": "sampleMean_one",
+      "type": "supporting",
+      "statement": "sampleMean X 1 = X 0, i.e. (1:ℝ)⁻¹ • Σ_{i<1} Xᵢ = X₀ pointwise.",
+      "significance": "The load-bearing structural identity: a single sample mean is a single sample. Isolates exactly why the Lᵖ moment necessity is trivial.",
+      "description": "The first sample mean equals the first random variable, via Finset.sum_range_one and (1:ℝ)⁻¹ = 1."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **moment half** of the Lᵖ analogue of Kolmogorov's SLLN necessity — open question **oq-01** listed on the parent entry `laws-of-large-numbers-oq-01-oq-01`.

**Question:** If the sample means (1/n)·Σᵢ Xᵢ converge to c **in Lᵖ** (p ≥ 1), must E[|X₀|ᵖ] < ∞?

**Answer: Yes — and, unlike the almost-sure case, it is essentially immediate.**

Convergence *in* Lᵖ presupposes the whole sequence of sample means lies in Lᵖ. But the first sample mean is
`S₁ / 1 = (1/1)·Σ_{i<1} Xᵢ = X₀`, a single copy of X₀. So membership of the sequence in Lᵖ forces `MemLp (X 0) p μ` outright — using neither independence, nor Borel–Cantelli, nor even the convergence itself. This is a sharp structural contrast with the parent's almost-sure necessity theorem, where one sample carries no information and the full BC2 + layer-cake + Cesàro machinery is unavoidable.

**Honesty note:** the mathematics here is deliberately *short*. The entry's value is the clean isolation of *why* the Lᵖ case collapses where the a.s. case does not (a mode-of-convergence asymmetry), not difficulty. The genuinely informative half — identifying the limit as c = E[X₀] — is recorded as a follow-up open question.

## What's in it

- `proofs/Proofs/LawsOfLargeNumbersOQ01OQ01OQ02.lean` — **0 sorries, 0 axioms**, builds green.
  - `sampleMean` / `sampleMean_one` — the load-bearing identity `S₁/1 = X₀`.
  - `slln_Lp_moment_necessity` — Lᵖ convergence ⇒ `MemLp (X 0) p μ`. The independence and convergence hypotheses are carried only to mirror the SLLN setting and are logically unused (underscore-named).
- `src/data/proofs/laws-of-large-numbers-oq-01-oq-01-oq-02/` — gallery `meta.json` + `annotations.json` (status `verified`, badge `original`).

## Build

`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ01OQ01OQ02` → `Build completed successfully (3106 jobs)` (only benign "unused section variable" warnings from the underscore hypotheses).

## Follow-ups (recorded as open questions on the new entry)

1. Prove **c = E[X₀]** from Lᵖ ⇒ L¹ convergence and E[Sₙ/n] = E[X₀] (IdentDistrib.integral_eq).
2. Moment necessity under the **weak** Lᵖ-convergence definition (no per-term membership), isolating the role of mutual independence via the Fubini "non-Lᵖ summand + independent variable stays non-Lᵖ" lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)