### PR TITLE
Research: desargues-oq-02-oq-03 session 2 — R-inference fix + converse plan

### DIFF
--- a/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
@@ -46,13 +46,34 @@ the positive/coordinatized direction.
 quaternion `example`. Placed outside the `proofs/Proofs/` glob so it cannot break
 the gallery build.
 
+## Converse strategy (Desargues ⇒ division ring) — for a future session
+
+The deep half. Classical route (Artin/Hartshorne): from a Desarguesian
+projective plane, coordinatize by a *ternary ring* and use the two
+Desargues specializations to upgrade it:
+- **Minor Desargues (center on the axis)** ⇒ addition is associative and the
+  additive loop is a group (translations form a group).
+- **Major Desargues (center off the axis)** ⇒ multiplication is associative and
+  the nonzero elements form a group ⇒ the coordinate ternary ring is an
+  associative division ring (skew field). Distributivity comes from both.
+- Commutativity of `·` would require *Pappus*, which is strictly stronger — so
+  the natural converse target is a **division ring**, matching the forward
+  direction. This is why keeping scalars on the left (non-commutative-safe)
+  in the forward file is the right convention to meet the converse at.
+
+Formalization-wise this is a large project (define the ternary ring from an
+abstract incidence geometry, then two long synthetic⇒algebraic derivations).
+A tractable *first* milestone: prove the additive-group half from Minor
+Desargues in a fixed affine chart `R^2` — i.e. that the "translation" maps
+`x ↦ x + v` compose associatively — which the forward `cross_eq`/`nucleus_sum`
+group arithmetic already half-supplies in the easy direction.
+
 ## Dead Ends / Deferred
 
 - **Uniqueness of the intersection point** (that `a-b` is *the* unique
   intersection, not merely *an* incident point) needs general-position
   hypotheses (non-degenerate triangles, distinct lines) — deferred.
-- **The converse** (Desargues ⇒ division-ring coordinatization) is the hard
-  coordinatization theorem — not attempted this session.
+- **The converse** — see strategy above; not attempted, needs verified infra.
 
 ## Blockers
 
