### PR TITLE
Enrich ζ(8)=π⁸/9450 (basel-problem-oq-08-oq-02-oq-01): keyInsights 3→5

### DIFF
--- a/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/meta.json
@@ -72,7 +72,9 @@
     "keyInsights": [
       "**Even zeta values are rational multiples of powers of π.** ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!); at k = 4, B₈ = −1/30 yields ζ(8) = π⁸/9450.",
       "**The Bernoulli recurrence chains.** Mathlib stops its packaged Bernoulli evaluations at B₄, and computing B₈ from the recurrence requires B₆ as a summand — so the degree-8 value genuinely builds on the degree-6 work rather than restarting from Mathlib. Curiously B₈ = B₄ = −1/30 even though the recurrences differ.",
-      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35, ζ(8)/ζ(2)⁴ = 24/175."
+      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35, ζ(8)/ζ(2)⁴ = 24/175.",
+      "**The sign resolves to positivity automatically.** In ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!) the Bernoulli numbers alternate in sign (B₂ > 0, B₄ < 0, B₆ > 0, B₈ < 0), so the prefactor (−1)^{k+1} and the sign of B_{2k} always cancel — forcing a positive value, exactly as any convergent sum of positive terms 1/n^{2k} must be. At k = 4 this is the double flip (−1)⁵·(−1/30) = +1/30 that the Lean proof clears with a single `ring`.",
+      "**The Dirichlet series and the analytic continuation are recorded separately.** `tsum_one_div_nat_pow_eight` (the real sum ∑' 1/n⁸) and `riemannZeta_eight_eq` (Mathlib's `riemannZeta 8` over ℂ) are proved from *different* lemmas — `hasSum_zeta_nat` versus `riemannZeta_two_mul_nat` — because the series and the continuation are distinct objects that coincide only on the half-plane Re(s) > 1. Keeping both makes the distinction honest: for odd integers and for Re(s) ≤ 1 the continuation is not given by the series at all."
     ],
     "prerequisites": [
       "Infinite sums / tsum and HasSum in Mathlib",


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-08-oq-02-oq-01` (quality 94, pass 0).

This entry was recently reverted from a corrupt enrichment (#34820 → #34859). Starting from the clean restored state, this pass makes a small, targeted, non-destructive addition.

## Change
- `overview.keyInsights`: **3 → 5** (role minimum is 4–5). Two new insights, both grounded in the actual Lean proof:
  1. **Automatic positivity**: in ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!) the prefactor (−1)^{k+1} and the alternating sign of B_{2k} always cancel, forcing a positive sum — the double flip (−1)⁵·(−1/30) the proof clears with `ring`.
  2. **Series vs. analytic continuation**: `tsum_one_div_nat_pow_eight` (real Dirichlet series, via `hasSum_zeta_nat`) and `riemannZeta_eight_eq` (Mathlib `riemannZeta` over ℂ, via `riemannZeta_two_mul_nat`) are proved from different lemmas because the objects coincide only on Re(s) > 1.

## Verification
- `meta.json` valid JSON, 13.0 KB (well under the 60 KB cap; `check-meta-size.ts` passes)
- Data-generation phase of `pnpm build` processed the entry cleanly
- No changes to annotations, status, badge, or axiomCount (remains `verified`, 0 axioms, 0 sorries — consistent with the Lean file)
- Only `meta.json` changed; +3/−1 lines