### PR TITLE
Enrich The Complex Gaussian Integral (π/b)^{1/2}: 3→5 sections, added analytic-continuation insight

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -29,30 +29,50 @@
       "Working over b : ℂ rather than b : ℝ is what makes this a genuine generalization rather than a notation change: the value (π/b)^{1/2} is a Complex.cpow (principal branch), reducing to a real square root only on the positive real axis.",
       "The recovery of the real parent is not a trivial 'set b = 1' — it requires identifying a real-valued integral with the ℂ-coercion of its complex form (integral_complex_ofReal) and a complex principal (1/2)-power of a positive real with that real's square root (Complex.ofReal_cpow). These two casts are exactly where naive specialization fails.",
       "The right half-plane re b > 0 is precisely the region of absolute convergence; the continuation to the boundary re b = 0 is what yields the Fresnel integrals, so this entry is the analytic bridge between the Gaussian and oscillatory regimes.",
-      "As with the parent, the hard analysis (differentiating under the integral, polar evaluation) is inherited from Mathlib; the entry's contribution is the gallery framing and the explicit, correctly-cast parent recovery — honestly badged 'mathlib'."
+      "As with the parent, the hard analysis (differentiating under the integral, polar evaluation) is inherited from Mathlib; the entry's contribution is the gallery framing and the explicit, correctly-cast parent recovery — honestly badged 'mathlib'.",
+      "The complex evaluation is at heart an identity-theorem argument: both ∫ e^{-bx²} dx and (π/b)^{1/2} are holomorphic in b on the right half-plane re b > 0 and agree on the positive real axis, where the classical real Gaussian applies, so by analytic continuation they agree throughout. The real integral does not merely 'specialize' to the complex one — it rigidly determines it."
     ]
   },
   "sections": [
     {
-      "id": "open-question-context",
-      "title": "Open Question & Analytic-Continuation Context",
+      "id": "oq-context",
+      "title": "Open Question & the Real-to-Complex Generalization",
       "startLine": 1,
-      "endLine": 31,
-      "summary": "Imports, the module docstring framing the open question and analytic-continuation context, and `open Real Complex MeasureTheory` — the setup for restating Mathlib's complex Gaussian integral."
+      "endLine": 18,
+      "summary": "Docstring framing the open question (extend ∫ e^{-x²} = √π to ∫ e^{-bx²} = (π/b)^{1/2} for b : ℂ, re b > 0) and its answer via Mathlib's integral_gaussian_complex. Explains this is a genuine generalization to the full complex right half-plane, the analytic continuation underlying Fresnel-type oscillatory integrals as re b → 0⁺.",
+      "mathContext": "$\\int_{\\mathbb{R}} e^{-bx^2}\\,dx=(\\pi/b)^{1/2}$ for $\\operatorname{re}b>0$."
     },
     {
-      "id": "complex-gaussian",
+      "id": "principal-power",
+      "title": "Why the Value Is a Principal ½-Power",
+      "startLine": 19,
+      "endLine": 31,
+      "summary": "Docstring note that, unlike the real case, the value is a complex principal (1/2)-power (Complex.cpow, principal branch) rather than a real square root, collapsing to √π only on the positive real axis. Also states the recovery route: integral_complex_ofReal and Complex.ofReal_cpow.",
+      "mathContext": "$(\\pi/b)^{1/2}=$ Complex.cpow (principal branch); $=\\sqrt{\\cdot}$ only on $\\mathbb{R}_{>0}$."
+    },
+    {
+      "id": "complex-integral",
       "title": "The Complex Gaussian Integral",
       "startLine": 32,
       "endLine": 38,
-      "summary": "gaussian_integral_complex restates Mathlib's integral_gaussian_complex: for 0 < re b, ∫ x : ℝ, exp(-b·x²) = (π/b)^{1/2} over the complex right half-plane."
+      "summary": "gaussian_integral_complex: for every b : ℂ with 0 < b.re, ∫_ℝ e^{-b x²} dx = (π/b)^{1/2}, a restatement of Mathlib's integral_gaussian_complex generalizing the real parent to the complex right half-plane.",
+      "mathContext": "$0<\\operatorname{re}b\\Rightarrow \\int_{\\mathbb{R}} e^{-bx^2}=(\\pi/b)^{1/2}$."
     },
     {
-      "id": "parent-recovery",
+      "id": "recovery-statement",
       "title": "Recovering √π as the b = 1 Case",
       "startLine": 40,
+      "endLine": 44,
+      "summary": "gaussian_integral_eq_sqrt_pi_via_complex: the real parent ∫_ℝ e^{-x²} dx = √π recovered as the b = 1 specialization of the complex result, via the bridge theorem — not a trivial substitution.",
+      "mathContext": "$b=1:\\ \\int_{\\mathbb{R}} e^{-x^2}\\,dx=\\sqrt{\\pi}$."
+    },
+    {
+      "id": "casting-steps",
+      "title": "The Two Casting Steps",
+      "startLine": 45,
       "endLine": 60,
-      "summary": "gaussian_integral_eq_sqrt_pi_via_complex derives the real ∫ e^{-x²} = √π from the complex result at b = 1 via two casting lemmas (hLcast through integral_complex_ofReal, hRcast through Complex.ofReal_cpow) and exact_mod_cast."
+      "summary": "The proof's two casts, exactly where naive specialization fails: identifying the real-valued integral with the ℂ-coercion of its complex form (integral_complex_ofReal), and the complex principal power (π/1)^{1/2} with (√π : ℂ) via Complex.ofReal_cpow and Real.sqrt_eq_rpow, closed by exact_mod_cast.",
+      "mathContext": "$(\\pi/1)^{1/2}=(\\sqrt{\\pi}:\\mathbb{C})$ via ofReal_cpow; real integral $=$ ℂ-pushforward."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-01` (quality 94 → 100).

Two genuine, non-padding improvements closing the exact scoring gaps:

- **Sections 3 → 5.** The former header section (1–31) collapsed two distinct docstring concepts the annotations already separate — the OQ framing / real-to-complex generalization (1–18) and the principal-½-power subtlety (19–31) — and the recovery section (40–60) collapsed the `b = 1` statement (40–44) with the two casting steps (45–60). Section navigation now mirrors the annotation and theorem boundaries.
- **keyInsights 4 → 5.** Added a genuinely distinct insight: the complex evaluation is at heart an identity-theorem argument — both `∫ e^{-bx²} dx` and `(π/b)^{1/2}` are holomorphic on `re b > 0` and agree on the positive real axis, so analytic continuation makes the real Gaussian *rigidly determine* the complex one, rather than merely being a special case of it. This is not a restatement of the existing four (cpow branch, casting subtlety, convergence region, provenance).

No content deleted; `mathlib` badge and axiom fields unchanged.
