### PR TITLE
Research: hurwitz-oq-03-oq-01 — real part re:A→ℝ well-defined (Frobenius Step 3, ⚠️ BUILD-PENDING)

### DIFF
--- a/proofs/Proofs/HurwitzOnlyIf.lean
+++ b/proofs/Proofs/HurwitzOnlyIf.lean
@@ -214,6 +214,113 @@ theorem anticommutator_real_affine (A : Type*) [NormedDivisionRing A] [NormedAlg
   rw [hx, hy] at key
   linear_combination (norm := module) key
 
+/-! ### Frobenius Step 3: the imaginary subspace `Im A` is well-defined
+
+Completing the square (Step 2) singles out the *imaginary* elements — those whose square is a
+nonpositive real scalar. The lemmas below are the structural backbone of the decomposition
+`A = ℝ • 1 ⊕ Im A` (0 new sorries; ⚠️ build verification pending — the Docker/containerd
+toolchain was unavailable at authoring time, so these proofs are hand-audited but not yet
+machine-checked):
+
+* `isImaginary_zero`, `eq_zero_of_isImaginary_of_isReal`: `Im A ∩ ℝ • 1 = {0}`.
+* `exists_isImaginary_sub_smul` **and** `isImaginary_sub_smul_unique`: every `a : A` has a
+  *unique* real part `c` with `a - c • 1 ∈ Im A`. Together these make the projection
+  `re : A → ℝ` well-defined — the next Step-3 milestone (proving `re` is `ℝ`-linear, so
+  `Im A = ker re` is a subspace) builds directly on this. -/
+
+/-- An element of a normed division ring is **imaginary** when its square is a nonpositive
+real scalar multiple of `1`. Genuinely imaginary elements (square scalar `< 0`) lie outside
+`ℝ • 1`; the only imaginary real scalar is `0`. This is the concrete `Im A` from the
+`A = ℝ • 1 ⊕ Im A` decomposition, cut out by the sign dichotomy of Frobenius Step 2. -/
+def IsImaginary (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A] (a : A) : Prop :=
+  ∃ r : ℝ, r ≤ 0 ∧ a ^ 2 = r • (1 : A)
+
+/-- `0` is imaginary: its square is `0 = 0 • 1` and `0 ≤ 0`. -/
+theorem isImaginary_zero (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A] :
+    IsImaginary A (0 : A) :=
+  ⟨0, le_refl 0, by simp⟩
+
+/-- **`Im A ∩ ℝ • 1 = {0}`.** An imaginary element that is also a real scalar multiple of `1`
+must be `0`: writing `a = s • 1` gives `a ^ 2 = s ^ 2 • 1`, so the imaginary scalar equals
+`s ^ 2 ≥ 0`; combined with `≤ 0` this forces `s = 0`. Uses that `ℝ` acts without zero
+divisors on `A` (`smul_eq_zero`, `one_ne_zero`) and `s ^ 2 = 0 ⟹ s = 0`. -/
+theorem eq_zero_of_isImaginary_of_isReal (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    (a : A) (hi : IsImaginary A a) (s : ℝ) (hs : a = s • (1 : A)) : a = 0 := by
+  obtain ⟨r, hr_le, hr_eq⟩ := hi
+  have h1 : a ^ 2 = (s ^ 2) • (1 : A) := by
+    rw [hs, pow_two, smul_mul_assoc, one_mul, smul_smul, ← pow_two]
+  have h2 : (s ^ 2 - r) • (1 : A) = 0 := by
+    rw [sub_smul, ← h1, hr_eq, sub_self]
+  have h3 : s ^ 2 - r = 0 := by
+    rcases smul_eq_zero.mp h2 with h | h
+    · exact h
+    · exact absurd h one_ne_zero
+  have h4 : s ^ 2 = r := by linarith
+  have h5 : s = 0 := by
+    have hsq0 : s ^ 2 = 0 := by linarith [sq_nonneg s]
+    exact sq_eq_zero_iff.mp hsq0
+  rw [hs, h5, zero_smul]
+
+/-- **Real part exists.** Every `a : A` admits a real scalar `c` with `a - c • 1 ∈ Im A`.
+From completing the square (`exists_real_shift_sq_scalar`) we get `(a - c₀ • 1) ^ 2 = r • 1`; if
+`r ≤ 0` this is already imaginary, and if `r > 0` then Step 2b puts `a - c₀ • 1 ∈ ℝ • 1`, so
+absorbing that scalar makes the imaginary part exactly `0`. -/
+theorem exists_isImaginary_sub_smul (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    [Module.Finite ℝ A] (a : A) : ∃ c : ℝ, IsImaginary A (a - c • (1 : A)) := by
+  obtain ⟨c, r, hcr⟩ := exists_real_shift_sq_scalar A a
+  rcases le_or_lt r 0 with hr | hr
+  · exact ⟨c, r, hr, hcr⟩
+  · obtain ⟨s, hs⟩ := eq_smul_one_of_sq_eq_nonneg_smul A (a - c • (1 : A)) r (le_of_lt hr) hcr
+    refine ⟨c + s, ?_⟩
+    have hzero : a - (c + s) • (1 : A) = 0 := by
+      rw [add_smul, sub_add_eq_sub_sub, hs, sub_self]
+    rw [hzero]
+    exact isImaginary_zero A
+
+/-- **Real part is unique.** If `a - c • 1` and `a - c' • 1` are both imaginary, then `c = c'`.
+Writing `d = c' - c`, expanding `(a - c' • 1) ^ 2 = (a - c • 1) ^ 2 - (2d) • (a - c • 1) + d² • 1`
+and using both square-scalar hypotheses gives `(2d) • (a - c • 1) ∈ ℝ • 1`; if `d ≠ 0` this puts
+the imaginary element `a - c • 1` into `ℝ • 1`, forcing it to `0` by
+`eq_zero_of_isImaginary_of_isReal`, whence `a - c' • 1 = (c - c') • 1 ∈ ℝ • 1` is likewise `0`,
+so `c = c'`. Together with `exists_isImaginary_sub_smul` this makes `re : A → ℝ` well-defined. -/
+theorem isImaginary_sub_smul_unique (A : Type*) [NormedDivisionRing A] [NormedAlgebra ℝ A]
+    (a : A) (c c' : ℝ) (h : IsImaginary A (a - c • (1 : A)))
+    (h' : IsImaginary A (a - c' • (1 : A))) : c = c' := by
+  by_contra hne
+  obtain ⟨r, _hr_le, hr_eq⟩ := h
+  obtain ⟨r', _hr'_le, hr'_eq⟩ := h'
+  set d := c' - c with hd_def
+  have hd : d ≠ 0 := sub_ne_zero.mpr (Ne.symm hne)
+  have hu'_eq : a - c' • (1 : A) = (a - c • (1 : A)) - d • (1 : A) := by
+    rw [hd_def, sub_smul]; abel
+  have hkey : (2 * d) • (a - c • (1 : A)) = (r + d ^ 2 - r') • (1 : A) := by
+    have expand : (a - c' • (1 : A)) ^ 2
+        = (a - c • (1 : A)) * (a - c • (1 : A)) - (2 * d) • (a - c • (1 : A))
+            + (d ^ 2) • (1 : A) := by
+      rw [hu'_eq]
+      simp only [sq, mul_sub, sub_mul, mul_smul_comm, smul_mul_assoc, one_mul, mul_one]
+      module
+    rw [← pow_two] at expand
+    rw [hr'_eq, hr_eq] at expand
+    linear_combination (norm := module) expand
+  have h2d : (2 * d) ≠ 0 := mul_ne_zero (by norm_num : (2 : ℝ) ≠ 0) hd
+  have hu_real : a - c • (1 : A) = ((r + d ^ 2 - r') / (2 * d)) • (1 : A) := by
+    have hinv : a - c • (1 : A) = (2 * d)⁻¹ • ((2 * d) • (a - c • (1 : A))) := by
+      rw [inv_smul_smul₀ h2d]
+    rw [hinv, hkey, smul_smul, div_eq_inv_mul]
+  have hu0 : a - c • (1 : A) = 0 :=
+    eq_zero_of_isImaginary_of_isReal A (a - c • (1 : A)) ⟨r, _hr_le, hr_eq⟩ _ hu_real
+  have ha : a = c • (1 : A) := by rw [sub_eq_zero] at hu0; exact hu0
+  have hu'_real : a - c' • (1 : A) = (c - c') • (1 : A) := by rw [ha, ← sub_smul]
+  have hu'0 : a - c' • (1 : A) = 0 :=
+    eq_zero_of_isImaginary_of_isReal A (a - c' • (1 : A)) ⟨r', _hr'_le, hr'_eq⟩ (c - c') hu'_real
+  rw [hu'_real] at hu'0
+  have hcc : c - c' = 0 := by
+    rcases smul_eq_zero.mp hu'0 with h1 | h1
+    · exact h1
+    · exact absurd h1 one_ne_zero
+  exact hne (sub_eq_zero.mp hcc)
+
 /-! ### The General (Division Ring) Case -/
 
 /-- **Frobenius Step 3, commutative subcase — fully verified.** If a normed division ring

--- a/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/knowledge.md
+++ b/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01/knowledge.md
@@ -103,3 +103,48 @@ Lowest-risk verifiable increment when tooling returns.
   (provable now via Gelfand–Mazur), then (b) target keystone lemma (2), the anticommutator
   polarization; or submit `hurwitz_only_if_ring` to Aristotle noting it is Frobenius' theorem
   with Steps 1–2 supplied as context.
+
+### 2026-07-04 (Session 2, researcher-11) — ACT (build-pending)
+
+**Mode**: REVISIT. **Outcome**: progress (4 new lemmas drafted + hand-audited; ⚠️ build-blocked).
+
+**What I did.** Advanced Frobenius Step 3 by making the real-part projection `re : A → ℝ`
+well-defined — the structural prerequisite to "`Im A` is a subspace". Added to
+`Proofs/HurwitzOnlyIf.lean` (after `anticommutator_real_affine`):
+- `def IsImaginary A a := ∃ r ≤ 0, a^2 = r•1` — the concrete `Im A`.
+- `isImaginary_zero`.
+- `eq_zero_of_isImaginary_of_isReal` — `Im A ∩ ℝ•1 = {0}` (a=s•1 imaginary ⟹ s²=r≤0, s²≥0 ⟹ s=0).
+- `exists_isImaginary_sub_smul` — every `a` has a real `c` with `a-c•1 ∈ Im A`
+  (from `exists_real_shift_sq_scalar`; the `r>0` branch collapses to `0` via Step 2b).
+- `isImaginary_sub_smul_unique` — that `c` is **unique**: if `a-c•1`, `a-c'•1` both imaginary,
+  expand `(a-c'•1)² = (a-c•1)² - 2d•(a-c•1) + d²•1` (d=c'-c), giving `2d•(a-c•1) ∈ ℝ•1`; if
+  `d≠0` this forces the imaginary `a-c•1 ∈ ℝ•1`, hence `=0` by the lemma above, then
+  `a-c'•1 = (c-c')•1 ∈ ℝ•1` is `0` too, so `c=c'`.
+
+Together `exists_… + …_unique` = well-definedness of `re`. Next milestone: prove `re` additive
+(`re(a+b)=re(a)+re(b)`), i.e. `Im A` closed under `+` — THE keystone, equivalent to
+"anticommutator of imaginaries is scalar". That needs a linear-(in)dependence case split on
+`{x,y,1}` (see Session-1 roadmap item 2); I set it up mentally as `anticommutator_imaginary_scalar`
+but did not land it this session.
+
+**Tooling blocker (unchanged from Session 1).** BOTH verification paths down:
+- Docker: containerd/buildkit metadata DBs return `input/output error` (VM-disk corruption,
+  not disk space — 32% used). `docker ps` works but any build/prune hits the corrupt blob.
+  Needs an operator Docker Desktop restart; not self-triggered (shared infra).
+- Aristotle MCP: `prove` returns `{"status":"error","message":"Resource not found."}` (404).
+Proofs are hand-audited (the `(x−k•1)²` expansion reuses the verbatim
+`simp only [sq, mul_sub, sub_mul, mul_smul_comm, smul_mul_assoc, one_mul, mul_one]; module`
+incantation from the already-verified `exists_real_shift_sq_scalar`), but NOT machine-checked.
+PR gated `loom:review-requested` so the deployer will not auto-merge until Docker returns.
+
+**Infra note.** The daemon force-reset worktree `researcher-11` to the stale
+`origin/feature/researcher-11` (missing the anticommutator commit) mid-session, wiping
+uncommitted edits. Reworked on a fresh non-daemon branch `research/hurwitz-oq-03-oq-01-realpart`
+off `origin/main`.
+
+**Next steps.**
+1. When Docker returns: build `Proofs.HurwitzOnlyIf`; fix any lemma-name drift
+   (`sub_add_eq_sub_sub`, `inv_smul_smul₀`, `div_eq_inv_mul`, `sq_eq_zero_iff`).
+2. Land the keystone `anticommutator_imaginary_scalar` (linear-independence case split).
+3. Define `re` via `Classical.choose exists_isImaginary_sub_smul`; prove `re` `ℝ`-linear using
+   the keystone; then `Im A = LinearMap.ker re` is a subspace.

--- a/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-oq-03-oq-01-wip-01.json
@@ -32,27 +32,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: commutative subcase of Frobenius Step 3 VERIFIED (hurwitz_only_if_ring_comm, 0 sorry, Gelfand-Mazur via NormedField promotion). hurwitz_only_if_ring sorry now scoped to strictly non-commutative case. Non-comm case open (Clifford/Radon-Hurwitz, Mathlib gap).",
+    "progressSummary": "ACT (build-pending): real-part projection re:A→ℝ made well-defined (existence + uniqueness, 4 new lemmas, 0 new sorry) — structural prerequisite to Im A being a subspace. Hand-audited; NOT machine-checked (Docker containerd + Aristotle both down). Keystone (anticommutator of imaginaries scalar) still open.",
     "builtItems": [
       "hurwitz_only_if_ring_comm in HurwitzOnlyIf.lean (commutative Frobenius subcase, 0 sorry)",
-      "Case split narrowing hurwitz_only_if_ring sorry to non-commutative case"
+      "Case split narrowing hurwitz_only_if_ring sorry to non-commutative case",
+      "IsImaginary predicate + isImaginary_zero + eq_zero_of_isImaginary_of_isReal (Im A ∩ ℝ•1 = {0}) in HurwitzOnlyIf.lean (build-pending)",
+      "exists_isImaginary_sub_smul + isImaginary_sub_smul_unique: real part exists & is unique (HurwitzOnlyIf.lean, build-pending)"
     ],
     "insights": [
       "The target file HurwitzOnlyIf.lean has exactly ONE real sorry (hurwitz_only_if_ring); grep -c=4 is inflated by 3 docstring mentions of the word sorry.",
       "The remaining sorry is precisely Frobenius theorem: NormedDivisionRing is associative so finrank in {1,2,4} (subset of {1,2,4,8}); octonions excluded by associativity.",
       "Frobenius Steps 1-2 are already VERIFIED in-file (minpoly_natDegree_le_two, exists_quadratic, exists_real_shift_sq_scalar, eq_smul_one_of_sq_eq_nonneg_smul). Only Step 3 (global structure) remains.",
       "Step 3 keystone is the anticommutator polarization: for imaginary x,y, x*y+y*x in R*1. This single lemma makes re:A->R linear and ImA a subspace; prove it first.",
-      "Commutative subcase of hurwitz_only_if_ring is provable NOW without Step 3: a commutative NormedDivisionRing is a NormedField, so hurwitz_field_case (Gelfand-Mazur) applies via a letI NormedField instance."
+      "Commutative subcase of hurwitz_only_if_ring is provable NOW without Step 3: a commutative NormedDivisionRing is a NormedField, so hurwitz_field_case (Gelfand-Mazur) applies via a letI NormedField instance.",
+      "Well-definedness of the real part re:A→ℝ = existence + uniqueness of c with a-c•1 imaginary; uniqueness reduces to Im A ∩ ℝ•1 = {0} via the (a-c•1)² expansion.",
+      "re additive ⟺ Im A closed under + ⟺ anticommutator of imaginaries is scalar — these three are logically equivalent, so the keystone is irreducible (no shortcut through re-linearity)."
     ],
     "mathlibGaps": [
       "Mathlib (2026-07) has Gelfand-Mazur (Analysis.Normed.Algebra.GelfandMazur) but NOT the classification of finite-dim real division algebras (Frobenius).",
       "No Clifford-algebra / Radon-Hurwitz-number / positive-definite-quadratic-space machinery to discharge Step 3 directly; must be built locally (~250-450 lines, elementary)."
     ],
     "nextSteps": [
-      "First commit (lowest risk, provable now): hurwitz_only_if_ring_comm assuming forall x y, x*y=y*x, via letI NormedField from commutativity + reuse hurwitz_field_case.",
-      "Keystone Step-3 lemma: anticommutator polarization x*y+y*x in R*1 for x,y imaginary, from (x+y)^2 - x^2 - y^2 and cancellation of linear parts.",
-      "Then re:A->R linear, ImA=ker re is subspace, A = R*1 (+) ImA; B(x,y)=-(x*y+y*x)/2 positive-definite symmetric; finrank ImA in {0,1,3}.",
-      "Alternative: submit hurwitz_only_if_ring to Aristotle once MCP is restored, hint=Frobenius theorem, context_files=HurwitzOnlyIf.lean supplying Steps 1-2."
+      "Rebuild Proofs.HurwitzOnlyIf once Docker/containerd is restored; fix any lemma-name drift",
+      "Land keystone anticommutator_imaginary_scalar via linear-independence case split on {x,y,1}",
+      "Define re := Classical.choose exists_isImaginary_sub_smul; prove ℝ-linear; Im A = ker re is a subspace"
     ],
     "markdown": "# Knowledge Base: hurwitz-theorem-oq-03-oq-01-wip-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Advances the **strictly non-commutative Frobenius case** — the last `sorry` in
`hurwitz_only_if_ring` (`Proofs/HurwitzOnlyIf.lean`) — by making the real-part projection
`re : A → ℝ` **well-defined**. This is the structural prerequisite for the next milestone,
"`Im A` is an `ℝ`-subspace".

Four new lemmas (0 new `sorry`), after the existing `anticommutator_real_affine`:

| Lemma | Statement |
|---|---|
| `IsImaginary A a` | `∃ r ≤ 0, a^2 = r • 1` — the concrete `Im A` |
| `isImaginary_zero` | `0 ∈ Im A` |
| `eq_zero_of_isImaginary_of_isReal` | `Im A ∩ ℝ•1 = {0}` |
| `exists_isImaginary_sub_smul` | every `a` has a real `c` with `a - c•1 ∈ Im A` (existence of `re`) |
| `isImaginary_sub_smul_unique` | that `c` is unique (`re` well-defined) |

**Math.** Existence: complete the square (`exists_real_shift_sq_scalar`); the `r > 0` branch
collapses to `0` by Step 2b. Uniqueness: with `d = c'−c`, expand
`(a−c'•1)² = (a−c•1)² − 2d•(a−c•1) + d²•1`, so `2d•(a−c•1) ∈ ℝ•1`; if `d ≠ 0` the imaginary
element `a−c•1` lands in `ℝ•1`, hence is `0`, forcing `c = c'`.

Existence + uniqueness ⇒ `re : A → ℝ` well-defined. **Next**: `re` additive
(⟺ `Im A` closed under `+` ⟺ anticommutator of imaginaries is scalar — the keystone), then
`Im A = ker re` is a subspace.

## ⚠️ BUILD-PENDING — do not auto-merge

Both verification tools were **down** at authoring time:
- **Docker**: containerd/buildkit metadata DBs return `input/output error` (Docker-VM disk
  corruption, *not* disk space — host at 32%). `docker ps` works; any build/prune hits the
  corrupt blob. Needs an operator Docker Desktop restart.
- **Aristotle MCP**: `prove` returns `{"status":"error","message":"Resource not found."}` (404).

Proofs are **hand-audited but not machine-checked**. The `(x−k•1)²` expansion reuses the
verbatim `simp only [sq, mul_sub, sub_mul, mul_smul_comm, smul_mul_assoc, one_mul, mul_one]; module`
incantation from the already-verified `exists_real_shift_sq_scalar`. Residual risk is
lemma-name drift (`sub_add_eq_sub_sub`, `inv_smul_smul₀`, `div_eq_inv_mul`, `sq_eq_zero_iff`).

**Gated `loom:review-requested`** so the deployer will not merge until
`./proofs/scripts/docker-build.sh Proofs.HurwitzOnlyIf` passes.

## Verification
```
./proofs/scripts/docker-build.sh Proofs.HurwitzOnlyIf   # run once containerd is restored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)