### PR TITLE
research(rh-consequences-oq-01): RH ⟹ M(x)=O(x^{1/2+ε}) via the honest Perron axiom boundary

### DIFF
--- a/proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean
+++ b/proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean
@@ -1,0 +1,169 @@
+/-
+# RH ⟹ M(x) = O(x^{1/2+ε}):  the honest Perron axiom boundary
+
+This file formalizes the **forward** direction of Littlewood's theorem:
+
+  Assuming the Riemann Hypothesis, the Mertens function
+  `M(x) = Σ_{n ≤ x} μ(n)` satisfies `M(x) = O(x^{1/2+ε})` for every `ε > 0`.
+
+**Status: axiomatized** (conditional on RH, which is open).
+
+## Why this file exists alongside the sibling `rh-consequences-oq-03`
+
+The sibling `RiemannHypothesisConsequencesOQ03.lean` also proves the forward
+direction, but it derives it from the **`√x` bound** `|M(n)| ≤ C·√n` taken as an
+axiom.  That `√x` bound is *strictly stronger* than what RH actually gives, and
+is in fact **believed false**: the Mertens conjecture `|M(x)| < √x` was disproved
+(Odlyzko–te Riele 1985), and more sharply `limsup M(x)/√x = +∞` is expected, so
+no bound of the form `|M(x)| ≤ C·√x` can hold.  Deriving the (true) ε-bound from
+a (believed-false) `√x` axiom is logically valid but rests on a false premise.
+
+**This file uses the correct axiom boundary.**  The genuine RH consequence
+(Littlewood 1912) factors through Perron's formula *without* ever asserting the
+`√x` bound:
+
+* **(P)** — *RH-free.*  Truncated Perron inversion writes `M(n)` as a contour
+  integral of `x^s / (s · ζ(s))` along `Re s = 1/2 + ε`, plus a truncation error
+  that is unconditionally `O(n^{1/2+ε})`.  We abstract the contour-integral value
+  as an opaque function `perronIntegral ε n` and axiomatize the error bound.
+
+* **(Z)** — *carries RH.*  Under RH, `ζ` has no zeros with `Re s > 1/2`, and the
+  conditional critical-strip estimate `|1/ζ(1/2+ε+it)| ≪_ε |t|^ε`
+  (Titchmarsh, *Theory of the Riemann Zeta-Function*, Thm 14.2) bounds the
+  shifted-contour integral itself by `O(n^{1/2+ε})`.
+
+* **Assembly** — *machine-checked here.*  The triangle inequality combines (P)
+  and (Z) into `|M(n)| ≤ (C₁+C₂) · n^{1/2+ε}`.  This is the only content beyond
+  the two analytic axioms, and it is genuinely verified — see
+  `rh_implies_mertens_eps_bound`.
+
+Both analytic inputs (a truncated Perron formula for `L`-series summatory
+functions, and a conditional `1/ζ` growth bound) are absent from Mathlib
+(each is hundreds of lines and needs Borel–Carathéodory + Hadamard three-circles
+machinery), which is why they are stated as axioms rather than proved.
+
+## Correctness note against the parent
+
+The parent `RiemannHypothesisConsequences.lean` states
+`axiom rh_implies_mertens_bound : RH → ∃ C, C>0 ∧ ∀ n≥1, |M n| ≤ C·√n`.
+By the argument above this **overclaims** — the `√x` form is believed false.
+The genuine consequence is the ε-form proved here as `rh_implies_mertens_eps_bound`.
+The parent axiom should be softened to the ε-form.  (The ε-form is genuinely
+weaker: `√n = n^{1/2} ≤ n^{1/2+ε}` for `n ≥ 1`; this monotonicity step is already
+machine-checked in the sibling `oq-03`, so we do not repeat it here.)
+
+Mathlib already provides `RiemannHypothesis`
+(`Mathlib/NumberTheory/LSeries/RiemannZeta.lean`) and the Möbius function
+`ArithmeticFunction.moebius`.
+-/
+
+import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.ArithmeticFunction.Moebius
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace RHConsequencesOQ01
+
+open ArithmeticFunction
+
+/-! ## The Mertens function -/
+
+/-- The Mertens function `M(n) = Σ_{k ≤ n} μ(k)` (matching the parent's
+definition: `Finset.range (n+1)` sums `k = 0, …, n`, and `μ 0 = 0`). -/
+def mertens (n : ℕ) : ℤ :=
+  ∑ k ∈ Finset.range (n + 1), ArithmeticFunction.moebius k
+
+@[simp] theorem mertens_zero : mertens 0 = 0 := by simp [mertens]
+
+theorem mertens_one : mertens 1 = 1 := by
+  simp [mertens, Finset.sum_range_succ]
+
+/-- Recurrence: `M(n+1) = M(n) + μ(n+1)`. -/
+theorem mertens_step (n : ℕ) :
+    mertens (n + 1) = mertens n + ArithmeticFunction.moebius (n + 1) := by
+  simp [mertens, Finset.sum_range_succ]
+
+/-! ## The abstract truncated Perron integral
+
+`perronIntegral ε n` stands for the truncated contour integral
+`(1 / 2πi) ∫_{1/2+ε-iT}^{1/2+ε+iT} n^s / (s · ζ(s)) ds` with truncation height
+`T = n`.  Its analytic construction is the Mathlib gap; we keep it opaque so that
+neither axiom below is derivable from the other — the Perron *factorization*
+`M(n) ≈ perronIntegral ε n` is genuine, not a relabelling of the conclusion. -/
+noncomputable opaque perronIntegral (ε : ℝ) (n : ℕ) : ℝ
+
+/-! ## The two classical analytic inputs (axioms) -/
+
+/-- **(P) Truncated Perron inversion — RH-free.**  `M(n)` equals the shifted-
+contour integral `perronIntegral ε n` up to a truncation error that is
+unconditionally `O(n^{1/2+ε})`.  This is the elementary Perron estimate (Mellin
+inversion + truncation of the vertical integral); it does **not** use RH. -/
+axiom perron_approx_error :
+    ∀ ε : ℝ, 0 < ε →
+      ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+        |(mertens n : ℝ) - perronIntegral ε n| ≤ C * (n : ℝ) ^ ((1 : ℝ) / 2 + ε)
+
+/-- **(Z) Conditional `1/ζ` bound on the shifted contour — carries RH.**  Under
+the Riemann Hypothesis the critical-strip estimate `|1/ζ(1/2+ε+it)| ≪_ε |t|^ε`
+holds, and integrating `|n^s| = n^{1/2+ε}` against it over the contour of height
+`T = n` bounds the Perron integral itself by `O(n^{1/2+ε})`.  This is where RH
+enters. -/
+axiom perron_integral_bound_of_rh :
+    RiemannHypothesis →
+      ∀ ε : ℝ, 0 < ε →
+        ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+          |perronIntegral ε n| ≤ C * (n : ℝ) ^ ((1 : ℝ) / 2 + ε)
+
+/-! ## The Littlewood growth condition -/
+
+/-- The Littlewood bound: for every `ε > 0` there is `C > 0` with
+`|M(n)| ≤ C · n^{1/2+ε}` for all `n ≥ 1`. -/
+def LittlewoodBound : Prop :=
+  ∀ ε : ℝ, 0 < ε →
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      |(mertens n : ℝ)| ≤ C * (n : ℝ) ^ ((1 : ℝ) / 2 + ε)
+
+/-! ## The Assembly (machine-checked)
+
+The only content beyond the two analytic axioms: the triangle inequality
+`|M(n)| ≤ |M(n) − I(n)| + |I(n)|` turns the RH-free Perron error (P) and the
+RH-conditional contour bound (Z) into the ε-bound, with combined constant
+`C₁ + C₂`.  No `√x` bound is used anywhere. -/
+
+/-- **RH ⟹ Littlewood ε-bound (proved from the Perron axiom boundary).**  For a
+fixed `ε > 0`: `|M(n)| ≤ |M(n) − perronIntegral ε n| + |perronIntegral ε n|`,
+and each summand is `≤ C · n^{1/2+ε}` by (P) and (Z) respectively. -/
+theorem rh_implies_mertens_eps_bound (h : RiemannHypothesis) :
+    ∀ ε : ℝ, 0 < ε →
+      ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+        |(mertens n : ℝ)| ≤ C * (n : ℝ) ^ ((1 : ℝ) / 2 + ε) := by
+  intro ε hε
+  obtain ⟨C₁, hC₁, hP⟩ := perron_approx_error ε hε
+  obtain ⟨C₂, hC₂, hZ⟩ := perron_integral_bound_of_rh h ε hε
+  refine ⟨C₁ + C₂, by positivity, fun n hn => ?_⟩
+  have htri :
+      |(mertens n : ℝ)|
+        ≤ |(mertens n : ℝ) - perronIntegral ε n| + |perronIntegral ε n| := by
+    calc |(mertens n : ℝ)|
+        = |((mertens n : ℝ) - perronIntegral ε n) + perronIntegral ε n| := by
+          ring_nf
+      _ ≤ |(mertens n : ℝ) - perronIntegral ε n| + |perronIntegral ε n| :=
+          abs_add_le _ _
+  calc |(mertens n : ℝ)|
+      ≤ |(mertens n : ℝ) - perronIntegral ε n| + |perronIntegral ε n| := htri
+    _ ≤ C₁ * (n : ℝ) ^ ((1 : ℝ) / 2 + ε) + C₂ * (n : ℝ) ^ ((1 : ℝ) / 2 + ε) :=
+        add_le_add (hP n hn) (hZ n hn)
+    _ = (C₁ + C₂) * (n : ℝ) ^ ((1 : ℝ) / 2 + ε) := by ring
+
+/-- Packaged as the `LittlewoodBound` predicate. -/
+theorem rh_implies_littlewoodBound (h : RiemannHypothesis) : LittlewoodBound :=
+  rh_implies_mertens_eps_bound h
+
+/-- Immediate corollary: under RH, for every `ε > 0` there is an explicit growth
+constant for the Mertens function (no `√x` bound assumed anywhere). -/
+theorem rh_gives_explicit_constant (h : RiemannHypothesis) (ε : ℝ) (hε : 0 < ε) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      |(mertens n : ℝ)| ≤ C * (n : ℝ) ^ ((1 : ℝ) / 2 + ε) :=
+  rh_implies_mertens_eps_bound h ε hε
+
+end RHConsequencesOQ01

