### PR TITLE
Research: ballot Measure.map uniform fiber transfer (build-pending)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02OQ01.lean
@@ -1,0 +1,205 @@
+/-
+# Ballot Problem OQ-01-OQ-02-OQ-01-OQ-02-OQ-01: Uniform Fiber Transfer via `Measure.map`
+
+Open Question from `ballot-problem-oq-01-oq-02-oq-01-oq-02`
+("General Uniform Fiber Transfer"):
+
+  "Can the event-wise uniform fiber transfer be lifted to the clean, structural
+   statement about `MeasureTheory.Measure.map`? Rather than checking each event,
+   express the whole transfer as a single pushforward identity for `Measure.count`
+   restricted to `A` and `T`."
+
+## The Answer
+
+YES. If `f : α → β` maps `A` into `T` (`MapsTo f A T`) with every fiber
+`A ∩ f⁻¹'{t}` of the same cardinality `c` over the finite set `T`, then the
+pushforward of the restricted counting measure scales by `c`:
+
+  `(Measure.count.restrict A).map f = c • Measure.count.restrict T`.
+
+As a corollary, the uniform probability measure `uniformOn A` pushes forward to
+`uniformOn T` — recovering the parent's event-wise transfer as a single
+normalization step.
+
+## Why the `MapsTo` hypothesis (a mathematical subtlety)
+
+The parent theorem `uniformOn_fiber_transfer_all` used only `SurjOn f A T`
+(`T ⊆ f '' A`) because it evaluated on events `P ⊆ T`, where points outside `T`
+are irrelevant. The *global* pushforward identity, however, is tested on ALL
+measurable `S ⊆ β`. If some element of `A` were sent outside `T`, that mass
+would land at a point where the right-hand side `c • count.restrict T` is zero,
+breaking the equality. `MapsTo f A T` (equivalently `f '' A ⊆ T`) is exactly the
+condition that no mass escapes `T`. Together with the uniform-fiber hypothesis
+(which forces every `t ∈ T` to have a nonempty preimage when `c > 0`), this gives
+`f '' A = T`.
+
+## Proof Strategy
+
+Prove equality of measures with `Measure.ext`: it suffices to agree on every
+measurable `S ⊆ β`.
+
+  LHS S = ((count.restrict A).map f) S
+        = (count.restrict A) (f⁻¹' S)          -- `Measure.map_apply`
+        = count (f⁻¹' S ∩ A)                    -- `Measure.restrict_apply`
+        = count (A ∩ f⁻¹'(S ∩ T))               -- `MapsTo` set rewrite
+        = ((A ∩ f⁻¹'(S ∩ T)).ncard : ℝ≥0∞)      -- finite: `count = ncard`
+        = (c * (S ∩ T).ncard : ℝ≥0∞)            -- parent `uniform_fiber_count`
+        = c * count (S ∩ T)                      -- finite: `ncard = count`
+
+  RHS S = (c • count.restrict T) S
+        = c * (count.restrict T) S               -- `smul_apply`, `nsmul_eq_mul`
+        = c * count (S ∩ T)                       -- `Measure.restrict_apply`
+
+The factor `c` and the intersection `S ∩ T` match on both sides, so the whole
+identity collapses onto the already-verified counting lemma
+`BallotGeneralFiberTransfer.uniform_fiber_count`.
+
+## Status
+
+UNVERIFIED / build-pending. The Docker build wrapper and the Aristotle proof
+service were both unavailable during this session, so this file has NOT been
+machine-checked. The proof reduces to the verified parent lemma
+`uniform_fiber_count` via standard Mathlib measure-theory API
+(`Measure.map_apply`, `Measure.restrict_apply`, `Measure.count_apply_finite`,
+`Set.ncard_eq_toFinset_card`, `Measure.map_smul`). It must be built before being
+marked `verified`.
+-/
+
+import Proofs.BallotProblemOQ01OQ02OQ01OQ02
+import Mathlib.Tactic
+
+open ProbabilityTheory Set MeasureTheory
+
+namespace BallotCountMapTransfer
+
+/-
+══════════════════════════════════════════════════════════════
+PART I: count ↔ ncard BRIDGE
+══════════════════════════════════════════════════════════════ -/
+
+/-- On a finite set, the counting measure equals the natural-number cardinality
+    (`ncard`), cast into `ℝ≥0∞`. This is the bridge that lets the purely
+    combinatorial parent lemma `uniform_fiber_count` (stated in `ncard`) discharge
+    a measure-theoretic goal. -/
+theorem count_eq_ncard {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α]
+    (s : Set α) (hs : s.Finite) :
+    Measure.count s = (s.ncard : ℝ≥0∞) := by
+  rw [Measure.count_apply_finite s hs, Set.ncard_eq_toFinset_card s hs]
+
+/-
+══════════════════════════════════════════════════════════════
+PART II: THE MapsTo SET REWRITE
+══════════════════════════════════════════════════════════════ -/
+
+/-- When `f` maps `A` into `T`, testing the preimage of an arbitrary `S` against
+    `A` is the same as testing the preimage of `S ∩ T`: elements of `A` already
+    land in `T`, so intersecting the target with `T` changes nothing. -/
+theorem preimage_inter_of_mapsTo {α β : Type*} (f : α → β) (A : Set α) (T : Set β)
+    (hmaps : MapsTo f A T) (S : Set β) :
+    f ⁻¹' S ∩ A = A ∩ f ⁻¹' (S ∩ T) := by
+  ext x
+  simp only [mem_inter_iff, mem_preimage]
+  constructor
+  · rintro ⟨hS, hA⟩
+    exact ⟨hA, hS, hmaps hA⟩
+  · rintro ⟨hA, hS, _⟩
+    exact ⟨hS, hA⟩
+
+/-
+══════════════════════════════════════════════════════════════
+PART III: MAIN THEOREM — the `Measure.map` pushforward identity
+══════════════════════════════════════════════════════════════ -/
+
+/-- **Uniform Fiber Transfer as a `Measure.map` identity.**
+
+    Let `f : α → β` be measurable, mapping `A` into the finite set `T`, with every
+    fiber `A ∩ f⁻¹'{t}` of the same cardinality `c` over `T`. Then the pushforward
+    of the restricted counting measure scales by `c`:
+
+      `(Measure.count.restrict A).map f = c • Measure.count.restrict T`.
+
+    This is the structural (event-free) form of the parent's
+    `uniformOn_fiber_transfer_all`. -/
+theorem count_restrict_map_eq
+    {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    [MeasurableSingletonClass α] [MeasurableSingletonClass β]
+    (f : α → β) (hf : Measurable f)
+    (A : Set α) (T : Set β) (hA : A.Finite) (hT : T.Finite)
+    (hmaps : MapsTo f A T)
+    (c : ℕ) (hc : ∀ t ∈ T, (A ∩ f ⁻¹' {t}).ncard = c) :
+    (Measure.count.restrict A).map f = c • Measure.count.restrict T := by
+  -- Agree on every measurable set `S`.
+  refine Measure.ext (fun S hS => ?_)
+  -- LHS: unfold the pushforward and the restriction.
+  rw [Measure.map_apply hf hS, Measure.restrict_apply (hf hS),
+      preimage_inter_of_mapsTo f A T hmaps S]
+  -- The two relevant sets are finite.
+  have hST : (S ∩ T).Finite := hT.subset inter_subset_right
+  have hAfib : (A ∩ f ⁻¹' (S ∩ T)).Finite := hA.subset inter_subset_left
+  -- LHS = count(A ∩ f⁻¹'(S∩T)) = ncard(...) = c * ncard(S∩T).
+  rw [count_eq_ncard _ hAfib,
+      BallotGeneralFiberTransfer.uniform_fiber_count f A hA T hT c hc (S ∩ T)
+        inter_subset_right]
+  -- RHS: `c •` a restricted count, unfolded on `S`.
+  rw [Measure.smul_apply, Measure.restrict_apply hS, count_eq_ncard _ hST,
+      nsmul_eq_mul]
+  -- Both sides are `(c : ℝ≥0∞) * (S ∩ T).ncard`.
+  push_cast
+  ring
+
+/-
+══════════════════════════════════════════════════════════════
+PART IV: COROLLARY — `uniformOn` pushforward
+══════════════════════════════════════════════════════════════ -/
+
+/-- **`uniformOn` transfer, structural form.**
+
+    Under the same hypotheses (with `c > 0` and `T` nonempty, so both uniform
+    measures are genuine probability measures), the uniform distribution on `A`
+    pushes forward to the uniform distribution on `T`:
+
+      `(uniformOn A).map f = uniformOn T`.
+
+    This recovers the parent's event-wise `uniformOn_fiber_transfer_all` in one
+    normalization step from the counting identity `count_restrict_map_eq`. -/
+theorem uniformOn_map_eq
+    {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    [MeasurableSingletonClass α] [MeasurableSingletonClass β]
+    (f : α → β) (hf : Measurable f)
+    (A : Set α) (T : Set β) (hA : A.Finite) (hT : T.Finite)
+    (hT_ne : T.Nonempty)
+    (hmaps : MapsTo f A T)
+    (c : ℕ) (hc_pos : 0 < c) (hc : ∀ t ∈ T, (A ∩ f ⁻¹' {t}).ncard = c) :
+    (uniformOn A).map f = uniformOn T := by
+  -- `uniformOn s = (count s)⁻¹ • count.restrict s` (definition via `cond`).
+  -- Surjectivity from the fibers: every `t ∈ T` has `c > 0` preimages in `A`.
+  have hf_surj : SurjOn f A T := fun t ht => by
+    obtain ⟨x, hx⟩ := Set.nonempty_of_ncard_ne_zero (s := A ∩ f ⁻¹' {t})
+      (by rw [hc t ht]; exact hc_pos.ne')
+    exact ⟨x, hx.1, hx.2⟩
+  -- Counting relation `count A = c * count T` from the surjective fiber decomposition.
+  have hA_ncard : A.ncard = c * T.ncard := by
+    rw [BallotGeneralFiberTransfer.surjOn_fiber_decomp f A T hf_surj]
+    exact BallotFiberTransfer.ncard_biUnion_eq_of_uniform
+      (fun t => A ∩ f ⁻¹' {t}) T hT
+      (fun t _ => hA.subset inter_subset_left)
+      (fun t₁ _ t₂ _ hne => BallotGeneralFiberTransfer.singleton_fiber_disjoint f A t₁ t₂ hne)
+      c hc
+  -- Positivity / finiteness facts for the ℝ≥0∞ arithmetic.
+  have hT_pos : 0 < T.ncard := Set.ncard_pos hT |>.mpr hT_ne
+  have hcountT : Measure.count (T : Set β) = (T.ncard : ℝ≥0∞) := count_eq_ncard T hT
+  have hcountA : Measure.count (A : Set α) = (A.ncard : ℝ≥0∞) := count_eq_ncard A hA
+  -- Expand `uniformOn` as a scalar multiple of the restricted count, then push
+  -- the map through the scalar (`Measure.map_smul`) and apply the main identity.
+  unfold uniformOn ProbabilityTheory.cond
+  rw [Measure.map_smul, count_restrict_map_eq f hf A T hA hT hmaps c hc]
+  -- Goal: `(count A)⁻¹ • (c • count.restrict T) = (count T)⁻¹ • count.restrict T`.
+  rw [smul_smul, hcountA, hcountT, hA_ncard]
+  -- `(c * T.ncard)⁻¹ * c = (T.ncard)⁻¹` in ℝ≥0∞ (c ≠ 0, T.ncard ≠ 0, both finite).
+  congr 1
+  have hc0 : (c : ℝ≥0∞) ≠ 0 := by exact_mod_cast hc_pos.ne'
+  have hcT : ((c * T.ncard : ℕ) : ℝ≥0∞) = (c : ℝ≥0∞) * (T.ncard : ℝ≥0∞) := by push_cast; ring
+  rw [hcT, ENNReal.mul_inv (Or.inl hc0) (Or.inl (by exact_mod_cast (by omega : c * T.ncard ≠ 0))),
+      mul_comm, mul_assoc, ENNReal.inv_mul_cancel hc0 (ENNReal.natCast_ne_top c), mul_one]
+
+end BallotCountMapTransfer

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -1,21 +1,136 @@
 # Knowledge Base: ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
 
-Insights accumulated during research on this problem.
+Uniform Fiber Transfer via `MeasureTheory.Measure.map`.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Lift the parent's **event-wise** uniform fiber transfer (`uniformOn A (f⁻¹'P) =
+uniformOn T P` for events `P ⊆ T`, verified in
+`proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02.lean`) to the **structural**
+pushforward identity for the counting measure:
+
+    (Measure.count.restrict A).map f = c • Measure.count.restrict T
+
+with the corollary `(uniformOn A).map f = uniformOn T`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### KEY INSIGHT — the correct hypothesis is `MapsTo`, not `SurjOn`
+
+The parent theorem used only `SurjOn f A T` (`T ⊆ f '' A`) because it evaluated on
+events `P ⊆ T`, where the behaviour of `f` outside the fibers over `T` is
+irrelevant. The **global** `Measure.map` identity is tested on *all* measurable
+`S ⊆ β`. If any element of `A` mapped outside `T`, that mass would land where the
+RHS `c • count.restrict T` is zero — breaking the equality. The right hypothesis
+is therefore **`MapsTo f A T`** (equivalently `f '' A ⊆ T`): no mass escapes `T`.
+Combined with the uniform-fiber hypothesis (which, for `c > 0`, forces `SurjOn`),
+this yields `f '' A = T`. This is the one genuinely new mathematical requirement
+the lift introduces over the parent.
+
+### The proof collapses onto the verified parent counting lemma
+
+Testing on a measurable `S`, the LHS reduces — via `Measure.map_apply` then
+`Measure.restrict_apply` — to `count (f⁻¹'S ∩ A)`. Using `MapsTo`,
+`f⁻¹'S ∩ A = A ∩ f⁻¹'(S ∩ T)`. On the finite set this counting measure equals
+`ncard`, and `BallotGeneralFiberTransfer.uniform_fiber_count` gives
+`(A ∩ f⁻¹'(S∩T)).ncard = c * (S∩T).ncard`. The RHS is `c * count (S ∩ T)`. Both
+sides are `(c : ℝ≥0∞) * (S ∩ T).ncard`. So the whole `Measure.map` statement is
+just the already-verified `ncard` lemma dressed in measure-theoretic API — no new
+combinatorics.
+
+### The `count ↔ ncard` bridge is the only piece of new plumbing
+
+`Measure.count s = (s.ncard : ℝ≥0∞)` for finite `s`, proved from
+`Measure.count_apply_finite` + `Set.ncard_eq_toFinset_card` (both require
+`MeasurableSingletonClass`). This is the adapter between the combinatorial parent
+(stated in `ncard`) and the measure-theoretic target.
+
+### The `uniformOn` corollary is one normalization step
+
+`uniformOn s = Measure.count[|s] = (count s)⁻¹ • count.restrict s`
+(`ProbabilityTheory.cond`). Pushing the map through the scalar with
+`Measure.map_smul` and applying the counting identity leaves
+`(count A)⁻¹ • (c • count.restrict T)`. Since `count A = c * count T` (finite,
+`c > 0`), the scalar `(count A)⁻¹ * c` collapses to `(count T)⁻¹`, giving
+`uniformOn T`. The ℝ≥0∞ arithmetic uses `ENNReal.mul_inv` and
+`ENNReal.inv_mul_cancel` with `c ≠ 0`, `T.ncard ≠ 0`, `c` and `T.ncard` finite.
+
+---
+
+## Exact Mathlib API used
+
+| Purpose | Lemma |
+|---------|-------|
+| pushforward on measurable set | `MeasureTheory.Measure.map_apply hf hS` |
+| restriction on measurable set | `MeasureTheory.Measure.restrict_apply` |
+| finite count = card | `MeasureTheory.Measure.count_apply_finite` |
+| card = toFinset card | `Set.ncard_eq_toFinset_card` |
+| measure extensionality | `MeasureTheory.Measure.ext` |
+| scalar of measure on set | `MeasureTheory.Measure.smul_apply` |
+| map of scalar multiple | `MeasureTheory.Measure.map_smul` |
+| nonempty fiber ⇒ surjective | `Set.nonempty_of_ncard_ne_zero` |
+| `count A = c • count T` | parent `BallotFiberTransfer.ncard_biUnion_eq_of_uniform` |
+| the core counting identity | parent `BallotGeneralFiberTransfer.uniform_fiber_count` |
+| `uniformOn` = conditioned count | `ProbabilityTheory.uniformOn`, `ProbabilityTheory.cond` |
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **`SurjOn`-only hypothesis**: insufficient for the global `Measure.map`
+  identity (see KEY INSIGHT). Do not restate the parent's hypotheses verbatim.
+- **Singleton-determination of `count`**: tempting ("count is a sum of Diracs")
+  but unnecessary — `Measure.ext` over measurable sets plus the finite
+  `count = ncard` bridge is cleaner and avoids `tsum` bookkeeping for infinite
+  targets. `T` is finite, so `S ∩ T` is always finite.
+
+---
+
+## Sessions
+
+### Session 2026-07-04 (Session 1) — ORIENT + scaffold
+
+**Mode**: FRESH
+**Outcome**: progress (build-pending)
+
+**What I did**
+- Read parent `BallotProblemOQ01OQ02OQ01OQ02.lean`; confirmed the verified lemma
+  `uniform_fiber_count` (ncard form) is exactly the combinatorial core needed.
+- Derived the correct hypothesis set (`MapsTo f A T`, not `SurjOn`) for the
+  global pushforward — the one new mathematical content of the lift.
+- Pinned exact Mathlib API from the local mathlib4 checkout (signatures verified,
+  not compiled): `count_apply_finite`, `map_apply`, `restrict_apply`, `smul_apply`,
+  `map_smul`, `ncard_eq_toFinset_card`, `nonempty_of_ncard_ne_zero`, `Measure.ext`.
+- Wrote `proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02OQ01.lean`:
+  - `count_eq_ncard` (finite bridge),
+  - `preimage_inter_of_mapsTo` (the `MapsTo` set rewrite),
+  - `count_restrict_map_eq` (MAIN — the `Measure.map` identity),
+  - `uniformOn_map_eq` (corollary — `uniformOn` pushforward).
+
+**Key findings**
+- The lift adds no new combinatorics; it reduces entirely to the parent lemma
+  plus the finite `count ↔ ncard` bridge.
+- `MapsTo` is the essential extra hypothesis.
+
+**Files modified**
+- `proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02OQ01.lean` (new)
+
+**Blocker this session**
+- DUAL-TOOL BLACKOUT: Docker build wrapper (containerd blob I/O error) and
+  Aristotle proof service ("Resource not found" / 404) both unavailable. The file
+  is therefore **UNVERIFIED / build-pending** — the proof structure is complete
+  and reduces to verified lemmas, but has not been machine-checked. Marked so in
+  the PR body to keep the deployer from auto-merging.
+
+**Next steps**
+- Build `Proofs.BallotProblemOQ01OQ02OQ01OQ02OQ01` once Docker recovers; fix any
+  coercion / lemma-argument mismatches (most likely spots: the `ENNReal.mul_inv`
+  argument forms in `uniformOn_map_eq`, and `push_cast`/`nsmul_eq_mul` in
+  `count_restrict_map_eq`).
+- Once verified (0 sorries, 0 axioms), create the gallery entry
+  `src/data/proofs/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/` and mark
+  `status: verified`.

--- a/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01/state.md
@@ -1,25 +1,32 @@
 # Research State: ballot-problem-oq-01-oq-02-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04T17:46:11-07:00
-**Iteration**: 1
+**Since**: 2026-07-04
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Scaffolded the `Measure.map` pushforward identity and its `uniformOn` corollary,
+reducing both to the verified parent lemma `uniform_fiber_count`. File written but
+NOT machine-checked (dual-tool blackout).
 
 ## Active Approach
-None yet.
+Approach B (evaluate on measurable sets via `Measure.map_apply`), with the key
+correction that the clean hypothesis is `MapsTo f A T` (not `SurjOn`). Bridge
+`count ↔ ncard` on finite sets to reuse the combinatorial parent lemma verbatim.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (Approach B)
 
 ## Blockers
-None.
+Build verification blocked: Docker build wrapper (containerd blob I/O error) and
+Aristotle proof service (404) both unavailable this session. File is build-pending.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Build `Proofs.BallotProblemOQ01OQ02OQ01OQ02OQ01` when Docker recovers; fix any
+coercion/argument mismatches (likely spots: `ENNReal.mul_inv` args in
+`uniformOn_map_eq`; `push_cast`/`nsmul_eq_mul` in `count_restrict_map_eq`). Then
+create the gallery entry and mark verified.


### PR DESCRIPTION
## Summary

Lifts the parent **event-wise** uniform fiber transfer (`ballot-problem-oq-01-oq-02-oq-01-oq-02`, verified) to the **structural** `MeasureTheory.Measure.map` pushforward identity for the counting measure:

```
(Measure.count.restrict A).map f = c • Measure.count.restrict T
```

plus the corollary `(uniformOn A).map f = uniformOn T`.

## Mathematical content

The one new idea over the parent: the clean *global* identity requires **`MapsTo f A T`** (f maps A into T), not just the parent's `SurjOn`. The global identity is tested on *all* measurable `S ⊆ β`; any mass mapped outside `T` would land where the RHS `c • count.restrict T` is zero, breaking equality. With `MapsTo`, the proof collapses entirely onto the verified parent lemma `uniform_fiber_count` via a finite `count = ncard` bridge — no new combinatorics.

New declarations in `proofs/Proofs/BallotProblemOQ01OQ02OQ01OQ02OQ01.lean`:
- `count_eq_ncard` — finite `count = ncard` bridge
- `preimage_inter_of_mapsTo` — the `MapsTo` set rewrite
- `count_restrict_map_eq` — **main** pushforward identity
- `uniformOn_map_eq` — `uniformOn` corollary

0 sorries.

## ⚠️ UNVERIFIED / build-pending — DO NOT MERGE until built

The Docker build wrapper (containerd blob I/O error) and Aristotle (404) were **both unavailable** this session, so this file has **NOT been machine-checked**. The proof structure is complete and reduces to verified lemmas, but likely needs minor coercion fixups (see `state.md` for the suspected spots). Build `Proofs.BallotProblemOQ01OQ02OQ01OQ02OQ01` and confirm 0 sorries / 0 axioms before marking verified or creating a gallery entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)