### PR TITLE
Seeker: replenish research pool with 5 diverse problem stubs

### DIFF
--- a/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: chebyshev-pnt-bridge-oq-01-oq-04
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/literature/README.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for chebyshev-pnt-bridge-oq-01-oq-04
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/problem.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/problem.md
@@ -1,0 +1,91 @@
+# Problem: Multinomial Kummer Carry Bound and π(kn)
+
+**Slug**: chebyshev-pnt-bridge-oq-01-oq-04
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a prime $p$ and the central multinomial coefficient $\binom{kn}{n,n,\dots,n}$ ($k$ blocks of size $n$),
+
+$$
+p^{\,v_p\!\left(\binom{kn}{n,\dots,n}\right)} \le kn,
+$$
+
+and consequently a Chebyshev-type lower bound $\pi(kn) \gtrsim \dfrac{\log \binom{kn}{n,\dots,n}}{\log(kn)}$.
+
+### Plain Language
+
+The parent proof `chebyshev-pnt-bridge-oq-01` formalizes $p^{v_p(\binom{2n}{n})} \le 2n$ via Kummer's theorem (a prime power dividing the central binomial coefficient is at most $2n$), the key input to Chebyshev's elementary bounds on $\pi(x)$. This problem generalizes from binomial ($k=2$) to **multinomial** ($k \ge 2$) coefficients: Kummer's theorem counts base-$p$ carries when adding several numbers, so the same one-line valuation bound should extend, yielding a lower bound on $\pi(kn)$.
+
+### Why This Matters
+
+Elementary Chebyshev-type bounds on the prime-counting function are a cornerstone of analytic number theory before the full PNT. Extending the carry-counting core to multinomials broadens the elementary toolkit and directly exercises Mathlib's factorization API in a multi-term setting.
+
+## Known Results
+
+### What's Already Proven
+- $p^{v_p(\binom{2n}{n})} \le 2n$ — gallery `chebyshev-pnt-bridge-oq-01`.
+- Kummer's theorem / `Nat.pow_factorization_choose_le` — Mathlib (binomial form).
+- Legendre's formula for $v_p(m!)$ — Mathlib.
+
+### What's Still Open (for formalization)
+- The multinomial valuation bound $p^{v_p} \le kn$.
+- The resulting $\pi(kn)$ lower bound in elementary form.
+
+### Our Goal
+Prove the multinomial valuation bound in Lean (via Legendre's formula for $v_p(m!)$ applied to $\frac{(kn)!}{(n!)^k}$ and the carry interpretation), then derive the Chebyshev-style lower bound on $\pi(kn)$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| chebyshev-pnt-bridge-oq-01 | Direct parent; binomial case | Kummer, Legendre |
+| infinitude-primes | Prime counting context | — |
+
+## Initial Thoughts
+
+### Potential Approaches
+1. **Legendre-formula route**: write $v_p\!\big(\tfrac{(kn)!}{(n!)^k}\big) = \sum_{i\ge 1}\big(\lfloor kn/p^i\rfloor - k\lfloor n/p^i\rfloor\big)$; the bound $p^{v_p}\le kn$ follows from summing only over $p^i \le kn$.
+2. **Direct carry counting**: adapt Mathlib's binomial `pow_factorization_choose_le` proof to the multinomial factorization.
+
+### Key Difficulties
+- Mathlib's multinomial-coefficient API is thinner than the binomial one; may need `Nat.multinomial` lemmas.
+- Bounding the number of nonzero carry terms by $\log_p(kn)$.
+
+### What Would a Proof Need?
+- Lemma: $v_p\!\big(\binom{kn}{n,\dots,n}\big) \le \log_p(kn)$.
+- Bridge from valuation bound to $\pi$ lower bound.
+
+## Tractability Assessment
+
+**Difficulty**: Medium (leaning tractable)
+
+**Justification**: The parent's one-line core (`Nat.pow_factorization_choose_le`) strongly suggests a direct multinomial analogue; the main work is API plumbing for `Nat.multinomial`.
+
+## References
+
+### Texts
+- Nathanson, *Elementary Methods in Number Theory* (Chebyshev bounds).
+
+### Mathlib
+- `Nat.pow_factorization_choose_le`, `Nat.multinomial`, `Nat.Prime.factorization_factorial`, `Nat.primeCounting`.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - analytic-number-theory
+  - kummer
+  - chebyshev
+related_proofs:
+  - chebyshev-pnt-bridge-oq-01
+  - infinitude-primes
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/state.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-01-oq-04/state.md
@@ -1,0 +1,25 @@
+# Research State: chebyshev-pnt-bridge-oq-01-oq-04
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T18:35:41-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/cube-root-3-irrational-oq-02-oq-03/knowledge.md
+++ b/research/problems/cube-root-3-irrational-oq-02-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: cube-root-3-irrational-oq-02-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/cube-root-3-irrational-oq-02-oq-03/literature/README.md
+++ b/research/problems/cube-root-3-irrational-oq-02-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for cube-root-3-irrational-oq-02-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/cube-root-3-irrational-oq-02-oq-03/problem.md
+++ b/research/problems/cube-root-3-irrational-oq-02-oq-03/problem.md
@@ -1,0 +1,89 @@
+# Problem: Vahlen–Capelli Irreducibility of Xⁿ − a over ℚ
+
+**Slug**: cube-root-3-irrational-oq-02-oq-03
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a field $K$ and $a \in K^\times$, the binomial $X^n - a$ is irreducible over $K$ iff
+
+$$
+a \notin K^p \ \text{for every prime } p \mid n, \quad\text{and}\quad \bigl(4 \mid n \implies a \notin -4K^4\bigr).
+$$
+
+### Plain Language
+
+The gallery proof `cube-root-3-irrational-oq-02` shows $\sqrt[3]{3}$ is irrational by proving $X^3 - 3$ is irreducible over $\mathbb{Q}$ via Eisenstein. This problem asks for the full classical converse/criterion: exactly when is $X^n - a$ irreducible? The clean answer is the **Vahlen–Capelli theorem** (Lang, *Algebra*, VI.9.1). Half is trivial (a perfect $n$-th power gives a rational root), but the complete criterion — including the delicate $4 \mid n$ exceptional case involving $-4K^4$ — is the substantive content.
+
+### Why This Matters
+
+The criterion is the definitive statement on irreducibility of pure binomials, underpinning radical extensions, Kummer theory, and cyclotomic constructions. Mathlib has Eisenstein and some cyclotomic irreducibility but, as far as is known, no general Vahlen–Capelli binomial criterion — a genuine formalization gap.
+
+## Known Results
+
+### What's Already Proven
+- Eisenstein's criterion — `Polynomial.irreducible_of_eisenstein_criterion` (Mathlib).
+- $X^3 - 3$ irreducible over $\mathbb{Q}$ — gallery `cube-root-3-irrational-oq-02`.
+- Cyclotomic polynomial irreducibility — Mathlib `Polynomial.cyclotomic`.
+
+### What's Still Open (for formalization)
+- The general Vahlen–Capelli criterion for arbitrary $n$ and field $K$.
+- The $4 \mid n$ exceptional clause ($a \notin -4K^4$).
+
+### Our Goal
+Formalize the criterion, at minimum over $\mathbb{Q}$ and for $n$ not divisible by 4 (the clean case: $X^n - a$ irreducible iff $a$ is not a $p$-th power for any prime $p \mid n$). Then attempt the $4 \mid n$ refinement.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| cube-root-3-irrational-oq-02 | Direct parent; $n=3$ special case | Eisenstein |
+| abel-ruffini-galois-extensions | Radical extensions, splitting fields | Galois theory |
+
+## Initial Thoughts
+
+### Potential Approaches
+1. **Prime-power reduction**: reduce to $n = p^k$ via multiplicativity of the criterion, then handle prime and prime-power cases. Standard textbook route.
+2. **Field-norm / Kummer-theoretic**: use that $[K(\alpha):K] = n$ iff the relevant power conditions hold, connecting to the structure of $K^\times / (K^\times)^n$.
+
+### Key Difficulties
+- The $-4K^4$ exceptional case (e.g. $X^4 + 4 = (X^2-2X+2)(X^2+2X+2)$) must be handled explicitly.
+- Managing arbitrary base fields vs specializing to $\mathbb{Q}$.
+
+### What Would a Proof Need?
+- Lemma: if $a$ is not a $p$-th power for any $p \mid n$ (and the 4-clause holds), then $[K(\sqrt[n]{a}):K] = n$.
+- Multiplicativity/reduction to prime-power $n$.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**: Classical, fully-understood mathematics with a known clean proof; the clean ($4 \nmid n$) case is a reasonable Lean target. The 4-clause adds real but bounded difficulty.
+
+## References
+
+### Papers / Texts
+- S. Lang, *Algebra*, Theorem VI.9.1 (Vahlen–Capelli).// Karpilovsky, *Topics in Field Theory*.
+
+### Mathlib
+- `Polynomial.irreducible_of_eisenstein_criterion`, `Polynomial.cyclotomic`, `Algebra.adjoin`, `IsSplittingField`.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - field-theory
+  - polynomial-irreducibility
+  - vahlen-capelli
+related_proofs:
+  - cube-root-3-irrational-oq-02
+  - abel-ruffini-galois-extensions
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/cube-root-3-irrational-oq-02-oq-03/state.md
+++ b/research/problems/cube-root-3-irrational-oq-02-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: cube-root-3-irrational-oq-02-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T18:35:41-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/derangements-convergence-oq-04-oq-03/knowledge.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: derangements-convergence-oq-04-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/derangements-convergence-oq-04-oq-03/literature/README.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for derangements-convergence-oq-04-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/derangements-convergence-oq-04-oq-03/problem.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/problem.md
@@ -1,0 +1,90 @@
+# Problem: Divisibility & Congruence for Generalized r-Derangement Numbers
+
+**Slug**: derangements-convergence-oq-04-oq-03
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $D_r(n)$ denote the number of $r$-derangements (permutations of $[n]$ avoiding a fixed cycle structure / with a prescribed forbidden-fixed-set of size $r$). Determine and prove the analogue of the classical identities
+
+$$
+(n-1) \mid D(n), \qquad D(n) \equiv (-1)^n \pmod{n-1},
+$$
+
+for $D_r(n)$: i.e. which divisibility relation $f(n,r) \mid D_r(n)$ and which congruence $D_r(n) \equiv g(n,r)$ hold.
+
+### Plain Language
+
+The parent proof `derangements-convergence-oq-04` establishes $(n-1) \mid D(n)$ for ordinary derangement numbers $D(n) = n!\sum_{k=0}^n \frac{(-1)^k}{k!}$. This problem asks whether an analogous divisibility or sign-congruence survives for the **generalized ($r$-)derangement numbers**, which count permutations avoiding a fixed cycle structure. The recurrence $D(n) = (n-1)(D(n-1) + D(n-2))$ is the engine behind the classical result; the task is to find and formalize the corresponding recurrence-driven identity for $D_r(n)$.
+
+### Why This Matters
+
+Derangement congruences are a clean testbed for formalizing integer recurrences and modular arithmetic in Lean. Generalizing to $r$-derangements connects to rencontres numbers and the combinatorics of restricted permutations — an area where Mathlib has `Nat.derangements` but little on the generalized family.
+
+## Known Results
+
+### What's Already Proven
+- $(n-1) \mid D(n)$ and the recurrence $D(n)=(n-1)(D(n-1)+D(n-2))$ — gallery `derangements-convergence-oq-04`.
+- `Nat.derangements` cardinality and basic recurrences — Mathlib.
+
+### What's Still Open (for formalization)
+- Identifying the correct $r$-derangement recurrence.
+- The divisibility/congruence analogue for $D_r(n)$.
+
+### Our Goal
+Fix a precise definition of $D_r(n)$ (e.g. permutations with exactly the first $r$ points forbidden as fixed points, or the two-variable rencontres numbers), derive its recurrence, and prove the resulting divisibility/congruence.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| derangements-convergence-oq-04 | Direct parent; $r=$ all case | Recurrence, induction |
+| derangements-convergence | Base derangement asymptotics | Inclusion-exclusion |
+
+## Initial Thoughts
+
+### Potential Approaches
+1. **Recurrence + induction**: establish $D_r(n) = (n-1)(D_r(n-1)+D_r(n-2)) + (\text{correction})$ and push the divisibility through by induction, mirroring the parent.
+2. **Inclusion–exclusion closed form**: derive $D_r(n)$ as a signed sum and read off the congruence via a telescoping/valuation argument.
+
+### Key Difficulties
+- Choosing the "right" generalization ($r$-derangements are defined several inequivalent ways in the literature); pick the one with the cleanest identity.
+- The correction term may break simple $(n-1)$-divisibility, requiring a modified modulus.
+
+### What Would a Proof Need?
+- A clean recurrence for $D_r(n)$.
+- An inductive divisibility/congruence lemma.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**: Self-contained combinatorial number theory reducible to integer recurrences; the main risk is definitional (selecting the generalization that admits a clean theorem).
+
+## References
+
+### Texts
+- Stanley, *Enumerative Combinatorics* I (rencontres numbers).
+
+### Mathlib
+- `Nat.derangements`, `Finset.sum`, `Int.ModEq`, induction on recurrences.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - derangements
+  - divisibility
+  - congruence
+related_proofs:
+  - derangements-convergence-oq-04
+  - derangements-convergence
+difficulty: medium
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/derangements-convergence-oq-04-oq-03/state.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: derangements-convergence-oq-04-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T18:35:42-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: desargues-theorem-oq-02-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/desargues-theorem-oq-02-oq-03/literature/README.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for desargues-theorem-oq-02-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/desargues-theorem-oq-02-oq-03/problem.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/problem.md
@@ -1,0 +1,88 @@
+# Problem: Desargues' Theorem over Free Rank-3 Modules on Non-Commutative Rings
+
+**Slug**: desargues-theorem-oq-02-oq-03
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $R$ be a (possibly non-commutative) ring and $M = R^3$ a free left $R$-module of rank 3, with the associated projective plane $\mathbb{P}(M)$ of rank-1/rank-2 submodules. Determine the precise conditions on $R$ under which the **Desargues configuration** holds: if two triangles are perspective from a point, they are perspective from a line.
+
+$$
+\text{Desargues holds in } \mathbb{P}(R^3) \iff R \text{ is a division ring (skew field).}
+$$
+
+### Plain Language
+
+The parent proof `desargues-theorem-oq-02` exhibits the **Moulton plane**, a non-Desarguesian projective plane, as a counterexample showing Desargues' theorem fails without a coordinatizing division ring. This problem investigates the positive/coordinatized direction: over a free rank-3 module on a non-commutative ring, when does Desargues hold? The classical answer (the **coordinatization theorem** of projective geometry) is that Desargues holds exactly when the plane is coordinatized by a division ring — commutativity of $R$ is *not* required (that governs Pappus, not Desargues).
+
+### Why This Matters
+
+The Desargues ⇔ division-ring equivalence is the foundational bridge between synthetic projective geometry and linear algebra, and separates cleanly from the Pappus ⇔ field (commutative) result. Formalizing it clarifies the exact algebraic hypotheses and complements the gallery's Moulton-plane counterexample with the structural theorem.
+
+## Known Results
+
+### What's Already Proven
+- Moulton plane is non-Desarguesian — gallery `desargues-theorem-oq-02`.
+- Desargues in $\mathbb{P}^2$ over a field — classical; partial Mathlib projective-geometry API.
+
+### What's Still Open (for formalization)
+- Desargues for $\mathbb{P}(R^3)$ with $R$ a non-commutative division ring.
+- The converse: failure of Desargues ⇒ non-division-ring coordinatization.
+
+### Our Goal
+Formalize the forward direction: over a division ring $R$ (allowing non-commutative), Desargues' theorem holds in $\mathbb{P}(R^3)$. Clarify precisely where the division-ring hypothesis (existence of inverses) enters and why commutativity is unnecessary.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| desargues-theorem-oq-02 | Direct parent; counterexample side | Moulton plane |
+| desargues-theorem-oq-01 | Sibling generalization | Incidence geometry |
+
+## Initial Thoughts
+
+### Potential Approaches
+1. **Linear-algebra coordinates**: represent points as rank-1 submodules of $R^3$; carry out the standard determinant-free perspectivity computation, being careful to keep scalars on a consistent side (left vs right multiplication) since $R$ is non-commutative.
+2. **Synthetic + coordinatization**: invoke the abstract coordinatization theorem, if a usable projective-plane axiomatization is available.
+
+### Key Difficulties
+- Non-commutativity forces care with left/right scalar actions; the classical determinant proof must be replaced with an inverse-based argument.
+- Mathlib's projective-space API (`Projectivization`) is built for division rings but the Desargues statement itself may need to be set up from scratch.
+
+### What Would a Proof Need?
+- A workable incidence/projective-plane model over $R^3$.
+- The perspectivity computation using only $R$-inverses (no commutativity).
+
+## Tractability Assessment
+
+**Difficulty**: Medium–High
+
+**Justification**: Mathematically classical and well-understood, but the Lean projective-geometry infrastructure for Desargues specifically appears thin; setup cost is the main risk rather than the mathematics.
+
+## References
+
+### Texts
+- Hartshorne, *Foundations of Projective Geometry*.// Artin, *Geometric Algebra* (Desargues ⇔ division ring).
+
+### Mathlib
+- `Projectivization`, `Module`, `DivisionRing`, incidence structures.
+
+## Metadata
+
+```yaml
+tags:
+  - projective-geometry
+  - incidence-geometry
+  - non-commutative-algebra
+  - desargues
+related_proofs:
+  - desargues-theorem-oq-02
+  - desargues-theorem-oq-01
+difficulty: high
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/desargues-theorem-oq-02-oq-03/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: desargues-theorem-oq-02-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T18:35:43-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/erdos-1092-oq-02/knowledge.md
+++ b/research/problems/erdos-1092-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1092-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1092-oq-02/literature/README.md
+++ b/research/problems/erdos-1092-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1092-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1092-oq-02/problem.md
+++ b/research/problems/erdos-1092-oq-02/problem.md
@@ -1,0 +1,89 @@
+# Problem: Rödl's Chromatic-Decomposition Construction for r ≥ 3
+
+**Slug**: erdos-1092-oq-02
+**Created**: 2026-07-04
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Erdős problem #1092 concerns the chromatic decomposition threshold. Rödl's construction resolves the $r = 2$ (bipartite / $\chi = 2$) target. Question: does the construction generalize to $r \ge 3$?
+
+$$
+\text{Does Rödl's construction extend from } \chi\text{-target } 2 \text{ to } r \ge 3,
+\text{ or does the threshold behavior change for higher chromatic targets?}
+$$
+
+### Plain Language
+
+The parent `erdos-1092` studies when a graph's edge set can be decomposed with a prescribed chromatic-threshold behavior; Rödl's construction gives the extremal example for the base ($r=2$) case. This problem asks whether the same construction — and the same threshold — persists when the target chromatic number is raised to $r \ge 3$, or whether a genuinely different phenomenon (a shifted or qualitatively different threshold) emerges.
+
+### Why This Matters
+
+Erdős-type extremal/decomposition thresholds are central to modern combinatorics. Determining whether a known extremal construction is "stable" under raising the chromatic target sharpens understanding of the whole family and is a natural formalization target given the gallery's existing $r=2$ treatment.
+
+## Known Results
+
+### What's Already Proven
+- The $r = 2$ case via Rödl's construction — gallery `erdos-1092`.
+- Standard chromatic-number and Turán-type API — Mathlib `SimpleGraph`.
+
+### What's Still Open (for formalization)
+- Whether Rödl's construction generalizes to $r \ge 3$.
+- The correct threshold statement for higher chromatic targets.
+
+### Our Goal
+First **survey/decide** (ORIENT phase) whether the mathematical answer is known in the literature. If the generalization holds, formalize the construction and threshold for a fixed small $r$ (e.g. $r = 3$). If it provably fails, formalize the obstruction.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| erdos-1092 | Direct parent; $r=2$ case | Rödl construction |
+| erdos-458-oq-05 | Chromatic/extremal neighborhood | Probabilistic method |
+
+## Initial Thoughts
+
+### Potential Approaches
+1. **Lift the construction**: attempt a direct block/product generalization of Rödl's construction with $r$ color classes and check the threshold arithmetic.
+2. **Counterexample search**: look for small $r=3$ instances where the $r=2$ threshold fails, indicating changed behavior.
+
+### Key Difficulties
+- This is a genuinely research-level extremal question; the literature answer may be unknown, making it exploratory.
+- Formalizing extremal graph constructions in Lean is heavy on `Finset`/`SimpleGraph` bookkeeping.
+
+### What Would a Proof Need?
+- A clean generalized construction OR a clean obstruction.
+- Threshold arithmetic verified for the chosen $r$.
+
+## Tractability Assessment
+
+**Difficulty**: High
+
+**Justification**: Open Erdős-family extremal question; strong ORIENT/survey phase needed before committing. Best suited to a Scout survey followed by a bounded formalization of whichever direction (generalization vs obstruction) the literature supports.
+
+## References
+
+### Papers
+- Erdős Problems database, #1092.// V. Rödl, constructions in chromatic/extremal graph theory.
+
+### Mathlib
+- `SimpleGraph`, `SimpleGraph.chromaticNumber`, `SimpleGraph.CliqueFree`, Turán-type lemmas.
+
+## Metadata
+
+```yaml
+tags:
+  - erdos
+  - graph-theory
+  - chromatic-number
+  - extremal-graph-theory
+related_proofs:
+  - erdos-1092
+  - erdos-458-oq-05
+difficulty: high
+source: gallery-gap
+created: 2026-07-04
+```

--- a/research/problems/erdos-1092-oq-02/state.md
+++ b/research/problems/erdos-1092-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1092-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-07-04T18:35:43-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary
Seeker replenishment cycle. The available candidate pool dropped to 14 (below the operational threshold of 15). This PR adds 5 diverse, concrete, formalizable research-problem workspaces, restoring the pool to 19 available.

## Problems added (all tier B, distinct domains)
| Slug | Domain | Sig/Tract |
|------|--------|-----------|
| cube-root-3-irrational-oq-02-oq-03 | Field theory (Vahlen–Capelli binomial irreducibility) | 6/5 |
| chebyshev-pnt-bridge-oq-01-oq-04 | Analytic number theory (multinomial Kummer bound) | 5/6 |
| derangements-convergence-oq-04-oq-03 | Combinatorics (r-derangement congruences) | 5/5 |
| desargues-theorem-oq-02-oq-03 | Projective geometry / non-commutative algebra | 5/4 |
| erdos-1092-oq-02 | Extremal graph theory (Erdős #1092) | 6/4 |

Each has a filled problem.md (validated free of template placeholders via validate-seeker-stubs.ts). Database and operational .lean/state pool already updated out-of-band (gitignored).

Note: this is a math-agent PR — do NOT add loom:review-requested; the deployer merges directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)