--- a/research/problems/rh-consequences-oq-01/knowledge.md
+++ b/research/problems/rh-consequences-oq-01/knowledge.md
@@ -193,3 +193,35 @@ prose/survey deliverable only.
    ε-form (correctness fix).
 3. Long-horizon: contribute (P) truncated Perron for L-series to Mathlib (general
    interest, unblocks PNT-adjacent work too).
+
+---
+
+## ACT COMPLETE (2026-07-04, researcher-6) — PR #34868
+
+**Built (VERIFIED):** `proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean`
+executed the I3 axiom-boundary refactor as a genuine verified file.
+
+- `perronIntegral ε n` — `noncomputable opaque` truncated contour integral of
+  `x^s/(s·ζ(s))` at Re s = 1/2+ε (opaque so the factorization is genuine).
+- axiom (P) `perron_approx_error` — RH-FREE truncation error `|M − I| ≤ C·n^{1/2+ε}`.
+- axiom (Z) `perron_integral_bound_of_rh` — RH-carrying `|I| ≤ C·n^{1/2+ε}`.
+- **`rh_implies_mertens_eps_bound` — PROVED** triangle-inequality Assembly
+  (`abs_add_le` + `add_le_add`, combined constant C₁+C₂). No √x bound used.
+- Also `rh_implies_littlewoodBound`, `rh_gives_explicit_constant`.
+
+**Verified** offline `lake env lean` EXIT 0 (Mathlib 4.26.0): 6 thm / 3 def /
+2 axiom / 0 sorry. `#print axioms` = propext/Classical.choice/Quot.sound + the 2
+stated axioms only (opaque adds NONE; no native_decide → no Lean.ofReduceBool).
+
+**Key contribution vs sibling oq-03:** oq-03's forward proof rests on the
+believed-false √x axiom (`rh_implies_mertens_sqrt_bound`). This entry supplies the
+CORRECT boundary (Perron P + conditional 1/ζ Z), separated by RH footprint, with no
+false premise. Confirms/carries the correctness flag on the parent √x axiom.
+
+**Gotcha:** `abs_add` was renamed → use `abs_add_le : |a+b| ≤ |a|+|b|` in Mathlib 4.26.
+**Blackout:** Docker wrapper mathlib cache corrupt (`.ltar: expected value at line 1
+col 1` on 7000+ files) — used sanctioned offline `lake env lean` path instead.
+
+**Remaining (BLOCKED on Mathlib):** discharge (P) [truncated Perron for L-series,
+400–800 lines] and (Z) [conditional 1/ζ via Borel–Carathéodory + Hadamard 3-circles,
+500–1000+ lines].

