### PR TITLE
Enrich Vahlen–Capelli Criterion: overview, sections, conclusion, 8 annotations

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 65, "endLine": 71 },
+    "type": "context",
+    "title": "Imports: Kummer extensions and geometric sums",
+    "content": "The proof rests on two Mathlib pillars. `Mathlib.FieldTheory.KummerExtension` supplies the odd-exponent half of the criterion (`X_pow_sub_C_irreducible_iff_forall_prime_of_odd`) and is exactly the file whose even-case `TODO` this entry targets. `Mathlib.Algebra.Ring.GeomSum` supplies the factorisation `x − y ∣ xⁿ − yⁿ` (`sub_dvd_pow_sub_pow`) used for the condition-(1) obstruction. Everything lives in the `Polynomial` namespace, so `X` and `C` denote the indeterminate and the constant-coefficient embedding.",
+    "mathContext": "$K[X]$ with $X$ the indeterminate and $C : K \\to K[X]$ the constant embedding, $C(a)$ the degree-0 polynomial $a$.",
+    "significance": "context",
+    "relatedConcepts": ["Kummer extension", "polynomial ring", "geometric sum factorisation"],
+    "prerequisites": ["field theory", "polynomial rings"]
+  },
+  {
+    "id": "ann-predicate",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 77, "endLine": 85 },
+    "type": "definition",
+    "title": "The Vahlen–Capelli condition as a predicate",
+    "content": "`VahlenCapelliCond K n a` packages the two-part criterion into a reusable `Prop`. Condition (1) — `a` is not a `p`-th power for any prime `p ∣ n` — is the naive obstruction familiar from Eisenstein arguments. Condition (2) — if `4 ∣ n` then `a` is never of the form `−4b⁴` — is the subtle extra content that appears only in characteristic-free even theory. Encoding the criterion as a first-class predicate lets both `vahlen_capelli_odd` and the full `vahlen_capelli` share one statement, and makes the odd-case collapse (condition (2) becomes vacuous when `4 ∤ n`) a proof about the predicate rather than a restatement.",
+    "mathContext": "$\\bigl(\\forall p\\text{ prime},\\, p \\mid n \\Rightarrow a \\notin K^p\\bigr) \\wedge \\bigl(4 \\mid n \\Rightarrow a \\notin -4K^4\\bigr)$",
+    "significance": "key",
+    "relatedConcepts": ["p-th power obstruction", "binomial irreducibility", "Kummer theory"],
+    "prerequisites": ["divisibility", "field theory"]
+  },
+  {
+    "id": "ann-sophie-germain",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "insight",
+    "title": "The Sophie Germain identity — engine of condition (2)",
+    "content": "The single most important algebraic fact in the whole file: `u⁴ + 4v⁴` is never irreducible over any commutative ring because it factors into two quadratics. Discovered by Sophie Germain around 1825 in her work on Fermat's Last Theorem, this identity is *why* condition (2) exists at all. Setting `u = X^m`, `v = C b` turns it into a genuine polynomial factorisation; without it, `−4·K⁴` would be an inexplicable special case. That Lean closes it with a bare `ring` belies its mathematical weight — the whole even/odd asymmetry of binomial irreducibility flows from these four terms.",
+    "mathContext": "$u^4 + 4v^4 = (u^2 - 2uv + 2v^2)(u^2 + 2uv + 2v^2)$",
+    "significance": "key",
+    "relatedConcepts": ["Sophie Germain identity", "Aurifeuillian factorisation", "sum of two squares"],
+    "prerequisites": ["commutative ring", "polynomial algebra"]
+  },
+  {
+    "id": "ann-factor-capelli",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 105, "endLine": 118 },
+    "type": "technique",
+    "title": "Lifting Sophie Germain to the polynomial ring",
+    "content": "`factor_capelli` specialises the identity to `u = X^m`. The one non-`ring` step is the rewrite `X^{4m} = (X^m)⁴`, done via `pow_mul` and commutativity of `4 * m`; once the exponent is folded into the base, `ring` closes the rest. The result is an explicit split of `X^{4m} + 4(C b)⁴` into two degree-`2m` polynomials. This is the polynomial incarnation of the Capelli obstruction: whenever the radicand equals `−4b⁴` and `4 ∣ n`, the binomial visibly factors.",
+    "mathContext": "$X^{4m} + 4(Cb)^4 = \\bigl((X^m)^2 - 2(Cb)X^m + 2(Cb)^2\\bigr)\\bigl((X^m)^2 + 2(Cb)X^m + 2(Cb)^2\\bigr)$",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial factorisation", "exponent manipulation"],
+    "prerequisites": ["polynomial rings", "power laws"]
+  },
+  {
+    "id": "ann-capelli-dvd",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 120, "endLine": 133 },
+    "type": "technique",
+    "title": "Turning the factorisation into a proper divisor",
+    "content": "Two small lemmas convert the algebraic identity into a reducibility witness. `C_neg_four_mul_pow` is pure bookkeeping — pushing `C` through negation, multiplication and powers so that `X^{4m} − C(−4b⁴)` becomes `X^{4m} + 4(C b)⁴`. Then `capelli_factor_dvd` exhibits the first quadratic factor as an explicit divisor via `sub_neg_eq_add` and `factor_capelli`. Because that factor has degree `2m`, strictly between `0` and `4m` for `m ≥ 1`, its existence proves `X^n − C a` is reducible — establishing the *necessity* of condition (2).",
+    "mathContext": "$\\bigl((X^m)^2 - 2(Cb)X^m + 2(Cb)^2\\bigr) \\mid \\bigl(X^{4m} - C(-4b^4)\\bigr)$",
+    "significance": "supporting",
+    "relatedConcepts": ["proper divisor", "reducibility witness", "constant embedding"],
+    "prerequisites": ["divisibility in polynomial rings"]
+  },
+  {
+    "id": "ann-power-obstruction",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 139, "endLine": 151 },
+    "type": "technique",
+    "title": "The p-th power obstruction — necessity of condition (1)",
+    "content": "`obstruction_pow_dvd` handles the other necessity direction. If `a = cᵖ` is a perfect `p`-th power with `p ∣ n` (`n = pm`), then `X^m − C c` divides `X^n − C a`. The proof mirrors `factor_capelli`: rewrite `X^{pm} = (X^m)ᵖ`, push `C` through the power with `map_pow`, then invoke the elementary `sub_dvd_pow_sub_pow` (`x − y ∣ xⁿ − yⁿ`). For a prime `p ∣ n` the divisor has degree `m = n/p`, again strictly interior, so it witnesses reducibility. Together with `capelli_factor_dvd` this proves the full contrapositive: failing either condition forces a proper factor.",
+    "mathContext": "$(X^m - Cc) \\mid (X^{pm} - C(c^p)), \\quad \\text{since } x - y \\mid x^p - y^p$",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric sum", "perfect power", "reducibility witness"],
+    "prerequisites": ["divisibility", "geometric series identity"]
+  },
+  {
+    "id": "ann-odd-case",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 157, "endLine": 170 },
+    "type": "concept",
+    "title": "The odd case — a complete iff via Mathlib",
+    "content": "For odd `n`, condition (2) is vacuous: an odd number is never divisible by 4, proved by `omega` after decomposing `n = 2k+1`. So `VahlenCapelliCond K n a` collapses to condition (1), which is precisely Mathlib's `X_pow_sub_C_irreducible_iff_forall_prime_of_odd`. The `constructor` splits the iff: forward, pad condition (1) with the vacuously-true condition (2); backward, project onto condition (1). This branch is fully machine-checked with zero sorries — it is the solid ground on which the full theorem stands.",
+    "mathContext": "$n \\text{ odd} \\Rightarrow 4 \\nmid n \\Rightarrow \\text{condition (2) vacuous} \\Rightarrow \\text{Irreducible}(X^n - Ca) \\leftrightarrow \\text{cond (1)}$",
+    "significance": "key",
+    "relatedConcepts": ["Kummer extension", "odd exponent", "vacuous truth"],
+    "prerequisites": ["field theory", "parity arguments"]
+  },
+  {
+    "id": "ann-full-criterion",
+    "proofId": "cube-root-3-irrational-oq-02-oq-03",
+    "range": { "startLine": 176, "endLine": 200 },
+    "type": "insight",
+    "title": "The full criterion and the isolated even-sufficiency gap",
+    "content": "The capstone theorem splits on parity: the odd branch discharges completely via `vahlen_capelli_odd`, while the even branch carries the sole `sorry`. That `sorry` is honest — it is the exact even-sufficiency step (conditions (1),(2) ⟹ irreducible for `4 ∣ n`) that Mathlib itself flags as an open `TODO`, citing Lang, *Algebra*, VI §9. Necessity for all `n` is already fully available from the obstruction lemmas above; only sufficiency in the even case remains. The docstring records the standard reduction: peel off the odd part `t` in `n = 2ᵏt`, then induct on `k`, where the inductive obstruction is exactly the `−4b⁴` factorisation that condition (2) rules out. The `wip` badge and single-sorry count faithfully reflect this state.",
+    "mathContext": "$\\text{Irreducible}(X^n - Ca) \\leftrightarrow \\text{VahlenCapelliCond}\\, K\\, n\\, a; \\quad n = 2^k t,\\ t \\text{ odd}$",
+    "significance": "key",
+    "relatedConcepts": ["Vahlen–Capelli theorem", "Capelli's theorem", "induction on 2-adic valuation"],
+    "prerequisites": ["field theory", "irreducibility of polynomials"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-03/meta.json
@@ -44,6 +44,80 @@
     "definitionCount": 1,
     "theoremCount": 7
   },
+  "overview": {
+    "historicalContext": "The irreducibility of pure binomials X^n − a is one of the oldest questions in the theory of equations. Abel and Galois already understood the odd-prime case, but the definitive criterion is due to Theodor Vahlen (1895) and Alfredo Capelli (1897), who independently settled when X^n − a is irreducible over a field: it is irreducible iff a is not a p-th power for any prime p ∣ n and — the subtle extra clause — a ∉ −4·K⁴ whenever 4 ∣ n. This last condition traces directly to the Sophie Germain identity u⁴+4v⁴ = (u²−2uv+2v²)(u²+2uv+2v²), which Germain introduced around 1825 during her work on Fermat's Last Theorem. Serge Lang's Algebra (VI §9) gives the modern textbook treatment. Mathlib formalises only the odd-exponent half (X_pow_sub_C_irreducible_iff_forall_prime_of_odd) and leaves the even case as an explicit TODO citing exactly this Lang reference — so this entry attacks a concrete, named gap in the library. The problem descends from the parent gallery entry proving ∛3 irrational by Eisenstein: that argument is the case n = 3, a = 3, and Vahlen–Capelli is the exact iff that generalises the ad hoc Eisenstein bound to every exponent and radicand.",
+    "problemStatement": "For a field $K$, an element $a \\in K$, and $n \\ge 1$: $X^n - Ca$ is irreducible over $K$ iff (1) $a$ is not a $p$-th power in $K$ for every prime $p \\mid n$, and (2) if $4 \\mid n$ then $a \\notin -4K^4$, i.e. $a \\ne -4b^4$ for all $b \\in K$.",
+    "proofStrategy": "Encode the two-part criterion as a predicate VahlenCapelliCond, then split the biconditional by parity. Necessity holds for all n and is fully proved: two obstruction lemmas exhibit explicit proper divisors — obstruction_pow_dvd (if a = cᵖ then X^{n/p} − Cc divides the binomial, via x−y ∣ xⁿ−yⁿ) for condition (1), and capelli_factor_dvd (the Sophie Germain / Capelli factorisation of X^{4m} + 4(Cb)⁴ into two degree-2m quadratics) for condition (2). The odd branch of sufficiency is complete: for odd n condition (2) is vacuous (4 ∤ n by omega), so the criterion reduces verbatim to Mathlib's Kummer-extension theorem. The even-sufficiency direction — the hard Capelli theorem — is isolated as the sole sorry, with a documented reduction: write n = 2ᵏt with t odd, dispatch the odd part after substituting X ↦ X^{2ᵏ}, then induct on k with the −4b⁴ factorisation as the inductive obstruction that condition (2) forbids.",
+    "keyInsights": [
+      "The entire even/odd asymmetry of binomial irreducibility comes from a single algebraic fact: u⁴+4v⁴ factors into two quadratics (Sophie Germain, ~1825). Condition (2) of the criterion exists only because this factorisation exists.",
+      "Necessity and sufficiency have completely different difficulty profiles. Necessity is elementary and holds for every n — it is just producing an explicit proper divisor. Sufficiency for 4 ∣ n is the genuinely hard content and is precisely what Mathlib leaves open.",
+      "Both necessity witnesses are the *same idea* applied to different factorisations: condition (1) uses x−y ∣ xⁿ−yⁿ (a p-th power splits off a linear-in-X^m factor); condition (2) uses u⁴+4v⁴ (a −4b⁴ radicand splits off a quadratic-in-X^m factor).",
+      "For odd n the criterion collapses onto Mathlib's existing theorem because condition (2)'s hypothesis 4 ∣ n can never fire — a structural vacuity, not an omission. The Lean proof makes this collapse a theorem about the predicate rather than a re-derivation.",
+      "The sole sorry is honest and well-localised: it coincides exactly with an open TODO in Mathlib/FieldTheory/KummerExtension.lean, so the wip badge marks a real research frontier rather than an incomplete routine argument.",
+      "The reduction n = 2ᵏt (odd t) shows the even case is not monolithic: coprime-exponent multiplicativity of irreducibility peels away t, concentrating all difficulty in the pure 2-power tower n = 2ᵏ, where induction on k meets the Sophie Germain obstruction."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Imports and namespace",
+      "startLine": 65,
+      "endLine": 75,
+      "summary": "Pulls in KummerExtension (the odd-case theorem and the file whose even-case TODO this targets) and GeomSum (the x−y ∣ xⁿ−yⁿ divisibility), opens the Polynomial namespace for X and C."
+    },
+    {
+      "id": "predicate",
+      "title": "Part 0 — The Vahlen–Capelli criterion as a predicate",
+      "startLine": 77,
+      "endLine": 85,
+      "summary": "Defines VahlenCapelliCond bundling condition (1) (no p-th power for prime p ∣ n) and condition (2) (a ∉ −4K⁴ when 4 ∣ n) into one reusable Prop shared by the odd and full theorems."
+    },
+    {
+      "id": "sophie-germain",
+      "title": "Part 1 — The Sophie Germain / Capelli identity",
+      "startLine": 87,
+      "endLine": 99,
+      "summary": "Proves u⁴+4v⁴ = (u²−2uv+2v²)(u²+2uv+2v²) over any commutative ring by ring. This is the algebraic source of condition (2) and the mathematical heart of the file."
+    },
+    {
+      "id": "necessity-two",
+      "title": "Part 2 — Necessity of condition (2): the −4·K⁴ obstruction",
+      "startLine": 101,
+      "endLine": 133,
+      "summary": "Lifts Sophie Germain to X^{4m}+4(Cb)⁴ (factor_capelli), handles the C-bookkeeping (C_neg_four_mul_pow), and packages the first quadratic as an explicit proper divisor of X^{4m} − C(−4b⁴) (capelli_factor_dvd)."
+    },
+    {
+      "id": "necessity-one",
+      "title": "Part 3 — Necessity of condition (1): the p-th power obstruction",
+      "startLine": 135,
+      "endLine": 151,
+      "summary": "Shows X^m − Cc divides X^{pm} − C(cᵖ) via sub_dvd_pow_sub_pow, so a perfect p-th power radicand (p ∣ n) forces a proper degree-m divisor."
+    },
+    {
+      "id": "odd-case",
+      "title": "Part 4 — The odd case: full iff via Mathlib",
+      "startLine": 153,
+      "endLine": 170,
+      "summary": "For odd n condition (2) is vacuous, so vahlen_capelli_odd reduces the criterion to X_pow_sub_C_irreducible_iff_forall_prime_of_odd — a complete, sorry-free biconditional."
+    },
+    {
+      "id": "full-criterion",
+      "title": "Part 5 — The full criterion and the open even-sufficiency gap",
+      "startLine": 172,
+      "endLine": 202,
+      "summary": "Assembles vahlen_capelli by parity: odd branch closed via Part 4, even branch carries the sole sorry with a documented n = 2ᵏt reduction — the exact even-sufficiency TODO from Mathlib's KummerExtension."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalises the Vahlen–Capelli criterion for binomial irreducibility as a single predicate and proves everything except the one direction Mathlib itself leaves open. The Sophie Germain identity, both necessity-obstruction factorisations (for conditions (1) and (2)), and the complete odd-exponent biconditional are all established; the even-sufficiency step (conditions (1),(2) ⟹ irreducible when 4 ∣ n) is isolated as the sole sorry, matching the explicit TODO in Mathlib/FieldTheory/KummerExtension.lean.",
+    "implications": "Closing the remaining sorry would upgrade Mathlib's odd-only Kummer-extension result to the full classical criterion, giving a complete, uniform account of when a pure binomial is irreducible over an arbitrary field — the exact generalisation the parent ∛3-irrationality (Eisenstein, n=3) entry motivates. The reusable VahlenCapelliCond predicate and the two elementary obstruction lemmas are already independently useful: they supply machine-checked necessity witnesses for every n, and the Sophie Germain factorisation is a standalone ring identity applicable well beyond this criterion (Aurifeuillian factorisations, sums of powers).",
+    "openQuestions": [
+      "Complete the even-sufficiency sorry: prove conditions (1),(2) ⟹ Irreducible(X^n − Ca) for 4 ∣ n, following the n = 2ᵏt reduction and induction on the 2-adic valuation k sketched in the docstring.",
+      "Formalise the coprime-exponent multiplicativity of binomial irreducibility (X^{st} − Ca behaviour under gcd(s,t)=1) that the reduction relies on, if not already available in Mathlib.",
+      "Upstream the finished criterion to Mathlib to discharge the standing TODO in KummerExtension.lean, generalising X_pow_sub_C_irreducible_iff_forall_prime_of_odd to all n.",
+      "Derive the classical corollaries (e.g. irreducibility of cyclotomic-adjacent binomials, degree of radical field extensions K(a^{1/n})/K) as immediate consequences of the full iff."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "cube-root-3-irrational-oq-02",


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-02-oq-03` (quality 0, passes 0 — first pass).

The entry previously had only a 3.3 KB meta.json with no `overview`, `sections`, `conclusion`, or annotations. This pass adds all of them.

## Added
- **overview**: `historicalContext` (Vahlen 1895 / Capelli 1897; Sophie Germain identity ~1825; Lang *Algebra* VI §9), `problemStatement` (LaTeX), `proofStrategy`, and 6 `keyInsights`.
- **sections**: 7 sections mapping every part of the 202-line Lean file (predicate, Sophie Germain identity, both necessity obstructions, odd-case iff, full criterion).
- **conclusion**: `summary`, `implications`, and 4 `openQuestions` (completing the even-sufficiency sorry, upstreaming to Mathlib, etc.).
- **annotations.json** (new): 8 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. All resolve cleanly against the Lean file (verified by `scripts/annotations/build.ts`).

## Integrity
- Preserved honest `badge: wip`, `sorries: 1`, `status: formalized`. The single sorry is the even-sufficiency direction, which matches the explicit `TODO` in `Mathlib/FieldTheory/KummerExtension.lean`. No status/axiom claims were inflated.
- meta.json now 12 KB (well under the 60 KB cap; `check-meta-size.ts` passes).

## Verification
- JSON validates; `scripts/annotations/build.ts` links the entry with no unresolved-line warnings; `check-meta-size.ts` passes. Full `pnpm build` data phase passes; the only failure is a pre-existing `tsc: command not found` (node_modules absent in this worktree), unrelated to the JSON changes.