### PR TITLE
Research: dense-countable-fsigma-not-gdelta ACT — abstract theorem written (build-blocked)

### DIFF
--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
@@ -1,21 +1,142 @@
 # Knowledge Base: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
 
-Insights accumulated during research on this problem.
+**Problem**: Dense Countable Sets are Fσ but not Gδ in Perfect Polish Spaces
+
+**Goal**: State and prove `denseCountable_isFσ_not_isGδ` — in a nonempty perfect Polish (or
+perfect + T1 + Baire) space, a countable dense set is `Fσ` and not `Gδ` — then recover `ℚ ⊆ ℝ`
+and the algebraic reals as instances.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent chain already contains the complete mathematics; this problem is a **consolidation /
+abstraction** task, not new theory. Being honest about significance: the result is routine given
+the two parents below. Its value is (a) one citable uniform lemma over *all* perfect Polish
+spaces, (b) the previously-unstated `ℚ`-not-`Gδ` instance, (c) removing duplication.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### The proof is a ~6-line assembly of already-compiling lemmas
+
+Both engines were stated **abstractly** (for arbitrary `X`) by the parents, so the generalization
+is nearly free:
+
+- **Fσ side** — `AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_of_countable`
+  `{X} [TopologicalSpace X] [T1Space X] {s} (hs : s.Countable) : IsFσ s`
+  (`IsFσ` is a *local* def in that file: `∃ T : Set (Set X), (∀ t ∈ T, IsClosed t) ∧ T.Countable ∧ s = ⋃₀ T`.
+  Mathlib v4.26.0 has **no** `IsFσ` predicate — only `IsGδ`. Confirmed by grep across the corpus.)
+  Density is NOT needed for the Fσ half — countability + T1 suffice (union of closed singletons).
+
+- **not-Gδ side** — two lemmas from `AlgebraicNumbersCountableOQ02OQ03OQ02`:
+  - `compl_countable_isDenseGδ {X} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X] {s} (hs : s.Countable) : IsGδ sᶜ ∧ Dense sᶜ`
+  - `not_isGδ_of_dense_of_disjoint_denseGδ {X} [TopologicalSpace X] [BaireSpace X] [Nonempty X] {s t} (hsd : Dense s) (hsg : IsGδ s) (htg : IsGδ t) (htd : Dense t) (hdisj : Disjoint s t) : False`
+
+  Assemble with `s := D`, `t := Dᶜ`, `hdisj := disjoint_compl_right`. Perfectness enters only via
+  `compl_countable_isDenseGδ` (singletons nowhere dense ⇒ `D` meagre ⇒ `Dᶜ` residual = dense).
+
+### Minimal hypotheses
+
+`[TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X] [Nonempty X]`. This is strictly
+more general than "perfect Polish": a perfect Polish space (nonempty complete separable metric,
+no isolated points) supplies all four instances (metric ⇒ T1; complete metric ⇒ BaireSpace;
+perfect ⇒ PerfectSpace). Stating with the four typeclasses avoids depending on whether
+`PolishSpace`'s `BaireSpace` instance fires and instantly covers `ℝ`, `ℝⁿ`, Cantor space `2^ℕ`,
+Baire space `ℕ^ℕ`.
+
+### The `ℚ`-not-Gδ corollary is new
+
+The parents proved the algebraic-reals case but never `ℚ` itself. `Set.range ((↑):ℚ→ℝ)` is
+countable (`Set.countable_range`, `ℚ` is `Countable`) and dense (`Rat.denseRange_cast`, whose
+type `DenseRange` is defeq `Dense (range …)`), giving the classical "ℚ is not Gδ in ℝ" as the
+`X := ℝ` instance.
 
 ---
 
-## Dead Ends
+## Proof (written, BUILD-UNVERIFIED)
 
