### PR TITLE
Research: zassenhaus-butterfly oq-04-oq-03 — statement + common-middle-quotient architecture (build-blocked)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean
@@ -1,0 +1,228 @@
+/-
+  Zassenhaus (Butterfly) Lemma  (OQ-04-OQ-03)
+
+  A self-contained formalization of the Zassenhaus butterfly lemma for subgroups,
+  the key ingredient of the Schreier refinement theorem and hence of an
+  independent (non-lattice) route to Jordan–Hölder.
+
+  ## Statement
+
+  Let `A ⊴ A'` and `B ⊴ B'` be subgroups of a group `G` (here `A ≤ A'` with `A`
+  relatively normal in `A'`, and likewise for `B`).  Then
+  ```
+      A (A' ∩ B')            B (B' ∩ A')
+     ────────────    ≅      ────────────
+      A (A' ∩ B )            B (B' ∩ A )
+  ```
+  where a "product" `A (A' ∩ B')` is realized as the subgroup join
+  `A ⊔ (A' ⊓ B')` — legitimate because `A ⊴ A'` normalizes `A' ⊓ B' ≤ A'`.
+
+  ## Proof architecture (classical, via a common middle quotient)
+
+  Both butterfly quotients are shown isomorphic to the single quotient
+  ```
+      (A' ∩ B') ⧸ D ,      D := (A ∩ B') (A' ∩ B) = (A ⊓ B') ⊔ (A' ⊓ B).
+  ```
+  The isomorphism `(A' ∩ B')/D  ≃  A(A'∩B') / A(A'∩B)` is a *refined second
+  isomorphism theorem*: the homomorphism
+  ```
+      ψ : (A' ⊓ B')  →  (A ⊔ (A'⊓B')) ⧸ (A ⊔ (A'⊓B)) ,   ψ = mk' ∘ inclusion
+  ```
+  is surjective (because `A ⊴ A'` lets us absorb the `A`-part) with kernel exactly
+  `D.subgroupOf (A' ⊓ B')`.  This is the *same construction* used for `second_iso`
+  in `AbelRuffiniGaloisExtensionsOQ04` (there proved sorry-free via
+  `QuotientGroup.quotientKerEquivOfSurjective`); the butterfly lemma is obtained by
+  running it twice and composing.
+
+  ## Proof status (BUILD-BLOCKED — Docker/Aristotle unavailable this session)
+
+  * `zassenhaus_middle_left_le` / `zassenhaus_D_le` … normality/containment
+    scaffolding, proved directly (mirrors the parent file's compiled API usage).
+  * `half_diamond_iso` … the refined second isomorphism, structured exactly like
+    the parent's `second_iso`.  Two analytic steps — surjectivity via `A ⊴ A'`
+    conjugation, and the kernel computation `ker ψ = D` — are isolated as `sorry`s
+    with full proof sketches inline.  Each is a concrete, closed sub-goal.
+  * `zassenhaus_butterfly` … assembles the two half-diamonds.
+
+  This file has NOT been machine-checked (build infrastructure was unavailable).
+  Lemma names and tactic idioms were taken from the sibling compiled file
+  `AbelRuffiniGaloisExtensionsOQ04.lean`.  Treat every `sorry` as an open,
+  fully-specified obligation, not as an axiom.
+-/
+
+import Mathlib.Tactic
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Subgroup.Basic
+
+namespace AbelRuffiniGaloisExtensionsOQ04OQ03
+
+open Subgroup QuotientGroup
+
+variable {G : Type*} [Group G]
+
+-- ============================================================
+-- PART I: The four subgroups and the middle datum
+-- ============================================================
+
+/-- Package of a Zassenhaus configuration: `A ⊴ A'` and `B ⊴ B'`. -/
+structure ZConfig (G : Type*) [Group G] where
+  A  : Subgroup G
+  A' : Subgroup G
+  B  : Subgroup G
+  B' : Subgroup G
+  hAle : A ≤ A'
+  hAn  : (A.subgroupOf A').Normal
+  hBle : B ≤ B'
+  hBn  : (B.subgroupOf B').Normal
+
+namespace ZConfig
+
+variable (Z : ZConfig G)
+
+/-- The upper "product" `A (A' ∩ B') = A ⊔ (A' ⊓ B')`.  Marked `abbrev` so that
+    the containment lemmas below elaborate transparently. -/
+abbrev upper : Subgroup G := Z.A ⊔ (Z.A' ⊓ Z.B')
+
+/-- The lower "product" `A (A' ∩ B) = A ⊔ (A' ⊓ B)`. -/
+abbrev lower : Subgroup G := Z.A ⊔ (Z.A' ⊓ Z.B)
+
+/-- The middle subgroup `A' ∩ B'`. -/
+abbrev mid : Subgroup G := Z.A' ⊓ Z.B'
+
+/-- The common denominator `D = (A ∩ B') (A' ∩ B) = (A ⊓ B') ⊔ (A' ⊓ B)`. -/
+abbrev D : Subgroup G := (Z.A ⊓ Z.B') ⊔ (Z.A' ⊓ Z.B)
+
+lemma lower_le_upper : Z.lower ≤ Z.upper :=
+  sup_le_sup_left (inf_le_inf_left Z.A' Z.hBle) Z.A
+
+lemma mid_le_upper : Z.mid ≤ Z.upper := le_sup_right
+
+-- ============================================================
+-- PART II: Containments defining the common denominator `D`
+-- ============================================================
+
+/-- `A ⊓ B' ≤ A' ⊓ B'` — the left factor of `D` sits inside the middle. -/
+lemma inf_A_B'_le_mid : Z.A ⊓ Z.B' ≤ Z.mid :=
+  le_inf (inf_le_left.trans Z.hAle) inf_le_right
+
+/-- `A' ⊓ B ≤ A' ⊓ B'` — the right factor of `D` sits inside the middle. -/
+lemma inf_A'_B_le_mid : Z.A' ⊓ Z.B ≤ Z.mid :=
+  le_inf inf_le_left (inf_le_right.trans Z.hBle)
+
+/-- `D ≤ A' ⊓ B'`: the common denominator lies in the middle subgroup. -/
+lemma D_le_mid : Z.D ≤ Z.mid :=
+  sup_le Z.inf_A_B'_le_mid Z.inf_A'_B_le_mid
+
+/-- `A' ⊓ B ≤ A ⊔ (A' ⊓ B) = lower`. -/
+lemma inf_A'_B_le_lower : Z.A' ⊓ Z.B ≤ Z.lower := le_sup_right
+
+/-- `A ⊓ B' ≤ lower` (through `A`). -/
+lemma inf_A_B'_le_lower : Z.A ⊓ Z.B' ≤ Z.lower :=
+  inf_le_left.trans le_sup_left
+
+/-- `D ≤ lower`: everything in the denominator is already in `A (A' ∩ B)`. -/
+lemma D_le_lower : Z.D ≤ Z.lower :=
+  sup_le Z.inf_A_B'_le_lower Z.inf_A'_B_le_lower
+
+-- ============================================================
+-- PART III: The refined second isomorphism ("half-diamond")
+-- ============================================================
+
+/--
+**Half-diamond isomorphism.**  The middle quotient by `D` is isomorphic to the
+upper butterfly quotient:
+```
+    (A' ∩ B') ⧸ D  ≃*  A(A' ∩ B') ⧸ A(A' ∩ B).
+```
+
+Proof is the refined second isomorphism theorem, built exactly as the parent
+file's `second_iso`: the homomorphism `ψ = mk' ∘ inclusion : (A'⊓B') → upper/lower`
+is surjective with kernel `D.subgroupOf (A'⊓B')`, then
+`QuotientGroup.quotientKerEquivOfSurjective` closes it.
+
+Two obligations remain (isolated as `sorry`, each a concrete closed goal):
+* `hφ_surj` — surjectivity, using `A ⊴ A'` to absorb the `A`-component of any
+  element of `upper = A ⊔ (A'⊓B')` (conjugation `h⁻¹ a h ∈ A ≤ lower`), verbatim
+  analogue of the parent's `hn_sup.conj_mem'` argument.
+* `hker`   — kernel computation.  `h ∈ (A'⊓B') ∩ lower` iff `h ∈ D`: write
+  `h = a·c` with `a ∈ A`, `c ∈ A'⊓B`; then `a = h c⁻¹ ∈ A ⊓ B'` (as `h ∈ B'`,
+  `c ∈ B ≤ B'`, `h,c ∈ A'`), so `h = a·c ∈ (A⊓B') ⊔ (A'⊓B) = D`.  The reverse is
+  `D_le_lower` together with `D_le_mid`.
+-/
+theorem half_diamond_iso
+    (hlowerN : (Z.lower.subgroupOf Z.upper).Normal)
+    (hDN : (Z.D.subgroupOf Z.mid).Normal) :
+    Nonempty
+      (Z.mid ⧸ Z.D.subgroupOf Z.mid ≃* Z.upper ⧸ Z.lower.subgroupOf Z.upper) := by
+  haveI := hlowerN
+  haveI := hDN
+  -- ψ : (A' ⊓ B') → upper ⧸ lower,  via inclusion of `mid` into `upper`.
+  let ψ : Z.mid →* Z.upper ⧸ Z.lower.subgroupOf Z.upper :=
+    (mk' (Z.lower.subgroupOf Z.upper)).comp (inclusion Z.mid_le_upper)
+  -- Kernel: exactly `D`, viewed inside `mid`.
+  have hker : ψ.ker = Z.D.subgroupOf Z.mid := by
+    -- ker ψ = { h ∈ mid : h ∈ lower } = mid ⊓ lower = D  (see docstring).
+    sorry
+  -- Surjectivity: absorb the `A`-part using `A ⊴ A'`.
+  have hφ_surj : Function.Surjective ψ := by
+    sorry
+  haveI : (ψ.ker).Normal := by rw [hker]; infer_instance
+  have e := QuotientGroup.quotientKerEquivOfSurjective ψ hφ_surj
+  rw [hker] at e
+  exact ⟨e.symm⟩
+
+-- ============================================================
+-- PART IV: The Zassenhaus butterfly lemma
+-- ============================================================
+
+/-- The mirror configuration obtained by swapping the roles of `(A, A')` and
+    `(B, B')`.  Note `mirror.mid = B' ⊓ A'` and `mirror.D = (B ⊓ A') ⊔ (B' ⊓ A)`,
+    which equal `Z.mid` and `Z.D` up to `inf`/`sup` commutativity. -/
+def mirror : ZConfig G where
+  A := Z.B; A' := Z.B'; B := Z.A; B' := Z.A'
+  hAle := Z.hBle; hAn := Z.hBn; hBle := Z.hAle; hBn := Z.hAn
+
+/--
+**Zassenhaus butterfly lemma.**  For `A ⊴ A'` and `B ⊴ B'`,
+```
+    A(A' ∩ B') ⧸ A(A' ∩ B)  ≃*  B(B' ∩ A') ⧸ B(B' ∩ A).
+```
+
+Assembled from two `half_diamond_iso` applications sharing the middle quotient
+`(A'∩B') ⧸ D`.  The bridge between `Z.mid`/`Z.D` and `mirror.mid`/`mirror.D` is
+`inf_comm`/`sup_comm` (handled by `QuotientGroup.quotientMulEquivOfEq`), isolated
+below as `bridge`.
+-/
+theorem zassenhaus_butterfly
+    (hLU  : (Z.lower.subgroupOf Z.upper).Normal)
+    (hLU' : ((Z.mirror).lower.subgroupOf (Z.mirror).upper).Normal)
+    (hDN  : (Z.D.subgroupOf Z.mid).Normal)
+    (hDN' : ((Z.mirror).D.subgroupOf (Z.mirror).mid).Normal) :
+    Nonempty
+      (Z.upper ⧸ Z.lower.subgroupOf Z.upper ≃*
+        (Z.mirror).upper ⧸ (Z.mirror).lower.subgroupOf (Z.mirror).upper) := by
+  obtain ⟨eL⟩ := Z.half_diamond_iso hLU hDN
+  obtain ⟨eR⟩ := (Z.mirror).half_diamond_iso hLU' hDN'
+  -- eL : Z.mid ⧸ Z.D ≃* Z.upper ⧸ Z.lower
+  -- eR : mirror.mid ⧸ mirror.D ≃* mirror.upper ⧸ mirror.lower
+  -- Bridge the two middle quotients: mirror.mid = Z.mid, mirror.D = Z.D (comm).
+  have bridge :
+      Nonempty
+        (Z.mid ⧸ Z.D.subgroupOf Z.mid ≃*
+          (Z.mirror).mid ⧸ (Z.mirror).D.subgroupOf (Z.mirror).mid) := by
+    -- `mirror.mid = B' ⊓ A' = A' ⊓ B' = Z.mid` and `mirror.D = Z.D` by comm;
+    -- transport via `QuotientGroup.quotientMulEquivOfEq` / `MulEquiv.subgroupCongr`.
+    sorry
+  obtain ⟨eM⟩ := bridge
+  exact ⟨eL.symm.trans (eM.trans eR)⟩
+
+-- ============================================================
+-- PART V: Verification stubs
+-- ============================================================
+
+#check @half_diamond_iso
+#check @zassenhaus_butterfly
+
+end ZConfig
+
+end AbelRuffiniGaloisExtensionsOQ04OQ03

--- a/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md
@@ -1,21 +1,107 @@
 # Knowledge Base: abel-ruffini-galois-extensions-oq-04-oq-03
 
-Insights accumulated during research on this problem.
+Zassenhaus (butterfly) lemma and Schreier refinement — an independent (non-lattice)
+route to Jordan–Hölder. Neither is currently in Mathlib.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Goal: formalize the Zassenhaus butterfly lemma for subgroups
+```
+    A(A' ∩ B') ⧸ A(A' ∩ B)  ≃*  B(B' ∩ A') ⧸ B(B' ∩ A)       (A ⊴ A', B ⊴ B')
+```
+and then Schreier refinement (any two subnormal series admit equivalent
+refinements), giving a second proof of Jordan–Hölder logically independent of
+Mathlib's abstract `JordanHolderLattice` (used by the parent oq-04).
 
 ---
 
-## Insights
+## Session 2026-07-04 (Session 1) — ORIENT → ACT — build-blocked
 
-[Insights from research attempts will be accumulated here]
+**Mode**: FRESH.  **Outcome**: architecture fixed + statement + scaffolding written
+(NOT machine-checked: Docker and Aristotle both unavailable this session).
+
+### Key structural insight (the whole proof in one line)
+
+Both butterfly quotients are isomorphic to a **single common middle quotient**
+```
+    (A' ∩ B') ⧸ D ,     D := (A ∩ B')(A' ∩ B) = (A ⊓ B') ⊔ (A' ⊓ B).
+```
+So the butterfly lemma = (half-diamond on the A-side)⁻¹ ∘ (bridge) ∘ (half-diamond
+on the B-side).  No degree-of-freedom is lost; the entire content is the single
+"half-diamond" isomorphism, run twice.
+
+### The half-diamond is a *refined* second isomorphism theorem
+
+`(A' ∩ B') ⧸ D  ≃*  A(A'∩B') ⧸ A(A'∩B)` is realized by the homomorphism
+```
+    ψ : (A' ⊓ B')  →  (A ⊔ (A'⊓B')) ⧸ (A ⊔ (A'⊓B)) ,      ψ = mk' ∘ inclusion.
+```
+* **Surjective**: any element of `upper = A ⊔ (A'⊓B')` is `a·h` with `a ∈ A`,
+  `h ∈ A'⊓B'`; since `A ⊴ A'` and `h ∈ A' `, `h⁻¹ a h ∈ A ≤ lower`, so `mk'(a·h) =
+  mk'(h) = ψ(h)`.  (Verbatim analogue of the parent's `hn_sup.conj_mem'` step.)
+* **ker ψ = D**: `h ∈ (A'⊓B') ∩ lower` ⟺ `h ∈ D`.  Forward: `h = a·c` with `a∈A`,
+  `c ∈ A'⊓B`; then `a = h·c⁻¹`, and `h,c ∈ A'` ⟹ `a∈A'`, while `h∈B'`, `c∈B≤B'` ⟹
+  `a∈B'`; with `a∈A` this gives `a ∈ A⊓B'`, so `h = a·c ∈ (A⊓B')⊔(A'⊓B) = D`.
+  Reverse: `D ≤ lower` (`D_le_lower`) and `D ≤ A'⊓B'` (`D_le_mid`).
+Then `QuotientGroup.quotientKerEquivOfSurjective` closes it — exactly the mechanism
+the sibling `AbelRuffiniGaloisExtensionsOQ04.second_iso` uses (there sorry-free).
+
+### Critical discovery for tractability
+
+The parent file `AbelRuffiniGaloisExtensionsOQ04.lean` already contains a
+**fully-compiled diamond isomorphism** (`second_iso`, `(x⊔y)/x ≃* y/(x⊓y)`) built
+from `mk' ∘ inclusion` + `quotientKerEquivOfSurjective` +
+`normal_subgroupOf_of_le_normalizer`.  The Zassenhaus half-diamond is the *same
+construction* with `x := A`, `y := A'⊓B'`, and a product denominator `D` in place
+of `x⊓y`.  Only the kernel computation genuinely changes (product `D`, not a plain
+`⊓`).  So the "1–2 weeks, no template" estimate in problem.md is too pessimistic:
+there IS a template, and the remaining work is one kernel-membership lemma.
+
+### What I built (proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean)
+
+- `ZConfig` structure packaging `A ⊴ A'`, `B ⊴ B'`; abbreviations `upper`, `lower`,
+  `mid`, `D`.
+- Verified-quality scaffolding (bedrock lattice API, mirrors compiled parent):
+  `lower_le_upper`, `mid_le_upper`, `inf_A_B'_le_mid`, `inf_A'_B_le_mid`,
+  `D_le_mid`, `inf_A'_B_le_lower`, `inf_A_B'_le_lower`, `D_le_lower`.
+- `half_diamond_iso` — statement + full proof skeleton; `sorry` on exactly two
+  concrete sub-goals (`hφ_surj`, `hker`) with inline sketches above.
+- `mirror` — role-swap `ZConfig`; `zassenhaus_butterfly` — assembles two
+  half-diamonds; `sorry` only on the `inf_comm`/`sup_comm` `bridge`.
+
+### Files Modified
+- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean` (new)
+- `research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md`
+
+### Honest status
+The **main theorem is not proved** — 3 `sorry`s remain (surjectivity, kernel,
+comm-bridge). The statement and architecture are complete and the scaffolding
+lemmas are bedrock-safe, but nothing was machine-checked (build blackout). Each
+`sorry` is a fully-specified closed obligation, not an axiom.
+
+### Next Steps
+1. Discharge `hker`: replicate parent `second_iso`'s `ext`/`mem_subgroupOf`/
+   `Subgroup.mem_sup` pattern; forward direction needs the `a = h·c⁻¹ ∈ A⊓B'`
+   membership computation.
+2. Discharge `hφ_surj`: `q.inductionOn'` + `Subgroup.mem_sup.mp` + conjugation
+   `hAn.conj_mem'` to absorb the `A`-part (copy parent lines 192–202).
+3. Discharge `bridge`: `mirror.mid = B'⊓A' = A'⊓B'` and `mirror.D = (B⊓A')⊔(B'⊓A)
+   = (A⊓B')⊔(A'⊓B)` via `inf_comm`/`sup_comm`; transport quotient with
+   `QuotientGroup.quotientMulEquivOfEq` — or restate `mirror` so the two middle
+   quotients are definitionally equal.
+4. Provide the four `Normal` instances as lemmas (products of relatively-normal
+   subgroups are normal in `A'⊓B'`) so the theorems can drop those hypotheses.
+5. Then Schreier refinement: Zassenhaus is the inductive step interleaving two
+   subnormal series; the multiset-of-factors equivalence is the separate effort.
+6. Submit the whole file to Aristotle once the 404 blackout lifts — it is now
+   KNOWN math with an explicit skeleton, a strong Aristotle candidate.
 
 ---
 
-## Dead Ends
-
-[Approaches known not to work will be documented here]
+## Dead Ends / Cautions
+- `A(A'∩B')` is a subgroup **only because** `A ⊴ A'` normalizes `A'⊓B' ≤ A'`; do
+  not treat set-product `A * (A'∩B')` generically — always use the join `⊔`.
+- Building `ψ` *out of* the product `upper` is awkward; build it *into* the
+  quotient *from* the clean subgroup `mid = A'⊓B'` (as the parent does from `y`).


### PR DESCRIPTION
## Zassenhaus Butterfly Lemma — architecture + statement (research, build-blocked)

**Problem**: `abel-ruffini-galois-extensions-oq-04-oq-03` — the Zassenhaus (butterfly) lemma and Schreier refinement, a genuine Mathlib gap and the classical route to Jordan–Hölder independent of the parent oq-04's abstract `JordanHolderLattice`.

### Result
```
A(A'∩B') ⧸ A(A'∩B)  ≃*  B(B'∩A') ⧸ B(B'∩A)        (A ⊴ A', B ⊴ B')
```

### Key insight (makes it tractable)
Both butterfly quotients are isomorphic to a **single common middle quotient**
`(A'∩B') ⧸ D`, `D = (A⊓B') ⊔ (A'⊓B)`. The half-diamond
`(A'∩B')/D ≃* A(A'∩B')/A(A'∩B)` is a *refined second isomorphism theorem* built as
`mk' ∘ inclusion` + `quotientKerEquivOfSurjective` — the **same compiled construction**
already used sorry-free by the sibling `AbelRuffiniGaloisExtensionsOQ04.second_iso`.
So problem.md's "1–2 weeks, no template" estimate is too pessimistic: there is a
template, and the residual work is one kernel-membership lemma.

### What ships
- `ZConfig` structure (`A ⊴ A'`, `B ⊴ B'`) + `upper`/`lower`/`mid`/`D` abbrevs.
- 8 bedrock-safe containment/normality scaffolding lemmas.
- `half_diamond_iso` + `zassenhaus_butterfly`, with **3 fully-specified `sorry`s**
  (surjectivity via `A ⊴ A'` conjugation, `ker ψ = D`, and the `inf_comm`/`sup_comm`
  bridge). Each is a concrete closed obligation with an inline proof sketch, not an axiom.

### Honest status
⚠️ **Not machine-checked** — Docker build and Aristotle were both unavailable this
session (Aristotle returns 404; Docker containerd EIO). The main theorem is **not
proved** (3 sorries). Lemma names/idioms were taken from the compiled sibling file to
maximize compile probability, but this needs a build pass. Strong Aristotle candidate
once the 404 lifts (now KNOWN math with an explicit skeleton).

Full decomposition + next steps in `research/problems/abel-ruffini-galois-extensions-oq-04-oq-03/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
