### PR TITLE
research(prob-method-applications-wip-01-oq-02): Property B m(k) ≥ 2^(k-1) from the abstract first-moment engine

### DIFF
--- a/proofs/Proofs/ProbMethodApplicationsWIPOQ02.lean
+++ b/proofs/Proofs/ProbMethodApplicationsWIPOQ02.lean
@@ -1,0 +1,121 @@
+/-
+  Probabilistic Method Applications — WIP OQ-02
+
+  Open question (prob-method-applications-wip-01-oq-02):
+    "Formalize Property B (m(k) ≥ 2^(k-1)) directly from the abstract
+     first-moment engine `exists_good_of_card_bound` / `ramsey_avoidance`."
+
+  The companion file `ProbMethodApplicationsWIP.lean` proves the abstract
+  first-moment avoidance engine
+
+      ProbMethod.Core.ramsey_avoidance :
+        (cliques : Finset (Finset E)) (m : ℕ)
+        (∀ K ∈ cliques, K.card = m)
+        (cliques.card * 2^(|E| - m + 1) < 2^|E|)
+        ⟹ ∃ S : Finset E, ∀ K ∈ cliques, ¬ (K ⊆ S ∨ Disjoint K S),
+
+  over an arbitrary finite "ground" set `E`, where a block `K` is monochromatic
+  under the colouring `S` (= the set of `true`-coloured ground elements) exactly
+  when `K ⊆ S` (all `true`) or `Disjoint K S` (all `false`).
+
+  Its docstring advertises a *Ramsey* reading (`E` = the edge set of `Kₙ`,
+  blocks = the `Kₘ`-cliques), carried out in `ProbMethodApplicationsWIPOQ01`.
+  This file supplies the *other* headline consequence of the same engine —
+  **Property B**, the 2-colourability threshold for uniform hypergraphs.
+
+  Reading of the engine for Property B:
+    * take `E := V`, the **vertex** set of a hypergraph (not the edge set of
+      `Kₙ`);
+    * take `cliques := edges`, the family of hyperedges, each a `k`-element
+      subset of `V`;
+    * a colouring `S : Finset V` splits `V` into `true`/`false` classes, and a
+      hyperedge `e` is monochromatic exactly when `e ⊆ S ∨ Disjoint e S`.
+  The engine's hypothesis `edges.card · 2^(|V| - k + 1) < 2^|V|` is equivalent,
+  since `2^|V| = 2^(k-1)·2^(|V|-k+1)` for `k ≤ |V|`, to the classical Property B
+  criterion `edges.card < 2^(k-1)`.  The engine then produces a proper
+  2-colouring, i.e. one with no monochromatic edge.
+
+  Consequences proved here (both `0 sorry`, `0 axiom`):
+    * `property_B_two_colorable` — every `k`-uniform hypergraph with fewer than
+      `2^(k-1)` edges is 2-colourable;
+    * `property_B_lower_bound`   — its contrapositive, **m(k) ≥ 2^(k-1)**: every
+      `k`-uniform hypergraph that is *not* 2-colourable has at least `2^(k-1)`
+      edges (Erdős, 1963/64).
+
+  `m(k)` denotes the least number of edges in a non-2-colourable `k`-uniform
+  hypergraph; the lower bound `m(k) ≥ 2^(k-1)` is exactly the statement that no
+  hypergraph below that edge count can fail to be 2-colourable, which is what
+  `property_B_lower_bound` asserts (uniformly over all vertex types `V`).
+
+  Status: 0 sorries, 0 axioms, no native_decide.
+-/
+import Mathlib
+import Proofs.ProbMethodApplicationsWIP
+
+open Finset
+
+namespace ProbMethod.PropertyB
+
+open ProbMethod.Core
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A hypergraph `edges` on vertex set `V` is **2-colourable** (has *Property B*)
+when some 2-colouring `S : Finset V` (the vertices coloured `true`) leaves no
+hyperedge monochromatic.  A hyperedge `e` is monochromatic under `S` exactly
+when `ProbMethod.Core.Mono e S`, i.e. `e ⊆ S` (all `true`) or `Disjoint e S`
+(all `false`). -/
+def TwoColorable (edges : Finset (Finset V)) : Prop :=
+  ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S
+
+/-- **Property B (Erdős 1963/64), upper form.**
+Every `k`-uniform hypergraph on `V` with strictly fewer than `2^(k-1)` edges is
+2-colourable.
+
+The proof is a direct instantiation of the abstract union-bound engine
+`ProbMethod.Core.ramsey_avoidance` with the *vertex* set `V` as ground set: the
+only arithmetic content is turning the classical criterion `edges.card < 2^(k-1)`
+into the engine's hypothesis `edges.card · 2^(|V|-k+1) < 2^|V|`, using
+`2^|V| = 2^(k-1)·2^(|V|-k+1)` (valid since a nonempty `k`-edge forces `k ≤ |V|`). -/
+theorem property_B_two_colorable
+    (edges : Finset (Finset V)) (k : ℕ) (hk : 1 ≤ k)
+    (huniform : ∀ e ∈ edges, e.card = k)
+    (hsmall : edges.card < 2 ^ (k - 1)) :
+    TwoColorable edges := by
+  rcases edges.eq_empty_or_nonempty with hE | hE
+  · -- No edges: any colouring is proper.
+    exact ⟨∅, by simp [hE]⟩
+  · -- A witnessing edge pins `k ≤ |V|`, which drives the exponent bookkeeping.
+    obtain ⟨e₀, he₀⟩ := hE
+    have hkn : k ≤ Fintype.card V := by
+      have h1 := Finset.card_le_univ e₀
+      rwa [huniform e₀ he₀] at h1
+    have hpos : 0 < 2 ^ (Fintype.card V - k + 1) := pow_pos (by norm_num) _
+    have hmul : edges.card * 2 ^ (Fintype.card V - k + 1)
+        < 2 ^ (k - 1) * 2 ^ (Fintype.card V - k + 1) :=
+      mul_lt_mul_of_pos_right hsmall hpos
+    have hlt : edges.card * 2 ^ (Fintype.card V - k + 1) < 2 ^ (Fintype.card V) := by
+      refine hmul.trans_le (le_of_eq ?_)
+      rw [← pow_add]
+      congr 1
+      omega
+    exact ramsey_avoidance edges k huniform hlt
+
+/-- **Property B lower bound: m(k) ≥ 2^(k-1).**
+Every `k`-uniform hypergraph on `V` that is *not* 2-colourable has at least
+`2^(k-1)` hyperedges.
+
+This is the contrapositive of `property_B_two_colorable`.  Since it holds for
+every finite vertex type `V`, it is exactly the Erdős lower bound on
+`m(k)`, the minimum number of edges in a non-2-colourable `k`-uniform
+hypergraph: no such hypergraph can have fewer than `2^(k-1)` edges. -/
+theorem property_B_lower_bound
+    (edges : Finset (Finset V)) (k : ℕ) (hk : 1 ≤ k)
+    (huniform : ∀ e ∈ edges, e.card = k)
+    (hnot : ¬ TwoColorable edges) :
+    2 ^ (k - 1) ≤ edges.card := by
+  by_contra h
+  push_neg at h
+  exact hnot (property_B_two_colorable edges k hk huniform h)
+
+end ProbMethod.PropertyB

