### PR TITLE
Enrich Sharpness of the Constant 1/2 in the Half-Period Fourier Decay Method

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/annotations.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-circle-translate-halfperiod-defs",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 79, "endLine": 85 },
+    "type": "definition",
+    "title": "Translation and half-period on AddCircle T",
+    "content": "Two lightweight definitions carry the whole argument. `circleTranslate s x = x + ↑s` shifts a point of the circle group `AddCircle T` by a real amount `s`. `halfPeriod T n` returns `T/(2n)` for `n ≠ 0` (and `0` for `n = 0`) — exactly half the period `T/n` of the `n`-th Fourier mode. Shifting by a half-period is the single geometric operation that flips the sign of `fourier n`, which is the engine of the entire sharpness argument.",
+    "mathContext": "$\\text{circleTranslate}_s(x) = x + s \\pmod{T}, \\qquad \\text{halfPeriod}(T,n) = \\dfrac{T}{2n}\\ (n \\neq 0).$ The mode $e_n(x) = e^{2\\pi i n x / T}$ has period $T/n$, so a shift by $T/(2n)$ advances its phase by exactly $\\pi$.",
+    "significance": "technical",
+    "relatedConcepts": ["circle group", "quotient group ℝ/Tℤ", "period of a character", "group translation"],
+    "prerequisites": ["quotient groups", "Fourier characters on a compact abelian group"]
+  },
+  {
+    "id": "ann-halfperiod-neg-conjugate",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "technique",
+    "title": "Half-period translation negates the conjugate mode",
+    "content": "The core algebraic identity: translating the conjugate character `fourier (-n)` by the half-period `T/(2n)` sends it to its own negative. Because `e_{-n}(x + T/(2n)) = e^{-i\\pi} e_{-n}(x) = -e_{-n}(x)`, the phase advance of exactly $\\pi$ becomes multiplication by $-1$. The Lean proof rewrites `fourier (-n)` via `fourier_neg`, reshapes `T/(2n)` into `T/2/n`, and applies the Mathlib lemma `fourier_add_half_inv_index`, which encodes the half-period sign flip.",
+    "mathContext": "$e_{-n}\\!\\left(x + \\tfrac{T}{2n}\\right) = e^{-2\\pi i n \\cdot (T/2n)/T}\\, e_{-n}(x) = e^{-i\\pi} e_{-n}(x) = -\\,e_{-n}(x).$",
+    "significance": "key",
+    "relatedConcepts": ["Fourier characters", "roots of unity", "phase shift", "half-period symmetry"],
+    "prerequisites": ["complex exponentials", "characters of AddCircle"]
+  },
+  {
+    "id": "ann-difference-formula",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 97, "endLine": 128 },
+    "type": "insight",
+    "title": "The half-period difference formula for Fourier coefficients",
+    "content": "The pivotal identity `2·ĉ_n(f) = ∫ (f(x) − f(x + T/(2n)))·e_{-n}(x) dx`. It is exact, not an estimate. Proof: split the integrand using `f(x)·e_{-n}(x)` and the translated term, then apply Haar translation invariance (`integral_add_right_eq_self`) — the translated integral equals the original — combined with the sign flip `e_{-n}(x + T/(2n)) = −e_{-n}(x)`. The two copies of `ĉ_n(f)` add rather than cancel, producing the factor `2`. This symmetrization converts a single integral into a *difference* of `f`, which is what lets a modulus-of-continuity bound on `f` control the coefficient.",
+    "mathContext": "$2\\hat{c}_n(f) = \\int_{\\mathbb{R}/T\\mathbb{Z}} \\bigl(f(x) - f(x + \\tfrac{T}{2n})\\bigr)\\, e_{-n}(x)\\, dx.$ Uses translation invariance $\\int g(x{+}s)\\,dx = \\int g(x)\\,dx$ of the Haar (probability) measure and $e_{-n}(x{+}\\tfrac{T}{2n}) = -e_{-n}(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Haar measure invariance", "symmetrization trick", "Fourier coefficient", "modulus of continuity"],
+    "prerequisites": ["Lebesgue integration", "translation-invariant measures", "Fourier analysis on AddCircle"]
+  },
+  {
+    "id": "ann-method-bound-half",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 135, "endLine": 162 },
+    "type": "concept",
+    "title": "The half-period method bound ‖ĉ_n(f)‖ ≤ M/2",
+    "content": "The abstraction that isolates where the constant `1/2` comes from. If the half-period difference `‖f(x) − f(x + T/(2n))‖` is uniformly bounded by `M`, then `‖ĉ_n(f)‖ ≤ M/2`. Proof: take norms in the difference formula, bound `‖·‖` of the integral by the integral of `‖·‖`, use `‖e_{-n}‖ = 1` pointwise (`fourier_norm_eq_one`) to strip the character, and integrate the constant `M` against the probability measure (total mass 1). The result `‖2·ĉ_n‖ ≤ M` gives `‖ĉ_n‖ ≤ M/2`. Crucially the bound depends only on the uniform difference bound `M`, not on Hölder continuity — specializing `M = C·(T/(2|n|))^α` recovers the parent's Hölder decay theorem exactly.",
+    "mathContext": "If $\\sup_x \\|f(x) - f(x + \\tfrac{T}{2n})\\| \\le M$ then $\\|\\hat{c}_n(f)\\| \\le \\tfrac{M}{2}$. The $\\tfrac12$ is precisely the reciprocal of the symmetrization factor $2$; specializing $M = C\\,(\\tfrac{T}{2|n|})^\\alpha$ yields $\\|\\hat{c}_n(f)\\| \\le \\tfrac{C}{2}\\,(\\tfrac{T}{2|n|})^\\alpha$.",
+    "significance": "key",
+    "relatedConcepts": ["triangle inequality for integrals", "probability measure", "Hölder decay", "operator bound"],
+    "prerequisites": ["norm_integral_le_integral_norm", "monotonicity of the integral"]
+  },
+  {
+    "id": "ann-halfperiod-pos-negates",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 169, "endLine": 175 },
+    "type": "technique",
+    "title": "Half-period translation negates the positive mode",
+    "content": "The mirror of the conjugate identity, for the mode `fourier n` itself: `fourier n (x + T/(2n)) = −fourier n(x)`. This is the direct consequence of `fourier_add_half_inv_index` without the extra conjugation step. It is what makes the pure mode an extremal witness — the function equals the negative of its own half-period translate everywhere.",
+    "mathContext": "$e_n\\!\\left(x + \\tfrac{T}{2n}\\right) = e^{i\\pi} e_n(x) = -\\,e_n(x)$ for all $x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fourier modes", "half-period antisymmetry", "phase shift"],
+    "prerequisites": ["complex exponentials"]
+  },
+  {
+    "id": "ann-diff-eq-two",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 177, "endLine": 185 },
+    "type": "insight",
+    "title": "Uniform saturation: the mode's half-period difference is exactly 2",
+    "content": "Because `fourier n(x + T/(2n)) = −fourier n(x)`, the half-period difference is `fourier n(x) − (−fourier n(x)) = 2·fourier n(x)`, whose norm is `2·‖e_n(x)‖ = 2·1 = 2` at *every* `x`. This is the precise, machine-checked form of the informal claim in the parent that the extremal 'saturates the bound for all x simultaneously'. Unlike a Hölder extremal, which only saturates its inequality in an asymptotic or pointwise-worst-case sense, the pure mode saturates the uniform difference identically — the tightest possible situation.",
+    "mathContext": "$\\bigl\\|e_n(x) - e_n(x + \\tfrac{T}{2n})\\bigr\\| = \\|e_n(x) + e_n(x)\\| = 2\\,\\|e_n(x)\\| = 2 \\quad \\text{for every } x.$",
+    "significance": "key",
+    "relatedConcepts": ["extremal function", "uniform saturation", "sup norm", "sharpness witness"],
+    "prerequisites": ["norm of complex exponential", "|e_n| = 1"]
+  },
+  {
+    "id": "ann-orthonormality-coeff-one",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 187, "endLine": 202 },
+    "type": "technique",
+    "title": "Diagonal orthonormality: ĉ_n(fourier n) = 1",
+    "content": "The self-coefficient of a pure mode is `1`. In the coefficient integral `∫ e_{-n}(x)·e_n(x) dx`, the product of a character and its conjugate collapses to the trivial character: `e_{-n}·e_n = e_{-n+n} = e_0 ≡ 1` (via `fourier_add` and `fourier_zero`). Integrating the constant `1` against the probability measure `haarAddCircle` gives `1`. This is the diagonal case of the orthonormality relations `∫ e_{-n} e_m = δ_{nm}` for the Fourier basis, and its norm `1` is what makes the equality `1 = 2/2` in the method bound possible.",
+    "mathContext": "$\\hat{c}_n(e_n) = \\int e_{-n}(x)\\, e_n(x)\\, dx = \\int e_0(x)\\, dx = \\int 1 \\, d\\mu = 1,$ since $\\mu = \\text{haarAddCircle}$ is a probability measure. Diagonal case of $\\langle e_n, e_m\\rangle = \\delta_{nm}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthonormal basis", "Fourier basis", "Kronecker delta", "probability measure"],
+    "prerequisites": ["orthonormality of characters", "Haar measure normalization"]
+  },
+  {
+    "id": "ann-equality-attained",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 209, "endLine": 217 },
+    "type": "insight",
+    "title": "Equality is attained: the method bound is tight",
+    "content": "The two computations combine into a case of equality. For `f = fourier n` the uniform half-period difference is `M = 2` and the coefficient norm is `‖ĉ_n‖ = 1 = 2/2`. So the inequality `‖ĉ_n(f)‖ ≤ M/2` from `fourierCoeff_le_half_uniformDiff` holds with *equality* — the method bound cannot be improved by any pointwise argument, because there is an explicit function realizing it.",
+    "mathContext": "$\\|\\hat{c}_n(e_n)\\| = 1 = \\tfrac{2}{2} = \\tfrac{M}{2}, \\qquad M = \\sup_x\\|e_n(x) - e_n(x{+}\\tfrac{T}{2n})\\| = 2.$",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "extremal witness", "tightness", "sharp inequality"],
+    "prerequisites": ["the method bound", "the saturation identity"]
+  },
+  {
+    "id": "ann-optimality-lower-bound",
+    "proofId": "fourier-series-oq-02-oq-03-wip-01",
+    "range": { "startLine": 219, "endLine": 235 },
+    "type": "insight",
+    "title": "Optimality: 1/2 is the least admissible constant",
+    "content": "The capstone. Suppose some constant `k` makes `‖ĉ_n(f)‖ ≤ k·M` hold for *every* continuous `f` with uniform half-period difference `≤ M`. Instantiate at the pure mode `f = fourier n` with `M = 2`: the hypothesis gives `1 = ‖ĉ_n‖ ≤ k·2`, hence `1/2 ≤ k`. So no constant below `1/2` can replace it — `1/2` is exactly the least admissible constant of the half-period method. Note the scope: this proves optimality of the *method* constant, not of the Hölder-class constant k(α); pure modes are smooth and leave slack in the Hölder inequality that only asymptotic sawtooths saturate.",
+    "mathContext": "For all admissible $k$: instantiating the pure mode gives $1 = \\|\\hat{c}_n(e_n)\\| \\le k \\cdot 2 \\implies k \\ge \\tfrac12$. Therefore $\\inf\\{k : \\|\\hat{c}_n(f)\\| \\le k M \\ \\forall f\\} = \\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["optimal constant", "infimum over admissible constants", "extremal principle", "method vs class sharpness"],
+    "prerequisites": ["universal quantification", "the equality case"]
+  }
+]