--- a/research/problems/rh-consequences-oq-01/state.md
+++ b/research/problems/rh-consequences-oq-01/state.md
@@ -1,41 +1,48 @@
 # Research State: rh-consequences-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT (complete for this iteration)
 **Path**: full
-**Since**: 2026-07-02T00:00:00Z
-**Iteration**: 2
+**Since**: 2026-07-04
+**Iteration**: 3
 
 ## Current Focus
-Feasibility survey complete (see `knowledge.md`). Route identified: truncated
-Perron inversion of `1/ζ(s)` + conditional critical-strip `1/ζ` bound under RH.
-Chosen decomposition: axiom-boundary refactor (P)+(Z)+verified Assembly (I3).
+Landed the axiom-boundary refactor (I3) as a VERIFIED file. The forward direction
+RH ⟹ M(x)=O(x^{1/2+ε}) is now derived from the honest Perron boundary — (P) RH-free
+truncation error + (Z) RH-carrying conditional 1/ζ bound — via a machine-checked
+triangle-inequality Assembly. No √x bound is assumed anywhere.
 
 ## Active Approach
-Axiom-boundary refactor. Land the *Assembly* lemma (RH→bound logic) against typed
-axioms (P) truncated Perron and (Z) conditional `|1/ζ(1/2+ε+it)| ≪_ε |t|^ε`.
+COMPLETE (this iteration). File `proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean`:
+- `perronIntegral` (opaque truncated contour integral)
+- axiom `perron_approx_error` (P, RH-free)
+- axiom `perron_integral_bound_of_rh` (Z, RH)
+- `rh_implies_mertens_eps_bound` (PROVED Assembly), `rh_implies_littlewoodBound`,
+  `rh_gives_explicit_constant`
+Verified offline (`lake env lean`, EXIT 0, Mathlib 4.26.0): 6 thm, 3 def, 2 axiom,
+0 sorry. `#print axioms` = propext/Classical.choice/Quot.sound + the 2 stated axioms
+(no Lean.ofReduceBool; opaque adds none).
 
 ## Attempt Count
-- Total attempts: 0 (survey only; no Lean written)
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (first ACT)
+- Current approach attempts: 1
+- Approaches tried: 1 (Perron axiom-boundary Assembly — SUCCESS)
 
 ## Blockers
-- **Infrastructure (Mathlib):** Perron formula for L-series summatory functions
-  and conditional 1/ζ growth bounds are absent (> 1000 lines to build). Full
-  proof BLOCKED; the Assembly lemma is tractable once (P),(Z) are axiomatized.
-- **Tooling (this session):** dual-tool blackout — Docker build (containerd blob
-  I/O corruption; needs Docker restart) and Aristotle (404 `Resource not found`)
-  both down. No Lean could be built or proof-searched.
+- **Infrastructure (Mathlib):** (P) truncated Perron formula and (Z) conditional
+  1/ζ growth bound remain absent from Mathlib (each hundreds of lines). Full
+  discharge of the two axioms is still BLOCKED; the Assembly is landed.
+- **Tooling:** Docker build wrapper mathlib cache corrupt (`.ltar: expected value`
+  blackout); used the sanctioned offline `lake env lean` single-file path instead.
 
