### PR TITLE
Research: derangements-convergence-oq-04-oq-03 — sharp CRT-fused congruence D(n)≡(−1)^{n+1}(n−1) mod n(n−1)

### DIFF
--- a/research/problems/derangements-convergence-oq-04-oq-03/knowledge.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/knowledge.md
@@ -1,21 +1,92 @@
 # Knowledge Base: derangements-convergence-oq-04-oq-03
 
-Insights accumulated during research on this problem.
+Divisibility & congruence for (generalized r-)derangement numbers.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Parent `derangements-convergence-oq-04` proved two SEPARATE facts about
+`D(n) = numDerangements n`:
+
+- `(n − 1) ∣ D(n)`  (from the additive recurrence `D(n) = (n−1)(D(n−2)+D(n−1))`)
+- `D(n) ≡ (−1)^n (mod n)`  (from the multiplicative recurrence `D(n+1) = (n+1)D(n) − (−1)^n`)
+
+**Note — the child problem statement is internally inconsistent.** It writes both
+`(n−1) ∣ D(n)` and `D(n) ≡ (−1)^n (mod n−1)`. But `(n−1) ∣ D(n)` means
+`D(n) ≡ 0 (mod n−1)`, so the second would force `(−1)^n ≡ 0 (mod n−1)`, false for
+`n > 2`. The correct companion modulus is `n`, not `n−1`.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Session 2026-07-04 (Session 2, researcher-14) — FRESH → ACT
+
+**Outcome:** progress (new theorem derived + Lean-drafted, UNVERIFIED under build blackout).
+
+**Main mathematical content.** Because `gcd(n, n−1) = 1`, the two parent facts are
+not independent — the Chinese Remainder Theorem fuses them into a single **sharp**
+congruence modulo `n(n−1)`:
+
+> **D(n) ≡ (−1)^(n+1)·(n − 1)  (mod n(n−1)).**
+
+This determines `D(n)` modulo `n(n−1)` exactly and is strictly stronger than either
+parent fact. Numerically verified for `2 ≤ n ≤ 9`:
+
+| n | D(n) | D(n) mod n(n−1) | (−1)^(n+1)(n−1) mod n(n−1) |
+|---|------|-----------------|-----------------------------|
+| 4 | 9    | 9               | 9                           |
+| 5 | 44   | 4               | 4                           |
+| 6 | 265  | 25              | 25                          |
+| 7 | 1854 | 6               | 6                           |
+| 8 | 14833| 49              | 49                          |
+| 9 |133496| 8               | 8                           |
+
+**Structural theorem (`crt_combine`).** The fusion is *combinatorics-free*. It is a
+property of the recurrence **shape**, not of derangements:
+
+> If `(n−1) ∣ a` and `n ∣ (a − u)`, then `n(n−1) ∣ (a + u·(n−1))`.
+
+Proof needs no coprimality hypothesis: write `a = (n−1)k`; then `n ∣ (a − u)`
+forces `n ∣ (k + u)` (since `(n−1)k ≡ −k mod n`), and multiplying back by `(n−1)`
+gives the claim. Holds for every `n`, including degenerate `n = 0, 1`.
+
+**Consequence for the r-derangement ask.** Any r-derangement family `D_r(n)` whose
+counting sequence inherits BOTH a `(n−1)`-factor (or `(n+r−1)`-factor) additive
+recurrence AND a `±1`-corrected multiplicative recurrence automatically satisfies
+the same fused congruence — one only needs the two divisibilities, then `crt_combine`
+does the rest. The combinatorial definition is irrelevant to the arithmetic
+conclusion.
+
+**Lean (UNVERIFIED draft):** `lean/DerangementsConvergenceOQ04OQ03.lean`
+- `crt_combine` — the CRT engine (full proof)
+- `sub_one_dvd` — `(n:ℤ−1) ∣ D(n)` over ℤ for all n (self-contained)
+- `dvd_numDerangements_sub_sign` — `n ∣ (D(n) − (−1)^n)`
+- `numDerangements_combined_dvd` / `numDerangements_combined_congr` — the sharp result
+- value sanity checks `D(4)=9, D(5)=44, D(6)=265`
+
+**Why UNVERIFIED:** Docker Lean build image blob corrupted (containerd meta.db EIO),
+Aristotle MCP returns 404. File placed under `research/.../lean/` (not globbed by the
+lakefile) so it cannot break the gallery build. Promote to `proofs/Proofs/` after a
+clean build.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Literal combinatorial r-derangements: Mathlib has no definition of permutations
+  avoiding a prescribed cycle structure / no cycles of length ≤ r, nor their
+  recurrence. Building it (EGF/species) is >500 lines and was not attempted under
+  the build blackout. `crt_combine` deliberately routes around this.
+
+---
+
+## Next Steps
+
+1. Machine-check `DerangementsConvergenceOQ04OQ03.lean` once Docker is restored; if
+   clean, promote into `proofs/Proofs/` and add a verified gallery entry.
+2. Define r-derangements by their recurrence, prove the `(n+r−1)`-factor + sign
+   facts, then instantiate `crt_combine` for the literal r-derangement congruence.
+3. Determine whether `n(n−1)` is the exact modulus (period) of `D(n)` or whether
+   more structure holds mod `n(n−1)(n−2)`.

