### PR TITLE
fix(gallery): correct erdos-1-wip-01 source path casing (WIP→Wip)

### DIFF
--- a/src/data/proofs/erdos-1-wip-01/meta.json
+++ b/src/data/proofs/erdos-1-wip-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "date": "2026-04-26",
     "status": "verified",
-    "proofRepoPath": "Proofs/Erdos1WIP01.lean",
+    "proofRepoPath": "Proofs/Erdos1Wip01.lean",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -199,7 +199,7 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "path": "Proofs/Erdos1WIP01.lean",
+    "path": "Proofs/Erdos1Wip01.lean",
     "lineCount": 319,
     "theoremCount": 13,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

`erdos-1-wip-01/meta.json` pointed at `Proofs/Erdos1WIP01.lean`, but the tracked Lean source is `Proofs/Erdos1Wip01.lean` (lowercase `Wip`, matching the sibling files `Erdos1Wip01OQ02.lean` / `Erdos1Wip01OQ03.lean`).

Both `meta.proofRepoPath` and the top-level `leanFile.path` carried the wrong casing. On case-sensitive filesystems (Linux CI/deploy) these pointers resolve to a nonexistent path, breaking source/annotation display for this verified entry. macOS's case-insensitive FS masked the typo locally.

## Evidence

**Before**: `"proofRepoPath": "Proofs/Erdos1WIP01.lean"` and `"leanFile": { "path": "Proofs/Erdos1WIP01.lean", ... }`
**After**: both reference `Proofs/Erdos1Wip01.lean` — the actual tracked file (319 lines, 13 theorems, 0 sorries, 0 axioms), confirming the `verified` status is legitimate; only the pointer casing was wrong.

Minimal 2-line diff; no content or status change.

---
Automated fix by lean-mechanic agent.