### PR TITLE
Enrich Prime Gap Bound Conditional on RH: annotations + sections

### DIFF
--- a/src/data/proofs/rh-consequences-oq-02/annotations.json
+++ b/src/data/proofs/rh-consequences-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-nthprime-def",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "definition",
+    "title": "The n-th prime and the n-th prime gap",
+    "content": "`nthPrime n` is defined as `Nat.nth Nat.Prime n`, the 0-indexed enumeration of the primes: p_0 = 2, p_1 = 3, p_2 = 5, .... `primeGap n` is the truncated Nat subtraction `nthPrime (n+1) - nthPrime n`. Because the enumeration is strictly increasing, this subtraction never underflows, so the Nat value equals the true gap. Both are `noncomputable` since `Nat.nth` selects the n-th element of an abstract infinite set rather than computing it.",
+    "mathContext": "$p_n = \\mathrm{nth}\\,\\mathbb{P}\\,n,\\qquad g_n = p_{n+1} - p_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["prime enumeration", "Nat.nth", "prime gaps", "noncomputable definitions"],
+    "prerequisites": ["prime numbers", "well-ordering of the naturals"]
+  },
+  {
+    "id": "ann-enumeration-infra",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "technique",
+    "title": "Prime-enumeration infrastructure from an infinite set",
+    "content": "Three facts drive everything downstream, all derived from `Nat.infinite_setOf_prime` (Euclid's theorem that primes are infinite): `nthPrime_prime` (every `p_n` is prime, via `Nat.nth_mem_of_infinite`), `nthPrime_strictMono` (the enumeration strictly increases, via `Nat.nth_strictMono`), and `nthPrime_le_succ` (`p_n ≤ p_{n+1}`, an immediate corollary). Strict monotonicity is what guarantees the gap subtraction is well-behaved and that `p_{n+1}` is genuinely the *next* prime after `p_n`.",
+    "mathContext": "$p_0 < p_1 < p_2 < \\cdots,\\qquad \\{p_n : n \\in \\mathbb{N}\\} = \\mathbb{P}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Euclid's theorem", "strict monotonicity", "order-preserving enumeration"],
+    "prerequisites": ["infinitude of primes", "monotone functions on the naturals"]
+  },
+  {
+    "id": "ann-bridge-lemma",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 87, "endLine": 110 },
+    "type": "insight",
+    "title": "The order-preserving bridge lemma",
+    "content": "The crux of the reduction: if `q` is prime and `q > p_n`, then `p_{n+1} ≤ q`. This is what upgrades 'there exists a prime in the short interval' to 'the very next prime lies in the short interval'. The proof works through the counting function `Nat.count Nat.Prime`, which counts primes below its argument: `count Prime (p_n + 1) = n + 1` (there are n+1 primes at or below p_n) and `count` increases by exactly one at each prime (`Nat.count_succ` with `if_pos`). A `by_contra` assuming `q < p_{n+1}` forces `count Prime q ≥ n+1` yet `count Prime (q+1) ≤ n+1`, contradicting the one-step increase at the prime q. This is a self-contained reproof of the same bridge used in the prime-gap-bounds entry.",
+    "mathContext": "$q \\in \\mathbb{P},\\ q > p_n \\ \\Longrightarrow\\ p_{n+1} \\le q,\\qquad \\pi(p_n) = n+1$",
+    "significance": "key",
+    "relatedConcepts": ["prime counting function", "Nat.count", "proof by contradiction", "least element"],
+    "prerequisites": ["prime counting function", "monotonicity of counting"]
+  },
+  {
+    "id": "ann-bertrand-baseline",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 119, "endLine": 126 },
+    "type": "concept",
+    "title": "Unconditional baseline: gap ≤ p_n from Bertrand's postulate",
+    "content": "`primeGap_le_nthPrime` proves the *unconditional*, axiom-free bound `p_{n+1} - p_n ≤ p_n`. It applies `Nat.exists_prime_lt_and_le_two_mul` (Bertrand's postulate: a prime `q` with `p_n < q ≤ 2p_n`) and then the bridge lemma to get `p_{n+1} ≤ q ≤ 2p_n`, so `p_{n+1} - p_n ≤ p_n`. This linear bound is the honest yardstick against which RH's improvement is measured: RH sharpens the multiplicative factor from `p_n` all the way down to `√p_n · log p_n`.",
+    "mathContext": "$p_{n+1} - p_n \\le p_n \\quad\\text{(equivalently } p_{n+1} \\le 2p_n\\text{)}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Bertrand's postulate", "Chebyshev's theorem", "unconditional bounds"],
+    "prerequisites": ["Bertrand's postulate"]
+  },
+  {
+    "id": "ann-rh-axiom",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 137, "endLine": 144 },
+    "type": "context",
+    "title": "The single analytic axiom: RH forces a prime into every short interval",
+    "content": "This is the one genuine assumption of the entry. `rh_implies_short_interval_prime` states that RH yields an absolute constant `C > 0` such that every interval `(x, x + C√x·log x]` with `x ≥ 2` contains a prime. Classically this follows from RH's control of the error term in π(x) via the explicit formula and zero-density estimates — machinery not yet in Mathlib, which is why it is axiomatized rather than proved. It is the *entire* analytic content of Cramér's theorem; everything else in the file is elementary. Note the axiom is stated as an implication from `RiemannHypothesis`, so the conditional structure is honest: no unconditional prime-distribution claim is smuggled in.",
+    "mathContext": "$\\mathrm{RH} \\Rightarrow \\exists C>0,\\ \\forall x \\ge 2,\\ \\bigl(x,\\, x + C\\sqrt{x}\\log x\\,\\bigr] \\cap \\mathbb{P} \\ne \\varnothing$",
+    "significance": "key",
+    "relatedConcepts": ["Riemann Hypothesis", "explicit formula", "zero-density estimates", "short intervals", "prime counting error term"],
+    "prerequisites": ["Riemann zeta function", "prime number theorem with error term"]
+  },
+  {
+    "id": "ann-bound-predicate",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 150, "endLine": 154 },
+    "type": "definition",
+    "title": "The conditional gap-bound predicate",
+    "content": "`PrimeGapBoundRH` spells out the big-O statement `p_{n+1} - p_n = O(√p_n·log p_n)` with an explicit witness constant: `∃ C > 0, ∀ n, (primeGap n : ℝ) ≤ C·√p_n·log p_n`. Making the constant existential and uniform in `n` is the correct formalization of a big-O bound; casting `primeGap n` to `ℝ` lets the √ and log live in `Real`.",
+    "mathContext": "$\\exists C>0,\\ \\forall n,\\ g_n \\le C\\,\\sqrt{p_n}\\,\\log p_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["big-O notation", "asymptotic bounds", "existential witness"],
+    "prerequisites": ["asymptotic notation", "real-valued bounds"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 156, "endLine": 178 },
+    "type": "insight",
+    "title": "Main theorem: the machine-checked reduction",
+    "content": "`rh_implies_prime_gap_bound` performs the elementary reduction that constitutes the file's genuine mathematical content. Instantiate the short-interval axiom at `x = p_n ≥ 2` to obtain a prime `q` with `p_n < q ≤ p_n + C√p_n·log p_n`. The bridge lemma gives `p_{n+1} ≤ q`. The delicate step is casting the Nat gap to ℝ: `Nat.cast_sub (nthPrime_le_succ n)` turns `primeGap n` into `(p_{n+1} : ℝ) - (p_n : ℝ)`, safe precisely because the enumeration is monotone. A short `calc`/`linarith` chain then yields `p_{n+1} - p_n ≤ q - p_n ≤ C√p_n·log p_n`. No `native_decide` appears, so the file carries no `Lean.ofReduceBool` dependency — the lone assumption is the analytic axiom.",
+    "mathContext": "$p_{n+1} - p_n \\le q - p_n \\le C\\sqrt{p_n}\\log p_n$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.cast_sub", "linarith", "conditional theorem", "big-O reduction"],
+    "prerequisites": ["Nat-to-Real casting", "linear arithmetic over ordered fields"]
+  },
+  {
+    "id": "ann-restatement",
+    "proofId": "rh-consequences-oq-02",
+    "range": { "startLine": 180, "endLine": 190 },
+    "type": "context",
+    "title": "Readability restatement: a prime just past each p_n",
+    "content": "`rh_implies_prime_after_each_prime` re-packages the axiom in prime-indexed form: under RH, for every `n` there is a prime `q` with `p_n < q ≤ p_n + C√p_n·log p_n`. It is immediate from the axiom (instantiated at `x = p_n`) and carries no new mathematical work — recorded only to make the short-interval consequence legible at the level of consecutive primes. The substantive theorem remains `rh_implies_prime_gap_bound`.",
+    "mathContext": "$\\forall n,\\ \\exists q \\in \\mathbb{P},\\ p_n < q \\le p_n + C\\sqrt{p_n}\\log p_n$",
+    "significance": "technical",
+    "relatedConcepts": ["short intervals", "restatement", "readability lemma"],
+    "prerequisites": ["prime enumeration"]
+  }
+]

