### PR TITLE
Enrich Eisenstein's Criterion (Xⁿ−p irreducibility): 0→4 cross-references

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -193,9 +193,30 @@
     "implications": "Commutativity under composition places the Chebyshev family, alongside the power maps xⁿ, at the centre of Ritt's 1923 classification of commuting polynomials. The monoid-morphism viewpoint makes the Chebyshev indexing a faithful translation of integer multiplication into polynomial composition, a structure exploited in iteration, approximation theory, and fast multiple-angle evaluation. Because the law is a polynomial identity over an arbitrary commutative ring, all of this holds beyond the trigonometric setting where Tₙ originates.",
     "openQuestions": [
       "Formalize the converse direction of Ritt's theorem: characterize all polynomials that commute with a fixed Chebyshev polynomial Tₙ (n ≥ 2) as exactly the other Chebyshev polynomials (up to conjugation by an affine map).",
-      "Establish the analogous composition/commutation theory for the Chebyshev polynomials of the second kind Uₙ and the Dickson polynomials, identifying which structural laws survive."
+      "Establish the analogous composition/commutation theory for the Chebyshev polynomials of the second kind Uₙ and the Dickson polynomials, identifying which structural laws survive. (Carried out in the child entry chebyshev-polynomials-oq-01-oq-02.)"
     ]
   },
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01",
+      "relationship": "extended by",
+      "description": "Direct child. Where this entry proves the multiplicative composition law T_{mn} = T_m ∘ T_n, that entry proves the additive companion T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, coupling the first-kind Tₙ to the second-kind Uₙ — the additive counterpart to the composition structure established here."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-02",
+      "relationship": "extended by",
+      "description": "Direct child that resolves this entry's second open question: it develops the composition/commutation theory for the second-kind Chebyshev polynomials Uₙ and the Dickson polynomials, the analogue of the first-kind composition semigroup {Tₙ} proved here."
+    },
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+      "relationship": "extended by",
+      "description": "Grandchild. Packages T_add, U_add, and the Pell/Cassini identity T² − (X²−1)U² = 1 into a single SL₂ matrix representation, whose multiplicativity re-encodes the composition and addition laws (including the T_{mn} = T_m ∘ T_n proved here) as matrix-power identities."
+    },
+    {
+      "targetId": "de-moivre-oq-01",
+      "relationship": "related",
+      "description": "The trigonometric origin: the multiple-angle formulas cos(nθ) = Tₙ(cos θ) come from De Moivre's theorem, and the composition law T_{mn} = T_m ∘ T_n proved here is precisely the polynomial shadow of cos(mnθ) = cos(m·(nθ)). That entry derives the explicit multiple-angle expansions from De Moivre; this one lifts their nesting structure to identities over an arbitrary commutative ring."
+    }
+  ],
   "sorries": 0
 }

--- a/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
@@ -130,6 +130,28 @@
       "Investigate the coefficients of $\\Phi_n$: they lie in $\\{-1,0,1\\}$ until $n=105$, where a coefficient $-2$ first appears — can this first 'non-flat' cyclotomic be machine-checked as a witness that the coefficients are not universally bounded by $1$?"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "cyclotomic-polynomials-oq-02",