--- a/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-wip-01/meta.json
@@ -45,6 +45,36 @@
       "Sharpness of the METHOD constant is weaker than sharpness of the HÖLDER-class constant k(α). Pure modes are smooth and do not saturate the Hölder inequality ‖f(x)−f(x+h)‖ ≤ C·h^α (which carries the remaining slack); the Hölder extremals are the asymptotic piecewise-linear sawtooths, whose exact coefficient computation is not attempted here. This boundary is stated explicitly to avoid overclaiming."
     ]
   },
+  "sections": [
+    {
+      "id": "part-0-infrastructure",
+      "title": "Part 0 — Half-Period Infrastructure",
+      "startLine": 74,
+      "endLine": 128,
+      "summary": "Self-contained re-derivation of the half-period toolkit (mirroring FourierSeriesOQ02, which currently fails to build): the definitions circleTranslate and halfPeriod, the sign-flip identity fourier_translate_halfperiod_neg for the conjugate mode, and the exact difference formula 2·ĉ_n(f) = ∫(f(x)−f(x+T/(2n)))·e_{-n}(x)dx via Haar translation invariance."
+    },
+    {
+      "id": "part-1-method-bound",
+      "title": "Part I — The Half-Period Method Bound",
+      "startLine": 130,
+      "endLine": 162,
+      "summary": "fourierCoeff_le_half_uniformDiff: a uniform half-period difference bound M yields ‖ĉ_n(f)‖ ≤ M/2. This isolates the source of every 1/2 in the Hölder decay theory; specializing M = C·(T/(2|n|))^α recovers the parent's fourierCoeff_holder_decay."
+    },
+    {
+      "id": "part-2-pure-mode-saturates",
+      "title": "Part II — The Pure Mode Saturates the Method",
+      "startLine": 164,
+      "endLine": 202,
+      "summary": "fourier_translate_halfperiod_pos negates the positive mode; fourier_halfperiod_diff_eq_two shows its half-period difference equals exactly 2 at every point; fourierCoeff_fourier_self computes ĉ_n(fourier n) = 1 by diagonal orthonormality, with norm 1."
+    },
+    {
+      "id": "part-3-sharpness",
+      "title": "Part III — Sharpness of the Constant 1/2",
+      "startLine": 204,
+      "endLine": 237,
+      "summary": "halfPeriod_constant_sharp exhibits equality (M = 2, ‖ĉ_n‖ = 2/2 = 1). method_constant_ge_half proves any universally valid constant k satisfies 1/2 ≤ k, so 1/2 is the least admissible constant of the half-period method, with the pure mode as extremal witness."
+    }
+  ],
   "conclusion": {
     "summary": "This entry connects the abstract 1/2 of the parent to actual Fourier coefficients and proves it is the least admissible constant in the half-period translation method, with the pure mode fourier n as an exact extremal witness (uniform half-period difference 2, coefficient norm 1 = 2/2). The parent's Hölder decay bound is re-derived as a corollary of the uniform-difference method bound. All eight theorems are machine-checked with no sorries and no axioms beyond Lean's foundational three.",
     "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `fourier-series-oq-02-oq-03-wip-01` (passes: 0, quality: 33 — no prior annotations).

## Changes
- **Added `annotations.json`** (new file, 9 annotations) covering every part of the 235-line Lean proof:
  - Part 0: `circleTranslate`/`halfPeriod` definitions, half-period sign-flip identity, and the exact difference formula `2·ĉ_n(f) = ∫(f(x)−f(x+T/(2n)))·e_{-n}(x)dx`
  - Part I: the method bound `‖ĉ_n(f)‖ ≤ M/2` from a uniform half-period difference bound
  - Part II: the pure mode negates under half-period translation ⟹ difference exactly 2; diagonal orthonormality ⟹ `ĉ_n(fourier n) = 1`
  - Part III: equality case and optimality `1/2 ≤ k`
  - Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Added `sections` array** to `meta.json` mapping the four proof parts to line ranges with summaries.

## Guardrails
- `meta.json` is 9.7 KB — well under the ~60 KB cap.
- Content is faithful to the Lean source; the method-vs-Hölder-class sharpness distinction is preserved (no overclaiming). Axiom/status fields unchanged and consistent with the source (0 sorries, 0 axioms).
- `pnpm build` passes.