### PR TITLE
Fix gallery integrity #34794: downgrade 7 verified-but-sourceless entries

### DIFF
--- a/src/data/proofs/erdos-1207-oq-04/meta.json
+++ b/src/data/proofs/erdos-1207-oq-04/meta.json
@@ -2,12 +2,12 @@
   "id": "erdos-1207-oq-04",
   "title": "Erdős #1207 (OQ-04): Isometric transport and the dimension lift P_d(n) ≥ P₁(n)",
   "slug": "erdos-1207-oq-04",
-  "description": "A follow-up to Erdős #1207 that carries the one-dimensional theory into every dimension. The parent entry sets up isosceles-freeness for an arbitrary metric space and the d=1 bridge to 3-AP-free sets; OQ-03 gives the explicit lower bound P₁(3ᵏ) ≥ 2ᵏ on the line. Here we prove that isosceles-freeness transports along any isometric embedding, so placing a one-dimensional configuration on a coordinate axis of ℝ^d realises it isometrically in higher dimensions. Consequences: dimension monotonicity P_d(n) ≥ P₁(n) for all d ≥ 1, and an explicit isosceles-free set of 2ᵏ points in ℝ^d (and in the plane ℝ²), i.e. P_d(3ᵏ) ≥ 2ᵏ. Fully verified, 0 axioms, 0 sorries.",
+  "description": "A follow-up to Erdős #1207 that carries the one-dimensional theory into every dimension. The parent entry sets up isosceles-freeness for an arbitrary metric space and the d=1 bridge to 3-AP-free sets; OQ-03 gives the explicit lower bound P₁(3ᵏ) ≥ 2ᵏ on the line. Here we prove that isosceles-freeness transports along any isometric embedding, so placing a one-dimensional configuration on a coordinate axis of ℝ^d realises it isometrically in higher dimensions. Consequences: dimension monotonicity P_d(n) ≥ P₁(n) for all d ≥ 1, and an explicit isosceles-free set of 2ᵏ points in ℝ^d (and in the plane ℝ²), i.e. P_d(3ᵏ) ≥ 2ᵏ. Formalization pending — the Lean source file is not yet present on main (issue #34794); the machine-verified claim will be restored once it lands and builds.",
   "meta": {
     "author": "Erdős (Er80); formalization by researcher-6",
     "sourceUrl": "https://erdosproblems.com/1207",
     "date": "1980",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos1207OQ04.lean",
     "tags": [
       "erdos",
@@ -20,7 +20,7 @@
       "dimension-monotonicity",
       "open"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1207,
     "erdosUrl": "https://erdosproblems.com/1207",
@@ -66,7 +66,8 @@
     "lineCount": 122,
     "assumptions": "None. All declarations are fully machine-checked: 0 axiom declarations, 0 structure-encoded assumptions, 0 sorries. This records the dimension-monotone lower-bound side of P_d(n); it does not resolve the open growth question (whether P_2(n) is subpolynomial is exactly Erdős's problem, and no upper bound is proved here).",
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "**Erdős #1207 in general dimension.** The problem asks to estimate P_d(n), the largest guaranteed isosceles-free subset of an n-point set in ℝ^d, and highlights the planar case P_2(n). The parent formalization handles the line d=1 (isosceles-free = 3-AP-free) and OQ-03 gives the base-3 lower bound P₁(3ᵏ) ≥ 2ᵏ. A basic but essential observation is that lower bounds are dimension-monotone: any construction on a line sits isometrically inside ℝ^d, so P_d(n) ≥ P₁(n). This entry makes that transport principle precise and machine-checked.",

--- a/src/data/proofs/erdos-76-packing-upper-bound/meta.json
+++ b/src/data/proofs/erdos-76-packing-upper-bound/meta.json
@@ -2,11 +2,11 @@
   "id": "erdos-76-packing-upper-bound",
   "title": "Erdős #76: The Elementary n²/6 Upper Bound on Monochromatic Triangle Packings",
   "slug": "erdos-76-packing-upper-bound",
-  "description": "Discharges, unconditionally and without axioms, the packing upper bound left as a `sorry` in the parent entry Erdős Problem #76 (Erdos76Problem.lean). The parent formalizes the Erdős–Faudree–Ordman conjecture — solved by Gruslys & Letzter (2020) — that every 2-coloring of K_n contains at least (1+o(1))·n²/12 edge-disjoint monochromatic triangles, and leaves the matching upper bound maxPackingSize c ≤ C(n,2)/3 (≈ n²/6) unproven. That upper bound is pure edge counting: each triangle occupies exactly 6 ordered edges (its offDiag), the triangles of a packing are pairwise edge-disjoint, so their edge sets sit disjointly inside the n(n−1) ordered edges of K_n; hence 6·(packing size) ≤ n²−n and (packing size) ≤ C(n,2)/3. This entry re-declares the triangle/packing machinery locally and proves the bound in full — for arbitrary packings (packing_card_le_choose) and for the maximum monochromatic packing of any coloring (maxPackingSize_le), the exact statement the parent leaves open. The factor-of-2 gap between this trivial upper bound n²/6 and the true optimum n²/12 is precisely what makes Erdős #76 deep: the extremal coloring sacrifices half its edges on a triangle-free red bipartite subgraph. Fully verified, 0 sorries, 0 axioms.",
+  "description": "Discharges, unconditionally and without axioms, the packing upper bound left as a `sorry` in the parent entry Erdős Problem #76 (Erdos76Problem.lean). The parent formalizes the Erdős–Faudree–Ordman conjecture — solved by Gruslys & Letzter (2020) — that every 2-coloring of K_n contains at least (1+o(1))·n²/12 edge-disjoint monochromatic triangles, and leaves the matching upper bound maxPackingSize c ≤ C(n,2)/3 (≈ n²/6) unproven. That upper bound is pure edge counting: each triangle occupies exactly 6 ordered edges (its offDiag), the triangles of a packing are pairwise edge-disjoint, so their edge sets sit disjointly inside the n(n−1) ordered edges of K_n; hence 6·(packing size) ≤ n²−n and (packing size) ≤ C(n,2)/3. This entry re-declares the triangle/packing machinery locally and proves the bound in full — for arbitrary packings (packing_card_le_choose) and for the maximum monochromatic packing of any coloring (maxPackingSize_le), the exact statement the parent leaves open. The factor-of-2 gap between this trivial upper bound n²/6 and the true optimum n²/12 is precisely what makes Erdős #76 deep: the extremal coloring sacrifices half its edges on a triangle-free red bipartite subgraph. Formalization pending — the Lean source file is not yet present on main (issue #34794); the machine-verified claim will be restored once it lands and builds.",
   "meta": {
     "author": "Lean Genius Researcher",
     "date": "2026",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/Erdos76PackingUpperBound.lean",
     "tags": [
       "combinatorics",
@@ -19,7 +19,7 @@
       "erdos",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 160,
@@ -37,7 +37,8 @@
       "A fully local, axiom-free re-declaration of the triangle-packing vocabulary (Triangle, Triangle.edges as offDiag, isPacking, Color, EdgeColoring, isMonochromatic, monochromaticPacking, maxPackingSize) matching the parent Erdos76Problem.lean so the result drops directly into its narrative."
     ],
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "Erdős Problem #76 (conjectured by Erdős, Faudree and Ordman; resolved by Gruslys and Letzter, 2020) asks how many edge-disjoint monochromatic triangles every 2-coloring of the edges of K_n must contain. The answer is (1+o(1))·n²/12, achieved by the balanced bipartition: split the vertices into two equal halves, color within-half edges blue (two K_{n/2} cliques, each packing ≈ n²/24 triangles via Steiner triple systems) and between-half edges red. The red class K_{n/2,n/2} is triangle-free, so it contributes nothing — the count comes entirely from the two blue cliques, giving 2·n²/24 = n²/12. The genuinely hard content is the matching lower bound (every coloring achieves ≥ n²/12), which Gruslys and Letzter proved via the Szemerédi regularity lemma and a greedy-absorption method.",

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius research",
     "date": "2026",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ04OQ02.lean",
     "tags": [
       "algebra",
@@ -18,7 +18,7 @@
       "steinitz",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 110,
@@ -63,7 +63,8 @@
       "not_nonempty_ringEquiv_algebraicClosure_rat_complex with card_algebraicClosure_rat: the honesty statements showing the cardinality hypothesis is necessary — AlgebraicClosure ℚ is algebraically closed of characteristic 0 but countable (#=ℵ₀), hence not isomorphic to ℂ. This concretely refutes the naïve 'unique up to isomorphism' reading."
     ],
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "Steinitz (1910), in his foundational paper on field theory, proved that an algebraically closed field is determined up to isomorphism by two invariants: its characteristic and the cardinality of a transcendence basis over the prime field. For uncountable fields the transcendence degree equals the cardinality of the field, so an uncountable algebraically closed field is classified by (characteristic, cardinality). ℂ, being algebraically closed (the Fundamental Theorem of Algebra), of characteristic 0, and of cardinality the continuum 𝔠, is therefore the unique such field with those invariants — but only after the cardinality is pinned down. Dropping the cardinality constraint, the classification fails spectacularly: there are algebraically closed characteristic-0 fields of every infinite cardinality.",

--- a/src/data/proofs/inverse-galois-oq-04-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-04-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "verified",
+    "status": "pending",
     "tags": [
       "algebra",
       "galois-theory",
@@ -19,7 +19,7 @@
       "polynomial-factorization"
     ],
     "proofRepoPath": "Proofs/InverseGaloisA5DedekindKummerInput.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
     "prerequisites": [
@@ -50,7 +50,8 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 0,
-    "additionalFiles": []
+    "additionalFiles": [],
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "The Inverse Galois Problem asks whether every finite group occurs as $\\mathrm{Gal}(K/\\mathbb{Q})$. The alternating group $A_5$ — the smallest non-solvable group — is realizable over $\\mathbb{Q}$, and the Lean development `Proofs.InverseGaloisA5` formalizes this down to one remaining assumption, `three_dvd_gal_card : 3 \\mid \\mathrm{card}\\,q.\\mathrm{Gal}$, for the quintic $q = X^5 - 5X^4 + 10X^3 - 10X^2 + 25X - 5$. A companion reduction rewrites that as $3 \\mid \\mathrm{inertiaDegIn}_{(7)}(\\mathcal{O}_{q.\\mathrm{SplittingField}})$, provable by a three-step Kummer–Dedekind route. Two abstract bricks already machine-checked the inertia reasoning: `inverse-galois-oq-04-oq-01` (Step 1: an irreducible factor mod $p$ yields a prime of that inertia degree) and `inverse-galois-oq-04` (Steps 2–3: inertia-degree tower multiplicativity and Galois uniformity). Both take as a hypothesis that a chosen polynomial is a monic irreducible factor of the minimal polynomial mod $p$. This entry supplies that hypothesis concretely for the $A_5$ quintic at $p = 7$.",

--- a/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06-oq-02-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-07-02",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/InverseGaloisPSL27.lean",
     "tags": [
       "galois-theory",
@@ -16,7 +16,7 @@
       "finite-fields",
       "psl27"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-07-02",
     "axiomCount": 0,
@@ -45,7 +45,8 @@
         "id": "inverse-galois",
         "relationship": "Extends: base inverse Galois problem"
       }
-    ]
+    ],
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "PSL(2,7), the simple group of order 168, is the second-smallest non-abelian simple group (after A₅ of order 60). It carries the famous exceptional isomorphism PSL(2,7) ≅ PSL(3,2) = GL(3,2) — the automorphism group of the Fano plane — one of only a handful of coincidences between the two infinite families of finite simple groups of Lie type. Realizing PSL(2,7) as a Galois group over ℚ is a classical success of the inverse Galois program: Wolfram Trinks exhibited (1968) the degree-7 polynomial x⁷−7x+3 whose Galois group is exactly PSL(2,7) acting on its seven roots, computed by Dedekind reduction modulo several primes. The full formalization of that realization is out of reach of current Mathlib (it needs Dedekind's theorem to produce the Frobenius permutation, the same gap the sibling A₅ entry records), but the group-order arithmetic — what order the target group has, and which cycle-length divisibilities constrain the Galois group — is fully elementary and axiom-free.",

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -23,10 +23,10 @@
     "sorries": 0
   },
   "title": "The Conjugacy-Class Size Formula over Nat.card",
-  "description": "Specialises the orbit-counting index identity to the conjugation action ConjAct G on G, proving the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Mathlib's total cardinal Nat.card — the single-orbit heart of the class equation. Under conjugation the orbit of g is its conjugacy class (orbit_eq_carrier_conjClasses) and the stabilizer is its centralizer; feeding these into the parent's orbit-stabilizer identities gives the size formula, unconditionally (no Finite/Fintype hypothesis), because the underlying orbit-quotient bijection needs none and the centralizer/stabilizer index match transports through the surjective isomorphism ConjAct.toConjAct. The product form |class(g)|·|C_G(g)| = |G| and restatements over the honest ConjClasses carrier are also given, together with the degenerate central-element case [G : C_G(g)] = 1. Fully verified: 0 axioms, 0 sorries.",
+  "description": "Specialises the orbit-counting index identity to the conjugation action ConjAct G on G, proving the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Mathlib's total cardinal Nat.card — the single-orbit heart of the class equation. Under conjugation the orbit of g is its conjugacy class (orbit_eq_carrier_conjClasses) and the stabilizer is its centralizer; feeding these into the parent's orbit-stabilizer identities gives the size formula, unconditionally (no Finite/Fintype hypothesis), because the underlying orbit-quotient bijection needs none and the centralizer/stabilizer index match transports through the surjective isomorphism ConjAct.toConjAct. The product form |class(g)|·|C_G(g)| = |G| and restatements over the honest ConjClasses carrier are also given, together with the degenerate central-element case [G : C_G(g)] = 1. Formalization pending — the Lean source file is not yet present on main (issue #34794); the machine-verified claim will be restored once it lands and builds.",
   "meta": {
     "author": "Lean Genius",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01OQ01.lean",
     "tags": [
       "group-theory",
@@ -44,7 +44,7 @@
     "lineCount": 149,
     "theoremCount": 6,
     "definitionCount": 0,
-    "badge": "mathlib",
+    "badge": "wip",
     "originalContributions": [
       "card_conjugacyClass_eq_index_centralizer: Nat.card (orbit (ConjAct G) g) = (centralizer {g}).index — the conjugacy-class size formula, proved unconditionally (no Finite/Fintype) by transporting orbitEquivQuotientStabilizer through Nat.card and matching the centralizer index to the stabilizer index",
       "index_centralizer_eq_index_stabilizer: (centralizer {g}).index = (stabilizer (ConjAct G) g).index — the centralizer is the comap of the conjugation stabilizer along the surjective isomorphism ConjAct.toConjAct, and comap along a surjection preserves index",
@@ -85,7 +85,8 @@
         "description": "Nat.card (centralizer {g}) = Nat.card (stabilizer (ConjAct G) g) — matches the centralizer cardinality to the conjugation stabilizer cardinality, used in the product form.",
         "module": "Mathlib.GroupTheory.Rank"
       }
-    ]
+    ],
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "openQuestions": [],
   "crossReferences": [

--- a/src/data/proofs/shannon-channel-coding-bec-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-bec-oq-03/meta.json
@@ -16,7 +16,7 @@
     "author": "Claude Shannon (1948) / Robert Fano (1961), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fano%27s_inequality",
     "date": "1961",
-    "status": "verified",
+    "status": "pending",
     "proofRepoPath": "Proofs/ShannonChannelCodingBECOQ03.lean",
     "tags": [
       "information-theory",
@@ -28,7 +28,7 @@
       "converse",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -64,7 +64,8 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "verificationNote": "Downgraded from 'verified' to 'pending' by mechanic (issue #34794): the Lean source file listed in proofRepoPath does not exist on main and has never appeared in any git commit, so the machine-verified claim is unbacked. Restore to 'verified' only once the Lean file lands and builds."
   },
   "overview": {
     "historicalContext": "Fano's inequality (1961) is the analytic heart of the converse to Shannon's channel coding theorem: it lower-bounds the conditional entropy H(X|Y) — and hence the decoding error probability — by the residual uncertainty that the channel leaves about the input. For a discrete memoryless channel the single-use converse says (1 - P_e)·log|X| ≤ C + h(P_e), where C is the channel capacity, P_e the Fano error term, and h the binary entropy. The binary erasure channel is the transparent test case: an input bit is either received intact (probability 1-p) or replaced by a known erasure symbol (probability p), giving capacity 1 - p bits.\n\nThe base gallery entry proves the BEC's information capacity (1 - p)·log 2 axiom-free, and the sibling oq-02 obtains the operational coding theorem by invoking the framework's abstract achievability/converse AXIOMS. This entry closes a genuinely axiom-free gap between them: it instantiates the gallery's already-PROVED abstract Fano converse at the BEC, the one channel-specific input being that the uniform-input Fano error term equals exactly p/2.",


### PR DESCRIPTION
Closes #34794.

## Problem
A gallery integrity sweep found **7 entries** whose `meta.json` is merged to `main` with `status: "verified"` but whose Lean source file (`proofRepoPath`) **does not exist anywhere in git history** — the public gallery advertises machine-verified proofs with zero Lean backing.

Independently reproduced: all 7 `.lean` files are absent from the working tree and `git log --all` shows no commit ever contained them.

## Fix
The issue offers two remedies. Option 1 (land the Lean source) is **impossible** here — the files exist on no branch. So this applies **option 2 (downgrade the overclaim)** for all 7:

- `meta.status`: `verified` → `pending` (valid existing enum, already used elsewhere)
- `meta.badge`: → `wip`
- added `meta.verificationNote` documenting the reason and the restore condition
- softened 3 description-level "Fully verified" prose overclaims

The `verified` claim can be restored once the corresponding Lean file lands on main and builds.

## Entries downgraded
| slug | was |
|------|-----|
| fundamental-theorem-algebra-oq-04-oq-02 | verified/original |
| erdos-76-packing-upper-bound | verified/original |
| shannon-channel-coding-bec-oq-03 | verified/original |
| erdos-1207-oq-04 | verified/verified |
| inverse-galois-oq-06-oq-02-oq-01 | verified/original |
| lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01 | verified/mathlib |
| inverse-galois-oq-04-oq-02 | verified/original |

Data-only change (7 `meta.json` files); no Lean build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)