### PR TITLE
Enrich ζ(6)=π⁶/945 (basel-problem-oq-12): forward cross-reference to ζ(8)

### DIFF
--- a/src/data/proofs/basel-problem-oq-12/meta.json
+++ b/src/data/proofs/basel-problem-oq-12/meta.json
@@ -116,6 +116,11 @@
       "targetId": "basel-problem-oq-08",
       "relationship": "sibling",
       "description": "ζ(4) = π⁴/90, the k = 2 case; this entry is the next value ζ(6) in the family."
+    },
+    {
+      "targetId": "basel-problem-oq-15",
+      "relationship": "extendedBy",
+      "description": "ζ(8) = π⁸/9450, the k = 4 case — the next even zeta value in Euler's family after this ζ(6), built from the same hasSum_zeta_nat template with B₈ = −1/30. It realises this entry's first open question (\"Can ζ(8) = π⁸/9450 be obtained the same way?\"), the B₈ recurrence consuming this entry's B₆ = 1/42 as a summand."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-12` (ζ(6) = π⁶/945; quality 94, pass 0).

## Assessment
The entry already meets all enrichment minimums (4 keyInsights, 5 annotations each with mathContext, 745-char historicalContext, conclusion with implications + 2 open questions, sections covering the full 77-line Lean file). Rather than pad it, this pass fixes one genuine navigational gap.

## Change
- **Added one crossReference** from ζ(6) forward to `basel-problem-oq-15` (ζ(8) = π⁸/9450, the k = 4 case). The even-zeta family previously linked only backward (ζ(2) ← ζ(4) ← ζ(6)); ζ(6) dead-ended going forward even though the ζ(8) entry now exists in the gallery. The new link:
  - realises this entry's own first open question ("Can ζ(8) = π⁸/9450 be obtained the same way?"), and
  - reflects the real dependency: the ζ(8) proof's B₈ recurrence consumes this entry's B₆ = 1/42 as a summand.
- Verified `basel-problem-oq-08` genuinely is ζ(4) (existing crossReference is accurate — left unchanged).

## Verification
- `meta.json` valid JSON, 10.2 KB (well under 60 KB cap; `check-meta-size.ts` passes)
- No changes to status/badge/axiomCount (remains `verified`, 0 axioms, 0 sorries)
- Only `meta.json` changed; +5/−0 lines (crossReferences 2 → 3)