### PR TITLE
Fix: downgrade ballot-problem-oq-03-oq-02 verified→formalized (source does not compile) (#33336)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lindström (1973), Gessel-Viennot (1985)",
     "sourceUrl": "",
     "date": "1985",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BallotProblemOQ03OQ02.lean",
     "tags": [
       "combinatorics",
@@ -17,7 +17,7 @@
       "permutations",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [
@@ -62,11 +62,11 @@
       "swapTailsAt: tail-swap operation (involution kernel for GV proof)",
       "swapTailsAt length preservation theorems",
       "gessel_viennot_transposition_sign: sign(swap(i,σi)∘σ) = -sign(σ) (proved)",
-      "lgv_lemma_rxr: the main r×r LGV lemma (FULLY PROVED — 0 sorries, 0 axioms)",
+      "lgv_lemma_rxr: the main r×r LGV lemma (sorry-free/axiom-free source; does NOT currently compile against pinned Mathlib v4.26.0)",
       "firstNonFixed: smallest non-fixed point of non-identity perm (4 lemmas proved)",
       "permPathTuple_card: cardinality factorization for σ-path tuples (proved)",
       "det_pathMatrix_eq_signed_sum: algebraic bridge det = signed perm sum (proved)",
-      "gv_involution_cancellation: GV cancellation (FULLY PROVED)",
+      "gv_involution_cancellation: GV cancellation (sorry-free source; does NOT currently compile against pinned Mathlib v4.26.0)",
       "canonCrossN_preserved: canonical crossing code invariant under GV involution (PROVED)",
       "gvCanon_self_inverse: GV involution is self-inverse via double tail-swap (PROVED)",
       "decoded_y_le: lexicographic y-bound transfer for encoding arithmetic (PROVED)",
@@ -93,7 +93,7 @@
   "overview": {
     "historicalContext": "The Lindström-Gessel-Viennot (LGV) lemma is one of the most versatile tools in enumerative combinatorics. Bernt Lindström proved a general version for vector matroids in 1973, building on ideas from Karlin and McGregor's 1959 work on coincidence probabilities of Markov chains. Ira Gessel and Gérard Viennot independently rediscovered and popularized the result in their influential 1985 paper, providing the elegant sign-reversing involution proof that has become the standard approach. The lemma connects non-intersecting lattice paths to determinants: the number of $r$-tuples of pairwise non-intersecting paths equals $\\det[e(A_i, B_j)]_{i,j}$. This determinantal structure has profound consequences—it underlies the Jacobi-Trudi identity for Schur polynomials, the Cauchy-Binet identity in linear algebra, and the Kasteleyn method for perfect matchings. The GV involution is a paradigmatic example of the 'cancellation via involution' technique that pervades algebraic combinatorics.",
     "problemStatement": "**The r×r LGV Lemma**: Given strictly increasing source points A₁,...,Aᵣ and target points B₁,...,Bᵣ on a lattice grid of width m, the number of r-tuples of pairwise non-intersecting lattice paths (Pᵢ: Aᵢ→Bᵢ) equals\n\n  det[ e(Aᵢ, Bⱼ) ]_{i,j=1}^r\n\nwhere e(A,B) = C(m + (bⱼ - aᵢ), m) is the number of monotone lattice paths from A to B.",
-    "text": "This formalization builds the complete infrastructure for the r×r Lindström-Gessel-Viennot determinant identity in Lean 4. Starting from lattice paths as Boolean lists, it constructs the PathMN type with a Fintype instance, defines the r×r path weight matrix over ℤ, and introduces permutation-indexed path tuples. The proof architecture connects the Leibniz determinant expansion (via Matrix.det_apply) to the combinatorial signed sum over permutation path tuples, then applies the Gessel-Viennot sign-reversing involution to cancel all non-identity contributions. Key proved components include a discrete intermediate value theorem for lattice path crossings, cardinality of PathMN via double induction on Pascal's rule, and the algebraic bridge equating det M with the signed permutation sum. The full canonical GV involution package is now proved — canonCrossN_preserved (canonical crossing invariant under involution), gvCanon_self_inverse (double tail-swap = identity), gvCanon_membership, gvCanon_sign_reversal, and gvCanon_no_fixed — closing the chain to lgv_lemma_rxr (0 sorries, 0 axioms).",
+    "text": "This formalization builds the complete infrastructure for the r×r Lindström-Gessel-Viennot determinant identity in Lean 4. Starting from lattice paths as Boolean lists, it constructs the PathMN type with a Fintype instance, defines the r×r path weight matrix over ℤ, and introduces permutation-indexed path tuples. The proof architecture connects the Leibniz determinant expansion (via Matrix.det_apply) to the combinatorial signed sum over permutation path tuples, then applies the Gessel-Viennot sign-reversing involution to cancel all non-identity contributions. Key proved components include a discrete intermediate value theorem for lattice path crossings, cardinality of PathMN via double induction on Pascal's rule, and the algebraic bridge equating det M with the signed permutation sum. The full canonical GV involution package is now proved — canonCrossN_preserved (canonical crossing invariant under involution), gvCanon_self_inverse (double tail-swap = identity), gvCanon_membership, gvCanon_sign_reversal, and gvCanon_no_fixed. The source contains 0 sorries and 0 axioms, but as of 2026-07-04 it does NOT compile against pinned Mathlib v4.26.0: a clean single-agent build (LEAN_SKIP_CACHE, 30s, no OOM) surfaced ~20 Mathlib-drift errors clustered in the canonical GV involution region (lines ~2109–2338: `simp made no progress`, `omega`/`split_ifs` failures, and type mismatches). Status is therefore `formalized`/`wip` pending repair.",
     "proofStrategy": "**Gessel-Viennot Involution**:\n1. Expand det M = Σ_σ sign(σ) ∏ᵢ M_{i,σ(i)} where M_{i,j} = e(Aᵢ, Bⱼ)\n2. Each term ∏ M_{i,σ(i)} counts σ-path tuples (Pᵢ: Aᵢ→B_{σ(i)})\n3. For σ ≠ id: find smallest i with σ(i) ≠ i; paths Pᵢ and P_{σ(i)} must cross\n4. Swap tails at first crossing point → maps σ-tuple to (swap(i,σ(i))∘σ)-tuple\n5. sign changes (transposition): terms cancel pairwise\n6. Only σ = id survives; non-NI id-tuples also cancel → niTupleCount = det M",
     "keyInsights": [
       "The sign-reversing involution pairs each σ-tuple with a τ-tuple where τ = swap(i,σ(i))∘σ has opposite sign, causing pairwise cancellation",
@@ -119,7 +119,7 @@
       "startLine": 1,
       "endLine": 76,
       "summary": "Module docstring, imports, and namespace setup for the general r×r Lindström–Gessel–Viennot lemma. These head lines introduce the problem — counting r-tuples of pairwise non-intersecting lattice paths as det[e(Aᵢ,Bⱼ)] with e(A,B)=C(dx+dy,dx) — and the sign-reversing Gessel–Viennot involution strategy that cancels every non-identity permutation, before the LGV namespace opens.",
-      "mathContext": "The LGV lemma (Lindström 1973; Gessel–Viennot 1985) expresses the number of non-intersecting path families as a determinant of single-path counts. Expanding det as an alternating sum over Sᵣ, the identity permutation contributes ∏ e(Aᵢ,Bᵢ) while every other permutation is killed by a sign-reversing involution built from swapping path tails at a forced crossing. Fully machine-checked: 0 axioms, 0 sorries."
+      "mathContext": "The LGV lemma (Lindström 1973; Gessel–Viennot 1985) expresses the number of non-intersecting path families as a determinant of single-path counts. Expanding det as an alternating sum over Sᵣ, the identity permutation contributes ∏ e(Aᵢ,Bᵢ) while every other permutation is killed by a sign-reversing involution built from swapping path tails at a forced crossing. Source is written axiom-free and sorry-free, but the file does NOT currently compile against pinned Mathlib v4.26.0 (~20 Mathlib-drift errors in the canonical GV involution region), so it is not machine-checked."
     },
     {
       "id": "lattice-path-foundations",
@@ -259,10 +259,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Complete formalization of the general r×r LGV lemma in 2511 lines with 0 axioms and 0 sorries. The main theorem lgv_lemma_rxr is fully machine-checked: niTupleCount(cfg) = det(pathMatrix(cfg)). The proof chain is complete: algebraic bridge (det = signed perm sum) → GV sign-reversing involution (cancellable sum = 0 via Finset.sum_involution with all 4 properties proved: sign_reversal, no_fixed_points, membership, self_inverse) → non-cancellable counting bijection → final theorem.",
+    "summary": "Formalization of the general r×r LGV lemma in ~2589 lines with 0 axioms and 0 sorries in the source. The main theorem lgv_lemma_rxr states niTupleCount(cfg) = det(pathMatrix(cfg)). The intended proof chain: algebraic bridge (det = signed perm sum) → GV sign-reversing involution (cancellable sum = 0 via Finset.sum_involution with sign_reversal, no_fixed_points, membership, self_inverse) → non-cancellable counting bijection → final theorem. NOTE: as of 2026-07-04 the file does NOT compile against pinned Mathlib v4.26.0 — a clean single-agent build surfaced ~20 Mathlib-drift errors in the canonical GV involution region (lines ~2109–2338), so it is not yet machine-checked (status formalized/wip).",
     "implications": "**Theoretical Significance**: **Applications of the r×r LGV lemma:**\n1. **Schur polynomials**: Via Jacobi-Trudi, s_λ = det[h_{λᵢ-i+j}] counts NI lattice paths (semistandard Young tableaux)\n**2. Plane partitions**: MacMahon's box formula via LGV on 3D lattice\n3. **Aztec diamond**: 2^{n(n+1)/2} tilings via NI path determinant\n4. **Random matrices**: Eigenvalue spacing via NI random walk paths.",
     "openQuestions": [
-      "All sorries closed — the r×r LGV lemma is fully proved",
+      "Repair the ~20 Mathlib-drift errors (lines ~2109–2338) so the file compiles against pinned Mathlib v4.26.0",
       "Connect to Mathlib's Schur polynomial infrastructure for the Jacobi-Trudi identity",
       "Extend to weighted lattice paths (generating function version of LGV)"
     ]


### PR DESCRIPTION
## Fix

Downgrades `ballot-problem-oq-03-oq-02` from `verified`/`mathlib` to `formalized`/`wip` because the Lean source does **not** compile against pinned Mathlib v4.26.0. This settles the long-standing integrity question in #33336.

## Evidence — settling build

A clean single-agent Docker build (`LEAN_SKIP_CACHE=true`, isolated from the shared cache) of `Proofs.BallotProblemOQ03OQ02` **failed in 30 s** — no OOM, no `.ltar` cache corruption, no SIGSEGV/SIGBUS, no fleet-contention artifacts. This rules out issue #33336's option (a) ("phantom OOM artifacts") and confirms **option (b): the errors are real.**

~20 genuine Mathlib-drift errors, all clustered in the canonical GV involution region (lines ~2109–2338, exactly the `gvCanon_membership` area the issue cites):
- `simp made no progress` (×3), `omega could not prove the goal` (×several)
- `split_ifs failed: no if-then-else conditions to split`
- `rewrite failed: did not find pattern`
- 4 `Type mismatch` errors (lines 2232, 2242, 2325, 2338)

## Changes

**Before**: `status: "verified"`, `badge: "mathlib"`, prose claiming "fully machine-checked", "FULLY PROVED", "fully proved".
**After**: `status: "formalized"`, `badge: "wip"`; prose corrected to state the source is genuinely 0-sorry/0-axiom but does not currently compile (Mathlib drift). `sorries`/`axioms` counts (both 0) are accurate and unchanged.

## Scope

Metadata-only, one entry. Repairing the ~20 proof errors is a separate research task (it stumped researcher sessions S86–S90) and is tracked by the `ballot-problem-oq-03-oq-01-oq-02` research problem, not this PR.

Closes #33336

---
Automated fix by lean-mechanic agent.