### PR TITLE
research(fibonacci-identities-oq-05-oq-01-oq-02): Gibonacci/Lucas weighted product-sum

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ05OQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ05OQ01OQ02.lean
@@ -1,0 +1,149 @@
+import Mathlib
+
+set_option linter.unusedTactic false
+
+/-!
+# Weighted product-sum identities for Lucas and Gibonacci sequences
+
+The parent file `FibonacciIdentitiesOQ05OQ01.lean` proves the **weighted product-sum**
+closed form for Fibonacci numbers:
+`2·∑_{k≤n} k FₖFₖ₊₁ = 2n Fₙ₊₁² − 2 Fₙ Fₙ₊₁ + (if n even then −n else n+1)`.
+Its open question asks to generalize this to Lucas numbers and to arbitrary **Gibonacci**
+(generalized Fibonacci) sequences, and to see what the parity correction `±1` becomes.
+
+## Answer
+For any integer sequence `G` satisfying the Fibonacci recurrence `Gₙ₊₂ = Gₙ + Gₙ₊₁`, put
+the **discriminant** `D := G₁² − G₁G₀ − G₀²`. Then:
+
+* `gib_cassini` — Cassini generalizes verbatim with `D` in place of `1`:
+  `Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ · D`.
+
+* `gib_weighted_prod_sum` — the weighted product-sum has the closed form
+  `2·∑_{k≤n} k GₖGₖ₊₁ = 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1)`.
+  So the parity correction `±1` of the Fibonacci case is exactly `±D`: **the correction is
+  governed by the discriminant**, plus a constant `2G₀G₁` coming from a nonzero initial seed.
+
+## Specializations
+* **Fibonacci** (`G₀=0, G₁=1`): `D = 1`, `2G₀G₁ = 0`, recovering the parent identity exactly
+  (`fib_weighted_prod_sum` below).
+* **Lucas** (`L₀=2, L₁=1`): `D = 1 − 2 − 4 = −5` (the Fibonacci–Lucas discriminant, the `5`
+  under the `√5` of Binet's formula) and `2L₀L₁ = 4`, giving
+  `2·∑ k LₖLₖ₊₁ = 2n Lₙ₊₁² − 2 Lₙ Lₙ₊₁ + 4 − 5·(if n even then −n else n+1)`
+  (`lucas_weighted_prod_sum`), and Cassini `Lₙ₊₁² − Lₙ₊₁Lₙ − Lₙ² = −5·(−1)ⁿ`.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ05OQ01OQ02
+
+open Finset
+
+section Gibonacci
+
+variable (G : ℕ → ℤ) (hrec : ∀ n, G (n + 2) = G n + G (n + 1))
+
+include hrec
+
+/-- **Cassini for a Gibonacci sequence.** With discriminant `D = G₁² − G₁G₀ − G₀²`,
+`Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ · D`. Proved by induction off the recurrence; the Fibonacci
+case (`D = 1`) is the classical Cassini identity. -/
+theorem gib_cassini (n : ℕ) :
+    G (n + 1) ^ 2 - G (n + 1) * G n - (G n) ^ 2
+      = (-1) ^ n * (G 1 ^ 2 - G 1 * G 0 - (G 0) ^ 2) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    have hr : G (n + 1 + 1) = G n + G (n + 1) := hrec n
+    have hsign : (-1 : ℤ) ^ (n + 1) = -(-1) ^ n := by rw [pow_succ]; ring
+    rw [hsign, hr]
+    linear_combination -ih
+
+/-- **Weighted product-sum for a Gibonacci sequence** (closed form).
+`2·∑_{k≤n} k GₖGₖ₊₁ = 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1)`,
+where `D = G₁² − G₁G₀ − G₀²`. The parity correction of the Fibonacci case is scaled by the
+discriminant `D`; the constant `2 G₀ G₁` is the contribution of a nonzero seed. -/
+theorem gib_weighted_prod_sum (n : ℕ) :
+    2 * ∑ k ∈ Finset.range (n + 1), (k : ℤ) * G k * G (k + 1)
+      = 2 * n * (G (n + 1)) ^ 2 - 2 * G n * G (n + 1)
+        + 2 * G 0 * G 1
+        + (G 1 ^ 2 - G 1 * G 0 - (G 0) ^ 2) * (if Even n then -(n : ℤ) else (n + 1)) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, mul_add, ih]
+    have hr : G (n + 1 + 1) = G n + G (n + 1) := hrec n
+    have hcass := gib_cassini G hrec n
+    rcases Nat.even_or_odd n with hn | hn
+    · -- n even ⇒ (n+1) odd
+      have hodd : ¬ Even (n + 1) := by simp [Nat.even_add_one, hn]
+      have hcass1 : G (n + 1) ^ 2 - G (n + 1) * G n - (G n) ^ 2
+          = (G 1 ^ 2 - G 1 * G 0 - (G 0) ^ 2) := by
+        rw [hcass, hn.neg_one_pow]; ring
+      rw [if_pos hn, if_neg hodd, hr]
+      push_cast
+      linear_combination 2 * ((n : ℤ) + 1) * hcass1
+    · -- n odd ⇒ (n+1) even
+      have hev : Even (n + 1) := hn.add_one
+      have hne : ¬ Even n := by simpa [Nat.not_even_iff_odd] using hn
+      have hcass1 : G (n + 1) ^ 2 - G (n + 1) * G n - (G n) ^ 2
+          = -(G 1 ^ 2 - G 1 * G 0 - (G 0) ^ 2) := by
+        rw [hcass, hn.neg_one_pow]; ring
+      rw [if_neg hne, if_pos hev, hr]
+      push_cast
+      linear_combination 2 * ((n : ℤ) + 1) * hcass1
+
+end Gibonacci
+
+/-! ## Fibonacci recovery (`D = 1`, seed `2G₀G₁ = 0`) -/
+
+/-- The integer-cast Fibonacci sequence satisfies the Gibonacci recurrence. -/
+private theorem fib_hrec (n : ℕ) :
+    ((Nat.fib (n + 2) : ℤ)) = (Nat.fib n : ℤ) + (Nat.fib (n + 1) : ℤ) := by
+  have h := Nat.fib_add_two (n := n)
+  exact_mod_cast h
+
+/-- **Fibonacci weighted product-sum**, recovered from the Gibonacci formula: the
+discriminant is `D = 1` and the seed constant `2 F₀ F₁ = 0`, so the correction is `±1`. -/
+theorem fib_weighted_prod_sum (n : ℕ) :
+    2 * ∑ k ∈ Finset.range (n + 1), (k : ℤ) * Nat.fib k * Nat.fib (k + 1)
+      = 2 * n * (Nat.fib (n + 1)) ^ 2 - 2 * Nat.fib n * Nat.fib (n + 1)
+        + (if Even n then -(n : ℤ) else (n + 1)) := by
+  have h := gib_weighted_prod_sum (fun m => (Nat.fib m : ℤ)) fib_hrec n
+  simp only [Nat.fib_zero, Nat.fib_one, Nat.cast_zero, Nat.cast_one] at h
+  linear_combination h
+
+/-! ## Lucas numbers (`D = −5`, seed `2L₀L₁ = 4`) -/
+
+/-- The **Lucas numbers** `L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁`, as an integer sequence. -/
+def Luc : ℕ → ℤ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => Luc n + Luc (n + 1)
+
+@[simp] theorem Luc_zero : Luc 0 = 2 := rfl
+@[simp] theorem Luc_one : Luc 1 = 1 := rfl
+
+theorem Luc_rec (n : ℕ) : Luc (n + 2) = Luc n + Luc (n + 1) := by
+  cases n <;> rfl
+
+/-- **Cassini for Lucas numbers:** `Lₙ₊₁² − Lₙ₊₁Lₙ − Lₙ² = (−1)ⁿ · (−5)`. The Fibonacci
+`±1` is replaced by the discriminant `−5`. -/
+theorem lucas_cassini (n : ℕ) :
+    Luc (n + 1) ^ 2 - Luc (n + 1) * Luc n - (Luc n) ^ 2 = (-1) ^ n * (-5) := by
+  have h := gib_cassini Luc Luc_rec n
+  rw [Luc_zero, Luc_one] at h
+  linear_combination h
+
+/-- **Lucas weighted product-sum:**
+`2·∑_{k≤n} k LₖLₖ₊₁ = 2n Lₙ₊₁² − 2 Lₙ Lₙ₊₁ + 4 − 5·(if n even then −n else n+1)`.
+The parity correction is scaled by the Lucas discriminant `D = −5`, with seed constant
+`2 L₀ L₁ = 4`. -/
+theorem lucas_weighted_prod_sum (n : ℕ) :
+    2 * ∑ k ∈ Finset.range (n + 1), (k : ℤ) * Luc k * Luc (k + 1)
+      = 2 * n * (Luc (n + 1)) ^ 2 - 2 * Luc n * Luc (n + 1)
+        + 4 + (-5) * (if Even n then -(n : ℤ) else (n + 1)) := by
+  have h := gib_weighted_prod_sum Luc Luc_rec n
+  rw [Luc_zero, Luc_one] at h
+  linear_combination h
+
+end FibonacciIdentitiesOQ05OQ01OQ02

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-01-oq-02/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "fibonacci-identities-oq-05-oq-01-oq-02",
+  "title": "Weighted Product-Sum Identities for Lucas and Gibonacci Sequences",
+  "slug": "fibonacci-identities-oq-05-oq-01-oq-02",
+  "description": "Generalizes the parent's Fibonacci weighted product-sum 2·∑ k FₖFₖ₊₁ to arbitrary Gibonacci (generalized Fibonacci) sequences and to Lucas numbers, showing the parity correction ±1 becomes ±D for the discriminant D = G₁² − G₁G₀ − G₀² (with D = 1 for Fibonacci, D = −5 for Lucas). Fully verified, 0 axioms / 0 sorries.",
+  "meta": {
+    "author": "Classical (Lucas; Gibonacci folklore); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas",
+      "gibonacci",
+      "cassini",
+      "summation-identity",
+      "weighted-sum",
+      "discriminant",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ05OQ01OQ02.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "lineCount": 149,
+    "mathlib_version": "4.26.0",
+    "assumptions": [],
+    "originalContributions": [
+      "gib_cassini: the Cassini identity for an arbitrary Gibonacci sequence — Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ·D with discriminant D = G₁² − G₁G₀ − G₀².",
+      "gib_weighted_prod_sum: the closed form 2·∑_{k≤n} k GₖGₖ₊₁ = 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1), exhibiting the parent's ±1 parity correction as the discriminant ±D plus a seed constant 2G₀G₁.",
+      "lucas_cassini and lucas_weighted_prod_sum: the Lucas specializations (D = −5, seed 2L₀L₁ = 4), tying the '5' of Binet's formula to the parity correction.",
+      "fib_weighted_prod_sum: recovers the parent's Fibonacci identity as the D = 1, seed = 0 special case, confirming the generalization is faithful."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — supplies the Gibonacci recurrence hypothesis for the integer-cast Fibonacci sequence",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off ∑_{k<n+1}, the induction step for both closed-form sums",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow / Even.neg_one_pow",
+        "description": "Evaluates (−1)ⁿ by parity, turning the Cassini sign into ±D in the induction step",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "dateAdded": "2026-07-04"
+  },
+  "parent": "fibonacci-identities-oq-05-oq-01",
+  "openQuestion": "Generalize fib_weighted_prod_sum to ∑ k Lₖ Lₖ₊₁ for Lucas numbers and to general Gibonacci sequences, tracking how the parity correction becomes a discriminant.",
+  "overview": {
+    "historicalContext": "The parent entry proves the Fibonacci weighted product-sum 2·∑_{k≤n} k FₖFₖ₊₁ = 2n Fₙ₊₁² − 2 Fₙ Fₙ₊₁ + (if n even then −n else n+1), whose sign correction ±1 comes from Cassini's identity Fₙ₊₁² − Fₙ₊₁Fₙ − Fₙ² = (−1)ⁿ. Lucas numbers (L₀=2, L₁=1) and, more generally, any Gibonacci sequence (G₀=a, G₁=b, Gₙ₊₂=Gₙ+Gₙ₊₁) satisfy a Cassini identity with the constant 1 replaced by the discriminant D = b² − ab − a² — the same quantity that appears (as 5) under the √5 in Binet's formula for Fibonacci/Lucas. The natural question is what the weighted product-sum becomes for these sequences, and the answer makes the role of the discriminant explicit.",
+    "problemStatement": "For an arbitrary integer Gibonacci sequence G with Gₙ₊₂ = Gₙ + Gₙ₊₁, find and verify the closed form of the weighted product-sum 2·∑_{k≤n} k GₖGₖ₊₁, isolating the dependence on the discriminant D = G₁² − G₁G₀ − G₀², and specialize to the Lucas numbers.",
+    "proofStrategy": "Work over ℤ with G and its recurrence as hypotheses (include hrec). (1) gib_cassini: prove Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ·D by induction, the step closing via the recurrence and a sign flip (linear_combination -ih). (2) gib_weighted_prod_sum: prove the closed form by induction; peel the top term with sum_range_succ, split on the parity of n, and discharge each branch with linear_combination 2(n+1)·(Cassini), where Cassini contributes exactly the D-scaled increment of the correction term. (3) Instantiate G := (Nat.fib · : ℤ) (D=1, seed 0) to recover the parent identity, and define Luc directly (D=−5, seed 4) to obtain the Lucas closed form; both specializations are one linear_combination against the general theorem after substituting the seed values.",
+    "keyInsights": [
+      "The Fibonacci parity correction ±1 is not special: for a general Gibonacci sequence it is exactly ±D where D = G₁² − G₁G₀ − G₀² is the Cassini discriminant. The sign alternates with parity; the magnitude is the invariant D.",
+      "A nonzero initial seed contributes a single extra constant 2 G₀ G₁ to the closed form, absent for Fibonacci (G₀ = 0) but equal to 4 for Lucas — so the full correction is 2 G₀ G₁ + D·(parity term).",
+      "For Lucas numbers the discriminant is D = −5, directly exhibiting the '5' of Binet's formula as the coefficient governing the weighted sum's parity correction; Cassini reads Lₙ₊₁² − Lₙ₊₁Lₙ − Lₙ² = −5·(−1)ⁿ.",
+      "Abstracting the recurrence as a hypothesis makes Fibonacci and Lucas mere instances of one induction, so the parent's four-line Fibonacci proof and the new Lucas identity are the same theorem evaluated at different seeds."
+    ],
+    "prerequisites": [
+      "The parent Fibonacci weighted product-sum identity",
+      "Cassini's identity and its generalization to Gibonacci sequences",
+      "Induction over Finset.range sums (sum_range_succ)",
+      "Parity case analysis and (−1)ⁿ evaluation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "States the open question and the answer: for a Gibonacci sequence the parity correction is ±D for the discriminant D = G₁² − G₁G₀ − G₀², plus a seed constant 2G₀G₁; lists the Fibonacci (D=1) and Lucas (D=−5) specializations."
+    },
+    {
+      "id": "gibonacci",
+      "title": "The Gibonacci core: Cassini and the weighted product-sum",
+      "startLine": 45,
+      "endLine": 97,
+      "summary": "For an arbitrary sequence satisfying the Fibonacci recurrence, proves gib_cassini (Cassini with discriminant D) and gib_weighted_prod_sum (the general closed form) by induction, splitting on parity and closing each branch with a linear_combination against Cassini."
+    },
+    {
+      "id": "fib-recovery",
+      "title": "Fibonacci recovery (D = 1, seed 0)",
+      "startLine": 98,
+      "endLine": 115,
+      "summary": "Instantiates the general theorem at the integer-cast Fibonacci sequence (fib_hrec supplies the recurrence) to reproduce the parent's Fibonacci weighted product-sum, confirming the generalization is faithful."
+    },
+    {
+      "id": "lucas",
+      "title": "Lucas numbers (D = −5, seed 4)",
+      "startLine": 116,
+      "endLine": 149,
+      "summary": "Defines the Lucas sequence, proves its recurrence, and specializes the general results to lucas_cassini (±(−5)) and lucas_weighted_prod_sum (correction 4 − 5·(parity term))."
+    }
+  ],
+  "conclusion": {
+    "summary": "Lifts the parent's Fibonacci weighted product-sum to arbitrary Gibonacci sequences: 2·∑_{k≤n} k GₖGₖ₊₁ = 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1), where D = G₁² − G₁G₀ − G₀² is the Cassini discriminant. The parent's parity correction ±1 is revealed as the D = 1 instance; Lucas numbers give D = −5 and seed constant 4. Fully machine-checked: 0 axioms, 0 sorries.",
+    "implications": "The identity shows the weighted product-sum is governed by a single sequence invariant, the Cassini discriminant, uniformly across all Gibonacci sequences. Casting the recurrence as a hypothesis reduces the Fibonacci and Lucas identities to one induction, and cleanly exposes where the '5' of the Fibonacci/Lucas field enters the summation.",
+    "openQuestions": [
+      "Does the alternating product-sum (parent's fib_alt_prod_sum_reduction) admit an analogous Gibonacci form with an irreducible remainder scaled by D?",
+      "Can the seed constant 2 G₀ G₁ and discriminant D be combined into a single closed form via the associated quadratic form of the sequence?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Parent: proves the Fibonacci weighted product-sum with parity correction ±1. This entry generalizes it to Gibonacci and Lucas sequences, showing the correction is the Cassini discriminant D (=1 for Fibonacci, −5 for Lucas), and recovers the parent as the D=1 case."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-05",
+      "relationship": "relatedTo",
+      "description": "Grandparent: the product-sum staircase identity whose weighted refinement is generalized here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gib_cassini",
+      "type": "core",
+      "description": "Cassini's identity for an arbitrary Gibonacci sequence: Gₙ₊₁² − Gₙ₊₁Gₙ − Gₙ² = (−1)ⁿ·D with D = G₁² − G₁G₀ − G₀². By induction off the recurrence; the classical Fibonacci Cassini is the D=1 case.",
+      "leanType": "(G : ℕ → ℤ) (hrec : ∀ n, G (n+2) = G n + G (n+1)) (n : ℕ) → G (n+1)^2 - G (n+1) * G n - (G n)^2 = (-1)^n * (G 1^2 - G 1 * G 0 - (G 0)^2)"
+    },
+    {
+      "name": "gib_weighted_prod_sum",
+      "type": "core",
+      "description": "The weighted product-sum closed form for a Gibonacci sequence: 2·∑_{k≤n} k GₖGₖ₊₁ = 2n Gₙ₊₁² − 2 Gₙ Gₙ₊₁ + 2 G₀ G₁ + D·(if n even then −n else n+1). The parent's ±1 correction is the discriminant ±D, plus the seed constant 2 G₀ G₁.",
+      "leanType": "(G : ℕ → ℤ) (hrec : ∀ n, G (n+2) = G n + G (n+1)) (n : ℕ) → 2 * ∑ k ∈ range (n+1), (k:ℤ) * G k * G (k+1) = 2*n*(G (n+1))^2 - 2*G n*G (n+1) + 2*G 0*G 1 + (G 1^2 - G 1*G 0 - (G 0)^2) * (if Even n then -(n:ℤ) else (n+1))"
+    },
+    {
+      "name": "lucas_weighted_prod_sum",
+      "type": "core",
+      "description": "Lucas specialization (D = −5, seed 2L₀L₁ = 4): 2·∑_{k≤n} k LₖLₖ₊₁ = 2n Lₙ₊₁² − 2 Lₙ Lₙ₊₁ + 4 − 5·(if n even then −n else n+1). The parity correction is scaled by the Lucas discriminant −5.",
+      "leanType": "(n : ℕ) → 2 * ∑ k ∈ range (n+1), (k:ℤ) * Luc k * Luc (k+1) = 2*n*(Luc (n+1))^2 - 2*Luc n*Luc (n+1) + 4 + (-5)*(if Even n then -(n:ℤ) else (n+1))"
+    },
+    {
+      "name": "lucas_cassini",
+      "type": "supporting",
+      "description": "Cassini for Lucas numbers: Lₙ₊₁² − Lₙ₊₁Lₙ − Lₙ² = (−1)ⁿ·(−5). The Fibonacci ±1 becomes the discriminant −5.",
+      "leanType": "(n : ℕ) → Luc (n+1)^2 - Luc (n+1) * Luc n - (Luc n)^2 = (-1)^n * (-5)"
+    },
+    {
+      "name": "fib_weighted_prod_sum",
+      "type": "supporting",
+      "description": "Recovers the parent's Fibonacci weighted product-sum as the D = 1, seed = 0 special case of the general Gibonacci theorem, confirming faithfulness of the generalization.",
+      "leanType": "(n : ℕ) → 2 * ∑ k ∈ range (n+1), (k:ℤ) * Nat.fib k * Nat.fib (k+1) = 2*n*(Nat.fib (n+1))^2 - 2*Nat.fib n*Nat.fib (n+1) + (if Even n then -(n:ℤ) else (n+1))"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Édouard Lucas"
+      ],
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics, vol. 1",
+      "note": "Origin of the Lucas sequence and the Gibonacci framework; the discriminant D governing the identities here is the Cassini invariant of these sequences."
+    },
+    {
+      "authors": [
+        "Thomas Koshy"
+      ],
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Standard reference for Cassini's identity, Gibonacci sequences, and summation identities of the type generalized here."
+    },
+    {
+      "authors": [
+        "The Mathlib Community"
+      ],
+      "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",
+      "year": "2024",
+      "venue": "https://github.com/leanprover-community/mathlib4",
+      "note": "Provides Nat.fib_add_two, Finset.sum_range_succ, and the (−1)ⁿ parity lemmas used to drive the inductions."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset"],
+    "namespace": "FibonacciIdentitiesOQ05OQ01OQ02",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ05OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New verified gallery entry `fibonacci-identities-oq-05-oq-01-oq-02` answering the parent's open question: generalize the Fibonacci weighted product-sum `2·∑ k FₖFₖ₊₁` to **Lucas numbers and arbitrary Gibonacci sequences**, tracking how the parity correction becomes a discriminant.

For any integer sequence `G` with `Gₙ₊₂ = Gₙ + Gₙ₊₁`, set the Cassini discriminant `D = G₁² − G₁G₀ − G₀²`. Then:

- `gib_cassini` — $G_{n+1}^2 - G_{n+1}G_n - G_n^2 = (-1)^n D$ (Fibonacci Cassini is `D=1`).
- `gib_weighted_prod_sum` — $2\sum_{k\le n} k\,G_k G_{k+1} = 2n G_{n+1}^2 - 2 G_n G_{n+1} + 2G_0 G_1 + D\,(\text{if } n \text{ even then } -n \text{ else } n+1)$.

So the parent's `±1` correction is exactly `±D`, plus a seed constant `2G₀G₁`.

**Specializations:**
- `fib_weighted_prod_sum` — recovers the parent identity (`D = 1`, seed `0`), confirming the generalization is faithful.
- `lucas_cassini` / `lucas_weighted_prod_sum` — Lucas numbers give `D = −5` (the `5` under `√5` in Binet's formula) and seed constant `4`: $2\sum k L_k L_{k+1} = 2n L_{n+1}^2 - 2 L_n L_{n+1} + 4 - 5(\text{if } n \text{ even then } -n \text{ else } n+1)$.

The recurrence is abstracted as a hypothesis, so Fibonacci and Lucas are instances of one induction.

## Verification
- Built via `./proofs/scripts/docker-build.sh Proofs.FibonacciIdentitiesOQ05OQ01OQ02` — succeeded.
- 9 theorems, 1 definition (the Lucas sequence), **0 sorries, 0 axioms**, no `native_decide`.
- `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)