### PR TITLE
Enrich 2-Group Backbone of Wantzel-Galois Constructibility: add annotations

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-istwogroup-def",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 71, "endLine": 81 },
+    "type": "definition",
+    "title": "The 2-group predicate, stated with Nat.card",
+    "content": "`IsTwoGroup G := ∃ k, Nat.card G = 2^k`. The deliberate choice of `Nat.card` (rather than the parent entry's `Fintype.card`) is what lets the predicate plug directly into Mathlib's `IsPGroup` / `Sylow` / `Index` API, all of which are phrased in `Nat.card`. `isTwoGroup_of_fintype_card` supplies the one-line bridge back to the parent's `Fintype.card` formulation via `Nat.card_eq_fintype_card`, so the two entries interoperate without friction.",
+    "mathContext": "$\\text{IsTwoGroup}(G) \\iff \\exists k,\\ |G| = 2^k$",
+    "significance": "supporting",
+    "relatedConcepts": ["p-group", "Nat.card vs Fintype.card", "group order"],
+    "prerequisites": ["finite groups", "order of a group"]
+  },
+  {
+    "id": "ann-ispgroup-adapter",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 83, "endLine": 87 },
+    "type": "technique",
+    "title": "Adapter into Mathlib's IsPGroup",
+    "content": "`isPGroup_two` converts 'order is 2^k' into Mathlib's structural predicate `IsPGroup 2 G` via `IsPGroup.of_card`. This single adapter unlocks the entire p-group toolbox — nilpotency, the class equation, Sylow theory — for the constructibility setting. Everything structural downstream is obtained by specializing generic p-group results to p = 2.",
+    "mathContext": "$|G| = 2^k \\ \\Longrightarrow\\ \\text{IsPGroup}\\,2\\,G$",
+    "significance": "supporting",
+    "relatedConcepts": ["IsPGroup.of_card", "prime power order", "p-group API"],
+    "prerequisites": ["p-groups", "prime powers"]
+  },
+  {
+    "id": "ann-nilpotent",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 89, "endLine": 94 },
+    "type": "insight",
+    "title": "Every finite 2-group is nilpotent",
+    "content": "`isNilpotent` applies `IsPGroup.isNilpotent` (which needs the typeclass witness `Fact (Nat.Prime 2)`, supplied by `Nat.prime_two`) to conclude `Group.IsNilpotent G`. Nilpotency is the deep structural fact powering sufficiency: a finite p-group has a nontrivial center (class equation), which bootstraps an ascending central series, hence a descending chain of normal subgroups. It is strictly stronger than solvability and is exactly what guarantees the index-2 step below can be taken with the subgroup normal in the whole group.",
+    "mathContext": "$G \\text{ a finite } 2\\text{-group} \\ \\Longrightarrow\\ G \\text{ nilpotent} \\quad (Z(G) \\ne 1)$",
+    "significance": "key",
+    "relatedConcepts": ["nilpotent group", "upper central series", "center of a p-group", "class equation"],
+    "prerequisites": ["nilpotent groups", "center of a group"]
+  },
+  {
+    "id": "ann-solvable",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 96, "endLine": 101 },
+    "type": "concept",
+    "title": "Solvability, via nilpotent ⟹ solvable",
+    "content": "`isSolvable` records that a finite 2-group is solvable, deduced from nilpotency through Mathlib's `IsNilpotent.to_isSolvable` instance (`infer_instance` after installing the nilpotency witness). Solvability is logically weaker than the nilpotency just proved, but it is stated separately because it is the customary hypothesis in the classical Galois phrasing of constructibility — and it is the property that links this entry to the Abel–Ruffini / radical-tower circle of ideas.",
+    "mathContext": "$G \\text{ nilpotent} \\ \\Longrightarrow\\ G \\text{ solvable}$",
+    "significance": "supporting",
+    "relatedConcepts": ["solvable group", "derived series", "Abel–Ruffini", "Galois solvability"],
+    "prerequisites": ["solvable groups"]
+  },
+  {
+    "id": "ann-chain-step",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 103, "endLine": 132 },
+    "type": "insight",
+    "title": "The chain step: a normal index-2 subgroup",
+    "content": "`exists_normal_index_two_subgroup` is the inductive engine of the whole sufficiency direction. For a nontrivial finite 2-group, nontriviality forces the exponent to be a successor `k = m+1` (else `|G| = 2^0 = 1`, contradicting `Nontrivial`). Then `2^m ∣ |G| = 2^(m+1)`, so Sylow's first theorem (`Sylow.exists_subgroup_card_pow_prime`) produces a subgroup `H` of order `2^m`. Its index is computed from `Subgroup.card_mul_index` (`|H|·[G:H] = |G|`): `2^m · [G:H] = 2^(m+1)`, cancelling to `[G:H] = 2`. Finally `Subgroup.normal_of_index_eq_two` makes `H` normal for free. Iterating on successive quotients yields the full normal chain `G = G₀ ▷ G₁ ▷ ⋯ ▷ Gₖ = 1` with every factor ℤ/2 — the group-theoretic shadow of a compass-and-straightedge tower.",
+    "mathContext": "$G \\text{ nontrivial } 2\\text{-group} \\ \\Longrightarrow\\ \\exists H \\trianglelefteq G,\\ [G:H] = 2$",
+    "significance": "key",
+    "relatedConcepts": ["Sylow's first theorem", "subgroup index", "index-2 is normal", "normal series", "quotient group"],
+    "prerequisites": ["Sylow theory", "Lagrange's theorem", "normal subgroups"]
+  },
+  {
+    "id": "ann-galois-bridge-context",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 134, "endLine": 145 },
+    "type": "context",
+    "title": "What is left: the Galois-correspondence translation",
+    "content": "The summary records the clean factorization of Wantzel–Galois sufficiency: the group-theoretic core (a 2-group is nilpotent/solvable with a descending normal index-2 chain) is proved here with 0 axioms / 0 sorries; the remaining step is field theory, not group theory. Under the Galois correspondence the descending chain `G = G₀ ▷ ⋯ ▷ Gₖ = 1` of index-2 subgroups maps to an ascending tower of fixed fields `ℚ = F₀ ⊂ ⋯ ⊂ Fₖ = K` with each `[Fᵢ₊₁ : Fᵢ] = 2` — a tower of quadratic extensions, i.e. the `IsConstructible` witness in the parent entry. Discharging that translation would close the parent's `wantzel_galois_iff` sufficiency sorry.",
+    "mathContext": "$G_i \\trianglelefteq G,\\ [G_i : G_{i+1}] = 2 \\ \\longleftrightarrow\\ [F_{i+1} : F_i] = 2$",
+    "significance": "context",
+    "relatedConcepts": ["Galois correspondence", "fixed field", "IntermediateField tower", "quadratic extension", "constructible number"],
+    "prerequisites": ["Galois correspondence", "field extensions", "fundamental theorem of Galois theory"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **angle-trisection-oq-02-oq-01-oq-02-oq-03** (The 2-Group Backbone of Wantzel-Galois Constructibility), passes: 0.

meta.json was already rich (mainTheorems, references, sections, keyInsights). The gap was **no annotations.json**.

## Added
- **annotations.json** (6 annotations) — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - the `IsTwoGroup` predicate (stated via `Nat.card` for API interop) + the `Fintype.card` bridge
  - the `IsPGroup` adapter that unlocks the p-group toolbox
  - **nilpotency** of every finite 2-group (center/class-equation core)
  - **solvability** via nilpotent ⟹ solvable
  - the **normal index-2 chain step** (Sylow + `card_mul_index` + index-2-is-normal) — the inductive engine
  - the Galois-correspondence translation to a quadratic tower (context; left to a companion entry)

## Integrity
- No meta.json change. `status: verified`, `axiomCount: 0`, `sorries: 0` preserved and accurate (file has 0 axioms/0 sorries). meta.json 14.4 KB, within caps.
