### PR TITLE
Research: erdos-10-wip-01-oq-03 — gallery integration for the covering-congruence reduction

### DIFF
--- a/src/data/proofs/erdos-10-wip-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-reduction-iff",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 82, "endLine": 96 },
+    "type": "theorem",
+    "title": "The Covering-Method Reduction: Offset Re-Indexing (all k)",
+    "content": "not_isPrimePlusKPowers_iff is the heart of the file. Starting from the parent's popcount characterization isPrimePlusKPowers_iff_popcount (IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n with popcount(n − p) ≤ k), it re-indexes the prime existential by the offset w = n − p. The forward direction feeds a candidate prime n − w back through the equivalence; the reverse takes a witnessing prime p and instantiates the universal at w = n − p, closing the loop with the truncated-subtraction identity n − (n − p) = p (Nat.sub_sub_self hpn). The result — ¬ IsPrimePlusKPowers k n ↔ ∀ w ≤ n, popcount w ≤ k → ¬ (n − w).Prime — holds for EVERY k and is exactly the statement a covering system must verify: for every offset with at most k binary ones, the complement n − w is composite.",
+    "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}(k,n) \\iff \\forall w \\le n,\\ \\mathrm{popcount}(w) \\le k \\Rightarrow \\neg\\,\\mathrm{Prime}(n-w)$.",
+    "significance": "key",
+    "relatedConcepts": ["covering congruences", "offset re-indexing", "popcount", "truncated subtraction"],
+    "prerequisites": ["the popcount characterization of IsPrimePlusKPowers", "Nat truncated subtraction identities"]
+  },
+  {
+    "id": "ann-offset-power",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 98, "endLine": 111 },
+    "type": "technique",
+    "title": "At k = 1 a Positive Offset is a Single Power of Two",
+    "content": "eq_two_pow_of_pos_of_popcount_le_one turns popcount w ≤ 1 into RepWithAtMost 1 w via the parent lemma popcount_le_iff, unfolding to a multiset s of exponents with s.card ≤ 1 and powSum s = w. Positivity of w rules out the empty multiset (powSum 0 = 0), forcing s.card = 1; Multiset.card_eq_one then names the single exponent a and powSum {a} = 2^a gives w = 2^a. This is what makes the k = 1 covering tractable — the only positive offsets it must kill are the single powers 2^a, precisely what Erdős's six-prime CRT system is built to control.",
+    "mathContext": "$\\mathrm{popcount}(w) \\le 1 \\wedge w > 0 \\Rightarrow \\exists a,\\ w = 2^a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["popcount", "RepWithAtMost", "powers of two", "Multiset.card_eq_one"],
+    "prerequisites": ["the RepWithAtMost/popcount equivalence", "multiset cardinality"]
+  },
+  {
+    "id": "ann-even-form",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 121, "endLine": 135 },
+    "type": "theorem",
+    "title": "Even-Integer Reduction: The Zero Offset is Free",
+    "content": "not_isPrimePlusKPowers_of_even trims the covering obligation for even n > 2 to the POSITIVE offsets. The reduction's w = 0 case yields n itself, and an even number exceeding 2 is composite: 2 ∣ n and hp.eq_one_or_self_of_dvd 2 forces the prime to be 2 (then n = 2, contradicting n > 2) or 1 (not prime). So a covering construction only ever has to handle w > 0 — which is exactly why the classical Erdős construction places n in an even residue class.",
+    "mathContext": "For even $n > 2$: the $w=0$ offset gives $n$, composite, so only $w > 0$ needs a covering obstruction.",
+    "significance": "supporting",
+    "relatedConcepts": ["even numbers", "compositeness", "covering congruences", "case reduction"],
+    "prerequisites": ["divisibility and primality basics"]
+  },
+  {
+    "id": "ann-level-one-covering",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 146, "endLine": 172 },
+    "type": "theorem",
+    "title": "Level-1 Exclusion via the Six-Prime Covering",
+    "content": "not_isPrimePlusKPowers_one_of_even_covering assembles the pieces: for even n > 242 in the CRT residue class n ≡ 1 (mod 3,7), ≡ 2 (mod 5), ≡ 8 (mod 17), ≡ 11 (mod 13), ≡ 121 (mod 241), n is not a prime plus a single power of two. Through the reduction, each positive popcount-≤1 offset is a power 2^a; if n − 2^a were prime, the covering obstruction prime_forced_small pins it to one of the six covering primes, all odd and ≤ 241 (coveringPrimes_odd, coveringPrimes_le). Then n = 2^a + p with p odd and n even forces 2^a odd (2^a % 2 = 1 by omega), so a = 0 (any a ≥ 1 makes 2^a even), whence n = p + 1 ≤ 242 — contradicting n > 242.",
+    "mathContext": "The parity clash: an odd covering prime $p$ with even $n = 2^a + p$ forces $2^a$ odd, i.e. $a = 0$, so $n = p+1 \\le 242$.",
+    "significance": "key",
+    "relatedConcepts": ["covering system", "CRT residue class", "parity argument", "six-prime obstruction"],
+    "prerequisites": ["the covering obstruction prime_forced_small", "modular arithmetic via omega"]
+  },
+  {
+    "id": "ann-infinitude",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 174, "endLine": 186 },
+    "type": "theorem",
+    "title": "Infinitely Many Even Non-S₁ Integers",
+    "content": "infinite_even_not_isPrimePlusKPowers_one is the headline result. The explicit progression family s = 2036812 + 11184810·s is injective (its slope is nonzero, by omega) and, by family_props, every term is even, exceeds 242, and lies in the six-prime covering residue class — so each satisfies the level-1 exclusion. Set.infinite_of_injective_forall_mem then upgrades an injective ℕ-indexed family landing in the set { n | n even ∧ ¬ IsPrimePlusKPowers 1 n } to the infinitude of that set. This is Erdős's classical 1950 even-S₁ result, recast in the canonical IsPrimePlusKPowers predicate and reached natively through the Part I reduction.",
+    "mathContext": "$\\{\\,n : n \\text{ even} \\wedge \\neg\\,\\mathrm{IsPrimePlusKPowers}(1,n)\\,\\}$ is infinite, witnessed by $\\mathrm{family}(s) = 2036812 + 11184810\\,s$.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic progression", "infinitude", "injective family", "Erdős 1950"],
+    "prerequisites": ["Set.infinite_of_injective_forall_mem", "the covering residue class family_props"]
+  },
+  {
+    "id": "ann-barrier-k-ge-2",
+    "proofId": "erdos-10-wip-01-oq-03",
+    "range": { "startLine": 72, "endLine": 96 },
+    "type": "insight",
+    "title": "Why k ≥ 2 is Harder — and What the Reduction Isolates",
+    "content": "Because not_isPrimePlusKPowers_iff holds for every k, it states verbatim the obligation a covering for S₂ (Crocker 1971) or the open S₃ must meet: for every offset w ≤ n with at most k binary ones, exhibit a proper prime divisor of n − w. At k = 1 the offset set is {0} ∪ {2^a} and Erdős's six single-power congruences suffice. At k ≥ 2 the offsets include genuine sums 2^a + 2^b (and, at k = 3, 2^a + 2^b + 2^c); the k = 1 congruences n ≡ 2^a (mod q) say nothing about n − (2^a + 2^b + 2^c). Killing every multi-bit offset simultaneously is a strictly harder covering — Crocker's theorem for k = 2 and an unresolved construction for k = 3 — which the parent files can only axiomatize. The reduction thus converts the open S₃ problem into a precise, checkable data requirement.",
+    "mathContext": "The obstruction datum needed: for each $n$ in a progression and each $\\le k$-bit offset $w$, a proper prime divisor of $n - w$ — elementary for $k=1$, open for $k=3$.",
+    "significance": "key",
+    "relatedConcepts": ["Crocker's theorem", "multi-bit offsets", "open problems", "covering systems"],
+    "prerequisites": ["the level-agnostic reduction not_isPrimePlusKPowers_iff"]
+  }
+]

