### PR TITLE
Research: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05 ORIENT — multi-block RCF, CRT coprime block-merge as first increment

### DIFF
--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/knowledge.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/knowledge.md
@@ -1,0 +1,189 @@
+# Knowledge Base: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05
+
+Multi-block rational canonical form (RCF) via the K[X]-module structure theorem.
+
+---
+
+## Problem Understanding
+
+**Goal.** For any field `K` and `A ∈ Mₙ(K)`, prove `A` is similar to a direct sum of
+companion matrices of its invariant factors `p₁ ∣ p₂ ∣ … ∣ p_r` (the rational canonical
+form). The single-block (nonderogatory) case is fully proved in the gallery scaffold
+`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02` (688 lines, 0 sorries, 0 axioms).
+
+**Honest scope verdict (this session).** Full multi-block RCF is a **Mathlib-PR-scale**
+contribution (>1000 lines): Mathlib has the abstract PID structure theorem but has **no
+companion matrix, no companion↔module bridge, and no RCF**. Delivering the whole thing in
+one build-enabled session is not realistic. The right research move is to isolate the
+**first genuinely self-contained increment** that (a) reuses the existing scaffold as a
+black box and (b) is buildable at ~400–600 lines. This session identifies that increment
+precisely, grounds every API reference, and hands the next session a lemma dependency
+chain. (Build tooling — Docker + Aristotle — is in a blackout, so no new Lean was
+compiled; deliverable is the ORIENT design + statement skeleton.)
+
+---
+
+## Mathlib API Map (verified against /Users/rwalters/GitHub/mathlib4, v4.26-era)
+
+| Need | Mathlib provides? | Symbol |
+|------|-------------------|--------|
+| PID structure theorem (prime-power form) | ✅ | `Module.equiv_directSum_of_isTorsion` (`Mathlib/Algebra/Module/PID.lean:233`) |
+| PID structure theorem (free × torsion) | ✅ | `Module.equiv_free_prod_directSum` (`…/PID.lean:259`) |
+| K[X]-module structure via an endomorphism | ✅ | `Module.AEval'` (`Mathlib/Algebra/Polynomial/Module/AEval.lean`) |
+| minpoly = annihilator generator of `AEval'` | ✅ | `Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean:167` |
+| block-diagonal is a ring hom (⇒ `aeval` distributes) | ✅ | `Matrix.blockDiagonalRingHom`, `Matrix.blockDiagonal_pow` (`Mathlib/Data/Matrix/Block.lean:435,445`) |
+| block-triangular charpoly = ∏ block charpolys | ✅ | `Matrix.BlockTriangular.charpoly`, `charpoly_fromBlocks_zero₁₂/₂₁` (`…/Charpoly/Basic.lean:179–199`) |
+| `minpoly ∣ charpoly` | ✅ | `Matrix.minpoly_dvd_charpoly` (`…/Charpoly/Minpoly.lean:47`) |
+| **companion matrix** | ❌ | *gallery-local* `companionMx` only (Mathlib has none — all "companion" hits are `QuadraticForm.exists_companion`) |
+| **companion charpoly = p** | ❌ | not in Mathlib, not yet in gallery |
+| **minpoly of a block-diagonal matrix = lcm** | ❌ | not in Mathlib |
+| **RCF / block-companion similarity** | ❌ | not in Mathlib |
+
+**Reusable scaffold lemmas** (from `CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean`,
+namespace `CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02`, `open GeneralCyclicVector`):
+
+- `minpoly_companionMx_eq (p) (hp_monic) (hp_deg : p.natDegree = n) (hn) : minpoly K (companionMx p) = p`  (L:635)
+- `nonderogatory_iff_similar_to_companion (M) (hn) : IsNonderogatory M ↔ ∃ P, IsUnit P ∧ P⁻¹*M*P = companionMx (minpoly K M)`  (L:395)
+- `aeval_companionMx_p_eq_zero`  (L:581)
+
+---
+
+## The First Increment: CRT / elementary-divisor block-merge
+
+**Theorem (block-merge, coprime case).** For monic `p, q ∈ K[X]` with `IsCoprime p q`
+(and positive degrees), the block matrix
+`D = fromBlocks (companionMx p) 0 0 (companionMx q)` (over `Fin dₚ ⊕ Fin d_q`) is
+similar — after the reindexing `finSumFinEquiv : Fin dₚ ⊕ Fin d_q ≃ Fin (dₚ+d_q)` — to
+`companionMx (p*q)`. This is the Chinese-Remainder step
+`K[X]/(pq) ≅ K[X]/(p) ⊕ K[X]/(q)` realized at the matrix level, i.e. the bridge between
+the **elementary-divisor** form (coprime prime-power blocks) and the **invariant-factor**
+form (single companion block). It is the mathematical heart of "multi-block."
+
+**Why this is the right first target.** It is the smallest theorem that (i) is genuinely
+about *more than one block*, (ii) reuses the entire single-block scaffold as a black box,
+and (iii) produces upstream-worthy lemmas (companion charpoly, block-diagonal minpoly)
+that every later RCF step also needs.
+
+### Proof strategy (reduces the merge to nonderogatory-ness via the scaffold)
+
+`nonderogatory_iff_similar_to_companion` already gives: any nonderogatory `M` is similar
+to `companionMx (minpoly K M)`. So it suffices to prove **`D` is nonderogatory with
+`minpoly K D = p*q`**; then `D ~ companionMx (p*q)` follows immediately. Chain:
+
+1. **L2 `charpoly_companionMx` : `(companionMx p).charpoly = p`** (monic `p`, deg `n`).
+   *Not in Mathlib.* Classical companion charpoly. Buildable independently (~120 lines)
+   via cofactor expansion, or bootstrapped from `minpoly_companionMx_eq` + the fact that
+   a nonderogatory matrix has `charpoly = minpoly` (companion is cyclic at `e₀`).
+
+2. **L3 `charpoly_fromBlocks` : `(fromBlocks A 0 0 B).charpoly = A.charpoly * B.charpoly`.**
+   Direct from `Matrix.charpoly_fromBlocks_zero₂₁` (already in Mathlib). ⇒
+   `D.charpoly = p*q` using L2. (~30 lines.)
+
+3. **L1 `minpoly_fromBlocks = lcm` : `minpoly K (fromBlocks A 0 0 B) = lcm (minpoly K A) (minpoly K B)`.**
+   *The lynchpin, not in Mathlib.* Argument: `f` annihilates `fromBlocks A 0 0 B` ⟺ `f`
+   annihilates `A` and `f` annihilates `B`, because `aeval` distributes over the block
+   ring hom (`fromBlocks` is block-multiplicative:
+   `(fromBlocks A 0 0 B)^k = fromBlocks (A^k) 0 0 (B^k)`, so
+   `aeval (fromBlocks A 0 0 B) f = fromBlocks (aeval A f) 0 0 (aeval B f)`). Hence the
+   annihilator ideal of the block matrix is `(minpoly A) ⊓ (minpoly B)` in the PID `K[X]`,
+   whose monic generator is `lcm`. Use `minpoly.dvd` for both directions plus the PID
+   ideal-intersection = lcm fact and `Polynomial`'s `GCDMonoid`. (~150–200 lines; the real
+   work of the increment.)
+
+4. **L5 coprime monic ⇒ `lcm p q = p*q`.** `IsCoprime p q` ⇒ `gcd p q` is a unit ⇒
+   `lcm = normalize (p*q) = p*q` (both monic ⇒ `normalize` fixes it). Mathlib
+   `GCDMonoid`/`normalize_eq_self` for monic polynomials. (~30 lines.)
+
+5. **Assemble.** `minpoly K D = lcm p q = p*q` (L1+L5). `D.charpoly = p*q` (L2+L3). Over a
+   field, `minpoly D = charpoly D` ⇒ `D` nonderogatory (Cayley–Hamilton gives
+   `minpoly ∣ charpoly` always; equality of the two monic polys of equal degree ⇒ the
+   scaffold's degree criterion for `IsNonderogatory`). Then
+   `nonderogatory_iff_similar_to_companion` + `minpoly K D = p*q` ⇒
+   `D ~ companionMx (p*q)`. (~60 lines + reindex bookkeeping.)
+
+**Buildability estimate:** ~400–600 lines total. Decision: **BUILD (high value)** in a
+future build-enabled session — the lemmas L1, L2 are independently upstream-worthy and are
+prerequisites for *any* RCF route.
+
+### The r-block generalization (after the coprime merge)
+
+- **Elementary → invariant divisors:** iterate the coprime merge across distinct prime
+  factors; group prime powers with the same prime into a single companion via repeated
+  L1/L3. Standard, but heavy index bookkeeping.
+- **Existence of the decomposition:** apply `Module.equiv_directSum_of_isTorsion` to
+  `Module.AEval' (Matrix.toLin' A)` (finite + torsion since `Kⁿ` is finite-dimensional and
+  `minpoly` annihilates), giving `⨁ K[X]/(pᵢ^{eᵢ})`; each summand is `A`-cyclic ⇒ companion
+  block via the scaffold; assemble block-diagonal + change of basis
+  (`LinearMap.toMatrix` / `Matrix.reindex`). This is the >1000-line remainder — deferred.
+
+---
+
+## Insights
+
+- Mathlib has the *abstract* PID cyclic decomposition but **nothing connecting it to
+  companion matrices**; the entire matrix ↔ module bridge (companion charpoly/minpoly,
+  block minpoly = lcm, block-companion similarity) is a green field. This is why RCF is a
+  standing Mathlib gap despite the structure theorem being present.
+- The single-block scaffold is *more reusable than it looks*: because
+  `nonderogatory_iff_similar_to_companion` turns "similar to a companion" into the purely
+  local property "nonderogatory," the multi-block coprime merge collapses to a
+  minpoly/charpoly *computation* (`minpoly D = charpoly D = p*q`) rather than an explicit
+  change-of-basis construction. The change of basis is supplied by the scaffold.
+- The CRT/elementary-divisor merge is the correct decomposition point: it is the minimal
+  multi-block statement, and its two novel lemmas (companion charpoly, block minpoly=lcm)
+  are on the critical path of every subsequent RCF step.
+- `fromBlocks` (not `blockDiagonal`) is the correct constructor for two companion blocks:
+  the blocks have *different* sizes `Fin dₚ`, `Fin d_q`, which `blockDiagonal` forbids;
+  `fromBlocks` lives over `Fin dₚ ⊕ Fin d_q`, and `charpoly_fromBlocks_zero₂₁` already
+  handles its charpoly.
+
+## Dead Ends / Cautions
+
+- **Smith normal form route (problem.md Approach B):** Mathlib's Smith-normal-form support
+  over `K[X]` is thin; extracting invariant factors of `XI − A` constructively is likely a
+  larger gap than the module-transport route. Not recommended as the entry point.
+- Do **not** start with the full abstract module-transport for general RCF — the reindex /
+  block-basis assembly bookkeeping dominates and yields no reusable sub-lemmas until the
+  very end. Start with the coprime merge, which produces upstream lemmas immediately.
+
+## Next Steps
+
+1. (Build-enabled) Implement **L2 `charpoly_companionMx`** — companion charpoly = p.
+   Self-contained; upstream-worthy on its own.
+2. Implement **L1 `minpoly_fromBlocks = lcm`** via block-multiplicativity of `aeval` +
+   PID annihilator-ideal = `⊓` = `lcm`. The lynchpin.
+3. Assemble **L3 charpoly_fromBlocks**, **L5 coprime⇒lcm=product**, and the merge theorem
+   `companion_blockmerge_coprime` using `nonderogatory_iff_similar_to_companion`.
+4. Only then tackle the r-block invariant-factor assembly + `Module.equiv_directSum_of_isTorsion`
+   transport for full RCF.
+
+See `lean/OQ01OQ02OQ05-skeleton.lean` for the statement skeleton (WIP, not build-verified).
+
+---
+
+## Session Log
+
+### Session 2026-07-04 (Session 1) — ORIENT: API map + first-increment decomposition
+
+**Mode**: FRESH · **Outcome**: scouted/oriented (no Lean compiled — Docker+Aristotle blackout)
+
+**What I did**
+- Read the 688-line single-block scaffold; extracted the two reusable public lemmas
+  (`minpoly_companionMx_eq`, `nonderogatory_iff_similar_to_companion`).
+- Grounded the full Mathlib API surface against a local mathlib4 checkout (table above);
+  confirmed Mathlib has the PID structure theorem + `AEval'` but **no companion matrix and
+  no RCF**.
+- Identified the CRT/elementary-divisor **coprime block-merge** as the correct first
+  increment and wrote a 5-step proof plan (L1–L5) with buildability estimates.
+
+**Key findings**
+- The scaffold's `nonderogatory_iff_similar_to_companion` collapses the coprime merge to a
+  minpoly=charpoly computation — no explicit change-of-basis needed at this stage.
+- Lynchpin lemma is L1 (`minpoly_fromBlocks = lcm`), provable via block-multiplicativity of
+  `aeval` (`fromBlocks A 0 0 B`'s powers are block-diagonal) + PID annihilator ideal = `⊓`.
+- `fromBlocks` (over `⊕`), not `blockDiagonal`, is required (unequal block sizes).
+
+**Files modified**: this `knowledge.md`, `state.md`, `src/data/research/problems/…json`,
+`lean/OQ01OQ02OQ05-skeleton.lean` (WIP draft).
+
+**Next steps**: implement L2 then L1 (see Next Steps above) once build tooling recovers.

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/lean/OQ01OQ02OQ05-skeleton.lean
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/lean/OQ01OQ02OQ05-skeleton.lean
@@ -1,0 +1,87 @@
+/-
+  ============================================================================
+  WIP DRAFT — NOT BUILD-VERIFIED (Docker + Aristotle tooling blackout 2026-07-04)
+  ============================================================================
+
+  cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05
+  Multi-block RCF via the K[X]-module structure theorem.
+
+  This is the STATEMENT SKELETON for the first self-contained increment toward
+  multi-block RCF: the CRT / elementary-divisor **coprime block-merge**. It is a
+  design artifact only — the signatures were hand-checked against a local mathlib4
+  checkout but NOT compiled (no build tooling available this session). Do not open
+  a PR from this file. Move it into proofs/Proofs/ and discharge the sorries only
+  after `docker-build.sh` is confirmed working.
+
+  Reuses (as black boxes) from CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02:
+    · minpoly_companionMx_eq
+    · nonderogatory_iff_similar_to_companion
+  See knowledge.md for the full L1–L5 proof plan and Mathlib API map.
+-/
+import Mathlib
+import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02OQ05
+
+open Matrix Polynomial
+open CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02
+open GeneralCyclicVector
+
+variable {K : Type*} [Field K]
+
+/-- **L2** (Mathlib gap): the characteristic polynomial of a companion matrix is its
+    defining polynomial. Bootstrap route: companion is cyclic at `e₀`, hence
+    nonderogatory, hence `charpoly = minpoly = p` via `minpoly_companionMx_eq`. -/
+theorem charpoly_companionMx {n : ℕ} (p : K[X])
+    (hp_monic : p.Monic) (hp_deg : p.natDegree = n) (hn : 0 < n) :
+    (companionMx (n := n) p).charpoly = p := by
+  sorry
+
+/-- **L3**: charpoly of a two-block matrix factors (immediate from Mathlib's
+    `Matrix.charpoly_fromBlocks_zero₂₁`). Stated over the `⊕`-index. -/
+theorem charpoly_fromBlocks_companion {dp dq : ℕ}
+    (A : Matrix (Fin dp) (Fin dp) K) (B : Matrix (Fin dq) (Fin dq) K) :
+    (fromBlocks A 0 0 B).charpoly = A.charpoly * B.charpoly := by
+  sorry
+
+/-- **L1** (lynchpin, Mathlib gap): the minimal polynomial of a two-block matrix is the
+    lcm of the blocks' minimal polynomials. Proof: `(fromBlocks A 0 0 B)^k =
+    fromBlocks (A^k) 0 0 (B^k)` ⇒ `aeval` distributes over blocks ⇒ a polynomial
+    annihilates the block matrix iff it annihilates each block ⇒ annihilator ideal is
+    the meet `(minpoly A) ⊓ (minpoly B)`, whose monic generator (PID `K[X]`) is `lcm`. -/
+theorem minpoly_fromBlocks_eq_lcm {dp dq : ℕ}
+    (A : Matrix (Fin dp) (Fin dp) K) (B : Matrix (Fin dq) (Fin dq) K) :
+    minpoly K (fromBlocks A 0 0 B) = lcm (minpoly K A) (minpoly K B) := by
+  sorry
+
+/-- **L5**: for coprime monic polynomials, lcm = product (normalize fixes monics). -/
+theorem lcm_eq_mul_of_isCoprime_monic {p q : K[X]}
+    (hp : p.Monic) (hq : q.Monic) (h : IsCoprime p q) :
+    lcm p q = p * q := by
+  sorry
+
+/-- **Main increment — CRT coprime block-merge.**
+    For coprime monic `p, q` (positive degree), the companion block-diagonal
+    `fromBlocks (C p) 0 0 (C q)` is similar, after reindexing
+    `Fin dₚ ⊕ Fin d_q ≃ Fin (dₚ + d_q)`, to the single companion `C (p*q)`.
+
+    Strategy (see knowledge.md §Proof strategy):
+      minpoly D = lcm p q = p*q    (L1 + L5)
+      charpoly D = p*q             (L2 + L3)  ⇒ D nonderogatory (minpoly = charpoly)
+      nonderogatory_iff_similar_to_companion ⇒ D ~ companionMx (minpoly D) = C (p*q). -/
+theorem companion_blockmerge_coprime {dp dq : ℕ}
+    (p q : K[X]) (hp : p.Monic) (hq : q.Monic)
+    (hpdeg : p.natDegree = dp) (hqdeg : q.natDegree = dq)
+    (hdp : 0 < dp) (hdq : 0 < dq) (hpq : IsCoprime p q) :
+    ∃ P : Matrix (Fin (dp + dq)) (Fin (dp + dq)) K, IsUnit P ∧
+      P⁻¹ *
+        (reindex finSumFinEquiv finSumFinEquiv
+          (fromBlocks (companionMx (n := dp) p) 0 0 (companionMx (n := dq) q))) * P
+        = companionMx (n := dp + dq) (p * q) := by
+  sorry
+
+end CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02OQ05

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/literature/README.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/problem.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/problem.md
@@ -1,0 +1,138 @@
+# Problem: Multi-block rational canonical form via the K[X]-module structure theorem
+
+**Slug**: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\forall\, K \text{ a field},\ \forall\, A \in M_n(K),\quad
+A \sim \bigoplus_{i=1}^{r} C(p_i),\qquad p_1 \mid p_2 \mid \cdots \mid p_r,
+$$
+where each $C(p_i)$ is the companion matrix of an invariant factor $p_i \in K[X]$ and
+$\prod_i p_i$ is the characteristic polynomial. Equivalently: every finitely generated
+torsion $K[X]$-module decomposes as $\bigoplus_i K[X]/(p_i)$ with $p_1\mid\cdots\mid p_r$,
+and this yields the rational canonical form (RCF) of $A$.
+
+### Plain Language
+
+The parent gallery proof shows a **nonderogatory** (single-cyclic-vector) matrix is
+similar to the companion matrix of its characteristic polynomial — the single-block
+case. This problem removes the nonderogatory hypothesis: *every* square matrix over
+*any* field is similar to a direct sum of companion blocks (its rational canonical
+form). The natural route is the structure theorem for finitely generated modules over
+the PID $K[X]$, viewing $K^n$ as a $K[X]$-module via $A$.
+
+### Why This Matters
+
+RCF is a cornerstone of linear algebra and is currently a **Mathlib gap**: Mathlib has
+the module structure theorem over PIDs but does not package the general matrix RCF /
+similarity-to-block-companion form. Delivering it is a substantial, genuinely useful
+upstream contribution, with the single-block scaffold already in the gallery.
+
+## Known Results
+
+### What's Already Proven
+
+- Single-block case: nonderogatory $A$ is similar to $C(\chi_A)$ — gallery proof
+  `cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02`.
+- Structure theorem for f.g. modules over a PID — available in Mathlib
+  (`Mathlib.Algebra.Module.PID`, invariant factors / `Module.equiv_directSum_...`).
+- Cayley–Hamilton over commutative rings — Mathlib `Matrix.aeval_self_charpoly`.
+
+### What's Still Open
+
+- Packaging the $K[X]$-module decomposition of $K^n$ into a similarity statement
+  $A \sim \bigoplus C(p_i)$ with an explicit change-of-basis matrix.
+- Uniqueness of invariant factors as a similarity invariant (RCF canonicality).
+
+### Our Goal
+
+Formalize: for any field $K$ and $A \in M_n(K)$, $A$ is similar to the direct sum of
+companion matrices of its invariant factors, using the PID structure theorem with the
+single-block companion result as the per-summand scaffold.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02 | Single-block scaffold | cyclic vector, Krylov matrix, companion similarity |
+| cayley-hamilton | Cayley–Hamilton over general rings | adjugate/charpoly identities |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — module structure theorem transport**:
+   Give $K^n$ the $K[X]$-module structure $p \cdot v = p(A)v$; apply Mathlib's PID
+   invariant-factor decomposition; each cyclic summand $K[X]/(p_i)$ gives a companion
+   block via the single-block result.
+   - Why it might work: reuses existing Mathlib PID machinery + the scaffold lemma.
+   - Risk: translating an abstract module iso into an explicit matrix similarity
+     (basis assembly, block-diagonal change of basis).
+
+2. **Approach B — direct invariant-factor computation via Smith normal form**:
+   Compute the Smith normal form of $XI - A$ over $K[X]$; its nontrivial diagonal
+   entries are the invariant factors.
+   - Why it might work: constructive, avoids abstract module transport.
+   - Risk: Smith normal form over $K[X]$ may itself be a partial Mathlib gap.
+
+### Key Difficulties
+
+- Bridging the abstract module isomorphism to a concrete `Matrix.SimilarTo` statement.
+- Block-diagonal basis assembly and index bookkeeping across summands.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the $A$-module structure on $K^n$ is f.g. torsion over $K[X]$.
+- Key lemma 2: each invariant-factor summand $K[X]/(p_i)$ is $A$-cyclic ⇒ companion block.
+- Technical requirements: explicit change-of-basis extraction from the module iso.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**:
+- Mathlib supplies the PID structure theorem, but packaging RCF as matrix similarity
+  is nontrivial and currently missing upstream.
+- The single-block scaffold reduces per-summand risk substantially.
+- Explicit basis/similarity extraction is the main formalization overhead.
+
+**Estimated Effort**:
+- Exploration: 2–4 days mapping Mathlib PID API to the matrix setting
+- If tractable: multiple weeks (Mathlib-PR-scale)
+- If hard: Smith-normal-form gaps could extend it
+
+## References
+
+### Papers
+- Dummit & Foote, *Abstract Algebra*, Ch. 12 — rational canonical form via PID modules.
+
+### Online Resources
+- Mathlib `Module.PID` docs — invariant factors and cyclic decomposition.
+
+### Mathlib
+- `Mathlib.Algebra.Module.PID` — structure theorem for f.g. modules over a PID.
+- `Matrix.charpoly`, `Matrix.companion` (if present) — companion-matrix API.
+- `LinearMap.toMatrix` — basis change-of-coordinates for the similarity statement.
+
+## Metadata
+
+```yaml
+tags:
+  - linear-algebra
+  - rational-canonical-form
+  - module-theory
+  - cayley-hamilton
+  - mathlib-gap
+related_proofs:
+  - cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02
+  - cayley-hamilton
+difficulty: high
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/state.md
+++ b/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05/state.md
@@ -1,0 +1,33 @@
+# Research State: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05
+
+## Current State
+**Phase**: ORIENT
+**Path**: full
+**Since**: 2026-07-04T17:54:16-07:00
+**Iteration**: 2
+
+## Current Focus
+First self-contained increment toward multi-block RCF: the CRT / elementary-divisor
+**coprime block-merge** `fromBlocks (C p) 0 0 (C q) ~ C (p*q)` for coprime monic `p,q`.
+Statement skeleton drafted in `lean/OQ01OQ02OQ05-skeleton.lean` (WIP, not build-verified).
+
+## Active Approach
+Approach A (module structure / companion-similarity), entered via its minimal multi-block
+case: reduce the coprime merge to `minpoly D = charpoly D = p*q` and invoke the scaffold's
+`nonderogatory_iff_similar_to_companion`. Lemma chain L1–L5 documented in knowledge.md.
+
+## Attempt Count
+- Total attempts: 1 (ORIENT survey; no Lean compiled — tooling blackout)
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- Build tooling blackout: Docker containerd blob I/O error + Aristotle 404. No new Lean
+  could be compiled this session; deliverable is the grounded ORIENT design.
+- Full RCF is >1000-line (Mathlib-PR-scale); intentionally deferred behind the coprime
+  merge increment.
+
+## Next Action
+Once build tooling recovers: implement L2 (`charpoly_companionMx`), then L1
+(`minpoly_fromBlocks_eq_lcm`, the lynchpin), then assemble L3/L5 and the merge theorem
+`companion_blockmerge_coprime`. See knowledge.md §Next Steps.

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05.json
@@ -1,0 +1,207 @@
+{
+  "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05",
+  "title": "Multi-block rational canonical form via the K[X]-module structure theorem",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall\\, K \\text{ a field},\\ \\forall\\, A \\in M_n(K),\\quad\nA \\sim \\bigoplus_{i=1}^{r} C(p_i),\\qquad p_1 \\mid p_2 \\mid \\cdots \\mid p_r,",
+    "plain": "The parent gallery proof shows a **nonderogatory** (single-cyclic-vector) matrix is",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "Single-block: nonderogatory A ~ C(minpoly A) — scaffold CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02 (688 lines, 0 sorries): minpoly_companionMx_eq, nonderogatory_iff_similar_to_companion.",
+      "Mathlib has PID structure theorem (Module.equiv_directSum_of_isTorsion) and K[X]-module structure (Module.AEval')."
+    ],
+    "open": [
+      "companion charpoly (charpoly_companionMx) — Mathlib gap",
+      "minpoly of a block-diagonal/fromBlocks matrix = lcm — Mathlib gap (lynchpin L1)",
+      "block-companion similarity / RCF packaging — Mathlib gap"
+    ],
+    "goal": "Prove the coprime block-merge fromBlocks(C p) 0 0 (C q) ~ C(p*q) as the first multi-block increment, then iterate to full RCF via the PID structure theorem."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-07-04T17:07:08-07:00",
+    "iteration": 2,
+    "focus": "First self-contained increment: CRT/elementary-divisor coprime block-merge fromBlocks(C p) 0 0 (C q) ~ C(p*q). Statement skeleton drafted; L1-L5 proof plan documented.",
+    "blockers": [
+      "Build tooling blackout (Docker containerd I/O error + Aristotle 404): no new Lean compiled this session.",
+      "Full RCF is >1000-line Mathlib-PR-scale; deferred behind the coprime-merge increment."
+    ],
+    "nextAction": "Build-enabled: implement L2 (charpoly_companionMx), then L1 (minpoly_fromBlocks_eq_lcm, lynchpin), then assemble L3/L5 and companion_blockmerge_coprime.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: full Mathlib API grounded; identified CRT coprime block-merge as first buildable increment (~400-600 lines) reusing the single-block scaffold; L1-L5 lemma chain + statement skeleton documented. No Lean compiled (tooling blackout).",
+    "builtItems": [],
+    "insights": [
+      "Mathlib has the abstract PID cyclic decomposition but NOTHING connecting it to companion matrices — the whole matrix-module bridge (companion charpoly/minpoly, block minpoly=lcm, block-companion similarity) is a green field; this is why RCF is a standing Mathlib gap despite the structure theorem being present.",
+      "The scaffold lemma nonderogatory_iff_similar_to_companion collapses the coprime merge to a minpoly=charpoly COMPUTATION (minpoly D = charpoly D = p*q) — no explicit change of basis needed at this stage; the scaffold supplies it.",
+      "The CRT/elementary-divisor coprime merge is the minimal genuine multi-block statement and its two novel lemmas (companion charpoly, block minpoly=lcm) lie on the critical path of every later RCF step.",
+      "fromBlocks (over Fin dp sum Fin dq), not blockDiagonal, is the correct constructor: companion blocks have unequal sizes; Mathlib charpoly_fromBlocks_zero21 already gives the block charpoly."
+    ],
+    "mathlibGaps": [
+      "No companion matrix in Mathlib (all `companion` hits are QuadraticForm.exists_companion); gallery defines companionMx locally.",
+      "No companion charpoly (charpoly_companionMx): needs building (~120 lines).",
+      "No minpoly of block-diagonal/fromBlocks = lcm (L1 lynchpin): needs building (~150-200 lines) via block-multiplicativity of aeval + PID annihilator ideal = meet = lcm.",
+      "No rational canonical form / block-companion similarity packaging in Mathlib."
+    ],
+    "nextSteps": [
+      "L2 charpoly_companionMx: companion charpoly = p (bootstrap: companion cyclic at e0 => nonderogatory => charpoly=minpoly=p via minpoly_companionMx_eq).",
+      "L1 minpoly_fromBlocks_eq_lcm (lynchpin): (fromBlocks A 0 0 B)^k = fromBlocks (A^k) 0 0 (B^k) => aeval distributes => annihilator ideal = (minpoly A) meet (minpoly B) => monic generator = lcm.",
+      "L3 charpoly_fromBlocks (from Mathlib charpoly_fromBlocks_zero21) + L5 lcm=product for coprime monic; then assemble companion_blockmerge_coprime via nonderogatory_iff_similar_to_companion.",
+      "Only then: r-block invariant-factor assembly + Module.equiv_directSum_of_isTorsion transport of Module.AEval'(toLin A) for full RCF (>1000 lines, deferred)."
+    ],
+    "markdown": "# Knowledge Base: cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "linear-algebra",
+    "rational-canonical-form",
+    "module-theory",
+    "cayley-hamilton",
+    "mathlib-gap"
+  ],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-cyclic-vector-all-fields",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-02",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01",
+    "cayley-hamilton-cyclic-vector-all-fields-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib/Algebra/Module/PID.lean:233 Module.equiv_directSum_of_isTorsion",
+      "Mathlib/Algebra/Polynomial/Module/AEval.lean Module.AEval'",
+      "Mathlib/LinearAlgebra/AnnihilatingPolynomial.lean:167 (minpoly = annihilator generator)",
+      "Mathlib/Data/Matrix/Block.lean:435 Matrix.blockDiagonalRingHom / :445 blockDiagonal_pow",
+      "Mathlib/LinearAlgebra/Matrix/Charpoly/Basic.lean:185 charpoly_fromBlocks_zero21",
+      "Mathlib/LinearAlgebra/Matrix/Charpoly/Minpoly.lean:47 Matrix.minpoly_dvd_charpoly"
+    ]
+  },
+  "started": "2026-07-05T00:19:51.460Z",
+  "lastUpdate": "2026-07-04T00:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFields.lean",
+      "lineCount": 267,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+      "lineCount": 133,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean",
+      "lineCount": 137,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean",
+      "lineCount": 689,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ02.lean",
+      "lineCount": 208,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean",
+      "lineCount": 331,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ03.lean",
+      "lineCount": 313,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean",
+      "lineCount": 134,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Bridge.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean",
+      "lineCount": 111,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03Converse.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean",
+      "filename": "CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean",
+      "lineCount": 166,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ03PID.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