@@ -67,3 +88,18 @@ Verification blackout 2026-07-04: Docker image build fails (containerd
   no-zero-divisors step; showed commutativity unused (quaternion example).
 - Could not machine-check (dual blackout). File placed under `research/lean/`.
 - Next: verify + promote when infra returns; then attempt uniqueness / converse.
+
+### Session 2026-07-04 (Session 2) — Manual review + converse plan
+**Mode**: RESUME · **Outcome**: progress (blackout persists — still cannot verify)
+- Re-tested infra: `docker run hello-world` still fails (containerd blob EIO),
+  no lean image; Aristotle `prove` (with the file as `context_files`) still
+  returns `{"status":"error","message":"Resource not found."}` (404). No verify.
+- **Hand-review catch (fixed):** the Part III quaternion `example` left the ring
+  `R` as an unpinned implicit — all its variables are `M`-typed and `NormPersp`
+  does not capture `R`, so `Module ?R (Fin 3 → Quaternion ℝ)` would stall TC
+  synthesis on a metavariable. Fixed by naming `Dep (R := Quaternion ℝ) …` and
+  `desargues (R := Quaternion ℝ) …`. Safe regardless of whether inference would
+  have succeeded (it pins the intended ring). Still UNVERIFIED.
+- Recorded the classical converse strategy (minor/major Desargues ⇒
+  additive/multiplicative group ⇒ division ring) as a springboard.
+- Next: unchanged — verify + promote when infra returns.

--- a/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
@@ -1,21 +1,69 @@
 # Knowledge Base: desargues-theorem-oq-02-oq-03
 
-Insights accumulated during research on this problem.
+Desargues' theorem over free rank-3 modules on (non-commutative) division rings.
+Forward direction: Desargues holds over any division ring; commutativity unused.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Classical result (Artin, *Geometric Algebra*): the Desargues configuration holds
+in the projective plane `P(R^3)` **iff** `R` is a division ring. Commutativity is
+*not* required — that governs Pappus. The parent `desargues-theorem-oq-02`
+supplies the failure direction (Moulton plane, non-Desarguesian). This problem is
+the positive/coordinatized direction.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The nucleus is a telescoping identity.** The whole geometric content is
+  `(a-b) + (b-c) + (c-a) = 0`. It holds in *any* `AddCommGroup` module — no
+  division, no commutativity. Linear dependence of the three cross vectors (with
+  the canonical witness `(1,1,1)`) is exactly collinearity of the three
+  side-intersection points.
+- **Cross-vector coincidence.** Under normalized central perspectivity
+  `o = a+a' = b+b' = c+c'`, one gets `a - b = b' - a'` (pure group arithmetic).
+  This is what makes `a - b` lie on *both* line `AB` and line `A'B'`, i.e. be
+  their intersection point.
+- **Commutativity genuinely unused.** The entire proof typechecks over
+  `[DivisionRing R]`, not `[Field R]`, and applies to modules over the
+  quaternions `H`. Scalars are only ever applied by left-multiplication to a
+  single vector; no scalar is ever moved across a product.
+- **Where division enters (exactly one spot).** Rescaling a *raw* perspectivity
+  `o = α·a + β·a'` to normalized form `o = (α·a) + (β·a')` needs the rescaled
+  representatives `α·a`, `β·a'` to remain nonzero — i.e. **no zero divisors**.
+  A general ring can have `α·a = 0` with `α, a ≠ 0`, which is precisely how
+  Desargues can fail without a division ring (`normalize_perspective`,
+  `smul_ne_zero'`).
 
----
+## What was built (UNVERIFIED — blackout)
 
-## Dead Ends
+`research/problems/.../lean/DesarguesTheoremOQ02OQ03.lean` (178 lines, 7 theorems,
+1 def, 0 sorries):
+`nucleus_sum`, `Dep`/`cross_dep`, `cross_eq`, `sub_mem_span`, `desargues`
+(the assembled statement), `smul_ne_zero'`, `normalize_perspective`, plus a
+quaternion `example`. Placed outside the `proofs/Proofs/` glob so it cannot break
+the gallery build.
 
-[Approaches known not to work will be documented here]
+## Dead Ends / Deferred
+
+- **Uniqueness of the intersection point** (that `a-b` is *the* unique
+  intersection, not merely *an* incident point) needs general-position
+  hypotheses (non-degenerate triangles, distinct lines) — deferred.
+- **The converse** (Desargues ⇒ division-ring coordinatization) is the hard
+  coordinatization theorem — not attempted this session.
+
+## Blockers
+
+Verification blackout 2026-07-04: Docker image build fails (containerd
+`meta.db` I/O error); Aristotle MCP `prove_file` returns 404. File is UNVERIFIED.
+
+## Sessions
+
+### Session 2026-07-04 (Session 1) — Forward direction formalized
+**Mode**: FRESH · **Outcome**: progress (build-blocked)
+- Formalized the linear-algebra Desargues over a division ring; isolated the
+  no-zero-divisors step; showed commutativity unused (quaternion example).
+- Could not machine-check (dual blackout). File placed under `research/lean/`.
+- Next: verify + promote when infra returns; then attempt uniqueness / converse.

--- a/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
+++ b/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
@@ -172,7 +172,7 @@ end Desargues
     secretly using commutativity. -/
 example (o a a' b b' c c' : Fin 3 → Quaternion ℝ)
     (h : NormPersp o a a' b b' c c') :
-    Dep (a - b) (b - c) (c - a) :=
-  (desargues o a a' b b' c c' h).1
+    Dep (R := Quaternion ℝ) (a - b) (b - c) (c - a) :=
+  (desargues (R := Quaternion ℝ) o a a' b b' c c' h).1
 
 end DesarguesTheoremOQ02OQ03

--- a/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
+++ b/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
@@ -1,0 +1,178 @@
+/-
+# Desargues' Theorem over Free Modules on (Non-Commutative) Division Rings (OQ-02-OQ-03)
+
+Research Question: Over a free rank-3 module `M = R^3` on a possibly
+non-commutative ring `R`, under what conditions does Desargues' theorem hold,
+and precisely where does the division-ring hypothesis enter?
+
+Answer (forward direction, formalized here): Desargues' theorem holds whenever
+`R` is a division ring, and **commutativity is never used** (that governs Pappus,
+not Desargues). We isolate the linear-algebra heart of the theorem:
+
+  * `nucleus_sum` — the three "cross" vectors telescope to `0`. This is the
+    entire geometric content and holds in ANY module: no division, no
+    commutativity.
+  * `cross_dep` — hence the three intersection points are collinear.
+  * `cross_eq` — under normalized central perspectivity the unprimed cross
+    vector `a - b` equals the primed cross vector `b' - a'`, so `a - b` is the
+    genuine intersection of lines `AB` and `A'B'`.
+  * `desargues` — the assembled theorem: two triangles centrally perspective
+    (in normalized form) from `O` are axially perspective (their three side
+    intersections are collinear and each lies on both relevant lines).
+  * `normalize_perspective` / `smul_ne_zero'` — the ONLY place invertibility is
+    used: rescaling a raw perspectivity `o = α•a + β•a'` to the normalized
+    `o = ã + ã'` requires `α, β` invertible and the *absence of zero divisors*
+    (so the rescaled representatives stay nonzero). Commutativity is not used
+    here either.
+
+This complements the gallery's Moulton-plane counterexample
+(`desargues-theorem-oq-02`), which realizes the failure direction. Together they
+frame the classical equivalence: Desargues holds in `P(R^3)` iff `R` is a
+division ring.
+
+Reference: Artin, *Geometric Algebra* (Desargues ⇔ division ring);
+Hartshorne, *Foundations of Projective Geometry*.
+
+BUILD STATUS: UNVERIFIED. Written during a Docker + Aristotle blackout
+(containerd `meta.db` I/O error on image build; Aristotle MCP returns 404), so
+this file has NOT been machine-checked. It is deliberately placed under
+`research/problems/.../lean/` (outside the `proofs/Proofs/` glob) so it cannot
+break the gallery build. Parts I–II (`nucleus_sum`, `cross_dep`, `cross_eq`,
+`desargues`, `normalize_perspective`) are the reviewed mathematical core; the
+Part III quaternion `example` is an instance-resolution demonstration.
+
+Tags: projective-geometry, desargues, division-ring, non-commutative, modules
+-/
+
+import Mathlib
+
+namespace DesarguesTheoremOQ02OQ03
+
+variable {R : Type*} {M : Type*}
+
+/-! ## Part I — The nucleus identity (holds in any module) -/
+
+section Nucleus
+variable [Ring R] [AddCommGroup M] [Module R M]
+
+/-- Projective collinearity of three representative vectors: they satisfy a
+    nontrivial vanishing linear combination (linear dependence). For pairwise
+    independent vectors over a division ring this is exactly the statement that
+    the three projective points lie on a common line. -/
+def Dep (u v w : M) : Prop :=
+  ∃ a b c : R, (a ≠ 0 ∨ b ≠ 0 ∨ c ≠ 0) ∧ a • u + b • v + c • w = 0
+
+/-- **Nucleus identity.** The three cross vectors telescope to zero.
+    No division ring, no commutativity — pure `AddCommGroup` arithmetic. -/
+theorem nucleus_sum (a b c : M) : (a - b) + (b - c) + (c - a) = 0 := by
+  abel
+
+/-- The three cross vectors are linearly dependent, with the canonical witness
+    `(1, 1, 1)`. Geometrically: the three side-intersection points are always
+    collinear. Needs only `Nontrivial R` (so `1 ≠ 0`). -/
+theorem cross_dep [Nontrivial R] (a b c : M) : Dep (a - b) (b - c) (c - a) := by
+  refine ⟨1, 1, 1, Or.inl one_ne_zero, ?_⟩
+  simp only [one_smul]
+  exact nucleus_sum a b c
+
+/-- Membership helper: `x - y` lies in the span of any set containing `x, y`. -/
+theorem sub_mem_span {x y : M} {s : Set M} (hx : x ∈ s) (hy : y ∈ s) :
+    x - y ∈ Submodule.span R s :=
+  Submodule.sub_mem _ (Submodule.subset_span hx) (Submodule.subset_span hy)
+
+/-- **Cross-vector coincidence.** Under normalized central perspectivity
+    `o = a + a' = b + b'`, the unprimed cross vector equals the primed one.
+    This is exactly what makes `a - b` a point of BOTH line `AB` and line
+    `A'B'`, i.e. their intersection. Pure group arithmetic. -/
+theorem cross_eq (o a a' b b' : M) (ha : o = a + a') (hb : o = b + b') :
+    a - b = b' - a' := by
+  have h : a + a' = b + b' := by rw [← ha]; exact hb
+  calc a - b = (a + a') - (b + a') := by abel
+    _ = (b + b') - (b + a') := by rw [h]
+    _ = b' - a' := by abel
+
+end Nucleus
+
+/-! ## Part II — Desargues' theorem over a division ring -/
+
+section Desargues
+variable [DivisionRing R] [AddCommGroup M] [Module R M]
+
+/-- Two triangles `A B C` and `A' B' C'` are *centrally perspective in
+    normalized form* from `O` when representative vectors satisfy
+    `o = a + a' = b + b' = c + c'`. Over a division ring any central
+    perspectivity can be put in this form — see `normalize_perspective`. -/
+structure NormPersp (o a a' b b' c c' : M) : Prop where
+  ha : o = a + a'
+  hb : o = b + b'
+  hc : o = c + c'
+
+/-- **Desargues' theorem (linear form).** If triangles `ABC` and `A'B'C'` are
+    centrally perspective (normalized) from `O`, then the three intersection
+    points of corresponding sides are collinear (`Dep`), and each cross vector
+    lies on both of the lines it is meant to intersect. Commutativity of `R`
+    is never used. -/
+theorem desargues (o a a' b b' c c' : M) (h : NormPersp o a a' b b' c c') :
+    Dep (a - b) (b - c) (c - a) ∧
+    (a - b ∈ Submodule.span R ({a, b} : Set M) ∧
+     a - b ∈ Submodule.span R ({a', b'} : Set M)) ∧
+    (b - c ∈ Submodule.span R ({b, c} : Set M) ∧
+     b - c ∈ Submodule.span R ({b', c'} : Set M)) ∧
+    (c - a ∈ Submodule.span R ({c, a} : Set M) ∧
+     c - a ∈ Submodule.span R ({c', a'} : Set M)) := by
+  refine ⟨cross_dep a b c, ⟨?_, ?_⟩, ⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
+  -- a - b on line AB
+  · exact sub_mem_span (by simp) (by simp)
+  -- a - b = b' - a' on line A'B'
+  · rw [cross_eq o a a' b b' h.ha h.hb]
+    exact sub_mem_span (by simp) (by simp)
+  -- b - c on line BC
+  · exact sub_mem_span (by simp) (by simp)
+  -- b - c = c' - b' on line B'C'
+  · rw [cross_eq o b b' c c' h.hb h.hc]
+    exact sub_mem_span (by simp) (by simp)
+  -- c - a on line CA
+  · exact sub_mem_span (by simp) (by simp)
+  -- c - a = a' - c' on line C'A'
+  · rw [cross_eq o c c' a a' h.hc h.ha]
+    exact sub_mem_span (by simp) (by simp)
+
+/-- Nonzero scalars scale nonzero vectors to nonzero vectors — the "no zero
+    divisors" fact that a division ring supplies. This is the crux the
+    forward direction needs and a general ring lacks. -/
+theorem smul_ne_zero' (α : R) (a : M) (hα : α ≠ 0) (ha : a ≠ 0) : α • a ≠ 0 := by
+  intro h
+  apply ha
+  have h2 : α⁻¹ • (α • a) = α⁻¹ • (0 : M) := by rw [h]
+  rwa [smul_smul, inv_mul_cancel₀ hα, one_smul, smul_zero] at h2
+
+/-- **Where the division-ring hypothesis enters.** A raw central perspectivity
+    presents `o` as a linear combination `o = α • a + β • a'` of the two vertex
+    representatives. When `α, β ≠ 0` (forced by `O ≠ A'` and `O ≠ A`), the
+    rescaled vectors `α • a`, `β • a'` still represent the *same* projective
+    points `A`, `A'` (they are nonzero, because a division ring has no zero
+    divisors) and satisfy the normalized equation `o = (α•a) + (β•a')`.
+
+    This is the ONLY step requiring invertibility; it uses no commutativity. -/
+theorem normalize_perspective
+    (o a a' : M) (α β : R) (ho : o = α • a + β • a')
+    (ha : a ≠ 0) (ha' : a' ≠ 0) (hα : α ≠ 0) (hβ : β ≠ 0) :
+    ∃ ã ã' : M, ã ≠ 0 ∧ ã' ≠ 0 ∧
+      (∃ u : Rˣ, ã = (u : R) • a) ∧ (∃ v : Rˣ, ã' = (v : R) • a') ∧
+      o = ã + ã' :=
+  ⟨α • a, β • a', smul_ne_zero' α a hα ha, smul_ne_zero' β a' hβ ha',
+    ⟨Units.mk0 α hα, rfl⟩, ⟨Units.mk0 β hβ, rfl⟩, ho⟩
+
+end Desargues
+
+/-! ## Part III — The non-commutative case is genuinely covered -/
+
+/-- The real quaternions `ℍ` form a non-commutative division ring, so Desargues
+    applies verbatim to modules over `ℍ`. This witnesses that the theorem is not
+    secretly using commutativity. -/
+example (o a a' b b' c c' : Fin 3 → Quaternion ℝ)
+    (h : NormPersp o a a' b b' c c') :
+    Dep (a - b) (b - c) (c - a) :=
+  (desargues o a a' b b' c c' h).1
+
+end DesarguesTheoremOQ02OQ03

--- a/research/problems/desargues-theorem-oq-02-oq-03/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/state.md
@@ -1,25 +1,33 @@
 # Research State: desargues-theorem-oq-02-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04T18:35:43-07:00
+**Since**: 2026-07-04
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Forward direction formalized: Desargues holds over any division ring. The
+geometric core is the telescoping nucleus identity `(a-b)+(b-c)+(c-a)=0` (holds
+in any module), plus a cross-vector coincidence lemma making each `a-b` the
+intersection of the two corresponding sides. Division-ring hypothesis isolated to
+a single no-zero-divisors rescaling step; commutativity shown unused.
 
 ## Active Approach
-None yet.
+Linear-algebra / coordinate proof (approach 1 of problem.md), scalars kept on the
+left throughout so non-commutativity is a non-issue.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+Verification blackout 2026-07-04: Docker image build fails (containerd meta.db
+I/O error); Aristotle MCP prove_file returns 404. Lean file UNVERIFIED.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When infra returns: docker-build.sh Proofs.DesarguesTheoremOQ02OQ03 (move file
+into proofs/Proofs/ first); if clean, promote to a gallery proof entry. Then
+strengthen to intersection-uniqueness (general position) and attempt the converse
+(Desargues ⇒ division-ring coordinatization).

--- a/research/problems/desargues-theorem-oq-02-oq-03/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/state.md
@@ -4,7 +4,7 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-07-04
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
 Forward direction formalized: Desargues holds over any division ring. The
@@ -23,8 +23,10 @@ left throughout so non-commutativity is a non-issue.
 - Approaches tried: 1
 
 ## Blockers
-Verification blackout 2026-07-04: Docker image build fails (containerd meta.db
-I/O error); Aristotle MCP prove_file returns 404. Lean file UNVERIFIED.
+Verification blackout 2026-07-04 (persists through Session 2): `docker run
+hello-world` fails (containerd blob EIO), no lean image; Aristotle MCP `prove`
+(file as context_files) still returns 404 "Resource not found". Lean file
+UNVERIFIED. Session 2 hand-fixed an R-inference bug in the Part III example.
 
 ## Next Action
 When infra returns: docker-build.sh Proofs.DesarguesTheoremOQ02OQ03 (move file

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-03.json
@@ -1,0 +1,100 @@
+{
+  "slug": "desargues-theorem-oq-02-oq-03",
+  "title": "Desargues' Theorem over Free Rank-3 Modules on (Non-Commutative) Division Rings",
+  "phase": "ACT",
+  "status": "progress",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 4,
+  "started": "2026-07-04T19:00:00-07:00",
+  "lastUpdate": "2026-07-04",
+  "path": "full",
+  "problemStatement": "Over a free rank-3 module M = R^3 on a possibly non-commutative ring R, determine when the Desargues configuration holds. The classical answer: Desargues holds in P(R^3) iff R is a division ring; commutativity is not required (that governs Pappus). This session formalizes the forward direction — Desargues holds over any division ring — and isolates precisely where the division-ring hypothesis (absence of zero divisors) enters, showing commutativity is never used.",
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-07-04",
+    "iteration": 1,
+    "focus": "Linear-algebra proof of Desargues formalized as the 'nucleus' identity (a-b)+(b-c)+(c-a)=0 (holds in ANY module, no division/commutativity) plus a cross-vector coincidence lemma making each a-b the genuine intersection of lines AB and A'B'. Division-ring hypothesis isolated to a single no-zero-divisors rescaling step (normalize_perspective / smul_ne_zero').",
+    "blockers": [
+      "Verification blackout 2026-07-04: Docker image build fails with containerd meta.db I/O error; Aristotle MCP prove_file returns 404. Lean file UNVERIFIED (not machine-checked)."
+    ],
+    "nextAction": "When infra returns, docker-build.sh Proofs.DesarguesTheoremOQ02OQ03 (move file from research/lean/ into proofs/Proofs/ first). If it builds clean, promote to a gallery proof entry. Then attempt the converse direction (failure of Desargues => non-division coordinatization).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "insights": [
+      "The entire geometric content of Desargues is the telescoping identity (a-b)+(b-c)+(c-a)=0 on 'cross' vectors — this holds in ANY AddCommGroup module, requiring neither division nor commutativity.",
+      "Under normalized central perspectivity o = a+a' = b+b' = c+c', the unprimed cross vector a-b equals the primed cross vector b'-a', which is exactly why a-b lies on BOTH line AB and line A'B' (i.e. is their intersection point). This is pure group arithmetic.",
+      "Commutativity of R is genuinely unused: the whole proof typechecks over [DivisionRing R] (not [Field R]); this matches the classical fact that commutativity governs Pappus, not Desargues.",
+      "The division-ring hypothesis enters at exactly one point: rescaling a raw perspectivity o = alpha*a + beta*a' to normalized form o = (alpha*a) + (beta*a') requires the rescaled representatives to stay nonzero, i.e. NO ZERO DIVISORS. A general ring can have alpha*a = 0 with alpha, a both nonzero, breaking the normalization.",
+      "Scalar rescaling of a representative vector is left-multiplication alpha*a (left module); the argument never needs to move a scalar across a product, which is why non-commutativity causes no trouble."
+    ],
+    "builtItems": [
+      "nucleus_sum : (a-b)+(b-c)+(c-a)=0 in any module (research/.../lean/DesarguesTheoremOQ02OQ03.lean) — 0 sorries",
+      "Dep + cross_dep : the three cross vectors are linearly dependent (collinear intersection points), witness (1,1,1)",
+      "cross_eq : o=a+a'=b+b' => a-b = b'-a' (cross-vector coincidence)",
+      "sub_mem_span : x,y in s => x-y in span R s (line-membership helper)",
+      "desargues : full statement — NormPersp o a a' b b' c c' => Dep of the three intersections AND each cross vector lies on both relevant lines; proved over [DivisionRing R], commutativity unused",
+      "smul_ne_zero' + normalize_perspective : the no-zero-divisors rescaling step isolating the division-ring hypothesis",
+      "Quaternion example : Desargues applies to modules over the non-commutative division ring H = Quaternion R"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Desargues-configuration statement; the projective incidence layer (Projectivization) is built for division rings but the Desargues theorem itself must be set up from scratch.",
+      "No ready abstract projective-plane axiomatization tying synthetic incidence to R^3 coordinatization, so the 'intersection point' is encoded here directly as span membership rather than via a projective-plane structure."
+    ],
+    "nextSteps": [
+      "Machine-verify DesarguesTheoremOQ02OQ03.lean once Docker/Aristotle recover; promote to proofs/Proofs/ + gallery entry if clean.",
+      "Strengthen 'a-b is THE intersection' to a uniqueness statement (needs general-position hypotheses: triangles non-degenerate, lines distinct) — currently only membership in both lines is shown.",
+      "Attempt the converse: if Desargues holds in a projective plane then it is coordinatized by a division ring (the hard coordinatization direction).",
+      "Formalize the contrast explicitly: exhibit a ring R with zero divisors where normalize_perspective fails, linking to the Moulton counterexample of the parent oq-02."
+    ],
+    "progressSummary": "PROGRESS: forward direction of Desargues-over-division-ring formalized (7 theorems, 0 sorries, UNVERIFIED pending build). Division-ring hypothesis isolated to one no-zero-divisors step; commutativity shown unused (proof lives over DivisionRing, applies to quaternions)."
+  },
+  "knownResults": {
+    "proven": [
+      "Moulton plane is non-Desarguesian (gallery desargues-theorem-oq-02) — the failure direction.",
+      "Desargues in P^2 over a field — classical."
+    ],
+    "open": [
+      "Converse: failure of Desargues implies non-division-ring coordinatization (the coordinatization theorem).",
+      "Machine verification of the present forward-direction formalization."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean",
+      "filename": "DesarguesTheoremOQ02OQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "verified": false,
+      "note": "UNVERIFIED — Docker + Aristotle blackout 2026-07-04. Placed outside the Proofs glob so it cannot break the gallery build."
+    }
+  ],
+  "relatedProofs": [
+    "desargues-theorem",
+    "desargues-theorem-oq-01",
+    "desargues-theorem-oq-02",
+    "desargues-theorem-oq-04"
+  ],
+  "references": [
+    "Artin, Geometric Algebra (Desargues <=> division ring)",
+    "Hartshorne, Foundations of Projective Geometry"
+  ],
+  "significance_note": "The Desargues <=> division-ring equivalence is the foundational bridge between synthetic projective geometry and linear algebra, cleanly separated from the Pappus <=> field (commutative) result.",
+  "tags": [
+    "projective-geometry",
+    "incidence-geometry",
+    "non-commutative-algebra",
+    "division-ring",
+    "desargues",
+    "seeker-selected"
+  ]
+}


### PR DESCRIPTION
Follow-up to #34834 (forward direction, merged). Session 2 of ACT on
`desargues-theorem-oq-02-oq-03`, still under a verification blackout
(Docker containerd EIO + Aristotle MCP 404), so the Lean file remains
**UNVERIFIED** — this is research scratch under `research/problems/.../lean/`,
outside the `proofs/Proofs/` glob, and does not touch the gallery build.

**Changes**
- Hand-review fix in the Part III quaternion `example`: `R` was an unpinned
  implicit (all vars `M`-typed, `NormPersp` doesn't capture `R`), so
  `Module ?R (Fin 3 → Quaternion ℝ)` would stall typeclass synthesis on a
  metavariable. Pinned with `Dep (R := Quaternion ℝ) …` / `desargues (R := …)`.
- Recorded the classical converse strategy (minor/major Desargues ⇒
  additive/multiplicative group ⇒ division ring) in `knowledge.md`.
- `state.md` → iteration 2; session-2 log.

No gallery `meta.json` claims are added or changed; nothing here is presented
as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)