### PR TITLE
Enrich cyclotomic-polynomials-oq-01: degree-as-bridge + ring-genericity insights

### DIFF
--- a/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
+++ b/src/data/proofs/cyclotomic-polynomials-oq-01/meta.json
@@ -115,7 +115,9 @@
     "keyInsights": [
       "The degree of a cyclotomic polynomial is Euler's totient: $\\deg \\Phi_n = \\varphi(n)$. This single fact links the polynomial's shape to elementary number theory.",
       "Prime cyclotomics are the simplest: $\\Phi_p = 1 + X + \\dots + X^{p-1}$ is a geometric sum, so $\\deg \\Phi_p = p-1$ and $\\Phi_p(1) = p$.",
-      "The divisor factorization $\\prod_{d\\mid n}\\Phi_d = X^n - 1$ carries all the arithmetic: taking degrees turns it into Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$, since the product degree is the sum of factor degrees (each $\\Phi_d \\neq 0$ over the domain $\\mathbb{Z}$) and $X^n-1$ has degree $n$."
+      "The divisor factorization $\\prod_{d\\mid n}\\Phi_d = X^n - 1$ carries all the arithmetic: taking degrees turns it into Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$, since the product degree is the sum of factor degrees (each $\\Phi_d \\neq 0$ over the domain $\\mathbb{Z}$) and $X^n-1$ has degree $n$.",
+      "Degree is the bridge that transports algebra to arithmetic. Gauss's identity is never proved combinatorially here — it is *read off* the polynomial identity by applying $\\deg$ to both sides, which converts the product into a sum and $X^n-1$ into $n$. Evaluation gives nothing comparable: $(X^n-1)$ at $1$ is $0$, so the degree map — not a ring homomorphism — is exactly the invariant that keeps both sides informative.",
+      "The degree formula is ring-agnostic, but the Gauss derivation asks for a domain. $\\deg\\Phi_n=\\varphi(n)$ holds over *any* nontrivial ring because $\\Phi_n$ is monic with fixed integer coefficients. The identity $\\sum_{d\\mid n}\\varphi(d)=n$, however, is derived specifically over $\\mathbb{Z}$: the step $\\deg\\prod_d\\Phi_d = \\sum_d\\deg\\Phi_d$ uses the integral-domain form of `natDegree_prod` (each factor nonzero, no degree-cancelling zero divisors)."
     ]
   },
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `cyclotomic-polynomials-oq-01` (had 3 keyInsights, below the 4–5 minimum).

Two accurate, bounded additions (3→5 keyInsights):
- **Degree as the bridge:** Gauss's ∑_{d|n} φ(d) = n is not proved combinatorially — it is read off the polynomial identity ∏Φ_d = Xⁿ−1 by applying `deg` to both sides. Evaluation degenerates (Xⁿ−1 at 1 is 0), so the degree map is exactly the invariant that keeps both sides informative.
- **Ring genericity:** deg Φ_n = φ(n) holds over any nontrivial ring (Φ_n is monic with fixed integer coefficients), while the Gauss derivation is taken over ℤ specifically — the step deg∏ = ∑deg uses the integral-domain form of `natDegree_prod`.

meta.json: 14.9 → 15.8 KB (well under the ~60 KB cap). No other fields touched.