--- a/src/data/proofs/prob-method-applications-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "wipoq02-framing",
+    "proofId": "prob-method-applications-wip-01-oq-02",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "context",
+    "title": "The Other Face of the Engine: Property B",
+    "content": "The module docstring frames the entry. The companion file ProbMethodApplicationsWIP.lean proves an abstract first-moment / union-bound avoidance engine ProbMethod.Core.ramsey_avoidance over an arbitrary finite ground set E: if a family of bad blocks is few enough relative to 2^{|E|}, some subset S avoids every block (no block is entirely inside S or entirely outside it). The sibling entry read E as the edges of K_n to recover Erdős's Ramsey bound R(k,k) > n. This file supplies the engine's other advertised consequence — Property B — by reading E as the vertex set V of a hypergraph and the blocks as the hyperedges. The engine's counting hypothesis then becomes the classical criterion edges.card < 2^{k−1}, and its output is a proper 2-colouring.",
+    "mathContext": "$\\text{engine: } |\\text{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\Rightarrow \\exists S \\text{ avoiding all blocks};\\quad \\text{here } E = V,\\ m = k,\\ \\text{blocks} = \\text{hyperedges}.$",
+    "significance": "supporting",
+    "prerequisites": ["the probabilistic / first-moment method", "union bound", "Property B for k-uniform hypergraphs"],
+    "relatedConcepts": ["abstract avoidance engine", "hypergraph 2-colouring", "Erdős m(k) bound", "ground set as vertices vs. edges"]
+  },
+  {
+    "id": "wipoq02-definition",
+    "proofId": "prob-method-applications-wip-01-oq-02",
+    "range": { "startLine": 63, "endLine": 69 },
+    "type": "definition",
+    "title": "2-Colourability as a Subset Predicate",
+    "content": "TwoColorable edges := ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S encodes hypergraph 2-colourability. A 2-colouring is the subset S of true-coloured vertices; a hyperedge e is monochromatic under S exactly when e ⊆ S (all true) or Disjoint e S (all false) — the parent file's reducible predicate Mono e S. Because the hypergraph's edges live in Finset (Finset V), the same type the engine uses for its blocks, the engine's bad blocks and the hypergraph's edges are literally identical, so no translation between an abstract avoiding set and a Boolean colouring is required (unlike the Ramsey instantiation).",
+    "mathContext": "$\\text{TwoColorable}(\\mathrm{edges}) := \\exists S,\\ \\forall e \\in \\mathrm{edges},\\ \\neg(e \\subseteq S \\vee e \\cap S = \\varnothing)$",
+    "significance": "key",
+    "prerequisites": ["subset as 2-colouring", "ProbMethod.Core.Mono (contained-or-disjoint monochromaticity)"],
+    "relatedConcepts": ["hypergraph 2-colouring", "membership colouring", "Property B"]
+  },
+  {
+    "id": "wipoq02-instantiation",
+    "proofId": "prob-method-applications-wip-01-oq-02",
+    "range": { "startLine": 71, "endLine": 92 },
+    "type": "lemma",
+    "title": "Instantiating the Engine over the Vertex Set",
+    "content": "property_B_two_colorable takes a hypergraph edges : Finset (Finset V) with every hyperedge of size k and fewer than 2^{k−1} edges. If there are no edges, any colouring is proper, so ⟨∅, _⟩ witnesses TwoColorable vacuously. Otherwise pick a witnessing edge e₀; since e₀ ⊆ V and |e₀| = k, Finset.card_le_univ gives k ≤ Fintype.card V. This k ≤ |V| is exactly what the exponent split of the next step needs — it is derived, not assumed, so the theorem carries no separate hypothesis relating k to the number of vertices.",
+    "mathContext": "$e_0 \\subseteq V,\\ |e_0| = k \\ \\Rightarrow\\ k \\le |V|;\\qquad \\mathrm{edges} = \\varnothing \\Rightarrow \\text{vacuously 2-colourable}$",
+    "significance": "key",
+    "prerequisites": ["Finset.card_le_univ", "Finset.eq_empty_or_nonempty"],
+    "relatedConcepts": ["k-uniform hypergraph", "deriving k ≤ |V| from a witnessing edge", "vacuous colouring of the empty hypergraph"]
+  },
+  {
+    "id": "wipoq02-arithmetic",
+    "proofId": "prob-method-applications-wip-01-oq-02",
+    "range": { "startLine": 93, "endLine": 102 },
+    "type": "insight",
+    "title": "One Power-of-Two Identity Is the Whole Proof",
+    "content": "The engine requires edges.card · 2^{|V|−k+1} < 2^{|V|}. From hsmall : edges.card < 2^{k−1} and 0 < 2^{|V|−k+1} (pow_pos), mul_lt_mul_of_pos_right gives edges.card · 2^{|V|−k+1} < 2^{k−1} · 2^{|V|−k+1}. Rewriting the RHS with pow_add in reverse yields 2^{(k−1)+(|V|−k+1)}, and the exponent (k−1)+(|V|−k+1) equals |V| (omega, from 1 ≤ k ≤ |V|), so the RHS is exactly 2^{|V|}. This is the classical statement that the expected number of monochromatic edges is below 1; the probabilistic content lives inside ramsey_avoidance, which is then invoked directly to return the avoiding subset S (the 2-colouring).",
+    "mathContext": "$2^{|V|} = 2^{k-1}\\cdot 2^{|V|-k+1},\\qquad \\mathrm{edges.card}\\cdot 2^{|V|-k+1} < 2^{|V|} \\iff \\mathrm{edges.card} < 2^{k-1}$",
+    "significance": "key",
+    "prerequisites": ["mul_lt_mul_of_pos_right", "pow_add", "pow_pos", "omega on natural-number subtraction"],
+    "relatedConcepts": ["first-moment criterion", "expected monochromatic count below one", "cancelling the common factor"]
+  },
+  {
+    "id": "wipoq02-lower-bound",
+    "proofId": "prob-method-applications-wip-01-oq-02",
+    "range": { "startLine": 104, "endLine": 119 },
+    "type": "lemma",
+    "title": "The Erdős Lower Bound m(k) ≥ 2^{k−1}",
+    "content": "property_B_lower_bound is the contrapositive of the upper form: by_contra together with push_neg turns ¬(2^{k−1} ≤ edges.card) into edges.card < 2^{k−1}, which by property_B_two_colorable makes the hypergraph 2-colourable — contradicting the hypothesis that it is not. Because the statement holds for every finite vertex type V, it is exactly the Erdős (1963/64) lower bound m(k) ≥ 2^{k−1} on the minimum number of edges in a non-2-colourable k-uniform hypergraph: no such hypergraph can drop below 2^{k−1} edges.",
+    "mathContext": "$\\neg\\,\\text{TwoColorable}(\\mathrm{edges}) \\ \\Rightarrow\\ 2^{k-1} \\le \\mathrm{edges.card}$",
+    "significance": "key",
+    "prerequisites": ["contrapositive via by_contra / push_neg"],
+    "relatedConcepts": ["extremal function m(k)", "Property B lower bound", "Erdős 1963/64"]
+  }
+]

