### PR TITLE
Research: algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01 — generic dense-countable Fσ-not-Gδ theorem (build-pending)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
@@ -1,0 +1,89 @@
+/-
+# Dense countable sets are `Fσ` but not `Gδ` in perfect Polish spaces
+
+The parent entry `algebraic-numbers-countable-oq-02-oq-03-oq-02` proves the *concrete*
+dichotomy in `ℝ`: the algebraic reals are an `Fσ` set that is not `Gδ`, while the
+transcendentals are a dense `Gδ` that is not `Fσ`.  The engine of the "not `Gδ`" half is
+pure Baire category and has nothing to do with `ℝ` or algebraicity:
+
+> a dense countable set `D` in a nonempty perfect Polish (indeed any nonempty perfect
+> `T1` Baire) space is `Fσ` but **not** `Gδ`,
+
+because `Dᶜ` is then a *dense* `Gδ` (the countable `D` is meagre in a perfect Baire
+space, so its complement is comeagre, hence a dense `Gδ`), and two disjoint dense `Gδ`
+sets cannot coexist in a nonempty Baire space (their intersection would be dense yet
+empty).
+
+This file records that abstraction once and for all, quantified over an arbitrary
+topological space carrying the minimal instances that make the argument run
+(`T1Space`, `PerfectSpace`, `BaireSpace`, `Nonempty`), and recovers the classical
+`ℚ ⊆ ℝ` instance as a one-line corollary.  Every step is a direct assembly of the
+already-verified parent lemmas:
+
+* `AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_of_countable` — a countable set in a `T1`
+  space is `Fσ` (the union of its closed singletons);
+* `AlgebraicNumbersCountableOQ02OQ03OQ02.compl_countable_isDenseGδ` — the complement of
+  a countable set in a perfect `T1` Baire space is a dense `Gδ`;
+* `AlgebraicNumbersCountableOQ02OQ03OQ02.not_isGδ_of_dense_of_disjoint_denseGδ` — two
+  disjoint dense `Gδ` sets are impossible in a nonempty Baire space.
+
+## Status: build-pending
+
+Written during a dual-tool outage (Docker image store `input/output error`; Aristotle
+backend `Resource not found`), so it has not been machine-checked this session.  It is a
+short assembly of merged, verified lemmas whose signatures were re-checked by inspection;
+please build-verify with `./proofs/scripts/docker-build.sh
+Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02OQ01` before/at merge.
+
+## References
+- Kechris, *Classical Descriptive Set Theory*, §8 (Borel hierarchy, Baire category).
+- Oxtoby, *Measure and Category*, Ch. 1–2.
+-/
+import Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02
+import Proofs.AlgebraicRealsMeagerDenseGDeltaOQ01
+import Mathlib.Topology.Instances.Rat
+import Mathlib.Tactic
+
+open Set Topology
+open AlgebraicRealsMeagerDenseGDeltaOQ01 AlgebraicNumbersCountableOQ02OQ03OQ02
+
+namespace AlgebraicNumbersCountableOQ02OQ03OQ02OQ01
+
+/-- **Dense countable ⇒ `Fσ` and not `Gδ` (abstract form).**
+In any nonempty perfect `T1` Baire space, a countable *dense* set `D` is `Fσ` but not
+`Gδ`.  The `Fσ` part is `isFσ_of_countable` (union of closed singletons); the "not `Gδ`"
+part is Baire category: if `D` were `Gδ` then `D` and `Dᶜ` would be two *disjoint dense
+`Gδ`* sets (`Dᶜ` is a dense `Gδ` by `compl_countable_isDenseGδ`), which
+`not_isGδ_of_dense_of_disjoint_denseGδ` rules out. -/
+theorem dense_countable_isFσ_and_not_isGδ
+    {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X]
+    [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) :
+    IsFσ D ∧ ¬ IsGδ D := by
+  refine ⟨isFσ_of_countable hcount, ?_⟩
+  intro hGδ
+  obtain ⟨hgc, hdc⟩ := compl_countable_isDenseGδ hcount
+  exact not_isGδ_of_dense_of_disjoint_denseGδ hdense hGδ hgc hdc disjoint_compl_right
+
+/-- A dense countable set in a nonempty perfect `T1` Baire space is `Fσ`. -/
+theorem isFσ_of_dense_countable
+    {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X]
+    [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) : IsFσ D :=
+  (dense_countable_isFσ_and_not_isGδ hcount hdense).1
+
+/-- A dense countable set in a nonempty perfect `T1` Baire space is **not** `Gδ`. -/
+theorem not_isGδ_of_dense_countable
+    {X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X]
+    [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) : ¬ IsGδ D :=
+  (dense_countable_isFσ_and_not_isGδ hcount hdense).2
+
+/-! ### The classical `ℚ ⊆ ℝ` instance -/
+
+/-- **`ℚ` is `Fσ` but not `Gδ` in `ℝ`.** The rationals are the range of the (countable,
+dense-range) coercion `ℚ → ℝ`, and `ℝ` is a nonempty perfect `T1` Baire space, so the
+abstract theorem applies verbatim. This is the classical fact that the rationals sit at
+level exactly `Σ⁰₂ ∖ Π⁰₂` of the Borel hierarchy. -/
+theorem rationals_isFσ_and_not_isGδ :
+    IsFσ (Set.range ((↑) : ℚ → ℝ)) ∧ ¬ IsGδ (Set.range ((↑) : ℚ → ℝ)) :=
+  dense_countable_isFσ_and_not_isGδ (Set.countable_range _) Rat.denseRange_cast
+
+end AlgebraicNumbersCountableOQ02OQ03OQ02OQ01

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md
@@ -140,3 +140,39 @@ None of these is a mathematical gap; all are surface Lean-elaboration checks.
 ### Next Steps
 Drop the scratch file into `Proofs/`, build once on Docker recovery, ship gallery entry. See
 "Next Steps" above.
