### PR TITLE
Enrich Alternating Series Test: certified-interval insight + Knopp reference

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01/meta.json
@@ -63,7 +63,8 @@
       "The limit of an alternating series with antitone terms is always trapped between two consecutive partial sums; the whole estimate follows from the gap between them being exactly the next term",
       "Parity is the only case split needed: it fixes the sign (-1)^N and hence which side of l the partial sum falls on",
       "Mathlib already proves both one-sided bracket inequalities; the contribution is assembling them into the symmetric |S_N − l| ≤ f N that is what one actually uses",
-      "The alternating harmonic series is the canonical instance: error ≤ 1/(N+1) makes the slow convergence to log 2 quantitative"
+      "The alternating harmonic series is the canonical instance: error ≤ 1/(N+1) makes the slow convergence to log 2 quantitative",
+      "The two-sided bound does more than estimate — it certifies: consecutive partial sums S_N and S_{N+1} bracket the true limit l in an interval of known width f N, so an alternating series delivers both an approximation and a rigorous error bar for free, a guarantee most convergent series cannot offer without separate tail analysis"
     ],
     "prerequisites": [
       "Convergence of sequences and series in ℝ",
@@ -144,6 +145,12 @@
       "title": "Principles of Mathematical Analysis",
       "year": "1976",
       "note": "Alternating series test and the truncation error bound (Theorem 3.43)"
+    },
+    {
+      "authors": "Knopp, K.",
+      "title": "Theory and Application of Infinite Series",
+      "year": "1951",
+      "note": "The classical reference for alternating (Leibniz) series and the remainder estimate |S_N − l| ≤ a_N, with the sharpened trapping between consecutive terms"
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01` (passes: 0, quality: 94).

This entry was already at target on every dimension (5 fully-populated annotations, substantial historicalContext, 4 keyInsights, 3 openQuestions, sections covering the full 88-line file, 6 crossReferences). Per the size-guardrail / diminishing-returns rule I did **not** inflate it — I added two genuinely distinct, high-signal items and stopped:

- **New keyInsight (→ 5)** on the *certified-interval* character of the bound: consecutive partial sums S_N and S_{N+1} bracket the true limit in an interval of known width f N, so an alternating series delivers both an approximation **and** a rigorous error bar for free — a guarantee most convergent series lack without separate tail analysis. This is distinct from the four existing insights (trapping, parity split, symmetric-bound assembly, harmonic instance).
- **New reference** — Knopp, *Theory and Application of Infinite Series* (1951), the classical citation for the Leibniz remainder estimate |S_N − l| ≤ a_N.

meta.json: 14.5 KB → 15.1 KB (well under the 60 KB cap). No status/badge/axiom changes — entry remains `verified` / `mathlib` / 0 axioms, accurately reflecting the Lean source.