+      "relationship": "extended by",
+      "description": "Direct sibling that continues the structural program with the prime-power cyclotomics and the eval-at-one law Φ_n(1) ∈ {p, 1} (p when n is a prime power p^k, else 1) — the general evaluation refining the Φ_p(1) = p fact packaged here."
+    },
+    {
+      "targetId": "eisenstein-criterion-oq-01",
+      "relationship": "related",
+      "description": "Bears on this entry's second open question. Eisenstein's criterion (applied to Φ_p(X+1)) is the classical route to the irreducibility of the prime cyclotomic Φ_p over ℚ; that entry formalises Eisenstein and the irreducibility of Xⁿ − p, the irreducibility toolkit this entry's structural facts feed into."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-oq-01",
+      "relationship": "related",
+      "description": "The constructibility payoff of cyclotomic theory: the Gauss–Wantzel theorem, proved via cyclotomic fields, uses exactly the degree fact deg Φ_n = φ(n) = [ℚ(ζ_n):ℚ] established here (open question 2) to decide which regular n-gons are compass-and-straightedge constructible."
+    },
+    {
+      "targetId": "de-moivre-oq-05-oq-02",
+      "relationship": "related",
+      "description": "Relates to this entry's first open question (the Möbius-inversion form). It proves the sum of the primitive n-th roots of unity — the roots of Φ_n — equals μ(n), i.e. the second coefficient of Φ_n is −μ(n); a concrete Möbius-function shadow of the same divisor/inversion structure that governs the Φ_d factorization of Xⁿ − 1."
+    }
+  ],
   "references": [
     {
       "authors": "Gauss, Carl Friedrich",

--- a/src/data/proofs/eisenstein-criterion-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/meta.json
@@ -103,7 +103,28 @@
       "mathContext": "$X^2-2,\\ X^3-2,\\ X^5-3$ irreducible over $\\mathbb{Z}$."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+      "relationship": "extended by",
+      "description": "Direct descendant that resolves this entry's first open question: it derives the irreducibility of the p-th cyclotomic polynomial Φ_p by applying the criterion to the shifted polynomial Φ_p(X + 1), whose coefficients are Eisenstein at p."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-01",
+      "relationship": "related",
+      "description": "The n = 3 application of this entry's flagship Xⁿ − p result: X³ − 3 is Eisenstein at 3, hence irreducible, so ∛3 is irrational — the concrete case of the second open question here ([ℚ(ⁿ√p):ℚ] = n via the minimal polynomial Xⁿ − p). That entry also treats the general prime case."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-01",
+      "relationship": "related",
+      "description": "A high-profile application of Eisenstein irreducibility: the quintic X⁵ − 4X + 2 is Eisenstein at 2, hence irreducible over ℚ — the first step in exhibiting a polynomial with Galois group S₅ and thus a concrete unsolvable-by-radicals example."
+    },
+    {
+      "targetId": "cyclotomic-polynomials-oq-01",
+      "relationship": "related",
+      "description": "Reciprocal structural entry: its open question on the irreducibility of Φ_n over ℚ is answered for the prime case exactly by Eisenstein applied to Φ_p(X + 1) — the criterion formalised here is the tool that cyclotomic entry points to."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -171,7 +192,7 @@
     "summary": "Formalizes Eisenstein's irreducibility criterion (irreducible_of_eisenstein) and applies it to the canonical family: Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1 (irreducible_X_pow_sub_C_prime), with the concrete instances X² − 2, X³ − 2, X⁵ − 3. The application uses P = (p) and reduces the five Eisenstein hypotheses to elementary divisibility facts about the coefficients 1, 0, …, 0, −p. All 5 theorems verified with 0 sorries and 0 axioms, no native_decide.",
     "implications": "Eisenstein's criterion is the standard elementary irreducibility test in algebra and number theory. The Xⁿ − p family it certifies supplies algebraic numbers of every degree (the minimal polynomial of ⁿ√p), underpins field-extension and Galois-theory examples, and — via the substitution X ↦ X + 1 — gives the classical proof that the p-th cyclotomic polynomial is irreducible.",
     "openQuestions": [
-      "Derive the irreducibility of the p-th cyclotomic polynomial Φ_p by applying the criterion to Φ_p(X + 1)",
+      "Derive the irreducibility of the p-th cyclotomic polynomial Φ_p by applying the criterion to Φ_p(X + 1) (carried out in the descendant entry eisenstein-criterion-oq-01-oq-03-oq-02)",
       "State the consequence for field degrees: ⁿ√p has minimal polynomial Xⁿ − p, hence [ℚ(ⁿ√p) : ℚ] = n",
       "Generalize the coefficient bookkeeping to Eisenstein-at-p polynomials with arbitrary lower coefficients divisible by p (general IsEisensteinAt instances)"
     ]


### PR DESCRIPTION
Enrichment pass for `eisenstein-criterion-oq-01`. Empty crossReferences → 4 links, three tied to the entry's open questions:

- **eisenstein-criterion-oq-01-oq-03-oq-02** (*extended by*) — **resolves open question 1**: Φ_p irreducibility via Φ_p(X+1).
- **cube-root-3-irrational-oq-01** (*related*) — the ∛3 / general-prime case of **open question 2** (Xⁿ−p minimal polynomial, [ℚ(ⁿ√p):ℚ]=n).
- **abel-ruffini-galois-extensions-oq-01** (*related*) — X⁵−4X+2 is Eisenstein at 2; the S₅ unsolvable-quintic application.
- **cyclotomic-polynomials-oq-01** (*related*) — reciprocal structural entry whose Φ_n-irreducibility question this criterion answers for the prime case.

Also annotated open question 1 with its resolution. Size 14.0 KB → 16.6 KB (under cap). `pnpm build` passes.