### PR TITLE
Enrich Erdős #1: Conway–Guy Construction (erdos-1-wip-01-oq-03): crossReferences 0→4

### DIFF
--- a/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-wip-01-oq-03/meta.json
@@ -111,5 +111,27 @@
       "Erdős's original question: is f(n) ≥ c·2ⁿ for an absolute constant c? The best known lower bounds (Erdős–Moser type, via the second moment method) fall short of the conjectured constant.",
       "Can kernel `decide` be pushed past n = 8 without native_decide, e.g. by a smarter reflected decision procedure that avoids materializing the full 2ⁿ-element subset-sum finset?"
     ]
-  }
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1-wip-01",
+      "relationship": "extends",
+      "description": "The direct parent this open-question entry advances. It develops the distinct-subset-sums problem (Erdős #1); this entry supplies the Conway–Guy construction showing an n-element set with all 2ⁿ subset sums distinct and largest element below the powers-of-two benchmark 2ⁿ⁻¹."
+    },
+    {
+      "targetId": "erdos-1",
+      "relationship": "related",
+      "description": "The root formalization of Erdős Problem #1 — the minimum largest element f(n) of an n-set with distinct subset sums. This entry contributes the upper-bound side: the Conway–Guy sequence beats the trivial {1,2,4,…,2ⁿ⁻¹} construction, sharpening the known bounds on f(n)."
+    },
+    {
+      "targetId": "erdos-1-oq-03",
+      "relationship": "related",
+      "description": "A sibling entry on the same third open question of Erdős #1, developing a complementary facet of the distinct-subset-sums bound that this Conway–Guy construction entry addresses."
+    },
+    {
+      "targetId": "erdos-340-greedy-sidon",
+      "relationship": "related",
+      "description": "A neighbouring additive-combinatorics problem sharing the distinct-sums theme. Sidon sets (all pairwise sums distinct) are the pairwise analogue of the all-subset-sums-distinct sets of Erdős #1; the greedy-construction and extremal-growth questions run in close parallel."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-1-wip-01-oq-03` — closes the mechanical gap of **0 crossReferences**.

Added 4 accurate cross-references to verified sibling gallery entries: `erdos-1-wip-01`, `erdos-1`, `erdos-1-oq-03`, `erdos-340-greedy-sidon`.

Each cross-ref names the specific proof-level relationship (parent/extends, shared tool, or contrasting approach). meta.json only, under the 60 KB cap. Built via git plumbing off origin/main.