### PR TITLE
Research: seeker replenish pool 14→19 — 5 diverse challenging candidates

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: abel-ruffini-galois-extensions-oq-04-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/literature/README.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for abel-ruffini-galois-extensions-oq-04-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/problem.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/problem.md
@@ -1,0 +1,120 @@
+# Problem: Schreier Refinement Theorem and the Zassenhaus Butterfly Lemma
+
+**Slug**: abel-ruffini-galois-extensions-oq-04-oq-03
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+**Zassenhaus (butterfly) lemma.** Let $A \trianglelefteq A^\ast$ and $B \trianglelefteq B^\ast$ be subgroups of a group $G$. Then
+$$
+\frac{A\,(A^\ast \cap B^\ast)}{A\,(A^\ast \cap B)} \;\cong\; \frac{B\,(B^\ast \cap A^\ast)}{B\,(B^\ast \cap A)} .
+$$
+
+**Schreier refinement theorem.** Any two subnormal (normal) series of a group admit equivalent refinements: there exist refinements with the same multiset of factor groups up to isomorphism.
+
+### Plain Language
+
+The parent entry formalizes Jordan–Hölder uniqueness via Mathlib's `JordanHolderLattice`. The standard textbook route to Jordan–Hölder goes through Schreier refinement, which in turn rests on the Zassenhaus butterfly lemma. Neither Schreier refinement nor the Zassenhaus lemma is currently in Mathlib. This problem asks to formalize them, giving a self-contained derivation of comparability of composition series that does not merely reuse Mathlib's abstract lattice-theoretic Jordan–Hölder.
+
+### Why This Matters
+
+The Zassenhaus lemma and Schreier refinement are foundational group theory taught in every first algebra course, yet absent from Mathlib. Adding them fills a genuine library gap, provides an independent second proof route to Jordan–Hölder, and supplies reusable machinery for module composition series and the general theory of subnormal series.
+
+## Known Results
+
+### What's Already Proven
+
+- Jordan–Hölder uniqueness through the abstract lattice interface — parent `abel-ruffini-galois-extensions-oq-04` and Mathlib's `CompositionSeries.jordan_holder`.
+- Second and third isomorphism theorems for groups — `Mathlib.GroupTheory.QuotientGroup`.
+- The `JordanHolderLattice` typeclass and its consequences.
+
+### What's Still Open
+
+- The Zassenhaus butterfly lemma as a named, reusable Mathlib-style theorem.
+- The Schreier refinement theorem for (sub)normal series.
+- A Jordan–Hölder derivation via Schreier that is logically independent of the existing lattice proof.
+
+### Our Goal
+
+Formalize the Zassenhaus lemma for subgroups with the stated isomorphism, then use it to prove Schreier refinement, and (stretch) re-derive comparability of composition series without invoking `JordanHolderLattice`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| abel-ruffini-galois-extensions-oq-04 | Parent: Jordan–Hölder via lattice | `JordanHolderLattice`, composition series |
+| abel-ruffini-galois-extensions-oq-03-oq-01 | Solvability / normal series context | subnormal series, solvable groups |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — isomorphism-theorem assembly**: Build the butterfly lemma directly from the second isomorphism theorem applied twice to the products $A(A^\ast \cap B^\ast)$ and $B(B^\ast \cap A^\ast)$, exhibiting both quotients as $(A^\ast \cap B^\ast)/\bigl((A^\ast \cap B)(A \cap B^\ast)\bigr)$.
+   - Why it might work: the classical proof reduces the whole lemma to one common middle quotient via the second isomorphism theorem, all of which Mathlib has.
+   - Risk: the normality bookkeeping ($A \trianglelefteq A^\ast$ giving $A^\ast \cap B \trianglelefteq A^\ast \cap B^\ast$, etc.) is fiddly and Mathlib's `Subgroup.normal` lemmas may not cover every intersection/product needed.
+
+2. **Approach B — refinement first, lemma as a black box**: State Schreier refinement, insert Zassenhaus as the key inductive step, and prove Zassenhaus only in the form actually consumed.
+   - Why it might work: minimizes the surface of the butterfly lemma to what is needed.
+   - Risk: harder to reuse; still needs the core isomorphism.
+
+### Key Difficulties
+
+- Establishing all the normality relations among products and intersections of the four subgroups.
+- Managing Mathlib's `Subgroup` product (`Subgroup.mul` / `⊔`) versus set-product `A * B` and their normality lemmas.
+- Bookkeeping the "equivalent refinement" as a multiset/permutation of factor isomorphisms.
+
+### What Would a Proof Need?
+
+- Key lemma 1: normality of $A(A^\ast \cap B) \trianglelefteq A(A^\ast \cap B^\ast)$ and its mirror.
+- Key lemma 2: both butterfly quotients isomorphic to the common middle quotient (double application of the second isomorphism theorem).
+- Technical requirements: `QuotientGroup.quotientMulEquivOfEq`, second isomorphism theorem, `Subgroup.normal_comap`/product-normality lemmas.
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- The core isomorphism is standard and every ingredient (isomorphism theorems, subgroup products) exists in Mathlib.
+- The difficulty is entirely in normality bookkeeping and product/intersection subgroup manipulation, which is notoriously verbose in Lean.
+- No comparable formalization exists yet, so there is no template to copy.
+
+**Estimated Effort**:
+- Exploration: 2–3 days to nail down the subgroup product/normality API.
+- If tractable: 1–2 weeks for the butterfly lemma; Schreier refinement adds more.
+- If hard: the multiset-of-factors equivalence could be a substantial separate effort.
+
+## References
+
+### Papers
+- Zassenhaus, "Zum Satz von Jordan-Hölder-Schreier", *Abh. Math. Sem. Univ. Hamburg* 10 (1934).
+- Lang, *Algebra* (3rd ed.), Chapter I — butterfly lemma and Schreier refinement.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/ — `QuotientGroup`, `Subgroup`, `CompositionSeries`.
+
+### Mathlib
+- `Mathlib.GroupTheory.QuotientGroup` — isomorphism theorems.
+- `Mathlib.Order.JordanHolder` — `JordanHolderLattice`, `CompositionSeries.jordan_holder`.
+- `Mathlib.GroupTheory.Subgroup.Basic` — subgroup products and normality.
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - jordan-holder
+  - composition-series
+  - zassenhaus-lemma
+  - schreier-refinement
+  - abel-ruffini
+related_proofs:
+  - abel-ruffini-galois-extensions-oq-04
+  - abel-ruffini-galois-extensions-oq-03-oq-01
+difficulty: high
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: abel-ruffini-galois-extensions-oq-04-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T17:46:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/literature/README.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/problem.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/problem.md
@@ -1,0 +1,117 @@
+# Problem: Dense Countable Sets are Fσ but not Gδ in Perfect Polish Spaces
+
+**Slug**: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\, X \text{ a perfect Polish space},\ \forall\, D \subseteq X \text{ countable and dense}:\quad D \in \mathbf{\Sigma}^0_2 \ \wedge\ D \notin \mathbf{\Pi}^0_2 .
+$$
+
+Equivalently, every dense countable subset of a nonempty perfect Polish space is $F_\sigma$ (a countable union of closed sets) but not $G_\delta$ (a countable intersection of open sets).
+
+### Plain Language
+
+The parent entry shows that the algebraic reals are $F_\sigma$ but not $G_\delta$, while the transcendental reals form a dense $G_\delta$. That proof rests on Baire category: a dense $G_\delta$ set is "large", and a dense countable set cannot also be $G_\delta$ or its complement (also dense $G_\delta$) would meet it, contradicting Baire. This problem abstracts the argument once and for all: replace "algebraic reals in $\mathbb{R}$" by "any countable dense set in any perfect Polish space", recovering the $\mathbb{Q} \subseteq \mathbb{R}$ and algebraic-reals cases as instances.
+
+### Why This Matters
+
+This is the natural home for a family of scattered results. A single abstract theorem yields, as corollaries: $\mathbb{Q}$ is not $G_\delta$ in $\mathbb{R}$; the algebraic reals are not $G_\delta$; any countable dense subset of $\mathbb{R}^n$, Cantor space, or Baire space is not $G_\delta$. It is a clean, citable descriptive-set-theory lemma and removes duplication across gallery entries.
+
+## Known Results
+
+### What's Already Proven
+
+- `algebraicReals_not_isGδ` — the concrete algebraic-reals case (parent `algebraic-numbers-countable-oq-02-oq-03-oq-02`).
+- The transcendental reals are a dense $G_\delta$ (sibling entry).
+- Baire category theorem for complete metric / Polish spaces — `Mathlib.Topology.Baire`.
+- A countable set with no isolated points-hypothesis fails to be $G_\delta$ in a Baire space where singletons are nowhere dense.
+
+### What's Still Open
+
+- The uniform statement quantified over all perfect Polish spaces and all countable dense subsets.
+- The clean packaging so `ℚ ⊆ ℝ`, algebraic reals, and Cantor/Baire space are one-line instances.
+
+### Our Goal
+
+State and prove `denseCountable_isFσ_not_isGδ`: in a nonempty perfect Polish space, a countable dense set is $F_\sigma$ and not $G_\delta$, then re-derive the parent's `algebraicReals_not_isGδ` from it.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| algebraic-numbers-countable-oq-02-oq-03-oq-02 | Direct parent (concrete case) | Baire category, $G_\delta$ complement |
+| algebraic-numbers-countable-oq-02-oq-03 | Transcendental reals dense $G_\delta$ | dense $G_\delta$, comeager sets |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Baire via the complement**: A countable set $D$ is $F_\sigma$ (union of its singletons, each closed in a $T_1$ space). If $D$ were also $G_\delta$, then in a perfect space each singleton is nowhere dense, so $D$ is meager; but a dense $G_\delta$ is comeager, and meager + comeager forces the whole space to be meager, contradicting Baire.
+   - Why it might work: exactly the parent's argument, only the ambient space is generalized.
+   - Risk: need the perfectness hypothesis (no isolated points) to guarantee singletons are nowhere dense.
+
+2. **Approach B — direct nowhere-dense intersection**: Show $D$ dense $G_\delta$ and its dense $G_\delta$ complement would be disjoint dense comeager sets, impossible in a Baire space.
+   - Why it might work: symmetric and short.
+   - Risk: constructing the complement's $G_\delta$ structure requires $D$ countable, needs care.
+
+### Key Difficulties
+
+- Correctly capturing "perfect" (`Perfect` / no isolated points) so singletons are nowhere dense.
+- Choosing Mathlib's spelling of $F_\sigma$ / $G_\delta$ (`IsGδ`, `IsFsigma` if present, or via `residual`/`meager`).
+
+### What Would a Proof Need?
+
+- Key lemma 1: in a perfect $T_1$ space, every singleton is nowhere dense, hence a countable set is meager.
+- Key lemma 2: a dense $G_\delta$ in a Baire space is comeager; a meager comeager set is empty-complemented, contradiction.
+- Technical requirements: `Perfect`, `IsGδ`, `meager`/`residual`, Baire category API.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematical content is already validated in the concrete parent case.
+- The work is abstraction: identifying the minimal hypotheses (perfect Polish, or perfect + Baire + $T_1$) and threading Mathlib's `IsGδ`/`meager` lemmas.
+- Mathlib already has strong Baire-category infrastructure.
+
+**Estimated Effort**:
+- Exploration: 1 day to survey `IsGδ` / `meager` / `Perfect` API.
+- If tractable: 2–4 days including re-deriving the parent as a corollary.
+- If hard: only if the $F_\sigma$ side lacks direct Mathlib support.
+
+## References
+
+### Papers
+- Kechris, *Classical Descriptive Set Theory* (1995), Section 8 — Borel hierarchy, Baire category, perfect Polish spaces.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/ — `IsGδ`, `Perfect`, `residual`, `meager`.
+
+### Mathlib
+- `Mathlib.Topology.Baire` — Baire category theorem.
+- `Mathlib.Topology.GDelta` — `IsGδ` API.
+- `Mathlib.Topology.Perfect` — perfect sets / no isolated points.
+
+## Metadata
+
+```yaml
+tags:
+  - topology
+  - baire-category
+  - descriptive-set-theory
+  - gdelta-set
+  - borel-hierarchy
+  - real-analysis
+related_proofs:
+  - algebraic-numbers-countable-oq-02-oq-03-oq-02
+  - algebraic-numbers-countable-oq-02-oq-03
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T17:46:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/knowledge.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: angle-trisection-oq-02-oq-01-oq-02-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/literature/README.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for angle-trisection-oq-02-oq-01-oq-02-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/problem.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/problem.md
@@ -1,0 +1,118 @@
+# Problem: Full Wantzel–Galois Constructibility Theorem via Mathlib Galois Theory
+
+**Slug**: angle-trisection-oq-02-oq-01-oq-02-oq-03
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+A complex number $\alpha$ is straightedge-and-compass constructible if and only if there is a tower
+$$
+\mathbb{Q} = F_0 \subseteq F_1 \subseteq \dots \subseteq F_m,\qquad [F_{i+1}:F_i] = 2,\qquad \alpha \in F_m .
+$$
+Equivalently (Wantzel–Galois form): $\alpha$ is constructible iff $\alpha$ is algebraic over $\mathbb{Q}$ and the Galois group of the Galois closure of $\mathbb{Q}(\alpha)/\mathbb{Q}$ is a $2$-group; in particular constructibility forces $[\mathbb{Q}(\alpha):\mathbb{Q}]$ to be a power of $2$.
+
+### Plain Language
+
+The parent entry establishes the constructibility framework and the degree-power-of-two necessary condition. This problem asks for the full biconditional using Mathlib's Galois correspondence `IntermediateField.orderIsoOfGal` together with the structure theory of finite $2$-groups (existence of a chief series with index-$2$ steps, since a $p$-group has normal subgroups of every order). The characterization then upgrades the "degree is a power of two" necessary condition to a genuine iff by building the quadratic tower from the group-side subnormal series.
+
+### Why This Matters
+
+This is the definitive statement behind the three classical impossibility theorems (trisecting the angle, doubling the cube, squaring the circle via constructibility). A Galois-theoretic proof, rather than an ad hoc tower argument, connects the gallery's constructibility work to Mathlib's substantial Galois correspondence and $p$-group theory, and gives a single reusable theorem from which all impossibility corollaries follow.
+
+## Known Results
+
+### What's Already Proven
+
+- Constructibility implies $[\mathbb{Q}(\alpha):\mathbb{Q}]$ is a power of $2$ — parent `angle-trisection-oq-02-oq-01-oq-02`.
+- Angle trisection / cube duplication impossibility from the degree obstruction — sibling gallery entries.
+- Mathlib Galois correspondence `IntermediateField.orderIsoOfGal`, `IsGalois`, and fundamental theorem.
+- $p$-groups have a normal subgroup of each order dividing $|G|$ — `Mathlib.GroupTheory.PGroup` / Sylow development.
+
+### What's Still Open
+
+- The sufficiency direction phrased through the Galois closure and a $2$-group chief series, i.e. building the index-$2$ tower from the group side.
+- The clean biconditional `IsConstructible α ↔ (IsIntegral ℚ α ∧ IsPGroup 2 (Gal (normalClosure ...)))`.
+
+### Our Goal
+
+Prove the Wantzel–Galois biconditional: assemble the Galois-closure $2$-group condition, use $p$-group chief series to produce the quadratic tower, and connect it to the existing constructibility predicate — recovering the degree condition as a corollary.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| angle-trisection-oq-02-oq-01-oq-02 | Parent: degree power-of-two necessity | quadratic towers, field degree |
+| angle-trisection-oq-02-oq-01 | Constructibility predicate setup | tower of quadratic extensions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — Galois closure + 2-group chief series**: Take $L$ = Galois closure of $\mathbb{Q}(\alpha)$; if $\mathrm{Gal}(L/\mathbb{Q})$ is a $2$-group, use the $p$-group normal-series theorem to get $1 = G_0 \trianglelefteq \dots \trianglelefteq G_m = G$ with $[G_{i+1}:G_i]=2$, then translate through `orderIsoOfGal` into the fixed-field tower with $[F_{i+1}:F_i]=2$.
+   - Why it might work: every ingredient (`orderIsoOfGal`, $p$-group series) is in Mathlib.
+   - Risk: connecting the abstract fixed-field tower to the gallery's concrete `IsConstructible` predicate may need bridging lemmas about towers of quadratic extensions.
+
+2. **Approach B — direct induction on the tower without closure**: Strengthen the parent by induction, avoiding the Galois closure, matching each quadratic step to a constructibility step.
+   - Why it might work: closer to the existing proof; less Galois machinery.
+   - Risk: this is essentially the classical elementary route and may not exercise `orderIsoOfGal` as the problem intends; the "only if" with non-normal $\mathbb{Q}(\alpha)$ still needs the closure.
+
+### Key Difficulties
+
+- Relating the Mathlib `IntermediateField` fixed-field tower to the gallery's constructibility predicate.
+- Handling non-Galois $\mathbb{Q}(\alpha)$ by passing to the normal/Galois closure and controlling its degree.
+- $p$-group chief-series API: extracting an index-$2$ normal series in usable form.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a finite $2$-group has a chief series with all factors of order $2$ (from `IsPGroup`).
+- Key lemma 2: `orderIsoOfGal` turns that subgroup series into an intermediate-field tower with $[F_{i+1}:F_i]=2$.
+- Key lemma 3: a quadratic tower over $\mathbb{Q}$ containing $\alpha$ implies `IsConstructible α` and conversely.
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**:
+- Mathlib's Galois correspondence and $p$-group theory are mature, which is a strong asset.
+- The bridge between the abstract tower and the concrete geometric constructibility predicate is the real risk and may be the bulk of the work.
+- Comparable but strictly easier (degree-only) results already live in the gallery.
+
+**Estimated Effort**:
+- Exploration: 2–3 days to map `orderIsoOfGal` and `IsPGroup` series API.
+- If tractable: 1–2 weeks for the full biconditional.
+- If hard: the closure-degree and predicate-bridge steps could extend this considerably.
+
+## References
+
+### Papers
+- Wantzel, "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas", *J. Math. Pures Appl.* (1837).
+- Stewart, *Galois Theory* (4th ed.), Chapters on constructibility and the three classical problems.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/ — `IntermediateField.orderIsoOfGal`, `IsGalois`, `IsPGroup`.
+
+### Mathlib
+- `Mathlib.FieldTheory.Galois` — Galois correspondence, `orderIsoOfGal`.
+- `Mathlib.GroupTheory.PGroup` — $p$-group normal-subgroup existence.
+- `Mathlib.FieldTheory.IntermediateField` — intermediate-field towers and degrees.
+
+## Metadata
+
+```yaml
+tags:
+  - geometry
+  - galois-theory
+  - constructibility
+  - impossibility
+  - p-groups
+related_proofs:
+  - angle-trisection-oq-02-oq-01-oq-02
+  - angle-trisection-oq-02-oq-01
+difficulty: high
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-02-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: angle-trisection-oq-02-oq-01-oq-02-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T17:46:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/literature/README.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/problem.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/problem.md
@@ -1,0 +1,116 @@
+# Problem: Uniform Fiber Transfer via MeasureTheory.Measure.map
+
+**Slug**: ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+Let $f : A \to T$ be a measurable surjection between finite (or measurable) sets all of whose fibers have equal cardinality $c$. Then pushing the restricted counting measure along $f$ scales it by $c$:
+$$
+\bigl(\operatorname{Measure.count}\restriction A\bigr).\mathrm{map}\, f \;=\; c \cdot \bigl(\operatorname{Measure.count}\restriction T\bigr),
+$$
+and consequently the induced uniform probability measure `uniformOn A` pushes forward to `uniformOn T`.
+
+### Plain Language
+
+The parent entry ("General Uniform Fiber Transfer") proves, event by event, that an equal-fiber surjection preserves the uniform distribution — it transfers `uniformOn` on the domain to `uniformOn` on the codomain. This problem asks whether that fact can be lifted to the clean, structural statement about `MeasureTheory.Measure.map`: rather than checking each event, express the whole transfer as a single pushforward identity for `Measure.count` restricted to $A$ and $T$.
+
+### Why This Matters
+
+Equal-fiber counting arguments underlie the reflection/counting proofs of the ballot problem and many combinatorial-probability identities. A one-line `Measure.map` formulation is far more reusable than per-event equalities: it plugs directly into Mathlib's measure-theoretic machinery (change of variables, expectation transport) and makes the ballot-problem formalization compose with the general theory instead of re-deriving transfers by hand.
+
+## Known Results
+
+### What's Already Proven
+
+- Event-wise uniform fiber transfer: `uniformOn A` maps to `uniformOn T` under an equal-fiber surjection — parent `ballot-problem-oq-01-oq-02-oq-01-oq-02`.
+- `Measure.count` and its restriction API — `Mathlib.MeasureTheory.Measure.Count`.
+- `Measure.map` pushforward and its behavior on measurable functions — `Mathlib.MeasureTheory.Measure.Map`.
+- `uniformOn` (formerly `condCount`) as normalized restricted counting measure.
+
+### What's Still Open
+
+- The structural identity `(Measure.count.restrict A).map f = c • Measure.count.restrict T` for equal-fiber $f$.
+- The corollary that `uniformOn A` maps to `uniformOn T` derived from that identity rather than event-wise.
+
+### Our Goal
+
+Prove the `Measure.map` pushforward identity for equal-fiber measurable surjections and recover the parent's uniform-transfer statement as a normalization corollary.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| ballot-problem-oq-01-oq-02-oq-01-oq-02 | Parent: event-wise uniform transfer | `uniformOn`, fiber cardinality |
+| ballot-problem-oq-01-oq-02-oq-01 | Fiber-transfer setup | equal-fiber surjection, counting |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — evaluate on singletons then extend**: Compute both sides on singletons $\{t\}$: the pushforward mass at $t$ is $\operatorname{count}(f^{-1}\{t\} \cap A) = c$, matching $c \cdot \operatorname{count}\{t\}$. Extend to all measurable sets by countable additivity / the fact that counting measure is determined by its values on singletons.
+   - Why it might work: `Measure.count` is a sum of Diracs, so `map` commutes with the sum and each fiber contributes exactly $c$.
+   - Risk: Mathlib's `Measure.map` requires measurability of $f$; on general measurable spaces the singleton argument needs `MeasurableSingletonClass`.
+
+2. **Approach B — via `Measure.map_apply` on preimages**: For measurable $S \subseteq T$, `(count.restrict A).map f S = count (A ∩ f⁻¹ S) = c * count S` using the equal-fiber hypothesis summed over $S$.
+   - Why it might work: directly uses `Measure.map_apply` and additivity over the fibers of $S$.
+   - Risk: summing fiber cardinalities over an arbitrary (possibly infinite) measurable $S$ needs `tsum` bookkeeping.
+
+### Key Difficulties
+
+- Measurability side-conditions for `Measure.map` (needs $f$ measurable, likely `MeasurableSingletonClass` on $T$).
+- Turning "every fiber has cardinality $c$" into a summed identity Mathlib can discharge with `tsum`/`Finset.sum`.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `(Measure.count.restrict A) (f⁻¹ S) = c * Measure.count S` for measurable $S \subseteq T$, from equal fibers.
+- Key lemma 2: `Measure.map_apply` reduces the pushforward to preimage measure, closing the identity.
+- Technical requirements: `MeasurableSingletonClass`, `Measure.count` as a sum of Diracs, `uniformOn` normalization.
+
+## Tractability Assessment
+
+**Difficulty**: Medium (leaning tractable)
+
+**Justification**:
+- The mathematical content is already validated event-wise in the parent; this is a reformulation into Mathlib's canonical `Measure.map` idiom.
+- `Measure.count` and `Measure.map` both have solid Mathlib APIs.
+- Main friction is measurability plumbing and `tsum` summation, not deep mathematics.
+
+**Estimated Effort**:
+- Exploration: half a day to a day mapping `Measure.count` / `Measure.map` lemmas.
+- If tractable: 2–4 days for the pushforward identity plus the `uniformOn` corollary.
+- If hard: only if infinite-support measurability cases prove awkward.
+
+## References
+
+### Papers
+- Feller, *An Introduction to Probability Theory and Its Applications*, Vol. 1 — ballot problem and reflection/counting arguments.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/ — `MeasureTheory.Measure.count`, `MeasureTheory.Measure.map`, `uniformOn`.
+
+### Mathlib
+- `Mathlib.MeasureTheory.Measure.Count` — counting measure.
+- `Mathlib.MeasureTheory.Measure.Map` — pushforward `Measure.map`, `Measure.map_apply`.
+- `Mathlib.Probability.UniformOn` — uniform distribution on finite sets.
+
+## Metadata
+
+```yaml
+tags:
+  - probability
+  - combinatorics
+  - ballot-problem
+  - measure-theory
+  - fiber-transfer
+related_proofs:
+  - ballot-problem-oq-01-oq-02-oq-01-oq-02
+  - ballot-problem-oq-01-oq-02-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T17:46:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: cauchy-interlacing-theorem-oq-01-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/literature/README.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for cauchy-interlacing-theorem-oq-01-oq-01-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,119 @@
+# Problem: Matrix-Level Cauchy Interlacing from the Compression Identity
+
+**Slug**: cauchy-interlacing-theorem-oq-01-oq-01-oq-01
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{compress}(\text{toEuclideanLin}\, A)\, H \;\cong_U\; \text{toEuclideanLin}\bigl(A.\text{submatrix}\; j.\text{succAbove}\; j.\text{succAbove}\bigr)
+$$
+
+so that for a Hermitian $A \in \mathbb{C}^{n\times n}$ with eigenvalues $\lambda_1 \ge \dots \ge \lambda_n$ and the principal $(n-1)\times(n-1)$ submatrix $B$ obtained by deleting row and column $j$, with eigenvalues $\mu_1 \ge \dots \ge \mu_{n-1}$, one has the interlacing
+$$
+\lambda_{k+1} \le \mu_k \le \lambda_k, \qquad 1 \le k \le n-1 .
+$$
+
+### Plain Language
+
+The parent gallery entry proves the geometric fact that orthogonally compressing a linear map to the coordinate hyperplane $H = e_j^{\perp}$ yields exactly the principal submatrix of $A$ with row and column $j$ deleted. This problem closes the loop: package that identity into the classical matrix statement that the eigenvalues of the deleted-row-and-column principal submatrix interlace the eigenvalues of $A$.
+
+### Why This Matters
+
+Cauchy interlacing is a workhorse of spectral graph theory, numerical linear algebra, and perturbation theory. Mathlib has the abstract min–max (Courant–Fischer) machinery and now the compression-equals-submatrix bridge, but no user-facing corollary phrased with `Matrix.submatrix` and eigenvalues. Supplying it makes the theorem citable by downstream results such as eigenvalue bounds for graphs, quadrature, and Sturm sequences.
+
+## Known Results
+
+### What's Already Proven
+
+- Orthogonal compression to $e_j^{\perp}$ equals the principal submatrix — parent proof `cauchy-interlacing-theorem-oq-01-oq-01`.
+- Courant–Fischer min–max characterization of Hermitian eigenvalues — Mathlib spectral API.
+- Interlacing for a self-adjoint operator restricted to a codimension-one subspace — the abstract form underlying the parent entry.
+
+### What's Still Open
+
+- The explicit unitary equivalence `compress (toEuclideanLin A) H ≃ toEuclideanLin (A.submatrix j.succAbove j.succAbove)` as a bundled `LinearIsometryEquiv`.
+- The final `Matrix`-level corollary stated with `Matrix.IsHermitian.eigenvalues` and monotone-ordered eigenvalue indices.
+
+### Our Goal
+
+Prove the matrix-level interlacing corollary $\lambda_{k+1} \le \mu_k \le \lambda_k$ for the delete-$j$ principal submatrix, using the compression identity plus the abstract subspace-interlacing theorem, with the isometry $e_{j.\text{succAbove}\, i} \mapsto e_i$ made explicit.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| cauchy-interlacing-theorem-oq-01-oq-01 | Direct parent: compression equals principal submatrix | orthogonal projection, `toEuclideanLin` |
+| cauchy-interlacing-theorem-oq-01 | Abstract subspace interlacing | Courant–Fischer min–max |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — build the isometry first**: Construct the `LinearIsometryEquiv` from `EuclideanSpace ℂ (Fin (n-1))` onto $H = e_j^{\perp}$ sending $e_i \mapsto e_{j.\text{succAbove}\, i}$, then transport eigenvalues through it.
+   - Why it might work: `Fin.succAbove` is exactly the "skip index $j$" embedding, so the basis correspondence is essentially definitional.
+   - Risk: bookkeeping between `orthogonalProjection`, `Submodule.subtypeₗᵢ`, and `toEuclideanLin` may need several bridging `ext`/`simp` lemmas.
+
+2. **Approach B — go through quadratic forms**: Show the Rayleigh quotients of $B$ on $\mathbb{C}^{n-1}$ coincide with those of $A$ restricted to $H$, then apply min–max directly without an explicit unitary.
+   - Why it might work: avoids bundling the isometry; only needs equality of Rayleigh quotients on matching subspaces.
+   - Risk: min–max index alignment ($k$ versus $k+1$) is error-prone; still needs the compression identity.
+
+### Key Difficulties
+
+- Aligning Mathlib's eigenvalue ordering conventions with the interlacing indices $k$ and $k+1$.
+- Cleanly transporting the self-adjoint structure across the isometry so `IsHermitian` is preserved on the submatrix.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `compress (toEuclideanLin A) H` is unitarily equivalent to `toEuclideanLin (A.submatrix j.succAbove j.succAbove)` (bundled isometry).
+- Key lemma 2: eigenvalues are invariant under unitary equivalence (available in Mathlib).
+- Technical requirements: `Fin.succAbove` basis embedding, `orthogonalProjection` API, Courant–Fischer with correct index conventions.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The hard geometric step (compression equals submatrix) is already done in the parent.
+- Remaining work is largely glue: an explicit isometry plus an index-careful application of an existing min–max theorem.
+- Similar unitary-transport-of-eigenvalues arguments already appear in Mathlib's spectral theorem development.
+
+**Estimated Effort**:
+- Exploration: 1–2 days to map the exact Mathlib API surface.
+- If tractable: 3–5 days for the bundled isometry and final corollary.
+- If hard: index-convention friction could extend this.
+
+## References
+
+### Papers
+- Horn & Johnson, *Matrix Analysis* (2nd ed., 2013), Section 4.3 — Cauchy interlacing and eigenvalues of principal submatrices.
+
+### Online Resources
+- https://leanprover-community.github.io/mathlib4_docs/ — `Matrix.IsHermitian.eigenvalues`, `EuclideanSpace`, `toEuclideanLin`.
+
+### Mathlib
+- `Mathlib.Analysis.InnerProductSpace.Spectrum` — spectral theorem and eigenvalue min–max.
+- `Mathlib.LinearAlgebra.Matrix.Hermitian` — Hermitian matrix eigenvalue API.
+- `Fin.succAbove` — the delete-index embedding.
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - spectral
+  - hermitian
+  - cauchy-interlacing
+  - principal-submatrix
+  - eigenvalues
+related_proofs:
+  - cauchy-interlacing-theorem-oq-01-oq-01
+  - cauchy-interlacing-theorem-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cauchy-interlacing-theorem-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: cauchy-interlacing-theorem-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T17:46:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Seeker Replenishment

The available candidate pool (`.lean/state/candidate-pool.json`) dropped to **14**, below the seeker threshold of **15**. This PR adds **5 fresh, genuinely-open** formalization problems spanning distinct mathematical domains, bringing the pool to **19 available**.

### Selected problems

| Slug | Domain | Sig | Tract | Summary |
|------|--------|-----|-------|---------|
| `cauchy-interlacing-theorem-oq-01-oq-01-oq-01` | linear algebra / spectral | 6 | 7 | Matrix-level Cauchy interlacing corollary from the compression=submatrix identity |
| `algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01` | topology / descriptive set theory | 6 | 6 | Dense countable sets are Fσ but not Gδ in perfect Polish spaces |
| `abel-ruffini-galois-extensions-oq-04-oq-03` | group theory | 7 | 5 | Zassenhaus butterfly lemma + Schreier refinement (genuine Mathlib gap) |
| `angle-trisection-oq-02-oq-01-oq-02-oq-03` | geometry / Galois | 7 | 5 | Full Wantzel–Galois constructibility via `orderIsoOfGal` + 2-group series |
| `ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01` | probability / measure | 5 | 7 | Uniform fiber transfer via `MeasureTheory.Measure.map` |

Each is a child of an existing verified gallery entry, so the surrounding context and techniques are already in place — these close well-scoped follow-up gaps rather than open moonshots.

### Provenance / validation
- Confirmed all 5 slugs were fresh (absent from DB and the 3903-entry pool).
- Inserted into `research/db/knowledge.db`, regenerated `research/candidate-pool.json` via `sync_pool.py`, and surgically appended to `.lean/state/candidate-pool.json` (both gitignored local state).
- All 5 `problem.md` stubs filled with genuine content and **pass `validate-seeker-stubs.ts`** (no template placeholders leak to the gallery).

Only the tracked `research/problems/*/` workspaces are in this PR; pool/DB state is gitignored and already updated on disk for researchers to claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)