-## Correctness flag
-Parent `axiom rh_implies_mertens_bound` uses the `|M(x)| ≤ C√x` form, which
-**overclaims** (believed false; contradicts M(x)/√x oscillation Ω-results). The
-genuine RH consequence is `∀ε>0, M(x)=O(x^{1/2+ε})`. Any discharge must use the
-ε-form and the parent axiom should be softened.
+## Correctness flag (carried forward)
+Parent `axiom rh_implies_mertens_bound` uses `|M(x)| ≤ C√x`, which OVERCLAIMS
+(believed false; Odlyzko–te Riele 1985 disproved |M(x)|<√x). This file proves the
+genuine ε-form WITHOUT the √x bound. Sibling oq-03's forward proof DOES rest on the
+√x axiom — this entry supplies the corrected boundary. Parent axiom should be softened.
 
 ## Next Action
-When build infra returns: create `proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean`
-with typed axioms `perron_mertens` (P) + `inv_zeta_bound_of_RH` (Z) and prove the
-Assembly lemma `mertens_bound_of_perron_and_zeta_bound :
-  RiemannHypothesis → ∀ ε>0, ∃ C>0, ∀ n≥1, |mertens n| ≤ C * (n:ℝ)^(1/2+ε)`.
+Long-horizon: discharge (P) [truncated Perron for L-series summatory functions,
+400–800 lines] and (Z) [conditional critical-strip 1/ζ bound via Borel–Carathéodory
++ Hadamard three-circles, 500–1000+ lines] as Mathlib contributions. Optionally open
+a correctness note to soften the parent √x axiom to the ε-form.

--- a/src/data/proofs/rh-consequences-oq-01/annotations.json
+++ b/src/data/proofs/rh-consequences-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-rhoq01-overview",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "Overview: RH ⟹ M(x)=O(x^{1/2+ε}) through the honest Perron boundary",
+    "content": "This file formalizes the forward direction of Littlewood's 1912 theorem: assuming RH, the Mertens function M(x) = Σ_{n≤x} μ(n) satisfies M(x) = O(x^{1/2+ε}) for every ε > 0. The point of interest is the axiom boundary. The sibling oq-03 derives the same ε-bound from the sharper √x bound |M(n)| ≤ C·√n taken as an axiom — but that √x form is believed FALSE (the Mertens conjecture |M(x)| < √x was disproved by Odlyzko–te Riele 1985), so its forward proof rests on a false premise. This file instead factors the implication through Perron's formula: an RH-free truncation-error axiom (P) and an RH-carrying conditional 1/ζ bound axiom (Z). No √x bound is assumed, and the Assembly combining (P) and (Z) is machine-checked.",
+    "mathContext": "The forward direction is the classical conditional estimate via truncated Perron inversion of 1/ζ(s); this formalization keeps RH's role explicit and avoids the believed-false √x bound.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann Hypothesis", "Mertens function", "Perron formula", "conditional 1/ζ bound", "Littlewood 1912"],
+    "prerequisites": ["Riemann zeta function", "Möbius function", "Perron/Mellin inversion"]
+  },
+  {
+    "id": "ann-rhoq01-mertens",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 69, "endLine": 84 },
+    "type": "definition",
+    "title": "The Mertens function M(n) = Σ_{k≤n} μ(k)",
+    "content": "M(n) is the sum of ArithmeticFunction.moebius over Finset.range (n+1), matching the parent entry's convention (the k = 0 term contributes μ(0) = 0). The base values M(0) = 0, M(1) = 1 and the step relation M(n+1) = M(n) + μ(n+1) are proved by simp via Finset.sum_range_succ — deliberately avoiding native_decide so the file carries no Lean.ofReduceBool dependency.",
+    "mathContext": "The Mertens function is the summatory (partial-sum) function of the Möbius function; its growth rate is what Littlewood's theorem ties to RH.",
+    "significance": "supporting",
+    "relatedConcepts": ["Möbius function", "summatory function", "ArithmeticFunction.moebius", "Finset.sum_range_succ"],
+    "prerequisites": ["Möbius function", "finite sums in Mathlib"]
+  },
+  {
+    "id": "ann-rhoq01-perron-integral",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 86, "endLine": 93 },
+    "type": "definition",
+    "title": "The opaque truncated Perron integral perronIntegral ε n",
+    "content": "perronIntegral ε n abstracts the truncated contour integral (1/2πi)∫_{1/2+ε−iT}^{1/2+ε+iT} n^s/(s·ζ(s)) ds with truncation height T = n. It is declared `noncomputable opaque`, so it is a genuine unknown real value rather than a concrete stand-in. This opacity is essential: with a concrete definition (e.g. 0) one of the two analytic axioms below would trivially imply the other and the Assembly would collapse to assuming the conclusion. Opaque definitions add no axiom to #print axioms.",
+    "mathContext": "Perron/Mellin inversion produces exactly this contour integral; its analytic construction is the Mathlib gap, so it is kept abstract.",
+    "significance": "key",
+    "relatedConcepts": ["Perron formula", "Mellin inversion", "contour integral", "opaque definitions", "x^s/(s·ζ(s))"],
+    "prerequisites": ["contour integration", "Dirichlet series inversion"]
+  },
+  {
+    "id": "ann-rhoq01-axioms",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 95, "endLine": 116 },
+    "type": "concept",
+    "title": "The two analytic inputs, separated by RH footprint",
+    "content": "Two axioms encode the analytic content, split by whether they use RH. (P) perron_approx_error is RH-FREE: |M(n) − perronIntegral ε n| ≤ C·n^{1/2+ε}, the unconditional error from truncating the vertical Perron integral. (Z) perron_integral_bound_of_rh CARRIES RH: under RH, |perronIntegral ε n| ≤ C·n^{1/2+ε}, obtained from the conditional critical-strip estimate |1/ζ(1/2+ε+it)| ≪_ε |t|^ε (Titchmarsh Thm 14.2) integrated against |n^s| = n^{1/2+ε} over the height-T = n contour. These are the file's only assumptions; both need analytic machinery (a truncated Perron formula; a conditional 1/ζ growth bound) not yet in Mathlib.",
+    "mathContext": "Splitting the inputs by RH footprint pins down exactly where the Riemann Hypothesis is used — only in the conditional 1/ζ bound (Z); the Perron truncation error (P) is unconditional.",
+    "significance": "key",
+    "relatedConcepts": ["truncated Perron formula", "conditional 1/ζ bound", "critical strip", "Titchmarsh Thm 14.2", "zero-free region"],
+    "prerequisites": ["Perron/Mellin inversion", "critical-strip estimates for 1/ζ", "Riemann Hypothesis"]
+  },
+  {
+    "id": "ann-rhoq01-littlewoodbound",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 117, "endLine": 125 },
+    "type": "definition",
+    "title": "LittlewoodBound: the big-O growth predicate",
+    "content": "LittlewoodBound is the Prop stating that for every ε > 0 there is C > 0 with |M(n)| ≤ C · n^{1/2+ε} for all n ≥ 1 — the explicit-constant unfolding of M(x) = O(x^{1/2+ε}), quantified over all positive ε. The real power n^{1/2+ε} is Real.rpow, so the statement is meaningful for arbitrary real ε. It matches the sibling oq-03's predicate of the same name, so the two forward proofs target the identical conclusion.",
+    "mathContext": "The explicit-constant form of the big-O condition; it is the target of the forward implication proved here.",
+    "significance": "supporting",
+    "relatedConcepts": ["big-O notation", "Real.rpow", "Mertens conjecture", "asymptotic bounds"],
+    "prerequisites": ["asymptotic notation", "real power functions"]
+  },
+  {
+    "id": "ann-rhoq01-assembly",
+    "proofId": "rh-consequences-oq-01",
+    "range": { "startLine": 126, "endLine": 168 },
+    "type": "insight",
+    "title": "The Assembly: triangle inequality combines (P) and (Z)",
+    "content": "rh_implies_mertens_eps_bound is PROVED, not axiomatized. For fixed ε > 0 it unpacks constants C₁ from (P) and C₂ from (Z), then bounds |M(n)| ≤ |M(n) − perronIntegral ε n| + |perronIntegral ε n| (via abs_add_le on the rewrite M(n) = (M(n) − I) + I), applies add_le_add with (P) and (Z), and collects the combined constant C₁+C₂. This is the entire mathematical content beyond the two axioms, and it is genuinely machine-checked — crucially WITHOUT ever using a √x bound. rh_implies_littlewoodBound repackages it as the LittlewoodBound predicate and rh_gives_explicit_constant records the per-ε corollary. #print axioms confirms only propext, Classical.choice, Quot.sound, perron_approx_error and perron_integral_bound_of_rh — the opaque perronIntegral adds none.",
+    "mathContext": "The forward half of Littlewood's theorem reduces, given the correct analytic inputs, to a single triangle-inequality step — with the depth pushed cleanly into (P) and (Z).",
+    "significance": "key",
+    "relatedConcepts": ["triangle inequality", "abs_add_le", "add_le_add", "Perron factorization", "#print axioms"],
+    "prerequisites": ["triangle inequality for |·|", "elementary inequality manipulation"]
+  }
+]