--- a/research/problems/derangements-convergence-oq-04-oq-03/lean/DerangementsConvergenceOQ04OQ03.lean
+++ b/research/problems/derangements-convergence-oq-04-oq-03/lean/DerangementsConvergenceOQ04OQ03.lean
@@ -1,0 +1,164 @@
+/-
+  Sharp combined congruence for derangement numbers, and the structural
+  "CRT engine" behind divisibility results for r-derangement families.
+
+  Problem: derangements-convergence-oq-04-oq-03
+  Parent : derangements-convergence-oq-04
+
+  ## Status: UNVERIFIED DRAFT
+
+  The Docker Lean build harness is unavailable this session (corrupted
+  containerd image blob → the build image cannot be inspected or rebuilt),
+  and the Aristotle MCP endpoint returns 404. This file therefore has NOT
+  been machine-checked. It lives under `research/problems/.../lean/`, which
+  is NOT globbed by `proofs/lakefile.toml`, so it cannot break the gallery
+  build. Promote it into `proofs/Proofs/` only after a clean Docker build.
+
+  ## What the parent proved (derangements-convergence-oq-04)
+
+  For D(n) = numDerangements n, the parent established TWO separate facts:
+    * (n − 1) ∣ D(n)                    [from the additive recurrence
+                                         D(n) = (n−1)·(D(n−2)+D(n−1))]
+    * n ∣ (D(n) − (−1)^n), i.e.
+      D(n) ≡ (−1)^n (mod n)             [from the multiplicative recurrence
+                                         D(n+1) = (n+1)·D(n) − (−1)^n]
+
+  ## What this file adds (the child problem)
+
+  The child asks whether "an analogous divisibility or sign-congruence
+  survives" for generalised r-derangement families. The honest answer,
+  developed here, has two parts.
+
+  1. **A structural theorem (`crt_combine`).** The two parent facts are not
+     independent: because gcd(n, n−1) = 1, the Chinese Remainder Theorem
+     fuses them into a single sharp congruence *modulo n(n−1)*. We isolate
+     the mechanism as an abstract lemma about ANY integer `a`:
+
+        if (n−1) ∣ a  and  n ∣ (a − u),  then  n(n−1) ∣ (a + u·(n−1)).
+
+     This is exactly the "recurrence-driven identity" the problem asks for,
+     stripped of the combinatorial object: any counting sequence `a = D_r(n)`
+     that inherits BOTH a `(n−1)`-factor additive recurrence AND a
+     `±1`-corrected multiplicative recurrence automatically satisfies the
+     fused congruence. So the phenomenon is not special to ordinary
+     derangements — it is a property of the recurrence *shape*.
+
+  2. **The sharp combined congruence for D(n) (`numDerangements_combined_*`).**
+     Instantiating the engine at `a = D(n)`, `u = (−1)^n` yields
+
+        D(n) ≡ (−1)^(n+1)·(n − 1)   (mod n(n−1)).
+
+     This is strictly stronger than either parent fact and pins D(n) down
+     modulo n(n−1) exactly (verified numerically for 2 ≤ n ≤ 9:
+       n=4: D=9 ≡ 9,  n=5: D=44 ≡ 4,  n=6: D=265 ≡ 25,  n=7: D=1854 ≡ 6,
+       n=8: D=14833 ≡ 49,  n=9: D=133496 ≡ 8, all mod n(n−1)).
+
+  ## On the literal "r-derangement numbers"
+
+  Mathlib has no native definition of r-derangements (permutations avoiding
+  a prescribed cycle structure), so a fully combinatorial treatment would
+  require building that object and its recurrence from scratch (an EGF /
+  species argument, > 500 lines, not attempted under the build blackout).
+  The value of `crt_combine` is precisely that it makes the combinatorial
+  definition irrelevant to the *arithmetic* conclusion: the moment one has
+  the two recurrences for a family D_r, the fused congruence follows for free.
+
+  All results below are elementary (integer arithmetic + the two standard
+  Mathlib recurrences `numDerangements_add_two` and `numDerangements_succ`).
+-/
+
+import Mathlib
+
+open Nat
+
+namespace DerangementsConvergenceOQ04OQ03
+
+/-! ### The structural CRT engine -/
+
+/-- **Structural theorem.** Because `n` and `n − 1` are coprime, the two
+    divisibility facts `(n−1) ∣ a` and `n ∣ (a − u)` fuse, via the Chinese
+    Remainder Theorem, into a single congruence modulo `n(n−1)`:
+
+      `n(n−1) ∣ (a + u·(n−1))`,  i.e.  `a ≡ −u·(n−1)  (mod n(n−1))`.
+
+    The proof is a direct elimination and needs no coprimality hypothesis:
+    write `a = (n−1)·k`; the second hypothesis forces `n ∣ (k + u)`, and
+    multiplying back by `(n−1)` gives the claim. It holds for every `n`
+    (including the degenerate `n = 0, 1`). -/
+theorem crt_combine (n : ℕ) (a u : ℤ)
+    (h1 : ((n : ℤ) - 1) ∣ a) (h2 : (n : ℤ) ∣ (a - u)) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣ (a + u * ((n : ℤ) - 1)) := by
+  obtain ⟨k, hk⟩ := h1
+  -- From `n ∣ (a − u)` and `a = (n−1)·k ≡ −k (mod n)` we get `n ∣ (k + u)`.
+  have hn : (n : ℤ) ∣ (k + u) := by
+    have e : (k + u) = (n : ℤ) * k - (a - u) := by rw [hk]; ring
+    rw [e]
+    exact dvd_sub' (dvd_mul_right (n : ℤ) k) h2
+  obtain ⟨t, ht⟩ := hn
+  refine ⟨t, ?_⟩
+  have e2 : a + u * ((n : ℤ) - 1) = ((n : ℤ) - 1) * (k + u) := by rw [hk]; ring
+  rw [e2, ht]; ring
+
+/-! ### The two parent recurrence facts, self-contained -/
+
+/-- `(n − 1) ∣ D(n)` over `ℤ`, read off the additive recurrence
+    `D(m+2) = (m+1)·(D(m) + D(m+1))`. Stated over `ℤ` so it feeds
+    `crt_combine` directly and covers the degenerate cases `n = 0, 1`. -/
+theorem sub_one_dvd (n : ℕ) : ((n : ℤ) - 1) ∣ (numDerangements n : ℤ) := by
+  match n with
+  | 0 =>
+      rw [show numDerangements 0 = 1 from by decide]
+      exact ⟨-1, by norm_num⟩
+  | 1 =>
+      rw [show numDerangements 1 = 0 from by decide]
+      simp
+  | (m + 2) =>
+      have h : ((numDerangements (m + 2) : ℤ))
+          = ((m : ℤ) + 1) * ((numDerangements m : ℤ) + (numDerangements (m + 1) : ℤ)) := by
+        exact_mod_cast numDerangements_add_two m
+      refine ⟨(numDerangements m : ℤ) + (numDerangements (m + 1) : ℤ), ?_⟩
+      rw [h]; push_cast; ring
+
+/-- `n ∣ (D(n) − (−1)^n)`, i.e. `D(n) ≡ (−1)^n (mod n)`, read off the
+    multiplicative recurrence `D(n+1) = (n+1)·D(n) − (−1)^n`. -/
+theorem dvd_numDerangements_sub_sign (n : ℕ) :
+    (n : ℤ) ∣ ((numDerangements n : ℤ) - (-1) ^ n) := by
+  cases n with
+  | zero => simp
+  | succ k =>
+    refine ⟨numDerangements k, ?_⟩
+    rw [numDerangements_succ k, pow_succ]
+    push_cast
+    ring
+
+/-! ### The sharp combined congruence for D(n) -/
+
+/-- **Main result (divisibility form).** For every `n`,
+      `n(n−1) ∣ (D(n) + (−1)^n·(n−1))`.
+    Obtained by feeding the two recurrence facts into `crt_combine`. -/
+theorem numDerangements_combined_dvd (n : ℕ) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣ ((numDerangements n : ℤ) + (-1) ^ n * ((n : ℤ) - 1)) :=
+  crt_combine n (numDerangements n : ℤ) ((-1) ^ n) (sub_one_dvd n)
+    (dvd_numDerangements_sub_sign n)
+
+/-- **Main result (congruence form).** For every `n`,
+      `D(n) ≡ (−1)^(n+1)·(n − 1)   (mod n(n−1))`.
+    Equivalent restatement of `numDerangements_combined_dvd`, since
+    `(−1)^(n+1)·(n−1) = −(−1)^n·(n−1)`. This is strictly stronger than
+    each of the parent facts `(n−1) ∣ D(n)` and `D(n) ≡ (−1)^n (mod n)`,
+    and determines `D(n)` modulo `n(n−1)` exactly. -/
+theorem numDerangements_combined_congr (n : ℕ) :
+    ((n : ℤ) * ((n : ℤ) - 1)) ∣ ((numDerangements n : ℤ) - (-1) ^ (n + 1) * ((n : ℤ) - 1)) := by
+  have h := numDerangements_combined_dvd n
+  have e : (numDerangements n : ℤ) - (-1) ^ (n + 1) * ((n : ℤ) - 1)
+      = (numDerangements n : ℤ) + (-1) ^ n * ((n : ℤ) - 1) := by
+    rw [pow_succ]; ring
+  rw [e]; exact h
+
+/-! ### Sanity checks (values match the classical derangement sequence) -/
+
+example : numDerangements 4 = 9 := by decide
+example : numDerangements 5 = 44 := by decide
+example : numDerangements 6 = 265 := by decide
+
+end DerangementsConvergenceOQ04OQ03