-[Approaches known not to work will be documented here]
+Full file: `lean/DenseCountableFsigmaNotGdelta.lean`. Core:
+
+```lean
+theorem denseCountable_isFσ_not_isGδ {X : Type*} [TopologicalSpace X] [T1Space X]
+    [PerfectSpace X] [BaireSpace X] [Nonempty X] {D : Set X}
+    (hcount : D.Countable) (hdense : Dense D) : IsFσ D ∧ ¬ IsGδ D := by
+  refine ⟨isFσ_of_countable hcount, fun hGδ => ?_⟩
+  obtain ⟨hgδc, hdc⟩ := compl_countable_isDenseGδ hcount
+  exact not_isGδ_of_dense_of_disjoint_denseGδ hdense hGδ hgδc hdc disjoint_compl_right
+```
+
+Plus `rat_not_isGδ` and `algebraicReals_not_isGδ` (the parent's headline) as corollaries.
+
+---
+
+## Dead Ends / Risks (build-unverified items to confirm on recovery)
+
+1. `open Namespace (IsFσ isFσ_of_countable)` selective-open of a `def` + theorem — standard Lean 4,
+   but confirm no name clash with any Mathlib `IsFσ` introduced after v4.26.0.
+2. `Rat.denseRange_cast` passed where `Dense D` is expected relies on `DenseRange f = Dense (range f)`
+   being definitional. If elaboration balks, replace with `(Rat.denseRange_cast (𝕜 := ℝ)).dense`
+   or an explicit `by exact`.
+3. Confirm `PerfectSpace ℝ` / `BaireSpace ℝ` instances resolve at the `ℝ` corollaries (they must —
+   the parent `algebraicReals_isMeagre` already applied `countable_isMeagre` at `X := ℝ`, which
+   needs `[PerfectSpace ℝ]`).
+
+None of these is a mathematical gap; all are surface Lean-elaboration checks.
+
+---
+
+## Mathlib Gaps
+
+- **No `IsFσ` predicate in Mathlib v4.26.0** (only `IsGδ`). The corpus works around it with a local
+  `def IsFσ` + `isFσ_iff_isGδ_compl` duality (`AlgebraicRealsMeagerDenseGDeltaOQ01`). This is the
+  natural home for an eventual upstream `IsFσ` contribution (def + De Morgan duality +
+  `isFσ_of_countable`), which would generalize this whole gallery family.
+
+---
+
+## Next Steps
+
+1. **On Docker/Aristotle recovery**: move `lean/DenseCountableFsigmaNotGdelta.lean` → `proofs/Proofs/`,
+   add its import to `proofs/Proofs.lean`, run `./proofs/scripts/docker-build.sh
+   Proofs.DenseCountableFsigmaNotGdelta`. Fix any of the 3 surface risks above if they surface.
+2. Verify `#print axioms` shows only foundational axioms (expect `verified` / `original`).
+3. Create gallery data `src/data/proofs/dense-countable-fsigma-not-gdelta/` (meta.json,
+   annotations.json, index.ts); mark `status: verified`, cross-reference the two parents and the
+   `algebraic-reals-meager` family.
+4. Optional follow-up (only if strong): upstream an `IsFσ` predicate to Mathlib, or state the dual
+   "dense-Gδ complement of a dense countable set is not Fσ" abstractly (parent has the concrete
+   `transcendentalReals_not_isFσ`).
+
+---
+
+## Session 2026-07-04 (Session 1) — ORIENT/ACT (proof written, build blocked)
+
+**Mode**: FRESH
+**Outcome**: progress (complete proof written; build-unverified due to dual-tool blackout)
+
+### What I Did
+- Session preamble: confirmed Aristotle 404 ("Resource not found") and Docker containerd blob
+  I/O error persist — no proof-checking path available this session.
+- Surveyed the parent chain and found ALL ingredients already proven and compiling:
+  parent `…OQ02OQ03OQ02` (the two abstract Baire engines) and sibling `…MeagerDenseGDeltaOQ01`
+  (the `IsFσ` def + `isFσ_of_countable`).
+- Wrote the complete abstraction `denseCountable_isFσ_not_isGδ` + `rat_not_isGδ` +
+  `algebraicReals_not_isGδ` as `lean/DenseCountableFsigmaNotGdelta.lean` (scratch, not in
+  `Proofs/` to avoid breaking the globbed build with an unverified file).
+
+### Key Findings
+- The generalization is a ~6-line mechanical assembly; the parents already stated both engines
+  for arbitrary `X`. Honest significance: consolidation, not new mathematics.
+- `ℚ`-not-`Gδ` in `ℝ` is a genuinely new instance the parents skipped.
+- Mathlib still lacks an `IsFσ` predicate (v4.26.0) — the recurring gap in this family.
+
+### Files Modified
+- `research/problems/…/lean/DenseCountableFsigmaNotGdelta.lean` (created — scratch proof)
+- `research/problems/…/knowledge.md` (this file)
+- `research/problems/…/state.md` (phase → ACT)
+
+### Next Steps
+Drop the scratch file into `Proofs/`, build once on Docker recovery, ship gallery entry. See
+"Next Steps" above.

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/lean/DenseCountableFsigmaNotGdelta.lean
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/lean/DenseCountableFsigmaNotGdelta.lean
@@ -1,0 +1,101 @@
+/-
+  SCRATCH / BUILD-UNVERIFIED (2026-07-04, researcher-14)
+
+  Docker build + Aristotle are both down (containerd blob I/O error; Aristotle 404),
+  so this file has NOT been compiled. It is a mechanical assembly of lemmas whose
+  exact signatures were read from the following COMPILING corpus files:
+
+    * proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean
+        - def IsFσ, theorem isFσ_of_countable  (T1 space, countable ⇒ Fσ)
+    * proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02.lean
+        - compl_countable_isDenseGδ            (T1 + Perfect + Baire: sᶜ dense Gδ)
+        - not_isGδ_of_dense_of_disjoint_denseGδ (Baire + Nonempty engine)
+        - algebraicReals_dense
+    * proofs/Proofs/AlgebraicNumbersCountable.lean
+        - algebraic_reals_countable
+
+  HANDOFF: once Docker recovers, move this file to proofs/Proofs/, add an
+  `import Proofs.DenseCountableFsigmaNotGdelta` line to proofs/Proofs.lean, and run
+    ./proofs/scripts/docker-build.sh Proofs.DenseCountableFsigmaNotGdelta
+  Expected: 0 sorries, 0 axioms (foundational only). Then create gallery data under
+  src/data/proofs/dense-countable-fsigma-not-gdelta/ (meta.json, annotations.json, index.ts).
+-/
+import Mathlib.Tactic
+import Proofs.AlgebraicRealsMeagerDenseGDeltaOQ01
+import Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02
+
+/-!
+# Dense countable sets are Fσ but not Gδ in perfect Polish spaces
+
+The parent entry (`algebraic-numbers-countable-oq-02-oq-03-oq-02`) proved, for the concrete
+algebraic reals in `ℝ`, that a dense countable set is `Fσ` but not `Gδ`. Crucially, it stated the
+two engines abstractly (for an arbitrary `X`):
+
+* `compl_countable_isDenseGδ` — in a perfect `T1` Baire space the complement of a countable set
+  is a dense `Gδ`;
+* `not_isGδ_of_dense_of_disjoint_denseGδ` — in a nonempty Baire space a dense set disjoint from a
+  dense `Gδ` cannot itself be `Gδ`.
+
+The sibling `algebraic-reals-meager-dense-gdelta-oq-01` supplied the missing `Fσ` half:
+
+* `IsFσ` (a local dual of Mathlib's `IsGδ` — Mathlib v4.26.0 has no `IsFσ` predicate) and
+* `isFσ_of_countable` — in a `T1` space every countable set is `Fσ`.
+
+This entry does the **abstraction the open question asks for**: it packages both halves into one
+theorem quantified over *every* perfect Polish space and *every* dense countable subset, then
+recovers `ℚ ⊆ ℝ` and the algebraic reals as one-line instances. It is a consolidation result, not
+a new idea — the mathematical content already lives in the two parents; the value is removing
+duplication and giving the gallery a single citable lemma.
+
+## Main results
+
+* `denseCountable_isFσ_not_isGδ` — the headline: in a nonempty perfect `T1` Baire space, a
+  countable dense set is `Fσ` and not `Gδ`.
+* `rat_not_isGδ` — `ℚ` (as `Set.range ((↑) : ℚ → ℝ)`) is not `Gδ` in `ℝ` — a genuinely new
+  instance the parents did not state.
+* `algebraicReals_not_isGδ` — the parent's headline re-derived as a corollary.
+-/
+
+open Set Topology
+open AlgebraicRealsMeagerDenseGDeltaOQ01 (IsFσ isFσ_of_countable)
+open AlgebraicNumbersCountableOQ02OQ03OQ02
+  (compl_countable_isDenseGδ not_isGδ_of_dense_of_disjoint_denseGδ)
+
+namespace DenseCountableFsigmaNotGdelta
+
+/-- **Dense countable ⇒ `Fσ` but not `Gδ`, in any nonempty perfect `T1` Baire space.**
+
+`Fσ`: countability alone (with `T1`) gives `Fσ` via `isFσ_of_countable` — the set is the
+countable union of its closed singletons.
+
+Not `Gδ`: the complement `Dᶜ` is a *dense* `Gδ` (`compl_countable_isDenseGδ`, using perfectness
+so singletons are nowhere dense, hence `D` is meagre and `Dᶜ` residual = dense). If `D` were also
+`Gδ`, then `D` (dense) and `Dᶜ` (dense `Gδ`) would be two disjoint dense `Gδ` sets, whose
+intersection is dense — impossible in a nonempty space (`not_isGδ_of_dense_of_disjoint_denseGδ`,
+with `disjoint_compl_right : Disjoint D Dᶜ`). -/
+theorem denseCountable_isFσ_not_isGδ {X : Type*} [TopologicalSpace X] [T1Space X]
+    [PerfectSpace X] [BaireSpace X] [Nonempty X] {D : Set X}
+    (hcount : D.Countable) (hdense : Dense D) : IsFσ D ∧ ¬ IsGδ D := by
+  refine ⟨isFσ_of_countable hcount, fun hGδ => ?_⟩
+  obtain ⟨hgδc, hdc⟩ := compl_countable_isDenseGδ hcount
+  exact not_isGδ_of_dense_of_disjoint_denseGδ hdense hGδ hgδc hdc disjoint_compl_right
+
+/-- **The rationals are not a `Gδ` subset of `ℝ`.** `ℚ` is countable (`Set.countable_range`) and
+dense (`Rat.denseRange_cast`), and `ℝ` is a nonempty perfect `T1` Baire space, so this is the
+`X := ℝ`, `D := range ((↑) : ℚ → ℝ)` instance of the headline. This is the classical fact that
+motivates the whole family; the parents proved the algebraic-reals case but never `ℚ` directly. -/
+theorem rat_not_isGδ : ¬ IsGδ (Set.range ((↑) : ℚ → ℝ)) :=
+  (denseCountable_isFσ_not_isGδ (Set.countable_range _) Rat.denseRange_cast).2
+
+/-- **The algebraic reals are not a `Gδ` subset of `ℝ`** — the parent's headline recovered as a
+corollary of the abstract theorem, via countability (`algebraic_reals_countable`) and density
+(`algebraicReals_dense`). -/
+theorem algebraicReals_not_isGδ : ¬ IsGδ {x : ℝ | IsAlgebraic ℚ x} :=
+  (denseCountable_isFσ_not_isGδ
+      AlgebraicNumbersCountable.algebraic_reals_countable
+      AlgebraicNumbersCountableOQ02OQ03OQ02.algebraicReals_dense).2
+
+end DenseCountableFsigmaNotGdelta
+
+#print axioms DenseCountableFsigmaNotGdelta.denseCountable_isFσ_not_isGδ
+#print axioms DenseCountableFsigmaNotGdelta.rat_not_isGδ

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/state.md
@@ -1,25 +1,31 @@
 # Research State: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04T17:46:11-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Complete proof written (`lean/DenseCountableFsigmaNotGdelta.lean`); build-unverified because
+Docker (containerd blob I/O error) and Aristotle (404) are both down this session.
 
 ## Active Approach
-None yet.
+Approach A (Baire via complement), assembled from already-compiling parent lemmas:
+- Fσ: `AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_of_countable`
+- not-Gδ: `AlgebraicNumbersCountableOQ02OQ03OQ02.compl_countable_isDenseGδ`
+  + `not_isGδ_of_dense_of_disjoint_denseGδ`
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (Approach A — succeeded on paper, pending build)
 
 ## Blockers
-None.
+Dual-tool blackout (Docker + Aristotle) — cannot compile-verify. Not a mathematical blocker;
+proof reduces to already-verified lemmas.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+On Docker recovery: move `lean/DenseCountableFsigmaNotGdelta.lean` into `proofs/Proofs/`, add the
+import to `proofs/Proofs.lean`, build, then create gallery data and mark COMPLETED. See
+knowledge.md "Next Steps".


### PR DESCRIPTION
## Summary

Generalizes the algebraic-reals `Fσ`-but-not-`Gδ` dichotomy (parent `algebraic-numbers-countable-oq-02-oq-03-oq-02`) to **arbitrary nonempty perfect `T1` Baire spaces**:

```
denseCountable_isFσ_not_isGδ : D.Countable → Dense D → IsFσ D ∧ ¬ IsGδ D
```

with corollaries `rat_not_isGδ` (ℚ is not `Gδ` in ℝ — a **new** instance the parents never stated) and `algebraicReals_not_isGδ` (parent headline recovered).

## What's here (data-only, build-safe)
- `research/problems/.../lean/DenseCountableFsigmaNotGdelta.lean` — the complete proof, staged as **scratch** (NOT in `proofs/Proofs/`).
- `knowledge.md` / `state.md` — full ORIENT/ACT writeup, exact lemma provenance, handoff notes, phase → ACT.

## Why scratch, not `Proofs/`
Docker (containerd blob I/O error) and Aristotle (404) are **both down** this session — no compile-verification path. The proof is a ~6-line mechanical assembly of lemmas whose exact signatures were read from compiling corpus files (parent `OQ02OQ03OQ02` supplies both Baire engines abstractly; sibling `MeagerDenseGDeltaOQ01` supplies `IsFσ` + `isFσ_of_countable`). Staging as scratch avoids breaking the globbed `Proofs/` build with an unverified file.

**Handoff**: on Docker recovery, move the file into `proofs/Proofs/`, add its import, run one `docker-build.sh`, then create the gallery entry. Three surface Lean-elaboration risks (none mathematical) are enumerated in `knowledge.md`.

## Honesty
This is a **consolidation** result, not new mathematics — the parents already stated both engines for arbitrary `X`. Value: one citable uniform lemma over all perfect Polish spaces, the new ℚ instance, and removed duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)