### PR TITLE
Enrich Second-Moment Sum ∑k²rᵏ (summation-by-parts-oq-01-oq-02-oq-01): 4th keyInsight

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
@@ -77,7 +77,8 @@
     "keyInsights": [
       "**Field, not analysis.** The sibling entry works over $\\mathbb{R}$; but the identity is a polynomial-over-$(r-1)^3$ statement needing no norm and no convergence — it holds over any field for every $r\\neq1$, with $r(1+r)/(1-r)^3$ merely its $n\\to\\infty$ shadow when $|r|<1$.",
       "**Linear differences are the fingerprint of $k^2$.** Abel summation expresses the sum via the forward differences of the weight: constant ($1$) for the first moment, linear ($2k+1$) for the second. The order of the discrete derivative is read off directly from how the correction term is weighted.",
-      "**One consistent family.** The falling-factorial form, the second-moment form, and the sibling first-moment form are tied by $k^2=k(k-1)+k$ as a term-by-term identity of finite sums — the second moment is literally the sum of the other two."
+      "**One consistent family.** The falling-factorial form, the second-moment form, and the sibling first-moment form are tied by $k^2=k(k-1)+k$ as a term-by-term identity of finite sums — the second moment is literally the sum of the other two.",
+      "**Eulerian polynomials index the whole family.** The first- and second-moment sums are the $m=1,2$ cases of $\\sum_{k} k^m r^k$, which is always a rational function with denominator $(r-1)^{m+1}$ and numerator the Eulerian polynomial $A_m(r)$ (the generating identity $\\sum_{k\\ge 0} k^m r^k = A_m(r)/(1-r)^{m+1}$, with Eulerian numbers as coefficients). The $(r-1)^3$ seen here is precisely the $m=2$ denominator; Abel summation is the mechanism that lowers $m$ by one at each pass, so the falling-factorial computation is a hand-cranked recursion on this Eulerian family."
     ]
   },
   "sections": [


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-02-oq-01` (Second-Moment Sum ∑ k²·rᵏ over Any Field). **Gap:** only 3 keyInsights (minimum 4).

Added a 4th keyInsight placing the entry in its family: ∑ kᵐrᵏ = A_m(r)/(1−r)^{m+1} where A_m is the **Eulerian polynomial**; the (r−1)³ denominator this entry sees is exactly the m=2 case, and Abel summation is the recursion lowering m by one per pass. Consistent with the entry's own '(r−1)³ statement' framing and its sibling first-moment (m=1) entry. keyInsights 3→4; localized diff; valid JSON.