### PR TITLE
Enrich Cyclotomic Polynomials structural entry: add crossReferences (0→4)

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -193,9 +193,30 @@
     "implications": "Commutativity under composition places the Chebyshev family, alongside the power maps xⁿ, at the centre of Ritt's 1923 classification of commuting polynomials. The monoid-morphism viewpoint makes the Chebyshev indexing a faithful translation of integer multiplication into polynomial composition, a structure exploited in iteration, approximation theory, and fast multiple-angle evaluation. Because the law is a polynomial identity over an arbitrary commutative ring, all of this holds beyond the trigonometric setting where Tₙ originates.",
     "openQuestions": [
       "Formalize the converse direction of Ritt's theorem: characterize all polynomials that commute with a fixed Chebyshev polynomial Tₙ (n ≥ 2) as exactly the other Chebyshev polynomials (up to conjugation by an affine map).",
-      "Establish the analogous composition/commutation theory for the Chebyshev polynomials of the second kind Uₙ and the Dickson polynomials, identifying which structural laws survive."
+      "Establish the analogous composition/commutation theory for the Chebyshev polynomials of the second kind Uₙ and the Dickson polynomials, identifying which structural laws survive. (Carried out in the child entry chebyshev-polynomials-oq-01-oq-02.)"
     ]
   },
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01",
+      "relationship": "extended by",
+      "description": "Direct child. Where this entry proves the multiplicative composition law T_{mn} = T_m ∘ T_n, that entry proves the additive companion T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, coupling the first-kind Tₙ to the second-kind Uₙ — the additive counterpart to the composition structure established here."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-02",
+      "relationship": "extended by",
+      "description": "Direct child that resolves this entry's second open question: it develops the composition/commutation theory for the second-kind Chebyshev polynomials Uₙ and the Dickson polynomials, the analogue of the first-kind composition semigroup {Tₙ} proved here."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+      "relationship": "extended by",
+      "description": "Grandchild. Packages T_add, U_add, and the Pell/Cassini identity T² − (X²−1)U² = 1 into a single SL₂ matrix representation, whose multiplicativity re-encodes the composition and addition laws (including the T_{mn} = T_m ∘ T_n proved here) as matrix-power identities."
+    },
+    {
+      "targetId": "de-moivre-oq-01",
+      "relationship": "related",
+      "description": "The trigonometric origin: the multiple-angle formulas cos(nθ) = Tₙ(cos θ) come from De Moivre's theorem, and the composition law T_{mn} = T_m ∘ T_n proved here is precisely the polynomial shadow of cos(mnθ) = cos(m·(nθ)). That entry derives the explicit multiple-angle expansions from De Moivre; this one lifts their nesting structure to identities over an arbitrary commutative ring."
+    }
+  ],
   "sorries": 0
 }

--- a/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
@@ -130,6 +130,28 @@
       "Investigate the coefficients of $\\Phi_n$: they lie in $\\{-1,0,1\\}$ until $n=105$, where a coefficient $-2$ first appears — can this first 'non-flat' cyclotomic be machine-checked as a witness that the coefficients are not universally bounded by $1$?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "cyclotomic-polynomials-oq-02",
+      "relationship": "extended by",
+      "description": "Direct sibling that continues the structural program with the prime-power cyclotomics and the eval-at-one law Φ_n(1) ∈ {p, 1} (p when n is a prime power p^k, else 1) — the general evaluation refining the Φ_p(1) = p fact packaged here."
+    },
+    {
+      "targetId": "eisenstein-criterion-oq-01",
+      "relationship": "related",
+      "description": "Bears on this entry's second open question. Eisenstein's criterion (applied to Φ_p(X+1)) is the classical route to the irreducibility of the prime cyclotomic Φ_p over ℚ; that entry formalises Eisenstein and the irreducibility of Xⁿ − p, the irreducibility toolkit this entry's structural facts feed into."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The constructibility payoff of cyclotomic theory: the Gauss–Wantzel theorem, proved via cyclotomic fields, uses exactly the degree fact deg Φ_n = φ(n) = [ℚ(ζ_n):ℚ] established here (open question 2) to decide which regular n-gons are compass-and-straightedge constructible."
+    },
+    {
+      "targetId": "de-moivre-oq-05-oq-02",
+      "relationship": "related",
+      "description": "Relates to this entry's first open question (the Möbius-inversion form). It proves the sum of the primitive n-th roots of unity — the roots of Φ_n — equals μ(n), i.e. the second coefficient of Φ_n is −μ(n); a concrete Möbius-function shadow of the same divisor/inversion structure that governs the Φ_d factorization of Xⁿ − 1."
+    }
+  ],
   "references": [
     {
       "authors": "Gauss, Carl Friedrich",


### PR DESCRIPTION
Enrichment pass for `cyclotomic-polynomials-oq-01` (Degree φ(n), prime form, divisor product Xⁿ−1 = ∏ Φ_d). The entry had **no crossReferences key at all**. Added it with 4 links, three tied to the entry's open questions:

- **cyclotomic-polynomials-oq-02** (*extended by*) — prime-power cyclotomics and the eval-at-one law Φ_n(1) ∈ {p, 1}.
- **eisenstein-criterion-oq-01** (*related*) — Eisenstein's criterion, the classical irreducibility tool behind **open question 2**.
- **angle-trisection-oq-02-oq-03-oq-01** (*related*) — Gauss–Wantzel constructibility, which uses the deg Φ_n = φ(n) = [ℚ(ζ_n):ℚ] fact of **open question 2**.
- **de-moivre-oq-05-oq-02** (*related*) — sum of primitive n-th roots = μ(n), a Möbius shadow tied to **open question 1**.

Size 12.3 KB → 14.9 KB (under cap). `pnpm build` passes.