ORIENT session on **multi-block rational canonical form (RCF) via the K[X]-module structure theorem** (`cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-02-oq-05`).

Full RCF is a **>1000-line, Mathlib-PR-scale** contribution: Mathlib has the abstract PID structure theorem (`Module.equiv_directSum_of_isTorsion`) and the K[X]-module structure (`Module.AEval'`) but **no companion matrix and no RCF** — the entire matrix↔module bridge is a green field. Rather than attempt the whole thing, this session isolates the **first self-contained, buildable increment** and grounds every Mathlib API reference against a local mathlib4 checkout.

## First increment: CRT / elementary-divisor coprime block-merge

For coprime monic `p, q`:  `fromBlocks (C p) 0 0 (C q)  ~  C (p*q)`.

This is the Chinese-Remainder step `K[X]/(pq) ≅ K[X]/(p) ⊕ K[X]/(q)` at the matrix level — the bridge between elementary-divisor and invariant-factor forms, and the mathematical heart of "multi-block."

**Key idea:** the existing 688-line single-block scaffold's `nonderogatory_iff_similar_to_companion` collapses the merge to a *computation* — it suffices to show `minpoly D = charpoly D = p*q`; the change of basis is supplied by the scaffold. Lemma chain (documented with buildability estimates, ~400–600 lines total):

- **L2** `charpoly_companionMx` — companion charpoly = p (Mathlib gap, ~120 lines)
- **L1** `minpoly_fromBlocks_eq_lcm` — **lynchpin**, via block-multiplicativity of `aeval` + PID annihilator-ideal = meet = lcm (Mathlib gap, ~150–200 lines)
- **L3** `charpoly_fromBlocks` (from Mathlib `charpoly_fromBlocks_zero₂₁`) + **L5** `lcm = product` for coprime monic
- Assemble `companion_blockmerge_coprime` via `nonderogatory_iff_similar_to_companion`

## Deliverables (all build-independent)

- `research/problems/…/knowledge.md` — full Mathlib API map + L1–L5 proof plan
- `src/data/research/problems/….json` — structured knowledge (0 → 12 items, MODERATE tier), phase → ORIENT
- `research/problems/…/lean/OQ01OQ02OQ05-skeleton.lean` — **WIP statement skeleton, NOT build-verified** (Docker + Aristotle tooling blackout this session). Lives under `research/`, never built by the deployer.

No `proofs/Proofs/` changes; no new axioms/sorries in the built tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)