### PR TITLE
Research: desargues-theorem-oq-02-oq-03 — fix Part IV quaternion build bug (pin R)

### DIFF
--- a/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/knowledge.md
@@ -94,3 +94,27 @@ Verification blackout 2026-07-04: Docker image build fails (containerd
   (`smul_eq_mul`, `push_neg`, `by_contra`, `abel`) — high confidence, hand-checked.
 - Full geometric converse (Hilbert coordinatization) still deferred — large.
 - Next: verify + promote when infra returns; then general-position uniqueness.
+
+### Session 2026-07-04 (researcher-14, iter 4) — Quaternion-pin build fix + blackout root-cause
+**Mode**: RESUME · **Outcome**: progress (surgical build fix; verification still infra-blocked)
+- Fixed a build-blocking elaboration bug in the Part IV quaternion `example`. On
+  `main` it read `Dep (a-b)(b-c)(c-a) := (desargues o a a' b b' c c' h).1` with `R`
+  UNPINNED. `Dep {R} (u v w : M)` mentions `R` only inside its `∃ a b c : R`
+  binder, so unifying against `M = Fin 3 → Quaternion ℝ` leaves `?R` free and
+  `Module ?R (Fin 3 → Quaternion ℝ)` cannot be synthesized → the `example` fails
+  to elaborate. Pinned `(R := Quaternion ℝ)` on BOTH `Dep` and `desargues`.
+- Kept main's richer Part V (`ZMod 6` negative + `ZMod 5` positive, 4 `decide`
+  witnesses) — strictly better than the transient `ZMod 4` variant that lived on a
+  side branch; that branch is superseded.
+- Blackout ROOT-CAUSED this session: `docker ps` succeeds but `docker images` /
+  any build fails with `content.v1.content/blobs/sha256/…: input/output error` —
+  containerd content store corrupted. Cause: disk exhaustion, `/System/Volumes/
+  Data` 98% full (21Gi free). Not transient. Aristotle MCP `prove` (sorried
+  converse hinge) still 404 "Resource not found". Recorded so later sessions treat
+  the blackout as an infra-repair blocker, not a passing outage.
+- Full manual re-audit of every tactic vs Mathlib v4.26.0 — all sound (abel, simp,
+  calc, decide, smul_smul/inv_mul_cancel₀, Submodule.sub_mem/subset_span,
+  Units.mk0 defeq, NormPersp is R-free so quaternion `h` typechecks).
+- Next: `docker-build.sh Proofs.DesarguesTheoremOQ02OQ03` (copy into proofs/Proofs/
+  first) the moment infra returns; if clean, promote to gallery. Then general-
+  position uniqueness + full geometric converse (Hilbert coordinatization).

--- a/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
+++ b/research/problems/desargues-theorem-oq-02-oq-03/lean/DesarguesTheoremOQ02OQ03.lean
@@ -40,17 +40,23 @@ Reference: Artin, *Geometric Algebra* (Desargues ⇔ division ring);
 Hartshorne, *Foundations of Projective Geometry*.
 
 BUILD STATUS: UNVERIFIED. The Docker + Aristotle blackout persists on
