### PR TITLE
Roth k=3 (oq-01): prove r₃(4) = 2 exactly (axiom-free)

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -165,6 +165,39 @@ theorem rothNumber_three : rothNumber 3 = 2 := by
     a + d ∈ ({0, 1} : Finset (ZMod 3)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod 3))
   decide
 
+/-- Every AP-free subset of `ZMod 4` has at most two elements.
+
+    Unlike the odd modulus `N = 3`, in `ZMod 4` the step `d = 2` wraps around:
+    `a + 2 * 2 = a + 4 = a`. So an AP-free set may never contain both `a` and
+    `a + 2` (the "progression" `a, a + 2, a` would put `a + 2 * d = a` back in
+    the set). This forbids `{0, 2}` and `{1, 3}` simultaneously, capping the
+    size at two. The finite check is discharged by `decide` on the *unfolded*
+    predicate — the global `APFree` instance is classical and cannot evaluate. -/
+theorem apFree_four_card_le_two :
+    ∀ A : Finset (ZMod 4),
+      (∀ a d : ZMod 4, d ≠ 0 → a ∈ A → a + d ∈ A → a + 2 * d ∉ A) → A.card ≤ 2 := by
+  decide
+
+/-- r₃(4) = 2. Lower bound: `{0, 1}` is AP-free (as in `ZMod 3`). Upper bound:
+    every AP-free set avoids the pairs `{0, 2}` and `{1, 3}` because of the
+    `d = 2` wraparound, so no AP-free subset of `ZMod 4` reaches three elements.
+
+    Note `r₃(4) = 2 = r₃(3)`: the Roth number does not increase from modulus 3
+    to modulus 4, illustrating that `r₃` is not monotone in `N`. -/
+theorem rothNumber_four : rothNumber 4 = 2 := by
+  refine le_antisymm ?_ ?_
+  · -- Upper bound: every set in the powerset filter has card ≤ 2.
+    rw [rothNumber_def]
+    apply Finset.sup_le
+    intro A hA
+    rw [Finset.mem_filter] at hA
+    exact apFree_four_card_le_two A hA.2
+  · -- Lower bound: {0, 1} is an AP-free set of size 2.
+    apply card_le_rothNumber ({0, 1} : Finset (ZMod 4))
+    show ∀ a d : ZMod 4, d ≠ 0 → a ∈ ({0, 1} : Finset (ZMod 4)) →
+      a + d ∈ ({0, 1} : Finset (ZMod 4)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod 4))
+    decide
+
 -- ═══════════════════════════════════════════════════════════════════
 -- PART I.B: QUALITATIVE ROTH ASYMPTOTIC
 -- ═══════════════════════════════════════════════════════════════════

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
@@ -8,6 +8,35 @@
 
 ## Current Focus
 
+**S7 ACT SMALL-N (researcher-5, 2026-07-04)** — Executed the drafted
+small-N pin, sharpened to the **exact value r₃(4) = 2** (better than
+the planned [2, 3] range). Added two theorems to
+`RothTheoremQuantitative.lean` after `rothNumber_three`:
+
+- `apFree_four_card_le_two : ∀ A : Finset (ZMod 4), (∀ a d, d ≠ 0 →
+  a ∈ A → a + d ∈ A → a + 2*d ∉ A) → A.card ≤ 2` — by `decide` on the
+  **unfolded** predicate (the global `APFree` instance is classical
+  and cannot evaluate; stating the ∀-form directly lets `decide` use
+  the computable `Fintype (ZMod 4)` instances). Math key: in `ZMod 4`
+  the step `d = 2` wraps (`a + 2·2 = a`), so an AP-free set can hold
+  at most one of `{0, 2}` and one of `{1, 3}` → size ≤ 2.
+- `rothNumber_four : rothNumber 4 = 2` — `le_antisymm`; upper bound
+  via `rothNumber_def` + `Finset.sup_le` + `apFree_four_card_le_two`,
+  lower bound via `card_le_rothNumber {0,1}` + defeq-unfold `decide`
+  (identical idiom to the green `rothNumber_three`).
+
+Axiom-free, 0 new sorries. Note `r₃(4) = 2 = r₃(3)`: `r₃` is not
+monotone in `N`. The four landmark sorries (Roth/Behrend/
+Bloom–Sisask/Kelley–Meka) remain multi-PR efforts, untouched.
+
+**BUILD STATUS**: NOT Docker-verified — the containerd blob I/O
+error still blocks all Docker builds for every agent (disk healthy
+at 33%; needs a Docker/containerd restart, not space). PR gated with
+`loom:review-requested` so the deployer will NOT auto-merge until a
+build passes. The `decide` over `Finset (ZMod 4)` (16 subsets) is
+the sole novel construct; everything else mirrors proven-green
+lemmas.
+
 **S6 ACT REPAIR (researcher-1, 2026-06-12)** — Implemented the full
 fresh-build repair AND found the true root cause S3–S5 all missed:
 **the `noncomputable def rothNumber` itself never compiled on fresh

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -218,9 +218,9 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 306,
+    "lineCount": 339,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 2,
     "path": "Proofs/RothTheoremQuantitative.lean",
     "sorries": 4,


### PR DESCRIPTION
## Summary

Executes the drafted **S7 small-N pin** for `roth-theorem-k3-oq-01`, sharpening it from the planned `[2, 3]` range to the **exact value r₃(4) = 2**. Two new theorems in `proofs/Proofs/RothTheoremQuantitative.lean` (after `rothNumber_three`):

- **`apFree_four_card_le_two`** — every AP-free subset of `ZMod 4` has at most two elements. Math key: in `ZMod 4` the step `d = 2` wraps around (`a + 2·2 = a + 4 = a`), so an AP-free set may contain at most one of `{0, 2}` and one of `{1, 3}`, capping the size at 2. Proved by `decide` on the **unfolded** predicate (the file's global `APFree` decidability instance is classical and cannot evaluate; stating the ∀-form directly lets `decide` use the computable `Fintype (ZMod 4)` instances — the same reason `rothNumber_three` unfolds before `decide`).
- **`rothNumber_four : rothNumber 4 = 2`** — `le_antisymm`: upper bound via `rothNumber_def` + `Finset.sup_le` + the lemma above; lower bound via `card_le_rothNumber {0,1}` + defeq-unfold `decide` (identical idiom to the green `rothNumber_three`).

Note **`r₃(4) = 2 = r₃(3)`**: the Roth number is not monotone in `N` — a small but genuine structural fact complementing the existing supermultiplicativity results (`rothNumber_mul_coprime`, `two_mul_rothNumber_le`).

## Integrity

- **Axiom-free**, **0 new sorries**. The four landmark bound sorries (Roth 1953 / Behrend 1946 / Bloom–Sisask 2020 / Kelley–Meka 2023) are untouched multi-PR efforts.
- `meta.json` counts bumped by delta (+2 theorems, +33 lines).

## ⚠️ Build verification pending

**NOT Docker-verified.** The containerd blob I/O error (`/var/lib/desktop-containerd/.../blobs/...: input/output error`) still blocks `./proofs/scripts/docker-build.sh` for every agent (disk is healthy at 33% — this needs a Docker/containerd **restart**, not space). 

This PR is gated with `loom:review-requested` so the deployer does **not** auto-merge before a build passes. The `decide` over `Finset (ZMod 4)` (16 subsets) is the sole novel construct; the lower bound and all supporting lemmas mirror proven-green code. **Please run `./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative` before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)