--- a/research/problems/derangements-convergence-oq-04-oq-03/state.md
+++ b/research/problems/derangements-convergence-oq-04-oq-03/state.md
@@ -1,25 +1,20 @@
-# Research State: derangements-convergence-oq-04-oq-03
+# State: derangements-convergence-oq-04-oq-03
 
-## Current State
-**Phase**: OBSERVE
-**Path**: full
-**Since**: 2026-07-04T18:35:42-07:00
-**Iteration**: 1
+**Phase:** ACT
+**Status:** in-progress (draft UNVERIFIED — build blackout)
 
-## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+## Current result
+Sharp CRT-fused congruence, drafted in Lean (unverified):
 
-## Active Approach
-None yet.
+  D(n) ≡ (−1)^(n+1)·(n − 1)   (mod n(n−1))
 
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+unifying the parent's `(n−1) ∣ D(n)` and `D(n) ≡ (−1)^n (mod n)`.
+Structural engine `crt_combine` transfers the result to any r-derangement
+family sharing the two recurrences.
 
 ## Blockers
-None.
+- Docker Lean build image blob corrupted (containerd meta.db EIO) → no machine check.
+- Aristotle MCP returns 404.
 
-## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+## Next
+Machine-check once Docker restored; promote draft into proofs/Proofs/.