-2026-07-04 (containerd `meta.db` I/O error on image build; Aristotle MCP
-`prove_file` returns an error), so this file has NOT been machine-checked. It is
-deliberately placed under `research/problems/.../lean/` (outside the
-`proofs/Proofs/` glob) so it cannot break the gallery build. Parts I–II
-(`nucleus_sum`, `cross_dep`, `cross_eq`, `desargues`, `normalize_perspective`)
-and Part III (`zero_divisor_breaks_normalization`,
+2026-07-04 and is now root-caused: the Docker containerd content store is
+corrupted (blob `input/output error` on any image build) because the host disk
+`/System/Volumes/Data` is 98% full; Aristotle MCP `prove` returns 404 "Resource
+not found". So this file has NOT been machine-checked. It is deliberately placed
+under `research/problems/.../lean/` (outside the `proofs/Proofs/` glob) so it
+cannot break the gallery build. Parts I–II (`nucleus_sum`, `cross_dep`,
+`cross_eq`, `desargues`, `normalize_perspective`) and Part III
+(`zero_divisor_breaks_normalization`,
 `smul_preserves_nonzero_iff_no_zero_divisors`) are the reviewed mathematical
-core; the Part IV quaternion `example` is an instance-resolution demonstration.
-Part V pins the dichotomy to explicit finite rings (`ZMod 6` negative, `ZMod 5`
-positive) via `decide`; those four `example`s are the one self-certifying part
-of the file (finite `DecidableEq` rings), pending only the full kernel check.
+core; the Part IV quaternion `example` is an instance-resolution demonstration —
+its `R` is now pinned `(R := Quaternion ℝ)` on both `Dep` and `desargues`,
+fixing a build-blocking elaboration bug (with `R` unpinned, `Dep`'s implicit `R`
+appears only inside its `∃`-binder, so `Module ?R (Fin 3 → Quaternion ℝ)` cannot
+be synthesized and the `example` fails to elaborate). Part V pins the dichotomy
+to explicit finite rings (`ZMod 6` negative, `ZMod 5` positive) via `decide`;
+those four `example`s are the one self-certifying part of the file (finite
+`DecidableEq` rings), pending only the full kernel check.
 
 Tags: projective-geometry, desargues, division-ring, non-commutative, modules
 -/
@@ -230,8 +236,8 @@ end Necessity
     secretly using commutativity. -/
 example (o a a' b b' c c' : Fin 3 → Quaternion ℝ)
     (h : NormPersp o a a' b b' c c') :
-    Dep (a - b) (b - c) (c - a) :=
-  (desargues o a a' b b' c c' h).1
+    Dep (R := Quaternion ℝ) (a - b) (b - c) (c - a) :=
+  (desargues (R := Quaternion ℝ) o a a' b b' c c' h).1
 
 /-! ## Part V — Concrete witnesses on both sides of the dichotomy
 

--- a/research/problems/desargues-theorem-oq-02-oq-03/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-03/state.md
@@ -3,8 +3,8 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-07-04
-**Iteration**: 3
+**Since**: 2026-07-04T20:10-07:00
+**Iteration**: 4
 
 ## Current Focus
 Forward direction formalized (division ring ⇒ Desargues, commutativity unused).
@@ -32,12 +32,22 @@ module over itself (the coordinate line).
 - Current approach attempts: 3
 - Approaches tried: 1
 
+Session 5 (researcher-14, iter 4): fixed a build-blocking elaboration bug in the
+Part IV quaternion `example` — `R` was unpinned on both `Dep` and `desargues`, so
+`Dep`'s implicit `R` (appearing only inside its `∃`-binder) could not be inferred
+and `Module ?R (Fin 3 → Quaternion ℝ)` failed to synthesize. Pinned
+`(R := Quaternion ℝ)` on both. Kept the richer `ZMod 6`/`ZMod 5` Part-V witnesses
+from main. Re-tested infra: BOTH channels still down (details below).
+
 ## Blockers
-Verification blackout persists 2026-07-04: Docker image build fails (containerd
-meta.db I/O error, confirmed again this session via `docker run hello-world`);
-Aristotle MCP `prove_file` returns "An error occurred while processing your
-request". Lean file UNVERIFIED (proofs hand-checked; Part V is decide-only and
-uses standard finite-ring idioms).
+Verification blackout persists 2026-07-04, now ROOT-CAUSED. Docker daemon is up
+(`docker ps` OK) but any image build / `docker images` fails with containerd
+content-store blob `input/output error` — the store is corrupted. Underlying
+cause: disk exhaustion, `/System/Volumes/Data` is 98% full (21Gi free). NOT
+transient; needs host-level disk cleanup + containerd repair (out of agent
+scope). Aristotle MCP `prove` now returns 404 "Resource not found". Lean file
+UNVERIFIED but hand-checked line-by-line against Mathlib v4.26.0 (all elementary
+tactics; Part V is `decide`-only).
 
 ## Next Action
 When infra returns: docker-build.sh Proofs.DesarguesTheoremOQ02OQ03 (move file


### PR DESCRIPTION
## Summary
Surgical fix to the research Lean file for `desargues-theorem-oq-02-oq-03` (Desargues over non-commutative division rings). The file lives under `research/problems/.../lean/` — outside the `proofs/Proofs/` gallery glob — so it cannot affect the gallery build.

### The bug
The Part IV quaternion `example` on `main` had `R` unpinned:
```lean
Dep (a - b) (b - c) (c - a) := (desargues o a a' b b' c c' h).1
```
`Dep {R} (u v w : M)` mentions `R` only inside its `∃ a b c : R` binder. Unifying the goal against `M = Fin 3 → Quaternion ℝ` leaves `?R` a free metavariable, so `Module ?R (Fin 3 → Quaternion ℝ)` cannot be synthesized and the `example` fails to elaborate.

### The fix
Pin `(R := Quaternion ℝ)` on both `Dep` and `desargues`:
```lean
Dep (R := Quaternion ℝ) (a - b) (b - c) (c - a) :=
  (desargues (R := Quaternion ℝ) o a a' b b' c c' h).1
```
The richer Part V witnesses (`ZMod 6` negative / `ZMod 5` positive, `decide`-checked) are unchanged.

### Verification status
**UNVERIFIED by machine** — a verification blackout persists and is now root-caused: Docker's containerd content store is corrupted (blob `input/output error` on any image build) because the host disk `/System/Volumes/Data` is 98% full; Aristotle MCP `prove` returns 404. Every tactic was re-audited by hand against Mathlib v4.26.0 (all elementary: `abel`, `simp`, `calc`, `decide`, `smul_smul`/`inv_mul_cancel₀`, `Submodule.sub_mem`). `state.md`/`knowledge.md` updated with the fix and root-cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)