### PR TITLE
Research: erdos-153-oq-03 — Section VII explicit Finset.sym count (⚠️ BUILD-PENDING)

### DIFF
--- a/proofs/Proofs/Erdos153OQ03.lean
+++ b/proofs/Proofs/Erdos153OQ03.lean
@@ -39,7 +39,10 @@ constrained* as the Sidon (h = 2) case, because every B_h set is Sidon.
 - `isBhSet_affine`         : affine invariance — {c·a+t} is B_h whenever A is (c ≥ 1)
 - `hSumset`                : the h-fold sumset {a₁+⋯+a_h : aᵢ ∈ A}
 - `isBhSet_iff_injOn`      : B_h ⟺ Multiset.sum is injective on `A.sym h`
-- `card_hSumset_of_isBhSet`: sharp count — |h-fold sumset| = |A.sym h| = C(|A|+h−1, h)
+- `card_hSumset_of_isBhSet`: sharp count — |h-fold sumset| = |A.sym h|
+- `card_sym`                 : finset "stars and bars" — |A.sym h| = C(|A|+h−1, h)
+- `card_sym_eq_multichoose` : the same count packaged as `multichoose |A| h`
+- `card_hSumset_eq_choose`  : sharp count in closed form — |h-fold sumset| = C(|A|+h−1, h)
 -/
 import Mathlib
 
@@ -453,5 +456,71 @@ restatement of "all `h`-fold sums distinct". -/
 theorem card_hSumset_of_isBhSet {h : ℕ} {A : Finset ℕ} (H : IsBhSet h A) :
     (hSumset h A).card = (A.sym h).card :=
   Finset.card_image_of_injOn ((isBhSet_iff_injOn h A).mp H)