--- a/src/data/research/problems/derangements-convergence-oq-04-oq-03.json
+++ b/src/data/research/problems/derangements-convergence-oq-04-oq-03.json
@@ -1,0 +1,314 @@
+{
+  "slug": "derangements-convergence-oq-04-oq-03",
+  "title": "Divisibility & Congruence for Generalized r-Derangement Numbers",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(n-1) \\mid D(n), \\qquad D(n) \\equiv (-1)^n \\pmod{n-1},",
+    "plain": "The parent proof `derangements-convergence-oq-04` establishes $(n-1) \\mid D(n)$ for ordinary derangement numbers $D(n) = n!\\sum_{k=0}^n \\frac{(-1)^k}{k!}$. This problem asks whether an analogous divisibility or sign-congruence survives for the **generalized ($r$-)derangement numbers**, which count permutations avoiding a fixed cycle structure. The recurrence $D(n) = (n-1)(D(n-1) + D(n-2))$ is the engine behind the classical result; the task is to find and formalize the corresponding recurrence-driven identity for $D_r(n)$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-04T18:35:42-07:00",
+    "iteration": 2,
+    "focus": "Proved sharp combined congruence D(n) = (-1)^(n+1)(n-1) mod n(n-1) via a CRT engine lemma; drafted UNVERIFIED Lean (build blackout).",
+    "blockers": [],
+    "nextAction": "Machine-check the draft once Docker build is restored; then optionally build combinatorial r-derangement object + recurrence to instantiate crt_combine literally.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: derived and Lean-drafted (UNVERIFIED) the sharp CRT-fused congruence D(n) = (-1)^(n+1)(n-1) (mod n(n-1)), unifying the two parent facts; isolated the structural engine crt_combine that transfers to any r-derangement family sharing the two recurrences.",
+    "builtItems": [
+      "crt_combine (research/problems/derangements-convergence-oq-04-oq-03/lean/DerangementsConvergenceOQ04OQ03.lean): CRT engine (n-1)|a AND n|(a-u) => n(n-1)|(a+u(n-1)).",
+      "sub_one_dvd: (n:Z-1)|D(n) over Z for all n via numDerangements_add_two.",
+      "dvd_numDerangements_sub_sign: n|(D(n)-(-1)^n) via numDerangements_succ.",
+      "numDerangements_combined_dvd / numDerangements_combined_congr: sharp fused congruence D(n) = (-1)^(n+1)(n-1) mod n(n-1)."
+    ],
+    "insights": [
+      "Parent problem statement is internally inconsistent: writes both (n-1)|D(n) and D(n)=(-1)^n mod (n-1); correct companion is mod n not mod n-1. Genuine facts: (n-1)|D(n) and D(n)=(-1)^n (mod n).",
+      "gcd(n,n-1)=1 so the two parent facts are not independent: CRT fuses them into D(n) = (-1)^(n+1)(n-1) (mod n(n-1)), pinning D(n) mod n(n-1) exactly. Verified numerically 2<=n<=9.",
+      "The fusion is combinatorics-free: it is a property of the recurrence SHAPE. Any sequence with a (n-1)-factor additive recurrence and a +-1-corrected multiplicative recurrence inherits the fused congruence (crt_combine).",
+      "crt_combine needs no coprimality hypothesis: writing a=(n-1)k, the mod-n fact forces n|(k+u); multiply back by (n-1). Works for all n including degenerate n=0,1."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no native r-derangement definition or recurrence; combinatorial instantiation of crt_combine needs building that object (EGF/species, >500 lines).",
+      "No local Lean build this session: Docker image blob corrupted (containerd meta.db EIO), Aristotle MCP 404. Draft UNVERIFIED."
+    ],
+    "nextSteps": [
+      "Machine-check DerangementsConvergenceOQ04OQ03.lean once Docker restored; if clean, promote into proofs/Proofs/ and add verified gallery entry.",
+      "Define r-derangements by recurrence, prove (n+r-1)-factor + sign facts, instantiate crt_combine for the literal r-derangement fused congruence.",
+      "Investigate whether n(n-1) is the exact period of D(n) modulo m, or more structure holds mod n(n-1)(n-2)."
+    ],
+    "markdown": "# Knowledge Base: derangements-convergence-oq-04-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "derangements",
+    "divisibility",
+    "congruence"
+  ],
+  "relatedProofs": [
+    "derangements",
+    "derangements-convergence",
+    "derangements-convergence-oq-01",
+    "derangements-convergence-oq-01-oq-01",
+    "derangements-convergence-oq-02",
+    "derangements-convergence-oq-03",
+    "derangements-convergence-oq-03-oq-01",
+    "derangements-convergence-oq-03-oq-01-oq-02",
+    "derangements-convergence-oq-03-oq-02",
+    "derangements-convergence-oq-03-oq-03",
+    "derangements-convergence-oq-04",
+    "derangements-convergence-oq-04-oq-02",
+    "derangements-convergence-oq-04-oq-04",
+    "derangements-convergence-oq-05",
+    "derangements-convergence-oq-05-oq-01",
+    "derangements-convergence-oq-05-oq-03",
+    "derangements-convergence-oq-06",
+    "derangements-convergence-oq-06-oq-01",
+    "derangements-convergence-oq-07",
+    "derangements-convergence-oq-07-oq-01",
+    "derangements-convergence-oq-07-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-05T01:52:27.439Z",
+  "lastUpdate": "2026-07-05T02:13:23Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/DerangementsConvergence.lean",
+      "filename": "DerangementsConvergence.lean",
+      "lineCount": 273,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 153,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01OQ01.lean",
+      "filename": "DerangementsConvergenceOQ01OQ01.lean",
+      "lineCount": 255,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ02.lean",
+      "filename": "DerangementsConvergenceOQ02.lean",
+      "lineCount": 240,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ02.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ03.lean",
+      "filename": "DerangementsConvergenceOQ03.lean",
+      "lineCount": 89,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ03.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ03OQ01.lean",
+      "filename": "DerangementsConvergenceOQ03OQ01.lean",
+      "lineCount": 118,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean",
+      "filename": "DerangementsConvergenceOQ03OQ01OQ02.lean",
+      "lineCount": 267,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ03OQ02.lean",
+      "filename": "DerangementsConvergenceOQ03OQ02.lean",
+      "lineCount": 83,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ03OQ03.lean",
+      "filename": "DerangementsConvergenceOQ03OQ03.lean",
+      "lineCount": 176,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ04.lean",
+      "filename": "DerangementsConvergenceOQ04.lean",
+      "lineCount": 93,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ04.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ04OQ02.lean",
+      "filename": "DerangementsConvergenceOQ04OQ02.lean",
+      "lineCount": 204,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ04OQ04.lean",
+      "filename": "DerangementsConvergenceOQ04OQ04.lean",
+      "lineCount": 148,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ04OQ04.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ05.lean",
+      "filename": "DerangementsConvergenceOQ05.lean",
+      "lineCount": 170,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ05.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ05OQ01.lean",
+      "filename": "DerangementsConvergenceOQ05OQ01.lean",
+      "lineCount": 131,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ05OQ03.lean",
+      "filename": "DerangementsConvergenceOQ05OQ03.lean",
+      "lineCount": 163,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ05OQ03.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ06.lean",
+      "filename": "DerangementsConvergenceOQ06.lean",
+      "lineCount": 148,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ06.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ06OQ01.lean",
+      "filename": "DerangementsConvergenceOQ06OQ01.lean",
+      "lineCount": 184,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ06OQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ07.lean",
+      "filename": "DerangementsConvergenceOQ07.lean",
+      "lineCount": 122,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ07.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ07OQ01.lean",
+      "filename": "DerangementsConvergenceOQ07OQ01.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ07OQ01.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ07OQ02.lean",
+      "filename": "DerangementsConvergenceOQ07OQ02.lean",
+      "lineCount": 121,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ07OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
`derangements-convergence-oq-04-oq-03` — divisibility & congruence for (generalized r-)derangement numbers. Parent `derangements-convergence-oq-04` proved two **separate** facts:
- `(n−1) ∣ D(n)`
- `D(n) ≡ (−1)ⁿ (mod n)`

## Result (this PR)
Because `gcd(n, n−1) = 1`, those two facts are **not independent** — CRT fuses them into a single **sharp** congruence:

> **D(n) ≡ (−1)ⁿ⁺¹·(n − 1)  (mod n(n−1))**

which pins `D(n)` modulo `n(n−1)` **exactly** (strictly stronger than either parent fact). Verified numerically for `2 ≤ n ≤ 9`.

The mechanism is isolated as a combinatorics-free **structural theorem** `crt_combine`:
> if `(n−1) ∣ a` and `n ∣ (a − u)` then `n(n−1) ∣ (a + u·(n−1))`.

So **any** r-derangement family whose sequence inherits a `(n−1)`-factor additive recurrence and a `±1`-corrected multiplicative recurrence automatically satisfies the same fused congruence — directly answering the "does an analogous divisibility/sign-congruence survive?" question without needing a native r-derangement definition.

Also documents that the child **problem statement is internally inconsistent** (it mixes `mod n` and `mod n−1`); the correct companion modulus is `n`.

## Lean — ⚠️ UNVERIFIED DRAFT
`research/problems/derangements-convergence-oq-04-oq-03/lean/DerangementsConvergenceOQ04OQ03.lean`
- `crt_combine`, `sub_one_dvd`, `dvd_numDerangements_sub_sign`, `numDerangements_combined_dvd`, `numDerangements_combined_congr` (all with full proofs, no `sorry`)

**Not machine-checked**: Docker Lean build image blob is corrupted (containerd `meta.db` I/O error) and the Aristotle MCP endpoint returns 404 this session. The file lives under `research/.../lean/`, which is **not** globbed by `proofs/lakefile.toml`, so it cannot break the gallery build. Promote into `proofs/Proofs/` after a clean build. Lemma names/usage mirror the parent's already-verified file.

## Data
- Updated `src/data/research/problems/derangements-convergence-oq-04-oq-03.json` (phase → ACT, knowledge accumulated)
- `knowledge.md` / `state.md` session record

🤖 Generated with [Claude Code](https://claude.com/claude-code)