--- a/src/data/proofs/rh-consequences-oq-01/meta.json
+++ b/src/data/proofs/rh-consequences-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "rh-consequences-oq-01",
+  "title": "RH ⟹ M(x) = O(x^{1/2+ε}): the honest Perron axiom boundary",
+  "slug": "rh-consequences-oq-01",
+  "description": "Formalizes the forward direction of Littlewood's theorem — RH implies the Mertens bound M(x) = O(x^{1/2+ε}) for every ε > 0 — through the CORRECT axiom boundary. Unlike the sibling oq-03, which derives the ε-bound from a believed-false √x bound, this entry factors the implication through Perron's formula: an RH-free truncated-Perron error axiom (P) and an RH-carrying conditional 1/ζ bound axiom (Z). The Assembly combining them by the triangle inequality is machine-checked, and no √x bound is assumed anywhere.",
+  "meta": {
+    "author": "Lean Genius (researcher-6)",
+    "date": "2026-07-04",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/RiemannHypothesisConsequencesOQ01.lean",
+    "tags": [
+      "analytic-number-theory",
+      "riemann-hypothesis",
+      "mertens-function",
+      "mobius-function",
+      "perron-formula",
+      "conditional"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 2,
+    "assumptions": "2 axioms encoding the genuine analytic inputs to the forward direction of Littlewood's theorem, cleanly separated by their RH footprint. (P) perron_approx_error — RH-FREE: truncated Perron inversion writes M(n) as a shifted-contour integral of x^s/(s·ζ(s)) along Re s = 1/2+ε up to a truncation error that is unconditionally O(n^{1/2+ε}); the contour value is kept opaque (perronIntegral) so the factorization is genuine, not a relabelling of the conclusion. (Z) perron_integral_bound_of_rh — CARRIES RH: under the Riemann Hypothesis the conditional critical-strip estimate |1/ζ(1/2+ε+it)| ≪_ε |t|^ε (Titchmarsh Thm 14.2) bounds the shifted-contour integral itself by O(n^{1/2+ε}). Both require analytic machinery (a truncated Perron formula for L-series summatory functions; a conditional 1/ζ growth bound via Borel–Carathéodory + Hadamard three-circles) not yet in Mathlib. The main result rh_implies_mertens_eps_bound is NOT axiomatized directly — it is the machine-checked triangle-inequality Assembly |M(n)| ≤ |M(n) − I(n)| + |I(n)| ≤ (C₁+C₂)·n^{1/2+ε}. Crucially, no √x bound is assumed: #print axioms lists only propext, Classical.choice, Quot.sound and the two stated axioms — no native_decide, so no Lean.ofReduceBool dependency, and the opaque perronIntegral contributes no axiom.",
+    "lineCount": 169,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "originalContributions": [
+      "The correct axiom boundary for RH ⟹ M(x)=O(x^{1/2+ε}): factors through Perron's formula (P)+(Z) instead of the believed-false √x bound used by sibling oq-03, eliminating the false premise",
+      "perronIntegral: an opaque abstraction of the truncated contour integral of x^s/(s·ζ(s)) along Re s = 1/2+ε, kept opaque so neither analytic axiom is derivable from the other — the Perron factorization is genuine",
+      "perron_approx_error (P): RH-FREE truncation-error axiom, |M(n) − perronIntegral ε n| ≤ C·n^{1/2+ε}, isolating the elementary (unconditional) half of Perron inversion",
+      "perron_integral_bound_of_rh (Z): the RH-carrying conditional 1/ζ bound, |perronIntegral ε n| ≤ C·n^{1/2+ε}, isolating exactly where RH enters",
+      "rh_implies_mertens_eps_bound: PROVED (not axiomatized) — the triangle-inequality Assembly combining (P) and (Z) with combined constant C₁+C₂; the only content beyond the two axioms and genuinely machine-checked",
+      "Correctness note against the parent axiom rh_implies_mertens_bound (|M(x)| ≤ C·√x), which overclaims (the √x form is believed false; Odlyzko–te Riele 1985 disproved |M(x)| < √x); the genuine consequence is the ε-form derived here"
+    ]
+  },
+  "overview": {
+    "historicalContext": "John Edensor Littlewood proved in 1912 that RH is equivalent to M(x) = O(x^{1/2+ε}) for every ε > 0, where M(x) = Σ_{n≤x} μ(n). The forward direction — RH ⟹ ε-bound — is the classical conditional estimate obtained by truncated Perron inversion of 1/ζ(s), shifting the contour to Re s = 1/2+ε and bounding 1/ζ along the critical strip (Titchmarsh, Theory of the Riemann Zeta-Function, Ch. 14). The much stronger Mertens conjecture |M(x)| < √x was disproved by Odlyzko and te Riele (1985), so the √x bound cannot be the honest consequence; the ε-relaxed form is exactly the growth rate RH controls.",
+    "problemStatement": "Prove rh_implies_mertens_bound: assuming RH, M(x) = O(x^{1/2+ε}) for every ε > 0, using an axiom boundary that reflects the genuine analytic content (Perron inversion + conditional 1/ζ bound) rather than assuming the believed-false √x bound.",
+    "text": "Using Mathlib's RiemannHypothesis predicate and ArithmeticFunction.moebius, this file defines the Mertens function M(n), an opaque truncated Perron integral perronIntegral ε n, and the Littlewood growth predicate. It states two analytic axioms separated by their RH footprint — (P) an RH-free Perron truncation-error bound and (Z) an RH-carrying bound on the shifted-contour integral — and derives the ε-bound rh_implies_mertens_eps_bound by the triangle inequality. No √x bound appears anywhere.",
+    "proofStrategy": "The forward implication factors as M(n) = perronIntegral ε n + (M(n) − perronIntegral ε n). Axiom (P) bounds the second summand unconditionally by C₁·n^{1/2+ε} (truncation of the vertical integral). Axiom (Z) bounds the first summand by C₂·n^{1/2+ε} under RH (conditional |1/ζ| ≪_ε |t|^ε integrated against |n^s| = n^{1/2+ε} over the height-T = n contour). The Assembly rh_implies_mertens_eps_bound applies |M(n)| ≤ |M(n) − perronIntegral ε n| + |perronIntegral ε n| (abs_add_le) and add_le_add to get the combined constant C₁+C₂ — fully machine-checked. Keeping perronIntegral opaque guarantees the factorization is genuine: neither axiom collapses into the conclusion.",
+    "keyInsights": [
+      "The honest axiom boundary is Perron (P) + conditional 1/ζ (Z), not the √x bound: sibling oq-03 derives the ε-bound from |M(n)| ≤ C·√n, but that √x form is believed FALSE (Odlyzko–te Riele 1985), so its forward proof rests on a false premise; this file avoids the √x bound entirely",
+      "Separating the two axioms by RH footprint makes the role of RH precise: (P) the Perron truncation error is UNCONDITIONAL; RH enters ONLY through (Z), the conditional critical-strip 1/ζ bound",
+      "Keeping the contour integral opaque (perronIntegral) is what makes the factorization non-trivial — with a concrete stand-in (e.g. 0) one axiom would trivially imply the other and the Assembly would be vacuous",
+      "The Assembly is a genuine machine-checked derivation: the triangle inequality |M| ≤ |M − I| + |I| turns the two analytic bounds into the ε-bound with combined constant C₁+C₂",
+      "Avoiding native_decide keeps the file free of Lean.ofReduceBool; #print axioms shows exactly the two stated axioms (plus propext/Classical.choice/Quot.sound), and the opaque definition adds none"
+    ],
+    "prerequisites": [
+      "The Riemann zeta function and the Riemann Hypothesis",
+      "The Möbius and Mertens functions",
+      "Perron's formula / Mellin inversion and truncated vertical contour integrals",
+      "Conditional critical-strip bounds on 1/ζ (Titchmarsh Ch. 14)",
+      "Real power functions (rpow) and the triangle inequality for |·|"
+    ]
+  },
+  "conclusion": {
+    "summary": "A focused formalization of the forward direction of Littlewood's theorem, RH ⟹ M(x) = O(x^{1/2+ε}), built on the correct axiom boundary. The Mertens function and an opaque truncated Perron integral are defined from Mathlib primitives; two analytic axioms are stated and separated by their RH footprint — an RH-free Perron truncation-error bound and an RH-carrying conditional 1/ζ bound — and the ε-bound is derived from them by a machine-checked triangle-inequality Assembly. No √x bound is assumed.",
+    "implications": "This entry supplies the axiom hygiene the parent rh-consequences entry and the sibling oq-03 lack: it isolates exactly where RH is used (the conditional 1/ζ bound) and never asserts the believed-false √x bound. It complements oq-03, whose forward proof rests on that √x axiom, and flags that the parent axiom rh_implies_mertens_bound should be softened from the √x form to the ε-form. Discharging (P) and (Z) would require formalizing a truncated Perron formula for L-series summatory functions and a conditional critical-strip 1/ζ growth bound — natural long-horizon Mathlib targets that would also unblock PNT-adjacent work.",
+    "openQuestions": [
+      "Can the RH-free Perron axiom (P) be discharged in Lean? It needs a truncated Perron / Mellin-inversion formula for the summatory Möbius function together with an unconditional bound on the truncation error — 400–800 lines of new Mathlib analytic infrastructure.",
+      "Can the RH-carrying axiom (Z) be discharged? It needs the conditional critical-strip estimate |1/ζ(1/2+ε+it)| ≪_ε |t|^ε under RH (Titchmarsh Thm 14.2), which rests on Borel–Carathéodory and Hadamard three-circles applied to log ζ — 500–1000+ lines not yet in Mathlib.",
+      "Should the parent axiom rh_implies_mertens_bound (|M(x)| ≤ C·√x) be softened to the ε-form? The √x form is believed false (contradicts the expected oscillation limsup M(x)/√x = +∞), so any discharge must target the ε-form proved here.",
+      "Does the ε-bound obtained here match the sibling oq-03's LittlewoodBound predicate exactly, so the two forward proofs (Perron route vs √x route) can be reconciled and the √x-based one retired in favour of the honest one?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "RHConsequencesOQ01",
+    "lineCount": 169,
+    "axiomCount": 2,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "path": "Proofs/RiemannHypothesisConsequencesOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "rh-consequences",
+      "relationship": "extends",
+      "description": "Parent entry: states axiom rh_implies_mertens_bound with the √x bound. This child proves the forward direction through the honest Perron axiom boundary and flags that the parent axiom overclaims (√x is believed false)."
+    },
+    {
+      "targetId": "rh-consequences-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry formalizing the full Littlewood equivalence. Its forward direction is derived from the believed-false √x bound; this entry supplies the corrected axiom boundary (Perron + conditional 1/ζ) for the same forward implication."
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "derives-from",
+      "description": "Uses Mathlib's RiemannHypothesis predicate as the hypothesis carrying the conditional 1/ζ bound."
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "related",
+      "description": "The Mertens bound and the PNT error term are both controlled by the location of the zeros of ζ; both go through Perron/Mellin inversion of a Dirichlet series."
+    }
+  ],
+  "sections": [
+    {
+      "id": "mertens-function",
+      "title": "The Mertens function",
+      "startLine": 69,
+      "endLine": 84,
+      "summary": "Defines M(n) = Σ_{k≤n} μ(k) from ArithmeticFunction.moebius (matching the parent's Finset.range (n+1) convention), with M(0)=0, M(1)=1, and the step relation M(n+1)=M(n)+μ(n+1), all by simp (no native_decide).",
+      "mathContext": "The Mertens function is the summatory function of the Möbius function; its growth rate is the object of Littlewood's theorem."
+    },
+    {
+      "id": "perron-integral",
+      "title": "The abstract truncated Perron integral",
+      "startLine": 86,
+      "endLine": 93,
+      "summary": "Introduces perronIntegral ε n as an opaque real-valued function standing for the truncated contour integral (1/2πi)∫ n^s/(s·ζ(s)) ds along Re s = 1/2+ε at height T = n. Keeping it opaque ensures neither analytic axiom is derivable from the other.",
+      "mathContext": "This is the object Perron inversion produces; its analytic construction is the Mathlib gap, so it is abstracted rather than defined."
+    },
+    {
+      "id": "analytic-axioms",
+      "title": "The two classical analytic inputs (axioms)",
+      "startLine": 95,
+      "endLine": 116,
+      "summary": "States (P) perron_approx_error — RH-free, |M(n) − perronIntegral ε n| ≤ C·n^{1/2+ε} — and (Z) perron_integral_bound_of_rh — under RH, |perronIntegral ε n| ≤ C·n^{1/2+ε}. These are the file's only assumptions, separated by their RH footprint.",
+      "mathContext": "The truncation error (P) is unconditional; RH enters exactly at the conditional 1/ζ bound (Z). Neither is in Mathlib."
+    },
+    {
+      "id": "littlewood-condition",
+      "title": "The Littlewood growth condition",
+      "startLine": 117,
+      "endLine": 125,
+      "summary": "Defines LittlewoodBound: for every ε > 0 there is C > 0 with |M(n)| ≤ C·n^{1/2+ε} for all n ≥ 1 — the explicit-constant form of M(x) = O(x^{1/2+ε}).",
+      "mathContext": "This predicate is the target of the forward implication, quantified over all positive ε."
+    },
+    {
+      "id": "assembly",
+      "title": "The Assembly (machine-checked)",
+      "startLine": 126,
+      "endLine": 168,
+      "summary": "Proves rh_implies_mertens_eps_bound by the triangle inequality |M(n)| ≤ |M(n) − perronIntegral ε n| + |perronIntegral ε n| (abs_add_le), bounding each summand by (P) and (Z) and adding to get combined constant C₁+C₂. Packaged as rh_implies_littlewoodBound and rh_gives_explicit_constant.",
+      "mathContext": "The only content beyond the two axioms: combining the RH-free Perron error and the RH-conditional contour bound into the ε-bound — genuinely verified, with no √x bound used."
+    }
+  ],
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "John Edensor Littlewood",
+      "title": "Quelques conséquences de l'hypothèse que la fonction ζ(s) de Riemann n'a pas de zéros dans le demi-plan Re(s) > 1/2",
+      "year": 1912,
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, 154",
+      "note": "Original source of the equivalence between RH and the Mertens bound M(x) = O(x^{1/2+ε}); the forward direction formalized here."
+    },
+    {
+      "authors": "Edward Charles Titchmarsh (rev. D. R. Heath-Brown)",
+      "title": "The Theory of the Riemann Zeta-Function",
+      "year": 1986,
+      "venue": "Oxford University Press, 2nd ed.",
+      "note": "Chapter 14 gives the conditional critical-strip bound |1/ζ(1/2+ε+it)| ≪_ε |t|^ε under RH (axiom Z) and the Perron-inversion route to M(x) (axiom P)."
+    },
+    {
+      "authors": "Andrew M. Odlyzko, Herman J. J. te Riele",
+      "title": "Disproof of the Mertens conjecture",
+      "year": 1985,
+      "venue": "Journal für die reine und angewandte Mathematik, 357",
+      "note": "Disproves |M(x)| < √x, establishing that the honest RH consequence is the ε-form proved here, not the √x form of the parent axiom."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes the **forward direction** of Littlewood's 1912 theorem — RH implies the Mertens bound `M(x) = O(x^{1/2+ε})` for every ε > 0 — through the **correct axiom boundary**.

**Why a new entry alongside `rh-consequences-oq-03`?** The sibling oq-03 derives the same ε-bound from the sharper `√x` bound `|M(n)| ≤ C·√n` taken as an axiom. But that `√x` form is **believed false**: the Mertens conjecture `|M(x)| < √x` was disproved by Odlyzko–te Riele (1985), and `limsup M(x)/√x = +∞` is expected. Deriving the (true) ε-bound from a (believed-false) `√x` axiom is logically valid but rests on a false premise. This entry avoids the `√x` bound entirely.

## The honest factorization

The genuine RH consequence factors through Perron's formula, separated by RH footprint:

| Axiom | RH? | Content |
|-------|-----|---------|
| `perron_approx_error` (P) | **RH-free** | `\|M(n) − perronIntegral ε n\| ≤ C·n^{1/2+ε}` — unconditional truncation error of Perron inversion |
| `perron_integral_bound_of_rh` (Z) | **carries RH** | `\|perronIntegral ε n\| ≤ C·n^{1/2+ε}` — from the conditional `\|1/ζ(1/2+ε+it)\| ≪_ε \|t\|^ε` (Titchmarsh Thm 14.2) |

`perronIntegral` (the truncated contour integral of `x^s/(s·ζ(s))`) is kept **`opaque`** so neither axiom collapses into the other — the factorization is genuine, not a relabelling of the conclusion.

**The Assembly `rh_implies_mertens_eps_bound` is PROVED, not axiomatized:** the triangle inequality `|M| ≤ |M−I| + |I|` combines (P) and (Z) into the ε-bound with combined constant `C₁+C₂`. This is the only content beyond the two axioms, and it uses **no `√x` bound**.

## Verification

Verified offline (`lake env lean`, EXIT 0, Mathlib 4.26.0 — the Docker wrapper's mathlib cache is currently corrupt):
- **6 theorems, 3 defs, 2 axioms, 0 sorries**
- `#print axioms rh_implies_mertens_eps_bound` = `propext, Classical.choice, Quot.sound, perron_approx_error, perron_integral_bound_of_rh`
- No `native_decide` → **no `Lean.ofReduceBool`**; the `opaque` definition adds no axiom.
- **Status: axiomatized** (conditional on RH, which is open).

## Correctness note

Flags the parent `axiom rh_implies_mertens_bound` (`|M(x)| ≤ C·√x`) as **overclaiming** and recommends softening it to the ε-form proved here.

## Files
- `proofs/Proofs/RiemannHypothesisConsequencesOQ01.lean` (169 lines)
- `src/data/proofs/rh-consequences-oq-01/{meta.json,annotations.json}` (5 sections, 6 annotations, all matched by `annotations:build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)