+
+/-!
+## Section VII: The explicit multiset-coefficient count
+
+Section VI reduced `|hSumset h A|` to `(A.sym h).card`, the number of size-`h`
+multisets drawable from `A`.  To make the promised closed form
+`C(|A| + h − 1, h)` fully explicit we still need the **cardinality of the
+`Finset.sym`** itself.
+
+Mathlib supplies the *type-level* "stars and bars" identity
+`Sym.card_sym_eq_choose : Fintype.card (Sym α k) = C(Fintype.card α + k − 1, k)`
+but — perhaps surprisingly — no analogous statement for the *finset* operation
+`A.sym h`.  We supply that missing bridge (`card_sym`): the size-`h` multisets
+drawn from a finite set `A ⊆ ℕ` are in bijection with `Sym ↥A h` via the
+coercion `Sym.map (Subtype.val)`, which is injective, and whose image is exactly
+`A.sym h`.  Transporting `Sym.card_sym_eq_choose` across that bijection gives the
+count, and composing with Section VI yields the sharp `B_h` sumset formula in
+closed binomial form.
+-/
+
+/-- **Cardinality of `Finset.sym` (the missing finset "stars and bars").**
+The size-`h` multisets drawable from a finite set `A ⊆ ℕ` number exactly
+`C(|A| + h − 1, h)`.  Mathlib has this at the `Fintype` level
+(`Sym.card_sym_eq_choose`) but not for the `Finset.sym` operation; we bridge the
+two by identifying `A.sym h` with the injective image of `Sym ↥A h` under the
+coercion `Sym.map Subtype.val`. -/
+theorem card_sym (h : ℕ) (A : Finset ℕ) :
+    (A.sym h).card = (A.card + h - 1).choose h := by
+  -- the lift `Sym ↥A h → Sym ℕ h`, `s ↦ s.map (Subtype.val)`, is injective …
+  have hf : Function.Injective (Sym.map (Subtype.val : {x // x ∈ A} → ℕ)) :=
+    Sym.map_injective Subtype.val_injective h
+  -- … and its image is precisely `A.sym h`.
+  have himg : A.sym h
+      = Finset.univ.image (Sym.map (Subtype.val : {x // x ∈ A} → ℕ)) := by
+    ext t
+    simp only [Finset.mem_image, Finset.mem_univ, true_and, Finset.mem_sym_iff]
+    constructor
+    · -- surjectivity onto `A.sym h`: `attach` then relabel into `↥A`.
+      intro ht
+      refine ⟨(Sym.attach t).map (fun x => (⟨x.1, ht x.1 x.2⟩ : {x // x ∈ A})), ?_⟩
+      rw [Sym.map_map]
+      exact Sym.attach_map_coe t
+    · -- membership: every entry of `s.map val` lands back in `A`.
+      rintro ⟨s, rfl⟩ a ha
+      rw [Sym.mem_map] at ha
+      obtain ⟨x, _, rfl⟩ := ha
+      exact x.2
+  rw [himg, Finset.card_image_of_injective _ hf, Finset.card_univ,
+    Sym.card_sym_eq_choose, Fintype.card_coe]
+
+/-- **`Finset.sym` count in `multichoose` form.**  The `multichoose`-packaged
+restatement of `card_sym`: `A.sym h` has cardinality `multichoose |A| h`, the
+number of size-`h` multisets on `|A|` symbols. -/
+theorem card_sym_eq_multichoose (h : ℕ) (A : Finset ℕ) :
+    (A.sym h).card = (A.card).multichoose h := by
+  rw [card_sym, Nat.multichoose_eq]
+
+/-- **The sharp `B_h` sumset formula in closed binomial form.**  For a `B_h` set
+`A`, the `h`-fold sumset has cardinality *exactly* the multiset coefficient
+`C(|A| + h − 1, h)`.  Combines the injectivity count `card_hSumset_of_isBhSet`
+(Section VI) with the finset "stars and bars" identity `card_sym`.  This is the
+fully explicit form of the sharp counting identity: a `B_h` set is precisely one
+whose `h`-fold sumset attains the pigeonhole maximum `C(|A| + h − 1, h)`. -/
+theorem card_hSumset_eq_choose {h : ℕ} {A : Finset ℕ} (H : IsBhSet h A) :
+    (hSumset h A).card = (A.card + h - 1).choose h := by
+  rw [card_hSumset_of_isBhSet H, card_sym]
 
 end Erdos153OQ03

--- a/research/problems/erdos-153/knowledge.md
+++ b/research/problems/erdos-153/knowledge.md
@@ -87,6 +87,32 @@ signatures; verify with `./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03`
 when a tool returns. `card_sym` is standalone and Mathlib-worthy (a candidate
 `Finset.card_sym` upstream contribution).
 
+### Session 2026-07-04b (researcher-8) — re-audit; blackout persists
+
+**Mode**: REVISIT · **Outcome**: no build (blackout), confidence raised via audit
+
+Re-verified every Mathlib name/signature used by Section VII against the *current*
+mathlib4 docs (independent second pass): `Sym.map_injective`, `Sym.attach`,
+`Sym.attach_map_coe`, `Sym.map_map`, `Sym.mem_map`, `Sym.card_sym_eq_choose`
+(`{α} [Fintype α] (k) [Fintype (Sym α k)] : Fintype.card (Sym α k) =
+(Fintype.card α + k − 1).choose k`), `Nat.multichoose_eq` (`n.multichoose k =
+(n+k−1).choose k`) — all confirmed exactly as used. New corroborating signal: the
+**already-merged** base file (commit 21997e39c74) builds `Finset.mem_sym_iff`,
+`Sym.coe_injective`, `Sym.mem_coe` (lines 436–445), so the `Finset.sym`/`Sym` API
+is proven-good in this exact toolchain. Sole residual risk: the defeq at the
+`exact Sym.attach_map_coe t` after `rw [Sym.map_map]` (needs
+`Subtype.val ∘ (fun x => ⟨x.1,_⟩) ≡ Subtype.val` by β/η) — high confidence, only a
+build can settle it.
+
+**Infra update (important):** disk has RECOVERED to 32% (25 Gi free), yet the
+containerd content-store corruption *persists* — even `docker run <existing-imageID>`
+fails with `blob … input/output error`. So this is NOT a disk-space issue; it needs
+a **Docker Desktop restart/factory-reset** (a host action I won't take unilaterally
+while two other agents have in-flight `lean-build-*` containers). Two pre-existing
+containers still run; no *new* container can start until Docker is reset.
+PR #34776 stays gated (`loom:review-requested`) as BUILD-PENDING — correct
+conservative posture until a build confirms.
+
 ---
 
 *Generated from erdosproblems.com on 2026-01-12*

--- a/research/problems/erdos-153/knowledge.md
+++ b/research/problems/erdos-153/knowledge.md
@@ -50,7 +50,42 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### Session 2026-07-04 (researcher-8) — OQ-03 Section VII: explicit multiset-coefficient count
+
+**Mode**: REVISIT (infrastructure) · **Outcome**: proof written, BUILD-PENDING (dual-tool blackout)
+
+Added Section VII to `proofs/Proofs/Erdos153OQ03.lean` closing the gap between
+Section VI's `|hSumset h A| = |A.sym h|` and the docstring's promised closed form
+`C(|A|+h−1, h)`.
+
+**Key mathematical finding — a real Mathlib gap.** Mathlib supplies the type-level
+stars-and-bars identity `Sym.card_sym_eq_choose : Fintype.card (Sym α k) =
+C(Fintype.card α + k − 1, k)` (`Mathlib/Data/Sym/Card.lean`) but has **no**
+cardinality lemma for the *finset* operation `Finset.sym` (confirmed absent from
+the `Finset/Sym` docs page; the erdos-340 notes flagged the same). New lemma:
+
+```
+card_sym (h : ℕ) (A : Finset ℕ) : (A.sym h).card = (A.card + h - 1).choose h
+```
+
+Bridge recipe (all names doc-confirmed): the coercion map
+`Sym.map (Subtype.val : ↥A → ℕ) : Sym ↥A h → Sym ℕ h` is
+- **injective** — `Sym.map_injective Subtype.val_injective`;
+- **onto `A.sym h`** — for `t` with all entries in `A` (`Finset.mem_sym_iff`),
+  lift via `Sym.attach t : Sym {x // x ∈ t} h`, relabel each element into `↥A`,
+  and `Sym.map_map` + `Sym.attach_map_coe` recover `t`; membership of the image
+  uses `Sym.mem_map`.
+So `A.sym h = univ.image (Sym.map val)`; `Finset.card_image_of_injective` +
+`Finset.card_univ` + `Sym.card_sym_eq_choose` + `Fintype.card_coe` give the count.
+Companions: `card_sym_eq_multichoose` (`Nat.multichoose_eq`) and the capstone
+`card_hSumset_eq_choose : IsBhSet h A → |hSumset h A| = C(|A|+h−1, h)`.
+
+**Verification status.** NOT machine-checked this session: local Docker's
+containerd content store is corrupted (blob `input/output error`, disk 97%), and
+Aristotle's `prove` backend returns 404. Proof written against Mathlib-doc
+signatures; verify with `./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03`
+when a tool returns. `card_sym` is standalone and Mathlib-worthy (a candidate
+`Finset.card_sym` upstream contribution).
 
 ---
 

--- a/research/problems/erdos-153/state.md
+++ b/research/problems/erdos-153/state.md
@@ -41,11 +41,21 @@ Proof written against Mathlib-docs-confirmed lemma signatures; residual risk is
 limited to exact arg positions (`Sym.attach_map_coe` explicit/implicit `s`;
 `Sym.map_injective` arg count).
 
+**Re-audit (2026-07-04b, researcher-8).** All 8 Mathlib names re-verified against
+current mathlib4 docs; `Sym.card_sym_eq_choose` and `Nat.multichoose_eq`
+signatures match exactly. Corroborating: the already-merged base file (commit
+21997e39c74) builds `Finset.mem_sym_iff`/`Sym.coe_injective`/`Sym.mem_coe` in this
+same toolchain — the API is proven-good. **Infra update:** disk RECOVERED to 32%
+but containerd corruption persists (even `docker run <imageID>` fails) — so it's a
+Docker-Desktop-restart issue, not disk. Still declined (two peer builds in flight).
+
 ## Next Action
 
-VERIFY Section VII once either tool returns:
+VERIFY Section VII once Docker recovers (needs a Docker Desktop restart —
+containerd content store is corrupted independent of disk):
 `./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03`
 (file is NOT registered in `Proofs.lean`, so build it by module name).
+Sole residual risk: β/η defeq at `exact Sym.attach_map_coe t` (line 500).
 If a lemma name/arg drifts, the fixes are one-liners — the math is settled.
 
 ## Attempt Counts

--- a/research/problems/erdos-153/state.md
+++ b/research/problems/erdos-153/state.md
@@ -1,27 +1,55 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T09:56:05.235Z
-**Iteration**: 1
+**Phase**: INFRASTRUCTURE (B_h infrastructure build-out for OQ-03)
+**Since**: 2026-07-04
+**Iteration**: 7
 
 ## Current Focus
 
-Initial exploration of the problem.
+OQ-03 (`Erdos153OQ03.lean`): the B_h generalization of Sidon sets. The parent
+gap-variance conjecture is open; this file builds reusable, fully-proved
+structural infrastructure. Sections I–VI (nesting, Sidon bridge, invariances,
+sharp injectivity count `|hSumset| = |A.sym h|`) already merged (0 sorry/axiom).
 
 ## Active Approach
 
-None yet.
+Section VII (researcher-8, 2026-07-04): make the docstring's promised closed
+form `C(|A|+h−1, h)` explicit by supplying the **missing `Finset.sym`
+cardinality lemma** and composing it with Section VI.
+
+- `card_sym (h A) : (A.sym h).card = (A.card + h - 1).choose h` — Mathlib has
+  this only at the `Fintype` level (`Sym.card_sym_eq_choose`); there is NO
+  `Finset.card_sym`. Bridge: `Sym.map (Subtype.val : ↥A → ℕ)` is injective
+  (`Sym.map_injective`) and its image is exactly `A.sym h` (surjectivity via
+  `Sym.attach` + `Sym.attach_map_coe`; membership via `Finset.mem_sym_iff`,
+  `Sym.mem_map`). Transport `Sym.card_sym_eq_choose` across it.
+- `card_sym_eq_multichoose` — same count as `multichoose |A| h`.
+- `card_hSumset_eq_choose (H : IsBhSet h A)` — sharp sumset count in closed form.
 
 ## Blockers
 
-None.
+**Dual verification-tool blackout (2026-07-04).** Section VII is written but
+NOT machine-verified this session:
+- Local Docker: containerd content store corrupted (`input/output error`
+  reading image blobs `3d1c9c6b5563`, `28bd5fe8b56d`); new `docker run` cannot
+  start. Two peer agent builds were active, so a Docker Desktop restart was
+  declined. Disk 97% (25Gi free) — the known cause of containerd corruption.
+- Aristotle MCP: `prove` returns `{"status":"error","message":"Resource not
+  found."}` (404 backend outage).
+
+Proof written against Mathlib-docs-confirmed lemma signatures; residual risk is
+limited to exact arg positions (`Sym.attach_map_coe` explicit/implicit `s`;
+`Sym.map_injective` arg count).
 
 ## Next Action
 
-Begin problem exploration.
+VERIFY Section VII once either tool returns:
+`./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03`
+(file is NOT registered in `Proofs.lean`, so build it by module name).
+If a lemma name/arg drifts, the fixes are one-liners — the math is settled.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1


### PR DESCRIPTION
## ⚠️ BUILD-PENDING — do NOT merge until Lean-verified

Both verification backends were unavailable this session:
- **Local Docker**: containerd content store corrupted (`input/output error` reading image blobs `3d1c9c6b5563` / `28bd5fe8b56d`; disk 97% — the known cause). New `docker run` cannot start; two peer agent builds were active so a Docker Desktop restart was declined.
- **Aristotle MCP**: `prove` returns `{"status":"error","message":"Resource not found."}` (404 backend outage).

**Action for reviewer / next session with working tools:** run
```
./proofs/scripts/docker-build.sh Proofs.Erdos153OQ03
```
(the file is intentionally NOT registered in `Proofs.lean`, so build it by module name). If green, remove `loom:review-requested` to allow merge. If a lemma name/arg drifts, the fixes are one-liners — the mathematics is settled.

## What this adds

Section VII of `proofs/Proofs/Erdos153OQ03.lean`, closing the gap between Section VI's proven `|hSumset h A| = |A.sym h|` and the docstring's promised closed form `C(|A|+h−1, h)`.

| Lemma | Statement |
|-------|-----------|
| `card_sym` | `(A.sym h).card = (A.card + h - 1).choose h` |
| `card_sym_eq_multichoose` | `(A.sym h).card = (A.card).multichoose h` |
| `card_hSumset_eq_choose` | `IsBhSet h A → (hSumset h A).card = (A.card + h - 1).choose h` |

## Why `card_sym` is genuinely new

Mathlib supplies the **type-level** stars-and-bars identity `Sym.card_sym_eq_choose : Fintype.card (Sym α k) = C(Fintype.card α + k − 1, k)` but has **no** cardinality lemma for the **finset** operation `Finset.sym` (confirmed absent from the `Finset/Sym` docs page). The bridge:

- `Sym.map (Subtype.val : ↥A → ℕ) : Sym ↥A h → Sym ℕ h` is **injective** (`Sym.map_injective`);
- its **image is exactly `A.sym h`** — surjectivity by lifting `t` through `Sym.attach` and relabeling into `↥A` (`Sym.attach_map_coe`, `Sym.map_map`); membership via `Finset.mem_sym_iff`, `Sym.mem_map`.

Transport `Sym.card_sym_eq_choose` across the resulting bijection (`Finset.card_image_of_injective`, `Finset.card_univ`, `Fintype.card_coe`). `card_sym` is standalone and a candidate upstream Mathlib contribution.

No `sorry`, no `axiom`, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)