### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01): build-verify generic Fσ-not-Gδ + gallery entry

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean
@@ -27,13 +27,13 @@ already-verified parent lemmas:
 * `AlgebraicNumbersCountableOQ02OQ03OQ02.not_isGδ_of_dense_of_disjoint_denseGδ` — two
   disjoint dense `Gδ` sets are impossible in a nonempty Baire space.
 
-## Status: build-pending
+## Status: verified
 
-Written during a dual-tool outage (Docker image store `input/output error`; Aristotle
-backend `Resource not found`), so it has not been machine-checked this session.  It is a
-short assembly of merged, verified lemmas whose signatures were re-checked by inspection;
-please build-verify with `./proofs/scripts/docker-build.sh
-Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02OQ01` before/at merge.
+Machine-checked with `./proofs/scripts/docker-build.sh
+Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02OQ01` (Mathlib 4.26.0): builds cleanly with 0
+sorries and no axioms beyond the standard `propext`/`Classical.choice`/`Quot.sound`.  (It
+was originally written build-pending during a tool outage; this session build-verifies it
+and adds the gallery entry.)
 
 ## References
 - Kechris, *Classical Descriptive Set Theory*, §8 (Borel hierarchy, Baire category).

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01",
+  "title": "Dense Countable Sets are Fσ but not Gδ in Perfect Polish Spaces",
+  "slug": "algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01",
+  "description": "Abstracts the parent's concrete ℝ dichotomy into a space-agnostic theorem: in any nonempty perfect T1 Baire space, a dense countable set is Fσ but not Gδ. Recovers ℚ ⊆ ℝ (rationals at level Σ⁰₂ ∖ Π⁰₂) as a one-line corollary. Fully verified, 0 axioms / 0 sorries.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gδ_set",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean",
+    "tags": [
+      "topology",
+      "baire-category",
+      "descriptive-set-theory",
+      "gdelta-set",
+      "borel-hierarchy",
+      "polish-space",
+      "algebraic-numbers",
+      "transcendental-numbers",
+      "real-analysis"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-07-04",
+    "mathlib_version": "4.26.0",
+    "assumptions": [],
+    "mathlibDependencies": [
+      {
+        "theorem": "PerfectSpace / BaireSpace / T1Space",
+        "description": "Typeclasses carrying exactly the hypotheses the Baire-category argument needs; ℝ is an instance of all of them",
+        "module": "Mathlib.Topology.Perfect / Mathlib.Topology.Baire"
+      },
+      {
+        "theorem": "Rat.denseRange_cast",
+        "description": "The coercion ℚ → ℝ has dense range — supplies density for the classical rationals instance",
+        "module": "Mathlib.Topology.Instances.Rat"
+      },
+      {
+        "theorem": "Set.countable_range",
+        "description": "The range of a map from a countable type is countable — gives countability of the rationals in ℝ",
+        "module": "Mathlib.Data.Set.Countable"
+      }
+    ],
+    "originalContributions": [
+      "dense_countable_isFσ_and_not_isGδ: the space-agnostic dichotomy — in any nonempty perfect T1 Baire space, a dense countable set is Fσ but not Gδ.",
+      "Isolates the Baire-category engine of the parent's ℝ result from any dependence on ℝ or algebraicity, quantifying over the minimal typeclass hypotheses (T1Space, PerfectSpace, BaireSpace, Nonempty).",
+      "rationals_isFσ_and_not_isGδ: the classical ℚ ⊆ ℝ instance recovered as a one-line corollary, placing the rationals at level exactly Σ⁰₂ ∖ Π⁰₂ of the Borel hierarchy."
+    ],
+    "prerequisites": [
+      "Baire category theorem and meagre/comeagre sets",
+      "Fσ and Gδ sets; the Borel hierarchy levels Σ⁰₂, Π⁰₂",
+      "Perfect spaces (no isolated points) and T1 separation",
+      "Two disjoint dense Gδ sets cannot coexist in a nonempty Baire space"
+    ],
+    "relatedProblems": [],
+    "lineCount": 89,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "parent": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+  "openQuestion": "Generic theorem: a dense countable set is Fσ but not Gδ in a perfect Polish space — can the parent's concrete ℝ dichotomy be abstracted to arbitrary perfect Polish (perfect T1 Baire) spaces, recovering the classical instances as corollaries?",
+  "overview": {
+    "historicalContext": "The parent entry proves the concrete dichotomy in ℝ: the algebraic reals form an Fσ set that is not Gδ, while the transcendentals form a dense Gδ that is not Fσ. The 'not Gδ' half is pure Baire category and never uses ℝ or algebraicity: a countable set D in a perfect Baire space is meagre, so its complement is a dense Gδ, and two disjoint dense Gδ sets cannot coexist in a nonempty Baire space. This entry records that abstraction once, over an arbitrary space carrying the minimal instances that make the argument run.",
+    "problemStatement": "State and verify the space-agnostic theorem — in any nonempty perfect T1 Baire space, a dense countable set is Fσ but not Gδ — as a direct assembly of the already-verified parent lemmas, and recover the classical ℚ ⊆ ℝ instance as a corollary.",
+    "proofStrategy": "The Fσ part is isFσ_of_countable (a countable set in a T1 space is the union of its closed singletons). For the 'not Gδ' part: if D were Gδ, then D and Dᶜ would be two disjoint dense Gδ sets — Dᶜ is a dense Gδ by compl_countable_isDenseGδ (the countable D is meagre in a perfect Baire space) — which not_isGδ_of_dense_of_disjoint_denseGδ forbids. The ℚ ⊆ ℝ corollary applies the abstract theorem to Set.range ((↑) : ℚ → ℝ) using Set.countable_range and Rat.denseRange_cast, since ℝ is a nonempty perfect T1 Baire space.",
+    "keyInsights": [
+      "The 'not Gδ' phenomenon for a dense countable set is entirely topological: it depends only on the ambient space being nonempty, perfect, T1, and Baire — not on ℝ, algebraicity, or any arithmetic.",
+      "Density is essential: a countable set that is Fσ-but-not-Gδ must be dense, because the obstruction is exactly that its complement is a competing dense Gδ.",
+      "The abstraction makes the classical placement of ℚ at Borel level Σ⁰₂ ∖ Π⁰₂ a one-line instance, and applies uniformly to any countable dense subset of any perfect Polish space (e.g. ℚⁿ ⊆ ℝⁿ, dyadic rationals in Cantor/Baire space)."
+    ],
+    "prerequisites": [
+      "Baire category theorem; meagre and comeagre sets",
+      "Fσ and Gδ sets and the Borel hierarchy",
+      "Perfect and T1 topological spaces",
+      "The parent's ℝ algebraic/transcendental dichotomy"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and reduction to parent lemmas",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Explains that the 'not Gδ' engine is pure Baire category and lists the three verified parent lemmas the theorem assembles: isFσ_of_countable, compl_countable_isDenseGδ, and not_isGδ_of_dense_of_disjoint_denseGδ."
+    },
+    {
+      "id": "abstract-theorem",
+      "title": "The space-agnostic dichotomy",
+      "startLine": 49,
+      "endLine": 78,
+      "summary": "dense_countable_isFσ_and_not_isGδ over an arbitrary nonempty perfect T1 Baire space, with the two projections isFσ_of_dense_countable and not_isGδ_of_dense_countable."
+    },
+    {
+      "id": "rationals-instance",
+      "title": "The classical ℚ ⊆ ℝ instance",
+      "startLine": 79,
+      "endLine": 89,
+      "summary": "rationals_isFσ_and_not_isGδ: ℚ is Fσ but not Gδ in ℝ, recovered by applying the abstract theorem to the dense countable range of ℚ → ℝ."
+    }
+  ],
+  "theorems": [
+    {
+      "name": "dense_countable_isFσ_and_not_isGδ",
+      "type": "core",
+      "description": "The abstract dichotomy: in any nonempty perfect T1 Baire space, a dense countable set D is Fσ but not Gδ. Fσ from isFσ_of_countable; not Gδ because otherwise D and its dense-Gδ complement would be two disjoint dense Gδ sets.",
+      "leanType": "{X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X] [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) → IsFσ D ∧ ¬ IsGδ D"
+    },
+    {
+      "name": "not_isGδ_of_dense_countable",
+      "type": "core",
+      "description": "The 'not Gδ' half in isolation: a dense countable set in a nonempty perfect T1 Baire space is not Gδ — the Baire-category obstruction, independent of ℝ or algebraicity.",
+      "leanType": "{X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X] [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) → ¬ IsGδ D"
+    },
+    {
+      "name": "isFσ_of_dense_countable",
+      "type": "supporting",
+      "description": "The 'Fσ' half: a countable set in a T1 space is Fσ (the union of its closed singletons).",
+      "leanType": "{X : Type*} [TopologicalSpace X] [T1Space X] [PerfectSpace X] [BaireSpace X] [Nonempty X] {D : Set X} (hcount : D.Countable) (hdense : Dense D) → IsFσ D"
+    },
+    {
+      "name": "rationals_isFσ_and_not_isGδ",
+      "type": "core",
+      "description": "The classical instance: ℚ is Fσ but not Gδ in ℝ, placing the rationals at Borel level exactly Σ⁰₂ ∖ Π⁰₂. A one-line corollary of the abstract theorem applied to the dense countable range of ℚ → ℝ.",
+      "leanType": "IsFσ (Set.range ((↑) : ℚ → ℝ)) ∧ ¬ IsGδ (Set.range ((↑) : ℚ → ℝ))"
+    }
+  ],
+  "conclusion": {
+    "summary": "Records the Baire-category core of the parent's ℝ dichotomy as a space-agnostic theorem: in any nonempty perfect T1 Baire space, a dense countable set is Fσ but not Gδ. The classical ℚ ⊆ ℝ result is recovered as a one-line corollary. Machine-checked: 0 axioms, 0 sorries.",
+    "implications": "Separates the topological content (Baire category) of the algebraic/transcendental Borel-hierarchy dichotomy from any arithmetic, so the same theorem applies verbatim to every countable dense subset of every perfect Polish space. The rationals' placement at Σ⁰₂ ∖ Π⁰₂ becomes an instance rather than a bespoke proof.",
+    "openQuestions": [
+      "Can the dual statement — a dense comeagre Gδ (e.g. the complement of a countable dense set) is not Fσ — be abstracted to the same generality?",
+      "Does the theorem extend to non-metrizable perfect Baire spaces where 'Polish' fails but the four typeclass hypotheses still hold?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Parent: proves the concrete ℝ dichotomy (algebraic reals Fσ-not-Gδ, transcendentals dense Gδ). This entry abstracts the Baire-category engine of the 'not Gδ' half to arbitrary perfect T1 Baire spaces and recovers ℚ ⊆ ℝ as a corollary."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Alexander S. Kechris"
+      ],
+      "title": "Classical Descriptive Set Theory",
+      "year": "1995",
+      "venue": "Graduate Texts in Mathematics 156, Springer, §8",
+      "note": "Borel hierarchy and Baire category; the Σ⁰₂ ∖ Π⁰₂ placement of dense countable sets."
+    },
+    {
+      "authors": [
+        "John C. Oxtoby"
+      ],
+      "title": "Measure and Category",
+      "year": "1980",
+      "venue": "Graduate Texts in Mathematics 2, Springer, Ch. 1–2",
+      "note": "Baire category theorem and the impossibility of two disjoint dense Gδ sets."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02", "Proofs.AlgebraicRealsMeagerDenseGDeltaOQ01", "Mathlib"],
+    "opens": ["Set", "Topology"],
+    "namespace": "AlgebraicNumbersCountableOQ02OQ03OQ02OQ01",
+    "lineCount": 89,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The generic theorem file `AlgebraicNumbersCountableOQ02OQ03OQ02OQ01.lean` was added **build-pending** in #34842 during a tool outage and never machine-checked, and had no gallery entry. This PR closes both gaps:

- **Build-verified** via `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ03OQ02OQ01` (Mathlib 4.26.0): builds cleanly, **0 sorries**, no axioms beyond the standard `propext`/`Classical.choice`/`Quot.sound`. Docstring status updated build-pending → verified.
- **Added the missing gallery entry** `src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02-oq-01/meta.json` (status `verified`, badge `original`).

## Content
The file abstracts the parent's concrete ℝ dichotomy into a space-agnostic theorem: in any nonempty perfect T1 Baire space, a dense countable set is Fσ but not Gδ (`dense_countable_isFσ_and_not_isGδ`), recovering ℚ ⊆ ℝ (rationals at Borel level Σ⁰₂ ∖ Π⁰₂) as a one-line corollary (`rationals_isFσ_and_not_isGδ`). 4 theorems, 0 defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)