--- a/src/data/proofs/prob-method-applications-wip-01-oq-02/index.ts
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ProbMethodApplicationsWIPOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodApplicationsWip01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodApplicationsWip01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodApplicationsWip01Oq02Data: ProofData = {
+  proof: probMethodApplicationsWip01Oq02Proof,
+  annotations: probMethodApplicationsWip01Oq02Annotations,
+}

--- a/src/data/proofs/prob-method-applications-wip-01-oq-02/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01-oq-02/meta.json
@@ -1,0 +1,211 @@
+{
+  "id": "prob-method-applications-wip-01-oq-02",
+  "title": "Property B from the Abstract First-Moment Engine: m(k) ≥ 2^{k-1}",
+  "slug": "prob-method-applications-wip-01-oq-02",
+  "description": "The work-in-progress file ProbMethodApplicationsWIP.lean proves an abstract first-moment / union-bound avoidance engine ramsey_avoidance over an arbitrary finite ground set E: if a family of bad blocks is few enough (|cliques|·2^{|E|−m+1} < 2^{|E|}) then some subset S avoids them all. A sibling entry instantiates E as the edge set of K_n to recover Erdős's Ramsey bound R(k,k) > n. This entry supplies the other headline consequence of the same engine — Property B, the 2-colourability threshold for uniform hypergraphs — by reading the ground set E as the vertex set V of a hypergraph (not the edges of K_n) and the blocks as the hyperedges. The engine's hypothesis edges.card·2^{|V|−k+1} < 2^{|V|} is equivalent, since 2^{|V|} = 2^{k−1}·2^{|V|−k+1} for k ≤ |V|, to the classical criterion edges.card < 2^{k−1}, so every k-uniform hypergraph with fewer than 2^{k−1} edges is 2-colourable (property_B_two_colorable). Its contrapositive is the Erdős (1963/64) lower bound m(k) ≥ 2^{k−1}: every non-2-colourable k-uniform hypergraph has at least 2^{k−1} edges (property_B_lower_bound). Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Paul Erdős (1963/64); abstract engine and Property B instantiation formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Property_B",
+    "date": "1963",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodApplicationsWIPOQ02.lean",
+    "tags": [
+      "probabilistic-method",
+      "combinatorics",
+      "hypergraph-coloring",
+      "property-b",
+      "first-moment-method",
+      "union-bound",
+      "erdos"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_le_univ",
+        "description": "s.card ≤ Fintype.card α. Applied to a witnessing hyperedge e₀ (with e₀.card = k) it yields k ≤ Fintype.card V — the inequality that lets the exponents |V| − k + 1 and k − 1 be split cleanly.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "a < b → 0 < c → a·c < b·c. Multiplies the classical criterion edges.card < 2^{k−1} by the positive factor 2^{|V|−k+1} to reach edges.card·2^{|V|−k+1} < 2^{k−1}·2^{|V|−k+1}.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "pow_add",
+        "description": "a^{m+n} = a^m·a^n. Used in reverse to collapse 2^{k−1}·2^{|V|−k+1} into 2^{(k−1)+(|V|−k+1)} = 2^{|V|}, identifying the split RHS with the engine's threshold 2^{|V|}.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "pow_pos",
+        "description": "0 < a → 0 < a^n. Supplies positivity of 2^{|V|−k+1}, the factor cancelled to turn the engine's counting hypothesis into the classical Property B criterion.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "ProbMethod.Core.ramsey_avoidance",
+        "description": "The abstract first-moment avoidance engine from the parent file: (cliques.card·2^{|E|−m+1} < 2^{|E|}) with all blocks of size m ⟹ ∃ S, no block is monochromatic. Instantiated here at E = V, m = k, cliques = the hyperedges, it delivers the proper 2-colouring directly.",
+        "module": "Proofs.ProbMethodApplicationsWIP"
+      }
+    ],
+    "originalContributions": [
+      "property_B_two_colorable: every k-uniform hypergraph on a finite vertex type V with strictly fewer than 2^{k−1} hyperedges is 2-colourable, obtained by instantiating ProbMethod.Core.ramsey_avoidance with the vertex set V as ground set and the hyperedges as the bad blocks. This is the hypergraph-colouring reading of the abstract engine, distinct from the Ramsey (edge-set of K_n) reading in the sibling entry.",
+      "The arithmetic bridge: the engine's uniform-block hypothesis edges.card·2^{|V|−k+1} < 2^{|V|} is shown equivalent to the classical Property B criterion edges.card < 2^{k−1} by writing 2^{|V|} = 2^{k−1}·2^{|V|−k+1} (pow_add) and cancelling the positive factor (mul_lt_mul_of_pos_right, pow_pos). The needed exponent identity (k−1)+(|V|−k+1) = |V| holds because a nonempty k-edge forces k ≤ |V| (Finset.card_le_univ), with the empty-hypergraph case dispatched separately as vacuously 2-colourable.",
+      "property_B_lower_bound: the contrapositive m(k) ≥ 2^{k−1} — every non-2-colourable k-uniform hypergraph has at least 2^{k−1} hyperedges. Because it is stated uniformly over all finite vertex types V, it is exactly the Erdős (1963/64) lower bound on m(k), the minimum number of edges in a non-2-colourable k-uniform hypergraph.",
+      "TwoColorable: a reusable predicate ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S expressing hypergraph 2-colourability through the parent file's set-theoretic monochromaticity notion Mono e S = (e ⊆ S ∨ Disjoint e S), making the membership-colouring translation (vertices coloured true = S) the definition rather than an afterthought.",
+      "Answers the sibling entry's stated open question — 'instantiate the same abstract engine for Property B (2-colourability of k-uniform hypergraphs), reusing the membership-colouring translation' — closing the loop on the parent file's docstring claim that its engine yields Property B as well as the Ramsey bound."
+    ],
+    "dateAdded": "2026-07-04",
+    "relatedProblems": [
+      {
+        "id": "prob-method-applications-wip-01",
+        "relationship": "Instantiates this parent file's abstract ramsey_avoidance engine at the vertex set of a hypergraph, turning its docstring's asserted Property B application into a machine-checked theorem — the hypergraph-colouring counterpart of the engine's Ramsey reading."
+      },
+      {
+        "id": "prob-method-applications-wip-01-oq-01",
+        "relationship": "Sibling instantiation of the same engine. That entry reads the ground set as the edge set of K_n (recovering R(k,k) > n); this one reads it as the vertex set of a hypergraph (recovering Property B, m(k) ≥ 2^{k−1}), and answers the open question that entry explicitly posed."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for property_B_two_colorable and property_B_lower_bound — no sorryAx, no Lean.ofReduceBool. The mathematical content of the bound is carried entirely by the parent file's ProbMethod.Core.ramsey_avoidance engine; the contribution here is the faithful hypergraph-2-colourability instantiation of that engine plus the elementary power-of-two arithmetic bridging the engine's hypothesis and the classical criterion edges.card < 2^{k−1}, and the contrapositive m(k) lower bound. This is a unification/instantiation result, not a new bound: the value is deriving the classical Property B threshold as a genuine corollary of the reusable abstract engine.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "A hypergraph has Property B (after Felix Bernstein, 1908) when its vertices can be 2-coloured with no edge monochromatic. For k-uniform hypergraphs, m(k) denotes the least number of edges forcing failure of Property B. Erdős (1963/64) gave the two classical bounds via the probabilistic method: the lower bound m(k) ≥ 2^{k−1}, proved by the first-moment / union bound (colour each vertex independently at random; a fixed k-edge is monochromatic with probability 2^{1−k}, so fewer than 2^{k−1} edges give expected monochromatic count below 1 and a good colouring exists), and a probabilistic upper bound m(k) = O(k^2 2^k). The lean-genius gallery abstracts the union-bound heart of such arguments into a single reusable engine, ProbMethod.Core.ramsey_avoidance, stated over an arbitrary finite ground set E where a block is monochromatic under a subset-colouring S exactly when it is contained in S or disjoint from S. The parent file's docstring advertises that this engine yields both the Ramsey bound (E = edges of K_n) and Property B (E = vertices of a hypergraph); the sibling entry carried out the Ramsey reading, and this entry supplies the Property B reading, recovering the lower bound m(k) ≥ 2^{k−1}.",
+    "problemStatement": "Instantiate the abstract avoidance engine ProbMethod.Core.ramsey_avoidance for hypergraph 2-colourability: take the ground set to be the vertex set V of a k-uniform hypergraph and the bad blocks to be the hyperedges, reduce the engine's counting hypothesis to the classical criterion edges.card < 2^{k−1}, and conclude both that few-edge hypergraphs are 2-colourable and the Erdős lower bound m(k) ≥ 2^{k−1}.",
+    "text": "Model a hypergraph as edges : Finset (Finset V) over a finite vertex type V, with every hyperedge a k-element set. A 2-colouring is a subset S : Finset V (the vertices coloured true), and a hyperedge e is monochromatic under S when e ⊆ S (all true) or Disjoint e S (all false) — the parent file's predicate Mono e S. The hypergraph is 2-colourable (TwoColorable) when some S makes no hyperedge monochromatic. The abstract engine ramsey_avoidance asks for edges.card · 2^{|V|−k+1} < 2^{|V|}. When there is at least one edge, its k vertices force k ≤ |V|, so 2^{|V|} = 2^{k−1} · 2^{|V|−k+1}; cancelling the positive factor 2^{|V|−k+1} turns the engine's hypothesis into edges.card < 2^{k−1}. The engine then returns an avoiding set S, i.e. a proper 2-colouring — establishing property_B_two_colorable. The empty hypergraph is vacuously 2-colourable. The contrapositive, property_B_lower_bound, states m(k) ≥ 2^{k−1}: a k-uniform hypergraph that is not 2-colourable must have at least 2^{k−1} edges.",
+    "proofStrategy": "Everything is finite and over ℕ; the parent engine has already discharged the averaging.\n\n1. **Definition.** TwoColorable edges := ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S, reusing ProbMethod.Core.Mono for the contained-or-disjoint monochromaticity.\n\n2. **Empty case.** If edges = ∅ every colouring is proper, so ⟨∅, _⟩ witnesses TwoColorable vacuously.\n\n3. **Pin k ≤ |V|.** A witnessing edge e₀ with e₀.card = k satisfies e₀.card ≤ Fintype.card V (Finset.card_le_univ), giving k ≤ |V| — the hypothesis the exponent split needs.\n\n4. **Arithmetic bridge.** From hsmall : edges.card < 2^{k−1} and 0 < 2^{|V|−k+1} (pow_pos), mul_lt_mul_of_pos_right yields edges.card · 2^{|V|−k+1} < 2^{k−1} · 2^{|V|−k+1}. Rewriting the RHS with pow_add in reverse gives 2^{(k−1)+(|V|−k+1)}, and (k−1)+(|V|−k+1) = |V| (omega, using 1 ≤ k ≤ |V|), so the RHS is exactly 2^{|V|}. Hence edges.card · 2^{|V|−k+1} < 2^{|V|}, the engine's hypothesis.\n\n5. **Invoke the engine.** ProbMethod.Core.ramsey_avoidance edges k huniform (the counting bound) returns S : Finset V with ∀ e ∈ edges, ¬ Mono e S — precisely TwoColorable edges.\n\n6. **Contrapositive.** For property_B_lower_bound, by_contra plus push_neg turns ¬ (2^{k−1} ≤ edges.card) into edges.card < 2^{k−1}, feeding property_B_two_colorable to contradict non-2-colourability. This is the m(k) ≥ 2^{k−1} bound.",
+    "keyInsights": [
+      "**Same engine, different ground set.** The Ramsey instantiation reads the abstract ground set E as the *edges* of K_n; Property B reads it as the *vertices* of a hypergraph. The one abstract union bound therefore produces two classical theorems that look unrelated on the surface — a diagonal Ramsey lower bound and a hypergraph-colouring threshold — confirming the parent file's engine is genuinely reusable, not tailored to Ramsey.",
+      "**The whole proof is one arithmetic identity.** Once the engine is in hand, Property B reduces to 2^{|V|} = 2^{k−1}·2^{|V|−k+1}. The classical statement 'expected monochromatic edges < 1' is exactly the cancellation of the common factor 2^{|V|−k+1}; the probabilistic content lives entirely inside ramsey_avoidance, and the corollary needs only pow_add and a positivity fact.",
+      "**A nonempty edge is what makes the exponents behave.** The split 2^{|V|} = 2^{k−1}·2^{|V|−k+1} requires k ≤ |V|, which is not assumed but *derived*: any single k-edge is a subset of the |V| vertices, so k ≤ |V| (Finset.card_le_univ). The empty hypergraph, where this argument is unavailable, is handled separately and is vacuously 2-colourable.",
+      "**The lower bound is the contrapositive.** m(k) ≥ 2^{k−1} is not a separate argument: 'fewer than 2^{k−1} edges ⟹ 2-colourable' contrapositives directly to 'not 2-colourable ⟹ at least 2^{k−1} edges'. Stated uniformly over all finite vertex types V, this single implication is the Erdős lower bound on the extremal function m(k).",
+      "**Monochromaticity as set membership.** Encoding a 2-colouring as a subset S and 'edge e monochromatic' as e ⊆ S ∨ Disjoint e S (rather than as a function V → Bool with a same-colour predicate) is what lets the hypergraph problem plug straight into the engine: the engine's abstract blocks and the hypergraph's edges are literally the same Finset (Finset V), with no translation layer."
+    ],
+    "prerequisites": [
+      "The first-moment / union-bound existence principle (number of bad outcomes below the total ⟹ a good outcome exists)",
+      "Property B and the extremal function m(k) for 2-colourability of k-uniform hypergraphs",
+      "The abstract ProbMethod.Core.ramsey_avoidance engine and its set-theoretic monochromaticity predicate Mono",
+      "Elementary manipulation of powers of two over ℕ (pow_add, positivity, natural-number subtraction)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "framing",
+      "title": "Open Question and the Abstract Avoidance Engine",
+      "startLine": 1,
+      "endLine": 59,
+      "mathContext": "$|\\text{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\ \\Rightarrow\\ \\exists S,\\ \\forall K,\\ \\neg(K\\subseteq S \\vee K\\cap S = \\varnothing)$",
+      "summary": "Module docstring and imports (the companion ProbMethodApplicationsWIP). Records the open question posed by the sibling Ramsey entry — instantiate the abstract engine ProbMethod.Core.ramsey_avoidance for Property B (2-colourability of k-uniform hypergraphs) — and explains the reading used here: take the engine's ground set E to be the vertex set V of a hypergraph and the bad blocks to be the hyperedges, so the engine's counting hypothesis becomes the classical criterion edges.card < 2^{k−1}."
+    },
+    {
+      "id": "definition",
+      "title": "Property B as a Subset-Colouring Predicate",
+      "startLine": 63,
+      "endLine": 69,
+      "mathContext": "$\\text{TwoColorable}(\\mathrm{edges}) := \\exists S,\\ \\forall e \\in \\mathrm{edges},\\ \\neg(e \\subseteq S \\vee e \\cap S = \\varnothing)$",
+      "summary": "The predicate TwoColorable edges := ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S encodes hypergraph 2-colourability through the parent file's monochromaticity notion Mono e S = (e ⊆ S ∨ Disjoint e S). A 2-colouring is the set S of true-coloured vertices; an edge is bad exactly when all its vertices lie in S or all lie outside it. This makes the engine's abstract blocks and the hypergraph's edges the same type, with no translation layer."
+    },
+    {
+      "id": "instantiation",
+      "title": "Instantiating the Engine over the Vertex Set",
+      "startLine": 71,
+      "endLine": 92,
+      "mathContext": "$e_0 \\subseteq V,\\ |e_0| = k \\ \\Rightarrow\\ k \\le |V|$",
+      "summary": "property_B_two_colorable takes edges over a finite vertex type V with every hyperedge of size k, and fewer than 2^{k−1} edges. The empty hypergraph is vacuously 2-colourable. Otherwise a witnessing edge e₀ has k = e₀.card ≤ Fintype.card V (Finset.card_le_univ), pinning k ≤ |V| — the inequality that the exponent bookkeeping of the next step requires."
+    },
+    {
+      "id": "arithmetic-bridge",
+      "title": "The Arithmetic Bridge and the Engine Call",
+      "startLine": 93,
+      "endLine": 102,
+      "mathContext": "$2^{|V|} = 2^{k-1}\\cdot 2^{|V|-k+1},\\qquad \\mathrm{edges.card}\\cdot 2^{|V|-k+1} < 2^{|V|} \\iff \\mathrm{edges.card} < 2^{k-1}$",
+      "summary": "Multiplying edges.card < 2^{k−1} by the positive factor 2^{|V|−k+1} (mul_lt_mul_of_pos_right, pow_pos) gives edges.card·2^{|V|−k+1} < 2^{k−1}·2^{|V|−k+1}; pow_add in reverse plus (k−1)+(|V|−k+1) = |V| (omega) identifies the RHS with 2^{|V|}. This is exactly the engine's hypothesis, so ProbMethod.Core.ramsey_avoidance returns an avoiding subset S — a proper 2-colouring."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The Erdős Lower Bound m(k) ≥ 2^{k−1}",
+      "startLine": 104,
+      "endLine": 119,
+      "mathContext": "$\\neg\\,\\text{TwoColorable}(\\mathrm{edges}) \\ \\Rightarrow\\ 2^{k-1} \\le \\mathrm{edges.card}$",
+      "summary": "property_B_lower_bound is the contrapositive of property_B_two_colorable: by_contra and push_neg turn ¬(2^{k−1} ≤ edges.card) into edges.card < 2^{k−1}, which by the upper form makes the hypergraph 2-colourable, contradicting the hypothesis. Uniform over all finite vertex types V, this is the Erdős (1963/64) bound m(k) ≥ 2^{k−1} on the minimum edge count of a non-2-colourable k-uniform hypergraph."
+    }
+  ],
+  "conclusion": {
+    "summary": "The abstract first-moment avoidance engine ProbMethod.Core.ramsey_avoidance is instantiated over the vertex set of a k-uniform hypergraph, recovering Property B: every hypergraph with fewer than 2^{k−1} edges is 2-colourable (property_B_two_colorable), and its contrapositive is the Erdős lower bound m(k) ≥ 2^{k−1} (property_B_lower_bound). The only work beyond the engine is the arithmetic identity 2^{|V|} = 2^{k−1}·2^{|V|−k+1} and its consequence that the engine's counting hypothesis coincides with the classical criterion edges.card < 2^{k−1}. Zero sorries, zero axioms, no native_decide.",
+    "implications": "Together with the sibling Ramsey instantiation, this shows the parent file's union-bound engine is genuinely reusable: one abstract lemma yields both a diagonal Ramsey lower bound (ground set = edges of K_n) and a hypergraph 2-colourability threshold (ground set = vertices), fulfilling both applications its docstring asserted. The subset-as-colouring encoding means the hypergraph's edges are literally the engine's blocks, so no membership-translation step is needed — a small simplification over the Ramsey instantiation, which had to convert an avoiding edge set back into a Boolean colouring.",
+    "openQuestions": [
+      "Formalize the matching Erdős probabilistic upper bound m(k) = O(k^2 2^k) (a random k-uniform hypergraph on O(k^2 2^k) edges fails Property B with positive probability), pinning m(k) between 2^{k−1} and O(k^2 2^k).",
+      "Derive the Beck / Radhakrishnan–Srinivasan improved lower bound m(k) = Ω(2^k √(k / log k)) via the semi-random (Lovász Local Lemma / partial-colouring) method, and connect it to the gallery's Lovász Local Lemma entries.",
+      "State m(k) itself as a Lean-level extremal function (an infimum over all finite vertex types and k-uniform hypergraphs) and prove 2^{k−1} ≤ m(k) as a bound on that infimum, rather than the uniform per-hypergraph implication used here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-applications-wip-01",
+      "relationship": "extends",
+      "description": "Instantiates this file's abstract ramsey_avoidance engine at the vertex set of a hypergraph, turning its docstring's asserted Property B application into a machine-checked corollary (m(k) ≥ 2^{k−1})."
+    },
+    {
+      "targetId": "prob-method-applications-wip-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling instantiation of the same engine over a different ground set (edges of K_n vs. vertices of a hypergraph); this entry answers the open question that entry posed, extending the engine's first-moment output from the Ramsey bound to Property B."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ProbMethodApplicationsWIPOQ02.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.ProbMethodApplicationsWIP"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ProbMethod.PropertyB",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 2
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On a combinatorial problem",
+      "year": "1963",
+      "venue": "Nordisk Matematisk Tidskrift 11, 5–10",
+      "note": "Introduces the probabilistic lower bound m(k) ≥ 2^{k−1} for 2-colourability of k-uniform hypergraphs (Property B) — the bound formalized here."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "On a combinatorial problem. II",
+      "year": "1964",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae 15, 445–447",
+      "note": "Gives the probabilistic upper bound m(k) = O(k^2 2^k), complementing the 2^{k−1} lower bound proved here."
+    },
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 1 presents Property B and the first-moment lower bound m(k) ≥ 2^{k−1}; the abstract union-bound engine instantiated here is its combinatorial core."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "property_B_two_colorable",
+      "type": "core",
+      "description": "Every k-uniform hypergraph on a finite vertex type V with strictly fewer than 2^{k−1} edges is 2-colourable, obtained by instantiating the abstract ProbMethod.Core.ramsey_avoidance engine over the vertex set V.",
+      "leanType": "(edges : Finset (Finset V)) → (k : ℕ) → 1 ≤ k → (∀ e ∈ edges, e.card = k) → edges.card < 2 ^ (k - 1) → TwoColorable edges"
+    },
+    {
+      "name": "property_B_lower_bound",
+      "type": "core",
+      "description": "Property B lower bound m(k) ≥ 2^{k−1}: every k-uniform hypergraph that is not 2-colourable has at least 2^{k−1} edges. The contrapositive of property_B_two_colorable, uniform over all finite vertex types.",
+      "leanType": "(edges : Finset (Finset V)) → (k : ℕ) → 1 ≤ k → (∀ e ∈ edges, e.card = k) → ¬ TwoColorable edges → 2 ^ (k - 1) ≤ edges.card"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Instantiates the parent file's abstract union-bound engine `ProbMethod.Core.ramsey_avoidance` (from `Proofs/ProbMethodApplicationsWIP.lean`) at the **vertex** set of a k-uniform hypergraph — the complementary reading to the sibling entry OQ-01, which instantiates the same engine at the **edge** set of `Kₙ` to get the Ramsey bound `R(k,k) > n`. This recovers the classical **Property B** threshold.

New file `Proofs/ProbMethodApplicationsWIPOQ02.lean` (namespace `ProbMethod.PropertyB`):

- `TwoColorable edges := ∃ S : Finset V, ∀ e ∈ edges, ¬ Mono e S` — hypergraph 2-colourability via the parent's contained-or-disjoint monochromaticity predicate.
- `property_B_two_colorable` — every k-uniform hypergraph with fewer than `2^(k-1)` edges is 2-colourable.
- `property_B_lower_bound` — its contrapositive **m(k) ≥ 2^(k-1)** (Erdős 1963/64): every non-2-colourable k-uniform hypergraph has at least `2^(k-1)` edges.

## Why it's a genuine corollary, not a rename

The engine already carries the union bound. The only content beyond it is the identity `2^|V| = 2^(k-1)·2^(|V|-k+1)` (valid because a nonempty k-edge forces `k ≤ |V|`, derived via `Finset.card_le_univ`), which turns the engine's counting hypothesis `edges.card·2^(|V|-k+1) < 2^|V|` into the classical criterion `edges.card < 2^(k-1)`. This directly answers the open question the OQ-01 gallery entry posed ("instantiate the same abstract engine for Property B").

## Verification

Verified offline (`lake env lean`, EXIT 0) against Mathlib 4.26.0 — Docker build wrapper is currently hitting a containerd `meta.db` I/O error, so the sanctioned single-file path was used (same as prior WIP entries).

`#print axioms` for both theorems reports only `propext`, `Classical.choice`, `Quot.sound` — **0 sorry, 0 axiom, no native_decide, no sorryAx, no Lean.ofReduceBool**. Status `verified`.

Gallery data (`meta.json`, `annotations.json`, `index.ts`) included; 5 sections, 5 key insights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)