### PR TITLE
Research: abel-ruffini-galois-extensions-oq-10 ORIENT — RIGP for Sₙ/Aₙ reduced to Artin fixed-field

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-10/GenericSnAnRealization.draft.lean
+++ b/research/problems/abel-ruffini-galois-extensions-oq-10/GenericSnAnRealization.draft.lean
@@ -1,0 +1,125 @@
+/-
+  DESIGN DRAFT — NOT YET BUILD-VERIFIED. Lives outside the `proofs/Proofs/` glob on
+  purpose: Docker build + Aristotle were both unavailable the session this was written,
+  so it must not enter gallery CI until it compiles. Promote to `proofs/Proofs/` only
+  after a clean `./proofs/scripts/docker-build.sh`.
+
+  Generic / regular realization of Sₙ and Aₙ as Galois groups
+  (abel-ruffini-galois-extensions-oq-10, the Sₙ/Aₙ case of RIGP)
+
+  Idea: the symmetric group Sₙ = Equiv.Perm (Fin n) acts faithfully on the rational
+  function field F = ℚ(x₁,…,xₙ) by permuting the variables. Artin's fixed-field theorem
+  (Mathlib `FixedPoints.toAlgAutMulEquiv`) then hands us
+
+      Sₙ  ≃*  Gal(F / F^{Sₙ}),        F^{Sₙ} = ℚ(e₁,…,eₙ)  (symmetric functions),
+
+  and likewise for the alternating subgroup Aₙ ≤ Sₙ. Both fixed fields are purely
+  transcendental over ℚ, so ℚ is algebraically closed in them and the extensions are
+  *regular* — i.e. these are RIGP realizations, not merely IGP.
+
+  The whole abstract engine is already in Mathlib; the ONLY thing to build is the
+  concrete permutation action on the fraction field (Mathlib ships symmetric polynomials
+  as `∀ e, rename e p = p`, not as fixed points of a `MulSemiringAction`).
+-/
+import Mathlib
+
+open scoped Classical
+open MvPolynomial Equiv
+
+noncomputable section
+
+variable (n : ℕ)
+
+/-- The polynomial ring ℚ[x₁,…,xₙ]. -/
+abbrev P : Type := MvPolynomial (Fin n) ℚ
+
+/-- The rational function field ℚ(x₁,…,xₙ). -/
+abbrev F : Type := FractionRing (MvPolynomial (Fin n) ℚ)
+
+/-! ### Step 1 — the permutation action on the fraction field
+
+`renameEquiv ℚ e` permutes the variables of `P`; `IsFractionRing.ringEquivOfRingEquiv`
+lifts it to `F`. Package the lift as a monoid hom `Perm (Fin n) →* RingAut F`, then turn
+that into a `MulSemiringAction` with `MulSemiringAction.compHom`. -/
+
+/-- The ring automorphism of `F` induced by permuting variables by `e`. -/
+def permAutF (e : Equiv.Perm (Fin n)) : RingAut (F n) :=
+  IsFractionRing.ringEquivOfRingEquiv (K := F n) (L := F n)
+    (MvPolynomial.renameEquiv ℚ e).toRingEquiv
+
+/-- `Perm (Fin n) →* RingAut F`. `map_one'`/`map_mul'` follow from `renameEquiv_refl`
+    and `renameEquiv_trans` plus functoriality of `ringEquivOfRingEquiv`
+    (`IsFractionRing.ringEquivOfRingEquiv_eq`/uniqueness of the fraction-field lift). -/
+def permToAutF : Equiv.Perm (Fin n) →* RingAut (F n) where
+  toFun := permAutF n
+  map_one' := by
+    -- renameEquiv ℚ (1 : Perm) = AlgEquiv.refl  (renameEquiv_refl), lift of refl is refl
+    sorry
+  map_mul' e f := by
+    -- renameEquiv ℚ (e * f) = (renameEquiv ℚ e).trans/comp (renameEquiv ℚ f)  (direction
+    -- via Equiv.Perm.mul_def + renameEquiv_trans); ringEquivOfRingEquiv is functorial
+    -- because the fraction-field extension of a ring hom is unique.
+    sorry
+
+/-- The permutation action of `Sₙ` on `F = ℚ(x₁,…,xₙ)`. -/
+instance permAction : MulSemiringAction (Equiv.Perm (Fin n)) (F n) :=
+  MulSemiringAction.compHom _ (permToAutF n)
+
+/-! ### Step 2 — faithfulness
+
+Distinct permutations act differently already on `P` (`rename e (X i) = X (e i)`), and `P`
+embeds in `F` via `algebraMap`, so the action on `F` is faithful. -/
+
+instance permFaithful : FaithfulSMul (Equiv.Perm (Fin n)) (F n) := by
+  -- e • algebraMap (X i) = algebraMap (X (e i)); if the action is trivial then X (e i)=X i
+  -- for all i, hence e i = i (X injective on Fin n), hence e = 1.
+  sorry
+
+/-! ### Step 3 — Artin ⟹ Sₙ is a Galois group
+
+Everything below is a direct application of `Mathlib/FieldTheory/Fixed.lean`. -/
+
+/-- **Sₙ realized.** `Equiv.Perm (Fin n) ≅ Gal(F / F^{Sₙ})`. -/
+def realizeSn :
+    Equiv.Perm (Fin n) ≃*
+      (F n ≃ₐ[FixedPoints.subfield (Equiv.Perm (Fin n)) (F n)] F n) :=
+  FixedPoints.toAlgAutMulEquiv _ _
+
+/-- `F / F^{Sₙ}` is Galois (from Mathlib's `Normal` + `IsSeparable` + `FiniteDimensional`
+    instances on `FixedPoints.subfield`). -/
+example : IsGalois (FixedPoints.subfield (Equiv.Perm (Fin n)) (F n)) (F n) := inferInstance
+
+/-- The degree of the generic Sₙ extension is `n!`. -/
+theorem finrank_Sn :
+    Module.finrank (FixedPoints.subfield (Equiv.Perm (Fin n)) (F n)) (F n)
+      = Nat.factorial n := by
+  rw [FixedPoints.finrank_eq_card]
+  simp [Fintype.card_perm, Fintype.card_fin]
+
+/-! ### Step 4 — Aₙ realized (same machinery, restricted action)
+
+`alternatingGroup (Fin n) ≤ Perm (Fin n)` inherits the action by
+`MulSemiringAction.compHom _ ((permToAutF n).comp (alternatingGroup (Fin n)).subtype)`,
+and is faithful as a subgroup of a faithful action. -/
+
+instance altAction : MulSemiringAction (alternatingGroup (Fin n)) (F n) :=
+  MulSemiringAction.compHom _
+    ((permToAutF n).comp (alternatingGroup (Fin n)).subtype)
+
+instance altFaithful : FaithfulSMul (alternatingGroup (Fin n)) (F n) := by
+  sorry
+
+/-- **Aₙ realized.** `alternatingGroup (Fin n) ≅ Gal(F / F^{Aₙ})`.
+    `F^{Aₙ} = ℚ(e₁,…,eₙ)(√disc)`. -/
+def realizeAn :
+    alternatingGroup (Fin n) ≃*
+      (F n ≃ₐ[FixedPoints.subfield (alternatingGroup (Fin n)) (F n)] F n) :=
+  FixedPoints.toAlgAutMulEquiv _ _
+
+/-- Degree of the generic Aₙ extension is `n!/2` (for `n ≥ 2`). -/
+theorem finrank_An :
+    Module.finrank (FixedPoints.subfield (alternatingGroup (Fin n)) (F n)) (F n)
+      = Fintype.card (alternatingGroup (Fin n)) := by
+  rw [FixedPoints.finrank_eq_card]
+
+end

