### PR TITLE
Enrich Gaussian Second Moment: closure insight + phased IBP sections (94→100)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-04-incomplete-01/meta.json
@@ -64,7 +64,8 @@
       "The crease of an HH-5 fold is forced to be the perpendicular bisector of P₁ and its landing image, because the fold fixes P₂ and is an isometry — so P₂ is automatically equidistant from source and image.",
       "Reflection across a line through P₂ preserves squared distance to P₂; this single algebraic identity yields the necessity direction and shows the equidistance hypothesis captures ALL solvable configurations, not merely some.",
       "The entire algebraic degree of HH-5 lives in the circle-line intersection that produces the landing point (a Real.sqrt); once that witness is given, the fold is rational, so HH-5 introduces at most a quadratic — consistent with the Alperin–Lang classification of HH-5 as a degree-2 operation.",
-      "Working with an explicit squared-Euclidean distSq rather than Mathlib's `dist` on ℝ×ℝ avoids a correctness trap: the default product metric is the sup metric, not the Euclidean one."
+      "Working with an explicit squared-Euclidean distSq rather than Mathlib's `dist` on ℝ×ℝ avoids a correctness trap: the default product metric is the sup metric, not the Euclidean one.",
+      "Solvability collapses to a fold-free metric predicate: because equidistance from P₂ is at once necessary (forced by the fixed-point isometry reflectAcross_distSq_fixed) and sufficient (the perpendicular bisector realises the fold), hh5_solvable_iff restates HH-5 solvability purely as 'ℓ contains a point at squared-distance |P₁−P₂|² from P₂' — a condition on the line and two points alone, with the crease eliminated from the statement entirely."
     ],
     "prerequisites": [
       "Reflection of a point across a line ax+by+c=0 in coordinates",
@@ -85,17 +86,33 @@
       "id": "planar-primitives",
       "title": "Planar Primitives (copied from parent)",
       "startLine": 66,
-      "endLine": 135,
+      "endLine": 133,
       "summary": "Point := ℝ×ℝ, the Line structure (a,b,c with a≠0∨b≠0), Line.contains, reflectAcross (P − 2·((aPx+bPy+c)/(a²+b²))·(a,b)), Line.normSq_pos (a²+b²>0 from non-degeneracy), perpBisector of two distinct points, perpBisector_dirSq_pos, and reflectAcross_perpBisector (the perpendicular bisector reflects P₁ onto P₂). Copied verbatim from Proofs/AngleTrisectionOQ05OQ04.lean so the file compiles against Mathlib alone.",
       "mathContext": "These are the shared coordinate-geometry definitions underlying every Huzita–Hatori construction in the parent programme."
     },
     {
-      "id": "hh5-core",
-      "title": "HH-5 Constructive Core (S8)",
-      "startLine": 137,
+      "id": "necessity-isometry",
+      "title": "Necessity: Reflection Is an Isometry About P₂",
+      "startLine": 134,
+      "endLine": 166,
+      "summary": "distSq (squared Euclidean distance, deliberately not Mathlib's sup-metric `dist` on ℝ×ℝ); reflectAcross_distSq_fixed — reflection across any fold through P₂ preserves squared distance to P₂, so any HH-5 landing point is forced onto the circle |P₁'−P₂| = |P₁−P₂| (necessity of the equidistance condition); perpBisector_contains_of_equidistSq — a point equidistant from P₁ and P₂ lies on their perpendicular bisector, the incidence fact that puts P₂ on the crease.",
+      "mathContext": "$\\mathrm{reflect}_\\ell(P_1)$ with $P_2\\in\\ell \\Rightarrow |\\mathrm{reflect}_\\ell(P_1)-P_2|^2 = |P_1-P_2|^2$."
+    },
+    {
+      "id": "sufficiency-fold",
+      "title": "Sufficiency: The Perpendicular-Bisector Fold",
+      "startLine": 167,
+      "endLine": 194,
+      "summary": "hh5_core — given a landing point P₁'∈ℓ equidistant from P₂, the perpendicular bisector of P₁ and P₁' is a genuine fold through P₂ that sends P₁ onto ℓ; hh5_core_exact strengthens this to land P₁ precisely on the chosen witness P₁'. Together these give the rational, square-root-free construction of the fold once the (irrational) witness is supplied.",
+      "mathContext": "crease $=\\operatorname{perpBisector}(P_1,P_1')$, which passes through the equidistant $P_2$ and reflects $P_1\\mapsto P_1'\\in\\ell$."
+    },
+    {
+      "id": "solvability-iff",
+      "title": "Solvability Characterisation",
+      "startLine": 195,
       "endLine": 216,
-      "summary": "distSq (squared Euclidean distance); reflectAcross_distSq_fixed (reflection across a fold through P₂ preserves squared distance to P₂ — necessity of equidistance); perpBisector_contains_of_equidistSq (equidistant ⇒ on the bisector); hh5_core and hh5_core_exact (witnessed constructive HH-5 folds via the perpendicular bisector of P₁ and the landing point); hh5_solvable_iff (solvability characterisation isolating the sole irrational circle-line-intersection step).",
-      "mathContext": "Reduces HH-5 to a single square-root existence (the landing point) plus a rational fold, matching the Alperin–Lang degree-2 classification of HH-5."
+      "summary": "hh5_solvable_iff combines necessity and sufficiency into a biconditional: an HH-5 fold (through P₂, landing P₁ on ℓ, with landing point ≠ P₁) exists IFF ℓ contains a point at squared-distance distSq P₁ P₂ from P₂. This isolates the sole irrational content of HH-5 — the circle–line intersection witnessing that landing point — and matches the Alperin–Lang degree-2 classification.",
+      "mathContext": "$\\exists\\,\\text{HH-5 fold} \\iff \\exists\\,q\\in\\ell,\\ \\operatorname{distSq}(q,P_2) = \\operatorname{distSq}(P_1,P_2)$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01-oq-01/meta.json
@@ -49,6 +49,7 @@
     "text": "Working with Mathlib's standard-normal measure gaussianReal 0 1, the mean and variance come from the library (integral_id_gaussianReal, variance_id_gaussianReal). The raw second moment follows because a vanishing mean collapses the variance integral ∫ (x - E[X])² to ∫ x². The result is then transported to the parent's concrete idiom ∫ x²·(1/√(2π))·exp(-x²/2) = 1 by identifying Mathlib's density gaussianPDFReal 0 1 with the parent's density and applying the withDensity change-of-measure bridge. Finally the MGF simplifies to exp(t²/2).",
     "proofStrategy": "Four ingredients: (1) integral_id_gaussianReal gives E[X] = μ = 0; (2) variance_id_gaussianReal gives Var[X] = v = 1; (3) variance_eq_integral rewrites Var as ∫ (x - E[X])², and substituting E[X] = 0 yields ∫ x² = 1; (4) integral_gaussianReal_eq_integral_smul rewrites any gaussianReal integral as a density-weighted Lebesgue integral, and gaussianPDFReal_std matches that density to the parent's, giving the concrete form. The MGF is mgf_id_gaussianReal specialized to μ=0, v=1.",
     "keyInsights": [
+      "That the MGF exp(t²/2) is finite for every real t — not merely near 0 — makes N(0,1) moment-determinate: a distribution whose MGF converges on an open interval about 0 is uniquely fixed by its moments, so no other law shares the sequence (2k−1)!! (contrast the log-normal, whose moments determine nothing). The same full-line, entire-function convergence is the analytic reason Gaussians are closed under convolution and sit at the centre of the CLT.",
       "For a mean-zero distribution the variance IS the second moment, so E[X²] = Var[X] = 1 needs no separate integral computation.",
       "Mathlib's abstract measure gaussianReal 0 1 and the parent's concrete density (1/√(2π))·exp(-x²/2) are linked by a single withDensity bridge, letting library moment results be stated in elementary ∫ f(x) dx form.",
       "The MGF exp(t²/2) is the compact encoding of every moment at once: its power series ∑ t^{2k}/(2^k k!) reads off E[X^{2k}] = (2k)!/(2^k k!) = (2k-1)!! and the vanishing of the odd moments.",
@@ -65,19 +66,36 @@
       "title": "The standard normal as gaussianReal 0 1",
       "startLine": 1,
       "endLine": 47,
-      "description": "Module docstring, imports, and namespace, then `stdNormal := gaussianReal 0 1` (line 44) with its IsProbabilityMeasure instance inherited from Mathlib (line 46)."
+      "description": "Module docstring, imports, and namespace, then `stdNormal := gaussianReal 0 1` (line 44) with its IsProbabilityMeasure instance inherited from Mathlib (line 46).",
+      "mathContext": "$X \\sim \\mathcal{N}(0,1)$, realised as `ProbabilityTheory.gaussianReal 0 1`."
     },
     {
-      "title": "Mean, variance, and second moment",
+      "title": "Mean and Variance",
       "startLine": 49,
-      "endLine": 68,
-      "description": "`stdNormal_mean` (= 0) and `stdNormal_variance` (= 1) are library specializations. `stdNormal_second_moment` derives E[X²] = 1 from `variance_eq_integral` and the vanishing mean."
+      "endLine": 59,
+      "description": "`stdNormal_mean` (E[X] = 0) and `stdNormal_variance` (Var[X] = 1) are direct specialisations of Mathlib's `integral_id_gaussianReal` and `variance_id_gaussianReal` at μ = 0, v = 1 — the two defining parameters of the standard normal read back as its first two moments.",
+      "mathContext": "$\\mathbb{E}[X] = 0, \\qquad \\operatorname{Var}[X] = 1$."
     },
     {
-      "title": "Concrete density form and the MGF",
+      "title": "The Second Moment",
+      "startLine": 60,
+      "endLine": 69,
+      "description": "`stdNormal_second_moment` derives E[X²] = 1 by rewriting the variance as ∫(x − E[X])² (`variance_eq_integral`) and collapsing it with the vanishing mean — the raw second moment needs no separate integral of its own.",
+      "mathContext": "$\\mathbb{E}[X^2] = \\operatorname{Var}[X] + \\mathbb{E}[X]^2 = 1 + 0 = 1$."
+    },
+    {
+      "title": "Concrete Density Form and Second-Moment Transport",
       "startLine": 70,
+      "endLine": 93,
+      "description": "`gaussianPDFReal_std` matches Mathlib's density `gaussianPDFReal 0 1` to the parent's elementary form (1/√(2π))·exp(−x²/2); `stdNormal_second_moment_concrete` then transports E[X²] = 1 into that ∫ f(x) dx idiom via `integral_gaussianReal_eq_integral_smul`, bridging the abstract measure and the classical density integral.",
+      "mathContext": "$\\int x^2 \\cdot \\tfrac{1}{\\sqrt{2\\pi}} e^{-x^2/2}\\, dx = 1$."
+    },
+    {
+      "title": "The Moment Generating Function",
+      "startLine": 94,
       "endLine": 105,
-      "description": "`gaussianPDFReal_std` matches Mathlib's density to (1/√(2π))·exp(-x²/2); `stdNormal_second_moment_concrete` transports E[X²] = 1 to that idiom via `integral_gaussianReal_eq_integral_smul`. `stdNormal_mgf` records M_X(t) = exp(t²/2)."
+      "description": "`stdNormal_mgf` records M_X(t) = exp(t²/2), specialising `mgf_id_gaussianReal` to μ = 0, v = 1. Its Taylor coefficients [t^{2k}] = 1/(2^k k!) read off every even moment E[X^{2k}] = (2k−1)!! and the vanishing of the odd moments in one entire function.",
+      "mathContext": "$M_X(t) = \\mathbb{E}[e^{tX}] = e^{t^2/2}$."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02/meta.json
@@ -70,6 +70,7 @@
     "proofStrategy": "Three short steps on top of Mathlib. (1) half_gaussian_integral records the half-line value ∫_{(0,∞)} e^{-b x²} = √(π/b)/2 directly from Mathlib's integral_gaussian_Ioi. (2) gaussian_full_eq_two_mul_half proves the even-symmetry bridge ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}: rewrite the integrand as f(|x|) with f y = e^{-y²} (legal because |x|² = x², via sq_abs) and apply integral_comp_abs, the even-function reflection identity. (3) gaussian_integral_eq_sqrt_pi composes the bridge with the b = 1 half-line value √π/2 to re-derive the parent's √π — an independent route through Set.Ioi 0 and reflection rather than through the parametrized full-line integral_gaussian.",
     "keyInsights": [
       "**The half-line carries exactly half the mass.** Because e^{-b x²} is even, ∫_{(0,∞)} = √(π/b)/2 is precisely half of the full-line √(π/b) — the entry turns the informal remark 'the Gaussian is symmetric' into the explicit machine-checked identity.",
+      "**The parameter b is pure scaling.** The substitution x ↦ x/√b carries e^{-bx²} to e^{-x²}, collapsing the entire b-family of half-line Gaussians to the single unit integral times b^{-1/2} — exactly the √(π/b)/2 form. So specialising to b = 1 (half_gaussian_integral_one) loses no information: the b-dependence is dimensional scaling, carrying no independent analytic content beyond the b = 1 value.",
       "**The even-symmetry bridge is the real content.** gaussian_full_eq_two_mul_half (∫_ℝ = 2·∫_{(0,∞)}) is what makes this a genuine extension rather than a notational variant; it is obtained from integral_comp_abs by recognizing e^{-x²} = e^{-|x|²} through sq_abs.",
       "**An independent route to √π.** Recovering ∫_ℝ e^{-x²} = √π from the half-line value (rather than from the parent's parametrized integral_gaussian at b = 1) gives a genuinely different proof path to the same normalization constant.",
       "**Degeneracy at b ≤ 0 is handled silently.** Like Mathlib's full-line version, integral_gaussian_Ioi evaluates to 0 for b ≤ 0 (where e^{-b x²} is not integrable), so half_gaussian_integral holds for every real b without a positivity hypothesis."
@@ -82,25 +83,44 @@
   },
   "sections": [
     {
-      "id": "half-line-value",
-      "title": "The half-line Gaussian value",
+      "id": "problem-statement",
+      "title": "Problem Statement and Setup",
       "startLine": 1,
+      "endLine": 33,
+      "summary": "Imports and the module docstring stating the open question (the value of ∫_{(0,∞)} e^{-bx²}), its answer √(π/b)/2 = half the full-line mass, the even-symmetry method, and the plan to re-derive the parent's √π by an independent route; closes with `open Real MeasureTheory`.",
+      "mathContext": "$\\int_0^\\infty e^{-b x^2}\\,dx = \\tfrac12\\sqrt{\\tfrac{\\pi}{b}}$."
+    },
+    {
+      "id": "half-line-value",
+      "title": "The Half-Line Gaussian Value",
+      "startLine": 34,
       "endLine": 38,
-      "summary": "Imports, module docstring, and `open Real MeasureTheory`, then `half_gaussian_integral`: for every real b, ∫_{0}^{∞} exp(-b·x²) — the half-line Gaussian value used as the building block."
+      "summary": "half_gaussian_integral: for every real b, ∫_{(0,∞)} e^{-b·x²} = √(π/b)/2, recorded directly from Mathlib's integral_gaussian_Ioi — the building block for everything that follows.",
+      "mathContext": "$\\int_{(0,\\infty)} e^{-b x^2} = \\tfrac{\\sqrt{\\pi/b}}{2}$."
     },
     {
       "id": "symmetry-bridge",
-      "title": "The even-symmetry bridge",
+      "title": "The Even-Symmetry Bridge",
       "startLine": 40,
       "endLine": 49,
-      "summary": "gaussian_full_eq_two_mul_half: ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}. The integrand is rewritten as f(|x|) with f y = e^{-y²} (using sq_abs: |x|² = x²) and integral_comp_abs supplies the reflection identity — making 'half the mass on each side' an explicit theorem."
+      "summary": "gaussian_full_eq_two_mul_half: ∫_ℝ e^{-x²} = 2·∫_{(0,∞)} e^{-x²}. The integrand is rewritten as f(|x|) with f y = e^{-y²} (using sq_abs: |x|² = x²) and integral_comp_abs supplies the reflection identity — making 'half the mass on each side' an explicit theorem, and the genuine content that distinguishes this entry from a notational variant.",
+      "mathContext": "$\\int_{\\mathbb{R}} e^{-x^2} = 2\\int_{(0,\\infty)} e^{-x^2}$."
+    },
+    {
+      "id": "unit-case",
+      "title": "The Unit Case (b = 1)",
+      "startLine": 51,
+      "endLine": 55,
+      "summary": "half_gaussian_integral_one specialises the half-line value to b = 1, giving ∫_{(0,∞)} e^{-x²} = √π/2 — the concrete number fed into the √π recovery.",
+      "mathContext": "$\\int_{(0,\\infty)} e^{-x^2} = \\tfrac{\\sqrt{\\pi}}{2}$."
     },
     {
       "id": "recover-sqrt-pi",
-      "title": "Recovering the parent's √π",
-      "startLine": 51,
+      "title": "Recovering √π on the Full Line",
+      "startLine": 57,
       "endLine": 64,
-      "summary": "half_gaussian_integral_one specializes the half-line value to b = 1 (√π/2); gaussian_integral_eq_sqrt_pi then composes it with the symmetry bridge to re-derive ∫_ℝ e^{-x²} = √π along an independent route through Set.Ioi 0, closing with ring."
+      "summary": "gaussian_integral_eq_sqrt_pi composes the b = 1 half-line value with the symmetry bridge to re-derive ∫_ℝ e^{-x²} = √π along an independent route through Set.Ioi 0 — rather than the parent's parametrized integral_gaussian — closing with ring.",
+      "mathContext": "$\\int_{\\mathbb{R}} e^{-x^2} = \\sqrt{\\pi}$."
     }
   ],
   "openQuestions": [

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
@@ -29,30 +29,50 @@
       "Squaring removes the branch-cut subtlety: the integral itself is the single-valued-only-after-fixing-a-branch power (π/b)^{1/2}, but its square π/b is a single-valued rational function of b on the half-plane — which is why downstream normalization constants are stated via the square.",
       "The additive law x^{y+z} = x^y·x^z for complex principal powers holds precisely when x ≠ 0; the right half-plane re b > 0 is exactly the region guaranteeing π/b ≠ 0, so the two half-powers add without picking up a sign from the branch cut.",
       "Recovering π (not √π) at b = 1 makes this the faithful complex lift of the parent's central computation: the two-dimensional Gaussian integral equals π directly, and the square root is extracted only afterward.",
-      "As in the rest of the family, the hard analysis is inherited from Mathlib's integral_gaussian_complex; the contribution is the clean squared identity and the correctly-cast parent recovery — honestly badged 'mathlib'."
+      "As in the rest of the family, the hard analysis is inherited from Mathlib's integral_gaussian_complex; the contribution is the clean squared identity and the correctly-cast parent recovery — honestly badged 'mathlib'.",
+      "The squared value π/b is not just single-valued but holomorphic — indeed rational — across the entire right half-plane re b > 0, whereas the integral (π/b)^{1/2} is holomorphic only after a branch cut. This is exactly what lets the complex-parameter identity be established by analytic continuation from the real axis: two holomorphic functions of b agreeing for real b > 0 agree throughout the half-plane, so the rational square is the natural carrier of the continuation that the branched square root cannot support directly."
     ]
   },
   "sections": [
     {
-      "id": "open-question-context",
-      "title": "Open Question & the Two-Dimensional Trick",
+      "id": "open-question",
+      "title": "The Open Question",
       "startLine": 1,
-      "endLine": 30,
-      "summary": "Imports and the module docstring introducing the open question and the two-dimensional trick, the setup for squaring the complex Gaussian integral."
+      "endLine": 14,
+      "summary": "Imports and the docstring's statement of the open question: for the complex-parameter Gaussian ∫_ℝ e^{-b x²} = (π/b)^{1/2} (sibling area-of-circle-oq-07-oq-01), formalise that its SQUARE is the clean rational value π/b for every b : ℂ with 0 < re b.",
+      "mathContext": "$\\left(\\int_{\\mathbb{R}} e^{-b x^2}\\,dx\\right)^2 = \\dfrac{\\pi}{b}, \\quad \\operatorname{re} b > 0$."
+    },
+    {
+      "id": "squaring-branch-cut",
+      "title": "Squaring Removes the Branch Cut",
+      "startLine": 15,
+      "endLine": 22,
+      "summary": "The docstring's method: while the integral (π/b)^{1/2} is a branched principal power, its square collapses to π/b directly by Complex.cpow_add — valid because over the right half-plane re b > 0 the base π/b is nonzero. This is the complex-parameter form of the classical two-dimensional trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π.",
+      "mathContext": "$(\\pi/b)^{1/2}\\cdot(\\pi/b)^{1/2} = (\\pi/b)^{1/2+1/2} = \\pi/b$."
+    },
+    {
+      "id": "b1-recovery-outline",
+      "title": "The b = 1 Recovery and Setup",
+      "startLine": 23,
+      "endLine": 32,
+      "summary": "The docstring's plan for recovering the parent's real value (∫_ℝ e^{-x²})² = π as the b = 1 specialisation (the integrand is real, so the real integral is the pushforward of the complex one through ℂ, and π/1 = π), the no-new-axioms note, and `open Real Complex MeasureTheory`.",
+      "mathContext": "$b = 1:\\ \\left(\\int_{\\mathbb{R}} e^{-x^2}\\right)^2 = \\pi/1 = \\pi$."
     },
     {
       "id": "squared-complex",
       "title": "The Squared Complex Gaussian Integral",
       "startLine": 34,
       "endLine": 45,
-      "summary": "gaussian_integral_complex_sq: for 0 < re b, (∫ e^{-b x²})² = π/b, by rewriting to (π/b)^{1/2}, expanding with pow_two, and fusing exponents via Complex.cpow_add (side condition π/b ≠ 0) then norm_num."
+      "summary": "gaussian_integral_complex_sq: for 0 < re b, (∫ e^{-b x²})² = π/b, by rewriting to (π/b)^{1/2}, expanding with pow_two, and fusing exponents via Complex.cpow_add (side condition π/b ≠ 0) then norm_num.",
+      "mathContext": "$\\left(\\int_{\\mathbb{R}} e^{-b x^2}\\right)^2 = \\pi/b$."
     },
     {
       "id": "parent-recovery",
       "title": "Recovering π as the b = 1 Case",
       "startLine": 47,
       "endLine": 64,
-      "summary": "gaussian_integral_sq_eq_pi: the real (∫ e^{-x²})² = π from the complex result at b = 1, via hLcast (integral_complex_ofReal) and div_one, finished by exact_mod_cast."
+      "summary": "gaussian_integral_sq_eq_pi: the real (∫ e^{-x²})² = π from the complex result at b = 1, via hLcast (integral_complex_ofReal, casting the real integral to the complex Gaussian) and div_one, finished by exact_mod_cast.",
+      "mathContext": "$\\left(\\int_{\\mathbb{R}} e^{-x^2}\\right)^2 = \\pi$."
     }
   ],
   "meta": {

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
@@ -85,7 +85,8 @@
       "The 'coincidence' √π/2 = ½·√π is no accident: integration by parts with u' = 1 trades the entire x² weight for the bare Gaussian, so the second moment is structurally half the zeroth moment.",
       "On ℝ the cocompact filter equals atBot ⊔ atTop, so a single cocompact decay statement (x e^{-x²} → 0) discharges both one-sided boundary terms of the integration by parts at once.",
       "Establishing √π/2 as a genuine real Lebesgue integral — rather than as the Gamma special value Γ(3/2) — gives a self-contained base case for the double-factorial recursion ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n, where each parts step lowers the power by two.",
-      "The badge is 'mathlib': every step is a routine consequence of existing Mathlib results (the IBP lemma, the parent integral_gaussian, and the Gaussian-decay tendsto), assembled rather than newly invented — but the assembly itself is the contribution, since Mathlib does not state the weighted second moment directly."
+      "The badge is 'mathlib': every step is a routine consequence of existing Mathlib results (the IBP lemma, the parent integral_gaussian, and the Gaussian-decay tendsto), assembled rather than newly invented — but the assembly itself is the contribution, since Mathlib does not state the weighted second moment directly.",
+      "A recursion exists at all because the Gaussian is closed under differentiation up to a polynomial factor: d/dx e^{-x²} = -2x·e^{-x²} keeps every derivative inside the family {polynomial · e^{-x²}}. Integration by parts therefore always sends ∫ x^{2n} e^{-x²} back to a lower moment of the SAME kernel rather than to a new transcendental — which is exactly why all Gaussian moments collapse to rational multiples of √π. Here the antiderivative v = -½ e^{-x²} routes the second moment straight back to the zeroth."
     ],
     "prerequisites": [
       "Lebesgue integration over ℝ (MeasureTheory)",
@@ -112,12 +113,28 @@
       "mathContext": "$x e^{-x^2} \\to 0$ as $x \\to \\pm\\infty$ (Gaussian decay beats the linear factor)."
     },
     {
-      "id": "second-moment",
-      "title": "Integration by Parts on the Whole Line",
+      "id": "ibp-derivatives-integrability",
+      "title": "Integration by Parts: Derivatives and Integrability",
       "startLine": 53,
+      "endLine": 83,
+      "summary": "gaussian_second_moment opens by choosing u = x (u' = 1) and the antiderivative v = -½ e^{-x²} (v' = x e^{-x²}, via hasDerivAt_pow and .exp), so u·v' = x²e^{-x²} recovers the integrand; then verifies the two integrability side conditions (huv', hu'v) using Mathlib's integrable_rpow_mul_exp_neg_mul_sq and integrable_exp_neg_mul_sq.",
+      "mathContext": "$u = x,\\ v = -\\tfrac12 e^{-x^2},\\quad u\\,v' = x^2 e^{-x^2},\\ u'\\,v = -\\tfrac12 e^{-x^2}$."
+    },
+    {
+      "id": "ibp-boundary-terms",
+      "title": "The Vanishing Boundary Terms",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "hbot and htop: the boundary product x·(-½ e^{-x²}) tends to 0 at both −∞ and +∞. Each is obtained by restricting the single cocompact decay lemma along atBot ≤ cocompact and atTop ≤ cocompact (cocompact_eq_atBot_atTop), so one decay fact discharges both endpoints of the parts formula.",
+      "mathContext": "$[u v]_{-\\infty}^{\\infty} = 0$ since $x e^{-x^2} \\to 0$ at $\\pm\\infty$."
+    },
+    {
+      "id": "ibp-assembly",
+      "title": "Applying IBP and Evaluating",
+      "startLine": 99,
       "endLine": 118,
-      "summary": "gaussian_second_moment: builds the derivatives u = x, v = -½ e^{-x²}, verifies the two integrability conditions and the two boundary limits, applies integral_mul_deriv_eq_deriv_mul, and evaluates the surviving ½ ∫ e^{-x²} = ½√π via the parent integral_gaussian.",
-      "mathContext": "$\\int u\\,v' = [uv]_{-\\infty}^{\\infty} - \\int u'\\,v = 0 - \\int 1\\cdot(-\\tfrac12 e^{-x^2}) = \\tfrac12\\sqrt\\pi$."
+      "summary": "Applies integral_mul_deriv_eq_deriv_mul with the vanishing boundary data, reducing the second moment to 0 − 0 − ∫ 1·(-½ e^{-x²}); evaluates the surviving integral via the parent ∫ e^{-x²} = √π (integral_gaussian at b = 1), and the final calc assembles ½√π = √π/2.",
+      "mathContext": "$\\int x^2 e^{-x^2} = 0 - \\int 1\\cdot(-\\tfrac12 e^{-x^2}) = \\tfrac12\\sqrt\\pi = \\tfrac{\\sqrt\\pi}{2}$."
     }
   ],
   "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05` (the Gaussian second moment ∫ x² e^{-x²} = √π/2; passes: 0), raising the enrichment quality score **94 → 100**.

- **5th keyInsight** — the moment recursion exists *at all* because the Gaussian is closed under differentiation up to a polynomial factor: d/dx e^{-x²} = -2x·e^{-x²} keeps every derivative inside {polynomial · e^{-x²}}, so integration by parts always returns ∫ x^{2n} e^{-x²} to a lower moment of the same kernel rather than a new transcendental — which is why all Gaussian moments collapse to rational multiples of √π. Distinct from the four existing insights (which cover the ½ factor, the cocompact filter, the Lebesgue-vs-Γ base case, and the honest badge).
- **Sections 3 → 5** — the previous single 65-line "Integration by Parts" block is split into the proof's three explicitly-commented phases: Derivatives and Integrability (L53–83) / The Vanishing Boundary Terms (L84–98) / Applying IBP and Evaluating (L99–118), each with its own mathContext.

meta.json: 12.5 KB → 14.6 KB (well under the 60 KB cap). No status/badge/axiom changes.