--- a/src/data/proofs/rh-consequences-oq-02/meta.json
+++ b/src/data/proofs/rh-consequences-oq-02/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "rh-consequences-oq-02",
+  "title": "Prime Gap Bound Conditional on the Riemann Hypothesis",
+  "slug": "rh-consequences-oq-02",
+  "description": "Formalizes Cramér's 1920 conditional theorem that the Riemann Hypothesis implies consecutive prime gaps satisfy p_{n+1} - p_n = O(√p_n · log p_n). The analytic content — that RH forces every interval (x, x + C√x·log x] to contain a prime — is isolated in a single axiom; the reduction to the consecutive-gap statement is machine-checked with no further assumptions, and an unconditional Bertrand baseline (gap ≤ p_n, 0 axioms) quantifies how much RH sharpens the bound.",
+  "meta": {
+    "author": "Lean Genius (researcher-11)",
+    "date": "2026-07-04",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/RiemannHypothesisConsequencesOQ02.lean",
+    "tags": [
+      "analytic-number-theory",
+      "riemann-hypothesis",
+      "prime-gaps",
+      "prime-counting",
+      "short-intervals",
+      "cramer",
+      "conditional"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-07-04",
+    "axiomCount": 1,
+    "assumptions": "1 axiom encoding the classical analytic input: rh_implies_short_interval_prime — under RH there is an absolute constant C > 0 such that every interval (x, x + C·√x·log x] with x ≥ 2 contains a prime. This is the standard short-interval consequence of RH (via the explicit formula and zero-free / zero-density estimates), whose analytic machinery is not yet in Mathlib. Everything downstream is machine-checked: rh_implies_prime_gap_bound derives the consecutive-gap statement p_{n+1} - p_n = O(√p_n·log p_n) by an elementary order-preserving-enumeration argument (the next prime after p_n is at most any prime exceeding p_n). No native_decide is used, so the proof carries no Lean.ofReduceBool dependency. The unconditional companion primeGap_le_nthPrime (gap ≤ p_n, from Bertrand's postulate) uses NO axioms.",
+    "lineCount": 192,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "buildStatus": "build-pending",
+    "originalContributions": [
+      "rh_implies_prime_gap_bound: PROVED (not axiomatized) — the honest elementary reduction from RH short-interval prime existence to the consecutive prime-gap bound p_{n+1} - p_n ≤ C·√p_n·log p_n, via the order-preserving enumeration of primes",
+      "PrimeGapBoundRH: precise ∃C>0, ∀n, (p_{n+1}-p_n) ≤ C·√p_n·log p_n formalization of the conditional O(√p_n log p_n) gap bound",
+      "primeGap_le_nthPrime: UNCONDITIONAL baseline (0 axioms) — p_{n+1} - p_n ≤ p_n proved from Bertrand's postulate, the linear bound that RH sharpens to near-√p_n",
+      "nthPrime_succ_le_of_prime_gt: self-contained reproof (from the Nat.count / Nat.nth enumeration API) that the next prime after p_n is at most any prime exceeding p_n — the order-preserving bridge lemma making the reduction machine-checked",
+      "rh_implies_prime_after_each_prime: restatement that under RH a prime always occurs in the short interval (p_n, p_n + C√p_n·log p_n] just past each prime",
+      "nthPrime, primeGap, nthPrime_prime, nthPrime_strictMono, nthPrime_le_succ: self-contained prime-enumeration infrastructure"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Harald Cramér proved in 1920 that, assuming the Riemann Hypothesis, consecutive prime gaps satisfy p_{n+1} - p_n = O(√p_n · log p_n). The result follows from RH's control of the error term in the prime counting function π(x) = li(x) + O(√x log x), which forces primes into short intervals. The best UNCONDITIONAL bound is Baker–Harman–Pintz (2001), p_{n+1} - p_n = O(p_n^{0.525}), still weaker than Cramér's conditional √p_n·log p_n; and Cramér's own conjecture that gaps are O((log p_n)^2) remains far out of reach. RH thus occupies a precise middle ground: a power-1/2 saving no unconditional method attains.",
+    "problemStatement": "State and, as far as the missing analytic machinery allows, prove the conditional prime gap bound p_{n+1} - p_n = O(√p_n · log p_n) under the Riemann Hypothesis, isolating exactly the analytic input that must be assumed.",
+    "text": "Using Mathlib's built-in RiemannHypothesis predicate and the prime enumeration Nat.nth Nat.Prime, this file defines the n-th prime p_n, the n-th prime gap p_{n+1} - p_n, and the conditional bound predicate PrimeGapBoundRH. The single analytic assumption (rh_implies_short_interval_prime) states that RH forces a prime into every interval (x, x + C√x·log x]. From it the consecutive-gap bound is derived outright: applying the axiom at x = p_n yields a prime q with p_n < q ≤ p_n + C√p_n·log p_n; since p_{n+1} is the least prime above p_n, p_{n+1} ≤ q, so the gap is bounded. An unconditional Bertrand baseline (gap ≤ p_n) is proved with no axioms for contrast.",
+    "proofStrategy": "The reduction rests on the order-preserving bridge lemma nthPrime_succ_le_of_prime_gt: if q is prime and q > p_n then p_{n+1} ≤ q, reproved from the Nat.count / Nat.nth enumeration API (count Prime is monotone and steps by one at each prime). Given the short-interval axiom, instantiate at x = (p_n : ℝ) ≥ 2 to obtain a prime q in (p_n, p_n + C√p_n·log p_n]; the bridge lemma gives p_{n+1} ≤ q, and casting to ℝ with Nat.cast_sub turns p_{n+1} - p_n ≤ q - p_n ≤ C√p_n·log p_n. The analytic input rh_implies_short_interval_prime is the sole axiom: proving it needs the explicit formula and zero-density estimates for ζ that are not yet in Mathlib. The unconditional companion uses Nat.exists_prime_lt_and_le_two_mul (Bertrand) in place of the axiom, giving p_{n+1} ≤ 2p_n.",
+    "keyInsights": [
+      "The conditional gap bound cleanly factors into ONE analytic input (RH ⟹ prime in every short interval (x, x+C√x log x]) and a purely elementary combinatorial reduction to consecutive gaps — the file makes the reduction machine-checked and axiomatizes only the analytic half",
+      "The next prime after p_n is the least prime exceeding p_n; formalized via the Nat.count / Nat.nth enumeration, this is exactly what turns 'a prime lies in the short interval' into 'the very next prime lies in the short interval'",
+      "RH gives a power-1/2 saving: unconditionally only p_{n+1} - p_n = O(p_n) (Bertrand, proved here) or O(p_n^{0.525}) (Baker–Harman–Pintz) is known, so the √p_n·log p_n bound genuinely requires the hypothesis",
+      "Avoiding native_decide keeps the file free of the Lean.ofReduceBool dependency — the only assumption is the single stated analytic axiom",
+      "Cramér's conjecture p_{n+1} - p_n = O((log p_n)^2) is far stronger than what RH yields; even under RH the √p_n·log p_n bound is the current ceiling"
+    ],
+    "prerequisites": [
+      "The Riemann zeta function and the Riemann Hypothesis",
+      "The prime counting function and the short-interval distribution of primes",
+      "The enumeration of primes Nat.nth Nat.Prime and the counting function Nat.count",
+      "Bertrand's postulate (a prime in (n, 2n]) for the unconditional baseline"
+    ]
+  },
+  "sections": [
+    {
+      "id": "prime-enumeration",
+      "title": "Prime enumeration",
+      "startLine": 54,
+      "endLine": 77,
+      "summary": "Defines the n-th prime p_n as Nat.nth Nat.Prime n and the n-th gap p_{n+1} - p_n, then records the three structural facts derived from the infinitude of primes: each p_n is prime, the enumeration is strictly increasing, and p_n ≤ p_{n+1}."
+    },
+    {
+      "id": "bridge-lemma",
+      "title": "Order-preserving bridge lemma",
+      "startLine": 79,
+      "endLine": 110,
+      "summary": "Proves nthPrime_succ_le_of_prime_gt: if q is prime and q > p_n then p_{n+1} ≤ q. Argued through the prime counting function Nat.count, which increases by exactly one at each prime. This upgrades 'a prime lies in the short interval' to 'the next prime lies in the short interval'."
+    },
+    {
+      "id": "bertrand-baseline",
+      "title": "Unconditional Bertrand baseline",
+      "startLine": 112,
+      "endLine": 126,
+      "summary": "primeGap_le_nthPrime: the axiom-free bound p_{n+1} - p_n ≤ p_n, from Bertrand's postulate (a prime in (p_n, 2p_n]) plus the bridge lemma. The linear yardstick RH sharpens to near-√p_n."
+    },
+    {
+      "id": "rh-axiom",
+      "title": "The RH-conditional analytic input",
+      "startLine": 128,
+      "endLine": 144,
+      "summary": "The single axiom rh_implies_short_interval_prime: RH forces an absolute constant C > 0 with a prime in every interval (x, x + C√x·log x] for x ≥ 2. The entire analytic content of Cramér's theorem, isolated here because the explicit-formula / zero-density machinery is not yet in Mathlib."
+    },
+    {
+      "id": "conditional-bound",
+      "title": "The conditional prime gap bound",
+      "startLine": 146,
+      "endLine": 192,
+      "summary": "Defines PrimeGapBoundRH (∃C>0 bounding every gap by C√p_n·log p_n) and proves the main theorem rh_implies_prime_gap_bound by the elementary machine-checked reduction, plus the readability restatement rh_implies_prime_after_each_prime."
+    }
+  ],
+  "conclusion": {
+    "summary": "A focused formalization of Cramér's conditional prime gap bound p_{n+1} - p_n = O(√p_n · log p_n) under RH. The n-th prime and prime gap are defined from Mathlib's prime enumeration, the reduction from short-interval prime existence to the consecutive-gap bound is proved outright, and only the analytic short-interval input is axiomatized. An unconditional Bertrand baseline (gap ≤ p_n, 0 axioms) is included to quantify RH's improvement.",
+    "implications": "This entry isolates the precise logical content of the conditional gap bound, separating the elementary combinatorial reduction (a genuine machine-checked derivation) from the single deep analytic input on short intervals. It complements the broader rh-consequences family and the bounded-prime-gaps entries. Discharging rh_implies_short_interval_prime would require formalizing RH's explicit-formula control of π(x), a natural target once that machinery reaches Mathlib.",
+    "openQuestions": [
+      "Can the axiomatized short-interval input (rh_implies_short_interval_prime) be discharged in Lean from a formalized statement of RH? A proof needs the explicit formula for ψ(x) or π(x) with the RH error term O(√x log x), plus zero-density input to place a prime in (x, x + C√x log x] — machinery not yet in Mathlib.",
+      "Can the exponent on the logarithm be reduced from the interval form C√x·log x toward Cramér's conjectural O((log x)^2) gap, or is √x·log x the honest RH ceiling? Formalizing the sharper conditional constants would sharpen the bound.",
+      "Does the RH short-interval input reduce to the Mertens √x bound already axiomatized in rh-consequences-oq-03, giving a single shared analytic axiom across the RH-consequences family?",
+      "Can the unconditional baseline be improved inside Lean from Bertrand's gap ≤ p_n toward the Baker–Harman–Pintz O(p_n^{0.525}) bound, closing part of the gap to the conditional result without assuming RH?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "RHConsequencesOQ02",
+    "lineCount": 192,
+    "axiomCount": 1,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/RiemannHypothesisConsequencesOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "rh-consequences",
+      "relationship": "extends",
+      "description": "Parent entry: states RH's consequences for the Mertens and Chebyshev functions. This child derives the conditional prime-gap consequence p_{n+1} - p_n = O(√p_n log p_n)."
+    },
+    {
+      "targetId": "rh-consequences-oq-03",
+      "relationship": "related",
+      "description": "Sibling RH-consequence: Littlewood's equivalence RH ⟺ M(x) = O(x^{1/2+ε}). Both isolate a single deep analytic input and machine-check the elementary remainder."
+    },
+    {
+      "targetId": "prime-gap-bounds",
+      "relationship": "related",
+      "description": "Shares the prime-enumeration bridge lemma nth_prime_succ_le_of_prime_gt (next prime is least prime above p_n) and the unconditional Bertrand p_n ≤ 2^{n+1} machinery."
+    },
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "Complementary direction: bounded-prime-gaps bounds the liminf of gaps (Zhang/Maynard), while this entry bounds the growth of every gap conditionally on RH."
+    }
+  ]
+}


### PR DESCRIPTION
Enrichment pass for **rh-consequences-oq-02** (Prime Gap Bound Conditional on the Riemann Hypothesis), passes: 0.

The meta.json overview/conclusion was already rich; the real gaps were **no annotations.json** and **no sections array**.

## Added
- **annotations.json** (8 annotations) — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - prime enumeration definitions (`nthPrime`, `primeGap`)
  - the enumeration infrastructure from infinitude of primes
  - the order-preserving **bridge lemma** via `Nat.count` (the key step)
  - the unconditional **Bertrand baseline** (gap ≤ p_n, 0 axioms)
  - the single analytic **axiom** (RH ⟹ prime in every short interval)
  - the `PrimeGapBoundRH` predicate
  - the machine-checked **main reduction** and the readability restatement
- **sections** array in meta.json covering all 5 logical parts of the 192-line file

## Integrity
- Preserved `status: axiomatized`, `badge: axiom`, `axiomCount: 1` — accurate: one `axiom` (`rh_implies_short_interval_prime`), no `native_decide`, no `Lean.ofReduceBool`. Annotations explicitly flag the conditional structure and the axiomatized analytic input.
- meta.json 12.5 KB, within all size caps.