--- a/research/problems/abel-ruffini-galois-extensions-oq-10/knowledge.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-10/knowledge.md
@@ -1,0 +1,150 @@
+# abel-ruffini-galois-extensions-oq-10 — Knowledge
+
+## Problem
+
+**Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$.**
+Hilbert (1892) proved every $S_n$ (and via specialization $A_n$) is realizable as
+$\mathrm{Gal}(L/\mathbb{Q})$. The *regular* IGP asks for a **regular** extension
+$L/\mathbb{Q}(t_1,\dots,t_m)$ (equivalently $\mathbb{Q}$ algebraically closed in $L$,
+i.e. the cover is geometrically connected) with $\mathrm{Gal}(L/\mathbb{Q}(t))\cong G$.
+The problem card cites Thompson's rigidity criterion (1984) and Belyi's three‑point
+covers (1979) — but those are the machinery for the **general** RIGP. For the two
+specific groups named here, $S_n$ and $A_n$, RIGP has a **classical, elementary
+resolution** via the *generic polynomial*, and that resolution is what is formalizable
+in today's Mathlib.
+
+## Summary
+
+**Central finding (Session 1, ORIENT).** Both the $S_n$ and the $A_n$ halves of RIGP
+reduce to the **same** Mathlib construction: Artin's fixed‑field theorem applied to the
+permutation action on the rational function field $\mathbb{Q}(x_1,\dots,x_n)$.
+
+- $S_n$ acts faithfully on $F := \mathbb{Q}(x_1,\dots,x_n)$ by permuting the variables.
+- The fixed field $F^{S_n}$ is the field of **symmetric** rational functions
+  $\mathbb{Q}(e_1,\dots,e_n)$ (elementary symmetric functions), which is purely
+  transcendental over $\mathbb{Q}$ — hence $\mathbb{Q}$ is algebraically closed in it,
+  so the extension $F/F^{S_n}$ is **regular**. This is the generic $S_n$ extension and
+  *is* the standard RIGP‑for‑$S_n$ proof.
+- Artin ⟹ $F/F^{S_n}$ is finite Galois with $\mathrm{Gal}\cong S_n$ and
+  $[F:F^{S_n}] = n!$.
+- $A_n \le S_n$ acts on the same $F$; Artin gives $F/F^{A_n}$ Galois with group $A_n$,
+  where $F^{A_n} = \mathbb{Q}(e_1,\dots,e_n)(\sqrt{\mathrm{disc}})$ (still purely
+  transcendental over $\mathbb{Q}$, so regular). This is RIGP for $A_n$.
+
+So **the Belyi/rigidity machinery in the problem card is unnecessary for $S_n$ and
+$A_n$**; the elementary generic‑polynomial route suffices and is Mathlib‑reachable.
+
+## The exact Mathlib API path
+
+The abstract engine is already in Mathlib (`Mathlib/FieldTheory/Fixed.lean`), for any
+finite group $G$ acting **faithfully** on a field $F$:
+
+| Mathlib declaration | Gives |
+|---|---|
+| `FixedPoints.subfield G F : Subfield F` | the fixed field $F^G$ |
+| `instance : Normal (FixedPoints.subfield G F) F` | normality |
+| `instance : Algebra.IsSeparable (FixedPoints.subfield G F) F` | separability |
+| `instance : FiniteDimensional (FixedPoints.subfield G F) F` | finiteness ⟹ `IsGalois` |
+| `FixedPoints.finrank_eq_card [Fintype G] [FaithfulSMul G F]` | $[F:F^G] = \lvert G\rvert$ |
+| `FixedPoints.toAlgAutMulEquiv [Finite G] [FaithfulSMul G F] : G ≃* (F ≃ₐ[F^G] F)` | **the Galois‑group isomorphism** |
+
+`toAlgAutMulEquiv` is the headline: it produces $G \cong \mathrm{Gal}(F/F^G)$ as a group
+isomorphism, directly realizing $G$ as a Galois group. Instantiating $G = S_n$ (or $A_n$)
+and $F = \mathbb{Q}(x_1,\dots,x_n)$ gives the theorem.
+
+## The single infrastructure gap
+
+Mathlib does **not** ship a `MulSemiringAction (Equiv.Perm (Fin n)) (MvPolynomial (Fin n) ℚ)`
+(symmetric polynomials are defined pointwise as `∀ e, rename e p = p`, not as fixed
+points of an action). So the only missing piece is:
+
+**Build the permutation action on $F = \mathrm{FractionRing}(\mathrm{MvPolynomial}\,(\mathrm{Fin}\,n)\,\mathbb{Q})$.**
+
+All the ingredients exist:
+
+1. `MvPolynomial.renameEquiv ℚ e : MvPolynomial (Fin n) ℚ ≃ₐ[ℚ] MvPolynomial (Fin n) ℚ`
+   for `e : Fin n ≃ Fin n`, with functoriality lemmas `renameEquiv_refl`,
+   `renameEquiv_trans` (`Mathlib/Algebra/MvPolynomial/Rename.lean`).
+2. Extend each `renameEquiv ℚ e` to the fraction field with
+   `IsFractionRing.ringEquivOfRingEquiv` (or the algebra version
+   `IsFractionRing.fieldEquivOfAlgEquiv`, `Mathlib/RingTheory/Localization/FractionRing.lean`).
+3. Assemble a monoid hom `Equiv.Perm (Fin n) →* RingAut F` and turn it into an action via
+   `MulSemiringAction.compHom` (`RingAut R` acts on `R` by
+   `Mathlib/Algebra/Ring/Action/End.lean`).
+4. Faithfulness `FaithfulSMul (Equiv.Perm (Fin n)) F`: reduces to faithfulness on
+   `MvPolynomial` (`rename` sends `X i ↦ X (e i)`, injective on the generators), which
+   embeds in `F`.
+
+**Size estimate:** ~120–180 lines, all standard API — a clean **BUILD** target, not a
+blocker. The only real proof obligations are the two monoid‑hom functoriality proofs
+(map_one/map_mul for the extension) and faithfulness.
+
+## Infrastructure Assessment
+
+- **Needed:** perm `MulSemiringAction` on `FractionRing (MvPolynomial (Fin n) ℚ)` +
+  faithfulness. **Decision: BUILD** (~150 lines).
+- **NOT needed:** Belyi maps, Thompson rigidity, Hilbert irreducibility, algebraic
+  geometry of covers. (Those are for RIGP of *general* groups; irrelevant to $S_n$/$A_n$.)
+- **Regularity ("R" in RIGP):** an extra observation that $F^{S_n}=\mathbb{Q}(e_1,\dots,e_n)$
+  and $F^{A_n}=\mathbb{Q}(e)(\sqrt{\mathrm{disc}})$ are purely transcendental over
+  $\mathbb{Q}$, so $\mathbb{Q}$ is algebraically closed in them. Formalizing the
+  *regularity* claim itself is a secondary target (Mathlib has limited "regular
+  extension" API); the core Galois‑group realization does not depend on it.
+
+## Relation to existing gallery work
+
+- `AbelRuffiniGaloisExtensionsOQ01.lean` already realizes **$S_5$** concretely and
+  *unconditionally* over $\mathbb{Q}$ via the specific quintic $X^5-4X+2$
+  (`galEquivS5 : (X⁵−4X+2).Gal ≃* Equiv.Perm (Fin 5)`). That is the *specialized*
+  (ordinary IGP) picture for one $n$; the present roadmap gives the **generic/regular**
+  picture for **all $n$** simultaneously via the function field.
+- The 68‑file `AbelRuffini*` family supplies solvability/`Equiv.Perm` lemmas but the
+  fixed‑field route here is self‑contained on top of `Mathlib/FieldTheory/Fixed.lean`.
+
+## Status
+
+- **Phase:** ORIENT (feasibility + full API‑cited roadmap; no verified Lean committed).
+- **Build/verify blackout:** Docker build unavailable and Aristotle MCP returns 404
+  ("Resource not found") this session, so no new `.lean` was added to the built
+  `proofs/Proofs/` glob (avoids risking gallery CI with unverifiable code). A design
+  draft lives at `GenericSnAnRealization.draft.lean` in this directory (non‑globbed).
+
+## Sessions
+
+### Session 2026-07-04 (Session 1) — ORIENT
+
+**Mode:** FRESH · **Outcome:** progress (ORIENT roadmap)
+
+**What I did**
+- Surveyed the `AbelRuffini*` family (68 files); confirmed OQ‑01 realizes $S_5$
+  concretely but no generic/all‑$n$ or $A_n$ realization exists.
+- Read `Mathlib/FieldTheory/Fixed.lean`; identified `FixedPoints.toAlgAutMulEquiv`,
+  `finrank_eq_card`, and the `Normal`/`IsSeparable`/`FiniteDimensional` instances as the
+  complete abstract Artin engine.
+- Reduced **both** $S_n$ and $A_n$ RIGP to one construction (perm action on
+  $\mathbb{Q}(x_1,\dots,x_n)$ + Artin), and pinned the *single* missing piece to the
+  perm `MulSemiringAction` on the fraction field (~150 lines, all API present:
+  `renameEquiv`, `IsFractionRing.ringEquivOfRingEquiv`/`fieldEquivOfAlgEquiv`,
+  `MulSemiringAction.compHom`, `RingAut` action).
+- Noted the **regularity** observation (fixed fields purely transcendental over
+  $\mathbb{Q}$) that makes these *regular* realizations, resolving the "R" in RIGP.
+
+**Key findings**
+- The Belyi/Thompson‑rigidity framing on the problem card is a red herring for the
+  specific groups $S_n,A_n$; they have the elementary generic‑polynomial resolution.
+- Artin's fixed‑field theorem in current Mathlib is strong enough to realize *any* finite
+  group acting faithfully on a field — the whole difficulty is producing the concrete
+  faithful action, here the variable‑permutation action on rational functions.
+
+**Files**
+- `research/problems/abel-ruffini-galois-extensions-oq-10/knowledge.md` (this file)
+- `research/problems/abel-ruffini-galois-extensions-oq-10/GenericSnAnRealization.draft.lean`
+- `src/data/research/problems/abel-ruffini-galois-extensions-oq-10.json` (knowledge fields)
+
+**Next steps**
+1. When build/Aristotle access returns: implement `permToAutF` (monoid hom
+   `Perm (Fin n) →* RingAut F`) and `FaithfulSMul`, then state `realizeSn`/`realizeAn`
+   via `toAlgAutMulEquiv`; promote the draft into `proofs/Proofs/` and build.
+2. Prove `[F:F^{S_n}] = n!` via `finrank_eq_card` + `Fintype.card_perm`.
+3. Secondary: formalize regularity ($\mathbb{Q}$ algebraically closed in the fixed field)
+   to upgrade "IGP" to "RIGP" explicitly.

--- a/research/problems/abel-ruffini-galois-extensions-oq-10/problem.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-10/problem.md
@@ -1,0 +1,39 @@
+# Problem: Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$ — Thompson's rigi...
+
+## Statement
+
+### Plain Language
+AVAILABLE: **Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$ — Thompson's rigidity criterion (1984) and Belyi's three-point cover construction (1979)**: Hilbert (1892, reference above) proved every $S_n$ is realizable as $\mathrm{Gal}(L/\mathbb{Q})$ via specialization of the generic polynomial, but the **regular inverse Galois problem** asks more: which ….
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 5
+tags:
+  - abel-ruffini
+  - galois-theory
+  - group-theory
+  - seeker-selected
+  - solvability
+  - symmetric-groups
+```
+
+**Significance**: 7/10
+**Tractability**: 5/10
+
+## Why This Matters
+
+1. **Research value** - AVAILABLE: **Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$ — Thompson's rigidity criterion (1984) and Belyi's three-point cover construction (1979)**: Hilbert (1892, reference above) proved every $S_n$ is realizable as $\mathrm{Gal}(L/\mathbb{Q})$ via specialization of the generic polynomial, but the **regular inverse Galois problem** asks more: which …
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/abel-ruffini-galois-extensions-oq-10/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-10/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: ORIENT
+**Since**: 2026-07-04T19:40:29-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -27117,6 +27117,12 @@
       "lastAudited": "2026-07-02T01:18:34Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-07-05T02:27:44Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-10.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-10.json
@@ -1,0 +1,346 @@
+{
+  "slug": "abel-ruffini-galois-extensions-oq-10",
+  "title": "Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$ — Thompson's rigi...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: **Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$ — Thompson's rigidity criterion (1984) and Belyi's three-point cover construction (1979)**: Hilbert (1892, reference above) proved every $S_n$ is realizable as $\\mathrm{Gal}(L/\\mathbb{Q})$ via specialization of the generic polynomial, but the **regular inverse Galois problem** asks more: which ….",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-07-02T23:52:36.440Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT: RIGP for Sₙ AND Aₙ reduced to one Mathlib construction (Artin FixedPoints.toAlgAutMulEquiv on the perm action on ℚ(x₁..xₙ)); sole gap = building the perm MulSemiringAction on the fraction field (~150 lines, all API present). Belyi/rigidity unnecessary for these groups. No verified Lean committed (Docker+Aristotle blackout); design draft written non-globbed.",
+    "builtItems": [
+      "ORIENT roadmap + API map committed: research/problems/abel-ruffini-galois-extensions-oq-10/knowledge.md",
+      "Design draft (non-globbed, NOT build-verified): research/problems/abel-ruffini-galois-extensions-oq-10/GenericSnAnRealization.draft.lean — permToAutF, permAction, realizeSn/realizeAn via FixedPoints.toAlgAutMulEquiv, finrank_Sn=n!"
+    ],
+    "insights": [
+      "Both the Sₙ and Aₙ halves of RIGP reduce to ONE construction: Artin fixed-field theorem (Mathlib FixedPoints.toAlgAutMulEquiv) applied to the variable-permutation action of Perm(Fin n) on the rational function field ℚ(x₁..xₙ).",
+      "Fixed field F^{Sₙ} = ℚ(e₁..eₙ) (elementary symmetric functions) is purely transcendental over ℚ, so ℚ is algebraically closed in it ⟹ the generic Sₙ extension is REGULAR, resolving the R in RIGP for Sₙ. Same for Aₙ with F^{Aₙ}=ℚ(e)(√disc).",
+      "The Belyi three-point-cover / Thompson-rigidity machinery cited on the problem card is only needed for RIGP of GENERAL groups; for the specific groups Sₙ and Aₙ the elementary generic-polynomial route suffices and is Mathlib-reachable today.",
+      "Gallery OQ-01 (AbelRuffiniGaloisExtensionsOQ01) realizes S₅ concretely over ℚ via X⁵−4X+2 (specialized/ordinary IGP, one n); the fixed-field route gives the generic/regular picture for ALL n at once, plus Aₙ."
+    ],
+    "mathlibGaps": [
+      "Mathlib ships NO MulSemiringAction (Equiv.Perm (Fin n)) (MvPolynomial (Fin n) ℚ): symmetric polys are defined pointwise as ∀e, rename e p = p (RingTheory/MvPolynomial/Symmetric/Defs.lean), not as fixed points of a group action.",
+      "No automatic transport of a ring MulSemiringAction to a Localization/FractionRing; the perm action on ℚ(x₁..xₙ) must be built by hand (~150 lines) via renameEquiv + IsFractionRing.ringEquivOfRingEquiv + MulSemiringAction.compHom.",
+      "Mathlib has limited regular-extension (ℚ alg-closed-in-L) API, so formalizing the REGULARITY claim itself (vs the Galois-group realization) is a separate secondary target."
+    ],
+    "nextSteps": [
+      "When Docker build / Aristotle access returns: implement permToAutF map_one/map_mul (renameEquiv_refl/_trans + ringEquivOfRingEquiv functoriality) and FaithfulSMul, then promote draft into proofs/Proofs/ and docker-build.",
+      "Prove [F:F^{Sₙ}]=n! via FixedPoints.finrank_eq_card + Fintype.card_perm (already drafted as finrank_Sn).",
+      "Secondary: formalize regularity (ℚ algebraically closed in ℚ(e₁..eₙ)) to upgrade IGP→RIGP explicitly."
+    ]
+  },
+  "tags": [
+    "abel-ruffini",
+    "galois-theory",
+    "group-theory",
+    "seeker-selected",
+    "solvability",
+    "symmetric-groups"
+  ],
+  "relatedProofs": [
+    "abel-ruffini",
+    "abel-ruffini-galois-extensions",
+    "abel-ruffini-galois-extensions-oq-01",
+    "abel-ruffini-galois-extensions-oq-02",
+    "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "abel-ruffini-galois-extensions-oq-03",
+    "abel-ruffini-galois-extensions-oq-03-oq-01",
+    "abel-ruffini-galois-extensions-oq-04",
+    "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "abel-ruffini-galois-extensions-oq-04-oq-01-oq-01",
+    "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "abel-ruffini-galois-extensions-oq-05",
+    "abel-ruffini-galois-extensions-oq-05-oq-01",
+    "abel-ruffini-galois-extensions-oq-05-oq-02",
+    "abel-ruffini-galois-extensions-oq-07",
+    "abel-ruffini-galois-extensions-oq-11"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-07-03T06:52:01.409Z",
+  "lastUpdate": "2026-07-03T06:52:01.409Z",
+  "significance": 7,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "filename": "AbelRuffiniGaloisExtensions.lean",
+      "lineCount": 535,
+      "theoremCount": 57,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 22,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ02.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ02.lean",
+      "lineCount": 202,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ02OQ01.lean",
+      "lineCount": 130,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ03.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ03.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ03OQ01.lean",
+      "lineCount": 774,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 11,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04.lean",
+      "lineCount": 235,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04OQ01.lean",
+      "lineCount": 122,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04OQ02.lean",
+      "lineCount": 117,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ04OQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 7,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ05.lean",
+      "lineCount": 215,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
+      "lineCount": 202,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ02.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ05OQ02.lean",
+      "lineCount": 98,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06.lean",
+      "lineCount": 531,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean",
+      "lineCount": 666,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirection.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean",
+      "lineCount": 184,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionAssembly.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean",
+      "lineCount": 87,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionMainAssembly.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean",
+      "lineCount": 280,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean",
+      "lineCount": 271,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle.lean",
+      "lineCount": 48,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
+      "lineCount": 1974,
+      "theoremCount": 23,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 7,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ11.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ11.lean",
+      "lineCount": 139,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ11.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
**abel-ruffini-galois-extensions-oq-10** — Regular inverse Galois problem (RIGP) for $S_n$ and $A_n$. Phase: OBSERVE → **ORIENT**. Knowledge: EMPTY → **MODERATE** (12 items).

## Central finding
Both the $S_n$ and $A_n$ halves of RIGP reduce to a **single Mathlib construction** — Artin's fixed-field theorem (`FixedPoints.toAlgAutMulEquiv`) applied to the variable-permutation action of `Perm (Fin n)` on the rational function field $\mathbb{Q}(x_1,\dots,x_n)$:

- $S_n \cong \mathrm{Gal}(F / F^{S_n})$ with $F^{S_n} = \mathbb{Q}(e_1,\dots,e_n)$ (symmetric functions), $[F:F^{S_n}] = n!$.
- $A_n \cong \mathrm{Gal}(F / F^{A_n})$ with $F^{A_n} = \mathbb{Q}(e)(\sqrt{\mathrm{disc}})$.
- Both fixed fields are purely transcendental over $\mathbb{Q}$ ⟹ $\mathbb{Q}$ algebraically closed in them ⟹ the realizations are **regular** (the "R" in RIGP).

**The Belyi / Thompson-rigidity machinery cited on the problem card is unnecessary for these two groups** — it is the method for RIGP of *general* groups. $S_n$ and $A_n$ admit the elementary generic-polynomial route, which is reachable in today's Mathlib.

## Sole infrastructure gap (BUILD, ~150 lines)
Mathlib ships no `MulSemiringAction (Perm (Fin n)) (MvPolynomial (Fin n) ℚ)` (symmetric polys are defined pointwise, not as fixed points), and does not auto-transport ring actions to localizations. The one missing piece is the perm action on $F = \mathrm{FractionRing}(\mathrm{MvPolynomial}\,(\mathrm{Fin}\,n)\,\mathbb{Q})$ + faithfulness. All API is present: `renameEquiv`, `IsFractionRing.ringEquivOfRingEquiv`, `MulSemiringAction.compHom`, the `RingAut` action, and `FixedPoints.{toAlgAutMulEquiv, finrank_eq_card}`.

## What's in this PR
- `knowledge.md` — full ORIENT roadmap with exact Mathlib API citations.
- `GenericSnAnRealization.draft.lean` — a **non-globbed design draft** (skeleton: `permToAutF`, `permAction`, `realizeSn`/`realizeAn`, `finrank_Sn = n!`) with the two functoriality/faithfulness proofs left as `sorry`.
- Updated problem JSON knowledge fields; state.md phase → ORIENT.

## Honesty note
**No verified Lean is committed to the built `proofs/Proofs/` glob.** Docker build and the Aristotle MCP (404 this session) were both unavailable, so the draft is deliberately kept out of CI until it compiles. This is an ORIENT deliverable — a concrete, API-cited formalization plan — not a verified proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)