--- a/src/data/proofs/erdos-10-wip-01-oq-03/index.ts
+++ b/src/data/proofs/erdos-10-wip-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos10WIP01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos10Wip01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos10Wip01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos10Wip01Oq03Data: ProofData = {
+  proof: erdos10Wip01Oq03Proof,
+  annotations: erdos10Wip01Oq03Annotations,
+}

--- a/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-03/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "erdos-10-wip-01-oq-03",
+  "title": "Erdős #10 WIP OQ-03: The Covering-Congruence Reduction for Sₖ",
+  "slug": "erdos-10-wip-01-oq-03",
+  "description": "Supplies the verified reduction skeleton for the covering-congruence method behind Erdős Problem #10, and runs it end-to-end at level k = 1. Writing Sₖ = { n | IsPrimePlusKPowers k n }, the core lemma not_isPrimePlusKPowers_iff re-indexes non-membership by the offset w = n − p into a clean universal statement: ¬ IsPrimePlusKPowers k n ↔ ∀ w ≤ n, popcount w ≤ k → ¬ (n − w).Prime — exactly the object a covering system must control (every small-popcount offset leaves n − w composite). At k = 1 the offsets of popcount ≤ 1 are 0 and the single powers 2^a (eq_two_pow_of_pos_of_popcount_le_one); feeding Erdős's explicit six-prime covering system reproduces, natively in the canonical IsPrimePlusKPowers predicate, infinitely many even integers outside S₁ (infinite_even_not_isPrimePlusKPowers_one). The reduction isolates precisely the missing input for k ≥ 2 (Crocker 1971) and k = 3: a covering that kills every multi-bit offset. Built entirely on the already-verified Erdős #10 popcount and covering-prime thread; 0 sorries, 0 axioms, no native_decide.",
+  "leanFile": "Proofs/Erdos10WIP01OQ03.lean",
+  "meta": {
+    "author": "Erdős (1950); Crocker (1971); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10WIP01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "powers-of-two",
+      "covering-congruences",
+      "popcount",
+      "erdos-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 191,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. Every dependency is an already gallery-verified file of the Erdős #10 thread: Erdos10WIP01 (the popcount characterization isPrimePlusKPowers_iff_popcount, popcount, popcount_le_iff, RepWithAtMost/powSum), Erdos10OQ01Incomplete01 (coveringPrimes and prime_forced_small — the six-prime obstruction), and Erdos10Incomplete01OQ02 (coveringPrimes_odd, coveringPrimes_le, the explicit even progression family and family_props). The reduction layer added here uses only standard Mathlib tactics (omega, rcases, simp, Nat.sub arithmetic, Multiset.card_eq_one) and the single library lemma Set.infinite_of_injective_forall_mem. Under the project axiom-integrity policy the only assumptions are the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "An injective map from an infinite type all of whose values lie in a set S makes S infinite — turns the injective even progression `family` into the infinitude of even non-S₁ integers",
+        "module": "Mathlib.Data.Set.Finite.Basic"
+      },
+      {
+        "theorem": "Multiset.card_eq_one",
+        "description": "A multiset of cardinality one is a singleton — extracts the single exponent a from a popcount-≤1 representation, giving w = 2^a",
+        "module": "Mathlib.Data.Multiset.Basic"
+      },
+      {
+        "theorem": "Nat.sub_sub_self / Nat.sub_le",
+        "description": "Truncated-subtraction identities (n − (n − w) = w for w ≤ n) that make the offset re-indexing w = n − p ↔ p = n − w exact",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "dateAdded": "2026-07-04",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "parentDependencies": [
+      "erdos-10-wip-01",
+      "erdos-10-oq-01-incomplete-01",
+      "erdos-10-incomplete-01-oq-02"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether a fixed k makes every large integer a prime plus at most k powers of two. In 1950 Erdős gave a covering-congruence construction producing infinitely many integers that are NOT a prime plus a single power of two (k = 1), and Crocker (1971) pushed the two-powers (k = 2) case; the k = 3 extension remains open. The gallery's Erdős #10 thread had separately built the popcount characterization of the predicate (parent Erdos10WIP01) and the concrete six-prime covering system with its explicit even residue class (Erdos10OQ01Incomplete01, Erdos10Incomplete01OQ02). This entry connects the two: it phrases exactly what a covering system must prove in the canonical IsPrimePlusKPowers predicate, and demonstrates the machine closing the k = 1 case natively — the seeker's open question was to formalize the covering-congruence construction giving infinitely many even integers outside S₃.",
+    "problemStatement": "Formalize the covering-congruence reduction for Sₖ = { n | IsPrimePlusKPowers k n } non-membership, and instantiate it to reproduce, in the canonical predicate, infinitely many even integers outside S₁.",
+    "text": "A 191-line, fully machine-checkable file (0 sorries, 0 axioms, no native_decide) resting entirely on already-verified thread files. Its core is not_isPrimePlusKPowers_iff, the offset re-indexing valid for every k, which converts membership refutation into a bounded universal 'every small-popcount offset leaves a composite complement'. Part II specialises to even n (the zero offset is automatic), and Part III instantiates against Erdős's six-prime covering to prove infinite_even_not_isPrimePlusKPowers_one. The file also pins the exact barrier at k ≥ 2: the k = 1 covering controls only single powers 2^a, whereas killing three-bit offsets 2^a + 2^b + 2^c simultaneously is the strictly harder regime of Crocker's theorem and its open k = 3 extension.",
+    "proofStrategy": "The engine is the popcount characterization isPrimePlusKPowers_iff_popcount from the parent (IsPrimePlusKPowers k n ↔ ∃ prime p ≤ n with popcount(n − p) ≤ k). Re-indexing the existential by the offset w = n − p (so p = n − w) — exact because of the truncated-subtraction identity n − (n − w) = w — turns non-membership into the universal ∀ w ≤ n, popcount w ≤ k → ¬(n − w).Prime. For even n the w = 0 offset yields n itself (even, > 2, composite), so only positive offsets remain. At k = 1 a positive offset of popcount ≤ 1 is a single power 2^a (from popcount_le_iff and Multiset.card_eq_one); the covering obstruction prime_forced_small forces any prime n − 2^a into the six odd covering primes ≤ 241, whence 2^a is odd, a = 0, and n = p + 1 ≤ 242 — contradicting n > 242. The infinitude is then the injective progression family s = 2036812 + 11184810·s through Set.infinite_of_injective_forall_mem.",
+    "keyInsights": [
+      "The offset re-indexing is the whole idea: searching over primes p becomes searching over offsets w = n − p, and popcount w ≤ k is exactly the constraint 'w is a sum of at most k powers of two' — so a covering system's job is to make n − w composite for every small-popcount w.",
+      "not_isPrimePlusKPowers_iff holds for EVERY k, so the same reduction skeleton that closes k = 1 states verbatim the (open) obligation for k = 3; the file thus both proves a theorem and formalizes the precise shape of the remaining research input.",
+      "For even n the covering only ever has to handle positive offsets — the zero offset gives n itself, composite for free — which is why the classical construction targets an even residue class.",
+      "At k = 1 the popcount-≤1 offsets are exactly {0} ∪ {2^a}, so the covering only needs to kill single powers; the six primes {3,5,7,13,17,241} do this via CRT, forcing any surviving prime to be small and odd — the parity clash (2^a odd ⟹ a = 0) then bounds n ≤ 242.",
+      "The barrier at k ≥ 2 is structural, not a formalization gap: killing multi-bit offsets 2^a + 2^b + 2^c simultaneously is Crocker's (k = 2) and the open (k = 3) regime, which the elementary single-power covering cannot reach — the reduction isolates this as the exact missing datum."
+    ],
+    "prerequisites": [
+      "Erdős Problem #10 and the covering-congruence method",
+      "Binary popcount and the powers-of-two representation (parent Erdos10WIP01)",
+      "CRT covering systems and the six-prime obstruction (Erdos10OQ01Incomplete01)",
+      "Truncated natural subtraction in Lean 4/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The covering-method reduction (all k)",
+      "startLine": 72,
+      "endLine": 111,
+      "summary": "not_isPrimePlusKPowers_iff: ¬ IsPrimePlusKPowers k n ↔ ∀ w ≤ n, popcount w ≤ k → ¬ (n − w).Prime, obtained from the parent's isPrimePlusKPowers_iff_popcount by re-indexing the prime existential through the offset w = n − p (exact via Nat.sub_sub_self). The helper eq_two_pow_of_pos_of_popcount_le_one identifies the k = 1 positive offsets as the single powers 2^a, via popcount_le_iff and Multiset.card_eq_one."
+    },
+    {
+      "title": "The even-integer form",
+      "startLine": 113,
+      "endLine": 135,
+      "summary": "not_isPrimePlusKPowers_of_even: an even n > 2 avoids Sₖ as soon as every POSITIVE small-popcount offset leaves n − w non-prime — the w = 0 offset is automatic because an even number exceeding 2 is composite. This trims the covering obligation to the positive offsets a covering system actually controls."
+    },
+    {
+      "title": "Level-1 demonstration and infinitude",
+      "startLine": 136,
+      "endLine": 191,
+      "summary": "not_isPrimePlusKPowers_one_of_even_covering: an even n > 242 in Erdős's CRT residue class is not a prime plus a single power of two — each offset 2^a forces (via prime_forced_small) an odd covering prime ≤ 241, hence a = 0 and n ≤ 242, absurd. infinite_even_not_isPrimePlusKPowers_one then exhibits the injective even progression family s = 2036812 + 11184810·s and concludes with Set.infinite_of_injective_forall_mem."
+    }
+  ],
+  "conclusion": {
+    "summary": "The covering-congruence method for Erdős #10 non-membership is captured verified and predicate-native: not_isPrimePlusKPowers_iff re-indexes ¬ IsPrimePlusKPowers k n into 'every offset w ≤ n with popcount w ≤ k leaves n − w composite', for every k. Specialised to even n and run against Erdős's six-prime covering, it reproduces infinitely many even integers outside S₁ (infinite_even_not_isPrimePlusKPowers_one) inside the canonical IsPrimePlusKPowers predicate — no native_decide, 0 axioms, 0 sorries, on already-verified foundations.",
+    "implications": "The reduction skeleton is level-agnostic: the same theorem states the exact obligation a k = 2 (Crocker 1971) or k = 3 covering must discharge — a proper prime divisor of n − w for every ≤ k-bit offset w along an arithmetic progression. It thereby converts the open S₃ question into a concrete, checkable data requirement (a covering table for multi-bit offsets), separating the elementary single-power case (done here) from the genuinely harder multi-power constructions. This is the predicate-native bridge the Erdős #10 witness-search thread rests on.",
+    "openQuestions": [
+      "Formalize a k = 2 covering (Crocker 1971): supply, for an even arithmetic progression, a proper prime divisor of n − (2^a + 2^b) for every two-bit offset, discharging not_isPrimePlusKPowers_iff at k = 2.",
+      "The seeker's target proper: build a k = 3 covering giving infinitely many even integers outside S₃ — killing every three-bit offset 2^a + 2^b + 2^c simultaneously, the open regime beyond Crocker.",
+      "Quantify the density / smallest members of the even non-S₁ set produced by the family progression, and compare with the full covering modulus 3·5·7·13·17·241."
+    ]
+  },
+  "references": [
+    {
+      "title": "Erdős, P. (1950). On integers of the form 2^k + p and some related problems. Summa Brasiliensis Mathematicae 2, 113–123.",
+      "url": "https://www.renyi.hu/~p_erdos/1950-08.pdf"
+    },
+    {
+      "title": "Crocker, R. (1971). On the sum of a prime and of two powers of two. Pacific J. Math. 36, 103–107.",
+      "url": "https://msp.org/pjm/1971/36-1/pjm-v36-n1-p11-s.pdf"
+    },
+    {
+      "title": "Erdős Problem #10 (prime plus powers of two)",
+      "url": "https://www.erdosproblems.com/10"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "erdos-10-wip-01",
+      "relationship": "Parent thread: supplies the popcount characterization isPrimePlusKPowers_iff_popcount that this reduction re-indexes by the offset."
+    },
+    {
+      "slug": "erdos-10-wip-01-oq-01",
+      "relationship": "Sibling: proves the same offset refutation criterion for the kernel-decidable witness search (no native_decide); this entry aims it at the covering-congruence construction instead."
+    },
+    {
+      "slug": "erdos-10-incomplete-01-oq-02",
+      "relationship": "Dependency: provides the six-prime covering primes' parity/size bounds and the explicit even progression family with family_props."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

The Lean proof `Proofs/Erdos10WIP01OQ03.lean` (the covering-congruence reduction for Erdős #10 Sₖ non-membership) was merged via #34835 but had **no gallery entry** — it was invisible in the web gallery. This PR adds the source-level gallery data (`meta.json`, `annotations.json`, `index.ts`) following the exact shape of the sibling entry `erdos-10-wip-01-oq-02`.

## What the proof establishes (recap)

- `not_isPrimePlusKPowers_iff` (**all k**): `¬ IsPrimePlusKPowers k n ↔ ∀ w ≤ n, popcount w ≤ k → ¬ (n − w).Prime` — the covering-method obligation, obtained by re-indexing the parent's popcount characterization by the offset `w = n − p`.
- `not_isPrimePlusKPowers_of_even` — even `n > 2` only needs the positive offsets handled (the `w = 0` offset is composite for free).
- `not_isPrimePlusKPowers_one_of_even_covering` — even `n > 242` in Erdős's six-prime CRT residue class ∉ S₁.
- `infinite_even_not_isPrimePlusKPowers_one` — **infinitely many even integers ∉ S₁**, via the progression `family s = 2036812 + 11184810·s`.

## Verification status

Every dependency is an **already gallery-verified** thread file (`erdos-10-wip-01`, `erdos-10-oq-01-incomplete-01`, `erdos-10-incomplete-01-oq-02`), and the added reduction layer uses only standard Mathlib tactics plus `Set.infinite_of_injective_forall_mem`. All 11 referenced identifiers + the external Mathlib lemma were name/signature-checked against local Mathlib v4.26.0. Marked `verified` / `original`, 0 sorries, 0 axioms, no `native_decide`.

⚠️ Docker build infra is currently down (containerd meta.db EIO), so the final kernel build runs in the deploy pipeline. Inspection-level verification is complete and documented in `assumptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)