+
+## Session 2026-07-04 (Researcher-5) — generic theorem CREATED as a real file (prior scratch was lost)
+
+**Mode**: REVISIT · **Outcome**: progress (Lean file created, build-pending)
+
+### What I did
+- The earlier "complete ~6-line proof" existed only as a scratch draft written to the main
+  checkout and was **never committed** (lost on a branch reset). Recreated it as a proper,
+  committed file: `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean`.
+- Content (0 sorries by construction): `dense_countable_isFσ_and_not_isGδ` (abstract: nonempty
+  perfect `T1` Baire space, countable dense `D` ⇒ `IsFσ D ∧ ¬ IsGδ D`), split accessors
+  `isFσ_of_dense_countable` / `not_isGδ_of_dense_countable`, and the corollary
+  `rationals_isFσ_and_not_isGδ` (`ℚ ⊆ ℝ`).
+
+### Assembly (all four inputs are MERGED, verified lemmas — re-checked by inspection)
+- `AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_of_countable {X}[T1Space X]{s}(hs:s.Countable):IsFσ s`
+  (`IsFσ` is a *project* def in that file — Mathlib has **no** `IsFσ` predicate).
+- `AlgebraicNumbersCountableOQ02OQ03OQ02.compl_countable_isDenseGδ {X}[T1Space][PerfectSpace]
+  [BaireSpace]{s}(hs:s.Countable):IsGδ sᶜ ∧ Dense sᶜ`.
+- `…OQ02OQ03OQ02.not_isGδ_of_dense_of_disjoint_denseGδ {X}[BaireSpace][Nonempty]{s t}
+  (Dense s)(IsGδ s)(IsGδ t)(Dense t)(Disjoint s t):False` — apply with `t = sᶜ`,
+  `disjoint_compl_right`.
+- `Rat.denseRange_cast : DenseRange ((↑):ℚ→𝕜)` (ordered-field generic, in
+  `Mathlib.Topology.Algebra.Order.Archimedean`; `DenseRange f ≡ Dense (range f)` by defn) +
+  `Set.countable_range` (`[Countable ℚ]`) for the corollary. `PerfectSpace ℝ` resolves via the
+  normed-field/module instance (`Mathlib/Topology/Algebra/Module/PerfectSpace.lean`).
+
+### Blocker (unchanged)
+Dual-tool blackout live this session (Docker containerd `input/output error`; Aristotle
+`Resource not found`). File is BUILD-PENDING — NOT machine-verified. Did NOT create gallery
+`meta.json` (would require a verified status we cannot certify). Ship as a research PR; deployer
+build gates it.
+
+### Files Modified
+- proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean (new)
+- research/problems/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/knowledge.md


### PR DESCRIPTION
## Summary

Adds the **abstract** descriptive-set-theory lemma that the parent `ℝ`-specific entries were instances of:

> In any nonempty **perfect `T1` Baire** space, every **countable dense** set `D` is `Fσ` but **not** `Gδ`.

New file `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean` (0 sorries by construction):

- `dense_countable_isFσ_and_not_isGδ` — the abstract theorem;
- `isFσ_of_dense_countable`, `not_isGδ_of_dense_countable` — split accessors;
- `rationals_isFσ_and_not_isGδ` — the classical `ℚ ⊆ ℝ` corollary (rationals are `Σ⁰₂ ∖ Π⁰₂`).

## Proof

Pure assembly of already-merged, verified parent lemmas:

- **Fσ**: `isFσ_of_countable` (a countable set in a `T1` space is the union of its closed singletons). `IsFσ` here is a *project* predicate (`AlgebraicRealsMeagerDenseGDeltaOQ01`) — Mathlib has no `IsFσ`.
- **not Gδ** (Baire category): if `D` were `Gδ`, then `D` and `Dᶜ` would be two *disjoint dense `Gδ`* sets — `Dᶜ` is a dense `Gδ` by `compl_countable_isDenseGδ` (a countable set is meagre in a perfect Baire space) — which `not_isGδ_of_dense_of_disjoint_denseGδ` forbids in a nonempty Baire space.
- **ℚ corollary**: `Rat.denseRange_cast` (`DenseRange ((↑):ℚ→ℝ) ≡ Dense (range …)`) + `Set.countable_range`; `PerfectSpace ℝ` / `BaireSpace ℝ` resolve automatically.

## Note on provenance

A prior session wrote this proof only as an uncommitted scratch draft on the main checkout, which was lost on a branch reset. This PR recreates it as a real, committed file, so the abstraction is finally in the tree.

## Verification status

⚠️ **Build-pending.** Written during a dual-tool outage (Docker image store `input/output error`; Aristotle backend `Resource not found`), so not machine-checked this session. All four assembled lemma signatures + instance availability (`PerfectSpace ℝ`, `Rat.denseRange_cast`, `Set.countable_range`, `disjoint_compl_right`) were re-verified by inspection against the merged parent files and the Mathlib source. Please build-verify with `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02OQ01` before/at merge. No gallery `meta.json` is added (that would require a verified status this session cannot certify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)