### PR TITLE
Enrich ζ(8)=π⁸/9450 (basel-problem-oq-15): keyInsight + family cross-ref

### DIFF
--- a/src/data/proofs/basel-problem-oq-15/meta.json
+++ b/src/data/proofs/basel-problem-oq-15/meta.json
@@ -71,7 +71,8 @@
     "keyInsights": [
       "**Even zeta values are rational multiples of powers of π.** ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!); at k = 4, B₈ = −1/30 yields ζ(8) = π⁸/9450.",
       "**The missing Bernoulli numbers are the real work.** Mathlib stops its packaged Bernoulli evaluations at B₄; reaching B₈ = −1/30 forces the recurrence to be unrolled twice (B₆ = 1/42 as an intermediate), the one step the gallery adds over a pure Mathlib lookup.",
-      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35."
+      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35.",
+      "**The elementary series and the analytic ζ agree at s = 8.** The value π⁸/9450 is certified twice: once as the elementary convergent sum ∑' n, 1/n⁸ (`tsum_one_div_nat_pow_eight`, from `hasSum_zeta_nat`) and once as `riemannZeta 8` — Mathlib's analytically-continued ζ over ℂ (`riemannZeta_eight_eq`, from `riemannZeta_two_mul_nat`). The entry thus confirms that the deep analytic object and the naive p-series coincide at the even integer 8, where the general Riemann-zeta identity ζ(s) = ∑ n^{-s} holds only for Re(s) > 1."
     ],
     "prerequisites": [
       "Infinite sums / tsum and HasSum in Mathlib",
@@ -124,6 +125,11 @@
       "targetId": "basel-problem",
       "relationship": "related",
       "description": "The Basel problem proves ζ(2) = π²/6; this entry is the degree-8 analogue ζ(8) = π⁸/9450, and the ratio theorem combines both even-zeta values"
+    },
+    {
+      "targetId": "basel-problem-oq-08",
+      "relationship": "related",
+      "description": "ζ(4) = π⁴/90, the degree-4 even-zeta value and this entry's grandparent in the family ζ(2) → ζ(4) → ζ(6) → ζ(8). Its π-free ratio ζ(4)/ζ(2)² = 2/5 opens the rational chain 2/5, 8/35, 24/175 that this entry's ζ(8)/ζ(2)⁴ = 24/175 continues."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-15` (ζ(8) = π⁸/9450).

**Gaps addressed:** entry had only 3 keyInsights (below the 4-minimum) and did not link to `basel-problem-oq-08` (ζ(4)), its grandparent in the even-zeta family.

**Changes:**
- Added a 4th keyInsight: the elementary p-series ∑' 1/n⁸ and Mathlib's analytically-continued `riemannZeta 8` are *both* proved to π⁸/9450 (via `hasSum_zeta_nat` and `riemannZeta_two_mul_nat`) — the entry certifies the naive sum and the deep analytic object agree at s = 8. This reflects theorems already in the Lean file.
- Added a crossReference to `basel-problem-oq-08` (ζ(4) = π⁴/90), completing the ζ(2)→ζ(4)→ζ(6)→ζ(8) chain; its ratio ζ(4)/ζ(2)² = 2/5 opens the rational chain 2/5, 8/35, 24/175 the entry already names.

**Verification:** valid JSON; all 3 crossReference targets exist; keyInsights 3→4, crossRefs 2→3; meta.json 12.6 KB (well under 60 KB cap). Full `tsc` build not run (worktree lacks node_modules) but the annotation build step parses every meta.json cleanly.